### PR TITLE
discovery/gossiper: copy bolt key to prevent panic

### DIFF
--- a/discovery/gossiper.go
+++ b/discovery/gossiper.go
@@ -796,7 +796,13 @@ func (d *AuthenticatedGossiper) resendAnnounceSignatures() error {
 			if err != nil {
 				return err
 			}
-			t := msgTuple{peer, msg, k}
+
+			// Make a copy of the database key corresponding to
+			// these AnnounceSignatures.
+			dbKey := make([]byte, len(k))
+			copy(dbKey, k)
+
+			t := msgTuple{peer, msg, dbKey}
 
 			// Add the message to the slice, such that we can
 			// resend it after the database transaction is over.


### PR DESCRIPTION
Corrects an instance that holds a reference to a boltdb
byte slice after returning from the transaction. This
can cause panics under certain conditions, which is
avoided by creating a copy of the key.