### PR TITLE
Update Slack invite link

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ resources including talks, articles, and example applications can be found at:
 [dev.lightning.community](http://dev.lightning.community).
 
 Finally, we also have an active
-[Slack](https://join.slack.com/t/lightningcommunity/shared_invite/MjI4OTg3MzQ4MjI2LTE1MDMxNzM1NTMtNjlmOGYzOTI1Ng)
+[Slack](https://lightningcommunity.slack.com/join/shared_invite/enQtMjk0OTYxNzI4NzExLTFhZDA5YTYxZDU2YWQyOTQzN2ZkMzk3ZGUwNGM0NjE2NzQyNjAyZTkwOTFkZjJmMmMyNzlmNmE5YTRmMGFhM2Q)
 where protocol developers, application developers, testers and users gather to
 discuss various aspects of `lnd` and also Lightning in general.
 


### PR DESCRIPTION
The previous link was dead.