### PR TITLE
Add upload of integration logs from TravisCI builds (fixes #302)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,3 +25,5 @@ env:
 script:
   - export PATH=$PATH:$HOME/gopath/bin
   - ./gotest.sh
+after_script:
+  - find *.log | xargs -I{} sh -c "cat {} | nc termbin.com 9999 | xargs -r0 printf '{} uploaded to %s'"

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,8 +17,11 @@ install:
   - popd
   - popd
 env:
-  - RACE=false
-  - RACE=true
+  global:
+    - LOGS=true
+  matrix:
+    - RACE=false
+    - RACE=true
 script:
   - export PATH=$PATH:$HOME/gopath/bin
   - ./gotest.sh

--- a/gotest.sh
+++ b/gotest.sh
@@ -113,19 +113,22 @@ NEED_LINT="false"
 NEED_COVERAGE="false"
 NEED_RACE="false"
 NEED_INSTALL="false"
+NEED_LOGS="false"
 
-while getopts "lrci" flag; do
+while getopts "lrcio" flag; do
         case "${flag}" in
             l) NEED_LINT="true" ;;
             r) NEED_RACE="true" ;;
             c) NEED_COVERAGE="true" ;;
             i) NEED_INSTALL="true" ;;
+            o) NEED_LOGS="true" ;;
             *)
-                printf '\nUsage: %s [-l] [-r] [-c] [-i], where:\n' $0
+                printf '\nUsage: %s [-l] [-r] [-c] [-i] [-o], where:\n' $0
                 printf ' -l: include code lint check\n'
                 printf ' -r: run tests with race condition check\n'
                 printf ' -c: run tests with test coverage\n'
                 printf ' -i: reinstall project dependencies\n'
+                printf ' -o: generate logs for spawned lnd instances\n'
                 exit 1 ;;
         esac
     done
@@ -164,7 +167,13 @@ fi
 # we may calmly send coverage profile (if script is run on travis)
 if [ "$NEED_COVERAGE" == "true" ] || [ "$RACE" == "false" ]; then
     print "* Running integration tests"
-    go test -v -tags rpctest
+
+    LOGOUTPUT_FLAG=""
+    if [ "$NEED_LOGS" == "true" ] || [ "$LOGS" == "true" ]; then
+        LOGOUTPUT_FLAG="-logoutput=true"
+    fi
+
+    go test -v -tags rpctest "$LOGOUTPUT_FLAG"
 
     test_with_coverage_profile
 fi


### PR DESCRIPTION
This PR adds: 

- Functionality to `gotest.sh` to log the output of `lnd` instances used for integration testing to file.
- Uploading of those log files to [termbin.com ](http://www.termbin.com) from TravisCI integration builds.

As an example of a build with this enabled, you can look at [this build](https://travis-ci.org/samvrlewis/lnd/builds/286942025), which is a build from my `ci_logging_test` branch. That branch has the same diff as my `ci_logging` branch but with a small inclusion to allow TravisCI builds to work (as I described in [my comment](https://github.com/lightningnetwork/lnd/issues/302#issuecomment-335133834) the other day). If you scroll to the end of the job logs where `RACE=false` you'll see a `after_script` section with an output like this:

```
output0.log uploaded to http://termbin.com/aloqr
output1.log uploaded to http://termbin.com/3ggh
output2.log uploaded to http://termbin.com/abb9
output3.log uploaded to http://termbin.com/rk9j
output4.log uploaded to http://termbin.com/956p
output5.log uploaded to http://termbin.com/iwwt
```

I ended up using termbin.com as after I posted about transfer.sh, they shut down a few days later! I'm open to suggestions for a different service to save the logs to, termbin looked the most reputable service that had been around for a decent amount of time. As far as I can tell, termbin doesn't have any limits to file sizes and keeps files for 30 days, which, from what I understand, should be sufficient.

As always, please let me know if I should change anything or do anything differently.