### PR TITLE
Travis - prevent FAIL during integration test

### DIFF
--- a/htlcswitch/link_test.go
+++ b/htlcswitch/link_test.go
@@ -1693,6 +1693,9 @@ func updateState(batchTick chan time.Time, link *channelLink,
 // TODO(roasbeef): add sync hook into packet processing so can eliminate all
 // sleep in this test and the one below
 func TestChannelLinkBandwidthConsistency(t *testing.T) {
+	if !hodl.DebugBuild {
+		t.Fatalf("htlcswitch tests must be run with '-tags debug")
+	}
 	t.Parallel()
 
 	// TODO(roasbeef): replace manual bit twiddling with concept of
@@ -2628,6 +2631,10 @@ func TestChannelLinkTrimCircuitsPending(t *testing.T) {
 // TestChannelLinkTrimCircuitsNoCommit checks that the switch and link properly trim
 // circuits if the ADDs corresponding to open circuits are never committed.
 func TestChannelLinkTrimCircuitsNoCommit(t *testing.T) {
+	if !hodl.DebugBuild {
+		t.Fatalf("htlcswitch tests must be run with '-tags debug")
+	}
+
 	t.Parallel()
 
 	const (


### PR DESCRIPTION
As can Currently when running integration test without tag=debug (race = false), 3 tests fails . (as can be seen here [on Travis](https://travis-ci.org/lightningnetwork/lnd/jobs/405774237) by searching "--- fail"):

--- FAIL: TestChannelLinkTrimCircuitsNoCommit (0.76s)
	link_test.go:3806: line: 2741: wrong number of open circuits: want 0, got 2

--- FAIL: TestChannelLinkBandwidthConsistency (3.89s)
	link_test.go:1534: line 1939: alice's link bandwidth is incorrect: expected 399994624000 mSAT, got 499995656000 mSAT

--- FAIL: TestMask (0.00s)
	mask_test.go:91: htlcswitch tests must be run with '-tags debug'

Avoid that by skipping these tests.

Note that while 3 tests failed, the travis job is still marked green. This is handled by #1593 