### PR TITLE
lnwallet/interface_test: extend publish timeout

### DIFF
--- a/lnwallet/interface_test.go
+++ b/lnwallet/interface_test.go
@@ -1841,7 +1841,7 @@ func waitForMempoolTx(r *rpctest.Harness, txid *chainhash.Hash) error {
 	var found bool
 	var tx *btcutil.Tx
 	var err error
-	timeout := time.After(10 * time.Second)
+	timeout := time.After(30 * time.Second)
 	for !found {
 		// Do a short wait
 		select {


### PR DESCRIPTION
This commit extends the amount of time we wait for transaction to enter the mempool from 10 to 30 seconds. The wallet's interface tests seem to be particularly slow when run with the race flag, a problem which is only exacerbated by the slowness of travis.

The bug in question is:
```
--- FAIL: TestLightningWallet/btcwallet/bitcoind:publish_transaction (28.59s)
          interface_test.go:1362: tx not relayed to miner: timeout after 10s
```
which can sometimes arise on neutrino as well.

With 10s and the race flag, I was able to repro the issues locally fairly consistently. I have not seen it arise with the longer timeout.