### PR TITLE
channeldb: add new migration to finalize invoice migration for outgoi…

### DIFF
--- a/channeldb/db.go
+++ b/channeldb/db.go
@@ -53,6 +53,12 @@ var (
 			number:    2,
 			migration: migrateInvoiceTimeSeries,
 		},
+		{
+			// The DB version that updated the embedded invoice in
+			// outgoing payments to match the new format.
+			number:    3,
+			migration: migrateInvoiceTimeSeriesOutgoingPayments,
+		},
 	}
 
 	// Big endian is the preferred byte order, due to cursor scans over


### PR DESCRIPTION
…ng payments

In this commit, we migrate the database away from a partially migrated
state. In a prior commit, we migrated the database in order to update
the Invoice struct with three new fields: add index, settle index, paid
amt.  However, it was overlooked that the OutgoingPayment struct also
embedded an Invoice within it. As a result, nodes that upgraded to the
first migration found themselves unable to start up, or call
listpayments, as the internal invoice within the OutgoignPayment hadn't
yet been updated.  This would result in an OOM typically as we went to
allocate a slice with a integer that should have been small, but may
have ended up actually being a set of random bytes, so a very large
number.

In this commit, we finish the DB migration by also migrating the
internal invoice within each OutgoingPayment.

Fixes #1538.
Fixes #1546.