### PR TITLE
ChannelRouter and graph re-org awareness

### DIFF
--- a/channeldb/graph.go
+++ b/channeldb/graph.go
@@ -3,8 +3,10 @@ package channeldb
 import (
 	"bytes"
 	"encoding/binary"
+	"fmt"
 	"image/color"
 	"io"
+	"math"
 	"net"
 	"time"
 
@@ -86,12 +88,17 @@ var (
 	// number of channels, etc.
 	graphMetaBucket = []byte("graph-meta")
 
-	// pruneTipKey is a key within the above graphMetaBucket that stores
-	// the best known blockhash+height that the channel graph has been
-	// known to be pruned to. Once a new block is discovered, any channels
-	// that have been closed (by spending the outpoint) can safely be
-	// removed from the graph.
-	pruneTipKey = []byte("prune-tip")
+	// pruneLogBucket is a bucket within the graphMetaBucket that stores
+	// a mapping from the block height to the hash for the blocks used to
+	// prune the graph.
+	// Once a new block is discovered, any channels that have been closed
+	// (by spending the outpoint) can safely be removed from the graph, and
+	// the block is added to the prune log. We need to keep such a log for
+	// the case where a reorg happens, and we must "rewind" the state of the
+	// graph by removing channels that were previously confirmed. In such a
+	// case we'll remove all entries from the prune log with a block height
+	// that no longer exists.
+	pruneLogBucket = []byte("prune-log")
 
 	edgeBloomKey = []byte("edge-bloom")
 	nodeBloomKey = []byte("node-bloom")
@@ -560,11 +567,12 @@ func (c *ChannelGraph) UpdateChannelEdge(edge *ChannelEdgeInfo) error {
 }
 
 const (
-	// pruneTipBytes is the total size of the value which stores the
-	// current prune tip of the graph. The prune tip indicates if the
-	// channel graph is in sync with the current UTXO state. The structure
-	// is: blockHash || blockHeight, taking 36 bytes total.
-	pruneTipBytes = 32 + 4
+	// pruneTipBytes is the total size of the value which stores a prune
+	// entry of the graph in the prune log. The "prune tip" is the last
+	// entry in the prune log, and indicates if the channel graph is in
+	// sync with the current UTXO state. The structure of the value
+	// is: blockHash, taking 32 bytes total.
+	pruneTipBytes = 32
 )
 
 // PruneGraph prunes newly closed channels from the channel graph in response
@@ -641,14 +649,21 @@ func (c *ChannelGraph) PruneGraph(spentOutputs []*wire.OutPoint,
 			return err
 		}
 
-		// With the graph pruned, update the current "prune tip" which
-		// can be used to check if the graph is fully synced with the
-		// current UTXO state.
+		pruneBucket, err := metaBucket.CreateBucketIfNotExists(pruneLogBucket)
+		if err != nil {
+			return err
+		}
+
+		// With the graph pruned, add a new entry to the prune log,
+		// which can be used to check if the graph is fully synced with
+		// the current UTXO state.
+		var blockHeightBytes [4]byte
+		byteOrder.PutUint32(blockHeightBytes[:], blockHeight)
+
 		var newTip [pruneTipBytes]byte
 		copy(newTip[:], blockHash[:])
-		byteOrder.PutUint32(newTip[32:], blockHeight)
 
-		return metaBucket.Put(pruneTipKey, newTip[:])
+		return pruneBucket.Put(blockHeightBytes[:], newTip[:])
 	})
 	if err != nil {
 		return nil, err
@@ -657,15 +672,115 @@ func (c *ChannelGraph) PruneGraph(spentOutputs []*wire.OutPoint,
 	return chansClosed, nil
 }
 
+// DisconnectBlockAtHeight is used to indicate that the block specified
+// by the passed height has been disconnected from the main chain. This
+// will "rewind" the graph back to the height below, deleting channels
+// that are no longer confirmed from the graph. The prune log will be
+// set to the last prune height valid for the remaining chain.
+// Channels that were removed from the graph resulting from the
+// disconnected block are returned.
+func (c *ChannelGraph) DisconnectBlockAtHeight(height uint32) ([]*ChannelEdgeInfo,
+	error) {
+
+	// Every channel having a ShortChannelID starting at 'height'
+	// will no longer be confirmed.
+	startShortChanID := lnwire.ShortChannelID{
+		BlockHeight: height,
+	}
+
+	// Delete everything after this height from the db.
+	endShortChanID := lnwire.ShortChannelID{
+		BlockHeight: math.MaxUint32 & 0x00ffffff,
+		TxIndex:     math.MaxUint32 & 0x00ffffff,
+		TxPosition:  math.MaxUint16,
+	}
+	// The block height will be the 3 first bytes of the channel IDs.
+	var chanIDStart [8]byte
+	byteOrder.PutUint64(chanIDStart[:], startShortChanID.ToUint64())
+	var chanIDEnd [8]byte
+	byteOrder.PutUint64(chanIDEnd[:], endShortChanID.ToUint64())
+
+	// Keep track of the channels that are removed from the graph.
+	var removedChans []*ChannelEdgeInfo
+
+	if err := c.db.Update(func(tx *bolt.Tx) error {
+		edges, err := tx.CreateBucketIfNotExists(edgeBucket)
+		if err != nil {
+			return err
+		}
+
+		edgeIndex, err := edges.CreateBucketIfNotExists(edgeIndexBucket)
+		if err != nil {
+			return err
+		}
+
+		chanIndex, err := edges.CreateBucketIfNotExists(channelPointBucket)
+		if err != nil {
+			return err
+		}
+
+		// Scan from chanIDStart to chanIDEnd, deleting every
+		// found edge.
+		cursor := edgeIndex.Cursor()
+		for k, v := cursor.Seek(chanIDStart[:]); k != nil &&
+			bytes.Compare(k, chanIDEnd[:]) <= 0; k, v = cursor.Next() {
+
+			edgeInfoReader := bytes.NewReader(v)
+			edgeInfo, err := deserializeChanEdgeInfo(edgeInfoReader)
+			if err != nil {
+				return err
+			}
+			err = delChannelByEdge(edges, edgeIndex, chanIndex,
+				&edgeInfo.ChannelPoint)
+			if err != nil && err != ErrEdgeNotFound {
+				return err
+			}
+
+			removedChans = append(removedChans, edgeInfo)
+		}
+
+		// Delete all the entries in the prune log having a height
+		// greater or equal to the block disconnected.
+		metaBucket, err := tx.CreateBucketIfNotExists(graphMetaBucket)
+		if err != nil {
+			return err
+		}
+
+		pruneBucket, err := metaBucket.CreateBucketIfNotExists(pruneLogBucket)
+		if err != nil {
+			return err
+		}
+
+		var pruneKeyStart [4]byte
+		byteOrder.PutUint32(pruneKeyStart[:], height)
+
+		var pruneKeyEnd [4]byte
+		byteOrder.PutUint32(pruneKeyEnd[:], math.MaxUint32)
+
+		pruneCursor := pruneBucket.Cursor()
+		for k, _ := pruneCursor.Seek(pruneKeyStart[:]); k != nil &&
+			bytes.Compare(k, pruneKeyEnd[:]) <= 0; k, _ = pruneCursor.Next() {
+			if err := pruneCursor.Delete(); err != nil {
+				return err
+			}
+		}
+
+		return nil
+	}); err != nil {
+		return nil, err
+	}
+
+	return removedChans, nil
+}
+
 // PruneTip returns the block height and hash of the latest block that has been
 // used to prune channels in the graph. Knowing the "prune tip" allows callers
 // to tell if the graph is currently in sync with the current best known UTXO
 // state.
 func (c *ChannelGraph) PruneTip() (*chainhash.Hash, uint32, error) {
 	var (
-		currentTip [pruneTipBytes]byte
-		tipHash    chainhash.Hash
-		tipHeight  uint32
+		tipHash   chainhash.Hash
+		tipHeight uint32
 	)
 
 	err := c.db.View(func(tx *bolt.Tx) error {
@@ -673,23 +788,30 @@ func (c *ChannelGraph) PruneTip() (*chainhash.Hash, uint32, error) {
 		if graphMeta == nil {
 			return ErrGraphNotFound
 		}
-
-		tipBytes := graphMeta.Get(pruneTipKey)
-		if tipBytes == nil {
+		pruneBucket := graphMeta.Bucket(pruneLogBucket)
+		if pruneBucket == nil {
 			return ErrGraphNeverPruned
 		}
-		copy(currentTip[:], tipBytes)
+
+		pruneCursor := pruneBucket.Cursor()
+
+		// The prune key with the largest block height will be our
+		// prune tip.
+		k, v := pruneCursor.Last()
+		if k == nil {
+			return ErrGraphNeverPruned
+		}
+
+		// Once we have the prune tip, the value will be the block hash,
+		// and the key the block height.
+		copy(tipHash[:], v[:])
+		tipHeight = byteOrder.Uint32(k[:])
 
 		return nil
 	})
 	if err != nil {
 		return nil, 0, err
 	}
-
-	// Once we have the prune tip, the first 32 bytes are the block hash,
-	// with the latter 4 bytes being the block height.
-	copy(tipHash[:], currentTip[:32])
-	tipHeight = byteOrder.Uint32(currentTip[32:])
 
 	return &tipHash, tipHeight, nil
 }
@@ -778,6 +900,10 @@ func delChannelByEdge(edges *bolt.Bucket, edgeIndex *bolt.Bucket,
 	// the keys which house both of the directed edges for this
 	// channel.
 	nodeKeys := edgeIndex.Get(chanID)
+	if nodeKeys == nil {
+		return fmt.Errorf("could not find nodekeys for chanID %v",
+			chanID)
+	}
 
 	// The edge key is of the format pubKey || chanID. First we
 	// construct the latter half, populating the channel ID.

--- a/routing/chainview/btcd.go
+++ b/routing/chainview/btcd.go
@@ -1,14 +1,17 @@
 package chainview
 
 import (
+	"bytes"
+	"encoding/hex"
 	"fmt"
 	"sync"
 	"sync/atomic"
-	"time"
 
+	"github.com/roasbeef/btcd/btcjson"
 	"github.com/roasbeef/btcd/chaincfg/chainhash"
 	"github.com/roasbeef/btcd/rpcclient"
 	"github.com/roasbeef/btcd/wire"
+	"github.com/roasbeef/btcutil"
 )
 
 // BtcdFilteredChainView is an implementation of the FilteredChainView
@@ -17,34 +20,27 @@ type BtcdFilteredChainView struct {
 	started int32
 	stopped int32
 
-	// bestHash is the hash of the latest block in the main chain.
-	bestHash chainhash.Hash
-
-	// bestHeight is the height of the latest block in the main chain.
-	bestHeight int32
+	// bestHeight is the height of the latest block added to the
+	// blockQueue from the onFilteredConnectedMethod. It is used to
+	// determine up to what height we would need to rescan in case
+	// of a filter update.
+	bestHeightMtx sync.Mutex
+	bestHeight    uint32
 
 	btcdConn *rpcclient.Client
 
-	// newBlocks is the channel in which new filtered blocks are sent over.
-	newBlocks chan *FilteredBlock
-
-	// staleBlocks is the channel in which blocks that have been
-	// disconnected from the mainchain are sent over.
-	staleBlocks chan *FilteredBlock
+	// blockEventQueue is the ordered queue used to keep the order
+	// of connected and disconnected blocks sent to the reader of the
+	// chainView.
+	blockQueue *blockEventQueue
 
 	// filterUpdates is a channel in which updates to the utxo filter
 	// attached to this instance are sent over.
 	filterUpdates chan filterUpdate
 
-	// The three field below are used to implement a synchronized queue
-	// that lets use instantly handle sent notifications without blocking
-	// the main websockets notification loop.
-	chainUpdates      []*chainUpdate
-	chainUpdateSignal chan struct{}
-	chainUpdateMtx    sync.Mutex
-
 	// chainFilter is the set of utox's that we're currently watching
 	// spends for within the chain.
+	filterMtx   sync.RWMutex
 	chainFilter map[wire.OutPoint]struct{}
 
 	// filterBlockReqs is a channel in which requests to filter select
@@ -63,18 +59,15 @@ var _ FilteredChainView = (*BtcdFilteredChainView)(nil)
 // RPC credentials for an active btcd instance.
 func NewBtcdFilteredChainView(config rpcclient.ConnConfig) (*BtcdFilteredChainView, error) {
 	chainView := &BtcdFilteredChainView{
-		newBlocks:         make(chan *FilteredBlock),
-		staleBlocks:       make(chan *FilteredBlock),
-		chainUpdateSignal: make(chan struct{}),
-		chainFilter:       make(map[wire.OutPoint]struct{}),
-		filterUpdates:     make(chan filterUpdate),
-		filterBlockReqs:   make(chan *filterBlockReq),
-		quit:              make(chan struct{}),
+		chainFilter:     make(map[wire.OutPoint]struct{}),
+		filterUpdates:   make(chan filterUpdate),
+		filterBlockReqs: make(chan *filterBlockReq),
+		quit:            make(chan struct{}),
 	}
 
 	ntfnCallbacks := &rpcclient.NotificationHandlers{
-		OnBlockConnected:    chainView.onBlockConnected,
-		OnBlockDisconnected: chainView.onBlockDisconnected,
+		OnFilteredBlockConnected:    chainView.onFilteredBlockConnected,
+		OnFilteredBlockDisconnected: chainView.onFilteredBlockDisconnected,
 	}
 
 	// Disable connecting to btcd within the rpcclient.New method. We
@@ -86,6 +79,8 @@ func NewBtcdFilteredChainView(config rpcclient.ConnConfig) (*BtcdFilteredChainVi
 		return nil, err
 	}
 	chainView.btcdConn = chainConn
+
+	chainView.blockQueue = newBlockEventQueue()
 
 	return chainView, nil
 }
@@ -110,12 +105,16 @@ func (b *BtcdFilteredChainView) Start() error {
 		return err
 	}
 
-	bestHash, bestHeight, err := b.btcdConn.GetBestBlock()
+	_, bestHeight, err := b.btcdConn.GetBestBlock()
 	if err != nil {
 		return err
 	}
 
-	b.bestHash, b.bestHeight = *bestHash, bestHeight
+	b.bestHeightMtx.Lock()
+	b.bestHeight = uint32(bestHeight)
+	b.bestHeightMtx.Unlock()
+
+	b.blockQueue.Start()
 
 	b.wg.Add(1)
 	go b.chainFilterer()
@@ -137,6 +136,8 @@ func (b *BtcdFilteredChainView) Stop() error {
 	// cleans up all related resources.
 	b.btcdConn.Shutdown()
 
+	b.blockQueue.Stop()
+
 	log.Infof("FilteredChainView stopping")
 
 	close(b.quit)
@@ -145,39 +146,68 @@ func (b *BtcdFilteredChainView) Stop() error {
 	return nil
 }
 
-// chainUpdate encapsulates an update to the current main chain. This struct is
-// used as an element within an unbounded queue in order to avoid blocking the
-// main rpc dispatch rule.
-type chainUpdate struct {
-	blockHash   *chainhash.Hash
-	blockHeight int32
+// onFilteredBlockConnected is called for each block that's connected to the
+// end of the main chain. Based on our current chain filter, the block may or
+// may not include any relevant transactions.
+func (b *BtcdFilteredChainView) onFilteredBlockConnected(height int32,
+	header *wire.BlockHeader, txns []*btcutil.Tx) {
+
+	mtxs := make([]*wire.MsgTx, len(txns))
+	for i, tx := range txns {
+		mtx := tx.MsgTx()
+		mtxs[i] = mtx
+
+		for _, txIn := range mtx.TxIn {
+			// We can delete this outpoint from the chainFilter, as
+			// we just received a block where it was spent. In case
+			// of a reorg, this outpoint might get "un-spent", but
+			// that's okay since it would never be wise to consider
+			// the channel open again (since a spending transaction
+			// exists on the network).
+			b.filterMtx.Lock()
+			delete(b.chainFilter, txIn.PreviousOutPoint)
+			b.filterMtx.Unlock()
+		}
+
+	}
+
+	// We record the height of the last connected block added to the
+	// blockQueue such that we can scan up to this height in case of
+	// a rescan. It must be protected by a mutex since a filter update
+	// might be trying to read it concurrently.
+	b.bestHeightMtx.Lock()
+	b.bestHeight = uint32(height)
+	b.bestHeightMtx.Unlock()
+
+	block := &FilteredBlock{
+		Hash:         header.BlockHash(),
+		Height:       uint32(height),
+		Transactions: mtxs,
+	}
+
+	b.blockQueue.Add(&blockEvent{
+		eventType: connected,
+		block:     block,
+	})
 }
 
-// onBlockConnected implements on OnBlockConnected callback for rpcclient.
-// Ingesting a block updates the wallet's internal utxo state based on the
-// outputs created and destroyed within each block.
-func (b *BtcdFilteredChainView) onBlockConnected(hash *chainhash.Hash,
-	height int32, t time.Time) {
+// onFilteredBlockDisconnected is a callback which is executed once a block is
+// disconnected from the end of the main chain.
+func (b *BtcdFilteredChainView) onFilteredBlockDisconnected(height int32,
+	header *wire.BlockHeader) {
 
-	// Append this new chain update to the end of the queue of new chain
-	// updates.
-	b.chainUpdateMtx.Lock()
-	b.chainUpdates = append(b.chainUpdates, &chainUpdate{hash, height})
-	b.chainUpdateMtx.Unlock()
+	log.Debugf("got disconnected block at height %d: %v", height,
+		header.BlockHash())
 
-	// Launch a goroutine to signal the notification dispatcher that a new
-	// block update is available. We do this in a new goroutine in order to
-	// avoid blocking the main loop of the rpc client.
-	go func() {
-		b.chainUpdateSignal <- struct{}{}
-	}()
-}
+	filteredBlock := &FilteredBlock{
+		Hash:   header.BlockHash(),
+		Height: uint32(height),
+	}
 
-// onBlockDisconnected implements on OnBlockDisconnected callback for rpcclient.
-func (b *BtcdFilteredChainView) onBlockDisconnected(hash *chainhash.Hash,
-	height int32, t time.Time) {
-
-	// TODO(roasbeef): impl
+	b.blockQueue.Add(&blockEvent{
+		eventType: disconnected,
+		block:     filteredBlock,
+	})
 }
 
 // filterBlockReq houses a request to manually filter a block specified by
@@ -231,7 +261,9 @@ func (b *BtcdFilteredChainView) chainFilterer() {
 				if _, ok := b.chainFilter[prevOp]; ok {
 					filteredTxns = append(filteredTxns, tx)
 
+					b.filterMtx.Lock()
 					delete(b.chainFilter, prevOp)
+					b.filterMtx.Unlock()
 
 					break
 				}
@@ -241,87 +273,118 @@ func (b *BtcdFilteredChainView) chainFilterer() {
 		return filteredTxns
 	}
 
+	decodeJSONBlock := func(block *btcjson.RescannedBlock,
+		height uint32) (*FilteredBlock, error) {
+		hash, err := chainhash.NewHashFromStr(block.Hash)
+		if err != nil {
+			return nil, err
+
+		}
+		txs := make([]*wire.MsgTx, 0, len(block.Transactions))
+		for _, str := range block.Transactions {
+			b, err := hex.DecodeString(str)
+			if err != nil {
+				return nil, err
+			}
+			tx := &wire.MsgTx{}
+			err = tx.Deserialize(bytes.NewReader(b))
+			if err != nil {
+				return nil, err
+			}
+			txs = append(txs, tx)
+		}
+		return &FilteredBlock{
+			Hash:         *hash,
+			Height:       height,
+			Transactions: txs,
+		}, nil
+	}
+
 	for {
 		select {
-
-		// A new block has been connected to the end of the main chain.
-		// So we'll need to dispatch a new FilteredBlock notification.
-		case <-b.chainUpdateSignal:
-			// A new update is available, so pop the new chain
-			// update from the front of the update queue.
-			b.chainUpdateMtx.Lock()
-			update := b.chainUpdates[0]
-			b.chainUpdates[0] = nil // Set to nil to prevent GC leak.
-			b.chainUpdates = b.chainUpdates[1:]
-			b.chainUpdateMtx.Unlock()
-
-			// Now that we have the new block has, fetch the new
-			// block itself.
-			newBlock, err := b.btcdConn.GetBlock(update.blockHash)
-			if err != nil {
-				log.Errorf("Unable to get block: %v", err)
-				continue
-			}
-			b.bestHash, b.bestHeight = *update.blockHash, update.blockHeight
-
-			// Next, we'll scan this block to see if it modified
-			// any of the UTXO set that we're watching.
-			filteredTxns := filterBlock(newBlock)
-
-			// Finally, launch a goroutine to dispatch this
-			// filtered block notification.
-			go func() {
-				b.newBlocks <- &FilteredBlock{
-					Hash:         *update.blockHash,
-					Height:       uint32(update.blockHeight),
-					Transactions: filteredTxns,
-				}
-			}()
-
 		// The caller has just sent an update to the current chain
 		// filter, so we'll apply the update, possibly rewinding our
 		// state partially.
 		case update := <-b.filterUpdates:
+
 			// First, we'll add all the new UTXO's to the set of
 			// watched UTXO's, eliminating any duplicates in the
 			// process.
 			log.Debugf("Updating chain filter with new UTXO's: %v",
 				update.newUtxos)
 			for _, newOp := range update.newUtxos {
+				b.filterMtx.Lock()
 				b.chainFilter[newOp] = struct{}{}
+				b.filterMtx.Unlock()
 			}
+
+			// Apply the new TX filter to btcd, which will cause
+			// all following notifications from and calls to it
+			// return blocks filtered with the new filter.
+			b.btcdConn.LoadTxFilter(false, []btcutil.Address{},
+				update.newUtxos)
+
+			// All blocks gotten after we loaded the filter will
+			// have the filter applied, but we will need to rescan
+			// the blocks up to the height of the block we last
+			// added to the blockQueue.
+			b.bestHeightMtx.Lock()
+			bestHeight := b.bestHeight
+			b.bestHeightMtx.Unlock()
 
 			// If the update height matches our best known height,
 			// then we don't need to do any rewinding.
-			if update.updateHeight == uint32(b.bestHeight) {
+			if update.updateHeight == bestHeight {
 				continue
 			}
 
 			// Otherwise, we'll rewind the state to ensure the
 			// caller doesn't miss any relevant notifications.
 			// Starting from the height _after_ the update height,
-			// we'll walk forwards, manually filtering blocks.
-			for i := int32(update.updateHeight) + 1; i < b.bestHeight+1; i++ {
+			// we'll walk forwards, rescanning one block at a time
+			// with btcd applying the newly loaded filter to each
+			// block.
+			for i := update.updateHeight + 1; i < bestHeight+1; i++ {
 				blockHash, err := b.btcdConn.GetBlockHash(int64(i))
 				if err != nil {
-					log.Errorf("Unable to get block hash: %v", err)
+					log.Warnf("Unable to get block hash "+
+						"for block at height %d: %v",
+						i, err)
 					continue
 				}
-				block, err := b.btcdConn.GetBlock(blockHash)
+
+				// To avoid dealing with the case where a reorg
+				// is happening while we rescan, we scan one
+				// block at a time, skipping blocks that might
+				// have gone missing.
+				rescanned, err := b.btcdConn.RescanBlocks(
+					[]chainhash.Hash{*blockHash})
 				if err != nil {
-					log.Errorf("Unable to get block: %v", err)
+					log.Warnf("Unable to rescan block "+
+						"with hash %v at height %d: %v",
+						blockHash, i, err)
 					continue
 				}
 
-				filteredTxns := filterBlock(block)
-
-				go func(height uint32) {
-					b.newBlocks <- &FilteredBlock{
-						Hash:         *blockHash,
-						Height:       height,
-						Transactions: filteredTxns,
-					}
-				}(uint32(i))
+				// If no block was returned from the rescan,
+				// it means no maching transactions were found.
+				if len(rescanned) != 1 {
+					log.Debugf("no matching block found "+
+						"for rescan of hash %v",
+						blockHash)
+					continue
+				}
+				decoded, err := decodeJSONBlock(
+					&rescanned[0], uint32(i))
+				if err != nil {
+					log.Errorf("Unable to decode block: %v",
+						err)
+					continue
+				}
+				b.blockQueue.Add(&blockEvent{
+					eventType: connected,
+					block:     decoded,
+				})
 			}
 
 		// We've received a new request to manually filter a block.
@@ -393,7 +456,7 @@ func (b *BtcdFilteredChainView) UpdateFilter(ops []wire.OutPoint, updateHeight u
 //
 // NOTE: This is part of the FilteredChainView interface.
 func (b *BtcdFilteredChainView) FilteredBlocks() <-chan *FilteredBlock {
-	return b.newBlocks
+	return b.blockQueue.newBlocks
 }
 
 // DisconnectedBlocks returns a receive only channel which will be sent upon
@@ -402,5 +465,5 @@ func (b *BtcdFilteredChainView) FilteredBlocks() <-chan *FilteredBlock {
 //
 // NOTE: This is part of the FilteredChainView interface.
 func (b *BtcdFilteredChainView) DisconnectedBlocks() <-chan *FilteredBlock {
-	return b.staleBlocks
+	return b.blockQueue.staleBlocks
 }

--- a/routing/chainview/queue.go
+++ b/routing/chainview/queue.go
@@ -1,0 +1,148 @@
+package chainview
+
+import "sync"
+
+// blockEventType is the possible types of a blockEvent.
+type blockEventType uint8
+
+const (
+	// connected is the type of a blockEvent representing a block
+	// that was connected to our current chain.
+	connected blockEventType = iota
+
+	// disconnected is the type of a blockEvent representing a
+	// block that is stale/disconnected from our current chain.
+	disconnected
+)
+
+// blockEvent represent a block that was either connected
+// or disconnected from the current chain.
+type blockEvent struct {
+	eventType blockEventType
+	block     *FilteredBlock
+}
+
+// blockEventQueue is an ordered queue for block events sent from a
+// FilteredChainView. The two types of possible block events are
+// connected/new blocks, and disconnected/stale blocks. The
+// blockEventQueue keeps the order of these events intact, while
+// still being non-blocking. This is important in order for the
+// chainView's call to onBlockConnected/onBlockDisconnected to not
+// get blocked, and for the consumer of the block events to always
+// get the events in the correct order.
+type blockEventQueue struct {
+	queueCond *sync.Cond
+	queueMtx  sync.Mutex
+	queue     []*blockEvent
+
+	// newBlocks is the channel where the consumer of the queue
+	// will receive connected/new blocks from the FilteredChainView.
+	newBlocks chan *FilteredBlock
+
+	// stleBlocks is the channel where the consumer of the queue will
+	// receive disconnected/stale blocks from the FilteredChainView.
+	staleBlocks chan *FilteredBlock
+
+	wg   sync.WaitGroup
+	quit chan struct{}
+}
+
+// newBlockEventQueue creates a new blockEventQueue.
+func newBlockEventQueue() *blockEventQueue {
+	b := &blockEventQueue{
+		newBlocks:   make(chan *FilteredBlock),
+		staleBlocks: make(chan *FilteredBlock),
+		quit:        make(chan struct{}),
+	}
+	b.queueCond = sync.NewCond(&b.queueMtx)
+
+	return b
+}
+
+// Start starts the blockEventQueue coordinator such that it can start handling
+// events.
+func (b *blockEventQueue) Start() {
+	b.wg.Add(1)
+	go b.queueCoordinator()
+}
+
+// Stop signals the queue coordinator to stop, such that the queue can be
+// shut down.
+func (b *blockEventQueue) Stop() {
+	close(b.quit)
+
+	b.queueCond.Signal()
+	b.wg.Wait()
+}
+
+// queueCoordinator is the queue's main loop, handling incoming block events
+// and handing them off to the correct output channel.
+//
+// NB: MUST be run as a goroutine from the Start() method.
+func (b *blockEventQueue) queueCoordinator() {
+	defer b.wg.Done()
+
+	for {
+		// First, we'll check our condition. If the queue of events is
+		// empty, then we'll wait until a new item is added.
+		b.queueCond.L.Lock()
+		for len(b.queue) == 0 {
+			b.queueCond.Wait()
+
+			// If we were woke up in order to exit, then we'll do
+			// so. Otherwise, we'll check the queue for any new
+			// items.
+			select {
+			case <-b.quit:
+				b.queueCond.L.Unlock()
+				return
+			default:
+			}
+		}
+
+		// Grab the first element in the queue, and nil the index to
+		// avoid gc leak.
+		event := b.queue[0]
+		b.queue[0] = nil
+		b.queue = b.queue[1:]
+		b.queueCond.L.Unlock()
+
+		// In the case this is a connected block, we'll send it on the
+		// newBlocks channel. In case it is a disconnected block, we'll
+		// send it on the staleBlocks channel. This send will block
+		// until it is received by the consumer on the other end, making
+		// sure we won't try to send any other block event before the
+		// consumer is aware of this one.
+		switch event.eventType {
+		case connected:
+			select {
+			case b.newBlocks <- event.block:
+			case <-b.quit:
+				return
+			}
+		case disconnected:
+			select {
+			case b.staleBlocks <- event.block:
+			case <-b.quit:
+				return
+			}
+		}
+	}
+}
+
+// Add puts the provided blockEvent at the end of the event queue, making sure
+// it will first be received after all previous events. This method is
+// non-blocking, in the sense that it will never wait for the consumer of the
+// queue to read form the other end, making it safe to call from the
+// FilteredChainView's onBlockConnected/onBlockDisconnected.
+func (b *blockEventQueue) Add(event *blockEvent) {
+
+	// Lock the condition, and add the event to the end of queue.
+	b.queueCond.L.Lock()
+	b.queue = append(b.queue, event)
+	b.queueCond.L.Unlock()
+
+	// With the event added, we signal to the queueCoordinator that
+	// there are new events to handle.
+	b.queueCond.Signal()
+}


### PR DESCRIPTION
This PR makes the channel router re-org aware, by making the router handle stale blocks delivered from the chain view. The channel graph now gets support for "reverse pruning", through the method `DisconnectBlockAtHeight`. This method will remove edges from the channel graph that gets "negative confirmations" because of a reorg, leaving the database in a state consistent with the best height the router is aware of.

### blockEventQueue
This PR also introduces a new queue implementation for ordered block events, modeled after the `htlcswitch`'s `packetQueue`. This is used to ensure the notifications about connected/disconnected blocks from the chain view is handled by the router in the correct order.

### Tests
Several tests are added to ensure the re-org awareness is working as expected in the affected parts of the code:
`router`
`channeldb`
`routing/chainview`
`lnd_test`

~~NB: Needs a fix for https://github.com/lightninglabs/neutrino/pull/18 for all tests to be able to pass.~~ Fixed

Closes #270.