### PR TITLE
config: determine the bitcoind chain directory from the chain params …

### DIFF
--- a/config.go
+++ b/config.go
@@ -1046,18 +1046,13 @@ func extractBitcoindRPCParams(bitcoindConfigPath string) (string, string, string
 	}
 
 	chainDir := "/"
-	netRE, err := regexp.Compile(`(?m)^\s*(testnet|regtest)=[\d]+`)
-	if err != nil {
-		return "", "", "", err
-	}
-	netSubmatches := netRE.FindSubmatch(configContents)
-	if netSubmatches != nil {
-		switch string(netSubmatches[1]) {
-		case "testnet":
-			chainDir = "/testnet3/"
-		case "regtest":
-			chainDir = "/regtest/"
-		}
+	switch activeNetParams.Params.Name {
+	case "testnet3":
+		chainDir = "/testnet3/"
+	case "testnet4":
+		chainDir = "/testnet4/"
+	case "regtest":
+		chainDir = "/regtest/"
 	}
 
 	cookie, err := ioutil.ReadFile(dataDir + chainDir + ".cookie")


### PR DESCRIPTION
…instead of the config file. This is more reliable in case the chain was selected with a bitcoind commandline option instead of a line in the config file.

Note: using the params name might be a bit of a shaky solution, but it works for now. 
Also note that using a commandline option instead of a config file option for specifying testnet is (I think) very common, especially when people also want to be able to use mainnet.