### PR TITLE
Remove peer_id

### DIFF
--- a/cmd/lncli/commands.go
+++ b/cmd/lncli/commands.go
@@ -388,15 +388,9 @@ var openChannelCommand = cli.Command{
 	of the funding output is returned.
 
 	One can manually set the fee to be used for the funding transaction via either
-	the --conf_target or --sat_per_byte arguments. This is optional.
-
-	NOTE: peer_id and node_key are mutually exclusive, only one should be used, not both.`,
+	the --conf_target or --sat_per_byte arguments. This is optional.`,
 	ArgsUsage: "node-key local-amt push-amt",
 	Flags: []cli.Flag{
-		cli.IntFlag{
-			Name:  "peer_id",
-			Usage: "the relative id of the peer to open a channel with",
-		},
 		cli.StringFlag{
 			Name: "node_key",
 			Usage: "the identity public key of the target node/peer " +
@@ -463,11 +457,6 @@ func openChannel(ctx *cli.Context) error {
 		return nil
 	}
 
-	if ctx.IsSet("peer_id") && ctx.IsSet("node_key") {
-		return fmt.Errorf("both peer_id and lightning_id cannot be set " +
-			"at the same time, only one can be specified")
-	}
-
 	req := &lnrpc.OpenChannelRequest{
 		TargetConf:  int32(ctx.Int64("conf_target")),
 		SatPerByte:  ctx.Int64("sat_per_byte"),
@@ -475,8 +464,6 @@ func openChannel(ctx *cli.Context) error {
 	}
 
 	switch {
-	case ctx.IsSet("peer_id"):
-		req.TargetPeerId = int32(ctx.Int("peer_id"))
 	case ctx.IsSet("node_key"):
 		nodePubHex, err := hex.DecodeString(ctx.String("node_key"))
 		if err != nil {

--- a/docker/README.md
+++ b/docker/README.md
@@ -123,7 +123,6 @@ alice$ lncli listpeers
     "peers": [
         {
             "pub_key": "0343bc80b914aebf8e50eb0b8e445fc79b9e6e8e5e018fa8c5f85c7d429c117b38",
-            "peer_id": 1,
             "address": "172.19.0.4:9735",
             "bytes_sent": "357",
             "bytes_recv": "357",
@@ -141,7 +140,6 @@ bob$ lncli listpeers
     "peers": [
         {
             "pub_key": "03d0cd35b761f789983f3cfe82c68170cd1c3266b39220c24f7dd72ef4be0883eb",
-            "peer_id": 1,
             "address": "172.19.0.3:51932",
             "bytes_sent": "357",
             "bytes_recv": "357",

--- a/fundingmanager_test.go
+++ b/fundingmanager_test.go
@@ -434,7 +434,6 @@ func openChannel(t *testing.T, alice, bob *testNode, localFundingAmt,
 	// Create a funding request and start the workflow.
 	errChan := make(chan error, 1)
 	initReq := &openChanReq{
-		targetPeerID:    int32(1),
 		targetPubkey:    bob.privKey.PubKey(),
 		chainHash:       *activeNetParams.GenesisHash,
 		localFundingAmt: localFundingAmt,

--- a/lnrpc/rpc.pb.go
+++ b/lnrpc/rpc.pb.go
@@ -832,8 +832,6 @@ func (m *ConnectPeerRequest) GetPerm() bool {
 }
 
 type ConnectPeerResponse struct {
-	// / The id of the newly connected peer
-	PeerId int32 `protobuf:"varint,1,opt,name=peer_id" json:"peer_id,omitempty"`
 }
 
 func (m *ConnectPeerResponse) Reset()                    { *m = ConnectPeerResponse{} }
@@ -1113,8 +1111,6 @@ func (m *ListChannelsResponse) GetChannels() []*ActiveChannel {
 type Peer struct {
 	// / The identity pubkey of the peer
 	PubKey string `protobuf:"bytes,1,opt,name=pub_key" json:"pub_key,omitempty"`
-	// / The peer's id from the local point of view
-	PeerId int32 `protobuf:"varint,2,opt,name=peer_id" json:"peer_id,omitempty"`
 	// / Network address of the peer; eg `127.0.0.1:10011`
 	Address string `protobuf:"bytes,3,opt,name=address" json:"address,omitempty"`
 	// / Bytes of data transmitted to this peer
@@ -1635,8 +1631,6 @@ func (m *PendingUpdate) GetOutputIndex() uint32 {
 }
 
 type OpenChannelRequest struct {
-	// / The peer_id of the node to open a channel with
-	TargetPeerId int32 `protobuf:"varint,1,opt,name=target_peer_id" json:"target_peer_id,omitempty"`
 	// / The pubkey of the node to open a channel with
 	NodePubkey []byte `protobuf:"bytes,2,opt,name=node_pubkey,proto3" json:"node_pubkey,omitempty"`
 	// / The hex encoded pubkey of the node to open a channel with

--- a/lnrpc/rpc.pb.go
+++ b/lnrpc/rpc.pb.go
@@ -839,13 +839,6 @@ func (m *ConnectPeerResponse) String() string            { return proto.CompactT
 func (*ConnectPeerResponse) ProtoMessage()               {}
 func (*ConnectPeerResponse) Descriptor() ([]byte, []int) { return fileDescriptor0, []int{23} }
 
-func (m *ConnectPeerResponse) GetPeerId() int32 {
-	if m != nil {
-		return m.PeerId
-	}
-	return 0
-}
-
 type DisconnectPeerRequest struct {
 	// / The pubkey of the node to disconnect from
 	PubKey string `protobuf:"bytes,1,opt,name=pub_key" json:"pub_key,omitempty"`
@@ -1137,13 +1130,6 @@ func (m *Peer) GetPubKey() string {
 		return m.PubKey
 	}
 	return ""
-}
-
-func (m *Peer) GetPeerId() int32 {
-	if m != nil {
-		return m.PeerId
-	}
-	return 0
 }
 
 func (m *Peer) GetAddress() string {
@@ -1653,13 +1639,6 @@ func (m *OpenChannelRequest) Reset()                    { *m = OpenChannelReques
 func (m *OpenChannelRequest) String() string            { return proto.CompactTextString(m) }
 func (*OpenChannelRequest) ProtoMessage()               {}
 func (*OpenChannelRequest) Descriptor() ([]byte, []int) { return fileDescriptor0, []int{41} }
-
-func (m *OpenChannelRequest) GetTargetPeerId() int32 {
-	if m != nil {
-		return m.TargetPeerId
-	}
-	return 0
-}
 
 func (m *OpenChannelRequest) GetNodePubkey() []byte {
 	if m != nil {

--- a/lnrpc/rpc.proto
+++ b/lnrpc/rpc.proto
@@ -630,8 +630,6 @@ message ConnectPeerRequest {
     bool perm = 2;
 }
 message ConnectPeerResponse {
-    /// The id of the newly connected peer
-    int32 peer_id = 1 [json_name = "peer_id"];
 }
 
 message DisconnectPeerRequest {
@@ -737,9 +735,6 @@ message ListChannelsResponse {
 message Peer {
     /// The identity pubkey of the peer
     string pub_key = 1 [json_name = "pub_key"];
-
-    /// The peer's id from the local point of view
-    int32 peer_id = 2 [json_name = "peer_id"];
 
     /// Network address of the peer; eg `127.0.0.1:10011`
     string address = 3 [json_name = "address"];
@@ -857,9 +852,6 @@ message PendingUpdate {
 }
 
 message OpenChannelRequest {
-
-    /// The peer_id of the node to open a channel with
-    int32 target_peer_id = 1 [json_name = "target_peer_id"];
 
     /// The pubkey of the node to open a channel with
     bytes node_pubkey = 2 [json_name = "node_pubkey"];

--- a/lnrpc/rpc.swagger.json
+++ b/lnrpc/rpc.swagger.json
@@ -1127,14 +1127,7 @@
       }
     },
     "lnrpcConnectPeerResponse": {
-      "type": "object",
-      "properties": {
-        "peer_id": {
-          "type": "integer",
-          "format": "int32",
-          "title": "/ The id of the newly connected peer"
-        }
-      }
+      "type": "object"
     },
     "lnrpcCreateWalletRequest": {
       "type": "object",
@@ -1559,11 +1552,6 @@
     "lnrpcOpenChannelRequest": {
       "type": "object",
       "properties": {
-        "target_peer_id": {
-          "type": "integer",
-          "format": "int32",
-          "title": "/ The peer_id of the node to open a channel with"
-        },
         "node_pubkey": {
           "type": "string",
           "format": "byte",
@@ -1696,11 +1684,6 @@
         "pub_key": {
           "type": "string",
           "title": "/ The identity pubkey of the peer"
-        },
-        "peer_id": {
-          "type": "integer",
-          "format": "int32",
-          "title": "/ The peer's id from the local point of view"
         },
         "address": {
           "type": "string",

--- a/peer.go
+++ b/peer.go
@@ -274,7 +274,7 @@ func (p *peer) Start() error {
 	// registering them with the switch and launching the necessary
 	// goroutines required to operate them.
 	peerLog.Debugf("Loaded %v active channels from database with "+
-		"peerIDKey(%x)", len(activeChans), p.PubKey())
+		"NodeKey(%x)", len(activeChans), p.PubKey())
 	if err := p.loadActiveChannels(activeChans); err != nil {
 		return fmt.Errorf("unable to load channels: %v", err)
 	}
@@ -308,7 +308,7 @@ func (p *peer) loadActiveChannels(chans []*channeldb.OpenChannel) error {
 		p.activeChannels[chanID] = lnChan
 		p.activeChanMtx.Unlock()
 
-		peerLog.Infof("peerIDKey(%x) loading ChannelPoint(%v)", p.PubKey(), chanPoint)
+		peerLog.Infof("NodeKey(%x) loading ChannelPoint(%v)", p.PubKey(), chanPoint)
 
 		// Skip adding any permanently irreconcilable channels to the
 		// htlcswitch.
@@ -1245,7 +1245,7 @@ out:
 			p.activeChanMtx.Unlock()
 
 			peerLog.Infof("New channel active ChannelPoint(%v) "+
-				"with peerIDKey(%x)", chanPoint, p.PubKey())
+				"with NodeKey(%x)", chanPoint, p.PubKey())
 
 			// Next, we'll assemble a ChannelLink along with the
 			// necessary items it needs to function.
@@ -1302,7 +1302,7 @@ out:
 			// local payments and also passively forward payments.
 			if err := p.server.htlcSwitch.AddLink(link); err != nil {
 				peerLog.Errorf("can't register new channel "+
-					"link(%v) with peerIdKey(%x)", chanPoint, p.PubKey())
+					"link(%v) with NodeKey(%x)", chanPoint, p.PubKey())
 			}
 
 			close(newChanReq.done)

--- a/peer.go
+++ b/peer.go
@@ -106,7 +106,6 @@ type peer struct {
 	pubKeyBytes [33]byte
 
 	inbound bool
-	id      int32
 
 	// This mutex protects all the stats below it.
 	sync.RWMutex
@@ -179,7 +178,6 @@ func newPeer(conn net.Conn, connReq *connmgr.ConnReq, server *server,
 		conn: conn,
 		addr: addr,
 
-		id:      atomic.AddInt32(&numNodes, 1),
 		inbound: inbound,
 		connReq: connReq,
 
@@ -276,7 +274,7 @@ func (p *peer) Start() error {
 	// registering them with the switch and launching the necessary
 	// goroutines required to operate them.
 	peerLog.Debugf("Loaded %v active channels from database with "+
-		"peerID(%v)", len(activeChans), p.id)
+		"peerIDKey(%x)", len(activeChans), p.PubKey())
 	if err := p.loadActiveChannels(activeChans); err != nil {
 		return fmt.Errorf("unable to load channels: %v", err)
 	}
@@ -310,7 +308,7 @@ func (p *peer) loadActiveChannels(chans []*channeldb.OpenChannel) error {
 		p.activeChannels[chanID] = lnChan
 		p.activeChanMtx.Unlock()
 
-		peerLog.Infof("peerID(%v) loading ChannelPoint(%v)", p.id, chanPoint)
+		peerLog.Infof("peerIDKey(%x) loading ChannelPoint(%v)", p.PubKey(), chanPoint)
 
 		// Skip adding any permanently irreconcilable channels to the
 		// htlcswitch.
@@ -1247,7 +1245,7 @@ out:
 			p.activeChanMtx.Unlock()
 
 			peerLog.Infof("New channel active ChannelPoint(%v) "+
-				"with peerId(%v)", chanPoint, p.id)
+				"with peerIDKey(%x)", chanPoint, p.PubKey())
 
 			// Next, we'll assemble a ChannelLink along with the
 			// necessary items it needs to function.
@@ -1304,7 +1302,7 @@ out:
 			// local payments and also passively forward payments.
 			if err := p.server.htlcSwitch.AddLink(link); err != nil {
 				peerLog.Errorf("can't register new channel "+
-					"link(%v) with peerId(%v)", chanPoint, p.id)
+					"link(%v) with peerIdKey(%x)", chanPoint, p.PubKey())
 			}
 
 			close(newChanReq.done)

--- a/pilot.go
+++ b/pilot.go
@@ -93,7 +93,7 @@ func (c *chanController) OpenChannel(target *btcec.PublicKey,
 	// TODO(halseth): make configurable?
 	minHtlc := lnwire.NewMSatFromSatoshis(1)
 
-	updateStream, errChan := c.server.OpenChannel(-1, target, amt, 0,
+	updateStream, errChan := c.server.OpenChannel(target, amt, 0,
 		minHtlc, feePerWeight, false)
 
 	select {

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -720,6 +720,11 @@ func (r *rpcServer) OpenChannel(in *lnrpc.OpenChannelRequest,
 
 	// TODO(roasbeef): also return channel ID?
 
+	// Ensure that the NodePubKey is set before attempting to use it
+	if len(in.NodePubkey) == 0 {
+		return fmt.Errorf("NodePubKey is not set")
+	}
+
 	// Parse the raw bytes of the node key into a pubkey object so we
 	// can easily manipulate it.
 	nodePubKey, err = btcec.ParsePubKey(in.NodePubkey, btcec.S256())

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -668,7 +668,7 @@ func (r *rpcServer) DisconnectPeer(ctx context.Context,
 func (r *rpcServer) OpenChannel(in *lnrpc.OpenChannelRequest,
 	updateStream lnrpc.Lightning_OpenChannelServer) error {
 
-	rpcsLog.Tracef("[openchannel] request to identityPub(%v) "+
+	rpcsLog.Tracef("[openchannel] request to NodeKey(%v) "+
 		"allocation(us=%v, them=%v)", in.NodePubkeyString,
 		in.LocalFundingAmount, in.PushSat)
 
@@ -766,7 +766,7 @@ out:
 	for {
 		select {
 		case err := <-errChan:
-			rpcsLog.Errorf("unable to open channel to identityPub(%x): %v",
+			rpcsLog.Errorf("unable to open channel to NodeKey(%x): %v",
 				nodePubKeyBytes, err)
 			return err
 		case fundingUpdate := <-updateChan:
@@ -803,7 +803,7 @@ out:
 		}
 	}
 
-	rpcsLog.Tracef("[openchannel] success identityPub(%x), ChannelPoint(%v)",
+	rpcsLog.Tracef("[openchannel] success NodeKey(%x), ChannelPoint(%v)",
 		nodePubKeyBytes, outpoint)
 	return nil
 }
@@ -815,7 +815,7 @@ out:
 func (r *rpcServer) OpenChannelSync(ctx context.Context,
 	in *lnrpc.OpenChannelRequest) (*lnrpc.ChannelPoint, error) {
 
-	rpcsLog.Tracef("[openchannel] request to identityPub(%v) "+
+	rpcsLog.Tracef("[openchannel] request to NodeKey(%v) "+
 		"allocation(us=%v, them=%v)", in.NodePubkeyString,
 		in.LocalFundingAmount, in.PushSat)
 
@@ -883,7 +883,7 @@ func (r *rpcServer) OpenChannelSync(ctx context.Context,
 	select {
 	// If an error occurs them immediately return the error to the client.
 	case err := <-errChan:
-		rpcsLog.Errorf("unable to open channel to identityPub(%x): %v",
+		rpcsLog.Errorf("unable to open channel to NodeKey(%x): %v",
 			nodepubKey, err)
 		return nil, err
 

--- a/server.go
+++ b/server.go
@@ -1773,7 +1773,7 @@ func (s *server) DisconnectPeer(pubKey *btcec.PublicKey) error {
 }
 
 // OpenChannel sends a request to the server to open a channel to the specified
-// peer identified by Public Key with the passed channel funding parameters.
+// peer identified by nodeKey with the passed channel funding parameters.
 //
 // NOTE: This function is safe for concurrent access.
 func (s *server) OpenChannel(nodeKey *btcec.PublicKey,

--- a/server.go
+++ b/server.go
@@ -75,7 +75,6 @@ type server struct {
 	lightningID [32]byte
 
 	mu         sync.RWMutex
-	peersByID  map[int32]*peer
 	peersByPub map[string]*peer
 
 	inboundPeers  map[string]*peer
@@ -173,7 +172,6 @@ func newServer(listenAddrs []string, chanDB *channeldb.DB, cc *chainControl,
 		persistentConnReqs:     make(map[string][]*connmgr.ConnReq),
 		ignorePeerTermination:  make(map[*peer]struct{}),
 
-		peersByID:              make(map[int32]*peer),
 		peersByPub:             make(map[string]*peer),
 		inboundPeers:           make(map[string]*peer),
 		outboundPeers:          make(map[string]*peer),
@@ -1575,7 +1573,6 @@ func (s *server) addPeer(p *peer) {
 
 	pubStr := string(p.addr.IdentityKey.SerializeCompressed())
 
-	s.peersByID[p.id] = p
 	s.peersByPub[pubStr] = p
 
 	if p.inbound {
@@ -1632,7 +1629,6 @@ func (s *server) removePeer(p *peer) {
 
 	pubStr := string(p.addr.IdentityKey.SerializeCompressed())
 
-	delete(s.peersByID, p.id)
 	delete(s.peersByPub, pubStr)
 
 	if p.inbound {
@@ -1646,7 +1642,6 @@ func (s *server) removePeer(p *peer) {
 // initiation of a channel funding workflow to the peer with either the
 // specified relative peer ID, or a global lightning  ID.
 type openChanReq struct {
-	targetPeerID int32
 	targetPubkey *btcec.PublicKey
 
 	chainHash chainhash.Hash
@@ -1778,10 +1773,10 @@ func (s *server) DisconnectPeer(pubKey *btcec.PublicKey) error {
 }
 
 // OpenChannel sends a request to the server to open a channel to the specified
-// peer identified by ID with the passed channel funding parameters.
+// peer identified by Public Key with the passed channel funding parameters.
 //
 // NOTE: This function is safe for concurrent access.
-func (s *server) OpenChannel(peerID int32, nodeKey *btcec.PublicKey,
+func (s *server) OpenChannel(nodeKey *btcec.PublicKey,
 	localAmt btcutil.Amount, pushAmt lnwire.MilliSatoshi,
 	minHtlc lnwire.MilliSatoshi,
 	fundingFeePerByte btcutil.Amount,
@@ -1806,16 +1801,13 @@ func (s *server) OpenChannel(peerID int32, nodeKey *btcec.PublicKey,
 	// First attempt to locate the target peer to open a channel with, if
 	// we're unable to locate the peer then this request will fail.
 	s.mu.RLock()
-	if peer, ok := s.peersByID[peerID]; ok {
-		targetPeer = peer
-	} else if peer, ok := s.peersByPub[string(pubKeyBytes)]; ok {
+	if peer, ok := s.peersByPub[string(pubKeyBytes)]; ok {
 		targetPeer = peer
 	}
 	s.mu.RUnlock()
 
 	if targetPeer == nil {
-		errChan <- fmt.Errorf("unable to find peer nodeID(%x), "+
-			"peerID(%v)", pubKeyBytes, peerID)
+		errChan <- fmt.Errorf("unable to find peer nodeID(%x)", pubKeyBytes)
 		return updateChan, errChan
 	}
 
@@ -1839,7 +1831,6 @@ func (s *server) OpenChannel(peerID int32, nodeKey *btcec.PublicKey,
 	// instead of blocking on this request which is exported as a
 	// synchronous request to the outside world.
 	req := &openChanReq{
-		targetPeerID:        peerID,
 		targetPubkey:        nodeKey,
 		chainHash:           *activeNetParams.GenesisHash,
 		localFundingAmt:     localAmt,
@@ -1865,8 +1856,8 @@ func (s *server) Peers() []*peer {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
-	peers := make([]*peer, 0, len(s.peersByID))
-	for _, peer := range s.peersByID {
+	peers := make([]*peer, 0, len(s.peersByPub))
+	for _, peer := range s.peersByPub {
 		peers = append(peers, peer)
 	}
 

--- a/server.go
+++ b/server.go
@@ -1807,7 +1807,7 @@ func (s *server) OpenChannel(nodeKey *btcec.PublicKey,
 	s.mu.RUnlock()
 
 	if targetPeer == nil {
-		errChan <- fmt.Errorf("unable to find peer nodeID(%x)", pubKeyBytes)
+		errChan <- fmt.Errorf("unable to find peer NodeKey(%x)", pubKeyBytes)
 		return updateChan, errChan
 	}
 


### PR DESCRIPTION
Mentioned here: https://github.com/lightningnetwork/lnd/issues/508#issuecomment-353575130

This removes peer_id from the RPC/cli stuff and the internal usage of the peer ID, relying just on the public key

Obviously this is a breaking interface change but lnd isn't exactly stable yet so this spares any deprecation process