### PR TITLE
slice fix

### DIFF
--- a/lnwire/lnwire.go
+++ b/lnwire/lnwire.go
@@ -587,6 +587,9 @@ func readElement(r io.Reader, element interface{}) error {
 		length := binary.BigEndian.Uint16(addrLen[:])
 
 		var addrBytes [34]byte
+		if length > 34 {
+			return fmt.Errorf("Cannot read %d bytes into addrBytes", length)
+		}
 		if _, err = io.ReadFull(r, addrBytes[:length]); err != nil {
 			return err
 		}


### PR DESCRIPTION
This is a very simple bug that `go-fuzz` found.  If `length` is greater than 34, a `runtime error: slice bounds out of range` happens.  An error should be returned instead.