### PR TITLE
Make log rotation configurable.

### DIFF
--- a/config.go
+++ b/config.go
@@ -46,6 +46,7 @@ const (
 	defaultMaxPendingChannels = 1
 	defaultNoEncryptWallet    = false
 	defaultTrickleDelay       = 30 * 1000
+	defaultMaxLogFiles        = 3
 
 	defaultBroadcastDelta = 10
 
@@ -157,6 +158,7 @@ type config struct {
 	ReadMacPath    string `long:"readonlymacaroonpath" description:"Path to write the read-only macaroon for lnd's RPC and REST services if it doesn't exist"`
 	InvoiceMacPath string `long:"invoicemacaroonpath" description:"Path to the invoice-only macaroon for lnd's RPC and REST services if it doesn't exist"`
 	LogDir         string `long:"logdir" description:"Directory to log output."`
+	MaxLogFiles    int64  `long:"maxlogfiles" description:"Maximum logfiles to keep (0 for no rotation)"`
 
 	RPCListeners  []string `long:"rpclisten" description:"Add an interface/port to listen for RPC connections"`
 	RESTListeners []string `long:"restlisten" description:"Add an interface/port to listen for REST connections"`
@@ -221,6 +223,7 @@ func loadConfig() (*config, error) {
 		InvoiceMacPath: defaultInvoiceMacPath,
 		ReadMacPath:    defaultReadMacPath,
 		LogDir:         defaultLogDir,
+		MaxLogFiles:    defaultMaxLogFiles,
 		Bitcoin: &chainConfig{
 			MinHTLC:       defaultBitcoinMinHTLCMSat,
 			BaseFee:       defaultBitcoinBaseFeeMSat,
@@ -660,7 +663,7 @@ func loadConfig() (*config, error) {
 		normalizeNetwork(activeNetParams.Name))
 
 	// Initialize logging at the default logging level.
-	initLogRotator(filepath.Join(cfg.LogDir, defaultLogFilename))
+	initLogRotator(filepath.Join(cfg.LogDir, defaultLogFilename), cfg.MaxLogFiles)
 
 	// Parse, validate, and set debug log level(s).
 	if err := parseAndSetDebugLevels(cfg.DebugLevel); err != nil {

--- a/log.go
+++ b/log.go
@@ -116,14 +116,14 @@ var subsystemLoggers = map[string]btclog.Logger{
 // initLogRotator initializes the logging rotator to write logs to logFile and
 // create roll files in the same directory.  It must be called before the
 // package-global log rotator variables are used.
-func initLogRotator(logFile string) {
+func initLogRotator(logFile string, MaxLogFiles int64) {
 	logDir, _ := filepath.Split(logFile)
 	err := os.MkdirAll(logDir, 0700)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "failed to create log directory: %v\n", err)
 		os.Exit(1)
 	}
-	r, err := rotator.New(logFile, 10*1024, false, 3)
+	r, err := rotator.New(logFile, 10*1024, false, int(MaxLogFiles))
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "failed to create file rotator: %v\n", err)
 		os.Exit(1)

--- a/sample-lnd.conf
+++ b/sample-lnd.conf
@@ -12,6 +12,9 @@
 ; Rotated logs are compressed in place.
 ; logdir=~/.lnd/logs
 
+; Number of logfiles that the log rotation should keep. Setting it to 0 disables deletion of old log files.
+; maxlogfiles=3
+
 ; Path to TLS certificate for lnd's RPC and REST services.
 ; tlscertpath=~/.lnd/tls.cert
 


### PR DESCRIPTION
Log rotation is a bit too eager at times, especially during debug. This pull request adds the "maxlogfiles" config option. 0 turns off deletion of logfiles (leaving management to the user).