### PR TITLE
rpcserver: flip inbound bool for display, fix internally later

### DIFF
--- a/rpcserver.go
+++ b/rpcserver.go
@@ -1185,7 +1185,7 @@ func (r *rpcServer) ListPeers(ctx context.Context,
 			PubKey:    hex.EncodeToString(nodePub),
 			PeerId:    serverPeer.id,
 			Address:   serverPeer.conn.RemoteAddr().String(),
-			Inbound:   serverPeer.inbound,
+			Inbound:   !serverPeer.inbound, // Flip for display
 			BytesRecv: atomic.LoadUint64(&serverPeer.bytesReceived),
 			BytesSent: atomic.LoadUint64(&serverPeer.bytesSent),
 			SatSent:   satSent,


### PR DESCRIPTION
Inbound boolean is backwards internally, flip for display purposes on ListPeers.