### PR TITLE
multi: macaroon root key encryption

### DIFF
--- a/macaroons/auth.go
+++ b/macaroons/auth.go
@@ -2,13 +2,9 @@ package macaroons
 
 import (
 	"encoding/hex"
-	"fmt"
-
-	"google.golang.org/grpc/metadata"
 
 	"golang.org/x/net/context"
 
-	"gopkg.in/macaroon-bakery.v2/bakery"
 	macaroon "gopkg.in/macaroon.v2"
 )
 
@@ -46,41 +42,4 @@ func NewMacaroonCredential(m *macaroon.Macaroon) MacaroonCredential {
 	ms := MacaroonCredential{}
 	ms.Macaroon = m.Clone()
 	return ms
-}
-
-// ValidateMacaroon validates the capabilities of a given request given a
-// bakery service, context, and uri. Within the passed context.Context, we
-// expect a macaroon to be encoded as request metadata using the key
-// "macaroon".
-func ValidateMacaroon(ctx context.Context, requiredPermissions []bakery.Op,
-	svc *bakery.Bakery) error {
-
-	// Get macaroon bytes from context and unmarshal into macaroon.
-	md, ok := metadata.FromIncomingContext(ctx)
-	if !ok {
-		return fmt.Errorf("unable to get metadata from context")
-	}
-	if len(md["macaroon"]) != 1 {
-		return fmt.Errorf("expected 1 macaroon, got %d",
-			len(md["macaroon"]))
-	}
-
-	// With the macaroon obtained, we'll now decode the hex-string
-	// encoding, then unmarshal it from binary into its concrete struct
-	// representation.
-	macBytes, err := hex.DecodeString(md["macaroon"][0])
-	if err != nil {
-		return err
-	}
-	mac := &macaroon.Macaroon{}
-	err = mac.UnmarshalBinary(macBytes)
-	if err != nil {
-		return err
-	}
-
-	// Check the method being called against the permitted operation and
-	// the expiration time and IP address and return the result.
-	authChecker := svc.Checker.Auth(macaroon.Slice{mac})
-	_, err = authChecker.Allow(ctx, requiredPermissions...)
-	return err
 }

--- a/macaroons/service.go
+++ b/macaroons/service.go
@@ -1,13 +1,16 @@
 package macaroons
 
 import (
+	"encoding/hex"
 	"fmt"
 	"path"
 
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/metadata"
 
 	"gopkg.in/macaroon-bakery.v2/bakery"
 	"gopkg.in/macaroon-bakery.v2/bakery/checkers"
+	macaroon "gopkg.in/macaroon.v2"
 
 	"golang.org/x/net/context"
 
@@ -20,6 +23,15 @@ var (
 	dbFilename = "macaroons.db"
 )
 
+// Service encapsulates bakery.Bakery and adds a Close() method that zeroes the
+// root key service encryption keys, as well as utility methods to validate a
+// macaroon against the bakery and gRPC middleware for macaroon-based auth.
+type Service struct {
+	bakery.Bakery
+
+	rks *RootKeyStorage
+}
+
 // NewService returns a service backed by the macaroon Bolt DB stored in the
 // passed directory. The `checks` argument can be any of the `Checker` type
 // functions defined in this package, or a custom checker if desired. This
@@ -27,7 +39,7 @@ var (
 // listing the same checker more than once is not harmful. Default checkers,
 // such as those for `allow`, `time-before`, `declared`, and `error` caveats
 // are registered automatically and don't need to be added.
-func NewService(dir string, checks ...Checker) (*bakery.Bakery, error) {
+func NewService(dir string, checks ...Checker) (*Service, error) {
 	// Open the database that we'll use to store the primary macaroon key,
 	// and all generated macaroons+caveats.
 	macaroonDB, err := bolt.Open(path.Join(dir, dbFilename), 0600,
@@ -62,7 +74,7 @@ func NewService(dir string, checks ...Checker) (*bakery.Bakery, error) {
 		}
 	}
 
-	return svc, nil
+	return &Service{*svc, rootKeyStore}, nil
 }
 
 // isRegistered checks to see if the required checker has already been
@@ -83,7 +95,7 @@ func isRegistered(c *checkers.Checker, name string) bool {
 
 // UnaryServerInterceptor is a GRPC interceptor that checks whether the
 // request is authorized by the included macaroons.
-func UnaryServerInterceptor(svc *bakery.Bakery,
+func (svc *Service) UnaryServerInterceptor(
 	permissionMap map[string][]bakery.Op) grpc.UnaryServerInterceptor {
 
 	return func(ctx context.Context, req interface{},
@@ -95,8 +107,7 @@ func UnaryServerInterceptor(svc *bakery.Bakery,
 				"required for method", info.FullMethod)
 		}
 
-		err := ValidateMacaroon(ctx, permissionMap[info.FullMethod],
-			svc)
+		err := svc.ValidateMacaroon(ctx, permissionMap[info.FullMethod])
 		if err != nil {
 			return nil, err
 		}
@@ -107,7 +118,7 @@ func UnaryServerInterceptor(svc *bakery.Bakery,
 
 // StreamServerInterceptor is a GRPC interceptor that checks whether the
 // request is authorized by the included macaroons.
-func StreamServerInterceptor(svc *bakery.Bakery,
+func (svc *Service) StreamServerInterceptor(
 	permissionMap map[string][]bakery.Op) grpc.StreamServerInterceptor {
 
 	return func(srv interface{}, ss grpc.ServerStream,
@@ -118,12 +129,61 @@ func StreamServerInterceptor(svc *bakery.Bakery,
 				"for method", info.FullMethod)
 		}
 
-		err := ValidateMacaroon(ss.Context(),
-			permissionMap[info.FullMethod], svc)
+		err := svc.ValidateMacaroon(ss.Context(),
+			permissionMap[info.FullMethod])
 		if err != nil {
 			return err
 		}
 
 		return handler(srv, ss)
 	}
+}
+
+// ValidateMacaroon validates the capabilities of a given request given a
+// bakery service, context, and uri. Within the passed context.Context, we
+// expect a macaroon to be encoded as request metadata using the key
+// "macaroon".
+func (svc *Service) ValidateMacaroon(ctx context.Context,
+	requiredPermissions []bakery.Op) error {
+
+	// Get macaroon bytes from context and unmarshal into macaroon.
+	md, ok := metadata.FromIncomingContext(ctx)
+	if !ok {
+		return fmt.Errorf("unable to get metadata from context")
+	}
+	if len(md["macaroon"]) != 1 {
+		return fmt.Errorf("expected 1 macaroon, got %d",
+			len(md["macaroon"]))
+	}
+
+	// With the macaroon obtained, we'll now decode the hex-string
+	// encoding, then unmarshal it from binary into its concrete struct
+	// representation.
+	macBytes, err := hex.DecodeString(md["macaroon"][0])
+	if err != nil {
+		return err
+	}
+	mac := &macaroon.Macaroon{}
+	err = mac.UnmarshalBinary(macBytes)
+	if err != nil {
+		return err
+	}
+
+	// Check the method being called against the permitted operation and
+	// the expiration time and IP address and return the result.
+	authChecker := svc.Checker.Auth(macaroon.Slice{mac})
+	_, err = authChecker.Allow(ctx, requiredPermissions...)
+	return err
+}
+
+// Close closes the database that underlies the RootKeyStore and zeroes the
+// encryption keys.
+func (svc *Service) Close() error {
+	return svc.rks.Close()
+}
+
+// CreateUnlock calls the underlying root key store's CreateUnlock and returns
+// the result.
+func (svc *Service) CreateUnlock(password *[]byte) error {
+	return svc.rks.CreateUnlock(password)
 }

--- a/macaroons/store.go
+++ b/macaroons/store.go
@@ -8,6 +8,8 @@ import (
 	"golang.org/x/net/context"
 
 	"github.com/boltdb/bolt"
+
+	"github.com/roasbeef/btcwallet/snacl"
 )
 
 const (
@@ -25,13 +27,28 @@ var (
 	// TODO(aakselrod): Add support for key rotation.
 	defaultRootKeyID = []byte("0")
 
-	// macaroonBucketName is the name of the macaroon store bucket.
-	macaroonBucketName = []byte("macaroons")
+	// encryptedKeyID is the name of the database key that stores the
+	// encryption key, encrypted with a salted + hashed password. The
+	// format is 32 bytes of salt, and the rest is encrypted key.
+	encryptedKeyID = []byte("enckey")
+
+	// ErrAlreadyUnlocked specifies that the store has already been
+	// unlocked.
+	ErrAlreadyUnlocked = fmt.Errorf("macaroon store already unlocked")
+
+	// ErrStoreLocked specifies that the store needs to be unlocked with
+	// a password.
+	ErrStoreLocked = fmt.Errorf("macaroon store is locked")
+
+	// ErrPasswordRequired specifies that a nil password has been passed.
+	ErrPasswordRequired = fmt.Errorf("a non-nil password is required")
 )
 
 // RootKeyStorage implements the bakery.RootKeyStorage interface.
 type RootKeyStorage struct {
 	*bolt.DB
+
+	encKey *snacl.SecretKey
 }
 
 // NewRootKeyStorage creates a RootKeyStorage instance.
@@ -47,11 +64,65 @@ func NewRootKeyStorage(db *bolt.DB) (*RootKeyStorage, error) {
 	}
 
 	// Return the DB wrapped in a RootKeyStorage object.
-	return &RootKeyStorage{db}, nil
+	return &RootKeyStorage{db, nil}, nil
+}
+
+// CreateUnlock sets an encryption key if one is not already set, otherwise it
+// checks if the password is correct for the stored encryption key.
+func (r *RootKeyStorage) CreateUnlock(password *[]byte) error {
+	// Check if we've already unlocked the store; return an error if so.
+	if r.encKey != nil {
+		return ErrAlreadyUnlocked
+	}
+
+	// Check if a nil password has been passed; return an error if so.
+	if password == nil {
+		return ErrPasswordRequired
+	}
+
+	return r.Update(func(tx *bolt.Tx) error {
+		bucket := tx.Bucket(rootKeyBucketName)
+		dbKey := bucket.Get(encryptedKeyID)
+		if len(dbKey) > 0 {
+			// We've already stored a key, so try to unlock with
+			// the password.
+			encKey := &snacl.SecretKey{}
+			err := encKey.Unmarshal(dbKey)
+			if err != nil {
+				return err
+			}
+
+			err = encKey.DeriveKey(password)
+			if err != nil {
+				return err
+			}
+
+			r.encKey = encKey
+			return nil
+		}
+
+		// We haven't yet stored a key, so create a new one.
+		encKey, err := snacl.NewSecretKey(password, snacl.DefaultN,
+			snacl.DefaultR, snacl.DefaultP)
+		if err != nil {
+			return err
+		}
+
+		err = bucket.Put(encryptedKeyID, encKey.Marshal())
+		if err != nil {
+			return err
+		}
+
+		r.encKey = encKey
+		return nil
+	})
 }
 
 // Get implements the Get method for the bakery.RootKeyStorage interface.
 func (r *RootKeyStorage) Get(_ context.Context, id []byte) ([]byte, error) {
+	if r.encKey == nil {
+		return nil, ErrStoreLocked
+	}
 	var rootKey []byte
 	err := r.View(func(tx *bolt.Tx) error {
 		dbKey := tx.Bucket(rootKeyBucketName).Get(id)
@@ -60,8 +131,13 @@ func (r *RootKeyStorage) Get(_ context.Context, id []byte) ([]byte, error) {
 				string(id))
 		}
 
-		rootKey = make([]byte, len(dbKey))
-		copy(rootKey[:], dbKey)
+		decKey, err := r.encKey.Decrypt(dbKey)
+		if err != nil {
+			return err
+		}
+
+		rootKey = make([]byte, len(decKey))
+		copy(rootKey[:], decKey)
 		return nil
 	})
 	if err != nil {
@@ -75,27 +151,51 @@ func (r *RootKeyStorage) Get(_ context.Context, id []byte) ([]byte, error) {
 // interface.
 // TODO(aakselrod): Add support for key rotation.
 func (r *RootKeyStorage) RootKey(_ context.Context) ([]byte, []byte, error) {
+	if r.encKey == nil {
+		return nil, nil, ErrStoreLocked
+	}
 	var rootKey []byte
 	id := defaultRootKeyID
 	err := r.Update(func(tx *bolt.Tx) error {
 		ns := tx.Bucket(rootKeyBucketName)
-		rootKey = ns.Get(id)
+		dbKey := ns.Get(id)
 
-		// If there's no root key stored in the bucket yet, create one.
-		if len(rootKey) != 0 {
+		// If there's a root key stored in the bucket, decrypt it and
+		// return it.
+		if len(dbKey) != 0 {
+			decKey, err := r.encKey.Decrypt(dbKey)
+			if err != nil {
+				return err
+			}
+
+			rootKey = make([]byte, len(decKey))
+			copy(rootKey[:], decKey[:])
 			return nil
 		}
 
-		// Create a RootKeyLen-byte root key.
+		// Otherwise, create a RootKeyLen-byte root key, encrypt it,
+		// and store it in the bucket.
 		rootKey = make([]byte, RootKeyLen)
 		if _, err := io.ReadFull(rand.Reader, rootKey[:]); err != nil {
 			return err
 		}
-		return ns.Put(id, rootKey)
+
+		encKey, err := r.encKey.Encrypt(rootKey)
+		if err != nil {
+			return err
+		}
+		return ns.Put(id, encKey)
 	})
 	if err != nil {
 		return nil, nil, err
 	}
 
 	return rootKey, id, nil
+}
+
+// Close closes the underlying database and zeroes the encryption key stored
+// in memory.
+func (r *RootKeyStorage) Close() error {
+	r.encKey.Zero()
+	return r.DB.Close()
 }

--- a/macaroons/store_test.go
+++ b/macaroons/store_test.go
@@ -1,0 +1,137 @@
+package macaroons_test
+
+import (
+	"bytes"
+	"io/ioutil"
+	"os"
+	"path"
+	"testing"
+
+	"github.com/boltdb/bolt"
+
+	"github.com/lightningnetwork/lnd/macaroons"
+
+	"github.com/roasbeef/btcwallet/snacl"
+)
+
+func TestStore(t *testing.T) {
+	tempDir, err := ioutil.TempDir("", "macaroonstore-")
+	if err != nil {
+		t.Fatalf("Error creating temp dir: %v", err)
+	}
+	defer os.RemoveAll(tempDir)
+
+	db, err := bolt.Open(path.Join(tempDir, "weks.db"), 0600,
+		bolt.DefaultOptions)
+	if err != nil {
+		t.Fatalf("Error opening store DB: %v", err)
+	}
+
+	store, err := macaroons.NewRootKeyStorage(db)
+	if err != nil {
+		db.Close()
+		t.Fatalf("Error creating root key store: %v", err)
+	}
+	defer store.Close()
+
+	key, id, err := store.RootKey(nil)
+	if err != macaroons.ErrStoreLocked {
+		t.Fatalf("Received %v instead of ErrStoreLocked", err)
+	}
+
+	key, err = store.Get(nil, nil)
+	if err != macaroons.ErrStoreLocked {
+		t.Fatalf("Received %v instead of ErrStoreLocked", err)
+	}
+
+	pw := []byte("weks")
+	err = store.CreateUnlock(&pw)
+	if err != nil {
+		t.Fatalf("Error creating store encryption key: %v", err)
+	}
+
+	key, id, err = store.RootKey(nil)
+	if err != nil {
+		t.Fatalf("Error getting root key from store: %v", err)
+	}
+	rootID := id
+
+	key2, err := store.Get(nil, id)
+	if err != nil {
+		t.Fatalf("Error getting key with ID %s: %v", string(id), err)
+	}
+	if !bytes.Equal(key, key2) {
+		t.Fatalf("Root key doesn't match: expected %v, got %v",
+			key, key2)
+	}
+
+	badpw := []byte("badweks")
+	err = store.CreateUnlock(&badpw)
+	if err != macaroons.ErrAlreadyUnlocked {
+		t.Fatalf("Received %v instead of ErrAlreadyUnlocked", err)
+	}
+
+	store.Close()
+	// Between here and the re-opening of the store, it's possible to get
+	// a double-close, but that's not such a big deal since the tests will
+	// fail anyway in that case.
+	db, err = bolt.Open(path.Join(tempDir, "weks.db"), 0600,
+		bolt.DefaultOptions)
+	if err != nil {
+		t.Fatalf("Error opening store DB: %v", err)
+	}
+
+	store, err = macaroons.NewRootKeyStorage(db)
+	if err != nil {
+		db.Close()
+		t.Fatalf("Error creating root key store: %v", err)
+	}
+
+	err = store.CreateUnlock(&badpw)
+	if err != snacl.ErrInvalidPassword {
+		t.Fatalf("Received %v instead of ErrInvalidPassword", err)
+	}
+
+	err = store.CreateUnlock(nil)
+	if err != macaroons.ErrPasswordRequired {
+		t.Fatalf("Received %v instead of ErrPasswordRequired", err)
+	}
+
+	key, id, err = store.RootKey(nil)
+	if err != macaroons.ErrStoreLocked {
+		t.Fatalf("Received %v instead of ErrStoreLocked", err)
+	}
+
+	key, err = store.Get(nil, nil)
+	if err != macaroons.ErrStoreLocked {
+		t.Fatalf("Received %v instead of ErrStoreLocked", err)
+	}
+
+	err = store.CreateUnlock(&pw)
+	if err != nil {
+		t.Fatalf("Error unlocking root key store: %v", err)
+	}
+
+	key, err = store.Get(nil, rootID)
+	if err != nil {
+		t.Fatalf("Error getting key with ID %s: %v",
+			string(rootID), err)
+	}
+	if !bytes.Equal(key, key2) {
+		t.Fatalf("Root key doesn't match: expected %v, got %v",
+			key2, key)
+	}
+
+	key, id, err = store.RootKey(nil)
+	if err != nil {
+		t.Fatalf("Error getting root key from store: %v", err)
+	}
+	if !bytes.Equal(key, key2) {
+		t.Fatalf("Root key doesn't match: expected %v, got %v",
+			key2, key)
+	}
+	if !bytes.Equal(rootID, id) {
+		t.Fatalf("Root ID doesn't match: expected %v, got %v",
+			rootID, id)
+	}
+}


### PR DESCRIPTION
This PR enables macaroon root key encryption in the database to prevent attackers with access to the filesystem or backups from being able to generate their own macaroons and steal money via RPC. It makes the following changes to support this:

* Updates the `RootKeyStore` code with a `CreateUnlock()` and a `Close()` method in order to set a password, and zero the encryption key in memory on close
* Wraps the `bakery.Bakery` in a `macaroons.Service` which can pass `CreateUnlock()` and `Close()` requests to the underlying `RootKeyStore` and makes several functions into methods on the new struct (in particular, `UnaryServerInterceptor()`, `StreamServerInterceptor()`, and `VerifyMacaroon()`
* Updates the `walletunlocker` and `lncli` packages, as well as the main `lnd.go` file, to work with the updates above
* Adds macaroon root key store tests to ensure encryption works as specified