### PR TITLE
lnwallet: Add 2nd-stage htlc size constants and outgoing GenWitnessFunc

### DIFF
--- a/lnwallet/size.go
+++ b/lnwallet/size.go
@@ -186,20 +186,29 @@ const (
 	// weight limits.
 	MaxHTLCNumber = 966
 
-	// ToLocalPenaltyScriptSize 83 bytes
+	// ToLocalScriptSize 83 bytes
 	//      - OP_IF: 1 byte
 	//              - OP_DATA: 1 byte (revocationkey length)
 	//              - revocationkey: 33 bytes
 	//              - OP_CHECKSIG: 1 byte
 	//      - OP_ELSE: 1 byte
 	//              - OP_DATA: 1 byte (localkey length)
-	//              - localkey: 33 bytes
+	//              - local_delay_key: 33 bytes
 	//              - OP_CHECKSIG_VERIFY: 1 byte
 	//              - OP_DATA: 1 byte (delay length)
 	//              - delay: 8 bytes
 	//              -OP_CHECKSEQUENCEVERIFY: 1 byte
 	//      - OP_ENDIF: 1 byte
-	ToLocalPenaltyScriptSize = 1 + 1 + 33 + 1 + 1 + 1 + 33 + 1 + 1 + 8 + 1 + 1
+	ToLocalScriptSize = 1 + 1 + 33 + 1 + 1 + 1 + 33 + 1 + 1 + 8 + 1 + 1
+
+	// ToLocalTimeoutWitnessSize x bytes
+	//     - number_of_witness_elements: 1 byte
+	//     - local_delay_sig_length: 1 byte
+	//     - local_delay_sig: 73 bytes
+	//     - zero_length: 1 byte
+	//     - witness_script_length: 1 byte
+	//     - witness_script (to_local_script)
+	ToLocalTimeoutWitnessSize = 1 + 1 + 73 + 1 + 1 + ToLocalScriptSize
 
 	// ToLocalPenaltyWitnessSize 160 bytes
 	//      - number_of_witness_elements: 1 byte
@@ -208,9 +217,9 @@ const (
 	//      - one_length: 1 byte
 	//      - witness_script_length: 1 byte
 	//      - witness_script (to_local_script)
-	ToLocalPenaltyWitnessSize = 1 + 1 + 73 + 1 + 1 + ToLocalPenaltyScriptSize
+	ToLocalPenaltyWitnessSize = 1 + 1 + 73 + 1 + 1 + ToLocalScriptSize
 
-	// AcceptedHtlcPenaltyScriptSize 139 bytes
+	// AcceptedHtlcScriptSize 139 bytes
 	//      - OP_DUP: 1 byte
 	//      - OP_HASH160: 1 byte
 	//      - OP_DATA: 1 byte (RIPEMD160(SHA256(revocationkey)) length)
@@ -245,8 +254,21 @@ const (
 	//                      - OP_CHECKSIG: 1 byte
 	//              - OP_ENDIF: 1 byte
 	//      - OP_ENDIF: 1 byte
-	AcceptedHtlcPenaltyScriptSize = 3*1 + 20 + 5*1 + 33 + 7*1 + 20 + 4*1 +
+	AcceptedHtlcScriptSize = 3*1 + 20 + 5*1 + 33 + 7*1 + 20 + 4*1 +
 		33 + 5*1 + 4 + 5*1
+
+	// AcceptedHtlcSuccessWitnessSize 325 bytes
+	//    - number_of_witness_elements: 1 byte
+	//    - nil_length: 1 byte
+	//    - sig_alice_length: 1 byte
+	//    - sig_alice: 73 bytes
+	//    - sig_bob_length: 1 byte
+	//    - sig_bob: 73 bytes
+	//    - preimage_length: 1 byte
+	//    - preimage: 32 bytes
+	//    - witness_script_length: 1 byte
+	//    - witness_script (accepted_htlc_script)
+	AcceptedHtlcSuccessWitnessSize = 1 + 1 + 73 + 1 + 73 + 1 + 32 + 1 + AcceptedHtlcScriptSize
 
 	// AcceptedHtlcPenaltyWitnessSize 249 bytes
 	//    - number_of_witness_elements: 1 byte
@@ -256,8 +278,7 @@ const (
 	//    - revocation_key: 33 bytes
 	//    - witness_script_length: 1 byte
 	//    - witness_script (accepted_htlc_script)
-	AcceptedHtlcPenaltyWitnessSize = 1 + 1 + 73 + 1 + 33 + 1 +
-		AcceptedHtlcPenaltyScriptSize
+	AcceptedHtlcPenaltyWitnessSize = 1 + 1 + 73 + 1 + 33 + 1 + AcceptedHtlcScriptSize
 
 	// OfferedHtlcScriptSize 133 bytes
 	//      - OP_DUP: 1 byte
@@ -302,6 +323,18 @@ const (
 	//    - witness_script_length: 1 byte
 	//    - witness_script (offered_htlc_script)
 	OfferedHtlcWitnessSize = 1 + 1 + 73 + 1 + 33 + 1 + OfferedHtlcScriptSize
+
+	// OfferedHtlcTimeoutWitnessSize 285 bytes
+	// - number_of_witness_elements: 1 byte
+	// - nil_length: 1 byte
+	// - sig_alice_length: 1 byte
+	// - sig_alice: 73 bytes
+	// - sig_bob_length: 1 byte
+	// - sig_bob: 73 bytes
+	// - nil_length: 1 byte
+	// - witness_script_length: 1 byte
+	// - witness_script (offered_htlc_script)
+	OfferedHtlcTimeoutWitnessSize = 1 + 1 + 1 + 73 + 1 + 73 + 1 + 1 + OfferedHtlcScriptSize
 
 	// OfferedHtlcPenaltyWitnessSize 243 bytes
 	//      - number_of_witness_elements: 1 byte

--- a/lnwallet/witnessgen.go
+++ b/lnwallet/witnessgen.go
@@ -13,17 +13,18 @@ import (
 type WitnessType uint16
 
 const (
-	// CommitmentTimeLock is a witness that allows us to spend the output of a
-	// commitment transaction after a relative lock-time lockout.
+	// CommitmentTimeLock is a witness that allows us to spend the output of
+	// a commitment transaction after a relative lock-time lockout.
 	CommitmentTimeLock WitnessType = 0
 
-	// CommitmentNoDelay is a witness that allows us to spend a settled no-delay
-	// output immediately on a counterparty's commitment transaction.
+	// CommitmentNoDelay is a witness that allows us to spend a settled
+	// no-delay output immediately on a counterparty's commitment
+	// transaction.
 	CommitmentNoDelay WitnessType = 1
 
-	// CommitmentRevoke is a witness that allows us to sweep the settled output
-	// of a malicious counterparty's who broadcasts a revoked commitment
-	// transaction.
+	// CommitmentRevoke is a witness that allows us to sweep the settled
+	// output of a malicious counterparty's who broadcasts a revoked
+	// commitment transaction.
 	CommitmentRevoke WitnessType = 2
 
 	// HtlcOfferedRevoke is a witness that allows us to sweep an HTLC
@@ -33,6 +34,15 @@ const (
 	// HtlcAcceptedRevoke is a witness that allows us to sweep an HTLC
 	// output that we accepted from the counterparty.
 	HtlcAcceptedRevoke WitnessType = 4
+
+	// HtlcOfferedTimeout is a witness that allows us to sweep an HTLC
+	// output that we extended to a party, but was never fulfilled.
+	HtlcOfferedTimeout WitnessType = 5
+
+	// HtlcAcceptedSuccess is a witness that allows us to sweep an HTLC
+	// output that was offered to us, and for which we have a payment
+	// preimage.
+	HtlcAcceptedSuccess WitnessType = 6
 )
 
 // WitnessGenerator represents a function which is able to generate the final
@@ -64,6 +74,8 @@ func (wt WitnessType) GenWitnessFunc(signer Signer,
 			return ReceiverHtlcSpendRevoke(signer, desc, tx)
 		case HtlcAcceptedRevoke:
 			return SenderHtlcSpendRevoke(signer, desc, tx)
+		case HtlcOfferedTimeout:
+			return HtlcSpendSuccess(signer, desc, tx)
 		default:
 			return nil, fmt.Errorf("unknown witness type: %v", wt)
 		}


### PR DESCRIPTION
This PR is being split from #384, and adds most of the wallet features required to sign outgoing HTLCs that will be incubated in the utxo nursery. The constants are derived from prior calculations made in [BOLT-05](https://github.com/lightningnetwork/lightning-rfc/blob/master/05-onchain.md).

We create a separate, public method for signing htlc success transactions so that it matches the same signature of our other witness generation functions. The txn version, sig cache, and sequence number are already set by the caller in the context of the onchain subsystems.