### PR TITLE
[bugfix] Wait for confirmation before marking channel cooperatively closed

### DIFF
--- a/breacharbiter.go
+++ b/breacharbiter.go
@@ -165,6 +165,8 @@ func (b *breachArbiter) Start() error {
 	// finished our responsibilities. If the removal is successful, we also
 	// remove the entry from our in-memory map, to avoid any further action
 	// for this channel.
+	// TODO(halseth): no need continue on IsPending once closed channels
+	// actually means close transaction is confirmed.
 	for _, chanSummary := range closedChans {
 		if chanSummary.IsPending {
 			continue

--- a/channeldb/channel.go
+++ b/channeldb/channel.go
@@ -1673,12 +1673,12 @@ type ChannelCloseSummary struct {
 
 	// IsPending indicates whether this channel is in the 'pending close'
 	// state, which means the channel closing transaction has been
-	// broadcast, but not confirmed yet or has not yet been fully resolved.
-	// In the case of a channel that has been cooperatively closed, it will
-	// no longer be considered pending as soon as the closing transaction
-	// has been confirmed. However, for channel that have been force
-	// closed, they'll stay marked as "pending" until _all_ the pending
-	// funds have been swept.
+	// confirmed, but not yet been fully resolved. In the case of a channel
+	// that has been cooperatively closed, it will go straight into the
+	// fully resolved state as soon as the closing transaction has been
+	// confirmed. However, for channel that have been force closed, they'll
+	// stay marked as "pending" until _all_ the pending funds have been
+	// swept.
 	IsPending bool
 
 	// RemoteCurrentRevocation is the current revocation for their

--- a/contractcourt/chain_arbitrator.go
+++ b/contractcourt/chain_arbitrator.go
@@ -737,20 +737,5 @@ func (c *ChainArbitrator) SubscribeChannelEvents(
 	return watcher.SubscribeChannelEvents(), nil
 }
 
-// BeginCoopChanClose allows the initiator or responder to a cooperative
-// channel closure to signal to the ChainArbitrator that we're starting close
-// negotiation. The caller can use this context to allow the underlying chain
-// watcher to be prepared to act if *any* of the transactions that may
-// potentially be signed off on during fee negotiation are confirmed.
-func (c *ChainArbitrator) BeginCoopChanClose(chanPoint wire.OutPoint) (*CooperativeCloseCtx, error) {
-	watcher, ok := c.activeWatchers[chanPoint]
-	if !ok {
-		return nil, fmt.Errorf("unable to find watcher for: %v",
-			chanPoint)
-	}
-
-	return watcher.BeginCooperativeClose(), nil
-}
-
 // TODO(roasbeef): arbitration reports
 //  * types: contested, waiting for success conf, etc

--- a/contractcourt/chain_arbitrator.go
+++ b/contractcourt/chain_arbitrator.go
@@ -392,11 +392,17 @@ func (c *ChainArbitrator) Start() error {
 	}
 
 	// Next, for each channel is the closing state, we'll launch a
-	// corresponding more restricted resolver.
+	// corresponding more restricted resolver, as we don't have to watch
+	// the chain any longer, only resolve the contracts on the confirmed
+	// commitment.
 	for _, closeChanInfo := range closingChannels {
 		// If this is a pending cooperative close channel then we'll
 		// simply launch a goroutine to wait until the closing
 		// transaction has been confirmed.
+		// TODO(halseth): can remove this since no coop close channels
+		// should be "pending close" after the recent changes. Keeping
+		// it for a bit in case someone with a coop close channel in
+		// the pending close state upgrades to the new commit.
 		if closeChanInfo.CloseType == channeldb.CooperativeClose {
 			go c.watchForChannelClose(closeChanInfo)
 

--- a/contractcourt/chain_watcher.go
+++ b/contractcourt/chain_watcher.go
@@ -10,7 +10,6 @@ import (
 	"github.com/lightningnetwork/lnd/channeldb"
 	"github.com/lightningnetwork/lnd/lnwallet"
 	"github.com/roasbeef/btcd/chaincfg"
-	"github.com/roasbeef/btcd/chaincfg/chainhash"
 	"github.com/roasbeef/btcd/txscript"
 	"github.com/roasbeef/btcd/wire"
 	"github.com/roasbeef/btcutil"
@@ -123,12 +122,6 @@ type chainWatcher struct {
 	// clientSubscriptions is a map that keeps track of all the active
 	// client subscriptions for events related to this channel.
 	clientSubscriptions map[uint64]*ChainEventSubscription
-
-	// possibleCloses is a map from cooperative closing transaction txid to
-	// a close summary that describes the nature of the channel closure.
-	// We'll use this map to keep track of all possible channel closures to
-	// ensure out db state is correct in the end.
-	possibleCloses map[chainhash.Hash]*channeldb.ChannelCloseSummary
 }
 
 // newChainWatcher returns a new instance of a chainWatcher for a channel given
@@ -158,7 +151,6 @@ func newChainWatcher(cfg chainWatcherConfig) (*chainWatcher, error) {
 		stateHintObfuscator: stateHint,
 		quit:                make(chan struct{}),
 		clientSubscriptions: make(map[uint64]*ChainEventSubscription),
-		possibleCloses:      make(map[chainhash.Hash]*channeldb.ChannelCloseSummary),
 	}, nil
 }
 
@@ -748,150 +740,6 @@ func (c *chainWatcher) dispatchContractBreach(spendEvent *chainntnfs.SpendDetail
 
 	log.Infof("Breached channel=%v marked pending-closed",
 		c.cfg.chanState.FundingOutpoint)
-
-	return nil
-}
-
-// CooperativeCloseCtx is a transactional object that's used by external
-// parties to initiate a cooperative closure negotiation. During the
-// negotiation, we sign multiple versions of a closing transaction, either of
-// which may be counter signed and broadcast by the remote party at any time.
-// As a result, we'll need to watch the chain to see if any of these confirm,
-// only afterwards will we mark the channel as fully closed.
-type CooperativeCloseCtx struct {
-	// potentialCloses is a channel will be used by the party negotiating
-	// the cooperative closure to send possible closing states to the chain
-	// watcher to ensure we detect all on-chain spends.
-	potentialCloses chan *channeldb.ChannelCloseSummary
-
-	// activeCloses keeps track of all the txid's that we're currently
-	// watching for.
-	activeCloses map[chainhash.Hash]struct{}
-
-	// watchCancel will be closed once *one* of the txid's in the map above
-	// is confirmed. This will cause all the lingering goroutines to exit.
-	watchCancel chan struct{}
-
-	watcher *chainWatcher
-
-	sync.Mutex
-}
-
-// BeginCooperativeClose should be called by the party negotiating the
-// cooperative closure before the first signature is sent to the remote party.
-// This will return a context that should be used to communicate possible
-// closing states so we can act on them.
-func (c *chainWatcher) BeginCooperativeClose() *CooperativeCloseCtx {
-	// We'll simply return a new close context that will be used be the
-	// caller to notify us of potential closes.
-	return &CooperativeCloseCtx{
-		potentialCloses: make(chan *channeldb.ChannelCloseSummary),
-		watchCancel:     make(chan struct{}),
-		activeCloses:    make(map[chainhash.Hash]struct{}),
-		watcher:         c,
-	}
-}
-
-// LogPotentialClose should be called by the party negotiating the cooperative
-// closure once they signed a new state, but *before* they transmit it to the
-// remote party. This will ensure that the chain watcher is able to log the new
-// state it should watch the chain for.
-func (c *CooperativeCloseCtx) LogPotentialClose(potentialClose *channeldb.ChannelCloseSummary) {
-	c.Lock()
-	defer c.Unlock()
-
-	// We'll check to see if we're already watching for a close of this
-	// channel, if so, then we'll exit early to avoid launching a duplicate
-	// goroutine.
-	if _, ok := c.activeCloses[potentialClose.ClosingTXID]; ok {
-		return
-	}
-
-	// Otherwise, we'll mark this txid as currently being watched.
-	c.activeCloses[potentialClose.ClosingTXID] = struct{}{}
-
-	// We'll take this potential close, and launch a goroutine which will
-	// wait until it's confirmed, then update the database state. When a
-	// potential close gets confirmed, we'll cancel out all other launched
-	// goroutines.
-	go func() {
-		confNtfn, err := c.watcher.cfg.notifier.RegisterConfirmationsNtfn(
-			&potentialClose.ClosingTXID, 1,
-			uint32(potentialClose.CloseHeight),
-		)
-		if err != nil {
-			log.Errorf("unable to register for conf: %v", err)
-			return
-		}
-
-		log.Infof("closeCtx: waiting for txid=%v to close "+
-			"ChannelPoint(%v) on chain", potentialClose.ClosingTXID,
-			c.watcher.cfg.chanState.FundingOutpoint)
-
-		select {
-		case confInfo, ok := <-confNtfn.Confirmed:
-			if !ok {
-				log.Errorf("notifier exiting")
-				return
-			}
-
-			log.Infof("closeCtx: ChannelPoint(%v) is fully closed, at "+
-				"height: %v", c.watcher.cfg.chanState.FundingOutpoint,
-				confInfo.BlockHeight)
-
-			close(c.watchCancel)
-
-			c.watcher.Lock()
-			for _, sub := range c.watcher.clientSubscriptions {
-				select {
-				case sub.CooperativeClosure <- struct{}{}:
-				case <-c.watcher.quit:
-				}
-			}
-			c.watcher.Unlock()
-
-			err := c.watcher.cfg.chanState.CloseChannel(potentialClose)
-			if err != nil {
-				log.Warnf("closeCtx: unable to update latest "+
-					"close for ChannelPoint(%v): %v",
-					c.watcher.cfg.chanState.FundingOutpoint, err)
-			}
-
-			err = c.watcher.cfg.markChanClosed()
-			if err != nil {
-				log.Errorf("closeCtx: unable to mark chan fully "+
-					"closed: %v", err)
-				return
-			}
-
-		case <-c.watchCancel:
-			log.Debugf("Exiting watch for close of txid=%v for "+
-				"ChannelPoint(%v)", potentialClose.ClosingTXID,
-				c.watcher.cfg.chanState.FundingOutpoint)
-
-		case <-c.watcher.quit:
-			return
-		}
-	}()
-}
-
-// Finalize should be called once both parties agree on a final transaction to
-// close out the channel. This method will immediately mark the channel as
-// pending closed in the database, then launch a goroutine to mark the channel
-// fully closed upon confirmation.
-func (c *CooperativeCloseCtx) Finalize(preferredClose *channeldb.ChannelCloseSummary) error {
-	chanPoint := c.watcher.cfg.chanState.FundingOutpoint
-
-	log.Infof("Finalizing chan close for ChannelPoint(%v)", chanPoint)
-
-	err := c.watcher.cfg.chanState.CloseChannel(preferredClose)
-	if err != nil {
-		log.Errorf("closeCtx: unable to close ChannelPoint(%v): %v",
-			chanPoint, err)
-		return err
-	}
-
-	go c.LogPotentialClose(preferredClose)
 
 	return nil
 }

--- a/lnwallet/channel.go
+++ b/lnwallet/channel.go
@@ -5580,13 +5580,6 @@ func (lc *LightningChannel) CompleteCooperativeClose(localSig, remoteSig []byte,
 	return closeTx, ourBalance, nil
 }
 
-// DeleteState deletes all state concerning the channel from the underlying
-// database, only leaving a small summary describing metadata of the
-// channel's lifetime.
-func (lc *LightningChannel) DeleteState(c *channeldb.ChannelCloseSummary) error {
-	return lc.channelState.CloseChannel(c)
-}
-
 // AvailableBalance returns the current available balance within the channel.
 // By available balance, we mean that if at this very instance s new commitment
 // were to be created which evals all the log entries, what would our available

--- a/lnwallet/channel.go
+++ b/lnwallet/channel.go
@@ -5896,6 +5896,16 @@ func (lc *LightningChannel) State() *channeldb.OpenChannel {
 	return lc.channelState
 }
 
+// MarkCommitmentBroadcasted marks the channel as a commitment transaction has
+// been broadcast, either our own or the remote, and we should watch the chain
+// for it to confirm before taking any further action.
+func (lc *LightningChannel) MarkCommitmentBroadcasted() error {
+	lc.Lock()
+	defer lc.Unlock()
+
+	return lc.channelState.MarkCommitmentBroadcasted()
+}
+
 // ActiveHtlcs returns a slice of HTLC's which are currently active on *both*
 // commitment transactions.
 func (lc *LightningChannel) ActiveHtlcs() []channeldb.HTLC {

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -1455,6 +1455,10 @@ func (r *rpcServer) PendingChannels(ctx context.Context,
 
 		// If the channel was closed cooperatively, then we'll only
 		// need to tack on the closing txid.
+		// TODO(halseth): remove. After recent changes, a coop closed
+		// channel should never be in the "pending close" state.
+		// Keeping for now to let someone that upgraded in the middle
+		// of a close let their closing tx confirm.
 		case channeldb.CooperativeClose:
 			resp.PendingClosingChannels = append(
 				resp.PendingClosingChannels,


### PR DESCRIPTION
This PR fixes an issue where we could go through a cooperative close, and marking the channel as closed in the DB before it was confirmed. This would lead to potential issues as we wouldn't start the necessary submodules to watch for the final close on restarts. 

In #1017 we changed the definition of a closed channel to be a channel that has had its closing tx confirmed. This PR makes this true also for cooperative closes.