### PR TITLE
Introduce channel reserve limit

### DIFF
--- a/channeldb/channel.go
+++ b/channeldb/channel.go
@@ -738,9 +738,10 @@ type ChannelSnapshot struct {
 
 	ChannelPoint *wire.OutPoint
 
-	Capacity      btcutil.Amount
-	LocalBalance  btcutil.Amount
-	RemoteBalance btcutil.Amount
+	Capacity       btcutil.Amount
+	LocalBalance   btcutil.Amount
+	RemoteBalance  btcutil.Amount
+	ChannelReserve btcutil.Amount
 
 	NumUpdates uint64
 
@@ -763,6 +764,7 @@ func (c *OpenChannel) Snapshot() *ChannelSnapshot {
 		Capacity:              c.Capacity,
 		LocalBalance:          c.OurBalance,
 		RemoteBalance:         c.TheirBalance,
+		ChannelReserve:        c.OurChannelReserve,
 		NumUpdates:            c.NumUpdates,
 		TotalSatoshisSent:     c.TotalSatoshisSent,
 		TotalSatoshisReceived: c.TotalSatoshisReceived,

--- a/channeldb/channel.go
+++ b/channeldb/channel.go
@@ -57,17 +57,19 @@ var (
 	// sequential prefix scans, and second to eliminate write amplification
 	// caused by serializing/deserializing the *entire* struct with each
 	// update.
-	chanCapacityPrefix   = []byte("ccp")
-	selfBalancePrefix    = []byte("sbp")
-	theirBalancePrefix   = []byte("tbp")
-	minFeePerKbPrefix    = []byte("mfp")
-	theirDustLimitPrefix = []byte("tdlp")
-	ourDustLimitPrefix   = []byte("odlp")
-	updatePrefix         = []byte("uup")
-	satSentPrefix        = []byte("ssp")
-	satReceivedPrefix    = []byte("srp")
-	netFeesPrefix        = []byte("ntp")
-	isPendingPrefix      = []byte("pdg")
+	chanCapacityPrefix     = []byte("ccp")
+	selfBalancePrefix      = []byte("sbp")
+	theirBalancePrefix     = []byte("tbp")
+	minFeePerKbPrefix      = []byte("mfp")
+	theirDustLimitPrefix   = []byte("tdlp")
+	ourDustLimitPrefix     = []byte("odlp")
+	theirChanReservePrefix = []byte("tcrp")
+	ourChanReservePrefix   = []byte("ocrp")
+	updatePrefix           = []byte("uup")
+	satSentPrefix          = []byte("ssp")
+	satReceivedPrefix      = []byte("srp")
+	netFeesPrefix          = []byte("ntp")
+	isPendingPrefix        = []byte("pdg")
 
 	// chanIDKey stores the node, and channelID for an active channel.
 	chanIDKey = []byte("cik")
@@ -150,6 +152,14 @@ type OpenChannel struct {
 	// generated for our commitment transaction; ie. HTLCs below
 	// this amount are not enforceable onchain from out point of view.
 	OurDustLimit btcutil.Amount
+
+	// TheirChannelReserve is the threshold which our counterparts channel
+	// balance is not allowed to fall below.
+	TheirChannelReserve btcutil.Amount
+
+	// OurChannelReserve is the threshold which our channel balance is not
+	// allowed to fall below.
+	OurChannelReserve btcutil.Amount
 
 	// OurCommitKey is the key to be used within our commitment transaction
 	// to generate the scripts for outputs paying to ourself, and
@@ -802,6 +812,12 @@ func putOpenChannel(openChanBucket *bolt.Bucket, nodeChanBucket *bolt.Bucket,
 	if err := putChanOurDustLimit(openChanBucket, channel); err != nil {
 		return err
 	}
+	if err := putChanTheirChannelReserve(openChanBucket, channel); err != nil {
+		return err
+	}
+	if err := putChanOurChannelReserve(openChanBucket, channel); err != nil {
+		return err
+	}
 	if err := putChanNumUpdates(openChanBucket, channel); err != nil {
 		return err
 	}
@@ -888,6 +904,12 @@ func fetchOpenChannel(openChanBucket *bolt.Bucket, nodeChanBucket *bolt.Bucket,
 	}
 	if err = fetchChanOurDustLimit(openChanBucket, channel); err != nil {
 		return nil, fmt.Errorf("unable to read their dust limit: %v", err)
+	}
+	if err = fetchChanTheirChannelReserve(openChanBucket, channel); err != nil {
+		return nil, err
+	}
+	if err = fetchChanOurChannelReserve(openChanBucket, channel); err != nil {
+		return nil, err
 	}
 	if err = fetchChanNumUpdates(openChanBucket, channel); err != nil {
 		return nil, fmt.Errorf("unable to read num updates: %v", err)
@@ -1078,6 +1100,38 @@ func putChanOurDustLimit(openChanBucket *bolt.Bucket, channel *OpenChannel) erro
 	return openChanBucket.Put(keyPrefix, scratch)
 }
 
+func putChanTheirChannelReserve(openChanBucket *bolt.Bucket, channel *OpenChannel) error {
+	scratch := make([]byte, 8)
+	byteOrder.PutUint64(scratch, uint64(channel.TheirChannelReserve))
+
+	var b bytes.Buffer
+	if err := writeOutpoint(&b, channel.ChanID); err != nil {
+		return err
+	}
+
+	keyPrefix := make([]byte, 4+b.Len())
+	copy(keyPrefix, theirChanReservePrefix)
+	copy(keyPrefix[4:], b.Bytes())
+
+	return openChanBucket.Put(keyPrefix, scratch)
+}
+
+func putChanOurChannelReserve(openChanBucket *bolt.Bucket, channel *OpenChannel) error {
+	scratch := make([]byte, 8)
+	byteOrder.PutUint64(scratch, uint64(channel.OurChannelReserve))
+
+	var b bytes.Buffer
+	if err := writeOutpoint(&b, channel.ChanID); err != nil {
+		return err
+	}
+
+	keyPrefix := make([]byte, 4+b.Len())
+	copy(keyPrefix, ourChanReservePrefix)
+	copy(keyPrefix[4:], b.Bytes())
+
+	return openChanBucket.Put(keyPrefix, scratch)
+}
+
 func deleteChanMinFeePerKb(openChanBucket *bolt.Bucket, chanID []byte) error {
 	keyPrefix := make([]byte, 3+len(chanID))
 	copy(keyPrefix, minFeePerKbPrefix)
@@ -1147,6 +1201,38 @@ func deleteChanOurDustLimit(openChanBucket *bolt.Bucket, chanID []byte) error {
 	copy(ourDustKey[3:], chanID)
 
 	return openChanBucket.Delete(ourDustKey)
+}
+
+func fetchChanTheirChannelReserve(openChanBucket *bolt.Bucket, channel *OpenChannel) error {
+	var b bytes.Buffer
+	if err := writeOutpoint(&b, channel.ChanID); err != nil {
+		return err
+	}
+
+	keyPrefix := make([]byte, 4+b.Len())
+	copy(keyPrefix, theirChanReservePrefix)
+	copy(keyPrefix[4:], b.Bytes())
+
+	chanReserveBytes := openChanBucket.Get(keyPrefix)
+	channel.TheirChannelReserve = btcutil.Amount(byteOrder.Uint64(chanReserveBytes))
+
+	return nil
+}
+
+func fetchChanOurChannelReserve(openChanBucket *bolt.Bucket, channel *OpenChannel) error {
+	var b bytes.Buffer
+	if err := writeOutpoint(&b, channel.ChanID); err != nil {
+		return err
+	}
+
+	keyPrefix := make([]byte, 4+b.Len())
+	copy(keyPrefix, ourChanReservePrefix)
+	copy(keyPrefix[4:], b.Bytes())
+
+	chanReserveBytes := openChanBucket.Get(keyPrefix)
+	channel.OurChannelReserve = btcutil.Amount(byteOrder.Uint64(chanReserveBytes))
+
+	return nil
 }
 
 func putChanNumUpdates(openChanBucket *bolt.Bucket, channel *OpenChannel) error {

--- a/htlcswitch.go
+++ b/htlcswitch.go
@@ -637,7 +637,7 @@ func (h *htlcSwitch) handleRegisterLink(req *registerLinkMsg) {
 	chanPoint := req.linkInfo.ChannelPoint
 	newLink := &link{
 		capacity:           req.linkInfo.Capacity,
-		availableBandwidth: int64(req.linkInfo.LocalBalance),
+		availableBandwidth: int64(req.linkInfo.LocalBalance - req.linkInfo.ChannelReserve),
 		peer:               req.peer,
 		chanPoint:          chanPoint,
 	}


### PR DESCRIPTION
In this PR I introduce the channel reserve limit. Currently only the remote peer's reserve limit is enforced when we receive an HTLC from them. 

Checking that the local reserve limit isn't breached didn't seem to look good in lnwallet/channel.go, but rather after having reviewed #118 (and assuming this will be merged), having Bandwidth() of the htlcmanager return the expected local balance, with the reserve limit subtracted from it, would be a better solution. Feedback on this would be much appreciated.