### PR TITLE
Travis - channel not opened before timeout

### DIFF
--- a/lnd_test.go
+++ b/lnd_test.go
@@ -8783,7 +8783,18 @@ func testSwitchOfflineDelivery(net *lntest.NetworkHarness, t *harnessTest) {
 
 	// Open a channel with 100k satoshis between Alice and Bob with Alice
 	// being the sole funder of the channel.
+	net.Alice.SetPort(19550)
+	err := net.RestartNode(net.Alice,nil)
+	if err != nil{
+		t.Fatalf("unable to restart Alice: %v", err)
+	}
+
 	ctxt, _ := context.WithTimeout(ctxb, timeout)
+	if err := net.EnsureConnected(ctxt, net.Alice, net.Bob); err != nil {
+		t.Fatalf("unable to reconnect Alice to Bob: %v", err)
+	}
+
+	ctxt, _ = context.WithTimeout(ctxb, timeout)
 	chanPointAlice := openChannelAndAssert(
 		ctxt, t, net, net.Alice, net.Bob, chanAmt, pushAmt, false,
 	)

--- a/lntest/node.go
+++ b/lntest/node.go
@@ -254,6 +254,13 @@ func (hn *HarnessNode) Name() string {
 	return hn.cfg.Name
 }
 
+// SetPort can be used to change P2P port of a node
+// TODO (Offer): remove once issue 1496 is resolved
+func (hn *HarnessNode) SetPort(port int)  {
+	hn.cfg.P2PPort = port
+}
+
+
 // Start launches a new process running lnd. Additionally, the PID of the
 // launched process is saved in order to possibly kill the process forcibly
 // later.


### PR DESCRIPTION
See issue #1496

This provides temporary solution until the bug described by 1496 is solved.

Alice and Bob connected.
testSwitchCircuitPersistence - restarts Alice and Bob. They will restore the connection by not always it will be by Alice
In case connection restored by Bob, testSwitchOfflineDelivery will fail.