### PR TITLE
docs: update Go version to 1.9 in Contribution Checklist

### DIFF
--- a/docs/code_contribution_guidelines.md
+++ b/docs/code_contribution_guidelines.md
@@ -451,7 +451,7 @@ Rejoice as you will now be listed as a [contributor](https://github.com/lightnin
 
 #### 6.1. Contribution Checklist
 
-- [&nbsp;&nbsp;] All changes are Go version 1.5 compliant
+- [&nbsp;&nbsp;] All changes are Go version 1.9 compliant
 - [&nbsp;&nbsp;] The code being submitted is commented according to the
   [Code Documentation and Commenting](#CodeDocumentation) section
 - [&nbsp;&nbsp;] For new code: Code is accompanied by tests which exercise both


### PR DESCRIPTION
According to install.md, the minimum version of Go supported at the 
moment is 1.9, so update the Go version referenced in Contribution 
Checklist to 1.9 as well.