### PR TITLE
Fix: custom port (peerport config) in node announcement

### DIFF
--- a/server.go
+++ b/server.go
@@ -205,7 +205,7 @@ func newServer(listenAddrs []string, chanDB *channeldb.DB, cc *chainControl,
 		var addr string
 		_, _, err = net.SplitHostPort(ip)
 		if err != nil {
-			addr = net.JoinHostPort(ip, strconv.Itoa(defaultPeerPort))
+			addr = net.JoinHostPort(ip, strconv.Itoa(cfg.PeerPort))
 		} else {
 			addr = ip
 		}


### PR DESCRIPTION
lncli getinfo was always returning current node uri with the default (9735) port, even though a custom port was set