### PR TITLE
config: only normalize and resolve tor DNS host if it has changed

### DIFF
--- a/config.go
+++ b/config.go
@@ -438,14 +438,18 @@ func loadConfig() (*config, error) {
 	}
 	cfg.Tor.SOCKS = socks.String()
 
-	dns, err := lncfg.ParseAddressString(
-		cfg.Tor.DNS, strconv.Itoa(defaultTorDNSPort),
-		cfg.net.ResolveTCPAddr,
-	)
-	if err != nil {
-		return nil, err
+	// We'll only attempt to normalize and resolve the DNS host if it hasn't
+	// changed, as it doesn't need to be done for the default.
+	if cfg.Tor.DNS != defaultTorDNS {
+		dns, err := lncfg.ParseAddressString(
+			cfg.Tor.DNS, strconv.Itoa(defaultTorDNSPort),
+			cfg.net.ResolveTCPAddr,
+		)
+		if err != nil {
+			return nil, err
+		}
+		cfg.Tor.DNS = dns.String()
 	}
-	cfg.Tor.DNS = dns.String()
 
 	control, err := lncfg.ParseAddressString(
 		cfg.Tor.Control, strconv.Itoa(defaultTorControlPort),


### PR DESCRIPTION
In the event that the default Tor DNS host wouldn't resolve, it would
prevent `lnd` from starting due to the failed lookup. This should fail
silently as it's only crucial during bootstrapping. However, if the user
has explicitly modified this, we should let them know of the error
immediately.

Related to #1463.