### PR TITLE
multi: update primary interfaces to be compatible with latest version of BIP 158, use latest btcd+neutrino+btcwallet

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -79,7 +79,7 @@
     "txscript",
     "wire"
   ]
-  revision = "86fed781132ac890ee03e906e4ecd5d6fa180c64"
+  revision = "9a2f9524024889e129a5422aca2cff73cb3eabf6"
 
 [[projects]]
   name = "github.com/btcsuite/btclog"
@@ -97,7 +97,7 @@
     "hdkeychain",
     "txsort"
   ]
-  revision = "d4cc87b860166d00d6b5b9e0d3b3d71d6088d4d4"
+  revision = "ab6388e0c60ae4834a1f57511e20c17b5f78be4b"
 
 [[projects]]
   name = "github.com/btcsuite/btcwallet"
@@ -118,7 +118,7 @@
     "walletdb/bdb",
     "wtxmgr"
   ]
-  revision = "64b5b448f5e6853a2d870f388504a7807bc951f1"
+  revision = "a4d9da433fcfaeec50d3e9657e6d511d14cddadf"
 
 [[projects]]
   branch = "master"
@@ -231,7 +231,7 @@
     "filterdb",
     "headerfs"
   ]
-  revision = "03f4c660ea0d1586331f32561185d45eab1ba4c9"
+  revision = "d5054cea8fe43c324a473e8aa7e0f6dd93622125"
 
 [[projects]]
   name = "github.com/lightningnetwork/lightning-onion"
@@ -404,6 +404,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "7ac5bd06ab8aa8f6a01f191092ac37d1e33200f366fa3b52fb4152369d76c5be"
+  inputs-digest = "dcfe757e222cc26b43d926797fb0cb9f87a18da54dca6615e701eb715c35b375"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -44,7 +44,7 @@
 
 [[constraint]]
   name = "github.com/lightninglabs/neutrino"
-  revision = "03f4c660ea0d1586331f32561185d45eab1ba4c9"
+  revision = "d5054cea8fe43c324a473e8aa7e0f6dd93622125"
 
 [[constraint]]
   name = "github.com/lightningnetwork/lightning-onion"
@@ -64,15 +64,15 @@
 
 [[constraint]]
   name = "github.com/btcsuite/btcutil"
-  revision = "d4cc87b860166d00d6b5b9e0d3b3d71d6088d4d4"
+  revision = "ab6388e0c60ae4834a1f57511e20c17b5f78be4b"
 
 [[constraint]]
   name = "github.com/btcsuite/btcd"
-  revision = "86fed781132ac890ee03e906e4ecd5d6fa180c64"
+  revision = "9a2f9524024889e129a5422aca2cff73cb3eabf6"
 
 [[constraint]]
   name = "github.com/btcsuite/btcwallet"
-  revision = "64b5b448f5e6853a2d870f388504a7807bc951f1"
+  revision = "a4d9da433fcfaeec50d3e9657e6d511d14cddadf"
 
 [[constraint]]
   name = "github.com/tv42/zbase32"

--- a/breacharbiter.go
+++ b/breacharbiter.go
@@ -298,6 +298,7 @@ func convertToSecondLevelRevoke(bo *breachedOutput, breachInfo *retributionInfo,
 	newAmt := spendingTx.TxOut[0].Value
 	bo.amt = btcutil.Amount(newAmt)
 	bo.signDesc.Output.Value = newAmt
+	bo.signDesc.Output.PkScript = spendingTx.TxOut[0].PkScript
 
 	// Finally, we'll need to adjust the witness program in the
 	// SignDescriptor.

--- a/breacharbiter.go
+++ b/breacharbiter.go
@@ -196,8 +196,10 @@ func (b *breachArbiter) Start() error {
 		// Register for a notification when the breach transaction is
 		// confirmed on chain.
 		breachTXID := retInfo.commitHash
+		breachScript := retInfo.breachedOutputs[0].signDesc.Output.PkScript
 		confChan, err := b.cfg.Notifier.RegisterConfirmationsNtfn(
-			&breachTXID, 1, retInfo.breachHeight)
+			&breachTXID, breachScript, 1, retInfo.breachHeight,
+		)
 		if err != nil {
 			brarLog.Errorf("unable to register for conf updates "+
 				"for txid: %v, err: %v", breachTXID, err)
@@ -556,8 +558,10 @@ justiceTxBroadcast:
 	// notify the caller that initiated the retribution workflow that the
 	// deed has been done.
 	justiceTXID := finalTx.TxHash()
+	justiceScript := finalTx.TxOut[0].PkScript
 	confChan, err = b.cfg.Notifier.RegisterConfirmationsNtfn(
-		&justiceTXID, 1, breachConfHeight)
+		&justiceTXID, justiceScript, 1, breachConfHeight,
+	)
 	if err != nil {
 		brarLog.Errorf("unable to register for conf for txid(%v): %v",
 			justiceTXID, err)
@@ -720,8 +724,10 @@ func (b *breachArbiter) handleBreachHandoff(breachEvent *ContractBreachEvent) {
 	// confirmed in the chain to ensure we're not dealing with a moving
 	// target.
 	breachTXID := &retInfo.commitHash
-	cfChan, err := b.cfg.Notifier.RegisterConfirmationsNtfn(breachTXID, 1,
-		retInfo.breachHeight)
+	breachScript := retInfo.breachedOutputs[0].signDesc.Output.PkScript
+	cfChan, err := b.cfg.Notifier.RegisterConfirmationsNtfn(
+		breachTXID, breachScript, 1, retInfo.breachHeight,
+	)
 	if err != nil {
 		brarLog.Errorf("unable to register for conf updates for "+
 			"txid: %v, err: %v", breachTXID, err)

--- a/breacharbiter.go
+++ b/breacharbiter.go
@@ -360,6 +360,7 @@ func (b *breachArbiter) waitForSpendEvent(breachInfo *retributionInfo,
 			var err error
 			spendNtfn, err = b.cfg.Notifier.RegisterSpendNtfn(
 				&breachedOutput.outpoint,
+				breachedOutput.signDesc.Output.PkScript,
 				breachInfo.breachHeight,
 			)
 			if err != nil {

--- a/breacharbiter_test.go
+++ b/breacharbiter_test.go
@@ -18,7 +18,12 @@ import (
 	"testing"
 	"time"
 
+	"github.com/btcsuite/btcd/btcec"
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"github.com/btcsuite/btcd/txscript"
+	"github.com/btcsuite/btcd/wire"
 	"github.com/btcsuite/btclog"
+	"github.com/btcsuite/btcutil"
 	"github.com/go-errors/errors"
 	"github.com/lightningnetwork/lnd/chainntnfs"
 	"github.com/lightningnetwork/lnd/channeldb"
@@ -27,11 +32,6 @@ import (
 	"github.com/lightningnetwork/lnd/lnwallet"
 	"github.com/lightningnetwork/lnd/lnwire"
 	"github.com/lightningnetwork/lnd/shachain"
-	"github.com/btcsuite/btcd/btcec"
-	"github.com/btcsuite/btcd/chaincfg/chainhash"
-	"github.com/btcsuite/btcd/txscript"
-	"github.com/btcsuite/btcd/wire"
-	"github.com/btcsuite/btcutil"
 )
 
 var (

--- a/breacharbiter_test.go
+++ b/breacharbiter_test.go
@@ -1012,6 +1012,11 @@ func TestBreachHandoffSuccess(t *testing.T) {
 		ProcessACK: make(chan error, 1),
 		BreachRetribution: &lnwallet.BreachRetribution{
 			BreachTransaction: bobClose.CloseTx,
+			LocalOutputSignDesc: &lnwallet.SignDescriptor{
+				Output: &wire.TxOut{
+					PkScript: breachKeys[0],
+				},
+			},
 		},
 	}
 	contractBreaches <- breach
@@ -1039,6 +1044,11 @@ func TestBreachHandoffSuccess(t *testing.T) {
 		ProcessACK: make(chan error, 1),
 		BreachRetribution: &lnwallet.BreachRetribution{
 			BreachTransaction: bobClose.CloseTx,
+			LocalOutputSignDesc: &lnwallet.SignDescriptor{
+				Output: &wire.TxOut{
+					PkScript: breachKeys[0],
+				},
+			},
 		},
 	}
 
@@ -1083,6 +1093,11 @@ func TestBreachHandoffFail(t *testing.T) {
 		ProcessACK: make(chan error, 1),
 		BreachRetribution: &lnwallet.BreachRetribution{
 			BreachTransaction: bobClose.CloseTx,
+			LocalOutputSignDesc: &lnwallet.SignDescriptor{
+				Output: &wire.TxOut{
+					PkScript: breachKeys[0],
+				},
+			},
 		},
 	}
 	contractBreaches <- breach
@@ -1130,6 +1145,11 @@ func TestBreachHandoffFail(t *testing.T) {
 		ProcessACK: make(chan error, 1),
 		BreachRetribution: &lnwallet.BreachRetribution{
 			BreachTransaction: bobClose.CloseTx,
+			LocalOutputSignDesc: &lnwallet.SignDescriptor{
+				Output: &wire.TxOut{
+					PkScript: breachKeys[0],
+				},
+			},
 		},
 	}
 

--- a/chainntnfs/bitcoindnotify/bitcoind.go
+++ b/chainntnfs/bitcoindnotify/bitcoind.go
@@ -784,7 +784,7 @@ type confirmationNotification struct {
 // which will be triggered once the txid reaches numConfs number of
 // confirmations.
 func (b *BitcoindNotifier) RegisterConfirmationsNtfn(txid *chainhash.Hash,
-	numConfs, heightHint uint32) (*chainntnfs.ConfirmationEvent, error) {
+	_ []byte, numConfs, heightHint uint32) (*chainntnfs.ConfirmationEvent, error) {
 
 	ntfn := &confirmationNotification{
 		ConfNtfn: chainntnfs.ConfNtfn{

--- a/chainntnfs/bitcoindnotify/bitcoind.go
+++ b/chainntnfs/bitcoindnotify/bitcoind.go
@@ -577,7 +577,7 @@ type spendCancel struct {
 // across the 'Spend' channel. The heightHint should represent the earliest
 // height in the chain where the transaction could have been spent in.
 func (b *BitcoindNotifier) RegisterSpendNtfn(outpoint *wire.OutPoint,
-	heightHint uint32) (*chainntnfs.SpendEvent, error) {
+	pkScript []byte, heightHint uint32) (*chainntnfs.SpendEvent, error) {
 
 	ntfn := &spendNotification{
 		targetOutpoint: outpoint,

--- a/chainntnfs/btcdnotify/btcd.go
+++ b/chainntnfs/btcdnotify/btcd.go
@@ -695,7 +695,7 @@ type spendCancel struct {
 // across the 'Spend' channel. The heightHint should represent the earliest
 // height in the chain where the transaction could have been spent in.
 func (b *BtcdNotifier) RegisterSpendNtfn(outpoint *wire.OutPoint,
-	heightHint uint32) (*chainntnfs.SpendEvent, error) {
+	pkScript []byte, heightHint uint32) (*chainntnfs.SpendEvent, error) {
 
 	ntfn := &spendNotification{
 		targetOutpoint: outpoint,
@@ -710,6 +710,7 @@ func (b *BtcdNotifier) RegisterSpendNtfn(outpoint *wire.OutPoint,
 	case b.notificationRegistry <- ntfn:
 	}
 
+	// TODO(roasbeef): update btcd rescan logic to also use both
 	if err := b.chainConn.NotifySpent([]*wire.OutPoint{outpoint}); err != nil {
 		return nil, err
 	}

--- a/chainntnfs/btcdnotify/btcd.go
+++ b/chainntnfs/btcdnotify/btcd.go
@@ -822,7 +822,7 @@ type confirmationNotification struct {
 // RegisterConfirmationsNtfn registers a notification with BtcdNotifier
 // which will be triggered once the txid reaches numConfs number of
 // confirmations.
-func (b *BtcdNotifier) RegisterConfirmationsNtfn(txid *chainhash.Hash,
+func (b *BtcdNotifier) RegisterConfirmationsNtfn(txid *chainhash.Hash, _ []byte,
 	numConfs, heightHint uint32) (*chainntnfs.ConfirmationEvent, error) {
 
 	ntfn := &confirmationNotification{

--- a/chainntnfs/interface.go
+++ b/chainntnfs/interface.go
@@ -20,19 +20,21 @@ import (
 // resource
 type ChainNotifier interface {
 	// RegisterConfirmationsNtfn registers an intent to be notified once
-	// txid reaches numConfs confirmations. The returned ConfirmationEvent
-	// should properly notify the client once the specified number of
-	// confirmations has been reached for the txid, as well as if the
-	// original tx gets re-org'd out of the mainchain.  The heightHint
-	// parameter is provided as a convenience to light clients. The
-	// heightHint denotes the earliest height in the blockchain in which the
-	// target txid _could_ have been included in the chain.  This can be
-	// used to bound the search space when checking to see if a
-	// notification can immediately be dispatched due to historical data.
+	// txid reaches numConfs confirmations. We also pass in the pkScript as
+	// the default light client instead needs to match on scripts created
+	// in the block. The returned ConfirmationEvent should properly notify
+	// the client once the specified number of confirmations has been
+	// reached for the txid, as well as if the original tx gets re-org'd
+	// out of the mainchain.  The heightHint parameter is provided as a
+	// convenience to light clients. The heightHint denotes the earliest
+	// height in the blockchain in which the target txid _could_ have been
+	// included in the chain.  This can be used to bound the search space
+	// when checking to see if a notification can immediately be dispatched
+	// due to historical data.
 	//
 	// NOTE: Dispatching notifications to multiple clients subscribed to
 	// the same (txid, numConfs) tuple MUST be supported.
-	RegisterConfirmationsNtfn(txid *chainhash.Hash, numConfs,
+	RegisterConfirmationsNtfn(txid *chainhash.Hash, pkScript []byte, numConfs,
 		heightHint uint32) (*ConfirmationEvent, error)
 
 	// RegisterSpendNtfn registers an intent to be notified once the target

--- a/chainntnfs/interface.go
+++ b/chainntnfs/interface.go
@@ -53,7 +53,7 @@ type ChainNotifier interface {
 	// NOTE: Dispatching notifications to multiple clients subscribed to a
 	// spend of the same outpoint MUST be supported.
 	RegisterSpendNtfn(outpoint *wire.OutPoint, pkScript []byte,
-		heightHint uint32, mempool bool) (*SpendEvent, error)
+		heightHint uint32) (*SpendEvent, error)
 
 	// RegisterBlockEpochNtfn registers an intent to be notified of each
 	// new block connected to the tip of the main chain. The returned

--- a/chainntnfs/interface.go
+++ b/chainntnfs/interface.go
@@ -38,7 +38,9 @@ type ChainNotifier interface {
 		heightHint uint32) (*ConfirmationEvent, error)
 
 	// RegisterSpendNtfn registers an intent to be notified once the target
-	// outpoint is successfully spent within a transaction. The returned
+	// outpoint is successfully spent within a transaction. The script that
+	// the outpoint creates must also be specified. This allows this
+	// interface to be implemented by BIP 158-like filtering. The returned
 	// SpendEvent will receive a send on the 'Spend' transaction once a
 	// transaction spending the input is detected on the blockchain.  The
 	// heightHint parameter is provided as a convenience to light clients.
@@ -50,8 +52,8 @@ type ChainNotifier interface {
 	//
 	// NOTE: Dispatching notifications to multiple clients subscribed to a
 	// spend of the same outpoint MUST be supported.
-	RegisterSpendNtfn(outpoint *wire.OutPoint,
-		heightHint uint32) (*SpendEvent, error)
+	RegisterSpendNtfn(outpoint *wire.OutPoint, pkScript []byte,
+		heightHint uint32, mempool bool) (*SpendEvent, error)
 
 	// RegisterBlockEpochNtfn registers an intent to be notified of each
 	// new block connected to the tip of the main chain. The returned

--- a/chainntnfs/interface_test.go
+++ b/chainntnfs/interface_test.go
@@ -58,10 +58,10 @@ var (
 	testAddr = addrPk.AddressPubKeyHash()
 )
 
-func getTestTxId(miner *rpctest.Harness) (*chainhash.Hash, error) {
+func getTestTxIdAndScript(miner *rpctest.Harness) (*chainhash.Hash, []byte, error) {
 	script, err := txscript.PayToAddrScript(testAddr)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	outputs := []*wire.TxOut{
@@ -70,7 +70,13 @@ func getTestTxId(miner *rpctest.Harness) (*chainhash.Hash, error) {
 			PkScript: script,
 		},
 	}
-	return miner.SendOutputs(outputs, 10)
+
+	txid, err := miner.SendOutputs(outputs, 10)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return txid, script, nil
 }
 
 func waitForMempoolTx(r *rpctest.Harness, txid *chainhash.Hash) error {
@@ -116,7 +122,7 @@ func testSingleConfirmationNotification(miner *rpctest.Harness,
 	// We're spending from a coinbase output here, so we use the dedicated
 	// function.
 
-	txid, err := getTestTxId(miner)
+	txid, pkScript, err := getTestTxIdAndScript(miner)
 	if err != nil {
 		t.Fatalf("unable to create test tx: %v", err)
 	}
@@ -134,8 +140,9 @@ func testSingleConfirmationNotification(miner *rpctest.Harness,
 	// Now that we have a txid, register a confirmation notification with
 	// the chainntfn source.
 	numConfs := uint32(1)
-	confIntent, err := notifier.RegisterConfirmationsNtfn(txid, numConfs,
-		uint32(currentHeight))
+	confIntent, err := notifier.RegisterConfirmationsNtfn(
+		txid, pkScript, numConfs, uint32(currentHeight),
+	)
 	if err != nil {
 		t.Fatalf("unable to register ntfn: %v", err)
 	}
@@ -184,7 +191,7 @@ func testMultiConfirmationNotification(miner *rpctest.Harness,
 	//
 	// Again, we'll begin by creating a fresh transaction, so we can obtain
 	// a fresh txid.
-	txid, err := getTestTxId(miner)
+	txid, pkScript, err := getTestTxIdAndScript(miner)
 	if err != nil {
 		t.Fatalf("unable to create test addr: %v", err)
 	}
@@ -200,8 +207,9 @@ func testMultiConfirmationNotification(miner *rpctest.Harness,
 	}
 
 	numConfs := uint32(6)
-	confIntent, err := notifier.RegisterConfirmationsNtfn(txid, numConfs,
-		uint32(currentHeight))
+	confIntent, err := notifier.RegisterConfirmationsNtfn(
+		txid, pkScript, numConfs, uint32(currentHeight),
+	)
 	if err != nil {
 		t.Fatalf("unable to register ntfn: %v", err)
 	}
@@ -242,12 +250,13 @@ func testBatchConfirmationNotification(miner *rpctest.Harness,
 	// verify they're each notified at the proper number of confirmations
 	// below.
 	for i, numConfs := range confSpread {
-		txid, err := getTestTxId(miner)
+		txid, pkScript, err := getTestTxIdAndScript(miner)
 		if err != nil {
 			t.Fatalf("unable to create test addr: %v", err)
 		}
-		confIntent, err := notifier.RegisterConfirmationsNtfn(txid,
-			numConfs, uint32(currentHeight))
+		confIntent, err := notifier.RegisterConfirmationsNtfn(
+			txid, pkScript, numConfs, uint32(currentHeight),
+		)
 		if err != nil {
 			t.Fatalf("unable to register ntfn: %v", err)
 		}
@@ -303,7 +312,7 @@ func testBatchConfirmationNotification(miner *rpctest.Harness,
 func createSpendableOutput(miner *rpctest.Harness,
 	t *testing.T) (*wire.OutPoint, []byte) {
 
-	txid, err := getTestTxId(miner)
+	txid, _, err := getTestTxIdAndScript(miner)
 	if err != nil {
 		t.Fatalf("unable to create test addr: %v", err)
 	}
@@ -554,7 +563,7 @@ func testMultiClientConfirmationNotification(miner *rpctest.Harness,
 	// We'd like to test the case of a multiple clients registered to
 	// receive a confirmation notification for the same transaction.
 
-	txid, err := getTestTxId(miner)
+	txid, pkScript, err := getTestTxIdAndScript(miner)
 	if err != nil {
 		t.Fatalf("unable to create test tx: %v", err)
 	}
@@ -578,8 +587,9 @@ func testMultiClientConfirmationNotification(miner *rpctest.Harness,
 	// Register for a conf notification for the above generated txid with
 	// numConfsClients distinct clients.
 	for i := 0; i < numConfsClients; i++ {
-		confClient, err := notifier.RegisterConfirmationsNtfn(txid,
-			numConfs, uint32(currentHeight))
+		confClient, err := notifier.RegisterConfirmationsNtfn(
+			txid, pkScript, numConfs, uint32(currentHeight),
+		)
 		if err != nil {
 			t.Fatalf("unable to register for confirmation: %v", err)
 		}
@@ -620,7 +630,7 @@ func testTxConfirmedBeforeNtfnRegistration(miner *rpctest.Harness,
 	// spending from a coinbase output here, so we use the dedicated
 	// function.
 
-	txid3, err := getTestTxId(miner)
+	txid3, pkScript3, err := getTestTxIdAndScript(miner)
 	if err != nil {
 		t.Fatalf("unable to create test tx: %v", err)
 	}
@@ -640,7 +650,7 @@ func testTxConfirmedBeforeNtfnRegistration(miner *rpctest.Harness,
 		t.Fatalf("unable to generate block: %v", err)
 	}
 
-	txid1, err := getTestTxId(miner)
+	txid1, pkScript1, err := getTestTxIdAndScript(miner)
 	if err != nil {
 		t.Fatalf("unable to create test tx: %v", err)
 	}
@@ -650,7 +660,7 @@ func testTxConfirmedBeforeNtfnRegistration(miner *rpctest.Harness,
 		t.Fatalf("tx not relayed to miner: %v", err)
 	}
 
-	txid2, err := getTestTxId(miner)
+	txid2, pkScript2, err := getTestTxIdAndScript(miner)
 	if err != nil {
 		t.Fatalf("unable to create test tx: %v", err)
 	}
@@ -675,8 +685,9 @@ func testTxConfirmedBeforeNtfnRegistration(miner *rpctest.Harness,
 	// which is included in the last block. The height hint is the height before
 	// the block is included. This notification should fire immediately since
 	// only 1 confirmation is required.
-	ntfn1, err := notifier.RegisterConfirmationsNtfn(txid1, 1,
-		uint32(currentHeight))
+	ntfn1, err := notifier.RegisterConfirmationsNtfn(
+		txid1, pkScript1, 1, uint32(currentHeight),
+	)
 	if err != nil {
 		t.Fatalf("unable to register ntfn: %v", err)
 	}
@@ -713,8 +724,9 @@ func testTxConfirmedBeforeNtfnRegistration(miner *rpctest.Harness,
 	// Register a confirmation notification for tx2, requiring 3 confirmations.
 	// This transaction is only partially confirmed, so the notification should
 	// not fire yet.
-	ntfn2, err := notifier.RegisterConfirmationsNtfn(txid2, 3,
-		uint32(currentHeight))
+	ntfn2, err := notifier.RegisterConfirmationsNtfn(
+		txid2, pkScript2, 3, uint32(currentHeight),
+	)
 	if err != nil {
 		t.Fatalf("unable to register ntfn: %v", err)
 	}
@@ -740,8 +752,9 @@ func testTxConfirmedBeforeNtfnRegistration(miner *rpctest.Harness,
 	// Finally register a confirmation notification for tx3, requiring 1
 	// confirmation. Ensure that conf notifications do not refire on txs
 	// 1 or 2.
-	ntfn3, err := notifier.RegisterConfirmationsNtfn(txid3, 1,
-		uint32(currentHeight-1))
+	ntfn3, err := notifier.RegisterConfirmationsNtfn(
+		txid3, pkScript3, 1, uint32(currentHeight-1),
+	)
 	if err != nil {
 		t.Fatalf("unable to register ntfn: %v", err)
 	}
@@ -775,7 +788,7 @@ func testLazyNtfnConsumer(miner *rpctest.Harness,
 
 	// Create a transaction to be notified about. We'll register for
 	// notifications on this transaction but won't be prompt in checking them
-	txid, err := getTestTxId(miner)
+	txid, pkScript, err := getTestTxIdAndScript(miner)
 	if err != nil {
 		t.Fatalf("unable to create test tx: %v", err)
 	}
@@ -798,8 +811,9 @@ func testLazyNtfnConsumer(miner *rpctest.Harness,
 		t.Fatalf("unable to generate blocks: %v", err)
 	}
 
-	firstConfIntent, err := notifier.RegisterConfirmationsNtfn(txid, numConfs,
-		uint32(currentHeight))
+	firstConfIntent, err := notifier.RegisterConfirmationsNtfn(
+		txid, pkScript, numConfs, uint32(currentHeight),
+	)
 	if err != nil {
 		t.Fatalf("unable to register ntfn: %v", err)
 	}
@@ -812,7 +826,7 @@ func testLazyNtfnConsumer(miner *rpctest.Harness,
 	// Now make another transaction, just because we haven't checked to see
 	// if the first transaction has confirmed doesn't mean that we shouldn't
 	// be able to see if this transaction confirms first
-	txid, err = getTestTxId(miner)
+	txid, pkScript, err = getTestTxIdAndScript(miner)
 	if err != nil {
 		t.Fatalf("unable to create test tx: %v", err)
 	}
@@ -829,9 +843,9 @@ func testLazyNtfnConsumer(miner *rpctest.Harness,
 
 	numConfs = 1
 
-	secondConfIntent, err := notifier.RegisterConfirmationsNtfn(txid, numConfs,
-		uint32(currentHeight))
-
+	secondConfIntent, err := notifier.RegisterConfirmationsNtfn(
+		txid, pkScript, numConfs, uint32(currentHeight),
+	)
 	if err != nil {
 		t.Fatalf("unable to register ntfn: %v", err)
 	}
@@ -1150,7 +1164,7 @@ func testReorgConf(miner *rpctest.Harness, notifier chainntnfs.ChainNotifier,
 		t.Fatalf("unable to remove node: %v", err)
 	}
 
-	txid, err := getTestTxId(miner)
+	txid, pkScript, err := getTestTxIdAndScript(miner)
 	if err != nil {
 		t.Fatalf("unable to create test tx: %v", err)
 	}
@@ -1168,8 +1182,9 @@ func testReorgConf(miner *rpctest.Harness, notifier chainntnfs.ChainNotifier,
 	// Now that we have a txid, register a confirmation notification with
 	// the chainntfn source.
 	numConfs := uint32(2)
-	confIntent, err := notifier.RegisterConfirmationsNtfn(txid, numConfs,
-		uint32(currentHeight))
+	confIntent, err := notifier.RegisterConfirmationsNtfn(
+		txid, pkScript, numConfs, uint32(currentHeight),
+	)
 	if err != nil {
 		t.Fatalf("unable to register ntfn: %v", err)
 	}

--- a/chainntnfs/interface_test.go
+++ b/chainntnfs/interface_test.go
@@ -420,8 +420,9 @@ func testSpendNotification(miner *rpctest.Harness,
 	const numClients = 5
 	spendClients := make([]*chainntnfs.SpendEvent, numClients)
 	for i := 0; i < numClients; i++ {
-		spentIntent, err := notifier.RegisterSpendNtfn(outpoint,
-			uint32(currentHeight))
+		spentIntent, err := notifier.RegisterSpendNtfn(
+			outpoint, pkScript, uint32(currentHeight),
+		)
 		if err != nil {
 			t.Fatalf("unable to register for spend ntfn: %v", err)
 		}
@@ -471,8 +472,9 @@ func testSpendNotification(miner *rpctest.Harness,
 
 	// Make sure registering a client after the tx is in the mempool still
 	// doesn't trigger a notification.
-	spentIntent, err := notifier.RegisterSpendNtfn(outpoint,
-		uint32(currentHeight))
+	spentIntent, err := notifier.RegisterSpendNtfn(
+		outpoint, pkScript, uint32(currentHeight),
+	)
 	if err != nil {
 		t.Fatalf("unable to register for spend ntfn: %v", err)
 	}
@@ -918,8 +920,9 @@ func testSpendBeforeNtfnRegistration(miner *rpctest.Harness,
 		const numClients = 2
 		spendClients := make([]*chainntnfs.SpendEvent, numClients)
 		for i := 0; i < numClients; i++ {
-			spentIntent, err := notifier.RegisterSpendNtfn(outpoint,
-				uint32(currentHeight))
+			spentIntent, err := notifier.RegisterSpendNtfn(
+				outpoint, pkScript, uint32(currentHeight),
+			)
 			if err != nil {
 				t.Fatalf("unable to register for spend ntfn: %v",
 					err)
@@ -998,8 +1001,9 @@ func testCancelSpendNtfn(node *rpctest.Harness,
 	const numClients = 2
 	spendClients := make([]*chainntnfs.SpendEvent, numClients)
 	for i := 0; i < numClients; i++ {
-		spentIntent, err := notifier.RegisterSpendNtfn(outpoint,
-			uint32(currentHeight))
+		spentIntent, err := notifier.RegisterSpendNtfn(
+			outpoint, pkScript, uint32(currentHeight),
+		)
 		if err != nil {
 			t.Fatalf("unable to register for spend ntfn: %v", err)
 		}

--- a/chainntnfs/neutrinonotify/neutrino.go
+++ b/chainntnfs/neutrinonotify/neutrino.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcd/rpcclient"
+	"github.com/btcsuite/btcd/txscript"
 	"github.com/btcsuite/btcd/wire"
 	"github.com/btcsuite/btcutil"
 	"github.com/btcsuite/btcutil/gcs/builder"
@@ -317,8 +318,19 @@ func (n *NeutrinoNotifier) notificationDispatcher() {
 					defer n.wg.Done()
 
 					confDetails, err := n.historicalConfDetails(
-						msg.TxID, currentHeight,
-						msg.heightHint,
+						msg.TxID, msg.pkScript, currentHeight, msg.heightHint,
+					)
+					if err != nil {
+						chainntnfs.Log.Error(err)
+					}
+
+					// We'll map the script into an address
+					// type so we can instruct neutrino to
+					// match if the transaction containing
+					// the script is found in a block.
+					params := n.p2pNode.ChainParams()
+					_, addrs, _, err := txscript.ExtractPkScriptAddrs(
+						msg.pkScript, &params,
 					)
 					if err != nil {
 						chainntnfs.Log.Error(err)

--- a/chainparams.go
+++ b/chainparams.go
@@ -1,13 +1,13 @@
 package main
 
 import (
-	"github.com/lightningnetwork/lnd/keychain"
-	litecoinCfg "github.com/ltcsuite/ltcd/chaincfg"
-	litecoinWire "github.com/ltcsuite/ltcd/wire"
 	"github.com/btcsuite/btcd/chaincfg"
 	bitcoinCfg "github.com/btcsuite/btcd/chaincfg"
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	bitcoinWire "github.com/btcsuite/btcd/wire"
+	"github.com/lightningnetwork/lnd/keychain"
+	litecoinCfg "github.com/ltcsuite/ltcd/chaincfg"
+	litecoinWire "github.com/ltcsuite/ltcd/wire"
 )
 
 // activeNetParams is a pointer to the parameters specific to the currently

--- a/channeldb/channel_test.go
+++ b/channeldb/channel_test.go
@@ -10,16 +10,16 @@ import (
 	"runtime"
 	"testing"
 
-	"github.com/davecgh/go-spew/spew"
-	"github.com/lightningnetwork/lnd/keychain"
-	"github.com/lightningnetwork/lnd/lnwire"
-	"github.com/lightningnetwork/lnd/shachain"
 	"github.com/btcsuite/btcd/btcec"
 	"github.com/btcsuite/btcd/chaincfg"
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcd/wire"
 	"github.com/btcsuite/btcutil"
 	_ "github.com/btcsuite/btcwallet/walletdb/bdb"
+	"github.com/davecgh/go-spew/spew"
+	"github.com/lightningnetwork/lnd/keychain"
+	"github.com/lightningnetwork/lnd/lnwire"
+	"github.com/lightningnetwork/lnd/shachain"
 )
 
 var (

--- a/contractcourt/chain_arbitrator.go
+++ b/contractcourt/chain_arbitrator.go
@@ -5,13 +5,13 @@ import (
 	"sync"
 	"sync/atomic"
 
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"github.com/btcsuite/btcd/wire"
+	"github.com/btcsuite/btcutil"
 	"github.com/lightningnetwork/lnd/chainntnfs"
 	"github.com/lightningnetwork/lnd/channeldb"
 	"github.com/lightningnetwork/lnd/lnwallet"
 	"github.com/lightningnetwork/lnd/lnwire"
-	"github.com/btcsuite/btcd/chaincfg/chainhash"
-	"github.com/btcsuite/btcd/wire"
-	"github.com/btcsuite/btcutil"
 )
 
 // ResolutionMsg is a message sent by resolvers to outside sub-systems once an

--- a/contractcourt/chain_watcher.go
+++ b/contractcourt/chain_watcher.go
@@ -173,8 +173,21 @@ func (c *chainWatcher) Start() error {
 		heightHint = chanState.FundingBroadcastHeight
 	}
 
+	localKey := chanState.LocalChanCfg.MultiSigKey.PubKey.SerializeCompressed()
+	remoteKey := chanState.RemoteChanCfg.MultiSigKey.PubKey.SerializeCompressed()
+	multiSigScript, err := lnwallet.GenMultiSigScript(
+		localKey, remoteKey,
+	)
+	if err != nil {
+		return err
+	}
+	pkScript, err := lnwallet.WitnessScriptHash(multiSigScript)
+	if err != nil {
+		return err
+	}
+
 	spendNtfn, err := c.cfg.notifier.RegisterSpendNtfn(
-		fundingOut, heightHint,
+		fundingOut, pkScript, heightHint,
 	)
 	if err != nil {
 		return err

--- a/contractcourt/chain_watcher_test.go
+++ b/contractcourt/chain_watcher_test.go
@@ -6,11 +6,11 @@ import (
 	"testing"
 	"time"
 
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"github.com/btcsuite/btcd/wire"
 	"github.com/lightningnetwork/lnd/chainntnfs"
 	"github.com/lightningnetwork/lnd/lnwallet"
 	"github.com/lightningnetwork/lnd/lnwire"
-	"github.com/btcsuite/btcd/chaincfg/chainhash"
-	"github.com/btcsuite/btcd/wire"
 )
 
 type mockNotifier struct {
@@ -35,7 +35,7 @@ func (m *mockNotifier) Start() error {
 func (m *mockNotifier) Stop() error {
 	return nil
 }
-func (m *mockNotifier) RegisterSpendNtfn(outpoint *wire.OutPoint,
+func (m *mockNotifier) RegisterSpendNtfn(outpoint *wire.OutPoint, _ []byte,
 	heightHint uint32) (*chainntnfs.SpendEvent, error) {
 	return &chainntnfs.SpendEvent{
 		Spend:  m.spendChan,

--- a/contractcourt/chain_watcher_test.go
+++ b/contractcourt/chain_watcher_test.go
@@ -17,7 +17,7 @@ type mockNotifier struct {
 	spendChan chan *chainntnfs.SpendDetail
 }
 
-func (m *mockNotifier) RegisterConfirmationsNtfn(txid *chainhash.Hash, numConfs,
+func (m *mockNotifier) RegisterConfirmationsNtfn(txid *chainhash.Hash, _ []byte, numConfs,
 	heightHint uint32) (*chainntnfs.ConfirmationEvent, error) {
 	return nil, nil
 }

--- a/contractcourt/channel_arbitrator.go
+++ b/contractcourt/channel_arbitrator.go
@@ -5,12 +5,12 @@ import (
 	"sync"
 	"sync/atomic"
 
+	"github.com/btcsuite/btcd/wire"
 	"github.com/davecgh/go-spew/spew"
 	"github.com/lightningnetwork/lnd/chainntnfs"
 	"github.com/lightningnetwork/lnd/channeldb"
 	"github.com/lightningnetwork/lnd/lnwallet"
 	"github.com/lightningnetwork/lnd/lnwire"
-	"github.com/btcsuite/btcd/wire"
 )
 
 const (

--- a/contractcourt/channel_arbitrator_test.go
+++ b/contractcourt/channel_arbitrator_test.go
@@ -5,11 +5,11 @@ import (
 	"testing"
 	"time"
 
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"github.com/btcsuite/btcd/wire"
 	"github.com/lightningnetwork/lnd/chainntnfs"
 	"github.com/lightningnetwork/lnd/lnwallet"
 	"github.com/lightningnetwork/lnd/lnwire"
-	"github.com/btcsuite/btcd/chaincfg/chainhash"
-	"github.com/btcsuite/btcd/wire"
 )
 
 type mockChainIO struct{}
@@ -18,7 +18,7 @@ func (*mockChainIO) GetBestBlock() (*chainhash.Hash, int32, error) {
 	return nil, 0, nil
 }
 
-func (*mockChainIO) GetUtxo(op *wire.OutPoint,
+func (*mockChainIO) GetUtxo(op *wire.OutPoint, _ []byte,
 	heightHint uint32) (*wire.TxOut, error) {
 	return nil, nil
 }

--- a/contractcourt/contract_resolvers.go
+++ b/contractcourt/contract_resolvers.go
@@ -172,6 +172,7 @@ func (h *htlcTimeoutResolver) Resolve() (ContractResolver, error) {
 		// has been spent by a confirmed transaction.
 		spendNtfn, err := h.Notifier.RegisterSpendNtfn(
 			&h.htlcResolution.ClaimOutpoint,
+			h.htlcResolution.SweepSignDesc.Output.PkScript,
 			h.broadcastHeight,
 		)
 		if err != nil {
@@ -582,7 +583,9 @@ func (h *htlcSuccessResolver) Resolve() (ContractResolver, error) {
 	// To wrap this up, we'll wait until the second-level transaction has
 	// been spent, then fully resolve the contract.
 	spendNtfn, err := h.Notifier.RegisterSpendNtfn(
-		&h.htlcResolution.ClaimOutpoint, h.broadcastHeight,
+		&h.htlcResolution.ClaimOutpoint,
+		h.htlcResolution.SweepSignDesc.Output.PkScript,
+		h.broadcastHeight,
 	)
 	if err != nil {
 		return nil, err
@@ -783,17 +786,34 @@ func (h *htlcOutgoingContestResolver) Resolve() (ContractResolver, error) {
 	// output. If this isn't our commitment transaction, it'll be right on
 	// the resolution. Otherwise, we fetch this pointer from the input of
 	// the time out transaction.
-	var outPointToWatch wire.OutPoint
+	var (
+		outPointToWatch wire.OutPoint
+		scriptToWatch   []byte
+		err             error
+	)
 	if h.htlcResolution.SignedTimeoutTx == nil {
 		outPointToWatch = h.htlcResolution.ClaimOutpoint
+		scriptToWatch = h.htlcResolution.SweepSignDesc.Output.PkScript
 	} else {
+		// If this is the remote party's commitment, then we'll need to
+		// grab watch the output that our timeout transaction points
+		// to. We can directly grab the outpoint, then also extract the
+		// witness script (the last element of the witness stack) to
+		// re-construct the pkScipt we need to watch.
 		outPointToWatch = h.htlcResolution.SignedTimeoutTx.TxIn[0].PreviousOutPoint
+		witness := h.htlcResolution.SignedTimeoutTx.TxIn[0].Witness
+		scriptToWatch, err = lnwallet.WitnessScriptHash(
+			witness[len(witness)-1],
+		)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	// First, we'll register for a spend notification for this output. If
-	// the remote party sweeps with the pre-image, we'll  be notified.
+	// the remote party sweeps with the pre-image, we'll be notified.
 	spendNtfn, err := h.Notifier.RegisterSpendNtfn(
-		&outPointToWatch, h.broadcastHeight,
+		&outPointToWatch, scriptToWatch, h.broadcastHeight,
 	)
 	if err != nil {
 		return nil, err
@@ -802,6 +822,7 @@ func (h *htlcOutgoingContestResolver) Resolve() (ContractResolver, error) {
 	// We'll quickly check to see if the output has already been spent.
 	select {
 	// If the output has already been spent, then we can stop early and
+	// sweep the pre-image from the output.
 	case commitSpend, ok := <-spendNtfn.Spend:
 		if !ok {
 			return nil, fmt.Errorf("quitting")
@@ -1295,6 +1316,7 @@ func (c *commitSweepResolver) Resolve() (ContractResolver, error) {
 		// until the commitment output has been spent.
 		spendNtfn, err := c.Notifier.RegisterSpendNtfn(
 			&c.commitResolution.SelfOutPoint,
+			c.commitResolution.SelfOutputSignDesc.Output.PkScript,
 			c.broadcastHeight,
 		)
 		if err != nil {

--- a/contractcourt/contract_resolvers.go
+++ b/contractcourt/contract_resolvers.go
@@ -211,8 +211,9 @@ func (h *htlcTimeoutResolver) Resolve() (ContractResolver, error) {
 		// Otherwise, this is our commitment, so we'll watch for the
 		// second-level transaction to be sufficiently confirmed.
 		secondLevelTXID := h.htlcResolution.SignedTimeoutTx.TxHash()
+		sweepScript := h.htlcResolution.SignedTimeoutTx.TxOut[0].PkScript
 		confNtfn, err := h.Notifier.RegisterConfirmationsNtfn(
-			&secondLevelTXID, 1, h.broadcastHeight,
+			&secondLevelTXID, sweepScript, 1, h.broadcastHeight,
 		)
 		if err != nil {
 			return nil, err
@@ -521,8 +522,9 @@ func (h *htlcSuccessResolver) Resolve() (ContractResolver, error) {
 		// With the sweep transaction broadcast, we'll wait for its
 		// confirmation.
 		sweepTXID := h.sweepTx.TxHash()
+		sweepScript := h.sweepTx.TxOut[0].PkScript
 		confNtfn, err := h.Notifier.RegisterConfirmationsNtfn(
-			&sweepTXID, 1, h.broadcastHeight,
+			&sweepTXID, sweepScript, 1, h.broadcastHeight,
 		)
 		if err != nil {
 			return nil, err
@@ -1193,8 +1195,9 @@ func (c *commitSweepResolver) Resolve() (ContractResolver, error) {
 	//
 	// TODO(roasbeef): instead sweep asap if remote commit? yeh
 	commitTXID := c.commitResolution.SelfOutPoint.Hash
+	sweepScript := c.commitResolution.SelfOutputSignDesc.Output.PkScript
 	confNtfn, err := c.Notifier.RegisterConfirmationsNtfn(
-		&commitTXID, 1, c.broadcastHeight,
+		&commitTXID, sweepScript, 1, c.broadcastHeight,
 	)
 	if err != nil {
 		return nil, err
@@ -1329,8 +1332,9 @@ func (c *commitSweepResolver) Resolve() (ContractResolver, error) {
 	// Now we'll wait until the sweeping transaction has been fully
 	// confirmed.  Once it's confirmed, we can mark this contract resolved.
 	sweepTXID := c.sweepTx.TxHash()
+	sweepingScript := c.sweepTx.TxOut[0].PkScript
 	confNtfn, err = c.Notifier.RegisterConfirmationsNtfn(
-		&sweepTXID, 1, c.broadcastHeight,
+		&sweepTXID, sweepingScript, 1, c.broadcastHeight,
 	)
 	if err != nil {
 		return nil, err

--- a/discovery/gossiper_test.go
+++ b/discovery/gossiper_test.go
@@ -18,6 +18,9 @@ import (
 	"io/ioutil"
 	"os"
 
+	"github.com/btcsuite/btcd/btcec"
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"github.com/btcsuite/btcd/wire"
 	"github.com/davecgh/go-spew/spew"
 	"github.com/go-errors/errors"
 	"github.com/lightningnetwork/lnd/chainntnfs"
@@ -26,9 +29,6 @@ import (
 	"github.com/lightningnetwork/lnd/lnwallet"
 	"github.com/lightningnetwork/lnd/lnwire"
 	"github.com/lightningnetwork/lnd/routing"
-	"github.com/btcsuite/btcd/btcec"
-	"github.com/btcsuite/btcd/chaincfg/chainhash"
-	"github.com/btcsuite/btcd/wire"
 )
 
 var (
@@ -258,12 +258,12 @@ func newMockNotifier() *mockNotifier {
 }
 
 func (m *mockNotifier) RegisterConfirmationsNtfn(txid *chainhash.Hash,
-	numConfs, _ uint32) (*chainntnfs.ConfirmationEvent, error) {
+	_ []byte, numConfs, _ uint32) (*chainntnfs.ConfirmationEvent, error) {
 
 	return nil, nil
 }
 
-func (m *mockNotifier) RegisterSpendNtfn(outpoint *wire.OutPoint,
+func (m *mockNotifier) RegisterSpendNtfn(outpoint *wire.OutPoint, _ []byte,
 	_ uint32) (*chainntnfs.SpendEvent, error) {
 	return nil, nil
 }

--- a/fundingmanager_test.go
+++ b/fundingmanager_test.go
@@ -29,6 +29,10 @@ import (
 	"github.com/lightningnetwork/lnd/lnrpc"
 	"github.com/lightningnetwork/lnd/lnwallet"
 	"github.com/lightningnetwork/lnd/lnwire"
+
+	"github.com/btcsuite/btcd/btcec"
+	"github.com/btcsuite/btcd/wire"
+	"github.com/btcsuite/btcutil"
 )
 
 const (
@@ -126,7 +130,7 @@ func (m *mockNotifier) Stop() error {
 	return nil
 }
 
-func (m *mockNotifier) RegisterSpendNtfn(outpoint *wire.OutPoint,
+func (m *mockNotifier) RegisterSpendNtfn(outpoint *wire.OutPoint, _ []byte,
 	heightHint uint32) (*chainntnfs.SpendEvent, error) {
 	return &chainntnfs.SpendEvent{
 		Spend:  make(chan *chainntnfs.SpendDetail),

--- a/fundingmanager_test.go
+++ b/fundingmanager_test.go
@@ -98,8 +98,9 @@ type mockNotifier struct {
 	epochChan      chan *chainntnfs.BlockEpoch
 }
 
-func (m *mockNotifier) RegisterConfirmationsNtfn(txid *chainhash.Hash, numConfs,
-	heightHint uint32) (*chainntnfs.ConfirmationEvent, error) {
+func (m *mockNotifier) RegisterConfirmationsNtfn(txid *chainhash.Hash,
+	_ []byte, numConfs, heightHint uint32) (*chainntnfs.ConfirmationEvent, error) {
+
 	if numConfs == 6 {
 		return &chainntnfs.ConfirmationEvent{
 			Confirmed: m.sixConfChannel,

--- a/fundingmanager_test.go
+++ b/fundingmanager_test.go
@@ -29,10 +29,6 @@ import (
 	"github.com/lightningnetwork/lnd/lnrpc"
 	"github.com/lightningnetwork/lnd/lnwallet"
 	"github.com/lightningnetwork/lnd/lnwire"
-
-	"github.com/btcsuite/btcd/btcec"
-	"github.com/btcsuite/btcd/wire"
-	"github.com/btcsuite/btcutil"
 )
 
 const (

--- a/htlcswitch/mock.go
+++ b/htlcswitch/mock.go
@@ -13,6 +13,10 @@ import (
 	"testing"
 	"time"
 
+	"github.com/btcsuite/btcd/btcec"
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"github.com/btcsuite/btcd/txscript"
+	"github.com/btcsuite/btcd/wire"
 	"github.com/btcsuite/fastsha256"
 	"github.com/go-errors/errors"
 	"github.com/lightningnetwork/lightning-onion"
@@ -22,10 +26,6 @@ import (
 	"github.com/lightningnetwork/lnd/lnpeer"
 	"github.com/lightningnetwork/lnd/lnwallet"
 	"github.com/lightningnetwork/lnd/lnwire"
-	"github.com/btcsuite/btcd/btcec"
-	"github.com/btcsuite/btcd/chaincfg/chainhash"
-	"github.com/btcsuite/btcd/txscript"
-	"github.com/btcsuite/btcd/wire"
 )
 
 type mockPreimageCache struct {
@@ -800,7 +800,7 @@ func (m *mockNotifier) Stop() error {
 	return nil
 }
 
-func (m *mockNotifier) RegisterSpendNtfn(outpoint *wire.OutPoint,
+func (m *mockNotifier) RegisterSpendNtfn(outpoint *wire.OutPoint, _ []byte,
 	heightHint uint32) (*chainntnfs.SpendEvent, error) {
 
 	return &chainntnfs.SpendEvent{

--- a/htlcswitch/mock.go
+++ b/htlcswitch/mock.go
@@ -781,7 +781,7 @@ type mockNotifier struct {
 	epochChan chan *chainntnfs.BlockEpoch
 }
 
-func (m *mockNotifier) RegisterConfirmationsNtfn(txid *chainhash.Hash,
+func (m *mockNotifier) RegisterConfirmationsNtfn(txid *chainhash.Hash, _ []byte,
 	numConfs uint32, heightHint uint32) (*chainntnfs.ConfirmationEvent, error) {
 	return nil, nil
 }

--- a/lnwallet/btcwallet/blockchain.go
+++ b/lnwallet/btcwallet/blockchain.go
@@ -9,10 +9,10 @@ import (
 	"github.com/btcsuite/btcd/wire"
 	"github.com/btcsuite/btcutil"
 
-	"github.com/lightninglabs/neutrino"
-	"github.com/lightningnetwork/lnd/lnwallet"
 	"github.com/btcsuite/btcwallet/chain"
 	"github.com/btcsuite/btcwallet/waddrmgr"
+	"github.com/lightninglabs/neutrino"
+	"github.com/lightningnetwork/lnd/lnwallet"
 )
 
 var (
@@ -33,15 +33,21 @@ func (b *BtcWallet) GetBestBlock() (*chainhash.Hash, int32, error) {
 	return b.chain.GetBestBlock()
 }
 
-// GetUtxo returns the original output referenced by the passed outpoint.
+// GetUtxo returns the original output referenced by the passed outpoint that
+// creates the target pkScript.
 //
 // This method is a part of the lnwallet.BlockChainIO interface.
-func (b *BtcWallet) GetUtxo(op *wire.OutPoint, heightHint uint32) (*wire.TxOut, error) {
+func (b *BtcWallet) GetUtxo(op *wire.OutPoint, pkScript []byte,
+	heightHint uint32) (*wire.TxOut, error) {
+
 	switch backend := b.chain.(type) {
 
 	case *chain.NeutrinoClient:
 		spendReport, err := backend.CS.GetUtxo(
-			neutrino.WatchOutPoints(*op),
+			neutrino.WatchInputs(neutrino.InputWithScript{
+				OutPoint: *op,
+				PkScript: pkScript,
+			}),
 			neutrino.StartBlock(&waddrmgr.BlockStamp{
 				Height: int32(heightHint),
 			}),

--- a/lnwallet/channel.go
+++ b/lnwallet/channel.go
@@ -1427,7 +1427,7 @@ func (lc *LightningChannel) createSignDesc() error {
 	localKey := lc.localChanCfg.MultiSigKey.PubKey.SerializeCompressed()
 	remoteKey := lc.remoteChanCfg.MultiSigKey.PubKey.SerializeCompressed()
 
-	multiSigScript, err := genMultiSigScript(localKey, remoteKey)
+	multiSigScript, err := GenMultiSigScript(localKey, remoteKey)
 	if err != nil {
 		return err
 	}

--- a/lnwallet/interface.go
+++ b/lnwallet/interface.go
@@ -237,10 +237,12 @@ type BlockChainIO interface {
 
 	// GetUtxo attempts to return the passed outpoint if it's still a
 	// member of the utxo set. The passed height hint should be the "birth
-	// height" of the passed outpoint. In the case that the output is in
+	// height" of the passed outpoint. The script passed should be the
+	// script that the oupoint creates. In the case that the output is in
 	// the UTXO set, then the output corresponding to that output is
 	// returned.  Otherwise, a non-nil error will be returned.
-	GetUtxo(op *wire.OutPoint, heightHint uint32) (*wire.TxOut, error)
+	GetUtxo(op *wire.OutPoint, pkScript []byte,
+		heightHint uint32) (*wire.TxOut, error)
 
 	// GetBlockHash returns the hash of the block in the best blockchain
 	// at the given height.

--- a/lnwallet/interface.go
+++ b/lnwallet/interface.go
@@ -238,7 +238,7 @@ type BlockChainIO interface {
 	// GetUtxo attempts to return the passed outpoint if it's still a
 	// member of the utxo set. The passed height hint should be the "birth
 	// height" of the passed outpoint. The script passed should be the
-	// script that the oupoint creates. In the case that the output is in
+	// script that the outpoint creates. In the case that the output is in
 	// the UTXO set, then the output corresponding to that output is
 	// returned.  Otherwise, a non-nil error will be returned.
 	GetUtxo(op *wire.OutPoint, pkScript []byte,

--- a/lnwallet/interface_test.go
+++ b/lnwallet/interface_test.go
@@ -1738,7 +1738,7 @@ func testReorgWalletBalance(r *rpctest.Harness, w *lnwallet.LightningWallet,
 		t.Fatalf("unable to synchronize mining nodes: %v", err)
 	}
 
-	// Step 3: Do a set of reorgs by disconecting the two miners, mining
+	// Step 3: Do a set of reorgs by disconnecting the two miners, mining
 	// one block on the passed miner and two on the created miner,
 	// connecting them, and waiting for them to sync.
 	for i := 0; i < 5; i++ {
@@ -1918,19 +1918,20 @@ func waitForMempoolTx(r *rpctest.Harness, txid *chainhash.Hash) error {
 }
 
 func waitForWalletSync(r *rpctest.Harness, w *lnwallet.LightningWallet) error {
-	var synced bool
-	var err error
-	var bestHash, knownHash *chainhash.Hash
-	var bestHeight, knownHeight int32
-	timeout := time.After(10 * time.Second)
+	var (
+		synced                  bool
+		err                     error
+		bestHash, knownHash     *chainhash.Hash
+		bestHeight, knownHeight int32
+	)
+	timeout := time.After(30 * time.Second)
 	for !synced {
 		// Do a short wait
 		select {
 		case <-timeout:
-			return fmt.Errorf("timeout after 10s")
-		default:
+			return fmt.Errorf("timeout after 30s")
+		case <-time.Tick(50 * time.Millisecond):
 		}
-		time.Sleep(100 * time.Millisecond)
 
 		// Check whether the chain source of the wallet is caught up to
 		// the harness it's supposed to be catching up to.

--- a/lnwallet/script_utils.go
+++ b/lnwallet/script_utils.go
@@ -57,9 +57,9 @@ func WitnessScriptHash(witnessScript []byte) ([]byte, error) {
 	return bldr.Script()
 }
 
-// genMultiSigScript generates the non-p2sh'd multisig script for 2 of 2
+// GenMultiSigScript generates the non-p2sh'd multisig script for 2 of 2
 // pubkeys.
-func genMultiSigScript(aPub, bPub []byte) ([]byte, error) {
+func GenMultiSigScript(aPub, bPub []byte) ([]byte, error) {
 	if len(aPub) != 33 || len(bPub) != 33 {
 		return nil, fmt.Errorf("Pubkey size error. Compressed pubkeys only")
 	}
@@ -91,7 +91,7 @@ func GenFundingPkScript(aPub, bPub []byte, amt int64) ([]byte, *wire.TxOut, erro
 	}
 
 	// First, create the 2-of-2 multi-sig script itself.
-	witnessScript, err := genMultiSigScript(aPub, bPub)
+	witnessScript, err := GenMultiSigScript(aPub, bPub)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/lnwallet/script_utils_test.go
+++ b/lnwallet/script_utils_test.go
@@ -8,12 +8,12 @@ import (
 	"testing"
 	"time"
 
-	"github.com/lightningnetwork/lnd/keychain"
 	"github.com/btcsuite/btcd/btcec"
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcd/txscript"
 	"github.com/btcsuite/btcd/wire"
 	"github.com/btcsuite/btcutil"
+	"github.com/lightningnetwork/lnd/keychain"
 )
 
 // TestCommitmentSpendValidation test the spendability of both outputs within

--- a/mock.go
+++ b/mock.go
@@ -5,15 +5,15 @@ import (
 	"fmt"
 	"sync"
 
-	"github.com/lightningnetwork/lnd/chainntnfs"
-	"github.com/lightningnetwork/lnd/keychain"
-	"github.com/lightningnetwork/lnd/lnwallet"
 	"github.com/btcsuite/btcd/btcec"
 	"github.com/btcsuite/btcd/chaincfg"
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcd/txscript"
 	"github.com/btcsuite/btcd/wire"
 	"github.com/btcsuite/btcutil"
+	"github.com/lightningnetwork/lnd/chainntnfs"
+	"github.com/lightningnetwork/lnd/keychain"
+	"github.com/lightningnetwork/lnd/lnwallet"
 )
 
 // The block height returned by the mock BlockChainIO's GetBestBlock.
@@ -105,7 +105,7 @@ func (m *mockNotfier) Start() error {
 func (m *mockNotfier) Stop() error {
 	return nil
 }
-func (m *mockNotfier) RegisterSpendNtfn(outpoint *wire.OutPoint,
+func (m *mockNotfier) RegisterSpendNtfn(outpoint *wire.OutPoint, _ []byte,
 	heightHint uint32) (*chainntnfs.SpendEvent, error) {
 	return &chainntnfs.SpendEvent{
 		Spend:  make(chan *chainntnfs.SpendDetail),
@@ -131,7 +131,7 @@ func makeMockSpendNotifier() *mockSpendNotifier {
 }
 
 func (m *mockSpendNotifier) RegisterSpendNtfn(outpoint *wire.OutPoint,
-	heightHint uint32) (*chainntnfs.SpendEvent, error) {
+	_ []byte, heightHint uint32) (*chainntnfs.SpendEvent, error) {
 	m.mtx.Lock()
 	defer m.mtx.Unlock()
 
@@ -172,7 +172,7 @@ func (*mockChainIO) GetBestBlock() (*chainhash.Hash, int32, error) {
 	return activeNetParams.GenesisHash, fundingBroadcastHeight, nil
 }
 
-func (*mockChainIO) GetUtxo(op *wire.OutPoint,
+func (*mockChainIO) GetUtxo(op *wire.OutPoint, _ []byte,
 	heightHint uint32) (*wire.TxOut, error) {
 	return nil, nil
 }

--- a/mock.go
+++ b/mock.go
@@ -85,8 +85,8 @@ type mockNotfier struct {
 	confChannel chan *chainntnfs.TxConfirmation
 }
 
-func (m *mockNotfier) RegisterConfirmationsNtfn(txid *chainhash.Hash, numConfs,
-	heightHint uint32) (*chainntnfs.ConfirmationEvent, error) {
+func (m *mockNotfier) RegisterConfirmationsNtfn(txid *chainhash.Hash,
+	_ []byte, numConfs, heightHint uint32) (*chainntnfs.ConfirmationEvent, error) {
 	return &chainntnfs.ConfirmationEvent{
 		Confirmed: m.confChannel,
 	}, nil

--- a/routing/chainview/btcd.go
+++ b/routing/chainview/btcd.go
@@ -12,6 +12,7 @@ import (
 	"github.com/btcsuite/btcd/rpcclient"
 	"github.com/btcsuite/btcd/wire"
 	"github.com/btcsuite/btcutil"
+	"github.com/lightningnetwork/lnd/channeldb"
 )
 
 // BtcdFilteredChainView is an implementation of the FilteredChainView
@@ -447,11 +448,18 @@ type filterUpdate struct {
 // rewound to ensure all relevant notifications are dispatched.
 //
 // NOTE: This is part of the FilteredChainView interface.
-func (b *BtcdFilteredChainView) UpdateFilter(ops []wire.OutPoint, updateHeight uint32) error {
+func (b *BtcdFilteredChainView) UpdateFilter(ops []channeldb.EdgePoint,
+	updateHeight uint32) error {
+
+	newUtxos := make([]wire.OutPoint, len(ops))
+	for i, op := range ops {
+		newUtxos[i] = op.OutPoint
+	}
+
 	select {
 
 	case b.filterUpdates <- filterUpdate{
-		newUtxos:     ops,
+		newUtxos:     newUtxos,
 		updateHeight: updateHeight,
 	}:
 		return nil

--- a/routing/chainview/interface.go
+++ b/routing/chainview/interface.go
@@ -3,6 +3,7 @@ package chainview
 import (
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcd/wire"
+	"github.com/lightningnetwork/lnd/channeldb"
 )
 
 // FilteredChainView represents a subscription to a certain subset of the
@@ -42,7 +43,7 @@ type FilteredChainView interface {
 	// relevant notifications are dispatched, meaning blocks with a height
 	// lower than the best known height might be sent over the
 	// FilteredBlocks() channel.
-	UpdateFilter(ops []wire.OutPoint, updateHeight uint32) error
+	UpdateFilter(ops []channeldb.EdgePoint, updateHeight uint32) error
 
 	// FilterBlock takes a block hash, and returns a FilteredBlocks which
 	// is the result of applying the current registered UTXO sub-set on the

--- a/routing/chainview/interface_test.go
+++ b/routing/chainview/interface_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/btcsuite/btcd/wire"
 	"github.com/btcsuite/btcutil"
 	"github.com/lightninglabs/neutrino"
+	"github.com/lightningnetwork/lnd/channeldb"
 	"github.com/ltcsuite/ltcd/btcjson"
 
 	"github.com/btcsuite/btcwallet/walletdb"
@@ -238,8 +239,11 @@ func testFilterBlockNotifications(node *rpctest.Harness,
 		t.Fatalf("unable to get current height: %v", err)
 	}
 
-	// Now we'll add both output to the current filter.
-	filter := []wire.OutPoint{*outPoint1, *outPoint2}
+	// Now we'll add both outpoints to the current filter.
+	filter := []channeldb.EdgePoint{
+		{targetScript, *outPoint1},
+		{targetScript, *outPoint2},
+	}
 	err = chainView.UpdateFilter(filter, uint32(currentHeight))
 	if err != nil {
 		t.Fatalf("unable to update filter: %v", err)
@@ -382,8 +386,9 @@ func testUpdateFilterBackTrack(node *rpctest.Harness,
 
 	// After the block has been mined+notified we'll update the filter with
 	// a _prior_ height so a "rewind" occurs.
-	filter := []wire.OutPoint{*outPoint}
-
+	filter := []channeldb.EdgePoint{
+		{testScript, *outPoint},
+	}
 	err = chainView.UpdateFilter(filter, uint32(currentHeight))
 	if err != nil {
 		t.Fatalf("unable to update filter: %v", err)
@@ -496,7 +501,10 @@ func testFilterSingleBlock(node *rpctest.Harness, chainView FilteredChainView,
 
 	// Now we'll manually trigger filtering the block generated above.
 	// First, we'll add the two outpoints to our filter.
-	filter := []wire.OutPoint{*outPoint1, *outPoint2}
+	filter := []channeldb.EdgePoint{
+		{testScript, *outPoint1},
+		{testScript, *outPoint2},
+	}
 	err = chainView.UpdateFilter(filter, uint32(currentHeight))
 	if err != nil {
 		t.Fatalf("unable to update filter: %v", err)

--- a/routing/chainview/interface_test.go
+++ b/routing/chainview/interface_test.go
@@ -570,6 +570,13 @@ func testFilterBlockDisconnected(node *rpctest.Harness,
 	newBlocks := reorgView.FilteredBlocks()
 	disconnectedBlocks := reorgView.DisconnectedBlocks()
 
+	// If this the neutrino backend, then we'll give it some time to catch
+	// up, as it's a bit slower to consume new blocks compared to the RPC
+	// backends.
+	if _, ok := reorgView.(*CfFilteredChainView); ok {
+		time.Sleep(time.Second * 3)
+	}
+
 	_, oldHeight, err := reorgNode.Node.GetBestBlock()
 	if err != nil {
 		t.Fatalf("unable to get current height: %v", err)
@@ -599,7 +606,8 @@ func testFilterBlockDisconnected(node *rpctest.Harness,
 		case block := <-newBlocks:
 			if i < oldHeight {
 				t.Fatalf("did not expect to get new block "+
-					"in iteration %d", i)
+					"in iteration %d, old height: %v", i,
+					oldHeight)
 			}
 			expectedHeight := uint32(i - oldHeight + 1)
 			if block.Height != expectedHeight {

--- a/routing/chainview/neutrino.go
+++ b/routing/chainview/neutrino.go
@@ -12,6 +12,7 @@ import (
 	"github.com/btcsuite/btcutil/gcs/builder"
 	"github.com/btcsuite/btcwallet/waddrmgr"
 	"github.com/lightninglabs/neutrino"
+	"github.com/lightningnetwork/lnd/channeldb"
 )
 
 // CfFilteredChainView is an implementation of the FilteredChainView interface
@@ -96,7 +97,7 @@ func (c *CfFilteredChainView) Start() error {
 	// required that an user MUST set a addr/outpoint/txid when creating a
 	// rescan. To get around this, we'll add a "zero" outpoint, that won't
 	// actually be matched.
-	var zeroPoint wire.OutPoint
+	var zeroPoint neutrino.InputWithScript
 	rescanOptions := []neutrino.RescanOption{
 		neutrino.StartBlock(startingPoint),
 		neutrino.QuitChan(c.quit),
@@ -106,7 +107,7 @@ func (c *CfFilteredChainView) Start() error {
 				OnFilteredBlockDisconnected: c.onFilteredBlockDisconnected,
 			},
 		),
-		neutrino.WatchOutPoints(zeroPoint),
+		neutrino.WatchInputs(zeroPoint),
 	}
 
 	// Finally, we'll create our rescan struct, start it, and launch all
@@ -314,7 +315,7 @@ func (c *CfFilteredChainView) FilterBlock(blockHash *chainhash.Hash) (*FilteredB
 // rewound to ensure all relevant notifications are dispatched.
 //
 // NOTE: This is part of the FilteredChainView interface.
-func (c *CfFilteredChainView) UpdateFilter(ops []wire.OutPoint,
+func (c *CfFilteredChainView) UpdateFilter(ops []channeldb.EdgePoint,
 	updateHeight uint32) error {
 
 	log.Debugf("Updating chain filter with new UTXO's: %v", ops)
@@ -323,14 +324,22 @@ func (c *CfFilteredChainView) UpdateFilter(ops []wire.OutPoint,
 	// UTXO's, ignoring duplicates in the process.
 	c.filterMtx.Lock()
 	for _, op := range ops {
-		c.chainFilter[op] = builder.OutPointToFilterEntry(op)
+		c.chainFilter[op.OutPoint] = op.FundingPkScript
 	}
 	c.filterMtx.Unlock()
+
+	inputs := make([]neutrino.InputWithScript, len(ops))
+	for i, op := range ops {
+		inputs[i] = neutrino.InputWithScript{
+			PkScript: op.FundingPkScript,
+			OutPoint: op.OutPoint,
+		}
+	}
 
 	// With our internal chain view update, we'll craft a new update to the
 	// chainView which includes our new UTXO's, and current update height.
 	rescanUpdate := []neutrino.UpdateOption{
-		neutrino.AddOutPoints(ops...),
+		neutrino.AddInputs(inputs...),
 		neutrino.Rewind(updateHeight),
 		neutrino.DisableDisconnectedNtfns(true),
 	}

--- a/routing/notifications_test.go
+++ b/routing/notifications_test.go
@@ -10,15 +10,15 @@ import (
 
 	prand "math/rand"
 
+	"github.com/btcsuite/btcd/btcec"
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"github.com/btcsuite/btcd/wire"
+	"github.com/btcsuite/btcutil"
 	"github.com/go-errors/errors"
 	"github.com/lightningnetwork/lnd/channeldb"
 	"github.com/lightningnetwork/lnd/lnwallet"
 	"github.com/lightningnetwork/lnd/lnwire"
 	"github.com/lightningnetwork/lnd/routing/chainview"
-	"github.com/btcsuite/btcd/btcec"
-	"github.com/btcsuite/btcd/chaincfg/chainhash"
-	"github.com/btcsuite/btcd/wire"
-	"github.com/btcsuite/btcutil"
 )
 
 var (
@@ -176,7 +176,7 @@ func (m *mockChain) addUtxo(op wire.OutPoint, out *wire.TxOut) {
 	m.utxos[op] = *out
 	m.Unlock()
 }
-func (m *mockChain) GetUtxo(op *wire.OutPoint, _ uint32) (*wire.TxOut, error) {
+func (m *mockChain) GetUtxo(op *wire.OutPoint, _ []byte, _ uint32) (*wire.TxOut, error) {
 	m.RLock()
 	defer m.RUnlock()
 
@@ -242,12 +242,12 @@ func (m *mockChainView) Reset() {
 	m.staleBlocks = make(chan *chainview.FilteredBlock, 10)
 }
 
-func (m *mockChainView) UpdateFilter(ops []wire.OutPoint, updateHeight uint32) error {
+func (m *mockChainView) UpdateFilter(ops []channeldb.EdgePoint, updateHeight uint32) error {
 	m.Lock()
 	defer m.Unlock()
 
 	for _, op := range ops {
-		m.filter[op] = struct{}{}
+		m.filter[op.OutPoint] = struct{}{}
 	}
 
 	return nil

--- a/routing/router.go
+++ b/routing/router.go
@@ -967,7 +967,7 @@ func (r *ChannelRouter) processUpdate(msg interface{}) error {
 		// to obtain the full funding outpoint that's encoded within
 		// the channel ID.
 		channelID := lnwire.NewShortChanIDFromInt(msg.ChannelID)
-		fundingPoint, err := r.fetchChanPoint(&channelID)
+		fundingPoint, _, err := r.fetchChanPoint(&channelID)
 		if err != nil {
 			r.rejectMtx.Lock()
 			r.rejectCache[msg.ChannelID] = struct{}{}
@@ -977,11 +977,25 @@ func (r *ChannelRouter) processUpdate(msg interface{}) error {
 				"chan_id=%v: %v", msg.ChannelID, err)
 		}
 
+		// Recreate witness output to be sure that declared in channel
+		// edge bitcoin keys and channel value corresponds to the
+		// reality.
+		witnessScript, err := lnwallet.GenMultiSigScript(
+			msg.BitcoinKey1Bytes[:], msg.BitcoinKey2Bytes[:],
+		)
+		if err != nil {
+			return err
+		}
+		fundingPkScript, err := lnwallet.WitnessScriptHash(witnessScript)
+		if err != nil {
+			return err
+		}
+
 		// Now that we have the funding outpoint of the channel, ensure
 		// that it hasn't yet been spent. If so, then this channel has
 		// been closed so we'll ignore it.
 		chanUtxo, err := r.cfg.Chain.GetUtxo(
-			fundingPoint, channelID.BlockHeight,
+			fundingPoint, fundingPkScript, channelID.BlockHeight,
 		)
 		if err != nil {
 			r.rejectMtx.Lock()
@@ -993,26 +1007,14 @@ func (r *ChannelRouter) processUpdate(msg interface{}) error {
 				fundingPoint, err)
 		}
 
-		// Recreate witness output to be sure that declared in channel
-		// edge bitcoin keys and channel value corresponds to the
-		// reality.
-		_, witnessOutput, err := lnwallet.GenFundingPkScript(
-			msg.BitcoinKey1Bytes[:], msg.BitcoinKey2Bytes[:],
-			chanUtxo.Value,
-		)
-		if err != nil {
-			return errors.Errorf("unable to create funding pk "+
-				"script: %v", err)
-		}
-
 		// By checking the equality of witness pkscripts we checks that
 		// funding witness script is multisignature lock which contains
 		// both local and remote public keys which was declared in
 		// channel edge and also that the announced channel value is
 		// right.
-		if !bytes.Equal(witnessOutput.PkScript, chanUtxo.PkScript) {
+		if !bytes.Equal(fundingPkScript, chanUtxo.PkScript) {
 			return errors.Errorf("pkScript mismatch: expected %x, "+
-				"got %x", witnessOutput.PkScript, chanUtxo.PkScript)
+				"got %x", fundingPkScript, chanUtxo.PkScript)
 		}
 
 		// TODO(roasbeef): this is a hack, needs to be removed
@@ -1034,7 +1036,12 @@ func (r *ChannelRouter) processUpdate(msg interface{}) error {
 		// update the current UTXO filter within our active
 		// FilteredChainView so we are notified if/when this channel is
 		// closed.
-		filterUpdate := []wire.OutPoint{*fundingPoint}
+		filterUpdate := []channeldb.EdgePoint{
+			{
+				FundingPkScript: fundingPkScript,
+				OutPoint:        *fundingPoint,
+			},
+		}
 		err = r.cfg.ChainView.UpdateFilter(
 			filterUpdate, atomic.LoadUint32(&r.bestHeight),
 		)
@@ -1105,7 +1112,9 @@ func (r *ChannelRouter) processUpdate(msg interface{}) error {
 			// Before we can update the channel information, we'll
 			// ensure that the target channel is still open by
 			// querying the utxo-set for its existence.
-			chanPoint, err := r.fetchChanPoint(&channelID)
+			chanPoint, fundingPkScript, err := r.fetchChanPoint(
+				&channelID,
+			)
 			if err != nil {
 				r.rejectMtx.Lock()
 				r.rejectCache[msg.ChannelID] = struct{}{}
@@ -1116,7 +1125,7 @@ func (r *ChannelRouter) processUpdate(msg interface{}) error {
 					msg.ChannelID, err)
 			}
 			_, err = r.cfg.Chain.GetUtxo(
-				chanPoint, channelID.BlockHeight,
+				chanPoint, fundingPkScript, channelID.BlockHeight,
 			)
 			if err != nil {
 				r.rejectMtx.Lock()
@@ -1157,21 +1166,22 @@ func (r *ChannelRouter) processUpdate(msg interface{}) error {
 }
 
 // fetchChanPoint retrieves the original outpoint which is encoded within the
-// channelID.
+// channelID. This method also return the public key script for the target
+// transaction.
 //
 // TODO(roasbeef): replace with call to GetBlockTransaction? (would allow to
 // later use getblocktxn)
-func (r *ChannelRouter) fetchChanPoint(chanID *lnwire.ShortChannelID) (*wire.OutPoint, error) {
+func (r *ChannelRouter) fetchChanPoint(chanID *lnwire.ShortChannelID) (*wire.OutPoint, []byte, error) {
 	// First fetch the block hash by the block number encoded, then use
 	// that hash to fetch the block itself.
 	blockNum := int64(chanID.BlockHeight)
 	blockHash, err := r.cfg.Chain.GetBlockHash(blockNum)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	fundingBlock, err := r.cfg.Chain.GetBlock(blockHash)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	// As a sanity check, ensure that the advertised transaction index is
@@ -1179,7 +1189,7 @@ func (r *ChannelRouter) fetchChanPoint(chanID *lnwire.ShortChannelID) (*wire.Out
 	// block.
 	numTxns := uint32(len(fundingBlock.Transactions))
 	if chanID.TxIndex > numTxns-1 {
-		return nil, fmt.Errorf("tx_index=#%v is out of range "+
+		return nil, nil, fmt.Errorf("tx_index=#%v is out of range "+
 			"(max_index=%v), network_chan_id=%v\n", chanID.TxIndex,
 			numTxns-1, spew.Sdump(chanID))
 	}
@@ -1190,7 +1200,7 @@ func (r *ChannelRouter) fetchChanPoint(chanID *lnwire.ShortChannelID) (*wire.Out
 	return &wire.OutPoint{
 		Hash:  fundingTx.TxHash(),
 		Index: uint32(chanID.TxPosition),
-	}, nil
+	}, fundingTx.TxOut[chanID.TxPosition].PkScript, nil
 }
 
 // routingMsg couples a routing related routing topology update to the

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -1083,7 +1083,7 @@ func (r *rpcServer) CloseChannel(in *lnrpc.CloseChannelRequest,
 		errChan = make(chan error, 1)
 		notifier := r.server.cc.chainNotifier
 		go waitForChanToClose(uint32(bestHeight), notifier, errChan, chanPoint,
-			&closingTxid, func() {
+			&closingTxid, closingTx.TxOut[0].PkScript, func() {
 				// Respond to the local subsystem which
 				// requested the channel closure.
 				updateChan <- &lnrpc.CloseStatusUpdate{

--- a/test_utils.go
+++ b/test_utils.go
@@ -10,6 +10,10 @@ import (
 	"net"
 	"os"
 
+	"github.com/btcsuite/btcd/btcec"
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"github.com/btcsuite/btcd/wire"
+	"github.com/btcsuite/btcutil"
 	"github.com/lightningnetwork/lnd/chainntnfs"
 	"github.com/lightningnetwork/lnd/channeldb"
 	"github.com/lightningnetwork/lnd/contractcourt"
@@ -18,10 +22,6 @@ import (
 	"github.com/lightningnetwork/lnd/lnwallet"
 	"github.com/lightningnetwork/lnd/lnwire"
 	"github.com/lightningnetwork/lnd/shachain"
-	"github.com/btcsuite/btcd/btcec"
-	"github.com/btcsuite/btcd/chaincfg/chainhash"
-	"github.com/btcsuite/btcd/wire"
-	"github.com/btcsuite/btcutil"
 )
 
 var (

--- a/utxonursery.go
+++ b/utxonursery.go
@@ -1145,7 +1145,9 @@ func (u *utxoNursery) registerSweepConf(finalTx *wire.MsgTx,
 	finalTxID := finalTx.TxHash()
 
 	confChan, err := u.cfg.Notifier.RegisterConfirmationsNtfn(
-		&finalTxID, u.cfg.ConfDepth, heightHint)
+		&finalTxID, finalTx.TxOut[0].PkScript, u.cfg.ConfDepth,
+		heightHint,
+	)
 	if err != nil {
 		utxnLog.Errorf("unable to register notification for "+
 			"sweep confirmation: %v", finalTxID)
@@ -1251,7 +1253,9 @@ func (u *utxoNursery) registerTimeoutConf(baby *babyOutput, heightHint uint32) e
 
 	// Register for the confirmation of presigned htlc txn.
 	confChan, err := u.cfg.Notifier.RegisterConfirmationsNtfn(
-		&birthTxID, u.cfg.ConfDepth, heightHint)
+		&birthTxID, baby.timeoutTx.TxOut[0].PkScript, u.cfg.ConfDepth,
+		heightHint,
+	)
 	if err != nil {
 		return err
 	}
@@ -1316,8 +1320,10 @@ func (u *utxoNursery) registerPreschoolConf(kid *kidOutput, heightHint uint32) e
 	// de-duplicate
 	//  * need to do above?
 
-	confChan, err := u.cfg.Notifier.RegisterConfirmationsNtfn(&txID,
-		u.cfg.ConfDepth, heightHint)
+	pkScript := kid.signDesc.Output.PkScript
+	confChan, err := u.cfg.Notifier.RegisterConfirmationsNtfn(
+		&txID, pkScript, u.cfg.ConfDepth, heightHint,
+	)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
In this commit, we update all the primary interfaces to be compatible with the latest version of BIP 158. The major change is that we can no longer watch directly from txid's, instead we need to use the `pkScript` of an output on the transaction to use for filter matching. Similarly, for all spend notifications, we also need to pass in the `pkScript` of the _previous output script_. The following changes have been propagated to all relevant packages to ensure that the current codebase will be able to support the new version of the neutrino protocol without any other significant changes. 

This PR also updates the `dep` files to point to the latest versions of `btcwallet`, `btcd`, and neutrino. With this set of updates, the `lnd`+`neutrino` combo should be able to sync against `btcd` master (after an additional bug fix is added there ;). 

**NOTE TO REVIEWERS:** if this is scheduled to land before the expanded set of integration tests to cover `bitcoind` and `neutrino`, take special care to ensure that all areas where was pass in a new `pkScript` are actually passing in the _proper_ script. Otherwise, it's possible for us to miss sets of notifications which may have dire consequences. 


In this PR, we update the btcwallet dep to point to the latest
version of btcwallet. This new set of commits fixes two bugs:

   1. Ensure tx replacement works
     * fixes #763
