### PR TITLE
funding+pilot: increase min channel size, allow specifying chan size range for autopilot

### DIFF
--- a/config.go
+++ b/config.go
@@ -121,10 +121,11 @@ type bitcoindConfig struct {
 }
 
 type autoPilotConfig struct {
-	// TODO(roasbeef): add
-	Active      bool    `long:"active" description:"If the autopilot agent should be active or not."`
-	MaxChannels int     `long:"maxchannels" description:"The maximum number of channels that should be created"`
-	Allocation  float64 `long:"allocation" description:"The percentage of total funds that should be committed to automatic channel establishment"`
+	Active         bool    `long:"active" description:"If the autopilot agent should be active or not."`
+	MaxChannels    int     `long:"maxchannels" description:"The maximum number of channels that should be created"`
+	Allocation     float64 `long:"allocation" description:"The percentage of total funds that should be committed to automatic channel establishment"`
+	MinChannelSize int64   `long:"minchansize" description:"The smallest channel that the autopilot agent should create"`
+	MaxChannelSize int64   `long:"maxchansize" description:"The larget channel taht the autopilot agent should create"`
 }
 
 type torConfig struct {
@@ -248,8 +249,10 @@ func loadConfig() (*config, error) {
 		MaxPendingChannels: defaultMaxPendingChannels,
 		NoEncryptWallet:    defaultNoEncryptWallet,
 		Autopilot: &autoPilotConfig{
-			MaxChannels: 5,
-			Allocation:  0.6,
+			MaxChannels:    5,
+			Allocation:     0.6,
+			MinChannelSize: int64(minChanFundingSize),
+			MaxChannelSize: int64(maxFundingAmount),
 		},
 		TrickleDelay: defaultTrickleDelay,
 		Alias:        defaultAlias,
@@ -331,6 +334,42 @@ func loadConfig() (*config, error) {
 	cfg.LtcdMode.Dir = cleanAndExpandPath(cfg.LtcdMode.Dir)
 	cfg.BitcoindMode.Dir = cleanAndExpandPath(cfg.BitcoindMode.Dir)
 	cfg.LitecoindMode.Dir = cleanAndExpandPath(cfg.LitecoindMode.Dir)
+
+	// Ensure that the user didn't attempt to specify negative values for
+	// any of the autopilot params.
+	if cfg.Autopilot.MaxChannelSize < 0 {
+		str := "%s: autopilot.maxchansize must be greater than zero"
+		err := fmt.Errorf(str)
+		fmt.Fprintln(os.Stderr, err)
+		return nil, err
+	}
+	if cfg.Autopilot.Allocation < 0 {
+		str := "%s: autopilot.allocation must be greater than zero"
+		err := fmt.Errorf(str)
+		fmt.Fprintln(os.Stderr, err)
+		return nil, err
+	}
+	if cfg.Autopilot.MinChannelSize < 0 {
+		str := "%s: autopilot.minchansize must be greater than zero"
+		err := fmt.Errorf(str)
+		fmt.Fprintln(os.Stderr, err)
+		return nil, err
+	}
+	if cfg.Autopilot.MaxChannelSize < 0 {
+		str := "%s: autopilot.maxchansize must be greater than zero"
+		err := fmt.Errorf(str)
+		fmt.Fprintln(os.Stderr, err)
+		return nil, err
+	}
+
+	// Ensure that the specified values for the min and max channel size
+	// don't are within the bounds of the normal chan size constraints.
+	if cfg.Autopilot.MinChannelSize < int64(minChanFundingSize) {
+		cfg.Autopilot.MinChannelSize = int64(minChanFundingSize)
+	}
+	if cfg.Autopilot.MaxChannelSize > int64(maxFundingAmount) {
+		cfg.Autopilot.MaxChannelSize = int64(maxFundingAmount)
+	}
 
 	// Setup dial and DNS resolution functions depending on the specified
 	// options. The default is to use the standard golang "net" package

--- a/fundingmanager.go
+++ b/fundingmanager.go
@@ -60,6 +60,10 @@ const (
 	// for the funding transaction to be confirmed before forgetting about
 	// the channel. 288 blocks is ~48 hrs
 	maxWaitNumBlocksFundingConf = 288
+
+	// minChanFundingSize is the smallest channel that we'll allow to be
+	// created over the RPC interface.
+	minChanFundingSize = btcutil.Amount(20000)
 )
 
 // reservationWithCtx encapsulates a pending channel reservation. This wrapper

--- a/pilot.go
+++ b/pilot.go
@@ -142,11 +142,9 @@ func initAutoPilot(svr *server, cfg *autoPilotConfig) (*autopilot.Agent, error) 
 
 	// First, we'll create the preferential attachment heuristic,
 	// initialized with the passed auto pilot configuration parameters.
-	//
-	// TODO(roasbeef): switch here to dispatch specified heuristic
-	minChanSize := svr.cc.wallet.Cfg.DefaultConstraints.DustLimit * 5
 	prefAttachment := autopilot.NewConstrainedPrefAttachment(
-		minChanSize, maxFundingAmount,
+		btcutil.Amount(cfg.MinChannelSize),
+		btcutil.Amount(cfg.MaxChannelSize),
 		uint16(cfg.MaxChannels), cfg.Allocation,
 	)
 


### PR DESCRIPTION
In this PR, we raise the min channel size to 20k satoshis. This
will be evaluated before we check for dusty commitments. The goal of
this is to ensure ample room for fees at current, and future fee
levels.

We also, we add two new configuration parameters to allow users
to specify the min and max size that the autopilot agent will create.
This is useful as now users can set the values to more or less the same
size, which will allow them to control the size of each created
channel.

Before this commit, if this wasn’t set, then the agent would try to
shove as much money into a channel up until the max chan size. This was
nice on testnet, but on main net, users will likely not want all their
funds to be in a single channel, and instead be distributed across many
channels. With things like AMP, have more channels becomes more
desirable.
