### PR TITLE
rpc: add support for unix sockets

### DIFF
--- a/cmd/lncli/main.go
+++ b/cmd/lncli/main.go
@@ -14,6 +14,7 @@ import (
 
 	macaroon "gopkg.in/macaroon.v2"
 
+	"github.com/lightningnetwork/lnd/lncfg"
 	"github.com/lightningnetwork/lnd/lnrpc"
 	"github.com/lightningnetwork/lnd/macaroons"
 	"github.com/roasbeef/btcutil"
@@ -26,6 +27,8 @@ import (
 const (
 	defaultTLSCertFilename  = "tls.cert"
 	defaultMacaroonFilename = "admin.macaroon"
+	defaultRpcPort          = "10009"
+	defaultRpcHostPort      = "localhost:" + defaultRpcPort
 )
 
 var (
@@ -143,6 +146,13 @@ func getClientConn(ctx *cli.Context, skipMacaroons bool) *grpc.ClientConn {
 		opts = append(opts, grpc.WithPerRPCCredentials(cred))
 	}
 
+	// We need to use a custom dialer so we can also connect to unix sockets
+	// and not just TCP addresses.
+	opts = append(
+		opts, grpc.WithDialer(
+			lncfg.ClientAddressDialer(defaultRpcPort),
+		),
+	)
 	conn, err := grpc.Dial(ctx.GlobalString("rpcserver"), opts...)
 	if err != nil {
 		fatal(err)
@@ -159,7 +169,7 @@ func main() {
 	app.Flags = []cli.Flag{
 		cli.StringFlag{
 			Name:  "rpcserver",
-			Value: "localhost:10009",
+			Value: defaultRpcHostPort,
 			Usage: "host:port of ln daemon",
 		},
 		cli.StringFlag{

--- a/lncfg/address.go
+++ b/lncfg/address.go
@@ -1,0 +1,161 @@
+package lncfg
+
+import (
+	"time"
+	"net"
+	"fmt"
+	"crypto/tls"
+	"strings"
+)
+
+var (
+	loopBackAddrs = []string{"localhost", "127.0.0.1", "[::1]"}
+)
+
+// NormalizeAddresses returns a new slice with all the passed addresses
+// normalized with the given default port and all duplicates removed.
+func NormalizeAddresses(addrs []string,
+	defaultPort string) ([]net.Addr, error) {
+	result := make([]net.Addr, 0, len(addrs))
+	seen := map[string]struct{}{}
+	for _, strAddr := range addrs {
+		addr, err := ParseAddressString(strAddr, defaultPort)
+		if err != nil {
+			return nil, err
+		}
+
+		if _, ok := seen[addr.String()]; !ok {
+			result = append(result, addr)
+			seen[addr.String()] = struct{}{}
+		}
+	}
+	return result, nil
+}
+
+// EnforceSafeAuthentication enforces "safe" authentication taking into account
+// the interfaces that the RPC servers are listening on, and if macaroons are
+// activated or not. To protect users from using dangerous config combinations,
+// we'll prevent disabling authentication if the sever is listening on a public
+// interface.
+func EnforceSafeAuthentication(addrs []net.Addr, macaroonsActive bool) error {
+	// We'll now examine all addresses that this RPC server is listening
+	// on. If it's a localhost address, we'll skip it, otherwise, we'll
+	// return an error if macaroons are inactive.
+	for _, addr := range addrs {
+		if IsLoopback(addr) || IsUnix(addr) {
+			continue
+		}
+
+		if !macaroonsActive {
+			return fmt.Errorf("Detected RPC server listening on "+
+				"publicly reachable interface %v with "+
+				"authentication disabled! Refusing to start "+
+				"with --no-macaroons specified.", addr)
+		}
+	}
+
+	return nil
+}
+
+// ListenOnAddress creates a listener that listens on the given
+// address.
+func ListenOnAddress(addr net.Addr) (net.Listener, error) {
+	return net.Listen(addr.Network(), addr.String())
+}
+
+// TlsListenOnAddress creates a TLS listener that listens on the given
+// address.
+func TlsListenOnAddress(addr net.Addr,
+	config *tls.Config) (net.Listener, error) {
+	return tls.Listen(addr.Network(), addr.String(), config)
+}
+
+// IsLoopback returns true if an address describes a loopback interface.
+func IsLoopback(addr net.Addr) bool {
+	for _, loopback := range loopBackAddrs {
+		if strings.Contains(addr.String(), loopback) {
+			return true
+		}
+	}
+
+	return false
+}
+
+// isUnix returns true if an address describes an Unix socket address.
+func IsUnix(addr net.Addr) bool {
+	return strings.HasPrefix(addr.Network(), "unix")
+}
+
+// ParseAddressString converts an address in string format to a net.Addr that is
+// compatible with lnd. UDP is not supported because lnd needs reliable
+// connections.
+func ParseAddressString(strAddress string,
+	defaultPort string) (net.Addr, error) {
+	var parsedNetwork, parsedAddr string
+
+	// Addresses can either be in network://address:port format or only
+	// address:port. We want to support both.
+	if strings.Contains(strAddress, "://") {
+		parts := strings.Split(strAddress, "://")
+		parsedNetwork, parsedAddr = parts[0], parts[1]
+	} else if strings.Contains(strAddress, ":") {
+		parts := strings.Split(strAddress, ":")
+		parsedNetwork = parts[0]
+		parsedAddr = strings.Join(parts[1:], ":")
+	}
+
+	// Only TCP and Unix socket addresses are valid. We can't use IP or
+	// UDP only connections for anything we do in lnd.
+	switch parsedNetwork {
+	case "unix", "unixpacket":
+		return net.ResolveUnixAddr(parsedNetwork, parsedAddr)
+	case "tcp", "tcp4", "tcp6":
+		return net.ResolveTCPAddr(parsedNetwork,
+			verifyPort(parsedAddr, defaultPort))
+	case "ip", "ip4", "ip6", "udp", "udp4", "udp6", "unixgram":
+		return nil, fmt.Errorf("only TCP or unix socket "+
+			"addresses are supported: %s", parsedAddr)
+	default:
+		// There was no network specified, just try to parse as host
+		// and port.
+		return net.ResolveTCPAddr(
+			"tcp", verifyPort(strAddress, defaultPort),
+		)
+	}
+}
+
+// verifyPort makes sure that an address string has both a host and a port.
+// If there is no port found, the default port is appended.
+func verifyPort(strAddress string, defaultPort string) string {
+	host, port, err := net.SplitHostPort(strAddress)
+	if err != nil {
+		// If we already have an IPv6 address with brackets, don't use
+		// the JoinHostPort function, since it will always add a pair
+		// of brackets too.
+		if strings.HasPrefix(strAddress, "[") {
+			strAddress = strAddress + ":" + defaultPort
+		} else {
+			strAddress = net.JoinHostPort(strAddress, defaultPort)
+		}
+	} else if host == "" && port == "" {
+		// The string ':' is parsed as valid empty host and empty port.
+		// But in that case, we want the default port to be applied too.
+		strAddress = ":" + defaultPort
+	}
+
+	return strAddress
+}
+
+// ClientAddressDialer creates a gRPC dialer that can also dial unix socket
+// addresses instead of just TCP addresses.
+func ClientAddressDialer(defaultPort string) func(string,
+	time.Duration) (net.Conn, error) {
+	return func(addr string, timeout time.Duration) (net.Conn, error) {
+		parsedAddr, err := ParseAddressString(addr, defaultPort)
+		if err != nil {
+			return nil, err
+		}
+		return net.DialTimeout(parsedAddr.Network(),
+			parsedAddr.String(), timeout)
+	}
+}

--- a/lncfg/address_test.go
+++ b/lncfg/address_test.go
@@ -1,0 +1,99 @@
+// +build !rpctest
+
+package lncfg
+
+import "testing"
+
+// addressTest defines a test vector for an address that contains the non-
+// normalized input and the expected normalized output.
+type addressTest struct {
+	address         string
+	expectedNetwork string
+	expectedAddress string
+	isLoopback      bool
+	isUnix          bool
+}
+
+var (
+	defaultTestPort    = "1234"
+	addressTestVectors = []addressTest{
+		{"tcp://127.0.0.1:9735", "tcp", "127.0.0.1:9735", true, false},
+		{"tcp:127.0.0.1:9735", "tcp", "127.0.0.1:9735", true, false},
+		{"127.0.0.1:9735", "tcp", "127.0.0.1:9735", true, false},
+		{":9735", "tcp", ":9735", false, false},
+		{"", "tcp", ":1234", false, false},
+		{":", "tcp", ":1234", false, false},
+		{"tcp4://127.0.0.1:9735", "tcp", "127.0.0.1:9735", true, false},
+		{"tcp4:127.0.0.1:9735", "tcp", "127.0.0.1:9735", true, false},
+		{"127.0.0.1", "tcp", "127.0.0.1:1234", true, false},
+		{"[::1]", "tcp", "[::1]:1234", true, false},
+		{"::1", "tcp", "[::1]:1234", true, false},
+		{"tcp6://::1", "tcp", "[::1]:1234", true, false},
+		{"tcp6:::1", "tcp", "[::1]:1234", true, false},
+		{"localhost:9735", "tcp", "127.0.0.1:9735", true, false},
+		{"localhost", "tcp", "127.0.0.1:1234", true, false},
+		{"unix:///tmp/lnd.sock", "unix", "/tmp/lnd.sock", false, true},
+		{"unix:/tmp/lnd.sock", "unix", "/tmp/lnd.sock", false, true},
+	}
+	invalidTestVectors = []string{
+		"some string",
+		"://",
+		"12.12.12",
+		"123",
+	}
+)
+
+// TestAddresses ensures that all supported address formats can be parsed and
+// normalized correctly.
+func TestAddresses(t *testing.T) {
+	// First, test all correct addresses.
+	for _, testVector := range addressTestVectors {
+		addr := []string{testVector.address}
+		normalized, err := NormalizeAddresses(addr, defaultTestPort)
+		if err != nil {
+			t.Fatalf("unable to normalize address %s: %v",
+				testVector.address, err)
+		}
+		netAddr := normalized[0]
+		if err != nil {
+			t.Fatalf("unable to split normalized address: %v", err)
+		}
+		if netAddr.Network() != testVector.expectedNetwork ||
+			netAddr.String() != testVector.expectedAddress {
+			t.Fatalf(
+				"mismatched address: expected %s://%s, got "+
+					"%s://%s",
+				testVector.expectedNetwork,
+				testVector.expectedAddress,
+				netAddr.Network(), netAddr.String(),
+			)
+		}
+		isAddrLoopback := IsLoopback(normalized[0])
+		if testVector.isLoopback != isAddrLoopback {
+			t.Fatalf(
+				"mismatched loopback detection: expected "+
+					"%v, got %v for addr %s",
+				testVector.isLoopback, isAddrLoopback,
+				testVector.address,
+			)
+		}
+		isAddrUnix := IsUnix(normalized[0])
+		if testVector.isUnix != isAddrUnix {
+			t.Fatalf(
+				"mismatched unix detection: expected "+
+					"%v, got %v for addr %s",
+				testVector.isUnix, isAddrUnix,
+				testVector.address,
+			)
+		}
+	}
+
+	// Finally, test invalid inputs to see if they are handled correctly.
+	for _, testVector := range invalidTestVectors {
+		addr := []string{testVector}
+		_, err := NormalizeAddresses(addr, defaultTestPort)
+		if err == nil {
+			t.Fatalf("expected error when parsing %v", testVector)
+		}
+	}
+}

--- a/lnd.go
+++ b/lnd.go
@@ -522,9 +522,11 @@ func lndMain() error {
 
 	// Next, Start the gRPC server listening for HTTP/2 connections.
 	for _, listener := range cfg.RPCListeners {
-		lis, err := net.Listen("tcp", listener)
+		lis, err := listenOnAddress(listener)
 		if err != nil {
-			ltndLog.Errorf("RPC server unable to listen on %s", listener)
+			ltndLog.Errorf(
+				"RPC server unable to listen on %s", listener,
+			)
 			return err
 		}
 		defer lis.Close()
@@ -536,21 +538,25 @@ func lndMain() error {
 
 	// Finally, start the REST proxy for our gRPC server above.
 	mux := proxy.NewServeMux()
-	err = lnrpc.RegisterLightningHandlerFromEndpoint(ctx, mux,
-		cfg.RPCListeners[0], proxyOpts)
+	err = lnrpc.RegisterLightningHandlerFromEndpoint(
+		ctx, mux, cfg.RPCListeners[0].String(), proxyOpts,
+	)
 	if err != nil {
 		return err
 	}
 	for _, restEndpoint := range cfg.RESTListeners {
-		listener, err := tls.Listen("tcp", restEndpoint, tlsConf)
+		lis, err := tlsListenOnAddress(restEndpoint, tlsConf)
 		if err != nil {
-			ltndLog.Errorf("gRPC proxy unable to listen on %s", restEndpoint)
+			ltndLog.Errorf(
+				"gRPC proxy unable to listen on %s",
+				restEndpoint,
+			)
 			return err
 		}
-		defer listener.Close()
+		defer lis.Close()
 		go func() {
-			rpcsLog.Infof("gRPC proxy started at %s", listener.Addr())
-			http.Serve(listener, mux)
+			rpcsLog.Infof("gRPC proxy started at %s", lis.Addr())
+			http.Serve(lis, mux)
 		}()
 	}
 
@@ -735,6 +741,10 @@ func genCertPair(certFile, keyFile string) error {
 		dnsNames = append(dnsNames, cfg.TLSExtraDomain)
 	}
 
+	// Also add fake hostnames for unix sockets, otherwise hostname
+	// verification will fail in the client.
+	dnsNames = append(dnsNames, "unix", "unixpacket")
+
 	// Generate a private key for the certificate.
 	priv, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 	if err != nil {
@@ -883,7 +893,7 @@ type WalletUnlockParams struct {
 // waitForWalletPassword will spin up gRPC and REST endpoints for the
 // WalletUnlocker server, and block until a password is provided by
 // the user to this RPC server.
-func waitForWalletPassword(grpcEndpoints, restEndpoints []string,
+func waitForWalletPassword(grpcEndpoints, restEndpoints []net.Addr,
 	serverOpts []grpc.ServerOption, proxyOpts []grpc.DialOption,
 	tlsConf *tls.Config) (*WalletUnlockParams, error) {
 
@@ -916,17 +926,22 @@ func waitForWalletPassword(grpcEndpoints, restEndpoints []string,
 	for _, grpcEndpoint := range grpcEndpoints {
 		// Start a gRPC server listening for HTTP/2 connections, solely
 		// used for getting the encryption password from the client.
-		lis, err := net.Listen("tcp", grpcEndpoint)
+		lis, err := listenOnAddress(grpcEndpoint)
 		if err != nil {
-			ltndLog.Errorf("password RPC server unable to listen on %s",
-				grpcEndpoint)
+			ltndLog.Errorf(
+				"password RPC server unable to listen on %s",
+				grpcEndpoint,
+			)
 			return nil, err
 		}
 		defer lis.Close()
 
 		wg.Add(1)
 		go func() {
-			rpcsLog.Infof("password RPC server listening on %s", lis.Addr())
+			rpcsLog.Infof(
+				"password RPC server listening on %s",
+				lis.Addr(),
+			)
 			wg.Done()
 			grpcServer.Serve(lis)
 		}()
@@ -939,8 +954,9 @@ func waitForWalletPassword(grpcEndpoints, restEndpoints []string,
 
 	mux := proxy.NewServeMux()
 
-	err := lnrpc.RegisterWalletUnlockerHandlerFromEndpoint(ctx, mux,
-		grpcEndpoints[0], proxyOpts)
+	err := lnrpc.RegisterWalletUnlockerHandlerFromEndpoint(
+		ctx, mux, grpcEndpoints[0].String(), proxyOpts,
+	)
 	if err != nil {
 		return nil, err
 	}
@@ -948,17 +964,22 @@ func waitForWalletPassword(grpcEndpoints, restEndpoints []string,
 	srv := &http.Server{Handler: mux}
 
 	for _, restEndpoint := range restEndpoints {
-		lis, err := tls.Listen("tcp", restEndpoint, tlsConf)
+		lis, err := tlsListenOnAddress(restEndpoint, tlsConf)
 		if err != nil {
-			ltndLog.Errorf("password gRPC proxy unable to listen on %s",
-				restEndpoint)
+			ltndLog.Errorf(
+				"password gRPC proxy unable to listen on %s",
+				restEndpoint,
+			)
 			return nil, err
 		}
 		defer lis.Close()
 
 		wg.Add(1)
 		go func() {
-			rpcsLog.Infof("password gRPC proxy started at %s", lis.Addr())
+			rpcsLog.Infof(
+				"password gRPC proxy started at %s",
+				lis.Addr(),
+			)
 			wg.Done()
 			srv.Serve(lis)
 		}()

--- a/lnd.go
+++ b/lnd.go
@@ -38,6 +38,7 @@ import (
 	"github.com/lightningnetwork/lnd/autopilot"
 	"github.com/lightningnetwork/lnd/channeldb"
 	"github.com/lightningnetwork/lnd/keychain"
+	"github.com/lightningnetwork/lnd/lncfg"
 	"github.com/lightningnetwork/lnd/lnrpc"
 	"github.com/lightningnetwork/lnd/lnwallet"
 	"github.com/lightningnetwork/lnd/lnwallet/btcwallet"
@@ -522,7 +523,7 @@ func lndMain() error {
 
 	// Next, Start the gRPC server listening for HTTP/2 connections.
 	for _, listener := range cfg.RPCListeners {
-		lis, err := listenOnAddress(listener)
+		lis, err := lncfg.ListenOnAddress(listener)
 		if err != nil {
 			ltndLog.Errorf(
 				"RPC server unable to listen on %s", listener,
@@ -545,7 +546,7 @@ func lndMain() error {
 		return err
 	}
 	for _, restEndpoint := range cfg.RESTListeners {
-		lis, err := tlsListenOnAddress(restEndpoint, tlsConf)
+		lis, err := lncfg.TlsListenOnAddress(restEndpoint, tlsConf)
 		if err != nil {
 			ltndLog.Errorf(
 				"gRPC proxy unable to listen on %s",
@@ -926,7 +927,7 @@ func waitForWalletPassword(grpcEndpoints, restEndpoints []net.Addr,
 	for _, grpcEndpoint := range grpcEndpoints {
 		// Start a gRPC server listening for HTTP/2 connections, solely
 		// used for getting the encryption password from the client.
-		lis, err := listenOnAddress(grpcEndpoint)
+		lis, err := lncfg.ListenOnAddress(grpcEndpoint)
 		if err != nil {
 			ltndLog.Errorf(
 				"password RPC server unable to listen on %s",
@@ -964,7 +965,7 @@ func waitForWalletPassword(grpcEndpoints, restEndpoints []net.Addr,
 	srv := &http.Server{Handler: mux}
 
 	for _, restEndpoint := range restEndpoints {
-		lis, err := tlsListenOnAddress(restEndpoint, tlsConf)
+		lis, err := lncfg.TlsListenOnAddress(restEndpoint, tlsConf)
 		if err != nil {
 			ltndLog.Errorf(
 				"password gRPC proxy unable to listen on %s",

--- a/sample-lnd.conf
+++ b/sample-lnd.conf
@@ -14,7 +14,7 @@
 
 ; Number of logfiles that the log rotation should keep. Setting it to 0 disables deletion of old log files.
 ; maxlogfiles=3
-; 
+;
 ; Max log file size in MB before it is rotated.
 ; maxlogfilesize=10
 
@@ -29,7 +29,7 @@
 ; the line below.
 ; no-macaroons=true
 
-; Path to write the admin macaroon for lnd's RPC and REST services if it 
+; Path to write the admin macaroon for lnd's RPC and REST services if it
 ; doesn't exist. This can be set if one wishes to store the admin macaroon in a
 ; distinct location. By default, it is stored within lnd's main home directory.
 ; Applications that are able to read this file, gains admin macaroon access
@@ -38,11 +38,11 @@
 ; Path to write the read-only macaroon for lnd's RPC and REST services if it
 ; doesn't exist. This can be set if one wishes to store the read-only macaroon
 ; in a distinct location. The read only macaroon allows users which can read
-; the file to access RPC's which don't modify the state of the daemon.
+; the file to access RPCs which don't modify the state of the daemon.
 ; readonlymacaroonpath=~/.lnd/readonly.macaroon
-                       
 
-; Specify the interfaces to listen on for p2p connections.  One listen 
+
+; Specify the interfaces to listen on for p2p connections.  One listen
 ; address per line.
 ; All ipv4 on port 9735:
 ;   listen=0.0.0.0:9735
@@ -50,25 +50,29 @@
 ;   listen=0.0.0.0:9735
 ;   listen=[::1]:9736
 
-; Disable listening for incoming p2p connections.  This will override all 
+; Disable listening for incoming p2p connections.  This will override all
 ; listeners.
 ; nolisten=1
 
-; Specify the interfaces to listen on for gRPC connections.  One listen 
+; Specify the interfaces to listen on for gRPC connections.  One listen
 ; address per line.
 ; Only ipv4 localhost on port 10009:
 ;   rpclisten=localhost:10009
 ; On ipv4 localhost port 10009 and ipv6 port 10010:
 ;   rpclisten=localhost:10009
 ;   rpclisten=[::1]:10010
+; On an Unix socket:
+;   rpclisten=unix:///var/run/lnd/lnd-rpclistener.sock
 
-; Specify the interfaces to listen on for REST connections.  One listen 
+; Specify the interfaces to listen on for REST connections.  One listen
 ; address per line.
 ; All ipv4 interfaces on port 8080:
 ;   restlisten=0.0.0.0:8080
 ; On ipv4 localhost port 80 and 443:
 ;   restlisten=localhost:80
 ;   restlisten=localhost:443
+; On an Unix socket:
+;   restlisten=unix:///var/run/lnd-restlistener.sock
 
 
 ; Adding an external IP will advertise your node to the network. This signals
@@ -135,7 +139,7 @@ bitcoin.active=1
 
 ; Use Bitcoin's test network.
 ; bitcoin.testnet=1
-; 
+;
 ; Use Bitcoin's simulation test network
 bitcoin.simnet=1
 
@@ -146,7 +150,7 @@ bitcoin.simnet=1
 bitcoin.node=btcd
 
 ; Use the bitcoind back-end
-; bitcoin.node=bitcoind 
+; bitcoin.node=bitcoind
 
 ; Use the neutrino (light client) back-end
 ; bitcoin.node=neutrino
@@ -163,7 +167,7 @@ bitcoin.node=btcd
 ; setting is assumed to be localhost with the default port for the current
 ; network.
 ; btcd.rpchost=localhost
-              
+
 ; Username for RPC connections to btcd. By default, lnd will attempt to
 ; automatically obtain the credentials, so this likely won't need to be set
 ; (other than for simnet mode).
@@ -181,7 +185,7 @@ bitcoin.node=btcd
 ; The raw bytes of the daemon's PEM-encoded certificate chain which will be used
 ; to authenticate the RPC connection. This only needs to be set if the btcd
 ; node is on a remote host.
-; btcd.rawrpccert=   
+; btcd.rawrpccert=
 
 
 [Bitcoind]
@@ -190,7 +194,7 @@ bitcoin.node=btcd
 ; setting is assumed to be localhost with the default port for the current
 ; network.
 ; bitcoind.rpchost=localhost
-              
+
 ; Username for RPC connections to bitcoind. By default, lnd will attempt to
 ; automatically obtain the credentials, so this likely won't need to be set
 ; (other than for a remote bitcoind instance).
@@ -205,7 +209,7 @@ bitcoin.node=btcd
 ; bitcoind. By default, lnd will attempt to automatically obtain this
 ; information, so this likely won't need to be set (other than for a remote
 ; bitcoind instance).
-; bitcoind.zmqpath=tcp://127.0.0.1:28332 
+; bitcoind.zmqpath=tcp://127.0.0.1:28332
 
 
 [neutrino]
@@ -232,7 +236,7 @@ bitcoin.node=btcd
 litecoin.node=ltcd
 
 ; Use the litecoind back-end
-; litecoin.node=litecoind 
+; litecoin.node=litecoind
 
 
 [Ltcd]
@@ -241,7 +245,7 @@ litecoin.node=ltcd
 ; setting is assumed to be localhost with the default port for the current
 ; network.
 ; ltcd.rpchost=localhost
-              
+
 ; Username for RPC connections to ltcd. By default, lnd will attempt to
 ; automatically obtain the credentials, so this likely won't need to be set
 ; (other than for simnet mode).
@@ -259,7 +263,7 @@ litecoin.node=ltcd
 ; The raw bytes of the daemon's PEM-encoded certificate chain which will be used
 ; to authenticate the RPC connection. This only needs to be set if the ltcd
 ; node is on a remote host.
-; ltcd.rawrpccert= 
+; ltcd.rawrpccert=
 
 
 [Litecoind]
@@ -268,7 +272,7 @@ litecoin.node=ltcd
 ; setting is assumed to be localhost with the default port for the current
 ; network.
 ; litecoind.rpchost=localhost
-              
+
 ; Username for RPC connections to litecoind. By default, lnd will attempt to
 ; automatically obtain the credentials, so this likely won't need to be set
 ; (other than for a remote litecoind instance).
@@ -305,7 +309,7 @@ litecoin.node=ltcd
 [tor]
 ; The port that Tor's exposed SOCKS5 proxy is listening on. Using Tor allows
 ; outbound-only connections (listening will be disabled) -- NOTE port must be
-; between 1024 and 65535 
+; between 1024 and 65535
 ; tor.socks=9050
 
 ; The DNS server as IP:PORT that Tor will use for SRV queries - NOTE must have

--- a/server.go
+++ b/server.go
@@ -85,7 +85,7 @@ type server struct {
 
 	// listenAddrs is the list of addresses the server is currently
 	// listening on.
-	listenAddrs []string
+	listenAddrs []net.Addr
 
 	// torController is a client that will communicate with a locally
 	// running Tor server. This client will handle initiating and
@@ -207,17 +207,19 @@ func parseAddr(address string) (net.Addr, error) {
 
 // newServer creates a new instance of the server which is to listen using the
 // passed listener address.
-func newServer(listenAddrs []string, chanDB *channeldb.DB, cc *chainControl,
+func newServer(listenAddrs []net.Addr, chanDB *channeldb.DB, cc *chainControl,
 	privKey *btcec.PrivateKey) (*server, error) {
 
 	var err error
 
 	listeners := make([]net.Listener, len(listenAddrs))
-	for i, addr := range listenAddrs {
+	for i, listenAddr := range listenAddrs {
 		// Note: though brontide.NewListener uses ResolveTCPAddr, it
 		// doesn't need to call the general lndResolveTCP function
 		// since we are resolving a local address.
-		listeners[i], err = brontide.NewListener(privKey, addr)
+		listeners[i], err = brontide.NewListener(
+			privKey, listenAddr.String(),
+		)
 		if err != nil {
 			return nil, err
 		}
@@ -363,14 +365,17 @@ func newServer(listenAddrs []string, chanDB *channeldb.DB, cc *chainControl,
 
 	// If we were requested to automatically configure port forwarding,
 	// we'll use the ports that the server will be listening on.
-	externalIPs := cfg.ExternalIPs
+	externalIpStrings := make([]string, len(cfg.ExternalIPs))
+	for idx, ip := range cfg.ExternalIPs {
+		externalIpStrings[idx] = ip.String()
+	}
 	if s.natTraversal != nil {
 		listenPorts := make([]uint16, 0, len(listenAddrs))
 		for _, listenAddr := range listenAddrs {
 			// At this point, the listen addresses should have
 			// already been normalized, so it's safe to ignore the
 			// errors.
-			_, portStr, _ := net.SplitHostPort(listenAddr)
+			_, portStr, _ := net.SplitHostPort(listenAddr.String())
 			port, _ := strconv.Atoi(portStr)
 
 			listenPorts = append(listenPorts, uint16(port))
@@ -385,23 +390,21 @@ func newServer(listenAddrs []string, chanDB *channeldb.DB, cc *chainControl,
 			srvrLog.Infof("Automatically set up port forwarding "+
 				"using %s to advertise external IP",
 				s.natTraversal.Name())
-			externalIPs = append(externalIPs, ips...)
+			externalIpStrings = append(externalIpStrings, ips...)
 		}
 	}
 
 	// If external IP addresses have been specified, add those to the list
 	// of this server's addresses.
-	externalIPs = normalizeAddresses(
-		externalIPs, strconv.Itoa(defaultPeerPort),
+	externalIPs, err := normalizeAddresses(
+		externalIpStrings, strconv.Itoa(defaultPeerPort),
 	)
+	if err != nil {
+		return nil, err
+	}
 	selfAddrs := make([]net.Addr, 0, len(externalIPs))
 	for _, ip := range cfg.ExternalIPs {
-		addr, err := parseAddr(ip)
-		if err != nil {
-			return nil, err
-		}
-
-		selfAddrs = append(selfAddrs, addr)
+		selfAddrs = append(selfAddrs, ip)
 	}
 
 	// If we were requested to route connections through Tor and to
@@ -881,7 +884,7 @@ func (s *server) watchExternalIP() {
 	// them when detecting a new IP.
 	ipsSetByUser := make(map[string]struct{})
 	for _, ip := range cfg.ExternalIPs {
-		ipsSetByUser[ip] = struct{}{}
+		ipsSetByUser[ip.String()] = struct{}{}
 	}
 
 	forwardedPorts := s.natTraversal.ForwardedPorts()
@@ -1246,7 +1249,7 @@ func (s *server) initTorController() error {
 	for _, listenAddr := range s.listenAddrs {
 		// At this point, the listen addresses should have already been
 		// normalized, so it's safe to ignore the errors.
-		_, portStr, _ := net.SplitHostPort(listenAddr)
+		_, portStr, _ := net.SplitHostPort(listenAddr.String())
 		port, _ := strconv.Atoi(portStr)
 		listenPorts[port] = struct{}{}
 	}

--- a/server.go
+++ b/server.go
@@ -24,6 +24,7 @@ import (
 	"github.com/lightningnetwork/lnd/contractcourt"
 	"github.com/lightningnetwork/lnd/discovery"
 	"github.com/lightningnetwork/lnd/htlcswitch"
+	"github.com/lightningnetwork/lnd/lncfg"
 	"github.com/lightningnetwork/lnd/lnpeer"
 	"github.com/lightningnetwork/lnd/lnrpc"
 	"github.com/lightningnetwork/lnd/lnwallet"
@@ -396,7 +397,7 @@ func newServer(listenAddrs []net.Addr, chanDB *channeldb.DB, cc *chainControl,
 
 	// If external IP addresses have been specified, add those to the list
 	// of this server's addresses.
-	externalIPs, err := normalizeAddresses(
+	externalIPs, err := lncfg.NormalizeAddresses(
 		externalIpStrings, strconv.Itoa(defaultPeerPort),
 	)
 	if err != nil {


### PR DESCRIPTION
This PR fixes #1224.

Thanks a lot to @Richard87 for [his initial proposal](https://github.com/lightningnetwork/lnd/pull/495#issuecomment-355931289), I was able to use quite a lot of that code.

As described in the issue, Unix sockets are only supported for the gRPC and REST listeners. It doesn't make sense for the p2p listener to listen on an Unix socket.

Currently, TLS cannot be disabled on any of the servers, not even for the loopback interface. So the same applies for Unix sockets, they still require a client certificate to connect.