### PR TITLE
[WIP, feedback wanted] macaroons: add new request hash caveat to improve replay protection

### DIFF
--- a/docs/grpc/javascript.md
+++ b/docs/grpc/javascript.md
@@ -185,7 +185,7 @@ var lnrpcDescriptor = grpc.load("rpc.proto");
 var lnrpc = lnrpcDescriptor.lnrpc;
 var client = new lnrpc.Lightning('some.address:10009', grpc.credentials.createInsecure());
 
-client.getInfo({}, meta);
+client.getInfo({}, meta, (err, res) => { ... });
 ```
 
 However, this can get tiresome to do for each request, so to avoid explicitly including the macaroon we can update the credentials to include it automatically.

--- a/lnd.go
+++ b/lnd.go
@@ -338,11 +338,12 @@ func Main(lisCfg ListenerCfg) error {
 		// Create the macaroon authentication/authorization service.
 		macaroonService, err = macaroons.NewService(
 			networkDir, macaroons.IPLockChecker,
+			macaroons.RequestHashChecker,
 		)
 		if err != nil {
-			err := fmt.Errorf("Unable to set up macaroon "+
+			err := fmt.Errorf("unable to set up macaroon "+
 				"authentication: %v", err)
-			ltndLog.Error(err)
+			srvrLog.Error(err)
 			return err
 		}
 		defer macaroonService.Close()

--- a/macaroons/service.go
+++ b/macaroons/service.go
@@ -1,7 +1,9 @@
 package macaroons
 
 import (
+	"crypto/sha256"
 	"encoding/hex"
+	"encoding/json"
 	"fmt"
 	"os"
 	"path"
@@ -103,8 +105,23 @@ func isRegistered(c *checkers.Checker, name string) bool {
 	return false
 }
 
-// UnaryServerInterceptor is a GRPC interceptor that checks whether the
-// request is authorized by the included macaroons.
+// requestHash builds a SHA256 hash out of a request object (if available)
+// and the request URI.
+func requestHash(req interface{}, uri string) string {
+	strToHash := ""
+	reqJSON, err := json.Marshal(req)
+	if err == nil {
+		strToHash = string(reqJSON)
+	}
+	sum256 := sha256.Sum256([]byte(uri + strToHash))
+	return hex.EncodeToString(sum256[:])
+}
+
+// UnaryServerInterceptor is a gRPC interceptor for synchronous incoming
+// (server side) requests that checks whether the request is authorized by the
+// included macaroons. It also calculates the SHA256 hash of the incoming
+// request object and stores it in the context for further macaroon caveat
+// checkers to verify.
 func (svc *Service) UnaryServerInterceptor(
 	permissionMap map[string][]bakery.Op) grpc.UnaryServerInterceptor {
 
@@ -112,50 +129,121 @@ func (svc *Service) UnaryServerInterceptor(
 		info *grpc.UnaryServerInfo,
 		handler grpc.UnaryHandler) (interface{}, error) {
 
+		// Check that there is a permission defined for the full method
+		// of the incoming request. Then validate every caveat of the
+		// macaroon.
 		if _, ok := permissionMap[info.FullMethod]; !ok {
 			return nil, fmt.Errorf("%s: unknown permissions "+
 				"required for method", info.FullMethod)
 		}
-
-		err := svc.ValidateMacaroon(ctx, permissionMap[info.FullMethod])
+		err := svc.ValidateMacaroon(
+			ctx, req, info.FullMethod,
+			permissionMap[info.FullMethod],
+		)
 		if err != nil {
 			return nil, err
 		}
-
 		return handler(ctx, req)
 	}
 }
 
-// StreamServerInterceptor is a GRPC interceptor that checks whether the
-// request is authorized by the included macaroons.
+// UnaryClientInterceptor is a gRPC interceptor for synchronous outgoing
+// (client side) requests that calculates the SHA256 sum of the request
+// object and adds that as a first-party caveat to the macaroon for
+// better replay protection.
+func UnaryClientInterceptor(
+	mac *macaroon.Macaroon) grpc.UnaryClientInterceptor {
+	return func(ctx context.Context, method string, req, reply interface{},
+		cc *grpc.ClientConn, invoker grpc.UnaryInvoker,
+		opts ...grpc.CallOption) error {
+
+		// Add a new constraint to the macaroon that checks the hash of
+		// the request object and method. Since the whole interceptor is
+		// only added if the request hash check is enabled, we don't
+		// need to check that here again.
+		mac, err := AddConstraints(
+			mac, RequestHashConstraint(requestHash(req, method)),
+		)
+		if err != nil {
+			return fmt.Errorf("error adding constraint: %v", err)
+		}
+		cred := NewMacaroonCredential(mac)
+		opts = append(opts, grpc.PerRPCCredentials(cred))
+		return invoker(ctx, method, req, reply, cc, opts...)
+	}
+}
+
+// StreamServerInterceptor is a gRPC interceptor for streaming incoming
+// (server side) requests that checks whether the request is authorized by the
+// included macaroons. It also calculates the SHA256 hash of the incoming
+// method name and stores it in the context for further macaroon caveat
+// checkers to verify.
 func (svc *Service) StreamServerInterceptor(
 	permissionMap map[string][]bakery.Op) grpc.StreamServerInterceptor {
 
 	return func(srv interface{}, ss grpc.ServerStream,
 		info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
 
+		// Check that there is a permission defined for the full method
+		// of the incoming request. Then validate every caveat of the
+		// macaroon.
 		if _, ok := permissionMap[info.FullMethod]; !ok {
-			return fmt.Errorf("%s: unknown permissions required "+
-				"for method", info.FullMethod)
+			return fmt.Errorf(
+				"%s: unknown permissions required for method",
+				info.FullMethod,
+			)
 		}
-
 		err := svc.ValidateMacaroon(
-			ss.Context(), permissionMap[info.FullMethod],
+			ss.Context(), nil, info.FullMethod,
+			permissionMap[info.FullMethod],
 		)
 		if err != nil {
 			return err
 		}
-
 		return handler(srv, ss)
 	}
 }
 
+// StreamClientInterceptor is a gRPC interceptor for streaming outgoing
+// (client side) requests that calculates the SHA256 sum of the method name
+// and adds that as a first-party caveat to the macaroon for better replay
+// protection.
+func StreamClientInterceptor(
+	mac *macaroon.Macaroon) grpc.StreamClientInterceptor {
+	return func(ctx context.Context, desc *grpc.StreamDesc,
+		cc *grpc.ClientConn, method string, streamer grpc.Streamer,
+		opts ...grpc.CallOption) (grpc.ClientStream, error) {
+
+		// Add a new constraint to the macaroon that checks the hash of
+		// the request object and method. Since the whole interceptor is
+		// only added if the request hash check is enabled, we don't
+		// need to check that here again.
+		mac, err := AddConstraints(
+			mac, RequestHashConstraint(requestHash(nil, method)),
+		)
+		if err != nil {
+			return nil, fmt.Errorf(
+				"error adding constraint: %v", err,
+			)
+		}
+		cred := NewMacaroonCredential(mac)
+		opts = append(opts, grpc.PerRPCCredentials(cred))
+		return streamer(ctx, desc, cc, method, opts...)
+	}
+}
+
 // ValidateMacaroon validates the capabilities of a given request given a
-// bakery service, context, and uri. Within the passed context.Context, we
-// expect a macaroon to be encoded as request metadata using the key
-// "macaroon".
+// bakery service, context, request object uri and required permissions.
+// Within the passed context.Context, we expect a macaroon to be encoded as
+// request metadata using the key "macaroon".
 func (svc *Service) ValidateMacaroon(ctx context.Context,
-	requiredPermissions []bakery.Op) error {
+	req interface{}, uri string, requiredPermissions []bakery.Op) error {
+
+	// Since this is the only place where we get the full request object
+	// in a generic way, we need to calculate the hash of it here. We do
+	// this, even if the macaroon might not have a condition set for it.
+	// But the performance impact should be negligible.
+	ctx = context.WithValue(ctx, KeyRequestHash, requestHash(req, uri))
 
 	// Get macaroon bytes from context and unmarshal into macaroon.
 	md, ok := metadata.FromIncomingContext(ctx)


### PR DESCRIPTION
This PR addresses #285.

To make sure that a macaroon that is somehow intercepted during transmission cannot be used by an attacker, the `lncli` already sets a caveat for a 60 second timeout. Additionally, the macaroon can be locked down to a specific IP address.
With this PR the gRPC client (for now, just `lncli`, the feature can be disabled with `--no-macaroon-request-hash`) creates a SHA256 hash of the method name concatenated with the JSON serialized request gRPC object.
That hash is added to the macaroon as a first-party caveat named `request-hash`.
On the server side, this caveat is validated by hashing the method and request object again.

I'm not sure if I'm on the right track with my implementation. That's why I created the PR with the status 'work in progress'. I would really appreciate feedback on what I did, especially from @aakselrod since he created the original issue/feature request.

As I see it, the following questions arise from the way I implemented it:
* The solution works well for unary/synchronous requests, since the request data is available and can be hashed. For streaming/asynchronous requests, this cannot be done, because the macaroon is only sent at the beginning, when opening the connection. But through that connection, many requests can then be made and no further macaroon is required. For example, the `SendPayment` is a streaming command where several payments can be sent through the same stream but with only one macaroon that is sent at the beginning. So the only thing we can hash is the method name itself (like `lnrpc.SendPayment`). But if an attacker can sniff that macaroon, he can send payments himself (until the 60 second timeout runs out). So my question is: Does anyone have an idea on how to further improve the replay protection for streaming requests?
* The JSON serialization of a request object should produce the same output for the same object on all platforms/languages/libraries, because this is done by the gRPC library that should behave the same in Java, JavaScript, Python, Ruby, and so on. So it would be possible for this feature to work for other clients than just `lncli` and should in principle also be doable over the REST gateway. My question is: Should we provide code samples on how to do that for all languages? Should we maybe write some kind of simple integration tests for the languages we support?

This is the current state of the implementation:
- [x] Get the `request-hash` feature to work for unary/synchronous requests in `lncli`.
- [x] Get the `request-hash` feature to work for streaming/asynchronous requests in `lncli`.
- [x] Add a feature toggle parameter called `--no-macaroon-request-hash`.
- [x] Add a test for the `UnaryServerInterceptor`.
- [ ] Add documentation on how this is implemented in `lncli`.
- [ ] Add documentation on how the request hash feature can be used by app developers using the gRPC interface.
- [ ] Finish tests for all client and server interceptors.
- [ ] Manually test all unary and stream commands in `lncli`.
- [ ] Split commits into smaller changes

As always, thank you for your input!