### PR TITLE
channeldb: avoid creating empty buckets

### DIFF
--- a/channeldb/graph.go
+++ b/channeldb/graph.go
@@ -1067,25 +1067,30 @@ func (c *ChannelGraph) DeleteChannelEdge(chanPoint *wire.OutPoint) error {
 	return c.db.Update(func(tx *bbolt.Tx) error {
 		// First grab the edges bucket which houses the information
 		// we'd like to delete
-		edges, err := tx.CreateBucketIfNotExists(edgeBucket)
-		if err != nil {
-			return err
+		edges := tx.Bucket(edgeBucket)
+		if edges == nil {
+			return ErrEdgeNotFound
 		}
-		// Next grab the two edge indexes which will also need to be updated.
-		edgeIndex, err := edges.CreateBucketIfNotExists(edgeIndexBucket)
-		if err != nil {
-			return err
+
+		// Next grab the two edge indexes which will also need to be
+		// updated.
+		edgeIndex := edges.Bucket(edgeIndexBucket)
+		if edgeIndex == nil {
+			return ErrEdgeNotFound
 		}
-		chanIndex, err := edges.CreateBucketIfNotExists(channelPointBucket)
-		if err != nil {
-			return err
+
+		chanIndex := edges.Bucket(channelPointBucket)
+		if chanIndex == nil {
+			return ErrEdgeNotFound
 		}
 		nodes, err := tx.CreateBucketIfNotExists(nodeBucket)
 		if err != nil {
 			return err
 		}
 
-		return delChannelByEdge(edges, edgeIndex, chanIndex, nodes, chanPoint)
+		return delChannelByEdge(
+			edges, edgeIndex, chanIndex, nodes, chanPoint,
+		)
 	})
 }
 

--- a/channeldb/graph.go
+++ b/channeldb/graph.go
@@ -1638,13 +1638,14 @@ func delChannelByEdge(edges *bbolt.Bucket, edgeIndex *bbolt.Bucket,
 // the nodes on either side of the channel.
 func (c *ChannelGraph) UpdateEdgePolicy(edge *ChannelEdgePolicy) error {
 	return c.db.Update(func(tx *bbolt.Tx) error {
-		edges, err := tx.CreateBucketIfNotExists(edgeBucket)
-		if err != nil {
-			return err
+		edges := tx.Bucket(edgeBucket)
+		if edge == nil {
+			return ErrEdgeNotFound
 		}
-		edgeIndex, err := edges.CreateBucketIfNotExists(edgeIndexBucket)
-		if err != nil {
-			return err
+
+		edgeIndex := edges.Bucket(edgeIndexBucket)
+		if edgeIndex == nil {
+			return ErrEdgeNotFound
 		}
 		nodes, err := tx.CreateBucketIfNotExists(nodeBucket)
 		if err != nil {

--- a/channeldb/graph.go
+++ b/channeldb/graph.go
@@ -652,13 +652,14 @@ func (c *ChannelGraph) UpdateChannelEdge(edge *ChannelEdgeInfo) error {
 	binary.BigEndian.PutUint64(chanKey[:], edge.ChannelID)
 
 	return c.db.Update(func(tx *bbolt.Tx) error {
-		edges, err := tx.CreateBucketIfNotExists(edgeBucket)
-		if err != nil {
-			return err
+		edges := tx.Bucket(edgeBucket)
+		if edge == nil {
+			return ErrEdgeNotFound
 		}
-		edgeIndex, err := edges.CreateBucketIfNotExists(edgeIndexBucket)
-		if err != nil {
-			return err
+
+		edgeIndex := edges.Bucket(edgeIndexBucket)
+		if edgeIndex == nil {
+			return ErrEdgeNotFound
 		}
 
 		if edgeInfo := edgeIndex.Get(chanKey[:]); edgeInfo == nil {

--- a/channeldb/graph.go
+++ b/channeldb/graph.go
@@ -1083,9 +1083,10 @@ func (c *ChannelGraph) DeleteChannelEdge(chanPoint *wire.OutPoint) error {
 		if chanIndex == nil {
 			return ErrEdgeNotFound
 		}
-		nodes, err := tx.CreateBucketIfNotExists(nodeBucket)
-		if err != nil {
-			return err
+
+		nodes := tx.Bucket(nodeBucket)
+		if nodes == nil {
+			return ErrGraphNodeNotFound
 		}
 
 		return delChannelByEdge(

--- a/channeldb/graph.go
+++ b/channeldb/graph.go
@@ -710,9 +710,9 @@ func (c *ChannelGraph) PruneGraph(spentOutputs []*wire.OutPoint,
 		if err != nil {
 			return err
 		}
-		nodes, err := tx.CreateBucketIfNotExists(nodeBucket)
-		if err != nil {
-			return err
+		nodes := tx.Bucket(nodeBucket)
+		if nodes == nil {
+			return ErrSourceNodeNotSet
 		}
 
 		// For each of the outpoints that have been spent within the

--- a/channeldb/graph.go
+++ b/channeldb/graph.go
@@ -1528,11 +1528,10 @@ func delEdgeUpdateIndexEntry(edgesBucket *bbolt.Bucket, chanID uint64,
 
 	// First, we'll fetch the edge update index bucket which currently
 	// stores an entry for the channel we're about to delete.
-	updateIndex, err := edgesBucket.CreateBucketIfNotExists(
-		edgeUpdateIndexBucket,
-	)
-	if err != nil {
-		return err
+	updateIndex := edgesBucket.Bucket(edgeUpdateIndexBucket)
+	if updateIndex == nil {
+		// No edges in bucket, return early.
+		return nil
 	}
 
 	// Now that we have the bucket, we'll attempt to construct a template

--- a/channeldb/graph.go
+++ b/channeldb/graph.go
@@ -795,9 +795,9 @@ func (c *ChannelGraph) PruneGraph(spentOutputs []*wire.OutPoint,
 // node gains more channels, it will be re-added back to the graph.
 func (c *ChannelGraph) PruneGraphNodes() error {
 	return c.db.Update(func(tx *bbolt.Tx) error {
-		nodes, err := tx.CreateBucketIfNotExists(nodeBucket)
-		if err != nil {
-			return err
+		nodes := tx.Bucket(nodeBucket)
+		if nodes == nil {
+			return ErrGraphNodesNotFound
 		}
 		edges := tx.Bucket(edgeBucket)
 		if edges == nil {

--- a/routing/router.go
+++ b/routing/router.go
@@ -445,7 +445,8 @@ func (r *ChannelRouter) Start() error {
 	// Finally, before we proceed, we'll prune any unconnected nodes from
 	// the graph in order to ensure we maintain a tight graph of "useful"
 	// nodes.
-	if err := r.cfg.Graph.PruneGraphNodes(); err != nil {
+	err = r.cfg.Graph.PruneGraphNodes()
+	if err != nil && err != channeldb.ErrGraphNodesNotFound {
 		return err
 	}
 

--- a/routing/router_test.go
+++ b/routing/router_test.go
@@ -170,10 +170,10 @@ func TestFindRoutesFeeSorting(t *testing.T) {
 
 	const startingBlockHeight = 101
 	ctx, cleanUp, err := createTestCtxFromFile(startingBlockHeight, basicGraphFilePath)
-	defer cleanUp()
 	if err != nil {
 		t.Fatalf("unable to create router: %v", err)
 	}
+	defer cleanUp()
 
 	// In this test we'd like to ensure proper integration of the various
 	// functions that are involved in path finding, and also route
@@ -225,10 +225,10 @@ func TestFindRoutesWithFeeLimit(t *testing.T) {
 	ctx, cleanUp, err := createTestCtxFromFile(
 		startingBlockHeight, basicGraphFilePath,
 	)
-	defer cleanUp()
 	if err != nil {
 		t.Fatalf("unable to create router: %v", err)
 	}
+	defer cleanUp()
 
 	// This test will attempt to find routes from roasbeef to sophon for 100
 	// satoshis with a fee limit of 10 satoshis. There are two routes from
@@ -280,10 +280,10 @@ func TestSendPaymentRouteFailureFallback(t *testing.T) {
 
 	const startingBlockHeight = 101
 	ctx, cleanUp, err := createTestCtxFromFile(startingBlockHeight, basicGraphFilePath)
-	defer cleanUp()
 	if err != nil {
 		t.Fatalf("unable to create router: %v", err)
 	}
+	defer cleanUp()
 
 	// Craft a LightningPayment struct that'll send a payment from roasbeef
 	// to luo ji for 1000 satoshis, with a maximum of 1000 satoshis in fees.
@@ -516,10 +516,10 @@ func TestSendPaymentErrorRepeatedFeeInsufficient(t *testing.T) {
 
 	const startingBlockHeight = 101
 	ctx, cleanUp, err := createTestCtxFromFile(startingBlockHeight, basicGraphFilePath)
-	defer cleanUp()
 	if err != nil {
 		t.Fatalf("unable to create router: %v", err)
 	}
+	defer cleanUp()
 
 	// Craft a LightningPayment struct that'll send a payment from roasbeef
 	// to luo ji for 100 satoshis.
@@ -620,10 +620,10 @@ func TestSendPaymentErrorNonFinalTimeLockErrors(t *testing.T) {
 
 	const startingBlockHeight = 101
 	ctx, cleanUp, err := createTestCtxFromFile(startingBlockHeight, basicGraphFilePath)
-	defer cleanUp()
 	if err != nil {
 		t.Fatalf("unable to create router: %v", err)
 	}
+	defer cleanUp()
 
 	// Craft a LightningPayment struct that'll send a payment from roasbeef
 	// to sophon for 1k satoshis.
@@ -755,10 +755,10 @@ func TestSendPaymentErrorPathPruning(t *testing.T) {
 
 	const startingBlockHeight = 101
 	ctx, cleanUp, err := createTestCtxFromFile(startingBlockHeight, basicGraphFilePath)
-	defer cleanUp()
 	if err != nil {
 		t.Fatalf("unable to create router: %v", err)
 	}
+	defer cleanUp()
 
 	// Craft a LightningPayment struct that'll send a payment from roasbeef
 	// to luo ji for 1000 satoshis, with a maximum of 1000 satoshis in fees.
@@ -997,10 +997,10 @@ func TestIgnoreNodeAnnouncement(t *testing.T) {
 	const startingBlockHeight = 101
 	ctx, cleanUp, err := createTestCtxFromFile(startingBlockHeight,
 		basicGraphFilePath)
-	defer cleanUp()
 	if err != nil {
 		t.Fatalf("unable to create router: %v", err)
 	}
+	defer cleanUp()
 
 	pub := priv1.PubKey()
 	node := &channeldb.LightningNode{
@@ -1030,10 +1030,10 @@ func TestAddEdgeUnknownVertexes(t *testing.T) {
 	const startingBlockHeight = 101
 	ctx, cleanUp, err := createTestCtxFromFile(startingBlockHeight,
 		basicGraphFilePath)
-	defer cleanUp()
 	if err != nil {
 		t.Fatalf("unable to create router: %v", err)
 	}
+	defer cleanUp()
 
 	var pub1 [33]byte
 	copy(pub1[:], priv1.PubKey().SerializeCompressed())
@@ -1299,10 +1299,10 @@ func TestWakeUpOnStaleBranch(t *testing.T) {
 
 	const startingBlockHeight = 101
 	ctx, cleanUp, err := createTestCtxSingleNode(startingBlockHeight)
-	defer cleanUp()
 	if err != nil {
 		t.Fatalf("unable to create router: %v", err)
 	}
+	defer cleanUp()
 
 	const chanValue = 10000
 
@@ -1502,10 +1502,10 @@ func TestDisconnectedBlocks(t *testing.T) {
 
 	const startingBlockHeight = 101
 	ctx, cleanUp, err := createTestCtxSingleNode(startingBlockHeight)
-	defer cleanUp()
 	if err != nil {
 		t.Fatalf("unable to create router: %v", err)
 	}
+	defer cleanUp()
 
 	const chanValue = 10000
 
@@ -1692,10 +1692,10 @@ func TestRouterChansClosedOfflinePruneGraph(t *testing.T) {
 
 	const startingBlockHeight = 101
 	ctx, cleanUp, err := createTestCtxSingleNode(startingBlockHeight)
-	defer cleanUp()
 	if err != nil {
 		t.Fatalf("unable to create router: %v", err)
 	}
+	defer cleanUp()
 
 	const chanValue = 10000
 
@@ -1845,10 +1845,10 @@ func TestFindPathFeeWeighting(t *testing.T) {
 
 	const startingBlockHeight = 101
 	ctx, cleanUp, err := createTestCtxFromFile(startingBlockHeight, basicGraphFilePath)
-	defer cleanUp()
 	if err != nil {
 		t.Fatalf("unable to create router: %v", err)
 	}
+	defer cleanUp()
 
 	var preImage [32]byte
 	copy(preImage[:], bytes.Repeat([]byte{9}, 32))
@@ -1903,10 +1903,10 @@ func TestIsStaleNode(t *testing.T) {
 
 	const startingBlockHeight = 101
 	ctx, cleanUp, err := createTestCtxSingleNode(startingBlockHeight)
-	defer cleanUp()
 	if err != nil {
 		t.Fatalf("unable to create router: %v", err)
 	}
+	defer cleanUp()
 
 	// Before we can insert a node in to the database, we need to create a
 	// channel that it's linked to.
@@ -1985,10 +1985,10 @@ func TestIsKnownEdge(t *testing.T) {
 
 	const startingBlockHeight = 101
 	ctx, cleanUp, err := createTestCtxSingleNode(startingBlockHeight)
-	defer cleanUp()
 	if err != nil {
 		t.Fatalf("unable to create router: %v", err)
 	}
+	defer cleanUp()
 
 	// First, we'll create a new channel edge (just the info) and insert it
 	// into the database.
@@ -2038,10 +2038,10 @@ func TestIsStaleEdgePolicy(t *testing.T) {
 	const startingBlockHeight = 101
 	ctx, cleanUp, err := createTestCtxFromFile(startingBlockHeight,
 		basicGraphFilePath)
-	defer cleanUp()
 	if err != nil {
 		t.Fatalf("unable to create router: %v", err)
 	}
+	defer cleanUp()
 
 	// First, we'll create a new channel edge (just the info) and insert it
 	// into the database.


### PR DESCRIPTION
This PR removes several cases of the call to `CreateBucketIfNotExists` within the channel database, from calls where we were not adding anything to the buckets, but rather querying or deleting. This ensures we are not creating empty buckets unnecessarily, and makes it easier to keep track of where the different buckets are initially created.

Note that this change shouldn't alter behaviour of the DB, and aims to return the same errors as would have been returned even when the buckets were created.

### TODO:

- [x] make sure buckets are properly created here: https://github.com/lightningnetwork/lnd/blob/master/channeldb/db.go#L223