### PR TITLE
cmd/lncli+lnd: Add alias and color customization

### DIFF
--- a/config.go
+++ b/config.go
@@ -55,6 +55,9 @@ const (
 	defaultLitecoinBaseFeeMSat   = 1000
 	defaultLitecoinFeeRate       = 1
 	defaultLitecoinTimeLockDelta = 576
+
+	defaultAlias = ""
+	defaultColor = "#3399FF"
 )
 
 var (
@@ -172,6 +175,9 @@ type config struct {
 	NoEncryptWallet bool `long:"noencryptwallet" description:"If set, wallet will be encrypted using the default passphrase."`
 
 	TrickleDelay int `long:"trickledelay" description:"Time in milliseconds between each release of announcements to the network"`
+
+	Alias string `long:"alias" description:"The node alias. Used as a moniker by peers and intelligence services"`
+	Color string `long:"color" description:"The color of the node in hex format (i.e. '#3399FF'). Used to customize node appearance in intelligence services"`
 }
 
 // loadConfig initializes and parses the config using a config file and command
@@ -227,6 +233,8 @@ func loadConfig() (*config, error) {
 			Allocation:  0.6,
 		},
 		TrickleDelay: defaultTrickleDelay,
+		Alias:        defaultAlias,
+		Color:        defaultColor,
 	}
 
 	// Pre-parse the command line options to pick up an alternative config

--- a/lnwire/node_announcement.go
+++ b/lnwire/node_announcement.go
@@ -40,7 +40,8 @@ func NewNodeAlias(s string) (NodeAlias, error) {
 
 // String returns a utf8 string representation of the alias bytes.
 func (n NodeAlias) String() string {
-	return string(n[:])
+	// Trim trailing zero-bytes for presentation
+	return string(bytes.Trim(n[:], "\x00"))
 }
 
 // NodeAnnouncement message is used to announce the presence of a Lightning

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -1141,6 +1141,7 @@ func (r *rpcServer) GetInfo(ctx context.Context,
 		Testnet:            activeNetParams.Params == &chaincfg.TestNet3Params,
 		Chains:             activeChains,
 		Uris:               uris,
+		Alias:              nodeAnn.Alias.String(),
 	}, nil
 }
 

--- a/server.go
+++ b/server.go
@@ -220,14 +220,19 @@ func newServer(listenAddrs []string, chanDB *channeldb.DB, cc *chainControl,
 
 	chanGraph := chanDB.ChannelGraph()
 
-	defaultColor := color.RGBA{ // #3399FF
-		R: 51,
-		G: 153,
-		B: 255,
+	// Parse node color from configuration.
+	color, err := parseHexColor(cfg.Color)
+	if err != nil {
+		srvrLog.Errorf("unable to parse color: %v\n", err)
+		return nil, err
 	}
 
-	// TODO(roasbeef): make alias configurable
-	alias, err := lnwire.NewNodeAlias(hex.EncodeToString(serializedPubKey[:10]))
+	// If no alias is provided, default to first 10 characters of public key
+	alias := cfg.Alias
+	if alias == "" {
+		alias = hex.EncodeToString(serializedPubKey[:10])
+	}
+	nodeAlias, err := lnwire.NewNodeAlias(alias)
 	if err != nil {
 		return nil, err
 	}
@@ -236,9 +241,9 @@ func newServer(listenAddrs []string, chanDB *channeldb.DB, cc *chainControl,
 		LastUpdate:           time.Now(),
 		Addresses:            selfAddrs,
 		PubKey:               privKey.PubKey(),
-		Alias:                alias.String(),
+		Alias:                nodeAlias.String(),
 		Features:             s.globalFeatures,
-		Color:                defaultColor,
+		Color:                color,
 	}
 
 	// If our information has changed since our last boot, then we'll
@@ -250,9 +255,9 @@ func newServer(listenAddrs []string, chanDB *channeldb.DB, cc *chainControl,
 		Timestamp: uint32(selfNode.LastUpdate.Unix()),
 		Addresses: selfNode.Addresses,
 		NodeID:    selfNode.PubKey,
-		Alias:     alias,
+		Alias:     nodeAlias,
 		Features:  selfNode.Features.RawFeatureVector,
-		RGBColor:  defaultColor,
+		RGBColor:  color,
 	}
 	selfNode.AuthSig, err = discovery.SignAnnouncement(s.nodeSigner,
 		s.identityPriv.PubKey(), nodeAnn,
@@ -1702,4 +1707,22 @@ func (s *server) Peers() []*peer {
 	}
 
 	return peers
+}
+
+// parseHexColor takes a hex string representation of a color in the
+// form "#RRGGBB", parses the hex color values, and returns a color.RGBA
+// struct of the same color.
+func parseHexColor(colorStr string) (color.RGBA, error) {
+	if len(colorStr) != 7 || colorStr[0] != '#' {
+		return color.RGBA{}, errors.New("Color must be in format #RRGGBB")
+	}
+
+	// Decode the hex color string to bytes.
+	// The resulting byte array is in the form [R, G, B].
+	colorBytes, err := hex.DecodeString(colorStr[1:])
+	if err != nil {
+		return color.RGBA{}, err
+	}
+
+	return color.RGBA{R: colorBytes[0], G: colorBytes[1], B: colorBytes[2]}, nil
 }

--- a/server_test.go
+++ b/server_test.go
@@ -1,0 +1,34 @@
+package main
+
+import "testing"
+
+func TestParseHexColor(t *testing.T) {
+	empty := ""
+	color, err := parseHexColor(empty)
+	if err == nil {
+		t.Fatalf("Empty color string should return error, but did not")
+	}
+
+	tooLong := "#1234567"
+	color, err = parseHexColor(tooLong)
+	if err == nil {
+		t.Fatalf("Invalid color string %s should return error, but did not",
+			tooLong)
+	}
+
+	invalidFormat := "$123456"
+	color, err = parseHexColor(invalidFormat)
+	if err == nil {
+		t.Fatalf("Invalid color string %s should return error, but did not",
+			invalidFormat)
+	}
+
+	valid := "#C0FfeE"
+	color, err = parseHexColor(valid)
+	if err != nil {
+		t.Fatalf("Color %s valid to parse: %s", valid, err)
+	}
+	if color.R != 0xc0 || color.G != 0xff || color.B != 0xee {
+		t.Fatalf("Color %s incorrectly parsed as %v", valid, color)
+	}
+}


### PR DESCRIPTION
* This commit allows the node's 'alias' and 'color' to be configured.
* This implements the `SetAlias` command on the rpcserver and
in `lncli`.
* Adds node alias info to the output of the `getinfo` command
* ~~~Adds the '[lucasb-eyer/go-colorful](https://github.com/lucasb-eyer/go-colorful)' dependency for hex color code parsing.~~~
* Addresses #273; related to previous work of #342.

This is my first PR (substantive) to `lnd`; feedback welcomed 😄