### PR TITLE
Initial macaroon implementation

### DIFF
--- a/config.go
+++ b/config.go
@@ -24,6 +24,8 @@ const (
 	defaultDataDirname        = "data"
 	defaultTLSCertFilename    = "tls.cert"
 	defaultTLSKeyFilename     = "tls.key"
+	defaultAdminMacFilename   = "admin.macaroon"
+	defaultReadMacFilename    = "readonly.macaroon"
 	defaultLogLevel           = "info"
 	defaultLogDirname         = "logs"
 	defaultLogFilename        = "lnd.log"
@@ -36,12 +38,14 @@ const (
 )
 
 var (
-	lndHomeDir         = btcutil.AppDataDir("lnd", false)
-	defaultConfigFile  = filepath.Join(lndHomeDir, defaultConfigFilename)
-	defaultDataDir     = filepath.Join(lndHomeDir, defaultDataDirname)
-	defaultTLSCertPath = filepath.Join(lndHomeDir, defaultTLSCertFilename)
-	defaultTLSKeyPath  = filepath.Join(lndHomeDir, defaultTLSKeyFilename)
-	defaultLogDir      = filepath.Join(lndHomeDir, defaultLogDirname)
+	lndHomeDir          = btcutil.AppDataDir("lnd", false)
+	defaultConfigFile   = filepath.Join(lndHomeDir, defaultConfigFilename)
+	defaultDataDir      = filepath.Join(lndHomeDir, defaultDataDirname)
+	defaultTLSCertPath  = filepath.Join(lndHomeDir, defaultTLSCertFilename)
+	defaultTLSKeyPath   = filepath.Join(lndHomeDir, defaultTLSKeyFilename)
+	defaultAdminMacPath = filepath.Join(lndHomeDir, defaultAdminMacFilename)
+	defaultReadMacPath  = filepath.Join(lndHomeDir, defaultReadMacFilename)
+	defaultLogDir       = filepath.Join(lndHomeDir, defaultLogDirname)
 
 	btcdHomeDir            = btcutil.AppDataDir("btcd", false)
 	defaultBtcdRPCCertFile = filepath.Join(btcdHomeDir, "rpc.cert")
@@ -88,11 +92,14 @@ type autoPilotConfig struct {
 type config struct {
 	ShowVersion bool `short:"V" long:"version" description:"Display version information and exit"`
 
-	ConfigFile  string `long:"C" long:"configfile" description:"Path to configuration file"`
-	DataDir     string `short:"b" long:"datadir" description:"The directory to store lnd's data within"`
-	TLSCertPath string `long:"tlscertpath" description:"Path to TLS certificate for lnd's RPC and REST services"`
-	TLSKeyPath  string `long:"tlskeypath" description:"Path to TLS private key for lnd's RPC and REST services"`
-	LogDir      string `long:"logdir" description:"Directory to log output."`
+	ConfigFile   string `long:"C" long:"configfile" description:"Path to configuration file"`
+	DataDir      string `short:"b" long:"datadir" description:"The directory to store lnd's data within"`
+	TLSCertPath  string `long:"tlscertpath" description:"Path to TLS certificate for lnd's RPC and REST services"`
+	TLSKeyPath   string `long:"tlskeypath" description:"Path to TLS private key for lnd's RPC and REST services"`
+	NoMacaroons  bool   `long:"no-macaroons" description:"Disable macaroon authentication"`
+	AdminMacPath string `long:"adminmacaroonpath" description:"Path to write the admin macaroon for lnd's RPC and REST services if it doesn't exist"`
+	ReadMacPath  string `long:"readonlymacaroonpath" description:"Path to write the read-only macaroon for lnd's RPC and REST services if it doesn't exist"`
+	LogDir       string `long:"logdir" description:"Directory to log output."`
 
 	Listeners   []string `long:"listen" description:"Add an interface/port to listen for connections (default all interfaces port: 5656)"`
 	ExternalIPs []string `long:"externalip" description:"Add an ip to the list of local addresses we claim to listen on to peers"`
@@ -132,6 +139,8 @@ func loadConfig() (*config, error) {
 		DebugLevel:          defaultLogLevel,
 		TLSCertPath:         defaultTLSCertPath,
 		TLSKeyPath:          defaultTLSKeyPath,
+		AdminMacPath:        defaultAdminMacPath,
+		ReadMacPath:         defaultReadMacPath,
 		LogDir:              defaultLogDir,
 		PeerPort:            defaultPeerPort,
 		RPCPort:             defaultRPCPort,

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: d40636a5875b6dedd06b34514ea3430717c02153ecd16f32aa5bcedeedd6a833
-updated: 2017-08-02T21:19:34.129016558-07:00
+hash: 6569f51a7172f16b26c374cdcf3cae0abea234207ac99bfa6dc4712406bfc4d2
+updated: 2017-08-09T14:51:02.638659953-06:00
 imports:
 - name: github.com/aead/chacha20
   version: d31a916ded42d1640b9d89a26f8abd53cc96790c
@@ -180,4 +180,14 @@ imports:
   - stats
   - tap
   - transport
+- name: gopkg.in/macaroon.v1
+  version: d8fd13e6951f2ce46f0964a58149cf2f103cac9a
+- name: gopkg.in/macaroon-bakery.v1
+  version: 8e14f8b0f5e286ad100ca8d6ce5bde0f0dfb8b21
+- name: github.com/juju/loggo
+  version: 8232ab8918d91c72af1a9fb94d3edbe31d88b790
+- name: github.com/rogpeppe/fastuuid
+  version: 6724a57986aff9bff1a1770e9347036def7c89f6
+- name: gopkg.in/errgo.v1
+  version: 442357a80af5c6bf9b6d51ae791a39c3421004f3
 testImports: []

--- a/glide.yaml
+++ b/glide.yaml
@@ -71,3 +71,8 @@ import:
   - chaincfg
 - package: github.com/lightninglabs/neutrino
   version: 807d3e267a2863654e99dda39ac4daac78943f7e
+- package: gopkg.in/macaroon.v1
+- package: gopkg.in/macaroon-bakery.v1
+- package: github.com/juju/loggo
+- package: github.com/rogpeppe/fastuuid
+- package: gopkg.in/errgo.v1

--- a/macaroons/auth.go
+++ b/macaroons/auth.go
@@ -1,0 +1,76 @@
+package macaroons
+
+import (
+	"encoding/hex"
+	"fmt"
+
+	"golang.org/x/net/context"
+	"google.golang.org/grpc/metadata"
+
+	"gopkg.in/macaroon-bakery.v1/bakery"
+	"gopkg.in/macaroon-bakery.v1/bakery/checkers"
+	macaroon "gopkg.in/macaroon.v1"
+)
+
+// MacaroonCredential wraps a macaroon to implement the
+// credentials.PerRPCCredentials interface.
+type MacaroonCredential struct {
+	*macaroon.Macaroon
+}
+
+// RequireTransportSecurity implements the PerRPCCredentials interface.
+func (m MacaroonCredential) RequireTransportSecurity() bool {
+	return true
+}
+
+// GetRequestMetadata implements the PerRPCCredentials interface.
+func (m MacaroonCredential) GetRequestMetadata(ctx context.Context,
+	uri ...string) (map[string]string, error) {
+	macBytes, err := m.MarshalBinary()
+	if err != nil {
+		return nil, err
+	}
+	md := make(map[string]string)
+	md["macaroon"] = hex.EncodeToString(macBytes)
+	return md, nil
+}
+
+// NewMacaroonCredential returns a copy of the passed macaroon wrapped in a
+// MacaroonCredential struct which implements PerRPCCredentials.
+func NewMacaroonCredential(m *macaroon.Macaroon) MacaroonCredential {
+	ms := MacaroonCredential{}
+	ms.Macaroon = m.Clone()
+	return ms
+}
+
+// ValidateMacaroon validates auth given a bakery service, context, and uri.
+func ValidateMacaroon(ctx context.Context, method string,
+	svc *bakery.Service) error {
+	// Get macaroon bytes from context and unmarshal into macaroon.
+	// TODO(aakselrod): use FromIncomingContext after grpc update in glide.
+	md, ok := metadata.FromContext(ctx)
+	if !ok {
+		return fmt.Errorf("unable to get metadata from context")
+	}
+	if len(md["macaroon"]) != 1 {
+		return fmt.Errorf("expected 1 macaroon, got %d",
+			len(md["macaroon"]))
+	}
+	macBytes, err := hex.DecodeString(md["macaroon"][0])
+	if err != nil {
+		return err
+	}
+	mac := &macaroon.Macaroon{}
+	err = mac.UnmarshalBinary(macBytes)
+	if err != nil {
+		return err
+	}
+
+	// Check the method being called against the permitted operation and the
+	// expiration time and return the result.
+	// TODO(aakselrod): Add more checks as required.
+	return svc.Check(macaroon.Slice{mac}, checkers.New(
+		checkers.OperationChecker(method),
+		checkers.TimeBefore,
+	))
+}

--- a/macaroons/service.go
+++ b/macaroons/service.go
@@ -1,0 +1,44 @@
+package macaroons
+
+import (
+	"path"
+
+	"gopkg.in/macaroon-bakery.v1/bakery"
+
+	"github.com/boltdb/bolt"
+)
+
+var (
+	// dbFileName is the filename within the data directory which contains
+	// the macaroon stores.
+	dbFilename = "macaroons.db"
+)
+
+// NewService returns a service backed by the macaroon Bolt DB stored in the
+// passed directory.
+func NewService(dir string) (*bakery.Service, error) {
+	// Open the database.
+	macaroonDB, err := bolt.Open(path.Join(dir, dbFilename), 0600,
+		bolt.DefaultOptions)
+	if err != nil {
+		return nil, err
+	}
+	rootKeyStore, err := NewRootKeyStorage(macaroonDB)
+	if err != nil {
+		return nil, err
+	}
+	macaroonStore, err := NewStorage(macaroonDB)
+	if err != nil {
+		return nil, err
+	}
+	macaroonParams := bakery.NewServiceParams{
+		Location:     "lnd",
+		Store:        macaroonStore,
+		RootKeyStore: rootKeyStore,
+		// No third-party caveat support for now.
+		// TODO(aakselrod): Add third-party caveat support.
+		Locator: nil,
+		Key:     nil,
+	}
+	return bakery.NewService(macaroonParams)
+}

--- a/macaroons/store.go
+++ b/macaroons/store.go
@@ -1,0 +1,145 @@
+package macaroons
+
+import (
+	"crypto/rand"
+	"fmt"
+	"io"
+
+	"github.com/boltdb/bolt"
+)
+
+const (
+	// RootKeyLen is the length of a root key.
+	RootKeyLen = 32
+)
+
+var (
+	// rootKeyBucketName is the name of the root key store bucket.
+	rootKeyBucketName = []byte("macrootkeys")
+
+	// defaultRootKeyID is the ID of the default root key. The first is
+	// just 0, to emulate the memory storage that comes with bakery.
+	// TODO(aakselrod): Add support for key rotation.
+	defaultRootKeyID = "0"
+
+	// macaroonBucketName is the name of the macaroon store bucket.
+	macaroonBucketName = []byte("macaroons")
+)
+
+// RootKeyStorage implements the bakery.RootKeyStorage interface.
+type RootKeyStorage struct {
+	*bolt.DB
+}
+
+// NewRootKeyStorage creates a RootKeyStorage instance.
+// TODO(aakselrod): Add support for encryption of data with passphrase.
+func NewRootKeyStorage(db *bolt.DB) (*RootKeyStorage, error) {
+	// If the store's bucket doesn't exist, create it.
+	err := db.Update(func(tx *bolt.Tx) error {
+		_, err := tx.CreateBucketIfNotExists(rootKeyBucketName)
+		return err
+	})
+	if err != nil {
+		return nil, err
+	}
+	// Return the DB wrapped in a RootKeyStorage object.
+	return &RootKeyStorage{db}, nil
+}
+
+// Get implements the Get method for the bakery.RootKeyStorage interface.
+func (r *RootKeyStorage) Get(id string) ([]byte, error) {
+	var rootKey []byte
+	err := r.View(func(tx *bolt.Tx) error {
+		rootKey = tx.Bucket(rootKeyBucketName).Get([]byte(id))
+		if len(rootKey) == 0 {
+			return fmt.Errorf("root key with id %s doesn't exist",
+				id)
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return rootKey, nil
+}
+
+// RootKey implements the RootKey method for the bakery.RootKeyStorage
+// interface.
+// TODO(aakselrod): Add support for key rotation.
+func (r *RootKeyStorage) RootKey() ([]byte, string, error) {
+	var rootKey []byte
+	id := defaultRootKeyID
+	err := r.Update(func(tx *bolt.Tx) error {
+		ns := tx.Bucket(rootKeyBucketName)
+		rootKey = ns.Get([]byte(id))
+
+		// If there's no root key stored in the bucket yet, create one.
+		if len(rootKey) != 0 {
+			return nil
+		}
+
+		// Create a RootKeyLen-byte root key.
+		rootKey = make([]byte, RootKeyLen)
+		if _, err := io.ReadFull(rand.Reader, rootKey[:]); err != nil {
+			return err
+		}
+		return ns.Put([]byte(id), rootKey)
+	})
+	if err != nil {
+		return nil, "", err
+	}
+	return rootKey, id, nil
+}
+
+// Storage implements the bakery.Storage interface.
+type Storage struct {
+	*bolt.DB
+}
+
+// NewStorage creates a Storage instance.
+// TODO(aakselrod): Add support for encryption of data with passphrase.
+func NewStorage(db *bolt.DB) (*Storage, error) {
+	// If the store's bucket doesn't exist, create it.
+	err := db.Update(func(tx *bolt.Tx) error {
+		_, err := tx.CreateBucketIfNotExists(macaroonBucketName)
+		return err
+	})
+	if err != nil {
+		return nil, err
+	}
+	// Return the DB wrapped in a Storage object.
+	return &Storage{db}, nil
+}
+
+// Put implements the Put method for the bakery.Storage interface.
+func (s *Storage) Put(location string, item string) error {
+	return s.Update(func(tx *bolt.Tx) error {
+		return tx.Bucket(macaroonBucketName).Put([]byte(location),
+			[]byte(item))
+	})
+}
+
+// Get implements the Get method for the bakery.Storage interface.
+func (s *Storage) Get(location string) (string, error) {
+	var item string
+	err := s.View(func(tx *bolt.Tx) error {
+		itemBytes := tx.Bucket(macaroonBucketName).Get([]byte(location))
+		if len(itemBytes) == 0 {
+			return fmt.Errorf("couldn't get item for location %s",
+				location)
+		}
+		item = string(itemBytes)
+		return nil
+	})
+	if err != nil {
+		return "", err
+	}
+	return item, nil
+}
+
+// Del implements the Del method for the bakery.Storage interface.
+func (s *Storage) Del(location string) error {
+	return s.Update(func(tx *bolt.Tx) error {
+		return tx.Bucket(macaroonBucketName).Delete([]byte(location))
+	})
+}


### PR DESCRIPTION
This is an initial macaroon implementation. It partially fixes issue #20.

`lncli` already includes the client-side macaroon usage with basic replay protection (an additional caveat that makes the request good for only 1 minute by default). To authenticate your request to `lnd` with your own framework, put the hex-encoded macaroon in the GRPC request's metadata under the key `macaroon`. To authenticate your request to `lnd` via the REST proxy, put the hex-encoded macaroon in an HTTP header called `Grpc-metadata-macaroon` like so:

```
$ curl -k --header "Grpc-metadata-macaroon: 303031316C6F636174696F6E206C6E640A303033326964656E74696669657220302D31306563323637613262306566633137613235376662363561616463656161610A3031326363696420616C6C6F77207665726966796D65737361676520676574696E666F206C69737470656572732077616C6C657462616C616E6365206368616E6E656C62616C616E63652070656E64696E676368616E6E656C73206C6973746368616E6E656C73206C6F6F6B7570696E766F696365206C697374696E766F6963657320737562736372696265696E766F69636573207375627363726962657472616E73616374696F6E73206765747472616E73616374696F6E732064657363726962656772617068206765746368616E696E666F206765746E6F6465696E666F207175657279726F75746573206765746E6574776F726B696E666F207375627363726962656368616E6E656C6772617068206C6973747061796D656E7473206465636F64657061797265710A303032667369676E61747572652021A83E1B1EEDC26B8AC36DEF17DE0A06F1B11C253212A270EBA30A8E552634760A" https://localhost:8080/v1/getinfo
{"identity_pubkey":"02c5f2d1e9aa3acc59e385d8c5a45daac39314d930d8a3837be4fbb0f611401c0c","block_height":1156969,"block_hash":"0000000000000409567a8c97e501ef2c76e3df07ad287b016fdfca5659ca5e96","synced_to_chain":true,"testnet":true,"chains":["bitcoin"]}
```

Macaroons can be turned off with the `--no-macaroons` option to both `lnd` and `lncli`. If `lnd` is run with `--no-macaroons` and the client passes a macaroon, the macaroon will be ignored. If `lnd` is run with `--no-macaroons` before it generates macaroon files, `lncli` **must** be run with `--no-macaroons` or it will still look for a macaroon file and fail.

This PR also removes `lncli`'s dependency on `lnd.conf` for the TLS certificate, as that was causing issues for users. Now, the TLS certificate specification behaves like macaroon file specification: only a command-line switch with a default settings.

Additional future improvements over the next weeks/months:
* Add macaroon-specific tests
* Add command-line tool to create/delegate macaroons
* Encrypt the macaroon database with the wallet password
* Add support for root key rotation and possibly macaroon rotation
* Add support for accounting-based macaroons
* Add better request replay protection
* Add support for additional restrictions, such as requester's source IP
* Add third-party caveat support (long-term, requires further analysis and design)