### PR TITLE
server: prevent increasing epochErrors if conn was established

### DIFF
--- a/server.go
+++ b/server.go
@@ -1346,6 +1346,10 @@ func (s *server) peerBootstrapper(numTargetPeers uint32,
 					s.connectToPeer(a, errChan)
 					select {
 					case err := <-errChan:
+						if err == nil {
+							return
+						}
+
 						srvrLog.Errorf("Unable to "+
 							"connect to %v: %v",
 							a, err)
@@ -1413,6 +1417,9 @@ func (s *server) initialPeerBootstrap(ignore map[autopilot.NodeID]struct{},
 				// us down.
 				select {
 				case err := <-errChan:
+					if err == nil {
+						return
+					}
 					srvrLog.Errorf("Unable to connect to "+
 						"%v: %v", addr, err)
 				// TODO: tune timeout? 3 seconds might be *too*


### PR DESCRIPTION
Noticed this issue while checking out the logs from #1700.

In this commit, we fix a small bug where we would increase epochErrors
by one even if connections were successfully established. Due to this,
we would stay stuck inside of the peer bootstrapper loop without
requerying for new peers.