### PR TITLE
Docker: Build LND locally rather than pulling down from GitHub

### DIFF
--- a/docker/lnd/Dockerfile
+++ b/docker/lnd/Dockerfile
@@ -1,26 +1,35 @@
-FROM golang:1.10
+FROM golang:1.10-alpine as builder
 
 MAINTAINER Olaoluwa Osuntokun <lightning.engineering>
 
-# Expose lnd ports (server, rpc).
-EXPOSE 9735 10009
+# Copy in the local repository to build from.
+COPY . /go/src/github.com/lightningnetwork/lnd
 
 # Force Go to use the cgo based DNS resolver. This is required to ensure DNS
 # queries required to connect to linked containers succeed.
 ENV GODEBUG netdns=cgo
 
-# Install dep to manage vendor.
-RUN go get -u github.com/golang/dep/cmd/dep
-
-# Grab and install the latest version of lnd and all related dependencies.
-RUN git clone https://github.com/lightningnetwork/lnd $GOPATH/src/github.com/lightningnetwork/lnd
-
-# Make lnd folder default.
-WORKDIR $GOPATH/src/github.com/lightningnetwork/lnd
-
 # Install dependencies and install/build lnd.
-RUN dep ensure
-RUN go install . ./cmd/...
+RUN apk add --no-cache \
+    git \
+    make \
+&&  cd /go/src/github.com/lightningnetwork/lnd \
+&&  make
 
+# Start a new, final image to reduce size.
+FROM alpine as final
+
+# Expose lnd ports (server, rpc).
+EXPOSE 9735 10009
+
+# Copy the binaries and entrypoint from the builder image.
+COPY --from=builder /go/src/github.com/lightningnetwork/lnd/lncli /bin/
+COPY --from=builder /go/src/github.com/lightningnetwork/lnd/lnd /bin/
+
+# Add bash.
+RUN apk add --no-cache \
+    bash
+
+# Copy the entrypoint script.
 COPY "docker/lnd/start-lnd.sh" .
 RUN chmod +x start-lnd.sh


### PR DESCRIPTION
PR closes #1167.  Only modified the `lnd` Dockerfile.

Functionally identical to before.  Changes are:

* Copies the repository into the container before building, to allow local changes to be used.
* Uses alpine containers for smaller resultant images
* Uses a disposable build container for even smaller resultant image.