### PR TITLE
docs: add line wrap to contribution checklist

### DIFF
--- a/docs/code_contribution_guidelines.md
+++ b/docs/code_contribution_guidelines.md
@@ -461,6 +461,9 @@ Rejoice as you will now be listed as a [contributor](https://github.com/lightnin
 - [&nbsp;&nbsp;] Any new logging statements use an appropriate subsystem and
   logging level
 - [&nbsp;&nbsp;] Code has been formatted with `go fmt`
+- [&nbsp;&nbsp;] For code and documentation: lines are wrapped at 80 characters
+  (the tab character should be counted as 8 characters, not 4, as some IDEs do
+  per default)
 - [&nbsp;&nbsp;] Running `go test` does not fail any tests
 - [&nbsp;&nbsp;] Running `go vet` does not report any issues
 - [&nbsp;&nbsp;] Running [golint](https://github.com/golang/lint) does not


### PR DESCRIPTION
From reading the contribution guidelines, it was not really clear to me that lines of code should not be longer than 80 characters and that the tab character should be counted as 8 chars.
So after asking @halseth in the chat, we agreed that this should be mentioned in the guidelines.