### PR TITLE
docker: btcd requires Go 1.8 or newer and fails to build with 1.7

### DIFF
--- a/docker/btcd/Dockerfile
+++ b/docker/btcd/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.7
+FROM golang:1.8
 
 MAINTAINER Olaoluwa Osuntokun <laolu@lightning.network>
 


### PR DESCRIPTION
The btcd docker container fails to build with Golang 1.7 because this
version of Go is missing time.Until (used by the btcd server)