### PR TITLE
Move nodesigner and invoiceregistry to own packages

### DIFF
--- a/invoiceregistry/log.go
+++ b/invoiceregistry/log.go
@@ -1,0 +1,42 @@
+package invoiceregistry
+
+import "github.com/btcsuite/btclog"
+
+// log is a logger that is initialized with no output filters.  This
+// means the package will not perform any logging by default until the caller
+// requests it.
+var log btclog.Logger
+
+// The default amount of logging is none.
+func init() {
+	DisableLog()
+}
+
+// DisableLog disables all library log output.  Logging output is disabled
+// by default until UseLogger is called.
+func DisableLog() {
+	log = btclog.Disabled
+}
+
+// UseLogger uses a specified Logger to output package logging info.
+// This should be used in preference to SetLogWriter if the caller is also
+// using btclog.
+func UseLogger(logger btclog.Logger) {
+	log = logger
+}
+
+// logClosure is used to provide a closure over expensive logging operations
+// so don't have to be performed when the logging level doesn't warrant it.
+type logClosure func() string
+
+// String invokes the underlying function and returns the result.
+func (c logClosure) String() string {
+	return c()
+}
+
+// newLogClosure returns a new closure over a function that returns a string
+// which itself provides a Stringer interface so that it can be used with the
+// logging system.
+func newLogClosure(c func() string) logClosure {
+	return logClosure(c)
+}

--- a/lnd.go
+++ b/lnd.go
@@ -35,6 +35,7 @@ import (
 	"github.com/lightningnetwork/lnd/lnwallet"
 	"github.com/lightningnetwork/lnd/lnwire"
 	"github.com/lightningnetwork/lnd/macaroons"
+	"github.com/lightningnetwork/lnd/nodesigner"
 	"github.com/roasbeef/btcd/btcec"
 	"github.com/roasbeef/btcutil"
 )
@@ -158,7 +159,7 @@ func lndMain() error {
 
 	// Next, we'll initialize the funding manager itself so it can answer
 	// queries while the wallet+chain are still syncing.
-	nodeSigner := newNodeSigner(idPrivKey)
+	nodeSigner := nodesigner.NewNodeSigner(idPrivKey)
 	var chanIDSeed [32]byte
 	if _, err := rand.Read(chanIDSeed[:]); err != nil {
 		return err

--- a/log.go
+++ b/log.go
@@ -16,6 +16,7 @@ import (
 	"github.com/lightningnetwork/lnd/channeldb"
 	"github.com/lightningnetwork/lnd/discovery"
 	"github.com/lightningnetwork/lnd/htlcswitch"
+	"github.com/lightningnetwork/lnd/invoiceregistry"
 	"github.com/lightningnetwork/lnd/lnwallet"
 	"github.com/lightningnetwork/lnd/routing"
 	"github.com/roasbeef/btcd/connmgr"
@@ -70,6 +71,7 @@ var (
 	crtrLog = backendLog.Logger("CRTR")
 	btcnLog = backendLog.Logger("BTCN")
 	atplLog = backendLog.Logger("ATPL")
+	invrLog = backendLog.Logger("INVR")
 )
 
 // Initialize package-global logger variables.
@@ -83,6 +85,7 @@ func init() {
 	routing.UseLogger(crtrLog)
 	neutrino.UseLogger(btcnLog)
 	autopilot.UseLogger(atplLog)
+	invoiceregistry.UseLogger(invrLog)
 }
 
 // subsystemLoggers maps each subsystem identifier to its associated logger.
@@ -103,6 +106,7 @@ var subsystemLoggers = map[string]btclog.Logger{
 	"CRTR": crtrLog,
 	"BTCN": btcnLog,
 	"ATPL": atplLog,
+	"INVR": invrLog,
 }
 
 // initLogRotator initializes the logging rotator to write logs to logFile and

--- a/nodesigner/nodesigner.go
+++ b/nodesigner/nodesigner.go
@@ -1,4 +1,4 @@
-package main
+package nodesigner
 
 import (
 	"fmt"
@@ -10,19 +10,19 @@ import (
 
 // nodeSigner is an implementation of the MessageSigner interface backed by the
 // identity private key of running lnd node.
-type nodeSigner struct {
+type NodeSigner struct {
 	privKey *btcec.PrivateKey
 }
 
 // newNodeSigner creates a new instance of the nodeSigner backed by the target
 // private key.
-func newNodeSigner(key *btcec.PrivateKey) *nodeSigner {
+func NewNodeSigner(key *btcec.PrivateKey) *NodeSigner {
 	priv := &btcec.PrivateKey{}
 	priv.Curve = btcec.S256()
 	priv.PublicKey.X = key.X
 	priv.PublicKey.Y = key.Y
 	priv.D = key.D
-	return &nodeSigner{
+	return &NodeSigner{
 		privKey: priv,
 	}
 }
@@ -30,7 +30,7 @@ func newNodeSigner(key *btcec.PrivateKey) *nodeSigner {
 // SignMessage signs a double-sha256 digest of the passed msg under the
 // resident node's private key. If the target public key is _not_ the node's
 // private key, then an error will be returned.
-func (n *nodeSigner) SignMessage(pubKey *btcec.PublicKey,
+func (n *NodeSigner) SignMessage(pubKey *btcec.PublicKey,
 	msg []byte) (*btcec.Signature, error) {
 
 	// If this isn't our identity public key, then we'll exit early with an
@@ -52,7 +52,7 @@ func (n *nodeSigner) SignMessage(pubKey *btcec.PublicKey,
 // SignCompact signs a double-sha256 digest of the msg parameter under the
 // resident node's private key. The returned signature is a pubkey-recoverable
 // signature.
-func (n *nodeSigner) SignCompact(msg []byte) ([]byte, error) {
+func (n *NodeSigner) SignCompact(msg []byte) ([]byte, error) {
 
 	// Otherwise, we'll sign the dsha256 of the target message.
 	digest := chainhash.DoubleHashB(msg)
@@ -72,4 +72,4 @@ func (n *nodeSigner) SignCompact(msg []byte) ([]byte, error) {
 
 // A compile time check to ensure that nodeSigner implements the MessageSigner
 // interface.
-var _ lnwallet.MessageSigner = (*nodeSigner)(nil)
+var _ lnwallet.MessageSigner = (*NodeSigner)(nil)

--- a/server.go
+++ b/server.go
@@ -18,6 +18,7 @@ import (
 	"github.com/lightningnetwork/lnd/discovery"
 	"github.com/lightningnetwork/lnd/lnrpc"
 	"github.com/lightningnetwork/lnd/lnwire"
+	"github.com/lightningnetwork/lnd/nodesigner"
 	"github.com/lightningnetwork/lnd/routing"
 	"github.com/roasbeef/btcd/btcec"
 	"github.com/roasbeef/btcd/chaincfg/chainhash"
@@ -42,7 +43,7 @@ type server struct {
 
 	// nodeSigner is an implementation of the MessageSigner implementation
 	// that's backed by the identity private key of the running lnd node.
-	nodeSigner *nodeSigner
+	nodeSigner *nodesigner.NodeSigner
 
 	// lightningID is the sha256 of the public key corresponding to our
 	// long-term identity private key.
@@ -121,7 +122,7 @@ func newServer(listenAddrs []string, chanDB *channeldb.DB, cc *chainControl,
 		utxoNursery: newUtxoNursery(chanDB, cc.chainNotifier, cc.wallet),
 
 		identityPriv: privKey,
-		nodeSigner:   newNodeSigner(privKey),
+		nodeSigner:   nodesigner.NewNodeSigner(privKey),
 
 		// TODO(roasbeef): derive proper onion key based on rotation
 		// schedule


### PR DESCRIPTION
This PR marks the start of a bigger effort to move various lnd subsystems into their own packages. This is done to facilitate easier unit testing and less coupling between the distinct parts of lnd.

The two files moved in this PR are `nodesigner.go` and `invoiceregistry.go`. These were chosen as a start basically because they have few (no?) dependencies that must be moved alongside them, making them low-hanging, but nevertheless tasty fruits.

Follow up PRs will move `fundingManager` and `peer` (order TBD).