### PR TITLE
Expose sync height to gRPC interface

### DIFF
--- a/fundingmanager.go
+++ b/fundingmanager.go
@@ -789,7 +789,7 @@ func (f *fundingManager) handleFundingOpen(fmsg *fundingOpenMsg) {
 	// We'll also reject any requests to create channels until we're fully
 	// synced to the network as we won't be able to properly validate the
 	// confirmation of the funding transaction.
-	isSynced, err := f.cfg.Wallet.IsSynced()
+	isSynced, _, err := f.cfg.Wallet.IsSynced()
 	if err != nil {
 		fndgLog.Errorf("unable to query wallet: %v", err)
 		return

--- a/lnd.go
+++ b/lnd.go
@@ -430,7 +430,7 @@ func lndMain() error {
 			"start_height=%v", bestHeight)
 
 		for {
-			synced, err := activeChainControl.wallet.IsSynced()
+			synced, _, err := activeChainControl.wallet.IsSynced()
 			if err != nil {
 				return err
 			}

--- a/lnrpc/rpc.pb.go
+++ b/lnrpc/rpc.pb.go
@@ -1159,6 +1159,8 @@ type GetInfoResponse struct {
 	Chains []string `protobuf:"bytes,11,rep,name=chains" json:"chains,omitempty"`
 	// / The URIs of the current node.
 	Uris []string `protobuf:"bytes,12,rep,name=uris" json:"uris,omitempty"`
+	// / Timestamp of the best block known to the wallet
+	BestHeaderTimestamp int64 `protobuf:"varint,12,opt,name=best_header_timestamp" json:"best_header_timestamp,omitempty"`
 }
 
 func (m *GetInfoResponse) Reset()                    { *m = GetInfoResponse{} }
@@ -1241,6 +1243,13 @@ func (m *GetInfoResponse) GetUris() []string {
 		return m.Uris
 	}
 	return nil
+}
+
+func (m *GetInfoResponse) GetBestHeaderTimestamp() int64 {
+	if m != nil {
+		return m.BestHeaderTimestamp
+	}
+	return 0
 }
 
 type ConfirmationUpdate struct {

--- a/lnrpc/rpc.proto
+++ b/lnrpc/rpc.proto
@@ -803,6 +803,9 @@ message GetInfoResponse {
 
     /// The URIs of the current node.
     repeated string uris = 12 [json_name = "uris"];
+
+		/// Timestamp of the block best known to the wallet
+    int64 best_header_timestamp = 12 [ json_name = "best_header_timestamp" ];
 }
 
 message ConfirmationUpdate {

--- a/lnrpc/rpc.swagger.json
+++ b/lnrpc/rpc.swagger.json
@@ -1224,7 +1224,12 @@
             "type": "string"
           },
           "description": "/ The URIs of the current node."
-        }
+        },
+        "best_header_timestamp": {
+          "type": "integer",
+          "format": "int64",
+          "title": "/ Timestamp of the best block known to the wallet"
+        },
       }
     },
     "lnrpcGraphTopologyUpdate": {

--- a/lnwallet/interface.go
+++ b/lnwallet/interface.go
@@ -198,7 +198,9 @@ type WalletController interface {
 
 	// IsSynced returns a boolean indicating if from the PoV of the wallet,
 	// it has fully synced to the current best block in the main chain.
-	IsSynced() (bool, error)
+	// It also returns an int64 indicating the timestamp of the best block
+	// known to the wallet, expressed in Unix epoch time
+	IsSynced() (bool, int64, error)
 
 	// Start initializes the wallet, making any necessary connections,
 	// starting up required goroutines etc.

--- a/lnwallet/interface_test.go
+++ b/lnwallet/interface_test.go
@@ -1410,7 +1410,7 @@ func waitForWalletSync(w *lnwallet.LightningWallet) error {
 	var err error
 	timeout := time.After(10 * time.Second)
 	for !synced {
-		synced, err = w.IsSynced()
+		synced, _, err = w.IsSynced()
 		if err != nil {
 			return err
 		}

--- a/mock.go
+++ b/mock.go
@@ -253,8 +253,8 @@ func (m *mockWalletController) PublishTransaction(tx *wire.MsgTx) error {
 func (*mockWalletController) SubscribeTransactions() (lnwallet.TransactionSubscription, error) {
 	return nil, nil
 }
-func (*mockWalletController) IsSynced() (bool, error) {
-	return true, nil
+func (*mockWalletController) IsSynced() (bool, int64, error) {
+	return true, int64(0), nil
 }
 func (*mockWalletController) Start() error {
 	return nil

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -700,7 +700,7 @@ func (r *rpcServer) OpenChannelSync(ctx context.Context,
 
 	// Creation of channels before the wallet syncs up is currently
 	// disallowed.
-	isSynced, err := r.server.cc.wallet.IsSynced()
+	isSynced, _, err := r.server.cc.wallet.IsSynced()
 	if err != nil {
 		return nil, err
 	}
@@ -1105,7 +1105,7 @@ func (r *rpcServer) GetInfo(ctx context.Context,
 		return nil, fmt.Errorf("unable to get best block info: %v", err)
 	}
 
-	isSynced, err := r.server.cc.wallet.IsSynced()
+	isSynced, bestHeaderTimestamp, err := r.server.cc.wallet.IsSynced()
 	if err != nil {
 		return nil, fmt.Errorf("unable to sync PoV of the wallet "+
 			"with current best block in the main chain: %v", err)
@@ -1141,6 +1141,7 @@ func (r *rpcServer) GetInfo(ctx context.Context,
 		Testnet:            activeNetParams.Params == &chaincfg.TestNet3Params,
 		Chains:             activeChains,
 		Uris:               uris,
+		BestHeaderTimestamp: int64(bestHeaderTimestamp),
 	}, nil
 }
 


### PR DESCRIPTION
This commit adds `sync_height` to the gRPC interface in order that
clients calculate progress while `lnd` syncs to the blockchain.

`sync_height` is exposed via the `GetInfo()` rpc call. Additionally,
`IsSynced()` returns the syncHeight as the second value in the tuple
that is returned, providing additional detail when querying about the
status of the sync. The `BtcWallet` interface has also been updated
accordingly.

This commit was created to support the issue to [Add progress bar for chain sync] (https://github.com/lightninglabs/lightning-app/issues/10) in lightning-app