### PR TITLE
channeldb: fail Open on db reversion

### DIFF
--- a/channeldb/error.go
+++ b/channeldb/error.go
@@ -7,6 +7,10 @@ var (
 	// created.
 	ErrNoChanDBExists = fmt.Errorf("channel db has not yet been created")
 
+	// ErrDBReversion is returned when detecting an attempt to revert to a
+	// prior database version.
+	ErrDBReversion = fmt.Errorf("channel db cannot revert to prior version")
+
 	// ErrLinkNodesNotFound is returned when node info bucket hasn't been
 	// created.
 	ErrLinkNodesNotFound = fmt.Errorf("no link nodes exist")


### PR DESCRIPTION
This PR adds a check that fails `channeldb.Open` when we detect a user reverting to an older database version. This allows lnd to revert to older commits w/ the same db version, but prevents us from reverting past the last migration.

Inspired by issues reported #1671 