### PR TITLE
channeldb+routing: prune unconnected graph vertexes on start up 

### DIFF
--- a/channeldb/graph.go
+++ b/channeldb/graph.go
@@ -734,7 +734,11 @@ func (c *ChannelGraph) pruneGraphNodes(tx *bolt.Tx, nodes *bolt.Bucket,
 			numChansLeft++
 			return nil
 		})
-		if err != nil {
+
+		// If we're unable read the node, or no edges exist in the
+		// graph atm (so all the nodes are unconnected), then we'll
+		// just skip this node all together.
+		if err != nil && err != ErrGraphNoEdgesFound {
 			continue
 		}
 

--- a/routing/router.go
+++ b/routing/router.go
@@ -956,34 +956,6 @@ func (r *ChannelRouter) processUpdate(msg interface{}) error {
 				"chan_id=%v", msg.ChannelID)
 		}
 
-		// Query the database for the existence of the two nodes in this
-		// channel. If not found, add a partial node to the database,
-		// containing only the node keys.
-		_, exists, _ = r.cfg.Graph.HasLightningNode(msg.NodeKey1Bytes)
-		if !exists {
-			node1 := &channeldb.LightningNode{
-				PubKeyBytes:          msg.NodeKey1Bytes,
-				HaveNodeAnnouncement: false,
-			}
-			err := r.cfg.Graph.AddLightningNode(node1)
-			if err != nil {
-				return errors.Errorf("unable to add node %v to"+
-					" the graph: %v", node1.PubKeyBytes, err)
-			}
-		}
-		_, exists, _ = r.cfg.Graph.HasLightningNode(msg.NodeKey2Bytes)
-		if !exists {
-			node2 := &channeldb.LightningNode{
-				PubKeyBytes:          msg.NodeKey2Bytes,
-				HaveNodeAnnouncement: false,
-			}
-			err := r.cfg.Graph.AddLightningNode(node2)
-			if err != nil {
-				return errors.Errorf("unable to add node %v to"+
-					" the graph: %v", node2.PubKeyBytes, err)
-			}
-		}
-
 		// Before we can add the channel to the channel graph, we need
 		// to obtain the full funding outpoint that's encoded within
 		// the channel ID.


### PR DESCRIPTION
IN this PR, we extend a recently merged PR to prune all unconnected graph vertexes on start up, just as we do for link nodes which on longer have an active channel. This change ensures that we maintain a compact lively channel graph at all times. 

Fixes #1607.