### PR TITLE
Fixed link to /docker/README.md

### DIFF
--- a/docs/DOCKER.md
+++ b/docs/DOCKER.md
@@ -3,7 +3,7 @@
 ## Development/testing
 
 For development or testing, or to spin up a `btcd` backend alongside `lnd`,
-check out the documentation at [docker/README.md](docker/README.md).
+check out the documentation at [docker/README.md](../docker/README.md).
 
 ## Production
 


### PR DESCRIPTION
Link must be /docker/README.md, relative to the repository's root. Previously it was relative to /docs, resulting in 404.