### PR TITLE
Add regtest support to lnd

### DIFF
--- a/config.go
+++ b/config.go
@@ -57,6 +57,7 @@ type chainConfig struct {
 
 	TestNet3 bool `long:"testnet" description:"Use the test network"`
 	SimNet   bool `long:"simnet" description:"Use the simulation test network"`
+	RegTest  bool `long:"regtest" description:"Use the regression test network"`
 }
 
 type neutrinoConfig struct {
@@ -230,6 +231,10 @@ func loadConfig() (*config, error) {
 		if cfg.Bitcoin.TestNet3 {
 			numNets++
 			activeNetParams = bitcoinTestNetParams
+		}
+		if cfg.Bitcoin.RegTest {
+			numNets++
+			activeNetParams = regTestNetParams
 		}
 		if cfg.Bitcoin.SimNet {
 			activeNetParams = bitcoinSimNetParams

--- a/params.go
+++ b/params.go
@@ -45,6 +45,12 @@ var liteTestNetParams = litecoinNetParams{
 	rpcPort: "19334",
 }
 
+// regTestNetParams contains parameters specific to a local regtest network.
+var regTestNetParams = bitcoinNetParams{
+	Params:  &bitcoinCfg.RegressionNetParams,
+	rpcPort: "18334",
+}
+
 // applyLitecoinParams applies the relevant chain configuration parameters that
 // differ for litecoin to the chain parameters typed for btcsuite derivation.
 // This function is used in place of using something like interface{} to


### PR DESCRIPTION
Support for regtest allows us to create integration tests to verify
interoperability with other implementations. This seems to work, and
allows to connect to `btcd` and indirectly to `bitcoind` so we can run
lnd on the same network as eclair and c-lightning.

For details about my integration framework check this repo:
https://github.com/cdecker/lightning-integration