### PR TITLE
Utilize new golang 1.8 features within the codebase -#276

### DIFF
--- a/channeldb/channel.go
+++ b/channeldb/channel.go
@@ -793,9 +793,9 @@ const (
 )
 
 // ChannelCloseSummary contains the final state of a channel at the point it
-// was close. Once a channel is closed, all the information pertaining to that
-// channel within the openChannelBucket is deleted, and a compact summary is
-// but in place instead.
+// was closed. Once a channel is closed, all the information pertaining to
+// that channel within the openChannelBucket is deleted, and a compact
+// summary is put in place instead.
 type ChannelCloseSummary struct {
 	// ChanPoint is the outpoint for this channel's funding transaction,
 	// and is used as a unique identifier for the channel.
@@ -978,7 +978,7 @@ func putChannelCloseSummary(tx *bolt.Tx, chanID []byte,
 }
 
 func serializeChannelCloseSummary(w io.Writer, cs *ChannelCloseSummary) error {
-	if err := writeBool(w, cs.IsPending); err != nil {
+	if err := binary.Write(w, byteOrder, cs.IsPending); err != nil {
 		return err
 	}
 
@@ -1032,8 +1032,8 @@ func deserializeCloseChannelSummary(r io.Reader) (*ChannelCloseSummary, error) {
 	c := &ChannelCloseSummary{}
 
 	var err error
-	c.IsPending, err = readBool(r)
-	if err != nil {
+
+	if err := binary.Read(r, byteOrder, &c.IsPending); err != nil {
 		return nil, err
 	}
 
@@ -1055,7 +1055,7 @@ func deserializeCloseChannelSummary(r io.Reader) (*ChannelCloseSummary, error) {
 	}
 
 	var closeType [1]byte
-	if _, err := io.ReadFull(r, closeType[:]); err != nil {
+	if err := binary.Read(r, byteOrder, closeType[:]); err != nil {
 		return nil, err
 	}
 	c.CloseType = ClosureType(closeType[0])
@@ -1855,7 +1855,8 @@ func putChanFundingInfo(nodeChanBucket *bolt.Bucket, channel *OpenChannel) error
 	} else {
 		boolByte[0] = 0
 	}
-	if _, err := b.Write(boolByte[:]); err != nil {
+
+	if err := binary.Write(&b, byteOrder, boolByte[:]); err != nil {
 		return err
 	}
 
@@ -1894,8 +1895,11 @@ func fetchChanFundingInfo(nodeChanBucket *bolt.Bucket, channel *OpenChannel) err
 
 	infoBytes := bytes.NewReader(nodeChanBucket.Get(fundTxnKey))
 
+	var err error
 	var boolByte [1]byte
-	if _, err := io.ReadFull(infoBytes, boolByte[:]); err != nil {
+	err = binary.Read(infoBytes, byteOrder, boolByte[:])
+
+	if err != nil {
 		return err
 	}
 	if boolByte[0] == 1 {
@@ -1905,11 +1909,15 @@ func fetchChanFundingInfo(nodeChanBucket *bolt.Bucket, channel *OpenChannel) err
 	}
 
 	var chanType [1]byte
-	if _, err := io.ReadFull(infoBytes, chanType[:]); err != nil {
+	err = binary.Read(infoBytes, byteOrder, chanType[:])
+
+	if err != nil {
 		return err
 	}
 	channel.ChanType = ChannelType(chanType[0])
-	if _, err := io.ReadFull(infoBytes, channel.ChainHash[:]); err != nil {
+	err = binary.Read(infoBytes, byteOrder, channel.ChainHash[:])
+
+	if err != nil {
 		return err
 	}
 
@@ -2049,7 +2057,7 @@ func serializeHTLC(w io.Writer, h *HTLC) error {
 		boolByte[0] = 0
 	}
 
-	if _, err := w.Write(boolByte[:]); err != nil {
+	if err := binary.Write(w, byteOrder, boolByte[:]); err != nil {
 		return err
 	}
 
@@ -2080,7 +2088,7 @@ func deserializeHTLC(r io.Reader) (*HTLC, error) {
 	}
 
 	var scratch [1]byte
-	if _, err := r.Read(scratch[:]); err != nil {
+	if err := binary.Read(r, byteOrder, scratch[:]); err != nil {
 		return nil, err
 	}
 
@@ -2347,34 +2355,3 @@ func readOutpoint(r io.Reader, o *wire.OutPoint) error {
 
 	return nil
 }
-
-func writeBool(w io.Writer, b bool) error {
-	boolByte := byte(0x01)
-	if !b {
-		boolByte = byte(0x00)
-	}
-
-	if _, err := w.Write([]byte{boolByte}); err != nil {
-		return err
-	}
-
-	return nil
-}
-
-// TODO(roasbeef): make sweep to use this and above everywhere
-//   * using this because binary.Write can only handle bools post go1.8
-func readBool(r io.Reader) (bool, error) {
-	var boolByte [1]byte
-	if _, err := io.ReadFull(r, boolByte[:]); err != nil {
-		return false, err
-	}
-
-	if boolByte[0] == 0x00 {
-		return false, nil
-	}
-
-	return true, nil
-}
-
-// TODO(roasbeef): add readElement/writeElement funcs
-//  * after go1.9 can use binary.WriteBool etc?

--- a/channeldb/invoices.go
+++ b/channeldb/invoices.go
@@ -3,6 +3,7 @@ package channeldb
 import (
 	"bytes"
 	"crypto/sha256"
+	"encoding/binary"
 	"fmt"
 	"io"
 	"time"
@@ -325,11 +326,7 @@ func serializeInvoice(w io.Writer, i *Invoice) error {
 		return err
 	}
 
-	var settleByte [1]byte
-	if i.Terms.Settled {
-		settleByte[0] = 1
-	}
-	if _, err := w.Write(settleByte[:]); err != nil {
+	if err := binary.Write(w, byteOrder, i.Terms.Settled); err != nil {
 		return err
 	}
 
@@ -378,12 +375,8 @@ func deserializeInvoice(r io.Reader) (*Invoice, error) {
 	}
 	invoice.Terms.Value = lnwire.MilliSatoshi(byteOrder.Uint64(scratch[:]))
 
-	var settleByte [1]byte
-	if _, err := io.ReadFull(r, settleByte[:]); err != nil {
+	if err := binary.Read(r, byteOrder, &invoice.Terms.Settled); err != nil {
 		return nil, err
-	}
-	if settleByte[0] == 1 {
-		invoice.Terms.Settled = true
 	}
 
 	return invoice, nil

--- a/channeldb/waitingproof.go
+++ b/channeldb/waitingproof.go
@@ -207,12 +207,7 @@ func (p *WaitingProof) Key() WaitingProofKey {
 
 // Encode writes the internal representation of waiting proof in byte stream.
 func (p *WaitingProof) Encode(w io.Writer) error {
-	var b [1]byte
-	if p.isRemote {
-		b[0] = 1
-	}
-
-	if _, err := w.Write(b[:]); err != nil {
+	if err := binary.Write(w, byteOrder, p.isRemote); err != nil {
 		return err
 	}
 
@@ -223,16 +218,11 @@ func (p *WaitingProof) Encode(w io.Writer) error {
 	return nil
 }
 
-// Decode reads the data from the byte stream and initialize the
+// Decode reads the data from the byte stream and initializes the
 // waiting proof object with it.
 func (p *WaitingProof) Decode(r io.Reader) error {
-	var b [1]byte
-	if _, err := r.Read(b[:]); err != nil {
+	if err := binary.Read(r, byteOrder, &p.isRemote); err != nil {
 		return err
-	}
-
-	if b[0] == 1 {
-		(*p).isRemote = true
 	}
 
 	msg := &lnwire.AnnounceSignatures{}

--- a/lnwallet/channel.go
+++ b/lnwallet/channel.go
@@ -2272,7 +2272,7 @@ func genRemoteHtlcSigJobs(commitPoint *btcec.PublicKey,
 // decrements the available revocation window by 1. After a successful method
 // call, the remote party's commitment chain is extended by a new commitment
 // which includes all updates to the HTLC log prior to this method invocation.
-// The first return parameter it he signature for the commitment transaction
+// The first return parameter is the signature for the commitment transaction
 // itself, while the second parameter is a slice of all HTLC signatures (if
 // any). The HTLC signatures are sorted according to the BIP 69 order of the
 // HTLC's on the commitment transaction.
@@ -2297,7 +2297,7 @@ func (lc *LightningChannel) SignNextCommitment() (*btcec.Signature, []*btcec.Sig
 		return nil, nil, err
 	}
 
-	// Grab the next commitment point for the remote party. This well be
+	// Grab the next commitment point for the remote party. This will be
 	// used within fetchCommitmentView to derive all the keys necessary to
 	// construct the commitment state.
 	commitPoint := lc.channelState.RemoteNextRevocation
@@ -2358,13 +2358,14 @@ func (lc *LightningChannel) SignNextCommitment() (*btcec.Signature, []*btcec.Sig
 	// We'll need to send over the signatures to the remote party in the
 	// order as they appear on the commitment transaction after BIP 69
 	// sorting.
-	sortedSigs := sortableSignBatch(sigBatch)
-	sort.Sort(sortedSigs)
+	sort.Slice(sigBatch, func(i, j int) bool {
+		return sigBatch[i].outputIndex < sigBatch[j].outputIndex
+	})
 
 	// With the jobs sorted, we'll now iterate through all the responses to
 	// gather each of the signatures in order.
 	htlcSigs := make([]*btcec.Signature, 0, len(sigBatch))
-	for _, htlcSigJob := range sortedSigs {
+	for _, htlcSigJob := range sigBatch {
 		jobResp := <-htlcSigJob.resp
 
 		// If an error occurred, then we'll cancel any other active

--- a/lnwallet/channel.go
+++ b/lnwallet/channel.go
@@ -2272,10 +2272,10 @@ func genRemoteHtlcSigJobs(commitPoint *btcec.PublicKey,
 // decrements the available revocation window by 1. After a successful method
 // call, the remote party's commitment chain is extended by a new commitment
 // which includes all updates to the HTLC log prior to this method invocation.
-// The first return parameter is the signature for the commitment transaction
-// itself, while the second parameter is a slice of all HTLC signatures (if
-// any). The HTLC signatures are sorted according to the BIP 69 order of the
-// HTLC's on the commitment transaction.
+// The first return parameter is the signature for the commitment
+// transaction itself, while the second parameter is a slice of all
+// HTLC signatures (if any). The HTLC signatures are sorted according to
+// the BIP 69 order of the HTLC's on the commitment transaction.
 func (lc *LightningChannel) SignNextCommitment() (*btcec.Signature, []*btcec.Signature, error) {
 	lc.Lock()
 	defer lc.Unlock()

--- a/lnwallet/sigpool.go
+++ b/lnwallet/sigpool.go
@@ -83,29 +83,6 @@ type signJob struct {
 	resp chan signJobResp
 }
 
-// sortableSignBatch is a type wrapper around a slice of signJobs which is able
-// to sort each job according to tis outputs index. Such sorting is necessary
-// as when creating a new commitment state, we need to send over all the HTLC
-// signatures (if any) in the exact order the appears on the commitment
-// transaction after BIP 69 sorting.
-type sortableSignBatch []signJob
-
-// Len returns the number of items sortable batch of sign jobs. It is part of
-// the sort.Interface implementation.
-func (s sortableSignBatch) Len() int { return len(s) }
-
-// Less returns whether the item in the batch with index i should sort before
-// the item with index j. It is part of the sort.Interface implementation.
-func (s sortableSignBatch) Less(i, j int) bool {
-	return s[i].outputIndex < s[j].outputIndex
-}
-
-// Swap swaps the items at the passed indices in the priority queue. It is part
-// of the sort.Interface implementation.
-func (s sortableSignBatch) Swap(i, j int) {
-	s[i], s[j] = s[j], s[i]
-}
-
 // signJobResp is the response to a sign job. Both channels are to be read in
 // order to ensure no unnecessary goroutine blocking occurs. Additionally, both
 // channels should be buffered.

--- a/routing/heap_test.go
+++ b/routing/heap_test.go
@@ -35,7 +35,9 @@ func TestHeapOrdering(t *testing.T) {
 
 	// Sort the regular slice, we'll compare this against all the entries
 	// popped from the heap.
-	sort.Sort(&distanceHeap{sortedEntries})
+	sort.Slice(sortedEntries, func(i, j int) bool {
+		return sortedEntries[i].dist < sortedEntries[j].dist
+	})
 
 	// One by one, pop of all the entries from the heap, they should come
 	// out in sorted order.

--- a/routing/pathfind.go
+++ b/routing/pathfind.go
@@ -159,41 +159,6 @@ func (r *Route) ToHopPayloads() []sphinx.HopData {
 	return hopPayloads
 }
 
-// sortableRoutes is a slice of routes that can be sorted. Routes are typically
-// sorted according to their total cumulative fee within the route. In the case
-// that two routes require and identical amount of fees, then the total
-// time-lock will be used as the tie breaker.
-type sortableRoutes []*Route
-
-// Len returns the number of routes in the collection.
-//
-// NOTE: This is part of the sort.Interface implementation.
-func (s sortableRoutes) Len() int {
-	return len(s)
-}
-
-// Less reports whether the route with index i should sort before the route
-// with index j. To make this decision we first check if the total fees
-// required for both routes are equal. If so, then we'll let the total time
-// lock be the tie breaker. Otherwise, we'll put the route with the lowest
-// total fees first.
-//
-// NOTE: This is part of the sort.Interface implementation.
-func (s sortableRoutes) Less(i, j int) bool {
-	if s[i].TotalFees == s[j].TotalFees {
-		return s[i].TotalTimeLock < s[j].TotalTimeLock
-	}
-
-	return s[i].TotalFees < s[j].TotalFees
-}
-
-// Swap swaps the elements with indexes i and j.
-//
-// NOTE: This is part of the sort.Interface implementation.
-func (s sortableRoutes) Swap(i, j int) {
-	s[i], s[j] = s[j], s[i]
-}
-
 // newRoute returns a fully valid route between the source and target that's
 // capable of supporting a payment of `amtToSend` after fees are fully
 // computed. If the route is too long, or the selected path cannot support the

--- a/routing/router.go
+++ b/routing/router.go
@@ -872,13 +872,13 @@ func (r *ChannelRouter) FindRoutes(target *btcec.PublicKey,
 	}
 
 	// Finally, we'll sort the set of validate routes to optimize for
-	// lowest total fees, using the required time-lock within the route as
-	// a tie-breaker.
+	// lowest total fees, using the required time-lock within the
+	// route as a tie-breaker.
 	sort.Slice(validRoutes, func(i, j int) bool {
 		// To make this decision we first check if the total fees
-		// required for both routes are equal. If so, then we'll let the total time
-		// lock be the tie breaker. Otherwise, we'll put the route with the lowest
-		// total fees first.
+		// required for both routes are equal. If so, then we'll let
+		// the total time lock be the tie breaker. Otherwise, we'll
+		// put the route with the lowest total fees first.
 		if validRoutes[i].TotalFees == validRoutes[j].TotalFees {
 			timeLockI := validRoutes[i].TotalTimeLock
 			timeLockJ := validRoutes[j].TotalTimeLock

--- a/routing/router.go
+++ b/routing/router.go
@@ -849,7 +849,7 @@ func (r *ChannelRouter) FindRoutes(target *btcec.PublicKey,
 	// each path. During this process, some paths may be discarded if they
 	// aren't able to support the total satoshis flow once fees have been
 	// factored in.
-	validRoutes := make(sortableRoutes, 0, len(shortestPaths))
+	validRoutes := make([]*Route, 0, len(shortestPaths))
 	for _, path := range shortestPaths {
 		// Attempt to make the path into a route. We snip off the first
 		// hop in the path as it contains a "self-hop" that is inserted
@@ -874,7 +874,19 @@ func (r *ChannelRouter) FindRoutes(target *btcec.PublicKey,
 	// Finally, we'll sort the set of validate routes to optimize for
 	// lowest total fees, using the required time-lock within the route as
 	// a tie-breaker.
-	sort.Sort(validRoutes)
+	sort.Slice(validRoutes, func(i, j int) bool {
+		// To make this decision we first check if the total fees
+		// required for both routes are equal. If so, then we'll let the total time
+		// lock be the tie breaker. Otherwise, we'll put the route with the lowest
+		// total fees first.
+		if validRoutes[i].TotalFees == validRoutes[j].TotalFees {
+			timeLockI := validRoutes[i].TotalTimeLock
+			timeLockJ := validRoutes[j].TotalTimeLock
+			return timeLockI < timeLockJ
+		}
+
+		return validRoutes[i].TotalFees < validRoutes[j].TotalFees
+	})
 
 	log.Debugf("Obtained %v paths sending %v to %x: %v", len(validRoutes),
 		amt, dest, newLogClosure(func() string {


### PR DESCRIPTION
Issue #276 - Use `sort.Slice` function rather than re-creating `sort.Sort` interfaces. Use `binary.Read/Write` with `bool` arguments within `channeldb`.