### PR TITLE
Litecoind Backend

### DIFF
--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -178,17 +178,33 @@ installing `lnd` in preparation for the
 lnd --bitcoin.active --bitcoin.testnet --debuglevel=debug --btcd.rpcuser=kek --btcd.rpcpass=kek --externalip=X.X.X.X
 ```
 
-#### Running lnd using the bitcoind backend
+#### Running lnd using the bitcoind or litecoind backend
 
-To configure your bitcoind backend for use with lnd, first complete and verify the following:
+The configuration for bitcoind and litecoind are nearly identical, the following
+steps can be mirrored with loss of generality to enable a litecoind backend.
+Setup will be described in regards to `bitciond`, but note that `lnd` uses a
+distinct `litecoin.node=litecoind` argument and analogous subconfigurations
+prefixed by `litecoind`.
 
-- The `bitcoind` instance must
-be configured with `--txindex` just like `btcd` above
-- Additionally, since `lnd` uses [ZeroMQ](https://github.com/bitcoin/bitcoin/blob/master/doc/zmq.md) to interface with `bitcoind`, *your `bitcoind` installation must be compiled with ZMQ*. If you installed it from source, this is likely the case, but if you installed it via Homebrew in the past it may not be included ([this has now been fixed](https://github.com/Homebrew/homebrew-core/pull/23088) in the latest Homebrew recipe for bitcoin)
-- Configure the `bitcoind` instance for ZMQ with `--zmqpubrawblock` and `--zmqpubrawtx`
-(the latter is optional but allows you to see unconfirmed transactions in your
-wallet). They must be combined in the same ZMQ socket address (e.g. `--zmqpubrawblock=tcp://127.0.0.1:28332` and `--zmqpubrawtx=tcp://127.0.0.1:28332`).
-- Start `bitcoind` running against testnet, and let it complete a full sync with the testnet chain (alternatively, use `--bitcoind.regtest` instead).
+To configure your bitcoind backend for use with lnd, first complete and verify
+the following:
+
+- The `bitcoind` instance must be configured with `--txindex` just like `btcd`
+  above
+- Additionally, since `lnd` uses
+  [ZeroMQ](https://github.com/bitcoin/bitcoin/blob/master/doc/zmq.md) to
+  interface with `bitcoind`, *your `bitcoind` installation must be compiled with
+  ZMQ*. If you installed it from source, this is likely the case, but if you
+  installed it via Homebrew in the past it may not be included ([this has now
+  been fixed](https://github.com/Homebrew/homebrew-core/pull/23088) in the
+  latest Homebrew recipe for bitcoin)
+- Configure the `bitcoind` instance for ZMQ with `--zmqpubrawblock` and
+  `--zmqpubrawtx` (the latter is optional but allows you to see unconfirmed
+  transactions in your wallet). They must be combined in the same ZMQ socket
+  address (e.g. `--zmqpubrawblock=tcp://127.0.0.1:28332` and
+  `--zmqpubrawtx=tcp://127.0.0.1:28332`).
+- Start `bitcoind` running against testnet, and let it complete a full sync with
+  the testnet chain (alternatively, use `--bitcoind.regtest` instead).
 
 Here's a sample `bitcoin.conf` for use with lnd:
 ```
@@ -268,8 +284,8 @@ Notice the `[Bitcoin]` section. This section houses the parameters for the
 Bitcoin chain. `lnd` also supports Litecoin testnet4 (but not both BTC and LTC
 at the same time), so when working with Litecoin be sure to set to parameters
 for Litecoin accordingly. For node configuration, the sections are called
-`[Btcd]`, `[Bitcoind]`, `[Neutrino]`, and `[Ltcd]` depending on which chain
-and node type you're using.
+`[Btcd]`, `[Bitcoind]`, `[Neutrino]`, `[Ltcd]`, and `[Litecoind]` depending on
+which chain and node type you're using.
 
 # Accurate as of:
 - _roasbeef/btcd commit:_ `f8c02aff4e7a807ba0c1349e2db03695d8e790e8` 

--- a/fundingmanager.go
+++ b/fundingmanager.go
@@ -42,12 +42,19 @@ const (
 	// TODO(roasbeef): add command line param to modify
 	maxFundingAmount = btcutil.Amount(1 << 24)
 
-	// minRemoteDelay and maxRemoteDelay is the extremes of the CSV delay
-	// we will require the remote to use for its commitment transaction.
-	// The actual delay we will require will be somewhere between these
-	// values, depending on channel size.
-	minRemoteDelay = 144
-	maxRemoteDelay = 2016
+	// minBtcRemoteDelay and maxBtcRemoteDelay is the extremes of the
+	// Bitcoin CSV delay we will require the remote to use for its
+	// commitment transaction. The actual delay we will require will be
+	// somewhere between these values, depending on channel size.
+	minBtcRemoteDelay uint16 = 144
+	maxBtcRemoteDelay uint16 = 2016
+
+	// minLtcRemoteDelay and maxLtcRemoteDelay is the extremes of the
+	// Litecoin CSV delay we will require the remote to use for its
+	// commitment transaction. The actual delay we will require will be
+	// somewhere between these values, depending on channel size.
+	minLtcRemoteDelay uint16 = 576
+	maxLtcRemoteDelay uint16 = 8064
 
 	// maxWaitNumBlocksFundingConf is the maximum number of blocks to wait
 	// for the funding transaction to be confirmed before forgetting about

--- a/fundingmanager_test.go
+++ b/fundingmanager_test.go
@@ -166,7 +166,7 @@ func createTestWallet(cdb *channeldb.DB, netParams *chaincfg.Params,
 		ChainIO:            bio,
 		FeeEstimator:       estimator,
 		NetParams:          *netParams,
-		DefaultConstraints: defaultChannelConstraints,
+		DefaultConstraints: defaultBtcChannelConstraints,
 	})
 	if err != nil {
 		return nil, err

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -2095,6 +2095,9 @@ func (r *rpcServer) AddInvoice(ctx context.Context,
 	default:
 		// TODO(roasbeef): assumes set delta between versions
 		defaultDelta := cfg.Bitcoin.TimeLockDelta
+		if registeredChains.PrimaryChain() == litecoinChain {
+			defaultDelta = cfg.Litecoin.TimeLockDelta
+		}
 		options = append(options, zpay32.CLTVExpiry(uint64(defaultDelta)))
 	}
 


### PR DESCRIPTION
Adds `litecoind` backend and configuration for `lnd`. Internally, this uses the same driver as `bitciond`, so we are able to reuse the majority of the logic. The node configuration options have also been expanded to include `ltcd` and `litecoind` distinctly.

The supported backend types are:
- `bitcoind.node=[btcd|bitcoind|neutrino]`
- `litecoind.node=[ltcd|litecoind]`

supporting analogous configurations to `bitcoind`, e.g.
- `litecoind.rpcuser`
- `litecoind.rpcpassword`
- `litecoind.zmqpath`
- etc.

Note, due to some limitations of the cli tooling, both will display `[btcd|bitcond|neutrino|ltcd|litecoind]` as options, but will fail if backends for the wrong chain are swapped.

I've also moved the majority of the chain-related constants into `chainregistry.go`, and updated them to include types where appropriate in their definition. The notable parameter changes are:
- bump the Litecoin default static fee estimator rate from 100 msat to 200 mlit.
- introduce Litecoin min relay tx of 1000 litoshis.

The docs have been updated explaining that setup is identical to `bitciond` except for the use of `litecoind` configuration arguments.

