### PR TITLE
config+cmd/lncli: separate macaroons by network

### DIFF
--- a/cmd/lncli/main.go
+++ b/cmd/lncli/main.go
@@ -252,10 +252,13 @@ func main() {
 // passed path, cleans the result, and returns it.
 // This function is taken from https://github.com/btcsuite/btcd
 func cleanAndExpandPath(path string) string {
+	if path == "" {
+		return ""
+	}
+
 	// Expand initial ~ to OS specific home directory.
 	if strings.HasPrefix(path, "~") {
 		var homeDir string
-
 		user, err := user.Current()
 		if err == nil {
 			homeDir = user.HomeDir

--- a/cmd/lncli/main.go
+++ b/cmd/lncli/main.go
@@ -25,6 +25,8 @@ import (
 )
 
 const (
+	defaultDataDir          = "data"
+	defaultChainSubDir      = "chain"
 	defaultTLSCertFilename  = "tls.cert"
 	defaultMacaroonFilename = "admin.macaroon"
 	defaultRPCPort          = "10009"
@@ -32,13 +34,12 @@ const (
 )
 
 var (
-	//Commit stores the current commit hash of this build. This should be
-	//set using -ldflags during compilation.
+	// Commit stores the current commit hash of this build. This should be
+	// set using -ldflags during compilation.
 	Commit string
 
-	defaultLndDir       = btcutil.AppDataDir("lnd", false)
-	defaultTLSCertPath  = filepath.Join(defaultLndDir, defaultTLSCertFilename)
-	defaultMacaroonPath = filepath.Join(defaultLndDir, defaultMacaroonFilename)
+	defaultLndDir      = btcutil.AppDataDir("lnd", false)
+	defaultTLSCertPath = filepath.Join(defaultLndDir, defaultTLSCertFilename)
 )
 
 func fatal(err error) {
@@ -67,30 +68,11 @@ func getClient(ctx *cli.Context) (lnrpc.LightningClient, func()) {
 }
 
 func getClientConn(ctx *cli.Context, skipMacaroons bool) *grpc.ClientConn {
-	lndDir := cleanAndExpandPath(ctx.GlobalString("lnddir"))
-	if lndDir != defaultLndDir {
-		// If a custom lnd directory was set, we'll also check if custom
-		// paths for the TLS cert and macaroon file were set as well. If
-		// not, we'll override their paths so they can be found within
-		// the custom lnd directory set. This allows us to set a custom
-		// lnd directory, along with custom paths to the TLS cert and
-		// macaroon file.
-		tlsCertPath := cleanAndExpandPath(ctx.GlobalString("tlscertpath"))
-		if tlsCertPath == defaultTLSCertPath {
-			ctx.GlobalSet("tlscertpath",
-				filepath.Join(lndDir, defaultTLSCertFilename))
-		}
-
-		macPath := cleanAndExpandPath(ctx.GlobalString("macaroonpath"))
-		if macPath == defaultMacaroonPath {
-			ctx.GlobalSet("macaroonpath",
-				filepath.Join(lndDir, defaultMacaroonFilename))
-		}
-	}
+	// First, we'll parse the args from the command.
+	tlsCertPath, macPath := parseArgs(ctx)
 
 	// Load the specified TLS certificate and build transport credentials
 	// with it.
-	tlsCertPath := cleanAndExpandPath(ctx.GlobalString("tlscertpath"))
 	creds, err := credentials.NewClientTLSFromFile(tlsCertPath, "")
 	if err != nil {
 		fatal(err)
@@ -105,7 +87,6 @@ func getClientConn(ctx *cli.Context, skipMacaroons bool) *grpc.ClientConn {
 	// if we're not skipping macaroon processing.
 	if !ctx.GlobalBool("no-macaroons") && !skipMacaroons {
 		// Load the specified macaroon file.
-		macPath := cleanAndExpandPath(ctx.GlobalString("macaroonpath"))
 		macBytes, err := ioutil.ReadFile(macPath)
 		if err != nil {
 			fatal(err)
@@ -161,6 +142,53 @@ func getClientConn(ctx *cli.Context, skipMacaroons bool) *grpc.ClientConn {
 	return conn
 }
 
+// parseArgs parses the TLS certificate and macaroon paths from the command.
+func parseArgs(ctx *cli.Context) (string, string) {
+	// We'll start off by parsing the active chain and network. These are
+	// needed to determine the correct path to the macaroon when not
+	// specified.
+	chain := strings.ToLower(ctx.GlobalString("chain"))
+	switch chain {
+	case "bitcoin", "litecoin":
+	default:
+		err := fmt.Errorf("unknown chain: %v", chain)
+		fatal(err)
+	}
+
+	network := strings.ToLower(ctx.GlobalString("network"))
+	switch network {
+	case "mainnet", "testnet", "regtest", "simnet":
+	default:
+		err := fmt.Errorf("unknown network: %v", network)
+		fatal(err)
+	}
+
+	var tlsCertPath, macPath string
+	lndDir := cleanAndExpandPath(ctx.GlobalString("lnddir"))
+	if lndDir != defaultLndDir {
+		// If a custom lnd directory was set, we'll also check if custom
+		// paths for the TLS cert and macaroon file were set as well. If
+		// not, we'll override their paths so they can be found within
+		// the custom lnd directory set. This allows us to set a custom
+		// lnd directory, along with custom paths to the TLS cert and
+		// macaroon file.
+		tlsCertPath = cleanAndExpandPath(ctx.GlobalString("tlscertpath"))
+		if tlsCertPath == defaultTLSCertPath {
+			tlsCertPath = filepath.Join(lndDir, defaultTLSCertFilename)
+		}
+
+		macPath = cleanAndExpandPath(ctx.GlobalString("macaroonpath"))
+		if macPath == "" {
+			macPath = filepath.Join(
+				lndDir, defaultDataDir, defaultChainSubDir,
+				chain, network, defaultMacaroonFilename,
+			)
+		}
+	}
+
+	return tlsCertPath, macPath
+}
+
 func main() {
 	app := cli.NewApp()
 	app.Name = "lncli"
@@ -199,7 +227,6 @@ func main() {
 		},
 		cli.StringFlag{
 			Name:  "macaroonpath",
-			Value: defaultMacaroonPath,
 			Usage: "path to macaroon file",
 		},
 		cli.Int64Flag{

--- a/cmd/lncli/main.go
+++ b/cmd/lncli/main.go
@@ -182,6 +182,17 @@ func main() {
 			Value: defaultTLSCertPath,
 			Usage: "path to TLS certificate",
 		},
+		cli.StringFlag{
+			Name:  "chain, c",
+			Usage: "the chain lnd is running on e.g. bitcoin",
+			Value: "bitcoin",
+		},
+		cli.StringFlag{
+			Name: "network, n",
+			Usage: "the network lnd is running on e.g. mainnet, " +
+				"testnet, etc.",
+			Value: "mainnet",
+		},
 		cli.BoolFlag{
 			Name:  "no-macaroons",
 			Usage: "disable macaroon authentication",

--- a/config.go
+++ b/config.go
@@ -76,10 +76,6 @@ var (
 	defaultTLSCertPath = filepath.Join(defaultLndDir, defaultTLSCertFilename)
 	defaultTLSKeyPath  = filepath.Join(defaultLndDir, defaultTLSKeyFilename)
 
-	defaultAdminMacPath   = filepath.Join(defaultLndDir, defaultAdminMacFilename)
-	defaultReadMacPath    = filepath.Join(defaultLndDir, defaultReadMacFilename)
-	defaultInvoiceMacPath = filepath.Join(defaultLndDir, defaultInvoiceMacFilename)
-
 	defaultBtcdDir         = btcutil.AppDataDir("btcd", false)
 	defaultBtcdRPCCertFile = filepath.Join(defaultBtcdDir, "rpc.cert")
 
@@ -256,9 +252,6 @@ func loadConfig() (*config, error) {
 		DebugLevel:     defaultLogLevel,
 		TLSCertPath:    defaultTLSCertPath,
 		TLSKeyPath:     defaultTLSKeyPath,
-		AdminMacPath:   defaultAdminMacPath,
-		InvoiceMacPath: defaultInvoiceMacPath,
-		ReadMacPath:    defaultReadMacPath,
 		LogDir:         defaultLogDir,
 		MaxLogFiles:    defaultMaxLogFiles,
 		MaxLogFileSize: defaultMaxLogFileSize,
@@ -347,9 +340,6 @@ func loadConfig() (*config, error) {
 		preCfg.DataDir = filepath.Join(lndDir, defaultDataDirname)
 		preCfg.TLSCertPath = filepath.Join(lndDir, defaultTLSCertFilename)
 		preCfg.TLSKeyPath = filepath.Join(lndDir, defaultTLSKeyFilename)
-		preCfg.AdminMacPath = filepath.Join(lndDir, defaultAdminMacFilename)
-		preCfg.InvoiceMacPath = filepath.Join(lndDir, defaultInvoiceMacFilename)
-		preCfg.ReadMacPath = filepath.Join(lndDir, defaultReadMacFilename)
 		preCfg.LogDir = filepath.Join(lndDir, defaultLogDirname)
 		preCfg.Tor.V2PrivateKeyPath = filepath.Join(lndDir, defaultTorV2PrivateKeyFilename)
 	}
@@ -777,17 +767,17 @@ func loadConfig() (*config, error) {
 	// If a custom macaroon directory wasn't specified and the data
 	// directory has changed from the default path, then we'll also update
 	// the path for the macaroons to be generated.
-	if cfg.DataDir != defaultDataDir && cfg.AdminMacPath == defaultAdminMacPath {
+	if cfg.AdminMacPath == "" {
 		cfg.AdminMacPath = filepath.Join(
 			networkDir, defaultAdminMacFilename,
 		)
 	}
-	if cfg.DataDir != defaultDataDir && cfg.ReadMacPath == defaultReadMacPath {
+	if cfg.ReadMacPath == "" {
 		cfg.ReadMacPath = filepath.Join(
 			networkDir, defaultReadMacFilename,
 		)
 	}
-	if cfg.DataDir != defaultDataDir && cfg.InvoiceMacPath == defaultInvoiceMacPath {
+	if cfg.InvoiceMacPath == "" {
 		cfg.InvoiceMacPath = filepath.Join(
 			networkDir, defaultInvoiceMacFilename,
 		)

--- a/config.go
+++ b/config.go
@@ -768,24 +768,28 @@ func loadConfig() (*config, error) {
 	// At this point, we'll save the base data directory in order to ensure
 	// we don't store the macaroon database within any of the chain
 	// namespaced directories.
-	macaroonDatabaseDir = cfg.DataDir
+	networkDir = filepath.Join(
+		cfg.DataDir, defaultChainSubDirname,
+		registeredChains.PrimaryChain().String(),
+		normalizeNetwork(activeNetParams.Name),
+	)
 
 	// If a custom macaroon directory wasn't specified and the data
 	// directory has changed from the default path, then we'll also update
 	// the path for the macaroons to be generated.
 	if cfg.DataDir != defaultDataDir && cfg.AdminMacPath == defaultAdminMacPath {
 		cfg.AdminMacPath = filepath.Join(
-			cfg.DataDir, defaultAdminMacFilename,
+			networkDir, defaultAdminMacFilename,
 		)
 	}
 	if cfg.DataDir != defaultDataDir && cfg.ReadMacPath == defaultReadMacPath {
 		cfg.ReadMacPath = filepath.Join(
-			cfg.DataDir, defaultReadMacFilename,
+			networkDir, defaultReadMacFilename,
 		)
 	}
 	if cfg.DataDir != defaultDataDir && cfg.InvoiceMacPath == defaultInvoiceMacPath {
 		cfg.InvoiceMacPath = filepath.Join(
-			cfg.DataDir, defaultInvoiceMacFilename,
+			networkDir, defaultInvoiceMacFilename,
 		)
 	}
 

--- a/config.go
+++ b/config.go
@@ -934,10 +934,13 @@ func loadConfig() (*config, error) {
 // passed path, cleans the result, and returns it.
 // This function is taken from https://github.com/btcsuite/btcd
 func cleanAndExpandPath(path string) string {
+	if path == "" {
+		return ""
+	}
+
 	// Expand initial ~ to OS specific home directory.
 	if strings.HasPrefix(path, "~") {
 		var homeDir string
-
 		user, err := user.Current()
 		if err == nil {
 			homeDir = user.HomeDir

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -306,10 +306,12 @@ Github](https://github.com/lightningnetwork/lnd/issues/20).
 
 Running `lnd` for the first time will by default generate the `admin.macaroon`,
 `read_only.macaroon`, and `macaroons.db` files that are used to authenticate
-into `lnd`. They will be stored in the default `lnd` data directory. Note that
-if you specified an alternative data directory (via the `--datadir` argument),
-you will have to additionally pass the updated location of the `admin.macaroon`
-file into `lncli` using the `--macaroonpath` argument.
+into `lnd`. They will be stored in the network directory (default:
+`lnddir/data/chain/bitcoin/mainnet`) so that it's possible to use a distinct
+password for mainnet, testnet, simnet, etc. Note that if you specified an
+alternative data directory (via the `--datadir` argument), you will have to
+additionally pass the updated location of the `admin.macaroon` file into `lncli`
+using the `--macaroonpath` argument.
 
 To disable macaroons for testing, pass the `--no-macaroons` flag into *both*
 `lnd` and `lncli`.

--- a/docs/grpc/java.md
+++ b/docs/grpc/java.md
@@ -158,7 +158,7 @@ public class Main {
   }
 
   private static final String CERT_PATH = "/Users/user/Library/Application Support/Lnd/tls.cert";
-  private static final String MACAROON_PATH = "/Users/user/Library/Application Support/Lnd/admin.macaroon";
+  private static final String MACAROON_PATH = "/Users/user/Library/Application Support/Lnd/data/chain/bitcoin/simnet/admin.macaroon";
   private static final String HOST = "localhost";
   private static final int PORT = 10009;
 

--- a/docs/grpc/javascript.md
+++ b/docs/grpc/javascript.md
@@ -174,9 +174,9 @@ var grpc = require('grpc');
 
 process.env.GRPC_SSL_CIPHER_SUITES = 'HIGH+ECDSA'
 
-// Lnd admin macaroon is at ~/.lnd/admin.macaroon on Linux and
-// ~/Library/Application Support/Lnd/admin.macaroon on Mac
-var m = fs.readFileSync('~/.lnd/admin.macaroon');
+// Lnd admin macaroon is at ~/.lnd/data/chain/bitcoin/simnet/admin.macaroon on Linux and
+// ~/Library/Application Support/Lnd/data/chain/bitcoin/simnet/admin.macaroon on Mac
+var m = fs.readFileSync('~/.lnd/data/chain/bitcoin/simnet/admin.macaroon');
 var macaroon = m.toString('hex');
 var meta = new grpc.Metadata().add('macaroon', macaroon);
 
@@ -195,9 +195,9 @@ var grpc = require('grpc');
 
 process.env.GRPC_SSL_CIPHER_SUITES = 'HIGH+ECDSA'
 
-// Lnd admin macaroon is at ~/.lnd/admin.macaroon on Linux and
-// ~/Library/Application Support/Lnd/admin.macaroon on Mac
-var m = fs.readFileSync('~/.lnd/admin.macaroon');
+// Lnd admin macaroon is at ~/.lnd/data/chain/bitcoin/simnet/admin.macaroon on Linux and
+// ~/Library/Application Support/Lnd/data/chain/bitcoin/simnet/admin.macaroon on Mac
+var m = fs.readFileSync('~/.lnd/data/chain/bitcoin/simnet/admin.macaroon');
 var macaroon = m.toString('hex');
 
 // build meta data credentials

--- a/docs/grpc/python.md
+++ b/docs/grpc/python.md
@@ -140,9 +140,9 @@ To authenticate using macaroons you need to include the macaroon in the metadata
 ```python
 import codecs
 
-# Lnd admin macaroon is at ~/.lnd/admin.macaroon on Linux and
-# ~/Library/Application Support/Lnd/admin.macaroon on Mac
-with open(os.path.expanduser('~/.lnd/admin.macaroon'), 'rb') as f:
+# Lnd admin macaroon is at ~/.lnd/data/chain/bitcoin/simnet/admin.macaroon on Linux and
+# ~/Library/Application Support/Lnd/data/chain/bitcoin/simnet/admin.macaroon on Mac
+with open(os.path.expanduser('~/.lnd/data/chain/bitcoin/simnet/admin.macaroon'), 'rb') as f:
     macaroon_bytes = f.read()
     macaroon = codecs.encode(macaroon_bytes, 'hex')
 ```

--- a/docs/grpc/ruby.md
+++ b/docs/grpc/ruby.md
@@ -119,9 +119,9 @@ You should now see the details of the settled invoice appear.
 To authenticate using macaroons you need to include the macaroon in the metadata of the request.
 
 ```ruby
-# Lnd admin macaroon is at ~/.lnd/admin.macaroon on Linux and
-# ~/Library/Application Support/Lnd/admin.macaroon on Mac
-macaroon_binary = File.read(File.expand_path("~/.lnd/admin.macaroon"))
+# Lnd admin macaroon is at ~/.lnd/data/chain/bitcoin/simnet/admin.macaroon on Linux and
+# ~/Library/Application Support/Lnd/data/chain/bitcoin/simnet/admin.macaroon on Mac
+macaroon_binary = File.read(File.expand_path("~/.lnd/data/chain/bitcoin/simnet/admin.macaroon"))
 macaroon = macaroon_binary.each_byte.map { |b| b.to_s(16).rjust(2,'0') }.join
 ```
 
@@ -154,7 +154,7 @@ And then we would include it when we create our stub like so.
 ```ruby
 certificate = File.read(File.expand_path("~/.lnd/tls.cert"))
 credentials = GRPC::Core::ChannelCredentials.new(certificate)
-macaroon_binary = File.read(File.expand_path("~/.lnd/admin.macaroon"))
+macaroon_binary = File.read(File.expand_path("~/.lnd/data/chain/bitcoin/simnet/admin.macaroon"))
 macaroon = macaroon_binary.each_byte.map { |b| b.to_s(16).rjust(2,'0') }.join
 
 stub = Lnrpc::Lightning::Stub.new(

--- a/docs/macaroons.md
+++ b/docs/macaroons.md
@@ -86,11 +86,12 @@ it won't be checked for validity.
 Since `lnd` requires macaroons by default in order to call RPC methods, `lncli`
 now reads a macaroon and provides it in the RPC call. Unless the path is
 changed by the `--macaroonpath` option, `lncli` tries to read the macaroon from
-`~/.lnd/admin.macaroon` by default and will error if that file doesn't exist
-unless provided the `--no-macaroons` option. Keep this in mind when running
-`lnd` with `--no-macaroons`, as `lncli` will error out unless called the same
-way **or** `lnd` has generated a macaroon on a previous run without this
-option.
+the network directory of `lnd`'s currently active network (e.g. for simnet
+`lnddir/data/chain/bitcoin/simnet/admin.macaroon`) by default and will error if
+that file doesn't exist unless provided the `--no-macaroons` option. Keep this
+in mind when running `lnd` with `--no-macaroons`, as `lncli` will error out
+unless called the same way **or** `lnd` has generated a macaroon on a previous
+run without this option.
 
 `lncli` also adds a caveat which makes it valid for only 60 seconds by default
 to help prevent replay in case the macaroon is somehow intercepted in
@@ -114,7 +115,7 @@ Where `<macaroon>` is the hex encoded binary data from the macaroon file itself.
 
 A very simple example using `curl` may look something like this:
 
-    curl --insecure --header "Grpc-Metadata-macaroon: $(xxd -ps -u -c 1000  $HOME/.lnd/admin.macaroon)" https://localhost:8080/v1/getinfo
+    curl --insecure --header "Grpc-Metadata-macaroon: $(xxd -ps -u -c 1000  $HOME/.lnd/data/chain/bitcoin/simnet/admin.macaroon)" https://localhost:8080/v1/getinfo
 
 Have a look at the [Java GRPC example](/docs/grpc/java.md) for programmatic usage details.
 

--- a/lnd.go
+++ b/lnd.go
@@ -54,14 +54,17 @@ const (
 )
 
 var (
-	//Commit stores the current commit hash of this build. This should be
-	//set using -ldflags during compilation.
+	// Commit stores the current commit hash of this build. This should be
+	// set using -ldflags during compilation.
 	Commit string
 
 	cfg              *config
 	registeredChains = newChainRegistry()
 
-	macaroonDatabaseDir string
+	// networkDir is the path to the directory of the currently active
+	// network. This path will hold the files related to each different
+	// network.
+	networkDir string
 
 	// End of ASN.1 time.
 	endOfTime = time.Date(2049, 12, 31, 23, 59, 59, 0, time.UTC)
@@ -234,8 +237,9 @@ func lndMain() error {
 	var macaroonService *macaroons.Service
 	if !cfg.NoMacaroons {
 		// Create the macaroon authentication/authorization service.
-		macaroonService, err = macaroons.NewService(macaroonDatabaseDir,
-			macaroons.IPLockChecker)
+		macaroonService, err = macaroons.NewService(
+			networkDir, macaroons.IPLockChecker,
+		)
 		if err != nil {
 			srvrLog.Errorf("unable to create macaroon service: %v", err)
 			return err
@@ -708,7 +712,7 @@ func waitForWalletPassword(grpcEndpoints, restEndpoints []net.Addr,
 	// deleted within it and recreated when successfully changing the
 	// wallet's password.
 	macaroonFiles := []string{
-		filepath.Join(macaroonDatabaseDir, macaroons.DBFilename),
+		filepath.Join(networkDir, macaroons.DBFilename),
 		cfg.AdminMacPath, cfg.ReadMacPath, cfg.InvoiceMacPath,
 	}
 	pwService := walletunlocker.New(

--- a/sample-lnd.conf
+++ b/sample-lnd.conf
@@ -39,15 +39,23 @@
 
 ; Path to write the admin macaroon for lnd's RPC and REST services if it
 ; doesn't exist. This can be set if one wishes to store the admin macaroon in a
-; distinct location. By default, it is stored within lnd's main home directory.
-; Applications that are able to read this file, gains admin macaroon access
-; adminmacaroonpath=~/.lnd/admin.macaroon
+; distinct location. By default, it is stored within lnd's network directory.
+; Applications that are able to read this file, gain admin macaroon access.
+; adminmacaroonpath=~/.lnd/data/chain/bitcoin/simnet/admin.macaroon
 
 ; Path to write the read-only macaroon for lnd's RPC and REST services if it
 ; doesn't exist. This can be set if one wishes to store the read-only macaroon
 ; in a distinct location. The read only macaroon allows users which can read
-; the file to access RPCs which don't modify the state of the daemon.
-; readonlymacaroonpath=~/.lnd/readonly.macaroon
+; the file to access RPCs which don't modify the state of the daemon. By
+; default, it is stored within lnd's network directory.
+; readonlymacaroonpath=~/.lnd/data/chain/bitcoin/simnet/readonly.macaroon
+
+; Path to write the invoice macaroon for lnd's RPC and REST services if it
+; doesn't exist. This can be set if one wishes to store the invoice macaroon in
+; a distinct location. By default, it is stored within lnd's network directory.
+; The invoice macaroon allows users which can read the file to gain read and
+; write access to all invoice related RPCs.
+; invoicemacaroonpath=~/.lnd/data/chain/bitcoin/simnet/invoice.macaroon
 
 
 ; Specify the interfaces to listen on for p2p connections.  One listen


### PR DESCRIPTION
In this PR, we modify the path of where macaroon files are created. Now, we'll create them under the active network directory (e.g. for simnet `lnddir/data/chain/bitcoin/simnet`. This allows us to have different macaroons per chain _and_ network. This was needed as previously we'd share the same macaroons and password for different networks.

When migrating from an existing node, the previous macaroons files will still reside within their current location, but will no longer be valid.

Replaces #1313.
Fixes #1249.