### PR TITLE
Update INSTALL.md

### DIFF
--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -34,7 +34,7 @@
     that your shell will be able to detect the binaries you install.
 
     ```bash
-    export GOPATH=~/gocode
+    export GOPATH=~/go
     export PATH=$PATH:$GOPATH/bin
     ```
 


### PR DESCRIPTION
Went through installation on MacOS High Sieria v. 10.13.3 and installed Go with Homebrew but the installed folder's name was not "gocode" so the export paths did not work by blindly following the instructions. Since the instructions are suggesting using Homebrew's installation, these paths should match.