### PR TITLE
htlcswitch: trivial whitespace

### DIFF
--- a/htlcswitch/switch.go
+++ b/htlcswitch/switch.go
@@ -1930,7 +1930,7 @@ query:
 func (s *Switch) getLinks(destination [33]byte) ([]ChannelLink, error) {
 	links, ok := s.interfaceIndex[destination]
 	if !ok {
-		return nil, errors.Errorf("unable to locate channel link by"+
+		return nil, errors.Errorf("unable to locate channel link by "+
 			"destination hop id %x", destination)
 	}
 


### PR DESCRIPTION
Missing space results in `unable to get channel links: unable to locate channel link bydestination hop id` log messages