### PR TITLE
fundingmanager: fixes range-goroutine scoping bug

### DIFF
--- a/fundingmanager.go
+++ b/fundingmanager.go
@@ -640,7 +640,7 @@ func (f *fundingManager) Start() error {
 			go func(dbChan *channeldb.OpenChannel) {
 				defer f.wg.Done()
 
-				err = f.annAfterSixConfs(channel, shortChanID)
+				err = f.annAfterSixConfs(dbChan, shortChanID)
 				if err != nil {
 					fndgLog.Errorf("error sending channel "+
 						"announcement: %v", err)


### PR DESCRIPTION
This commit fixes an issue in funding manager startup,
where a goroutine reads from a range value. The method in
question could cause a channel to be announced at the
wrong time.

This may have been a cause for certain channels having
phantom HTLCs before they had even received the funding
locked message from the remote peer.

This is fixed simply by using the locally scoped
variable passed in as an argument to the goroutine.