### PR TITLE
Ignore node announcements for nodes not found in any existing channel

### DIFF
--- a/channeldb/graph_test.go
+++ b/channeldb/graph_test.go
@@ -51,14 +51,15 @@ func createTestVertex(db *DB) (*LightningNode, error) {
 
 	pub := priv.PubKey().SerializeCompressed()
 	return &LightningNode{
-		AuthSig:    testSig,
-		LastUpdate: time.Unix(updateTime, 0),
-		PubKey:     priv.PubKey(),
-		Color:      color.RGBA{1, 2, 3, 0},
-		Alias:      "kek" + string(pub[:]),
-		Features:   testFeatures,
-		Addresses:  testAddrs,
-		db:         db,
+		HaveNodeAnnouncement: true,
+		AuthSig:              testSig,
+		LastUpdate:           time.Unix(updateTime, 0),
+		PubKey:               priv.PubKey(),
+		Color:                color.RGBA{1, 2, 3, 0},
+		Alias:                "kek" + string(pub[:]),
+		Features:             testFeatures,
+		Addresses:            testAddrs,
+		db:                   db,
 	}, nil
 }
 
@@ -77,14 +78,15 @@ func TestNodeInsertionAndDeletion(t *testing.T) {
 	// graph, so we'll create a test vertex to start with.
 	_, testPub := btcec.PrivKeyFromBytes(btcec.S256(), key[:])
 	node := &LightningNode{
-		AuthSig:    testSig,
-		LastUpdate: time.Unix(1232342, 0),
-		PubKey:     testPub,
-		Color:      color.RGBA{1, 2, 3, 0},
-		Alias:      "kek",
-		Features:   testFeatures,
-		Addresses:  testAddrs,
-		db:         db,
+		HaveNodeAnnouncement: true,
+		AuthSig:              testSig,
+		LastUpdate:           time.Unix(1232342, 0),
+		PubKey:               testPub,
+		Color:                color.RGBA{1, 2, 3, 0},
+		Alias:                "kek",
+		Features:             testFeatures,
+		Addresses:            testAddrs,
+		db:                   db,
 	}
 
 	// First, insert the node into the graph DB. This should succeed
@@ -107,6 +109,71 @@ func TestNodeInsertionAndDeletion(t *testing.T) {
 	}
 
 	// The two nodes should match exactly!
+	if err := compareNodes(node, dbNode); err != nil {
+		t.Fatalf("nodes don't match: %v", err)
+	}
+
+	// Next, delete the node from the graph, this should purge all data
+	// related to the node.
+	if err := graph.DeleteLightningNode(testPub); err != nil {
+		t.Fatalf("unable to delete node; %v", err)
+	}
+
+	// Finally, attempt to fetch the node again. This should fail as the
+	// node should've been deleted from the database.
+	_, err = graph.FetchLightningNode(testPub)
+	if err != ErrGraphNodeNotFound {
+		t.Fatalf("fetch after delete should fail!")
+	}
+}
+
+// TestPartialNode checks that we can add and retrieve a LightningNode where
+// where only the pubkey is known to the database.
+func TestPartialNode(t *testing.T) {
+	t.Parallel()
+
+	db, cleanUp, err := makeTestDB()
+	defer cleanUp()
+	if err != nil {
+		t.Fatalf("unable to make test database: %v", err)
+	}
+
+	graph := db.ChannelGraph()
+
+	// We want to be able to insert nodes into the graph that only has the
+	// PubKey set.
+	_, testPub := btcec.PrivKeyFromBytes(btcec.S256(), key[:])
+	node := &LightningNode{
+		PubKey:               testPub,
+		HaveNodeAnnouncement: false,
+	}
+
+	if err := graph.AddLightningNode(node); err != nil {
+		t.Fatalf("unable to add node: %v", err)
+	}
+
+	// Next, fetch the node from the database to ensure everything was
+	// serialized properly.
+	dbNode, err := graph.FetchLightningNode(testPub)
+	if err != nil {
+		t.Fatalf("unable to locate node: %v", err)
+	}
+
+	if _, exists, err := graph.HasLightningNode(testPub); err != nil {
+		t.Fatalf("unable to query for node: %v", err)
+	} else if !exists {
+		t.Fatalf("node should be found but wasn't")
+	}
+
+	// The two nodes should match exactly! (with default values for
+	// LastUpdate and db set to satisfy compareNodes())
+	node = &LightningNode{
+		PubKey:               testPub,
+		HaveNodeAnnouncement: false,
+		LastUpdate:           time.Unix(0, 0),
+		db:                   db,
+	}
+
 	if err := compareNodes(node, dbNode); err != nil {
 		t.Fatalf("nodes don't match: %v", err)
 	}
@@ -928,6 +995,10 @@ func compareNodes(a, b *LightningNode) error {
 	if !reflect.DeepEqual(a.db, b.db) {
 		return fmt.Errorf("db doesn't match: expected %#v, \n "+
 			"got %#v", a.db, b.db)
+	}
+	if !reflect.DeepEqual(a.HaveNodeAnnouncement, b.HaveNodeAnnouncement) {
+		return fmt.Errorf("HaveNodeAnnouncement doesn't match: expected %#v, \n "+
+			"got %#v", a.HaveNodeAnnouncement, b.HaveNodeAnnouncement)
 	}
 
 	return nil

--- a/discovery/service.go
+++ b/discovery/service.go
@@ -439,8 +439,9 @@ func (d *AuthenticatedGossiper) processNetworkAnnouncement(nMsg *networkMsg) []l
 
 	switch msg := nMsg.msg.(type) {
 
-	// A new node announcement has arrived which either presents a new
-	// node, or a node updating previously advertised information.
+	// A new node announcement has arrived which either presents new information
+	// about a node in one of the channels we know about, or a updating
+	// previously advertised information.
 	case *lnwire.NodeAnnouncement:
 		if nMsg.isRemote {
 			if err := d.validateNodeAnn(msg); err != nil {
@@ -453,12 +454,13 @@ func (d *AuthenticatedGossiper) processNetworkAnnouncement(nMsg *networkMsg) []l
 		}
 
 		node := &channeldb.LightningNode{
-			LastUpdate: time.Unix(int64(msg.Timestamp), 0),
-			Addresses:  msg.Addresses,
-			PubKey:     msg.NodeID,
-			Alias:      msg.Alias.String(),
-			AuthSig:    msg.Signature,
-			Features:   msg.Features,
+			HaveNodeAnnouncement: true,
+			LastUpdate:           time.Unix(int64(msg.Timestamp), 0),
+			Addresses:            msg.Addresses,
+			PubKey:               msg.NodeID,
+			Alias:                msg.Alias.String(),
+			AuthSig:              msg.Signature,
+			Features:             msg.Features,
 		}
 
 		if err := d.cfg.Router.AddNode(node); err != nil {
@@ -537,6 +539,11 @@ func (d *AuthenticatedGossiper) processNetworkAnnouncement(nMsg *networkMsg) []l
 			BitcoinKey2: msg.BitcoinKey2,
 			AuthProof:   proof,
 		}
+
+		// We will add the edge to the channel router. If the nodes
+		// present in this channel are not present in the database, a
+		// partial node will be added to represent each node while we
+		// wait for a node announcement.
 		if err := d.cfg.Router.AddEdge(edge); err != nil {
 			if routing.IsError(err, routing.ErrOutdated,
 				routing.ErrIgnored) {
@@ -896,30 +903,10 @@ func (d *AuthenticatedGossiper) synchronizeWithNode(syncReq *syncRequest) error 
 	// containing all the messages to be sent to the target peer.
 	var announceMessages []lnwire.Message
 
-	// First run through all the vertexes in the graph, retrieving the data
-	// for the announcement we originally retrieved.
-	var numNodes uint32
-	if err := d.cfg.Router.ForEachNode(func(node *channeldb.LightningNode) error {
-		ann := &lnwire.NodeAnnouncement{
-			Signature: node.AuthSig,
-			Timestamp: uint32(node.LastUpdate.Unix()),
-			Addresses: node.Addresses,
-			NodeID:    node.PubKey,
-			Alias:     lnwire.NewAlias(node.Alias),
-			Features:  node.Features,
-		}
-		announceMessages = append(announceMessages, ann)
-
-		numNodes++
-
-		return nil
-	}); err != nil {
-		return err
-	}
-
-	// With the vertexes gathered, we'll no retrieve the initial
-	// announcement, as well as the latest channel update announcement for
-	// both of the directed infos that make up the channel.
+	// As peers are expecting channel announcements before node
+	// announcements, we first retrieve the initial announcement, as well as
+	// the latest channel update announcement for both of the directed edges
+	// that make up each channel, and queue these to be sent to the peer.
 	var numEdges uint32
 	if err := d.cfg.Router.ForEachChannel(func(chanInfo *channeldb.ChannelEdgeInfo,
 		e1, e2 *channeldb.ChannelEdgePolicy) error {
@@ -944,6 +931,32 @@ func (d *AuthenticatedGossiper) synchronizeWithNode(syncReq *syncRequest) error 
 		return nil
 	}); err != nil && err != channeldb.ErrGraphNoEdgesFound {
 		log.Errorf("unable to sync infos with peer: %v", err)
+		return err
+	}
+
+	// Run through all the vertexes in the graph, retrieving the data for
+	// the node announcements we originally retrieved.
+	var numNodes uint32
+	if err := d.cfg.Router.ForEachNode(func(node *channeldb.LightningNode) error {
+		// If this is a node we never received a node announcement for,
+		// we skip it.
+		if !node.HaveNodeAnnouncement {
+			return nil
+		}
+		ann := &lnwire.NodeAnnouncement{
+			Signature: node.AuthSig,
+			Timestamp: uint32(node.LastUpdate.Unix()),
+			Addresses: node.Addresses,
+			NodeID:    node.PubKey,
+			Alias:     lnwire.NewAlias(node.Alias),
+			Features:  node.Features,
+		}
+		announceMessages = append(announceMessages, ann)
+
+		numNodes++
+
+		return nil
+	}); err != nil {
 		return err
 	}
 

--- a/fundingmanager.go
+++ b/fundingmanager.go
@@ -161,6 +161,10 @@ type fundingConfig struct {
 	// distinct sub-system?
 	SignMessage func(pubKey *btcec.PublicKey, msg []byte) (*btcec.Signature, error)
 
+	// SignNodeAnnouncement is used by the fundingManager to sign the
+	// updated self node announcements sent after each channel announcement.
+	SignNodeAnnouncement func(nodeAnn *lnwire.NodeAnnouncement) (*btcec.Signature, error)
+
 	// SendAnnouncement is used by the FundingManager to announce newly
 	// created channels to the rest of the Lightning Network.
 	SendAnnouncement func(msg lnwire.Message) error
@@ -1355,7 +1359,6 @@ func (f *fundingManager) newChanAnnouncement(localPubKey, remotePubKey *btcec.Pu
 func (f *fundingManager) announceChannel(localIDKey, remoteIDKey, localFundingKey,
 	remoteFundingKey *btcec.PublicKey, shortChanID lnwire.ShortChannelID,
 	chanID lnwire.ChannelID) {
-
 	ann, err := f.newChanAnnouncement(localIDKey, remoteIDKey, localFundingKey,
 		remoteFundingKey, shortChanID, chanID)
 	if err != nil {
@@ -1369,6 +1372,46 @@ func (f *fundingManager) announceChannel(localIDKey, remoteIDKey, localFundingKe
 	f.cfg.SendAnnouncement(ann.chanAnn)
 	f.cfg.SendAnnouncement(ann.chanUpdateAnn)
 	f.cfg.SendAnnouncement(ann.chanProof)
+
+	// Now that the channel is announced to the network, we will also create
+	// and send a node announcement. This is done since a node announcement
+	// is only accepted after a channel is known for that particular node,
+	// and this might be our first channel.
+	graph := f.cfg.Wallet.Cfg.Database.ChannelGraph()
+	self, err := graph.FetchLightningNode(f.cfg.IDKey)
+	if err != nil {
+		fndgLog.Errorf("unable to fetch own lightning node from "+
+			"channel graph: %v", err)
+		return
+	}
+
+	// Create node announcement with updated timestamp to make sure it gets
+	// propagated in the network, in particular by our local announcement
+	// process logic. In case we just sent one, add one second to the time,
+	// to make sure it gets propagated.
+	timestamp := time.Now().Unix()
+	if timestamp <= self.LastUpdate.Unix() {
+		timestamp = self.LastUpdate.Unix() + 1
+	}
+	nodeAnn := &lnwire.NodeAnnouncement{
+		Timestamp: uint32(timestamp),
+		Addresses: self.Addresses,
+		NodeID:    self.PubKey,
+		Alias:     lnwire.NewAlias(self.Alias),
+		Features:  self.Features,
+	}
+
+	// Since the timestamp is changed, we cannot reuse the old signature
+	// and must re-sign the announcement.
+	sign, err := f.cfg.SignNodeAnnouncement(nodeAnn)
+	if err != nil {
+		fndgLog.Errorf("unable to generate signature for self node "+
+			"announcement: %v", err)
+		return
+	}
+
+	nodeAnn.Signature = sign
+	f.cfg.SendAnnouncement(nodeAnn)
 }
 
 // initFundingWorkflow sends a message to the funding manager instructing it

--- a/lnd.go
+++ b/lnd.go
@@ -18,6 +18,7 @@ import (
 	flags "github.com/btcsuite/go-flags"
 	proxy "github.com/grpc-ecosystem/grpc-gateway/runtime"
 	"github.com/lightningnetwork/lnd/channeldb"
+	"github.com/lightningnetwork/lnd/discovery"
 	"github.com/lightningnetwork/lnd/lnrpc"
 	"github.com/lightningnetwork/lnd/lnwallet"
 	"github.com/lightningnetwork/lnd/lnwire"
@@ -129,6 +130,16 @@ func lndMain() error {
 			return activeChainControl.msgSigner.SignMessage(
 				pubKey, msg,
 			)
+		},
+		SignNodeAnnouncement: func(nodeAnn *lnwire.NodeAnnouncement) (*btcec.Signature, error) {
+			sig, err := discovery.SignAnnouncement(nodeSigner,
+				server.identityPriv.PubKey(),
+				nodeAnn,
+			)
+			if err != nil {
+				return nil, err
+			}
+			return sig, nil
 		},
 		SendAnnouncement: func(msg lnwire.Message) error {
 			server.discoverSrv.ProcessLocalAnnouncement(msg,

--- a/routing/errors.go
+++ b/routing/errors.go
@@ -35,7 +35,8 @@ const (
 	ErrOutdated
 
 	// ErrIgnored is returned when the update have been ignored because
-	// this update can't bring us something new.
+	// this update can't bring us something new, or because a node
+	// announcement was given for node not found in any channel.
 	ErrIgnored
 )
 

--- a/routing/notifications_test.go
+++ b/routing/notifications_test.go
@@ -52,13 +52,14 @@ func createTestNode() (*channeldb.LightningNode, error) {
 
 	pub := priv.PubKey().SerializeCompressed()
 	return &channeldb.LightningNode{
-		LastUpdate: time.Unix(updateTime, 0),
-		Addresses:  testAddrs,
-		PubKey:     priv.PubKey(),
-		Color:      color.RGBA{1, 2, 3, 0},
-		Alias:      "kek" + string(pub[:]),
-		AuthSig:    testSig,
-		Features:   testFeatures,
+		HaveNodeAnnouncement: true,
+		LastUpdate:           time.Unix(updateTime, 0),
+		Addresses:            testAddrs,
+		PubKey:               priv.PubKey(),
+		Color:                color.RGBA{1, 2, 3, 0},
+		Alias:                "kek" + string(pub[:]),
+		AuthSig:              testSig,
+		Features:             testFeatures,
 	}, nil
 }
 
@@ -297,7 +298,7 @@ func TestEdgeUpdateNotification(t *testing.T) {
 	ctx.chain.addBlock(fundingBlock, chanID.BlockHeight)
 
 	// Next we'll create two test nodes that the fake channel will be open
-	// between and add then as members of the channel graph.
+	// between.
 	node1, err := createTestNode()
 	if err != nil {
 		t.Fatalf("unable to create test node: %v", err)
@@ -305,15 +306,6 @@ func TestEdgeUpdateNotification(t *testing.T) {
 	node2, err := createTestNode()
 	if err != nil {
 		t.Fatalf("unable to create test node: %v", err)
-	}
-
-	// Send the two node topology updates to the channel router so they
-	// can be validated and stored within the graph database.
-	if err := ctx.router.AddNode(node1); err != nil {
-		t.Fatal(err)
-	}
-	if err := ctx.router.AddNode(node2); err != nil {
-		t.Fatal(err)
 	}
 
 	// Finally, to conclude our test set up, we'll create a channel
@@ -462,20 +454,34 @@ func TestEdgeUpdateNotification(t *testing.T) {
 func TestNodeUpdateNotification(t *testing.T) {
 	t.Parallel()
 
-	ctx, cleanUp, err := createTestCtx(1)
+	const startingBlockHeight = 101
+	ctx, cleanUp, err := createTestCtx(startingBlockHeight)
 	defer cleanUp()
 	if err != nil {
 		t.Fatalf("unable to create router: %v", err)
 	}
 
-	// Create a new client to receive notifications.
-	ntfnClient, err := ctx.router.SubscribeTopology()
+	// We only accept node announcements from nodes having a known channel,
+	// so create one now.
+	const chanValue = 10000
+	fundingTx, _, chanID, err := createChannelEdge(ctx,
+		bitcoinKey1.SerializeCompressed(),
+		bitcoinKey2.SerializeCompressed(),
+		chanValue, startingBlockHeight)
 	if err != nil {
-		t.Fatalf("unable to subscribe for channel notifications: %v", err)
+		t.Fatalf("unable create channel edge: %v", err)
 	}
 
-	// Create two random nodes to add to send as node announcement messages
-	// to trigger notifications.
+	// We'll also add a record for the block that included our funding
+	// transaction.
+	fundingBlock := &wire.MsgBlock{
+		Transactions: []*wire.MsgTx{fundingTx},
+	}
+	ctx.chain.addBlock(fundingBlock, chanID.BlockHeight)
+
+	// Create two nodes acting as endpoints in the created channel, and use
+	// them to trigger notifications by sending updated node announcement
+	// messages.
 	node1, err := createTestNode()
 	if err != nil {
 		t.Fatalf("unable to create test node: %v", err)
@@ -485,7 +491,34 @@ func TestNodeUpdateNotification(t *testing.T) {
 		t.Fatalf("unable to create test node: %v", err)
 	}
 
-	// Change network topology by adding nodes to the channel router.
+	edge := &channeldb.ChannelEdgeInfo{
+		ChannelID:   chanID.ToUint64(),
+		NodeKey1:    node1.PubKey,
+		NodeKey2:    node2.PubKey,
+		BitcoinKey1: bitcoinKey1,
+		BitcoinKey2: bitcoinKey2,
+		AuthProof: &channeldb.ChannelAuthProof{
+			NodeSig1:    testSig,
+			NodeSig2:    testSig,
+			BitcoinSig1: testSig,
+			BitcoinSig2: testSig,
+		},
+	}
+
+	// Adding the edge will add the nodes to the graph, but with no info
+	// except the pubkey known.
+	if err := ctx.router.AddEdge(edge); err != nil {
+		t.Fatalf("unable to add edge: %v", err)
+	}
+
+	// Create a new client to receive notifications.
+	ntfnClient, err := ctx.router.SubscribeTopology()
+	if err != nil {
+		t.Fatalf("unable to subscribe for channel notifications: %v", err)
+	}
+
+	// Change network topology by adding the updated info for the two nodes
+	// to the channel router.
 	if err := ctx.router.AddNode(node1); err != nil {
 		t.Fatalf("unable to add node: %v", err)
 	}
@@ -610,25 +643,67 @@ func TestNotificationCancellation(t *testing.T) {
 		t.Fatalf("unable to subscribe for channel notifications: %v", err)
 	}
 
+	// We'll create the utxo for a new channel.
+	const chanValue = 10000
+	fundingTx, _, chanID, err := createChannelEdge(ctx,
+		bitcoinKey1.SerializeCompressed(),
+		bitcoinKey2.SerializeCompressed(),
+		chanValue, startingBlockHeight)
+	if err != nil {
+		t.Fatalf("unable create channel edge: %v", err)
+	}
+
+	// We'll also add a record for the block that included our funding
+	// transaction.
+	fundingBlock := &wire.MsgBlock{
+		Transactions: []*wire.MsgTx{fundingTx},
+	}
+	ctx.chain.addBlock(fundingBlock, chanID.BlockHeight)
+
 	// We'll create a fresh new node topology update to feed to the channel
 	// router.
-	node, err := createTestNode()
+	node1, err := createTestNode()
+	if err != nil {
+		t.Fatalf("unable to create test node: %v", err)
+	}
+	node2, err := createTestNode()
 	if err != nil {
 		t.Fatalf("unable to create test node: %v", err)
 	}
 
 	// Before we send the message to the channel router, we'll cancel the
 	// notifications for this client. As a result, the notification
-	// triggered by accepting this announcement shouldn't be sent to the
-	// client.
+	// triggered by accepting the channel announcements shouldn't be sent
+	// to the client.
 	ntfnClient.Cancel()
 
-	if err := ctx.router.AddNode(node); err != nil {
+	edge := &channeldb.ChannelEdgeInfo{
+		ChannelID:   chanID.ToUint64(),
+		NodeKey1:    node1.PubKey,
+		NodeKey2:    node2.PubKey,
+		BitcoinKey1: bitcoinKey1,
+		BitcoinKey2: bitcoinKey2,
+		AuthProof: &channeldb.ChannelAuthProof{
+			NodeSig1:    testSig,
+			NodeSig2:    testSig,
+			BitcoinSig1: testSig,
+			BitcoinSig2: testSig,
+		},
+	}
+	if err := ctx.router.AddEdge(edge); err != nil {
+		t.Fatalf("unable to add edge: %v", err)
+	}
+
+	if err := ctx.router.AddNode(node1); err != nil {
+		t.Fatalf("unable to add node: %v", err)
+	}
+
+	if err := ctx.router.AddNode(node2); err != nil {
 		t.Fatalf("unable to add node: %v", err)
 	}
 
 	select {
-	// The notification shouldn't be sent, however, the channel should be
+	// The notifications shouldn't be sent, however, the channel should be
 	// closed, causing the second read-value to be false.
 	case _, ok := <-ntfnClient.TopologyChanges:
 		if !ok {
@@ -671,20 +746,14 @@ func TestChannelCloseNotification(t *testing.T) {
 	ctx.chain.addBlock(fundingBlock, chanID.BlockHeight)
 
 	// Next we'll create two test nodes that the fake channel will be open
-	// between and add then as members of the channel graph.
+	// between.
 	node1, err := createTestNode()
 	if err != nil {
 		t.Fatalf("unable to create test node: %v", err)
 	}
-	if err := ctx.router.AddNode(node1); err != nil {
-		t.Fatal(err)
-	}
 	node2, err := createTestNode()
 	if err != nil {
 		t.Fatalf("unable to create test node: %v", err)
-	}
-	if err := ctx.router.AddNode(node2); err != nil {
-		t.Fatal(err)
 	}
 
 	// Finally, to conclude our test set up, we'll create a channel

--- a/routing/pathfind_test.go
+++ b/routing/pathfind_test.go
@@ -165,12 +165,13 @@ func parseTestGraph(path string) (*channeldb.ChannelGraph, func(), aliasMap, err
 		}
 
 		dbNode := &channeldb.LightningNode{
-			AuthSig:    testSig,
-			LastUpdate: time.Now(),
-			Addresses:  testAddrs,
-			PubKey:     pub,
-			Alias:      node.Alias,
-			Features:   testFeatures,
+			HaveNodeAnnouncement: true,
+			AuthSig:              testSig,
+			LastUpdate:           time.Now(),
+			Addresses:            testAddrs,
+			PubKey:               pub,
+			Alias:                node.Alias,
+			Features:             testFeatures,
 		}
 
 		// We require all aliases within the graph to be unique for our

--- a/server.go
+++ b/server.go
@@ -208,11 +208,12 @@ func newServer(listenAddrs []string, chanDB *channeldb.DB, cc *chainControl,
 	// TODO(roasbeef): make alias configurable
 	alias := lnwire.NewAlias(hex.EncodeToString(serializedPubKey[:10]))
 	self := &channeldb.LightningNode{
-		LastUpdate: time.Now(),
-		Addresses:  selfAddrs,
-		PubKey:     privKey.PubKey(),
-		Alias:      alias.String(),
-		Features:   globalFeatures,
+		HaveNodeAnnouncement: true,
+		LastUpdate:           time.Now(),
+		Addresses:            selfAddrs,
+		PubKey:               privKey.PubKey(),
+		Alias:                alias.String(),
+		Features:             globalFeatures,
 	}
 
 	// If our information has changed since our last boot, then we'll


### PR DESCRIPTION
As specified in BOLT#7, we should ignore any node announcements for nodes that we have not gotten any channel announcements for. This is to prevent an attacker to DoSing the network by creating a lot of cheap nodes.

- We are now sending a node announcement (self) after every channel announcement
- When we receive a channel announcement we are adding a node to the graph which only has the pubkey field set. The rest will be set when a node announcement for the same node is received.

Fixes #138. 