### PR TITLE
[refactor] lnwallet/channel: add NewLocalForceCloseSummary

### DIFF
--- a/contractcourt/chain_arbitrator.go
+++ b/contractcourt/chain_arbitrator.go
@@ -196,7 +196,7 @@ func newActiveChannelArbitrator(channel *channeldb.OpenChannel,
 		ChanPoint:   chanPoint,
 		ShortChanID: channel.ShortChanID,
 		BlockEpochs: blockEpoch,
-		ForceCloseChan: func() (*lnwallet.ForceCloseSummary, error) {
+		ForceCloseChan: func() (*lnwallet.LocalForceCloseSummary, error) {
 			// With the channels fetched, attempt to locate
 			// the target channel according to its channel
 			// point.

--- a/contractcourt/channel_arbitrator.go
+++ b/contractcourt/channel_arbitrator.go
@@ -89,7 +89,7 @@ type ChannelArbitratorConfig struct {
 	// is watching over. We'll use this when we decide that we need to go
 	// to chain. The returned summary contains all items needed to
 	// eventually resolve all outputs on chain.
-	ForceCloseChan func() (*lnwallet.ForceCloseSummary, error)
+	ForceCloseChan func() (*lnwallet.LocalForceCloseSummary, error)
 
 	// CloseChannel is a function closure that marks a channel under watch
 	// as "closing". In this phase, we will no longer accept any updates to


### PR DESCRIPTION
This commit renames ForceCloseSummary to LocalForceCloseSummary, and
adds a new method NewLocalForceCloseSummary that can be used to derive a
LocalForceCloseSummary if our commitment transaction gets confirmed
in-chain. It is meant to accompany the NewUnilateralCloseSummary
method, which is used for the same purpose if a remote commitment is
seen in-chain.

This PR is a building block for an upcoming, larger change to the `contractcourt` package, where we will only act on a channel's commitment that gets confirmed in-chain. In this case it will be useful to fetch a `LocalForceCloseSummary` if we find our commitment in-chain, without having to "ForceClose" the channel a second time.