### PR TITLE
[trivial] pilot: add goroutine to waitgroup

### DIFF
--- a/pilot.go
+++ b/pilot.go
@@ -198,6 +198,7 @@ func initAutoPilot(svr *server, cfg *autoPilotConfig) (*autopilot.Agent, error) 
 		}
 
 	}()
+	svr.wg.Add(1)
 	go func() {
 		defer txnSubscription.Cancel()
 		defer svr.wg.Done()


### PR DESCRIPTION
This PR fixes a small benign issue that could make the call to `wg.Done()` panic at server shutdown, since the goroutine was not added to the waitgroup.