### PR TITLE
Makefile: Restore linter

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -199,7 +199,7 @@ fmt:
 lint: $(LINT_BIN)
 	@$(call print, "Linting source.")
 	$(LINT_BIN) --install 1> /dev/null
-	test -z "$($(LINT))"
+	test -z "$$($(LINT))"
 
 list:
 	@$(call print, "Listing commands.")

--- a/autopilot/agent.go
+++ b/autopilot/agent.go
@@ -4,10 +4,10 @@ import (
 	"sync"
 	"sync/atomic"
 
-	"github.com/davecgh/go-spew/spew"
-	"github.com/lightningnetwork/lnd/lnwire"
 	"github.com/btcsuite/btcd/btcec"
 	"github.com/btcsuite/btcutil"
+	"github.com/davecgh/go-spew/spew"
+	"github.com/lightningnetwork/lnd/lnwire"
 )
 
 // Config couples all the items that an autopilot agent needs to function.

--- a/autopilot/graph.go
+++ b/autopilot/graph.go
@@ -7,11 +7,11 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/btcsuite/btcd/btcec"
+	"github.com/btcsuite/btcutil"
 	"github.com/coreos/bbolt"
 	"github.com/lightningnetwork/lnd/channeldb"
 	"github.com/lightningnetwork/lnd/lnwire"
-	"github.com/btcsuite/btcd/btcec"
-	"github.com/btcsuite/btcutil"
 )
 
 var (

--- a/autopilot/interface.go
+++ b/autopilot/interface.go
@@ -3,10 +3,10 @@ package autopilot
 import (
 	"net"
 
-	"github.com/lightningnetwork/lnd/lnwire"
 	"github.com/btcsuite/btcd/btcec"
 	"github.com/btcsuite/btcd/wire"
 	"github.com/btcsuite/btcutil"
+	"github.com/lightningnetwork/lnd/lnwire"
 )
 
 // Node node is an interface which represents n abstract vertex within the

--- a/autopilot/prefattach_test.go
+++ b/autopilot/prefattach_test.go
@@ -8,10 +8,10 @@ import (
 
 	prand "math/rand"
 
-	"github.com/lightningnetwork/lnd/channeldb"
-	"github.com/lightningnetwork/lnd/lnwire"
 	"github.com/btcsuite/btcd/btcec"
 	"github.com/btcsuite/btcutil"
+	"github.com/lightningnetwork/lnd/channeldb"
+	"github.com/lightningnetwork/lnd/lnwire"
 )
 
 func TestConstrainedPrefAttachmentNeedMoreChan(t *testing.T) {

--- a/breacharbiter_test.go
+++ b/breacharbiter_test.go
@@ -1259,7 +1259,7 @@ func TestBreachSecondLevelTransfer(t *testing.T) {
 	// output is spent by a second level tx.
 	secondLvlTx := &wire.MsgTx{
 		TxOut: []*wire.TxOut{
-			&wire.TxOut{Value: 1},
+			{Value: 1},
 		},
 	}
 	notifier.Spend(htlcOutpoint, 2, secondLvlTx)

--- a/brontide/conn.go
+++ b/brontide/conn.go
@@ -7,8 +7,8 @@ import (
 	"net"
 	"time"
 
-	"github.com/lightningnetwork/lnd/lnwire"
 	"github.com/btcsuite/btcd/btcec"
+	"github.com/lightningnetwork/lnd/lnwire"
 )
 
 // Conn is an implementation of net.Conn which enforces an authenticated key

--- a/brontide/noise_test.go
+++ b/brontide/noise_test.go
@@ -9,8 +9,8 @@ import (
 	"sync"
 	"testing"
 
-	"github.com/lightningnetwork/lnd/lnwire"
 	"github.com/btcsuite/btcd/btcec"
+	"github.com/lightningnetwork/lnd/lnwire"
 )
 
 type maybeNetConn struct {

--- a/chainntnfs/bitcoindnotify/driver.go
+++ b/chainntnfs/bitcoindnotify/driver.go
@@ -3,9 +3,9 @@ package bitcoindnotify
 import (
 	"fmt"
 
-	"github.com/lightningnetwork/lnd/chainntnfs"
 	"github.com/btcsuite/btcd/chaincfg"
 	"github.com/btcsuite/btcd/rpcclient"
+	"github.com/lightningnetwork/lnd/chainntnfs"
 )
 
 // createNewNotifier creates a new instance of the ChainNotifier interface

--- a/chainntnfs/btcdnotify/driver.go
+++ b/chainntnfs/btcdnotify/driver.go
@@ -3,8 +3,8 @@ package btcdnotify
 import (
 	"fmt"
 
-	"github.com/lightningnetwork/lnd/chainntnfs"
 	"github.com/btcsuite/btcd/rpcclient"
+	"github.com/lightningnetwork/lnd/chainntnfs"
 )
 
 // createNewNotifier creates a new instance of the ChainNotifier interface

--- a/chan_series.go
+++ b/chan_series.go
@@ -3,11 +3,11 @@ package main
 import (
 	"time"
 
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/lightningnetwork/lnd/channeldb"
 	"github.com/lightningnetwork/lnd/discovery"
 	"github.com/lightningnetwork/lnd/lnwire"
 	"github.com/lightningnetwork/lnd/routing"
-	"github.com/btcsuite/btcd/chaincfg/chainhash"
 )
 
 // chanSeries is an implementation of the discovery.ChannelGraphTimeSeries

--- a/chancloser.go
+++ b/chancloser.go
@@ -3,13 +3,13 @@ package main
 import (
 	"fmt"
 
+	"github.com/btcsuite/btcd/txscript"
+	"github.com/btcsuite/btcd/wire"
+	"github.com/btcsuite/btcutil"
 	"github.com/davecgh/go-spew/spew"
 	"github.com/lightningnetwork/lnd/htlcswitch"
 	"github.com/lightningnetwork/lnd/lnwallet"
 	"github.com/lightningnetwork/lnd/lnwire"
-	"github.com/btcsuite/btcd/txscript"
-	"github.com/btcsuite/btcd/wire"
-	"github.com/btcsuite/btcutil"
 )
 
 var (

--- a/channeldb/addr_test.go
+++ b/channeldb/addr_test.go
@@ -10,8 +10,8 @@ import (
 
 type unknownAddrType struct{}
 
-func (_ unknownAddrType) Network() string { return "unknown" }
-func (_ unknownAddrType) String() string  { return "unknown" }
+func (t unknownAddrType) Network() string { return "unknown" }
+func (t unknownAddrType) String() string  { return "unknown" }
 
 var addrTests = []struct {
 	expAddr net.Addr

--- a/channeldb/channel.go
+++ b/channeldb/channel.go
@@ -299,7 +299,7 @@ type ChannelStatus uint8
 
 var (
 	// Default is the normal state of an open channel.
-	Default ChannelStatus = 0
+	Default ChannelStatus
 
 	// Borked indicates that the channel has entered an irreconcilable
 	// state, triggered by a state desynchronization or channel breach.

--- a/channeldb/codec.go
+++ b/channeldb/codec.go
@@ -6,13 +6,13 @@ import (
 	"io"
 	"net"
 
-	"github.com/lightningnetwork/lnd/keychain"
-	"github.com/lightningnetwork/lnd/lnwire"
-	"github.com/lightningnetwork/lnd/shachain"
 	"github.com/btcsuite/btcd/btcec"
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcd/wire"
 	"github.com/btcsuite/btcutil"
+	"github.com/lightningnetwork/lnd/keychain"
+	"github.com/lightningnetwork/lnd/lnwire"
+	"github.com/lightningnetwork/lnd/shachain"
 )
 
 // outPointSize is the size of a serialized outpoint on disk.

--- a/channeldb/db.go
+++ b/channeldb/db.go
@@ -613,8 +613,8 @@ func (d *DB) MarkChanFullyClosed(chanPoint *wire.OutPoint) error {
 // pruneLinkNode determines whether we should garbage collect a link node from
 // the database due to no longer having any open channels with it. If there are
 // any left, then this acts as a no-op.
-func (db *DB) pruneLinkNode(tx *bolt.Tx, remotePub *btcec.PublicKey) error {
-	openChannels, err := db.fetchOpenChannels(tx, remotePub)
+func (d *DB) pruneLinkNode(tx *bolt.Tx, remotePub *btcec.PublicKey) error {
+	openChannels, err := d.fetchOpenChannels(tx, remotePub)
 	if err != nil {
 		return fmt.Errorf("unable to fetch open channels for peer %x: "+
 			"%v", remotePub.SerializeCompressed(), err)
@@ -627,20 +627,20 @@ func (db *DB) pruneLinkNode(tx *bolt.Tx, remotePub *btcec.PublicKey) error {
 	log.Infof("Pruning link node %x with zero open channels from database",
 		remotePub.SerializeCompressed())
 
-	return db.deleteLinkNode(tx, remotePub)
+	return d.deleteLinkNode(tx, remotePub)
 }
 
 // PruneLinkNodes attempts to prune all link nodes found within the databse with
 // whom we no longer have any open channels with.
-func (db *DB) PruneLinkNodes() error {
-	return db.Update(func(tx *bolt.Tx) error {
-		linkNodes, err := db.fetchAllLinkNodes(tx)
+func (d *DB) PruneLinkNodes() error {
+	return d.Update(func(tx *bolt.Tx) error {
+		linkNodes, err := d.fetchAllLinkNodes(tx)
 		if err != nil {
 			return err
 		}
 
 		for _, linkNode := range linkNodes {
-			err := db.pruneLinkNode(tx, linkNode.IdentityPub)
+			err := d.pruneLinkNode(tx, linkNode.IdentityPub)
 			if err != nil {
 				return err
 			}

--- a/channeldb/forwarding_package_test.go
+++ b/channeldb/forwarding_package_test.go
@@ -7,10 +7,10 @@ import (
 	"runtime"
 	"testing"
 
+	"github.com/btcsuite/btcd/wire"
 	"github.com/coreos/bbolt"
 	"github.com/lightningnetwork/lnd/channeldb"
 	"github.com/lightningnetwork/lnd/lnwire"
-	"github.com/btcsuite/btcd/wire"
 )
 
 // TestPkgFilterBruteForce tests the behavior of a pkg filter up to size 1000,

--- a/channeldb/graph.go
+++ b/channeldb/graph.go
@@ -809,8 +809,8 @@ func (c *ChannelGraph) pruneGraphNodes(tx *bolt.Tx, nodes *bolt.Bucket,
 
 		// With the nodes extracted, we'll increase the ref count of
 		// each of the nodes.
-		nodeRefCounts[node1] += 1
-		nodeRefCounts[node2] += 1
+		nodeRefCounts[node1]++
+		nodeRefCounts[node2]++
 
 		return nil
 	})

--- a/channeldb/nodes.go
+++ b/channeldb/nodes.go
@@ -129,13 +129,13 @@ func putLinkNode(nodeMetaBucket *bolt.Bucket, l *LinkNode) error {
 
 // DeleteLinkNode removes the link node with the given identity from the
 // database.
-func (d *DB) DeleteLinkNode(identity *btcec.PublicKey) error {
-	return d.Update(func(tx *bolt.Tx) error {
-		return d.deleteLinkNode(tx, identity)
+func (db *DB) DeleteLinkNode(identity *btcec.PublicKey) error {
+	return db.Update(func(tx *bolt.Tx) error {
+		return db.deleteLinkNode(tx, identity)
 	})
 }
 
-func (d *DB) deleteLinkNode(tx *bolt.Tx, identity *btcec.PublicKey) error {
+func (db *DB) deleteLinkNode(tx *bolt.Tx, identity *btcec.PublicKey) error {
 	nodeMetaBucket := tx.Bucket(nodeInfoBucket)
 	if nodeMetaBucket == nil {
 		return ErrLinkNodesNotFound

--- a/cmd/lncli/commands.go
+++ b/cmd/lncli/commands.go
@@ -18,11 +18,11 @@ import (
 	"syscall"
 
 	"github.com/awalterschulze/gographviz"
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"github.com/btcsuite/btcutil"
 	"github.com/golang/protobuf/jsonpb"
 	"github.com/golang/protobuf/proto"
 	"github.com/lightningnetwork/lnd/lnrpc"
-	"github.com/btcsuite/btcd/chaincfg/chainhash"
-	"github.com/btcsuite/btcutil"
 	"github.com/urfave/cli"
 	"golang.org/x/crypto/ssh/terminal"
 	"golang.org/x/net/context"

--- a/cmd/lncli/main.go
+++ b/cmd/lncli/main.go
@@ -27,8 +27,8 @@ import (
 const (
 	defaultTLSCertFilename  = "tls.cert"
 	defaultMacaroonFilename = "admin.macaroon"
-	defaultRpcPort          = "10009"
-	defaultRpcHostPort      = "localhost:" + defaultRpcPort
+	defaultRPCPort          = "10009"
+	defaultRPCHostPort      = "localhost:" + defaultRPCPort
 )
 
 var (
@@ -150,7 +150,7 @@ func getClientConn(ctx *cli.Context, skipMacaroons bool) *grpc.ClientConn {
 	// and not just TCP addresses.
 	opts = append(
 		opts, grpc.WithDialer(
-			lncfg.ClientAddressDialer(defaultRpcPort),
+			lncfg.ClientAddressDialer(defaultRPCPort),
 		),
 	)
 	conn, err := grpc.Dial(ctx.GlobalString("rpcserver"), opts...)
@@ -169,7 +169,7 @@ func main() {
 	app.Flags = []cli.Flag{
 		cli.StringFlag{
 			Name:  "rpcserver",
-			Value: defaultRpcHostPort,
+			Value: defaultRPCHostPort,
 			Usage: "host:port of ln daemon",
 		},
 		cli.StringFlag{

--- a/cmd/lncli/main.go
+++ b/cmd/lncli/main.go
@@ -14,10 +14,10 @@ import (
 
 	macaroon "gopkg.in/macaroon.v2"
 
+	"github.com/btcsuite/btcutil"
 	"github.com/lightningnetwork/lnd/lncfg"
 	"github.com/lightningnetwork/lnd/lnrpc"
 	"github.com/lightningnetwork/lnd/macaroons"
-	"github.com/btcsuite/btcutil"
 	"github.com/urfave/cli"
 
 	"google.golang.org/grpc"

--- a/contractcourt/briefcase.go
+++ b/contractcourt/briefcase.go
@@ -6,11 +6,11 @@ import (
 	"fmt"
 	"io"
 
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"github.com/btcsuite/btcd/wire"
 	"github.com/coreos/bbolt"
 	"github.com/lightningnetwork/lnd/channeldb"
 	"github.com/lightningnetwork/lnd/lnwallet"
-	"github.com/btcsuite/btcd/chaincfg/chainhash"
-	"github.com/btcsuite/btcd/wire"
 )
 
 // ContractResolutions is a wrapper struct around the two forms of resolutions

--- a/contractcourt/briefcase_test.go
+++ b/contractcourt/briefcase_test.go
@@ -10,15 +10,15 @@ import (
 
 	prand "math/rand"
 
+	"github.com/btcsuite/btcd/btcec"
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"github.com/btcsuite/btcd/txscript"
+	"github.com/btcsuite/btcd/wire"
 	"github.com/coreos/bbolt"
 	"github.com/davecgh/go-spew/spew"
 	"github.com/lightningnetwork/lnd/channeldb"
 	"github.com/lightningnetwork/lnd/lnwallet"
 	"github.com/lightningnetwork/lnd/lnwire"
-	"github.com/btcsuite/btcd/btcec"
-	"github.com/btcsuite/btcd/chaincfg/chainhash"
-	"github.com/btcsuite/btcd/txscript"
-	"github.com/btcsuite/btcd/wire"
 )
 
 var (

--- a/discovery/ann_validation.go
+++ b/discovery/ann_validation.go
@@ -3,11 +3,11 @@ package discovery
 import (
 	"bytes"
 
+	"github.com/btcsuite/btcd/btcec"
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/davecgh/go-spew/spew"
 	"github.com/go-errors/errors"
 	"github.com/lightningnetwork/lnd/lnwire"
-	"github.com/btcsuite/btcd/btcec"
-	"github.com/btcsuite/btcd/chaincfg/chainhash"
 )
 
 // ValidateChannelAnn validates the channel announcement message and checks

--- a/discovery/bootstrapper.go
+++ b/discovery/bootstrapper.go
@@ -12,13 +12,13 @@ import (
 	"strings"
 	"time"
 
+	"github.com/btcsuite/btcd/btcec"
+	"github.com/btcsuite/btcutil/bech32"
 	"github.com/davecgh/go-spew/spew"
 	"github.com/lightningnetwork/lnd/autopilot"
 	"github.com/lightningnetwork/lnd/lnwire"
 	"github.com/lightningnetwork/lnd/tor"
 	"github.com/miekg/dns"
-	"github.com/btcsuite/btcd/btcec"
-	"github.com/btcsuite/btcutil/bech32"
 )
 
 func init() {

--- a/discovery/gossiper.go
+++ b/discovery/gossiper.go
@@ -1225,9 +1225,9 @@ func (d *AuthenticatedGossiper) networkHandler() {
 	}
 }
 
-// TODO(roasbeef): d/c peers that send uupdates not on our chain
+// TODO(roasbeef): d/c peers that send updates not on our chain
 
-// InitPeerSyncState is called by outside sub-systems when a connection is
+// InitSyncState is called by outside sub-systems when a connection is
 // established to a new peer that understands how to perform channel range
 // queries. We'll allocate a new gossip syncer for it, and start any goroutines
 // needed to handle new queries. The recvUpdates bool indicates if we should

--- a/discovery/utils.go
+++ b/discovery/utils.go
@@ -1,11 +1,11 @@
 package discovery
 
 import (
+	"github.com/btcsuite/btcd/btcec"
 	"github.com/go-errors/errors"
 	"github.com/lightningnetwork/lnd/channeldb"
 	"github.com/lightningnetwork/lnd/lnwallet"
 	"github.com/lightningnetwork/lnd/lnwire"
-	"github.com/btcsuite/btcd/btcec"
 )
 
 // CreateChanAnnouncement is a helper function which creates all channel

--- a/htlcswitch/circuit_test.go
+++ b/htlcswitch/circuit_test.go
@@ -6,13 +6,13 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/btcsuite/btcd/btcec"
+	bitcoinCfg "github.com/btcsuite/btcd/chaincfg"
+	"github.com/btcsuite/btcutil"
 	"github.com/lightningnetwork/lightning-onion"
 	"github.com/lightningnetwork/lnd/channeldb"
 	"github.com/lightningnetwork/lnd/htlcswitch"
 	"github.com/lightningnetwork/lnd/lnwire"
-	"github.com/btcsuite/btcd/btcec"
-	bitcoinCfg "github.com/btcsuite/btcd/chaincfg"
-	"github.com/btcsuite/btcutil"
 )
 
 var (

--- a/htlcswitch/failure.go
+++ b/htlcswitch/failure.go
@@ -5,9 +5,9 @@ import (
 	"fmt"
 	"io"
 
+	"github.com/btcsuite/btcd/btcec"
 	"github.com/lightningnetwork/lightning-onion"
 	"github.com/lightningnetwork/lnd/lnwire"
-	"github.com/btcsuite/btcd/btcec"
 )
 
 // ForwardingError wraps an lnwire.FailureMessage in a struct that also

--- a/htlcswitch/iterator.go
+++ b/htlcswitch/iterator.go
@@ -4,9 +4,9 @@ import (
 	"encoding/binary"
 	"io"
 
+	"github.com/btcsuite/btcd/btcec"
 	"github.com/lightningnetwork/lightning-onion"
 	"github.com/lightningnetwork/lnd/lnwire"
-	"github.com/btcsuite/btcd/btcec"
 )
 
 // NetworkHop indicates the blockchain network that is intended to be the next

--- a/htlcswitch/link.go
+++ b/htlcswitch/link.go
@@ -40,10 +40,12 @@ const (
 	// and accepting updates.
 	minCommitFeePerKw = 253
 
-	// DefaultMinLinkFeeUpdateTimeout and DefaultMaxLinkFeeUpdateTimeout
-	// represent the default timeout bounds in which a link should propose
-	// to update its commitment fee rate.
+	// DefaultMinLinkFeeUpdateTimeout represents the minimum interval in
+	// which a link should propose to update its commitment fee rate.
 	DefaultMinLinkFeeUpdateTimeout = 10 * time.Minute
+
+	// DefaultMaxLinkFeeUpdateTimeout represents the maximum interval in
+	// which a link should propose to update its commitment fee rate.
 	DefaultMaxLinkFeeUpdateTimeout = 60 * time.Minute
 )
 

--- a/htlcswitch/switch_test.go
+++ b/htlcswitch/switch_test.go
@@ -9,12 +9,12 @@ import (
 	"testing"
 	"time"
 
+	"github.com/btcsuite/btcutil"
 	"github.com/btcsuite/fastsha256"
 	"github.com/davecgh/go-spew/spew"
 	"github.com/go-errors/errors"
 	"github.com/lightningnetwork/lnd/channeldb"
 	"github.com/lightningnetwork/lnd/lnwire"
-	"github.com/btcsuite/btcutil"
 )
 
 func genPreimage() ([32]byte, error) {

--- a/htlcswitch/test_utils.go
+++ b/htlcswitch/test_utils.go
@@ -14,6 +14,10 @@ import (
 	"testing"
 	"time"
 
+	"github.com/btcsuite/btcd/btcec"
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"github.com/btcsuite/btcd/wire"
+	"github.com/btcsuite/btcutil"
 	"github.com/btcsuite/fastsha256"
 	"github.com/coreos/bbolt"
 	"github.com/go-errors/errors"
@@ -24,10 +28,6 @@ import (
 	"github.com/lightningnetwork/lnd/lnwallet"
 	"github.com/lightningnetwork/lnd/lnwire"
 	"github.com/lightningnetwork/lnd/shachain"
-	"github.com/btcsuite/btcd/btcec"
-	"github.com/btcsuite/btcd/chaincfg/chainhash"
-	"github.com/btcsuite/btcd/wire"
-	"github.com/btcsuite/btcutil"
 )
 
 var (

--- a/lncfg/address.go
+++ b/lncfg/address.go
@@ -72,8 +72,8 @@ func ListenOnAddress(addr net.Addr) (net.Listener, error) {
 	return net.Listen(addr.Network(), addr.String())
 }
 
-// TlsListenOnAddress creates a TLS listener that listens on the given address.
-func TlsListenOnAddress(addr net.Addr,
+// TLSListenOnAddress creates a TLS listener that listens on the given address.
+func TLSListenOnAddress(addr net.Addr,
 	config *tls.Config) (net.Listener, error) {
 	return tls.Listen(addr.Network(), addr.String(), config)
 }

--- a/lnd.go
+++ b/lnd.go
@@ -360,7 +360,7 @@ func lndMain() error {
 		return err
 	}
 	for _, restEndpoint := range cfg.RESTListeners {
-		lis, err := lncfg.TlsListenOnAddress(restEndpoint, tlsConf)
+		lis, err := lncfg.TLSListenOnAddress(restEndpoint, tlsConf)
 		if err != nil {
 			ltndLog.Errorf(
 				"gRPC proxy unable to listen on %s",
@@ -761,7 +761,7 @@ func waitForWalletPassword(grpcEndpoints, restEndpoints []net.Addr,
 	srv := &http.Server{Handler: mux}
 
 	for _, restEndpoint := range restEndpoints {
-		lis, err := lncfg.TlsListenOnAddress(restEndpoint, tlsConf)
+		lis, err := lncfg.TLSListenOnAddress(restEndpoint, tlsConf)
 		if err != nil {
 			ltndLog.Errorf(
 				"password gRPC proxy unable to listen on %s",

--- a/lnd_test.go
+++ b/lnd_test.go
@@ -3995,7 +3995,9 @@ func testInvoiceRoutingHints(net *lntest.NetworkHarness, t *harnessTest) {
 
 		// We'll decode the invoice's payment request to determine which
 		// channels were used as routing hints.
-		payReq := &lnrpc.PayReqString{resp.PaymentRequest}
+		payReq := &lnrpc.PayReqString{
+			PayReq: resp.PaymentRequest,
+		}
 		decoded, err = net.Alice.DecodePayReq(ctxb, payReq)
 		if err != nil {
 			predErr = fmt.Errorf("unable to decode payment "+
@@ -10784,7 +10786,7 @@ func testRouteFeeCutoff(net *lntest.NetworkHarness, t *harnessTest) {
 		for i, hop := range route.Hops {
 			if hop.ChanId != hopChanIDs[i] {
 				t.Fatalf("expected chan id %d, got %d",
-					hop.ChanId)
+					hopChanIDs[i], hop.ChanId)
 			}
 		}
 	}

--- a/lntest/harness.go
+++ b/lntest/harness.go
@@ -11,7 +11,6 @@ import (
 	"golang.org/x/net/context"
 	"google.golang.org/grpc/grpclog"
 
-	"github.com/lightningnetwork/lnd/lnrpc"
 	"github.com/btcsuite/btcd/chaincfg"
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcd/integration/rpctest"
@@ -19,6 +18,7 @@ import (
 	"github.com/btcsuite/btcd/txscript"
 	"github.com/btcsuite/btcd/wire"
 	"github.com/btcsuite/btcutil"
+	"github.com/lightningnetwork/lnd/lnrpc"
 )
 
 // NetworkHarness is an integration testing harness for the lightning network.

--- a/lntest/node.go
+++ b/lntest/node.go
@@ -302,8 +302,10 @@ func (hn *HarnessNode) start(lndError chan<- error) error {
 						hex.EncodeToString(hn.PubKey[:logPubKeyBytes]))
 					err := os.Rename(fileName, newFileName)
 					if err != nil {
-						fmt.Errorf("could not rename %s to %s: %v",
-							fileName, newFileName, err)
+						fmt.Printf("could not rename "+
+							"%s to %s: %v\n",
+							fileName, newFileName,
+							err)
 					}
 				}
 			}
@@ -481,7 +483,7 @@ func (hn *HarnessNode) writePidFile() error {
 	return nil
 }
 
-// connectRPC uses the TLS certificate and admin macaroon files written by the
+// ConnectRPC uses the TLS certificate and admin macaroon files written by the
 // lnd node to create a gRPC client connection.
 func (hn *HarnessNode) ConnectRPC(useMacs bool) (*grpc.ClientConn, error) {
 	// Wait until TLS certificate and admin macaroon are created before

--- a/lntest/node.go
+++ b/lntest/node.go
@@ -20,13 +20,13 @@ import (
 	"google.golang.org/grpc/credentials"
 	macaroon "gopkg.in/macaroon.v2"
 
-	"github.com/go-errors/errors"
-	"github.com/lightningnetwork/lnd/lnrpc"
-	"github.com/lightningnetwork/lnd/macaroons"
 	"github.com/btcsuite/btcd/chaincfg"
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcd/rpcclient"
 	"github.com/btcsuite/btcd/wire"
+	"github.com/go-errors/errors"
+	"github.com/lightningnetwork/lnd/lnrpc"
+	"github.com/lightningnetwork/lnd/macaroons"
 )
 
 var (

--- a/lnwallet/btcwallet/driver.go
+++ b/lnwallet/btcwallet/driver.go
@@ -3,8 +3,8 @@ package btcwallet
 import (
 	"fmt"
 
-	"github.com/lightningnetwork/lnd/lnwallet"
 	"github.com/btcsuite/btcwallet/chain"
+	"github.com/lightningnetwork/lnd/lnwallet"
 )
 
 const (

--- a/lnwallet/btcwallet/signer.go
+++ b/lnwallet/btcwallet/signer.go
@@ -1,9 +1,6 @@
 package btcwallet
 
 import (
-	"github.com/go-errors/errors"
-	"github.com/lightningnetwork/lnd/keychain"
-	"github.com/lightningnetwork/lnd/lnwallet"
 	"github.com/btcsuite/btcd/btcec"
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcd/txscript"
@@ -12,6 +9,9 @@ import (
 	"github.com/btcsuite/btcwallet/waddrmgr"
 	base "github.com/btcsuite/btcwallet/wallet"
 	"github.com/btcsuite/btcwallet/walletdb"
+	"github.com/go-errors/errors"
+	"github.com/lightningnetwork/lnd/keychain"
+	"github.com/lightningnetwork/lnd/lnwallet"
 )
 
 // FetchInputInfo queries for the WalletController's knowledge of the passed

--- a/lnwallet/channel.go
+++ b/lnwallet/channel.go
@@ -3924,7 +3924,7 @@ func (i *InvalidCommitSigError) Error() string {
 // error interface.
 var _ error = (*InvalidCommitSigError)(nil)
 
-// InvalidCommitSigError is a struc that implements the error interface to
+// InvalidHtlcSigError is a struct that implements the error interface to
 // report a failure to validate an htlc signature from a remote peer. We'll use
 // the items in this struct to generate a rich error message for the remote
 // peer when we receive an invalid signature from it. Doing so can greatly aide

--- a/lnwallet/config.go
+++ b/lnwallet/config.go
@@ -1,10 +1,10 @@
 package lnwallet
 
 import (
+	"github.com/btcsuite/btcd/chaincfg"
 	"github.com/lightningnetwork/lnd/chainntnfs"
 	"github.com/lightningnetwork/lnd/channeldb"
 	"github.com/lightningnetwork/lnd/keychain"
-	"github.com/btcsuite/btcd/chaincfg"
 )
 
 // Config is a struct which houses configuration parameters which modify the

--- a/lnwallet/errors.go
+++ b/lnwallet/errors.go
@@ -4,9 +4,9 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/lightningnetwork/lnd/lnwire"
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcutil"
+	"github.com/lightningnetwork/lnd/lnwire"
 )
 
 // ReservationError wraps certain errors returned during channel reservation

--- a/lnwallet/fee_estimator_test.go
+++ b/lnwallet/fee_estimator_test.go
@@ -3,8 +3,8 @@ package lnwallet_test
 import (
 	"testing"
 
-	"github.com/lightningnetwork/lnd/lnwallet"
 	"github.com/btcsuite/btcutil"
+	"github.com/lightningnetwork/lnd/lnwallet"
 )
 
 // TestFeeRateTypes checks that converting fee rates between the

--- a/lnwallet/interface_test.go
+++ b/lnwallet/interface_test.go
@@ -2190,7 +2190,6 @@ func runTests(t *testing.T, walletDriver *lnwallet.WalletDriver,
 				t.Fatalf("couldn't start bob client: %v", err)
 			}
 		default:
-			return
 			t.Fatalf("unknown chain driver: %v", backEnd)
 		}
 

--- a/lnwallet/reservation.go
+++ b/lnwallet/reservation.go
@@ -4,12 +4,12 @@ import (
 	"net"
 	"sync"
 
-	"github.com/lightningnetwork/lnd/channeldb"
-	"github.com/lightningnetwork/lnd/lnwire"
 	"github.com/btcsuite/btcd/btcec"
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcd/wire"
 	"github.com/btcsuite/btcutil"
+	"github.com/lightningnetwork/lnd/channeldb"
+	"github.com/lightningnetwork/lnd/lnwire"
 )
 
 // ChannelContribution is the primary constituent of the funding workflow

--- a/lnwallet/signdescriptor.go
+++ b/lnwallet/signdescriptor.go
@@ -5,10 +5,10 @@ import (
 	"errors"
 	"io"
 
-	"github.com/lightningnetwork/lnd/keychain"
 	"github.com/btcsuite/btcd/btcec"
 	"github.com/btcsuite/btcd/txscript"
 	"github.com/btcsuite/btcd/wire"
+	"github.com/lightningnetwork/lnd/keychain"
 )
 
 var (

--- a/lnwallet/signdescriptor_test.go
+++ b/lnwallet/signdescriptor_test.go
@@ -5,10 +5,10 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/lightningnetwork/lnd/keychain"
 	"github.com/btcsuite/btcd/btcec"
 	"github.com/btcsuite/btcd/txscript"
 	"github.com/btcsuite/btcd/wire"
+	"github.com/lightningnetwork/lnd/keychain"
 )
 
 func TestSignDescriptorSerialization(t *testing.T) {

--- a/lnwallet/sigpool.go
+++ b/lnwallet/sigpool.go
@@ -5,9 +5,9 @@ import (
 	"sync"
 	"sync/atomic"
 
-	"github.com/lightningnetwork/lnd/lnwire"
 	"github.com/btcsuite/btcd/btcec"
 	"github.com/btcsuite/btcd/wire"
+	"github.com/lightningnetwork/lnd/lnwire"
 )
 
 const (

--- a/lnwallet/size_test.go
+++ b/lnwallet/size_test.go
@@ -3,12 +3,12 @@ package lnwallet_test
 import (
 	"testing"
 
-	"github.com/lightningnetwork/lnd/lnwallet"
 	"github.com/btcsuite/btcd/blockchain"
 	"github.com/btcsuite/btcd/chaincfg"
 	"github.com/btcsuite/btcd/txscript"
 	"github.com/btcsuite/btcd/wire"
 	"github.com/btcsuite/btcutil"
+	"github.com/lightningnetwork/lnd/lnwallet"
 )
 
 // TestTxWeightEstimator tests that transaction weight estimates are calculated

--- a/lnwallet/test_utils.go
+++ b/lnwallet/test_utils.go
@@ -12,16 +12,16 @@ import (
 	"os"
 	"sync"
 
-	"github.com/lightningnetwork/lnd/channeldb"
-	"github.com/lightningnetwork/lnd/keychain"
-	"github.com/lightningnetwork/lnd/lnwire"
-	"github.com/lightningnetwork/lnd/shachain"
 	"github.com/btcsuite/btcd/btcec"
 	"github.com/btcsuite/btcd/chaincfg"
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcd/txscript"
 	"github.com/btcsuite/btcd/wire"
 	"github.com/btcsuite/btcutil"
+	"github.com/lightningnetwork/lnd/channeldb"
+	"github.com/lightningnetwork/lnd/keychain"
+	"github.com/lightningnetwork/lnd/lnwire"
+	"github.com/lightningnetwork/lnd/shachain"
 )
 
 var (

--- a/lnwallet/transactions_test.go
+++ b/lnwallet/transactions_test.go
@@ -6,16 +6,16 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/davecgh/go-spew/spew"
-	"github.com/lightningnetwork/lnd/channeldb"
-	"github.com/lightningnetwork/lnd/keychain"
-	"github.com/lightningnetwork/lnd/lnwire"
-	"github.com/lightningnetwork/lnd/shachain"
 	"github.com/btcsuite/btcd/btcec"
 	"github.com/btcsuite/btcd/chaincfg"
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcd/wire"
 	"github.com/btcsuite/btcutil"
+	"github.com/davecgh/go-spew/spew"
+	"github.com/lightningnetwork/lnd/channeldb"
+	"github.com/lightningnetwork/lnd/keychain"
+	"github.com/lightningnetwork/lnd/lnwire"
+	"github.com/lightningnetwork/lnd/shachain"
 )
 
 /**

--- a/lnwire/gossip_timestamp_range.go
+++ b/lnwire/gossip_timestamp_range.go
@@ -72,7 +72,7 @@ func (g *GossipTimestampRange) MsgType() MessageType {
 // version.
 //
 // This is part of the lnwire.Message interface.
-func (c *GossipTimestampRange) MaxPayloadLength(uint32) uint32 {
+func (g *GossipTimestampRange) MaxPayloadLength(uint32) uint32 {
 	// 32 + 4 + 4
 	//
 	// TODO(roasbeef): update to 8 byte timestmaps?

--- a/macaroons/constraints_test.go
+++ b/macaroons/constraints_test.go
@@ -99,7 +99,7 @@ func TestIpLockConstraint(t *testing.T) {
 // TestIPLockBadIP tests that an IP constraint cannot be added if the
 // provided string is not a valid IP address.
 func TestIPLockBadIP(t *testing.T) {
-	constraintFunc := macaroons.IPLockConstraint("127.0.0/800");
+	constraintFunc := macaroons.IPLockConstraint("127.0.0/800")
 	testMacaroon := createDummyMacaroon(t)
 	err := constraintFunc(testMacaroon)
 	if err == nil {

--- a/macaroons/constraints_test.go
+++ b/macaroons/constraints_test.go
@@ -1,11 +1,11 @@
 package macaroons_test
 
 import (
-	"testing"
 	"github.com/lightningnetwork/lnd/macaroons"
 	"gopkg.in/macaroon.v2"
-	"time"
 	"strings"
+	"testing"
+	"time"
 )
 
 var (

--- a/macaroons/service_test.go
+++ b/macaroons/service_test.go
@@ -1,18 +1,18 @@
 package macaroons_test
 
 import (
-	"testing"
-	"path"
-	"os"
 	"context"
-	"io/ioutil"
 	"encoding/hex"
+	"io/ioutil"
+	"os"
+	"path"
+	"testing"
 
 	"github.com/coreos/bbolt"
 	"github.com/lightningnetwork/lnd/macaroons"
-	"gopkg.in/macaroon-bakery.v2/bakery/checkers"
-	"gopkg.in/macaroon-bakery.v2/bakery"
 	"google.golang.org/grpc/metadata"
+	"gopkg.in/macaroon-bakery.v2/bakery"
+	"gopkg.in/macaroon-bakery.v2/bakery/checkers"
 )
 
 var (

--- a/nodesigner.go
+++ b/nodesigner.go
@@ -3,9 +3,9 @@ package main
 import (
 	"fmt"
 
-	"github.com/lightningnetwork/lnd/lnwallet"
 	"github.com/btcsuite/btcd/btcec"
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"github.com/lightningnetwork/lnd/lnwallet"
 )
 
 // nodeSigner is an implementation of the MessageSigner interface backed by the

--- a/nursery_store.go
+++ b/nursery_store.go
@@ -5,10 +5,10 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/coreos/bbolt"
-	"github.com/lightningnetwork/lnd/channeldb"
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcd/wire"
+	"github.com/coreos/bbolt"
+	"github.com/lightningnetwork/lnd/channeldb"
 )
 
 //	              Overview of Nursery Store Storage Hierarchy

--- a/nursery_store_test.go
+++ b/nursery_store_test.go
@@ -8,9 +8,9 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/btcsuite/btcd/wire"
 	"github.com/btcsuite/btclog"
 	"github.com/lightningnetwork/lnd/channeldb"
-	"github.com/btcsuite/btcd/wire"
 )
 
 func init() {

--- a/peer_test.go
+++ b/peer_test.go
@@ -6,7 +6,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/btcsuite/btcd/wire"
 	"github.com/btcsuite/btclog"
+	"github.com/btcsuite/btcutil"
 	"github.com/lightningnetwork/lnd/chainntnfs"
 	"github.com/lightningnetwork/lnd/channeldb"
 	"github.com/lightningnetwork/lnd/contractcourt"
@@ -14,8 +16,6 @@ import (
 	"github.com/lightningnetwork/lnd/lnrpc"
 	"github.com/lightningnetwork/lnd/lnwallet"
 	"github.com/lightningnetwork/lnd/lnwire"
-	"github.com/btcsuite/btcd/wire"
-	"github.com/btcsuite/btcutil"
 )
 
 func init() {

--- a/routing/missioncontrol.go
+++ b/routing/missioncontrol.go
@@ -5,10 +5,10 @@ import (
 	"sync"
 	"time"
 
+	"github.com/btcsuite/btcd/btcec"
 	"github.com/coreos/bbolt"
 	"github.com/lightningnetwork/lnd/channeldb"
 	"github.com/lightningnetwork/lnd/lnwire"
-	"github.com/btcsuite/btcd/btcec"
 )
 
 const (

--- a/routing/notifications.go
+++ b/routing/notifications.go
@@ -6,13 +6,13 @@ import (
 	"sync"
 	"sync/atomic"
 
+	"github.com/btcsuite/btcd/btcec"
+	"github.com/btcsuite/btcd/wire"
+	"github.com/btcsuite/btcutil"
 	"github.com/davecgh/go-spew/spew"
 	"github.com/go-errors/errors"
 	"github.com/lightningnetwork/lnd/channeldb"
 	"github.com/lightningnetwork/lnd/lnwire"
-	"github.com/btcsuite/btcd/btcec"
-	"github.com/btcsuite/btcd/wire"
-	"github.com/btcsuite/btcutil"
 )
 
 // TopologyClient represents an intent to receive notifications from the

--- a/routing/pathfind.go
+++ b/routing/pathfind.go
@@ -8,13 +8,13 @@ import (
 
 	"container/heap"
 
+	"github.com/btcsuite/btcd/btcec"
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"github.com/btcsuite/btcutil"
 	"github.com/coreos/bbolt"
 	"github.com/lightningnetwork/lightning-onion"
 	"github.com/lightningnetwork/lnd/channeldb"
 	"github.com/lightningnetwork/lnd/lnwire"
-	"github.com/btcsuite/btcd/btcec"
-	"github.com/btcsuite/btcd/chaincfg/chainhash"
-	"github.com/btcsuite/btcutil"
 )
 
 const (

--- a/routing/pathfind.go
+++ b/routing/pathfind.go
@@ -66,7 +66,7 @@ type HopHint struct {
 // ChannelHop describes the channel through which an intermediate or final
 // hop can be reached. This struct contains the relevant routing policy of
 // the particular edge (which is a property of the source node of the channel
-// edge), as well as the total capacity. It also includes the origin chain of 
+// edge), as well as the total capacity. It also includes the origin chain of
 // the channel itself.
 type ChannelHop struct {
 	// Capacity is the total capacity of the channel being traversed. This
@@ -87,7 +87,7 @@ type ChannelHop struct {
 // is in line with the definition given in BOLT #4: Onion Routing Protocol.
 // The struct houses the channel along which this hop can be reached and
 // the values necessary to create the HTLC that needs to be sent to the
-// next hop. It is also used to encode the per-hop payload included within 
+// next hop. It is also used to encode the per-hop payload included within
 // the Sphinx packet.
 type Hop struct {
 	// Channel is the active payment channel edge along which the packet
@@ -297,7 +297,7 @@ func newRoute(amtToSend, feeLimit lnwire.MilliSatoshi, sourceVertex Vertex,
 		route.chanIndex[edge.ChannelID] = struct{}{}
 
 		// If this isn't a direct payment, and this isn't the edge to
-		// the last hop in the route, then we'll also populate the 
+		// the last hop in the route, then we'll also populate the
 		// nextHop map to allow easy route traversal by callers.
 		if len(pathEdges) > 1 && i != len(pathEdges)-1 {
 			route.nextHopMap[v] = route.Hops[i+1].Channel
@@ -316,7 +316,7 @@ func newRoute(amtToSend, feeLimit lnwire.MilliSatoshi, sourceVertex Vertex,
 		// reporting through RPC. Set to zero for the final hop.
 		fee := lnwire.MilliSatoshi(0)
 
-		// If the current hop isn't the last hop, then add enough funds 
+		// If the current hop isn't the last hop, then add enough funds
 		// to pay for transit over the next link.
 		if i != len(pathEdges)-1 {
 			// We'll grab the per-hop payload of the next hop (the
@@ -324,13 +324,13 @@ func newRoute(amtToSend, feeLimit lnwire.MilliSatoshi, sourceVertex Vertex,
 			// route so we can calculate fees properly.
 			nextHop := route.Hops[i+1]
 
-			// The amount that the current hop needs to forward is 
+			// The amount that the current hop needs to forward is
 			// based on how much the next hop forwards plus the fee
 			// that needs to be paid to the next hop.
 			amtToForward = nextHop.AmtToForward + nextHop.Fee
 
 			// The fee that needs to be paid to the current hop is
-			// based on the amount that this hop needs to forward 
+			// based on the amount that this hop needs to forward
 			// and its policy for the outgoing channel. This policy
 			// is stored as part of the incoming channel of
 			// the next hop.
@@ -358,7 +358,7 @@ func newRoute(amtToSend, feeLimit lnwire.MilliSatoshi, sourceVertex Vertex,
 		// enough capacity to carry the required amount which
 		// includes the fee dictated at each hop. Make the comparison
 		// in msat to prevent rounding errors.
-		if currentHop.AmtToForward + fee > lnwire.NewMSatFromSatoshis(
+		if currentHop.AmtToForward+fee > lnwire.NewMSatFromSatoshis(
 			currentHop.Channel.Capacity) {
 
 			err := fmt.Sprintf("channel graph has insufficient "+
@@ -439,9 +439,9 @@ type edgeWithPrev struct {
 
 // edgeWeight computes the weight of an edge. This value is used when searching
 // for the shortest path within the channel graph between two nodes. Weight is
-// is the fee itself plus a time lock penalty added to it. This benefits 
-// channels with shorter time lock deltas and shorter (hops) routes in general. 
-// RiskFactor controls the influence of time lock on route selection. This is 
+// is the fee itself plus a time lock penalty added to it. This benefits
+// channels with shorter time lock deltas and shorter (hops) routes in general.
+// RiskFactor controls the influence of time lock on route selection. This is
 // currently a fixed value, but might be configurable in the future.
 func edgeWeight(amt lnwire.MilliSatoshi, e *channeldb.ChannelEdgePolicy) int64 {
 	// First, we'll compute the "pure" fee through this hop. We say pure,

--- a/routing/pathfind_test.go
+++ b/routing/pathfind_test.go
@@ -16,12 +16,12 @@ import (
 	"testing"
 	"time"
 
-	"github.com/lightningnetwork/lnd/channeldb"
-	"github.com/lightningnetwork/lnd/lnwire"
 	"github.com/btcsuite/btcd/btcec"
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcd/wire"
 	"github.com/btcsuite/btcutil"
+	"github.com/lightningnetwork/lnd/channeldb"
+	"github.com/lightningnetwork/lnd/lnwire"
 
 	prand "math/rand"
 )

--- a/routing/pathfind_test.go
+++ b/routing/pathfind_test.go
@@ -543,13 +543,13 @@ func TestFindLowestFeePath(t *testing.T) {
 		t.Fatalf("unable to find path: %v", err)
 	}
 	route, err := newRoute(
-		paymentAmt, infinity, sourceVertex, path, startingHeight, 
+		paymentAmt, infinity, sourceVertex, path, startingHeight,
 		finalHopCLTV)
 	if err != nil {
 		t.Fatalf("unable to create path: %v", err)
 	}
 
-	// Assert that the lowest fee route is returned.	
+	// Assert that the lowest fee route is returned.
 	if !bytes.Equal(route.Hops[0].Channel.Node.PubKeyBytes[:],
 		aliases["b"].SerializeCompressed()) {
 		t.Fatalf("expected route to pass through b, "+
@@ -899,47 +899,47 @@ func TestNewRoute(t *testing.T) {
 	)
 
 	createHop := func(baseFee lnwire.MilliSatoshi,
-		feeRate lnwire.MilliSatoshi, 
+		feeRate lnwire.MilliSatoshi,
 		capacity btcutil.Amount,
-		timeLockDelta uint16) (*ChannelHop) {
+		timeLockDelta uint16) *ChannelHop {
 
-		return &ChannelHop {
-			ChannelEdgePolicy: &channeldb.ChannelEdgePolicy {
+		return &ChannelHop{
+			ChannelEdgePolicy: &channeldb.ChannelEdgePolicy{
 				Node: &channeldb.LightningNode{},
 				FeeProportionalMillionths: feeRate,
-				FeeBaseMSat: baseFee,
-				TimeLockDelta: timeLockDelta,
+				FeeBaseMSat:               baseFee,
+				TimeLockDelta:             timeLockDelta,
 			},
 			Capacity: capacity,
 		}
 	}
 
-	testCases := []struct { 
+	testCases := []struct {
 		// name identifies the test case in the test output.
-		name 		      string
+		name string
 
 		// hops is the list of hops (the route) that gets passed into
 		// the call to newRoute.
-		hops 	    	      []*ChannelHop
+		hops []*ChannelHop
 
 		// paymentAmount is the amount that is send into the route
 		// indicated by hops.
-		paymentAmount 	      lnwire.MilliSatoshi
+		paymentAmount lnwire.MilliSatoshi
 
 		// expectedFees is a list of fees that every hop is expected
 		// to charge for forwarding.
-		expectedFees	      []lnwire.MilliSatoshi
+		expectedFees []lnwire.MilliSatoshi
 
 		// expectedTimeLocks is a list of time lock values that every
 		// hop is expected to specify in its outgoing HTLC. The time
 		// lock values in this list are relative to the current block
 		// height.
-		expectedTimeLocks     []uint32
+		expectedTimeLocks []uint32
 
 		// expectedTotalAmount is the total amount that is expected to
 		// be returned from newRoute. This amount should include all
 		// the fees to be paid to intermediate hops.
-		expectedTotalAmount   lnwire.MilliSatoshi
+		expectedTotalAmount lnwire.MilliSatoshi
 
 		// expectedTotalTimeLock is the time lock that is expected to
 		// be returned from newRoute. This is the time lock that should
@@ -949,106 +949,106 @@ func TestNewRoute(t *testing.T) {
 
 		// expectError indicates whether the newRoute call is expected
 		// to fail or succeed.
-		expectError	      bool
+		expectError bool
 
 		// expectedErrorCode indicates the expected error code when
 		// expectError is true.
-		expectedErrorCode     errorCode
-	} {
-	{
-		// For a single hop payment, no fees are expected to be paid.
-		name: "single hop", 
-		paymentAmount: 100000,
-		hops: []*ChannelHop { 
-			createHop(100, 1000, 1000, 10),
-		},
-		expectedFees: []lnwire.MilliSatoshi {0},
-		expectedTimeLocks: []uint32 {1},
-		expectedTotalAmount: 100000,
-		expectedTotalTimeLock: 1,
-	}, {
-		// For a two hop payment, only the fee for the first hop
-		// needs to be paid. The destination hop does not require
-		// a fee to receive the payment.
-		name: "two hop", 
-		paymentAmount: 100000,
-		hops: []*ChannelHop { 
-			createHop(0, 1000, 1000, 10), 
-			createHop(30, 1000, 1000, 5),
-		},
-		expectedFees: []lnwire.MilliSatoshi {130, 0},
-		expectedTimeLocks: []uint32 {1, 1},
-		expectedTotalAmount: 100130,
-		expectedTotalTimeLock: 6,
-	}, {
-		// Insufficient capacity in first channel when fees are added.
-		name: "two hop insufficient", 
-		paymentAmount: 100000,
-		hops: []*ChannelHop { 
-			createHop(0, 1000, 100, 10), 
-			createHop(0, 1000, 1000, 5),
-		},
-		expectError: true,
-		expectedErrorCode: ErrInsufficientCapacity,
-	}, {
-		// A three hop payment where the first and second hop
-		// will both charge 1 msat. The fee for the first hop
-		// is actually slightly higher than 1, because the amount 
-		// to forward also includes the fee for the second hop. This
-		// gets rounded down to 1.
-		name: "three hop", 
-		paymentAmount: 100000,
-		hops: []*ChannelHop { 
-			createHop(0, 10, 1000, 10), 
-			createHop(0, 10, 1000, 5), 
-			createHop(0, 10, 1000, 3),
-		},
-		expectedFees: []lnwire.MilliSatoshi {1, 1, 0},
-		expectedTotalAmount: 100002,
-		expectedTimeLocks: []uint32 {4, 1, 1},
-		expectedTotalTimeLock: 9,
-	}, {
-		// A three hop payment where the fee of the first hop
-		// is slightly higher (11) than the fee at the second hop,
-		// because of the increase amount to forward.
-		name: "three hop with fee carry over", 
-		paymentAmount: 100000,
-		hops: []*ChannelHop { 
-			createHop(0, 10000, 1000, 10), 
-			createHop(0, 10000, 1000, 5), 
-			createHop(0, 10000, 1000, 3),
-		},
-		expectedFees: []lnwire.MilliSatoshi {1010, 1000, 0},
-		expectedTotalAmount: 102010,
-		expectedTimeLocks: []uint32 {4, 1, 1},
-		expectedTotalTimeLock: 9,
-	}, {
-		// A three hop payment where the fee policies of the first and
-		// second hop are just high enough to show the fee carry over
-		// effect.
-		name: "three hop with minimal fees for carry over", 
-		paymentAmount: 100000,
-		hops: []*ChannelHop { 
-			createHop(0, 10000, 1000, 10), 
-			
-			// First hop charges 0.1% so the second hop fee
-			// should show up in the first hop fee as 1 msat
-			// extra.
-			createHop(0, 1000, 1000, 5), 
+		expectedErrorCode errorCode
+	}{
+		{
+			// For a single hop payment, no fees are expected to be paid.
+			name:          "single hop",
+			paymentAmount: 100000,
+			hops: []*ChannelHop{
+				createHop(100, 1000, 1000, 10),
+			},
+			expectedFees:          []lnwire.MilliSatoshi{0},
+			expectedTimeLocks:     []uint32{1},
+			expectedTotalAmount:   100000,
+			expectedTotalTimeLock: 1,
+		}, {
+			// For a two hop payment, only the fee for the first hop
+			// needs to be paid. The destination hop does not require
+			// a fee to receive the payment.
+			name:          "two hop",
+			paymentAmount: 100000,
+			hops: []*ChannelHop{
+				createHop(0, 1000, 1000, 10),
+				createHop(30, 1000, 1000, 5),
+			},
+			expectedFees:          []lnwire.MilliSatoshi{130, 0},
+			expectedTimeLocks:     []uint32{1, 1},
+			expectedTotalAmount:   100130,
+			expectedTotalTimeLock: 6,
+		}, {
+			// Insufficient capacity in first channel when fees are added.
+			name:          "two hop insufficient",
+			paymentAmount: 100000,
+			hops: []*ChannelHop{
+				createHop(0, 1000, 100, 10),
+				createHop(0, 1000, 1000, 5),
+			},
+			expectError:       true,
+			expectedErrorCode: ErrInsufficientCapacity,
+		}, {
+			// A three hop payment where the first and second hop
+			// will both charge 1 msat. The fee for the first hop
+			// is actually slightly higher than 1, because the amount
+			// to forward also includes the fee for the second hop. This
+			// gets rounded down to 1.
+			name:          "three hop",
+			paymentAmount: 100000,
+			hops: []*ChannelHop{
+				createHop(0, 10, 1000, 10),
+				createHop(0, 10, 1000, 5),
+				createHop(0, 10, 1000, 3),
+			},
+			expectedFees:          []lnwire.MilliSatoshi{1, 1, 0},
+			expectedTotalAmount:   100002,
+			expectedTimeLocks:     []uint32{4, 1, 1},
+			expectedTotalTimeLock: 9,
+		}, {
+			// A three hop payment where the fee of the first hop
+			// is slightly higher (11) than the fee at the second hop,
+			// because of the increase amount to forward.
+			name:          "three hop with fee carry over",
+			paymentAmount: 100000,
+			hops: []*ChannelHop{
+				createHop(0, 10000, 1000, 10),
+				createHop(0, 10000, 1000, 5),
+				createHop(0, 10000, 1000, 3),
+			},
+			expectedFees:          []lnwire.MilliSatoshi{1010, 1000, 0},
+			expectedTotalAmount:   102010,
+			expectedTimeLocks:     []uint32{4, 1, 1},
+			expectedTotalTimeLock: 9,
+		}, {
+			// A three hop payment where the fee policies of the first and
+			// second hop are just high enough to show the fee carry over
+			// effect.
+			name:          "three hop with minimal fees for carry over",
+			paymentAmount: 100000,
+			hops: []*ChannelHop{
+				createHop(0, 10000, 1000, 10),
 
-			// Second hop charges a fixed 1000 msat.
-			createHop(1000, 0, 1000, 3),
-		},
-		expectedFees: []lnwire.MilliSatoshi {101, 1000, 0},
-		expectedTotalAmount: 101101,
-		expectedTimeLocks: []uint32 {4, 1, 1},
-		expectedTotalTimeLock: 9,
-	} }
-	
+				// First hop charges 0.1% so the second hop fee
+				// should show up in the first hop fee as 1 msat
+				// extra.
+				createHop(0, 1000, 1000, 5),
+
+				// Second hop charges a fixed 1000 msat.
+				createHop(1000, 0, 1000, 3),
+			},
+			expectedFees:          []lnwire.MilliSatoshi{101, 1000, 0},
+			expectedTotalAmount:   101101,
+			expectedTimeLocks:     []uint32{4, 1, 1},
+			expectedTotalTimeLock: 9,
+		}}
+
 	for _, testCase := range testCases {
 		assertRoute := func(t *testing.T, route *Route) {
 			if route.TotalAmount != testCase.expectedTotalAmount {
-				t.Errorf("Expected total amount is be %v" + 
+				t.Errorf("Expected total amount is be %v"+
 					", but got %v instead",
 					testCase.expectedTotalAmount,
 					route.TotalAmount)
@@ -1057,42 +1057,42 @@ func TestNewRoute(t *testing.T) {
 			for i := 0; i < len(testCase.expectedFees); i++ {
 				if testCase.expectedFees[i] !=
 					route.Hops[i].Fee {
-	
-					t.Errorf("Expected fee for hop %v to " +
-						 "be %v, but got %v instead",
-						 i, testCase.expectedFees[i],
-						 route.Hops[i].Fee)
+
+					t.Errorf("Expected fee for hop %v to "+
+						"be %v, but got %v instead",
+						i, testCase.expectedFees[i],
+						route.Hops[i].Fee)
 				}
 			}
 
-			expectedTimeLockHeight := startingHeight + 
+			expectedTimeLockHeight := startingHeight +
 				testCase.expectedTotalTimeLock
 
 			if route.TotalTimeLock != expectedTimeLockHeight {
-					
-				t.Errorf("Expected total time lock to be %v" + 
+
+				t.Errorf("Expected total time lock to be %v"+
 					", but got %v instead",
 					expectedTimeLockHeight,
 					route.TotalTimeLock)
 			}
-	
+
 			for i := 0; i < len(testCase.expectedTimeLocks); i++ {
-				expectedTimeLockHeight := startingHeight + 
+				expectedTimeLockHeight := startingHeight +
 					testCase.expectedTimeLocks[i]
 
 				if expectedTimeLockHeight !=
 					route.Hops[i].OutgoingTimeLock {
-	
-					t.Errorf("Expected time lock for hop " + 
+
+					t.Errorf("Expected time lock for hop "+
 						"%v to be %v, but got %v instead",
-						 i, expectedTimeLockHeight,
-						 route.Hops[i].OutgoingTimeLock)
+						i, expectedTimeLockHeight,
+						route.Hops[i].OutgoingTimeLock)
 				}
 			}
 		}
-	
+
 		t.Run(testCase.name, func(t *testing.T) {
-			route, err := newRoute(testCase.paymentAmount, 
+			route, err := newRoute(testCase.paymentAmount,
 				noFeeLimit,
 				sourceVertex, testCase.hops, startingHeight,
 				finalHopCLTV)
@@ -1100,10 +1100,10 @@ func TestNewRoute(t *testing.T) {
 			if testCase.expectError {
 				expectedCode := testCase.expectedErrorCode
 				if err == nil || !IsError(err, expectedCode) {
-					t.Errorf("expected newRoute to fail " + 
-						 "with error code %v, but got" +
-						 "%v instead", 
-						 expectedCode, err)
+					t.Errorf("expected newRoute to fail "+
+						"with error code %v, but got"+
+						"%v instead",
+						expectedCode, err)
 				}
 			} else {
 				if err != nil {

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -18,6 +18,13 @@ import (
 
 	"sync/atomic"
 
+	"github.com/btcsuite/btcd/blockchain"
+	"github.com/btcsuite/btcd/btcec"
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"github.com/btcsuite/btcd/txscript"
+	"github.com/btcsuite/btcd/wire"
+	"github.com/btcsuite/btcutil"
+	"github.com/btcsuite/btcwallet/waddrmgr"
 	"github.com/coreos/bbolt"
 	"github.com/davecgh/go-spew/spew"
 	"github.com/lightningnetwork/lnd/channeldb"
@@ -28,13 +35,6 @@ import (
 	"github.com/lightningnetwork/lnd/routing"
 	"github.com/lightningnetwork/lnd/signal"
 	"github.com/lightningnetwork/lnd/zpay32"
-	"github.com/btcsuite/btcd/blockchain"
-	"github.com/btcsuite/btcd/btcec"
-	"github.com/btcsuite/btcd/chaincfg/chainhash"
-	"github.com/btcsuite/btcd/txscript"
-	"github.com/btcsuite/btcd/wire"
-	"github.com/btcsuite/btcutil"
-	"github.com/btcsuite/btcwallet/waddrmgr"
 	"github.com/tv42/zbase32"
 	"golang.org/x/net/context"
 )
@@ -2450,7 +2450,7 @@ func (r *rpcServer) AddInvoice(ctx context.Context,
 		return nil, fmt.Errorf("payments of negative value "+
 			"are not allowed, value is %v", invoice.Value)
 	}
-	
+
 	amt := btcutil.Amount(invoice.Value)
 	amtMSat := lnwire.NewMSatFromSatoshis(amt)
 

--- a/server.go
+++ b/server.go
@@ -366,9 +366,9 @@ func newServer(listenAddrs []net.Addr, chanDB *channeldb.DB, cc *chainControl,
 
 	// If we were requested to automatically configure port forwarding,
 	// we'll use the ports that the server will be listening on.
-	externalIpStrings := make([]string, len(cfg.ExternalIPs))
+	externalIPStrings := make([]string, len(cfg.ExternalIPs))
 	for idx, ip := range cfg.ExternalIPs {
-		externalIpStrings[idx] = ip.String()
+		externalIPStrings[idx] = ip.String()
 	}
 	if s.natTraversal != nil {
 		listenPorts := make([]uint16, 0, len(listenAddrs))
@@ -391,14 +391,14 @@ func newServer(listenAddrs []net.Addr, chanDB *channeldb.DB, cc *chainControl,
 			srvrLog.Infof("Automatically set up port forwarding "+
 				"using %s to advertise external IP",
 				s.natTraversal.Name())
-			externalIpStrings = append(externalIpStrings, ips...)
+			externalIPStrings = append(externalIPStrings, ips...)
 		}
 	}
 
 	// If external IP addresses have been specified, add those to the list
 	// of this server's addresses.
 	externalIPs, err := lncfg.NormalizeAddresses(
-		externalIpStrings, strconv.Itoa(defaultPeerPort),
+		externalIPStrings, strconv.Itoa(defaultPeerPort),
 		cfg.net.ResolveTCPAddr,
 	)
 	if err != nil {
@@ -2593,8 +2593,6 @@ func (s *server) ConnectToPeer(addr *lnwire.NetAddress, perm bool) error {
 	case <-s.quit:
 		return ErrServerShuttingDown
 	}
-
-	return nil
 }
 
 // connectToPeer establishes a connection to a remote peer. errChan is used to

--- a/shachain/store.go
+++ b/shachain/store.go
@@ -4,8 +4,8 @@ import (
 	"encoding/binary"
 	"io"
 
-	"github.com/go-errors/errors"
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"github.com/go-errors/errors"
 )
 
 // Store is an interface which serves as an abstraction over data structure

--- a/utxonursery_test.go
+++ b/utxonursery_test.go
@@ -8,12 +8,12 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/lightningnetwork/lnd/lnwallet"
 	"github.com/btcsuite/btcd/btcec"
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcd/txscript"
 	"github.com/btcsuite/btcd/wire"
 	"github.com/btcsuite/btcutil"
+	"github.com/lightningnetwork/lnd/lnwallet"
 )
 
 var (

--- a/walletunlocker/service.go
+++ b/walletunlocker/service.go
@@ -7,14 +7,14 @@ import (
 	"os"
 	"time"
 
+	"github.com/btcsuite/btcd/chaincfg"
+	"github.com/btcsuite/btcwallet/wallet"
 	"github.com/lightningnetwork/lnd/aezeed"
+	"github.com/lightningnetwork/lnd/keychain"
 	"github.com/lightningnetwork/lnd/lnrpc"
 	"github.com/lightningnetwork/lnd/lnwallet"
 	"github.com/lightningnetwork/lnd/lnwallet/btcwallet"
-	"github.com/btcsuite/btcd/chaincfg"
-	"github.com/btcsuite/btcwallet/wallet"
 	"golang.org/x/net/context"
-	"github.com/lightningnetwork/lnd/keychain"
 )
 
 // WalletInitMsg is a message sent by the UnlockerService when a user wishes to

--- a/walletunlocker/service_test.go
+++ b/walletunlocker/service_test.go
@@ -8,14 +8,14 @@ import (
 	"testing"
 	"time"
 
+	"github.com/btcsuite/btcd/chaincfg"
+	"github.com/btcsuite/btcwallet/wallet"
 	"github.com/lightningnetwork/lnd/aezeed"
+	"github.com/lightningnetwork/lnd/keychain"
 	"github.com/lightningnetwork/lnd/lnrpc"
 	"github.com/lightningnetwork/lnd/lnwallet/btcwallet"
 	"github.com/lightningnetwork/lnd/walletunlocker"
-	"github.com/btcsuite/btcd/chaincfg"
-	"github.com/btcsuite/btcwallet/wallet"
 	"golang.org/x/net/context"
-	"github.com/lightningnetwork/lnd/keychain"
 )
 
 const (

--- a/witness_beacon.go
+++ b/witness_beacon.go
@@ -3,10 +3,10 @@ package main
 import (
 	"sync"
 
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/lightningnetwork/lnd/channeldb"
 	"github.com/lightningnetwork/lnd/contractcourt"
 	"github.com/lightningnetwork/lnd/lnwallet"
-	"github.com/btcsuite/btcd/chaincfg/chainhash"
 )
 
 // preimageSubscriber reprints an active subscription to be notified once the

--- a/zpay32/invoice.go
+++ b/zpay32/invoice.go
@@ -7,13 +7,13 @@ import (
 	"strings"
 	"time"
 
-	"github.com/lightningnetwork/lnd/lnwire"
-	"github.com/lightningnetwork/lnd/routing"
 	"github.com/btcsuite/btcd/btcec"
 	"github.com/btcsuite/btcd/chaincfg"
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcutil"
 	"github.com/btcsuite/btcutil/bech32"
+	"github.com/lightningnetwork/lnd/lnwire"
+	"github.com/lightningnetwork/lnd/routing"
 )
 
 const (

--- a/zpay32/invoice_internal_test.go
+++ b/zpay32/invoice_internal_test.go
@@ -7,12 +7,12 @@ import (
 	"testing"
 	"time"
 
-	"github.com/lightningnetwork/lnd/lnwire"
-	"github.com/lightningnetwork/lnd/routing"
 	"github.com/btcsuite/btcd/btcec"
 	"github.com/btcsuite/btcd/chaincfg"
 	"github.com/btcsuite/btcutil"
 	"github.com/btcsuite/btcutil/bech32"
+	"github.com/lightningnetwork/lnd/lnwire"
+	"github.com/lightningnetwork/lnd/routing"
 )
 
 // TestDecodeAmount ensures that the amount string in the hrp of the Invoice

--- a/zpay32/invoice_test.go
+++ b/zpay32/invoice_test.go
@@ -11,13 +11,13 @@ import (
 	"testing"
 	"time"
 
-	"github.com/lightningnetwork/lnd/lnwire"
-	"github.com/lightningnetwork/lnd/routing"
 	"github.com/btcsuite/btcd/btcec"
 	"github.com/btcsuite/btcd/chaincfg"
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcd/wire"
 	"github.com/btcsuite/btcutil"
+	"github.com/lightningnetwork/lnd/lnwire"
+	"github.com/lightningnetwork/lnd/routing"
 
 	litecoinCfg "github.com/ltcsuite/ltcd/chaincfg"
 )


### PR DESCRIPTION
When we switched to using the Makefile, our linter stopped being executed on travis. It has been silently succeeding ever since. This PR restores compliance with the linter, and then fixes the Makefile to run the executable on travis.

TL;DR: don't forget to escape your dollars