### PR TITLE
Switch Persistence [3/4]: Circuit Map Persistence

### DIFF
--- a/htlcswitch/circuit.go
+++ b/htlcswitch/circuit.go
@@ -1,184 +1,229 @@
 package htlcswitch
 
 import (
-	"fmt"
-	"sync"
+	"encoding/binary"
+	"io"
 
-	"github.com/go-errors/errors"
+	"github.com/lightningnetwork/lnd/channeldb"
 	"github.com/lightningnetwork/lnd/lnwire"
 )
 
-// PaymentCircuit is used by the HTLC switch subsystem to determine the
-// backwards path for the settle/fail HTLC messages. A payment circuit
-// will be created once a channel link forwards the HTLC add request and
-// removed when we receive a settle/fail HTLC message.
+// EmptyCircuitKey is a default value for an outgoing circuit key returned when
+// a circuit's keystone has not been set. Note that this value is invalid for
+// use as a keystone, since the outgoing channel id can never be equal to
+// sourceHop.
+var EmptyCircuitKey CircuitKey
+
+// CircuitKey is a tuple of channel ID and HTLC ID, used to uniquely identify
+// HTLCs in a circuit. Circuits are identified primarily by the circuit key of
+// the incoming HTLC. However, a circuit may also be referenced by its outgoing
+// circuit key after the HTLC has been forwarded via the outgoing link.
+type CircuitKey = channeldb.CircuitKey
+
+// PaymentCircuit is used by the switch as placeholder between when the
+// switch makes a forwarding decision and the outgoing link determines the
+// proper HTLC ID for the local log. After the outgoing HTLC ID has been
+// determined, the half circuit will be converted into a full PaymentCircuit.
 type PaymentCircuit struct {
+	// AddRef is the forward reference of the Add update in the incoming
+	// link's forwarding package. This value is set on the htlcPacket of the
+	// returned settle/fail so that it can be removed from disk.
+	AddRef channeldb.AddRef
+
+	// Incoming is the circuit key identifying the incoming channel and htlc
+	// index from which this ADD originates.
+	Incoming CircuitKey
+
+	// Outgoing is the circuit key identifying the outgoing channel, and the
+	// HTLC index that was used to forward the ADD. It will be nil if this
+	// circuit's keystone has not been set.
+	Outgoing *CircuitKey
+
 	// PaymentHash used as unique identifier of payment.
 	PaymentHash [32]byte
 
-	// IncomingChanID identifies the channel from which add HTLC request
-	// came and to which settle/fail HTLC request will be returned back.
-	// Once the switch forwards the settle/fail message to the src the
-	// circuit is considered to be completed.
-	IncomingChanID lnwire.ShortChannelID
+	// IncomingAmount is the value of the HTLC from the incoming link.
+	IncomingAmount lnwire.MilliSatoshi
 
-	// IncomingHTLCID is the ID in the update_add_htlc message we received
-	// from the incoming channel, which will be included in any settle/fail
-	// messages we send back.
-	IncomingHTLCID uint64
-
-	// IncomingAmt is the value of the incoming HTLC. If we take this and
-	// subtract it from the OutgoingAmt, then we'll compute the total fee
-	// attached to this payment circuit.
-	IncomingAmt lnwire.MilliSatoshi
-
-	// OutgoingChanID identifies the channel to which we propagate the HTLC
-	// add update and from which we are expecting to receive HTLC
-	// settle/fail request back.
-	OutgoingChanID lnwire.ShortChannelID
-
-	// OutgoingHTLCID is the ID in the update_add_htlc message we sent to
-	// the outgoing channel.
-	OutgoingHTLCID uint64
-
-	// OutgoingAmt is the value of the outgoing HTLC. If we subtract this
-	// from the IncomingAmt, then we'll compute the total fee attached to
-	// this payment circuit.
-	OutgoingAmt lnwire.MilliSatoshi
+	// OutgoingAmount specifies the value of the HTLC leaving the switch,
+	// either as a payment or forwarded amount.
+	OutgoingAmount lnwire.MilliSatoshi
 
 	// ErrorEncrypter is used to re-encrypt the onion failure before
 	// sending it back to the originator of the payment.
 	ErrorEncrypter ErrorEncrypter
+
+	// LoadedFromDisk is set true for any circuits loaded after the circuit
+	// map is reloaded from disk.
+	//
+	// NOTE: This value is determined implicitly during a restart. It is not
+	// persisted, and should never be set outside the circuit map.
+	LoadedFromDisk bool
 }
 
-// circuitKey is a channel ID, HTLC ID tuple used as an identifying key for a
-// payment circuit. The circuit map is keyed with the identifier for the
-// outgoing HTLC
-type circuitKey struct {
-	chanID lnwire.ShortChannelID
-	htlcID uint64
+// HasKeystone returns true if an outgoing link has assigned this circuit's
+// outgoing circuit key.
+func (c *PaymentCircuit) HasKeystone() bool {
+	return c.Outgoing != nil
 }
 
-// String returns a string representation of the circuitKey.
-func (k *circuitKey) String() string {
-	return fmt.Sprintf("(Chan ID=%s, HTLC ID=%d)", k.chanID, k.htlcID)
-}
+// newPaymentCircuit initializes a payment circuit on the heap using the payment
+// hash and an in-memory htlc packet.
+func newPaymentCircuit(hash *[32]byte, pkt *htlcPacket) *PaymentCircuit {
+	var addRef channeldb.AddRef
+	if pkt.sourceRef != nil {
+		addRef = *pkt.sourceRef
+	}
 
-// CircuitMap is a data structure that implements thread safe storage of
-// circuit routing information. The switch consults a circuit map to determine
-// where to forward HTLC update messages. Each circuit is stored with its
-// outgoing HTLC as the primary key because, each offered HTLC has at most one
-// received HTLC, but there may be multiple offered or received HTLCs with the
-// same payment hash. Circuits are also indexed to provide fast lookups by
-// payment hash.
-//
-// TODO(andrew.shvv) make it persistent
-type CircuitMap struct {
-	mtx       sync.RWMutex
-	circuits  map[circuitKey]*PaymentCircuit
-	hashIndex map[[32]byte]map[PaymentCircuit]struct{}
-}
-
-// NewCircuitMap creates a new instance of the CircuitMap.
-func NewCircuitMap() *CircuitMap {
-	return &CircuitMap{
-		circuits:  make(map[circuitKey]*PaymentCircuit),
-		hashIndex: make(map[[32]byte]map[PaymentCircuit]struct{}),
+	return &PaymentCircuit{
+		AddRef: addRef,
+		Incoming: CircuitKey{
+			ChanID: pkt.incomingChanID,
+			HtlcID: pkt.incomingHTLCID,
+		},
+		PaymentHash:    *hash,
+		IncomingAmount: pkt.incomingAmount,
+		OutgoingAmount: pkt.amount,
+		ErrorEncrypter: pkt.obfuscator,
 	}
 }
 
-// LookupByHTLC looks up the payment circuit by the outgoing channel and HTLC
-// IDs. Returns nil if there is no such circuit.
-func (cm *CircuitMap) LookupByHTLC(chanID lnwire.ShortChannelID, htlcID uint64) *PaymentCircuit {
-	cm.mtx.RLock()
-
-	key := circuitKey{
-		chanID: chanID,
-		htlcID: htlcID,
+// makePaymentCircuit initalizes a payment circuit on the stack using the
+// payment hash and an in-memory htlc packet.
+func makePaymentCircuit(hash *[32]byte, pkt *htlcPacket) PaymentCircuit {
+	var addRef channeldb.AddRef
+	if pkt.sourceRef != nil {
+		addRef = *pkt.sourceRef
 	}
-	circuit := cm.circuits[key]
 
-	cm.mtx.RUnlock()
-	return circuit
+	return PaymentCircuit{
+		AddRef: addRef,
+		Incoming: CircuitKey{
+			ChanID: pkt.incomingChanID,
+			HtlcID: pkt.incomingHTLCID,
+		},
+		PaymentHash:    *hash,
+		IncomingAmount: pkt.incomingAmount,
+		OutgoingAmount: pkt.amount,
+		ErrorEncrypter: pkt.obfuscator,
+	}
 }
 
-// LookupByPaymentHash looks up and returns any payment circuits with a given
-// payment hash.
-func (cm *CircuitMap) LookupByPaymentHash(hash [32]byte) []*PaymentCircuit {
-	cm.mtx.RLock()
-
-	var circuits []*PaymentCircuit
-	if circuitSet, ok := cm.hashIndex[hash]; ok {
-		circuits = make([]*PaymentCircuit, 0, len(circuitSet))
-		for circuit := range circuitSet {
-			circuits = append(circuits, &circuit)
-		}
+// Encode writes a PaymentCircuit to the provided io.Writer.
+func (c *PaymentCircuit) Encode(w io.Writer) error {
+	if err := c.AddRef.Encode(w); err != nil {
+		return err
 	}
 
-	cm.mtx.RUnlock()
-	return circuits
+	if err := c.Incoming.Encode(w); err != nil {
+		return err
+	}
+
+	if _, err := w.Write(c.PaymentHash[:]); err != nil {
+		return err
+	}
+
+	var scratch [8]byte
+
+	binary.BigEndian.PutUint64(scratch[:], uint64(c.IncomingAmount))
+	if _, err := w.Write(scratch[:]); err != nil {
+		return err
+	}
+
+	binary.BigEndian.PutUint64(scratch[:], uint64(c.OutgoingAmount))
+	if _, err := w.Write(scratch[:]); err != nil {
+		return err
+	}
+
+	// Defaults to EncrypterTypeNone.
+	var encrypterType EncrypterType
+	if c.ErrorEncrypter != nil {
+		encrypterType = c.ErrorEncrypter.Type()
+	}
+
+	err := binary.Write(w, binary.BigEndian, encrypterType)
+	if err != nil {
+		return err
+	}
+
+	// Skip encoding of error encrypter if this half add does not have one.
+	if encrypterType == EncrypterTypeNone {
+		return nil
+	}
+
+	return c.ErrorEncrypter.Encode(w)
 }
 
-// Add adds a new active payment circuit to the CircuitMap.
-func (cm *CircuitMap) Add(circuit *PaymentCircuit) error {
-	cm.mtx.Lock()
-
-	key := circuitKey{
-		chanID: circuit.OutgoingChanID,
-		htlcID: circuit.OutgoingHTLCID,
+// Decode reads a PaymentCircuit from the provided io.Reader.
+func (c *PaymentCircuit) Decode(r io.Reader) error {
+	if err := c.AddRef.Decode(r); err != nil {
+		return err
 	}
-	cm.circuits[key] = circuit
 
-	// Add circuit to the hash index.
-	if _, ok := cm.hashIndex[circuit.PaymentHash]; !ok {
-		cm.hashIndex[circuit.PaymentHash] = make(map[PaymentCircuit]struct{})
+	if err := c.Incoming.Decode(r); err != nil {
+		return err
 	}
-	cm.hashIndex[circuit.PaymentHash][*circuit] = struct{}{}
 
-	cm.mtx.Unlock()
-	return nil
+	if _, err := io.ReadFull(r, c.PaymentHash[:]); err != nil {
+		return err
+	}
+
+	var scratch [8]byte
+
+	if _, err := io.ReadFull(r, scratch[:]); err != nil {
+		return err
+	}
+	c.IncomingAmount = lnwire.MilliSatoshi(
+		binary.BigEndian.Uint64(scratch[:]))
+
+	if _, err := io.ReadFull(r, scratch[:]); err != nil {
+		return err
+	}
+	c.OutgoingAmount = lnwire.MilliSatoshi(
+		binary.BigEndian.Uint64(scratch[:]))
+
+	// Read the encrypter type used for this circuit.
+	var encrypterType EncrypterType
+	err := binary.Read(r, binary.BigEndian, &encrypterType)
+	if err != nil {
+		return err
+	}
+
+	switch encrypterType {
+	case EncrypterTypeNone:
+		// No encrypter was provided, such as when the payment is
+		// locally initiated.
+		return nil
+
+	case EncrypterTypeSphinx:
+		// Sphinx encrypter was used as this is a forwarded HTLC.
+		c.ErrorEncrypter = NewSphinxErrorEncrypter()
+
+	case EncrypterTypeMock:
+		// Test encrypter.
+		c.ErrorEncrypter = NewMockObfuscator()
+
+	default:
+		return UnknownEncrypterType(encrypterType)
+	}
+
+	return c.ErrorEncrypter.Decode(r)
 }
 
-// Remove destroys the target circuit by removing it from the circuit map.
-func (cm *CircuitMap) Remove(chanID lnwire.ShortChannelID, htlcID uint64) error {
-	cm.mtx.Lock()
-	defer cm.mtx.Unlock()
-
-	// Look up circuit so that pointer can be matched in the hash index.
-	key := circuitKey{
-		chanID: chanID,
-		htlcID: htlcID,
-	}
-	circuit, found := cm.circuits[key]
-	if !found {
-		return errors.Errorf("Can't find circuit for HTLC %v", key)
-	}
-	delete(cm.circuits, key)
-
-	// Remove circuit from hash index.
-	circuitsWithHash, ok := cm.hashIndex[circuit.PaymentHash]
-	if !ok {
-		return errors.Errorf("Can't find circuit in hash index for HTLC %v",
-			key)
-	}
-
-	if _, ok = circuitsWithHash[*circuit]; !ok {
-		return errors.Errorf("Can't find circuit in hash index for HTLC %v",
-			key)
-	}
-
-	delete(circuitsWithHash, *circuit)
-	if len(circuitsWithHash) == 0 {
-		delete(cm.hashIndex, circuit.PaymentHash)
-	}
-	return nil
+// InKey returns the primary identifier for the circuit corresponding to the
+// incoming HTLC.
+func (c *PaymentCircuit) InKey() CircuitKey {
+	return c.Incoming
 }
 
-// pending returns number of circuits which are waiting for to be completed
-// (settle/fail responses to be received).
-func (cm *CircuitMap) pending() int {
-	cm.mtx.RLock()
-	count := len(cm.circuits)
-	cm.mtx.RUnlock()
-	return count
+// OutKey returns the keystone identifying the outgoing link and HTLC ID. If the
+// circuit hasn't been completed, this method returns an EmptyKeystone, which is
+// an invalid outgoing circuit key. Only call this method if HasKeystone returns
+// true.
+func (c *PaymentCircuit) OutKey() CircuitKey {
+	if c.Outgoing != nil {
+		return *c.Outgoing
+	}
+
+	return EmptyCircuitKey
 }

--- a/htlcswitch/circuit_map.go
+++ b/htlcswitch/circuit_map.go
@@ -1,0 +1,846 @@
+package htlcswitch
+
+import (
+	"bytes"
+	"fmt"
+	"sync"
+
+	"github.com/boltdb/bolt"
+	"github.com/go-errors/errors"
+	"github.com/lightningnetwork/lnd/channeldb"
+	"github.com/lightningnetwork/lnd/lnwire"
+)
+
+var (
+	// ErrCorruptedCircuitMap indicates that the on-disk bucketing structure
+	// has altered since the circuit map instance was initialized.
+	ErrCorruptedCircuitMap = errors.New("circuit map has been corrupted")
+
+	// ErrCircuitNotInHashIndex indicates that a particular circuit did not
+	// appear in the in-memory hash index.
+	ErrCircuitNotInHashIndex = errors.New("payment circuit not found in " +
+		"hash index")
+
+	// ErrUnknownCircuit signals that circuit could not be removed from the
+	// map because it was not found.
+	ErrUnknownCircuit = errors.New("unknown payment circuit")
+
+	// ErrCircuitClosing signals that an htlc has already closed this
+	// circuit in-memory.
+	ErrCircuitClosing = errors.New("circuit has already been closed")
+
+	// ErrDuplicateCircuit signals that this circuit was previously
+	// added.
+	ErrDuplicateCircuit = errors.New("duplicate circuit add")
+
+	// ErrUnknownKeystone signals that no circuit was found using the
+	// outgoing circuit key.
+	ErrUnknownKeystone = errors.New("unknown circuit keystone")
+
+	// ErrDuplicateKeystone signals that this circuit was previously
+	// assigned a keystone.
+	ErrDuplicateKeystone = errors.New("cannot add duplicate keystone")
+)
+
+// CircuitModifier is a common interface used by channel links to modify the
+// contents of the circuit map maintained by the switch.
+type CircuitModifier interface {
+	// OpenCircuits preemptively records a batch keystones that will mark
+	// currently pending circuits as open. These changes can be rolled back
+	// on restart if the outgoing Adds do not make it into a commitment txn.
+	OpenCircuits(...Keystone) error
+
+	// TrimOpenCircuits removes a channel's open channels with htlc indexes
+	// above `start`.
+	TrimOpenCircuits(chanID lnwire.ShortChannelID, start uint64) error
+
+	// DeleteCircuits removes the incoming circuit key to remove all
+	// persistent references to a circuit. Returns a ErrUnknownCircuit if
+	// any of the incoming keys are not known.
+	DeleteCircuits(inKeys ...CircuitKey) error
+}
+
+// CircuitFwdActions represents the forwarding decision made by the circuit map,
+// and is returned from CommitCircuits. The sequence of circuits provided to
+// CommitCircuits is split into three subsequences, allowing the caller to do an
+// in-order scan, comparing the head of each subsequence, to determine the
+// decision made by the circuit map.
+type CircuitFwdActions struct {
+	// Adds is the subsequence of circuits that were successfully committed
+	// in the circuit map.
+	Adds []*PaymentCircuit
+
+	// Drops is the subsequence of circuits for which no action should be
+	// done.
+	Drops []*PaymentCircuit
+
+	// Fails is the subsequence of circuits that should be failed back by
+	// the calling link.
+	Fails []*PaymentCircuit
+}
+
+// CircuitMap is an interface for managing the construction and teardown of
+// payment circuits used by the switch.
+type CircuitMap interface {
+	CircuitModifier
+
+	// CommitCircuits attempts to add the given circuits to the circuit
+	// map. The list of circuits is split into three distinct subsequences,
+	// corresponding to adds, drops, and fails. Adds should be forwarded to
+	// the switch, while fails should be failed back locally within the
+	// calling link.
+	CommitCircuits(circuit ...*PaymentCircuit) (*CircuitFwdActions, error)
+
+	// CloseCircuit marks the circuit identified by `outKey` as closing
+	// in-memory, which prevents duplicate settles/fails from completing an
+	// open circuit twice.
+	CloseCircuit(outKey CircuitKey) (*PaymentCircuit, error)
+
+	// FailCircuit is used by locally failed HTLCs to mark the circuit
+	// identified by `inKey` as closing in-memory, which prevents duplicate
+	// settles/fails from being accepted for the same circuit.
+	FailCircuit(inKey CircuitKey) (*PaymentCircuit, error)
+
+	// LookupCircuit queries the circuit map for the circuit identified by
+	// inKey.
+	LookupCircuit(inKey CircuitKey) *PaymentCircuit
+
+	// LookupOpenCircuit queries the circuit map for a circuit identified by
+	// its outgoing circuit key.
+	LookupOpenCircuit(outKey CircuitKey) *PaymentCircuit
+
+	// LookupByPaymentHash queries the circuit map and returns all open
+	// circuits that use the given payment hash.
+	LookupByPaymentHash(hash [32]byte) []*PaymentCircuit
+
+	// NumPending returns the total number of active circuits added by
+	// CommitCircuits.
+	NumPending() int
+
+	// NumOpen returns the number of circuits with HTLCs that have been
+	// forwarded via an outgoing link.
+	NumOpen() int
+}
+
+var (
+	// circuitAddKey is the key used to retrieve the bucket containing
+	// payment circuits. A circuit records information about how to return a
+	// packet to the source link, potentially including an error encrypter
+	// for applying this hop's encryption to the payload in the reverse
+	// direction.
+	circuitAddKey = []byte("circuit-adds")
+
+	// circuitKeystoneKey is used to retrieve the bucket containing circuit
+	// keystones, which are set in place once a forwarded packet is assigned
+	// an index on an outgoing commitment txn.
+	circuitKeystoneKey = []byte("circuit-keystones")
+)
+
+// circuitMap is a data structure that implements thread safe, persistent
+// storage of circuit routing information. The switch consults a circuit map to
+// determine where to forward returning HTLC update messages. Circuits are
+// always identifiable by their incoming CircuitKey, in addition to their
+// outgoing CircuitKey if the circuit is fully-opened.
+type circuitMap struct {
+	// db provides the persistent storage engine for the circuit map.
+	// TODO(conner): create abstraction to allow for the substitution of
+	// other persistence engines.
+	db *channeldb.DB
+
+	mtx sync.RWMutex
+
+	// pending is an in-memory mapping of all half payment circuits, and
+	// is kept in sync with the on-disk contents of the circuit map.
+	pending map[CircuitKey]*PaymentCircuit
+
+	// opened is an in-memory mapping of all full payment circuits, which is
+	// also synchronized with the persistent state of the circuit map.
+	opened map[CircuitKey]*PaymentCircuit
+
+	// closed is an in-memory set of circuits for which the switch has
+	// received a settle or fail. This precedes the actual deletion of a
+	// circuit from disk.
+	closed map[CircuitKey]struct{}
+
+	// hashIndex is a volatile index that facilitates fast queries by
+	// payment hash against the contents of circuits. This index can be
+	// reconstructed entirely from the set of persisted full circuits on
+	// startup.
+	hashIndex map[[32]byte]map[CircuitKey]struct{}
+}
+
+// NewCircuitMap creates a new instance of the circuitMap.
+func NewCircuitMap(db *channeldb.DB) (CircuitMap, error) {
+	cm := &circuitMap{
+		db: db,
+	}
+
+	// Initialize the on-disk buckets used by the circuit map.
+	if err := cm.initBuckets(); err != nil {
+		return nil, err
+	}
+
+	// Load any previously persisted circuit into back into memory.
+	if err := cm.restoreMemState(); err != nil {
+		return nil, err
+	}
+
+	// Trim any keystones that were not committed in an outgoing commit txn.
+	//
+	// NOTE: This operation will be applied to the persistent state of all
+	// active channels. Therefore, it must be called before any links are
+	// created to avoid interfering with normal operation.
+	if err := cm.trimAllOpenCircuits(); err != nil {
+		return nil, err
+	}
+
+	return cm, nil
+}
+
+// initBuckets ensures that the primary buckets used by the circuit are
+// initialized so that we can assume their existence after startup.
+func (cm *circuitMap) initBuckets() error {
+	return cm.db.Update(func(tx *bolt.Tx) error {
+		_, err := tx.CreateBucketIfNotExists(circuitKeystoneKey)
+		if err != nil {
+			return err
+		}
+
+		_, err = tx.CreateBucketIfNotExists(circuitAddKey)
+		return err
+	})
+}
+
+// restoreMemState loads the contents of the half circuit and full circuit buckets
+// from disk and reconstructs the in-memory representation of the circuit map.
+// Afterwards, the state of the hash index is reconstructed using the recovered
+// set of full circuits.
+func (cm *circuitMap) restoreMemState() error {
+
+	var (
+		opened  = make(map[CircuitKey]*PaymentCircuit)
+		pending = make(map[CircuitKey]*PaymentCircuit)
+	)
+
+	if err := cm.db.View(func(tx *bolt.Tx) error {
+		// Restore any of the circuits persisted in the circuit bucket
+		// back into memory.
+		circuitBkt := tx.Bucket(circuitAddKey)
+		if circuitBkt == nil {
+			return ErrCorruptedCircuitMap
+		}
+
+		if err := circuitBkt.ForEach(func(_, v []byte) error {
+			circuit, err := decodeCircuit(v)
+			if err != nil {
+				return err
+			}
+
+			circuit.LoadedFromDisk = true
+			pending[circuit.Incoming] = circuit
+
+			return nil
+		}); err != nil {
+			return err
+		}
+
+		// Furthermore, load the keystone bucket and resurrect the
+		// keystones used in any open circuits.
+		keystoneBkt := tx.Bucket(circuitKeystoneKey)
+		if keystoneBkt == nil {
+			return ErrCorruptedCircuitMap
+		}
+
+		if err := keystoneBkt.ForEach(func(k, v []byte) error {
+			var (
+				inKey  CircuitKey
+				outKey = &CircuitKey{}
+			)
+
+			// Decode the incoming and outgoing circuit keys.
+			if err := inKey.SetBytes(v); err != nil {
+				return err
+			}
+			if err := outKey.SetBytes(k); err != nil {
+				return err
+			}
+
+			// Retrieve the pending circuit, set its keystone, then
+			// add it to the opened map.
+			circuit := pending[inKey]
+			circuit.Outgoing = outKey
+			opened[*outKey] = circuit
+
+			return nil
+		}); err != nil {
+			return err
+		}
+
+		return nil
+
+	}); err != nil {
+		return err
+	}
+
+	cm.pending = pending
+	cm.opened = opened
+	cm.closed = make(map[CircuitKey]struct{})
+
+	// Finally, reconstruct the hash index by running through our set of
+	// open circuits.
+	cm.hashIndex = make(map[[32]byte]map[CircuitKey]struct{})
+	for _, circuit := range opened {
+		cm.addCircuitToHashIndex(circuit)
+	}
+
+	return nil
+}
+
+// decodeCircuit reconstructs an in-memory payment circuit from a byte slice.
+// The byte slice is assumed to have been generated by the circuit's Encode
+// method.
+func decodeCircuit(v []byte) (*PaymentCircuit, error) {
+	var circuit = &PaymentCircuit{}
+
+	circuitReader := bytes.NewReader(v)
+	if err := circuit.Decode(circuitReader); err != nil {
+		return nil, err
+	}
+
+	return circuit, nil
+}
+
+// trimAllOpenCircuits reads the set of active channels from disk and trims
+// keystones for any non-pending channels. This method is intended to be called
+// on startup. Each link will also trim it's own circuits upon startup.
+//
+// NOTE: This operation will be applied to the persistent state of all active
+// channels. Therefore, it must be called before any links are created to avoid
+// interfering with normal operation.
+func (cm *circuitMap) trimAllOpenCircuits() error {
+	activeChannels, err := cm.db.FetchAllChannels()
+	if err != nil {
+		return err
+	}
+
+	for _, activeChannel := range activeChannels {
+		if activeChannel.IsPending {
+			continue
+		}
+
+		chanID := activeChannel.ShortChanID
+		start := activeChannel.LocalCommitment.LocalHtlcIndex
+		if err := cm.TrimOpenCircuits(chanID, start); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// TrimOpenCircuits removes a channel's keystones above the short chan id's
+// highest committed htlc index. This has the effect of returning those circuits
+// to a half-open state. Since opening of circuits is done in advance of
+// actually committing the Add htlcs into a commitment txn, this allows circuits
+// to be opened preemetively, since we can roll them back after any failures.
+func (cm *circuitMap) TrimOpenCircuits(chanID lnwire.ShortChannelID,
+	start uint64) error {
+
+	var trimmedOutKeys []CircuitKey
+
+	// Scan forward from the last unacked htlc id, stopping as soon as we
+	// don't find any more. Outgoing htlc id's must be assigned in order, so
+	// there should never be disjoint segments of keystones to trim.
+	cm.mtx.Lock()
+	for i := start; ; i++ {
+		outKey := CircuitKey{
+			ChanID: chanID,
+			HtlcID: i,
+		}
+
+		circuit, ok := cm.opened[outKey]
+		if !ok {
+			break
+		}
+
+		circuit.Outgoing = nil
+		delete(cm.opened, outKey)
+		trimmedOutKeys = append(trimmedOutKeys, outKey)
+		cm.removeCircuitFromHashIndex(circuit)
+	}
+	cm.mtx.Unlock()
+
+	if len(trimmedOutKeys) == 0 {
+		return nil
+	}
+
+	return cm.db.Update(func(tx *bolt.Tx) error {
+		keystoneBkt := tx.Bucket(circuitKeystoneKey)
+		if keystoneBkt == nil {
+			return ErrCorruptedCircuitMap
+		}
+
+		for _, outKey := range trimmedOutKeys {
+			err := keystoneBkt.Delete(outKey.Bytes())
+			if err != nil {
+				return err
+			}
+		}
+
+		return nil
+	})
+}
+
+// LookupByHTLC looks up the payment circuit by the outgoing channel and HTLC
+// IDs. Returns nil if there is no such circuit.
+func (cm *circuitMap) LookupCircuit(inKey CircuitKey) *PaymentCircuit {
+	cm.mtx.RLock()
+	defer cm.mtx.RUnlock()
+
+	return cm.pending[inKey]
+}
+
+// LookupOpenCircuit searches for the circuit identified by its outgoing circuit
+// key.
+func (cm *circuitMap) LookupOpenCircuit(outKey CircuitKey) *PaymentCircuit {
+	cm.mtx.RLock()
+	defer cm.mtx.RUnlock()
+
+	return cm.opened[outKey]
+}
+
+// LookupByPaymentHash looks up and returns any payment circuits with a given
+// payment hash.
+func (cm *circuitMap) LookupByPaymentHash(hash [32]byte) []*PaymentCircuit {
+	cm.mtx.RLock()
+	defer cm.mtx.RUnlock()
+
+	var circuits []*PaymentCircuit
+	if circuitSet, ok := cm.hashIndex[hash]; ok {
+		// Iterate over the outgoing circuit keys found with this hash,
+		// and retrieve the circuit from the opened map.
+		circuits = make([]*PaymentCircuit, 0, len(circuitSet))
+		for key := range circuitSet {
+			if circuit, ok := cm.opened[key]; ok {
+				circuits = append(circuits, circuit)
+			}
+		}
+	}
+
+	return circuits
+}
+
+// CommitCircuits accepts any number of circuits and persistently adds them to
+// the switch's circuit map. The method returns a list of circuits that had not
+// been seen prior by the switch. A link should only forward HTLCs corresponding
+// to the returned circuits to the switch.
+//
+// NOTE: This method uses batched writes to improve performance, gains will only
+// be realized if it is called concurrently from separate goroutines.
+func (cm *circuitMap) CommitCircuits(circuits ...*PaymentCircuit) (
+	*CircuitFwdActions, error) {
+
+	actions := &CircuitFwdActions{}
+
+	// If an empty list was passed, return early to avoid grabbing the lock.
+	if len(circuits) == 0 {
+		return actions, nil
+	}
+
+	// First, we reconcile the provided circuits with our set of pending
+	// circuits to construct a set of new circuits that need to be written
+	// to disk. The circuit's pointer is stored so that we only permit this
+	// exact circuit to be forwarded through the switch. If a circuit is
+	// already pending, the htlc will be reforwarded by the switch.
+	//
+	// NOTE: We track an additional addFails subsequence, which permits us
+	// to fail back all packets that weren't dropped if we encounter an
+	// error when committing the circuits.
+	cm.mtx.Lock()
+	var adds, drops, fails, addFails []*PaymentCircuit
+	for _, circuit := range circuits {
+		inKey := circuit.InKey()
+		if foundCircuit, ok := cm.pending[inKey]; ok {
+			switch {
+
+			// This circuit has a keystone, it's waiting for a
+			// response from the remote peer on the outgoing link.
+			// Drop it like it's hot, ensure duplicates get caught.
+			case foundCircuit.HasKeystone():
+				drops = append(drops, circuit)
+
+			// If no keystone is set and the switch has not been
+			// restarted, the corresponding packet should still be
+			// in the outgoing link's mailbox. It will be delivered
+			// if it comes online before the switch goes down.
+			//
+			// NOTE: Dropping here prevents a flapping, incoming
+			// link from failing a duplicate add while it is still
+			// in the server's memory mailboxes.
+			case !foundCircuit.LoadedFromDisk:
+				drops = append(drops, circuit)
+
+			// Otherwise, the in-mem packet has been lost due to a
+			// restart. It is now safe to send back a failure along
+			// the incoming link. The incoming link should be able
+			// detect and ignore duplicate packets of this type.
+			default:
+				fails = append(fails, circuit)
+				addFails = append(addFails, circuit)
+			}
+
+			continue
+		}
+
+		cm.pending[inKey] = circuit
+		adds = append(adds, circuit)
+		addFails = append(addFails, circuit)
+	}
+	cm.mtx.Unlock()
+
+	// If all circuits are dropped or failed, we are done.
+	if len(adds) == 0 {
+		actions.Drops = drops
+		actions.Fails = fails
+		return actions, nil
+	}
+
+	// Now, optimistically serialize the circuits to add.
+	var bs = make([]bytes.Buffer, len(adds))
+	for i, circuit := range adds {
+		if err := circuit.Encode(&bs[i]); err != nil {
+			actions.Drops = drops
+			actions.Fails = addFails
+			return actions, err
+		}
+	}
+
+	// Write the entire batch of circuits to the persistent circuit bucket
+	// using bolt's Batch write. This method must be called from multiple,
+	// distinct goroutines to have any impact on performance.
+	err := cm.db.Batch(func(tx *bolt.Tx) error {
+		circuitBkt := tx.Bucket(circuitAddKey)
+		if circuitBkt == nil {
+			return ErrCorruptedCircuitMap
+		}
+
+		for i, circuit := range adds {
+			inKeyBytes := circuit.InKey().Bytes()
+			circuitBytes := bs[i].Bytes()
+
+			err := circuitBkt.Put(inKeyBytes, circuitBytes)
+			if err != nil {
+				return err
+			}
+		}
+
+		return nil
+	})
+
+	// Return if the write succeeded.
+	if err == nil {
+		actions.Adds = adds
+		actions.Drops = drops
+		actions.Fails = fails
+		return actions, nil
+	}
+
+	// Otherwise, rollback the circuits added to the pending set if the
+	// write failed.
+	cm.mtx.Lock()
+	for _, circuit := range adds {
+		delete(cm.pending, circuit.InKey())
+	}
+	cm.mtx.Unlock()
+
+	// Since our write failed, we will return the dropped packets and mark
+	// all other circuits as failed.
+	actions.Drops = drops
+	actions.Fails = addFails
+
+	return actions, err
+}
+
+// Keystone is a tuple binding an incoming and outgoing CircuitKey. Keystones
+// are preemptively written by an outgoing link before signing a new commitment
+// state, and cements which HTLCs we are awaiting a response from a remote peer.
+type Keystone struct {
+	InKey  CircuitKey
+	OutKey CircuitKey
+}
+
+// String returns a human readable description of the Keystone.
+func (k *Keystone) String() string {
+	return fmt.Sprintf("%s --> %s", k.InKey, k.OutKey)
+}
+
+// OpenCircuits sets the outgoing circuit key for the circuit identified by
+// inKey, persistently marking the circuit as opened. After the changes have
+// been persisted, the circuit map's in-memory indexes are updated so that this
+// circuit can be queried using LookupByKeystone or LookupByPaymentHash.
+func (cm *circuitMap) OpenCircuits(keystones ...Keystone) error {
+	if len(keystones) == 0 {
+		return nil
+	}
+
+	// Check that all keystones correspond to committed-but-unopened
+	// circuits.
+	cm.mtx.RLock()
+	openedCircuits := make([]*PaymentCircuit, 0, len(keystones))
+	for _, ks := range keystones {
+		if _, ok := cm.opened[ks.OutKey]; ok {
+			cm.mtx.RUnlock()
+			return ErrDuplicateKeystone
+		}
+
+		circuit, ok := cm.pending[ks.InKey]
+		if !ok {
+			cm.mtx.RUnlock()
+			return ErrUnknownCircuit
+		}
+
+		openedCircuits = append(openedCircuits, circuit)
+	}
+	cm.mtx.RUnlock()
+
+	err := cm.db.Update(func(tx *bolt.Tx) error {
+		// Now, load the circuit bucket to which we will write the
+		// already serialized circuit.
+		keystoneBkt := tx.Bucket(circuitKeystoneKey)
+		if keystoneBkt == nil {
+			return ErrCorruptedCircuitMap
+		}
+
+		for _, ks := range keystones {
+			outBytes := ks.OutKey.Bytes()
+			inBytes := ks.InKey.Bytes()
+			err := keystoneBkt.Put(outBytes, inBytes)
+			if err != nil {
+				return err
+			}
+		}
+
+		return nil
+	})
+
+	if err != nil {
+		return err
+	}
+
+	cm.mtx.Lock()
+	for i, circuit := range openedCircuits {
+		ks := keystones[i]
+
+		// Since our persistent operation was successful, we can now
+		// modify the in memory representations. Set the outgoing
+		// circuit key on our pending circuit, add the same circuit to
+		// set of opened circuits, and add this circuit to the hash
+		// index.
+		circuit.Outgoing = &CircuitKey{}
+		*circuit.Outgoing = ks.OutKey
+
+		cm.opened[ks.OutKey] = circuit
+		cm.addCircuitToHashIndex(circuit)
+	}
+	cm.mtx.Unlock()
+
+	return nil
+}
+
+// addCirciutToHashIndex inserts a circuit into the circuit map's hash index, so
+// that it can be queried using LookupByPaymentHash.
+func (cm *circuitMap) addCircuitToHashIndex(c *PaymentCircuit) {
+	if _, ok := cm.hashIndex[c.PaymentHash]; !ok {
+		cm.hashIndex[c.PaymentHash] = make(map[CircuitKey]struct{})
+	}
+	cm.hashIndex[c.PaymentHash][c.OutKey()] = struct{}{}
+}
+
+// FailCircuit marks the circuit identified by `inKey` as closing in-memory,
+// which prevents duplicate settles/fails from completing an open circuit twice.
+func (cm *circuitMap) FailCircuit(
+	inKey CircuitKey) (*PaymentCircuit, error) {
+
+	cm.mtx.Lock()
+	defer cm.mtx.Unlock()
+
+	circuit, ok := cm.pending[inKey]
+	if !ok {
+		return nil, ErrUnknownCircuit
+	}
+
+	_, ok = cm.closed[inKey]
+	if ok {
+		return nil, ErrCircuitClosing
+	}
+
+	cm.closed[inKey] = struct{}{}
+
+	return circuit, nil
+}
+
+// CloseCircuit marks the circuit identified by `outKey` as closing
+// in-memory, which prevents duplicate settles/fails from completing an open
+// circuit twice.
+func (cm *circuitMap) CloseCircuit(
+	outKey CircuitKey) (*PaymentCircuit, error) {
+
+	cm.mtx.Lock()
+	defer cm.mtx.Unlock()
+
+	circuit, ok := cm.opened[outKey]
+	if !ok {
+		return nil, ErrUnknownCircuit
+	}
+
+	_, ok = cm.closed[circuit.Incoming]
+	if ok {
+		return nil, ErrCircuitClosing
+	}
+
+	cm.closed[circuit.Incoming] = struct{}{}
+
+	return circuit, nil
+}
+
+// DeleteCircuits destroys the target circuit by removing it from the circuit map,
+// additionally removing the circuit's keystone if the HTLC was forwarded
+// through an outgoing link. The circuit should be identified by its incoming
+// circuit key.
+func (cm *circuitMap) DeleteCircuits(inKeys ...CircuitKey) error {
+
+	var (
+		closingCircuits = make(map[CircuitKey]struct{})
+		removedCircuits = make(map[CircuitKey]*PaymentCircuit)
+	)
+
+	cm.mtx.Lock()
+	// First check that all provided keys are still known to the circuit
+	// map.
+	for _, inKey := range inKeys {
+		if _, ok := cm.pending[inKey]; !ok {
+			cm.mtx.Unlock()
+			return ErrUnknownCircuit
+		}
+	}
+
+	// If no offenders were found, remove any references to the circuit from
+	// memory, keeping track of which circuits were removed, and which ones
+	// had been marked closed. This can be used to restore these entries
+	// later if the persistent removal fails.
+	for _, inKey := range inKeys {
+		circuit := cm.pending[inKey]
+
+		delete(cm.pending, inKey)
+
+		if _, ok := cm.closed[inKey]; ok {
+			closingCircuits[inKey] = struct{}{}
+			delete(cm.closed, inKey)
+		}
+
+		if circuit.HasKeystone() {
+			delete(cm.opened, circuit.OutKey())
+			cm.removeCircuitFromHashIndex(circuit)
+		}
+
+		removedCircuits[inKey] = circuit
+	}
+	cm.mtx.Unlock()
+
+	err := cm.db.Batch(func(tx *bolt.Tx) error {
+		for _, circuit := range removedCircuits {
+			// If this htlc made it to an outgoing link, load the
+			// keystone bucket from which we will remove the
+			// outgoing circuit key.
+			if circuit.HasKeystone() {
+				keystoneBkt := tx.Bucket(circuitKeystoneKey)
+				if keystoneBkt == nil {
+					return ErrCorruptedCircuitMap
+				}
+
+				outKey := circuit.OutKey()
+
+				err := keystoneBkt.Delete(outKey.Bytes())
+				if err != nil {
+					return err
+				}
+			}
+
+			// Remove the circuit itself based on the incoming
+			// circuit key.
+			circuitBkt := tx.Bucket(circuitAddKey)
+			if circuitBkt == nil {
+				return ErrCorruptedCircuitMap
+			}
+
+			inKey := circuit.InKey()
+			if err := circuitBkt.Delete(inKey.Bytes()); err != nil {
+				return err
+			}
+		}
+
+		return nil
+	})
+
+	// Return if the write succeeded.
+	if err == nil {
+		return nil
+	}
+
+	// If the persistent changes failed, restore the circuit map to it's
+	// previous state.
+	cm.mtx.Lock()
+	for inKey, circuit := range removedCircuits {
+		cm.pending[inKey] = circuit
+
+		if _, ok := closingCircuits[inKey]; ok {
+			cm.closed[inKey] = struct{}{}
+		}
+
+		if circuit.HasKeystone() {
+			cm.opened[circuit.OutKey()] = circuit
+			cm.addCircuitToHashIndex(circuit)
+		}
+	}
+	cm.mtx.Unlock()
+
+	return err
+}
+
+// removeCircuitFromHashIndex removes the given circuit from the hash index,
+// pruning any unnecessary memory optimistically.
+func (cm *circuitMap) removeCircuitFromHashIndex(c *PaymentCircuit) {
+	// Locate bucket containing this circuit's payment hashes.
+	circuitsWithHash, ok := cm.hashIndex[c.PaymentHash]
+	if !ok {
+		return
+	}
+
+	outKey := c.OutKey()
+
+	// Remove this circuit from the set of circuitsWithHash.
+	delete(circuitsWithHash, outKey)
+
+	// Prune the payment hash bucket if no other entries remain.
+	if len(circuitsWithHash) == 0 {
+		delete(cm.hashIndex, c.PaymentHash)
+	}
+}
+
+// NumPending returns the number of active circuits added to the circuit map.
+func (cm *circuitMap) NumPending() int {
+	cm.mtx.RLock()
+	defer cm.mtx.RUnlock()
+
+	return len(cm.pending)
+}
+
+// NumOpen returns the number of circuits that have been opened by way of
+// setting their keystones. This is the number of HTLCs that are waiting for a
+// settle/fail response from a remote peer.
+func (cm *circuitMap) NumOpen() int {
+	cm.mtx.RLock()
+	defer cm.mtx.RUnlock()
+
+	return len(cm.opened)
+}

--- a/htlcswitch/circuit_test.go
+++ b/htlcswitch/circuit_test.go
@@ -1,155 +1,1312 @@
 package htlcswitch_test
 
 import (
+	"bytes"
+	"io/ioutil"
+	"reflect"
 	"testing"
 
+	"github.com/lightningnetwork/lnd/channeldb"
 	"github.com/lightningnetwork/lnd/htlcswitch"
 	"github.com/lightningnetwork/lnd/lnwire"
+	"github.com/roasbeef/btcutil"
 )
 
-func TestCircuitMap(t *testing.T) {
+var (
+	hash1 = [32]byte{0x01}
+	hash2 = [32]byte{0x02}
+	hash3 = [32]byte{0x03}
+)
+
+func TestCircuitMapInit(t *testing.T) {
 	t.Parallel()
 
-	var hash1, hash2, hash3 [32]byte
-	hash1[0] = 1
-	hash2[0] = 2
-	hash3[0] = 3
+	// Initialize new database for circuit map.
+	cdb := makeCircuitDB(t, "")
+	_, err := htlcswitch.NewCircuitMap(cdb)
+	if err != nil {
+		t.Fatalf("unable to create persistent circuit map: %v", err)
+	}
+
+	restartCircuitMap(t, cdb)
+}
+
+var halfCircuitTests = []struct {
+	hash      [32]byte
+	inValue   btcutil.Amount
+	outValue  btcutil.Amount
+	chanID    lnwire.ShortChannelID
+	htlcID    uint64
+	encrypter htlcswitch.ErrorEncrypter
+}{
+	{
+		hash:      hash1,
+		inValue:   0,
+		outValue:  1000,
+		chanID:    lnwire.NewShortChanIDFromInt(1),
+		htlcID:    1,
+		encrypter: nil,
+	},
+	{
+		hash:      hash2,
+		inValue:   2100,
+		outValue:  2000,
+		chanID:    lnwire.NewShortChanIDFromInt(2),
+		htlcID:    2,
+		encrypter: htlcswitch.NewMockObfuscator(),
+	},
+	{
+		hash:      hash3,
+		inValue:   10000,
+		outValue:  9000,
+		chanID:    lnwire.NewShortChanIDFromInt(3),
+		htlcID:    3,
+		encrypter: htlcswitch.NewSphinxErrorEncrypter(),
+	},
+}
+
+// TestHalfCircuitSerialization checks that the half circuits can be properly
+// encoded and decoded properly. A critical responsibility of this test is to
+// verify that the various ErrorEncrypter implementations can be properly
+// reconstructed from a serialized half circuit.
+func TestHalfCircuitSerialization(t *testing.T) {
+	t.Parallel()
+
+	for i, test := range halfCircuitTests {
+		circuit := &htlcswitch.PaymentCircuit{
+			PaymentHash:    test.hash,
+			IncomingAmount: lnwire.NewMSatFromSatoshis(test.inValue),
+			OutgoingAmount: lnwire.NewMSatFromSatoshis(test.outValue),
+			Incoming: htlcswitch.CircuitKey{
+				ChanID: test.chanID,
+				HtlcID: test.htlcID,
+			},
+			ErrorEncrypter: test.encrypter,
+		}
+
+		// Write the half circuit to our buffer.
+		var b bytes.Buffer
+		if err := circuit.Encode(&b); err != nil {
+			t.Fatalf("unable to encode half payment circuit test=%d: %v", i, err)
+		}
+
+		// Then try to decode the serialized bytes.
+		var circuit2 htlcswitch.PaymentCircuit
+		circuitReader := bytes.NewReader(b.Bytes())
+		if err := circuit2.Decode(circuitReader); err != nil {
+			t.Fatalf("unable to decode half payment circuit test=%d: %v", i, err)
+		}
+
+		// Reconstructed half circuit should match the original.
+		if !equalIgnoreLFD(circuit, &circuit2) {
+			t.Fatalf("unexpected half circuit test=%d, want %v, got %v",
+				i, circuit, circuit2)
+		}
+	}
+}
+
+func TestCircuitMapPersistence(t *testing.T) {
+	t.Parallel()
 
 	var (
-		chan1 = lnwire.NewShortChanIDFromInt(1)
-		chan2 = lnwire.NewShortChanIDFromInt(2)
+		chan1      = lnwire.NewShortChanIDFromInt(1)
+		chan2      = lnwire.NewShortChanIDFromInt(2)
+		circuitMap htlcswitch.CircuitMap
+		err        error
 	)
 
-	circuitMap := htlcswitch.NewCircuitMap()
+	cdb := makeCircuitDB(t, "")
+	circuitMap, err = htlcswitch.NewCircuitMap(cdb)
+	if err != nil {
+		t.Fatalf("unable to create persistent circuit map: %v", err)
+	}
 
-	circuit := circuitMap.LookupByHTLC(chan1, 0)
+	circuit := circuitMap.LookupCircuit(htlcswitch.CircuitKey{chan1, 0})
 	if circuit != nil {
 		t.Fatalf("LookupByHTLC returned a circuit before any were added: %v",
 			circuit)
 	}
 
+	circuit1 := &htlcswitch.PaymentCircuit{
+		Incoming: htlcswitch.CircuitKey{
+			ChanID: chan2,
+			HtlcID: 1,
+		},
+		PaymentHash:    hash1,
+		ErrorEncrypter: htlcswitch.NewMockObfuscator(),
+	}
+	if _, err := circuitMap.CommitCircuits(circuit1); err != nil {
+		t.Fatalf("unable to add half circuit: %v", err)
+	}
+
+	// Circuit map should have one circuit that has not been fully opened.
+	assertNumCircuitsWithHash(t, circuitMap, hash1, 0)
+	assertHasCircuit(t, circuitMap, circuit1)
+
+	cdb, circuitMap = restartCircuitMap(t, cdb)
+
+	assertNumCircuitsWithHash(t, circuitMap, hash1, 0)
+	assertHasCircuit(t, circuitMap, circuit1)
+
 	// Add multiple circuits with same destination channel but different HTLC
 	// IDs and payment hashes.
-	circuitMap.Add(&htlcswitch.PaymentCircuit{
-		PaymentHash:    hash1,
-		IncomingChanID: chan2,
-		IncomingHTLCID: 1,
-		OutgoingChanID: chan1,
-		OutgoingHTLCID: 0,
-	})
+	keystone1 := htlcswitch.Keystone{
+		InKey: circuit1.Incoming,
+		OutKey: htlcswitch.CircuitKey{
+			ChanID: chan1,
+			HtlcID: 0,
+		},
+	}
+	circuit1.Outgoing = &keystone1.OutKey
+	if err := circuitMap.OpenCircuits(keystone1); err != nil {
+		t.Fatalf("unable to add full circuit: %v", err)
+	}
 
-	circuitMap.Add(&htlcswitch.PaymentCircuit{
+	// Circuit map should reflect addition of circuit1, and the change
+	// should survive a restart.
+	assertNumCircuitsWithHash(t, circuitMap, hash1, 1)
+	assertHasCircuit(t, circuitMap, circuit1)
+	assertHasKeystone(t, circuitMap, keystone1.OutKey, circuit1)
+
+	cdb, circuitMap = restartCircuitMap(t, cdb)
+
+	assertNumCircuitsWithHash(t, circuitMap, hash1, 1)
+	assertHasCircuit(t, circuitMap, circuit1)
+	assertHasKeystone(t, circuitMap, keystone1.OutKey, circuit1)
+
+	circuit2 := &htlcswitch.PaymentCircuit{
+		Incoming: htlcswitch.CircuitKey{
+			ChanID: chan2,
+			HtlcID: 2,
+		},
 		PaymentHash:    hash2,
-		IncomingChanID: chan2,
-		IncomingHTLCID: 2,
-		OutgoingChanID: chan1,
-		OutgoingHTLCID: 1,
-	})
+		ErrorEncrypter: htlcswitch.NewMockObfuscator(),
+	}
+	if _, err := circuitMap.CommitCircuits(circuit2); err != nil {
+		t.Fatalf("unable to add half circuit: %v", err)
+	}
+
+	assertHasCircuit(t, circuitMap, circuit2)
+
+	keystone2 := htlcswitch.Keystone{
+		InKey: circuit2.Incoming,
+		OutKey: htlcswitch.CircuitKey{
+			ChanID: chan1,
+			HtlcID: 1,
+		},
+	}
+	circuit2.Outgoing = &keystone2.OutKey
+	if err := circuitMap.OpenCircuits(keystone2); err != nil {
+		t.Fatalf("unable to add full circuit: %v", err)
+	}
+
+	// Should have two full circuits, one under hash1 and another under
+	// hash2. Both half payment circuits should have been removed when the
+	// full circuits were added.
+	assertNumCircuitsWithHash(t, circuitMap, hash1, 1)
+	assertHasCircuit(t, circuitMap, circuit1)
+	assertHasKeystone(t, circuitMap, keystone1.OutKey, circuit1)
+
+	assertNumCircuitsWithHash(t, circuitMap, hash2, 1)
+	assertHasCircuit(t, circuitMap, circuit2)
+	assertHasKeystone(t, circuitMap, keystone2.OutKey, circuit2)
+
+	assertNumCircuitsWithHash(t, circuitMap, hash3, 0)
+
+	cdb, circuitMap = restartCircuitMap(t, cdb)
+
+	assertNumCircuitsWithHash(t, circuitMap, hash1, 1)
+	assertHasCircuit(t, circuitMap, circuit1)
+	assertHasKeystone(t, circuitMap, keystone1.OutKey, circuit1)
+
+	assertNumCircuitsWithHash(t, circuitMap, hash2, 1)
+	assertHasCircuit(t, circuitMap, circuit2)
+	assertHasKeystone(t, circuitMap, keystone2.OutKey, circuit2)
+
+	assertNumCircuitsWithHash(t, circuitMap, hash3, 0)
+
+	circuit3 := &htlcswitch.PaymentCircuit{
+		Incoming: htlcswitch.CircuitKey{
+			ChanID: chan1,
+			HtlcID: 2,
+		},
+		PaymentHash:    hash3,
+		ErrorEncrypter: htlcswitch.NewMockObfuscator(),
+	}
+	if _, err := circuitMap.CommitCircuits(circuit3); err != nil {
+		t.Fatalf("unable to add half circuit: %v", err)
+	}
+
+	assertHasCircuit(t, circuitMap, circuit3)
+	cdb, circuitMap = restartCircuitMap(t, cdb)
+	assertHasCircuit(t, circuitMap, circuit3)
 
 	// Add another circuit with an already-used HTLC ID but different
 	// destination channel.
-	circuitMap.Add(&htlcswitch.PaymentCircuit{
-		PaymentHash:    hash3,
-		IncomingChanID: chan1,
-		IncomingHTLCID: 2,
-		OutgoingChanID: chan2,
-		OutgoingHTLCID: 0,
-	})
-
-	circuit = circuitMap.LookupByHTLC(chan1, 0)
-	if circuit == nil {
-		t.Fatal("LookupByHTLC failed to find circuit")
+	keystone3 := htlcswitch.Keystone{
+		InKey: circuit3.Incoming,
+		OutKey: htlcswitch.CircuitKey{
+			ChanID: chan2,
+			HtlcID: 0,
+		},
 	}
-	if circuit.PaymentHash != hash1 || circuit.IncomingHTLCID != 1 {
-		t.Fatalf("LookupByHTLC found unexpected circuit: %v", circuit)
+	circuit3.Outgoing = &keystone3.OutKey
+	if err := circuitMap.OpenCircuits(keystone3); err != nil {
+		t.Fatalf("unable to add full circuit: %v", err)
 	}
 
-	circuit = circuitMap.LookupByHTLC(chan1, 1)
-	if circuit == nil {
-		t.Fatal("LookupByHTLC failed to find circuit")
-	}
-	if circuit.PaymentHash != hash2 || circuit.IncomingHTLCID != 2 {
-		t.Fatalf("LookupByHTLC found unexpected circuit: %v", circuit)
-	}
+	// Check that all have been marked as full circuits, and that no half
+	// circuits are currently being tracked.
+	assertHasKeystone(t, circuitMap, keystone1.OutKey, circuit1)
+	assertHasKeystone(t, circuitMap, keystone2.OutKey, circuit2)
+	assertHasKeystone(t, circuitMap, keystone3.OutKey, circuit3)
+	cdb, circuitMap = restartCircuitMap(t, cdb)
+	assertHasKeystone(t, circuitMap, keystone1.OutKey, circuit1)
+	assertHasKeystone(t, circuitMap, keystone2.OutKey, circuit2)
+	assertHasKeystone(t, circuitMap, keystone3.OutKey, circuit3)
 
-	circuit = circuitMap.LookupByHTLC(chan2, 0)
-	if circuit == nil {
-		t.Fatal("LookupByHTLC failed to find circuit")
+	// Even though a circuit was added with chan1, HTLC ID 2 as the source,
+	// the lookup should go by destination channel, HTLC ID.
+	invalidKeystone := htlcswitch.CircuitKey{
+		ChanID: chan1,
+		HtlcID: 2,
 	}
-	if circuit.PaymentHash != hash3 || circuit.IncomingHTLCID != 2 {
-		t.Fatalf("LookupByHTLC found unexpected circuit: %v", circuit)
-	}
-
-	// Even though a circuit was added with chan1, HTLC ID 2 as the source, the
-	// lookup should go by destination channel, HTLC ID.
-	circuit = circuitMap.LookupByHTLC(chan1, 2)
+	circuit = circuitMap.LookupOpenCircuit(invalidKeystone)
 	if circuit != nil {
 		t.Fatalf("LookupByHTLC returned a circuit without being added: %v",
 			circuit)
 	}
 
+	circuit4 := &htlcswitch.PaymentCircuit{
+		Incoming: htlcswitch.CircuitKey{
+			ChanID: chan2,
+			HtlcID: 3,
+		},
+		PaymentHash:    hash1,
+		ErrorEncrypter: htlcswitch.NewMockObfuscator(),
+	}
+	if _, err := circuitMap.CommitCircuits(circuit4); err != nil {
+		t.Fatalf("unable to add half circuit: %v", err)
+	}
+
+	// Circuit map should still only show one circuit with hash1, since we
+	// have not set the keystone for circuit4.
+	assertNumCircuitsWithHash(t, circuitMap, hash1, 1)
+	assertHasCircuit(t, circuitMap, circuit4)
+
+	cdb, circuitMap = restartCircuitMap(t, cdb)
+
+	assertNumCircuitsWithHash(t, circuitMap, hash1, 1)
+	assertHasCircuit(t, circuitMap, circuit4)
+
 	// Add a circuit with a destination channel and payment hash that are
 	// already added but a different HTLC ID.
-	circuitMap.Add(&htlcswitch.PaymentCircuit{
-		PaymentHash:    hash1,
-		IncomingChanID: chan2,
-		IncomingHTLCID: 3,
-		OutgoingChanID: chan1,
-		OutgoingHTLCID: 3,
-	})
-
-	circuit = circuitMap.LookupByHTLC(chan1, 3)
-	if circuit == nil {
-		t.Fatal("LookupByHTLC failed to find circuit")
+	keystone4 := htlcswitch.Keystone{
+		InKey: circuit4.Incoming,
+		OutKey: htlcswitch.CircuitKey{
+			ChanID: chan1,
+			HtlcID: 3,
+		},
 	}
-	if circuit.PaymentHash != hash1 || circuit.IncomingHTLCID != 3 {
-		t.Fatalf("LookupByHTLC found unexpected circuit: %v", circuit)
+	circuit4.Outgoing = &keystone4.OutKey
+	if err := circuitMap.OpenCircuits(keystone4); err != nil {
+		t.Fatalf("unable to add full circuit: %v", err)
 	}
 
-	// Check lookups by payment hash.
-	circuits := circuitMap.LookupByPaymentHash(hash1)
-	if len(circuits) != 2 {
-		t.Fatalf("LookupByPaymentHash returned wrong number of circuits for "+
-			"hash1: expected %d, got %d", 2, len(circuits))
-	}
+	// Verify that all circuits have been fully added.
+	assertHasCircuit(t, circuitMap, circuit1)
+	assertHasKeystone(t, circuitMap, keystone1.OutKey, circuit1)
+	assertHasCircuit(t, circuitMap, circuit2)
+	assertHasKeystone(t, circuitMap, keystone2.OutKey, circuit2)
+	assertHasCircuit(t, circuitMap, circuit3)
+	assertHasKeystone(t, circuitMap, keystone3.OutKey, circuit3)
+	assertHasCircuit(t, circuitMap, circuit4)
+	assertHasKeystone(t, circuitMap, keystone4.OutKey, circuit4)
 
-	circuits = circuitMap.LookupByPaymentHash(hash2)
-	if len(circuits) != 1 {
-		t.Fatalf("LookupByPaymentHash returned wrong number of circuits for "+
-			"hash2: expected %d, got %d", 1, len(circuits))
-	}
+	// Verify that each circuit is exposed via the proper hash bucketing.
+	assertNumCircuitsWithHash(t, circuitMap, hash1, 2)
+	assertHasCircuitForHash(t, circuitMap, hash1, circuit1)
+	assertHasCircuitForHash(t, circuitMap, hash1, circuit4)
+
+	assertNumCircuitsWithHash(t, circuitMap, hash2, 1)
+	assertHasCircuitForHash(t, circuitMap, hash2, circuit2)
+
+	assertNumCircuitsWithHash(t, circuitMap, hash3, 1)
+	assertHasCircuitForHash(t, circuitMap, hash3, circuit3)
+
+	// Restart, then run checks again.
+	cdb, circuitMap = restartCircuitMap(t, cdb)
+
+	// Verify that all circuits have been fully added.
+	assertHasCircuit(t, circuitMap, circuit1)
+	assertHasKeystone(t, circuitMap, keystone1.OutKey, circuit1)
+	assertHasCircuit(t, circuitMap, circuit2)
+	assertHasKeystone(t, circuitMap, keystone2.OutKey, circuit2)
+	assertHasCircuit(t, circuitMap, circuit3)
+	assertHasKeystone(t, circuitMap, keystone3.OutKey, circuit3)
+	assertHasCircuit(t, circuitMap, circuit4)
+	assertHasKeystone(t, circuitMap, keystone4.OutKey, circuit4)
+
+	// Verify that each circuit is exposed via the proper hash bucketing.
+	assertNumCircuitsWithHash(t, circuitMap, hash1, 2)
+	assertHasCircuitForHash(t, circuitMap, hash1, circuit1)
+	assertHasCircuitForHash(t, circuitMap, hash1, circuit4)
+
+	assertNumCircuitsWithHash(t, circuitMap, hash2, 1)
+	assertHasCircuitForHash(t, circuitMap, hash2, circuit2)
+
+	assertNumCircuitsWithHash(t, circuitMap, hash3, 1)
+	assertHasCircuitForHash(t, circuitMap, hash3, circuit3)
 
 	// Test removing circuits and the subsequent lookups.
-	err := circuitMap.Remove(chan1, 0)
+	err = circuitMap.DeleteCircuits(circuit1.Incoming)
 	if err != nil {
 		t.Fatalf("Remove returned unexpected error: %v", err)
 	}
 
-	circuits = circuitMap.LookupByPaymentHash(hash1)
-	if len(circuits) != 1 {
-		t.Fatalf("LookupByPaymentHash returned wrong number of circuits for "+
-			"hash1: expecected %d, got %d", 1, len(circuits))
-	}
-	if circuits[0].OutgoingHTLCID != 3 {
-		t.Fatalf("LookupByPaymentHash returned wrong circuit for hash1: %v",
-			circuits[0])
-	}
+	// There should be exactly one remaining circuit with hash1, and it
+	// should be circuit4.
+	assertNumCircuitsWithHash(t, circuitMap, hash1, 1)
+	assertHasCircuitForHash(t, circuitMap, hash1, circuit4)
+	cdb, circuitMap = restartCircuitMap(t, cdb)
+	assertNumCircuitsWithHash(t, circuitMap, hash1, 1)
+	assertHasCircuitForHash(t, circuitMap, hash1, circuit4)
 
 	// Removing already-removed circuit should return an error.
-	err = circuitMap.Remove(chan1, 0)
+	err = circuitMap.DeleteCircuits(circuit1.Incoming)
 	if err == nil {
 		t.Fatal("Remove did not return expected not found error")
 	}
 
+	// Verify that nothing related to hash1 has changed
+	assertNumCircuitsWithHash(t, circuitMap, hash1, 1)
+	assertHasCircuitForHash(t, circuitMap, hash1, circuit4)
+
 	// Remove last remaining circuit with payment hash hash1.
-	err = circuitMap.Remove(chan1, 3)
+	err = circuitMap.DeleteCircuits(circuit4.Incoming)
 	if err != nil {
 		t.Fatalf("Remove returned unexpected error: %v", err)
 	}
 
-	circuits = circuitMap.LookupByPaymentHash(hash1)
-	if len(circuits) != 0 {
+	assertNumCircuitsWithHash(t, circuitMap, hash1, 0)
+	assertNumCircuitsWithHash(t, circuitMap, hash2, 1)
+	assertNumCircuitsWithHash(t, circuitMap, hash3, 1)
+	cdb, circuitMap = restartCircuitMap(t, cdb)
+	assertNumCircuitsWithHash(t, circuitMap, hash1, 0)
+	assertNumCircuitsWithHash(t, circuitMap, hash2, 1)
+	assertNumCircuitsWithHash(t, circuitMap, hash3, 1)
+
+	// Remove last remaining circuit with payment hash hash2.
+	err = circuitMap.DeleteCircuits(circuit2.Incoming)
+	if err != nil {
+		t.Fatalf("Remove returned unexpected error: %v", err)
+	}
+
+	// There should now only be one remaining circuit, with hash3.
+	assertNumCircuitsWithHash(t, circuitMap, hash2, 0)
+	assertNumCircuitsWithHash(t, circuitMap, hash3, 1)
+	cdb, circuitMap = restartCircuitMap(t, cdb)
+	assertNumCircuitsWithHash(t, circuitMap, hash2, 0)
+	assertNumCircuitsWithHash(t, circuitMap, hash3, 1)
+
+	// Remove last remaining circuit with payment hash hash3.
+	err = circuitMap.DeleteCircuits(circuit3.Incoming)
+	if err != nil {
+		t.Fatalf("Remove returned unexpected error: %v", err)
+	}
+
+	// Check that the circuit map is empty, even after restarting.
+	assertNumCircuitsWithHash(t, circuitMap, hash3, 0)
+	cdb, circuitMap = restartCircuitMap(t, cdb)
+	assertNumCircuitsWithHash(t, circuitMap, hash3, 0)
+}
+
+// assertHasKeystone tests that the circuit map contains the provided payment
+// circuit.
+func assertHasKeystone(t *testing.T, cm htlcswitch.CircuitMap,
+	outKey htlcswitch.CircuitKey, c *htlcswitch.PaymentCircuit) {
+
+	circuit := cm.LookupOpenCircuit(outKey)
+	if !equalIgnoreLFD(circuit, c) {
+		t.Fatalf("unexpected circuit, want: %v, got %v", c, circuit)
+	}
+}
+
+// assertDoesNotHaveKeystone tests that the circuit map does not contain a
+// circuit for the provided outgoing circuit key.
+func assertDoesNotHaveKeystone(t *testing.T, cm htlcswitch.CircuitMap,
+	outKey htlcswitch.CircuitKey) {
+
+	circuit := cm.LookupOpenCircuit(outKey)
+	if circuit != nil {
+		t.Fatalf("expected no circuit for keystone %s, found %v",
+			outKey, circuit)
+	}
+}
+
+// assertHasCircuitForHash tests that the provided circuit appears in the list
+// of circuits for the given hash.
+func assertHasCircuitForHash(t *testing.T, cm htlcswitch.CircuitMap, hash [32]byte,
+	circuit *htlcswitch.PaymentCircuit) {
+
+	circuits := cm.LookupByPaymentHash(hash)
+	for _, c := range circuits {
+		if equalIgnoreLFD(c, circuit) {
+			return
+		}
+	}
+
+	t.Fatalf("unable to find circuit: %v by hash: %v", circuit, hash)
+}
+
+// assertNumCircuitsWithHash tests that the circuit has the right number of full
+// circuits, indexed by the given hash.
+func assertNumCircuitsWithHash(t *testing.T, cm htlcswitch.CircuitMap,
+	hash [32]byte, expectedNum int) {
+
+	circuits := cm.LookupByPaymentHash(hash)
+	if len(circuits) != expectedNum {
 		t.Fatalf("LookupByPaymentHash returned wrong number of circuits for "+
-			"hash1: expecected %d, got %d", 0, len(circuits))
+			"hash=%v: expecected %d, got %d", hash, expectedNum,
+			len(circuits))
+	}
+}
+
+// assertHasCircuit queries the circuit map using the half-circuit's half
+// key, and fails if the returned half-circuit differs from the provided one.
+func assertHasCircuit(t *testing.T, cm htlcswitch.CircuitMap,
+	c *htlcswitch.PaymentCircuit) {
+
+	c2 := cm.LookupCircuit(c.Incoming)
+	if !equalIgnoreLFD(c, c2) {
+		t.Fatalf("expected circuit: %v, got %v", c, c2)
+	}
+}
+
+// equalIgnoreLFD compares two payment circuits, but ignores the current value
+// of LoadedFromDisk. The value is temporarily set to false for the comparison
+// and then restored.
+func equalIgnoreLFD(c, c2 *htlcswitch.PaymentCircuit) bool {
+	ogLFD := c.LoadedFromDisk
+	ogLFD2 := c2.LoadedFromDisk
+
+	c.LoadedFromDisk = false
+	c2.LoadedFromDisk = false
+
+	isEqual := reflect.DeepEqual(c, c2)
+
+	c.LoadedFromDisk = ogLFD
+	c2.LoadedFromDisk = ogLFD2
+
+	return isEqual
+}
+
+// assertDoesNotHaveCircuit queries the circuit map using the circuit's
+// incoming circuit key, and fails if it is found.
+func assertDoesNotHaveCircuit(t *testing.T, cm htlcswitch.CircuitMap,
+	c *htlcswitch.PaymentCircuit) {
+
+	c2 := cm.LookupCircuit(c.Incoming)
+	if c2 != nil {
+		t.Fatalf("expected no circuit for %v, got %v", c, c2)
+	}
+}
+
+// makeCircuitDB initializes a new test channeldb for testing the persistence of
+// the circuit map. If an empty string is provided as a path, a temp directory
+// will be created.
+func makeCircuitDB(t *testing.T, path string) *channeldb.DB {
+	if path == "" {
+		var err error
+		path, err = ioutil.TempDir("", "circuitdb")
+		if err != nil {
+			t.Fatalf("unable to create temp path: %v", err)
+		}
+	}
+
+	db, err := channeldb.Open(path)
+	if err != nil {
+		t.Fatalf("unable to open channel db: %v", err)
+	}
+
+	return db
+}
+
+// Creates a new circuit map, backed by a freshly opened channeldb. The existing
+// channeldb is closed in order to simulate a complete restart.
+func restartCircuitMap(t *testing.T, cdb *channeldb.DB) (*channeldb.DB,
+	htlcswitch.CircuitMap) {
+
+	// Record the current temp path and close current db.
+	dbPath := cdb.Path()
+	cdb.Close()
+
+	// Reinitialize circuit map with same db path.
+	cdb2 := makeCircuitDB(t, dbPath)
+	cm2, err := htlcswitch.NewCircuitMap(cdb2)
+	if err != nil {
+		t.Fatalf("unable to recreate persistent circuit map: %v", err)
+	}
+
+	return cdb2, cm2
+}
+
+// TestCircuitMapCommitCircuits tests the following behavior of CommitCircuits:
+// 1. New circuits are successfully added.
+// 2. Duplicate circuits are dropped anytime before circuit map shutsdown.
+// 3. Duplicate circuits are failed anytime after circuit map restarts.
+func TestCircuitMapCommitCircuits(t *testing.T) {
+	t.Parallel()
+
+	var (
+		chan1      = lnwire.NewShortChanIDFromInt(1)
+		circuitMap htlcswitch.CircuitMap
+		err        error
+	)
+
+	cdb := makeCircuitDB(t, "")
+	circuitMap, err = htlcswitch.NewCircuitMap(cdb)
+	if err != nil {
+		t.Fatalf("unable to create persistent circuit map: %v", err)
+	}
+
+	circuit := &htlcswitch.PaymentCircuit{
+		Incoming: htlcswitch.CircuitKey{
+			ChanID: chan1,
+			HtlcID: 3,
+		},
+		ErrorEncrypter: htlcswitch.NewSphinxErrorEncrypter(),
+	}
+
+	// First we will try to add an new circuit to the circuit map, this
+	// should succeed.
+	actions, err := circuitMap.CommitCircuits(circuit)
+	if err != nil {
+		t.Fatalf("failed to commit circuits: %v", err)
+	}
+	if len(actions.Drops) > 0 {
+		t.Fatalf("new circuit should not have been dropped")
+	}
+	if len(actions.Fails) > 0 {
+		t.Fatalf("new circuit should not have failed")
+	}
+	if len(actions.Adds) != 1 {
+		t.Fatalf("only one circuit should have been added, found %d",
+			len(actions.Adds))
+	}
+
+	circuit2 := circuitMap.LookupCircuit(circuit.Incoming)
+	if !reflect.DeepEqual(circuit, circuit2) {
+		t.Fatalf("unexpected committed circuit: got %v, want %v",
+			circuit2, circuit)
+	}
+
+	// Then we will try to readd the same circuit again, this should result
+	// in the circuit being dropped. This can happen if the incoming link
+	// flaps.
+	actions, err = circuitMap.CommitCircuits(circuit)
+	if err != nil {
+		t.Fatalf("failed to commit circuits: %v", err)
+	}
+	if len(actions.Adds) > 0 {
+		t.Fatalf("duplicate circuit should not have been added to circuit map")
+	}
+	if len(actions.Fails) > 0 {
+		t.Fatalf("duplicate circuit should not have failed")
+	}
+	if len(actions.Drops) != 1 {
+		t.Fatalf("only one circuit should have been dropped, found %d",
+			len(actions.Drops))
+	}
+
+	// Finally, restart the circuit map, which will cause the added circuit
+	// to be loaded from disk. Since the keystone was never set, subsequent
+	// attempts to commit the circuit should cause the circuit map to
+	// indicate that that the HTLC should be failed back.
+	cdb, circuitMap = restartCircuitMap(t, cdb)
+
+	actions, err = circuitMap.CommitCircuits(circuit)
+	if err != nil {
+		t.Fatalf("failed to commit circuits: %v", err)
+	}
+	if len(actions.Adds) > 0 {
+		t.Fatalf("duplicate circuit with incomplete forwarding " +
+			"decision should not have been added to circuit map")
+	}
+	if len(actions.Drops) > 0 {
+		t.Fatalf("duplicate circuit with incomplete forwarding " +
+			"decision should not have been dropped by circuit map")
+	}
+	if len(actions.Fails) != 1 {
+		t.Fatalf("only one duplicate circuit with incomplete "+
+			"forwarding decision should have been failed, found: "+
+			"%d", len(actions.Fails))
+	}
+
+	// Lookup the committed circuit again, it should be identical apart from
+	// the loaded from disk flag.
+	circuit2 = circuitMap.LookupCircuit(circuit.Incoming)
+	if !equalIgnoreLFD(circuit, circuit2) {
+		t.Fatalf("unexpected committed circuit: got %v, want %v",
+			circuit2, circuit)
+	}
+}
+
+// TestCircuitMapOpenCircuits checks that circuits are properly opened, and that
+// duplicate attempts to open a circuit will result in an error.
+func TestCircuitMapOpenCircuits(t *testing.T) {
+	t.Parallel()
+
+	var (
+		chan1      = lnwire.NewShortChanIDFromInt(1)
+		chan2      = lnwire.NewShortChanIDFromInt(2)
+		circuitMap htlcswitch.CircuitMap
+		err        error
+	)
+
+	cdb := makeCircuitDB(t, "")
+	circuitMap, err = htlcswitch.NewCircuitMap(cdb)
+	if err != nil {
+		t.Fatalf("unable to create persistent circuit map: %v", err)
+	}
+
+	circuit := &htlcswitch.PaymentCircuit{
+		Incoming: htlcswitch.CircuitKey{
+			ChanID: chan1,
+			HtlcID: 3,
+		},
+		ErrorEncrypter: htlcswitch.NewSphinxErrorEncrypter(),
+	}
+
+	// First we will try to add an new circuit to the circuit map, this
+	// should succeed.
+	_, err = circuitMap.CommitCircuits(circuit)
+	if err != nil {
+		t.Fatalf("failed to commit circuits: %v", err)
+	}
+
+	keystone := htlcswitch.Keystone{
+		InKey: circuit.Incoming,
+		OutKey: htlcswitch.CircuitKey{
+			ChanID: chan2,
+			HtlcID: 2,
+		},
+	}
+
+	// Open the circuit for the first time.
+	err = circuitMap.OpenCircuits(keystone)
+	if err != nil {
+		t.Fatalf("failed to open circuits: %v", err)
+	}
+
+	// Check that we can retrieve the open circuit if the circuit map before
+	// the circuit map is restarted.
+	circuit2 := circuitMap.LookupOpenCircuit(keystone.OutKey)
+	if !reflect.DeepEqual(circuit, circuit2) {
+		t.Fatalf("unexpected open circuit: got %v, want %v",
+			circuit2, circuit)
+	}
+
+	if !circuit2.HasKeystone() {
+		t.Fatalf("open circuit should have keystone")
+	}
+	if !reflect.DeepEqual(&keystone.OutKey, circuit2.Outgoing) {
+		t.Fatalf("expected open circuit to have outgoing key: %v, found %v",
+			&keystone.OutKey, circuit2.Outgoing)
+	}
+
+	// Open the circuit for a second time, which should fail due to a
+	// duplicate keystone
+	err = circuitMap.OpenCircuits(keystone)
+	if err != htlcswitch.ErrDuplicateKeystone {
+		t.Fatalf("failed to open circuits: %v", err)
+	}
+
+	// Then we will try to readd the same circuit again, this should result
+	// in the circuit being dropped. This can happen if the incoming link
+	// flaps OR the switch is entirely restarted and the outgoing link has
+	// not received a response.
+	actions, err := circuitMap.CommitCircuits(circuit)
+	if err != nil {
+		t.Fatalf("failed to commit circuits: %v", err)
+	}
+	if len(actions.Adds) > 0 {
+		t.Fatalf("duplicate circuit should not have been added to circuit map")
+	}
+	if len(actions.Fails) > 0 {
+		t.Fatalf("duplicate circuit should not have failed")
+	}
+	if len(actions.Drops) != 1 {
+		t.Fatalf("only one circuit should have been dropped, found %d",
+			len(actions.Drops))
+	}
+
+	// Now, restart the circuit map, which will cause the opened circuit to
+	// be loaded from disk. Since we set the keystone on this circuit, it
+	// should be restored as such in memory.
+	//
+	// NOTE: The channel db doesn't have any channel data, so no keystones
+	// will be trimmed.
+	cdb, circuitMap = restartCircuitMap(t, cdb)
+
+	// Check that we can still query for the open circuit.
+	circuit2 = circuitMap.LookupOpenCircuit(keystone.OutKey)
+	if !equalIgnoreLFD(circuit, circuit2) {
+		t.Fatalf("unexpected open circuit: got %v, want %v",
+			circuit2, circuit)
+	}
+
+	// Try to open the circuit again, we expect this to fail since the open
+	// circuit was restored.
+	err = circuitMap.OpenCircuits(keystone)
+	if err != htlcswitch.ErrDuplicateKeystone {
+		t.Fatalf("failed to open circuits: %v", err)
+	}
+
+	// Lastly, with the circuit map restarted, try one more time to recommit
+	// the open circuit. This should be dropped, and is expected to happen
+	// if the incoming link flaps OR the switch is entirely restarted and
+	// the outgoing link has not received a response.
+	actions, err = circuitMap.CommitCircuits(circuit)
+	if err != nil {
+		t.Fatalf("failed to commit circuits: %v", err)
+	}
+	if len(actions.Adds) > 0 {
+		t.Fatalf("duplicate circuit should not have been added to circuit map")
+	}
+	if len(actions.Fails) > 0 {
+		t.Fatalf("duplicate circuit should not have failed")
+	}
+	if len(actions.Drops) != 1 {
+		t.Fatalf("only one circuit should have been dropped, found %d",
+			len(actions.Drops))
+	}
+}
+
+func assertCircuitsOpenedPreRestart(t *testing.T,
+	circuitMap htlcswitch.CircuitMap,
+	circuits []*htlcswitch.PaymentCircuit,
+	keystones []htlcswitch.Keystone) {
+
+	for i, circuit := range circuits {
+		keystone := keystones[i]
+
+		openCircuit := circuitMap.LookupOpenCircuit(keystone.OutKey)
+		if !reflect.DeepEqual(circuit, openCircuit) {
+			t.Fatalf("unexpected open circuit %d: got %v, want %v",
+				i, openCircuit, circuit)
+		}
+
+		if !openCircuit.HasKeystone() {
+			t.Fatalf("open circuit %d should have keystone", i)
+		}
+		if !reflect.DeepEqual(&keystone.OutKey, openCircuit.Outgoing) {
+			t.Fatalf("expected open circuit %d to have outgoing "+
+				"key: %v, found %v", i,
+				&keystone.OutKey, openCircuit.Outgoing)
+		}
+	}
+}
+
+func assertCircuitsOpenedPostRestart(t *testing.T,
+	circuitMap htlcswitch.CircuitMap,
+	circuits []*htlcswitch.PaymentCircuit,
+	keystones []htlcswitch.Keystone) {
+
+	for i, circuit := range circuits {
+		keystone := keystones[i]
+
+		openCircuit := circuitMap.LookupOpenCircuit(keystone.OutKey)
+		if !equalIgnoreLFD(circuit, openCircuit) {
+			t.Fatalf("unexpected open circuit %d: got %v, want %v",
+				i, openCircuit, circuit)
+		}
+
+		if !openCircuit.HasKeystone() {
+			t.Fatalf("open circuit %d should have keystone", i)
+		}
+		if !reflect.DeepEqual(&keystone.OutKey, openCircuit.Outgoing) {
+			t.Fatalf("expected open circuit %d to have outgoing "+
+				"key: %v, found %v", i,
+				&keystone.OutKey, openCircuit.Outgoing)
+		}
+	}
+}
+
+func assertCircuitsNotOpenedPreRestart(t *testing.T,
+	circuitMap htlcswitch.CircuitMap,
+	circuits []*htlcswitch.PaymentCircuit,
+	keystones []htlcswitch.Keystone,
+	offset int) {
+
+	for i := range circuits {
+		keystone := keystones[i]
+
+		openCircuit := circuitMap.LookupOpenCircuit(keystone.OutKey)
+		if openCircuit != nil {
+			t.Fatalf("expected circuit %d not to be open",
+				offset+i)
+		}
+
+		circuit := circuitMap.LookupCircuit(keystone.InKey)
+		if circuit == nil {
+			t.Fatalf("expected to find unopened circuit %d",
+				offset+i)
+		}
+		if circuit.HasKeystone() {
+			t.Fatalf("circuit %d should not have keystone",
+				offset+i)
+		}
+	}
+}
+
+// TestCircuitMapTrimOpenCircuits verifies that the circuit map properly removes
+// circuits from disk and the in-memory state when TrimOpenCircuits is used.
+// This test checks that a successful trim survives a restart, and that circuits
+// added before the restart can also be trimmed.
+func TestCircuitMapTrimOpenCircuits(t *testing.T) {
+	t.Parallel()
+
+	var (
+		chan1      = lnwire.NewShortChanIDFromInt(1)
+		chan2      = lnwire.NewShortChanIDFromInt(2)
+		circuitMap htlcswitch.CircuitMap
+		err        error
+	)
+
+	cdb := makeCircuitDB(t, "")
+	circuitMap, err = htlcswitch.NewCircuitMap(cdb)
+	if err != nil {
+		t.Fatalf("unable to create persistent circuit map: %v", err)
+	}
+
+	const nCircuits = 10
+	const firstTrimIndex = 7
+	const secondTrimIndex = 3
+
+	// Create a list of all circuits that will be committed in the circuit
+	// map. The incoming HtlcIDs are chosen so that there is overlap with
+	// the outgoing HtlcIDs, but ensures that the test is not dependent on
+	// them being equal.
+	circuits := make([]*htlcswitch.PaymentCircuit, nCircuits)
+	for i := range circuits {
+		circuits[i] = &htlcswitch.PaymentCircuit{
+			Incoming: htlcswitch.CircuitKey{
+				ChanID: chan1,
+				HtlcID: uint64(i + 3),
+			},
+			ErrorEncrypter: htlcswitch.NewSphinxErrorEncrypter(),
+		}
+	}
+
+	// First we will try to add an new circuit to the circuit map, this
+	// should succeed.
+	_, err = circuitMap.CommitCircuits(circuits...)
+	if err != nil {
+		t.Fatalf("failed to commit circuits: %v", err)
+	}
+
+	// Now create a list of the keystones that we will use to preemptively
+	// open the circuits. We set the index as the outgoing HtlcID to i
+	// simplify the indexing logic of the test.
+	keystones := make([]htlcswitch.Keystone, nCircuits)
+	for i := range keystones {
+		keystones[i] = htlcswitch.Keystone{
+			InKey: circuits[i].Incoming,
+			OutKey: htlcswitch.CircuitKey{
+				ChanID: chan2,
+				HtlcID: uint64(i),
+			},
+		}
+	}
+
+	// Open the circuits for the first time.
+	err = circuitMap.OpenCircuits(keystones...)
+	if err != nil {
+		t.Fatalf("failed to open circuits: %v", err)
+	}
+
+	// Check that all circuits are marked open.
+	assertCircuitsOpenedPreRestart(t, circuitMap, circuits, keystones)
+
+	// Now trim up above outgoing htlcid `firstTrimIndex` (7). This should
+	// leave the first 7 circuits open, and the rest should be reverted to
+	// an unopened state.
+	err = circuitMap.TrimOpenCircuits(chan2, firstTrimIndex)
+	if err != nil {
+		t.Fatalf("unable to trim circuits")
+	}
+
+	assertCircuitsOpenedPreRestart(t,
+		circuitMap,
+		circuits[:firstTrimIndex],
+		keystones[:firstTrimIndex],
+	)
+
+	assertCircuitsNotOpenedPreRestart(
+		t,
+		circuitMap,
+		circuits[firstTrimIndex:],
+		keystones[firstTrimIndex:],
+		firstTrimIndex,
+	)
+
+	// Restart the circuit map, verify that that the trim is reflected on
+	// startup.
+	cdb, circuitMap = restartCircuitMap(t, cdb)
+
+	assertCircuitsOpenedPostRestart(
+		t,
+		circuitMap,
+		circuits[:firstTrimIndex],
+		keystones[:firstTrimIndex],
+	)
+
+	assertCircuitsNotOpenedPreRestart(
+		t,
+		circuitMap,
+		circuits[firstTrimIndex:],
+		keystones[firstTrimIndex:],
+		firstTrimIndex,
+	)
+
+	// Now, trim above outgoing htlcid `secondTrimIndex` (3). Only the first
+	// three circuits should be open, with any others being reverted back to
+	// unopened.
+	err = circuitMap.TrimOpenCircuits(chan2, secondTrimIndex)
+	if err != nil {
+		t.Fatalf("unable to trim circuits")
+	}
+
+	assertCircuitsOpenedPostRestart(
+		t,
+		circuitMap,
+		circuits[:secondTrimIndex],
+		keystones[:secondTrimIndex],
+	)
+
+	assertCircuitsNotOpenedPreRestart(
+		t,
+		circuitMap,
+		circuits[secondTrimIndex:],
+		keystones[secondTrimIndex:],
+		secondTrimIndex,
+	)
+
+	// Restart the circuit map one last time to make sure the changes are
+	// persisted.
+	cdb, circuitMap = restartCircuitMap(t, cdb)
+
+	assertCircuitsOpenedPostRestart(
+		t,
+		circuitMap,
+		circuits[:secondTrimIndex],
+		keystones[:secondTrimIndex],
+	)
+
+	assertCircuitsNotOpenedPreRestart(
+		t,
+		circuitMap,
+		circuits[secondTrimIndex:],
+		keystones[secondTrimIndex:],
+		secondTrimIndex,
+	)
+}
+
+// TestCircuitMapCloseOpenCircuits asserts that the circuit map can properly
+// close open circuits, and that it allows at most one response to do so
+// successfully. It also checks that a circuit is reopened if the close was not
+// persisted via DeleteCircuits, and can again be closed.
+func TestCircuitMapCloseOpenCircuits(t *testing.T) {
+	t.Parallel()
+
+	var (
+		chan1      = lnwire.NewShortChanIDFromInt(1)
+		chan2      = lnwire.NewShortChanIDFromInt(2)
+		circuitMap htlcswitch.CircuitMap
+		err        error
+	)
+
+	cdb := makeCircuitDB(t, "")
+	circuitMap, err = htlcswitch.NewCircuitMap(cdb)
+	if err != nil {
+		t.Fatalf("unable to create persistent circuit map: %v", err)
+	}
+
+	circuit := &htlcswitch.PaymentCircuit{
+		Incoming: htlcswitch.CircuitKey{
+			ChanID: chan1,
+			HtlcID: 3,
+		},
+		ErrorEncrypter: htlcswitch.NewSphinxErrorEncrypter(),
+	}
+
+	// First we will try to add an new circuit to the circuit map, this
+	// should succeed.
+	_, err = circuitMap.CommitCircuits(circuit)
+	if err != nil {
+		t.Fatalf("failed to commit circuits: %v", err)
+	}
+
+	keystone := htlcswitch.Keystone{
+		InKey: circuit.Incoming,
+		OutKey: htlcswitch.CircuitKey{
+			ChanID: chan2,
+			HtlcID: 2,
+		},
+	}
+
+	// Open the circuit for the first time.
+	err = circuitMap.OpenCircuits(keystone)
+	if err != nil {
+		t.Fatalf("failed to open circuits: %v", err)
+	}
+
+	// Check that we can retrieve the open circuit if the circuit map before
+	// the circuit map is restarted.
+	circuit2 := circuitMap.LookupOpenCircuit(keystone.OutKey)
+	if !reflect.DeepEqual(circuit, circuit2) {
+		t.Fatalf("unexpected open circuit: got %v, want %v",
+			circuit2, circuit)
+	}
+
+	// Open the circuit for a second time, which should fail due to a
+	// duplicate keystone
+	err = circuitMap.OpenCircuits(keystone)
+	if err != htlcswitch.ErrDuplicateKeystone {
+		t.Fatalf("failed to open circuits: %v", err)
+	}
+
+	// Close the open circuit for the first time, which should succeed.
+	_, err = circuitMap.FailCircuit(circuit.Incoming)
+	if err != nil {
+		t.Fatalf("unable to close unopened circuit")
+	}
+
+	// Closing the circuit a second time should result in a failure.
+	_, err = circuitMap.FailCircuit(circuit.Incoming)
+	if err != htlcswitch.ErrCircuitClosing {
+		t.Fatalf("unable to close unopened circuit")
+	}
+
+	// Now, restart the circuit map, which will cause the opened circuit to
+	// be loaded from disk. Since we set the keystone on this circuit, it
+	// should be restored as such in memory.
+	//
+	// NOTE: The channel db doesn't have any channel data, so no keystones
+	// will be trimmed.
+	cdb, circuitMap = restartCircuitMap(t, cdb)
+
+	// Close the open circuit for the first time, which should succeed.
+	_, err = circuitMap.FailCircuit(circuit.Incoming)
+	if err != nil {
+		t.Fatalf("unable to close unopened circuit")
+	}
+
+	// Closing the circuit a second time should result in a failure.
+	_, err = circuitMap.FailCircuit(circuit.Incoming)
+	if err != htlcswitch.ErrCircuitClosing {
+		t.Fatalf("unable to close unopened circuit")
+	}
+}
+
+// TestCircuitMapCloseUnopenedCircuit tests that closing an unopened circuit
+// allows at most semantics, and that the close is not persisted across
+// restarts.
+func TestCircuitMapCloseUnopenedCircuit(t *testing.T) {
+	t.Parallel()
+
+	var (
+		chan1      = lnwire.NewShortChanIDFromInt(1)
+		circuitMap htlcswitch.CircuitMap
+		err        error
+	)
+
+	cdb := makeCircuitDB(t, "")
+	circuitMap, err = htlcswitch.NewCircuitMap(cdb)
+	if err != nil {
+		t.Fatalf("unable to create persistent circuit map: %v", err)
+	}
+
+	circuit := &htlcswitch.PaymentCircuit{
+		Incoming: htlcswitch.CircuitKey{
+			ChanID: chan1,
+			HtlcID: 3,
+		},
+		ErrorEncrypter: htlcswitch.NewSphinxErrorEncrypter(),
+	}
+
+	// First we will try to add an new circuit to the circuit map, this
+	// should succeed.
+	_, err = circuitMap.CommitCircuits(circuit)
+	if err != nil {
+		t.Fatalf("failed to commit circuits: %v", err)
+	}
+
+	// Close the open circuit for the first time, which should succeed.
+	_, err = circuitMap.FailCircuit(circuit.Incoming)
+	if err != nil {
+		t.Fatalf("unable to close unopened circuit")
+	}
+
+	// Closing the circuit a second time should result in a failure.
+	_, err = circuitMap.FailCircuit(circuit.Incoming)
+	if err != htlcswitch.ErrCircuitClosing {
+		t.Fatalf("unable to close unopened circuit")
+	}
+
+	// Now, restart the circuit map, which will result in the circuit being
+	// reopened, since no attempt to delete the circuit was made.
+	cdb, circuitMap = restartCircuitMap(t, cdb)
+
+	// Close the open circuit for the first time, which should succeed.
+	_, err = circuitMap.FailCircuit(circuit.Incoming)
+	if err != nil {
+		t.Fatalf("unable to close unopened circuit")
+	}
+
+	// Closing the circuit a second time should result in a failure.
+	_, err = circuitMap.FailCircuit(circuit.Incoming)
+	if err != htlcswitch.ErrCircuitClosing {
+		t.Fatalf("unable to close unopened circuit")
+	}
+}
+
+// TestCircuitMapDeleteUnopenedCircuit checks that an unopened circuit can be
+// removed persistently from the circuit map.
+func TestCircuitMapDeleteUnopenedCircuit(t *testing.T) {
+	t.Parallel()
+
+	var (
+		chan1      = lnwire.NewShortChanIDFromInt(1)
+		circuitMap htlcswitch.CircuitMap
+		err        error
+	)
+
+	cdb := makeCircuitDB(t, "")
+	circuitMap, err = htlcswitch.NewCircuitMap(cdb)
+	if err != nil {
+		t.Fatalf("unable to create persistent circuit map: %v", err)
+	}
+
+	circuit := &htlcswitch.PaymentCircuit{
+		Incoming: htlcswitch.CircuitKey{
+			ChanID: chan1,
+			HtlcID: 3,
+		},
+		ErrorEncrypter: htlcswitch.NewSphinxErrorEncrypter(),
+	}
+
+	// First we will try to add an new circuit to the circuit map, this
+	// should succeed.
+	_, err = circuitMap.CommitCircuits(circuit)
+	if err != nil {
+		t.Fatalf("failed to commit circuits: %v", err)
+	}
+
+	// Close the open circuit for the first time, which should succeed.
+	_, err = circuitMap.FailCircuit(circuit.Incoming)
+	if err != nil {
+		t.Fatalf("unable to close unopened circuit")
+	}
+
+	err = circuitMap.DeleteCircuits(circuit.Incoming)
+	if err != nil {
+		t.Fatalf("unable to close unopened circuit")
+	}
+
+	// Check that we can retrieve the open circuit if the circuit map before
+	// the circuit map is restarted.
+	circuit2 := circuitMap.LookupCircuit(circuit.Incoming)
+	if circuit2 != nil {
+		t.Fatalf("unexpected open circuit: got %v, want %v",
+			circuit2, nil)
+	}
+
+	// Now, restart the circuit map, and check that the deletion survived
+	// the restart.
+	cdb, circuitMap = restartCircuitMap(t, cdb)
+
+	circuit2 = circuitMap.LookupCircuit(circuit.Incoming)
+	if circuit2 != nil {
+		t.Fatalf("unexpected open circuit: got %v, want %v",
+			circuit2, nil)
+	}
+}
+
+// TestCircuitMapDeleteUnopenedCircuit checks that an open circuit can be
+// removed persistently from the circuit map.
+func TestCircuitMapDeleteOpenCircuit(t *testing.T) {
+	t.Parallel()
+
+	var (
+		chan1      = lnwire.NewShortChanIDFromInt(1)
+		chan2      = lnwire.NewShortChanIDFromInt(2)
+		circuitMap htlcswitch.CircuitMap
+		err        error
+	)
+
+	cdb := makeCircuitDB(t, "")
+	circuitMap, err = htlcswitch.NewCircuitMap(cdb)
+	if err != nil {
+		t.Fatalf("unable to create persistent circuit map: %v", err)
+	}
+
+	circuit := &htlcswitch.PaymentCircuit{
+		Incoming: htlcswitch.CircuitKey{
+			ChanID: chan1,
+			HtlcID: 3,
+		},
+		ErrorEncrypter: htlcswitch.NewSphinxErrorEncrypter(),
+	}
+
+	// First we will try to add an new circuit to the circuit map, this
+	// should succeed.
+	_, err = circuitMap.CommitCircuits(circuit)
+	if err != nil {
+		t.Fatalf("failed to commit circuits: %v", err)
+	}
+
+	keystone := htlcswitch.Keystone{
+		InKey: circuit.Incoming,
+		OutKey: htlcswitch.CircuitKey{
+			ChanID: chan2,
+			HtlcID: 2,
+		},
+	}
+
+	// Open the circuit for the first time.
+	err = circuitMap.OpenCircuits(keystone)
+	if err != nil {
+		t.Fatalf("failed to open circuits: %v", err)
+	}
+
+	// Close the open circuit for the first time, which should succeed.
+	_, err = circuitMap.FailCircuit(circuit.Incoming)
+	if err != nil {
+		t.Fatalf("unable to close unopened circuit")
+	}
+
+	// Persistently remove the circuit identified by incoming chan id.
+	err = circuitMap.DeleteCircuits(circuit.Incoming)
+	if err != nil {
+		t.Fatalf("unable to close unopened circuit")
+	}
+
+	// Check that we can no longer retrieve the open circuit.
+	circuit2 := circuitMap.LookupOpenCircuit(keystone.OutKey)
+	if circuit2 != nil {
+		t.Fatalf("unexpected open circuit: got %v, want %v",
+			circuit2, nil)
+	}
+
+	// Now, restart the circuit map, and check that the deletion survived
+	// the restart.
+	cdb, circuitMap = restartCircuitMap(t, cdb)
+
+	circuit2 = circuitMap.LookupOpenCircuit(keystone.OutKey)
+	if circuit2 != nil {
+		t.Fatalf("unexpected open circuit: got %v, want %v",
+			circuit2, nil)
 	}
 }


### PR DESCRIPTION
This PR isolates the changes to the circuit map included in #761 in order to isolate it for review. 

The major additions include:
 - Full persistence of circuits, including the onion error encrypters.
 - Batched writes so that the circuit map can be updated atomically at the granularity of the channel state transitions.
 - Persistent duplicate detection for adds, with indication as to whether the packet should be dropped or failed back.
 - Duplicate detection for settles and fails, ensuring that at most one response is delivered to the originating link.

Fixes #80. 

Overview
=======
All HTLCs are tracked via a `CircuitKey`, which is a tuple of `lnwire.ShortChanID` and its remote HTLC index. The circuit map's primary job is to keep track of the relationships between the `CircuitKey`s of Adds from incoming links and Adds from outgoing `CircuitKeys`. Before an HTLC is forwarded to the next intermediary, the circuit map is always updated with a `Keystone`, which binds an incoming `CircuitKey` to an outgoing `CircuitKey`. After receiving a response for a particular outgoing HTLC, the circuit map is queried using the outgoing `CircuitKey`, to determine which link the packet originated from.

The primary methods exposed by the circuit map are:
```golang
        // CommitCircuits attempts to add the given circuit's to the circuit
        // map. The list of circuits is split into three distinct subsequences,                                                                          
        // corresponding to adds, drops, and fails. Adds should be forwarded to                                                                          
        // the switch, while fails should be failed back locally within the                                                                              
        // calling link.                 
        CommitCircuits(circuit ...*PaymentCircuit) ([]*PaymentCircuit,
                []*PaymentCircuit, []*PaymentCircuit, error)

        // OpenCircuits preemptively records a batch keystones that will mark
        // currently pending circuits as open. These changes can be rolled back
        // on restart if the outgoing Adds do not make it into a commitment txn.
        OpenCircuits(...Keystone) error

        // CloseCircuit marks the circuit identified by `outKey` as closing
        // in-memory, which prevents duplicate settles/fails from completing an
        // open circuit twice.
        CloseCircuit(outKey CircuitKey) (*PaymentCircuit, error)

        // FailCircuit is used by locally failed HTLCs to mark the circuit
        // identified by `inKey` as closing in-memory, which prevents duplicate
        // settles/fails from being accepted for the same circuit.
        FailCircuit(inKey CircuitKey) (*PaymentCircuit, error)

        // DeleteCircuits removes the incoming circuit key to remove all
        // persistent references to a circuit. Returns a ErrUnknownCircuit if
        // any of the incoming keys are not known.
        DeleteCircuits(inKeys ...CircuitKey) error

        // TrimOpenCircuits removes a channel's open channels with htlc indexes
        // above `start`.
        TrimOpenCircuits(chanID lnwire.ShortChannelID, start uint64) error
```

Basic Operation
============
The general flow of the circuit map is as follows:
 1. Incoming Link: Locks in batch of Adds, and forwards a valid subset of those for which it wasn't the exit hop to the switch.
 1. Switch: Receives a batch of Adds to forward from the incoming link, and uses to `CommitCircuits` to register the incoming Adds with the circuit map. This batch is always expected to be a subset of the Adds locked into a particular link.
1. Outgoing Link: Before signing a new commitment state, batch writes a `Keystone`s of each Add to preemptively mark the circuit as open using `OpenCircuits`.
1. Outgoing Link: Receives a response (Settle or Fail) for an outgoing HTLC, and forwards the packet to the switch.
1. Switch: Attempts to complete an open circuit by passing the outgoing `CircuitKey` to `CloseCircuit`, this recovers the incoming `CircuitKey` from which the Add originated. This operation marks (in-memory) that the circuit is closing, and ensures at most one packet for a particular outgoing `CircuitKey` is allowed to pass through the switch.
1. Incoming Link: After signing a new commitment state, removes all information about all circuits that received a Settle or Fail from the circuit map, by batch deleting their incoming `CircuitKey`s using `DeleteCircuits`.

Failure Conditions
=============
In order to handle failures properly, we must ensure that the we can recover from failures between any of those six steps. Here we describe generally how they are handled:
- 1-2: The incoming link's forwarding package will replay any Adds that have not received a response. This makes the duplicate detection in `CommitCircuits` super critical.
- 2-3 A: Upon replay of Adds, the switch will detect that the Adds were never assigned keystones, and fail them back.
-2-3 B: If an HTLC fails locally in the outgoing link, it uses `FailCircuit` to close a circuit that was never opened. A response is delivered to the incoming link, which always checks its mailbox for a response before attempting to commit new circuits in the switch.
- 3-4: If a commitment was never signed, the preemptively opening of circuits can be reverted using `TrimOpenCircuits`. This is intended to be done once by the link at startup, and by each link as it is initialized to protect ourselves from inconsistencies stemming from flapping links.
- 4-5: The outgoing link's forwarding package will replay any Settles/Fails. As a caveat, the outgoing link may try to do so repeatedly if it flaps. The at-most-once semantics of `CloseCircuit` prevent duplicates responses from flowing back through.
- 5-6: The `CommitDiff` of each signed commitment records which circuits need to be deleted. After a restart, this is performed during channel resynchronization to make the circuit map consistent with the channel's state.

Note: This PR does not compile, as it is dependent on a number of other changes to the switch #761, #777, and #775.