### PR TITLE
Add Autopilot.ConfTarget attr and open channels with it

### DIFF
--- a/cmd/lncli/commands.go
+++ b/cmd/lncli/commands.go
@@ -718,7 +718,7 @@ func closeChannel(ctx *cli.Context) error {
 
 	// After parsing the request, we'll spin up a goroutine that will
 	// retrieve the closing transaction ID when attempting to close the
-	// channel. We do this to because `executeChannelClose` can block, so we
+	// channel. We do this too because `executeChannelClose` can block, so we
 	// would like to present the closing transaction ID to the user as soon
 	// as it is broadcasted.
 	var wg sync.WaitGroup

--- a/config.go
+++ b/config.go
@@ -132,6 +132,7 @@ type autoPilotConfig struct {
 	Allocation     float64 `long:"allocation" description:"The percentage of total funds that should be committed to automatic channel establishment"`
 	MinChannelSize int64   `long:"minchansize" description:"The smallest channel that the autopilot agent should create"`
 	MaxChannelSize int64   `long:"maxchansize" description:"The largest channel that the autopilot agent should create"`
+	ConfTarget     uint32  `long:"conf_target" description:"Targeted number of blocks within which the channel should be confirmed"`
 }
 
 type torConfig struct {
@@ -373,6 +374,12 @@ func loadConfig() (*config, error) {
 	}
 	if cfg.Autopilot.MaxChannelSize < 0 {
 		str := "%s: autopilot.maxchansize must be non-negative"
+		err := fmt.Errorf(str, funcName)
+		fmt.Fprintln(os.Stderr, err)
+		return nil, err
+	}
+	if cfg.Autopilot.ConfTarget < 0 {
+		str := "%s: autopilot.confirm_in must be non-negative"
 		err := fmt.Errorf(str, funcName)
 		fmt.Fprintln(os.Stderr, err)
 		return nil, err

--- a/config.go
+++ b/config.go
@@ -132,8 +132,8 @@ type autoPilotConfig struct {
 	Allocation      float64             `long:"allocation" description:"The percentage of total funds that should be committed to automatic channel establishment"`
 	MinChannelSize  int64               `long:"minchansize" description:"The smallest channel that the autopilot agent should create"`
 	MaxChannelSize  int64               `long:"maxchansize" description:"The largest channel that the autopilot agent should create"`
-	ConfTarget      uint32              `long:"conftarget" description:"Targeted number of blocks within which the channel should be confirmed"`
-	OpenChanFeeRate lnwire.MilliSatoshi `long:"openchanfeerate" description:"The fee in millisatoshi we will charge for forwarding payments on our channels. If set, this value supersedes that of 'conftarget'."`
+	ConfTarget      uint32              `long:"conftarget" description:"Targeted number of blocks within which the channel should be confirmed; used to set a transaction fee target"`
+	OpenChanFeeRate lnwire.MilliSatoshi `long:"openchanfeerate" description:"The fee in millisatoshi we will target for channel commitment transactions. If set, this value supersedes that of 'conftarget'."`
 }
 
 type torConfig struct {

--- a/pilot.go
+++ b/pilot.go
@@ -107,8 +107,8 @@ func (c *chanController) OpenChannel(target *btcec.PublicKey,
 		return err
 	}
 
-	// TODO(halseth): make configurable?
-	minHtlc := lnwire.NewMSatFromSatoshis(1)
+	// Use chainConfig.MinHTLC for autopilot-opened channels
+	minHtlc := cfg.Bitcoin.MinHTLC
 
 	updateStream, errChan := c.server.OpenChannel(target, amt, 0,
 		minHtlc, feePerVSize, false, 0)

--- a/pilot.go
+++ b/pilot.go
@@ -85,7 +85,14 @@ func (c *chanController) OpenChannel(target *btcec.PublicKey,
 
 	// With the connection established, we'll now establish our connection
 	// to the target peer, waiting for the first update before we exit.
-	feePerVSize, err := c.server.cc.feeEstimator.EstimateFeePerVSize(3)
+	// We target 3 blocks or less in which to establish the connection,
+	// unless the user specified `cfg.Autopilot.ConfTarget`.
+	confTarget := cfg.Autopilot.ConfTarget
+	if confTarget == 0 { // The zero values for integer and floats is 0. nil is not a valid integer or float value.
+		confTarget = 3
+	}
+
+	feePerVSize, err := c.server.cc.feeEstimator.EstimateFeePerVSize(confTarget)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## Description

This PR adds two configuration options for `Autopilot`:
1. `Autopilot.OpenChanFeeRate` typed as `SatoshiPerVByte`
1. `Autopilot.ConfTarget` typed as `uint32`

Both concern the fees that the autopilot will include in the open channel mainchain transactions. The former is an explicit satoshis per byte integer target, and the latter is a "attempt to confirm this transaction in `n` blocks or fewer".

## Documentation

[Here](https://github.com/lightningnetwork/lnd/issues/886) is the related issue.

## TODOs

* [x] add 'satoshis per byte' fee target option as well (currently I've only done 'confirm in `n` blocks please autopilot')
* [ ] add tests?
* [ ] document the new config option(s)