### PR TITLE
Configurable CoinType for HD Derivation

### DIFF
--- a/chainparams.go
+++ b/chainparams.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"github.com/lightningnetwork/lnd/keychain"
 	litecoinCfg "github.com/ltcsuite/ltcd/chaincfg"
 	"github.com/roasbeef/btcd/chaincfg"
 	bitcoinCfg "github.com/roasbeef/btcd/chaincfg"
@@ -16,41 +17,47 @@ var activeNetParams = bitcoinTestNetParams
 // corresponding RPC port of a daemon running on the particular network.
 type bitcoinNetParams struct {
 	*bitcoinCfg.Params
-	rpcPort string
+	rpcPort  string
+	CoinType uint32
 }
 
 // litecoinNetParams couples the p2p parameters of a network with the
 // corresponding RPC port of a daemon running on the particular network.
 type litecoinNetParams struct {
 	*litecoinCfg.Params
-	rpcPort string
+	rpcPort  string
+	CoinType uint32
 }
 
 // bitcoinTestNetParams contains parameters specific to the 3rd version of the
 // test network.
 var bitcoinTestNetParams = bitcoinNetParams{
-	Params:  &bitcoinCfg.TestNet3Params,
-	rpcPort: "18334",
+	Params:   &bitcoinCfg.TestNet3Params,
+	rpcPort:  "18334",
+	CoinType: keychain.CoinTypeTestnet,
 }
 
 // bitcoinSimNetParams contains parameters specific to the simulation test
 // network.
 var bitcoinSimNetParams = bitcoinNetParams{
-	Params:  &bitcoinCfg.SimNetParams,
-	rpcPort: "18556",
+	Params:   &bitcoinCfg.SimNetParams,
+	rpcPort:  "18556",
+	CoinType: keychain.CoinTypeTestnet,
 }
 
 // liteTestNetParams contains parameters specific to the 4th version of the
 // test network.
 var liteTestNetParams = litecoinNetParams{
-	Params:  &litecoinCfg.TestNet4Params,
-	rpcPort: "19334",
+	Params:   &litecoinCfg.TestNet4Params,
+	rpcPort:  "19334",
+	CoinType: keychain.CoinTypeTestnet,
 }
 
 // regTestNetParams contains parameters specific to a local regtest network.
 var regTestNetParams = bitcoinNetParams{
-	Params:  &bitcoinCfg.RegressionNetParams,
-	rpcPort: "18334",
+	Params:   &bitcoinCfg.RegressionNetParams,
+	rpcPort:  "18334",
+	CoinType: keychain.CoinTypeTestnet,
 }
 
 // applyLitecoinParams applies the relevant chain configuration parameters that
@@ -91,4 +98,5 @@ func applyLitecoinParams(params *bitcoinNetParams) {
 	params.Checkpoints = checkPoints
 
 	params.rpcPort = liteTestNetParams.rpcPort
+	params.CoinType = liteTestNetParams.CoinType
 }

--- a/chainregistry.go
+++ b/chainregistry.go
@@ -134,6 +134,7 @@ func newChainControlFromConfig(cfg *config, chanDB *channeldb.DB,
 		DataDir:      homeChainConfig.ChainDir,
 		NetParams:    activeNetParams.Params,
 		FeeEstimator: cc.feeEstimator,
+		CoinType:     activeNetParams.CoinType,
 	}
 
 	var (
@@ -436,6 +437,10 @@ func newChainControlFromConfig(cfg *config, chanDB *channeldb.DB,
 	cc.signer = wc
 	cc.chainIO = wc
 
+	keyRing := keychain.NewBtcWalletKeyRing(
+		wc.InternalWallet(), activeNetParams.CoinType,
+	)
+
 	// Create, and start the lnwallet, which handles the core payment
 	// channel logic, and exposes control via proxy state machines.
 	walletCfg := lnwallet.Config{
@@ -444,7 +449,7 @@ func newChainControlFromConfig(cfg *config, chanDB *channeldb.DB,
 		WalletController:   wc,
 		Signer:             cc.signer,
 		FeeEstimator:       cc.feeEstimator,
-		SecretKeyRing:      keychain.NewBtcWalletKeyRing(wc.InternalWallet()),
+		SecretKeyRing:      keyRing,
 		ChainIO:            cc.chainIO,
 		DefaultConstraints: defaultChannelConstraints,
 		NetParams:          *activeNetParams.Params,

--- a/keychain/btcwallet.go
+++ b/keychain/btcwallet.go
@@ -10,15 +10,21 @@ import (
 	"github.com/roasbeef/btcwallet/walletdb"
 )
 
-var (
-	// lightningKeyScope is the key scope that will be used within the
-	// waddrmgr to create an HD chain for deriving all of our required
-	// keys.
-	lightningKeyScope = waddrmgr.KeyScope{
-		Purpose: BIP0043Purpose,
-		Coin:    0,
-	}
+const (
+	// CoinTypeBitcoin specifies the BIP44 coin type for Bitcoin key
+	// derivation.
+	CoinTypeBitcoin uint32 = 0
 
+	// CoinTypeTestnet specifies the BIP44 coin type for all testnet key
+	// derivation.
+	CoinTypeTestnet = 1
+
+	// CoinTypeLitecoin specifies the BIP44 coin type for Litecoin key
+	// derivation.
+	CoinTypeLitecoin = 2
+)
+
+var (
 	// lightningAddrSchema is the scope addr schema for all keys that we
 	// derive. We'll treat them all as p2wkh addresses, as atm we must
 	// specify a particular type.
@@ -44,6 +50,10 @@ type BtcWalletKeyRing struct {
 	// transactions in order to derive addresses and lookup relevant keys
 	wallet *wallet.Wallet
 
+	// chainKeyScope defines the purpose and coin type to be used when generating
+	// keys for this keyring.
+	chainKeyScope waddrmgr.KeyScope
+
 	// lightningScope is a pointer to the scope that we'll be using as a
 	// sub key manager to derive all the keys that we require.
 	lightningScope *waddrmgr.ScopedKeyManager
@@ -54,9 +64,18 @@ type BtcWalletKeyRing struct {
 //
 // NOTE: The passed waddrmgr.Manager MUST be unlocked in order for the keychain
 // to function.
-func NewBtcWalletKeyRing(w *wallet.Wallet) SecretKeyRing {
+func NewBtcWalletKeyRing(w *wallet.Wallet, coinType uint32) SecretKeyRing {
+	// Construct the key scope that will be used within the waddrmgr to
+	// create an HD chain for deriving all of our required keys. A different
+	// scope is used for each specific coin type.
+	chainKeyScope := waddrmgr.KeyScope{
+		Purpose: BIP0043Purpose,
+		Coin:    coinType,
+	}
+
 	return &BtcWalletKeyRing{
-		wallet: w,
+		wallet:        w,
+		chainKeyScope: chainKeyScope,
 	}
 }
 
@@ -80,9 +99,7 @@ func (b *BtcWalletKeyRing) keyScope() (*waddrmgr.ScopedKeyManager, error) {
 
 	// If the manager is indeed unlocked, then we'll fetch the scope, cache
 	// it, and return to the caller.
-	lnScope, err := b.wallet.Manager.FetchScopedKeyManager(
-		lightningKeyScope,
-	)
+	lnScope, err := b.wallet.Manager.FetchScopedKeyManager(b.chainKeyScope)
 	if err != nil {
 		return nil, err
 	}

--- a/lnwallet/btcwallet/config.go
+++ b/lnwallet/btcwallet/config.go
@@ -75,6 +75,9 @@ type Config struct {
 
 	// NetParams is the net parameters for the target chain.
 	NetParams *chaincfg.Params
+
+	// CoinType specifies the BIP 44 coin type to be used for derivation.
+	CoinType uint32
 }
 
 // NetworkDir returns the directory name of a network directory to hold wallet

--- a/lnwallet/btcwallet/signer.go
+++ b/lnwallet/btcwallet/signer.go
@@ -83,7 +83,7 @@ func (b *BtcWallet) fetchPrivKey(keyDesc *keychain.KeyDescriptor) (*btcec.Privat
 	if !keyDesc.KeyLocator.IsEmpty() {
 		// We'll assume the special lightning key scope in this case.
 		scopedMgr, err := b.wallet.Manager.FetchScopedKeyManager(
-			lightningKeyScope,
+			b.chainKeyScope,
 		)
 		if err != nil {
 			return nil, err

--- a/lnwallet/interface_test.go
+++ b/lnwallet/interface_test.go
@@ -2149,6 +2149,7 @@ func runTests(t *testing.T, walletDriver *lnwallet.WalletDriver,
 			NetParams:    netParams,
 			ChainSource:  aliceClient,
 			FeeEstimator: feeEstimator,
+			CoinType:     keychain.CoinTypeTestnet,
 		}
 		aliceWalletController, err = walletDriver.New(aliceWalletConfig)
 		if err != nil {
@@ -2157,6 +2158,7 @@ func runTests(t *testing.T, walletDriver *lnwallet.WalletDriver,
 		aliceSigner = aliceWalletController.(*btcwallet.BtcWallet)
 		aliceKeyRing = keychain.NewBtcWalletKeyRing(
 			aliceWalletController.(*btcwallet.BtcWallet).InternalWallet(),
+			keychain.CoinTypeTestnet,
 		)
 
 		bobWalletConfig := &btcwallet.Config{
@@ -2166,6 +2168,7 @@ func runTests(t *testing.T, walletDriver *lnwallet.WalletDriver,
 			NetParams:    netParams,
 			ChainSource:  bobClient,
 			FeeEstimator: feeEstimator,
+			CoinType:     keychain.CoinTypeTestnet,
 		}
 		bobWalletController, err = walletDriver.New(bobWalletConfig)
 		if err != nil {
@@ -2174,6 +2177,7 @@ func runTests(t *testing.T, walletDriver *lnwallet.WalletDriver,
 		bobSigner = bobWalletController.(*btcwallet.BtcWallet)
 		bobKeyRing = keychain.NewBtcWalletKeyRing(
 			bobWalletController.(*btcwallet.BtcWallet).InternalWallet(),
+			keychain.CoinTypeTestnet,
 		)
 		bio = bobWalletController.(*btcwallet.BtcWallet)
 	default:


### PR DESCRIPTION
In order to support independent key derivation for both BTC and LTC, this PR adds the ability to parameterize keyrings generated by the new `keychain` package using a BIP 44 coin type. Each of our chain params now carries `CoinType` field, which is passed down to the btcwallet using `activeNetParams`. Three coin type constants are now defined in the `keychain` package, in accordance with [slip-0044](https://github.com/satoshilabs/slips/blob/master/slip-0044.md):
1. `keychain.CoinTypeBitcion = 0`
1. `keychain.CoinTypeTestnet = 1`
1. `keychain.CoinTypeLitecoin = 2`

The `keychain` tests have been extended to also test derivation for each of these scopes.