### PR TITLE
Travis: fix sudo required and apt-get update command

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,11 +2,11 @@ language: go
 go:
   - 1.8.5
   - 1.9.2
-sudo: false
+sudo: required
 install:
-  - add-apt-repository -y ppa:bitcoin/bitcoin
-  - apt-update
-  - apt-get -y install bitcoind
+  - sudo add-apt-repository -y ppa:bitcoin/bitcoin -y
+  - sudo apt-get update -q
+  - sudo apt-get install bitcoind -y
   - GLIDE_TAG=v0.12.3
   - GLIDE_DOWNLOAD="https://github.com/Masterminds/glide/releases/download/$GLIDE_TAG/glide-$GLIDE_TAG-linux-amd64.tar.gz"
   - curl -L $GLIDE_DOWNLOAD | tar -xvz


### PR DESCRIPTION
Hi, 

I noticed this issue on lnd

https://travis-ci.org/lightningnetwork/lnd/jobs/329707733#L467

````0.20s$ add-apt-repository -y ppa:bitcoin/bitcoin
Error: must run as root
````

Also after fixing that ````apt-update```` gave the error in Travis: ````apt-update: command not found````

Correct me if I'm wrong but I think it should be ````sudo apt-get update````

According to Travis: https://docs.travis-ci.com/user/installing-dependencies/#Installing-Packages-from-a-custom-APT-repository 