### PR TITLE
lnwallet: Better transaction fee estimation for funding transactions.

### DIFF
--- a/lnwallet/interface.go
+++ b/lnwallet/interface.go
@@ -20,8 +20,12 @@ var ErrNotMine = errors.New("the passed output doesn't belong to the wallet")
 type AddressType uint8
 
 const (
+	// UnknownAddressType represents an output with an unknown or non-standard
+	// script.
+	UnknownAddressType AddressType = iota
+
 	// WitnessPubKey represents a p2wkh address.
-	WitnessPubKey AddressType = iota
+	WitnessPubKey
 
 	// NestedWitnessPubKey represents a p2sh output which is itself a
 	// nested p2wkh output.
@@ -34,7 +38,11 @@ const (
 // Utxo is an unspent output denoted by its outpoint, and output value of the
 // original output.
 type Utxo struct {
-	Value btcutil.Amount
+	AddressType   AddressType
+	Value         btcutil.Amount
+	PkScript      []byte
+	RedeemScript  []byte
+	WitnessScript []byte
 	wire.OutPoint
 }
 

--- a/lnwallet/size.go
+++ b/lnwallet/size.go
@@ -132,18 +132,6 @@ const (
 	// - LockTime: 4 bytes
 	BaseTxSize = 4 + 4
 
-	// BaseSweepTxSize 42 + 41 * num-swept-inputs bytes
-	//	- Version: 4 bytes
-	//	- WitnessHeader <---- part of the witness data
-	//	- CountTxIn: 2 byte
-	//	- TxIn: 41 * num-swept-inputs bytes
-	//		....SweptInputs....
-	//	- CountTxOut: 1 byte
-	//	- TxOut: 31 bytes
-	//		P2WPKHOutput: 31 bytes
-	//	- LockTime: 4 bytes
-	BaseSweepTxSize = 4 + 2 + 1 + P2WKHOutputSize + 4
-
 	// BaseCommitmentTxSize 125 + 43 * num-htlc-outputs bytes
 	//	- Version: 4 bytes
 	//	- WitnessHeader <---- part of the witness data
@@ -351,8 +339,15 @@ func (twe *TxWeightEstimator) AddP2PKHInput() {
 // AddP2WKHInput updates the weight estimate to account for an additional input
 // spending a P2PWKH output.
 func (twe *TxWeightEstimator) AddP2WKHInput() {
+	twe.AddWitnessInput(P2WKHWitnessSize)
+}
+
+// AddWitnessInput updates the weight estimate to account for an additional
+// input spending a pay-to-witness output. This accepts the total size of the
+// witness as a parameter.
+func (twe *TxWeightEstimator) AddWitnessInput(witnessSize int) {
 	twe.inputSize += InputSize
-	twe.inputWitnessSize += P2WKHWitnessSize
+	twe.inputWitnessSize += witnessSize
 	twe.inputCount++
 	twe.hasWitness = true
 }

--- a/lnwallet/size_test.go
+++ b/lnwallet/size_test.go
@@ -1,0 +1,123 @@
+package lnwallet_test
+
+import (
+	"testing"
+
+	"github.com/lightningnetwork/lnd/lnwallet"
+	"github.com/roasbeef/btcd/blockchain"
+	"github.com/roasbeef/btcd/chaincfg"
+	"github.com/roasbeef/btcd/txscript"
+	"github.com/roasbeef/btcd/wire"
+	"github.com/roasbeef/btcutil"
+)
+
+// TestTxWeightEstimator tests that transaction weight estimates are calculated
+// correctly by comparing against an actual (though invalid) transaction
+// matching the template.
+func TestTxWeightEstimator(t *testing.T) {
+	netParams := &chaincfg.MainNetParams
+
+	p2pkhAddr, err := btcutil.NewAddressPubKeyHash(
+		make([]byte, 20), netParams)
+	if err != nil {
+		t.Fatalf("Failed to generate address: %v", err)
+	}
+	p2pkhScript, err := txscript.PayToAddrScript(p2pkhAddr)
+	if err != nil {
+		t.Fatalf("Failed to generate scriptPubKey: %v", err)
+	}
+
+	p2wkhAddr, err := btcutil.NewAddressWitnessPubKeyHash(
+		make([]byte, 20), netParams)
+	if err != nil {
+		t.Fatalf("Failed to generate address: %v", err)
+	}
+	p2wkhScript, err := txscript.PayToAddrScript(p2wkhAddr)
+	if err != nil {
+		t.Fatalf("Failed to generate scriptPubKey: %v", err)
+	}
+
+	p2wshAddr, err := btcutil.NewAddressWitnessScriptHash(
+		make([]byte, 32), netParams)
+	if err != nil {
+		t.Fatalf("Failed to generate address: %v", err)
+	}
+	p2wshScript, err := txscript.PayToAddrScript(p2wshAddr)
+	if err != nil {
+		t.Fatalf("Failed to generate scriptPubKey: %v", err)
+	}
+
+	testCases := []struct {
+		numP2PKHInputs  int
+		numP2WKHInputs  int
+		numP2PKHOutputs int
+		numP2WKHOutputs int
+		numP2WSHOutputs int
+	}{
+		{
+			numP2PKHInputs:  1,
+			numP2PKHOutputs: 2,
+		},
+		{
+			numP2PKHInputs:  1,
+			numP2WKHInputs:  1,
+			numP2WKHOutputs: 1,
+			numP2WSHOutputs: 1,
+		},
+		{
+			numP2WKHInputs:  1,
+			numP2WKHOutputs: 1,
+			numP2WSHOutputs: 1,
+		},
+		{
+			numP2WKHInputs:  2,
+			numP2WKHOutputs: 1,
+			numP2WSHOutputs: 1,
+		},
+	}
+
+	for i, test := range testCases {
+		var weightEstimate lnwallet.TxWeightEstimator
+		tx := wire.NewMsgTx(1)
+
+		for j := 0; j < test.numP2PKHInputs; j++ {
+			weightEstimate.AddP2PKHInput()
+
+			signature := make([]byte, 73)
+			compressedPubKey := make([]byte, 33)
+			scriptSig, err := txscript.NewScriptBuilder().AddData(signature).
+				AddData(compressedPubKey).Script()
+			if err != nil {
+				t.Fatalf("Failed to generate scriptSig: %v", err)
+			}
+
+			tx.AddTxIn(&wire.TxIn{SignatureScript: scriptSig})
+		}
+		for j := 0; j < test.numP2WKHInputs; j++ {
+			weightEstimate.AddP2WKHInput()
+
+			signature := make([]byte, 73)
+			compressedPubKey := make([]byte, 33)
+			witness := wire.TxWitness{signature, compressedPubKey}
+			tx.AddTxIn(&wire.TxIn{Witness: witness})
+		}
+		for j := 0; j < test.numP2PKHOutputs; j++ {
+			weightEstimate.AddP2PKHOutput()
+			tx.AddTxOut(&wire.TxOut{PkScript: p2pkhScript})
+		}
+		for j := 0; j < test.numP2WKHOutputs; j++ {
+			weightEstimate.AddP2WKHOutput()
+			tx.AddTxOut(&wire.TxOut{PkScript: p2wkhScript})
+		}
+		for j := 0; j < test.numP2WSHOutputs; j++ {
+			weightEstimate.AddP2WSHOutput()
+			tx.AddTxOut(&wire.TxOut{PkScript: p2wshScript})
+		}
+
+		expectedWeight := blockchain.GetTransactionWeight(btcutil.NewTx(tx))
+		if weightEstimate.Weight() != int(expectedWeight) {
+			t.Errorf("Case %d: Got wrong weight: expected %d, got %d",
+				i, expectedWeight, weightEstimate.Weight())
+		}
+	}
+}

--- a/mock.go
+++ b/mock.go
@@ -149,7 +149,9 @@ func (*mockWalletController) SendOutputs(outputs []*wire.TxOut) (*chainhash.Hash
 // need one unspent for the funding transaction.
 func (*mockWalletController) ListUnspentWitness(confirms int32) ([]*lnwallet.Utxo, error) {
 	utxo := &lnwallet.Utxo{
-		Value: btcutil.Amount(10 * btcutil.SatoshiPerBitcoin),
+		AddressType: lnwallet.WitnessPubKey,
+		Value:       btcutil.Amount(10 * btcutil.SatoshiPerBitcoin),
+		PkScript:    make([]byte, 22),
 		OutPoint: wire.OutPoint{
 			Hash:  chainhash.Hash{},
 			Index: 0,


### PR DESCRIPTION
The fee estimation code for funding transactions has a few problems. Aside from a few numerical errors (eg. not accounting for the vin and vout length varint sizes), I noticed that fee estimation was duplicated in a few places. Hopefully this is a little cleaner.

Beyond just a refactor, I think there are further enhancements required to be compatible with wallets that have unspent P2PKH outputs, or pay-to-witness nested in P2SH. I'm not sure what the best way to solve this is -- seems like we need to query the WalletController for the output type to perform accurate fee estimation. Open to suggestions here, but that can be done in a future PR.