### PR TITLE
Validate channel constraints

### DIFF
--- a/breacharbiter_test.go
+++ b/breacharbiter_test.go
@@ -1268,8 +1268,8 @@ func createInitChannels(revocationWindow int) (*lnwallet.LightningChannel, *lnwa
 		ChannelConstraints: channeldb.ChannelConstraints{
 			DustLimit:        aliceDustLimit,
 			MaxPendingAmount: lnwire.MilliSatoshi(rand.Int63()),
-			ChanReserve:      btcutil.Amount(rand.Int63()),
-			MinHTLC:          lnwire.MilliSatoshi(rand.Int63()),
+			ChanReserve:      0,
+			MinHTLC:          0,
 			MaxAcceptedHtlcs: uint16(rand.Int31()),
 		},
 		CsvDelay:            uint16(csvTimeoutAlice),
@@ -1283,8 +1283,8 @@ func createInitChannels(revocationWindow int) (*lnwallet.LightningChannel, *lnwa
 		ChannelConstraints: channeldb.ChannelConstraints{
 			DustLimit:        bobDustLimit,
 			MaxPendingAmount: lnwire.MilliSatoshi(rand.Int63()),
-			ChanReserve:      btcutil.Amount(rand.Int63()),
-			MinHTLC:          lnwire.MilliSatoshi(rand.Int63()),
+			ChanReserve:      0,
+			MinHTLC:          0,
 			MaxAcceptedHtlcs: uint16(rand.Int31()),
 		},
 		CsvDelay:            uint16(csvTimeoutBob),

--- a/channeldb/channel.go
+++ b/channeldb/channel.go
@@ -109,7 +109,7 @@ const (
 )
 
 // ChannelConstraints represents a set of constraints meant to allow a node to
-// limit their exposure, enact flow control and ensure that all HTLC's are
+// limit their exposure, enact flow control and ensure that all HTLCs are
 // economically relevant This struct will be mirrored for both sides of the
 // channel, as each side will enforce various constraints that MUST be adhered
 // to for the life time of the channel. The parameters for each of these
@@ -121,27 +121,28 @@ type ChannelConstraints struct {
 	// as an actual output, but is instead burned to miner's fees.
 	DustLimit btcutil.Amount
 
-	// MaxPendingAmount is the maximum pending HTLC value that can be
-	// present within the channel at a particular time. This value is set
-	// by the initiator of the channel and must be upheld at all times.
-	MaxPendingAmount lnwire.MilliSatoshi
-
-	// ChanReserve is an absolute reservation on the channel for this
-	// particular node. This means that the current settled balance for
-	// this node CANNOT dip below the reservation amount. This acts as a
-	// defense against costless attacks when either side no longer has any
-	// skin in the game.
+	// ChanReserve is an absolute reservation on the channel for the
+	// owner of this set of constraints. This means that the current
+	// settled balance for this node CANNOT dip below the reservation
+	// amount. This acts as a defense against costless attacks when
+	// either side no longer has any skin in the game.
 	ChanReserve btcutil.Amount
 
-	// MinHTLC is the minimum HTLC accepted for a direction of the channel.
-	// If any HTLC's below this amount are offered, then the HTLC will be
-	// rejected. This, in tandem with the dust limit allows a node to
-	// regulate the smallest HTLC that it deems economically relevant.
+	// MaxPendingAmount is the maximum pending HTLC value that the
+	// owner of these constraints can offer the remote node at a
+	// particular time.
+	MaxPendingAmount lnwire.MilliSatoshi
+
+	// MinHTLC is the minimum HTLC value that the the owner of these
+	// constraints can offer the remote node. If any HTLCs below this
+	// amount are offered, then the HTLC will be rejected. This, in
+	// tandem with the dust limit allows a node to regulate the
+	// smallest HTLC that it deems economically relevant.
 	MinHTLC lnwire.MilliSatoshi
 
-	// MaxAcceptedHtlcs is the maximum amount of HTLC's that are to be
-	// accepted by the owner of this set of constraints. This allows each
-	// node to limit their over all exposure to HTLC's that may need to be
+	// MaxAcceptedHtlcs is the maximum number of HTLCs that the owner of
+	// this set of constraints can offer the remote node. This allows each
+	// node to limit their over all exposure to HTLCs that may need to be
 	// acted upon in the case of a unilateral channel closure or a contract
 	// breach.
 	MaxAcceptedHtlcs uint16

--- a/fundingmanager_test.go
+++ b/fundingmanager_test.go
@@ -278,6 +278,16 @@ func createTestFundingManager(t *testing.T, privKey *btcec.PrivateKey,
 		RequiredRemoteDelay: func(amt btcutil.Amount) uint16 {
 			return 4
 		},
+		RequiredRemoteChanReserve: func(chanAmt btcutil.Amount) btcutil.Amount {
+			return chanAmt / 100
+		},
+		RequiredRemoteMaxValue: func(chanAmt btcutil.Amount) lnwire.MilliSatoshi {
+			reserve := lnwire.NewMSatFromSatoshis(chanAmt / 100)
+			return lnwire.NewMSatFromSatoshis(chanAmt) - reserve
+		},
+		RequiredRemoteMaxHTLCs: func(chanAmt btcutil.Amount) uint16 {
+			return uint16(lnwallet.MaxHTLCNumber / 2)
+		},
 		ArbiterChan: arbiterChan,
 		WatchNewChannel: func(*channeldb.OpenChannel) error {
 			return nil

--- a/fundingmanager_test.go
+++ b/fundingmanager_test.go
@@ -154,13 +154,14 @@ func createTestWallet(cdb *channeldb.DB, netParams *chaincfg.Params,
 	estimator lnwallet.FeeEstimator) (*lnwallet.LightningWallet, error) {
 
 	wallet, err := lnwallet.NewLightningWallet(lnwallet.Config{
-		Database:         cdb,
-		Notifier:         notifier,
-		WalletController: wc,
-		Signer:           signer,
-		ChainIO:          bio,
-		FeeEstimator:     estimator,
-		NetParams:        *netParams,
+		Database:           cdb,
+		Notifier:           notifier,
+		WalletController:   wc,
+		Signer:             signer,
+		ChainIO:            bio,
+		FeeEstimator:       estimator,
+		NetParams:          *netParams,
+		DefaultConstraints: defaultChannelConstraints,
 	})
 	if err != nil {
 		return nil, err

--- a/htlcswitch/link.go
+++ b/htlcswitch/link.go
@@ -1264,8 +1264,9 @@ func (l *channelLink) Bandwidth() lnwire.MilliSatoshi {
 	// TODO(roasbeef): subtract reserve
 	channelBandwidth := l.channel.AvailableBalance()
 	overflowBandwidth := l.overflowQueue.TotalHtlcAmount()
+	reserve := lnwire.NewMSatFromSatoshis(l.channel.GetReserve())
 
-	return channelBandwidth - overflowBandwidth
+	return channelBandwidth - overflowBandwidth - reserve
 }
 
 // policyUpdate is a message sent to a channel link when an outside sub-system

--- a/htlcswitch/link.go
+++ b/htlcswitch/link.go
@@ -1261,12 +1261,21 @@ type getBandwidthCmd struct {
 //
 // NOTE: Part of the ChannelLink interface.
 func (l *channelLink) Bandwidth() lnwire.MilliSatoshi {
-	// TODO(roasbeef): subtract reserve
 	channelBandwidth := l.channel.AvailableBalance()
 	overflowBandwidth := l.overflowQueue.TotalHtlcAmount()
-	reserve := lnwire.NewMSatFromSatoshis(l.channel.GetReserve())
+	linkBandwidth := channelBandwidth - overflowBandwidth
+	reserve := lnwire.NewMSatFromSatoshis(l.channel.LocalChanReserve())
 
-	return channelBandwidth - overflowBandwidth - reserve
+	// If the channel reserve is greater than the total available
+	// balance of the link, just return 0.
+	if linkBandwidth < reserve {
+		return 0
+	}
+
+	// Else the amount that is available to flow through the link at
+	// this point is the available balance minus the reserve amount
+	// we are required to keep as collateral.
+	return linkBandwidth - reserve
 }
 
 // policyUpdate is a message sent to a channel link when an outside sub-system

--- a/htlcswitch/link_test.go
+++ b/htlcswitch/link_test.go
@@ -1405,8 +1405,8 @@ func (m *mockPeer) Disconnect(reason error) {
 
 var _ Peer = (*mockPeer)(nil)
 
-func newSingleLinkTestHarness(chanAmt btcutil.Amount) (ChannelLink,
-	*lnwallet.LightningChannel, chan time.Time, func(), error) {
+func newSingleLinkTestHarness(chanAmt, chanReserve btcutil.Amount) (
+	ChannelLink, *lnwallet.LightningChannel, chan time.Time, func(), error) {
 	globalEpoch := &chainntnfs.BlockEpochEvent{
 		Epochs: make(chan *chainntnfs.BlockEpoch),
 		Cancel: func() {
@@ -1415,7 +1415,8 @@ func newSingleLinkTestHarness(chanAmt btcutil.Amount) (ChannelLink,
 
 	chanID := lnwire.NewShortChanIDFromInt(4)
 	aliceChannel, bobChannel, fCleanUp, _, err := createTestChannel(
-		alicePrivKey, bobPrivKey, chanAmt, chanAmt, chanID,
+		alicePrivKey, bobPrivKey, chanAmt, chanAmt,
+		chanReserve, chanReserve, chanID,
 	)
 	if err != nil {
 		return nil, nil, nil, nil, err
@@ -1659,7 +1660,7 @@ func TestChannelLinkBandwidthConsistency(t *testing.T) {
 
 	// We'll start the test by creating a single instance of
 	const chanAmt = btcutil.SatoshiPerBitcoin * 5
-	link, bobChannel, tmr, cleanUp, err := newSingleLinkTestHarness(chanAmt)
+	link, bobChannel, tmr, cleanUp, err := newSingleLinkTestHarness(chanAmt, 0)
 	if err != nil {
 		t.Fatalf("unable to create link: %v", err)
 	}
@@ -1992,7 +1993,8 @@ func TestChannelLinkBandwidthConsistencyOverflow(t *testing.T) {
 	var mockBlob [lnwire.OnionPacketSize]byte
 
 	const chanAmt = btcutil.SatoshiPerBitcoin * 5
-	aliceLink, bobChannel, batchTick, cleanUp, err := newSingleLinkTestHarness(chanAmt)
+	aliceLink, bobChannel, batchTick, cleanUp, err :=
+		newSingleLinkTestHarness(chanAmt, 0)
 	if err != nil {
 		t.Fatalf("unable to create link: %v", err)
 	}
@@ -2189,6 +2191,134 @@ func TestChannelLinkBandwidthConsistencyOverflow(t *testing.T) {
 		t.Fatalf("wrong overflow queue length: expected %v, got %v", 0,
 			coreLink.overflowQueue.Length())
 	}
+}
+
+// TestChannelLinkBandwidthChanReserve checks that the bandwidth available
+// on the channel link reflects the channel reserve that must be kept
+// at all times.
+func TestChannelLinkBandwidthChanReserve(t *testing.T) {
+	t.Parallel()
+
+	// First start a link that has a balance greater than it's
+	// channel reserve.
+	const chanAmt = btcutil.SatoshiPerBitcoin * 5
+	const chanReserve = btcutil.SatoshiPerBitcoin * 1
+	aliceLink, bobChannel, batchTimer, cleanUp, err :=
+		newSingleLinkTestHarness(chanAmt, chanReserve)
+	if err != nil {
+		t.Fatalf("unable to create link: %v", err)
+	}
+	defer cleanUp()
+
+	var (
+		mockBlob               [lnwire.OnionPacketSize]byte
+		coreLink               = aliceLink.(*channelLink)
+		coreChan               = coreLink.channel
+		defaultCommitFee       = coreChan.StateSnapshot().CommitFee
+		aliceStartingBandwidth = aliceLink.Bandwidth()
+		aliceMsgs              = coreLink.cfg.Peer.(*mockPeer).sentMsgs
+	)
+
+	estimator := &lnwallet.StaticFeeEstimator{
+		FeeRate: 24,
+	}
+	feePerWeight, err := estimator.EstimateFeePerWeight(1)
+	if err != nil {
+		t.Fatalf("unable to query fee estimator: %v", err)
+	}
+	feePerKw := feePerWeight * 1000
+	htlcFee := lnwire.NewMSatFromSatoshis(
+		btcutil.Amount((int64(feePerKw) * lnwallet.HtlcWeight) / 1000),
+	)
+
+	// The starting bandwidth of the channel should be exactly the amount
+	// that we created the channel between her and Bob, minus the channel
+	// reserve.
+	expectedBandwidth := lnwire.NewMSatFromSatoshis(
+		chanAmt - defaultCommitFee - chanReserve)
+	assertLinkBandwidth(t, aliceLink, expectedBandwidth)
+
+	// Next, we'll create an HTLC worth 3 BTC, and send it into the link as
+	// a switch initiated payment.  The resulting bandwidth should
+	// now be decremented to reflect the new HTLC.
+	htlcAmt := lnwire.NewMSatFromSatoshis(3 * btcutil.SatoshiPerBitcoin)
+	invoice, htlc, err := generatePayment(htlcAmt, htlcAmt, 5, mockBlob)
+	if err != nil {
+		t.Fatalf("unable to create payment: %v", err)
+	}
+	addPkt := htlcPacket{
+		htlc: htlc,
+	}
+	aliceLink.HandleSwitchPacket(&addPkt)
+	time.Sleep(time.Millisecond * 100)
+	assertLinkBandwidth(t, aliceLink, aliceStartingBandwidth-htlcAmt-htlcFee)
+
+	// Alice should send the HTLC to Bob.
+	var msg lnwire.Message
+	select {
+	case msg = <-aliceMsgs:
+	case <-time.After(2 * time.Second):
+		t.Fatalf("did not receive message")
+	}
+
+	addHtlc, ok := msg.(*lnwire.UpdateAddHTLC)
+	if !ok {
+		t.Fatalf("expected UpdateAddHTLC, got %T", msg)
+	}
+
+	bobIndex, err := bobChannel.ReceiveHTLC(addHtlc)
+	if err != nil {
+		t.Fatalf("bob failed receiving htlc: %v", err)
+	}
+
+	// Lock in the HTLC.
+	if err := updateState(batchTimer, coreLink, bobChannel, true); err != nil {
+		t.Fatalf("unable to update state: %v", err)
+	}
+
+	assertLinkBandwidth(t, aliceLink, aliceStartingBandwidth-htlcAmt-htlcFee)
+
+	// If we now send in a valid HTLC settle for the prior HTLC we added,
+	// then the bandwidth should remain unchanged as the remote party will
+	// gain additional channel balance.
+	err = bobChannel.SettleHTLC(invoice.Terms.PaymentPreimage, bobIndex)
+	if err != nil {
+		t.Fatalf("unable to settle htlc: %v", err)
+	}
+	htlcSettle := &lnwire.UpdateFulfillHTLC{
+		ID:              bobIndex,
+		PaymentPreimage: invoice.Terms.PaymentPreimage,
+	}
+	aliceLink.HandleChannelUpdate(htlcSettle)
+	time.Sleep(time.Millisecond * 500)
+
+	// Since the settle is not locked in yet, Alice's bandwidth should still
+	// reflect that she has to pay the fee.
+	assertLinkBandwidth(t, aliceLink, aliceStartingBandwidth-htlcAmt-htlcFee)
+
+	// Lock in the settle.
+	if err := updateState(batchTimer, coreLink, bobChannel, false); err != nil {
+		t.Fatalf("unable to update state: %v", err)
+	}
+
+	time.Sleep(time.Millisecond * 100)
+	assertLinkBandwidth(t, aliceLink, aliceStartingBandwidth-htlcAmt)
+
+	// Now we create a channel that has a channel reserve that is
+	// greater than it's balance. In these case only payments can
+	// be received on this channel, not sent. The available bandwidth
+	// should therefore be 0.
+	const bobChanAmt = btcutil.SatoshiPerBitcoin * 1
+	const bobChanReserve = btcutil.SatoshiPerBitcoin * 1.5
+	bobLink, _, _, bobCleanUp, err := newSingleLinkTestHarness(bobChanAmt,
+		bobChanReserve)
+	if err != nil {
+		t.Fatalf("unable to create link: %v", err)
+	}
+	defer bobCleanUp()
+
+	// Make sure bandwidth is reported as 0.
+	assertLinkBandwidth(t, bobLink, 0)
 }
 
 // TestChannelRetransmission tests the ability of the channel links to

--- a/htlcswitch/test_utils.go
+++ b/htlcswitch/test_utils.go
@@ -97,10 +97,26 @@ func createTestChannel(alicePrivKey, bobPrivKey []byte,
 	bobKeyPriv, bobKeyPub := btcec.PrivKeyFromBytes(btcec.S256(), bobPrivKey)
 
 	channelCapacity := aliceAmount + bobAmount
-	aliceDustLimit := btcutil.Amount(200)
-	bobDustLimit := btcutil.Amount(800)
 	csvTimeoutAlice := uint32(5)
 	csvTimeoutBob := uint32(4)
+
+	aliceConstraints := &channeldb.ChannelConstraints{
+		DustLimit: btcutil.Amount(200),
+		MaxPendingAmount: lnwire.NewMSatFromSatoshis(
+			channelCapacity),
+		ChanReserve:      0,
+		MinHTLC:          0,
+		MaxAcceptedHtlcs: lnwallet.MaxHTLCNumber / 2,
+	}
+
+	bobConstraints := &channeldb.ChannelConstraints{
+		DustLimit: btcutil.Amount(800),
+		MaxPendingAmount: lnwire.NewMSatFromSatoshis(
+			channelCapacity),
+		ChanReserve:      0,
+		MinHTLC:          0,
+		MaxAcceptedHtlcs: lnwallet.MaxHTLCNumber / 2,
+	}
 
 	var hash [sha256.Size]byte
 	randomSeed, err := generateRandomBytes(sha256.Size)
@@ -116,9 +132,7 @@ func createTestChannel(alicePrivKey, bobPrivKey []byte,
 	fundingTxIn := wire.NewTxIn(prevOut, nil, nil)
 
 	aliceCfg := channeldb.ChannelConfig{
-		ChannelConstraints: channeldb.ChannelConstraints{
-			DustLimit: aliceDustLimit,
-		},
+		ChannelConstraints:  *aliceConstraints,
 		CsvDelay:            uint16(csvTimeoutAlice),
 		MultiSigKey:         aliceKeyPub,
 		RevocationBasePoint: aliceKeyPub,
@@ -127,9 +141,7 @@ func createTestChannel(alicePrivKey, bobPrivKey []byte,
 		HtlcBasePoint:       aliceKeyPub,
 	}
 	bobCfg := channeldb.ChannelConfig{
-		ChannelConstraints: channeldb.ChannelConstraints{
-			DustLimit: bobDustLimit,
-		},
+		ChannelConstraints:  *bobConstraints,
 		CsvDelay:            uint16(csvTimeoutBob),
 		MultiSigKey:         bobKeyPub,
 		RevocationBasePoint: bobKeyPub,

--- a/lnd.go
+++ b/lnd.go
@@ -388,6 +388,24 @@ func lndMain() error {
 			cid := lnwire.NewChanIDFromOutPoint(&chanPoint)
 			return server.htlcSwitch.UpdateShortChanID(cid, sid)
 		},
+		RequiredRemoteChanReserve: func(chanAmt btcutil.Amount) btcutil.Amount {
+			// By default, we'll require the remote peer to maintain
+			// at least 1% of the total channel capacity at all
+			// times.
+			return chanAmt / 100
+		},
+		RequiredRemoteMaxValue: func(chanAmt btcutil.Amount) lnwire.MilliSatoshi {
+			// By default, we'll allow the remote peer to fully
+			// utilize the full bandwidth of the channel, minus our
+			// required reserve.
+			reserve := lnwire.NewMSatFromSatoshis(chanAmt / 100)
+			return lnwire.NewMSatFromSatoshis(chanAmt) - reserve
+		},
+		RequiredRemoteMaxHTLCs: func(chanAmt btcutil.Amount) uint16 {
+			// By default, we'll permit them to utilize the full
+			// channel bandwidth.
+			return uint16(lnwallet.MaxHTLCNumber / 2)
+		},
 	})
 	if err != nil {
 		return err

--- a/lnd_test.go
+++ b/lnd_test.go
@@ -4103,7 +4103,8 @@ out:
 	// Alice's side, leaving on 10k satoshis of available balance for bob.
 	// There's a max payment amount, so we'll have to do this
 	// incrementally.
-	amtToSend := int64(chanAmt) - 20000
+	chanReserve := int64(chanAmt / 100)
+	amtToSend := int64(chanAmt) - chanReserve - 20000
 	amtSent := int64(0)
 	for amtSent != amtToSend {
 		// We'll send in chunks of the max payment amount. If we're
@@ -4642,8 +4643,10 @@ func testAsyncPayments(net *lntest.NetworkHarness, t *harnessTest) {
 		t.Fatalf("unable to get alice channel info: %v", err)
 	}
 
-	// Calculate the number of invoices.
-	numInvoices := int(info.LocalBalance / paymentAmt)
+	// Calculate the number of invoices. We will deplete the channel
+	// all the way down to the channel reserve.
+	chanReserve := info.LocalBalance / 100
+	numInvoices := int((info.LocalBalance - chanReserve) / paymentAmt)
 	bobAmt := int64(numInvoices * paymentAmt)
 	aliceAmt := info.LocalBalance - bobAmt
 

--- a/lnwallet/interface_test.go
+++ b/lnwallet/interface_test.go
@@ -296,7 +296,7 @@ func testDualFundingReservationWorkflow(miner *rpctest.Harness,
 	}
 	aliceChanReservation.SetNumConfsRequired(numReqConfs)
 	aliceChanReservation.CommitConstraints(csvDelay, lnwallet.MaxHTLCNumber/2,
-		lnwire.NewMSatFromSatoshis(fundingAmount), 10)
+		lnwire.NewMSatFromSatoshis(fundingAmount), 1, 10)
 
 	// The channel reservation should now be populated with a multi-sig key
 	// from our HD chain, a change output with 3 BTC, and 2 outputs
@@ -319,7 +319,7 @@ func testDualFundingReservationWorkflow(miner *rpctest.Harness,
 		t.Fatalf("bob unable to init channel reservation: %v", err)
 	}
 	bobChanReservation.CommitConstraints(csvDelay, lnwallet.MaxHTLCNumber/2,
-		lnwire.NewMSatFromSatoshis(fundingAmount), 10)
+		lnwire.NewMSatFromSatoshis(fundingAmount), 1, 10)
 	bobChanReservation.SetNumConfsRequired(numReqConfs)
 
 	assertContributionInitPopulated(t, bobChanReservation.OurContribution())
@@ -649,7 +649,7 @@ func testSingleFunderReservationWorkflow(miner *rpctest.Harness,
 	}
 	aliceChanReservation.SetNumConfsRequired(numReqConfs)
 	aliceChanReservation.CommitConstraints(csvDelay, lnwallet.MaxHTLCNumber/2,
-		lnwire.NewMSatFromSatoshis(fundingAmt), 10)
+		lnwire.NewMSatFromSatoshis(fundingAmt), 1, 10)
 
 	// Verify all contribution fields have been set properly.
 	aliceContribution := aliceChanReservation.OurContribution()
@@ -661,7 +661,6 @@ func testSingleFunderReservationWorkflow(miner *rpctest.Harness,
 		t.Fatalf("coin selection failed, should have one change outputs, "+
 			"instead have: %v", len(aliceContribution.ChangeOutputs))
 	}
-	aliceContribution.CsvDelay = csvDelay
 	assertContributionInitPopulated(t, aliceContribution)
 
 	// Next, Bob receives the initial request, generates a corresponding
@@ -673,12 +672,11 @@ func testSingleFunderReservationWorkflow(miner *rpctest.Harness,
 		t.Fatalf("unable to create bob reservation: %v", err)
 	}
 	bobChanReservation.CommitConstraints(csvDelay, lnwallet.MaxHTLCNumber/2,
-		lnwire.NewMSatFromSatoshis(fundingAmt), 10)
+		lnwire.NewMSatFromSatoshis(fundingAmt), 1, 10)
 	bobChanReservation.SetNumConfsRequired(numReqConfs)
 
 	// We'll ensure that Bob's contribution also gets generated properly.
 	bobContribution := bobChanReservation.OurContribution()
-	bobContribution.CsvDelay = csvDelay
 	assertContributionInitPopulated(t, bobContribution)
 
 	// With his contribution generated, he can now process Alice's


### PR DESCRIPTION
This PR is a continuation of #371, which fixes issue #298.

~~A few TODOs are left as comments in the code, and must be addressed before merge:~~

- [x] `channel.go:3371`: // TODO: do we need to consider htlc fees here?
- [x] `channel.go:3411`: // TODO: can we have != Add here?