### PR TITLE
multi: share the same bitcoind connection between multiple rescan clients

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -12,7 +12,7 @@
     "internal/modes",
   ]
   pruneopts = "UT"
-  revision = "e06297f34865a50b8e473105e52cb64ad1b55da8"
+  revision = "c0276d75487ef7aceab140c9eb31601dd7d18bd4"
 
 [[projects]]
   branch = "master"
@@ -46,14 +46,14 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:9968b12a9d89a2f0aff1e67b36544002d86f35757253055289ecb6051c4081b1"
+  digest = "1:e05c7b72aeba7570b1d2f9c6dc9f0373d224b16b70fa886c504de867bffe1c2e"
   name = "github.com/aead/chacha20"
   packages = [
     ".",
     "chacha",
   ]
   pruneopts = "UT"
-  revision = "e2538746bfea853aaa589feb8ec46bd46ee78f86"
+  revision = "8b13a72661dae6e9e5dea04f344f0dc95ea29547"
 
 [[projects]]
   branch = "master"
@@ -120,7 +120,7 @@
   revision = "ab6388e0c60ae4834a1f57511e20c17b5f78be4b"
 
 [[projects]]
-  digest = "1:9fd2a2efb76ddbde252f60de59aa921e3995ca1a477102b570dff963fd43d4b2"
+  digest = "1:a9bb59675f2aa863eff2bab6f0668b5e6feacaf6b7978fe5a654b068d5ca8e36"
   name = "github.com/btcsuite/btcwallet"
   packages = [
     "chain",
@@ -140,7 +140,7 @@
     "wtxmgr",
   ]
   pruneopts = "UT"
-  revision = "a4d9da433fcfaeec50d3e9657e6d511d14cddadf"
+  revision = "1ede0a1a66bad8f7db796615e496a0a0faba5182"
 
 [[projects]]
   branch = "master"
@@ -298,10 +298,9 @@
   revision = "ac4d9da8f1d67c95f1fafdc65e1a4902d6f5a940"
 
 [[projects]]
-  digest = "1:9acb4594b6cbb2658faebd72023de1e6b8a2b9af05384b97033771dfcd2e9f9d"
+  digest = "1:9e09c46058b3f1456c2690bd853ecd769fce3df943f7883fba64cb8f2be34f33"
   name = "github.com/ltcsuite/ltcd"
   packages = [
-    "btcjson",
     "chaincfg",
     "chaincfg/chainhash",
     "wire",
@@ -384,7 +383,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:29581da029e6dfb8e5ad30790fc66f9b59ba43805b66d840ea84000027175073"
+  digest = "1:01b240e338435648db3155614b819aa03735c3e7920712f32638f53272895bfb"
   name = "golang.org/x/sys"
   packages = [
     "cpu",
@@ -392,7 +391,7 @@
     "windows",
   ]
   pruneopts = "UT"
-  revision = "56ede360ec1c541828fb88741b3f1049406d28f5"
+  revision = "904bdc257025c7b3f43c19360ad3ab85783fad78"
 
 [[projects]]
   digest = "1:436b24586f8fee329e0dd65fd67c817681420cda1d7f934345c13fe78c212a73"
@@ -534,7 +533,6 @@
     "github.com/kkdai/bstream",
     "github.com/lightninglabs/neutrino",
     "github.com/lightningnetwork/lightning-onion",
-    "github.com/ltcsuite/ltcd/btcjson",
     "github.com/ltcsuite/ltcd/chaincfg",
     "github.com/ltcsuite/ltcd/wire",
     "github.com/miekg/dns",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -72,7 +72,7 @@
 
 [[constraint]]
   name = "github.com/btcsuite/btcwallet"
-  revision = "a4d9da433fcfaeec50d3e9657e6d511d14cddadf"
+  revision = "1ede0a1a66bad8f7db796615e496a0a0faba5182"
 
 [[constraint]]
   name = "github.com/tv42/zbase32"

--- a/chainntnfs/bitcoindnotify/driver.go
+++ b/chainntnfs/bitcoindnotify/driver.go
@@ -3,38 +3,25 @@ package bitcoindnotify
 import (
 	"fmt"
 
-	"github.com/btcsuite/btcd/chaincfg"
-	"github.com/btcsuite/btcd/rpcclient"
+	"github.com/btcsuite/btcwallet/chain"
 	"github.com/lightningnetwork/lnd/chainntnfs"
 )
 
 // createNewNotifier creates a new instance of the ChainNotifier interface
 // implemented by BitcoindNotifier.
 func createNewNotifier(args ...interface{}) (chainntnfs.ChainNotifier, error) {
-	if len(args) != 3 {
+	if len(args) != 1 {
 		return nil, fmt.Errorf("incorrect number of arguments to "+
-			".New(...), expected 3, instead passed %v", len(args))
+			".New(...), expected 1, instead passed %v", len(args))
 	}
 
-	config, ok := args[0].(*rpcclient.ConnConfig)
+	chainConn, ok := args[0].(*chain.BitcoindConn)
 	if !ok {
-		return nil, fmt.Errorf("first argument to bitcoindnotifier." +
-			"New is incorrect, expected a *rpcclient.ConnConfig")
+		return nil, fmt.Errorf("first argument to bitcoindnotify.New " +
+			"is incorrect, expected a *chain.BitcoindConn")
 	}
 
-	zmqConnect, ok := args[1].(string)
-	if !ok {
-		return nil, fmt.Errorf("second argument to bitcoindnotifier." +
-			"New is incorrect, expected a string")
-	}
-
-	params, ok := args[2].(chaincfg.Params)
-	if !ok {
-		return nil, fmt.Errorf("third argument to bitcoindnotifier." +
-			"New is incorrect, expected a chaincfg.Params")
-	}
-
-	return New(config, zmqConnect, params)
+	return New(chainConn), nil
 }
 
 // init registers a driver for the BtcdNotifier concrete implementation of the

--- a/config.go
+++ b/config.go
@@ -133,11 +133,12 @@ type btcdConfig struct {
 }
 
 type bitcoindConfig struct {
-	Dir     string `long:"dir" description:"The base directory that contains the node's data, logs, configuration file, etc."`
-	RPCHost string `long:"rpchost" description:"The daemon's rpc listening address. If a port is omitted, then the default port for the selected chain parameters will be used."`
-	RPCUser string `long:"rpcuser" description:"Username for RPC connections"`
-	RPCPass string `long:"rpcpass" default-mask:"-" description:"Password for RPC connections"`
-	ZMQPath string `long:"zmqpath" description:"The path to the ZMQ socket providing at least raw blocks. Raw transactions can be handled as well."`
+	Dir            string `long:"dir" description:"The base directory that contains the node's data, logs, configuration file, etc."`
+	RPCHost        string `long:"rpchost" description:"The daemon's rpc listening address. If a port is omitted, then the default port for the selected chain parameters will be used."`
+	RPCUser        string `long:"rpcuser" description:"Username for RPC connections"`
+	RPCPass        string `long:"rpcpass" default-mask:"-" description:"Password for RPC connections"`
+	ZMQPubRawBlock string `long:"zmqpubrawblock" description:"The address listening for ZMQ connections to deliver raw block notifications"`
+	ZMQPubRawTx    string `long:"zmqpubrawtx" description:"The address listening for ZMQ connections to deliver raw transaction notifications"`
 }
 
 type autoPilotConfig struct {
@@ -1057,8 +1058,12 @@ func parseRPCParams(cConfig *chainConfig, nodeConfig interface{}, net chainCode,
 		switch net {
 		case bitcoinChain:
 			daemonName = "btcd"
+			confDir = conf.Dir
+			confFile = "btcd"
 		case litecoinChain:
 			daemonName = "ltcd"
+			confDir = conf.Dir
+			confFile = "ltcd"
 		}
 
 		// If only ONE of RPCUser or RPCPass is set, we assume the
@@ -1068,18 +1073,11 @@ func parseRPCParams(cConfig *chainConfig, nodeConfig interface{}, net chainCode,
 				"%[1]v.rpcuser, %[1]v.rpcpass", daemonName)
 		}
 
-		switch net {
-		case bitcoinChain:
-			confDir = conf.Dir
-			confFile = "btcd"
-		case litecoinChain:
-			confDir = conf.Dir
-			confFile = "ltcd"
-		}
 	case *bitcoindConfig:
-		// If all of RPCUser, RPCPass, and ZMQPath are set, we assume
-		// those parameters are good to use.
-		if conf.RPCUser != "" && conf.RPCPass != "" && conf.ZMQPath != "" {
+		// If all of RPCUser, RPCPass, ZMQBlockHost, and ZMQTxHost are
+		// set, we assume those parameters are good to use.
+		if conf.RPCUser != "" && conf.RPCPass != "" &&
+			conf.ZMQPubRawBlock != "" && conf.ZMQPubRawTx != "" {
 			return nil
 		}
 
@@ -1087,24 +1085,23 @@ func parseRPCParams(cConfig *chainConfig, nodeConfig interface{}, net chainCode,
 		switch net {
 		case bitcoinChain:
 			daemonName = "bitcoind"
-		case litecoinChain:
-			daemonName = "litecoind"
-		}
-		// If only one or two of the parameters are set, we assume the
-		// user did that unintentionally.
-		if conf.RPCUser != "" || conf.RPCPass != "" || conf.ZMQPath != "" {
-			return fmt.Errorf("please set all or none of "+
-				"%[1]v.rpcuser, %[1]v.rpcpass, "+
-				"and %[1]v.zmqpath", daemonName)
-		}
-
-		switch net {
-		case bitcoinChain:
 			confDir = conf.Dir
 			confFile = "bitcoin"
 		case litecoinChain:
+			daemonName = "litecoind"
 			confDir = conf.Dir
 			confFile = "litecoin"
+		}
+
+		// If only one or two of the parameters are set, we assume the
+		// user did that unintentionally.
+		if conf.RPCUser != "" || conf.RPCPass != "" ||
+			conf.ZMQPubRawBlock != "" || conf.ZMQPubRawTx != "" {
+
+			return fmt.Errorf("please set all or none of "+
+				"%[1]v.rpcuser, %[1]v.rpcpass, "+
+				"%[1]v.zmqpubrawblock, %[1]v.zmqpubrawtx",
+				daemonName)
 		}
 	}
 
@@ -1132,13 +1129,15 @@ func parseRPCParams(cConfig *chainConfig, nodeConfig interface{}, net chainCode,
 		nConf.RPCUser, nConf.RPCPass = rpcUser, rpcPass
 	case "bitcoind", "litecoind":
 		nConf := nodeConfig.(*bitcoindConfig)
-		rpcUser, rpcPass, zmqPath, err := extractBitcoindRPCParams(confFile)
+		rpcUser, rpcPass, zmqBlockHost, zmqTxHost, err :=
+			extractBitcoindRPCParams(confFile)
 		if err != nil {
 			return fmt.Errorf("unable to extract RPC credentials:"+
 				" %v, cannot start w/o RPC connection",
 				err)
 		}
-		nConf.RPCUser, nConf.RPCPass, nConf.ZMQPath = rpcUser, rpcPass, zmqPath
+		nConf.RPCUser, nConf.RPCPass = rpcUser, rpcPass
+		nConf.ZMQPubRawBlock, nConf.ZMQPubRawTx = zmqBlockHost, zmqTxHost
 	}
 
 	fmt.Printf("Automatically obtained %v's RPC credentials\n", daemonName)
@@ -1196,13 +1195,12 @@ func extractBtcdRPCParams(btcdConfigPath string) (string, string, error) {
 // location of bitcoind's bitcoin.conf on the target system. The routine looks
 // for a cookie first, optionally following the datadir configuration option in
 // the bitcoin.conf. If it doesn't find one, it looks for rpcuser/rpcpassword.
-func extractBitcoindRPCParams(bitcoindConfigPath string) (string, string, string, error) {
-
+func extractBitcoindRPCParams(bitcoindConfigPath string) (string, string, string, string, error) {
 	// First, we'll open up the bitcoind configuration file found at the
 	// target destination.
 	bitcoindConfigFile, err := os.Open(bitcoindConfigPath)
 	if err != nil {
-		return "", "", "", err
+		return "", "", "", "", err
 	}
 	defer bitcoindConfigFile.Close()
 
@@ -1210,18 +1208,36 @@ func extractBitcoindRPCParams(bitcoindConfigPath string) (string, string, string
 	// we can attempt to locate the RPC credentials.
 	configContents, err := ioutil.ReadAll(bitcoindConfigFile)
 	if err != nil {
-		return "", "", "", err
+		return "", "", "", "", err
 	}
 
-	// First, we look for the ZMQ path for raw blocks. If raw transactions
-	// are sent over this interface, we can also get unconfirmed txs.
-	zmqPathRE, err := regexp.Compile(`(?m)^\s*zmqpubrawblock\s*=\s*([^\s]+)`)
+	// First, we'll look for the ZMQ hosts providing raw block and raw
+	// transaction notifications.
+	zmqBlockHostRE, err := regexp.Compile(
+		`(?m)^\s*zmqpubrawblock\s*=\s*([^\s]+)`,
+	)
 	if err != nil {
-		return "", "", "", err
+		return "", "", "", "", err
 	}
-	zmqPathSubmatches := zmqPathRE.FindSubmatch(configContents)
-	if len(zmqPathSubmatches) < 2 {
-		return "", "", "", fmt.Errorf("unable to find zmqpubrawblock in config")
+	zmqBlockHostSubmatches := zmqBlockHostRE.FindSubmatch(configContents)
+	if len(zmqBlockHostSubmatches) < 2 {
+		return "", "", "", "", fmt.Errorf("unable to find " +
+			"zmqpubrawblock in config")
+	}
+	zmqTxHostRE, err := regexp.Compile(`(?m)^\s*zmqpubrawtx\s*=\s*([^\s]+)`)
+	if err != nil {
+		return "", "", "", "", err
+	}
+	zmqTxHostSubmatches := zmqTxHostRE.FindSubmatch(configContents)
+	if len(zmqTxHostSubmatches) < 2 {
+		return "", "", "", "", errors.New("unable to find zmqpubrawtx " +
+			"in config")
+	}
+	zmqBlockHost := string(zmqBlockHostSubmatches[1])
+	zmqTxHost := string(zmqTxHostSubmatches[1])
+	if zmqBlockHost == zmqTxHost {
+		return "", "", "", "", errors.New("zmqpubrawblock and " +
+			"zmqpubrawtx must be different")
 	}
 
 	// Next, we'll try to find an auth cookie. We need to detect the chain
@@ -1229,7 +1245,7 @@ func extractBitcoindRPCParams(bitcoindConfigPath string) (string, string, string
 	dataDir := path.Dir(bitcoindConfigPath)
 	dataDirRE, err := regexp.Compile(`(?m)^\s*datadir\s*=\s*([^\s]+)`)
 	if err != nil {
-		return "", "", "", err
+		return "", "", "", "", err
 	}
 	dataDirSubmatches := dataDirRE.FindSubmatch(configContents)
 	if dataDirSubmatches != nil {
@@ -1250,8 +1266,8 @@ func extractBitcoindRPCParams(bitcoindConfigPath string) (string, string, string
 	if err == nil {
 		splitCookie := strings.Split(string(cookie), ":")
 		if len(splitCookie) == 2 {
-			return splitCookie[0], splitCookie[1],
-				string(zmqPathSubmatches[1]), nil
+			return splitCookie[0], splitCookie[1], zmqBlockHost,
+				zmqTxHost, nil
 		}
 	}
 
@@ -1260,11 +1276,12 @@ func extractBitcoindRPCParams(bitcoindConfigPath string) (string, string, string
 	// expression then we'll exit with an error.
 	rpcUserRegexp, err := regexp.Compile(`(?m)^\s*rpcuser\s*=\s*([^\s]+)`)
 	if err != nil {
-		return "", "", "", err
+		return "", "", "", "", err
 	}
 	userSubmatches := rpcUserRegexp.FindSubmatch(configContents)
 	if userSubmatches == nil {
-		return "", "", "", fmt.Errorf("unable to find rpcuser in config")
+		return "", "", "", "", fmt.Errorf("unable to find rpcuser in " +
+			"config")
 	}
 
 	// Similarly, we'll use another regular expression to find the set
@@ -1272,15 +1289,16 @@ func extractBitcoindRPCParams(bitcoindConfigPath string) (string, string, string
 	// error.
 	rpcPassRegexp, err := regexp.Compile(`(?m)^\s*rpcpassword\s*=\s*([^\s]+)`)
 	if err != nil {
-		return "", "", "", err
+		return "", "", "", "", err
 	}
 	passSubmatches := rpcPassRegexp.FindSubmatch(configContents)
 	if passSubmatches == nil {
-		return "", "", "", fmt.Errorf("unable to find rpcpassword in config")
+		return "", "", "", "", fmt.Errorf("unable to find rpcpassword " +
+			"in config")
 	}
 
 	return string(userSubmatches[1]), string(passSubmatches[1]),
-		string(zmqPathSubmatches[1]), nil
+		zmqBlockHost, zmqTxHost, nil
 }
 
 // normalizeNetwork returns the common name of a network type used to create

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -240,10 +240,10 @@ the following:
   ([this has now been fixed](https://github.com/Homebrew/homebrew-core/pull/23088) 
   in the latest Homebrew recipe for bitcoin)
 - Configure the `bitcoind` instance for ZMQ with `--zmqpubrawblock` and
-  `--zmqpubrawtx` (the latter is optional but allows you to see unconfirmed
-  transactions in your wallet). They must be combined in the same ZMQ socket
-  address (e.g. `--zmqpubrawblock=tcp://127.0.0.1:28332` and
-  `--zmqpubrawtx=tcp://127.0.0.1:28332`).
+  `--zmqpubrawtx`. These options must each use their own unique address in order
+  to provide a reliable delivery of notifications (e.g.
+  `--zmqpubrawblock=tcp://127.0.0.1:28332` and
+  `--zmqpubrawtx=tcp://127.0.0.1:28333`).
 - Start `bitcoind` running against testnet, and let it complete a full sync with
   the testnet chain (alternatively, use `--bitcoind.regtest` instead).
 
@@ -253,21 +253,43 @@ testnet=1
 server=1
 daemon=1
 zmqpubrawblock=tcp://127.0.0.1:28332
-zmqpubrawtx=tcp://127.0.0.1:28332
+zmqpubrawtx=tcp://127.0.0.1:28333
 ```
 
-Once all of the above is complete, and you've confirmed `bitcoind` is fully updated with the latest blocks on testnet, run the command below to launch `lnd` with `bitcoind` as your backend (as with `bitcoind`, you can create an `lnd.conf` to save these options, more info on that is described further below):
+Once all of the above is complete, and you've confirmed `bitcoind` is fully
+updated with the latest blocks on testnet, run the command below to launch `lnd`
+with `bitcoind` as your backend (as with `bitcoind`, you can create an
+`lnd.conf` to save these options, more info on that is described further below):
 
 ```
-lnd --bitcoin.active --bitcoin.testnet --debuglevel=debug --bitcoin.node=bitcoind --bitcoind.rpcuser=REPLACEME --bitcoind.rpcpass=REPLACEME --bitcoind.zmqpath=tcp://127.0.0.1:28332 --externalip=X.X.X.X
+lnd --bitcoin.active --bitcoin.testnet --debuglevel=debug --bitcoin.node=bitcoind --bitcoind.rpcuser=REPLACEME --bitcoind.rpcpass=REPLACEME --bitcoind.zmqpubrawblock=tcp://127.0.0.1:28332 --bitcoind.zmqpubrawblock=tcp://127.0.0.1:28333 --externalip=X.X.X.X
 ```
 
 *NOTE:*
-- The auth parameters `rpcuser` and `rpcpass` parameters can typically be determined by `lnd` for a `bitcoind` instance running under the same user, including when using cookie auth. In this case, you can exclude them from the `lnd` options entirely.
-- If you DO choose to explicitly pass the auth parameters in your `lnd.conf` or command line options for `lnd` (`bitcoind.rpcuser` and `bitcoind.rpcpass` as shown in example command above), you must also specify the `bitcoind.zmqpath` option. Otherwise, `lnd` will attempt to get the configuration from your `bitcoin.conf`.
-- You must ensure the same address (including port) is used for the `bitcoind.zmqpath` option passed to `lnd` as for the `zmqpubrawblock` and `zmqpubrawtx` passed in the `bitcoind` options.
-- When running lnd and bitcoind on the same Windows machine, ensure you use 127.0.0.1, not localhost, for all configuration options that require a TCP/IP host address.  If you use "localhost" as the host name, you may see extremely slow inter-process-communication between lnd and the bitcoind backend.  If lnd is experiencing this issue, you'll see "Waiting for chain backend to finish sync, start_height=XXXXXX" as the last entry in the console or log output, and lnd will appear to hang.  Normal lnd output will quickly show multiple messages like this as lnd consumes blocks from bitcoind.
-- Don't connect more than one instance of `lnd` to `bitcoind`.  With the default `bitcoind` settings, having more than one instance of `lnd`, or `lnd` plus any application that consumes the RPC could cause `lnd` to miss crucial updates from the backend.
+- The auth parameters `rpcuser` and `rpcpass` parameters can typically be
+  determined by `lnd` for a `bitcoind` instance running under the same user,
+  including when using cookie auth. In this case, you can exclude them from the
+  `lnd` options entirely.
+- If you DO choose to explicitly pass the auth parameters in your `lnd.conf` or
+  command line options for `lnd` (`bitcoind.rpcuser` and `bitcoind.rpcpass` as
+  shown in example command above), you must also specify the
+  `bitcoind.zmqpubrawblock` and `bitcoind.zmqpubrawtx` options. Otherwise, `lnd`
+  will attempt to get the configuration from your `bitcoin.conf`.
+- You must ensure the same addresses are used for the `bitcoind.zmqpubrawblock`
+  and `bitcoind.zmqpubrawtx` options passed to `lnd` as for the `zmqpubrawblock`
+  and `zmqpubrawtx` passed in the `bitcoind` options respectively.
+- When running lnd and bitcoind on the same Windows machine, ensure you use
+  127.0.0.1, not localhost, for all configuration options that require a TCP/IP
+  host address.  If you use "localhost" as the host name, you may see extremely
+  slow inter-process-communication between lnd and the bitcoind backend.  If lnd
+  is experiencing this issue, you'll see "Waiting for chain backend to finish
+  sync, start_height=XXXXXX" as the last entry in the console or log output, and
+  lnd will appear to hang.  Normal lnd output will quickly show multiple
+  messages like this as lnd consumes blocks from bitcoind.
+- Don't connect more than two or three instances of `lnd` to `bitcoind`. With
+  the default `bitcoind` settings, having more than one instance of `lnd`, or
+  `lnd` plus any application that consumes the RPC could cause `lnd` to miss
+  crucial updates from the backend.
 
 #### Disabling Wallet Encryption
 

--- a/sample-lnd.conf
+++ b/sample-lnd.conf
@@ -205,11 +205,11 @@ bitcoin.node=btcd
 ; (other than for a remote bitcoind instance).
 ; bitcoind.rpcpass=kek
 
-; ZMQ socket which sends rawblock and (optionally) rawtx notifications from
-; bitcoind. By default, lnd will attempt to automatically obtain this
-; information, so this likely won't need to be set (other than for a remote
-; bitcoind instance).
-; bitcoind.zmqpath=tcp://127.0.0.1:28332
+; ZMQ socket which sends rawblock and rawtx notifications from bitcoind. By
+; default, lnd will attempt to automatically obtain this information, so this
+; likely won't need to be set (other than for a remote bitcoind instance).
+; bitcoind.zmqblockhost=tcp://127.0.0.1:28332
+; bitcoind.zmqtxhost=tcp://127.0.0.1:28333
 
 
 [neutrino]
@@ -283,11 +283,11 @@ litecoin.node=ltcd
 ; (other than for a remote litecoind instance).
 ; litecoind.rpcpass=kek
 
-; ZMQ socket which sends rawblock and (optionally) rawtx notifications from
-; litecoind. By default, lnd will attempt to automatically obtain this
-; information, so this likely won't need to be set (other than for a remote
-; litecoind instance).
-; litecoind.zmqpath=tcp://127.0.0.1:28332
+; ZMQ socket which sends rawblock and rawtx notifications from litecoind. By
+; default, lnd will attempt to automatically obtain this information, so this
+; likely won't need to be set (other than for a remote litecoind instance).
+; litecoind.zmqblockhost=tcp://127.0.0.1:28332
+; litecoind.zmqtxhost=tcp://127.0.0.1:28333
 
 
 [autopilot]


### PR DESCRIPTION
In this PR, we introduce a nice optimization with regards to `lnd`'s interaction with a `bitcoind` backend. Within `lnd`, we currently have three different subsystems responsible for watching the chain: `chainntnfs`, `lnwallet`, and `routing/chainview`. Each of these subsystems has an active RPC and ZMQ connection to the underlying `bitcoind` node. This would incur a toll on the underlying `bitcoind` node and would cause us to miss ZMQ events, which are crucial to `lnd`. We remedy this issue by sharing the same connection to a `bitcoind` node between the different clients within `lnd`.

We now also require the backing `bitcoind` node to use different hosts to provide its ZMQ raw block and raw transaction notifications (`zmqpubrawblock` and `zmqpubrawtx`). This was needed as the notification queue maintained by the `bitcoind` node would sometimes overflow with transactions and would cause block notifications to be dropped/missed.

Depends on https://github.com/btcsuite/btcwallet/pull/511.
Fixes #1174.