### PR TITLE
lnwallet: enforce fee floor and dust-reserve adherence

### DIFF
--- a/fundingmanager.go
+++ b/fundingmanager.go
@@ -994,10 +994,10 @@ func (f *fundingManager) handleFundingOpen(fmsg *fundingOpenMsg) {
 	// party is attempting to dictate for our commitment transaction.
 	err = reservation.CommitConstraints(
 		msg.CsvDelay, msg.MaxAcceptedHTLCs, msg.MaxValueInFlight,
-		msg.HtlcMinimum, msg.ChannelReserve,
+		msg.HtlcMinimum, msg.ChannelReserve, msg.DustLimit,
 	)
 	if err != nil {
-		fndgLog.Errorf("Unaccaptable channel constraints: %v", err)
+		fndgLog.Errorf("Unacceptable channel constraints: %v", err)
 		f.failFundingFlow(fmsg.peerAddress.IdentityKey,
 			fmsg.msg.PendingChannelID, err,
 		)
@@ -1146,7 +1146,7 @@ func (f *fundingManager) handleFundingAccept(fmsg *fundingAcceptMsg) {
 	resCtx.reservation.SetNumConfsRequired(uint16(msg.MinAcceptDepth))
 	err = resCtx.reservation.CommitConstraints(
 		msg.CsvDelay, msg.MaxAcceptedHTLCs, msg.MaxValueInFlight,
-		msg.HtlcMinimum, msg.ChannelReserve,
+		msg.HtlcMinimum, msg.ChannelReserve, msg.DustLimit,
 	)
 	if err != nil {
 		fndgLog.Warnf("Unacceptable channel constraints: %v", err)

--- a/fundingmanager_test.go
+++ b/fundingmanager_test.go
@@ -294,8 +294,15 @@ func createTestFundingManager(t *testing.T, privKey *btcec.PrivateKey,
 		RequiredRemoteDelay: func(amt btcutil.Amount) uint16 {
 			return 4
 		},
-		RequiredRemoteChanReserve: func(chanAmt btcutil.Amount) btcutil.Amount {
-			return chanAmt / 100
+		RequiredRemoteChanReserve: func(chanAmt,
+			dustLimit btcutil.Amount) btcutil.Amount {
+
+			reserve := chanAmt / 100
+			if reserve < dustLimit {
+				reserve = dustLimit
+			}
+
+			return reserve
 		},
 		RequiredRemoteMaxValue: func(chanAmt btcutil.Amount) lnwire.MilliSatoshi {
 			reserve := lnwire.NewMSatFromSatoshis(chanAmt / 100)

--- a/lnwallet/errors.go
+++ b/lnwallet/errors.go
@@ -59,6 +59,15 @@ func ErrCsvDelayTooLarge(remoteDelay, maxDelay uint16) ReservationError {
 	}
 }
 
+// ErrChanReserveTooSmall returns an error indicating that the channel reserve
+// the remote is requiring is too small to be accepted.
+func ErrChanReserveTooSmall(reserve, dustLimit btcutil.Amount) ReservationError {
+	return ReservationError{
+		fmt.Errorf("channel reserve of %v sat is too small, min is %v "+
+			"sat", int64(reserve), int64(dustLimit)),
+	}
+}
+
 // ErrChanReserveTooLarge returns an error indicating that the chan reserve the
 // remote is requiring, is too large to be accepted.
 func ErrChanReserveTooLarge(reserve,

--- a/lnwallet/fee_estimator.go
+++ b/lnwallet/fee_estimator.go
@@ -95,6 +95,12 @@ type BtcdFeeEstimator struct {
 	// actually produce fee estimates.
 	fallBackFeeRate SatPerVByte
 
+	// minFeeRate is the minimum relay fee, in sat/vbyte, of the backend
+	// node. This will be used as the default fee rate of a transaction when
+	// the estimated fee rate is too low to allow the transaction to
+	// propagate through the network.
+	minFeeRate SatPerVByte
+
 	btcdConn *rpcclient.Client
 }
 
@@ -127,6 +133,22 @@ func (b *BtcdFeeEstimator) Start() error {
 	if err := b.btcdConn.Connect(20); err != nil {
 		return err
 	}
+
+	// Once the connection to the backend node has been established, we'll
+	// query it for its minimum relay fee.
+	info, err := b.btcdConn.GetInfo()
+	if err != nil {
+		return err
+	}
+
+	relayFee, err := btcutil.NewAmount(info.RelayFee)
+	if err != nil {
+		return err
+	}
+
+	// The fee rate is expressed in sat/KB, so we'll manually convert it to
+	// our desired sat/vbyte rate.
+	b.minFeeRate = SatPerVByte(relayFee / 1000)
 
 	return nil
 }
@@ -183,12 +205,20 @@ func (b *BtcdFeeEstimator) fetchEstimatePerVSize(
 	// The value returned is expressed in fees per KB, while we want
 	// fee-per-byte, so we'll divide by 1000 to map to satoshis-per-byte
 	// before returning the estimate.
-	satPerByte := satPerKB / 1000
+	satPerByte := SatPerVByte(satPerKB / 1000)
+
+	// Before proceeding, we'll make sure that this fee rate respects the
+	// minimum relay fee set on the backend node.
+	if satPerByte < b.minFeeRate {
+		walletLog.Debugf("Using backend node's minimum relay fee rate "+
+			"of %v sat/vbyte", b.minFeeRate)
+		satPerByte = b.minFeeRate
+	}
 
 	walletLog.Debugf("Returning %v sat/vbyte for conf target of %v",
 		int64(satPerByte), confTarget)
 
-	return SatPerVByte(satPerByte), nil
+	return satPerByte, nil
 }
 
 // A compile-time assertion to ensure that BtcdFeeEstimator implements the
@@ -203,6 +233,12 @@ type BitcoindFeeEstimator struct {
 	// is returned if the fee estimator does not yet have enough data to
 	// actually produce fee estimates.
 	fallBackFeeRate SatPerVByte
+
+	// minFeeRate is the minimum relay fee, in sat/vbyte, of the backend
+	// node. This will be used as the default fee rate of a transaction when
+	// the estimated fee rate is too low to allow the transaction to
+	// propagate through the network.
+	minFeeRate SatPerVByte
 
 	bitcoindConn *rpcclient.Client
 }
@@ -235,6 +271,32 @@ func NewBitcoindFeeEstimator(rpcConfig rpcclient.ConnConfig,
 //
 // NOTE: This method is part of the FeeEstimator interface.
 func (b *BitcoindFeeEstimator) Start() error {
+	// Once the connection to the backend node has been established, we'll
+	// query it for its minimum relay fee. Since the `getinfo` RPC has been
+	// deprecated for `bitcoind`, we'll need to send a `getnetworkinfo`
+	// command as a raw request.
+	resp, err := b.bitcoindConn.RawRequest("getnetworkinfo", nil)
+	if err != nil {
+		return err
+	}
+
+	// Parse the response to retrieve the relay fee in sat/KB.
+	info := struct {
+		RelayFee float64 `json:"relayfee"`
+	}{}
+	if err := json.Unmarshal(resp, &info); err != nil {
+		return err
+	}
+
+	relayFee, err := btcutil.NewAmount(info.RelayFee)
+	if err != nil {
+		return err
+	}
+
+	// The fee rate is expressed in sat/KB, so we'll manually convert it to
+	// our desired sat/vbyte rate.
+	b.minFeeRate = SatPerVByte(relayFee / 1000)
+
 	return nil
 }
 
@@ -304,12 +366,20 @@ func (b *BitcoindFeeEstimator) fetchEstimatePerVSize(
 	// The value returned is expressed in fees per KB, while we want
 	// fee-per-byte, so we'll divide by 1000 to map to satoshis-per-byte
 	// before returning the estimate.
-	satPerByte := satPerKB / 1000
+	satPerByte := SatPerVByte(satPerKB / 1000)
+
+	// Before proceeding, we'll make sure that this fee rate respects the
+	// minimum relay fee set on the backend node.
+	if satPerByte < b.minFeeRate {
+		walletLog.Debugf("Using backend node's minimum relay fee rate "+
+			"of %v sat/vbyte", b.minFeeRate)
+		satPerByte = b.minFeeRate
+	}
 
 	walletLog.Debugf("Returning %v sat/vbyte for conf target of %v",
 		int64(satPerByte), confTarget)
 
-	return SatPerVByte(satPerByte), nil
+	return satPerByte, nil
 }
 
 // A compile-time assertion to ensure that BitcoindFeeEstimator implements the

--- a/lnwallet/interface_test.go
+++ b/lnwallet/interface_test.go
@@ -305,8 +305,14 @@ func testDualFundingReservationWorkflow(miner *rpctest.Harness,
 		t.Fatalf("unable to initialize funding reservation: %v", err)
 	}
 	aliceChanReservation.SetNumConfsRequired(numReqConfs)
-	aliceChanReservation.CommitConstraints(csvDelay, lnwallet.MaxHTLCNumber/2,
-		lnwire.NewMSatFromSatoshis(fundingAmount), 1, 10)
+	err = aliceChanReservation.CommitConstraints(
+		csvDelay, lnwallet.MaxHTLCNumber/2,
+		lnwire.NewMSatFromSatoshis(fundingAmount), 1, fundingAmount/100,
+		lnwallet.DefaultDustLimit(),
+	)
+	if err != nil {
+		t.Fatalf("unable to verify constraints: %v", err)
+	}
 
 	// The channel reservation should now be populated with a multi-sig key
 	// from our HD chain, a change output with 3 BTC, and 2 outputs
@@ -328,8 +334,14 @@ func testDualFundingReservationWorkflow(miner *rpctest.Harness,
 	if err != nil {
 		t.Fatalf("bob unable to init channel reservation: %v", err)
 	}
-	bobChanReservation.CommitConstraints(csvDelay, lnwallet.MaxHTLCNumber/2,
-		lnwire.NewMSatFromSatoshis(fundingAmount), 1, 10)
+	err = bobChanReservation.CommitConstraints(
+		csvDelay, lnwallet.MaxHTLCNumber/2,
+		lnwire.NewMSatFromSatoshis(fundingAmount), 1, fundingAmount/100,
+		lnwallet.DefaultDustLimit(),
+	)
+	if err != nil {
+		t.Fatalf("unable to verify constraints: %v", err)
+	}
 	bobChanReservation.SetNumConfsRequired(numReqConfs)
 
 	assertContributionInitPopulated(t, bobChanReservation.OurContribution())
@@ -675,8 +687,14 @@ func testSingleFunderReservationWorkflow(miner *rpctest.Harness,
 		t.Fatalf("unable to init channel reservation: %v", err)
 	}
 	aliceChanReservation.SetNumConfsRequired(numReqConfs)
-	aliceChanReservation.CommitConstraints(csvDelay, lnwallet.MaxHTLCNumber/2,
-		lnwire.NewMSatFromSatoshis(fundingAmt), 1, 10)
+	err = aliceChanReservation.CommitConstraints(
+		csvDelay, lnwallet.MaxHTLCNumber/2,
+		lnwire.NewMSatFromSatoshis(fundingAmt), 1, fundingAmt/100,
+		lnwallet.DefaultDustLimit(),
+	)
+	if err != nil {
+		t.Fatalf("unable to verify constraints: %v", err)
+	}
 
 	// Verify all contribution fields have been set properly.
 	aliceContribution := aliceChanReservation.OurContribution()
@@ -698,8 +716,14 @@ func testSingleFunderReservationWorkflow(miner *rpctest.Harness,
 	if err != nil {
 		t.Fatalf("unable to create bob reservation: %v", err)
 	}
-	bobChanReservation.CommitConstraints(csvDelay, lnwallet.MaxHTLCNumber/2,
-		lnwire.NewMSatFromSatoshis(fundingAmt), 1, 10)
+	err = bobChanReservation.CommitConstraints(
+		csvDelay, lnwallet.MaxHTLCNumber/2,
+		lnwire.NewMSatFromSatoshis(fundingAmt), 1, fundingAmt/100,
+		lnwallet.DefaultDustLimit(),
+	)
+	if err != nil {
+		t.Fatalf("unable to verify constraints: %v", err)
+	}
 	bobChanReservation.SetNumConfsRequired(numReqConfs)
 
 	// We'll ensure that Bob's contribution also gets generated properly.


### PR DESCRIPTION
In this PR, we fix an issue where sometimes transactions wouldn't provide enough of a fee to be relayed by the backend node. This was caused due to `bitcoind` no longer using the minimum relay fee when estimating fees (see https://github.com/bitcoin/bitcoin/commit/fd29d3df299bd06c0e6bb218863e0c855b3b91af). This would especially cause issues when sweeping outputs after a contract breach, etc. Now, we'll fetch the minimum relay fee from the backend node and ensure it is set as a lower bound if the estimated fee ends up dipping below it.

We also enforce that the channel reserve is above the dust limit. The minimum channel size has also been modified to reflect this change. This allows us to avoid dust outputs from being created in the commitment transactions. This fixes some incompatibility issues between `c-lightning` and `lnd`, due to`lnd` not fully being BOLT-2 compliant.

Fixes #1030.