### PR TITLE
funding: during funding error fail before sending Error to peer 

### DIFF
--- a/fundingmanager.go
+++ b/fundingmanager.go
@@ -676,13 +676,16 @@ func (f *fundingManager) failFundingFlow(peer *btcec.PublicKey,
 
 	fndgLog.Errorf("Failing funding flow: %v", spew.Sdump(errMsg))
 
+	if _, err := f.cancelReservationCtx(peer, tempChanID); err != nil {
+		fndgLog.Errorf("unable to cancel reservation: %v", err)
+	}
+
 	err := f.cfg.SendToPeer(peer, errMsg)
 	if err != nil {
 		fndgLog.Errorf("unable to send error message to peer %v", err)
 		return
 	}
 
-	f.cancelReservationCtx(peer, tempChanID)
 	return
 }
 

--- a/lnwallet/wallet.go
+++ b/lnwallet/wallet.go
@@ -807,6 +807,9 @@ func (l *LightningWallet) handleContributionMsg(req *addContributionMsg) {
 	fundingOutpoint := wire.NewOutPoint(&fundingTxID, multiSigIndex)
 	pendingReservation.partialState.FundingOutpoint = *fundingOutpoint
 
+	walletLog.Debugf("Funding tx for ChannelPoint(%v) generated: %v",
+		fundingOutpoint, spew.Sdump(fundingTx))
+
 	// Initialize an empty sha-chain for them, tracking the current pending
 	// revocation hash (we don't yet know the preimage so we can't add it
 	// to the chain).
@@ -878,6 +881,11 @@ func (l *LightningWallet) handleContributionMsg(req *addContributionMsg) {
 	// instead we'll just send signatures.
 	txsort.InPlaceSort(ourCommitTx)
 	txsort.InPlaceSort(theirCommitTx)
+
+	walletLog.Debugf("Local commit tx for ChannelPoint(%v): %v",
+		fundingOutpoint, spew.Sdump(ourCommitTx))
+	walletLog.Debugf("Remote commit tx for ChannelPoint(%v): %v",
+		fundingOutpoint, spew.Sdump(theirCommitTx))
 
 	// Record newly available information within the open channel state.
 	chanState.FundingOutpoint = *fundingOutpoint
@@ -1180,6 +1188,11 @@ func (l *LightningWallet) handleSingleFunderSigs(req *addSingleFunderSigsMsg) {
 	txsort.InPlaceSort(theirCommitTx)
 	chanState.LocalCommitment.CommitTx = ourCommitTx
 	chanState.RemoteCommitment.CommitTx = theirCommitTx
+
+	walletLog.Debugf("Local commit tx for ChannelPoint(%v): %v",
+		req.fundingOutpoint, spew.Sdump(ourCommitTx))
+	walletLog.Debugf("Remote commit tx for ChannelPoint(%v): %v",
+		req.fundingOutpoint, spew.Sdump(theirCommitTx))
 
 	channelValue := int64(pendingReservation.partialState.Capacity)
 	hashCache := txscript.NewTxSigHashes(ourCommitTx)


### PR DESCRIPTION
In this commit, we modify the logic executed when we decide that we
need to fail a funding flow. Before this commit, if the remote party
disconnected while we were attempting to fail the funding flow with an
error. Then we'd never actually cancel the reservation. This meant that
any inputs selected for that transaction would be locked until a
restart.

We fix this issue by always cancelling the reservation first, and
ensuring that failure to cancel the reservation doesn't prevent us from
sending the error.

Finally, we add some additional logging on the `debug` level for 
transactions generated during the initial funding flow. 

Partially addresses #710.