### PR TITLE
update reason for using btcd fork to be regarding neutrino additions

### DIFF
--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -76,10 +76,9 @@ go install; go test -v -p 1 $(go list ./... | grep -v  '/vendor/')
 
 ### Installing btcd
 
-`lnd` currently requires `btcd` with segwit support, which is not yet merged
-into the master branch. Instead, [roasbeef](https://github.com/roasbeef/btcd)
-maintains a fork with his segwit implementation applied. To install, run the
-following commands:
+`lnd` currently requires the [roasbeef](https://github.com/roasbeef/btcd) fork
+of `btcd` due to neutrino additions that are not yet available in the master
+branch. To install, run the following commands:
 
 Install **btcd**: (must be from roasbeef fork, not from btcsuite)
 ```


### PR DESCRIPTION
Reason for continuing to use the roasbeef fork of btcd is no longer segwit missing from master, but the neutrino work that is missing from master. See issue: https://github.com/lightningnetwork/lnd/issues/740