### PR TITLE
walletunlocker: use KeyDerivationVersion for generating cipher seed

### DIFF
--- a/walletunlocker/service.go
+++ b/walletunlocker/service.go
@@ -12,6 +12,7 @@ import (
 	"github.com/roasbeef/btcd/chaincfg"
 	"github.com/roasbeef/btcwallet/wallet"
 	"golang.org/x/net/context"
+	"github.com/lightningnetwork/lnd/keychain"
 )
 
 // WalletInitMsg is a message sent by the UnlockerService when a user wishes to
@@ -129,8 +130,9 @@ func (u *UnlockerService) GenSeed(ctx context.Context,
 	// Now that we have our set of entropy, we'll create a new cipher seed
 	// instance.
 	//
-	// TODO(roasbeef): should use current keychain version here
-	cipherSeed, err := aezeed.New(0, &entropy, time.Now())
+	cipherSeed, err := aezeed.New(
+		keychain.KeyDerivationVersion, &entropy, time.Now(),
+	)
 	if err != nil {
 		return nil, err
 	}

--- a/walletunlocker/service_test.go
+++ b/walletunlocker/service_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/roasbeef/btcd/chaincfg"
 	"github.com/roasbeef/btcwallet/wallet"
 	"golang.org/x/net/context"
+	"github.com/lightningnetwork/lnd/keychain"
 )
 
 const (
@@ -189,7 +190,9 @@ func TestInitWallet(t *testing.T) {
 
 	// Once we have the unlocker service created, we'll now instantiate a
 	// new cipher seed instance.
-	cipherSeed, err := aezeed.New(0, &testEntropy, time.Now())
+	cipherSeed, err := aezeed.New(
+		keychain.KeyDerivationVersion, &testEntropy, time.Now(),
+	)
 	if err != nil {
 		t.Fatalf("unable to create seed: %v", err)
 	}


### PR DESCRIPTION
Replace hard coded internal version with KeyDerivationVersion specified
in keychain package.