### PR TITLE
autopilot: modify the graph interface to return raw bytes for node pubkeys, not entire key

### DIFF
--- a/autopilot/graph.go
+++ b/autopilot/graph.go
@@ -59,12 +59,12 @@ type dbNode struct {
 var _ Node = (*dbNode)(nil)
 
 // PubKey is the identity public key of the node. This will be used to attempt
-// to target a node for channel opening by the main autopilot agent.
+// to target a node for channel opening by the main autopilot agent. The key
+// will be returned in serialized compressed format.
 //
 // NOTE: Part of the autopilot.Node interface.
-func (d dbNode) PubKey() *btcec.PublicKey {
-	pubKey, _ := d.node.PubKey()
-	return pubKey
+func (d dbNode) PubKey() [33]byte {
+	return d.node.PubKeyBytes
 }
 
 // Addrs returns a slice of publicly reachable public TCP addresses that the
@@ -406,8 +406,11 @@ var _ Node = (*memNode)(nil)
 // to target a node for channel opening by the main autopilot agent.
 //
 // NOTE: Part of the autopilot.Node interface.
-func (m memNode) PubKey() *btcec.PublicKey {
-	return m.pub
+func (m memNode) PubKey() [33]byte {
+	var n [33]byte
+	copy(n[:], m.pub.SerializeCompressed())
+
+	return n
 }
 
 // Addrs returns a slice of publicly reachable public TCP addresses that the

--- a/autopilot/interface.go
+++ b/autopilot/interface.go
@@ -17,8 +17,8 @@ import (
 type Node interface {
 	// PubKey is the identity public key of the node. This will be used to
 	// attempt to target a node for channel opening by the main autopilot
-	// agent.
-	PubKey() *btcec.PublicKey
+	// agent. The key will be returned in serialized compressed format.
+	PubKey() [33]byte
 
 	// Addrs returns a slice of publicly reachable public TCP addresses
 	// that the peer is known to be listening on.

--- a/autopilot/prefattach_test.go
+++ b/autopilot/prefattach_test.go
@@ -1,6 +1,7 @@
 package autopilot
 
 import (
+	"bytes"
 	"io/ioutil"
 	"os"
 	"testing"
@@ -344,11 +345,14 @@ func TestConstrainedPrefAttachmentSelectTwoVertexes(t *testing.T) {
 			// The node attached to should be amongst the two edges
 			// created above.
 			for _, directive := range directives {
+				edge1Pub := edge1.Peer.PubKey()
+				edge2Pub := edge2.Peer.PubKey()
+
 				switch {
-				case directive.PeerKey.IsEqual(edge1.Peer.PubKey()):
-				case directive.PeerKey.IsEqual(edge2.Peer.PubKey()):
+				case bytes.Equal(directive.PeerKey.SerializeCompressed(), edge1Pub[:]):
+				case bytes.Equal(directive.PeerKey.SerializeCompressed(), edge2Pub[:]):
 				default:
-					t1.Fatalf("attache to unknown node: %x",
+					t1.Fatalf("attached to unknown node: %x",
 						directive.PeerKey.SerializeCompressed())
 				}
 
@@ -472,8 +476,15 @@ func TestConstrainedPrefAttachmentSelectGreedyAllocation(t *testing.T) {
 			if err != nil {
 				t1.Fatalf("unable to create channel: %v", err)
 			}
+			peerPubBytes := edge1.Peer.PubKey()
+			peerPub, err := btcec.ParsePubKey(
+				peerPubBytes[:], btcec.S256(),
+			)
+			if err != nil {
+				t.Fatalf("unable to parse pubkey: %v", err)
+			}
 			_, _, err = graph.addRandChannel(
-				edge1.Peer.PubKey(), nil, chanCapacity,
+				peerPub, nil, chanCapacity,
 			)
 			if err != nil {
 				t1.Fatalf("unable to create channel: %v", err)


### PR DESCRIPTION

In this PR, we modify the Node interface to return a set of raw
bytes, rather than the full pubkey struct. We do this as within the
package, commonly we only require the pubkey bytes for fingerprinting
purposes. Before this commit, we were forced to _always_ decompress the
pubkey which can be expensive done thousands of times a second.

This was noticed while profiling a node that was running with relatively high autopilot settings: 
```
         .          .    176:           if err := g.ForEachNode(func(node Node) error {
      30ms     14.66s    177:                   nID := NewNodeID(node.PubKey())
```
![screen shot 2018-08-29 at 3 47 54 pm](https://user-images.githubusercontent.com/998190/44819778-edf35900-aba2-11e8-8ab9-bddf14d77679.png)
