### PR TITLE
Travis - Prevents random failures (start - race)

### DIFF
--- a/lnd.go
+++ b/lnd.go
@@ -568,44 +568,41 @@ func lndMain() error {
 		}()
 	}
 
-	// If we're not in simnet mode, We'll wait until we're fully synced to
-	// continue the start up of the remainder of the daemon. This ensures
-	// that we don't accept any possibly invalid state transitions, or
-	// accept channels with spent funds.
-	if !(cfg.Bitcoin.SimNet || cfg.Litecoin.SimNet) {
-		_, bestHeight, err := activeChainControl.chainIO.GetBestBlock()
-		if err != nil {
-			return err
-		}
+	// We'll wait until we're fully synced to continue the start up of the
+	// remainder of the daemon. This ensures that we don't accept any possibly
+	// invalid state transitions, or accept channels with spent funds.
+	_, bestHeight, err := activeChainControl.chainIO.GetBestBlock()
+	if err != nil {
+		return err
+	}
 
-		ltndLog.Infof("Waiting for chain backend to finish sync, "+
-			"start_height=%v", bestHeight)
+	ltndLog.Infof("Waiting for chain backend to finish sync, "+
+		"start_height=%v", bestHeight)
 
 		for {
 			if !signal.Alive() {
 				return nil
 			}
 
-			synced, _, err := activeChainControl.wallet.IsSynced()
-			if err != nil {
-				return err
-			}
-
-			if synced {
-				break
-			}
-
-			time.Sleep(time.Second * 1)
-		}
-
-		_, bestHeight, err = activeChainControl.chainIO.GetBestBlock()
+		synced, _, err := activeChainControl.wallet.IsSynced()
 		if err != nil {
 			return err
 		}
 
-		ltndLog.Infof("Chain backend is fully synced (end_height=%v)!",
-			bestHeight)
+		if synced {
+			break
+		}
+
+		time.Sleep(time.Second * 1)
 	}
+
+	_, bestHeight, err = activeChainControl.chainIO.GetBestBlock()
+	if err != nil {
+		return err
+	}
+
+	ltndLog.Infof("Chain backend is fully synced (end_height=%v)!",
+		bestHeight)
 
 	// With all the relevant chains initialized, we can finally start the
 	// server itself.

--- a/server.go
+++ b/server.go
@@ -707,8 +707,8 @@ func (s *server) Started() bool {
 // NOTE: This function is safe for concurrent access.
 func (s *server) Start() error {
 	// Already running?
-	if !atomic.CompareAndSwapInt32(&s.started, 0, 1) {
-		return nil
+	if s.Started(){
+		return fmt.Errorf("server started already")
 	}
 
 	if s.torController != nil {
@@ -779,6 +779,10 @@ func (s *server) Start() error {
 		go s.peerBootstrapper(defaultMinPeers, bootstrappers)
 	} else {
 		srvrLog.Infof("Auto peer bootstrapping is disabled")
+	}
+
+	if !atomic.CompareAndSwapInt32(&s.started, 0, 1) {
+		return fmt.Errorf("can't mark server as started")
 	}
 
 	return nil


### PR DESCRIPTION
When running Travis integration tests, sometimes there are random errors:

Nodes fail to stop
A node can't execute RPC call since the server is not running yet.

The reason for the problem is a race between LND startup and RPC stop call. Since the RPC port is open before the server startup is done a test may send a stop request (via RPC) before the startup is done. This may lead to a situation that the LND process will not stop.

This fix handles the problems by the following changes:

Ensure the completion of server startup. This is done by calling DisconnectPeer with an invalid pubKey and checking the result. DisconnectPeer returns an error ("chain backend is still syncing") until the server is marked started.

Indicates “server started” at the end of the Start() function and not at the start of it.

As an implication of this fix, we can also remove the special handling in lnd.go for using simnet (see diff). This makes the integration tests more realistic for testnet and mainnet.