### PR TITLE
channeldb: abstract out calls to bolt.DB

### DIFF
--- a/contractcourt/briefcase.go
+++ b/contractcourt/briefcase.go
@@ -281,7 +281,7 @@ var (
 // boltArbitratorLog is an implementation of the ArbitratorLog interface backed
 // by a bolt DB instance.
 type boltArbitratorLog struct {
-	db *bolt.DB
+	db *channeldb.DB
 
 	cfg ChannelArbitratorConfig
 
@@ -290,7 +290,7 @@ type boltArbitratorLog struct {
 
 // newBoltArbitratorLog returns a new instance of the boltArbitratorLog given
 // an arbitrator config, and the items needed to create its log scope.
-func newBoltArbitratorLog(db *bolt.DB, cfg ChannelArbitratorConfig,
+func newBoltArbitratorLog(db *channeldb.DB, cfg ChannelArbitratorConfig,
 	chainHash chainhash.Hash, chanPoint wire.OutPoint) (*boltArbitratorLog, error) {
 
 	scope, err := newLogScope(chainHash, chanPoint)

--- a/contractcourt/briefcase_test.go
+++ b/contractcourt/briefcase_test.go
@@ -10,7 +10,6 @@ import (
 
 	prand "math/rand"
 
-	"github.com/coreos/bbolt"
 	"github.com/davecgh/go-spew/spew"
 	"github.com/lightningnetwork/lnd/channeldb"
 	"github.com/lightningnetwork/lnd/lnwallet"
@@ -95,7 +94,7 @@ var (
 	}
 )
 
-func makeTestDB() (*bolt.DB, func(), error) {
+func makeTestDB() (*channeldb.DB, func(), error) {
 	// First, create a temporary directory to be used for the duration of
 	// this test.
 	tempDirName, err := ioutil.TempDir("", "arblog")
@@ -103,7 +102,7 @@ func makeTestDB() (*bolt.DB, func(), error) {
 		return nil, nil, err
 	}
 
-	db, err := bolt.Open(tempDirName+"/test.db", 0600, nil)
+	db, err := channeldb.Open(tempDirName + "/test.db")
 	if err != nil {
 		return nil, nil, err
 	}

--- a/contractcourt/chain_arbitrator.go
+++ b/contractcourt/chain_arbitrator.go
@@ -243,7 +243,7 @@ func newActiveChannelArbitrator(channel *channeldb.OpenChannel,
 	// TODO(roasbeef); abstraction leak...
 	//  * rework: adaptor method to set log scope w/ factory func
 	chanLog, err := newBoltArbitratorLog(
-		c.chanSource.DB, arbCfg, c.cfg.ChainHash, chanPoint,
+		c.chanSource, arbCfg, c.cfg.ChainHash, chanPoint,
 	)
 	if err != nil {
 		blockEpoch.Cancel()
@@ -392,7 +392,7 @@ func (c *ChainArbitrator) Start() error {
 			ChainEvents:           &ChainEventSubscription{},
 		}
 		chanLog, err := newBoltArbitratorLog(
-			c.chanSource.DB, arbCfg, c.cfg.ChainHash, chanPoint,
+			c.chanSource, arbCfg, c.cfg.ChainHash, chanPoint,
 		)
 		if err != nil {
 			blockEpoch.Cancel()


### PR DESCRIPTION
**Problem:**
Creating a bolt.DB requires use of file IO (bolt.Open calls os.OpenFile, and is the only sane way to make a bolt.DB).

This results in difficulties in unit testing:
1. Test DBs are harder to create than they should be.
2. Setting up test DBs with appropriate test data is MUCH harder than it could be with a test dummy.
2. A test isn't actually a unit test if it relies upon IO.

This problem is compounded by the following situations:
1. server.go can't be unit tested without using a bolt.DB.
2. Most of the lnd codebase _currently_ has explicit dependencies upon bolt.DB.

**Potential Solution 1 (present in this PR):**
Create an interface, DBSource, which matches the relevant portion of the bolt.DB API, and replace the instance of bolt.DB within channel.DB with an instance of DBSource.

**Potential Solution 2 (similar and slightly better, but with more code churn):**
Same as above, except channel.DB is changed into that interface (but with GetDBPath present too).

This solution seems better since it removes one unnecessary level of abstraction, but every time "*DB" is stored in a struct, it must now be replaced with just "DB" (affecting perhaps 15 structs). I'm happy to go down this route, I just need confirmation that the code churn is acceptable.

**Potential follow-up items**
- Remove direct dependencies on channeldb.DB throughout the code base.
- Move channeldb.DB to it's own package which doesn't reference channels. ChainArbitrator half-heartedly tried to break the association with channels by passing around a raw bolt.DB (but this was changed in this PR in order to increase the consistency of the code-base and improve the unit-testability of chain arbiter).