### PR TITLE
lnwallet: fix infite loop inside coin select func

### DIFF
--- a/lnwallet/wallet.go
+++ b/lnwallet/wallet.go
@@ -1425,7 +1425,7 @@ func coinSelect(feeRatePerWeight uint64, amt btcutil.Amount,
 		// The difference between the selected amount and the amount
 		// requested will be used to pay fees, and generate a change
 		// output with the remaining.
-		overShootAmt := totalSat - amtNeeded
+		overShootAmt := totalSat - amt
 
 		// Based on the estimated size and fee rate, if the excess
 		// amount isn't enough to pay fees, then increase the requested


### PR DESCRIPTION
Fix wrong calculation of overshot amount which causes coin select
function to go into infinite loop. If overshoot amount is calculated
by subtraction of `totalSatoshis` and `amtNeeded` than on the second
iteration of loop amtNeeded already include `requiredFee` inside, which
causes continuation of coin selection.