### PR TITLE
docs: add macaroon example to python docs, update syntax to python 3

### DIFF
--- a/docs/grpc/python.md
+++ b/docs/grpc/python.md
@@ -55,7 +55,7 @@ import os
 
 # Lnd cert is at ~/.lnd/tls.cert on Linux and
 # ~/Library/Application Support/Lnd/tls.cert on Mac
-cert = open(os.path.expanduser('~/.lnd/tls.cert')).read()
+cert = open(os.path.expanduser('~/.lnd/tls.cert'), 'rb').read()
 creds = grpc.ssl_channel_credentials(cert)
 channel = grpc.secure_channel('localhost:10009', creds)
 stub = lnrpc.LightningStub(channel)
@@ -72,7 +72,7 @@ is at the default `localhost:10009`, with an open channel between the two nodes.
 ```python
 # Retrieve and display the wallet balance
 response = stub.WalletBalance(ln.WalletBalanceRequest(witness_only=True))
-print response.total_balance
+print(response.total_balance)
 ```
 
 #### Response-streaming RPC
@@ -80,7 +80,7 @@ print response.total_balance
 ```python
 request = ln.InvoiceSubscription()
 for invoice in stub.SubscribeInvoices(request):
-    print invoice
+    print(invoice)
 ```
 
 Now, create an invoice for your node at `localhost:10009`and send a payment to
@@ -124,7 +124,7 @@ dest_bytes = codecs.decode(dest_hex, 'hex')
 request_iterable = request_generator(dest=dest_bytes, amt=100)
 
 for payment in stub.SendPayment(request_iterable):
-    print payment
+    print(payment)
 ```
 This example will send a payment of 100 satoshis every 2 seconds.
 

--- a/docs/grpc/python.md
+++ b/docs/grpc/python.md
@@ -53,6 +53,11 @@ import rpc_pb2_grpc as lnrpc
 import grpc
 import os
 
+# Due to updated ECDSA generated tls.cert we need to let gprc know that
+# we need to use that cipher suite otherwise there will be a handhsake
+# error when we communicate with the lnd rpc server.
+os.environ["GRPC_SSL_CIPHER_SUITES"] = 'HIGH+ECDSA'
+
 # Lnd cert is at ~/.lnd/tls.cert on Linux and
 # ~/Library/Application Support/Lnd/tls.cert on Mac
 cert = open(os.path.expanduser('~/.lnd/tls.cert'), 'rb').read()


### PR DESCRIPTION
In this PR, we add an example of how to use macaroons with the python grpc library. 

In this PR, we also update the python grpc example to use the correct cipher suite to ensure the ssl handshake works. The current example code does not work with the latest version of LND.

In this PR, we also update python 2 syntax to python 3.