### PR TITLE
lnd: fix typo in log message on launch

### DIFF
--- a/lnd.go
+++ b/lnd.go
@@ -118,7 +118,7 @@ func lndMain() error {
 		network = "mainnet"
 
 	case cfg.Bitcoin.SimNet:
-		network = "simmnet"
+		network = "simnet"
 
 	case cfg.Bitcoin.RegTest:
 		network = "regtest"


### PR DESCRIPTION
nitspick

```
$ lnd --bitcoin.active --bitcoin.simnet ...
...
2018-05-24 01:14:14.503 [INF] LTND: Version 0.4.1-beta commit=
2018-05-24 01:14:14.503 [INF] LTND: Active chain: Bitcoin (network=simmnet)
```