### PR TITLE
exec git fetch before git checkout

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -97,7 +97,7 @@ $(DEP_BIN):
 $(GLIDE_BIN):
 	@$(call print, "Fetching glide.")
 	go get -d $(GLIDE_PKG)
-	cd ${GOPATH}/src/$(GLIDE_PKG) && git checkout $(GLIDE_COMMIT) 
+	cd ${GOPATH}/src/$(GLIDE_PKG) && ( git checkout $(GLIDE_COMMIT) || ( git fetch --all && git checkout $(GLIDE_COMMIT) ) )
 	$(GOINSTALL) $(GLIDE_PKG)
 
 $(GOVERALLS_BIN):
@@ -119,7 +119,7 @@ $(BTCD_DIR):
 
 btcd: $(GLIDE_BIN) $(BTCD_DIR)
 	@$(call print, "Compiling btcd dependencies.")
-	cd $(BTCD_DIR) && git checkout $(BTCD_COMMIT) && glide install
+	cd $(BTCD_DIR) && ( git checkout $(BTCD_COMMIT) || ( git fetch --all && git checkout $(BTCD_COMMIT) ) ) && glide install
 	@$(call print, "Installing btcd and btcctl.")
 	$(GOINSTALL) $(BTCD_PKG)
 	$(GOINSTALL) $(BTCD_PKG)/cmd/btcctl


### PR DESCRIPTION
This error occurred when I tried to execute `make unit`.
I think updating revision is not assumed in this case. (it is related to
 https://github.com/lightningnetwork/lnd/pull/1714)

```
cd <path>/src/github.com/btcsuite/btcd && git checkout f899737d7f2764dc13e4d01ff00108ec58f766a9                           
fatal: reference is not a tree: f899737d7f2764dc13e4d01ff00108ec58f766a9 
```

To prevent this error, I added `git fetch --all` before `git checkout`.

Fixes #1750. 