### PR TITLE
README - Update Slack invite link

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,8 +60,7 @@ resources including talks, articles, and example applications can be found at:
 [dev.lightning.community](http://dev.lightning.community).
 
 Finally, we also have an active
-[Slack](https://lightningcommunity.slack.com/join/shared_invite/enQtMjk0OTYxNzI4NzExLTFhZDA5YTYxZDU2YWQyOTQzN2ZkMzk3ZGUwNGM0NjE2NzQyNjAyZTkwOTFkZjJmMmMyNzlmNmE5YTRmMGFhM2Q)
-where protocol developers, application developers, testers and users gather to
+[Slack](https://join.slack.com/t/lightningcommunity/shared_invite/enQtMzQ0OTQyNjE5NjU1LWRiMGNmOTZiNzU0MTVmYzc1ZGFkZTUyNzUwOGJjMjYwNWRkNWQzZWE3MTkwZjdjZGE5ZGNiNGVkMzI2MDU4ZTE) where protocol developers, application developers, testers and users gather to
 discuss various aspects of `lnd` and also Lightning in general.
 
 ## Installation


### PR DESCRIPTION
Current link leads to "This invite is no longer active"

![image](https://user-images.githubusercontent.com/2483304/38626794-61623ae6-3d7b-11e8-85dc-630521058bb8.png)

Updated link to match what exists on https://dev.lightning.community/