### PR TITLE
tests: extend integration tests to grab snapshot of active goroutines on failure

### DIFF
--- a/lntest/node.go
+++ b/lntest/node.go
@@ -188,6 +188,9 @@ type HarnessNode struct {
 	// NodeID is a unique identifier for the node within a NetworkHarness.
 	NodeID int
 
+	//TestPort is port which allows us to obtain valuable debug information
+	TestPort int
+
 	// PubKey is the serialized compressed identity public key of the node.
 	// This field will only be populated once the node itself has been
 	// started via the start() method.
@@ -252,6 +255,7 @@ func newNode(cfg nodeConfig) (*HarnessNode, error) {
 		cfg:               &cfg,
 		NodeID:            nodeNum,
 		chanWatchRequests: make(chan *chanWatchRequest),
+		TestPort:          9000 + nodeNum,
 		openChans:         make(map[wire.OutPoint]int),
 		openClients:       make(map[wire.OutPoint][]chan struct{}),
 


### PR DESCRIPTION
Closes: https://github.com/lightningnetwork/lnd/issues/1219
Short description: upon test failures, scan through all active nodes, hit their profile page, write it to disk using a similar naming scheme as to the regular set of logs.