### PR TITLE
increase mining nodes timeout from 20 to 40 seconds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -115,9 +115,14 @@ $(BTCD_DIR):
 btcd: $(GLIDE_BIN) $(BTCD_DIR)
 	@$(call print, "Compiling btcd dependencies.")
 	cd $(BTCD_DIR) && git checkout $(BTCD_COMMIT) && glide install
+	@$(call print, "Patching btcd to allow longer startup of btc deamon.")
+	cd $(BTCD_DIR) && cp integration/rpctest/rpc_harness.go integration/rpctest/rpc_harness.go.prev
+	cd $(BTCD_DIR) && cat integration/rpctest/rpc_harness.go.prev|sed -e "195 s/20/40/" >integration/rpctest/rpc_harness.go;
 	@$(call print, "Installing btcd and btcctl.")
 	$(GOINSTALL) $(BTCD_PKG)
 	$(GOINSTALL) $(BTCD_PKG)/cmd/btcctl
+	cd $(BTCD_DIR) && cp integration/rpctest/rpc_harness.go.prev integration/rpctest/rpc_harness.go
+	cd $(BTCD_DIR) && rm integration/rpctest/rpc_harness.go.prev
 
 # ============
 # INSTALLATION


### PR DESCRIPTION
Avoid the error "unable to set up mining node: connection timeout"

LND's unit test is using BTCD integration/rpctest/rpc-harness to bring up mining nodes. The timeout for setting up a mining node is currently 20 seconds and is hard coded within BTCD without any external interface which allows it to be increased.

Many times these 20 seconds are too short for LND's tests under Travis which cause the test to fail with "unable to set up mining node: connection timeout"

This commit patches BTCD prior to the build and changes the 20 second to 40 second.

In order to see the problem just change 40 to 3 and rerun the tests.