### PR TITLE
Server-Peer Synchronization

### DIFF
--- a/fundingmanager.go
+++ b/fundingmanager.go
@@ -359,26 +359,6 @@ func (f *fundingManager) Stop() error {
 	return nil
 }
 
-type numPendingReq struct {
-	resp chan uint32
-	err  chan error
-}
-
-// NumPendingChannels returns the number of pending channels currently
-// progressing through the reservation workflow.
-func (f *fundingManager) NumPendingChannels() (uint32, error) {
-	respChan := make(chan uint32, 1)
-	errChan := make(chan error)
-
-	req := &numPendingReq{
-		resp: respChan,
-		err:  errChan,
-	}
-	f.queries <- req
-
-	return <-respChan, <-errChan
-}
-
 // nextPendingChanID returns the next free pending channel ID to be used to
 // identify a particular future channel funding workflow.
 func (f *fundingManager) nextPendingChanID() [32]byte {
@@ -459,8 +439,6 @@ func (f *fundingManager) reservationCoordinator() {
 
 		case req := <-f.queries:
 			switch msg := req.(type) {
-			case *numPendingReq:
-				f.handleNumPending(msg)
 			case *pendingChansReq:
 				f.handlePendingChannels(msg)
 			}
@@ -468,20 +446,6 @@ func (f *fundingManager) reservationCoordinator() {
 			return
 		}
 	}
-}
-
-// handleNumPending handles a request for the total number of pending channels.
-func (f *fundingManager) handleNumPending(msg *numPendingReq) {
-	// TODO(roasbeef): remove this method?
-	dbPendingChannels, err := f.cfg.Wallet.Cfg.Database.FetchPendingChannels()
-	if err != nil {
-		close(msg.resp)
-		msg.err <- err
-		return
-	}
-
-	msg.resp <- uint32(len(dbPendingChannels))
-	msg.err <- nil
 }
 
 // handlePendingChannels responds to a request for details concerning all

--- a/htlcswitch/mock.go
+++ b/htlcswitch/mock.go
@@ -330,7 +330,7 @@ func (s *mockServer) Stop() {
 		return
 	}
 
-	go s.htlcSwitch.Stop()
+	s.htlcSwitch.Stop()
 
 	close(s.quit)
 	s.wg.Wait()

--- a/lnd.go
+++ b/lnd.go
@@ -145,8 +145,8 @@ func lndMain() error {
 			return nil
 		},
 		ArbiterChan:    server.breachArbiter.newContracts,
-		SendToPeer:     server.sendToPeer,
-		FindPeer:       server.findPeer,
+		SendToPeer:     server.SendToPeer,
+		FindPeer:       server.FindPeer,
 		TempChanIDSeed: chanIDSeed,
 		FindChannel: func(chanID lnwire.ChannelID) (*lnwallet.LightningChannel, error) {
 			dbChannels, err := chanDB.FetchAllChannels()

--- a/lnd_test.go
+++ b/lnd_test.go
@@ -290,6 +290,8 @@ func assertNumConnections(
 					bob.nodeID, err)
 			}
 			if len(aNumPeers.Peers) != expected {
+				// Continue polling if this is not the final
+				// loop.
 				if i > 0 {
 					continue
 				}
@@ -297,12 +299,18 @@ func assertNumConnections(
 					"expected %v, got %v", expected, len(aNumPeers.Peers))
 			}
 			if len(bNumPeers.Peers) != expected {
+				// Continue polling if this is not the final
+				// loop.
 				if i > 0 {
 					continue
 				}
 				t.Fatalf("number of peers connected to bob is incorrect: "+
 					"expected %v, got %v", expected, len(bNumPeers.Peers))
 			}
+
+			// Alice and Bob both have the required number of
+			// peers, stop polling and return to caller.
+			return
 		}
 	}
 }

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -611,7 +611,7 @@ func (r *rpcServer) CloseChannel(in *lnrpc.CloseChannelRequest,
 		// as eligible for forwarding HTLC's. If the peer is online,
 		// then we'll also purge all of its indexes.
 		remotePub := &channel.StateSnapshot().RemoteIdentity
-		if peer, err := r.server.findPeer(remotePub); err == nil {
+		if peer, err := r.server.FindPeer(remotePub); err == nil {
 			// TODO(roasbeef): actually get the active channel
 			// instead too?
 			//  * so only need to grab from database
@@ -1108,7 +1108,7 @@ func (r *rpcServer) ListChannels(ctx context.Context,
 		chanID, _ = graph.ChannelID(&chanPoint)
 
 		var peerOnline bool
-		if _, err := r.server.findPeer(nodePub); err == nil {
+		if _, err := r.server.FindPeer(nodePub); err == nil {
 			peerOnline = true
 		}
 

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -812,11 +812,12 @@ func (r *rpcServer) GetInfo(ctx context.Context,
 		activeChannels += uint32(len(serverPeer.ChannelSnapshots()))
 	}
 
-	pendingChannels, err := r.server.fundingMgr.NumPendingChannels()
+	pendingChannels, err := r.server.chanDB.FetchPendingChannels()
 	if err != nil {
-		return nil, fmt.Errorf("unable to get number of pending "+
+		return nil, fmt.Errorf("unable to get retrieve pending "+
 			"channels: %v", err)
 	}
+	nPendingChannels := uint32(len(pendingChannels))
 
 	idPub := r.server.identityPriv.PubKey().SerializeCompressed()
 
@@ -839,7 +840,7 @@ func (r *rpcServer) GetInfo(ctx context.Context,
 	// TODO(roasbeef): add synced height n stuff
 	return &lnrpc.GetInfoResponse{
 		IdentityPubkey:     hex.EncodeToString(idPub),
-		NumPendingChannels: pendingChannels,
+		NumPendingChannels: nPendingChannels,
 		NumActiveChannels:  activeChannels,
 		NumPeers:           uint32(len(serverPeers)),
 		BlockHeight:        uint32(bestHeight),


### PR DESCRIPTION
This commit alters the synchronization patterns used in the server such that the internal state is protected by a single mutex.  Overall, this simplifies the ability to reason about the behavior and manipulation of the internal state, which has resolved a few flakes related to race conditions that were observed beforehand.

This PR originated as a fix for synchronizing the message broadcast, but has expanded into a full refactor of the server's synchronization.  A significant portion of this refactor was spent properly synchronizing disconnections from peers.  We observed a some flakes related to the timing of disconnections, particularly during restarts.  We also modified the implementation of `assertNumConnections` to poll for 3 seconds to ensure that the remote peer has acknowledged a disconnecting local peer, and has had time to gracefully exit.

To the best of my knowledge, this resolves #212 and resolves #242.  The former is improved by adding synchronization to message broadcasts, while the latter involved fixing a case where the server's lock was not released properly after attempting an outbound connection.