### PR TITLE
docker: update docker instructions to be aware of multi-chain config (2)

### DIFF
--- a/docker/lnd/start-lnd.sh
+++ b/docker/lnd/start-lnd.sh
@@ -47,10 +47,10 @@ BITCOIN_NETWORK=$(set_default "$BITCOIN_NETWORK" "simnet")
 lnd \
     --datadir="/data" \
     --logdir="/data" \
-    --rpccert="/rpc/rpc.cert" \
     --bitcoin.active \
     "--bitcoin.$BITCOIN_NETWORK" \
     --bitcoin.rpchost="btcd" \
+    --bitcoin.rpccert="/rpc/rpc.cert" \
     --bitcoin.rpcuser="$RPCUSER" \
     --bitcoin.rpcpass="$RPCPASS" \
     --debuglevel="$DEBUG" \


### PR DESCRIPTION
This commit contains replacement of previous --rpccert flag on newest --bitcoin.rpccert flag in docker lnd config. Before this change, the lnd nodes has been dropped at startup.