### PR TITLE
Add channel reserve limit

### DIFF
--- a/channeldb/channel.go
+++ b/channeldb/channel.go
@@ -648,6 +648,8 @@ type ChannelSnapshot struct {
 	LocalBalance  btcutil.Amount
 	RemoteBalance btcutil.Amount
 
+	LocalReserveLimit btcutil.Amount
+
 	NumUpdates uint64
 
 	TotalSatoshisSent     uint64
@@ -669,6 +671,7 @@ func (c *OpenChannel) Snapshot() *ChannelSnapshot {
 		Capacity:              c.Capacity,
 		LocalBalance:          c.OurBalance,
 		RemoteBalance:         c.TheirBalance,
+		LocalReserveLimit:     c.OurChannelReserve,
 		NumUpdates:            c.NumUpdates,
 		TotalSatoshisSent:     c.TotalSatoshisSent,
 		TotalSatoshisReceived: c.TotalSatoshisReceived,

--- a/htlcswitch.go
+++ b/htlcswitch.go
@@ -518,7 +518,7 @@ func (h *htlcSwitch) handleRegisterLink(req *registerLinkMsg) {
 	chanPoint := req.linkInfo.ChannelPoint
 	newLink := &link{
 		capacity:           req.linkInfo.Capacity,
-		availableBandwidth: int64(req.linkInfo.LocalBalance),
+		availableBandwidth: int64(req.linkInfo.LocalBalance - req.linkInfo.LocalReserveLimit),
 		linkChan:           req.linkChan,
 		peer:               req.peer,
 		chanPoint:          chanPoint,


### PR DESCRIPTION
This PR adds the channel reserve limit for both peers in a channel and keeps the respective balances above it when adding/receiving HTLCs.