### PR TITLE
peer: ensure we stop the channel if error happens in loadActiveChannels

### DIFF
--- a/peer.go
+++ b/peer.go
@@ -306,6 +306,7 @@ func (p *peer) loadActiveChannels(chans []*channeldb.OpenChannel) error {
 			p.server.cc.signer, p.server.witnessBeacon, dbChan,
 		)
 		if err != nil {
+			lnChan.Stop()
 			return err
 		}
 
@@ -325,6 +326,7 @@ func (p *peer) loadActiveChannels(chans []*channeldb.OpenChannel) error {
 		if dbChan.IsBorked {
 			peerLog.Warnf("ChannelPoint(%v) is borked, won't "+
 				"start.", chanPoint)
+			lnChan.Stop()
 			continue
 		}
 
@@ -333,15 +335,18 @@ func (p *peer) loadActiveChannels(chans []*channeldb.OpenChannel) error {
 		if _, ok := p.failedChannels[chanID]; ok {
 			peerLog.Warnf("ChannelPoint(%v) is failed, won't "+
 				"start.", chanPoint)
+			lnChan.Stop()
 			continue
 		}
 
 		blockEpoch, err := p.server.cc.chainNotifier.RegisterBlockEpochNtfn()
 		if err != nil {
+			lnChan.Stop()
 			return err
 		}
 		_, currentHeight, err := p.server.cc.chainIO.GetBestBlock()
 		if err != nil {
+			lnChan.Stop()
 			return err
 		}
 
@@ -351,6 +356,7 @@ func (p *peer) loadActiveChannels(chans []*channeldb.OpenChannel) error {
 		graph := p.server.chanDB.ChannelGraph()
 		info, p1, p2, err := graph.FetchChannelEdgesByOutpoint(chanPoint)
 		if err != nil && err != channeldb.ErrEdgeNotFound {
+			lnChan.Stop()
 			return err
 		}
 
@@ -394,6 +400,7 @@ func (p *peer) loadActiveChannels(chans []*channeldb.OpenChannel) error {
 			*chanPoint, false,
 		)
 		if err != nil {
+			lnChan.Stop()
 			return err
 		}
 		linkCfg := htlcswitch.ChannelLinkConfig{
@@ -430,6 +437,7 @@ func (p *peer) loadActiveChannels(chans []*channeldb.OpenChannel) error {
 			uint32(currentHeight))
 
 		if err := p.server.htlcSwitch.AddLink(link); err != nil {
+			lnChan.Stop()
 			return err
 		}
 	}


### PR DESCRIPTION
In this commit, we fix a goroutine leak that could occur if while we
were loading an error occurred in any of the steps after we created the
channel object, but before it was actually loaded in to the script. If
an error occurs at any step, we ensure that we’ll stop toe channel.
Otherwise, the sigPool goroutines would still be lingering and never be
stopped.