### PR TITLE
Use remoteACKed index when calculating availableBalance.

### DIFF
--- a/htlcswitch/link.go
+++ b/htlcswitch/link.go
@@ -83,6 +83,34 @@ func ExpectedFee(f ForwardingPolicy, htlcAmt lnwire.MilliSatoshi) lnwire.MilliSa
 	return f.BaseFee + (htlcAmt*f.FeeRate)/1000000
 }
 
+// Ticker is an interface used to wrap a time.Ticker in a struct,
+// making mocking it easier.
+type Ticker interface {
+	Start() <-chan time.Time
+	Stop()
+}
+
+// BatchTicker implements the Ticker interface, and wraps a time.Ticker.
+type BatchTicker struct {
+	ticker *time.Ticker
+}
+
+// NewBatchTicker returns a new BatchTicker that wraps the passed
+// time.Ticker.
+func NewBatchTicker(t *time.Ticker) *BatchTicker {
+	return &BatchTicker{t}
+}
+
+// Start returns the tick channel for the underlying time.Ticker.
+func (t *BatchTicker) Start() <-chan time.Time {
+	return t.ticker.C
+}
+
+// Stop stops the underlying time.Ticker.
+func (t *BatchTicker) Stop() {
+	t.ticker.Stop()
+}
+
 // ChannelLinkConfig defines the configuration for the channel link. ALL
 // elements within the configuration MUST be non-nil for channel link to carry
 // out its duties.
@@ -167,6 +195,17 @@ type ChannelLinkConfig struct {
 	// reestablishment message to the remote peer. It should be done if our
 	// clients have been restarted, or remote peer have been reconnected.
 	SyncStates bool
+
+	// BatchTicker is the ticker that determines the interval that we'll
+	// use to check the batch to see if there're any updates we should
+	// flush out. By batching updates into a single commit, we attempt
+	// to increase throughput by maximizing the number of updates
+	// coalesced into a single commit.
+	BatchTicker Ticker
+
+	// BatchSize is the max size of a batch of updates done to the link
+	// before we do a state update.
+	BatchSize uint32
 }
 
 // channelLink is the service which drives a channel's commitment update
@@ -588,8 +627,8 @@ func (l *channelLink) htlcManager() {
 		}
 	}
 
-	batchTimer := time.NewTicker(50 * time.Millisecond)
-	defer batchTimer.Stop()
+	batchTick := l.cfg.BatchTicker.Start()
+	defer l.cfg.BatchTicker.Stop()
 
 	// TODO(roasbeef): fail chan in case of protocol violation
 out:
@@ -667,7 +706,7 @@ out:
 				break out
 			}
 
-		case <-batchTimer.C:
+		case <-batchTick:
 			// If the current batch is empty, then we have no work
 			// here.
 			if l.batchCounter == 0 {
@@ -899,7 +938,7 @@ func (l *channelLink) handleDownStreamPkt(pkt *htlcPacket, isReProcess bool) {
 
 	// If this newly added update exceeds the min batch size for adds, or
 	// this is a settle request, then initiate an update.
-	if l.batchCounter >= 10 || isSettle {
+	if l.batchCounter >= l.cfg.BatchSize || isSettle {
 		if err := l.updateCommitTx(); err != nil {
 			l.fail("unable to update commitment: %v", err)
 			return

--- a/htlcswitch/mock.go
+++ b/htlcswitch/mock.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"sync"
 	"testing"
+	"time"
 
 	"io"
 	"sync/atomic"
@@ -616,4 +617,15 @@ func (m *mockNotifier) RegisterSpendNtfn(outpoint *wire.OutPoint) (*chainntnfs.S
 	return &chainntnfs.SpendEvent{
 		Spend: make(chan *chainntnfs.SpendDetail),
 	}, nil
+}
+
+type mockTicker struct {
+	ticker <-chan time.Time
+}
+
+func (m *mockTicker) Start() <-chan time.Time {
+	return m.ticker
+}
+
+func (m *mockTicker) Stop() {
 }

--- a/lnwallet/channel.go
+++ b/lnwallet/channel.go
@@ -4948,7 +4948,8 @@ func (lc *LightningChannel) availableBalance() (lnwire.MilliSatoshi, int64) {
 
 	// Next we'll grab the current set of log updates that are still active
 	// and haven't been garbage collected.
-	htlcView := lc.fetchHTLCView(lc.remoteUpdateLog.logIndex,
+	remoteACKedIndex := lc.localCommitChain.tip().theirMessageIndex
+	htlcView := lc.fetchHTLCView(remoteACKedIndex,
 		lc.localUpdateLog.logIndex)
 	feePerKw := lc.channelState.LocalCommitment.FeePerKw
 	dustLimit := lc.channelState.LocalChanCfg.DustLimit

--- a/lnwallet/sigpool.go
+++ b/lnwallet/sigpool.go
@@ -259,6 +259,8 @@ func (s *sigPool) SubmitSignBatch(signJobs []signJob) {
 		case s.signJobs <- job:
 		case <-job.cancel:
 			// TODO(roasbeef): return error?
+		case <-s.quit:
+			return
 		}
 	}
 }

--- a/peer.go
+++ b/peer.go
@@ -397,6 +397,9 @@ func (p *peer) loadActiveChannels(chans []*channeldb.OpenChannel) error {
 				)
 			},
 			SyncStates: true,
+			BatchTicker: htlcswitch.NewBatchTicker(
+				time.NewTicker(50 * time.Millisecond)),
+			BatchSize: 10,
 		}
 		link := htlcswitch.NewChannelLink(linkCfg, lnChan,
 			uint32(currentHeight))
@@ -1289,6 +1292,9 @@ out:
 					)
 				},
 				SyncStates: false,
+				BatchTicker: htlcswitch.NewBatchTicker(
+					time.NewTicker(50 * time.Millisecond)),
+				BatchSize: 10,
 			}
 			link := htlcswitch.NewChannelLink(linkConfig, newChan,
 				uint32(currentHeight))


### PR DESCRIPTION
This PR fixes a bug that could happen in some cases where we received updates from the remote peer increasing our balance.

The reason for this is that the previous version of `availableBalance` used the remote node's `logIndex` when calculating the balance currently available to us for new HTLCs. If the remote has sent us an update that _increases_ our balance, we think we have more balance available. The problem is that when the remote receives our new HTLC, it cannot know for sure if we have received the update increasing our balance, as we haven't ACKed it yet. We should therefore assume that the remote will reject the HTLC we are adding, since we don't have the balance available.

The proposed fix for this is to use the `ackedIndex` in `availableBalance` instead.

A test that makes the previous version of `availableBalance` return a balance that leads us to think that we can add a new HTLC (while in reality it should be rejected) is added.

The `channelLink` tests are updated to reflect that remote updates now have to be ACKed before they alter our balance.
  