### PR TITLE
lnrpc: Add additional steps in README.md to install `glog` and `genproto`.

### DIFF
--- a/lnrpc/README.md
+++ b/lnrpc/README.md
@@ -149,7 +149,12 @@ $ unzip protoc-3.4.0-osx-x86_64.zip -d protoc
 $ export PATH=$PWD/protoc/bin:$PATH
 ```
 
-2. Install `golang/protobuf` at commit `ab9f9a6dab164b7d1246e0e688b0ab7b94d8553e`.
+2. Install `golang/glog`.
+```bash
+$ git clone https://github.com/golang/glog $GOPATH/src/github.com/golang/glog
+```
+
+3. Install `golang/protobuf` at commit `ab9f9a6dab164b7d1246e0e688b0ab7b94d8553e`.
 ```bash
 $ git clone https://github.com/golang/protobuf $GOPATH/src/github.com/golang/protobuf
 $ cd $GOPATH/src/github.com/golang/protobuf
@@ -157,7 +162,14 @@ $ git reset --hard ab9f9a6dab164b7d1246e0e688b0ab7b94d8553e
 $ make
 ```
 
-3. Install `grpc-ecosystem/grpc-gateway` at commit `f2862b476edcef83412c7af8687c9cd8e4097c0f`.
+4. Install `genproto`.
+```bash
+$ git clone https://github.com/google/go-genproto $GOPATH/src/google.golang.org/genproto
+$ cd $GOPATH/src/google.golang.org/genproto
+$ git reset --hard 40b7550fd0ba4b8f7e9d70ed40fcd4f3375db1de
+```
+
+5. Install `grpc-ecosystem/grpc-gateway` at commit `f2862b476edcef83412c7af8687c9cd8e4097c0f`.
 ```bash
 $ git clone https://github.com/grpc-ecosystem/grpc-gateway $GOPATH/src/github.com/grpc-ecosystem/grpc-gateway
 $ cd $GOPATH/src/github.com/grpc-ecosystem/grpc-gateway


### PR DESCRIPTION
In order to build `grpc-ecosystem/grpc-gateway` the packages `golang/glog`
and `genproto` are additionally required.

In order to match the versions of `protobuf` and `grpc-gateway` used
by lnrpc, `genproto` must also be set to the following commit:
40b7550fd0ba4b8f7e9d70ed40fcd4f3375db1de

Fixes #1570

Quick note that executing `go get google.golang.org/genproto` will result in the repository `github.com/google/go-genproto` being cloned, even though it looks strange since the package name and repository location are different.