### PR TITLE
lnwallet: avoid creating dust change outputs in funding txns

### DIFF
--- a/lnwallet/wallet.go
+++ b/lnwallet/wallet.go
@@ -1318,8 +1318,9 @@ func (l *LightningWallet) selectCoinsAndChange(feeRatePerWeight btcutil.Amount,
 	}
 
 	// Record any change output(s) generated as a result of the coin
-	// selection.
-	if changeAmt != 0 {
+	// selection, but only if the addition of the output won't lead to the
+	// creation of dust.
+	if changeAmt != 0 && changeAmt > DefaultDustLimit() {
 		changeAddr, err := l.NewAddress(WitnessPubKey, true)
 		if err != nil {
 			return err


### PR DESCRIPTION
Before this commit, if the remaining change was small enough, then it
was possible for us to generate a non-std funding transaction. This is
an issue as the txn would fail to propagate, meaning funds could
potentially be stuck in limbo if users didn't manually drop their
transaction history.

To avoid this scenario, we won't create a change output that is dusty.
Instead, we'll add these as miner fees.

Fixes #690.