### PR TITLE
Various ChannelDelta fixes

### DIFF
--- a/lnwallet/channel.go
+++ b/lnwallet/channel.go
@@ -276,7 +276,8 @@ func (c *commitment) toChannelDelta(ourCommit bool) (*channeldb.ChannelDelta, er
 			pkScript = p.ourPkScript
 		}
 		for i, txOut := range c.txn.TxOut {
-			if bytes.Equal(txOut.PkScript, pkScript) {
+			if bytes.Equal(txOut.PkScript, pkScript) &&
+				txOut.Value == int64(p.Amount) {
 				if contains(dups[p.RHash], uint16(i)) {
 					continue
 				}


### PR DESCRIPTION
This PR aims to fix several things with ChannelDeltas:
* toChannelDelta now handles duplicate payment hashes
* fixes a bug that created incorrect ChannelDeltas
* ~Exclude dust HTLC outputs in ChannelDeltas~

See commit messages for more info.