### PR TITLE
htlcswitch: properly apply the fee constraints of the *outgoing* link when accepting HTLC's

### DIFF
--- a/discovery/gossiper.go
+++ b/discovery/gossiper.go
@@ -1147,6 +1147,12 @@ func (d *AuthenticatedGossiper) processChanPolicyUpdate(
 	}
 
 	haveChanFilter := len(chansToUpdate) != 0
+	if haveChanFilter {
+		log.Infof("Updating routing policies for chan_points=%v",
+			spew.Sdump(chansToUpdate))
+	} else {
+		log.Infof("Updating routing policies for all chans")
+	}
 
 	type edgeWithInfo struct {
 		info *channeldb.ChannelEdgeInfo
@@ -2145,8 +2151,8 @@ func (d *AuthenticatedGossiper) updateChannel(info *channeldb.ChannelEdgeInfo,
 
 	var err error
 
-	// Make sure timestamp is always increased, such that our update
-	// gets propagated.
+	// Make sure timestamp is always increased, such that our update gets
+	// propagated.
 	timestamp := time.Now().Unix()
 	if timestamp <= edge.LastUpdate.Unix() {
 		timestamp = edge.LastUpdate.Unix() + 1

--- a/discovery/gossiper.go
+++ b/discovery/gossiper.go
@@ -1097,8 +1097,9 @@ func (d *AuthenticatedGossiper) retransmitStaleChannels() error {
 	for _, chanToUpdate := range edgesToUpdate {
 		// Re-sign and update the channel on disk and retrieve our
 		// ChannelUpdate to broadcast.
-		chanAnn, chanUpdate, err := d.updateChannel(chanToUpdate.info,
-			chanToUpdate.edge)
+		chanAnn, chanUpdate, err := d.updateChannel(
+			chanToUpdate.info, chanToUpdate.edge,
+		)
 		if err != nil {
 			return fmt.Errorf("unable to update channel: %v", err)
 		}
@@ -1131,8 +1132,8 @@ func (d *AuthenticatedGossiper) retransmitStaleChannels() error {
 
 // processChanPolicyUpdate generates a new set of channel updates with the new
 // channel policy applied for each specified channel identified by its channel
-// point. In the case that no channel points are specified, then the update will
-// be applied to all channels. Finally, the backing ChannelGraphSource is
+// point. In the case that no channel points are specified, then the update
+// will be applied to all channels. Finally, the backing ChannelGraphSource is
 // updated with the latest information reflecting the applied updates.
 //
 // TODO(roasbeef): generalize into generic for any channel update
@@ -1147,12 +1148,17 @@ func (d *AuthenticatedGossiper) processChanPolicyUpdate(
 
 	haveChanFilter := len(chansToUpdate) != 0
 
-	var chanUpdates []networkMsg
+	type edgeWithInfo struct {
+		info *channeldb.ChannelEdgeInfo
+		edge *channeldb.ChannelEdgePolicy
+	}
+	var edgesToUpdate []edgeWithInfo
 
 	// Next, we'll loop over all the outgoing channels the router knows of.
 	// If we have a filter then we'll only collected those channels,
 	// otherwise we'll collect them all.
-	err := d.cfg.Router.ForAllOutgoingChannels(func(info *channeldb.ChannelEdgeInfo,
+	err := d.cfg.Router.ForAllOutgoingChannels(func(
+		info *channeldb.ChannelEdgeInfo,
 		edge *channeldb.ChannelEdgePolicy) error {
 
 		// If we have a channel filter, and this channel isn't a part
@@ -1161,20 +1167,37 @@ func (d *AuthenticatedGossiper) processChanPolicyUpdate(
 			return nil
 		}
 
-		// Apply the new fee schema to the edge.
+		// Now that we know we should update this channel, we'll update
+		// its set of policies.
 		edge.FeeBaseMSat = policyUpdate.newSchema.BaseFee
 		edge.FeeProportionalMillionths = lnwire.MilliSatoshi(
 			policyUpdate.newSchema.FeeRate,
 		)
-
-		// Apply the new TimeLockDelta.
 		edge.TimeLockDelta = uint16(policyUpdate.newSchema.TimeLockDelta)
 
-		// Re-sign and update the backing ChannelGraphSource, and
+		edgesToUpdate = append(edgesToUpdate, edgeWithInfo{
+			info: info,
+			edge: edge,
+		})
+
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	// With the set of edges we need to update retrieved, we'll now re-sign
+	// them, and insert them into the database.
+	var chanUpdates []networkMsg
+	for _, edgeInfo := range edgesToUpdate {
+		// Now that we've collected all the channels we need to update,
+		// we'll Re-sign and update the backing ChannelGraphSource, and
 		// retrieve our ChannelUpdate to broadcast.
-		_, chanUpdate, err := d.updateChannel(info, edge)
+		_, chanUpdate, err := d.updateChannel(
+			edgeInfo.info, edgeInfo.edge,
+		)
 		if err != nil {
-			return err
+			return nil, err
 		}
 
 		// We set ourselves as the source of this message to indicate
@@ -1183,11 +1206,6 @@ func (d *AuthenticatedGossiper) processChanPolicyUpdate(
 			peer: d.selfKey,
 			msg:  chanUpdate,
 		})
-
-		return nil
-	})
-	if err != nil {
-		return nil, err
 	}
 
 	return chanUpdates, nil

--- a/htlcswitch/interfaces.go
+++ b/htlcswitch/interfaces.go
@@ -76,6 +76,14 @@ type ChannelLink interface {
 	// policy to govern if it an incoming HTLC should be forwarded or not.
 	UpdateForwardingPolicy(ForwardingPolicy)
 
+	// HtlcSatifiesPolicy should return a nil error if the passed HTLC
+	// details satisfy the current forwarding policy fo the target link.
+	// Otherwise, a valid protocol failure message should be returned in
+	// order to signal to the source of the HTLC, the policy consistency
+	// issue.
+	HtlcSatifiesPolicy(payHash [32]byte,
+		incomingAmt, amtToForward lnwire.MilliSatoshi) lnwire.FailureMessage
+
 	// Bandwidth returns the amount of milli-satoshis which current link
 	// might pass through channel link. The value returned from this method
 	// represents the up to date available flow through the channel. This

--- a/htlcswitch/link_test.go
+++ b/htlcswitch/link_test.go
@@ -1476,8 +1476,8 @@ func newSingleLinkTestHarness(chanAmt, chanReserve btcutil.Amount) (
 			ErrorEncrypter, lnwire.FailCode) {
 			return obfuscator, lnwire.CodeNone
 		},
-		GetLastChannelUpdate: mockGetChanUpdateMessage,
-		PreimageCache:        pCache,
+		FetchLastChannelUpdate: mockGetChanUpdateMessage,
+		PreimageCache:          pCache,
 		UpdateContractSignals: func(*contractcourt.ContractSignals) error {
 			return nil
 		},

--- a/htlcswitch/link_test.go
+++ b/htlcswitch/link_test.go
@@ -826,7 +826,7 @@ func TestUpdateForwardingPolicy(t *testing.T) {
 	// update logic
 	newPolicy := n.globalPolicy
 	newPolicy.BaseFee = lnwire.NewMSatFromSatoshis(1000)
-	n.firstBobChannelLink.UpdateForwardingPolicy(newPolicy)
+	n.secondBobChannelLink.UpdateForwardingPolicy(newPolicy)
 
 	// Next, we'll send the payment again, using the exact same per-hop
 	// payload for each node. This payment should fail as it won't factor

--- a/htlcswitch/mock.go
+++ b/htlcswitch/mock.go
@@ -604,6 +604,10 @@ func (f *mockChannelLink) HandleChannelUpdate(lnwire.Message) {
 
 func (f *mockChannelLink) UpdateForwardingPolicy(_ ForwardingPolicy) {
 }
+func (f *mockChannelLink) HtlcSatifiesPolicy([32]byte, lnwire.MilliSatoshi,
+	lnwire.MilliSatoshi) lnwire.FailureMessage {
+	return nil
+}
 
 func (f *mockChannelLink) Stats() (uint64, lnwire.MilliSatoshi, lnwire.MilliSatoshi) {
 	return 0, 0, 0

--- a/htlcswitch/switch.go
+++ b/htlcswitch/switch.go
@@ -393,9 +393,9 @@ func (s *Switch) UpdateForwardingPolicies(newPolicy ForwardingPolicy,
 		return spew.Sdump(newPolicy)
 	}))
 
-	s.indexMtx.RLock()
-
 	var linksToUpdate []ChannelLink
+
+	s.indexMtx.RLock()
 
 	// If no channels have been targeted, then we'll collect all inks to
 	// update their policies.

--- a/lnwire/short_channel_id.go
+++ b/lnwire/short_channel_id.go
@@ -36,7 +36,7 @@ func NewShortChanIDFromInt(chanID uint64) ShortChannelID {
 
 // ToUint64 converts the ShortChannelID into a compact format encoded within a
 // uint64 (8 bytes).
-func (c *ShortChannelID) ToUint64() uint64 {
+func (c ShortChannelID) ToUint64() uint64 {
 	// TODO(roasbeef): explicit error on overflow?
 	return ((uint64(c.BlockHeight) << 40) | (uint64(c.TxIndex) << 16) |
 		(uint64(c.TxPosition)))

--- a/routing/router.go
+++ b/routing/router.go
@@ -1724,12 +1724,12 @@ func (r *ChannelRouter) SendPayment(payment *LightningPayment) ([32]byte, *Route
 				// We'll now check to see if we've already
 				// reported a fee related failure for this
 				// node. If so, then we'll actually prune out
-				// the edge for now.
+				// the vertex for now.
 				chanID := update.ShortChannelID
 				_, ok := errFailedFeeChans[chanID]
 				if ok {
-					pruneEdgeFailure(
-						paySession, route, errSource,
+					pruneVertexFailure(
+						paySession, route, errSource, false,
 					)
 					continue
 				}

--- a/routing/router_test.go
+++ b/routing/router_test.go
@@ -297,7 +297,7 @@ func TestSendPaymentErrorRepeatedFeeInsufficient(t *testing.T) {
 	// to luo ji for 100 satoshis.
 	var payHash [32]byte
 	payment := LightningPayment{
-		Target:      ctx.aliases["luoji"],
+		Target:      ctx.aliases["sophon"],
 		Amount:      lnwire.NewMSatFromSatoshis(1000),
 		PaymentHash: payHash,
 	}
@@ -306,9 +306,9 @@ func TestSendPaymentErrorRepeatedFeeInsufficient(t *testing.T) {
 	copy(preImage[:], bytes.Repeat([]byte{9}, 32))
 
 	// We'll also fetch the first outgoing channel edge from roasbeef to
-	// luo ji. We'll obtain this as we'll need to to generate the
+	// son goku. We'll obtain this as we'll need to to generate the
 	// FeeInsufficient error that we'll send back.
-	chanID := uint64(689530843)
+	chanID := uint64(3495345)
 	_, _, edgeUpateToFail, err := ctx.graph.FetchChannelEdgesByID(chanID)
 	if err != nil {
 		t.Fatalf("unable to fetch chan id: %v", err)
@@ -324,24 +324,21 @@ func TestSendPaymentErrorRepeatedFeeInsufficient(t *testing.T) {
 		FeeRate:         uint32(edgeUpateToFail.FeeProportionalMillionths),
 	}
 
-	sourceNode := ctx.router.selfNode
+	// The error will be returned by Son Goku.
+	sourceNode := ctx.aliases["songoku"]
 
 	// We'll now modify the SendToSwitch method to return an error for the
-	// outgoing channel to luo ji. This will be a fee related error, so it
-	// should only cause the edge to be pruned after the second attempt.
+	// outgoing channel to Son goku. This will be a fee related error, so
+	// it should only cause the edge to be pruned after the second attempt.
 	ctx.router.cfg.SendToSwitch = func(n [33]byte,
 		_ *lnwire.UpdateAddHTLC, _ *sphinx.Circuit) ([32]byte, error) {
 
-		if bytes.Equal(ctx.aliases["luoji"].SerializeCompressed(), n[:]) {
-			pub, err := sourceNode.PubKey()
-			if err != nil {
-				return preImage, err
-			}
+		if bytes.Equal(sourceNode.SerializeCompressed(), n[:]) {
 			return [32]byte{}, &htlcswitch.ForwardingError{
-				ErrorSource: pub,
+				ErrorSource: sourceNode,
 
 				// Within our error, we'll add a channel update
-				// which is meant to refelct he new fee
+				// which is meant to reflect he new fee
 				// schedule for the node/channel.
 				FailureMessage: &lnwire.FailFeeInsufficient{
 					Update: errChanUpdate,
@@ -371,8 +368,8 @@ func TestSendPaymentErrorRepeatedFeeInsufficient(t *testing.T) {
 			preImage[:], paymentPreImage[:])
 	}
 
-	// The route should have satoshi as the first hop.
-	if route.Hops[0].Channel.Node.Alias != "satoshi" {
+	// The route should have pham nuwen as the first hop.
+	if route.Hops[0].Channel.Node.Alias != "phamnuwen" {
 		t.Fatalf("route should go through satoshi as first hop, "+
 			"instead passes through: %v",
 			route.Hops[0].Channel.Node.Alias)

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -3331,7 +3331,7 @@ func (r *rpcServer) UpdateChannelPolicy(ctx context.Context,
 		TimeLockDelta: req.TimeLockDelta,
 	}
 
-	rpcsLog.Tracef("[updatechanpolicy] updating channel policy base_fee=%v, "+
+	rpcsLog.Debugf("[updatechanpolicy] updating channel policy base_fee=%v, "+
 		"rate_float=%v, rate_fixed=%v, time_lock_delta: %v, targets=%v",
 		req.BaseFeeMsat, req.FeeRate, feeRateFixed, req.TimeLockDelta,
 		spew.Sdump(targetChans))


### PR DESCRIPTION
In this commit, we fix an existing bug in the forwarding logic in the link. Before this commit, we would actually apply the fee policies of the _incoming_ link when accepting new HTLC's. This was incorrect as we should actually be applying the fees of the _outgoing_ link, as we'll be using that link's payment bandwidth to support the HTLC. This bug cause a ton of issues when routing on mainnet, as we would reject an HTLC for violating the policy of the incoming link, then send the policy of the incoming link. The router would them prune the _outgoing_ link, as that is the proper policy that _should_ have been applied. This process would then at times repeat tens of times, until we gave up with a timeout error. 

To fix this issue, we've added a series of new methods to the link and switch to allow the incoming link to validate an HTLC against the fee policy of the outgoing link. Along the way, we've simplified some logic (`linkControl`) within the link and the switch. 

Finally, we also fix an existing deadlock bug in the gossiper that would manifest due to attempting to create a `bolt` write transaction, while we already have an active read transaction open. 

Fixes #922. 