### PR TITLE
lnwire: Support upfront shutdown script feature

### DIFF
--- a/lnwire/features.go
+++ b/lnwire/features.go
@@ -46,6 +46,11 @@ const (
 	// efficient network view reconciliation.
 	GossipQueriesOptional FeatureBit = 7
 
+	// UpfrontShutdownScript indicates that the node supports committing upfront
+	// to the shutdown script when opening channels.  This prevents a node that
+	// has been compromised from having all the channel funds stolen.
+	UpfrontShutdownScript FeatureBit = 4
+
 	// maxAllowedSize is a maximum allowed size of feature vector.
 	//
 	// NOTE: Within the protocol, the maximum allowed message size is 65535
@@ -72,6 +77,7 @@ var LocalFeatures = map[FeatureBit]string{
 	InitialRoutingSync:      "initial-routing-sync",
 	GossipQueriesRequired:   "gossip-queries-required",
 	GossipQueriesOptional:   "gossip-queries-optional",
+	UpfrontShutdownScript:   "option-upfront-shutdown-script",
 }
 
 // GlobalFeatures is a mapping of known global feature bits to a descriptive

--- a/lnwire/open_channel.go
+++ b/lnwire/open_channel.go
@@ -122,6 +122,11 @@ type OpenChannel struct {
 	// Currently, the least significant bit of this bit field indicates the
 	// initiator of the channel wishes to advertise this channel publicly.
 	ChannelFlags FundingFlag
+
+	// UpfrontShutdownAddress is the script to which the channel funds should
+	// be paid when mutually closing the channel.  This is to be enforced by
+	// the remote node even if this node is compromised later.
+	UpfrontShutdownAddress DeliveryAddress
 }
 
 // A compile time check to ensure OpenChannel implements the lnwire.Message
@@ -153,6 +158,7 @@ func (o *OpenChannel) Encode(w io.Writer, pver uint32) error {
 		o.HtlcPoint,
 		o.FirstCommitmentPoint,
 		o.ChannelFlags,
+		o.UpfrontShutdownAddress,
 	)
 }
 
@@ -181,6 +187,7 @@ func (o *OpenChannel) Decode(r io.Reader, pver uint32) error {
 		&o.HtlcPoint,
 		&o.FirstCommitmentPoint,
 		&o.ChannelFlags,
+		&o.UpfrontShutdownAddress,
 	)
 }
 
@@ -197,6 +204,13 @@ func (o *OpenChannel) MsgType() MessageType {
 //
 // This is part of the lnwire.Message interface.
 func (o *OpenChannel) MaxPayloadLength(uint32) uint32 {
+	var length uint32
+
 	// (32 * 2) + (8 * 6) + (4 * 1) + (2 * 2) + (33 * 6) + 1
-	return 319
+	length = 319 // base length
+
+	// Upfront shutdown script
+	length += 2 + deliveryAddressMaxSize
+
+	return length
 }

--- a/lnwire/shutdown.go
+++ b/lnwire/shutdown.go
@@ -22,6 +22,15 @@ type Shutdown struct {
 // p2wpkh.
 type DeliveryAddress []byte
 
+// deliveryAddressMaxSize is the maximum expected size in bytes of a
+// DeliveryAddress based on the types of scripts we know.
+// Following are the known scripts and their sizes in bytes.
+// - pay to witness script hash: 34
+// - pay to pubkey hash: 25
+// - pay to script hash: 22
+// - pay to witness pubkey hash: 22.
+const deliveryAddressMaxSize = 34
+
 // NewShutdown creates a new Shutdown message.
 func NewShutdown(cid ChannelID, addr DeliveryAddress) *Shutdown {
 	return &Shutdown{
@@ -71,11 +80,8 @@ func (s *Shutdown) MaxPayloadLength(pver uint32) uint32 {
 	// Len - 2 bytes
 	length += 2
 
-	// ScriptPubKey - 34 bytes for pay to witness script hash
-	length += 34
-
-	// NOTE: pay to pubkey hash is 25 bytes, pay to script hash is 22
-	// bytes, and pay to witness pubkey hash is 22 bytes in length.
+	// ScriptPubKey
+	length += deliveryAddressMaxSize
 
 	return length
 }


### PR DESCRIPTION
I noticed that this was part of the RFC, but not yet implemented here.