### PR TITLE
docs: update docker step-by-step readme

### DIFF
--- a/config.go
+++ b/config.go
@@ -54,7 +54,7 @@ type config struct {
 	DataDir    string `short:"b" long:"datadir" description:"The directory to store lnd's data within"`
 	LogDir     string `long:"logdir" description:"Directory to log output."`
 
-	Listeners   []string `long:"listen" description:"Add an interface/port to listen for connections (default all interfaces port: 10011)"`
+	Listeners   []string `long:"listen" description:"Add an interface/port to listen for connections (default all interfaces port: 5656)"`
 	ExternalIPs []string `long:"externalip" description:"Add an ip to the list of local addresses we claim to listen on to peers"`
 
 	DebugLevel string `short:"d" long:"debuglevel" description:"Logging level for all subsystems {trace, debug, info, warn, error, critical} -- You may also specify <subsystem>=<level>,<subsystem2>=<level>,... to set the log level for individual subsystems -- Use show to list available subsystems"`

--- a/docker/README.md
+++ b/docker/README.md
@@ -115,7 +115,7 @@ bob$ lncli getinfo
 $ docker inspect "bob" | grep IPAddress
 
 # Connect "Alice" to the "Bob" node:
-alice$ lncli connect <bob_pubkey>@<bob_host>:10011
+alice$ lncli connect <bob_pubkey>@<bob_host>:5656
 
 # Check list of peers on "Alice" side:
 alice$ lncli listpeers
@@ -124,7 +124,7 @@ alice$ lncli listpeers
         {
             "pub_key": "0343bc80b914aebf8e50eb0b8e445fc79b9e6e8e5e018fa8c5f85c7d429c117b38",
             "peer_id": 1,
-            "address": "172.19.0.4:10011",
+            "address": "172.19.0.4:5656",
             "bytes_sent": "357",
             "bytes_recv": "357",
             "sat_sent": "0",

--- a/docker/README.md
+++ b/docker/README.md
@@ -250,7 +250,7 @@ bob$ lncli walletbalance
 In order to be more confident with `lnd` commands I suggest you to try 
 to create a mini lightning network cluster ([Create lightning network cluster](#create-lightning-network-cluster)).
 
-In this section we will try to connect our node to the faucent/hub node 
+In this section we will try to connect our node to the faucet/hub node 
 which will create with as the channel and send as some amount of 
 bitcoins. The schema will be following:
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -115,7 +115,7 @@ bob$ lncli getinfo
 $ docker inspect "bob" | grep IPAddress
 
 # Connect "Alice" to the "Bob" node:
-alice$ lncli connect <bob_pubkey>@<bob_host>:5656
+alice$ lncli connect <bob_pubkey>@<bob_host>
 
 # Check list of peers on "Alice" side:
 alice$ lncli listpeers
@@ -295,7 +295,7 @@ After `btcd` synced, connect `Alice` to the `Faucet` node.
 $ docker-compose up -d "alice"; docker exec -i -t "alice" bash
 
 # Connect "Alice" to the "Faucet" node:
-alice$ lncli connect <faucet_identity_address>@<faucet_host>:5656
+alice$ lncli connect <faucet_identity_address>@<faucet_host>
 ```
 
 After connection was achieved the `Faucet` node should create the channel

--- a/docker/README.md
+++ b/docker/README.md
@@ -295,7 +295,7 @@ After `btcd` synced, connect `Alice` to the `Faucet` node.
 $ docker-compose up -d "alice"; docker exec -i -t "alice" bash
 
 # Connect "Alice" to the "Faucet" node:
-alice$ lncli connect <faucet_identity_address>@<faucet_host>:10011
+alice$ lncli connect <faucet_identity_address>@<faucet_host>:5656
 ```
 
 After connection was achieved the `Faucet` node should create the channel

--- a/docker/lnd/Dockerfile
+++ b/docker/lnd/Dockerfile
@@ -3,7 +3,7 @@ FROM golang:1.8
 MAINTAINER Olaoluwa Osuntokun <laolu@lightning.network>
 
 # Expose lnd ports (server, rpc).
-EXPOSE 10011 10009
+EXPOSE 5656 10009
 
 # Force Go to use the cgo based DNS resolver. This is required to ensure DNS
 # queries required to connect to linked containers succeed.


### PR DESCRIPTION
Error `connection refused` was thrown when user tries to get "Alice" to connect to "Bob" node due to port mismatch introduced in this change [1] here.

This commit updates the port value to reflect the new change introduced in [1].

Reference:
[1] https://github.com/lightningnetwork/lnd/commit/72772ce4df051501cf4936e9fedd62bb13463bf2