### PR TITLE
Cleanup Directory Structure

### DIFF
--- a/config.go
+++ b/config.go
@@ -27,6 +27,8 @@ import (
 const (
 	defaultConfigFilename     = "lnd.conf"
 	defaultDataDirname        = "data"
+	defaultChainSubDirname    = "chain"
+	defaultGraphSubDirname    = "graph"
 	defaultTLSCertFilename    = "tls.cert"
 	defaultTLSKeyFilename     = "tls.key"
 	defaultAdminMacFilename   = "admin.macaroon"
@@ -328,7 +330,10 @@ func loadConfig() (*config, error) {
 				"ltcd: %v", err)
 			return nil, err
 		}
-		cfg.Litecoin.ChainDir = filepath.Join(cfg.DataDir, litecoinChain.String())
+
+		cfg.Litecoin.ChainDir = filepath.Join(cfg.DataDir,
+			defaultChainSubDirname,
+			litecoinChain.String())
 
 		// Finally we'll register the litecoin chain as our current
 		// primary chain.
@@ -388,7 +393,9 @@ func loadConfig() (*config, error) {
 			// No need to get RPC parameters.
 		}
 
-		cfg.Bitcoin.ChainDir = filepath.Join(cfg.DataDir, bitcoinChain.String())
+		cfg.Bitcoin.ChainDir = filepath.Join(cfg.DataDir,
+			defaultChainSubDirname,
+			bitcoinChain.String())
 
 		// Finally we'll register the bitcoin chain as our current
 		// primary chain.
@@ -431,16 +438,13 @@ func loadConfig() (*config, error) {
 	// TODO(roasbeef): when we go full multi-chain remove the additional
 	// namespacing on the target chain.
 	cfg.DataDir = cleanAndExpandPath(cfg.DataDir)
-	cfg.DataDir = filepath.Join(cfg.DataDir, activeNetParams.Name)
-	cfg.DataDir = filepath.Join(cfg.DataDir,
-		registeredChains.primaryChain.String())
 
 	// Append the network type to the log directory so it is "namespaced"
 	// per network in the same fashion as the data directory.
 	cfg.LogDir = cleanAndExpandPath(cfg.LogDir)
-	cfg.LogDir = filepath.Join(cfg.LogDir, activeNetParams.Name)
 	cfg.LogDir = filepath.Join(cfg.LogDir,
-		registeredChains.primaryChain.String())
+		registeredChains.PrimaryChain().String(),
+		normalizeNetwork(activeNetParams.Name))
 
 	// Ensure that the paths to the TLS key and certificate files are
 	// expanded and cleaned.
@@ -915,4 +919,14 @@ func enforceSafeAuthentication(addrs []string, macaroonsActive bool) error {
 	}
 
 	return nil
+}
+
+// normalizeNetwork returns the common name of a network type used to create
+// file paths. This allows differently versioned networks to use the same path.
+func normalizeNetwork(network string) string {
+	if strings.HasPrefix(network, "testnet") {
+		return "testnet"
+	}
+
+	return network
 }

--- a/lnd.go
+++ b/lnd.go
@@ -19,6 +19,7 @@ import (
 	"net/http"
 	_ "net/http/pprof"
 	"os"
+	"path/filepath"
 	"runtime"
 	"runtime/pprof"
 	"sync"
@@ -133,9 +134,14 @@ func lndMain() error {
 		defer pprof.StopCPUProfile()
 	}
 
+	// Create the network-segmented directory for the channel database.
+	graphDir := filepath.Join(cfg.DataDir,
+		defaultGraphSubDirname,
+		normalizeNetwork(activeNetParams.Name))
+
 	// Open the channeldb, which is dedicated to storing channel, and
 	// network related metadata.
-	chanDB, err := channeldb.Open(cfg.DataDir)
+	chanDB, err := channeldb.Open(graphDir)
 	if err != nil {
 		ltndLog.Errorf("unable to open channeldb: %v", err)
 		return err

--- a/lntest/node.go
+++ b/lntest/node.go
@@ -114,7 +114,7 @@ func (cfg nodeConfig) RESTAddr() string {
 }
 
 func (cfg nodeConfig) DBPath() string {
-	return filepath.Join(cfg.DataDir, cfg.NetParams.Name, "bitcoin/channel.db")
+	return filepath.Join(cfg.DataDir, "graph", "simnet/channel.db")
 }
 
 // genArgs generates a slice of command line arguments from the lightning node


### PR DESCRIPTION
This PR restructures the layout of the data and log directories used by lnd. The primary motivation for doing so is to separate chain-specific data from the channel graph data, which _can_ be shared across multiple chains. Chain-specific data predominately includes the `wallet.db` files, but also includes files required by neutrino when the RPC backend is not in use. 

Example of new data directory structure
----------------------------------------
```
data/
├── admin.macaroon                                                  
├── chain                                                           
│   ├── bitcoin                                                     
│   │   └── testnet                                                 
│   │       ├── block_headers.bin                                   
│   │       ├── ext_filter_headers.bin                              
│   │       ├── neutrino.db                                         
│   │       ├── reg_filter_headers.bin                              
│   │       └── wallet.db                                           
│   └── litecoin                                                    
│       └── testnet4                                                
│           └── wallet.db                                           
├── graph                                                           
│   └── testnet                                                     
│       └── channel.db                                              
├── macaroons.db                                                    
└── readonly.macaroon 
```
**Note:** We currently use roasbeef/btcwallet as our wallet engine on both BTC and LTC. When creating `wallet.db`'s, it automatically normalizes "testnet3" to "testnet" in the directory structure. This normalization does not happen for LTC's testnet4 because btcd/wire does not recognize the TestNet4 constant (defined in ltcd/wire) used to instantiate our LTC params, which leaves "testnet4" unnormalized. This is benign, for now, since we currently do not support neutrino for LTC. Thus, the wallet file should be the sole file, but should be addressed before enabling LTC neutrino support. The neutrino database path _will_ normalize any network name prefixed with "testnet", and so would place them in different directories.

The log structure was slightly modified to by reversing the order of the chain and network names, so as to better match the data directory.

Example of new log directory structure
--------------------------------------
```
log/
└── bitcoin
    └── testnet
        └── lnd.log
```

This PR closes #409.
  
  
  