### PR TITLE
Explain what to do if btcd.conf not found

### DIFF
--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -64,6 +64,13 @@ $ sed -i 's#; rpclimituser=whatever_limited_username_you_want#rpclimituser=kek#'
 $ sed -i 's#; rpclimitpass=#rpclimitpass=kek#' /Users/[username]/Library/Application Support/Btcd/btcd.conf
 ```
 
+If you did not have a `btcd.conf` file yet, you can simply paste the following into it:
+````
+[Application Options]
+rpclimituser=<the username you picked in lnd.conf>
+rpclimitpass=<the password you picked in lnd.conf>
+````
+
 **Then, regardless of OS:**
 ```
 $ btcctl --testnet stop


### PR DESCRIPTION
Not sure if this case makes sense to you, but it seems to be what happened in my case (on Mac OS), and this solution worked.

I also  wondered why in the `sed` command it says "any user/pass you like" and not "the one you picked before", as I did in my case, since that seemed to make sense. :)