### PR TITLE
BIP-141 name fix

### DIFF
--- a/channeldb/channel.go
+++ b/channeldb/channel.go
@@ -127,7 +127,7 @@ type OpenChannel struct {
 
 	OurMultiSigKey      *btcec.PublicKey
 	TheirMultiSigKey    *btcec.PublicKey
-	FundingRedeemScript []byte
+	FundingWitnessScript []byte
 
 	// In blocks
 	LocalCsvDelay  uint32
@@ -1095,7 +1095,7 @@ func putChanFundingInfo(nodeChanBucket *bolt.Bucket, channel *OpenChannel) error
 		return err
 	}
 
-	if err := wire.WriteVarBytes(&b, 0, channel.FundingRedeemScript[:]); err != nil {
+	if err := wire.WriteVarBytes(&b, 0, channel.FundingWitnessScript[:]); err != nil {
 		return err
 	}
 
@@ -1151,7 +1151,7 @@ func fetchChanFundingInfo(nodeChanBucket *bolt.Bucket, channel *OpenChannel) err
 		return err
 	}
 
-	channel.FundingRedeemScript, err = wire.ReadVarBytes(infoBytes, 0, 520, "")
+	channel.FundingWitnessScript, err = wire.ReadVarBytes(infoBytes, 0, 520, "")
 	if err != nil {
 		return err
 	}

--- a/channeldb/channel_test.go
+++ b/channeldb/channel_test.go
@@ -148,7 +148,7 @@ func createTestChannelState(cdb *DB) (*OpenChannel, error) {
 		FundingOutpoint:            testOutpoint,
 		OurMultiSigKey:             privKey.PubKey(),
 		TheirMultiSigKey:           privKey.PubKey(),
-		FundingRedeemScript:        script,
+		FundingWitnessScript:        script,
 		TheirCurrentRevocation:     privKey.PubKey(),
 		TheirCurrentRevocationHash: key,
 		OurDeliveryScript:          script,
@@ -257,7 +257,7 @@ func TestOpenChannelPutGetDelete(t *testing.T) {
 		newState.TheirMultiSigKey.SerializeCompressed()) {
 		t.Fatalf("their multisig key doesn't match")
 	}
-	if !bytes.Equal(state.FundingRedeemScript, newState.FundingRedeemScript) {
+	if !bytes.Equal(state.FundingWitnessScript, newState.FundingWitnessScript) {
 		t.Fatalf("redeem script doesn't match")
 	}
 

--- a/lnwallet/btcwallet/btcwallet.go
+++ b/lnwallet/btcwallet/btcwallet.go
@@ -56,7 +56,7 @@ type BtcWallet struct {
 var _ lnwallet.WalletController = (*BtcWallet)(nil)
 
 // New returns a new fully initialized instance of BtcWallet given a valid
-// confirguration struct.
+// configuration struct.
 func New(cfg *Config) (*BtcWallet, error) {
 	// Ensure the wallet exists or create it when the create flag is set.
 	netDir := networkDir(cfg.DataDir, cfg.NetParams)

--- a/lnwallet/btcwallet/signer.go
+++ b/lnwallet/btcwallet/signer.go
@@ -96,7 +96,7 @@ func (b *BtcWallet) fetchPrivKey(pub *btcec.PublicKey) (*btcec.PrivateKey, error
 //
 // This is a part of the WalletController interface.
 func (b *BtcWallet) SignOutputRaw(tx *wire.MsgTx, signDesc *lnwallet.SignDescriptor) ([]byte, error) {
-	redeemScript := signDesc.RedeemScript
+	witnessScript := signDesc.WitnessScript
 
 	privKey, err := b.fetchPrivKey(signDesc.PubKey)
 	if err != nil {
@@ -105,7 +105,7 @@ func (b *BtcWallet) SignOutputRaw(tx *wire.MsgTx, signDesc *lnwallet.SignDescrip
 
 	amt := signDesc.Output.Value
 	sig, err := txscript.RawTxInWitnessSignature(tx, signDesc.SigHashes, 0,
-		amt, redeemScript, txscript.SigHashAll, privKey)
+		amt, witnessScript, txscript.SigHashAll, privKey)
 	if err != nil {
 		return nil, err
 	}

--- a/lnwallet/channel_test.go
+++ b/lnwallet/channel_test.go
@@ -58,11 +58,11 @@ type mockSigner struct {
 
 func (m *mockSigner) SignOutputRaw(tx *wire.MsgTx, signDesc *SignDescriptor) ([]byte, error) {
 	amt := signDesc.Output.Value
-	redeemScript := signDesc.RedeemScript
+	witnessScript := signDesc.WitnessScript
 	privKey := m.key
 
 	sig, err := txscript.RawTxInWitnessSignature(tx, signDesc.SigHashes,
-		signDesc.InputIndex, amt, redeemScript, txscript.SigHashAll, privKey)
+		signDesc.InputIndex, amt, witnessScript, txscript.SigHashAll, privKey)
 	if err != nil {
 		return nil, err
 	}
@@ -179,7 +179,7 @@ func createTestChannels(revocationWindow int) (*LightningChannel, *LightningChan
 	csvTimeoutAlice := uint32(5)
 	csvTimeoutBob := uint32(4)
 
-	redeemScript, _, err := GenFundingPkScript(aliceKeyPub.SerializeCompressed(),
+	witnessScript, _, err := GenFundingPkScript(aliceKeyPub.SerializeCompressed(),
 		bobKeyPub.SerializeCompressed(), int64(channelCapacity))
 	if err != nil {
 		return nil, nil, nil, err
@@ -240,7 +240,7 @@ func createTestChannels(revocationWindow int) (*LightningChannel, *LightningChan
 		FundingOutpoint:        prevOut,
 		OurMultiSigKey:         aliceKeyPub,
 		TheirMultiSigKey:       bobKeyPub,
-		FundingRedeemScript:    redeemScript,
+		FundingWitnessScript:    witnessScript,
 		LocalCsvDelay:          csvTimeoutAlice,
 		RemoteCsvDelay:         csvTimeoutBob,
 		TheirCurrentRevocation: bobRevokeKey,
@@ -260,7 +260,7 @@ func createTestChannels(revocationWindow int) (*LightningChannel, *LightningChan
 		FundingOutpoint:        prevOut,
 		OurMultiSigKey:         bobKeyPub,
 		TheirMultiSigKey:       aliceKeyPub,
-		FundingRedeemScript:    redeemScript,
+		FundingWitnessScript:    witnessScript,
 		LocalCsvDelay:          csvTimeoutBob,
 		RemoteCsvDelay:         csvTimeoutAlice,
 		TheirCurrentRevocation: aliceRevokeKey,

--- a/lnwallet/interface.go
+++ b/lnwallet/interface.go
@@ -154,10 +154,10 @@ type SignDescriptor struct {
 	// key corresponding to this public key.
 	PubKey *btcec.PublicKey
 
-	// RedeemScript is the full script required to properly redeem the
+	// WitnessScript is the full script required to properly redeem the
 	// output. This field will only be populated if a p2wsh or a p2sh
 	// output is being signed.
-	RedeemScript []byte
+	WitnessScript []byte
 
 	// Output is the target output which should be signed. The PkScript and
 	// Value fields within the output should be properly populated,

--- a/lnwallet/interface.go
+++ b/lnwallet/interface.go
@@ -145,9 +145,9 @@ type BlockChainIO interface {
 	GetTransaction(txid *wire.ShaHash) (*wire.MsgTx, error)
 }
 
-// SignDescriptor houses the necessary information required to succesfully sign
+// SignDescriptor houses the necessary information required to successfully sign
 // a given output. This struct is used by the Signer interface in order to gain
-// access to critial data needed to generate a valid signature.
+// access to critical data needed to generate a valid signature.
 type SignDescriptor struct {
 	// Pubkey is the public key to which the signature should be generated
 	// over. The Signer should then generate a signature with the private

--- a/lnwallet/interface_test.go
+++ b/lnwallet/interface_test.go
@@ -479,14 +479,14 @@ func testDualFundingReservationWorkflow(miner *rpctest.Harness, wallet *lnwallet
 	chanInfo := lnc.StateSnapshot()
 
 	// Obtain bob's signature for the closure transaction.
-	redeemScript := lnc.FundingRedeemScript
+	witnessScript := lnc.FundingWitnessScript
 	fundingOut := lnc.ChannelPoint()
 	fundingTxIn := wire.NewTxIn(fundingOut, nil, nil)
 	bobCloseTx := lnwallet.CreateCooperativeCloseTx(fundingTxIn,
 		chanInfo.RemoteBalance, chanInfo.LocalBalance,
 		lnc.RemoteDeliveryScript, lnc.LocalDeliveryScript,
 		false)
-	bobSig, err := bobNode.signCommitTx(bobCloseTx, redeemScript, int64(lnc.Capacity))
+	bobSig, err := bobNode.signCommitTx(bobCloseTx, witnessScript, int64(lnc.Capacity))
 	if err != nil {
 		t.Fatalf("unable to generate bob's signature for closing tx: %v", err)
 	}
@@ -495,7 +495,7 @@ func testDualFundingReservationWorkflow(miner *rpctest.Harness, wallet *lnwallet
 	// be accepted, and found in the next mined block.
 	ourKey := chanReservation.OurContribution().MultiSigKey.SerializeCompressed()
 	theirKey := chanReservation.TheirContribution().MultiSigKey.SerializeCompressed()
-	witness := lnwallet.SpendMultiSig(redeemScript, ourKey, aliceCloseSig,
+	witness := lnwallet.SpendMultiSig(witnessScript, ourKey, aliceCloseSig,
 		theirKey, bobSig)
 	bobCloseTx.TxIn[0].Witness = witness
 	if err := wallet.PublishTransaction(bobCloseTx); err != nil {

--- a/lnwallet/reservation.go
+++ b/lnwallet/reservation.go
@@ -24,7 +24,7 @@ type ChannelContribution struct {
 	Inputs []*wire.TxIn
 
 	// ChangeOutputs are the Outputs to be used in the case that the total
-	// value of the fund ing inputs is greater than the total potential
+	// value of the funding inputs is greater than the total potential
 	// channel capacity.
 	ChangeOutputs []*wire.TxOut
 
@@ -52,28 +52,29 @@ type ChannelContribution struct {
 
 // InputScripts represents any script inputs required to redeem a previous
 // output. This struct is used rather than just a witness, or scripSig in
-// order to accomdate nested p2sh which utilizes both types of input scripts.
+// order to accommodate nested p2sh which utilizes both types of input scripts.
 type InputScript struct {
 	Witness   [][]byte
 	ScriptSig []byte
 }
 
 // ChannelReservation represents an intent to open a lightning payment channel
-// a counterpaty. The funding proceses from reservation to channel opening is a
-// 3-step process. In order to allow for full concurrency during the reservation
-// workflow, resources consumed by a contribution are "locked" themselves. This
-// prevents a number of race conditions such as two funding transactions
-// double-spending the same input. A reservation can also be cancelled, which
-// removes the resources from limbo, allowing another reservation to claim them.
+// a counterparty. The funding processes from reservation to channel opening
+// is a 3-step process. In order to allow for full concurrency during the
+// reservation workflow, resources consumed by a contribution are "locked"
+// themselves. This prevents a number of race conditions such as two funding
+// transactions double-spending the same input. A reservation can also be
+// cancelled, which removes the resources from limbo, allowing another
+// reservation to claim them.
 //
 // The reservation workflow consists of the following three steps:
 //  1. lnwallet.InitChannelReservation
-//     * One requests the wallet to allocate the neccessary resources for a
+//     * One requests the wallet to allocate the necessary resources for a
 //      channel reservation. These resources a put in limbo for the lifetime
 //      of a reservation.
 //    * Once completed the reservation will have the wallet's contribution
 //      accessible via the .OurContribution() method. This contribution
-//      contains the neccessary items to allow the remote party to build both
+//      contains the necessary items to allow the remote party to build both
 //      the funding, and commitment transactions.
 //  2. ChannelReservation.ProcessContribution/ChannelReservation.ProcessSingleContribution
 //     * The counterparty presents their contribution to the payment channel.
@@ -84,7 +85,7 @@ type InputScript struct {
 //     * All signatures crafted by us, are now available via .OurSignatures().
 //  3. ChannelReservation.CompleteReservation/ChannelReservation.CompleteReservationSingle
 //     * The final step in the workflow. The counterparty presents the
-//       signatures for all their inputs to the funding transation, as well
+//       signatures for all their inputs to the funding transaction, as well
 //       as a signature to our version of the commitment transaction.
 //     * We then verify the validity of all signatures before considering the
 //       channel "open".

--- a/lnwallet/reservation.go
+++ b/lnwallet/reservation.go
@@ -329,7 +329,7 @@ func (r *ChannelReservation) FinalFundingTx() *wire.MsgTx {
 func (r *ChannelReservation) FundingRedeemScript() []byte {
 	r.RLock()
 	defer r.RUnlock()
-	return r.partialState.FundingRedeemScript
+	return r.partialState.FundingWitnessScript
 }
 
 // LocalCommitTx returns the commitment transaction for the local node involved

--- a/lnwallet/script_utils.go
+++ b/lnwallet/script_utils.go
@@ -25,11 +25,11 @@ var (
 
 // witnessScriptHash generates a pay-to-witness-script-hash public key script
 // paying to a version 0 witness program paying to the passed redeem script.
-func witnessScriptHash(redeemScript []byte) ([]byte, error) {
+func witnessScriptHash(witnessScript []byte) ([]byte, error) {
 	bldr := txscript.NewScriptBuilder()
 
 	bldr.AddOp(txscript.OP_0)
-	scriptHash := fastsha256.Sum256(redeemScript)
+	scriptHash := fastsha256.Sum256(witnessScript)
 	bldr.AddData(scriptHash[:])
 	return bldr.Script()
 }
@@ -68,31 +68,31 @@ func GenFundingPkScript(aPub, bPub []byte, amt int64) ([]byte, *wire.TxOut, erro
 	}
 
 	// First, create the 2-of-2 multi-sig script itself.
-	redeemScript, err := genMultiSigScript(aPub, bPub)
+	witnessScript, err := genMultiSigScript(aPub, bPub)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	// With the 2-of-2 script in had, generate a p2wsh script which pays
 	// to the funding script.
-	pkScript, err := witnessScriptHash(redeemScript)
+	pkScript, err := witnessScriptHash(witnessScript)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	return redeemScript, wire.NewTxOut(amt, pkScript), nil
+	return witnessScript, wire.NewTxOut(amt, pkScript), nil
 }
 
 // SpendMultiSig generates the witness stack required to redeem the 2-of-2 p2wsh
 // multi-sig output.
-func SpendMultiSig(redeemScript, pubA, sigA, pubB, sigB []byte) [][]byte {
+func SpendMultiSig(witnessScript, pubA, sigA, pubB, sigB []byte) [][]byte {
 	witness := make([][]byte, 4)
 
 	// When spending a p2wsh multi-sig script, rather than an OP_0, we add
 	// a nil stack element to eat the extra pop.
 	witness[0] = nil
 
-	// When initially generating the redeemScript, we sorted the serialized
+	// When initially generating the witnessScript, we sorted the serialized
 	// public keys in descending order. So we do a quick comparison in order
 	// ensure the signatures appear on the Script Virtual Machine stack in
 	// the correct order.
@@ -105,7 +105,7 @@ func SpendMultiSig(redeemScript, pubA, sigA, pubB, sigB []byte) [][]byte {
 	}
 
 	// Finally, add the pre-image as the last witness element.
-	witness[3] = redeemScript
+	witness[3] = witnessScript
 
 	return witness
 }
@@ -621,7 +621,7 @@ func CommitSpendTimeout(signer Signer, signDesc *SignDescriptor,
 	witnessStack := wire.TxWitness(make([][]byte, 3))
 	witnessStack[0] = append(sweepSig, byte(txscript.SigHashAll))
 	witnessStack[1] = []byte{0}
-	witnessStack[2] = signDesc.RedeemScript
+	witnessStack[2] = signDesc.WitnessScript
 
 	return witnessStack, nil
 }

--- a/lnwallet/script_utils.go
+++ b/lnwallet/script_utils.go
@@ -94,7 +94,7 @@ func SpendMultiSig(redeemScript, pubA, sigA, pubB, sigB []byte) [][]byte {
 
 	// When initially generating the redeemScript, we sorted the serialized
 	// public keys in descending order. So we do a quick comparison in order
-	// ensure the signatures appear on the Script Virual Machine stack in
+	// ensure the signatures appear on the Script Virtual Machine stack in
 	// the correct order.
 	if bytes.Compare(pubA, pubB) == -1 {
 		witness[1] = sigB
@@ -556,7 +556,7 @@ func commitScriptToSelf(csvTimeout uint32, selfKey, revokeKey *btcec.PublicKey) 
 	// signature with the revocation public key. The revocation public key
 	// will *only* be known to the other party if we have divulged the
 	// revocation hash, allowing them to homomorphically derive the proper
-	// private key which coresponds to the revoke public key.
+	// private key which corresponds to the revoke public key.
 	builder := txscript.NewScriptBuilder()
 
 	builder.AddOp(txscript.OP_IF)

--- a/lnwallet/script_utils_test.go
+++ b/lnwallet/script_utils_test.go
@@ -82,7 +82,7 @@ func TestCommitmentSpendValidation(t *testing.T) {
 	}
 	sweepTx.TxIn[0].Sequence = lockTimeToSequence(false, csvTimeout)
 	signDesc := &SignDescriptor{
-		RedeemScript: delayScript,
+		WitnessScript: delayScript,
 		SigHashes:    txscript.NewTxSigHashes(sweepTx),
 		Output: &wire.TxOut{
 			Value: int64(channelBalance),

--- a/lnwallet/script_utils_test.go
+++ b/lnwallet/script_utils_test.go
@@ -16,13 +16,13 @@ import (
 // the commitment transaction.
 //
 // The following spending cases are covered by this test:
-//   * Alice's spend from the delayed output on her commitment transaciton.
+//   * Alice's spend from the delayed output on her commitment transaction.
 //   * Bob's spend from Alice's delayed output when she broadcasts a revoked
 //     commitment transaction.
 //   * Bob's spend from his unencumbered output within Alice's commitment
 //     transaction.
 func TestCommitmentSpendValidation(t *testing.T) {
-	// We generate a fake output, and the coresponding txin. This output
+	// We generate a fake output, and the corresponding txin. This output
 	// doesn't need to exist, as we'll only be validating spending from the
 	// transaction that references this.
 	fundingOut := &wire.OutPoint{

--- a/lnwallet/wallet.go
+++ b/lnwallet/wallet.go
@@ -668,7 +668,7 @@ func (l *LightningWallet) handleContributionMsg(req *addContributionMsg) {
 	}
 	pendingReservation.partialState.FundingRedeemScript = redeemScript
 
-	// Sort the transaction. Since both side agree to a cannonical
+	// Sort the transaction. Since both side agree to a canonical
 	// ordering, by sorting we no longer need to send the entire
 	// transaction. Only signatures will be exchanged.
 	fundingTx.AddTxOut(multiSigOut)
@@ -708,7 +708,7 @@ func (l *LightningWallet) handleContributionMsg(req *addContributionMsg) {
 	}
 
 	// Locate the index of the multi-sig outpoint in order to record it
-	// since the outputs are cannonically sorted. If this is a single funder
+	// since the outputs are canonically sorted. If this is a single funder
 	// workflow, then we'll also need to send this to the remote node.
 	fundingTxID := fundingTx.TxSha()
 	_, multiSigIndex := FindScriptOutputIndex(fundingTx, multiSigOut.PkScript)
@@ -888,7 +888,7 @@ func (l *LightningWallet) handleSingleContribution(req *addSingleContributionMsg
 }
 
 // handleFundingCounterPartySigs is the final step in the channel reservation
-// workflow. During this setp, we validate *all* the received signatures for
+// workflow. During this step, we validate *all* the received signatures for
 // inputs to the funding transaction. If any of these are invalid, we bail,
 // and forcibly cancel this funding request. Additionally, we ensure that the
 // signature we received from the counterparty for our version of the commitment
@@ -1201,7 +1201,7 @@ out:
 
 // selectCoinsAndChange performs coin selection in order to obtain witness
 // outputs which sum to at least 'numCoins' amount of satoshis. If coin
-// selection is succesful/possible, then the selected coins are available
+// selection is successful/possible, then the selected coins are available
 // within the passed contribution's inputs. If necessary, a change address will
 // also be generated.
 // TODO(roasbeef): remove hardcoded fees and req'd confs for outputs.
@@ -1210,7 +1210,7 @@ func (l *LightningWallet) selectCoinsAndChange(feeRate uint64, amt btcutil.Amoun
 
 	// We hold the coin select mutex while querying for outputs, and
 	// performing coin selection in order to avoid inadvertent double
-	// spends accross funding transactions.
+	// spends across funding transactions.
 	l.coinSelectMtx.Lock()
 	defer l.coinSelectMtx.Unlock()
 
@@ -1222,7 +1222,7 @@ func (l *LightningWallet) selectCoinsAndChange(feeRate uint64, amt btcutil.Amoun
 		return err
 	}
 
-	// Peform coin selection over our available, unlocked unspent outputs
+	// Perform coin selection over our available, unlocked unspent outputs
 	// in order to find enough coins to meet the funding amount
 	// requirements.
 	selectedCoins, changeAmt, err := coinSelect(feeRate, amt, coins)

--- a/peer.go
+++ b/peer.go
@@ -655,8 +655,8 @@ func (p *peer) executeForceClose(channel *lnwallet.LightningChannel) (*wire.ShaH
 		return nil, err
 	}
 
-	// Send the closed channel sumary over to the utxoNursery in order to
-	// have its outputs sweeped back into the wallet once they're mature.
+	// Send the closed channel summary over to the utxoNursery in order to
+	// have its outputs swept back into the wallet once they're mature.
 	p.server.utxoNursery.incubateOutputs(closeSummary)
 
 	return &txid, nil


### PR DESCRIPTION
As far as I see we generate `PW2SH` output in funding transaction and in specification [they use](https://github.com/bitcoin/bips/blob/master/bip-0141.mediawiki#witness-program) `witnessScript` field name. I think we should stick with this one in order to not create confusion later (if we gonna use [`P2WSH nested in P2SH`](https://github.com/bitcoin/bips/blob/master/bip-0141.mediawiki#p2wsh-nested-in-bip16-p2sh) for backward wallets compatibility).