### PR TITLE
Support for additional macaroon constraints

### DIFF
--- a/cmd/lncli/main.go
+++ b/cmd/lncli/main.go
@@ -92,7 +92,10 @@ func getClientConn(ctx *cli.Context) *grpc.ClientConn {
 		}
 
 		// Apply constraints to the macaroon.
-		constrainedMac := macaroons.AddConstraints(mac, macConstraints...)
+		constrainedMac, err := macaroons.AddConstraints(mac, macConstraints...)
+		if err != nil {
+			fatal(err)
+		}
 
 		// Now we append the macaroon credentials to the dial options.
 		cred := macaroons.NewMacaroonCredential(constrainedMac)

--- a/cmd/lncli/main.go
+++ b/cmd/lncli/main.go
@@ -85,6 +85,9 @@ func getClientConn(ctx *cli.Context) *grpc.ClientConn {
 			// TODO(aakselrod): add better anti-replay protection.
 			macaroons.TimeoutConstraint(ctx.GlobalInt64("macaroontimeout")),
 
+			// Lock macaroon down to a specific IP address.
+			macaroons.IPLockConstraint(ctx.GlobalString("macaroonip")),
+
 			// ... Add more constraints if needed.
 		}
 
@@ -133,6 +136,10 @@ func main() {
 			Name:  "macaroontimeout",
 			Value: 60,
 			Usage: "anti-replay macaroon validity time in seconds",
+		},
+		cli.StringFlag{
+			Name:  "macaroonip",
+			Usage: "if set, lock macaroon to specific IP address",
 		},
 	}
 	app.Commands = []cli.Command{

--- a/lnd.go
+++ b/lnd.go
@@ -20,7 +20,6 @@ import (
 	"time"
 
 	"gopkg.in/macaroon-bakery.v1/bakery"
-	"gopkg.in/macaroon-bakery.v1/bakery/checkers"
 
 	"golang.org/x/net/context"
 
@@ -566,11 +565,8 @@ func genMacaroons(svc *bakery.Service, admFile, roFile string) error {
 	}
 
 	// Generate the read-only macaroon and write it to a file.
-	caveat := checkers.AllowCaveat(roPermissions...)
-	roMacaroon := admMacaroon.Clone()
-	if err = svc.AddCaveat(roMacaroon, caveat); err != nil {
-		return err
-	}
+	roMacaroon := macaroons.AddConstraints(admMacaroon,
+		macaroons.PermissionsConstraint(roPermissions...))
 	roBytes, err := roMacaroon.MarshalBinary()
 	if err != nil {
 		return err

--- a/lnd.go
+++ b/lnd.go
@@ -565,8 +565,11 @@ func genMacaroons(svc *bakery.Service, admFile, roFile string) error {
 	}
 
 	// Generate the read-only macaroon and write it to a file.
-	roMacaroon := macaroons.AddConstraints(admMacaroon,
+	roMacaroon, err := macaroons.AddConstraints(admMacaroon,
 		macaroons.PermissionsConstraint(roPermissions...))
+	if err != nil {
+		return err
+	}
 	roBytes, err := roMacaroon.MarshalBinary()
 	if err != nil {
 		return err

--- a/lnd.go
+++ b/lnd.go
@@ -566,7 +566,7 @@ func genMacaroons(svc *bakery.Service, admFile, roFile string) error {
 
 	// Generate the read-only macaroon and write it to a file.
 	roMacaroon, err := macaroons.AddConstraints(admMacaroon,
-		macaroons.PermissionsConstraint(roPermissions...))
+		macaroons.AllowConstraint(roPermissions...))
 	if err != nil {
 		return err
 	}

--- a/macaroons/auth.go
+++ b/macaroons/auth.go
@@ -97,7 +97,7 @@ func ValidateMacaroon(ctx context.Context, method string,
 	//
 	// TODO(aakselrod): Add more checks as required.
 	return svc.Check(macaroon.Slice{mac}, checkers.New(
-		PermissionsChecker(method),
+		AllowChecker(method),
 		TimeoutChecker(),
 		IPLockChecker(peerAddr),
 	))

--- a/macaroons/auth.go
+++ b/macaroons/auth.go
@@ -85,7 +85,7 @@ func ValidateMacaroon(ctx context.Context, method string,
 	//
 	// TODO(aakselrod): Add more checks as required.
 	return svc.Check(macaroon.Slice{mac}, checkers.New(
-		checkers.OperationChecker(method),
-		checkers.TimeBefore,
+		PermissionsChecker(method),
+		TimeoutChecker(),
 	))
 }

--- a/macaroons/constraints.go
+++ b/macaroons/constraints.go
@@ -1,0 +1,86 @@
+package macaroons
+
+import (
+	"fmt"
+	"net"
+	"time"
+
+	"gopkg.in/macaroon-bakery.v1/bakery/checkers"
+	macaroon "gopkg.in/macaroon.v1"
+)
+
+// Constraint type adds a layer of indirection over macaroon caveats and
+// checkers.
+type Constraint func(*macaroon.Macaroon)
+
+// AddConstraints returns new derived macaroon by applying every passed
+// constraint and tightening its restrictions.
+func AddConstraints(mac *macaroon.Macaroon, cs ...Constraint) *macaroon.Macaroon {
+	newMac := mac.Clone()
+	for _, constraint := range cs {
+		constraint(newMac)
+	}
+	return newMac
+}
+
+// Each *Constraint function is a functional option, which takes a pointer
+// to the macaroon and adds another restriction to it. For each *Constraint,
+// the corresponding *Checker is provided.
+
+// PermissionsConstraint restricts allowed operations set to the ones
+// passed to it.
+func PermissionsConstraint(ops ...string) func(*macaroon.Macaroon) {
+	return func(mac *macaroon.Macaroon) {
+		caveat := checkers.AllowCaveat(ops...)
+		mac.AddFirstPartyCaveat(caveat.Condition)
+	}
+}
+
+// PermissionsChecker wraps default checkers.OperationChecker.
+func PermissionsChecker(method string) checkers.Checker {
+	return checkers.OperationChecker(method)
+}
+
+// TimeoutConstraint restricts the lifetime of the macaroon
+// to the amount of seconds given.
+func TimeoutConstraint(seconds int64) func(*macaroon.Macaroon) {
+	return func(mac *macaroon.Macaroon) {
+		macaroonTimeout := time.Duration(seconds)
+		requestTimeout := time.Now().Add(time.Second * macaroonTimeout)
+		caveat := checkers.TimeBeforeCaveat(requestTimeout)
+		mac.AddFirstPartyCaveat(caveat.Condition)
+	}
+}
+
+// TimeoutChecker wraps default checkers.TimeBefore checker.
+func TimeoutChecker() checkers.Checker {
+	return checkers.TimeBefore
+}
+
+// IPLockConstraint locks macaroon to a specific IP address.
+// If address is an empty string, this constraint does nothing to
+// accommodate default value's desired behavior.
+func IPLockConstraint(ipAddr string) func(*macaroon.Macaroon) {
+	return func(mac *macaroon.Macaroon) {
+		if ipAddr != "" {
+			macaroonIPAddr := net.ParseIP(ipAddr)
+			caveat := checkers.ClientIPAddrCaveat(macaroonIPAddr)
+			mac.AddFirstPartyCaveat(caveat.Condition)
+		}
+	}
+}
+
+// IPLockChecker accepts client IP from the validation context and compares it
+// with IP locked in the macaroon.
+func IPLockChecker(clientIP string) checkers.Checker {
+	return checkers.CheckerFunc{
+		Condition_: checkers.CondClientIPAddr,
+		Check_: func(_, cav string) error {
+			if !net.ParseIP(cav).Equal(net.ParseIP(clientIP)) {
+				msg := "macaroon locked to different IP address"
+				return fmt.Errorf(msg)
+			}
+			return nil
+		},
+	}
+}

--- a/macaroons/constraints.go
+++ b/macaroons/constraints.go
@@ -29,17 +29,17 @@ func AddConstraints(mac *macaroon.Macaroon, cs ...Constraint) (*macaroon.Macaroo
 // to the macaroon and adds another restriction to it. For each *Constraint,
 // the corresponding *Checker is provided.
 
-// PermissionsConstraint restricts allowed operations set to the ones
+// AllowConstraint restricts allowed operations set to the ones
 // passed to it.
-func PermissionsConstraint(ops ...string) func(*macaroon.Macaroon) error {
+func AllowConstraint(ops ...string) func(*macaroon.Macaroon) error {
 	return func(mac *macaroon.Macaroon) error {
 		caveat := checkers.AllowCaveat(ops...)
 		return mac.AddFirstPartyCaveat(caveat.Condition)
 	}
 }
 
-// PermissionsChecker wraps default checkers.OperationChecker.
-func PermissionsChecker(method string) checkers.Checker {
+// AllowChecker wraps default checkers.OperationChecker.
+func AllowChecker(method string) checkers.Checker {
 	return checkers.OperationChecker(method)
 }
 


### PR DESCRIPTION
Implements #287.

Details:
- [x] Add `macaroons/constraints.go` that provides an indirection layer over macaroon caveats and checkers.
- [x] Replace caveats with variadic `AddConstraints()` that accepts constraints as functional options.
- [x] Implement IP lock constraint (~having problems with getting remote's IP withing the context of `ValidateMacaroon`~ found a way to extract it from peer info: 94399cb).

