### PR TITLE
Notify on confirmed spends during btcd rescans

### DIFF
--- a/chainntnfs/btcdnotify/btcd.go
+++ b/chainntnfs/btcdnotify/btcd.go
@@ -370,8 +370,8 @@ out:
 				chainntnfs.Log.Error(err)
 			}
 
-		// NOTE: we currently only use txUpdates for mempool spends. It
-		// might get removed entirely in the future.
+		// NOTE: we currently only use txUpdates for mempool spends and
+		// rescan spends. It might get removed entirely in the future.
 		case item := <-b.txUpdates.ChanOut():
 			newSpend := item.(*txUpdate)
 			spendingTx := newSpend.tx
@@ -397,7 +397,10 @@ out:
 					// TODO(roasbeef): after change to
 					// loadfilter, only notify on block
 					// inclusion?
+
+					confirmedSpend := false
 					if newSpend.details != nil {
+						confirmedSpend = true
 						spendDetails.SpendingHeight = newSpend.details.Height
 					} else {
 						spendDetails.SpendingHeight = currentHeight + 1
@@ -409,17 +412,25 @@ out:
 					// the spend within a block.
 					rem := make(map[uint64]*spendNotification)
 					for c, ntfn := range clients {
-						// If this client didn't want
+						// If this is a mempool spend,
+						// and this client didn't want
 						// to be notified on mempool
 						// spends, store it for later.
-						if !ntfn.mempool {
+						if !confirmedSpend && !ntfn.mempool {
 							rem[c] = ntfn
 							continue
 						}
 
-						chainntnfs.Log.Infof("Dispatching "+
+						confStr := "unconfirmed"
+						if confirmedSpend {
+							confStr = "confirmed"
+						}
+
+						chainntnfs.Log.Infof("Dispatching %s "+
 							"spend notification for "+
-							"outpoint=%v", ntfn.targetOutpoint)
+							"outpoint=%v at height %v",
+							confStr, ntfn.targetOutpoint,
+							spendDetails.SpendingHeight)
 						ntfn.spendChan <- spendDetails
 
 						// Close spendChan to ensure that any calls to Cancel will not


### PR DESCRIPTION
This commit fixes a recently introduced bug (https://github.com/lightningnetwork/lnd/pull/969) in the btcdnotifier, where
we would skip all spend clients waiting for a confirmed spend in
txUpdates. The regular case where a spend is included in a new block was
correctly handled in onBlockConnected, but the txUpdates queue is also
used for confirmed spends during rescans, which we would miss. This
commit fixes that by checking if the tx update is confirmed or
unconfirmed, and acts accordingly.