### PR TITLE
[autopilot]: add OnNodeUpdate trigger

### DIFF
--- a/pilot.go
+++ b/pilot.go
@@ -306,6 +306,13 @@ func initAutoPilot(svr *server, cfg *autoPilotConfig) (*autopilot.Agent, error) 
 					pilot.OnChannelClose(chanID)
 				}
 
+				// If new nodes were added to the graph, or nod
+				// information has changed, we'll poke autopilot
+				// to see if it can make use of them.
+				if len(topChange.NodeUpdates) > 0 {
+					pilot.OnNodeUpdates()
+				}
+
 			case <-svr.quit:
 				return
 			}


### PR DESCRIPTION
Adds a new external signal alerting autopilot that
new nodes have been added to the channel graph or
an existing node has modified its channel
announcment. This allows autopilot to examine its
current state, and attempt to open channels if our
target state is not yet met.