### PR TITLE
wallet: theirBalance fix

### DIFF
--- a/lnwallet/reservation.go
+++ b/lnwallet/reservation.go
@@ -173,7 +173,7 @@ func NewChannelReservation(capacity, fundingAmt, feePerKw btcutil.Amount,
 			// slides split the amount funded and the commitment
 			// fee.
 			ourBalance = fundingMSat - (feeMSat / 2)
-			theirBalance = capacityMSat - fundingMSat - (feeMSat / 2) + pushMSat
+			theirBalance = capacityMSat - fundingMSat - (feeMSat / 2)
 		}
 
 		initiator = true


### PR DESCRIPTION
This commit fixes a miscalculation: an incorrectly calculated `theirBalance` by removing the added `pushMSat` in the dual-funder workflow (`pushMSat` does not exist in the dual funder workflow and should therefore not be used).