### PR TITLE
trivial: Check correct bucket for nil

### DIFF
--- a/channeldb/graph.go
+++ b/channeldb/graph.go
@@ -734,7 +734,7 @@ func (c *ChannelGraph) ChannelID(chanPoint *wire.OutPoint) (uint64, error) {
 			return ErrGraphNoEdgesFound
 		}
 		chanIndex := edges.Bucket(channelPointBucket)
-		if edges == nil {
+		if chanIndex == nil {
 			return ErrGraphNoEdgesFound
 		}
 


### PR DESCRIPTION
This PR fixes a nil pointer dereference that happened because the bucket was never checked for nilness.