### PR TITLE
lnwire+lnwallet+htlcswitch: modify lnwire.MilliSatoshi to be unsigned, fix fee related bugs that emerged

### DIFF
--- a/htlcswitch/link.go
+++ b/htlcswitch/link.go
@@ -1729,15 +1729,18 @@ func (l *channelLink) processLockedInHtlcs(
 					fwdInfo.AmountToForward,
 				)
 
-				// If the amount of the incoming HTLC, minus
-				// our expected fee isn't equal to the
-				// forwarding instructions, then either the
-				// values have been tampered with, or the send
-				// used incorrect/dated information to
+				// If the actual fee is less than our expected
+				// fee, then we'll reject this HTLC as it
+				// didn't provide a sufficient amount of fees,
+				// or the values have been tampered with, or
+				// the send used incorrect/dated information to
 				// construct the forwarding information for
 				// this hop. In any case, we'll cancel this
 				// HTLC.
-				if pd.Amount-expectedFee < fwdInfo.AmountToForward {
+				actualFee := pd.Amount - fwdInfo.AmountToForward
+				if pd.Amount < fwdInfo.AmountToForward ||
+					actualFee < expectedFee {
+
 					log.Errorf("Incoming htlc(%x) has "+
 						"insufficient fee: expected "+
 						"%v, got %v", pd.RHash[:],

--- a/htlcswitch/link_test.go
+++ b/htlcswitch/link_test.go
@@ -777,7 +777,7 @@ func TestUpdateForwardingPolicy(t *testing.T) {
 		testStartingHeight,
 		n.firstBobChannelLink, n.carolChannelLink)
 
-	// First, send this 1 BTC payment over the three hops, the payment
+	// First, send this 10 mSAT payment over the three hops, the payment
 	// should succeed, and all balances should be updated accordingly.
 	payResp, err := n.makePayment(n.aliceServer, n.carolServer,
 		n.bobServer.PubKey(), hops, amountNoFee, htlcAmt,
@@ -827,7 +827,7 @@ func TestUpdateForwardingPolicy(t *testing.T) {
 	n.firstBobChannelLink.UpdateForwardingPolicy(newPolicy)
 
 	// Next, we'll send the payment again, using the exact same per-hop
-	// payload for each node. This payment should fail as it wont' factor
+	// payload for each node. This payment should fail as it won't factor
 	// in Bob's new fee policy.
 	_, err = n.makePayment(n.aliceServer, n.carolServer,
 		n.bobServer.PubKey(), hops, amountNoFee, htlcAmt,

--- a/lnwallet/channel_test.go
+++ b/lnwallet/channel_test.go
@@ -2477,7 +2477,7 @@ func TestAddHTLCNegativeBalance(t *testing.T) {
 	}
 
 	// Alice now has an available balance of 2 BTC. We'll add a new HTLC of
-	// value 2 BTC, which should make Alice's balance negative (since (she
+	// value 2 BTC, which should make Alice's balance negative (since she
 	// has to pay a commitment fee).
 	htlcAmt = lnwire.NewMSatFromSatoshis(2 * btcutil.SatoshiPerBitcoin)
 	htlc, _ := createHTLC(numHTLCs+1, htlcAmt)
@@ -4378,7 +4378,7 @@ func TestDesyncHTLCs(t *testing.T) {
 
 	// Alice now has gotten all her original balance (5 BTC) back, however,
 	// adding a new HTLC at this point SHOULD fail, since if she adds the
-	// HTLC and sign the next state, Bob cannot assume she received the
+	// HTLC and signs the next state, Bob cannot assume she received the
 	// FailHTLC, and must assume she doesn't have the necessary balance
 	// available.
 	//

--- a/lnwallet/channel_test.go
+++ b/lnwallet/channel_test.go
@@ -2462,8 +2462,8 @@ func TestAddHTLCNegativeBalance(t *testing.T) {
 	}
 	defer cleanUp()
 
-	// We set the channel reserve to 0, such that we can add HTLCs
-	// all the way to a negative balance.
+	// We set the channel reserve to 0, such that we can add HTLCs all the
+	// way to a negative balance.
 	aliceChannel.localChanCfg.ChanReserve = 0
 
 	// First, we'll add 3 HTLCs of 1 BTC each to Alice's commitment.
@@ -2476,14 +2476,15 @@ func TestAddHTLCNegativeBalance(t *testing.T) {
 		}
 	}
 
-	// Alice now has an available balance of 2 BTC. We'll add a new HTLC
-	// of value 2 BTC, which should make Alice's balance negative (since
-	// (she has to pay a commitment fee).
+	// Alice now has an available balance of 2 BTC. We'll add a new HTLC of
+	// value 2 BTC, which should make Alice's balance negative (since (she
+	// has to pay a commitment fee).
 	htlcAmt = lnwire.NewMSatFromSatoshis(2 * btcutil.SatoshiPerBitcoin)
 	htlc, _ := createHTLC(numHTLCs+1, htlcAmt)
 	_, err = aliceChannel.AddHTLC(htlc)
 	if err != ErrBelowChanReserve {
-		t.Fatalf("expected balance below channel reserve, instead got: %v", err)
+		t.Fatalf("expected balance below channel reserve, instead "+
+			"got: %v", err)
 	}
 }
 
@@ -4375,23 +4376,22 @@ func TestDesyncHTLCs(t *testing.T) {
 		t.Fatalf("unable to recv htlc cancel: %v", err)
 	}
 
-	// Alice now has gotten all here original balance (5 BTC) back,
-	// however, adding a new HTLC at this point SHOULD fail, since
-	// if she add the HTLC and sign the next state, Bob cannot assume
-	// she received the FailHTLC, and must assume she doesn't have
-	// the necessary balance available.
+	// Alice now has gotten all her original balance (5 BTC) back, however,
+	// adding a new HTLC at this point SHOULD fail, since if she adds the
+	// HTLC and sign the next state, Bob cannot assume she received the
+	// FailHTLC, and must assume she doesn't have the necessary balance
+	// available.
 	//
-	// We try adding an HTLC of value 1 BTC, which should fail
-	// because the balance is unavailable.
+	// We try adding an HTLC of value 1 BTC, which should fail because the
+	// balance is unavailable.
 	htlcAmt = lnwire.NewMSatFromSatoshis(1 * btcutil.SatoshiPerBitcoin)
 	htlc, _ = createHTLC(1, htlcAmt)
 	if _, err = aliceChannel.AddHTLC(htlc); err != ErrBelowChanReserve {
-		t.Fatalf("expected ErrInsufficientBalance, instead received: %v",
-			err)
+		t.Fatalf("expected ErrBelowChanReserve, instead received: %v", err)
 	}
 
-	// Now do a state transition, which will ACK the FailHTLC, making
-	// Alice able to add the new HTLC.
+	// Now do a state transition, which will ACK the FailHTLC, making Alice
+	// able to add the new HTLC.
 	if err := forceStateTransition(aliceChannel, bobChannel); err != nil {
 		t.Fatalf("unable to complete state update: %v", err)
 	}
@@ -4403,7 +4403,8 @@ func TestDesyncHTLCs(t *testing.T) {
 // TODO(roasbeef): testing.Quick test case for retrans!!!
 
 // TestMaxAcceptedHTLCs tests that the correct error message (ErrMaxHTLCNumber)
-// is thrown when a node tries to accept more than MaxAcceptedHTLCs in a channel.
+// is thrown when a node tries to accept more than MaxAcceptedHTLCs in a
+// channel.
 func TestMaxAcceptedHTLCs(t *testing.T) {
 	t.Parallel()
 

--- a/lnwallet/reservation.go
+++ b/lnwallet/reservation.go
@@ -288,40 +288,36 @@ func (r *ChannelReservation) CommitConstraints(csvDelay, maxHtlcs uint16,
 		return ErrCsvDelayTooLarge(csvDelay, maxDelay)
 	}
 
-	// Fail if we consider the channel reserve to be too large.
-	// We currently fail if it is greater than 20% of the
-	// channel capacity.
+	// Fail if we consider the channel reserve to be too large.  We
+	// currently fail if it is greater than 20% of the channel capacity.
 	maxChanReserve := r.partialState.Capacity / 5
 	if chanReserve > maxChanReserve {
 		return ErrChanReserveTooLarge(chanReserve, maxChanReserve)
 	}
 
-	// Fail if the minimum HTLC value is too large. If this is
-	// too large, the channel won't be useful for sending small
-	// payments. This limit is currently set to maxValueInFlight,
-	// effictively letting the remote setting this as large as
-	// it wants.
-	// TODO(halseth): set a reasonable/dynamic value.
+	// Fail if the minimum HTLC value is too large. If this is too large,
+	// the channel won't be useful for sending small payments. This limit
+	// is currently set to maxValueInFlight, effectively letting the remote
+	// setting this as large as it wants.
 	if minHtlc > maxValueInFlight {
 		return ErrMinHtlcTooLarge(minHtlc, maxValueInFlight)
 	}
 
-	// Fail if maxHtlcs is above the maximum allowed number of 483.
-	// This number is specified in BOLT-02.
+	// Fail if maxHtlcs is above the maximum allowed number of 483.  This
+	// number is specified in BOLT-02.
 	if maxHtlcs > uint16(MaxHTLCNumber/2) {
 		return ErrMaxHtlcNumTooLarge(maxHtlcs, uint16(MaxHTLCNumber/2))
 	}
 
-	// Fail if we consider maxHtlcs too small. If this is too small
-	// we cannot offer many HTLCs to the remote.
+	// Fail if we consider maxHtlcs too small. If this is too small we
+	// cannot offer many HTLCs to the remote.
 	const minNumHtlc = 5
 	if maxHtlcs < minNumHtlc {
 		return ErrMaxHtlcNumTooSmall(maxHtlcs, minNumHtlc)
 	}
 
-	// Fail if we consider maxValueInFlight too small. We currently
-	// require the remote to at least allow minNumHtlc * minHtlc
-	// in flight.
+	// Fail if we consider maxValueInFlight too small. We currently require
+	// the remote to at least allow minNumHtlc * minHtlc in flight.
 	if maxValueInFlight < minNumHtlc*minHtlc {
 		return ErrMaxValueInFlightTooSmall(maxValueInFlight,
 			minNumHtlc*minHtlc)

--- a/lnwallet/transactions_test.go
+++ b/lnwallet/transactions_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/davecgh/go-spew/spew"
 	"github.com/lightningnetwork/lnd/channeldb"
 	"github.com/lightningnetwork/lnd/keychain"
 	"github.com/lightningnetwork/lnd/lnwire"
@@ -806,8 +807,9 @@ func TestCommitmentAndHTLCTransactions(t *testing.T) {
 			dustLimit:    tc.dustLimit,
 			isOurs:       true,
 		}
-		err = channel.createCommitmentTx(commitmentView, theHTLCView,
-			keys)
+		err = channel.createCommitmentTx(
+			commitmentView, theHTLCView, keys,
+		)
 		if err != nil {
 			t.Errorf("Case %d: Failed to create new commitment tx: %v", i, err)
 			continue
@@ -836,8 +838,8 @@ func TestCommitmentAndHTLCTransactions(t *testing.T) {
 		// Check that commitment transaction was created correctly.
 		if commitTx.WitnessHash() != *expectedCommitmentTx.WitnessHash() {
 			t.Errorf("Case %d: Generated unexpected commitment tx: "+
-				"expected %s, got %s", i, expectedCommitmentTx.WitnessHash(),
-				commitTx.WitnessHash())
+				"expected %s, got %s", i, spew.Sdump(expectedCommitmentTx),
+				spew.Sdump(commitTx))
 			continue
 		}
 

--- a/lnwire/msat.go
+++ b/lnwire/msat.go
@@ -8,7 +8,7 @@ import (
 
 // mSatScale is a value that's used to scale satoshis to milli-satoshis, and
 // the other way around.
-const mSatScale int64 = 1000
+const mSatScale uint64 = 1000
 
 // MilliSatoshi are the native unit of the Lightning Network. A milli-satoshi
 // is simply 1/1000th of a satoshi. There are 1000 milli-satoshis in a single
@@ -16,12 +16,12 @@ const mSatScale int64 = 1000
 // milli-satoshis. As milli-satoshis aren't deliverable on the native
 // blockchain, before settling to broadcasting, the values are rounded down to
 // the nearest satoshi.
-type MilliSatoshi int64
+type MilliSatoshi uint64
 
 // NewMSatFromSatoshis creates a new MilliSatoshi instance from a target amount
 // of satoshis.
 func NewMSatFromSatoshis(sat btcutil.Amount) MilliSatoshi {
-	return MilliSatoshi(int64(sat) * mSatScale)
+	return MilliSatoshi(uint64(sat) * mSatScale)
 }
 
 // ToBTC converts the target MilliSatoshi amount to its corresponding value
@@ -34,10 +34,12 @@ func (m MilliSatoshi) ToBTC() float64 {
 // ToSatoshis converts the target MilliSatoshi amount to satoshis. Simply, this
 // sheds a factor of 1000 from the mSAT amount in order to convert it to SAT.
 func (m MilliSatoshi) ToSatoshis() btcutil.Amount {
-	return btcutil.Amount(int64(m) / mSatScale)
+	return btcutil.Amount(uint64(m) / mSatScale)
 }
 
 // String returns the string representation of the mSAT amount.
 func (m MilliSatoshi) String() string {
-	return fmt.Sprintf("%v mSAT", int64(m))
+	return fmt.Sprintf("%v mSAT", uint64(m))
 }
+
+// TODO(roasbeef): extend with arithmetic operations?

--- a/zpay32/invoice_internal_test.go
+++ b/zpay32/invoice_internal_test.go
@@ -150,10 +150,6 @@ func TestEncodeAmount(t *testing.T) {
 		result string
 	}{
 		{
-			msat:  -10,   // mSat
-			valid: false, // negative amount
-		},
-		{
 			msat:   1, // mSat
 			valid:  true,
 			result: "10p", // pBTC


### PR DESCRIPTION
In this PR, we correct a _minor_ deviation (with tangible ramifications) of our implementation from the specification. In the spec, all integers are unsigned unless otherwise state. However, our definition of `lnwire.MilliSatoshi` was an `int64`. As many of the other implementations used the equivalent of an `uint64`, users have been reporting certain compatibility issues due to this divergence. 

To remedy this, we'll now properly use:
```go
type MilliSatoshi uint64
```

Once this initial change was made, a number of bugs emerged. Many of these weren't bugs under the existing logic as negative integers were possible, and the checks assumed so. Once we moved to unsigned integers, integer underflow went silently undetected. As a result, we've tightened up several consistency checks through the wallet, and the switch in order to ensure the same (at times even stronger) behavior is kept in place. 

Fixes https://github.com/cdecker/lightning-integration/issues/11. 