### PR TITLE
tests: add timeout in 'revoked uncooperative close retribution' test

### DIFF
--- a/gotest.sh
+++ b/gotest.sh
@@ -85,15 +85,18 @@ lint_check() {
     print "* Run static checks"
 
     # Make sure gometalinter is installed and $GOPATH/bin is in your path.
-    if [ ! -x "$(type -p gometalinter)" ]; then
+    if [ ! -x "$(type -p gometalinter.v1)" ]; then
         print "** Install gometalinter"
-        go get -v github.com/alecthomas/gometalinter
-        gometalinter --install
+        go get -u gopkg.in/alecthomas/gometalinter.v1
+        gometalinter.v1 --install
     fi
+
+    # Update metalinter if needed.
+    gometalinter.v1 --install 1>/dev/null
 
     # Automatic checks
     linter_targets=$(glide novendor | grep -v lnrpc)
-    test -z "$(gometalinter --disable-all \
+    test -z "$(gometalinter.v1 --disable-all \
     --enable=gofmt \
     --enable=vet \
     --enable=golint \

--- a/lnd_test.go
+++ b/lnd_test.go
@@ -1467,6 +1467,14 @@ func testRevokedCloseRetribution(net *networkHarness, t *harnessTest) {
 		return bobChannelInfo.Channels[0], nil
 	}
 
+	// Wait for Alice to receive the channel edge from the funding manager.
+	ctxt, _ = context.WithTimeout(ctxb, timeout)
+	err := net.Alice.WaitForNetworkChannelOpen(ctxt, chanPoint)
+	if err != nil {
+		t.Fatalf("alice didn't see the alice->bob channel before "+
+			"timeout: %v", err)
+	}
+
 	// Open up a payment stream to Alice that we'll use to send payment to
 	// Bob. We also create a small helper function to send payments to Bob,
 	// consuming the payment hashes we generated above.

--- a/lnwire/channel_announcement_test.go
+++ b/lnwire/channel_announcement_test.go
@@ -58,9 +58,7 @@ func TestChannelAnnoucementValidation(t *testing.T) {
 	firstBitcoinPrivKey, firstBitcoinPubKey := getKeys("bitcoin-key-1")
 	secondBitcoinPrivKey, secondBitcoinPubKey := getKeys("bitcoin-key-2")
 
-	var hash []byte
-
-	hash = chainhash.DoubleHashB(firstNodePubKey.SerializeCompressed())
+	hash := chainhash.DoubleHashB(firstNodePubKey.SerializeCompressed())
 	firstBitcoinSig, _ := firstBitcoinPrivKey.Sign(hash)
 
 	hash = chainhash.DoubleHashB(secondNodePubKey.SerializeCompressed())

--- a/lnwire/signature.go
+++ b/lnwire/signature.go
@@ -65,7 +65,7 @@ func deserializeSigFromWire(e **btcec.Signature, b [64]byte) error {
 
 	// Create a canonical serialized signature. DER format is:
 	// 0x30 <length> 0x02 <length r> r 0x02 <length s> s
-	sigBytes := make([]byte, 6+rLen+sLen, 6+rLen+sLen)
+	sigBytes := make([]byte, 6+rLen+sLen)
 	sigBytes[0] = 0x30            // DER signature magic value
 	sigBytes[1] = 4 + rLen + sLen // Length of rest of signature
 	sigBytes[2] = 0x02            // Big integer magic value

--- a/networktest.go
+++ b/networktest.go
@@ -462,7 +462,7 @@ func (l *lightningNode) lightningNetworkWatcher() {
 				// If this is a open request, then it can be
 				// dispatched if the number of edges seen for
 				// the channel is at least two.
-				if numEdges, _ := openChans[targetChan]; numEdges >= 2 {
+				if numEdges := openChans[targetChan]; numEdges >= 2 {
 					close(watchRequest.eventChan)
 					continue
 				}


### PR DESCRIPTION
Hmm, looks like timeout hasn't been added there for a reason, but without it, locally, test is not working for me. And also the amount of time to run the integration tests jumped from `~57` sec to `~62` which means this timeout justified, at least on my machine.

I think that it is related to the fact that channel announce is spawned as `goroutine` (in `funding manager`) and for some reason goroutine scheduler postpone its execution. 