### PR TITLE
Replace maintainer by label in Dockerfiles

### DIFF
--- a/docker/btcd/Dockerfile
+++ b/docker/btcd/Dockerfile
@@ -1,6 +1,6 @@
 FROM golang:1.12-alpine as builder
 
-MAINTAINER Olaoluwa Osuntokun <laolu@lightning.network>
+LABEL maintainer="Olaoluwa Osuntokun <laolu@lightning.engineering>"
 
 # Install build dependencies such as git and glide.
 RUN apk add --no-cache git gcc musl-dev

--- a/docker/lnd/Dockerfile
+++ b/docker/lnd/Dockerfile
@@ -1,6 +1,6 @@
 FROM golang:1.12-alpine as builder
 
-MAINTAINER Olaoluwa Osuntokun <lightning.engineering>
+LABEL maintainer="Olaoluwa Osuntokun <laolu@lightning.engineering>"
 
 # Copy in the local repository to build from.
 COPY . /go/src/github.com/lightningnetwork/lnd

--- a/docker/ltcd/Dockerfile
+++ b/docker/ltcd/Dockerfile
@@ -1,6 +1,6 @@
 FROM golang:1.12-alpine as builder
 
-MAINTAINER Olaoluwa Osuntokun <lightning.engineering>
+LABEL maintainer="Olaoluwa Osuntokun <laolu@lightning.engineering>"
 
 # Grab and install the latest version of roasbeef's fork of ltcd and all
 # related dependencies.


### PR DESCRIPTION
The maintainer instruction is deprecated, see:
https://docs.docker.com/engine/reference/builder/#maintainer-deprecated

Also unified the maintainer value. Please check if this is correct, because in one you used `laolu@lightning.network`, in another just `lightning.engineering` without `laolu@`, while according to some commits in the repo the email addresses of your companies' engineers seems to be `<name>@lightning.engineering`.