### PR TITLE
Add payment circuit persistence

### DIFF
--- a/htlcswitch/circuit.go
+++ b/htlcswitch/circuit.go
@@ -4,10 +4,40 @@ import (
 	"bytes"
 	"crypto/sha256"
 	"encoding/hex"
-	"sync"
 
+	"encoding/binary"
+
+	"io"
+
+	"github.com/boltdb/bolt"
 	"github.com/go-errors/errors"
+	"github.com/lightningnetwork/lnd/channeldb"
 	"github.com/lightningnetwork/lnd/lnwire"
+)
+
+var (
+	// ErrPaymentCircuitNotFound is returned if payment circuit haven't been
+	// found.
+	ErrPaymentCircuitNotFound = errors.New("payment circuit haven't been found")
+
+	// circuitBucketKey name of the bucket which stores the payment circuits.
+	circuitBucketKey = []byte("circuitbucket")
+
+	// counterCircuitBucketKey name of the bucket which stores the number of
+	// the circuits with the same key.
+	counterCircuitBucketKey = []byte("circuitcounters")
+)
+
+const (
+	// mockObfuscatorCode represents the mock implementation of the
+	// obfuscator and is used to understand that we should use the
+	// constructor of mock obfuscator implementation.
+	mockObfuscatorCode byte = 0
+
+	// failureObfuscatorCode represents the real sphinx implementation of the
+	// obfuscator and is used to understand that we should use the
+	// constructor of failure/sphinx obfuscator implementation.
+	failureObfuscatorCode byte = 1
 )
 
 // circuitKey uniquely identifies an active circuit between two open channels.
@@ -41,9 +71,6 @@ type paymentCircuit struct {
 	// Obfuscator is used to re-encrypt the onion failure before sending it
 	// back to the originator of the payment.
 	Obfuscator Obfuscator
-
-	// RefCount is used to count the circuits with the same circuit key.
-	RefCount int
 }
 
 // newPaymentCircuit creates new payment circuit instance.
@@ -53,82 +80,220 @@ func newPaymentCircuit(src, dest lnwire.ShortChannelID, key circuitKey,
 		Src:         src,
 		Dest:        dest,
 		PaymentHash: key,
-		RefCount:    1,
 		Obfuscator:  obfuscator,
 	}
 }
 
 // isEqual checks the equality of two payment circuits.
-func (a *paymentCircuit) isEqual(b *paymentCircuit) bool {
-	return bytes.Equal(a.PaymentHash[:], b.PaymentHash[:]) &&
-		a.Src == b.Src &&
-		a.Dest == b.Dest
+func (c *paymentCircuit) isEqual(b *paymentCircuit) bool {
+	return bytes.Equal(c.PaymentHash[:], b.PaymentHash[:]) &&
+		c.Src == b.Src &&
+		c.Dest == b.Dest
 }
 
-// circuitMap is a data structure that implements thread safe storage of
+// Decode reads the data from the byte stream and initialize the
+// payment circuit with data.
+func (c *paymentCircuit) Decode(r io.Reader) error {
+	if _, err := r.Read(c.PaymentHash[:]); err != nil {
+		return err
+	}
+
+	var srcBytes [8]byte
+	if _, err := r.Read(srcBytes[:]); err != nil {
+		return err
+	}
+	c.Src = lnwire.NewShortChanIDFromInt(binary.BigEndian.Uint64(srcBytes[:]))
+
+	var destBytes [8]byte
+	if _, err := r.Read(destBytes[:]); err != nil {
+		return err
+	}
+	c.Dest = lnwire.NewShortChanIDFromInt(binary.BigEndian.Uint64(destBytes[:]))
+
+	var code [1]byte
+	if _, err := r.Read(code[:]); err != nil {
+		return err
+	}
+
+	switch code[0] {
+	case failureObfuscatorCode:
+		c.Obfuscator = &FailureObfuscator{}
+	case mockObfuscatorCode:
+		c.Obfuscator = &mockObfuscator{}
+	default:
+		return errors.New("unknown obfuscator type")
+	}
+
+	return c.Obfuscator.Decode(r)
+}
+
+// Encode writes the internal representation of payment circuit in byte stream.
+func (c *paymentCircuit) Encode(w io.Writer) error {
+	if _, err := w.Write(c.PaymentHash[:]); err != nil {
+		return err
+	}
+
+	var srcBytes [8]byte
+	binary.BigEndian.PutUint64(srcBytes[:], c.Src.ToUint64())
+	if _, err := w.Write(srcBytes[:]); err != nil {
+		return err
+	}
+
+	var destBytes [8]byte
+	binary.BigEndian.PutUint64(destBytes[:], c.Dest.ToUint64())
+	if _, err := w.Write(destBytes[:]); err != nil {
+		return err
+	}
+
+	var code [1]byte
+	switch c.Obfuscator.(type) {
+	case *FailureObfuscator:
+		code[0] = failureObfuscatorCode
+	case *mockObfuscator:
+		code[0] = mockObfuscatorCode
+	default:
+		return errors.New("unknown obfuscator type")
+	}
+
+	if _, err := w.Write(code[:]); err != nil {
+		return err
+	}
+
+	return c.Obfuscator.Encode(w)
+}
+
+// Key uniquely identifies an active circuit between two open channels.
+// Currently, the payment hash is used to uniquely identify each circuit.
+// TODO(roasbeef): include dest+src+amt in key
+func (c *paymentCircuit) Key() circuitKey {
+	return circuitKey(c.PaymentHash)
+}
+
+// circuitStorage is a data structure that implements thread safe storage of
 // circuits. Each circuit key (payment hash) may have several of circuits
 // corresponding to it due to the possibility of repeated payment hashes.
-//
-// TODO(andrew.shvv) make it persistent
-type circuitMap struct {
-	sync.RWMutex
-	circuits map[circuitKey]*paymentCircuit
+type circuitStorage struct {
+	db *channeldb.DB
 }
 
-// newCircuitMap creates a new instance of the circuitMap.
-func newCircuitMap() *circuitMap {
-	return &circuitMap{
-		circuits: make(map[circuitKey]*paymentCircuit),
-	}
+// newCircuitMap creates a new instance of the circuitStorage.
+func newCircuitMap(db *channeldb.DB) *circuitStorage {
+	return &circuitStorage{db}
 }
 
-// add adds a new active payment circuit to the circuitMap.
-func (m *circuitMap) add(circuit *paymentCircuit) error {
-	m.Lock()
-	defer m.Unlock()
-
-	// Examine the circuit map to see if this circuit is already in use or
-	// not. If so, then we'll simply increment the reference count.
-	// Otherwise, we'll create a new circuit from scratch.
-	//
-	// TODO(roasbeef): include dest+src+amt in key
-	if c, ok := m.circuits[circuit.PaymentHash]; ok {
-		c.RefCount++
-		return nil
-	}
-
-	m.circuits[circuit.PaymentHash] = circuit
-
-	return nil
-}
-
-// remove destroys the target circuit by removing it from the circuit map.
-func (m *circuitMap) remove(key circuitKey) (*paymentCircuit, error) {
-	m.Lock()
-	defer m.Unlock()
-
-	if circuit, ok := m.circuits[key]; ok {
-		if circuit.RefCount--; circuit.RefCount == 0 {
-			delete(m.circuits, key)
+// add adds a new active payment circuit to the circuitStorage.
+func (m *circuitStorage) add(incomingCircuit *paymentCircuit) error {
+	return m.db.Batch(func(tx *bolt.Tx) error {
+		key := incomingCircuit.Key()
+		circuitBucket, err := tx.CreateBucketIfNotExists(circuitBucketKey)
+		if err != nil {
+			return err
 		}
 
-		return circuit, nil
-	}
+		counterBucket, err := tx.CreateBucketIfNotExists(counterCircuitBucketKey)
+		if err != nil {
+			return err
+		}
 
-	return nil, errors.Errorf("can't find circuit"+
-		" for key %v", key)
+		// Examine the circuit map to see if this circuit is already in use or
+		// not. If so, then we'll simply increment the reference count.
+		// Otherwise, we'll add new circuit in storage.
+		refCounter := uint64(1)
+		if data := counterBucket.Get(key[:]); data != nil {
+			refCounter = binary.BigEndian.Uint64(data)
+			refCounter++
+		}
+
+		// Update reference counter of the payment circuit.
+		var refCounterBytes [8]byte
+		binary.BigEndian.PutUint64(refCounterBytes[:], refCounter)
+		if err := counterBucket.Put(key[:], refCounterBytes[:]); err != nil {
+			return err
+		}
+
+		// If object have been putted in the storage already than exit,
+		// otherwise encode it and put it in the storage.
+		if refCounter != 1 {
+			return nil
+		}
+
+		// Encode the objects and place it in the circuitBucket.
+		var b bytes.Buffer
+		if err := incomingCircuit.Encode(&b); err != nil {
+			return err
+		}
+
+		return circuitBucket.Put(key[:], b.Bytes())
+	})
+}
+
+// remove destroys the target circuit by removing it from the circuit storage.
+func (m *circuitStorage) remove(key circuitKey) (*paymentCircuit, error) {
+	existedCircuit := &paymentCircuit{}
+	return existedCircuit, m.db.Batch(func(tx *bolt.Tx) error {
+		// Get or create the top circuitBucket.
+		circuitBucket := tx.Bucket(circuitBucketKey)
+		if circuitBucket == nil {
+			return ErrPaymentCircuitNotFound
+		}
+
+		counterBucket := tx.Bucket(counterCircuitBucketKey)
+		if counterBucket == nil {
+			return ErrPaymentCircuitNotFound
+		}
+
+		var refCounter uint64
+		if data := counterBucket.Get(key[:]); data != nil {
+			refCounter = binary.BigEndian.Uint64(data)
+		} else {
+			return ErrPaymentCircuitNotFound
+		}
+
+		// Retrieve the payment circuit to return it for the function.
+		data := circuitBucket.Get(key[:])
+		if data == nil {
+			return ErrPaymentCircuitNotFound
+		}
+
+		r := bytes.NewReader(data[:])
+		if err := existedCircuit.Decode(r); err != nil {
+			return err
+		}
+
+		if refCounter--; refCounter == 0 {
+			if err := circuitBucket.Delete(key[:]); err != nil {
+				return err
+			}
+		}
+
+		var refCounterBytes [8]byte
+		binary.BigEndian.PutUint64(refCounterBytes[:], refCounter)
+		return counterBucket.Put(key[:], refCounterBytes[:])
+	})
 }
 
 // pending returns number of circuits which are waiting for to be completed
 // (settle/fail responses to be received).
-func (m *circuitMap) pending() int {
-	m.RLock()
-	defer m.RUnlock()
+func (m *circuitStorage) pending() int {
+	var lengthCircuits uint64
+	m.db.View(func(tx *bolt.Tx) error {
+		counterBucket := tx.Bucket(counterCircuitBucketKey)
+		if counterBucket == nil {
+			return nil
+		}
 
-	var length int
-	for _, circuits := range m.circuits {
-		length += circuits.RefCount
-	}
+		// Iterate over objects buckets.
+		return counterBucket.ForEach(func(k, data []byte) error {
+			// Skip buckets fields.
+			if data == nil {
+				return nil
+			}
 
-	return length
+			// Using get instance handler return an empty storable instance and
+			// populate it with decoded data.
+			lengthCircuits += binary.BigEndian.Uint64(data)
+			return nil
+		})
+	})
+	return int(lengthCircuits)
 }

--- a/htlcswitch/circuit_test.go
+++ b/htlcswitch/circuit_test.go
@@ -1,0 +1,56 @@
+package htlcswitch
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/lightningnetwork/lnd/lnwire"
+)
+
+// TestPaymentCircuitMapStorage test the decode/encode abitlities of the
+// payment circuit and also check that the logic of circuit storage is right.
+func TestPaymentCircuitMapStorage(t *testing.T) {
+	cdb, cleanUp, err := makeTestDB()
+	defer cleanUp()
+	if err != nil {
+		t.Fatalf("unable to make test database: %v", err)
+	}
+
+	circuit1 := &paymentCircuit{
+		PaymentHash: [32]byte{1},
+		Src:         lnwire.NewShortChanIDFromInt(1),
+		Dest:        lnwire.NewShortChanIDFromInt(2),
+		Obfuscator:  newMockObfuscator(),
+	}
+
+	circuitMap := newCircuitMap(cdb)
+
+	if err := circuitMap.add(circuit1); err != nil {
+		t.Fatalf("unable to add payment circuit: %v", err)
+	}
+
+	if circuitMap.pending() != 1 {
+		t.Fatal("wrong number of payment circuits")
+	}
+
+	if err := circuitMap.add(circuit1); err != nil {
+		t.Fatalf("unable to add payment circuit: %v", err)
+	}
+
+	if circuitMap.pending() != 2 {
+		t.Fatal("wrong number of payment circuits")
+	}
+
+	circuit2, err := circuitMap.remove(circuit1.Key())
+	if err != nil {
+		t.Fatalf("unable to remove payment circuit: %v", err)
+	}
+
+	if circuitMap.pending() != 1 {
+		t.Fatal("wrong number of payment circuits")
+	}
+
+	if !reflect.DeepEqual(circuit1, circuit2) {
+		t.Fatal("payment circuits serialization is wrong")
+	}
+}

--- a/htlcswitch/failure.go
+++ b/htlcswitch/failure.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/lightningnetwork/lightning-onion"
 	"github.com/lightningnetwork/lnd/lnwire"
+	"io"
 )
 
 // Deobfuscator is an interface that is used to decrypt the onion encrypted
@@ -33,11 +34,17 @@ type Obfuscator interface {
 	// an additional layer of onion encryption. This process repeats until
 	// the error arrives at the source of the payment.
 	BackwardObfuscate(lnwire.OpaqueReason) lnwire.OpaqueReason
+
+	// Decode reads the bytes stream and converts it to the object.
+	Decode(io.Reader) error
+
+	// Encode converts object to the bytes stream and write it in th writer.
+	Encode(io.Writer) error
 }
 
 // FailureObfuscator is used to obfuscate the onion failure.
 type FailureObfuscator struct {
-	*sphinx.OnionObfuscator
+	sphinx.OnionObfuscator
 }
 
 // InitialObfuscate transforms a concrete failure message into an encrypted
@@ -75,7 +82,7 @@ var _ Obfuscator = (*FailureObfuscator)(nil)
 // FailureDeobfuscator wraps the sphinx data obfuscator and adds awareness of
 // the lnwire onion failure messages to it.
 type FailureDeobfuscator struct {
-	*sphinx.OnionDeobfuscator
+	sphinx.OnionDeobfuscator
 }
 
 // Deobfuscate peels off each layer of onion encryption from the first hop, to

--- a/htlcswitch/iterator.go
+++ b/htlcswitch/iterator.go
@@ -217,6 +217,6 @@ func (p *OnionProcessor) DecodeOnionObfuscator(r io.Reader) (Obfuscator, lnwire.
 	}
 
 	return &FailureObfuscator{
-		OnionObfuscator: onionObfuscator,
+		OnionObfuscator: *onionObfuscator,
 	}, lnwire.CodeNone
 }

--- a/htlcswitch/link_test.go
+++ b/htlcswitch/link_test.go
@@ -737,8 +737,10 @@ func TestChannelLinkMultiHopUnknownPaymentHash(t *testing.T) {
 	// Send payment and expose err channel.
 	_, err = n.aliceServer.htlcSwitch.SendHTLC(n.bobServer.PubKey(), htlc,
 		newMockDeobfuscator())
-	if err.Error() != lnwire.CodeUnknownPaymentHash.String() {
-		t.Fatal("error haven't been received")
+	if err == nil {
+		t.Fatalf("error haven't been received: %v", err)
+	} else if err.Error() != lnwire.CodeUnknownPaymentHash.String() {
+		t.Fatalf("wrong error have been received: %v", err)
 	}
 
 	// Wait for Alice to receive the revocation.

--- a/htlcswitch/switch_test.go
+++ b/htlcswitch/switch_test.go
@@ -40,7 +40,14 @@ func TestSwitchForward(t *testing.T) {
 	aliceChannelLink := newMockChannelLink(chanID1, aliceChanID, alicePeer)
 	bobChannelLink := newMockChannelLink(chanID2, bobChanID, bobPeer)
 
+	cdb, cleanUp, err := makeTestDB()
+	defer cleanUp()
+	if err != nil {
+		t.Fatalf("unable to make test database: %v", err)
+	}
+
 	s := New(Config{
+		DB: cdb,
 		UpdateTopology: func(msg *lnwire.ChannelUpdate) error {
 			return nil
 		},
@@ -122,7 +129,14 @@ func TestSwitchCancel(t *testing.T) {
 	aliceChannelLink := newMockChannelLink(chanID1, aliceChanID, alicePeer)
 	bobChannelLink := newMockChannelLink(chanID2, bobChanID, bobPeer)
 
+	cdb, cleanUp, err := makeTestDB()
+	defer cleanUp()
+	if err != nil {
+		t.Fatalf("unable to make test database: %v", err)
+	}
+
 	s := New(Config{
+		DB: cdb,
 		UpdateTopology: func(msg *lnwire.ChannelUpdate) error {
 			return nil
 		},
@@ -202,7 +216,14 @@ func TestSwitchAddSamePayment(t *testing.T) {
 	aliceChannelLink := newMockChannelLink(chanID1, aliceChanID, alicePeer)
 	bobChannelLink := newMockChannelLink(chanID2, bobChanID, bobPeer)
 
+	cdb, cleanUp, err := makeTestDB()
+	defer cleanUp()
+	if err != nil {
+		t.Fatalf("unable to make test database: %v", err)
+	}
+
 	s := New(Config{
+		DB: cdb,
 		UpdateTopology: func(msg *lnwire.ChannelUpdate) error {
 			return nil
 		},
@@ -302,7 +323,14 @@ func TestSwitchSendPayment(t *testing.T) {
 	alicePeer := newMockServer(t, "alice")
 	aliceChannelLink := newMockChannelLink(chanID1, aliceChanID, alicePeer)
 
+	cdb, cleanUp, err := makeTestDB()
+	defer cleanUp()
+	if err != nil {
+		t.Fatalf("unable to make test database: %v", err)
+	}
+
 	s := New(Config{
+		DB: cdb,
 		UpdateTopology: func(msg *lnwire.ChannelUpdate) error {
 			return nil
 		},

--- a/htlcswitch/test_utils.go
+++ b/htlcswitch/test_utils.go
@@ -50,6 +50,31 @@ var (
 		"3135609736119018462340006816851118", 10)
 )
 
+// makeTestDB creates a new instance of the ChannelDB for testing purposes. A
+// callback which cleans up the created temporary directories is also returned
+// and intended to be executed after the test completes.
+func makeTestDB() (*channeldb.DB, func(), error) {
+	// First, create a temporary directory to be used for the duration of
+	// this test.
+	tempDirName, err := ioutil.TempDir("", "channeldb")
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// Next, create channeldb for the first time.
+	cdb, err := channeldb.Open(tempDirName)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	cleanUp := func() {
+		cdb.Close()
+		os.RemoveAll(tempDirName)
+	}
+
+	return cdb, cleanUp, nil
+}
+
 // mockGetChanUpdateMessage helper function which returns topology update
 // of the channel
 func mockGetChanUpdateMessage() (*lnwire.ChannelUpdate, error) {

--- a/server.go
+++ b/server.go
@@ -162,6 +162,7 @@ func newServer(listenAddrs []string, chanDB *channeldb.DB, cc *chainControl,
 	}
 
 	s.htlcSwitch = htlcswitch.New(htlcswitch.Config{
+		DB: chanDB,
 		LocalChannelClose: func(pubKey []byte,
 			request *htlcswitch.ChanClose) {
 			s.peersMtx.RLock()
@@ -248,7 +249,7 @@ func newServer(listenAddrs []string, chanDB *channeldb.DB, cc *chainControl,
 			// decryptor so we can parse+decode any failures
 			// incurred by this payment within the switch.
 			errorDecryptor := &htlcswitch.FailureDeobfuscator{
-				OnionDeobfuscator: sphinx.NewOnionDeobfuscator(circuit),
+				OnionDeobfuscator: *sphinx.NewOnionDeobfuscator(circuit),
 			}
 
 			var firstHopPub [33]byte


### PR DESCRIPTION
In this commit the payment circuit persistence have been added which
is needed to properly propagate the settle/fail htlc messages after node
restart.