### PR TITLE
[htlcswitch/link] use FailFinalExpiryTooSoon as exit hop

### DIFF
--- a/htlcswitch/link.go
+++ b/htlcswitch/link.go
@@ -9,6 +9,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/davecgh/go-spew/spew"
 	"github.com/go-errors/errors"
 	"github.com/lightningnetwork/lnd/channeldb"
@@ -17,7 +18,6 @@ import (
 	"github.com/lightningnetwork/lnd/lnpeer"
 	"github.com/lightningnetwork/lnd/lnwallet"
 	"github.com/lightningnetwork/lnd/lnwire"
-	"github.com/btcsuite/btcd/chaincfg/chainhash"
 )
 
 func init() {
@@ -2155,7 +2155,7 @@ func (l *channelLink) processRemoteAdds(fwdPkg *channeldb.FwdPkg,
 					"soon: expiry=%v, best_height=%v",
 					pd.RHash[:], pd.Timeout, heightNow)
 
-				failure := lnwire.FailFinalIncorrectCltvExpiry{}
+				failure := lnwire.FailFinalExpiryTooSoon{}
 				l.sendHTLCError(
 					pd.HtlcIndex, &failure, obfuscator, pd.SourceRef,
 				)

--- a/htlcswitch/link_test.go
+++ b/htlcswitch/link_test.go
@@ -15,6 +15,10 @@ import (
 	"testing"
 	"time"
 
+	"github.com/btcsuite/btcd/btcec"
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"github.com/btcsuite/btcd/wire"
+	"github.com/btcsuite/btcutil"
 	"github.com/coreos/bbolt"
 	"github.com/davecgh/go-spew/spew"
 	"github.com/go-errors/errors"
@@ -24,10 +28,6 @@ import (
 	"github.com/lightningnetwork/lnd/lnpeer"
 	"github.com/lightningnetwork/lnd/lnwallet"
 	"github.com/lightningnetwork/lnd/lnwire"
-	"github.com/btcsuite/btcd/btcec"
-	"github.com/btcsuite/btcd/chaincfg/chainhash"
-	"github.com/btcsuite/btcd/wire"
-	"github.com/btcsuite/btcutil"
 )
 
 const (
@@ -1247,7 +1247,7 @@ func TestChannelLinkExpiryTooSoonExitNode(t *testing.T) {
 	}
 
 	switch ferr.FailureMessage.(type) {
-	case *lnwire.FailFinalIncorrectCltvExpiry:
+	case *lnwire.FailFinalExpiryTooSoon:
 	default:
 		t.Fatalf("incorrect error, expected final time lock too "+
 			"early, instead have: %v", err)


### PR DESCRIPTION
This PR corrects our exit hop logic to return
FailFinalExpiryTooSoon if the following check is true:
```golang
       pd.Timeout-expiryGraceDelta <= heightNow
```

Previously we returned FailFinalIncorrectCltvExpiry, which
should only be returned if the packet was misconstructed.

Fixes #1615 