### PR TITLE
rpc: remove SetAlias from the rpc docs

### DIFF
--- a/lnrpc/README.md
+++ b/lnrpc/README.md
@@ -89,8 +89,6 @@ description):
        amount of payment.
   * GetNetworkInfo
      * Returns some network level statistics.
-  * SetAlias
-     * Sets the node alias which is to be advertised on the network.
 
 ## Installation and Updating
 


### PR DESCRIPTION
The docs were out-of-date with the code.