### PR TITLE
[htlcswitch]: Set AddRef on failed packets

### DIFF
--- a/htlcswitch/mock.go
+++ b/htlcswitch/mock.go
@@ -500,11 +500,12 @@ func (s *mockServer) readHandler(message lnwire.Message) error {
 		return fmt.Errorf("unknown message type: %T", msg)
 	}
 
-	// Dispatch the commitment update message to the proper
-	// channel link dedicated to this channel.
+	// Dispatch the commitment update message to the proper channel link
+	// dedicated to this channel. If the link is not found, we will discard
+	// the message.
 	link, err := s.htlcSwitch.GetLink(targetChan)
 	if err != nil {
-		return err
+		return nil
 	}
 
 	// Create goroutine for this, in order to be able to properly stop

--- a/htlcswitch/switch.go
+++ b/htlcswitch/switch.go
@@ -1174,6 +1174,7 @@ func (s *Switch) failAddPacket(packet *htlcPacket,
 	log.Error(failErr)
 
 	failPkt := &htlcPacket{
+		sourceRef:      packet.sourceRef,
 		incomingChanID: packet.incomingChanID,
 		incomingHTLCID: packet.incomingHTLCID,
 		circuit:        packet.circuit,

--- a/htlcswitch/test_utils.go
+++ b/htlcswitch/test_utils.go
@@ -877,7 +877,7 @@ func newThreeHopNetwork(t testing.TB, aliceChannel, firstBobChannel,
 
 	const (
 		batchTimeout        = 50 * time.Millisecond
-		fwdPkgTimeout       = 5 * time.Second
+		fwdPkgTimeout       = 15 * time.Second
 		minFeeUpdateTimeout = 30 * time.Minute
 		maxFeeUpdateTimeout = 40 * time.Minute
 	)


### PR DESCRIPTION
This PR fixes a long-standing, albeit benign, issue within the HTLC switch. The channels and switch maintain persistent references, essentially log pointers, to any htlcs that may need to be reforwarded internally after the switch is restarted or a peer reconnects. In this PR, we fix a instance where one of these references was not set for any packets failed by the switch. The end result is that we would continue to retransmit them internally with each restart/connection and never cleanup these references.

The switch fails all packets using a single method `failAddPacket` in multiple places. To test that this reference is being set properly, I chose to extend `TestChannelLinkMultiHopUnknownNextHop` which is one place where this method is used.

In doing so, I noticed that this test was also broken and has now been fixed. Before, the sent payments would never clear Alice's node because we were using Dave's pubkey (which isn't even in the test lol). This would result in `handleLocalDispatch` returning an error, though the test would succeed because we were expecting the same error from the remote node.

With the tests fixed, we then inspect Bob's forwarding packages to ensure that the `AckFilter` containing the add Packet has been fully acked. The case here we are specifically testing is when a packet is failed by Bob's switch, and ensuring that the ack is persisted in the forwarding package of the incoming link.

The first commit fixes `TestChannelLinkMultiHopUnknownNextHop` and adds the assertions that test if the `AckFilter` has been fully acked. Running the test on this commit will cause the test to fail. The second commit properly sets the AddRef on packets failed by the switch, which causes the test to pass.