### PR TITLE
WIP - wallet: fully validate all channel constraints

### DIFF
--- a/fundingmanager_test.go
+++ b/fundingmanager_test.go
@@ -124,13 +124,14 @@ func createTestWallet(cdb *channeldb.DB, netParams *chaincfg.Params,
 	estimator lnwallet.FeeEstimator) (*lnwallet.LightningWallet, error) {
 
 	wallet, err := lnwallet.NewLightningWallet(lnwallet.Config{
-		Database:         cdb,
-		Notifier:         notifier,
-		WalletController: wc,
-		Signer:           signer,
-		ChainIO:          bio,
-		FeeEstimator:     estimator,
-		NetParams:        *netParams,
+		Database:           cdb,
+		Notifier:           notifier,
+		WalletController:   wc,
+		Signer:             signer,
+		ChainIO:            bio,
+		FeeEstimator:       estimator,
+		NetParams:          *netParams,
+		DefaultConstraints: defaultChannelConstraints,
 	})
 	if err != nil {
 		return nil, err

--- a/htlcswitch/link.go
+++ b/htlcswitch/link.go
@@ -234,13 +234,12 @@ func NewChannelLink(cfg ChannelLinkConfig, channel *lnwallet.LightningChannel,
 	currentHeight uint32) ChannelLink {
 
 	return &channelLink{
-		cfg:               cfg,
-		channel:           channel,
-		clearedOnionBlobs: make(map[uint64][lnwire.OnionPacketSize]byte),
-		upstream:          make(chan lnwire.Message),
-		downstream:        make(chan *htlcPacket),
-		linkControl:       make(chan interface{}),
-		// TODO(roasbeef): just do reserve here?
+		cfg:                cfg,
+		channel:            channel,
+		clearedOnionBlobs:  make(map[uint64][lnwire.OnionPacketSize]byte),
+		upstream:           make(chan lnwire.Message),
+		downstream:         make(chan *htlcPacket),
+		linkControl:        make(chan interface{}),
 		availableBandwidth: uint64(channel.StateSnapshot().LocalBalance),
 		cancelReasons:      make(map[uint64]lnwire.OpaqueReason),
 		logCommitTimer:     time.NewTimer(300 * time.Millisecond),
@@ -932,8 +931,8 @@ type getBandwidthCmd struct {
 //
 // NOTE: Part of the ChannelLink interface.
 func (l *channelLink) Bandwidth() lnwire.MilliSatoshi {
-	// TODO(roasbeef): subtract reserverj
-	return lnwire.MilliSatoshi(atomic.LoadUint64(&l.availableBandwidth))
+	return lnwire.MilliSatoshi(atomic.LoadUint64(
+		&l.availableBandwidth) - uint64(l.channel.GetReserve()*1000))
 }
 
 // policyUpdate is a message sent to a channel link when an outside sub-system

--- a/lnwallet/channel.go
+++ b/lnwallet/channel.go
@@ -49,6 +49,23 @@ var (
 	ErrMaxHTLCNumber = fmt.Errorf("commitment transaction exceed max " +
 		"htlc number")
 
+	// ErrMaxPendingAmount is returned when a proposed HTLC would exceed
+	// the overall maximum pending value of all HTLC's if committed in a
+	// state transition.
+	ErrMaxPendingAmount = fmt.Errorf("commitment transaction exceed max" +
+		"overall htlc value")
+
+	// ErrBelowChanReserve is returned when a proposed HTLC would cause
+	// one of the peer's funds to dip below the channel reserve limit.
+	ErrBelowChanReserve = fmt.Errorf("commitment transaction dips peer " +
+		"below chan reserve")
+
+	// ErrBelowMinHTLC is returned when a proposed HTLC has a value that
+	// is below the minimum HTLC value constraint for either us or our
+	// peer depending on which flags are set.
+	ErrBelowMinHTLC = fmt.Errorf("proposed HTLC value is below minimum " +
+		"allowed HTLC value")
+
 	// ErrInsufficientBalance is returned when a proposed HTLC would
 	// exceed the available balance.
 	ErrInsufficientBalance = fmt.Errorf("insufficient local balance")
@@ -1515,7 +1532,7 @@ func htlcSuccessFee(feePerKw btcutil.Amount) btcutil.Amount {
 // htlcIsDust determines if an HTLC output is dust or not depending on two
 // bits: if the HTLC is incoming and if the HTLC will be placed on our
 // commitment transaction, or theirs. These two pieces of information are
-// require as we currently used second-level HTLC transactions ass off-chain
+// require as we currently used second-level HTLC transactions as off-chain
 // covenants. Depending on the two bits, we'll either be using a timeout or
 // success transaction which have different weights.
 func htlcIsDust(incoming, ourCommit bool,
@@ -2436,14 +2453,18 @@ func (lc *LightningChannel) SignNextCommitment() (*btcec.Signature, []*btcec.Sig
 	return sig, htlcSigs, nil
 }
 
-// validateCommitmentSanity is used to validate that on current state the commitment
-// transaction is valid in terms of propagating it over Bitcoin network, and
-// also that all outputs are meet Bitcoin spec requirements and they are
-// spendable.
+// validateCommitmentSanity is used to validate the current state of the
+// commitment transaction in terms of the ChannelConstraints that we and our
+// remote peer agreed upon during the funding workflow.
 func (lc *LightningChannel) validateCommitmentSanity(theirLogCounter,
 	ourLogCounter uint64, prediction bool, local bool, remote bool) error {
 
-	// TODO(roasbeef): verify remaining sanity requirements
+	// In this step, we verify that the total number of active HTLC's does
+	// not exceed our constraint if the remote flag is set. If the local
+	// flag is set, we check that we not exceed the remote peer's constraint.
+	// If both the local and remote flags are set, we check that both of us
+	// adhere to the other's constraints. This step verifies the
+	// MaxAcceptedHtlcs field of ChannelConstraints.
 	htlcCount := 0
 
 	// If we adding or receiving the htlc we increase the number of htlcs
@@ -2483,20 +2504,139 @@ func (lc *LightningChannel) validateCommitmentSanity(theirLogCounter,
 		}
 	}
 
-	// If we're validating the commitment sanity for HTLC _log_ update by a
-	// particular side, then we'll only consider half of the available HTLC
-	// bandwidth. However, if we're validating the _creation_ of a new
-	// commitment state, then we'll use the full value as the sum of the
-	// contribution of both sides shouldn't exceed the max number.
+	// If we're updating the commitment sanity for HTLC _log_ update by a
+	// particular side, then we'll only consider their bandwidth constraint.
+	// However, if we're validating the _creation_ of a new commitment state,
+	// then we'll use the full combined constraints as the sum of the
+	// contribution of both sides shouldn't exceed this max number.
 	var maxHTLCNumber int
 	if local && remote {
-		maxHTLCNumber = MaxHTLCNumber
-	} else {
-		maxHTLCNumber = MaxHTLCNumber / 2
+		maxHTLCNumber = int(lc.localChanCfg.MaxAcceptedHtlcs +
+			lc.remoteChanCfg.MaxAcceptedHtlcs)
+	} else if local {
+		maxHTLCNumber = int(lc.remoteChanCfg.MaxAcceptedHtlcs)
+	} else if remote {
+		maxHTLCNumber = int(lc.localChanCfg.MaxAcceptedHtlcs)
 	}
 
 	if htlcCount > maxHTLCNumber {
 		return ErrMaxHTLCNumber
+	}
+
+	// In this step, we verify that the maximum overall pending HTLC value
+	// is not met for either party depending on which of [local|remote]
+	// flags are set. This step verifies the MaxPendingAmount field of
+	// ChannelConstraints.
+	if remote {
+		pendingAmount := lnwire.NewMSatFromSatoshis(0)
+
+		for _, entry := range view.theirUpdates {
+			if entry.EntryType == Add {
+				pendingAmount += entry.Amount
+			} else {
+				pendingAmount -= entry.Amount
+			}
+		}
+
+		if pendingAmount > lc.localChanCfg.MaxPendingAmount {
+			return ErrMaxPendingAmount
+		}
+	}
+
+	if local {
+		pendingAmount := lnwire.NewMSatFromSatoshis(0)
+
+		for _, entry := range view.ourUpdates {
+			if entry.EntryType == Add {
+				pendingAmount += entry.Amount
+			} else {
+				pendingAmount -= entry.Amount
+			}
+		}
+
+		if pendingAmount > lc.remoteChanCfg.MaxPendingAmount {
+			return ErrMaxPendingAmount
+		}
+	}
+
+	// In this step, we verify that our channel reserves are still met
+	// with the new commitment transaction. This step verifies ChanReserve
+	// of ChannelConstraints.
+	if remote {
+		theirRemoteBalance := lc.remoteCommitChain.tail().theirBalance
+
+		for _, entry := range view.theirUpdates {
+			if entry.EntryType == Add &&
+				entry.addCommitHeightRemote == 0 {
+				theirRemoteBalance -= entry.Amount
+			} else if entry.EntryType == Settle &&
+				entry.removeCommitHeightRemote == 0 {
+				theirRemoteBalance += entry.Amount
+			}
+		}
+		for _, entry := range view.ourUpdates {
+			if entry.EntryType == Fail &&
+				entry.removeCommitHeightRemote == 0 {
+				theirRemoteBalance += entry.Amount
+			}
+		}
+
+		if theirRemoteBalance.ToSatoshis() < lc.localChanCfg.ChanReserve {
+			return ErrBelowChanReserve
+		}
+	}
+
+	if local {
+		ourLocalBalance := lc.localCommitChain.tail().ourBalance
+
+		for _, entry := range view.ourUpdates {
+			if entry.EntryType == Add &&
+				entry.addCommitHeightLocal == 0 {
+				ourLocalBalance -= entry.Amount
+			} else if entry.EntryType == Settle &&
+				entry.removeCommitHeightLocal == 0 {
+				ourLocalBalance += entry.Amount
+			}
+		}
+		for _, entry := range view.theirUpdates {
+			if entry.EntryType == Fail &&
+				entry.removeCommitHeightLocal == 0 {
+				ourLocalBalance += entry.Amount
+			}
+		}
+
+		if ourLocalBalance.ToSatoshis() < lc.remoteChanCfg.ChanReserve {
+			return ErrBelowChanReserve
+		}
+	}
+
+	// In this step, we verify that no HTLC's value is below either our
+	// or our peer's MinHTLC in ChannelConstraints depending on which of
+	// the [local|remote] flags are set.
+	if remote {
+		for _, entry := range view.theirUpdates {
+			if entry.Amount < lc.localChanCfg.MinHTLC {
+				return ErrBelowMinHTLC
+			}
+		}
+		for _, entry := range view.ourUpdates {
+			if entry.Amount < lc.localChanCfg.MinHTLC {
+				return ErrBelowMinHTLC
+			}
+		}
+	}
+
+	if local {
+		for _, entry := range view.ourUpdates {
+			if entry.Amount < lc.remoteChanCfg.MinHTLC {
+				return ErrBelowMinHTLC
+			}
+		}
+		for _, entry := range view.theirUpdates {
+			if entry.Amount < lc.remoteChanCfg.MinHTLC {
+				return ErrBelowMinHTLC
+			}
+		}
 	}
 
 	return nil
@@ -2681,8 +2821,9 @@ func (lc *LightningChannel) ReceiveNewCommitment(commitSig *btcec.Signature,
 	commitPoint := ComputeCommitmentPoint(commitSecret[:])
 
 	// With the current commitment point re-calculated, construct the new
-	// commitment view which includes all the entries we know of in their
-	// HTLC log, and up to ourLogIndex in our HTLC log.
+	// commitment view which includes all the entries (pending or committed)
+	// we know of in the remote node's HTLC log, but only our local changes
+	// up to the last change the remote node has ACK'd.
 	localCommitmentView, err := lc.fetchCommitmentView(false,
 		lc.localUpdateLog.ackedIndex, lc.remoteUpdateLog.logIndex,
 		commitPoint)
@@ -4008,4 +4149,9 @@ func (lc *LightningChannel) RemoteNextRevocation() *btcec.PublicKey {
 	defer lc.Unlock()
 
 	return lc.channelState.RemoteNextRevocation
+}
+
+// GetReserve returns our local ChanReserve requirement for the remote party.
+func (lc *LightningChannel) GetReserve() btcutil.Amount {
+	return lc.localChanCfg.ChanReserve
 }

--- a/lnwallet/channel.go
+++ b/lnwallet/channel.go
@@ -2563,7 +2563,7 @@ func (lc *LightningChannel) validateCommitmentSanity(theirLogCounter,
 	// with the new commitment transaction. This step verifies ChanReserve
 	// of ChannelConstraints.
 	if remote {
-		theirRemoteBalance := lc.remoteCommitChain.tail().theirBalance
+		theirRemoteBalance := lc.remoteCommitChain.tip().theirBalance
 
 		for _, entry := range view.theirUpdates {
 			if entry.EntryType == Add &&
@@ -2587,7 +2587,7 @@ func (lc *LightningChannel) validateCommitmentSanity(theirLogCounter,
 	}
 
 	if local {
-		ourLocalBalance := lc.localCommitChain.tail().ourBalance
+		ourLocalBalance := lc.localCommitChain.tip().ourBalance
 
 		for _, entry := range view.ourUpdates {
 			if entry.EntryType == Add &&

--- a/lnwallet/interface_test.go
+++ b/lnwallet/interface_test.go
@@ -261,6 +261,7 @@ func testDualFundingReservationWorkflow(miner *rpctest.Harness,
 		t.Fatalf("unable to initialize funding reservation: %v", err)
 	}
 	aliceChanReservation.SetNumConfsRequired(numReqConfs)
+	aliceChanReservation.OurContribution().DustLimit = lnwallet.DefaultDustLimit()
 	aliceChanReservation.CommitConstraints(csvDelay, lnwallet.MaxHTLCNumber/2,
 		lnwire.NewMSatFromSatoshis(fundingAmount), 10)
 
@@ -284,6 +285,7 @@ func testDualFundingReservationWorkflow(miner *rpctest.Harness,
 	if err != nil {
 		t.Fatalf("bob unable to init channel reservation: %v", err)
 	}
+	bobChanReservation.OurContribution().DustLimit = lnwallet.DefaultDustLimit()
 	bobChanReservation.CommitConstraints(csvDelay, lnwallet.MaxHTLCNumber/2,
 		lnwire.NewMSatFromSatoshis(fundingAmount), 10)
 	bobChanReservation.SetNumConfsRequired(numReqConfs)


### PR DESCRIPTION
This PR address #298.

This PR introduces changes that alter the funding / reservation workflow as well as the validateCommitmentSanity function to fully validate all channel constraints. The funding / reservation workflow also now includes function closures to create sane values for the ChannelConstraints fields. When exchanging their respective ChannelConstraints, each node now performs validation on the peer's
values. Additionally, validateCommitmentSanity now validates that the MaxPendingAmount, ChanReserve, MinHTLC, & MaxAcceptedHTLCs limits are all adhered to during the lifetime of a channel. Unit tests were also included to account for these new changes.