### PR TITLE
Support for macaroon root key rotation

### DIFF
--- a/config.go
+++ b/config.go
@@ -26,6 +26,7 @@ const (
 	defaultTLSKeyFilename     = "tls.key"
 	defaultAdminMacFilename   = "admin.macaroon"
 	defaultReadMacFilename    = "readonly.macaroon"
+	defaultMacTimeout         = 7 * 24 * 3600
 	defaultLogLevel           = "info"
 	defaultLogDirname         = "logs"
 	defaultLogFilename        = "lnd.log"
@@ -100,8 +101,9 @@ type config struct {
 	NoMacaroons  bool   `long:"no-macaroons" description:"Disable macaroon authentication"`
 	AdminMacPath string `long:"adminmacaroonpath" description:"Path to write the admin macaroon for lnd's RPC and REST services if it doesn't exist"`
 	ReadMacPath  string `long:"readonlymacaroonpath" description:"Path to write the read-only macaroon for lnd's RPC and REST services if it doesn't exist"`
-	LogDir       string `long:"logdir" description:"Directory to log output."`
+	MacTimeout   int64  `long:"macaroontimeout" description:"Timeout for the macaroon rotation in seconds"`
 
+	LogDir      string   `long:"logdir" description:"Directory to log output."`
 	Listeners   []string `long:"listen" description:"Add an interface/port to listen for connections (default all interfaces port: 9735)"`
 	ExternalIPs []string `long:"externalip" description:"Add an ip to the list of local addresses we claim to listen on to peers"`
 
@@ -145,6 +147,7 @@ func loadConfig() (*config, error) {
 		TLSKeyPath:          defaultTLSKeyPath,
 		AdminMacPath:        defaultAdminMacPath,
 		ReadMacPath:         defaultReadMacPath,
+		MacTimeout:          defaultMacTimeout,
 		LogDir:              defaultLogDir,
 		PeerPort:            defaultPeerPort,
 		RPCPort:             defaultRPCPort,

--- a/macaroons/auth.go
+++ b/macaroons/auth.go
@@ -79,7 +79,7 @@ func ValidateMacaroon(ctx context.Context, method string,
 	}
 	peerAddr, _, err := net.SplitHostPort(pr.Addr.String())
 	if err != nil {
-		return fmt.Errorf("unable to parse peer address")
+		return fmt.Errorf("unable to parse peer address: %s", peerAddr)
 	}
 
 	// With the macaroon obtained, we'll now decode the hex-string

--- a/macaroons/auth.go
+++ b/macaroons/auth.go
@@ -14,6 +14,9 @@ import (
 	macaroon "gopkg.in/macaroon.v1"
 )
 
+// DefaultChecker is used by the lndMain to check macaroon files at startup.
+var DefaultChecker = checkers.New(TimeoutChecker())
+
 // MacaroonCredential wraps a macaroon to implement the
 // credentials.PerRPCCredentials interface.
 type MacaroonCredential struct {

--- a/macaroons/constraints.go
+++ b/macaroons/constraints.go
@@ -67,7 +67,8 @@ func IPLockConstraint(ipAddr string) func(*macaroon.Macaroon) error {
 		if ipAddr != "" {
 			macaroonIPAddr := net.ParseIP(ipAddr)
 			if macaroonIPAddr == nil {
-				return fmt.Errorf("incorrect macaroon IP-lock address")
+				msg := "incorrect macaroon IP-lock address: %s"
+				return fmt.Errorf(msg, ipAddr)
 			}
 			caveat := checkers.ClientIPAddrCaveat(macaroonIPAddr)
 			return mac.AddFirstPartyCaveat(caveat.Condition)


### PR DESCRIPTION
Implements #286. Based off #313.
Subtasks from issue:
- [x] Update the `RootKeyStorage` implementation to generate a new root key and ID every time `RootKey()` is called.
- [x] Update `genMacaroons()` in `lnd.go` to add a `TimeBeforeCaveat` with a sane default timeout and possibly a command-line option in config.go to modify that timeout if desired.
- [x] Update the code in `lndMain()` in `lnd.go` that checks for macaroon file existence to also check for macaroon validity/expiration.
