### PR TITLE
lnd_test: invoice subscription cancel lingering goroutine

### DIFF
--- a/lnd_test.go
+++ b/lnd_test.go
@@ -2254,9 +2254,17 @@ func testInvoiceSubscriptions(net *networkHarness, t *harnessTest) {
 		t.Fatalf("unable to subscribe to bob's invoice updates: %v", err)
 	}
 
+	quit := make(chan struct{})
 	updateSent := make(chan struct{})
 	go func() {
 		invoiceUpdate, err := bobInvoiceSubscription.Recv()
+		select {
+		case <-quit:
+			// Received cancellation
+			return
+		default:
+		}
+
 		if err != nil {
 			t.Fatalf("unable to recv invoice update: %v", err)
 		}
@@ -2285,6 +2293,7 @@ func testInvoiceSubscriptions(net *networkHarness, t *harnessTest) {
 	if err != nil {
 		// TODO(roasbeef): will need to make num blocks to advertise a
 		// node param
+		close(quit)
 		t.Fatalf("channel not seen by alice before timeout: %v", err)
 	}
 
@@ -2296,15 +2305,18 @@ func testInvoiceSubscriptions(net *networkHarness, t *harnessTest) {
 	ctxt, _ = context.WithTimeout(ctxb, timeout)
 	resp, err := net.Alice.SendPaymentSync(ctxt, sendReq)
 	if err != nil {
+		close(quit)
 		t.Fatalf("unable to send payment: %v", err)
 	}
 	if resp.PaymentError != "" {
+		close(quit)
 		t.Fatalf("error when attempting recv: %v", resp.PaymentError)
 	}
 
 	select {
-	case <-time.After(time.Second * 5):
-		t.Fatalf("update not sent after 5 seconds")
+	case <-time.After(time.Second * 10):
+		close(quit)
+		t.Fatalf("update not sent after 10 seconds")
 	case <-updateSent: // Fall through on success
 	}
 


### PR DESCRIPTION
This commit adds a small cancellation check to the invoice subscription integration test. Calls to Fatalf were observed on travis after the test had ended stemming from the subscriber's goroutine, which could happen if the subscription is late. It also extends the timeout on the test from 5 to
10 seconds.