### PR TITLE
Specify --txindex optional for bitcoind in installation docs

### DIFF
--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -207,8 +207,8 @@ prefixed by `litecoind`.
 To configure your bitcoind backend for use with lnd, first complete and verify
 the following:
 
-- The `bitcoind` instance must be configured with `--txindex` just like `btcd`
-  above
+- The `bitcoind` instance can optionally be configured with `--txindex` just like `btcd`
+  above.
 - Additionally, since `lnd` uses
   [ZeroMQ](https://github.com/bitcoin/bitcoin/blob/master/doc/zmq.md) to
   interface with `bitcoind`, *your `bitcoind` installation must be compiled with


### PR DESCRIPTION
Self-explanatory. [PR 751](https://github.com/lightningnetwork/lnd/pull/751) made -txindex no longer a requirement when using lnd with bitcoind.