### PR TITLE
Fix typos in comments

### DIFF
--- a/chancloser.go
+++ b/chancloser.go
@@ -20,7 +20,7 @@ var (
 	ErrChanAlreadyClosing = fmt.Errorf("channel shutdown already initiated")
 
 	// ErrChanCloseNotFinished is returned when a caller attempts to access
-	// a field or function that is continent on the channel closure
+	// a field or function that is contingent on the channel closure
 	// negotiation already being completed.
 	ErrChanCloseNotFinished = fmt.Errorf("close negotiation not finished")
 
@@ -36,8 +36,8 @@ var (
 type closeState uint8
 
 const (
-	// closeIdle is the initial starting state. In this state, the stat
-	// machine has been instantiated, but not state transitions have been
+	// closeIdle is the initial starting state. In this state, the state
+	// machine has been instantiated, but no state transitions have been
 	// attempted. If a state machine receives a message while in this
 	// state, then it is the responder to an initiated cooperative channel
 	// closure.
@@ -51,16 +51,16 @@ const (
 	closeShutdownInitiated
 
 	// closeFeeNegotiation is the third, and most persistent state. Both
-	// parties enter this state after they've sent and receive a shutdown
+	// parties enter this state after they've sent and received a shutdown
 	// message. During this phase, both sides will send monotonically
 	// increasing fee requests until one side accepts the last fee rate
 	// offered by the other party. In this case, the party will broadcast
 	// the closing transaction, and send the accepted fee to the remote
-	// party. This then causes a shift into the close finished state.
+	// party. This then causes a shift into the closeFinished state.
 	closeFeeNegotiation
 
 	// closeFinished is the final state of the state machine. In this,
-	// state, a side has accepted a fee offer and has broadcast the valid
+	// state a side has accepted a fee offer and has broadcast the valid
 	// closing transaction to the network. During this phase, the closing
 	// transaction becomes available for examination.
 	closeFinished
@@ -192,7 +192,7 @@ func newChannelCloser(cfg chanCloseCfg, deliveryScript []byte,
 	}
 }
 
-// initChanShutdown beings the shutdown process by un-registering the channel,
+// initChanShutdown begins the shutdown process by un-registering the channel,
 // and creating a valid shutdown message to our target delivery address.
 func (c *channelCloser) initChanShutdown() (*lnwire.Shutdown, error) {
 	// With both items constructed we'll now send the shutdown message for
@@ -203,7 +203,7 @@ func (c *channelCloser) initChanShutdown() (*lnwire.Shutdown, error) {
 	// TODO(roasbeef): err if channel has htlc's?
 
 	// Before returning the shutdown message, we'll unregister the channel
-	// to ensure that it isn't see as usable within the system.
+	// to ensure that it isn't seen as usable within the system.
 	//
 	// TODO(roasbeef): fail if err?
 	c.cfg.unregisterChannel(c.cid)
@@ -214,8 +214,8 @@ func (c *channelCloser) initChanShutdown() (*lnwire.Shutdown, error) {
 }
 
 // ShutdownChan is the first method that's to be called by the initiator of the
-// cooperative channel closure. This message returns the shutdown message to to
-// sent to the remote party. Upon completion, we enter the
+// cooperative channel closure. This message returns the shutdown message to
+// send to the remote party. Upon completion, we enter the
 // closeShutdownInitiated phase as we await a response.
 func (c *channelCloser) ShutdownChan() (*lnwire.Shutdown, error) {
 	// If we attempt to shutdown the channel for the first time, and we're
@@ -289,7 +289,7 @@ func (c *channelCloser) ProcessCloseMsg(msg lnwire.Message) ([]lnwire.Message, b
 		// transaction.
 		c.remoteDeliveryScript = shutDownMsg.Address
 
-		// We'll generate a shutdown message of our own to set across
+		// We'll generate a shutdown message of our own to send across
 		// the wire.
 		localShutdown, err := c.initChanShutdown()
 		if err != nil {
@@ -318,7 +318,7 @@ func (c *channelCloser) ProcessCloseMsg(msg lnwire.Message) ([]lnwire.Message, b
 			msgsToSend = append(msgsToSend, closeSigned)
 		}
 
-		// We'll return both sent of messages to sent to the remote
+		// We'll return both sets of messages to send to the remote
 		// party to kick off the fee negotiation process.
 		return msgsToSend, false, nil
 
@@ -362,7 +362,7 @@ func (c *channelCloser) ProcessCloseMsg(msg lnwire.Message) ([]lnwire.Message, b
 		return nil, false, nil
 
 	// If we're receiving a message while we're in the fee negotiation
-	// phase, then this indicates the remote party is responding a closed
+	// phase, then this indicates the remote party is responding to a closed
 	// signed message we sent, or kicking off the process with their own.
 	case closeFeeNegotiation:
 		// First, we'll assert that we're actually getting a
@@ -512,7 +512,7 @@ func (c *channelCloser) proposeCloseSigned(fee btcutil.Amount) (*lnwire.ClosingS
 	peerLog.Infof("ChannelPoint(%v): proposing fee of %v sat to close "+
 		"chan", c.chanPoint, int64(fee))
 
-	// We'll assembled a ClosingSigned message using this information and
+	// We'll assemble a ClosingSigned message using this information and
 	// return it to the caller so we can kick off the final stage of the
 	// channel closure project.
 	closeSignedMsg := lnwire.NewClosingSigned(c.cid, fee, parsedSig)
@@ -559,7 +559,7 @@ func feeInAcceptableRange(localFee, remoteFee btcutil.Amount) bool {
 
 // rachetFee is our step function used to inch our fee closer to something that
 // both sides can agree on. If up is true, then we'll attempt to increase our
-// offered fee. Otherwise, if up if false, then we'll attempt to decrease our
+// offered fee. Otherwise, if up is false, then we'll attempt to decrease our
 // offered fee.
 func rachetFee(fee btcutil.Amount, up bool) btcutil.Amount {
 	// If we need to rachet up, then we'll increase our fee by 10%.

--- a/channeldb/channel.go
+++ b/channeldb/channel.go
@@ -122,11 +122,11 @@ const (
 
 // ChannelConstraints represents a set of constraints meant to allow a node to
 // limit their exposure, enact flow control and ensure that all HTLCs are
-// economically relevant This struct will be mirrored for both sides of the
+// economically relevant. This struct will be mirrored for both sides of the
 // channel, as each side will enforce various constraints that MUST be adhered
 // to for the life time of the channel. The parameters for each of these
-// constraints is static for the duration of the channel, meaning the channel
-// must be teared down for them to change.
+// constraints are static for the duration of the channel, meaning the channel
+// must be torn down for them to change.
 type ChannelConstraints struct {
 	// DustLimit is the threshold (in satoshis) below which any outputs
 	// should be trimmed. When an output is trimmed, it isn't materialized
@@ -145,7 +145,7 @@ type ChannelConstraints struct {
 	// particular time.
 	MaxPendingAmount lnwire.MilliSatoshi
 
-	// MinHTLC is the minimum HTLC value that the the owner of these
+	// MinHTLC is the minimum HTLC value that the owner of these
 	// constraints can offer the remote node. If any HTLCs below this
 	// amount are offered, then the HTLC will be rejected. This, in
 	// tandem with the dust limit allows a node to regulate the
@@ -364,13 +364,13 @@ type OpenChannel struct {
 	RemoteChanCfg ChannelConfig
 
 	// LocalCommitment is the current local commitment state for the local
-	// party. This is stored distinct from the state of of the remote party
+	// party. This is stored distinct from the state of the remote party
 	// as there are certain asymmetric parameters which affect the
 	// structure of each commitment.
 	LocalCommitment ChannelCommitment
 
 	// RemoteCommitment is the current remote commitment state for the
-	// remote party. This is stored distinct from the state of of the local
+	// remote party. This is stored distinct from the state of the local
 	// party as there are certain asymmetric parameters which affect the
 	// structure of each commitment.
 	RemoteCommitment ChannelCommitment
@@ -772,7 +772,7 @@ type HTLC struct {
 	// incremented for each update (includes settle+fail).
 	HtlcIndex uint64
 
-	// LogIndex is the cumulative log index of this this HTLC. This differs
+	// LogIndex is the cumulative log index of this HTLC. This differs
 	// from the HtlcIndex as this will be incremented for each new log
 	// update added.
 	LogIndex uint64

--- a/channeldb/channel_test.go
+++ b/channeldb/channel_test.go
@@ -488,7 +488,7 @@ func TestChannelStateTransition(t *testing.T) {
 		t.Fatalf("unable to add to commit chain: %v", err)
 	}
 
-	// The commitment tip should now match the the commitment that we just
+	// The commitment tip should now match the commitment that we just
 	// inserted.
 	diskCommitDiff, err := channel.RemoteCommitChainTip()
 	if err != nil {

--- a/channeldb/graph_test.go
+++ b/channeldb/graph_test.go
@@ -311,7 +311,7 @@ func TestEdgeInsertionDeletion(t *testing.T) {
 		t.Fatalf("unable to create test node: %v", err)
 	}
 
-	// In in addition to the fake vertexes we create some fake channel
+	// In addition to the fake vertexes we create some fake channel
 	// identifiers.
 	chanID := uint64(prand.Int63())
 	outpoint := wire.OutPoint{
@@ -636,7 +636,7 @@ func TestEdgeInfoUpdates(t *testing.T) {
 		secondNode = node1
 	}
 
-	// In in addition to the fake vertexes we create some fake channel
+	// In addition to the fake vertexes we create some fake channel
 	// identifiers.
 	chanID := uint64(prand.Int63())
 	outpoint := wire.OutPoint{
@@ -880,7 +880,7 @@ func TestGraphTraversal(t *testing.T) {
 	}
 
 	// Iterate through all the known channels within the graph DB, once
-	// again if the map is empty that that indicates that all edges have
+	// again if the map is empty that indicates that all edges have
 	// properly been reached.
 	err = graph.ForEachChannel(func(ei *ChannelEdgeInfo, _ *ChannelEdgePolicy,
 		_ *ChannelEdgePolicy) error {
@@ -901,7 +901,7 @@ func TestGraphTraversal(t *testing.T) {
 	err = firstNode.ForEachChannel(nil, func(_ *bolt.Tx, _ *ChannelEdgeInfo,
 		outEdge, inEdge *ChannelEdgePolicy) error {
 
-		// Each each should indicate that it's outgoing (pointed
+		// Each should indicate that it's outgoing (pointed
 		// towards the second node).
 		if !bytes.Equal(outEdge.Node.PubKeyBytes[:], secondNode.PubKeyBytes[:]) {
 			return fmt.Errorf("wrong outgoing edge")

--- a/channeldb/invoices.go
+++ b/channeldb/invoices.go
@@ -45,7 +45,7 @@ const (
 	// within the database along side incoming/outgoing invoices.
 	MaxReceiptSize = 1024
 
-	// MaxPaymentRequestSize is the max size of a a payment request for
+	// MaxPaymentRequestSize is the max size of a payment request for
 	// this invoice.
 	// TODO(halseth): determine the max length payment request when field
 	// lengths are final.

--- a/cmd/lncli/commands.go
+++ b/cmd/lncli/commands.go
@@ -1880,7 +1880,7 @@ func describeGraph(ctx *cli.Context) error {
 }
 
 // normalizeFunc is a factory function which returns a function that normalizes
-// the capacity of of edges within the graph. The value of the returned
+// the capacity of edges within the graph. The value of the returned
 // function can be used to either plot the capacities, or to use a weight in a
 // rendering of the graph.
 func normalizeFunc(edges []*lnrpc.ChannelEdge, scaleFactor float64) func(int64) float64 {

--- a/contractcourt/channel_arbitrator.go
+++ b/contractcourt/channel_arbitrator.go
@@ -43,7 +43,7 @@ type WitnessSubscription struct {
 
 // WitnessBeacon is a global beacon of witnesses. Contract resolvers will use
 // this interface to lookup witnesses (preimages typically) of contracts
-// they're trying to resolver, add new preimages they resolver, and finally
+// they're trying to resolve, add new preimages they resolve, and finally
 // receive new updates each new time a preimage is discovered.
 //
 // TODO(roasbeef): need to delete the pre-images once we've used them
@@ -669,7 +669,7 @@ func (c *ChannelArbitrator) advanceState(currentHeight uint32,
 	}
 }
 
-// ChainAction is an enum that that encompasses all possible on-chain actions
+// ChainAction is an enum that encompasses all possible on-chain actions
 // we'll take for a set of HTLC's.
 type ChainAction uint8
 
@@ -831,7 +831,7 @@ func (c *ChannelArbitrator) checkChainActions(height uint32,
 	// Now that we know we'll need to go on-chain, we'll examine all of our
 	// active outgoing HTLC's to see if we either need to: sweep them after
 	// a timeout (then cancel backwards), cancel them backwards
-	// immediately, or or watch them as they're still active contracts.
+	// immediately, or watch them as they're still active contracts.
 	for _, htlc := range c.activeHTLCs.outgoingHTLCs {
 		switch {
 		// If the HTLC is dust, then we can cancel it backwards
@@ -1033,7 +1033,7 @@ func (c *ChannelArbitrator) prepContractResolutions(htlcActions ChainActionMap,
 			}
 
 		// If we can timeout the HTLC directly, then we'll create the
-		// proper resolver to to so, who will then cancel the packet
+		// proper resolver to do so, who will then cancel the packet
 		// backwards.
 		case HtlcTimeoutAction:
 			for _, htlc := range htlcs {

--- a/contractcourt/contract_resolvers.go
+++ b/contractcourt/contract_resolvers.go
@@ -719,7 +719,7 @@ var _ ContractResolver = (*htlcSuccessResolver)(nil)
 // htlcOutgoingContestResolver is a ContractResolver that's able to resolve an
 // outgoing HTLC that is still contested. An HTLC is still contested, if at the
 // time that we broadcast the commitment transaction, it isn't able to be fully
-// resolved. This this case, we'll either wait for the HTLC to timeout, or for
+// resolved. In this case, we'll either wait for the HTLC to timeout, or for
 // us to learn of the preimage.
 type htlcOutgoingContestResolver struct {
 	// htlcTimeoutResolver is the inner solver that this resolver may turn

--- a/discovery/gossiper_test.go
+++ b/discovery/gossiper_test.go
@@ -582,7 +582,7 @@ func TestProcessAnnouncement(t *testing.T) {
 		}
 	}
 
-	// Create node valid, signed announcement, process it with with
+	// Create node valid, signed announcement, process it with 
 	// gossiper service, check that valid announcement have been
 	// propagated farther into the lightning network, and check that we
 	// added new node into router.

--- a/htlcswitch/circuit_test.go
+++ b/htlcswitch/circuit_test.go
@@ -734,7 +734,7 @@ func TestCircuitMapCommitCircuits(t *testing.T) {
 	// Finally, restart the circuit map, which will cause the added circuit
 	// to be loaded from disk. Since the keystone was never set, subsequent
 	// attempts to commit the circuit should cause the circuit map to
-	// indicate that that the HTLC should be failed back.
+	// indicate that the HTLC should be failed back.
 	cfg, circuitMap = restartCircuitMap(t, cfg)
 
 	actions, err = circuitMap.CommitCircuits(circuit)
@@ -1055,7 +1055,7 @@ func TestCircuitMapTrimOpenCircuits(t *testing.T) {
 		firstTrimIndex,
 	)
 
-	// Restart the circuit map, verify that that the trim is reflected on
+	// Restart the circuit map, verify that the trim is reflected on
 	// startup.
 	cfg, circuitMap = restartCircuitMap(t, cfg)
 

--- a/htlcswitch/link.go
+++ b/htlcswitch/link.go
@@ -1169,7 +1169,7 @@ func (l *channelLink) handleUpstreamMsg(msg lnwire.Message) {
 		// TODO(roasbeef): pipeline to switch
 
 		// As we've learned of a new preimage for the first time, we'll
-		// add it to to our preimage cache. By doing this, we ensure
+		// add it to our preimage cache. By doing this, we ensure
 		// any contested contracts watched by any on-chain arbitrators
 		// can now sweep this HTLC on-chain.
 		go func() {
@@ -1252,7 +1252,7 @@ func (l *channelLink) handleUpstreamMsg(msg lnwire.Message) {
 			return
 		}
 
-		// As we've just just accepted a new state, we'll now
+		// As we've just accepted a new state, we'll now
 		// immediately send the remote peer a revocation for our prior
 		// state.
 		nextRevocation, currentHtlcs, err := l.channel.RevokeCurrentCommitment()
@@ -1907,7 +1907,7 @@ func (l *channelLink) processRemoteAdds(fwdPkg *channeldb.FwdPkg,
 			//
 			// NOTE: Though our recovery and forwarding logic is
 			// predominately batched, settling invoices happens
-			// iteratively. We may reject one of of two payments
+			// iteratively. We may reject one of two payments
 			// for the same rhash at first, but then restart and
 			// reject both after seeing that the invoice has been
 			// settled. Without any record of which one settles
@@ -2048,7 +2048,7 @@ func (l *channelLink) processRemoteAdds(fwdPkg *channeldb.FwdPkg,
 
 		// There are additional channels left within this route. So
 		// we'll verify that our forwarding constraints have been
-		// properly met by by this incoming HTLC.
+		// properly met by this incoming HTLC.
 		default:
 			switch fwdPkg.State {
 			case channeldb.FwdStateProcessed:

--- a/htlcswitch/switch.go
+++ b/htlcswitch/switch.go
@@ -1865,7 +1865,7 @@ func (s *Switch) UpdateShortChanID(chanID lnwire.ChannelID,
 func (s *Switch) updateShortChanID(chanID lnwire.ChannelID,
 	shortChanID lnwire.ShortChannelID) error {
 
-	// First, we'll extract the current link as is from the link link
+	// First, we'll extract the current link as is from the link 
 	// index. If the link isn't even in the index, then we'll return an
 	// error.
 	link, ok := s.linkIndex[chanID]

--- a/lnd_test.go
+++ b/lnd_test.go
@@ -2740,7 +2740,7 @@ func testPrivateChannels(net *lntest.NetworkHarness, t *harnessTest) {
 	timeout := time.Duration(time.Second * 5)
 	var networkChans []*lnrpc.ChannelPoint
 
-	// We create the the following topology:
+	// We create the following topology:
 	//
 	// Dave --100k--> Alice --200k--> Bob
 	//  ^		    ^

--- a/lnwallet/README.md
+++ b/lnwallet/README.md
@@ -13,7 +13,7 @@ derivation, and the commitment update state machine.
 The package is used within `lnd` as the core wallet of the daemon. The wallet
 itself is composed of several distinct interfaces that decouple the
 implementation of things like signing and blockchain access. This separation
-allows new `WalletController` implementations to be be easily dropped into
+allows new `WalletController` implementations to be easily dropped into
 `lnd` without disrupting the code base. A series of integration tests at the
 interface level are also in place to ensure conformance of the implementation
 with the interface.

--- a/lnwallet/btcwallet/btcwallet.go
+++ b/lnwallet/btcwallet/btcwallet.go
@@ -260,7 +260,7 @@ func (b *BtcWallet) GetPrivKey(a btcutil.Address) (*btcec.PrivateKey, error) {
 
 // SendOutputs funds, signs, and broadcasts a Bitcoin transaction paying out to
 // the specified outputs. In the case the wallet has insufficient funds, or the
-// outputs are non-standard, a non-nil error will be be returned.
+// outputs are non-standard, a non-nil error will be returned.
 //
 // This is a part of the WalletController interface.
 func (b *BtcWallet) SendOutputs(outputs []*wire.TxOut,

--- a/lnwallet/channel.go
+++ b/lnwallet/channel.go
@@ -913,7 +913,7 @@ type CommitmentKeyRing struct {
 	// TODO(roasbeef): need delay tweak as well?
 
 	// LocalHtlcKeyTweak is the teak used to derive the local HTLC key from
-	// the local HTLC base point point. This value is needed in order to
+	// the local HTLC base point. This value is needed in order to
 	// derive the final key used within the HTLC scripts in the commitment
 	// transaction.
 	LocalHtlcKeyTweak []byte
@@ -1520,7 +1520,7 @@ func (lc *LightningChannel) logUpdateToPayDesc(logUpdate *channeldb.LogUpdate,
 			pd.theirWitnessScript = theirWitnessScript
 		}
 
-	// For HTLC's we we're offered we'll fetch the original offered HTLc
+	// For HTLC's we're offered we'll fetch the original offered HTLC
 	// from the remote party's update log so we can retrieve the same
 	// PaymentDescriptor that SettleHTLC would produce.
 	case *lnwire.UpdateFulfillHTLC:
@@ -1787,7 +1787,7 @@ type HtlcRetribution struct {
 	// SecondLevelWitnessScript is the witness script that will be created
 	// if the second level HTLC transaction for this output is
 	// broadcast/confirmed. We provide this as if the remote party attempts
-	// to to go the second level to claim the HTLC then we'll need to
+	// to go to the second level to claim the HTLC then we'll need to
 	// update the SignDesc above accordingly to sweep properly.
 	SecondLevelWitnessScript []byte
 
@@ -3172,7 +3172,7 @@ func (lc *LightningChannel) ProcessChanSyncMsg(
 //   3. We didn't get the last RevokeAndAck message they sent, so they'll
 //      re-send it.
 func (lc *LightningChannel) ChanSyncMsg() (*lnwire.ChannelReestablish, error) {
-	// The remote commitment height that we we'll send in the
+	// The remote commitment height that we'll send in the
 	// ChannelReestablish message is our current commitment height plus
 	// one. If the receiver thinks that our commitment height is actually
 	// *equal* to this value, then they'll re-send the last commitment that
@@ -4093,7 +4093,7 @@ func (lc *LightningChannel) RemoveFwdPkg(height uint64) error {
 
 // NextRevocationKey returns the commitment point for the _next_ commitment
 // height. The pubkey returned by this function is required by the remote party
-// along with their revocation base to to extend our commitment chain with a
+// along with their revocation base to extend our commitment chain with a
 // new commitment.
 func (lc *LightningChannel) NextRevocationKey() (*btcec.PublicKey, error) {
 	lc.RLock()

--- a/lnwallet/channel_test.go
+++ b/lnwallet/channel_test.go
@@ -700,7 +700,7 @@ func TestSimpleAddSettleWorkflow(t *testing.T) {
 	// At this point, Bob should have 6 BTC settled, with Alice still having
 	// 4 BTC. Alice's channel should show 1 BTC sent and Bob's channel
 	// should show 1 BTC received. They should also be at commitment height
-	// two, with the revocation window extended by by 1 (5).
+	// two, with the revocation window extended by 1 (5).
 	mSatTransferred := lnwire.NewMSatFromSatoshis(btcutil.SatoshiPerBitcoin)
 	if aliceChannel.channelState.TotalMSatSent != mSatTransferred {
 		t.Fatalf("alice satoshis sent incorrect %v vs %v expected",
@@ -3602,7 +3602,7 @@ func TestFeeUpdateRejectInsaneFee(t *testing.T) {
 	startingFeeRate := SatPerKWeight(aliceChannel.channelState.LocalCommitment.FeePerKw)
 	newFeeRate := startingFeeRate * 1000000
 
-	// Both Alice and Bob should reject this new fee rate as it it far too
+	// Both Alice and Bob should reject this new fee rate as it is far too
 	// large.
 	if err := aliceChannel.UpdateFee(newFeeRate); err == nil {
 		t.Fatalf("alice should have rejected fee update")
@@ -4445,7 +4445,7 @@ func TestDesyncHTLCs(t *testing.T) {
 		t.Fatalf("unable to complete state update: %v", err)
 	}
 
-	// Now let let Bob fail this HTLC.
+	// Now let Bob fail this HTLC.
 	err = bobChannel.FailHTLC(bobIndex, []byte("failreason"), nil, nil, nil)
 	if err != nil {
 		t.Fatalf("unable to cancel HTLC: %v", err)

--- a/lnwallet/fee_estimator.go
+++ b/lnwallet/fee_estimator.go
@@ -163,7 +163,7 @@ func (b *BtcdFeeEstimator) EstimateFeePerVSize(numBlocks uint32) (SatPerVByte, e
 	return feeEstimate, nil
 }
 
-// fetchEstimate returns a fee estimate for a transaction be be confirmed in
+// fetchEstimate returns a fee estimate for a transaction to be confirmed in
 // confTarget blocks. The estimate is returned in sat/vbyte.
 func (b *BtcdFeeEstimator) fetchEstimatePerVSize(
 	confTarget uint32) (SatPerVByte, error) {
@@ -268,7 +268,7 @@ func (b *BitcoindFeeEstimator) EstimateFeePerVSize(numBlocks uint32) (SatPerVByt
 	return feeEstimate, nil
 }
 
-// fetchEstimatePerVSize returns a fee estimate for a transaction be be confirmed in
+// fetchEstimatePerVSize returns a fee estimate for a transaction to be confirmed in
 // confTarget blocks. The estimate is returned in sat/vbyte.
 func (b *BitcoindFeeEstimator) fetchEstimatePerVSize(
 	confTarget uint32) (SatPerVByte, error) {

--- a/lnwallet/script_utils.go
+++ b/lnwallet/script_utils.go
@@ -1246,7 +1246,7 @@ func DeriveRevocationPrivKey(revokeBasePriv *btcec.PrivateKey,
 func SetStateNumHint(commitTx *wire.MsgTx, stateNum uint64,
 	obfuscator [StateHintSize]byte) error {
 
-	// With the current schema we are only able able to encode state num
+	// With the current schema we are only able to encode state num
 	// hints up to 2^48. Therefore if the passed height is greater than our
 	// state hint ceiling, then exit early.
 	if stateNum > maxStateHint {

--- a/lnwallet/script_utils_test.go
+++ b/lnwallet/script_utils_test.go
@@ -175,7 +175,7 @@ func TestCommitmentSpendValidation(t *testing.T) {
 	}
 
 	// In order to test the final scenario, we modify the TxIn of the sweep
-	// transaction to instead point to to the regular output (non delay)
+	// transaction to instead point to the regular output (non delay)
 	// within the commitment transaction.
 	sweepTx.TxIn[0] = &wire.TxIn{
 		PreviousOutPoint: wire.OutPoint{

--- a/lnwallet/wallet.go
+++ b/lnwallet/wallet.go
@@ -1366,7 +1366,7 @@ func initStateHints(commit1, commit2 *wire.MsgTx,
 }
 
 // selectInputs selects a slice of inputs necessary to meet the specified
-// selection amount. If input selection is unable to succeed to to insufficient
+// selection amount. If input selection is unable to succeed due to insufficient
 // funds, a non-nil error is returned. Additionally, the total amount of the
 // selected coins are returned in order for the caller to properly handle
 // change+fees.

--- a/lnwire/channel_id.go
+++ b/lnwire/channel_id.go
@@ -25,7 +25,7 @@ const (
 type ChannelID [32]byte
 
 // ConnectionWideID is an all-zero ChannelID, which is used to represent a
-// message intended for all channels to to specific peer.
+// message intended for all channels to specific peer.
 var ConnectionWideID = ChannelID{}
 
 // String returns the string representation of the ChannelID. This is just the

--- a/lnwire/netaddress.go
+++ b/lnwire/netaddress.go
@@ -22,7 +22,7 @@ type NetAddress struct {
 	// the node.
 	IdentityKey *btcec.PublicKey
 
-	// Address is is the IP address and port of the node. This is left
+	// Address is the IP address and port of the node. This is left
 	// general so that multiple implementations can be used.
 	Address net.Addr
 

--- a/lnwire/pong.go
+++ b/lnwire/pong.go
@@ -11,7 +11,7 @@ type PongPayload []byte
 // Pong message.
 type Pong struct {
 	// PongBytes is a set of opaque bytes that corresponds to the
-	// NumPongBytes defined in the ping message that this this pong is
+	// NumPongBytes defined in the ping message that this pong is
 	// replying to.
 	PongBytes PongPayload
 }

--- a/pilot.go
+++ b/pilot.go
@@ -278,7 +278,7 @@ func initAutoPilot(svr *server, cfg *autoPilotConfig) (*autopilot.Agent, error) 
 					pilot.OnChannelOpen(edge)
 				}
 
-				// For each closed closed channel, we'll obtain
+				// For each closed channel, we'll obtain
 				// the chanID of the closed channel and send it
 				// to the pilot.
 				for _, chanClose := range topChange.ClosedChannels {

--- a/routing/chainview/interface.go
+++ b/routing/chainview/interface.go
@@ -5,7 +5,7 @@ import (
 	"github.com/roasbeef/btcd/wire"
 )
 
-// FilteredChainView represents a subscription to a certain subset of of the
+// FilteredChainView represents a subscription to a certain subset of the
 // UTXO set for a particular chain. This interface is useful from the point of
 // view of maintaining an up-to-date channel graph for the Lightning Network.
 // The subset of the UTXO to be subscribed is that of all the currently opened

--- a/routing/pathfind.go
+++ b/routing/pathfind.go
@@ -471,7 +471,7 @@ func findPath(tx *bolt.Tx, graph *channeldb.ChannelGraph,
 	//  * similar to route caching, but doesn't factor in the amount
 
 	// To start, we add the source of our path finding attempt to the
-	// distance map with with a distance of 0. This indicates our starting
+	// distance map with a distance of 0. This indicates our starting
 	// point in the graph traversal.
 	sourceVertex := Vertex(sourceNode.PubKeyBytes)
 	distance[sourceVertex] = nodeWithDist{

--- a/routing/router.go
+++ b/routing/router.go
@@ -1205,8 +1205,8 @@ func pruneChannelFromRoutes(routes []*Route, skipChan uint64) []*Route {
 }
 
 // pathsToFeeSortedRoutes takes a set of paths, and returns a corresponding set
-// of of routes. A route differs from a path in that it has full time-lock and
-// fee information attached. The set of routes return ed may be less than the
+// of routes. A route differs from a path in that it has full time-lock and
+// fee information attached. The set of routes returned may be less than the
 // initial set of paths as it's possible we drop a route if it can't handle the
 // total payment flow after fees are calculated.
 func pathsToFeeSortedRoutes(source Vertex, paths [][]*ChannelHop, finalCLTVDelta uint16,
@@ -1260,7 +1260,7 @@ func pathsToFeeSortedRoutes(source Vertex, paths [][]*ChannelHop, finalCLTVDelta
 // FindRoutes attempts to query the ChannelRouter for a bounded number
 // available paths to a particular target destination which is able to send
 // `amt` after factoring in channel capacities and cumulative fees along each
-// route route.  To `numPaths eligible paths, we use a modified version of
+// route.  To `numPaths eligible paths, we use a modified version of
 // Yen's algorithm which itself uses a modified version of Dijkstra's algorithm
 // within its inner loop.  Once we have a set of candidate routes, we calculate
 // the required fee and time lock values running backwards along the route. The

--- a/server.go
+++ b/server.go
@@ -1366,7 +1366,7 @@ func (s *server) peerConnected(conn net.Conn, connReq *connmgr.ConnReq,
 	// feature vector to advertise to the remote node.
 	localFeatures := lnwire.NewRawFeatureVector()
 
-	// We'll only request a full channel graph sync if we detect that that
+	// We'll only request a full channel graph sync if we detect that
 	// we aren't fully synced yet.
 	if s.shouldRequestGraphSync() {
 		localFeatures.Set(lnwire.InitialRoutingSync)

--- a/shachain/utils.go
+++ b/shachain/utils.go
@@ -50,7 +50,7 @@ func getPrefix(index index, position uint8) uint64 {
 	return (uint64(index) & mask)
 }
 
-// countTrailingZeros count number of of trailing zero bits, this function is
+// countTrailingZeros counts number of trailing zero bits, this function is
 // used to determine the number of element bucket.
 func countTrailingZeros(index index) uint8 {
 	var zeros uint8

--- a/utxonursery.go
+++ b/utxonursery.go
@@ -910,8 +910,8 @@ func (u *utxoNursery) graduateClass(classHeight uint32) error {
 	return u.cfg.Store.GraduateHeight(classHeight)
 }
 
-// craftSweepTx accepts accepts a list of kindergarten outputs, and baby
-// outputs which don't required a second-layer claim, and signs and generates a
+// craftSweepTx accepts a list of kindergarten outputs, and baby
+// outputs which don't require a second-layer claim, and signs and generates a
 // signed txn that spends from them. This method also makes an accurate fee
 // estimate before generating the required witnesses.
 func (u *utxoNursery) createSweepTx(kgtnOutputs []kidOutput,


### PR DESCRIPTION
Fix typos in comments to make it easier to read them.

chancloser.go
"This message returns the shutdown message to TO senT to the remote party" -> "This message returns the shutdown message to senD to the remote party"
"when a caller attempts to access a field or function that is continent on the channel closure negotiation already being completed." -> "when a caller attempts to access a field or function that is continGent on the channel closure negotiation already being completed."
"In this state, the stat machine has been instantiated, but noT state transitions have been attempted." -> "In this state, the statE machine has been instantiated, but no state transitions have been attempted."
"Both parties enter this state after they've sent and receive a shutdown message." -> "Both parties enter this state after they've sent and receiveD a shutdown message."
"This then causes a shift into the close finished state." -> "This then causes a shift into the closeFinished state."
"In this, state, a side has accepted a fee offer" -> "In this state, a side has accepted a fee offer"
"initChanShutdown beinGs the shutdown process by un-registering the channel" -> "initChanShutdown begins the shutdown process by un-registering the channel"
"to ensure that it isn't see as usable within the system." -> "to ensure that it isn't seeN as usable within the system."
"We'll generate a shutdown message of our own to set across the wire." -> "We'll generate a shutdown message of our own to send across the wire."
"We'll return both seNt of messages to senT to the remote party to kick off the fee negotiation process." -> "We'll return both sets of messages to send to the remote party to kick off the fee negotiation process."
"then this indicates the remote party is responding a closed signed message we sent, or kicking off the process with their own." -> "then this indicates the remote party is responding TO a closed signed message we sent, or kicking off the process with their own."
"We'll assembleD a ClosingSigned message using this information" -> "We'll assemble a ClosingSigned message using this information"
"If up is true, then we'll attempt to increase our offered fee. Otherwise, if up iF false, then we'll attempt" -> "If up is true, then we'll attempt to increase our offered fee. Otherwise, if up is false, then we'll attempt"

channeldb/channel.go
"MinHTLC is the minimum HTLC value that the THE owner of these" -> "MinHTLC is the minimum HTLC value that the owner of these"
"This is stored distinct from the state of OF the remote party" -> "This is stored distinct from the state of the remote party"
"This is stored distinct from the state of OF the local party" -> "This is stored distinct from the state of the local party"
"LogIndex is the cumulative log index of this THIS HTLC." -> "LogIndex is the cumulative log index of this HTLC."
"The parameters for each of these constraints IS static for the duration of the channel, meaning the channel must be TEARED down for them to change." -> "The parameters for each of these constraints are static for the duration of the channel, meaning the channel must be torn down for them to change."

channeldb/channel_test.go
"The commitment tip should now match the THE commitment that we just inserted." -> "The commitment tip should now match the commitment that we just inserted."

channeldb/graph_test.go
"In IN addition to the fake vertexes we create some fake channel identifiers." -> "In addition to the fake vertexes we create some fake channel identifiers."
"if the map is empty that THAT indicates" -> "if the map is empty that indicates"
"Each EACH should indicate that it's outgoing" -> "Each should indicate that it's outgoing"

channeldb/invoices.go
"MaxPaymentRequestSize is the max size of a A payment request for this invoice." -> "MaxPaymentRequestSize is the max size of a payment request for this invoice."

cmd/lncli/commands.go
"normalizeFunc is a factory function which returns a function that normalizes the capacity of OF edges within the graph." -> "normalizeFunc is a factory function which returns a function that normalizes the capacity of edges within the graph."

contractcourt/channel_arbitrator.go
"ChainAction is an enum that THAT encompasses all possible on-chain actions" -> "ChainAction is an enum that encompasses all possible on-chain actions"
"Contract resolvers will use this interface to lookup witnesses (preimages typically) of contracts they're trying to resolveR, add new preimages they resolveR, and finally receive new updates each new time a preimage is discovered." -> "Contract resolvers will use this interface to lookup witnesses (preimages typically) of contracts they're trying to resolve, add new preimages they resolve, and finally receive new updates each new time a preimage is discovered."
"or OR watch them as they're still active contracts." -> "or watch them as they're still active contracts."
"If we can timeout the HTLC directly, then we'll create the proper resolver to TO so, who will then cancel the packet backwards." -> "If we can timeout the HTLC directly, then we'll create the proper resolver to DO so, who will then cancel the packet backwards."

contractcourt/contract_resolvers.go
"THIS this case, we'll either wait for the HTLC to timeout, or for us to learn of the preimage." -> "IN this case, we'll either wait for the HTLC to timeout, or for us to learn of the preimage."

discovery/gossiper_test.go
"process it with WITH gossiper service" -> "process it with gossiper service"

htlcswitch/circuit_test.go
"indicate that THAT the HTLC should be failed back." -> "indicate that the HTLC should be failed back."
"Restart the circuit map, verify that THAT the trim is reflected on startup." -> "Restart the circuit map, verify that the trim is reflected on startup."

htlcswitch/link.go
"add it to TO our preimage cache" -> "add it to our preimage cache"
"As we've just JUST accepted a new state" -> "As we've just accepted a new state"
"We may reject one of OF two payments" -> "We may reject one of two payments"
"have been properly met by BY this incoming HTLC." -> "have been properly met by this incoming HTLC."

htlcswitch/switch.go
"First, we'll extract the current link as is from the link LINK index." -> "First, we'll extract the current link as is from the link index."

lnd_test.go
"We create the THE following topology:" -> "We create the following topology:"

lnwallet/README.md
"implementations to be BE easily dropped into" -> "implementations to be easily dropped into"

lnwallet/btcwallet/btcwallet.go
"a non-nil error will be BE returned" -> "a non-nil error will be returned"

lnwallet/channel.go
"derive the local HTLC key from the local HTLC base point POINT." -> "derive the local HTLC key from the local HTLC base point."
"For HTLC's WE we're offered we'll fetch the original offered HTLc" -> "For HTLC's we're offered we'll fetch the original offered HTLC"
"if the remote party attempts to TO go the second level to claim the HTLC" -> "if the remote party attempts to go TO the second level to claim the HTLC"
"The remote commitment height that WE we'll send" -> "The remote commitment height that we'll send"
"along with their revocation base to TO extend our commitment chain" -> "along with their revocation base to extend our commitment chain"

lnwallet/channel_test.go
"with the revocation window extended by BY 1 (5)." -> "with the revocation window extended by 1 (5)."
"Both Alice and Bob should reject this new fee rate as it IT far too large" -> "Both Alice and Bob should reject this new fee rate as it iS far too large"
"Now let LET Bob fail this HTLC." -> "Now let Bob fail this HTLC."

lnwallet/fee_estimator.go
"fetchEstimate returns a fee estimate for a transaction BE be confirmed in confTarget blocks." -> "fetchEstimate returns a fee estimate for a transaction TO be confirmed in confTarget blocks."
"fetchEstimatePerVSize returns a fee estimate for a transaction BE be confirmed in confTarget blocks" -> "fetchEstimatePerVSize returns a fee estimate for a transaction TO be confirmed in confTarget blocks"

lnwallet/script_utils.go
"With the current schema we are only able ABLE to encode state" -> "With the current schema we are only able to encode state"

lnwallet/script_utils_test.go
"transaction to instead point to TO the regular output" -> "transaction to instead point to the regular output"

lnwallet/wallet.go
"If input selection is unable to succeed TO to insufficient funds" -> "If input selection is unable to succeed DUE to insufficient funds"

lnwire/channel_id.go
"a message intended for all channels to TO specific peer." -> "a message intended for all channels to specific peer."

lnwire/netaddress.go
"Address is IS the IP address and port of the node." -> "Address is the IP address and port of the node."

lnwire/pong.go
"defined in the ping message that this THIS pong is replying to." -> "defined in the ping message that this pong is replying to."

pilot.go
"For each closed CLOSED channel" -> "For each closed channel"

routing/chainview/interface.go
"a subscription to a certain subset of OF the UTXO set" -> "a subscription to a certain subset of the UTXO set"

routing/pathfind.go
"to the distance map with WITH a distance of 0." -> "to the distance map with a distance of 0."

routing/router.go
"returns a corresponding set of OF routes." -> "returns a corresponding set of routes."
"The set of routes return ED may be less than" -> "The set of routes returned may be less than"
"cumulative fees along each route ROUTE." -> "cumulative fees along each route."

server.go
"if we detect that THAT we aren't fully synced yet." -> "if we detect that we aren't fully synced yet."

shachain/utils.go
"countTrailingZeros count number of OF trailing zero bits" -> "countTrailingZeros counts number of trailing zero bits"

utxonursery.go
"craftSweepTx accepts ACCEPTS a list of kindergarten outputs, and baby outputs which don't requirED a second-layer claim" -> "craftSweepTx accepts a list of kindergarten outputs, and baby outputs which don't require a second-layer claim"