### PR TITLE
build: up golang.org/x/crypto to the go1.11 branch

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -330,7 +330,7 @@
   revision = "1efa31f08b9333f1bd4882d61f9d668a70cd902e"
 
 [[projects]]
-  digest = "1:61cf25ac3ac0c8c50959666ddf732a396fbc445570be051c8b9795c8a087fde7"
+  digest = "1:381cef09c1e5c31eee50d98d7b7d921856c1a5bebf6932138cce77367252bdbf"
   name = "golang.org/x/crypto"
   packages = [
     "blake2b",
@@ -338,6 +338,7 @@
     "curve25519",
     "hkdf",
     "internal/chacha20",
+    "internal/subtle",
     "nacl/box",
     "nacl/secretbox",
     "pbkdf2",
@@ -349,7 +350,7 @@
     "ssh/terminal",
   ]
   pruneopts = "UT"
-  revision = "49796115aa4b964c318aad4f3084fdb41e9aa067"
+  revision = "56440b844dfe139a8ac053f4ecac0b20b79058f4"
 
 [[projects]]
   digest = "1:0764abb1e99bb977d1b9f320d02859d4a737252da3e1fd233c4ae0f9522e7446"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -84,7 +84,7 @@
 
 [[constraint]]
   name = "golang.org/x/crypto"
-  revision = "49796115aa4b964c318aad4f3084fdb41e9aa067"
+  revision = "56440b844dfe139a8ac053f4ecac0b20b79058f4"
 
 [[constraint]]
   name = "golang.org/x/net"


### PR DESCRIPTION
The build now is fine:

```
[0:17:52] i:maurycy:~/go/src/github.com/lightningnetwork/lnd> make clean && make
 Cleaning source.
rm -f ./lnd ./lncli
rm -f -r ./vendor
 Compiling dependencies.
dep ensure -v
(1/42) Wrote gopkg.in/macaroon.v2@bed2a428da6e56d950bed5b41fcbae3141e5b0d0
(2/42) Wrote github.com/jackpal/go-nat-pmp@28a68d0c24adce1da43f8df6a57340909ecd7fdd
(3/42) Wrote github.com/NebulousLabs/fastrand@master
(4/42) Wrote github.com/btcsuite/btcwallet@7b84dc25a61634c450d21ec7f47d5e916eb88fdb
(5/42) Wrote github.com/Yawning/aez@4dad034d9db2caec23fb8f69b9160ae16f8d46a3
(6/42) Wrote github.com/coreos/bbolt@4f5275f4ebbf6fe7cb772de987fa96ee674460a7
(7/42) Wrote github.com/juju/loggo@master
(8/42) Wrote github.com/jrick/logrotate@a93b200c26cbae3bb09dd0dc2c7c7fe1468a034a
(9/42) Wrote github.com/btcsuite/fastsha256@master
(10/42) Wrote git.schwanenlied.me/yawning/bsaes.git@master
(11/42) Wrote github.com/btcsuite/go-socks@master
(12/42) Wrote github.com/rogpeppe/fastuuid@master
(13/42) Wrote github.com/jessevdk/go-flags@f88afde2fa19a30cf50ba4b05b3d13bc6bae3079
(14/42) Wrote github.com/btcsuite/websocket@master
(15/42) Wrote github.com/NebulousLabs/go-upnp@29b680b06c82d044ebea91bf3069038eb562df2a
(16/42) Wrote github.com/kkdai/bstream@f391b8402d23024e7c0f624b31267a89998fca95
(17/42) Wrote github.com/btcsuite/golangcrypto@master
(18/42) Wrote github.com/aead/chacha20@master
(19/42) Wrote github.com/davecgh/go-spew@8991bc29aa16c548c550c7ff78260e27b9ab7c73
(20/42) Wrote github.com/lightninglabs/gozmq@master
(21/42) Wrote github.com/aead/siphash@master
(22/42) Wrote github.com/lightninglabs/neutrino@166fe699d5964581d24e6bfff0aa329cfb6a8bc9
(23/42) Wrote github.com/go-errors/errors@a6af135bd4e28680facf08a3d206b454abc877a4
(24/42) Wrote github.com/lightningnetwork/lightning-onion@ac4d9da8f1d67c95f1fafdc65e1a4902d6f5a940
(25/42) Wrote github.com/btcsuite/btclog@84c8d2346e9fc8c7b947e243b9c24e6df9fd206a
(26/42) Wrote github.com/golang/protobuf@bbd03ef6da3a115852eaf24c8a1c46aeb39aa175
(27/42) Wrote github.com/btcsuite/btcutil@ab6388e0c60ae4834a1f57511e20c17b5f78be4b
(28/42) Wrote github.com/grpc-ecosystem/grpc-gateway@f2862b476edcef83412c7af8687c9cd8e4097c0f
(29/42) Wrote github.com/miekg/dns@79bfde677fa81ff8d27c4330c35bda075d360641
(30/42) Wrote github.com/jackpal/gateway@v1.0.4
(31/42) Wrote github.com/tv42/zbase32@501572607d0273fc75b3b261fa4904d63f6ffa0e
(32/42) Wrote gopkg.in/errgo.v1@v1
(33/42) Wrote github.com/urfave/cli@1efa31f08b9333f1bd4882d61f9d668a70cd902e
(34/42) Wrote github.com/btcsuite/btcd@79e00513b1011888b1e675157ab89f527f901cae
(35/42) Wrote google.golang.org/grpc@b3ddf786825de56a4178401b7e174ee332173b66
(36/42) Wrote gopkg.in/macaroon-bakery.v2@94012773d2874a067572bd16d7d11ae02968b47b
(37/42) Wrote github.com/ltcsuite/ltcd@cdab10132e8c6e4a3ffd112dba54791946d28906
(38/42) Wrote golang.org/x/crypto@56440b844dfe139a8ac053f4ecac0b20b79058f4
(39/42) Wrote google.golang.org/genproto@df60624c1e9b9d2973e889c7a1cff73155da81c4
(40/42) Wrote golang.org/x/sys@master
(41/42) Wrote golang.org/x/net@ae89d30ce0c63142b652837da33d782e2b0a9b25
(42/42) Wrote golang.org/x/text@v0.3.0
 Building debug lnd and lncli.
go build -v -tags=debug -o lnd-debug -ldflags "-X main.Commit=5daa4f1c0ce2d56f7003370e07ed33504bdd7468" github.com/lightningnetwork/lnd
go build -v -tags=debug -o lncli-debug -ldflags "-X main.Commit=5daa4f1c0ce2d56f7003370e07ed33504bdd7468" github.com/lightningnetwork/lnd/cmd/lncli
```

The `56440b844dfe139a8ac053f4ecac0b20b79058f4` `golang.org/x/crypto`'s commit is marked as the `origin/release-branch.go1.11` branch, hence used.

ref #1789