### PR TITLE
[trivial] server: fix deadlock in sendToPeer at peer shutdown

### DIFF
--- a/server.go
+++ b/server.go
@@ -958,6 +958,8 @@ func (s *server) sendToPeer(target *btcec.PublicKey,
 		select {
 		case err := <-errChan:
 			return err
+		case <-targetPeer.quit:
+			return fmt.Errorf("peer shutting down")
 		case <-s.quit:
 			return ErrServerShuttingDown
 		}


### PR DESCRIPTION
This commit fixes a deadlock that could occur when
a peer disconnected during a call to sentToPeer. In
This particular case, a message would successfully
be queued, the peer would shutdown, and we would
block waiting for an error to be returned on the
message's error channel, which would deadlock.
This fixes that by also checking for peer shutdown.