### PR TITLE
RFC - Add a (fixed) timeout when writing a message to a peer node

### DIFF
--- a/peer.go
+++ b/peer.go
@@ -40,6 +40,9 @@ const (
 	// idleTimeout is the duration of inactivity before we time out a peer.
 	idleTimeout = 5 * time.Minute
 
+	// writeMessageTimeout is the timeout used when writing a message to peer.
+	writeMessageTimeout = 10 * time.Second
+
 	// outgoingQueueLen is the buffer size of the channel which houses
 	// messages to be sent across the wire, requested by objects outside
 	// this struct.
@@ -1249,7 +1252,7 @@ func (p *peer) writeMessage(msg lnwire.Message) error {
 	n, err := lnwire.WriteMessage(b, msg, 0)
 	atomic.AddUint64(&p.bytesSent, uint64(n))
 
-	p.conn.SetWriteDeadline(time.Now().Add(10 * time.Second))
+	p.conn.SetWriteDeadline(time.Now().Add(writeMessageTimeout))
 
 	// Finally, write the message itself in a single swoop.
 	_, err = p.conn.Write(b.Bytes())


### PR DESCRIPTION
I our tests, we saw that in several cases, we couldn't open a channel or do anything that needs an answer from a remote peer. It seems that the reason is that the remote peer was stuck when sending a message to our peer. As soon as the connection is stuck, no message can be sent by the remote peer.
The solution is to add a timeout by using the SetWriteDeadline mechanism.
There is even a TODO comment which asks if we need to use such a mechanism
In this PR, the timeout is hardcoded to 10 seconds. It solves the problems that we had.
Do you think the timeout needs to be a config option instead ? The argument against that is that the timeout doesn't depend on this specific node, but on it's peers.
What do you think?