### PR TITLE
networktest: use StopDaemon RPC to stop lnd instead of SIGINT

### DIFF
--- a/networktest.go
+++ b/networktest.go
@@ -11,7 +11,6 @@ import (
 	"net"
 	"os"
 	"path/filepath"
-	"runtime"
 	"strconv"
 	"strings"
 	"sync"
@@ -308,13 +307,11 @@ func (l *lightningNode) Stop() error {
 	default:
 	}
 
-	if runtime.GOOS == "windows" {
-		if err := l.cmd.Process.Signal(os.Kill); err != nil {
-			return err
-		}
-	} else if err := l.cmd.Process.Signal(os.Interrupt); err != nil {
-		return err
-	}
+	// Don't watch for error because sometimes the RPC connection gets
+	// closed before a response is returned.
+	req := lnrpc.StopRequest{}
+	ctx := context.Background()
+	l.LightningClient.StopDaemon(ctx, &req)
 
 	close(l.quit)
 	l.wg.Wait()


### PR DESCRIPTION
This PR uses the `StopDaemon` RPC to stop `lnd` instead of SIGINT (or SIGKILL on Windows).

Currently, tests often fail with the reason:

```lnd_test.go:67: Error outside of test: *errors.errorString lnd finished with error (stderr):```

This is because `lnd` exits with error code 130 (stopped by SIGINT). When `StopDaemon` is used, the process exits without an error code. However, the code in this PR doesn't watch for an error returned from the RPC server as the connection is often dropped by `lnd` as it shuts down before the response can be sent/read.