### PR TITLE
Add a command line arg that allows users to specify the REST port

### DIFF
--- a/config.go
+++ b/config.go
@@ -26,6 +26,7 @@ const (
 	defaultLogDirname         = "logs"
 	defaultLogFilename        = "lnd.log"
 	defaultRPCPort            = 10009
+	defaultRESTPort           = 8080
 	defaultPeerPort           = 5656
 	defaultRPCHost            = "localhost"
 	defaultMaxPendingChannels = 1
@@ -87,6 +88,7 @@ type config struct {
 
 	PeerPort           int  `long:"peerport" description:"The port to listen on for incoming p2p connections"`
 	RPCPort            int  `long:"rpcport" description:"The port for the rpc server"`
+	RESTPort           int  `long:"restport" description:"The port for the REST server"`
 	DebugHTLC          bool `long:"debughtlc" description:"Activate the debug htlc mode. With the debug HTLC mode, all payments sent use a pre-determined R-Hash. Additionally, all HTLCs sent to a node with the debug HTLC R-Hash are immediately settled in the next available state transition."`
 	MaxPendingChannels int  `long:"maxpendingchannels" description:"The maximum number of incoming pending channels permitted per peer."`
 
@@ -112,6 +114,7 @@ func loadConfig() (*config, error) {
 		LogDir:             defaultLogDir,
 		PeerPort:           defaultPeerPort,
 		RPCPort:            defaultRPCPort,
+		RESTPort:           defaultRESTPort,
 		MaxPendingChannels: defaultMaxPendingChannels,
 		Bitcoin: &chainConfig{
 			RPCHost: defaultRPCHost,

--- a/lnd.go
+++ b/lnd.go
@@ -196,8 +196,9 @@ func lndMain() error {
 		return err
 	}
 	go func() {
-		rpcsLog.Infof("gRPC proxy started")
-		http.ListenAndServe(":8080", mux)
+		restEndpoint := fmt.Sprintf(":%d", loadedConfig.RESTPort)
+		rpcsLog.Infof("gRPC proxy started at localhost%s", restEndpoint)
+		http.ListenAndServe(restEndpoint, mux)
 	}()
 
 	// If we're not in simnet mode, We'll wait until we're fully synced to


### PR DESCRIPTION
- Still use port `8080` by default