### PR TITLE
Btcd depends on glide

### DIFF
--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -120,6 +120,11 @@ On FreeBSD, use gmake instead of make.
 
 To install btcd, run the following commands:
 
+Install [**Glide**](https://github.com/Masterminds/glide), [btcd's](https://github.com/btcsuite/btcd) dependency management tool:
+```
+curl https://glide.sh/get | sh
+```
+
 Install **btcd**:
 ```
 make btcd


### PR DESCRIPTION
Part of these instructions are to `make btcd` which depends on glide. This step fails if glide is not present on the machine we're using to setup lnd.