### PR TITLE
add support for litecoin mainnet

### DIFF
--- a/chainregistry.go
+++ b/chainregistry.go
@@ -16,8 +16,11 @@ const (
 	// bitcoinChain is Bitcoin's testnet chain.
 	bitcoinChain chainCode = iota
 
-	// litecoinChain is Litecoin's testnet chain.
+	// litecoinChain is Litecoin's mainnet chain.
 	litecoinChain
+
+	// litecointestChain is Litecoin's testnet chain.
+	litecointestChain
 )
 
 // String returns a string representation of the target chainCode.
@@ -27,8 +30,10 @@ func (c chainCode) String() string {
 		return "bitcoin"
 	case litecoinChain:
 		return "litecoin"
+	case litecointestChain:
+		return "litecointest"
 	default:
-		return "kekcoin"
+		panic("unknown chainCode")
 	}
 }
 
@@ -51,8 +56,16 @@ var (
 		0x68, 0xd6, 0x19, 0x00, 0x00, 0x00, 0x00, 0x00,
 	})
 
-	// litecoinGenesis is the genesis hash of Litecoin's testnet4 chain.
+	// litecoinGenesis is the genesis hash of Litecoin's main chain.
 	litecoinGenesis = chainhash.Hash([chainhash.HashSize]byte{
+		0xe2, 0xbf, 0x04, 0x7e, 0x7e, 0x5a, 0x19, 0x1a,
+		0xa4, 0xef, 0x34, 0xd3, 0x14, 0x97, 0x9d, 0xc9,
+		0x98, 0x6e, 0x0f, 0x19, 0x25, 0x1e, 0xda, 0xba,
+		0x59, 0x40, 0xfd, 0x1f, 0xe3, 0x65, 0xa7, 0x12,
+	})
+
+	// litecointestGenesis is the genesis hash of Litecoin's testnet4 chain.
+	litecointestGenesis = chainhash.Hash([chainhash.HashSize]byte{
 		0xa0, 0x29, 0x3e, 0x4e, 0xeb, 0x3d, 0xa6, 0xe6,
 		0xf5, 0x6f, 0x81, 0xed, 0x59, 0x5f, 0x57, 0x88,
 		0x0d, 0x1a, 0x21, 0x56, 0x9e, 0x13, 0xee, 0xfd,
@@ -62,15 +75,17 @@ var (
 	// chainMap is a simple index that maps a chain's genesis hash to the
 	// chainCode enum for that chain.
 	chainMap = map[chainhash.Hash]chainCode{
-		bitcoinGenesis:  bitcoinChain,
-		litecoinGenesis: litecoinChain,
+		bitcoinGenesis:      bitcoinChain,
+		litecoinGenesis:     litecoinChain,
+		litecointestGenesis: litecointestChain,
 	}
 
 	// reverseChainMap is the inverse of the chainMap above: it maps the
 	// chain enum for a chain to its genesis hash.
 	reverseChainMap = map[chainCode]chainhash.Hash{
-		bitcoinChain:  bitcoinGenesis,
-		litecoinChain: litecoinGenesis,
+		bitcoinChain:      bitcoinGenesis,
+		litecoinChain:     litecoinGenesis,
+		litecointestChain: litecointestGenesis,
 	}
 )
 

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -48,7 +48,7 @@ $ btcctl --testnet getinfo
 {
   "version": 120000,
   "protocolversion": 70002,
-  "blocks": 1114996, 
+  "blocks": 1114996,
   "timeoffset": 0,
   "connections": 7,
   "proxy": "",
@@ -60,7 +60,7 @@ $ btcctl --testnet getinfo
 ```
 
 Additionally, you can monitor btcd's logs to track its syncing progress in real
-time. 
+time.
 
 You can test your `btcd` node's connectivity using the `getpeerinfo` command:
 ```
@@ -100,7 +100,7 @@ $ lnd --bitcoin.active --bitcoin.simnet --debughtlc
 
 Optionally, if you'd like to have a persistent configuration between `lnd`
 launches, allowing you to simply type `lnd --bitcoin.testnet --bitcoin.active`
-at the command line. You can create an `lnd.conf`. 
+at the command line. You can create an `lnd.conf`.
 
 **On MacOS, located at:**
 `/Users/[username]/Library/Application Support/Lnd/lnd.conf`
@@ -126,7 +126,8 @@ bitcoin.rpchost=localhost:18334
 Notice the `[Bitcoin]` section. This section houses the parameters for the
 Bitcoin chain. Also `lnd` also supports Litecoin, one is able to also specified
 (but not concurrently with Bitcoin!) the proper parameters, so `lnd` knows to
-be active on Litecoin's testnet4.
+be active on Litecoin's mainnet (or configure `litecoin.testnet=1` to use the
+testnet4).
 
 #### Accurate as of:
 roasbeef/btcd commit: 54362e17a5b80643ef1e12edc08895a2e2a1202b

--- a/lnd.go
+++ b/lnd.go
@@ -73,7 +73,8 @@ func lndMain() error {
 	// Set the RPC config from the "home" chain. Multi-chain isn't yet
 	// active, so we'll restrict usage to a particular chain for now.
 	homeChainConfig := cfg.Bitcoin
-	if registeredChains.PrimaryChain() == litecoinChain {
+	if registeredChains.PrimaryChain() == litecoinChain ||
+		registeredChains.PrimaryChain() == litecointestChain {
 		homeChainConfig = cfg.Litecoin
 	}
 	ltndLog.Infof("Primary chain is set to: %v",

--- a/params.go
+++ b/params.go
@@ -45,29 +45,35 @@ var liteTestNetParams = litecoinNetParams{
 	rpcPort: "19334",
 }
 
+// liteMainNetParams contains parameters specific to the litecoin main net
+var liteMainNetParams = litecoinNetParams{
+	Params:  &litecoinCfg.MainNetParams,
+	rpcPort: "8334",
+}
+
 // applyLitecoinParams applies the relevant chain configuration parameters that
 // differ for litecoin to the chain parameters typed for btcsuite derivation.
 // This function is used in place of using something like interface{} to
 // abstract over _which_ chain (or fork) the parameters are for.
-func applyLitecoinParams(params *bitcoinNetParams) {
-	params.Name = liteTestNetParams.Name
-	params.Net = wire.BitcoinNet(liteTestNetParams.Net)
-	params.DefaultPort = liteTestNetParams.DefaultPort
-	params.CoinbaseMaturity = liteTestNetParams.CoinbaseMaturity
+func applyLitecoinParams(params *bitcoinNetParams, ltcParams *litecoinNetParams) {
+	params.Name = ltcParams.Name
+	params.Net = wire.BitcoinNet(ltcParams.Net)
+	params.DefaultPort = ltcParams.DefaultPort
+	params.CoinbaseMaturity = ltcParams.CoinbaseMaturity
 
-	copy(params.GenesisHash[:], liteTestNetParams.GenesisHash[:])
+	copy(params.GenesisHash[:], ltcParams.GenesisHash[:])
 
 	// Address encoding magics
-	params.PubKeyHashAddrID = liteTestNetParams.PubKeyHashAddrID
-	params.ScriptHashAddrID = liteTestNetParams.ScriptHashAddrID
-	params.PrivateKeyID = liteTestNetParams.PrivateKeyID
-	params.WitnessPubKeyHashAddrID = liteTestNetParams.WitnessPubKeyHashAddrID
-	params.WitnessScriptHashAddrID = liteTestNetParams.WitnessScriptHashAddrID
+	params.PubKeyHashAddrID = ltcParams.PubKeyHashAddrID
+	params.ScriptHashAddrID = ltcParams.ScriptHashAddrID
+	params.PrivateKeyID = ltcParams.PrivateKeyID
+	params.WitnessPubKeyHashAddrID = ltcParams.WitnessPubKeyHashAddrID
+	params.WitnessScriptHashAddrID = ltcParams.WitnessScriptHashAddrID
 
-	copy(params.HDPrivateKeyID[:], liteTestNetParams.HDPrivateKeyID[:])
-	copy(params.HDPublicKeyID[:], liteTestNetParams.HDPublicKeyID[:])
+	copy(params.HDPrivateKeyID[:], ltcParams.HDPrivateKeyID[:])
+	copy(params.HDPublicKeyID[:], ltcParams.HDPublicKeyID[:])
 
-	params.HDCoinType = liteTestNetParams.HDCoinType
+	params.HDCoinType = ltcParams.HDCoinType
 
-	params.rpcPort = liteTestNetParams.rpcPort
+	params.rpcPort = ltcParams.rpcPort
 }


### PR DESCRIPTION
 - Rename existing litecoin vars to litecointest.
 - Add litecoin mainnet chain params

(This is a first step; lnd doesn't work yet with litecoin (mainnet or testnet) because it relies on `roasbeef/btcwallet`, which links to the wrong net params).