### PR TITLE
channeldb: properly prune stale entries within edge update index

### DIFF
--- a/channeldb/db.go
+++ b/channeldb/db.go
@@ -74,6 +74,12 @@ var (
 			number:    5,
 			migration: paymentStatusesMigration,
 		},
+		{
+			// The DB version that properly prunes stale entries
+			// from the edge update index.
+			number:    6,
+			migration: migratePruneEdgeUpdateIndex,
+		},
 	}
 
 	// Big endian is the preferred byte order, due to cursor scans over

--- a/channeldb/graph.go
+++ b/channeldb/graph.go
@@ -1617,14 +1617,18 @@ func (c *ChannelGraph) UpdateEdgePolicy(edge *ChannelEdgePolicy) error {
 		if err != nil {
 			return err
 		}
+		nodes, err := tx.CreateBucketIfNotExists(nodeBucket)
+		if err != nil {
+			return err
+		}
 
-		return updateEdgePolicy(edges, edgeIndex, edge)
+		return updateEdgePolicy(edges, edgeIndex, nodes, edge)
 	})
 }
 
 // updateEdgePolicy attempts to update an edge's policy within the relevant
 // buckets using an existing database transaction.
-func updateEdgePolicy(edges, edgeIndex *bolt.Bucket,
+func updateEdgePolicy(edges, edgeIndex, nodes *bolt.Bucket,
 	edge *ChannelEdgePolicy) error {
 
 	// Create the channelID key be converting the channel ID
@@ -1652,7 +1656,7 @@ func updateEdgePolicy(edges, edgeIndex *bolt.Bucket,
 
 	// Finally, with the direction of the edge being updated
 	// identified, we update the on-disk edge representation.
-	return putChanEdgePolicy(edges, edge, fromNode, toNode)
+	return putChanEdgePolicy(edges, nodes, edge, fromNode, toNode)
 }
 
 // LightningNode represents an individual vertex/node within the channel graph.
@@ -2949,7 +2953,9 @@ func deserializeChanEdgeInfo(r io.Reader) (ChannelEdgeInfo, error) {
 	return edgeInfo, nil
 }
 
-func putChanEdgePolicy(edges *bolt.Bucket, edge *ChannelEdgePolicy, from, to []byte) error {
+func putChanEdgePolicy(edges, nodes *bolt.Bucket, edge *ChannelEdgePolicy,
+	from, to []byte) error {
+
 	var edgeKey [33 + 8]byte
 	copy(edgeKey[:], from)
 	byteOrder.PutUint64(edgeKey[33:], edge.ChannelID)
@@ -3012,17 +3018,20 @@ func putChanEdgePolicy(edges *bolt.Bucket, edge *ChannelEdgePolicy, from, to []b
 
 		// In order to delete the old entry, we'll need to obtain the
 		// *prior* update time in order to delete it. To do this, we'll
-		// create an offset to slice in. Starting backwards, we'll
-		// create an offset than puts us right after the flags
-		// variable:
-		//
-		//  * pubkeySize + fee+policySize + timelockSize + flagSize
-		updateEnd := 33 + (8 * 3) + 2 + 1
-		updateStart := updateEnd - 8
-		oldUpdateTime := edgeBytes[updateStart:updateEnd]
+		// need to deserialize the existing policy within the database
+		// (now outdated by the new one), and delete its corresponding
+		// entry within the update index.
+		oldEdgePolicy, err := deserializeChanEdgePolicy(
+			bytes.NewReader(edgeBytes), nodes,
+		)
+		if err != nil {
+			return err
+		}
+
+		oldUpdateTime := uint64(oldEdgePolicy.LastUpdate.Unix())
 
 		var oldIndexKey [8 + 8]byte
-		copy(oldIndexKey[:], oldUpdateTime)
+		byteOrder.PutUint64(oldIndexKey[:8], oldUpdateTime)
 		byteOrder.PutUint64(oldIndexKey[8:], edge.ChannelID)
 
 		if err := updateIndex.Delete(oldIndexKey[:]); err != nil {

--- a/channeldb/graph.go
+++ b/channeldb/graph.go
@@ -1644,9 +1644,9 @@ func updateEdgePolicy(edges, edgeIndex *bolt.Bucket,
 	var fromNode, toNode []byte
 	if edge.Flags&lnwire.ChanUpdateDirection == 0 {
 		fromNode = nodeInfo[:33]
-		toNode = nodeInfo[33:67]
+		toNode = nodeInfo[33:66]
 	} else {
-		fromNode = nodeInfo[33:67]
+		fromNode = nodeInfo[33:66]
 		toNode = nodeInfo[:33]
 	}
 
@@ -3103,7 +3103,7 @@ func fetchChanEdgePolicies(edgeIndex *bolt.Bucket, edges *bolt.Bucket,
 
 	// Similarly, the second node is contained within the latter
 	// half of the edge information.
-	node2Pub := edgeInfo[33:67]
+	node2Pub := edgeInfo[33:66]
 	edge2, err := fetchChanEdgePolicy(edges, chanID, node2Pub, nodes)
 	if err != nil {
 		return nil, nil, err

--- a/channeldb/graph.go
+++ b/channeldb/graph.go
@@ -1222,7 +1222,9 @@ func (c *ChannelGraph) ChanUpdatesInHorizon(startTime, endTime time.Time) ([]Cha
 			// First, we'll fetch the static edge information.
 			edgeInfo, err := fetchChanEdgeInfo(edgeIndex, chanID)
 			if err != nil {
-				return err
+				chanID := byteOrder.Uint64(chanID)
+				return fmt.Errorf("unable to fetch info for "+
+					"edge with chan_id=%v: %v", chanID, err)
 			}
 			edgeInfo.db = c.db
 
@@ -1232,7 +1234,10 @@ func (c *ChannelGraph) ChanUpdatesInHorizon(startTime, endTime time.Time) ([]Cha
 				edgeIndex, edges, nodes, chanID, c.db,
 			)
 			if err != nil {
-				return err
+				chanID := byteOrder.Uint64(chanID)
+				return fmt.Errorf("unable to fetch policies "+
+					"for edge with chan_id=%v: %v", chanID,
+					err)
 			}
 
 			// Finally, we'll collate this edge with the rest of

--- a/channeldb/graph_test.go
+++ b/channeldb/graph_test.go
@@ -2178,6 +2178,26 @@ func TestChannelEdgePruningUpdateIndexDeletion(t *testing.T) {
 		uint64(edge2.LastUpdate.Unix()),
 	)
 
+	// Now, we'll update the edge policies to ensure the old timestamps are
+	// removed from the update index.
+	edge1.Flags = 2
+	edge1.LastUpdate = time.Now()
+	if err := graph.UpdateEdgePolicy(edge1); err != nil {
+		t.Fatalf("unable to update edge: %v", err)
+	}
+	edge2.Flags = 3
+	edge2.LastUpdate = edge1.LastUpdate.Add(time.Hour)
+	if err := graph.UpdateEdgePolicy(edge2); err != nil {
+		t.Fatalf("unable to update edge: %v", err)
+	}
+
+	// With the policies updated, we should now be able to find their
+	// updated entries within the update index.
+	checkIndexTimestamps(
+		uint64(edge1.LastUpdate.Unix()),
+		uint64(edge2.LastUpdate.Unix()),
+	)
+
 	// Now we'll prune the graph, removing the edges, and also the update
 	// index entries from the database all together.
 	var blockHash chainhash.Hash


### PR DESCRIPTION
In this PR, we attempt to fix a number of issues with regards to the edge update index. To summarize, the edge update index is responsible for only storing the _latest_ update for each edge policy. When a new update arrives, we'd attempt to remove the old entry within the index before adding the new one. However, none of the entries were being removed due to some offset miscalculations. To remedy this, we correctly calculate each offset and add a database migration to properly prune all stale entries within the index.

This will also fix a number of issues with regards to gossip peer queries. Whenever a peer requested for channels within a time horizon, we'd end up sending them stale entries, causing them to attempt to fetch channel announcements for them, even though they no longer existed.