### PR TITLE
Always propagate self node announcement 

### DIFF
--- a/discovery/service_test.go
+++ b/discovery/service_test.go
@@ -141,6 +141,12 @@ func (r *mockGraphSource) UpdateEdge(edge *channeldb.ChannelEdgePolicy) error {
 	return nil
 }
 
+func (r *mockGraphSource) SourceNode() *channeldb.LightningNode {
+	return &channeldb.LightningNode{
+		PubKey: nodeKeyPub1,
+	}
+}
+
 func (r *mockGraphSource) SelfEdges() ([]*channeldb.ChannelEdgePolicy, error) {
 	return nil, nil
 }

--- a/lnd.go
+++ b/lnd.go
@@ -137,7 +137,7 @@ func lndMain() error {
 			)
 		},
 		CurrentNodeAnnouncement: func() (*lnwire.NodeAnnouncement, error) {
-			return server.genNodeAnnouncement(true)
+			return server.genNodeAnnouncement(false)
 		},
 		SendAnnouncement: func(msg lnwire.Message) error {
 			server.discoverSrv.ProcessLocalAnnouncement(msg,

--- a/routing/router.go
+++ b/routing/router.go
@@ -46,6 +46,10 @@ type ChannelGraphSource interface {
 	// edge considered as not fully constructed.
 	UpdateEdge(policy *channeldb.ChannelEdgePolicy) error
 
+	// SourceNode returns the "source" node which is the center of the
+	// star-graph.
+	SourceNode() *channeldb.LightningNode
+
 	// ForAllOutgoingChannels is used to iterate over all channels
 	// eminating from the "source" node which is the center of the
 	// star-graph.
@@ -1118,6 +1122,14 @@ func (r *ChannelRouter) UpdateEdge(update *channeldb.ChannelEdgePolicy) error {
 	case <-r.quit:
 		return errors.New("router has been shutted down")
 	}
+}
+
+// SourceNode returns the "source" node which is the center of the
+// star-graph.
+//
+// NOTE: This method is part of the ChannelGraphSource interface.
+func (r *ChannelRouter) SourceNode() *channeldb.LightningNode {
+	return r.selfNode
 }
 
 // CurrentBlockHeight returns the block height from POV of the router subsystem.

--- a/routing/router_test.go
+++ b/routing/router_test.go
@@ -108,6 +108,29 @@ func createTestCtx(startingHeight uint32, testGraph ...string) (*testCtx, func()
 	}, cleanUp, nil
 }
 
+// TestGetSourceNode checks that we can fetch the graph's source node from the
+// router.
+func TestGetSourceNode(t *testing.T) {
+	t.Parallel()
+
+	const startingBlockHeight = 101
+	ctx, cleanUp, err := createTestCtx(startingBlockHeight, basicGraphFilePath)
+	defer cleanUp()
+	if err != nil {
+		t.Fatalf("unable to create router: %v", err)
+	}
+
+	routerSource := ctx.router.SourceNode()
+	graphSource, err := ctx.graph.SourceNode()
+	if err != nil {
+		t.Fatalf("failed getting graph source node: %v", err)
+	}
+	if !routerSource.PubKey.IsEqual(graphSource.PubKey) {
+		t.Fatalf("router source node (%v) does not match graph source "+
+			"node (%v)", routerSource.PubKey, graphSource.PubKey)
+	}
+}
+
 // TestFindRoutesFeeSorting asserts that routes found by the FindRoutes method
 // within the channel router are properly returned in a sorted order, with the
 // lowest fee route coming first.


### PR DESCRIPTION
This PR changes the way a `self NodeAnnouncement` is created and sent after a new channel is opened. Now the `fundingManager` will send the same `NodeAnnouncement` as was sent last time. The `processNetworkAnnouncement` logic in `AuthenticatedGossiper` is changed to always propagate a self node announcement to peers, even though it is considered outdated.

### Reasoning
After opening a channel, the `fundingManager` would get a "refreshed" `NodeAnnouncement`, and broadcast it to the network. In tests however, this refreshed announcement didn't always get a timestamp that was bigger than the last sent announcement, causing the `testGraphTopologyNotifications` to be flaky.

 ### Additional info 
`testGraphTopologyNotifications` does now only expect a `topologyUpdate` about nodes not already known in the channel graph.