### PR TITLE
networktest: add wait for lnd to be started without errors

### DIFF
--- a/networktest.go
+++ b/networktest.go
@@ -187,6 +187,12 @@ func (l *lightningNode) start(lndError chan error) error {
 		close(l.processExit)
 	}()
 
+	select {
+	case <-l.processExit:
+		return errors.New("lnd process was shutted down on the start")
+	case <-time.After(5 * time.Second):
+	}
+
 	pid, err := os.Create(filepath.Join(l.cfg.DataDir,
 		fmt.Sprintf("%v.pid", l.nodeId)))
 	if err != nil {
@@ -334,7 +340,7 @@ func newNetworkHarness() (*networkHarness, error) {
 		activeNodes:   make(map[int]*lightningNode),
 		seenTxns:      make(chan chainhash.Hash),
 		watchRequests: make(chan *watchRequest),
-		lndErrorChan:  make(chan error),
+		lndErrorChan:  make(chan error, 2),
 	}, nil
 }
 


### PR DESCRIPTION
Trying to start the `lnd` integration tests I bumped into very strange bug, if ports `19555|19556` already in use, integration tests just stuck.

As it should be `cmd.Wait()` returns error and sends it to `lndErrorChan` channel, but for some mysterious reasons goroutine which is responsible for receiving this error just stuck on `ht.Fatalf` (to be more specific on `runtime.Goexit()` method).

Goroutine responsible for receiving the error (`lnd_test.go:1794`):
```golang
go func() {
	select {
	case err := <-lndHarness.ProcessErrors():
		ht.Fatalf("lnd finished with error (stderr): "+
			"\n%v", err)
	case <-testsFin:
		return
	}
}()
```

I bypass this strange bug by adding wait for `lnd` start. If somebody may test this, or propose more intelligent solution, it would be great.

Output in case of `port already in use` problem (after fix):
```
=== RUN   TestLightningNetworkDaemon
--- FAIL: TestLightningNetworkDaemon (4.30s)
	lnd_test.go:62: Error outside of test: *errors.errorString lnd finished with error (stderr):
		open /Users/andrey/Library/Application Support/Lnd/lnd.conf: no such file or directory
		listen tcp :19555: bind: address already in use

		/Users/andrey/GoProjects/src/github.com/lightningnetwork/lnd/lnd_test.go:1799 (0x9bd5e)
			TestLightningNetworkDaemon.func1: "\n%v", err)
		/usr/local/Cellar/go/1.7.4_2/libexec/src/runtime/asm_amd64.s:2086 (0x5e371)
			goexit: BYTE	$0x90	// NOP
	lnd_test.go:62: Error outside of test: *errors.errorString unable to set up test lightning network: lnd process was shutted down on the start
		/Users/andrey/GoProjects/src/github.com/lightningnetwork/lnd/lnd_test.go:1839 (0x97cba)
			TestLightningNetworkDaemon: ht.Fatalf("unable to set up test lightning network: %v", err)
		/usr/local/Cellar/go/1.7.4_2/libexec/src/testing/testing.go:610 (0x7e841)
			tRunner: fn(t)
		/usr/local/Cellar/go/1.7.4_2/libexec/src/runtime/asm_amd64.s:2086 (0x5e371)
			goexit: BYTE	$0x90	// NOP
FAIL
exit status 1
```