### PR TITLE
[mini] rpcserver: remove uneccessary signal to breacharbiter at force close

### DIFF
--- a/rpcserver.go
+++ b/rpcserver.go
@@ -1031,12 +1031,6 @@ func (r *rpcServer) CloseChannel(in *lnrpc.CloseChannelRequest,
 			r.server.htlcSwitch.RemoveLink(chanID)
 		}
 
-		select {
-		case r.server.breachArbiter.settledContracts <- *chanPoint:
-		case <-r.quit:
-			return fmt.Errorf("server shutting down")
-		}
-
 		// With the necessary indexes cleaned up, we'll now force close
 		// the channel.
 		chainArbitrator := r.server.chainArb


### PR DESCRIPTION
This signal is no longer needed, as the breacharbiter is given
the UnilateralClosure chain event.