### PR TITLE
Add chmod +x to start scripts in dockerfiles

### DIFF
--- a/docker/btcd/Dockerfile
+++ b/docker/btcd/Dockerfile
@@ -35,3 +35,7 @@ VOLUME ["/rpc"]
 
 COPY "start-btcctl.sh" .
 COPY "start-btcd.sh" .
+
+RUN chmod +x start-btcctl.sh
+RUN chmod +x start-btcd.sh
+

--- a/docker/lnd/Dockerfile
+++ b/docker/lnd/Dockerfile
@@ -23,3 +23,4 @@ RUN glide install
 RUN go install . ./cmd/...
 
 COPY "docker/lnd/start-lnd.sh" .
+RUN chmod +x start-lnd.sh


### PR DESCRIPTION
docker-compose fails to start because the starting scripts do not have execution permissions.