### PR TITLE
Add a link to the license for README license badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![Build Status](http://img.shields.io/travis/lightningnetwork/lnd.svg)]
 (https://travis-ci.org/lightningnetwork/lnd) 
 [![MIT licensed](https://img.shields.io/badge/license-MIT-blue.svg)]
+(https://github.com/lightningnetwork/lnd/blob/master/LICENSE)
 
 
 `lnd` is a complete implementation of a node on the [Lightning

--- a/brontide/README.md
+++ b/brontide/README.md
@@ -4,6 +4,7 @@ brontide
 [![Build Status](http://img.shields.io/travis/lightningnetwork/lnd.svg)]
 (https://travis-ci.org/lightningnetwork/lnd) 
 [![MIT licensed](https://img.shields.io/badge/license-MIT-blue.svg)]
+(https://github.com/lightningnetwork/lnd/blob/master/LICENSE)
 [![GoDoc](https://img.shields.io/badge/godoc-reference-blue.svg)]
 (http://godoc.org/github.com/lightningnetwork/lnd/brontide)
 

--- a/chainntnfs/README.md
+++ b/chainntnfs/README.md
@@ -4,6 +4,7 @@ chainntnfs
 [![Build Status](http://img.shields.io/travis/lightningnetwork/lnd.svg)]
 (https://travis-ci.org/lightningnetwork/lnd) 
 [![MIT licensed](https://img.shields.io/badge/license-MIT-blue.svg)]
+(https://github.com/lightningnetwork/lnd/blob/master/LICENSE)
 [![GoDoc](https://img.shields.io/badge/godoc-reference-blue.svg)]
 (http://godoc.org/github.com/lightningnetwork/lnd/chainntnfs)
 

--- a/channeldb/README.md
+++ b/channeldb/README.md
@@ -4,6 +4,7 @@ channeldb
 [![Build Status](http://img.shields.io/travis/lightningnetwork/lnd.svg)]
 (https://travis-ci.org/lightningnetwork/lnd) 
 [![MIT licensed](https://img.shields.io/badge/license-MIT-blue.svg)]
+(https://github.com/lightningnetwork/lnd/blob/master/LICENSE)
 [![GoDoc](https://img.shields.io/badge/godoc-reference-blue.svg)]
 (http://godoc.org/github.com/lightningnetwork/lnd/channeldb)
 

--- a/lnrpc/README.md
+++ b/lnrpc/README.md
@@ -4,6 +4,7 @@ lnrpc
 [![Build Status](http://img.shields.io/travis/lightningnetwork/lnd.svg)]
 (https://travis-ci.org/lightningnetwork/lnd) 
 [![MIT licensed](https://img.shields.io/badge/license-MIT-blue.svg)]
+(https://github.com/lightningnetwork/lnd/blob/master/LICENSE)
 [![GoDoc](https://img.shields.io/badge/godoc-reference-blue.svg)]
 (http://godoc.org/github.com/lightningnetwork/lnd/lnrpc)
 

--- a/lnwallet/README.md
+++ b/lnwallet/README.md
@@ -4,6 +4,7 @@ lnwallet
 [![Build Status](http://img.shields.io/travis/lightningnetwork/lnd.svg)]
 (https://travis-ci.org/lightningnetwork/lnd) 
 [![MIT licensed](https://img.shields.io/badge/license-MIT-blue.svg)]
+(https://github.com/lightningnetwork/lnd/blob/master/LICENSE)
 [![GoDoc](https://img.shields.io/badge/godoc-reference-blue.svg)]
 (http://godoc.org/github.com/lightningnetwork/lnd/lnwallet)
 

--- a/lnwire/README.md
+++ b/lnwire/README.md
@@ -4,6 +4,7 @@ lnwire
 [![Build Status](http://img.shields.io/travis/lightningnetwork/lnd.svg)]
 (https://travis-ci.org/lightningnetwork/lnd) 
 [![MIT licensed](https://img.shields.io/badge/license-MIT-blue.svg)]
+(https://github.com/lightningnetwork/lnd/blob/master/LICENSE)
 [![GoDoc](https://img.shields.io/badge/godoc-reference-blue.svg)]
 (http://godoc.org/github.com/lightningnetwork/lnd/lnwire)
 

--- a/routing/README.md
+++ b/routing/README.md
@@ -4,6 +4,7 @@ routing
 [![Build Status](http://img.shields.io/travis/lightningnetwork/lnd.svg)]
 (https://travis-ci.org/lightningnetwork/lnd) 
 [![MIT licensed](https://img.shields.io/badge/license-MIT-blue.svg)]
+(https://github.com/lightningnetwork/lnd/blob/master/LICENSE)
 [![GoDoc](https://img.shields.io/badge/godoc-reference-blue.svg)]
 (http://godoc.org/github.com/lightningnetwork/lnd/routing)
 

--- a/zpay32/README.md
+++ b/zpay32/README.md
@@ -4,6 +4,7 @@ zpay32
 [![Build Status](http://img.shields.io/travis/lightningnetwork/lnd.svg)]
 (https://travis-ci.org/lightningnetwork/lnd) 
 [![MIT licensed](https://img.shields.io/badge/license-MIT-blue.svg)]
+(https://github.com/lightningnetwork/lnd/blob/master/LICENSE)
 [![GoDoc](https://img.shields.io/badge/godoc-reference-blue.svg)]
 (http://godoc.org/github.com/lightningnetwork/lnd/zpay32)
 


### PR DESCRIPTION
This pull request makes a link from each license badge.

Previously:
[![MIT licensed](https://img.shields.io/badge/license-MIT-blue.svg)]

Now:
[![MIT licensed](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/lightningnetwork/lnd/blob/master/LICENSE)