### PR TITLE
docs: note on golang-1.8-go bin path

### DIFF
--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -14,6 +14,7 @@
     ```
     sudo apt-get install golang-1.8-go
     ```
+    > Note that golang-1.8-go puts binaries in /usr/lib/go-1.8/bin. If you want them on your PATH, you need to make that change yourself.
 
     On Mac OS X
     ```


### PR DESCRIPTION
This is a nit-pick, but the golang-1.8-go package puts binaries in `/usr/lib/go-1.8/bin` and I was a little bit confused about that. This PR adds a small note on the problem