### PR TITLE
AddInvoice: check for negative amt

### DIFF
--- a/rpcserver.go
+++ b/rpcserver.go
@@ -2445,6 +2445,12 @@ func (r *rpcServer) AddInvoice(ctx context.Context,
 			len(invoice.DescriptionHash), channeldb.MaxPaymentRequestSize)
 	}
 
+	// The value of the invoice must not be negative.
+	if invoice.Value < 0 {
+		return nil, fmt.Errorf("payments of negative value "+
+			"are not allowed, value is %v", invoice.Value)
+	}
+	
 	amt := btcutil.Amount(invoice.Value)
 	amtMSat := lnwire.NewMSatFromSatoshis(amt)
 


### PR DESCRIPTION
AddInvoice with zero or negative values result in a strange error message:
also negative values are implicitly converted to uint in NewMSatFromSatoshis(), that leads to incredibly high amounts.