### PR TITLE
Fix License of use Lnd. 

### DIFF
--- a/docs/code_contribution_guidelines.md
+++ b/docs/code_contribution_guidelines.md
@@ -470,9 +470,8 @@ Rejoice as you will now be listed as a [contributor](https://github.com/lightnin
 
 #### 6.2. Licensing of Contributions
 ****
-All contributions must be licensed with the
-[MIT license](https://github.com/lightningnetwork/lnd/blob/master/LICENSE).  This is
-the same license as all of the code found within lnd.
+All contributions have Copyright (C) 2015-2018 The Lightning Network Developers
+This is the same license as all of the code found within lnd.
 
 
 ## Acknowledgements


### PR DESCRIPTION
Hi, 

this repository not use MIT default license 


this is not the full MIT license,

license is Copyright not MIT!
https://help.github.com/articles/licensing-a-repository/ 
example of the MIT license
https://github.com/angular/angular.js/blob/master/LICENSE 
not equal
https://github.com/lightningnetwork/lnd/commit/f6fde399e1f91fb951eda7ab485facedc1c72dc2#diff-9879d6db96fd29134fc802214163b95a

or the License Father MIT:
https://directory.fsf.org/wiki/License:X11