### PR TITLE
Fixing it's/its typos in comments

### DIFF
--- a/autopilot/agent.go
+++ b/autopilot/agent.go
@@ -269,7 +269,7 @@ func mergeChanState(pendingChans map[NodeID]Channel,
 
 // controller implements the closed-loop control system of the Agent. The
 // controller will make a decision w.r.t channel placement within the graph
-// based on: it's current internal state of the set of active channels open,
+// based on: its current internal state of the set of active channels open,
 // and external state changes as a result of decisions it  makes w.r.t channel
 // allocation, or attributes affecting its control loop being updated by the
 // backing Lightning Node.

--- a/autopilot/interface.go
+++ b/autopilot/interface.go
@@ -86,7 +86,7 @@ type ChannelGraph interface {
 // to, and also the parameters which should be used in the channel creation.
 type AttachmentDirective struct {
 	// PeerKey is the target node for this attachment directive. It can be
-	// identified by it's public key, and therefore can be used along with
+	// identified by its public key, and therefore can be used along with
 	// a ChannelOpener implementation to execute the directive.
 	PeerKey *btcec.PublicKey
 

--- a/chancloser.go
+++ b/chancloser.go
@@ -552,7 +552,7 @@ func (c *channelCloser) proposeCloseSigned(fee btcutil.Amount) (*lnwire.ClosingS
 // consider their fee acceptable if it's within 30% of our fee.
 func feeInAcceptableRange(localFee, remoteFee btcutil.Amount) bool {
 	// If our offer is lower than theirs, then we'll accept their
-	// offer it it's no more than 30% *greater* than our current
+	// offer if it's no more than 30% *greater* than our current
 	// offer.
 	if localFee < remoteFee {
 		acceptableRange := localFee + ((localFee * 3) / 10)

--- a/channeldb/channel.go
+++ b/channeldb/channel.go
@@ -33,7 +33,7 @@ var (
 	openChannelBucket = []byte("open-chan-bucket")
 
 	// chanInfoKey can be accessed within the bucket for a channel
-	// (identified by it's chanPoint). This key stores all the static
+	// (identified by its chanPoint). This key stores all the static
 	// information for a channel which is decided at the end of  the
 	// funding flow.
 	chanInfoKey = []byte("chan-info-key")

--- a/channeldb/channel_test.go
+++ b/channeldb/channel_test.go
@@ -496,7 +496,7 @@ func TestChannelStateTransition(t *testing.T) {
 		t.Fatalf("expected ErrNoPendingCommit, instead got %v", err)
 	}
 
-	// We should be able to fetch the channel delta created above by it's
+	// We should be able to fetch the channel delta created above by its
 	// update number with all the state properly reconstructed.
 	diskPrevCommit, err := channel.FindPreviousState(
 		oldRemoteCommit.CommitHeight,

--- a/channeldb/db.go
+++ b/channeldb/db.go
@@ -473,7 +473,7 @@ func (d *DB) FetchClosedChannel(chanID *wire.OutPoint) (*ChannelCloseSummary, er
 
 // MarkChanFullyClosed marks a channel as fully closed within the database. A
 // channel should be marked as fully closed if the channel was initially
-// cooperatively closed and it's reach a single confirmation, or after all the
+// cooperatively closed and it's reached a single confirmation, or after all the
 // pending funds in a channel that has been forcibly closed have been swept.
 func (d *DB) MarkChanFullyClosed(chanPoint *wire.OutPoint) error {
 	return d.Update(func(tx *bolt.Tx) error {

--- a/channeldb/graph.go
+++ b/channeldb/graph.go
@@ -38,7 +38,7 @@ var (
 	sourceKey = []byte("source")
 
 	// aliasIndexBucket is a sub-bucket that's nested within the main
-	// nodeBucket. This bucket maps the public key of a node to it's
+	// nodeBucket. This bucket maps the public key of a node to its
 	// current alias. This bucket is provided as it can be used within a
 	// future UI layer to add an additional degree of confirmation.
 	aliasIndexBucket = []byte("alias")
@@ -539,7 +539,7 @@ func (c *ChannelGraph) HasChannelEdge(chanID uint64) (time.Time, time.Time, bool
 }
 
 // UpdateChannelEdge retrieves and update edge of the graph database. Method
-// only reserved for updating an edge info after it's already been created.
+// only reserved for updating an edge info after its already been created.
 // In order to maintain this constraints, we return an error in the scenario
 // that an edge info hasn't yet been created yet, but someone attempts to update
 // it.
@@ -816,7 +816,7 @@ func (c *ChannelGraph) PruneTip() (*chainhash.Hash, uint32, error) {
 	return &tipHash, tipHeight, nil
 }
 
-// DeleteChannelEdge removes an edge from the database as identified by it's
+// DeleteChannelEdge removes an edge from the database as identified by its
 // funding outpoint. If the edge does not exist within the database, then
 // ErrEdgeNotFound will be returned.
 func (c *ChannelGraph) DeleteChannelEdge(chanPoint *wire.OutPoint) error {

--- a/channeldb/invoices.go
+++ b/channeldb/invoices.go
@@ -174,8 +174,8 @@ func (d *DB) AddInvoice(i *Invoice) error {
 	})
 }
 
-// LookupInvoice attempts to look up an invoice according to it's 32 byte
-// payment hash. In an invoice which can settle the HTLC identified by the
+// LookupInvoice attempts to look up an invoice according to its 32 byte
+// payment hash. If an invoice which can settle the HTLC identified by the
 // passed payment hash isn't found, then an error is returned. Otherwise, the
 // full invoice is returned. Before setting the incoming HTLC, the values
 // SHOULD be checked to ensure the payer meets the agreed upon contractual

--- a/cmd/lncli/commands.go
+++ b/cmd/lncli/commands.go
@@ -1429,7 +1429,7 @@ func normalizeFunc(edges []*lnrpc.ChannelEdge, scaleFactor float64) func(int64) 
 
 	for _, edge := range edges {
 		// In order to obtain saner values, we reduce the capacity of a
-		// channel to it's base 2 logarithm.
+		// channel to its base 2 logarithm.
 		z := math.Log2(float64(edge.Capacity))
 
 		if z < min {
@@ -1514,7 +1514,7 @@ func drawChannelGraph(graph *lnrpc.ChannelGraph) error {
 		edgeWeight := strconv.FormatFloat(amt, 'f', -1, 64)
 
 		// The label for each edge will simply be a truncated version
-		// of it's channel ID.
+		// of its channel ID.
 		chanIDStr := strconv.FormatUint(edge.ChannelId, 10)
 		edgeLabel := fmt.Sprintf(`"cid:%v"`, truncateStr(chanIDStr, 7))
 

--- a/contractcourt/channel_arbitrator.go
+++ b/contractcourt/channel_arbitrator.go
@@ -482,7 +482,7 @@ func (c *ChannelArbitrator) stateStep(bestHeight uint32, bestHash *chainhash.Has
 		}
 
 		// Now that the transaction has been broadcast, we can mark
-		// that it's has been closed to outside sub-systems.
+		// that it has been closed to outside sub-systems.
 		err = c.markContractClosed(
 			closeTx, closeSummary.ChanSnapshot, &contractRes,
 			bestHeight,

--- a/discovery/gossiper.go
+++ b/discovery/gossiper.go
@@ -190,7 +190,7 @@ type AuthenticatedGossiper struct {
 	// channelMtx is used to restrict the database access to one
 	// goroutine per channel ID. This is done to ensure that when
 	// the gossiper is handling an announcement, the db state stays
-	// consistent between when the DB is first read to it's written.
+	// consistent between when the DB is first read until it's written.
 	channelMtx *multimutex.Mutex
 
 	sync.Mutex
@@ -1001,7 +1001,7 @@ func (d *AuthenticatedGossiper) networkHandler() {
 
 // retransmitStaleChannels examines all outgoing channels that the source node
 // is known to maintain to check to see if any of them are "stale". A channel
-// is stale iff, the last timestamp of it's rebroadcast is older then
+// is stale iff, the last timestamp of its rebroadcast is older then
 // broadcastInterval.
 func (d *AuthenticatedGossiper) retransmitStaleChannels() error {
 	// Iterate over all of our channels and check if any of them fall

--- a/fundingmanager.go
+++ b/fundingmanager.go
@@ -660,7 +660,7 @@ func (f *fundingManager) CancelPeerReservations(nodePub [33]byte) {
 }
 
 // failFundingFlow will fail the active funding flow with the target peer,
-// identified by it's unique temporary channel ID. This method is send an error
+// identified by its unique temporary channel ID. This method is send an error
 // to the remote peer, and also remove the reservation from our set of pending
 // reservations.
 //
@@ -1293,7 +1293,7 @@ func (f *fundingManager) processFundingSigned(msg *lnwire.FundingSigned,
 // confirmations, a message is sent to the responding peer along with a compact
 // encoding of the location of the channel within the blockchain.
 func (f *fundingManager) handleFundingSigned(fmsg *fundingSignedMsg) {
-	// As the funding signed message will reference the reservation by it's
+	// As the funding signed message will reference the reservation by its
 	// permanent channel ID, we'll need to perform an intermediate look up
 	// before we can obtain the reservation.
 	f.resMtx.Lock()

--- a/htlcswitch/circuit.go
+++ b/htlcswitch/circuit.go
@@ -56,7 +56,7 @@ func (k *circuitKey) String() string {
 
 // CircuitMap is a data structure that implements thread safe storage of
 // circuit routing information. The switch consults a circuit map to determine
-// where to forward HTLC update messages. Each circuit is stored with it's
+// where to forward HTLC update messages. Each circuit is stored with its
 // outgoing HTLC as the primary key because, each offered HTLC has at most one
 // received HTLC, but there may be multiple offered or received HTLCs with the
 // same payment hash. Circuits are also indexed to provide fast lookups by

--- a/htlcswitch/interfaces.go
+++ b/htlcswitch/interfaces.go
@@ -10,7 +10,7 @@ import (
 // InvoiceDatabase is an interface which represents the persistent subsystem
 // which may search, lookup and settle invoices.
 type InvoiceDatabase interface {
-	// LookupInvoice attempts to look up an invoice according to it's 32
+	// LookupInvoice attempts to look up an invoice according to its 32
 	// byte payment hash.
 	LookupInvoice(chainhash.Hash) (channeldb.Invoice, error)
 

--- a/lnrpc/rpc.swagger.json
+++ b/lnrpc/rpc.swagger.json
@@ -251,7 +251,7 @@
     },
     "/v1/getinfo": {
       "get": {
-        "summary": "* lncli: `getinfo`\nGetInfo returns general information concerning the lightning node including\nit's identity pubkey, alias, the chains it is connected to, and information\nconcerning the number of open+pending channels.",
+        "summary": "* lncli: `getinfo`\nGetInfo returns general information concerning the lightning node including\nits identity pubkey, alias, the chains it is connected to, and information\nconcerning the number of open+pending channels.",
         "operationId": "GetInfo",
         "responses": {
           "200": {

--- a/lnwallet/btcwallet/btcwallet.go
+++ b/lnwallet/btcwallet/btcwallet.go
@@ -272,7 +272,7 @@ func (b *BtcWallet) FetchRootKey() (*btcec.PrivateKey, error) {
 
 	if rootAddrHash == nil {
 		// Otherwise, we need to generate a fresh address from the
-		// wallet, then stores it's hash160 within the database so we
+		// wallet, then stores its hash160 within the database so we
 		// can look up the exact key later.
 		if err := walletdb.Update(b.db, func(tx walletdb.ReadWriteTx) error {
 			addrmgrNs := tx.ReadWriteBucket(waddrmgrNamespaceKey)

--- a/lnwallet/channel.go
+++ b/lnwallet/channel.go
@@ -997,7 +997,7 @@ func (u *updateLog) appendHtlc(pd *PaymentDescriptor) {
 	u.logIndex++
 }
 
-// lookupHtlc attempts to look up an offered HTLC according to it's offer
+// lookupHtlc attempts to look up an offered HTLC according to its offer
 // index. If the entry isn't found, then a nil pointer is returned.
 func (u *updateLog) lookupHtlc(i uint64) *PaymentDescriptor {
 	htlc, ok := u.htlcIndex[i]
@@ -2585,7 +2585,7 @@ func (lc *LightningChannel) createCommitDiff(
 		}
 
 		// Knowing that this update is a part of this new commitment,
-		// we'll create a log update and not it's index in the log so
+		// we'll create a log update and not its index in the log so
 		// we can later restore it properly if a restart occurs.
 		logUpdate := channeldb.LogUpdate{
 			LogIndex: pd.LogIndex,

--- a/lnwallet/script_utils.go
+++ b/lnwallet/script_utils.go
@@ -373,7 +373,7 @@ func senderHtlcSpendTimeout(receiverSig []byte, signer Signer,
 // receiverHTLCScript constructs the public key script for an incoming HTLC
 // output payment for the receiver's version of the commitment transaction. The
 // possible execution paths from this script include:
-//   * The receiver of the HTLC uses it's second level HTLC transaction to
+//   * The receiver of the HTLC uses its second level HTLC transaction to
 //     advance the state of the HTLC into the delay+claim state.
 //   * The sender of the HTLC sweeps all the funds of the HTLC as a breached
 //     commitment was broadcast.

--- a/lnwallet/wallet.go
+++ b/lnwallet/wallet.go
@@ -1089,7 +1089,7 @@ func (l *LightningWallet) handleFundingCounterPartySigs(msg *addCounterPartySigs
 	res.partialState.LocalChanCfg = res.ourContribution.toChanConfig()
 	res.partialState.RemoteChanCfg = res.theirContribution.toChanConfig()
 
-	// Add the complete funding transaction to the DB, in it's open bucket
+	// Add the complete funding transaction to the DB, in its open bucket
 	// which will be used for the lifetime of this channel.
 	// TODO(roasbeef):
 	//  * attempt to retransmit funding transactions on re-start

--- a/nursery_store.go
+++ b/nursery_store.go
@@ -479,7 +479,7 @@ func (ns *nurseryStore) PreschoolToKinder(kid *kidOutput) error {
 		}
 
 		// In the case of a Late Registration, we've already graduated
-		// the class that this kid is destined for. So we'll bump it's
+		// the class that this kid is destined for. So we'll bump its
 		// height by one to ensure we don't forget to graduate it.
 		lastGradHeight, err := ns.getLastGraduatedHeight(tx)
 		if err != nil {

--- a/nursery_store_test.go
+++ b/nursery_store_test.go
@@ -187,7 +187,7 @@ func TestNurseryStoreIncubate(t *testing.T) {
 
 			// The total number of outputs for this channel should
 			// not have changed, and the kindergarten output should
-			// reside at it's maturity height.
+			// reside at its maturity height.
 			assertNumChanOutputs(t, ns, test.chanPoint, test.nOutputs)
 			assertKndrAtMaturityHeight(t, ns, test.commOutput)
 
@@ -227,7 +227,7 @@ func TestNurseryStoreIncubate(t *testing.T) {
 
 			// The total number of outputs for this channel should
 			// not have changed, but the kindergarten output should
-			// have been removed from it's maturity height.
+			// have been removed from its maturity height.
 			assertNumChanOutputs(t, ns, test.chanPoint, test.nOutputs)
 			assertKndrNotAtMaturityHeight(t, ns, test.commOutput)
 
@@ -258,7 +258,7 @@ func TestNurseryStoreIncubate(t *testing.T) {
 					test.nOutputs)
 
 				// If the output hasn't moved to kndr, it should
-				// be at it's crib expiry height, otherwise is
+				// be at its crib expiry height, otherwise is
 				// should have been removed.
 				for j := range test.htlcOutputs {
 					if j > i {
@@ -459,7 +459,7 @@ func TestNurseryStoreGraduate(t *testing.T) {
 	}
 
 	// Then, move the commitment output to the kindergarten bucket, such
-	// that it resides in the height index at it's maturity height.
+	// that it resides in the height index at its maturity height.
 	err = ns.PreschoolToKinder(kid)
 	if err != nil {
 		t.Fatalf("unable to move pscl output to kndr: %v", err)
@@ -478,7 +478,7 @@ func TestNurseryStoreGraduate(t *testing.T) {
 		assertHeightIsPurged(t, ns, uint32(i))
 	}
 
-	// Check that the commitment output currently exists at it's maturity
+	// Check that the commitment output currently exists at its maturity
 	// height.
 	assertKndrAtMaturityHeight(t, ns, kid)
 

--- a/routing/notifications.go
+++ b/routing/notifications.go
@@ -219,7 +219,7 @@ func createCloseSummaries(blockHeight uint32,
 
 // NetworkNodeUpdate is an update for a  node within the Lightning Network. A
 // NetworkNodeUpdate is sent out either when a new node joins the network, or a
-// node broadcasts a new update with a newer time stamp that supersedes it's
+// node broadcasts a new update with a newer time stamp that supersedes its
 // old update. All updates are properly authenticated.
 type NetworkNodeUpdate struct {
 	// Addresses is a slice of all the node's known addresses.

--- a/routing/router.go
+++ b/routing/router.go
@@ -1318,7 +1318,7 @@ func generateSphinxPacket(route *Route, paymentHash []byte) ([]byte,
 		return nil, nil, err
 	}
 
-	// Finally, encode Sphinx packet using it's wire representation to be
+	// Finally, encode Sphinx packet using its wire representation to be
 	// included within the HTLC add packet.
 	var onionBlob bytes.Buffer
 	if err := sphinxPacket.Encode(&onionBlob); err != nil {

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -958,7 +958,7 @@ out:
 	return nil
 }
 
-// fetchActiveChannel attempts to locate a channel identified by it's channel
+// fetchActiveChannel attempts to locate a channel identified by its channel
 // point from the database's set of all currently opened channels.
 func (r *rpcServer) fetchActiveChannel(chanPoint wire.OutPoint) (*lnwallet.LightningChannel, error) {
 	dbChannels, err := r.server.chanDB.FetchAllChannels()
@@ -990,7 +990,7 @@ func (r *rpcServer) fetchActiveChannel(chanPoint wire.OutPoint) (*lnwallet.Light
 }
 
 // GetInfo returns general information concerning the lightning node including
-// it's identity pubkey, alias, the chains it is connected to, and information
+// its identity pubkey, alias, the chains it is connected to, and information
 // concerning the number of open+pending channels.
 func (r *rpcServer) GetInfo(ctx context.Context,
 	in *lnrpc.GetInfoRequest) (*lnrpc.GetInfoResponse, error) {

--- a/server.go
+++ b/server.go
@@ -1504,7 +1504,7 @@ func (s *server) addPeer(p *peer) {
 	}
 
 	// Track the new peer in our indexes so we can quickly look it up either
-	// according to its public key, or it's peer ID.
+	// according to its public key, or its peer ID.
 	// TODO(roasbeef): pipe all requests through to the
 	// queryHandler/peerManager
 

--- a/utxonursery.go
+++ b/utxonursery.go
@@ -615,7 +615,7 @@ func (u *utxoNursery) reloadPreschool() error {
 	}
 
 	// For each of the preschool outputs stored in the nursery store, load
-	// it's close summary from disk so that we can get an accurate height
+	// its close summary from disk so that we can get an accurate height
 	// hint from which to start our range for spend notifications.
 	for i := range psclOutputs {
 		kid := &psclOutputs[i]
@@ -1443,8 +1443,8 @@ type htlcMaturityReport struct {
 
 	// stage indicates whether the htlc is in the CLTV-timeout stage (1) or
 	// the CSV-delay stage (2). A stage 1 htlc's maturity height will be set
-	// to it's expiry height, while a stage 2 htlc's maturity height will be
-	// set to it's confirmation height plus the maturity requirement.
+	// to its expiry height, while a stage 2 htlc's maturity height will be
+	// set to its confirmation height plus the maturity requirement.
 	stage uint32
 }
 


### PR DESCRIPTION
I noticed a couple of places in the API documentation where "it's" was used in place of "its" so I went ahead and cleaned these up wherever I could find them in the code.