### PR TITLE
lncli: add a convenience command for paying an invoice

### DIFF
--- a/cmd/lncli/main.go
+++ b/cmd/lncli/main.go
@@ -177,6 +177,7 @@ func main() {
 		verifyMessageCommand,
 		feeReportCommand,
 		updateFeesCommand,
+		payInvoiceCommand,
 	}
 
 	if err := app.Run(os.Args); err != nil {


### PR DESCRIPTION
Added a new command payinvoice to lncli which takes an encoded payment request as argument