### PR TITLE
routing: route around height disagreements during htlc routing attempts 

### DIFF
--- a/routing/pathfind.go
+++ b/routing/pathfind.go
@@ -543,7 +543,8 @@ func findPath(tx *bolt.Tx, graph *channeldb.ChannelGraph,
 			// amount to our relaxation condition.
 			if tempDist < distance[v].dist &&
 				edgeInfo.Capacity >= amt.ToSatoshis() &&
-				amt >= outEdge.MinHTLC {
+				amt >= outEdge.MinHTLC &&
+				outEdge.TimeLockDelta != 0 {
 
 				distance[v] = nodeWithDist{
 					dist: tempDist,

--- a/routing/pathfind_test.go
+++ b/routing/pathfind_test.go
@@ -654,7 +654,7 @@ func TestPathInsufficientCapacity(t *testing.T) {
 	// though we have a 2-hop link.
 	target := aliases["sophon"]
 
-	const payAmt = btcutil.SatoshiPerBitcoin
+	payAmt := lnwire.NewMSatFromSatoshis(btcutil.SatoshiPerBitcoin)
 	_, err = findPath(nil, graph, sourceNode, target, ignoredVertexes,
 		ignoredEdges, payAmt)
 	if !IsError(err, ErrNoPathFound) {

--- a/routing/router_test.go
+++ b/routing/router_test.go
@@ -818,7 +818,7 @@ func TestAddEdgeUnknownVertexes(t *testing.T) {
 		t.Fatalf("unable to update edge policy: %v", err)
 	}
 
-	// We should now be able to find one route to node 2.
+	// We should now be able to find two routes to node 2.
 	paymentAmt := lnwire.NewMSatFromSatoshis(100)
 	targetNode := priv2.PubKey()
 	routes, err := ctx.router.FindRoutes(targetNode, paymentAmt,
@@ -826,8 +826,8 @@ func TestAddEdgeUnknownVertexes(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unable to find any routes: %v", err)
 	}
-	if len(routes) != 1 {
-		t.Fatalf("expected to find 1 route, found: %v", len(routes))
+	if len(routes) != 2 {
+		t.Fatalf("expected to find 2 route, found: %v", len(routes))
 	}
 
 	// Now check that we can update the node info for the partial node
@@ -862,15 +862,15 @@ func TestAddEdgeUnknownVertexes(t *testing.T) {
 		t.Fatalf("could not add node: %v", err)
 	}
 
-	// Should still be able to find the route, and the info should be
+	// Should still be able to find the routes, and the info should be
 	// updated.
 	routes, err = ctx.router.FindRoutes(targetNode, paymentAmt,
 		defaultNumRoutes, DefaultFinalCLTVDelta)
 	if err != nil {
 		t.Fatalf("unable to find any routes: %v", err)
 	}
-	if len(routes) != 1 {
-		t.Fatalf("expected to find 1 route, found: %v", len(routes))
+	if len(routes) != 2 {
+		t.Fatalf("expected to find 2 route, found: %v", len(routes))
 	}
 
 	copy1, err := ctx.graph.FetchLightningNode(priv1.PubKey())

--- a/routing/testdata/basic_graph.json
+++ b/routing/testdata/basic_graph.json
@@ -27,7 +27,8 @@
 "                                    ▼                                           │       ", 
 "                              ┌──────────┐                                      │       ", 
 "                              │ roasbeef │◀─────────────────────────────────────┘       ", 
-"                              └──────────┘               100k satoshis                  "
+"                              └──────────┘               100k satoshis                  ",
+" the graph also includes a channel from roasbeef to sophon via pham nuwen"
     ], 
     "nodes": [
         {
@@ -54,9 +55,62 @@
             "source": false, 
             "pubkey": "036264734b40c9e91d3d990a8cdfbbe23b5b0b7ad3cd0e080a25dcd05d39eeb7eb", 
             "alias": "sophon"
+        },
+        {
+            "source": false,
+            "pubkey": "02a1d2856be336a58af08989aea0d8c41e072ccc392c46f8ce0e6e069f002035f3",
+            "alias": "phamnuwen"
         }
     ], 
     "edges": [
+        {
+            "node_1": "02a1d2856be336a58af08989aea0d8c41e072ccc392c46f8ce0e6e069f002035f3",
+            "node_2": "0367cec75158a4129177bfb8b269cb586efe93d751b43800d456485e81c2620ca6",
+            "channel_id": 999991,
+            "channel_point": "48a0e8b856fef01d9feda7d25a4fac6dae48749e28ba356b92d712ab7f5bd2d0:0", 
+            "flags": 1,
+            "expiry": 1,
+            "min_htlc": 1000, 
+            "fee_base_msat": 10000,
+            "fee_rate": 1000000, 
+            "capacity": 100000
+        },
+        {
+            "node_1": "02a1d2856be336a58af08989aea0d8c41e072ccc392c46f8ce0e6e069f002035f3",
+            "node_2": "0367cec75158a4129177bfb8b269cb586efe93d751b43800d456485e81c2620ca6",
+            "channel_id": 999991,
+            "channel_point": "48a0e8b856fef01d9feda7d25a4fac6dae48749e28ba356b92d712ab7f5bd2d0:0", 
+            "flags": 0,
+            "expiry": 1,
+            "min_htlc": 1000, 
+            "fee_base_msat": 10000, 
+            "fee_rate": 1000000, 
+            "capacity": 100000
+        },
+        {
+            "node_1": "02a1d2856be336a58af08989aea0d8c41e072ccc392c46f8ce0e6e069f002035f3",
+            "node_2": "036264734b40c9e91d3d990a8cdfbbe23b5b0b7ad3cd0e080a25dcd05d39eeb7eb",
+            "channel_id": 99999,
+            "channel_point": "05ffda8890d0a4fffe0ddca0b1932ba0415b1d5868a99515384a4e7883d96b88:0", 
+            "flags": 1,
+            "expiry": 1,
+            "min_htlc": 1000, 
+            "fee_base_msat": 10000,
+            "fee_rate": 1000000, 
+            "capacity": 100000
+        },
+        {
+            "node_1": "02a1d2856be336a58af08989aea0d8c41e072ccc392c46f8ce0e6e069f002035f3",
+            "node_2": "036264734b40c9e91d3d990a8cdfbbe23b5b0b7ad3cd0e080a25dcd05d39eeb7eb",
+            "channel_id": 99999,
+            "channel_point": "05ffda8890d0a4fffe0ddca0b1932ba0415b1d5868a99515384a4e7883d96b88:0", 
+            "flags": 0,
+            "expiry": 1,
+            "min_htlc": 1000, 
+            "fee_base_msat": 10000, 
+            "fee_rate": 1000000, 
+            "capacity": 100000
+        },
         {
             "node_1": "0367cec75158a4129177bfb8b269cb586efe93d751b43800d456485e81c2620ca6",
 	    "node_2": "032b480de5d002f1a8fd1fe1bbf0a0f1b07760f65f052e66d56f15d71097c01add",


### PR DESCRIPTION
In this PR, we reverse an existing assumption in the codebase: if we ever get a non-final CLTV related routing error, then we're at fault as we're not yet properly synced to the chain. Since this assumption was added, we actually ensure that we're fully synced to the chain, before the rest of the daemon starts up, so this assumption is no longer valid. 

As is now, if we attempt to route through a node that doesn't know what the current height is well cease payment attempts all together as it was assumed be a terminal error. This PR fixes that by simply pruning away nodes that disagree with our view of the current chain, allowing us to route around these faulty nodes. We also add a test case that failed before this new modification. The test ensures that we'll properly route around nodes that send us non-final CLTV related errors. 

Fixes the latter portion of #922. 