### PR TITLE
wallet: channel test fee fix for added HTLC

### DIFF
--- a/lnwallet/channel_test.go
+++ b/lnwallet/channel_test.go
@@ -1289,10 +1289,10 @@ func TestChannelBalanceDustLimit(t *testing.T) {
 
 	// This amount should leave an amount larger than Alice's dust limit
 	// once fees have been subtracted, but smaller than Bob's dust limit.
-	defaultFee := calcStaticFee(0)
-	dustLimit := aliceChannel.channelState.LocalChanCfg.DustLimit
+	// We account in fees for the HTLC we will be adding.
+	defaultFee := calcStaticFee(1)
 	aliceBalance := aliceChannel.channelState.LocalBalance.ToSatoshis()
-	htlcSat := aliceBalance - (defaultFee + dustLimit + 100)
+	htlcSat := aliceBalance - defaultFee
 	htlcSat += htlcSuccessFee(aliceChannel.channelState.FeePerKw)
 
 	htlcAmount := lnwire.NewMSatFromSatoshis(htlcSat)


### PR DESCRIPTION
This commit fixes the TestChannelBalanceDustLimit unit test in channel_test.go. The unit test does not account for the fees required by adding an HTLC. As a result, Alice's balance drops below 0 at certain points. By using the correct fee, this is avoided. The negative balance can be observed [here](https://github.com/lightningnetwork/lnd/blob/master/lnwallet/channel.go#L1846) in `ourBalance`.