### PR TITLE
server: fix panic when error occurres on peer intialisation 

### DIFF
--- a/server.go
+++ b/server.go
@@ -448,10 +448,9 @@ func (s *server) peerConnected(conn net.Conn, connReq *connmgr.ConnReq, inbound 
 	p, err := newPeer(conn, connReq, s, peerAddr, inbound)
 	if err != nil {
 		srvrLog.Errorf("unable to create peer %v", err)
-		if p.connReq != nil {
-			s.connMgr.Remove(p.connReq.ID())
+		if connReq != nil {
+			s.connMgr.Remove(connReq.ID())
 		}
-		p.Disconnect()
 		return
 	}
 


### PR DESCRIPTION
If error occurred on peer initialisation then `p` is nil which cause
panic while accessing peer variables.