### PR TITLE
Update channel packager sid

### DIFF
--- a/channeldb/channel_test.go
+++ b/channeldb/channel_test.go
@@ -898,6 +898,16 @@ func TestRefreshShortChanID(t *testing.T) {
 			"updated before refreshing short_chan_id")
 	}
 
+	// Now that the receiver's short channel id has been updated, check to
+	// ensure that the channel packager's source has been updated as well.
+	// This ensures that the packager will read and write to buckets
+	// corresponding to the new short chan id, instead of the prior.
+	if state.Packager.(*ChannelPackager).source != chanOpenLoc {
+		t.Fatalf("channel packager source was not updated: want %v, "+
+			"got %v", chanOpenLoc,
+			state.Packager.(*ChannelPackager).source)
+	}
+
 	// Now, refresh the short channel ID of the pending channel.
 	err = pendingChannel.RefreshShortChanID()
 	if err != nil {
@@ -910,5 +920,15 @@ func TestRefreshShortChanID(t *testing.T) {
 		t.Fatalf("expected pending channel short_chan_id to be "+
 			"refreshed: want %v, got %v", state.ShortChanID(),
 			pendingChannel.ShortChanID())
+	}
+
+	// Check to ensure that the _other_ OpenChannel channel packager's
+	// source has also been updated after the refresh. This ensures that the
+	// other packagers will read and write to buckets corresponding to the
+	// updated short chan id.
+	if pendingChannel.Packager.(*ChannelPackager).source != chanOpenLoc {
+		t.Fatalf("channel packager source was not updated: want %v, "+
+			"got %v", chanOpenLoc,
+			pendingChannel.Packager.(*ChannelPackager).source)
 	}
 }


### PR DESCRIPTION
In this PR, we improve the consistency of a channel's forwarding packager. Each `ChannelPackager` maintains the short channel id of the channel it managers. We made recent changes to improve the consistency of update a channel's short channel id, and refreshing any changes from disk. However, these updates were never carried over to the `ChannelPackager`'s short channel id.  FWIW, this problem has existed even before these changes, though now the solution is done in tandem with the existing serialization points.

Two assertions have been added to `TestRefreshShortChanID`, ensuring that the packager's short channel id is updated. Checking out the commit with the tests shows these assertions failing, which are then fixed with the changes to `channeldb/channel.go`.

