### PR TITLE
Subtract funding tx fee from requested channel capacity

### DIFF
--- a/fundingmanager.go
+++ b/fundingmanager.go
@@ -2555,6 +2555,11 @@ func (f *fundingManager) handleInitFundingMsg(msg *initFundingMsg) {
 		return
 	}
 
+	// The channel capacity and localAmt can be updated during channel
+	// reservation.
+	capacity = reservation.Capacity
+	localAmt = reservation.OurContribution().FundingAmount
+
 	// Obtain a new pending channel ID which is used to track this
 	// reservation throughout its lifetime.
 	chanID := f.nextPendingChanID()

--- a/lnwallet/reservation.go
+++ b/lnwallet/reservation.go
@@ -128,6 +128,11 @@ type ChannelReservation struct {
 	chanOpenErr chan error
 
 	wallet *LightningWallet
+
+	// Capacity is the chosen capacity of this channel. This may be less than
+	// the supplied capacity if fees were subtracted during the channel
+	// reservation.
+	Capacity btcutil.Amount
 }
 
 // NewChannelReservation creates a new channel reservation. This function is
@@ -261,6 +266,7 @@ func NewChannelReservation(capacity, fundingAmt btcutil.Amount,
 		chanOpen:      make(chan *openChanDetails, 1),
 		chanOpenErr:   make(chan error, 1),
 		wallet:        wallet,
+		Capacity:      capacity,
 	}, nil
 }
 

--- a/lnwallet/wallet.go
+++ b/lnwallet/wallet.go
@@ -475,6 +475,10 @@ func (l *LightningWallet) handleFundingReserveRequest(req *initFundingReserveMsg
 			req.resp <- nil
 			return
 		}
+
+		// FIXME(simon): This doesn't work for dual funder channels.
+		req.capacity = selectedAmt
+		req.fundingAmount = selectedAmt
 	}
 
 	id := atomic.AddUint64(&l.nextFundingID, 1)

--- a/lnwallet/wallet.go
+++ b/lnwallet/wallet.go
@@ -1388,11 +1388,12 @@ func initStateHints(commit1, commit2 *wire.MsgTx,
 }
 
 // selectInputsAndFees selects a slice of inputs necessary to meet the specified
-// selection amount. If input selection is unable to succeed due to insufficient
-// funds, a non-nil error is returned. Additionally, the total amount of the
-// selected coins are returned in order for the caller to properly handle
-// change+fees.
-func selectInputsAndFees(feeRate SatPerVByte, amt btcutil.Amount, coins []*Utxo) (btcutil.Amount, btcutil.Amount, []*Utxo, error) {
+// selection amount. If successful, the selected amount is returned minus the
+// fees. If input selection is unable to succeed due to insufficient funds, a
+// non-nil error is returned. Additionally, the total amount of the selected
+// coins are returned in order for the caller to properly handle change.
+func selectInputsAndFees(feeRate SatPerVByte, amt btcutil.Amount,
+	coins []*Utxo) (btcutil.Amount, btcutil.Amount, []*Utxo, error) {
 	satSelected := btcutil.Amount(0)
 	requiredFee := btcutil.Amount(0)
 
@@ -1431,9 +1432,9 @@ func selectInputsAndFees(feeRate SatPerVByte, amt btcutil.Amount, coins []*Utxo)
 }
 
 // coinSelect attempts to select a sufficient amount of coins, including a
-// change output to fund amt satoshis, adhering to the specified fee rate. The
-// specified fee rate should be expressed in sat/vbyte for coin selection to
-// function properly.
+// change output to fund amt satoshis inclusive of the fee at the specified fee
+// rate. The specified fee rate should be expressed in sat/vbyte for coin
+// selection to function properly.
 func coinSelect(feeRate SatPerVByte, amt btcutil.Amount,
 	coins []*Utxo) ([]*Utxo, btcutil.Amount, btcutil.Amount, error) {
 

--- a/lnwallet/wallet.go
+++ b/lnwallet/wallet.go
@@ -1437,22 +1437,19 @@ func selectInputsAndFees(feeRate SatPerVByte, amt btcutil.Amount,
 // selection to function properly.
 func coinSelect(feeRate SatPerVByte, amt btcutil.Amount,
 	coins []*Utxo) ([]*Utxo, btcutil.Amount, btcutil.Amount, error) {
-
-	// First perform an initial round of coin selection to estimate
-	// the required fee.
+	// Select enough outputs from our wallet to cover the requested amount.
 	totalSat, requiredFee, selectedUtxos, err := selectInputsAndFees(feeRate, amt, coins)
 	if err != nil {
 		return nil, 0, 0, err
 	}
 
-	// The difference between the selected amount and the amount
-	// requested will be used to pay fees, and generate a change
-	// output with the remaining.
-	overShootAmt := totalSat - amt
+	// The selected amount is returned minus the fees that this transaction
+	// requires.
+	selectedAmt := amt - requiredFee
 
-	// If the fee is sufficient, then calculate the size of the
-	// change output.
-	changeAmt := overShootAmt
+	// Calculate the size of the change output given the selectedAmt that's
+	// being spent.
+	changeAmt := totalSat - amt
 
-	return selectedUtxos, amt - requiredFee, changeAmt, nil
+	return selectedUtxos, selectedAmt, changeAmt, nil
 }


### PR DESCRIPTION
In this PR we address a minor usability issue when opening a channel that uses the entire remaining wallet balance. Currently if a user wants to spend their entire wallet balance on channels they would issue a "lncli walletbalance" and use the total_balance as the local_amt in "lncli openchannel", however this will error out as openchannel requires the wallet to have enough to cover the fee for the funding transaction as well as the local_amt for the channel. This PR causes the fee for the funding transaction to be subtracted from the local_amt passed to openchannel, allowing users to pass the entire wallet balance to openchannel. A similar issue occurs when running autopilot with autopilot.allocation=1.0 as autopilot will attempt to call openchannel without leaving enough room for the fee and having that repeatedly fail.

This is currently WIP as I haven't yet updated the tests to reflect any of the changed functionality. But more importantly I would like feedback on whether this implementation makes sense, or if there's a better way to architect it. Finally, this should all probably exist behind a flag as otherwise it would be a surprising change in the default behaviour.

Related issues: #619 #986