### PR TITLE
config+cmd/lncli: add flags to specify the base directory for lnd and supported backend nodes

### DIFF
--- a/cmd/lncli/main.go
+++ b/cmd/lncli/main.go
@@ -28,9 +28,9 @@ const (
 )
 
 var (
-	lndHomeDir          = btcutil.AppDataDir("lnd", false)
-	defaultTLSCertPath  = filepath.Join(lndHomeDir, defaultTLSCertFilename)
-	defaultMacaroonPath = filepath.Join(lndHomeDir, defaultMacaroonFilename)
+	defaultLndDir       = btcutil.AppDataDir("lnd", false)
+	defaultTLSCertPath  = filepath.Join(defaultLndDir, defaultTLSCertFilename)
+	defaultMacaroonPath = filepath.Join(defaultLndDir, defaultMacaroonFilename)
 )
 
 func fatal(err error) {
@@ -59,6 +59,27 @@ func getClient(ctx *cli.Context) (lnrpc.LightningClient, func()) {
 }
 
 func getClientConn(ctx *cli.Context, skipMacaroons bool) *grpc.ClientConn {
+	lndDir := cleanAndExpandPath(ctx.GlobalString("lnddir"))
+	if lndDir != defaultLndDir {
+		// If a custom lnd directory was set, we'll also check if custom
+		// paths for the TLS cert and macaroon file were set as well. If
+		// not, we'll override their paths so they can be found within
+		// the custom lnd directory set. This allows us to set a custom
+		// lnd directory, along with custom paths to the TLS cert and
+		// macaroon file.
+		tlsCertPath := cleanAndExpandPath(ctx.GlobalString("tlscertpath"))
+		if tlsCertPath == defaultTLSCertPath {
+			ctx.GlobalSet("tlscertpath",
+				filepath.Join(lndDir, defaultTLSCertFilename))
+		}
+
+		macPath := cleanAndExpandPath(ctx.GlobalString("macaroonpath"))
+		if macPath == defaultMacaroonPath {
+			ctx.GlobalSet("no-macaroons",
+				filepath.Join(lndDir, defaultMacaroonFilename))
+		}
+	}
+
 	// Load the specified TLS certificate and build transport credentials
 	// with it.
 	tlsCertPath := cleanAndExpandPath(ctx.GlobalString("tlscertpath"))
@@ -137,6 +158,11 @@ func main() {
 			Usage: "host:port of ln daemon",
 		},
 		cli.StringFlag{
+			Name:  "lnddir",
+			Value: defaultLndDir,
+			Usage: "path to lnd's base directory",
+		},
+		cli.StringFlag{
 			Name:  "tlscertpath",
 			Value: defaultTLSCertPath,
 			Usage: "path to TLS certificate",
@@ -210,7 +236,7 @@ func main() {
 func cleanAndExpandPath(path string) string {
 	// Expand initial ~ to OS specific home directory.
 	if strings.HasPrefix(path, "~") {
-		homeDir := filepath.Dir(lndHomeDir)
+		homeDir := filepath.Dir(defaultLndDir)
 		path = strings.Replace(path, "~", homeDir, 1)
 	}
 

--- a/cmd/lncli/main.go
+++ b/cmd/lncli/main.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"os/user"
 	"path/filepath"
 	"strings"
 
@@ -236,7 +237,15 @@ func main() {
 func cleanAndExpandPath(path string) string {
 	// Expand initial ~ to OS specific home directory.
 	if strings.HasPrefix(path, "~") {
-		homeDir := filepath.Dir(defaultLndDir)
+		var homeDir string
+
+		user, err := user.Current()
+		if err == nil {
+			homeDir = user.HomeDir
+		} else {
+			homeDir = os.Getenv("HOME")
+		}
+
 		path = strings.Replace(path, "~", homeDir, 1)
 	}
 

--- a/config.go
+++ b/config.go
@@ -9,6 +9,7 @@ import (
 	"io/ioutil"
 	"net"
 	"os"
+	"os/user"
 	"path"
 	"path/filepath"
 	"regexp"
@@ -609,7 +610,15 @@ func loadConfig() (*config, error) {
 func cleanAndExpandPath(path string) string {
 	// Expand initial ~ to OS specific home directory.
 	if strings.HasPrefix(path, "~") {
-		homeDir := filepath.Dir(defaultLndDir)
+		var homeDir string
+
+		user, err := user.Current()
+		if err == nil {
+			homeDir = user.HomeDir
+		} else {
+			homeDir = os.Getenv("HOME")
+		}
+
 		path = strings.Replace(path, "~", homeDir, 1)
 	}
 


### PR DESCRIPTION
In this PR, we introduce new configuration flags in order to specify the base directory for `lnd` and supported backend nodes (i.e. `btcd`, `bitcoind`, etc.).

Currently, there's no way to have all of `lnd`'s data under a single directory other than just using the default. This PR introduces a new flag to modify that. This is especially useful for testing environments, where you wish to have everything contained within a specific directory. Fixes #248.

Also, there's no way of pointing `lnd` to use a specific `bitcoind` datadir. Some users have set paths other than the default for different purposes. This PR introduces a flag to the supported backend nodes to help remedy that. Fixes #670.