### PR TITLE
docker: replace bash shells with last command

### DIFF
--- a/docker/btcd/start-btcctl.sh
+++ b/docker/btcd/start-btcctl.sh
@@ -43,7 +43,7 @@ RPCUSER=$(set_default "$RPCUSER" "devuser")
 RPCPASS=$(set_default "$RPCPASS" "devpass")
 NETWORK=$(set_default "$NETWORK" "simnet")
 
-btcctl \
+exec btcctl \
     "--$NETWORK" \
     --rpccert="/rpc/rpc.cert" \
     --rpcuser="$RPCUSER" \

--- a/docker/btcd/start-btcd.sh
+++ b/docker/btcd/start-btcd.sh
@@ -67,5 +67,5 @@ PARAMS="$PARAMS $@"
 
 # Print command and start bitcoin node.
 echo "Command: btcd $PARAMS"
-btcd $PARAMS
+exec btcd $PARAMS
 

--- a/docker/lnd/start-lnd.sh
+++ b/docker/lnd/start-lnd.sh
@@ -49,7 +49,7 @@ if [[ "$CHAIN" == "litecoin" ]]; then
     BACKEND="ltcd"
 fi
 
-lnd \
+exec lnd \
     --noencryptwallet \
     --logdir="/data" \
     "--$CHAIN.active" \

--- a/docker/ltcd/start-ltcctl.sh
+++ b/docker/ltcd/start-ltcctl.sh
@@ -43,7 +43,7 @@ RPCUSER=$(set_default "$RPCUSER" "devuser")
 RPCPASS=$(set_default "$RPCPASS" "devpass")
 NETWORK=$(set_default "$NETWORK" "simnet")
 
-ltcctl \
+exec ltcctl \
     "--$NETWORK" \
     --rpccert="/rpc/rpc.cert" \
     --rpcuser="$RPCUSER" \

--- a/docker/ltcd/start-ltcd.sh
+++ b/docker/ltcd/start-ltcd.sh
@@ -67,5 +67,5 @@ PARAMS="$PARAMS $@"
 
 # Print command and start bitcoin node.
 echo "Command: ltcd $PARAMS"
-ltcd $PARAMS
+exec ltcd $PARAMS
 


### PR DESCRIPTION
It is better to replace bash shell with potentially long-running
last script command. This way the running command will receive all
potential unix process signals directly.

A concrete example which motivated this change:
Exec of btcd is needed for graceful shutdown of btcd during
`docker-compose down`. Docker Compose properly sends this signal to our
start-btcd.sh bash shell but it is not further signalled to the running
btcd process. Docker Compose then kills whole container forcefully after
some timeout.

An alternative solution would be to trap SIGTERM in our bash script and
forward it to running btcd. Which would be IMO ugly and error prone.