### PR TITLE
lnd_test: removes unnecessary disconnects from switch itest

### DIFF
--- a/lnd_test.go
+++ b/lnd_test.go
@@ -7208,16 +7208,6 @@ func testSwitchOfflineDelivery(net *lntest.NetworkHarness, t *harnessTest) {
 	assertAmountPaid(t, ctxb, "Bob(local) => Alice(remote)", net.Bob,
 		aliceFundPoint, amountPaid+(baseFee*numPayments)*2, int64(0))
 
-	ctxt, _ = context.WithTimeout(ctxb, timeout)
-	if err := net.DisconnectNodes(ctxt, dave, net.Alice); err != nil {
-		t.Fatalf("unable to disconnect alice from dave: %v", err)
-	}
-
-	ctxt, _ = context.WithTimeout(ctxb, timeout)
-	if err := net.ConnectNodes(ctxt, dave, net.Alice); err != nil {
-		t.Fatalf("unable to reconnect alice to dave: %v", err)
-	}
-
 	// Lastly, we will send one more payment to ensure all channels are
 	// still functioning properly.
 	finalInvoice := &lnrpc.Invoice{
@@ -7523,16 +7513,6 @@ func testSwitchOfflineDeliveryPersistence(net *lntest.NetworkHarness, t *harness
 		aliceFundPoint, int64(0), amountPaid+((baseFee*numPayments)*2))
 	assertAmountPaid(t, ctxb, "Bob(local) => Alice(remote)", net.Bob,
 		aliceFundPoint, amountPaid+(baseFee*numPayments)*2, int64(0))
-
-	ctxt, _ = context.WithTimeout(ctxb, timeout)
-	if err := net.DisconnectNodes(ctxt, dave, net.Alice); err != nil {
-		t.Fatalf("unable to disconnect alice from dave: %v", err)
-	}
-
-	ctxt, _ = context.WithTimeout(ctxb, timeout)
-	if err := net.ConnectNodes(ctxt, dave, net.Alice); err != nil {
-		t.Fatalf("unable to reconnect alice to dave: %v", err)
-	}
 
 	// Lastly, we will send one more payment to ensure all channels are
 	// still functioning properly.


### PR DESCRIPTION
This commit removes two unnecessary disconnect/reconnect attempts
from the switch itest. Both occur after the primary test has been
completed, and were being executed before doing a final sanity check
that the path is still usable. Nothing about the test behavior should
change.

Honestly don't remember the reason they were added in the first place,
might have been stragglers. This should fix an issue where the final payment
reports `UnknownNextPeer` due to the links not having fully reactivated.