### PR TITLE
docs: fix python example code issues

### DIFF
--- a/docs/grpc/python.md
+++ b/docs/grpc/python.md
@@ -51,6 +51,7 @@ and set up a channel and stub to your connect to your `lnd` node:
 import rpc_pb2 as ln
 import rpc_pb2_grpc as lnrpc
 import grpc
+import os
 
 # Lnd cert is at ~/.lnd/tls.cert on Linux and
 # ~/Library/Application Support/Lnd/tls.cert on Mac
@@ -78,7 +79,7 @@ print response.total_balance
 
 ```python
 request = ln.InvoiceSubscription()
-for invoice in stub.SubscribeInvoices(request);
+for invoice in stub.SubscribeInvoices(request):
     print invoice
 ```
 


### PR DESCRIPTION
added missing import, fix `;` typo in docs