### PR TITLE
 multi: retain original copyright on files copied/modified from btcsuite

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (C) 2015-2016 The Lightning Network Developers
+Copyright (C) 2015-2017 The Lightning Network Developers
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/cmd/lncli/main.go
+++ b/cmd/lncli/main.go
@@ -1,3 +1,7 @@
+// Copyright (c) 2013-2017 The btcsuite developers
+// Copyright (c) 2015-2016 The Decred developers
+// Copyright (C) 2015-2017 The Lightning Network Developers
+
 package main
 
 import (

--- a/config.go
+++ b/config.go
@@ -1,3 +1,7 @@
+// Copyright (c) 2013-2017 The btcsuite developers
+// Copyright (c) 2015-2016 The Decred developers
+// Copyright (C) 2015-2017 The Lightning Network Developers
+
 package main
 
 import (

--- a/lnd.go
+++ b/lnd.go
@@ -1,3 +1,7 @@
+// Copyright (c) 2013-2017 The btcsuite developers
+// Copyright (c) 2015-2016 The Decred developers
+// Copyright (C) 2015-2017 The Lightning Network Developers
+
 package main
 
 import (

--- a/lnwire/message.go
+++ b/lnwire/message.go
@@ -1,6 +1,9 @@
-package lnwire
-
+// Copyright (c) 2013-2017 The btcsuite developers
+// Copyright (c) 2015-2016 The Decred developers
 // code derived from https://github .com/btcsuite/btcd/blob/master/wire/message.go
+// Copyright (C) 2015-2017 The Lightning Network Developers
+
+package lnwire
 
 import (
 	"bytes"

--- a/signal.go
+++ b/signal.go
@@ -1,6 +1,9 @@
-package main
-
+// Copyright (c) 2013-2017 The btcsuite developers
+// Copyright (c) 2015-2016 The Decred developers
 // Heavily inspired by https://github.com/btcsuite/btcd/blob/master/signal.go
+// Copyright (C) 2015-2017 The Lightning Network Developers
+
+package main
 
 import (
 	"os"

--- a/version.go
+++ b/version.go
@@ -1,6 +1,9 @@
-package main
-
+// Copyright (c) 2013-2017 The btcsuite developers
+// Copyright (c) 2015-2016 The Decred developers
 // Heavily inspired by https://github.com/btcsuite/btcd/blob/master/version.go
+// Copyright (C) 2015-2017 The Lightning Network Developers
+
+package main
 
 import (
 	"bytes"


### PR DESCRIPTION
Early in the lifetime of the project here were a few files we either
copied entirely, or used as the basis for code within lnd. Before this
PR, this was not recognized by retaining the original copyright. With
this commit, we remedy that by explicitly noting the copyright in the
relevant files.

Fixes #423.

cc: @davecgh @marcopeereboom