### PR TITLE
Hide hodl config production

### DIFF
--- a/htlcswitch/hodl/config_debug.go
+++ b/htlcswitch/hodl/config_debug.go
@@ -1,3 +1,5 @@
+// +build debug
+
 package hodl
 
 // Config is a struct enumerating the possible command line flags that are used

--- a/htlcswitch/hodl/config_production.go
+++ b/htlcswitch/hodl/config_production.go
@@ -1,0 +1,11 @@
+// +build !debug
+
+package hodl
+
+// Config is an empty struct disabling command line hodl flags in production.
+type Config struct{}
+
+// Mask in production always returns MaskNone.
+func (c *Config) Mask() Mask {
+	return MaskNone
+}


### PR DESCRIPTION
This PR places the `hodl.Config` struct behind a build flag,
so that the command line flags are hidden in production
builds.

```
Production help before commit:

Tor:
      --tor.active
      --tor.socks=
      --tor.dns=
      --tor.streamisolation
      --tor.control=
      --tor.v2
      --tor.v2privatekeypath=
      --tor.v3

hodl:
      --hodl.exit-settle
      --hodl.add-incoming
      --hodl.settle-incoming
      --hodl.fail-incoming
      --hodl.add-outgoing
      --hodl.settle-outgoing
      --hodl.fail-outgoing
      --hodl.commit
      --hodl.bogus-settle

Help Options:
  -h, --help

Production help after commit:

Tor:
      --tor.active
      --tor.socks=
      --tor.dns=
      --tor.streamisolation
      --tor.control=
      --tor.v2
      --tor.v2privatekeypath=
      --tor.v3

Help Options:
  -h, --help
```