### PR TITLE
fix build target in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -123,7 +123,7 @@ btcd: $(GLIDE_BIN) $(BTCD_DIR)
 # INSTALLATION
 # ============
 
-build:
+build: dep
 	@$(call print, "Building debug lnd and lncli.")
 	$(GOBUILD) -tags=$(TEST_TAGS) -o lnd-debug $(LDFLAGS) $(PKG)
 	$(GOBUILD) -tags=$(TEST_TAGS) -o lncli-debug $(LDFLAGS) $(PKG)/cmd/lncli
@@ -133,7 +133,7 @@ install:
 	go install -v $(LDFLAGS) $(PKG)
 	go install -v $(LDFLAGS) $(PKG)/cmd/lncli
 
-scratch: dep build
+scratch: build
 
 
 # =======


### PR DESCRIPTION
The 'build' target depends from 'dep' target but this relation to be defined in 'scratch' not in build
Due to we have a problem when run `make -j7` for example: targets dep & build to be runned parallelly not consistently (https://github.com/lightningnetwork/lnd/issues/1256)