### PR TITLE
server: fix inbound/outbound peer connection logic

### DIFF
--- a/rpcserver.go
+++ b/rpcserver.go
@@ -1292,7 +1292,7 @@ func (r *rpcServer) ListPeers(ctx context.Context,
 		peer := &lnrpc.Peer{
 			PubKey:    hex.EncodeToString(nodePub),
 			Address:   serverPeer.conn.RemoteAddr().String(),
-			Inbound:   !serverPeer.inbound, // Flip for display
+			Inbound:   serverPeer.inbound,
 			BytesRecv: atomic.LoadUint64(&serverPeer.bytesReceived),
 			BytesSent: atomic.LoadUint64(&serverPeer.bytesSent),
 			SatSent:   satSent,

--- a/server.go
+++ b/server.go
@@ -1537,7 +1537,8 @@ func (s *server) shouldRequestGraphSync() bool {
 
 // peerConnected is a function that handles initialization a newly connected
 // peer by adding it to the server's global list of all active peers, and
-// starting all the goroutines the peer needs to function properly.
+// starting all the goroutines the peer needs to function properly. The inbound
+// boolean should be true if the peer initiated the connection to us.
 func (s *server) peerConnected(conn net.Conn, connReq *connmgr.ConnReq,
 	inbound bool) {
 
@@ -1549,7 +1550,7 @@ func (s *server) peerConnected(conn net.Conn, connReq *connmgr.ConnReq,
 	// peer's address for reconnection purposes.
 	//
 	// TODO: leave the address field empty if there aren't any?
-	if !inbound {
+	if inbound {
 		advertisedAddr, err := s.fetchNodeAdvertisedAddr(pubKey)
 		if err != nil {
 			srvrLog.Errorf("Unable to retrieve advertised address "+
@@ -1672,7 +1673,7 @@ func (s *server) InboundPeerConnected(conn net.Conn) {
 	case ErrPeerNotConnected:
 		// We were unable to locate an existing connection with the
 		// target peer, proceed to connect.
-		s.peerConnected(conn, nil, false)
+		s.peerConnected(conn, nil, true)
 
 	case nil:
 		// We already have a connection with the incoming peer. If the
@@ -1699,7 +1700,7 @@ func (s *server) InboundPeerConnected(conn net.Conn) {
 		s.removePeer(connectedPeer)
 		s.ignorePeerTermination[connectedPeer] = struct{}{}
 		s.scheduledPeerConnection[pubStr] = func() {
-			s.peerConnected(conn, nil, false)
+			s.peerConnected(conn, nil, true)
 		}
 	}
 }
@@ -1769,7 +1770,7 @@ func (s *server) OutboundPeerConnected(connReq *connmgr.ConnReq, conn net.Conn) 
 	case ErrPeerNotConnected:
 		// We were unable to locate an existing connection with the
 		// target peer, proceed to connect.
-		s.peerConnected(conn, connReq, true)
+		s.peerConnected(conn, connReq, false)
 
 	case nil:
 		// We already have a connection open with the target peer.
@@ -1800,7 +1801,7 @@ func (s *server) OutboundPeerConnected(connReq *connmgr.ConnReq, conn net.Conn) 
 		s.removePeer(connectedPeer)
 		s.ignorePeerTermination[connectedPeer] = struct{}{}
 		s.scheduledPeerConnection[pubStr] = func() {
-			s.peerConnected(conn, connReq, true)
+			s.peerConnected(conn, connReq, false)
 		}
 	}
 }


### PR DESCRIPTION
This PR attempts to fix a small bug where inbound peers were being tracked as outbound and outbound as inbound.

I went through the rest of the connection logic and our uses of inbound/outbound connections seem to be consistent with their respective meanings. Inbound connections should be connections initiated by the remote peer, while outbound connections should be initiated locally.

I believe the small patch below should be enough to remedy this issue, although I might have missed something.

Fixes #997.