### PR TITLE
Switch Persistence [2/4] Infra for Forwarding Packages

### DIFF
--- a/channeldb/forwarding_package.go
+++ b/channeldb/forwarding_package.go
@@ -1,0 +1,921 @@
+package channeldb
+
+import (
+	"bytes"
+	"encoding/binary"
+	"fmt"
+	"io"
+
+	"github.com/boltdb/bolt"
+	"github.com/go-errors/errors"
+	"github.com/lightningnetwork/lnd/lnwire"
+)
+
+// ErrCorruptedFwdPkg signals that the on-disk structure of the forwarding
+// package has potentially been mangled.
+var ErrCorruptedFwdPkg = errors.New("fwding package db has been corrupted")
+
+// FwdState is an enum used to describe the lifecycle of a FwdPkg.
+type FwdState byte
+
+const (
+	// FwdStateLockedIn is the starting state for all forwarding packages.
+	// Packages in this state have not yet committed to the exact set of
+	// Adds to forward to the switch.
+	FwdStateLockedIn FwdState = iota
+
+	// FwdStateProcessed marks the state in which all Adds have been
+	// locally processed and the forwarding decision to the switch has been
+	// persisted.
+	FwdStateProcessed
+
+	// FwdStateCompleted signals that all Adds have been acked, and that all
+	// settles and fails have been delivered to their sources. Packages in
+	// this state can be removed permanently.
+	FwdStateCompleted
+)
+
+var (
+	// fwdPackagesKey is the root-level bucket that all forwarding packages
+	// are written. This bucket is further subdivided based on the short
+	// channel ID of each channel.
+	fwdPackagesKey = []byte("fwd-packages")
+
+	// addBucketKey is the bucket to which all Add log updates are written.
+	addBucketKey = []byte("add-updates")
+
+	// failSettleBucketKey is the bucket to which all Settle/Fail log
+	// updates are written.
+	failSettleBucketKey = []byte("fail-settle-updates")
+
+	// fwdFilterKey is a key used to write the set of Adds that passed
+	// validation and are to be forwarded to the switch.
+	// NOTE: The presence of this key within a forwarding package indicates
+	// that the package has reached FwdStateProcessed.
+	fwdFilterKey = []byte("fwd-filter-key")
+
+	// ackFilterKey is a key used to access the PkgFilter indicating which
+	// Adds have received a Settle/Fail. This response may come from a
+	// number of sources, including: exitHop settle/fails, switch failures,
+	// chain arbiter interjections, as well as settle/fails from the
+	// next hop in the route.
+	ackFilterKey = []byte("ack-filter-key")
+
+	// settleFailFilterKey is a key used to access the PkgFilter indicating
+	// which Settles/Fails in have been received and processed by the link
+	// that originally received the Add.
+	settleFailFilterKey = []byte("settle-fail-filter-key")
+)
+
+// PkgFilter is used to compactly represent a particular subset of the Adds in a
+// forwarding package. Each filter is represented as a simple, statically-sized
+// bitvector, where the elements are intended to be the indices of the Adds as
+// they are written in the FwdPkg.
+type PkgFilter struct {
+	count  uint16
+	filter []byte
+}
+
+// NewPkgFilter initializes an empty PkgFilter supporting `count` elements.
+func NewPkgFilter(count uint16) *PkgFilter {
+	// We add 7 to ensure that the integer division yields properly rounded
+	// values.
+	filterLen := (count + 7) / 8
+
+	return &PkgFilter{
+		count:  count,
+		filter: make([]byte, filterLen),
+	}
+}
+
+// Count returns the number of elements represented by this PkgFilter.
+func (f *PkgFilter) Count() uint16 {
+	return f.count
+}
+
+// Set marks the `i`-th element as included by this filter.
+// NOTE: It is assumed that i is always less than count.
+func (f *PkgFilter) Set(i uint16) {
+	byt := i / 8
+	bit := i % 8
+
+	// Set the i-th bit in the filter.
+	// TODO(conner): ignore if > count to prevent panic?
+	f.filter[byt] |= byte(1 << (7 - bit))
+}
+
+// Contains queries the filter for membership of index `i`.
+// NOTE: It is assumed that i is always less than count.
+func (f *PkgFilter) Contains(i uint16) bool {
+	byt := i / 8
+	bit := i % 8
+
+	// Read the i-th bit in the filter.
+	// TODO(conner): ignore if > count to prevent panic?
+	return f.filter[byt]&(1<<(7-bit)) != 0
+}
+
+// Equal checks two PkgFilters for equality.
+func (f *PkgFilter) Equal(f2 *PkgFilter) bool {
+	if f == f2 {
+		return true
+	}
+	if f.count != f2.count {
+		return false
+	}
+
+	return bytes.Equal(f.filter, f2.filter)
+}
+
+// IsFull returns true if every element in the filter has been Set, and false
+// otherwise.
+func (f *PkgFilter) IsFull() bool {
+	// Batch validate bytes that are fully used.
+	for i := uint16(0); i < f.count/8; i++ {
+		if f.filter[i] != 0xFF {
+			return false
+		}
+	}
+
+	// If the count is not a multiple of 8, check that the filter contains
+	// all remaining bits.
+	rem := f.count % 8
+	for idx := f.count - rem; idx < f.count; idx++ {
+		if !f.Contains(idx) {
+			return false
+		}
+	}
+
+	return true
+}
+
+// Size returns number of bytes produced when the PkgFilter is serialized.
+func (f *PkgFilter) Size() uint16 {
+	// 2 bytes for uint16 `count`, then round up number of bytes required to
+	// represent `count` bits.
+	return 2 + (f.count+7)/8
+}
+
+// Encode writes the filter to the provided io.Writer.
+func (f *PkgFilter) Encode(w io.Writer) error {
+	if err := binary.Write(w, binary.BigEndian, f.count); err != nil {
+		return err
+	}
+
+	_, err := w.Write(f.filter)
+
+	return err
+}
+
+// Decode reads the filter from the provided io.Reader.
+func (f *PkgFilter) Decode(r io.Reader) error {
+	if err := binary.Read(r, binary.BigEndian, &f.count); err != nil {
+		return err
+	}
+
+	f.filter = make([]byte, f.Size()-2)
+	_, err := io.ReadFull(r, f.filter)
+
+	return err
+}
+
+// FwdPkg records all adds, settles, and fails that were locked in as a result
+// of the remote peer sending us a revocation. Each package is identified by
+// the short chanid and remote commitment height corresponding to the revocation
+// that locked in the HTLCs. For everything except a locally initiated payment,
+// settles and fails in a forwarding package must have a corresponding Add in
+// another package, and can be removed individually once the source link has
+// received the fail/settle.
+//
+// Adds cannot be removed, as we need to present the same batch of Adds to
+// properly handle replay protection. Instead, we use a PkgFilter to mark that
+// we have finished processing a particular Add. A FwdPkg should only be deleted
+// after the AckFilter is full and all settles and fails have been persistently
+// removed.
+type FwdPkg struct {
+	// Source identifies the channel that wrote this forwarding package.
+	Source lnwire.ShortChannelID
+
+	// Height is the height of the remote commitment chain that locked in
+	// this forwarding package.
+	Height uint64
+
+	// State signals the persistent condition of the package and directs how
+	// to reprocess the package in the event of failures.
+	State FwdState
+
+	// Adds contains all add messages which need to be processed and
+	// forwarded to the switch. Adds does not change over the life of a
+	// forwarding package.
+	Adds []LogUpdate
+
+	// FwdFilter is a filter containing the indices of all Adds that were
+	// forwarded to the switch.
+	FwdFilter *PkgFilter
+
+	// AckFilter is a filter containing the indices of all Adds for which
+	// the source has received a settle or fail and is reflected in the next
+	// commitment txn. A package should not be removed until IsFull()
+	// returns true.
+	AckFilter *PkgFilter
+
+	// SettleFails contains all settle and fail messages that should be
+	// forwarded to the switch.
+	SettleFails []LogUpdate
+
+	// SettleFailFilter is a filter containing the indices of all Settle or
+	// Fails originating in this package that have been received and locked
+	// into the incoming link's commitment state.
+	SettleFailFilter *PkgFilter
+}
+
+// NewFwdPkg initializes a new forwarding package in FwdStateLockedIn. This
+// should be used to create a package at the time we receive a revocation.
+func NewFwdPkg(source lnwire.ShortChannelID, height uint64,
+	addUpdates, settleFailUpdates []LogUpdate) *FwdPkg {
+
+	nAddUpdates := uint16(len(addUpdates))
+	nSettleFailUpdates := uint16(len(settleFailUpdates))
+
+	return &FwdPkg{
+		Source:           source,
+		Height:           height,
+		State:            FwdStateLockedIn,
+		Adds:             addUpdates,
+		FwdFilter:        NewPkgFilter(nAddUpdates),
+		AckFilter:        NewPkgFilter(nAddUpdates),
+		SettleFails:      settleFailUpdates,
+		SettleFailFilter: NewPkgFilter(nSettleFailUpdates),
+	}
+}
+
+// ID returns an unique identifier for this package, used to ensure that sphinx
+// replay processing of this batch is idempotent.
+func (f *FwdPkg) ID() []byte {
+	var id = make([]byte, 16)
+	byteOrder.PutUint64(id[:8], f.Source.ToUint64())
+	byteOrder.PutUint64(id[8:], f.Height)
+	return id
+}
+
+// String returns a human-readable description of the forwarding package.
+func (f *FwdPkg) String() string {
+	return fmt.Sprintf("%T(src=%v, height=%v, nadds=%v, nfailsettles=%v)",
+		f, f.Source, f.Height, len(f.Adds), len(f.SettleFails))
+}
+
+// AddRef is used to identify a particular Add in a FwdPkg. The short channel ID
+// is assumed to be that of the packager.
+type AddRef struct {
+	// Height is the remote commitment height that locked in the Add.
+	Height uint64
+
+	// Index is the index of the Add within the fwd pkg's Adds.
+	//
+	// NOTE: This index is static over the lifetime of a forwarding package.
+	Index uint16
+}
+
+// Encode serializes the AddRef to the given io.Writer.
+func (a *AddRef) Encode(w io.Writer) error {
+	if err := binary.Write(w, binary.BigEndian, a.Height); err != nil {
+		return err
+	}
+
+	return binary.Write(w, binary.BigEndian, a.Index)
+}
+
+// Decode deserializes the AddRef from the given io.Reader.
+func (a *AddRef) Decode(r io.Reader) error {
+	if err := binary.Read(r, binary.BigEndian, &a.Height); err != nil {
+		return err
+	}
+
+	return binary.Read(r, binary.BigEndian, &a.Index)
+}
+
+// SettleFailRef is used to locate a Settle/Fail in another channel's FwdPkg. A
+// channel does not remove its own Settle/Fail htlcs, so the source is provided
+// to locate a db bucket belonging to another channel.
+type SettleFailRef struct {
+	// Source identifies the outgoing link that locked in the settle or
+	// fail. This is then used by the *incoming* link to find the settle
+	// fail in another link's forwarding packages.
+	Source lnwire.ShortChannelID
+
+	// Height is the remote commitment height that locked in this
+	// Settle/Fail.
+	Height uint64
+
+	// Index is the index of the Add with the fwd pkg's SettleFails.
+	//
+	// NOTE: This index is static over the lifetime of a forwarding package.
+	Index uint16
+}
+
+// SettleFailAcker is a generic interface providing the ability to acknowledge
+// settle/fail HTLCs stored in forwarding packages.
+type SettleFailAcker interface {
+	// AckSettleFails atomically updates the settle-fail filters in *other*
+	// channels' forwarding packages.
+	AckSettleFails(tx *bolt.Tx, settleFailRefs ...SettleFailRef) error
+}
+
+// GlobalFwdPkgReader is an interface used to retrieve the forwarding packages
+// of any active channel.
+type GlobalFwdPkgReader interface {
+	// LoadChannelFwdPkgs loads all known forwarding packages for the given
+	// channel.
+	LoadChannelFwdPkgs(tx *bolt.Tx,
+		source lnwire.ShortChannelID) ([]*FwdPkg, error)
+}
+
+// FwdOperator defines the interfaces for managing forwarding packages that are
+// external to a particular channel. This interface is used by the switch to
+// read forwarding packages from arbitrary channels, and acknowledge settles and
+// fails for locally-sourced payments.
+type FwdOperator interface {
+	// GlobalFwdPkgReader provides read access to all known forwarding
+	// packages
+	GlobalFwdPkgReader
+
+	// SettleFailAcker grants the ability to acknowledge settles or fails
+	// residing in arbitrary forwarding packages.
+	SettleFailAcker
+}
+
+// SwitchPackager is a concrete implementation of the FwdOperator interface.
+// A SwitchPackager offers the ability to read any forwarding package, and ack
+// arbitrary settle and fail HTLCs.
+type SwitchPackager struct{}
+
+// NewSwitchPackager instantiates a new SwitchPackager.
+func NewSwitchPackager() *SwitchPackager {
+	return &SwitchPackager{}
+}
+
+// AckSettleFails atomically updates the settle-fail filters in *other*
+// channels' forwarding packages, to mark that the switch has received a settle
+// or fail residing in the forwarding package of a link.
+func (*SwitchPackager) AckSettleFails(tx *bolt.Tx,
+	settleFailRefs ...SettleFailRef) error {
+
+	return ackSettleFails(tx, settleFailRefs)
+}
+
+// LoadChannelFwdPkgs loads all forwarding packages for a particular channel.
+func (*SwitchPackager) LoadChannelFwdPkgs(tx *bolt.Tx,
+	source lnwire.ShortChannelID) ([]*FwdPkg, error) {
+
+	return loadChannelFwdPkgs(tx, source)
+}
+
+// FwdPackager supports all operations required to modify fwd packages, such as
+// creation, updates, reading, and removal. The interfaces are broken down in
+// this way to support future delegation of the subinterfaces.
+type FwdPackager interface {
+	// AddFwdPkg serializes and writes a FwdPkg for this channel at the
+	// remote commitment height included in the forwarding package.
+	AddFwdPkg(tx *bolt.Tx, fwdPkg *FwdPkg) error
+
+	// SetFwdFilter looks up the forwarding package at the remote `height`
+	// and sets the `fwdFilter`, marking the Adds for which:
+	// 1) We are not the exit node
+	// 2) Passed all validation
+	// 3) Should be forwarded to the switch immediately after a failure
+	SetFwdFilter(tx *bolt.Tx, height uint64, fwdFilter *PkgFilter) error
+
+	// AckAddHtlcs atomically updates the add filters in this channel's
+	// forwarding packages to mark the resolution of an Add that was
+	// received from the remote party.
+	AckAddHtlcs(tx *bolt.Tx, addRefs ...AddRef) error
+
+	// SettleFailAcker allows a link to acknowledge settle/fail HTLCs
+	// belonging to other channels.
+	SettleFailAcker
+
+	// LoadFwdPkgs loads all known forwarding packages owned by this
+	// channel.
+	LoadFwdPkgs(tx *bolt.Tx) ([]*FwdPkg, error)
+
+	// RemovePkg deletes a forwarding package owned by this channel at
+	// the provided remote `height`.
+	RemovePkg(tx *bolt.Tx, height uint64) error
+}
+
+// ChannelPackager is used by a channel to manage the lifecycle of its forwarding
+// packages. The packager is tied to a particular source channel ID, allowing it
+// to create and edit its own packages. Each packager also has the ability to
+// remove fail/settle htlcs that correspond to an add contained in one of
+// source's packages.
+type ChannelPackager struct {
+	source lnwire.ShortChannelID
+}
+
+// NewChannelPackager creates a new packager for a single channel.
+func NewChannelPackager(source lnwire.ShortChannelID) *ChannelPackager {
+	return &ChannelPackager{
+		source: source,
+	}
+}
+
+// AddFwdPkg writes a newly locked in forwarding package to disk.
+func (*ChannelPackager) AddFwdPkg(tx *bolt.Tx, fwdPkg *FwdPkg) error {
+	fwdPkgBkt, err := tx.CreateBucketIfNotExists(fwdPackagesKey)
+	if err != nil {
+		return err
+	}
+
+	source := makeLogKey(fwdPkg.Source.ToUint64())
+	sourceBkt, err := fwdPkgBkt.CreateBucketIfNotExists(source[:])
+	if err != nil {
+		return err
+	}
+
+	heightKey := makeLogKey(fwdPkg.Height)
+	heightBkt, err := sourceBkt.CreateBucketIfNotExists(heightKey[:])
+	if err != nil {
+		return err
+	}
+
+	// Write ADD updates we received at this commit height.
+	addBkt, err := heightBkt.CreateBucketIfNotExists(addBucketKey)
+	if err != nil {
+		return err
+	}
+
+	// Write SETTLE/FAIL updates we received at this commit height.
+	failSettleBkt, err := heightBkt.CreateBucketIfNotExists(failSettleBucketKey)
+	if err != nil {
+		return err
+	}
+
+	for i := range fwdPkg.Adds {
+		err = putLogUpdate(addBkt, uint16(i), &fwdPkg.Adds[i])
+		if err != nil {
+			return err
+		}
+	}
+
+	// Persist the initialized pkg filter, which will be used to determine
+	// when we can remove this forwarding package from disk.
+	var ackFilterBuf bytes.Buffer
+	if err := fwdPkg.AckFilter.Encode(&ackFilterBuf); err != nil {
+		return err
+	}
+
+	if err := heightBkt.Put(ackFilterKey, ackFilterBuf.Bytes()); err != nil {
+		return err
+	}
+
+	for i := range fwdPkg.SettleFails {
+		err = putLogUpdate(failSettleBkt, uint16(i), &fwdPkg.SettleFails[i])
+		if err != nil {
+			return err
+		}
+	}
+
+	var settleFailFilterBuf bytes.Buffer
+	err = fwdPkg.SettleFailFilter.Encode(&settleFailFilterBuf)
+	if err != nil {
+		return err
+	}
+
+	return heightBkt.Put(settleFailFilterKey, settleFailFilterBuf.Bytes())
+}
+
+// putLogUpdate writes an htlc to the provided `bkt`, using `index` as the key.
+func putLogUpdate(bkt *bolt.Bucket, idx uint16, htlc *LogUpdate) error {
+	var b bytes.Buffer
+	if err := htlc.Encode(&b); err != nil {
+		return err
+	}
+
+	return bkt.Put(uint16Key(idx), b.Bytes())
+}
+
+// LoadFwdPkgs scans the forwarding log for any packages that haven't been
+// processed, and returns their deserialized log updates in a map indexed by the
+// remote commitment height at which the updates were locked in.
+func (p *ChannelPackager) LoadFwdPkgs(tx *bolt.Tx) ([]*FwdPkg, error) {
+	return loadChannelFwdPkgs(tx, p.source)
+}
+
+// loadChannelFwdPkgs loads all forwarding packages owned by `source`.
+func loadChannelFwdPkgs(tx *bolt.Tx, source lnwire.ShortChannelID) ([]*FwdPkg, error) {
+	fwdPkgBkt := tx.Bucket(fwdPackagesKey)
+	if fwdPkgBkt == nil {
+		return nil, nil
+	}
+
+	sourceKey := makeLogKey(source.ToUint64())
+	sourceBkt := fwdPkgBkt.Bucket(sourceKey[:])
+	if sourceBkt == nil {
+		return nil, nil
+	}
+
+	var heights []uint64
+	if err := sourceBkt.ForEach(func(k, _ []byte) error {
+		if len(k) != 8 {
+			return ErrCorruptedFwdPkg
+		}
+
+		heights = append(heights, byteOrder.Uint64(k))
+
+		return nil
+	}); err != nil {
+		return nil, err
+	}
+
+	// Load the forwarding package for each retrieved height.
+	fwdPkgs := make([]*FwdPkg, 0, len(heights))
+	for _, height := range heights {
+		fwdPkg, err := loadFwdPkg(fwdPkgBkt, source, height)
+		if err != nil {
+			return nil, err
+		}
+
+		fwdPkgs = append(fwdPkgs, fwdPkg)
+	}
+
+	return fwdPkgs, nil
+}
+
+// loadFwPkg reads the packager's fwd pkg at a given height, and determines the
+// appropriate FwdState.
+func loadFwdPkg(fwdPkgBkt *bolt.Bucket, source lnwire.ShortChannelID,
+	height uint64) (*FwdPkg, error) {
+
+	sourceKey := makeLogKey(source.ToUint64())
+	sourceBkt := fwdPkgBkt.Bucket(sourceKey[:])
+	if sourceBkt == nil {
+		return nil, ErrCorruptedFwdPkg
+	}
+
+	heightKey := makeLogKey(height)
+	heightBkt := sourceBkt.Bucket(heightKey[:])
+	if heightBkt == nil {
+		return nil, ErrCorruptedFwdPkg
+	}
+
+	// Load ADDs from disk.
+	addBkt := heightBkt.Bucket(addBucketKey)
+	if addBkt == nil {
+		return nil, ErrCorruptedFwdPkg
+	}
+
+	adds, err := loadHtlcs(addBkt)
+	if err != nil {
+		return nil, err
+	}
+
+	// Load ack filter from disk.
+	ackFilterBytes := heightBkt.Get(ackFilterKey)
+	if ackFilterBytes == nil {
+		return nil, ErrCorruptedFwdPkg
+	}
+	ackFilterReader := bytes.NewReader(ackFilterBytes)
+
+	ackFilter := &PkgFilter{}
+	if err := ackFilter.Decode(ackFilterReader); err != nil {
+		return nil, err
+	}
+
+	// Load SETTLE/FAILs from disk.
+	failSettleBkt := heightBkt.Bucket(failSettleBucketKey)
+	if failSettleBkt == nil {
+		return nil, ErrCorruptedFwdPkg
+	}
+
+	failSettles, err := loadHtlcs(failSettleBkt)
+	if err != nil {
+		return nil, err
+	}
+
+	// Load settle fail filter from disk.
+	settleFailFilterBytes := heightBkt.Get(settleFailFilterKey)
+	if settleFailFilterBytes == nil {
+		return nil, ErrCorruptedFwdPkg
+	}
+	settleFailFilterReader := bytes.NewReader(settleFailFilterBytes)
+
+	settleFailFilter := &PkgFilter{}
+	if err := settleFailFilter.Decode(settleFailFilterReader); err != nil {
+		return nil, err
+	}
+
+	// Initialize the fwding package, which always starts in the
+	// FwdStateLockedIn. We can determine what state the package was left in
+	// by examining constraints on the information loaded from disk.
+	fwdPkg := &FwdPkg{
+		Source:           source,
+		State:            FwdStateLockedIn,
+		Height:           height,
+		Adds:             adds,
+		AckFilter:        ackFilter,
+		SettleFails:      failSettles,
+		SettleFailFilter: settleFailFilter,
+	}
+
+	// Check to see if we have written the set exported filter adds to
+	// disk. If we haven't, processing of this package was never started, or
+	// failed during the last attempt.
+	fwdFilterBytes := heightBkt.Get(fwdFilterKey)
+	if fwdFilterBytes == nil {
+		nAdds := uint16(len(adds))
+		fwdPkg.FwdFilter = NewPkgFilter(nAdds)
+		return fwdPkg, nil
+	}
+
+	fwdFilterReader := bytes.NewReader(fwdFilterBytes)
+	fwdPkg.FwdFilter = &PkgFilter{}
+	if err := fwdPkg.FwdFilter.Decode(fwdFilterReader); err != nil {
+		return nil, err
+	}
+
+	// Otherwise, a complete round of processing was completed, and we
+	// advance the package to FwdStateProcessed.
+	fwdPkg.State = FwdStateProcessed
+
+	// If every add, settle, and fail has been fully acknowledged, we can
+	// safely set the package's state to FwdStateCompleted, signalling that
+	// it can be garbage collected.
+	if fwdPkg.AckFilter.IsFull() && fwdPkg.SettleFailFilter.IsFull() {
+		fwdPkg.State = FwdStateCompleted
+	}
+
+	return fwdPkg, nil
+}
+
+// loadHtlcs retrieves all serialized htlcs in a bucket, returning
+// them in order of the indexes they were written under.
+func loadHtlcs(bkt *bolt.Bucket) ([]LogUpdate, error) {
+	var htlcs []LogUpdate
+	if err := bkt.ForEach(func(_, v []byte) error {
+		var htlc LogUpdate
+		if err := htlc.Decode(bytes.NewReader(v)); err != nil {
+			return err
+		}
+
+		htlcs = append(htlcs, htlc)
+
+		return nil
+	}); err != nil {
+		return nil, err
+	}
+
+	return htlcs, nil
+}
+
+// SetFwdFilter writes the set of indexes corresponding to Adds at the
+// `height` that are to be forwarded to the switch. Calling this method causes
+// the forwarding package at `height` to be in FwdStateProcessed. We write this
+// forwarding decision so that we always arrive at the same behavior for HTLCs
+// leaving this channel. After a restart, we skip validation of these Adds,
+// since they are assumed to have already been validated, and make the switch or
+// outgoing link responsible for handling replays.
+func (p *ChannelPackager) SetFwdFilter(tx *bolt.Tx, height uint64,
+	fwdFilter *PkgFilter) error {
+
+	fwdPkgBkt := tx.Bucket(fwdPackagesKey)
+	if fwdPkgBkt == nil {
+		return ErrCorruptedFwdPkg
+	}
+
+	source := makeLogKey(p.source.ToUint64())
+	sourceBkt := fwdPkgBkt.Bucket(source[:])
+	if sourceBkt == nil {
+		return ErrCorruptedFwdPkg
+	}
+
+	heightKey := makeLogKey(height)
+	heightBkt := sourceBkt.Bucket(heightKey[:])
+	if heightBkt == nil {
+		return ErrCorruptedFwdPkg
+	}
+
+	// If the fwd filter has already been written, we return early to avoid
+	// modifying the persistent state.
+	forwardedAddsBytes := heightBkt.Get(fwdFilterKey)
+	if forwardedAddsBytes != nil {
+		return nil
+	}
+
+	// Otherwise we serialize and write the provided fwd filter.
+	var b bytes.Buffer
+	if err := fwdFilter.Encode(&b); err != nil {
+		return err
+	}
+
+	return heightBkt.Put(fwdFilterKey, b.Bytes())
+}
+
+// AckAddHtlcs accepts a list of references to add htlcs, and updates the
+// AckAddFilter of those forwarding packages to indicate that a settle or fail
+// has been received in response to the add.
+func (p *ChannelPackager) AckAddHtlcs(tx *bolt.Tx, addRefs ...AddRef) error {
+	if len(addRefs) == 0 {
+		return nil
+	}
+
+	fwdPkgBkt := tx.Bucket(fwdPackagesKey)
+	if fwdPkgBkt == nil {
+		return ErrCorruptedFwdPkg
+	}
+
+	sourceKey := makeLogKey(p.source.ToUint64())
+	sourceBkt := fwdPkgBkt.Bucket(sourceKey[:])
+	if sourceBkt == nil {
+		return ErrCorruptedFwdPkg
+	}
+
+	// Organize the forward references such that we just get a single slice
+	// of indexes for each unique height.
+	heightDiffs := make(map[uint64][]uint16)
+	for _, addRef := range addRefs {
+		heightDiffs[addRef.Height] = append(
+			heightDiffs[addRef.Height],
+			addRef.Index,
+		)
+	}
+
+	// Load each height bucket once and remove all acked htlcs at that
+	// height.
+	for height, indexes := range heightDiffs {
+		err := ackAddHtlcsAtHeight(sourceBkt, height, indexes)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// ackAddHtlcsAtHeight updates the AddAckFilter of a single forwarding package
+// with a list of indexes, writing the resulting filter back in its place.
+func ackAddHtlcsAtHeight(sourceBkt *bolt.Bucket, height uint64,
+	indexes []uint16) error {
+
+	heightKey := makeLogKey(height)
+	heightBkt := sourceBkt.Bucket(heightKey[:])
+	if heightBkt == nil {
+		return ErrCorruptedFwdPkg
+	}
+
+	// Load ack filter from disk.
+	ackFilterBytes := heightBkt.Get(ackFilterKey)
+	if ackFilterBytes == nil {
+		return ErrCorruptedFwdPkg
+	}
+
+	ackFilter := &PkgFilter{}
+	ackFilterReader := bytes.NewReader(ackFilterBytes)
+	if err := ackFilter.Decode(ackFilterReader); err != nil {
+		return err
+	}
+
+	// Update the ack filter for this height.
+	for _, index := range indexes {
+		ackFilter.Set(index)
+	}
+
+	// Write the resulting filter to disk.
+	var ackFilterBuf bytes.Buffer
+	if err := ackFilter.Encode(&ackFilterBuf); err != nil {
+		return err
+	}
+
+	return heightBkt.Put(ackFilterKey, ackFilterBuf.Bytes())
+}
+
+// AckSettleFails persistently acknowledges settles or fails from a remote forwarding
+// package. This should only be called after the source of the Add has locked in
+// the settle/fail, or it becomes otherwise safe to forgo retransmitting the
+// settle/fail after a restart.
+func (p *ChannelPackager) AckSettleFails(tx *bolt.Tx, settleFailRefs ...SettleFailRef) error {
+	return ackSettleFails(tx, settleFailRefs)
+}
+
+// ackSettleFails persistently acknowledges a batch of settle fail references.
+func ackSettleFails(tx *bolt.Tx, settleFailRefs []SettleFailRef) error {
+	if len(settleFailRefs) == 0 {
+		return nil
+	}
+
+	fwdPkgBkt := tx.Bucket(fwdPackagesKey)
+	if fwdPkgBkt == nil {
+		return ErrCorruptedFwdPkg
+	}
+
+	// Organize the forward references such that we just get a single slice
+	// of indexes for each unique destination-height pair.
+	destHeightDiffs := make(map[lnwire.ShortChannelID]map[uint64][]uint16)
+	for _, settleFailRef := range settleFailRefs {
+		destHeights, ok := destHeightDiffs[settleFailRef.Source]
+		if !ok {
+			destHeights = make(map[uint64][]uint16)
+			destHeightDiffs[settleFailRef.Source] = destHeights
+		}
+
+		destHeights[settleFailRef.Height] = append(
+			destHeights[settleFailRef.Height],
+			settleFailRef.Index,
+		)
+	}
+
+	// With the references organized by destination and height, we now load
+	// each remote bucket, and update the settle fail filter for  any
+	// settle/fail htlcs.
+	for dest, destHeights := range destHeightDiffs {
+		destKey := makeLogKey(dest.ToUint64())
+		destBkt := fwdPkgBkt.Bucket(destKey[:])
+		if destBkt == nil {
+			continue
+		}
+
+		for height, indexes := range destHeights {
+			err := ackSettleFailsAtHeight(destBkt, height, indexes)
+			if err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+// ackSettleFailsAtHeight given a destination bucket, acks the provided indexes
+// at particular a height by updating the settle fail filter.
+func ackSettleFailsAtHeight(destBkt *bolt.Bucket, height uint64,
+	indexes []uint16) error {
+
+	heightKey := makeLogKey(height)
+	heightBkt := destBkt.Bucket(heightKey[:])
+	if heightBkt == nil {
+		return nil
+	}
+
+	// Load ack filter from disk.
+	settleFailFilterBytes := heightBkt.Get(settleFailFilterKey)
+	if settleFailFilterBytes == nil {
+		return ErrCorruptedFwdPkg
+	}
+
+	settleFailFilter := &PkgFilter{}
+	settleFailFilterReader := bytes.NewReader(settleFailFilterBytes)
+	if err := settleFailFilter.Decode(settleFailFilterReader); err != nil {
+		return err
+	}
+
+	// Update the ack filter for this height.
+	for _, index := range indexes {
+		settleFailFilter.Set(index)
+	}
+
+	// Write the resulting filter to disk.
+	var settleFailFilterBuf bytes.Buffer
+	if err := settleFailFilter.Encode(&settleFailFilterBuf); err != nil {
+		return err
+	}
+
+	return heightBkt.Put(settleFailFilterKey, settleFailFilterBuf.Bytes())
+}
+
+// RemovePkg deletes the forwarding package at the given height from the
+// packager's source bucket.
+func (p *ChannelPackager) RemovePkg(tx *bolt.Tx, height uint64) error {
+	fwdPkgBkt := tx.Bucket(fwdPackagesKey)
+	if fwdPkgBkt == nil {
+		return nil
+	}
+
+	sourceBytes := makeLogKey(p.source.ToUint64())
+	sourceBkt := fwdPkgBkt.Bucket(sourceBytes[:])
+	if sourceBkt == nil {
+		return ErrCorruptedFwdPkg
+	}
+
+	heightKey := makeLogKey(height)
+
+	return sourceBkt.DeleteBucket(heightKey[:])
+}
+
+// uint16Key writes the provided 16-bit unsigned integer to a 2-byte slice.
+func uint16Key(i uint16) []byte {
+	key := make([]byte, 2)
+	byteOrder.PutUint16(key, i)
+	return key
+}
+
+// uint16FromKey reconstructs a 16-bit unsigned integer from a 2-byte slice.
+func uint16FromKey(key []byte) uint16 {
+	return byteOrder.Uint16(key)
+}
+
+// Compile-time constraint to ensure that ChannelPackager implements the public
+// FwdPackager interface.
+var _ FwdPackager = (*ChannelPackager)(nil)
+
+// Compile-time constraint to ensure that SwitchPackager implements the public
+// FwdOperator interface.
+var _ FwdOperator = (*SwitchPackager)(nil)

--- a/channeldb/forwarding_package_test.go
+++ b/channeldb/forwarding_package_test.go
@@ -1,0 +1,815 @@
+package channeldb_test
+
+import (
+	"bytes"
+	"io/ioutil"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/boltdb/bolt"
+	"github.com/lightningnetwork/lnd/channeldb"
+	"github.com/lightningnetwork/lnd/lnwire"
+	"github.com/roasbeef/btcd/wire"
+)
+
+// TestPkgFilterBruteForce tests the behavior of a pkg filter up to size 1000,
+// which is greater than the number of HTLCs we permit on a commitment txn.
+// This should encapsulate every potential filter used in practice.
+func TestPkgFilterBruteForce(t *testing.T) {
+	t.Parallel()
+
+	checkPkgFilterRange(t, 1000)
+}
+
+// checkPkgFilterRange verifies the behavior of a pkg filter when doing a linear
+// insertion of `high` elements. This is primarily to test that IsFull functions
+// properly for all relevant sizes of `high`.
+func checkPkgFilterRange(t *testing.T, high int) {
+	for i := uint16(0); i < uint16(high); i++ {
+		f := channeldb.NewPkgFilter(i)
+
+		if f.Count() != i {
+			t.Fatalf("pkg filter count=%d is actually %d",
+				i, f.Count())
+		}
+		checkPkgFilterEncodeDecode(t, i, f)
+
+		for j := uint16(0); j < i; j++ {
+			if f.Contains(j) {
+				t.Fatalf("pkg filter count=%d contains %d "+
+					"before being added", i, j)
+			}
+
+			f.Set(j)
+			checkPkgFilterEncodeDecode(t, i, f)
+
+			if !f.Contains(j) {
+				t.Fatalf("pkg filter count=%d missing %d "+
+					"after being added", i, j)
+			}
+
+			if j < i-1 && f.IsFull() {
+				t.Fatalf("pkg filter count=%d already full", i)
+			}
+		}
+
+		if !f.IsFull() {
+			t.Fatalf("pkg filter count=%d not full", i)
+		}
+		checkPkgFilterEncodeDecode(t, i, f)
+	}
+}
+
+// TestPkgFilterRand uses a random permutation to verify the proper behavior of
+// the pkg filter if the entries are not inserted in-order.
+func TestPkgFilterRand(t *testing.T) {
+	t.Parallel()
+
+	checkPkgFilterRand(t, 3, 17)
+}
+
+// checkPkgFilterRand checks the behavior of a pkg filter by randomly inserting
+// indices and asserting the invariants. The order in which indices are inserted
+// is parameterized by a base `b` coprime to `p`, and using modular
+// exponentiation to generate all elements in [1,p).
+func checkPkgFilterRand(t *testing.T, b, p uint16) {
+	f := channeldb.NewPkgFilter(p)
+	var j = b
+	for i := uint16(1); i < p; i++ {
+		if f.Contains(j) {
+			t.Fatalf("pkg filter contains %d-%d "+
+				"before being added", i, j)
+		}
+
+		f.Set(j)
+		checkPkgFilterEncodeDecode(t, i, f)
+
+		if !f.Contains(j) {
+			t.Fatalf("pkg filter missing %d-%d "+
+				"after being added", i, j)
+		}
+
+		if i < p-1 && f.IsFull() {
+			t.Fatalf("pkg filter %d already full", i)
+		}
+		checkPkgFilterEncodeDecode(t, i, f)
+
+		j = (b * j) % p
+	}
+
+	// Set 0 independently, since it will never be emitted by the generator.
+	f.Set(0)
+	checkPkgFilterEncodeDecode(t, p, f)
+
+	if !f.IsFull() {
+		t.Fatalf("pkg filter count=%d not full", p)
+	}
+	checkPkgFilterEncodeDecode(t, p, f)
+}
+
+// checkPkgFilterEncodeDecode tests the serialization of a pkg filter by:
+//   1) writing it to a buffer
+//   2) verifying the number of bytes written matches the filter's Size()
+//   3) reconstructing the filter decoding the bytes
+//   4) checking that the two filters are the same according to Equal
+func checkPkgFilterEncodeDecode(t *testing.T, i uint16, f *channeldb.PkgFilter) {
+	var b bytes.Buffer
+	if err := f.Encode(&b); err != nil {
+		t.Fatalf("unable to serialize pkg filter: %v", err)
+	}
+
+	// +2 for uint16 length
+	size := uint16(len(b.Bytes()))
+	if size != f.Size() {
+		t.Fatalf("pkg filter count=%d serialized size differs, "+
+			"Size(): %d, len(bytes): %v", i, f.Size(), size)
+	}
+
+	reader := bytes.NewReader(b.Bytes())
+
+	f2 := &channeldb.PkgFilter{}
+	if err := f2.Decode(reader); err != nil {
+		t.Fatalf("unable to deserialize pkg filter: %v", err)
+	}
+
+	if !f.Equal(f2) {
+		t.Fatalf("pkg filter count=%v does is not equal "+
+			"after deserialization, want: %v, got %v",
+			i, f, f2)
+	}
+}
+
+var (
+	chanID = lnwire.NewChanIDFromOutPoint(&wire.OutPoint{})
+
+	adds = []channeldb.LogUpdate{
+		{
+			LogIndex: 0,
+			UpdateMsg: &lnwire.UpdateAddHTLC{
+				ChanID:      chanID,
+				ID:          1,
+				Amount:      100,
+				Expiry:      1000,
+				PaymentHash: [32]byte{0},
+			},
+		},
+		{
+			LogIndex: 1,
+			UpdateMsg: &lnwire.UpdateAddHTLC{
+				ChanID:      chanID,
+				ID:          1,
+				Amount:      101,
+				Expiry:      1001,
+				PaymentHash: [32]byte{1},
+			},
+		},
+	}
+
+	settleFails = []channeldb.LogUpdate{
+		{
+			LogIndex: 2,
+			UpdateMsg: &lnwire.UpdateFulfillHTLC{
+				ChanID:          chanID,
+				ID:              0,
+				PaymentPreimage: [32]byte{0},
+			},
+		},
+		{
+			LogIndex: 3,
+			UpdateMsg: &lnwire.UpdateFailHTLC{
+				ChanID: chanID,
+				ID:     1,
+				Reason: []byte{},
+			},
+		},
+	}
+)
+
+// TestPackagerEmptyFwdPkg checks that the state transitions exhibited by a
+// forwarding package that contains no adds, fails or settles. We expect that
+// the fwdpkg reaches FwdStateCompleted immediately after writing the forwarding
+// decision via SetFwdFilter.
+func TestPackagerEmptyFwdPkg(t *testing.T) {
+	t.Parallel()
+
+	db := makeFwdPkgDB(t, "")
+
+	shortChanID := lnwire.NewShortChanIDFromInt(1)
+	packager := channeldb.NewChannelPackager(shortChanID)
+
+	// To begin, there should be no forwarding packages on disk.
+	fwdPkgs := loadFwdPkgs(t, db, packager)
+	if len(fwdPkgs) != 0 {
+		t.Fatalf("no forwarding packages should exist, found %d", len(fwdPkgs))
+	}
+
+	// Next, create and write a new forwarding package with no htlcs.
+	fwdPkg := channeldb.NewFwdPkg(shortChanID, 0, nil, nil)
+
+	if err := db.Update(func(tx *bolt.Tx) error {
+		return packager.AddFwdPkg(tx, fwdPkg)
+	}); err != nil {
+		t.Fatalf("unable to add fwd pkg: %v", err)
+	}
+
+	// There should now be one fwdpkg on disk. Since no forwarding decision
+	// has been written, we expect it to be FwdStateLockedIn. With no HTLCs,
+	// the ack filter will have no elements, and should always return true.
+	fwdPkgs = loadFwdPkgs(t, db, packager)
+	if len(fwdPkgs) != 1 {
+		t.Fatalf("expected 1 fwdpkg, instead found %d", len(fwdPkgs))
+	}
+	assertFwdPkgState(t, fwdPkgs[0], channeldb.FwdStateLockedIn)
+	assertFwdPkgNumAddsSettleFails(t, fwdPkgs[0], 0, 0)
+	assertAckFilterIsFull(t, fwdPkgs[0], true)
+
+	// Now, write the forwarding decision. In this case, its just an empty
+	// fwd filter.
+	if err := db.Update(func(tx *bolt.Tx) error {
+		return packager.SetFwdFilter(tx, fwdPkg.Height, fwdPkg.FwdFilter)
+	}); err != nil {
+		t.Fatalf("unable to set fwdfiter: %v", err)
+	}
+
+	// We should still have one package on disk. Since the forwarding
+	// decision has been written, it will minimally be in FwdStateProcessed.
+	// However with no htlcs, it should leap frog to FwdStateCompleted.
+	fwdPkgs = loadFwdPkgs(t, db, packager)
+	if len(fwdPkgs) != 1 {
+		t.Fatalf("expected 1 fwdpkg, instead found %d", len(fwdPkgs))
+	}
+	assertFwdPkgState(t, fwdPkgs[0], channeldb.FwdStateCompleted)
+	assertFwdPkgNumAddsSettleFails(t, fwdPkgs[0], 0, 0)
+	assertAckFilterIsFull(t, fwdPkgs[0], true)
+
+	// Lastly, remove the completed forwarding package from disk.
+	if err := db.Update(func(tx *bolt.Tx) error {
+		return packager.RemovePkg(tx, fwdPkg.Height)
+	}); err != nil {
+		t.Fatalf("unable to remove fwdpkg: %v", err)
+	}
+
+	// Check that the fwd package was actually removed.
+	fwdPkgs = loadFwdPkgs(t, db, packager)
+	if len(fwdPkgs) != 0 {
+		t.Fatalf("no forwarding packages should exist, found %d", len(fwdPkgs))
+	}
+}
+
+// TestPackagerOnlyAdds checks that the fwdpkg does not reach FwdStateCompleted
+// as soon as all the adds in the package have been acked using AckAddHtlcs.
+func TestPackagerOnlyAdds(t *testing.T) {
+	t.Parallel()
+
+	db := makeFwdPkgDB(t, "")
+
+	shortChanID := lnwire.NewShortChanIDFromInt(1)
+	packager := channeldb.NewChannelPackager(shortChanID)
+
+	// To begin, there should be no forwarding packages on disk.
+	fwdPkgs := loadFwdPkgs(t, db, packager)
+	if len(fwdPkgs) != 0 {
+		t.Fatalf("no forwarding packages should exist, found %d", len(fwdPkgs))
+	}
+
+	// Next, create and write a new forwarding package that only has add
+	// htlcs.
+	fwdPkg := channeldb.NewFwdPkg(shortChanID, 0, adds, nil)
+
+	nAdds := len(adds)
+
+	if err := db.Update(func(tx *bolt.Tx) error {
+		return packager.AddFwdPkg(tx, fwdPkg)
+	}); err != nil {
+		t.Fatalf("unable to add fwd pkg: %v", err)
+	}
+
+	// There should now be one fwdpkg on disk. Since no forwarding decision
+	// has been written, we expect it to be FwdStateLockedIn. The package
+	// has unacked add HTLCs, so the ack filter should not be full.
+	fwdPkgs = loadFwdPkgs(t, db, packager)
+	if len(fwdPkgs) != 1 {
+		t.Fatalf("expected 1 fwdpkg, instead found %d", len(fwdPkgs))
+	}
+	assertFwdPkgState(t, fwdPkgs[0], channeldb.FwdStateLockedIn)
+	assertFwdPkgNumAddsSettleFails(t, fwdPkgs[0], nAdds, 0)
+	assertAckFilterIsFull(t, fwdPkgs[0], false)
+
+	// Now, write the forwarding decision. Since we have not explicitly
+	// added any adds to the fwdfilter, this would indicate that all of the
+	// adds were 1) settled locally by this link (exit hop), or 2) the htlc
+	// was failed locally.
+	if err := db.Update(func(tx *bolt.Tx) error {
+		return packager.SetFwdFilter(tx, fwdPkg.Height, fwdPkg.FwdFilter)
+	}); err != nil {
+		t.Fatalf("unable to set fwdfiter: %v", err)
+	}
+
+	for i := range adds {
+		// We should still have one package on disk. Since the forwarding
+		// decision has been written, it will minimally be in FwdStateProcessed.
+		// However not allf of the HTLCs have been acked, so should not
+		// have advanced further.
+		fwdPkgs = loadFwdPkgs(t, db, packager)
+		if len(fwdPkgs) != 1 {
+			t.Fatalf("expected 1 fwdpkg, instead found %d", len(fwdPkgs))
+		}
+		assertFwdPkgState(t, fwdPkgs[0], channeldb.FwdStateProcessed)
+		assertFwdPkgNumAddsSettleFails(t, fwdPkgs[0], nAdds, 0)
+		assertAckFilterIsFull(t, fwdPkgs[0], false)
+
+		addRef := channeldb.AddRef{
+			Height: fwdPkg.Height,
+			Index:  uint16(i),
+		}
+
+		if err := db.Update(func(tx *bolt.Tx) error {
+			return packager.AckAddHtlcs(tx, addRef)
+		}); err != nil {
+			t.Fatalf("unable to ack add htlc: %v", err)
+		}
+	}
+
+	// We should still have one package on disk. Now that all adds have been
+	// acked, the ack filter should return true and the package should be
+	// FwdStateCompleted since there are no other settle/fail packets.
+	fwdPkgs = loadFwdPkgs(t, db, packager)
+	if len(fwdPkgs) != 1 {
+		t.Fatalf("expected 1 fwdpkg, instead found %d", len(fwdPkgs))
+	}
+	assertFwdPkgState(t, fwdPkgs[0], channeldb.FwdStateCompleted)
+	assertFwdPkgNumAddsSettleFails(t, fwdPkgs[0], nAdds, 0)
+	assertAckFilterIsFull(t, fwdPkgs[0], true)
+
+	// Lastly, remove the completed forwarding package from disk.
+	if err := db.Update(func(tx *bolt.Tx) error {
+		return packager.RemovePkg(tx, fwdPkg.Height)
+	}); err != nil {
+		t.Fatalf("unable to remove fwdpkg: %v", err)
+	}
+
+	// Check that the fwd package was actually removed.
+	fwdPkgs = loadFwdPkgs(t, db, packager)
+	if len(fwdPkgs) != 0 {
+		t.Fatalf("no forwarding packages should exist, found %d", len(fwdPkgs))
+	}
+}
+
+// TestPackagerOnlySettleFails asserts that the fwdpkg remains in
+// FwdStateProcessed after writing the forwarding decision when there are no
+// adds in the fwdpkg. We expect this because an empty FwdFilter will always
+// return true, but we are still waiting for the remaining fails and settles to
+// be deleted.
+func TestPackagerOnlySettleFails(t *testing.T) {
+	t.Parallel()
+
+	db := makeFwdPkgDB(t, "")
+
+	shortChanID := lnwire.NewShortChanIDFromInt(1)
+	packager := channeldb.NewChannelPackager(shortChanID)
+
+	// To begin, there should be no forwarding packages on disk.
+	fwdPkgs := loadFwdPkgs(t, db, packager)
+	if len(fwdPkgs) != 0 {
+		t.Fatalf("no forwarding packages should exist, found %d", len(fwdPkgs))
+	}
+
+	// Next, create and write a new forwarding package that only has add
+	// htlcs.
+	fwdPkg := channeldb.NewFwdPkg(shortChanID, 0, nil, settleFails)
+
+	nSettleFails := len(settleFails)
+
+	if err := db.Update(func(tx *bolt.Tx) error {
+		return packager.AddFwdPkg(tx, fwdPkg)
+	}); err != nil {
+		t.Fatalf("unable to add fwd pkg: %v", err)
+	}
+
+	// There should now be one fwdpkg on disk. Since no forwarding decision
+	// has been written, we expect it to be FwdStateLockedIn. The package
+	// has unacked add HTLCs, so the ack filter should not be full.
+	fwdPkgs = loadFwdPkgs(t, db, packager)
+	if len(fwdPkgs) != 1 {
+		t.Fatalf("expected 1 fwdpkg, instead found %d", len(fwdPkgs))
+	}
+	assertFwdPkgState(t, fwdPkgs[0], channeldb.FwdStateLockedIn)
+	assertFwdPkgNumAddsSettleFails(t, fwdPkgs[0], 0, nSettleFails)
+	assertAckFilterIsFull(t, fwdPkgs[0], true)
+
+	// Now, write the forwarding decision. Since we have not explicitly
+	// added any adds to the fwdfilter, this would indicate that all of the
+	// adds were 1) settled locally by this link (exit hop), or 2) the htlc
+	// was failed locally.
+	if err := db.Update(func(tx *bolt.Tx) error {
+		return packager.SetFwdFilter(tx, fwdPkg.Height, fwdPkg.FwdFilter)
+	}); err != nil {
+		t.Fatalf("unable to set fwdfiter: %v", err)
+	}
+
+	for i := range settleFails {
+		// We should still have one package on disk. Since the
+		// forwarding decision has been written, it will minimally be in
+		// FwdStateProcessed. However, not all of the HTLCs have been
+		// acked, so should not have advanced further.
+		fwdPkgs = loadFwdPkgs(t, db, packager)
+		if len(fwdPkgs) != 1 {
+			t.Fatalf("expected 1 fwdpkg, instead found %d", len(fwdPkgs))
+		}
+		assertFwdPkgState(t, fwdPkgs[0], channeldb.FwdStateProcessed)
+		assertFwdPkgNumAddsSettleFails(t, fwdPkgs[0], 0, nSettleFails)
+		assertSettleFailFilterIsFull(t, fwdPkgs[0], false)
+		assertAckFilterIsFull(t, fwdPkgs[0], true)
+
+		failSettleRef := channeldb.SettleFailRef{
+			Source: shortChanID,
+			Height: fwdPkg.Height,
+			Index:  uint16(i),
+		}
+
+		if err := db.Update(func(tx *bolt.Tx) error {
+			return packager.AckSettleFails(tx, failSettleRef)
+		}); err != nil {
+			t.Fatalf("unable to ack add htlc: %v", err)
+		}
+	}
+
+	// We should still have one package on disk. Now that all settles and
+	// fails have been removed, package should be FwdStateCompleted since
+	// there are no other add packets.
+	fwdPkgs = loadFwdPkgs(t, db, packager)
+	if len(fwdPkgs) != 1 {
+		t.Fatalf("expected 1 fwdpkg, instead found %d", len(fwdPkgs))
+	}
+	assertFwdPkgState(t, fwdPkgs[0], channeldb.FwdStateCompleted)
+	assertFwdPkgNumAddsSettleFails(t, fwdPkgs[0], 0, nSettleFails)
+	assertSettleFailFilterIsFull(t, fwdPkgs[0], true)
+	assertAckFilterIsFull(t, fwdPkgs[0], true)
+
+	// Lastly, remove the completed forwarding package from disk.
+	if err := db.Update(func(tx *bolt.Tx) error {
+		return packager.RemovePkg(tx, fwdPkg.Height)
+	}); err != nil {
+		t.Fatalf("unable to remove fwdpkg: %v", err)
+	}
+
+	// Check that the fwd package was actually removed.
+	fwdPkgs = loadFwdPkgs(t, db, packager)
+	if len(fwdPkgs) != 0 {
+		t.Fatalf("no forwarding packages should exist, found %d", len(fwdPkgs))
+	}
+}
+
+// TestPackagerAddsThenSettleFails writes a fwdpkg containing both adds and
+// settle/fails, then checks the behavior when the adds are acked before any of
+// the settle fails. Here we expect pkg to remain in FwdStateProcessed while the
+// remainder of the fail/settles are being deleted.
+func TestPackagerAddsThenSettleFails(t *testing.T) {
+	t.Parallel()
+
+	db := makeFwdPkgDB(t, "")
+
+	shortChanID := lnwire.NewShortChanIDFromInt(1)
+	packager := channeldb.NewChannelPackager(shortChanID)
+
+	// To begin, there should be no forwarding packages on disk.
+	fwdPkgs := loadFwdPkgs(t, db, packager)
+	if len(fwdPkgs) != 0 {
+		t.Fatalf("no forwarding packages should exist, found %d", len(fwdPkgs))
+	}
+
+	// Next, create and write a new forwarding package that only has add
+	// htlcs.
+	fwdPkg := channeldb.NewFwdPkg(shortChanID, 0, adds, settleFails)
+
+	nAdds := len(adds)
+	nSettleFails := len(settleFails)
+
+	if err := db.Update(func(tx *bolt.Tx) error {
+		return packager.AddFwdPkg(tx, fwdPkg)
+	}); err != nil {
+		t.Fatalf("unable to add fwd pkg: %v", err)
+	}
+
+	// There should now be one fwdpkg on disk. Since no forwarding decision
+	// has been written, we expect it to be FwdStateLockedIn. The package
+	// has unacked add HTLCs, so the ack filter should not be full.
+	fwdPkgs = loadFwdPkgs(t, db, packager)
+	if len(fwdPkgs) != 1 {
+		t.Fatalf("expected 1 fwdpkg, instead found %d", len(fwdPkgs))
+	}
+	assertFwdPkgState(t, fwdPkgs[0], channeldb.FwdStateLockedIn)
+	assertFwdPkgNumAddsSettleFails(t, fwdPkgs[0], nAdds, nSettleFails)
+	assertAckFilterIsFull(t, fwdPkgs[0], false)
+
+	// Now, write the forwarding decision. Since we have not explicitly
+	// added any adds to the fwdfilter, this would indicate that all of the
+	// adds were 1) settled locally by this link (exit hop), or 2) the htlc
+	// was failed locally.
+	if err := db.Update(func(tx *bolt.Tx) error {
+		return packager.SetFwdFilter(tx, fwdPkg.Height, fwdPkg.FwdFilter)
+	}); err != nil {
+		t.Fatalf("unable to set fwdfiter: %v", err)
+	}
+
+	for i := range adds {
+		// We should still have one package on disk. Since the forwarding
+		// decision has been written, it will minimally be in FwdStateProcessed.
+		// However not allf of the HTLCs have been acked, so should not
+		// have advanced further.
+		fwdPkgs = loadFwdPkgs(t, db, packager)
+		if len(fwdPkgs) != 1 {
+			t.Fatalf("expected 1 fwdpkg, instead found %d", len(fwdPkgs))
+		}
+		assertFwdPkgState(t, fwdPkgs[0], channeldb.FwdStateProcessed)
+		assertFwdPkgNumAddsSettleFails(t, fwdPkgs[0], nAdds, nSettleFails)
+		assertSettleFailFilterIsFull(t, fwdPkgs[0], false)
+		assertAckFilterIsFull(t, fwdPkgs[0], false)
+
+		addRef := channeldb.AddRef{
+			Height: fwdPkg.Height,
+			Index:  uint16(i),
+		}
+
+		if err := db.Update(func(tx *bolt.Tx) error {
+			return packager.AckAddHtlcs(tx, addRef)
+		}); err != nil {
+			t.Fatalf("unable to ack add htlc: %v", err)
+		}
+	}
+
+	for i := range settleFails {
+		// We should still have one package on disk. Since the
+		// forwarding decision has been written, it will minimally be in
+		// FwdStateProcessed.  However not allf of the HTLCs have been
+		// acked, so should not have advanced further.
+		fwdPkgs = loadFwdPkgs(t, db, packager)
+		if len(fwdPkgs) != 1 {
+			t.Fatalf("expected 1 fwdpkg, instead found %d", len(fwdPkgs))
+		}
+		assertFwdPkgState(t, fwdPkgs[0], channeldb.FwdStateProcessed)
+		assertFwdPkgNumAddsSettleFails(t, fwdPkgs[0], nAdds, nSettleFails)
+		assertSettleFailFilterIsFull(t, fwdPkgs[0], false)
+		assertAckFilterIsFull(t, fwdPkgs[0], true)
+
+		failSettleRef := channeldb.SettleFailRef{
+			Source: shortChanID,
+			Height: fwdPkg.Height,
+			Index:  uint16(i),
+		}
+
+		if err := db.Update(func(tx *bolt.Tx) error {
+			return packager.AckSettleFails(tx, failSettleRef)
+		}); err != nil {
+			t.Fatalf("unable to remove settle/fail htlc: %v", err)
+		}
+	}
+
+	// We should still have one package on disk. Now that all settles and
+	// fails have been removed, package should be FwdStateCompleted since
+	// there are no other add packets.
+	fwdPkgs = loadFwdPkgs(t, db, packager)
+	if len(fwdPkgs) != 1 {
+		t.Fatalf("expected 1 fwdpkg, instead found %d", len(fwdPkgs))
+	}
+	assertFwdPkgState(t, fwdPkgs[0], channeldb.FwdStateCompleted)
+	assertFwdPkgNumAddsSettleFails(t, fwdPkgs[0], nAdds, nSettleFails)
+	assertSettleFailFilterIsFull(t, fwdPkgs[0], true)
+	assertAckFilterIsFull(t, fwdPkgs[0], true)
+
+	// Lastly, remove the completed forwarding package from disk.
+	if err := db.Update(func(tx *bolt.Tx) error {
+		return packager.RemovePkg(tx, fwdPkg.Height)
+	}); err != nil {
+		t.Fatalf("unable to remove fwdpkg: %v", err)
+	}
+
+	// Check that the fwd package was actually removed.
+	fwdPkgs = loadFwdPkgs(t, db, packager)
+	if len(fwdPkgs) != 0 {
+		t.Fatalf("no forwarding packages should exist, found %d", len(fwdPkgs))
+	}
+}
+
+// TestPackagerSettleFailsThenAdds writes a fwdpkg with both adds and
+// settle/fails, then checks the behavior when the settle/fails are removed
+// before any of the adds have been acked. This should cause the fwdpkg to
+// remain in FwdStateProcessed until the final ack is recorded, at which point
+// it should be promoted directly to FwdStateCompleted.since all adds have been
+// removed.
+func TestPackagerSettleFailsThenAdds(t *testing.T) {
+	t.Parallel()
+
+	db := makeFwdPkgDB(t, "")
+
+	shortChanID := lnwire.NewShortChanIDFromInt(1)
+	packager := channeldb.NewChannelPackager(shortChanID)
+
+	// To begin, there should be no forwarding packages on disk.
+	fwdPkgs := loadFwdPkgs(t, db, packager)
+	if len(fwdPkgs) != 0 {
+		t.Fatalf("no forwarding packages should exist, found %d", len(fwdPkgs))
+	}
+
+	// Next, create and write a new forwarding package that has both add
+	// and settle/fail htlcs.
+	fwdPkg := channeldb.NewFwdPkg(shortChanID, 0, adds, settleFails)
+
+	nAdds := len(adds)
+	nSettleFails := len(settleFails)
+
+	if err := db.Update(func(tx *bolt.Tx) error {
+		return packager.AddFwdPkg(tx, fwdPkg)
+	}); err != nil {
+		t.Fatalf("unable to add fwd pkg: %v", err)
+	}
+
+	// There should now be one fwdpkg on disk. Since no forwarding decision
+	// has been written, we expect it to be FwdStateLockedIn. The package
+	// has unacked add HTLCs, so the ack filter should not be full.
+	fwdPkgs = loadFwdPkgs(t, db, packager)
+	if len(fwdPkgs) != 1 {
+		t.Fatalf("expected 1 fwdpkg, instead found %d", len(fwdPkgs))
+	}
+	assertFwdPkgState(t, fwdPkgs[0], channeldb.FwdStateLockedIn)
+	assertFwdPkgNumAddsSettleFails(t, fwdPkgs[0], nAdds, nSettleFails)
+	assertAckFilterIsFull(t, fwdPkgs[0], false)
+
+	// Now, write the forwarding decision. Since we have not explicitly
+	// added any adds to the fwdfilter, this would indicate that all of the
+	// adds were 1) settled locally by this link (exit hop), or 2) the htlc
+	// was failed locally.
+	if err := db.Update(func(tx *bolt.Tx) error {
+		return packager.SetFwdFilter(tx, fwdPkg.Height, fwdPkg.FwdFilter)
+	}); err != nil {
+		t.Fatalf("unable to set fwdfiter: %v", err)
+	}
+
+	// Simulate another channel deleting the settle/fails it received from
+	// the original fwd pkg.
+	// TODO(conner): use different packager/s?
+	for i := range settleFails {
+		// We should still have one package on disk. Since the
+		// forwarding decision has been written, it will minimally be in
+		// FwdStateProcessed.  However none all of the add HTLCs have
+		// been acked, so should not have advanced further.
+		fwdPkgs = loadFwdPkgs(t, db, packager)
+		if len(fwdPkgs) != 1 {
+			t.Fatalf("expected 1 fwdpkg, instead found %d", len(fwdPkgs))
+		}
+		assertFwdPkgState(t, fwdPkgs[0], channeldb.FwdStateProcessed)
+		assertFwdPkgNumAddsSettleFails(t, fwdPkgs[0], nAdds, nSettleFails)
+		assertSettleFailFilterIsFull(t, fwdPkgs[0], false)
+		assertAckFilterIsFull(t, fwdPkgs[0], false)
+
+		failSettleRef := channeldb.SettleFailRef{
+			Source: shortChanID,
+			Height: fwdPkg.Height,
+			Index:  uint16(i),
+		}
+
+		if err := db.Update(func(tx *bolt.Tx) error {
+			return packager.AckSettleFails(tx, failSettleRef)
+		}); err != nil {
+			t.Fatalf("unable to remove settle/fail htlc: %v", err)
+		}
+	}
+
+	// Now simulate this channel receiving a fail/settle for the adds in the
+	// fwdpkg.
+	for i := range adds {
+		// Again, we should still have one package on disk and be in
+		// FwdStateProcessed. This should not change until all of the
+		// add htlcs have been acked.
+		fwdPkgs = loadFwdPkgs(t, db, packager)
+		if len(fwdPkgs) != 1 {
+			t.Fatalf("expected 1 fwdpkg, instead found %d", len(fwdPkgs))
+		}
+		assertFwdPkgState(t, fwdPkgs[0], channeldb.FwdStateProcessed)
+		assertFwdPkgNumAddsSettleFails(t, fwdPkgs[0], nAdds, nSettleFails)
+		assertSettleFailFilterIsFull(t, fwdPkgs[0], true)
+		assertAckFilterIsFull(t, fwdPkgs[0], false)
+
+		addRef := channeldb.AddRef{
+			Height: fwdPkg.Height,
+			Index:  uint16(i),
+		}
+
+		if err := db.Update(func(tx *bolt.Tx) error {
+			return packager.AckAddHtlcs(tx, addRef)
+		}); err != nil {
+			t.Fatalf("unable to ack add htlc: %v", err)
+		}
+	}
+
+	// We should still have one package on disk. Now that all settles and
+	// fails have been removed, package should be FwdStateCompleted since
+	// there are no other add packets.
+	fwdPkgs = loadFwdPkgs(t, db, packager)
+	if len(fwdPkgs) != 1 {
+		t.Fatalf("expected 1 fwdpkg, instead found %d", len(fwdPkgs))
+	}
+	assertFwdPkgState(t, fwdPkgs[0], channeldb.FwdStateCompleted)
+	assertFwdPkgNumAddsSettleFails(t, fwdPkgs[0], nAdds, nSettleFails)
+	assertSettleFailFilterIsFull(t, fwdPkgs[0], true)
+	assertAckFilterIsFull(t, fwdPkgs[0], true)
+
+	// Lastly, remove the completed forwarding package from disk.
+	if err := db.Update(func(tx *bolt.Tx) error {
+		return packager.RemovePkg(tx, fwdPkg.Height)
+	}); err != nil {
+		t.Fatalf("unable to remove fwdpkg: %v", err)
+	}
+
+	// Check that the fwd package was actually removed.
+	fwdPkgs = loadFwdPkgs(t, db, packager)
+	if len(fwdPkgs) != 0 {
+		t.Fatalf("no forwarding packages should exist, found %d", len(fwdPkgs))
+	}
+}
+
+// assertFwdPkgState checks the current state of a fwdpkg meets our
+// expectations.
+func assertFwdPkgState(t *testing.T, fwdPkg *channeldb.FwdPkg,
+	state channeldb.FwdState) {
+	_, _, line, _ := runtime.Caller(1)
+	if fwdPkg.State != state {
+		t.Fatalf("line %d: expected fwdpkg in state %v, found %v",
+			line, state, fwdPkg.State)
+	}
+}
+
+// assertFwdPkgNumAddsSettleFails checks that the number of adds and
+// settle/fail log updates are correct.
+func assertFwdPkgNumAddsSettleFails(t *testing.T, fwdPkg *channeldb.FwdPkg,
+	expectedNumAdds, expectedNumSettleFails int) {
+	_, _, line, _ := runtime.Caller(1)
+	if len(fwdPkg.Adds) != expectedNumAdds {
+		t.Fatalf("line %d: expected fwdpkg to have %d adds, found %d",
+			line, expectedNumAdds, len(fwdPkg.Adds))
+	}
+
+	if len(fwdPkg.SettleFails) != expectedNumSettleFails {
+		t.Fatalf("line %d: expected fwdpkg to have %d settle/fails, found %d",
+			line, expectedNumSettleFails, len(fwdPkg.SettleFails))
+	}
+}
+
+// assertAckFilterIsFull checks whether or not a fwdpkg's ack filter matches our
+// expected full-ness.
+func assertAckFilterIsFull(t *testing.T, fwdPkg *channeldb.FwdPkg, expected bool) {
+	_, _, line, _ := runtime.Caller(1)
+	if fwdPkg.AckFilter.IsFull() != expected {
+		t.Fatalf("line %d: expected fwdpkg ack filter IsFull to be %v, "+
+			"found %v", line, expected, fwdPkg.AckFilter.IsFull())
+	}
+}
+
+// assertSettleFailFilterIsFull checks whether or not a fwdpkg's settle fail
+// filter matches our expected full-ness.
+func assertSettleFailFilterIsFull(t *testing.T, fwdPkg *channeldb.FwdPkg, expected bool) {
+	_, _, line, _ := runtime.Caller(1)
+	if fwdPkg.SettleFailFilter.IsFull() != expected {
+		t.Fatalf("line %d: expected fwdpkg settle/fail filter IsFull to be %v, "+
+			"found %v", line, expected, fwdPkg.SettleFailFilter.IsFull())
+	}
+}
+
+// loadFwdPkgs is a helper method that reads all forwarding packages for a
+// particular packager.
+func loadFwdPkgs(t *testing.T, db *bolt.DB,
+	packager channeldb.FwdPackager) []*channeldb.FwdPkg {
+
+	var fwdPkgs []*channeldb.FwdPkg
+	if err := db.View(func(tx *bolt.Tx) error {
+		var err error
+		fwdPkgs, err = packager.LoadFwdPkgs(tx)
+		return err
+	}); err != nil {
+		t.Fatalf("unable to load fwd pkgs: %v", err)
+	}
+
+	return fwdPkgs
+}
+
+// makeFwdPkgDB initializes a test database for forwarding packages. If the
+// provided path is an empty, it will create a temp dir/file to use.
+func makeFwdPkgDB(t *testing.T, path string) *bolt.DB {
+	if path == "" {
+		var err error
+		path, err = ioutil.TempDir("", "fwdpkgdb")
+		if err != nil {
+			t.Fatalf("unable to create temp path: %v", err)
+		}
+
+		path = filepath.Join(path, "fwdpkg.db")
+	}
+
+	db, err := bolt.Open(path, 0600, nil)
+	if err != nil {
+		t.Fatalf("unable to open boltdb: %v", err)
+	}
+
+	return db
+}

--- a/channeldb/invoices.go
+++ b/channeldb/invoices.go
@@ -432,6 +432,12 @@ func settleInvoice(invoices *bolt.Bucket, invoiceNum []byte) error {
 		return err
 	}
 
+	// Add idempotency to duplicate settles, return here to avoid
+	// overwriting the previous info.
+	if invoice.Terms.Settled {
+		return nil
+	}
+
 	invoice.Terms.Settled = true
 	invoice.SettleDate = time.Now()
 

--- a/htlcswitch/test_utils.go
+++ b/htlcswitch/test_utils.go
@@ -5,15 +5,12 @@ import (
 	"crypto/rand"
 	"crypto/sha256"
 	"fmt"
+	"io/ioutil"
+	"math/big"
+	"net"
+	"os"
 	"testing"
 	"time"
-
-	"io/ioutil"
-	"os"
-
-	"math/big"
-
-	"net"
 
 	"github.com/btcsuite/fastsha256"
 	"github.com/go-errors/errors"
@@ -266,6 +263,7 @@ func createTestChannel(alicePrivKey, bobPrivKey []byte,
 		RemoteCommitment:        aliceCommit,
 		ShortChanID:             chanID,
 		Db:                      dbAlice,
+		Packager:                channeldb.NewChannelPackager(chanID),
 	}
 
 	bobChannelState := &channeldb.OpenChannel{
@@ -283,6 +281,7 @@ func createTestChannel(alicePrivKey, bobPrivKey []byte,
 		RemoteCommitment:        bobCommit,
 		ShortChanID:             chanID,
 		Db:                      dbBob,
+		Packager:                channeldb.NewChannelPackager(chanID),
 	}
 
 	if err := aliceChannelState.SyncPending(bobAddr, broadcastHeight); err != nil {


### PR DESCRIPTION
This PR lays the groundwork for integrating forwarding packages into the switch. Forwarding packages will serve as the primary component in recovering from failures, as they will hold and direct how to reconstruct the switch's in-memory state prior to a crash.

Overview
=======
After receiving a revocation from the remote party, we construct and persist a forwarding package containing all Adds, Settles, and Fails that were locked in as a result. Internally, a forwarding package treats Adds separately from Settles and Fails. This is due to the fact that these two categories of HTLCs have different semantics during forwarding:

 - Adds are always propagated on a best effort basis and must pass various levels of validation. As such their final destination is not fully determined at the time they are locked in. Extra care is required to make sure we are always consistent in making a forwarding decision.
 - Settles and Fails are locked-in in response to a preexisting Add that was locked in one of the incoming link's forwarding packages. Unlike the best-effort semantics of Add HTLCS, Settles and Fails must _always_ be delivered to the incoming link, otherwise the sender will be left hanging  🤜 ...

Forwarding Filters
=============
Once a link has processed a forwarding package for the first time, it writes a _forwarding filter_ (using `SetFwdFilter`) to remember which Adds it intends to forward to the switch. This is represented as a `channeldb.PkgFilter`, which is bitvector containing the indexes of all Adds that passed validation and for which we were not the exit hop.

Upon restarts, if we detect that a forwarding decision has already been made, we just reconstruct the next onion packets and deliver them to the switch, which will decide whether or not to forward, drop, or failback the packet. This prevents situations during restarts where an Add was previously forwarded, but validating the HTLC at the time causes us to fail back the packet, such as expiring timelocks.

Without this protection, we could have an HTLC extended on an outgoing link, but failback along the incoming link and not get paid.

Acknowledgements
==============
We track which Adds, Settles and Fails have been acknowledged by updating persistent `channeldb.PkgFilter`s in the forwarding package. We use _acknowledgement_ to occur when a Settle or Fail is locked in by the incoming link.

- If an Add is an exit hop, fails validation at any point, or does not get committed by an outgoing link, the incoming link will only ack its own Add. Otherwise, it will ack it's own Add and that of a Settle or Fail from the outgoing link, only after the response is locked in on the incoming link.
- When a Settle or Fail returns and gets locked in the by the _incoming_ link, it ack's the Settle or Fail in the fwdpkg of the outgoing link. As implemented, a link is able to atomically ack from multiple sources at once, offering consistency even when many channels are forwarding.

This is another reason for separating Adds from Settles and Fails, since acknowledging and reading Settles and Fails needs to be done by other channels and/or the switch, while Adds should only be read/modified by the link at which they arrived.

NOTE: Adds, Settles, and Fails are *always* ack'd atomically with commitment signing. This helps ensures that we never run into inconsistencies internally. Forwarding packages thus serve as the primary persistence mechanism for reliably getting any HTLCs we have received into a signed outgoing commitment. Once an HTLC is included into a `channeldb.CommitDiff`, channel resync will ensure it is delivered to the remote party.

Garbage Collection
==============
Garbage collection happens completely asynchronously by periodically reading forwarding package from disk, and removing it only if all indexes in the `channeldb.PkgFilter`s have been set. This operation will be performed by every link independently via a timer using `LoadFwdPkgs` and `RemoveFwdPkg`. 

All modifications to forwarding packages are coordinated through the database, which means this garbage collection process does not impose any other synchronization constraints on the active links. As such, it should be safe to interleave reading and deleting of forwarding packages with concurrent modifications to other packages.

Batching
======
The design of the forwarding packages shoots to minimize the number of writes that need to occur to deliver the htlcs safely. Most of the persistent operations are batched at the granularity of the channel's state transitions, which allowed our performance to stay comparable to the switch pre-persistence.