### PR TITLE
(g)make calls dep which is not in $PATH

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -106,7 +106,7 @@ $(LINT_BIN):
 
 dep: $(DEP_BIN)
 	@$(call print, "Compiling dependencies.")
-	dep ensure -v
+	${DEP_BIN} ensure -v
 
 $(BTCD_DIR):
 	@$(call print, "Fetching btcd.")


### PR DESCRIPTION
$ gmake
Fetching dep.
go get -u github.com/golang/dep/cmd/dep
Compiling dependencies.
dep ensure -v
gmake: dep: Command not found
gmake: *** [Makefile:109: dep] Error 127

Changed dep to ${DEP_BIN} to fix this