### PR TITLE
macaroons: don't attempt zeroing key from mem if it doesn't exist

### DIFF
--- a/macaroons/store.go
+++ b/macaroons/store.go
@@ -196,6 +196,8 @@ func (r *RootKeyStorage) RootKey(_ context.Context) ([]byte, []byte, error) {
 // Close closes the underlying database and zeroes the encryption key stored
 // in memory.
 func (r *RootKeyStorage) Close() error {
-	r.encKey.Zero()
+	if r.encKey != nil {
+		r.encKey.Zero()
+	}
 	return r.DB.Close()
 }


### PR DESCRIPTION
Solves the issue [mentioned in Slack](https://lightningcommunity.slack.com/archives/C6BKD3RKR/p1521328392000048) where if the wallet unlocker is unable to bind to any ports at startup then this store will be Close()'d even though it was never unlocked, causing a panic.