### PR TITLE
Wire error handoff

### DIFF
--- a/fundingmanager.go
+++ b/fundingmanager.go
@@ -2639,6 +2639,22 @@ func (f *fundingManager) getReservationCtx(peerKey *btcec.PublicKey,
 	return resCtx, nil
 }
 
+// IsPendingChannel returns a boolean indicating whether the channel identified
+// by the pendingChanID and given peer is pending, meaning it is in the process
+// of being funded. After the funding transaction has been confirmed, the
+// channel will receive a new, permanent channel ID, and will no longer be
+// considered pending.
+func (f *fundingManager) IsPendingChannel(pendingChanID [32]byte,
+	peerAddress *lnwire.NetAddress) bool {
+
+	peerIDKey := newSerializedKey(peerAddress.IdentityKey)
+	f.resMtx.RLock()
+	_, ok := f.activeReservations[peerIDKey][pendingChanID]
+	f.resMtx.RUnlock()
+
+	return ok
+}
+
 func copyPubKey(pub *btcec.PublicKey) *btcec.PublicKey {
 	return &btcec.PublicKey{
 		Curve: btcec.S256(),

--- a/fundingmanager.go
+++ b/fundingmanager.go
@@ -835,12 +835,15 @@ func (f *fundingManager) handleFundingOpen(fmsg *fundingOpenMsg) {
 
 	// TODO(roasbeef): modify to only accept a _single_ pending channel per
 	// block unless white listed
+	f.resMtx.RLock()
 	if len(f.activeReservations[peerIDKey]) >= cfg.MaxPendingChannels {
+		f.resMtx.RUnlock()
 		f.failFundingFlow(
 			fmsg.peerAddress.IdentityKey, fmsg.msg.PendingChannelID,
 			lnwire.ErrMaxPendingChannels)
 		return
 	}
+	f.resMtx.RUnlock()
 
 	// We'll also reject any requests to create channels until we're fully
 	// synced to the network as we won't be able to properly validate the

--- a/lnwire/channel_id.go
+++ b/lnwire/channel_id.go
@@ -24,6 +24,10 @@ const (
 // ChannelID can be calculated by XOR'ing the big-endian serialization of the
 type ChannelID [32]byte
 
+// ConnectionWideID is an all-zero ChannelID, which is used to represent a
+// message intended for all channels to to specific peer.
+var ConnectionWideID = ChannelID{}
+
 // String returns the string representation of the ChannelID. This is just the
 // hex string encoding of the ChannelID itself.
 func (c ChannelID) String() string {


### PR DESCRIPTION
This adds functionality in the peer for inspecting the `channelID` of a received error message, and handing it off to the `fundingmanager` in case of a pending channel ID, or the `channelLink` otherwise. It also handles the case of an all-zero channel ID, meaning that it should be forwarded to all channels with the peer.

Logic is also added to the `link`, in order to fail the channel in the event of receiving the error.