### PR TITLE
discovery: ensure gossiper syncer has idempotent exit/start, fix deadlock 

### DIFF
--- a/discovery/syncer.go
+++ b/discovery/syncer.go
@@ -805,6 +805,12 @@ func (g *gossipSyncer) FilterGossipMsgs(msgs ...msgWithSenders) {
 		return
 	}
 
+	// If we've been signalled to exit, or are exiting, then we'll stop
+	// short.
+	if atomic.LoadUint32(&g.stopped) == 1 {
+		return
+	}
+
 	// TODO(roasbeef): need to ensure that peer still online...send msg to
 	// gossiper on peer termination to signal peer disconnect?
 


### PR DESCRIPTION
In this commit, we fix an existing deadlock in the
gossiper->server->peer pipeline by ensuring that we're not holding the
syncer mutex while we attempt to have a syncer filter out the rest of
gossip messages.
