### PR TITLE
htlcswitch: randomize link fee updates

### DIFF
--- a/htlcswitch/switch_test.go
+++ b/htlcswitch/switch_test.go
@@ -30,12 +30,12 @@ func genPreimage() ([32]byte, error) {
 func TestSwitchSendPending(t *testing.T) {
 	t.Parallel()
 
-	alicePeer, err := newMockServer(t, "alice", nil)
+	alicePeer, err := newMockServer(t, "alice", testStartingHeight, nil)
 	if err != nil {
 		t.Fatalf("unable to create alice server: %v", err)
 	}
 
-	s, err := initSwitchWithDB(nil)
+	s, err := initSwitchWithDB(testStartingHeight, nil)
 	if err != nil {
 		t.Fatalf("unable to init switch: %v", err)
 	}
@@ -125,16 +125,16 @@ func TestSwitchSendPending(t *testing.T) {
 func TestSwitchForward(t *testing.T) {
 	t.Parallel()
 
-	alicePeer, err := newMockServer(t, "alice", nil)
+	alicePeer, err := newMockServer(t, "alice", testStartingHeight, nil)
 	if err != nil {
 		t.Fatalf("unable to create alice server: %v", err)
 	}
-	bobPeer, err := newMockServer(t, "bob", nil)
+	bobPeer, err := newMockServer(t, "bob", testStartingHeight, nil)
 	if err != nil {
 		t.Fatalf("unable to create bob server: %v", err)
 	}
 
-	s, err := initSwitchWithDB(nil)
+	s, err := initSwitchWithDB(testStartingHeight, nil)
 	if err != nil {
 		t.Fatalf("unable to init switch: %v", err)
 	}
@@ -230,11 +230,11 @@ func TestSwitchForwardFailAfterFullAdd(t *testing.T) {
 
 	chanID1, chanID2, aliceChanID, bobChanID := genIDs()
 
-	alicePeer, err := newMockServer(t, "alice", nil)
+	alicePeer, err := newMockServer(t, "alice", testStartingHeight, nil)
 	if err != nil {
 		t.Fatalf("unable to create alice server: %v", err)
 	}
-	bobPeer, err := newMockServer(t, "bob", nil)
+	bobPeer, err := newMockServer(t, "bob", testStartingHeight, nil)
 	if err != nil {
 		t.Fatalf("unable to create bob server: %v", err)
 	}
@@ -249,7 +249,7 @@ func TestSwitchForwardFailAfterFullAdd(t *testing.T) {
 		t.Fatalf("unable to open channeldb: %v", err)
 	}
 
-	s, err := initSwitchWithDB(cdb)
+	s, err := initSwitchWithDB(testStartingHeight, cdb)
 	if err != nil {
 		t.Fatalf("unable to init switch: %v", err)
 	}
@@ -344,7 +344,7 @@ func TestSwitchForwardFailAfterFullAdd(t *testing.T) {
 		t.Fatalf("unable to reopen channeldb: %v", err)
 	}
 
-	s2, err := initSwitchWithDB(cdb2)
+	s2, err := initSwitchWithDB(testStartingHeight, cdb2)
 	if err != nil {
 		t.Fatalf("unable reinit switch: %v", err)
 	}
@@ -421,11 +421,11 @@ func TestSwitchForwardSettleAfterFullAdd(t *testing.T) {
 
 	chanID1, chanID2, aliceChanID, bobChanID := genIDs()
 
-	alicePeer, err := newMockServer(t, "alice", nil)
+	alicePeer, err := newMockServer(t, "alice", testStartingHeight, nil)
 	if err != nil {
 		t.Fatalf("unable to create alice server: %v", err)
 	}
-	bobPeer, err := newMockServer(t, "bob", nil)
+	bobPeer, err := newMockServer(t, "bob", testStartingHeight, nil)
 	if err != nil {
 		t.Fatalf("unable to create bob server: %v", err)
 	}
@@ -440,7 +440,7 @@ func TestSwitchForwardSettleAfterFullAdd(t *testing.T) {
 		t.Fatalf("unable to open channeldb: %v", err)
 	}
 
-	s, err := initSwitchWithDB(cdb)
+	s, err := initSwitchWithDB(testStartingHeight, cdb)
 	if err != nil {
 		t.Fatalf("unable to init switch: %v", err)
 	}
@@ -535,7 +535,7 @@ func TestSwitchForwardSettleAfterFullAdd(t *testing.T) {
 		t.Fatalf("unable to reopen channeldb: %v", err)
 	}
 
-	s2, err := initSwitchWithDB(cdb2)
+	s2, err := initSwitchWithDB(testStartingHeight, cdb2)
 	if err != nil {
 		t.Fatalf("unable reinit switch: %v", err)
 	}
@@ -615,11 +615,11 @@ func TestSwitchForwardDropAfterFullAdd(t *testing.T) {
 
 	chanID1, chanID2, aliceChanID, bobChanID := genIDs()
 
-	alicePeer, err := newMockServer(t, "alice", nil)
+	alicePeer, err := newMockServer(t, "alice", testStartingHeight, nil)
 	if err != nil {
 		t.Fatalf("unable to create alice server: %v", err)
 	}
-	bobPeer, err := newMockServer(t, "bob", nil)
+	bobPeer, err := newMockServer(t, "bob", testStartingHeight, nil)
 	if err != nil {
 		t.Fatalf("unable to create bob server: %v", err)
 	}
@@ -634,7 +634,7 @@ func TestSwitchForwardDropAfterFullAdd(t *testing.T) {
 		t.Fatalf("unable to open channeldb: %v", err)
 	}
 
-	s, err := initSwitchWithDB(cdb)
+	s, err := initSwitchWithDB(testStartingHeight, cdb)
 	if err != nil {
 		t.Fatalf("unable to init switch: %v", err)
 	}
@@ -721,7 +721,7 @@ func TestSwitchForwardDropAfterFullAdd(t *testing.T) {
 		t.Fatalf("unable to reopen channeldb: %v", err)
 	}
 
-	s2, err := initSwitchWithDB(cdb2)
+	s2, err := initSwitchWithDB(testStartingHeight, cdb2)
 	if err != nil {
 		t.Fatalf("unable reinit switch: %v", err)
 	}
@@ -778,11 +778,11 @@ func TestSwitchForwardFailAfterHalfAdd(t *testing.T) {
 
 	chanID1, chanID2, aliceChanID, bobChanID := genIDs()
 
-	alicePeer, err := newMockServer(t, "alice", nil)
+	alicePeer, err := newMockServer(t, "alice", testStartingHeight, nil)
 	if err != nil {
 		t.Fatalf("unable to create alice server: %v", err)
 	}
-	bobPeer, err := newMockServer(t, "bob", nil)
+	bobPeer, err := newMockServer(t, "bob", testStartingHeight, nil)
 	if err != nil {
 		t.Fatalf("unable to create bob server: %v", err)
 	}
@@ -797,7 +797,7 @@ func TestSwitchForwardFailAfterHalfAdd(t *testing.T) {
 		t.Fatalf("unable to open channeldb: %v", err)
 	}
 
-	s, err := initSwitchWithDB(cdb)
+	s, err := initSwitchWithDB(testStartingHeight, cdb)
 	if err != nil {
 		t.Fatalf("unable to init switch: %v", err)
 	}
@@ -879,7 +879,7 @@ func TestSwitchForwardFailAfterHalfAdd(t *testing.T) {
 		t.Fatalf("unable to reopen channeldb: %v", err)
 	}
 
-	s2, err := initSwitchWithDB(cdb2)
+	s2, err := initSwitchWithDB(testStartingHeight, cdb2)
 	if err != nil {
 		t.Fatalf("unable reinit switch: %v", err)
 	}
@@ -936,11 +936,11 @@ func TestSwitchForwardCircuitPersistence(t *testing.T) {
 
 	chanID1, chanID2, aliceChanID, bobChanID := genIDs()
 
-	alicePeer, err := newMockServer(t, "alice", nil)
+	alicePeer, err := newMockServer(t, "alice", testStartingHeight, nil)
 	if err != nil {
 		t.Fatalf("unable to create alice server: %v", err)
 	}
-	bobPeer, err := newMockServer(t, "bob", nil)
+	bobPeer, err := newMockServer(t, "bob", testStartingHeight, nil)
 	if err != nil {
 		t.Fatalf("unable to create bob server: %v", err)
 	}
@@ -955,7 +955,7 @@ func TestSwitchForwardCircuitPersistence(t *testing.T) {
 		t.Fatalf("unable to open channeldb: %v", err)
 	}
 
-	s, err := initSwitchWithDB(cdb)
+	s, err := initSwitchWithDB(testStartingHeight, cdb)
 	if err != nil {
 		t.Fatalf("unable to init switch: %v", err)
 	}
@@ -1036,7 +1036,7 @@ func TestSwitchForwardCircuitPersistence(t *testing.T) {
 		t.Fatalf("unable to reopen channeldb: %v", err)
 	}
 
-	s2, err := initSwitchWithDB(cdb2)
+	s2, err := initSwitchWithDB(testStartingHeight, cdb2)
 	if err != nil {
 		t.Fatalf("unable reinit switch: %v", err)
 	}
@@ -1129,7 +1129,7 @@ func TestSwitchForwardCircuitPersistence(t *testing.T) {
 		t.Fatalf("unable to reopen channeldb: %v", err)
 	}
 
-	s3, err := initSwitchWithDB(cdb3)
+	s3, err := initSwitchWithDB(testStartingHeight, cdb3)
 	if err != nil {
 		t.Fatalf("unable reinit switch: %v", err)
 	}
@@ -1167,16 +1167,16 @@ func TestSkipIneligibleLinksMultiHopForward(t *testing.T) {
 
 	var packet *htlcPacket
 
-	alicePeer, err := newMockServer(t, "alice", nil)
+	alicePeer, err := newMockServer(t, "alice", testStartingHeight, nil)
 	if err != nil {
 		t.Fatalf("unable to create alice server: %v", err)
 	}
-	bobPeer, err := newMockServer(t, "bob", nil)
+	bobPeer, err := newMockServer(t, "bob", testStartingHeight, nil)
 	if err != nil {
 		t.Fatalf("unable to create bob server: %v", err)
 	}
 
-	s, err := initSwitchWithDB(nil)
+	s, err := initSwitchWithDB(testStartingHeight, nil)
 	if err != nil {
 		t.Fatalf("unable to init switch: %v", err)
 	}
@@ -1237,12 +1237,12 @@ func TestSkipIneligibleLinksLocalForward(t *testing.T) {
 
 	// We'll create a single link for this test, marking it as being unable
 	// to forward form the get go.
-	alicePeer, err := newMockServer(t, "alice", nil)
+	alicePeer, err := newMockServer(t, "alice", testStartingHeight, nil)
 	if err != nil {
 		t.Fatalf("unable to create alice server: %v", err)
 	}
 
-	s, err := initSwitchWithDB(nil)
+	s, err := initSwitchWithDB(testStartingHeight, nil)
 	if err != nil {
 		t.Fatalf("unable to init switch: %v", err)
 	}
@@ -1289,16 +1289,16 @@ func TestSkipIneligibleLinksLocalForward(t *testing.T) {
 func TestSwitchCancel(t *testing.T) {
 	t.Parallel()
 
-	alicePeer, err := newMockServer(t, "alice", nil)
+	alicePeer, err := newMockServer(t, "alice", testStartingHeight, nil)
 	if err != nil {
 		t.Fatalf("unable to create alice server: %v", err)
 	}
-	bobPeer, err := newMockServer(t, "bob", nil)
+	bobPeer, err := newMockServer(t, "bob", testStartingHeight, nil)
 	if err != nil {
 		t.Fatalf("unable to create bob server: %v", err)
 	}
 
-	s, err := initSwitchWithDB(nil)
+	s, err := initSwitchWithDB(testStartingHeight, nil)
 	if err != nil {
 		t.Fatalf("unable to init switch: %v", err)
 	}
@@ -1402,16 +1402,16 @@ func TestSwitchAddSamePayment(t *testing.T) {
 
 	chanID1, chanID2, aliceChanID, bobChanID := genIDs()
 
-	alicePeer, err := newMockServer(t, "alice", nil)
+	alicePeer, err := newMockServer(t, "alice", testStartingHeight, nil)
 	if err != nil {
 		t.Fatalf("unable to create alice server: %v", err)
 	}
-	bobPeer, err := newMockServer(t, "bob", nil)
+	bobPeer, err := newMockServer(t, "bob", testStartingHeight, nil)
 	if err != nil {
 		t.Fatalf("unable to create bob server: %v", err)
 	}
 
-	s, err := initSwitchWithDB(nil)
+	s, err := initSwitchWithDB(testStartingHeight, nil)
 	if err != nil {
 		t.Fatalf("unable to init switch: %v", err)
 	}
@@ -1561,12 +1561,12 @@ func TestSwitchAddSamePayment(t *testing.T) {
 func TestSwitchSendPayment(t *testing.T) {
 	t.Parallel()
 
-	alicePeer, err := newMockServer(t, "alice", nil)
+	alicePeer, err := newMockServer(t, "alice", testStartingHeight, nil)
 	if err != nil {
 		t.Fatalf("unable to create alice server: %v", err)
 	}
 
-	s, err := initSwitchWithDB(nil)
+	s, err := initSwitchWithDB(testStartingHeight, nil)
 	if err != nil {
 		t.Fatalf("unable to init switch: %v", err)
 	}
@@ -1804,8 +1804,6 @@ func TestMultiHopPaymentForwardingEvents(t *testing.T) {
 			t.Fatalf("unable to send payment: %v", err)
 		}
 	}
-
-	time.Sleep(time.Millisecond * 200)
 
 	// With all 10 payments sent. We'll now manually stop each of the
 	// switches so we can examine their end state.

--- a/htlcswitch/test_utils.go
+++ b/htlcswitch/test_utils.go
@@ -882,6 +882,12 @@ func newThreeHopNetwork(t testing.TB, aliceChannel, firstBobChannel,
 		quit:      make(chan struct{}),
 	}
 
+	const (
+		batchTimeout     = 50 * time.Millisecond
+		fwdPkgTimeout    = 5 * time.Second
+		feeUpdateTimeout = 30 * time.Minute
+	)
+
 	pCache := &mockPreimageCache{
 		// hash -> preimage
 		preimageMap: make(map[[32]byte][]byte),
@@ -921,11 +927,14 @@ func newThreeHopNetwork(t testing.TB, aliceChannel, firstBobChannel,
 			UpdateContractSignals: func(*contractcourt.ContractSignals) error {
 				return nil
 			},
-			ChainEvents:    &contractcourt.ChainEventSubscription{},
-			SyncStates:     true,
-			BatchTicker:    &mockTicker{aliceTicker.C},
-			FwdPkgGCTicker: &mockTicker{time.NewTicker(5 * time.Second).C},
-			BatchSize:      10,
+			ChainEvents:         &contractcourt.ChainEventSubscription{},
+			SyncStates:          true,
+			BatchSize:           10,
+			BatchTicker:         &mockTicker{time.NewTicker(batchTimeout).C},
+			FwdPkgGCTicker:      &mockTicker{time.NewTicker(fwdPkgTimeout).C},
+			MinFeeUpdateTimeout: feeUpdateTimeout,
+			MaxFeeUpdateTimeout: feeUpdateTimeout,
+			OnChannelFailure:    func(lnwire.ChannelID, lnwire.ShortChannelID, LinkFailureError) {},
 		},
 		aliceChannel,
 		startingHeight,
@@ -970,11 +979,14 @@ func newThreeHopNetwork(t testing.TB, aliceChannel, firstBobChannel,
 			UpdateContractSignals: func(*contractcourt.ContractSignals) error {
 				return nil
 			},
-			ChainEvents:    &contractcourt.ChainEventSubscription{},
-			SyncStates:     true,
-			BatchTicker:    &mockTicker{firstBobTicker.C},
-			FwdPkgGCTicker: &mockTicker{time.NewTicker(5 * time.Second).C},
-			BatchSize:      10,
+			ChainEvents:         &contractcourt.ChainEventSubscription{},
+			SyncStates:          true,
+			BatchSize:           10,
+			BatchTicker:         &mockTicker{time.NewTicker(batchTimeout).C},
+			FwdPkgGCTicker:      &mockTicker{time.NewTicker(fwdPkgTimeout).C},
+			MinFeeUpdateTimeout: feeUpdateTimeout,
+			MaxFeeUpdateTimeout: feeUpdateTimeout,
+			OnChannelFailure:    func(lnwire.ChannelID, lnwire.ShortChannelID, LinkFailureError) {},
 		},
 		firstBobChannel,
 		startingHeight,
@@ -1019,11 +1031,14 @@ func newThreeHopNetwork(t testing.TB, aliceChannel, firstBobChannel,
 			UpdateContractSignals: func(*contractcourt.ContractSignals) error {
 				return nil
 			},
-			ChainEvents:    &contractcourt.ChainEventSubscription{},
-			SyncStates:     true,
-			BatchTicker:    &mockTicker{secondBobTicker.C},
-			FwdPkgGCTicker: &mockTicker{time.NewTicker(5 * time.Second).C},
-			BatchSize:      10,
+			ChainEvents:         &contractcourt.ChainEventSubscription{},
+			SyncStates:          true,
+			BatchSize:           10,
+			BatchTicker:         &mockTicker{time.NewTicker(batchTimeout).C},
+			FwdPkgGCTicker:      &mockTicker{time.NewTicker(fwdPkgTimeout).C},
+			MinFeeUpdateTimeout: feeUpdateTimeout,
+			MaxFeeUpdateTimeout: feeUpdateTimeout,
+			OnChannelFailure:    func(lnwire.ChannelID, lnwire.ShortChannelID, LinkFailureError) {},
 		},
 		secondBobChannel,
 		startingHeight,
@@ -1068,11 +1083,14 @@ func newThreeHopNetwork(t testing.TB, aliceChannel, firstBobChannel,
 			UpdateContractSignals: func(*contractcourt.ContractSignals) error {
 				return nil
 			},
-			ChainEvents:    &contractcourt.ChainEventSubscription{},
-			SyncStates:     true,
-			BatchTicker:    &mockTicker{carolTicker.C},
-			FwdPkgGCTicker: &mockTicker{time.NewTicker(5 * time.Second).C},
-			BatchSize:      10,
+			ChainEvents:         &contractcourt.ChainEventSubscription{},
+			SyncStates:          true,
+			BatchSize:           10,
+			BatchTicker:         &mockTicker{time.NewTicker(batchTimeout).C},
+			FwdPkgGCTicker:      &mockTicker{time.NewTicker(fwdPkgTimeout).C},
+			MinFeeUpdateTimeout: feeUpdateTimeout,
+			MaxFeeUpdateTimeout: feeUpdateTimeout,
+			OnChannelFailure:    func(lnwire.ChannelID, lnwire.ShortChannelID, LinkFailureError) {},
 		},
 		carolChannel,
 		startingHeight,

--- a/peer.go
+++ b/peer.go
@@ -535,7 +535,6 @@ func (p *peer) addLink(chanPoint *wire.OutPoint,
 		ForwardPackets: p.server.htlcSwitch.ForwardPackets,
 		FwrdingPolicy:  *forwardingPolicy,
 		FeeEstimator:   p.server.cc.feeEstimator,
-		BlockEpochs:    blockEpoch,
 		PreimageCache:  p.server.witnessBeacon,
 		ChainEvents:    chainEvents,
 		UpdateContractSignals: func(signals *contractcourt.ContractSignals) error {
@@ -555,9 +554,7 @@ func (p *peer) addLink(chanPoint *wire.OutPoint,
 		MaxFeeUpdateTimeout: htlcswitch.DefaultMaxLinkFeeUpdateTimeout,
 	}
 
-	link := htlcswitch.NewChannelLink(
-		linkCfg, lnChan, uint32(currentHeight),
-	)
+	link := htlcswitch.NewChannelLink(linkCfg, lnChan)
 
 	// With the channel link created, we'll now notify the htlc switch so
 	// this channel can be used to dispatch local payments and also

--- a/peer.go
+++ b/peer.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bytes"
 	"container/list"
 	"fmt"
 	"net"
@@ -9,14 +10,11 @@ import (
 	"time"
 
 	"github.com/davecgh/go-spew/spew"
-	"github.com/lightningnetwork/lnd/brontide"
-	"github.com/lightningnetwork/lnd/contractcourt"
-
-	"bytes"
-
 	"github.com/go-errors/errors"
+	"github.com/lightningnetwork/lnd/brontide"
 	"github.com/lightningnetwork/lnd/chainntnfs"
 	"github.com/lightningnetwork/lnd/channeldb"
+	"github.com/lightningnetwork/lnd/contractcourt"
 	"github.com/lightningnetwork/lnd/htlcswitch"
 	"github.com/lightningnetwork/lnd/lnrpc"
 	"github.com/lightningnetwork/lnd/lnwallet"
@@ -551,11 +549,15 @@ func (p *peer) addLink(chanPoint *wire.OutPoint,
 			time.NewTicker(50 * time.Millisecond)),
 		FwdPkgGCTicker: htlcswitch.NewBatchTicker(
 			time.NewTicker(time.Minute)),
-		BatchSize:    10,
-		UnsafeReplay: cfg.UnsafeReplay,
+		BatchSize:           10,
+		UnsafeReplay:        cfg.UnsafeReplay,
+		MinFeeUpdateTimeout: htlcswitch.DefaultMinLinkFeeUpdateTimeout,
+		MaxFeeUpdateTimeout: htlcswitch.DefaultMaxLinkFeeUpdateTimeout,
 	}
-	link := htlcswitch.NewChannelLink(linkCfg, lnChan,
-		uint32(currentHeight))
+
+	link := htlcswitch.NewChannelLink(
+		linkCfg, lnChan, uint32(currentHeight),
+	)
 
 	// With the channel link created, we'll now notify the htlc switch so
 	// this channel can be used to dispatch local payments and also

--- a/server.go
+++ b/server.go
@@ -284,6 +284,11 @@ func newServer(listenAddrs []string, chanDB *channeldb.DB, cc *chainControl,
 			debugPre[:], debugHash[:])
 	}
 
+	_, currentHeight, err := s.cc.chainIO.GetBestBlock()
+	if err != nil {
+		return nil, err
+	}
+
 	s.htlcSwitch, err = htlcswitch.New(htlcswitch.Config{
 		DB:      chanDB,
 		SelfKey: s.identityPriv.PubKey(),
@@ -313,7 +318,8 @@ func newServer(listenAddrs []string, chanDB *channeldb.DB, cc *chainControl,
 		SwitchPackager:         channeldb.NewSwitchPackager(),
 		ExtractErrorEncrypter:  s.sphinx.ExtractErrorEncrypter,
 		FetchLastChannelUpdate: fetchLastChanUpdate(s, serializedPubKey),
-	})
+		Notifier:               s.cc.chainNotifier,
+	}, uint32(currentHeight))
 	if err != nil {
 		return nil, err
 	}

--- a/test_utils.go
+++ b/test_utils.go
@@ -341,10 +341,17 @@ func createTestPeer(notifier chainntnfs.ChainNotifier,
 		breachArbiter: breachArbiter,
 		chainArb:      chainArb,
 	}
+
+	_, currentHeight, err := s.cc.chainIO.GetBestBlock()
+	if err != nil {
+		return nil, nil, nil, nil, err
+	}
+
 	htlcSwitch, err := htlcswitch.New(htlcswitch.Config{
 		DB:             dbAlice,
 		SwitchPackager: channeldb.NewSwitchPackager(),
-	})
+		Notifier:       notifier,
+	}, uint32(currentHeight))
 	if err != nil {
 		return nil, nil, nil, nil, err
 	}


### PR DESCRIPTION
In this PR, we modify the behavior of links updating their commitment fees. Rather than attempting to update the commitment fee for each link every time a new block comes in, we'll use a timer with a random interval between 10 and 60 minutes for each link to determine when to update their corresponding commitment fee. This prevents us from oscillating the fee rate for our various commitment transactions.

We also move the block height dependency from the links in the switch to the switch itself. This is possible due to a recent change on the links no longer depending on the block height to update their commitment fees. We'll now only have the switch be alerted of new blocks coming in and
links will retrieve the height from it atomically.

Fixes #1129.