### PR TITLE
lncli: improve error message for unlock commands

### DIFF
--- a/cmd/lncli/commands.go
+++ b/cmd/lncli/commands.go
@@ -69,13 +69,27 @@ func printRespJSON(resp proto.Message) {
 func actionDecorator(f func(*cli.Context) error) func(*cli.Context) error {
 	return func(c *cli.Context) error {
 		if err := f(c); err != nil {
+			s, ok := status.FromError(err)
+
+			// If it's a command for the UnlockerService (like
+			// 'create' or 'unlock') but the wallet is already
+			// unlocked, then these methods aren't recognized any
+			// more because this service is shut down after
+			// successful unlock. That's why the code
+			// 'Unimplemented' means something different for these
+			// two commands.
+			if s.Code() == codes.Unimplemented &&
+				(c.Command.Name == "create" ||
+					c.Command.Name == "unlock") {
+				return fmt.Errorf("Wallet is already unlocked")
+			}
+
 			// lnd might be active, but not possible to contact
 			// using RPC if the wallet is encrypted. If we get
 			// error code Unimplemented, it means that lnd is
 			// running, but the RPC server is not active yet (only
 			// WalletUnlocker server active) and most likely this
 			// is because of an encrypted wallet.
-			s, ok := status.FromError(err)
 			if ok && s.Code() == codes.Unimplemented {
 				return fmt.Errorf("Wallet is encrypted. " +
 					"Please unlock using 'lncli unlock', " +


### PR DESCRIPTION
As reported in #1191, if you issue the `unlock` or `create` command again after the wallet is already unlocked, you get a strange error message:
```
[lncli] Wallet is encrypted. Please unlock using 'lncli unlock', or set password using 'lncli create' if this is the first time starting lnd.
```
This is because the `UnlockerService` is shut down after successful unlock and therefore the unlock commands aren't recognized on the gRPC interface any more (status=Unimplemented).

I improved the error message for this special case since the current message is very misleading.

Fixes #1191. 