### PR TITLE
server+connmgr: fix issues w.r.t automatically re-establishing connections. 

### DIFF
--- a/fundingmanager.go
+++ b/fundingmanager.go
@@ -942,7 +942,6 @@ func (f *fundingManager) handleFundingOpen(fmsg *fundingOpenMsg) {
 		return
 	}
 
-	// TODO(roasbeef): error if funding flow already ongoing
 	fndgLog.Infof("Recv'd fundingRequest(amt=%v, push=%v, delay=%v, "+
 		"pendingId=%x) from peer(%x)", amt, msg.PushAmount,
 		msg.CsvDelay, msg.PendingChannelID,

--- a/server.go
+++ b/server.go
@@ -690,16 +690,6 @@ func (s *server) peerBootstrapper(numTargetPeers uint32,
 				return
 			}
 
-			// Add bootstrapped peer as persistent to maintain
-			// connectivity even if we have no open channels.
-			targetPub := string(conn.RemotePub().SerializeCompressed())
-			s.mu.Lock()
-			s.persistentPeers[targetPub] = struct{}{}
-			if _, ok := s.persistentPeersBackoff[targetPub]; !ok {
-				s.persistentPeersBackoff[targetPub] = defaultBackoff
-			}
-			s.mu.Unlock()
-
 			s.OutboundPeerConnected(nil, conn)
 		}(addr)
 	}
@@ -804,16 +794,6 @@ func (s *server) peerBootstrapper(numTargetPeers uint32,
 						atomic.AddUint32(&epochErrors, 1)
 						return
 					}
-
-					// Add bootstrapped peer as persistent to maintain
-					// connectivity even if we have no open channels.
-					targetPub := string(conn.RemotePub().SerializeCompressed())
-					s.mu.Lock()
-					s.persistentPeers[targetPub] = struct{}{}
-					if _, ok := s.persistentPeersBackoff[targetPub]; !ok {
-						s.persistentPeersBackoff[targetPub] = defaultBackoff
-					}
-					s.mu.Unlock()
 
 					s.OutboundPeerConnected(nil, conn)
 				}(addr)


### PR DESCRIPTION
This PR sets out to fix a number of issues that have been reported related to the way we attempt to automatically re-establish connections to: persistent peers that disconnect from us, and also persistent peers that we have channels open with. 

First, we'll no longer add boostrap peers to out set of persistent connections. We do this as the only peers that we're concerned with, are the ones that we have channels open with. This had also caused issues if the chosen peers were incompatible with us for w/e reason, which would cause us to continually re-connect to them over and over again. 

Additionally, we'll now look up the "proper" port of a peer for reconnection purposes. This ensures that when a peer disconnects, even if it was an inbound connections, we'll use the correct port when reconnecting.

Fixes #935, #941, #979. 