### PR TITLE
docs: fix entry for externalip

### DIFF
--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -115,7 +115,8 @@ debuglevel=trace
 debughtlc=true
 maxpendingchannels=10
 profile=5060
-externalip=128.111.13.23,111.32.29.29
+externalip=128.111.13.23
+externalip=111.32.29.29
 
 [Bitcoin]
 bitcoin.active=1


### PR DESCRIPTION
In order to specify multiple external IP addresses in the configuration
file, each IP address must be on a separate line, preceded by “externalip=“.