### PR TITLE
[htlcswitch]: Relax Circuit Deletion

### DIFF
--- a/htlcswitch/circuit_map.go
+++ b/htlcswitch/circuit_map.go
@@ -225,8 +225,10 @@ func (cm *circuitMap) initBuckets() error {
 
 // restoreMemState loads the contents of the half circuit and full circuit
 // buckets from disk and reconstructs the in-memory representation of the
-// circuit map.  Afterwards, the state of the hash index is reconstructed using
-// the recovered set of full circuits.
+// circuit map. Afterwards, the state of the hash index is reconstructed using
+// the recovered set of full circuits. This method will also remove any stray
+// keystones, which are those that appear fully-opened, but have no pending
+// circuit related to the intended incoming link.
 func (cm *circuitMap) restoreMemState() error {
 	log.Infof("Restoring in-memory circuit state from disk")
 
@@ -235,7 +237,7 @@ func (cm *circuitMap) restoreMemState() error {
 		pending = make(map[CircuitKey]*PaymentCircuit)
 	)
 
-	if err := cm.cfg.DB.View(func(tx *bolt.Tx) error {
+	if err := cm.cfg.DB.Update(func(tx *bolt.Tx) error {
 		// Restore any of the circuits persisted in the circuit bucket
 		// back into memory.
 		circuitBkt := tx.Bucket(circuitAddKey)
@@ -264,6 +266,7 @@ func (cm *circuitMap) restoreMemState() error {
 			return ErrCorruptedCircuitMap
 		}
 
+		var strayKeystones []Keystone
 		if err := keystoneBkt.ForEach(func(k, v []byte) error {
 			var (
 				inKey  CircuitKey
@@ -280,13 +283,43 @@ func (cm *circuitMap) restoreMemState() error {
 
 			// Retrieve the pending circuit, set its keystone, then
 			// add it to the opened map.
-			circuit := pending[inKey]
-			circuit.Outgoing = outKey
-			opened[*outKey] = circuit
+			circuit, ok := pending[inKey]
+			if ok {
+				circuit.Outgoing = outKey
+				opened[*outKey] = circuit
+			} else {
+				strayKeystones = append(strayKeystones, Keystone{
+					InKey:  inKey,
+					OutKey: *outKey,
+				})
+			}
 
 			return nil
 		}); err != nil {
 			return err
+		}
+
+		// If any stray keystones were found, we'll proceed to prune
+		// them from the circuit map's persistent storage. This may
+		// manifest on older nodes that had updated channels before
+		// their short channel id was set properly. We believe this
+		// issue has been fixed, though this will allow older nodes to
+		// recover without additional intervention.
+		for _, strayKeystone := range strayKeystones {
+			// As a precaution, we will only cleanup keystones
+			// related to locally-initiated payments. If a
+			// documented case of stray keystones emerges for
+			// forwarded payments, this check should be removed, but
+			// with extreme caution.
+			if strayKeystone.OutKey.ChanID != sourceHop {
+				continue
+			}
+
+			log.Infof("Removing stray keystone: %v", strayKeystone)
+			err := keystoneBkt.Delete(strayKeystone.OutKey.Bytes())
+			if err != nil {
+				return err
+			}
 		}
 
 		return nil

--- a/htlcswitch/circuit_map.go
+++ b/htlcswitch/circuit_map.go
@@ -770,10 +770,12 @@ func (cm *circuitMap) CloseCircuit(outKey CircuitKey) (*PaymentCircuit, error) {
 	return circuit, nil
 }
 
-// DeleteCircuits destroys the target circuit by removing it from the circuit map,
-// additionally removing the circuit's keystone if the HTLC was forwarded
-// through an outgoing link. The circuit should be identified by its incoming
-// circuit key.
+// DeleteCircuits destroys the target circuits by removing them from the circuit
+// map, additionally removing the circuits' keystones if any HTLCs were
+// forwarded through an outgoing link. The circuits should be identified by its
+// incoming circuit key. If a given circuit is not found in the circuit map, it
+// will be ignored from the query. This would typically indicate that the
+// circuit was already cleaned up at a different point in time.
 func (cm *circuitMap) DeleteCircuits(inKeys ...CircuitKey) error {
 
 	log.Tracef("Deleting resolved circuits: %v", newLogClosure(func() string {
@@ -786,22 +788,15 @@ func (cm *circuitMap) DeleteCircuits(inKeys ...CircuitKey) error {
 	)
 
 	cm.mtx.Lock()
-	// First check that all provided keys are still known to the circuit
-	// map.
+	// Remove any references to the circuits from memory, keeping track of
+	// which circuits were removed, and which ones had been marked closed.
+	// This can be used to restore these entries later if the persistent
+	// removal fails.
 	for _, inKey := range inKeys {
-		if _, ok := cm.pending[inKey]; !ok {
-			cm.mtx.Unlock()
-			return ErrUnknownCircuit
+		circuit, ok := cm.pending[inKey]
+		if !ok {
+			continue
 		}
-	}
-
-	// If no offenders were found, remove any references to the circuit from
-	// memory, keeping track of which circuits were removed, and which ones
-	// had been marked closed. This can be used to restore these entries
-	// later if the persistent removal fails.
-	for _, inKey := range inKeys {
-		circuit := cm.pending[inKey]
-
 		delete(cm.pending, inKey)
 
 		if _, ok := cm.closed[inKey]; ok {

--- a/htlcswitch/circuit_map.go
+++ b/htlcswitch/circuit_map.go
@@ -495,8 +495,13 @@ func (cm *circuitMap) LookupByPaymentHash(hash [32]byte) []*PaymentCircuit {
 func (cm *circuitMap) CommitCircuits(circuits ...*PaymentCircuit) (
 	*CircuitFwdActions, error) {
 
+	inKeys := make([]CircuitKey, 0, len(circuits))
+	for _, circuit := range circuits {
+		inKeys = append(inKeys, circuit.Incoming)
+	}
+
 	log.Tracef("Committing fresh circuits: %v", newLogClosure(func() string {
-		return spew.Sdump(circuits)
+		return spew.Sdump(inKeys)
 	}))
 
 	actions := &CircuitFwdActions{}


### PR DESCRIPTION
This PR relaxes the very strict behavior of `DeleteCircuits` originally implemented w/in the circuit map. In light of 1) the split mailbox issue prior to #1551, and 2) upcoming changes to cleanup stray references/circuits w/in the switch #1698,  this will need to be in place to properly clean up stray references as the batches may not correspond 1:1 to a batch of HTLCs settled on the commitment transaction that locked them in. See commit messages for more details