### PR TITLE
travis - avoid deep compare error

### DIFF
--- a/lnwire/lnwire_test.go
+++ b/lnwire/lnwire_test.go
@@ -666,7 +666,9 @@ func TestLightningWireProtocol(t *testing.T) {
 				return
 			}
 
-			numChanIDs := rand.Int31n(5000)
+			// random number of ChanIDs. Make sure it is not zero to avoid
+			// deep compare error
+			numChanIDs := 1 + rand.Int31n(5000)
 
 			for i := int32(0); i < numChanIDs; i++ {
 				req.ShortChanIDs = append(req.ShortChanIDs,
@@ -698,7 +700,9 @@ func TestLightningWireProtocol(t *testing.T) {
 				req.EncodingType = EncodingSortedPlain
 			}
 
-			numChanIDs := rand.Int31n(5000)
+			// random number of ChanIDs. Make sure it is not zero to avoid
+			// deep compare error
+			numChanIDs := 1 + rand.Int31n(5000)
 
 			req.ShortChanIDs = make([]ShortChannelID, numChanIDs)
 			for i := int32(0); i < numChanIDs; i++ {


### PR DESCRIPTION
This problem will show up when running TestLightningWireProtocol when the random number of numChanIDs is zero. This problem is depends on the random function so we will see it only from time to time,

to simulate the problem just add

    numChanIDs = 0

    after line 701 at lnwire_test.go (so you force the random number to bu zero) to make it:

    			numChanIDs := rand.Int31n(5000)
    			numChanIDs = 0

    			req.ShortChanIDs = make([]ShortChannelID, numChanIDs)
    and run the test you will see the problem.

when running the tests you will get:

	lnwire_test.go:231: messages don't match after re-encoding: (*lnwire.ReplyChannelRange)(0xc420226230)({
		 QueryChannelRange: (lnwire.QueryChannelRange) {
		  ChainHash: (chainhash.Hash) (len=32 cap=32) b4d468adaa51fd220dad7373cb0442ca6ac4978671d01e63adececfaff69624d,
		  FirstBlockHeight: (uint32) 647747300,
		  NumBlocks: (uint32) 438264374
		 },
		 Complete: (uint8) 0,
		 EncodingType: (lnwire.ShortChanIDEncoding) 1,
		 ShortChanIDs: ([]lnwire.ShortChannelID) {
		 }
		})
		 vs (*lnwire.ReplyChannelRange)(0xc420226000)({
		 QueryChannelRange: (lnwire.QueryChannelRange) {
		  ChainHash: (chainhash.Hash) (len=32 cap=32) b4d468adaa51fd220dad7373cb0442ca6ac4978671d01e63adececfaff69624d,
		  FirstBlockHeight: (uint32) 647747300,
		  NumBlocks: (uint32) 438264374
		 },
		 Complete: (uint8) 0,
		 EncodingType: (lnwire.ShortChanIDEncoding) 1,
		 ShortChanIDs: ([]lnwire.ShortChannelID) <nil>
		})

Process finished with exit code 1