### PR TITLE
[lnwire]: align behavior of query sids corpus for zero-length slices

### DIFF
--- a/lnwire/lnwire_test.go
+++ b/lnwire/lnwire_test.go
@@ -668,11 +668,9 @@ func TestLightningWireProtocol(t *testing.T) {
 
 			numChanIDs := rand.Int31n(5000)
 
-			req.ShortChanIDs = make([]ShortChannelID, numChanIDs)
 			for i := int32(0); i < numChanIDs; i++ {
-				req.ShortChanIDs[i] = NewShortChanIDFromInt(
-					uint64(r.Int63()),
-				)
+				req.ShortChanIDs = append(req.ShortChanIDs,
+					NewShortChanIDFromInt(uint64(r.Int63())))
 			}
 
 			v[0] = reflect.ValueOf(req)

--- a/lnwire/query_short_chan_ids.go
+++ b/lnwire/query_short_chan_ids.go
@@ -146,10 +146,13 @@ func decodeShortChanIDs(r io.Reader) (ShortChanIDEncoding, []ShortChannelID, err
 		// compute the number of bytes encoded based on the size of the
 		// query body.
 		numShortChanIDs := len(queryBody) / 8
-		shortChanIDs := make([]ShortChannelID, numShortChanIDs)
+		if numShortChanIDs == 0 {
+			return encodingType, nil, nil
+		}
 
 		// Finally, we'll read out the exact number of short channel
 		// ID's to conclude our parsing.
+		shortChanIDs := make([]ShortChannelID, numShortChanIDs)
 		bodyReader := bytes.NewReader(queryBody)
 		for i := 0; i < numShortChanIDs; i++ {
 			if err := readElements(bodyReader, &shortChanIDs[i]); err != nil {


### PR DESCRIPTION
Modifies the behavior of the quick test for
MsgQueryShortChanIDs, such that the generated
slice of expected short chan ids is always nil
if no elements are returned. This mimics the
behavior of the zlib decompression, where
elements are appended to the slice, instead of
assigning to preallocated slice.

We also alter the behavior of the regular
short channel id encoding, such that it returns a nil
slice if the decoded number of elements is 0. This is
done so that it matches the behavior of the zlib
decompression, allowing us to test both in using the
same corpus.