### PR TITLE
multi: fix reliable re-processing+re-transmission of FundingLocked factoring in ChannelReestabilshment 

### DIFF
--- a/htlcswitch/interfaces.go
+++ b/htlcswitch/interfaces.go
@@ -85,6 +85,13 @@ type ChannelLink interface {
 	// the channel link opened.
 	Peer() Peer
 
+	// EligibleToForward returns a bool indicating if the channel is able
+	// to actively accept requests to forward HTLC's. A channel may be
+	// active, but not able to forward HTLC's if it hasn't yet finalized
+	// the pre-channel operation protocol with the remote peer. The switch
+	// will use this function in forwarding decisions accordingly.
+	EligibleToForward() bool
+
 	// Start/Stop are used to initiate the start/stop of the channel link
 	// functioning.
 	Start() error

--- a/htlcswitch/link.go
+++ b/htlcswitch/link.go
@@ -292,6 +292,14 @@ func (l *channelLink) Stop() {
 	l.cfg.BlockEpochs.Cancel()
 }
 
+// EligibleToForward returns a bool indicating if the channel is able to
+// actively accept requests to forward HTLC's. We're able to forward HTLC's if
+// we know the remote party's next revocation point. Otherwise, we can't
+// initiate new channel state.
+func (l *channelLink) EligibleToForward() bool {
+	return l.channel.RemoteNextRevocation() != nil
+}
+
 // sampleNetworkFee samples the current fee rate on the network to get into the
 // chain in a timely manner. The returned value is expressed in fee-per-kw, as
 // this is the native rate used when computing the fee for commitment

--- a/htlcswitch/link.go
+++ b/htlcswitch/link.go
@@ -405,10 +405,12 @@ func (l *channelLink) htlcManager() {
 			// this, as at this point we can't be sure if they've
 			// really received the FundingLocked message.
 			if remoteChanSyncMsg.NextLocalCommitHeight == 1 &&
-				localChanSyncMsg.NextLocalCommitHeight == 1 {
+				localChanSyncMsg.NextLocalCommitHeight == 1 &&
+				!l.channel.IsPending() {
 
-				log.Debugf("Resending fundingLocked message " +
-					"to peer")
+				log.Infof("ChannelPoint(%v): resending "+
+					"FundingLocked message to peer",
+					l.channel.ChannelPoint())
 
 				nextRevocation, err := l.channel.NextRevocationKey()
 				if err != nil {
@@ -453,7 +455,7 @@ out:
 	for {
 		select {
 		// A new block has arrived, we'll check the network fee to see
-		// if we should adjust our commitment fee , and also update our
+		// if we should adjust our commitment fee, and also update our
 		// track of the best current height.
 		case blockEpoch, ok := <-l.cfg.BlockEpochs.Epochs:
 			if !ok {

--- a/htlcswitch/mock.go
+++ b/htlcswitch/mock.go
@@ -430,6 +430,7 @@ func (f *mockChannelLink) Bandwidth() lnwire.MilliSatoshi     { return 99999999 
 func (f *mockChannelLink) Peer() Peer                         { return f.peer }
 func (f *mockChannelLink) Start() error                       { return nil }
 func (f *mockChannelLink) Stop()                              {}
+func (f *mockChannelLink) EligibleToForward() bool            { return true }
 
 var _ ChannelLink = (*mockChannelLink)(nil)
 

--- a/htlcswitch/switch.go
+++ b/htlcswitch/switch.go
@@ -366,7 +366,9 @@ func (s *Switch) handleLocalDispatch(payment *pendingPayment, packet *htlcPacket
 		)
 		for _, link := range links {
 			bandwidth := link.Bandwidth()
-			if bandwidth > largestBandwidth {
+			if link.EligibleToForward() &&
+				bandwidth > largestBandwidth {
+
 				largestBandwidth = bandwidth
 			}
 
@@ -488,7 +490,9 @@ func (s *Switch) handlePacketForward(packet *htlcPacket) error {
 		// bandwidth.
 		var destination ChannelLink
 		for _, link := range interfaceLinks {
-			if link.Bandwidth() >= htlc.Amount {
+			if link.EligibleToForward() &&
+				link.Bandwidth() >= htlc.Amount {
+
 				destination = link
 				break
 			}

--- a/lnwallet/channel.go
+++ b/lnwallet/channel.go
@@ -5115,3 +5115,12 @@ func (lc *LightningChannel) CommitFeeRate() btcutil.Amount {
 
 	return lc.channelState.LocalCommitment.FeePerKw
 }
+
+// IsPending returns true if the channel's funding transaction has been fully
+// confirmed, and false otherwise.
+func (lc *LightningChannel) IsPending() bool {
+	lc.RLock()
+	defer lc.RUnlock()
+
+	return lc.channelState.IsPending
+}

--- a/peer.go
+++ b/peer.go
@@ -308,17 +308,6 @@ func (p *peer) loadActiveChannels(chans []*channeldb.OpenChannel) error {
 
 		chanPoint := &dbChan.FundingOutpoint
 
-		// If the channel we read form disk has a nil next revocation
-		// key, then we'll skip loading this channel. We must do this
-		// as it doesn't yet have the needed items required to initiate
-		// a local state transition, or one triggered by forwarding an
-		// HTLC.
-		if lnChan.RemoteNextRevocation() == nil {
-			peerLog.Debugf("Skipping ChannelPoint(%v), lacking "+
-				"next commit point", chanPoint)
-			continue
-		}
-
 		chanID := lnwire.NewChanIDFromOutPoint(chanPoint)
 
 		p.activeChanMtx.Lock()

--- a/peer.go
+++ b/peer.go
@@ -922,6 +922,8 @@ func (p *peer) logWireMessage(msg lnwire.Message, read bool) {
 	}))
 
 	switch m := msg.(type) {
+	case *lnwire.ChannelReestablish:
+		m.LocalUnrevokedCommitPoint.Curve = nil
 	case *lnwire.RevokeAndAck:
 		m.NextRevocationKey.Curve = nil
 	case *lnwire.NodeAnnouncement:

--- a/peer.go
+++ b/peer.go
@@ -294,12 +294,6 @@ func (p *peer) Start() error {
 // channels returned by the database.
 func (p *peer) loadActiveChannels(chans []*channeldb.OpenChannel) error {
 	for _, dbChan := range chans {
-		// If the channel isn't yet open, then we don't need to process
-		// it any further.
-		if dbChan.IsPending {
-			continue
-		}
-
 		lnChan, err := lnwallet.NewLightningChannel(p.server.cc.signer,
 			p.server.cc.chainNotifier, p.server.cc.feeEstimator, dbChan)
 		if err != nil {

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -1465,8 +1465,11 @@ func (r *rpcServer) ListChannels(ctx context.Context,
 
 		channelID := lnwire.NewChanIDFromOutPoint(&chanPoint)
 		var linkActive bool
-		if _, err := r.server.htlcSwitch.GetLink(channelID); err == nil {
-			linkActive = true
+		if link, err := r.server.htlcSwitch.GetLink(channelID); err == nil {
+			// A channel is only considered active if it is known
+			// by the switch *and* able to forward
+			// incoming/outgoing payments.
+			linkActive = link.EligibleToForward()
 		}
 
 		// As this is required for display purposes, we'll calculate


### PR DESCRIPTION
This PR set out to remedy the issues that many users have reported surrounding their channels not being shown as "active" after the funding process has completed. 

## Existing Issue
The original logic surrounding process retransmitted `FundingLocked` message and also re-sending the message was written without mind for the requirements around re-sending the `ChannelReestablishment` message upon reconnect. This was drawn to my attention after realizing I had a flapping connection to a `c-lightning` node. The funding flow with the node didn't complete before I shutdown my local node. As a result, both nodes needed to retransmit the `FundingLocked` as we hadn't done any channel updates yet. However, my local `lnd` node was unable to do so for the following reasons:
  
   * Before this PR, [we wouldn't add a channel to the link if we hadn't processed the `FundingLocked` message](https://github.com/lightningnetwork/lnd/blob/ccd1dad71e776b304020049184212419719c8265/peer.go#L311).
   * This means that we wouldn't re-send the `ChannelReestablishment` message, nor the `FundingLocked` message upon reconnection. [This is due to the fact that we only re-send if the channel was added to the link](https://github.com/lightningnetwork/lnd/blob/ccd1dad71e776b304020049184212419719c8265/htlcswitch/link.go#L394). 
    * Since we didn't add the channel to the link, the other peer wouldn't re-send the `FundingLocked` message as the spec dictates to only do so _after_ both sides have sent and received the `ChannelReestablishment` message. 
    * The above series of actions would result in neither peer re-sending or re-processing the `FundingLocked` message. 

## Fix For Issue

In order to fix this, the following changes have been made:
   * We now _always_ add an open channel to the link upon reconnection with an existing channel peer.
   * A new method `EligibleToForward` has been added to the `ChannelLink` interface. This should return true, iff, the link is fully able to cary and forward any incoming HTLC's. The current default implementation of this only returns true if we have already processed the `FundingLocked` message.
   * `ListChannels` now only marks a channel as "active", iff, it has fully processed the `FundingLocked` message.
   *  In order to handle processing a retransmitted `FundingLocked` message for this first time, the `channelManager` will now detect if the newly sent channel (by the `fundingManager`) is more "up to date". The channel is more up-to-date if the old channel didn't have the remote next revocation set. If it's newer, then it'll re-send to the `breachArbiter` (to ensure it has the latest channel) and then update the revocation point in-place. After this is update, the `EligibleToForward` will now return `true` within the switch. 