### PR TITLE
Flesh out gRPC guides, consolidate installation docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,53 +51,9 @@ said, `lnd` the current status of `lnd`'s BOLT compliance is:
   - [X] BOLT 8: Encrypted and Authenticated Transport
 
 ## Installation
-  In order to build from source, the following build dependencies are 
-  required:
+  In order to build from source, please see [the installation
+  instructions](docs/INSTALL.md).
   
-  * **Go:** Installation instructions can be found [here](http://golang.org/doc/install). 
-  
-    It is recommended to add `$GOPATH/bin` to your `PATH` at this point.
-    **Note:** If you are building with `Go 1.5`, then you'll need to 
-    enable the vendor experiment by setting the `GO15VENDOREXPERIMENT` 
-    environment variable to `1`. If you're using `Go 1.6` or later, then
-    it is safe to skip this step.
-
-  * **Glide:** This project uses `Glide` to manage dependencies as well 
-    as to provide *reproducible builds*. To install `Glide`, execute the
-    following command (assumes you already have Go properly installed):
-    ```
-    $ go get -u github.com/Masterminds/glide
-    ```
-  * **btcd:** This project currently requires `btcd` with segwit support,
-    which is not yet merged into the master branch. Instead,
-    [roasbeef](https://github.com/roasbeef/btcd) maintains a fork with his
-    segwit implementation applied. To install, please see 
-    [the installation instructions](docs/INSTALL.md).
-
-With the preliminary steps completed, to install `lnd`, `lncli`, and all
-related dependencies run the following commands:
-```
-$ git clone https://github.com/lightningnetwork/lnd $GOPATH/src/github.com/lightningnetwork/lnd
-$ cd $GOPATH/src/github.com/lightningnetwork/lnd
-$ glide install
-$ go install . ./cmd/...
-```
-
-### Updating
-To update your version of `lnd` to the latest version run the following 
-commands:
-```
-$ cd $GOPATH/src/github.com/lightningnetwork/lnd
-$ git pull && glide install
-$ go install . ./cmd/...
-```
-
-### Tests
-To check that `lnd` was installed properly run the following command:
-```
-go install; go test -v -p 1 $(go list ./... | grep -v  '/vendor/')
-```
-
 ## IRC
   * irc.freenode.net
   * channel #lnd

--- a/docker/README.md
+++ b/docker/README.md
@@ -279,7 +279,7 @@ bitcoins. The schema will be following:
 ```
 
 First of all you need to run `btcd` node in `testnet` and wait it to be 
-synced with test network (`May the Force and Patience be with you` ᕦ(ò_óˇ)ᕤ).
+synced with test network (`May the Force and Patience be with you`).
 ```bash 
 # Init bitcoin network env variable:
 $ export NETWORK="testnet"

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -17,18 +17,16 @@
 
     At this point, you should set your `$GOPATH` environment variable, which
     represents the path to your workspace. By default, `$GOPATH` is set to
-    `~/go`. Be sure to set your `$GOPATH` every time you open a new terminal
-    window.
-    ```
-    export GOPATH=~/projects/lightning
-    ```
-    It is recommended to add `$GOPATH/bin` to your `PATH` at this point, like
-    so:
+    `~/go`. You wll also need to add `$GOPATH/bin` to your `PATH`. This ensures
+    that your shell will be able to detect the binaries you install.
+
     ```bash
+    export GOPATH=~/projects/lightning
     export PATH=$PATH:$GOPATH/bin
     ```
-    This will ensure that your shell will be able to detect the binaries that
-    were just installed.
+    We recommend placing the above in your .bashrc or in a setup
+    script so that you can avoid typing this every time you open a new terminal
+    window.
 
   * **Glide:** This project uses `Glide` to manage dependencies as well 
     as to provide *reproducible builds*. To install `Glide`, execute the
@@ -131,7 +129,7 @@ If you are doing local development, such as for the tutorial, you'll want to
 start both `btcd` and `lnd` in the `simnet` mode. Simnet is similar to regtest
 in that you'll be able to instantly mine blocks as needed to test `lnd`
 locally. In order to start either daemon in the `simnet` mode use `simnet`
-instead of `testnet`, such as adding the `--bitcoin.simnet` flag instead of the
+instead of `testnet`, adding the `--bitcoin.simnet` flag instead of the
 `--bitcoin.testnet` flag.
 
 Another relevant command line flag for local testing of new `lnd` developments
@@ -144,7 +142,9 @@ of your `sendpayment` commands.
 ### Running LND
 
 If you are on testnet, run this command after `btcd` has finished syncing.
-Otherwise, replace `--bitcoin.testnet` with `--bitcoin.simnet`
+Otherwise, replace `--bitcoin.testnet` with `--bitcoin.simnet`. If you
+installing `lnd` in preparation for the
+[tutorial](//dev.lightning.community/tutorial), you may skip this step.
 ```
 lnd --bitcoin.active --bitcoin.testnet --debuglevel=debug --bitcoin.rpcuser=kek --bitcoin.rpcpass=kek --externalip=X.X.X.X
 ```

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -1,50 +1,106 @@
-# Installation for lnd and btcd
+# Installation
 
-### If Glide isn't installed, install it:
+### Preliminaries
+  In order to work with [`lnd`](https://github.com/lightningnetwork/lnd), the following build dependencies are required:
+  
+  * **Go:** `lnd` is written in Go. To install, run one of the following commands:
+  
+    ```
+    # On Linux:
+    sudo apt-get install golang-go
+
+    # On Mac OS X
+    brew install go
+    ```
+    More detailed installation instructions can be found
+    [here](http://golang.org/doc/install). 
+
+    At this point, you should set your `$GOPATH` environment variable, which
+    represents the path to your workspace. By default, `$GOPATH` is set to
+    `~/go`. Be sure to set your `$GOPATH` every time you open a new terminal
+    window.
+    ```
+    export GOPATH=~/projects/lightning
+    ```
+    It is recommended to add `$GOPATH/bin` to your `PATH` at this point, like
+    so:
+    ```bash
+    export PATH=$PATH:$GOPATH/bin
+    ```
+    This will ensure that your shell will be able to detect the binaries that
+    were just installed.
+
+  * **Glide:** This project uses `Glide` to manage dependencies as well 
+    as to provide *reproducible builds*. To install `Glide`, execute the
+    following command (assumes you already have Go properly installed):
+    ```
+    go get -u github.com/Masterminds/glide
+    ```
+
+### Installing LND
+
+With the preliminary steps completed, to install `lnd`, `lncli`, and all
+related dependencies run the following commands:
+```
+git clone https://github.com/lightningnetwork/lnd $GOPATH/src/github.com/lightningnetwork/lnd
+cd $GOPATH/src/github.com/lightningnetwork/lnd
+glide install
+go install . ./cmd/...
+```
+
+**Updating**
+
+To update your version of `lnd` to the latest version run the following 
+commands:
+```
+cd $GOPATH/src/github.com/lightningnetwork/lnd
+git pull && glide install
+go install . ./cmd/...
+```
+
+**Tests**
+
+To check that `lnd` was installed properly run the following command:
+```
+go install; go test -v -p 1 $(go list ./... | grep -v  '/vendor/')
+```
+
+### Installing BTCD
+
+`lnd` currently requires `btcd` with segwit support, which is not yet merged
+into the master branch. Instead, [roasbeef](https://github.com/roasbeef/btcd)
+maintains a fork with his segwit implementation applied. To install, run the
+following commands:
+
+Install **btcutil**: (must be from roasbeef fork, not from btcsuite)
+```
+go get -u github.com/roasbeef/btcutil
+```
+
+Install **btcd**: (must be from roasbeef fork, not from btcsuite)
+```
+cd $GOPATH/src/github.com/roasbeef/btcd
+glide install
+go install . ./cmd/...
+```
+
+### Starting btcd
+
+Running the following command will create `rpc.cert` and default `btcd.conf`.
 
 ```
-$ go get -u github.com/Masterminds/glide
+btcd --testnet --txindex --rpcuser=kek --rpcpass=kek
 ```
-
-### Install lnd:
-
-```
-$ cd $GOPATH
-$ git clone https://github.com/lightningnetwork/lnd $GOPATH/src/github.com/lightningnetwork/lnd
-$ cd $GOPATH/src/github.com/lightningnetwork/lnd
-$ glide install
-$ go install . ./cmd/...
-```
-
-### Install btcutil: (must be from roasbeef fork, not from btcsuite)
-
-```
-$ go get -u github.com/roasbeef/btcutil
-```
-
-### Install btcd: (must be from roasbeef fork, not from btcsuite)
-
-```
-$ cd $GOPATH/src/github.com/roasbeef/btcd
-$ glide install
-$ go install . ./cmd/...
-```
-
-### Start btcd (will create rpc.cert and default btcd.conf):
-
-```
-$ btcd --testnet --txindex --rpcuser=kek --rpcpass=kek
-```
-
-Before you'll be able to use `lnd` on testnet, `btcd` needs to first fully sync
-the blockchain. Depending on your hardware, this may take up to a few hours.
+If you want to use `lnd` on testnet, `btcd` needs to first fully sync the
+testnet blockchain. Depending on your hardware, this may take up to a few
+hours.
 
 (NOTE: It may take several minutes to find segwit-enabled peers.)
 
-While `btcd` is syncing you can check on it's progress using btcd's `getinfo`
+While `btcd` is syncing you can check on its progress using btcd's `getinfo`
 RPC command:
 ```
-$ btcctl --testnet getinfo
+btcctl --testnet --rpcuser=kek --rpcpass=kek getinfo
 {
   "version": 120000,
   "protocolversion": 70002,
@@ -64,26 +120,18 @@ time.
 
 You can test your `btcd` node's connectivity using the `getpeerinfo` command:
 ```
-$ btcctl --testnet getpeerinfo | more
+btcctl --testnet --rpcuser=kek --rpcpass=kek getpeerinfo | more
 ```
 
-### Start lnd: (once btcd has synced testnet)
+### LND
 
-```
-$ lnd --bitcoin.active --bitcoin.testnet --debuglevel=debug --externalip=X.X.X.X
-```
+#### Simnet vs. Testnet Development
 
-If you'd like to signal to other nodes on the network that you'll accept
-incoming channels (as peers need to connect inbound to initiate a channel
-funding workflow), then the `--externalip` flag should be set to your publicly
-reachable IP address.
-
-#### Simnet Development
-
-If doing local development, you'll want to start both `btcd` and `lnd` in the
-`simnet` mode. Simnet is similar to regtest in that you'll be able to instantly
-mine blocks as needed to test `lnd` locally. In order to start either daemon in
-the `simnet` mode add the `--bitcoin.simnet` flag instead of the
+If you are doing local development, such as for the tutorial, you'll want to
+start both `btcd` and `lnd` in the `simnet` mode. Simnet is similar to regtest
+in that you'll be able to instantly mine blocks as needed to test `lnd`
+locally. In order to start either daemon in the `simnet` mode use `simnet`
+instead of `testnet`, such as adding the `--bitcoin.simnet` flag instead of the
 `--bitcoin.testnet` flag.
 
 Another relevant command line flag for local testing of new `lnd` developments
@@ -92,15 +140,25 @@ automatically settle a special type of HTLC sent to it. This means that you
 won't need to manually insert invoices in order to test payment connectivity.
 To send this "special" HTLC type, include the `--debugsend` command at the end
 of your `sendpayment` commands.
+
+### Running LND
+
+If you are on testnet, run this command after `btcd` has finished syncing.
+Otherwise, replace `--bitcoin.testnet` with `--bitcoin.simnet`
 ```
-$ lnd --bitcoin.active --bitcoin.simnet --debughtlc
+lnd --bitcoin.active --bitcoin.testnet --debuglevel=debug --bitcoin.rpcuser=kek --bitcoin.rpcpass=kek --externalip=X.X.X.X
 ```
 
-### Create an lnd.conf (Optional)
+If you'd like to signal to other nodes on the network that you'll accept
+incoming channels (as peers need to connect inbound to initiate a channel
+funding workflow), then the `--externalip` flag should be set to your publicly
+reachable IP address.
+
+# Creating an lnd.conf (Optional)
 
 Optionally, if you'd like to have a persistent configuration between `lnd`
 launches, allowing you to simply type `lnd --bitcoin.testnet --bitcoin.active`
-at the command line. You can create an `lnd.conf`. 
+at the command line, you can create an `lnd.conf`. 
 
 **On MacOS, located at:**
 `/Users/[username]/Library/Application Support/Lnd/lnd.conf`
@@ -114,23 +172,17 @@ Here's a sample `lnd.conf` to get you started:
 debuglevel=trace
 debughtlc=true
 maxpendingchannels=10
-profile=5060
-externalip=128.111.13.23
-externalip=111.32.29.29
 
 [Bitcoin]
 bitcoin.active=1
-bitcoin.rpchost=localhost:18334
 ```
 
 Notice the `[Bitcoin]` section. This section houses the parameters for the
-Bitcoin chain. Also `lnd` also supports Litecoin, one is able to also specified
-(but not concurrently with Bitcoin!) the proper parameters, so `lnd` knows to
-be active on Litecoin's testnet4.
+Bitcoin chain. `lnd` also supports Litecoin testnet4 (but not both BTC and LTC
+at the same time), so when working with Litecoin be sure to set to parameters
+for Litecoin accordingly.
 
-#### Accurate as of:
-roasbeef/btcd commit: f8c02aff4e7a807ba0c1349e2db03695d8e790e8
-
-roasbeef/btcutil commit: a259eaf2ec1b54653cdd67848a41867f280797ee
-
-lightningnetwork/lnd commit: d7b36c6
+# Accurate as of:
+- _roasbeef/btcd commit:_ `f8c02aff4e7a807ba0c1349e2db03695d8e790e8` 
+- _roasbeef/btcutil commit:_ `a259eaf2ec1b54653cdd67848a41867f280797ee` 
+- _lightningnetwork/lnd commit:_ `d7b36c6`

--- a/docs/grpc/javascript.md
+++ b/docs/grpc/javascript.md
@@ -1,13 +1,13 @@
 # How to write a simple `lnd` client in Javascript using `node.js`
 
-First, you'll need to initialize a simple nodejs project:
+### Setup and Installation
 
+First, you'll need to initialize a simple nodejs project:
 ```
 npm init (or npm init -f if you want to use the default values without prompt)
 ```
 
 Then you need to install the Javascript grpc library dependency:
-
 ```
 npm install grpc --save
 ```
@@ -18,35 +18,34 @@ at least somewhere reachable by your Javascript code).
 The `rpc.proto` file is [located in the `lnrpc` directory of the `lnd`
 sources](https://github.com/lightningnetwork/lnd/blob/master/lnrpc/rpc.proto).
 
-In order to allow the auto code generated to compile the protos succucsfully,
+In order to allow the auto code generated to compile the protos successfully,
 you'll need to comment out the following line:
 ```
 //import "google/api/annotations.proto";
 ```
 
-Let's now write some Javascript code that simply displays the `getinfo` command
-result on the console:
+#### Imports and Client
+
+Every time you work with Javascript gRPC, you will have to import `grpc`, load
+`rpc.proto`, and create a connection to your client like so:
 
 ```js
 var grpc = require('grpc');
-
 var lnrpcDescriptor = grpc.load("rpc.proto");
-
 var lnrpc = lnrpcDescriptor.lnrpc;
-
 var lightning = new lnrpc.Lightning('localhost:10009', grpc.credentials.createInsecure());
-
-lightning.getInfo({}, function(err, response) {
-	console.log('GetInfo:', response);
-});
-
 ```
 
-You just have to lauch your newly created Javascript file `getinfo.js` using
-`nodejs`:
+### Examples
 
-```
-node getinfo.js
+Let's walk through some examples of Javascript gRPC clients.
+
+#### Simple RPC
+
+```js
+> lightning.getInfo({}, function(err, response) {
+  	console.log('GetInfo:', response);
+  });
 ```
 
 You should get something like this in your console:
@@ -55,19 +54,96 @@ You should get something like this in your console:
 GetInfo: { identity_pubkey: '03c892e3f3f077ea1e381c081abb36491a2502bc43ed37ffb82e264224f325ff27',
   alias: '',
   num_pending_channels: 0,
-  num_active_channels: 0,
-  num_peers: 0,
-  block_height: 1087612,
-  block_hash: '000000000000024b2acc37958b15010057c6abc0a48f83c8dd67034bee2cb823',
-  synced_to_chain: true,
-  testnet: true }
+  num_active_channels: 1,
+  num_peers: 1,
+  block_height: 1006,
+  block_hash: '198ba1dc43b4190e507fa5c7aea07a74ec0009a9ab308e1736dbdab5c767ff8e',
+  synced_to_chain: false,
+  testnet: false,
+  chains: [ 'bitcoin' ] }
 ```
 
+#### Response-streaming RPC
+
+```js
+var call = lightning.subscribeInvoices({});
+call.on('data', function(invoice) {
+    console.log(invoice);
+})
+.on('end', function() {
+  // The server has finished sending
+})
+.on('status', function(status) {
+  // Process status
+  console.log("Current status" + status);
+});
+```
+Now, create an invoice for your node at `localhost:10009` and send a payment to
+it. Your Javascript console should display the details of the recently satisfied
+invoice.
+
+#### Bidirectional-streaming RPC
+
+This example has a few dependencies:
+```shell
+npm install --save async lodash bytebuffer
+```
+
+You can run the following in your shell or put it in a program and run it like
+`node script.js`
+
+```js
+// Load some libraries specific to this example
+var async = require('async');
+var _ = require('lodash');
+var ByteBuffer = require('bytebuffer');
+
+var dest_pubkey = <RECEIVER_ID_PUBKEY>;
+var dest_pubkey_bytes = ByteBuffer.fromHex(dest_pubkey);
+
+// Set a listener on the bidirectional stream
+var call = lightning.sendPayment();
+call.on('data', function(payment) {
+  console.log("Payment sent:");
+  console.log(payment);
+});
+call.on('end', function() {
+  // The server has finished
+  console.log("END");
+});
+
+// You can send single payments like this
+call.write({ dest: dest_pubkey_bytes, amt: 6969 });
+
+// Or send a bunch of them like this
+function paymentSender(destination, amount) {
+  return function(callback) {
+    console.log("Sending " + amount + " satoshis");
+    console.log("To: " + destination);
+    call.write({
+      dest: destination,
+      amt: amount
+    });
+    _.delay(callback, 2000);
+  };
+}
+var payment_senders = [];
+for (var i = 0; i < 10; i++) {
+  payment_senders[i] = paymentSender(dest_pubkey_bytes, 100);
+}
+async.series(payment_senders, function() {
+  call.end();
+});
+
+```
+This example will send a payment of 100 satoshis every 2 seconds.
+
+### Conclusion
+
 With the above, you should have all the `lnd` related `gRPC` dependencies
-installed locally in your local project. In order to get up to speed with
-`protofbuf` usage from Javascript, see [this official `protobuf` reference for
+installed locally in your project. In order to get up to speed with `protofbuf`
+usage from Javascript, see [this official `protobuf` reference for
 Javascript](https://developers.google.com/protocol-buffers/docs/reference/javascript-generated).
 Additionally, [this official gRPC
-resource](http://www.grpc.io/docs/tutorials/basic/node.html) details how to
-drive `gRPC` from `node.js` including the basics of making RPC calls, streaming
-RPC's (bi-directional and uni-directional), etc.
+resource](http://www.grpc.io/docs/tutorials/basic/node.html) provides more
+details around how to drive `gRPC` from `node.js`.

--- a/docs/grpc/python.md
+++ b/docs/grpc/python.md
@@ -44,7 +44,7 @@ Python gRPC.
 
 #### Imports and Client
 
-Everytime you use Python gRPC, you will have to import the generated rpc modeuls
+Everytime you use Python gRPC, you will have to import the generated rpc modules
 and set up a channel and stub to your connect to your `lnd` node:
 
 ```python
@@ -52,13 +52,19 @@ import rpc_pb2 as ln
 import rpc_pb2_grpc as lnrpc
 import grpc
 
-channel = grpc.insecure_channel('localhost:10009')
+# Lnd cert is at ~/.lnd/tls.cert on Linux and
+# ~/Library/Application Support/Lnd/tls.cert on Mac
+cert = open('~/.lnd/tls.cert').read()
+creds = grpc.ssl_channel_credentials(cert)
+channel = grpc.secure_channel('localhost:10009', creds)
 stub = lnrpc.LightningStub(channel)
 ```
 
 ### Examples
 
-Let's walk through some examples of Python gRPC clients.
+Let's walk through some examples of Python gRPC clients. These examples assume
+that you have at least two `lnd` nodes running, the RPC location of one of which
+is at the default `localhost:10009`, with an open channel between the two nodes.
 
 #### Simple RPC
 
@@ -75,8 +81,19 @@ request = ln.InvoiceSubscription()
 for invoice in stub.SubscribeInvoices(request);
     print invoice
 ```
-Now, create an invoice for your node at `localhost:10009` and send a payment to
-it. Your Python console should display the details of the recently satisfied
+
+Now, create an invoice for your node at `localhost:10009`and send a payment to
+it from another node.
+```bash
+$ lncli addinvoice --value=100
+{
+	"r_hash": <R_HASH>,
+	"pay_req": <PAY_REQ>
+}
+$ lncli sendpayment --pay_req=<PAY_REQ>
+```
+
+Your Python console should now display the details of the recently satisfied
 invoice.
 
 #### Bidirectional-streaming RPC


### PR DESCRIPTION
Python and Javascript gRPC guides
- Now serve as complete standalone guides programmatically pulled into [dev.lightning.community](http://dev.lightning.community)
- Contains code examples for Simple, Response-streaming, and Bidirectional RPCs

Consolidate installation docs

Remove characters from the docker guide that break utf-8 encoding (you have to decode it with `latin-1` codec which is too hacky to implement as special logic in the dev site rendering code