### PR TITLE
Make CurrentNodeAnnouncement threadsafe

### DIFF
--- a/fundingmanager.go
+++ b/fundingmanager.go
@@ -172,7 +172,7 @@ type fundingConfig struct {
 
 	// CurrentNodeAnnouncement should return the latest, fully signed node
 	// announcement from the backing Lighting Network node.
-	CurrentNodeAnnouncement func() (*lnwire.NodeAnnouncement, error)
+	CurrentNodeAnnouncement func() (lnwire.NodeAnnouncement, error)
 
 	// SendAnnouncement is used by the FundingManager to announce newly
 	// created channels to the rest of the Lightning Network.
@@ -1413,7 +1413,7 @@ func (f *fundingManager) announceChannel(localIDKey, remoteIDKey, localFundingKe
 		fndgLog.Errorf("can't generate node announcement: %v", err)
 		return
 	}
-	f.cfg.SendAnnouncement(nodeAnn)
+	f.cfg.SendAnnouncement(&nodeAnn)
 }
 
 // initFundingWorkflow sends a message to the funding manager instructing it

--- a/lnd.go
+++ b/lnd.go
@@ -136,7 +136,7 @@ func lndMain() error {
 				pubKey, msg,
 			)
 		},
-		CurrentNodeAnnouncement: func() (*lnwire.NodeAnnouncement, error) {
+		CurrentNodeAnnouncement: func() (lnwire.NodeAnnouncement, error) {
 			return server.genNodeAnnouncement(true)
 		},
 		SendAnnouncement: func(msg lnwire.Message) error {

--- a/server.go
+++ b/server.go
@@ -394,12 +394,12 @@ func (s *server) Stop() error {
 // genNodeAnnouncement generates and returns the current fully signed node
 // announcement. If refresh is true, then the time stamp of the announcement
 // will be updated in order to ensure it propagates through the network.
-func (s *server) genNodeAnnouncement(refresh bool) (*lnwire.NodeAnnouncement, error) {
+func (s *server) genNodeAnnouncement(refresh bool) (lnwire.NodeAnnouncement, error) {
 	s.annMtx.Lock()
 	defer s.annMtx.Unlock()
 
 	if !refresh {
-		return s.currentNodeAnn, nil
+		return *s.currentNodeAnn, nil
 	}
 
 	var err error
@@ -414,7 +414,7 @@ func (s *server) genNodeAnnouncement(refresh bool) (*lnwire.NodeAnnouncement, er
 		s.nodeSigner, s.identityPriv.PubKey(), s.currentNodeAnn,
 	)
 
-	return s.currentNodeAnn, err
+	return *s.currentNodeAnn, err
 }
 
 // establishPersistentConnections attempts to establish persistent connections


### PR DESCRIPTION
Previously, calling `CurrentNodeAnnouncement` twice in a row, would cause the first returned `NodeAnnoucement` to be modified by the second call, since a pointer to the stored struct is returned. This PR changes that by instead returning a copy of the current `NodeAnnouncement`, making the second call not altering the first one.