### PR TITLE
integration tests: shut down nodes using defer

### DIFF
--- a/lnd_test.go
+++ b/lnd_test.go
@@ -1673,6 +1673,7 @@ func testChannelForceClosure(net *lntest.NetworkHarness, t *harnessTest) {
 	if err != nil {
 		t.Fatalf("unable to create new nodes: %v", err)
 	}
+	defer shutdownAndAssert(net, t, carol)
 
 	// We must let Alice have an open channel before she can send a node
 	// announcement, so we open a channel with Carol,
@@ -4933,6 +4934,7 @@ func testRevokedCloseRetributionZeroValueRemoteOutput(net *lntest.NetworkHarness
 	if err != nil {
 		t.Fatalf("unable to create new nodes: %v", err)
 	}
+	defer shutdownAndAssert(net, t, carol)
 
 	// We must let Alice have an open channel before she can send a node
 	// announcement, so we open a channel with Carol,
@@ -5167,6 +5169,7 @@ func testRevokedCloseRetributionRemoteHodl(net *lntest.NetworkHarness,
 	if err != nil {
 		t.Fatalf("unable to create new nodes: %v", err)
 	}
+	defer shutdownAndAssert(net, t, carol)
 
 	// We'll also create a new node Dave, who will have a channel with
 	// Carol, and also use similar settings so we can broadcast a commit
@@ -5175,6 +5178,7 @@ func testRevokedCloseRetributionRemoteHodl(net *lntest.NetworkHarness,
 	if err != nil {
 		t.Fatalf("unable to create new dave node: %v", err)
 	}
+	defer shutdownAndAssert(net, t, dave)
 
 	// We must let Dave communicate with Carol before they are able to open
 	// channel, so we connect Dave and Carol,

--- a/lntest/node.go
+++ b/lntest/node.go
@@ -249,6 +249,11 @@ func (hn *HarnessNode) DBPath() string {
 	return hn.cfg.DBPath()
 }
 
+// Name returns the name of this node set during initialization.
+func (hn *HarnessNode) Name() string {
+	return hn.cfg.Name
+}
+
 // Start launches a new process running lnd. Additionally, the PID of the
 // launched process is saved in order to possibly kill the process forcibly
 // later.


### PR DESCRIPTION
This PR adds to commits to ensure proper cleanup during integration tests:
1. We shut down nodes created temporarily during the test cases using defers instead of at the end of the test. This makes it easier to remember to shut them down, as it is done right after they are started.
2. We add shutdowns for a few nodes that were missing it.