### PR TITLE
Update docs with more detailed info for ZMQ support

### DIFF
--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -212,10 +212,11 @@ the following:
 - Additionally, since `lnd` uses
   [ZeroMQ](https://github.com/bitcoin/bitcoin/blob/master/doc/zmq.md) to
   interface with `bitcoind`, *your `bitcoind` installation must be compiled with
-  ZMQ*. If you installed it from source, this is likely the case, but if you
-  installed it via Homebrew in the past it may not be included ([this has now
-  been fixed](https://github.com/Homebrew/homebrew-core/pull/23088) in the
-  latest Homebrew recipe for bitcoin)
+  ZMQ*. Note that if you installed bitcoind from source and ZMQ was not present, 
+  then ZMQ support will be quietly disabled, and lnd will be unable to connect to 
+  bitcoind. If you installed bitcoind via Homebrew in the past ZMQ may not be included 
+  ([this has now been fixed](https://github.com/Homebrew/homebrew-core/pull/23088) 
+  in the latest Homebrew recipe for bitcoin)
 - Configure the `bitcoind` instance for ZMQ with `--zmqpubrawblock` and
   `--zmqpubrawtx` (the latter is optional but allows you to see unconfirmed
   transactions in your wallet). They must be combined in the same ZMQ socket

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -212,9 +212,9 @@ the following:
 - Additionally, since `lnd` uses
   [ZeroMQ](https://github.com/bitcoin/bitcoin/blob/master/doc/zmq.md) to
   interface with `bitcoind`, *your `bitcoind` installation must be compiled with
-  ZMQ*. Note that if you installed bitcoind from source and ZMQ was not present, 
-  then ZMQ support will be disabled, and lnd will quit on a `connection refused` error. 
-  If you installed bitcoind via Homebrew in the past ZMQ may not be included 
+  ZMQ*. Note that if you installed `bitcoind` from source and ZMQ was not present, 
+  then ZMQ support will be disabled, and `lnd` will quit on a `connection refused` error. 
+  If you installed `bitcoind` via Homebrew in the past ZMQ may not be included 
   ([this has now been fixed](https://github.com/Homebrew/homebrew-core/pull/23088) 
   in the latest Homebrew recipe for bitcoin)
 - Configure the `bitcoind` instance for ZMQ with `--zmqpubrawblock` and

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -213,8 +213,8 @@ the following:
   [ZeroMQ](https://github.com/bitcoin/bitcoin/blob/master/doc/zmq.md) to
   interface with `bitcoind`, *your `bitcoind` installation must be compiled with
   ZMQ*. Note that if you installed bitcoind from source and ZMQ was not present, 
-  then ZMQ support will be quietly disabled, and lnd will be unable to connect to 
-  bitcoind. If you installed bitcoind via Homebrew in the past ZMQ may not be included 
+  then ZMQ support will be disabled, and lnd will quit on a `connection refused` error. 
+  If you installed bitcoind via Homebrew in the past ZMQ may not be included 
   ([this has now been fixed](https://github.com/Homebrew/homebrew-core/pull/23088) 
   in the latest Homebrew recipe for bitcoin)
 - Configure the `bitcoind` instance for ZMQ with `--zmqpubrawblock` and


### PR DESCRIPTION
Currently, the `lnd` docs state ZMQ is "likely enabled" if you compile 'bitcoind' from source, yet the `bitcoind` build docs do not all explicitly mention installing the ZMQ library. 

In the `bitcoind` docs, the [`build-unix.md`](https://github.com/bitcoin/bitcoin/blob/master/doc/build-unix.md) has explicit instructions to install ZMQ, but the [`build-osx.md`](https://github.com/bitcoin/bitcoin/blob/master/doc/build-osx.md) and [`build-windows.md`](https://github.com/bitcoin/bitcoin/blob/master/doc/build-windows.md) do not mention it at all.  

So it is actually quite easy to compile from source without ZMQ enabled (and `bitcoind` will function just fine without it). Doing so results in a `connection refused` error when `lnd` attempts to connect to the localhost on startup, and this non-specific error can be tough to diagnose as a ZMQ-related issue.

My edit removes the assumption that ZMQ is present if installed from source, and mentions the error encountered if ZMQ is not present. 



