### PR TITLE
lnwallet: Commitment refactor

### DIFF
--- a/lnwallet/script_utils.go
+++ b/lnwallet/script_utils.go
@@ -1046,30 +1046,21 @@ func SingleTweakBytes(commitPoint, basePoint *btcec.PublicKey) []byte {
 // TODO(roasbeef): should be using double-scalar mult here
 func TweakPubKey(basePoint, commitPoint *btcec.PublicKey) *btcec.PublicKey {
 	tweakBytes := SingleTweakBytes(commitPoint, basePoint)
-	tweakX, tweakY := btcec.S256().ScalarBaseMult(tweakBytes)
-
-	// TODO(roasbeef): check that both passed on curve?
-
-	x, y := btcec.S256().Add(basePoint.X, basePoint.Y, tweakX, tweakY)
-
-	return &btcec.PublicKey{
-		X:     x,
-		Y:     y,
-		Curve: btcec.S256(),
-	}
+	return TweakPubKeyWithTweak(basePoint, tweakBytes)
 }
 
 // TweakPubKeyWithTweak is the exact same as the TweakPubKey function, however
 // it accepts the raw tweak bytes directly rather than the commitment point.
 func TweakPubKeyWithTweak(pubKey *btcec.PublicKey, tweakBytes []byte) *btcec.PublicKey {
-	tweakX, tweakY := btcec.S256().ScalarBaseMult(tweakBytes)
+	curve := btcec.S256()
+	tweakX, tweakY := curve.ScalarBaseMult(tweakBytes)
 
-	x, y := btcec.S256().Add(pubKey.X, pubKey.Y, tweakX, tweakY)
-
+	// TODO(roasbeef): check that both passed on curve?
+	x, y := curve.Add(pubKey.X, pubKey.Y, tweakX, tweakY)
 	return &btcec.PublicKey{
 		X:     x,
 		Y:     y,
-		Curve: btcec.S256(),
+		Curve: curve,
 	}
 }
 

--- a/lnwallet/script_utils_test.go
+++ b/lnwallet/script_utils_test.go
@@ -71,9 +71,13 @@ func TestCommitmentSpendValidation(t *testing.T) {
 	// This is Alice's commitment transaction, so she must wait a CSV delay
 	// of 5 blocks before sweeping the output, while bob can spend
 	// immediately with either the revocation key, or his regular key.
-	commitmentTx, err := CreateCommitTx(fakeFundingTxIn, aliceDelayKey,
-		bobPayKey, revokePubKey, csvTimeout, channelBalance,
-		channelBalance, DefaultDustLimit())
+	keyRing := &commitmentKeyRing{
+		delayKey:      aliceDelayKey,
+		revocationKey: revokePubKey,
+		paymentKey:    bobPayKey,
+	}
+	commitmentTx, err := CreateCommitTx(fakeFundingTxIn, keyRing, csvTimeout,
+		channelBalance, channelBalance, DefaultDustLimit())
 	if err != nil {
 		t.Fatalf("unable to create commitment transaction: %v", nil)
 	}


### PR DESCRIPTION
Refactor some of the commitment code in channel.go. Helps in the implementation of https://github.com/lightningnetwork/lnd/pull/350.

### lnwallet: Refactor commitment key generation code.
Create struct holding all commitment keys to clean up code and avoid deriving keys multiple times.

### lnwallet: Split tx generation code out of fetchCommitmentView.
This moves the commitment transaction generation code out of fetchCommitmentView into createCommitmentTx. Aside from being a pretty clean logical split, this allows the transaction generation code to be unit tested more effectively.




