### PR TITLE
bump ltc payment limit

### DIFF
--- a/config.go
+++ b/config.go
@@ -175,6 +175,7 @@ type config struct {
 	UnsafeDisconnect   bool `long:"unsafe-disconnect" description:"Allows the rpcserver to intentionally disconnect from peers with open channels. USED FOR TESTING ONLY."`
 	UnsafeReplay       bool `long:"unsafe-replay" description:"Causes a link to replay the adds on its commitment txn after starting up, this enables testing of the sphinx replay logic."`
 	MaxPendingChannels int  `long:"maxpendingchannels" description:"The maximum number of incoming pending channels permitted per peer."`
+	LargerPayment      bool `long:"largerpayment" description:"Support local feature LargerPayment which has a higher channel capacity and payment limit."`
 
 	Bitcoin      *chainConfig    `group:"Bitcoin" namespace:"bitcoin"`
 	BtcdMode     *btcdConfig     `group:"btcd" namespace:"btcd"`

--- a/lnwire/features.go
+++ b/lnwire/features.go
@@ -21,6 +21,11 @@ const (
 	// connection is established.
 	InitialRoutingSync FeatureBit = 3
 
+	// Largerpayment is a local feature bit meaning that the local node
+	// support opening a channel with funding_satoshis larger than defined
+	// in BOLT-02
+	LargerPayment FeatureBit = 7
+
 	// maxAllowedSize is a maximum allowed size of feature vector.
 	//
 	// NOTE: Within the protocol, the maximum allowed message size is 65535
@@ -43,6 +48,7 @@ const (
 // bits is provided in the BOLT-09 specification.
 var LocalFeatures = map[FeatureBit]string{
 	InitialRoutingSync: "initial-routing-sync",
+	LargerPayment: "larger-payment",
 }
 
 // GlobalFeatures is a mapping of known global feature bits to a descriptive

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -299,7 +299,7 @@ var (
 	}
 )
 
-const (
+var (
 	// maxPaymentMSat is the maximum allowed payment permitted currently as
 	// defined in BOLT-0002.
 	maxPaymentMSat = lnwire.MilliSatoshi(math.MaxUint32)
@@ -332,6 +332,10 @@ func newRPCServer(s *server) *rpcServer {
 
 // Start launches any helper goroutines required for the rpcServer to function.
 func (r *rpcServer) Start() error {
+	if registeredChains.PrimaryChain() == litecoinChain {
+		maxPaymentMSat = maxPaymentMSat * 60
+	}
+
 	if atomic.AddInt32(&r.started, 1) != 1 {
 		return nil
 	}

--- a/server.go
+++ b/server.go
@@ -1383,6 +1383,11 @@ func (s *server) peerConnected(conn net.Conn, connReq *connmgr.ConnReq,
 	// feature vector to advertise to the remote node.
 	localFeatures := lnwire.NewRawFeatureVector()
 
+	// Signal that we support larger payment if the feautre is enabled.
+	if cfg.LargerPayment {
+		localFeatures.Set(lnwire.LargerPayment)
+	}
+
 	// We'll only request a full channel graph sync if we detect that that
 	// we aren't fully synced yet.
 	if s.shouldRequestGraphSync() {


### PR DESCRIPTION
increase litecoin payment limit to (0.04 * 60) as BTC is about 60 times more expensive than LTC
fixes #980 