### PR TITLE
chainregistry: correctly establish connection to bitcoind

### DIFF
--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -262,7 +262,7 @@ with `bitcoind` as your backend (as with `bitcoind`, you can create an
 `lnd.conf` to save these options, more info on that is described further below):
 
 ```
-lnd --bitcoin.active --bitcoin.testnet --debuglevel=debug --bitcoin.node=bitcoind --bitcoind.rpcuser=REPLACEME --bitcoind.rpcpass=REPLACEME --bitcoind.zmqpubrawblock=tcp://127.0.0.1:28332 --bitcoind.zmqpubrawblock=tcp://127.0.0.1:28333 --externalip=X.X.X.X
+lnd --bitcoin.active --bitcoin.testnet --debuglevel=debug --bitcoin.node=bitcoind --bitcoind.rpcuser=REPLACEME --bitcoind.rpcpass=REPLACEME --bitcoind.zmqpubrawblock=tcp://127.0.0.1:28332 --bitcoind.zmqpubrawtx=tcp://127.0.0.1:28333 --externalip=X.X.X.X
 ```
 
 *NOTE:*

--- a/sample-lnd.conf
+++ b/sample-lnd.conf
@@ -208,8 +208,8 @@ bitcoin.node=btcd
 ; ZMQ socket which sends rawblock and rawtx notifications from bitcoind. By
 ; default, lnd will attempt to automatically obtain this information, so this
 ; likely won't need to be set (other than for a remote bitcoind instance).
-; bitcoind.zmqblockhost=tcp://127.0.0.1:28332
-; bitcoind.zmqtxhost=tcp://127.0.0.1:28333
+; bitcoind.zmqpubrawblock=tcp://127.0.0.1:28332
+; bitcoind.zmqpubrawtx=tcp://127.0.0.1:28333
 
 
 [neutrino]
@@ -286,8 +286,8 @@ litecoin.node=ltcd
 ; ZMQ socket which sends rawblock and rawtx notifications from litecoind. By
 ; default, lnd will attempt to automatically obtain this information, so this
 ; likely won't need to be set (other than for a remote litecoind instance).
-; litecoind.zmqblockhost=tcp://127.0.0.1:28332
-; litecoind.zmqtxhost=tcp://127.0.0.1:28333
+; litecoind.zmqpubrawblock=tcp://127.0.0.1:28332
+; litecoind.zmqpubrawtx=tcp://127.0.0.1:28333
 
 
 [autopilot]


### PR DESCRIPTION
In this commit, we fix a bug recently introduced where we would
construct the parameters required to connect to a bitcoind backend, but
never actually started the connection.