### PR TITLE
move defaultchanconfs setting in sample-lnd.conf to bitcoin section

### DIFF
--- a/sample-lnd.conf
+++ b/sample-lnd.conf
@@ -90,11 +90,6 @@
 ; The maximum number of incoming pending channels permitted per peer.
 ; maxpendingchannels=1
 
-; The default number of confirmations a channel must have before it's considered
-; open. We'll require any incoming channel requests to wait this many
-; confirmations before we consider the channel active.
-; defaultchanconfs=3
-                       
 ; If true, then automatic network bootstrapping will not be attempted. This
 ; means that your node won't attempt to automatically seek out peers on the
 ; network.
@@ -137,6 +132,11 @@ bitcoin.node=btcd
 
 ; Use the neutrino (light client) back-end
 ; bitcoin.node=neutrino
+
+; The default number of confirmations a channel must have before it's considered
+; open. We'll require any incoming channel requests to wait this many
+; confirmations before we consider the channel active.
+; bitcoin.defaultchanconfs=3
 
 
 [Btcd]


### PR DESCRIPTION
It looks like, since https://github.com/lightningnetwork/lnd/pull/506, `defaultchanconfs` is nested under `bitcoin`. Using this parameter at the top level generates a warning message:
```
2018-03-17 23:07:08.273 [WRN] LTND: /home/bitcoin/.lnd/lnd.conf:7: unknown option: defaultchanconfs
```
and using it nested under `bitcoin` does not. 