### PR TITLE
autopilot: prevent duplicate conns to same peer

### DIFF
--- a/autopilot/agent_test.go
+++ b/autopilot/agent_test.go
@@ -321,7 +321,7 @@ func TestAgentChannelFailureSignal(t *testing.T) {
 	// request attachment directives, return a fake so the agent will
 	// attempt to open a channel.
 	var fakeDirective = AttachmentDirective{
-		PeerKey: self,
+		NodeKey: self,
 		NodeID:  NewNodeID(self),
 		ChanAmt: btcutil.SatoshiPerBitcoin,
 		Addrs: []net.Addr{
@@ -659,7 +659,7 @@ func TestAgentImmediateAttach(t *testing.T) {
 		}
 		nodeID := NewNodeID(pub)
 		directives[i] = AttachmentDirective{
-			PeerKey: pub,
+			NodeKey: pub,
 			NodeID:  nodeID,
 			ChanAmt: btcutil.SatoshiPerBitcoin,
 			Addrs: []net.Addr{
@@ -790,7 +790,7 @@ func TestAgentPrivateChannels(t *testing.T) {
 			t.Fatalf("unable to generate key: %v", err)
 		}
 		directives[i] = AttachmentDirective{
-			PeerKey: pub,
+			NodeKey: pub,
 			NodeID:  NewNodeID(pub),
 			ChanAmt: btcutil.SatoshiPerBitcoin,
 			Addrs: []net.Addr{
@@ -911,7 +911,7 @@ func TestAgentPendingChannelState(t *testing.T) {
 	}
 	nodeID := NewNodeID(nodeKey)
 	nodeDirective := AttachmentDirective{
-		PeerKey: nodeKey,
+		NodeKey: nodeKey,
 		NodeID:  nodeID,
 		ChanAmt: 0.5 * btcutil.SatoshiPerBitcoin,
 		Addrs: []net.Addr{
@@ -1273,7 +1273,7 @@ func TestAgentSkipPendingConns(t *testing.T) {
 		t.Fatalf("unable to generate key: %v", err)
 	}
 	nodeDirective := AttachmentDirective{
-		PeerKey: nodeKey,
+		NodeKey: nodeKey,
 		NodeID:  NewNodeID(nodeKey),
 		ChanAmt: 0.5 * btcutil.SatoshiPerBitcoin,
 		Addrs: []net.Addr{

--- a/autopilot/interface.go
+++ b/autopilot/interface.go
@@ -85,10 +85,10 @@ type ChannelGraph interface {
 // AttachmentHeuristic. It details to which node a channel should be created
 // to, and also the parameters which should be used in the channel creation.
 type AttachmentDirective struct {
-	// PeerKey is the target node for this attachment directive. It can be
+	// NodeKey is the target node for this attachment directive. It can be
 	// identified by its public key, and therefore can be used along with
 	// a ChannelOpener implementation to execute the directive.
-	PeerKey *btcec.PublicKey
+	NodeKey *btcec.PublicKey
 
 	// NodeID is the serialized compressed pubkey of the target node.
 	NodeID NodeID

--- a/autopilot/interface.go
+++ b/autopilot/interface.go
@@ -90,6 +90,9 @@ type AttachmentDirective struct {
 	// a ChannelOpener implementation to execute the directive.
 	PeerKey *btcec.PublicKey
 
+	// NodeID is the serialized compressed pubkey of the target node.
+	NodeID NodeID
+
 	// ChanAmt is the size of the channel that should be opened, expressed
 	// in satoshis.
 	ChanAmt btcutil.Amount

--- a/autopilot/prefattach.go
+++ b/autopilot/prefattach.go
@@ -245,7 +245,7 @@ func (p *ConstrainedPrefAttachment) Select(self *btcec.PublicKey, g ChannelGraph
 		}
 		directives = append(directives, AttachmentDirective{
 			// TODO(roasbeef): need curve?
-			PeerKey: &btcec.PublicKey{
+			NodeKey: &btcec.PublicKey{
 				X: pub.X,
 				Y: pub.Y,
 			},

--- a/autopilot/prefattach.go
+++ b/autopilot/prefattach.go
@@ -249,7 +249,8 @@ func (p *ConstrainedPrefAttachment) Select(self *btcec.PublicKey, g ChannelGraph
 				X: pub.X,
 				Y: pub.Y,
 			},
-			Addrs: selectedNode.Addrs(),
+			NodeID: NewNodeID(pub),
+			Addrs:  selectedNode.Addrs(),
 		})
 
 		// With the node selected, we'll add it to the set of visited

--- a/autopilot/prefattach_test.go
+++ b/autopilot/prefattach_test.go
@@ -349,11 +349,11 @@ func TestConstrainedPrefAttachmentSelectTwoVertexes(t *testing.T) {
 				edge2Pub := edge2.Peer.PubKey()
 
 				switch {
-				case bytes.Equal(directive.PeerKey.SerializeCompressed(), edge1Pub[:]):
-				case bytes.Equal(directive.PeerKey.SerializeCompressed(), edge2Pub[:]):
+				case bytes.Equal(directive.NodeKey.SerializeCompressed(), edge1Pub[:]):
+				case bytes.Equal(directive.NodeKey.SerializeCompressed(), edge2Pub[:]):
 				default:
 					t1.Fatalf("attached to unknown node: %x",
-						directive.PeerKey.SerializeCompressed())
+						directive.NodeKey.SerializeCompressed())
 				}
 
 				// As the number of funds available exceed the
@@ -634,8 +634,8 @@ func TestConstrainedPrefAttachmentSelectSkipNodes(t *testing.T) {
 			// We'll simulate a channel update by adding the nodes
 			// we just establish channel with the to set of nodes
 			// to be skipped.
-			skipNodes[NewNodeID(directives[0].PeerKey)] = struct{}{}
-			skipNodes[NewNodeID(directives[1].PeerKey)] = struct{}{}
+			skipNodes[NewNodeID(directives[0].NodeKey)] = struct{}{}
+			skipNodes[NewNodeID(directives[1].NodeKey)] = struct{}{}
 
 			// If we attempt to make a call to the Select function,
 			// without providing any new information, then we


### PR DESCRIPTION
This PR modifies the autopilot agent to track
all pending connection requests, and forgo further
attempts if a connection is already present.
Previously, the agent would try and establish
hundreds of requests to a node, especially if the
connections were timing out and not returning.

This resulted in an OOM OMM when cranking up
maxchannels to 200, since there would be close
to 10k pending connections before the program was
terminated. The issue was compounded by periodic
batch timeouts, causing autopilot to try and
process thousands of triggers for failing
connections to the same peer.

With these fixes, autopilot will skip nodes that we
are trying to connect to during heuristic selection.
The CPU and memory utilization have been significantly
reduced as a result.