### PR TITLE
multi: hidden service support for lnd 

### DIFF
--- a/channeldb/addr.go
+++ b/channeldb/addr.go
@@ -10,11 +10,11 @@ import (
 )
 
 // alphabet is the alphabet that the base32 library will use for encoding
-// and decoding v2 onion addresses.
+// and decoding v2 and v3 onion addresses.
 const alphabet = "abcdefghijklmnopqrstuvwxyz234567"
 
 // encoding represents a base32 encoding compliant with Tor's base32 encoding
-// scheme for v2 hidden services.
+// scheme for v2 and v3 hidden services.
 var encoding = base32.NewEncoding(alphabet)
 
 // addressType specifies the network protocol and version that should be used

--- a/channeldb/addr.go
+++ b/channeldb/addr.go
@@ -134,8 +134,8 @@ func deserializeAddr(r io.Reader) (net.Addr, error) {
 		if _, err := r.Read(hs[:]); err != nil {
 			return nil, err
 		}
-		onionString := encoding.EncodeToString(hs[:])
-		addr.HiddenService = append([]byte(onionString), []byte(".onion"))
+		onionString := encoding.EncodeToString(hs[:]) + ".onion"
+		addr.HiddenService = []byte(onionString)
 		address = addr
 	case v3OnionAddr:
 		// TODO(eugene)

--- a/channeldb/addr.go
+++ b/channeldb/addr.go
@@ -1,11 +1,21 @@
 package channeldb
 
 import (
+	"encoding/base32"
 	"io"
 	"net"
 
 	"github.com/btcsuite/go-socks/socks"
+	"github.com/lightningnetwork/lnd/torsvc"
 )
+
+// alphabet is the alphabet that the base32 library will use for encoding
+// and decoding v2 onion addresses.
+const alphabet = "abcdefghijklmnopqrstuvwxyz234567"
+
+// encoding represents a base32 encoding compliant with Tor's base32 encoding
+// scheme for v2 hidden services.
+var encoding = base32.NewEncoding(alphabet)
 
 // addressType specifies the network protocol and version that should be used
 // when connecting to a node at a particular address.
@@ -59,6 +69,29 @@ func encodeTCPAddr(w io.Writer, addr *net.TCPAddr) error {
 	return nil
 }
 
+func encodeOnionAddr(w io.Writer, addr *torsvc.OnionAddress) error {
+	var scratch [1]byte
+
+	if len(addr.HiddenService) == 22 {
+		// v2 hidden service
+		scratch[0] = uint8(v2OnionAddr)
+		if _, err := w.Write(scratch[:1]); err != nil {
+			return err
+		}
+		data, err := encoding.DecodeString(addr.String()[:16])
+		if err != nil {
+			return err
+		}
+		if _, err := w.Write(data); err != nil {
+			return err
+		}
+	} else {
+		// v3 hidden service
+	}
+
+	return nil
+}
+
 // deserializeAddr reads the serialized raw representation of an address and
 // deserializes it into the actual address, to avoid performing address
 // resolution in the database module
@@ -70,7 +103,6 @@ func deserializeAddr(r io.Reader) (net.Addr, error) {
 		return nil, err
 	}
 
-	// TODO(roasbeef): also add onion addrs
 	switch addressType(scratch[0]) {
 	case tcp4Addr:
 		addr := &net.TCPAddr{}
@@ -96,6 +128,17 @@ func deserializeAddr(r io.Reader) (net.Addr, error) {
 		}
 		addr.Port = int(byteOrder.Uint16(scratch[:2]))
 		address = addr
+	case v2OnionAddr:
+		addr := &torsvc.OnionAddress{}
+		var hs [10]byte
+		if _, err := r.Read(hs[:]); err != nil {
+			return nil, err
+		}
+		onionString := encoding.EncodeToString(hs[:])
+		addr.HiddenService = append([]byte(onionString), []byte(".onion"))
+		address = addr
+	case v3OnionAddr:
+		// TODO(eugene)
 	default:
 		return nil, ErrUnknownAddressType
 	}
@@ -110,6 +153,9 @@ func serializeAddr(w io.Writer, address net.Addr) error {
 	switch addr := address.(type) {
 	case *net.TCPAddr:
 		return encodeTCPAddr(w, addr)
+
+	case *torsvc.OnionAddress:
+		return encodeOnionAddr(w, addr)
 
 	// If this is a proxied address (due to the connection being
 	// established over a SOCKs proxy, then we'll convert it into its

--- a/config.go
+++ b/config.go
@@ -138,7 +138,7 @@ type torConfig struct {
 	Socks           string `long:"socks" description:"The port that Tor's exposed SOCKS5 proxy is listening on. Using Tor allows outbound-only connections (listening will be disabled) -- NOTE port must be between 1024 and 65535"`
 	Control         string `long:"control" description:"The port that Tor's ControlPort is listening on -- NOTE port must be between 1024 and 65535"`
 	ControlPassword string `long:"controlpass" description:"The password to be used for authenticating to Tor's ControlPort."`
-	VirtPort        string `long:"virtport" description:"The virtual port as described in Tor's control-spec to be used when creating hidden services -- NOTE port must be between 1024 and 65535"`
+	VirtPort        string `long:"virtport" description:"The virtual port as described in Tor's control-spec to be used when creating hidden services -- NOTE port can be below 1024"`
 	TargPort        string `long:"targport" description:"The target port as described in Tor's control-spec to be used when creating hidden services -- NOTE port must be between 1024 and 65535"`
 	PrivKey         string `long:"privkey" description:"The private key used to create a hidden service."`
 	Save            bool   `long:"save" description:"Save private keys to file when dealing with dynamically created hidden services."`

--- a/config.go
+++ b/config.go
@@ -40,6 +40,7 @@ const (
 	defaultRPCPort            = 10009
 	defaultRESTPort           = 8080
 	defaultPeerPort           = 9735
+	defaultOnionPort          = 80
 	defaultRPCHost            = "localhost"
 	defaultMaxPendingChannels = 1
 	defaultNoEncryptWallet    = false

--- a/config.go
+++ b/config.go
@@ -370,17 +370,7 @@ func loadConfig() (*config, error) {
 		// Validate targport
 		torport, err = strconv.Atoi(cfg.Tor.TargPort)
 		if err != nil || torport < 1024 || torport > 65535 {
-			str := "%s: The tor controlport must be between 1024 and 65535"
-			err := fmt.Errorf(str, funcName)
-			fmt.Fprintln(os.Stderr, err)
-			fmt.Fprintln(os.Stderr, usageMessage)
-			return nil, err
-		}
-
-		// Validate virtport
-		torport, err = strconv.Atoi(cfg.Tor.VirtPort)
-		if err != nil || torport < 1024 || torport > 65535 {
-			str := "%s: The tor controlport must be between 1024 and 65535"
+			str := "%s: The tor target port must be between 1024 and 65535"
 			err := fmt.Errorf(str, funcName)
 			fmt.Fprintln(os.Stderr, err)
 			fmt.Fprintln(os.Stderr, usageMessage)

--- a/lnwire/lnwire.go
+++ b/lnwire/lnwire.go
@@ -711,8 +711,8 @@ func readElement(r io.Reader, element interface{}) error {
 				if _, err = io.ReadFull(addrBuf, hs[:]); err != nil {
 					return err
 				}
-				onionString := encoding.EncodeToString(hs[:])
-				address.HiddenService = append([]byte(onionString), []byte(".onion"))
+				onionString := encoding.EncodeToString(hs[:]) + ".onion"
+				address.HiddenService = []byte(onionString)
 
 				// TODO(eugene) - port?
 

--- a/lnwire/lnwire.go
+++ b/lnwire/lnwire.go
@@ -12,11 +12,11 @@ import (
 	"net"
 
 	"github.com/go-errors/errors"
+	"github.com/lightningnetwork/lnd/torsvc"
 	"github.com/roasbeef/btcd/btcec"
 	"github.com/roasbeef/btcd/chaincfg/chainhash"
 	"github.com/roasbeef/btcd/wire"
 	"github.com/roasbeef/btcutil"
-	"github.com/lightningnetwork/lnd/torsvc"
 )
 
 // MaxSliceLength is the maximum allowed length for any opaque byte slices in

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -37,6 +37,7 @@ import (
 	"github.com/roasbeef/btcwallet/waddrmgr"
 	"github.com/tv42/zbase32"
 	"golang.org/x/net/context"
+	"github.com/lightningnetwork/lnd/torsvc"
 )
 
 var (
@@ -582,20 +583,48 @@ func (r *rpcServer) ConnectPeer(ctx context.Context,
 		return nil, fmt.Errorf("cannot make connection to self")
 	}
 
-	// If the address doesn't already have a port, we'll assume the current
-	// default port.
-	var addr string
-	_, _, err = net.SplitHostPort(in.Addr.Host)
+	var host net.Addr
+	addrLen := len(in.Addr.Host)
+	h, p, err := net.SplitHostPort(in.Addr.Host)
 	if err != nil {
-		addr = net.JoinHostPort(in.Addr.Host, strconv.Itoa(defaultPeerPort))
-	} else {
-		addr = in.Addr.Host
-	}
+		if (addrLen == 22 || addrLen == 62) && in.Addr.Host[addrLen-6:] == ".onion" {
+			// hidden service without a port
+			host = &torsvc.OnionAddress{
+				HiddenService: in.Addr.Host,
+				Port:          defaultOnionPort,
+			}
+		} else {
+			// ipv4/6 address without a port
+			addr := net.JoinHostPort(in.Addr.Host, strconv.Itoa(defaultPeerPort))
 
-	// We use ResolveTCPAddr here in case we wish to resolve hosts over Tor.
-	host, err := cfg.net.ResolveTCPAddr("tcp", addr)
-	if err != nil {
-		return nil, err
+			// We use ResolveTCPAddr here in case we wish to resolve hosts over Tor.
+			host, err = cfg.net.ResolveTCPAddr("tcp", addr)
+			if err != nil {
+				return nil, err
+			}
+		}
+	} else {
+		hostLen := len(h)
+		if (hostLen == 22 || hostLen == 62) && h[hostLen-6:] == ".onion" {
+			// hidden service with port
+			port, err := strconv.Atoi(p)
+			if err != nil {
+				return nil, err
+			}
+
+			host = &torsvc.OnionAddress{
+				HiddenService: h,
+				Port:          port,
+			}
+		} else {
+			// ipv4/6 address with port
+
+			// We use ResolveTCPAddr here in case we wish to resolve hosts over Tor.
+			host, err = cfg.net.ResolveTCPAddr("tcp", in.Addr.Host)
+			if err != nil {
+				return nil, err
+			}
+		}
 	}
 
 	peerAddr := &lnwire.NetAddress{

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -26,6 +26,7 @@ import (
 	"github.com/lightningnetwork/lnd/lnwallet"
 	"github.com/lightningnetwork/lnd/lnwire"
 	"github.com/lightningnetwork/lnd/routing"
+	"github.com/lightningnetwork/lnd/torsvc"
 	"github.com/lightningnetwork/lnd/zpay32"
 	"github.com/roasbeef/btcd/blockchain"
 	"github.com/roasbeef/btcd/btcec"
@@ -37,7 +38,6 @@ import (
 	"github.com/roasbeef/btcwallet/waddrmgr"
 	"github.com/tv42/zbase32"
 	"golang.org/x/net/context"
-	"github.com/lightningnetwork/lnd/torsvc"
 )
 
 var (

--- a/server.go
+++ b/server.go
@@ -306,7 +306,7 @@ func newServer(listenAddrs []string, chanDB *channeldb.DB, cc *chainControl,
 		// We have successfully created a v2 hidden service via the
 		// ControlPort and will now add it to the list of addresses
 		// we listen on.
-		p, err := strconv.Atoi(s.torCtrl.TargPort)
+		p, err := strconv.Atoi(s.torCtrl.VirtPort)
 		if err != nil {
 			return nil, err
 		}
@@ -317,6 +317,8 @@ func newServer(listenAddrs []string, chanDB *channeldb.DB, cc *chainControl,
 		}
 
 		selfAddrs = append(selfAddrs, onionAddr)
+
+		srvrLog.Infof("Listening on %s:%d", onionAddr.HiddenService, onionAddr.Port)
 	}
 
 	chanGraph := chanDB.ChannelGraph()

--- a/server.go
+++ b/server.go
@@ -890,7 +890,6 @@ func (s *server) establishPersistentConnections() error {
 		return err
 	}
 
-	// TODO(eugene) - onion addresses
 	for _, node := range linkNodes {
 		for _, address := range node.Addresses {
 			switch addr := address.(type) {
@@ -898,8 +897,12 @@ func (s *server) establishPersistentConnections() error {
 				if addr.Port == 0 {
 					addr.Port = defaultPeerPort
 				}
-			}
 
+			case *torsvc.OnionAddress:
+				if addr.Port == 0 {
+					addr.Port = defaultOnionPort
+				}
+			}
 		}
 		pubStr := string(node.IdentityPub.SerializeCompressed())
 

--- a/server.go
+++ b/server.go
@@ -639,7 +639,9 @@ func (s *server) Stop() error {
 	s.cc.feeEstimator.Stop()
 
 	// Disconnect from Tor's ControlPort.
-	s.torCtrl.Close()
+	if s.torCtrl != nil {
+		s.torCtrl.Close()
+	}
 
 	// Disconnect from each active peers to ensure that
 	// peerTerminationWatchers signal completion to each peer.

--- a/torsvc/onionaddr.go
+++ b/torsvc/onionaddr.go
@@ -5,19 +5,24 @@ import (
 	"strconv"
 )
 
+// OnionAddress is a struct housing a hidden service (v2 & v3) as well as the
+// Virtual Port that this hidden service can be reached at.
 type OnionAddress struct {
 	HiddenService string
-	Port int
+	Port          int
 }
 
 // A compile-time check to ensure that OnionAddress implements the net.Addr
 // interface.
 var _ net.Addr = (*OnionAddress)(nil)
 
+// String returns a string version of OnionAddress
 func (o *OnionAddress) String() string {
 	return net.JoinHostPort(o.HiddenService, strconv.Itoa(o.Port))
 }
 
+// Network returns the network that this implementation of net.Addr will use.
+// In this case, because Tor only allows "tcp", the network is "tcp".
 func (o *OnionAddress) Network() string {
 	// Tor only allows "tcp"
 	return "tcp"

--- a/torsvc/onionaddr.go
+++ b/torsvc/onionaddr.go
@@ -1,0 +1,23 @@
+package torsvc
+
+import (
+	"net"
+	"fmt"
+)
+
+type OnionAddress struct {
+	HiddenService []byte
+}
+
+// A compile-time check to ensure that OnionAddress implements the net.Addr
+// interface.
+var _ net.Addr = (*OnionAddress)(nil)
+
+func (o *OnionAddress) String() string {
+	return fmt.Sprintf("%s", o.HiddenService)
+}
+
+func (o *OnionAddress) Network() string {
+	// Tor only allows "tcp"
+	return "tcp"
+}

--- a/torsvc/onionaddr.go
+++ b/torsvc/onionaddr.go
@@ -2,11 +2,12 @@ package torsvc
 
 import (
 	"net"
-	"fmt"
+	"strconv"
 )
 
 type OnionAddress struct {
-	HiddenService []byte
+	HiddenService string
+	Port int
 }
 
 // A compile-time check to ensure that OnionAddress implements the net.Addr
@@ -14,7 +15,7 @@ type OnionAddress struct {
 var _ net.Addr = (*OnionAddress)(nil)
 
 func (o *OnionAddress) String() string {
-	return fmt.Sprintf("%s", o.HiddenService)
+	return net.JoinHostPort(o.HiddenService, strconv.Itoa(o.Port))
 }
 
 func (o *OnionAddress) Network() string {

--- a/torsvc/torcontrol.go
+++ b/torsvc/torcontrol.go
@@ -1,10 +1,10 @@
 package torsvc
 
 import (
-	"net"
-	"net/textproto"
 	"bufio"
 	"fmt"
+	"net"
+	"net/textproto"
 	"strings"
 )
 
@@ -15,6 +15,9 @@ const (
 	success = 250
 )
 
+// TorControl houses options for interacting with Tor's ControlPort. These
+// options determine the hidden service creation configuration that LND will use
+// when automatically creating hidden services.
 type TorControl struct {
 	conn     net.Conn
 	reader   *textproto.Reader
@@ -85,12 +88,12 @@ func (tc *TorControl) AddOnion() (string, error) {
 		return "", fmt.Errorf("Could not retrieve hidden service")
 	}
 
-	return messageStr[j+1:k], err
+	return messageStr[j+1 : k], err
 }
 
-// TODO(eugene)
 // DelOnion deletes a Tor v2 hidden service given its ServiceID.
 func (tc *TorControl) DelOnion() error {
+	// TODO(eugene)
 	return nil
 }
 
@@ -130,7 +133,7 @@ func (tc *TorControl) sendCommand(command string) (int, string, error) {
 	// variable.
 	code, message, err := tc.reader.ReadResponse(success)
 	if err != nil {
-		return code, message, fmt.Errorf("Reading Tor's ControlPort " +
+		return code, message, fmt.Errorf("Reading Tor's ControlPort "+
 			"command status failed: %s", err)
 	}
 

--- a/torsvc/torcontrol.go
+++ b/torsvc/torcontrol.go
@@ -1,0 +1,138 @@
+package torsvc
+
+import (
+	"net"
+	"net/textproto"
+	"bufio"
+	"fmt"
+	"strings"
+)
+
+const (
+	addStr  = "ADD_ONION"
+	authStr = "AUTHENTICATE"
+	delStr  = "DEL_ONION"
+	success = 250
+)
+
+type TorControl struct {
+	conn     net.Conn
+	reader   *textproto.Reader
+	Password string
+	Port     string
+	TargPort string
+	VirtPort string
+	PrivKey  string
+	Save     bool
+}
+
+// AuthWithPass authenticates via password to Tor's ControlPort.
+//
+// Note: AuthWithPass must be called even if the ControlPort has no
+// authentication mechanism in place.
+func (tc *TorControl) AuthWithPass() error {
+	_, _, err := tc.sendCommand(authStr + " \"" + tc.Password + "\"\n")
+	return err
+}
+
+// AddOnion creates a Tor v2 hidden service. This hidden service is available as
+// long as the connection to Tor's ControlPort is kept open.
+func (tc *TorControl) AddOnion() (string, error) {
+	var command string
+
+	// If a private key is provided to the AddOnion command, we use it instead
+	// of creating a new v2 hidden service.
+	if tc.PrivKey != "" {
+		command = addStr + " RSA1024:" + tc.PrivKey
+	} else {
+		command = addStr + " NEW:RSA1024"
+	}
+
+	// If we are not going to save this private key, set the DiscardPk flag.
+	if !tc.Save {
+		command += " Flags=DiscardPk"
+	}
+
+	// Add the VIRTPORT and TARGET ports to the command.
+	command += " Port=" + tc.VirtPort + "," + tc.TargPort + "\n"
+
+	// Send the command to Tor's ControlPort.
+	_, message, err := tc.sendCommand(command)
+	if tc.Save {
+		// TODO(eugene)
+		// Parse out the private key from response and store it somewhere.
+	}
+
+	// Parse out the hidden service from the response and return it.
+	i := strings.Index(message, "ServiceID")
+	if i == -1 {
+		return "", fmt.Errorf("Could not retrieve hidden service")
+	}
+
+	messageStr := message[i:]
+
+	j := strings.Index(messageStr, "=")
+	if j == -1 {
+		return "", fmt.Errorf("Could not retrieve hidden service")
+	}
+
+	k := strings.Index(messageStr, "\n")
+	if k == -1 {
+		return "", fmt.Errorf("Could not retrieve hidden service")
+	}
+
+	if j+1 >= k {
+		return "", fmt.Errorf("Could not retrieve hidden service")
+	}
+
+	return messageStr[j+1:k], err
+}
+
+// TODO(eugene)
+// DelOnion deletes a Tor v2 hidden service given its ServiceID.
+func (tc *TorControl) DelOnion() error {
+	return nil
+}
+
+// Open opens the connection to Tor's ControlPort.
+func (tc *TorControl) Open() error {
+	var err error
+	tc.conn, err = net.Dial("tcp", "localhost:"+tc.Port)
+	if err != nil {
+		return err
+	}
+
+	reader := bufio.NewReader(tc.conn)
+	tc.reader = textproto.NewReader(reader)
+
+	return nil
+}
+
+// Close closes the connection to Tor's ControlPort.
+func (tc *TorControl) Close() error {
+	if err := tc.conn.Close(); err != nil {
+		return err
+	}
+	tc.reader = nil
+	return nil
+}
+
+// sendCommand sends a command for execution to Tor's ControlPort.
+func (tc *TorControl) sendCommand(command string) (int, string, error) {
+	// Write command to Tor's ControlPort.
+	_, err := tc.conn.Write([]byte(command))
+	if err != nil {
+		return 0, "", fmt.Errorf("Writing to Tor's ControlPort failed: %s", err)
+	}
+
+	// ReadResponse supports multi-line responses whereas ReadCodeLine does not.
+	// In some cases, the response will need to be parsed out from the message
+	// variable.
+	code, message, err := tc.reader.ReadResponse(success)
+	if err != nil {
+		return code, message, fmt.Errorf("Reading Tor's ControlPort " +
+			"command status failed: %s", err)
+	}
+
+	return code, message, nil
+}


### PR DESCRIPTION
This PR adds support for hidden services to lnd.  Both v2 and v3 hidden services are supported.  When starting up lnd, if configured correctly, lnd will talk to Tor's ControlPort and will automatically create a v2 hidden service to listen on.  Currently v3 hidden service support via ControlPort is [unstable](https://blog.torproject.org/tor-0331-alpha-released-back-unstable-development) and will be added when it becomes stable.  Password authentication is the only authentication supported at this time to the ControlPort and the private keys to automatically created v2 hidden services are not saved.

Usage (v3 hidden service already exists - optionally specify port after hidden service):
`lnd ... --externalip=36nashufr653kgfvtwc5xr4pap2hcwcwzm4s5i5wrl22w3u7mjscegyd.onion`

Usage (automatically creating v2 hidden service):
NOTE `listen` and `targport` must be the same port.

`lnd --listen=localhost:10011 ... --tor.control=9051 --tor.controlpass=cat --tor.virtport=80 --tor.targport=10011`


I wasn't sure where or how to save the private keys generated by the ControlPort.  I also did not write code allowing for the aforementioned private keys to be passed into lnd.  Those are still TODOs. When this PR is merged, the lnd tor docs will need to be updated.