### PR TITLE
neutrino: error if we get a nil cfilter back

### DIFF
--- a/routing/chainview/neutrino.go
+++ b/routing/chainview/neutrino.go
@@ -241,6 +241,10 @@ func (c *CfFilteredChainView) FilterBlock(blockHash *chainhash.Hash) (*FilteredB
 		return nil, err
 	}
 
+	if filter == nil {
+		return nil, fmt.Errorf("Unable to fetch filter")
+	}
+
 	// Before we can match the filter, we'll need to map each item in our
 	// chain filter to the representation that included in the compact
 	// filters.


### PR DESCRIPTION
When upgrading from v0.4.1-beta, the cfilter database has to be dropped (as #1035 mentions). Without doing this, lnd returned a nil filter when it was unable to add the new cfilter to the old chain, and then segfault when it tried to use it. This PR just adds an error if it doesn't get a filter instead (which ends up causing lnd to terminate cleanly).