### PR TITLE
contractcourt: move responsibility for closing channels ChannelArbitrator

### DIFF
--- a/channeldb/channel.go
+++ b/channeldb/channel.go
@@ -2055,14 +2055,14 @@ func putChannelCloseSummary(tx *bolt.Tx, chanID []byte,
 	summary.LocalChanConfig = lastChanState.LocalChanCfg
 
 	var b bytes.Buffer
-	if err := serializeChannelCloseSummary(&b, summary); err != nil {
+	if err := SerializeChannelCloseSummary(&b, summary); err != nil {
 		return err
 	}
 
 	return closedChanBucket.Put(chanID, b.Bytes())
 }
 
-func serializeChannelCloseSummary(w io.Writer, cs *ChannelCloseSummary) error {
+func SerializeChannelCloseSummary(w io.Writer, cs *ChannelCloseSummary) error {
 	err := WriteElements(w,
 		cs.ChanPoint, cs.ShortChanID, cs.ChainHash, cs.ClosingTXID,
 		cs.CloseHeight, cs.RemotePub, cs.Capacity, cs.SettledBalance,
@@ -2110,10 +2110,10 @@ func fetchChannelCloseSummary(tx *bolt.Tx,
 	}
 
 	summaryReader := bytes.NewReader(summaryBytes)
-	return deserializeCloseChannelSummary(summaryReader)
+	return DeserializeCloseChannelSummary(summaryReader)
 }
 
-func deserializeCloseChannelSummary(r io.Reader) (*ChannelCloseSummary, error) {
+func DeserializeCloseChannelSummary(r io.Reader) (*ChannelCloseSummary, error) {
 	c := &ChannelCloseSummary{}
 
 	err := ReadElements(r,

--- a/channeldb/db.go
+++ b/channeldb/db.go
@@ -496,7 +496,7 @@ func (d *DB) FetchClosedChannels(pendingOnly bool) ([]*ChannelCloseSummary, erro
 
 		return closeBucket.ForEach(func(chanID []byte, summaryBytes []byte) error {
 			summaryReader := bytes.NewReader(summaryBytes)
-			chanSummary, err := deserializeCloseChannelSummary(summaryReader)
+			chanSummary, err := DeserializeCloseChannelSummary(summaryReader)
 			if err != nil {
 				return err
 			}
@@ -544,7 +544,7 @@ func (d *DB) FetchClosedChannel(chanID *wire.OutPoint) (*ChannelCloseSummary, er
 		}
 
 		summaryReader := bytes.NewReader(summaryBytes)
-		chanSummary, err = deserializeCloseChannelSummary(summaryReader)
+		chanSummary, err = DeserializeCloseChannelSummary(summaryReader)
 
 		return err
 	}); err != nil {
@@ -582,7 +582,7 @@ func (d *DB) MarkChanFullyClosed(chanPoint *wire.OutPoint) error {
 		}
 
 		chanSummaryReader := bytes.NewReader(chanSummaryBytes)
-		chanSummary, err := deserializeCloseChannelSummary(
+		chanSummary, err := DeserializeCloseChannelSummary(
 			chanSummaryReader,
 		)
 		if err != nil {
@@ -592,7 +592,7 @@ func (d *DB) MarkChanFullyClosed(chanPoint *wire.OutPoint) error {
 		chanSummary.IsPending = false
 
 		var newSummary bytes.Buffer
-		err = serializeChannelCloseSummary(&newSummary, chanSummary)
+		err = SerializeChannelCloseSummary(&newSummary, chanSummary)
 		if err != nil {
 			return err
 		}

--- a/contractcourt/briefcase.go
+++ b/contractcourt/briefcase.go
@@ -81,6 +81,14 @@ type ArbitratorLog interface {
 	// contract resolutions from persistent storage.
 	FetchContractResolutions() (*ContractResolutions, error)
 
+	// LogCloseSummary logs the summary of a channel's close transaction
+	// seen on-chain.
+	LogCloseSummary(*channeldb.ChannelCloseSummary) error
+
+	// FetchCloseSummary fetches the close summary previously written to
+	// the log.
+	FetchCloseSummary() (*channeldb.ChannelCloseSummary, error)
+
 	// LogChainActions stores a set of chain actions which are derived from
 	// our set of active contracts, and the on-chain state. We'll write
 	// this et of cations when: we decide to go on-chain to resolve a
@@ -270,6 +278,11 @@ var (
 	// the full set of resolutions for a channel.
 	resolutionsKey = []byte("resolutions")
 
+	// closeSummaryKey is the key under the logScope that we'll use to
+	// store a channel close summary when a closing transaction is seen
+	// on-chain.
+	closeSummaryKey = []byte("close-summary")
+
 	// actionsBucketKey is the key under the logScope that we'll use to
 	// store all chain actions once they're determined.
 	actionsBucketKey = []byte("chain-actions")
@@ -287,6 +300,10 @@ var (
 	// errNoResolutions is returned when the log doesn't contain any active
 	// chain resolutions.
 	errNoResolutions = fmt.Errorf("no contract resolutions exist")
+
+	// erNoCloseSummary is returned when the log doesn't contain any close
+	// summary for the channel.
+	errNoCloseSummary = fmt.Errorf("no channel close summary exists")
 
 	// errNoActions is retuned when the log doesn't contain any stored
 	// chain actions.
@@ -732,6 +749,63 @@ func (b *boltArbitratorLog) FetchContractResolutions() (*ContractResolutions, er
 	}
 
 	return c, err
+}
+
+// LogCloseSummary logs the summary of a channel's close transaction
+// seen on-chain.
+//
+// NOTE: Part of the ContractResolver interface.
+func (b *boltArbitratorLog) LogCloseSummary(c *channeldb.ChannelCloseSummary) error {
+	return b.db.Batch(func(tx *bolt.Tx) error {
+		scopeBucket, err := tx.CreateBucketIfNotExists(b.scopeKey[:])
+		if err != nil {
+			return err
+		}
+
+		var b bytes.Buffer
+		err = channeldb.SerializeChannelCloseSummary(&b, c)
+		if err != nil {
+			return err
+		}
+
+		return scopeBucket.Put(closeSummaryKey, b.Bytes())
+	})
+}
+
+// FetchCloseSummary fetches the close summary previously written to
+// the log.
+//
+// NOTE: Part of the ContractResolver interface.
+func (b *boltArbitratorLog) FetchCloseSummary() (
+	*channeldb.ChannelCloseSummary, error) {
+
+	var c *channeldb.ChannelCloseSummary
+	var err error
+	err = b.db.View(func(tx *bolt.Tx) error {
+		scopeBucket := tx.Bucket(b.scopeKey[:])
+		if scopeBucket == nil {
+			return errScopeBucketNoExist
+		}
+
+		summaryBytes := scopeBucket.Get(closeSummaryKey)
+		if summaryBytes == nil {
+			return errNoCloseSummary
+		}
+
+		r := bytes.NewReader(summaryBytes)
+
+		c, err = channeldb.DeserializeCloseChannelSummary(r)
+		if err != nil {
+			return err
+		}
+
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return c, nil
 }
 
 // LogChainActions stores a set of chain actions which are derived from our set

--- a/contractcourt/briefcase.go
+++ b/contractcourt/briefcase.go
@@ -117,9 +117,21 @@ const (
 	// waiting for it to confirm.
 	StateCommitmentBroadcasted ArbitratorState = 6
 
+	// StateCommitmentConfirmed is a state that indicates that the
+	// commitment has been confirmed. In this state we'll mark the channel
+	// closed in the database.
+	//
+	// NOTE: We mark the channel closed in the database in its own state to
+	// handle the case where a state transition fails after marking the
+	// channel closed. After the channel is marked closed we'll no longer
+	// detect chain events for this channel. In this case we'll restart
+	// from StateCommitmentConfirmed and retry the transition.
+	StateCommitmentConfirmed ArbitratorState = 7
+
 	// StateContractClosed is a state that indicates the contract has
-	// already been "closed", meaning the commitment is confirmed on chain.
-	// At this point, we can now examine our active contracts, in order to
+	// already been "closed", meaning the commitment is confirmed on chain
+	// and we have marked the channel closed in the database. At this
+	// point, we can now examine our active contracts, in order to
 	// create the proper resolver for each one.
 	StateContractClosed ArbitratorState = 2
 
@@ -150,6 +162,9 @@ func (a ArbitratorState) String() string {
 
 	case StateCommitmentBroadcasted:
 		return "StateCommitmentBroadcasted"
+
+	case StateCommitmentConfirmed:
+		return "StateCommitmentConfirmed"
 
 	case StateContractClosed:
 		return "StateContractClosed"

--- a/contractcourt/chain_arbitrator.go
+++ b/contractcourt/chain_arbitrator.go
@@ -243,6 +243,7 @@ func newActiveChannelArbitrator(channel *channeldb.OpenChannel,
 			return chanMachine.ForceClose()
 		},
 		MarkCommitmentBroadcasted: channel.MarkCommitmentBroadcasted,
+		MarkChannelClosed:         channel.CloseChannel,
 		ChainArbitratorConfig:     c.cfg,
 		ChainEvents:               chanEvents,
 	}

--- a/contractcourt/channel_arbitrator.go
+++ b/contractcourt/channel_arbitrator.go
@@ -95,6 +95,13 @@ type ChannelArbitratorConfig struct {
 	// being broadcast, and we are waiting for the commitment to confirm.
 	MarkCommitmentBroadcasted func() error
 
+	// MarkChannelClosed marks the channel closed in the database, with the
+	// passed close summary. After this method successfully returns we can
+	// no longer expect to receive chain events for this channel, and must
+	// be able to recover from a failure without getting the close event
+	// again.
+	MarkChannelClosed func(*channeldb.ChannelCloseSummary) error
+
 	// MarkChannelResolved is a function closure that serves to mark a
 	// channel as "fully resolved". A channel itself can be considered
 	// fully resolved once all active contracts have individually been

--- a/contractcourt/channel_arbitrator.go
+++ b/contractcourt/channel_arbitrator.go
@@ -613,7 +613,11 @@ func (c *ChannelArbitrator) stateStep(triggerHeight uint32,
 
 		log.Infof("ChannelPoint(%v) has been fully resolved "+
 			"on-chain at height=%v", c.cfg.ChanPoint, triggerHeight)
-		return nextState, closeTx, c.cfg.MarkChannelResolved()
+
+		if err := c.cfg.MarkChannelResolved(); err != nil {
+			log.Errorf("unable to mark channel resolved: %v", err)
+			return StateError, closeTx, err
+		}
 	}
 
 	if err := c.log.CommitState(nextState); err != nil {

--- a/contractcourt/channel_arbitrator.go
+++ b/contractcourt/channel_arbitrator.go
@@ -620,14 +620,9 @@ func (c *ChannelArbitrator) stateStep(triggerHeight uint32,
 		}
 	}
 
-	if err := c.log.CommitState(nextState); err != nil {
-		return StateError, nil, err
-	}
-
 	log.Tracef("ChannelArbitrator(%v): next_state=%v", c.cfg.ChanPoint,
 		nextState)
 
-	c.state = nextState
 	return nextState, closeTx, nil
 }
 
@@ -658,7 +653,8 @@ func (c *ChannelArbitrator) advanceState(triggerHeight uint32,
 			triggerHeight, trigger,
 		)
 		if err != nil {
-			log.Errorf("unable to advance state: %v", err)
+			log.Errorf("ChannelArbitrator(%v): unable to advance "+
+				"state: %v", c.cfg.ChanPoint, err)
 			return priorState, nil, err
 		}
 
@@ -671,16 +667,31 @@ func (c *ChannelArbitrator) advanceState(triggerHeight uint32,
 		// exit early.
 		if stateCallback != nil {
 			if err := stateCallback(nextState); err != nil {
+				log.Errorf("ChannelArbitrator(%v): unable to "+
+					"execute state callback: %v",
+					c.cfg.ChanPoint, err)
 				return nextState, closeTx, err
 			}
 		}
+
+		// As the prior state and the state callback was successfully
+		// executed, we can now commit the next state. This ensures
+		// that we will re-execute the prior state and callback if
+		// anything fails.
+		if err := c.log.CommitState(nextState); err != nil {
+			log.Errorf("ChannelArbitrator(%v): unable to commit "+
+				"next state(%v): %v", c.cfg.ChanPoint,
+				nextState, err)
+			return priorState, nil, err
+		}
+		c.state = nextState
 
 		// Our termination transition is a noop transition. If we get
 		// our prior state back as the next state, then we'll
 		// terminate.
 		if nextState == priorState {
-			log.Tracef("ChannelArbitrator(%v): terminating at state=%v",
-				c.cfg.ChanPoint, nextState)
+			log.Tracef("ChannelArbitrator(%v): terminating at "+
+				"state=%v", c.cfg.ChanPoint, nextState)
 			return nextState, forceCloseTx, nil
 		}
 	}

--- a/contractcourt/channel_arbitrator.go
+++ b/contractcourt/channel_arbitrator.go
@@ -1410,22 +1410,25 @@ func (c *ChannelArbitrator) channelAttendant(bestHeight int32) {
 				HtlcResolutions:  *closeInfo.HtlcResolutions,
 			}
 
-			// When processing a unilateral close event, we'll
-			// transition directly to the ContractClosed state.
-			// When the state machine reaches that state, we'll log
-			// out the set of resolutions.
 			stateCb := func(nextState ArbitratorState) error {
-				if nextState != StateContractClosed {
-					return nil
-				}
 
-				err := c.log.LogContractResolutions(
-					contractRes,
-				)
-				if err != nil {
-					return fmt.Errorf("unable to "+
-						"write resolutions: %v",
-						err)
+				switch nextState {
+
+				// When processing a unilateral close event,
+				// we'll transition to the ContractClosed
+				// state. When the state machine reaches that
+				// state, we'll log out the set of resolutions,
+				// such that they are available to fetch in
+				// that state.
+				case StateContractClosed:
+					err := c.log.LogContractResolutions(
+						contractRes,
+					)
+					if err != nil {
+						return fmt.Errorf("unable to "+
+							"write resolutions: %v",
+							err)
+					}
 				}
 
 				return nil
@@ -1467,21 +1470,25 @@ func (c *ChannelArbitrator) channelAttendant(bestHeight int32) {
 			// present on their commitment.
 			c.activeHTLCs = newHtlcSet(uniClosure.RemoteCommit.Htlcs)
 
-			// When processing a unilateral close event, we'll
-			// transition directly to the ContractClosed state.
-			// When the state machine reaches that state, we'll log
-			// out the set of resolutions.
 			stateCb := func(nextState ArbitratorState) error {
-				if nextState != StateContractClosed {
-					return nil
-				}
 
-				err := c.log.LogContractResolutions(
-					contractRes,
-				)
-				if err != nil {
-					return fmt.Errorf("unable to write "+
-						"resolutions: %v", err)
+				switch nextState {
+
+				// When processing a unilateral close event,
+				// we'll transition to the ContractClosed
+				// state. When the state machine reaches that
+				// state, we'll log out the set of resolutions,
+				// such that they are available to fetch in
+				// that state.
+				case StateContractClosed:
+					err := c.log.LogContractResolutions(
+						contractRes,
+					)
+					if err != nil {
+						return fmt.Errorf("unable to "+
+							"write resolutions: %v",
+							err)
+					}
 				}
 
 				return nil

--- a/contractcourt/channel_arbitrator_test.go
+++ b/contractcourt/channel_arbitrator_test.go
@@ -77,7 +77,9 @@ func createTestChannelArbitrator() (*ChannelArbitrator, chan struct{}, func(), e
 		MarkCommitmentBroadcasted: func() error {
 			return nil
 		},
-
+		MarkChannelClosed: func(*channeldb.ChannelCloseSummary) error {
+			return nil
+		},
 		ChainArbitratorConfig: chainArbCfg,
 		ChainEvents:           chanEvents,
 	}

--- a/contractcourt/channel_arbitrator_test.go
+++ b/contractcourt/channel_arbitrator_test.go
@@ -5,11 +5,18 @@ import (
 	"testing"
 	"time"
 
+	"github.com/btcsuite/btcd/btcec"
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcd/wire"
 	"github.com/lightningnetwork/lnd/chainntnfs"
+	"github.com/lightningnetwork/lnd/channeldb"
 	"github.com/lightningnetwork/lnd/lnwallet"
 	"github.com/lightningnetwork/lnd/lnwire"
+)
+
+var (
+	privKey, _ = btcec.NewPrivateKey(btcec.S256())
+	pubKey     = privKey.PubKey()
 )
 
 type mockChainIO struct{}
@@ -41,7 +48,7 @@ func createTestChannelArbitrator() (*ChannelArbitrator, chan struct{}, func(), e
 	chanEvents := &ChainEventSubscription{
 		RemoteUnilateralClosure: make(chan *lnwallet.UnilateralCloseSummary, 1),
 		LocalUnilateralClosure:  make(chan *LocalUnilateralCloseInfo, 1),
-		CooperativeClosure:      make(chan struct{}, 1),
+		CooperativeClosure:      make(chan *CooperativeCloseInfo, 1),
 		ContractBreach:          make(chan *lnwallet.BreachRetribution, 1),
 	}
 
@@ -71,6 +78,9 @@ func createTestChannelArbitrator() (*ChannelArbitrator, chan struct{}, func(), e
 			summary := &lnwallet.LocalForceCloseSummary{
 				CloseTx:         &wire.MsgTx{},
 				HtlcResolutions: &lnwallet.HtlcResolutions{},
+				ChanSnapshot: channeldb.ChannelSnapshot{
+					RemoteIdentity: *pubKey,
+				},
 			}
 			return summary, nil
 		},
@@ -120,9 +130,16 @@ func TestChannelArbitratorCooperativeClose(t *testing.T) {
 	// It should start out in the default state.
 	assertState(t, chanArb, StateDefault)
 
+	commitSpend := &chainntnfs.SpendDetail{
+		SpenderTxHash: &chainhash.Hash{},
+	}
+
 	// Cooperative close should do nothing.
 	// TODO: this will change?
-	chanArb.cfg.ChainEvents.CooperativeClosure <- struct{}{}
+	closeInfo := &CooperativeCloseInfo{
+		SpendDetail: commitSpend,
+	}
+	chanArb.cfg.ChainEvents.CooperativeClosure <- closeInfo
 	assertState(t, chanArb, StateDefault)
 }
 
@@ -152,6 +169,9 @@ func TestChannelArbitratorRemoteForceClose(t *testing.T) {
 	uniClose := &lnwallet.UnilateralCloseSummary{
 		SpendDetail:     commitSpend,
 		HtlcResolutions: &lnwallet.HtlcResolutions{},
+		ChannelCloseSummary: channeldb.ChannelCloseSummary{
+			RemotePub: pubKey,
+		},
 	}
 	chanArb.cfg.ChainEvents.RemoteUnilateralClosure <- uniClose
 
@@ -239,6 +259,9 @@ func TestChannelArbitratorLocalForceClose(t *testing.T) {
 		&lnwallet.LocalForceCloseSummary{
 			CloseTx:         &wire.MsgTx{},
 			HtlcResolutions: &lnwallet.HtlcResolutions{},
+			ChanSnapshot: channeldb.ChannelSnapshot{
+				RemoteIdentity: *pubKey,
+			},
 		},
 	}
 	// It should mark the channel as resolved.
@@ -326,6 +349,9 @@ func TestChannelArbitratorLocalForceCloseRemoteConfirmed(t *testing.T) {
 	uniClose := &lnwallet.UnilateralCloseSummary{
 		SpendDetail:     commitSpend,
 		HtlcResolutions: &lnwallet.HtlcResolutions{},
+		ChannelCloseSummary: channeldb.ChannelCloseSummary{
+			RemotePub: pubKey,
+		},
 	}
 	chanArb.cfg.ChainEvents.RemoteUnilateralClosure <- uniClose
 
@@ -414,6 +440,9 @@ func TestChannelArbitratorLocalForceDoubleSpend(t *testing.T) {
 	uniClose := &lnwallet.UnilateralCloseSummary{
 		SpendDetail:     commitSpend,
 		HtlcResolutions: &lnwallet.HtlcResolutions{},
+		ChannelCloseSummary: channeldb.ChannelCloseSummary{
+			RemotePub: pubKey,
+		},
 	}
 	chanArb.cfg.ChainEvents.RemoteUnilateralClosure <- uniClose
 


### PR DESCRIPTION
This PR moves the responsibility for closing local and channels in the database from the chain watcher to the channel arbitrator.

We do this because we previously would close the channel in the
database, before sending the event to the channel arbitrator. This could
lead to a situation where the channel was marked closed, but the channel
arbitrator didn't receive the event before shutdown. As we don't listen
for chain events for channels that are closed, those channels would be
stuck in the pending close state forever, as the channel arbitrator
state machine wouldn't progress.

We introduce a new state StateCommitmentConfirmed that is used
exclusively for marking the channel closed in the database. Before
transitioning to this new state, we make sure the ChannelCloseSummary is
written to the log in the stateCallback. And before transitioning away
from this state (to StateContractClosed) we make sure the channel is
marked closed in the database. This ensures that if any of these steps
fail, we have the information necessary to recover.