### PR TITLE
config: add MaxRemoteDelay chainConfig option

### DIFF
--- a/config.go
+++ b/config.go
@@ -108,6 +108,7 @@ type chainConfig struct {
 
 	DefaultNumChanConfs int                 `long:"defaultchanconfs" description:"The default number of confirmations a channel must have before it's considered open. If this is not set, we will scale the value according to the channel size."`
 	DefaultRemoteDelay  int                 `long:"defaultremotedelay" description:"The default number of blocks we will require our channel counterparty to wait before accessing its funds in case of unilateral close. If this is not set, we will scale the value according to the channel size."`
+	MaxRemoteDelay      int                 `long:"maxremotedelay" description:"The max number of blocks we will require our channel counterparty to wait before accessing its funds in case of unilateral close. This also affects the scaling of the remote delay based on the channel size."`
 	MinHTLC             lnwire.MilliSatoshi `long:"minhtlc" description:"The smallest HTLC we are willing to forward on our channels, in millisatoshi"`
 	BaseFee             lnwire.MilliSatoshi `long:"basefee" description:"The base fee in millisatoshi we will charge for forwarding payments on our channels"`
 	FeeRate             lnwire.MilliSatoshi `long:"feerate" description:"The fee rate used when forwarding payments on our channels. The total fee charged is basefee + (amount * feerate / 1000000), where amount is the forwarded amount."`

--- a/server.go
+++ b/server.go
@@ -817,7 +817,16 @@ func newServer(listenAddrs []net.Addr, chanDB *channeldb.DB, cc *chainControl,
 				return defaultDelay
 			}
 
-			// If not we scale according to channel size.
+			// In case the user has explicitly specified
+			// a max value for the remote delay, we use it and
+			// also for the scaling based on the channel size.
+			maxRemoteDelayOverride := uint16(chainCfg.MaxRemoteDelay)
+			if maxRemoteDelayOverride > 0 {
+				maxRemoteDelay = maxRemoteDelayOverride
+			}
+
+			// If no default value is provided,
+			// we scale according to channel size.
 			delay := uint16(btcutil.Amount(maxRemoteDelay) *
 				chanAmt / maxFundingAmount)
 			if delay < minRemoteDelay {


### PR DESCRIPTION
The scaling of remoteDelay based on the channel size is really useful, but the upper limit of 2016 blocks can be too long.

I could see you might not want to get polluted by a lot of options, but I use it locally and thought I'd share. 