### PR TITLE
Adds second layer HTLC output types to UtxoNursery

### DIFF
--- a/utxonursery.go
+++ b/utxonursery.go
@@ -1231,3 +1231,8 @@ func readTxOut(r io.Reader, txo *wire.TxOut) error {
 
 	return nil
 }
+
+// Compile-time constraint to ensure kidOutput and babyOutpt implement the
+// CsvSpendableOutput interface.
+var _ CsvSpendableOutput = (*kidOutput)(nil)
+var _ CsvSpendableOutput = (*babyOutput)(nil)

--- a/utxonursery_test.go
+++ b/utxonursery_test.go
@@ -167,48 +167,130 @@ var (
 
 	kidOutputs = []kidOutput{
 		{
+			breachedOutput: breachedOutput{
+				amt:         btcutil.Amount(13e7),
+				outpoint:    outPoints[0],
+				witnessType: lnwallet.CommitmentTimeLock,
+			},
 			originChanPoint:  outPoints[1],
-			amt:              btcutil.Amount(13e7),
-			outPoint:         outPoints[0],
 			blocksToMaturity: uint32(100),
-			witnessType:      lnwallet.CommitmentTimeLock,
 			confHeight:       uint32(1770001),
 		},
 
 		{
+			breachedOutput: breachedOutput{
+				amt:         btcutil.Amount(24e7),
+				outpoint:    outPoints[1],
+				witnessType: lnwallet.CommitmentTimeLock,
+			},
 			originChanPoint:  outPoints[0],
-			amt:              btcutil.Amount(24e7),
-			outPoint:         outPoints[1],
 			blocksToMaturity: uint32(50),
-			witnessType:      lnwallet.CommitmentTimeLock,
 			confHeight:       uint32(22342321),
 		},
 
 		{
+			breachedOutput: breachedOutput{
+				amt:         btcutil.Amount(2e5),
+				outpoint:    outPoints[2],
+				witnessType: lnwallet.CommitmentTimeLock,
+			},
 			originChanPoint:  outPoints[2],
-			amt:              btcutil.Amount(2e5),
-			outPoint:         outPoints[2],
 			blocksToMaturity: uint32(12),
-			witnessType:      lnwallet.CommitmentTimeLock,
 			confHeight:       uint32(34241),
+		},
+	}
+
+	babyOutputs = []babyOutput{
+		{
+			kidOutput: kidOutputs[0],
+			expiry:    3829,
+			timeoutTx: timeoutTx,
+		},
+		{
+			kidOutput: kidOutputs[1],
+			expiry:    85903,
+			timeoutTx: timeoutTx,
+		},
+		{
+			kidOutput: kidOutputs[2],
+			expiry:    4,
+			timeoutTx: timeoutTx,
+		},
+	}
+
+	// Dummy timeout tx used to test serialization, borrowed from btcd
+	// msgtx_test
+	timeoutTx = &wire.MsgTx{
+		Version: 1,
+		TxIn: []*wire.TxIn{
+			{
+				PreviousOutPoint: wire.OutPoint{
+					Hash: chainhash.Hash{
+						0xa5, 0x33, 0x52, 0xd5, 0x13, 0x57, 0x66, 0xf0,
+						0x30, 0x76, 0x59, 0x74, 0x18, 0x26, 0x3d, 0xa2,
+						0xd9, 0xc9, 0x58, 0x31, 0x59, 0x68, 0xfe, 0xa8,
+						0x23, 0x52, 0x94, 0x67, 0x48, 0x1f, 0xf9, 0xcd,
+					},
+					Index: 19,
+				},
+				SignatureScript: []byte{},
+				Witness: [][]byte{
+					{ // 70-byte signature
+						0x30, 0x43, 0x02, 0x1f, 0x4d, 0x23, 0x81, 0xdc,
+						0x97, 0xf1, 0x82, 0xab, 0xd8, 0x18, 0x5f, 0x51,
+						0x75, 0x30, 0x18, 0x52, 0x32, 0x12, 0xf5, 0xdd,
+						0xc0, 0x7c, 0xc4, 0xe6, 0x3a, 0x8d, 0xc0, 0x36,
+						0x58, 0xda, 0x19, 0x02, 0x20, 0x60, 0x8b, 0x5c,
+						0x4d, 0x92, 0xb8, 0x6b, 0x6d, 0xe7, 0xd7, 0x8e,
+						0xf2, 0x3a, 0x2f, 0xa7, 0x35, 0xbc, 0xb5, 0x9b,
+						0x91, 0x4a, 0x48, 0xb0, 0xe1, 0x87, 0xc5, 0xe7,
+						0x56, 0x9a, 0x18, 0x19, 0x70, 0x01,
+					},
+					{ // 33-byte serialize pub key
+						0x03, 0x07, 0xea, 0xd0, 0x84, 0x80, 0x7e, 0xb7,
+						0x63, 0x46, 0xdf, 0x69, 0x77, 0x00, 0x0c, 0x89,
+						0x39, 0x2f, 0x45, 0xc7, 0x64, 0x25, 0xb2, 0x61,
+						0x81, 0xf5, 0x21, 0xd7, 0xf3, 0x70, 0x06, 0x6a,
+						0x8f,
+					},
+				},
+				Sequence: 0xffffffff,
+			},
+		},
+		TxOut: []*wire.TxOut{
+			{
+				Value: 395019,
+				PkScript: []byte{ // p2wkh output
+					0x00, // Version 0 witness program
+					0x14, // OP_DATA_20
+					0x9d, 0xda, 0xc6, 0xf3, 0x9d, 0x51, 0xe0, 0x39,
+					0x8e, 0x53, 0x2a, 0x22, 0xc4, 0x1b, 0xa1, 0x89,
+					0x40, 0x6a, 0x85, 0x23, // 20-byte pub key hash
+				},
+			},
 		},
 	}
 )
 
-func TestAddSerializedKidsToList(t *testing.T) {
-	var b bytes.Buffer
+func init() {
+	for i := range signDescriptors {
 
-	for i := 0; i < 3; i++ {
-		kid := &kidOutputs[i]
-		descriptor := &signDescriptors[i]
 		pk, err := btcec.ParsePubKey(keys[i], btcec.S256())
 		if err != nil {
-			t.Fatalf("unable to parse pub key: %v", keys[i])
+			panic("unable to parse pub key: %v")
 		}
-		descriptor.PubKey = pk
-		kid.signDescriptor = descriptor
+		signDescriptors[i].PubKey = pk
 
-		if err := serializeKidOutput(&b, &kidOutputs[i]); err != nil {
+		kidOutputs[i].signDesc = signDescriptors[i]
+		babyOutputs[i].kidOutput.signDesc = signDescriptors[i]
+
+	}
+}
+
+func TestDeserializeKidsList(t *testing.T) {
+	var b bytes.Buffer
+	for _, kid := range kidOutputs {
+		if err := kid.Encode(&b); err != nil {
 			t.Fatalf("unable to serialize and add kid output to "+
 				"list: %v", err)
 		}
@@ -219,7 +301,7 @@ func TestAddSerializedKidsToList(t *testing.T) {
 		t.Fatalf("unable to deserialize kid output list: %v", err)
 	}
 
-	for i := 0; i < 3; i++ {
+	for i := range kidOutputs {
 		if !reflect.DeepEqual(&kidOutputs[i], kidList[i]) {
 			t.Fatalf("kidOutputs don't match \n%+v\n%+v",
 				&kidOutputs[i], kidList[i])
@@ -227,29 +309,47 @@ func TestAddSerializedKidsToList(t *testing.T) {
 	}
 }
 
-func TestSerializeKidOutput(t *testing.T) {
-	kid := &kidOutputs[0]
-	descriptor := &signDescriptors[0]
-	pk, err := btcec.ParsePubKey(keys[0], btcec.S256())
-	if err != nil {
-		t.Fatalf("unable to parse pub key: %v", keys[0])
+func TestKidOutputSerialization(t *testing.T) {
+	for i, kid := range kidOutputs {
+		var b bytes.Buffer
+		if err := kid.Encode(&b); err != nil {
+			t.Fatalf("Encode #%d: unable to serialize "+
+				"kid output: %v", i, err)
+		}
+
+		var deserializedKid kidOutput
+		if err := deserializedKid.Decode(&b); err != nil {
+			t.Fatalf("Decode #%d: unable to deserialize "+
+				"kid output: %v", i, err)
+		}
+
+		if !reflect.DeepEqual(kid, deserializedKid) {
+			t.Fatalf("DeepEqual #%d: unexpected kidOutput, "+
+				"want %+v, got %+v",
+				i, kid, deserializedKid)
+		}
 	}
-	descriptor.PubKey = pk
-	kid.signDescriptor = descriptor
+}
 
-	var b bytes.Buffer
+func TestBabyOutputSerialization(t *testing.T) {
+	for i, baby := range babyOutputs {
+		var b bytes.Buffer
+		if err := baby.Encode(&b); err != nil {
+			t.Fatalf("Encode #%d: unable to serialize "+
+				"baby output: %v", i, err)
+		}
 
-	if err := serializeKidOutput(&b, kid); err != nil {
-		t.Fatalf("unable to serialize kid output: %v", err)
-	}
+		var deserializedBaby babyOutput
+		if err := deserializedBaby.Decode(&b); err != nil {
+			t.Fatalf("Decode #%d: unable to deserialize "+
+				"baby output: %v", i, err)
+		}
 
-	deserializedKid, err := deserializeKidOutput(&b)
-	if err != nil {
-		t.Fatalf(err.Error())
-	}
+		if !reflect.DeepEqual(baby, deserializedBaby) {
+			t.Fatalf("DeepEqual #%d: unexpected babyOutput, "+
+				"want %+v, got %+v",
+				i, baby, deserializedBaby)
+		}
 
-	if !reflect.DeepEqual(kid, deserializedKid) {
-		t.Fatalf("kidOutputs don't match %+v vs %+v", kid,
-			deserializedKid)
 	}
 }

--- a/utxonursery_test.go
+++ b/utxonursery_test.go
@@ -4,6 +4,7 @@ package main
 
 import (
 	"bytes"
+	"fmt"
 	"reflect"
 	"testing"
 
@@ -273,11 +274,12 @@ var (
 )
 
 func init() {
+	// Finish initializing our test vectors by parsing the desired public keys and
+	// properly populating the sign descriptors of all baby and kid outputs.
 	for i := range signDescriptors {
-
 		pk, err := btcec.ParsePubKey(keys[i], btcec.S256())
 		if err != nil {
-			panic("unable to parse pub key: %v")
+			panic(fmt.Sprintf("unable to parse pub key during init: %v", err))
 		}
 		signDescriptors[i].PubKey = pk
 


### PR DESCRIPTION
This PR marks the first of several to follow aimed at refactoring the persistence and on-chain handling of HTLC outputs in the utxo nursery.

We introduce two new types in this PR:
- `babyOutput`: A struct representing a CLTV delayed output that will mature into a `kidOutput` after the CLTV output has been spent. HTLCs that need incubation will begin their two stage journey through the utxo nursery in this state.
- `CsvSpendableOutput`: An interface for accessing and generating sweep transactions that spend from CSV delayed outputs. This is an extension of the `SpendableOutput` interface introduced during the recent breach arbiter refactoring, in efforts to modularize on chain handling.  The existing `kidOutput` struct now implements this new interface, and direct access to internal state by the utxo nursery is now performed through public interface methods.