### PR TITLE
Display help with closechannel

### DIFF
--- a/cmd/lncli/commands.go
+++ b/cmd/lncli/commands.go
@@ -625,7 +625,7 @@ func closeChannel(ctx *cli.Context) error {
 
 	// Show command help if no arguments provieded
 	if ctx.NArg() == 0 && ctx.NumFlags() == 0 {
-		cli.ShowCommandHelp(ctx, "closeChannel")
+		cli.ShowCommandHelp(ctx, "closechannel")
 		return nil
 	}
 


### PR DESCRIPTION
Currently `lncli closechannel` will exit and print nothing, giving the user no information.
This fixes a typo and displays the help when no args are passed.