### PR TITLE
Update go version for Docker lnd build

### DIFF
--- a/docker/lnd/Dockerfile
+++ b/docker/lnd/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.9
+FROM golang:1.10
 
 MAINTAINER Olaoluwa Osuntokun <lightning.engineering>
 

--- a/docker/lnd/Dockerfile
+++ b/docker/lnd/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.8
+FROM golang:1.9
 
 MAINTAINER Olaoluwa Osuntokun <lightning.engineering>
 


### PR DESCRIPTION
Per #815, https://github.com/lightningnetwork/lnd/blob/master/htlcswitch/circuit.go#L21 depends on go version >= 1.9

Before this change:
```
Building lnd
Step 1/11 : FROM golang:1.8
...
Step 9/11 : RUN go install . ./cmd/...
 ---> Running in 7f5d6ac430e5
# github.com/lightningnetwork/lnd/htlcswitch
htlcswitch/circuit.go:21: syntax error: unexpected = in type declaration
ERROR: Service 'lnd' failed to build: The command '/bin/sh -c go install . ./cmd/...' returned a non-zero code: 2
```
After:
```
Building lnd
Step 1/11 : FROM golang:1.9
1.9: Pulling from library/golang
3e731ddb7fc9: Pull complete
47cafa6a79d0: Pull complete
79fcf5a213c7: Pull complete
68e99216b7ad: Pull complete
9fc7abc9c77e: Pull complete
7fefae002ae5: Pull complete
7eef770e7cf3: Pull complete
fea064ba669b: Pull complete
Digest: sha256:caa4d6b6a468ffc4cc1f2d88cd95019bf057eb33bea1407dd55bd79755a26bb4
Status: Downloaded newer image for golang:1.9
 ---> 8ebf49f75a15
...
Step 9/11 : RUN go install . ./cmd/...
 ---> Running in ba871e58d517
Removing intermediate container ba871e58d517
 ---> fe16f8578770
Step 10/11 : COPY "docker/lnd/start-lnd.sh" .
...
 ---> 1f1d47432540
Successfully built 1f1d47432540
Successfully tagged lnd:latest
...
```