### PR TITLE
chainntnfs: Fix btcdnotify race condition causing double heap add

### DIFF
--- a/chainntnfs/btcdnotify/btcd.go
+++ b/chainntnfs/btcdnotify/btcd.go
@@ -295,7 +295,7 @@ out:
 				// If the notification can be partially or
 				// fully dispatched, then we can skip the first
 				// phase for ntfns.
-				if b.attemptHistoricalDispatch(msg, currentHeight) {
+				if b.attemptHistoricalDispatch(msg) {
 					continue
 				}
 
@@ -420,8 +420,8 @@ out:
 // can skip straight to the confirmations heap.
 //
 // Returns true if the transaction was either partially or completely confirmed
-func (b *BtcdNotifier) attemptHistoricalDispatch(msg *confirmationsNotification,
-	currentHeight int32) bool {
+func (b *BtcdNotifier) attemptHistoricalDispatch(
+	msg *confirmationsNotification) bool {
 
 	chainntnfs.Log.Infof("Attempting to trigger dispatch for %v from "+
 		"historical chain", msg.txid)
@@ -482,8 +482,8 @@ func (b *BtcdNotifier) attemptHistoricalDispatch(msg *confirmationsNotification,
 
 	// Otherwise, the transaction has only been *partially* confirmed, so
 	// we need to insert it into the confirmation heap.
-	confsLeft := msg.numConfirmations - uint32(tx.Confirmations)
-	confHeight := uint32(currentHeight) + confsLeft
+	// Find the block height at which this transaction will be confirmed
+	confHeight := uint32(block.Height) + msg.numConfirmations - 1
 	heapEntry := &confEntry{
 		msg,
 		confDetails,

--- a/chainntnfs/btcdnotify/btcd.go
+++ b/chainntnfs/btcdnotify/btcd.go
@@ -418,6 +418,8 @@ out:
 // attemptHistoricalDispatch tries to use historical information to decide if a
 // notification ca be dispatched immediately, or is partially confirmed so it
 // can skip straight to the confirmations heap.
+//
+// Returns true if the transaction was either partially or completely confirmed
 func (b *BtcdNotifier) attemptHistoricalDispatch(msg *confirmationsNotification,
 	currentHeight int32) bool {
 
@@ -489,7 +491,7 @@ func (b *BtcdNotifier) attemptHistoricalDispatch(msg *confirmationsNotification,
 	}
 	heap.Push(b.confHeap, heapEntry)
 
-	return false
+	return true
 }
 
 // notifyBlockEpochs notifies all registered block epoch clients of the newly


### PR DESCRIPTION
Came across this as I was working on https://github.com/lightningnetwork/lnd/issues/27.

As described in the commit messages, the race condition happens when a notification is being registered to the notifier at the same time as a block containing that notification is generated. This causes both the `attemptHistoricalDispatch` and the `checkConfirmationTrigger` functions to add the same confirmation intent to the confirmation heap. It's probably a fairly rare case that's more likely to come up in tests than real use, but I think the ramifications of it occurring are fairly bad.

When the tx eventually does reach the required number of confirmations, this causes the confirmation to be written to the `Confirmed` channel twice and, because the channel is buffered with a size of 1, this can cause the notifier to block until the channel is read from at least once.

Running the new test (`testLazyNtfnConsumer`) on my PC without the fix to `btcd.go` applied, the test hangs forever about half of the time. With the fix it doesn't hang. (As a side note, this is probably my go noobiness speaking but why does it hang forever? The test looks like it runs in its own goroutine to the notifier's dispatch loop and the `time.After(20 * time.Second)` should time it out, shouldn't it?).

I also noticed that, in this scenario of the transaction being included in a block that the notifier has yet to process, the current height that's passed in to the historical dispatcher will be incorrect. This has the follow on effect of making the target confirmation height wrong. My third commit addresses this.

As always, yell at me if I've messed anything up. :smile: 