### PR TITLE
contractcourt/channel_arbitrator: ignore ErrDoubleSpend on force close

### DIFF
--- a/contractcourt/channel_arbitrator.go
+++ b/contractcourt/channel_arbitrator.go
@@ -451,7 +451,9 @@ func (c *ChannelArbitrator) stateStep(bestHeight uint32, bestHash *chainhash.Has
 		if err := c.cfg.PublishTx(closeTx); err != nil {
 			log.Errorf("ChannelArbitrator(%v): unable to broadcast "+
 				"close tx: %v", c.cfg.ChanPoint, err)
-			return StateError, closeTx, err
+			if err != lnwallet.ErrDoubleSpend {
+				return StateError, closeTx, err
+			}
 		}
 
 		// As we've have broadcast the commitment transaction, we send


### PR DESCRIPTION
This commit mitigates a problem within the ChannelArbitrator, where
after a restart we would start up in the state StateBroadcastCommit but
fail to broadcast out commitment because a conflicting transaction (most
likely our own commitment) was already broadcast. A more complete fix
for this case will be added later, but this commit let the
ChannelArbitrator continue, trying to close out the channel.

Partially mitigates #880 before the bigger `contractcourt` revamping is landed.