### PR TITLE
invoice: improve "wrong network" error message

### DIFF
--- a/zpay32/invoice.go
+++ b/zpay32/invoice.go
@@ -290,7 +290,8 @@ func Decode(invoice string, net *chaincfg.Params) (*Invoice, error) {
 	// The next characters should be a valid prefix for a segwit BIP173
 	// address that match the active network.
 	if !strings.HasPrefix(hrp[2:], net.Bech32HRPSegwit) {
-		return nil, fmt.Errorf("unknown network")
+		return nil, fmt.Errorf(
+			"invoice not for current active network '%s'", net.Name)
 	}
 	decodedInvoice.Net = net
 


### PR DESCRIPTION
When using invoice.Decode, for instance with "lncli decodepayreq", if the network of the invoice does not match the active network, an error message of "wrong network" will be returned. Unfortunately this error message is not detailed enough to indicate to the user what they have done wrong (see conversations on LND slack). This PR provides a more descriptive error message to decrease user confusion.

Example command:
`lncli decodepayreq lnbc10u1pdd8ksmpp5gaektzj5krc6hykdayavctnwk33sm8385dq7nt7gp6a8uylyullsdp9gdhkjmnsv9hxjceqgdhk6mt4de5hg7fqffshycqzysvee2c49hz0wuzrggrntmc4p8ppk880ekhagre5sd9kk3hmt35dzjgzw5p2sp7vp9fnzhzly76yn89qmx0577tpeqnq5u02zzg57fj9sp8yyffl
`

Old output:
`[lncli] rpc error: code = Unknown desc = unknown network`

New output:
`[lncli] rpc error: code = Unknown desc = "testnet3" is the active network, but the specified invoice is for a different network`

This is part of the initiative to improve error message user friendliness (https://github.com/lightningnetwork/lnd/issues/671).