### PR TITLE
discovery: format log message with Errorf

### DIFF
--- a/discovery/gossiper.go
+++ b/discovery/gossiper.go
@@ -1571,7 +1571,7 @@ func (d *AuthenticatedGossiper) processNetworkAnnouncement(nMsg *networkMsg) []n
 		// We'll ignore any channel announcements that target any chain
 		// other than the set of chains we know of.
 		if !bytes.Equal(msg.ChainHash[:], d.cfg.ChainHash[:]) {
-			log.Error("Ignoring ChannelUpdate from "+
+			log.Errorf("Ignoring ChannelUpdate from "+
 				"chain=%v, gossiper on chain=%v", msg.ChainHash,
 				d.cfg.ChainHash)
 			d.rejectMtx.Lock()


### PR DESCRIPTION
Fixes a typo in the log message formatting.