### PR TITLE
[htlcswitch] Optionally force close channel on link failure

### DIFF
--- a/contractcourt/channel_arbitrator.go
+++ b/contractcourt/channel_arbitrator.go
@@ -85,8 +85,10 @@ type ChannelArbitratorConfig struct {
 
 	// ForceCloseChan should force close the contract that this attendant
 	// is watching over. We'll use this when we decide that we need to go
-	// to chain. The returned summary contains all items needed to
-	// eventually resolve all outputs on chain.
+	// to chain. It should in addition tell the switch to remove the
+	// corresponding link, such that we won't accept any new updates. The
+	// returned summary contains all items needed to eventually resolve all
+	// outputs on chain.
 	ForceCloseChan func() (*lnwallet.LocalForceCloseSummary, error)
 
 	// MarkCommitmentBroadcasted should mark the channel as the commitment
@@ -434,9 +436,10 @@ func (c *ChannelArbitrator) stateStep(triggerHeight uint32,
 		// Now that we have all the actions decided for the set of
 		// HTLC's, we'll broadcast the commitment transaction, and
 		// signal the link to exit.
-		//
-		// TODO(roasbeef): need to report to switch that channel is
-		// inactive, should close link
+
+		// We'll tell the switch that it should remove the link for
+		// this channel, in addition to fetching the force close
+		// summary needed to close this channel on chain.
 		closeSummary, err := c.cfg.ForceCloseChan()
 		if err != nil {
 			log.Errorf("ChannelArbitrator(%v): unable to "+

--- a/htlcswitch/hodl/config.go
+++ b/htlcswitch/hodl/config.go
@@ -21,6 +21,8 @@ type Config struct {
 	FailOutgoing bool `long:"fail-outgoing" description:"Instructs the node to drop outgoing FAILs before applying them to the channel state"`
 
 	Commit bool `long:"commit" description:"Instructs the node to add HTLCs to its local commitment state and to open circuits for any ADDs, but abort before committing the changes"`
+
+	BogusSettle bool `long:"bogus-settle" description:"Instructs the node to settle back any incoming HTLC with a bogus preimage"`
 }
 
 // Mask extracts the flags specified in the configuration, composing a Mask from
@@ -51,6 +53,9 @@ func (c *Config) Mask() Mask {
 	}
 	if c.Commit {
 		flags = append(flags, Commit)
+	}
+	if c.BogusSettle {
+		flags = append(flags, BogusSettle)
 	}
 
 	// NOTE: The value returned here will only honor the configuration if

--- a/htlcswitch/hodl/flags.go
+++ b/htlcswitch/hodl/flags.go
@@ -51,6 +51,10 @@ const (
 	// Commit drops all HTLC after any outgoing circuits have been
 	// opened, but before the in-memory commitment state is persisted.
 	Commit
+
+	// BogusSettle attempts to settle back any incoming HTLC for which we
+	// are the exit node with a bogus preimage.
+	BogusSettle
 )
 
 // String returns a human-readable identifier for a given Flag.
@@ -72,6 +76,8 @@ func (f Flag) String() string {
 		return "FailOutgoing"
 	case Commit:
 		return "Commit"
+	case BogusSettle:
+		return "BogusSettle"
 	default:
 		return "UnknownHodlFlag"
 	}
@@ -98,6 +104,8 @@ func (f Flag) Warning() string {
 		msg = "will not update channel state with downstream FAIL"
 	case Commit:
 		msg = "will not commit pending channel updates"
+	case BogusSettle:
+		msg = "will settle HTLC with bogus preimage"
 	default:
 		msg = "incorrect hodl flag usage"
 	}

--- a/htlcswitch/hodl/mask_test.go
+++ b/htlcswitch/hodl/mask_test.go
@@ -67,6 +67,7 @@ var hodlMaskTests = []struct {
 			hodl.SettleOutgoing,
 			hodl.FailOutgoing,
 			hodl.Commit,
+			hodl.BogusSettle,
 		),
 		flags: map[hodl.Flag]struct{}{
 			hodl.ExitSettle:     {},
@@ -77,6 +78,7 @@ var hodlMaskTests = []struct {
 			hodl.SettleOutgoing: {},
 			hodl.FailOutgoing:   {},
 			hodl.Commit:         {},
+			hodl.BogusSettle:    {},
 		},
 	},
 }

--- a/htlcswitch/interfaces.go
+++ b/htlcswitch/interfaces.go
@@ -130,10 +130,6 @@ type Peer interface {
 
 	// PubKey returns the serialize public key of the source peer.
 	PubKey() [33]byte
-
-	// Disconnect disconnects with peer if we have error which we can't
-	// properly handle.
-	Disconnect(reason error)
 }
 
 // ForwardingLog is an interface that represents a time series database which

--- a/htlcswitch/link.go
+++ b/htlcswitch/link.go
@@ -2206,6 +2206,16 @@ func (l *channelLink) processRemoteAdds(fwdPkg *channeldb.FwdPkg,
 
 			l.infof("settling %x as exit hop", pd.RHash)
 
+			// If the link is in hodl.BogusSettle mode, replace the
+			// preimage with a fake one before sending it to the
+			// peer.
+			if l.cfg.DebugHTLC &&
+				l.cfg.HodlMask.Active(hodl.BogusSettle) {
+				l.warnf(hodl.BogusSettle.Warning())
+				preimage = [32]byte{}
+				copy(preimage[:], bytes.Repeat([]byte{2}, 32))
+			}
+
 			// HTLC was successfully settled locally send
 			// notification about it remote peer.
 			l.cfg.Peer.SendMessage(&lnwire.UpdateFulfillHTLC{

--- a/htlcswitch/link_test.go
+++ b/htlcswitch/link_test.go
@@ -1396,6 +1396,8 @@ type mockPeer struct {
 	quit         chan struct{}
 }
 
+var _ Peer = (*mockPeer)(nil)
+
 func (m *mockPeer) SendMessage(msg lnwire.Message, sync bool) error {
 	if m.disconnected {
 		return fmt.Errorf("disconnected")
@@ -1412,8 +1414,6 @@ func (m *mockPeer) WipeChannel(*wire.OutPoint) error {
 }
 func (m *mockPeer) PubKey() [33]byte {
 	return [33]byte{}
-}
-func (m *mockPeer) Disconnect(reason error) {
 }
 
 var _ Peer = (*mockPeer)(nil)

--- a/htlcswitch/linkfailure.go
+++ b/htlcswitch/linkfailure.go
@@ -1,0 +1,95 @@
+package htlcswitch
+
+import "github.com/go-errors/errors"
+
+var (
+	// ErrLinkShuttingDown signals that the link is shutting down.
+	ErrLinkShuttingDown = errors.New("link shutting down")
+)
+
+// errorCode encodes the possible types of errors that will make us fail the
+// current link.
+type errorCode uint8
+
+const (
+	// ErrInternalError indicates that something internal in the link
+	// failed. In this case we will send a generic error to our peer.
+	ErrInternalError errorCode = iota
+
+	// ErrRemoteError indicates that our peer sent an error, prompting up
+	// to fail the link.
+	ErrRemoteError
+
+	// ErrSyncError indicates that we failed synchronizing the state of the
+	// channel with our peer.
+	ErrSyncError
+
+	// ErrInvalidUpdate indicates that the peer send us an invalid update.
+	ErrInvalidUpdate
+
+	// ErrInvalidCommitment indicates that the remote peer sent us an
+	// invalid commitment signature.
+	ErrInvalidCommitment
+
+	// ErrInvalidRevocation indicates that the remote peer send us an
+	// invalid revocation message.
+	ErrInvalidRevocation
+)
+
+// LinkFailureError encapsulates an error that will make us fail the current
+// link. It contains the necessary information needed to determine if we should
+// force close the channel in the process, and if any error data should be sent
+// to the peer.
+type LinkFailureError struct {
+	// code is the type of error this LinkFailureError encapsulates.
+	code errorCode
+
+	// ForceClose indicates whether we should force close the channel
+	// because of this error.
+	ForceClose bool
+
+	// SendData is a byte slice that will be sent to the peer. If nil a
+	// generic error will be sent.
+	SendData []byte
+}
+
+// A compile time check to ensure LinkFailureError implements the error
+// interface.
+var _ error = (*LinkFailureError)(nil)
+
+// Error returns a generic error for the LinkFailureError.
+//
+// NOTE: Part of the error interface.
+func (e LinkFailureError) Error() string {
+	switch e.code {
+	case ErrInternalError:
+		return "internal error"
+	case ErrRemoteError:
+		return "remote error"
+	case ErrSyncError:
+		return "sync error"
+	case ErrInvalidUpdate:
+		return "invalid update"
+	case ErrInvalidCommitment:
+		return "invalid commitment"
+	case ErrInvalidRevocation:
+		return "invalid revocation"
+	default:
+		return "unknown error"
+	}
+}
+
+// ShouldSendToPeer indicates whether we should send an error to the peer if
+// the link fails with this LinkFailureError.
+func (e LinkFailureError) ShouldSendToPeer() bool {
+	switch e.code {
+	// If the failure is a result of the peer sending us an error, we don't
+	// have to respond with one.
+	case ErrRemoteError:
+		return false
+
+	// In all other cases we will attempt to send our peer an error message.
+	default:
+		return true
+	}
+}

--- a/htlcswitch/mock.go
+++ b/htlcswitch/mock.go
@@ -506,12 +506,6 @@ func (s *mockServer) PubKey() [33]byte {
 	return s.id
 }
 
-func (s *mockServer) Disconnect(reason error) {
-	fmt.Printf("server %v disconnected due to %v\n", s.name, reason)
-
-	s.t.Fatalf("server %v was disconnected: %v", s.name, reason)
-}
-
 func (s *mockServer) WipeChannel(*wire.OutPoint) error {
 	return nil
 }


### PR DESCRIPTION
This PR adds the option to force close a channel in case of a failure within the link. Now calls to `fail(...)` will always mark the channel inactive and disconnect the peer, and can optionally force close the channel.

### TODO:
- [x] determine which cases we want to force close the channel for sure. Some cases are possible to recover from, and we should only force close if we absolutely _have to_.
- [x] expand unit test after decision is made on the above.
- [x] integration test?

Putting PR up to get some initial feedback.