### PR TITLE
rpcserver: fix pendingchannels panic

### DIFF
--- a/rpcserver.go
+++ b/rpcserver.go
@@ -744,12 +744,17 @@ func (r *rpcServer) PendingChannels(ctx context.Context,
 	if includeOpen {
 		pendingOpenChans := r.server.fundingMgr.PendingChannels()
 		for _, pendingOpen := range pendingOpenChans {
+			channelPointStr := "<non initialized yet>"
+			if pendingOpen.channelPoint != nil {
+				channelPointStr = pendingOpen.channelPoint.String()
+			}
+
 			// TODO(roasbeef): add confirmation progress
 			pub := pendingOpen.identityPub.SerializeCompressed()
 			pendingChan := &lnrpc.PendingChannelResponse_PendingChannel{
 				PeerId:        pendingOpen.peerId,
 				IdentityKey:   hex.EncodeToString(pub),
-				ChannelPoint:  pendingOpen.channelPoint.String(),
+				ChannelPoint:  channelPointStr,
 				Capacity:      int64(pendingOpen.capacity),
 				LocalBalance:  int64(pendingOpen.localBalance),
 				RemoteBalance: int64(pendingOpen.remoteBalance),


### PR DESCRIPTION
Fix for #144 issue.

The proper fix should be discussed with @Roasbeef, at this point solution is done just on order node work without crashing.