### PR TITLE
Reduce fundingmanager chan send deadlock scenarios

### DIFF
--- a/fundingmanager.go
+++ b/fundingmanager.go
@@ -775,13 +775,7 @@ func (f *fundingManager) CancelPeerReservations(nodePub [33]byte) {
 				"node=%x: %v", nodePub[:], err)
 		}
 
-		if resCtx.err != nil {
-			select {
-			case resCtx.err <- fmt.Errorf("peer disconnected"):
-			default:
-			}
-		}
-
+		resCtx.err <- fmt.Errorf("peer disconnected")
 		delete(nodeReservations, pendingID)
 	}
 

--- a/fundingmanager.go
+++ b/fundingmanager.go
@@ -1488,9 +1488,8 @@ func (f *fundingManager) handleFundingSigned(fmsg *fundingSignedMsg) {
 		err := fmt.Errorf("Unable to find signed reservation for "+
 			"chan_id=%x", fmsg.msg.ChanID)
 		fndgLog.Warnf(err.Error())
-		// TODO: add ErrChanNotFound?
 		f.failFundingFlow(fmsg.peerAddress.IdentityKey,
-			pendingChanID, err)
+			fmsg.msg.ChanID, err)
 		return
 	}
 

--- a/fundingmanager.go
+++ b/fundingmanager.go
@@ -1441,6 +1441,11 @@ func (f *fundingManager) handleFundingCreated(fmsg *fundingCreatedMsg) {
 		case <-timeoutChan:
 			// We did not see the funding confirmation before
 			// timeout, so we forget the channel.
+			err := fmt.Errorf("timeout waiting for funding tx "+
+				"(%v) to confirm", completeChan.FundingOutpoint)
+			fndgLog.Warnf(err.Error())
+			f.failFundingFlow(fmsg.peerAddress.IdentityKey,
+				pendingChanID, err)
 			deleteFromDatabase()
 			return
 		case <-f.quit:

--- a/fundingmanager_test.go
+++ b/fundingmanager_test.go
@@ -1447,6 +1447,9 @@ func TestFundingManagerFundingTimeout(t *testing.T) {
 		Height: fundingBroadcastHeight + 288,
 	}
 
+	// Bob should have sent an Error message to Alice.
+	assertErrorSent(t, bob.msgChan)
+
 	// Should not be pending anymore.
 	assertNumPendingChannelsBecomes(t, bob, 0)
 }
@@ -1510,6 +1513,9 @@ func TestFundingManagerFundingNotTimeoutInitiator(t *testing.T) {
 
 	// Since Alice was the initiator, the channel should not have timed out
 	assertNumPendingChannelsRemains(t, alice, 1)
+
+	// Bob should have sent an Error message to Alice.
+	assertErrorSent(t, bob.msgChan)
 
 	// Since Bob was not the initiator, the channel should timeout
 	assertNumPendingChannelsBecomes(t, bob, 0)

--- a/server.go
+++ b/server.go
@@ -2006,7 +2006,11 @@ func (s *server) OpenChannel(nodeKey *btcec.PublicKey,
 	fundingFeePerVSize lnwallet.SatPerVByte, private bool,
 	remoteCsvDelay uint16) (chan *lnrpc.OpenStatusUpdate, chan error) {
 
-	updateChan := make(chan *lnrpc.OpenStatusUpdate, 1)
+	// The updateChan will have a buffer of 2, since we expect a
+	// ChanPending + a ChanOpen update, and we want to make sure the
+	// funding process is not blocked if the caller is not reading the
+	// updates.
+	updateChan := make(chan *lnrpc.OpenStatusUpdate, 2)
 	errChan := make(chan error, 1)
 
 	var (


### PR DESCRIPTION
This PR consists of several commits meant to simplify and reduce the cases where we can end up deadlocking on sending errors on the error channels within `fundingmanager`. 

The biggest change is that we now determine whether to send on the `resCtx.err` channel inside `failFundingFlow`.

After this change we will send on the `resCtx.err` channel only _after_ a call to `cancelReservationCtx`, making sure it won't be attempted again (which would cause a deadlock).

We also increase the buffer of the `updateChan` to 2, so we can safely send on it during the funding workflow without blocking.

Fixes #1254. 