### PR TITLE
rpcserver: incorrect payment error message when user does not have enough funds

### DIFF
--- a/rpcserver.go
+++ b/rpcserver.go
@@ -2186,6 +2186,25 @@ func (r *rpcServer) dispatchPaymentIntent(
 	}, nil
 }
 
+// validateUserBalance checks if the user has sufficient funds to complete
+// the payment request. In the case the user does not have sufficient funds,
+// an error will be returned.
+func validateUserBalance(r *rpcServer, payIntent rpcPaymentIntent) error {
+	payAmt := payIntent.msat.ToSatoshis()
+
+	walletBalance, err := r.WalletBalance(context.Background(), &lnrpc.WalletBalanceRequest{})
+	if err != nil {
+		return err
+	}
+	totalBalance := btcutil.Amount(walletBalance.GetTotalBalance())
+
+	if totalBalance < payAmt {
+		return errors.New("not enough funds")
+	}
+
+	return nil
+}
+
 // sendPayment takes a paymentStream (a source of pre-built routes or payment
 // requests) and continually attempt to dispatch payment requests written to
 // the write end of the stream. Responses will also be streamed back to the


### PR DESCRIPTION
fixes #1680 

This PR addresses an incorrect payment error message as described in #1680.

This should return "not enough funds" as an error message when a user attempts to complete a payment request without sufficient funds in their balance.