### PR TITLE
Docs: Inconsistent ZMQ port numbers in examples

### DIFF
--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -212,8 +212,8 @@ testnet=1
 txindex=1
 server=1
 daemon=1
-zmqpubrawblock=tcp://127.0.0.1:18501
-zmqpubrawtx=tcp://127.0.0.1:18501
+zmqpubrawblock=tcp://127.0.0.1:28332
+zmqpubrawtx=tcp://127.0.0.1:28332
 ```
 
 Once all of the above is complete, and you've confirmed `bitcoind` is fully updated with the latest blocks on testnet, run the command below to launch `lnd` with `bitcoind` as your backend (as with `bitcoind`, you can create an `lnd.conf` to save these options, more info on that is described further below):


### PR DESCRIPTION
The port numbers used in the ZMQ examples are inconsistent between:

- The initial explanation of ZMQ
```
They must be combined in the same ZMQ socket
  address (e.g. `--zmqpubrawblock=tcp://127.0.0.1:28332` and
  `--zmqpubrawtx=tcp://127.0.0.1:28332`).
```

- The sample bitcoin.conf
```
zmqpubrawblock=tcp://127.0.0.1:18501
zmqpubrawtx=tcp://127.0.0.1:18501
```

- The lnd command-line example:
```
lnd --bitcoin.active --bitcoin.testnet --debuglevel=debug --bitcoin.node=bitcoind --bitcoind.rpcuser=REPLACEME --bitcoind.rpcpass=REPLACEME --bitcoind.zmqpath=tcp://127.0.0.1:28332 --externalip=X.X.X.X
```

I changed the sample bitcoin.conf port numbers to 28332 so they match the rest of the examples.