### PR TITLE
Adhere to max-weight limits within LCP state machine #28

### DIFF
--- a/fundingmanager.go
+++ b/fundingmanager.go
@@ -827,7 +827,7 @@ func (f *fundingManager) handleErrorGenericMsg(fmsg *fundingErrorMsg) {
 				"exceeded -- unable to cancel reservation: %v",
 				err)
 		} else {
-			resCtx.err <- grpc.Errorf(OpenChannelFundingError,
+			resCtx.err <- grpc.Errorf(ErrorMaxPendingChannels,
 				"unable to create channel, max number of "+
 					"pending channels exceeded.")
 		}

--- a/htlcswitch.go
+++ b/htlcswitch.go
@@ -222,7 +222,7 @@ func (h *htlcSwitch) SendHTLC(htlcPkt *htlcPacket) error {
 // their links. The duties of the forwarder are similar to that of a network
 // switch, in that it facilitates multi-hop payments by acting as a central
 // messaging bus. The switch communicates will active links to create, manage,
-// and tearn down active onion routed payments.Each active channel is modeled
+// and tear down active onion routed payments.Each active channel is modeled
 // as networked device with meta-data such as the available payment bandwidth,
 // and total link capacity.
 func (h *htlcSwitch) htlcForwarder() {
@@ -292,7 +292,7 @@ out:
 			switch wireMsg := pkt.msg.(type) {
 			// A link has just forwarded us a new HTLC, therefore
 			// we initiate the payment circuit within our internal
-			// staate so we can properly forward the ultimate
+			// state so we can properly forward the ultimate
 			// settle message.
 			case *lnwire.HTLCAddRequest:
 				// Create the two ends of the payment circuit
@@ -328,7 +328,7 @@ out:
 
 				// With the circuit initiated, send the htlcPkt
 				// to the clearing link within the circuit to
-				// continue propagating the HTLC accross the
+				// continue propagating the HTLC across the
 				// network.
 				circuit.clear.linkChan <- &htlcPacket{
 					msg: wireMsg,

--- a/lnd_test.go
+++ b/lnd_test.go
@@ -885,8 +885,8 @@ func testMaxPendingChannels(net *networkHarness, t *harnessTest) {
 	_, err = net.OpenChannel(ctx, net.Alice, carol, amount, 1)
 	if err == nil {
 		t.Fatalf("error wasn't received")
-	} else if grpc.Code(err) != OpenChannelFundingError {
-		t.Fatalf("not expected error was received : %v", err)
+	} else if grpc.Code(err) != ErrorMaxPendingChannels {
+		t.Fatalf("not expected error was received: %v", err)
 	}
 
 	// For now our channels are in pending state, in order to not

--- a/lnwallet/channel.go
+++ b/lnwallet/channel.go
@@ -1014,7 +1014,7 @@ func (lc *LightningChannel) evaluateHTLCView(view *htlcView, ourBalance,
 
 // processAddEntry evaluates the effect of an add entry within the HTLC log.
 // If the HTLC hasn't yet been committed in either chain, then the height it
-// was commited is updated. Keeping track of this inclusion height allows us to
+// was committed is updated. Keeping track of this inclusion height allows us to
 // later compact the log once the change is fully committed in both chains.
 func processAddEntry(htlc *PaymentDescriptor, ourBalance, theirBalance *btcutil.Amount,
 	nextHeight uint64, remoteChain bool, isIncoming bool) {
@@ -1165,7 +1165,7 @@ func (lc *LightningChannel) SignNextCommitment() ([]byte, uint32, error) {
 // the remote party. This method will should be called in response to the
 // remote party initiating a new change, or when the remote party sends a
 // signature fully accepting a new state we've initiated. If we are able to
-// succesfully validate the signature, then the generated commitment is added
+// successfully validate the signature, then the generated commitment is added
 // to our local commitment chain. Once we send a revocation for our prior
 // state, then this newly added commitment becomes our current accepted channel
 // state.
@@ -1992,7 +1992,7 @@ func CreateCommitTx(fundingOutput *wire.TxIn, selfKey, theirKey *btcec.PublicKey
 	}
 
 	// Next, we create the script paying to them. This is just a regular
-	// P2WKH output, without any added CSV delay.
+	// P2WPKH output, without any added CSV delay.
 	theirWitnessKeyHash, err := commitScriptUnencumbered(theirKey)
 	if err != nil {
 		return nil, err

--- a/lnwallet/channel_test.go
+++ b/lnwallet/channel_test.go
@@ -135,7 +135,7 @@ func initRevocationWindows(chanA, chanB *LightningChannel, windowSize int) error
 	return nil
 }
 
-// forceStateTransition executes the neccessary interaction between the two
+// forceStateTransition executes the necessary interaction between the two
 // commitment state machines to transition to a new state locking in any
 // pending updates.
 func forceStateTransition(chanA, chanB *LightningChannel) error {
@@ -320,7 +320,7 @@ func createTestChannels(revocationWindow int) (*LightningChannel, *LightningChan
 // TestSimpleAddSettleWorkflow tests a simple channel scenario wherein the
 // local node (Alice in this case) creates a new outgoing HTLC to bob, commits
 // this change, then bob immediately commits a settlement of the HTLC after the
-// initial add is fully commited in both commit chains.
+// initial add is fully committed in both commit chains.
 // TODO(roasbeef): write higher level framework to exercise various states of
 // the state machine
 //  * DSL language perhaps?
@@ -389,7 +389,7 @@ func TestSimpleAddSettleWorkflow(t *testing.T) {
 	}
 	// Alice then processes this revocation, sending her own recovation for
 	// her prior commitment transaction. Alice shouldn't have any HTLC's to
-	// forward since she's sending anoutgoing HTLC.
+	// forward since she's sending an outgoing HTLC.
 	if htlcs, err := aliceChannel.ReceiveRevocation(bobRevocation); err != nil {
 		t.Fatalf("alice unable to rocess bob's revocation: %v", err)
 	} else if len(htlcs) != 0 {
@@ -441,7 +441,7 @@ func TestSimpleAddSettleWorkflow(t *testing.T) {
 	}
 
 	// Alice's revocation window should now be one beyond the size of the
-	// intial window. Same goes for Bob.
+	// initial window. Same goes for Bob.
 	if aliceChannel.revocationWindowEdge != 4 {
 		t.Fatalf("alice revocation window not incremented, is %v should be %v",
 			aliceChannel.revocationWindowEdge, 4)

--- a/lnwallet/channel_test.go
+++ b/lnwallet/channel_test.go
@@ -731,6 +731,108 @@ func TestCooperativeChannelClosure(t *testing.T) {
 	}
 }
 
+// TestCheckHTLCNumberConstraint checks that we can't add HTLC or receive
+// HTLC if number of HTLCs exceed maximum available number, also this test
+// checks that if for some reason max number of HTLCs was exceeded and not
+// caught before, the creation of new commitment will not be possible because
+// of validation error.
+func TestCheckHTLCNumberConstraint(t *testing.T) {
+	createHTLC := func(i int) *lnwire.HTLCAddRequest {
+		preimage := bytes.Repeat([]byte{byte(i)}, 32)
+		paymentHash := fastsha256.Sum256(preimage)
+		return &lnwire.HTLCAddRequest{
+			RedemptionHashes: [][32]byte{paymentHash},
+			Amount:           lnwire.CreditsAmount(1e7),
+			Expiry:           uint32(5),
+		}
+	}
+
+	checkError := func(err error) error {
+		if err == nil {
+			return errors.New("Exceed max htlc count error was " +
+				"not received")
+		} else if err != ErrMaxHTLCNumber {
+			return errors.Errorf("Unexpected error occured: %v", err)
+		}
+
+		return nil
+	}
+
+	// Create a test channel which will be used for the duration of this
+	// unittest. The channel will be funded evenly with Alice having 5 BTC,
+	// and Bob having 5 BTC.
+	aliceChannel, bobChannel, cleanUp, err := createTestChannels(3)
+	if err != nil {
+		t.Fatalf("unable to create test channels: %v", err)
+	}
+	defer cleanUp()
+
+	// Add max available number of HTLCs.
+	for i := 0; i < MaxHTLCNumber; i++ {
+		htlc := createHTLC(i)
+		if _, err := aliceChannel.AddHTLC(htlc); err != nil {
+			t.Fatalf("alice unable to add htlc: %v", err)
+		}
+		if _, err := bobChannel.ReceiveHTLC(htlc); err != nil {
+			t.Fatalf("bob unable to receive htlc: %v", err)
+		}
+	}
+
+	// Next addition should cause HTLC max number validation error.
+	htlc := createHTLC(0)
+	if _, err := aliceChannel.AddHTLC(htlc); err != nil {
+		if err := checkError(err); err != nil {
+			t.Fatal(err)
+		}
+	} else {
+		t.Fatal("Error was not received")
+	}
+	if _, err := bobChannel.AddHTLC(htlc); err != nil {
+		if err := checkError(err); err != nil {
+			t.Fatal(err)
+		}
+	} else {
+		t.Fatal("Error was not received")
+	}
+	if _, err := aliceChannel.ReceiveHTLC(htlc); err != nil {
+		if err := checkError(err); err != nil {
+			t.Fatal(err)
+		}
+	} else {
+		t.Fatal("Error was not received")
+	}
+	if _, err := bobChannel.ReceiveHTLC(htlc); err != nil {
+		if err := checkError(err); err != nil {
+			t.Fatal(err)
+		}
+	} else {
+		t.Fatal("Error was not received")
+	}
+
+	// Manually add HTLC to check SignNextCommitment validation error.
+	pd := &PaymentDescriptor{Index: aliceChannel.theirLogCounter}
+	aliceChannel.theirLogIndex[pd.Index] = aliceChannel.theirUpdateLog.PushBack(pd)
+	aliceChannel.theirLogCounter++
+
+	_, _, err = aliceChannel.SignNextCommitment()
+	if err := checkError(err); err != nil {
+		t.Fatal(err)
+	}
+
+	// Manually add HTLC to check ReceiveNewCommitment validation error.
+	pd = &PaymentDescriptor{Index: bobChannel.theirLogCounter}
+	bobChannel.theirLogIndex[pd.Index] = bobChannel.theirUpdateLog.PushBack(pd)
+	bobChannel.theirLogCounter++
+
+	// And on this stage we should receive the weight error.
+	someSig := []byte("somesig")
+	err = bobChannel.ReceiveNewCommitment(someSig, aliceChannel.theirLogCounter)
+	if err := checkError(err); err != nil {
+		t.Fatal(err)
+	}
+
+}
+
 func TestStateUpdatePersistence(t *testing.T) {
 	// Create a test channel which will be used for the duration of this
 	// unittest. The channel will be funded evenly with Alice having 5 BTC,

--- a/lnwallet/script_utils.go
+++ b/lnwallet/script_utils.go
@@ -340,7 +340,7 @@ func senderHtlcSpendTimeout(commitScript []byte, outputAmt btcutil.Amount,
 //
 // Possible Input Scripts:
 //    RECVR: <sig> <preimage> 1
-//    REVOK: <sig> <preimage> 1 0
+//    REVOK: <sig> <preimage> 0 1
 //    SENDR: <sig> 0 0
 //
 // OP_IF
@@ -358,7 +358,7 @@ func senderHtlcSpendTimeout(commitScript []byte, outputAmt btcutil.Amount,
 // 	<revoke hash> OP_EQUALVERIFY
 //     OP_ELSE
 // 	//Refund
-// 	<absolute blockehight> OP_CHECKLOCKTIMEVERIFY OP_DROP
+// 	<absolute blockheight> OP_CHECKLOCKTIMEVERIFY OP_DROP
 //     OP_ENDIF
 //     <sender key> OP_CHECKSIG
 // OP_ENDIF

--- a/lnwallet/size.go
+++ b/lnwallet/size.go
@@ -1,0 +1,136 @@
+package lnwallet
+
+import (
+	"github.com/roasbeef/btcd/blockchain"
+)
+
+const (
+	WitnessFactor = blockchain.WitnessScaleFactor
+	MaxTransactionWeightPolicy = blockchain.MaxBlockCost / 10
+
+	// The weight(cost), which is different from the !size! (see BIP-141),
+	// is calculated as:
+	// Weight = 4 * BaseSize + WitnessSize (weight).
+	// BaseSize - size of the transaction without witness data (bytes).
+	// WitnessSize - witness size (bytes).
+	// Weight - the metric for determining the cost of the transaction.
+
+	// P2WSH: 34 bytes
+	//	- OP_0: 1 byte
+	//	- OP_DATA: 1 byte (WitnessScriptSHA256 length)
+	//	- WitnessScriptSHA256: 32 bytes
+	P2WSHSize = 1 + 1 + 32
+
+	// P2PKH: 22 bytes
+	//	- OP_0: 1 byte
+	//	- OP_DATA: 1 byte (PublicKeyHASH160 length)
+	//	- PublicKeyHASH160: 20 bytes
+	P2WPKHSize = 1 + 1 + 20
+
+	// MultiSig: 71 bytes
+	//	- OP_2: 1 byte
+	//	- OP_DATA: 1 byte (pubKeyAlice length)
+	//	- pubKeyAlice: 33 bytes
+	//	- OP_DATA: 1 byte (pubKeyBob length)
+	//	- pubKeyBob: 33 bytes
+	//	- OP_2: 1 byte
+	//	- OP_CHECKMULTISIG: 1 byte
+	MultiSigSize = 1 + 1 + 33 + 1 + 33 + 1 + 1
+
+	// Witness: 222 bytes
+	//	- NumberOfWitnessElements: 1 byte
+	//	- NilLength: 1 byte
+	//	- sigAliceLength: 1 byte
+	//	- sigAlice: 73 bytes
+	//	- sigBobLength: 1 byte
+	//	- sigBob: 73 bytes
+	//	- WitnessScriptLength: 1 byte
+	//	- WitnessScript (MultiSig)
+	WitnessSize = 1 + 1 + 1 + 73 + 1 + 73 + 1 + MultiSigSize
+
+	// FundingInput: 41 bytes
+	//	- PreviousOutPoint:
+	//		- Hash: 32 bytes
+	//		- Index: 4 bytes
+	//	- OP_DATA: 1 byte (ScriptSigLength)
+	//	- ScriptSig: 0 bytes
+	//	- Witness <----	we use "Witness" instead of "ScriptSig" for
+	// 			transaction validation, but "Witness" is stored
+	// 			separately and cost for it size is smaller. So
+	// 			we separate the calculation of ordinary data
+	// 			from witness data.
+	//	- Sequence: 4 bytes
+	FundingInputSize = 32 + 4 + 1 + 4
+
+	// OutputPayingToUs: 43 bytes
+	//	- Value: 8 bytes
+	//	- VarInt: 1 byte (PkScript length)
+	//	- PkScript (P2WSH)
+	CommitmentDelayOutput = 8 + 1 + P2WSHSize
+
+	// OutputPayingToThem: 31 bytes
+	//	- Value: 8 bytes
+	//	- VarInt: 1 byte (PkScript length)
+	//	- PkScript (P2WPKH)
+	CommitmentKeyHashOutput = 8 + 1 + P2WPKHSize
+
+	// HTLCOutput: 43 bytes
+	//	- Value: 8 bytes
+	//	- VarInt: 1 byte (PkScript length)
+	//	- PkScript (PW2SH)
+	HTLCSize = 8 + 1 + P2WSHSize
+
+	// WitnessHeader: 2 bytes
+	//	- Flag: 1 byte
+	//	- Marker: 1 byte
+	WitnessHeaderSize = 1 + 1
+
+	// CommitmentTransaction: 125 bytes
+	//	- Version: 4 bytes
+	//	- WitnessHeader <---- part of the witness data
+	//	- CountTxIn: 1 byte
+	//	- TxIn:
+	//		FundingInput
+	//	- CountTxOut: 1 byte
+	//	- TxOut:
+	//		OutputPayingToThem,
+	//		OutputPayingToUs,
+	//		....HTLCOutputs...
+	//	- LockTime: 4 bytes
+	BaseCommitmentTxSize = 4 + 1 + FundingInputSize + 1 +
+		CommitmentDelayOutput + CommitmentKeyHashOutput + 4
+
+	// CommitmentTransactionCost: 500 weight
+	BaseCommitmentTxCost = WitnessFactor * BaseCommitmentTxSize
+
+	// WitnessCommitmentTxCost: 224 weight
+	WitnessCommitmentTxCost = WitnessHeaderSize + WitnessSize
+
+	// HTLCCost: 172 weight
+	HTLCCost = WitnessFactor * HTLCSize
+
+	// MaxHTLCNumber shows as the maximum number HTLCs which can be
+	// included in commitment transaction. This numbers was calculated by
+	// Rusty Russel in "BOLT #5: Recommendations for On-chain Transaction
+	// Handling", based on the fact that we need to sweep all HTLCs within
+	// one penalty transaction.
+	MaxHTLCNumber = 1253
+)
+
+
+// estimateCommitTxCost estimate commitment transaction cost depending on the
+// precalculated cost of base transaction, witness data, which is needed for
+// paying for funding tx, and htlc cost multiplied by their count.
+func estimateCommitTxCost(count int, prediction bool) int64 {
+	// Make prediction about the size of commitment transaction with
+	// additional HTLC.
+	if prediction {
+		count++
+	}
+
+	htlcCost := int64(count * HTLCCost)
+	baseCost := int64(BaseCommitmentTxCost)
+	witnessCost := int64(WitnessCommitmentTxCost)
+
+	return htlcCost + baseCost + witnessCost
+}

--- a/lnwire/error_generic.go
+++ b/lnwire/error_generic.go
@@ -15,6 +15,10 @@ const (
 	// ErrorMaxPendingChannels is returned by remote peer when the number
 	// of active pending channels exceeds their maximum policy limit.
 	ErrorMaxPendingChannels ErrorCode = 1
+
+	// ErrorMaxTransactionWeight is returned by remote peer when transaction
+	// weight exceed maximum allowable value.
+	ErrorMaxTransactionWeight ErrorCode = 2
 )
 
 // ErrorGeneric represents a generic error bound to an exact channel. The

--- a/lnwire/error_generic.go
+++ b/lnwire/error_generic.go
@@ -15,10 +15,6 @@ const (
 	// ErrorMaxPendingChannels is returned by remote peer when the number
 	// of active pending channels exceeds their maximum policy limit.
 	ErrorMaxPendingChannels ErrorCode = 1
-
-	// ErrorMaxTransactionWeight is returned by remote peer when transaction
-	// weight exceed maximum allowable value.
-	ErrorMaxTransactionWeight ErrorCode = 2
 )
 
 // ErrorGeneric represents a generic error bound to an exact channel. The

--- a/peer.go
+++ b/peer.go
@@ -977,7 +977,7 @@ type commitmentState struct {
 	logCommitTimer <-chan time.Time
 
 	// switchChan is a channel used to send packets to the htlc switch for
-	// fowarding.
+	// forwarding.
 	switchChan chan<- *htlcPacket
 
 	// sphinx is an instance of the Sphinx onion Router for this node. The

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -29,7 +29,9 @@ import (
 )
 
 const (
-	OpenChannelFundingError = 100
+	// ErrorMaxPendingChannels is an additional gRPC error, which is
+	// returned if max pending channel restriction was violated.
+	ErrorMaxPendingChannels = 100
 )
 
 var (


### PR DESCRIPTION
@Roasbeef In this commit I wanted to show what have been done in [#28 issue](https://github.com/lightningnetwork/lnd/issues/28), and would like to get the feedback - Am I doing things right or maybe there is much better way to estimate the size of commitment transaction? For now there is big error (`94 weight`) between estimated transaction cost and actual one, and before dig into problem I think it would be better to show you in which direction I am going to.
## 
- **Related BIPs:**
  - [BIP 141](https://github.com/bitcoin/bips/blob/master/bip-0141.mediawiki)
  - [BIP 144](https://github.com/bitcoin/bips/blob/master/bip-0144.mediawiki)
- **Related issues:**
  - [btcwallet #424 - Add support for new Segregated Witness standard output types](https://github.com/btcsuite/btcwallet/pull/424)
  - [btcd #656 - Add Support for Segregated Witness](https://github.com/btcsuite/btcd/pull/656)
## 

```
- Commitment transaction:
    - Version: 4 bytes
    - TxIn:
        [
            - PreviousOutPoint:
                - Hash: 32 bytes
                - Index: 4 bytes
            - ScriptSig (Unlock script): 0 bytes  
            - Witness:
                - nil byte: 1 byte
                - sigAlice: 73 bytes
                - sigBob: 73 bytes
                - WitnessScript (MultiSig)
            - Sequence: 4 bytes
        ]
    - TxOut:
        // Output paying to them.
        [
            - Value: 8 bytes
            - PkScriptLength: 8 bytes
            - PkScript (PW2SH)
        ],

        // Output paying to us.
        [
            - Value: 8 bytes
            - PkScriptLength: 8 bytes
            - PkScript (P2PKH)
        ],

        // One of the unsettled HTLCs (might not exist at all).
        [
            - Value: 8 bytes
            - PkScriptLegth: 8 bytes
            - PkScript (PW2SH)
        ],
        ....other HTLCs...

    - LockTime: 4 bytes

- PW2SH:
    - OP_0: 1 byte
    - WitnessScriptSHA256: 32 bytes

- P2PKH:
    - OP_0: 1 byte
    - PublicKeyHASH160: 20 bytes

- MultiSig:
    - OP_2: 1 byte
    - pubKeyAliceLength: 1 byte
    - pubKeyAlice: 33 bytes
    - pubKeyBobLength: 1 byte
    - pubKeyBob: 33 bytes
    - OP_2: 1 byte
    - OP_CHECKMULTISIG: 1 byte
```
