### PR TITLE
htlcswitch+routing: minor forwarding perf improvements

### DIFF
--- a/htlcswitch/link.go
+++ b/htlcswitch/link.go
@@ -1566,8 +1566,13 @@ func (l *channelLink) updateCommitTx() error {
 	if err == lnwallet.ErrNoWindow {
 		l.tracef("revocation window exhausted, unable to send: %v, "+
 			"dangling_opens=%v, dangling_closes%v",
-			l.batchCounter, spew.Sdump(l.openedCircuits),
-			spew.Sdump(l.closedCircuits))
+			l.batchCounter, newLogClosure(func() string {
+				return spew.Sdump(l.openedCircuits)
+			}),
+			newLogClosure(func() string {
+				return spew.Sdump(l.closedCircuits)
+			}),
+		)
 		return nil
 	} else if err != nil {
 		return err

--- a/htlcswitch/switch.go
+++ b/htlcswitch/switch.go
@@ -1251,7 +1251,7 @@ func (s *Switch) closeCircuit(pkt *htlcPacket) (*PaymentCircuit, error) {
 // we're the originator of the payment, so the link stops attempting to
 // re-broadcast.
 func (s *Switch) ackSettleFail(settleFailRef channeldb.SettleFailRef) error {
-	return s.cfg.DB.Update(func(tx *bolt.Tx) error {
+	return s.cfg.DB.Batch(func(tx *bolt.Tx) error {
 		return s.cfg.SwitchPackager.AckSettleFails(tx, settleFailRef)
 	})
 }

--- a/routing/router.go
+++ b/routing/router.go
@@ -1458,7 +1458,10 @@ func generateSphinxPacket(route *Route, paymentHash []byte) ([]byte,
 	hopPayloads := route.ToHopPayloads()
 
 	log.Tracef("Constructed per-hop payloads for payment_hash=%x: %v",
-		paymentHash[:], spew.Sdump(hopPayloads))
+		paymentHash[:], newLogClosure(func() string {
+			return spew.Sdump(hopPayloads)
+		}),
+	)
 
 	sessionKey, err := btcec.NewPrivateKey(btcec.S256())
 	if err != nil {
@@ -1467,8 +1470,9 @@ func generateSphinxPacket(route *Route, paymentHash []byte) ([]byte,
 
 	// Next generate the onion routing packet which allows us to perform
 	// privacy preserving source routing across the network.
-	sphinxPacket, err := sphinx.NewOnionPacket(nodes, sessionKey,
-		hopPayloads, paymentHash)
+	sphinxPacket, err := sphinx.NewOnionPacket(
+		nodes, sessionKey, hopPayloads, paymentHash,
+	)
 	if err != nil {
 		return nil, nil, err
 	}


### PR DESCRIPTION
I was profiling single hop throughput the other day and noticed a few easy low hanging fruits to increase perf a bit:
  1. In many areas were were using `spw.Sdump` _without_ wrapping the call in a `newLogClosure` instance. As a result, even if the log level wasn't hit, we'd still incur the expensive calls to the `reflect` package.   
  2. The call to update the database in `ackSettleFail` wasn't using `Batch`, so as a result, it would cause multiple goroutines trying to send an HTLC to block. 

As a bonus, the `--debughtlc` flag now works again!