### PR TITLE
channeldb: don't reject duplicate waiting proofs

### DIFF
--- a/channeldb/waitingproof.go
+++ b/channeldb/waitingproof.go
@@ -56,10 +56,6 @@ func NewWaitingProofStore(db *DB) (*WaitingProofStore, error) {
 
 // Add adds new waiting proof in the storage.
 func (s *WaitingProofStore) Add(proof *WaitingProof) error {
-	if _, ok := s.cache[proof.Key()]; ok {
-		return ErrWaitingProofAlreadyExist
-	}
-
 	return s.db.Batch(func(tx *bolt.Tx) error {
 		var err error
 		var b bytes.Buffer
@@ -81,6 +77,7 @@ func (s *WaitingProofStore) Add(proof *WaitingProof) error {
 		}
 
 		s.cache[proof.Key()] = struct{}{}
+
 		return nil
 	})
 }


### PR DESCRIPTION
In this commit, we modify the waiting proof slightly to acept dupliacte
waiting proofs, rather than reject them. Otherwise, it's possible that
the remote node first sends us their half of the waiting proof (before
we do), we write that to disk, then upon restart, we'll try to add it
again, but be rejected by the system.

Fixes #1315.