### PR TITLE
macaroons: segregate macaroons on the network level

### DIFF
--- a/cmd/lncli/main.go
+++ b/cmd/lncli/main.go
@@ -29,6 +29,10 @@ const (
 	defaultMacaroonFilename = "admin.macaroon"
 	defaultRPCPort          = "10009"
 	defaultRPCHostPort      = "localhost:" + defaultRPCPort
+	defaultDataDirname      = "data"
+	defaultChainSubDirname  = "chain"
+	defaultChain            = "bitcoin"
+	defaultNetwork          = "mainnet"
 )
 
 var (
@@ -37,6 +41,7 @@ var (
 	Commit string
 
 	defaultLndDir       = btcutil.AppDataDir("lnd", false)
+	defaultDataDir      = filepath.Join(defaultLndDir, defaultDataDirname)
 	defaultTLSCertPath  = filepath.Join(defaultLndDir, defaultTLSCertFilename)
 	defaultMacaroonPath = filepath.Join(defaultLndDir, defaultMacaroonFilename)
 )
@@ -176,6 +181,21 @@ func main() {
 			Name:  "lnddir",
 			Value: defaultLndDir,
 			Usage: "path to lnd's base directory",
+		},
+		cli.StringFlag{
+			Name:  "datadir",
+			Value: defaultDataDir,
+			Usage: "path to lnd's data directory",
+		},
+		cli.StringFlag{
+			Name:  "chain",
+			Value: defaultChain,
+			Usage: "chain to use",
+		},
+		cli.StringFlag{
+			Name:  "network",
+			Value: defaultNetwork,
+			Usage: "network to use",
 		},
 		cli.StringFlag{
 			Name:  "tlscertpath",

--- a/cmd/lncli/main.go
+++ b/cmd/lncli/main.go
@@ -73,14 +73,7 @@ func getClientConn(ctx *cli.Context, skipMacaroons bool) *grpc.ClientConn {
 	lndDir := cleanAndExpandPath(ctx.GlobalString("lnddir"))
 	chain := ctx.GlobalString("chain")
 	network := ctx.GlobalString("network")
-
-	var dataDir string
-	if ctx.GlobalIsSet("datadir") {
-		dataDir = cleanAndExpandPath(ctx.GlobalString("datadir"))
-	} else {
-		dataDir = filepath.Join(lndDir, defaultDataDirname)
-	}
-
+	dataDir := filepath.Join(lndDir, defaultDataDirname)
 	networkDir := filepath.Join(
 		dataDir,
 		defaultChainSubDirname,
@@ -196,10 +189,6 @@ func main() {
 			Name:  "lnddir",
 			Value: defaultLndDir,
 			Usage: "path to lnd's base directory",
-		},
-		cli.StringFlag{
-			Name:  "datadir",
-			Usage: "if set, assign a custom path to lnd's data directory",
 		},
 		cli.StringFlag{
 			Name:  "chain",

--- a/cmd/lncli/main.go
+++ b/cmd/lncli/main.go
@@ -71,24 +71,24 @@ func getClient(ctx *cli.Context) (lnrpc.LightningClient, func()) {
 
 func getClientConn(ctx *cli.Context, skipMacaroons bool) *grpc.ClientConn {
 	lndDir := cleanAndExpandPath(ctx.GlobalString("lnddir"))
-	dataDir := cleanAndExpandPath(ctx.GlobalString("datadir"))
 	chain := ctx.GlobalString("chain")
 	network := ctx.GlobalString("network")
 
-	// Compute networkDir base path based on dataDir
-	// or fallback to lndDir.
-	networkDirBase := filepath.Join(lndDir, defaultDataDirname)
-	if len(ctx.GlobalString("datadir")) != 0 {
-		networkDirBase = dataDir
+	var dataDir string
+	if ctx.GlobalIsSet("datadir") {
+		dataDir = cleanAndExpandPath(ctx.GlobalString("datadir"))
+	} else {
+		dataDir = filepath.Join(lndDir, defaultDataDirname)
 	}
+
 	networkDir := filepath.Join(
-		networkDirBase,
+		dataDir,
 		defaultChainSubDirname,
 		chain, network,
 	)
 
 	// If a custom macaroonpath is not set, we'll use the default path.
-	if len(ctx.GlobalString("macaroonpath")) == 0 {
+	if !ctx.GlobalIsSet("macaroonpath") {
 		ctx.GlobalSet(
 			"macaroonpath",
 			filepath.Join(networkDir, defaultMacaroonFilename),

--- a/config.go
+++ b/config.go
@@ -765,10 +765,9 @@ func loadConfig() (*config, error) {
 		}
 	}
 
-	// Store the macaroon database within the network level
-	// so it is possible to use a distinct password for testnet,
-	// simnet, mainnet etc.
-	macaroonDatabaseDir = filepath.Join(cfg.DataDir,
+	// Compute network directory to store network specific
+	// files such as macaroon database, macaroons etc.
+	networkDir = filepath.Join(cfg.DataDir,
 		defaultChainSubDirname,
 		registeredChains.PrimaryChain().String(),
 		normalizeNetwork(activeNetParams.Name))
@@ -777,17 +776,17 @@ func loadConfig() (*config, error) {
 	// store the macaroons within the network level.
 	if cfg.AdminMacPath == defaultAdminMacPath {
 		cfg.AdminMacPath = filepath.Join(
-			macaroonDatabaseDir, defaultAdminMacFilename,
+			networkDir, defaultAdminMacFilename,
 		)
 	}
 	if cfg.ReadMacPath == defaultReadMacPath {
 		cfg.ReadMacPath = filepath.Join(
-			macaroonDatabaseDir, defaultReadMacFilename,
+			networkDir, defaultReadMacFilename,
 		)
 	}
 	if cfg.InvoiceMacPath == defaultInvoiceMacPath {
 		cfg.InvoiceMacPath = filepath.Join(
-			macaroonDatabaseDir, defaultInvoiceMacFilename,
+			networkDir, defaultInvoiceMacFilename,
 		)
 	}
 

--- a/config.go
+++ b/config.go
@@ -765,10 +765,13 @@ func loadConfig() (*config, error) {
 		}
 	}
 
-	// At this point, we'll save the base data directory in order to ensure
-	// we don't store the macaroon database within any of the chain
-	// namespaced directories.
-	macaroonDatabaseDir = cfg.DataDir
+	// Store the macaroon database within the network level
+	// so it is possible to use a distinct password for testnet,
+	// simnet, mainnet etc.
+	macaroonDatabaseDir = filepath.Join(cfg.DataDir,
+		defaultChainSubDirname,
+		registeredChains.PrimaryChain().String(),
+		normalizeNetwork(activeNetParams.Name))
 
 	// If a custom macaroon directory wasn't specified and the data
 	// directory has changed from the default path, then we'll also update

--- a/config.go
+++ b/config.go
@@ -76,10 +76,6 @@ var (
 	defaultTLSCertPath = filepath.Join(defaultLndDir, defaultTLSCertFilename)
 	defaultTLSKeyPath  = filepath.Join(defaultLndDir, defaultTLSKeyFilename)
 
-	defaultAdminMacPath   = filepath.Join(defaultLndDir, defaultAdminMacFilename)
-	defaultReadMacPath    = filepath.Join(defaultLndDir, defaultReadMacFilename)
-	defaultInvoiceMacPath = filepath.Join(defaultLndDir, defaultInvoiceMacFilename)
-
 	defaultBtcdDir         = btcutil.AppDataDir("btcd", false)
 	defaultBtcdRPCCertFile = filepath.Join(defaultBtcdDir, "rpc.cert")
 
@@ -256,9 +252,6 @@ func loadConfig() (*config, error) {
 		DebugLevel:     defaultLogLevel,
 		TLSCertPath:    defaultTLSCertPath,
 		TLSKeyPath:     defaultTLSKeyPath,
-		AdminMacPath:   defaultAdminMacPath,
-		InvoiceMacPath: defaultInvoiceMacPath,
-		ReadMacPath:    defaultReadMacPath,
 		LogDir:         defaultLogDir,
 		MaxLogFiles:    defaultMaxLogFiles,
 		MaxLogFileSize: defaultMaxLogFileSize,
@@ -774,17 +767,17 @@ func loadConfig() (*config, error) {
 
 	// If a custom macaroon path wasn't specified we'll
 	// store the macaroons within the network level.
-	if cfg.AdminMacPath == defaultAdminMacPath {
+	if cfg.AdminMacPath == "." {
 		cfg.AdminMacPath = filepath.Join(
 			networkDir, defaultAdminMacFilename,
 		)
 	}
-	if cfg.ReadMacPath == defaultReadMacPath {
+	if cfg.ReadMacPath == "." {
 		cfg.ReadMacPath = filepath.Join(
 			networkDir, defaultReadMacFilename,
 		)
 	}
-	if cfg.InvoiceMacPath == defaultInvoiceMacPath {
+	if cfg.InvoiceMacPath == "." {
 		cfg.InvoiceMacPath = filepath.Join(
 			networkDir, defaultInvoiceMacFilename,
 		)

--- a/config.go
+++ b/config.go
@@ -773,22 +773,21 @@ func loadConfig() (*config, error) {
 		registeredChains.PrimaryChain().String(),
 		normalizeNetwork(activeNetParams.Name))
 
-	// If a custom macaroon directory wasn't specified and the data
-	// directory has changed from the default path, then we'll also update
-	// the path for the macaroons to be generated.
-	if cfg.DataDir != defaultDataDir && cfg.AdminMacPath == defaultAdminMacPath {
+	// If a custom macaroon path wasn't specified we'll
+	// store the macaroons within the network level.
+	if cfg.AdminMacPath == defaultAdminMacPath {
 		cfg.AdminMacPath = filepath.Join(
-			cfg.DataDir, defaultAdminMacFilename,
+			macaroonDatabaseDir, defaultAdminMacFilename,
 		)
 	}
-	if cfg.DataDir != defaultDataDir && cfg.ReadMacPath == defaultReadMacPath {
+	if cfg.ReadMacPath == defaultReadMacPath {
 		cfg.ReadMacPath = filepath.Join(
-			cfg.DataDir, defaultReadMacFilename,
+			macaroonDatabaseDir, defaultReadMacFilename,
 		)
 	}
-	if cfg.DataDir != defaultDataDir && cfg.InvoiceMacPath == defaultInvoiceMacPath {
+	if cfg.InvoiceMacPath == defaultInvoiceMacPath {
 		cfg.InvoiceMacPath = filepath.Join(
-			cfg.DataDir, defaultInvoiceMacFilename,
+			macaroonDatabaseDir, defaultInvoiceMacFilename,
 		)
 	}
 

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -306,7 +306,7 @@ Github](https://github.com/lightningnetwork/lnd/issues/20).
 
 Running `lnd` for the first time will by default generate the `admin.macaroon`,
 `read_only.macaroon`, and `macaroons.db` files that are used to authenticate
-into `lnd`. They will be stored in the network directory (default: `lndDir/data/chain/bitcoin/testnet`)
+into `lnd`. They will be stored in the network directory (default: `lndDir/data/chain/bitcoin/simnet`)
 so that it's possible to use a distinct password for testnet, simnet, regest, mainnet, etc.
 Note that if you specified an alternative data directory (via the `--datadir` argument),
 you will have to additionally pass the updated location of the `admin.macaroon`

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -306,8 +306,9 @@ Github](https://github.com/lightningnetwork/lnd/issues/20).
 
 Running `lnd` for the first time will by default generate the `admin.macaroon`,
 `read_only.macaroon`, and `macaroons.db` files that are used to authenticate
-into `lnd`. They will be stored in the default `lnd` data directory. Note that
-if you specified an alternative data directory (via the `--datadir` argument),
+into `lnd`. They will be stored in the network directory (default: `lndDir/data/chain/bitcoin/testnet`)
+so that it's possible to use a distinct password for testnet, simnet, regest, mainnet, etc.
+Note that if you specified an alternative data directory (via the `--datadir` argument),
 you will have to additionally pass the updated location of the `admin.macaroon`
 file into `lncli` using the `--macaroonpath` argument.
 

--- a/docs/grpc/java.md
+++ b/docs/grpc/java.md
@@ -158,7 +158,7 @@ public class Main {
   }
 
   private static final String CERT_PATH = "/Users/user/Library/Application Support/Lnd/tls.cert";
-  private static final String MACAROON_PATH = "/Users/user/Library/Application Support/Lnd/admin.macaroon";
+  private static final String MACAROON_PATH = "/Users/user/Library/Application Support/Lnd/data/bitcoin/testnet/admin.macaroon";
   private static final String HOST = "localhost";
   private static final int PORT = 10009;
 

--- a/docs/grpc/javascript.md
+++ b/docs/grpc/javascript.md
@@ -174,9 +174,10 @@ var grpc = require('grpc');
 
 process.env.GRPC_SSL_CIPHER_SUITES = 'HIGH+ECDSA'
 
-// Lnd admin macaroon is at ~/.lnd/admin.macaroon on Linux and
-// ~/Library/Application Support/Lnd/admin.macaroon on Mac
-var m = fs.readFileSync('~/.lnd/admin.macaroon');
+// Lnd admin macaroon is at ~/.lnd/data/chain/bitcoin/testnet/admin.macaroon
+// on Linux and ~/Library/Application Support/Lnd/data/chain/bitcoin/testnet/admin.macaroon
+// on Mac.
+var m = fs.readFileSync('~/.lnd/data/chain/bitcoin/testnet/admin.macaroon');
 var macaroon = m.toString('hex');
 var meta = new grpc.Metadata().add('macaroon', macaroon);
 
@@ -195,9 +196,10 @@ var grpc = require('grpc');
 
 process.env.GRPC_SSL_CIPHER_SUITES = 'HIGH+ECDSA'
 
-// Lnd admin macaroon is at ~/.lnd/admin.macaroon on Linux and
-// ~/Library/Application Support/Lnd/admin.macaroon on Mac
-var m = fs.readFileSync('~/.lnd/admin.macaroon');
+// Lnd admin macaroon is at ~/.lnd/data/chain/bitcoin/testnet/admin.macaroon
+// on Linux and ~/Library/Application Support/Lnd/data/chain/bitcoin/testnet/admin.macaroon
+// on Mac.
+var m = fs.readFileSync('~/.lnd/data/chain/bitcoin/testnet/admin.macaroon');
 var macaroon = m.toString('hex');
 
 // build meta data credentials

--- a/docs/grpc/javascript.md
+++ b/docs/grpc/javascript.md
@@ -174,10 +174,10 @@ var grpc = require('grpc');
 
 process.env.GRPC_SSL_CIPHER_SUITES = 'HIGH+ECDSA'
 
-// Lnd admin macaroon is at ~/.lnd/data/chain/bitcoin/testnet/admin.macaroon
-// on Linux and ~/Library/Application Support/Lnd/data/chain/bitcoin/testnet/admin.macaroon
+// Lnd admin macaroon is at ~/.lnd/data/[chainDir]/[chain]/[network]/admin.macaroon
+// on Linux and ~/Library/Application Support/Lnd/data/[chainDir]/[chain]/[network]/admin.macaroon
 // on Mac.
-var m = fs.readFileSync('~/.lnd/data/chain/bitcoin/testnet/admin.macaroon');
+var m = fs.readFileSync('~/.lnd/data/chain/bitcoin/simnet/admin.macaroon');
 var macaroon = m.toString('hex');
 var meta = new grpc.Metadata().add('macaroon', macaroon);
 
@@ -196,10 +196,10 @@ var grpc = require('grpc');
 
 process.env.GRPC_SSL_CIPHER_SUITES = 'HIGH+ECDSA'
 
-// Lnd admin macaroon is at ~/.lnd/data/chain/bitcoin/testnet/admin.macaroon
-// on Linux and ~/Library/Application Support/Lnd/data/chain/bitcoin/testnet/admin.macaroon
+// Lnd admin macaroon is at ~/.lnd/data/[chainDir]/[chain]/[network]/admin.macaroon
+// on Linux and ~/Library/Application Support/Lnd/data/[chainDir]/[chain]/[network]/admin.macaroon
 // on Mac.
-var m = fs.readFileSync('~/.lnd/data/chain/bitcoin/testnet/admin.macaroon');
+var m = fs.readFileSync('~/.lnd/data/chain/bitcoin/simnet/admin.macaroon');
 var macaroon = m.toString('hex');
 
 // build meta data credentials

--- a/docs/grpc/python.md
+++ b/docs/grpc/python.md
@@ -140,9 +140,9 @@ To authenticate using macaroons you need to include the macaroon in the metadata
 ```python
 import codecs
 
-# Lnd admin macaroon is at ~/.lnd/admin.macaroon on Linux and
-# ~/Library/Application Support/Lnd/admin.macaroon on Mac
-with open(os.path.expanduser('~/.lnd/admin.macaroon'), 'rb') as f:
+# Lnd admin macaroon is at ~/.lnd/data/chain/bitcoin/testnet/admin.macaroon on Linux and
+# ~/Library/Application Support/Lnd/data/chain/bitcoin/testnet/admin.macaroon on Mac
+with open(os.path.expanduser('~/.lnd/data/chain/bitcoin/testnet/admin.macaroon'), 'rb') as f:
     macaroon_bytes = f.read()
     macaroon = codecs.encode(macaroon_bytes, 'hex')
 ```

--- a/docs/grpc/python.md
+++ b/docs/grpc/python.md
@@ -140,9 +140,9 @@ To authenticate using macaroons you need to include the macaroon in the metadata
 ```python
 import codecs
 
-# Lnd admin macaroon is at ~/.lnd/data/chain/bitcoin/testnet/admin.macaroon on Linux and
-# ~/Library/Application Support/Lnd/data/chain/bitcoin/testnet/admin.macaroon on Mac
-with open(os.path.expanduser('~/.lnd/data/chain/bitcoin/testnet/admin.macaroon'), 'rb') as f:
+# Lnd admin macaroon is at ~/.lnd/data/[chainDir]/[chain]/[network]/admin.macaroon on Linux and
+# ~/Library/Application Support/Lnd/data/[chainDir]/[chain]/[network]/admin.macaroon on Mac
+with open(os.path.expanduser('~/.lnd/data/chain/bitcoin/simnet/admin.macaroon'), 'rb') as f:
     macaroon_bytes = f.read()
     macaroon = codecs.encode(macaroon_bytes, 'hex')
 ```

--- a/docs/macaroons.md
+++ b/docs/macaroons.md
@@ -86,7 +86,7 @@ it won't be checked for validity.
 Since `lnd` requires macaroons by default in order to call RPC methods, `lncli`
 now reads a macaroon and provides it in the RPC call. Unless the path is
 changed by the `--macaroonpath` option, `lncli` tries to read the macaroon from
-`~/.lnd/data/chain/bitcoin/testnet/admin.macaroon` by default
+`~/.lnd/data/chain/bitcoin/mainnet/admin.macaroon` by default
 and will error if that file doesn't exist unless provided the `--no-macaroons` option.
 Keep this in mind when running `lnd` with `--no-macaroons`, as `lncli` will error
 out unless called the same way **or** `lnd` has generated a macaroon on a previous run without this
@@ -114,7 +114,7 @@ Where `<macaroon>` is the hex encoded binary data from the macaroon file itself.
 
 A very simple example using `curl` may look something like this:
 
-    curl --insecure --header "Grpc-Metadata-macaroon: $(xxd -ps -u -c 1000  $HOME/.lnd/data/chain/bitcoin/testnet/admin.macaroon)" https://localhost:8080/v1/getinfo
+    curl --insecure --header "Grpc-Metadata-macaroon: $(xxd -ps -u -c 1000  $HOME/.lnd/data/chain/bitcoin/mainnet/admin.macaroon)" https://localhost:8080/v1/getinfo
 
 Have a look at the [Java GRPC example](/docs/grpc/java.md) for programmatic usage details.
 

--- a/docs/macaroons.md
+++ b/docs/macaroons.md
@@ -86,10 +86,10 @@ it won't be checked for validity.
 Since `lnd` requires macaroons by default in order to call RPC methods, `lncli`
 now reads a macaroon and provides it in the RPC call. Unless the path is
 changed by the `--macaroonpath` option, `lncli` tries to read the macaroon from
-`~/.lnd/admin.macaroon` by default and will error if that file doesn't exist
-unless provided the `--no-macaroons` option. Keep this in mind when running
-`lnd` with `--no-macaroons`, as `lncli` will error out unless called the same
-way **or** `lnd` has generated a macaroon on a previous run without this
+`~/.lnd/data/chain/bitcoin/testnet/admin.macaroon` by default
+and will error if that file doesn't exist unless provided the `--no-macaroons` option.
+Keep this in mind when running `lnd` with `--no-macaroons`, as `lncli` will error
+out unless called the same way **or** `lnd` has generated a macaroon on a previous run without this
 option.
 
 `lncli` also adds a caveat which makes it valid for only 60 seconds by default
@@ -114,7 +114,7 @@ Where `<macaroon>` is the hex encoded binary data from the macaroon file itself.
 
 A very simple example using `curl` may look something like this:
 
-    curl --insecure --header "Grpc-Metadata-macaroon: $(xxd -ps -u -c 1000  $HOME/.lnd/admin.macaroon)" https://localhost:8080/v1/getinfo
+    curl --insecure --header "Grpc-Metadata-macaroon: $(xxd -ps -u -c 1000  $HOME/.lnd/data/chain/bitcoin/testnet/admin.macaroon)" https://localhost:8080/v1/getinfo
 
 Have a look at the [Java GRPC example](/docs/grpc/java.md) for programmatic usage details.
 

--- a/lnd.go
+++ b/lnd.go
@@ -61,7 +61,7 @@ var (
 	cfg              *config
 	registeredChains = newChainRegistry()
 
-	macaroonDatabaseDir string
+	networkDir string
 
 	// End of ASN.1 time.
 	endOfTime = time.Date(2049, 12, 31, 23, 59, 59, 0, time.UTC)
@@ -234,7 +234,7 @@ func lndMain() error {
 	var macaroonService *macaroons.Service
 	if !cfg.NoMacaroons {
 		// Create the macaroon authentication/authorization service.
-		macaroonService, err = macaroons.NewService(macaroonDatabaseDir,
+		macaroonService, err = macaroons.NewService(networkDir,
 			macaroons.IPLockChecker)
 		if err != nil {
 			srvrLog.Errorf("unable to create macaroon service: %v", err)
@@ -708,7 +708,7 @@ func waitForWalletPassword(grpcEndpoints, restEndpoints []net.Addr,
 	// deleted within it and recreated when successfully changing the
 	// wallet's password.
 	macaroonFiles := []string{
-		filepath.Join(macaroonDatabaseDir, macaroons.DBFilename),
+		filepath.Join(networkDir, macaroons.DBFilename),
 		cfg.AdminMacPath, cfg.ReadMacPath, cfg.InvoiceMacPath,
 	}
 	pwService := walletunlocker.New(

--- a/lnd.go
+++ b/lnd.go
@@ -206,6 +206,13 @@ func lndMain() error {
 		unlockedWallet  *wallet.Wallet
 	)
 
+	// Ensure network directory exists.
+	if !fileExists(networkDir) {
+		if err := os.MkdirAll(networkDir, 0700); err != nil {
+			return err
+		}
+	}
+
 	// We wait until the user provides a password over RPC. In case lnd is
 	// started with the --noencryptwallet flag, we use the default password
 	// for wallet encryption.

--- a/macaroons/README.md
+++ b/macaroons/README.md
@@ -9,7 +9,7 @@ For a more high-level overview see
 ## Root key
 
 At startup, if the option `--no-macaroons` is **not** used, a Bolt DB key/value
-store named `data/macaroons.db` is created with a bucket named `macrootkeys`.
+store named `data/[chainDir]/[chain]/[network]/macaroons.db` is created with a bucket named `macrootkeys`.
 In this DB the following two key/value pairs are stored:
 
 * Key `0`: the encrypted root key (32 bytes).

--- a/sample-lnd.conf
+++ b/sample-lnd.conf
@@ -39,15 +39,25 @@
 
 ; Path to write the admin macaroon for lnd's RPC and REST services if it
 ; doesn't exist. This can be set if one wishes to store the admin macaroon in a
-; distinct location. By default, it is stored within lnd's main home directory.
+; distinct location. By default, it is stored within lnd's main main chain's
+; network directory.
 ; Applications that are able to read this file, gains admin macaroon access
-; adminmacaroonpath=~/.lnd/data/chain/bitcoin/testnet/admin.macaroon
+; adminmacaroonpath=~/.lnd/data/chain/bitcoin/simnet/admin.macaroon
+
+; Path to write the invoice macaroon for lnd's RPC and REST services if it
+; doesn't exist. This can be set if one wishes to store the invoice macaroon in a
+; distinct location. By default, it is stored within lnd's main main chain's
+; network directory.
+; The read only macaroon allows users which can read the file to access RPC's
+; read and write acces to all invoice related gRPC commands.
+; invoicemacaroonpath=~/.lnd/data/chain/bitcoin/simnet/admin.macaroon
 
 ; Path to write the read-only macaroon for lnd's RPC and REST services if it
-; doesn't exist. This can be set if one wishes to store the read-only macaroon
+; doesn't exist. By default, it is stored within lnd's main main chain's
+; network directory. This can be set if one wishes to store the read-only macaroon
 ; in a distinct location. The read only macaroon allows users which can read
 ; the file to access RPC's which don't modify the state of the daemon.
-; readonlymacaroonpath=~/.lnd/data/chain/bitcoin/testnet/readonly.macaroon
+; readonlymacaroonpath=~/.lnd/data/chain/bitcoin/simnet/readonly.macaroon
 
 ; Specify the interfaces to listen on for p2p connections.  One listen
 ; address per line.

--- a/sample-lnd.conf
+++ b/sample-lnd.conf
@@ -42,7 +42,7 @@
 ; distinct location. By default, it is stored within lnd's main main chain's
 ; network directory.
 ; Applications that are able to read this file, gains admin macaroon access
-; adminmacaroonpath=~/.lnd/data/chain/bitcoin/simnet/admin.macaroon
+; adminmacaroonpath=~/.lnd/data/chain/bitcoin/mainnet/admin.macaroon
 
 ; Path to write the invoice macaroon for lnd's RPC and REST services if it
 ; doesn't exist. This can be set if one wishes to store the invoice macaroon in a
@@ -50,14 +50,14 @@
 ; network directory.
 ; The read only macaroon allows users which can read the file to access RPC's
 ; read and write acces to all invoice related gRPC commands.
-; invoicemacaroonpath=~/.lnd/data/chain/bitcoin/simnet/admin.macaroon
+; invoicemacaroonpath=~/.lnd/data/chain/bitcoin/mainnet/admin.macaroon
 
 ; Path to write the read-only macaroon for lnd's RPC and REST services if it
 ; doesn't exist. By default, it is stored within lnd's main main chain's
 ; network directory. This can be set if one wishes to store the read-only macaroon
 ; in a distinct location. The read only macaroon allows users which can read
 ; the file to access RPC's which don't modify the state of the daemon.
-; readonlymacaroonpath=~/.lnd/data/chain/bitcoin/simnet/readonly.macaroon
+; readonlymacaroonpath=~/.lnd/data/chain/bitcoin/mainnet/readonly.macaroon
 
 ; Specify the interfaces to listen on for p2p connections.  One listen
 ; address per line.

--- a/sample-lnd.conf
+++ b/sample-lnd.conf
@@ -41,14 +41,13 @@
 ; doesn't exist. This can be set if one wishes to store the admin macaroon in a
 ; distinct location. By default, it is stored within lnd's main home directory.
 ; Applications that are able to read this file, gains admin macaroon access
-; adminmacaroonpath=~/.lnd/admin.macaroon
+; adminmacaroonpath=~/.lnd/data/chain/bitcoin/testnet/admin.macaroon
 
 ; Path to write the read-only macaroon for lnd's RPC and REST services if it
 ; doesn't exist. This can be set if one wishes to store the read-only macaroon
 ; in a distinct location. The read only macaroon allows users which can read
-; the file to access RPCs which don't modify the state of the daemon.
-; readonlymacaroonpath=~/.lnd/readonly.macaroon
-
+; the file to access RPC's which don't modify the state of the daemon.
+; readonlymacaroonpath=~/.lnd/data/chain/bitcoin/testnet/readonly.macaroon
 
 ; Specify the interfaces to listen on for p2p connections.  One listen
 ; address per line.


### PR DESCRIPTION
https://github.com/lightningnetwork/lnd/issues/1249

This PR:
* moves the storage of `macaroon.db` and macaroons within the `[chainDir]/[chain]/[network]` directory
* adds `dataDir`, `chain` and `network` flags to `lncli` in order to determine which macaroons to use
* updates documentation for the changes listed above