### PR TITLE
statsd: proof of concept

### DIFF
--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -102,6 +102,10 @@
   name = "gopkg.in/macaroon.v2"
   revision = "bed2a428da6e56d950bed5b41fcbae3141e5b0d0"
 
+[[constraint]]
+  name = "github.com/quipo/statsd"
+  revision = "3d6a5565f3141ac42f8353d97b2c016da2752006"
+
 [prune]
   go-tests = true
   unused-packages = true

--- a/peer.go
+++ b/peer.go
@@ -511,6 +511,9 @@ func (p *peer) readNextMessage() (lnwire.Message, error) {
 	// TODO(roasbeef): add message summaries
 	p.logWireMessage(nextMsg, true)
 
+	// Track the message
+	p.trackWireMessage(nextMsg, true)
+
 	return nextMsg, nil
 }
 
@@ -1101,6 +1104,95 @@ func (p *peer) logWireMessage(msg lnwire.Message, read bool) {
 	}))
 }
 
+// messageStat returns a statsd, and human, readable string that describes an
+// incoming/outgoing message.
+func messageStat(msg lnwire.Message) string {
+	switch msg.(type) {
+	case *lnwire.Init:
+		return "init"
+
+	case *lnwire.OpenChannel:
+		return "open_channel"
+
+	case *lnwire.AcceptChannel:
+		return "accept_channel"
+
+	case *lnwire.FundingCreated:
+		return "funding_created"
+
+	case *lnwire.FundingSigned:
+		return "funding_signed"
+
+	case *lnwire.FundingLocked:
+		return "funding_locked"
+
+	case *lnwire.Shutdown:
+		return "shutdown"
+
+	case *lnwire.ClosingSigned:
+		return "closing_signed"
+
+	case *lnwire.UpdateAddHTLC:
+		return "update_add_htlc"
+
+	case *lnwire.UpdateFailHTLC:
+		return "update_fail_htlc"
+
+	case *lnwire.UpdateFulfillHTLC:
+		return "update_fulfill_htlc"
+
+	case *lnwire.CommitSig:
+		return "commit_sig"
+
+	case *lnwire.RevokeAndAck:
+		return "revoke_and_ack"
+
+	case *lnwire.UpdateFailMalformedHTLC:
+		return "update_fail_malformed_htlc"
+
+	case *lnwire.Error:
+		return "error"
+
+	case *lnwire.AnnounceSignatures:
+		return "announce_signatures"
+
+	case *lnwire.ChannelAnnouncement:
+		return "channel_announcement"
+
+	case *lnwire.ChannelUpdate:
+		return "channel_update"
+
+	case *lnwire.NodeAnnouncement:
+		return "node_announcement"
+
+	case *lnwire.Ping:
+		return "ping"
+
+	case *lnwire.Pong:
+		return "pong"
+
+	case *lnwire.UpdateFee:
+		return "update_fee"
+
+	case *lnwire.ChannelReestablish:
+		return "channel_reestablish"
+	}
+
+	return ""
+}
+
+// trackWireMessage tracks the receipt or sending of particular wire message.
+func (p *peer) trackWireMessage(msg lnwire.Message, read bool) {
+	prefix := "peer.received"
+	if !read {
+		prefix = "peer.sending"
+	}
+
+	stat := fmt.Sprintf("%v.%v", prefix, messageStat(msg))
+
+	p.server.statsd.Increment(stat, 1)
+}
+
 // writeMessage writes the target lnwire.Message to the remote peer.
 func (p *peer) writeMessage(msg lnwire.Message) error {
 	// Simply exit if we're shutting down.
@@ -1110,6 +1202,9 @@ func (p *peer) writeMessage(msg lnwire.Message) error {
 
 	// TODO(roasbeef): add message summaries
 	p.logWireMessage(msg, false)
+
+	// Track the message
+	p.trackWireMessage(msg, false)
 
 	// We'll re-slice of static write buffer to allow this new message to
 	// utilize all available space. We also ensure we cap the capacity of

--- a/server.go
+++ b/server.go
@@ -125,6 +125,8 @@ type server struct {
 
 	connMgr *connmgr.ConnManager
 
+	statsd *statsdConnection
+
 	// globalFeatures feature vector which affects HTLCs and thus are also
 	// advertised to other nodes.
 	globalFeatures *lnwire.FeatureVector
@@ -541,6 +543,12 @@ func newServer(listenAddrs []string, chanDB *channeldb.DB, cc *chainControl,
 		return nil, err
 	}
 	s.connMgr = cmgr
+
+	statsd, err := NewStatsdConnection()
+	if err != nil {
+		return nil, err
+	}
+	s.statsd = statsd
 
 	return s, nil
 }

--- a/statsd.go
+++ b/statsd.go
@@ -1,0 +1,51 @@
+package main
+
+import (
+	"time"
+	"github.com/quipo/statsd"
+)
+
+var (
+	statsdInterval = time.Second * 2
+)
+
+const (
+	statsdPrefix   = "lnd."
+	statsdAddress  = "localhost:8125"
+)
+
+type statsdConnection struct {
+	statsdClient *statsd.StatsdClient
+	statsdBuffer *statsd.StatsdBuffer
+}
+
+// NewStatsdConnection opens a new statsd connection.
+func NewStatsdConnection() (*statsdConnection, error) {
+	client := statsd.NewStatsdClient(statsdAddress, statsdPrefix)
+
+	err := client.CreateSocket()
+	if err != nil {
+		return nil, err
+	}
+
+	buffer := statsd.NewStatsdBuffer(statsdInterval, client)
+
+	conn := &statsdConnection{
+		statsdClient: client,
+		statsdBuffer: buffer,
+	}
+
+	return conn, nil
+}
+
+// Close closes the statsd connection.
+func (c *statsdConnection) Close() error {
+	c.statsdBuffer.Close()
+
+	return nil
+}
+
+// Increment increments the stat with the count.
+func (c *statsdConnection) Increment(stat string, count int64) {
+	c.statsdBuffer.Incr(stat, count)
+}


### PR DESCRIPTION
This is a _proof of concept_ for a [StatsD](https://github.com/etsy/statsd) integration. It already works and gathers statistics about peers, similarly to `logWireMessage`. It can be useful to collect [any metric](https://github.com/etsy/statsd/blob/master/docs/metric_types.md) (counts, samples, gauges, timings etc.) in real time and, importantly, measure the real-world performance in a machine- and dashboard-friendly format, increase the observability. There's [a](https://graphiteapp.org/) [huge](https://grafana.com/) [ecosystem](https://www.datadoghq.com/) around the protocol, which [has advantages over others](https://mobile.twitter.com/copyconstruct/status/965985224684273665?s=19).

Gotchas:

 * I have mixed feelings about embedding the `statsdConnection` in  `server`. It should be either global or per package, increasing granularity.
 * The code could be abstracted to `stats` or `telemetry`, enabling other integrations or use cases (#1253 ? scoring?).
 * The code could be enabled with a [build tag](https://dave.cheney.net/2013/10/12/how-to-use-conditional-compilation-with-the-go-build-tool).
 * Which data points are the most important? What is the MVP here?



Before commiting more time, I would like to hear what you think.