### PR TITLE
zpay32+rpc: ensure we can encode an expiry of math.MaxUint64, limit to 1 year in seconds

### DIFF
--- a/zpay32/invoice.go
+++ b/zpay32/invoice.go
@@ -1056,8 +1056,8 @@ func writeTaggedField(bufferBase32 *bytes.Buffer, dataType byte, data []byte) er
 
 // base32ToUint64 converts a base32 encoded number to uint64.
 func base32ToUint64(data []byte) (uint64, error) {
-	// Maximum that fits in uint64 is 64 / 5 = 12 groups.
-	if len(data) > 12 {
+	// Maximum that fits in uint64 is ceil(64 / 5) = 12 groups.
+	if len(data) > 13 {
 		return 0, fmt.Errorf("cannot parse data of length %d as uint64",
 			len(data))
 	}
@@ -1077,9 +1077,9 @@ func uint64ToBase32(num uint64) []byte {
 		return []byte{0}
 	}
 
-	// To fit an uint64, we need at most is 64 / 5 = 12 groups.
-	arr := make([]byte, 12)
-	i := 12
+	// To fit an uint64, we need at most is ceil(64 / 5) = 13 groups.
+	arr := make([]byte, 13)
+	i := 13
 	for num > 0 {
 		i--
 		arr[i] = byte(num & uint64(31)) // 0b11111 in binary


### PR DESCRIPTION
In this commit, we fix a logic error in our routine for converting a
uint64 to/from base32. Before this commit, we assumed that the max
number of groups was 12. However, the math.MaxUint64 (1<<64 - 1) can
actually consume more than 12 groups with an extra set of bits. Before
this commit, we would panic when attempting to parse an invoice
generated like so:
  * addinvoice --amt 1337000 --expiry 99999999999999999

To fix this issue, we modify our logic to expect at most 13 groups.
Additionally, we've added a new test that would panic before applying
this commit.

As an additional layer of defense, we'll reject any expiry greater 
than 1 year.

Fixes #972. 