### PR TITLE
add 'git clone' line for btcd

### DIFF
--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -72,6 +72,7 @@ following commands:
 
 Install **btcd**: (must be from roasbeef fork, not from btcsuite)
 ```
+git clone https://github.com/roasbeef/btcd $GOPATH/src/github.com/roasbeef/btcd
 cd $GOPATH/src/github.com/roasbeef/btcd
 glide install
 go install . ./cmd/...


### PR DESCRIPTION
The installation instructions for btcd were missing a 'git clone' command.