### PR TITLE
config.go: check for RPCUser AND RPCPass (AND ZMQPath for bitcoind)

### DIFF
--- a/config.go
+++ b/config.go
@@ -621,12 +621,29 @@ func parseRPCParams(cConfig *chainConfig, nodeConfig interface{}, net chainCode,
 	// specified, we can return.
 	switch conf := nodeConfig.(type) {
 	case *btcdConfig:
-		if conf.RPCUser != "" || conf.RPCPass != "" {
+		// If both RPCUser and RPCPass are set, we assume those
+		// credentials are good to use.
+		if conf.RPCUser != "" && conf.RPCPass != "" {
 			return nil
 		}
+		// If only ONE of RPCUser or RPCPass is set, we assume the
+		// user did that unintentionally.
+		if conf.RPCUser != "" || conf.RPCPass != "" {
+			return fmt.Errorf("please set both or neither of " +
+				"btcd.rpcuser and btcd.rpcpass")
+		}
 	case *bitcoindConfig:
-		if conf.RPCUser != "" || conf.RPCPass != "" || conf.ZMQPath != "" {
+		// If all of RPCUser, RPCPass, and ZMQPath are set, we assume
+		// those parameters are good to use.
+		if conf.RPCUser != "" && conf.RPCPass != "" && conf.ZMQPath != "" {
 			return nil
+		}
+		// If only one or two of the parameters are set, we assume the
+		// user did that unintentionally.
+		if conf.RPCUser != "" || conf.RPCPass != "" || conf.ZMQPath != "" {
+			return fmt.Errorf("please set all or none of " +
+				"bitcoind.rpcuser, bitcoind.rpcpass, and " +
+				"bitcoind.zmqpath")
 		}
 	}
 


### PR DESCRIPTION
This fixes config parsing such that:

* In the case of `btcd`, `lnd.conf` or command line options MUST specify BOTH `btcd.rpcuser` and `btcd.rpcpass` in order to avoid attempting to get authentication parameters from `btcd.conf` or NEITHER to get the parameters from `btcd.conf`; otherwise an error is returned asking the user to specify both or neither.
* In the case of `bitcoind`, `lnd.conf` or command line options MUST specify ALL OF `bitcoind.rpcuser`, `bitcoind.rpcpass`, and `bitcoind.zmqpath` in order to avoid attempting to get authentication parameters and the ZMQ path from `bitcoin.conf` or NONE to get the parameters from `bitcoin.conf`; otherwise an error is returned asking the user to specify all or none.

This should fix #621 when merged; however, in order to fix the underlying panic, glide should also be updated to the latest `gozmq` and (after the `btcwallet` glide is updated) `btcwallet`.