### PR TITLE
rpcserver: add missing continue if link wasn't retrieved from the switch

### DIFF
--- a/rpcserver.go
+++ b/rpcserver.go
@@ -2254,6 +2254,7 @@ func (r *rpcServer) AddInvoice(ctx context.Context,
 			if err != nil {
 				rpcsLog.Errorf("Unable to get link for "+
 					"channel %v: %v", chanPoint, err)
+				continue
 			}
 
 			if !link.EligibleToForward() {


### PR DESCRIPTION
In this PR, we fix a recently introduced bug that could lead to a panic when including the routing hints in an invoice.

A test case has also been added to ensure the routing hints are added correctly.
