### PR TITLE
htlcswitch: increase payment timeout in bydirectional unit test

### DIFF
--- a/htlcswitch/test_utils.go
+++ b/htlcswitch/test_utils.go
@@ -425,7 +425,7 @@ func (n *threeHopNetwork) makePayment(sendingPeer, receivingPeer Peer,
 	select {
 	case err := <-errChan:
 		return invoice, err
-	case <-time.After(12 * time.Second):
+	case <-time.After(20 * time.Second):
 		return invoice, errors.New("htlc was not settled in time")
 	}
 }


### PR DESCRIPTION
During travis tests the latency of payment might lead to test failure,
for that reason we increase the waiting timeout.