### PR TITLE
channeldb: update ShortChanID in-mem during MarkAsOpen

### DIFF
--- a/channeldb/channel_test.go
+++ b/channeldb/channel_test.go
@@ -684,6 +684,16 @@ func TestFetchPendingChannels(t *testing.T) {
 		t.Fatalf("unable to mark channel as open: %v", err)
 	}
 
+	if pendingChannels[0].IsPending {
+		t.Fatalf("channel marked open should no longer be pending")
+	}
+
+	if pendingChannels[0].ShortChanID != chanOpenLoc {
+		t.Fatalf("channel opening height not updated: expected %v, "+
+			"got %v", spew.Sdump(pendingChannels[0].ShortChanID),
+			chanOpenLoc)
+	}
+
 	// Next, we'll re-fetch the channel to ensure that the open height was
 	// properly set.
 	openChans, err := cdb.FetchAllChannels()


### PR DESCRIPTION
Modifies the MarkAsOpen operation to also update the ShortChanID and IsPending fields in-memory. Before, only the on-disk representation was updated, which may have lead to stale data channel states being passed in-memory.