### PR TITLE
docs: clarify how to generate protobuf definitions

### DIFF
--- a/docs/code_contribution_guidelines.md
+++ b/docs/code_contribution_guidelines.md
@@ -356,6 +356,9 @@ generate identical compiled protos and related files:
    * grpc-ecosystem/grpc-gateway: `f2862b476edcef83412c7af8687c9cd8e4097c0f`
    * golang/protobuf: `ab9f9a6dab164b7d1246e0e688b0ab7b94d8553e`
 
+For detailed instructions on how to compile modifications to `lnd`'s `protobuf`
+definitions, check out the [lnrpc README](https://github.com/lightningnetwork/lnd/blob/master/lnrpc/README.md).
+
 Additionally, in order to maintain a uniform display of the RPC responses
 rendered by `lncli`, all added or modified `protof` definitions, _must_ attach
 the proper `json_name` option for all fields. An example of such an option can

--- a/lnrpc/README.md
+++ b/lnrpc/README.md
@@ -97,3 +97,32 @@ description):
 ```bash
 $ go get -u github.com/lightningnetwork/lnd/lnrpc
 ```
+
+## Generate protobuf definitions
+
+1. Download [v.3.4.0](https://github.com/google/protobuf/releases/tag/v3.4.0) of
+`protoc` for your operating system and add it to your `PATH`.
+For example, if using macOS:
+```bash
+$ curl -LO https://github.com/google/protobuf/releases/download/v3.4.0/protoc-3.4.0-osx-x86_64.zip
+$ unzip protoc-3.4.0-osx-x86_64.zip -d protoc
+$ export PATH=$PWD/protoc/bin:$PATH
+```
+
+2. Install `golang/protobuf` at commit `ab9f9a6dab164b7d1246e0e688b0ab7b94d8553e`.
+```bash
+$ git clone https://github.com/golang/protobuf $GOPATH/src/github.com/golang/protobuf
+$ cd $GOPATH/src/github.com/golang/protobuf
+$ git reset --hard ab9f9a6dab164b7d1246e0e688b0ab7b94d8553e
+$ make
+```
+
+3. Install `grpc-ecosystem/grpc-gateway` at commit `f2862b476edcef83412c7af8687c9cd8e4097c0f`.
+```bash
+$ git clone https://github.com/grpc-ecosystem/grpc-gateway $GOPATH/src/github.com/grpc-ecosystem/grpc-gateway
+$ cd $GOPATH/src/github.com/grpc-ecosystem/grpc-gateway
+$ git reset --hard f2862b476edcef83412c7af8687c9cd8e4097c0f
+$ go install ./protoc-gen-grpc-gateway ./protoc-gen-swagger
+```
+
+4. Run `gen_protos.sh` to generate new protobuf definitions.


### PR DESCRIPTION
I'm submitting these changes since I was working on another PR (#562) that involved modifying some `protobuf` definitions. I had some trouble doing so due to being new to the project.

I've confirmed the documented steps below work as intended. We could also just integrate them into `gen_protos.sh` to make things simpler. I'm open to discussion :)