### PR TITLE
routing: use correct fees by searching backwards

### DIFF
--- a/autopilot/graph.go
+++ b/autopilot/graph.go
@@ -85,6 +85,17 @@ func (d dbNode) ForEachChannel(cb func(ChannelEdge) error) error {
 	return d.node.ForEachChannel(d.tx, func(tx *bolt.Tx,
 		ei *channeldb.ChannelEdgeInfo, ep, _ *channeldb.ChannelEdgePolicy) error {
 
+		// Skip channels for which no outgoing edge policy is available.
+		//
+		// TODO(joostjager): Ideally the case where channels have a nil
+		// policy should be supported, as auto pilot is not looking at
+		// the policies. For now, it is not easily possible to get a
+		// reference to the other end LightningNode object without
+		// retrieving the policy.
+		if ep == nil {
+			return nil
+		}
+
 		pubkey, _ := ep.Node.PubKey()
 		edge := ChannelEdge{
 			Channel: Channel{

--- a/channeldb/db.go
+++ b/channeldb/db.go
@@ -59,6 +59,14 @@ var (
 			number:    3,
 			migration: migrateInvoiceTimeSeriesOutgoingPayments,
 		},
+		{
+			// The version of the database where every channel
+			// always has two entries in the edges bucket. If
+			// a policy is unknown, this will be represented
+			// by a special byte sequence.
+			number:    4,
+			migration: migrateEdgePolicies,
+		},
 	}
 
 	// Big endian is the preferred byte order, due to cursor scans over

--- a/channeldb/graph.go
+++ b/channeldb/graph.go
@@ -56,15 +56,21 @@ var (
 	// edgeBucket is a bucket which houses all of the edge or channel
 	// information within the channel graph. This bucket essentially acts
 	// as an adjacency list, which in conjunction with a range scan, can be
-	// used to iterate over all the _outgoing_ edges for a particular node.
-	// Key in the bucket use a prefix scheme which leads with the node's
-	// public key and sends with the compact edge ID. For each edgeID,
-	// there will be two entries within the bucket, as the graph is
-	// directed: nodes may have different policies w.r.t to fees for their
-	// respective directions.
+	// used to iterate over all the incoming and outgoing edges for a
+	// particular node. Key in the bucket use a prefix scheme which leads
+	// with the node's public key and sends with the compact edge ID.
+	// For each chanID, there will be two entries within the bucket, as the
+	// graph is directed: nodes may have different policies w.r.t to fees
+	// for their respective directions.
 	//
-	// maps: pubKey || edgeID -> edge policy for node
+	// maps: pubKey || chanID -> channel edge policy for node
 	edgeBucket = []byte("graph-edge")
+
+	// unknownPolicy is represented as an empty slice. It is
+	// used as the value in edgeBucket for unknown channel edge policies.
+	// Unknown policies are still stored in the database to enable efficient
+	// lookup of incoming channel edges.
+	unknownPolicy = []byte{}
 
 	// chanStart is an array of all zero bytes which is used to perform
 	// range scans within the edgeBucket to obtain all of the outgoing
@@ -509,6 +515,18 @@ func (c *ChannelGraph) AddChannelEdge(edge *ChannelEdgeInfo) error {
 		// nodes and also store the static components of the channel.
 		if err := putChanEdgeInfo(edgeIndex, edge, chanKey); err != nil {
 			return err
+		}
+
+		// Mark edge policies for both sides as unknown. This is to
+		// enable efficient incoming channel lookup for a node.
+		for _, key := range []*[33]byte{&edge.NodeKey1Bytes,
+			&edge.NodeKey2Bytes} {
+
+			err := putChanEdgePolicyUnknown(edges, edge.ChannelID,
+				key[:])
+			if err != nil {
+				return err
+			}
 		}
 
 		// Finally we add it to the channel index which maps channel
@@ -1759,12 +1777,14 @@ func (c *ChannelGraph) HasLightningNode(nodePub [33]byte) (time.Time, bool, erro
 	return updateTime, exists, nil
 }
 
-// ForEachChannel iterates through all the outgoing channel edges from this
-// node, executing the passed callback with each edge as its sole argument. The
-// first edge policy is the outgoing edge *to* the connecting node, while the
-// second is the incoming edge *from* the connecting node. If the callback
-// returns an error, then the iteration is halted with the error propagated
-// back up to the caller.
+// ForEachChannel iterates through all channels of this node, executing the
+// passed callback with an edge info structure and the policies of each end
+// of the channel. The first edge policy is the outgoing edge *to* the
+// the connecting node, while the second is the incoming edge *from* the
+// connecting node. If the callback returns an error, then the iteration is
+// halted with the error propagated back up to the caller.
+//
+// Unknown policies are passed into the callback as nil values.
 //
 // If the caller wishes to re-use an existing boltdb transaction, then it
 // should be passed as the first argument.  Otherwise the first argument should
@@ -1805,44 +1825,51 @@ func (l *LightningNode) ForEachChannel(tx *bolt.Tx,
 		// as its prefix. This indicates that we've stepped over into
 		// another node's edges, so we can terminate our scan.
 		edgeCursor := edges.Cursor()
-		for nodeEdge, edgeInfo := edgeCursor.Seek(nodeStart[:]); bytes.HasPrefix(nodeEdge, nodePub); nodeEdge, edgeInfo = edgeCursor.Next() {
-			// If the prefix still matches, then the value is the
-			// raw edge information. So we can now serialize the
-			// edge info and fetch the outgoing node in order to
-			// retrieve the full channel edge.
-			edgeReader := bytes.NewReader(edgeInfo)
-			toEdgePolicy, err := deserializeChanEdgePolicy(edgeReader, nodes)
-			if err != nil {
-				return err
-			}
-			toEdgePolicy.db = l.db
-			toEdgePolicy.Node.db = l.db
-
+		for nodeEdge, _ := edgeCursor.Seek(nodeStart[:]); bytes.HasPrefix(nodeEdge, nodePub); nodeEdge, _ = edgeCursor.Next() {
+			// If the prefix still matches, the channel id is
+			// returned in nodeEdge. Channel id is used to lookup
+			// the node at the other end of the channel and both
+			// edge policies.
 			chanID := nodeEdge[33:]
 			edgeInfo, err := fetchChanEdgeInfo(edgeIndex, chanID)
 			if err != nil {
 				return err
 			}
 
-			// We'll also fetch the incoming edge so this
-			// information can be available to the caller.
-			incomingNode := toEdgePolicy.Node.PubKeyBytes[:]
-			fromEdgePolicy, err := fetchChanEdgePolicy(
-				edges, chanID, incomingNode, nodes,
-			)
-			if err != nil && err != ErrEdgeNotFound &&
-				err != ErrGraphNodeNotFound {
+			otherNode, err := edgeInfo.OtherNodeKeyBytes(nodePub)
+			if err != nil {
 				return err
 			}
-			if fromEdgePolicy != nil {
-				fromEdgePolicy.db = l.db
-				if fromEdgePolicy.Node != nil {
-					fromEdgePolicy.Node.db = l.db
+
+			policy1, policy2, err := fetchChanEdgePolicies(edgeIndex,
+				edges, nodes, chanID, l.db)
+
+			var incomingPolicy, outgoingPolicy *ChannelEdgePolicy
+
+			if policy1 != nil {
+				switch {
+				case bytes.Equal(nodePub, policy1.Node.PubKeyBytes[:]):
+					incomingPolicy = policy1
+				case bytes.Equal(otherNode, policy1.Node.PubKeyBytes[:]):
+					outgoingPolicy = policy1
+				default:
+					return fmt.Errorf("Unexpected node in policy")
+				}
+			}
+
+			if policy2 != nil {
+				switch {
+				case bytes.Equal(nodePub, policy2.Node.PubKeyBytes[:]):
+					incomingPolicy = policy2
+				case bytes.Equal(otherNode, policy2.Node.PubKeyBytes[:]):
+					outgoingPolicy = policy2
+				default:
+					return fmt.Errorf("Unexpected node in policy")
 				}
 			}
 
 			// Finally, we execute the callback.
-			err = cb(tx, &edgeInfo, toEdgePolicy, fromEdgePolicy)
+			err = cb(tx, &edgeInfo, outgoingPolicy, incomingPolicy)
 			if err != nil {
 				return err
 			}
@@ -2014,6 +2041,21 @@ func (c *ChannelEdgeInfo) BitcoinKey2() (*btcec.PublicKey, error) {
 	c.bitcoinKey2 = key
 
 	return key, nil
+}
+
+// OtherNodeKeyBytes returns the node key bytes of the other end of
+// the channel.
+func (c *ChannelEdgeInfo) OtherNodeKeyBytes(thisNodeKey []byte) (
+	[]byte, error) {
+
+	switch {
+	case bytes.Equal(c.NodeKey1Bytes[:], thisNodeKey):
+		return c.NodeKey2Bytes[:], nil
+	case bytes.Equal(c.NodeKey2Bytes[:], thisNodeKey):
+		return c.NodeKey1Bytes[:], nil
+	default:
+		return nil, fmt.Errorf("Node not participating in this channel")
+	}
 }
 
 // ChannelAuthProof is the authentication proof (the signature portion) for a
@@ -2871,7 +2913,9 @@ func putChanEdgePolicy(edges *bolt.Bucket, edge *ChannelEdgePolicy, from, to []b
 
 	// If there was already an entry for this edge, then we'll need to
 	// delete the old one to ensure we don't leave around any after-images.
-	if edgeBytes := edges.Get(edgeKey[:]); edgeBytes != nil {
+	// An unknown policy value does not have a update time recorded, so
+	// it also does not need to be removed.
+	if edgeBytes := edges.Get(edgeKey[:]); edgeBytes != nil && !bytes.Equal(edgeBytes[:], unknownPolicy) {
 		// In order to delete the old entry, we'll need to obtain the
 		// *prior* update time in order to delete it. To do this, we'll
 		// create an offset to slice in. Starting backwards, we'll
@@ -2899,6 +2943,20 @@ func putChanEdgePolicy(edges *bolt.Bucket, edge *ChannelEdgePolicy, from, to []b
 	return edges.Put(edgeKey[:], b.Bytes()[:])
 }
 
+// putChanEdgePolicyUnknown marks the edge policy as unknown in the edges bucket.
+func putChanEdgePolicyUnknown(edges *bolt.Bucket, channelID uint64, from []byte) error {
+	var edgeKey [33 + 8]byte
+	copy(edgeKey[:], from)
+	byteOrder.PutUint64(edgeKey[33:], channelID)
+
+	if edges.Get(edgeKey[:]) != nil {
+		return fmt.Errorf("Cannot write unknown policy for channel %v "+
+			" when there is already a policy present", channelID)
+	}
+
+	return edges.Put(edgeKey[:], unknownPolicy)
+}
+
 func fetchChanEdgePolicy(edges *bolt.Bucket, chanID []byte,
 	nodePub []byte, nodes *bolt.Bucket) (*ChannelEdgePolicy, error) {
 
@@ -2909,6 +2967,11 @@ func fetchChanEdgePolicy(edges *bolt.Bucket, chanID []byte,
 	edgeBytes := edges.Get(edgeKey[:])
 	if edgeBytes == nil {
 		return nil, ErrEdgeNotFound
+	}
+
+	// No need to deserialize unknown policy.
+	if bytes.Equal(edgeBytes[:], unknownPolicy) {
+		return nil, nil
 	}
 
 	edgeReader := bytes.NewReader(edgeBytes)
@@ -2930,7 +2993,7 @@ func fetchChanEdgePolicies(edgeIndex *bolt.Bucket, edges *bolt.Bucket,
 	// something other than edge non-existence.
 	node1Pub := edgeInfo[:33]
 	edge1, err := fetchChanEdgePolicy(edges, chanID, node1Pub, nodes)
-	if err != nil && err != ErrEdgeNotFound {
+	if err != nil {
 		return nil, nil, err
 	}
 
@@ -2945,7 +3008,7 @@ func fetchChanEdgePolicies(edgeIndex *bolt.Bucket, edges *bolt.Bucket,
 	// half of the edge information.
 	node2Pub := edgeInfo[33:67]
 	edge2, err := fetchChanEdgePolicy(edges, chanID, node2Pub, nodes)
-	if err != nil && err != ErrEdgeNotFound {
+	if err != nil {
 		return nil, nil, err
 	}
 

--- a/channeldb/graph_test.go
+++ b/channeldb/graph_test.go
@@ -350,6 +350,15 @@ func TestEdgeInsertionDeletion(t *testing.T) {
 		t.Fatalf("unable to create channel edge: %v", err)
 	}
 
+	// Ensure that both policies are returned as unknown (nil).
+	_, e1, e2, err := graph.FetchChannelEdgesByID(chanID)
+	if err != nil {
+		t.Fatalf("unable to fetch channel edge")
+	}
+	if e1 != nil || e2 != nil {
+		t.Fatalf("channel edges not unknown")
+	}
+
 	// Next, attempt to delete the edge from the database, again this
 	// should proceed without any issues.
 	if err := graph.DeleteChannelEdge(&outpoint); err != nil {
@@ -917,6 +926,12 @@ func TestGraphTraversal(t *testing.T) {
 	numNodeChans := 0
 	err = firstNode.ForEachChannel(nil, func(_ *bolt.Tx, _ *ChannelEdgeInfo,
 		outEdge, inEdge *ChannelEdgePolicy) error {
+
+		// All channels between first and second node should have fully
+		// (both sides) specified policies.
+		if inEdge == nil || outEdge == nil {
+			return fmt.Errorf("channel policy not present")
+		}
 
 		// Each should indicate that it's outgoing (pointed
 		// towards the second node).
@@ -1939,6 +1954,119 @@ func TestFetchChanInfos(t *testing.T) {
 		}
 		assertEdgeInfoEqual(t, resp[i].Info, edges[i].Info)
 	}
+}
+
+// TestIncompleteChannelPolicies tests that a channel that only has a policy
+// specified on one end is properly returned in ForEachChannel calls from
+// both sides.
+func TestIncompleteChannelPolicies(t *testing.T) {
+	t.Parallel()
+
+	db, cleanUp, err := makeTestDB()
+	defer cleanUp()
+	if err != nil {
+		t.Fatalf("unable to make test database: %v", err)
+	}
+
+	graph := db.ChannelGraph()
+
+	// Create two nodes.
+	node1, err := createTestVertex(db)
+	if err != nil {
+		t.Fatalf("unable to create test node: %v", err)
+	}
+	if err := graph.AddLightningNode(node1); err != nil {
+		t.Fatalf("unable to add node: %v", err)
+	}
+	node2, err := createTestVertex(db)
+	if err != nil {
+		t.Fatalf("unable to create test node: %v", err)
+	}
+	if err := graph.AddLightningNode(node2); err != nil {
+		t.Fatalf("unable to add node: %v", err)
+	}
+
+	// Create channel between nodes.
+	txHash := sha256.Sum256([]byte{0})
+	op := wire.OutPoint{
+		Hash:  txHash,
+		Index: 0,
+	}
+
+	channel, chanID := createEdge(
+		uint32(0), 0, 0, 0, node1, node2,
+	)
+
+	if err := graph.AddChannelEdge(&channel); err != nil {
+		t.Fatalf("unable to create channel edge: %v", err)
+	}
+
+	// Ensure that channel is reported with unknown policies.
+
+	checkPolicies := func(node *LightningNode, expectedIn, expectedOut bool) {
+		calls := 0
+		node.ForEachChannel(nil, func(_ *bolt.Tx, _ *ChannelEdgeInfo,
+			outEdge, inEdge *ChannelEdgePolicy) error {
+
+			if !expectedOut && outEdge != nil {
+				t.Fatalf("Expected no outgoing policy")
+			}
+
+			if expectedOut && outEdge == nil {
+				t.Fatalf("Expected an outgoing policy")
+			}
+
+			if !expectedIn && inEdge != nil {
+				t.Fatalf("Expected no incoming policy")
+			}
+
+			if expectedIn && inEdge == nil {
+				t.Fatalf("Expected an incoming policy")
+			}
+
+			calls++
+
+			return nil
+		})
+
+		if calls != 1 {
+			t.Fatalf("Expected only one callback call")
+		}
+	}
+
+	checkPolicies(node2, false, false)
+
+	// Only create an edge policy for node1 and leave the policy for node2
+	// unknown.
+	updateTime := time.Unix(1234, 0)
+
+	edgePolicy := newEdgePolicy(
+		chanID.ToUint64(), op, db, updateTime.Unix(),
+	)
+	edgePolicy.Flags = 0
+	edgePolicy.Node = node2
+	edgePolicy.SigBytes = testSig.Serialize()
+	if err := graph.UpdateEdgePolicy(edgePolicy); err != nil {
+		t.Fatalf("unable to update edge: %v", err)
+	}
+
+	checkPolicies(node1, false, true)
+	checkPolicies(node2, true, false)
+
+	// Create second policy and assert that both policies are reported
+	// as present.
+	edgePolicy = newEdgePolicy(
+		chanID.ToUint64(), op, db, updateTime.Unix(),
+	)
+	edgePolicy.Flags = 1
+	edgePolicy.Node = node1
+	edgePolicy.SigBytes = testSig.Serialize()
+	if err := graph.UpdateEdgePolicy(edgePolicy); err != nil {
+		t.Fatalf("unable to update edge: %v", err)
+	}
+
+	checkPolicies(node1, true, true)
+	checkPolicies(node2, true, true)
 }
 
 // TestChannelEdgePruningUpdateIndexDeletion tests that once edges are deleted

--- a/routing/heap.go
+++ b/routing/heap.go
@@ -1,6 +1,9 @@
 package routing
 
-import "github.com/lightningnetwork/lnd/channeldb"
+import (
+	"github.com/lightningnetwork/lnd/channeldb"
+	"github.com/lightningnetwork/lnd/lnwire"
+)
 
 // nodeWithDist is a helper struct that couples the distance from the current
 // source to a node with a pointer to the node itself.
@@ -12,6 +15,14 @@ type nodeWithDist struct {
 	// node is the vertex itself. This pointer can be used to explore all
 	// the outgoing edges (channels) emanating from a node.
 	node *channeldb.LightningNode
+
+	// amountToReceive is the amount that should be received by this node.
+	// Either as final payment to the final node or as an intermediate
+	// amount that includes also the fees for subsequent hops.
+	amountToReceive lnwire.MilliSatoshi
+
+	// fee is the fee that this node is charging for forwarding.
+	fee lnwire.MilliSatoshi
 }
 
 // distanceHeap is a min-distance heap that's used within our path finding

--- a/routing/missioncontrol.go
+++ b/routing/missioncontrol.go
@@ -375,7 +375,7 @@ func (p *paymentSession) RequestRoute(payment *LightningPayment,
 	path, err := findPath(
 		nil, p.mc.graph, p.additionalEdges, p.mc.selfNode,
 		payment.Target, pruneView.vertexes, pruneView.edges,
-		payment.Amount, p.bandwidthHints,
+		payment.Amount, payment.FeeLimit, p.bandwidthHints,
 	)
 	if err != nil {
 		return nil, err

--- a/routing/pathfind.go
+++ b/routing/pathfind.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/btcsuite/btcd/btcec"
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
-	"github.com/btcsuite/btcutil"
 	"github.com/coreos/bbolt"
 	"github.com/lightningnetwork/lightning-onion"
 	"github.com/lightningnetwork/lnd/channeldb"
@@ -69,9 +68,13 @@ type HopHint struct {
 // edge), as well as the total capacity. It also includes the origin chain of
 // the channel itself.
 type ChannelHop struct {
-	// Capacity is the total capacity of the channel being traversed. This
-	// value is expressed for stability in satoshis.
-	Capacity btcutil.Amount
+	// Bandwidth is an estimate of the maximum amount that can be sent
+	// through the channel in the direction indicated by ChannelEdgePolicy.
+	// It is based on the on-chain capacity of the channel, bandwidth
+	// hints passed in via SendRoute RPC and/or running amounts that
+	// represent pending payments. These running amounts have msat as
+	// unit. Therefore this property is expressed in msat too.
+	Bandwidth lnwire.MilliSatoshi
 
 	// Chain is a 32-byte has that denotes the base blockchain network of
 	// the channel. The 32-byte hash is the "genesis" block of the
@@ -107,6 +110,14 @@ type Hop struct {
 	// payment, this difference nets the hop fees for forwarding the
 	// payment.
 	Fee lnwire.MilliSatoshi
+}
+
+// edgePolicyWithSource is a helper struct to keep track of the source node
+// of a channel edge. ChannelEdgePolicy only contains to destination node
+// of the edge.
+type edgePolicyWithSource struct {
+	sourceNode *channeldb.LightningNode
+	edge       *channeldb.ChannelEdgePolicy
 }
 
 // computeFee computes the fee to forward an HTLC of `amt` milli-satoshis over
@@ -358,13 +369,12 @@ func newRoute(amtToSend, feeLimit lnwire.MilliSatoshi, sourceVertex Vertex,
 		// enough capacity to carry the required amount which
 		// includes the fee dictated at each hop. Make the comparison
 		// in msat to prevent rounding errors.
-		if currentHop.AmtToForward+fee > lnwire.NewMSatFromSatoshis(
-			currentHop.Channel.Capacity) {
+		if currentHop.AmtToForward+fee > currentHop.Channel.Bandwidth {
 
 			err := fmt.Sprintf("channel graph has insufficient "+
 				"capacity for the payment: need %v, have %v",
-				currentHop.AmtToForward.ToSatoshis(),
-				currentHop.Channel.Capacity)
+				currentHop.AmtToForward+fee,
+				currentHop.Channel.Bandwidth)
 
 			return nil, newErrf(ErrInsufficientCapacity, err)
 		}
@@ -430,32 +440,22 @@ func (v Vertex) String() string {
 	return fmt.Sprintf("%x", v[:])
 }
 
-// edgeWithPrev is a helper struct used in path finding that couples an
-// directional edge with the node's ID in the opposite direction.
-type edgeWithPrev struct {
-	edge     *ChannelHop
-	prevNode [33]byte
-}
-
 // edgeWeight computes the weight of an edge. This value is used when searching
 // for the shortest path within the channel graph between two nodes. Weight is
 // is the fee itself plus a time lock penalty added to it. This benefits
 // channels with shorter time lock deltas and shorter (hops) routes in general.
 // RiskFactor controls the influence of time lock on route selection. This is
 // currently a fixed value, but might be configurable in the future.
-func edgeWeight(amt lnwire.MilliSatoshi, e *channeldb.ChannelEdgePolicy) int64 {
-	// First, we'll compute the "pure" fee through this hop. We say pure,
-	// as this may not be what's ultimately paid as fees are properly
-	// calculated backwards, while we're going in the reverse direction.
-	pureFee := int64(computeFee(amt, e))
-
+func edgeWeight(lockedAmt lnwire.MilliSatoshi, fee lnwire.MilliSatoshi,
+	timeLockDelta uint16) int64 {
 	// timeLockPenalty is the penalty for the time lock delta of this channel.
 	// It is controlled by RiskFactorBillionths and scales proportional
 	// to the amount that will pass through channel. Rationale is that it if
 	// a twice as large amount gets locked up, it is twice as bad.
-	timeLockPenalty := int64(amt) * int64(e.TimeLockDelta) * RiskFactorBillionths / 1000000000
+	timeLockPenalty := int64(lockedAmt) * int64(timeLockDelta) *
+		RiskFactorBillionths / 1000000000
 
-	return pureFee + timeLockPenalty
+	return int64(fee) + timeLockPenalty
 }
 
 // findPath attempts to find a path from the source node within the
@@ -465,12 +465,15 @@ func edgeWeight(amt lnwire.MilliSatoshi, e *channeldb.ChannelEdgePolicy) int64 {
 // and the destination. The distance metric used for edges is related to the
 // time-lock+fee costs along a particular edge. If a path is found, this
 // function returns a slice of ChannelHop structs which encoded the chosen path
-// from the target to the source.
+// from the target to the source. The search is performed backwards from
+// destination node back to source. This is to properly accumulate fees
+// that need to be paid along the path and accurately check the amount
+// to forward at every node against the available bandwidth.
 func findPath(tx *bolt.Tx, graph *channeldb.ChannelGraph,
 	additionalEdges map[Vertex][]*channeldb.ChannelEdgePolicy,
 	sourceNode *channeldb.LightningNode, target *btcec.PublicKey,
 	ignoredNodes map[Vertex]struct{}, ignoredEdges map[uint64]struct{},
-	amt lnwire.MilliSatoshi,
+	amt lnwire.MilliSatoshi, feeLimit lnwire.MilliSatoshi,
 	bandwidthHints map[uint64]lnwire.MilliSatoshi) ([]*ChannelHop, error) {
 
 	var err error
@@ -488,7 +491,9 @@ func findPath(tx *bolt.Tx, graph *channeldb.ChannelGraph,
 	var nodeHeap distanceHeap
 
 	// For each node in the graph, we create an entry in the distance
-	// map for the node set with a distance of "infinity".
+	// map for the node set with a distance of "infinity". graph.ForEachNode
+	// also returns the source node, so there is no need to add the source
+	// node explictly.
 	distance := make(map[Vertex]nodeWithDist)
 	if err := graph.ForEachNode(tx, func(_ *bolt.Tx, node *channeldb.LightningNode) error {
 		// TODO(roasbeef): with larger graph can just use disk seeks
@@ -502,36 +507,60 @@ func findPath(tx *bolt.Tx, graph *channeldb.ChannelGraph,
 		return nil, err
 	}
 
-	// We'll also include all the nodes found within the additional edges
-	// that are not known to us yet in the distance map.
-	for vertex := range additionalEdges {
+	additionalEdgesWithSrc := make(map[Vertex][]*edgePolicyWithSource)
+	for vertex, outgoingEdgePolicies := range additionalEdges {
+		// We'll also include all the nodes found within the additional edges
+		// that are not known to us yet in the distance map.
 		node := &channeldb.LightningNode{PubKeyBytes: vertex}
 		distance[vertex] = nodeWithDist{
 			dist: infinity,
 			node: node,
 		}
+
+		// Build reverse lookup to find incoming edges. Needed
+		// because search is taken place from target to source.
+		for _, outgoingEdgePolicy := range outgoingEdgePolicies {
+			toVertex := outgoingEdgePolicy.Node.PubKeyBytes
+			incomingEdgePolicy := &edgePolicyWithSource{
+				sourceNode: node,
+				edge:       outgoingEdgePolicy,
+			}
+
+			additionalEdgesWithSrc[toVertex] =
+				append(additionalEdgesWithSrc[toVertex],
+					incomingEdgePolicy)
+		}
 	}
+
+	sourceVertex := Vertex(sourceNode.PubKeyBytes)
 
 	// We can't always assume that the end destination is publicly
 	// advertised to the network and included in the graph.ForEachNode call
-	// above, so we'll manually include the target node.
+	// above, so we'll manually include the target node. The target
+	// node charges no fee. Distance is set to 0, because this is the
+	// starting point of the graph traversal. We are searching backwards to
+	// get the fees first time right and correctly match channel bandwidth.
 	targetVertex := NewVertex(target)
 	targetNode := &channeldb.LightningNode{PubKeyBytes: targetVertex}
 	distance[targetVertex] = nodeWithDist{
-		dist: infinity,
-		node: targetNode,
+		dist:            0,
+		node:            targetNode,
+		amountToReceive: amt,
+		fee:             0,
 	}
 
-	// We'll use this map as a series of "previous" hop pointers. So to get
-	// to `Vertex` we'll take the edge that it's mapped to within `prev`.
-	prev := make(map[Vertex]edgeWithPrev)
+	// We'll use this map as a series of "next" hop pointers. So to get
+	// from `Vertex` to the target node, we'll take the edge that it's
+	// mapped to within `next`.
+	next := make(map[Vertex]*ChannelHop)
 
 	// processEdge is a helper closure that will be used to make sure edges
 	// satisfy our specific requirements.
-	processEdge := func(edge *channeldb.ChannelEdgePolicy,
-		bandwidth lnwire.MilliSatoshi, pivot Vertex) {
+	processEdge := func(fromNode *channeldb.LightningNode,
+		edge *channeldb.ChannelEdgePolicy,
+		bandwidth lnwire.MilliSatoshi, toNode Vertex) {
 
-		v := Vertex(edge.Node.PubKeyBytes)
+		fromVertex := Vertex(fromNode.PubKeyBytes)
 
 		// If the edge is currently disabled, then we'll stop here, as
 		// we shouldn't attempt to route through it.
@@ -542,61 +571,114 @@ func findPath(tx *bolt.Tx, graph *channeldb.ChannelGraph,
 
 		// If this vertex or edge has been black listed, then we'll skip
 		// exploring this edge.
-		if _, ok := ignoredNodes[v]; ok {
+		if _, ok := ignoredNodes[fromVertex]; ok {
 			return
 		}
 		if _, ok := ignoredEdges[edge.ChannelID]; ok {
 			return
 		}
 
-		// Compute the tentative distance to this new channel/edge which
-		// is the distance to our pivot node plus the weight of this
-		// edge.
-		tempDist := distance[pivot].dist + edgeWeight(amt, edge)
+		toNodeDist := distance[toNode]
 
-		// If this new tentative distance is better than the current
-		// best known distance to this node, then we record the new
-		// better distance, and also populate our "next hop" map with
-		// this edge. We'll also shave off irrelevant edges by adding
-		// the sufficient capacity of an edge and clearing their
-		// min-htlc amount to our relaxation condition.
-		if tempDist < distance[v].dist && bandwidth >= amt &&
-			amt >= edge.MinHTLC && edge.TimeLockDelta != 0 {
+		amountToSend := toNodeDist.amountToReceive
 
-			distance[v] = nodeWithDist{
-				dist: tempDist,
-				node: edge.Node,
-			}
-
-			prev[v] = edgeWithPrev{
-				edge: &ChannelHop{
-					ChannelEdgePolicy: edge,
-					Capacity:          bandwidth.ToSatoshis(),
-				},
-				prevNode: pivot,
-			}
-
-			// Add this new node to our heap as we'd like to further
-			// explore down this edge.
-			heap.Push(&nodeHeap, distance[v])
+		// If the estimated band width of the channel edge is not able
+		// to carry the amount that needs to be send, return.
+		if bandwidth < amountToSend {
+			return
 		}
+
+		// If the amountToSend is less than the minimum required amount,
+		// return.
+		if amountToSend < edge.MinHTLC {
+			return
+		}
+
+		// Compute fee that fromNode is charging. It is based on the
+		// amount that needs to be sent to the next node in the route.
+		//
+		// Source node has no precedessor to pay a fee. Therefore set
+		// fee to zero, because it should not be included in the
+		// fee limit check and edge weight.
+		//
+		// Also determine the time lock delta that will be added to
+		// the route if fromNode is selected. If fromNode is the
+		// source node, no additional timelock is required.
+		var fee lnwire.MilliSatoshi
+		var timeLockDelta uint16
+		if fromVertex != sourceVertex {
+			fee = computeFee(amountToSend, edge)
+			timeLockDelta = edge.TimeLockDelta
+		}
+
+		// amountToReceive is the amount that the node that
+		// is added to the distance map needs to receive from
+		// a (to be found) previous node in the route. That
+		// previous node will need to pay the amount that this
+		// node forwards plus the fee it charges.
+		amountToReceive := amountToSend + fee
+
+		// Check if accumulated fees would exceed fee limit when
+		// this node would be added to the path.
+		totalFee := amountToReceive - amt
+		if totalFee > feeLimit {
+			return
+		}
+
+		// By adding fromNode in the route, there will be an extra
+		// weight composed of the fee that this node will charge and
+		// the amount that will be locked for timeLockDelta blocks
+		// in the HTLC that is handed out to fromNode.
+		weight := edgeWeight(amountToReceive, fee, timeLockDelta)
+
+		// Compute the tentative distance to this new channel/edge which
+		// is the distance from our toNode to the target node plus the
+		// weight of this edge.
+		tempDist := toNodeDist.dist + weight
+
+		// If this new tentative distance is not better than the current
+		// best known distance to this node, return.
+		if tempDist >= distance[fromVertex].dist {
+			return
+		}
+
+		// If the edge has no time lock delta, the payment will always
+		// fail, so return.
+		//
+		// TODO(joostjager): Is this really true? Can't it be that
+		// nodes take this risk in exchange for a extraordinary high
+		// fee?
+		if edge.TimeLockDelta == 0 {
+			return
+		}
+
+		// All conditions are met and this new tentative distance is
+		// better than the current best known distance to this node.
+		// The new better distance is recorded, and also our
+		// "next hop" map is populated with this edge.
+		distance[fromVertex] = nodeWithDist{
+			dist:            tempDist,
+			node:            fromNode,
+			amountToReceive: amountToReceive,
+			fee:             fee,
+		}
+
+		next[fromVertex] = &ChannelHop{
+			ChannelEdgePolicy: edge,
+			Bandwidth:         bandwidth,
+		}
+
+		// Add this new node to our heap as we'd like to further
+		// explore backwards through this edge.
+		heap.Push(&nodeHeap, distance[fromVertex])
 	}
 
 	// TODO(roasbeef): also add path caching
 	//  * similar to route caching, but doesn't factor in the amount
 
-	// To start, we add the source of our path finding attempt to the
-	// distance map with a distance of 0. This indicates our starting
-	// point in the graph traversal.
-	sourceVertex := Vertex(sourceNode.PubKeyBytes)
-	distance[sourceVertex] = nodeWithDist{
-		dist: 0,
-		node: sourceNode,
-	}
-
-	// To start, our source node will the sole item within our distance
+	// To start, our target node will the sole item within our distance
 	// heap.
-	heap.Push(&nodeHeap, distance[sourceVertex])
+	heap.Push(&nodeHeap, distance[targetVertex])
 
 	for nodeHeap.Len() != 0 {
 		// Fetch the node within the smallest distance from our source
@@ -604,20 +686,28 @@ func findPath(tx *bolt.Tx, graph *channeldb.ChannelGraph,
 		partialPath := heap.Pop(&nodeHeap).(nodeWithDist)
 		bestNode := partialPath.node
 
-		// If we've reached our target (or we don't have any outgoing
+		// If we've reached our source (or we don't have any incoming
 		// edges), then we're done here and can exit the graph
 		// traversal early.
-		if bytes.Equal(bestNode.PubKeyBytes[:], targetVertex[:]) {
+		if bytes.Equal(bestNode.PubKeyBytes[:], sourceVertex[:]) {
 			break
 		}
 
 		// Now that we've found the next potential step to take we'll
-		// examine all the outgoing edge (channels) from this node to
+		// examine all the incoming edges (channels) from this node to
 		// further our graph traversal.
 		pivot := Vertex(bestNode.PubKeyBytes)
 		err := bestNode.ForEachChannel(tx, func(tx *bolt.Tx,
 			edgeInfo *channeldb.ChannelEdgeInfo,
-			outEdge, _ *channeldb.ChannelEdgePolicy) error {
+			_, inEdge *channeldb.ChannelEdgePolicy) error {
+
+			// If there is no edge policy for this candidate
+			// node, skip. Note that we are searching backwards
+			// so this node would have come prior to the pivot
+			// node in the route.
+			if inEdge == nil {
+				return nil
+			}
 
 			// We'll query the lower layer to see if we can obtain
 			// any more up to date information concerning the
@@ -632,7 +722,31 @@ func findPath(tx *bolt.Tx, graph *channeldb.ChannelGraph,
 				)
 			}
 
-			processEdge(outEdge, edgeBandwidth, pivot)
+			// Lookup the source node at the other side of the
+			// channel via edgeInfo. This is necessary because this
+			// information is not present in inEdge.
+			channelSourcePubKeyBytes, err := edgeInfo.OtherNodeKeyBytes(pivot[:])
+			if err != nil {
+				return err
+			}
+
+			channelSourcePubKey, err := btcec.ParsePubKey(
+				channelSourcePubKeyBytes[:], btcec.S256())
+			if err != nil {
+				return err
+			}
+
+			// Lookup the full node details in order to be able to
+			// later iterate over all incoming edges of the source
+			// node.
+			channelSource, err := graph.FetchLightningNode(channelSourcePubKey)
+			if err != nil {
+				return err
+			}
+
+			// Check if this candidate node is better than what
+			// we already have.
+			processEdge(channelSource, inEdge, edgeBandwidth, pivot)
 
 			// TODO(roasbeef): return min HTLC as error in end?
 
@@ -647,31 +761,31 @@ func findPath(tx *bolt.Tx, graph *channeldb.ChannelGraph,
 		// of the private channel, we'll assume it was selected as a
 		// routing hint due to having enough capacity for the payment
 		// and use the payment amount as its capacity.
-		for _, edge := range additionalEdges[bestNode.PubKeyBytes] {
-			processEdge(edge, amt, pivot)
+		bandWidth := partialPath.amountToReceive
+		for _, reverseEdge := range additionalEdgesWithSrc[bestNode.PubKeyBytes] {
+			processEdge(reverseEdge.sourceNode, reverseEdge.edge, bandWidth, pivot)
 		}
 	}
 
-	// If the target node isn't found in the prev hop map, then a path
+	// If the source node isn't found in the next hop map, then a path
 	// doesn't exist, so we terminate in an error.
-	if _, ok := prev[NewVertex(target)]; !ok {
+	if _, ok := next[sourceVertex]; !ok {
 		return nil, newErrf(ErrNoPathFound, "unable to find a path to "+
 			"destination")
 	}
 
-	// If the potential route if below the max hop limit, then we'll use
-	// the prevHop map to unravel the path. We end up with a list of edges
-	// in the reverse direction which we'll use to properly calculate the
-	// timelock and fee values.
-	pathEdges := make([]*ChannelHop, 0, len(prev))
-	prevNode := NewVertex(target)
-	for prevNode != sourceVertex { // TODO(roasbeef): assumes no cycles
-		// Add the current hop to the limit of path edges then walk
-		// backwards from this hop via the prev pointer for this hop
-		// within the prevHop map.
-		pathEdges = append(pathEdges, prev[prevNode].edge)
+	// Use the nextHop map to unravel the forward path from source to target.
+	pathEdges := make([]*ChannelHop, 0, len(next))
+	currentNode := sourceVertex
+	for currentNode != targetVertex { // TODO(roasbeef): assumes no cycles
+		// Determine the next hop forward using the next map.
+		nextNode := next[currentNode]
 
-		prevNode = Vertex(prev[prevNode].prevNode)
+		// Add the next hop to the list of path edges.
+		pathEdges = append(pathEdges, nextNode)
+
+		// Advance current node.
+		currentNode = Vertex(nextNode.Node.PubKeyBytes)
 	}
 
 	// The route is invalid if it spans more than 20 hops. The current
@@ -682,13 +796,6 @@ func findPath(tx *bolt.Tx, graph *channeldb.ChannelGraph,
 	if numEdges > HopLimit {
 		return nil, newErr(ErrMaxHopsExceeded, "potential path has "+
 			"too many hops")
-	}
-
-	// As our traversal of the prev map above walked backwards from the
-	// target to the source in the route, we need to reverse it before
-	// returning the final route.
-	for i := 0; i < numEdges/2; i++ {
-		pathEdges[i], pathEdges[numEdges-i-1] = pathEdges[numEdges-i-1], pathEdges[i]
 	}
 
 	return pathEdges, nil
@@ -707,7 +814,7 @@ func findPath(tx *bolt.Tx, graph *channeldb.ChannelGraph,
 // algorithm in a block box manner.
 func findPaths(tx *bolt.Tx, graph *channeldb.ChannelGraph,
 	source *channeldb.LightningNode, target *btcec.PublicKey,
-	amt lnwire.MilliSatoshi, numPaths uint32,
+	amt lnwire.MilliSatoshi, feeLimit lnwire.MilliSatoshi, numPaths uint32,
 	bandwidthHints map[uint64]lnwire.MilliSatoshi) ([][]*ChannelHop, error) {
 
 	ignoredEdges := make(map[uint64]struct{})
@@ -725,7 +832,7 @@ func findPaths(tx *bolt.Tx, graph *channeldb.ChannelGraph,
 	// satoshis along the path before fees are calculated.
 	startingPath, err := findPath(
 		tx, graph, nil, source, target, ignoredVertexes, ignoredEdges,
-		amt, bandwidthHints,
+		amt, feeLimit, bandwidthHints,
 	)
 	if err != nil {
 		log.Errorf("Unable to find path: %v", err)
@@ -799,7 +906,7 @@ func findPaths(tx *bolt.Tx, graph *channeldb.ChannelGraph,
 			// shortest path from the spur node to the destination.
 			spurPath, err := findPath(
 				tx, graph, nil, spurNode, target,
-				ignoredVertexes, ignoredEdges, amt,
+				ignoredVertexes, ignoredEdges, amt, feeLimit,
 				bandwidthHints,
 			)
 

--- a/routing/router.go
+++ b/routing/router.go
@@ -2136,6 +2136,10 @@ func (r *ChannelRouter) ForAllOutgoingChannels(cb func(*channeldb.ChannelEdgeInf
 	return r.selfNode.ForEachChannel(nil, func(_ *bolt.Tx, c *channeldb.ChannelEdgeInfo,
 		e, _ *channeldb.ChannelEdgePolicy) error {
 
+		if e == nil {
+			return fmt.Errorf("Channel from self node has no policy")
+		}
+
 		return cb(c, e)
 	})
 }

--- a/routing/router.go
+++ b/routing/router.go
@@ -1384,7 +1384,7 @@ func (r *ChannelRouter) FindRoutes(target *btcec.PublicKey,
 	// we'll execute our KSP algorithm to find the k-shortest paths from
 	// our source to the destination.
 	shortestPaths, err := findPaths(
-		tx, r.cfg.Graph, r.selfNode, target, amt, numPaths,
+		tx, r.cfg.Graph, r.selfNode, target, amt, feeLimit, numPaths,
 		bandwidthHints,
 	)
 	if err != nil {

--- a/routing/router_test.go
+++ b/routing/router_test.go
@@ -1687,7 +1687,7 @@ func TestFindPathFeeWeighting(t *testing.T) {
 	// path even though the direct path has a higher potential time lock.
 	path, err := findPath(
 		nil, ctx.graph, nil, sourceNode, target, ignoreVertex,
-		ignoreEdge, amt, nil,
+		ignoreEdge, amt, noFeeLimit, nil,
 	)
 	if err != nil {
 		t.Fatalf("unable to find path: %v", err)

--- a/routing/testdata/basic_graph.json
+++ b/routing/testdata/basic_graph.json
@@ -2,32 +2,33 @@
     "info": [
     "This file encodes a basic graph that resembles the following ascii graph:",  
     "", 
-"                           50k satoshis       ┌──────┐                                 ", 
+"                           50k satoshis       ┌──────┐                                  ", 
 "                         ┌───────────────────▶│luo ji│◀─┐                               ",
-"                         │                    └──────┘  │                               ",
-"                         │                              │                               ", 
-"                         │                              │                               ", 
-"                         │                              │                               ",  
-"                         │                              │                               ",  
-"                         │                              │                               ",   
+"                         │                    └──────┘  │      ┌──────┐                 ",
+"                         │                              │      | elst |                 ", 
+"                         │                              │      └──────┘                 ", 
+"                         │                              │         ▲                     ",  
+"                         │                              │         | 100k sat            ",  
+"                         │                              │         ▼                     ",   
 "                         ▼                              │      ┌──────┐                 ",  
 "                    ┌────────┐                          │      │sophon│◀┐               ",  
 "                    │satoshi │                          │      └──────┘ │               ",  
-"                    └────────┘                          │               │               ",  
-"                         ▲                              │               │  500 satoshis ",          
-"                         │          ┌───────────────────┘               │               ",  
-"                         │          │   100k satoshis                   │               ",  
-"                         │          │                                   │               ",  
-"                         │          │                                   │  ┌────────┐   ", 
-"                         └──────────┤                                   └─▶│son goku│   ", 
-"                    10k satoshis    │                                      └────────┘   ", 
-"                                    │                                           ▲       ", 
-"                                    │                                           │       ", 
-"                                    │                                           │       ", 
-"                                    ▼                                           │       ", 
-"                              ┌──────────┐                                      │       ", 
-"                              │ roasbeef │◀─────────────────────────────────────┘       ", 
-"                              └──────────┘               100k satoshis                  ",
+"                    └────────┘                          │        ▲      │               ",  
+"                         ▲                              │        |      │ 110k satoshis ",          
+"                         │          ┌───────────────────┘        |      │               ",  
+"                         │          │   100k satoshis            |      │               ",  
+"                         │          │                            |      │               ",  
+"                         │          │                   120k sat |      │  ┌────────┐   ", 
+"                         └──────────┤                   (hi fee) ▼      └─▶│son goku│   ", 
+"                    10k satoshis    │                ┌────────────┐        └────────┘   ", 
+"                                    │                | pham nuwen |             ▲       ", 
+"                                    │                └────────────┘             │       ", 
+"                                    │                    ▲                      │       ", 
+"                                    ▼                    | 120k sat (hi fee)    │       ", 
+"                              ┌──────────┐               |                      │       ", 
+"                              │ roasbeef │◀──────────────┴──────────────────────┘       ", 
+"                              └──────────┘                         100k satoshis        ",
+
 " the graph also includes a channel from roasbeef to sophon via pham nuwen"
     ], 
     "nodes": [
@@ -60,10 +61,39 @@
             "source": false,
             "pubkey": "02a1d2856be336a58af08989aea0d8c41e072ccc392c46f8ce0e6e069f002035f3",
             "alias": "phamnuwen"
+        },
+        {
+            "source": false,
+            "pubkey": "02a4b236b69b09b8efe6ccf822fa95ee95a0196451f4d066a450b7489e2e354a64",
+            "alias": "elst"
         }
     ], 
     "edges": [
         {
+            "node_1": "02a4b236b69b09b8efe6ccf822fa95ee95a0196451f4d066a450b7489e2e354a64",
+            "node_2": "036264734b40c9e91d3d990a8cdfbbe23b5b0b7ad3cd0e080a25dcd05d39eeb7eb",
+            "channel_id": 15433,
+            "channel_point": "33bd5d49a50e284221561b91e781f1fca0d60341c9f9dd785b5e379a6d88af3d:0", 
+            "flags": 1,
+            "expiry": 1,
+            "min_htlc": 1000, 
+            "fee_base_msat": 200,
+            "fee_rate": 0, 
+            "capacity": 100000
+        },
+        {
+            "node_1": "02a4b236b69b09b8efe6ccf822fa95ee95a0196451f4d066a450b7489e2e354a64",
+            "node_2": "036264734b40c9e91d3d990a8cdfbbe23b5b0b7ad3cd0e080a25dcd05d39eeb7eb",
+            "channel_id": 15433,
+            "channel_point": "33bd5d49a50e284221561b91e781f1fca0d60341c9f9dd785b5e379a6d88af3d:0", 
+            "flags": 0,
+            "expiry": 1,
+            "min_htlc": 1000, 
+            "fee_base_msat": 200, 
+            "fee_rate": 0, 
+            "capacity": 100000
+        },
+        {
             "node_1": "02a1d2856be336a58af08989aea0d8c41e072ccc392c46f8ce0e6e069f002035f3",
             "node_2": "0367cec75158a4129177bfb8b269cb586efe93d751b43800d456485e81c2620ca6",
             "channel_id": 999991,
@@ -72,8 +102,8 @@
             "expiry": 1,
             "min_htlc": 1000, 
             "fee_base_msat": 10000,
-            "fee_rate": 1000000, 
-            "capacity": 100000
+            "fee_rate": 100000, 
+            "capacity": 120000
         },
         {
             "node_1": "02a1d2856be336a58af08989aea0d8c41e072ccc392c46f8ce0e6e069f002035f3",
@@ -84,8 +114,8 @@
             "expiry": 1,
             "min_htlc": 1000, 
             "fee_base_msat": 10000, 
-            "fee_rate": 1000000, 
-            "capacity": 100000
+            "fee_rate": 100000, 
+            "capacity": 120000
         },
         {
             "node_1": "02a1d2856be336a58af08989aea0d8c41e072ccc392c46f8ce0e6e069f002035f3",
@@ -96,8 +126,8 @@
             "expiry": 1,
             "min_htlc": 1000, 
             "fee_base_msat": 10000,
-            "fee_rate": 1000000, 
-            "capacity": 100000
+            "fee_rate": 100000, 
+            "capacity": 120000
         },
         {
             "node_1": "02a1d2856be336a58af08989aea0d8c41e072ccc392c46f8ce0e6e069f002035f3",
@@ -108,8 +138,8 @@
             "expiry": 1,
             "min_htlc": 1000, 
             "fee_base_msat": 10000, 
-            "fee_rate": 1000000, 
-            "capacity": 100000
+            "fee_rate": 100000, 
+            "capacity": 120000
         },
         {
             "node_1": "0367cec75158a4129177bfb8b269cb586efe93d751b43800d456485e81c2620ca6",
@@ -145,7 +175,7 @@
             "min_htlc": 1, 
             "fee_base_msat": 10, 
             "fee_rate": 1000, 
-            "capacity": 500 
+            "capacity": 110000
         },
         {
 	    "node_1": "032b480de5d002f1a8fd1fe1bbf0a0f1b07760f65f052e66d56f15d71097c01add",
@@ -157,7 +187,7 @@
             "min_htlc": 1, 
             "fee_base_msat": 10, 
             "fee_rate": 1000, 
-            "capacity": 500 
+            "capacity": 110000 
         },
         {
             "node_1": "0367cec75158a4129177bfb8b269cb586efe93d751b43800d456485e81c2620ca6",

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -3274,7 +3274,7 @@ func marshallRoute(route *routing.Route) *lnrpc.Route {
 	for i, hop := range route.Hops {
 		resp.Hops[i] = &lnrpc.Hop{
 			ChanId:           hop.Channel.ChannelID,
-			ChanCapacity:     int64(hop.Channel.Capacity),
+			ChanCapacity:     int64(hop.Channel.Bandwidth.ToSatoshis()),
 			AmtToForward:     int64(hop.AmtToForward.ToSatoshis()),
 			AmtToForwardMsat: int64(hop.AmtToForward),
 			Fee:              int64(hop.Fee.ToSatoshis()),
@@ -3324,8 +3324,9 @@ func unmarshallRoute(rpcroute *lnrpc.Route,
 
 		routingHop := &routing.ChannelHop{
 			ChannelEdgePolicy: channelEdgePolicy,
-			Capacity:          btcutil.Amount(hop.ChanCapacity),
-			Chain:             edgeInfo.ChainHash,
+			Bandwidth: lnwire.NewMSatFromSatoshis(
+				btcutil.Amount(hop.ChanCapacity)),
+			Chain: edgeInfo.ChainHash,
 		}
 
 		route.Hops[i] = &routing.Hop{

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -3743,6 +3743,12 @@ func (r *rpcServer) FeeReport(ctx context.Context,
 	err = selfNode.ForEachChannel(nil, func(_ *bolt.Tx, chanInfo *channeldb.ChannelEdgeInfo,
 		edgePolicy, _ *channeldb.ChannelEdgePolicy) error {
 
+		// Self node should always have policies for its channels.
+		if edgePolicy == nil {
+			return fmt.Errorf("no policy for outgoing channel %v ",
+				chanInfo.ChannelID)
+		}
+
 		// We'll compute the effective fee rate by converting from a
 		// fixed point fee rate to a floating point fee rate. The fee
 		// rate field in the database the amount of mSAT charged per


### PR DESCRIPTION
The original findPath implementation can come up with a path that is rejected in newRoute because of "channel graph has insufficient capacity". The reason is that findPath calculates with the same amt all the way, while newRoute takes into account that amt needs to increase with every hop (looking from target back to source).

This change makes findPath use the correct fees and eliminates the possibility that newRoute returns the insufficient capacity error.

In this PR:
- Refactor of the path finding unit test to be able add more cases without code duplication (table driven).
- Unit test for invalid "channel graph has insufficient capacity" result
- Reworked search algorithm to already take into account increasing amounts that need to be send to next hops