### PR TITLE
config: adds an extra tls ip to config

### DIFF
--- a/config.go
+++ b/config.go
@@ -149,6 +149,7 @@ type config struct {
 	DataDir      string `short:"b" long:"datadir" description:"The directory to store lnd's data within"`
 	TLSCertPath  string `long:"tlscertpath" description:"Path to TLS certificate for lnd's RPC and REST services"`
 	TLSKeyPath   string `long:"tlskeypath" description:"Path to TLS private key for lnd's RPC and REST services"`
+	TLSExtraIP   string `long:"tlsextraip" description:"Adds an extra ip to the generated certificate"`
 	NoMacaroons  bool   `long:"no-macaroons" description:"Disable macaroon authentication"`
 	AdminMacPath string `long:"adminmacaroonpath" description:"Path to write the admin macaroon for lnd's RPC and REST services if it doesn't exist"`
 	ReadMacPath  string `long:"readonlymacaroonpath" description:"Path to write the read-only macaroon for lnd's RPC and REST services if it doesn't exist"`

--- a/lnd.go
+++ b/lnd.go
@@ -608,6 +608,12 @@ func genCertPair(certFile, keyFile string) error {
 		}
 	}
 
+	// Add extra IP to the slice.
+	ipAddr := net.ParseIP(cfg.TLSExtraIP)
+	if ipAddr != nil {
+		addIP(ipAddr)
+	}
+
 	// Collect the host's names into a slice.
 	host, err := os.Hostname()
 	if err != nil {


### PR DESCRIPTION
This commit adds the `tlsextraip` flag to the cli to add an
ip to the generated certificate. This is usefull when using
a loadbalancer to access the node.

Fixes #684. 