### PR TITLE
Add bootstrap peers to set of persistent peers for connection retry

### DIFF
--- a/server.go
+++ b/server.go
@@ -569,6 +569,13 @@ func (s *server) peerBootstrapper(numTargetPeers uint32,
 				return
 			}
 
+			// Add bootstrapped peer as persistent to maintain
+			// connectivity even if we have no open channels.
+			targetPub := string(conn.RemotePub().SerializeCompressed())
+			s.mu.Lock()
+			s.persistentPeers[targetPub] = struct{}{}
+			s.mu.Unlock()
+
 			s.OutboundPeerConnected(nil, conn)
 		}(addr)
 	}
@@ -672,6 +679,14 @@ func (s *server) peerBootstrapper(numTargetPeers uint32,
 						atomic.AddUint32(&epochErrors, 1)
 						return
 					}
+
+					// Add bootstrapped peer as persistent to maintain
+					// connectivity even if we have no open channels.
+					targetPub := string(conn.RemotePub().SerializeCompressed())
+					s.mu.Lock()
+					s.persistentPeers[targetPub] = struct{}{}
+					s.mu.Unlock()
+
 					s.OutboundPeerConnected(nil, conn)
 				}(addr)
 			}


### PR DESCRIPTION
Peers are treated as transient by default. When a peer is disconnected,
no attempt is made to reconnect. However, if we have a channel open
with a peer that peer will be added as persistent. If a persistent peer
becomes disconnected then we will attempt to reconnect.

This behavior implies that a fresh node - those without any channels -
will fall off the network over time as remote nodes restart or due to
connectivity changes. This change marks bootstrap peers as persistent
and ensures that the node remains connected to those specific peers over
time. This does not keep the node connected in the case that all
bootstrap peers are down.

This relates to #451 