### PR TITLE
Add spend notification to client map before recording it with backend

### DIFF
--- a/chainntnfs/bitcoindnotify/bitcoind.go
+++ b/chainntnfs/bitcoindnotify/bitcoind.go
@@ -488,10 +488,6 @@ type spendCancel struct {
 func (b *BitcoindNotifier) RegisterSpendNtfn(outpoint *wire.OutPoint,
 	_ uint32) (*chainntnfs.SpendEvent, error) {
 
-	if err := b.chainConn.NotifySpent([]*wire.OutPoint{outpoint}); err != nil {
-		return nil, err
-	}
-
 	ntfn := &spendNotification{
 		targetOutpoint: outpoint,
 		spendChan:      make(chan *chainntnfs.SpendDetail, 1),
@@ -502,6 +498,10 @@ func (b *BitcoindNotifier) RegisterSpendNtfn(outpoint *wire.OutPoint,
 	case <-b.quit:
 		return nil, ErrChainNotifierShuttingDown
 	case b.notificationRegistry <- ntfn:
+	}
+
+	if err := b.chainConn.NotifySpent([]*wire.OutPoint{outpoint}); err != nil {
+		return nil, err
 	}
 
 	// The following conditional checks to ensure that when a spend notification

--- a/chainntnfs/btcdnotify/btcd.go
+++ b/chainntnfs/btcdnotify/btcd.go
@@ -508,10 +508,6 @@ type spendCancel struct {
 func (b *BtcdNotifier) RegisterSpendNtfn(outpoint *wire.OutPoint,
 	_ uint32) (*chainntnfs.SpendEvent, error) {
 
-	if err := b.chainConn.NotifySpent([]*wire.OutPoint{outpoint}); err != nil {
-		return nil, err
-	}
-
 	ntfn := &spendNotification{
 		targetOutpoint: outpoint,
 		spendChan:      make(chan *chainntnfs.SpendDetail, 1),
@@ -522,6 +518,10 @@ func (b *BtcdNotifier) RegisterSpendNtfn(outpoint *wire.OutPoint,
 	case <-b.quit:
 		return nil, ErrChainNotifierShuttingDown
 	case b.notificationRegistry <- ntfn:
+	}
+
+	if err := b.chainConn.NotifySpent([]*wire.OutPoint{outpoint}); err != nil {
+		return nil, err
 	}
 
 	// The following conditional checks to ensure that when a spend notification


### PR DESCRIPTION
This PR attempts to fix a race that could occur during integration tests, where the backend would respond to a `NotifySpent` call before we had added the `spendNotification` to our map of clients, resulting in the notification being lost.