### PR TITLE
htlcswitch: Fix typo in logging

### DIFF
--- a/htlcswitch/switch.go
+++ b/htlcswitch/switch.go
@@ -723,9 +723,10 @@ func (s *Switch) htlcForwarder() {
 
 			// Otherwise, we'll log this diff, then accumulate the
 			// new stats into the running total.
-			log.Infof("Sent %v satoshis received %v satoshi "+
+			log.Infof("Sent %v satoshis received %v satoshis "+
 				"in the last 10 seconds (%v tx/sec)",
-				diffSatSent, diffSatRecv, float64(diffNumUpdates)/10)
+				int64(diffSatSent), int64(diffSatRecv),
+				float64(diffNumUpdates)/10)
 
 			totalNumUpdates += diffNumUpdates
 			totalSatSent += diffSatSent


### PR DESCRIPTION
Because the .String() method of an amount already includes a unit string
("BTC" usually), it was printing "0.00000001 BTC satoshi".