### PR TITLE
build: update neutrino to latest version

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -279,15 +279,16 @@
   revision = "462a8a75388506b68f76661af8d649f0b88e5301"
 
 [[projects]]
-  digest = "1:6957e94f0689b74dacdfc9a964fba9efc3524439b644b107c65140a597cb2e0d"
+  digest = "1:461543cea211913463b96ed3bf8cbdadf23c5ac8ec205bcbbc79edeba9e93a9a"
   name = "github.com/lightninglabs/neutrino"
   packages = [
     ".",
     "filterdb",
     "headerfs",
+    "headerlist",
   ]
   pruneopts = "UT"
-  revision = "d5054cea8fe43c324a473e8aa7e0f6dd93622125"
+  revision = "b451667d69910cd20995452c56e02441896a3349"
 
 [[projects]]
   digest = "1:58ab6d6525898cbeb86dc29a68f8e9bfe95254b9032134eb9458779574872260"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -44,7 +44,7 @@
 
 [[constraint]]
   name = "github.com/lightninglabs/neutrino"
-  revision = "d5054cea8fe43c324a473e8aa7e0f6dd93622125"
+  revision = "b451667d69910cd20995452c56e02441896a3349"
 
 [[constraint]]
   name = "github.com/lightningnetwork/lightning-onion"

--- a/lnwallet/interface_test.go
+++ b/lnwallet/interface_test.go
@@ -1924,13 +1924,13 @@ func waitForWalletSync(r *rpctest.Harness, w *lnwallet.LightningWallet) error {
 		bestHash, knownHash     *chainhash.Hash
 		bestHeight, knownHeight int32
 	)
-	timeout := time.After(30 * time.Second)
+	timeout := time.After(10 * time.Second)
 	for !synced {
 		// Do a short wait
 		select {
 		case <-timeout:
 			return fmt.Errorf("timeout after 30s")
-		case <-time.Tick(50 * time.Millisecond):
+		case <-time.Tick(100 * time.Millisecond):
 		}
 
 		// Check whether the chain source of the wallet is caught up to


### PR DESCRIPTION
In this PR, we update the neutrino dep to the latest version checked into its master branch. This version fixes a number of bugs, and also adds optimizations to the cfheaders download. Once this PR is merged, we should see a more stable set of integration tests, as the timeout issue in the `lnwallet` re-org test should be fixed