### PR TITLE
wire: Correct fuzz test for MsgCommitSig.

### DIFF
--- a/lnwire/lnwire_test.go
+++ b/lnwire/lnwire_test.go
@@ -316,8 +316,13 @@ func TestLightningWireProtocol(t *testing.T) {
 			}
 			req.CommitSig = testSig
 
+			// Only create the slice if there will be any signatures
+			// in it to prevent false positive test failures due to
+			// an empty slice versus a nil slice.
 			numSigs := uint16(r.Int31n(1020))
-			req.HtlcSigs = make([]*btcec.Signature, numSigs)
+			if numSigs > 0 {
+				req.HtlcSigs = make([]*btcec.Signature, numSigs)
+			}
 			for i := 0; i < int(numSigs); i++ {
 				req.HtlcSigs[i] = testSig
 			}


### PR DESCRIPTION
This corrects the fuzz test in `TestLightningWireProtocol` for `MsgCommitSig` to avoid creating an empty slice since the decoded message only creates a slice when there are greater than zero signatures and an empty slice is not considered equal to a nil slice under reflection.

This can be tested by running the `TestLightningWireProtocol` 100 times in a loop with and without this change.

For example, here is the redacted output prior to this PR:
```base
$ for i in $(seq 0 1 100); do go test -run TestLightningWireProtocol; done
```

```
...
        lnwire_test.go:127: messages don't match after re-encoding: (*lnwire.CommitSig)(0xc04204a900)({
                 ChanID: (lnwire.ChannelID) (len=32 cap=32) 19fda145e1053c5d36890e5169101beeb80875fea036c0b8de1c7bc66c427739,
                 CommitSig: (*btcec.Signature)(0x8bcac0)({
                  R: (*big.Int)(0xc042003260)(63724406601629180062774974542967536251589935445068131219452686511677818569431),
                  S: (*big.Int)(0xc042003280)(18801056069249825825291287104931333862866033135609736119018462340006816851118)
                 }),
                 HtlcSigs: ([]*btcec.Signature) {
                 }
                })
                 vs (*lnwire.CommitSig)(0xc04204a940)({
                 ChanID: (lnwire.ChannelID) (len=32 cap=32) 19fda145e1053c5d36890e5169101beeb80875fea036c0b8de1c7bc66c427739,
                 CommitSig: (*btcec.Signature)(0xc0424fd340)({
                  R: (*big.Int)(0xc042196e60)(63724406601629180062774974542967536251589935445068131219452686511677818569431),
                  S: (*big.Int)(0xc042196e80)(18801056069249825825291287104931333862866033135609736119018462340006816851118)
                 }),
                 HtlcSigs: ([]*btcec.Signature) <nil>
                })
...
```

With this PR, it successfully ran 100 iterations without fail.