### PR TITLE
Add update_fee message as specified in BOLT2

### DIFF
--- a/channeldb/channel.go
+++ b/channeldb/channel.go
@@ -428,6 +428,7 @@ func (c *OpenChannel) UpdateCommitment(newCommitment *wire.MsgTx,
 		c.NumUpdates = delta.UpdateNum
 		c.Htlcs = delta.Htlcs
 		c.CommitFee = delta.CommitFee
+		c.FeePerKw = delta.FeePerKw
 
 		// First we'll write out the current latest dynamic channel
 		// state: the current channel balance, the number of updates,
@@ -443,6 +444,9 @@ func (c *OpenChannel) UpdateCommitment(newCommitment *wire.MsgTx,
 			return err
 		}
 		if err := putChanCommitFee(chanBucket, c); err != nil {
+			return err
+		}
+		if err := putChanFeePerKw(chanBucket, c); err != nil {
 			return err
 		}
 		if err := putChanCommitTxns(nodeChanBucket, c); err != nil {
@@ -516,6 +520,10 @@ type ChannelDelta struct {
 	// CommitFee is the fee that has been subtracted from the channel
 	// initiator's balance at this point in the commitment chain.
 	CommitFee btcutil.Amount
+
+	// FeePerKw is the fee per kw used to calculate the commit fee at this point
+	// in the commit chain.
+	FeePerKw btcutil.Amount
 
 	// UpdateNum is the update number that this ChannelDelta represents the
 	// total number of commitment updates to this point. This can be viewed
@@ -2206,6 +2214,11 @@ func serializeChannelDelta(w io.Writer, delta *ChannelDelta) error {
 		return err
 	}
 
+	byteOrder.PutUint64(scratch[:], uint64(delta.FeePerKw))
+	if _, err := w.Write(scratch[:]); err != nil {
+		return err
+	}
+
 	return nil
 }
 
@@ -2248,6 +2261,11 @@ func deserializeChannelDelta(r io.Reader) (*ChannelDelta, error) {
 		return nil, err
 	}
 	delta.CommitFee = btcutil.Amount(byteOrder.Uint64(scratch[:]))
+
+	if _, err := r.Read(scratch[:]); err != nil {
+		return nil, err
+	}
+	delta.FeePerKw = btcutil.Amount(byteOrder.Uint64(scratch[:]))
 
 	return delta, nil
 }

--- a/htlcswitch/link_test.go
+++ b/htlcswitch/link_test.go
@@ -252,7 +252,7 @@ func TestChannelLinkBidirectionalOneHopPayments(t *testing.T) {
 }
 
 // TestChannelLinkMultiHopPayment checks the ability to send payment over two
-// hopes. In this test we send the payment from Carol to Alice over Bob peer.
+// hops. In this test we send the payment from Carol to Alice over Bob peer.
 // (Carol -> Bob -> Alice) and checking that HTLC was settled properly and
 // balances were changed in two channels.
 func TestChannelLinkMultiHopPayment(t *testing.T) {

--- a/lnwire/lnwire_test.go
+++ b/lnwire/lnwire_test.go
@@ -524,6 +524,12 @@ func TestLightningWireProtocol(t *testing.T) {
 			},
 		},
 		{
+			msgType: MsgUpdateFee,
+			scenario: func(m UpdateFee) bool {
+				return mainScenario(&m)
+			},
+		},
+		{
 			msgType: MsgChannelAnnouncement,
 			scenario: func(m ChannelAnnouncement) bool {
 				return mainScenario(&m)

--- a/lnwire/message.go
+++ b/lnwire/message.go
@@ -39,6 +39,7 @@ const (
 	MsgUpdateFailHTLC                        = 131
 	MsgCommitSig                             = 132
 	MsgRevokeAndAck                          = 133
+	MsgUpdateFee                             = 137
 	MsgChannelAnnouncement                   = 256
 	MsgNodeAnnouncement                      = 257
 	MsgChannelUpdate                         = 258
@@ -149,6 +150,8 @@ func makeEmptyMessage(msgType MessageType) (Message, error) {
 		msg = &CommitSig{}
 	case MsgRevokeAndAck:
 		msg = &RevokeAndAck{}
+	case MsgUpdateFee:
+		msg = &UpdateFee{}
 	case MsgError:
 		msg = &Error{}
 	case MsgChannelAnnouncement:

--- a/lnwire/update_fee.go
+++ b/lnwire/update_fee.go
@@ -1,0 +1,69 @@
+package lnwire
+
+import (
+	"io"
+
+	"github.com/roasbeef/btcutil"
+)
+
+// UpdateFee is the message the channel initiator sends to the other peer if
+// the channel commitment fee needs to be updated.
+type UpdateFee struct {
+	// ChanID is the channel that this UpdateFee is meant for.
+	ChanID ChannelID
+
+	// FeePerKw is the fee-per-kw on commit transactions that the sender of
+	// this message wants to use for this channel.
+	FeePerKw btcutil.Amount
+}
+
+// NewUpdateFee creates a new UpdateFee message.
+func NewUpdateFee(chanID ChannelID, feePerKw btcutil.Amount) *UpdateFee {
+	return &UpdateFee{
+		ChanID:   chanID,
+		FeePerKw: feePerKw,
+	}
+}
+
+// A compile time check to ensure UpdateFee implements the lnwire.Message
+// interface.
+var _ Message = (*UpdateFee)(nil)
+
+// Decode deserializes a serialized UpdateFee message stored in the
+// passed io.Reader observing the specified protocol version.
+//
+// This is part of the lnwire.Message interface.
+func (c *UpdateFee) Decode(r io.Reader, pver uint32) error {
+	return readElements(r,
+		&c.ChanID,
+		&c.FeePerKw,
+	)
+}
+
+// Encode serializes the target UpdateFee into the passed io.Writer
+// observing the protocol version specified.
+//
+// This is part of the lnwire.Message interface.
+func (c *UpdateFee) Encode(w io.Writer, pver uint32) error {
+	return writeElements(w,
+		c.ChanID,
+		c.FeePerKw,
+	)
+}
+
+// MsgType returns the integer uniquely identifying this message type on the
+// wire.
+//
+// This is part of the lnwire.Message interface.
+func (c *UpdateFee) MsgType() MessageType {
+	return MsgUpdateFee
+}
+
+// MaxPayloadLength returns the maximum allowed payload size for a
+// UpdateFee complete message observing the specified protocol version.
+//
+// This is part of the lnwire.Message interface.
+func (c *UpdateFee) MaxPayloadLength(uint32) uint32 {
+	// 32 + 8
+	return 40
+}

--- a/peer.go
+++ b/peer.go
@@ -473,6 +473,9 @@ out:
 		case *lnwire.CommitSig:
 			isChanUpdate = true
 			targetChan = msg.ChanID
+		case *lnwire.UpdateFee:
+			isChanUpdate = true
+			targetChan = msg.ChanID
 
 		case *lnwire.ChannelUpdate,
 			*lnwire.ChannelAnnouncement,


### PR DESCRIPTION
This PR adds support for sending and receiving the `update_fee` message specified in BOLT#2.

It does not currently implement the actual logic for when to send this message.

TODO:
- [x] Add tests for `channelLink` code