### PR TITLE
htlcswitch/link: Only send update_fee message when channel is eligable

### DIFF
--- a/htlcswitch/link.go
+++ b/htlcswitch/link.go
@@ -1140,6 +1140,14 @@ func (l *channelLink) updateChannelFee(feePerKw btcutil.Amount) error {
 		return err
 	}
 
+	// We skip sending the update_fee message if the channel is not currently
+	// eligable to forward messages
+	if !l.EligibleToForward() {
+		log.Infof("ChannelPoint(%v): skipping transmission of update_fee. " +
+			"channel is not eligable for forwarding messages")
+		return nil
+	}
+
 	// We'll then attempt to send a new UpdateFee message, and also lock it
 	// in immediately by triggering a commitment update.
 	msg := lnwire.NewUpdateFee(l.ChanID(), uint32(feePerKw))


### PR DESCRIPTION
Addresses #470.

Per [BOLT-2](https://github.com/lightningnetwork/lightning-rfc/blob/master/02-peer-protocol.md#updating-fees-update_fee), there seemingly aren't any issues with skipping transmission of `update_fee` in this case. Upon receipt of the next block the channel will retry to update its fee (if appropriate)