### PR TITLE
Rename decodepayreq to decodeinvoice

### DIFF
--- a/cmd/lncli/commands.go
+++ b/cmd/lncli/commands.go
@@ -1773,7 +1773,7 @@ func debugLevel(ctx *cli.Context) error {
 	return nil
 }
 
-var decodeInvoiceComamnd = cli.Command{
+var decodeInvoiceCommand = cli.Command{
 	Name:        "decodeinvoice",
 	Usage:       "Decode an invoice.",
 	Description: "Decode the passed invoice revealing the destination, payment hash and value of the payment request",

--- a/cmd/lncli/commands.go
+++ b/cmd/lncli/commands.go
@@ -1773,21 +1773,21 @@ func debugLevel(ctx *cli.Context) error {
 	return nil
 }
 
-var decodePayReqComamnd = cli.Command{
-	Name:        "decodepayreq",
-	Usage:       "Decode a payment request.",
-	Description: "Decode the passed payment request revealing the destination, payment hash and value of the payment request",
-	ArgsUsage:   "pay_req",
+var decodeInvoiceComamnd = cli.Command{
+	Name:        "decodeinvoice",
+	Usage:       "Decode an invoice.",
+	Description: "Decode the passed invoice revealing the destination, payment hash and value of the payment request",
+	ArgsUsage:   "invoice",
 	Flags: []cli.Flag{
 		cli.StringFlag{
-			Name:  "pay_req",
-			Usage: "the bech32 encoded payment request",
+			Name:  "invoice",
+			Usage: "the bech32 encoded invoice",
 		},
 	},
-	Action: actionDecorator(decodePayReq),
+	Action: actionDecorator(decodeInvoice),
 }
 
-func decodePayReq(ctx *cli.Context) error {
+func decodeInvoice(ctx *cli.Context) error {
 	ctxb := context.Background()
 	client, cleanUp := getClient(ctx)
 	defer cleanUp()
@@ -1795,14 +1795,15 @@ func decodePayReq(ctx *cli.Context) error {
 	var payreq string
 
 	switch {
-	case ctx.IsSet("pay_req"):
-		payreq = ctx.String("pay_req")
+	case ctx.IsSet("invoice"):
+		payreq = ctx.String("invoice")
 	case ctx.Args().Present():
 		payreq = ctx.Args().First()
 	default:
-		return fmt.Errorf("pay_req argument missing")
+		return fmt.Errorf("invoice argument missing")
 	}
 
+	// TODO Rename to DecodeInvoice
 	resp, err := client.DecodePayReq(ctxb, &lnrpc.PayReqString{
 		PayReq: payreq,
 	})

--- a/cmd/lncli/main.go
+++ b/cmd/lncli/main.go
@@ -11,12 +11,11 @@ import (
 	"path/filepath"
 	"strings"
 
-	"gopkg.in/macaroon.v1"
-
 	"github.com/lightningnetwork/lnd/lnrpc"
 	"github.com/lightningnetwork/lnd/macaroons"
 	"github.com/roasbeef/btcutil"
 	"github.com/urfave/cli"
+	macaroon "gopkg.in/macaroon.v1"
 
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
@@ -187,7 +186,7 @@ func main() {
 		queryRoutesCommand,
 		getNetworkInfoCommand,
 		debugLevelCommand,
-		decodePayReqComamnd,
+		decodeInvoiceComamnd,
 		listChainTxnsCommand,
 		stopCommand,
 		signMessageCommand,

--- a/cmd/lncli/main.go
+++ b/cmd/lncli/main.go
@@ -186,7 +186,7 @@ func main() {
 		queryRoutesCommand,
 		getNetworkInfoCommand,
 		debugLevelCommand,
-		decodeInvoiceComamnd,
+		decodeInvoiceCommand,
 		listChainTxnsCommand,
 		stopCommand,
 		signMessageCommand,


### PR DESCRIPTION
Currently "payment request" and "invoice" are used interchangeably which I think can be confusing to developers new to the project.
This PR renames `decodepayreq ` to `decodeinvoice` which I believe to be more clear and consistent.