### PR TITLE
docker: add missing backslash to start-lnd.sh

### DIFF
--- a/docker/lnd/start-lnd.sh
+++ b/docker/lnd/start-lnd.sh
@@ -46,7 +46,7 @@ NETWORK=$(set_default "$NETWORK" "simnet")
 CHAIN=$(set_default "$CHAIN" "bitcoin")
 
 lnd \
-    --noencryptwallet
+    --noencryptwallet \
     --logdir="/data" \
     "--$CHAIN.rpccert"="/rpc/rpc.cert" \
     "--$CHAIN.active" \


### PR DESCRIPTION
Fixes: https://github.com/lightningnetwork/lnd/issues/420

A back slash was missing in the `start-lnd.sh` script.