### PR TITLE
HTLC: added MaxTimeLock for HTLCs expiring in distant future

### DIFF
--- a/chainregistry.go
+++ b/chainregistry.go
@@ -33,6 +33,7 @@ var defaultBitcoinForwardingPolicy = htlcswitch.ForwardingPolicy{
 	BaseFee:       lnwire.NewMSatFromSatoshis(1),
 	FeeRate:       1,
 	TimeLockDelta: 144,
+	MaxTimeLock:   21600,
 }
 
 // defaultLitecoinForwardingPolicy is the default forwarding policy used for
@@ -42,6 +43,7 @@ var defaultLitecoinForwardingPolicy = htlcswitch.ForwardingPolicy{
 	BaseFee:       1,
 	FeeRate:       1,
 	TimeLockDelta: 576,
+	MaxTimeLock:   86400,
 }
 
 // defaultChannelConstraints is the default set of channel constraints that are

--- a/channeldb/graph.go
+++ b/channeldb/graph.go
@@ -1224,6 +1224,11 @@ type ChannelEdgePolicy struct {
 	// HTLCs for each millionth of a satoshi forwarded.
 	FeeProportionalMillionths lnwire.MilliSatoshi
 
+	// MaxTimeLock is the maximum number of blocks an incoming HTLC's time-lock
+	// value can have. If an incoming HTLC has a time-lock value greater
+	// than MaxTimeLock, it will be rejected.
+	MaxTimeLock uint16
+
 	// Node is the LightningNode that this directed edge leads to. Using
 	// this pointer the channel graph can further be traversed.
 	Node *LightningNode

--- a/htlcswitch/switch.go
+++ b/htlcswitch/switch.go
@@ -412,6 +412,8 @@ func (s *Switch) handleLocalDispatch(payment *pendingPayment, packet *htlcPacket
 				update = &failure.Update
 			case *lnwire.FailExpiryTooSoon:
 				update = &failure.Update
+			case *lnwire.FailExpiryTooLate:
+				update = &failure.Update
 			case *lnwire.FailChannelDisabled:
 				update = &failure.Update
 			}

--- a/htlcswitch/test_utils.go
+++ b/htlcswitch/test_utils.go
@@ -546,6 +546,7 @@ func newThreeHopNetwork(t *testing.T, aliceToBob,
 		MinHTLC:       lnwire.NewMSatFromSatoshis(5),
 		BaseFee:       lnwire.NewMSatFromSatoshis(1),
 		TimeLockDelta: 6,
+		MaxTimeLock:   21600,
 	}
 	obfuscator := newMockObfuscator()
 	aliceChannelLink := NewChannelLink(

--- a/lnwire/onion_error_test.go
+++ b/lnwire/onion_error_test.go
@@ -30,6 +30,7 @@ var onionFailures = []FailureMessage{
 	&FailUnknownPaymentHash{},
 	&FailIncorrectPaymentAmount{},
 	&FailFinalExpiryTooSoon{},
+	&FailFinalExpiryTooLate{},
 
 	NewInvalidOnionVersion(testOnionHash),
 	NewInvalidOnionHmac(testOnionHash),
@@ -40,6 +41,7 @@ var onionFailures = []FailureMessage{
 	NewFeeInsufficient(testAmount, testChannelUpdate),
 	NewIncorrectCltvExpiry(testCtlvExpiry, testChannelUpdate),
 	NewExpiryTooSoon(testChannelUpdate),
+	NewExpiryTooLate(testChannelUpdate),
 	NewChannelDisabled(testFlags, testChannelUpdate),
 	NewFinalIncorrectCltvExpiry(testCtlvExpiry),
 	NewFinalIncorrectHtlcAmount(testAmount),

--- a/peer.go
+++ b/peer.go
@@ -350,6 +350,7 @@ func (p *peer) loadActiveChannels(chans []*channeldb.OpenChannel) error {
 				BaseFee:       selfPolicy.FeeBaseMSat,
 				FeeRate:       selfPolicy.FeeProportionalMillionths,
 				TimeLockDelta: uint32(selfPolicy.TimeLockDelta),
+				MaxTimeLock:   uint32(selfPolicy.MaxTimeLock),
 			}
 		} else {
 			forwardingPolicy = &p.server.cc.routingPolicy


### PR DESCRIPTION
This commit addresses the first checkbox of issue #304.
Future commits will address the later checkboxes.

This commit adjusts the ForwardingPolicy in link.go by adding a MaxTimeLock field. MaxTimeLock is the absolute maximum time-lock value that an incoming HTLC is allowed to have. If an incoming
HTLC's time-lock value is greater than the current block height + a node's MaxTimeLock, it will be rejected. This will prevent a DoS vector against the future, persistent, decayed shared-secret log when it's implemented. This commit also includes two tests in link_test.go for MaxTimeLock.