### PR TITLE
server: make node announcement creation conditional on startup

### DIFF
--- a/lnwire/node_announcement.go
+++ b/lnwire/node_announcement.go
@@ -158,9 +158,9 @@ func (a *NodeAnnouncement) DataToSign() ([]byte, error) {
 	return w.Bytes(), nil
 }
 
-// CompareNodes compares the configurable fields within two NodeAnnouncement
+// IsEqual compares the configurable fields within two NodeAnnouncement
 // objects, and returns whether they are equal or not.
-func (a *NodeAnnouncement) CompareNodes(b *NodeAnnouncement) bool {
+func (a *NodeAnnouncement) IsEqual(b *NodeAnnouncement) bool {
 	if !a.NodeID.IsEqual(b.NodeID) {
 		return false
 	}

--- a/lnwire/node_announcement.go
+++ b/lnwire/node_announcement.go
@@ -57,7 +57,7 @@ func (n NodeAlias) String() string {
 
 // NodeAnnouncement message is used to announce the presence of a Lightning
 // node and also to signal that the node is accepting incoming connections.
-// Each NodeAnnouncement authenticating the advertised information within the
+// Each node authenticates the advertised information within the
 // announcement via a signature using the advertised node pubkey.
 type NodeAnnouncement struct {
 	// Signature is used to prove the ownership of node id.
@@ -156,4 +156,40 @@ func (a *NodeAnnouncement) DataToSign() ([]byte, error) {
 	// TODO(roasbeef): also capture the excess bytes in msg padded out?
 
 	return w.Bytes(), nil
+}
+
+// CompareNodes compares the configurable fields within two NodeAnnouncement
+// objects, and returns whether they are equal or not.
+func (a *NodeAnnouncement) CompareNodes(b *NodeAnnouncement) bool {
+	if !a.NodeID.IsEqual(b.NodeID) {
+		return false
+	}
+	if a.Alias != b.Alias {
+		return false
+	}
+	if a.RGBColor != b.RGBColor {
+		return false
+	}
+
+	// When comparing Address arrays the order does not matter.
+	m := make(map[net.Addr]bool)
+	for _, addr := range a.Addresses {
+		m[addr] = true
+	}
+	for _, addr := range b.Addresses {
+		if _, eq := m[addr]; !eq {
+			return false
+		}
+	}
+
+	if len(a.Features.flags) != len(b.Features.flags) {
+		return false
+	}
+	for index, aFlag := range a.Features.flags {
+		if bFlag, exist := b.Features.flags[index]; !exist || aFlag != bFlag {
+			return false
+		}
+	}
+
+	return true
 }

--- a/lnwire/node_announcement.go
+++ b/lnwire/node_announcement.go
@@ -171,8 +171,12 @@ func (a *NodeAnnouncement) CompareNodes(b *NodeAnnouncement) bool {
 		return false
 	}
 
+	if len(a.Addresses) != len(b.Addresses) {
+		return false
+	}
 	// When comparing Address arrays the order does not matter.
 	m := make(map[net.Addr]bool)
+
 	for _, addr := range a.Addresses {
 		m[addr] = true
 	}

--- a/lnwire/node_announcement_test.go
+++ b/lnwire/node_announcement_test.go
@@ -23,7 +23,6 @@ func TestCompareNodeAnnouncements(t *testing.T) {
 	a1, _ := net.ResolveTCPAddr("tcp", "127.0.0.1:9735")
 	a2, _ := net.ResolveTCPAddr("tcp", "10.0.0.1:9000")
 
-
 	// Create a node announcement with the dummy data above
 	node1 := &NodeAnnouncement{
 		Features:  randFeatureVector(prand.New(randSource)),
@@ -36,32 +35,32 @@ func TestCompareNodeAnnouncements(t *testing.T) {
 	// Create a copy of node1, but switch the order of the
 	// addresses array. Compare nodes should still return
 	// true because the order of the addresses don't matter
-	node2 := new (NodeAnnouncement)
+	node2 := new(NodeAnnouncement)
 
 	*node2 = *node1
 	node2.Addresses = []net.Addr{a1, a2}
-	if !node1.CompareNodes(node2) {
+	if !node1.IsEqual(node2) {
 		t.Fatalf("expected node comparison to return true")
 	}
 
-	// Ensure CompareNodes returns false when the nodes' feature
+	// Ensure IsEqual returns false when the nodes' feature
 	// vectors are not equal.
 	*node2 = *node1
 	node2.Features = randFeatureVector(prand.New(randSource))
-	if node1.CompareNodes(node2) {
+	if node1.IsEqual(node2) {
 		t.Fatalf("expected node comparison to return false")
 	}
 
-	// Ensure CompareNodes returns false when the nodes' 
+	// Ensure IsEqual returns false when the nodes'
 	// aliases are not equal.
 	*node2 = *node1
 	alias2, _ := NewNodeAlias("kek2")
 	node2.Alias = alias2
-	if node1.CompareNodes(node2) {
+	if node1.IsEqual(node2) {
 		t.Fatalf("expected node comparison to return false")
 	}
-	
-	// Ensure CompareNodes returns false when the nodes' 
+
+	// Ensure IsEqual returns false when the nodes'
 	// RGBColors are not equal.
 	*node2 = *node1
 	node2.RGBColor = RGB{
@@ -69,25 +68,25 @@ func TestCompareNodeAnnouncements(t *testing.T) {
 		green: uint8(prand.Int31()),
 		blue:  uint8(prand.Int31()),
 	}
-	if node1.CompareNodes(node2) {
+	if node1.IsEqual(node2) {
 		t.Fatalf("expected node comparison to return false")
 	}
 
-	// Ensure CompareNodes returns false when the nodes' 
+	// Ensure IsEqual returns false when the nodes'
 	// address arrays are not fully equal.
 	*node2 = *node1
 	a3, _ := net.ResolveTCPAddr("tcp", "10.0.0.1:9001")
 	node2.Addresses = []net.Addr{a2, a3}
-	if node1.CompareNodes(node2) {
+	if node1.IsEqual(node2) {
 		t.Fatalf("expected node comparison to return false")
 	}
-	
-	// Ensure CompareNodes returns false when the nodes' 
+
+	// Ensure IsEqual returns false when the nodes'
 	// public keys are not equal.
 	*node2 = *node1
 	priv2, _ := btcec.NewPrivateKey(btcec.S256())
 	node2.NodeID = priv2.PubKey()
-	if node1.CompareNodes(node2) {
+	if node1.IsEqual(node2) {
 		t.Fatalf("expected node comparison to return false")
 	}
 }

--- a/lnwire/node_announcement_test.go
+++ b/lnwire/node_announcement_test.go
@@ -1,0 +1,93 @@
+package lnwire
+
+import (
+	prand "math/rand"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/roasbeef/btcd/btcec"
+)
+
+func TestCompareNodeAnnouncements(t *testing.T) {
+	t.Parallel()
+
+	randSource := prand.NewSource(time.Now().Unix())
+	priv, _ := btcec.NewPrivateKey(btcec.S256())
+	alias, _ := NewNodeAlias("kek")
+	rgb := RGB{
+		red:   uint8(prand.Int31()),
+		green: uint8(prand.Int31()),
+		blue:  uint8(prand.Int31()),
+	}
+	a1, _ := net.ResolveTCPAddr("tcp", "127.0.0.1:9735")
+	a2, _ := net.ResolveTCPAddr("tcp", "10.0.0.1:9000")
+
+
+	// Create a node announcement with the dummy data above
+	node1 := &NodeAnnouncement{
+		Features:  randFeatureVector(prand.New(randSource)),
+		Alias:     alias,
+		RGBColor:  rgb,
+		Addresses: []net.Addr{a2, a1},
+		NodeID:    priv.PubKey(),
+	}
+
+	// Create a copy of node1, but switch the order of the
+	// addresses array. Compare nodes should still return
+	// true because the order of the addresses don't matter
+	node2 := new (NodeAnnouncement)
+
+	*node2 = *node1
+	node2.Addresses = []net.Addr{a1, a2}
+	if !node1.CompareNodes(node2) {
+		t.Fatalf("expected node comparison to return true")
+	}
+
+	// Ensure CompareNodes returns false when the nodes' feature
+	// vectors are not equal.
+	*node2 = *node1
+	node2.Features = randFeatureVector(prand.New(randSource))
+	if node1.CompareNodes(node2) {
+		t.Fatalf("expected node comparison to return false")
+	}
+
+	// Ensure CompareNodes returns false when the nodes' 
+	// aliases are not equal.
+	*node2 = *node1
+	alias2, _ := NewNodeAlias("kek2")
+	node2.Alias = alias2
+	if node1.CompareNodes(node2) {
+		t.Fatalf("expected node comparison to return false")
+	}
+	
+	// Ensure CompareNodes returns false when the nodes' 
+	// RGBColors are not equal.
+	*node2 = *node1
+	node2.RGBColor = RGB{
+		red:   uint8(prand.Int31()),
+		green: uint8(prand.Int31()),
+		blue:  uint8(prand.Int31()),
+	}
+	if node1.CompareNodes(node2) {
+		t.Fatalf("expected node comparison to return false")
+	}
+
+	// Ensure CompareNodes returns false when the nodes' 
+	// address arrays are not fully equal.
+	*node2 = *node1
+	a3, _ := net.ResolveTCPAddr("tcp", "10.0.0.1:9001")
+	node2.Addresses = []net.Addr{a2, a3}
+	if node1.CompareNodes(node2) {
+		t.Fatalf("expected node comparison to return false")
+	}
+	
+	// Ensure CompareNodes returns false when the nodes' 
+	// public keys are not equal.
+	*node2 = *node1
+	priv2, _ := btcec.NewPrivateKey(btcec.S256())
+	node2.NodeID = priv2.PubKey()
+	if node1.CompareNodes(node2) {
+		t.Fatalf("expected node comparison to return false")
+	}
+}

--- a/server.go
+++ b/server.go
@@ -309,16 +309,16 @@ func newServer(listenAddrs []string, chanDB *channeldb.DB, cc *chainControl,
 		Features:  globalFeatures,
 	}
 
-	updateNodeAnn := true
-
 	// Try to retrieve the old source node from disk. During startup it
 	// is possible for there to be no source node, and this should not be
 	// treated as an error.
+	chanGraph := chanDB.ChannelGraph()
 	oldNode, err := chanGraph.SourceNode()
 	if err != nil && err != channeldb.ErrSourceNodeNotSet {
 		return nil, fmt.Errorf("unable to read old source node from disk")
 	}
 
+	updateNodeAnn := true
 	if oldNode != nil {
 		oldAlias, err := lnwire.NewNodeAlias(oldNode.Alias)
 		if err != nil {
@@ -335,7 +335,7 @@ func newServer(listenAddrs []string, chanDB *channeldb.DB, cc *chainControl,
 
 		// If the nodes are not equal than there have been config changes
 		// and we should propagate the updated node.
-		updateNodeAnn = !nodeAnn.CompareNodes(oldNodeAnn)
+		updateNodeAnn = !nodeAnn.IsEqual(oldNodeAnn)
 	}
 
 	// If our information has changed since our last boot, then we'll


### PR DESCRIPTION
Before this PR, we would unconditionally create a new node announcement, write it to the database, sign it, and broadcast it to the network. This is unnecessary as we should only do this if there were any changes between the last node announcement and the current one.

We address this by reading our last node announcement from disk and checking if it's equal to the current one. If it's not, we'll sign the new one and broadcast it.

Replaces #325 and fixes #274.