### PR TITLE
multi: memoize pubkey+signature decoding to reduce GC bursts, add reject cache to stop zombie churn

### DIFF
--- a/autopilot/agent_test.go
+++ b/autopilot/agent_test.go
@@ -9,6 +9,7 @@ import (
 
 	"errors"
 	"fmt"
+
 	"github.com/roasbeef/btcd/btcec"
 	"github.com/roasbeef/btcd/wire"
 	"github.com/roasbeef/btcutil"

--- a/channeldb/channel_test.go
+++ b/channeldb/channel_test.go
@@ -81,6 +81,8 @@ var (
 		Index: 0,
 	}
 	privKey, pubKey = btcec.PrivKeyFromBytes(btcec.S256(), key[:])
+
+	wireSig, _ = lnwire.NewSigFromSignature(testSig)
 )
 
 // makeTestDB creates a new instance of the ChannelDB for testing purposes. A
@@ -428,10 +430,10 @@ func TestChannelStateTransition(t *testing.T) {
 		Commitment: remoteCommit,
 		CommitSig: &lnwire.CommitSig{
 			ChanID:    lnwire.ChannelID(key),
-			CommitSig: testSig,
-			HtlcSigs: []*btcec.Signature{
-				testSig,
-				testSig,
+			CommitSig: wireSig,
+			HtlcSigs: []lnwire.Sig{
+				wireSig,
+				wireSig,
 			},
 		},
 		LogUpdates: []LogUpdate{

--- a/channeldb/graph.go
+++ b/channeldb/graph.go
@@ -1020,17 +1020,17 @@ type LightningNode struct {
 //
 // NOTE: By having this method to access an attribute, we ensure we only need
 // to fully deserialize the pubkey if absolutely necessary.
-func (c *LightningNode) PubKey() (*btcec.PublicKey, error) {
-	if c.pubKey != nil {
-		return c.pubKey, nil
+func (l *LightningNode) PubKey() (*btcec.PublicKey, error) {
+	if l.pubKey != nil {
+		return l.pubKey, nil
 	}
 
-	key, err := btcec.ParsePubKey(c.PubKeyBytes[:], btcec.S256())
+	key, err := btcec.ParsePubKey(l.PubKeyBytes[:], btcec.S256())
 	if err != nil {
 		return nil, err
 	}
-	c.pubKey = key
-	c.pubKey.Curve = nil
+	l.pubKey = key
+	l.pubKey.Curve = nil
 
 	return key, nil
 }
@@ -1040,15 +1040,15 @@ func (c *LightningNode) PubKey() (*btcec.PublicKey, error) {
 //
 // NOTE: By having this method to access an attribute, we ensure we only need
 // to fully deserialize the signature if absolutely necessary.
-func (c *LightningNode) AuthSig() (*btcec.Signature, error) {
-	return btcec.ParseSignature(c.AuthSigBytes, btcec.S256())
+func (l *LightningNode) AuthSig() (*btcec.Signature, error) {
+	return btcec.ParseSignature(l.AuthSigBytes, btcec.S256())
 }
 
 // AddPubKey is a setter-link method that can be used to swap out the public
 // key for a node.
-func (c *LightningNode) AddPubKey(key *btcec.PublicKey) {
-	c.pubKey = key
-	copy(c.PubKeyBytes[:], key.SerializeCompressed())
+func (l *LightningNode) AddPubKey(key *btcec.PublicKey) {
+	l.pubKey = key
+	copy(l.PubKeyBytes[:], key.SerializeCompressed())
 }
 
 // FetchLightningNode attempts to look up a target node by its identity public
@@ -1442,7 +1442,7 @@ type ChannelAuthProof struct {
 	BitcoinSig2Bytes []byte
 }
 
-// NodeSig1 is the signature using the identity key of the node that is first
+// Node1Sig is the signature using the identity key of the node that is first
 // in a lexicographical ordering of the serialized public keys of the two nodes
 // that created the channel.
 //
@@ -1463,7 +1463,7 @@ func (c *ChannelAuthProof) Node1Sig() (*btcec.Signature, error) {
 	return sig, nil
 }
 
-// NodeSig2 is the signature using the identity key of the node that is second
+// Node2Sig is the signature using the identity key of the node that is second
 // in a lexicographical ordering of the serialized public keys of the two nodes
 // that created the channel.
 //
@@ -1526,11 +1526,11 @@ func (c *ChannelAuthProof) BitcoinSig2() (*btcec.Signature, error) {
 
 // IsEmpty check is the authentication proof is empty Proof is empty if at
 // least one of the signatures are equal to nil.
-func (p *ChannelAuthProof) IsEmpty() bool {
-	return len(p.NodeSig1Bytes) == 0 ||
-		len(p.NodeSig2Bytes) == 0 ||
-		len(p.BitcoinSig1Bytes) == 0 ||
-		len(p.BitcoinSig2Bytes) == 0
+func (c *ChannelAuthProof) IsEmpty() bool {
+	return len(c.NodeSig1Bytes) == 0 ||
+		len(c.NodeSig2Bytes) == 0 ||
+		len(c.BitcoinSig1Bytes) == 0 ||
+		len(c.BitcoinSig2Bytes) == 0
 }
 
 // ChannelEdgePolicy represents a *directed* edge within the channel graph. For

--- a/channeldb/waitingproof_test.go
+++ b/channeldb/waitingproof_test.go
@@ -21,8 +21,8 @@ func TestWaitingProofStore(t *testing.T) {
 	defer cleanup()
 
 	proof1 := NewWaitingProof(true, &lnwire.AnnounceSignatures{
-		NodeSignature:    testSig,
-		BitcoinSignature: testSig,
+		NodeSignature:    wireSig,
+		BitcoinSignature: wireSig,
 	})
 
 	store, err := NewWaitingProofStore(db)

--- a/discovery/ann_validation.go
+++ b/discovery/ann_validation.go
@@ -26,23 +26,56 @@ func ValidateChannelAnn(a *lnwire.ChannelAnnouncement) error {
 
 	// First we'll verify that the passed bitcoin key signature is indeed a
 	// signature over the computed hash digest.
-	if !a.BitcoinSig1.Verify(dataHash, copyPubKey(a.BitcoinKey1)) {
+	bitcoinSig1, err := a.BitcoinSig1.ToSignature()
+	if err != nil {
+		return err
+	}
+	bitcoinKey1, err := btcec.ParsePubKey(a.BitcoinKey1[:], btcec.S256())
+	if err != nil {
+		return err
+	}
+	if !bitcoinSig1.Verify(dataHash, bitcoinKey1) {
 		return errors.New("can't verify first bitcoin signature")
 	}
 
 	// If that checks out, then we'll verify that the second bitcoin
 	// signature is a valid signature of the bitcoin public key over hash
 	// digest as well.
-	if !a.BitcoinSig2.Verify(dataHash, copyPubKey(a.BitcoinKey2)) {
+	bitcoinSig2, err := a.BitcoinSig2.ToSignature()
+	if err != nil {
+		return err
+	}
+	bitcoinKey2, err := btcec.ParsePubKey(a.BitcoinKey2[:], btcec.S256())
+	if err != nil {
+		return err
+	}
+	if !bitcoinSig2.Verify(dataHash, bitcoinKey2) {
 		return errors.New("can't verify second bitcoin signature")
 	}
 
 	// Both node signatures attached should indeed be a valid signature
 	// over the selected digest of the channel announcement signature.
-	if !a.NodeSig1.Verify(dataHash, copyPubKey(a.NodeID1)) {
+	nodeSig1, err := a.NodeSig1.ToSignature()
+	if err != nil {
+		return err
+	}
+	nodeKey1, err := btcec.ParsePubKey(a.NodeID1[:], btcec.S256())
+	if err != nil {
+		return err
+	}
+	if !nodeSig1.Verify(dataHash, nodeKey1) {
 		return errors.New("can't verify data in first node signature")
 	}
-	if !a.NodeSig2.Verify(dataHash, copyPubKey(a.NodeID2)) {
+
+	nodeSig2, err := a.NodeSig2.ToSignature()
+	if err != nil {
+		return err
+	}
+	nodeKey2, err := btcec.ParsePubKey(a.NodeID2[:], btcec.S256())
+	if err != nil {
+		return err
+	}
+	if !nodeSig2.Verify(dataHash, nodeKey2) {
 		return errors.New("can't verify data in second node signature")
 	}
 
@@ -61,17 +94,26 @@ func ValidateNodeAnn(a *lnwire.NodeAnnouncement) error {
 		return err
 	}
 
+	nodeSig, err := a.Signature.ToSignature()
+	if err != nil {
+		return err
+	}
+	nodeKey, err := btcec.ParsePubKey(a.NodeID[:], btcec.S256())
+	if err != nil {
+		return err
+	}
+
 	// Finally ensure that the passed signature is valid, if not we'll
 	// return an error so this node announcement can be rejected.
 	dataHash := chainhash.DoubleHashB(data)
-	if !a.Signature.Verify(dataHash, copyPubKey(a.NodeID)) {
+	if !nodeSig.Verify(dataHash, nodeKey) {
 		var msgBuf bytes.Buffer
 		if _, err := lnwire.WriteMessage(&msgBuf, a, 0); err != nil {
 			return err
 		}
 
 		return errors.Errorf("signature on NodeAnnouncement(%x) is "+
-			"invalid: %x", a.NodeID.SerializeCompressed(),
+			"invalid: %x", nodeKey.SerializeCompressed(),
 			msgBuf.Bytes())
 	}
 
@@ -90,7 +132,12 @@ func ValidateChannelUpdateAnn(pubKey *btcec.PublicKey,
 	}
 	dataHash := chainhash.DoubleHashB(data)
 
-	if !a.Signature.Verify(dataHash, copyPubKey(pubKey)) {
+	nodeSig, err := a.Signature.ToSignature()
+	if err != nil {
+		return err
+	}
+
+	if !nodeSig.Verify(dataHash, pubKey) {
 		return errors.Errorf("invalid signature for channel "+
 			"update %v", spew.Sdump(a))
 	}

--- a/discovery/utils.go
+++ b/discovery/utils.go
@@ -16,24 +16,46 @@ import (
 func createChanAnnouncement(chanProof *channeldb.ChannelAuthProof,
 	chanInfo *channeldb.ChannelEdgeInfo,
 	e1, e2 *channeldb.ChannelEdgePolicy) (*lnwire.ChannelAnnouncement,
-	*lnwire.ChannelUpdate, *lnwire.ChannelUpdate) {
+	*lnwire.ChannelUpdate, *lnwire.ChannelUpdate, error) {
 
 	// First, using the parameters of the channel, along with the channel
 	// authentication chanProof, we'll create re-create the original
 	// authenticated channel announcement.
 	chanID := lnwire.NewShortChanIDFromInt(chanInfo.ChannelID)
 	chanAnn := &lnwire.ChannelAnnouncement{
-		NodeSig1:       chanProof.NodeSig1,
-		NodeSig2:       chanProof.NodeSig2,
 		ShortChannelID: chanID,
-		BitcoinSig1:    chanProof.BitcoinSig1,
-		BitcoinSig2:    chanProof.BitcoinSig2,
-		NodeID1:        chanInfo.NodeKey1,
-		NodeID2:        chanInfo.NodeKey2,
+		NodeID1:        chanInfo.NodeKey1Bytes,
+		NodeID2:        chanInfo.NodeKey2Bytes,
 		ChainHash:      chanInfo.ChainHash,
-		BitcoinKey1:    chanInfo.BitcoinKey1,
+		BitcoinKey1:    chanInfo.BitcoinKey1Bytes,
+		BitcoinKey2:    chanInfo.BitcoinKey2Bytes,
 		Features:       lnwire.NewRawFeatureVector(),
-		BitcoinKey2:    chanInfo.BitcoinKey2,
+	}
+
+	var err error
+	chanAnn.BitcoinSig1, err = lnwire.NewSigFromRawSignature(
+		chanProof.BitcoinSig1Bytes,
+	)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	chanAnn.BitcoinSig2, err = lnwire.NewSigFromRawSignature(
+		chanProof.BitcoinSig2Bytes,
+	)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	chanAnn.NodeSig1, err = lnwire.NewSigFromRawSignature(
+		chanProof.NodeSig1Bytes,
+	)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	chanAnn.NodeSig2, err = lnwire.NewSigFromRawSignature(
+		chanProof.NodeSig2Bytes,
+	)
+	if err != nil {
+		return nil, nil, nil, err
 	}
 
 	// We'll unconditionally queue the channel's existence chanProof as it
@@ -46,7 +68,6 @@ func createChanAnnouncement(chanProof *channeldb.ChannelAuthProof,
 	var edge1Ann, edge2Ann *lnwire.ChannelUpdate
 	if e1 != nil {
 		edge1Ann = &lnwire.ChannelUpdate{
-			Signature:       e1.Signature,
 			ChainHash:       chanInfo.ChainHash,
 			ShortChannelID:  chanID,
 			Timestamp:       uint32(e1.LastUpdate.Unix()),
@@ -56,10 +77,13 @@ func createChanAnnouncement(chanProof *channeldb.ChannelAuthProof,
 			BaseFee:         uint32(e1.FeeBaseMSat),
 			FeeRate:         uint32(e1.FeeProportionalMillionths),
 		}
+		edge1Ann.Signature, err = lnwire.NewSigFromRawSignature(e1.SigBytes)
+		if err != nil {
+			return nil, nil, nil, err
+		}
 	}
 	if e2 != nil {
 		edge2Ann = &lnwire.ChannelUpdate{
-			Signature:       e2.Signature,
 			ChainHash:       chanInfo.ChainHash,
 			ShortChannelID:  chanID,
 			Timestamp:       uint32(e2.LastUpdate.Unix()),
@@ -69,9 +93,13 @@ func createChanAnnouncement(chanProof *channeldb.ChannelAuthProof,
 			BaseFee:         uint32(e2.FeeBaseMSat),
 			FeeRate:         uint32(e2.FeeProportionalMillionths),
 		}
+		edge2Ann.Signature, err = lnwire.NewSigFromRawSignature(e2.SigBytes)
+		if err != nil {
+			return nil, nil, nil, err
+		}
 	}
 
-	return chanAnn, edge1Ann, edge2Ann
+	return chanAnn, edge1Ann, edge2Ann, nil
 }
 
 // copyPubKey performs a copy of the target public key, setting a fresh curve

--- a/fundingmanager.go
+++ b/fundingmanager.go
@@ -1062,14 +1062,6 @@ func (f *fundingManager) handleFundingAccept(fmsg *fundingAcceptMsg) {
 	// the commitment transaction to the remote peer.
 	outPoint := resCtx.reservation.FundingOutpoint()
 	_, sig := resCtx.reservation.OurSignatures()
-	commitSig, err := btcec.ParseSignature(sig, btcec.S256())
-	if err != nil {
-		fndgLog.Errorf("Unable to parse signature: %v", err)
-		f.failFundingFlow(fmsg.peerAddress.IdentityKey,
-			msg.PendingChannelID, []byte(err.Error()))
-		resCtx.err <- err
-		return
-	}
 
 	// A new channel has almost finished the funding process. In order to
 	// properly synchronize with the writeHandler goroutine, we add a new
@@ -1095,7 +1087,14 @@ func (f *fundingManager) handleFundingAccept(fmsg *fundingAcceptMsg) {
 	fundingCreated := &lnwire.FundingCreated{
 		PendingChannelID: pendingChanID,
 		FundingPoint:     *outPoint,
-		CommitSig:        commitSig,
+	}
+	fundingCreated.CommitSig, err = lnwire.NewSigFromRawSignature(sig)
+	if err != nil {
+		fndgLog.Errorf("Unable to parse signature: %v", err)
+		f.failFundingFlow(fmsg.peerAddress.IdentityKey,
+			msg.PendingChannelID, []byte(err.Error()))
+		resCtx.err <- err
+		return
 	}
 	err = f.cfg.SendToPeer(fmsg.peerAddress.IdentityKey, fundingCreated)
 	if err != nil {
@@ -1148,7 +1147,7 @@ func (f *fundingManager) handleFundingCreated(fmsg *fundingCreatedMsg) {
 	// funding transaction will broadcast after our next message.
 	// CompleteReservationSingle will also mark the channel as 'IsPending'
 	// in the database.
-	commitSig := fmsg.msg.CommitSig.Serialize()
+	commitSig := fmsg.msg.CommitSig.ToSignatureBytes()
 	completeChan, err := resCtx.reservation.CompleteReservationSingle(
 		&fundingOut, commitSig)
 	if err != nil {
@@ -1191,11 +1190,8 @@ func (f *fundingManager) handleFundingCreated(fmsg *fundingCreatedMsg) {
 
 	// With their signature for our version of the commitment transaction
 	// verified, we can now send over our signature to the remote peer.
-	//
-	// TODO(roasbeef): just have raw bytes in wire msg? avoids decoding
-	// then decoding shortly afterwards.
 	_, sig := resCtx.reservation.OurSignatures()
-	ourCommitSig, err := btcec.ParseSignature(sig, btcec.S256())
+	ourCommitSig, err := lnwire.NewSigFromRawSignature(sig)
 	if err != nil {
 		fndgLog.Errorf("unable to parse signature: %v", err)
 		f.failFundingFlow(fmsg.peerAddress.IdentityKey,
@@ -1344,7 +1340,7 @@ func (f *fundingManager) handleFundingSigned(fmsg *fundingSignedMsg) {
 	// The remote peer has responded with a signature for our commitment
 	// transaction. We'll verify the signature for validity, then commit
 	// the state to disk as we can now open the channel.
-	commitSig := fmsg.msg.CommitSig.Serialize()
+	commitSig := fmsg.msg.CommitSig.ToSignatureBytes()
 	completeChan, err := resCtx.reservation.CompleteReservation(nil, commitSig)
 	if err != nil {
 		fndgLog.Errorf("Unable to complete reservation sign complete: %v", err)
@@ -2127,19 +2123,19 @@ func (f *fundingManager) newChanAnnouncement(localPubKey, remotePubKey *btcec.Pu
 	selfBytes := localPubKey.SerializeCompressed()
 	remoteBytes := remotePubKey.SerializeCompressed()
 	if bytes.Compare(selfBytes, remoteBytes) == -1 {
-		chanAnn.NodeID1 = localPubKey
-		chanAnn.NodeID2 = remotePubKey
-		chanAnn.BitcoinKey1 = localFundingKey
-		chanAnn.BitcoinKey2 = remoteFundingKey
+		copy(chanAnn.NodeID1[:], localPubKey.SerializeCompressed())
+		copy(chanAnn.NodeID2[:], remotePubKey.SerializeCompressed())
+		copy(chanAnn.BitcoinKey1[:], localFundingKey.SerializeCompressed())
+		copy(chanAnn.BitcoinKey2[:], remoteFundingKey.SerializeCompressed())
 
 		// If we're the first node then update the chanFlags to
 		// indicate the "direction" of the update.
 		chanFlags = 0
 	} else {
-		chanAnn.NodeID1 = remotePubKey
-		chanAnn.NodeID2 = localPubKey
-		chanAnn.BitcoinKey1 = remoteFundingKey
-		chanAnn.BitcoinKey2 = localFundingKey
+		copy(chanAnn.NodeID1[:], remotePubKey.SerializeCompressed())
+		copy(chanAnn.NodeID2[:], localPubKey.SerializeCompressed())
+		copy(chanAnn.BitcoinKey1[:], remoteFundingKey.SerializeCompressed())
+		copy(chanAnn.BitcoinKey2[:], localFundingKey.SerializeCompressed())
 
 		// If we're the second node then update the chanFlags to
 		// indicate the "direction" of the update.
@@ -2171,7 +2167,12 @@ func (f *fundingManager) newChanAnnouncement(localPubKey, remotePubKey *btcec.Pu
 	if err != nil {
 		return nil, err
 	}
-	chanUpdateAnn.Signature, err = f.cfg.SignMessage(f.cfg.IDKey, chanUpdateMsg)
+	sig, err := f.cfg.SignMessage(f.cfg.IDKey, chanUpdateMsg)
+	if err != nil {
+		return nil, errors.Errorf("unable to generate channel "+
+			"update announcement signature: %v", err)
+	}
+	chanUpdateAnn.Signature, err = lnwire.NewSigFromSignature(sig)
 	if err != nil {
 		return nil, errors.Errorf("unable to generate channel "+
 			"update announcement signature: %v", err)
@@ -2203,10 +2204,16 @@ func (f *fundingManager) newChanAnnouncement(localPubKey, remotePubKey *btcec.Pu
 	// provide the other side with the necessary signatures required to
 	// allow them to reconstruct the full channel announcement.
 	proof := &lnwire.AnnounceSignatures{
-		ChannelID:        chanID,
-		ShortChannelID:   shortChanID,
-		NodeSignature:    nodeSig,
-		BitcoinSignature: bitcoinSig,
+		ChannelID:      chanID,
+		ShortChannelID: shortChanID,
+	}
+	proof.NodeSignature, err = lnwire.NewSigFromSignature(nodeSig)
+	if err != nil {
+		return nil, err
+	}
+	proof.BitcoinSignature, err = lnwire.NewSigFromSignature(bitcoinSig)
+	if err != nil {
+		return nil, err
 	}
 
 	return &chanAnnouncement{

--- a/fundingmanager_test.go
+++ b/fundingmanager_test.go
@@ -5,6 +5,7 @@ package main
 import (
 	"fmt"
 	"io/ioutil"
+	"math/big"
 	"net"
 	"os"
 	"path/filepath"
@@ -79,6 +80,13 @@ var (
 		IdentityKey: bobPubKey,
 		Address:     bobTCPAddr,
 	}
+
+	testSig = &btcec.Signature{
+		R: new(big.Int),
+		S: new(big.Int),
+	}
+	_, _ = testSig.R.SetString("63724406601629180062774974542967536251589935445068131219452686511677818569431", 10)
+	_, _ = testSig.S.SetString("18801056069249825825291287104931333862866033135609736119018462340006816851118", 10)
 )
 
 type mockNotifier struct {
@@ -217,7 +225,7 @@ func createTestFundingManager(t *testing.T, privKey *btcec.PrivateKey,
 		Notifier:     chainNotifier,
 		FeeEstimator: estimator,
 		SignMessage: func(pubKey *btcec.PublicKey, msg []byte) (*btcec.Signature, error) {
-			return nil, nil
+			return testSig, nil
 		},
 		SendAnnouncement: func(msg lnwire.Message) error {
 			select {
@@ -319,7 +327,7 @@ func recreateAliceFundingManager(t *testing.T, alice *testNode) {
 		FeeEstimator: oldCfg.FeeEstimator,
 		SignMessage: func(pubKey *btcec.PublicKey,
 			msg []byte) (*btcec.Signature, error) {
-			return nil, nil
+			return testSig, nil
 		},
 		SendAnnouncement: func(msg lnwire.Message) error {
 			select {

--- a/htlcswitch/link_test.go
+++ b/htlcswitch/link_test.go
@@ -57,13 +57,6 @@ func messageToString(msg lnwire.Message) string {
 	switch m := msg.(type) {
 	case *lnwire.RevokeAndAck:
 		m.NextRevocationKey.Curve = nil
-	case *lnwire.NodeAnnouncement:
-		m.NodeID.Curve = nil
-	case *lnwire.ChannelAnnouncement:
-		m.NodeID1.Curve = nil
-		m.NodeID2.Curve = nil
-		m.BitcoinKey1.Curve = nil
-		m.BitcoinKey2.Curve = nil
 	case *lnwire.AcceptChannel:
 		m.FundingKey.Curve = nil
 		m.RevocationPoint.Curve = nil

--- a/htlcswitch/test_utils.go
+++ b/htlcswitch/test_utils.go
@@ -48,6 +48,7 @@ var (
 		R: new(big.Int),
 		S: new(big.Int),
 	}
+	wireSig, _ = lnwire.NewSigFromSignature(testSig)
 
 	_, _ = testSig.R.SetString("6372440660162918006277497454296753625158993"+
 		"5445068131219452686511677818569431", 10)
@@ -55,11 +56,11 @@ var (
 		"3135609736119018462340006816851118", 10)
 )
 
-// mockGetChanUpdateMessage helper function which returns topology update
-// of the channel
+// mockGetChanUpdateMessage helper function which returns topology update of
+// the channel
 func mockGetChanUpdateMessage() (*lnwire.ChannelUpdate, error) {
 	return &lnwire.ChannelUpdate{
-		Signature: testSig,
+		Signature: wireSig,
 	}, nil
 }
 

--- a/lnwallet/channel_test.go
+++ b/lnwallet/channel_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"crypto/sha256"
 	"io/ioutil"
-	"math/big"
 	"math/rand"
 	"os"
 	"reflect"
@@ -2768,20 +2767,20 @@ func TestChanSyncOweCommitment(t *testing.T) {
 			t.Fatalf("expected a CommitSig message, instead have %v",
 				spew.Sdump(aliceMsgsToSend[4]))
 		}
-		if !commitSigMsg.CommitSig.IsEqual(aliceSig) {
+		if commitSigMsg.CommitSig != aliceSig {
 			t.Fatalf("commit sig msgs don't match: expected %x got %x",
-				aliceSig.Serialize(), commitSigMsg.CommitSig.Serialize())
+				aliceSig, commitSigMsg.CommitSig)
 		}
 		if len(commitSigMsg.HtlcSigs) != len(aliceHtlcSigs) {
 			t.Fatalf("wrong number of htlc sigs: expected %v, got %v",
 				len(aliceHtlcSigs), len(commitSigMsg.HtlcSigs))
 		}
 		for i, htlcSig := range commitSigMsg.HtlcSigs {
-			if !htlcSig.IsEqual(aliceHtlcSigs[i]) {
+			if htlcSig != aliceHtlcSigs[i] {
 				t.Fatalf("htlc sig msgs don't match: "+
 					"expected %x got %x",
-					aliceHtlcSigs[i].Serialize(),
-					htlcSig.Serialize())
+					aliceHtlcSigs[i],
+					htlcSig)
 			}
 		}
 	}
@@ -3228,20 +3227,19 @@ func TestChanSyncOweRevocationAndCommit(t *testing.T) {
 			t.Fatalf("expected bob to re-send commit sig, instead sending: %v",
 				spew.Sdump(bobMsgsToSend[1]))
 		}
-		if !bobReCommitSigMsg.CommitSig.IsEqual(bobSig) {
+		if bobReCommitSigMsg.CommitSig != bobSig {
 			t.Fatalf("commit sig msgs don't match: expected %x got %x",
-				bobSig.Serialize(), bobReCommitSigMsg.CommitSig.Serialize())
+				bobSig, bobReCommitSigMsg.CommitSig)
 		}
 		if len(bobReCommitSigMsg.HtlcSigs) != len(bobHtlcSigs) {
 			t.Fatalf("wrong number of htlc sigs: expected %v, got %v",
 				len(bobHtlcSigs), len(bobReCommitSigMsg.HtlcSigs))
 		}
 		for i, htlcSig := range bobReCommitSigMsg.HtlcSigs {
-			if !htlcSig.IsEqual(aliceHtlcSigs[i]) {
+			if htlcSig != aliceHtlcSigs[i] {
 				t.Fatalf("htlc sig msgs don't match: "+
 					"expected %x got %x",
-					bobHtlcSigs[i].Serialize(),
-					htlcSig.Serialize())
+					bobHtlcSigs[i], htlcSig)
 			}
 		}
 	}
@@ -3426,21 +3424,20 @@ func TestChanSyncOweRevocationAndCommitForceTransition(t *testing.T) {
 		t.Fatalf("revocation msgs don't match: expected %v, got %v",
 			bobRevocation, bobReRevoke)
 	}
-	if !bobReCommitSigMsg.CommitSig.IsEqual(bobSigMsg.CommitSig) {
+	if bobReCommitSigMsg.CommitSig != bobSigMsg.CommitSig {
 		t.Fatalf("commit sig msgs don't match: expected %x got %x",
-			bobSigMsg.CommitSig.Serialize(),
-			bobReCommitSigMsg.CommitSig.Serialize())
+			bobSigMsg.CommitSig,
+			bobReCommitSigMsg.CommitSig)
 	}
 	if len(bobReCommitSigMsg.HtlcSigs) != len(bobSigMsg.HtlcSigs) {
 		t.Fatalf("wrong number of htlc sigs: expected %v, got %v",
 			len(bobSigMsg.HtlcSigs), len(bobReCommitSigMsg.HtlcSigs))
 	}
 	for i, htlcSig := range bobReCommitSigMsg.HtlcSigs {
-		if htlcSig.IsEqual(bobSigMsg.HtlcSigs[i]) {
+		if htlcSig != bobSigMsg.HtlcSigs[i] {
 			t.Fatalf("htlc sig msgs don't match: "+
 				"expected %x got %x",
-				bobSigMsg.HtlcSigs[i].Serialize(),
-				htlcSig.Serialize())
+				bobSigMsg.HtlcSigs[i], htlcSig)
 		}
 	}
 
@@ -3598,20 +3595,19 @@ func TestChannelRetransmissionFeeUpdate(t *testing.T) {
 		t.Fatalf("expected a CommitSig message, instead have %v",
 			spew.Sdump(aliceMsgsToSend[1]))
 	}
-	if !commitSigMsg.CommitSig.IsEqual(aliceSig) {
+	if commitSigMsg.CommitSig != aliceSig {
 		t.Fatalf("commit sig msgs don't match: expected %x got %x",
-			aliceSig.Serialize(), commitSigMsg.CommitSig.Serialize())
+			aliceSig, commitSigMsg.CommitSig)
 	}
 	if len(commitSigMsg.HtlcSigs) != len(aliceHtlcSigs) {
 		t.Fatalf("wrong number of htlc sigs: expected %v, got %v",
 			len(aliceHtlcSigs), len(commitSigMsg.HtlcSigs))
 	}
 	for i, htlcSig := range commitSigMsg.HtlcSigs {
-		if !htlcSig.IsEqual(aliceHtlcSigs[i]) {
+		if htlcSig != aliceHtlcSigs[i] {
 			t.Fatalf("htlc sig msgs don't match: "+
 				"expected %x got %x",
-				aliceHtlcSigs[i].Serialize(),
-				htlcSig.Serialize())
+				aliceHtlcSigs[i], htlcSig)
 		}
 	}
 
@@ -4127,7 +4123,7 @@ func TestInvalidCommitSigError(t *testing.T) {
 
 	// Before the signature gets to Bob, we'll mutate it, such that the
 	// signature is now actually invalid.
-	aliceSig.R.Add(aliceSig.R, new(big.Int).SetInt64(1))
+	aliceSig[0] ^= 88
 
 	// Bob should reject this new state, and return the proper error.
 	err = bobChannel.ReceiveNewCommitment(aliceSig, aliceHtlcSigs)

--- a/lnwallet/sigpool.go
+++ b/lnwallet/sigpool.go
@@ -5,6 +5,7 @@ import (
 	"sync"
 	"sync/atomic"
 
+	"github.com/lightningnetwork/lnd/lnwire"
 	"github.com/roasbeef/btcd/btcec"
 	"github.com/roasbeef/btcd/wire"
 )
@@ -90,7 +91,7 @@ type signJobResp struct {
 	// sig is the generated signature for a particular signJob In the case
 	// of an error during signature generation, then this value sent will
 	// be nil.
-	sig *btcec.Signature
+	sig lnwire.Sig
 
 	// err is the error that occurred when executing the specified
 	// signature job. In the case that no error occurred, this value will
@@ -185,7 +186,7 @@ func (s *sigPool) poolWorker() {
 			if err != nil {
 				select {
 				case sigMsg.resp <- signJobResp{
-					sig: nil,
+					sig: lnwire.Sig{},
 					err: err,
 				}:
 					continue
@@ -196,7 +197,7 @@ func (s *sigPool) poolWorker() {
 				}
 			}
 
-			sig, err := btcec.ParseSignature(rawSig, btcec.S256())
+			sig, err := lnwire.NewSigFromRawSignature(rawSig)
 			select {
 			case sigMsg.resp <- signJobResp{
 				sig: sig,

--- a/lnwire/announcement_signatures.go
+++ b/lnwire/announcement_signatures.go
@@ -1,10 +1,6 @@
 package lnwire
 
-import (
-	"io"
-
-	"github.com/roasbeef/btcd/btcec"
-)
+import "io"
 
 // AnnounceSignatures this is a direct message between two endpoints of a
 // channel and serves as an opt-in mechanism to allow the announcement of
@@ -27,13 +23,13 @@ type AnnounceSignatures struct {
 	// NodeSignature is the signature which contains the signed announce
 	// channel message, by this signature we proof that we possess of the
 	// node pub key and creating the reference node_key -> bitcoin_key.
-	NodeSignature *btcec.Signature
+	NodeSignature Sig
 
 	// BitcoinSignature is the signature which contains the signed node
 	// public key, by this signature we proof that we possess of the
 	// bitcoin key and and creating the reverse reference bitcoin_key ->
 	// node_key.
-	BitcoinSignature *btcec.Signature
+	BitcoinSignature Sig
 }
 
 // A compile time check to ensure AnnounceSignatures implements the

--- a/lnwire/channel_announcement.go
+++ b/lnwire/channel_announcement.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"io"
 
-	"github.com/roasbeef/btcd/btcec"
 	"github.com/roasbeef/btcd/chaincfg/chainhash"
 )
 
@@ -16,14 +15,14 @@ type ChannelAnnouncement struct {
 	// references between node's channel and node. Requiring both nodes
 	// to sign indicates they are both willing to route other payments via
 	// this node.
-	NodeSig1 *btcec.Signature
-	NodeSig2 *btcec.Signature
+	NodeSig1 Sig
+	NodeSig2 Sig
 
 	// This signatures are used by nodes in order to create cross
 	// references between node's channel and node. Requiring the bitcoin
 	// signatures proves they control the channel.
-	BitcoinSig1 *btcec.Signature
-	BitcoinSig2 *btcec.Signature
+	BitcoinSig1 Sig
+	BitcoinSig2 Sig
 
 	// Features is the feature vector that encodes the features supported
 	// by the target node. This field can be used to signal the type of the

--- a/lnwire/channel_announcement.go
+++ b/lnwire/channel_announcement.go
@@ -41,13 +41,13 @@ type ChannelAnnouncement struct {
 	// The public keys of the two nodes who are operating the channel, such
 	// that is NodeID1 the numerically-lesser than NodeID2 (ascending
 	// numerical order).
-	NodeID1 *btcec.PublicKey
-	NodeID2 *btcec.PublicKey
+	NodeID1 [33]byte
+	NodeID2 [33]byte
 
 	// Public keys which corresponds to the keys which was declared in
 	// multisig funding transaction output.
-	BitcoinKey1 *btcec.PublicKey
-	BitcoinKey2 *btcec.PublicKey
+	BitcoinKey1 [33]byte
+	BitcoinKey2 [33]byte
 }
 
 // A compile time check to ensure ChannelAnnouncement implements the

--- a/lnwire/channel_update.go
+++ b/lnwire/channel_update.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"io"
 
-	"github.com/roasbeef/btcd/btcec"
 	"github.com/roasbeef/btcd/chaincfg/chainhash"
 )
 
@@ -32,7 +31,7 @@ const (
 type ChannelUpdate struct {
 	// Signature is used to validate the announced data and prove the
 	// ownership of node id.
-	Signature *btcec.Signature
+	Signature Sig
 
 	// ChainHash denotes the target chain that this channel was opened
 	// within. This value should be the genesis hash of the target chain.

--- a/lnwire/closing_signed.go
+++ b/lnwire/closing_signed.go
@@ -3,7 +3,6 @@ package lnwire
 import (
 	"io"
 
-	"github.com/roasbeef/btcd/btcec"
 	"github.com/roasbeef/btcutil"
 )
 
@@ -27,12 +26,12 @@ type ClosingSigned struct {
 	FeeSatoshis btcutil.Amount
 
 	// Signature is for the proposed channel close transaction.
-	Signature *btcec.Signature
+	Signature Sig
 }
 
 // NewClosingSigned creates a new empty ClosingSigned message.
 func NewClosingSigned(cid ChannelID, fs btcutil.Amount,
-	sig *btcec.Signature) *ClosingSigned {
+	sig Sig) *ClosingSigned {
 
 	return &ClosingSigned{
 		ChannelID:   cid,

--- a/lnwire/commit_sig.go
+++ b/lnwire/commit_sig.go
@@ -1,10 +1,6 @@
 package lnwire
 
-import (
-	"io"
-
-	"github.com/roasbeef/btcd/btcec"
-)
+import "io"
 
 // CommitSig is sent by either side to stage any pending HTLC's in the
 // receiver's pending set into a new commitment state.  Implicitly, the new
@@ -26,7 +22,7 @@ type CommitSig struct {
 	// If initiating a new commitment state, this signature should ONLY
 	// cover all of the sending party's pending log updates, and the log
 	// updates of the remote party that have been ACK'd.
-	CommitSig *btcec.Signature
+	CommitSig Sig
 
 	// HtlcSigs is a signature for each relevant HTLC output within the
 	// created commitment. The order of the signatures is expected to be
@@ -35,7 +31,7 @@ type CommitSig struct {
 	// sender of this message), a signature for a HTLC timeout transaction
 	// should be signed, for each incoming HTLC the HTLC timeout
 	// transaction should be signed.
-	HtlcSigs []*btcec.Signature
+	HtlcSigs []Sig
 }
 
 // NewCommitSig creates a new empty CommitSig message.

--- a/lnwire/funding_created.go
+++ b/lnwire/funding_created.go
@@ -3,7 +3,6 @@ package lnwire
 import (
 	"io"
 
-	"github.com/roasbeef/btcd/btcec"
 	"github.com/roasbeef/btcd/wire"
 )
 
@@ -24,7 +23,7 @@ type FundingCreated struct {
 
 	// CommitSig is Alice's signature from Bob's version of the commitment
 	// transaction.
-	CommitSig *btcec.Signature
+	CommitSig Sig
 }
 
 // A compile time check to ensure FundingCreated implements the lnwire.Message

--- a/lnwire/funding_signed.go
+++ b/lnwire/funding_signed.go
@@ -1,10 +1,6 @@
 package lnwire
 
-import (
-	"io"
-
-	"github.com/roasbeef/btcd/btcec"
-)
+import "io"
 
 // FundingSigned is sent from Bob (the responder) to Alice (the initiator)
 // after receiving the funding outpoint and her signature for Bob's version of
@@ -16,7 +12,7 @@ type FundingSigned struct {
 
 	// CommitSig is Bob's signature for Alice's version of the commitment
 	// transaction.
-	CommitSig *btcec.Signature
+	CommitSig Sig
 }
 
 // A compile time check to ensure FundingSigned implements the lnwire.Message

--- a/lnwire/lnwire.go
+++ b/lnwire/lnwire.go
@@ -204,6 +204,10 @@ func writeElement(w io.Writer, element interface{}) error {
 		if _, err := w.Write(e[:]); err != nil {
 			return err
 		}
+	case [33]byte:
+		if _, err := w.Write(e[:]); err != nil {
+			return err
+		}
 	case []byte:
 		if _, err := w.Write(e[:]); err != nil {
 			return err
@@ -525,6 +529,10 @@ func readElement(r io.Reader, element interface{}) error {
 
 		*e = PongPayload(make([]byte, pongLen))
 		if _, err := io.ReadFull(r, *e); err != nil {
+			return err
+		}
+	case *[33]byte:
+		if _, err := io.ReadFull(r, e[:]); err != nil {
 			return err
 		}
 	case []byte:

--- a/lnwire/node_announcement.go
+++ b/lnwire/node_announcement.go
@@ -7,8 +7,6 @@ import (
 	"io"
 	"net"
 	"unicode/utf8"
-
-	"github.com/roasbeef/btcd/btcec"
 )
 
 var (
@@ -59,7 +57,7 @@ type NodeAnnouncement struct {
 	Timestamp uint32
 
 	// NodeID is a public key which is used as node identification.
-	NodeID *btcec.PublicKey
+	NodeID [33]byte
 
 	// RGBColor is used to customize their node's appearance in maps and
 	// graphs

--- a/lnwire/node_announcement.go
+++ b/lnwire/node_announcement.go
@@ -50,7 +50,7 @@ func (n NodeAlias) String() string {
 // announcement via a signature using the advertised node pubkey.
 type NodeAnnouncement struct {
 	// Signature is used to prove the ownership of node id.
-	Signature *btcec.Signature
+	Signature Sig
 
 	// Features is the list of protocol features this node supports.
 	Features *RawFeatureVector

--- a/lnwire/onion_error_test.go
+++ b/lnwire/onion_error_test.go
@@ -11,8 +11,9 @@ var (
 	testAmount        = MilliSatoshi(1)
 	testCtlvExpiry    = uint32(2)
 	testFlags         = uint16(2)
+	sig, _            = NewSigFromSignature(testSig)
 	testChannelUpdate = ChannelUpdate{
-		Signature:      testSig,
+		Signature:      sig,
 		ShortChannelID: NewShortChanIDFromInt(1),
 		Timestamp:      1,
 		Flags:          1,

--- a/lnwire/signature.go
+++ b/lnwire/signature.go
@@ -6,12 +6,16 @@ import (
 	"github.com/roasbeef/btcd/btcec"
 )
 
-// SerializeSigToWire serializes a *Signature to [64]byte in the format
-// specified by the Lightning RFC.
-func SerializeSigToWire(b *[64]byte, e *btcec.Signature) error {
+// Sig is a fixed-sized ECDSA signature. Unlike Bitcoin, we use fixed sized
+// signatures on the wire, instead of DER encoded signatures. This type
+// provides several methods to convert to/from a regular Bitcoin DER encoded
+// signature (raw bytes and *btcec.Signature).
+type Sig [64]byte
 
-	// Serialize the signature with all the checks that entails.
-	sig := e.Serialize()
+// NewSigFromRawSignature returns a Sig from a Bitcoin raw signature encoded in
+// the cannonical DER encoding.
+func NewSigFromRawSignature(sig []byte) (Sig, error) {
+	var b Sig
 
 	// Extract lengths of R and S. The DER representation is laid out as
 	// 0x30 <length> 0x02 <length r> r 0x02 <length s> s
@@ -23,14 +27,14 @@ func SerializeSigToWire(b *[64]byte, e *btcec.Signature) error {
 	sLen := sig[5+rLen]
 
 	// Check to make sure R and S can both fit into their intended buffers.
-	// We check S first because these code blocks decrement sLen and
-	// rLen in the case of a 33-byte 0-padded integer returned from
-	// Serialize() and rLen is used in calculating array indices for
-	// S. We can track this with additional variables, but it's more
-	// efficient to just check S first.
+	// We check S first because these code blocks decrement sLen and rLen
+	// in the case of a 33-byte 0-padded integer returned from Serialize()
+	// and rLen is used in calculating array indices for S. We can track
+	// this with additional variables, but it's more efficient to just
+	// check S first.
 	if sLen > 32 {
 		if (sLen > 33) || (sig[6+rLen] != 0x00) {
-			return fmt.Errorf("S is over 32 bytes long " +
+			return b, fmt.Errorf("S is over 32 bytes long " +
 				"without padding")
 		}
 		sLen--
@@ -42,7 +46,7 @@ func SerializeSigToWire(b *[64]byte, e *btcec.Signature) error {
 	// Do the same for R as we did for S
 	if rLen > 32 {
 		if (rLen > 33) || (sig[4] != 0x00) {
-			return fmt.Errorf("R is over 32 bytes long " +
+			return b, fmt.Errorf("R is over 32 bytes long " +
 				"without padding")
 		}
 		rLen--
@@ -50,13 +54,33 @@ func SerializeSigToWire(b *[64]byte, e *btcec.Signature) error {
 	} else {
 		copy(b[32-rLen:], sig[4:4+rLen])
 	}
-	return nil
+
+	return b, nil
 }
 
-// DeserializeSigFromWire deserializes a *Signature from [64]byte in the format
-// specified by the Lightning RFC.
-func DeserializeSigFromWire(e **btcec.Signature, b [64]byte) error {
+// NewSigFromSignature creates a new signature as used on the wire, from an
+// existing btcec.Signature.
+func NewSigFromSignature(e *btcec.Signature) (Sig, error) {
+	// Serialize the signature with all the checks that entails.
+	return NewSigFromRawSignature(e.Serialize())
+}
 
+// ToSignature converts the fixed-sized signature to a btcec.Signature objects
+// which can be used for signature validation checks.
+func (b *Sig) ToSignature() (*btcec.Signature, error) {
+	// Parse the signature with strict checks.
+	sigBytes := b.ToSignatureBytes()
+	sig, err := btcec.ParseDERSignature(sigBytes, btcec.S256())
+	if err != nil {
+		return nil, err
+	}
+
+	return sig, nil
+}
+
+// ToSignatureBytes serializes the target fixed-sized signature into the raw
+// bytes of a DER encoding.
+func (b *Sig) ToSignatureBytes() []byte {
 	// Extract canonically-padded bigint representations from buffer
 	r := extractCanonicalPadding(b[0:32])
 	s := extractCanonicalPadding(b[32:64])
@@ -75,13 +99,7 @@ func DeserializeSigFromWire(e **btcec.Signature, b [64]byte) error {
 	copy(sigBytes[4:], r)         // Copy R
 	copy(sigBytes[rLen+6:], s)    // Copy S
 
-	// Parse the signature with strict checks.
-	sig, err := btcec.ParseDERSignature(sigBytes, btcec.S256())
-	if err != nil {
-		return err
-	}
-	*e = sig
-	return nil
+	return sigBytes
 }
 
 // extractCanonicalPadding is a utility function to extract the canonical

--- a/lnwire/signature_test.go
+++ b/lnwire/signature_test.go
@@ -14,16 +14,16 @@ func TestSignatureSerializeDeserialize(t *testing.T) {
 	// Local-scoped closure to serialize and deserialize a Signature and
 	// check for errors as well as check if the results are correct.
 	signatureSerializeDeserialize := func(e btcec.Signature) error {
-		var b [64]byte
-		err := SerializeSigToWire(&b, &e)
+		sig, err := NewSigFromSignature(&e)
 		if err != nil {
 			return err
 		}
-		var e2 *btcec.Signature
-		err = DeserializeSigFromWire(&e2, b)
+
+		e2, err := sig.ToSignature()
 		if err != nil {
 			return err
 		}
+
 		if e.R.Cmp(e2.R) != 0 {
 			return fmt.Errorf("Pre/post-serialize Rs don't match"+
 				": %s, %s", e.R, e2.R)

--- a/peer_test.go
+++ b/peer_test.go
@@ -14,8 +14,6 @@ import (
 	"github.com/lightningnetwork/lnd/lnrpc"
 	"github.com/lightningnetwork/lnd/lnwallet"
 	"github.com/lightningnetwork/lnd/lnwire"
-	"github.com/roasbeef/btcd/btcec"
-	"github.com/roasbeef/btcd/txscript"
 	"github.com/roasbeef/btcd/wire"
 	"github.com/roasbeef/btcutil"
 )
@@ -95,8 +93,7 @@ func TestPeerChannelClosureAcceptFeeResponder(t *testing.T) {
 		t.Fatalf("error creating close proposal: %v", err)
 	}
 
-	initSig := append(initiatorSig, byte(txscript.SigHashAll))
-	parsedSig, err := btcec.ParseSignature(initSig, btcec.S256())
+	parsedSig, err := lnwire.NewSigFromRawSignature(initiatorSig)
 	if err != nil {
 		t.Fatalf("error parsing signature: %v", err)
 	}
@@ -183,7 +180,7 @@ func TestPeerChannelClosureAcceptFeeInitiator(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unable to create close proposal: %v", err)
 	}
-	parsedSig, err := btcec.ParseSignature(closeSig, btcec.S256())
+	parsedSig, err := lnwire.NewSigFromRawSignature(closeSig)
 	if err != nil {
 		t.Fatalf("unable to parse signature: %v", err)
 	}
@@ -295,7 +292,7 @@ func TestPeerChannelClosureFeeNegotiationsResponder(t *testing.T) {
 		t.Fatalf("error creating close proposal: %v", err)
 	}
 
-	parsedSig, err := btcec.ParseSignature(initiatorSig, btcec.S256())
+	parsedSig, err := lnwire.NewSigFromRawSignature(initiatorSig)
 	if err != nil {
 		t.Fatalf("error parsing signature: %v", err)
 	}
@@ -339,7 +336,7 @@ func TestPeerChannelClosureFeeNegotiationsResponder(t *testing.T) {
 		t.Fatalf("error creating close proposal: %v", err)
 	}
 
-	parsedSig, err = btcec.ParseSignature(initiatorSig, btcec.S256())
+	parsedSig, err = lnwire.NewSigFromRawSignature(initiatorSig)
 	if err != nil {
 		t.Fatalf("error parsing signature: %v", err)
 	}
@@ -384,8 +381,7 @@ func TestPeerChannelClosureFeeNegotiationsResponder(t *testing.T) {
 		t.Fatalf("error creating close proposal: %v", err)
 	}
 
-	initSig := append(initiatorSig, byte(txscript.SigHashAll))
-	parsedSig, err = btcec.ParseSignature(initSig, btcec.S256())
+	parsedSig, err = lnwire.NewSigFromRawSignature(initiatorSig)
 	if err != nil {
 		t.Fatalf("error parsing signature: %v", err)
 	}
@@ -478,7 +474,7 @@ func TestPeerChannelClosureFeeNegotiationsInitiator(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unable to create close proposal: %v", err)
 	}
-	parsedSig, err := btcec.ParseSignature(closeSig, btcec.S256())
+	parsedSig, err := lnwire.NewSigFromRawSignature(closeSig)
 	if err != nil {
 		t.Fatalf("unable to parse signature: %v", err)
 	}
@@ -544,7 +540,7 @@ func TestPeerChannelClosureFeeNegotiationsInitiator(t *testing.T) {
 		t.Fatalf("error creating close proposal: %v", err)
 	}
 
-	parsedSig, err = btcec.ParseSignature(responderSig, btcec.S256())
+	parsedSig, err = lnwire.NewSigFromRawSignature(responderSig)
 	if err != nil {
 		t.Fatalf("error parsing signature: %v", err)
 	}
@@ -590,8 +586,7 @@ func TestPeerChannelClosureFeeNegotiationsInitiator(t *testing.T) {
 		t.Fatalf("error creating close proposal: %v", err)
 	}
 
-	respSig := append(responderSig, byte(txscript.SigHashAll))
-	parsedSig, err = btcec.ParseSignature(respSig, btcec.S256())
+	parsedSig, err = lnwire.NewSigFromRawSignature(responderSig)
 	if err != nil {
 		t.Fatalf("error parsing signature: %v", err)
 	}

--- a/routing/missioncontrol.go
+++ b/routing/missioncontrol.go
@@ -239,7 +239,7 @@ func (p *paymentSession) RequestRoute(payment *LightningPayment,
 
 	// With the next candidate path found, we'll attempt to turn this into
 	// a route by applying the time-lock and fee requirements.
-	sourceVertex := NewVertex(p.mc.selfNode.PubKey)
+	sourceVertex := Vertex(p.mc.selfNode.PubKeyBytes)
 	route, err := newRoute(payment.Amount, sourceVertex, path, height,
 		finalCltvDelta)
 	if err != nil {

--- a/routing/notifications.go
+++ b/routing/notifications.go
@@ -296,9 +296,13 @@ func addToTopologyChange(graph *channeldb.ChannelGraph, update *TopologyChange,
 	// Any node announcement maps directly to a NetworkNodeUpdate struct.
 	// No further data munging or db queries are required.
 	case *channeldb.LightningNode:
+		pubKey, err := m.PubKey()
+		if err != nil {
+			return err
+		}
 		nodeUpdate := &NetworkNodeUpdate{
 			Addresses:   m.Addresses,
-			IdentityKey: m.PubKey,
+			IdentityKey: pubKey,
 			Alias:       m.Alias,
 		}
 		nodeUpdate.IdentityKey.Curve = nil
@@ -332,6 +336,15 @@ func addToTopologyChange(graph *channeldb.ChannelGraph, update *TopologyChange,
 			connectingNode = edgeInfo.NodeKey1
 		}
 
+		aNode, err := sourceNode()
+		if err != nil {
+			return err
+		}
+		cNode, err := connectingNode()
+		if err != nil {
+			return err
+		}
+
 		edgeUpdate := &ChannelEdgeUpdate{
 			ChanID:          m.ChannelID,
 			ChanPoint:       edgeInfo.ChannelPoint,
@@ -340,8 +353,8 @@ func addToTopologyChange(graph *channeldb.ChannelGraph, update *TopologyChange,
 			MinHTLC:         m.MinHTLC,
 			BaseFee:         m.FeeBaseMSat,
 			FeeRate:         m.FeeProportionalMillionths,
-			AdvertisingNode: sourceNode,
-			ConnectingNode:  connectingNode,
+			AdvertisingNode: aNode,
+			ConnectingNode:  cNode,
 		}
 		edgeUpdate.AdvertisingNode.Curve = nil
 		edgeUpdate.ConnectingNode.Curve = nil

--- a/routing/router.go
+++ b/routing/router.go
@@ -814,7 +814,7 @@ func (r *ChannelRouter) processUpdate(msg interface{}) error {
 		// attack by node announcements, we will ignore such nodes. If
 		// we do know about this node, check that this update brings
 		// info newer than what we already have.
-		lastUpdate, exists, err := r.cfg.Graph.HasLightningNode(msg.PubKey)
+		lastUpdate, exists, err := r.cfg.Graph.HasLightningNode(msg.PubKeyBytes)
 		if err != nil {
 			return errors.Errorf("unable to query for the "+
 				"existence of node: %v", err)
@@ -822,7 +822,7 @@ func (r *ChannelRouter) processUpdate(msg interface{}) error {
 		if !exists {
 			return newErrf(ErrIgnored, "Ignoring node announcement"+
 				" for node not found in channel graph (%x)",
-				msg.PubKey.SerializeCompressed())
+				msg.PubKeyBytes)
 		}
 
 		// If we've reached this point then we're aware of the vertex
@@ -833,16 +833,15 @@ func (r *ChannelRouter) processUpdate(msg interface{}) error {
 			lastUpdate.Equal(msg.LastUpdate) {
 
 			return newErrf(ErrOutdated, "Ignoring outdated "+
-				"announcement for %x", msg.PubKey.SerializeCompressed())
+				"announcement for %x", msg.PubKeyBytes)
 		}
 
 		if err := r.cfg.Graph.AddLightningNode(msg); err != nil {
 			return errors.Errorf("unable to add node %v to the "+
-				"graph: %v", msg.PubKey.SerializeCompressed(), err)
+				"graph: %v", msg.PubKeyBytes, err)
 		}
 
-		log.Infof("Updated vertex data for node=%x",
-			msg.PubKey.SerializeCompressed())
+		log.Infof("Updated vertex data for node=%x", msg.PubKeyBytes)
 
 	case *channeldb.ChannelEdgeInfo:
 		// Prior to processing the announcement we first check if we
@@ -859,30 +858,28 @@ func (r *ChannelRouter) processUpdate(msg interface{}) error {
 		// Query the database for the existence of the two nodes in this
 		// channel. If not found, add a partial node to the database,
 		// containing only the node keys.
-		_, exists, _ = r.cfg.Graph.HasLightningNode(msg.NodeKey1)
+		_, exists, _ = r.cfg.Graph.HasLightningNode(msg.NodeKey1Bytes)
 		if !exists {
 			node1 := &channeldb.LightningNode{
-				PubKey:               msg.NodeKey1,
+				PubKeyBytes:          msg.NodeKey1Bytes,
 				HaveNodeAnnouncement: false,
 			}
 			err := r.cfg.Graph.AddLightningNode(node1)
 			if err != nil {
 				return errors.Errorf("unable to add node %v to"+
-					" the graph: %v",
-					node1.PubKey.SerializeCompressed(), err)
+					" the graph: %v", node1.PubKeyBytes, err)
 			}
 		}
-		_, exists, _ = r.cfg.Graph.HasLightningNode(msg.NodeKey2)
+		_, exists, _ = r.cfg.Graph.HasLightningNode(msg.NodeKey2Bytes)
 		if !exists {
 			node2 := &channeldb.LightningNode{
-				PubKey:               msg.NodeKey2,
+				PubKeyBytes:          msg.NodeKey2Bytes,
 				HaveNodeAnnouncement: false,
 			}
 			err := r.cfg.Graph.AddLightningNode(node2)
 			if err != nil {
 				return errors.Errorf("unable to add node %v to"+
-					" the graph: %v",
-					node2.PubKey.SerializeCompressed(), err)
+					" the graph: %v", node2.PubKeyBytes, err)
 			}
 		}
 
@@ -911,8 +908,7 @@ func (r *ChannelRouter) processUpdate(msg interface{}) error {
 		// edge bitcoin keys and channel value corresponds to the
 		// reality.
 		_, witnessOutput, err := lnwallet.GenFundingPkScript(
-			msg.BitcoinKey1.SerializeCompressed(),
-			msg.BitcoinKey2.SerializeCompressed(),
+			msg.BitcoinKey1Bytes[:], msg.BitcoinKey2Bytes[:],
 			chanUtxo.Value,
 		)
 		if err != nil {
@@ -942,8 +938,7 @@ func (r *ChannelRouter) processUpdate(msg interface{}) error {
 		log.Infof("New channel discovered! Link "+
 			"connects %x and %x with ChannelPoint(%v): "+
 			"chan_id=%v, capacity=%v",
-			msg.NodeKey1.SerializeCompressed(),
-			msg.NodeKey2.SerializeCompressed(),
+			msg.NodeKey1Bytes, msg.NodeKey2Bytes,
 			fundingPoint, msg.ChannelID, msg.Capacity)
 
 		// As a new edge has been added to the channel graph, we'll
@@ -1183,7 +1178,8 @@ func (r *ChannelRouter) FindRoutes(target *btcec.PublicKey,
 
 	// We can short circuit the routing by opportunistically checking to
 	// see if the target vertex event exists in the current graph.
-	if _, exists, err := r.cfg.Graph.HasLightningNode(target); err != nil {
+	targetVertex := NewVertex(target)
+	if _, exists, err := r.cfg.Graph.HasLightningNode(targetVertex); err != nil {
 		return nil, err
 	} else if !exists {
 		log.Debugf("Target %x is not in known graph", dest)
@@ -1221,7 +1217,7 @@ func (r *ChannelRouter) FindRoutes(target *btcec.PublicKey,
 	// aren't able to support the total satoshis flow once fees have been
 	// factored in.
 	validRoutes := make([]*Route, 0, len(shortestPaths))
-	sourceVertex := NewVertex(r.selfNode.PubKey)
+	sourceVertex := Vertex(r.selfNode.PubKeyBytes)
 	for _, path := range shortestPaths {
 		// Attempt to make the path into a route. We snip off the first
 		// hop in the path as it contains a "self-hop" that is inserted
@@ -1289,10 +1285,14 @@ func generateSphinxPacket(route *Route, paymentHash []byte) ([]byte,
 		// We create a new instance of the public key to avoid possibly
 		// mutating the curve parameters, which are unset in a higher
 		// level in order to avoid spamming the logs.
+		nodePub, err := hop.Channel.Node.PubKey()
+		if err != nil {
+			return nil, nil, err
+		}
 		pub := btcec.PublicKey{
 			Curve: btcec.S256(),
-			X:     hop.Channel.Node.PubKey.X,
-			Y:     hop.Channel.Node.PubKey.Y,
+			X:     nodePub.X,
+			Y:     nodePub.Y,
 		}
 		nodes[i] = &pub
 	}
@@ -1453,7 +1453,7 @@ func (r *ChannelRouter) SendPayment(payment *LightningPayment) ([32]byte, *Route
 		// Attempt to send this payment through the network to complete
 		// the payment. If this attempt fails, then we'll continue on
 		// to the next available route.
-		firstHop := route.Hops[0].Channel.Node.PubKey
+		firstHop := route.Hops[0].Channel.Node.PubKeyBytes
 		preImage, sendError = r.cfg.SendToSwitch(firstHop, htlcAdd,
 			circuit)
 		if sendError != nil {
@@ -1693,7 +1693,7 @@ func (r *ChannelRouter) applyChannelUpdate(msg *lnwire.ChannelUpdate) error {
 	}
 
 	err := r.UpdateEdge(&channeldb.ChannelEdgePolicy{
-		Signature:                 msg.Signature,
+		SigBytes:                  msg.Signature.ToSignatureBytes(),
 		ChannelID:                 msg.ShortChannelID.ToUint64(),
 		LastUpdate:                time.Unix(int64(msg.Timestamp), 0),
 		Flags:                     msg.Flags,

--- a/routing/router.go
+++ b/routing/router.go
@@ -130,7 +130,7 @@ type Config struct {
 	// forward a fully encoded payment to the first hop in the route
 	// denoted by its public key. A non-nil error is to be returned if the
 	// payment was unsuccessful.
-	SendToSwitch func(firstHop *btcec.PublicKey, htlcAdd *lnwire.UpdateAddHTLC,
+	SendToSwitch func(firstHop [33]byte, htlcAdd *lnwire.UpdateAddHTLC,
 		circuit *sphinx.Circuit) ([sha256.Size]byte, error)
 
 	// ChannelPruneExpiry is the duration used to determine if a channel

--- a/routing/router.go
+++ b/routing/router.go
@@ -504,6 +504,94 @@ func (r *ChannelRouter) syncGraphWithChain() error {
 	return nil
 }
 
+// pruneZombieChans is a method that will be called periodically to prune out
+// any "zombie" channels. We consider channels zombies if *both* edges haven't
+// been updated since our zombie horizon. We do this periodically to keep a
+// health, lively routing table.
+func (r *ChannelRouter) pruneZombieChans() error {
+	var chansToPrune []wire.OutPoint
+	chanExpiry := r.cfg.ChannelPruneExpiry
+
+	log.Infof("Examining Channel Graph for zombie channels")
+
+	// First, we'll collect all the channels which are eligible for garbage
+	// collection due to being zombies.
+	filterPruneChans := func(info *channeldb.ChannelEdgeInfo,
+		e1, e2 *channeldb.ChannelEdgePolicy) error {
+
+		// We'll ensure that we don't attempt to prune our *own*
+		// channels from the graph, as in any case this should be
+		// re-advertised by the sub-system above us.
+		if info.NodeKey1Bytes == r.selfNode.PubKeyBytes ||
+			info.NodeKey2Bytes == r.selfNode.PubKeyBytes {
+
+			return nil
+		}
+
+		// If *both* edges haven't been updated for a period of
+		// chanExpiry, then we'll mark the channel itself as eligible
+		// for graph pruning.
+		e1Zombie, e2Zombie := true, true
+		if e1 != nil {
+			e1Zombie = time.Since(e1.LastUpdate) >= chanExpiry
+			if e1Zombie {
+				log.Tracef("Edge #1 of ChannelPoint(%v) "+
+					"last update: %v",
+					info.ChannelPoint, e1.LastUpdate)
+			}
+		}
+		if e2 != nil {
+			e2Zombie = time.Since(e2.LastUpdate) >= chanExpiry
+			if e2Zombie {
+				log.Tracef("Edge #2 of ChannelPoint(%v) "+
+					"last update: %v",
+					info.ChannelPoint, e2.LastUpdate)
+			}
+		}
+		if e1Zombie && e2Zombie {
+			log.Debugf("ChannelPoint(%v) is a zombie, collecting "+
+				"to prune", info.ChannelPoint)
+
+			// TODO(roasbeef): add ability to delete single
+			// directional edge
+			chansToPrune = append(chansToPrune, info.ChannelPoint)
+
+			// As we're detecting this as a zombie channel, we'll
+			// add this to the set of recently rejected items so we
+			// don't re-accept it shortly after.
+			r.rejectCache[info.ChannelID] = struct{}{}
+		}
+
+		return nil
+	}
+
+	r.rejectMtx.Lock()
+	err := r.cfg.Graph.ForEachChannel(filterPruneChans)
+	if err != nil {
+		r.rejectMtx.Unlock()
+		return fmt.Errorf("Unable to filter local zombie "+
+			"chans: %v", err)
+	}
+
+	log.Infof("Pruning %v Zombie Channels", len(chansToPrune))
+
+	// With the set zombie-like channels obtained, we'll do another pass to
+	// delete al zombie channels from the channel graph.
+	for _, chanToPrune := range chansToPrune {
+		log.Tracef("Pruning zombie chan ChannelPoint(%v)", chanToPrune)
+
+		err := r.cfg.Graph.DeleteChannelEdge(&chanToPrune)
+		if err != nil {
+			r.rejectMtx.Unlock()
+			return fmt.Errorf("Unable to prune zombie "+
+				"chans: %v", err)
+		}
+	}
+	r.rejectMtx.Unlock()
+
+	return nil
+}
+
 // networkHandler is the primary goroutine for the ChannelRouter. The roles of
 // this goroutine include answering queries related to the state of the
 // network, pruning the graph on new block notification, applying network
@@ -716,79 +804,8 @@ func (r *ChannelRouter) networkHandler() {
 		// state of the known graph to filter out any zombie channels
 		// for pruning.
 		case <-graphPruneTicker.C:
-
-			var chansToPrune []wire.OutPoint
-			chanExpiry := r.cfg.ChannelPruneExpiry
-
-			log.Infof("Examining Channel Graph for zombie channels")
-
-			// First, we'll collect all the channels which are
-			// eligible for garbage collection due to being
-			// zombies.
-			filterPruneChans := func(info *channeldb.ChannelEdgeInfo,
-				e1, e2 *channeldb.ChannelEdgePolicy) error {
-
-				// We'll ensure that we don't attempt to prune
-				// our *own* channels from the graph, as in any
-				// case this should be re-advertised by the
-				// sub-system above us.
-				if info.NodeKey1.IsEqual(r.selfNode.PubKey) ||
-					info.NodeKey2.IsEqual(r.selfNode.PubKey) {
-
-					return nil
-				}
-
-				// If *both* edges haven't been updated for a
-				// period of chanExpiry, then we'll mark the
-				// channel itself as eligible for graph
-				// pruning.
-				e1Zombie, e2Zombie := true, true
-				if e1 != nil {
-					e1Zombie = time.Since(e1.LastUpdate) >= chanExpiry
-					log.Tracef("Edge #1 of ChannelPoint(%v) "+
-						"last update: %v",
-						info.ChannelPoint, e1.LastUpdate)
-				}
-				if e2 != nil {
-					e2Zombie = time.Since(e2.LastUpdate) >= chanExpiry
-					log.Tracef("Edge #2 of ChannelPoint(%v) "+
-						"last update: %v",
-						info.ChannelPoint, e2.LastUpdate)
-				}
-				if e1Zombie && e2Zombie {
-					log.Infof("ChannelPoint(%v) is a "+
-						"zombie, collecting to prune",
-						info.ChannelPoint)
-
-					// TODO(roasbeef): add ability to
-					// delete single directional edge
-					chansToPrune = append(chansToPrune,
-						info.ChannelPoint)
-				}
-
-				return nil
-			}
-			err := r.cfg.Graph.ForEachChannel(filterPruneChans)
-			if err != nil {
-				log.Errorf("Unable to local zombie chans: %v", err)
-				continue
-			}
-
-			log.Infof("Pruning %v Zombie Channels", len(chansToPrune))
-
-			// With the set zombie-like channels obtained, we'll do
-			// another pass to delete al zombie channels from the
-			// channel graph.
-			for _, chanToPrune := range chansToPrune {
-				log.Tracef("Pruning zombie chan ChannelPoint(%v)",
-					chanToPrune)
-
-				err := r.cfg.Graph.DeleteChannelEdge(&chanToPrune)
-				if err != nil {
-					log.Errorf("Unable to prune zombie "+
-						"chans: %v", err)
-					continue
-				}
+			if err := r.pruneZombieChans(); err != nil {
+				log.Errorf("unable to prune zombies: %v", err)
 			}
 
 		// The router has been signalled to exit, to we exit our main

--- a/routing/router.go
+++ b/routing/router.go
@@ -237,6 +237,9 @@ type ChannelRouter struct {
 	// consistency between the various database accesses.
 	channelEdgeMtx *multimutex.Mutex
 
+	rejectMtx   sync.RWMutex
+	rejectCache map[uint64]struct{}
+
 	sync.RWMutex
 
 	quit chan struct{}
@@ -268,6 +271,7 @@ func New(cfg Config) (*ChannelRouter, error) {
 		channelEdgeMtx:    multimutex.NewMutex(),
 		selfNode:          selfNode,
 		routeCache:        make(map[routeTuple][]*Route),
+		rejectCache:       make(map[uint64]struct{}),
 		quit:              make(chan struct{}),
 	}, nil
 }
@@ -566,9 +570,10 @@ func (r *ChannelRouter) pruneZombieChans() error {
 	}
 
 	r.rejectMtx.Lock()
+	defer r.rejectMtx.Unlock()
+
 	err := r.cfg.Graph.ForEachChannel(filterPruneChans)
 	if err != nil {
-		r.rejectMtx.Unlock()
 		return fmt.Errorf("Unable to filter local zombie "+
 			"chans: %v", err)
 	}
@@ -582,12 +587,10 @@ func (r *ChannelRouter) pruneZombieChans() error {
 
 		err := r.cfg.Graph.DeleteChannelEdge(&chanToPrune)
 		if err != nil {
-			r.rejectMtx.Unlock()
 			return fmt.Errorf("Unable to prune zombie "+
 				"chans: %v", err)
 		}
 	}
-	r.rejectMtx.Unlock()
 
 	return nil
 }
@@ -861,6 +864,16 @@ func (r *ChannelRouter) processUpdate(msg interface{}) error {
 		log.Infof("Updated vertex data for node=%x", msg.PubKeyBytes)
 
 	case *channeldb.ChannelEdgeInfo:
+		// If we recently rejected this channel edge, then we won't
+		// attempt to re-process it.
+		r.rejectMtx.RLock()
+		if _, ok := r.rejectCache[msg.ChannelID]; ok {
+			r.rejectMtx.RUnlock()
+			return newErrf(ErrIgnored, "recently rejected "+
+				"chan_id=%v", msg.ChannelID)
+		}
+		r.rejectMtx.RUnlock()
+
 		// Prior to processing the announcement we first check if we
 		// already know of this channel, if so, then we can exit early.
 		_, _, exists, err := r.cfg.Graph.HasChannelEdge(msg.ChannelID)
@@ -972,6 +985,16 @@ func (r *ChannelRouter) processUpdate(msg interface{}) error {
 		}
 
 	case *channeldb.ChannelEdgePolicy:
+		// If we recently rejected this channel edge, then we won't
+		// attempt to re-process it.
+		r.rejectMtx.RLock()
+		if _, ok := r.rejectCache[msg.ChannelID]; ok {
+			r.rejectMtx.RUnlock()
+			return newErrf(ErrIgnored, "recently rejected "+
+				"chan_id=%v", msg.ChannelID)
+		}
+		r.rejectMtx.RUnlock()
+
 		channelID := lnwire.NewShortChanIDFromInt(msg.ChannelID)
 
 		// We make sure to hold the mutex for this channel ID,

--- a/routing/validation_barrier.go
+++ b/routing/validation_barrier.go
@@ -116,8 +116,8 @@ func (v *ValidationBarrier) InitJobDependencies(job interface{}) {
 			v.chanAnnFinSignal[shortID] = annFinCond
 			v.chanEdgeDependencies[shortID] = annFinCond
 
-			v.nodeAnnDependencies[Vertex(msg.NodeKey1)] = annFinCond
-			v.nodeAnnDependencies[Vertex(msg.NodeKey2)] = annFinCond
+			v.nodeAnnDependencies[Vertex(msg.NodeKey1Bytes)] = annFinCond
+			v.nodeAnnDependencies[Vertex(msg.NodeKey2Bytes)] = annFinCond
 		}
 
 	// These other types don't have any dependants, so no further
@@ -168,7 +168,7 @@ func (v *ValidationBarrier) WaitForDependants(job interface{}) {
 		shortID := lnwire.NewShortChanIDFromInt(msg.ChannelID)
 		signal, ok = v.chanEdgeDependencies[shortID]
 	case *channeldb.LightningNode:
-		vertex := Vertex(msg.PubKey)
+		vertex := Vertex(msg.PubKeyBytes)
 		signal, ok = v.nodeAnnDependencies[vertex]
 	case *lnwire.ChannelUpdate:
 		signal, ok = v.chanEdgeDependencies[msg.ShortChannelID]
@@ -234,7 +234,7 @@ func (v *ValidationBarrier) SignalDependants(job interface{}) {
 	// map, as if we reach this point, then all dependants have already
 	// finished executing and we can proceed.
 	case *channeldb.LightningNode:
-		delete(v.nodeAnnDependencies, Vertex(msg.PubKey))
+		delete(v.nodeAnnDependencies, Vertex(msg.PubKeyBytes))
 	case *lnwire.NodeAnnouncement:
 		delete(v.nodeAnnDependencies, Vertex(msg.NodeID))
 	case *lnwire.ChannelUpdate:


### PR DESCRIPTION
# The Problem
One day I ran a heap profile on the faucet (which had around 80+ active channels at the time), and I realized how much garbage we generated due to simple things like path finding, and syncing up new nodes: 
![screen shot 2018-01-30 at 8 43 58 pm](https://user-images.githubusercontent.com/998190/35605553-53cfdd2a-05fe-11e8-9db3-091f56f092d8.png)


# Solution #1 
Looking at that profile above, we see that a _substantial_ amount of garbage is generated _just_ by parsing pubkeys and signatures. Typically we decode these structs, but then end up _immediately_encoding them to write them out on the wire. This is extremely wasteful. The first part of this PR modifies both `channeldb` and `lnwire` to favor fixed-sized byte slices for pubkeys (`[33]byte`) and signatures (`[64]byte`). For the latter type, we introduce a new `lnwire.Sig` type which is a typedef for `[64]byte` that includes some helper functions for converting from the fixed-sized signature encoding to/from DER encoding. 

With this change, we'll read the pubkeys+sigs as raw bytes from the database, and then write those raw bytes out on the wire. This is a massive improvement, as now that heavy path within the callgraph above now disappears, as we'll just be doing mem copies now rather than operations in the field or group. 

# Solution #2 

The second portion of this PR stop the constant zombie chrun that exists on testnet. Testnet has around 5k active channels, with 6k of them actually being _zombies_. Zombie channels are abandoned channels that aren't actually used anymore (people wiped state, left their node, etc). Upon startup, we'll now immediately prune out any existing zombies on the network graph. From there on, we'll remember which channels were zombies, and the _ignore_ any new requests from them with the same update time. We'll also bubble this up to the `AuthenticatedGossiper` to prevent it from re-sending requests that the `ChannelRouter` has recently rejected. 