### PR TITLE
tests: fix several timeout issues

### DIFF
--- a/lnd_test.go
+++ b/lnd_test.go
@@ -2954,7 +2954,7 @@ func testBidirectionalAsyncPayments(net *networkHarness, t *harnessTest) {
 			if err != nil {
 				t.Fatalf(err.Error())
 			}
-		case <-time.After(time.Second * maxTime):
+		case <-time.After(maxTime):
 			t.Fatalf("waiting for payments to finish too long "+
 				"(%v)", maxTime)
 		}


### PR DESCRIPTION
This PR fixes several instances of a `<-time.After` inside a `select` inside a `for` loop, where the other channel read is from a ticker. In these instances, the `time.After` channel was re-created with every tick, so the timeout would never trigger.

Another timeout instance was fixed where the timeout was `20 * time.Second * time.Second` instead of just `20 * time.Second`.