### PR TITLE
channeldb: update channeldb to set and store SettleDate for invoices

### DIFF
--- a/channeldb/invoice_test.go
+++ b/channeldb/invoice_test.go
@@ -87,8 +87,9 @@ func TestInvoiceWorkflow(t *testing.T) {
 			spew.Sdump(fakeInvoice), spew.Sdump(dbInvoice))
 	}
 
-	// Settle the invoice, the versin retreived from the database should
-	// now have the settled bit toggle to true.
+	// Settle the invoice, the version retrieved from the database should
+	// now have the settled bit toggle to true and a non-default
+	// SettledDate
 	if err := db.SettleInvoice(paymentHash); err != nil {
 		t.Fatalf("unable to settle invoice: %v", err)
 	}
@@ -98,6 +99,10 @@ func TestInvoiceWorkflow(t *testing.T) {
 	}
 	if !dbInvoice2.Terms.Settled {
 		t.Fatalf("invoice should now be settled but isn't")
+	}
+
+	if dbInvoice2.SettleDate.IsZero() {
+		t.Fatalf("invoice should have non-zero SettledDate but isn't")
 	}
 
 	// Attempt to insert generated above again, this should fail as

--- a/lnd_test.go
+++ b/lnd_test.go
@@ -2262,10 +2262,14 @@ func testInvoiceSubscriptions(net *networkHarness, t *harnessTest) {
 		}
 
 		// The invoice update should exactly match the invoice created
-		// above, but should now be settled.
+		// above, but should now be settled and have SettleDate
 		if !invoiceUpdate.Settled {
 			t.Fatalf("invoice not settled but shoudl be")
 		}
+		if invoiceUpdate.SettleDate == 0 {
+			t.Fatalf("invoice should have non zero settle date, but doesn't")
+		}
+
 		if !bytes.Equal(invoiceUpdate.RPreimage, invoice.RPreimage) {
 			t.Fatalf("payment preimages don't match: expected %v, got %v",
 				invoice.RPreimage, invoiceUpdate.RPreimage)

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -2119,6 +2119,11 @@ func createRPCInvoice(invoice *channeldb.Invoice) (*lnrpc.Invoice, error) {
 		fallbackAddr = decoded.FallbackAddr.String()
 	}
 
+	settleDate := int64(0)
+	if !invoice.SettleDate.IsZero() {
+		settleDate = invoice.SettleDate.Unix()
+	}
+
 	// Expiry time will default to 3600 seconds if not specified
 	// explicitly.
 	expiry := int64(decoded.Expiry().Seconds())
@@ -2136,6 +2141,7 @@ func createRPCInvoice(invoice *channeldb.Invoice) (*lnrpc.Invoice, error) {
 		RPreimage:       preimage[:],
 		Value:           int64(satAmt),
 		CreationDate:    invoice.CreationDate.Unix(),
+		SettleDate:      settleDate,
 		Settled:         invoice.Terms.Settled,
 		PaymentRequest:  paymentRequest,
 		DescriptionHash: descHash,


### PR DESCRIPTION
This PR contains two commits that resolve a TODO from `channeldb/invoices.go`: https://github.com/lightningnetwork/lnd/compare/master...mlerner:ml/settle-date?expand=1#diff-9f84ce21f17bb10010b2d2b19cb17e3cL421

1) Add `SettleDate` to the channeldb representation of an invoice.
2) Update the rpcserver so that invoice related commands map the `SettleDate` stored in the database to the RPC representation of an invoice. 