### PR TITLE
Use 48-bit commitment transaction numbers

### DIFF
--- a/channeldb/channel.go
+++ b/channeldb/channel.go
@@ -185,7 +185,7 @@ type OpenChannel struct {
 	// StateHintObsfucator are the btyes selected by the initiator (derived
 	// from their shachain root) to obsfucate the state-hint encoded within
 	// the commitment transaction.
-	StateHintObsfucator [4]byte
+	StateHintObsfucator [6]byte
 
 	// ChanType denotes which type of channel this is.
 	ChanType ChannelType

--- a/channeldb/channel_test.go
+++ b/channeldb/channel_test.go
@@ -132,7 +132,7 @@ func createTestChannelState(cdb *DB) (*OpenChannel, error) {
 		}
 	}
 
-	var obsfucator [4]byte
+	var obsfucator [6]byte
 	copy(obsfucator[:], key[:])
 
 	return &OpenChannel{

--- a/lnwallet/channel.go
+++ b/lnwallet/channel.go
@@ -875,7 +875,7 @@ func (lc *LightningChannel) closeObserver(channelCloseNtfn *chainntnfs.SpendEven
 	// Decode the state hint encoded within the commitment transaction to
 	// determine if this is a revoked state or not.
 	obsfucator := lc.channelState.StateHintObsfucator
-	broadcastStateNum := uint64(GetStateNumHint(commitTxBroadcast, obsfucator))
+	broadcastStateNum := GetStateNumHint(commitTxBroadcast, obsfucator)
 
 	currentStateNum := lc.currentHeight
 
@@ -1125,7 +1125,7 @@ func (lc *LightningChannel) fetchCommitmentView(remoteChain bool,
 	// quickly recovering the necessary penalty state in the case of an
 	// uncooperative broadcast.
 	obsfucator := lc.channelState.StateHintObsfucator
-	stateNum := uint32(nextHeight)
+	stateNum := nextHeight
 	if err := SetStateNumHint(commitTx, stateNum, obsfucator); err != nil {
 		return nil, err
 	}

--- a/lnwallet/script_utils.go
+++ b/lnwallet/script_utils.go
@@ -784,7 +784,7 @@ func SetStateNumHint(commitTx *wire.MsgTx, stateNum uint64,
 	// With the current schema we are only able able to encode state num
 	// hints up to 2^48. Therefore if the passed height is greater than our
 	// state hint ceiling, then exit early.
-	if stateNum >= maxStateHint {
+	if stateNum > maxStateHint {
 		return fmt.Errorf("unable to encode state, %v is greater "+
 			"state num that max of %v", stateNum, maxStateHint)
 	}

--- a/lnwallet/script_utils_test.go
+++ b/lnwallet/script_utils_test.go
@@ -571,7 +571,7 @@ func TestCommitTxStateHint(t *testing.T) {
 	copy(obsfucator[:], testHdSeed[:StateHintSize])
 
 	for i := 0; i < 10000; i++ {
-		stateNum := uint32(i)
+		stateNum := uint64(i)
 
 		err := SetStateNumHint(commitTx, stateNum, obsfucator)
 		if err != nil {

--- a/lnwallet/script_utils_test.go
+++ b/lnwallet/script_utils_test.go
@@ -583,5 +583,27 @@ func TestCommitTxStateHint(t *testing.T) {
 			t.Fatalf("state number mismatched, expected %v, got %v",
 				stateNum, extractedStateNum)
 		}
+
+		//Test from maximum allowed state
+		stateNum = uint64(maxStateHint - i)
+		err = SetStateNumHint(commitTx, stateNum, obsfucator)
+		if err != nil {
+			t.Fatalf("unable to set state num %v: %v", i, err)
+		}
+
+		extractedStateNum = GetStateNumHint(commitTx, obsfucator)
+		if extractedStateNum != stateNum {
+			t.Fatalf("state number mismatched, expected %v, got %v",
+				stateNum, extractedStateNum)
+		}
+	}
+
+	if err := SetStateNumHint(commitTx, maxStateHint+1, obsfucator); err == nil {
+		t.Fatalf("state number should not exceed %X", maxStateHint)
+	}
+
+	commitTx.AddTxIn(&wire.TxIn{})
+	if err := SetStateNumHint(commitTx, 0, obsfucator); err == nil {
+		t.Fatalf("more than one input in commit transaction should not be valid")
 	}
 }

--- a/lnwallet/wallet.go
+++ b/lnwallet/wallet.go
@@ -1397,7 +1397,7 @@ func deriveStateHintObsfucator(elkremRoot *elkrem.ElkremSender) ([StateHintSize]
 	return obsfucator, nil
 }
 
-// initStateHints properly sets the obsfucated state ints ob both commitment
+// initStateHints properly sets the obsfucated state hints on both commitment
 // transactions using the passed obsfucator.
 func initStateHints(commit1, commit2 *wire.MsgTx,
 	obsfucator [StateHintSize]byte) error {

--- a/lnwire/lnwire.go
+++ b/lnwire/lnwire.go
@@ -174,6 +174,10 @@ func writeElement(w io.Writer, element interface{}) error {
 		if _, err := w.Write(e[:]); err != nil {
 			return err
 		}
+	case [6]byte:
+		if _, err := w.Write(e[:]); err != nil {
+			return err
+		}
 	case []byte:
 		if _, err := w.Write(e[:]); err != nil {
 			return err
@@ -465,6 +469,10 @@ func readElement(r io.Reader, element interface{}) error {
 
 		*e = OpaqueReason(make([]byte, reasonLen))
 		if _, err := io.ReadFull(r, *e); err != nil {
+			return err
+		}
+	case *[6]byte:
+		if _, err := io.ReadFull(r, e[:]); err != nil {
 			return err
 		}
 	case []byte:

--- a/lnwire/single_funding_complete.go
+++ b/lnwire/single_funding_complete.go
@@ -41,14 +41,14 @@ type SingleFundingComplete struct {
 	// the commitment transaction's only input. The initiator generates
 	// this value by hashing the 0th' state derived from the revocation PRF
 	// an additional time.
-	StateHintObsfucator [4]byte
+	StateHintObsfucator [6]byte
 }
 
 // NewSingleFundingComplete creates, and returns a new empty
 // SingleFundingResponse.
 func NewSingleFundingComplete(chanID uint64, fundingPoint wire.OutPoint,
 	commitSig *btcec.Signature, revokeKey *btcec.PublicKey,
-	obsfucator [4]byte) *SingleFundingComplete {
+	obsfucator [6]byte) *SingleFundingComplete {
 
 	return &SingleFundingComplete{
 		ChannelID:           chanID,

--- a/lnwire/single_funding_complete_test.go
+++ b/lnwire/single_funding_complete_test.go
@@ -7,8 +7,8 @@ import (
 )
 
 func TestSingleFundingCompleteWire(t *testing.T) {
-	var obsfucator [4]byte
-	copy(obsfucator[:], bytes.Repeat([]byte("k"), 4))
+	var obsfucator [6]byte
+	copy(obsfucator[:], bytes.Repeat([]byte("k"), 6))
 
 	// First create a new SFC message.
 	sfc := NewSingleFundingComplete(22, *outpoint1, commitSig1, pubKey,


### PR DESCRIPTION
TODO: fix deriveStateHintObsfucator to set correct obsfucator for the channel. According to the [spec](https://github.com/lightningnetwork/lightning-rfc/blob/master/03-transactions.md#commitment-transaction) the payment-basepoints from `open_channel` and `accept_channel` are needed, and they don't seem to be implemented yet.

Since I am pretty new to writing Go, please let me know if I have done something wrong.