### PR TITLE
chainntnfs: introduce persistent height hint layer to ChainNotifier implementations

### DIFF
--- a/chainntnfs/bitcoindnotify/bitcoind.go
+++ b/chainntnfs/bitcoindnotify/bitcoind.go
@@ -869,6 +869,18 @@ type confirmationNotification struct {
 func (b *BitcoindNotifier) RegisterConfirmationsNtfn(txid *chainhash.Hash,
 	_ []byte, numConfs, heightHint uint32) (*chainntnfs.ConfirmationEvent, error) {
 
+	// Before proceeding to register the notification, we'll query our
+	// height hint cache to determine whether a better one exists.
+	if hint, err := b.confirmHintCache.QueryConfirmHint(*txid); err == nil {
+		if hint > heightHint {
+			chainntnfs.Log.Debugf("Using height hint %d retrieved "+
+				"from cache for %v", hint, txid)
+			heightHint = hint
+		}
+	}
+
+	// Construct a notification request for the transaction and send it to
+	// the main event loop.
 	ntfn := &confirmationNotification{
 		ConfNtfn: chainntnfs.ConfNtfn{
 			ConfID:           atomic.AddUint64(&b.confClientCounter, 1),

--- a/chainntnfs/bitcoindnotify/bitcoind_debug.go
+++ b/chainntnfs/bitcoindnotify/bitcoind_debug.go
@@ -29,7 +29,8 @@ func (b *BitcoindNotifier) UnsafeStart(bestHeight int32, bestHash *chainhash.Has
 	}
 
 	b.txConfNotifier = chainntnfs.NewTxConfNotifier(
-		uint32(bestHeight), reorgSafetyLimit)
+		uint32(bestHeight), reorgSafetyLimit, b.confirmHintCache,
+	)
 
 	if generateBlocks != nil {
 		// Ensure no block notifications are pending when we start the

--- a/chainntnfs/bitcoindnotify/driver.go
+++ b/chainntnfs/bitcoindnotify/driver.go
@@ -1,6 +1,7 @@
 package bitcoindnotify
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/btcsuite/btcwallet/chain"
@@ -10,18 +11,30 @@ import (
 // createNewNotifier creates a new instance of the ChainNotifier interface
 // implemented by BitcoindNotifier.
 func createNewNotifier(args ...interface{}) (chainntnfs.ChainNotifier, error) {
-	if len(args) != 1 {
+	if len(args) != 3 {
 		return nil, fmt.Errorf("incorrect number of arguments to "+
-			".New(...), expected 1, instead passed %v", len(args))
+			".New(...), expected 2, instead passed %v", len(args))
 	}
 
 	chainConn, ok := args[0].(*chain.BitcoindConn)
 	if !ok {
-		return nil, fmt.Errorf("first argument to bitcoindnotify.New " +
+		return nil, errors.New("first argument to bitcoindnotify.New " +
 			"is incorrect, expected a *chain.BitcoindConn")
 	}
 
-	return New(chainConn), nil
+	spendHintCache, ok := args[1].(chainntnfs.SpendHintCache)
+	if !ok {
+		return nil, errors.New("second argument to bitcoindnotify.New " +
+			"is incorrect, expected a chainntnfs.SpendHintCache")
+	}
+
+	confirmHintCache, ok := args[2].(chainntnfs.ConfirmHintCache)
+	if !ok {
+		return nil, errors.New("third argument to bitcoindnotify.New " +
+			"is incorrect, expected a chainntnfs.ConfirmHintCache")
+	}
+
+	return New(chainConn, spendHintCache, confirmHintCache), nil
 }
 
 // init registers a driver for the BtcdNotifier concrete implementation of the

--- a/chainntnfs/btcdnotify/btcd_debug.go
+++ b/chainntnfs/btcdnotify/btcd_debug.go
@@ -28,7 +28,8 @@ func (b *BtcdNotifier) UnsafeStart(bestHeight int32, bestHash *chainhash.Hash,
 	}
 
 	b.txConfNotifier = chainntnfs.NewTxConfNotifier(
-		uint32(bestHeight), reorgSafetyLimit)
+		uint32(bestHeight), reorgSafetyLimit, b.confirmHintCache,
+	)
 
 	b.chainUpdates.Start()
 	b.txUpdates.Start()

--- a/chainntnfs/btcdnotify/driver.go
+++ b/chainntnfs/btcdnotify/driver.go
@@ -1,6 +1,7 @@
 package btcdnotify
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/btcsuite/btcd/rpcclient"
@@ -10,18 +11,30 @@ import (
 // createNewNotifier creates a new instance of the ChainNotifier interface
 // implemented by BtcdNotifier.
 func createNewNotifier(args ...interface{}) (chainntnfs.ChainNotifier, error) {
-	if len(args) != 1 {
-		return nil, fmt.Errorf("incorrect number of arguments to .New(...), "+
-			"expected 1, instead passed %v", len(args))
+	if len(args) != 3 {
+		return nil, fmt.Errorf("incorrect number of arguments to "+
+			".New(...), expected 2, instead passed %v", len(args))
 	}
 
 	config, ok := args[0].(*rpcclient.ConnConfig)
 	if !ok {
-		return nil, fmt.Errorf("first argument to btcdnotifier.New is " +
-			"incorrect, expected a *rpcclient.ConnConfig")
+		return nil, errors.New("first argument to btcdnotifier.New " +
+			"is incorrect, expected a *rpcclient.ConnConfig")
 	}
 
-	return New(config)
+	spendHintCache, ok := args[1].(chainntnfs.SpendHintCache)
+	if !ok {
+		return nil, errors.New("second argument to btcdnotifier.New " +
+			"is incorrect, expected a chainntnfs.SpendHintCache")
+	}
+
+	confirmHintCache, ok := args[2].(chainntnfs.ConfirmHintCache)
+	if !ok {
+		return nil, errors.New("third argument to btcdnotifier.New " +
+			"is incorrect, expected a chainntnfs.ConfirmHintCache")
+	}
+
+	return New(config, spendHintCache, confirmHintCache)
 }
 
 // init registers a driver for the BtcdNotifier concrete implementation of the

--- a/chainntnfs/height_hint_cache.go
+++ b/chainntnfs/height_hint_cache.go
@@ -1,0 +1,297 @@
+package chainntnfs
+
+import (
+	"bytes"
+	"errors"
+
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"github.com/btcsuite/btcd/wire"
+	bolt "github.com/coreos/bbolt"
+	"github.com/lightningnetwork/lnd/channeldb"
+)
+
+const (
+	// dbName is the default name of the database storing the height hints.
+	dbName = "heighthint.db"
+
+	// dbFilePermission is the default permission of the database file
+	// storing the height hints.
+	dbFilePermission = 0600
+)
+
+var (
+	// spendHintBucket is the name of the bucket which houses the height
+	// hint for outpoints. Each height hint represents the earliest height
+	// at which its corresponding outpoint could have been spent within.
+	spendHintBucket = []byte("spend-hints")
+
+	// confirmHintBucket is the name of the bucket which houses the height
+	// hints for transactions. Each height hint represents the earliest
+	// height at which its corresponding transaction could have been
+	// confirmed within.
+	confirmHintBucket = []byte("confirm-hints")
+
+	// ErrCorruptedHeightHintCache indicates that the on-disk bucketing
+	// structure has altered since the height hint cache instance was
+	// initialized.
+	ErrCorruptedHeightHintCache = errors.New("height hint cache has been " +
+		"corrupted")
+
+	// ErrSpendHintNotFound is an error returned when a spend hint for an
+	// outpoint was not found.
+	ErrSpendHintNotFound = errors.New("spend hint not found")
+
+	// ErrConfirmHintNotFound is an error returned when a confirm hint for a
+	// transaction was not found.
+	ErrConfirmHintNotFound = errors.New("confirm hint not found")
+)
+
+// SpendHintCache is an interface whose duty is to cache spend hints for
+// outpoints. A spend hint is defined as the earliest height in the chain at
+// which an outpoint could have been spent within.
+type SpendHintCache interface {
+	// CommitSpendHint commits a spend hint for the outpoints to the cache.
+	CommitSpendHint(height uint32, ops ...wire.OutPoint) error
+
+	// QuerySpendHint returns the latest spend hint for an outpoint.
+	// ErrSpendHintNotFound is returned if a spend hint does not exist
+	// within the cache for the outpoint.
+	QuerySpendHint(op wire.OutPoint) (uint32, error)
+
+	// PurgeSpendHint removes the spend hint for the outpoints from the
+	// cache.
+	PurgeSpendHint(ops ...wire.OutPoint) error
+}
+
+// ConfirmHintCache is an interface whose duty is to cache confirm hints for
+// transactions. A confirm hint is defined as the earliest height in the chain
+// at which a transaction could have been included in a block.
+type ConfirmHintCache interface {
+	// CommitConfirmHint commits a confirm hint for the transactions to the
+	// cache.
+	CommitConfirmHint(height uint32, txids ...chainhash.Hash) error
+
+	// QueryConfirmHint returns the latest confirm hint for a transaction
+	// hash. ErrConfirmHintNotFound is returned if a confirm hint does not
+	// exist within the cache for the transaction hash.
+	QueryConfirmHint(txid chainhash.Hash) (uint32, error)
+
+	// PurgeConfirmHint removes the confirm hint for the transactions from
+	// the cache.
+	PurgeConfirmHint(txids ...chainhash.Hash) error
+}
+
+// HeightHintCache is an implementation of the SpendHintCache and
+// ConfirmHintCache interfaces backed by a channeldb DB instance where the hints
+// will be stored.
+type HeightHintCache struct {
+	db *channeldb.DB
+}
+
+// Compile-time checks to ensure HeightHintCache satisfies the SpendHintCache
+// and ConfirmHintCache interfaces.
+var _ SpendHintCache = (*HeightHintCache)(nil)
+var _ ConfirmHintCache = (*HeightHintCache)(nil)
+
+// NewHeightHintCache returns a new height hint cache backed by a database.
+func NewHeightHintCache(db *channeldb.DB) (*HeightHintCache, error) {
+	cache := &HeightHintCache{db}
+	if err := cache.initBuckets(); err != nil {
+		return nil, err
+	}
+
+	return cache, nil
+}
+
+// initBuckets ensures that the primary buckets used by the circuit are
+// initialized so that we can assume their existence after startup.
+func (c *HeightHintCache) initBuckets() error {
+	return c.db.Update(func(tx *bolt.Tx) error {
+		_, err := tx.CreateBucketIfNotExists(spendHintBucket)
+		if err != nil {
+			return err
+		}
+
+		_, err = tx.CreateBucketIfNotExists(confirmHintBucket)
+		return err
+	})
+}
+
+// CommitSpendHint commits a spend hint for the outpoints to the cache.
+func (c *HeightHintCache) CommitSpendHint(height uint32, ops ...wire.OutPoint) error {
+	Log.Tracef("Updating spend hint to height %d for %v", height, ops)
+
+	return c.db.Batch(func(tx *bolt.Tx) error {
+		spendHints := tx.Bucket(spendHintBucket)
+		if spendHints == nil {
+			return ErrCorruptedHeightHintCache
+		}
+
+		var hint bytes.Buffer
+		if err := channeldb.WriteElement(&hint, height); err != nil {
+			return err
+		}
+
+		for _, op := range ops {
+			var outpoint bytes.Buffer
+			err := channeldb.WriteElement(&outpoint, op)
+			if err != nil {
+				return err
+			}
+
+			err = spendHints.Put(outpoint.Bytes(), hint.Bytes())
+			if err != nil {
+				return err
+			}
+		}
+
+		return nil
+	})
+}
+
+// QuerySpendHint returns the latest spend hint for an outpoint.
+// ErrSpendHintNotFound is returned if a spend hint does not exist within the
+// cache for the outpoint.
+func (c *HeightHintCache) QuerySpendHint(op wire.OutPoint) (uint32, error) {
+	var hint uint32
+	err := c.db.View(func(tx *bolt.Tx) error {
+		spendHints := tx.Bucket(spendHintBucket)
+		if spendHints == nil {
+			return ErrCorruptedHeightHintCache
+		}
+
+		var outpoint bytes.Buffer
+		if err := channeldb.WriteElement(&outpoint, op); err != nil {
+			return err
+		}
+
+		spendHint := spendHints.Get(outpoint.Bytes())
+		if spendHint == nil {
+			return ErrSpendHintNotFound
+		}
+
+		return channeldb.ReadElement(bytes.NewReader(spendHint), &hint)
+	})
+	if err != nil {
+		return 0, err
+	}
+
+	return hint, nil
+}
+
+// PurgeSpendHint removes the spend hint for the outpoints from the cache.
+func (c *HeightHintCache) PurgeSpendHint(ops ...wire.OutPoint) error {
+	Log.Tracef("Removing spend hints for %v", ops)
+
+	return c.db.Batch(func(tx *bolt.Tx) error {
+		spendHints := tx.Bucket(spendHintBucket)
+		if spendHints == nil {
+			return ErrCorruptedHeightHintCache
+		}
+
+		for _, op := range ops {
+			var outpoint bytes.Buffer
+			err := channeldb.WriteElement(&outpoint, op)
+			if err != nil {
+				return err
+			}
+
+			err = spendHints.Delete(outpoint.Bytes())
+			if err != nil {
+				return err
+			}
+		}
+
+		return nil
+	})
+}
+
+// CommitConfirmHint commits a confirm hint for the transactions to the cache.
+func (c *HeightHintCache) CommitConfirmHint(height uint32, txids ...chainhash.Hash) error {
+	Log.Tracef("Updating confirm hints to height %d for %v", height, txids)
+
+	return c.db.Batch(func(tx *bolt.Tx) error {
+		confirmHints := tx.Bucket(confirmHintBucket)
+		if confirmHints == nil {
+			return ErrCorruptedHeightHintCache
+		}
+
+		var hint bytes.Buffer
+		if err := channeldb.WriteElement(&hint, height); err != nil {
+			return err
+		}
+
+		for _, txid := range txids {
+			var txHash bytes.Buffer
+			err := channeldb.WriteElement(&txHash, txid)
+			if err != nil {
+				return err
+			}
+
+			err = confirmHints.Put(txHash.Bytes(), hint.Bytes())
+			if err != nil {
+				return err
+			}
+		}
+
+		return nil
+	})
+}
+
+// QueryConfirmHint returns the latest confirm hint for a transaction hash.
+// ErrConfirmHintNotFound is returned if a confirm hint does not exist within
+// the cache for the transaction hash.
+func (c *HeightHintCache) QueryConfirmHint(txid chainhash.Hash) (uint32, error) {
+	var hint uint32
+	err := c.db.View(func(tx *bolt.Tx) error {
+		confirmHints := tx.Bucket(confirmHintBucket)
+		if confirmHints == nil {
+			return ErrCorruptedHeightHintCache
+		}
+
+		var txHash bytes.Buffer
+		if err := channeldb.WriteElement(&txHash, txid); err != nil {
+			return err
+		}
+
+		confirmHint := confirmHints.Get(txHash.Bytes())
+		if confirmHint == nil {
+			return ErrConfirmHintNotFound
+		}
+
+		return channeldb.ReadElement(bytes.NewReader(confirmHint), &hint)
+	})
+	if err != nil {
+		return 0, err
+	}
+
+	return hint, nil
+}
+
+// PurgeConfirmHint removes the confirm hint for the transactions from the
+// cache.
+func (c *HeightHintCache) PurgeConfirmHint(txids ...chainhash.Hash) error {
+	Log.Tracef("Removing confirm hints for %v", txids)
+
+	return c.db.Batch(func(tx *bolt.Tx) error {
+		confirmHints := tx.Bucket(confirmHintBucket)
+		if confirmHints == nil {
+			return ErrCorruptedHeightHintCache
+		}
+
+		for _, txid := range txids {
+			var txHash bytes.Buffer
+			err := channeldb.WriteElement(&txHash, txid)
+			if err != nil {
+				return err
+			}
+
+			err = confirmHints.Delete(txHash.Bytes())
+			if err != nil {
+				return err
+			}
+		}
+
+		return nil
+	})
+}

--- a/chainntnfs/height_hint_cache_test.go
+++ b/chainntnfs/height_hint_cache_test.go
@@ -1,0 +1,148 @@
+package chainntnfs
+
+import (
+	"bytes"
+	"io/ioutil"
+	"testing"
+
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"github.com/btcsuite/btcd/wire"
+	"github.com/lightningnetwork/lnd/channeldb"
+)
+
+func initHintCache(t *testing.T) *HeightHintCache {
+	t.Helper()
+
+	tempDir, err := ioutil.TempDir("", "kek")
+	if err != nil {
+		t.Fatalf("unable to create temp dir: %v", err)
+	}
+	db, err := channeldb.Open(tempDir)
+	if err != nil {
+		t.Fatalf("unable to create db: %v", err)
+	}
+	hintCache, err := NewHeightHintCache(db)
+	if err != nil {
+		t.Fatalf("unable to create hint cache: %v", err)
+	}
+
+	return hintCache
+}
+
+// TestHeightHintCacheConfirms ensures that the height hint cache properly
+// caches confirm hints for transactions.
+func TestHeightHintCacheConfirms(t *testing.T) {
+	t.Parallel()
+
+	hintCache := initHintCache(t)
+
+	// Querying for a transaction hash not found within the cache should
+	// return an error indication so.
+	var unknownHash chainhash.Hash
+	_, err := hintCache.QueryConfirmHint(unknownHash)
+	if err != ErrConfirmHintNotFound {
+		t.Fatalf("expected ErrConfirmHintNotFound, got: %v", err)
+	}
+
+	// Now, we'll create some transaction hashes and commit them to the
+	// cache with the same confirm hint.
+	const height = 100
+	const numHashes = 5
+	txHashes := make([]chainhash.Hash, numHashes)
+	for i := 0; i < numHashes; i++ {
+		var txHash chainhash.Hash
+		copy(txHash[:], bytes.Repeat([]byte{byte(i)}, 32))
+		txHashes[i] = txHash
+	}
+
+	if err := hintCache.CommitConfirmHint(height, txHashes...); err != nil {
+		t.Fatalf("unable to add entries to cache: %v", err)
+	}
+
+	// With the hashes committed, we'll now query the cache to ensure that
+	// we're able to properly retrieve the confirm hints.
+	for _, txHash := range txHashes {
+		confirmHint, err := hintCache.QueryConfirmHint(txHash)
+		if err != nil {
+			t.Fatalf("unable to query for hint: %v", err)
+		}
+		if confirmHint != height {
+			t.Fatalf("expected confirm hint %d, got %d", height,
+				confirmHint)
+		}
+	}
+
+	// We'll also attempt to purge all of them in a single database
+	// transaction.
+	if err := hintCache.PurgeConfirmHint(txHashes...); err != nil {
+		t.Fatalf("unable to remove confirm hints: %v", err)
+	}
+
+	// Finally, we'll attempt to query for each hash. We should expect not
+	// to find a hint for any of them.
+	for _, txHash := range txHashes {
+		_, err := hintCache.QueryConfirmHint(txHash)
+		if err != ErrConfirmHintNotFound {
+			t.Fatalf("expected ErrConfirmHintNotFound, got :%v", err)
+		}
+	}
+}
+
+// TestHeightHintCacheSpends ensures that the height hint cache properly caches
+// spend hints for outpoints.
+func TestHeightHintCacheSpends(t *testing.T) {
+	t.Parallel()
+
+	hintCache := initHintCache(t)
+
+	// Querying for an outpoint not found within the cache should return an
+	// error indication so.
+	var unknownOutPoint wire.OutPoint
+	_, err := hintCache.QuerySpendHint(unknownOutPoint)
+	if err != ErrSpendHintNotFound {
+		t.Fatalf("expected ErrSpendHintNotFound, got: %v", err)
+	}
+
+	// Now, we'll create some outpoints and commit them to the cache with
+	// the same spend hint.
+	const height = 100
+	const numOutpoints = 5
+	var txHash chainhash.Hash
+	copy(txHash[:], bytes.Repeat([]byte{0xFF}, 32))
+	outpoints := make([]wire.OutPoint, numOutpoints)
+	for i := uint32(0); i < numOutpoints; i++ {
+		outpoints[i] = wire.OutPoint{Hash: txHash, Index: i}
+	}
+
+	if err := hintCache.CommitSpendHint(height, outpoints...); err != nil {
+		t.Fatalf("unable to add entry to cache: %v", err)
+	}
+
+	// With the outpoints committed, we'll now query the cache to ensure
+	// that we're able to properly retrieve the confirm hints.
+	for _, op := range outpoints {
+		spendHint, err := hintCache.QuerySpendHint(op)
+		if err != nil {
+			t.Fatalf("unable to query for hint: %v", err)
+		}
+		if spendHint != height {
+			t.Fatalf("expected spend hint %d, got %d", height,
+				spendHint)
+		}
+	}
+
+	// We'll also attempt to purge all of them in a single database
+	// transaction.
+	if err := hintCache.PurgeSpendHint(outpoints...); err != nil {
+		t.Fatalf("unable to remove spend hint: %v", err)
+	}
+
+	// Finally, we'll attempt to query for each outpoint. We should expect
+	// not to find a hint for any of them.
+	for _, op := range outpoints {
+		_, err = hintCache.QuerySpendHint(op)
+		if err != ErrSpendHintNotFound {
+			t.Fatalf("expected ErrSpendHintNotFound, got: %v", err)
+		}
+	}
+}

--- a/chainntnfs/neutrinonotify/driver.go
+++ b/chainntnfs/neutrinonotify/driver.go
@@ -1,6 +1,7 @@
 package neutrinonotify
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/lightninglabs/neutrino"
@@ -10,18 +11,30 @@ import (
 // createNewNotifier creates a new instance of the ChainNotifier interface
 // implemented by NeutrinoNotifier.
 func createNewNotifier(args ...interface{}) (chainntnfs.ChainNotifier, error) {
-	if len(args) != 1 {
-		return nil, fmt.Errorf("incorrect number of arguments to .New(...), "+
-			"expected 1, instead passed %v", len(args))
+	if len(args) != 2 {
+		return nil, fmt.Errorf("incorrect number of arguments to "+
+			".New(...), expected 2, instead passed %v", len(args))
 	}
 
 	config, ok := args[0].(*neutrino.ChainService)
 	if !ok {
-		return nil, fmt.Errorf("first argument to neutrinonotify.New is " +
-			"incorrect, expected a *neutrino.ChainService")
+		return nil, errors.New("first argument to neutrinonotify.New " +
+			"is incorrect, expected a *neutrino.ChainService")
 	}
 
-	return New(config)
+	spendHintCache, ok := args[1].(chainntnfs.SpendHintCache)
+	if !ok {
+		return nil, errors.New("second argument to neutrinonotify.New " +
+			"is  incorrect, expected a chainntfs.SpendHintCache")
+	}
+
+	confirmHintCache, ok := args[2].(chainntnfs.ConfirmHintCache)
+	if !ok {
+		return nil, errors.New("third argument to neutrinonotify.New " +
+			"is  incorrect, expected a chainntfs.ConfirmHintCache")
+	}
+
+	return New(config, spendHintCache, confirmHintCache)
 }
 
 // init registers a driver for the NeutrinoNotify concrete implementation of

--- a/chainntnfs/neutrinonotify/neutrino.go
+++ b/chainntnfs/neutrinonotify/neutrino.go
@@ -603,22 +603,23 @@ func (n *NeutrinoNotifier) handleBlockConnected(newBlock *filteredBlock) error {
 	// First process the block for our internal state. A new block has
 	// been connected to the main chain. Send out any N confirmation
 	// notifications which may have been triggered by this new block.
-	err := n.txConfNotifier.ConnectTip(&newBlock.hash, newBlock.height,
-		newBlock.txns)
+	err := n.txConfNotifier.ConnectTip(
+		&newBlock.hash, newBlock.height, newBlock.txns,
+	)
 	if err != nil {
 		return fmt.Errorf("unable to connect tip: %v", err)
 	}
 
-	chainntnfs.Log.Infof("New block: height=%v, sha=%v",
-		newBlock.height, newBlock.hash)
+	chainntnfs.Log.Infof("New block: height=%v, sha=%v", newBlock.height,
+		newBlock.hash)
 
 	n.bestHeight = newBlock.height
 
 	// Next, notify any subscribed clients of the block.
 	n.notifyBlockEpochs(int32(newBlock.height), &newBlock.hash)
 
-	// Finally, we'll scan over the list of relevant transactions and
-	// possibly dispatch notifications for confirmations and spends.
+	// Scan over the list of relevant transactions and possibly dispatch
+	// notifications for spends.
 	for _, tx := range newBlock.txns {
 		mtx := tx.MsgTx()
 		txSha := mtx.TxHash()
@@ -658,6 +659,24 @@ func (n *NeutrinoNotifier) handleBlockConnected(newBlock *filteredBlock) error {
 			}
 
 			delete(n.spendNotifications, prevOut)
+		}
+	}
+
+	// Finally, we'll update the spend height hint for all of our watched
+	// outpoints that have not been spent yet. This is safe to do as we do
+	// not watch already spent outpoints for spend notifications.
+	ops := make([]wire.OutPoint, 0, len(n.spendNotifications))
+	for op := range n.spendNotifications {
+		ops = append(ops, op)
+	}
+
+	if len(ops) > 0 {
+		err := n.spendHintCache.CommitSpendHint(newBlock.height, ops...)
+		if err != nil {
+			// The error is not fatal, so we should not return an
+			// error to the caller.
+			chainntnfs.Log.Errorf("Unable to update spend hint to "+
+				"%d for %v: %v", newBlock.height, ops, err)
 		}
 	}
 
@@ -740,15 +759,26 @@ func (n *NeutrinoNotifier) RegisterSpendNtfn(outpoint *wire.OutPoint,
 	currentHeight := n.bestHeight
 	n.heightMtx.RUnlock()
 
-	chainntnfs.Log.Infof("New spend notification for outpoint=%v, "+
-		"height_hint=%v", outpoint, heightHint)
+	// Before proceeding to register the notification, we'll query our
+	// height hint cache to determine whether a better one exists.
+	if hint, err := n.spendHintCache.QuerySpendHint(*outpoint); err == nil {
+		if hint > heightHint {
+			chainntnfs.Log.Debugf("Using height hint %d retrieved "+
+				"from cache for %v", hint, outpoint)
+			heightHint = hint
+		}
+	}
 
+	// Construct a notification request for the outpoint. We'll defer
+	// sending it to the main event loop until after we've guaranteed that
+	// the outpoint has not been spent.
 	ntfn := &spendNotification{
 		targetOutpoint: outpoint,
 		spendChan:      make(chan *chainntnfs.SpendDetail, 1),
 		spendID:        atomic.AddUint64(&n.spendClientCounter, 1),
 		heightHint:     heightHint,
 	}
+
 	spendEvent := &chainntnfs.SpendEvent{
 		Spend: ntfn.spendChan,
 		Cancel: func() {
@@ -760,8 +790,9 @@ func (n *NeutrinoNotifier) RegisterSpendNtfn(outpoint *wire.OutPoint,
 			// Submit spend cancellation to notification dispatcher.
 			select {
 			case n.notificationCancels <- cancel:
-				// Cancellation is being handled, drain the spend chan until it is
-				// closed before yielding to the caller.
+				// Cancellation is being handled, drain the
+				// spend chan until it is closed before yielding
+				// to the caller.
 				for {
 					select {
 					case _, ok := <-ntfn.spendChan:
@@ -849,6 +880,16 @@ func (n *NeutrinoNotifier) RegisterSpendNtfn(outpoint *wire.OutPoint,
 	case n.notificationRegistry <- ntfn:
 	case <-n.quit:
 		return nil, ErrChainNotifierShuttingDown
+	}
+
+	// Finally, we'll add a spent hint with the current height to the cache
+	// in order to better keep track of when this outpoint is spent.
+	err = n.spendHintCache.CommitSpendHint(currentHeight, *outpoint)
+	if err != nil {
+		// The error is not fatal, so we should not return an error to
+		// the caller.
+		chainntnfs.Log.Errorf("Unable to update spend hint to %d for "+
+			"%v: %v", currentHeight, outpoint, err)
 	}
 
 	return spendEvent, nil

--- a/chainntnfs/neutrinonotify/neutrino.go
+++ b/chainntnfs/neutrinonotify/neutrino.go
@@ -373,6 +373,7 @@ out:
 					rescanUpdate := []neutrino.UpdateOption{
 						neutrino.AddAddrs(addrs...),
 						neutrino.Rewind(currentHeight),
+						neutrino.DisableDisconnectedNtfns(true),
 					}
 					err = n.chainView.Update(rescanUpdate...)
 					if err != nil {
@@ -870,6 +871,7 @@ func (n *NeutrinoNotifier) RegisterSpendNtfn(outpoint *wire.OutPoint,
 	rescanUpdate := []neutrino.UpdateOption{
 		neutrino.AddInputs(inputToWatch),
 		neutrino.Rewind(currentHeight),
+		neutrino.DisableDisconnectedNtfns(true),
 	}
 
 	if err := n.chainView.Update(rescanUpdate...); err != nil {

--- a/chainntnfs/neutrinonotify/neutrino_debug.go
+++ b/chainntnfs/neutrinonotify/neutrino_debug.go
@@ -51,7 +51,8 @@ func (n *NeutrinoNotifier) UnsafeStart(bestHeight int32, bestHash *chainhash.Has
 	}
 
 	n.txConfNotifier = chainntnfs.NewTxConfNotifier(
-		uint32(bestHeight), reorgSafetyLimit)
+		uint32(bestHeight), reorgSafetyLimit, n.confirmHintCache,
+	)
 
 	n.chainConn = &NeutrinoChainConn{n.p2pNode}
 

--- a/chainntnfs/txconfnotifier_test.go
+++ b/chainntnfs/txconfnotifier_test.go
@@ -1,6 +1,7 @@
 package chainntnfs_test
 
 import (
+	"sync"
 	"testing"
 
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
@@ -10,6 +11,90 @@ import (
 )
 
 var zeroHash chainhash.Hash
+
+type mockHintCache struct {
+	mu         sync.Mutex
+	confHints  map[chainhash.Hash]uint32
+	spendHints map[wire.OutPoint]uint32
+}
+
+var _ chainntnfs.SpendHintCache = (*mockHintCache)(nil)
+var _ chainntnfs.ConfirmHintCache = (*mockHintCache)(nil)
+
+func (c *mockHintCache) CommitSpendHint(heightHint uint32, ops ...wire.OutPoint) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	for _, op := range ops {
+		c.spendHints[op] = heightHint
+	}
+
+	return nil
+}
+
+func (c *mockHintCache) QuerySpendHint(op wire.OutPoint) (uint32, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	hint, ok := c.spendHints[op]
+	if !ok {
+		return 0, chainntnfs.ErrSpendHintNotFound
+	}
+
+	return hint, nil
+}
+
+func (c *mockHintCache) PurgeSpendHint(ops ...wire.OutPoint) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	for _, op := range ops {
+		delete(c.spendHints, op)
+	}
+
+	return nil
+}
+
+func (c *mockHintCache) CommitConfirmHint(heightHint uint32, txids ...chainhash.Hash) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	for _, txid := range txids {
+		c.confHints[txid] = heightHint
+	}
+
+	return nil
+}
+
+func (c *mockHintCache) QueryConfirmHint(txid chainhash.Hash) (uint32, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	hint, ok := c.confHints[txid]
+	if !ok {
+		return 0, chainntnfs.ErrConfirmHintNotFound
+	}
+
+	return hint, nil
+}
+
+func (c *mockHintCache) PurgeConfirmHint(txids ...chainhash.Hash) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	for _, txid := range txids {
+		delete(c.confHints, txid)
+	}
+
+	return nil
+}
+
+func newMockHintCache() *mockHintCache {
+	return &mockHintCache{
+		confHints:  make(map[chainhash.Hash]uint32),
+		spendHints: make(map[wire.OutPoint]uint32),
+	}
+}
 
 // TestTxConfFutureDispatch tests that the TxConfNotifier dispatches
 // registered notifications when the transaction confirms after registration.
@@ -27,7 +112,8 @@ func TestTxConfFutureDispatch(t *testing.T) {
 		tx3 = wire.MsgTx{Version: 3}
 	)
 
-	txConfNotifier := chainntnfs.NewTxConfNotifier(10, 100)
+	hintCache := newMockHintCache()
+	txConfNotifier := chainntnfs.NewTxConfNotifier(10, 100, hintCache)
 
 	// Create the test transactions and register them with the
 	// TxConfNotifier before including them in a block to receive future
@@ -200,7 +286,8 @@ func TestTxConfHistoricalDispatch(t *testing.T) {
 		tx3 = wire.MsgTx{Version: 3}
 	)
 
-	txConfNotifier := chainntnfs.NewTxConfNotifier(10, 100)
+	hintCache := newMockHintCache()
+	txConfNotifier := chainntnfs.NewTxConfNotifier(10, 100, hintCache)
 
 	// Create the test transactions at a height before the TxConfNotifier's
 	// starting height so that they are confirmed once registering them.
@@ -351,7 +438,8 @@ func TestTxConfChainReorg(t *testing.T) {
 		tx3 = wire.MsgTx{Version: 3}
 	)
 
-	txConfNotifier := chainntnfs.NewTxConfNotifier(7, 100)
+	hintCache := newMockHintCache()
+	txConfNotifier := chainntnfs.NewTxConfNotifier(7, 100, hintCache)
 
 	// Tx 1 will be confirmed in block 9 and requires 2 confs.
 	tx1Hash := tx1.TxHash()
@@ -586,6 +674,147 @@ func TestTxConfChainReorg(t *testing.T) {
 	}
 }
 
+// TestTxConfHeightHintCache ensures that the height hints for transactions are
+// kept track of correctly with each new block connected/disconnected.
+func TestTxConfHeightHintCache(t *testing.T) {
+	t.Parallel()
+
+	const (
+		startingHeight = 10
+		tx1Height      = 11
+		tx2Height      = 12
+	)
+
+	// Initialize our TxConfNotifier instance backed by a height hint cache.
+	hintCache := newMockHintCache()
+	txConfNotifier := chainntnfs.NewTxConfNotifier(
+		startingHeight, 100, hintCache,
+	)
+
+	// Create two test transactions and register them for notifications.
+	tx1 := wire.MsgTx{Version: 1}
+	tx1Hash := tx1.TxHash()
+	ntfn1 := &chainntnfs.ConfNtfn{
+		TxID:             &tx1Hash,
+		NumConfirmations: 1,
+		Event:            chainntnfs.NewConfirmationEvent(1),
+	}
+
+	tx2 := wire.MsgTx{Version: 2}
+	tx2Hash := tx2.TxHash()
+	ntfn2 := &chainntnfs.ConfNtfn{
+		TxID:             &tx2Hash,
+		NumConfirmations: 2,
+		Event:            chainntnfs.NewConfirmationEvent(2),
+	}
+
+	if err := txConfNotifier.Register(ntfn1); err != nil {
+		t.Fatalf("unable to register tx1: %v", err)
+	}
+	if err := txConfNotifier.Register(ntfn2); err != nil {
+		t.Fatalf("unable to register tx2: %v", err)
+	}
+
+	// Both transactions should have a height hint of the starting height
+	// due to registering notifications for them.
+	hint, err := hintCache.QueryConfirmHint(tx1Hash)
+	if err != nil {
+		t.Fatalf("unable to query for hint: %v", err)
+	}
+	if hint != startingHeight {
+		t.Fatalf("expected hint %d, got %d", startingHeight, hint)
+	}
+
+	hint, err = hintCache.QueryConfirmHint(tx2Hash)
+	if err != nil {
+		t.Fatalf("unable to query for hint: %v", err)
+	}
+	if hint != startingHeight {
+		t.Fatalf("expected hint %d, got %d", startingHeight, hint)
+	}
+
+	// Create a new block that will include the first transaction and extend
+	// the chain.
+	block1 := btcutil.NewBlock(&wire.MsgBlock{
+		Transactions: []*wire.MsgTx{&tx1},
+	})
+
+	err = txConfNotifier.ConnectTip(
+		block1.Hash(), tx1Height, block1.Transactions(),
+	)
+	if err != nil {
+		t.Fatalf("Failed to connect block: %v", err)
+	}
+
+	// The height hint for the first transaction should now be updated to
+	// reflect its confirmation.
+	hint, err = hintCache.QueryConfirmHint(tx1Hash)
+	if err != nil {
+		t.Fatalf("unable to query for hint: %v", err)
+	}
+	if hint != tx1Height {
+		t.Fatalf("expected hint %d, got %d", tx1Height, hint)
+	}
+
+	// The height hint for the second transaction should also be updated due
+	// to it still being unconfirmed.
+	hint, err = hintCache.QueryConfirmHint(tx2Hash)
+	if err != nil {
+		t.Fatalf("unable to query for hint: %v", err)
+	}
+	if hint != tx1Height {
+		t.Fatalf("expected hint %d, got %d", tx1Height, hint)
+	}
+
+	// Now, we'll create another block that will include the second
+	// transaction and extend the chain.
+	block2 := btcutil.NewBlock(&wire.MsgBlock{
+		Transactions: []*wire.MsgTx{&tx2},
+	})
+
+	err = txConfNotifier.ConnectTip(
+		block2.Hash(), tx2Height, block2.Transactions(),
+	)
+	if err != nil {
+		t.Fatalf("Failed to connect block: %v", err)
+	}
+
+	// The height hint for the first transaction should remain the same.
+	hint, err = hintCache.QueryConfirmHint(tx1Hash)
+	if err != nil {
+		t.Fatalf("unable to query for hint: %v", err)
+	}
+	if hint != tx1Height {
+		t.Fatalf("expected hint %d, got %d", tx1Height, hint)
+	}
+
+	// The height hint for the second transaction should now be updated to
+	// reflect its confirmation.
+	hint, err = hintCache.QueryConfirmHint(tx2Hash)
+	if err != nil {
+		t.Fatalf("unable to query for hint: %v", err)
+	}
+	if hint != tx2Height {
+		t.Fatalf("expected hint %d, got %d", tx2Height, hint)
+	}
+
+	// Now, we'll attempt do disconnect the last block in order to simulate
+	// a chain reorg.
+	if err := txConfNotifier.DisconnectTip(tx2Height); err != nil {
+		t.Fatalf("Failed to disconnect block: %v", err)
+	}
+
+	// This should update the second transaction's height hint within the
+	// cache to the previous height.
+	hint, err = hintCache.QueryConfirmHint(tx2Hash)
+	if err != nil {
+		t.Fatalf("unable to query for hint: %v", err)
+	}
+	if hint != tx1Height {
+		t.Fatalf("expected hint %d, got %d", tx1Height, hint)
+	}
+}
+
 func TestTxConfTearDown(t *testing.T) {
 	t.Parallel()
 
@@ -594,7 +823,8 @@ func TestTxConfTearDown(t *testing.T) {
 		tx2 = wire.MsgTx{Version: 2}
 	)
 
-	txConfNotifier := chainntnfs.NewTxConfNotifier(10, 100)
+	hintCache := newMockHintCache()
+	txConfNotifier := chainntnfs.NewTxConfNotifier(10, 100, hintCache)
 
 	// Create the test transactions and register them with the
 	// TxConfNotifier to receive notifications.

--- a/lnwallet/interface_test.go
+++ b/lnwallet/interface_test.go
@@ -2068,7 +2068,19 @@ func TestLightningWallet(t *testing.T) {
 
 	rpcConfig := miningNode.RPCConfig()
 
-	chainNotifier, err := btcdnotify.New(&rpcConfig)
+	tempDir, err := ioutil.TempDir("", "channeldb")
+	if err != nil {
+		t.Fatalf("unable to create temp dir: %v", err)
+	}
+	db, err := channeldb.Open(tempDir)
+	if err != nil {
+		t.Fatalf("unable to create db: %v", err)
+	}
+	hintCache, err := chainntnfs.NewHeightHintCache(db)
+	if err != nil {
+		t.Fatalf("unable to create height hint cache: %v", err)
+	}
+	chainNotifier, err := btcdnotify.New(&rpcConfig, hintCache, hintCache)
 	if err != nil {
 		t.Fatalf("unable to create notifier: %v", err)
 	}


### PR DESCRIPTION
The role of the `heightHint` parameter within the `ChainNotifier` interface is to give them a lower bound on when to start looking for the earliest occurrence of the event. Usually this value isn't used as we remain online for the lifetime of the event. However, we currently have a concept of a "historical dispatch" of an event. This occurs when the stateless chain notifier instance is already live, and we receive a notification for an event with a `heightHint` value that is in the past. In this case, depending on various factors, we may have to fetch a set of blocks in the worst case to scan forward to determine if we need to dispatch an event. This can lead to some efficiency issues due to re-doing this process on every restart.

In this PR, we address this by introducing a persistent height hint layer to the different `ChainNotifier` implementations. Now, with this logic, we keep track of each transaction/outpoint we have registered a notification for as the chain progresses and update their height hint. This allows us to determine the *exact* height at which a transaction has been confirmed or an outpoint has been spent. By doing so, we optimize the `ChainNotifier` implementations to only have to fetch _one_ block.

Fixes #1168.

A follow-up PR will move the logic of keeping track spend notifications and their height hints into the `TxConfNotifier` struct in order to further abstract the logic within the different `ChainNotifier` implementations.