### PR TITLE
Travis - Remove the t.parallel() from TestChannelLinkBidirectionalOneHopePayments.

### DIFF
--- a/htlcswitch/link_test.go
+++ b/htlcswitch/link_test.go
@@ -251,7 +251,11 @@ func TestChannelLinkSingleHopPayment(t *testing.T) {
 // link to cope with bigger number of payment updates that commitment
 // transaction may consist.
 func TestChannelLinkBidirectionalOneHopPayments(t *testing.T) {
-	t.Parallel()
+	// this test creates 966 parallel goroutines which create CPU pressure.
+	// Test itself is OK but impact on other tests is huge. to avoid impact on
+	// other tests that are using timeouts (sleep(x)) this test should not use
+	// t.Parallel
+	//t.Parallel()
 
 	channels, cleanUp, _, err := createClusterChannels(
 		btcutil.SatoshiPerBitcoin*3,


### PR DESCRIPTION
This test is CPU intensive and creates ~966 goroutings. While the test itself is OK it has impact on other tests that are running in parallel. In these other tests we can find sleep(time) that is used for sync. Due to this test the sleep(time) may be too short and may cause these tests to fail.