### PR TITLE
Only consider channel active if added to switch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,10 +8,12 @@ install:
   - GLIDE_DOWNLOAD="https://github.com/Masterminds/glide/releases/download/$GLIDE_TAG/glide-$GLIDE_TAG-linux-amd64.tar.gz"
   - curl -L $GLIDE_DOWNLOAD | tar -xvz
   - export PATH=$PATH:$PWD/linux-amd64/
+  - BTCD_VERSION=$(cat glide.yaml | grep -A1 btcd | tail -n1 | awk '{ print $2}')
   - mkdir -p $GOPATH/src/github.com/roasbeef/
   - pushd $GOPATH/src/github.com/roasbeef/
   - git clone https://github.com/roasbeef/btcd
   - pushd btcd
+  - git checkout $BTCD_VERSION
   - glide install
   - go install . ./cmd/...
   - popd

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -1333,6 +1333,12 @@ func (r *rpcServer) ListChannels(ctx context.Context,
 			peerOnline = true
 		}
 
+		channelID := lnwire.NewChanIDFromOutPoint(&chanPoint)
+		var linkActive bool
+		if _, err := r.server.htlcSwitch.GetLink(channelID); err == nil {
+			linkActive = true
+		}
+
 		// As this is required for display purposes, we'll calculate
 		// the weight of the commitment transaction. We also add on the
 		// estimated weight of the witness to calculate the weight of
@@ -1344,7 +1350,7 @@ func (r *rpcServer) ListChannels(ctx context.Context,
 		commitWeight := commitBaseWeight + lnwallet.WitnessCommitmentTxWeight
 
 		channel := &lnrpc.ActiveChannel{
-			Active:                peerOnline,
+			Active:                peerOnline && linkActive,
 			RemotePubkey:          nodeID,
 			ChannelPoint:          chanPoint.String(),
 			ChanId:                chanID,


### PR DESCRIPTION
For a calls to ListChannels we now only set the
`ActiveChannel.Active=true` if the link is found by the
`htlcswitch`. This is done to be able to make it possible
to tell if a newly opened channel has been added to
the htlcswitch, such that we can synchronize on this
during tests before we attempt to close the channel.