### PR TITLE
Docker: build from local code

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,11 +4,13 @@ FROM golang:alpine as builder
 # queries required to connect to linked containers succeed.
 ENV GODEBUG netdns=cgo
 
+# Copy in the local repository to build from.
+COPY . /go/src/github.com/lightningnetwork/lnd
+
 # Install dependencies and build the binaries.
 RUN apk add --no-cache \
     git \
     make \
-&&  git clone https://github.com/lightningnetwork/lnd /go/src/github.com/lightningnetwork/lnd \
 &&  cd /go/src/github.com/lightningnetwork/lnd \
 &&  make \
 &&  make install


### PR DESCRIPTION
This PR slightly adjusts the main Dockerfile to match the one in the docker folder to build from local code rather than pulling from git.

Currently if automated builds are configured, the `latest` tag will always be what's in the repository but if a tag is created on the main repo, when it builds on Docker Hub it will just pull in the latest code in the Dockerfile.

TL;DR This allows automated tagged builds on Docker Hub.