### PR TITLE
release: create source archive with vendor folder

### DIFF
--- a/release.sh
+++ b/release.sh
@@ -21,6 +21,16 @@ MAINDIR=$PACKAGE-$TAG
 mkdir -p $MAINDIR
 cd $MAINDIR
 
+
+# Create source archive with vendor folder
+SRCARCHIVE="$PACKAGE-source-$TAG"
+make dep
+git -C .. archive --prefix="$SRCARCHIVE/" HEAD | tar xf -
+cp -R ../vendor $SRCARCHIVE/
+tar czf "$SRCARCHIVE.tar.gz" "$SRCARCHIVE/"
+rm -rf $SRCARCHIVE
+
+
 SYS="windows-386 windows-amd64 openbsd-386 openbsd-amd64 linux-386 linux-amd64 linux-arm linux-arm64 darwin-386 darwin-amd64 dragonfly-amd64 freebsd-386 freebsd-amd64 freebsd-arm netbsd-386 netbsd-amd64 linux-mips64 linux-mips64le linux-ppc64 linux-arm64"
 
 # Use the first element of $GOPATH in the case where GOPATH is a list


### PR DESCRIPTION
This will allow for easier integration into port frameworks like the OpenBSD one.

Tested on OpenBSD and Ubuntu Linux this time.

Thanks,
Fabian


Fixes #1550.