### PR TITLE
Travis - Stop cover tests in case of errors

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,6 +45,11 @@ COVER = for dir in $(GOLISTCOVER); do \
 			-covermode=count \
 			-coverprofile=$$dir/profile.tmp $$dir; \
 		\
+		if [ $$? != 0 ] ;\
+		then \
+		    exit 1 ;\
+		fi ;\
+		\
 		if [ -f $$dir/profile.tmp ]; then \
 			cat $$dir/profile.tmp | \
 				tail -n +2 >> profile.cov; \


### PR DESCRIPTION
enhance make file to stop the cover testing in case one of the tests failed. This release the travis resorces sooner.

Without this fix some tests may fail but the travis job run may looks good (green)

Also see #1587 