### PR TITLE
Docker: Use multi-stage builds and Alpine containers for btcd and ltcd

### DIFF
--- a/docker/btcd/Dockerfile
+++ b/docker/btcd/Dockerfile
@@ -1,6 +1,22 @@
-FROM golang:1.10
+FROM golang:1.10-alpine as builder
 
 MAINTAINER Olaoluwa Osuntokun <laolu@lightning.network>
+
+# Install build dependencies such as git and glide.
+RUN apk add --no-cache \
+    git \
+&&  go get -u github.com/Masterminds/glide
+
+WORKDIR $GOPATH/src/github.com/roasbeef/btcd
+
+# Grab and install the latest version of roasbeef's fork of btcd and all
+# related dependencies.
+RUN git clone https://github.com/roasbeef/btcd . \
+&&  glide install \
+&&  go install . ./cmd/...
+
+# Start a new image
+FROM alpine as final
 
 # Expose mainnet ports (server, rpc)
 EXPOSE 8333 8334
@@ -14,21 +30,26 @@ EXPOSE 18555 18556
 # Expose segnet ports (server, rpc)
 EXPOSE 28901 28902
 
-# Grab and install the latest version of roasbeef's fork of btcd and all
-# related dependencies.
-RUN go get -u github.com/Masterminds/glide
+# Copy the compiled binaries from the builder image.
+COPY --from=builder /go/bin/addblock /bin/
+COPY --from=builder /go/bin/btcctl /bin/
+COPY --from=builder /go/bin/btcd /bin/
+COPY --from=builder /go/bin/findcheckpoint /bin/
+COPY --from=builder /go/bin/gencerts /bin/
 
-WORKDIR $GOPATH/src/github.com/roasbeef/btcd
-RUN git clone https://github.com/roasbeef/btcd .
-RUN glide install
-RUN go install . ./cmd/...
+COPY "start-btcctl.sh" .
+COPY "start-btcd.sh" .
 
-RUN mkdir "/rpc" "/root/.btcd" "/root/.btcctl"
-RUN touch "/root/.btcd/btcd.conf"
-
+RUN apk add --no-cache \
+    bash \
+    ca-certificates \
+&&  mkdir "/rpc" "/root/.btcd" "/root/.btcctl" \
+&&  touch "/root/.btcd/btcd.conf" \
+&&  chmod +x start-btcctl.sh \
+&&  chmod +x start-btcd.sh \
 # Manually generate certificate and add all domains, it is needed to connect
 # "btcctl" and "lnd" to "btcd" over docker links.
-RUN "/go/bin/gencerts" --host="*" --directory="/rpc" --force
+&& "/bin/gencerts" --host="*" --directory="/rpc" --force
 
 # Create a volume to house pregenerated RPC credentials. This will be
 # shared with any lnd, btcctl containers so they can securely query btcd's RPC
@@ -37,10 +58,3 @@ RUN "/go/bin/gencerts" --host="*" --directory="/rpc" --force
 # Otherwise manually generated certificate will be overridden with shared
 # mounted volume! For more info read dockerfile "VOLUME" documentation.
 VOLUME ["/rpc"]
-
-COPY "start-btcctl.sh" .
-COPY "start-btcd.sh" .
-
-RUN chmod +x start-btcctl.sh
-RUN chmod +x start-btcd.sh
-

--- a/docker/lnd/Dockerfile
+++ b/docker/lnd/Dockerfile
@@ -14,7 +14,8 @@ RUN apk add --no-cache \
     git \
     make \
 &&  cd /go/src/github.com/lightningnetwork/lnd \
-&&  make
+&&  make \
+&&  make install
 
 # Start a new, final image to reduce size.
 FROM alpine as final
@@ -23,8 +24,8 @@ FROM alpine as final
 EXPOSE 9735 10009
 
 # Copy the binaries and entrypoint from the builder image.
-COPY --from=builder /go/src/github.com/lightningnetwork/lnd/lncli /bin/
-COPY --from=builder /go/src/github.com/lightningnetwork/lnd/lnd /bin/
+COPY --from=builder /go/bin/lncli /bin/
+COPY --from=builder /go/bin/lnd /bin/
 
 # Add bash.
 RUN apk add --no-cache \

--- a/docker/ltcd/Dockerfile
+++ b/docker/ltcd/Dockerfile
@@ -1,6 +1,18 @@
-FROM golang:1.10
+FROM golang:1.10-alpine as builder
 
 MAINTAINER Olaoluwa Osuntokun <lightning.engineering>
+
+# Grab and install the latest version of roasbeef's fork of ltcd and all
+# related dependencies.
+WORKDIR $GOPATH/src/github.com/ltcsuite/ltcd
+RUN apk add --no-cache git \
+&&  git clone https://github.com/ltcsuite/ltcd ./ \
+&&  go get -u github.com/Masterminds/glide \
+&&  glide install \
+&&  go install . ./cmd/ltcctl ./cmd/gencerts
+
+# Start a new image
+FROM alpine as final
 
 # Expose mainnet ports (server, rpc)
 EXPOSE 8333 8334
@@ -14,19 +26,23 @@ EXPOSE 18555 18556
 # Expose segnet ports (server, rpc)
 EXPOSE 28901 28902
 
-# Grab and install the latest version of roasbeef's fork of ltcd and all
-# related dependencies.
-WORKDIR $GOPATH/src/github.com/ltcsuite/ltcd
-RUN git clone https://github.com/ltcsuite/ltcd ./
-RUN go get -u github.com/Masterminds/glide
-RUN glide install
-RUN go install . ./cmd/ltcctl ./cmd/gencerts
+# Copy the compiled binaries from the builder image.
+COPY --from=builder /go/bin/ltcctl /bin/
+COPY --from=builder /go/bin/ltcd /bin/
+COPY --from=builder /go/bin/gencerts /bin/
 
-RUN mkdir "/rpc" "/root/.ltcd" "/root/.ltcctl"
-RUN touch "/root/.ltcd/ltcd.conf"
+COPY "start-ltcctl.sh" .
+COPY "start-ltcd.sh" .
 
+RUN apk add --no-cache \
+    bash \
+    ca-certificates \
+&&  chmod +x start-ltcctl.sh \
+&&  chmod +x start-ltcd.sh \
+&&  mkdir "/rpc" "/root/.ltcd" "/root/.ltcctl" \
+&&  touch "/root/.ltcd/ltcd.conf" \
 # "ltcctl" and "lnd" to "ltcd" over docker links.
-RUN "/go/bin/gencerts" --host="*" --directory="/rpc" --force
+&&  "/bin/gencerts" --host="*" --directory="/rpc" --force
 
 # Create a volume to house pregenerated RPC credentials. This will be
 # shared with any lnd, btcctl containers so they can securely query ltcd's RPC
@@ -35,10 +51,3 @@ RUN "/go/bin/gencerts" --host="*" --directory="/rpc" --force
 # Otherwise manually generated certificate will be overridden with shared
 # mounted volume! For more info read dockerfile "VOLUME" documentation.
 VOLUME ["/rpc"]
-
-COPY "start-ltcctl.sh" .
-COPY "start-ltcd.sh" .
-
-RUN chmod +x start-ltcctl.sh
-RUN chmod +x start-ltcd.sh
-


### PR DESCRIPTION
Similar to #1169 but implements multi-stage builds and alpine containers for btcd and ltcd.

Before:
```
btcd                   latest          7eefac9c9dd2        2 minutes ago       917MB
ltcd                   latest          8315899a2994        3 minutes ago       895MB
```
After:
```
btcd                   latest          8ca9cde8a96b        3 minutes ago        56.5MB
ltcd                   latest          532bd4f40cef        3 minutes ago        42.5MB
```

Also includes a fix for an issue in `lnd`'s Dockerfile related to recent changes to the Makefile that no longer creates binaries in the main directory.