### PR TITLE
recreate rpc.pb.go

### DIFF
--- a/lnrpc/rpc.pb.go
+++ b/lnrpc/rpc.pb.go
@@ -518,9 +518,7 @@ func (m *FeeLimit) String() string            { return proto.CompactTextString(m
 func (*FeeLimit) ProtoMessage()               {}
 func (*FeeLimit) Descriptor() ([]byte, []int) { return fileDescriptor0, []int{11} }
 
-type isFeeLimit_Limit interface {
-	isFeeLimit_Limit()
-}
+type isFeeLimit_Limit interface{ isFeeLimit_Limit() }
 
 type FeeLimit_Fixed struct {
 	Fixed int64 `protobuf:"varint,1,opt,name=fixed,oneof"`
@@ -787,9 +785,7 @@ func (m *ChannelPoint) String() string            { return proto.CompactTextStri
 func (*ChannelPoint) ProtoMessage()               {}
 func (*ChannelPoint) Descriptor() ([]byte, []int) { return fileDescriptor0, []int{15} }
 
-type isChannelPoint_FundingTxid interface {
-	isChannelPoint_FundingTxid()
-}
+type isChannelPoint_FundingTxid interface{ isChannelPoint_FundingTxid() }
 
 type ChannelPoint_FundingTxidBytes struct {
 	FundingTxidBytes []byte `protobuf:"bytes,1,opt,name=funding_txid_bytes,proto3,oneof"`
@@ -2038,9 +2034,7 @@ func (m *CloseStatusUpdate) String() string            { return proto.CompactTex
 func (*CloseStatusUpdate) ProtoMessage()               {}
 func (*CloseStatusUpdate) Descriptor() ([]byte, []int) { return fileDescriptor0, []int{48} }
 
-type isCloseStatusUpdate_Update interface {
-	isCloseStatusUpdate_Update()
-}
+type isCloseStatusUpdate_Update interface{ isCloseStatusUpdate_Update() }
 
 type CloseStatusUpdate_ClosePending struct {
 	ClosePending *PendingUpdate `protobuf:"bytes,1,opt,name=close_pending,oneof"`
@@ -2303,9 +2297,7 @@ func (m *OpenStatusUpdate) String() string            { return proto.CompactText
 func (*OpenStatusUpdate) ProtoMessage()               {}
 func (*OpenStatusUpdate) Descriptor() ([]byte, []int) { return fileDescriptor0, []int{51} }
 
-type isOpenStatusUpdate_Update interface {
-	isOpenStatusUpdate_Update()
-}
+type isOpenStatusUpdate_Update interface{ isOpenStatusUpdate_Update() }
 
 type OpenStatusUpdate_ChanPending struct {
 	ChanPending *PendingUpdate `protobuf:"bytes,1,opt,name=chan_pending,oneof"`
@@ -4493,9 +4485,7 @@ func (m *PolicyUpdateRequest) String() string            { return proto.CompactT
 func (*PolicyUpdateRequest) ProtoMessage()               {}
 func (*PolicyUpdateRequest) Descriptor() ([]byte, []int) { return fileDescriptor0, []int{101} }
 
-type isPolicyUpdateRequest_Scope interface {
-	isPolicyUpdateRequest_Scope()
-}
+type isPolicyUpdateRequest_Scope interface{ isPolicyUpdateRequest_Scope() }
 
 type PolicyUpdateRequest_Global struct {
 	Global bool `protobuf:"varint,1,opt,name=global,oneof"`


### PR DESCRIPTION
I got some diff when I tried to execute `lnrpc/gen_protos.sh`.

I used libprotoc 3.6.0 for OSX.