### PR TITLE
Switch Persistence [1/4]: Infra for Sphinx Batched Decoding and Replay Protection

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: e0cbbf733425814948ced513c5921d8a4920f179d059f39eeafbf337c32b4ead
-updated: 2018-03-08T20:06:04.267833-05:00
+hash: 607d774162a30647479b037b9291e372c92d1ab6b60808837b22c205ac58981f
+updated: 2018-03-08T21:10:50.953704-05:00
 imports:
 - name: git.schwanenlied.me/yawning/bsaes.git
   version: e06297f34865a50b8e473105e52cb64ad1b55da8
@@ -84,7 +84,7 @@ imports:
   - filterdb
   - headerfs
 - name: github.com/lightningnetwork/lightning-onion
-  version: dbb6dc0eaf32a043c9bc3cfed0fd5fd8db08e3b9
+  version: 9e4b184daf3e32e0c2e523b92ec1b2d6c51ad77f
 - name: github.com/ltcsuite/ltcd
   version: 5f654d5faab99ee2b3488fabba98e5f7a5257ee3
   subpackages:

--- a/glide.yaml
+++ b/glide.yaml
@@ -59,7 +59,7 @@ import:
 - package: google.golang.org/grpc
   version: b3ddf786825de56a4178401b7e174ee332173b66
 - package: github.com/lightningnetwork/lightning-onion
-  version: dbb6dc0eaf32a043c9bc3cfed0fd5fd8db08e3b9
+  version: 9e4b184daf3e32e0c2e523b92ec1b2d6c51ad77f
 - package: github.com/grpc-ecosystem/grpc-gateway
   version: f2862b476edcef83412c7af8687c9cd8e4097c0f
 - package: github.com/go-errors/errors

--- a/htlcswitch/link_test.go
+++ b/htlcswitch/link_test.go
@@ -9,12 +9,11 @@ import (
 	"testing"
 	"time"
 
-	"io"
-
 	"math"
 
 	"github.com/davecgh/go-spew/spew"
 	"github.com/go-errors/errors"
+	"github.com/lightningnetwork/lightning-onion"
 	"github.com/lightningnetwork/lnd/chainntnfs"
 	"github.com/lightningnetwork/lnd/channeldb"
 	"github.com/lightningnetwork/lnd/contractcourt"
@@ -1119,7 +1118,7 @@ func TestChannelLinkMultiHopDecodeError(t *testing.T) {
 
 	// Replace decode function with another which throws an error.
 	n.carolChannelLink.cfg.DecodeOnionObfuscator = func(
-		r io.Reader) (ErrorEncrypter, lnwire.FailCode) {
+		*sphinx.OnionPacket) (ErrorEncrypter, lnwire.FailCode) {
 		return nil, lnwire.CodeInvalidOnionVersion
 	}
 
@@ -1450,7 +1449,7 @@ func newSingleLinkTestHarness(chanAmt, chanReserve btcutil.Amount) (
 		Peer:              alicePeer,
 		Switch:            New(Config{}),
 		DecodeHopIterator: decoder.DecodeHopIterator,
-		DecodeOnionObfuscator: func(io.Reader) (ErrorEncrypter, lnwire.FailCode) {
+		DecodeOnionObfuscator: func(*sphinx.OnionPacket) (ErrorEncrypter, lnwire.FailCode) {
 			return obfuscator, lnwire.CodeNone
 		},
 		GetLastChannelUpdate: mockGetChanUpdateMessage,

--- a/htlcswitch/test_utils.go
+++ b/htlcswitch/test_utils.go
@@ -11,14 +11,13 @@ import (
 	"io/ioutil"
 	"os"
 
-	"io"
-
 	"math/big"
 
 	"net"
 
 	"github.com/btcsuite/fastsha256"
 	"github.com/go-errors/errors"
+	"github.com/lightningnetwork/lightning-onion"
 	"github.com/lightningnetwork/lnd/chainntnfs"
 	"github.com/lightningnetwork/lnd/channeldb"
 	"github.com/lightningnetwork/lnd/contractcourt"
@@ -800,7 +799,7 @@ func newThreeHopNetwork(t testing.TB, aliceChannel, firstBobChannel,
 			Peer:              bobServer,
 			Switch:            aliceServer.htlcSwitch,
 			DecodeHopIterator: decoder.DecodeHopIterator,
-			DecodeOnionObfuscator: func(io.Reader) (ErrorEncrypter,
+			DecodeOnionObfuscator: func(*sphinx.OnionPacket) (ErrorEncrypter,
 				lnwire.FailCode) {
 				return obfuscator, lnwire.CodeNone
 			},
@@ -846,7 +845,7 @@ func newThreeHopNetwork(t testing.TB, aliceChannel, firstBobChannel,
 			Peer:              aliceServer,
 			Switch:            bobServer.htlcSwitch,
 			DecodeHopIterator: decoder.DecodeHopIterator,
-			DecodeOnionObfuscator: func(io.Reader) (ErrorEncrypter,
+			DecodeOnionObfuscator: func(*sphinx.OnionPacket) (ErrorEncrypter,
 				lnwire.FailCode) {
 				return obfuscator, lnwire.CodeNone
 			},
@@ -892,7 +891,7 @@ func newThreeHopNetwork(t testing.TB, aliceChannel, firstBobChannel,
 			Peer:              carolServer,
 			Switch:            bobServer.htlcSwitch,
 			DecodeHopIterator: decoder.DecodeHopIterator,
-			DecodeOnionObfuscator: func(io.Reader) (ErrorEncrypter,
+			DecodeOnionObfuscator: func(*sphinx.OnionPacket) (ErrorEncrypter,
 				lnwire.FailCode) {
 				return obfuscator, lnwire.CodeNone
 			},
@@ -938,7 +937,7 @@ func newThreeHopNetwork(t testing.TB, aliceChannel, firstBobChannel,
 			Peer:              bobServer,
 			Switch:            carolServer.htlcSwitch,
 			DecodeHopIterator: decoder.DecodeHopIterator,
-			DecodeOnionObfuscator: func(io.Reader) (ErrorEncrypter,
+			DecodeOnionObfuscator: func(*sphinx.OnionPacket) (ErrorEncrypter,
 				lnwire.FailCode) {
 				return obfuscator, lnwire.CodeNone
 			},

--- a/lnd_test.go
+++ b/lnd_test.go
@@ -5006,7 +5006,7 @@ func testBidirectionalAsyncPayments(net *lntest.NetworkHarness, t *harnessTest) 
 
 	// Wait for Alice and Bob receive their payments, and throw and error
 	// if something goes wrong.
-	maxTime := 20 * time.Second
+	maxTime := 60 * time.Second
 	for i := 0; i < 2; i++ {
 		select {
 		case err := <-errChan:


### PR DESCRIPTION
This PR adds necessary infrastructure to reliably and safely forward sphinx packets. The two changes include:
1. Encoding/Decoding of `OnionErrorEncrypter`: This will allow the switch to persist the keys required to encrypt an error to the sender in case a forwarded packet returns a failure.
2. Batched Replay Protection: Atomically compare batches of sphinx packets against a persistent log to catch replays.

Note: The shared secrets held by `OnionErrorEncrypter`s are currently stored in plaintext on-disk. I will make a follow up PR to address this, where encoding will just write the original onion packet, and decoding is followed by an additional reconstruction step to rederive the shared secrets upon startup. This extra step will occur upon startup in the newly refactored circuit map.

The glide file should be made to point cfromknecht/lightning-onion@7291f19ac6517199dee681ff1f75a7c7a8e974d1 after it has been merged. This will introduce a slight change to the signature of `DecodeHopIterators`, but otherwise nothing else should change.

Fixes #304. 