### PR TITLE
[trivial] discovery: check proof for nilness before creating chanAnn

### DIFF
--- a/discovery/gossiper.go
+++ b/discovery/gossiper.go
@@ -1118,7 +1118,12 @@ func (d *AuthenticatedGossiper) processRejectedEdge(chanAnnMsg *lnwire.ChannelAn
 	}
 
 	// Otherwise, this means that the edge is within the graph, but it
-	// doesn't yet have a proper proof attached.
+	// doesn't yet have a proper proof attached. If we did not receive
+	// the proof such that we now can add it, there's nothing more we
+	// can do.
+	if proof == nil {
+		return nil, nil
+	}
 
 	// We'll then create then validate the new fully assembled
 	// announcement.
@@ -1329,7 +1334,7 @@ func (d *AuthenticatedGossiper) processNetworkAnnouncement(nMsg *networkMsg) []n
 				// Attempt to process the rejected message to
 				// see if we get any new announcements.
 				anns, rErr := d.processRejectedEdge(msg, proof)
-				if err != nil {
+				if rErr != nil {
 					nMsg.err <- rErr
 					return nil
 				}


### PR DESCRIPTION
This commit makes sure we are not attempting to create a
channel announcement with a nil ChannelAuthProof, as that
could cause a crash at startup whe the gossiper would
attempt to reprocess an edge coming from the fundingmanager.

It also makes sure we check the correct error returned from
processRejectedEdge.

Fixes the crash reported in #512