### PR TITLE
Correcting install docs to add path for upgrade instructions section

### DIFF
--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -66,6 +66,7 @@ make && make install
 To update your version of `lnd` to the latest version run the following
 commands:
 ```
+cd $GOPATH/src/github.com/lightningnetwork/lnd
 git pull
 make && make install
 ```


### PR DESCRIPTION
Attempt # 2 with no git history

Install docs needed path
```
cd $GOPATH/src/github.com/lightningnetwork/lnd
```
before `git pull` instructions