### PR TITLE
breacharbiter: reset witness func for 2nd conversion

### DIFF
--- a/breacharbiter.go
+++ b/breacharbiter.go
@@ -418,6 +418,11 @@ out:
 func convertToSecondLevelRevoke(bo *breachedOutput, breachInfo *retributionInfo,
 	spendDetails *chainntnfs.SpendDetail) {
 
+	// First, we reset the witness function in case BuildWitness has already
+	// been executed on this output, otherwise we will continue to generate
+	// the old witness.
+	bo.witnessFunc = nil
+
 	// In this case, we'll modify the witness type of this output to
 	// actually prepare for a second level revoke.
 	bo.witnessType = lnwallet.HtlcSecondLevelRevoke


### PR DESCRIPTION
Simple change to reset a breachedOutput's witness function when
converting to to spend from a second layer HTLC. Without doing so, we
would continue to generate the same witness since this function is only
constructed at signing-time if the value is nil.