### PR TITLE
config: ensure minchansize and use it in rpcserver also

### DIFF
--- a/fundingmanager.go
+++ b/fundingmanager.go
@@ -52,10 +52,6 @@ const (
 	// the channel. 288 blocks is ~48 hrs
 	maxWaitNumBlocksFundingConf = 288
 
-	// minChanFundingSize is the smallest channel that we'll allow to be
-	// created over the RPC interface.
-	minChanFundingSize = btcutil.Amount(20000)
-
 	// maxBtcFundingAmount is a soft-limit of the maximum channel size
 	// currently accepted on the Bitcoin chain within the Lightning
 	// Protocol. This limit is defined in BOLT-0002, and serves as an

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -759,9 +759,9 @@ func (r *rpcServer) OpenChannel(in *lnrpc.OpenChannelRequest,
 	// Restrict the size of the channel we'll actually open. At a later
 	// level, we'll ensure that the output we create after accounting for
 	// fees that a dust output isn't created.
-	if localFundingAmt < minChanFundingSize {
+	if localFundingAmt < btcutil.Amount(cfg.MinChanSize) {
 		return fmt.Errorf("channel is too small, the minimum channel "+
-			"size is: %v SAT", int64(minChanFundingSize))
+			"size is: %v SAT", cfg.MinChanSize)
 	}
 
 	var (
@@ -918,9 +918,9 @@ func (r *rpcServer) OpenChannelSync(ctx context.Context,
 	// Restrict the size of the channel we'll actually open. At a later
 	// level, we'll ensure that the output we create after accounting for
 	// fees that a dust output isn't created.
-	if localFundingAmt < minChanFundingSize {
+	if localFundingAmt < btcutil.Amount(cfg.MinChanSize) {
 		return nil, fmt.Errorf("channel is too small, the minimum channel "+
-			"size is: %v SAT", int64(minChanFundingSize))
+			"size is: %v SAT", cfg.MinChanSize)
 	}
 
 	// Based on the passed fee related parameters, we'll determine an


### PR DESCRIPTION
This is a proposal to make `minchansize` configuration more consistent.
`minChanFundingSize` is moved to config.go, and `minchansize` param is validated against it.
It is then also used in RPC server.