### PR TITLE
htlcswitch: in removeLink use new goroutine to stop existing link

### DIFF
--- a/htlcswitch/switch.go
+++ b/htlcswitch/switch.go
@@ -1883,7 +1883,7 @@ func (s *Switch) removeLink(chanID lnwire.ChannelID) error {
 		}
 	}
 
-	link.Stop()
+	go link.Stop()
 
 	return nil
 }


### PR DESCRIPTION
In this commit, we modify the removeLink method to be more asynchronous.
Before this commit, we would attempt to block until the peer exits.
However, it may be the case that at times time, then target link is
attempting to forward a batch of packets to the switch (forwardBatch).
Atm, this method doesn't pass in an external context/quit, so we can't
cancel this message/request. As a result, we'll now ensure that
`removeLink` doesn't block, so we can resume the switch's main loop as
soon as possible.

Fixes #1441. 