### PR TITLE
Move funding tx broadcasting to Fundingmanager

### DIFF
--- a/lnwallet/interface_test.go
+++ b/lnwallet/interface_test.go
@@ -430,6 +430,11 @@ func testDualFundingReservationWorkflow(miner *rpctest.Harness,
 		t.Fatalf("channel not detected as dual funder")
 	}
 
+	// Let Alice publish the funding transaction.
+	if err := alice.PublishTransaction(fundingTx); err != nil {
+		t.Fatalf("unable to publish funding tx: %v", err)
+	}
+
 	// Mine a single block, the funding transaction should be included
 	// within this block.
 	err = waitForMempoolTx(miner, &fundingSha)
@@ -844,6 +849,11 @@ func testSingleFunderReservationWorkflow(miner *rpctest.Harness,
 	if bobChannels[0].ChanType != channeldb.SingleFunder {
 		t.Fatalf("channel type is incorrect, expected %v instead got %v",
 			channeldb.SingleFunder, bobChannels[0].ChanType)
+	}
+
+	// Let Alice publish the funding transaction.
+	if err := alice.PublishTransaction(fundingTx); err != nil {
+		t.Fatalf("unable to publish funding tx: %v", err)
 	}
 
 	// Mine a single block, the funding transaction should be included

--- a/lnwallet/reservation.go
+++ b/lnwallet/reservation.go
@@ -4,12 +4,12 @@ import (
 	"net"
 	"sync"
 
-	"github.com/lightningnetwork/lnd/channeldb"
-	"github.com/lightningnetwork/lnd/lnwire"
 	"github.com/btcsuite/btcd/btcec"
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcd/wire"
 	"github.com/btcsuite/btcutil"
+	"github.com/lightningnetwork/lnd/channeldb"
+	"github.com/lightningnetwork/lnd/lnwire"
 )
 
 // ChannelContribution is the primary constituent of the funding workflow
@@ -434,11 +434,11 @@ func (r *ChannelReservation) OurSignatures() ([]*InputScript, []byte) {
 // https://github.com/bitcoin/bips/blob/master/bip-0069.mediawiki.
 // Additionally, verification is performed in order to ensure that the
 // counterparty supplied a valid signature to our version of the commitment
-// transaction.  Once this method returns, caller's should then call
-// .WaitForChannelOpen() which will block until the funding transaction obtains
-// the configured number of confirmations. Once the method unblocks, a
-// LightningChannel instance is returned, marking the channel available for
-// updates.
+// transaction.  Once this method returns, caller's should broadcast the
+// created funding transaction, then call .WaitForChannelOpen() which will
+// block until the funding transaction obtains the configured number of
+// confirmations. Once the method unblocks, a LightningChannel instance is
+// returned, marking the channel available for updates.
 func (r *ChannelReservation) CompleteReservation(fundingInputScripts []*InputScript,
 	commitmentSig []byte) (*channeldb.OpenChannel, error) {
 


### PR DESCRIPTION
Two commits to improve the handling of funding tx broadcasting errors.

#### fundingmanager: delete active reservation after channel is in DB
This commit makes sure we delete a pending channel from the set of
activeReservations within the fundingmanager immediately after the
channel is moved to the openChannelBucket in the DB. Previously we
wouldn't do this before the funding tx was confirmed, making it possible
that failing the funding flow at a later point would try to cancel a
non-existent reservation context.

#### lnwallet + funding: move funding tx publish to fundingmgr
This commit moves the responsibility for publishing the funding tx to
the network from the wallet to the funding manager. This is done to
distinguish the failure of completing the reservation within the wallet
and failure of publishing the transaction.

Earlier we could fail to broadcast the transaction, which would cause us
to fail the funding flow. This is not something we can do directly,
since the CompeteReservation call will mark the channel IsPending in the
databas.e