### PR TITLE
Makefile w/ dep

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,20 @@
+.PHONY: all glidebin glide deps install fmt test
+
+all: install
+
+glidebin:
+	go get -u github.com/Masterminds/glide
+
+glide: glidebin
+	glide install
+
+deps: glide
+
+install: deps
+	go install . ./cmd/...
+
+fmt:
+	go fmt ./... $$(go list ./... | grep -v '/vendor/')
+
+test:
+	go test -v -p 1 $$(go list ./... | grep -v '/vendor/')

--- a/Makefile
+++ b/Makefile
@@ -1,20 +1,92 @@
-.PHONY: all glidebin glide deps install fmt test
+PKG := github.com/lightningnetwork/lnd
+HAVE_DEP := $(shell command -v dep 2> /dev/null)
+COMMIT := $(shell git rev-parse HEAD)
+LDFLAGS := -ldflags "-X main.Commit=$(COMMIT)"
+RM := rm
 
-all: install
+all: scratch
 
-glidebin:
-	go get -u github.com/Masterminds/glide
 
-glide: glidebin
-	glide install
+# ==============================================================================
+# INSTALLATION
+# ==============================================================================
 
-deps: glide
+deps:
+ifndef HAVE_DEP
+	@echo "Fetching dep."
+	go get -u github.com/golang/dep/cmd/dep
+endif
+	@echo "Building dependencies."
+	dep ensure -v
 
-install: deps
-	go install . ./cmd/...
+build: 
+	@echo "Building lnd and lncli."
+	go build -v -o lnd $(LDFLAGS) $(PKG)
+	go build -v -o lncli $(LDFLAGS) $(PKG)/cmd/lncli
+
+install:
+	@echo "Installing lnd and lncli."
+	go install -v $(LDFLAGS) $(PKG)
+	go install -v $(LDFLAGS) $(PKG)/cmd/lncli
+
+scratch: deps build
+
+
+# ==============================================================================
+# TESTING
+# ==============================================================================
+
+# Define the integration test.run filter if the icase argument was provided.
+ifneq ($(icase),)
+	ITESTCASE := -test.run=TestLightningNetworkDaemon/$(icase)
+endif
+
+# UNIT_TARGTED is defined iff a specific package and/or unit test case is being
+# targeted.
+UNIT_TARGETED = 
+
+# If specific package is being unit tested, construct the full name of the
+# subpackage.
+ifneq ($(pkg),)
+	UNITPKG := $(PKG)/$(pkg)
+	UNIT_TARGETED = yes
+endif
+
+# If a specific unit test case is being target, construct test.run filter.
+ifneq ($(case),)
+	UNITCASE := -test.run=$(case)
+	UNIT_TARGETED = yes
+endif
+
+# If no unit targeting was input, default to running all tests. Otherwise,
+# construct the command to run the specific package/test case.
+ifndef UNIT_TARGETED
+	UNIT := go list $(PKG)/... | grep -v '/vendor/' | xargs go test
+else
+	UNIT := go test -test.v $(UNITPKG) $(UNITCASE)
+endif
+
+check: unit itest
+
+itest: install
+	@echo "Running integration tests."
+	go test -v -tags rpctest -logoutput $(ITESTCASE)
+
+unit:
+	@echo "Running unit tests."
+	$(UNIT)
+
+
+# ==============================================================================
+# UTILITIES
+# ==============================================================================
 
 fmt:
-	go fmt ./... $$(go list ./... | grep -v '/vendor/')
+	go list $(PKG)/... | grep -v '/vendor/' | xargs go fmt -x
 
-test:
-	go test -v -p 1 $$(go list ./... | grep -v '/vendor/')
+clean:
+	$(RM) ./lnd ./lncli
+	$(RM) -rf vendor
+
+
+.PHONY: all deps build install scratch check itest unit fmt clean

--- a/cmd/lncli/main.go
+++ b/cmd/lncli/main.go
@@ -29,6 +29,10 @@ const (
 )
 
 var (
+	//Commit stores the current commit hash of this build. This should be
+	//set using -ldflags during compilation.
+	Commit string
+
 	defaultLndDir       = btcutil.AppDataDir("lnd", false)
 	defaultTLSCertPath  = filepath.Join(defaultLndDir, defaultTLSCertFilename)
 	defaultMacaroonPath = filepath.Join(defaultLndDir, defaultMacaroonFilename)
@@ -150,7 +154,7 @@ func getClientConn(ctx *cli.Context, skipMacaroons bool) *grpc.ClientConn {
 func main() {
 	app := cli.NewApp()
 	app.Name = "lncli"
-	app.Version = "0.4"
+	app.Version = fmt.Sprintf("%s commit=%s", "0.4", Commit)
 	app.Usage = "control plane for your Lightning Network Daemon (lnd)"
 	app.Flags = []cli.Flag{
 		cli.StringFlag{

--- a/lnd.go
+++ b/lnd.go
@@ -57,6 +57,10 @@ const (
 )
 
 var (
+	//Commit stores the current commit hash of this build. This should be
+	//set using -ldflags during compilation.
+	Commit string
+
 	cfg              *config
 	shutdownChannel  = make(chan struct{})
 	registeredChains = newChainRegistry()

--- a/version.go
+++ b/version.go
@@ -55,6 +55,9 @@ func version() string {
 		version = fmt.Sprintf("%s+%s", version, build)
 	}
 
+	// Append commit hash of current build to version.
+	version = fmt.Sprintf("%s commit=%s", version, Commit)
+
 	return version
 }
 


### PR DESCRIPTION
This commit continues the work started by @sp4ke, in creating
a simple Makefile for lnd. The following commands are included:

Building
=====
 * `make` - builds everything (deps, lnd, and lncli) from scratch
 * `make deps` - installs dep if needed, then runs dep ensure
 * `make install` - builds lnd and lncli

Testing
=====
 * `make check` - runs unit and itests
 * `make unit` - runs the unit tests for all packages
   * optional `pkg=<subpackage>`
   * optional `case=<unit-test-case-regex>`
 * `make itest` - installs lnd and runs integration tests
   * optional `icase=<integration-test-case-regex>`

Util
===
 * `make fmt` - go fmt's all files

Compiling `lnd` and `lncli` with the Makefile will now inject the most recent commit hash! See `lnd --version` and `lncli --version`.