### PR TITLE
lncfg+config: parse and resolve onion addresses

### DIFF
--- a/config.go
+++ b/config.go
@@ -875,10 +875,7 @@ func loadConfig() (*config, error) {
 	// inbound support is enabled.
 	if cfg.Tor.V2 || cfg.Tor.V3 {
 		for _, addr := range cfg.Listeners {
-			// Due to the addresses being normalized above, we can
-			// skip checking the error.
-			host, _, _ := net.SplitHostPort(addr.String())
-			if lncfg.IsLoopback(addr) {
+			if lncfg.IsLoopback(addr.String()) {
 				continue
 			}
 

--- a/lncfg/address.go
+++ b/lncfg/address.go
@@ -52,7 +52,7 @@ func EnforceSafeAuthentication(addrs []net.Addr, macaroonsActive bool) error {
 	// on. If it's a localhost address, we'll skip it, otherwise, we'll
 	// return an error if macaroons are inactive.
 	for _, addr := range addrs {
-		if IsLoopback(addr) || IsUnix(addr) {
+		if IsLoopback(addr.String()) || IsUnix(addr) {
 			continue
 		}
 
@@ -79,9 +79,9 @@ func TlsListenOnAddress(addr net.Addr,
 }
 
 // IsLoopback returns true if an address describes a loopback interface.
-func IsLoopback(addr net.Addr) bool {
+func IsLoopback(addr string) bool {
 	for _, loopback := range loopBackAddrs {
-		if strings.Contains(addr.String(), loopback) {
+		if strings.Contains(addr, loopback) {
 			return true
 		}
 	}

--- a/lncfg/address_test.go
+++ b/lncfg/address_test.go
@@ -100,7 +100,7 @@ func TestAddresses(t *testing.T) {
 				netAddr.Network(), netAddr.String(),
 			)
 		}
-		isAddrLoopback := IsLoopback(normalized[0])
+		isAddrLoopback := IsLoopback(normalized[0].String())
 		if testVector.isLoopback != isAddrLoopback {
 			t.Fatalf("#%v: mismatched loopback detection: expected "+
 				"%v, got %v for addr %s",

--- a/lncfg/address_test.go
+++ b/lncfg/address_test.go
@@ -2,7 +2,10 @@
 
 package lncfg
 
-import "testing"
+import (
+	"net"
+	"testing"
+)
 
 // addressTest defines a test vector for an address that contains the non-
 // normalized input and the expected normalized output.
@@ -35,6 +38,34 @@ var (
 		{"unix:///tmp/lnd.sock", "unix", "/tmp/lnd.sock", false, true},
 		{"unix:/tmp/lnd.sock", "unix", "/tmp/lnd.sock", false, true},
 		{"123", "tcp", "127.0.0.1:123", true, false},
+		{
+			"4acth47i6kxnvkewtm6q7ib2s3ufpo5sqbsnzjpbi7utijcltosqemad.onion",
+			"tcp",
+			"4acth47i6kxnvkewtm6q7ib2s3ufpo5sqbsnzjpbi7utijcltosqemad.onion:1234",
+			false,
+			false,
+		},
+		{
+			"4acth47i6kxnvkewtm6q7ib2s3ufpo5sqbsnzjpbi7utijcltosqemad.onion:9735",
+			"tcp",
+			"4acth47i6kxnvkewtm6q7ib2s3ufpo5sqbsnzjpbi7utijcltosqemad.onion:9735",
+			false,
+			false,
+		},
+		{
+			"3g2upl4pq6kufc4m.onion",
+			"tcp",
+			"3g2upl4pq6kufc4m.onion:1234",
+			false,
+			false,
+		},
+		{
+			"3g2upl4pq6kufc4m.onion:9735",
+			"tcp",
+			"3g2upl4pq6kufc4m.onion:9735",
+			false,
+			false,
+		},
 	}
 	invalidTestVectors = []string{
 		"some string",
@@ -47,42 +78,41 @@ var (
 // normalized correctly.
 func TestAddresses(t *testing.T) {
 	// First, test all correct addresses.
-	for _, testVector := range addressTestVectors {
+	for i, testVector := range addressTestVectors {
 		addr := []string{testVector.address}
-		normalized, err := NormalizeAddresses(addr, defaultTestPort)
+		normalized, err := NormalizeAddresses(
+			addr, defaultTestPort, net.ResolveTCPAddr,
+		)
 		if err != nil {
-			t.Fatalf("unable to normalize address %s: %v",
-				testVector.address, err)
+			t.Fatalf("#%v: unable to normalize address %s: %v",
+				i, testVector.address, err)
 		}
 		netAddr := normalized[0]
 		if err != nil {
-			t.Fatalf("unable to split normalized address: %v", err)
+			t.Fatalf("#%v: unable to split normalized address: %v", i, err)
 		}
 		if netAddr.Network() != testVector.expectedNetwork ||
 			netAddr.String() != testVector.expectedAddress {
-			t.Fatalf(
-				"mismatched address: expected %s://%s, got "+
-					"%s://%s",
-				testVector.expectedNetwork,
+			t.Fatalf("#%v: mismatched address: expected %s://%s, "+
+				"got %s://%s",
+				i, testVector.expectedNetwork,
 				testVector.expectedAddress,
 				netAddr.Network(), netAddr.String(),
 			)
 		}
 		isAddrLoopback := IsLoopback(normalized[0])
 		if testVector.isLoopback != isAddrLoopback {
-			t.Fatalf(
-				"mismatched loopback detection: expected "+
-					"%v, got %v for addr %s",
-				testVector.isLoopback, isAddrLoopback,
+			t.Fatalf("#%v: mismatched loopback detection: expected "+
+				"%v, got %v for addr %s",
+				i, testVector.isLoopback, isAddrLoopback,
 				testVector.address,
 			)
 		}
 		isAddrUnix := IsUnix(normalized[0])
 		if testVector.isUnix != isAddrUnix {
-			t.Fatalf(
-				"mismatched unix detection: expected "+
-					"%v, got %v for addr %s",
-				testVector.isUnix, isAddrUnix,
+			t.Fatalf("#%v: mismatched unix detection: expected "+
+				"%v, got %v for addr %s",
+				i, testVector.isUnix, isAddrUnix,
 				testVector.address,
 			)
 		}
@@ -91,8 +121,11 @@ func TestAddresses(t *testing.T) {
 	// Finally, test invalid inputs to see if they are handled correctly.
 	for _, testVector := range invalidTestVectors {
 		addr := []string{testVector}
-		_, err := NormalizeAddresses(addr, defaultTestPort)
+		_, err := NormalizeAddresses(
+			addr, defaultTestPort, net.ResolveTCPAddr,
+		)
 		if err == nil {
+
 			t.Fatalf("expected error when parsing %v", testVector)
 		}
 	}

--- a/lncfg/address_test.go
+++ b/lncfg/address_test.go
@@ -34,12 +34,12 @@ var (
 		{"localhost", "tcp", "127.0.0.1:1234", true, false},
 		{"unix:///tmp/lnd.sock", "unix", "/tmp/lnd.sock", false, true},
 		{"unix:/tmp/lnd.sock", "unix", "/tmp/lnd.sock", false, true},
+		{"123", "tcp", "127.0.0.1:123", true, false},
 	}
 	invalidTestVectors = []string{
 		"some string",
 		"://",
-		"12.12.12",
-		"123",
+		"12.12.12.12.12",
 	}
 )
 

--- a/server.go
+++ b/server.go
@@ -404,7 +404,7 @@ func newServer(listenAddrs []net.Addr, chanDB *channeldb.DB, cc *chainControl,
 		return nil, err
 	}
 	selfAddrs := make([]net.Addr, 0, len(externalIPs))
-	for _, ip := range cfg.ExternalIPs {
+	for _, ip := range externalIPs {
 		selfAddrs = append(selfAddrs, ip)
 	}
 

--- a/server.go
+++ b/server.go
@@ -399,6 +399,7 @@ func newServer(listenAddrs []net.Addr, chanDB *channeldb.DB, cc *chainControl,
 	// of this server's addresses.
 	externalIPs, err := lncfg.NormalizeAddresses(
 		externalIpStrings, strconv.Itoa(defaultPeerPort),
+		cfg.net.ResolveTCPAddr,
 	)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
In this PR, we attempt to fix a regression w.r.t. parsing and resolving onion addresses throughout the config introduced in the unix sockets PR. We now properly parse and resolve onion addresses and set of tests has been added to ensure this.