### PR TITLE
Neutrino BIP fixes

### DIFF
--- a/chainntnfs/neutrinonotify/neutrino.go
+++ b/chainntnfs/neutrinonotify/neutrino.go
@@ -471,11 +471,12 @@ chainScan:
 		}
 		blockHash := header.BlockHash()
 
-		// With the hash computed, we can now fetch the extended filter
+		// With the hash computed, we can now fetch the basic filter
 		// for this height.
-		extFilter, err := n.p2pNode.GetCFilter(blockHash, true)
+		regFilter, err := n.p2pNode.GetCFilter(blockHash,
+			wire.GCSFilterRegular)
 		if err != nil {
-			chainntnfs.Log.Errorf("unable to retrieve extended "+
+			chainntnfs.Log.Errorf("unable to retrieve regular "+
 				"filter for height=%v: %v", scanHeight, err)
 			return false
 		}
@@ -483,14 +484,14 @@ chainScan:
 		// If the block has no transactions other than the coinbase
 		// transaction, then the filter may be nil, so we'll continue
 		// forward int that case.
-		if extFilter == nil {
+		if regFilter == nil {
 			continue
 		}
 
 		// In the case that the filter exists, we'll attempt to see if
 		// any element in it match our target txid.
 		key := builder.DeriveKey(&blockHash)
-		match, err := extFilter.Match(key, targetHash[:])
+		match, err := regFilter.Match(key, targetHash[:])
 		if err != nil {
 			chainntnfs.Log.Errorf("unable to query filter: %v", err)
 			return false

--- a/glide.lock
+++ b/glide.lock
@@ -1,4 +1,4 @@
-hash: 455c5f00a9528a6b9be73e74ab7fbd8b184c5b53a4f3db409033af31721c275b
+hash: 68c736061d5d8b10cfc314a86b8ed8cb63208d7dca7008d740f230b51b824374
 updated: 2017-10-30T19:08:26.782081708-07:00
 imports:
 - name: github.com/aead/chacha20
@@ -70,7 +70,7 @@ imports:
 - name: github.com/kkdai/bstream
   version: f391b8402d23024e7c0f624b31267a89998fca95
 - name: github.com/lightninglabs/neutrino
-  version: 01dcf832a5783e57ca6bc8d7f06c3456d2e00d88
+  version: 2fb43209a6f54fbf78ba71b50623503db611c371
   subpackages:
   - filterdb
   - headerfs
@@ -87,7 +87,7 @@ imports:
   subpackages:
   - internal/socket
 - name: github.com/roasbeef/btcd
-  version: a64d018fd91151b842522d64771610712565d30a
+  version: be2fceadae0af7355eca1eb3716c6f9c88d4fc20
   subpackages:
   - addrmgr
   - blockchain
@@ -105,7 +105,7 @@ imports:
 - name: github.com/roasbeef/btcrpcclient
   version: d0f4db8b4dad0ca3d569b804f21247c3dd96acbb
 - name: github.com/roasbeef/btcutil
-  version: 1584022350b4400b511beab6a013f0189adeef40
+  version: c4646eb27366f887b9e034ce91510fe720a31201
   subpackages:
   - base58
   - bech32
@@ -116,7 +116,7 @@ imports:
   - hdkeychain
   - txsort
 - name: github.com/roasbeef/btcwallet
-  version: fbd5b82e8efe29729e2c7ebed5900a210e931df2
+  version: ba1ef885d5d280a5fd222bdf78f708c855f22c81
   subpackages:
   - chain
   - internal/helpers

--- a/glide.yaml
+++ b/glide.yaml
@@ -15,7 +15,7 @@ import:
   - proto
 - package: github.com/howeyc/gopass
 - package: github.com/roasbeef/btcd
-  version: a64d018fd91151b842522d64771610712565d30a
+  version: be2fceadae0af7355eca1eb3716c6f9c88d4fc20
   subpackages:
   - blockchain
   - btcec
@@ -27,14 +27,14 @@ import:
 - package: github.com/roasbeef/btcrpcclient
   version: d0f4db8b4dad0ca3d569b804f21247c3dd96acbb
 - package: github.com/roasbeef/btcutil
-  version: 1584022350b4400b511beab6a013f0189adeef40
+  version: c4646eb27366f887b9e034ce91510fe720a31201
   subpackages:
   - bloom
   - coinset
   - hdkeychain
   - txsort
 - package: github.com/roasbeef/btcwallet
-  version: fbd5b82e8efe29729e2c7ebed5900a210e931df2
+  version: ba1ef885d5d280a5fd222bdf78f708c855f22c81
   subpackages:
   - chain
   - waddrmgr
@@ -71,7 +71,7 @@ import:
   subpackages:
   - chaincfg
 - package: github.com/lightninglabs/neutrino
-  version: 01dcf832a5783e57ca6bc8d7f06c3456d2e00d88
+  version: 2fb43209a6f54fbf78ba71b50623503db611c371
 - package: gopkg.in/macaroon.v1
 - package: gopkg.in/macaroon-bakery.v1
 - package: github.com/juju/loggo

--- a/routing/chainview/neutrino.go
+++ b/routing/chainview/neutrino.go
@@ -236,7 +236,7 @@ func (c *CfFilteredChainView) FilterBlock(blockHash *chainhash.Hash) (*FilteredB
 	// Next, using the block, hash, we'll fetch the compact filter for this
 	// block. We only require the regular filter as we're just looking for
 	// outpoint that have been spent.
-	filter, err := c.p2pNode.GetCFilter(*blockHash, false)
+	filter, err := c.p2pNode.GetCFilter(*blockHash, wire.GCSFilterRegular)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This PR updates `lnd` to be able to use the `btcd` and `neutrino` code which complies with the updated cfilter BIP.