### PR TITLE
lnd_test: swap connection direction of EnsureConnected

### DIFF
--- a/lnd_test.go
+++ b/lnd_test.go
@@ -6847,7 +6847,7 @@ func testSwitchCircuitPersistence(net *lntest.NetworkHarness, t *harnessTest) {
 	}
 
 	ctxt, _ = context.WithTimeout(ctxb, timeout)
-	err = net.EnsureConnected(ctxt, dave, carol)
+	err = net.EnsureConnected(ctxt, carol, dave)
 	if err != nil {
 		t.Fatalf("unable to reconnect dave and carol: %v", err)
 	}
@@ -7460,7 +7460,7 @@ func testSwitchOfflineDeliveryPersistence(net *lntest.NetworkHarness, t *harness
 	// Make Carol and Dave are reconnected before waiting for the htlcs to
 	// clear.
 	ctxt, _ = context.WithTimeout(ctxb, timeout)
-	err = net.EnsureConnected(ctxt, dave, carol)
+	err = net.EnsureConnected(ctxt, carol, dave)
 	if err != nil {
 		t.Fatalf("unable to reconnect dave and carol: %v", err)
 	}


### PR DESCRIPTION
Swaps the ordering of two calls to `EnsureConnected` where one node is restarted and needs to be reconnected to a still-standing node. It seems the exponential backoff of the still-standing node interferes with the call to `EnsureConnected`. To remedy this, we ensure the node that is restarted makes the connection request since it is not encumbered by any backoff.

This PR has been rebased over all outstanding improvements to the switch integration tests, we'll see how it goes on Travis 🙈