### PR TITLE
glide: add explicit version to x/crypto deps

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 31c7557ef187f50de28557359e5179a47d5f4f153ec9b4f1ad264f771e7d1b5c
-updated: 2018-03-01T16:45:01.924542733-08:00
+hash: ca248eaf0ddf2e5daab59a13c8a62df255721e11fd10b0169b608f9c3349ad58
+updated: 2018-03-04T21:24:12.266291-05:00
 imports:
 - name: git.schwanenlied.me/yawning/bsaes.git
   version: e06297f34865a50b8e473105e52cb64ad1b55da8
@@ -45,13 +45,13 @@ imports:
 - name: github.com/btcsuite/websocket
   version: 31079b6807923eb23992c421b114992b95131b55
 - name: github.com/davecgh/go-spew
-  version: 8991bc29aa16c548c550c7ff78260e27b9ab7c73
+  version: ecdeabc65495df2dec95d7c4a4c3e021903035e5
   subpackages:
   - spew
 - name: github.com/go-errors/errors
-  version: 3afebba5a48dbc89b574d890b6b34d9ee10b4785
+  version: 8fa88b06e5974e97fbf9899a7f86a344bfd1f105
 - name: github.com/golang/protobuf
-  version: bbd03ef6da3a115852eaf24c8a1c46aeb39aa175
+  version: ab9f9a6dab164b7d1246e0e688b0ab7b94d8553e
   subpackages:
   - jsonpb
   - proto
@@ -93,7 +93,9 @@ imports:
   - chaincfg/chainhash
   - wire
 - name: github.com/miekg/dns
-  version: 5364553f1ee9cddc7ac8b62dce148309c386695b
+  version: 946bd9fbed05568b0f3cd188353d8aa28f38b688
+  subpackages:
+  - internal/socket
 - name: github.com/roasbeef/btcd
   version: e6807bc4dd5ddbb95b4ab163f6dd61e4ad79463a
   subpackages:
@@ -155,8 +157,6 @@ imports:
   - blake2b
   - chacha20poly1305
   - curve25519
-  - ed25519
-  - ed25519/internal/edwards25519
   - hkdf
   - internal/chacha20
   - nacl/box
@@ -169,35 +169,30 @@ imports:
   - scrypt
   - ssh/terminal
 - name: golang.org/x/net
-  version: cbe0f9307d0156177f9dd5dc85da1a31abc5f2fb
+  version: 66aacef3dd8a676686c7ae3716979581e8b03c47
   subpackages:
-  - bpf
   - context
   - http2
   - http2/hpack
   - idna
-  - internal/iana
-  - internal/socket
   - internal/timeseries
-  - ipv4
-  - ipv6
   - lex/httplex
   - proxy
   - trace
 - name: golang.org/x/sys
-  version: 88d2dcc510266da9f7f8c7f34e1940716cab5f5c
+  version: ab9e364efd8b52800ff7ee48a9ffba4e0ed78dfb
   subpackages:
   - unix
   - windows
 - name: golang.org/x/text
-  version: 27420a1a391f5504f73155051cd274311bf70883
+  version: 18c65dde6afd36dbc39197ca72008895b8dfbfb6
   subpackages:
   - secure/bidirule
   - transform
   - unicode/bidi
   - unicode/norm
 - name: google.golang.org/genproto
-  version: 2b5a72b8730b0b16380010cfe5286c42108d88e7
+  version: ee236bd376b077c7a89f260c026c4735b195e459
   subpackages:
   - googleapis/api/annotations
   - googleapis/rpc/status
@@ -221,7 +216,7 @@ imports:
 - name: gopkg.in/errgo.v1
   version: 442357a80af5c6bf9b6d51ae791a39c3421004f3
 - name: gopkg.in/macaroon-bakery.v2
-  version: 22c04a94d902625448265ef041bb53e715452a40
+  version: 04cf5ef151a211d929975161aea7c65f94c90446
   subpackages:
   - bakery
   - bakery/checkers

--- a/glide.yaml
+++ b/glide.yaml
@@ -45,6 +45,7 @@ import:
 - package: github.com/urfave/cli
   version: ^1.18.0
 - package: golang.org/x/crypto
+  version: 49796115aa4b964c318aad4f3084fdb41e9aa067
   subpackages:
   - hkdf
   - nacl/secretbox


### PR DESCRIPTION
This commit resolves an issue where glide would try to install an older
version of x/crypto, which for me resulted in blake2b not exposing the
interfaces required by the new aezeed package. Using the explicit
version has seemed to resolve this entirely.