### PR TITLE
router: Validation Barrier Shutdown

### DIFF
--- a/routing/validation_barrier.go
+++ b/routing/validation_barrier.go
@@ -1,11 +1,17 @@
 package routing
 
 import (
+	"errors"
 	"sync"
 
 	"github.com/lightningnetwork/lnd/channeldb"
 	"github.com/lightningnetwork/lnd/lnwire"
 )
+
+// ErrVBarrierShuttingDown signals that the barrier has been requested to
+// shutdown, and that the caller should not treat the wait condition as
+// fulfilled.
+var ErrVBarrierShuttingDown = errors.New("validation barrier shutting down")
 
 // ValidationBarrier is a barrier used to ensure proper validation order while
 // concurrently validating new announcements for channel edges, and the
@@ -152,7 +158,7 @@ func (v *ValidationBarrier) CompleteJob() {
 // finished executing. This allows us a graceful way to schedule goroutines
 // based on any pending uncompleted dependent jobs. If this job doesn't have an
 // active dependent, then this function will return immediately.
-func (v *ValidationBarrier) WaitForDependants(job interface{}) {
+func (v *ValidationBarrier) WaitForDependants(job interface{}) error {
 
 	var (
 		signal chan struct{}
@@ -181,13 +187,13 @@ func (v *ValidationBarrier) WaitForDependants(job interface{}) {
 	case *lnwire.AnnounceSignatures:
 		// TODO(roasbeef): need to wait on chan ann?
 		v.Unlock()
-		return
+		return nil
 	case *channeldb.ChannelEdgeInfo:
 		v.Unlock()
-		return
+		return nil
 	case *lnwire.ChannelAnnouncement:
 		v.Unlock()
-		return
+		return nil
 	}
 	v.Unlock()
 
@@ -196,10 +202,13 @@ func (v *ValidationBarrier) WaitForDependants(job interface{}) {
 	if ok {
 		select {
 		case <-v.quit:
-			return
+			return ErrVBarrierShuttingDown
 		case <-signal:
+			return nil
 		}
 	}
+
+	return nil
 }
 
 // SignalDependants will signal any jobs that are dependent on this job that

--- a/routing/validation_barrier_test.go
+++ b/routing/validation_barrier_test.go
@@ -1,0 +1,151 @@
+package routing_test
+
+import (
+	"encoding/binary"
+	"testing"
+	"time"
+
+	"github.com/lightningnetwork/lnd/lnwire"
+	"github.com/lightningnetwork/lnd/routing"
+)
+
+// TestValidationBarrierSemaphore checks basic properties of the validation
+// barrier's semaphore wrt. enqueuing/dequeuing.
+func TestValidationBarrierSemaphore(t *testing.T) {
+	const (
+		numTasks        = 8
+		numPendingTasks = 8
+		timeout         = 50 * time.Millisecond
+	)
+
+	quit := make(chan struct{})
+	barrier := routing.NewValidationBarrier(numTasks, quit)
+
+	// Saturate the semaphore with jobs.
+	for i := 0; i < numTasks; i++ {
+		barrier.InitJobDependencies(nil)
+	}
+
+	// Spawn additional tasks that will signal completion when added.
+	jobAdded := make(chan struct{})
+	for i := 0; i < numPendingTasks; i++ {
+		go func() {
+			barrier.InitJobDependencies(nil)
+			jobAdded <- struct{}{}
+		}()
+	}
+
+	// Check that no jobs are added while semaphore is full.
+	select {
+	case <-time.After(timeout):
+		// Expected since no slots open.
+	case <-jobAdded:
+		t.Fatalf("job should not have been added")
+	}
+
+	// Complete jobs one at a time and verify that they get added.
+	for i := 0; i < numPendingTasks; i++ {
+		barrier.CompleteJob()
+
+		select {
+		case <-time.After(timeout):
+			t.Fatalf("timeout waiting for job to be added")
+		case <-jobAdded:
+			// Expected since one slot opened up.
+		}
+	}
+}
+
+// TestValidationBarrierQuit checks that pending validation tasks will return an
+// error from WaitForDependants if the barrier's quit signal is canceled.
+func TestValidationBarrierQuit(t *testing.T) {
+	const (
+		numTasks = 8
+		timeout  = 50 * time.Millisecond
+	)
+
+	quit := make(chan struct{})
+	barrier := routing.NewValidationBarrier(2*numTasks, quit)
+
+	// Create a set of unique channel announcements that we will prep for
+	// validation.
+	anns := make([]*lnwire.ChannelAnnouncement, 0, numTasks)
+	for i := 0; i < numTasks; i++ {
+		anns = append(anns, &lnwire.ChannelAnnouncement{
+			ShortChannelID: lnwire.NewShortChanIDFromInt(uint64(i)),
+			NodeID1:        nodeIDFromInt(uint64(2 * i)),
+			NodeID2:        nodeIDFromInt(uint64(2*i + 1)),
+		})
+		barrier.InitJobDependencies(anns[i])
+	}
+
+	// Create a set of channel updates, that must wait until their
+	// associated channel announcement has been verified.
+	chanUpds := make([]*lnwire.ChannelUpdate, 0, numTasks)
+	for i := 0; i < numTasks; i++ {
+		chanUpds = append(chanUpds, &lnwire.ChannelUpdate{
+			ShortChannelID: lnwire.NewShortChanIDFromInt(uint64(i)),
+		})
+		barrier.InitJobDependencies(chanUpds[i])
+	}
+
+	// Spawn additional tasks that will send the error returned after
+	// waiting for the announcements to finish. In the background, we will
+	// iteratively queue the channel updates, which will send back the error
+	// returned from waiting.
+	jobErrs := make(chan error)
+	for i := 0; i < numTasks; i++ {
+		go func(ii int) {
+			jobErrs <- barrier.WaitForDependants(chanUpds[ii])
+		}(i)
+	}
+
+	// Check that no jobs are added while semaphore is full.
+	select {
+	case <-time.After(timeout):
+		// Expected since no slots open.
+	case <-jobErrs:
+		t.Fatalf("job should not have been signaled")
+	}
+
+	// Complete the first half of jobs, one at a time, verifying that they
+	// get signaled. Then, quit the barrier and check that all others exit
+	// with the correct error.
+	for i := 0; i < numTasks; i++ {
+		switch {
+		// First half, signal completion and task semaphore
+		case i < numTasks/2:
+			barrier.SignalDependants(anns[i])
+			barrier.CompleteJob()
+
+		// At midpoint, quit the validation barrier.
+		case i == numTasks/2:
+			close(quit)
+		}
+
+		var err error
+		select {
+		case <-time.After(timeout):
+			t.Fatalf("timeout waiting for job to be signaled")
+		case err = <-jobErrs:
+		}
+
+		switch {
+		// First half should return without failure.
+		case i < numTasks/2 && err != nil:
+			t.Fatalf("unexpected failure while waiting: %v", err)
+
+		// Last half should return the shutdown error.
+		case i >= numTasks/2 && err != routing.ErrVBarrierShuttingDown:
+			t.Fatalf("expected failure after quitting: want %v, "+
+				"got %v", routing.ErrVBarrierShuttingDown, err)
+		}
+	}
+}
+
+// nodeIDFromInt creates a node ID by writing a uint64 to the first 8 bytes.
+func nodeIDFromInt(i uint64) [33]byte {
+	var nodeID [33]byte
+	binary.BigEndian.PutUint64(nodeID[:8], i)
+	return nodeID
+}


### PR DESCRIPTION
This commit improves the shutdown of the router's
pending validation tasks, by ensuring the pending
tasks exit early if the validation barrier
receives a shutdown request.

Currently, any goroutines blocked by `WaitForDependants`
will continue execution after a shutdown is signaled.
This may lead to unnexpected behavior as the relation
between updates is no longer upheld. It also has the
side effect of slowing down shutdown, since we
continue to process the remaining updates.

To remedy this, `WaitForDependants` now returns an error
that signals if a shutdown was requested. The blocked
goroutines can exit early upon seeing this error,
without also signaling completion of their task to
the dependent tasks, which should will now properly
wait to read the validation barrier's quit signal.