### PR TITLE
c-lightning rejects to_self_delay > 432 as unreasonably long

### DIFF
--- a/fundingmanager.go
+++ b/fundingmanager.go
@@ -46,7 +46,7 @@ const (
 	// The actual delay we will require will be somewhere between these
 	// values, depending on channel size.
 	minRemoteDelay = 144
-	maxRemoteDelay = 2016
+	maxRemoteDelay = 432
 
 	// maxWaitNumBlocksFundingConf is the maximum number of blocks to wait
 	// for the funding transaction to be confirmed before forgetting about


### PR DESCRIPTION
While attempting to open a channel to a c-lightning node, I got error:

"to_self_delay 600 greater than 432"

This had been submitted (by others) as an issue to c-lightning. The discussion resulted in a NAK as the developers consider more than 3 days as "unreasonable" and therefore in violation of BOLT-02:

See: https://github.com/ElementsProject/lightning/issues/1110

This creates an interoperability issue for large channels between LND and c-lightning. I don't think this is user-configurable on LND, so I changed it in the source code. 

