### PR TITLE
router: prevent rescan on startup

### DIFF
--- a/routing/chainview/btcd.go
+++ b/routing/chainview/btcd.go
@@ -366,12 +366,12 @@ func (b *BtcdFilteredChainView) chainFilterer() {
 					continue
 				}
 
-				// If no block was returned from the rescan,
-				// it means no maching transactions were found.
+				// If no block was returned from the rescan, it
+				// means no matching transactions were found.
 				if len(rescanned) != 1 {
-					log.Debugf("no matching block found "+
-						"for rescan of hash %v",
-						blockHash)
+					log.Tracef("rescan of block %v at "+
+						"height=%d yielded no "+
+						"transactions", blockHash, i)
 					continue
 				}
 				decoded, err := decodeJSONBlock(


### PR DESCRIPTION
This PR alters the behavior of the router's logic on startup, ensuring that the chain view is filtered using the router's latest prune height. Before, the chain was filtered using the `bestHeight` variable, which was uninitialized, benignly forcing a rescan from genesis. In tracking this down, we realized that we should actually be using the prune height, as this is representative of the channel view loaded from disk. The best height/hash are now only used during startup to determine if we are out of sync.

I've also updated the logging statement to be more helpful, and only print to trace 🙂