### PR TITLE
Breach Arbiter Sweep 2nd layer HTLCs

### DIFF
--- a/breacharbiter_test.go
+++ b/breacharbiter_test.go
@@ -173,24 +173,21 @@ var (
 
 	breachedOutputs = []breachedOutput{
 		{
-			amt:           btcutil.Amount(1e7),
-			outpoint:      breachOutPoints[0],
-			witnessType:   lnwallet.CommitmentNoDelay,
-			twoStageClaim: true,
+			amt:         btcutil.Amount(1e7),
+			outpoint:    breachOutPoints[0],
+			witnessType: lnwallet.CommitmentNoDelay,
 		},
 
 		{
-			amt:           btcutil.Amount(2e9),
-			outpoint:      breachOutPoints[1],
-			witnessType:   lnwallet.CommitmentRevoke,
-			twoStageClaim: false,
+			amt:         btcutil.Amount(2e9),
+			outpoint:    breachOutPoints[1],
+			witnessType: lnwallet.CommitmentRevoke,
 		},
 
 		{
-			amt:           btcutil.Amount(3e4),
-			outpoint:      breachOutPoints[2],
-			witnessType:   lnwallet.CommitmentDelayOutput,
-			twoStageClaim: false,
+			amt:         btcutil.Amount(3e4),
+			outpoint:    breachOutPoints[2],
+			witnessType: lnwallet.CommitmentDelayOutput,
 		},
 	}
 
@@ -240,7 +237,7 @@ func init() {
 	// channel point.
 	for i := range retributions {
 		retInfo := &retributions[i]
-		retInfo.remoteIdentity = *breachedOutputs[i].signDescriptor.PubKey
+		retInfo.remoteIdentity = breachedOutputs[i].signDesc.PubKey
 		retributionMap[retInfo.chanPoint] = *retInfo
 	}
 }
@@ -320,7 +317,7 @@ func initBreachedOutputs() error {
 				breachKeys[i])
 		}
 		sd.PubKey = pubkey
-		bo.signDescriptor = *sd
+		bo.signDesc = sd
 	}
 
 	return nil
@@ -395,7 +392,6 @@ func copyRetInfo(retInfo *retributionInfo) *retributionInfo {
 		selfOutput:     retInfo.selfOutput,
 		revokedOutput:  retInfo.revokedOutput,
 		htlcOutputs:    make([]*breachedOutput, nHtlcs),
-		doneChan:       retInfo.doneChan,
 	}
 
 	for i, htlco := range retInfo.htlcOutputs {
@@ -776,8 +772,8 @@ restartCheck:
 			foundSet[ret.chanPoint] = struct{}{}
 
 		} else {
-			return fmt.Errorf("unkwown retribution "+
-				"retrieved from db: %v", ret)
+			return fmt.Errorf("unkwown retribution retrieved "+
+				"from db: %v", ret)
 		}
 
 		return nil

--- a/breacharbiter_test.go
+++ b/breacharbiter_test.go
@@ -317,7 +317,7 @@ func initBreachedOutputs() error {
 				breachKeys[i])
 		}
 		sd.PubKey = pubkey
-		bo.signDesc = sd
+		bo.signDesc = *sd
 	}
 
 	return nil

--- a/lnwallet/channel.go
+++ b/lnwallet/channel.go
@@ -1032,6 +1032,12 @@ type HtlcRetribution struct {
 	// OutPoint is the target outpoint of this HTLC pointing to the
 	// breached commitment transaction.
 	OutPoint wire.OutPoint
+
+	// IsIncoming is a boolean flag that indicates whether or not this
+	// HTLC was accepted from the counterparty. A false value indicates that
+	// this HTLC was offered by us. This flag is used determine the exact
+	// witness type should be used to sweep the output.
+	IsIncoming bool
 }
 
 // BreachRetribution contains all the data necessary to bring a channel
@@ -1162,7 +1168,7 @@ func newBreachRetribution(chanState *channeldb.OpenChannel, stateNum uint64,
 	// With the commitment outputs located, we'll now generate all the
 	// retribution structs for each of the HTLC transactions active on the
 	// remote commitment transaction.
-	htlcRetributions := make([]HtlcRetribution, len(chanState.Htlcs))
+	htlcRetributions := make([]HtlcRetribution, len(revokedSnapshot.Htlcs))
 	for i, htlc := range revokedSnapshot.Htlcs {
 		var (
 			htlcScript []byte
@@ -1206,6 +1212,7 @@ func newBreachRetribution(chanState *channeldb.OpenChannel, stateNum uint64,
 				Hash:  commitHash,
 				Index: uint32(htlc.OutputIndex),
 			},
+			IsIncoming: htlc.Incoming,
 		}
 	}
 

--- a/lnwallet/signdescriptor.go
+++ b/lnwallet/signdescriptor.go
@@ -166,7 +166,7 @@ func ReadSignDescriptor(r io.Reader, sd *SignDescriptor) error {
 		return ErrTweakOverdose
 	}
 
-	witnessScript, err := wire.ReadVarBytes(r, 0, 100, "witnessScript")
+	witnessScript, err := wire.ReadVarBytes(r, 0, 500, "witnessScript")
 	if err != nil {
 		return err
 	}

--- a/lnwallet/size.go
+++ b/lnwallet/size.go
@@ -18,11 +18,30 @@ const (
 	//	- WitnessScriptSHA256: 32 bytes
 	P2WSHSize = 1 + 1 + 32
 
+	// P2WKHOutputSize 31 bytes
+	//      - value: 8 bytes
+	//      - var_int: 1 byte (pkscript_length)
+	//      - pkscript (p2wpkh): 22 bytes
+	P2WKHOutputSize = 8 + 1 + 22
+
+	// P2WSHOutputSize 43 bytes
+	//      - value: 8 bytes
+	//      - var_int: 1 byte (pkscript_length)
+	//      - pkscript (p2wsh): 34 bytes
+	P2WSHOutputSize = 8 + 1 + 34
+
 	// P2WPKHSize 22 bytes
 	//	- OP_0: 1 byte
 	//	- OP_DATA: 1 byte (PublicKeyHASH160 length)
 	//	- PublicKeyHASH160: 20 bytes
 	P2WPKHSize = 1 + 1 + 20
+
+	// P2WKHWitnessSize 108 bytes
+	//      - OP_DATA: 1 byte (signature length)
+	//      - signature
+	//      - OP_DATA: 1 byte (pubkey length)
+	//      - pubkey
+	P2WKHWitnessSize = 1 + 73 + 1 + 33
 
 	// MultiSigSize 71 bytes
 	//	- OP_2: 1 byte
@@ -45,7 +64,7 @@ const (
 	//	- WitnessScript (MultiSig)
 	WitnessSize = 1 + 1 + 1 + 73 + 1 + 73 + 1 + MultiSigSize
 
-	// FundingInputSize 41 bytes
+	// InputSize 41 bytes
 	//	- PreviousOutPoint:
 	//		- Hash: 32 bytes
 	//		- Index: 4 bytes
@@ -57,7 +76,12 @@ const (
 	// 			we separate the calculation of ordinary data
 	// 			from witness data.
 	//	- Sequence: 4 bytes
-	FundingInputSize = 32 + 4 + 1 + 4
+	InputSize = 32 + 4 + 1 + 4
+
+	// FundingInputSize represents the size of an input to a funding
+	// transaction, and is equivalent to the size of a standard segwit input
+	// as calculated above.
+	FundingInputSize = InputSize
 
 	// CommitmentDelayOutput 43 bytes
 	//	- Value: 8 bytes
@@ -82,7 +106,19 @@ const (
 	//	- Marker: 1 byte
 	WitnessHeaderSize = 1 + 1
 
-	// BaseCommitmentTxSize 125 43 * num-htlc-outputs bytes
+	// BaseSweepTxSize 42 + 41 * num-swept-inputs bytes
+	//	- Version: 4 bytes
+	//	- WitnessHeader <---- part of the witness data
+	//	- CountTxIn: 2 byte
+	//	- TxIn: 41 * num-swept-inputs bytes
+	//		....SweptInputs....
+	//	- CountTxOut: 1 byte
+	//	- TxOut: 31 bytes
+	//		P2WPKHOutput: 31 bytes
+	//	- LockTime: 4 bytes
+	BaseSweepTxSize = 4 + 2 + 1 + P2WKHOutputSize + 4
+
+	// BaseCommitmentTxSize 125 + 43 * num-htlc-outputs bytes
 	//	- Version: 4 bytes
 	//	- WitnessHeader <---- part of the witness data
 	//	- CountTxIn: 1 byte
@@ -119,7 +155,134 @@ const (
 	// of a contract breach, the punishment transaction is able to sweep
 	// all the HTLC's yet still remain below the widely used standard
 	// weight limits.
-	MaxHTLCNumber = 967
+	MaxHTLCNumber = 966
+
+	// ToLocalPenaltyScriptSize 83 bytes
+	//      - OP_IF: 1 byte
+	//              - OP_DATA: 1 byte (revocationkey length)
+	//              - revocationkey: 33 bytes
+	//              - OP_CHECKSIG: 1 byte
+	//      - OP_ELSE: 1 byte
+	//              - OP_DATA: 1 byte (localkey length)
+	//              - localkey: 33 bytes
+	//              - OP_CHECKSIG_VERIFY: 1 byte
+	//              - OP_DATA: 1 byte (delay length)
+	//              - delay: 8 bytes
+	//              -OP_CHECKSEQUENCEVERIFY: 1 byte
+	//      - OP_ENDIF: 1 byte
+	ToLocalPenaltyScriptSize = 1 + 1 + 33 + 1 + 1 + 1 + 33 + 1 + 1 + 8 + 1 + 1
+
+	// ToLocalPenaltyWitnessSize 160 bytes
+	//      - number_of_witness_elements: 1 byte
+	//      - revocation_sig_length: 1 byte
+	//      - revocation_sig: 73 bytes
+	//      - one_length: 1 byte
+	//      - witness_script_length: 1 byte
+	//      - witness_script (to_local_script)
+	ToLocalPenaltyWitnessSize = 1 + 1 + 73 + 1 + 1 + ToLocalPenaltyScriptSize
+
+	// AcceptedHtlcPenaltyScriptSize 139 bytes
+	//      - OP_DUP: 1 byte
+	//      - OP_HASH160: 1 byte
+	//      - OP_DATA: 1 byte (RIPEMD160(SHA256(revocationkey)) length)
+	//      - RIPEMD160(SHA256(revocationkey)): 20 bytes
+	//      - OP_EQUAL: 1 byte
+	//      - OP_IF: 1 byte
+	//              - OP_CHECKSIG: 1 byte
+	//      - OP_ELSE: 1 byte
+	//              - OP_DATA: 1 byte (remotekey length)
+	//              - remotekey: 33 bytes
+	//              - OP_SWAP: 1 byte
+	//              - OP_SIZE: 1 byte
+	//              - 32: 1 byte
+	//              - OP_EQUAL: 1 byte
+	//              - OP_IF: 1 byte
+	//                      - OP_HASH160: 1 byte
+	//                      - OP_DATA: 1 byte (RIPEMD160(payment_hash) length)
+	//                      - RIPEMD160(payment_hash): 20 bytes
+	//                      - OP_EQUALVERIFY: 1 byte
+	//                      - 2: 1 byte
+	//                      - OP_SWAP: 1 byte
+	//                      - OP_DATA: 1 byte (localkey length)
+	//                      - localkey: 33 bytes
+	//                      - 2: 1 byte
+	//                      - OP_CHECKMULTISIG: 1 byte
+	//              - OP_ELSE: 1 byte
+	//                      - OP_DROP: 1 byte
+	//                      - OP_DATA: 1 byte (cltv_expiry length)
+	//                      - cltv_expiry: 4 bytes
+	//                      - OP_CHECKLOCKTIMEVERIFY: 1 byte
+	//                      - OP_DROP: 1 byte
+	//                      - OP_CHECKSIG: 1 byte
+	//              - OP_ENDIF: 1 byte
+	//      - OP_ENDIF: 1 byte
+	AcceptedHtlcPenaltyScriptSize = 3*1 + 20 + 5*1 + 33 + 7*1 + 20 + 4*1 +
+		33 + 5*1 + 4 + 5*1
+
+	// AcceptedHtlcPenaltyWitnessSize 249 bytes
+	//    - number_of_witness_elements: 1 byte
+	//    - revocation_sig_length: 1 byte
+	//    - revocation_sig: 73 bytes
+	//    - revocation_key_length: 1 byte
+	//    - revocation_key: 33 bytes
+	//    - witness_script_length: 1 byte
+	//    - witness_script (accepted_htlc_script)
+	AcceptedHtlcPenaltyWitnessSize = 1 + 1 + 73 + 1 + 33 + 1 +
+		AcceptedHtlcPenaltyScriptSize
+
+	// OfferedHtlcScriptSize 133 bytes
+	//      - OP_DUP: 1 byte
+	//      - OP_HASH160: 1 byte
+	//      - OP_DATA: 1 byte (RIPEMD160(SHA256(revocationkey)) length)
+	//      - RIPEMD160(SHA256(revocationkey)): 20 bytes
+	//      - OP_EQUAL: 1 byte
+	//      - OP_IF: 1 byte
+	//              - OP_CHECKSIG: 1 byte
+	//      - OP_ELSE: 1 byte
+	//              - OP_DATA: 1 byte (remotekey length)
+	//              - remotekey: 33 bytes
+	//              - OP_SWAP: 1 byte
+	//              - OP_SIZE: 1 byte
+	//              - OP_DATA: 1 byte (32 length)
+	//              - 32: 1 byte
+	//              - OP_EQUAL: 1 byte
+	//              - OP_NOTIF: 1 byte
+	//                      - OP_DROP: 1 byte
+	//                      - 2: 1 byte
+	//                      - OP_SWAP: 1 byte
+	//                      - OP_DATA: 1 byte (localkey length)
+	//                      - localkey: 33 bytes
+	//                      - 2: 1 byte
+	//                      - OP_CHECKMULTISIG: 1 byte
+	//              - OP_ELSE: 1 byte
+	//                      - OP_HASH160: 1 byte
+	//                      - OP_DATA: 1 byte (RIPEMD160(payment_hash) length)
+	//                      - RIPEMD160(payment_hash): 20 bytes
+	//                      - OP_EQUALVERIFY: 1 byte
+	//                      - OP_CHECKSIG: 1 byte
+	//              - OP_ENDIF: 1 byte
+	//      - OP_ENDIF: 1 byte
+	OfferedHtlcScriptSize = 3*1 + 20 + 5*1 + 33 + 10*1 + 33 + 5*1 + 20 + 4*1
+
+	// OfferedHtlcWitnessSize 243 bytes
+	//    - number_of_witness_elements: 1 byte
+	//    - revocation_sig_length: 1 byte
+	//    - revocation_sig: 73 bytes
+	//    - revocation_key_length: 1 byte
+	//    - revocation_key: 33 bytes
+	//    - witness_script_length: 1 byte
+	//    - witness_script (offered_htlc_script)
+	OfferedHtlcWitnessSize = 1 + 1 + 73 + 1 + 33 + 1 + OfferedHtlcScriptSize
+
+	// OfferedHtlcPenaltyWitnessSize 243 bytes
+	//      - number_of_witness_elements: 1 byte
+	//      - revocation_sig_length: 1 byte
+	//      - revocation_sig: 73 bytes
+	//      - revocation_key_length: 1 byte
+	//      - revocation_key: 33 bytes
+	//      - witness_script_length: 1 byte
+	//      - witness_script (offered_htlc_script)
+	OfferedHtlcPenaltyWitnessSize = 1 + 1 + 73 + 1 + 1 + OfferedHtlcScriptSize
 )
 
 // estimateCommitTxWeight estimate commitment transaction weight depending on

--- a/lnwallet/witnessgen.go
+++ b/lnwallet/witnessgen.go
@@ -35,7 +35,7 @@ type WitnessGenerator func(tx *wire.MsgTx, hc *txscript.TxSigHashes,
 
 // GenWitnessFunc will return a WitnessGenerator function that an output
 // uses to generate the witness for a sweep transaction.
-func (wt WitnessType) GenWitnessFunc(signer *Signer,
+func (wt WitnessType) GenWitnessFunc(signer Signer,
 	descriptor *SignDescriptor) WitnessGenerator {
 
 	return func(tx *wire.MsgTx, hc *txscript.TxSigHashes,
@@ -47,11 +47,11 @@ func (wt WitnessType) GenWitnessFunc(signer *Signer,
 
 		switch wt {
 		case CommitmentTimeLock:
-			return CommitSpendTimeout(*signer, desc, tx)
+			return CommitSpendTimeout(signer, desc, tx)
 		case CommitmentNoDelay:
-			return CommitSpendNoDelay(*signer, desc, tx)
+			return CommitSpendNoDelay(signer, desc, tx)
 		case CommitmentRevoke:
-			return CommitSpendRevoke(*signer, desc, tx)
+			return CommitSpendRevoke(signer, desc, tx)
 		default:
 			return nil, fmt.Errorf("unknown witness type: %v", wt)
 		}

--- a/lnwallet/witnessgen.go
+++ b/lnwallet/witnessgen.go
@@ -25,6 +25,14 @@ const (
 	// of a malicious counterparty's who broadcasts a revoked commitment
 	// transaction.
 	CommitmentRevoke WitnessType = 2
+
+	// HtlcOfferedRevoke is a witness that allows us to sweep an HTLC
+	// output that we offered to the counterparty.
+	HtlcOfferedRevoke WitnessType = 3
+
+	// HtlcAcceptedRevoke is a witness that allows us to sweep an HTLC
+	// output that we accepted from the counterparty.
+	HtlcAcceptedRevoke WitnessType = 4
 )
 
 // WitnessGenerator represents a function which is able to generate the final
@@ -52,6 +60,10 @@ func (wt WitnessType) GenWitnessFunc(signer Signer,
 			return CommitSpendNoDelay(signer, desc, tx)
 		case CommitmentRevoke:
 			return CommitSpendRevoke(signer, desc, tx)
+		case HtlcOfferedRevoke:
+			return ReceiverHtlcSpendRevoke(signer, desc, tx)
+		case HtlcAcceptedRevoke:
+			return SenderHtlcSpendRevoke(signer, desc, tx)
 		default:
 			return nil, fmt.Errorf("unknown witness type: %v", wt)
 		}

--- a/utxonursery.go
+++ b/utxonursery.go
@@ -786,8 +786,7 @@ func fetchGraduatingOutputs(db *channeldb.DB, wallet *lnwallet.LightningWallet,
 	// output or not.
 	for _, kgtnOutput := range kgtnOutputs {
 		kgtnOutput.witnessFunc = kgtnOutput.witnessType.GenWitnessFunc(
-			wallet.Cfg.Signer, kgtnOutput.signDescriptor,
-		)
+			wallet.Cfg.Signer, kgtnOutput.signDescriptor)
 	}
 
 	utxnLog.Infof("New block: height=%v, sweeping %v mature outputs",

--- a/utxonursery.go
+++ b/utxonursery.go
@@ -786,7 +786,7 @@ func fetchGraduatingOutputs(db *channeldb.DB, wallet *lnwallet.LightningWallet,
 	// output or not.
 	for _, kgtnOutput := range kgtnOutputs {
 		kgtnOutput.witnessFunc = kgtnOutput.witnessType.GenWitnessFunc(
-			&wallet.Cfg.Signer, kgtnOutput.signDescriptor,
+			wallet.Cfg.Signer, kgtnOutput.signDescriptor,
 		)
 	}
 


### PR DESCRIPTION
This PR builds upon the initial work of #241 by enabling the breach arbiter to sweep 2nd layer HTLCs. In it's current state, this PR:
- [x] sweeps 2nd layer HTLCs from revoked commitment states.
- [x] uses proper fee estimation when generating justice and commit sweep transactions.
- [x] uses updated [BOLT 5 penalty txn fee calculation](https://github.com/lightningnetwork/lightning-rfc/pull/229) for justice txn fee.
- [x] adds a SpendableOutput interface that helps decouple transaction creation from the types of outputs being spent.
- [x] refactors txn generation logic to be more flexible w/ regard to spending these various types of outputs.
- [x] delays and memoizes the computation of the witness generation function needed to spend an output of interest.
- [x] add config for breach arbiter to enable more granular test cases and interleaving of different subsystems in the future.

Looking into a fix for issue #256 as this seems like the appropriate time to resolve this. A fix has been implemented, though it will be added in a separate PR to keep this one from spreading further.

This PR builds upon #308 which adds HodlHTLC mode.  The modified integration test (`testRevokedCloseRetributionRemoteHodl`) requires the remote node to be started with the `--htlchodl` flag in order to properly test that we are sweeping extended-but-unsettled HTLCs.
