### PR TITLE
chainntnfs: Isolate conf notifications during historical scans

### DIFF
--- a/chainntnfs/bitcoindnotify/bitcoind.go
+++ b/chainntnfs/bitcoindnotify/bitcoind.go
@@ -278,14 +278,19 @@ out:
 						return
 					}
 
-					if confDetails != nil {
-						err := b.txConfNotifier.UpdateConfDetails(
-							*msg.TxID, msg.ConfID,
-							confDetails,
-						)
-						if err != nil {
-							chainntnfs.Log.Error(err)
-						}
+					// If the historical dispatch finished
+					// without error, we will invoke
+					// UpdateConfDetails even if none were
+					// found. This allows the notifier to
+					// begin safely updating the height hint
+					// cache at tip, since any pending
+					// rescans have now completed.
+					err = b.txConfNotifier.UpdateConfDetails(
+						*msg.TxID, msg.ConfID,
+						confDetails,
+					)
+					if err != nil {
+						chainntnfs.Log.Error(err)
 					}
 				}()
 

--- a/chainntnfs/btcdnotify/btcd.go
+++ b/chainntnfs/btcdnotify/btcd.go
@@ -348,14 +348,19 @@ out:
 						return
 					}
 
-					if confDetails != nil {
-						err = b.txConfNotifier.UpdateConfDetails(
-							*msg.TxID, msg.ConfID,
-							confDetails,
-						)
-						if err != nil {
-							chainntnfs.Log.Error(err)
-						}
+					// If the historical dispatch finished
+					// without error, we will invoke
+					// UpdateConfDetails even if none were
+					// found. This allows the notifier to
+					// begin safely updating the height hint
+					// cache at tip, since any pending
+					// rescans have now completed.
+					err = b.txConfNotifier.UpdateConfDetails(
+						*msg.TxID, msg.ConfID,
+						confDetails,
+					)
+					if err != nil {
+						chainntnfs.Log.Error(err)
 					}
 				}()
 

--- a/chainntnfs/btcdnotify/btcd.go
+++ b/chainntnfs/btcdnotify/btcd.go
@@ -324,13 +324,7 @@ out:
 				}
 				b.spendNotifications[op][msg.spendID] = msg
 
-			case *chainntnfs.ConfNtfn:
-				chainntnfs.Log.Infof("New confirmation "+
-					"subscription: txid=%v, numconfs=%v",
-					msg.TxID, msg.NumConfirmations)
-
-				bestHeight := uint32(b.bestBlock.Height)
-
+			case *chainntnfs.HistoricalConfDispatch:
 				// Look up whether the transaction is already
 				// included in the active chain. We'll do this
 				// in a goroutine to prevent blocking
@@ -340,8 +334,7 @@ out:
 					defer b.wg.Done()
 
 					confDetails, _, err := b.historicalConfDetails(
-						msg.TxID, msg.HeightHint,
-						bestHeight,
+						msg.TxID, msg.StartHeight, msg.EndHeight,
 					)
 					if err != nil {
 						chainntnfs.Log.Error(err)
@@ -356,8 +349,7 @@ out:
 					// cache at tip, since any pending
 					// rescans have now completed.
 					err = b.txConfNotifier.UpdateConfDetails(
-						*msg.TxID, msg.ConfID,
-						confDetails,
+						*msg.TxID, confDetails,
 					)
 					if err != nil {
 						chainntnfs.Log.Error(err)
@@ -523,7 +515,7 @@ out:
 // historicalConfDetails looks up whether a transaction is already included in a
 // block in the active chain and, if so, returns details about the confirmation.
 func (b *BtcdNotifier) historicalConfDetails(txid *chainhash.Hash,
-	heightHint, currentHeight uint32) (*chainntnfs.TxConfirmation,
+	startHeight, endHeight uint32) (*chainntnfs.TxConfirmation,
 	chainntnfs.TxConfStatus, error) {
 
 	// We'll first attempt to retrieve the transaction using the node's
@@ -539,7 +531,7 @@ func (b *BtcdNotifier) historicalConfDetails(txid *chainhash.Hash,
 	case err != nil:
 		chainntnfs.Log.Debugf("Failed getting conf details from "+
 			"index (%v), scanning manually", err)
-		return b.confDetailsManually(txid, heightHint, currentHeight)
+		return b.confDetailsManually(txid, startHeight, endHeight)
 
 	// The transaction was found within the node's mempool.
 	case txStatus == chainntnfs.TxFoundMempool:
@@ -638,15 +630,15 @@ func (b *BtcdNotifier) confDetailsFromTxIndex(txid *chainhash.Hash,
 // earliest height the transaction could have been included in, to the current
 // height in the chain. If the transaction is found, its confirmation details
 // are returned. Otherwise, nil is returned.
-func (b *BtcdNotifier) confDetailsManually(txid *chainhash.Hash, heightHint,
-	currentHeight uint32) (*chainntnfs.TxConfirmation,
+func (b *BtcdNotifier) confDetailsManually(txid *chainhash.Hash, startHeight,
+	endHeight uint32) (*chainntnfs.TxConfirmation,
 	chainntnfs.TxConfStatus, error) {
 
 	targetTxidStr := txid.String()
 
 	// Begin scanning blocks at every height to determine where the
 	// transaction was included in.
-	for height := heightHint; height <= currentHeight; height++ {
+	for height := startHeight; height <= endHeight; height++ {
 		// Ensure we haven't been requested to shut down before
 		// processing the next height.
 		select {
@@ -1024,12 +1016,24 @@ func (b *BtcdNotifier) RegisterConfirmationsNtfn(txid *chainhash.Hash, _ []byte,
 		HeightHint:       heightHint,
 	}
 
-	if err := b.txConfNotifier.Register(ntfn); err != nil {
+	chainntnfs.Log.Infof("New confirmation subscription: "+
+		"txid=%v, numconfs=%v", txid, numConfs)
+
+	// Register the conf notification with txconfnotifier. A non-nil value
+	// for `dispatch` will be returned if we are required to perform a
+	// manual scan for the confirmation. Otherwise the notifier will begin
+	// watching at tip for the transaction to confirm.
+	dispatch, err := b.txConfNotifier.Register(ntfn)
+	if err != nil {
 		return nil, err
 	}
 
+	if dispatch == nil {
+		return ntfn.Event, nil
+	}
+
 	select {
-	case b.notificationRegistry <- ntfn:
+	case b.notificationRegistry <- dispatch:
 		return ntfn.Event, nil
 	case <-b.quit:
 		return nil, ErrChainNotifierShuttingDown

--- a/chainntnfs/neutrinonotify/neutrino.go
+++ b/chainntnfs/neutrinonotify/neutrino.go
@@ -465,13 +465,13 @@ out:
 
 			n.heightMtx.Lock()
 			if update.height != uint32(n.bestHeight) {
-				chainntnfs.Log.Infof("Missed disconnected" +
+				chainntnfs.Log.Infof("Missed disconnected " +
 					"blocks, attempting to catch up")
 			}
 
 			hash, err := n.p2pNode.GetBlockHash(int64(n.bestHeight))
 			if err != nil {
-				chainntnfs.Log.Errorf("Unable to fetch block hash"+
+				chainntnfs.Log.Errorf("Unable to fetch block hash "+
 					"for height %d: %v", n.bestHeight, err)
 				n.heightMtx.Unlock()
 				continue

--- a/chainntnfs/neutrinonotify/neutrino.go
+++ b/chainntnfs/neutrinonotify/neutrino.go
@@ -353,14 +353,22 @@ out:
 						chainntnfs.Log.Error(err)
 					}
 
+					// If the historical dispatch finished
+					// without error, we will invoke
+					// UpdateConfDetails even if none were
+					// found. This allows the notifier to
+					// begin safely updating the height hint
+					// cache at tip, since any pending
+					// rescans have now completed.
+					err = n.txConfNotifier.UpdateConfDetails(
+						*msg.TxID, msg.ConfID,
+						confDetails,
+					)
+					if err != nil {
+						chainntnfs.Log.Error(err)
+					}
+
 					if confDetails != nil {
-						err := n.txConfNotifier.UpdateConfDetails(
-							*msg.TxID, msg.ConfID,
-							confDetails,
-						)
-						if err != nil {
-							chainntnfs.Log.Error(err)
-						}
 						return
 					}
 

--- a/chainntnfs/txconfnotifier.go
+++ b/chainntnfs/txconfnotifier.go
@@ -27,6 +27,10 @@ type ConfNtfn struct {
 	// are requested.
 	TxID *chainhash.Hash
 
+	// PkScript is the public key script of an outpoint created in this
+	// transaction.
+	PkScript []byte
+
 	// NumConfirmations is the number of confirmations after which the
 	// notification is to be sent.
 	NumConfirmations uint32

--- a/chainntnfs/txconfnotifier.go
+++ b/chainntnfs/txconfnotifier.go
@@ -101,6 +101,27 @@ type TxConfNotifier struct {
 	sync.Mutex
 }
 
+// rescanState indicates the progression of a registration before the notifier
+// can begin dispatching confirmations at tip.
+type rescanState uint8
+
+const (
+	// rescanNotStarted is the initial state, denoting that a historical
+	// dispatch may be required.
+	rescanNotStarted rescanState = iota
+
+	// rescanPending indicates that a dispatch has already been made, and we
+	// are waiting for its completion. No other rescans should be dispatched
+	// while in this state.
+	rescanPending
+
+	// rescanComplete signals either that a rescan was dispatched and has
+	// completed, or that we began watching at tip immediately. In either
+	// case, the notifier can only dispatch notifications from tip when in
+	// this state.
+	rescanComplete
+)
+
 // NewTxConfNotifier creates a TxConfNotifier. The current height of the
 // blockchain is accepted as a parameter.
 func NewTxConfNotifier(startHeight uint32, reorgSafetyLimit uint32,

--- a/chainntnfs/txconfnotifier.go
+++ b/chainntnfs/txconfnotifier.go
@@ -687,7 +687,15 @@ func (tcn *TxConfNotifier) DisconnectTip(blockHeight uint32) error {
 	// clients is always non-blocking.
 	for initialHeight, txHashes := range tcn.txsByInitialHeight {
 		for txHash := range txHashes {
+			// If the transaction has been reorged out of the chain,
+			// we'll make sure to remove the cached confirmation
+			// details to prevent notifying clients with old
+			// information.
 			confSet := tcn.confNotifications[txHash]
+			if initialHeight == blockHeight {
+				confSet.details = nil
+			}
+
 			for _, ntfn := range confSet.ntfns {
 				// First, we'll attempt to drain an update
 				// from each notification to ensure sends to the

--- a/chainntnfs/txconfnotifier.go
+++ b/chainntnfs/txconfnotifier.go
@@ -207,6 +207,8 @@ func (tcn *TxConfNotifier) Register(
 
 	// Before proceeding to register the notification, we'll query our
 	// height hint cache to determine whether a better one exists.
+	//
+	// TODO(conner): verify that all submitted height hints are identical.
 	startHeight := ntfn.HeightHint
 	hint, err := tcn.hintCache.QueryConfirmHint(*ntfn.TxID)
 	if err == nil {

--- a/chainntnfs/txconfnotifier.go
+++ b/chainntnfs/txconfnotifier.go
@@ -48,6 +48,26 @@ type ConfNtfn struct {
 	dispatched bool
 }
 
+// HistoricalConfDispatch parameterizes a manual rescan for a particular
+// transaction identifier. The parameters include the start and end block
+// heights specifying the range of blocks to scan.
+type HistoricalConfDispatch struct {
+	// TxID is the transaction ID to search for in the historical dispatch.
+	TxID *chainhash.Hash
+
+	// PkScript is a public key script from an output created by this
+	// transaction.
+	PkScript []byte
+
+	// StartHeight specifies the block height at which to being the
+	// historical rescan.
+	StartHeight uint32
+
+	// EndHeight specifies the last block height (inclusive) that the
+	// historical scan should consider.
+	EndHeight uint32
+}
+
 // NewConfirmationEvent constructs a new ConfirmationEvent with newly opened
 // channels.
 func NewConfirmationEvent(numConfs uint32) *ConfirmationEvent {

--- a/chainntnfs/txconfnotifier.go
+++ b/chainntnfs/txconfnotifier.go
@@ -500,6 +500,7 @@ func (tcn *TxConfNotifier) ConnectTip(blockHash *chainhash.Hash,
 			TxIndex:     uint32(tx.Index()),
 		}
 
+		confSet.rescanStatus = rescanComplete
 		confSet.details = details
 		for _, ntfn := range confSet.ntfns {
 			ntfn.details = details

--- a/chainntnfs/txconfnotifier.go
+++ b/chainntnfs/txconfnotifier.go
@@ -287,7 +287,7 @@ func (tcn *TxConfNotifier) Register(
 // NOTE: The notification should be registered first to ensure notifications are
 // dispatched correctly.
 func (tcn *TxConfNotifier) UpdateConfDetails(txid chainhash.Hash,
-	clientID uint64, details *TxConfirmation) error {
+	details *TxConfirmation) error {
 
 	select {
 	case <-tcn.quit:

--- a/chainntnfs/txconfnotifier_test.go
+++ b/chainntnfs/txconfnotifier_test.go
@@ -124,7 +124,7 @@ func TestTxConfFutureDispatch(t *testing.T) {
 		NumConfirmations: tx1NumConfs,
 		Event:            chainntnfs.NewConfirmationEvent(tx1NumConfs),
 	}
-	if err := tcn.Register(&ntfn1); err != nil {
+	if _, err := tcn.Register(&ntfn1); err != nil {
 		t.Fatalf("unable to register ntfn: %v", err)
 	}
 
@@ -134,7 +134,7 @@ func TestTxConfFutureDispatch(t *testing.T) {
 		NumConfirmations: tx2NumConfs,
 		Event:            chainntnfs.NewConfirmationEvent(tx2NumConfs),
 	}
-	if err := tcn.Register(&ntfn2); err != nil {
+	if _, err := tcn.Register(&ntfn2); err != nil {
 		t.Fatalf("unable to register ntfn: %v", err)
 	}
 
@@ -298,7 +298,7 @@ func TestTxConfHistoricalDispatch(t *testing.T) {
 		NumConfirmations: tx1NumConfs,
 		Event:            chainntnfs.NewConfirmationEvent(tx1NumConfs),
 	}
-	if err := tcn.Register(&ntfn1); err != nil {
+	if _, err := tcn.Register(&ntfn1); err != nil {
 		t.Fatalf("unable to register ntfn: %v", err)
 	}
 
@@ -309,7 +309,7 @@ func TestTxConfHistoricalDispatch(t *testing.T) {
 		NumConfirmations: tx2NumConfs,
 		Event:            chainntnfs.NewConfirmationEvent(tx2NumConfs),
 	}
-	if err := tcn.Register(&ntfn2); err != nil {
+	if _, err := tcn.Register(&ntfn2); err != nil {
 		t.Fatalf("unable to register ntfn: %v", err)
 	}
 
@@ -448,7 +448,7 @@ func TestTxConfChainReorg(t *testing.T) {
 		NumConfirmations: tx1NumConfs,
 		Event:            chainntnfs.NewConfirmationEvent(tx1NumConfs),
 	}
-	if err := tcn.Register(&ntfn1); err != nil {
+	if _, err := tcn.Register(&ntfn1); err != nil {
 		t.Fatalf("unable to register ntfn: %v", err)
 	}
 
@@ -463,7 +463,8 @@ func TestTxConfChainReorg(t *testing.T) {
 		NumConfirmations: tx2NumConfs,
 		Event:            chainntnfs.NewConfirmationEvent(tx2NumConfs),
 	}
-	if err := tcn.Register(&ntfn2); err != nil {
+	if _, _, err := tcn.Register(&ntfn2); err != nil {
+	if _, err := tcn.Register(&ntfn2); err != nil {
 		t.Fatalf("unable to register ntfn: %v", err)
 	}
 
@@ -478,7 +479,7 @@ func TestTxConfChainReorg(t *testing.T) {
 		NumConfirmations: tx3NumConfs,
 		Event:            chainntnfs.NewConfirmationEvent(tx3NumConfs),
 	}
-	if err := tcn.Register(&ntfn3); err != nil {
+	if _, err := tcn.Register(&ntfn3); err != nil {
 		t.Fatalf("unable to register ntfn: %v", err)
 	}
 
@@ -724,10 +725,10 @@ func TestTxConfHeightHintCache(t *testing.T) {
 		Event:            chainntnfs.NewConfirmationEvent(2),
 	}
 
-	if err := tcn.Register(ntfn1); err != nil {
+	if _, err := tcn.Register(ntfn1); err != nil {
 		t.Fatalf("unable to register tx1: %v", err)
 	}
-	if err := tcn.Register(ntfn2); err != nil {
+	if _, err := tcn.Register(ntfn2); err != nil {
 		t.Fatalf("unable to register tx2: %v", err)
 	}
 
@@ -904,7 +905,7 @@ func TestTxConfTearDown(t *testing.T) {
 		NumConfirmations: 1,
 		Event:            chainntnfs.NewConfirmationEvent(1),
 	}
-	if err := tcn.Register(&ntfn1); err != nil {
+	if _, err := tcn.Register(&ntfn1); err != nil {
 		t.Fatalf("unable to register ntfn: %v", err)
 	}
 	if err := tcn.UpdateConfDetails(*ntfn1.TxID, 0, nil); err != nil {
@@ -917,7 +918,7 @@ func TestTxConfTearDown(t *testing.T) {
 		NumConfirmations: 2,
 		Event:            chainntnfs.NewConfirmationEvent(2),
 	}
-	if err := tcn.Register(&ntfn2); err != nil {
+	if _, err := tcn.Register(&ntfn2); err != nil {
 		t.Fatalf("unable to register ntfn: %v", err)
 	}
 	if err := tcn.UpdateConfDetails(*ntfn2.TxID, 0, nil); err != nil {

--- a/chainntnfs/txconfnotifier_test.go
+++ b/chainntnfs/txconfnotifier_test.go
@@ -113,7 +113,7 @@ func TestTxConfFutureDispatch(t *testing.T) {
 	)
 
 	hintCache := newMockHintCache()
-	txConfNotifier := chainntnfs.NewTxConfNotifier(10, 100, hintCache)
+	tcn := chainntnfs.NewTxConfNotifier(10, 100, hintCache)
 
 	// Create the test transactions and register them with the
 	// TxConfNotifier before including them in a block to receive future
@@ -124,7 +124,7 @@ func TestTxConfFutureDispatch(t *testing.T) {
 		NumConfirmations: tx1NumConfs,
 		Event:            chainntnfs.NewConfirmationEvent(tx1NumConfs),
 	}
-	if err := txConfNotifier.Register(&ntfn1); err != nil {
+	if err := tcn.Register(&ntfn1); err != nil {
 		t.Fatalf("unable to register ntfn: %v", err)
 	}
 
@@ -134,7 +134,7 @@ func TestTxConfFutureDispatch(t *testing.T) {
 		NumConfirmations: tx2NumConfs,
 		Event:            chainntnfs.NewConfirmationEvent(tx2NumConfs),
 	}
-	if err := txConfNotifier.Register(&ntfn2); err != nil {
+	if err := tcn.Register(&ntfn2); err != nil {
 		t.Fatalf("unable to register ntfn: %v", err)
 	}
 
@@ -162,7 +162,7 @@ func TestTxConfFutureDispatch(t *testing.T) {
 		Transactions: []*wire.MsgTx{&tx1, &tx2, &tx3},
 	})
 
-	err := txConfNotifier.ConnectTip(
+	err = tcn.ConnectTip(
 		block1.Hash(), 11, block1.Transactions(),
 	)
 	if err != nil {
@@ -225,7 +225,7 @@ func TestTxConfFutureDispatch(t *testing.T) {
 		Transactions: []*wire.MsgTx{&tx3},
 	})
 
-	err = txConfNotifier.ConnectTip(block2.Hash(), 12, block2.Transactions())
+	err = tcn.ConnectTip(block2.Hash(), 12, block2.Transactions())
 	if err != nil {
 		t.Fatalf("Failed to connect block: %v", err)
 	}
@@ -287,7 +287,7 @@ func TestTxConfHistoricalDispatch(t *testing.T) {
 	)
 
 	hintCache := newMockHintCache()
-	txConfNotifier := chainntnfs.NewTxConfNotifier(10, 100, hintCache)
+	tcn := chainntnfs.NewTxConfNotifier(10, 100, hintCache)
 
 	// Create the test transactions at a height before the TxConfNotifier's
 	// starting height so that they are confirmed once registering them.
@@ -298,7 +298,7 @@ func TestTxConfHistoricalDispatch(t *testing.T) {
 		NumConfirmations: tx1NumConfs,
 		Event:            chainntnfs.NewConfirmationEvent(tx1NumConfs),
 	}
-	if err := txConfNotifier.Register(&ntfn1); err != nil {
+	if err := tcn.Register(&ntfn1); err != nil {
 		t.Fatalf("unable to register ntfn: %v", err)
 	}
 
@@ -309,7 +309,7 @@ func TestTxConfHistoricalDispatch(t *testing.T) {
 		NumConfirmations: tx2NumConfs,
 		Event:            chainntnfs.NewConfirmationEvent(tx2NumConfs),
 	}
-	if err := txConfNotifier.Register(&ntfn2); err != nil {
+	if err := tcn.Register(&ntfn2); err != nil {
 		t.Fatalf("unable to register ntfn: %v", err)
 	}
 
@@ -320,7 +320,7 @@ func TestTxConfHistoricalDispatch(t *testing.T) {
 		BlockHeight: 9,
 		TxIndex:     1,
 	}
-	err := txConfNotifier.UpdateConfDetails(tx1Hash, ntfn1.ConfID, &txConf1)
+	err := tcn.UpdateConfDetails(tx1Hash, ntfn1.ConfID, &txConf1)
 	if err != nil {
 		t.Fatalf("unable to update conf details: %v", err)
 	}
@@ -353,7 +353,7 @@ func TestTxConfHistoricalDispatch(t *testing.T) {
 		BlockHeight: 9,
 		TxIndex:     2,
 	}
-	err = txConfNotifier.UpdateConfDetails(tx2Hash, ntfn2.ConfID, &txConf2)
+	err = tcn.UpdateConfDetails(tx2Hash, ntfn2.ConfID, &txConf2)
 	if err != nil {
 		t.Fatalf("unable to update conf details: %v", err)
 	}
@@ -381,7 +381,7 @@ func TestTxConfHistoricalDispatch(t *testing.T) {
 		Transactions: []*wire.MsgTx{&tx3},
 	})
 
-	err = txConfNotifier.ConnectTip(block.Hash(), 11, block.Transactions())
+	err = tcn.ConnectTip(block.Hash(), 11, block.Transactions())
 	if err != nil {
 		t.Fatalf("Failed to connect block: %v", err)
 	}
@@ -439,7 +439,7 @@ func TestTxConfChainReorg(t *testing.T) {
 	)
 
 	hintCache := newMockHintCache()
-	txConfNotifier := chainntnfs.NewTxConfNotifier(7, 100, hintCache)
+	tcn := chainntnfs.NewTxConfNotifier(7, 100, hintCache)
 
 	// Tx 1 will be confirmed in block 9 and requires 2 confs.
 	tx1Hash := tx1.TxHash()
@@ -448,7 +448,7 @@ func TestTxConfChainReorg(t *testing.T) {
 		NumConfirmations: tx1NumConfs,
 		Event:            chainntnfs.NewConfirmationEvent(tx1NumConfs),
 	}
-	if err := txConfNotifier.Register(&ntfn1); err != nil {
+	if err := tcn.Register(&ntfn1); err != nil {
 		t.Fatalf("unable to register ntfn: %v", err)
 	}
 
@@ -459,7 +459,7 @@ func TestTxConfChainReorg(t *testing.T) {
 		NumConfirmations: tx2NumConfs,
 		Event:            chainntnfs.NewConfirmationEvent(tx2NumConfs),
 	}
-	if err := txConfNotifier.Register(&ntfn2); err != nil {
+	if err := tcn.Register(&ntfn2); err != nil {
 		t.Fatalf("unable to register ntfn: %v", err)
 	}
 
@@ -470,7 +470,7 @@ func TestTxConfChainReorg(t *testing.T) {
 		NumConfirmations: tx3NumConfs,
 		Event:            chainntnfs.NewConfirmationEvent(tx3NumConfs),
 	}
-	if err := txConfNotifier.Register(&ntfn3); err != nil {
+	if err := tcn.Register(&ntfn3); err != nil {
 		t.Fatalf("unable to register ntfn: %v", err)
 	}
 
@@ -478,11 +478,11 @@ func TestTxConfChainReorg(t *testing.T) {
 	block1 := btcutil.NewBlock(&wire.MsgBlock{
 		Transactions: []*wire.MsgTx{&tx1},
 	})
-	err := txConfNotifier.ConnectTip(nil, 8, block1.Transactions())
+	err := tcn.ConnectTip(nil, 8, block1.Transactions())
 	if err != nil {
 		t.Fatalf("Failed to connect block: %v", err)
 	}
-	err = txConfNotifier.ConnectTip(nil, 9, nil)
+	err = tcn.ConnectTip(nil, 9, nil)
 	if err != nil {
 		t.Fatalf("Failed to connect block: %v", err)
 	}
@@ -490,7 +490,7 @@ func TestTxConfChainReorg(t *testing.T) {
 	block2 := btcutil.NewBlock(&wire.MsgBlock{
 		Transactions: []*wire.MsgTx{&tx2, &tx3},
 	})
-	err = txConfNotifier.ConnectTip(nil, 10, block2.Transactions())
+	err = tcn.ConnectTip(nil, 10, block2.Transactions())
 	if err != nil {
 		t.Fatalf("Failed to connect block: %v", err)
 	}
@@ -547,17 +547,17 @@ func TestTxConfChainReorg(t *testing.T) {
 
 	// The block that included tx2 and tx3 is disconnected and two next
 	// blocks without them are connected.
-	err = txConfNotifier.DisconnectTip(10)
+	err = tcn.DisconnectTip(10)
 	if err != nil {
 		t.Fatalf("Failed to connect block: %v", err)
 	}
 
-	err = txConfNotifier.ConnectTip(nil, 10, nil)
+	err = tcn.ConnectTip(nil, 10, nil)
 	if err != nil {
 		t.Fatalf("Failed to connect block: %v", err)
 	}
 
-	err = txConfNotifier.ConnectTip(nil, 11, nil)
+	err = tcn.ConnectTip(nil, 11, nil)
 	if err != nil {
 		t.Fatalf("Failed to connect block: %v", err)
 	}
@@ -605,12 +605,12 @@ func TestTxConfChainReorg(t *testing.T) {
 	})
 	block4 := btcutil.NewBlock(&wire.MsgBlock{})
 
-	err = txConfNotifier.ConnectTip(block3.Hash(), 12, block3.Transactions())
+	err = tcn.ConnectTip(block3.Hash(), 12, block3.Transactions())
 	if err != nil {
 		t.Fatalf("Failed to connect block: %v", err)
 	}
 
-	err = txConfNotifier.ConnectTip(block4.Hash(), 13, block4.Transactions())
+	err = tcn.ConnectTip(block4.Hash(), 13, block4.Transactions())
 	if err != nil {
 		t.Fatalf("Failed to connect block: %v", err)
 	}
@@ -687,7 +687,7 @@ func TestTxConfHeightHintCache(t *testing.T) {
 
 	// Initialize our TxConfNotifier instance backed by a height hint cache.
 	hintCache := newMockHintCache()
-	txConfNotifier := chainntnfs.NewTxConfNotifier(
+	tcn := chainntnfs.NewTxConfNotifier(
 		startingHeight, 100, hintCache,
 	)
 
@@ -708,10 +708,10 @@ func TestTxConfHeightHintCache(t *testing.T) {
 		Event:            chainntnfs.NewConfirmationEvent(2),
 	}
 
-	if err := txConfNotifier.Register(ntfn1); err != nil {
+	if err := tcn.Register(ntfn1); err != nil {
 		t.Fatalf("unable to register tx1: %v", err)
 	}
-	if err := txConfNotifier.Register(ntfn2); err != nil {
+	if err := tcn.Register(ntfn2); err != nil {
 		t.Fatalf("unable to register tx2: %v", err)
 	}
 
@@ -739,7 +739,7 @@ func TestTxConfHeightHintCache(t *testing.T) {
 		Transactions: []*wire.MsgTx{&tx1},
 	})
 
-	err = txConfNotifier.ConnectTip(
+	err = tcn.ConnectTip(
 		block1.Hash(), tx1Height, block1.Transactions(),
 	)
 	if err != nil {
@@ -772,7 +772,7 @@ func TestTxConfHeightHintCache(t *testing.T) {
 		Transactions: []*wire.MsgTx{&tx2},
 	})
 
-	err = txConfNotifier.ConnectTip(
+	err = tcn.ConnectTip(
 		block2.Hash(), tx2Height, block2.Transactions(),
 	)
 	if err != nil {
@@ -800,7 +800,7 @@ func TestTxConfHeightHintCache(t *testing.T) {
 
 	// Now, we'll attempt do disconnect the last block in order to simulate
 	// a chain reorg.
-	if err := txConfNotifier.DisconnectTip(tx2Height); err != nil {
+	if err := tcn.DisconnectTip(tx2Height); err != nil {
 		t.Fatalf("Failed to disconnect block: %v", err)
 	}
 
@@ -824,7 +824,7 @@ func TestTxConfTearDown(t *testing.T) {
 	)
 
 	hintCache := newMockHintCache()
-	txConfNotifier := chainntnfs.NewTxConfNotifier(10, 100, hintCache)
+	tcn := chainntnfs.NewTxConfNotifier(10, 100, hintCache)
 
 	// Create the test transactions and register them with the
 	// TxConfNotifier to receive notifications.
@@ -834,7 +834,7 @@ func TestTxConfTearDown(t *testing.T) {
 		NumConfirmations: 1,
 		Event:            chainntnfs.NewConfirmationEvent(1),
 	}
-	if err := txConfNotifier.Register(&ntfn1); err != nil {
+	if err := tcn.Register(&ntfn1); err != nil {
 		t.Fatalf("unable to register ntfn: %v", err)
 	}
 
@@ -844,7 +844,7 @@ func TestTxConfTearDown(t *testing.T) {
 		NumConfirmations: 2,
 		Event:            chainntnfs.NewConfirmationEvent(2),
 	}
-	if err := txConfNotifier.Register(&ntfn2); err != nil {
+	if err := tcn.Register(&ntfn2); err != nil {
 		t.Fatalf("unable to register ntfn: %v", err)
 	}
 
@@ -854,7 +854,7 @@ func TestTxConfTearDown(t *testing.T) {
 		Transactions: []*wire.MsgTx{&tx1, &tx2},
 	})
 
-	err := txConfNotifier.ConnectTip(block.Hash(), 11, block.Transactions())
+	err := tcn.ConnectTip(block.Hash(), 11, block.Transactions())
 	if err != nil {
 		t.Fatalf("Failed to connect block: %v", err)
 	}
@@ -890,7 +890,7 @@ func TestTxConfTearDown(t *testing.T) {
 	// The notification channels should be closed for notifications that
 	// have not been dispatched yet, so we should not expect to receive any
 	// more updates.
-	txConfNotifier.TearDown()
+	tcn.TearDown()
 
 	// tx1 should not receive any more updates because it has already been
 	// confirmed and the TxConfNotifier has been shut down.

--- a/chainntnfs/txconfnotifier_test.go
+++ b/chainntnfs/txconfnotifier_test.go
@@ -128,7 +128,6 @@ func TestTxConfFutureDispatch(t *testing.T) {
 		t.Fatalf("unable to register ntfn: %v", err)
 	}
 
-	err := tcn.UpdateConfDetails(*ntfn1.TxID, 0, nil)
 	tx2Hash := tx2.TxHash()
 	ntfn2 := chainntnfs.ConfNtfn{
 		TxID:             &tx2Hash,
@@ -163,7 +162,7 @@ func TestTxConfFutureDispatch(t *testing.T) {
 		Transactions: []*wire.MsgTx{&tx1, &tx2, &tx3},
 	})
 
-	err = tcn.ConnectTip(
+	err := tcn.ConnectTip(
 		block1.Hash(), 11, block1.Transactions(),
 	)
 	if err != nil {
@@ -453,6 +452,10 @@ func TestTxConfChainReorg(t *testing.T) {
 		t.Fatalf("unable to register ntfn: %v", err)
 	}
 
+	if err := tcn.UpdateConfDetails(*ntfn1.TxID, 0, nil); err != nil {
+		t.Fatalf("unable to deliver conf details: %v", err)
+	}
+
 	// Tx 2 will be confirmed in block 10 and requires 1 conf.
 	tx2Hash := tx2.TxHash()
 	ntfn2 := chainntnfs.ConfNtfn{
@@ -464,6 +467,10 @@ func TestTxConfChainReorg(t *testing.T) {
 		t.Fatalf("unable to register ntfn: %v", err)
 	}
 
+	if err := tcn.UpdateConfDetails(*ntfn2.TxID, 0, nil); err != nil {
+		t.Fatalf("unable to deliver conf details: %v", err)
+	}
+
 	// Tx 3 will be confirmed in block 10 and requires 2 confs.
 	tx3Hash := tx3.TxHash()
 	ntfn3 := chainntnfs.ConfNtfn{
@@ -473,6 +480,10 @@ func TestTxConfChainReorg(t *testing.T) {
 	}
 	if err := tcn.Register(&ntfn3); err != nil {
 		t.Fatalf("unable to register ntfn: %v", err)
+	}
+
+	if err := tcn.UpdateConfDetails(*ntfn3.TxID, 0, nil); err != nil {
+		t.Fatalf("unable to deliver conf details: %v", err)
 	}
 
 	// Sync chain to block 10. Txs 1 & 2 should be confirmed.
@@ -896,6 +907,9 @@ func TestTxConfTearDown(t *testing.T) {
 	if err := tcn.Register(&ntfn1); err != nil {
 		t.Fatalf("unable to register ntfn: %v", err)
 	}
+	if err := tcn.UpdateConfDetails(*ntfn1.TxID, 0, nil); err != nil {
+		t.Fatalf("unable to update conf details: %v", err)
+	}
 
 	tx2Hash := tx2.TxHash()
 	ntfn2 := chainntnfs.ConfNtfn{
@@ -905,6 +919,9 @@ func TestTxConfTearDown(t *testing.T) {
 	}
 	if err := tcn.Register(&ntfn2); err != nil {
 		t.Fatalf("unable to register ntfn: %v", err)
+	}
+	if err := tcn.UpdateConfDetails(*ntfn2.TxID, 0, nil); err != nil {
+		t.Fatalf("unable to update conf details: %v", err)
 	}
 
 	// Include the transactions in a block and add it to the TxConfNotifier.

--- a/chainntnfs/txconfnotifier_test.go
+++ b/chainntnfs/txconfnotifier_test.go
@@ -320,7 +320,7 @@ func TestTxConfHistoricalDispatch(t *testing.T) {
 		BlockHeight: 9,
 		TxIndex:     1,
 	}
-	err := tcn.UpdateConfDetails(tx1Hash, ntfn1.ConfID, &txConf1)
+	err := tcn.UpdateConfDetails(tx1Hash, &txConf1)
 	if err != nil {
 		t.Fatalf("unable to update conf details: %v", err)
 	}
@@ -353,7 +353,7 @@ func TestTxConfHistoricalDispatch(t *testing.T) {
 		BlockHeight: 9,
 		TxIndex:     2,
 	}
-	err = tcn.UpdateConfDetails(tx2Hash, ntfn2.ConfID, &txConf2)
+	err = tcn.UpdateConfDetails(tx2Hash, &txConf2)
 	if err != nil {
 		t.Fatalf("unable to update conf details: %v", err)
 	}
@@ -452,7 +452,7 @@ func TestTxConfChainReorg(t *testing.T) {
 		t.Fatalf("unable to register ntfn: %v", err)
 	}
 
-	if err := tcn.UpdateConfDetails(*ntfn1.TxID, 0, nil); err != nil {
+	if err := tcn.UpdateConfDetails(*ntfn1.TxID, nil); err != nil {
 		t.Fatalf("unable to deliver conf details: %v", err)
 	}
 
@@ -463,12 +463,11 @@ func TestTxConfChainReorg(t *testing.T) {
 		NumConfirmations: tx2NumConfs,
 		Event:            chainntnfs.NewConfirmationEvent(tx2NumConfs),
 	}
-	if _, _, err := tcn.Register(&ntfn2); err != nil {
 	if _, err := tcn.Register(&ntfn2); err != nil {
 		t.Fatalf("unable to register ntfn: %v", err)
 	}
 
-	if err := tcn.UpdateConfDetails(*ntfn2.TxID, 0, nil); err != nil {
+	if err := tcn.UpdateConfDetails(*ntfn2.TxID, nil); err != nil {
 		t.Fatalf("unable to deliver conf details: %v", err)
 	}
 
@@ -483,7 +482,7 @@ func TestTxConfChainReorg(t *testing.T) {
 		t.Fatalf("unable to register ntfn: %v", err)
 	}
 
-	if err := tcn.UpdateConfDetails(*ntfn3.TxID, 0, nil); err != nil {
+	if err := tcn.UpdateConfDetails(*ntfn3.TxID, nil); err != nil {
 		t.Fatalf("unable to deliver conf details: %v", err)
 	}
 
@@ -782,10 +781,10 @@ func TestTxConfHeightHintCache(t *testing.T) {
 
 	// Now, update the conf details reporting that the neither txn was found
 	// in the historical dispatch.
-	if err := tcn.UpdateConfDetails(tx1Hash, 0, nil); err != nil {
+	if err := tcn.UpdateConfDetails(tx1Hash, nil); err != nil {
 		t.Fatalf("unable to update conf details: %v", err)
 	}
-	if err := tcn.UpdateConfDetails(tx2Hash, 0, nil); err != nil {
+	if err := tcn.UpdateConfDetails(tx2Hash, nil); err != nil {
 		t.Fatalf("unable to update conf details: %v", err)
 	}
 
@@ -908,7 +907,7 @@ func TestTxConfTearDown(t *testing.T) {
 	if _, err := tcn.Register(&ntfn1); err != nil {
 		t.Fatalf("unable to register ntfn: %v", err)
 	}
-	if err := tcn.UpdateConfDetails(*ntfn1.TxID, 0, nil); err != nil {
+	if err := tcn.UpdateConfDetails(*ntfn1.TxID, nil); err != nil {
 		t.Fatalf("unable to update conf details: %v", err)
 	}
 
@@ -921,7 +920,7 @@ func TestTxConfTearDown(t *testing.T) {
 	if _, err := tcn.Register(&ntfn2); err != nil {
 		t.Fatalf("unable to register ntfn: %v", err)
 	}
-	if err := tcn.UpdateConfDetails(*ntfn2.TxID, 0, nil); err != nil {
+	if err := tcn.UpdateConfDetails(*ntfn2.TxID, nil); err != nil {
 		t.Fatalf("unable to update conf details: %v", err)
 	}
 


### PR DESCRIPTION
In this PR, we modify the `TxConfNotifier` to isolate confirmation notifications while a historical dispatch is being processed. The purpose of this is to segment which notifications should have their height hints updated in the cache. During a historical rescan, we don't yet know if the txn is in the chain, so we shouldn't continue to update its height hint until after finishing the rescan. Once the rescan finishes, the notification is grouped along with all other notifications at tip so that their height hints can progress as blocks are added.

This PR also introduces:
 - a reorg safety delta to height hints, currently 144 blocks
   - with the recent LRU cache added to neutrino, this shouldn't result too much unnecessary network I/O
   - the height hint is still clamped to whatever the client initial prescribes, so initial registration doesn't take a hit either
 - moves querying of confirmation height hints into the `TxConfNotifier`
 - reorders the persistence/spend-notification dispatch to improve external consistency

In a follow PR, we will do the same for spend notifications.

This PR depends on #1951, which contains the first four commits