### PR TITLE
Close spendChan after delivering ntfn

### DIFF
--- a/chainntnfs/btcdnotify/btcd.go
+++ b/chainntnfs/btcdnotify/btcd.go
@@ -398,8 +398,12 @@ out:
 							"spend notification for "+
 							"outpoint=%v", ntfn.targetOutpoint)
 						ntfn.spendChan <- spendDetails
-					}
 
+						// Close spendChan to ensure that any calls to Cancel will not
+						// block. This is safe to do since the channel is buffered, and the
+						// message can still be read by the receiver.
+						close(ntfn.spendChan)
+					}
 					delete(b.spendNotifications, prevOut)
 				}
 			}

--- a/chainntnfs/neutrinonotify/neutrino.go
+++ b/chainntnfs/neutrinonotify/neutrino.go
@@ -398,6 +398,11 @@ func (n *NeutrinoNotifier) notificationDispatcher() {
 								"spend notification for "+
 								"outpoint=%v", ntfn.targetOutpoint)
 							ntfn.spendChan <- spendDetails
+
+							// Close spendChan to ensure that any calls to Cancel will not
+							// block. This is safe to do since the channel is buffered, and the
+							// message can still be read by the receiver.
+							close(ntfn.spendChan)
 						}
 
 						delete(n.spendNotifications, prevOut)


### PR DESCRIPTION
Resolves a synchronization error that prevents channels from being closed properly, resulting in failed test cases due to timeouts.

Issue occurs when spend notifications has already been delivered when Cancel is called.  The delivery of notifications removes the reference to the spendChan from the registry's internal map, preventing the channel from being properly closed during the actual Cancel.  The solution is to close each channel after queuing the notification, this way we ensure that any subsequent reads will see the properly closed spendChan and exit.

Still in the process of ensuring other flakes are not produced or further related to this issue.