### PR TITLE
HTLC number mismatch fixes

### DIFF
--- a/lnwallet/channel.go
+++ b/lnwallet/channel.go
@@ -2540,7 +2540,7 @@ func genRemoteHtlcSigJobs(keyRing *CommitmentKeyRing,
 	remoteCommitView *commitment) ([]signJob, chan struct{}, error) {
 
 	txHash := remoteCommitView.txn.TxHash()
-	dustLimit := localChanCfg.DustLimit
+	dustLimit := remoteChanCfg.DustLimit
 	feePerKw := remoteCommitView.feePerKw
 
 	// With the keys generated, we'll make a slice with enough capacity to

--- a/lnwallet/channel.go
+++ b/lnwallet/channel.go
@@ -3465,12 +3465,6 @@ func genHtlcSigValidationJobs(localCommitmentView *commitment,
 	keyRing *CommitmentKeyRing, htlcSigs []lnwire.Sig,
 	localChanCfg, remoteChanCfg *channeldb.ChannelConfig) ([]verifyJob, error) {
 
-	// If this new commitment state doesn't have any HTLC's that are to be
-	// signed, then we'll return a nil slice.
-	if len(htlcSigs) == 0 {
-		return nil, nil
-	}
-
 	txHash := localCommitmentView.txn.TxHash()
 	feePerKw := localCommitmentView.feePerKw
 

--- a/lnwallet/channel.go
+++ b/lnwallet/channel.go
@@ -3532,6 +3532,12 @@ func genHtlcSigValidationJobs(localCommitmentView *commitment,
 				return sigHash, nil
 			}
 
+			// Make sure there are more signatures left.
+			if i >= len(htlcSigs) {
+				return nil, fmt.Errorf("not enough HTLC " +
+					"signatures.")
+			}
+
 			// With the sighash generated, we'll also store the
 			// signature so it can be written to disk if this state
 			// is valid.
@@ -3576,6 +3582,12 @@ func genHtlcSigValidationJobs(localCommitmentView *commitment,
 				}
 
 				return sigHash, nil
+			}
+
+			// Make sure there are more signatures left.
+			if i >= len(htlcSigs) {
+				return nil, fmt.Errorf("not enough HTLC " +
+					"signatures.")
 			}
 
 			// With the sighash generated, we'll also store the

--- a/lnwallet/channel.go
+++ b/lnwallet/channel.go
@@ -3606,6 +3606,13 @@ func genHtlcSigValidationJobs(localCommitmentView *commitment,
 		i++
 	}
 
+	// If we received a number of HTLC signatures that doesn't match our
+	// commitment, we'll return an error now.
+	if len(htlcSigs) != i {
+		return nil, fmt.Errorf("number of htlc sig mismatch. "+
+			"Expected %v sigs, got %v", i, len(htlcSigs))
+	}
+
 	return verifyJobs, nil
 }
 

--- a/lnwallet/channel_test.go
+++ b/lnwallet/channel_test.go
@@ -1530,6 +1530,30 @@ func TestHTLCSigNumber(t *testing.T) {
 		t.Fatalf("Expected Bob to reject signatures")
 	}
 
+	// ===================================================================
+	// Test that Bob will reject a commitment if Alice doesn't send any
+	// HTLC signatures.
+	// ===================================================================
+	aliceChannel, bobChannel, cleanUp = createChanWithHTLC(aboveDust)
+	defer cleanUp()
+
+	aliceSig, aliceHtlcSigs, err = aliceChannel.SignNextCommitment()
+	if err != nil {
+		t.Fatalf("Error signing next commitment: %v", err)
+	}
+
+	if len(aliceHtlcSigs) != 1 {
+		t.Fatalf("expected 1 htlc sig, instead got %v",
+			len(aliceHtlcSigs))
+	}
+
+	// Now just give Bob an empty htlcSig slice. He should reject the
+	// commitment because of this.
+	err = bobChannel.ReceiveNewCommitment(aliceSig, []lnwire.Sig{})
+	if err == nil {
+		t.Fatalf("Expected Bob to reject signatures")
+	}
+
 }
 
 // TestChannelBalanceDustLimit tests the condition when the remaining balance


### PR DESCRIPTION
This PR attempts to fix a number of issues that would arise because we allowed creating and receiving HTLC signatures that didn't match the number of HTLC outputs on the commitment.

Fixes #547 