### PR TITLE
payments+switch: add sender-side check to not pay same preimage twice

### DIFF
--- a/channeldb/db.go
+++ b/channeldb/db.go
@@ -59,6 +59,12 @@ var (
 			number:    3,
 			migration: migrateInvoiceTimeSeriesOutgoingPayments,
 		},
+		{
+			// The version with added payment statuses
+			// for each existing payment
+			number:    4,
+			migration: paymentStatusesMigration,
+		},
 	}
 
 	// Big endian is the preferred byte order, due to cursor scans over

--- a/channeldb/db_test.go
+++ b/channeldb/db_test.go
@@ -5,6 +5,8 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/go-errors/errors"
 )
 
 func TestOpenWithCreate(t *testing.T) {
@@ -32,4 +34,57 @@ func TestOpenWithCreate(t *testing.T) {
 	if !fileExists(dbPath) {
 		t.Fatalf("channeldb failed to create data directory")
 	}
+}
+
+// applyMigration is a helper test function that encapsulates the general steps
+// which are needed to properly check the result of applying migration function.
+func applyMigration(t *testing.T, beforeMigration, afterMigration func(d *DB),
+	migrationFunc migration, shouldFail bool) {
+
+	cdb, cleanUp, err := makeTestDB()
+	defer cleanUp()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// beforeMigration usually used for populating the database
+	// with test data.
+	beforeMigration(cdb)
+
+	// Create test meta info with zero database version and put it on disk.
+	// Than creating the version list pretending that new version was added.
+	meta := &Meta{DbVersionNumber: 0}
+	if err := cdb.PutMeta(meta); err != nil {
+		t.Fatalf("unable to store meta data: %v", err)
+	}
+
+	versions := []version{
+		{
+			number:    0,
+			migration: nil,
+		},
+		{
+			number:    1,
+			migration: migrationFunc,
+		},
+	}
+
+	defer func() {
+		if r := recover(); r != nil {
+			err = errors.New(r)
+		}
+
+		if err == nil && shouldFail {
+			t.Fatal("error wasn't received on migration stage")
+		} else if err != nil && !shouldFail {
+			t.Fatal("error was received on migration stage")
+		}
+
+		// afterMigration usually used for checking the database state and
+		// throwing the error if something went wrong.
+		afterMigration(cdb)
+	}()
+
+	// Sync with the latest version - applying migration function.
+	err = cdb.syncVersions(versions)
 }

--- a/channeldb/meta_test.go
+++ b/channeldb/meta_test.go
@@ -117,59 +117,6 @@ func TestGlobalVersionList(t *testing.T) {
 	}
 }
 
-// applyMigration is a helper test function that encapsulates the general steps
-// which are needed to properly check the result of applying migration function.
-func applyMigration(t *testing.T, beforeMigration, afterMigration func(d *DB),
-	migrationFunc migration, shouldFail bool) {
-
-	cdb, cleanUp, err := makeTestDB()
-	defer cleanUp()
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	// beforeMigration usually used for populating the database
-	// with test data.
-	beforeMigration(cdb)
-
-	// Create test meta info with zero database version and put it on disk.
-	// Than creating the version list pretending that new version was added.
-	meta := &Meta{DbVersionNumber: 0}
-	if err := cdb.PutMeta(meta); err != nil {
-		t.Fatalf("unable to store meta data: %v", err)
-	}
-
-	versions := []version{
-		{
-			number:    0,
-			migration: nil,
-		},
-		{
-			number:    1,
-			migration: migrationFunc,
-		},
-	}
-
-	defer func() {
-		if r := recover(); r != nil {
-			err = errors.New(r)
-		}
-
-		if err == nil && shouldFail {
-			t.Fatal("error wasn't received on migration stage")
-		} else if err != nil && !shouldFail {
-			t.Fatal("error was received on migration stage")
-		}
-
-		// afterMigration usually used for checking the database state and
-		// throwing the error if something went wrong.
-		afterMigration(cdb)
-	}()
-
-	// Sync with the latest version - applying migration function.
-	err = cdb.syncVersions(versions)
-}
-
 func TestMigrationWithPanic(t *testing.T) {
 	t.Parallel()
 

--- a/channeldb/migrations.go
+++ b/channeldb/migrations.go
@@ -2,6 +2,7 @@ package channeldb
 
 import (
 	"bytes"
+	"crypto/sha256"
 	"fmt"
 
 	"github.com/coreos/bbolt"
@@ -299,4 +300,47 @@ func migrateInvoiceTimeSeriesOutgoingPayments(tx *bolt.Tx) error {
 	log.Infof("Migration to outgoing payment invoices complete!")
 
 	return nil
+}
+
+// paymentStatusesMigration is a database migration intended for adding payment
+// statuses for each existing payment entity in bucket to be able control
+// transitions of statuses and prevent cases such as double payment
+func paymentStatusesMigration(tx *bolt.Tx) error {
+	// Get the bucket dedicated to storing payments
+	bucket := tx.Bucket(paymentBucket)
+	if bucket == nil {
+		return nil
+	}
+
+	// Get the bucket dedicated to storing statuses of payments,
+	// where a key is payment hash, value is payment status
+	paymentStatuses, err := tx.CreateBucketIfNotExists(paymentStatusBucket)
+	if err != nil {
+		return err
+	}
+
+	log.Infof("Migration database adds to all existing payments " +
+		"statuses as Completed")
+
+	// For each payment in the bucket, fetch all data.
+	return bucket.ForEach(func(k, v []byte) error {
+		// Ignores if it is sub-bucket.
+		if v == nil {
+			return nil
+		}
+
+		r := bytes.NewReader(v)
+		payment, err := deserializeOutgoingPayment(r)
+		if err != nil {
+			return err
+		}
+
+		// Calculate payment hash for current payment.
+		paymentHash := sha256.Sum256(payment.PaymentPreimage[:])
+
+		// Tries to update status for current payment to completed
+		// if it fails - migration abort transaction and return payment bucket
+		// to previous state.
+		return paymentStatuses.Put(paymentHash[:], StatusCompleted.Bytes())
+	})
 }

--- a/channeldb/migrations_test.go
+++ b/channeldb/migrations_test.go
@@ -1,0 +1,71 @@
+package channeldb
+
+import (
+	"crypto/sha256"
+	"testing"
+)
+
+func TestPaymentStatusesMigration(t *testing.T) {
+	t.Parallel()
+
+	fakePayment := makeFakePayment()
+	paymentHash := sha256.Sum256(fakePayment.PaymentPreimage[:])
+
+	// Add fake payment to the test database and verifies that it was created
+	// and there is only one payment and its status is not "Completed".
+	beforeMigrationFunc := func(d *DB) {
+		if err := d.AddPayment(fakePayment); err != nil {
+			t.Fatalf("unable to add payment: %v", err)
+		}
+
+		payments, err := d.FetchAllPayments()
+		if err != nil {
+			t.Fatalf("unable to fetch payments: %v", err)
+		}
+
+		if len(payments) != 1 {
+			t.Fatalf("wrong qty of paymets: expected 1, got %v",
+				len(payments))
+		}
+
+		paymentStatus, err := d.FetchPaymentStatus(paymentHash)
+		if err != nil {
+			t.Fatalf("unable to fetch payment status: %v", err)
+		}
+
+		// We should receive default status if we have any in database.
+		if paymentStatus != StatusGrounded {
+			t.Fatalf("wrong payment status: expected %v, got %v",
+				StatusGrounded.String(), paymentStatus.String())
+		}
+	}
+
+	// Verify that was created payment status "Completed" for our one fake
+	// payment.
+	afterMigrationFunc := func(d *DB) {
+		meta, err := d.FetchMeta(nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if meta.DbVersionNumber != 1 {
+			t.Fatal("migration 'paymentStatusesMigration' wasn't applied")
+		}
+
+		paymentStatus, err := d.FetchPaymentStatus(paymentHash)
+		if err != nil {
+			t.Fatalf("unable to fetch payment status: %v", err)
+		}
+
+		if paymentStatus != StatusCompleted {
+			t.Fatalf("wrong payment status: expected %v, got %v",
+				StatusCompleted.String(), paymentStatus.String())
+		}
+	}
+
+	applyMigration(t,
+		beforeMigrationFunc,
+		afterMigrationFunc,
+		paymentStatusesMigration,
+		false)
+}

--- a/channeldb/payments.go
+++ b/channeldb/payments.go
@@ -3,6 +3,7 @@ package channeldb
 import (
 	"bytes"
 	"encoding/binary"
+	"errors"
 	"io"
 
 	"github.com/coreos/bbolt"
@@ -17,7 +18,63 @@ var (
 	// which is a monotonically increasing uint64.  BoltDB's sequence
 	// feature is used for generating monotonically increasing id.
 	paymentBucket = []byte("payments")
+
+	// paymentStatusBucket is the name of the bucket within the database that
+	// stores the status of a payment indexed by the payment's preimage.
+	paymentStatusBucket = []byte("payment-status")
 )
+
+// PaymentStatus represent current status of payment
+type PaymentStatus byte
+
+const (
+	// StatusGrounded is status where payment is initiated and received
+	// an intermittent failure
+	StatusGrounded PaymentStatus = 0
+
+	// StatusInFlight is status where payment is initiated, but a response
+	// has not been received
+	StatusInFlight PaymentStatus = 1
+
+	// StatusCompleted is status where payment is initiated and complete
+	// a payment successfully
+	StatusCompleted PaymentStatus = 2
+)
+
+// Bytes returns status as slice of bytes
+func (ps PaymentStatus) Bytes() []byte {
+	return []byte{byte(ps)}
+}
+
+// FromBytes sets status from slice of bytes
+func (ps *PaymentStatus) FromBytes(status []byte) error {
+	if len(status) != 1 {
+		return errors.New("payment status is empty")
+	}
+
+	switch PaymentStatus(status[0]) {
+	case StatusGrounded, StatusInFlight, StatusCompleted:
+		*ps = PaymentStatus(status[0])
+	default:
+		return errors.New("unknown payment status")
+	}
+
+	return nil
+}
+
+// String returns readable representation of payment status
+func (ps PaymentStatus) String() string {
+	switch ps {
+	case StatusGrounded:
+		return "Grounded"
+	case StatusInFlight:
+		return "In Flight"
+	case StatusCompleted:
+		return "Completed"
+	default:
+		return "Unknown"
+	}
+}
 
 // OutgoingPayment represents a successful payment between the daemon and a
 // remote node. Details such as the total fee paid, and the time of the payment
@@ -127,6 +184,45 @@ func (db *DB) DeleteAllPayments() error {
 		_, err = tx.CreateBucket(paymentBucket)
 		return err
 	})
+}
+
+// UpdatePaymentStatus sets status for outgoing/finished payment to store status in
+// local database.
+func (db *DB) UpdatePaymentStatus(paymentHash [32]byte, status PaymentStatus) error {
+	return db.Batch(func(tx *bolt.Tx) error {
+		paymentStatuses, err := tx.CreateBucketIfNotExists(paymentStatusBucket)
+		if err != nil {
+			return err
+		}
+
+		return paymentStatuses.Put(paymentHash[:], status.Bytes())
+	})
+}
+
+// FetchPaymentStatus returns payment status for outgoing payment
+// if status of the payment isn't found it set to default status "StatusGrounded".
+func (db *DB) FetchPaymentStatus(paymentHash [32]byte) (PaymentStatus, error) {
+	// default status for all payments that wasn't recorded in database
+	paymentStatus := StatusGrounded
+
+	err := db.View(func(tx *bolt.Tx) error {
+		bucket := tx.Bucket(paymentStatusBucket)
+		if bucket == nil {
+			return nil
+		}
+
+		paymentStatusBytes := bucket.Get(paymentHash[:])
+		if paymentStatusBytes == nil {
+			return nil
+		}
+
+		return paymentStatus.FromBytes(paymentStatusBytes)
+	})
+	if err != nil {
+		return StatusGrounded, err
+	}
+
+	return paymentStatus, nil
 }
 
 func serializeOutgoingPayment(w io.Writer, p *OutgoingPayment) error {

--- a/htlcswitch/link_test.go
+++ b/htlcswitch/link_test.go
@@ -3569,8 +3569,8 @@ func TestChannelLinkAcceptDuplicatePayment(t *testing.T) {
 	// as it's a duplicate request.
 	_, err = n.aliceServer.htlcSwitch.SendHTLC(n.bobServer.PubKey(), htlc,
 		newMockDeobfuscator())
-	if err != nil {
-		t.Fatalf("error shouldn't have been received got: %v", err)
+	if err != ErrAlreadyPaid {
+		t.Fatalf("ErrAlreadyPaid should have been received got: %v", err)
 	}
 }
 

--- a/htlcswitch/mock.go
+++ b/htlcswitch/mock.go
@@ -120,14 +120,26 @@ type mockServer struct {
 
 var _ lnpeer.Peer = (*mockServer)(nil)
 
-func initSwitchWithDB(startingHeight uint32, db *channeldb.DB) (*Switch, error) {
-	if db == nil {
-		tempPath, err := ioutil.TempDir("", "switchdb")
-		if err != nil {
-			return nil, err
-		}
+func initDB() (*channeldb.DB, error) {
+	tempPath, err := ioutil.TempDir("", "switchdb")
+	if err != nil {
+		return nil, err
+	}
 
-		db, err = channeldb.Open(tempPath)
+	db, err := channeldb.Open(tempPath)
+	if err != nil {
+		return nil, err
+	}
+
+	return db, err
+}
+
+
+func initSwitchWithDB(startingHeight uint32, db *channeldb.DB) (*Switch, error) {
+	var err error
+
+	if db == nil {
+		db, err = initDB()
 		if err != nil {
 			return nil, err
 		}

--- a/htlcswitch/switch.go
+++ b/htlcswitch/switch.go
@@ -9,12 +9,12 @@ import (
 	"time"
 
 	"github.com/btcsuite/btcd/btcec"
-	"github.com/coreos/bbolt"
-	"github.com/davecgh/go-spew/spew"
-
 	"github.com/btcsuite/btcd/wire"
 	"github.com/btcsuite/btcutil"
+	"github.com/coreos/bbolt"
+	"github.com/davecgh/go-spew/spew"
 	"github.com/go-errors/errors"
+
 	"github.com/lightningnetwork/lnd/chainntnfs"
 	"github.com/lightningnetwork/lnd/channeldb"
 	"github.com/lightningnetwork/lnd/contractcourt"
@@ -181,6 +181,9 @@ type Switch struct {
 
 	paymentSequencer Sequencer
 
+	// control provides verification of sending htlc mesages
+	control ControlTower
+
 	// circuits is storage for payment circuits which are used to
 	// forward the settle/fail htlc updates back to the add htlc initiator.
 	circuits CircuitMap
@@ -266,6 +269,7 @@ func New(cfg Config, currentHeight uint32) (*Switch, error) {
 		cfg:               &cfg,
 		circuits:          circuitMap,
 		paymentSequencer:  sequencer,
+		control:           NewPaymentControl(cfg.DB),
 		linkIndex:         make(map[lnwire.ChannelID]ChannelLink),
 		mailOrchestrator:  newMailOrchestrator(),
 		forwardingIndex:   make(map[lnwire.ShortChannelID]ChannelLink),
@@ -320,6 +324,11 @@ func (s *Switch) ProcessContractResolution(msg contractcourt.ResolutionMsg) erro
 func (s *Switch) SendHTLC(nextNode [33]byte, htlc *lnwire.UpdateAddHTLC,
 	deobfuscator ErrorDecrypter) ([sha256.Size]byte, error) {
 
+	// Verify message by ControlTower implementation.
+	if err := s.control.CheckSend(htlc); err != nil {
+		return zeroPreimage, err
+	}
+
 	// Create payment and add to the map of payment in order later to be
 	// able to retrieve it and return response to the user.
 	payment := &pendingPayment{
@@ -352,6 +361,10 @@ func (s *Switch) SendHTLC(nextNode [33]byte, htlc *lnwire.UpdateAddHTLC,
 
 	if err := s.forward(packet); err != nil {
 		s.removePendingPayment(paymentID)
+		if err := s.control.Fail(htlc.PaymentHash); err != nil {
+			return zeroPreimage, err
+		}
+
 		return zeroPreimage, err
 	}
 
@@ -821,6 +834,10 @@ func (s *Switch) handleLocalDispatch(pkt *htlcPacket) error {
 		payment.preimage <- htlc.PaymentPreimage
 		s.removePendingPayment(pkt.incomingHTLCID)
 
+		if err := s.control.Success(pkt.circuit.PaymentHash); err != nil {
+			return err
+		}
+
 	// We've just received a fail update which means we can finalize the
 	// user payment and return fail response.
 	case *lnwire.UpdateFailHTLC:
@@ -885,6 +902,10 @@ func (s *Switch) parseFailedPayment(payment *pendingPayment, pkt *htlcPacket,
 			FailureMessage: lnwire.FailPermanentChannelFailure{},
 		}
 
+		if err := s.control.Fail(pkt.circuit.PaymentHash); err != nil {
+			log.Error(err)
+		}
+
 	// A regular multi-hop payment error that we'll need to
 	// decrypt.
 	default:
@@ -900,6 +921,10 @@ func (s *Switch) parseFailedPayment(payment *pendingPayment, pkt *htlcPacket,
 				ErrorSource:    s.cfg.SelfKey,
 				ExtraMsg:       userErr,
 				FailureMessage: lnwire.NewTemporaryChannelFailure(nil),
+			}
+
+			if err := s.control.Fail(pkt.circuit.PaymentHash); err != nil {
+				log.Error(err)
 			}
 		}
 	}

--- a/htlcswitch/switch_control.go
+++ b/htlcswitch/switch_control.go
@@ -1,0 +1,142 @@
+package htlcswitch
+
+import (
+	"errors"
+	"sync"
+
+	"github.com/lightningnetwork/lnd/channeldb"
+	"github.com/lightningnetwork/lnd/lnwire"
+)
+
+var (
+	// ErrAlreadyPaid is used when we have already paid
+	ErrAlreadyPaid = errors.New("invoice was already paid")
+
+	// ErrPaymentInFlight returns in case if payment is already "in flight"
+	ErrPaymentInFlight = errors.New("payment is in transition")
+
+	// ErrPaymentNotInitiated returns in case if payment wasn't initiated
+	// in switch
+	ErrPaymentNotInitiated = errors.New("payment isn't initiated")
+
+	// ErrPaymentAlreadyCompleted returns in case of attempt to complete
+	// completed payment
+	ErrPaymentAlreadyCompleted = errors.New("payment is already completed")
+)
+
+// ControlTower is a controller interface of sending HTLC messages to switch
+type ControlTower interface {
+	// CheckSend intercepts incoming message to provide checks
+	// and fail if specific message is not allowed by implementation
+	CheckSend(htlc *lnwire.UpdateAddHTLC) error
+
+	// Success marks message transition as successful
+	Success(paymentHash [32]byte) error
+
+	// Fail marks message transition as failed
+	Fail(paymentHash [32]byte) error
+}
+
+// paymentControl is implementation of ControlTower to restrict double payment
+// sending.
+type paymentControl struct {
+	mx sync.Mutex
+
+	db *channeldb.DB
+}
+
+// NewPaymentControl creates a new instance of the paymentControl.
+func NewPaymentControl(db *channeldb.DB) ControlTower {
+	return &paymentControl{
+		db: db,
+	}
+}
+
+// CheckSend checks that a sending htlc wasn't triggered before for specific
+// payment hash, if so, should trigger error depends on current status
+func (p *paymentControl) CheckSend(htlc *lnwire.UpdateAddHTLC) error {
+	p.mx.Lock()
+	defer p.mx.Unlock()
+
+	// Retrieve current status of payment from local database.
+	paymentStatus, err := p.db.FetchPaymentStatus(htlc.PaymentHash)
+	if err != nil {
+		return err
+	}
+
+	switch paymentStatus {
+	case channeldb.StatusGrounded:
+		// It is safe to reattempt a payment if we know that we haven't
+		// left one in flight prior to restarting and switch.
+		return p.db.UpdatePaymentStatus(htlc.PaymentHash,
+			channeldb.StatusInFlight)
+
+	case channeldb.StatusInFlight:
+		// Not clear if it's safe to reinitiate a payment if there
+		// is already a payment in flight, so we should withhold any
+		// additional attempts to send to that payment hash.
+		return ErrPaymentInFlight
+
+	case channeldb.StatusCompleted:
+		// It has been already paid and don't want to pay again.
+		return ErrAlreadyPaid
+	}
+
+	return nil
+}
+
+// Success proceed status changing of payment to next successful status
+func (p *paymentControl) Success(paymentHash [32]byte) error {
+	p.mx.Lock()
+	defer p.mx.Unlock()
+
+	paymentStatus, err := p.db.FetchPaymentStatus(paymentHash)
+	if err != nil {
+		return err
+	}
+
+	switch paymentStatus {
+	case channeldb.StatusGrounded:
+		// Payment isn't initiated but received.
+		return ErrPaymentNotInitiated
+
+	case channeldb.StatusInFlight:
+		// Successful transition from InFlight transition to Completed.
+		return p.db.UpdatePaymentStatus(paymentHash, channeldb.StatusCompleted)
+
+	case channeldb.StatusCompleted:
+		// Payment is completed before in should be ignored.
+		return ErrPaymentAlreadyCompleted
+	}
+
+	return nil
+}
+
+// Fail proceed status changing of payment to initial status in case of failure
+func (p *paymentControl) Fail(paymentHash [32]byte) error {
+	p.mx.Lock()
+	defer p.mx.Unlock()
+
+	paymentStatus, err := p.db.FetchPaymentStatus(paymentHash)
+	if err != nil {
+		return err
+	}
+
+	switch paymentStatus {
+	case channeldb.StatusGrounded:
+		// Unpredictable behavior when payment wasn't transited to
+		// StatusInFlight status and was failed.
+		return ErrPaymentNotInitiated
+
+	case channeldb.StatusInFlight:
+		// If payment wasn't processed by some reason should return to
+		// default status to unlock retrying option for the same payment hash.
+		return p.db.UpdatePaymentStatus(paymentHash, channeldb.StatusGrounded)
+
+	case channeldb.StatusCompleted:
+		// Payment is completed before and can't be moved to another status.
+		return ErrPaymentAlreadyCompleted
+	}
+
+	return nil
+}

--- a/htlcswitch/switch_control_test.go
+++ b/htlcswitch/switch_control_test.go
@@ -1,0 +1,206 @@
+package htlcswitch
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/btcsuite/fastsha256"
+	"github.com/lightningnetwork/lnd/channeldb"
+	"github.com/lightningnetwork/lnd/lnwire"
+)
+
+func genHtlc() (*lnwire.UpdateAddHTLC, error) {
+	preimage, err := genPreimage()
+	if err != nil {
+		return nil, fmt.Errorf("unable to generate preimage: %v", err)
+	}
+
+	rhash := fastsha256.Sum256(preimage[:])
+	htlc := &lnwire.UpdateAddHTLC{
+		PaymentHash: rhash,
+		Amount:      1,
+	}
+
+	return htlc, nil
+}
+
+// TestPaymentControlSwitch checks the ability of payment control
+// change states of payments
+func TestPaymentControlSwitch(t *testing.T) {
+	t.Parallel()
+
+	db, err := initDB()
+	if err != nil {
+		t.Fatalf("unable to init db: %v", err)
+	}
+
+	pControl := NewPaymentControl(db)
+
+	htlc, err := genHtlc()
+	if err != nil {
+		t.Fatalf("unable to generate htlc message: %v", err)
+	}
+
+	// Sends base htlc message which initiate base status
+	// and move it to StatusInFlight and verifies that it
+	// was changed.
+	if err := pControl.CheckSend(htlc); err != nil {
+		t.Fatalf("unable to send htlc message: %v", err)
+	}
+
+	pStatus, err := db.FetchPaymentStatus(htlc.PaymentHash)
+	if err != nil {
+		t.Fatalf("unable to fetch payment status: %v", err)
+	}
+
+	if pStatus != channeldb.StatusInFlight {
+		t.Fatalf("payment status mismatch: expected %v, got %v",
+			channeldb.StatusInFlight, pStatus)
+	}
+
+	// Verifies that status was changed to StatusCompleted.
+	if err := pControl.Success(htlc.PaymentHash); err != nil {
+		t.Fatalf("error shouldn't have been received, got: %v", err)
+	}
+
+	pStatus, err = db.FetchPaymentStatus(htlc.PaymentHash)
+	if err != nil {
+		t.Fatalf("unable to fetch payment status: %v", err)
+	}
+
+	if pStatus != channeldb.StatusCompleted {
+		t.Fatalf("payment status mismatch: expected %v, got %v",
+			channeldb.StatusCompleted, pStatus)
+	}
+}
+
+// TestPaymentControlSwitchFail checks that payment status returns
+// to initial status after fail
+func TestPaymentControlSwitchFail(t *testing.T) {
+	t.Parallel()
+
+	db, err := initDB()
+	if err != nil {
+		t.Fatalf("unable to init db: %v", err)
+	}
+
+	pControl := NewPaymentControl(db)
+
+	htlc, err := genHtlc()
+	if err != nil {
+		t.Fatalf("unable to generate htlc message: %v", err)
+	}
+
+	// Sends base htlc message which initiate StatusInFlight.
+	if err := pControl.CheckSend(htlc); err != nil {
+		t.Fatalf("unable to send htlc message: %v", err)
+	}
+
+	pStatus, err := db.FetchPaymentStatus(htlc.PaymentHash)
+	if err != nil {
+		t.Fatalf("unable to fetch payment status: %v", err)
+	}
+
+	if pStatus != channeldb.StatusInFlight {
+		t.Fatalf("payment status mismatch: expected %v, got %v",
+			channeldb.StatusInFlight, pStatus)
+	}
+
+	// Move payment to completed status, second payment should return error.
+	pControl.Fail(htlc.PaymentHash)
+
+	pStatus, err = db.FetchPaymentStatus(htlc.PaymentHash)
+	if err != nil {
+		t.Fatalf("unable to fetch payment status: %v", err)
+	}
+
+	if pStatus != channeldb.StatusGrounded {
+		t.Fatalf("payment status mismatch: expected %v, got %v",
+			channeldb.StatusGrounded, pStatus)
+	}
+}
+
+// TestPaymentControlSwitchDoubleSend checks the ability of payment control
+// to prevent double sending of htlc message, when message is in StatusInFlight
+func TestPaymentControlSwitchDoubleSend(t *testing.T) {
+	t.Parallel()
+
+	db, err := initDB()
+	if err != nil {
+		t.Fatalf("unable to init db: %v", err)
+	}
+
+	pControl := NewPaymentControl(db)
+
+	htlc, err := genHtlc()
+	if err != nil {
+		t.Fatalf("unable to generate htlc message: %v", err)
+	}
+
+	// Sends base htlc message which initiate base status
+	// and move it to StatusInFlight and verifies that it
+	// was changed.
+	if err := pControl.CheckSend(htlc); err != nil {
+		t.Fatalf("unable to send htlc message: %v", err)
+	}
+
+	pStatus, err := db.FetchPaymentStatus(htlc.PaymentHash)
+	if err != nil {
+		t.Fatalf("unable to fetch payment status: %v", err)
+	}
+
+	if pStatus != channeldb.StatusInFlight {
+		t.Fatalf("payment status mismatch: expected %v, got %v",
+			channeldb.StatusInFlight, pStatus)
+	}
+
+	// Tries to initiate double sending of htlc message with the same
+	// payment hash.
+	if err := pControl.CheckSend(htlc); err != ErrPaymentInFlight {
+		t.Fatalf("payment control wrong behaviour: " +
+			"double sending must trigger ErrPaymentInFlight error")
+	}
+}
+
+// TestPaymentControlSwitchDoublePay checks the ability of payment control
+// to prevent double payment
+func TestPaymentControlSwitchDoublePay(t *testing.T) {
+	t.Parallel()
+
+	db, err := initDB()
+	if err != nil {
+		t.Fatalf("unable to init db: %v", err)
+	}
+
+	pControl := NewPaymentControl(db)
+
+	htlc, err := genHtlc()
+	if err != nil {
+		t.Fatalf("unable to generate htlc message: %v", err)
+	}
+
+	// Sends base htlc message which initiate StatusInFlight.
+	if err := pControl.CheckSend(htlc); err != nil {
+		t.Fatalf("unable to send htlc message: %v", err)
+	}
+
+	pStatus, err := db.FetchPaymentStatus(htlc.PaymentHash)
+	if err != nil {
+		t.Fatalf("unable to fetch payment status: %v", err)
+	}
+
+	if pStatus != channeldb.StatusInFlight {
+		t.Fatalf("payment status mismatch: expected %v, got %v",
+			channeldb.StatusInFlight, pStatus)
+	}
+
+	// Move payment to completed status, second payment should return error.
+	if err := pControl.Success(htlc.PaymentHash); err != nil {
+		t.Fatalf("error shouldn't have been received, got: %v", err)
+	}
+
+	if err := pControl.CheckSend(htlc); err != ErrAlreadyPaid {
+		t.Fatalf("payment control wrong behaviour:" +
+			" double payment must trigger ErrAlreadyPaid")
+	}
+}

--- a/htlcswitch/switch_test.go
+++ b/htlcswitch/switch_test.go
@@ -1619,7 +1619,9 @@ func TestSwitchSendPayment(t *testing.T) {
 		}
 
 	case err := <-errChan:
-		t.Fatalf("unable to send payment: %v", err)
+		if err != ErrPaymentInFlight {
+			t.Fatalf("unable to send payment: %v", err)
+		}
 	case <-time.After(time.Second):
 		t.Fatal("request was not propagated to destination")
 	}
@@ -1636,11 +1638,11 @@ func TestSwitchSendPayment(t *testing.T) {
 		t.Fatal("request was not propagated to destination")
 	}
 
-	if s.numPendingPayments() != 2 {
+	if s.numPendingPayments() != 1 {
 		t.Fatal("wrong amount of pending payments")
 	}
 
-	if s.circuits.NumOpen() != 2 {
+	if s.circuits.NumOpen() != 1 {
 		t.Fatal("wrong amount of circuits")
 	}
 
@@ -1663,29 +1665,6 @@ func TestSwitchSendPayment(t *testing.T) {
 		},
 	}
 
-	if err := s.forward(packet); err != nil {
-		t.Fatalf("can't forward htlc packet: %v", err)
-	}
-
-	select {
-	case err := <-errChan:
-		if err.Error() != errors.New(lnwire.CodeIncorrectPaymentAmount).Error() {
-			t.Fatal("err wasn't received")
-		}
-	case <-time.After(time.Second):
-		t.Fatal("err wasn't received")
-	}
-
-	packet = &htlcPacket{
-		outgoingChanID: aliceChannelLink.ShortChanID(),
-		outgoingHTLCID: 1,
-		htlc: &lnwire.UpdateFailHTLC{
-			Reason: reason,
-		},
-	}
-
-	// Send second failure response and check that user were able to
-	// receive the error.
 	if err := s.forward(packet); err != nil {
 		t.Fatalf("can't forward htlc packet: %v", err)
 	}


### PR DESCRIPTION
Closes: https://github.com/lightningnetwork/lnd/issues/973

## Description from the ticket:
In reality, we aren't concerned so much with payments to individual invoices, so much as payments to the same payment hash. Since different invoices can be crafted with the same preimage, we should opt for the latter as it offers stronger protection. Additionally, we would want these checks to have durability, such that restarting does not compromise our sanity checks.