### PR TITLE
lnwallet: replace hard-coded fees with calls to FeeEstimator interface

### DIFF
--- a/channeldb/channel.go
+++ b/channeldb/channel.go
@@ -68,7 +68,7 @@ var (
 	updatePrefix         = []byte("uup")
 	satSentPrefix        = []byte("ssp")
 	satReceivedPrefix    = []byte("srp")
-	netFeesPrefix        = []byte("ntp")
+	commitFeePrefix      = []byte("cfp")
 	isPendingPrefix      = []byte("pdg")
 	openHeightPrefix     = []byte("open-height-prefix")
 
@@ -180,6 +180,13 @@ type OpenChannel struct {
 	// TheirBalance is the current available settled balance within the
 	// channel directly spendable by the remote node.
 	TheirBalance btcutil.Amount
+
+	// CommitFee is the amount calculated to be paid in fees for the
+	// current set of commitment transactions. The fee amount is
+	// persisted with the channel in order to allow the fee amount to be
+	// removed and recalculated with each channel state update, including
+	// updates that happen after a system restart.
+	CommitFee btcutil.Amount
 
 	// OurCommitKey is the latest version of the commitment state,
 	// broadcast able by us.
@@ -410,6 +417,7 @@ func (c *OpenChannel) UpdateCommitment(newCommitment *wire.MsgTx,
 		c.TheirBalance = delta.RemoteBalance
 		c.NumUpdates = delta.UpdateNum
 		c.Htlcs = delta.Htlcs
+		c.CommitFee = delta.CommitFee
 
 		// First we'll write out the current latest dynamic channel
 		// state: the current channel balance, the number of updates,
@@ -422,6 +430,9 @@ func (c *OpenChannel) UpdateCommitment(newCommitment *wire.MsgTx,
 			return err
 		}
 		if err := putChanNumUpdates(chanBucket, c); err != nil {
+			return err
+		}
+		if err := putChanCommitFee(chanBucket, c); err != nil {
 			return err
 		}
 		if err := putChanCommitTxns(nodeChanBucket, c); err != nil {
@@ -491,6 +502,10 @@ type ChannelDelta struct {
 	// RemoteBalanceis the balance of the remote node at this particular
 	// update number.
 	RemoteBalance btcutil.Amount
+
+	// CommitFee is the fee that has been subtracted from the channel
+	// initiator's balance at this point in the commitment chain.
+	CommitFee btcutil.Amount
 
 	// UpdateNum is the update number that this ChannelDelta represents the
 	// total number of commitment updates to this point. This can be viewed
@@ -975,6 +990,9 @@ func putOpenChannel(openChanBucket *bolt.Bucket, nodeChanBucket *bolt.Bucket,
 	if err := putChanOpenHeight(openChanBucket, channel); err != nil {
 		return err
 	}
+	if err := putChanCommitFee(openChanBucket, channel); err != nil {
+		return err
+	}
 
 	// Next, write out the fields of the channel update less frequently.
 	if err := putChannelIDs(nodeChanBucket, channel); err != nil {
@@ -1065,6 +1083,9 @@ func fetchOpenChannel(openChanBucket *bolt.Bucket, nodeChanBucket *bolt.Bucket,
 	if err := fetchChanOpenHeight(openChanBucket, channel); err != nil {
 		return nil, err
 	}
+	if err = fetchChanCommitFee(openChanBucket, channel); err != nil {
+		return nil, err
+	}
 
 	return channel, nil
 }
@@ -1096,6 +1117,9 @@ func deleteOpenChannel(openChanBucket *bolt.Bucket, nodeChanBucket *bolt.Bucket,
 		return err
 	}
 	if err := deleteChanOpenHeight(openChanBucket, channelID); err != nil {
+		return err
+	}
+	if err := deleteChanCommitFee(openChanBucket, channelID); err != nil {
 		return err
 	}
 
@@ -1574,6 +1598,46 @@ func deleteChanCommitKeys(nodeChanBucket *bolt.Bucket, chanID []byte) error {
 	copy(commitKey[:3], commitKeys)
 	copy(commitKey[3:], chanID)
 	return nodeChanBucket.Delete(commitKey)
+}
+
+func putChanCommitFee(openChanBucket *bolt.Bucket, channel *OpenChannel) error {
+	scratch := make([]byte, 8)
+	byteOrder.PutUint64(scratch, uint64(channel.CommitFee))
+
+	var b bytes.Buffer
+	if err := writeOutpoint(&b, channel.ChanID); err != nil {
+		return err
+	}
+
+	keyPrefix := make([]byte, 3+b.Len())
+	copy(keyPrefix, commitFeePrefix)
+	copy(keyPrefix[3:], b.Bytes())
+
+	return openChanBucket.Put(keyPrefix, scratch)
+}
+
+func fetchChanCommitFee(openChanBucket *bolt.Bucket, channel *OpenChannel) error {
+	var b bytes.Buffer
+	if err := writeOutpoint(&b, channel.ChanID); err != nil {
+		return err
+	}
+
+	keyPrefix := make([]byte, 3+b.Len())
+	copy(keyPrefix, commitFeePrefix)
+	copy(keyPrefix[3:], b.Bytes())
+
+	commitFeeBytes := openChanBucket.Get(keyPrefix)
+	channel.CommitFee = btcutil.Amount(byteOrder.Uint64(commitFeeBytes))
+
+	return nil
+}
+
+func deleteChanCommitFee(openChanBucket *bolt.Bucket, chanID []byte) error {
+	commitFeeKey := make([]byte, 3+len(chanID))
+	copy(commitFeeKey, commitFeePrefix)
+	copy(commitFeeKey[3:], chanID)
+
+	return openChanBucket.Delete(commitFeeKey)
 }
 
 func fetchChanCommitKeys(nodeChanBucket *bolt.Bucket, channel *OpenChannel) error {
@@ -2104,6 +2168,11 @@ func serializeChannelDelta(w io.Writer, delta *ChannelDelta) error {
 		}
 	}
 
+	byteOrder.PutUint64(scratch[:], uint64(delta.CommitFee))
+	if _, err := w.Write(scratch[:]); err != nil {
+		return err
+	}
+
 	return nil
 }
 
@@ -2142,6 +2211,10 @@ func deserializeChannelDelta(r io.Reader) (*ChannelDelta, error) {
 
 		delta.Htlcs[i] = htlc
 	}
+	if _, err := r.Read(scratch[:]); err != nil {
+		return nil, err
+	}
+	delta.CommitFee = btcutil.Amount(byteOrder.Uint64(scratch[:]))
 
 	return delta, nil
 }

--- a/fundingmanager.go
+++ b/fundingmanager.go
@@ -130,6 +130,10 @@ type fundingConfig struct {
 	// funds from on-chain transaction outputs into Lightning channels.
 	Wallet *lnwallet.LightningWallet
 
+	// FeeEstimator calculates appropriate fee rates based on historical
+	// transaction information.
+	FeeEstimator lnwallet.FeeEstimator
+
 	// ArbiterChan allows the FundingManager to notify the BreachArbiter
 	// that a new channel has been created that should be observed to
 	// ensure that the channel counterparty hasn't broadcasted an invalid
@@ -959,7 +963,8 @@ func (f *fundingManager) waitForFundingConfirmation(completeChan *channeldb.Open
 
 	// With the channel marked open, we'll create the state-machine object
 	// which wraps the database state.
-	channel, err := lnwallet.NewLightningChannel(nil, nil, completeChan)
+	channel, err := lnwallet.NewLightningChannel(nil, nil,
+		f.cfg.FeeEstimator, completeChan)
 	if err != nil {
 		fndgLog.Errorf("error creating new lightning channel: %v", err)
 		return

--- a/fundingmanager.go
+++ b/fundingmanager.go
@@ -579,6 +579,7 @@ func (f *fundingManager) handleFundingRequest(fmsg *fundingRequestMsg) {
 		MultiSigKey:     copyPubKey(msg.ChannelDerivationPoint),
 		CommitKey:       copyPubKey(msg.CommitmentKey),
 		DeliveryAddress: addrs[0],
+		DustLimit:       msg.DustLimit,
 		CsvDelay:        delay,
 	}
 	if err := reservation.ProcessSingleContribution(contribution); err != nil {
@@ -662,6 +663,7 @@ func (f *fundingManager) handleFundingResponse(fmsg *fundingResponseMsg) {
 		CommitKey:       copyPubKey(msg.CommitmentKey),
 		DeliveryAddress: addrs[0],
 		RevocationKey:   copyPubKey(msg.RevocationKey),
+		DustLimit:       msg.DustLimit,
 		CsvDelay:        msg.CsvDelay,
 	}
 	if err := resCtx.reservation.ProcessContribution(contribution); err != nil {

--- a/lnd.go
+++ b/lnd.go
@@ -149,11 +149,12 @@ func lndMain() error {
 	signer := wc
 	bio := wc
 	fundingSigner := wc
+	estimator := lnwallet.StaticFeeEstimator{FeeRate: 250}
 
 	// Create, and start the lnwallet, which handles the core payment
 	// channel logic, and exposes control via proxy state machines.
 	wallet, err := lnwallet.NewLightningWallet(chanDB, notifier, wc, signer,
-		bio, activeNetParams.Params)
+		bio, estimator, activeNetParams.Params)
 	if err != nil {
 		fmt.Printf("unable to create wallet: %v\n", err)
 		return err
@@ -191,7 +192,7 @@ func lndMain() error {
 	// With all the relevant chains initialized, we can finally start the
 	// server itself.
 	server, err := newServer(defaultListenAddrs, notifier, bio,
-		fundingSigner, wallet, chanDB, chainView)
+		fundingSigner, wallet, estimator, chanDB, chainView)
 	if err != nil {
 		srvrLog.Errorf("unable to create server: %v\n", err)
 		return err

--- a/lnd_test.go
+++ b/lnd_test.go
@@ -2190,7 +2190,8 @@ func testGraphTopologyNotifications(net *networkHarness, t *harnessTest) {
 			chanUpdate := graphUpdate.ChannelUpdates[0]
 			if chanUpdate.Capacity != int64(chanAmt) {
 				t.Fatalf("channel capacities mismatch: expected %v, "+
-					"got %v", chanAmt, chanUpdate.Capacity)
+					"got %v", chanAmt,
+					btcutil.Amount(chanUpdate.Capacity))
 			}
 			switch chanUpdate.AdvertisingNode {
 			case net.Alice.PubKeyStr:

--- a/lnd_test.go
+++ b/lnd_test.go
@@ -896,27 +896,7 @@ func testSingleHopInvoice(net *networkHarness, t *harnessTest) {
 	chanPoint := openChannelAndAssert(ctxt, t, net, net.Alice, net.Bob,
 		chanAmt, 0)
 
-	assertPaymentBalance := func(amt btcutil.Amount) {
-		balReq := &lnrpc.ChannelBalanceRequest{}
-
-		// The balances of Alice and Bob should be updated accordingly.
-		aliceBalance, err := net.Alice.ChannelBalance(ctxb, balReq)
-		if err != nil {
-			t.Fatalf("unable to query for alice's balance: %v", err)
-		}
-		bobBalance, err := net.Bob.ChannelBalance(ctxb, balReq)
-		if err != nil {
-			t.Fatalf("unable to query for bob's balance: %v", err)
-		}
-		if aliceBalance.Balance != int64(chanAmt-amt) {
-			t.Fatalf("Alice's balance is incorrect got %v, expected %v",
-				aliceBalance, int64(chanAmt-amt))
-		}
-		if bobBalance.Balance != int64(amt) {
-			t.Fatalf("Bob's balance is incorrect got %v, expected %v",
-				bobBalance, amt)
-		}
-
+	assertAmountSent := func(amt btcutil.Amount) {
 		// Both channels should also have properly accounted from the
 		// amount that has been sent/received over the channel.
 		listReq := &lnrpc.ListChannelsRequest{}
@@ -1006,7 +986,7 @@ func testSingleHopInvoice(net *networkHarness, t *harnessTest) {
 	// With the payment completed all balance related stats should be
 	// properly updated.
 	time.Sleep(time.Millisecond * 200)
-	assertPaymentBalance(paymentAmt)
+	assertAmountSent(paymentAmt)
 
 	// Create another invoice for Bob, this time leaving off the preimage
 	// to one will be randomly generated. We'll test the proper
@@ -1034,7 +1014,7 @@ func testSingleHopInvoice(net *networkHarness, t *harnessTest) {
 	// The second payment should also have succeeded, with the balances
 	// being update accordingly.
 	time.Sleep(time.Millisecond * 200)
-	assertPaymentBalance(paymentAmt * 2)
+	assertAmountSent(paymentAmt * 2)
 
 	ctxt, _ = context.WithTimeout(ctxb, timeout)
 	closeChannelAndAssert(ctxt, t, net, net.Alice, chanPoint, false)
@@ -1293,9 +1273,9 @@ func testMultiHopPayments(net *networkHarness, t *harnessTest) {
 	case <-finClear:
 	}
 
-	assertAsymmetricBalance := func(node *lightningNode,
-		chanPoint wire.OutPoint, localBalance,
-		remoteBalance int64) {
+	assertAmountPaid := func(node *lightningNode,
+		chanPoint wire.OutPoint, amountSent,
+		amountReceived int64) {
 
 		channelName := ""
 		switch chanPoint {
@@ -1305,7 +1285,7 @@ func testMultiHopPayments(net *networkHarness, t *harnessTest) {
 			channelName = "Alice(local) => Bob(remote)"
 		}
 
-		checkBalance := func() error {
+		checkAmountPaid := func() error {
 			listReq := &lnrpc.ListChannelsRequest{}
 			resp, err := node.ListChannels(ctxb, listReq)
 			if err != nil {
@@ -1317,16 +1297,19 @@ func testMultiHopPayments(net *networkHarness, t *harnessTest) {
 					continue
 				}
 
-				if channel.LocalBalance != localBalance {
-					return fmt.Errorf("%v: incorrect local "+
-						"balances: %v != %v", channelName,
-						channel.LocalBalance, localBalance)
+				if channel.TotalSatoshisSent != amountSent {
+					return fmt.Errorf("%v: incorrect amount"+
+						" sent: %v != %v", channelName,
+						channel.TotalSatoshisSent,
+						amountSent)
 				}
-
-				if channel.RemoteBalance != remoteBalance {
-					return fmt.Errorf("%v: incorrect remote "+
-						"balances: %v != %v", channelName,
-						channel.RemoteBalance, remoteBalance)
+				if channel.TotalSatoshisReceived !=
+					amountReceived {
+					return fmt.Errorf("%v: inccrrect amount"+
+						" received: %v != %v",
+						channelName,
+						channel.TotalSatoshisReceived,
+						amountReceived)
 				}
 
 				return nil
@@ -1348,9 +1331,9 @@ func testMultiHopPayments(net *networkHarness, t *harnessTest) {
 
 		for {
 			isTimeover := atomic.LoadUint32(&timeover) == 1
-			if err := checkBalance(); err != nil {
+			if err := checkAmountPaid(); err != nil {
 				if isTimeover {
-					t.Fatalf("Check balance failed: %v", err)
+					t.Fatalf("Check amount Paid failed: %v", err)
 				}
 			} else {
 				break
@@ -1363,12 +1346,11 @@ func testMultiHopPayments(net *networkHarness, t *harnessTest) {
 	// payment flow generated above. The order of asserts corresponds to
 	// increasing of time is needed to embed the HTLC in commitment
 	// transaction, in channel Carol->Alice->Bob, order is Bob,Alice,Carol.
-	const sourceBal = int64(95000)
-	const sinkBal = int64(5000)
-	assertAsymmetricBalance(net.Bob, aliceFundPoint, sinkBal, sourceBal)
-	assertAsymmetricBalance(net.Alice, aliceFundPoint, sourceBal, sinkBal)
-	assertAsymmetricBalance(net.Alice, carolFundPoint, sinkBal, sourceBal)
-	assertAsymmetricBalance(carol, carolFundPoint, sourceBal, sinkBal)
+	const amountPaid = int64(5000)
+	assertAmountPaid(net.Bob, aliceFundPoint, int64(0), amountPaid)
+	assertAmountPaid(net.Alice, aliceFundPoint, amountPaid, int64(0))
+	assertAmountPaid(net.Alice, carolFundPoint, int64(0), amountPaid)
+	assertAmountPaid(carol, carolFundPoint, amountPaid, int64(0))
 
 	ctxt, _ = context.WithTimeout(ctxb, timeout)
 	closeChannelAndAssert(ctxt, t, net, net.Alice, chanPointAlice, false)

--- a/lnd_test.go
+++ b/lnd_test.go
@@ -283,6 +283,20 @@ func assertNumConnections(ctxt context.Context, t *harnessTest,
 	}
 }
 
+// calcStaticFee calculates appropriate fees for commitment transactions.  This
+// function provides a simple way to allow test balance assertions to take fee
+// calculations into account.
+// TODO(bvu): Refactor when dynamic fee estimation is added.
+func calcStaticFee(numHTLCs int) btcutil.Amount {
+	const (
+		commitWeight = btcutil.Amount(724)
+		htlcWeight   = 172
+		feePerByte   = btcutil.Amount(250 * 4)
+	)
+	return feePerByte * (commitWeight +
+		btcutil.Amount(htlcWeight*numHTLCs)) / 1000
+}
+
 // testBasicChannelFunding performs a test exercising expected behavior from a
 // basic funding workflow. The test creates a new channel between Alice and
 // Bob, then immediately closes the channel after asserting some expected post
@@ -322,9 +336,9 @@ func testBasicChannelFunding(net *networkHarness, t *harnessTest) {
 	if err != nil {
 		t.Fatalf("unable to get bobs's balance: %v", err)
 	}
-	if aliceBal.Balance != int64(chanAmt-pushAmt) {
+	if aliceBal.Balance != int64(chanAmt-pushAmt-calcStaticFee(0)) {
 		t.Fatalf("alice's balance is incorrect: expected %v got %v",
-			chanAmt-pushAmt, aliceBal)
+			chanAmt-pushAmt-calcStaticFee(0), aliceBal)
 	}
 	if bobBal.Balance != int64(pushAmt) {
 		t.Fatalf("bob's balance is incorrect: expected %v got %v",
@@ -631,7 +645,7 @@ func testChannelBalance(net *networkHarness, t *harnessTest) {
 
 	// As this is a single funder channel, Alice's balance should be
 	// exactly 0.5 BTC since now state transitions have taken place yet.
-	checkChannelBalance(net.Alice, amount)
+	checkChannelBalance(net.Alice, amount-calcStaticFee(0))
 
 	// Ensure Bob currently has no available balance within the channel.
 	checkChannelBalance(net.Bob, 0)
@@ -1865,6 +1879,7 @@ func testHtlcErrorPropagation(net *networkHarness, t *harnessTest) {
 		t.Fatalf("channel not seen by alice before timeout: %v", err)
 	}
 
+	commitFee := calcStaticFee(0)
 	assertBaseBalance := func() {
 		balReq := &lnrpc.ChannelBalanceRequest{}
 		aliceBal, err := net.Alice.ChannelBalance(ctxb, balReq)
@@ -1875,13 +1890,13 @@ func testHtlcErrorPropagation(net *networkHarness, t *harnessTest) {
 		if err != nil {
 			t.Fatalf("unable to get channel balance: %v", err)
 		}
-		if aliceBal.Balance != int64(chanAmt) {
+		if aliceBal.Balance != int64(chanAmt-commitFee) {
 			t.Fatalf("alice has an incorrect balance: expected %v got %v",
-				int64(chanAmt), aliceBal)
+				int64(chanAmt-commitFee), aliceBal)
 		}
-		if bobBal.Balance != int64(chanAmt) {
+		if bobBal.Balance != int64(chanAmt-commitFee) {
 			t.Fatalf("bob has an incorrect balance: expected %v got %v",
-				int64(chanAmt), bobBal)
+				int64(chanAmt-commitFee), bobBal)
 		}
 	}
 

--- a/lnwallet/channel.go
+++ b/lnwallet/channel.go
@@ -571,6 +571,10 @@ type LightningChannel struct {
 
 	status channelState
 
+	// feeEstimator is used to calculate the fee rate for the channel's
+	// commitment and cooperative close transactions.
+	feeEstimator FeeEstimator
+
 	// Capcity is the total capacity of this channel.
 	Capacity btcutil.Amount
 
@@ -679,11 +683,13 @@ type LightningChannel struct {
 // automatically persist pertinent state to the database in an efficient
 // manner.
 func NewLightningChannel(signer Signer, events chainntnfs.ChainNotifier,
-	state *channeldb.OpenChannel) (*LightningChannel, error) {
+	fe FeeEstimator, state *channeldb.OpenChannel) (*LightningChannel,
+	error) {
 
 	lc := &LightningChannel{
 		signer:                signer,
 		channelEvents:         events,
+		feeEstimator:          fe,
 		currentHeight:         state.NumUpdates,
 		remoteCommitChain:     newCommitmentChain(state.NumUpdates),
 		localCommitChain:      newCommitmentChain(state.NumUpdates),

--- a/lnwallet/channel.go
+++ b/lnwallet/channel.go
@@ -683,8 +683,7 @@ type LightningChannel struct {
 // automatically persist pertinent state to the database in an efficient
 // manner.
 func NewLightningChannel(signer Signer, events chainntnfs.ChainNotifier,
-	fe FeeEstimator, state *channeldb.OpenChannel) (*LightningChannel,
-	error) {
+	fe FeeEstimator, state *channeldb.OpenChannel) (*LightningChannel, error) {
 
 	lc := &LightningChannel{
 		signer:                signer,
@@ -719,6 +718,7 @@ func NewLightningChannel(signer Signer, events chainntnfs.ChainNotifier,
 		ourMessageIndex:   0,
 		theirBalance:      state.TheirBalance,
 		theirMessageIndex: 0,
+		fee:               state.CommitFee,
 	})
 	walletLog.Debugf("ChannelPoint(%v), starting local commitment: %v",
 		state.ChanID, newLogClosure(func() string {
@@ -739,6 +739,7 @@ func NewLightningChannel(signer Signer, events chainntnfs.ChainNotifier,
 		ourMessageIndex:   0,
 		theirBalance:      state.TheirBalance,
 		theirMessageIndex: 0,
+		fee:               state.CommitFee,
 	}
 	if logTail == nil {
 		remoteCommitment.height = 0
@@ -1180,8 +1181,6 @@ func (lc *LightningChannel) restoreStateLogs() error {
 	lc.localCommitChain.tail().theirMessageIndex = theirCounter
 	lc.remoteCommitChain.tail().ourMessageIndex = ourCounter
 	lc.remoteCommitChain.tail().theirMessageIndex = theirCounter
-	lc.localCommitChain.tail().fee = lc.channelState.CommitFee
-	lc.remoteCommitChain.tail().fee = lc.channelState.CommitFee
 
 	return nil
 }
@@ -1249,6 +1248,10 @@ func (lc *LightningChannel) fetchCommitmentView(remoteChain bool,
 	ourBalance = commitChain.tip().ourBalance
 	theirBalance = commitChain.tip().theirBalance
 
+	// Add the fee from the previous commitment state back to the
+	// initiator's balance, so that the fee can be recalculated and
+	// re-applied in case fee estimation parameters have changed or the
+	// number of outstanding HTLCs has changed.
 	if lc.channelState.IsInitiator {
 		ourBalance = ourBalance + commitChain.tip().fee
 	} else if !lc.channelState.IsInitiator {
@@ -1265,24 +1268,54 @@ func (lc *LightningChannel) fetchCommitmentView(remoteChain bool,
 	filteredHTLCView := lc.evaluateHTLCView(htlcView, &ourBalance, &theirBalance,
 		nextHeight, remoteChain)
 
+	// Determine how many current HTLCs are over the dust limit, and should
+	// be counted for the purpose of fee calculation.
+	var dustLimit btcutil.Amount
+	if remoteChain {
+		dustLimit = lc.channelState.TheirDustLimit
+	} else {
+		dustLimit = lc.channelState.OurDustLimit
+	}
+	numHTLCs := 0
+	for _, htlc := range filteredHTLCView.ourUpdates {
+		if htlc.Amount < dustLimit {
+			continue
+		}
+		numHTLCs++
+	}
+	for _, htlc := range filteredHTLCView.theirUpdates {
+		if htlc.Amount < dustLimit {
+			continue
+		}
+		numHTLCs++
+	}
+
+	// Calculate the fee for the commitment transaction based on its size.
+	commitFee := btcutil.Amount(lc.feeEstimator.EstimateFeePerWeight(1)) *
+		(commitWeight + btcutil.Amount(htlcWeight*numHTLCs)) / 1000
+
+	if lc.channelState.IsInitiator {
+		ourBalance = ourBalance - commitFee
+	} else if !lc.channelState.IsInitiator {
+		theirBalance = theirBalance - commitFee
+	}
+
 	var selfKey *btcec.PublicKey
 	var remoteKey *btcec.PublicKey
 	var delay uint32
-	var delayBalance, p2wkhBalance, dustLimit btcutil.Amount
+	var delayBalance, p2wkhBalance btcutil.Amount
 	if remoteChain {
 		selfKey = lc.channelState.TheirCommitKey
 		remoteKey = lc.channelState.OurCommitKey
 		delay = lc.channelState.RemoteCsvDelay
 		delayBalance = theirBalance
 		p2wkhBalance = ourBalance
-		dustLimit = lc.channelState.TheirDustLimit
 	} else {
 		selfKey = lc.channelState.OurCommitKey
 		remoteKey = lc.channelState.TheirCommitKey
 		delay = lc.channelState.LocalCsvDelay
 		delayBalance = ourBalance
 		p2wkhBalance = theirBalance
-		dustLimit = lc.channelState.OurDustLimit
 	}
 
 	// Generate a new commitment transaction with all the latest
@@ -1339,6 +1372,7 @@ func (lc *LightningChannel) fetchCommitmentView(remoteChain bool,
 		ourMessageIndex:   ourLogIndex,
 		theirMessageIndex: theirLogIndex,
 		theirBalance:      theirBalance,
+		fee:               commitFee,
 	}
 
 	// In order to ensure _none_ of the HTLC's associated with this new
@@ -2479,6 +2513,17 @@ func (lc *LightningChannel) InitCooperativeClose() ([]byte, *chainhash.Hash, err
 		return nil, nil, ErrChanClosing
 	}
 
+	// Calculate the fee for the commitment transaction based on its size.
+	// For a cooperative close, there should be no HTLCs.
+	commitFee := btcutil.Amount(lc.feeEstimator.EstimateFeePerWeight(1)) *
+		commitWeight / 1000
+
+	if lc.channelState.IsInitiator {
+		lc.channelState.OurBalance = lc.channelState.OurBalance - commitFee
+	} else {
+		lc.channelState.TheirBalance = lc.channelState.TheirBalance - commitFee
+	}
+
 	closeTx := CreateCooperativeCloseTx(lc.fundingTxIn,
 		lc.channelState.OurDustLimit, lc.channelState.TheirDustLimit,
 		lc.channelState.OurBalance, lc.channelState.TheirBalance,
@@ -2527,6 +2572,17 @@ func (lc *LightningChannel) CompleteCooperativeClose(remoteSig []byte) (*wire.Ms
 	if lc.status == channelClosing || lc.status == channelClosed {
 		// TODO(roasbeef): check to ensure no pending payments
 		return nil, ErrChanClosing
+	}
+
+	// Calculate the fee for the commitment transaction based on its size.
+	// For a cooperative close, there should be no HTLCs.
+	commitFee := btcutil.Amount(lc.feeEstimator.EstimateFeePerWeight(1)) *
+		commitWeight / 1000
+
+	if lc.channelState.IsInitiator {
+		lc.channelState.OurBalance = lc.channelState.OurBalance - commitFee
+	} else {
+		lc.channelState.TheirBalance = lc.channelState.TheirBalance - commitFee
 	}
 
 	// Create the transaction used to return the current settled balance
@@ -2671,15 +2727,6 @@ func CreateCooperativeCloseTx(fundingTxIn *wire.TxIn,
 	// be omitted.
 	closeTx := wire.NewMsgTx(2)
 	closeTx.AddTxIn(fundingTxIn)
-
-	// The initiator of a cooperative closure pays the fee in entirety.
-	// Determine if we're the initiator so we can compute fees properly.
-	if initiator {
-		// TODO(roasbeef): take sat/byte here instead of properly calc
-		ourBalance -= 5000
-	} else {
-		theirBalance -= 5000
-	}
 
 	// Create both cooperative closure outputs, properly respecting the
 	// dust limits of both parties.

--- a/lnwallet/channel.go
+++ b/lnwallet/channel.go
@@ -232,6 +232,11 @@ type commitment struct {
 	ourBalance   btcutil.Amount
 	theirBalance btcutil.Amount
 
+	// fee is the amount that will be paid as fees for this commitment
+	// transaction. The fee is recorded here so that it can be added
+	// back and recalculated for each new update to the channel state.
+	fee btcutil.Amount
+
 	// htlcs is the set of HTLCs which remain unsettled within this
 	// commitment.
 	outgoingHTLCs []PaymentDescriptor
@@ -251,6 +256,7 @@ func (c *commitment) toChannelDelta(ourCommit bool) (*channeldb.ChannelDelta, er
 		LocalBalance:  c.ourBalance,
 		RemoteBalance: c.theirBalance,
 		UpdateNum:     c.height,
+		CommitFee:     c.fee,
 		Htlcs:         make([]*channeldb.HTLC, 0, numHtlcs),
 	}
 
@@ -1168,6 +1174,8 @@ func (lc *LightningChannel) restoreStateLogs() error {
 	lc.localCommitChain.tail().theirMessageIndex = theirCounter
 	lc.remoteCommitChain.tail().ourMessageIndex = ourCounter
 	lc.remoteCommitChain.tail().theirMessageIndex = theirCounter
+	lc.localCommitChain.tail().fee = lc.channelState.CommitFee
+	lc.remoteCommitChain.tail().fee = lc.channelState.CommitFee
 
 	return nil
 }
@@ -1232,12 +1240,13 @@ func (lc *LightningChannel) fetchCommitmentView(remoteChain bool,
 
 	// TODO(roasbeef): don't assume view is always fetched from tip?
 	var ourBalance, theirBalance btcutil.Amount
-	if commitChain.tip() == nil {
-		ourBalance = lc.channelState.OurBalance
-		theirBalance = lc.channelState.TheirBalance
-	} else {
-		ourBalance = commitChain.tip().ourBalance
-		theirBalance = commitChain.tip().theirBalance
+	ourBalance = commitChain.tip().ourBalance
+	theirBalance = commitChain.tip().theirBalance
+
+	if lc.channelState.IsInitiator {
+		ourBalance = ourBalance + commitChain.tip().fee
+	} else if !lc.channelState.IsInitiator {
+		theirBalance = theirBalance + commitChain.tip().fee
 	}
 
 	nextHeight := commitChain.tip().height + 1

--- a/lnwallet/channel_test.go
+++ b/lnwallet/channel_test.go
@@ -306,12 +306,15 @@ func createTestChannels(revocationWindow int) (*LightningChannel, *LightningChan
 	bobSigner := &mockSigner{bobKeyPriv}
 
 	notifier := &mockNotfier{}
+	estimator := &StaticFeeEstimator{50, 6}
 
-	channelAlice, err := NewLightningChannel(aliceSigner, notifier, aliceChannelState)
+	channelAlice, err := NewLightningChannel(aliceSigner, notifier,
+		estimator, aliceChannelState)
 	if err != nil {
 		return nil, nil, nil, err
 	}
-	channelBob, err := NewLightningChannel(bobSigner, notifier, bobChannelState)
+	channelBob, err := NewLightningChannel(bobSigner, notifier,
+		estimator, bobChannelState)
 	if err != nil {
 		return nil, nil, nil, err
 	}
@@ -1362,12 +1365,12 @@ func TestStateUpdatePersistence(t *testing.T) {
 	}
 	notifier := aliceChannel.channelEvents
 	aliceChannelNew, err := NewLightningChannel(aliceChannel.signer,
-		notifier, aliceChannels[0])
+		notifier, aliceChannel.feeEstimator, aliceChannels[0])
 	if err != nil {
 		t.Fatalf("unable to create new channel: %v", err)
 	}
 	bobChannelNew, err := NewLightningChannel(bobChannel.signer, notifier,
-		bobChannels[0])
+		bobChannel.feeEstimator, bobChannels[0])
 	if err != nil {
 		t.Fatalf("unable to create new channel: %v", err)
 	}

--- a/lnwallet/channel_test.go
+++ b/lnwallet/channel_test.go
@@ -544,7 +544,8 @@ func TestSimpleAddSettleWorkflow(t *testing.T) {
 	}
 	if aliceChannel.channelState.TotalSatoshisSent != satoshisTransferred {
 		t.Fatalf("alice satoshis sent incorrect %v vs %v expected",
-			aliceChannel.channelState.TotalSatoshisSent, satoshisTransferred)
+			aliceChannel.channelState.TotalSatoshisSent,
+			satoshisTransferred)
 	}
 	if aliceChannel.channelState.TotalSatoshisReceived != 0 {
 		t.Fatalf("alice satoshis received incorrect %v vs %v expected",
@@ -552,7 +553,8 @@ func TestSimpleAddSettleWorkflow(t *testing.T) {
 	}
 	if bobChannel.channelState.TotalSatoshisReceived != satoshisTransferred {
 		t.Fatalf("bob satoshis received incorrect %v vs %v expected",
-			bobChannel.channelState.TotalSatoshisReceived, satoshisTransferred)
+			bobChannel.channelState.TotalSatoshisReceived,
+			satoshisTransferred)
 	}
 	if bobChannel.channelState.TotalSatoshisSent != 0 {
 		t.Fatalf("bob satoshis sent incorrect %v vs %v expected",
@@ -567,24 +569,24 @@ func TestSimpleAddSettleWorkflow(t *testing.T) {
 			aliceChannel.currentHeight, 2)
 	}
 	if aliceChannel.revocationWindowEdge != 3 {
-		t.Fatalf("alice revocation window not incremented, is %v should be %v",
-			aliceChannel.revocationWindowEdge, 3)
+		t.Fatalf("alice revocation window not incremented, is %v "+
+			"should be %v", aliceChannel.revocationWindowEdge, 3)
 	}
 	if bobChannel.revocationWindowEdge != 3 {
-		t.Fatalf("alice revocation window not incremented, is %v should be %v",
-			bobChannel.revocationWindowEdge, 3)
+		t.Fatalf("alice revocation window not incremented, is %v "+
+			"should be %v", bobChannel.revocationWindowEdge, 3)
 	}
 
 	// The logs of both sides should now be cleared since the entry adding
 	// the HTLC should have been removed once both sides receive the
 	// revocation.
 	if aliceChannel.localUpdateLog.Len() != 0 {
-		t.Fatalf("alice's local not updated, should be empty, has %v entries "+
-			"instead", aliceChannel.localUpdateLog.Len())
+		t.Fatalf("alice's local not updated, should be empty, has %v "+
+			"entries instead", aliceChannel.localUpdateLog.Len())
 	}
 	if aliceChannel.remoteUpdateLog.Len() != 0 {
-		t.Fatalf("alice's remote not updated, should be empty, has %v entries "+
-			"instead", aliceChannel.remoteUpdateLog.Len())
+		t.Fatalf("alice's remote not updated, should be empty, has %v "+
+			"entries instead", aliceChannel.remoteUpdateLog.Len())
 	}
 	if len(aliceChannel.localUpdateLog.updateIndex) != 0 {
 		t.Fatalf("alice's local log index not cleared, should be empty but "+
@@ -885,12 +887,14 @@ func TestForceClose(t *testing.T) {
 	if closeSummary.SelfOutputSignDesc == nil {
 		t.Fatalf("alice fails to include to-self output in ForceCloseSummary")
 	} else {
-		if closeSummary.SelfOutputSignDesc.PubKey != aliceChannel.channelState.OurCommitKey {
+		if closeSummary.SelfOutputSignDesc.PubKey !=
+			aliceChannel.channelState.OurCommitKey {
 			t.Fatalf("alice incorrect pubkey in SelfOutputSignDesc")
 		}
 		if closeSummary.SelfOutputSignDesc.Output.Value != int64(aliceAmount) {
 			t.Fatalf("alice incorrect output value in SelfOutputSignDesc, "+
-				"expected %v, got %v", aliceChannel.channelState.OurBalance,
+				"expected %v, got %v",
+				aliceChannel.channelState.OurBalance,
 				closeSummary.SelfOutputSignDesc.Output.Value)
 		}
 	}
@@ -915,12 +919,14 @@ func TestForceClose(t *testing.T) {
 	if closeSummary.SelfOutputSignDesc == nil {
 		t.Fatalf("bob fails to include to-self output in ForceCloseSummary")
 	} else {
-		if closeSummary.SelfOutputSignDesc.PubKey != bobChannel.channelState.OurCommitKey {
+		if closeSummary.SelfOutputSignDesc.PubKey !=
+			bobChannel.channelState.OurCommitKey {
 			t.Fatalf("bob incorrect pubkey in SelfOutputSignDesc")
 		}
 		if closeSummary.SelfOutputSignDesc.Output.Value != int64(bobAmount) {
 			t.Fatalf("bob incorrect output value in SelfOutputSignDesc, "+
-				"expected %v, got %v", bobChannel.channelState.OurBalance,
+				"expected %v, got %v",
+				bobChannel.channelState.OurBalance,
 				closeSummary.SelfOutputSignDesc.Output.Value)
 		}
 	}
@@ -943,7 +949,8 @@ func TestForceClose(t *testing.T) {
 	aliceChannel.ForceCloseSignal = make(chan struct{})
 	bobChannel.ForceCloseSignal = make(chan struct{})
 
-	// Have Bobs' to-self output be below her dust limit and check ForceCloseSummary again on both peers.
+	// Have Bobs' to-self output be below her dust limit and check
+	// ForceCloseSummary again on both peers.
 	htlc, preimage := createHTLC(0, bobAmount-htlcAmount)
 	if _, err := bobChannel.AddHTLC(htlc); err != nil {
 		t.Fatalf("alice unable to add htlc: %v", err)
@@ -980,12 +987,15 @@ func TestForceClose(t *testing.T) {
 	if closeSummary.SelfOutputSignDesc == nil {
 		t.Fatalf("alice fails to include to-self output in ForceCloseSummary")
 	} else {
-		if closeSummary.SelfOutputSignDesc.PubKey != aliceChannel.channelState.OurCommitKey {
+		if closeSummary.SelfOutputSignDesc.PubKey !=
+			aliceChannel.channelState.OurCommitKey {
 			t.Fatalf("alice incorrect pubkey in SelfOutputSignDesc")
 		}
-		if closeSummary.SelfOutputSignDesc.Output.Value != int64(aliceAmount) {
+		if closeSummary.SelfOutputSignDesc.Output.Value !=
+			int64(aliceAmount) {
 			t.Fatalf("alice incorrect output value in SelfOutputSignDesc, "+
-				"expected %v, got %v", aliceChannel.channelState.OurBalance,
+				"expected %v, got %v",
+				aliceChannel.channelState.OurBalance,
 				closeSummary.SelfOutputSignDesc.Output.Value)
 		}
 	}
@@ -1006,7 +1016,8 @@ func TestForceClose(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unable to force close channel: %v", err)
 	}
-	// Bob's to-self output is below Bob's dust value and should be reflected in the ForceCloseSummary.
+	// Bob's to-self output is below Bob's dust value and should be
+	// reflected in the ForceCloseSummary.
 	if closeSummary.SelfOutputSignDesc != nil {
 		t.Fatalf("bob incorrectly includes to-self output in ForceCloseSummary")
 	}
@@ -1051,8 +1062,9 @@ func TestCheckDustLimit(t *testing.T) {
 	htlcAmount := btcutil.Amount(500)
 
 	if !((htlcAmount > aliceDustLimit) && (bobDustLimit > htlcAmount)) {
-		t.Fatal("htlc amount needs to be above Alice's dust limit, but " +
-			"below Bob's dust limit .")
+		t.Fatalf("htlc amount (%v) should be above Alice's dust limit (%v),"+
+			"and below Bob's dust limit (%v).", htlcAmount, aliceDustLimit,
+			bobDustLimit)
 	}
 
 	aliceAmount := aliceChannel.channelState.OurBalance
@@ -1077,25 +1089,31 @@ func TestCheckDustLimit(t *testing.T) {
 	// From Alice point of view HTLC's amount is bigger than dust limit.
 	commitment := aliceChannel.localCommitChain.tip()
 	if len(commitment.txn.TxOut) != 3 {
-		t.Fatal("htlc wasn't added")
+		t.Fatalf("incorrect number of outputs: expected %v, got %v",
+			3, len(commitment.txn.TxOut))
 	}
 	if commitment.ourBalance != aliceAmount-htlcAmount {
-		t.Fatal("our balance wasn't updated")
+		t.Fatalf("Alice has wrong balance: expected %v, got %v",
+			aliceAmount-htlcAmount, commitment.ourBalance)
 	}
 	if commitment.theirBalance != bobAmount {
-		t.Fatal("their balance was updated")
+		t.Fatalf("Alice has wrong balance for Bob: expected %v, got %v",
+			bobAmount, commitment.theirBalance)
 	}
 
 	// From Bob point of view HTLC's amount is lower then dust limit.
 	commitment = bobChannel.localCommitChain.tip()
 	if len(commitment.txn.TxOut) != 2 {
-		t.Fatal("HTLC with dust amount was added")
+		t.Fatalf("Incorrect number of outputs: expected %v, got %v",
+			2, len(commitment.txn.TxOut))
 	}
 	if commitment.theirBalance != aliceAmount-htlcAmount {
-		t.Fatal("their balance wasn't updated")
+		t.Fatalf("Bob has wrong balance for Alice: expected %v, got %v",
+			aliceAmount-htlcAmount, commitment.theirBalance)
 	}
 	if commitment.ourBalance != bobAmount {
-		t.Fatal("our balance was updated")
+		t.Fatalf("Bob has wrong balance: expected %v, got %v",
+			bobAmount, commitment.ourBalance)
 	}
 
 	// Settle HTLC and sign new commitment.
@@ -1108,29 +1126,35 @@ func TestCheckDustLimit(t *testing.T) {
 		t.Fatalf("alice unable to accept settle of outbound htlc: %v", err)
 	}
 	if err := forceStateTransition(bobChannel, aliceChannel); err != nil {
-		t.Fatalf("Can't update the channel state: %v", err)
+		t.Fatalf("state transition error: %v", err)
 	}
 
 	commitment = aliceChannel.localCommitChain.tip()
 	if len(commitment.txn.TxOut) != 2 {
-		t.Fatal("HTLC wasn't settled")
+		t.Fatalf("wrong number of outputs: expected %v, got %v",
+			2, len(commitment.txn.TxOut))
 	}
 	if commitment.ourBalance != aliceAmount-htlcAmount {
-		t.Fatal("our balance wasn't updated")
+		t.Fatalf("Alice has wrong balance: expected %v, got %v",
+			aliceAmount-htlcAmount, commitment.ourBalance)
 	}
 	if commitment.theirBalance != bobAmount+htlcAmount {
-		t.Fatal("their balance wasn't updated")
+		t.Fatalf("Alice has wrong balance for Bob: expected %v, got %v",
+			bobAmount, commitment.theirBalance)
 	}
 
 	commitment = bobChannel.localCommitChain.tip()
 	if len(commitment.txn.TxOut) != 2 {
-		t.Fatal("HTLC with dust amount wasn't settled")
+		t.Fatalf("wrong number of outputs: expected %v, got %v",
+			2, len(commitment.txn.TxOut))
 	}
 	if commitment.ourBalance != bobAmount+htlcAmount {
-		t.Fatalf("our balance wasn't updated")
+		t.Fatalf("Bob has wrong balance: expected %v, got %v",
+			bobAmount+htlcAmount, commitment.ourBalance)
 	}
 	if commitment.theirBalance != aliceAmount-htlcAmount {
-		t.Fatal("their balance wasn't updated")
+		t.Fatalf("Bob has wrong balance for Alice: expected %v, got %v",
+			aliceAmount-htlcAmount, commitment.theirBalance)
 	}
 
 	// Next we will test when a non-HTLC output in the commitment
@@ -1148,33 +1172,37 @@ func TestCheckDustLimit(t *testing.T) {
 		t.Fatalf("bob unable to receive htlc: %v", err)
 	}
 	if err := forceStateTransition(aliceChannel, bobChannel); err != nil {
-		t.Fatalf("Can't update the channel state: %v", err)
+		t.Fatalf("state transition error: %v", err)
 	}
 
 	// From Alice's point of view, her output is bigger than the dust limit
 	commitment = aliceChannel.localCommitChain.tip()
 	if len(commitment.txn.TxOut) != 3 {
-		t.Fatal("incorrect number of outputs in commitment transaction "+
-			"expected %v, got %v", 3, commitment.txn.TxOut)
+		t.Fatalf("incorrect number of outputs in commitment transaction "+
+			"expected %v, got %v", 3, len(commitment.txn.TxOut))
 	}
 	if commitment.ourBalance != aliceAmount-htlcAmount2 {
-		t.Fatal("our balance wasn't updated")
+		t.Fatalf("Alice has wrong balance: expected %v, got %v",
+			aliceAmount-htlcAmount, commitment.ourBalance)
 	}
 	if commitment.theirBalance != bobAmount {
-		t.Fatal("their balance was updated")
+		t.Fatalf("Alice has wrong balance for Bob: expected %v, got %v",
+			bobAmount, commitment.theirBalance)
 	}
 
 	// From Bob's point of view, Alice's output is lower than the dust limit
 	commitment = bobChannel.localCommitChain.tip()
 	if len(commitment.txn.TxOut) != 2 {
-		t.Fatal("incorrect number of outputs in commitment transaction "+
-			"expected %v, got %v", 2, commitment.txn.TxOut)
+		t.Fatalf("incorrect number of outputs in commitment transaction "+
+			"expected %v, got %v", 2, len(commitment.txn.TxOut))
 	}
 	if commitment.theirBalance != aliceAmount-htlcAmount2 {
-		t.Fatal("their balance wasn't updated")
+		t.Fatalf("Bob has wrong balance for Alice: expected %v, got %v",
+			aliceAmount-htlcAmount, commitment.theirBalance)
 	}
 	if commitment.ourBalance != bobAmount {
-		t.Fatal("our balance was updated")
+		t.Fatalf("Bob has wrong balance: expected %v, got %v",
+			bobAmount+htlcAmount, commitment.ourBalance)
 	}
 
 	// Settle HTLC and sign new commitment.
@@ -1187,33 +1215,36 @@ func TestCheckDustLimit(t *testing.T) {
 		t.Fatalf("alice unable to accept settle of outbound htlc: %v", err)
 	}
 	if err := forceStateTransition(bobChannel, aliceChannel); err != nil {
-		t.Fatalf("Can't update the channel state: %v", err)
+		t.Fatalf("state transition error: %v", err)
 	}
 
 	commitment = aliceChannel.localCommitChain.tip()
 	if len(commitment.txn.TxOut) != 2 {
-		t.Fatal("incorrect number of outputs in commitment transaction, "+
+		t.Fatalf("incorrect number of outputs in commitment transaction, "+
 			"expected %v got %v", 2, len(commitment.txn.TxOut))
 	}
 	if commitment.ourBalance != aliceAmount-htlcAmount2 {
-		t.Fatal("our balance wasn't updated")
+		t.Fatalf("Alice has wrong balance: expected %v, got %v",
+			aliceAmount-htlcAmount, commitment.ourBalance)
 	}
 	if commitment.theirBalance != bobAmount+htlcAmount2 {
-		t.Fatal("their balance wasn't updated")
+		t.Fatalf("Alice has wrong balance for Bob: expected %v, got %v",
+			bobAmount, commitment.theirBalance)
 	}
 
 	commitment = bobChannel.localCommitChain.tip()
 	if len(commitment.txn.TxOut) != 1 {
-		t.Fatal("incorrect number of outputs in commitment transaction, "+
+		t.Fatalf("incorrect number of outputs in commitment transaction, "+
 			"expected %v got %v", 1, len(commitment.txn.TxOut))
 	}
 	if commitment.ourBalance != bobAmount+htlcAmount2 {
-		t.Fatal("our balance wasn't updated")
+		t.Fatalf("Bob has wrong balance: expected %v, got %v",
+			bobAmount+htlcAmount, commitment.ourBalance)
 	}
 	if commitment.theirBalance != aliceAmount-htlcAmount2 {
-		t.Fatal("their balance wasn't updated")
+		t.Fatalf("Bob has wrong balance for Alice: expected %v, got %v",
+			aliceAmount-htlcAmount, commitment.theirBalance)
 	}
-
 }
 
 func TestStateUpdatePersistence(t *testing.T) {
@@ -1330,11 +1361,13 @@ func TestStateUpdatePersistence(t *testing.T) {
 		t.Fatalf("unable to fetch channel: %v", err)
 	}
 	notifier := aliceChannel.channelEvents
-	aliceChannelNew, err := NewLightningChannel(aliceChannel.signer, notifier, aliceChannels[0])
+	aliceChannelNew, err := NewLightningChannel(aliceChannel.signer,
+		notifier, aliceChannels[0])
 	if err != nil {
 		t.Fatalf("unable to create new channel: %v", err)
 	}
-	bobChannelNew, err := NewLightningChannel(bobChannel.signer, notifier, bobChannels[0])
+	bobChannelNew, err := NewLightningChannel(bobChannel.signer, notifier,
+		bobChannels[0])
 	if err != nil {
 		t.Fatalf("unable to create new channel: %v", err)
 	}
@@ -1344,42 +1377,50 @@ func TestStateUpdatePersistence(t *testing.T) {
 
 	// The state update logs of the new channels and the old channels
 	// should now be identical other than the height the HTLCs were added.
-	if aliceChannel.localUpdateLog.logIndex != aliceChannelNew.localUpdateLog.logIndex {
+	if aliceChannel.localUpdateLog.logIndex !=
+		aliceChannelNew.localUpdateLog.logIndex {
 		t.Fatalf("alice log counter: expected %v, got %v",
 			aliceChannel.localUpdateLog.logIndex,
 			aliceChannelNew.localUpdateLog.logIndex)
 	}
-	if aliceChannel.remoteUpdateLog.logIndex != aliceChannelNew.remoteUpdateLog.logIndex {
+	if aliceChannel.remoteUpdateLog.logIndex !=
+		aliceChannelNew.remoteUpdateLog.logIndex {
 		t.Fatalf("alice log counter: expected %v, got %v",
 			aliceChannel.remoteUpdateLog.logIndex,
 			aliceChannelNew.remoteUpdateLog.logIndex)
 	}
-	if aliceChannel.localUpdateLog.Len() != aliceChannelNew.localUpdateLog.Len() {
+	if aliceChannel.localUpdateLog.Len() !=
+		aliceChannelNew.localUpdateLog.Len() {
 		t.Fatalf("alice log len: expected %v, got %v",
 			aliceChannel.localUpdateLog.Len(),
 			aliceChannelNew.localUpdateLog.Len())
 	}
-	if aliceChannel.remoteUpdateLog.Len() != aliceChannelNew.remoteUpdateLog.Len() {
+	if aliceChannel.remoteUpdateLog.Len() !=
+		aliceChannelNew.remoteUpdateLog.Len() {
 		t.Fatalf("alice log len: expected %v, got %v",
 			aliceChannel.remoteUpdateLog.Len(),
 			aliceChannelNew.remoteUpdateLog.Len())
 	}
-	if bobChannel.localUpdateLog.logIndex != bobChannelNew.localUpdateLog.logIndex {
+	if bobChannel.localUpdateLog.logIndex !=
+		bobChannelNew.localUpdateLog.logIndex {
 		t.Fatalf("bob log counter: expected %v, got %v",
 			bobChannel.localUpdateLog.logIndex,
 			bobChannelNew.localUpdateLog.logIndex)
 	}
-	if bobChannel.remoteUpdateLog.logIndex != bobChannelNew.remoteUpdateLog.logIndex {
+	if bobChannel.remoteUpdateLog.logIndex !=
+		bobChannelNew.remoteUpdateLog.logIndex {
 		t.Fatalf("bob log counter: expected %v, got %v",
 			bobChannel.remoteUpdateLog.logIndex,
 			bobChannelNew.remoteUpdateLog.logIndex)
 	}
-	if bobChannel.localUpdateLog.Len() != bobChannelNew.localUpdateLog.Len() {
+	if bobChannel.localUpdateLog.Len() !=
+		bobChannelNew.localUpdateLog.Len() {
 		t.Fatalf("bob log len: expected %v, got %v",
 			bobChannelNew.localUpdateLog.Len(),
 			bobChannelNew.localUpdateLog.Len())
 	}
-	if bobChannel.remoteUpdateLog.Len() != bobChannelNew.remoteUpdateLog.Len() {
+	if bobChannel.remoteUpdateLog.Len() !=
+		bobChannelNew.remoteUpdateLog.Len() {
 		t.Fatalf("bob log len: expected %v, got %v",
 			bobChannel.remoteUpdateLog.Len(),
 			bobChannelNew.remoteUpdateLog.Len())
@@ -1390,11 +1431,11 @@ func TestStateUpdatePersistence(t *testing.T) {
 		htlc := entry.Value.(*PaymentDescriptor)
 		restoredHtlc := aliceChannelNew.localUpdateLog.lookup(htlc.Index)
 		if !bytes.Equal(htlc.ourPkScript, restoredHtlc.ourPkScript) {
-			t.Fatalf("alice ourPkScript in ourLog: expected %X..., got %X...",
+			t.Fatalf("alice ourPkScript in ourLog: expected %X, got %X",
 				htlc.ourPkScript[:5], restoredHtlc.ourPkScript[:5])
 		}
 		if !bytes.Equal(htlc.theirPkScript, restoredHtlc.theirPkScript) {
-			t.Fatalf("alice theirPkScript in ourLog: expected %X..., got %X...",
+			t.Fatalf("alice theirPkScript in ourLog: expected %X, got %X",
 				htlc.theirPkScript[:5], restoredHtlc.theirPkScript[:5])
 		}
 	}
@@ -1402,11 +1443,11 @@ func TestStateUpdatePersistence(t *testing.T) {
 		htlc := entry.Value.(*PaymentDescriptor)
 		restoredHtlc := aliceChannelNew.remoteUpdateLog.lookup(htlc.Index)
 		if !bytes.Equal(htlc.ourPkScript, restoredHtlc.ourPkScript) {
-			t.Fatalf("alice ourPkScript in theirLog: expected %X..., got %X...",
+			t.Fatalf("alice ourPkScript in theirLog: expected %X, got %X",
 				htlc.ourPkScript[:5], restoredHtlc.ourPkScript[:5])
 		}
 		if !bytes.Equal(htlc.theirPkScript, restoredHtlc.theirPkScript) {
-			t.Fatalf("alice theirPkScript in theirLog: expected %X..., got %X...",
+			t.Fatalf("alice theirPkScript in theirLog: expected %X, got %X",
 				htlc.theirPkScript[:5], restoredHtlc.theirPkScript[:5])
 		}
 	}
@@ -1414,11 +1455,11 @@ func TestStateUpdatePersistence(t *testing.T) {
 		htlc := entry.Value.(*PaymentDescriptor)
 		restoredHtlc := bobChannelNew.localUpdateLog.lookup(htlc.Index)
 		if !bytes.Equal(htlc.ourPkScript, restoredHtlc.ourPkScript) {
-			t.Fatalf("bob ourPkScript in ourLog: expected %X..., got %X...",
+			t.Fatalf("bob ourPkScript in ourLog: expected %X, got %X",
 				htlc.ourPkScript[:5], restoredHtlc.ourPkScript[:5])
 		}
 		if !bytes.Equal(htlc.theirPkScript, restoredHtlc.theirPkScript) {
-			t.Fatalf("bob theirPkScript in ourLog: expected %X..., got %X...",
+			t.Fatalf("bob theirPkScript in ourLog: expected %X, got %X",
 				htlc.theirPkScript[:5], restoredHtlc.theirPkScript[:5])
 		}
 	}
@@ -1426,11 +1467,11 @@ func TestStateUpdatePersistence(t *testing.T) {
 		htlc := entry.Value.(*PaymentDescriptor)
 		restoredHtlc := bobChannelNew.remoteUpdateLog.lookup(htlc.Index)
 		if !bytes.Equal(htlc.ourPkScript, restoredHtlc.ourPkScript) {
-			t.Fatalf("bob ourPkScript in theirLog: expected %X..., got %X...",
+			t.Fatalf("bob ourPkScript in theirLog: expected %X, got %X",
 				htlc.ourPkScript[:5], restoredHtlc.ourPkScript[:5])
 		}
 		if !bytes.Equal(htlc.theirPkScript, restoredHtlc.theirPkScript) {
-			t.Fatalf("bob theirPkScript in theirLog: expected %X..., got %X...",
+			t.Fatalf("bob theirPkScript in theirLog: expected %X, got %X",
 				htlc.theirPkScript[:5], restoredHtlc.theirPkScript[:5])
 		}
 	}
@@ -1596,7 +1637,7 @@ func TestCancelHTLC(t *testing.T) {
 	}
 }
 
-func TestCooperativeCloseDustAdherance(t *testing.T) {
+func TestCooperativeCloseDustAdherence(t *testing.T) {
 	// Create a test channel which will be used for the duration of this
 	// unittest. The channel will be funded evenly with Alice having 5 BTC,
 	// and Bob having 5 BTC.

--- a/lnwallet/interface.go
+++ b/lnwallet/interface.go
@@ -302,6 +302,26 @@ type MessageSigner interface {
 	SignMessage(pubKey *btcec.PublicKey, msg []byte) (*btcec.Signature, error)
 }
 
+// FeeEstimator provides the ability to estimate on-chain transaction fees for
+// various combinations of transaction sizes and desired confirmation time
+// (measured by number of blocks).
+type FeeEstimator interface {
+	// EstimateFeePerByte takes in a target for the number of blocks until
+	// an initial confirmation and returns the estimated fee expressed in
+	// satoshis/byte.
+	EstimateFeePerByte(numBlocks uint32) uint64
+
+	// EstimateFeePerWeight takes in a target for the number of blocks until
+	// an initial confirmation and returns the estimated fee expressed in
+	// satoshis/weight.
+	EstimateFeePerWeight(numBlocks uint32) uint64
+
+	// EstimateConfirmation will return the number of blocks expected for a
+	// transaction to be confirmed given a fee rate in satoshis per
+	// byte.
+	EstimateConfirmation(satPerByte int64) uint32
+}
+
 // WalletDriver represents a "driver" for a particular concrete
 // WalletController implementation. A driver is identified by a globally unique
 // string identifier along with a 'New()' method which is responsible for

--- a/lnwallet/interface_test.go
+++ b/lnwallet/interface_test.go
@@ -339,8 +339,9 @@ func createTestWallet(tempTestDir string, miningNode *rpctest.Harness,
 		return nil, err
 	}
 
+	estimator := lnwallet.StaticFeeEstimator{FeeRate: 250}
 	wallet, err := lnwallet.NewLightningWallet(cdb, notifier, wc, signer,
-		bio, netParams)
+		bio, estimator, netParams)
 	if err != nil {
 		return nil, err
 	}

--- a/lnwallet/reservation.go
+++ b/lnwallet/reservation.go
@@ -215,6 +215,7 @@ func NewChannelReservation(capacity, fundingAmt btcutil.Amount, minFeeRate btcut
 			TheirBalance: theirBalance,
 			MinFeePerKb:  minFeeRate,
 			Db:           wallet.ChannelDB,
+			CommitFee:    commitFee,
 		},
 		numConfsToOpen: numConfs,
 		pushSat:        pushSat,

--- a/lnwallet/reservation.go
+++ b/lnwallet/reservation.go
@@ -46,6 +46,11 @@ type ChannelContribution struct {
 	// initial version of this party's commitment transaction.
 	RevocationKey *btcec.PublicKey
 
+	// DustLimit is the threshold below which no HTLC output should be
+	// generated for this party. HTLCs below this amount are not
+	// enforceable on-chain from this party's point of view.
+	DustLimit btcutil.Amount
+
 	// CsvDelay The delay (in blocks) to be used for the pay-to-self output
 	// in this party's version of the commitment transaction.
 	CsvDelay uint32

--- a/lnwallet/script_utils.go
+++ b/lnwallet/script_utils.go
@@ -24,8 +24,6 @@ var (
 	// time is in seconds.
 	SequenceLockTimeSeconds = uint32(1 << 22)
 
-	OP_CHECKSEQUENCEVERIFY byte = txscript.OP_NOP3
-
 	// TimelockShift is used to make sure the commitment transaction is
 	// spendable by setting the locktime with it so that it is larger than
 	// 500,000,000, thus interpreting it as Unix epoch timestamp and not
@@ -236,7 +234,7 @@ func senderHTLCScript(absoluteTimeout, relativeTimeout uint32, senderKey,
 	builder.AddInt64(int64(absoluteTimeout))
 	builder.AddOp(txscript.OP_CHECKLOCKTIMEVERIFY)
 	builder.AddInt64(int64(relativeTimeout))
-	builder.AddOp(OP_CHECKSEQUENCEVERIFY)
+	builder.AddOp(txscript.OP_CHECKSEQUENCEVERIFY)
 	builder.AddOp(txscript.OP_2DROP)
 	builder.AddData(senderKey.SerializeCompressed())
 	builder.AddOp(txscript.OP_CHECKSIG)
@@ -401,7 +399,7 @@ func receiverHTLCScript(absoluteTimeout, relativeTimeout uint32, senderKey,
 	builder.AddData(paymentHash)
 	builder.AddOp(txscript.OP_EQUALVERIFY)
 	builder.AddInt64(int64(relativeTimeout))
-	builder.AddOp(OP_CHECKSEQUENCEVERIFY)
+	builder.AddOp(txscript.OP_CHECKSEQUENCEVERIFY)
 	builder.AddOp(txscript.OP_DROP)
 	builder.AddData(receiverKey.SerializeCompressed())
 	builder.AddOp(txscript.OP_CHECKSIG)
@@ -599,7 +597,7 @@ func commitScriptToSelf(csvTimeout uint32, selfKey, revokeKey *btcec.PublicKey) 
 	builder.AddData(selfKey.SerializeCompressed())
 	builder.AddOp(txscript.OP_CHECKSIGVERIFY)
 	builder.AddInt64(int64(csvTimeout))
-	builder.AddOp(OP_CHECKSEQUENCEVERIFY)
+	builder.AddOp(txscript.OP_CHECKSEQUENCEVERIFY)
 
 	builder.AddOp(txscript.OP_ENDIF)
 

--- a/peer.go
+++ b/peer.go
@@ -288,7 +288,7 @@ func (p *peer) loadActiveChannels(chans []*channeldb.OpenChannel) error {
 		}
 
 		lnChan, err := lnwallet.NewLightningChannel(p.server.lnwallet.Signer,
-			p.server.chainNotifier, dbChan)
+			p.server.chainNotifier, p.server.feeEstimator, dbChan)
 		if err != nil {
 			return err
 		}

--- a/routing/notifications_test.go
+++ b/routing/notifications_test.go
@@ -367,7 +367,7 @@ func TestEdgeUpdateNotification(t *testing.T) {
 		}
 		// TODO(roasbeef): this is a hack, needs to be removed
 		// after commitment fees are dynamic.
-		if edgeUpdate.Capacity != chanValue-5000 {
+		if edgeUpdate.Capacity != chanValue {
 			t.Fatalf("capacity of edge doesn't match: "+
 				"expected %v, got %v", chanValue, edgeUpdate.Capacity)
 		}
@@ -676,7 +676,7 @@ func TestChannelCloseNotification(t *testing.T) {
 		}
 		// TODO(roasbeef): this is a hack, needs to be removed
 		// after commitment fees are dynamic.
-		if closedChan.Capacity != chanValue-5000 {
+		if closedChan.Capacity != chanValue {
 			t.Fatalf("capacity of closed channel doesn't match: "+
 				"expected %v, got %v", chanValue, closedChan.Capacity)
 		}

--- a/routing/router.go
+++ b/routing/router.go
@@ -605,7 +605,7 @@ func (r *ChannelRouter) processUpdate(msg interface{}) error {
 
 		// TODO(roasbeef): this is a hack, needs to be removed
 		// after commitment fees are dynamic.
-		msg.Capacity = btcutil.Amount(chanUtxo.Value) - btcutil.Amount(5000)
+		msg.Capacity = btcutil.Amount(chanUtxo.Value)
 		msg.ChannelPoint = *fundingPoint
 		if err := r.cfg.Graph.AddChannelEdge(msg); err != nil {
 			return errors.Errorf("unable to add edge: %v", err)

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -625,7 +625,7 @@ func (r *rpcServer) fetchActiveChannel(chanPoint wire.OutPoint) (*lnwallet.Light
 	// Otherwise, we create a fully populated channel state machine which
 	// uses the db channel as backing storage.
 	return lnwallet.NewLightningChannel(r.server.lnwallet.Signer, nil,
-		dbChan)
+		lnwallet.StaticFeeEstimator{FeeRate: 250}, dbChan)
 }
 
 // forceCloseChan executes a unilateral close of the target channel by


### PR DESCRIPTION
This PR replaces the hard-coded 5000 satoshi fees with calls to the
FeeEstimator interface. This should provide a way to cleanly plug in
additional fee calculation algorithms in the future. This change
affected quite a few tests. When possible, the tests were changed to
assert amounts sent rather than balances so that fees wouldn't need to
be taken into account. There were several tests for which this wasn't
possible, so calls to the static fee calculator were made.

This PR addresses Issue #52.