### PR TITLE
lnwallet: fix lost balance of unmined transaction for neutrino

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -255,7 +255,8 @@
     "walletdb/bdb",
     "wtxmgr"
   ]
-  revision = "ccd48bb4720f2baeaa795cac81264f6ced2da4c7"
+  revision = "c221af374d5e08394f5cd354c9de82d852c3dfc2"
+  source = "github.com/vapopov/btcwallet"
 
 [[projects]]
   branch = "master"
@@ -404,6 +405,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "dc40dd185a90b723e4b3df4a077b4ad4f99648260661cac9d58121e8bd3474ef"
+  inputs-digest = "8ea57ed1a7ad34cb61ec14b7a808a6f8876dd5de9fd3b1278ec3f949c7efb76a"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -72,7 +72,8 @@
 
 [[constraint]]
   name = "github.com/roasbeef/btcwallet"
-  revision = "ccd48bb4720f2baeaa795cac81264f6ced2da4c7"
+  revision = "c221af374d5e08394f5cd354c9de82d852c3dfc2"
+  source = "github.com/vapopov/btcwallet"
 
 [[constraint]]
   name = "github.com/tv42/zbase32"

--- a/lnwallet/btcwallet/btcwallet.go
+++ b/lnwallet/btcwallet/btcwallet.go
@@ -21,6 +21,7 @@ import (
 	"github.com/roasbeef/btcwallet/waddrmgr"
 	base "github.com/roasbeef/btcwallet/wallet"
 	"github.com/roasbeef/btcwallet/walletdb"
+	"github.com/roasbeef/btcwallet/wtxmgr"
 )
 
 const (
@@ -449,6 +450,18 @@ func (b *BtcWallet) PublishTransaction(tx *wire.MsgTx) error {
 		}
 		return err
 	}
+
+	switch b.chain.(type) {
+		// For neutrino we need to trigger adding relevant tx manually
+		case *chain.NeutrinoClient:
+			rec, err := wtxmgr.NewTxRecordFromMsgTx(tx, time.Now())
+			if err != nil {
+				return err
+			}
+
+			b.wallet.AddRelevantTx(rec, nil)
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
If we use neutrino as a bitcoin backend - after opening channel we don't count credits for unmined transactions

```
~/g/s/g/l/lnd ❯ lncli connect 03193d512b010997885b232ecd6b300917e5288de8785d6d9f619a8952728c78e8@testnet-lnd.htlc.me 
{

}
~/g/s/g/l/lnd ❯ lncli walletbalance                                                                                                                                                 
{
    "total_balance": "163020941",
    "confirmed_balance": "163020941",
    "unconfirmed_balance": "0"
}
~ ❯ lncli openchannel 03193d512b010997885b232ecd6b300917e5288de8785d6d9f619a8952728c78e8 250000
{
	"funding_txid": "fa602ff6cd70a00cf803f581de04b9bb411d0f1bbb2cb0b9ad9b574fdddcdd53"
}
~/g/s/g/l/lnd ❯ lncli walletbalance                                                                                                                                                 
{
    "total_balance": "0",
    "confirmed_balance": "0",
    "unconfirmed_balance": "0"
}
```

For the flow with `bitcoind` it should work in this way, as I understand: publish tx to backand-> bticoind adds it to mempool -> bitcoind triggers `chain.RelevantTx` notification to lnd, and then we add amount of this tx as unmined credits. With neutrino we have no such notificaiton event, thats why the balance appears only after block confirmation with this transaction.

With this fix, right after opening a channel we able to see unconfirmed balance
```
~ ❯ lncli walletbalance
{
    "total_balance": "154706191",
    "confirmed_balance": "93897730",
    "unconfirmed_balance": "60808461"
}
```

If you can suggest how to fix it in more proper way, let me know