### PR TITLE
change lightning-api repo link redirect

### DIFF
--- a/lnrpc/rpc.proto
+++ b/lnrpc/rpc.proto
@@ -22,7 +22,7 @@ package lnrpc;
  * 
  * More information on how exactly the gRPC documentation is generated from
  * this proto file can be found here:
- * https://github.com/MaxFangX/lightning-api
+ * https://github.com/lightninglabs/lightning-api
  */
 
 // The WalletUnlocker service is used to set up a wallet password for


### PR DESCRIPTION
I found this link that serves a 301 to a newer repository own by Lightning Labs. I guess it makes change to change it in the proto file.