### PR TITLE
Store the payment preImage rather than rHash.

### DIFF
--- a/channeldb/payments.go
+++ b/channeldb/payments.go
@@ -37,11 +37,9 @@ type OutgoingPayment struct {
 	// compressed public key of each of the nodes involved in the payment.
 	Path [][33]byte
 
-	// PaymentHash is the payment hash (r-hash) used to send the payment.
-	//
-	// TODO(roasbeef): weave through preimage on payment success to can
-	// store only supplemental info the embedded Invoice
-	PaymentHash [32]byte
+	// PaymentPreimage is the preImage of a successful payment. This is used
+	// to calculate the PaymentHash as well as serve as a proof of payment.
+	PaymentPreimage [32]byte
 }
 
 // AddPayment saves a successful payment to the database. It is assumed that
@@ -163,7 +161,7 @@ func serializeOutgoingPayment(w io.Writer, p *OutgoingPayment) error {
 		return err
 	}
 
-	if _, err := w.Write(p.PaymentHash[:]); err != nil {
+	if _, err := w.Write(p.PaymentPreimage[:]); err != nil {
 		return err
 	}
 
@@ -204,7 +202,7 @@ func deserializeOutgoingPayment(r io.Reader) (*OutgoingPayment, error) {
 	}
 	p.TimeLockLength = byteOrder.Uint32(scratch[:4])
 
-	if _, err := r.Read(p.PaymentHash[:]); err != nil {
+	if _, err := r.Read(p.PaymentPreimage[:]); err != nil {
 		return nil, err
 	}
 

--- a/channeldb/payments_test.go
+++ b/channeldb/payments_test.go
@@ -2,7 +2,6 @@ package channeldb
 
 import (
 	"bytes"
-	"crypto/sha256"
 	"fmt"
 	"math/rand"
 	"reflect"
@@ -31,13 +30,14 @@ func makeFakePayment() *OutgoingPayment {
 		copy(fakePath[i][:], bytes.Repeat([]byte{byte(i)}, 33))
 	}
 
-	return &OutgoingPayment{
+	fakePayment := &OutgoingPayment{
 		Invoice:        *fakeInvoice,
 		Fee:            101,
 		Path:           fakePath,
 		TimeLockLength: 1000,
-		PaymentHash:    sha256.Sum256(rev[:]),
 	}
+	copy(fakePayment.PaymentPreimage[:], rev[:])
+	return fakePayment
 }
 
 // randomBytes creates random []byte with length in range [minLen, maxLen)
@@ -90,14 +90,13 @@ func makeRandomFakePayment() (*OutgoingPayment, error) {
 		copy(fakePath[i][:], b)
 	}
 
-	rHash := sha256.Sum256(fakeInvoice.Terms.PaymentPreimage[:])
 	fakePayment := &OutgoingPayment{
 		Invoice:        *fakeInvoice,
 		Fee:            lnwire.MilliSatoshi(rand.Intn(1001)),
 		Path:           fakePath,
 		TimeLockLength: uint32(rand.Intn(10000)),
-		PaymentHash:    rHash,
 	}
+	copy(fakePayment.PaymentPreimage[:], fakeInvoice.Terms.PaymentPreimage[:])
 
 	return fakePayment, nil
 }

--- a/lnrpc/rpc.pb.go
+++ b/lnrpc/rpc.pb.go
@@ -3199,12 +3199,21 @@ type Payment struct {
 	Path []string `protobuf:"bytes,4,rep,name=path" json:"path,omitempty"`
 	// / The fee paid for this payment in satoshis
 	Fee int64 `protobuf:"varint,5,opt,name=fee" json:"fee,omitempty"`
+	// / The payment preimage
+	PaymentPreimage string `protobuf:"bytes,6,opt,name=payment_preimage" json:"payment_preimage,omitempty"`
 }
 
 func (m *Payment) Reset()                    { *m = Payment{} }
 func (m *Payment) String() string            { return proto.CompactTextString(m) }
 func (*Payment) ProtoMessage()               {}
 func (*Payment) Descriptor() ([]byte, []int) { return fileDescriptor0, []int{80} }
+
+func (m *Payment) GetPaymentPreimage() string {
+	if m != nil {
+		return m.PaymentPreimage
+	}
+	return ""
+}
 
 func (m *Payment) GetPaymentHash() string {
 	if m != nil {

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -1533,7 +1533,7 @@ func (r *rpcServer) ListChannels(ctx context.Context,
 
 // savePayment saves a successfully completed payment to the database for
 // historical record keeping.
-func (r *rpcServer) savePayment(route *routing.Route, amount lnwire.MilliSatoshi, rHash []byte) error {
+func (r *rpcServer) savePayment(route *routing.Route, amount lnwire.MilliSatoshi, preImage []byte) error {
 
 	paymentPath := make([][33]byte, len(route.Hops))
 	for i, hop := range route.Hops {
@@ -1552,7 +1552,7 @@ func (r *rpcServer) savePayment(route *routing.Route, amount lnwire.MilliSatoshi
 		Fee:            route.TotalFees,
 		TimeLockLength: route.TotalTimeLock,
 	}
-	copy(payment.PaymentHash[:], rHash)
+	copy(payment.PaymentPreimage[:], preImage)
 
 	return r.server.chanDB.AddPayment(payment)
 }
@@ -1799,7 +1799,7 @@ func (r *rpcServer) SendPayment(paymentStream lnrpc.Lightning_SendPaymentServer)
 
 				// Save the completed payment to the database
 				// for record keeping purposes.
-				if err := r.savePayment(route, p.msat, rHash[:]); err != nil {
+				if err := r.savePayment(route, p.msat, preImage[:]); err != nil {
 					errChan <- err
 					return
 				}
@@ -1935,7 +1935,7 @@ func (r *rpcServer) SendPaymentSync(ctx context.Context,
 
 	// With the payment completed successfully, we now ave the details of
 	// the completed payment to the database for historical record keeping.
-	if err := r.savePayment(route, amtMSat, rHash[:]); err != nil {
+	if err := r.savePayment(route, amtMSat, preImage[:]); err != nil {
 		return nil, err
 	}
 
@@ -2984,11 +2984,13 @@ func (r *rpcServer) ListPayments(ctx context.Context,
 			path[i] = hex.EncodeToString(hop[:])
 		}
 
+		paymentHash := sha256.Sum256(payment.PaymentPreimage[:])
 		paymentsResp.Payments[i] = &lnrpc.Payment{
-			PaymentHash:  hex.EncodeToString(payment.PaymentHash[:]),
-			Value:        int64(payment.Terms.Value.ToSatoshis()),
-			CreationDate: payment.CreationDate.Unix(),
-			Path:         path,
+			PaymentHash:     hex.EncodeToString(paymentHash[:]),
+			Value:           int64(payment.Terms.Value.ToSatoshis()),
+			CreationDate:    payment.CreationDate.Unix(),
+			Path:            path,
+			PaymentPreimage: hex.EncodeToString(payment.PaymentPreimage[:]),
 		}
 	}
 


### PR DESCRIPTION
Fixes #481.

Prior to this commit, payments stored in the channel DB only kept a
record of the payment hash. This is a problem as the preimage is what
serves as proof of payment and a user should be able to look up this
value in the future (not just immediately after payment).

Instead of storing both the payment hash and the preimage, we store the
preimage only since the hash can be derrived from this using a SHA256.

In the RPC listpayments command, we now give the preimage in addition to
the payment hash.