### PR TITLE
Cache describegraph RPC response

### DIFF
--- a/channeldb/channel.go
+++ b/channeldb/channel.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/coreos/bbolt"
 	"github.com/lightningnetwork/lnd/keychain"
+	"github.com/lightningnetwork/lnd/lnrpc"
 	"github.com/lightningnetwork/lnd/lnwire"
 	"github.com/lightningnetwork/lnd/shachain"
 	"github.com/roasbeef/btcd/btcec"
@@ -2303,4 +2304,37 @@ func wipeChannelLogEntries(log *bolt.Bucket) error {
 	}
 
 	return nil
+}
+
+var (
+	// DescribeGraph RPC responses are cached. The cache is invalidated whenever
+	// a new channel is opened, a channel is closed, etc., similar to the
+	// queryRoutes cache in the routing package
+	// The cache is included here and not in rpcserver.go to avoid circular
+	// dependency for the routing package
+	describeGraphCache    *lnrpc.ChannelGraph
+	describeGraphCacheMtx sync.RWMutex
+)
+
+// Invalidates the DescribeGraph cache upon relevant changes in channel or node
+// states. Called from the routing package in parallel to invalidation of the
+// router cache.
+func InvalidateDescribeGraphCache() {
+	describeGraphCacheMtx.Lock()
+	describeGraphCache = nil
+	describeGraphCacheMtx.Unlock()
+}
+
+// Get DescribeGraph cashed response
+func GetDescribeGraphCache() *lnrpc.ChannelGraph {
+	describeGraphCacheMtx.RLock()
+	defer describeGraphCacheMtx.RUnlock()
+	return describeGraphCache
+}
+
+// Sets DescribeGraph cache with latest response
+func SetDescribeGraphCache(resp *lnrpc.ChannelGraph) {
+	describeGraphCacheMtx.Lock()
+	describeGraphCache = resp
+	describeGraphCacheMtx.Unlock()
 }

--- a/routing/router.go
+++ b/routing/router.go
@@ -726,6 +726,10 @@ func (r *ChannelRouter) networkHandler() {
 			r.routeCache = make(map[routeTuple][]*Route)
 			r.routeCacheMtx.Unlock()
 
+			// Invalidate the describe graph cache, as some channels
+			// might not be confirmed anymore.
+			channeldb.InvalidateDescribeGraphCache()
+
 			// TODO(halseth): notify client about the reorg?
 
 		// A new block has arrived, so we can prune the channel graph
@@ -794,6 +798,10 @@ func (r *ChannelRouter) networkHandler() {
 			r.routeCacheMtx.Lock()
 			r.routeCache = make(map[routeTuple][]*Route)
 			r.routeCacheMtx.Unlock()
+
+			// Invalidate the describe graph cache, as graph may
+			// have been pruned
+			channeldb.InvalidateDescribeGraphCache()
 
 			if len(chansClosed) == 0 {
 				continue
@@ -1152,6 +1160,9 @@ func (r *ChannelRouter) processUpdate(msg interface{}) error {
 		r.routeCacheMtx.Lock()
 		r.routeCache = make(map[routeTuple][]*Route)
 		r.routeCacheMtx.Unlock()
+
+		// Invalidate the describe graph cache as channels were updated/closed
+		channeldb.InvalidateDescribeGraphCache()
 	}
 
 	return nil


### PR DESCRIPTION
Cache is cleared upon node and channel update events, similar to the queryRoutes cache in the router.
Address issue #1232

When debuglevel is set to debug, LND prints the following message when the describegraph request is served from cache:
2018-06-12 11:56:14.972 [DBG] RPCS: [describegraph] cached response returned.

The following tests where performed on simnet, by running `lncli describegraph`checking that response is as expected and the same before/after cache and examining the debug printing on the lnd server. 

1. Single node:
Charlie not connected to any node:
First describegraph not cached. 
Second describegraph cached.

2. Two nodes connected by a channel
Alice and Bob are peers and have a channel between them:
First describegraph not cached.
Second describegraph cached.

3. Node and Channel change
Charlie is peered with Bob. Charlie learns the network from Bob. Cache@Charlie is reset correctly. Cache@Bob is not reset, as peer relations do not change the graph.
