### PR TITLE
fix incorrect documentation in ruby.md from value to amt

### DIFF
--- a/docs/grpc/ruby.md
+++ b/docs/grpc/ruby.md
@@ -90,7 +90,7 @@ end
 Now, create an invoice on your node:
 
 ```bash
-$ lncli addinvoice --value=590
+$ lncli addinvoice --amt=590
 {
 	"r_hash": <R_HASH>,
 	"pay_req": <PAY_REQ>


### PR DESCRIPTION
it looks like this field name was changed from `value` to `amt` in https://github.com/lightningnetwork/lnd/commit/ffbcf7db4f09cb932123029d201a9feef7894d7d
but this one was missed.