### PR TITLE
utxonursery: fix witness overwriting bug on sweep txn

### DIFF
--- a/utxonursery.go
+++ b/utxonursery.go
@@ -1095,8 +1095,12 @@ func (u *utxoNursery) populateSweepTx(txWeight uint64, classHeight uint32,
 			return nil, err
 		}
 	}
+
+	// Add offset to relative indexes so cltv witnesses don't overwrite csv
+	// witnesses.
+	offset := len(csvInputs)
 	for i, input := range cltvInputs {
-		if err := addWitness(i, input); err != nil {
+		if err := addWitness(offset+i, input); err != nil {
 			return nil, err
 		}
 	}


### PR DESCRIPTION
Fixes a minor indexing bug that could cause the
utxonursery to accidentally overwrite CSV
witnesses with other CLTV witnesses when populating
a sweep txn. Each type of output is treated
separately internally, the bug is introduced by
using the relative indexes of both sets as the final
indexes into the txins.

The fix adds an offset, equal to the number of CSV
outputs, to the relative indexes of the CLTV inputs.
This matches the order in which CSV and CLTV outputs
are added to the raw txn.