### PR TITLE
Integration tests: upload logs from TravisCI to file.io as well

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,4 +16,5 @@ script:
   - export PATH=$PATH:$GOPATH/bin
   - make travis
 after_script:
-  - find *.log | xargs -I{} sh -c "cat {} | nc termbin.com 9999 | xargs -r0 printf '{} uploaded to %s'"
+  - echo "Uploading to termbin.com..." && find *.log | xargs -I{} sh -c "cat {} | nc termbin.com 9999 | xargs -r0 printf '{} uploaded to %s'"
+  - echo "Uploading to file.io..." && tar -zcvO *.log | curl -s -F 'file=@-;filename=logs.tar.gz' https://file.io | xargs -r0 printf 'logs.tar.gz uploaded to %s\n'


### PR DESCRIPTION
As mentioned in #1133, the log files of the integration tests should be uploaded when run on TraviCI.
But this fails as the service [termbin](http://termbin.com) seems to truncate files after 1MB and refuse upload of files bigger than 16MB.

What I propose here is a very simple fix:
Upload all log files to [file.io](https://file.io) as well as termbin.
Their service allows for files up to 5GB and sets a default expiration of 14 days (could be configured if that is not enough).

The output would look something like this:
```
{"success":true,"key":"25Sosc","link":"https://file.io/25Sosc","expiry":"14 days"}
```

Advantages:
 * Integration test log files can be viewed again
 * No additional maintenance script to delete old files is needed
 * Free service with a nice attitude: 

> It was created simply out of the joy of trying to build cool things on the internet, and we thought it may be useful for others. We take privacy very seriously and do not save any data once it has been deleted.

Disadvantages:
 * You need to download all files even if you just want to see one, since they are all in an archive
 * Trust a third party service to be reliable
