### PR TITLE
lntest/harness: add pollIntervall to WaitPredicate

### DIFF
--- a/lntest/harness.go
+++ b/lntest/harness.go
@@ -1035,8 +1035,12 @@ func (n *NetworkHarness) AssertChannelExists(ctx context.Context,
 // several running lnd nodes. This function gives callers a way to assert that
 // some property is upheld within a particular time frame.
 func WaitPredicate(pred func() bool, timeout time.Duration) error {
+	const pollInterval = 20 * time.Millisecond
+
 	exitTimer := time.After(timeout)
 	for {
+		<-time.After(pollInterval)
+
 		select {
 		case <-exitTimer:
 			return fmt.Errorf("predicate not satisfied after time out")


### PR DESCRIPTION
This commit adds a poll 20 ms interval to WaitPredicate, similar to what
is done for WaitInvariant. This makes the predicate not being checked
super-rapidly, potentially filling the logs with useless info over the
wait predicate interval.