### PR TITLE
docs: Fix port in sample lnd.conf

### DIFF
--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -110,7 +110,7 @@ can create an `lnd.conf`.
 Here's a sample `lnd.conf` to get you started:
 ```
 [Application Options]
-btcdhost=localhost:18834
+btcdhost=localhost:18334
 debuglevel=trace
 debughtlc=true
 maxpendingchannels=10


### PR DESCRIPTION
This fixes a typo in docs/INSTALL.md in the btcd RPC port.