### PR TITLE
Make log rotation configurable

### DIFF
--- a/log.go
+++ b/log.go
@@ -116,14 +116,14 @@ var subsystemLoggers = map[string]btclog.Logger{
 // initLogRotator initializes the logging rotator to write logs to logFile and
 // create roll files in the same directory.  It must be called before the
 // package-global log rotator variables are used.
-func initLogRotator(logFile string) {
+func initLogRotator(logFile string, MaxLogFileSize int, MaxLogFiles int) {
 	logDir, _ := filepath.Split(logFile)
 	err := os.MkdirAll(logDir, 0700)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "failed to create log directory: %v\n", err)
 		os.Exit(1)
 	}
-	r, err := rotator.New(logFile, 10*1024, false, 3)
+	r, err := rotator.New(logFile, int64(MaxLogFileSize*1024), false, MaxLogFiles)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "failed to create file rotator: %v\n", err)
 		os.Exit(1)

--- a/sample-lnd.conf
+++ b/sample-lnd.conf
@@ -12,6 +12,12 @@
 ; Rotated logs are compressed in place.
 ; logdir=~/.lnd/logs
 
+; Number of logfiles that the log rotation should keep. Setting it to 0 disables deletion of old log files.
+; maxlogfiles=3
+; 
+; Max log file size in MB before it is rotated.
+; maxlogfilesize=10
+
 ; Path to TLS certificate for lnd's RPC and REST services.
 ; tlscertpath=~/.lnd/tls.cert
 


### PR DESCRIPTION
Adding possibility to configure more how many logs to keep, or to disable deletion of all logs alltogether, with the new config option maxlogfiles (0 = disable deleting old files)

Adding maxlogfilesize (in MB)