### PR TITLE
server: cleanup persistent connection retries

### DIFF
--- a/fundingmanager.go
+++ b/fundingmanager.go
@@ -942,7 +942,6 @@ func (f *fundingManager) handleFundingOpen(fmsg *fundingOpenMsg) {
 		return
 	}
 
-	// TODO(roasbeef): error if funding flow already ongoing
 	fndgLog.Infof("Recv'd fundingRequest(amt=%v, push=%v, delay=%v, "+
 		"pendingId=%x) from peer(%x)", amt, msg.PushAmount,
 		msg.CsvDelay, msg.PendingChannelID,

--- a/fundingmanager_test.go
+++ b/fundingmanager_test.go
@@ -300,7 +300,7 @@ func createTestFundingManager(t *testing.T, privKey *btcec.PrivateKey,
 			return uint16(lnwallet.MaxHTLCNumber / 2)
 		},
 		ArbiterChan: arbiterChan,
-		WatchNewChannel: func(*channeldb.OpenChannel) error {
+		WatchNewChannel: func(*channeldb.OpenChannel, *lnwire.NetAddress) error {
 			return nil
 		},
 		ReportShortChanID: func(wire.OutPoint, lnwire.ShortChannelID) error {

--- a/lnd.go
+++ b/lnd.go
@@ -433,8 +433,8 @@ func lndMain() error {
 		WatchNewChannel: func(channel *channeldb.OpenChannel,
 			addr *lnwire.NetAddress) error {
 
-			// First, we'll mark this new peer as a persistent
-			// re-connection purposes.
+			// First, we'll mark this new peer as a persistent peer
+			// for re-connection purposes.
 			server.mu.Lock()
 			pubStr := string(addr.IdentityKey.SerializeCompressed())
 			server.persistentPeers[pubStr] = struct{}{}

--- a/lntest/node.go
+++ b/lntest/node.go
@@ -147,6 +147,7 @@ func (cfg nodeConfig) genArgs() []string {
 	args = append(args, fmt.Sprintf("--rpclisten=%v", cfg.RPCAddr()))
 	args = append(args, fmt.Sprintf("--restlisten=%v", cfg.RESTAddr()))
 	args = append(args, fmt.Sprintf("--listen=%v", cfg.P2PAddr()))
+	args = append(args, fmt.Sprintf("--externalip=%v", cfg.P2PAddr()))
 	args = append(args, fmt.Sprintf("--logdir=%v", cfg.LogDir))
 	args = append(args, fmt.Sprintf("--datadir=%v", cfg.DataDir))
 	args = append(args, fmt.Sprintf("--tlscertpath=%v", cfg.TLSCertPath))

--- a/server.go
+++ b/server.go
@@ -690,16 +690,6 @@ func (s *server) peerBootstrapper(numTargetPeers uint32,
 				return
 			}
 
-			// Add bootstrapped peer as persistent to maintain
-			// connectivity even if we have no open channels.
-			targetPub := string(conn.RemotePub().SerializeCompressed())
-			s.mu.Lock()
-			s.persistentPeers[targetPub] = struct{}{}
-			if _, ok := s.persistentPeersBackoff[targetPub]; !ok {
-				s.persistentPeersBackoff[targetPub] = defaultBackoff
-			}
-			s.mu.Unlock()
-
 			s.OutboundPeerConnected(nil, conn)
 		}(addr)
 	}
@@ -804,16 +794,6 @@ func (s *server) peerBootstrapper(numTargetPeers uint32,
 						atomic.AddUint32(&epochErrors, 1)
 						return
 					}
-
-					// Add bootstrapped peer as persistent to maintain
-					// connectivity even if we have no open channels.
-					targetPub := string(conn.RemotePub().SerializeCompressed())
-					s.mu.Lock()
-					s.persistentPeers[targetPub] = struct{}{}
-					if _, ok := s.persistentPeersBackoff[targetPub]; !ok {
-						s.persistentPeersBackoff[targetPub] = defaultBackoff
-					}
-					s.mu.Unlock()
 
 					s.OutboundPeerConnected(nil, conn)
 				}(addr)


### PR DESCRIPTION
Complementary to #981.

This commits changes the behavior of our connection
reestablishment, and resolves some minor issues that
could lead to uncancelled requests or an infinite
connection loop.

 - Will not attempt to Remove connection requests with
   an ID of 0. This can happen for reconnect attempts
   that get scheduled, but have not started at the
   time the server cancels the connection requests.

 - Adds a per-peer cancellation channel, that is
   closed upon a successful inbound or outbound
   connection. The goroutine spwaned to handle the
   reconnect by the peerTerminationWatch now
   selects on this channel, and skips reconnecting
   if it is closed before the backoff matures.

 - Properly computes the backoff when no entry in
   persistentPeersBackoff is found. Previously, a
   value of 0 would be returned, cause all subsequent
   backoff attempts to use a backoff of 0.

 - Cancels a peer's retries and remove connections
   immediately after receiving an inbound connection,
   to mimic the structure of OutboundPeerConnected.

Fixes #935, #941, #979, #982.