### PR TITLE
Remove deprecated --witness_only arg

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -83,7 +83,7 @@ $ docker-compose run btcctl getblockchaininfo | grep -A 1 segwit
 
 Check `Alice` balance:
 ```
-alice$ lncli walletbalance --witness_only=true
+alice$ lncli walletbalance
 ```
 
 Connect `Bob` node to `Alice` node.


### PR DESCRIPTION
`lncli` command `walletbalance` apparently no longer supports the `--witness_only` argument. With the deprecated argument:
```
root@8a9ad8528430:/go/src/github.com/lightningnetwork/lnd# lncli walletbalance --witness_only=true
Incorrect Usage: flag provided but not defined: -witness_only

NAME:
   lncli walletbalance - Compute and display the wallet's current balance

USAGE:
   lncli walletbalance [arguments...]
[lncli] flag provided but not defined: -witness_only
```
After removing that argument:
```
root@8a9ad8528430:/go/src/github.com/lightningnetwork/lnd# lncli walletbalance
{
    "total_balance": "1505000000000",
    "confirmed_balance": "1505000000000",
    "unconfirmed_balance": "0"
}
```