### PR TITLE
lnwallet/size: correct commit to-local and 2nd stage script/witness sizes

### DIFF
--- a/breacharbiter.go
+++ b/breacharbiter.go
@@ -8,17 +8,17 @@ import (
 	"sync"
 	"sync/atomic"
 
+	"github.com/btcsuite/btcd/blockchain"
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"github.com/btcsuite/btcd/txscript"
+	"github.com/btcsuite/btcd/wire"
+	"github.com/btcsuite/btcutil"
 	"github.com/coreos/bbolt"
 	"github.com/davecgh/go-spew/spew"
 	"github.com/lightningnetwork/lnd/chainntnfs"
 	"github.com/lightningnetwork/lnd/channeldb"
 	"github.com/lightningnetwork/lnd/htlcswitch"
 	"github.com/lightningnetwork/lnd/lnwallet"
-	"github.com/btcsuite/btcd/blockchain"
-	"github.com/btcsuite/btcd/chaincfg/chainhash"
-	"github.com/btcsuite/btcd/txscript"
-	"github.com/btcsuite/btcd/wire"
-	"github.com/btcsuite/btcutil"
 )
 
 var (
@@ -993,7 +993,7 @@ func (b *breachArbiter) createJusticeTx(
 			witnessWeight = lnwallet.AcceptedHtlcPenaltyWitnessSize
 
 		case lnwallet.HtlcSecondLevelRevoke:
-			witnessWeight = lnwallet.SecondLevelHtlcPenaltyWitnessSize
+			witnessWeight = lnwallet.ToLocalPenaltyWitnessSize
 
 		default:
 			brarLog.Warnf("breached output in retribution info "+

--- a/lnwallet/size.go
+++ b/lnwallet/size.go
@@ -143,8 +143,8 @@ const (
 	WitnessHeaderSize = 1 + 1
 
 	// BaseTxSize 8 bytes
-	// - Version: 4 bytes
-	// - LockTime: 4 bytes
+	//      - Version: 4 bytes
+	//      - LockTime: 4 bytes
 	BaseTxSize = 4 + 4
 
 	// BaseCommitmentTxSize 125 + 43 * num-htlc-outputs bytes
@@ -186,67 +186,38 @@ const (
 	// weight limits.
 	MaxHTLCNumber = 966
 
-	// ToLocalScriptSize 83 bytes
-	//      - OP_IF: 1 byte
-	//              - OP_DATA: 1 byte (revocationkey length)
-	//              - revocationkey: 33 bytes
-	//              - OP_CHECKSIG: 1 byte
-	//      - OP_ELSE: 1 byte
-	//              - OP_DATA: 1 byte (localkey length)
-	//              - local_delay_key: 33 bytes
-	//              - OP_CHECKSIG_VERIFY: 1 byte
-	//              - OP_DATA: 1 byte (delay length)
-	//              - delay: 8 bytes
-	//              -OP_CHECKSEQUENCEVERIFY: 1 byte
-	//      - OP_ENDIF: 1 byte
-	ToLocalScriptSize = 1 + 1 + 33 + 1 + 1 + 1 + 33 + 1 + 1 + 8 + 1 + 1
-
-	// ToLocalTimeoutWitnessSize x bytes
-	//     - number_of_witness_elements: 1 byte
-	//     - local_delay_sig_length: 1 byte
-	//     - local_delay_sig: 73 bytes
-	//     - zero_length: 1 byte
-	//     - witness_script_length: 1 byte
-	//     - witness_script (to_local_script)
-	ToLocalTimeoutWitnessSize = 1 + 1 + 73 + 1 + 1 + ToLocalScriptSize
-
-	// ToLocalPenaltyWitnessSize 160 bytes
-	//      - number_of_witness_elements: 1 byte
-	//      - revocation_sig_length: 1 byte
-	//      - revocation_sig: 73 bytes
-	//      - one_length: 1 byte
-	//      - witness_script_length: 1 byte
-	//      - witness_script (to_local_script)
-	ToLocalPenaltyWitnessSize = 1 + 1 + 73 + 1 + 1 + ToLocalScriptSize
-
-	// SecondLevelHtlcScriptSize 73 bytes
+	// ToLocalScriptSize 79 bytes
 	//      - OP_IF: 1 byte
 	//          - OP_DATA: 1 byte
 	//          - revoke_key: 33 bytes
 	//      - OP_ELSE: 1 byte
-	//          - csv_delay: 1 byte
+	//          - OP_DATA: 1 byte
+	//          - csv_delay: 4 bytes
 	//          - OP_CHECKSEQUENCEVERIFY: 1 byte
 	//          - OP_DROP: 1 byte
+	//          - OP_DATA: 1 byte
 	//          - delay_key: 33 bytes
 	//      - OP_ENDIF: 1 byte
 	//      - OP_CHECKSIG: 1 byte
-	SecondLevelHtlcScriptSize = 73
+	ToLocalScriptSize = 1 + 1 + 33 + 1 + 1 + 4 + 1 + 1 + 1 + 33 + 1 + 1
 
-	// SecondLevelHtlcPenaltyWitnessSize 149 bytes
-	//  - number_of_witness_elements: 1 byte
-	//  - revoke_sig_length: 1 byte
-	//  - revoke_sig: 73 bytes
-	//  - OP_TRUE: 1 byte
-	//  - witness_script (second_level_script_size)
-	SecondLevelHtlcPenaltyWitnessSize = 1 + 1 + 73 + 1 + SecondLevelHtlcScriptSize
+	// ToLocalTimeoutWitnessSize 156 bytes
+	//      - number_of_witness_elements: 1 byte
+	//      - local_delay_sig_length: 1 byte
+	//      - local_delay_sig: 73 bytes
+	//      - zero_length: 1 byte
+	//      - witness_script_length: 1 byte
+	//      - witness_script (to_local_script)
+	ToLocalTimeoutWitnessSize = 1 + 1 + 73 + 1 + 1 + ToLocalScriptSize
 
-	// SecondLevelHtlcSuccessWitnessSize 149 bytes
-	//  - number_of_witness_elements: 1 byte
-	//  - success_sig_length: 1 byte
-	//  - success_sig: 73 bytes
-	//  - nil_length: 1 byte
-	//  - witness_script (second_level_script_size)
-	SecondLevelHtlcSuccessWitnessSize = 1 + 1 + 73 + 1 + SecondLevelHtlcScriptSize
+	// ToLocalPenaltyWitnessSize 156 bytes
+	//      - number_of_witness_elements: 1 byte
+	//      - revocation_sig_length: 1 byte
+	//      - revocation_sig: 73 bytes
+	//      - OP_TRUE: 1 byte
+	//      - witness_script_length: 1 byte
+	//      - witness_script (to_local_script)
+	ToLocalPenaltyWitnessSize = 1 + 1 + 73 + 1 + 1 + ToLocalScriptSize
 
 	// AcceptedHtlcScriptSize 139 bytes
 	//      - OP_DUP: 1 byte
@@ -286,34 +257,36 @@ const (
 	AcceptedHtlcScriptSize = 3*1 + 20 + 5*1 + 33 + 7*1 + 20 + 4*1 +
 		33 + 5*1 + 4 + 5*1
 
-	// AcceptedHtlcTimeoutWitnessSize 214
-	//  - number_of_witness_elements: 1 byte
-	//  - sender_sig: 73 bytes
-	//  - nil_length: 1 byte
-	//  - witness_script: (accepted_htlc_script)
-	AcceptedHtlcTimeoutWitnessSize = 1 + 73 + 1 + AcceptedHtlcScriptSize
+	// AcceptedHtlcTimeoutWitnessSize 216
+	//      - number_of_witness_elements: 1 byte
+	//      - sender_sig_length: 1 byte
+	//      - sender_sig: 73 bytes
+	//      - nil_length: 1 byte
+	//      - witness_script_length: 1 byte
+	//      - witness_script: (accepted_htlc_script)
+	AcceptedHtlcTimeoutWitnessSize = 1 + 1 + 73 + 1 + 1 + AcceptedHtlcScriptSize
 
-	// AcceptedHtlcSuccessWitnessSize 325 bytes
-	//    - number_of_witness_elements: 1 byte
-	//    - nil_length: 1 byte
-	//    - sig_alice_length: 1 byte
-	//    - sig_alice: 73 bytes
-	//    - sig_bob_length: 1 byte
-	//    - sig_bob: 73 bytes
-	//    - preimage_length: 1 byte
-	//    - preimage: 32 bytes
-	//    - witness_script_length: 1 byte
-	//    - witness_script (accepted_htlc_script)
+	// AcceptedHtlcSuccessWitnessSize 322 bytes
+	//      - number_of_witness_elements: 1 byte
+	//      - nil_length: 1 byte
+	//      - sig_alice_length: 1 byte
+	//      - sig_alice: 73 bytes
+	//      - sig_bob_length: 1 byte
+	//      - sig_bob: 73 bytes
+	//      - preimage_length: 1 byte
+	//      - preimage: 32 bytes
+	//      - witness_script_length: 1 byte
+	//      - witness_script (accepted_htlc_script)
 	AcceptedHtlcSuccessWitnessSize = 1 + 1 + 73 + 1 + 73 + 1 + 32 + 1 + AcceptedHtlcScriptSize
 
 	// AcceptedHtlcPenaltyWitnessSize 249 bytes
-	//    - number_of_witness_elements: 1 byte
-	//    - revocation_sig_length: 1 byte
-	//    - revocation_sig: 73 bytes
-	//    - revocation_key_length: 1 byte
-	//    - revocation_key: 33 bytes
-	//    - witness_script_length: 1 byte
-	//    - witness_script (accepted_htlc_script)
+	//      - number_of_witness_elements: 1 byte
+	//      - revocation_sig_length: 1 byte
+	//      - revocation_sig: 73 bytes
+	//      - revocation_key_length: 1 byte
+	//      - revocation_key: 33 bytes
+	//      - witness_script_length: 1 byte
+	//      - witness_script (accepted_htlc_script)
 	AcceptedHtlcPenaltyWitnessSize = 1 + 1 + 73 + 1 + 33 + 1 + AcceptedHtlcScriptSize
 
 	// OfferedHtlcScriptSize 133 bytes
@@ -351,26 +324,29 @@ const (
 	OfferedHtlcScriptSize = 3*1 + 20 + 5*1 + 33 + 10*1 + 33 + 5*1 + 20 + 4*1
 
 	// OfferedHtlcTimeoutWitnessSize 285 bytes
-	// - number_of_witness_elements: 1 byte
-	// - nil_length: 1 byte
-	// - sig_alice_length: 1 byte
-	// - sig_alice: 73 bytes
-	// - sig_bob_length: 1 byte
-	// - sig_bob: 73 bytes
-	// - nil_length: 1 byte
-	// - witness_script_length: 1 byte
-	// - witness_script (offered_htlc_script)
+	//      - number_of_witness_elements: 1 byte
+	//      - nil_length: 1 byte
+	//      - sig_alice_length: 1 byte
+	//      - sig_alice: 73 bytes
+	//      - sig_bob_length: 1 byte
+	//      - sig_bob: 73 bytes
+	//      - nil_length: 1 byte
+	//      - witness_script_length: 1 byte
+	//      - witness_script (offered_htlc_script)
 	OfferedHtlcTimeoutWitnessSize = 1 + 1 + 1 + 73 + 1 + 73 + 1 + 1 + OfferedHtlcScriptSize
 
-	// OfferedHtlcSuccessWitnessSize 283 bytes
-	// - number_of_witness_elements: 1 byte
-	// - nil_length: 1 byte
-	// - receiver_sig: 73 bytes
-	// - sender_sigs: 73 bytes
-	// - payment_preimage: 32 bytes
-	// - witness_script_length: 1 byte
-	// - witness_script (offered_htlc_script)
-	OfferedHtlcSuccessWitnessSize = 1 + 1 + 73 + 73 + 73 + 32 + 1 + OfferedHtlcScriptSize
+	// OfferedHtlcSuccessWitnessSize 317 bytes
+	//      - number_of_witness_elements: 1 byte
+	//      - nil_length: 1 byte
+	//      - receiver_sig_length: 1 byte
+	//      - receiver_sig: 73 bytes
+	//      - sender_sig_length: 1 byte
+	//      - sender_sig: 73 bytes
+	//      - payment_preimage_length: 1 byte
+	//      - payment_preimage: 32 bytes
+	//      - witness_script_length: 1 byte
+	//      - witness_script (offered_htlc_script)
+	OfferedHtlcSuccessWitnessSize = 1 + 1 + 1 + 73 + 1 + 73 + 1 + 32 + 1 + OfferedHtlcScriptSize
 
 	// OfferedHtlcPenaltyWitnessSize 243 bytes
 	//      - number_of_witness_elements: 1 byte
@@ -380,7 +356,7 @@ const (
 	//      - revocation_key: 33 bytes
 	//      - witness_script_length: 1 byte
 	//      - witness_script (offered_htlc_script)
-	OfferedHtlcPenaltyWitnessSize = 1 + 1 + 73 + 1 + 1 + OfferedHtlcScriptSize
+	OfferedHtlcPenaltyWitnessSize = 1 + 1 + 73 + 1 + 33 + 1 + OfferedHtlcScriptSize
 )
 
 // estimateCommitTxWeight estimate commitment transaction weight depending on

--- a/utxonursery.go
+++ b/utxonursery.go
@@ -8,14 +8,14 @@ import (
 	"sync"
 	"sync/atomic"
 
-	"github.com/davecgh/go-spew/spew"
-	"github.com/lightningnetwork/lnd/chainntnfs"
-	"github.com/lightningnetwork/lnd/channeldb"
-	"github.com/lightningnetwork/lnd/lnwallet"
 	"github.com/btcsuite/btcd/blockchain"
 	"github.com/btcsuite/btcd/txscript"
 	"github.com/btcsuite/btcd/wire"
 	"github.com/btcsuite/btcutil"
+	"github.com/davecgh/go-spew/spew"
+	"github.com/lightningnetwork/lnd/chainntnfs"
+	"github.com/lightningnetwork/lnd/channeldb"
+	"github.com/lightningnetwork/lnd/lnwallet"
 )
 
 //                          SUMMARY OF OUTPUT STATES
@@ -962,7 +962,7 @@ func (u *utxoNursery) createSweepTx(kgtnOutputs []kidOutput,
 		// sweep.
 		case lnwallet.HtlcOfferedTimeoutSecondLevel:
 			weightEstimate.AddWitnessInput(
-				lnwallet.SecondLevelHtlcSuccessWitnessSize,
+				lnwallet.ToLocalTimeoutWitnessSize,
 			)
 			csvOutputs = append(csvOutputs, input)
 
@@ -971,7 +971,7 @@ func (u *utxoNursery) createSweepTx(kgtnOutputs []kidOutput,
 		// sweep.
 		case lnwallet.HtlcAcceptedSuccessSecondLevel:
 			weightEstimate.AddWitnessInput(
-				lnwallet.SecondLevelHtlcSuccessWitnessSize,
+				lnwallet.ToLocalTimeoutWitnessSize,
 			)
 			csvOutputs = append(csvOutputs, input)
 


### PR DESCRIPTION
In this commit, we correct our size estimates for to-local scripts,
which are used on the commitment transaction and the htlc
success/timeout transactions. There have been observed cases of
transactions getting stuck because our estimates were too low, and cause
the transactions to not be relayed.

Our previous estimate for the commitment to-local script was correct
though comment had outdated script. Though the estimate is greater
than the actual size, this has been updated with a proposed estimate
of 79 bytes.

This estimate makes the assumption that CSV delays will be at most
4 bytes when serialized. Since this value is expressed in relative block
heights, this should be more than sufficient for our needs, even though
the maximum possible size for the little-endian int64 is 9 bytes (plus
an OP_DATA).

The other correction is to use the ToLocalScriptSize as our estimate for
htlc timeout/success scripts, as they are the same script. Previously,
our estimate was derived from the proper script, though we were 6 bytes
shy of the new to-local estimate, since we counted the csv_delay as 1
byte, and missed some other OP_DATAs.

All derived estimates have been updating depending on the new and
improved ToLocalScriptSize estimate, and fix some estimates that did not
include the witness length in the estimate.

Finally, we correct some weight miscalculations in:
 - AcceptedHtlcTimeoutWitnessSize: missing data push lengths
 - OfferedHtlcSuccessWitnessSize: extra 73 byte sig, missing data push lengths
 - OfferedHtlcPenaltyWitnessSize: missing 33 byte pubkey