### PR TITLE
WIP: Handling non-confirmed funding transactions

### DIFF
--- a/fundingmanager.go
+++ b/fundingmanager.go
@@ -430,19 +430,23 @@ func (f *fundingManager) Start() error {
 
 			select {
 			case <-timeoutChan:
-				// Timeout waiting for the funding transaction
-				// to confirm, so we forget the channel and
-				// delete it from the database.
+				// Timeout channel will be triggered if the number of blocks
+				// mined since the channel was initiated reaches
+				// maxWaitNumBlocksFundingConf and we are not the channel
+				// initiator.
+
 				closeInfo := &channeldb.ChannelCloseSummary{
 					ChainHash: ch.ChainHash,
 					ChanPoint: ch.FundingOutpoint,
 					RemotePub: ch.IdentityPub,
 					CloseType: channeldb.FundingCanceled,
 				}
+
 				if err := ch.CloseChannel(closeInfo); err != nil {
 					fndgLog.Errorf("Failed closing channel "+
 						"%v: %v", ch.FundingOutpoint, err)
 				}
+
 			case <-f.quit:
 				// The fundingManager is shutting down, and will
 				// resume wait on startup.
@@ -1485,10 +1489,11 @@ func (f *fundingManager) handleFundingSigned(fmsg *fundingSignedMsg) {
 }
 
 // waitForFundingWithTimeout is a wrapper around waitForFundingConfirmation that
-// will cancel the wait for confirmation if maxWaitNumBlocksFundingConf has
-// passed from bestHeight. In the case of timeout, the timeoutChan will be
-// closed. In case of error, confChan will be closed. In case of success,
-// a *lnwire.ShortChannelID will be passed to confChan.
+// will cancel the wait for confirmation if we are not the channel initiator and
+// the maxWaitNumBlocksFundingConf has passed from bestHeight.
+// In the case of timeout, the timeoutChan will be closed. In case of error,
+// confChan will be closed. In case of success, a *lnwire.ShortChannelID will be
+// passed to confChan.
 func (f *fundingManager) waitForFundingWithTimeout(completeChan *channeldb.OpenChannel,
 	confChan chan<- *lnwire.ShortChannelID, timeoutChan chan<- struct{}) {
 
@@ -1524,7 +1529,9 @@ func (f *fundingManager) waitForFundingWithTimeout(completeChan *channeldb.OpenC
 				return
 			}
 
-			if uint32(epoch.Height) >= maxHeight {
+			// If we are not the channel initiator it's safe
+			// to timeout the channel
+			if uint32(epoch.Height) >= maxHeight && !completeChan.IsInitiator {
 				fndgLog.Warnf("waited for %v blocks without "+
 					"seeing funding transaction confirmed,"+
 					" cancelling.", maxWaitNumBlocksFundingConf)
@@ -1537,6 +1544,11 @@ func (f *fundingManager) waitForFundingWithTimeout(completeChan *channeldb.OpenC
 				close(timeoutChan)
 				return
 			}
+
+			// TODO: If we are the channel initiator implement
+			// a method for recovering the funds from the funding
+			// transaction
+
 		case <-f.quit:
 			// The fundingManager is shutting down, will resume
 			// waiting for the funding transaction on startup.

--- a/fundingmanager_test.go
+++ b/fundingmanager_test.go
@@ -566,7 +566,7 @@ func openChannel(t *testing.T, alice, bob *testNode, localFundingAmt,
 	return fundingOutPoint
 }
 
-func assertNumPendingChannels(t *testing.T, node *testNode, expectedNum int) {
+func assertNumPendingChannelsBecomes(t *testing.T, node *testNode, expectedNum int) {
 	var numPendingChans int
 	for i := 0; i < testPollNumTries; i++ {
 		// If this is not the first try, sleep before retrying.
@@ -588,6 +588,28 @@ func assertNumPendingChannels(t *testing.T, node *testNode, expectedNum int) {
 
 	t.Fatalf("Expected node to have %d pending channels, had %v",
 		expectedNum, numPendingChans)
+}
+
+func assertNumPendingChannelsRemains(t *testing.T, node *testNode, expectedNum int) {
+	var numPendingChans int
+	for i := 0; i < 5; i++ {
+		// If this is not the first try, sleep before retrying.
+		if i > 0 {
+			time.Sleep(200 * time.Millisecond)
+		}
+		pendingChannels, err := node.fundingMgr.
+			cfg.Wallet.Cfg.Database.FetchPendingChannels()
+		if err != nil {
+			t.Fatalf("unable to fetch pending channels: %v", err)
+		}
+
+		numPendingChans = len(pendingChannels)
+		if numPendingChans != expectedNum {
+
+			t.Fatalf("Expected node to have %d pending channels, had %v",
+				expectedNum, numPendingChans)
+		}
+	}
 }
 
 func assertDatabaseState(t *testing.T, node *testNode,
@@ -1160,14 +1182,71 @@ func TestFundingManagerFundingTimeout(t *testing.T) {
 	}
 
 	// Bob should still be waiting for the channel to open.
-	assertNumPendingChannels(t, bob, 1)
+	assertNumPendingChannelsRemains(t, bob, 1)
 
 	bob.mockNotifier.epochChan <- &chainntnfs.BlockEpoch{
 		Height: fundingBroadcastHeight + 288,
 	}
 
 	// Should not be pending anymore.
-	assertNumPendingChannels(t, bob, 0)
+	assertNumPendingChannelsBecomes(t, bob, 0)
+}
+
+// TestFundingManagerFundingNotTimeoutInitiator checks that if the user was
+// the channel initiator, that it does not timeout when the lnd restarts
+func TestFundingManagerFundingNotTimeoutInitiator(t *testing.T) {
+
+	alice, bob := setupFundingManagers(t)
+	defer tearDownFundingManagers(t, alice, bob)
+
+	// We will consume the channel updates as we go, so no buffering is needed.
+	updateChan := make(chan *lnrpc.OpenStatusUpdate)
+
+	// Run through the process of opening the channel, up until the funding
+	// transaction is broadcasted.
+	_ = openChannel(t, alice, bob, 500000, 0, 1, updateChan, true)
+
+	// Alice will at this point be waiting for the funding transaction to be
+	// confirmed, so the channel should be considered pending.
+	pendingChannels, err := alice.fundingMgr.cfg.Wallet.Cfg.Database.FetchPendingChannels()
+	if err != nil {
+		t.Fatalf("unable to fetch pending channels: %v", err)
+	}
+	if len(pendingChannels) != 1 {
+		t.Fatalf("Expected Alice to have 1 pending channel, had  %v",
+			len(pendingChannels))
+	}
+
+	recreateAliceFundingManager(t, alice)
+
+	// Increase the height to 1 minus the maxWaitNumBlocksFundingConf height
+	alice.mockNotifier.epochChan <- &chainntnfs.BlockEpoch{
+		Height: fundingBroadcastHeight + maxWaitNumBlocksFundingConf - 1,
+	}
+
+	bob.mockNotifier.epochChan <- &chainntnfs.BlockEpoch{
+		Height: fundingBroadcastHeight + maxWaitNumBlocksFundingConf - 1,
+	}
+
+	// Assert both and Alice and Bob still have 1 pending channels
+	assertNumPendingChannelsRemains(t, alice, 1)
+
+	assertNumPendingChannelsRemains(t, bob, 1)
+
+	// Increase both Alice and Bob to maxWaitNumBlocksFundingConf height
+	alice.mockNotifier.epochChan <- &chainntnfs.BlockEpoch{
+		Height: fundingBroadcastHeight + maxWaitNumBlocksFundingConf,
+	}
+
+	bob.mockNotifier.epochChan <- &chainntnfs.BlockEpoch{
+		Height: fundingBroadcastHeight + maxWaitNumBlocksFundingConf,
+	}
+
+	// Since Alice was the initiator, the channel should not have timed out
+	assertNumPendingChannelsRemains(t, alice, 1)
+
+	// Since Bob was not the initiator, the channel should timeout
+	assertNumPendingChannelsBecomes(t, bob, 0)
 }
 
 // TestFundingManagerReceiveFundingLockedTwice checks that the fundingManager


### PR DESCRIPTION
This is a work in progress of issue #386 

I have added a check before a channel times out that we are not the initiator for the channel.
I have added a test to check this behavior

I also fixed an issue I found in [assertNumPendingChannels](https://github.com/lightningnetwork/lnd/blob/master/fundingmanager_test.go#L545).
The assertion could incorrect return true before a fundingmanager action had been correctly applied.

E.g If a closechannel command was tested,  closing the last remaining channel.
`assertNumPendingChannels(1)` and `assertNumPendingChannels(0)` would both return true
 
I can stick this in a separate issue if required 
 