### PR TITLE
Add reference to invoice.macaroon in macaroon documentation file

### DIFF
--- a/docs/macaroons.md
+++ b/docs/macaroons.md
@@ -49,19 +49,22 @@ user must remember several things:
   person receiving it cannot remove the caveat.
 
 This is used in `lnd` in an interesting way. By default, when `lnd` starts, it
-creates two files which contain macaroons: a file called `admin.macaroon`,
-which contains a macaroon with no caveats, and a file called
-`readonly.macaroon`, which is the *same* macaroon but with an additional caveat
-that permits only methods that don't change the state of `lnd`.
+creates three files which contain macaroons: a file called `admin.macaroon`,
+which contains a macaroon with no caveats, a file called `readonly.macaroon`,
+which is the *same* macaroon but with an additional caveat, that permits only
+methods that don't change the state of `lnd`, and `invoice.macaroon`, which
+only has access to invoice related methods.
 
 ## How macaroons are used by `lnd` and `lncli`.
 
-On startup, `lnd` checks to see if the `admin.macaroon` and `readonly.macaroon`
-files exist. If they *both* don't exist, `lnd` updates its database with a new
-macaroon ID, generates the `admin.macaroon` file with that ID, and generates
-the `readonly.macaroon` file with the same ID but an additional caveat which
-restricts the caller to using only read-only methods. This means a few
-important things:
+On startup, `lnd` checks to see if the `admin.macaroon`, `readonly.macaroon`
+and `invoice.macaroon` files exist. If they don't exist, `lnd` updates its
+database with a new macaroon ID, generates the three files `admin.macaroon`,
+`readonly.macaroon` and `invoice.macaroon`, all with the same ID. The
+`readonly.macaroon` file has an additional caveat which restricts the caller
+to using only read-only methods and the `invoice.macaroon` also has an
+additional caveat which restricts the caller to using only invoice related
+methods. This means a few important things:
 
 * You can delete the `admin.macaroon` and be left with only the
   `readonly.macaroon`, which can sometimes be useful (for example, if you want
@@ -69,10 +72,10 @@ important things:
   change its state).
 
 * If you delete the data directory which contains the `macaroons.db` file, this
-  invalidates the `admin.macaroon` and `readonly.macaroon` files. Invalid
-  macaroon files give you errors like `cannot get macaroon: root key with id 0
-  doesn't exist` or `verification failed: signature mismatch after caveat
-  verification`.
+  invalidates the `admin.macaroon`, `readonly.macaroon` and `invoice.macaroon`
+  files. Invalid macaroon files give you errors like `cannot get macaroon: root
+  key with id 0 doesn't exist` or `verification failed: signature mismatch
+  after caveat verification`.
 
 You can also run `lnd` with the `--no-macaroons` option, which skips the
 creation of the macaroon files and all macaroon checks within the RPC server.


### PR DESCRIPTION
The invoice.macaroon feature was added in PR https://github.com/lightningnetwork/lnd/pull/904 but there is no reference to this on the current documentation, this PR is a small change to let know to the user that this option is available.