### PR TITLE
htlcswitch+server: ensure we always send an update w/ a TempChannelFa…

### DIFF
--- a/htlcswitch/link_test.go
+++ b/htlcswitch/link_test.go
@@ -1460,7 +1460,12 @@ func newSingleLinkTestHarness(chanAmt, chanReserve btcutil.Amount) (
 
 	aliceDb := aliceChannel.State().Db
 
-	aliceSwitch, err := New(Config{DB: aliceDb})
+	aliceSwitch, err := New(Config{
+		DB: aliceDb,
+		FetchLastChannelUpdate: func(lnwire.ShortChannelID) (*lnwire.ChannelUpdate, error) {
+			return nil, nil
+		},
+	})
 	if err != nil {
 		return nil, nil, nil, nil, nil, err
 	}
@@ -3854,7 +3859,12 @@ func restartLink(aliceChannel *lnwallet.LightningChannel, aliceSwitch *Switch,
 
 	if aliceSwitch == nil {
 		var err error
-		aliceSwitch, err = New(Config{DB: aliceDb})
+		aliceSwitch, err = New(Config{
+			DB: aliceDb,
+			FetchLastChannelUpdate: func(lnwire.ShortChannelID) (*lnwire.ChannelUpdate, error) {
+				return nil, nil
+			},
+		})
 		if err != nil {
 			return nil, nil, nil, err
 		}

--- a/htlcswitch/mock.go
+++ b/htlcswitch/mock.go
@@ -140,6 +140,9 @@ func initSwitchWithDB(db *channeldb.DB) (*Switch, error) {
 		FwdingLog: &mockForwardingLog{
 			events: make(map[time.Time]channeldb.ForwardingEvent),
 		},
+		FetchLastChannelUpdate: func(lnwire.ShortChannelID) (*lnwire.ChannelUpdate, error) {
+			return nil, nil
+		},
 	})
 }
 

--- a/htlcswitch/switch.go
+++ b/htlcswitch/switch.go
@@ -135,6 +135,13 @@ type Config struct {
 	// error encrypters stored in the circuit map on restarts, since they
 	// are not stored directly within the database.
 	ExtractErrorEncrypter ErrorEncrypterExtracter
+
+	// FetchLastChannelUpdate retrieves the latest routing policy for a
+	// target channel. This channel will typically be the outgoing channel
+	// specified when we receive an incoming HTLC.  This will be used to
+	// provide payment senders our latest policy when sending encrypted
+	// error messages.
+	FetchLastChannelUpdate func(lnwire.ShortChannelID) (*lnwire.ChannelUpdate, error)
 }
 
 // Switch is the central messaging bus for all incoming/outgoing HTLCs.
@@ -458,7 +465,10 @@ func (s *Switch) forward(packet *htlcPacket) error {
 				return err
 			}
 
-			failure := lnwire.NewTemporaryChannelFailure(nil)
+			update, _ := s.cfg.FetchLastChannelUpdate(
+				packet.incomingChanID,
+			)
+			failure := lnwire.NewTemporaryChannelFailure(update)
 			addErr := ErrIncompleteForward
 
 			return s.failAddPacket(packet, failure, addErr)
@@ -589,7 +599,10 @@ func (s *Switch) ForwardPackets(packets ...*htlcPacket) chan error {
 	// left in a half added state, which can happen when recovering from
 	// failures.
 	for _, packet := range failedPackets {
-		failure := lnwire.NewTemporaryChannelFailure(nil)
+		update, _ := s.cfg.FetchLastChannelUpdate(
+			packet.incomingChanID,
+		)
+		failure := lnwire.NewTemporaryChannelFailure(update)
 		addErr := errors.Errorf("failing packet after detecting " +
 			"incomplete forward")
 
@@ -749,6 +762,8 @@ func (s *Switch) handleLocalDispatch(pkt *htlcPacket) error {
 				htlc.Amount, largestBandwidth)
 			log.Error(err)
 
+			// Note that we don't need to populate an update here,
+			// as this will go directly back to the router.
 			htlcErr := lnwire.NewTemporaryChannelFailure(nil)
 			return &ForwardingError{
 				ErrorSource:    s.cfg.SelfKey,
@@ -812,6 +827,10 @@ func (s *Switch) parseFailedPayment(payment *pendingPayment, pkt *htlcPacket,
 			userErr = fmt.Sprintf("unable to decode onion failure, "+
 				"htlc with hash(%x): %v", payment.paymentHash[:], err)
 			log.Error(userErr)
+
+			// As this didn't even clear the link, we don't need to
+			// apply an update here since it goes directly to the
+			// router.
 			failureMsg = lnwire.NewTemporaryChannelFailure(nil)
 		}
 		failure = &ForwardingError{
@@ -938,7 +957,10 @@ func (s *Switch) handlePacketForward(packet *htlcPacket) error {
 			// If packet was forwarded from another channel link
 			// than we should notify this link that some error
 			// occurred.
-			failure := lnwire.NewTemporaryChannelFailure(nil)
+			update, _ := s.cfg.FetchLastChannelUpdate(
+				packet.outgoingChanID,
+			)
+			failure := lnwire.NewTemporaryChannelFailure(update)
 			addErr := errors.Errorf("unable to find appropriate "+
 				"channel link insufficient capacity, need "+
 				"%v", htlc.Amount)
@@ -1799,7 +1821,7 @@ func (s *Switch) UpdateShortChanID(chanID lnwire.ChannelID,
 
 	s.indexMtx.Lock()
 
-	// First, we'll extract the current link as is from the link 
+	// First, we'll extract the current link as is from the link
 	// index. If the link isn't even in the index, then we'll return an
 	// error.
 	link, ok := s.linkIndex[chanID]

--- a/server.go
+++ b/server.go
@@ -237,6 +237,9 @@ func newServer(listenAddrs []string, chanDB *channeldb.DB, cc *chainControl,
 		FwdingLog:             chanDB.ForwardingLog(),
 		SwitchPackager:        channeldb.NewSwitchPackager(),
 		ExtractErrorEncrypter: s.sphinx.ExtractErrorEncrypter,
+		FetchLastChannelUpdate: fetchLastChanUpdate(
+			p.server.chanRouter, p.PubKey(),
+		),
 	})
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
…ilure

In this commit, we ensure that any time we send a TempChannelFailure
that's destined for a multi-hop source sender, then we'll always package
the latest channel update along with it.

Fixes #1126.