### PR TITLE
rpcserver: enforce fee floor for fee rates input by the user

### DIFF
--- a/rpcserver.go
+++ b/rpcserver.go
@@ -434,8 +434,14 @@ func determineFeePerKw(feeEstimator lnwallet.FeeEstimator, targetConf int32,
 	// If a manual sat/byte fee rate is set, then we'll use that directly.
 	// We'll need to convert it to sat/kw as this is what we use internally.
 	case feePerByte != 0:
-		feePerKB := lnwallet.SatPerKVByte(feePerByte * 1000)
-		return feePerKB.FeePerKWeight(), nil
+		feePerKW := lnwallet.SatPerKVByte(feePerByte * 1000).FeePerKWeight()
+		if feePerKW < lnwallet.FeePerKwFloor {
+			rpcsLog.Infof("Manual fee rate input of %d sat/kw is "+
+				"too low, using %d sat/kw instead", feePerKW,
+				lnwallet.FeePerKwFloor)
+			feePerKW = lnwallet.FeePerKwFloor
+		}
+		return feePerKW, nil
 
 	// Otherwise, we'll attempt a relaxed confirmation target for the
 	// transaction


### PR DESCRIPTION
In a previous commit, we modified our fee rates to be sat/kw internally
as it was possible that the estimated fee rate was not enough to
properly broadcast the transaction. To remedy this, we decided to add a
fee floor, but this would only be enforced when querying the fee
estimator. In this commit, we attempt to do the same thing, but for fee
rates input manually by the user.