### PR TITLE
server: add support for NAT traversal and watching dynamic IP changes

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -13,6 +13,25 @@
   revision = "e06297f34865a50b8e473105e52cb64ad1b55da8"
 
 [[projects]]
+  branch = "master"
+  name = "github.com/NebulousLabs/fastrand"
+  packages = ["."]
+  revision = "3cf7173006a0b7d2371fa1a220da7f9d48c7827c"
+
+[[projects]]
+  name = "github.com/NebulousLabs/go-upnp"
+  packages = [
+    ".",
+    "goupnp",
+    "goupnp/dcps/internetgateway1",
+    "goupnp/httpu",
+    "goupnp/scpd",
+    "goupnp/soap",
+    "goupnp/ssdp"
+  ]
+  revision = "29b680b06c82d044ebea91bf3069038eb562df2a"
+
+[[projects]]
   name = "github.com/Yawning/aez"
   packages = ["."]
   revision = "4dad034d9db2caec23fb8f69b9160ae16f8d46a3"
@@ -114,6 +133,17 @@
     "utilities"
   ]
   revision = "f2862b476edcef83412c7af8687c9cd8e4097c0f"
+
+[[projects]]
+  name = "github.com/jackpal/gateway"
+  packages = ["."]
+  revision = "3e333950771011fed13be63e62b9f473c5e0d9bf"
+  version = "v1.0.4"
+
+[[projects]]
+  name = "github.com/jackpal/go-nat-pmp"
+  packages = ["."]
+  revision = "28a68d0c24adce1da43f8df6a57340909ecd7fdd"
 
 [[projects]]
   name = "github.com/jessevdk/go-flags"
@@ -267,6 +297,9 @@
   name = "golang.org/x/net"
   packages = [
     "context",
+    "html",
+    "html/atom",
+    "html/charset",
     "http2",
     "http2/hpack",
     "idna",
@@ -291,12 +324,24 @@
   packages = [
     "collate",
     "collate/build",
+    "encoding",
+    "encoding/charmap",
+    "encoding/htmlindex",
+    "encoding/internal",
+    "encoding/internal/identifier",
+    "encoding/japanese",
+    "encoding/korean",
+    "encoding/simplifiedchinese",
+    "encoding/traditionalchinese",
+    "encoding/unicode",
     "internal/colltab",
     "internal/gen",
     "internal/tag",
     "internal/triegen",
     "internal/ucd",
+    "internal/utf8internal",
     "language",
+    "runes",
     "secure/bidirule",
     "transform",
     "unicode/bidi",
@@ -359,6 +404,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "2133b0035a81c856475302a127bc26d30217a30d1e41708d3604f2de82e1ab31"
+  inputs-digest = "dc40dd185a90b723e4b3df4a077b4ad4f99648260661cac9d58121e8bd3474ef"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -27,6 +27,10 @@
   revision = "f2862b476edcef83412c7af8687c9cd8e4097c0f"
 
 [[constraint]]
+  name = "github.com/jackpal/go-nat-pmp"
+  revision = "28a68d0c24adce1da43f8df6a57340909ecd7fdd"
+
+[[constraint]]
   name = "github.com/jessevdk/go-flags"
   revision = "f88afde2fa19a30cf50ba4b05b3d13bc6bae3079"
 
@@ -53,6 +57,10 @@
 [[constraint]]
   name = "github.com/miekg/dns"
   revision = "79bfde677fa81ff8d27c4330c35bda075d360641"
+
+[[constraint]]
+  name = "github.com/NebulousLabs/go-upnp"
+  revision = "29b680b06c82d044ebea91bf3069038eb562df2a"
 
 [[constraint]]
   name = "github.com/roasbeef/btcutil"

--- a/config.go
+++ b/config.go
@@ -790,18 +790,27 @@ func loadConfig() (*config, error) {
 
 	// Add default port to all RPC listener addresses if needed and remove
 	// duplicate addresses.
-	cfg.RPCListeners = normalizeAddresses(cfg.RPCListeners,
-		strconv.Itoa(defaultRPCPort))
+	cfg.RPCListeners = normalizeAddresses(
+		cfg.RPCListeners, strconv.Itoa(defaultRPCPort),
+	)
 
 	// Add default port to all REST listener addresses if needed and remove
 	// duplicate addresses.
-	cfg.RESTListeners = normalizeAddresses(cfg.RESTListeners,
-		strconv.Itoa(defaultRESTPort))
+	cfg.RESTListeners = normalizeAddresses(
+		cfg.RESTListeners, strconv.Itoa(defaultRESTPort),
+	)
 
 	// Add default port to all listener addresses if needed and remove
 	// duplicate addresses.
-	cfg.Listeners = normalizeAddresses(cfg.Listeners,
-		strconv.Itoa(defaultPeerPort))
+	cfg.Listeners = normalizeAddresses(
+		cfg.Listeners, strconv.Itoa(defaultPeerPort),
+	)
+
+	// Add default port to all external IP addresses if needed and remove
+	// duplicate addresses.
+	cfg.ExternalIPs = normalizeAddresses(
+		cfg.ExternalIPs, strconv.Itoa(defaultPeerPort),
+	)
 
 	// Finally, ensure that we are only listening on localhost if Tor
 	// inbound support is enabled.

--- a/config.go
+++ b/config.go
@@ -47,6 +47,7 @@ const (
 	defaultRPCHost            = "localhost"
 	defaultMaxPendingChannels = 1
 	defaultNoEncryptWallet    = false
+	defaultUpnpSupport        = false
 	defaultTrickleDelay       = 30 * 1000
 	defaultMaxLogFiles        = 3
 	defaultMaxLogFileSize     = 10
@@ -195,6 +196,7 @@ type config struct {
 	UnsafeDisconnect   bool `long:"unsafe-disconnect" description:"Allows the rpcserver to intentionally disconnect from peers with open channels. USED FOR TESTING ONLY."`
 	UnsafeReplay       bool `long:"unsafe-replay" description:"Causes a link to replay the adds on its commitment txn after starting up, this enables testing of the sphinx replay logic."`
 	MaxPendingChannels int  `long:"maxpendingchannels" description:"The maximum number of incoming pending channels permitted per peer."`
+	UpnpSupport        bool `long:"upnpsupport" description:"Toggle Upnp support for auto network discovery"`
 
 	Bitcoin      *chainConfig    `group:"Bitcoin" namespace:"bitcoin"`
 	BtcdMode     *btcdConfig     `group:"btcd" namespace:"btcd"`
@@ -248,6 +250,7 @@ func loadConfig() (*config, error) {
 		LogDir:         defaultLogDir,
 		MaxLogFiles:    defaultMaxLogFiles,
 		MaxLogFileSize: defaultMaxLogFileSize,
+		UpnpSupport:    defaultUpnpSupport,
 		Bitcoin: &chainConfig{
 			MinHTLC:       defaultBitcoinMinHTLCMSat,
 			BaseFee:       defaultBitcoinBaseFeeMSat,

--- a/config.go
+++ b/config.go
@@ -725,6 +725,12 @@ func loadConfig() (*config, error) {
 		)
 	}
 
+	if cfg.UpnpSupport && cfg.NatPmp {
+		str := "%s: Currently both Upnp and NAT-PMP cannot be " +
+			"enabled together"
+		return nil, fmt.Errorf(str, funcName)
+	}
+
 	// Append the network type to the log directory so it is "namespaced"
 	// per network in the same fashion as the data directory.
 	cfg.LogDir = filepath.Join(cfg.LogDir,

--- a/config.go
+++ b/config.go
@@ -196,7 +196,8 @@ type config struct {
 	UnsafeDisconnect   bool `long:"unsafe-disconnect" description:"Allows the rpcserver to intentionally disconnect from peers with open channels. USED FOR TESTING ONLY."`
 	UnsafeReplay       bool `long:"unsafe-replay" description:"Causes a link to replay the adds on its commitment txn after starting up, this enables testing of the sphinx replay logic."`
 	MaxPendingChannels int  `long:"maxpendingchannels" description:"The maximum number of incoming pending channels permitted per peer."`
-	UpnpSupport        bool `long:"upnpsupport" description:"Toggle Upnp support for auto network discovery"`
+	UpnpSupport        bool `long:"upnp" description:"Toggle Upnp support for auto network discovery"`
+	NatPmp             bool `long:"natpmp" description:"Toggle Nat Pmp support for auto network discovery"`
 
 	Bitcoin      *chainConfig    `group:"Bitcoin" namespace:"bitcoin"`
 	BtcdMode     *btcdConfig     `group:"btcd" namespace:"btcd"`

--- a/docs/nat_traversal.md
+++ b/docs/nat_traversal.md
@@ -1,0 +1,23 @@
+# NAT Traversal
+
+`lnd` has support for NAT traversal using a number of different techniques. At
+the time of writing this documentation, UPnP and NAT-PMP are supported. NAT
+traversal can be enabled through `lnd`'s `--nat` flag.
+
+```shell
+$ lnd ... --nat
+```
+
+On startup, `lnd` will try the different techniques until one is found that's
+supported by your hardware. The underlying dependencies used for these
+techniques rely on using system-specific binaries in order to detect your
+gateway device's address. This is needed because we need to be able to reach the
+gateway device to determine if it supports the specific NAT traversal technique
+currently being tried. Because of this, due to uncommon setups, it is possible
+that these binaries are not found in your system. If this is case, `lnd` will
+exit stating such error.
+
+As a bonus, `lnd` spawns a background thread that automatically detects IP
+address changes and propagates the new address update to the rest of the
+network. This is especially beneficial for users who were provided dynamic IP
+addresses from their internet service provider.

--- a/lnd.go
+++ b/lnd.go
@@ -26,8 +26,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/NebulousLabs/go-upnp"
-
 	"gopkg.in/macaroon-bakery.v2/bakery"
 
 	"golang.org/x/net/context"
@@ -310,29 +308,6 @@ func lndMain() error {
 		srvrLog.Infof("Proxying all network traffic via Tor "+
 			"(stream_isolation=%v)! NOTE: Ensure the backend node "+
 			"is proxying over Tor as well", cfg.Tor.StreamIsolation)
-	}
-
-	// Connect to router
-	d, err := upnp.Discover()
-	if err != nil {
-		fmt.Printf("Unable to discover router %v\n", err)
-		return err
-	}
-
-	// Get external IP
-	ip, err := d.ExternalIP()
-	if err != nil {
-		fmt.Printf("Unable to get external ip %v\n", err)
-		return err
-	}
-
-	ltndLog.Infof("Your external IP is: %s", ip)
-
-	// Forward peer port
-	err = d.Forward(uint16(cfg.PeerPort), "lnd pear port")
-	if err != nil {
-		fmt.Printf("Unable to forward pear port ip %v\n", err)
-		return err
 	}
 
 	// Set up the core server which will listen for incoming peer

--- a/lnd.go
+++ b/lnd.go
@@ -26,6 +26,8 @@ import (
 	"sync"
 	"time"
 
+	"github.com/NebulousLabs/go-upnp"
+
 	"gopkg.in/macaroon-bakery.v2/bakery"
 
 	"golang.org/x/net/context"
@@ -308,6 +310,29 @@ func lndMain() error {
 		srvrLog.Infof("Proxying all network traffic via Tor "+
 			"(stream_isolation=%v)! NOTE: Ensure the backend node "+
 			"is proxying over Tor as well", cfg.Tor.StreamIsolation)
+	}
+
+	// Connect to router
+	d, err := upnp.Discover()
+	if err != nil {
+		fmt.Printf("Unable to discover router %v\n", err)
+		return err
+	}
+
+	// Get external IP
+	ip, err := d.ExternalIP()
+	if err != nil {
+		fmt.Printf("Unable to get external ip %v\n", err)
+		return err
+	}
+
+	ltndLog.Infof("Your external IP is: %s", ip)
+
+	// Forward peer port
+	err = d.Forward(uint16(cfg.PeerPort), "lnd pear port")
+	if err != nil {
+		fmt.Printf("Unable to forward pear port ip %v\n", err)
+		return err
 	}
 
 	// Set up the core server which will listen for incoming peer

--- a/lnwire/node_announcement.go
+++ b/lnwire/node_announcement.go
@@ -85,6 +85,14 @@ type NodeAnnouncement struct {
 	Addresses []net.Addr
 }
 
+// UpdateNodeAnnAddrs is a functional option that allows updating the addresses
+// of the given node announcement.
+func UpdateNodeAnnAddrs(addrs []net.Addr) func(*NodeAnnouncement) {
+	return func(nodeAnn *NodeAnnouncement) {
+		nodeAnn.Addresses = addrs
+	}
+}
+
 // A compile time check to ensure NodeAnnouncement implements the
 // lnwire.Message interface.
 var _ Message = (*NodeAnnouncement)(nil)

--- a/nat/pmp.go
+++ b/nat/pmp.go
@@ -1,0 +1,117 @@
+package nat
+
+import (
+	"fmt"
+	"net"
+	"sync"
+	"time"
+
+	"github.com/jackpal/gateway"
+	natpmp "github.com/jackpal/go-nat-pmp"
+)
+
+// Compile-time check to ensure PMP implements the Traversal interface.
+var _ Traversal = (*PMP)(nil)
+
+// PMP is a concrete implementation of the Traversal interface that uses the
+// NAT-PMP technique.
+type PMP struct {
+	client *natpmp.Client
+
+	forwardedPortsMtx sync.Mutex
+	forwardedPorts    map[uint16]struct{}
+}
+
+// DiscoverPMP attempts to scan the local network for a NAT-PMP enabled device
+// within the given timeout.
+func DiscoverPMP(timeout time.Duration) (*PMP, error) {
+	// Retrieve the gateway IP address of the local network.
+	gatewayIP, err := gateway.DiscoverGateway()
+	if err != nil {
+		return nil, err
+	}
+
+	pmp := &PMP{
+		client:         natpmp.NewClientWithTimeout(gatewayIP, timeout),
+		forwardedPorts: make(map[uint16]struct{}),
+	}
+
+	// We'll then attempt to retrieve the external IP address of this
+	// device to ensure it is not behind multiple NATs.
+	if _, err := pmp.ExternalIP(); err != nil {
+		return nil, err
+	}
+
+	return pmp, nil
+}
+
+// ExternalIP returns the external IP address of the NAT-PMP enabled device.
+func (p *PMP) ExternalIP() (net.IP, error) {
+	res, err := p.client.GetExternalAddress()
+	if err != nil {
+		return nil, err
+	}
+
+	ip := net.IP(res.ExternalIPAddress[:])
+	if isPrivateIP(ip) {
+		return nil, ErrMultipleNAT
+	}
+
+	return ip, nil
+}
+
+// AddPortMapping enables port forwarding for the given port.
+func (p *PMP) AddPortMapping(port uint16) error {
+	p.forwardedPortsMtx.Lock()
+	defer p.forwardedPortsMtx.Unlock()
+
+	if _, exists := p.forwardedPorts[port]; exists {
+		return nil
+	}
+
+	_, err := p.client.AddPortMapping("tcp", int(port), int(port), 0)
+	if err != nil {
+		return err
+	}
+
+	p.forwardedPorts[port] = struct{}{}
+
+	return nil
+}
+
+// DeletePortMapping disables port forwarding for the given port.
+func (p *PMP) DeletePortMapping(port uint16) error {
+	p.forwardedPortsMtx.Lock()
+	defer p.forwardedPortsMtx.Unlock()
+
+	if _, exists := p.forwardedPorts[port]; !exists {
+		return fmt.Errorf("port %d is not being forwarded", port)
+	}
+
+	_, err := p.client.AddPortMapping("tcp", int(port), 0, 0)
+	if err != nil {
+		return err
+	}
+
+	delete(p.forwardedPorts, port)
+
+	return nil
+}
+
+// ForwardedPorts returns a list of ports currently being forwarded.
+func (p *PMP) ForwardedPorts() []uint16 {
+	p.forwardedPortsMtx.Lock()
+	defer p.forwardedPortsMtx.Unlock()
+
+	ports := make([]uint16, 0, len(p.forwardedPorts))
+	for port := range p.forwardedPorts {
+		ports = append(ports, port)
+	}
+
+	return ports
+}
+
+// Name returns the name of the specific NAT traversal technique used.
+func (p *PMP) Name() string {
+	return "NAT-PMP"
+}

--- a/nat/traversal.go
+++ b/nat/traversal.go
@@ -1,0 +1,58 @@
+package nat
+
+import (
+	"errors"
+	"net"
+)
+
+var (
+	// private24BitBlock contains the set of private IPv4 addresses within
+	// the 10.0.0.0/8 adddress space.
+	private24BitBlock *net.IPNet
+
+	// private20BitBlock contains the set of private IPv4 addresses within
+	// the 172.16.0.0/12 address space.
+	private20BitBlock *net.IPNet
+
+	// private16BitBlock contains the set of private IPv4 addresses within
+	// the 192.168.0.0/16 address space.
+	private16BitBlock *net.IPNet
+
+	// ErrMultipleNAT is an error returned when multiple NATs have been
+	// detected.
+	ErrMultipleNAT = errors.New("multiple NATs detected")
+)
+
+func init() {
+	_, private24BitBlock, _ = net.ParseCIDR("10.0.0.0/8")
+	_, private20BitBlock, _ = net.ParseCIDR("172.16.0.0/12")
+	_, private16BitBlock, _ = net.ParseCIDR("192.168.0.0/16")
+}
+
+// Traversal is an interface that brings together the different NAT traversal
+// techniques.
+type Traversal interface {
+	// ExternalIP returns the external IP address.
+	ExternalIP() (net.IP, error)
+
+	// AddPortMapping adds a port mapping for the given port between the
+	// private and public addresses.
+	AddPortMapping(port uint16) error
+
+	// DeletePortMapping deletes a port mapping for the given port between
+	// the private and public addresses.
+	DeletePortMapping(port uint16) error
+
+	// ForwardedPorts returns the ports currently being forwarded using NAT
+	// traversal.
+	ForwardedPorts() []uint16
+
+	// Name returns the name of the specific NAT traversal technique used.
+	Name() string
+}
+
+// isPrivateIP determines if the IP is private.
+func isPrivateIP(ip net.IP) bool {
+	return private24BitBlock.Contains(ip) ||
+		private20BitBlock.Contains(ip) || private16BitBlock.Contains(ip)
+}

--- a/nat/upnp.go
+++ b/nat/upnp.go
@@ -1,0 +1,112 @@
+package nat
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"sync"
+
+	upnp "github.com/NebulousLabs/go-upnp"
+)
+
+// Compile-time check to ensure UPnP implements the Traversal interface.
+var _ Traversal = (*UPnP)(nil)
+
+// UPnP is a concrete implementation of the Traversal interface that uses the
+// UPnP technique.
+type UPnP struct {
+	device *upnp.IGD
+
+	forwardedPortsMtx sync.Mutex
+	forwardedPorts    map[uint16]struct{}
+}
+
+// DiscoverUPnP scans the local network for a UPnP enabled device.
+func DiscoverUPnP(ctx context.Context) (*UPnP, error) {
+	// Scan the local network for a UPnP-enabled device.
+	device, err := upnp.DiscoverCtx(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	u := &UPnP{
+		device:         device,
+		forwardedPorts: make(map[uint16]struct{}),
+	}
+
+	// We'll then attempt to retrieve the external IP address of this
+	// device to ensure it is not behind multiple NATs.
+	if _, err := u.ExternalIP(); err != nil {
+		return nil, err
+	}
+
+	return u, nil
+}
+
+// ExternalIP returns the external IP address of the UPnP enabled device.
+func (u *UPnP) ExternalIP() (net.IP, error) {
+	ip, err := u.device.ExternalIP()
+	if err != nil {
+		return nil, err
+	}
+
+	if isPrivateIP(net.ParseIP(ip)) {
+		return nil, ErrMultipleNAT
+	}
+
+	return net.ParseIP(ip), nil
+}
+
+// AddPortMapping enables port forwarding for the given port.
+func (u *UPnP) AddPortMapping(port uint16) error {
+	u.forwardedPortsMtx.Lock()
+	defer u.forwardedPortsMtx.Unlock()
+
+	if _, exists := u.forwardedPorts[port]; exists {
+		return nil
+	}
+
+	if err := u.device.Forward(port, ""); err != nil {
+		return err
+	}
+
+	u.forwardedPorts[port] = struct{}{}
+
+	return nil
+}
+
+// DeletePortMapping disables port forwarding for the given port.
+func (u *UPnP) DeletePortMapping(port uint16) error {
+	u.forwardedPortsMtx.Lock()
+	defer u.forwardedPortsMtx.Unlock()
+
+	if _, exists := u.forwardedPorts[port]; !exists {
+		return fmt.Errorf("port %d is not being forwarded", port)
+	}
+
+	if err := u.device.Clear(port); err != nil {
+		return err
+	}
+
+	delete(u.forwardedPorts, port)
+
+	return nil
+}
+
+// ForwardedPorts returns a list of ports currently being forwarded.
+func (u *UPnP) ForwardedPorts() []uint16 {
+	u.forwardedPortsMtx.Lock()
+	defer u.forwardedPortsMtx.Unlock()
+
+	ports := make([]uint16, 0, len(u.forwardedPorts))
+	for port := range u.forwardedPorts {
+		ports = append(ports, port)
+	}
+
+	return ports
+}
+
+// Name returns the name of the specific NAT traversal technique used.
+func (u *UPnP) Name() string {
+	return "UPnP"
+}

--- a/sample-lnd.conf
+++ b/sample-lnd.conf
@@ -77,6 +77,18 @@
 ; (with host:port notation), the default port (9735) will be added to the
 ; address.
 ; externalip=
+;
+; Instead of explicitly stating your external IP address, you can also enable
+; UPnP or NAT-PMP support on the daemon. Both techniques will be tried and
+; require proper hardware support. In order to detect this hardware support,
+; `lnd` uses a dependency that retrieves the router's gateway address by using
+; different built-in binaries in each platform. Therefore, it is possible that
+; we are unable to detect the hardware and `lnd` will exit with an error
+; indicating this. This option will automatically retrieve your external IP
+; address, even after it has changed in the case of dynamic IPs, and advertise
+; it to the network using the ports the daemon is listening on. This does not
+; support devices behind multiple NATs.
+; nat=true
 
 
 ; Debug logging level.

--- a/server.go
+++ b/server.go
@@ -987,8 +987,8 @@ func (s *server) initTorController() error {
 // genNodeAnnouncement generates and returns the current fully signed node
 // announcement. If refresh is true, then the time stamp of the announcement
 // will be updated in order to ensure it propagates through the network.
-func (s *server) genNodeAnnouncement(
-	refresh bool) (lnwire.NodeAnnouncement, error) {
+func (s *server) genNodeAnnouncement(refresh bool,
+	updates ...func(*lnwire.NodeAnnouncement)) (lnwire.NodeAnnouncement, error) {
 
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -997,7 +997,9 @@ func (s *server) genNodeAnnouncement(
 		return *s.currentNodeAnn, nil
 	}
 
-	var err error
+	for _, update := range updates {
+		update(s.currentNodeAnn)
+	}
 
 	newStamp := uint32(time.Now().Unix())
 	if newStamp <= s.currentNodeAnn.Timestamp {

--- a/server.go
+++ b/server.go
@@ -310,27 +310,23 @@ func newServer(listenAddrs []string, chanDB *channeldb.DB, cc *chainControl,
 		// Connect to router
 		d, err := upnp.DiscoverCtx(context.Background())
 		if err != nil {
-			fmt.Printf("Upnp: Unable to discover router %v\n", err)
-			return nil, err
+			srvrLog.Errorf("Upnp: Unable to discover router %v\n", err)
 		}
 
 		// Get external IP
 		ip, err := d.ExternalIP()
 		if err != nil {
-			fmt.Printf("Upnp: Unable to get external ip %v\n", err)
-			return nil, err
+			srvrLog.Errorf("Upnp: Unable to get external ip %v\n", err)
 		}
-
-		ltndLog.Infof("Your external IP is: %s", ip)
 
 		// Forward peer port
 		err = d.Forward(uint16(cfg.PeerPort), "lnd peer port")
 		if err != nil {
-			fmt.Printf("Upnp: Unable to forward pear port ip %v\n", err)
-			return nil, err
+			srvrLog.Errorf("Upnp: Unable to forward pear port ip %v\n", err)
+		} else {
+			srvrLog.Infof("Your external IP is: %s", ip)
+			externalIPs = append(externalIPs, ip)
 		}
-
-		externalIPs = append(externalIPs, ip)
 
 	}
 

--- a/server.go
+++ b/server.go
@@ -303,10 +303,12 @@ func newServer(listenAddrs []string, chanDB *channeldb.DB, cc *chainControl,
 	// Gather external IPs from config
 	externalIPs := cfg.ExternalIPs
 
+	// If enabled, use either UPnP or NAT-PMP to automatically configure
+	// port forwarding for users behind a NAT
 	if cfg.UpnpSupport {
 
 		externalIP, err := configureUpnp()
-		if err != nil {
+		if err == nil {
 			externalIPs = append(externalIPs, externalIP)
 		}
 
@@ -315,7 +317,7 @@ func newServer(listenAddrs []string, chanDB *channeldb.DB, cc *chainControl,
 	if cfg.NatPmp {
 
 		externalIP, err := configureNatPmp()
-		if err != nil {
+		if err == nil {
 			externalIPs = append(externalIPs, externalIP)
 		}
 


### PR DESCRIPTION
In this PR, we address the following:

* Add new flags and documentation to toggle UPnP and NAT-PMP support.
* Add two different NAT traversal techniques: UPnP and NAT-PMP.
* Automatically detect the public facing IP address, using the specified NAT traversal technique, and advertise it to the network.
* Watch for dynamic IP changes periodically and broadcast a new node announcement with the updated IP address.

This currently does not support devices behind multiple NATs and will likely be not supported. Ideally, we can avoid this with the use of hidden services.

I would appreciate testing using the NAT-PMP technique as I do not have compatible equipment to do so.

Replaces #518, fixes #185.