### PR TITLE
Critical Vulnerability Fix: Negative Fee Infinite Loop

### DIFF
--- a/routing/heap.go
+++ b/routing/heap.go
@@ -7,7 +7,7 @@ import "github.com/lightningnetwork/lnd/channeldb"
 type nodeWithDist struct {
 	// dist is the distance to this node from the source node in our
 	// current context.
-	dist int64
+	dist uint64
 
 	// node is the vertex itself. This pointer can be used to explore all
 	// the outgoing edges (channels) emanating from a node.

--- a/routing/heap_test.go
+++ b/routing/heap_test.go
@@ -26,7 +26,7 @@ func TestHeapOrdering(t *testing.T) {
 	sortedEntries := make([]nodeWithDist, 0, numEntries)
 	for i := 0; i < numEntries; i++ {
 		entry := nodeWithDist{
-			dist: prand.Int63(),
+			dist: prand.Uint64(),
 		}
 
 		heap.Push(&nodeHeap, entry)

--- a/routing/pathfind.go
+++ b/routing/pathfind.go
@@ -443,17 +443,17 @@ type edgeWithPrev struct {
 // channels with shorter time lock deltas and shorter (hops) routes in general.
 // RiskFactor controls the influence of time lock on route selection. This is
 // currently a fixed value, but might be configurable in the future.
-func edgeWeight(amt lnwire.MilliSatoshi, e *channeldb.ChannelEdgePolicy) int64 {
+func edgeWeight(amt lnwire.MilliSatoshi, e *channeldb.ChannelEdgePolicy) uint64 {
 	// First, we'll compute the "pure" fee through this hop. We say pure,
 	// as this may not be what's ultimately paid as fees are properly
 	// calculated backwards, while we're going in the reverse direction.
-	pureFee := int64(computeFee(amt, e))
+	pureFee := uint64(computeFee(amt, e))
 
 	// timeLockPenalty is the penalty for the time lock delta of this channel.
 	// It is controlled by RiskFactorBillionths and scales proportional
 	// to the amount that will pass through channel. Rationale is that it if
 	// a twice as large amount gets locked up, it is twice as bad.
-	timeLockPenalty := int64(amt) * int64(e.TimeLockDelta) * RiskFactorBillionths / 1000000000
+	timeLockPenalty := uint64(amt) * uint64(e.TimeLockDelta) * RiskFactorBillionths / 1000000000
 
 	return pureFee + timeLockPenalty
 }


### PR DESCRIPTION
If edgeWeight can return a negative number, this can cause Dijkstra's to go into an infinite loop.
If a rogue node changes their base code and sets a negative fee that is more negative than a negative than a neighbor is positive, it will cause any node that tries to pathfind through them to go into an infinite loop and either crash their node, or their entire system the node is running on.

Solution: Ensure that edgeWeight can't yield a negative number.

Changed NodeWithDistance.dist from int64 to uint64
Changed edgeWeight to use and return Uint64

