### PR TITLE
[htlcswitch] fwdpkg cleanup

### DIFF
--- a/channeldb/channel.go
+++ b/channeldb/channel.go
@@ -1597,6 +1597,31 @@ func (c *OpenChannel) LoadFwdPkgs() ([]*FwdPkg, error) {
 	return fwdPkgs, nil
 }
 
+// AckAddHtlcs updates the AckAddFilter containing any of the provided AddRefs
+// indicating that a response to this Add has been committed to the remote party.
+// Doing so will prevent these Add HTLCs from being reforwarded internally.
+func (c *OpenChannel) AckAddHtlcs(addRefs ...AddRef) error {
+	c.Lock()
+	defer c.Unlock()
+
+	return c.Db.Update(func(tx *bolt.Tx) error {
+		return c.Packager.AckAddHtlcs(tx, addRefs...)
+	})
+}
+
+// AckSettleFails updates the SettleFailFilter containing any of the provided
+// SettleFailRefs, indicating that the response has been delivered to the
+// incoming link, corresponding to a particular AddRef. Doing so will prevent
+// the responses from being retransmitted internally.
+func (c *OpenChannel) AckSettleFails(settleFailRefs ...SettleFailRef) error {
+	c.Lock()
+	defer c.Unlock()
+
+	return c.Db.Update(func(tx *bolt.Tx) error {
+		return c.Packager.AckSettleFails(tx, settleFailRefs...)
+	})
+}
+
 // SetFwdFilter atomically sets the forwarding filter for the forwarding package
 // identified by `height`.
 func (c *OpenChannel) SetFwdFilter(height uint64, fwdFilter *PkgFilter) error {

--- a/channeldb/channel.go
+++ b/channeldb/channel.go
@@ -2440,10 +2440,18 @@ func deleteOpenChannel(chanBucket *bolt.Bucket, chanPointBytes []byte) error {
 
 }
 
+// makeLogKey converts a uint64 into an 8 byte array.
 func makeLogKey(updateNum uint64) [8]byte {
 	var key [8]byte
 	byteOrder.PutUint64(key[:], updateNum)
 	return key
+}
+
+// readLogKey parse the first 8- bytes of a byte slice into a uint64.
+//
+// NOTE: The slice must be at least 8 bytes long.
+func readLogKey(b []byte) uint64 {
+	return byteOrder.Uint64(b)
 }
 
 func appendChannelLogEntry(log *bolt.Bucket,

--- a/htlcswitch/link.go
+++ b/htlcswitch/link.go
@@ -1043,6 +1043,7 @@ func (l *channelLink) handleDownStreamPkt(pkt *htlcPacket, isReProcess bool) {
 		// mailbox, and the HTLC being added to the commitment state.
 		if l.cfg.DebugHTLC && l.cfg.HodlMask.Active(hodl.AddOutgoing) {
 			l.warnf(hodl.AddOutgoing.Warning())
+			l.mailBox.AckPacket(pkt.inKey())
 			return
 		}
 
@@ -1097,6 +1098,7 @@ func (l *channelLink) handleDownStreamPkt(pkt *htlcPacket, isReProcess bool) {
 					err := lnwire.EncodeFailure(&b, failure, 0)
 					if err != nil {
 						l.errorf("unable to encode failure: %v", err)
+						l.mailBox.AckPacket(pkt.inKey())
 						return
 					}
 					reason = lnwire.OpaqueReason(b.Bytes())
@@ -1106,6 +1108,7 @@ func (l *channelLink) handleDownStreamPkt(pkt *htlcPacket, isReProcess bool) {
 					reason, err = pkt.obfuscator.EncryptFirstHop(failure)
 					if err != nil {
 						l.errorf("unable to obfuscate error: %v", err)
+						l.mailBox.AckPacket(pkt.inKey())
 						return
 					}
 				}
@@ -1162,22 +1165,38 @@ func (l *channelLink) handleDownStreamPkt(pkt *htlcPacket, isReProcess bool) {
 		// commitment state.
 		if l.cfg.DebugHTLC && l.cfg.HodlMask.Active(hodl.SettleOutgoing) {
 			l.warnf(hodl.SettleOutgoing.Warning())
+			l.mailBox.AckPacket(pkt.inKey())
 			return
 		}
 
 		// An HTLC we forward to the switch has just settled somewhere
 		// upstream. Therefore we settle the HTLC within the our local
 		// state machine.
-		closedCircuitRef := pkt.inKey()
-		if err := l.channel.SettleHTLC(
+		inKey := pkt.inKey()
+		err := l.channel.SettleHTLC(
 			htlc.PaymentPreimage,
 			pkt.incomingHTLCID,
 			pkt.sourceRef,
 			pkt.destRef,
-			&closedCircuitRef,
-		); err != nil {
-			l.fail(LinkFailureError{code: ErrInternalError},
-				"unable to settle incoming HTLC: %v", err)
+			&inKey,
+		)
+		if err != nil {
+			l.errorf("unable to settle incoming HTLC for "+
+				"circuit-key=%v: %v", inKey, err)
+
+			// If the HTLC index for Settle response was not known
+			// to our commitment state, it has already been
+			// cleaned up by a prior response. We'll thus try to
+			// clean up any lingering state to ensure we don't
+			// continue reforwarding.
+			if _, ok := err.(lnwallet.ErrUnknownHtlcIndex); ok {
+				l.cleanupSpuriousResponse(pkt)
+			}
+
+			// Remove the packet from the link's mailbox to ensure
+			// it doesn't get replayed after a reconnection.
+			l.mailBox.AckPacket(inKey)
+
 			return
 		}
 
@@ -1204,20 +1223,37 @@ func (l *channelLink) handleDownStreamPkt(pkt *htlcPacket, isReProcess bool) {
 		// state.
 		if l.cfg.DebugHTLC && l.cfg.HodlMask.Active(hodl.FailOutgoing) {
 			l.warnf(hodl.FailOutgoing.Warning())
+			l.mailBox.AckPacket(pkt.inKey())
 			return
 		}
 
 		// An HTLC cancellation has been triggered somewhere upstream,
 		// we'll remove then HTLC from our local state machine.
-		closedCircuitRef := pkt.inKey()
-		if err := l.channel.FailHTLC(
+		inKey := pkt.inKey()
+		err := l.channel.FailHTLC(
 			pkt.incomingHTLCID,
 			htlc.Reason,
 			pkt.sourceRef,
 			pkt.destRef,
-			&closedCircuitRef,
-		); err != nil {
-			log.Errorf("unable to cancel HTLC: %v", err)
+			&inKey,
+		)
+		if err != nil {
+			l.errorf("unable to cancel incoming HTLC for "+
+				"circuit-key=%v: %v", inKey, err)
+
+			// If the HTLC index for Fail response was not known to
+			// our commitment state, it has already been cleaned up
+			// by a prior response. We'll thus try to clean up any
+			// lingering state to ensure we don't continue
+			// reforwarding.
+			if _, ok := err.(lnwallet.ErrUnknownHtlcIndex); ok {
+				l.cleanupSpuriousResponse(pkt)
+			}
+
+			// Remove the packet from the link's mailbox to ensure
+			// it doesn't get replayed after a reconnection.
+			l.mailBox.AckPacket(inKey)
+
 			return
 		}
 
@@ -1249,6 +1285,70 @@ func (l *channelLink) handleDownStreamPkt(pkt *htlcPacket, isReProcess bool) {
 				"unable to update commitment: %v", err)
 			return
 		}
+	}
+}
+
+// cleanupSpuriousResponse attempts to ack any AddRef or SettleFailRef
+// associated with this packet. If successful in doing so, it will also purge
+// the open circuit from the circuit map and remove the packet from the link's
+// mailbox.
+func (l *channelLink) cleanupSpuriousResponse(pkt *htlcPacket) {
+	inKey := pkt.inKey()
+
+	l.debugf("Cleaning up spurious response for incoming circuit-key=%v",
+		inKey)
+
+	// If the htlc packet doesn't have a source reference, it is unsafe to
+	// proceed, as skipping this ack may cause the htlc to be reforwarded.
+	if pkt.sourceRef == nil {
+		l.errorf("uanble to cleanup response for incoming "+
+			"circuit-key=%v, does not contain source reference",
+			inKey)
+		return
+	}
+
+	// If the source reference is present,  we will try to prevent this link
+	// from resending the packet to the switch. To do so, we ack the AddRef
+	// of the incoming HTLC belonging to this link.
+	err := l.channel.AckAddHtlcs(*pkt.sourceRef)
+	if err != nil {
+		l.errorf("unable to ack AddRef for incoming "+
+			"circuit-key=%v: %v", inKey, err)
+
+		// If this operation failed, it is unsafe to attempt removal of
+		// the destination reference or circuit, so we exit early. The
+		// cleanup may proceed with a different packet in the future
+		// that succeeds on this step.
+		return
+	}
+
+	// Now that we know this link will stop retransmitting Adds to the
+	// switch, we can begin to teardown the response reference and circuit
+	// map.
+	//
+	// If the packet includes a destination reference, then a response for
+	// this HTLC was locked into the outgoing channel. Attempt to remove
+	// this reference, so we stop retransmitting the response internally.
+	// Even if this fails, we will proceed in trying to delete the circuit.
+	// When retransmitting responses, the destination references will be
+	// cleaned up if an open circuit is not found in the circuit map.
+	if pkt.destRef != nil {
+		err := l.channel.AckSettleFails(*pkt.destRef)
+		if err != nil {
+			l.errorf("unable to ack SettleFailRef "+
+				"for incoming circuit-key=%v: %v",
+				inKey, err)
+		}
+	}
+
+	l.debugf("Deleting circuit for incoming circuit-key=%x", inKey)
+
+	// With all known references acked, we can now safely delete the circuit
+	// from the switch's circuit map, as the state is no longer needed.
+	err = l.cfg.Circuits.DeleteCircuits(inKey)
+	if err != nil {
+		l.errorf("unable to delete circuit for "+
+			"circuit-key=%v: %v", inKey, err)
 	}
 }
 

--- a/lnwallet/channel.go
+++ b/lnwallet/channel.go
@@ -4433,6 +4433,22 @@ func (lc *LightningChannel) LoadFwdPkgs() ([]*channeldb.FwdPkg, error) {
 	return lc.channelState.LoadFwdPkgs()
 }
 
+// AckAddHtlcs sets a bit in the FwdFilter of a forwarding package belonging to
+// this channel, that corresponds to the given AddRef. This method also succeeds
+// if no forwarding package is found.
+func (lc *LightningChannel) AckAddHtlcs(addRef channeldb.AddRef) error {
+	return lc.channelState.AckAddHtlcs(addRef)
+}
+
+// AckSettleFails sets a bit in the SettleFailFilter of a forwarding package
+// belonging to this channel, that corresponds to the given SettleFailRef. This
+// method also succeeds if no forwarding package is found.
+func (lc *LightningChannel) AckSettleFails(
+	settleFailRefs ...channeldb.SettleFailRef) error {
+
+	return lc.channelState.AckSettleFails(settleFailRefs...)
+}
+
 // SetFwdFilter writes the forwarding decision for a given remote commitment
 // height.
 func (lc *LightningChannel) SetFwdFilter(height uint64,
@@ -4572,21 +4588,18 @@ func (lc *LightningChannel) SettleHTLC(preimage [32]byte,
 
 	htlc := lc.remoteUpdateLog.lookupHtlc(htlcIndex)
 	if htlc == nil {
-		return fmt.Errorf("No HTLC with ID %d in channel %v", htlcIndex,
-			lc.ShortChanID())
+		return ErrUnknownHtlcIndex{lc.ShortChanID(), htlcIndex}
 	}
 
 	// Now that we know the HTLC exists, before checking to see if the
 	// preimage matches, we'll ensure that we haven't already attempted to
 	// modify the HTLC.
 	if lc.remoteUpdateLog.htlcHasModification(htlcIndex) {
-		return fmt.Errorf("HTLC with ID %d has already been settled",
-			htlcIndex)
+		return ErrHtlcIndexAlreadySettled(htlcIndex)
 	}
 
 	if htlc.RHash != sha256.Sum256(preimage[:]) {
-		return fmt.Errorf("Invalid payment preimage %x for hash %x",
-			preimage[:], htlc.RHash[:])
+		return ErrInvalidSettlePreimage{preimage[:], htlc.RHash[:]}
 	}
 
 	pd := &PaymentDescriptor{
@@ -4620,21 +4633,18 @@ func (lc *LightningChannel) ReceiveHTLCSettle(preimage [32]byte, htlcIndex uint6
 
 	htlc := lc.localUpdateLog.lookupHtlc(htlcIndex)
 	if htlc == nil {
-		return fmt.Errorf("No HTLC with ID %d in channel %v", htlcIndex,
-			lc.ShortChanID())
+		return ErrUnknownHtlcIndex{lc.ShortChanID(), htlcIndex}
 	}
 
 	// Now that we know the HTLC exists, before checking to see if the
 	// preimage matches, we'll ensure that they haven't already attempted
 	// to modify the HTLC.
 	if lc.localUpdateLog.htlcHasModification(htlcIndex) {
-		return fmt.Errorf("HTLC with ID %d has already been settled",
-			htlcIndex)
+		return ErrHtlcIndexAlreadySettled(htlcIndex)
 	}
 
 	if htlc.RHash != sha256.Sum256(preimage[:]) {
-		return fmt.Errorf("Invalid payment preimage %x for hash %x",
-			preimage[:], htlc.RHash[:])
+		return ErrInvalidSettlePreimage{preimage[:], htlc.RHash[:]}
 	}
 
 	pd := &PaymentDescriptor{
@@ -4688,15 +4698,13 @@ func (lc *LightningChannel) FailHTLC(htlcIndex uint64, reason []byte,
 
 	htlc := lc.remoteUpdateLog.lookupHtlc(htlcIndex)
 	if htlc == nil {
-		return fmt.Errorf("No HTLC with ID %d in channel %v", htlcIndex,
-			lc.ShortChanID())
+		return ErrUnknownHtlcIndex{lc.ShortChanID(), htlcIndex}
 	}
 
 	// Now that we know the HTLC exists, we'll ensure that we haven't
 	// already attempted to fail the HTLC.
 	if lc.remoteUpdateLog.htlcHasModification(htlcIndex) {
-		return fmt.Errorf("HTLC with ID %d has already been failed",
-			htlcIndex)
+		return ErrHtlcIndexAlreadyFailed(htlcIndex)
 	}
 
 	pd := &PaymentDescriptor{
@@ -4740,15 +4748,13 @@ func (lc *LightningChannel) MalformedFailHTLC(htlcIndex uint64,
 
 	htlc := lc.remoteUpdateLog.lookupHtlc(htlcIndex)
 	if htlc == nil {
-		return fmt.Errorf("No HTLC with ID %d in channel %v", htlcIndex,
-			lc.ShortChanID())
+		return ErrUnknownHtlcIndex{lc.ShortChanID(), htlcIndex}
 	}
 
 	// Now that we know the HTLC exists, we'll ensure that we haven't
 	// already attempted to fail the HTLC.
 	if lc.remoteUpdateLog.htlcHasModification(htlcIndex) {
-		return fmt.Errorf("HTLC with ID %d has already been failed",
-			htlcIndex)
+		return ErrHtlcIndexAlreadyFailed(htlcIndex)
 	}
 
 	pd := &PaymentDescriptor{
@@ -4785,15 +4791,13 @@ func (lc *LightningChannel) ReceiveFailHTLC(htlcIndex uint64, reason []byte,
 
 	htlc := lc.localUpdateLog.lookupHtlc(htlcIndex)
 	if htlc == nil {
-		return fmt.Errorf("No HTLC with ID %d in channel %v", htlcIndex,
-			lc.ShortChanID())
+		return ErrUnknownHtlcIndex{lc.ShortChanID(), htlcIndex}
 	}
 
 	// Now that we know the HTLC exists, we'll ensure that they haven't
 	// already attempted to fail the HTLC.
 	if lc.localUpdateLog.htlcHasModification(htlcIndex) {
-		return fmt.Errorf("HTLC with ID %d has already been failed",
-			htlcIndex)
+		return ErrHtlcIndexAlreadyFailed(htlcIndex)
 	}
 
 	pd := &PaymentDescriptor{

--- a/lnwallet/errors.go
+++ b/lnwallet/errors.go
@@ -125,3 +125,49 @@ func ErrChanTooSmall(chanSize, minChanSize btcutil.Amount) ReservationError {
 			chanSize, minChanSize),
 	}
 }
+
+// ErrHtlcIndexAlreadyFailed is returned when the HTLC index has already been
+// failed, but has not been committed by our commitment state.
+type ErrHtlcIndexAlreadyFailed uint64
+
+// Error returns a message indicating the index that had already been failed.
+func (e ErrHtlcIndexAlreadyFailed) Error() string {
+	return fmt.Sprintf("HTLC with ID %d has already been failed", e)
+}
+
+// ErrHtlcIndexAlreadySettled is returned when the HTLC index has already been
+// settled, but has not been committed by our commitment state.
+type ErrHtlcIndexAlreadySettled uint64
+
+// Error returns a message indicating the index that had already been settled.
+func (e ErrHtlcIndexAlreadySettled) Error() string {
+	return fmt.Sprintf("HTLC with ID %d has already been settled", e)
+}
+
+// ErrInvalidSettlePreimage is returned when trying to settle an HTLC, but the
+// preimage does not correspond to the payment hash.
+type ErrInvalidSettlePreimage struct {
+	preimage []byte
+	rhash    []byte
+}
+
+// Error returns an error message with the offending preimage and intended
+// payment hash.
+func (e ErrInvalidSettlePreimage) Error() string {
+	return fmt.Sprintf("Invalid payment preimage %x for hash %x",
+		e.preimage, e.rhash)
+}
+
+// ErrUnknownHtlcIndex is returned when locally settling or failing an HTLC, but
+// the HTLC index is not known to the channel. This typically indicates that the
+// HTLC was already settled in a prior commitment.
+type ErrUnknownHtlcIndex struct {
+	chanID lnwire.ShortChannelID
+	index  uint64
+}
+
+// Error returns an error logging the channel and HTLC index that was unknown.
+func (e ErrUnknownHtlcIndex) Error() string {
+	return fmt.Sprintf("No HTLC with ID %d in channel %v",
+		e.index, e.chanID)
+}


### PR DESCRIPTION
In this PR, we add some additional logic to cleanup spurious internal retransmission of htlc packets. #1747 addressed the root cause of most issues seen on this front, though this PR adds logic to clean up the aftermath.

should get rid of:
```
2018-07-27 20:23:25.255 [ERR] HSWC: ChannelLink(528615:1949:1) Failing link: unable to settle incoming HTLC: No HTLC with ID
```
```
2018-07-27 20:23:25.255 [ERR] HSWC: ChannelLink(528615:1949:1) unable to fail incoming HTLC: No HTLC with ID
```

Depends on:
 - [x] #1747 
 - [x] #1748 