### PR TITLE
tor+server: add automatic support for v3 onion services

### DIFF
--- a/config.go
+++ b/config.go
@@ -57,6 +57,7 @@ const (
 	defaultTorDNSPort              = 53
 	defaultTorControlPort          = 9051
 	defaultTorV2PrivateKeyFilename = "v2_onion_private_key"
+	defaultTorV3PrivateKeyFilename = "v3_onion_private_key"
 
 	defaultBroadcastDelta = 10
 
@@ -86,10 +87,9 @@ var (
 	defaultBitcoindDir  = btcutil.AppDataDir("bitcoin", false)
 	defaultLitecoindDir = btcutil.AppDataDir("litecoin", false)
 
-	defaultTorSOCKS            = net.JoinHostPort("localhost", strconv.Itoa(defaultTorSOCKSPort))
-	defaultTorDNS              = net.JoinHostPort(defaultTorDNSHost, strconv.Itoa(defaultTorDNSPort))
-	defaultTorControl          = net.JoinHostPort("localhost", strconv.Itoa(defaultTorControlPort))
-	defaultTorV2PrivateKeyPath = filepath.Join(defaultLndDir, defaultTorV2PrivateKeyFilename)
+	defaultTorSOCKS   = net.JoinHostPort("localhost", strconv.Itoa(defaultTorSOCKSPort))
+	defaultTorDNS     = net.JoinHostPort(defaultTorDNSHost, strconv.Itoa(defaultTorDNSPort))
+	defaultTorControl = net.JoinHostPort("localhost", strconv.Itoa(defaultTorControlPort))
 )
 
 type chainConfig struct {
@@ -148,14 +148,14 @@ type autoPilotConfig struct {
 }
 
 type torConfig struct {
-	Active           bool   `long:"active" description:"Allow outbound and inbound connections to be routed through Tor"`
-	SOCKS            string `long:"socks" description:"The host:port that Tor's exposed SOCKS5 proxy is listening on"`
-	DNS              string `long:"dns" description:"The DNS server as host:port that Tor will use for SRV queries - NOTE must have TCP resolution enabled"`
-	StreamIsolation  bool   `long:"streamisolation" description:"Enable Tor stream isolation by randomizing user credentials for each connection."`
-	Control          string `long:"control" description:"The host:port that Tor is listening on for Tor control connections"`
-	V2               bool   `long:"v2" description:"Automatically set up a v2 onion service to listen for inbound connections"`
-	V2PrivateKeyPath string `long:"v2privatekeypath" description:"The path to the private key of the onion service being created"`
-	V3               bool   `long:"v3" description:"Use a v3 onion service to listen for inbound connections"`
+	Active          bool   `long:"active" description:"Allow outbound and inbound connections to be routed through Tor"`
+	SOCKS           string `long:"socks" description:"The host:port that Tor's exposed SOCKS5 proxy is listening on"`
+	DNS             string `long:"dns" description:"The DNS server as host:port that Tor will use for SRV queries - NOTE must have TCP resolution enabled"`
+	StreamIsolation bool   `long:"streamisolation" description:"Enable Tor stream isolation by randomizing user credentials for each connection."`
+	Control         string `long:"control" description:"The host:port that Tor is listening on for Tor control connections"`
+	V2              bool   `long:"v2" description:"Automatically set up a v2 onion service to listen for inbound connections"`
+	V3              bool   `long:"v3" description:"Automatically set up a v3 onion service to listen for inbound connections"`
+	PrivateKeyPath  string `long:"privatekeypath" description:"The path to the private key of the onion service being created"`
 }
 
 // config defines the configuration options for lnd.
@@ -304,10 +304,9 @@ func loadConfig() (*config, error) {
 		Color:               defaultColor,
 		MinChanSize:         int64(minChanFundingSize),
 		Tor: &torConfig{
-			SOCKS:            defaultTorSOCKS,
-			DNS:              defaultTorDNS,
-			Control:          defaultTorControl,
-			V2PrivateKeyPath: defaultTorV2PrivateKeyPath,
+			SOCKS:   defaultTorSOCKS,
+			DNS:     defaultTorDNS,
+			Control: defaultTorControl,
 		},
 		net: &tor.ClearNet{},
 	}
@@ -363,7 +362,6 @@ func loadConfig() (*config, error) {
 		cfg.TLSCertPath = filepath.Join(lndDir, defaultTLSCertFilename)
 		cfg.TLSKeyPath = filepath.Join(lndDir, defaultTLSKeyFilename)
 		cfg.LogDir = filepath.Join(lndDir, defaultLogDirname)
-		cfg.Tor.V2PrivateKeyPath = filepath.Join(lndDir, defaultTorV2PrivateKeyFilename)
 	}
 
 	// Create the lnd directory if it doesn't already exist.
@@ -399,7 +397,7 @@ func loadConfig() (*config, error) {
 	cfg.LtcdMode.Dir = cleanAndExpandPath(cfg.LtcdMode.Dir)
 	cfg.BitcoindMode.Dir = cleanAndExpandPath(cfg.BitcoindMode.Dir)
 	cfg.LitecoindMode.Dir = cleanAndExpandPath(cfg.LitecoindMode.Dir)
-	cfg.Tor.V2PrivateKeyPath = cleanAndExpandPath(cfg.Tor.V2PrivateKeyPath)
+	cfg.Tor.PrivateKeyPath = cleanAndExpandPath(cfg.Tor.PrivateKeyPath)
 
 	// Ensure that the user didn't attempt to specify negative values for
 	// any of the autopilot params.
@@ -488,6 +486,19 @@ func loadConfig() (*config, error) {
 		// Therefore, we'll disable listening in order to avoid
 		// inadvertent leaks.
 		cfg.DisableListen = true
+	}
+
+	if cfg.Tor.PrivateKeyPath == "" {
+		switch {
+		case cfg.Tor.V2:
+			cfg.Tor.PrivateKeyPath = filepath.Join(
+				lndDir, defaultTorV2PrivateKeyFilename,
+			)
+		case cfg.Tor.V3:
+			cfg.Tor.PrivateKeyPath = filepath.Join(
+				lndDir, defaultTorV3PrivateKeyFilename,
+			)
+		}
 	}
 
 	// Set up the network-related functions that will be used throughout

--- a/docs/configuring_tor.md
+++ b/docs/configuring_tor.md
@@ -15,19 +15,14 @@ advertised IP address. Additionally, leaf nodes can also protect their location
 by using Tor for anonymous networking to establish connections.
 
 With widespread usage of Onion Services within the network, concerns about the
-difficulty of proper NAT traversal are alleviated, as usage of Onion Services
-allows nodes to accept inbound connections even if they're behind a NAT.
+difficulty of proper NAT traversal are alleviated, as usage of onion services
+allows nodes to accept inbound connections even if they're behind a NAT. At the
+time of writing this documentation, `lnd` supports both types of onion services:
+v2 and v3.
 
-At the time of writing this documentation, `lnd` supports both types of onion
-services: v2 and v3. However, only v2 onion services can automatically be
-created and set up by `lnd` until Tor Control support for v3 onion services is
-implemented in the stable release of the Tor daemon. v3 onion services can be
-used as long as they are set up manually. We'll cover the steps on how to do
-these things below.
-
-Before following the remainder of this documentation, you should ensure that
-you already have Tor installed locally. Official instructions to install the
-latest release of Tor can be found
+Before following the remainder of this documentation, you should ensure that you
+already have Tor installed locally. Official instructions to install the latest
+release of Tor can be found
 [here](https://www.torproject.org/docs/tor-doc-unix.html.en).
 
 **NOTE**: This documentation covers how to ensure that `lnd`'s _Lightning
@@ -80,13 +75,13 @@ At this point, we can now start `lnd` with the relevant arguments:
 
 Tor:
       --tor.active                                            Allow outbound and inbound connections to be routed through Tor
-      --tor.socks=                                            The port that Tor's exposed SOCKS5 proxy is listening on -- NOTE port must be between 1024 and 65535 (default: 9050)
-      --tor.dns=                                              The DNS server as IP:PORT that Tor will use for SRV queries - NOTE must have TCP resolution enabled (default: soa.nodes.lightning.directory:53)
+      --tor.socks=                                            The host:port that Tor's exposed SOCKS5 proxy is listening on (default: localhost:9050)
+      --tor.dns=                                              The DNS server as host:port that Tor will use for SRV queries - NOTE must have TCP resolution enabled (default: soa.nodes.lightning.directory:53)
       --tor.streamisolation                                   Enable Tor stream isolation by randomizing user credentials for each connection.
-      --tor.controlport=                                      The port that Tor is listening on for Tor control connections -- NOTE port must be between 1024 and 65535 (default: 9051)
+      --tor.control=                                          The host:port that Tor is listening on for Tor control connections (default: localhost:9051)
       --tor.v2                                                Automatically set up a v2 onion service to listen for inbound connections
-      --tor.v3                                                Use a v3 onion service to listen for inbound connections
-      --tor.privatekeypath=                                   The path to the private key of the onion service being created (default: /Users/user/Library/Application Support/Lnd/onion_private_key)
+      --tor.v3                                                Automatically set up a v3 onion service to listen for inbound connections
+      --tor.privatekeypath=                                   The path to the private key of the onion service being created
 ```
 
 There are a couple things here, so let's dissect them. The `--tor.active` flag
@@ -101,16 +96,18 @@ queries over Tor. So instead, we need to connect directly to the authoritative
 DNS server over TCP, in order query for `SRV` records that we can use to
 bootstrap our connections.
 
-Inbound connections are possible due to `lnd` automatically creating a v2 onion
+Inbound connections are possible due to `lnd` automatically creating an onion
 service. A path to save the onion service's private key can be specified with
-the `--tor.privatekeypath` flag. A v3 onion service can also be used, but it
-must be created manually. We'll expand on how this works in [Listening for
-Inbound Connections](#listening-for-inbound-connections).
+the `--tor.privatekeypath` flag.
 
 Most of these arguments have defaults, so as long as they apply to you, routing
-all outbound and inbound connections through Tor can simply be done with:
+all outbound and inbound connections through Tor can simply be done with either
+v2 or v3 onion services:
 ```shell
 ⛰  ./lnd --tor.active --tor.v2
+```
+```shell
+⛰  ./lnd --tor.active --tor.v3
 ```
 
 Outbound support only can also be used with:
@@ -118,8 +115,8 @@ Outbound support only can also be used with:
 ⛰  ./lnd --tor.active
 ```
 
-This will allow you to make all outgoing connections over Tor, but still allow
-regular (clearnet) incoming connections.
+This will allow you to make all outgoing connections over Tor. Listening is
+disabled to prevent inadvertent leaks.
 
 ## Tor Stream Isolation
 
@@ -138,50 +135,24 @@ specification of an additional argument:
 ## Listening for Inbound Connections
 
 In order to listen for inbound connections through Tor, an onion service must be
-created. There are two types of onion services: v2 and v3.
+created. There are two types of onion services: v2 and v3. v3 onion services
+are the latest generation of onion services and they provide a number of
+advantages over the legacy v2 onion services. To learn more about these
+benefits, see [Intro to Next Gen Onion Services](https://trac.torproject.org/projects/tor/wiki/doc/NextGenOnions).
 
-### v2 Onion Services
+Both types can be created and used automatically by `lnd`. Specifying which type
+should be used can easily be done by either using the `tor.v2` or `tor.v3` flag.
 
-v2 onion services can be created automatically by `lnd` and are currently the
-default. To do so, run `lnd` with the following arguments:
+For example, v3 onion services can be used with the following flags:
 ```
-⛰  ./lnd --tor.active --tor.v2
+⛰  ./lnd --tor.active --tor.v3
 ```
 
 This will automatically create a hidden service for your node to use to listen
 for inbound connections and advertise itself to the network. The onion service's
-private key is saved to a file named `onion_private_key` in `lnd`'s base
-directory. This will allow `lnd` to recreate the same hidden service upon
+private key is saved to a file named `v2_onion_private_key` or
+`v3_onion_private_key` depending on the type of onion service used in `lnd`'s
+base directory. This will allow `lnd` to recreate the same hidden service upon
 restart. If you wish to generate a new onion service, you can simply delete this
 file. The path to this private key file can also be modified with the
 `--tor.privatekeypath` argument.
-
-### v3 Onion Services
-
-v3 onion services are the latest generation of onion services and they provide a
-number of advantages over the legacy v2 onion services. To learn more about
-these benefits, see [Intro to Next Gen Onion Services](https://trac.torproject.org/projects/tor/wiki/doc/NextGenOnions).
-
-Unfortunately, at the time of writing this, v3 onion service support is still
-at an alpha level in the Tor daemon, so we're unable to automatically set them
-up within `lnd` unlike with v2 onion services. However, they can still be run
-manually! To do so, append the following lines to the torrc sample from above:
-```
-HiddenServiceDir PATH_TO_HIDDEN_SERVICE
-HiddenServiceVersion 3
-HiddenServicePort PORT_ONION_SERVICE_LISTENS_ON ADDRESS_LND_LISTENS_ON
-```
-
-If needed, instructions on how to set up a v3 onion service manually can be
-found [here](https://trac.torproject.org/projects/tor/wiki/doc/NextGenOnions#Howtosetupyourownprop224service).
-
-Once the v3 onion service is set up, `lnd` is able to use it to listen for
-inbound connections. You'll also need the onion service's hostname in order to
-advertise your node to the network. To do so, run `lnd` with the following
-arguments:
-```
-⛰  ./lnd --tor.active --tor.v3 --externalip=ONION_SERVICE_HOSTNAME
-```
-
-Once v3 onion service support is stable, `lnd` will be updated to also
-automatically set up v3 onion services.

--- a/tor/controller_test.go
+++ b/tor/controller_test.go
@@ -1,0 +1,68 @@
+package tor
+
+import "testing"
+
+// TestParseTorVersion is a series of tests for different version strings that
+// check the correctness of determining whether they support creating v3 onion
+// services through Tor control's port.
+func TestParseTorVersion(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		version string
+		valid   bool
+	}{
+		{
+			version: "0.3.3.6",
+			valid:   true,
+		},
+		{
+			version: "0.3.3.7",
+			valid:   true,
+		},
+		{
+			version: "0.3.4.6",
+			valid:   true,
+		},
+		{
+			version: "0.4.3.6",
+			valid:   true,
+		},
+		{
+			version: "1.3.3.6",
+			valid:   true,
+		},
+		{
+			version: "0.3.3.6-rc",
+			valid:   true,
+		},
+		{
+			version: "0.3.3.7-rc",
+			valid:   true,
+		},
+		{
+			version: "0.3.3.5-rc",
+			valid:   false,
+		},
+		{
+			version: "0.3.3.5",
+			valid:   false,
+		},
+		{
+			version: "0.3.2.6",
+			valid:   false,
+		},
+		{
+			version: "0.1.3.6",
+			valid:   false,
+		},
+	}
+
+	for i, test := range tests {
+		err := supportsV3(test.version)
+		if test.valid != (err == nil) {
+			t.Fatalf("test %d with version string %v failed: %v", i,
+				test.version, err)
+		}
+	}
+}


### PR DESCRIPTION
As of Tor version `0.3.3.6`, support has been added to create v3 onion services through Tor's control port. In this PR, we extend our current Tor controller implementation to support this.