### PR TITLE
lnd: use single asterisk for gitignore wildcards

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,13 +27,13 @@ _testmain.go
 /lnd
 
 cmd/cmd
-**.key
-**.hex
+*.key
+*.hex
 
 cmd/lncli/lncli
 
 # vim
-**.swp
+*.swp
 
 *.hex
 *.db


### PR DESCRIPTION
This stops ripgrep from complaining about

  invalid use of **; must be one path component

See https://github.com/BurntSushi/ripgrep/issues/373