### PR TITLE
walletunlocker: avoid returning error if macaroon files don't exist

### DIFF
--- a/walletunlocker/service.go
+++ b/walletunlocker/service.go
@@ -334,7 +334,8 @@ func (u *UnlockerService) ChangePassword(ctx context.Context,
 	// this after unlocking the wallet to ensure macaroon files don't get
 	// deleted with incorrect password attempts.
 	for _, file := range u.macaroonFiles {
-		if err := os.Remove(file); err != nil {
+		err := os.Remove(file)
+		if err != nil && !os.IsNotExist(err) {
 			return nil, err
 		}
 	}


### PR DESCRIPTION
In this commit, we fix a bug where it's possible that changing the
wallet's password fails due to not being able to remove non-existent
macaroon files. Since it's possible to run lnd without creating them,
changing the wallet's password would always result in a failure.