### PR TITLE
lncli: add command to delegate macaroons

### DIFF
--- a/cmd/lncli/main.go
+++ b/cmd/lncli/main.go
@@ -298,6 +298,7 @@ func main() {
 		exportChanBackupCommand,
 		verifyChanBackupCommand,
 		restoreChanBackupCommand,
+		delegateMacaroonCommand,
 	}
 
 	// Add any extra commands determined by build flags.


### PR DESCRIPTION
This PR addresses #283 and introduces the new command `delegatemacaroon` to the `lncli` tool.

Currently, this just exposes the functionality that the `lncli` already uses internally to the command line interface:
* Take an existing macaroon (by specifying `--macaroonpath`, default is `~/.lnd/admin.macaroon`)
* [optional] Add a timeout to it (by specifying `--timeout`)
* [optional] Restrict it to a specific IP address (by specifying `--ip_address`)

Depending on the `--format` parameter, the following output is produced (truncated for brevity):

**`lncli delegatemacaroon --format=json --timeout=3600 --ip_address=123.123.123.123`**:
```json
{
        "c": [
                {
                        "i": "time-before 2018-04-28T16:02:23.47112259Z"
                },
                {
                        "i": "ipaddr 123.123.123.123"
                }
        ],
        "l": "lnd",
        "i64": "AwoQ7V1quyefYWYwh9TyFCJCBhIBMBoWCgdhZGRyZXNzEgRy....",
        "s64": "BqjN2qrARiy4dRfX7H__3t0XRWqXtVjNs5gyXL7oU9Q"
}
```

**`lncli delegatemacaroon --format=hex --timeout=3600 --ip_address=123.123.123.123`**:
```json
{
        "macaroonHex": "0201036c6e6402bb01030a10ed5d6abb279f61663..."
}
```

Once new first-party caveats are introduced, they can be implemented here as well.

@aakselrod:
Does this cover your idea as described in #283?
As I see it, there are at least two ways to delegate macaroons in `lnd`:
1. Take one of the three existing macaroon files (`admin.macaroon`, `invoice.macaroon` and `readonly.macaroon`) and add first-party caveats to them (as implemented in this PR).
1. Bake fresh macaroons by using the encrypted root key in `macaroons.db` and define custom operations/permissions. Then add first-party caveats to those newly baked macaroons.
The second option has the advantage that the user can customize the allowed operations/permissions. But the big disadvantage that the `macaroons.db` need to be unlocked (`lnd` needs to be stopped) and decrypted with the wallet password.

Am I correct in the assumption that you meant to implement option 1 in your issue, instead of option 2?

Thanks for your feedback!