### PR TITLE
Cancel long-running Neutrino GetUTXO calls on quit

### DIFF
--- a/chainntnfs/neutrinonotify/neutrino.go
+++ b/chainntnfs/neutrinonotify/neutrino.go
@@ -837,6 +837,7 @@ func (n *NeutrinoNotifier) RegisterSpendNtfn(outpoint *wire.OutPoint,
 		neutrino.StartBlock(&waddrmgr.BlockStamp{
 			Height: int32(heightHint),
 		}),
+		neutrino.QuitChan(n.quit),
 	)
 	if err != nil && !strings.Contains(err.Error(), "not found") {
 		return nil, err

--- a/lnwallet/btcwallet/blockchain.go
+++ b/lnwallet/btcwallet/blockchain.go
@@ -51,6 +51,7 @@ func (b *BtcWallet) GetUtxo(op *wire.OutPoint, pkScript []byte,
 			neutrino.StartBlock(&waddrmgr.BlockStamp{
 				Height: int32(heightHint),
 			}),
+			neutrino.QuitChan(b.quit),
 		)
 		if err != nil {
 			return nil, err

--- a/lnwallet/btcwallet/btcwallet.go
+++ b/lnwallet/btcwallet/btcwallet.go
@@ -66,8 +66,9 @@ type BtcWallet struct {
 }
 
 // A compile time check to ensure that BtcWallet implements the
-// WalletController interface.
+// WalletController and BlockChainIO interfaces.
 var _ lnwallet.WalletController = (*BtcWallet)(nil)
+var _ lnwallet.BlockChainIO = (*BtcWallet)(nil)
 
 // New returns a new fully initialized instance of BtcWallet given a valid
 // configuration struct.


### PR DESCRIPTION
This PR makes sure long running calls to `GetUTXO` gets cancelled in case we are shutting down.

This is done by adding a `quit` channel to `BtcWallet`, and cancelling the call in case of shutdown.

Fixes #2300. 