### PR TITLE
chainntnfs: Use new ConcurrentQueue in neutrino notifier.

### DIFF
--- a/chainntnfs/neutrinonotify/neutrino.go
+++ b/chainntnfs/neutrinonotify/neutrino.go
@@ -65,13 +65,8 @@ type NeutrinoNotifier struct {
 
 	rescanErr <-chan error
 
-	newBlocksMtx          sync.Mutex
-	newBlocks             []*filteredBlock
-	newBlocksUpdateSignal chan struct{}
-
-	staleBlocksMtx          sync.Mutex
-	staleBlocks             []*filteredBlock
-	staleBlocksUpdateSignal chan struct{}
+	newBlocks   *chainntnfs.ConcurrentQueue
+	staleBlocks *chainntnfs.ConcurrentQueue
 
 	wg   sync.WaitGroup
 	quit chan struct{}
@@ -101,9 +96,9 @@ func New(node *neutrino.ChainService) (*NeutrinoNotifier, error) {
 
 		rescanErr: make(chan error),
 
-		newBlocksUpdateSignal: make(chan struct{}),
+		newBlocks: chainntnfs.NewConcurrentQueue(10),
 
-		staleBlocksUpdateSignal: make(chan struct{}),
+		staleBlocks: chainntnfs.NewConcurrentQueue(10),
 
 		quit: make(chan struct{}),
 	}
@@ -155,6 +150,9 @@ func (n *NeutrinoNotifier) Start() error {
 	n.chainView = n.p2pNode.NewRescan(rescanOptions...)
 	n.rescanErr = n.chainView.Start()
 
+	n.newBlocks.Start()
+	n.staleBlocks.Start()
+
 	n.wg.Add(1)
 	go n.notificationDispatcher()
 
@@ -170,6 +168,9 @@ func (n *NeutrinoNotifier) Stop() error {
 
 	close(n.quit)
 	n.wg.Wait()
+
+	n.newBlocks.Stop()
+	n.staleBlocks.Stop()
 
 	// Notify all pending clients of our shutdown by closing the related
 	// notification channels.
@@ -208,20 +209,11 @@ func (n *NeutrinoNotifier) onFilteredBlockConnected(height int32,
 
 	// Append this new chain update to the end of the queue of new chain
 	// updates.
-	n.newBlocksMtx.Lock()
-	n.newBlocks = append(n.newBlocks, &filteredBlock{
+	n.newBlocks.ChanIn() <- &filteredBlock{
 		hash:   header.BlockHash(),
 		height: uint32(height),
 		txns:   txns,
-	})
-	n.newBlocksMtx.Unlock()
-
-	// Launch a goroutine to signal the notification dispatcher that a new
-	// transaction update is available. We do this in a new goroutine in
-	// order to avoid blocking the main loop of the rescan.
-	go func() {
-		n.newBlocksUpdateSignal <- struct{}{}
-	}()
+	}
 }
 
 // onFilteredBlockDisconnected is a callback which is executed each time a new
@@ -231,19 +223,10 @@ func (n *NeutrinoNotifier) onFilteredBlockDisconnected(height int32,
 
 	// Append this new chain update to the end of the queue of new chain
 	// disconnects.
-	n.staleBlocksMtx.Lock()
-	n.staleBlocks = append(n.staleBlocks, &filteredBlock{
+	n.staleBlocks.ChanIn() <- &filteredBlock{
 		hash:   header.BlockHash(),
 		height: uint32(height),
-	})
-	n.staleBlocksMtx.Unlock()
-
-	// Launch a goroutine to signal the notification dispatcher that a new
-	// transaction update is available. We do this in a new goroutine in
-	// order to avoid blocking the main loop of the rescan.
-	go func() {
-		n.staleBlocksUpdateSignal <- struct{}{}
-	}()
+	}
 }
 
 // notificationDispatcher is the primary goroutine which handles client
@@ -335,14 +318,8 @@ func (n *NeutrinoNotifier) notificationDispatcher() {
 				n.blockEpochClients[msg.epochID] = msg
 			}
 
-		case <-n.newBlocksUpdateSignal:
-			// A new update is available, so pop the new chain
-			// update from the front of the update queue.
-			n.newBlocksMtx.Lock()
-			newBlock := n.newBlocks[0]
-			n.newBlocks[0] = nil // Set to nil to prevent GC leak.
-			n.newBlocks = n.newBlocks[1:]
-			n.newBlocksMtx.Unlock()
+		case item := <-n.newBlocks.ChanOut():
+			newBlock := item.(*filteredBlock)
 
 			n.heightMtx.Lock()
 			n.bestHeight = newBlock.height
@@ -417,15 +394,8 @@ func (n *NeutrinoNotifier) notificationDispatcher() {
 			// have been triggered by this new block.
 			n.notifyConfs(int32(newBlock.height))
 
-		case <-n.staleBlocksUpdateSignal:
-			// A new update is available, so pop the new chain
-			// update from the front of the update queue.
-			n.staleBlocksMtx.Lock()
-			staleBlock := n.staleBlocks[0]
-			n.staleBlocks[0] = nil // Set to nil to prevent GC leak.
-			n.staleBlocks = n.staleBlocks[1:]
-			n.staleBlocksMtx.Unlock()
-
+		case item := <-n.staleBlocks.ChanOut():
+			staleBlock := item.(*filteredBlock)
 			chainntnfs.Log.Warnf("Block disconnected from main "+
 				"chain: %v", staleBlock.hash)
 

--- a/chainntnfs/queue.go
+++ b/chainntnfs/queue.go
@@ -1,0 +1,86 @@
+package chainntnfs
+
+import (
+	"container/list"
+)
+
+// ConcurrentQueue is a concurrent-safe FIFO queue with unbounded capacity.
+// Clients interact with the queue by pushing items into the in channel and
+// popping items from the out channel. There is a goroutine that manages moving
+// items from the in channel to the out channel in the correct order that must
+// be started by calling Start().
+type ConcurrentQueue struct {
+	chanIn   chan interface{}
+	chanOut  chan interface{}
+	quit     chan struct{}
+	overflow *list.List
+}
+
+// NewConcurrentQueue constructs a ConcurrentQueue. The bufferSize parameter is
+// the capacity of the output channel. When the size of the queue is below this
+// threshold, pushes do not incur the overhead of the less efficient overflow
+// structure.
+func NewConcurrentQueue(bufferSize int) *ConcurrentQueue {
+	return &ConcurrentQueue{
+		chanIn:   make(chan interface{}),
+		chanOut:  make(chan interface{}, bufferSize),
+		quit:     make(chan struct{}),
+		overflow: list.New(),
+	}
+}
+
+// ChanIn returns a channel that can be used to push new items into the queue.
+func (cq *ConcurrentQueue) ChanIn() chan<- interface{} {
+	return cq.chanIn
+}
+
+// ChanOut returns a channel that can be used to pop items from the queue.
+func (cq *ConcurrentQueue) ChanOut() <-chan interface{} {
+	return cq.chanOut
+}
+
+// Start begins a goroutine that manages moving items from the in channel to the
+// out channel. The queue tries to move items directly to the out channel
+// minimize overhead, but if the out channel is full it pushes items to an
+// overflow queue. This must be called before using the queue.
+func (cq *ConcurrentQueue) Start() {
+	go func() {
+		for {
+			nextElement := cq.overflow.Front()
+			if nextElement == nil {
+				// Overflow queue is empty so incoming items can be pushed
+				// directly to the output channel. If output channel is full
+				// though, push to overflow.
+				select {
+				case item := <-cq.chanIn:
+					select {
+					case cq.chanOut <- item:
+						// Optimistically push directly to chanOut
+					default:
+						cq.overflow.PushBack(item)
+					}
+				case <-cq.quit:
+					return
+				}
+			} else {
+				// Overflow queue is not empty, so any new items get pushed to
+				// the back to preserve order.
+				select {
+				case item := <-cq.chanIn:
+					cq.overflow.PushBack(item)
+				case cq.chanOut <- nextElement.Value:
+					cq.overflow.Remove(nextElement)
+				case <-cq.quit:
+					return
+				}
+			}
+		}
+	}()
+}
+
+// Stop ends the goroutine that moves items from the in channel to the out
+// channel. This does not clear the queue state, so the queue can be restarted
+// without dropping items.
+func (cq *ConcurrentQueue) Stop() {
+	cq.quit <- struct{}{}
+}

--- a/chainntnfs/queue_test.go
+++ b/chainntnfs/queue_test.go
@@ -1,0 +1,26 @@
+package chainntnfs_test
+
+import (
+	"testing"
+
+	"github.com/lightningnetwork/lnd/chainntnfs"
+)
+
+func TestConcurrentQueue(t *testing.T) {
+	queue := chainntnfs.NewConcurrentQueue(100)
+	queue.Start()
+	defer queue.Stop()
+
+	// Pushes should never block for long.
+	for i := 0; i < 1000; i++ {
+		queue.ChanIn() <- i
+	}
+
+	// Pops also should not block for long. Expect elements in FIFO order.
+	for i := 0; i < 1000; i++ {
+		item := <-queue.ChanOut()
+		if i != item.(int) {
+			t.Fatalf("Dequeued wrong value: expected %d, got %d", i, item.(int))
+		}
+	}
+}


### PR DESCRIPTION
This creates a new type implementing a concurrent-safe unbounded FIFO queue. It is used in at least one place in chainntnfs/neutrinonotify to improve efficiency and reduce complexity. 

@Roasbeef Do you think this is safe?

chainntnfs is probably not the right package for this, it's probably better off in a util package of some sort (`lnutil` maybe?). Open to suggestions on where it should live.