### PR TITLE
routing: ensure generateSphinxPacket can handle being passed empty set of routes

### DIFF
--- a/routing/router_test.go
+++ b/routing/router_test.go
@@ -9,14 +9,14 @@ import (
 	"testing"
 	"time"
 
+	"github.com/btcsuite/btcd/wire"
 	"github.com/lightningnetwork/lnd/channeldb"
 	"github.com/lightningnetwork/lnd/htlcswitch"
-	"github.com/btcsuite/btcd/wire"
 
+	"github.com/btcsuite/btcd/btcec"
 	"github.com/davecgh/go-spew/spew"
 	"github.com/lightningnetwork/lightning-onion"
 	"github.com/lightningnetwork/lnd/lnwire"
-	"github.com/btcsuite/btcd/btcec"
 )
 
 // defaultNumRoutes is the default value for the maximum number of routes to
@@ -1939,5 +1939,18 @@ func TestIsStaleEdgePolicy(t *testing.T) {
 	}
 	if ctx.router.IsStaleEdgePolicy(*chanID, updateTimeStamp, 1) {
 		t.Fatalf("router failed to detect fresh edge policy")
+	}
+}
+
+// TestEmptyRoutesGenerateSphinxPacket tests that the generateSphinxPacket
+// function is able to gracefully handle being passed a nil set of hops for the
+// route by the caller.
+func TestEmptyRoutesGenerateSphinxPacket(t *testing.T) {
+	t.Parallel()
+
+	emptyRoute := &Route{}
+	_, _, err := generateSphinxPacket(emptyRoute, testHash[:])
+	if err != ErrNoRouteHopsProvided {
+		t.Fatalf("expected empty hops error: instead got: %v", err)
 	}
 }


### PR DESCRIPTION
In this commit, we add an additional defensive guard within `generateSphinxPacket` to ensure a caller of over the RPC interface cannot cause `lnd` to panic due to under-specifying the required set of inputs. 

Fixes #1651. 