### PR TITLE
channeldb: Fix payment serialization tests.

### DIFF
--- a/channeldb/invoice_test.go
+++ b/channeldb/invoice_test.go
@@ -12,14 +12,15 @@ import (
 )
 
 func randInvoice(value lnwire.MilliSatoshi) (*Invoice, error) {
-
 	var pre [32]byte
 	if _, err := rand.Read(pre[:]); err != nil {
 		return nil, err
 	}
 
 	i := &Invoice{
-		CreationDate: time.Now(),
+		// Use single second precision to avoid false positive test
+		// failures due to the monotonic time component.
+		CreationDate: time.Unix(time.Now().Unix(), 0),
 		Terms: ContractTerm{
 			PaymentPreimage: pre,
 			Value:           value,
@@ -43,7 +44,9 @@ func TestInvoiceWorkflow(t *testing.T) {
 	// Create a fake invoice which we'll use several times in the tests
 	// below.
 	fakeInvoice := &Invoice{
-		CreationDate: time.Now(),
+		// Use single second precision to avoid false positive test
+		// failures due to the monotonic time component.
+		CreationDate: time.Unix(time.Now().Unix(), 0),
 	}
 	fakeInvoice.Memo = []byte("memo")
 	fakeInvoice.Receipt = []byte("recipt")

--- a/channeldb/payments_test.go
+++ b/channeldb/payments_test.go
@@ -15,7 +15,9 @@ import (
 
 func makeFakePayment() *OutgoingPayment {
 	fakeInvoice := &Invoice{
-		CreationDate: time.Now(),
+		// Use single second precision to avoid false positive test
+		// failures due to the monotonic time component.
+		CreationDate: time.Unix(time.Now().Unix(), 0),
 		Memo:         []byte("fake memo"),
 		Receipt:      []byte("fake receipt"),
 	}
@@ -52,7 +54,9 @@ func randomBytes(minLen, maxLen int) ([]byte, error) {
 func makeRandomFakePayment() (*OutgoingPayment, error) {
 	var err error
 	fakeInvoice := &Invoice{
-		CreationDate: time.Now(),
+		// Use single second precision to avoid false positive test
+		// failures due to the monotonic time component.
+		CreationDate: time.Unix(time.Now().Unix(), 0),
 	}
 
 	fakeInvoice.Memo, err = randomBytes(1, 50)


### PR DESCRIPTION
This modifies the tests that deal serializing the `Invoice` type to limit the creation date to seconds since Go1.9 added the concept of a monotonic component to times which does not round trip through
`MarshalBinary` and `UnmarshalBinary` and therefore causes the tests to fail.

In particular, it modifies the creation dates in the `randInvoice`, `makeFakePayment`, `makeRandomFakePayment`, and `TestInvoiceWorkflow` functions.

This results in allowing `TestOutgoingPaymentSerialization`, `TestOutgoingPaymentWorkflow`, and `TestInvoiceWorkflow` to pass.