### PR TITLE
chains: add coinregistry and add noltc flag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,6 +36,7 @@ GOBUILD := go build -v
 GOINSTALL := go install -v
 GOTEST := go test -v
 
+GO_TAGS := ${TEST_TAGS}
 GOLIST := go list $(PKG)/... | grep -v '/vendor/'
 GOLISTCOVER := $(shell go list -f '{{.ImportPath}}' ./... | sed -e 's/^$(ESCPKG)/./')
 GOLISTLINT := $(shell go list -f '{{.Dir}}' ./... | grep -v 'lnrpc')
@@ -125,8 +126,8 @@ btcd: $(GLIDE_BIN) $(BTCD_DIR)
 
 build:
 	@$(call print, "Building debug lnd and lncli.")
-	$(GOBUILD) -tags=$(TEST_TAGS) -o lnd-debug $(LDFLAGS) $(PKG)
-	$(GOBUILD) -tags=$(TEST_TAGS) -o lncli-debug $(LDFLAGS) $(PKG)/cmd/lncli
+	$(GOBUILD) -tags=$(GO_TAGS) -o lnd-debug $(LDFLAGS) $(PKG)
+	$(GOBUILD) -tags=$(GO_TAGS) -o lncli-debug $(LDFLAGS) $(PKG)/cmd/lncli
 
 install:
 	@$(call print, "Installing lnd and lncli.")

--- a/chainparams.go
+++ b/chainparams.go
@@ -2,11 +2,7 @@ package main
 
 import (
 	"github.com/lightningnetwork/lnd/keychain"
-	litecoinCfg "github.com/ltcsuite/ltcd/chaincfg"
-	litecoinWire "github.com/ltcsuite/ltcd/wire"
-	"github.com/roasbeef/btcd/chaincfg"
 	bitcoinCfg "github.com/roasbeef/btcd/chaincfg"
-	"github.com/roasbeef/btcd/chaincfg/chainhash"
 	bitcoinWire "github.com/roasbeef/btcd/wire"
 )
 
@@ -18,14 +14,6 @@ var activeNetParams = bitcoinTestNetParams
 // corresponding RPC port of a daemon running on the particular network.
 type bitcoinNetParams struct {
 	*bitcoinCfg.Params
-	rpcPort  string
-	CoinType uint32
-}
-
-// litecoinNetParams couples the p2p parameters of a network with the
-// corresponding RPC port of a daemon running on the particular network.
-type litecoinNetParams struct {
-	*litecoinCfg.Params
 	rpcPort  string
 	CoinType uint32
 }
@@ -54,22 +42,6 @@ var bitcoinSimNetParams = bitcoinNetParams{
 	CoinType: keychain.CoinTypeTestnet,
 }
 
-// litecoinTestNetParams contains parameters specific to the 4th version of the
-// test network.
-var litecoinTestNetParams = litecoinNetParams{
-	Params:   &litecoinCfg.TestNet4Params,
-	rpcPort:  "19334",
-	CoinType: keychain.CoinTypeTestnet,
-}
-
-// litecoinMainNetParams contains the parameters specific to the current
-// Litecoin mainnet.
-var litecoinMainNetParams = litecoinNetParams{
-	Params:   &litecoinCfg.MainNetParams,
-	rpcPort:  "9334",
-	CoinType: keychain.CoinTypeLitecoin,
-}
-
 // regTestNetParams contains parameters specific to a local regtest network.
 var regTestNetParams = bitcoinNetParams{
 	Params:   &bitcoinCfg.RegressionNetParams,
@@ -77,54 +49,21 @@ var regTestNetParams = bitcoinNetParams{
 	CoinType: keychain.CoinTypeTestnet,
 }
 
-// applyLitecoinParams applies the relevant chain configuration parameters that
-// differ for litecoin to the chain parameters typed for btcsuite derivation.
-// This function is used in place of using something like interface{} to
-// abstract over _which_ chain (or fork) the parameters are for.
-func applyLitecoinParams(params *bitcoinNetParams, litecoinParams *litecoinNetParams) {
-	params.Name = litecoinParams.Name
-	params.Net = bitcoinWire.BitcoinNet(litecoinParams.Net)
-	params.DefaultPort = litecoinParams.DefaultPort
-	params.CoinbaseMaturity = litecoinParams.CoinbaseMaturity
-
-	copy(params.GenesisHash[:], litecoinParams.GenesisHash[:])
-
-	// Address encoding magics
-	params.PubKeyHashAddrID = litecoinParams.PubKeyHashAddrID
-	params.ScriptHashAddrID = litecoinParams.ScriptHashAddrID
-	params.PrivateKeyID = litecoinParams.PrivateKeyID
-	params.WitnessPubKeyHashAddrID = litecoinParams.WitnessPubKeyHashAddrID
-	params.WitnessScriptHashAddrID = litecoinParams.WitnessScriptHashAddrID
-	params.Bech32HRPSegwit = litecoinParams.Bech32HRPSegwit
-
-	copy(params.HDPrivateKeyID[:], litecoinParams.HDPrivateKeyID[:])
-	copy(params.HDPublicKeyID[:], litecoinParams.HDPublicKeyID[:])
-
-	params.HDCoinType = litecoinParams.HDCoinType
-
-	checkPoints := make([]chaincfg.Checkpoint, len(litecoinParams.Checkpoints))
-	for i := 0; i < len(litecoinParams.Checkpoints); i++ {
-		var chainHash chainhash.Hash
-		copy(chainHash[:], litecoinParams.Checkpoints[i].Hash[:])
-
-		checkPoints[i] = chaincfg.Checkpoint{
-			Height: litecoinParams.Checkpoints[i].Height,
-			Hash:   &chainHash,
-		}
-	}
-	params.Checkpoints = checkPoints
-
-	params.rpcPort = litecoinParams.rpcPort
-	params.CoinType = litecoinParams.CoinType
-}
-
 // isTestnet tests if the given params correspond to a testnet
 // parameter configuration.
 func isTestnet(params *bitcoinNetParams) bool {
-	switch params.Params.Net {
-	case bitcoinWire.TestNet3, bitcoinWire.BitcoinNet(litecoinWire.TestNet4):
+
+	// Test if the given params correspond to the bitcoin parameter
+	// configuration
+	if params.Params.Net == bitcoinWire.BitcoinNet(bitcoinWire.TestNet3) {
 		return true
-	default:
-		return false
 	}
+
+	// Test if the given params correspond to testnet parameter configuration
+	// of any registered coin
+	if registeredCoins.Any() {
+		return registeredCoins.IsTestNet(params)
+	}
+
+	return false
 }

--- a/chainparams_ltc.go
+++ b/chainparams_ltc.go
@@ -1,0 +1,96 @@
+// +build !noltc
+
+package main
+
+import (
+	"github.com/lightningnetwork/lnd/keychain"
+	litecoinCfg "github.com/ltcsuite/ltcd/chaincfg"
+	"github.com/roasbeef/btcd/chaincfg"
+	"github.com/roasbeef/btcd/chaincfg/chainhash"
+	bitcoinWire "github.com/roasbeef/btcd/wire"
+	litecoinWire "github.com/ltcsuite/ltcd/wire"
+)
+
+// litecoinNetParams couples the p2p parameters of a network with the
+// corresponding RPC port of a daemon running on the particular network.
+type litecoinNetParams struct {
+	*litecoinCfg.Params
+	rpcPort  string
+	CoinType uint32
+}
+
+// litecoinTestNetParams contains parameters specific to the 4th version of the
+// test network.
+var litecoinTestNetParams = litecoinNetParams{
+	Params:   &litecoinCfg.TestNet4Params,
+	rpcPort:  "19334",
+	CoinType: keychain.CoinTypeTestnet,
+}
+
+// litecoinMainNetParams contains the parameters specific to the current
+// Litecoin mainnet.
+var litecoinMainNetParams = litecoinNetParams{
+	Params:   &litecoinCfg.MainNetParams,
+	rpcPort:  "9334",
+	CoinType: keychain.CoinTypeLitecoin,
+}
+
+// ltcIsTestNet returns true if the given params correspond to a ltc testnet
+// parameter configuration.
+func ltcIsTestNet(params *bitcoinNetParams) bool {
+
+	if (params.Params.Net == bitcoinWire.BitcoinNet(litecoinWire.TestNet4)) {
+		return true
+	}
+
+	return false
+}
+
+// applyLitecoinParams applies the relevant chain configuration parameters that
+// differ for litecoin to the chain parameters typed for btcsuite derivation.
+// This function is used in place of using something like interface{} to
+// abstract over _which_ chain (or fork) the parameters are for.
+func applyLitecoinParams(params *bitcoinNetParams, cfg *config) {
+	var litecoinParams litecoinNetParams
+
+	if cfg.Litecoin.MainNet {
+		litecoinParams = litecoinMainNetParams
+	} else if cfg.Litecoin.TestNet3 {
+		litecoinParams = litecoinTestNetParams
+	}
+
+	params.Name = litecoinParams.Name
+	params.Net = bitcoinWire.BitcoinNet(litecoinParams.Net)
+	params.DefaultPort = litecoinParams.DefaultPort
+	params.CoinbaseMaturity = litecoinParams.CoinbaseMaturity
+
+	copy(params.GenesisHash[:], litecoinParams.GenesisHash[:])
+
+	// Address encoding magics
+	params.PubKeyHashAddrID = litecoinParams.PubKeyHashAddrID
+	params.ScriptHashAddrID = litecoinParams.ScriptHashAddrID
+	params.PrivateKeyID = litecoinParams.PrivateKeyID
+	params.WitnessPubKeyHashAddrID = litecoinParams.WitnessPubKeyHashAddrID
+	params.WitnessScriptHashAddrID = litecoinParams.WitnessScriptHashAddrID
+	params.Bech32HRPSegwit = litecoinParams.Bech32HRPSegwit
+
+	copy(params.HDPrivateKeyID[:], litecoinParams.HDPrivateKeyID[:])
+	copy(params.HDPublicKeyID[:], litecoinParams.HDPublicKeyID[:])
+
+	params.HDCoinType = litecoinParams.HDCoinType
+
+	checkPoints := make([]chaincfg.Checkpoint, len(litecoinParams.Checkpoints))
+	for i := 0; i < len(litecoinParams.Checkpoints); i++ {
+		var chainHash chainhash.Hash
+		copy(chainHash[:], litecoinParams.Checkpoints[i].Hash[:])
+
+		checkPoints[i] = chaincfg.Checkpoint{
+			Height: litecoinParams.Checkpoints[i].Height,
+			Hash:   &chainHash,
+		}
+	}
+	params.Checkpoints = checkPoints
+
+	params.rpcPort = litecoinParams.rpcPort
+	params.CoinType = litecoinParams.CoinType
+}

--- a/chainregistry_ltc.go
+++ b/chainregistry_ltc.go
@@ -1,0 +1,351 @@
+// +build !noltc
+
+package main
+
+import (
+	"encoding/hex"
+	"fmt"
+	"io/ioutil"
+	"net"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/lightningnetwork/lnd/chainntnfs/bitcoindnotify"
+	"github.com/lightningnetwork/lnd/chainntnfs/btcdnotify"
+	"github.com/lightningnetwork/lnd/channeldb"
+	"github.com/lightningnetwork/lnd/htlcswitch"
+	"github.com/lightningnetwork/lnd/keychain"
+	"github.com/lightningnetwork/lnd/lnwallet"
+	"github.com/lightningnetwork/lnd/lnwallet/btcwallet"
+	"github.com/lightningnetwork/lnd/lnwire"
+	"github.com/lightningnetwork/lnd/routing/chainview"
+	"github.com/roasbeef/btcutil"
+	"github.com/roasbeef/btcd/chaincfg/chainhash"
+	"github.com/roasbeef/btcd/rpcclient"
+	"github.com/roasbeef/btcwallet/chain"
+)
+
+const (
+	defaultLitecoinMinHTLCMSat   = lnwire.MilliSatoshi(1000)
+	defaultLitecoinBaseFeeMSat   = lnwire.MilliSatoshi(1000)
+	defaultLitecoinFeeRate       = lnwire.MilliSatoshi(1)
+	defaultLitecoinTimeLockDelta = 576
+	defaultLitecoinStaticFeeRate = lnwallet.SatPerVByte(200)
+	defaultLitecoinDustLimit     = btcutil.Amount(54600)
+)
+
+// defaultLtcChannelConstraints is the default set of channel constraints that are
+// meant to be used when initially funding a Litecoin channel.
+var defaultLtcChannelConstraints = channeldb.ChannelConstraints{
+	DustLimit:        defaultLitecoinDustLimit,
+	MaxAcceptedHtlcs: lnwallet.MaxHTLCNumber / 2,
+}
+
+var (
+	// litecoinTestnetGenesis is the genesis hash of Litecoin's testnet4
+	// chain.
+	litecoinTestnetGenesis = chainhash.Hash([chainhash.HashSize]byte{
+		0xa0, 0x29, 0x3e, 0x4e, 0xeb, 0x3d, 0xa6, 0xe6,
+		0xf5, 0x6f, 0x81, 0xed, 0x59, 0x5f, 0x57, 0x88,
+		0x0d, 0x1a, 0x21, 0x56, 0x9e, 0x13, 0xee, 0xfd,
+		0xd9, 0x51, 0x28, 0x4b, 0x5a, 0x62, 0x66, 0x49,
+	})
+
+	// litecoinMainnetGenesis is the genesis hash of Litecoin's main chain.
+	litecoinMainnetGenesis = chainhash.Hash([chainhash.HashSize]byte{
+		0xe2, 0xbf, 0x04, 0x7e, 0x7e, 0x5a, 0x19, 0x1a,
+		0xa4, 0xef, 0x34, 0xd3, 0x14, 0x97, 0x9d, 0xc9,
+		0x98, 0x6e, 0x0f, 0x19, 0x25, 0x1e, 0xda, 0xba,
+		0x59, 0x40, 0xfd, 0x1f, 0xe3, 0x65, 0xa7, 0x12,
+	})
+)
+
+func newLitecoinChainControlFromConfig(cfg *config, chanDB *channeldb.DB,
+	privateWalletPw, publicWalletPw []byte, birthday time.Time,
+	recoveryWindow uint32) (*chainControl, func(), error) {
+
+	// Set the RPC config from the "home" chain. Multi-chain isn't yet
+	// active, so we'll restrict usage to a particular chain for now.
+	homeChainConfig := cfg.Litecoin
+
+	ltndLog.Infof("Primary chain is set to: %v",
+		registeredChains.PrimaryChain())
+
+	cc := &chainControl{}
+
+	cc.routingPolicy = htlcswitch.ForwardingPolicy{
+		MinHTLC:       cfg.Litecoin.MinHTLC,
+		BaseFee:       cfg.Litecoin.BaseFee,
+		FeeRate:       cfg.Litecoin.FeeRate,
+		TimeLockDelta: cfg.Litecoin.TimeLockDelta,
+	}
+	cc.feeEstimator = lnwallet.StaticFeeEstimator{
+		FeeRate: defaultLitecoinStaticFeeRate,
+	}
+
+	walletConfig := &btcwallet.Config{
+		PrivatePass:    privateWalletPw,
+		PublicPass:     publicWalletPw,
+		Birthday:       birthday,
+		RecoveryWindow: recoveryWindow,
+		DataDir:        homeChainConfig.ChainDir,
+		NetParams:      activeNetParams.Params,
+		FeeEstimator:   cc.feeEstimator,
+		CoinType:       activeNetParams.CoinType,
+	}
+
+	var (
+		err          error
+		cleanUp      func()
+		bitcoindConn *chain.BitcoindClient
+	)
+
+	// If spv mode is active, then we'll be using a distinct set of
+	// chainControl interfaces that interface directly with the p2p network
+	// of the selected chain.
+	switch homeChainConfig.Node {
+	case "litecoind":
+		bitcoindMode := cfg.LitecoindMode
+
+		// Otherwise, we'll be speaking directly via RPC and ZMQ to a
+		// bitcoind node. If the specified host for the btcd/ltcd RPC
+		// server already has a port specified, then we use that
+		// directly. Otherwise, we assume the default port according to
+		// the selected chain parameters.
+		var bitcoindHost string
+
+		if strings.Contains(bitcoindMode.RPCHost, ":") {
+			bitcoindHost = bitcoindMode.RPCHost
+		} else {
+			// The RPC ports specified in chainparams.go assume
+			// btcd, which picks a different port so that btcwallet
+			// can use the same RPC port as bitcoind. We convert
+			// this back to the btcwallet/bitcoind port.
+			rpcPort, err := strconv.Atoi(activeNetParams.rpcPort)
+			if err != nil {
+				return nil, nil, err
+			}
+			rpcPort -= 2
+			bitcoindHost = fmt.Sprintf("%v:%d",
+				bitcoindMode.RPCHost, rpcPort)
+			if cfg.Bitcoin.Active && cfg.Bitcoin.RegTest {
+				conn, err := net.Dial("tcp", bitcoindHost)
+				if err != nil || conn == nil {
+					rpcPort = 18443
+					bitcoindHost = fmt.Sprintf("%v:%d",
+						bitcoindMode.RPCHost,
+						rpcPort)
+				} else {
+					conn.Close()
+				}
+			}
+		}
+
+		bitcoindUser := bitcoindMode.RPCUser
+		bitcoindPass := bitcoindMode.RPCPass
+
+		rpcConfig := &rpcclient.ConnConfig{
+			Host:                 bitcoindHost,
+			User:                 bitcoindUser,
+			Pass:                 bitcoindPass,
+			DisableConnectOnNew:  true,
+			DisableAutoReconnect: false,
+			DisableTLS:           true,
+			HTTPPostMode:         true,
+		}
+
+		cc.chainNotifier, err = bitcoindnotify.New(rpcConfig,
+			bitcoindMode.ZMQPath, *activeNetParams.Params)
+		if err != nil {
+			return nil, nil, err
+		}
+
+		// Next, we'll create an instance of the bitcoind chain view to
+		// be used within the routing layer.
+		cc.chainView, err = chainview.NewBitcoindFilteredChainView(
+			*rpcConfig, bitcoindMode.ZMQPath,
+			*activeNetParams.Params)
+		if err != nil {
+			srvrLog.Errorf("unable to create chain view: %v", err)
+			return nil, nil, err
+		}
+
+		// Create a special rpc+ZMQ client for bitcoind which will be
+		// used by the wallet for notifications, calls, etc.
+		bitcoindConn, err = chain.NewBitcoindClient(
+			activeNetParams.Params, bitcoindHost, bitcoindUser,
+			bitcoindPass, bitcoindMode.ZMQPath,
+			time.Millisecond*100)
+		if err != nil {
+			return nil, nil, err
+		}
+
+		walletConfig.ChainSource = bitcoindConn
+
+		// If we're not in regtest mode, then we'll attempt to use a
+		// proper fee estimator for testnet.
+		if cfg.Litecoin.Active {
+			ltndLog.Infof("Initializing litecoind backed fee estimator")
+
+			// Finally, we'll re-initialize the fee estimator, as
+			// if we're using litecoind as a backend, then we can
+			// use live fee estimates, rather than a statically
+			// coded value.
+			fallBackFeeRate := lnwallet.SatPerVByte(25)
+			cc.feeEstimator, err = lnwallet.NewBitcoindFeeEstimator(
+				*rpcConfig, fallBackFeeRate,
+			)
+			if err != nil {
+				return nil, nil, err
+			}
+			if err := cc.feeEstimator.Start(); err != nil {
+				return nil, nil, err
+			}
+		}
+	case "btcd", "ltcd":
+		// Otherwise, we'll be speaking directly via RPC to a node.
+		//
+		// So first we'll load btcd/ltcd's TLS cert for the RPC
+		// connection. If a raw cert was specified in the config, then
+		// we'll set that directly. Otherwise, we attempt to read the
+		// cert from the path specified in the config.
+		btcdMode := cfg.LtcdMode
+
+		var rpcCert []byte
+		if btcdMode.RawRPCCert != "" {
+			rpcCert, err = hex.DecodeString(btcdMode.RawRPCCert)
+			if err != nil {
+				return nil, nil, err
+			}
+		} else {
+			certFile, err := os.Open(btcdMode.RPCCert)
+			if err != nil {
+				return nil, nil, err
+			}
+			rpcCert, err = ioutil.ReadAll(certFile)
+			if err != nil {
+				return nil, nil, err
+			}
+			if err := certFile.Close(); err != nil {
+				return nil, nil, err
+			}
+		}
+
+		// If the specified host for the btcd/ltcd RPC server already
+		// has a port specified, then we use that directly. Otherwise,
+		// we assume the default port according to the selected chain
+		// parameters.
+		var btcdHost string
+		if strings.Contains(btcdMode.RPCHost, ":") {
+			btcdHost = btcdMode.RPCHost
+		} else {
+			btcdHost = fmt.Sprintf("%v:%v", btcdMode.RPCHost,
+				activeNetParams.rpcPort)
+		}
+
+		btcdUser := btcdMode.RPCUser
+		btcdPass := btcdMode.RPCPass
+		rpcConfig := &rpcclient.ConnConfig{
+			Host:                 btcdHost,
+			Endpoint:             "ws",
+			User:                 btcdUser,
+			Pass:                 btcdPass,
+			Certificates:         rpcCert,
+			DisableTLS:           false,
+			DisableConnectOnNew:  true,
+			DisableAutoReconnect: false,
+		}
+		cc.chainNotifier, err = btcdnotify.New(rpcConfig)
+		if err != nil {
+			return nil, nil, err
+		}
+
+		// Finally, we'll create an instance of the default chain view to be
+		// used within the routing layer.
+		cc.chainView, err = chainview.NewBtcdFilteredChainView(*rpcConfig)
+		if err != nil {
+			srvrLog.Errorf("unable to create chain view: %v", err)
+			return nil, nil, err
+		}
+
+		// Create a special websockets rpc client for btcd which will be used
+		// by the wallet for notifications, calls, etc.
+		chainRPC, err := chain.NewRPCClient(activeNetParams.Params, btcdHost,
+			btcdUser, btcdPass, rpcCert, false, 20)
+		if err != nil {
+			return nil, nil, err
+		}
+
+		walletConfig.ChainSource = chainRPC
+
+		// If we're not in simnet or regtest mode, then we'll attempt
+		// to use a proper fee estimator for testnet.
+		if !cfg.Litecoin.SimNet && !cfg.Litecoin.RegTest {
+
+			ltndLog.Infof("Initializing btcd backed fee estimator")
+
+			// Finally, we'll re-initialize the fee estimator, as
+			// if we're using btcd as a backend, then we can use
+			// live fee estimates, rather than a statically coded
+			// value.
+			fallBackFeeRate := lnwallet.SatPerVByte(25)
+			cc.feeEstimator, err = lnwallet.NewBtcdFeeEstimator(
+				*rpcConfig, fallBackFeeRate,
+			)
+			if err != nil {
+				return nil, nil, err
+			}
+			if err := cc.feeEstimator.Start(); err != nil {
+				return nil, nil, err
+			}
+		}
+	}
+
+	wc, err := btcwallet.New(*walletConfig)
+	if err != nil {
+		fmt.Printf("unable to create wallet controller: %v\n", err)
+		return nil, nil, err
+	}
+
+	cc.msgSigner = wc
+	cc.signer = wc
+	cc.chainIO = wc
+
+	// Select the default channel constraints for the primary chain.
+	channelConstraints := defaultLtcChannelConstraints
+
+	keyRing := keychain.NewBtcWalletKeyRing(
+		wc.InternalWallet(), activeNetParams.CoinType,
+	)
+
+	// Create, and start the lnwallet, which handles the core payment
+	// channel logic, and exposes control via proxy state machines.
+	walletCfg := lnwallet.Config{
+		Database:           chanDB,
+		Notifier:           cc.chainNotifier,
+		WalletController:   wc,
+		Signer:             cc.signer,
+		FeeEstimator:       cc.feeEstimator,
+		SecretKeyRing:      keyRing,
+		ChainIO:            cc.chainIO,
+		DefaultConstraints: channelConstraints,
+		NetParams:          *activeNetParams.Params,
+	}
+	wallet, err := lnwallet.NewLightningWallet(walletCfg)
+	if err != nil {
+		fmt.Printf("unable to create wallet: %v\n", err)
+		return nil, nil, err
+	}
+	if err := wallet.Startup(); err != nil {
+		fmt.Printf("unable to start wallet: %v\n", err)
+		return nil, nil, err
+	}
+
+	ltndLog.Info("LightningWallet opened")
+
+	cc.wallet = wallet
+
+	return cc, cleanUp, nil
+}

--- a/coinregistry.go
+++ b/coinregistry.go
@@ -1,0 +1,123 @@
+package main
+
+import (
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/lightningnetwork/lnd/channeldb"
+)
+
+// coinControl couples all interfaces necessary to handle a new coin
+type coinControl struct {
+	DefaultConfig func(*config) error
+	RegisterChain func(*config, string) (*config, error)
+	IsTestNet func(*bitcoinNetParams) bool
+	ChainControlFromConfig func(cfg *config, chanDB *channeldb.DB,
+		privateWalletPw, publicWalletPw []byte, birthday time.Time,
+		recoveryWindow uint32) (*chainControl, func(), error)
+}
+
+// coinRegistry keeps track of other than Bitcoin coins (eg: litecoin)
+type coinRegistry struct {
+	sync.RWMutex
+
+	coins map[chainCode]*coinControl
+}
+
+// newCoinRegistry creates a new coin registry.
+func newCoinRegistry() *coinRegistry {
+	return &coinRegistry{}
+}
+
+// RegisterCoin registers a new coin in the registry.
+func (c *coinRegistry) RegisterCoin(newCoin chainCode, cc *coinControl) error {
+	c.Lock()
+	defer c.Unlock()
+
+	if c.Any() {
+		return fmt.Errorf("only one registered coin possible")
+	}
+
+	c.coins[newCoin] = cc
+	return nil
+}
+
+// Any returns true if there is any coin registered
+func (c *coinRegistry) Any() bool {
+	c.RLock()
+	defer c.RUnlock()
+
+	return (c.NumCoins() > 0)
+}
+
+// None returns true if there are no coins registered
+func (c *coinRegistry) None() bool {
+	c.RLock()
+	defer c.RUnlock()
+
+	return (c.NumCoins() == 0)
+}
+
+// IsTestNet returns true if the coin is on the test net
+func (c *coinRegistry) IsTestNet(params *bitcoinNetParams) bool {
+	c.RLock()
+	defer c.RUnlock()
+
+	for _, control := range c.coins {
+		// XXX(maurycy): just return, we do not support many coins atm
+		return control.IsTestNet(params)
+	}
+
+	return false
+}
+
+// LookupCoin attempts to lookup a coinControl instance for the target chain.
+func (c *coinRegistry) LookupCoin(targetCoin chainCode) (*coinControl, bool) {
+	c.RLock()
+	defer c.RUnlock()
+
+	cc, ok := c.coins[targetCoin]
+	return cc, ok
+}
+
+// ChainControlFromConfig returns a chainControl for registered coins
+func (c *coinRegistry) ChainControlFromConfig(cfg *config,
+	chanDB *channeldb.DB, privateWalletPw, publicWalletPw []byte,
+	birthday time.Time, recoveryWindow uint32) (*chainControl, func(), error) {
+
+	c.Lock()
+	defer c.Unlock()
+
+	for _, control := range c.coins {
+		cc, cleanup, err := control.ChainControlFromConfig(cfg, chanDB,
+			privateWalletPw, publicWalletPw, birthday, recoveryWindow)
+
+		// XXX(maurycy): just return, we do not support many coins atm
+		return cc, cleanup, err
+	}
+
+	return nil, nil, nil
+}
+
+// DefaultConfig runs the defaultConfig over all coins.
+func (c *coinRegistry) DefaultConfig(cfg *config) error {
+	c.Lock()
+	defer c.Unlock()
+
+	for _, control := range c.coins {
+		if err := control.DefaultConfig(cfg); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// NumActiveChains returns the total number of coins.
+func (c *coinRegistry) NumCoins() uint32 {
+	c.RLock()
+	defer c.RUnlock()
+
+	return uint32(len(c.coins))
+}

--- a/config_ltc.go
+++ b/config_ltc.go
@@ -1,0 +1,145 @@
+// +build !noltc
+
+package main
+
+import (
+	"fmt"
+	"path/filepath"
+
+	"github.com/roasbeef/btcutil"
+)
+
+var (
+	defaultLtcdDir         = btcutil.AppDataDir("ltcd", false)
+	defaultLtcdRPCCertFile = filepath.Join(defaultLtcdDir, "rpc.cert")
+
+	defaultLitecoindDir = btcutil.AppDataDir("litecoin", false)
+)
+
+func init() {
+
+	err := registeredCoins.RegisterCoin(litecoinChain, &coinControl{
+		DefaultConfig:          ltcDefaultConfig,
+		RegisterChain:          ltcRegisterChain,
+		IsTestNet:              ltcIsTestNet,
+		ChainControlFromConfig: newLitecoinChainControlFromConfig,
+	})
+	if err != nil {
+		panic(err)
+	}
+}
+
+// ltcDefaultConfig applies the default chain configuration for litecoin.
+func ltcDefaultConfig(cfg *config) error {
+	cfg.Litecoin = &chainConfig{
+		MinHTLC:       defaultLitecoinMinHTLCMSat,
+		BaseFee:       defaultLitecoinBaseFeeMSat,
+		FeeRate:       defaultLitecoinFeeRate,
+		TimeLockDelta: defaultLitecoinTimeLockDelta,
+		Node:          "ltcd",
+	}
+
+	cfg.LtcdMode = &btcdConfig{
+		Dir:        defaultLtcdDir,
+		RPCHost:    defaultRPCHost,
+		RPCCert:    defaultLtcdRPCCertFile,
+		DaemonName: "ltcd",
+		File:       "ltcd",
+	}
+
+	cfg.LitecoindMode = &bitcoindConfig{
+		Dir:        defaultLitecoindDir,
+		RPCHost:    defaultRPCHost,
+		DaemonName: "litecoind",
+		File:       "litecoin",
+	}
+
+	return nil
+}
+
+func ltcRegisterChain(cfg *config, funcName string) (*config, error) {
+	if cfg.Litecoin.SimNet {
+		str := "%s: simnet mode for litecoin not currently supported"
+		return nil, fmt.Errorf(str, funcName)
+	}
+	if cfg.Litecoin.RegTest {
+		str := "%s: regnet mode for litecoin not currently supported"
+		return nil, fmt.Errorf(str, funcName)
+	}
+
+	if cfg.Litecoin.TimeLockDelta < minTimeLockDelta {
+		return nil, fmt.Errorf("timelockdelta must be at least %v",
+			minTimeLockDelta)
+	}
+
+	// Multiple networks can't be selected simultaneously.  Count
+	// number of network flags passed; assign active network params
+	// while we're at it.
+	numNets := 0
+	if cfg.Litecoin.MainNet {
+		numNets++
+	}
+	if cfg.Litecoin.TestNet3 {
+		numNets++
+	}
+
+	if numNets > 1 {
+		str := "%s: The mainnet, testnet, and simnet params " +
+			"can't be used together -- choose one of the " +
+			"three"
+		err := fmt.Errorf(str, funcName)
+		return nil, err
+	}
+
+	// The target network must be provided, otherwise, we won't
+	// know how to initialize the daemon.
+	if numNets == 0 {
+		str := "%s: either --litecoin.mainnet, or " +
+			"litecoin.testnet must be specified"
+		err := fmt.Errorf(str, funcName)
+		return nil, err
+	}
+
+	// The litecoin chain is the current active chain. However
+	// throughout the codebase we required chaincfg.Params. So as a
+	// temporary hack, we'll mutate the default net params for
+	// bitcoin with the litecoin specific information.
+	applyLitecoinParams(&activeNetParams, cfg)
+
+	switch cfg.Litecoin.Node {
+	case "ltcd":
+		err := parseRPCParams(cfg.Litecoin, cfg.LtcdMode,
+			litecoinChain, funcName)
+		if err != nil {
+			err := fmt.Errorf("unable to load RPC "+
+				"credentials for ltcd: %v", err)
+			return nil, err
+		}
+	case "litecoind":
+		if cfg.Litecoin.SimNet {
+			return nil, fmt.Errorf("%s: litecoind does not "+
+				"support simnet", funcName)
+		}
+		err := parseRPCParams(cfg.Litecoin, cfg.LitecoindMode,
+			litecoinChain, funcName)
+		if err != nil {
+			err := fmt.Errorf("unable to load RPC "+
+				"credentials for litecoind: %v", err)
+			return nil, err
+		}
+	default:
+		str := "%s: only ltcd and litecoind mode supported for " +
+			"litecoin at this time"
+		return nil, fmt.Errorf(str, funcName)
+	}
+
+	cfg.Litecoin.ChainDir = filepath.Join(cfg.DataDir,
+		defaultChainSubDirname,
+		litecoinChain.String())
+
+	// Finally we'll register the litecoin chain as our current
+	// primary chain.
+	registeredChains.RegisterPrimaryChain(litecoinChain)
+
+	return cfg, nil
+}

--- a/fundingmanager.go
+++ b/fundingmanager.go
@@ -53,6 +53,7 @@ const (
 	// Litecoin CSV delay we will require the remote to use for its
 	// commitment transaction. The actual delay we will require will be
 	// somewhere between these values, depending on channel size.
+	// TODO(maurycy): _ltc.go
 	minLtcRemoteDelay uint16 = 576
 	maxLtcRemoteDelay uint16 = 8064
 

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -2242,11 +2242,8 @@ func (r *rpcServer) AddInvoice(ctx context.Context,
 		options = append(options,
 			zpay32.CLTVExpiry(invoice.CltvExpiry))
 	default:
-		// TODO(roasbeef): assumes set delta between versions
-		defaultDelta := cfg.Bitcoin.TimeLockDelta
-		if registeredChains.PrimaryChain() == litecoinChain {
-			defaultDelta = cfg.Litecoin.TimeLockDelta
-		}
+		defaultDelta := cfg.TimeLockDelta()
+
 		options = append(options, zpay32.CLTVExpiry(uint64(defaultDelta)))
 	}
 

--- a/server.go
+++ b/server.go
@@ -602,8 +602,7 @@ func (s *server) Start() error {
 	// If network bootstrapping hasn't been disabled, then we'll configure
 	// the set of active bootstrappers, and launch a dedicated goroutine to
 	// maintain a set of persistent connections.
-	if !cfg.NoNetBootstrap && !(cfg.Bitcoin.SimNet || cfg.Litecoin.SimNet) &&
-		!(cfg.Bitcoin.RegTest || cfg.Litecoin.RegTest) {
+	if !cfg.NoNetBootstrap && !cfg.IsSimNet() && !cfg.IsRegTest() {
 
 		networkBootStrappers, err := initNetworkBootstrappers(s)
 		if err != nil {
@@ -683,7 +682,7 @@ func initNetworkBootstrappers(s *server) ([]discovery.NetworkPeerBootstrapper, e
 
 	// If this isn't simnet mode, then one of our additional bootstrapping
 	// sources will be the set of running DNS seeds.
-	if !cfg.Bitcoin.SimNet || !cfg.Litecoin.SimNet {
+	if !cfg.IsSimNet() {
 		dnsSeeds, ok := chainDNSSeeds[*activeNetParams.GenesisHash]
 
 		// If we have a set of DNS seeds for this chain, then we'll add


### PR DESCRIPTION
This is my first intermediate pull request, still work in progress, so please don't be too harsh.  I would love to hear early feedback, if I'm moving in the right direction.

It works by moving LTC-related code into separate files (`_ltc.go` suffix), temporarily guarded with the `+noltc` build tag, and registering it with a newly introduced `CoinRegistry`, similar to `ChainRegistry` but on the top layer.  At the moment, only one coin is supported but it should be possible to plug-in more.

What's missing is:

 * extending `config` (it shows `litecoin` flags even if the `+noltc` build tag is supplied). Perhaps I should leave it as is and raise an error if there's no litecoin in `registeredCoins`. What do you think?
 * tests for `CoinRegistry`, obviously. `make check` does not return any errors 
 * `Makefile` supplying `go build tags="ltc"` 

 ref #1251