### PR TITLE
WIP: Switch Circuit Persistence

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: a69cfd6352bed3cc0d24a01f42609b849f9f6d5664be7470b281bf6b09c58d84
-updated: 2018-02-06T17:14:31.208312805-08:00
+hash: 3af2998b2e02f88bee3a868cdb8bc1c75bf2fa5f35b5d5d35436b4c4efd57e6d
+updated: 2018-02-02T19:03:28.562644-08:00
 imports:
 - name: github.com/aead/chacha20
   version: d31a916ded42d1640b9d89a26f8abd53cc96790c

--- a/htlcswitch/circuit.go
+++ b/htlcswitch/circuit.go
@@ -1,174 +1,256 @@
 package htlcswitch
 
 import (
+	"encoding/binary"
 	"fmt"
-	"sync"
+	"io"
 
 	"github.com/go-errors/errors"
 	"github.com/lightningnetwork/lnd/lnwire"
 )
 
-// PaymentCircuit is used by the HTLC switch subsystem to determine the
-// backwards path for the settle/fail HTLC messages. A payment circuit
-// will be created once a channel link forwards the HTLC add request and
-// removed when we receive a settle/fail HTLC message.
+// ErrInvalidCircuitKeyLen signals that a circuit key could not be decoded
+// because the byte slice is of an invalid length.
+var ErrInvalidCircuitKeyLen = errors.New("length of serialized circuit " +
+	"key must be 16 bytes")
+
+// EmptyKeystone is a default value returned when a circuit's keystone has not
+// been set. Note that this value is invalid for use as a keystone, since the
+// outgoing link must not be equal to sourceHop.
+var EmptyKeystone CircuitKey
+
+// CircuitKey is a tuple of channel ID and HTLC ID, used to uniquely identify
+// HTLCs in a circuit. Circuits are identified primarily by the circuit key of
+// the incoming HTLC. However, a circuit may also be referenced by its outgoing
+// circuit key (keystone) after the HTLC has been forwarded via the outgoing
+// link.
+type CircuitKey struct {
+	ChanID lnwire.ShortChannelID
+	HtlcID uint64
+}
+
+// SetBytes deserializes the given bytes into this CircuitKey.
+func (k *CircuitKey) SetBytes(bs []byte) error {
+	if len(bs) != 16 {
+		return ErrInvalidCircuitKeyLen
+	}
+
+	k.ChanID = lnwire.NewShortChanIDFromInt(
+		binary.BigEndian.Uint64(bs[:8]))
+	k.HtlcID = binary.BigEndian.Uint64(bs[8:])
+
+	return nil
+}
+
+// Bytes returns the serialized bytes for this circuit key.
+func (k CircuitKey) Bytes() []byte {
+	var bs = make([]byte, 16)
+	binary.BigEndian.PutUint64(bs[:8], k.ChanID.ToUint64())
+	binary.BigEndian.PutUint64(bs[8:], k.HtlcID)
+	return bs
+}
+
+// Encode writes a CircuitKey to the provided io.Writer.
+func (k *CircuitKey) Encode(w io.Writer) error {
+	var scratch [16]byte
+	binary.BigEndian.PutUint64(scratch[:8], k.ChanID.ToUint64())
+	binary.BigEndian.PutUint64(scratch[8:], k.HtlcID)
+
+	_, err := w.Write(scratch[:])
+	return err
+}
+
+// Decode reads a CircuitKey from the provided io.Reader.
+func (k *CircuitKey) Decode(r io.Reader) error {
+	var scratch [16]byte
+
+	if _, err := io.ReadFull(r, scratch[:]); err != nil {
+		return err
+	}
+	k.ChanID = lnwire.NewShortChanIDFromInt(
+		binary.BigEndian.Uint64(scratch[:8]))
+	k.HtlcID = binary.BigEndian.Uint64(scratch[8:])
+
+	return nil
+}
+
+// String returns a string representation of the CircuitKey.
+func (k CircuitKey) String() string {
+	return fmt.Sprintf("(Chan ID=%s, HTLC ID=%d)", k.ChanID, k.HtlcID)
+}
+
+// PaymentCircuit is used by the switch as placeholder between when the
+// switch makes a forwarding decision and the outgoing link determines the
+// proper HTLC ID for the local log. After the outgoing HTLC ID has been
+// determined, the half circuit will be converted into a full PaymentCircuit.
 type PaymentCircuit struct {
+	// Incoming is the circuit key identifying the incoming channel and htlc
+	// index from which this ADD originates.
+	Incoming CircuitKey
+
+	// Outgoing is the circuit key identifying the outgoing channel, and the
+	// HTLC index that was used to forward the ADD. It will be nil if this
+	// circuit's keystone has not been set.
+	Outgoing *CircuitKey
+
 	// PaymentHash used as unique identifier of payment.
 	PaymentHash [32]byte
 
-	// IncomingChanID identifies the channel from which add HTLC request came
-	// and to which settle/fail HTLC request will be returned back. Once
-	// the switch forwards the settle/fail message to the src the circuit
-	// is considered to be completed.
-	IncomingChanID lnwire.ShortChannelID
+	// IncomingAmount is the value of the HTLC from the incoming link.
+	IncomingAmount lnwire.MilliSatoshi
 
-	// IncomingHTLCID is the ID in the update_add_htlc message we received from
-	// the incoming channel, which will be included in any settle/fail messages
-	// we send back.
-	IncomingHTLCID uint64
-
-	// OutgoingChanID identifies the channel to which we propagate the HTLC add
-	// update and from which we are expecting to receive HTLC settle/fail
-	// request back.
-	OutgoingChanID lnwire.ShortChannelID
-
-	// OutgoingHTLCID is the ID in the update_add_htlc message we sent to the
-	// outgoing channel.
-	OutgoingHTLCID uint64
+	// OutgoingAmount specifies the value of the HTLC leaving the switch,
+	// either as a payment or forwarded amount.
+	OutgoingAmount lnwire.MilliSatoshi
 
 	// ErrorEncrypter is used to re-encrypt the onion failure before
 	// sending it back to the originator of the payment.
 	ErrorEncrypter ErrorEncrypter
 }
 
-// circuitKey is a channel ID, HTLC ID tuple used as an identifying key for a
-// payment circuit. The circuit map is keyed with the identifier for the
-// outgoing HTLC
-type circuitKey struct {
-	chanID lnwire.ShortChannelID
-	htlcID uint64
+// HasKeystone returns true if an outgoing link has assigned an this circuit's
+// outgoing circuit key.
+func (c *PaymentCircuit) HasKeystone() bool {
+	return c.Outgoing != nil
 }
 
-// String returns a string representation of the circuitKey.
-func (k *circuitKey) String() string {
-	return fmt.Sprintf("(Chan ID=%s, HTLC ID=%d)", k.chanID, k.htlcID)
-}
-
-// CircuitMap is a data structure that implements thread safe storage of
-// circuit routing information. The switch consults a circuit map to determine
-// where to forward HTLC update messages. Each circuit is stored with its
-// outgoing HTLC as the primary key because, each offered HTLC has at most one
-// received HTLC, but there may be multiple offered or received HTLCs with the
-// same payment hash. Circuits are also indexed to provide fast lookups by
-// payment hash.
-//
-// TODO(andrew.shvv) make it persistent
-type CircuitMap struct {
-	mtx       sync.RWMutex
-	circuits  map[circuitKey]*PaymentCircuit
-	hashIndex map[[32]byte]map[PaymentCircuit]struct{}
-}
-
-// NewCircuitMap creates a new instance of the CircuitMap.
-func NewCircuitMap() *CircuitMap {
-	return &CircuitMap{
-		circuits:  make(map[circuitKey]*PaymentCircuit),
-		hashIndex: make(map[[32]byte]map[PaymentCircuit]struct{}),
+// newPaymentCircuit initalizes apayment circuit on the heap using the payment
+// hash and an in-memory htlc packet.
+func newPaymentCircuit(hash *[32]byte, pkt *htlcPacket) *PaymentCircuit {
+	return &PaymentCircuit{
+		Incoming: CircuitKey{
+			ChanID: pkt.incomingChanID,
+			HtlcID: pkt.incomingHTLCID,
+		},
+		PaymentHash:    *hash,
+		IncomingAmount: pkt.incomingAmount,
+		OutgoingAmount: pkt.amount,
+		ErrorEncrypter: pkt.obfuscator,
 	}
 }
 
-// LookupByHTLC looks up the payment circuit by the outgoing channel and HTLC
-// IDs. Returns nil if there is no such circuit.
-func (cm *CircuitMap) LookupByHTLC(chanID lnwire.ShortChannelID, htlcID uint64) *PaymentCircuit {
-	cm.mtx.RLock()
-
-	key := circuitKey{
-		chanID: chanID,
-		htlcID: htlcID,
+// makePaymentCircuit initalizes a payment circuit on the stack using the
+// payment hash and an in-memory htlc packet.
+func makePaymentCircuit(hash *[32]byte, pkt *htlcPacket) PaymentCircuit {
+	return PaymentCircuit{
+		Incoming: CircuitKey{
+			ChanID: pkt.incomingChanID,
+			HtlcID: pkt.incomingHTLCID,
+		},
+		PaymentHash:    *hash,
+		IncomingAmount: pkt.incomingAmount,
+		OutgoingAmount: pkt.amount,
+		ErrorEncrypter: pkt.obfuscator,
 	}
-	circuit := cm.circuits[key]
-
-	cm.mtx.RUnlock()
-	return circuit
 }
 
-// LookupByPaymentHash looks up and returns any payment circuits with a given
-// payment hash.
-func (cm *CircuitMap) LookupByPaymentHash(hash [32]byte) []*PaymentCircuit {
-	cm.mtx.RLock()
-
-	var circuits []*PaymentCircuit
-	if circuitSet, ok := cm.hashIndex[hash]; ok {
-		circuits = make([]*PaymentCircuit, 0, len(circuitSet))
-		for circuit := range circuitSet {
-			circuits = append(circuits, &circuit)
-		}
+// Encode writes a PaymentCircuit to the provided io.Writer.
+func (c *PaymentCircuit) Encode(w io.Writer) error {
+	if err := c.Incoming.Encode(w); err != nil {
+		return err
 	}
 
-	cm.mtx.RUnlock()
-	return circuits
+	if _, err := w.Write(c.PaymentHash[:]); err != nil {
+		return err
+	}
+
+	var scratch [8]byte
+
+	binary.BigEndian.PutUint64(scratch[:], uint64(c.IncomingAmount))
+	if _, err := w.Write(scratch[:]); err != nil {
+		return err
+	}
+
+	binary.BigEndian.PutUint64(scratch[:], uint64(c.OutgoingAmount))
+	if _, err := w.Write(scratch[:]); err != nil {
+		return err
+	}
+
+	// Defaults to EncrypterTypeNone.
+	var encrypterType EncrypterType
+	if c.ErrorEncrypter != nil {
+		encrypterType = c.ErrorEncrypter.Type()
+	}
+
+	err := binary.Write(w, binary.BigEndian, encrypterType)
+	if err != nil {
+		return err
+	}
+
+	// Skip encoding of error encrypter if this half add does not have one.
+	if encrypterType == EncrypterTypeNone {
+		return nil
+	}
+
+	return c.ErrorEncrypter.Encode(w)
 }
 
-// Add adds a new active payment circuit to the CircuitMap.
-func (cm *CircuitMap) Add(circuit *PaymentCircuit) error {
-	cm.mtx.Lock()
-
-	key := circuitKey{
-		chanID: circuit.OutgoingChanID,
-		htlcID: circuit.OutgoingHTLCID,
+// Decode reads a PaymentCircuit from the provided io.Reader.
+func (c *PaymentCircuit) Decode(r io.Reader) error {
+	if err := c.Incoming.Decode(r); err != nil {
+		return err
 	}
-	cm.circuits[key] = circuit
 
-	// Add circuit to the hash index.
-	if _, ok := cm.hashIndex[circuit.PaymentHash]; !ok {
-		cm.hashIndex[circuit.PaymentHash] = make(map[PaymentCircuit]struct{})
+	if _, err := io.ReadFull(r, c.PaymentHash[:]); err != nil {
+		return err
 	}
-	cm.hashIndex[circuit.PaymentHash][*circuit] = struct{}{}
 
-	cm.mtx.Unlock()
-	return nil
+	var scratch [8]byte
+
+	if _, err := io.ReadFull(r, scratch[:]); err != nil {
+		return err
+	}
+	c.IncomingAmount = lnwire.MilliSatoshi(
+		binary.BigEndian.Uint64(scratch[:]))
+
+	if _, err := io.ReadFull(r, scratch[:]); err != nil {
+		return err
+	}
+	c.OutgoingAmount = lnwire.MilliSatoshi(
+		binary.BigEndian.Uint64(scratch[:]))
+
+	// Read the encrypter type used for this circuit.
+	var encrypterType EncrypterType
+	err := binary.Read(r, binary.BigEndian, &encrypterType)
+	if err != nil {
+		return err
+	}
+
+	switch encrypterType {
+	case EncrypterTypeNone:
+		// No encrypter was provided, such as when the payment is
+		// locally initiated.
+		return nil
+
+	case EncrypterTypeSphinx:
+		// Sphinx encrypter was used as this is a forwarded HTLC.
+		c.ErrorEncrypter = NewSphinxErrorEncrypter()
+
+	case EncrypterTypeMock:
+		// Test encrypter.
+		c.ErrorEncrypter = NewMockObfuscator()
+
+	default:
+		return UnknownEncrypterType(encrypterType)
+	}
+
+	return c.ErrorEncrypter.Decode(r)
 }
 
-// Remove destroys the target circuit by removing it from the circuit map.
-func (cm *CircuitMap) Remove(chanID lnwire.ShortChannelID, htlcID uint64) error {
-	cm.mtx.Lock()
-	defer cm.mtx.Unlock()
-
-	// Look up circuit so that pointer can be matched in the hash index.
-	key := circuitKey{
-		chanID: chanID,
-		htlcID: htlcID,
-	}
-	circuit, found := cm.circuits[key]
-	if !found {
-		return errors.Errorf("Can't find circuit for HTLC %v", key)
-	}
-	delete(cm.circuits, key)
-
-	// Remove circuit from hash index.
-	circuitsWithHash, ok := cm.hashIndex[circuit.PaymentHash]
-	if !ok {
-		return errors.Errorf("Can't find circuit in hash index for HTLC %v",
-			key)
-	}
-
-	if _, ok = circuitsWithHash[*circuit]; !ok {
-		return errors.Errorf("Can't find circuit in hash index for HTLC %v",
-			key)
-	}
-
-	delete(circuitsWithHash, *circuit)
-	if len(circuitsWithHash) == 0 {
-		delete(cm.hashIndex, circuit.PaymentHash)
-	}
-	return nil
+// InKey returns the primary identifier for the circuit corresponding to the
+// incoming HTLC.
+func (c *PaymentCircuit) InKey() CircuitKey {
+	return c.Incoming
 }
 
-// pending returns number of circuits which are waiting for to be completed
-// (settle/fail responses to be received).
-func (cm *CircuitMap) pending() int {
-	cm.mtx.RLock()
-	count := len(cm.circuits)
-	cm.mtx.RUnlock()
-	return count
+// OutKey returns the keystone identifying the outgoing link and HTLC ID. If the
+// circuit hasn't been completed, this method returns an EmptyKeystone, which is
+// an invalid outgoing circuit key. Only call this method if HasKeystone returns
+// true.
+func (c *PaymentCircuit) OutKey() CircuitKey {
+	if c.Outgoing != nil {
+		return *c.Outgoing
+	}
+
+	return EmptyKeystone
 }

--- a/htlcswitch/circuit_map.go
+++ b/htlcswitch/circuit_map.go
@@ -1,0 +1,519 @@
+package htlcswitch
+
+import (
+	"bytes"
+	"sync"
+
+	"github.com/boltdb/bolt"
+	"github.com/go-errors/errors"
+	"github.com/lightningnetwork/lnd/channeldb"
+)
+
+var (
+	// ErrCorruptedCircuitMap indicates that the on-disk bucketing structure
+	// has altered since the circuit map instance was initialized.
+	ErrCorruptedCircuitMap = errors.New("circuit map has been corrupted")
+
+	// ErrCircuitNotInHashIndex indicates that a particular circuit did not
+	// appear in the in-memory hash index.
+	ErrCircuitNotInHashIndex = errors.New("payment circuit not found in " +
+		"hash index")
+
+	// ErrUnknownCircuit signals that circuit could not be removed from the
+	// map because it was not found.
+	ErrUnknownCircuit = errors.New("unknown payment circuit")
+
+	// ErrDuplicateCircuit signals that this circuit was previously
+	// added.
+	ErrDuplicateCircuit = errors.New("duplicate circuit add")
+
+	// ErrUnknownKeystone signals that no circuit was found using the
+	// outgoing circuit key.
+	ErrUnknownKeystone = errors.New("unknown circuit keystone")
+
+	// ErrDuplicateKeystone signals that this circuit was previously
+	// assigned a keystone.
+	ErrDuplicateKeystone = errors.New("cannot add duplicate keystone")
+)
+
+// CircuitMap is an interface for managing the construction and teardown of
+// payment circuits used by the switch.
+type CircuitMap interface {
+	// CommitCircuits attempts to add the given circuit's to the circuit
+	// map, returning a list of the circuits that had not been seen prior.
+	CommitCircuits(circuit ...*PaymentCircuit) ([]*PaymentCircuit, error)
+
+	// NumPending returns the total number of active circuits added by
+	// CommitCircuits.
+	NumPending() int
+
+	// SetKeystone is used to assign the outgoing circuit key to the circuit
+	// identified by inKey.
+	SetKeystone(inKey CircuitKey, outKey CircuitKey) error
+
+	// NumOpen returns the number of circuits with HTLCs that have been
+	// forwarded via an outgoing link.
+	NumOpen() int
+
+	// LookupCircuit queries the circuit map for the circuit identified by
+	// inKey.
+	LookupCircuit(inKey CircuitKey) *PaymentCircuit
+
+	// LookupByKeystone queries the circuit map for a circuit identified by
+	// its outgoing circuit key.
+	LookupByKeystone(outKey CircuitKey) *PaymentCircuit
+
+	// LookupByPaymentHash queries the circuit map and returns all open
+	// circuits that use the given payment hash.
+	LookupByPaymentHash(hash [32]byte) []*PaymentCircuit
+
+	// Delete removes the incoming circuit key to remove all references to a
+	// circuit.
+	Delete(inKey CircuitKey) error
+}
+
+var (
+
+	// circuitAddKey is the key used to retrieve the bucket containing
+	// payment circuits. A circuit records information about how to return a
+	// packet to the source link, potentially including an error encrypter
+	// for applying this hop's encryption to the payload in the reverse
+	// direction.
+	circuitAddKey = []byte("circuit-adds")
+
+	// circuitKeystoneKey is used to retrieve the bucket containing circuit
+	// keystones, which are set in place once a forwarded packet is assigned
+	// an index on an outgoing commitment txn.
+	circuitKeystoneKey = []byte("circuit-keysontes")
+)
+
+// circuitMap is a data structure that implements thread safe, persistent
+// storage of circuit routing information. The switch consults a circuit map to
+// determine where to forward HTLC update messages. Each circuit is stored with
+// it's outgoing HTLC as the primary key because, each offered HTLC has at most
+// one received HTLC, but there may be multiple offered or received HTLCs with
+// the same payment hash. Circuits are also indexed to provide fast lookups by
+// payment hash.
+type circuitMap struct {
+	// db provides the persistent storage engine for the circuit map.
+	// TODO(conner): create abstraction to allow for the substitution of
+	// other persistence engines.
+	db *channeldb.DB
+
+	mtx sync.RWMutex
+
+	// pending is an in-memory mapping of all half payment circuits, and
+	// is kept in sync with the on-disk contents of the circuit map.
+	pending map[CircuitKey]*PaymentCircuit
+
+	// opened is an in-memory maping of all full payment circuits, which is
+	// also synchronized with the persistent state of the circuit map.
+	opened map[CircuitKey]*PaymentCircuit
+
+	// hashIndex is a volatile index that facilitates fast queries by
+	// payment hash against the contents of circuits. This index can be
+	// reconstructed entirely from the set of persisted full circuits on
+	// startup.
+	hashIndex map[[32]byte]map[CircuitKey]struct{}
+}
+
+// NewCircuitMap creates a new instance of the circuitMap.
+func NewCircuitMap(db *channeldb.DB) (CircuitMap, error) {
+	cm := &circuitMap{
+		db: db,
+	}
+
+	// Initialize the on-disk buckets used by the circuit map.
+	if err := cm.initBuckets(); err != nil {
+		return nil, err
+	}
+
+	// Load any previously persisted circuit info back into memory.
+	if err := cm.restoreMemState(); err != nil {
+		return nil, err
+	}
+
+	return cm, nil
+}
+
+// initBuckets ensures that the primary buckets used by the circuit are
+// initialized so that we can assume their existence after startup.
+func (cm *circuitMap) initBuckets() error {
+	return cm.db.Update(func(tx *bolt.Tx) error {
+		_, err := tx.CreateBucketIfNotExists(circuitKeystoneKey)
+		if err != nil {
+			return err
+		}
+
+		_, err = tx.CreateBucketIfNotExists(circuitAddKey)
+		return err
+	})
+}
+
+// restoreMemState loads the contents of the half circuit and full circuit buckets
+// from disk and reconstructs the in-memory representation of the circuit map.
+// Afterwards, the state of the hash index is reconstructed using the recovered
+// set of full circuits.
+func (cm *circuitMap) restoreMemState() error {
+
+	var (
+		opened  = make(map[CircuitKey]*PaymentCircuit)
+		pending = make(map[CircuitKey]*PaymentCircuit)
+	)
+
+	if err := cm.db.View(func(tx *bolt.Tx) error {
+		// Restore any of the circuits persisted in the circuit bucket
+		// back into memory.
+		circuitBkt := tx.Bucket(circuitAddKey)
+		if circuitBkt == nil {
+			return ErrCorruptedCircuitMap
+		}
+
+		if err := circuitBkt.ForEach(func(_, v []byte) error {
+			circuit, err := restoreCircuit(v)
+			if err != nil {
+				return err
+			}
+
+			pending[circuit.Incoming] = circuit
+
+			return nil
+		}); err != nil {
+			return err
+		}
+
+		// Furthermore, load the keystone bucket and resurrect the
+		// keystones used in any open circuits.
+		keystoneBkt := tx.Bucket(circuitKeystoneKey)
+		if keystoneBkt == nil {
+			return ErrCorruptedCircuitMap
+		}
+
+		if err := keystoneBkt.ForEach(func(k, v []byte) error {
+			var (
+				inKey  CircuitKey
+				outKey = &CircuitKey{}
+			)
+
+			if err := inKey.SetBytes(v); err != nil {
+				return err
+			}
+			if err := outKey.SetBytes(k); err != nil {
+				return err
+			}
+
+			// Retrieve the pending circuit, set its keystone, then
+			// add it to the opened map.
+			circuit := pending[inKey]
+			circuit.Outgoing = outKey
+			opened[*outKey] = circuit
+
+			return nil
+		}); err != nil {
+			return err
+		}
+
+		return nil
+
+	}); err != nil {
+		return err
+	}
+
+	cm.pending = pending
+	cm.opened = opened
+
+	// Finally, reconstruct the hash index by running through our set of
+	// open circuits.
+	cm.hashIndex = make(map[[32]byte]map[CircuitKey]struct{})
+	for _, circuit := range opened {
+		cm.addCircuitToHashIndex(circuit)
+	}
+
+	return nil
+}
+
+// restoreCircuit reconstructs an in-memory payment circuit from a byte slice.
+// The byte slice is assumed to have been generated by the circuit's Encode
+// method.
+func restoreCircuit(v []byte) (*PaymentCircuit, error) {
+	var circuit = &PaymentCircuit{}
+
+	circuitReader := bytes.NewReader(v)
+	if err := circuit.Decode(circuitReader); err != nil {
+		return nil, err
+	}
+
+	return circuit, nil
+}
+
+// LookupByHTLC looks up the payment circuit by the outgoing channel and HTLC
+// IDs. Returns nil if there is no such circuit.
+func (cm *circuitMap) LookupCircuit(inKey CircuitKey) *PaymentCircuit {
+	cm.mtx.RLock()
+	defer cm.mtx.RUnlock()
+
+	return cm.pending[inKey]
+}
+
+// LookupByKeystone searches for the circuit identified by its outgoing circuit
+// key.
+func (cm *circuitMap) LookupByKeystone(outKey CircuitKey) *PaymentCircuit {
+	cm.mtx.RLock()
+	defer cm.mtx.RUnlock()
+
+	return cm.opened[outKey]
+}
+
+// LookupByPaymentHash looks up and returns any payment circuits with a given
+// payment hash.
+func (cm *circuitMap) LookupByPaymentHash(hash [32]byte) []*PaymentCircuit {
+	cm.mtx.RLock()
+	defer cm.mtx.RUnlock()
+
+	var circuits []*PaymentCircuit
+	if circuitSet, ok := cm.hashIndex[hash]; ok {
+		// Iterate over the outgoing circuit keys found with this hash,
+		// and retrieve the circuit from the opened map.
+		circuits = make([]*PaymentCircuit, 0, len(circuitSet))
+		for key := range circuitSet {
+			if circuit, ok := cm.opened[key]; ok {
+				circuits = append(circuits, circuit)
+			}
+		}
+	}
+
+	return circuits
+}
+
+// CommitCircuits accepts any number of circuits and persistently adds them to
+// the switch's circuit map. The method returns a list of circuits that had not
+// been seen prior by the switch. A link should only forward HTLCs corresponding
+// to the returned circuits to the switch.
+// NOTE: This method uses batched writes to improve performance, gains will only
+// be realized if it is called concurrently from separate goroutines. This
+// method is intended to be called in the htlcManager of each link.
+func (cm *circuitMap) CommitCircuits(
+	circuits ...*PaymentCircuit) ([]*PaymentCircuit, error) {
+
+	// If an empty list was passed, return early to avoid grabbing the lock.
+	if len(circuits) == 0 {
+		return nil, nil
+	}
+
+	// First, we reconcile the provided circuits with our set of pending
+	// circuits to construct a set of new circuits that need to be written
+	// to disk. The circuit's pointer is stored so that we only permit this
+	// exact circuit to be forwarded through the switch. If a circuit is
+	// already pending, the htlc will be reforwarded by the switch.
+	cm.mtx.Lock()
+	var circuitsToAdd []*PaymentCircuit
+	for _, circuit := range circuits {
+		inKey := circuit.InKey()
+		if _, ok := cm.pending[inKey]; !ok {
+			cm.pending[inKey] = circuit
+			circuitsToAdd = append(circuitsToAdd, circuit)
+		}
+	}
+	cm.mtx.Unlock()
+
+	// If all circuits were previously started, we are done.
+	if len(circuitsToAdd) == 0 {
+		return nil, nil
+	}
+
+	// Now, optimistically serialize the circuits to add.
+	var bs = make([]bytes.Buffer, len(circuitsToAdd))
+	for i, circuit := range circuitsToAdd {
+		if err := circuit.Encode(&bs[i]); err != nil {
+			return nil, err
+		}
+	}
+
+	// Write the entire batch of circuits to the persistent circuit bucket
+	// using bolt's Batch write. This method must be called from multiple,
+	// distinct goroutines to have any impact on performance.
+	err := cm.db.Batch(func(tx *bolt.Tx) error {
+		circuitBkt := tx.Bucket(circuitAddKey)
+		if circuitBkt == nil {
+			return ErrCorruptedCircuitMap
+		}
+
+		for i, circuit := range circuitsToAdd {
+			inKeyBytes := circuit.InKey().Bytes()
+			circuitBytes := bs[i].Bytes()
+
+			err := circuitBkt.Put(inKeyBytes, circuitBytes)
+			if err != nil {
+				return err
+			}
+		}
+
+		return nil
+	})
+
+	// Return if the write succeeded.
+	if err == nil {
+		return circuitsToAdd, nil
+	}
+
+	// Otherwise, rollback the circuits added to the pending set if the
+	// write failed.
+	cm.mtx.Lock()
+	for _, circuit := range circuitsToAdd {
+		inKey := circuit.InKey()
+		if _, ok := cm.pending[inKey]; !ok {
+			delete(cm.pending, inKey)
+		}
+	}
+	cm.mtx.Unlock()
+
+	return nil, err
+}
+
+// SetKeystone sets the outgoing circuit key for the circuit identified by
+// inKey, persistently marking the circuit as opened. After the changes have
+// been persisted, the circuit map's in-memory indexes are updated so that this
+// circuit can be queried using LookupByKeystone or LookupByPaymentHash.
+func (cm *circuitMap) SetKeystone(inKey, outKey CircuitKey) error {
+	cm.mtx.Lock()
+	defer cm.mtx.Unlock()
+
+	if _, ok := cm.opened[outKey]; ok {
+		return ErrDuplicateKeystone
+	}
+
+	circuit, ok := cm.pending[inKey]
+	if !ok {
+		return ErrUnknownCircuit
+	}
+
+	if err := cm.db.Update(func(tx *bolt.Tx) error {
+		// Now, load the circuit bucket to which we will write the
+		// already serialized circuit.
+		keystoneBkt := tx.Bucket(circuitKeystoneKey)
+		if keystoneBkt == nil {
+			return ErrCorruptedCircuitMap
+		}
+
+		return keystoneBkt.Put(outKey.Bytes(), inKey.Bytes())
+	}); err != nil {
+		return err
+	}
+
+	// Since our persistent operation was successful, we can now modify the
+	// in memory representations. Set the outgoing circuit key on our
+	// pending circuit, add the same circuit to set of opened circuits, and
+	// add this circuit to the hash index.
+	circuit.Outgoing = &CircuitKey{}
+	*circuit.Outgoing = outKey
+
+	cm.opened[outKey] = circuit
+	cm.addCircuitToHashIndex(circuit)
+
+	return nil
+}
+
+// addCirciutToHashIndex inserts a circuit into the circuit map's hash index, so
+// that it can be queried using LookupByPaymentHash.
+func (cm *circuitMap) addCircuitToHashIndex(c *PaymentCircuit) {
+	if _, ok := cm.hashIndex[c.PaymentHash]; !ok {
+		cm.hashIndex[c.PaymentHash] = make(map[CircuitKey]struct{})
+	}
+	cm.hashIndex[c.PaymentHash][c.OutKey()] = struct{}{}
+}
+
+// Delete destroys the target circuit by removing it from the circuit map,
+// additionally removing the circuit's keystone if the HTLC was forwarded
+// through an outgoing link. The circuit should be identified by its incoming
+// circuit key.
+func (cm *circuitMap) Delete(inKey CircuitKey) error {
+	cm.mtx.Lock()
+	defer cm.mtx.Unlock()
+
+	circuit, ok := cm.pending[inKey]
+	if !ok {
+		return ErrUnknownCircuit
+	}
+
+	if err := cm.db.Update(func(tx *bolt.Tx) error {
+		// If this htlc made it to an outgoing link, load the keystone
+		// bucket from which we will remove the outgoing circuit key.
+		if circuit.HasKeystone() {
+			keystoneBkt := tx.Bucket(circuitKeystoneKey)
+			if keystoneBkt == nil {
+				return ErrCorruptedCircuitMap
+			}
+
+			outKey := circuit.OutKey()
+
+			err := keystoneBkt.Delete(outKey.Bytes())
+			if err != nil {
+				return err
+			}
+		}
+
+		// Remove the circuit itself based on the incoming circuit key.
+		circuitBkt := tx.Bucket(circuitAddKey)
+		if circuitBkt == nil {
+			return ErrCorruptedCircuitMap
+		}
+
+		return circuitBkt.Delete(inKey.Bytes())
+	}); err != nil {
+		return err
+	}
+
+	// With the persistent changes made, remove all references to this
+	// circuit from memory.
+	delete(cm.pending, inKey)
+
+	if circuit.HasKeystone() {
+		delete(cm.opened, circuit.OutKey())
+		cm.removeCircuitFromHashIndex(circuit)
+	}
+
+	return nil
+}
+
+// removeCircuitFromHashIndex removes the given circuit from the hash index,
+// pruning any unnecessary memory optimistically.
+func (cm *circuitMap) removeCircuitFromHashIndex(c *PaymentCircuit) {
+	// Locate bucket containing this circuit's payment hashes.
+	circuitsWithHash, ok := cm.hashIndex[c.PaymentHash]
+	if !ok {
+		return
+	}
+
+	// Check that this circuit is a member of the set of circuit's with this
+	// payment hash.
+	outKey := c.OutKey()
+	if _, ok = circuitsWithHash[outKey]; !ok {
+		return
+	}
+
+	// If found, remove this circuit from the set.
+	delete(circuitsWithHash, outKey)
+
+	// Prune the payment hash bucket if no other entries remain.
+	if len(circuitsWithHash) == 0 {
+		delete(cm.hashIndex, c.PaymentHash)
+	}
+}
+
+// NumPending returns the number of active circuits added to the circuit map.
+func (cm *circuitMap) NumPending() int {
+	cm.mtx.RLock()
+	defer cm.mtx.RUnlock()
+
+	return len(cm.pending)
+}
+
+// NumOpen returns the number of circuits that have been opened by way of
+// setting their keystones. This is the number of HTLCs that are waiting for a
+// settle/fail response from a remote peer.
+func (cm *circuitMap) NumOpen() int {
+	cm.mtx.RLock()
+	defer cm.mtx.RUnlock()
+
+	return len(cm.opened)
+}

--- a/htlcswitch/circuit_test.go
+++ b/htlcswitch/circuit_test.go
@@ -1,155 +1,524 @@
 package htlcswitch_test
 
 import (
+	"bytes"
+	"io/ioutil"
+	"reflect"
 	"testing"
 
+	"github.com/lightningnetwork/lnd/channeldb"
 	"github.com/lightningnetwork/lnd/htlcswitch"
 	"github.com/lightningnetwork/lnd/lnwire"
+	"github.com/roasbeef/btcutil"
 )
 
-func TestCircuitMap(t *testing.T) {
+var (
+	hash1 = [32]byte{0x01}
+	hash2 = [32]byte{0x02}
+	hash3 = [32]byte{0x03}
+)
+
+func TestCircuitMapInit(t *testing.T) {
 	t.Parallel()
 
-	var hash1, hash2, hash3 [32]byte
-	hash1[0] = 1
-	hash2[0] = 2
-	hash3[0] = 3
+	// Initialize new database for circuit map.
+	cdb := makeCircuitDB(t, "")
+	_, err := htlcswitch.NewCircuitMap(cdb)
+	if err != nil {
+		t.Fatalf("unable to create persistent circuit map: %v", err)
+	}
+
+	restartCircuitMap(t, cdb)
+}
+
+var halfCircuitTests = []struct {
+	hash      [32]byte
+	inValue   btcutil.Amount
+	outValue  btcutil.Amount
+	chanID    lnwire.ShortChannelID
+	htlcID    uint64
+	encrypter htlcswitch.ErrorEncrypter
+}{
+	{
+		hash:      hash1,
+		inValue:   0,
+		outValue:  1000,
+		chanID:    lnwire.NewShortChanIDFromInt(1),
+		htlcID:    1,
+		encrypter: nil,
+	},
+	{
+		hash:      hash2,
+		inValue:   2100,
+		outValue:  2000,
+		chanID:    lnwire.NewShortChanIDFromInt(2),
+		htlcID:    2,
+		encrypter: htlcswitch.NewMockObfuscator(),
+	},
+	{
+		hash:      hash3,
+		inValue:   10000,
+		outValue:  9000,
+		chanID:    lnwire.NewShortChanIDFromInt(3),
+		htlcID:    3,
+		encrypter: htlcswitch.NewSphinxErrorEncrypter(),
+	},
+}
+
+// TestHalfCircuitSerialization checks that the half circuits can be properly
+// encoded and decoded properly. A critical responsibility of this test is to
+// verify that the various ErrorEncrypter implementations can be properly
+// reconstructed from a serialized half circuit.
+func TestHalfCircuitSerialization(t *testing.T) {
+	for i, test := range halfCircuitTests {
+		circuit := &htlcswitch.PaymentCircuit{
+			PaymentHash:    test.hash,
+			IncomingAmount: lnwire.NewMSatFromSatoshis(test.inValue),
+			OutgoingAmount: lnwire.NewMSatFromSatoshis(test.outValue),
+			Incoming: htlcswitch.CircuitKey{
+				ChanID: test.chanID,
+				HtlcID: test.htlcID,
+			},
+			ErrorEncrypter: test.encrypter,
+		}
+
+		// Write the half circuit to our buffer.
+		var b bytes.Buffer
+		if err := circuit.Encode(&b); err != nil {
+			t.Fatalf("unable to encode half payment circuit test=%d: %v", i, err)
+		}
+
+		// Then try to decode the serialized bytes.
+		var circuit2 htlcswitch.PaymentCircuit
+		circuitReader := bytes.NewReader(b.Bytes())
+		if err := circuit2.Decode(circuitReader); err != nil {
+			t.Fatalf("unable to decode half payment circuit test=%d: %v", i, err)
+		}
+
+		// Reconstructed half circuit should match the original.
+		if !reflect.DeepEqual(circuit, &circuit2) {
+			t.Fatalf("unexpected half circuit test=%d, want %v, got %v",
+				i, circuit, circuit2)
+		}
+	}
+}
+
+func TestCircuitMapPersistence(t *testing.T) {
+	t.Parallel()
 
 	var (
-		chan1 = lnwire.NewShortChanIDFromInt(1)
-		chan2 = lnwire.NewShortChanIDFromInt(2)
+		chan1      = lnwire.NewShortChanIDFromInt(1)
+		chan2      = lnwire.NewShortChanIDFromInt(2)
+		circuitMap htlcswitch.CircuitMap
+		err        error
 	)
 
-	circuitMap := htlcswitch.NewCircuitMap()
+	cdb := makeCircuitDB(t, "")
+	circuitMap, err = htlcswitch.NewCircuitMap(cdb)
+	if err != nil {
+		t.Fatalf("unable to create persistent circuit map: %v", err)
+	}
 
-	circuit := circuitMap.LookupByHTLC(chan1, 0)
+	circuit := circuitMap.LookupCircuit(htlcswitch.CircuitKey{chan1, 0})
 	if circuit != nil {
 		t.Fatalf("LookupByHTLC returned a circuit before any were added: %v",
 			circuit)
 	}
 
+	circuit1 := &htlcswitch.PaymentCircuit{
+		Incoming: htlcswitch.CircuitKey{
+			ChanID: chan2,
+			HtlcID: 1,
+		},
+		PaymentHash:    hash1,
+		ErrorEncrypter: htlcswitch.NewMockObfuscator(),
+	}
+	if _, err := circuitMap.CommitCircuits(circuit1); err != nil {
+		t.Fatalf("unable to add half circuit: %v", err)
+	}
+
+	// Circuit map should have one circuit that has not been fully opened.
+	assertNumCircuitsWithHash(t, circuitMap, hash1, 0)
+	assertHasCircuit(t, circuitMap, circuit1)
+
+	cdb, circuitMap = restartCircuitMap(t, cdb)
+
+	assertNumCircuitsWithHash(t, circuitMap, hash1, 0)
+	assertHasCircuit(t, circuitMap, circuit1)
+
 	// Add multiple circuits with same destination channel but different HTLC
 	// IDs and payment hashes.
-	circuitMap.Add(&htlcswitch.PaymentCircuit{
-		PaymentHash:    hash1,
-		IncomingChanID: chan2,
-		IncomingHTLCID: 1,
-		OutgoingChanID: chan1,
-		OutgoingHTLCID: 0,
-	})
+	keystone1 := htlcswitch.CircuitKey{
+		ChanID: chan1,
+		HtlcID: 0,
+	}
+	circuit1.Outgoing = &keystone1
 
-	circuitMap.Add(&htlcswitch.PaymentCircuit{
+	if err := circuitMap.SetKeystone(circuit1.Incoming, keystone1); err != nil {
+		t.Fatalf("unable to add full circuit: %v", err)
+	}
+
+	// Circuit map should reflect addition of circuit1, and the change
+	// should survive a restart.
+	assertNumCircuitsWithHash(t, circuitMap, hash1, 1)
+	assertHasCircuit(t, circuitMap, circuit1)
+	assertHasKeystone(t, circuitMap, keystone1, circuit1)
+
+	cdb, circuitMap = restartCircuitMap(t, cdb)
+
+	assertNumCircuitsWithHash(t, circuitMap, hash1, 1)
+	assertHasCircuit(t, circuitMap, circuit1)
+	assertHasKeystone(t, circuitMap, keystone1, circuit1)
+
+	circuit2 := &htlcswitch.PaymentCircuit{
+		Incoming: htlcswitch.CircuitKey{
+			ChanID: chan2,
+			HtlcID: 2,
+		},
 		PaymentHash:    hash2,
-		IncomingChanID: chan2,
-		IncomingHTLCID: 2,
-		OutgoingChanID: chan1,
-		OutgoingHTLCID: 1,
-	})
+		ErrorEncrypter: htlcswitch.NewMockObfuscator(),
+	}
+	if _, err := circuitMap.CommitCircuits(circuit2); err != nil {
+		t.Fatalf("unable to add half circuit: %v", err)
+	}
+
+	assertHasCircuit(t, circuitMap, circuit2)
+
+	keystone2 := htlcswitch.CircuitKey{
+		ChanID: chan1,
+		HtlcID: 1,
+	}
+	circuit2.Outgoing = &keystone2
+
+	if err := circuitMap.SetKeystone(circuit2.Incoming, keystone2); err != nil {
+		t.Fatalf("unable to add full circuit: %v", err)
+	}
+
+	// Should have two full circuits, one under hash1 and another under
+	// hash2. Both half payment circuits should have been removed when the
+	// full circuits were added.
+	assertNumCircuitsWithHash(t, circuitMap, hash1, 1)
+	assertHasCircuit(t, circuitMap, circuit1)
+	assertHasKeystone(t, circuitMap, keystone1, circuit1)
+
+	assertNumCircuitsWithHash(t, circuitMap, hash2, 1)
+	assertHasCircuit(t, circuitMap, circuit2)
+	assertHasKeystone(t, circuitMap, keystone2, circuit2)
+
+	assertNumCircuitsWithHash(t, circuitMap, hash3, 0)
+
+	cdb, circuitMap = restartCircuitMap(t, cdb)
+
+	assertNumCircuitsWithHash(t, circuitMap, hash1, 1)
+	assertHasCircuit(t, circuitMap, circuit1)
+	assertHasKeystone(t, circuitMap, keystone1, circuit1)
+
+	assertNumCircuitsWithHash(t, circuitMap, hash2, 1)
+	assertHasCircuit(t, circuitMap, circuit2)
+	assertHasKeystone(t, circuitMap, keystone2, circuit2)
+
+	assertNumCircuitsWithHash(t, circuitMap, hash3, 0)
+
+	circuit3 := &htlcswitch.PaymentCircuit{
+		Incoming: htlcswitch.CircuitKey{
+			ChanID: chan1,
+			HtlcID: 2,
+		},
+		PaymentHash:    hash3,
+		ErrorEncrypter: htlcswitch.NewMockObfuscator(),
+	}
+	if _, err := circuitMap.CommitCircuits(circuit3); err != nil {
+		t.Fatalf("unable to add half circuit: %v", err)
+	}
+
+	assertHasCircuit(t, circuitMap, circuit3)
+	cdb, circuitMap = restartCircuitMap(t, cdb)
+	assertHasCircuit(t, circuitMap, circuit3)
 
 	// Add another circuit with an already-used HTLC ID but different
 	// destination channel.
-	circuitMap.Add(&htlcswitch.PaymentCircuit{
-		PaymentHash:    hash3,
-		IncomingChanID: chan1,
-		IncomingHTLCID: 2,
-		OutgoingChanID: chan2,
-		OutgoingHTLCID: 0,
-	})
-
-	circuit = circuitMap.LookupByHTLC(chan1, 0)
-	if circuit == nil {
-		t.Fatal("LookupByHTLC failed to find circuit")
+	keystone3 := htlcswitch.CircuitKey{
+		ChanID: chan2,
+		HtlcID: 0,
 	}
-	if circuit.PaymentHash != hash1 || circuit.IncomingHTLCID != 1 {
-		t.Fatalf("LookupByHTLC found unexpected circuit: %v", circuit)
+	circuit3.Outgoing = &keystone3
+
+	if err := circuitMap.SetKeystone(circuit3.Incoming, keystone3); err != nil {
+		t.Fatalf("unable to add full circuit: %v", err)
 	}
 
-	circuit = circuitMap.LookupByHTLC(chan1, 1)
-	if circuit == nil {
-		t.Fatal("LookupByHTLC failed to find circuit")
-	}
-	if circuit.PaymentHash != hash2 || circuit.IncomingHTLCID != 2 {
-		t.Fatalf("LookupByHTLC found unexpected circuit: %v", circuit)
-	}
+	// Check that all have been marked as full circuits, and that no half
+	// circuits are currently being tracked.
+	assertHasKeystone(t, circuitMap, keystone1, circuit1)
+	assertHasKeystone(t, circuitMap, keystone2, circuit2)
+	assertHasKeystone(t, circuitMap, keystone3, circuit3)
+	cdb, circuitMap = restartCircuitMap(t, cdb)
+	assertHasKeystone(t, circuitMap, keystone1, circuit1)
+	assertHasKeystone(t, circuitMap, keystone2, circuit2)
+	assertHasKeystone(t, circuitMap, keystone3, circuit3)
 
-	circuit = circuitMap.LookupByHTLC(chan2, 0)
-	if circuit == nil {
-		t.Fatal("LookupByHTLC failed to find circuit")
+	// Even though a circuit was added with chan1, HTLC ID 2 as the source,
+	// the lookup should go by destination channel, HTLC ID.
+	invalidKeystone := htlcswitch.CircuitKey{
+		ChanID: chan1,
+		HtlcID: 2,
 	}
-	if circuit.PaymentHash != hash3 || circuit.IncomingHTLCID != 2 {
-		t.Fatalf("LookupByHTLC found unexpected circuit: %v", circuit)
-	}
-
-	// Even though a circuit was added with chan1, HTLC ID 2 as the source, the
-	// lookup should go by destination channel, HTLC ID.
-	circuit = circuitMap.LookupByHTLC(chan1, 2)
+	circuit = circuitMap.LookupByKeystone(invalidKeystone)
 	if circuit != nil {
 		t.Fatalf("LookupByHTLC returned a circuit without being added: %v",
 			circuit)
 	}
 
+	circuit4 := &htlcswitch.PaymentCircuit{
+		Incoming: htlcswitch.CircuitKey{
+			ChanID: chan2,
+			HtlcID: 3,
+		},
+		PaymentHash:    hash1,
+		ErrorEncrypter: htlcswitch.NewMockObfuscator(),
+	}
+	if _, err := circuitMap.CommitCircuits(circuit4); err != nil {
+		t.Fatalf("unable to add half circuit: %v", err)
+	}
+
+	// Circuit map should still only show one circuit with hash1, since we
+	// have not set the keystone for circuit4.
+	assertNumCircuitsWithHash(t, circuitMap, hash1, 1)
+	assertHasCircuit(t, circuitMap, circuit4)
+
+	cdb, circuitMap = restartCircuitMap(t, cdb)
+
+	assertNumCircuitsWithHash(t, circuitMap, hash1, 1)
+	assertHasCircuit(t, circuitMap, circuit4)
+
 	// Add a circuit with a destination channel and payment hash that are
 	// already added but a different HTLC ID.
-	circuitMap.Add(&htlcswitch.PaymentCircuit{
-		PaymentHash:    hash1,
-		IncomingChanID: chan2,
-		IncomingHTLCID: 3,
-		OutgoingChanID: chan1,
-		OutgoingHTLCID: 3,
-	})
-
-	circuit = circuitMap.LookupByHTLC(chan1, 3)
-	if circuit == nil {
-		t.Fatal("LookupByHTLC failed to find circuit")
+	keystone4 := htlcswitch.CircuitKey{
+		ChanID: chan1,
+		HtlcID: 3,
 	}
-	if circuit.PaymentHash != hash1 || circuit.IncomingHTLCID != 3 {
-		t.Fatalf("LookupByHTLC found unexpected circuit: %v", circuit)
+	circuit4.Outgoing = &keystone4
+
+	if err := circuitMap.SetKeystone(circuit4.Incoming, keystone4); err != nil {
+		t.Fatalf("unable to add full circuit: %v", err)
 	}
 
-	// Check lookups by payment hash.
-	circuits := circuitMap.LookupByPaymentHash(hash1)
-	if len(circuits) != 2 {
-		t.Fatalf("LookupByPaymentHash returned wrong number of circuits for "+
-			"hash1: expected %d, got %d", 2, len(circuits))
-	}
+	// Verify that all circuits have been fully added.
+	assertHasCircuit(t, circuitMap, circuit1)
+	assertHasKeystone(t, circuitMap, keystone1, circuit1)
+	assertHasCircuit(t, circuitMap, circuit2)
+	assertHasKeystone(t, circuitMap, keystone2, circuit2)
+	assertHasCircuit(t, circuitMap, circuit3)
+	assertHasKeystone(t, circuitMap, keystone3, circuit3)
+	assertHasCircuit(t, circuitMap, circuit4)
+	assertHasKeystone(t, circuitMap, keystone4, circuit4)
 
-	circuits = circuitMap.LookupByPaymentHash(hash2)
-	if len(circuits) != 1 {
-		t.Fatalf("LookupByPaymentHash returned wrong number of circuits for "+
-			"hash2: expected %d, got %d", 1, len(circuits))
-	}
+	// Verify that each circuit is exposed via the proper hash bucketing.
+	assertNumCircuitsWithHash(t, circuitMap, hash1, 2)
+	assertHasCircuitForHash(t, circuitMap, hash1, circuit1)
+	assertHasCircuitForHash(t, circuitMap, hash1, circuit4)
+
+	assertNumCircuitsWithHash(t, circuitMap, hash2, 1)
+	assertHasCircuitForHash(t, circuitMap, hash2, circuit2)
+
+	assertNumCircuitsWithHash(t, circuitMap, hash3, 1)
+	assertHasCircuitForHash(t, circuitMap, hash3, circuit3)
+
+	// Restart, then run checks again.
+	cdb, circuitMap = restartCircuitMap(t, cdb)
+
+	// Verify that all circuits have been fully added.
+	assertHasCircuit(t, circuitMap, circuit1)
+	assertHasKeystone(t, circuitMap, keystone1, circuit1)
+	assertHasCircuit(t, circuitMap, circuit2)
+	assertHasKeystone(t, circuitMap, keystone2, circuit2)
+	assertHasCircuit(t, circuitMap, circuit3)
+	assertHasKeystone(t, circuitMap, keystone3, circuit3)
+	assertHasCircuit(t, circuitMap, circuit4)
+	assertHasKeystone(t, circuitMap, keystone4, circuit4)
+
+	// Verify that each circuit is exposed via the proper hash bucketing.
+	assertNumCircuitsWithHash(t, circuitMap, hash1, 2)
+	assertHasCircuitForHash(t, circuitMap, hash1, circuit1)
+	assertHasCircuitForHash(t, circuitMap, hash1, circuit4)
+
+	assertNumCircuitsWithHash(t, circuitMap, hash2, 1)
+	assertHasCircuitForHash(t, circuitMap, hash2, circuit2)
+
+	assertNumCircuitsWithHash(t, circuitMap, hash3, 1)
+	assertHasCircuitForHash(t, circuitMap, hash3, circuit3)
 
 	// Test removing circuits and the subsequent lookups.
-	err := circuitMap.Remove(chan1, 0)
+	err = circuitMap.Delete(circuit1.Incoming)
 	if err != nil {
 		t.Fatalf("Remove returned unexpected error: %v", err)
 	}
 
-	circuits = circuitMap.LookupByPaymentHash(hash1)
-	if len(circuits) != 1 {
-		t.Fatalf("LookupByPaymentHash returned wrong number of circuits for "+
-			"hash1: expecected %d, got %d", 1, len(circuits))
-	}
-	if circuits[0].OutgoingHTLCID != 3 {
-		t.Fatalf("LookupByPaymentHash returned wrong circuit for hash1: %v",
-			circuits[0])
-	}
+	// There should be exactly one remaining circuit with hash1, and it
+	// should be circuit4.
+	assertNumCircuitsWithHash(t, circuitMap, hash1, 1)
+	assertHasCircuitForHash(t, circuitMap, hash1, circuit4)
+	cdb, circuitMap = restartCircuitMap(t, cdb)
+	assertNumCircuitsWithHash(t, circuitMap, hash1, 1)
+	assertHasCircuitForHash(t, circuitMap, hash1, circuit4)
 
 	// Removing already-removed circuit should return an error.
-	err = circuitMap.Remove(chan1, 0)
+	err = circuitMap.Delete(circuit1.Incoming)
 	if err == nil {
 		t.Fatal("Remove did not return expected not found error")
 	}
 
+	// Verify that nothing related to hash1 has changed
+	assertNumCircuitsWithHash(t, circuitMap, hash1, 1)
+	assertHasCircuitForHash(t, circuitMap, hash1, circuit4)
+
 	// Remove last remaining circuit with payment hash hash1.
-	err = circuitMap.Remove(chan1, 3)
+	err = circuitMap.Delete(circuit4.Incoming)
 	if err != nil {
 		t.Fatalf("Remove returned unexpected error: %v", err)
 	}
 
-	circuits = circuitMap.LookupByPaymentHash(hash1)
-	if len(circuits) != 0 {
-		t.Fatalf("LookupByPaymentHash returned wrong number of circuits for "+
-			"hash1: expecected %d, got %d", 0, len(circuits))
+	assertNumCircuitsWithHash(t, circuitMap, hash1, 0)
+	assertNumCircuitsWithHash(t, circuitMap, hash2, 1)
+	assertNumCircuitsWithHash(t, circuitMap, hash3, 1)
+	cdb, circuitMap = restartCircuitMap(t, cdb)
+	assertNumCircuitsWithHash(t, circuitMap, hash1, 0)
+	assertNumCircuitsWithHash(t, circuitMap, hash2, 1)
+	assertNumCircuitsWithHash(t, circuitMap, hash3, 1)
+
+	// Remove last remaining circuit with payment hash hash2.
+	err = circuitMap.Delete(circuit2.Incoming)
+	if err != nil {
+		t.Fatalf("Remove returned unexpected error: %v", err)
 	}
+
+	// There should now only be one remaining circuit, with hash3.
+	assertNumCircuitsWithHash(t, circuitMap, hash2, 0)
+	assertNumCircuitsWithHash(t, circuitMap, hash3, 1)
+	cdb, circuitMap = restartCircuitMap(t, cdb)
+	assertNumCircuitsWithHash(t, circuitMap, hash2, 0)
+	assertNumCircuitsWithHash(t, circuitMap, hash3, 1)
+
+	// Remove last remaining circuit with payment hash hash3.
+	err = circuitMap.Delete(circuit3.Incoming)
+	if err != nil {
+		t.Fatalf("Remove returned unexpected error: %v", err)
+	}
+
+	// Check that the circuit map is empty, even after restarting.
+	assertNumCircuitsWithHash(t, circuitMap, hash3, 0)
+	cdb, circuitMap = restartCircuitMap(t, cdb)
+	assertNumCircuitsWithHash(t, circuitMap, hash3, 0)
+}
+
+// assertHasKeystone tests that the circuit map contains the provided payment
+// circuit.
+func assertHasKeystone(t *testing.T, cm htlcswitch.CircuitMap,
+	outKey htlcswitch.CircuitKey, c *htlcswitch.PaymentCircuit) {
+
+	circuit := cm.LookupByKeystone(outKey)
+	if !reflect.DeepEqual(circuit, c) {
+		t.Fatalf("unexpected circuit, want: %v, got %v", c, circuit)
+	}
+}
+
+// assertDoesNotHaveKeystone tests that the circuit map does not contain a
+// circuit for the provided outgoing circuit key.
+func assertDoesNotHaveKeystone(t *testing.T, cm htlcswitch.CircuitMap,
+	outKey htlcswitch.CircuitKey) {
+
+	circuit := cm.LookupByKeystone(outKey)
+	if circuit != nil {
+		t.Fatalf("expected no circuit for keystone %s, found %v",
+			outKey, circuit)
+	}
+}
+
+// assertHasCircuitForHash tests that the provided circuit appears in the list
+// of circuits for the given hash.
+func assertHasCircuitForHash(t *testing.T, cm htlcswitch.CircuitMap, hash [32]byte,
+	circuit *htlcswitch.PaymentCircuit) {
+
+	circuits := cm.LookupByPaymentHash(hash)
+	for _, c := range circuits {
+		if reflect.DeepEqual(c, circuit) {
+			return
+		}
+	}
+
+	t.Fatalf("unable to find circuit: %v by hash: %v", circuit, hash)
+}
+
+// assertNumCircuitsWithHash tests that the circuit has the right number of full
+// circuits, indexed by the given hash.
+func assertNumCircuitsWithHash(t *testing.T, cm htlcswitch.CircuitMap,
+	hash [32]byte, expectedNum int) {
+
+	circuits := cm.LookupByPaymentHash(hash)
+	if len(circuits) != expectedNum {
+		t.Fatalf("LookupByPaymentHash returned wrong number of circuits for "+
+			"hash=%v: expecected %d, got %d", hash, expectedNum,
+			len(circuits))
+	}
+}
+
+// assertHasCircuit queries the circuit map using the half-circuit's half
+// key, and fails if the returned half-circuit differs from the provided one.
+func assertHasCircuit(t *testing.T, cm htlcswitch.CircuitMap,
+	c *htlcswitch.PaymentCircuit) {
+
+	c2 := cm.LookupCircuit(c.Incoming)
+	if !reflect.DeepEqual(c, c2) {
+		t.Fatalf("expected circuit: %v, got %v", c, c2)
+	}
+}
+
+// assertDoesNotHaveCircuit queries the circuit map using the circuit's
+// incoming circuit key, and fails if it is found.
+func assertDoesNotHaveCircuit(t *testing.T, cm htlcswitch.CircuitMap,
+	c *htlcswitch.PaymentCircuit) {
+
+	c2 := cm.LookupCircuit(c.Incoming)
+	if c2 != nil {
+		t.Fatalf("expected no circuit for %v, got %v", c, c2)
+	}
+}
+
+// makeCircuitDB initializes a new test channeldb for testing the persistence of
+// the circuit map. If an empty string is provided as a path, a temp directory
+// will be created.
+func makeCircuitDB(t *testing.T, path string) *channeldb.DB {
+	if path == "" {
+		var err error
+		path, err = ioutil.TempDir("", "circuitdb")
+		if err != nil {
+			t.Fatalf("unable to create temp path: %v", err)
+		}
+	}
+
+	db, err := channeldb.Open(path)
+	if err != nil {
+		t.Fatalf("unable to open channel db: %v", err)
+	}
+
+	return db
+}
+
+// Creates a new circuit map, backed by a freshly opened channeldb. The existing
+// channeldb is closed in order to simulate a complete restart.
+func restartCircuitMap(t *testing.T, cdb *channeldb.DB) (*channeldb.DB,
+	htlcswitch.CircuitMap) {
+
+	// Record the current temp path and close current db.
+	dbPath := cdb.Path()
+	cdb.Close()
+
+	// Reinitialize circuit map with same db path.
+	cdb2 := makeCircuitDB(t, dbPath)
+	cm2, err := htlcswitch.NewCircuitMap(cdb2)
+	if err != nil {
+		t.Fatalf("unable to recreate persistent circuit map: %v", err)
+	}
+
+	return cdb2, cm2
 }

--- a/htlcswitch/default_log.go
+++ b/htlcswitch/default_log.go
@@ -1,0 +1,8 @@
+// + build !stdlog
+
+package htlcswitch
+
+// The default amount of logging is none.
+func init() {
+	DisableLog()
+}

--- a/htlcswitch/failure.go
+++ b/htlcswitch/failure.go
@@ -3,6 +3,7 @@ package htlcswitch
 import (
 	"bytes"
 	"fmt"
+	"io"
 
 	"github.com/lightningnetwork/lightning-onion"
 	"github.com/lightningnetwork/lnd/lnwire"
@@ -45,6 +46,32 @@ type ErrorDecrypter interface {
 	DecryptError(lnwire.OpaqueReason) (*ForwardingError, error)
 }
 
+// EncrypterType establishes an enum used in serialization to indicate how to
+// decode a concrete instance of the ErrorEncrypter interface.
+type EncrypterType byte
+
+const (
+	// EncrypterTypeNone signals that no error encyrpter is present, this
+	// can happen if the htlc is originates in the switch.
+	EncrypterTypeNone EncrypterType = iota
+
+	// EncrypterTypeSphinx is used to identify a sphinx onion error
+	// encrypter instance.
+	EncrypterTypeSphinx
+
+	// EncrypterTypeMock is used to identify a mock obfuscator instance.
+	EncrypterTypeMock
+)
+
+// UnknownEncrypterType is an error message used to signal that an unexpected
+// EncrypterType was encountered during decoding.
+type UnknownEncrypterType EncrypterType
+
+// Error returns a formatted error indicating the invalid EncrypterType.
+func (e UnknownEncrypterType) Error() string {
+	return fmt.Sprintf("unknown error encrypter type: %d", e)
+}
+
 // ErrorEncrypter is an interface that is used to encrypt HTLC related errors
 // at the source of the error, and also at each intermediate hop all the way
 // back to the source of the payment.
@@ -59,6 +86,16 @@ type ErrorEncrypter interface {
 	// in an additional layer of onion encryption. This process repeats
 	// until the error arrives at the source of the payment.
 	IntermediateEncrypt(lnwire.OpaqueReason) lnwire.OpaqueReason
+
+	// Type returns an enum indicating the underlying concrete instance
+	// backing this interface.
+	Type() EncrypterType
+
+	// Encode serializes the encrypter to the given io.Writer.
+	Encode(io.Writer) error
+
+	// Decode deserializes the encrypter from the given io.Reader.
+	Decode(io.Reader) error
 }
 
 // SphinxErrorEncrypter is a concrete implementation of both the ErrorEncrypter
@@ -67,6 +104,14 @@ type ErrorEncrypter interface {
 // encryption and must be treated as such accordingly.
 type SphinxErrorEncrypter struct {
 	*sphinx.OnionErrorEncrypter
+}
+
+// NewSphinxErrorEncrypter initializes a new sphinx error encrypter as well as
+// the embedded onion error encrypter.
+func NewSphinxErrorEncrypter() *SphinxErrorEncrypter {
+	return &SphinxErrorEncrypter{
+		&sphinx.OnionErrorEncrypter{},
+	}
 }
 
 // EncryptFirstHop transforms a concrete failure message into an encrypted
@@ -95,6 +140,24 @@ func (s *SphinxErrorEncrypter) EncryptFirstHop(failure lnwire.FailureMessage) (l
 // NOTE: Part of the ErrorEncrypter interface.
 func (s *SphinxErrorEncrypter) IntermediateEncrypt(reason lnwire.OpaqueReason) lnwire.OpaqueReason {
 	return s.EncryptError(false, reason)
+}
+
+// Type returns the identifier for a sphinx error encrypter.
+func (s *SphinxErrorEncrypter) Type() EncrypterType {
+	return EncrypterTypeSphinx
+}
+
+// Encode serializes the error encrypter to the provided io.Writer.
+func (s *SphinxErrorEncrypter) Encode(w io.Writer) error {
+	return s.OnionErrorEncrypter.Encode(w)
+}
+
+// Decode reconstructs the error encrypter from the provided io.Reader.
+func (s *SphinxErrorEncrypter) Decode(r io.Reader) error {
+	if s.OnionErrorEncrypter == nil {
+		s.OnionErrorEncrypter = &sphinx.OnionErrorEncrypter{}
+	}
+	return s.OnionErrorEncrypter.Decode(r)
 }
 
 // A compile time check to ensure SphinxErrorEncrypter implements the

--- a/htlcswitch/interfaces.go
+++ b/htlcswitch/interfaces.go
@@ -47,7 +47,7 @@ type ChannelLink interface {
 	//
 	// NOTE: This function MUST be non-blocking (or block as little as
 	// possible).
-	HandleSwitchPacket(*htlcPacket)
+	HandleSwitchPacket(*htlcPacket) error
 
 	// HandleChannelUpdate handles the htlc requests as settle/add/fail
 	// which sent to us from remote peer we have a channel with.

--- a/htlcswitch/iterator.go
+++ b/htlcswitch/iterator.go
@@ -40,6 +40,10 @@ var (
 	// exitHop is a special "hop" which denotes that an incoming HTLC is
 	// meant to pay finally to the receiving node.
 	exitHop lnwire.ShortChannelID
+
+	// sourceHop is a sentinel value denoting that an incoming HTLC is
+	// initiated by our own switch.
+	sourceHop lnwire.ShortChannelID
 )
 
 // ForwardingInfo contains all the information that is necessary to forward and

--- a/htlcswitch/link.go
+++ b/htlcswitch/link.go
@@ -864,7 +864,7 @@ func (l *channelLink) handleDownStreamPkt(pkt *htlcPacket, isReProcess bool) {
 					incomingChanID: pkt.incomingChanID,
 					incomingHTLCID: pkt.incomingHTLCID,
 					amount:         htlc.Amount,
-					isRouted:       true,
+					hasSource:      true,
 					localFailure:   localFailure,
 					htlc: &lnwire.UpdateFailHTLC{
 						Reason: reason,
@@ -882,18 +882,20 @@ func (l *channelLink) handleDownStreamPkt(pkt *htlcPacket, isReProcess bool) {
 			"local_log_index=%v, batch_size=%v",
 			htlc.PaymentHash[:], index, l.batchCounter+1)
 
+		pkt.outgoingChanID = l.ShortChanID()
+		pkt.outgoingHTLCID = index
+		htlc.ID = index
+
+		log.Debugf("Persisting keystone to create open circuit: %v->%v",
+			pkt.inKey(), pkt.outKey())
+
 		// Create circuit (remember the path) in order to forward settle/fail
 		// packet back.
-		l.cfg.Switch.addCircuit(&PaymentCircuit{
-			PaymentHash:    htlc.PaymentHash,
-			IncomingChanID: pkt.incomingChanID,
-			IncomingHTLCID: pkt.incomingHTLCID,
-			OutgoingChanID: l.ShortChanID(),
-			OutgoingHTLCID: index,
-			ErrorEncrypter: pkt.obfuscator,
-		})
+		if err := l.cfg.Switch.setKeystone(pkt.inKey(), pkt.outKey()); err != nil {
+			l.fail("unable to add full circuit: %v", err)
+			return
+		}
 
-		htlc.ID = index
 		l.cfg.Peer.SendMessage(htlc)
 
 	case *lnwire.UpdateFulfillHTLC:
@@ -1130,18 +1132,28 @@ func (l *channelLink) handleUpstreamMsg(msg lnwire.Message) {
 		// htlc switch or settled if our node was last node in htlc
 		// path.
 		htlcsToForward := l.processLockedInHtlcs(htlcs)
+
+		log.Debugf("ChannelPoint(%v) forwarding %v HTLC's",
+			l.channel.ChannelPoint(), len(htlcsToForward))
+
+		errChan := l.cfg.Switch.forwardBatch(htlcsToForward...)
+
 		go func() {
-			log.Debugf("ChannelPoint(%v) forwarding %v HTLC's",
-				l.channel.ChannelPoint(), len(htlcsToForward))
-			for _, packet := range htlcsToForward {
-				if err := l.cfg.Switch.forward(packet); err != nil {
-					// TODO(roasbeef): cancel back htlc
-					// under certain conditions?
-					log.Errorf("channel link(%v): "+
-						"unhandled error while forwarding "+
-						"htlc packet over htlc  "+
-						"switch: %v", l, err)
+			for {
+				err, ok := <-errChan
+				if !ok {
+					// Err chan has been drained or switch
+					// is shutting down.  Either way,
+					// return.
+					return
+				} else if err == nil {
+					// Successfully forwarded.
+					continue
 				}
+
+				log.Errorf("channel link(%v): unhandled error "+
+					"while forwarding htlc packet over "+
+					"htlcswitch: %v", l, err)
 			}
 		}()
 
@@ -1334,8 +1346,11 @@ func (l *channelLink) String() string {
 // another peer or if the update was created by user
 //
 // NOTE: Part of the ChannelLink interface.
-func (l *channelLink) HandleSwitchPacket(packet *htlcPacket) {
-	l.mailBox.AddPacket(packet)
+func (l *channelLink) HandleSwitchPacket(pkt *htlcPacket) error {
+	log.Debugf("ChannelLink(%s) received switch packet inkey=%v, outkey=%v",
+		l.ShortChanID(), pkt.inKey(), pkt.outKey())
+	l.mailBox.AddPacket(pkt)
+	return nil
 }
 
 // HandleChannelUpdate handles the htlc requests as settle/add/fail which sent
@@ -1822,6 +1837,7 @@ func (l *channelLink) processLockedInHtlcs(
 					incomingChanID: l.ShortChanID(),
 					incomingHTLCID: pd.HtlcIndex,
 					outgoingChanID: fwdInfo.NextHop,
+					incomingAmount: pd.Amount,
 					amount:         addMsg.Amount,
 					htlc:           addMsg,
 					obfuscator:     obfuscator,

--- a/htlcswitch/link_test.go
+++ b/htlcswitch/link_test.go
@@ -1429,7 +1429,7 @@ func newSingleLinkTestHarness(chanAmt, chanReserve btcutil.Amount) (
 	var (
 		invoiceRegistry = newMockRegistry()
 		decoder         = &mockIteratorDecoder{}
-		obfuscator      = newMockObfuscator()
+		obfuscator      = NewMockObfuscator()
 		alicePeer       = &mockPeer{
 			sentMsgs: make(chan lnwire.Message, 2000),
 			quit:     make(chan struct{}),
@@ -1451,14 +1451,14 @@ func newSingleLinkTestHarness(chanAmt, chanReserve btcutil.Amount) (
 
 	aliceSwitch, err := New(Config{DB: aliceDb})
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, nil, nil, err
 	}
 
 	t := make(chan time.Time)
 	ticker := &mockTicker{t}
 	aliceCfg := ChannelLinkConfig{
 		FwrdingPolicy:     globalPolicy,
-		Peer:              &alicePeer,
+		Peer:              alicePeer,
 		Switch:            aliceSwitch,
 		DecodeHopIterator: decoder.DecodeHopIterator,
 		DecodeOnionObfuscator: func(io.Reader) (ErrorEncrypter, lnwire.FailCode) {
@@ -1671,7 +1671,7 @@ func TestChannelLinkBandwidthConsistency(t *testing.T) {
 
 	// We'll start the test by creating a single instance of
 	const chanAmt = btcutil.SatoshiPerBitcoin * 5
-	link, bobChannel, tmr, cleanUp, err := newSingleLinkTestHarness(chanAmt, 0)
+	aliceLink, bobChannel, tmr, cleanUp, err := newSingleLinkTestHarness(chanAmt, 0)
 	if err != nil {
 		t.Fatalf("unable to create link: %v", err)
 	}
@@ -1684,13 +1684,13 @@ func TestChannelLinkBandwidthConsistency(t *testing.T) {
 		coreLink               = aliceLink.(*channelLink)
 		defaultCommitFee       = coreChan.StateSnapshot().CommitFee
 		aliceStartingBandwidth = aliceLink.Bandwidth()
-		aliceMsgs              = aliceLink.cfg.Peer.(*mockPeer).sentMsgs
+		aliceMsgs              = coreLink.cfg.Peer.(*mockPeer).sentMsgs
 	)
 
 	// We put Alice into HodlHTLC mode, such that she won't settle
 	// incoming HTLCs automatically.
-	aliceLink.cfg.HodlHTLC = true
-	aliceLink.cfg.DebugHTLC = true
+	coreLink.cfg.HodlHTLC = true
+	coreLink.cfg.DebugHTLC = true
 
 	estimator := &lnwallet.StaticFeeEstimator{
 		FeeRate: 24,
@@ -1756,7 +1756,7 @@ func TestChannelLinkBandwidthConsistency(t *testing.T) {
 	}
 
 	// Lock in the HTLC.
-	if err := updateState(tmr, aliceLink, bobChannel, true); err != nil {
+	if err := updateState(tmr, coreLink, bobChannel, true); err != nil {
 		t.Fatalf("unable to update state: %v", err)
 	}
 
@@ -1782,7 +1782,7 @@ func TestChannelLinkBandwidthConsistency(t *testing.T) {
 	assertLinkBandwidth(t, aliceLink, aliceStartingBandwidth-htlcAmt-htlcFee)
 
 	// Lock in the settle.
-	if err := updateState(tmr, aliceLink, bobChannel, false); err != nil {
+	if err := updateState(tmr, coreLink, bobChannel, false); err != nil {
 		t.Fatalf("unable to update state: %v", err)
 	}
 
@@ -1837,7 +1837,7 @@ func TestChannelLinkBandwidthConsistency(t *testing.T) {
 	}
 
 	// Lock in the HTLC, which should not affect the bandwidth.
-	if err := updateState(tmr, aliceLink, bobChannel, true); err != nil {
+	if err := updateState(tmr, coreLink, bobChannel, true); err != nil {
 		t.Fatalf("unable to update state: %v", err)
 	}
 
@@ -1861,7 +1861,7 @@ func TestChannelLinkBandwidthConsistency(t *testing.T) {
 	assertLinkBandwidth(t, aliceLink, aliceStartingBandwidth-htlcAmt*2-htlcFee)
 
 	// Lock in the Fail.
-	if err := updateState(tmr, aliceLink, bobChannel, false); err != nil {
+	if err := updateState(tmr, coreLink, bobChannel, false); err != nil {
 		t.Fatalf("unable to update state: %v", err)
 	}
 
@@ -1878,7 +1878,7 @@ func TestChannelLinkBandwidthConsistency(t *testing.T) {
 	// remain unchanged (but Alice will need to pay the fee for the extra
 	// HTLC).
 	htlcAmt, totalTimelock, hops := generateHops(htlcAmt, testStartingHeight,
-		aliceLink)
+		coreLink)
 	blob, err := generateRoute(hops...)
 	if err != nil {
 		t.Fatalf("unable to gen route: %v", err)
@@ -1891,7 +1891,7 @@ func TestChannelLinkBandwidthConsistency(t *testing.T) {
 
 	// We must add the invoice to the registry, such that Alice expects
 	// this payment.
-	err = aliceLink.cfg.Registry.(*mockInvoiceRegistry).AddInvoice(*invoice)
+	err = coreLink.cfg.Registry.(*mockInvoiceRegistry).AddInvoice(*invoice)
 	if err != nil {
 		t.Fatalf("unable to add invoice to registry: %v", err)
 	}
@@ -1906,7 +1906,7 @@ func TestChannelLinkBandwidthConsistency(t *testing.T) {
 	assertLinkBandwidth(t, aliceLink, aliceStartingBandwidth-htlcAmt)
 
 	// Lock in the HTLC.
-	if err := updateState(tmr, aliceLink, bobChannel, false); err != nil {
+	if err := updateState(tmr, coreLink, bobChannel, false); err != nil {
 		t.Fatalf("unable to update state: %v", err)
 	}
 
@@ -1914,13 +1914,13 @@ func TestChannelLinkBandwidthConsistency(t *testing.T) {
 	assertLinkBandwidth(t, aliceLink, aliceStartingBandwidth-htlcAmt-htlcFee)
 
 	addPkt = htlcPacket{
-		htlc:           updateMsg,
+		htlc:           htlc,
 		incomingChanID: aliceLink.ShortChanID(),
 		incomingHTLCID: 0,
 		obfuscator:     NewMockObfuscator(),
 	}
 
-	circuit = makePaymentCircuit(&updateMsg.PaymentHash, &addPkt)
+	circuit = makePaymentCircuit(&htlc.PaymentHash, &addPkt)
 	_, err = coreLink.cfg.Switch.commitCircuits(&circuit)
 	if err != nil {
 		t.Fatalf("unable to commit circuit: %v", err)
@@ -1967,7 +1967,7 @@ func TestChannelLinkBandwidthConsistency(t *testing.T) {
 	// Finally, we'll test the scenario of failing an HTLC received by the
 	// remote node. This should result in no perceived bandwidth changes.
 	htlcAmt, totalTimelock, hops = generateHops(htlcAmt, testStartingHeight,
-		aliceLink)
+		coreLink)
 	blob, err = generateRoute(hops...)
 	if err != nil {
 		t.Fatalf("unable to gen route: %v", err)
@@ -1976,7 +1976,8 @@ func TestChannelLinkBandwidthConsistency(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unable to create payment: %v", err)
 	}
-	if err := aliceLink.cfg.Registry.(*mockInvoiceRegistry).AddInvoice(*invoice); err != nil {
+	err = coreLink.cfg.Registry.(*mockInvoiceRegistry).AddInvoice(*invoice)
+	if err != nil {
 		t.Fatalf("unable to add invoice to registry: %v", err)
 	}
 
@@ -1994,7 +1995,7 @@ func TestChannelLinkBandwidthConsistency(t *testing.T) {
 
 	// No changes before the HTLC is locked in.
 	assertLinkBandwidth(t, aliceLink, aliceStartingBandwidth)
-	if err := updateState(tmr, aliceLink, bobChannel, false); err != nil {
+	if err := updateState(tmr, coreLink, bobChannel, false); err != nil {
 		t.Fatalf("unable to update state: %v", err)
 	}
 
@@ -2002,13 +2003,13 @@ func TestChannelLinkBandwidthConsistency(t *testing.T) {
 	assertLinkBandwidth(t, aliceLink, aliceStartingBandwidth-htlcFee)
 
 	addPkt = htlcPacket{
-		htlc:           htlcAdd,
+		htlc:           htlc,
 		incomingChanID: aliceLink.ShortChanID(),
 		incomingHTLCID: 1,
 		obfuscator:     NewMockObfuscator(),
 	}
 
-	circuit = makePaymentCircuit(&htlcAdd.PaymentHash, &addPkt)
+	circuit = makePaymentCircuit(&htlc.PaymentHash, &addPkt)
 	_, err = coreLink.cfg.Switch.commitCircuits(&circuit)
 	if err != nil {
 		t.Fatalf("unable to commit circuit: %v", err)
@@ -2060,7 +2061,7 @@ func TestChannelLinkBandwidthConsistency(t *testing.T) {
 
 	// After failing an HTLC, the link will automatically trigger
 	// a state update.
-	if err := handleStateUpdate(aliceLink, bobChannel); err != nil {
+	if err := handleStateUpdate(coreLink, bobChannel); err != nil {
 		t.Fatalf("unable to update state: %v", err)
 	}
 	assertLinkBandwidth(t, aliceLink, aliceStartingBandwidth)
@@ -2165,7 +2166,7 @@ func TestChannelLinkBandwidthConsistencyOverflow(t *testing.T) {
 	htlcFee := lnwire.NewMSatFromSatoshis(
 		btcutil.Amount((int64(feePerKw) * commitWeight) / 1000),
 	)
-	expectedBandwidth = aliceStartingBandwidth - totalHtlcAmt - htlcFee
+	expectedBandwidth := aliceStartingBandwidth - totalHtlcAmt - htlcFee
 	expectedBandwidth += lnwire.NewMSatFromSatoshis(defaultCommitFee)
 	assertLinkBandwidth(t, aliceLink, expectedBandwidth)
 

--- a/htlcswitch/log.go
+++ b/htlcswitch/log.go
@@ -7,11 +7,6 @@ import "github.com/btcsuite/btclog"
 // requests it.
 var log btclog.Logger
 
-// The default amount of logging is none.
-func init() {
-	DisableLog()
-}
-
 // DisableLog disables all library log output.  Logging output is disabled
 // by default until UseLogger is called.
 func DisableLog() {

--- a/htlcswitch/mock.go
+++ b/htlcswitch/mock.go
@@ -4,6 +4,7 @@ import (
 	"crypto/sha256"
 	"encoding/binary"
 	"fmt"
+	"io/ioutil"
 	"sync"
 	"testing"
 	"time"
@@ -113,10 +114,33 @@ type mockServer struct {
 
 var _ Peer = (*mockServer)(nil)
 
-func newMockServer(t testing.TB, name string) *mockServer {
+func initSwitchWithDB(db *channeldb.DB) (*Switch, error) {
+	if db == nil {
+		tempPath, err := ioutil.TempDir("", "switchdb")
+		if err != nil {
+			return nil, err
+		}
+
+		db, err = channeldb.Open(tempPath)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return New(Config{
+		DB: db,
+	})
+}
+
+func newMockServer(t testing.TB, name string, db *channeldb.DB) (*mockServer, error) {
 	var id [33]byte
 	h := sha256.Sum256([]byte(name))
 	copy(id[:], h[:])
+
+	htlcSwitch, err := initSwitchWithDB(db)
+	if err != nil {
+		return nil, err
+	}
 
 	return &mockServer{
 		t:                t,
@@ -125,9 +149,9 @@ func newMockServer(t testing.TB, name string) *mockServer {
 		messages:         make(chan lnwire.Message, 3000),
 		quit:             make(chan struct{}),
 		registry:         newMockRegistry(),
-		htlcSwitch:       New(Config{}),
+		htlcSwitch:       htlcSwitch,
 		interceptorFuncs: make([]messageInterceptor, 0),
-	}
+	}, nil
 }
 
 func (s *mockServer) Start() error {
@@ -238,7 +262,8 @@ var _ HopIterator = (*mockHopIterator)(nil)
 // encodes the failure and do not makes any onion obfuscation.
 type mockObfuscator struct{}
 
-func newMockObfuscator() ErrorEncrypter {
+// NewMockObfuscator initializes a dummy mockObfuscator used for testing.
+func NewMockObfuscator() ErrorEncrypter {
 	return &mockObfuscator{}
 }
 
@@ -255,6 +280,18 @@ func (o *mockObfuscator) EncryptFirstHop(failure lnwire.FailureMessage) (
 func (o *mockObfuscator) IntermediateEncrypt(reason lnwire.OpaqueReason) lnwire.OpaqueReason {
 	return reason
 
+}
+
+func (o *mockObfuscator) Type() EncrypterType {
+	return EncrypterTypeMock
+}
+
+func (o *mockObfuscator) Encode(w io.Writer) error {
+	return nil
+}
+
+func (o *mockObfuscator) Decode(r io.Reader) error {
+	return nil
 }
 
 // mockDeobfuscator mock implementation of the failure deobfuscator which
@@ -436,6 +473,30 @@ type mockChannelLink struct {
 	htlcID uint64
 }
 
+// completeCircuit is a helper method for adding the finalized payment circuit
+// to the switch's circuit map. In testing, this should be executed after
+// receiving an htlc from the downstream packets channel.
+func (f *mockChannelLink) completeCircuit(pkt *htlcPacket) error {
+	switch htlc := pkt.htlc.(type) {
+	case *lnwire.UpdateAddHTLC:
+		pkt.outgoingChanID = f.shortChanID
+		pkt.outgoingHTLCID = f.htlcID
+		htlc.ID = f.htlcID
+
+		if err := f.htlcSwitch.setKeystone(pkt.inKey(), pkt.outKey()); err != nil {
+			return err
+		}
+
+		f.htlcID++
+	}
+
+	return nil
+}
+
+func (f *mockChannelLink) deleteCircuit(pkt *htlcPacket) error {
+	return f.htlcSwitch.deleteCircuit(pkt.inKey())
+}
+
 func newMockChannelLink(htlcSwitch *Switch, chanID lnwire.ChannelID,
 	shortChanID lnwire.ShortChannelID, peer Peer, eligible bool,
 ) *mockChannelLink {
@@ -450,21 +511,9 @@ func newMockChannelLink(htlcSwitch *Switch, chanID lnwire.ChannelID,
 	}
 }
 
-func (f *mockChannelLink) HandleSwitchPacket(packet *htlcPacket) {
-	switch htlc := packet.htlc.(type) {
-	case *lnwire.UpdateAddHTLC:
-		f.htlcSwitch.addCircuit(&PaymentCircuit{
-			PaymentHash:    htlc.PaymentHash,
-			IncomingChanID: packet.incomingChanID,
-			IncomingHTLCID: packet.incomingHTLCID,
-			OutgoingChanID: f.shortChanID,
-			OutgoingHTLCID: f.htlcID,
-			ErrorEncrypter: packet.obfuscator,
-		})
-		f.htlcID++
-	}
-
-	f.packets <- packet
+func (f *mockChannelLink) HandleSwitchPacket(pkt *htlcPacket) error {
+	f.packets <- pkt
+	return nil
 }
 
 func (f *mockChannelLink) HandleChannelUpdate(lnwire.Message) {

--- a/htlcswitch/packet.go
+++ b/htlcswitch/packet.go
@@ -27,6 +27,10 @@ type htlcPacket struct {
 	// outgoing channel.
 	outgoingHTLCID uint64
 
+	// incomingAmount is the value in milli-satoshis that arrived on an
+	// incoming link.
+	incomingAmount lnwire.MilliSatoshi
+
 	// amount is the value of the HTLC that is being created or modified.
 	amount lnwire.MilliSatoshi
 
@@ -42,10 +46,10 @@ type htlcPacket struct {
 	// encrypted with any shared secret.
 	localFailure bool
 
-	// isRouted is set to true if the incomingChanID and incomingHTLCID fields
-	// of a forwarded fail packet are already set and do not need to be looked
-	// up in the circuit map.
-	isRouted bool
+	// hasSource is set to true if the incomingChanID and incomingHTLCID
+	// fields of a forwarded fail packet are already set and do not need to
+	// be looked up in the circuit map.
+	hasSource bool
 
 	// isResolution is set to true if this packet was actually an incoming
 	// resolution message from an outside sub-system. We'll treat these as
@@ -53,4 +57,20 @@ type htlcPacket struct {
 	// encrypt all errors related to this packet as if we were the first
 	// hop.
 	isResolution bool
+}
+
+// inKey returns the circuit key used to identify the incoming htlc.
+func (p *htlcPacket) inKey() CircuitKey {
+	return CircuitKey{
+		ChanID: p.incomingChanID,
+		HtlcID: p.incomingHTLCID,
+	}
+}
+
+// outKey returns the circuit key used to identify the outgoing, forwarded htlc.
+func (p *htlcPacket) outKey() CircuitKey {
+	return CircuitKey{
+		ChanID: p.outgoingChanID,
+		HtlcID: p.outgoingHTLCID,
+	}
 }

--- a/htlcswitch/sequencer.go
+++ b/htlcswitch/sequencer.go
@@ -1,0 +1,76 @@
+package htlcswitch
+
+import (
+	"github.com/boltdb/bolt"
+	"github.com/go-errors/errors"
+	"github.com/lightningnetwork/lnd/channeldb"
+)
+
+// Sequencer emits sequence numbers for locally initiated HTLCs. These are
+// only used internally for tracking pending payments, however they must be
+// unique in order to avoid circuit key collision in the circuit map.
+type Sequencer interface {
+	// NextID returns a unique sequence number for each invocation.
+	NextID() (uint64, error)
+}
+
+var (
+	// nextPaymentIDKey identifies the bucket that will keep track of the
+	// persistent sequence numbers for payments.
+	nextPaymentIDKey = []byte("next-payment-id-key")
+
+	// ErrSequencerCorrupted signals that the persistence engine was not
+	// initialized, or has been corrupted since startup.
+	ErrSequencerCorrupted = errors.New(
+		"sequencer database has been corrupted")
+)
+
+// persistentSequencer is a concrete implementation of IDGenerator, that uses
+// channeldb to allocate sequence numbers.
+type persistentSequencer struct {
+	db *channeldb.DB
+}
+
+// NewPersistentSequencer initializes a new sequencer using a channeldb backend.
+func NewPersistentSequencer(db *channeldb.DB) (Sequencer, error) {
+	g := &persistentSequencer{
+		db: db,
+	}
+
+	// Ensure the database bucket is created before any updates are
+	// performed.
+	if err := g.initDB(); err != nil {
+		return nil, err
+	}
+
+	return g, nil
+}
+
+// NextID returns a unique sequence number for every invocation, persisting the
+// assignment to avoid reuse.
+func (g *persistentSequencer) NextID() (uint64, error) {
+	var nextPaymentID uint64
+	if err := g.db.Update(func(tx *bolt.Tx) error {
+		nextIDBkt := tx.Bucket(nextPaymentIDKey)
+		if nextIDBkt == nil {
+			return ErrSequencerCorrupted
+		}
+
+		// Cannot fail when used in Update.
+		nextPaymentID, _ = nextIDBkt.NextSequence()
+
+		return nil
+	}); err != nil {
+		return 0, err
+	}
+
+	return nextPaymentID, nil
+}
+
+// initDB populates the bucket used to generate payment sequence numbers.
+func (g *persistentSequencer) initDB() error {
+	return g.db.Update(func(tx *bolt.Tx) error {
+		_, err := tx.CreateBucketIfNotExists(nextPaymentIDKey)
+		return err
+	})
+}

--- a/htlcswitch/std_log.go
+++ b/htlcswitch/std_log.go
@@ -1,0 +1,21 @@
+// +build stdlog
+
+package htlcswitch
+
+import (
+	"os"
+
+	"github.com/btcsuite/btclog"
+)
+
+// When compiling with "stdlog" build flag, we will init the package with its
+// own logger that writes to stdout.
+func init() {
+	stdBackend := btclog.NewBackend(os.Stdout)
+	stdLogger := stdBackend.Logger("HSWC")
+
+	level, _ := btclog.LevelFromString("trace")
+	stdLogger.SetLevel(level)
+
+	UseLogger(stdLogger)
+}

--- a/htlcswitch/switch.go
+++ b/htlcswitch/switch.go
@@ -1018,7 +1018,7 @@ func (s *Switch) closeCircuit(htlc lnwire.Message, pkt *htlcPacket) (*PaymentCir
 func (s *Switch) teardownCircuit(circuit *PaymentCircuit, packet *htlcPacket) error {
 	var pktType string
 	switch htlc := packet.htlc.(type) {
-	case *lnwire.UpdateFufillHTLC:
+	case *lnwire.UpdateFulfillHTLC:
 		pktType = "SETTLE"
 	case *lnwire.UpdateFailHTLC:
 		pktType = "FAIL"

--- a/htlcswitch/switch_test.go
+++ b/htlcswitch/switch_test.go
@@ -465,7 +465,7 @@ func TestSwitchForwardSettleAfterFullAdd(t *testing.T) {
 		outgoingChanID: bobChannelLink.ShortChanID(),
 		outgoingHTLCID: 0,
 		amount:         1,
-		htlc: &lnwire.UpdateFufillHTLC{
+		htlc: &lnwire.UpdateFulfillHTLC{
 			PaymentPreimage: preimage,
 		},
 	}
@@ -792,7 +792,7 @@ func TestSwitchForwardCircuitPersistence(t *testing.T) {
 		outgoingChanID: bobChannelLink.ShortChanID(),
 		outgoingHTLCID: 0,
 		amount:         1,
-		htlc: &lnwire.UpdateFufillHTLC{
+		htlc: &lnwire.UpdateFulfillHTLC{
 			PaymentPreimage: preimage,
 		},
 	}

--- a/lnd_test.go
+++ b/lnd_test.go
@@ -3241,16 +3241,18 @@ func testRevokedCloseRetribution(net *lntest.NetworkHarness, t *harnessTest) {
 	var bobChan *lnrpc.ActiveChannel
 	var predErr error
 	err = lntest.WaitPredicate(func() bool {
-		bobChan, err = getBobChanInfo()
+		bChan, err := getBobChanInfo()
 		if err != nil {
 			t.Fatalf("unable to get bob's channel info: %v", err)
 		}
-		if bobChan.LocalBalance != 30000 {
+		if bChan.LocalBalance != 30000 {
 			predErr = fmt.Errorf("bob's balance is incorrect, "+
-				"got %v, expected %v", bobChan.LocalBalance,
+				"got %v, expected %v", bChan.LocalBalance,
 				30000)
 			return false
 		}
+
+		bobChan = bChan
 		return true
 	}, time.Second*15)
 	if err != nil {

--- a/lnd_test.go
+++ b/lnd_test.go
@@ -4960,7 +4960,7 @@ func testBidirectionalAsyncPayments(net *lntest.NetworkHarness, t *harnessTest) 
 
 	// Wait for Alice and Bob receive their payments, and throw and error
 	// if something goes wrong.
-	maxTime := 20 * time.Second
+	maxTime := 30 * time.Second
 	for i := 0; i < 2; i++ {
 		select {
 		case err := <-errChan:

--- a/server.go
+++ b/server.go
@@ -200,7 +200,8 @@ func newServer(listenAddrs []string, chanDB *channeldb.DB, cc *chainControl,
 			debugPre[:], debugHash[:])
 	}
 
-	s.htlcSwitch = htlcswitch.New(htlcswitch.Config{
+	htlcSwitch, err := htlcswitch.New(htlcswitch.Config{
+		DB:      chanDB,
 		SelfKey: s.identityPriv.PubKey(),
 		LocalChannelClose: func(pubKey []byte,
 			request *htlcswitch.ChanClose) {
@@ -225,6 +226,10 @@ func newServer(listenAddrs []string, chanDB *channeldb.DB, cc *chainControl,
 			}
 		},
 	})
+	if err != nil {
+		return nil, err
+	}
+	s.htlcSwitch = htlcSwitch
 
 	// If external IP addresses have been specified, add those to the list
 	// of this server's addresses. We need to use the cfg.net.ResolveTCPAddr

--- a/test_utils.go
+++ b/test_utils.go
@@ -264,7 +264,13 @@ func createTestPeer(notifier chainntnfs.ChainNotifier,
 		breachArbiter: breachArbiter,
 		chainArb:      chainArb,
 	}
-	s.htlcSwitch = htlcswitch.New(htlcswitch.Config{})
+	htlcSwitch, err := htlcswitch.New(htlcswitch.Config{
+		DB: dbAlice,
+	})
+	if err != nil {
+		return nil, nil, nil, nil, err
+	}
+	s.htlcSwitch = htlcSwitch
 	s.htlcSwitch.Start()
 
 	alicePeer := &peer{


### PR DESCRIPTION
This is a mostly complete PR that adds persistence to the switch's circuit map. The circuit map allows the switch to recall it's previous forwarding decisions, and provide direction on how to deliver any settles or fails that return to switch.

Circuit Keys
------------
The switch nows tracks incoming and outgoing HTLCs by way of `CircuitKey`, which is a tuple of `(ChanID, HtlcID)`. When an ADD packet is being forwarded, it's incoming channel and htlc ID are used to identify a particular `PaymentCircuit`. Once the forwarding decision has been made, the outgoing link sets the circuit's outgoing circuit key, referred to as the _keystone_. With the keystone set, the outgoing link is free to forward that packet. Upon return of a settle or fail packet, the keystone is used to retrieve the circuit to inform the switch of how to send the packet back to the source.

Forwarding ADDs
-----------------
Forwarding ADD packets through the switch now involves two primary operations:
1. `CommitCircuits(circuits ...[]*PaymentCircuit) ([]*PaymentCircuit, error)`: takes an arbitrary list of circuits and batch adds any unseen circuits to both the in-memory and on-disk representations. The list of circuits returned is the subset of circuits that were actually added, which prevents us from accidentally forwarding the same htlc twice.
2. `SetKeystone(inKey, outKey CircuitKey) error`: called by the outgoing link, after having decided the exact htlc ID. Once this method has been called, the circuit with `inKey` is considered _open_ and is expecting a fail or settle from the remote party.

Forwarding SETTLEs/FAILs
---------------------------
When a settle or fail is received from a remote peer, we lookup the circuit by its keystone (outgoing circuit key) to recover the circuit and determine the htlc's source. The circuit is then deleted from the circuit map before forwarding the fails and settles to the source link or via local dispatch. Later, this should be improved by having the switch only update in-memory data structures, and pushing the persistent write deeper into the link so that it happens just before signing next commitment that includes a particular settle/fail. This would allow the fails and settles to be batched, more closely resembling the batching of adds at the link-level. This would still allow the switch to drop duplicates because the in-memory representation will no longer contain the circuit.

The circuit serialization depends on the error encrypter serialization being merged into the lightning onion repo, [here](https://github.com/lightningnetwork/lightning-onion/pull/17). Note that this writes the shared secrets in plaintext to disk. A later PR will remedy this after the strong replay protection has been finished. Will need to update glide after that's been merged to master.