### PR TITLE
channeldb+discovery: ensure we store, validate and propagate announcements with opaque data

### DIFF
--- a/chan_series.go
+++ b/chan_series.go
@@ -159,13 +159,14 @@ func makeNodeAnn(n *channeldb.LightningNode) (*lnwire.NodeAnnouncement, error) {
 		return nil, err
 	}
 	return &lnwire.NodeAnnouncement{
-		Signature: wireSig,
-		Timestamp: uint32(n.LastUpdate.Unix()),
-		Addresses: n.Addresses,
-		NodeID:    n.PubKeyBytes,
-		Features:  n.Features.RawFeatureVector,
-		RGBColor:  n.Color,
-		Alias:     alias,
+		Signature:       wireSig,
+		Timestamp:       uint32(n.LastUpdate.Unix()),
+		Addresses:       n.Addresses,
+		NodeID:          n.PubKeyBytes,
+		Features:        n.Features.RawFeatureVector,
+		RGBColor:        n.Color,
+		Alias:           alias,
+		ExtraOpaqueData: n.ExtraOpaqueData,
 	}, nil
 }
 
@@ -277,6 +278,7 @@ func (c *chanSeries) FetchChanUpdates(chain chainhash.Hash,
 			HtlcMinimumMsat: e1.MinHTLC,
 			BaseFee:         uint32(e1.FeeBaseMSat),
 			FeeRate:         uint32(e1.FeeProportionalMillionths),
+			ExtraOpaqueData: e1.ExtraOpaqueData,
 		}
 		chanUpdate.Signature, err = lnwire.NewSigFromRawSignature(e1.SigBytes)
 		if err != nil {
@@ -295,6 +297,7 @@ func (c *chanSeries) FetchChanUpdates(chain chainhash.Hash,
 			HtlcMinimumMsat: e2.MinHTLC,
 			BaseFee:         uint32(e2.FeeBaseMSat),
 			FeeRate:         uint32(e2.FeeProportionalMillionths),
+			ExtraOpaqueData: e1.ExtraOpaqueData,
 		}
 		chanUpdate.Signature, err = lnwire.NewSigFromRawSignature(e2.SigBytes)
 		if err != nil {

--- a/channeldb/error.go
+++ b/channeldb/error.go
@@ -94,3 +94,13 @@ var (
 	// to the log not having any recorded events.
 	ErrNoForwardingEvents = fmt.Errorf("no recorded forwarding events")
 )
+
+// ErrTooManyExtraOpaqueBytes creates an error which should be returned if the
+// caller attempts to write an announcement message which bares too many extra
+// opaque bytes. We limit this value in order to ensure that we don't waste
+// disk space due to nodes unnecessarily padding out their announcements with
+// garbage data.
+func ErrTooManyExtraOpaqueBytes(numBytes int) error {
+	return fmt.Errorf("max allowed number of opaque bytes is %v, received "+
+		"%v bytes", MaxAllowedExtraOpaqueBytes, numBytes)
+}

--- a/channeldb/graph.go
+++ b/channeldb/graph.go
@@ -2860,7 +2860,10 @@ func deserializeLightningNode(r io.Reader) (LightningNode, error) {
 	node.ExtraOpaqueData, err = wire.ReadVarBytes(
 		r, 0, MaxAllowedExtraOpaqueBytes, "blob",
 	)
-	if err != nil && err != io.ErrUnexpectedEOF {
+	switch {
+	case err == io.ErrUnexpectedEOF:
+	case err == io.EOF:
+	case err != nil:
 		return LightningNode{}, err
 	}
 
@@ -3012,7 +3015,10 @@ func deserializeChanEdgeInfo(r io.Reader) (ChannelEdgeInfo, error) {
 	edgeInfo.ExtraOpaqueData, err = wire.ReadVarBytes(
 		r, 0, MaxAllowedExtraOpaqueBytes, "blob",
 	)
-	if err != nil && err != io.ErrUnexpectedEOF {
+	switch {
+	case err == io.ErrUnexpectedEOF:
+	case err == io.EOF:
+	case err != nil:
 		return ChannelEdgeInfo{}, err
 	}
 
@@ -3260,7 +3266,10 @@ func deserializeChanEdgePolicy(r io.Reader,
 	edge.ExtraOpaqueData, err = wire.ReadVarBytes(
 		r, 0, MaxAllowedExtraOpaqueBytes, "blob",
 	)
-	if err != nil && err != io.ErrUnexpectedEOF {
+	switch {
+	case err == io.ErrUnexpectedEOF:
+	case err == io.EOF:
+	case err != nil:
 		return nil, err
 	}
 

--- a/channeldb/graph_test.go
+++ b/channeldb/graph_test.go
@@ -87,6 +87,7 @@ func TestNodeInsertionAndDeletion(t *testing.T) {
 		Alias:                "kek",
 		Features:             testFeatures,
 		Addresses:            testAddrs,
+		ExtraOpaqueData:      []byte("extra new data"),
 		db:                   db,
 	}
 	copy(node.PubKeyBytes[:], testPub.SerializeCompressed())
@@ -614,6 +615,11 @@ func assertEdgeInfoEqual(t *testing.T, e1 *ChannelEdgeInfo,
 		t.Fatalf("capacity doesn't match: %v vs %v", e1.Capacity,
 			e2.Capacity)
 	}
+
+	if !bytes.Equal(e1.ExtraOpaqueData, e2.ExtraOpaqueData) {
+		t.Fatalf("extra data doesn't match: %v vs %v",
+			e2.ExtraOpaqueData, e2.ExtraOpaqueData)
+	}
 }
 
 func TestEdgeInfoUpdates(t *testing.T) {
@@ -675,8 +681,9 @@ func TestEdgeInfoUpdates(t *testing.T) {
 			BitcoinSig1Bytes: testSig.Serialize(),
 			BitcoinSig2Bytes: testSig.Serialize(),
 		},
-		ChannelPoint: outpoint,
-		Capacity:     1000,
+		ChannelPoint:    outpoint,
+		Capacity:        1000,
+		ExtraOpaqueData: []byte("new unknown feature"),
 	}
 	copy(edgeInfo.NodeKey1Bytes[:], firstNode.PubKeyBytes[:])
 	copy(edgeInfo.NodeKey2Bytes[:], secondNode.PubKeyBytes[:])
@@ -697,8 +704,9 @@ func TestEdgeInfoUpdates(t *testing.T) {
 		MinHTLC:                   2342135,
 		FeeBaseMSat:               4352345,
 		FeeProportionalMillionths: 3452352,
-		Node: secondNode,
-		db:   db,
+		Node:            secondNode,
+		ExtraOpaqueData: []byte("new unknown feature2"),
+		db:              db,
 	}
 	edge2 := &ChannelEdgePolicy{
 		SigBytes:                  testSig.Serialize(),
@@ -709,8 +717,9 @@ func TestEdgeInfoUpdates(t *testing.T) {
 		MinHTLC:                   2342135,
 		FeeBaseMSat:               4352345,
 		FeeProportionalMillionths: 90392423,
-		Node: firstNode,
-		db:   db,
+		Node:            firstNode,
+		ExtraOpaqueData: []byte("new unknown feature1"),
+		db:              db,
 	}
 
 	// Next, insert both nodes into the database, they should both be
@@ -2460,6 +2469,10 @@ func compareNodes(a, b *LightningNode) error {
 		return fmt.Errorf("HaveNodeAnnouncement doesn't match: expected %#v, \n "+
 			"got %#v", a.HaveNodeAnnouncement, b.HaveNodeAnnouncement)
 	}
+	if !bytes.Equal(a.ExtraOpaqueData, b.ExtraOpaqueData) {
+		return fmt.Errorf("extra data doesn't match: %v vs %v",
+			a.ExtraOpaqueData, b.ExtraOpaqueData)
+	}
 
 	return nil
 }
@@ -2495,6 +2508,10 @@ func compareEdgePolicies(a, b *ChannelEdgePolicy) error {
 		return fmt.Errorf("FeeProportionalMillionths doesn't match: "+
 			"expected %v, got %v", a.FeeProportionalMillionths,
 			b.FeeProportionalMillionths)
+	}
+	if !bytes.Equal(a.ExtraOpaqueData, b.ExtraOpaqueData) {
+		return fmt.Errorf("extra data doesn't match: %v vs %v",
+			a.ExtraOpaqueData, b.ExtraOpaqueData)
 	}
 	if err := compareNodes(a.Node, b.Node); err != nil {
 		return err

--- a/discovery/gossiper.go
+++ b/discovery/gossiper.go
@@ -275,13 +275,14 @@ func (d *AuthenticatedGossiper) SynchronizeNode(syncPeer lnpeer.Peer) error {
 			return nil, err
 		}
 		return &lnwire.NodeAnnouncement{
-			Signature: wireSig,
-			Timestamp: uint32(n.LastUpdate.Unix()),
-			Addresses: n.Addresses,
-			NodeID:    n.PubKeyBytes,
-			Features:  n.Features.RawFeatureVector,
-			RGBColor:  n.Color,
-			Alias:     alias,
+			Signature:       wireSig,
+			Timestamp:       uint32(n.LastUpdate.Unix()),
+			Addresses:       n.Addresses,
+			NodeID:          n.PubKeyBytes,
+			Features:        n.Features.RawFeatureVector,
+			RGBColor:        n.Color,
+			Alias:           alias,
+			ExtraOpaqueData: n.ExtraOpaqueData,
 		}, nil
 	}
 
@@ -1645,6 +1646,7 @@ func (d *AuthenticatedGossiper) processNetworkAnnouncement(
 			AuthSigBytes:         msg.Signature.ToSignatureBytes(),
 			Features:             features,
 			Color:                msg.RGBColor,
+			ExtraOpaqueData:      msg.ExtraOpaqueData,
 		}
 
 		if err := d.cfg.Router.AddNode(node); err != nil {
@@ -1767,6 +1769,7 @@ func (d *AuthenticatedGossiper) processNetworkAnnouncement(
 			BitcoinKey2Bytes: msg.BitcoinKey2,
 			AuthProof:        proof,
 			Features:         featureBuf.Bytes(),
+			ExtraOpaqueData:  msg.ExtraOpaqueData,
 		}
 
 		// We will add the edge to the channel router. If the nodes
@@ -2036,6 +2039,7 @@ func (d *AuthenticatedGossiper) processNetworkAnnouncement(
 			MinHTLC:                   msg.HtlcMinimumMsat,
 			FeeBaseMSat:               lnwire.MilliSatoshi(msg.BaseFee),
 			FeeProportionalMillionths: lnwire.MilliSatoshi(msg.FeeRate),
+			ExtraOpaqueData:           msg.ExtraOpaqueData,
 		}
 
 		if err := d.cfg.Router.UpdateEdge(update); err != nil {
@@ -2504,6 +2508,7 @@ func (d *AuthenticatedGossiper) updateChannel(info *channeldb.ChannelEdgeInfo,
 		HtlcMinimumMsat: edge.MinHTLC,
 		BaseFee:         uint32(edge.FeeBaseMSat),
 		FeeRate:         uint32(edge.FeeProportionalMillionths),
+		ExtraOpaqueData: edge.ExtraOpaqueData,
 	}
 	chanUpdate.Signature, err = lnwire.NewSigFromRawSignature(edge.SigBytes)
 	if err != nil {
@@ -2545,13 +2550,14 @@ func (d *AuthenticatedGossiper) updateChannel(info *channeldb.ChannelEdgeInfo,
 	if info.AuthProof != nil {
 		chanID := lnwire.NewShortChanIDFromInt(info.ChannelID)
 		chanAnn = &lnwire.ChannelAnnouncement{
-			ShortChannelID: chanID,
-			NodeID1:        info.NodeKey1Bytes,
-			NodeID2:        info.NodeKey2Bytes,
-			ChainHash:      info.ChainHash,
-			BitcoinKey1:    info.BitcoinKey1Bytes,
-			Features:       lnwire.NewRawFeatureVector(),
-			BitcoinKey2:    info.BitcoinKey2Bytes,
+			ShortChannelID:  chanID,
+			NodeID1:         info.NodeKey1Bytes,
+			NodeID2:         info.NodeKey2Bytes,
+			ChainHash:       info.ChainHash,
+			BitcoinKey1:     info.BitcoinKey1Bytes,
+			Features:        lnwire.NewRawFeatureVector(),
+			BitcoinKey2:     info.BitcoinKey2Bytes,
+			ExtraOpaqueData: edge.ExtraOpaqueData,
 		}
 		chanAnn.NodeSig1, err = lnwire.NewSigFromRawSignature(
 			info.AuthProof.NodeSig1Bytes,

--- a/discovery/utils.go
+++ b/discovery/utils.go
@@ -23,13 +23,14 @@ func CreateChanAnnouncement(chanProof *channeldb.ChannelAuthProof,
 	// authenticated channel announcement.
 	chanID := lnwire.NewShortChanIDFromInt(chanInfo.ChannelID)
 	chanAnn := &lnwire.ChannelAnnouncement{
-		ShortChannelID: chanID,
-		NodeID1:        chanInfo.NodeKey1Bytes,
-		NodeID2:        chanInfo.NodeKey2Bytes,
-		ChainHash:      chanInfo.ChainHash,
-		BitcoinKey1:    chanInfo.BitcoinKey1Bytes,
-		BitcoinKey2:    chanInfo.BitcoinKey2Bytes,
-		Features:       lnwire.NewRawFeatureVector(),
+		ShortChannelID:  chanID,
+		NodeID1:         chanInfo.NodeKey1Bytes,
+		NodeID2:         chanInfo.NodeKey2Bytes,
+		ChainHash:       chanInfo.ChainHash,
+		BitcoinKey1:     chanInfo.BitcoinKey1Bytes,
+		BitcoinKey2:     chanInfo.BitcoinKey2Bytes,
+		Features:        lnwire.NewRawFeatureVector(),
+		ExtraOpaqueData: chanInfo.ExtraOpaqueData,
 	}
 
 	var err error
@@ -76,6 +77,7 @@ func CreateChanAnnouncement(chanProof *channeldb.ChannelAuthProof,
 			HtlcMinimumMsat: e1.MinHTLC,
 			BaseFee:         uint32(e1.FeeBaseMSat),
 			FeeRate:         uint32(e1.FeeProportionalMillionths),
+			ExtraOpaqueData: e1.ExtraOpaqueData,
 		}
 		edge1Ann.Signature, err = lnwire.NewSigFromRawSignature(e1.SigBytes)
 		if err != nil {
@@ -92,6 +94,7 @@ func CreateChanAnnouncement(chanProof *channeldb.ChannelAuthProof,
 			HtlcMinimumMsat: e2.MinHTLC,
 			BaseFee:         uint32(e2.FeeBaseMSat),
 			FeeRate:         uint32(e2.FeeProportionalMillionths),
+			ExtraOpaqueData: e2.ExtraOpaqueData,
 		}
 		edge2Ann.Signature, err = lnwire.NewSigFromRawSignature(e2.SigBytes)
 		if err != nil {

--- a/lnwire/channel_announcement.go
+++ b/lnwire/channel_announcement.go
@@ -3,6 +3,7 @@ package lnwire
 import (
 	"bytes"
 	"io"
+	"io/ioutil"
 
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 )
@@ -48,6 +49,14 @@ type ChannelAnnouncement struct {
 	// multisig funding transaction output.
 	BitcoinKey1 [33]byte
 	BitcoinKey2 [33]byte
+
+	// ExtraOpaqueData is the set of data that was appended to this
+	// message, some of which we may not actually know how to iterate or
+	// parse. By holding onto this data, we ensure that we're able to
+	// properly validate the set of signatures that cover these new fields,
+	// and ensure we're able to make upgrades to the network in a forwards
+	// compatible manner.
+	ExtraOpaqueData []byte
 }
 
 // A compile time check to ensure ChannelAnnouncement implements the
@@ -59,7 +68,7 @@ var _ Message = (*ChannelAnnouncement)(nil)
 //
 // This is part of the lnwire.Message interface.
 func (a *ChannelAnnouncement) Decode(r io.Reader, pver uint32) error {
-	return readElements(r,
+	err := readElements(r,
 		&a.NodeSig1,
 		&a.NodeSig2,
 		&a.BitcoinSig1,
@@ -72,6 +81,23 @@ func (a *ChannelAnnouncement) Decode(r io.Reader, pver uint32) error {
 		&a.BitcoinKey1,
 		&a.BitcoinKey2,
 	)
+	if err != nil {
+		return err
+	}
+
+	// Now that we've read out all the fields that we explicitly know of,
+	// we'll collect the remainder into the ExtraOpaqueData field. If there
+	// aren't any bytes, then we'll snip off the slice to avoid carrying
+	// around excess capacity.
+	a.ExtraOpaqueData, err = ioutil.ReadAll(r)
+	if err != nil {
+		return err
+	}
+	if len(a.ExtraOpaqueData) == 0 {
+		a.ExtraOpaqueData = nil
+	}
+
+	return nil
 }
 
 // Encode serializes the target ChannelAnnouncement into the passed io.Writer
@@ -91,6 +117,7 @@ func (a *ChannelAnnouncement) Encode(w io.Writer, pver uint32) error {
 		a.NodeID2,
 		a.BitcoinKey1,
 		a.BitcoinKey2,
+		a.ExtraOpaqueData,
 	)
 }
 
@@ -107,42 +134,7 @@ func (a *ChannelAnnouncement) MsgType() MessageType {
 //
 // This is part of the lnwire.Message interface.
 func (a *ChannelAnnouncement) MaxPayloadLength(pver uint32) uint32 {
-	var length uint32
-
-	// NodeSig1 - 64 bytes
-	length += 64
-
-	// NodeSig2 - 64 bytes
-	length += 64
-
-	// BitcoinSig1 - 64 bytes
-	length += 64
-
-	// BitcoinSig2 - 64 bytes
-	length += 64
-
-	// Features  (max possible features)
-	length += 65096
-
-	// ChainHash - 32 bytes
-	length += 32
-
-	// ShortChannelID - 8 bytes
-	length += 8
-
-	// NodeID1 - 33 bytes
-	length += 33
-
-	// NodeID2 - 33 bytes
-	length += 33
-
-	// BitcoinKey1 - 33 bytes
-	length += 33
-
-	// BitcoinKey2 - 33 bytes
-	length += 33
-
-	return length
+	return 65533
 }
 
 // DataToSign is used to retrieve part of the announcement message which should
@@ -158,6 +150,7 @@ func (a *ChannelAnnouncement) DataToSign() ([]byte, error) {
 		a.NodeID2,
 		a.BitcoinKey1,
 		a.BitcoinKey2,
+		a.ExtraOpaqueData,
 	)
 	if err != nil {
 		return nil, err

--- a/lnwire/channel_update.go
+++ b/lnwire/channel_update.go
@@ -3,6 +3,7 @@ package lnwire
 import (
 	"bytes"
 	"io"
+	"io/ioutil"
 
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 )
@@ -73,6 +74,14 @@ type ChannelUpdate struct {
 	// FeeRate is the fee rate that will be charged per millionth of a
 	// satoshi.
 	FeeRate uint32
+
+	// ExtraOpaqueData is the set of data that was appended to this
+	// message, some of which we may not actually know how to iterate or
+	// parse. By holding onto this data, we ensure that we're able to
+	// properly validate the set of signatures that cover these new fields,
+	// and ensure we're able to make upgrades to the network in a forwards
+	// compatible manner.
+	ExtraOpaqueData []byte
 }
 
 // A compile time check to ensure ChannelUpdate implements the lnwire.Message
@@ -84,7 +93,7 @@ var _ Message = (*ChannelUpdate)(nil)
 //
 // This is part of the lnwire.Message interface.
 func (a *ChannelUpdate) Decode(r io.Reader, pver uint32) error {
-	return readElements(r,
+	err := readElements(r,
 		&a.Signature,
 		a.ChainHash[:],
 		&a.ShortChannelID,
@@ -95,6 +104,23 @@ func (a *ChannelUpdate) Decode(r io.Reader, pver uint32) error {
 		&a.BaseFee,
 		&a.FeeRate,
 	)
+	if err != nil {
+		return err
+	}
+
+	// Now that we've read out all the fields that we explicitly know of,
+	// we'll collect the remainder into the ExtraOpaqueData field. If there
+	// aren't any bytes, then we'll snip off the slice to avoid carrying
+	// around excess capacity.
+	a.ExtraOpaqueData, err = ioutil.ReadAll(r)
+	if err != nil {
+		return err
+	}
+	if len(a.ExtraOpaqueData) == 0 {
+		a.ExtraOpaqueData = nil
+	}
+
+	return nil
 }
 
 // Encode serializes the target ChannelUpdate into the passed io.Writer
@@ -112,6 +138,7 @@ func (a *ChannelUpdate) Encode(w io.Writer, pver uint32) error {
 		a.HtlcMinimumMsat,
 		a.BaseFee,
 		a.FeeRate,
+		a.ExtraOpaqueData,
 	)
 }
 
@@ -128,36 +155,7 @@ func (a *ChannelUpdate) MsgType() MessageType {
 //
 // This is part of the lnwire.Message interface.
 func (a *ChannelUpdate) MaxPayloadLength(pver uint32) uint32 {
-	var length uint32
-
-	// Signature - 64 bytes
-	length += 64
-
-	// ChainHash - 64 bytes
-	length += 32
-
-	// ShortChannelID - 8 bytes
-	length += 8
-
-	// Timestamp - 4 bytes
-	length += 4
-
-	// Flags - 2 bytes
-	length += 2
-
-	// Expiry - 2 bytes
-	length += 2
-
-	// HtlcMinimumMstat - 8 bytes
-	length += 8
-
-	// FeeBaseMstat - 4 bytes
-	length += 4
-
-	// FeeProportionalMillionths - 4 bytes
-	length += 4
-
-	return length
+	return 65533
 }
 
 // DataToSign is used to retrieve part of the announcement message which should
@@ -175,6 +173,7 @@ func (a *ChannelUpdate) DataToSign() ([]byte, error) {
 		a.HtlcMinimumMsat,
 		a.BaseFee,
 		a.FeeRate,
+		a.ExtraOpaqueData,
 	)
 	if err != nil {
 		return nil, err

--- a/lnwire/lnwire_test.go
+++ b/lnwire/lnwire_test.go
@@ -537,6 +537,17 @@ func TestLightningWireProtocol(t *testing.T) {
 				return
 			}
 
+			numExtraBytes := r.Int31n(1000)
+			if numExtraBytes > 0 {
+				req.ExtraOpaqueData = make([]byte, numExtraBytes)
+				_, err := r.Read(req.ExtraOpaqueData[:])
+				if err != nil {
+					t.Fatalf("unable to generate opaque "+
+						"bytes: %v", err)
+					return
+				}
+			}
+
 			v[0] = reflect.ValueOf(req)
 		},
 		MsgNodeAnnouncement: func(v []reflect.Value, r *rand.Rand) {
@@ -574,6 +585,17 @@ func TestLightningWireProtocol(t *testing.T) {
 				t.Fatalf("unable to generate addresses: %v", err)
 			}
 
+			numExtraBytes := r.Int31n(1000)
+			if numExtraBytes > 0 {
+				req.ExtraOpaqueData = make([]byte, numExtraBytes)
+				_, err := r.Read(req.ExtraOpaqueData[:])
+				if err != nil {
+					t.Fatalf("unable to generate opaque "+
+						"bytes: %v", err)
+					return
+				}
+			}
+
 			v[0] = reflect.ValueOf(req)
 		},
 		MsgChannelUpdate: func(v []reflect.Value, r *rand.Rand) {
@@ -596,6 +618,17 @@ func TestLightningWireProtocol(t *testing.T) {
 			if _, err := r.Read(req.ChainHash[:]); err != nil {
 				t.Fatalf("unable to generate chain hash: %v", err)
 				return
+			}
+
+			numExtraBytes := r.Int31n(1000)
+			if numExtraBytes > 0 {
+				req.ExtraOpaqueData = make([]byte, numExtraBytes)
+				_, err := r.Read(req.ExtraOpaqueData[:])
+				if err != nil {
+					t.Fatalf("unable to generate opaque "+
+						"bytes: %v", err)
+					return
+				}
 			}
 
 			v[0] = reflect.ValueOf(req)
@@ -621,6 +654,17 @@ func TestLightningWireProtocol(t *testing.T) {
 			if _, err := r.Read(req.ChannelID[:]); err != nil {
 				t.Fatalf("unable to generate chan id: %v", err)
 				return
+			}
+
+			numExtraBytes := r.Int31n(1000)
+			if numExtraBytes > 0 {
+				req.ExtraOpaqueData = make([]byte, numExtraBytes)
+				_, err := r.Read(req.ExtraOpaqueData[:])
+				if err != nil {
+					t.Fatalf("unable to generate opaque "+
+						"bytes: %v", err)
+					return
+				}
 			}
 
 			v[0] = reflect.ValueOf(req)

--- a/lnwire/onion_error_test.go
+++ b/lnwire/onion_error_test.go
@@ -6,6 +6,8 @@ import (
 	"encoding/binary"
 	"reflect"
 	"testing"
+
+	"github.com/davecgh/go-spew/spew"
 )
 
 var (
@@ -66,8 +68,8 @@ func TestEncodeDecodeCode(t *testing.T) {
 		}
 
 		if !reflect.DeepEqual(failure1, failure2) {
-			t.Fatalf("failure message are different, failure "+
-				"code(%v)", failure1.Code())
+			t.Fatalf("expected %v, got %v", spew.Sdump(failure1),
+				spew.Sdump(failure2))
 		}
 	}
 }

--- a/server.go
+++ b/server.go
@@ -3015,6 +3015,7 @@ func createChannelUpdate(info *channeldb.ChannelEdgeInfo,
 		HtlcMinimumMsat: policy.MinHTLC,
 		BaseFee:         uint32(policy.FeeBaseMSat),
 		FeeRate:         uint32(policy.FeeProportionalMillionths),
+		ExtraOpaqueData: policy.ExtraOpaqueData,
 	}
 
 	var err error


### PR DESCRIPTION
In this commit, we fix an existing bug within the codebase. For all gossip messages we stored, validated and propagated, we wouldn't also include any extra data up to the full length of the message. As a result, in the future if we upgrade in the forwards compatible manner by adding _new_ (possibly unknown fields to ourselves) to the end of a message, then we would be unable to properly validate an propagate the valid versions. 

In order to fix this, both in the database and in our wire parsing, if after we parse the regular message there are any additional bytes, we'll also read those and store those in the database. We ensure that in all cases where we read these announcements from disk, we properly include the extra bytes in the wire messages before we write them out onto the socket. 