### PR TITLE
Typo fixes in comments

### DIFF
--- a/brontide/noise_test.go
+++ b/brontide/noise_test.go
@@ -166,7 +166,7 @@ func TestWriteMessageChunking(t *testing.T) {
 
 	// Launch a new goroutine to write the large message generated above in
 	// chunks. We spawn a new goroutine because otherwise, we may block as
-	// the kernal waits for the buffer to flush.
+	// the kernel waits for the buffer to flush.
 	var wg sync.WaitGroup
 	wg.Add(1)
 	go func() {

--- a/channeldb/channel.go
+++ b/channeldb/channel.go
@@ -490,7 +490,7 @@ type ChannelDelta struct {
 	// increasing.
 	UpdateNum uint64
 
-	// Htlcs is the set of HTLC's that are pending at this particular
+	// Htlcs is the set of HTLCs that are pending at this particular
 	// commitment height.
 	Htlcs []*HTLC
 }

--- a/discovery/utils.go
+++ b/discovery/utils.go
@@ -108,7 +108,7 @@ func copyPubKey(pub *btcec.PublicKey) *btcec.PublicKey {
 }
 
 // SignAnnouncement is a helper function which is used to sign any outgoing
-// channel node node announcement messages.
+// channel node announcement messages.
 func SignAnnouncement(signer lnwallet.MessageSigner, pubKey *btcec.PublicKey,
 	msg lnwire.Message) (*btcec.Signature, error) {
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,15 +1,15 @@
-This document is written for people who are eager to do something with 
+This document is written for people who are eager to do something with
 the Lightning Network Daemon (`lnd`). This folder uses `docker-compose` to
 package `lnd` and `btcd` together to make deploying the two daemons as easy as
 typing a few commands. All configuration between `lnd` and `btcd` are handled
 automatically by their `docker-compose` config file.
 
 ### Prerequisites
-    Name  | Version 
+    Name  | Version
     --------|---------
     docker-compose | 1.9.0
     docker | 1.13.0
-  
+
 ### Table of content
  * [Create lightning network cluster](#create-lightning-network-cluster)
  * [Connect to faucet lightning node](#connect-to-faucet-lightning-node)
@@ -33,20 +33,20 @@ In the workflow below, we describe the steps required to recreate following
 topology, and send a payment from `Alice` to `Bob`.
 ```
 + ----- +                   + --- +
-| Alice | <--- channel ---> | Bob |  <---   Bob and Alice are the lightning network daemons which 
+| Alice | <--- channel ---> | Bob |  <---   Bob and Alice are the lightning network daemons which
 + ----- +                   + --- +         creates the channel and interact with each other using   
-    |                          |            Bitcoin network as source of truth. 
+    |                          |            Bitcoin network as source of truth.
     |                          |            
     + - - - -  - + - - - - - - +            
                  |
         + --------------- +
         | Bitcoin network |  <---  In current scenario for simplicity we create only one  
         + --------------- +        "btcd" node which represents the Bitcoin network, in  
-                                    real situation Alice and Bob will likely be 
+                                    real situation Alice and Bob will likely be
                                     connected to different Bitcoin nodes.
 ```
 
-**General workflow is the following:** 
+**General workflow is the following:**
 
  * Create a `btcd` node running on a private `simnet`.
  * Create `Alice`, one of the `lnd` nodes in our simulation network.
@@ -61,7 +61,7 @@ Start `btcd`, and then create an address for `Alice` that we'll directly mine
 bitcoin into.
 ```bash
 # Init bitcoin network env variable:
-$ export BITCOIN_NETWORK="simnet" 
+$ export BITCOIN_NETWORK="simnet"
 
 # Run "btcd" node:
 $ docker-compose up -d "btcd"
@@ -71,12 +71,12 @@ $ docker-compose up -d "alice"
 $ docker exec -i -t "alice" bash
 
 # Generate a new backward compatible nested p2sh address for Alice:
-alice$ lncli newaddress np2wkh 
+alice$ lncli newaddress np2wkh
 
 # Recreate "btcd" node and set Alice's address as mining address:
 $ MINING_ADDRESS=<alice_address> docker-compose up -d "btcd"
 
-# Generate 400 block (we need at least "100 >=" blocks because of coinbase 
+# Generate 400 block (we need at least "100 >=" blocks because of coinbase
 # block maturity and "300 ~=" in order to activate segwit):
 $ docker-compose run btcctl generate 400
 
@@ -188,8 +188,8 @@ Send the payment form `Alice` to `Bob`.
 # Add invoice on "Bob" side:
 bob$ lncli addinvoice --value=10000
 {
-        "r_hash": "<your_random_rhash_here>", 
-        "pay_req": "<encoded_invoice>", 
+        "r_hash": "<your_random_rhash_here>",
+        "pay_req": "<encoded_invoice>",
 }
 
 # Send payment from "Alice" to "Bob":
@@ -228,7 +228,7 @@ alice$ lncli listchannels
     ]
 }
 
-# Channel point consist of two numbers separated by colon the first one 
+# Channel point consist of two numbers separated by colon the first one
 # is "funding_txid" and the second one is "output_index":
 alice$ lncli closechannel --funding_txid=<funding_txid> --output_index=<output_index>
 
@@ -247,11 +247,11 @@ bob$ lncli walletbalance
 ```
 
 ### Connect to faucet lightning node
-In order to be more confident with `lnd` commands I suggest you to try 
+In order to be more confident with `lnd` commands I suggest you to try
 to create a mini lightning network cluster ([Create lightning network cluster](#create-lightning-network-cluster)).
 
-In this section we will try to connect our node to the faucet/hub node 
-which will create with as the channel and send as some amount of 
+In this section we will try to connect our node to the faucet/hub node
+which will create with as the channel and send as some amount of
 bitcoins. The schema will be following:
 
 ```
@@ -265,23 +265,23 @@ bitcoins. The schema will be following:
                        + --------------- +
                        | Bitcoin network |  <---  (3)   
                        + --------------- +        
-        
-        
- (1) You may connect an additinal node "Bob" and make the multihope 
+
+
+ (1) You may connect an additinal node "Bob" and make the multihop
  payment Alice->Faucet->Bob
-  
- (2) "Faucet", "Alice" and "Bob" are the lightning network daemons which 
- creates the channel and interact with each other using Bitcoin network 
+
+ (2) "Faucet", "Alice" and "Bob" are the lightning network daemons which
+ creates the channel and interact with each other using Bitcoin network
  as source of truth.
- 
- (3) In current scenario "Alice" and "Faucet" lightning network nodes 
+
+ (3) In current scenario "Alice" and "Faucet" lightning network nodes
  connected to different Bitcoin nodes. If you decide to connect "Bob"
  to "Faucet" than already created "btcd" node would be sufficient.
 ```
 
-First of all you need to run `btcd` node in `testnet` and wait it to be 
+First of all you need to run `btcd` node in `testnet` and wait it to be
 synced with test network (`May the Force and Patience be with you` ᕦ(ò_óˇ)ᕤ).
-```bash 
+```bash
 # Init bitcoin network env variable:
 $ export BITCOIN_NETWORK="testnet"
 
@@ -290,7 +290,7 @@ $ docker-compose up -d "btcd"
 ```
 
 After `btcd` synced, connect `Alice` to the `Faucet` node.
-```bash 
+```bash
 # Run "Alice" container and log into it:
 $ docker-compose up -d "alice"; docker exec -i -t "alice" bash
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,15 +1,15 @@
-This document is written for people who are eager to do something with
+This document is written for people who are eager to do something with 
 the Lightning Network Daemon (`lnd`). This folder uses `docker-compose` to
 package `lnd` and `btcd` together to make deploying the two daemons as easy as
 typing a few commands. All configuration between `lnd` and `btcd` are handled
 automatically by their `docker-compose` config file.
 
 ### Prerequisites
-    Name  | Version
+    Name  | Version 
     --------|---------
     docker-compose | 1.9.0
     docker | 1.13.0
-
+  
 ### Table of content
  * [Create lightning network cluster](#create-lightning-network-cluster)
  * [Connect to faucet lightning node](#connect-to-faucet-lightning-node)
@@ -33,20 +33,20 @@ In the workflow below, we describe the steps required to recreate following
 topology, and send a payment from `Alice` to `Bob`.
 ```
 + ----- +                   + --- +
-| Alice | <--- channel ---> | Bob |  <---   Bob and Alice are the lightning network daemons which
+| Alice | <--- channel ---> | Bob |  <---   Bob and Alice are the lightning network daemons which 
 + ----- +                   + --- +         creates the channel and interact with each other using   
-    |                          |            Bitcoin network as source of truth.
+    |                          |            Bitcoin network as source of truth. 
     |                          |            
     + - - - -  - + - - - - - - +            
                  |
         + --------------- +
         | Bitcoin network |  <---  In current scenario for simplicity we create only one  
         + --------------- +        "btcd" node which represents the Bitcoin network, in  
-                                    real situation Alice and Bob will likely be
+                                    real situation Alice and Bob will likely be 
                                     connected to different Bitcoin nodes.
 ```
 
-**General workflow is the following:**
+**General workflow is the following:** 
 
  * Create a `btcd` node running on a private `simnet`.
  * Create `Alice`, one of the `lnd` nodes in our simulation network.
@@ -61,7 +61,7 @@ Start `btcd`, and then create an address for `Alice` that we'll directly mine
 bitcoin into.
 ```bash
 # Init bitcoin network env variable:
-$ export BITCOIN_NETWORK="simnet"
+$ export BITCOIN_NETWORK="simnet" 
 
 # Run "btcd" node:
 $ docker-compose up -d "btcd"
@@ -71,12 +71,12 @@ $ docker-compose up -d "alice"
 $ docker exec -i -t "alice" bash
 
 # Generate a new backward compatible nested p2sh address for Alice:
-alice$ lncli newaddress np2wkh
+alice$ lncli newaddress np2wkh 
 
 # Recreate "btcd" node and set Alice's address as mining address:
 $ MINING_ADDRESS=<alice_address> docker-compose up -d "btcd"
 
-# Generate 400 block (we need at least "100 >=" blocks because of coinbase
+# Generate 400 block (we need at least "100 >=" blocks because of coinbase 
 # block maturity and "300 ~=" in order to activate segwit):
 $ docker-compose run btcctl generate 400
 
@@ -188,8 +188,8 @@ Send the payment form `Alice` to `Bob`.
 # Add invoice on "Bob" side:
 bob$ lncli addinvoice --value=10000
 {
-        "r_hash": "<your_random_rhash_here>",
-        "pay_req": "<encoded_invoice>",
+        "r_hash": "<your_random_rhash_here>", 
+        "pay_req": "<encoded_invoice>", 
 }
 
 # Send payment from "Alice" to "Bob":
@@ -228,7 +228,7 @@ alice$ lncli listchannels
     ]
 }
 
-# Channel point consist of two numbers separated by colon the first one
+# Channel point consist of two numbers separated by colon the first one 
 # is "funding_txid" and the second one is "output_index":
 alice$ lncli closechannel --funding_txid=<funding_txid> --output_index=<output_index>
 
@@ -247,11 +247,11 @@ bob$ lncli walletbalance
 ```
 
 ### Connect to faucet lightning node
-In order to be more confident with `lnd` commands I suggest you to try
+In order to be more confident with `lnd` commands I suggest you to try 
 to create a mini lightning network cluster ([Create lightning network cluster](#create-lightning-network-cluster)).
 
-In this section we will try to connect our node to the faucet/hub node
-which will create with as the channel and send as some amount of
+In this section we will try to connect our node to the faucet/hub node 
+which will create with as the channel and send as some amount of 
 bitcoins. The schema will be following:
 
 ```
@@ -265,23 +265,23 @@ bitcoins. The schema will be following:
                        + --------------- +
                        | Bitcoin network |  <---  (3)   
                        + --------------- +        
-
-
- (1) You may connect an additinal node "Bob" and make the multihop
+        
+        
+ (1) You may connect an additinal node "Bob" and make the multihope 
  payment Alice->Faucet->Bob
-
- (2) "Faucet", "Alice" and "Bob" are the lightning network daemons which
- creates the channel and interact with each other using Bitcoin network
+  
+ (2) "Faucet", "Alice" and "Bob" are the lightning network daemons which 
+ creates the channel and interact with each other using Bitcoin network 
  as source of truth.
-
- (3) In current scenario "Alice" and "Faucet" lightning network nodes
+ 
+ (3) In current scenario "Alice" and "Faucet" lightning network nodes 
  connected to different Bitcoin nodes. If you decide to connect "Bob"
  to "Faucet" than already created "btcd" node would be sufficient.
 ```
 
-First of all you need to run `btcd` node in `testnet` and wait it to be
+First of all you need to run `btcd` node in `testnet` and wait it to be 
 synced with test network (`May the Force and Patience be with you` ᕦ(ò_óˇ)ᕤ).
-```bash
+```bash 
 # Init bitcoin network env variable:
 $ export BITCOIN_NETWORK="testnet"
 
@@ -290,7 +290,7 @@ $ docker-compose up -d "btcd"
 ```
 
 After `btcd` synced, connect `Alice` to the `Faucet` node.
-```bash
+```bash 
 # Run "Alice" container and log into it:
 $ docker-compose up -d "alice"; docker exec -i -t "alice" bash
 

--- a/docs/code_contribution_guidelines.md
+++ b/docs/code_contribution_guidelines.md
@@ -344,7 +344,7 @@ Functions should _not_ just be layed out as a bare contiguous block of code.
 
 #### 4.5.6. Protobuf Compilation
 
-The `lnd` project uses `protobuf`, and its extension [`gRPC`](www.grpc.io) in
+The `lnd` project uses `protobuf`, and its extension [`gRPC`](http://www.grpc.io) in
 several areas and as the primary RPC interface. In order to ensure uniformity
 of all protos checked, in we require that all contributors pin against the
 _exact same_ version of `protoc`. As of the writing of this article, the `lnd`

--- a/htlcswitch.go
+++ b/htlcswitch.go
@@ -36,7 +36,7 @@ var (
 // the link have a value which defines the max number of pending HTLCs present
 // within the commitment transaction. Using this struct we establish a
 // synchronization primitive that ensure we don't send additional htlcPackets
-// to a link if the max limit has een reached. Once HTLCs are cleared from the
+// to a link if the max limit has been reached. Once HTLCs are cleared from the
 // commitment transaction, slots are freed up and more can proceed.
 type boundedLinkChan struct {
 	// slots is a buffered channel whose buffer is the total number of
@@ -644,7 +644,7 @@ func (h *htlcSwitch) handleRegisterLink(req *registerLinkMsg) {
 		chanID:             chanID,
 	}
 
-	// To ensure we never accidentally cause an HTLC overflow, we'll limit,
+	// To ensure we never accidentally cause an HTLC overflow,
 	// we'll use this buffered channel as as semaphore in order to limit
 	// the number of outstanding HTLCs we extend to the target link.
 	//const numSlots = (lnwallet.MaxHTLCNumber / 2) - 1

--- a/htlcswitch.go
+++ b/htlcswitch.go
@@ -33,14 +33,14 @@ var (
 
 // boundedLinkChan is a simple wrapper around a link's communication channel
 // that bounds the total flow into and through the channel. Channels attached
-// the link have a value which defines the max number of pending HTLC's present
+// the link have a value which defines the max number of pending HTLCs present
 // within the commitment transaction. Using this struct we establish a
 // synchronization primitive that ensure we don't send additional htlcPackets
-// to a link if the max limit has een reached. Once HTLC's are cleared from the
+// to a link if the max limit has een reached. Once HTLCs are cleared from the
 // commitment transaction, slots are freed up and more can proceed.
 type boundedLinkChan struct {
 	// slots is a buffered channel whose buffer is the total number of
-	// outstanding HTLC's we can add to a link's commitment transaction.
+	// outstanding HTLCs we can add to a link's commitment transaction.
 	// This channel is essentially used as a semaphore.
 	slots chan struct{}
 
@@ -646,7 +646,7 @@ func (h *htlcSwitch) handleRegisterLink(req *registerLinkMsg) {
 
 	// To ensure we never accidentally cause an HTLC overflow, we'll limit,
 	// we'll use this buffered channel as as semaphore in order to limit
-	// the number of outstanding HTLC's we extend to the target link.
+	// the number of outstanding HTLCs we extend to the target link.
 	//const numSlots = (lnwallet.MaxHTLCNumber / 2) - 1
 	const numSlots = lnwallet.MaxHTLCNumber - 5
 	newLink.boundedLinkChan = newBoundedLinkChan(numSlots, req.linkChan)

--- a/lnd_test.go
+++ b/lnd_test.go
@@ -423,7 +423,7 @@ peersPoll:
 	closeChannelAndAssert(ctxt, t, net, net.Alice, chanPoint, true)
 }
 
-// testChannelBalance creates a new channel between Alice and  Bob, then
+// testChannelBalance creates a new channel between Alice and Bob, then
 // checks channel balance to be equal amount specified while creation of channel.
 func testChannelBalance(net *networkHarness, t *harnessTest) {
 	timeout := time.Duration(time.Second * 5)
@@ -468,7 +468,7 @@ func testChannelBalance(net *networkHarness, t *harnessTest) {
 	}
 
 	// As this is a single funder channel, Alice's balance should be
-	// exactly 0.5 BTC since now state transitions have taken place yet.
+	// exactly 0.5 BTC since no state transitions have taken place yet.
 	checkChannelBalance(net.Alice, amount)
 
 	// Ensure Bob currently has no available balance within the channel.
@@ -1453,7 +1453,7 @@ func testRevokedCloseRetribution(net *networkHarness, t *harnessTest) {
 		bobPaymentHashes[i] = resp.RHash
 	}
 
-	// As we'll be querying the state of bob's channels frequently we'll
+	// As we'll be querying the state of Bob's channels frequently we'll
 	// create a closure helper function for the purpose.
 	getBobChanInfo := func() (*lnrpc.ActiveChannel, error) {
 		req := &lnrpc.ListChannelsRequest{}
@@ -1732,7 +1732,7 @@ out:
 		}
 	}
 
-	// With the channels, open we can now start to test our multi-hop error
+	// With the channels open, we can now start to test our multi-hop error
 	// scenarios. First, we'll generate an invoice from carol that we'll
 	// use to test some error cases.
 	const payAmt = 10000
@@ -1828,7 +1828,7 @@ out:
 	}
 
 	// To do so, we'll push most of the funds in the channel over to
-	// Alice's side, leaving on 10k satoshis of available balance for bob.
+	// Alice's side, leaving on 10k satoshis of available balance for Bob.
 	invoiceReq = &lnrpc.Invoice{
 		Value: int64(chanAmt) - 10000,
 	}

--- a/lnwallet/btcwallet/btcwallet.go
+++ b/lnwallet/btcwallet/btcwallet.go
@@ -132,7 +132,7 @@ func New(cfg Config) (*BtcWallet, error) {
 //
 // This is a part of the WalletController interface.
 func (b *BtcWallet) Start() error {
-	// Establish an RPC connection in additino to starting the goroutines
+	// Establish an RPC connection in addition to starting the goroutines
 	// in the underlying wallet.
 	if err := b.rpc.Start(); err != nil {
 		return err

--- a/lnwallet/channel.go
+++ b/lnwallet/channel.go
@@ -1814,7 +1814,7 @@ func (lc *LightningChannel) RevokeCurrentCommitment() (*lnwire.RevokeAndAck, err
 // windows are extended, or in response to a state update that we initiate. If
 // successful, then the remote commitment chain is advanced by a single
 // commitment, and a log compaction is attempted. In addition, a slice of
-// HTLC's which can be forwarded upstream are returned.
+// HTLCs which can be forwarded upstream are returned.
 func (lc *LightningChannel) ReceiveRevocation(revMsg *lnwire.RevokeAndAck) ([]*PaymentDescriptor, error) {
 	lc.Lock()
 	defer lc.Unlock()

--- a/lnwallet/channel_test.go
+++ b/lnwallet/channel_test.go
@@ -1271,7 +1271,7 @@ func TestStateUpdatePersistence(t *testing.T) {
 		t.Fatalf("unable to recv bob's htlc: %v", err)
 	}
 
-	// Next, Alice initiates a state transition to include the HTLC's she
+	// Next, Alice initiates a state transition to include the HTLCs she
 	// added above in a new commitment state.
 	if err := forceStateTransition(aliceChannel, bobChannel); err != nil {
 		t.Fatalf("unable to complete alice's state transition: %v", err)

--- a/lnwallet/channel_test.go
+++ b/lnwallet/channel_test.go
@@ -381,7 +381,7 @@ func TestSimpleAddSettleWorkflow(t *testing.T) {
 	}
 
 	// Bob receives this signature message, revokes his prior commitment
-	// given to him by Alice,a nd then finally send a signature for Alice's
+	// given to him by Alice, and then finally send a signature for Alice's
 	// commitment transaction.
 	if err := bobChannel.ReceiveNewCommitment(aliceSig); err != nil {
 		t.Fatalf("bob unable to process alice's new commitment: %v", err)

--- a/lnwallet/interface_test.go
+++ b/lnwallet/interface_test.go
@@ -1149,7 +1149,7 @@ func testSignOutputPrivateTweak(r *rpctest.Harness, w *lnwallet.LightningWallet,
 		outputIndex = 1
 	}
 
-	/// WIth the index located, we can create a transaction spending the
+	/// With the index located, we can create a transaction spending the
 	//referenced output.
 	sweepTx := wire.NewMsgTx(2)
 	sweepTx.AddTxIn(&wire.TxIn{

--- a/lnwallet/script_utils.go
+++ b/lnwallet/script_utils.go
@@ -228,7 +228,7 @@ func senderHTLCScript(absoluteTimeout, relativeTimeout uint32, senderKey,
 	builder.AddOp(txscript.OP_ELSE)
 
 	// In this case, the sender will need to wait for an absolute HTLC
-	// timeout, then afterwards a relative timeout before we claim re-claim
+	// timeout, then afterwards a relative timeout before we re-claim
 	// the unsettled funds. This delay gives the other party a chance to
 	// present the preimage to the revocation hash in the event that the
 	// sender (at this time) broadcasts this commitment transaction after

--- a/lnwallet/wallet.go
+++ b/lnwallet/wallet.go
@@ -242,7 +242,7 @@ type addSingleFunderSigsMsg struct {
 // a channel. However, once the chainntnfs package is complete, the wallet
 // will be compatible with multiple RPC/notification services such as Electrum,
 // Bitcoin Core + ZeroMQ, etc. Eventually, the wallet won't require a full-node
-// at all, as SPV support is integrated inot btcwallet.
+// at all, as SPV support is integrated into btcwallet.
 type LightningWallet struct {
 	// This mutex is to be held when generating external keys to be used
 	// as multi-sig, and commitment keys within the channel.

--- a/lnwire/announcement_signatures.go
+++ b/lnwire/announcement_signatures.go
@@ -6,7 +6,7 @@ import (
 	"github.com/roasbeef/btcd/btcec"
 )
 
-// AnnounceSignatures this is a direct message between two endpoints of a
+// AnnounceSignatures is a direct message between two endpoints of a
 // channel and serves as an opt-in mechanism to allow the announcement of
 // the channel to the rest of the network. It contains the necessary
 // signatures by the sender to construct the channel announcement message.
@@ -25,12 +25,12 @@ type AnnounceSignatures struct {
 	ShortChannelID ShortChannelID
 
 	// NodeSignature is the signature which contains the signed announce
-	// channel message, by this signature we proof that we posses of the
+	// channel message, by this signature we prove that we posses of the
 	// node pub key and creating the reference node_key -> bitcoin_key.
 	NodeSignature *btcec.Signature
 
 	// BitcoinSignature is the signature which contains the signed node
-	// public key, by this signature we proof that we posses of the
+	// public key, by this signature we prove that we posses of the
 	// bitcoin key and and creating the reverse reference bitcoin_key ->
 	// node_key.
 	BitcoinSignature *btcec.Signature

--- a/lnwire/channel_announcement.go
+++ b/lnwire/channel_announcement.go
@@ -11,14 +11,14 @@ import (
 // between two peers in the overlay, which is propagated by the discovery
 // service over broadcast handler.
 type ChannelAnnouncement struct {
-	// This signatures are used by nodes in order to create cross
+	// These signatures are used by nodes in order to create cross
 	// references between node's channel and node. Requiring both nodes
 	// to sign indicates they are both willing to route other payments via
 	// this node.
 	NodeSig1 *btcec.Signature
 	NodeSig2 *btcec.Signature
 
-	// This signatures are used by nodes in order to create cross
+	// These signatures are used by nodes in order to create cross
 	// references between node's channel and node. Requiring the bitcoin
 	// signatures proves they control the channel.
 	BitcoinSig1 *btcec.Signature
@@ -28,12 +28,12 @@ type ChannelAnnouncement struct {
 	ShortChannelID ShortChannelID
 
 	// The public keys of the two nodes who are operating the channel, such
-	// that is NodeID1 the numerically-lesser than NodeID2 (ascending
+	// that NodeID1 is numerically-lesser than NodeID2 (ascending
 	// numerical order).
 	NodeID1 *btcec.PublicKey
 	NodeID2 *btcec.PublicKey
 
-	// Public keys which corresponds to the keys which was declared in
+	// Public keys which corresponds to the keys which were declared in
 	// multisig funding transaction output.
 	BitcoinKey1 *btcec.PublicKey
 	BitcoinKey2 *btcec.PublicKey

--- a/lnwire/close_complete.go
+++ b/lnwire/close_complete.go
@@ -7,7 +7,7 @@ import (
 	"io"
 )
 
-// CloseComplete is sent by Bob signalling a fufillment and completion of
+// CloseComplete is sent by Bob signalling a fulfillment and completion of
 // Alice's prior CloseRequest message. After Alice receives Bob's CloseComplete
 // message, she is able to broadcast the fully signed transaction executing a
 // cooperative closure of the channel.

--- a/lnwire/commit_sig.go
+++ b/lnwire/commit_sig.go
@@ -6,13 +6,13 @@ import (
 	"github.com/roasbeef/btcd/btcec"
 )
 
-// CommitSig is sent by either side to stage any pending HTLC's in the
+// CommitSig is sent by either side to stage any pending HTLCs in the
 // receiver's pending set into a new commitment state.  Implicitly, the new
 // commitment transaction constructed which has been signed by CommitSig
-// includes all HTLC's in the remote node's pending set. A CommitSig message
+// includes all HTLCs in the remote node's pending set. A CommitSig message
 // may be sent after a series of UpdateAddHTLC/UpdateFufillHTLC messages in
-// order to batch add several HTLC's with a single signature covering all
-// implicitly accepted HTLC's.
+// order to batch add several HTLCs with a single signature covering all
+// implicitly accepted HTLCs.
 type CommitSig struct {
 	// ChanID uniquely identifies to which currently active channel this
 	// CommitSig applies to.

--- a/lnwire/features.go
+++ b/lnwire/features.go
@@ -168,7 +168,7 @@ func NewFeatureVectorFromReader(r io.Reader) (*FeatureVector, error) {
 
 // Encode encodes the features vector into bytes representation, every feature
 // encoded as 2 bits where odd bit determine whether the feature is "optional"
-// and even bit told us whether the feature is "required". The even/odd
+// and even bit tell us whether the feature is "required". The even/odd
 // semantic allows future incompatible changes, or backward compatible changes.
 // Bits generally assigned in pairs, so that optional features can later become
 // compulsory.
@@ -203,7 +203,7 @@ func (f *FeatureVector) Encode(w io.Writer) error {
 
 // Compare checks that features are compatible and returns the features which
 // were present in both remote and local feature vectors. If remote/local node
-// doesn't have the feature and local/remote node require it than such vectors
+// doesn't have the feature and local/remote node require it then such vectors
 // are incompatible.
 func (f *FeatureVector) Compare(f2 *FeatureVector) (*SharedFeatures, error) {
 	shared := newSharedFeatures(f.Copy())
@@ -215,14 +215,14 @@ func (f *FeatureVector) Compare(f2 *FeatureVector) (*SharedFeatures, error) {
 				return nil, errors.New("Remote node hasn't " +
 					"locally required feature")
 			case OptionalFlag:
-				// If feature is optional and remote side
-				// haven't it than it might be safely disabled.
+				// If feature is optional and remote side doesn't
+				// have it then it might be safely disabled.
 				delete(shared.flags, index)
 				continue
 			}
 		}
 
-		// If feature exists on both sides than such feature might be
+		// If feature exists on both sides then such feature might be
 		// considered as active.
 		shared.flags[index] = flag
 	}
@@ -234,14 +234,14 @@ func (f *FeatureVector) Compare(f2 *FeatureVector) (*SharedFeatures, error) {
 				return nil, errors.New("Local node hasn't " +
 					"locally required feature")
 			case OptionalFlag:
-				// If feature is optional and local side
-				// haven't it than it might be safely disabled.
+				// If feature is optional and local side doesn't
+				// have it then it might be safely disabled.
 				delete(shared.flags, index)
 				continue
 			}
 		}
 
-		// If feature exists on both sides than such feature might be
+		// If feature exists on both sides then such feature might be
 		// considered as active.
 		shared.flags[index] = flag
 	}
@@ -249,7 +249,7 @@ func (f *FeatureVector) Compare(f2 *FeatureVector) (*SharedFeatures, error) {
 	return shared, nil
 }
 
-// Copy generate new distinct instance of the feature vector.
+// Copy generates new distinct instance of the feature vector.
 func (f *FeatureVector) Copy() *FeatureVector {
 	features := make([]Feature, len(f.featuresMap))
 
@@ -276,12 +276,12 @@ func newSharedFeatures(f *FeatureVector) *SharedFeatures {
 }
 
 // IsActive checks is feature active or not, it might be disabled during
-// comparision with remote feature vector if it was optional and remote peer
+// comparison with remote feature vector if it was optional and remote peer
 // doesn't support it.
 func (f *SharedFeatures) IsActive(name featureName) bool {
 	index, ok := f.featuresMap[name]
 	if !ok {
-		// If we even have no such feature in feature map, than it
+		// If we even have no such feature in feature map, then it
 		// can't be active in any circumstances.
 		return false
 	}

--- a/lnwire/features_test.go
+++ b/lnwire/features_test.go
@@ -31,7 +31,7 @@ func TestFeaturesRemoteRequireError(t *testing.T) {
 }
 
 // TestFeaturesLocalRequireError checks that we throw an error if local peer has
-// required feature which remote peer don't support.
+// required feature which remote peer doesn't support.
 func TestFeaturesLocalRequireError(t *testing.T) {
 	const (
 		first  = "first"
@@ -52,7 +52,7 @@ func TestFeaturesLocalRequireError(t *testing.T) {
 	}
 }
 
-// TestOptionalFeature checks that if remote peer don't have the feature but
+// TestOptionalFeature checks that if remote peer doesn't have the feature but
 // on our side this feature is optional than we mark this feature as disabled.
 func TestOptionalFeature(t *testing.T) {
 	const first = "first"

--- a/lnwire/init_message.go
+++ b/lnwire/init_message.go
@@ -2,8 +2,8 @@ package lnwire
 
 import "io"
 
-// Init is the first message reveals the features supported or required by this
-// node. Nodes wait for receipt of the other's features to simplify error
+// Init is the first message and reveals the features supported or required by
+// this node. Nodes wait for receipt of the other's features to simplify error
 // diagnosis where features are incompatible. Each node MUST wait to receive
 // init before sending any other messages.
 type Init struct {
@@ -11,7 +11,7 @@ type Init struct {
 	// also advertised to other nodes.
 	GlobalFeatures *FeatureVector
 
-	// LocalFeatures is feature vector which only affect the protocol
+	// LocalFeatures is feature vector which only affects the protocol
 	// between two nodes.
 	LocalFeatures *FeatureVector
 }

--- a/lnwire/netaddress.go
+++ b/lnwire/netaddress.go
@@ -22,7 +22,7 @@ type NetAddress struct {
 	// the node.
 	IdentityKey *btcec.PublicKey
 
-	// Address is is the IP address and port of the node.
+	// Address is the IP address and port of the node.
 	Address *net.TCPAddr
 
 	// ChainNet is the Bitcoin network this node is associated with.

--- a/lnwire/revoke_and_ack.go
+++ b/lnwire/revoke_and_ack.go
@@ -10,7 +10,7 @@ import (
 // received, and validated. This message serves to revoke the prior commitment
 // transaction, which was the most up to date version until a CommitSig message
 // referencing the specified ChannelPoint was received.  Additionally, this
-// message also piggyback's the next revocation hash that Alice should use when
+// message also piggybacks the next revocation hash that Alice should use when
 // constructing the Bob's version of the next commitment transaction (which
 // would be done before sending a CommitSig message).  This piggybacking allows
 // Alice to send the next CommitSig message modifying Bob's commitment

--- a/lnwire/single_funding_complete.go
+++ b/lnwire/single_funding_complete.go
@@ -29,8 +29,8 @@ type SingleFundingComplete struct {
 	// RevocationKey is the initial key to be used for the revocation
 	// clause within the self-output of the initiators's commitment
 	// transaction. Once an initial new state is created, the initiator
-	// will send a preimage which will allow the initiator to sweep the
-	// initiator's funds if the violate the contract.
+	// will send a preimage which will allow the responder to sweep the
+	// initiator's funds if she violate the contract.
 	RevocationKey *btcec.PublicKey
 
 	// StateHintObsfucator is the set of bytes used by the initiator to

--- a/lnwire/single_funding_request.go
+++ b/lnwire/single_funding_request.go
@@ -53,7 +53,7 @@ type SingleFundingRequest struct {
 	CsvDelay uint32
 
 	// CommitmentKey is key the initiator of the funding workflow wishes to
-	// use within their versino of the commitment transaction for any
+	// use within their version of the commitment transaction for any
 	// delayed (CSV) or immediate outputs to them.
 	CommitmentKey *btcec.PublicKey
 
@@ -61,7 +61,7 @@ type SingleFundingRequest struct {
 	// derive the public key the initiator will use for the half of the
 	// 2-of-2 multi-sig. Using the channel derivation point (CDP), and the
 	// initiators identity public key (A), the channel public key is
-	// computed as: C = A + CDP. In order to be valid all CDP's MUST have
+	// computed as: C = A + CDP. In order to be valid all CDPs MUST have
 	// an odd y-coordinate.
 	ChannelDerivationPoint *btcec.PublicKey
 

--- a/lnwire/single_funding_response.go
+++ b/lnwire/single_funding_response.go
@@ -20,12 +20,12 @@ type SingleFundingResponse struct {
 	// derive the public key the responder will use for the half of the
 	// 2-of-2 multi-sig. Using the channel derivation point (CDP), and the
 	// responder's identity public key (A), the channel public key is
-	// computed as: C = A + CDP. In order to be valid all CDP's MUST have
+	// computed as: C = A + CDP. In order to be valid all CDPs MUST have
 	// an odd y-coordinate.
 	ChannelDerivationPoint *btcec.PublicKey
 
 	// CommitmentKey is key the responder to the funding workflow wishes to
-	// use within their versino of the commitment transaction for any
+	// use within their version of the commitment transaction for any
 	// delayed (CSV) or immediate outputs to them.
 	CommitmentKey *btcec.PublicKey
 
@@ -33,7 +33,7 @@ type SingleFundingResponse struct {
 	// clause within the self-output of the responder's commitment
 	// transaction. Once an initial new state is created, the responder
 	// will send a preimage which will allow the initiator to sweep the
-	// responder's funds if the violate the contract.
+	// responder's funds if she violate the contract.
 	RevocationKey *btcec.PublicKey
 
 	// CsvDelay is the number of blocks to use for the relative time lock

--- a/lnwire/update_add_htlc.go
+++ b/lnwire/update_add_htlc.go
@@ -14,7 +14,7 @@ const OnionPacketSize = 1254
 // HTLC to his remote commitment transaction. In addition to information
 // detailing the value, the ID, expiry, and the onion blob is also included
 // which allows Bob to derive the next hop in the route. The HTLC added by this
-// message is to be added to the remote node's "pending" HTLC's.  A subsequent
+// message is to be added to the remote node's "pending" HTLCs.  A subsequent
 // CommitSig message will move the pending HTLC to the newly created commitment
 // transaction, marking them as "staged".
 type UpdateAddHTLC struct {
@@ -37,7 +37,7 @@ type UpdateAddHTLC struct {
 	Amount btcutil.Amount
 
 	// PaymentHash is the payment hash to be included in the HTLC this
-	// request creates. The pre-image to this HTLC must be revelaed by the
+	// request creates. The pre-image to this HTLC must be revealed by the
 	// upstream peer in order to fully settle the HTLC.
 	PaymentHash [32]byte
 

--- a/lnwire/update_fulfill_htlc.go
+++ b/lnwire/update_fulfill_htlc.go
@@ -6,7 +6,7 @@ import "io"
 // particular HTLC referenced by its HTLCKey within a specific active channel
 // referenced by ChannelPoint.  A subsequent CommitSig message will be sent by
 // Alice to "lock-in" the removal of the specified HTLC, possible containing a
-// batch signature covering several settled HTLC's.
+// batch signature covering several settled HTLCs.
 type UpdateFufillHTLC struct {
 	// ChanID references an active channel which holds the HTLC to be
 	// settled.

--- a/networktest.go
+++ b/networktest.go
@@ -871,7 +871,7 @@ type txWatchRequest struct {
 	eventChan chan struct{}
 }
 
-// bitcoinNetworkWatcher is a goroutine which accepts async notification
+// networkWatcher is a goroutine which accepts async notification
 // requests for the broadcast of a target transaction, and then dispatches the
 // transaction once its seen on the Bitcoin network.
 func (n *networkHarness) networkWatcher() {

--- a/peer.go
+++ b/peer.go
@@ -1459,7 +1459,7 @@ func (p *peer) handleUpstreamMsg(state *commitmentState, msg lnwire.Message) {
 
 		// There are additional hops left within this route, so we
 		// track the next hop according to the index of this HTLC
-		// within their log. When forwarding locked-in HLTCs to the
+		// within their log. When forwarding locked-in HTLCs to the
 		// switch, we'll attach the routing information so the switch
 		// can finalize the circuit.
 		case sphinx.MoreHops:

--- a/peer.go
+++ b/peer.go
@@ -405,7 +405,7 @@ out:
 				continue
 
 			// If the error we encountered wasn't just a message we
-			// didn't recognize, then we'll stop all processing s
+			// didn't recognize, then we'll stop all processing as
 			// this is a fatal error.
 			default:
 				break out
@@ -857,7 +857,7 @@ func (p *peer) handleLocalClose(req *closeLinkReq) {
 
 	switch req.CloseType {
 	// A type of CloseRegular indicates that the user has opted to close
-	// out this channel on-chian, so we execute the cooperative channel
+	// out this channel on-chain, so we execute the cooperative channel
 	// closure workflow.
 	case CloseRegular:
 		closingTxid, err = p.executeCooperativeClose(channel)
@@ -1459,7 +1459,7 @@ func (p *peer) handleUpstreamMsg(state *commitmentState, msg lnwire.Message) {
 
 		// There are additional hops left within this route, so we
 		// track the next hop according to the index of this HTLC
-		// within their log. When forwarding locked-in HLTC's to the
+		// within their log. When forwarding locked-in HLTCs to the
 		// switch, we'll attach the routing information so the switch
 		// can finalize the circuit.
 		case sphinx.MoreHops:

--- a/routing/notifications.go
+++ b/routing/notifications.go
@@ -249,17 +249,17 @@ type ChannelEdgeUpdate struct {
 	// MinHTLC is the minimum HTLC amount that this channel will forward.
 	MinHTLC btcutil.Amount
 
-	// BaseFee is the base fee that will charged for all HTLC's forwarded
+	// BaseFee is the base fee that will charged for all HTLCs forwarded
 	// across the this channel direction.
 	BaseFee btcutil.Amount
 
-	// FeeRate is the fee rate that will be shared for all HTLC's forwarded
+	// FeeRate is the fee rate that will be shared for all HTLCs forwarded
 	// across this channel direction.
 	FeeRate btcutil.Amount
 
 	// TimeLockDelta is the time-lock expressed in blocks that will be
-	// added to outgoing HTLC's from incoming HTLC's. This value is the
-	// difference of the incoming and outgoing HTLC's time-locks routed
+	// added to outgoing HTLCs from incoming HTLCs. This value is the
+	// difference of the incoming and outgoing HTLCs time-locks routed
 	// through this hop.
 	TimeLockDelta uint16
 

--- a/routing/pathfind.go
+++ b/routing/pathfind.go
@@ -105,7 +105,7 @@ type Route struct {
 
 	// TotalFees is the sum of the fees paid at each hop within the final
 	// route. In the case of a one-hop payment, this value will be zero as
-	// we don't need to pay a fee it ourself.
+	// we don't need to pay a fee to ourself.
 	TotalFees btcutil.Amount
 
 	// TotalAmount is the total amount of funds required to complete a
@@ -266,7 +266,7 @@ func edgeWeight(e *channeldb.ChannelEdgePolicy) float64 {
 // Dijkstra's algorithm to find a single shortest path between the source node
 // and the destination. The distance metric used for edges is related to the
 // time-lock+fee costs along a particular edge. If a path is found, this
-// function returns a slice of ChannelHop structs which encoded the chosen path
+// function returns a slice of ChannelHop structs which encode the chosen path
 // from the target to the source.
 func findPath(graph *channeldb.ChannelGraph, sourceNode *channeldb.LightningNode,
 	target *btcec.PublicKey, ignoredNodes map[vertex]struct{},
@@ -278,8 +278,8 @@ func findPath(graph *channeldb.ChannelGraph, sourceNode *channeldb.LightningNode
 	var nodeHeap distanceHeap
 
 	// For each node/vertex the graph we create an entry in the distance
-	// map for the node set with a distance of "infinity".  We also mark
-	// add the node to our set of unvisited nodes.
+	// map for the node set with a distance of "infinity".  We also add
+	// the node to our set of unvisited nodes.
 	distance := make(map[vertex]nodeWithDist)
 	if err := graph.ForEachNode(nil, func(_ *bolt.Tx, node *channeldb.LightningNode) error {
 		// TODO(roasbeef): with larger graph can just use disk seeks

--- a/routing/router.go
+++ b/routing/router.go
@@ -312,9 +312,9 @@ func (r *ChannelRouter) syncGraphWithChain() error {
 	log.Infof("Syncing channel graph from height=%v (hash=%v) to height=%v "+
 		"(hash=%v)", pruneHeight, pruneHash, bestHeight, bestHash)
 
-	// If we're not yet caught up, then we'll walk forward in the chain in
-	// the chain pruning the channel graph with each new block in the chain
-	// that hasn't yet been consumed by the channel graph.
+	// If we're not yet caught up, then we'll walk forward in the chain
+	// pruning the channel graph with each new block in the chain that
+	// hasn't yet been consumed by the channel graph.
 	var numChansClosed uint32
 	for nextHeight := pruneHeight + 1; nextHeight <= uint32(bestHeight); nextHeight++ {
 		// Using the next height, fetch the next block to use in our
@@ -378,8 +378,7 @@ func (r *ChannelRouter) networkHandler() {
 		case updateMsg := <-r.networkUpdates:
 			// Process the routing update to determine if this is
 			// either a new update from our PoV or an update to a
-			// prior vertex/edge we previously
-			// accepted.
+			// prior vertex/edge we previously accepted.
 			err := r.processUpdate(updateMsg.msg)
 			updateMsg.err <- err
 			if err != nil {
@@ -846,7 +845,7 @@ func generateSphinxPacket(route *Route, paymentHash []byte) ([]byte, error) {
 		return nil, err
 	}
 
-	// Finally, encode Sphinx packet using it's wire representation to be
+	// Finally, encode Sphinx packet using its wire representation to be
 	// included within the HTLC add packet.
 	var onionBlob bytes.Buffer
 	if err := sphinxPacket.Encode(&onionBlob); err != nil {

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -263,7 +263,7 @@ func (r *rpcServer) OpenChannel(in *lnrpc.OpenChannelRequest,
 	const minChannelSize = btcutil.Amount(6000)
 
 	// Restrict the size of the channel we'll actually open. Atm, we
-	// require the amount to be above 6k satoahis s we currently hard-coded
+	// require the amount to be above 6k satoahis as we currently hard-coded
 	// a 5k satoshi fee in several areas. As a result 6k sat is the min
 	// channnel size that allows us to safely sit above the dust threshold
 	// after fees are applied
@@ -463,8 +463,8 @@ func (r *rpcServer) CloseChannel(in *lnrpc.CloseChannelRequest,
 			rpcsLog.Errorf("unable to force close transaction: %v", err)
 
 			// If the transaction we broadcast is detected as a
-			// double spend, the this indicates that the remote
-			// party has broadcast their commitment transaction be
+			// double spend, this indicates that the remote
+			// party has broadcast their commitment transaction but
 			// we didn't notice.
 			if strings.Contains(err.Error(), "fully-spent") ||
 				strings.Contains(err.Error(), "double spend") {
@@ -513,7 +513,7 @@ func (r *rpcServer) CloseChannel(in *lnrpc.CloseChannelRequest,
 				}
 
 				// As the channel has been closed, we can now
-				// delete it's state from the database.
+				// delete its state from the database.
 				rpcsLog.Infof("ChannelPoint(%v) is now "+
 					"closed at height %v", chanPoint,
 					txConf.BlockHeight)
@@ -582,7 +582,7 @@ out:
 	return nil
 }
 
-// fetchActiveChannel attempts to locate a channel identified by it's channel
+// fetchActiveChannel attempts to locate a channel identified by its channel
 // point from the database's set of all currently opened channels.
 func (r *rpcServer) fetchActiveChannel(chanPoint wire.OutPoint) (*lnwallet.LightningChannel, error) {
 	dbChannels, err := r.server.chanDB.FetchAllChannels()
@@ -629,7 +629,7 @@ func (r *rpcServer) forceCloseChan(channel *lnwallet.LightningChannel) (*chainha
 	txid := closeTx.TxHash()
 
 	// With the close transaction in hand, broadcast the transaction to the
-	// network, thereby entering the psot channel resolution state.
+	// network, thereby entering the post channel resolution state.
 	rpcsLog.Infof("Broadcasting force close transaction, ChannelPoint(%v): %v",
 		channel.ChannelPoint(), newLogClosure(func() string {
 			return spew.Sdump(closeTx)
@@ -646,7 +646,7 @@ func (r *rpcServer) forceCloseChan(channel *lnwallet.LightningChannel) (*chainha
 }
 
 // GetInfo serves a request to the "getinfo" RPC call. This call returns
-// general information concerning the lightning node including it's LN ID,
+// general information concerning the lightning node including its LN ID,
 // identity address, and information concerning the number of open+pending
 // channels.
 func (r *rpcServer) GetInfo(ctx context.Context,
@@ -710,7 +710,7 @@ func (r *rpcServer) ListPeers(ctx context.Context,
 		// In order to display the total number of satoshis of outbound
 		// (sent) and inbound (recv'd) satoshis that have been
 		// transported through this peer, we'll sum up the sent/recv'd
-		// values for each of the active channels we ahve with the
+		// values for each of the active channels we have with the
 		// peer.
 		chans := serverPeer.ChannelSnapshots()
 		for _, c := range chans {
@@ -1113,7 +1113,7 @@ func (r *rpcServer) SendPaymentSync(ctx context.Context,
 		return nil, err
 	}
 
-	// With the payment completed successfully, we now ave the details of
+	// With the payment completed successfully, we now add the details of
 	// the completed payment to the database for historical record keeping.
 	if err := r.savePayment(route, amt, rHash[:]); err != nil {
 		return nil, err
@@ -1450,7 +1450,7 @@ func (r *rpcServer) DescribeGraph(context.Context,
 
 	// Next, for each active channel we know of within the graph, create a
 	// similar response which details both the edge information as well as
-	// the routing policies of th nodes connecting the two edges.
+	// the routing policies of the nodes connecting the two edges.
 	err = graph.ForEachChannel(func(edgeInfo *channeldb.ChannelEdgeInfo,
 		c1, c2 *channeldb.ChannelEdgePolicy) error {
 
@@ -1510,7 +1510,7 @@ func marshalDbEdge(edgeInfo *channeldb.ChannelEdgeInfo,
 	return edge
 }
 
-// GetChainInfo returns the latest authenticated network announcement for the
+// GetChanInfo returns the latest authenticated network announcement for the
 // given channel identified by its channel ID: an 8-byte integer which uniquely
 // identifies the location of transaction's funding output within the block
 // chain.
@@ -1592,7 +1592,7 @@ func (r *rpcServer) GetNodeInfo(_ context.Context, in *lnrpc.NodeInfoRequest) (*
 	}, nil
 }
 
-// QueryRoutes attempts to query the daemons' Channel Router for a possible
+// QueryRoutes attempts to query the daemon's Channel Router for a possible
 // route to a target destination capable of carrying a specific amount of
 // satoshis within the route's flow. The retuned route contains the full
 // details required to craft and send an HTLC, also including the necessary
@@ -1804,7 +1804,7 @@ func (r *rpcServer) SubscribeChannelGraph(req *lnrpc.GraphTopologySubscription,
 	}
 }
 
-// marshallTopologyChange performs a mapping from the topology change sturct
+// marshallTopologyChange performs a mapping from the topology change struct
 // returned by the router to the form of notifications expected by the current
 // gRPC service.
 func marshallTopologyChange(topChange *routing.TopologyChange) *lnrpc.GraphTopologyUpdate {

--- a/server.go
+++ b/server.go
@@ -538,7 +538,7 @@ func (s *server) WaitForShutdown() {
 }
 
 // broadcastReq is a message sent to the server by a related subsystem when it
-// wishes to broadcast one or more messages to all connected peers. Thi
+// wishes to broadcast one or more messages to all connected peers.
 type broadcastReq struct {
 	ignore *btcec.PublicKey
 	msgs   []lnwire.Message
@@ -573,7 +573,7 @@ func (s *server) broadcastMessage(skip *btcec.PublicKey, msgs ...lnwire.Message)
 	}
 }
 
-// sendReq is  message sent to the server by a related subsystem which it
+// sendReq is a message sent to the server by a related subsystem which it
 // wishes to send a set of messages to a specified peer.
 type sendReq struct {
 	target *btcec.PublicKey
@@ -587,8 +587,8 @@ type nodeAddresses struct {
 	addresses []*net.TCPAddr
 }
 
-// sendToPeer send a message to the server telling it to send the specific set
-// of message to a particular peer. If the peer connect be found, then this
+// sendToPeer sends a message to the server telling it to send the specific set
+// of messages to a particular peer. If the peer cannot be found, then this
 // method will return a non-nil error.
 func (s *server) sendToPeer(target *btcec.PublicKey, msgs ...lnwire.Message) error {
 	errChan := make(chan error, 1)
@@ -694,7 +694,7 @@ func (s *server) peerConnected(conn net.Conn, connReq *connmgr.ConnReq, inbound 
 	}
 
 	// Now that we've established a connection, create a peer, and
-	// it to the set of currently active peers.
+	// add it to the set of currently active peers.
 	p, err := newPeer(conn, connReq, s, peerAddr, inbound)
 	if err != nil {
 		srvrLog.Errorf("unable to create peer %v", err)
@@ -863,7 +863,7 @@ func (s *server) addPeer(p *peer) {
 	}
 
 	// Track the new peer in our indexes so we can quickly look it up either
-	// according to its public key, or it's peer ID.
+	// according to its public key, or its peer ID.
 	// TODO(roasbeef): pipe all requests through to the
 	// queryHandler/peerManager
 	s.peersMtx.Lock()
@@ -1023,7 +1023,7 @@ out:
 				len(sMsg.msgs), target)
 
 			// Launch a new goroutine to handle this send request,
-			// this allows us process this request asynchronously
+			// this allows us to process this request asynchronously
 			// without blocking future send requests.
 			go func() {
 				s.peersMtx.RLock()
@@ -1062,7 +1062,7 @@ out:
 	s.wg.Done()
 }
 
-// handleListPeers sends a lice of all currently active peers to the original
+// handleListPeers sends a slice of all currently active peers to the original
 // caller.
 func (s *server) handleListPeers(msg *listPeersMsg) {
 	s.peersMtx.RLock()

--- a/shachain/utils.go
+++ b/shachain/utils.go
@@ -6,7 +6,7 @@ import (
 	"github.com/roasbeef/btcd/chaincfg/chainhash"
 )
 
-// changeBit is a function that flips a bit of the hash at a particluar
+// changeBit is a function that flips a bit of the hash at a particular
 // bit-index. You should be aware that the bit flipping in this
 // function is a bit strange, example:
 // hash: [0b00000000, 0b00000000,  ... 0b00000000]

--- a/shachain/utils.go
+++ b/shachain/utils.go
@@ -6,9 +6,9 @@ import (
 	"github.com/roasbeef/btcd/chaincfg/chainhash"
 )
 
-// changeBit is a functio that function that flips a bit of the hash at a
-// particluar bit-index. You should be aware that the bit flipping in this
-// function a bit strange, example:
+// changeBit is a function that flips a bit of the hash at a particluar
+// bit-index. You should be aware that the bit flipping in this
+// function is a bit strange, example:
 // hash: [0b00000000, 0b00000000,  ... 0b00000000]
 //	    0		   1       ...      31
 //

--- a/utxonursery.go
+++ b/utxonursery.go
@@ -558,7 +558,7 @@ func fetchGraduatingOutputs(db *channeldb.DB, wallet *lnwallet.LightningWallet,
 		return nil, err
 	}
 
-	// If no time-locked outputs can be swept at this point, ten we can
+	// If no time-locked outputs can be swept at this point, then we can
 	// exit early.
 	if len(results) == 0 {
 		return nil, nil
@@ -592,7 +592,7 @@ func fetchGraduatingOutputs(db *channeldb.DB, wallet *lnwallet.LightningWallet,
 // user's wallet.
 func sweepGraduatingOutputs(wallet *lnwallet.LightningWallet, kgtnOutputs []*kidOutput) error {
 	// Create a transaction which sweeps all the newly mature outputs into
-	// a output controlled by the wallet.
+	// an output controlled by the wallet.
 	// TODO(roasbeef): can be more intelligent about buffering outputs to
 	// be more efficient on-chain.
 	sweepTx, err := createSweepTx(wallet, kgtnOutputs)
@@ -805,7 +805,7 @@ func serializeKidOutput(w io.Writer, kid *kidOutput) error {
 }
 
 // deserializeKidOutput takes a byte array representation of a kidOutput
-// and converts it to an struct. Note that the witnessFunc method isn't added
+// and converts it to a struct. Note that the witnessFunc method isn't added
 // during deserialization and must be added later based on the value of the
 // witnessType field.
 func deserializeKidOutput(r io.Reader) (*kidOutput, error) {

--- a/zpay32/zbase32check.go
+++ b/zpay32/zbase32check.go
@@ -18,7 +18,7 @@ import (
 // (payment hash), 8-bytes for the payment amount in satoshis.
 const invoiceSize = 33 + 32 + 8
 
-// ErrCheckSumMismatch is returned byt he Decode function fi when
+// ErrCheckSumMismatch is returned by the Decode function if when
 // decoding an encoded invoice, the checksum doesn't match indicating
 // an error somewhere in the bitstream.
 var ErrCheckSumMismatch = errors.New("the checksum is incorrect")


### PR DESCRIPTION
A few fixes to typos in docs and comments I found when browsing the code base.