### PR TITLE
WIP: Revamp Peer Disconnection

### DIFF
--- a/server.go
+++ b/server.go
@@ -908,7 +908,7 @@ func (s *server) sendToPeer(target *btcec.PublicKey,
 	// Compute the target peer's identifier.
 	targetPubBytes := target.SerializeCompressed()
 
-	srvrLog.Infof("Attempting to send msgs %v to: %x",
+	srvrLog.Infof("Attempting to send %v msgs to: %x",
 		len(msgs), targetPubBytes)
 
 	// Lookup intended target in peersByPub, returning an error to the
@@ -954,7 +954,7 @@ func (s *server) sendPeerMessages(
 	}
 
 	for _, msg := range msgs {
-		targetPeer.queueMsg(msg, nil)
+		targetPeer.SendMessage(msg)
 	}
 }
 
@@ -1595,8 +1595,8 @@ func (s *server) Peers() []*peer {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	peers := make([]*peer, 0, len(s.peersByID))
-	for _, peer := range s.peersByID {
+	peers := make([]*peer, 0, len(s.peersByPub))
+	for _, peer := range s.peersByPub {
 		peers = append(peers, peer)
 	}
 


### PR DESCRIPTION
This PR is intended to address the following flake observed in the `graph_topology_notifications`:
```
    --- FAIL: TestLightningNetworkDaemon/graph_topology_notifications (17.59s)
    	lnd_test.go:66: Failed: (graph topology notifications): exited with error: 
    		*errors.errorString timeout waiting for graph notification 0
    		/home/travis/gopath/src/github.com/lightningnetwork/lnd/lnd_test.go:3344 (0xba7fd3)
    			testGraphTopologyNotifications: t.Fatalf("timeout waiting for graph notification %v", i)
    		/home/travis/gopath/src/github.com/lightningnetwork/lnd/lnd_test.go:88 (0xb9177b)
    			(*harnessTest).RunTestCase: testCase.test(net, h)
    		/home/travis/gopath/src/github.com/lightningnetwork/lnd/lnd_test.go:4110 (0xbc0197)
    			TestLightningNetworkDaemon.func3: ht.RunTestCase(testCase, lndHarness)
    		/home/travis/.gimme/versions/go1.8.5.linux.amd64/src/testing/testing.go:657 (0x4ee356)
    			tRunner: fn(t)
    		/home/travis/.gimme/versions/go1.8.5.linux.amd64/src/runtime/asm_amd64.s:2197 (0x45b711)
    			goexit: BYTE	$0x90	// NOP
```

After a non-trivial amount of travis flake hunting, the problem seems to have been an artifact of the shutdown procedure of the `readHandler` and the `writeHandler`. I have had trouble getting logs that clearly signal this is the issue, but have not encountered the error since making these changes. The bulk of the fix was to defer signalling waitgroups and closing `chanMsgStream` within the handlers. I also added some small fixes to the server code, specifically:
 - fixing a print statement, because I can't English write
 - use the peer's public `SendMessage`, which wraps the private method we used before
 - output of `Peers()` now returns the peers contained in the `peersByPub` map, instead `peersByID`

Status: Removed debug prints and error resurfaced 🤦‍♂️