### PR TITLE
multi: upgrade macaroons to v2, replace per-method auth with interceptors

### DIFF
--- a/cmd/lncli/main.go
+++ b/cmd/lncli/main.go
@@ -11,7 +11,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	"gopkg.in/macaroon.v1"
+	macaroon "gopkg.in/macaroon.v2"
 
 	"github.com/lightningnetwork/lnd/lnrpc"
 	"github.com/lightningnetwork/lnd/macaroons"

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 70e2030c50a730ad0ad428176f12851f35178e31e262bae82cedd89579a14b40
-updated: 2018-01-24T15:24:09.346726778-08:00
+hash: f72fdbb4d93ddd98991e830f978bfe9e08623e2a9976857b0f7668641486369c
+updated: 2018-01-29T15:55:37.905498329-07:00
 imports:
 - name: github.com/aead/chacha20
   version: d31a916ded42d1640b9d89a26f8abd53cc96790c
@@ -204,11 +204,11 @@ imports:
   - transport
 - name: gopkg.in/errgo.v1
   version: 442357a80af5c6bf9b6d51ae791a39c3421004f3
-- name: gopkg.in/macaroon-bakery.v1
-  version: 8e14f8b0f5e286ad100ca8d6ce5bde0f0dfb8b21
+- name: gopkg.in/macaroon-bakery.v2
+  version: 04cf5ef151a211d929975161aea7c65f94c90446
   subpackages:
   - bakery
   - bakery/checkers
-- name: gopkg.in/macaroon.v1
-  version: ab101776739ee61baab9bc50e4b33b5aeb3ac843
+- name: gopkg.in/macaroon.v2
+  version: bed2a428da6e56d950bed5b41fcbae3141e5b0d0
 testImports: []

--- a/glide.yaml
+++ b/glide.yaml
@@ -74,8 +74,8 @@ import:
   - chaincfg
 - package: github.com/lightninglabs/neutrino
   version: 6c8f30a130bb170348ceb754ce4204156efe2741
-- package: gopkg.in/macaroon.v1
-- package: gopkg.in/macaroon-bakery.v1
+- package: gopkg.in/macaroon.v2
+- package: gopkg.in/macaroon-bakery.v2
 - package: github.com/juju/loggo
 - package: github.com/rogpeppe/fastuuid
 - package: gopkg.in/errgo.v1

--- a/lnd.go
+++ b/lnd.go
@@ -24,7 +24,7 @@ import (
 	"sync"
 	"time"
 
-	"gopkg.in/macaroon-bakery.v1/bakery"
+	"gopkg.in/macaroon-bakery.v2/bakery"
 
 	"golang.org/x/net/context"
 
@@ -143,10 +143,15 @@ func lndMain() error {
 	defer chanDB.Close()
 
 	// Only process macaroons if --no-macaroons isn't set.
-	var macaroonService *bakery.Service
+	ctx := context.Background()
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	var macaroonService *bakery.Bakery
 	if !cfg.NoMacaroons {
 		// Create the macaroon authentication/authorization service.
-		macaroonService, err = macaroons.NewService(macaroonDatabaseDir)
+		macaroonService, err = macaroons.NewService(macaroonDatabaseDir,
+			macaroons.IPLockChecker)
 		if err != nil {
 			srvrLog.Errorf("unable to create macaroon service: %v", err)
 			return err
@@ -154,8 +159,8 @@ func lndMain() error {
 
 		// Create macaroon files for lncli to use if they don't exist.
 		if !fileExists(cfg.AdminMacPath) && !fileExists(cfg.ReadMacPath) {
-			err = genMacaroons(macaroonService, cfg.AdminMacPath,
-				cfg.ReadMacPath)
+			err = genMacaroons(ctx, macaroonService,
+				cfg.AdminMacPath, cfg.ReadMacPath)
 			if err != nil {
 				ltndLog.Errorf("unable to create macaroon "+
 					"files: %v", err)
@@ -368,9 +373,19 @@ func lndMain() error {
 	}
 	server.fundingMgr = fundingMgr
 
+	// Check macaroon authentication if macaroons aren't disabled.
+	if macaroonService != nil {
+		serverOpts = append(serverOpts,
+			grpc.UnaryInterceptor(macaroons.UnaryServerInterceptor(
+				macaroonService, permissions)),
+			grpc.StreamInterceptor(macaroons.StreamServerInterceptor(
+				macaroonService, permissions)),
+		)
+	}
+
 	// Initialize, and register our implementation of the gRPC interface
 	// exported by the rpcServer.
-	rpcServer := newRPCServer(server, macaroonService)
+	rpcServer := newRPCServer(server)
 	if err := rpcServer.Start(); err != nil {
 		return err
 	}
@@ -393,10 +408,6 @@ func lndMain() error {
 	}
 
 	// Finally, start the REST proxy for our gRPC server above.
-	ctx := context.Background()
-	ctx, cancel := context.WithCancel(ctx)
-	defer cancel()
-
 	mux := proxy.NewServeMux()
 	err = lnrpc.RegisterLightningHandlerFromEndpoint(ctx, mux,
 		cfg.RPCListeners[0], proxyOpts)
@@ -648,32 +659,35 @@ func genCertPair(certFile, keyFile string) error {
 
 // genMacaroons generates a pair of macaroon files; one admin-level and one
 // read-only. These can also be used to generate more granular macaroons.
-func genMacaroons(svc *bakery.Service, admFile, roFile string) error {
-	// Generate the admin macaroon and write it to a file.
-	admMacaroon, err := svc.NewMacaroon("", nil, nil)
-	if err != nil {
-		return err
-	}
-	admBytes, err := admMacaroon.MarshalBinary()
-	if err != nil {
-		return err
-	}
-	if err = ioutil.WriteFile(admFile, admBytes, 0600); err != nil {
-		return err
-	}
+func genMacaroons(ctx context.Context, svc *bakery.Bakery, admFile,
+	roFile string) error {
 
 	// Generate the read-only macaroon and write it to a file.
-	roMacaroon, err := macaroons.AddConstraints(admMacaroon,
-		macaroons.AllowConstraint(roPermissions...))
+	roMacaroon, err := svc.Oven.NewMacaroon(ctx, bakery.LatestVersion, nil,
+		readPermissions...)
 	if err != nil {
 		return err
 	}
-	roBytes, err := roMacaroon.MarshalBinary()
+	roBytes, err := roMacaroon.M().MarshalBinary()
 	if err != nil {
 		return err
 	}
 	if err = ioutil.WriteFile(roFile, roBytes, 0644); err != nil {
 		os.Remove(admFile)
+		return err
+	}
+
+	// Generate the admin macaroon and write it to a file.
+	admMacaroon, err := svc.Oven.NewMacaroon(ctx, bakery.LatestVersion,
+		nil, append(readPermissions, writePermissions...)...)
+	if err != nil {
+		return err
+	}
+	admBytes, err := admMacaroon.M().MarshalBinary()
+	if err != nil {
+		return err
+	}
+	if err = ioutil.WriteFile(admFile, admBytes, 0600); err != nil {
 		return err
 	}
 
@@ -685,7 +699,7 @@ func genMacaroons(svc *bakery.Service, admFile, roFile string) error {
 // the user to this RPC server.
 func waitForWalletPassword(grpcEndpoints, restEndpoints []string,
 	serverOpts []grpc.ServerOption, proxyOpts []grpc.DialOption,
-	tlsConf *tls.Config, macaroonService *bakery.Service) ([]byte, []byte, error) {
+	tlsConf *tls.Config, macaroonService *bakery.Bakery) ([]byte, []byte, error) {
 
 	// Set up a new PasswordService, which will listen
 	// for passwords provided over RPC.

--- a/lntest/node.go
+++ b/lntest/node.go
@@ -18,7 +18,7 @@ import (
 	"golang.org/x/net/context"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
-	macaroon "gopkg.in/macaroon.v1"
+	macaroon "gopkg.in/macaroon.v2"
 
 	"github.com/go-errors/errors"
 	"github.com/lightningnetwork/lnd/lnrpc"

--- a/macaroons/service.go
+++ b/macaroons/service.go
@@ -1,9 +1,15 @@
 package macaroons
 
 import (
+	"fmt"
 	"path"
 
-	"gopkg.in/macaroon-bakery.v1/bakery"
+	"google.golang.org/grpc"
+
+	"gopkg.in/macaroon-bakery.v2/bakery"
+	"gopkg.in/macaroon-bakery.v2/bakery/checkers"
+
+	"golang.org/x/net/context"
 
 	"github.com/boltdb/bolt"
 )
@@ -15,8 +21,13 @@ var (
 )
 
 // NewService returns a service backed by the macaroon Bolt DB stored in the
-// passed directory.
-func NewService(dir string) (*bakery.Service, error) {
+// passed directory. The `checks` argument can be any of the `Checker` type
+// functions defined in this package, or a custom checker if desired. This
+// constructor prevents double-registration of checkers to prevent panics, so
+// listing the same checker more than once is not harmful. Default checkers,
+// such as those for `allow`, `time-before`, `declared`, and `error` caveats
+// are registered automatically and don't need to be added.
+func NewService(dir string, checks ...Checker) (*bakery.Bakery, error) {
 	// Open the database that we'll use to store the primary macaroon key,
 	// and all generated macaroons+caveats.
 	macaroonDB, err := bolt.Open(path.Join(dir, dbFilename), 0600,
@@ -29,19 +40,90 @@ func NewService(dir string) (*bakery.Service, error) {
 	if err != nil {
 		return nil, err
 	}
-	macaroonStore, err := NewStorage(macaroonDB)
-	if err != nil {
-		return nil, err
-	}
 
-	macaroonParams := bakery.NewServiceParams{
+	macaroonParams := bakery.BakeryParams{
 		Location:     "lnd",
-		Store:        macaroonStore,
 		RootKeyStore: rootKeyStore,
 		// No third-party caveat support for now.
 		// TODO(aakselrod): Add third-party caveat support.
 		Locator: nil,
 		Key:     nil,
 	}
-	return bakery.NewService(macaroonParams)
+
+	svc := bakery.New(macaroonParams)
+
+	// Register all custom caveat checkers with the bakery's checker.
+	// TODO(aakselrod): Add more checks as required.
+	checker := svc.Checker.FirstPartyCaveatChecker.(*checkers.Checker)
+	for _, check := range checks {
+		cond, fun := check()
+		if !isRegistered(checker, cond) {
+			checker.Register(cond, "std", fun)
+		}
+	}
+
+	return svc, nil
+}
+
+// isRegistered checks to see if the required checker has already been
+// registered in order to avoid a panic caused by double registration.
+func isRegistered(c *checkers.Checker, name string) bool {
+	if c == nil {
+		return false
+	}
+
+	for _, info := range c.Info() {
+		if info.Name == name && info.Prefix == "std" {
+			return true
+		}
+	}
+
+	return false
+}
+
+// UnaryServerInterceptor is a GRPC interceptor that checks whether the
+// request is authorized by the included macaroons.
+func UnaryServerInterceptor(svc *bakery.Bakery,
+	permissionMap map[string][]bakery.Op) grpc.UnaryServerInterceptor {
+
+	return func(ctx context.Context, req interface{},
+		info *grpc.UnaryServerInfo,
+		handler grpc.UnaryHandler) (interface{}, error) {
+
+		if _, ok := permissionMap[info.FullMethod]; !ok {
+			return nil, fmt.Errorf("%s: unknown permissions "+
+				"required for method", info.FullMethod)
+		}
+
+		err := ValidateMacaroon(ctx, permissionMap[info.FullMethod],
+			svc)
+		if err != nil {
+			return nil, err
+		}
+
+		return handler(ctx, req)
+	}
+}
+
+// StreamServerInterceptor is a GRPC interceptor that checks whether the
+// request is authorized by the included macaroons.
+func StreamServerInterceptor(svc *bakery.Bakery,
+	permissionMap map[string][]bakery.Op) grpc.StreamServerInterceptor {
+
+	return func(srv interface{}, ss grpc.ServerStream,
+		info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
+
+		if _, ok := permissionMap[info.FullMethod]; !ok {
+			return fmt.Errorf("%s: unknown permissions required "+
+				"for method", info.FullMethod)
+		}
+
+		err := ValidateMacaroon(ss.Context(),
+			permissionMap[info.FullMethod], svc)
+		if err != nil {
+			return err
+		}
+
+		return handler(srv, ss)
+	}
 }

--- a/macaroons/store.go
+++ b/macaroons/store.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"io"
 
+	"golang.org/x/net/context"
+
 	"github.com/boltdb/bolt"
 )
 
@@ -21,7 +23,7 @@ var (
 	// just 0, to emulate the memory storage that comes with bakery.
 	//
 	// TODO(aakselrod): Add support for key rotation.
-	defaultRootKeyID = "0"
+	defaultRootKeyID = []byte("0")
 
 	// macaroonBucketName is the name of the macaroon store bucket.
 	macaroonBucketName = []byte("macaroons")
@@ -49,13 +51,13 @@ func NewRootKeyStorage(db *bolt.DB) (*RootKeyStorage, error) {
 }
 
 // Get implements the Get method for the bakery.RootKeyStorage interface.
-func (r *RootKeyStorage) Get(id string) ([]byte, error) {
+func (r *RootKeyStorage) Get(_ context.Context, id []byte) ([]byte, error) {
 	var rootKey []byte
 	err := r.View(func(tx *bolt.Tx) error {
-		dbKey := tx.Bucket(rootKeyBucketName).Get([]byte(id))
+		dbKey := tx.Bucket(rootKeyBucketName).Get(id)
 		if len(dbKey) == 0 {
 			return fmt.Errorf("root key with id %s doesn't exist",
-				id)
+				string(id))
 		}
 
 		rootKey = make([]byte, len(dbKey))
@@ -72,12 +74,12 @@ func (r *RootKeyStorage) Get(id string) ([]byte, error) {
 // RootKey implements the RootKey method for the bakery.RootKeyStorage
 // interface.
 // TODO(aakselrod): Add support for key rotation.
-func (r *RootKeyStorage) RootKey() ([]byte, string, error) {
+func (r *RootKeyStorage) RootKey(_ context.Context) ([]byte, []byte, error) {
 	var rootKey []byte
 	id := defaultRootKeyID
 	err := r.Update(func(tx *bolt.Tx) error {
 		ns := tx.Bucket(rootKeyBucketName)
-		rootKey = ns.Get([]byte(id))
+		rootKey = ns.Get(id)
 
 		// If there's no root key stored in the bucket yet, create one.
 		if len(rootKey) != 0 {
@@ -89,69 +91,11 @@ func (r *RootKeyStorage) RootKey() ([]byte, string, error) {
 		if _, err := io.ReadFull(rand.Reader, rootKey[:]); err != nil {
 			return err
 		}
-		return ns.Put([]byte(id), rootKey)
+		return ns.Put(id, rootKey)
 	})
 	if err != nil {
-		return nil, "", err
+		return nil, nil, err
 	}
 
 	return rootKey, id, nil
-}
-
-// Storage implements the bakery.Storage interface.
-type Storage struct {
-	*bolt.DB
-}
-
-// NewStorage creates a Storage instance.
-//
-// TODO(aakselrod): Add support for encryption of data with passphrase.
-func NewStorage(db *bolt.DB) (*Storage, error) {
-	// If the store's bucket doesn't exist, create it.
-	err := db.Update(func(tx *bolt.Tx) error {
-		_, err := tx.CreateBucketIfNotExists(macaroonBucketName)
-		return err
-	})
-	if err != nil {
-		return nil, err
-	}
-
-	// Return the DB wrapped in a Storage object.
-	return &Storage{db}, nil
-}
-
-// Put implements the Put method for the bakery.Storage interface.
-func (s *Storage) Put(location string, item string) error {
-	return s.Update(func(tx *bolt.Tx) error {
-		return tx.Bucket(macaroonBucketName).Put([]byte(location),
-			[]byte(item))
-	})
-}
-
-// Get implements the Get method for the bakery.Storage interface.
-func (s *Storage) Get(location string) (string, error) {
-	var item []byte
-	err := s.View(func(tx *bolt.Tx) error {
-		itemBytes := tx.Bucket(macaroonBucketName).Get([]byte(location))
-		if len(itemBytes) == 0 {
-			return fmt.Errorf("couldn't get item for location %s",
-				location)
-		}
-
-		item = make([]byte, len(itemBytes))
-		copy(item, itemBytes)
-		return nil
-	})
-	if err != nil {
-		return "", err
-	}
-
-	return string(item), nil
-}
-
-// Del implements the Del method for the bakery.Storage interface.
-func (s *Storage) Del(location string) error {
-	return s.Update(func(tx *bolt.Tx) error {
-		return tx.Bucket(macaroonBucketName).Delete([]byte(location))
-	})
 }

--- a/walletunlocker/service.go
+++ b/walletunlocker/service.go
@@ -8,7 +8,7 @@ import (
 	"github.com/roasbeef/btcd/chaincfg"
 	"github.com/roasbeef/btcwallet/wallet"
 	"golang.org/x/net/context"
-	"gopkg.in/macaroon-bakery.v1/bakery"
+	"gopkg.in/macaroon-bakery.v2/bakery"
 )
 
 // UnlockerService implements the WalletUnlocker service used to provide lnd
@@ -29,7 +29,7 @@ type UnlockerService struct {
 }
 
 // New creates and returns a new UnlockerService.
-func New(authSvc *bakery.Service, chainDir string,
+func New(authSvc *bakery.Bakery, chainDir string,
 	params *chaincfg.Params) *UnlockerService {
 	return &UnlockerService{
 		CreatePasswords: make(chan []byte, 1),


### PR DESCRIPTION
This PR reworks the macaroon authentication framework to use the v2 macaroon format and bakery API. It also replaces the code in each RPC method which calls the macaroon verifier with interceptors which call the macaroon verifier instead. In addition, the operation permissions are reworked to fit the new format of "allow" commands (specifically, entity/operation permissions instead of method permissions).