### PR TITLE
remove header from bitcoin conf documentation example

### DIFF
--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -190,7 +190,6 @@ wallet). They must be combined in the same ZMQ socket address (e.g. `--zmqpubraw
 
 Here's a sample `bitcoin.conf` for use with lnd:
 ```
-[Application Options]
 testnet=1
 txindex=1
 server=1


### PR DESCRIPTION
Remove header from bitcoind configuration example.  After doing some further testing, it seems that bitcoind will ignore the config if a header is included.  This is a followup to [PR](https://github.com/lightningnetwork/lnd/pull/702)