### PR TITLE
zpay32: Fix decoding when payment request is too short.

### DIFF
--- a/zpay32/zbase32check_test.go
+++ b/zpay32/zbase32check_test.go
@@ -94,3 +94,12 @@ func TestChecksumMismatch(t *testing.T) {
 		t.Fatalf("decode should fail with checksum mismatch, instead: %v", err)
 	}
 }
+
+func TestDecodeTooShort(t *testing.T) {
+	// We start with a pre-encoded too-short string.
+	payReqString := "ycyr8brdji"
+
+	if _, err := Decode(payReqString); err != ErrDataTooShort {
+		t.Fatalf("decode should fail with data too short, instead: %v", err)
+	}
+}


### PR DESCRIPTION
This pull request adds a check to zpay32's `Decode` function for data that's too short but validly encoded. This prevents a panic caused by accessing outside the slice bounds reported in issue #127 by `Ylbam` on IRC.