### PR TITLE
Help text & sample config improvements

### DIFF
--- a/autopilot/agent.go
+++ b/autopilot/agent.go
@@ -10,7 +10,7 @@ import (
 	"github.com/roasbeef/btcutil"
 )
 
-// Config couples all the items that that an autopilot agent needs to function.
+// Config couples all the items that an autopilot agent needs to function.
 // All items within the struct MUST be populated for the Agent to be able to
 // carry out its duties.
 type Config struct {

--- a/config.go
+++ b/config.go
@@ -150,7 +150,7 @@ type config struct {
 	RESTListeners []string `long:"restlisten" description:"Add an interface/port to listen for REST connections"`
 	Listeners     []string `long:"listen" description:"Add an interface/port to listen for peer connections"`
 	DisableListen bool     `long:"nolisten" description:"Disable listening for incoming peer connections"`
-	ExternalIPs   []string `long:"externalip" description:"Add an ip to the list of local addresses we claim to listen on to peers"`
+	ExternalIPs   []string `long:"externalip" description:"Add an ip:port to the list of local addresses we claim to listen on to peers. If a port is not specified, the default (9735) will be used regardless of other parameters"`
 
 	DebugLevel string `short:"d" long:"debuglevel" description:"Logging level for all subsystems {trace, debug, info, warn, error, critical} -- You may also specify <subsystem>=<level>,<subsystem2>=<level>,... to set the log level for individual subsystems -- Use show to list available subsystems"`
 

--- a/lnwire/lnwire.go
+++ b/lnwire/lnwire.go
@@ -31,7 +31,7 @@ type addressType uint8
 
 const (
 	// noAddr denotes a blank address. An address of this type indicates
-	// that a node doesn't have any advertise d addresses.
+	// that a node doesn't have any advertised addresses.
 	noAddr addressType = 0
 
 	// tcp4Addr denotes an IPv4 TCP address.

--- a/lnwire/lnwire.go
+++ b/lnwire/lnwire.go
@@ -37,7 +37,7 @@ const (
 	// tcp4Addr denotes an IPv4 TCP address.
 	tcp4Addr addressType = 1
 
-	// tcp4Addr denotes an IPv6 TCP address.
+	// tcp6Addr denotes an IPv6 TCP address.
 	tcp6Addr addressType = 2
 
 	// v2OnionAddr denotes a version 2 Tor onion service address.

--- a/sample-lnd.conf
+++ b/sample-lnd.conf
@@ -68,7 +68,7 @@
 ; Adding an external IP will advertise your node to the network. This signals
 ; that your node is available to accept incoming channels. If you don't wish to
 ; advertise your node, this value doesn't need to be set.
-;externalip=            
+; externalip=            
 
 
 ; Debug logging level.
@@ -79,11 +79,11 @@
 ; debuglevel=info
 
 ; Write CPU profile to the specified file.
-;cpuprofile=
+; cpuprofile=
 
 ; Enable HTTP profiling on given port -- NOTE port must be between 1024 and
 ; 65536. The profile can be access at: http://localhost:<PORT>/debug/pprof/.
-;profile=
+; profile=
 
 ; The maximum number of incoming pending channels permitted per peer.
 ; maxpendingchannels=1
@@ -193,10 +193,10 @@ bitcoin.node=btcd
 ; Connect only to the specified peers at startup. This creates a persistent
 ; connection to a target peer. This is recommended as there aren't many
 ; neutrino compliant full nodes on the test network yet.
-;neutrino.connect=
+; neutrino.connect=
 
 ; Add a peer to connect with at startup.
-;neutrino.addpeer=
+; neutrino.addpeer=
 
 
 [Litecoin]

--- a/sample-lnd.conf
+++ b/sample-lnd.conf
@@ -103,6 +103,14 @@
 ; to decrypt it. This value is ONLY to be used in testing environments.
 ; noencryptwallet=1
 
+; The alias your node will use, which can be up to 32 UTF-8 characters in
+; length.
+; alias=My Lightning ☇
+
+; The color of the node in hex format, used to customize node appearance in
+; intelligence services.
+; color=#3399FF
+
 
 [Bitcoin]
 


### PR DESCRIPTION
Adds color and alias examples to the sample config, closes #682 

Also clarifies the behavior of externalip when no port is specified, which caused confusion in #683, closes #651
