### PR TITLE
Many lines in the sample config were mission the section prefix. With…

### DIFF
--- a/sample-lnd.conf
+++ b/sample-lnd.conf
@@ -12,23 +12,23 @@ tlskeypath=~/.lnd/tls.key
 ; Disable macaroon authentication
 no-macaroons=false
 
-; Path to write the admin macaroon for lnd's RPC and REST services if it 
+; Path to write the admin macaroon for lnd's RPC and REST services if it
 ; doesn't exist
 adminmacaroonpath=~/.lnd/admin.macaroon
 
 ; Path to write the read-only macaroon for lnd's RPC and REST services if it
 ; doesn't exist
 readonlymacaroonpath=~/.lnd/readonly.macaroon
-                       
+
 ; Directory to log output.
 logdir=~/.lnd/logs
 
-; Add an interface/port to listen for connections 
+; Add an interface/port to listen for connections
 ; (default all interfaces port: 9735)
 listen=
 
 ; Add an ip to the list of local addresses we claim to listen on to peers
-;externalip=            
+;externalip=
 
 
 ; Logging level for all subsystems {trace, debug, info, warn, error, critical} --
@@ -57,7 +57,7 @@ maxpendingchannels=1
 ; The default number of confirmations a channel must have before it's considered
 ; open.
 defaultchanconfs=1
-                       
+
 ; If true, then automatic network bootstrapping will not be attempted.
 nobootstrap=false
 
@@ -68,104 +68,103 @@ noencryptwallet=false
 [Bitcoin]
 
 ; If the chain should be active or not.
-active=false
+bitcoin.active=false
 
 ; The directory to store the chains's data within.
-chaindir=
+bitcoin.chaindir=
 
 ; The daemon's rpc listening address. If a port is omitted, then the default port
 ; for the selected chain parameters will be used.
-rpchost=localhost
-              
+bitcoin.rpchost=localhost
+
 ; Username for RPC connections
-rpcuser= 
+bitcoin.rpcuser=
 
 ; Password for RPC connections
-rpcpass= 
+bitcoin.rpcpass=
 
 ; File containing the daemon's certificate file
-rpccert=~/.ltcd/rpc.cert
+bitcoin.rpccert=~/.ltcd/rpc.cert
 
 ; The raw bytes of the daemon's PEM-encoded certificate chain which will be used
 ; to authenticate the RPC connection.
-rawrpccert=   
+bitcoin.rawrpccert=
 
 ; Use the test network
-testnet=false
+bitcoin.testnet=false
 
 ; Use the simulation test network
-simnet=false
+bitcoin.simnet=false
 
 ; Use the regression test network
-regtest=false
+bitcoin.regtest=false
 
 
 [Litecoin]
 
 ; If the chain should be active or not.
-active=false
+litecoin.active=false
 
 ; The directory to store the chains's data within.
-;chaindir=
+;litecoin.chaindir=
 
 ; The daemon's rpc listening address. If a port is omitted, then the default port
 ; for the selected chain parameters will be used.
-rpchost=localhost
-              
+litecoin.rpchost=localhost
+
 ; Username for RPC connections
-;rpcuser= 
+;litecoin.rpcuser=
 
 ; Password for RPC connections
-;rpcpass= 
+;litecoin.rpcpass=
 
 ; File containing the daemon's certificate file
-rpccert=~/.ltcd/rpc.cert
+litecoin.rpccert=~/.ltcd/rpc.cert
 
 ; The raw bytes of the daemon's PEM-encoded certificate chain which will be used
 ; to authenticate the RPC connection.
-;rawrpccert=   
+;litecoin.rawrpccert=
 
 ; Use the test network
-testnet=false
+litecoin.testnet=false
 
 ; Use the simulation test network
-simnet=false
+litecoin.simnet=false
 
 ; Use the regression test network
-regtest=false
+litecoin.regtest=false
 
 
 [neutrino]
 
 ; If SPV mode should be active or not.
-active=false
+neutrino.active=false
 
 ; Add a peer to connect with at startup
-;addpeer=
+;neutrino.addpeer=
 
 ; Connect only to the specified peers at startup
-;connect=
+;neutrino.connect=
 
 ; Max number of inbound and outbound peers
-;maxpeers=
+;neutrino.maxpeers=
 
 ; How long to ban misbehaving peers.  Valid time units are {s, m, h}.  Minimum 1
 ; second
-;banduration=  
+;neutrino.banduration=
 
 ; Maximum allowed ban score before disconnecting and banning misbehaving peers.
-;banthreshold= 
+;neutrino.banthreshold=
 
 
 [autopilot]
 
 ; If the autopilot agent should be active or not.
-active=false
+autopilot.active=false
 
 ; The maximum number of channels that should be created
-maxchannels=5
+autopilot.maxchannels=5
 
 ; The percentage of total funds that should be committed to automatic channel
 ; establishment
-allocation=0.6
-             
+autopilot.allocation=0.6


### PR DESCRIPTION
… these prefixes absent, lnd will not start properly. This updates the config lines with the appropriate prefixes.