### PR TITLE
invoiceregistry: make the invoice ntfn chan buffered

### DIFF
--- a/invoiceregistry.go
+++ b/invoiceregistry.go
@@ -64,7 +64,7 @@ func newInvoiceRegistry(cdb *channeldb.DB) *invoiceRegistry {
 		notificationClients: make(map[uint32]*invoiceSubscription),
 		newSubscriptions:    make(chan *invoiceSubscription),
 		subscriptionCancels: make(chan uint32),
-		invoiceEvents:       make(chan *invoiceEvent),
+		invoiceEvents:       make(chan *invoiceEvent, 100),
 		quit:                make(chan struct{}),
 	}
 }


### PR DESCRIPTION
In this commit, we update the main invoiceEvents channel within the
invoiceregistry to now have an initial buffer size of 100. We do this as
it's been reported by users that on start up they're unable to actually
create or settle invoices manually. Traces have shown that this is due
to contention while holding the invoice mutex. To attempt to solve this,
we add an additional buffer to the channel as most sends will now be
routinely non blocking.