### PR TITLE
lnwallet/channel: handle error from sigpool start

### DIFF
--- a/lnwallet/channel.go
+++ b/lnwallet/channel.go
@@ -1353,7 +1353,7 @@ func NewLightningChannel(signer Signer, events chainntnfs.ChainNotifier,
 
 	// Finally, we'll kick of the signature job pool to handle any upcoming
 	// commitment state generation and validation.
-	if lc.sigPool.Start(); err != nil {
+	if err := lc.sigPool.Start(); err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
Properly handles the returned error from the channel sigpool's start method. The bug is currently benign, since `Start()` only ever returns nil.