### PR TITLE
lnwallet/btcwallet/btcwallet: adds extra double spend case

### DIFF
--- a/lnwallet/btcwallet/btcwallet.go
+++ b/lnwallet/btcwallet/btcwallet.go
@@ -427,6 +427,10 @@ func (b *BtcWallet) PublishTransaction(tx *wire.MsgTx) error {
 				// Output was already spent.
 				return lnwallet.ErrDoubleSpend
 			}
+			if strings.Contains(err.Error(), "already been spent") {
+				// Output was already spent.
+				return lnwallet.ErrDoubleSpend
+			}
 			if strings.Contains(err.Error(), "orphan transaction") {
 				// Transaction is spending either output that
 				// is missing or already spent.


### PR DESCRIPTION
Adds an extra case to the select statement to catch
an error produced by btcd. The error is meant to signal
that an output was previously spent, which can appear
under certain race conditions in spending/broadcasting.
This caused our final itest to fail because it would
not try to recraft the justice txn.