### PR TITLE
serializedSize() fix

### DIFF
--- a/lnwire/features.go
+++ b/lnwire/features.go
@@ -113,7 +113,19 @@ func (f *FeatureVector) SetFeatureFlag(name featureName, flag featureFlag) error
 // serializedSize returns the number of bytes which is needed to represent
 // feature vector in byte format.
 func (f *FeatureVector) serializedSize() uint16 {
-	return uint16(math.Ceil(float64(flagBitsSize*len(f.flags)) / 8))
+	// Find the largest index in f.flags
+	max := -1
+	for index := range f.flags {
+		if index > max {
+			max = index
+		}
+	}
+	if max == -1 {
+		return 0
+	}
+	// We calculate length via the largest index in f.flags so as to not
+	// get an index out of bounds in Encode's setFlag function.
+	return uint16(math.Ceil(float64(flagBitsSize*(max+1)) / 8))
 }
 
 // NewFeatureVectorFromReader decodes the feature vector from binary


### PR DESCRIPTION
This commit fixes an incorrectly calculated size of a `*FeatureVector` in the `serializedSize()` function.  

Deserialized messages read in via `lnwire.ReadMessage` are eventually passed to `NewFeatureVectorFromReader` in `features.go`.  In the loop on [line 152](https://github.com/lightningnetwork/lnd/blob/master/lnwire/features.go#L152), if a flag is invalid, it is not added to `f.flags`.  

This is fine, except for the fact that when serializing the now deserialized message, the `Encode` function on [line 192](https://github.com/lightningnetwork/lnd/blob/master/lnwire/features.go#L192) allocates a `[]byte` of length `f.serializedSize()`.  If there are missing indices because of `NewFeatureVectorFromReader` not processing invalid flags, serializedSize() can more than likely calculate an invalid length because it uses `len(f.flags)`.  For example, if we have a map that has indices in [0, 7764] and if indices (4, 5, 6, & 7) are found to have invalid flags and are thus not included in `f.flags`, the length calculated by serializedSize() will be 1941 instead of 1942.  This leads to a `runtime error: index out of range` when `setFlag` calls `data[byteNumber]` with `data[1941] = ...` which is out of bounds.