### PR TITLE
Add make instructions for Windows WSL users

### DIFF
--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -64,6 +64,14 @@ cd $GOPATH/src/github.com/lightningnetwork/lnd
 make && make install
 ```
 
+For Windows WSL users, make will need to be referenced directly via /usr/bin/make/, or alternatively by wrapping quotation marks around make, like so:
+
+```
+/usr/bin/make && /usr/bin/make install
+
+"make" && "make" install
+```
+
 Alternatively, if one doesn't wish to use `make`, then the `go` commands can be
 used directly:
 ```


### PR DESCRIPTION
This PR simply adds instructions for those that're running Windows WSL (Bash on Windows), and are having trouble running the make command, which seems to be a common issue.