### PR TITLE
Unify gossiper and router announcement handling

### DIFF
--- a/discovery/gossiper.go
+++ b/discovery/gossiper.go
@@ -1139,11 +1139,14 @@ func (d *AuthenticatedGossiper) networkHandler() {
 			d.Lock()
 			numPremature := len(d.prematureAnnouncements[uint32(newBlock.Height)])
 			d.Unlock()
-			if numPremature != 0 {
-				log.Infof("Re-processing %v premature "+
-					"announcements for height %v",
-					numPremature, blockHeight)
+
+			// Return early if no announcement to process.
+			if numPremature == 0 {
+				continue
 			}
+
+			log.Infof("Re-processing %v premature announcements "+
+				"for height %v", numPremature, blockHeight)
 
 			d.Lock()
 			for _, ann := range d.prematureAnnouncements[uint32(newBlock.Height)] {

--- a/discovery/gossiper.go
+++ b/discovery/gossiper.go
@@ -31,6 +31,10 @@ var (
 	// AnnounceSignatures messages, by persisting them until a send
 	// operation has succeeded.
 	messageStoreKey = []byte("message-store")
+
+	// ErrGossiperShuttingDown is an error that is returned if the gossiper
+	// is in the process of being shut down.
+	ErrGossiperShuttingDown = errors.New("gossiper is shutting down")
 )
 
 // networkMsg couples a routing related wire message with the peer that
@@ -476,7 +480,7 @@ func (d *AuthenticatedGossiper) ProcessRemoteAnnouncement(msg lnwire.Message,
 	select {
 	case d.networkMsgs <- nMsg:
 	case <-d.quit:
-		nMsg.err <- errors.New("gossiper has shut down")
+		nMsg.err <- ErrGossiperShuttingDown
 	}
 
 	return nMsg.err
@@ -502,7 +506,7 @@ func (d *AuthenticatedGossiper) ProcessLocalAnnouncement(msg lnwire.Message,
 	select {
 	case d.networkMsgs <- nMsg:
 	case <-d.quit:
-		nMsg.err <- errors.New("gossiper has shut down")
+		nMsg.err <- ErrGossiperShuttingDown
 	}
 
 	return nMsg.err

--- a/discovery/gossiper.go
+++ b/discovery/gossiper.go
@@ -1092,6 +1092,7 @@ func (d *AuthenticatedGossiper) networkHandler() {
 							"barrier shutdown: %v",
 							err)
 					}
+					announcement.err <- err
 					return
 				}
 

--- a/discovery/gossiper.go
+++ b/discovery/gossiper.go
@@ -1653,12 +1653,16 @@ func (d *AuthenticatedGossiper) processNetworkAnnouncement(nMsg *networkMsg) []n
 		// We'll ignore any channel announcements that target any chain
 		// other than the set of chains we know of.
 		if !bytes.Equal(msg.ChainHash[:], d.cfg.ChainHash[:]) {
-			log.Errorf("Ignoring ChannelAnnouncement from "+
+			err := fmt.Errorf("Ignoring ChannelAnnouncement from "+
 				"chain=%v, gossiper on chain=%v", msg.ChainHash,
 				d.cfg.ChainHash)
+			log.Errorf(err.Error())
+
 			d.rejectMtx.Lock()
 			d.recentRejects[msg.ShortChannelID.ToUint64()] = struct{}{}
 			d.rejectMtx.Unlock()
+
+			nMsg.err <- err
 			return nil
 		}
 
@@ -1863,12 +1867,16 @@ func (d *AuthenticatedGossiper) processNetworkAnnouncement(nMsg *networkMsg) []n
 		// We'll ignore any channel announcements that target any chain
 		// other than the set of chains we know of.
 		if !bytes.Equal(msg.ChainHash[:], d.cfg.ChainHash[:]) {
-			log.Errorf("Ignoring ChannelUpdate from "+
+			err := fmt.Errorf("Ignoring ChannelUpdate from "+
 				"chain=%v, gossiper on chain=%v", msg.ChainHash,
 				d.cfg.ChainHash)
+			log.Errorf(err.Error())
+
 			d.rejectMtx.Lock()
 			d.recentRejects[msg.ShortChannelID.ToUint64()] = struct{}{}
 			d.rejectMtx.Unlock()
+
+			nMsg.err <- err
 			return nil
 		}
 

--- a/discovery/gossiper_test.go
+++ b/discovery/gossiper_test.go
@@ -2005,10 +2005,8 @@ func TestReceiveRemoteChannelUpdateFirst(t *testing.T) {
 	// Recreate the case where the remote node is sending us its ChannelUpdate
 	// before we have been able to process our own ChannelAnnouncement and
 	// ChannelUpdate.
-	err = <-ctx.gossiper.ProcessRemoteAnnouncement(batch.chanUpdAnn2, remotePeer)
-	if err != nil {
-		t.Fatalf("unable to process :%v", err)
-	}
+	errRemoteAnn := ctx.gossiper.ProcessRemoteAnnouncement(batch.chanUpdAnn2, remotePeer)
+
 	select {
 	case <-ctx.broadcastedMessage:
 		t.Fatal("channel update announcement was broadcast")
@@ -2069,6 +2067,15 @@ func TestReceiveRemoteChannelUpdateFirst(t *testing.T) {
 
 	// At this point the remote ChannelUpdate we received earlier should
 	// be reprocessed, as we now have the necessary edge entry in the graph.
+	select {
+	case err := <-errRemoteAnn:
+		if err != nil {
+			t.Fatalf("error re-processing remote update: %v", err)
+		}
+	case <-time.After(2 * trickleDelay):
+		t.Fatalf("remote update was not processed")
+	}
+
 	// Check that the ChannelEdgePolicy was added to the graph.
 	chanInfo, e1, e2, err = ctx.router.GetChannelByID(batch.chanUpdAnn1.ShortChannelID)
 	if err != nil {

--- a/routing/errors.go
+++ b/routing/errors.go
@@ -39,6 +39,11 @@ const (
 	// announcement was given for node not found in any channel.
 	ErrIgnored
 
+	// ErrRejected is returned if the update is for a channel ID that was
+	// previously added to the reject cache because of an invalid update
+	// was attempted to be processed.
+	ErrRejected
+
 	// ErrPaymentAttemptTimeout is an error that indicates that a payment
 	// attempt timed out before we were able to successfully route an HTLC.
 	ErrPaymentAttemptTimeout

--- a/routing/errors.go
+++ b/routing/errors.go
@@ -31,7 +31,7 @@ const (
 	ErrTargetNotInNetwork
 
 	// ErrOutdated is returned when the routing update already have
-	// been applied.
+	// been applied, or a newer update is already known.
 	ErrOutdated
 
 	// ErrIgnored is returned when the update have been ignored because

--- a/routing/router.go
+++ b/routing/router.go
@@ -946,7 +946,7 @@ func (r *ChannelRouter) processUpdate(msg interface{}) error {
 		r.rejectMtx.RLock()
 		if _, ok := r.rejectCache[msg.ChannelID]; ok {
 			r.rejectMtx.RUnlock()
-			return newErrf(ErrIgnored, "recently rejected "+
+			return newErrf(ErrRejected, "recently rejected "+
 				"chan_id=%v", msg.ChannelID)
 		}
 		r.rejectMtx.RUnlock()
@@ -1055,7 +1055,7 @@ func (r *ChannelRouter) processUpdate(msg interface{}) error {
 		r.rejectMtx.RLock()
 		if _, ok := r.rejectCache[msg.ChannelID]; ok {
 			r.rejectMtx.RUnlock()
-			return newErrf(ErrIgnored, "recently rejected "+
+			return newErrf(ErrRejected, "recently rejected "+
 				"chan_id=%v", msg.ChannelID)
 		}
 		r.rejectMtx.RUnlock()

--- a/server.go
+++ b/server.go
@@ -738,11 +738,10 @@ func newServer(listenAddrs []net.Addr, chanDB *channeldb.DB, cc *chainControl,
 		CurrentNodeAnnouncement: func() (lnwire.NodeAnnouncement, error) {
 			return s.genNodeAnnouncement(true)
 		},
-		SendAnnouncement: func(msg lnwire.Message) error {
-			errChan := s.authGossiper.ProcessLocalAnnouncement(
+		SendAnnouncement: func(msg lnwire.Message) chan error {
+			return s.authGossiper.ProcessLocalAnnouncement(
 				msg, privKey.PubKey(),
 			)
-			return <-errChan
 		},
 		NotifyWhenOnline: s.NotifyWhenOnline,
 		TempChanIDSeed:   chanIDSeed,


### PR DESCRIPTION
This PR attempts to fix a few edge cases within the gossiper, where we wouldn't be consistent in how we returned errors when processing an announcement.

After this change, the gossiper and the router should satisfy the following expectations:

1. When a `ErrIgnored` or `ErrOutdated` is returned from the `router`, it means that the information provided by the ignored announcement (or newer information) is already present in the graph. This means that the caller can safely continue. Previously this was not always the case, as we might have decided to defer adding the information to the graph, or we returned one of the two errors in cases where the information was not already present.

2. We now **always** eventually return a result on the error channel for a processed announcement. Previously there were cases where we didn't do that. The `SendAnnouncement` method within the `fundingmanager` has been altered to return the actual error channel to make it explicit that we are waiting for the result of the sent announcement.