### PR TITLE
lnwallet: add basic transaction rebroadcaster implementation 

### DIFF
--- a/lnwallet/btcwallet/btcwallet.go
+++ b/lnwallet/btcwallet/btcwallet.go
@@ -399,6 +399,24 @@ func (b *BtcWallet) PublishTransaction(tx *wire.MsgTx) error {
 				// is missing or already spent.
 				return lnwallet.ErrDoubleSpend
 			}
+			if strings.Contains(err.Error(), "insufficient priority") {
+				// Transaction failed to broadcast due to not
+				// having enough of a fee to be accepted by the
+				// backend's mempool.
+				return lnwallet.ErrInsufficientFee
+			}
+			if strings.Contains(err.Error(), "under the required amount") {
+				// Transaction failed to broadcast due to not
+				// having enough of a fee to be accepted by the
+				// backend's mempool.
+				return lnwallet.ErrInsufficientFee
+			}
+			if strings.Contains(err.Error(), "low fees") {
+				// Transaction failed to broadcast due to not
+				// having enough of a fee to be accepted by the
+				// backend's mempool.
+				return lnwallet.ErrInsufficientFee
+			}
 
 		case *chain.BitcoindClient:
 			if strings.Contains(err.Error(), "txn-already-in-mempool") {
@@ -428,6 +446,12 @@ func (b *BtcWallet) PublishTransaction(tx *wire.MsgTx) error {
 				// is missing or already spent.
 				return lnwallet.ErrDoubleSpend
 			}
+			if strings.Contains(err.Error(), "fee not met") {
+				// Transaction failed to broadcast due to not
+				// having enough of a fee to be accepted by the
+				// backend's mempool.
+				return lnwallet.ErrInsufficientFee
+			}
 
 		case *chain.NeutrinoClient:
 			if strings.Contains(err.Error(), "already have") {
@@ -443,6 +467,30 @@ func (b *BtcWallet) PublishTransaction(tx *wire.MsgTx) error {
 			if strings.Contains(err.Error(), "already spent") {
 				// Output was already spent.
 				return lnwallet.ErrDoubleSpend
+			}
+			if strings.Contains(err.Error(), "insufficient priority") {
+				// Transaction failed to broadcast due to not
+				// having enough of a fee to be accepted by the
+				// network.
+				return lnwallet.ErrInsufficientFee
+			}
+			if strings.Contains(err.Error(), "under the required amount") {
+				// Transaction failed to broadcast due to not
+				// having enough of a fee to be accepted by the
+				// network.
+				return lnwallet.ErrInsufficientFee
+			}
+			if strings.Contains(err.Error(), "low fees") {
+				// Transaction failed to broadcast due to not
+				// having enough of a fee to be accepted by the
+				// network.
+				return lnwallet.ErrInsufficientFee
+			}
+			if strings.Contains(err.Error(), "fee not met") {
+				// Transaction failed to broadcast due to not
+				// having enough of a fee to be accepted by the
+				// network.
+				return lnwallet.ErrInsufficientFee
 			}
 
 		default:

--- a/lnwallet/interface.go
+++ b/lnwallet/interface.go
@@ -40,7 +40,12 @@ var (
 	// ErrDoubleSpend is returned from PublishTransaction in case the
 	// tx being published is spending an output spent by a conflicting
 	// transaction.
-	ErrDoubleSpend = errors.New("Transaction rejected: output already spent")
+	ErrDoubleSpend = errors.New("transaction rejected: output already spent")
+
+	// ErrInsufficientFee is an error returned from PublishTransaction when
+	// a transaction has too small of a fee to be accepted into the
+	// backend's mempool
+	ErrInsufficientFee = errors.New("transaction rejected: insufficient fee")
 
 	// ErrNotMine is an error denoting that a WalletController instance is
 	// unable to spend a specified output.

--- a/lnwallet/interface_test.go
+++ b/lnwallet/interface_test.go
@@ -1498,6 +1498,18 @@ func testPublishTransaction(r *rpctest.Harness,
 		}
 	}
 
+	// Now, we'll test the case where a transaction has an insufficient fee
+	// that does not allow it to propagate throughout the network.
+	weightEstimator := (&lnwallet.TxWeightEstimator{}).AddP2WKHInput().
+		AddP2WKHOutput()
+	weight := int64(weightEstimator.Weight())
+	txFee = lnwallet.SatPerKWeight(250).FeeForWeight(weight) - 1
+
+	tx8 := newTx(t, r, w, output, keyDesc, keyDesc.PubKey, txFee)
+	if err := w.PublishTransaction(tx8); err != lnwallet.ErrInsufficientFee {
+		t.Fatalf("expected ErrInsufficientFee, got: %v", err)
+	}
+
 	// TODO(halseth): test replaceable transactions when btcd
 	// gets RBF support.
 }

--- a/lnwallet/rebroadcaster.go
+++ b/lnwallet/rebroadcaster.go
@@ -1,0 +1,335 @@
+package lnwallet
+
+import (
+	"errors"
+	"fmt"
+	"sync"
+
+	"github.com/btcsuite/btcd/blockchain"
+	"github.com/btcsuite/btcd/txscript"
+	"github.com/btcsuite/btcd/wire"
+	"github.com/btcsuite/btcutil"
+)
+
+var (
+	// ErrRebroadcastMaxAttempts is an error returned when the rebroadcaster
+	// has reached its maximum number of allowed unsuccessful attempts.
+	ErrRebroadcastMaxAttempts = errors.New("exhausted maximum number of " +
+		"rebroadcast attempts")
+
+	// ErrRebroadcastMaxFee is an error returned when the rebroadcaster has
+	// reached the maximum fee allowed after bumping up the fee due to many
+	// unsuccessful attempts
+	ErrRebroadcastMaxFee = errors.New("exceeded rebroadcast max fee")
+
+	// ErrRebroadcastDustLimit is an error returned when the rebroadcaster
+	// is applying a new fee to the transaction but would result in the
+	// change output dipping below the dust limit.
+	ErrRebroadcastDustLimit = errors.New("change output dipped below " +
+		"dust limit")
+
+	// ErrRebroadcastHalt is an error returned when the rebroadcaster has
+	// been requested to halt.
+	ErrRebroadcastHalt = errors.New("rebroadcaster is exiting")
+)
+
+// WitnessSignDescriptor is a tuple of a transaction input's sign descriptor
+// along with its witness type. This is needed in order to use the generic
+// GenWitnessFunc in order to generate the correct witness for each type.
+type WitnessSignDescriptor struct {
+	WitnessType
+	*SignDescriptor
+}
+
+// TxRebroadcasterCfg contains all of the required fields to be able to bump a
+// transaction's current fee, re-sign it, and broadcast it to the network.
+//
+// NOTE: All fields are required unless otherwise noted.
+type TxRebroadcasterCfg struct {
+	// Tx is the transaction that should be rebroadcast.
+	Tx *wire.MsgTx
+
+	// ChangeOutputIndex is the index of the change output that should be
+	// used to bump the transaction's fee.
+	ChangeOutputIndex uint32
+
+	// Signer allows us to regenerate signatures for all inputs after
+	// applying the new fee to the transaction.
+	Signer Signer
+
+	// WitnessSignDescs is the sign descriptor that should be used to resign
+	// the input that maps to the change output.
+	//
+	// NOTE: The slice must be sorted in increasing ordered by the index of
+	// each input.
+	WitnessSignDescs []*WitnessSignDescriptor
+
+	// BumpPercentage is the percentage used to increase the last
+	// insufficient fee tried.
+	BumpPercentage int
+
+	// MaxAttempts is the maximum number of tries we should attempt to
+	// rebroadcast the transaction.
+	//
+	// NOTE: This field is optional if MaxFee is set.
+	MaxAttempts int
+
+	// MaxFee is the maximum fee in satoshis that we should allow to use on
+	// the transaction being rebroadcast.
+	//
+	// NOTE: This field is optional if MaxAttempts is set.
+	MaxFee btcutil.Amount
+
+	// DustLimit is the lower threshold value for which the change output's
+	// value should not dip below.
+	DustLimit btcutil.Amount
+
+	// ConsumeChangeOutput determines whether we should consume the whole
+	// change output to use as fees if it ends up dipping below the dust
+	// limit.
+	ConsumeChangeOutput bool
+
+	// FetchInputAmount is a callback used to fetch the amount of each of
+	// the transaction's inputs in order to calculate its fee.
+	FetchInputAmount func(*wire.OutPoint) (btcutil.Amount, error)
+
+	// Broadcast allows us to broadcast the transaction to the network. This
+	// will be used to broadcast the higher fee re-signed transaction to
+	// ensure it's accepted into the backend's mempool.
+	Broadcast func(*wire.MsgTx) error
+}
+
+// TxRebroadcaster is a helper struct that aids us in rebroadcasting
+// transactions with insufficient fees in order to propagate throughout the
+// network.
+type TxRebroadcaster struct {
+	cfg     TxRebroadcasterCfg
+	errChan chan error
+
+	mu          sync.Mutex
+	numAttempts int
+	lastFee     btcutil.Amount
+	lastTx      *wire.MsgTx
+}
+
+// NewTxRebroadcaster creates a new rebroadcaster using the given configuration.
+func NewTxRebroadcaster(cfg TxRebroadcasterCfg) (*TxRebroadcaster, error) {
+	// Validate the constraints specified within the config.
+	if cfg.BumpPercentage <= 0 {
+		return nil, errors.New("bump percentage must be set")
+	}
+	if cfg.MaxAttempts <= 0 && cfg.MaxFee <= 0 {
+		return nil, errors.New("either MaxAttempts or MaxFee must be set")
+	}
+	if cfg.DustLimit <= 0 {
+		return nil, errors.New("dust limit must be set")
+	}
+
+	// Ensure this is a valid transaction.
+	tx := btcutil.NewTx(cfg.Tx)
+	if err := blockchain.CheckTransactionSanity(tx); err != nil {
+		return nil, err
+	}
+
+	return &TxRebroadcaster{
+		cfg:     cfg,
+		errChan: make(chan error, 1),
+	}, nil
+}
+
+// Rebroadcast kicks off the automatic rebroadcast process. The quit channel can
+// be used to signal the rebroadcaster to terminate early.
+func (r *TxRebroadcaster) Rebroadcast(quit <-chan struct{}) <-chan error {
+	go r.rebroadcast(quit)
+
+	return r.errChan
+}
+
+// rebroadcast is the main handler of the rebroadcaster. For every attempt, the
+// current fee is bumped by the specified percentage. Each new transaction is
+// then signed and broadcast to the network. If the fee is not sufficient, the
+// whole process will be done again until either we can read from the quit
+// channel, we've reached the maximum fee allowed, or we've reached the maximum
+// number of attempts allowed.
+func (r *TxRebroadcaster) rebroadcast(quit <-chan struct{}) {
+	// We'll start off by computing the current fee of the transaction.
+	// We do this by subtracting the total value of the outputs from the
+	// total value of the inputs.
+	inputAmt := int64(0)
+	for _, input := range r.cfg.Tx.TxIn {
+		amount, err := r.cfg.FetchInputAmount(&input.PreviousOutPoint)
+		if err != nil {
+			r.errChan <- fmt.Errorf("unable to fetch utxo used as "+
+				"input: %v", err)
+			return
+		}
+
+		inputAmt += int64(amount)
+	}
+
+	outputAmt := int64(0)
+	for _, output := range r.cfg.Tx.TxOut {
+		outputAmt += output.Value
+	}
+
+	currentFee := inputAmt - outputAmt
+	changeOutput := r.cfg.Tx.TxOut[r.cfg.ChangeOutputIndex]
+
+	r.mu.Lock()
+	r.lastFee = btcutil.Amount(currentFee)
+	r.mu.Unlock()
+
+	// With the current fee computed, we can begin our rebroadcast attempts
+	// by bumping up the transaction's fee at every iteration.
+	for {
+		r.mu.Lock()
+		numAttempts := r.numAttempts
+		currentFee := r.lastFee
+		r.mu.Unlock()
+
+		if r.cfg.MaxAttempts > 0 && numAttempts >= r.cfg.MaxAttempts {
+			// TODO(wilmer): output should be moved to pool to be
+			// swept later on.
+			r.errChan <- ErrRebroadcastMaxAttempts
+			return
+		}
+
+		// Calculate the new fee that should be used for the transaction
+		// by taking into account the specified bump and ensure it
+		// respects the maximum fee allowed.
+		bump := currentFee * btcutil.Amount(r.cfg.BumpPercentage) / 100
+		newFee := currentFee + bump
+		if r.cfg.MaxFee > 0 && newFee > r.cfg.MaxFee {
+			// TODO(wilmer): output should be moved to pool to be
+			// swept later on.
+			r.errChan <- ErrRebroadcastMaxFee
+			return
+		}
+
+		// Apply the new fee to the transaction by subtracting the
+		// amount increased and ensure our change output hasn't dipped
+		// below the dust limit,
+		changeOutput.Value -= int64(bump)
+		if changeOutput.Value < int64(r.cfg.DustLimit) {
+			// If it has, then we'll also check whether this output
+			// shouldn't be consumed.
+			if !r.cfg.ConsumeChangeOutput {
+				r.errChan <- ErrRebroadcastDustLimit
+				return
+			}
+
+			// Otherwise, it should, so we'll remove it from the
+			// transaction.
+			outputs := r.cfg.Tx.TxOut
+			r.cfg.Tx.TxOut = append(
+				outputs[:r.cfg.ChangeOutputIndex],
+				outputs[r.cfg.ChangeOutputIndex+1:]...,
+			)
+		}
+
+		// Before signing the transaction, check to ensure that it meets
+		// some basic validity requirements.
+		tx := btcutil.NewTx(r.cfg.Tx)
+		if err := blockchain.CheckTransactionSanity(tx); err != nil {
+			r.errChan <- err
+			return
+		}
+
+		// With the new fee applied, we'll re-sign the transaction.
+		for i := range r.cfg.Tx.TxIn {
+			// Retrieve the sign descriptor for the current input.
+			if i >= len(r.cfg.WitnessSignDescs) {
+				r.errChan <- fmt.Errorf("missing sign "+
+					"descriptor for input with index %v", i)
+				return
+			}
+
+			signDesc := r.cfg.WitnessSignDescs[i]
+			signDesc.SigHashes = txscript.NewTxSigHashes(r.cfg.Tx)
+
+			// Determine the type of witness required for this input
+			// and generate it.
+			witnessFunc := signDesc.GenWitnessFunc(
+				r.cfg.Signer, signDesc.SignDescriptor,
+			)
+			newWitness, err := witnessFunc(
+				r.cfg.Tx, signDesc.SigHashes, i,
+			)
+			if err != nil {
+				r.errChan <- fmt.Errorf("unable to sign "+
+					"output: %v", err)
+				return
+			}
+			r.cfg.Tx.TxIn[i].Witness = newWitness
+		}
+
+		// We'll make sure we haven't been requested to stop right
+		// before attempting to rebroadcast the transaction.
+		if quit != nil {
+			select {
+			case <-quit:
+				r.errChan <- ErrRebroadcastHalt
+				return
+			default:
+			}
+		}
+
+		// Now that the transaction has had its new fee and signatures
+		// applied, we can attempt to rebroadcast it.
+		err := r.cfg.Broadcast(r.cfg.Tx)
+
+		r.mu.Lock()
+		r.numAttempts++
+		r.lastFee = newFee
+		r.lastTx = r.cfg.Tx
+		r.mu.Unlock()
+
+		switch err {
+		// If the transaction still has an insufficient fee, we'll bump
+		// it up once more.
+		case ErrInsufficientFee:
+			continue
+
+		// If a previous version of the transaction has already been
+		// seen in the network, then we should halt the rebroadcaster in
+		// order to avoid bumping up the fee once again.
+		case ErrDoubleSpend:
+			r.errChan <- nil
+			return
+
+		case nil:
+			r.errChan <- nil
+			return
+
+		default:
+			r.errChan <- fmt.Errorf("unable to rebroadcast "+
+				"transaction with higher fee: %v", err)
+			return
+		}
+	}
+}
+
+// NumAttempts returns the number of attempts the transaction was rebroadcast.
+func (r *TxRebroadcaster) NumAttempts() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.numAttempts
+}
+
+// LastFeeUsed returned the fee used in satoshis for the last rebroadcast
+// attempt.
+func (r *TxRebroadcaster) LastFeeUsed() btcutil.Amount {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.lastFee
+}
+
+// LastTxBroadcast returns the last version of the transaction that was
+// rebroadcast.
+//
+// NOTE: This may be nil if the tranasaction hasn't yet been rebroadcasted.
+func (r *TxRebroadcaster) LastTxBroadcast() *wire.MsgTx {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.lastTx
+}

--- a/lnwallet/rebroadcaster_test.go
+++ b/lnwallet/rebroadcaster_test.go
@@ -1,0 +1,571 @@
+package lnwallet
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/btcsuite/btcd/btcec"
+	"github.com/btcsuite/btcd/txscript"
+	"github.com/btcsuite/btcd/wire"
+	"github.com/btcsuite/btcutil"
+	"github.com/lightningnetwork/lnd/keychain"
+)
+
+type emptyMockSigner struct{}
+
+var _ Signer = (*emptyMockSigner)(nil)
+
+func (s *emptyMockSigner) SignOutputRaw(tx *wire.MsgTx,
+	signDesc *SignDescriptor) ([]byte, error) {
+
+	return nil, nil
+}
+
+func (s *emptyMockSigner) ComputeInputScript(tx *wire.MsgTx,
+	signDesc *SignDescriptor) (*InputScript, error) {
+
+	return nil, nil
+}
+
+// TestRebroadcasterFeeBump ensures that the rebroadcaster can properly bump a
+// transaction's current fee until it is deemed sufficient to be broadcast to
+// the network. It should be able to bump the fee successfully without exceeding
+// MaxAttempts and MaxFee.
+func TestRebroadcasterFeeBump(t *testing.T) {
+	t.Parallel()
+
+	// We'll start off by making a copy of the transaction to prevent
+	// mutating the state of the global variable.
+	tx := testTx.Copy()
+
+	// Calculate the current fee of the transaction.
+	outputAmt := btcutil.Amount(tx.TxOut[0].Value)
+	inputAmt := outputAmt + btcutil.SatoshiPerBitcoin
+	fee := inputAmt - outputAmt
+
+	// We'll assume that the current fee is insufficient and that a
+	// sufficient fee should be 1.5x more.
+	sufficientFee := fee + (btcutil.SatoshiPerBitcoin / 2)
+
+	// Recreate the sign descriptor needed in order to re-sign this
+	// transaction.
+	testPrivKey, _ := btcec.PrivKeyFromBytes(btcec.S256(), bobsPrivKey)
+	testPubKey := testPrivKey.PubKey()
+	signDesc := &WitnessSignDescriptor{
+		WitnessType: P2WPKH,
+		SignDescriptor: &SignDescriptor{
+			KeyDesc: keychain.KeyDescriptor{
+				PubKey: testPubKey,
+			},
+			SigHashes: txscript.NewTxSigHashes(tx),
+		},
+	}
+	signDescs := []*WitnessSignDescriptor{signDesc}
+
+	// We'll now set our constraints on the rebroadcaster. The fee will
+	// increase by 10% at every iteration. It should be able to reach the
+	// sufficientFee without exceeding maxAttempts and maxFee.
+	const bumpPercentage = 10
+	const maxAttempts = 10
+	maxFee := 2 * fee
+
+	cfg := TxRebroadcasterCfg{
+		Tx:                tx,
+		ChangeOutputIndex: 0,
+		Signer:            &emptyMockSigner{},
+		WitnessSignDescs:  signDescs,
+		BumpPercentage:    bumpPercentage,
+		MaxAttempts:       maxAttempts,
+		MaxFee:            maxFee,
+		DustLimit:         DefaultDustLimit(),
+		FetchInputAmount: func(*wire.OutPoint) (btcutil.Amount, error) {
+			return inputAmt, nil
+		},
+		Broadcast: func(tx *wire.MsgTx) error {
+			// Calculate the fee for the current version of the
+			// transaction being broadcast and check if it's still
+			// not enough.
+			fee := inputAmt - btcutil.Amount(tx.TxOut[0].Value)
+			if fee < sufficientFee {
+				return ErrInsufficientFee
+			}
+			return nil
+		},
+	}
+
+	rebroadcaster, err := NewTxRebroadcaster(cfg)
+	if err != nil {
+		t.Fatalf("unable to create tx rebroadcaster: %v", err)
+	}
+
+	// Kick off the rebroadcaster for this transaction.
+	errChan := rebroadcaster.Rebroadcast(nil)
+	select {
+	case err = <-errChan:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for result")
+	}
+
+	// The transaction should have been rebroadcasted successfully.
+	if err != nil {
+		t.Fatalf("received unexpected error: %v", err)
+	}
+
+	// Ensure that the last fee used is above the sufficientFee and below
+	// the maxFee.
+	lastFee := rebroadcaster.LastFeeUsed()
+	if lastFee < sufficientFee {
+		t.Fatalf("expected last fee used to be greater than %v, got %v",
+			sufficientFee, lastFee)
+	}
+	if lastFee > maxFee {
+		t.Fatalf("expected last fee used to be less than max %v, got %v",
+			maxFee, lastFee)
+	}
+}
+
+// TestRebroadcasterMaxFee ensures that the rebroadcaster respects its MaxFee
+// limit by halting the rebroadcast of the transaction after exceeding the
+// maximum allowed fee.
+func TestRebroadcasterMaxFee(t *testing.T) {
+	t.Parallel()
+
+	// We'll start off by making a copy of the transaction to prevent
+	// mutating the state of the global variable.
+	tx := testTx.Copy()
+
+	// Calculate the current fee of the transaction.
+	outputAmt := btcutil.Amount(tx.TxOut[0].Value)
+	inputAmt := outputAmt + btcutil.SatoshiPerBitcoin
+	fee := btcutil.Amount(inputAmt - outputAmt)
+
+	// Recreate the sign descriptor needed in order to re-sign this
+	// transaction.
+	testPrivKey, _ := btcec.PrivKeyFromBytes(btcec.S256(), bobsPrivKey)
+	testPubKey := testPrivKey.PubKey()
+	signDesc := &WitnessSignDescriptor{
+		WitnessType: P2WPKH,
+		SignDescriptor: &SignDescriptor{
+			KeyDesc: keychain.KeyDescriptor{
+				PubKey: testPubKey,
+			},
+			SigHashes: txscript.NewTxSigHashes(tx),
+		},
+	}
+	signDescs := []*WitnessSignDescriptor{signDesc}
+
+	// Set the constraints on the rebroadcaster. We should continue to
+	// rebroadcast the transaction until we've reached the max fee, which
+	// should then trigger the rebroadcaster to halt.
+	const bumpPercentage = 10
+	maxFee := fee + (btcutil.SatoshiPerBitcoin / 2)
+
+	cfg := TxRebroadcasterCfg{
+		Tx:                tx,
+		ChangeOutputIndex: 0,
+		Signer:            &emptyMockSigner{},
+		WitnessSignDescs:  signDescs,
+		BumpPercentage:    bumpPercentage,
+		MaxFee:            maxFee,
+		DustLimit:         DefaultDustLimit(),
+		FetchInputAmount: func(*wire.OutPoint) (btcutil.Amount, error) {
+			return inputAmt, nil
+		},
+		// Broadcast will always return ErrInsufficientFee in order to
+		// keep bumping up the fee and rebroadcasting until reaching the
+		// maximum fee allowed.
+		Broadcast: func(*wire.MsgTx) error {
+			return ErrInsufficientFee
+		},
+	}
+
+	rebroadcaster, err := NewTxRebroadcaster(cfg)
+	if err != nil {
+		t.Fatalf("unable to create tx rebroadcaster: %v", err)
+	}
+
+	// Kick off the rebroadcaster for this transaction.
+	errChan := rebroadcaster.Rebroadcast(nil)
+	select {
+	case err = <-errChan:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for result")
+	}
+
+	// The rebroadcaster should halt indicating that it reached its maximum
+	// fee allowed while attempting to rebroadcast the transaction.
+	if err != ErrRebroadcastMaxFee {
+		t.Fatalf("expected ErrRebroadcastMaxFee, got %v", err)
+	}
+
+	// Ensure the last fee used is below the maximum fee allowed.
+	lastFee := rebroadcaster.LastFeeUsed()
+	if lastFee > maxFee {
+		t.Fatalf("expected last fee used to be less than %v, got %v",
+			cfg.MaxFee, lastFee)
+	}
+}
+
+// TestRebroadcasterMaxAttempts ensures that the rebroadcaster respects its
+// MaxAttempts limit by halting the rebroadcast of the transaction after
+// exceeding the maximum allowed number of attempts.
+func TestRebroadcasterMaxAttempts(t *testing.T) {
+	t.Parallel()
+
+	// We'll start off by making a copy of the transaction to prevent
+	// mutating the state of the global variable.
+	tx := testTx.Copy()
+
+	// We'll assume that the input amount is the output's + 1 BTC,
+	// indicating there is a 1 BTC fee on the transaction.
+	outputAmt := btcutil.Amount(tx.TxOut[0].Value)
+	inputAmt := outputAmt + btcutil.SatoshiPerBitcoin
+
+	// Recreate the sign descriptor needed in order to re-sign this
+	// transaction.
+	testPrivKey, _ := btcec.PrivKeyFromBytes(btcec.S256(), bobsPrivKey)
+	testPubKey := testPrivKey.PubKey()
+	signDesc := &WitnessSignDescriptor{
+		WitnessType: P2WPKH,
+		SignDescriptor: &SignDescriptor{
+			KeyDesc: keychain.KeyDescriptor{
+				PubKey: testPubKey,
+			},
+			SigHashes: txscript.NewTxSigHashes(tx),
+		},
+	}
+	signDescs := []*WitnessSignDescriptor{signDesc}
+
+	// The rebroadcaster should not attempt to rebroadcast this transaction
+	// more than 10 times.
+	const maxAttempts = 10
+
+	cfg := TxRebroadcasterCfg{
+		Tx:                tx,
+		ChangeOutputIndex: 0,
+		Signer:            &emptyMockSigner{},
+		WitnessSignDescs:  signDescs,
+		BumpPercentage:    10,
+		MaxAttempts:       maxAttempts,
+		DustLimit:         DefaultDustLimit(),
+		MaxFee:            btcutil.Amount(outputAmt),
+		FetchInputAmount: func(*wire.OutPoint) (btcutil.Amount, error) {
+			return inputAmt, nil
+		},
+		// Broadcast will always return ErrInsufficientFee in order to
+		// keep bumping up the fee and rebroadcasting until reaching the
+		// maximum number of attempts allowed.
+		Broadcast: func(*wire.MsgTx) error {
+			return ErrInsufficientFee
+		},
+	}
+
+	rebroadcaster, err := NewTxRebroadcaster(cfg)
+	if err != nil {
+		t.Fatalf("unable to create tx rebroadcaster: %v", err)
+	}
+
+	// Kick off the rebroadcaster.
+	errChan := rebroadcaster.Rebroadcast(nil)
+	select {
+	case err = <-errChan:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for result")
+	}
+
+	// The rebroadcaster should halt indicating that it reached it's maximum
+	// number of rebroadcast attempts allowed.
+	if err != ErrRebroadcastMaxAttempts {
+		t.Fatalf("expected ErrMaxRebroadcastAttempts, got %v", err)
+	}
+
+	// The number of attempts should match the max number allowed.
+	numAttempts := rebroadcaster.NumAttempts()
+	if numAttempts != cfg.MaxAttempts {
+		t.Fatalf("expected %v attempts, got %v", cfg.MaxAttempts,
+			numAttempts)
+	}
+}
+
+// TestRebroadcasterDustLimit ensures that the rebroadcaster takes into account
+// what we consider as "dust" on the chain. When bumping up the fee on a
+// transaction, if the change outputs dips below this limit, then we should stop
+// attempting to rebroadcast the transaction.
+func TestRebroadcasterDustLimit(t *testing.T) {
+	t.Parallel()
+
+	// We'll start off by making a copy of the transaction to prevent
+	// mutating the state of the global variable.
+	tx := testTx.Copy()
+
+	// We'll assume that the input amount is the output's + 1 BTC,
+	// indicating there is a 1 BTC fee on the transaction.
+	outputAmt := btcutil.Amount(tx.TxOut[0].Value)
+	inputAmt := outputAmt + btcutil.SatoshiPerBitcoin
+
+	// We'll now set our constraints on the rebroadcaster. Since we're
+	// interested in detecting when a change output dips below the dust
+	// limit after applying the new fee, we'll set the dust limit to be 1
+	// satoshi below the current output's value, so that the check gets
+	// triggered at the first attempt of rebroadcasting.
+	const bumpPercentage = 100
+	const maxAttempts = 10
+	dustLimit := outputAmt - 1
+
+	// Recreate the sign descriptor needed in order to re-sign this
+	// transaction.
+	testPrivKey, _ := btcec.PrivKeyFromBytes(btcec.S256(), bobsPrivKey)
+	testPubKey := testPrivKey.PubKey()
+	signDesc := &WitnessSignDescriptor{
+		WitnessType: P2WPKH,
+		SignDescriptor: &SignDescriptor{
+			KeyDesc: keychain.KeyDescriptor{
+				PubKey: testPubKey,
+			},
+			SigHashes: txscript.NewTxSigHashes(tx),
+		},
+	}
+	signDescs := []*WitnessSignDescriptor{signDesc}
+
+	cfg := TxRebroadcasterCfg{
+		Tx:                tx,
+		ChangeOutputIndex: 0,
+		Signer:            &emptyMockSigner{},
+		WitnessSignDescs:  signDescs,
+		BumpPercentage:    bumpPercentage,
+		MaxAttempts:       maxAttempts,
+		FetchInputAmount: func(*wire.OutPoint) (btcutil.Amount, error) {
+			return inputAmt, nil
+		},
+		// Broadcast will always return ErrInsufficientFee in order to
+		// keep bumping up the fee and rebroadcasting until the output
+		// dips below the dust limit.
+		Broadcast: func(*wire.MsgTx) error {
+			return ErrInsufficientFee
+		},
+		// The output should not be consumed for this test.
+		DustLimit:           dustLimit,
+		ConsumeChangeOutput: false,
+	}
+
+	rebroadcaster, err := NewTxRebroadcaster(cfg)
+	if err != nil {
+		t.Fatalf("unable to create tx rebroadcaster: %v", err)
+	}
+
+	// Kick off the rebroadcaster.
+	errChan := rebroadcaster.Rebroadcast(nil)
+	select {
+	case err = <-errChan:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for result")
+	}
+
+	// The rebroadcaster should halt indicating that the change output
+	// dipped below the dust limit.
+	if err != ErrRebroadcastDustLimit {
+		t.Fatalf("expected ErrRebroadcastDustLimit, got %v", err)
+	}
+}
+
+// TestRebroadcasterConsumeOutput ensures that the rebroadcaster takes into
+// account what we consider as "dust" on the chain. When bumping up the fee on a
+// transaction with multiple outputs, if the change outputs dips below this
+// limit, then we should just consume the output as a whole.
+func TestRebroadcasterConsumeOutput(t *testing.T) {
+	t.Parallel()
+
+	// We'll start off by making a copy of the transaction to prevent
+	// mutating the state of the global variable.
+	tx := testTx.Copy()
+
+	// Since this test will be consuming an output, we'll add another one
+	// such that the transaction is still valid and can be rebroadcast.
+	// This new output will be seen as the change output.
+	tx.AddTxOut(&wire.TxOut{Value: btcutil.SatoshiPerBitcoin})
+
+	// We'll assume that the input amount is the output's + 1 BTC,
+	// indicating there is a 1 BTC fee on the transaction.
+	var outputAmt btcutil.Amount
+	for _, output := range tx.TxOut {
+		outputAmt += btcutil.Amount(output.Value)
+	}
+	inputAmt := outputAmt + btcutil.SatoshiPerBitcoin
+
+	// We'll also declare a sufficent fee for this transaction as being at
+	// least 2 BTC. By consuming the change output above, we should be able
+	// successfully rebroadcast the transaction.
+	sufficientFee := btcutil.Amount(2 * btcutil.SatoshiPerBitcoin)
+
+	// Recreate the sign descriptor needed in order to re-sign this
+	// transaction.
+	testPrivKey, _ := btcec.PrivKeyFromBytes(btcec.S256(), bobsPrivKey)
+	testPubKey := testPrivKey.PubKey()
+	signDesc := &WitnessSignDescriptor{
+		WitnessType: P2WPKH,
+		SignDescriptor: &SignDescriptor{
+			KeyDesc: keychain.KeyDescriptor{
+				PubKey: testPubKey,
+			},
+			SigHashes: txscript.NewTxSigHashes(tx),
+		},
+	}
+	signDescs := []*WitnessSignDescriptor{signDesc}
+
+	// We'll now set our constraints on the rebroadcaster. Since we're
+	// interested in detecting when a change output dips below the dust
+	// limit after applying the new fee, we'll set the dust limit to be 1
+	// satoshi below the current output's value, so that the check gets
+	// triggered at the first attempt of rebroadcasting. Since the output
+	// should also be consumed, we'll set that as well.
+	const bumpPercentage = 100
+	const maxAttempts = 10
+	dustLimit := outputAmt - 1
+
+	cfg := TxRebroadcasterCfg{
+		Tx:                  tx,
+		ChangeOutputIndex:   1,
+		Signer:              &emptyMockSigner{},
+		WitnessSignDescs:    signDescs,
+		BumpPercentage:      bumpPercentage,
+		MaxAttempts:         maxAttempts,
+		DustLimit:           dustLimit,
+		ConsumeChangeOutput: true,
+		FetchInputAmount: func(*wire.OutPoint) (btcutil.Amount, error) {
+			return inputAmt, nil
+		},
+		// Broadcast will always return ErrInsufficientFee in order to
+		// keep bumping up the fee and rebroadcasting until the output
+		// dips below the dust limit.
+		Broadcast: func(*wire.MsgTx) error {
+			// Calculate the fee for the current version of the
+			// transaction being broadcast and check if it's still
+			// not enough.
+			var outputAmt btcutil.Amount
+			for _, output := range tx.TxOut {
+				outputAmt += btcutil.Amount(output.Value)
+			}
+			fee := inputAmt - outputAmt
+			if fee < sufficientFee {
+				return ErrInsufficientFee
+			}
+			return nil
+		},
+	}
+
+	rebroadcaster, err := NewTxRebroadcaster(cfg)
+	if err != nil {
+		t.Fatalf("unable to create tx rebroadcaster: %v", err)
+	}
+
+	// Kick off the rebroadcaster.
+	errChan := rebroadcaster.Rebroadcast(nil)
+	select {
+	case err = <-errChan:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for result")
+	}
+
+	// The transaction should have been rebroadcast successfully.
+	if err != nil {
+		t.Fatalf("unable to rebroadcast tx: %v", err)
+	}
+
+	// Confirm that the transaction still has its other output left.
+	lastTxBroadcast := rebroadcaster.LastTxBroadcast()
+	if len(lastTxBroadcast.TxOut) != 1 {
+		t.Fatalf("expected transaction to have one output left, got %v",
+			len(lastTxBroadcast.TxOut))
+	}
+
+	// Since the change output was added without a PkScript, we'll check
+	// that to determine whether the correct output was consumed.
+	if lastTxBroadcast.TxOut[0].PkScript == nil {
+		t.Fatal("wrong output consumed")
+	}
+}
+
+// TestRebroadcasterConsumeOnlyOutput ensures that the rebroadcaster takes into
+// account what we consider as "dust" on the chain. When bumping up the fee on a
+// transaction with one output, if the change outputs dips below this limit,
+// then we should just consume the output as a whole. This leads to the
+// transaction being invalid as it no longer has any outputs.
+func TestRebroadcasterConsumeOnlyOutput(t *testing.T) {
+	t.Parallel()
+
+	// We'll start off by making a copy of the transaction to prevent
+	// mutating the state of the global variable.
+	tx := testTx.Copy()
+
+	// We'll assume that the input amount is the output's + 1 BTC,
+	// indicating there is a 1 BTC fee on the transaction.
+	outputAmt := btcutil.Amount(tx.TxOut[0].Value)
+	inputAmt := outputAmt + btcutil.SatoshiPerBitcoin
+
+	// Recreate the sign descriptor needed in order to re-sign this
+	// transaction.
+	testPrivKey, _ := btcec.PrivKeyFromBytes(btcec.S256(), bobsPrivKey)
+	testPubKey := testPrivKey.PubKey()
+	signDesc := &WitnessSignDescriptor{
+		WitnessType: P2WPKH,
+		SignDescriptor: &SignDescriptor{
+			KeyDesc: keychain.KeyDescriptor{
+				PubKey: testPubKey,
+			},
+			SigHashes: txscript.NewTxSigHashes(tx),
+		},
+	}
+	signDescs := []*WitnessSignDescriptor{signDesc}
+
+	// We'll now set our constraints on the rebroadcaster. Since we're
+	// interested in detecting when a change output dips below the dust
+	// limit after applying the new fee, we'll set the dust limit to be 1
+	// satoshi below the current output's value, so that the check gets
+	// triggered at the first attempt of rebroadcasting. Since the output
+	// should also be consumed, we'll set that as well.
+	const bumpPercentage = 100
+	const maxAttempts = 10
+	dustLimit := outputAmt - 1
+
+	cfg := TxRebroadcasterCfg{
+		Tx:                  tx,
+		ChangeOutputIndex:   0,
+		Signer:              &emptyMockSigner{},
+		WitnessSignDescs:    signDescs,
+		BumpPercentage:      bumpPercentage,
+		MaxAttempts:         maxAttempts,
+		DustLimit:           dustLimit,
+		ConsumeChangeOutput: true,
+		FetchInputAmount: func(*wire.OutPoint) (btcutil.Amount, error) {
+			return inputAmt, nil
+		},
+		// Broadcast will always return ErrInsufficientFee in order to
+		// keep bumping up the fee and rebroadcasting until the output
+		// dips below the dust limit.
+		Broadcast: func(*wire.MsgTx) error {
+			return ErrInsufficientFee
+		},
+	}
+
+	rebroadcaster, err := NewTxRebroadcaster(cfg)
+	if err != nil {
+		t.Fatalf("unable to create tx rebroadcaster: %v", err)
+	}
+
+	// Kick off the rebroadcaster.
+	errChan := rebroadcaster.Rebroadcast(nil)
+	select {
+	case err = <-errChan:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for result")
+	}
+
+	// Since the transaction only includes one output which has been
+	// consumed, the transaction is no longer valid, so the rebroadcaster
+	// should halt indicating such an error.
+	if !strings.Contains(err.Error(), "no outputs") {
+		t.Fatalf("expected transaction to have no outputs, got: %v",
+			err)
+	}
+}

--- a/lnwallet/witnessgen.go
+++ b/lnwallet/witnessgen.go
@@ -69,6 +69,9 @@ const (
 	// broadcast a revoked commitment, but then also immediately attempt to
 	// go to the second level to claim the HTLC.
 	HtlcSecondLevelRevoke WitnessType = 9
+
+	// P2WPKH is a witness that allows us to spend a P2WPKH output.
+	P2WPKH WitnessType = 10
 )
 
 // WitnessGenerator represents a function which is able to generate the final
@@ -119,6 +122,9 @@ func (wt WitnessType) GenWitnessFunc(signer Signer,
 
 		case HtlcSecondLevelRevoke:
 			return htlcSpendRevoke(signer, desc, tx)
+
+		case P2WPKH:
+			return spendP2WPKH(signer, desc, tx)
 
 		default:
 			return nil, fmt.Errorf("unknown witness type: %v", wt)


### PR DESCRIPTION
In this PR, we add a basic implementation of a transaction rebroadcaster. This allows us to continually rebroadcast a transaction with an insufficient fee while setting constraints like maximum fee allowed, maximum number of attempts allowed, etc.

Note: When running Neutrino and broadcasting a transaction, it's possible that the first response from one of our peers is an insufficient fee error. Currently, once detecting this, we don't wait for the response of our other peers, so this will need to be handled correctly as it's possible that one of our other peers doesn't deem this transaction as having an insufficient fee and we attempt to bump up the fee.