### PR TITLE
Address (most*) golint issues

### DIFF
--- a/chainntfs/btcdnotify/btcd.go
+++ b/chainntfs/btcdnotify/btcd.go
@@ -12,7 +12,7 @@ import (
 	"github.com/lightningnetwork/lnd/chainntfs"
 )
 
-// BtcdNotifier...
+// BtcdNotifier ...
 type BtcdNotifier struct {
 	// TODO(roasbeef): refactor to use the new NotificationServer
 	conn ChainConnection
@@ -37,7 +37,7 @@ type BtcdNotifier struct {
 
 var _ chainntnfs.ChainNotifier = (*BtcdNotifier)(nil)
 
-// NewBtcdNotifier...
+// NewBtcdNotifier ...
 func NewBtcdNotifier(c ChainConnection) (*BtcdNotifier, error) {
 	return &BtcdNotifier{
 		conn:                 c,
@@ -57,7 +57,7 @@ func NewBtcdNotifier(c ChainConnection) (*BtcdNotifier, error) {
 	}, nil
 }
 
-// Start...
+// Start ...
 func (b *BtcdNotifier) Start() error {
 	// Already started?
 	if atomic.AddInt32(&b.started, 1) != 1 {
@@ -71,7 +71,7 @@ func (b *BtcdNotifier) Start() error {
 	return nil
 }
 
-// Stop...
+// Stop ...
 func (b *BtcdNotifier) Stop() error {
 	// Already shutting down?
 	if atomic.AddInt32(&b.stopped, 1) != 1 {
@@ -84,7 +84,7 @@ func (b *BtcdNotifier) Stop() error {
 	return nil
 }
 
-// notificationDispatcher...
+// notificationDispatcher ...
 func (b *BtcdNotifier) notificationDispatcher() {
 out:
 	for {
@@ -175,7 +175,7 @@ out:
 	}
 }
 
-// initAllNotifications...
+// initAllNotifications ...
 func (b *BtcdNotifier) initAllNotifications() error {
 	var err error
 
@@ -195,14 +195,14 @@ func (b *BtcdNotifier) initAllNotifications() error {
 	return nil
 }
 
-// spendNotification....
+// spendNotification ....
 type spendNotification struct {
 	outpoint *wire.OutPoint
 
 	trigger *chainntnfs.NotificationTrigger
 }
 
-// confirmationNotification...
+// confirmationNotification ...
 // TODO(roasbeef): re-org funny business
 type confirmationsNotification struct {
 	txid *wire.ShaHash
@@ -213,7 +213,7 @@ type confirmationsNotification struct {
 	trigger *chainntnfs.NotificationTrigger
 }
 
-// RegisterSpendNotification...
+// RegisterSpendNotification ...
 // NOTE: eventChan MUST be buffered
 func (b *BtcdNotifier) RegisterSpendNotification(outpoint *wire.OutPoint,
 	trigger *chainntnfs.NotificationTrigger) error {
@@ -230,7 +230,7 @@ func (b *BtcdNotifier) RegisterSpendNotification(outpoint *wire.OutPoint,
 	return nil
 }
 
-// RegisterConfirmationsNotification...
+// RegisterConfirmationsNotification ...
 func (b *BtcdNotifier) RegisterConfirmationsNotification(txid *wire.ShaHash,
 	numConfs uint32, trigger *chainntnfs.NotificationTrigger) error {
 

--- a/chainntfs/btcdnotify/source.go
+++ b/chainntfs/btcdnotify/source.go
@@ -5,7 +5,7 @@ import (
 	"github.com/btcsuite/btcwallet/wtxmgr"
 )
 
-// ChainConnection...
+// ChainConnection ...
 // Required in order to avoid an import cycle, and do aide in testing.
 type ChainConnection interface {
 	ListenConnectedBlocks() (<-chan wtxmgr.BlockMeta, error)

--- a/chainntfs/chainntfs.go
+++ b/chainntfs/chainntfs.go
@@ -11,6 +11,8 @@ import "github.com/btcsuite/btcd/wire"
 //   * electrum?
 //   * SPV bloomfilter
 //   * other stuff maybe...
+
+// ChainNotifier ...
 type ChainNotifier interface {
 	RegisterConfirmationsNotification(txid *wire.ShaHash, numConfs uint32, trigger *NotificationTrigger) error
 	RegisterSpendNotification(outpoint *wire.OutPoint, trigger *NotificationTrigger) error
@@ -19,6 +21,7 @@ type ChainNotifier interface {
 	Stop() error
 }
 
+// NotificationTrigger ...
 type NotificationTrigger struct {
 	TriggerChan chan struct{}
 	Callback    func()

--- a/channeldb/channel.go
+++ b/channeldb/channel.go
@@ -24,20 +24,22 @@ var (
 	identityKey = []byte("idkey")
 
 	// TODO(roasbeef): replace w/ tesnet-L also revisit dependancy...
+
+	// ActiveNetParams ...
 	ActiveNetParams = &chaincfg.TestNet3Params
 )
 
-// Payment...
+// Payment ...
 type Payment struct {
 	// r [32]byte
 	// path *Route
 }
 
-// ClosedChannel...
+// ClosedChannel ...
 type ClosedChannel struct {
 }
 
-// OpenChannel...
+// OpenChannel ...
 // TODO(roasbeef): store only the essentials? optimize space...
 // TODO(roasbeef): switch to "column store"
 type OpenChannel struct {
@@ -98,8 +100,9 @@ type OpenChannel struct {
 }
 
 // These don't really belong here but not sure which other file to put them yet.
-// PutIdKey saves the private key used for
-func (c *DB) PutIdKey(pkh []byte) error {
+
+// PutIDKey saves the private key used for
+func (c *DB) PutIDKey(pkh []byte) error {
 	return c.namespace.Update(func(tx walletdb.Tx) error {
 		// Get the bucket dedicated to storing the meta-data for open
 		// channels.
@@ -108,8 +111,8 @@ func (c *DB) PutIdKey(pkh []byte) error {
 	})
 }
 
-// GetIdKey returns the IdKey
-func (c *DB) GetIdAdr() (*btcutil.AddressPubKeyHash, error) {
+// GetIDAdr returns the IDKey
+func (c *DB) GetIDAdr() (*btcutil.AddressPubKeyHash, error) {
 	var pkh []byte
 	err := c.namespace.View(func(tx walletdb.Tx) error {
 		// Get the bucket dedicated to storing the meta-data for open
@@ -125,7 +128,7 @@ func (c *DB) GetIdAdr() (*btcutil.AddressPubKeyHash, error) {
 	return btcutil.NewAddressPubKeyHash(pkh, ActiveNetParams)
 }
 
-// PutOpenChannel...
+// PutOpenChannel ...
 func (c *DB) PutOpenChannel(channel *OpenChannel) error {
 	return c.namespace.Update(func(tx walletdb.Tx) error {
 		// Get the bucket dedicated to storing the meta-data for open
@@ -140,7 +143,7 @@ func (c *DB) PutOpenChannel(channel *OpenChannel) error {
 	})
 }
 
-// GetOpenChannel...
+// FetchOpenChannel ...
 // TODO(roasbeef): assumes only 1 active channel per-node
 func (c *DB) FetchOpenChannel(nodeID [32]byte) (*OpenChannel, error) {
 	var channel *OpenChannel
@@ -166,7 +169,7 @@ func (c *DB) FetchOpenChannel(nodeID [32]byte) (*OpenChannel, error) {
 	return channel, err
 }
 
-// putChannel...
+// putChannel ...
 func putOpenChannel(activeChanBucket walletdb.Bucket, channel *OpenChannel,
 	addrmgr *waddrmgr.Manager) error {
 
@@ -215,7 +218,7 @@ func fetchOpenChannel(bucket walletdb.Bucket, nodeID [32]byte,
 	return channel, nil
 }
 
-// Encode...
+// Encode ...
 // TODO(roasbeef): checksum
 func (o *OpenChannel) Encode(b io.Writer, addrManager *waddrmgr.Manager) error {
 	if _, err := b.Write(o.TheirLNID[:]); err != nil {
@@ -306,7 +309,7 @@ func (o *OpenChannel) Encode(b io.Writer, addrManager *waddrmgr.Manager) error {
 	return nil
 }
 
-// Decode...
+// Decode ...
 func (o *OpenChannel) Decode(b io.Reader, addrManager *waddrmgr.Manager) error {
 	var scratch [8]byte
 

--- a/channeldb/db.go
+++ b/channeldb/db.go
@@ -17,7 +17,7 @@ var bufPool = &sync.Pool{
 	New: func() interface{} { return new(bytes.Buffer) },
 }
 
-// Store...
+// DB ...
 // TODO(roasbeef): CHECKSUMS, REDUNDANCY, etc etc.
 type DB struct {
 	// TODO(roasbeef): caching, etc?
@@ -26,7 +26,7 @@ type DB struct {
 	namespace walletdb.Namespace
 }
 
-// Wipe...
+// Wipe ...
 func (d *DB) Wipe() error {
 	return d.namespace.Update(func(tx walletdb.Tx) error {
 		rootBucket := tx.RootBucket()
@@ -35,20 +35,20 @@ func (d *DB) Wipe() error {
 	})
 }
 
-// New...
+// New ...
 // TODO(roasbeef): re-visit this dependancy...
 func New(addrmgr *waddrmgr.Manager, namespace walletdb.Namespace) *DB {
 	// TODO(roasbeef): create buckets if not created?
 	return &DB{addrmgr, namespace}
 }
 
-// Open...
+// Open ...
 // TODO(roasbeef): create+open, ditch New, fixes above
 func Open() *DB {
 	return nil
 }
 
-// Create...
+// Create ...
 func Create() *DB {
 	return nil
 }

--- a/cmd/lncli/commands.go
+++ b/cmd/lncli/commands.go
@@ -10,7 +10,7 @@ import (
 	"golang.org/x/net/context"
 )
 
-func printRespJson(resp interface{}) {
+func printRespJSON(resp interface{}) {
 	b, err := json.Marshal(resp)
 	if err != nil {
 		fatal(err)
@@ -21,6 +21,7 @@ func printRespJson(resp interface{}) {
 	out.WriteTo(os.Stdout)
 }
 
+// ShellCommand ...
 var ShellCommand = cli.Command{
 	Name:  "shell",
 	Usage: "enter interactive shell",
@@ -29,6 +30,7 @@ var ShellCommand = cli.Command{
 	},
 }
 
+// NewAddressCommand ...
 var NewAddressCommand = cli.Command{
 	Name:   "newaddress",
 	Usage:  "gets the next address in the HD chain",
@@ -44,9 +46,10 @@ func newAddress(ctx *cli.Context) {
 		fatal(err)
 	}
 
-	printRespJson(addr)
+	printRespJSON(addr)
 }
 
+// SendManyCommand ...
 var SendManyCommand = cli.Command{
 	Name: "sendmany",
 	Usage: "create and broadcast a transaction paying the specified " +
@@ -70,9 +73,10 @@ func sendMany(ctx *cli.Context) {
 		fatal(err)
 	}
 
-	printRespJson(txid)
+	printRespJSON(txid)
 }
 
+// ConnectCommand ...
 var ConnectCommand = cli.Command{
 	Name:   "connect",
 	Usage:  "connect to a remote lnd peer: <lnid>@host",
@@ -91,5 +95,5 @@ func connectPeer(ctx *cli.Context) {
 		fatal(err)
 	}
 
-	printRespJson(lnid)
+	printRespJSON(lnid)
 }

--- a/cmd/lnshell/commands.go
+++ b/cmd/lnshell/commands.go
@@ -8,8 +8,8 @@ import (
 	"google.golang.org/grpc"
 )
 
-// connects via grpc to the ln node.  default (hardcoded?) local:10K
-func RpcConnect(args []string) error {
+// RPCConnect connects via grpc to the ln node.  default (hardcoded?) local:10K
+func RPCConnect(args []string) error {
 	//	client := getClient(ctx)
 	opts := []grpc.DialOption{grpc.WithInsecure()}
 	conn, err := grpc.Dial("localhost:10000", opts...)
@@ -38,6 +38,7 @@ func RpcConnect(args []string) error {
 	return nil
 }
 
+// LnConnect ...
 func LnConnect(args []string) error {
 	if len(args) == 0 {
 		return fmt.Errorf("need: lnc pubkeyhash@hostname or pkh (via pbx)")

--- a/cmd/lnshell/lnshellmain.go
+++ b/cmd/lnshell/lnshellmain.go
@@ -53,6 +53,7 @@ func shellPrompt() error {
 	}
 }
 
+// Shellparse ...
 func Shellparse(cmdslice []string) error {
 	var err error
 	var args []string

--- a/lndc/listener.go
+++ b/lndc/listener.go
@@ -11,7 +11,7 @@ import (
 	"github.com/codahale/chacha20poly1305"
 )
 
-// Listener...
+// Listener ...
 type Listener struct {
 	longTermPriv *btcec.PrivateKey
 
@@ -20,7 +20,7 @@ type Listener struct {
 
 var _ net.Listener = (*Listener)(nil)
 
-// NewListener...
+// NewListener ...
 func NewListener(localPriv *btcec.PrivateKey, listenAddr string) (*Listener, error) {
 	addr, err := net.ResolveTCPAddr("tcp", listenAddr)
 	if err != nil {
@@ -115,7 +115,7 @@ func (l *Listener) createCipherConn(lnConn *LNDConn) (*btcec.PrivateKey, error) 
 
 // AuthListen...
 func (l *Listener) authenticateConnection(
-	myId *btcec.PrivateKey, lnConn *LNDConn, localEphPubBytes []byte) error {
+	myID *btcec.PrivateKey, lnConn *LNDConn, localEphPubBytes []byte) error {
 	var err error
 
 	// TODO(roasbeef): should be using read/write clear here?

--- a/lndc/lnadr.go
+++ b/lndc/lnadr.go
@@ -11,9 +11,9 @@ import (
 	"github.com/btcsuite/btcutil"
 )
 
-// lnAddr...
+// LNAdr ...
 type LNAdr struct {
-	lnId   [16]byte // redundant because adr contains it
+	lnID   [16]byte // redundant because adr contains it
 	PubKey *btcec.PublicKey
 
 	Base58Addr btcutil.Address // Base58 encoded address (1XXX...)
@@ -25,17 +25,17 @@ type LNAdr struct {
 
 // String...
 func (l *LNAdr) String() string {
-	var encodedId []byte
+	var encodedID []byte
 	if l.PubKey == nil {
-		encodedId = l.Base58Addr.ScriptAddress()
+		encodedID = l.Base58Addr.ScriptAddress()
 	} else {
-		encodedId = l.PubKey.SerializeCompressed()
+		encodedID = l.PubKey.SerializeCompressed()
 	}
 
-	return fmt.Sprintf("%v@%v", encodedId, l.NetAddr)
+	return fmt.Sprintf("%v@%v", encodedID, l.NetAddr)
 }
 
-// newLnAddr...
+// LnAddrFromString ...
 func LnAddrFromString(encodedAddr string) (*LNAdr, error) {
 	// The format of an lnaddr is "<pubkey or pkh>@host"
 	idHost := strings.Split(encodedAddr, "@")
@@ -86,7 +86,7 @@ func LnAddrFromString(encodedAddr string) (*LNAdr, error) {
 	}
 
 	// Finally, populate the lnid from the address.
-	copy(addr.lnId[:], addr.Base58Addr.ScriptAddress())
+	copy(addr.lnID[:], addr.Base58Addr.ScriptAddress())
 
 	return addr, nil
 }

--- a/lnwallet/config.go
+++ b/lnwallet/config.go
@@ -29,16 +29,16 @@ var (
 	walletDbName = "lnwallet.db"
 )
 
-// Config...
+// Config ...
 type Config struct {
 	DataDir string
 	LogDir  string
 
 	DebugLevel string
 
-	RpcHost string // localhost:18334
-	RpcUser string
-	RpcPass string
+	RPCHost string // localhost:18334
+	RPCUser string
+	RPCPass string
 
 	RPCCert string
 	RPCKey  string

--- a/lnwallet/reservation.go
+++ b/lnwallet/reservation.go
@@ -154,7 +154,7 @@ func (r *ChannelReservation) OurContribution() *ChannelContribution {
 	return r.ourContribution
 }
 
-// ProcesContribution verifies the counterparty's contribution to the pending
+// ProcessContribution verifies the counterparty's contribution to the pending
 // payment channel. As a result of this incoming message, lnwallet is able to
 // build the funding transaction, and both commitment transactions. Once this
 // message has been processed, all signatures to inputs to the funding
@@ -197,7 +197,7 @@ func (r *ChannelReservation) OurSignatures() ([][]byte, []byte) {
 	return r.ourFundingSigs, r.ourCommitmentSig
 }
 
-// CompleteFundingReservation finalizes the pending channel reservation,
+// CompleteReservation finalizes the pending channel reservation,
 // transitioning from a pending payment channel, to an open payment
 // channel. All passed signatures to the counterparty's inputs to the funding
 // transaction will be fully verified. Signatures are expected to be passed in
@@ -224,7 +224,7 @@ func (r *ChannelReservation) CompleteReservation(fundingSigs [][]byte,
 	return <-errChan
 }
 
-// OurSignatures returns the counterparty's signatures to all inputs to the
+// TheirSignatures returns the counterparty's signatures to all inputs to the
 // funding transaction belonging to them, as well as their signature for the
 // wallet's version of the commitment transaction. This methods is provided for
 // additional verification, such as needed by tests.

--- a/lnwallet/script_utils.go
+++ b/lnwallet/script_utils.go
@@ -13,9 +13,13 @@ import (
 var (
 	// TODO(roasbeef): remove these and use the one's defined in txscript
 	// within testnet-L.
-	SequenceLockTimeSeconds      = uint32(1 << 22)
-	SequenceLockTimeMask         = uint32(0x0000ffff)
-	OP_CHECKSEQUENCEVERIFY  byte = txscript.OP_NOP3
+
+	// SequenceLockTimeSeconds ...
+	SequenceLockTimeSeconds = uint32(1 << 22)
+	// SequenceLockTimeMask ...
+	SequenceLockTimeMask = uint32(0x0000ffff)
+	// OP_CHECKSEQUENCEVERIFY ...
+	OP_CHECKSEQUENCEVERIFY byte = txscript.OP_NOP3
 )
 
 // scriptHashPkScript generates a pay-to-script-hash public key script paying

--- a/lnwallet/setup.go
+++ b/lnwallet/setup.go
@@ -34,6 +34,7 @@ import (
 	"github.com/btcsuite/btcwallet/waddrmgr"
 	"github.com/btcsuite/btcwallet/wallet"
 	"github.com/btcsuite/btcwallet/walletdb"
+	// TODO: properly address golint's complaint: "a blank import should be only in a main or test package, or have a comment justifying it"
 	_ "github.com/btcsuite/btcwallet/walletdb/bdb"
 )
 

--- a/lnwallet/wallet.go
+++ b/lnwallet/wallet.go
@@ -37,12 +37,15 @@ const (
 )
 
 var (
+	// ErrInsufficientFunds ...
 	// Error types
 	ErrInsufficientFunds = errors.New("not enough available outputs to " +
 		"create funding transaction")
 
 	// Which bitcoin network are we using?
 	// TODO(roasbeef): config
+
+	// ActiveNetParams ...
 	ActiveNetParams = &chaincfg.TestNet3Params
 	// Namespace bucket keys.
 	lightningNamespaceKey = []byte("ln-wallet")
@@ -60,22 +63,13 @@ var (
 // NOTE: Ultimately, this will most likely be deprecated...
 type FundingType uint16
 
+// constants ...
 const (
-	// Use SegWit, assumes CSV+CLTV
-	SEGWIT FundingType = iota
-
-	// Use SIGHASH_NOINPUT, assumes CSV+CLTV
-	SIGHASH
-
-	// Use CSV without reserve
-	CSV
-
-	// Use CSV with reserve
-	// Reserve is a permanent amount of funds locked and the capacity.
-	CSV_RESERVE
-
-	// CLTV with reserve.
-	CLTV_RESERVE
+	SEGWIT      FundingType = iota // Use SegWit, assumes CSV+CLTV
+	SIGHASH                        // Use SIGHASH_NOINPUT, assumes CSV+CLTV
+	CSV                            // Use CSV without reserve
+	CSVReserve                     // Use CSV with reserve. Reserve is a permanent amount of funds locked and the capacity.
+	CLTVReserve                    // CLTV with reserve.
 )
 
 // initFundingReserveReq is the first message sent to initiate the workflow
@@ -312,7 +306,7 @@ func NewLightningWallet(config *Config) (*LightningWallet, walletdb.DB, error) {
 		}
 
 		idPubkeyHash := adrs[0].Address().ScriptAddress()
-		if err := cdb.PutIdKey(idPubkeyHash); err != nil {
+		if err := cdb.PutIDKey(idPubkeyHash); err != nil {
 			return nil, nil, err
 		}
 		log.Printf("stored identity key pubkey hash in channeldb\n")
@@ -350,7 +344,7 @@ func (l *LightningWallet) Startup() error {
 	// TODO(roasbeef): config...
 
 	rpcc, err := chain.NewClient(ActiveNetParams,
-		l.cfg.RpcHost, l.cfg.RpcUser, l.cfg.RpcPass, l.cfg.CACert, false)
+		l.cfg.RPCHost, l.cfg.RPCUser, l.cfg.RPCPass, l.cfg.CACert, false)
 	if err != nil {
 		return err
 	}

--- a/lnwallet/wallet_test.go
+++ b/lnwallet/wallet_test.go
@@ -97,7 +97,7 @@ func (b *bobNode) Contribution() *ChannelContribution {
 func (b *bobNode) signFundingTx(fundingTx *wire.MsgTx) ([][]byte, error) {
 	bobSigs := make([][]byte, 0, len(b.availableOutputs))
 	bobPkScript := b.changeOutputs[0].PkScript
-	for i, _ := range fundingTx.TxIn {
+	for i := range fundingTx.TxIn {
 		// Alice has already signed this input
 		if fundingTx.TxIn[i].SignatureScript != nil {
 			continue

--- a/lnwire/close_complete.go
+++ b/lnwire/close_complete.go
@@ -2,12 +2,13 @@ package lnwire
 
 import (
 	"fmt"
+	"io"
+
 	"github.com/btcsuite/btcd/btcec"
 	"github.com/btcsuite/btcd/wire"
-
-	"io"
 )
 
+// CloseComplete ...
 type CloseComplete struct {
 	ReservationID uint64
 
@@ -15,6 +16,7 @@ type CloseComplete struct {
 	CloseShaHash      *wire.ShaHash    // TxID of the Close Tx
 }
 
+// Decode ...
 func (c *CloseComplete) Decode(r io.Reader, pver uint32) error {
 	// ReservationID (8)
 	// ResponderCloseSig (73)
@@ -31,12 +33,12 @@ func (c *CloseComplete) Decode(r io.Reader, pver uint32) error {
 	return nil
 }
 
-// Creates a new CloseComplete
+// NewCloseComplete creates a new CloseComplete
 func NewCloseComplete() *CloseComplete {
 	return &CloseComplete{}
 }
 
-// Serializes the item from the CloseComplete struct
+// Encode serializes the item from the CloseComplete struct
 // Writes the data to w
 func (c *CloseComplete) Encode(w io.Writer, pver uint32) error {
 	// ReservationID
@@ -53,16 +55,18 @@ func (c *CloseComplete) Encode(w io.Writer, pver uint32) error {
 	return nil
 }
 
+// Command ...
 func (c *CloseComplete) Command() uint32 {
 	return CmdCloseComplete
 }
 
+// MaxPayloadLength ...
 func (c *CloseComplete) MaxPayloadLength(uint32) uint32 {
 	// 8 + 73 + 32
 	return 113
 }
 
-// Makes sure the struct data is valid (e.g. no negatives or invalid pkscripts)
+// Validate makes sure the struct data is valid (e.g. no negatives or invalid pkscripts)
 func (c *CloseComplete) Validate() error {
 	// We're good!
 	return nil

--- a/lnwire/close_request.go
+++ b/lnwire/close_request.go
@@ -2,12 +2,13 @@ package lnwire
 
 import (
 	"fmt"
+	"io"
+
 	"github.com/btcsuite/btcd/btcec"
 	"github.com/btcsuite/btcutil"
-
-	"io"
 )
 
+// CloseRequest ...
 type CloseRequest struct {
 	ReservationID uint64
 
@@ -15,6 +16,7 @@ type CloseRequest struct {
 	Fee               btcutil.Amount
 }
 
+// Decode ...
 func (c *CloseRequest) Decode(r io.Reader, pver uint32) error {
 	// ReservationID (8)
 	// RequesterCloseSig (73)
@@ -31,12 +33,12 @@ func (c *CloseRequest) Decode(r io.Reader, pver uint32) error {
 	return nil
 }
 
-// Creates a new CloseRequest
+// NewCloseRequest creates a new CloseRequest
 func NewCloseRequest() *CloseRequest {
 	return &CloseRequest{}
 }
 
-// Serializes the item from the CloseRequest struct
+// Encode serializes the item from the CloseRequest struct
 // Writes the data to w
 func (c *CloseRequest) Encode(w io.Writer, pver uint32) error {
 	// ReservationID
@@ -53,16 +55,18 @@ func (c *CloseRequest) Encode(w io.Writer, pver uint32) error {
 	return nil
 }
 
+// Command ...
 func (c *CloseRequest) Command() uint32 {
 	return CmdCloseRequest
 }
 
+// MaxPayloadLength ...
 func (c *CloseRequest) MaxPayloadLength(uint32) uint32 {
 	// 8 + 73 + 8
 	return 89
 }
 
-// Makes sure the struct data is valid (e.g. no negatives or invalid pkscripts)
+// Validate makes sure the struct data is valid (e.g. no negatives or invalid pkscripts)
 func (c *CloseRequest) Validate() error {
 	// Fee must be greater than 0
 	if c.Fee < 0 {

--- a/lnwire/close_request_test.go
+++ b/lnwire/close_request_test.go
@@ -1,8 +1,9 @@
 package lnwire
 
 import (
-	"github.com/btcsuite/btcutil"
 	"testing"
+
+	"github.com/btcsuite/btcutil"
 )
 
 var (

--- a/lnwire/commit_revocation.go
+++ b/lnwire/commit_revocation.go
@@ -5,6 +5,7 @@ import (
 	"io"
 )
 
+// CommitRevocation ...
 // Multiple Clearing Requests are possible by putting this inside an array of
 // clearing requests
 type CommitRevocation struct {
@@ -23,6 +24,7 @@ type CommitRevocation struct {
 	RevocationProof [20]byte
 }
 
+// Decode ...
 func (c *CommitRevocation) Decode(r io.Reader, pver uint32) error {
 	// ChannelID(8)
 	// CommitmentHeight(8)
@@ -39,12 +41,12 @@ func (c *CommitRevocation) Decode(r io.Reader, pver uint32) error {
 	return nil
 }
 
-// Creates a new CommitRevocation
+// NewCommitRevocation creates a new CommitRevocation
 func NewCommitRevocation() *CommitRevocation {
 	return &CommitRevocation{}
 }
 
-// Serializes the item from the CommitRevocation struct
+// Encode serializes the item from the CommitRevocation struct
 // Writes the data to w
 func (c *CommitRevocation) Encode(w io.Writer, pver uint32) error {
 	err := writeElements(w,
@@ -59,15 +61,17 @@ func (c *CommitRevocation) Encode(w io.Writer, pver uint32) error {
 	return nil
 }
 
+// Command ...
 func (c *CommitRevocation) Command() uint32 {
 	return CmdCommitRevocation
 }
 
+// MaxPayloadLength ...
 func (c *CommitRevocation) MaxPayloadLength(uint32) uint32 {
 	return 36
 }
 
-// Makes sure the struct data is valid (e.g. no negatives or invalid pkscripts)
+// Validate makes sure the struct data is valid (e.g. no negatives or invalid pkscripts)
 func (c *CommitRevocation) Validate() error {
 	// We're good!
 	return nil

--- a/lnwire/commit_signature.go
+++ b/lnwire/commit_signature.go
@@ -2,11 +2,13 @@ package lnwire
 
 import (
 	"fmt"
+	"io"
+
 	"github.com/btcsuite/btcd/btcec"
 	"github.com/btcsuite/btcutil"
-	"io"
 )
 
+// CommitSignature ...
 // Multiple Clearing Requests are possible by putting this inside an array of
 // clearing requests
 type CommitSignature struct {
@@ -34,6 +36,7 @@ type CommitSignature struct {
 	CommitSig *btcec.Signature // Requester's Commitment
 }
 
+// Decode ...
 func (c *CommitSignature) Decode(r io.Reader, pver uint32) error {
 	// ChannelID(8)
 	// CommitmentHeight(8)
@@ -56,12 +59,12 @@ func (c *CommitSignature) Decode(r io.Reader, pver uint32) error {
 	return nil
 }
 
-// Creates a new CommitSignature
+// NewCommitSignature creates a new CommitSignature
 func NewCommitSignature() *CommitSignature {
 	return &CommitSignature{}
 }
 
-// Serializes the item from the CommitSignature struct
+// Encode serializes the item from the CommitSignature struct
 // Writes the data to w
 func (c *CommitSignature) Encode(w io.Writer, pver uint32) error {
 	err := writeElements(w,
@@ -79,15 +82,17 @@ func (c *CommitSignature) Encode(w io.Writer, pver uint32) error {
 	return nil
 }
 
+// Command ...
 func (c *CommitSignature) Command() uint32 {
 	return CmdCommitSignature
 }
 
+// MaxPayloadLength ...
 func (c *CommitSignature) MaxPayloadLength(uint32) uint32 {
 	return 8192
 }
 
-// Makes sure the struct data is valid (e.g. no negatives or invalid pkscripts)
+// Validate makes sure the struct data is valid (e.g. no negatives or invalid pkscripts)
 func (c *CommitSignature) Validate() error {
 	if c.Fee < 0 {
 		// While fees can be negative, it's too confusing to allow

--- a/lnwire/commit_signature_test.go
+++ b/lnwire/commit_signature_test.go
@@ -1,8 +1,9 @@
 package lnwire
 
 import (
-	"github.com/btcsuite/btcutil"
 	"testing"
+
+	"github.com/btcsuite/btcutil"
 )
 
 var (

--- a/lnwire/error_generic.go
+++ b/lnwire/error_generic.go
@@ -5,6 +5,7 @@ import (
 	"io"
 )
 
+// ErrorGeneric ...
 // Multiple Clearing Requests are possible by putting this inside an array of
 // clearing requests
 type ErrorGeneric struct {
@@ -15,6 +16,7 @@ type ErrorGeneric struct {
 	Problem string
 }
 
+// Decode ...
 func (c *ErrorGeneric) Decode(r io.Reader, pver uint32) error {
 	// ChannelID(8)
 	// Problem
@@ -29,12 +31,12 @@ func (c *ErrorGeneric) Decode(r io.Reader, pver uint32) error {
 	return nil
 }
 
-// Creates a new ErrorGeneric
+// NewErrorGeneric creates a new ErrorGeneric
 func NewErrorGeneric() *ErrorGeneric {
 	return &ErrorGeneric{}
 }
 
-// Serializes the item from the ErrorGeneric struct
+// Encode serializes the item from the ErrorGeneric struct
 // Writes the data to w
 func (c *ErrorGeneric) Encode(w io.Writer, pver uint32) error {
 	err := writeElements(w,
@@ -48,16 +50,18 @@ func (c *ErrorGeneric) Encode(w io.Writer, pver uint32) error {
 	return nil
 }
 
+// Command ...
 func (c *ErrorGeneric) Command() uint32 {
 	return CmdErrorGeneric
 }
 
+// MaxPayloadLength ...
 func (c *ErrorGeneric) MaxPayloadLength(uint32) uint32 {
 	// 8+8192
 	return 8208
 }
 
-// Makes sure the struct data is valid (e.g. no negatives or invalid pkscripts)
+// Validate makes sure the struct data is valid (e.g. no negatives or invalid pkscripts)
 func (c *ErrorGeneric) Validate() error {
 	if len(c.Problem) > 8192 {
 		return fmt.Errorf("Problem string length too long")

--- a/lnwire/funding_request.go
+++ b/lnwire/funding_request.go
@@ -2,12 +2,14 @@ package lnwire
 
 import (
 	"fmt"
+	"io"
+
 	"github.com/btcsuite/btcd/btcec"
 	"github.com/btcsuite/btcd/wire"
 	"github.com/btcsuite/btcutil"
-	"io"
 )
 
+// FundingRequest ...
 type FundingRequest struct {
 	ReservationID uint64
 
@@ -53,6 +55,7 @@ type FundingRequest struct {
 	Inputs []*wire.TxIn
 }
 
+// Decode ...
 func (c *FundingRequest) Decode(r io.Reader, pver uint32) error {
 	// Reservation ID (8)
 	// Channel Type (1)
@@ -96,12 +99,12 @@ func (c *FundingRequest) Decode(r io.Reader, pver uint32) error {
 	return nil
 }
 
-// Creates a new FundingRequest
+// NewFundingRequest creates a new FundingRequest
 func NewFundingRequest() *FundingRequest {
 	return &FundingRequest{}
 }
 
-// Serializes the item from the FundingRequest struct
+// Encode serializes the item from the FundingRequest struct
 // Writes the data to w
 func (c *FundingRequest) Encode(w io.Writer, pver uint32) error {
 	// Channel Type
@@ -139,16 +142,18 @@ func (c *FundingRequest) Encode(w io.Writer, pver uint32) error {
 	return nil
 }
 
+// Command ...
 func (c *FundingRequest) Command() uint32 {
 	return CmdFundingRequest
 }
 
+// MaxPayloadLength ...
 func (c *FundingRequest) MaxPayloadLength(uint32) uint32 {
 	// 110 (base size) + 26 (pkscript) + 26 (pkscript) + 1 (numTxes) + 127*36(127 inputs * sha256+idx)
 	return 4735
 }
 
-// Makes sure the struct data is valid (e.g. no negatives or invalid pkscripts)
+// Validate makes sure the struct data is valid (e.g. no negatives or invalid pkscripts)
 func (c *FundingRequest) Validate() error {
 	var err error
 

--- a/lnwire/funding_request_test.go
+++ b/lnwire/funding_request_test.go
@@ -1,8 +1,9 @@
 package lnwire
 
 import (
-	"github.com/btcsuite/btcutil"
 	"testing"
+
+	"github.com/btcsuite/btcutil"
 )
 
 var (

--- a/lnwire/funding_response.go
+++ b/lnwire/funding_response.go
@@ -2,12 +2,14 @@ package lnwire
 
 import (
 	"fmt"
+	"io"
+
 	"github.com/btcsuite/btcd/btcec"
 	"github.com/btcsuite/btcd/wire"
 	"github.com/btcsuite/btcutil"
-	"io"
 )
 
+// FundingResponse ...
 type FundingResponse struct {
 	ChannelType uint8
 
@@ -38,6 +40,7 @@ type FundingResponse struct {
 	Inputs []*wire.TxIn
 }
 
+// Decode ...
 func (c *FundingResponse) Decode(r io.Reader, pver uint32) error {
 	// ReservationID (8)
 	// Channel Type (1)
@@ -80,12 +83,12 @@ func (c *FundingResponse) Decode(r io.Reader, pver uint32) error {
 	return nil
 }
 
-// Creates a new FundingResponse
+// NewFundingResponse creates a new FundingResponse
 func NewFundingResponse() *FundingResponse {
 	return &FundingResponse{}
 }
 
-// Serializes the item from the FundingResponse struct
+// Encode serializes the item from the FundingResponse struct
 // Writes the data to w
 func (c *FundingResponse) Encode(w io.Writer, pver uint32) error {
 	// ReservationID (8)
@@ -123,16 +126,18 @@ func (c *FundingResponse) Encode(w io.Writer, pver uint32) error {
 	return nil
 }
 
+// Command ...
 func (c *FundingResponse) Command() uint32 {
 	return CmdFundingResponse
 }
 
+// MaxPayloadLength ...
 func (c *FundingResponse) MaxPayloadLength(uint32) uint32 {
 	// 86 (base size) + 26 (pkscript) + 26 (pkscript) + 74sig + 1 (numTxes) + 127*36(127 inputs * sha256+idx)
 	return 4785
 }
 
-// Makes sure the struct data is valid (e.g. no negatives or invalid pkscripts)
+// Validate makes sure the struct data is valid (e.g. no negatives or invalid pkscripts)
 func (c *FundingResponse) Validate() error {
 	var err error
 

--- a/lnwire/funding_response_test.go
+++ b/lnwire/funding_response_test.go
@@ -1,8 +1,9 @@
 package lnwire
 
 import (
-	"github.com/btcsuite/btcutil"
 	"testing"
+
+	"github.com/btcsuite/btcutil"
 )
 
 var (

--- a/lnwire/funding_signaccept.go
+++ b/lnwire/funding_signaccept.go
@@ -2,10 +2,12 @@ package lnwire
 
 import (
 	"fmt"
-	"github.com/btcsuite/btcd/btcec"
 	"io"
+
+	"github.com/btcsuite/btcd/btcec"
 )
 
+// FundingSignAccept ...
 type FundingSignAccept struct {
 	ReservationID uint64
 
@@ -13,6 +15,7 @@ type FundingSignAccept struct {
 	FundingTXSigs []*btcec.Signature
 }
 
+// Decode ...
 func (c *FundingSignAccept) Decode(r io.Reader, pver uint32) error {
 	// ReservationID (8)
 	// CommitSig (73)
@@ -32,12 +35,12 @@ func (c *FundingSignAccept) Decode(r io.Reader, pver uint32) error {
 	return nil
 }
 
-// Creates a new FundingSignAccept
+// NewFundingSignAccept creates a new FundingSignAccept
 func NewFundingSignAccept() *FundingSignAccept {
 	return &FundingSignAccept{}
 }
 
-// Serializes the item from the FundingSignAccept struct
+// Encode serializes the item from the FundingSignAccept struct
 // Writes the data to w
 func (c *FundingSignAccept) Encode(w io.Writer, pver uint32) error {
 	// ReservationID
@@ -54,16 +57,18 @@ func (c *FundingSignAccept) Encode(w io.Writer, pver uint32) error {
 	return nil
 }
 
+// Command ...
 func (c *FundingSignAccept) Command() uint32 {
 	return CmdFundingSignAccept
 }
 
+// MaxPayloadLength ...
 func (c *FundingSignAccept) MaxPayloadLength(uint32) uint32 {
 	// 8 (base size) + 73 + (73maxSigSize*127maxInputs)
 	return 9352
 }
 
-// Makes sure the struct data is valid (e.g. no negatives or invalid pkscripts)
+// Validate makes sure the struct data is valid (e.g. no negatives or invalid pkscripts)
 func (c *FundingSignAccept) Validate() error {
 	// We're good!
 	return nil

--- a/lnwire/funding_signcomplete.go
+++ b/lnwire/funding_signcomplete.go
@@ -2,11 +2,13 @@ package lnwire
 
 import (
 	"fmt"
+	"io"
+
 	"github.com/btcsuite/btcd/btcec"
 	"github.com/btcsuite/btcd/wire"
-	"io"
 )
 
+// FundingSignComplete ...
 type FundingSignComplete struct {
 	ReservationID uint64
 
@@ -14,6 +16,7 @@ type FundingSignComplete struct {
 	FundingTXSigs []*btcec.Signature
 }
 
+// Decode ...
 func (c *FundingSignComplete) Decode(r io.Reader, pver uint32) error {
 	// ReservationID (8)
 	// TxID (32)
@@ -32,12 +35,12 @@ func (c *FundingSignComplete) Decode(r io.Reader, pver uint32) error {
 	return nil
 }
 
-// Creates a new FundingSignComplete
+// NewFundingSignComplete creates a new FundingSignComplete
 func NewFundingSignComplete() *FundingSignComplete {
 	return &FundingSignComplete{}
 }
 
-// Serializes the item from the FundingSignComplete struct
+// Encode serializes the item from the FundingSignComplete struct
 // Writes the data to w
 func (c *FundingSignComplete) Encode(w io.Writer, pver uint32) error {
 	err := writeElements(w,
@@ -51,16 +54,18 @@ func (c *FundingSignComplete) Encode(w io.Writer, pver uint32) error {
 	return nil
 }
 
+// Command ...
 func (c *FundingSignComplete) Command() uint32 {
 	return CmdFundingSignComplete
 }
 
+// MaxPayloadLength ...
 func (c *FundingSignComplete) MaxPayloadLength(uint32) uint32 {
 	// 8 (base size) + 32 + (73maxSigSize*127maxInputs)
 	return 9311
 }
 
-// Makes sure the struct data is valid (e.g. no negatives or invalid pkscripts)
+// Validate makes sure the struct data is valid (e.g. no negatives or invalid pkscripts)
 func (c *FundingSignComplete) Validate() error {
 	// We're good!
 	return nil

--- a/lnwire/htlc_addaccept.go
+++ b/lnwire/htlc_addaccept.go
@@ -5,11 +5,13 @@ import (
 	"io"
 )
 
+// HTLCAddAccept ...
 type HTLCAddAccept struct {
 	ChannelID uint64
-	HTLCKey HTLCKey
+	HTLCKey   HTLCKey
 }
 
+// Decode ...
 func (c *HTLCAddAccept) Decode(r io.Reader, pver uint32) error {
 	// ChannelID(8)
 	// HTLCKey(8)
@@ -24,12 +26,12 @@ func (c *HTLCAddAccept) Decode(r io.Reader, pver uint32) error {
 	return nil
 }
 
-// Creates a new HTLCAddAccept
+// NewHTLCAddAccept creates a new HTLCAddAccept
 func NewHTLCAddAccept() *HTLCAddAccept {
 	return &HTLCAddAccept{}
 }
 
-// Serializes the item from the HTLCAddAccept struct
+// Encode serializes the item from the HTLCAddAccept struct
 // Writes the data to w
 func (c *HTLCAddAccept) Encode(w io.Writer, pver uint32) error {
 	err := writeElements(w,
@@ -44,16 +46,18 @@ func (c *HTLCAddAccept) Encode(w io.Writer, pver uint32) error {
 	return nil
 }
 
+// Command ...
 func (c *HTLCAddAccept) Command() uint32 {
 	return CmdHTLCAddAccept
 }
 
+// MaxPayloadLength ...
 func (c *HTLCAddAccept) MaxPayloadLength(uint32) uint32 {
 	// 16 base size
 	return 16
 }
 
-// Makes sure the struct data is valid (e.g. no negatives or invalid pkscripts)
+// Validate makes sure the struct data is valid (e.g. no negatives or invalid pkscripts)
 func (c *HTLCAddAccept) Validate() error {
 	// We're good!
 	return nil

--- a/lnwire/htlc_addaccept_test.go
+++ b/lnwire/htlc_addaccept_test.go
@@ -7,7 +7,7 @@ import (
 var (
 	htlcAddAccept = &HTLCAddAccept{
 		ChannelID: uint64(12345678),
-		HTLCKey: HTLCKey(12345),
+		HTLCKey:   HTLCKey(12345),
 	}
 	htlcAddAcceptSerializedString  = "0000000000bc614e0000000000003039"
 	htlcAddAcceptSerializedMessage = "0709110b000003f2000000100000000000bc614e0000000000003039"

--- a/lnwire/htlc_addreject.go
+++ b/lnwire/htlc_addreject.go
@@ -5,11 +5,13 @@ import (
 	"io"
 )
 
+// HTLCAddReject ...
 type HTLCAddReject struct {
 	ChannelID uint64
-	HTLCKey HTLCKey
+	HTLCKey   HTLCKey
 }
 
+// Decode ...
 func (c *HTLCAddReject) Decode(r io.Reader, pver uint32) error {
 	// ChannelID(8)
 	// CommitmentHeight(8)
@@ -27,12 +29,12 @@ func (c *HTLCAddReject) Decode(r io.Reader, pver uint32) error {
 	return nil
 }
 
-// Creates a new HTLCAddReject
+// NewHTLCAddReject creates a new HTLCAddReject
 func NewHTLCAddReject() *HTLCAddReject {
 	return &HTLCAddReject{}
 }
 
-// Serializes the item from the HTLCAddReject struct
+// Encode serializes the item from the HTLCAddReject struct
 // Writes the data to w
 func (c *HTLCAddReject) Encode(w io.Writer, pver uint32) error {
 	err := writeElements(w,
@@ -47,16 +49,18 @@ func (c *HTLCAddReject) Encode(w io.Writer, pver uint32) error {
 	return nil
 }
 
+// Command ...
 func (c *HTLCAddReject) Command() uint32 {
 	return CmdHTLCAddReject
 }
 
+// MaxPayloadLength ...
 func (c *HTLCAddReject) MaxPayloadLength(uint32) uint32 {
 	// 16 base size
 	return 16
 }
 
-// Makes sure the struct data is valid (e.g. no negatives or invalid pkscripts)
+// Validate makes sure the struct data is valid (e.g. no negatives or invalid pkscripts)
 func (c *HTLCAddReject) Validate() error {
 	// We're good!
 	return nil

--- a/lnwire/htlc_addreject_test.go
+++ b/lnwire/htlc_addreject_test.go
@@ -7,7 +7,7 @@ import (
 var (
 	htlcAddReject = &HTLCAddReject{
 		ChannelID: uint64(12345678),
-		HTLCKey: HTLCKey(12345),
+		HTLCKey:   HTLCKey(12345),
 	}
 	htlcAddRejectSerializedString  = "0000000000bc614e0000000000003039"
 	htlcAddRejectSerializedMessage = "0709110b000003fc000000100000000000bc614e0000000000003039"

--- a/lnwire/htlc_addrequest.go
+++ b/lnwire/htlc_addrequest.go
@@ -5,6 +5,7 @@ import (
 	"io"
 )
 
+// HTLCAddRequest ...
 // Multiple Clearing Requests are possible by putting this inside an array of
 // clearing requests
 type HTLCAddRequest struct {
@@ -37,6 +38,7 @@ type HTLCAddRequest struct {
 	Blob []byte
 }
 
+// Decode ...
 func (c *HTLCAddRequest) Decode(r io.Reader, pver uint32) error {
 	// ChannelID(8)
 	// HTLCKey(8)
@@ -61,12 +63,12 @@ func (c *HTLCAddRequest) Decode(r io.Reader, pver uint32) error {
 	return nil
 }
 
-// Creates a new HTLCAddRequest
+// NewHTLCAddRequest creates a new HTLCAddRequest
 func NewHTLCAddRequest() *HTLCAddRequest {
 	return &HTLCAddRequest{}
 }
 
-// Serializes the item from the HTLCAddRequest struct
+// Encode serializes the item from the HTLCAddRequest struct
 // Writes the data to w
 func (c *HTLCAddRequest) Encode(w io.Writer, pver uint32) error {
 	err := writeElements(w,
@@ -85,17 +87,19 @@ func (c *HTLCAddRequest) Encode(w io.Writer, pver uint32) error {
 	return nil
 }
 
+// Command ...
 func (c *HTLCAddRequest) Command() uint32 {
 	return CmdHTLCAddRequest
 }
 
+// MaxPayloadLength ...
 func (c *HTLCAddRequest) MaxPayloadLength(uint32) uint32 {
 	// base size ~110, but blob can be variable.
 	// shouldn't be bigger than 8K though...
 	return 8192
 }
 
-// Makes sure the struct data is valid (e.g. no negatives or invalid pkscripts)
+// Validate makes sure the struct data is valid (e.g. no negatives or invalid pkscripts)
 func (c *HTLCAddRequest) Validate() error {
 	if c.Amount < 0 {
 		// While fees can be negative, it's too confusing to allow

--- a/lnwire/htlc_settleaccept.go
+++ b/lnwire/htlc_settleaccept.go
@@ -5,6 +5,7 @@ import (
 	"io"
 )
 
+// HTLCSettleAccept ...
 // Multiple Clearing Requests are possible by putting this inside an array of
 // clearing requests
 type HTLCSettleAccept struct {
@@ -15,6 +16,7 @@ type HTLCSettleAccept struct {
 	HTLCKey HTLCKey
 }
 
+// Decode ...
 func (c *HTLCSettleAccept) Decode(r io.Reader, pver uint32) error {
 	// ChannelID(8)
 	// HTLCKey(8)
@@ -29,12 +31,12 @@ func (c *HTLCSettleAccept) Decode(r io.Reader, pver uint32) error {
 	return nil
 }
 
-// Creates a new HTLCSettleAccept
+// NewHTLCSettleAccept creates a new HTLCSettleAccept
 func NewHTLCSettleAccept() *HTLCSettleAccept {
 	return &HTLCSettleAccept{}
 }
 
-// Serializes the item from the HTLCSettleAccept struct
+// Encode serializes the item from the HTLCSettleAccept struct
 // Writes the data to w
 func (c *HTLCSettleAccept) Encode(w io.Writer, pver uint32) error {
 	err := writeElements(w,
@@ -48,16 +50,18 @@ func (c *HTLCSettleAccept) Encode(w io.Writer, pver uint32) error {
 	return nil
 }
 
+// Command ...
 func (c *HTLCSettleAccept) Command() uint32 {
 	return CmdHTLCSettleAccept
 }
 
+// MaxPayloadLength ...
 func (c *HTLCSettleAccept) MaxPayloadLength(uint32) uint32 {
 	// 16
 	return 16
 }
 
-// Makes sure the struct data is valid (e.g. no negatives or invalid pkscripts)
+// Validate makes sure the struct data is valid (e.g. no negatives or invalid pkscripts)
 func (c *HTLCSettleAccept) Validate() error {
 	// We're good!
 	return nil

--- a/lnwire/htlc_settleaccept_test.go
+++ b/lnwire/htlc_settleaccept_test.go
@@ -7,7 +7,7 @@ import (
 var (
 	htlcSettleAccept = &HTLCSettleAccept{
 		ChannelID: uint64(12345678),
-		HTLCKey: HTLCKey(12345),
+		HTLCKey:   HTLCKey(12345),
 	}
 	htlcSettleAcceptSerializedString  = "0000000000bc614e0000000000003039"
 	htlcSettleAcceptSerializedMessage = "0709110b00000456000000100000000000bc614e0000000000003039"

--- a/lnwire/htlc_settlerequest.go
+++ b/lnwire/htlc_settlerequest.go
@@ -5,6 +5,7 @@ import (
 	"io"
 )
 
+// HTLCSettleRequest ...
 // Multiple Clearing Requests are possible by putting this inside an array of
 // clearing requests
 type HTLCSettleRequest struct {
@@ -18,6 +19,7 @@ type HTLCSettleRequest struct {
 	RedemptionProofs []*[20]byte
 }
 
+// Decode ...
 func (c *HTLCSettleRequest) Decode(r io.Reader, pver uint32) error {
 	// ChannelID(8)
 	// HTLCKey(8)
@@ -39,12 +41,12 @@ func (c *HTLCSettleRequest) Decode(r io.Reader, pver uint32) error {
 	return nil
 }
 
-// Creates a new HTLCSettleRequest
+// NewHTLCSettleRequest creates a new HTLCSettleRequest
 func NewHTLCSettleRequest() *HTLCSettleRequest {
 	return &HTLCSettleRequest{}
 }
 
-// Serializes the item from the HTLCSettleRequest struct
+// Encode serializes the item from the HTLCSettleRequest struct
 // Writes the data to w
 func (c *HTLCSettleRequest) Encode(w io.Writer, pver uint32) error {
 	err := writeElements(w,
@@ -59,16 +61,18 @@ func (c *HTLCSettleRequest) Encode(w io.Writer, pver uint32) error {
 	return nil
 }
 
+// Command ...
 func (c *HTLCSettleRequest) Command() uint32 {
 	return CmdHTLCSettleRequest
 }
 
+// MaxPayloadLength ...
 func (c *HTLCSettleRequest) MaxPayloadLength(uint32) uint32 {
 	// 21*15+16
 	return 331
 }
 
-// Makes sure the struct data is valid (e.g. no negatives or invalid pkscripts)
+// Validate makes sure the struct data is valid (e.g. no negatives or invalid pkscripts)
 func (c *HTLCSettleRequest) Validate() error {
 	// We're good!
 	return nil

--- a/lnwire/htlc_timeoutaccept.go
+++ b/lnwire/htlc_timeoutaccept.go
@@ -5,6 +5,7 @@ import (
 	"io"
 )
 
+// HTLCTimeoutAccept ...
 // Multiple Clearing Requests are possible by putting this inside an array of
 // clearing requests
 type HTLCTimeoutAccept struct {
@@ -15,6 +16,7 @@ type HTLCTimeoutAccept struct {
 	HTLCKey HTLCKey
 }
 
+// Decode ...
 func (c *HTLCTimeoutAccept) Decode(r io.Reader, pver uint32) error {
 	// ChannelID(8)
 	// HTLCKey(8)
@@ -29,12 +31,12 @@ func (c *HTLCTimeoutAccept) Decode(r io.Reader, pver uint32) error {
 	return nil
 }
 
-// Creates a new HTLCTimeoutAccept
+// NewHTLCTimeoutAccept creates a new HTLCTimeoutAccept
 func NewHTLCTimeoutAccept() *HTLCTimeoutAccept {
 	return &HTLCTimeoutAccept{}
 }
 
-// Serializes the item from the HTLCTimeoutAccept struct
+// Encode serializes the item from the HTLCTimeoutAccept struct
 // Writes the data to w
 func (c *HTLCTimeoutAccept) Encode(w io.Writer, pver uint32) error {
 	err := writeElements(w,
@@ -48,16 +50,18 @@ func (c *HTLCTimeoutAccept) Encode(w io.Writer, pver uint32) error {
 	return nil
 }
 
+// Command ...
 func (c *HTLCTimeoutAccept) Command() uint32 {
 	return CmdHTLCTimeoutAccept
 }
 
+// MaxPayloadLength ...
 func (c *HTLCTimeoutAccept) MaxPayloadLength(uint32) uint32 {
 	// 16
 	return 16
 }
 
-// Makes sure the struct data is valid (e.g. no negatives or invalid pkscripts)
+// Validate makes sure the struct data is valid (e.g. no negatives or invalid pkscripts)
 func (c *HTLCTimeoutAccept) Validate() error {
 	// We're good!
 	return nil

--- a/lnwire/htlc_timeoutaccept_test.go
+++ b/lnwire/htlc_timeoutaccept_test.go
@@ -7,7 +7,7 @@ import (
 var (
 	htlcTimeoutAccept = &HTLCTimeoutAccept{
 		ChannelID: uint64(12345678),
-		HTLCKey: HTLCKey(12345),
+		HTLCKey:   HTLCKey(12345),
 	}
 	htlcTimeoutAcceptSerializedString  = "0000000000bc614e0000000000003039"
 	htlcTimeoutAcceptSerializedMessage = "0709110b0000051e000000100000000000bc614e0000000000003039"

--- a/lnwire/htlc_timeoutrequest.go
+++ b/lnwire/htlc_timeoutrequest.go
@@ -5,6 +5,7 @@ import (
 	"io"
 )
 
+// HTLCTimeoutRequest ...
 // Multiple Clearing Requests are possible by putting this inside an array of
 // clearing requests
 type HTLCTimeoutRequest struct {
@@ -15,6 +16,7 @@ type HTLCTimeoutRequest struct {
 	HTLCKey HTLCKey
 }
 
+// Decode ...
 func (c *HTLCTimeoutRequest) Decode(r io.Reader, pver uint32) error {
 	// ChannelID(8)
 	// HTLCKey(8)
@@ -29,12 +31,12 @@ func (c *HTLCTimeoutRequest) Decode(r io.Reader, pver uint32) error {
 	return nil
 }
 
-// Creates a new HTLCTimeoutRequest
+// NewHTLCTimeoutRequest creates a new HTLCTimeoutRequest
 func NewHTLCTimeoutRequest() *HTLCTimeoutRequest {
 	return &HTLCTimeoutRequest{}
 }
 
-// Serializes the item from the HTLCTimeoutRequest struct
+// Encode serializes the item from the HTLCTimeoutRequest struct
 // Writes the data to w
 func (c *HTLCTimeoutRequest) Encode(w io.Writer, pver uint32) error {
 	err := writeElements(w,
@@ -48,16 +50,18 @@ func (c *HTLCTimeoutRequest) Encode(w io.Writer, pver uint32) error {
 	return nil
 }
 
+// Command ...
 func (c *HTLCTimeoutRequest) Command() uint32 {
 	return CmdHTLCTimeoutRequest
 }
 
+// MaxPayloadLength ...
 func (c *HTLCTimeoutRequest) MaxPayloadLength(uint32) uint32 {
 	// 16
 	return 16
 }
 
-// Makes sure the struct data is valid (e.g. no negatives or invalid pkscripts)
+// Validate makes sure the struct data is valid (e.g. no negatives or invalid pkscripts)
 func (c *HTLCTimeoutRequest) Validate() error {
 	// We're good!
 	return nil

--- a/lnwire/htlc_timeoutrequest_test.go
+++ b/lnwire/htlc_timeoutrequest_test.go
@@ -7,7 +7,7 @@ import (
 var (
 	htlcTimeoutRequest = &HTLCTimeoutRequest{
 		ChannelID: uint64(12345678),
-		HTLCKey: HTLCKey(12345),
+		HTLCKey:   HTLCKey(12345),
 	}
 	htlcTimeoutRequestSerializedString  = "0000000000bc614e0000000000003039"
 	htlcTimeoutRequestSerializedMessage = "0709110b00000514000000100000000000bc614e0000000000003039"

--- a/lnwire/lnwire.go
+++ b/lnwire/lnwire.go
@@ -4,29 +4,35 @@ import (
 	"bytes"
 	"encoding/binary"
 	"fmt"
+	"io"
+	"io/ioutil"
+
 	"github.com/btcsuite/btcd/btcec"
 	"github.com/btcsuite/btcd/wire"
 	"github.com/btcsuite/btcutil"
-	"io"
-	"io/ioutil"
 )
 
-var MAX_SLICE_LENGTH = 65535
+// MaxSliceLength ...
+var MaxSliceLength = 65535
 
-// Actual pkScript, not redeemScript
+// PkScript is the actual PkScript, not redeemScript
 type PkScript []byte
 
+// HTLCKey ...
 type HTLCKey uint64
+
+// CommitHeight ...
 type CommitHeight uint64
 
+// CreditsAmount ...
 // Subsatoshi amount (Micro-Satoshi, 1/1000th)
 // Should be a signed int to account for negative fees
-// 
+//
 // "In any science-fiction movie, anywhere in the galaxy, currency is referred
 // to as 'credits.'"
 // 	--Sam Humphries. Ebert, Roger (1999). Ebert's bigger little movie
 // 	glossary. Andrews McMeel. p. 172.
-// 
+//
 // https:// en.wikipedia.org/wiki/List_of_fictional_currencies
 // https:// en.wikipedia.org/wiki/Fictional_currency#Trends_in_the_use_of_fictional_currencies
 // http:// tvtropes.org/pmwiki/pmwiki.php/Main/WeWillSpendCreditsInTheFuture
@@ -197,7 +203,7 @@ func writeElement(w io.Writer, element interface{}) error {
 		return nil
 	case []byte:
 		sliceLength := len(e)
-		if sliceLength > MAX_SLICE_LENGTH {
+		if sliceLength > MaxSliceLength {
 			return fmt.Errorf("Slice length too long!")
 		}
 		// Write the size
@@ -437,7 +443,7 @@ func readElement(r io.Reader, element interface{}) error {
 			return err
 		}
 		if len(sig) != int(sigLength) {
-			return fmt.Errorf("EOF: Signature length mismatch.")
+			return fmt.Errorf("EOF: Signature length mismatch")
 		}
 		btcecSig, err := btcec.ParseSignature(sig, btcec.S256())
 		if err != nil {
@@ -487,8 +493,8 @@ func readElement(r io.Reader, element interface{}) error {
 		}
 
 		// Shouldn't need to do this, since it's uint16, but we
-		// might have a different value for MAX_SLICE_LENGTH...
-		if int(blobLength) > MAX_SLICE_LENGTH {
+		// might have a different value for MaxSliceLength...
+		if int(blobLength) > MaxSliceLength {
 			return fmt.Errorf("Slice length too long!")
 		}
 
@@ -499,7 +505,7 @@ func readElement(r io.Reader, element interface{}) error {
 			return err
 		}
 		if len(*e) != int(blobLength) {
-			return fmt.Errorf("EOF: Slice length mismatch.")
+			return fmt.Errorf("EOF: Slice length mismatch")
 		}
 		return nil
 	case *PkScript:
@@ -521,7 +527,7 @@ func readElement(r io.Reader, element interface{}) error {
 			return err
 		}
 		if len(*e) != int(scriptLength) {
-			return fmt.Errorf("EOF: Signature length mismatch.")
+			return fmt.Errorf("EOF: Signature length mismatch")
 		}
 		return nil
 	case *string:
@@ -535,7 +541,7 @@ func readElement(r io.Reader, element interface{}) error {
 		l := io.LimitReader(r, int64(strlen))
 		b, err := ioutil.ReadAll(l)
 		if len(b) != int(strlen) {
-			return fmt.Errorf("EOF: String length mismatch.")
+			return fmt.Errorf("EOF: String length mismatch")
 		}
 		*e = string(b)
 		if err != nil {
@@ -603,7 +609,7 @@ func readElements(r io.Reader, elements ...interface{}) error {
 	return nil
 }
 
-// Validates whether a PkScript byte array is P2SH or P2PKH
+// ValidatePkScript validates whether a PkScript byte array is P2SH or P2PKH
 func ValidatePkScript(pkScript PkScript) error {
 	if &pkScript == nil {
 		return fmt.Errorf("PkScript should not be empty!")

--- a/lnwire/lnwire_test.go
+++ b/lnwire/lnwire_test.go
@@ -3,12 +3,13 @@ package lnwire
 import (
 	"bytes"
 	"encoding/hex"
-	"github.com/btcsuite/btcd/btcec"
-	"github.com/btcsuite/btcd/txscript"
-	"github.com/btcsuite/btcd/wire"
 	"io/ioutil"
 	"reflect"
 	"testing"
+
+	"github.com/btcsuite/btcd/btcec"
+	"github.com/btcsuite/btcd/txscript"
+	"github.com/btcsuite/btcd/wire"
 )
 
 // Common variables and functions for the message tests
@@ -16,8 +17,8 @@ import (
 var (
 	// For debugging, writes to /dev/shm/
 	// Maybe in the future do it if you do "go test -v"
-	WRITE_FILE = true
-	filename   = "/dev/shm/serialized.raw"
+	WriteFile = true
+	filename  = "/dev/shm/serialized.raw"
 
 	// preimage: 9a2cbd088763db88dd8ba79e5726daa6aba4aa7e
 	// echo -n | openssl sha256 | openssl ripemd160 | openssl sha256 | openssl ripemd160
@@ -101,7 +102,7 @@ func SerializeTest(t *testing.T, message Message, expectedString string, filenam
 		}
 
 		// So I can do: hexdump -C /dev/shm/fundingRequest.raw
-		if WRITE_FILE {
+		if WriteFile {
 			err = ioutil.WriteFile(filename, b.Bytes(), 0644)
 			if err != nil {
 				t.Error(err.Error())

--- a/lnwire/message.go
+++ b/lnwire/message.go
@@ -1,3 +1,4 @@
+// Package lnwire ...
 // Code derived from https:// github.com/btcsuite/btcd/blob/master/wire/message.go
 package lnwire
 
@@ -11,58 +12,67 @@ import (
 
 //  message type identifyer bytes
 const (
-	MSGID_FUNDREQUEST  = 0x30
-	MSGID_FUNDRESPONSE = 0x31
+	MsgIDFundRequest  = 0x30
+	MsgIDFundResponse = 0x31
 
-	MSGID_CLOSEREQUEST  = 0x40
-	MSGID_CLOSERESPONSE = 0x41
+	MsgIDCloseRequest  = 0x40
+	MsgIDCloseResponse = 0x41
 
-	MSGID_TEXTCHAT = 0x70
+	MsgIDTextChat = 0x70
 
-	MSGID_FWDMSG     = 0x20
-	MSGID_FWDAUTHREQ = 0x21
+	MsgIDFwdMsg     = 0x20
+	MsgIDFwdAuthReq = 0x21
 )
 
 // 4-byte network + 4-byte message id + payload-length 4-byte
 const MessageHeaderSize = 12
 
-const MaxMessagePayload = 1024 * 1024 * 32 //  32MB
+// 32MB
+const MaxMessagePayload = 1024 * 1024 * 32
 
+// constants ...
 const (
 	// Funding channel open
+
 	CmdFundingRequest      = uint32(200)
 	CmdFundingResponse     = uint32(210)
 	CmdFundingSignAccept   = uint32(220)
 	CmdFundingSignComplete = uint32(230)
 
 	// Close channel
+
 	CmdCloseRequest  = uint32(300)
 	CmdCloseComplete = uint32(310)
 
 	// TODO Renumber to 1100
 	// HTLC payment
+
 	CmdHTLCAddRequest = uint32(1000)
 	CmdHTLCAddAccept  = uint32(1010)
 	CmdHTLCAddReject  = uint32(1020)
 
 	// TODO Renumber to 1200
 	// HTLC settlement
+
 	CmdHTLCSettleRequest = uint32(1100)
 	CmdHTLCSettleAccept  = uint32(1110)
 
 	// HTLC timeout
+
 	CmdHTLCTimeoutRequest = uint32(1300)
 	CmdHTLCTimeoutAccept  = uint32(1310)
 
 	// Commitments
+
 	CmdCommitSignature  = uint32(2000)
 	CmdCommitRevocation = uint32(2010)
 
 	// Error
+
 	CmdErrorGeneric = uint32(4000)
 )
 
-// Every message has these functions:
+// A Message has these functions:
 type Message interface {
 	Decode(io.Reader, uint32) error // (io, protocol version)
 	Encode(io.Writer, uint32) error // (io, protocol version)
@@ -165,6 +175,7 @@ func discardInput(r io.Reader, n uint32) {
 	}
 }
 
+// WriteMessage ...
 func WriteMessage(w io.Writer, msg Message, pver uint32, btcnet wire.BitcoinNet) (int, error) {
 	totalBytes := 0
 
@@ -219,6 +230,7 @@ func WriteMessage(w io.Writer, msg Message, pver uint32, btcnet wire.BitcoinNet)
 	return totalBytes, nil
 }
 
+// ReadMessage ...
 func ReadMessage(r io.Reader, pver uint32, btcnet wire.BitcoinNet) (int, Message, []byte, error) {
 	totalBytes := 0
 	n, hdr, err := readMessageHeader(r)
@@ -229,7 +241,7 @@ func ReadMessage(r io.Reader, pver uint32, btcnet wire.BitcoinNet) (int, Message
 
 	// Enforce maximum message payload
 	if hdr.length > MaxMessagePayload {
-		return totalBytes, nil, nil, fmt.Errorf("message payload is too large - header indicates %d bytes, but max message payload is %d bytes.", hdr.length, MaxMessagePayload)
+		return totalBytes, nil, nil, fmt.Errorf("message payload is too large - header indicates %d bytes, but max message payload is %d bytes", hdr.length, MaxMessagePayload)
 	}
 
 	// Check for messages in the wrong bitcoin network
@@ -250,7 +262,7 @@ func ReadMessage(r io.Reader, pver uint32, btcnet wire.BitcoinNet) (int, Message
 	mpl := msg.MaxPayloadLength(pver)
 	if hdr.length > mpl {
 		discardInput(r, hdr.length)
-		return totalBytes, nil, nil, fmt.Errorf("payload exceeds max length. indicates %v bytes, but max of message type %v is %v.", hdr.length, command, mpl)
+		return totalBytes, nil, nil, fmt.Errorf("payload exceeds max length. indicates %v bytes, but max of message type %v is %v", hdr.length, command, mpl)
 	}
 
 	// Read payload

--- a/peer.go
+++ b/peer.go
@@ -55,7 +55,7 @@ type peer struct {
 	lightningAddr   lndc.LNAdr
 	inbound         bool
 	protocolVersion uint32
-	peerId          int32
+	peerID          int32
 
 	// For purposes of detecting retransmits, etc.
 	lastNMessages map[lnwire.Message]struct{}
@@ -88,7 +88,7 @@ type peer struct {
 func newPeer(conn net.Conn, server *server) *peer {
 	return &peer{
 		conn:   conn,
-		peerId: atomic.AddInt32(&numNodes, 1),
+		peerID: atomic.AddInt32(&numNodes, 1),
 
 		lastNMessages: make(map[lnwire.Message]struct{}),
 

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -32,8 +32,8 @@ type rpcServer struct {
 
 var _ lnrpc.LightningServer = (*rpcServer)(nil)
 
-// newRpcServer...
-func newRpcServer(s *server) *rpcServer {
+// newRPCServer...
+func newRPCServer(s *server) *rpcServer {
 	return &rpcServer{server: s, quit: make(chan struct{}, 1)}
 }
 

--- a/server.go
+++ b/server.go
@@ -66,7 +66,7 @@ func newServer(listenAddrs []string, bitcoinNet *chaincfg.Params,
 		quit:         make(chan struct{}),
 	}
 
-	s.rpcServer = newRpcServer(s)
+	s.rpcServer = newRPCServer(s)
 
 	return s, nil
 }
@@ -83,7 +83,7 @@ func (s *server) addPeer(p *peer) {
 		return
 	}
 
-	s.peers[p.peerId] = p
+	s.peers[p.peerID] = p
 }
 
 // removePeer...
@@ -142,11 +142,11 @@ out:
 					// For the lndc crypto handshake, we
 					// either need a compressed pubkey, or a
 					// 20-byte pkh.
-					var remoteId []byte
+					var remoteID []byte
 					if addr.PubKey == nil {
-						remoteId = addr.Base58Addr.ScriptAddress()
+						remoteID = addr.Base58Addr.ScriptAddress()
 					} else {
-						remoteId = addr.PubKey.SerializeCompressed()
+						remoteID = addr.PubKey.SerializeCompressed()
 					}
 
 					// Attempt to connect to the remote
@@ -157,7 +157,7 @@ out:
 					ipAddr := addr.NetAddr.String()
 					conn := lndc.NewConn(nil)
 					if err := conn.Dial(
-						s.longTermPriv, ipAddr, remoteId); err != nil {
+						s.longTermPriv, ipAddr, remoteID); err != nil {
 						msg.reply <- err
 					}
 
@@ -251,7 +251,7 @@ func (s *server) Stop() error {
 
 // getIdentityPrivKey gets the identity private key out of the wallet DB.
 func getIdentityPrivKey(l *lnwallet.LightningWallet) (*btcec.PrivateKey, error) {
-	adr, err := l.ChannelDB.GetIdAdr()
+	adr, err := l.ChannelDB.GetIDAdr()
 	if err != nil {
 		return nil, err
 	}

--- a/shachain/shachain.go
+++ b/shachain/shachain.go
@@ -22,7 +22,7 @@ type chainBranch struct {
 	hash  [32]byte
 }
 
-// HyperShaChain...
+// HyperShaChain ...
 // * https://github.com/rustyrussell/ccan/blob/master/ccan/crypto/shachain/design.txt
 type HyperShaChain struct {
 	sync.RWMutex
@@ -35,13 +35,13 @@ type HyperShaChain struct {
 	lastHash wire.ShaHash
 }
 
-// NewHyperShaChain
+// New ...
 //  * used to track their pre-images
 func New() *HyperShaChain {
 	return &HyperShaChain{lastChainIndex: 0, numValid: 0}
 }
 
-// NewHyperShaChainFromSeed...
+// NewFromSeed ...
 //  * used to derive your own pre-images
 func NewFromSeed(seed *[32]byte, deriveTo uint64) (*HyperShaChain, error) {
 	var shaSeed [32]byte
@@ -95,7 +95,7 @@ func canDerive(from, to uint64) bool {
 	return ^from&to == 1
 }
 
-// getHash...
+// GetHash ...
 // index should be commitment #
 func (h *HyperShaChain) GetHash(index uint64) (*[32]byte, error) {
 	for i := uint64(0); i < h.numValid; i++ {
@@ -114,7 +114,7 @@ func (h *HyperShaChain) GetHash(index uint64) (*[32]byte, error) {
 	return nil, fmt.Errorf("unable to derive hash # %v", index)
 }
 
-// addHash
+// AddNextHash ...
 func (h *HyperShaChain) AddNextHash(hash [32]byte) error {
 	// Hashes for a remote chain must be added in order.
 	nextIdx := h.lastChainIndex + 1
@@ -144,14 +144,14 @@ func (h *HyperShaChain) AddNextHash(hash [32]byte) error {
 	return nil
 }
 
-// CurrentPreImage...
+// CurrentPreImage ...
 func (h *HyperShaChain) CurrentPreImage() *wire.ShaHash {
 	h.RLock()
 	defer h.RUnlock()
 	return &h.lastHash
 }
 
-// CurrentRevocationHash...
+// CurrentRevocationHash ...
 // TODO(roasbeef): *wire.ShaHash vs [wire.HashSize]byte ?
 func (h *HyperShaChain) CurrentRevocationHash() []byte {
 	h.RLock()
@@ -159,7 +159,7 @@ func (h *HyperShaChain) CurrentRevocationHash() []byte {
 	return btcutil.Hash160(h.lastHash[:])
 }
 
-// LocatePreImage...
+// LocatePreImage ...
 // Alice just broadcasted an old commitment tx, we need the revocation hash to
 // claim the funds so we don't get cheated. However, we aren't storing all the
 // pre-images in memory. So which shachain index # did she broadcast?
@@ -170,12 +170,14 @@ func (h *HyperShaChain) LocatePreImage(outputScript []byte) (uint64, *[32]byte) 
 	return 0, nil
 }
 
-// MarshallBinary...
+// Encode ...
+// (MarshallBinary ...)
 func (h *HyperShaChain) Encode(b io.Writer) error {
 	return nil
 }
 
-// UnmarshallBinary...
+// Decode ...
+// UnmarshallBinary ...
 func (h *HyperShaChain) Decode(b io.Reader) error {
 	return nil
 }

--- a/uspv/eight333.go
+++ b/uspv/eight333.go
@@ -18,14 +18,18 @@ const (
 	headerFileName = "headers.bin"
 	// Except hash-160s, those aren't backwards.  But anything that's 32 bytes is.
 	// because, cmon, 32?  Gotta reverse that.  But 20?  20 is OK.
+
+	// NETVERSION ...
 	NETVERSION = wire.TestNet3
-	VERSION    = 70011
+	// VERSION ...
+	VERSION = 70011
 )
 
 var (
 	params = &chaincfg.TestNet3Params
 )
 
+// SPVCon ...
 type SPVCon struct {
 	con        net.Conn // the (probably tcp) connection to the node
 	headerFile *os.File // file for SPV headers
@@ -45,6 +49,7 @@ type SPVCon struct {
 	TS *TxStore
 }
 
+// Open ...
 func (s *SPVCon) Open(remoteNode string, hfn string, inTs *TxStore) error {
 	// open header file
 	err := s.openHeaderFile(headerFileName)
@@ -139,6 +144,7 @@ func (s *SPVCon) openHeaderFile(hfn string) error {
 	return nil
 }
 
+// PongBack ...
 func (s *SPVCon) PongBack(nonce uint64) {
 	mpong := wire.NewMsgPong(nonce)
 
@@ -146,11 +152,13 @@ func (s *SPVCon) PongBack(nonce uint64) {
 	return
 }
 
+// SendFilter ...
 func (s *SPVCon) SendFilter(f *bloom.Filter) {
 	s.outMsgQueue <- f.MsgFilterLoad()
 	return
 }
 
+// AskForHeaders ...
 func (s *SPVCon) AskForHeaders() error {
 	var hdr wire.BlockHeader
 	ghdr := wire.NewMsgGetHeaders()
@@ -194,6 +202,7 @@ func (s *SPVCon) AskForHeaders() error {
 	return nil
 }
 
+// IngestHeaders ...
 func (s *SPVCon) IngestHeaders(m *wire.MsgHeaders) (bool, error) {
 	var err error
 	_, err = s.headerFile.Seek(-80, os.SEEK_END)
@@ -274,6 +283,7 @@ func (s *SPVCon) IngestHeaders(m *wire.MsgHeaders) (bool, error) {
 	return true, nil
 }
 
+// AskForMerkBlocks ...
 func (s *SPVCon) AskForMerkBlocks(current, last uint32) error {
 	var hdr wire.BlockHeader
 	_, err := s.headerFile.Seek(int64(current*80), os.SEEK_SET)

--- a/uspv/header.go
+++ b/uspv/header.go
@@ -90,6 +90,7 @@ func calcDiffAdjust(start, end wire.BlockHeader, p *chaincfg.Params) uint32 {
 	return blockchain.BigToCompact(newTarget)
 }
 
+// CheckHeader ...
 func CheckHeader(r io.ReadSeeker, height int64, p *chaincfg.Params) bool {
 	var err error
 	var cur, prev, epochStart wire.BlockHeader
@@ -179,11 +180,11 @@ func CheckHeader(r io.ReadSeeker, height int64, p *chaincfg.Params) bool {
 	return true // it must have worked if there's no errors and got to the end.
 }
 
-/* checkrange verifies a range of headers.  it checks their proof of work,
-difficulty adjustments, and that they all link in to each other properly.
-This is the only blockchain technology in the whole code base.
-Returns false if anything bad happens.  Returns true if the range checks
-out with no errors. */
+// CheckRange verifies a range of headers.  It checks their proof of work,
+// difficulty adjustments, and that they all link in to each other properly.
+// This is the only blockchain technology in the whole code base.
+// Returns false if anything bad happens.  Returns true if the range checks
+// out with no errors.
 func CheckRange(r io.ReadSeeker, first, last int64, p *chaincfg.Params) bool {
 	for i := first; i <= last; i++ {
 		if !CheckHeader(r, i, p) {

--- a/uspv/mblock.go
+++ b/uspv/mblock.go
@@ -6,6 +6,7 @@ import (
 	"github.com/btcsuite/btcd/wire"
 )
 
+// MakeMerkleParent ...
 func MakeMerkleParent(left *wire.ShaHash, right *wire.ShaHash) *wire.ShaHash {
 	// this can screw things up; CVE-2012-2459
 	if left != nil && right != nil && left.IsEqual(right) {

--- a/uspv/txstore.go
+++ b/uspv/txstore.go
@@ -10,6 +10,7 @@ import (
 	"github.com/btcsuite/btcutil/bloom"
 )
 
+// TxStore ...
 type TxStore struct {
 	KnownTxids []*wire.ShaHash
 	Utxos      []Utxo  // stacks on stacks
@@ -17,6 +18,7 @@ type TxStore struct {
 	Adrs       []MyAdr // endeavouring to acquire capital
 }
 
+// Utxo ...
 type Utxo struct { // cash money.
 	// combo of outpoint and txout which has all the info needed to spend
 	Op       wire.OutPoint
@@ -25,12 +27,13 @@ type Utxo struct { // cash money.
 	KeyIdx   uint32 // index for private key needed to sign / spend
 }
 
+// MyAdr ...
 type MyAdr struct { // an address I have the private key for
 	btcutil.Address
 	KeyIdx uint32 // index for private key needed to sign / spend
 }
 
-// add addresses into the TxStore
+// AddAdr adds addresses into the TxStore
 func (t *TxStore) AddAdr(a btcutil.Address, kidx uint32) {
 	var ma MyAdr
 	ma.Address = a
@@ -39,7 +42,7 @@ func (t *TxStore) AddAdr(a btcutil.Address, kidx uint32) {
 	return
 }
 
-// add txid of interest
+// AddTxid adds txid of interest
 func (t *TxStore) AddTxid(txid *wire.ShaHash) error {
 	if txid == nil {
 		return fmt.Errorf("tried to add nil txid")
@@ -48,7 +51,7 @@ func (t *TxStore) AddTxid(txid *wire.ShaHash) error {
 	return nil
 }
 
-// ... or I'm gonna fade away
+// GimmeFilter ... or I'm gonna fade away
 func (t *TxStore) GimmeFilter() (*bloom.Filter, error) {
 	if len(t.Adrs) == 0 {
 		return nil, fmt.Errorf("no addresses to filter for")
@@ -60,7 +63,7 @@ func (t *TxStore) GimmeFilter() (*bloom.Filter, error) {
 	return f, nil
 }
 
-// Ingest a tx into wallet, dealing with both gains and losses
+// IngestTx ingests a tx into wallet, dealing with both gains and losses
 func (t *TxStore) IngestTx(tx *wire.MsgTx) error {
 	var match bool
 	inTxid := tx.TxSha()
@@ -86,7 +89,7 @@ func (t *TxStore) IngestTx(tx *wire.MsgTx) error {
 	return nil
 }
 
-// Absorb money into wallet from a tx
+// AbsorbTx absorbs money into wallet from a tx
 func (t *TxStore) AbsorbTx(tx *wire.MsgTx) error {
 	if tx == nil {
 		return fmt.Errorf("Tried to add nil tx")
@@ -120,7 +123,7 @@ func (t *TxStore) AbsorbTx(tx *wire.MsgTx) error {
 	return nil
 }
 
-// Expell money from wallet due to a tx
+// ExpellTx expells money from wallet due to a tx
 func (t *TxStore) ExpellTx(tx *wire.MsgTx) error {
 	if tx == nil {
 		return fmt.Errorf("Tried to add nil tx")


### PR DESCRIPTION
Silence all complaints when `golint ./...` is run, *except* for those caused by generated gRPC code in **rpc.pb.go**, as well as the OP_CHECKSEQUENCEVERIFY opcode in **script_utils.go** 

### Fixed:

```
peer.go:58:2: struct field peerId should be peerID
rpcserver.go:36:6: func newRpcServer should be newRPCServer
server.go:145:10: var remoteId should be remoteID
chainntfs/chainntfs.go:5:1: comment on exported type ChainNotifier should be of the form "ChainNotifier ..." (with optional leading article)
chainntfs/chainntfs.go:22:6: exported type NotificationTrigger should have comment or be unexported
chainntfs/btcdnotify/btcd.go:15:1: comment on exported type BtcdNotifier should be of the form "BtcdNotifier ..." (with optional leading article)
chainntfs/btcdnotify/btcd.go:40:1: comment on exported function NewBtcdNotifier should be of the form "NewBtcdNotifier ..."
chainntfs/btcdnotify/btcd.go:60:1: comment on exported method BtcdNotifier.Start should be of the form "Start ..."
chainntfs/btcdnotify/btcd.go:74:1: comment on exported method BtcdNotifier.Stop should be of the form "Stop ..."
chainntfs/btcdnotify/btcd.go:216:1: comment on exported method BtcdNotifier.RegisterSpendNotification should be of the form "RegisterSpendNotification ..."
chainntfs/btcdnotify/btcd.go:233:1: comment on exported method BtcdNotifier.RegisterConfirmationsNotification should be of the form "RegisterConfirmationsNotification ..."
chainntfs/btcdnotify/source.go:8:1: comment on exported type ChainConnection should be of the form "ChainConnection ..." (with optional leading article)
channeldb/channel.go:26:2: comment on exported var ActiveNetParams should be of the form "ActiveNetParams ..."
channeldb/channel.go:30:1: comment on exported type Payment should be of the form "Payment ..." (with optional leading article)
channeldb/channel.go:36:1: comment on exported type ClosedChannel should be of the form "ClosedChannel ..." (with optional leading article)
channeldb/channel.go:40:1: comment on exported type OpenChannel should be of the form "OpenChannel ..." (with optional leading article)
channeldb/channel.go:100:1: comment on exported method DB.PutIdKey should be of the form "PutIdKey ..."
channeldb/channel.go:102:14: func PutIdKey should be PutIDKey
channeldb/channel.go:111:1: comment on exported method DB.GetIdAdr should be of the form "GetIdAdr ..."
channeldb/channel.go:112:14: func GetIdAdr should be GetIDAdr
channeldb/channel.go:128:1: comment on exported method DB.PutOpenChannel should be of the form "PutOpenChannel ..."
channeldb/channel.go:143:1: comment on exported method DB.FetchOpenChannel should be of the form "FetchOpenChannel ..."
channeldb/channel.go:218:1: comment on exported method OpenChannel.Encode should be of the form "Encode ..."
channeldb/channel.go:309:1: comment on exported method OpenChannel.Decode should be of the form "Decode ..."
channeldb/db.go:20:1: comment on exported type DB should be of the form "DB ..." (with optional leading article)
channeldb/db.go:29:1: comment on exported method DB.Wipe should be of the form "Wipe ..."
channeldb/db.go:38:1: comment on exported function New should be of the form "New ..."
channeldb/db.go:45:1: comment on exported function Open should be of the form "Open ..."
channeldb/db.go:51:1: comment on exported function Create should be of the form "Create ..."
cmd/lncli/commands.go:13:6: func printRespJson should be printRespJSON
cmd/lncli/commands.go:24:5: exported var ShellCommand should have comment or be unexported
cmd/lncli/commands.go:32:5: exported var NewAddressCommand should have comment or be unexported
cmd/lncli/commands.go:50:5: exported var SendManyCommand should have comment or be unexported
cmd/lncli/commands.go:76:5: exported var ConnectCommand should have comment or be unexported
cmd/lnshell/commands.go:11:1: comment on exported function RpcConnect should be of the form "RpcConnect ..."
cmd/lnshell/commands.go:12:6: func RpcConnect should be RPCConnect
cmd/lnshell/commands.go:41:1: exported function LnConnect should have comment or be unexported
cmd/lnshell/lnshellmain.go:56:1: exported function Shellparse should have comment or be unexported
elkrem/elkrem.go:37:1: comment on exported type ElkremNode should be of the form "ElkremNode ..." (with optional leading article)
elkrem/elkrem.go:39:6: type name will be used as elkrem.ElkremNode by other packages, and that stutters; consider calling this Node
elkrem/elkrem.go:44:6: exported type ElkremSender should have comment or be unexported
elkrem/elkrem.go:44:6: type name will be used as elkrem.ElkremSender by other packages, and that stutters; consider calling this Sender
elkrem/elkrem.go:50:6: exported type ElkremReceiver should have comment or be unexported
elkrem/elkrem.go:50:6: type name will be used as elkrem.ElkremReceiver by other packages, and that stutters; consider calling this Receiver
elkrem/elkrem.go:56:1: exported function LeftSha should have comment or be unexported
elkrem/elkrem.go:59:1: exported function RightSha should have comment or be unexported
elkrem/elkrem.go:85:1: comment on exported function NewElkremSender should be of the form "NewElkremSender ..."
elkrem/elkrem.go:98:1: comment on exported function NewElkremReceiver should be of the form "NewElkremReceiver ..."
elkrem/elkrem.go:105:1: comment on exported method ElkremSender.Next should be of the form "Next ..."
elkrem/elkrem.go:112:1: comment on exported method ElkremSender.AtIndex should be of the form "AtIndex ..."
elkrem/elkrem.go:118:1: exported method ElkremReceiver.AddNext should have comment or be unexported
elkrem/elkrem.go:143:1: exported method ElkremReceiver.AtIndex should have comment or be unexported
lndc/conn.go:18:1: comment on exported type LNDConn should be of the form "LNDConn ..." (with optional leading article)
lndc/conn.go:49:1: comment on exported function NewConn should be of the form "NewConn ..."
lndc/conn.go:54:1: comment on exported method LNDConn.Dial should be of the form "Dial ..."
lndc/conn.go:56:2: method parameter myId should be myID
lndc/conn.go:56:42: method parameter remoteId should be remoteID
lndc/conn.go:150:2: method parameter myId should be myID
lndc/conn.go:199:2: method parameter myId should be myID
lndc/listener.go:14:1: comment on exported type Listener should be of the form "Listener ..." (with optional leading article)
lndc/listener.go:23:1: comment on exported function NewListener should be of the form "NewListener ..."
lndc/listener.go:118:2: method parameter myId should be myID
lndc/lnadr.go:14:1: comment on exported type LNAdr should be of the form "LNAdr ..." (with optional leading article)
lndc/lnadr.go:16:2: struct field lnId should be lnID
lndc/lnadr.go:28:6: var encodedId should be encodedID
lndc/lnadr.go:38:1: comment on exported function LnAddrFromString should be of the form "LnAddrFromString ..."
lnstate/lnstate.go:45:2: don't use ALL_CAPS in Go names; use CamelCase
lnstate/lnstate.go:45:2: exported const MAX_STAGED_HTLCS should have comment (or a comment on this block) or be unexported
lnstate/lnstate.go:46:2: don't use ALL_CAPS in Go names; use CamelCase
lnstate/lnstate.go:47:2: don't use ALL_CAPS in Go names; use CamelCase
lnstate/lnstate.go:72:2: comment on exported const ADD_PRESTAGE should be of the form "ADD_PRESTAGE ..."
lnstate/lnstate.go:73:2: don't use ALL_CAPS in Go names; use CamelCase
lnstate/lnstate.go:74:2: don't use ALL_CAPS in Go names; use CamelCase
lnstate/lnstate.go:75:2: don't use ALL_CAPS in Go names; use CamelCase
lnstate/lnstate.go:76:2: don't use ALL_CAPS in Go names; use CamelCase
lnstate/lnstate.go:77:2: don't use ALL_CAPS in Go names; use CamelCase
lnstate/lnstate.go:79:2: comment on exported const TIMEOUT_PRESTAGE should be of the form "TIMEOUT_PRESTAGE ..."
lnstate/lnstate.go:80:2: don't use ALL_CAPS in Go names; use CamelCase
lnstate/lnstate.go:81:2: don't use ALL_CAPS in Go names; use CamelCase
lnstate/lnstate.go:82:2: don't use ALL_CAPS in Go names; use CamelCase
lnstate/lnstate.go:83:2: don't use ALL_CAPS in Go names; use CamelCase
lnstate/lnstate.go:85:2: comment on exported const SETTLE_PRESTAGE should be of the form "SETTLE_PRESTAGE ..."
lnstate/lnstate.go:86:2: don't use ALL_CAPS in Go names; use CamelCase
lnstate/lnstate.go:87:2: don't use ALL_CAPS in Go names; use CamelCase
lnstate/lnstate.go:88:2: don't use ALL_CAPS in Go names; use CamelCase
lnstate/lnstate.go:89:2: don't use ALL_CAPS in Go names; use CamelCase
lnstate/lnstate.go:101:6: exported type LNChannel should have comment or be unexported
lnstate/lnstate.go:150:6: exported type PaymentDescriptor should have comment or be unexported
lnstate/lnstate.go:201:4: should replace l.ourLastKey += 1 with l.ourLastKey++
lnstate/lnstate.go:205:4: should replace l.ourLastKey += 1 with l.ourLastKey++
lnstate/lnstate.go:216:1: exported method LNChannel.CreateHTLC should have comment or be unexported
lnstate/lnstate.go:225:21: error strings should not end with punctuation
lnwallet/channel.go:19:2: comment on exported const MaxPendingPayments should be of the form "MaxPendingPayments ..."
lnwallet/channel.go:28:1: comment on exported type LightningChannel should be of the form "LightningChannel ..." (with optional leading article)
lnwallet/channel.go:83:2: var fundingTxId should be fundingTxID
lnwallet/channel.go:95:1: comment on exported type PaymentDescriptor should be of the form "PaymentDescriptor ..." (with optional leading article)
lnwallet/channel.go:107:1: comment on exported type ChannelUpdate should be of the form "ChannelUpdate ..." (with optional leading article)
lnwallet/channel.go:127:1: comment on exported method ChannelUpdate.RevocationHash should be of the form "RevocationHash ..."
lnwallet/channel.go:141:1: comment on exported method ChannelUpdate.SignCounterPartyCommitment should be of the form "SignCounterPartyCommitment ..."
lnwallet/channel.go:163:1: comment on exported method ChannelUpdate.PreviousRevocationPreImage should be of the form "PreviousRevocationPreImage ..."
lnwallet/channel.go:179:1: comment on exported method ChannelUpdate.VerifyNewCommitmentSigs should be of the form "VerifyNewCommitmentSigs ..."
lnwallet/channel.go:219:1: comment on exported method ChannelUpdate.Commit should be of the form "Commit ..."
lnwallet/channel.go:266:1: comment on exported method LightningChannel.AddHTLC should be of the form "AddHTLC ..."
lnwallet/channel.go:420:1: comment on exported method LightningChannel.SettleHTLC should be of the form "SettleHTLC ..."
lnwallet/channel.go:525:1: comment on exported method LightningChannel.CancelHTLC should be of the form "CancelHTLC ..."
lnwallet/channel.go:530:1: comment on exported method LightningChannel.OurBalance should be of the form "OurBalance ..."
lnwallet/channel.go:537:1: comment on exported method LightningChannel.TheirBalance should be of the form "TheirBalance ..."
lnwallet/channel.go:544:1: comment on exported method LightningChannel.ForceClose should be of the form "ForceClose ..."
lnwallet/channel.go:549:1: comment on exported method LightningChannel.RequestPayment should be of the form "RequestPayment ..."
lnwallet/channel.go:555:1: comment on exported type PaymentRequest should be of the form "PaymentRequest ..." (with optional leading article)
lnwallet/config.go:32:1: comment on exported type Config should be of the form "Config ..." (with optional leading article)
lnwallet/config.go:39:2: struct field RpcHost should be RPCHost
lnwallet/config.go:40:2: struct field RpcUser should be RPCUser
lnwallet/config.go:41:2: struct field RpcPass should be RPCPass
lnwallet/reservation.go:157:1: comment on exported method ChannelReservation.ProcessContribution should be of the form "ProcessContribution ..."
lnwallet/reservation.go:200:1: comment on exported method ChannelReservation.CompleteReservation should be of the form "CompleteReservation ..."
lnwallet/reservation.go:227:1: comment on exported method ChannelReservation.TheirSignatures should be of the form "TheirSignatures ..."
lnwallet/script_utils.go:14:2: comment on exported var SequenceLockTimeSeconds should be of the form "SequenceLockTimeSeconds ..."
lnwallet/script_utils.go:17:2: exported var SequenceLockTimeMask should have comment or be unexported
lnwallet/setup.go:37:2: a blank import should be only in a main or test package, or have a comment justifying it
lnwallet/wallet.go:40:2: comment on exported var ErrInsufficientFunds should be of the form "ErrInsufficientFunds ..."
lnwallet/wallet.go:44:2: comment on exported var ActiveNetParams should be of the form "ActiveNetParams ..."
lnwallet/wallet.go:64:2: comment on exported const SEGWIT should be of the form "SEGWIT ..."
lnwallet/wallet.go:67:2: comment on exported const SIGHASH should be of the form "SIGHASH ..."
lnwallet/wallet.go:70:2: comment on exported const CSV should be of the form "CSV ..."
lnwallet/wallet.go:73:2: comment on exported const CSV_RESERVE should be of the form "CSV_RESERVE ..."
lnwallet/wallet.go:75:2: don't use ALL_CAPS in Go names; use CamelCase
lnwallet/wallet.go:77:2: comment on exported const CLTV_RESERVE should be of the form "CLTV_RESERVE ..."
lnwallet/wallet.go:78:2: don't use ALL_CAPS in Go names; use CamelCase
lnwallet/wallet_test.go:100:9: should omit 2nd value from range; this loop is equivalent to `for i := range ...`
lnwire/close_complete.go:11:6: exported type CloseComplete should have comment or be unexported
lnwire/close_complete.go:18:1: exported method CloseComplete.Decode should have comment or be unexported
lnwire/close_complete.go:34:1: comment on exported function NewCloseComplete should be of the form "NewCloseComplete ..."
lnwire/close_complete.go:39:1: comment on exported method CloseComplete.Encode should be of the form "Encode ..."
lnwire/close_complete.go:56:1: exported method CloseComplete.Command should have comment or be unexported
lnwire/close_complete.go:60:1: exported method CloseComplete.MaxPayloadLength should have comment or be unexported
lnwire/close_complete.go:65:1: comment on exported method CloseComplete.Validate should be of the form "Validate ..."
lnwire/close_request.go:11:6: exported type CloseRequest should have comment or be unexported
lnwire/close_request.go:18:1: exported method CloseRequest.Decode should have comment or be unexported
lnwire/close_request.go:34:1: comment on exported function NewCloseRequest should be of the form "NewCloseRequest ..."
lnwire/close_request.go:39:1: comment on exported method CloseRequest.Encode should be of the form "Encode ..."
lnwire/close_request.go:56:1: exported method CloseRequest.Command should have comment or be unexported
lnwire/close_request.go:60:1: exported method CloseRequest.MaxPayloadLength should have comment or be unexported
lnwire/close_request.go:65:1: comment on exported method CloseRequest.Validate should be of the form "Validate ..."
lnwire/commit_revocation.go:8:1: comment on exported type CommitRevocation should be of the form "CommitRevocation ..." (with optional leading article)
lnwire/commit_revocation.go:26:1: exported method CommitRevocation.Decode should have comment or be unexported
lnwire/commit_revocation.go:42:1: comment on exported function NewCommitRevocation should be of the form "NewCommitRevocation ..."
lnwire/commit_revocation.go:47:1: comment on exported method CommitRevocation.Encode should be of the form "Encode ..."
lnwire/commit_revocation.go:62:1: exported method CommitRevocation.Command should have comment or be unexported
lnwire/commit_revocation.go:66:1: exported method CommitRevocation.MaxPayloadLength should have comment or be unexported
lnwire/commit_revocation.go:70:1: comment on exported method CommitRevocation.Validate should be of the form "Validate ..."
lnwire/commit_signature.go:10:1: comment on exported type CommitSignature should be of the form "CommitSignature ..." (with optional leading article)
lnwire/commit_signature.go:37:1: exported method CommitSignature.Decode should have comment or be unexported
lnwire/commit_signature.go:59:1: comment on exported function NewCommitSignature should be of the form "NewCommitSignature ..."
lnwire/commit_signature.go:64:1: comment on exported method CommitSignature.Encode should be of the form "Encode ..."
lnwire/commit_signature.go:82:1: exported method CommitSignature.Command should have comment or be unexported
lnwire/commit_signature.go:86:1: exported method CommitSignature.MaxPayloadLength should have comment or be unexported
lnwire/commit_signature.go:90:1: comment on exported method CommitSignature.Validate should be of the form "Validate ..."
lnwire/error_generic.go:8:1: comment on exported type ErrorGeneric should be of the form "ErrorGeneric ..." (with optional leading article)
lnwire/error_generic.go:18:1: exported method ErrorGeneric.Decode should have comment or be unexported
lnwire/error_generic.go:32:1: comment on exported function NewErrorGeneric should be of the form "NewErrorGeneric ..."
lnwire/error_generic.go:37:1: comment on exported method ErrorGeneric.Encode should be of the form "Encode ..."
lnwire/error_generic.go:51:1: exported method ErrorGeneric.Command should have comment or be unexported
lnwire/error_generic.go:55:1: exported method ErrorGeneric.MaxPayloadLength should have comment or be unexported
lnwire/error_generic.go:60:1: comment on exported method ErrorGeneric.Validate should be of the form "Validate ..."
lnwire/funding_request.go:11:6: exported type FundingRequest should have comment or be unexported
lnwire/funding_request.go:56:1: exported method FundingRequest.Decode should have comment or be unexported
lnwire/funding_request.go:99:1: comment on exported function NewFundingRequest should be of the form "NewFundingRequest ..."
lnwire/funding_request.go:104:1: comment on exported method FundingRequest.Encode should be of the form "Encode ..."
lnwire/funding_request.go:142:1: exported method FundingRequest.Command should have comment or be unexported
lnwire/funding_request.go:146:1: exported method FundingRequest.MaxPayloadLength should have comment or be unexported
lnwire/funding_request.go:151:1: comment on exported method FundingRequest.Validate should be of the form "Validate ..."
lnwire/funding_response.go:11:6: exported type FundingResponse should have comment or be unexported
lnwire/funding_response.go:41:1: exported method FundingResponse.Decode should have comment or be unexported
lnwire/funding_response.go:83:1: comment on exported function NewFundingResponse should be of the form "NewFundingResponse ..."
lnwire/funding_response.go:88:1: comment on exported method FundingResponse.Encode should be of the form "Encode ..."
lnwire/funding_response.go:126:1: exported method FundingResponse.Command should have comment or be unexported
lnwire/funding_response.go:130:1: exported method FundingResponse.MaxPayloadLength should have comment or be unexported
lnwire/funding_response.go:135:1: comment on exported method FundingResponse.Validate should be of the form "Validate ..."
lnwire/funding_signaccept.go:9:6: exported type FundingSignAccept should have comment or be unexported
lnwire/funding_signaccept.go:16:1: exported method FundingSignAccept.Decode should have comment or be unexported
lnwire/funding_signaccept.go:35:1: comment on exported function NewFundingSignAccept should be of the form "NewFundingSignAccept ..."
lnwire/funding_signaccept.go:40:1: comment on exported method FundingSignAccept.Encode should be of the form "Encode ..."
lnwire/funding_signaccept.go:57:1: exported method FundingSignAccept.Command should have comment or be unexported
lnwire/funding_signaccept.go:61:1: exported method FundingSignAccept.MaxPayloadLength should have comment or be unexported
lnwire/funding_signaccept.go:66:1: comment on exported method FundingSignAccept.Validate should be of the form "Validate ..."
lnwire/funding_signcomplete.go:10:6: exported type FundingSignComplete should have comment or be unexported
lnwire/funding_signcomplete.go:17:1: exported method FundingSignComplete.Decode should have comment or be unexported
lnwire/funding_signcomplete.go:35:1: comment on exported function NewFundingSignComplete should be of the form "NewFundingSignComplete ..."
lnwire/funding_signcomplete.go:40:1: comment on exported method FundingSignComplete.Encode should be of the form "Encode ..."
lnwire/funding_signcomplete.go:54:1: exported method FundingSignComplete.Command should have comment or be unexported
lnwire/funding_signcomplete.go:58:1: exported method FundingSignComplete.MaxPayloadLength should have comment or be unexported
lnwire/funding_signcomplete.go:63:1: comment on exported method FundingSignComplete.Validate should be of the form "Validate ..."
lnwire/htlc_addaccept.go:8:6: exported type HTLCAddAccept should have comment or be unexported
lnwire/htlc_addaccept.go:13:1: exported method HTLCAddAccept.Decode should have comment or be unexported
lnwire/htlc_addaccept.go:27:1: comment on exported function NewHTLCAddAccept should be of the form "NewHTLCAddAccept ..."
lnwire/htlc_addaccept.go:32:1: comment on exported method HTLCAddAccept.Encode should be of the form "Encode ..."
lnwire/htlc_addaccept.go:47:1: exported method HTLCAddAccept.Command should have comment or be unexported
lnwire/htlc_addaccept.go:51:1: exported method HTLCAddAccept.MaxPayloadLength should have comment or be unexported
lnwire/htlc_addaccept.go:56:1: comment on exported method HTLCAddAccept.Validate should be of the form "Validate ..."
lnwire/htlc_addreject.go:8:6: exported type HTLCAddReject should have comment or be unexported
lnwire/htlc_addreject.go:13:1: exported method HTLCAddReject.Decode should have comment or be unexported
lnwire/htlc_addreject.go:30:1: comment on exported function NewHTLCAddReject should be of the form "NewHTLCAddReject ..."
lnwire/htlc_addreject.go:35:1: comment on exported method HTLCAddReject.Encode should be of the form "Encode ..."
lnwire/htlc_addreject.go:50:1: exported method HTLCAddReject.Command should have comment or be unexported
lnwire/htlc_addreject.go:54:1: exported method HTLCAddReject.MaxPayloadLength should have comment or be unexported
lnwire/htlc_addreject.go:59:1: comment on exported method HTLCAddReject.Validate should be of the form "Validate ..."
lnwire/htlc_addrequest.go:8:1: comment on exported type HTLCAddRequest should be of the form "HTLCAddRequest ..." (with optional leading article)
lnwire/htlc_addrequest.go:40:1: exported method HTLCAddRequest.Decode should have comment or be unexported
lnwire/htlc_addrequest.go:64:1: comment on exported function NewHTLCAddRequest should be of the form "NewHTLCAddRequest ..."
lnwire/htlc_addrequest.go:69:1: comment on exported method HTLCAddRequest.Encode should be of the form "Encode ..."
lnwire/htlc_addrequest.go:88:1: exported method HTLCAddRequest.Command should have comment or be unexported
lnwire/htlc_addrequest.go:92:1: exported method HTLCAddRequest.MaxPayloadLength should have comment or be unexported
lnwire/htlc_addrequest.go:98:1: comment on exported method HTLCAddRequest.Validate should be of the form "Validate ..."
lnwire/htlc_settleaccept.go:8:1: comment on exported type HTLCSettleAccept should be of the form "HTLCSettleAccept ..." (with optional leading article)
lnwire/htlc_settleaccept.go:18:1: exported method HTLCSettleAccept.Decode should have comment or be unexported
lnwire/htlc_settleaccept.go:32:1: comment on exported function NewHTLCSettleAccept should be of the form "NewHTLCSettleAccept ..."
lnwire/htlc_settleaccept.go:37:1: comment on exported method HTLCSettleAccept.Encode should be of the form "Encode ..."
lnwire/htlc_settleaccept.go:51:1: exported method HTLCSettleAccept.Command should have comment or be unexported
lnwire/htlc_settleaccept.go:55:1: exported method HTLCSettleAccept.MaxPayloadLength should have comment or be unexported
lnwire/htlc_settleaccept.go:60:1: comment on exported method HTLCSettleAccept.Validate should be of the form "Validate ..."
lnwire/htlc_settlerequest.go:8:1: comment on exported type HTLCSettleRequest should be of the form "HTLCSettleRequest ..." (with optional leading article)
lnwire/htlc_settlerequest.go:21:1: exported method HTLCSettleRequest.Decode should have comment or be unexported
lnwire/htlc_settlerequest.go:42:1: comment on exported function NewHTLCSettleRequest should be of the form "NewHTLCSettleRequest ..."
lnwire/htlc_settlerequest.go:47:1: comment on exported method HTLCSettleRequest.Encode should be of the form "Encode ..."
lnwire/htlc_settlerequest.go:62:1: exported method HTLCSettleRequest.Command should have comment or be unexported
lnwire/htlc_settlerequest.go:66:1: exported method HTLCSettleRequest.MaxPayloadLength should have comment or be unexported
lnwire/htlc_settlerequest.go:71:1: comment on exported method HTLCSettleRequest.Validate should be of the form "Validate ..."
lnwire/htlc_timeoutaccept.go:8:1: comment on exported type HTLCTimeoutAccept should be of the form "HTLCTimeoutAccept ..." (with optional leading article)
lnwire/htlc_timeoutaccept.go:18:1: exported method HTLCTimeoutAccept.Decode should have comment or be unexported
lnwire/htlc_timeoutaccept.go:32:1: comment on exported function NewHTLCTimeoutAccept should be of the form "NewHTLCTimeoutAccept ..."
lnwire/htlc_timeoutaccept.go:37:1: comment on exported method HTLCTimeoutAccept.Encode should be of the form "Encode ..."
lnwire/htlc_timeoutaccept.go:51:1: exported method HTLCTimeoutAccept.Command should have comment or be unexported
lnwire/htlc_timeoutaccept.go:55:1: exported method HTLCTimeoutAccept.MaxPayloadLength should have comment or be unexported
lnwire/htlc_timeoutaccept.go:60:1: comment on exported method HTLCTimeoutAccept.Validate should be of the form "Validate ..."
lnwire/htlc_timeoutrequest.go:8:1: comment on exported type HTLCTimeoutRequest should be of the form "HTLCTimeoutRequest ..." (with optional leading article)
lnwire/htlc_timeoutrequest.go:18:1: exported method HTLCTimeoutRequest.Decode should have comment or be unexported
lnwire/htlc_timeoutrequest.go:32:1: comment on exported function NewHTLCTimeoutRequest should be of the form "NewHTLCTimeoutRequest ..."
lnwire/htlc_timeoutrequest.go:37:1: comment on exported method HTLCTimeoutRequest.Encode should be of the form "Encode ..."
lnwire/htlc_timeoutrequest.go:51:1: exported method HTLCTimeoutRequest.Command should have comment or be unexported
lnwire/htlc_timeoutrequest.go:55:1: exported method HTLCTimeoutRequest.MaxPayloadLength should have comment or be unexported
lnwire/htlc_timeoutrequest.go:60:1: comment on exported method HTLCTimeoutRequest.Validate should be of the form "Validate ..."
lnwire/lnwire.go:14:5: don't use ALL_CAPS in Go names; use CamelCase
lnwire/lnwire.go:14:5: exported var MAX_SLICE_LENGTH should have comment or be unexported
lnwire/lnwire.go:16:1: comment on exported type PkScript should be of the form "PkScript ..." (with optional leading article)
lnwire/lnwire.go:19:6: exported type HTLCKey should have comment or be unexported
lnwire/lnwire.go:20:6: exported type CommitHeight should have comment or be unexported
lnwire/lnwire.go:22:1: comment on exported type CreditsAmount should be of the form "CreditsAmount ..." (with optional leading article)
lnwire/lnwire.go:440:22: error strings should not end with punctuation
lnwire/lnwire.go:502:22: error strings should not end with punctuation
lnwire/lnwire.go:524:22: error strings should not end with punctuation
lnwire/lnwire.go:538:22: error strings should not end with punctuation
lnwire/lnwire.go:606:1: comment on exported function ValidatePkScript should be of the form "ValidatePkScript ..."
lnwire/lnwire_test.go:19:2: don't use ALL_CAPS in Go names; use CamelCase
lnwire/message.go:1:1: package comment should be of the form "Package lnwire ..."
lnwire/message.go:14:2: don't use ALL_CAPS in Go names; use CamelCase
lnwire/message.go:15:2: don't use ALL_CAPS in Go names; use CamelCase
lnwire/message.go:17:2: don't use ALL_CAPS in Go names; use CamelCase
lnwire/message.go:18:2: don't use ALL_CAPS in Go names; use CamelCase
lnwire/message.go:20:2: don't use ALL_CAPS in Go names; use CamelCase
lnwire/message.go:22:2: don't use ALL_CAPS in Go names; use CamelCase
lnwire/message.go:23:2: don't use ALL_CAPS in Go names; use CamelCase
lnwire/message.go:29:7: exported const MaxMessagePayload should have comment or be unexported
lnwire/message.go:32:2: comment on exported const CmdFundingRequest should be of the form "CmdFundingRequest ..."
lnwire/message.go:34:2: exported const CmdFundingResponse should have comment (or a comment on this block) or be unexported
lnwire/message.go:38:2: comment on exported const CmdCloseRequest should be of the form "CmdCloseRequest ..."
lnwire/message.go:42:2: comment on exported const CmdHTLCAddRequest should be of the form "CmdHTLCAddRequest ..."
lnwire/message.go:48:2: comment on exported const CmdHTLCSettleRequest should be of the form "CmdHTLCSettleRequest ..."
lnwire/message.go:53:2: comment on exported const CmdHTLCTimeoutRequest should be of the form "CmdHTLCTimeoutRequest ..."
lnwire/message.go:57:2: comment on exported const CmdCommitSignature should be of the form "CmdCommitSignature ..."
lnwire/message.go:61:2: comment on exported const CmdErrorGeneric should be of the form "CmdErrorGeneric ..."
lnwire/message.go:65:1: comment on exported type Message should be of the form "Message ..." (with optional leading article)
lnwire/message.go:168:1: exported function WriteMessage should have comment or be unexported
lnwire/message.go:222:1: exported function ReadMessage should have comment or be unexported
lnwire/message.go:232:43: error strings should not end with punctuation
lnwire/message.go:253:43: error strings should not end with punctuation
shachain/shachain.go:25:1: comment on exported type HyperShaChain should be of the form "HyperShaChain ..." (with optional leading article)
shachain/shachain.go:38:1: comment on exported function New should be of the form "New ..."
shachain/shachain.go:44:1: comment on exported function NewFromSeed should be of the form "NewFromSeed ..."
shachain/shachain.go:98:1: comment on exported method HyperShaChain.GetHash should be of the form "GetHash ..."
shachain/shachain.go:117:1: comment on exported method HyperShaChain.AddNextHash should be of the form "AddNextHash ..."
shachain/shachain.go:147:1: comment on exported method HyperShaChain.CurrentPreImage should be of the form "CurrentPreImage ..."
shachain/shachain.go:154:1: comment on exported method HyperShaChain.CurrentRevocationHash should be of the form "CurrentRevocationHash ..."
shachain/shachain.go:162:1: comment on exported method HyperShaChain.LocatePreImage should be of the form "LocatePreImage ..."
shachain/shachain.go:173:1: comment on exported method HyperShaChain.Encode should be of the form "Encode ..."
shachain/shachain.go:178:1: comment on exported method HyperShaChain.Decode should be of the form "Decode ..."
uspv/eight333.go:19:2: comment on exported const NETVERSION should be of the form "NETVERSION ..."
uspv/eight333.go:22:2: exported const VERSION should have comment (or a comment on this block) or be unexported
uspv/eight333.go:29:6: exported type SPVCon should have comment or be unexported
uspv/eight333.go:48:1: exported method SPVCon.Open should have comment or be unexported
uspv/eight333.go:142:1: exported method SPVCon.PongBack should have comment or be unexported
uspv/eight333.go:149:1: exported method SPVCon.SendFilter should have comment or be unexported
uspv/eight333.go:154:1: exported method SPVCon.AskForHeaders should have comment or be unexported
uspv/eight333.go:197:1: exported method SPVCon.IngestHeaders should have comment or be unexported
uspv/eight333.go:277:1: exported method SPVCon.AskForMerkBlocks should have comment or be unexported
uspv/header.go:93:1: exported function CheckHeader should have comment or be unexported
uspv/header.go:182:1: comment on exported function CheckRange should be of the form "CheckRange ..."
uspv/mblock.go:9:1: exported function MakeMerkleParent should have comment or be unexported
uspv/txstore.go:13:6: exported type TxStore should have comment or be unexported
uspv/txstore.go:20:6: exported type Utxo should have comment or be unexported
uspv/txstore.go:28:6: exported type MyAdr should have comment or be unexported
uspv/txstore.go:33:1: comment on exported method TxStore.AddAdr should be of the form "AddAdr ..."
uspv/txstore.go:42:1: comment on exported method TxStore.AddTxid should be of the form "AddTxid ..."
uspv/txstore.go:51:1: comment on exported method TxStore.GimmeFilter should be of the form "GimmeFilter ..."
uspv/txstore.go:63:1: comment on exported method TxStore.IngestTx should be of the form "IngestTx ..."
uspv/txstore.go:89:1: comment on exported method TxStore.AbsorbTx should be of the form "AbsorbTx ..."
uspv/txstore.go:123:1: comment on exported method TxStore.ExpellTx should be of the form "ExpellTx ..."
```

### Left as-is:

```
lnrpc/rpc.pb.go:35:6: exported type SendManyRequest should have comment or be unexported
lnrpc/rpc.pb.go:39:1: exported method SendManyRequest.Reset should have comment or be unexported
lnrpc/rpc.pb.go:41:1: exported method SendManyRequest.ProtoMessage should have comment or be unexported
lnrpc/rpc.pb.go:42:1: exported method SendManyRequest.Descriptor should have comment or be unexported
lnrpc/rpc.pb.go:44:1: exported method SendManyRequest.GetAddrToAmount should have comment or be unexported
lnrpc/rpc.pb.go:51:6: exported type SendManyResponse should have comment or be unexported
lnrpc/rpc.pb.go:55:1: exported method SendManyResponse.Reset should have comment or be unexported
lnrpc/rpc.pb.go:57:1: exported method SendManyResponse.ProtoMessage should have comment or be unexported
lnrpc/rpc.pb.go:58:1: exported method SendManyResponse.Descriptor should have comment or be unexported
lnrpc/rpc.pb.go:60:6: exported type NewAddressRequest should have comment or be unexported
lnrpc/rpc.pb.go:63:1: exported method NewAddressRequest.Reset should have comment or be unexported
lnrpc/rpc.pb.go:65:1: exported method NewAddressRequest.ProtoMessage should have comment or be unexported
lnrpc/rpc.pb.go:66:1: exported method NewAddressRequest.Descriptor should have comment or be unexported
lnrpc/rpc.pb.go:68:6: exported type NewAddressResponse should have comment or be unexported
lnrpc/rpc.pb.go:72:1: exported method NewAddressResponse.Reset should have comment or be unexported
lnrpc/rpc.pb.go:74:1: exported method NewAddressResponse.ProtoMessage should have comment or be unexported
lnrpc/rpc.pb.go:75:1: exported method NewAddressResponse.Descriptor should have comment or be unexported
lnrpc/rpc.pb.go:77:6: exported type ConnectPeerRequest should have comment or be unexported
lnrpc/rpc.pb.go:78:2: struct field IdAtHost should be IDAtHost
lnrpc/rpc.pb.go:81:1: exported method ConnectPeerRequest.Reset should have comment or be unexported
lnrpc/rpc.pb.go:83:1: exported method ConnectPeerRequest.ProtoMessage should have comment or be unexported
lnrpc/rpc.pb.go:84:1: exported method ConnectPeerRequest.Descriptor should have comment or be unexported
lnrpc/rpc.pb.go:86:6: exported type ConnectPeerResponse should have comment or be unexported
lnrpc/rpc.pb.go:90:1: exported method ConnectPeerResponse.Reset should have comment or be unexported
lnrpc/rpc.pb.go:92:1: exported method ConnectPeerResponse.ProtoMessage should have comment or be unexported
lnrpc/rpc.pb.go:93:1: exported method ConnectPeerResponse.Descriptor should have comment or be unexported
lnrpc/rpc.pb.go:110:6: exported type LightningClient should have comment or be unexported
lnrpc/rpc.pb.go:120:1: exported function NewLightningClient should have comment or be unexported
lnrpc/rpc.pb.go:153:6: exported type LightningServer should have comment or be unexported
lnrpc/rpc.pb.go:159:1: exported function RegisterLightningServer should have comment or be unexported
lnrpc/rpc.pb.go:163:6: don't use underscores in Go names; func _Lightning_SendMany_Handler should be _LightningSendManyHandler
lnrpc/rpc.pb.go:175:6: don't use underscores in Go names; func _Lightning_NewAddress_Handler should be _LightningNewAddressHandler
lnrpc/rpc.pb.go:187:6: don't use underscores in Go names; func _Lightning_ConnectPeer_Handler should be _LightningConnectPeerHandler
lnrpc/rpc.pb.go:199:5: don't use underscores in Go names; var _Lightning_serviceDesc should be _LightningServiceDesc
```

```
lnwallet/script_utils.go:18:2: don't use ALL_CAPS in Go names; use CamelCase
```