### PR TITLE
discovery/gossiper: use Errorf instead of Error in log stmnt

### DIFF
--- a/discovery/gossiper.go
+++ b/discovery/gossiper.go
@@ -1363,7 +1363,7 @@ func (d *AuthenticatedGossiper) processNetworkAnnouncement(nMsg *networkMsg) []n
 		// We'll ignore any channel announcements that target any chain
 		// other than the set of chains we know of.
 		if !bytes.Equal(msg.ChainHash[:], d.cfg.ChainHash[:]) {
-			log.Error("Ignoring ChannelAnnouncement from "+
+			log.Errorf("Ignoring ChannelAnnouncement from "+
 				"chain=%v, gossiper on chain=%v", msg.ChainHash,
 				d.cfg.ChainHash)
 			d.rejectMtx.Lock()


### PR DESCRIPTION
Fixes a case where we don't properly format the log statement when ignoring announcements that belong to a chain we don't recognize.