### PR TITLE
Data loss protection

### DIFF
--- a/channeldb/db.go
+++ b/channeldb/db.go
@@ -456,7 +456,7 @@ func fetchChannels(d *DB, pending, waitingClose bool) ([]*OpenChannel, error) {
 					// than Default, then it means it is
 					// waiting to be closed.
 					channelWaitingClose :=
-						channel.ChanStatus != Default
+						channel.ChanStatus() != Default
 
 					// Only include it if we requested
 					// channels with the same waitingClose

--- a/htlcswitch/link_test.go
+++ b/htlcswitch/link_test.go
@@ -1489,7 +1489,8 @@ func newSingleLinkTestHarness(chanAmt, chanReserve btcutil.Amount) (
 		},
 		FetchLastChannelUpdate: mockGetChanUpdateMessage,
 		PreimageCache:          pCache,
-		OnChannelFailure: func(lnwire.ChannelID, lnwire.ShortChannelID, LinkFailureError) {
+		OnChannelFailure: func(lnwire.ChannelID,
+			lnwire.ShortChannelID, LinkFailureError) {
 		},
 		UpdateContractSignals: func(*contractcourt.ContractSignals) error {
 			return nil
@@ -3879,6 +3880,9 @@ func restartLink(aliceChannel *lnwallet.LightningChannel, aliceSwitch *Switch,
 		},
 		FetchLastChannelUpdate: mockGetChanUpdateMessage,
 		PreimageCache:          pCache,
+		OnChannelFailure: func(lnwire.ChannelID,
+			lnwire.ShortChannelID, LinkFailureError) {
+		},
 		UpdateContractSignals: func(*contractcourt.ContractSignals) error {
 			return nil
 		},

--- a/lnwallet/channel.go
+++ b/lnwallet/channel.go
@@ -4850,24 +4850,16 @@ type UnilateralCloseSummary struct {
 
 // NewUnilateralCloseSummary creates a new summary that provides the caller
 // with all the information required to claim all funds on chain in the event
-// that the remote party broadcasts their commitment. If the
-// remotePendingCommit value is set to true, then we'll use the next (second)
-// unrevoked commitment point to construct the summary. Otherwise, we assume
-// that the remote party broadcast the lower of their two possible commits.
+// that the remote party broadcasts their commitment. The commitPoint argument
+// should be set to the per_commitment_point corresponding to the spending
+// commitment.
 func NewUnilateralCloseSummary(chanState *channeldb.OpenChannel, signer Signer,
 	pCache PreimageCache, commitSpend *chainntnfs.SpendDetail,
 	remoteCommit channeldb.ChannelCommitment,
-	remotePendingCommit bool) (*UnilateralCloseSummary, error) {
+	commitPoint *btcec.PublicKey) (*UnilateralCloseSummary, error) {
 
 	// First, we'll generate the commitment point and the revocation point
-	// so we can re-construct the HTLC state and also our payment key. If
-	// this is the pending remote commitment, then we'll use the second
-	// unrevoked commit point in order to properly reconstruct the scripts
-	// we need to locate.
-	commitPoint := chanState.RemoteCurrentRevocation
-	if remotePendingCommit {
-		commitPoint = chanState.RemoteNextRevocation
-	}
+	// so we can re-construct the HTLC state and also our payment key.
 	keyRing := deriveCommitmentKeys(
 		commitPoint, false, &chanState.LocalChanCfg,
 		&chanState.RemoteChanCfg,

--- a/lnwallet/channel_test.go
+++ b/lnwallet/channel_test.go
@@ -3809,8 +3809,8 @@ func TestChanSyncInvalidLastSecret(t *testing.T) {
 	// Alice's former self should conclude that she possibly lost data as
 	// Bob is sending a valid commit secret for the latest state.
 	_, _, _, err = aliceOld.ProcessChanSyncMsg(bobChanSync)
-	if err != ErrCommitSyncDataLoss {
-		t.Fatalf("wrong error, expected ErrCommitSyncDataLoss "+
+	if err != ErrCommitSyncLocalDataLoss {
+		t.Fatalf("wrong error, expected ErrCommitSyncLocalDataLoss "+
 			"instead got: %v", err)
 	}
 

--- a/lnwallet/channel_test.go
+++ b/lnwallet/channel_test.go
@@ -4397,8 +4397,10 @@ func TestChannelUnilateralCloseHtlcResolution(t *testing.T) {
 		SpenderTxHash: &commitTxHash,
 	}
 	aliceCloseSummary, err := NewUnilateralCloseSummary(
-		aliceChannel.channelState, aliceChannel.Signer, aliceChannel.pCache,
-		spendDetail, aliceChannel.channelState.RemoteCommitment, false,
+		aliceChannel.channelState, aliceChannel.Signer,
+		aliceChannel.pCache, spendDetail,
+		aliceChannel.channelState.RemoteCommitment,
+		aliceChannel.channelState.RemoteCurrentRevocation,
 	)
 	if err != nil {
 		t.Fatalf("unable to create alice close summary: %v", err)
@@ -4545,8 +4547,10 @@ func TestChannelUnilateralClosePendingCommit(t *testing.T) {
 	// using this commitment, but with the wrong state, we should find that
 	// our output wasn't picked up.
 	aliceWrongCloseSummary, err := NewUnilateralCloseSummary(
-		aliceChannel.channelState, aliceChannel.Signer, aliceChannel.pCache,
-		spendDetail, aliceChannel.channelState.RemoteCommitment, false,
+		aliceChannel.channelState, aliceChannel.Signer,
+		aliceChannel.pCache, spendDetail,
+		aliceChannel.channelState.RemoteCommitment,
+		aliceChannel.channelState.RemoteCurrentRevocation,
 	)
 	if err != nil {
 		t.Fatalf("unable to create alice close summary: %v", err)
@@ -4564,8 +4568,10 @@ func TestChannelUnilateralClosePendingCommit(t *testing.T) {
 		t.Fatalf("unable to fetch remote chain tip: %v", err)
 	}
 	aliceCloseSummary, err := NewUnilateralCloseSummary(
-		aliceChannel.channelState, aliceChannel.Signer, aliceChannel.pCache,
-		spendDetail, aliceRemoteChainTip.Commitment, true,
+		aliceChannel.channelState, aliceChannel.Signer,
+		aliceChannel.pCache, spendDetail,
+		aliceRemoteChainTip.Commitment,
+		aliceChannel.channelState.RemoteNextRevocation,
 	)
 	if err != nil {
 		t.Fatalf("unable to create alice close summary: %v", err)

--- a/lnwallet/channel_test.go
+++ b/lnwallet/channel_test.go
@@ -10,13 +10,14 @@ import (
 	"runtime"
 	"testing"
 
-	"github.com/davecgh/go-spew/spew"
-	"github.com/lightningnetwork/lnd/chainntnfs"
-	"github.com/lightningnetwork/lnd/lnwire"
 	"github.com/btcsuite/btcd/blockchain"
+	"github.com/btcsuite/btcd/btcec"
 	"github.com/btcsuite/btcd/txscript"
 	"github.com/btcsuite/btcd/wire"
 	"github.com/btcsuite/btcutil"
+	"github.com/davecgh/go-spew/spew"
+	"github.com/lightningnetwork/lnd/chainntnfs"
+	"github.com/lightningnetwork/lnd/lnwire"
 )
 
 // forceStateTransition executes the necessary interaction between the two
@@ -2562,7 +2563,7 @@ func TestChanSyncFullySynced(t *testing.T) {
 	assertNoChanSyncNeeded(t, aliceChannelNew, bobChannelNew)
 }
 
-// restartChannel reads the passe channel from disk, and returns a newly
+// restartChannel reads the passed channel from disk, and returns a newly
 // initialized instance. This simulates one party restarting and losing their
 // in memory state.
 func restartChannel(channelOld *LightningChannel) (*LightningChannel, error) {
@@ -3483,6 +3484,228 @@ func TestChanSyncOweRevocationAndCommitForceTransition(t *testing.T) {
 	}
 	if _, _, _, err := bobChannel.ReceiveRevocation(aliceRevocation); err != nil {
 		t.Fatalf("bob unable to recv revocation: %v", err)
+	}
+}
+
+// TestChanSyncFailure tests the various scenarios during channel sync where we
+// should be able to detect that the channels cannot be synced because of
+// invalid state.
+func TestChanSyncFailure(t *testing.T) {
+	t.Parallel()
+
+	// Create a test channel which will be used for the duration of this
+	// unittest. The channel will be funded evenly with Alice having 5 BTC,
+	// and Bob having 5 BTC.
+	aliceChannel, bobChannel, cleanUp, err := CreateTestChannels()
+	if err != nil {
+		t.Fatalf("unable to create test channels: %v", err)
+	}
+	defer cleanUp()
+
+	htlcAmt := lnwire.NewMSatFromSatoshis(20000)
+	index := byte(0)
+
+	// advanceState is a helper method to fully advance the channel state
+	// by one.
+	advanceState := func() {
+		// We'll kick off the test by having Bob send Alice an HTLC,
+		// then lock it in with a state transition.
+		var bobPreimage [32]byte
+		copy(bobPreimage[:], bytes.Repeat([]byte{0xaa - index}, 32))
+		rHash := sha256.Sum256(bobPreimage[:])
+		bobHtlc := &lnwire.UpdateAddHTLC{
+			PaymentHash: rHash,
+			Amount:      htlcAmt,
+			Expiry:      uint32(10),
+			ID:          uint64(index),
+		}
+		index++
+
+		_, err := bobChannel.AddHTLC(bobHtlc, nil)
+		if err != nil {
+			t.Fatalf("unable to add bob's htlc: %v", err)
+		}
+		_, err = aliceChannel.ReceiveHTLC(bobHtlc)
+		if err != nil {
+			t.Fatalf("unable to recv bob's htlc: %v", err)
+		}
+		err = forceStateTransition(bobChannel, aliceChannel)
+		if err != nil {
+			t.Fatalf("unable to complete bob's state "+
+				"transition: %v", err)
+		}
+	}
+
+	// halfAdvance is a helper method that sends a new commitment signature
+	// from Alice to Bob, but doesn't make Bob revoke his current state.
+	halfAdvance := func() {
+		// We'll kick off the test by having Bob send Alice an HTLC,
+		// then lock it in with a state transition.
+		var bobPreimage [32]byte
+		copy(bobPreimage[:], bytes.Repeat([]byte{0xaa - index}, 32))
+		rHash := sha256.Sum256(bobPreimage[:])
+		bobHtlc := &lnwire.UpdateAddHTLC{
+			PaymentHash: rHash,
+			Amount:      htlcAmt,
+			Expiry:      uint32(10),
+			ID:          uint64(index),
+		}
+		index++
+
+		_, err := bobChannel.AddHTLC(bobHtlc, nil)
+		if err != nil {
+			t.Fatalf("unable to add bob's htlc: %v", err)
+		}
+		_, err = aliceChannel.ReceiveHTLC(bobHtlc)
+		if err != nil {
+			t.Fatalf("unable to recv bob's htlc: %v", err)
+		}
+
+		aliceSig, aliceHtlcSigs, err := aliceChannel.SignNextCommitment()
+		if err != nil {
+			t.Fatalf("unable to sign next commit: %v", err)
+		}
+		err = bobChannel.ReceiveNewCommitment(aliceSig, aliceHtlcSigs)
+		if err != nil {
+			t.Fatalf("unable to receive commit sig: %v", err)
+		}
+	}
+
+	// assertLocalDataLoss checks that aliceOld and bobChannel detects that
+	// Alice has lost state during sync.
+	assertLocalDataLoss := func(aliceOld *LightningChannel) {
+		aliceSyncMsg, err := aliceOld.ChanSyncMsg()
+		if err != nil {
+			t.Fatalf("unable to produce chan sync msg: %v", err)
+		}
+		bobSyncMsg, err := bobChannel.ChanSyncMsg()
+		if err != nil {
+			t.Fatalf("unable to produce chan sync msg: %v", err)
+		}
+
+		// Alice should detect from Bob's message that she lost state.
+		_, _, _, err = aliceOld.ProcessChanSyncMsg(bobSyncMsg)
+		if err != ErrCommitSyncLocalDataLoss {
+			t.Fatalf("wrong error, expected "+
+				"ErrCommitSyncLocalDataLoss instead got: %v",
+				err)
+		}
+
+		// Bob should detect that Alice probably lost state.
+		_, _, _, err = bobChannel.ProcessChanSyncMsg(aliceSyncMsg)
+		if err != ErrCommitSyncRemoteDataLoss {
+			t.Fatalf("wrong error, expected "+
+				"ErrCommitSyncRemoteDataLoss instead got: %v",
+				err)
+		}
+	}
+
+	// Start by advancing the state.
+	advanceState()
+
+	// They should be in sync.
+	assertNoChanSyncNeeded(t, aliceChannel, bobChannel)
+
+	// Make a copy of Alice's state from the database at this point.
+	aliceOld, err := restartChannel(aliceChannel)
+	if err != nil {
+		t.Fatalf("unable to restart channel: %v", err)
+	}
+
+	// Advance the states.
+	advanceState()
+
+	// Trying to sync up the old version of Alice's channel should detect
+	// that we are out of sync.
+	assertLocalDataLoss(aliceOld)
+
+	// Make sure the up-to-date channels still are in sync.
+	assertNoChanSyncNeeded(t, aliceChannel, bobChannel)
+
+	// Advance the state again, and do the same check.
+	advanceState()
+	assertNoChanSyncNeeded(t, aliceChannel, bobChannel)
+	assertLocalDataLoss(aliceOld)
+
+	// If we remove the recovery options from Bob's message, Alice cannot
+	// tell if she lost state, since Bob might be lying. She still should
+	// be able to detect that chains cannot be synced.
+	bobSyncMsg, err := bobChannel.ChanSyncMsg()
+	if err != nil {
+		t.Fatalf("unable to produce chan sync msg: %v", err)
+	}
+	bobSyncMsg.LocalUnrevokedCommitPoint = nil
+	_, _, _, err = aliceOld.ProcessChanSyncMsg(bobSyncMsg)
+	if err != ErrCannotSyncCommitChains {
+		t.Fatalf("wrong error, expected ErrCannotSyncCommitChains "+
+			"instead got: %v", err)
+	}
+
+	// If Bob lies about the NextLocalCommitHeight, making it greater than
+	// what Alice expect, she cannot tell for sure whether she lost state,
+	// but should detect the desync.
+	bobSyncMsg, err = bobChannel.ChanSyncMsg()
+	if err != nil {
+		t.Fatalf("unable to produce chan sync msg: %v", err)
+	}
+	bobSyncMsg.NextLocalCommitHeight++
+	_, _, _, err = aliceChannel.ProcessChanSyncMsg(bobSyncMsg)
+	if err != ErrCannotSyncCommitChains {
+		t.Fatalf("wrong error, expected ErrCannotSyncCommitChains "+
+			"instead got: %v", err)
+	}
+
+	// If Bob's NextLocalCommitHeight is lower than what Alice expects, Bob
+	// probably lost state.
+	bobSyncMsg, err = bobChannel.ChanSyncMsg()
+	if err != nil {
+		t.Fatalf("unable to produce chan sync msg: %v", err)
+	}
+	bobSyncMsg.NextLocalCommitHeight--
+	_, _, _, err = aliceChannel.ProcessChanSyncMsg(bobSyncMsg)
+	if err != ErrCommitSyncRemoteDataLoss {
+		t.Fatalf("wrong error, expected ErrCommitSyncRemoteDataLoss "+
+			"instead got: %v", err)
+	}
+
+	// If Alice and Bob's states are in sync, but Bob is sending the wrong
+	// LocalUnrevokedCommitPoint, Alice should detect this.
+	bobSyncMsg, err = bobChannel.ChanSyncMsg()
+	if err != nil {
+		t.Fatalf("unable to produce chan sync msg: %v", err)
+	}
+	p := bobSyncMsg.LocalUnrevokedCommitPoint.SerializeCompressed()
+	p[4] ^= 0x01
+	modCommitPoint, err := btcec.ParsePubKey(p, btcec.S256())
+	if err != nil {
+		t.Fatalf("unable to parse pubkey: %v", err)
+	}
+
+	bobSyncMsg.LocalUnrevokedCommitPoint = modCommitPoint
+	_, _, _, err = aliceChannel.ProcessChanSyncMsg(bobSyncMsg)
+	if err != ErrInvalidLocalUnrevokedCommitPoint {
+		t.Fatalf("wrong error, expected "+
+			"ErrInvalidLocalUnrevokedCommitPoint instead got: %v",
+			err)
+	}
+
+	// Make sure the up-to-date channels still are good.
+	assertNoChanSyncNeeded(t, aliceChannel, bobChannel)
+
+	// Finally check that Alice is also able to detect a wrong commit point
+	// when there's a pending remote commit.
+	halfAdvance()
+
+	bobSyncMsg, err = bobChannel.ChanSyncMsg()
+	if err != nil {
+		t.Fatalf("unable to produce chan sync msg: %v", err)
+	}
+	bobSyncMsg.LocalUnrevokedCommitPoint = modCommitPoint
+	_, _, _, err = aliceChannel.ProcessChanSyncMsg(bobSyncMsg)
+	if err != ErrInvalidLocalUnrevokedCommitPoint {
+		t.Fatalf("wrong error, expected "+
+			"ErrInvalidLocalUnrevokedCommitPoint instead got: %v",
+			err)
 	}
 }
 

--- a/peer.go
+++ b/peer.go
@@ -333,7 +333,7 @@ func (p *peer) loadActiveChannels(chans []*channeldb.OpenChannel) error {
 
 		// Skip adding any permanently irreconcilable channels to the
 		// htlcswitch.
-		if dbChan.ChanStatus != channeldb.Default {
+		if dbChan.ChanStatus() != channeldb.Default {
 			peerLog.Warnf("ChannelPoint(%v) has status %v, won't "+
 				"start.", chanPoint, dbChan.ChanStatus)
 			lnChan.Stop()


### PR DESCRIPTION
This PR implements the logic required for "data loss protection", as described in BOLT#2: https://github.com/lightningnetwork/lightning-rfc/blob/master/02-peer-protocol.md#message-retransmission

When syncing channel states we will now detect the cases where _we_ probably have lost our local state, meaning broadcasting our commitment would be unsafe as it could be considered a breach. Instead we store the `my_current_per_commitment_point` sent to us by the remote in the database. This commitment point can later be used to reclaim our funds if the remote party decides to unilaterally close the channel using the corresponding state.

If we detect that the remote party probably has lost state, we'll be a good citizen and force close the channel using our latest commitment.

@Roasbeef: what is meant by:
> In order to ensure we can carry out this process reliably we may need to ensure that they remote party first sends their re-sync message before we do. We can enforce this by requiring the initiator to send their message first.

?

Fixes #1131