### PR TITLE
Fixes incorrect links in Readme file

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,9 +53,9 @@ service. The exported API's are not yet stable, so be warned: they may change
 drastically in the near future.
 
 An automatically generated set of documentation for the RPC APIs can be found
-at [api.lightning.community](api.lightning.community). A set of developer
+at [api.lightning.community](http://api.lightning.community). A set of developer
 resources including talks, articles, and example applications can be found at:
-[dev.lightning.community](dev.lightning.community).
+[dev.lightning.community](http://dev.lightning.community).
 
 Finally, we also have an active
 [Slack](https://join.slack.com/t/lightningcommunity/shared_invite/MjI4OTg3MzQ4MjI2LTE1MDMxNzM1NTMtNjlmOGYzOTI1Ng)

--- a/lnwire/lnwire.go
+++ b/lnwire/lnwire.go
@@ -587,6 +587,9 @@ func readElement(r io.Reader, element interface{}) error {
 		length := binary.BigEndian.Uint16(addrLen[:])
 
 		var addrBytes [34]byte
+		if length > 34 {
+			return fmt.Errorf("Cannot read %d bytes into addrBytes", length)
+		}
 		if _, err = io.ReadFull(r, addrBytes[:length]); err != nil {
 			return err
 		}


### PR DESCRIPTION
The links to api.lightning.community and dev.lightning.community in the readme file are currently relative urls without http:// which points to a url on github.com which is wrong.

This PR updates both the links.