### PR TITLE
Add fee negotiation on channel cooperative shutdown.

### DIFF
--- a/fundingmanager_test.go
+++ b/fundingmanager_test.go
@@ -22,13 +22,9 @@ import (
 	_ "github.com/roasbeef/btcwallet/walletdb/bdb"
 
 	"github.com/roasbeef/btcd/btcec"
-	"github.com/roasbeef/btcd/txscript"
 	"github.com/roasbeef/btcd/wire"
 	"github.com/roasbeef/btcutil"
 )
-
-// The block height returned by the mock BlockChainIO's GetBestBlock.
-const fundingBroadcastHeight = 123
 
 var (
 	privPass = []byte("dummy-pass")
@@ -69,143 +65,6 @@ var (
 		Address:     bobTCPAddr,
 	}
 )
-
-// mockWalletController is used by the LightningWallet, and let us mock the
-// interaction with the bitcoin network.
-type mockWalletController struct {
-	rootKey               *btcec.PrivateKey
-	prevAddres            btcutil.Address
-	publishedTransactions chan *wire.MsgTx
-}
-
-// FetchInputInfo will be called to get info about the inputs to the funding
-// transaction.
-func (*mockWalletController) FetchInputInfo(
-	prevOut *wire.OutPoint) (*wire.TxOut, error) {
-	txOut := &wire.TxOut{
-		Value:    int64(10 * btcutil.SatoshiPerBitcoin),
-		PkScript: []byte("dummy"),
-	}
-	return txOut, nil
-}
-func (*mockWalletController) ConfirmedBalance(confs int32,
-	witness bool) (btcutil.Amount, error) {
-	return 0, nil
-}
-
-// NewAddress is called to get new addresses for delivery, change etc.
-func (m *mockWalletController) NewAddress(addrType lnwallet.AddressType,
-	change bool) (btcutil.Address, error) {
-	addr, _ := btcutil.NewAddressPubKey(
-		m.rootKey.PubKey().SerializeCompressed(), &chaincfg.MainNetParams)
-	return addr, nil
-}
-func (*mockWalletController) GetPrivKey(a btcutil.Address) (*btcec.PrivateKey, error) {
-	return nil, nil
-}
-
-// NewRawKey will be called to get keys to be used for the funding tx and the
-// commitment tx.
-func (m *mockWalletController) NewRawKey() (*btcec.PublicKey, error) {
-	return m.rootKey.PubKey(), nil
-}
-
-// FetchRootKey will be called to provide the wallet with a root key.
-func (m *mockWalletController) FetchRootKey() (*btcec.PrivateKey, error) {
-	return m.rootKey, nil
-}
-func (*mockWalletController) SendOutputs(outputs []*wire.TxOut) (*chainhash.Hash, error) {
-	return nil, nil
-}
-
-// ListUnspentWitness is called by the wallet when doing coin selection. We just
-// need one unspent for the funding transaction.
-func (*mockWalletController) ListUnspentWitness(confirms int32) ([]*lnwallet.Utxo, error) {
-	utxo := &lnwallet.Utxo{
-		Value: btcutil.Amount(10 * btcutil.SatoshiPerBitcoin),
-		OutPoint: wire.OutPoint{
-			Hash:  chainhash.Hash{},
-			Index: 0,
-		},
-	}
-	var ret []*lnwallet.Utxo
-	ret = append(ret, utxo)
-	return ret, nil
-}
-func (*mockWalletController) ListTransactionDetails() ([]*lnwallet.TransactionDetail, error) {
-	return nil, nil
-}
-func (*mockWalletController) LockOutpoint(o wire.OutPoint)   {}
-func (*mockWalletController) UnlockOutpoint(o wire.OutPoint) {}
-func (m *mockWalletController) PublishTransaction(tx *wire.MsgTx) error {
-	m.publishedTransactions <- tx
-	return nil
-}
-func (*mockWalletController) SubscribeTransactions() (lnwallet.TransactionSubscription, error) {
-	return nil, nil
-}
-func (*mockWalletController) IsSynced() (bool, error) {
-	return true, nil
-}
-func (*mockWalletController) Start() error {
-	return nil
-}
-func (*mockWalletController) Stop() error {
-	return nil
-}
-
-type mockSigner struct {
-	key *btcec.PrivateKey
-}
-
-func (m *mockSigner) SignOutputRaw(tx *wire.MsgTx,
-	signDesc *lnwallet.SignDescriptor) ([]byte, error) {
-	amt := signDesc.Output.Value
-	witnessScript := signDesc.WitnessScript
-	privKey := m.key
-
-	sig, err := txscript.RawTxInWitnessSignature(tx, signDesc.SigHashes,
-		signDesc.InputIndex, amt, witnessScript, txscript.SigHashAll,
-		privKey)
-	if err != nil {
-		return nil, err
-	}
-
-	return sig[:len(sig)-1], nil
-}
-
-func (m *mockSigner) ComputeInputScript(tx *wire.MsgTx,
-	signDesc *lnwallet.SignDescriptor) (*lnwallet.InputScript, error) {
-	witnessScript, err := txscript.WitnessScript(tx, signDesc.SigHashes,
-		signDesc.InputIndex, signDesc.Output.Value,
-		signDesc.Output.PkScript, txscript.SigHashAll, m.key, true)
-	if err != nil {
-		return nil, err
-	}
-
-	return &lnwallet.InputScript{
-		Witness: witnessScript,
-	}, nil
-}
-
-type mockChainIO struct{}
-
-func (*mockChainIO) GetBestBlock() (*chainhash.Hash, int32, error) {
-	return activeNetParams.GenesisHash, fundingBroadcastHeight, nil
-}
-
-func (*mockChainIO) GetUtxo(op *wire.OutPoint,
-	heightHint uint32) (*wire.TxOut, error) {
-	return nil, nil
-}
-
-func (*mockChainIO) GetBlockHash(blockHeight int64) (*chainhash.Hash, error) {
-	return nil, nil
-}
-
-func (*mockChainIO) GetBlock(blockHash *chainhash.Hash) (*wire.MsgBlock, error) {
-	return nil, nil
-}
 
 type mockNotifier struct {
 	confChannel chan *chainntnfs.TxConfirmation
@@ -250,7 +109,7 @@ type testNode struct {
 	testDir      string
 }
 
-func disableLogger(t *testing.T) {
+func disableFndgLogger(t *testing.T) {
 	channeldb.UseLogger(btclog.Disabled)
 	lnwallet.UseLogger(btclog.Disabled)
 	fndgLog = btclog.Disabled
@@ -652,7 +511,7 @@ func openChannel(t *testing.T, alice, bob *testNode, localFundingAmt,
 }
 
 func TestFundingManagerNormalWorkflow(t *testing.T) {
-	disableLogger(t)
+	disableFndgLogger(t)
 
 	shutdownChannel := make(chan struct{})
 
@@ -860,7 +719,7 @@ func TestFundingManagerNormalWorkflow(t *testing.T) {
 }
 
 func TestFundingManagerRestartBehavior(t *testing.T) {
-	disableLogger(t)
+	disableFndgLogger(t)
 
 	shutdownChannel := make(chan struct{})
 
@@ -1095,7 +954,7 @@ func TestFundingManagerRestartBehavior(t *testing.T) {
 }
 
 func TestFundingManagerFundingTimeout(t *testing.T) {
-	disableLogger(t)
+	disableFndgLogger(t)
 
 	shutdownChannel := make(chan struct{})
 

--- a/lnwallet/channel_test.go
+++ b/lnwallet/channel_test.go
@@ -737,17 +737,19 @@ func TestCooperativeChannelClosure(t *testing.T) {
 	bobFeeRate := uint64(bobChannel.channelState.FeePerKw)
 
 	// We'll store with both Alice and Bob creating a new close proposal
-	// with the same fee rate.
+	// with the same fee.
+	aliceFee := aliceChannel.CalcFee(aliceFeeRate)
 	aliceSig, _, err := aliceChannel.CreateCloseProposal(
-		aliceFeeRate, aliceDeliveryScript, bobDeliveryScript,
+		aliceFee, aliceDeliveryScript, bobDeliveryScript,
 	)
 	if err != nil {
 		t.Fatalf("unable to create alice coop close proposal: %v", err)
 	}
 	aliceCloseSig := append(aliceSig, byte(txscript.SigHashAll))
 
+	bobFee := bobChannel.CalcFee(bobFeeRate)
 	bobSig, _, err := bobChannel.CreateCloseProposal(
-		bobFeeRate, bobDeliveryScript, aliceDeliveryScript,
+		bobFee, bobDeliveryScript, aliceDeliveryScript,
 	)
 	if err != nil {
 		t.Fatalf("unable to create bob coop close proposal: %v", err)
@@ -759,7 +761,7 @@ func TestCooperativeChannelClosure(t *testing.T) {
 	// transaction is well formed, and the signatures verify.
 	aliceCloseTx, err := bobChannel.CompleteCooperativeClose(
 		bobCloseSig, aliceCloseSig, bobDeliveryScript,
-		aliceDeliveryScript, bobFeeRate)
+		aliceDeliveryScript, bobFee)
 	if err != nil {
 		t.Fatalf("unable to complete alice cooperative close: %v", err)
 	}
@@ -767,7 +769,7 @@ func TestCooperativeChannelClosure(t *testing.T) {
 
 	bobCloseTx, err := aliceChannel.CompleteCooperativeClose(
 		aliceCloseSig, bobCloseSig, aliceDeliveryScript,
-		bobDeliveryScript, aliceFeeRate)
+		bobDeliveryScript, aliceFee)
 	if err != nil {
 		t.Fatalf("unable to complete bob cooperative close: %v", err)
 	}
@@ -1590,14 +1592,16 @@ func TestCooperativeCloseDustAdherence(t *testing.T) {
 	// Both sides currently have over 1 BTC settled as part of their
 	// balances. As a result, performing a cooperative closure now result
 	// in both sides having an output within the closure transaction.
-	aliceSig, _, err := aliceChannel.CreateCloseProposal(aliceFeeRate,
+	aliceFee := aliceChannel.CalcFee(aliceFeeRate)
+	aliceSig, _, err := aliceChannel.CreateCloseProposal(aliceFee,
 		aliceDeliveryScript, bobDeliveryScript)
 	if err != nil {
 		t.Fatalf("unable to close channel: %v", err)
 	}
 	aliceCloseSig := append(aliceSig, byte(txscript.SigHashAll))
 
-	bobSig, _, err := bobChannel.CreateCloseProposal(bobFeeRate,
+	bobFee := bobChannel.CalcFee(bobFeeRate)
+	bobSig, _, err := bobChannel.CreateCloseProposal(bobFee,
 		bobDeliveryScript, aliceDeliveryScript)
 	if err != nil {
 		t.Fatalf("unable to close channel: %v", err)
@@ -1606,7 +1610,7 @@ func TestCooperativeCloseDustAdherence(t *testing.T) {
 
 	closeTx, err := bobChannel.CompleteCooperativeClose(
 		bobCloseSig, aliceCloseSig,
-		bobDeliveryScript, aliceDeliveryScript, bobFeeRate)
+		bobDeliveryScript, aliceDeliveryScript, bobFee)
 	if err != nil {
 		t.Fatalf("unable to accept channel close: %v", err)
 	}
@@ -1628,14 +1632,14 @@ func TestCooperativeCloseDustAdherence(t *testing.T) {
 
 	// Attempt another cooperative channel closure. It should succeed
 	// without any issues.
-	aliceSig, _, err = aliceChannel.CreateCloseProposal(aliceFeeRate,
+	aliceSig, _, err = aliceChannel.CreateCloseProposal(aliceFee,
 		aliceDeliveryScript, bobDeliveryScript)
 	if err != nil {
 		t.Fatalf("unable to close channel: %v", err)
 	}
 	aliceCloseSig = append(aliceSig, byte(txscript.SigHashAll))
 
-	bobSig, _, err = bobChannel.CreateCloseProposal(bobFeeRate,
+	bobSig, _, err = bobChannel.CreateCloseProposal(bobFee,
 		bobDeliveryScript, aliceDeliveryScript)
 	if err != nil {
 		t.Fatalf("unable to close channel: %v", err)
@@ -1644,7 +1648,7 @@ func TestCooperativeCloseDustAdherence(t *testing.T) {
 
 	closeTx, err = bobChannel.CompleteCooperativeClose(
 		bobCloseSig, aliceCloseSig,
-		bobDeliveryScript, aliceDeliveryScript, bobFeeRate)
+		bobDeliveryScript, aliceDeliveryScript, bobFee)
 	if err != nil {
 		t.Fatalf("unable to accept channel close: %v", err)
 	}
@@ -1667,14 +1671,14 @@ func TestCooperativeCloseDustAdherence(t *testing.T) {
 
 	// Our final attempt at another cooperative channel closure. It should
 	// succeed without any issues.
-	aliceSig, _, err = aliceChannel.CreateCloseProposal(aliceFeeRate,
+	aliceSig, _, err = aliceChannel.CreateCloseProposal(aliceFee,
 		aliceDeliveryScript, bobDeliveryScript)
 	if err != nil {
 		t.Fatalf("unable to close channel: %v", err)
 	}
 	aliceCloseSig = append(aliceSig, byte(txscript.SigHashAll))
 
-	bobSig, _, err = bobChannel.CreateCloseProposal(bobFeeRate,
+	bobSig, _, err = bobChannel.CreateCloseProposal(bobFee,
 		bobDeliveryScript, aliceDeliveryScript)
 	if err != nil {
 		t.Fatalf("unable to close channel: %v", err)
@@ -1683,7 +1687,7 @@ func TestCooperativeCloseDustAdherence(t *testing.T) {
 
 	closeTx, err = bobChannel.CompleteCooperativeClose(
 		bobCloseSig, aliceCloseSig,
-		bobDeliveryScript, aliceDeliveryScript, bobFeeRate)
+		bobDeliveryScript, aliceDeliveryScript, bobFee)
 	if err != nil {
 		t.Fatalf("unable to accept channel close: %v", err)
 	}

--- a/mock.go
+++ b/mock.go
@@ -1,0 +1,182 @@
+package main
+
+import (
+	"github.com/lightningnetwork/lnd/chainntnfs"
+	"github.com/lightningnetwork/lnd/lnwallet"
+	"github.com/roasbeef/btcd/btcec"
+	"github.com/roasbeef/btcd/chaincfg"
+	"github.com/roasbeef/btcd/chaincfg/chainhash"
+	"github.com/roasbeef/btcd/txscript"
+	"github.com/roasbeef/btcd/wire"
+	"github.com/roasbeef/btcutil"
+)
+
+// The block height returned by the mock BlockChainIO's GetBestBlock.
+const fundingBroadcastHeight = 123
+
+type mockSigner struct {
+	key *btcec.PrivateKey
+}
+
+func (m *mockSigner) SignOutputRaw(tx *wire.MsgTx,
+	signDesc *lnwallet.SignDescriptor) ([]byte, error) {
+	amt := signDesc.Output.Value
+	witnessScript := signDesc.WitnessScript
+	privKey := m.key
+
+	sig, err := txscript.RawTxInWitnessSignature(tx, signDesc.SigHashes,
+		signDesc.InputIndex, amt, witnessScript, txscript.SigHashAll,
+		privKey)
+	if err != nil {
+		return nil, err
+	}
+
+	return sig[:len(sig)-1], nil
+}
+
+func (m *mockSigner) ComputeInputScript(tx *wire.MsgTx,
+	signDesc *lnwallet.SignDescriptor) (*lnwallet.InputScript, error) {
+	witnessScript, err := txscript.WitnessScript(tx, signDesc.SigHashes,
+		signDesc.InputIndex, signDesc.Output.Value,
+		signDesc.Output.PkScript, txscript.SigHashAll, m.key, true)
+	if err != nil {
+		return nil, err
+	}
+
+	return &lnwallet.InputScript{
+		Witness: witnessScript,
+	}, nil
+}
+
+type mockNotfier struct {
+	confChannel chan *chainntnfs.TxConfirmation
+}
+
+func (m *mockNotfier) RegisterConfirmationsNtfn(txid *chainhash.Hash, numConfs,
+	heightHint uint32) (*chainntnfs.ConfirmationEvent, error) {
+	return &chainntnfs.ConfirmationEvent{
+		Confirmed: m.confChannel,
+	}, nil
+}
+func (m *mockNotfier) RegisterBlockEpochNtfn() (*chainntnfs.BlockEpochEvent,
+	error) {
+	return nil, nil
+}
+
+func (m *mockNotfier) Start() error {
+	return nil
+}
+
+func (m *mockNotfier) Stop() error {
+	return nil
+}
+func (m *mockNotfier) RegisterSpendNtfn(outpoint *wire.OutPoint,
+	heightHint uint32) (*chainntnfs.SpendEvent, error) {
+	return &chainntnfs.SpendEvent{
+		Spend:  make(chan *chainntnfs.SpendDetail),
+		Cancel: func() {},
+	}, nil
+}
+
+type mockChainIO struct{}
+
+func (*mockChainIO) GetBestBlock() (*chainhash.Hash, int32, error) {
+	return activeNetParams.GenesisHash, fundingBroadcastHeight, nil
+}
+
+func (*mockChainIO) GetUtxo(op *wire.OutPoint,
+	heightHint uint32) (*wire.TxOut, error) {
+	return nil, nil
+}
+
+func (*mockChainIO) GetBlockHash(blockHeight int64) (*chainhash.Hash, error) {
+	return nil, nil
+}
+
+func (*mockChainIO) GetBlock(blockHash *chainhash.Hash) (*wire.MsgBlock, error) {
+	return nil, nil
+}
+
+// mockWalletController is used by the LightningWallet, and let us mock the
+// interaction with the bitcoin network.
+type mockWalletController struct {
+	rootKey               *btcec.PrivateKey
+	prevAddres            btcutil.Address
+	publishedTransactions chan *wire.MsgTx
+}
+
+// FetchInputInfo will be called to get info about the inputs to the funding
+// transaction.
+func (*mockWalletController) FetchInputInfo(
+	prevOut *wire.OutPoint) (*wire.TxOut, error) {
+	txOut := &wire.TxOut{
+		Value:    int64(10 * btcutil.SatoshiPerBitcoin),
+		PkScript: []byte("dummy"),
+	}
+	return txOut, nil
+}
+func (*mockWalletController) ConfirmedBalance(confs int32,
+	witness bool) (btcutil.Amount, error) {
+	return 0, nil
+}
+
+// NewAddress is called to get new addresses for delivery, change etc.
+func (m *mockWalletController) NewAddress(addrType lnwallet.AddressType,
+	change bool) (btcutil.Address, error) {
+	addr, _ := btcutil.NewAddressPubKey(
+		m.rootKey.PubKey().SerializeCompressed(), &chaincfg.MainNetParams)
+	return addr, nil
+}
+func (*mockWalletController) GetPrivKey(a btcutil.Address) (*btcec.PrivateKey, error) {
+	return nil, nil
+}
+
+// NewRawKey will be called to get keys to be used for the funding tx and the
+// commitment tx.
+func (m *mockWalletController) NewRawKey() (*btcec.PublicKey, error) {
+	return m.rootKey.PubKey(), nil
+}
+
+// FetchRootKey will be called to provide the wallet with a root key.
+func (m *mockWalletController) FetchRootKey() (*btcec.PrivateKey, error) {
+	return m.rootKey, nil
+}
+func (*mockWalletController) SendOutputs(outputs []*wire.TxOut) (*chainhash.Hash, error) {
+	return nil, nil
+}
+
+// ListUnspentWitness is called by the wallet when doing coin selection. We just
+// need one unspent for the funding transaction.
+func (*mockWalletController) ListUnspentWitness(confirms int32) ([]*lnwallet.Utxo, error) {
+	utxo := &lnwallet.Utxo{
+		Value: btcutil.Amount(10 * btcutil.SatoshiPerBitcoin),
+		OutPoint: wire.OutPoint{
+			Hash:  chainhash.Hash{},
+			Index: 0,
+		},
+	}
+	var ret []*lnwallet.Utxo
+	ret = append(ret, utxo)
+	return ret, nil
+}
+func (*mockWalletController) ListTransactionDetails() ([]*lnwallet.TransactionDetail, error) {
+	return nil, nil
+}
+func (*mockWalletController) LockOutpoint(o wire.OutPoint)   {}
+func (*mockWalletController) UnlockOutpoint(o wire.OutPoint) {}
+func (m *mockWalletController) PublishTransaction(tx *wire.MsgTx) error {
+	m.publishedTransactions <- tx
+	return nil
+}
+func (*mockWalletController) SubscribeTransactions() (lnwallet.TransactionSubscription, error) {
+	return nil, nil
+}
+func (*mockWalletController) IsSynced() (bool, error) {
+	return true, nil
+}
+func (*mockWalletController) Start() error {
+	return nil
+}
+func (*mockWalletController) Stop() error {
+	return nil
+}

--- a/peer_test.go
+++ b/peer_test.go
@@ -1,1 +1,521 @@
 package main
+
+import (
+	"testing"
+	"time"
+
+	"github.com/btcsuite/btclog"
+	"github.com/lightningnetwork/lnd/chainntnfs"
+	"github.com/lightningnetwork/lnd/channeldb"
+	"github.com/lightningnetwork/lnd/htlcswitch"
+	"github.com/lightningnetwork/lnd/lnrpc"
+	"github.com/lightningnetwork/lnd/lnwallet"
+	"github.com/lightningnetwork/lnd/lnwire"
+	"github.com/roasbeef/btcd/btcec"
+	"github.com/roasbeef/btcd/txscript"
+	"github.com/roasbeef/btcd/wire"
+)
+
+func disablePeerLogger(t *testing.T) {
+	peerLog = btclog.Disabled
+	srvrLog = btclog.Disabled
+	lnwallet.UseLogger(btclog.Disabled)
+	htlcswitch.UseLogger(btclog.Disabled)
+	channeldb.UseLogger(btclog.Disabled)
+}
+
+// TestPeerChannelClosureAcceptFeeResponder tests the shutdown responder's
+// behavior if we can agree on the fee immediately.
+func TestPeerChannelClosureAcceptFeeResponder(t *testing.T) {
+	disablePeerLogger(t)
+	t.Parallel()
+
+	notifier := &mockNotfier{
+		confChannel: make(chan *chainntnfs.TxConfirmation),
+	}
+	broadcastTxChan := make(chan *wire.MsgTx)
+
+	responder, responderChan, initiatorChan, cleanUp, err := createTestPeer(
+		notifier, broadcastTxChan)
+	if err != nil {
+		t.Fatalf("unable to create test channels: %v", err)
+	}
+	defer cleanUp()
+
+	chanID := lnwire.NewChanIDFromOutPoint(responderChan.ChannelPoint())
+
+	// We send a shutdown request to Alice. She will now be the responding
+	// node in this shutdown procedure. We first expect Alice to answer this
+	// shutdown request with a Shutdown message.
+	responder.shutdownChanReqs <- lnwire.NewShutdown(chanID, dummyDeliveryScript)
+
+	var msg lnwire.Message
+	select {
+	case outMsg := <-responder.outgoingQueue:
+		msg = outMsg.msg
+	case <-time.After(time.Second * 5):
+		t.Fatalf("did not receive shutdown message")
+	}
+
+	shutdownMsg, ok := msg.(*lnwire.Shutdown)
+	if !ok {
+		t.Fatalf("expected Shutdown message, got %T", msg)
+	}
+
+	respDeliveryScript := shutdownMsg.Address
+
+	// Alice will thereafter send a ClosingSigned message, indicating her
+	// proposed closing transaction fee.
+	select {
+	case outMsg := <-responder.outgoingQueue:
+		msg = outMsg.msg
+	case <-time.After(time.Second * 5):
+		t.Fatalf("did not receive ClosingSigned message")
+	}
+
+	responderClosingSigned, ok := msg.(*lnwire.ClosingSigned)
+	if !ok {
+		t.Fatalf("expected ClosingSigned message, got %T", msg)
+	}
+
+	// We accept the fee, and send a ClosingSigned with the same fee back,
+	// so she knows we agreed.
+	peerFee := responderClosingSigned.FeeSatoshis
+	initiatorSig, proposedFee, err := initiatorChan.CreateCloseProposal(
+		peerFee, dummyDeliveryScript, respDeliveryScript)
+	if err != nil {
+		t.Fatalf("error creating close proposal: %v", err)
+	}
+
+	initSig := append(initiatorSig, byte(txscript.SigHashAll))
+	parsedSig, err := btcec.ParseSignature(initSig, btcec.S256())
+	if err != nil {
+		t.Fatalf("error parsing signature: %v", err)
+	}
+	closingSigned := lnwire.NewClosingSigned(chanID, proposedFee, parsedSig)
+	responder.closingSignedChanReqs <- closingSigned
+
+	// The responder will now see that we agreed on the fee, and broadcast
+	// the closing transaction.
+	select {
+	case <-broadcastTxChan:
+	case <-time.After(time.Second * 5):
+		t.Fatalf("closing tx not broadcast")
+	}
+
+	// And the initiator should be waiting for a confirmation notification.
+	notifier.confChannel <- &chainntnfs.TxConfirmation{}
+}
+
+// TestPeerChannelClosureAcceptFeeInitiator tests the shutdown initiator's
+// behavior if we can agree on the fee immediately.
+func TestPeerChannelClosureAcceptFeeInitiator(t *testing.T) {
+	disablePeerLogger(t)
+	t.Parallel()
+
+	notifier := &mockNotfier{
+		confChannel: make(chan *chainntnfs.TxConfirmation),
+	}
+	broadcastTxChan := make(chan *wire.MsgTx)
+
+	initiator, initiatorChan, responderChan, cleanUp, err := createTestPeer(
+		notifier, broadcastTxChan)
+	if err != nil {
+		t.Fatalf("unable to create test channels: %v", err)
+	}
+	defer cleanUp()
+
+	// We make the initiator send a shutdown request.
+	updateChan := make(chan *lnrpc.CloseStatusUpdate, 1)
+	errChan := make(chan error, 1)
+	closeCommand := &htlcswitch.ChanClose{
+		CloseType: htlcswitch.CloseRegular,
+		ChanPoint: initiatorChan.ChannelPoint(),
+		Updates:   updateChan,
+		Err:       errChan,
+	}
+	initiator.localCloseChanReqs <- closeCommand
+
+	// We should now be getting the shutdown request.
+	var msg lnwire.Message
+	select {
+	case outMsg := <-initiator.outgoingQueue:
+		msg = outMsg.msg
+	case <-time.After(time.Second * 5):
+		t.Fatalf("did not receive shutdown request")
+	}
+
+	shutdownMsg, ok := msg.(*lnwire.Shutdown)
+	if !ok {
+		t.Fatalf("expected Shutdown message, got %T", msg)
+	}
+
+	initiatorDeliveryScript := shutdownMsg.Address
+
+	// We'll answer the shutdown message with our own Shutdown, and then a
+	// ClosingSigned message.
+	chanID := shutdownMsg.ChannelID
+	initiator.shutdownChanReqs <- lnwire.NewShutdown(chanID,
+		dummyDeliveryScript)
+
+	estimator := lnwallet.StaticFeeEstimator{FeeRate: 50}
+	feeRate := estimator.EstimateFeePerWeight(1) * 1000
+	fee := responderChan.CalcFee(feeRate)
+	closeSig, proposedFee, err := responderChan.CreateCloseProposal(fee,
+		dummyDeliveryScript, initiatorDeliveryScript)
+	if err != nil {
+		t.Fatalf("unable to create close proposal: %v", err)
+	}
+	parsedSig, err := btcec.ParseSignature(closeSig, btcec.S256())
+	if err != nil {
+		t.Fatalf("unable to parse signature: %v", err)
+	}
+
+	closingSigned := lnwire.NewClosingSigned(shutdownMsg.ChannelID,
+		proposedFee, parsedSig)
+	initiator.closingSignedChanReqs <- closingSigned
+
+	// And we expect the initiator to accept the fee, and broadcast the
+	// closing transaction.
+	select {
+	case outMsg := <-initiator.outgoingQueue:
+		msg = outMsg.msg
+	case <-time.After(time.Second * 5):
+		t.Fatalf("did not receive closing signed message")
+	}
+
+	closingSignedMsg, ok := msg.(*lnwire.ClosingSigned)
+	if !ok {
+		t.Fatalf("expected ClosingSigned message, got %T", msg)
+	}
+
+	if closingSignedMsg.FeeSatoshis != proposedFee {
+		t.Fatalf("expected ClosingSigned fee to be %v, instead got %v",
+			proposedFee, closingSignedMsg.FeeSatoshis)
+	}
+
+	// The initiator will now see that we agreed on the fee, and broadcast
+	// the closing transaction.
+	select {
+	case <-broadcastTxChan:
+	case <-time.After(time.Second * 5):
+		t.Fatalf("closing tx not broadcast")
+	}
+
+	// And the initiator should be waiting for a confirmation notification.
+	notifier.confChannel <- &chainntnfs.TxConfirmation{}
+}
+
+// TestPeerChannelClosureFeeNegotiationsResponder tests the shutdown responder's
+// behavior in the case where we must do several rounds of fee negotiation
+// before we agree on a fee.
+func TestPeerChannelClosureFeeNegotiationsResponder(t *testing.T) {
+	disablePeerLogger(t)
+	t.Parallel()
+
+	notifier := &mockNotfier{
+		confChannel: make(chan *chainntnfs.TxConfirmation),
+	}
+	broadcastTxChan := make(chan *wire.MsgTx)
+
+	responder, responderChan, initiatorChan, cleanUp, err := createTestPeer(
+		notifier, broadcastTxChan)
+	if err != nil {
+		t.Fatalf("unable to create test channels: %v", err)
+	}
+	defer cleanUp()
+
+	chanID := lnwire.NewChanIDFromOutPoint(responderChan.ChannelPoint())
+
+	// We send a shutdown request to Alice. She will now be the responding
+	// node in this shutdown procedure. We first expect Alice to answer this
+	// shutdown request with a Shutdown message.
+	responder.shutdownChanReqs <- lnwire.NewShutdown(chanID,
+		dummyDeliveryScript)
+
+	var msg lnwire.Message
+	select {
+	case outMsg := <-responder.outgoingQueue:
+		msg = outMsg.msg
+	case <-time.After(time.Second * 5):
+		t.Fatalf("did not receive shutdown message")
+	}
+
+	shutdownMsg, ok := msg.(*lnwire.Shutdown)
+	if !ok {
+		t.Fatalf("expected Shutdown message, got %T", msg)
+	}
+
+	respDeliveryScript := shutdownMsg.Address
+
+	// Alice will thereafter send a ClosingSigned message, indicating her
+	// proposed closing transaction fee.
+	select {
+	case outMsg := <-responder.outgoingQueue:
+		msg = outMsg.msg
+	case <-time.After(time.Second * 5):
+		t.Fatalf("did not receive closing signed message")
+	}
+
+	responderClosingSigned, ok := msg.(*lnwire.ClosingSigned)
+	if !ok {
+		t.Fatalf("expected ClosingSigned message, got %T", msg)
+	}
+
+	// We don't agree with the fee, and will send back one that's 2.5x.
+	preferredRespFee := responderClosingSigned.FeeSatoshis
+	increasedFee := uint64(float64(preferredRespFee) * 2.5)
+	initiatorSig, proposedFee, err := initiatorChan.CreateCloseProposal(
+		increasedFee, dummyDeliveryScript, respDeliveryScript,
+	)
+	if err != nil {
+		t.Fatalf("error creating close proposal: %v", err)
+	}
+
+	parsedSig, err := btcec.ParseSignature(initiatorSig, btcec.S256())
+	if err != nil {
+		t.Fatalf("error parsing signature: %v", err)
+	}
+	closingSigned := lnwire.NewClosingSigned(chanID, proposedFee, parsedSig)
+	responder.closingSignedChanReqs <- closingSigned
+
+	// The responder will see the new fee we propose, but with current
+	// settings wont't accept anything over 2*FeeRate. We should get a new
+	// proposal back, which should have the average fee rate proposed.
+	select {
+	case outMsg := <-responder.outgoingQueue:
+		msg = outMsg.msg
+	case <-time.After(time.Second * 5):
+		t.Fatalf("did not receive closing signed message")
+	}
+
+	responderClosingSigned, ok = msg.(*lnwire.ClosingSigned)
+	if !ok {
+		t.Fatalf("expected ClosingSigned message, got %T", msg)
+	}
+
+	avgFee := (preferredRespFee + increasedFee) / 2
+	peerFee := responderClosingSigned.FeeSatoshis
+	if peerFee != avgFee {
+		t.Fatalf("expected ClosingSigned with fee %v, got %v",
+			proposedFee, responderClosingSigned.FeeSatoshis)
+	}
+
+	// We try negotiating a 2.1x fee, which should also be rejected.
+	increasedFee = uint64(float64(preferredRespFee) * 2.1)
+	initiatorSig, proposedFee, err = initiatorChan.CreateCloseProposal(
+		increasedFee, dummyDeliveryScript, respDeliveryScript,
+	)
+	if err != nil {
+		t.Fatalf("error creating close proposal: %v", err)
+	}
+
+	parsedSig, err = btcec.ParseSignature(initiatorSig, btcec.S256())
+	if err != nil {
+		t.Fatalf("error parsing signature: %v", err)
+	}
+	closingSigned = lnwire.NewClosingSigned(chanID, proposedFee, parsedSig)
+	responder.closingSignedChanReqs <- closingSigned
+
+	// It still won't be accepted, and we should get a new proposal, the
+	// average of what we proposed, and what they proposed last time.
+	select {
+	case outMsg := <-responder.outgoingQueue:
+		msg = outMsg.msg
+	case <-time.After(time.Second * 5):
+		t.Fatalf("did not receive closing signed message")
+	}
+
+	responderClosingSigned, ok = msg.(*lnwire.ClosingSigned)
+	if !ok {
+		t.Fatalf("expected ClosingSigned message, got %T", msg)
+	}
+
+	avgFee = (peerFee + increasedFee) / 2
+	peerFee = responderClosingSigned.FeeSatoshis
+	if peerFee != avgFee {
+		t.Fatalf("expected ClosingSigned with fee %v, got %v",
+			proposedFee, responderClosingSigned.FeeSatoshis)
+	}
+
+	// Accept fee.
+	initiatorSig, proposedFee, err = initiatorChan.CreateCloseProposal(
+		peerFee, dummyDeliveryScript, respDeliveryScript,
+	)
+	if err != nil {
+		t.Fatalf("error creating close proposal: %v", err)
+	}
+
+	initSig := append(initiatorSig, byte(txscript.SigHashAll))
+	parsedSig, err = btcec.ParseSignature(initSig, btcec.S256())
+	if err != nil {
+		t.Fatalf("error parsing signature: %v", err)
+	}
+	closingSigned = lnwire.NewClosingSigned(chanID, proposedFee, parsedSig)
+	responder.closingSignedChanReqs <- closingSigned
+
+	// The responder will now see that we agreed on the fee, and broadcast
+	// the closing transaction.
+	select {
+	case <-broadcastTxChan:
+	case <-time.After(time.Second * 5):
+		t.Fatalf("closing tx not broadcast")
+	}
+
+	// And the responder should be waiting for a confirmation notification.
+	notifier.confChannel <- &chainntnfs.TxConfirmation{}
+}
+
+// TestPeerChannelClosureFeeNegotiationsInitiator tests the shutdown initiator's
+// behavior in the case where we must do several rounds of fee negotiation
+// before we agree on a fee.
+func TestPeerChannelClosureFeeNegotiationsInitiator(t *testing.T) {
+	disablePeerLogger(t)
+	t.Parallel()
+
+	notifier := &mockNotfier{
+		confChannel: make(chan *chainntnfs.TxConfirmation),
+	}
+	broadcastTxChan := make(chan *wire.MsgTx)
+
+	initiator, initiatorChan, responderChan, cleanUp, err := createTestPeer(
+		notifier, broadcastTxChan)
+	if err != nil {
+		t.Fatalf("unable to create test channels: %v", err)
+	}
+	defer cleanUp()
+
+	// We make the initiator send a shutdown request.
+	updateChan := make(chan *lnrpc.CloseStatusUpdate, 1)
+	errChan := make(chan error, 1)
+	closeCommand := &htlcswitch.ChanClose{
+		CloseType: htlcswitch.CloseRegular,
+		ChanPoint: initiatorChan.ChannelPoint(),
+		Updates:   updateChan,
+		Err:       errChan,
+	}
+
+	initiator.localCloseChanReqs <- closeCommand
+
+	// We should now be getting the shutdown request.
+	var msg lnwire.Message
+	select {
+	case outMsg := <-initiator.outgoingQueue:
+		msg = outMsg.msg
+	case <-time.After(time.Second * 5):
+		t.Fatalf("did not receive shutdown request")
+	}
+
+	shutdownMsg, ok := msg.(*lnwire.Shutdown)
+	if !ok {
+		t.Fatalf("expected Shutdown message, got %T", msg)
+	}
+
+	initiatorDeliveryScript := shutdownMsg.Address
+
+	// We'll answer the shutdown message with our own Shutdown, and then a
+	// ClosingSigned message.
+	chanID := lnwire.NewChanIDFromOutPoint(initiatorChan.ChannelPoint())
+	respShutdown := lnwire.NewShutdown(chanID, dummyDeliveryScript)
+	initiator.shutdownChanReqs <- respShutdown
+
+	estimator := lnwallet.StaticFeeEstimator{FeeRate: 50}
+	initiatorIdealFeeRate := estimator.EstimateFeePerWeight(1) * 1000
+	initiatorIdealFee := responderChan.CalcFee(initiatorIdealFeeRate)
+	increasedFee := uint64(float64(initiatorIdealFee) * 2.5)
+	closeSig, proposedFee, err := responderChan.CreateCloseProposal(
+		increasedFee, dummyDeliveryScript, initiatorDeliveryScript,
+	)
+	if err != nil {
+		t.Fatalf("unable to create close proposal: %v", err)
+	}
+	parsedSig, err := btcec.ParseSignature(closeSig, btcec.S256())
+	if err != nil {
+		t.Fatalf("unable to parse signature: %v", err)
+	}
+
+	closingSigned := lnwire.NewClosingSigned(shutdownMsg.ChannelID,
+		proposedFee, parsedSig)
+	initiator.closingSignedChanReqs <- closingSigned
+
+	// And we expect the initiator to reject the fee, and suggest a lower
+	// one.
+	select {
+	case outMsg := <-initiator.outgoingQueue:
+		msg = outMsg.msg
+	case <-time.After(time.Second * 5):
+		t.Fatalf("did not receive closing signed")
+	}
+
+	closingSignedMsg, ok := msg.(*lnwire.ClosingSigned)
+	if !ok {
+		t.Fatalf("expected ClosingSigned message, got %T", msg)
+	}
+	avgFee := (initiatorIdealFee + increasedFee) / 2
+	peerFee := closingSignedMsg.FeeSatoshis
+	if peerFee != avgFee {
+		t.Fatalf("expected ClosingSigned fee to be %v, instead got %v",
+			avgFee, peerFee)
+	}
+
+	// We try negotiating a 2.1x fee, which should also be rejected.
+	increasedFee = uint64(float64(initiatorIdealFee) * 2.1)
+	responderSig, proposedFee, err := responderChan.CreateCloseProposal(
+		increasedFee, dummyDeliveryScript, initiatorDeliveryScript,
+	)
+	if err != nil {
+		t.Fatalf("error creating close proposal: %v", err)
+	}
+
+	parsedSig, err = btcec.ParseSignature(responderSig, btcec.S256())
+	if err != nil {
+		t.Fatalf("error parsing signature: %v", err)
+	}
+
+	closingSigned = lnwire.NewClosingSigned(chanID, proposedFee, parsedSig)
+	initiator.closingSignedChanReqs <- closingSigned
+
+	// It still won't be accepted, and we should get a new proposal, the
+	// average of what we proposed, and what they proposed last time.
+	select {
+	case outMsg := <-initiator.outgoingQueue:
+		msg = outMsg.msg
+	case <-time.After(time.Second * 5):
+		t.Fatalf("did not receive closing signed")
+	}
+
+	initiatorClosingSigned, ok := msg.(*lnwire.ClosingSigned)
+	if !ok {
+		t.Fatalf("expected ClosingSigned message, got %T", msg)
+	}
+
+	avgFee = (peerFee + increasedFee) / 2
+	peerFee = initiatorClosingSigned.FeeSatoshis
+	if peerFee != avgFee {
+		t.Fatalf("expected ClosingSigned with fee %v, got %v",
+			proposedFee, initiatorClosingSigned.FeeSatoshis)
+	}
+
+	// Accept fee.
+	responderSig, proposedFee, err = responderChan.CreateCloseProposal(
+		peerFee, dummyDeliveryScript, initiatorDeliveryScript,
+	)
+	if err != nil {
+		t.Fatalf("error creating close proposal: %v", err)
+	}
+
+	respSig := append(responderSig, byte(txscript.SigHashAll))
+	parsedSig, err = btcec.ParseSignature(respSig, btcec.S256())
+	if err != nil {
+		t.Fatalf("error parsing signature: %v", err)
+	}
+	closingSigned = lnwire.NewClosingSigned(chanID, proposedFee, parsedSig)
+	initiator.closingSignedChanReqs <- closingSigned
+
+	// Wait for closing tx to be broadcasted.
+	select {
+	case <-broadcastTxChan:
+	case <-time.After(time.Second * 5):
+		t.Fatalf("closing tx not broadcast")
+	}
+}

--- a/test_utils.go
+++ b/test_utils.go
@@ -1,0 +1,268 @@
+package main
+
+import (
+	"bytes"
+	"io/ioutil"
+	"math/rand"
+	"net"
+	"os"
+
+	"github.com/lightningnetwork/lnd/chainntnfs"
+	"github.com/lightningnetwork/lnd/channeldb"
+	"github.com/lightningnetwork/lnd/htlcswitch"
+	"github.com/lightningnetwork/lnd/lnwallet"
+	"github.com/lightningnetwork/lnd/lnwire"
+	"github.com/lightningnetwork/lnd/shachain"
+	"github.com/roasbeef/btcd/btcec"
+	"github.com/roasbeef/btcd/chaincfg/chainhash"
+	"github.com/roasbeef/btcd/wire"
+	"github.com/roasbeef/btcutil"
+)
+
+var (
+	alicesPrivKey = []byte{
+		0x2b, 0xd8, 0x06, 0xc9, 0x7f, 0x0e, 0x00, 0xaf,
+		0x1a, 0x1f, 0xc3, 0x32, 0x8f, 0xa7, 0x63, 0xa9,
+		0x26, 0x97, 0x23, 0xc8, 0xdb, 0x8f, 0xac, 0x4f,
+		0x93, 0xaf, 0x71, 0xdb, 0x18, 0x6d, 0x6e, 0x90,
+	}
+
+	bobsPrivKey = []byte{
+		0x81, 0xb6, 0x37, 0xd8, 0xfc, 0xd2, 0xc6, 0xda,
+		0x63, 0x59, 0xe6, 0x96, 0x31, 0x13, 0xa1, 0x17,
+		0xd, 0xe7, 0x95, 0xe4, 0xb7, 0x25, 0xb8, 0x4d,
+		0x1e, 0xb, 0x4c, 0xfd, 0x9e, 0xc5, 0x8c, 0xe9,
+	}
+
+	// Use a hard-coded HD seed.
+	testHdSeed = [32]byte{
+		0xb7, 0x94, 0x38, 0x5f, 0x2d, 0x1e, 0xf7, 0xab,
+		0x4d, 0x92, 0x73, 0xd1, 0x90, 0x63, 0x81, 0xb4,
+		0x4f, 0x2f, 0x6f, 0x25, 0x88, 0xa3, 0xef, 0xb9,
+		0x6a, 0x49, 0x18, 0x83, 0x31, 0x98, 0x47, 0x53,
+	}
+
+	// Just use some arbitrary bytes as delivery script.
+	dummyDeliveryScript = alicesPrivKey[:]
+)
+
+// createTestPeer creates a channel between two nodes, and returns a peer for
+// one of the nodes, together with the channel seen from both nodes.
+func createTestPeer(notifier chainntnfs.ChainNotifier,
+	publTx chan *wire.MsgTx) (*peer, *lnwallet.LightningChannel,
+	*lnwallet.LightningChannel, func(), error) {
+
+	aliceKeyPriv, aliceKeyPub := btcec.PrivKeyFromBytes(btcec.S256(),
+		alicesPrivKey)
+	bobKeyPriv, bobKeyPub := btcec.PrivKeyFromBytes(btcec.S256(),
+		bobsPrivKey)
+
+	channelCapacity := btcutil.Amount(10 * 1e8)
+	channelBal := channelCapacity / 2
+	aliceDustLimit := btcutil.Amount(200)
+	bobDustLimit := btcutil.Amount(1300)
+	csvTimeoutAlice := uint32(5)
+	csvTimeoutBob := uint32(4)
+
+	prevOut := &wire.OutPoint{
+		Hash:  chainhash.Hash(testHdSeed),
+		Index: 0,
+	}
+	fundingTxIn := wire.NewTxIn(prevOut, nil, nil)
+
+	aliceCfg := channeldb.ChannelConfig{
+		ChannelConstraints: channeldb.ChannelConstraints{
+			DustLimit:        aliceDustLimit,
+			MaxPendingAmount: btcutil.Amount(rand.Int63()),
+			ChanReserve:      btcutil.Amount(rand.Int63()),
+			MinHTLC:          btcutil.Amount(rand.Int63()),
+			MaxAcceptedHtlcs: uint16(rand.Int31()),
+		},
+		CsvDelay:            uint16(csvTimeoutAlice),
+		MultiSigKey:         aliceKeyPub,
+		RevocationBasePoint: aliceKeyPub,
+		PaymentBasePoint:    aliceKeyPub,
+		DelayBasePoint:      aliceKeyPub,
+	}
+	bobCfg := channeldb.ChannelConfig{
+		ChannelConstraints: channeldb.ChannelConstraints{
+			DustLimit:        bobDustLimit,
+			MaxPendingAmount: btcutil.Amount(rand.Int63()),
+			ChanReserve:      btcutil.Amount(rand.Int63()),
+			MinHTLC:          btcutil.Amount(rand.Int63()),
+			MaxAcceptedHtlcs: uint16(rand.Int31()),
+		},
+		CsvDelay:            uint16(csvTimeoutBob),
+		MultiSigKey:         bobKeyPub,
+		RevocationBasePoint: bobKeyPub,
+		PaymentBasePoint:    bobKeyPub,
+		DelayBasePoint:      bobKeyPub,
+	}
+
+	bobRoot := lnwallet.DeriveRevocationRoot(bobKeyPriv, testHdSeed, aliceKeyPub)
+	bobPreimageProducer := shachain.NewRevocationProducer(bobRoot)
+	bobFirstRevoke, err := bobPreimageProducer.AtIndex(0)
+	if err != nil {
+		return nil, nil, nil, nil, err
+	}
+	bobCommitPoint := lnwallet.ComputeCommitmentPoint(bobFirstRevoke[:])
+
+	aliceRoot := lnwallet.DeriveRevocationRoot(aliceKeyPriv, testHdSeed, bobKeyPub)
+	alicePreimageProducer := shachain.NewRevocationProducer(aliceRoot)
+	aliceFirstRevoke, err := alicePreimageProducer.AtIndex(0)
+	if err != nil {
+		return nil, nil, nil, nil, err
+	}
+	aliceCommitPoint := lnwallet.ComputeCommitmentPoint(aliceFirstRevoke[:])
+
+	aliceCommitTx, bobCommitTx, err := lnwallet.CreateCommitmentTxns(channelBal,
+		channelBal, &aliceCfg, &bobCfg, aliceCommitPoint, bobCommitPoint,
+		fundingTxIn)
+	if err != nil {
+		return nil, nil, nil, nil, err
+	}
+
+	alicePath, err := ioutil.TempDir("", "alicedb")
+	dbAlice, err := channeldb.Open(alicePath)
+	if err != nil {
+		return nil, nil, nil, nil, err
+	}
+
+	bobPath, err := ioutil.TempDir("", "bobdb")
+	dbBob, err := channeldb.Open(bobPath)
+	if err != nil {
+		return nil, nil, nil, nil, err
+	}
+
+	var obsfucator [lnwallet.StateHintSize]byte
+	copy(obsfucator[:], aliceFirstRevoke[:])
+
+	estimator := &lnwallet.StaticFeeEstimator{FeeRate: 50}
+	feePerKw := btcutil.Amount(estimator.EstimateFeePerWeight(1) * 1000)
+	aliceChannelState := &channeldb.OpenChannel{
+		LocalChanCfg:            aliceCfg,
+		RemoteChanCfg:           bobCfg,
+		IdentityPub:             aliceKeyPub,
+		FundingOutpoint:         *prevOut,
+		ChanType:                channeldb.SingleFunder,
+		FeePerKw:                feePerKw,
+		IsInitiator:             true,
+		Capacity:                channelCapacity,
+		LocalBalance:            channelBal,
+		RemoteBalance:           channelBal,
+		CommitTx:                *aliceCommitTx,
+		CommitSig:               bytes.Repeat([]byte{1}, 71),
+		RemoteCurrentRevocation: bobCommitPoint,
+		RevocationProducer:      alicePreimageProducer,
+		RevocationStore:         shachain.NewRevocationStore(),
+		Db:                      dbAlice,
+	}
+
+	addr := &net.TCPAddr{
+		IP:   net.ParseIP("127.0.0.1"),
+		Port: 18555,
+	}
+
+	if err := aliceChannelState.SyncPending(addr, 0); err != nil {
+		return nil, nil, nil, nil, err
+	}
+
+	bobChannelState := &channeldb.OpenChannel{
+		LocalChanCfg:            bobCfg,
+		RemoteChanCfg:           aliceCfg,
+		IdentityPub:             bobKeyPub,
+		FeePerKw:                feePerKw,
+		FundingOutpoint:         *prevOut,
+		ChanType:                channeldb.SingleFunder,
+		IsInitiator:             false,
+		Capacity:                channelCapacity,
+		LocalBalance:            channelBal,
+		RemoteBalance:           channelBal,
+		CommitTx:                *bobCommitTx,
+		CommitSig:               bytes.Repeat([]byte{1}, 71),
+		RemoteCurrentRevocation: aliceCommitPoint,
+		RevocationProducer:      bobPreimageProducer,
+		RevocationStore:         shachain.NewRevocationStore(),
+		Db:                      dbBob,
+	}
+
+	addr = &net.TCPAddr{
+		IP:   net.ParseIP("127.0.0.1"),
+		Port: 18556,
+	}
+
+	if err := bobChannelState.SyncPending(addr, 0); err != nil {
+		return nil, nil, nil, nil, err
+	}
+
+	cleanUpFunc := func() {
+		os.RemoveAll(bobPath)
+		os.RemoveAll(alicePath)
+	}
+
+	aliceSigner := &mockSigner{aliceKeyPriv}
+	bobSigner := &mockSigner{bobKeyPriv}
+
+	channelAlice, err := lnwallet.NewLightningChannel(aliceSigner, notifier,
+		estimator, aliceChannelState)
+	if err != nil {
+		return nil, nil, nil, nil, err
+	}
+	channelBob, err := lnwallet.NewLightningChannel(bobSigner, notifier,
+		estimator, bobChannelState)
+	if err != nil {
+		return nil, nil, nil, nil, err
+	}
+
+	chainIO := &mockChainIO{}
+	wallet := &lnwallet.LightningWallet{
+		WalletController: &mockWalletController{
+			rootKey:               aliceKeyPriv,
+			publishedTransactions: publTx,
+		},
+	}
+	cc := &chainControl{
+		feeEstimator:  estimator,
+		chainIO:       chainIO,
+		chainNotifier: notifier,
+		wallet:        wallet,
+	}
+
+	breachArbiter := &breachArbiter{
+		settledContracts: make(chan *wire.OutPoint, 10),
+	}
+
+	s := &server{
+		chanDB:        dbAlice,
+		cc:            cc,
+		breachArbiter: breachArbiter,
+	}
+	s.htlcSwitch = htlcswitch.New(htlcswitch.Config{})
+	s.htlcSwitch.Start()
+
+	alicePeer := &peer{
+		server:        s,
+		sendQueue:     make(chan outgoinMsg, 1),
+		outgoingQueue: make(chan outgoinMsg, outgoingQueueLen),
+
+		activeChannels: make(map[lnwire.ChannelID]*lnwallet.LightningChannel),
+		newChannels:    make(chan *newChannelMsg, 1),
+
+		localCloseChanReqs:    make(chan *htlcswitch.ChanClose),
+		shutdownChanReqs:      make(chan *lnwire.Shutdown),
+		closingSignedChanReqs: make(chan *lnwire.ClosingSigned),
+
+		localSharedFeatures:  nil,
+		globalSharedFeatures: nil,
+
+		queueQuit: make(chan struct{}),
+		quit:      make(chan struct{}),
+	}
+
+	chanID := lnwire.NewChanIDFromOutPoint(channelAlice.ChannelPoint())
+	alicePeer.activeChannels[chanID] = channelAlice
+
+	go alicePeer.channelManager()
+
+	return alicePeer, channelAlice, channelBob, cleanUpFunc, nil
+}


### PR DESCRIPTION
This PR adds a simple fee negotiation flow on channel shutdown. Currently, the algorithm works as follows:
- The node picks a desired fee and send it to the remote.
- When the node receives a fee proposal from the remote, it accepts it if it is in the range `[0.5*desired, 2*desired]`.
- If the remote's fee is not in this range, the node will propose the average of its own last sent fee and the remote's, restricted to this range.

Both nodes in the channel will broadcast the closing transaction the moment they have the signatures for a transaction with the agreed fee.

TODO:
- [ ] ~~If we cannot agree on a fee, we should fail the channel.~~