### PR TITLE
Start deprecating noencryptwallet

### DIFF
--- a/cmd/lncli/commands.go
+++ b/cmd/lncli/commands.go
@@ -1332,7 +1332,7 @@ var unlockCommand = cli.Command{
 	The unlock command is used to decrypt lnd's wallet state in order to
 	start up. This command MUST be run after booting up lnd before it's
 	able to carry out its duties. An exception is if a user is running with
-	--noencryptwallet, then a default passphrase will be used.
+	--noseedbackup, then a default passphrase will be used.
 	`,
 	Flags: []cli.Flag{
 		cli.IntFlag{
@@ -1400,8 +1400,8 @@ var changePasswordCommand = cli.Command{
 	is successful.
 
 	If one did not specify a password for their wallet (running lnd with
-	--noencryptwallet), one must restart their daemon without
-	--noencryptwallet and use this command. The "current password" field
+	--noseedbackup), one must restart their daemon without
+	--noseedbackup and use this command. The "current password" field
 	should be left empty.
 	`,
 	Action: actionDecorator(changePassword),

--- a/config.go
+++ b/config.go
@@ -45,7 +45,7 @@ const (
 	defaultPeerPort            = 9735
 	defaultRPCHost             = "localhost"
 	defaultMaxPendingChannels  = 1
-	defaultNoEncryptWallet     = false
+	defaultNoSeedBackup        = false
 	defaultTrickleDelay        = 30 * 1000
 	defaultInactiveChanTimeout = 20 * time.Minute
 	defaultMaxLogFiles         = 3
@@ -222,7 +222,7 @@ type config struct {
 
 	NoNetBootstrap bool `long:"nobootstrap" description:"If true, then automatic network bootstrapping will not be attempted."`
 
-	NoEncryptWallet bool `long:"noencryptwallet" description:"If set, wallet will be encrypted using the default passphrase."`
+	NoSeedBackup bool `long:"noseedbackup" description:"If true, NO SEED WILL BE EXPOSED AND THE WALLET WILL BE ENCRYPTED USING THE DEFAULT PASSPHRASE -- EVER. THIS FLAG IS ONLY FOR TESTING AND IS BEING DEPRECATED."`
 
 	TrickleDelay        int           `long:"trickledelay" description:"Time in milliseconds between each release of announcements to the network"`
 	InactiveChanTimeout time.Duration `long:"inactivechantimeout" description:"If a channel has been inactive for the set time, send a ChannelUpdate disabling it."`
@@ -288,7 +288,7 @@ func loadConfig() (*config, error) {
 			RPCHost: defaultRPCHost,
 		},
 		MaxPendingChannels: defaultMaxPendingChannels,
-		NoEncryptWallet:    defaultNoEncryptWallet,
+		NoSeedBackup:       defaultNoSeedBackup,
 		Autopilot: &autoPilotConfig{
 			MaxChannels:    5,
 			Allocation:     0.6,

--- a/docker/lnd/start-lnd.sh
+++ b/docker/lnd/start-lnd.sh
@@ -50,7 +50,7 @@ if [[ "$CHAIN" == "litecoin" ]]; then
 fi
 
 exec lnd \
-    --noencryptwallet \
+    --noseedbackup \
     --logdir="/data" \
     "--$CHAIN.active" \
     "--$CHAIN.$NETWORK" \

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -291,12 +291,6 @@ lnd --bitcoin.active --bitcoin.testnet --debuglevel=debug --bitcoin.node=bitcoin
   `lnd` plus any application that consumes the RPC could cause `lnd` to miss
   crucial updates from the backend.
 
-#### Disabling Wallet Encryption
-
-To disable encryption of the wallet files, pass the `--noencryptwallet` argument
-to `lnd`. Obviously beware the security implications of running an unencrypted
-wallet - this argument must only be used for testing purposes.
-
 #### Macaroons
 
 `lnd`'s authentication system is called **macaroons**, which are decentralized

--- a/lnd.go
+++ b/lnd.go
@@ -210,9 +210,9 @@ func lndMain() error {
 	)
 
 	// We wait until the user provides a password over RPC. In case lnd is
-	// started with the --noencryptwallet flag, we use the default password
+	// started with the --noseedbackup flag, we use the default password
 	// for wallet encryption.
-	if !cfg.NoEncryptWallet {
+	if !cfg.NoSeedBackup {
 		walletInitParams, err := waitForWalletPassword(
 			cfg.RPCListeners, cfg.RESTListeners, serverOpts,
 			proxyOpts, tlsConf,

--- a/lntest/node.go
+++ b/lntest/node.go
@@ -168,7 +168,7 @@ func (cfg nodeConfig) genArgs() []string {
 	args = append(args, fmt.Sprintf("--trickledelay=%v", trickleDelay))
 
 	if !cfg.HasSeed {
-		args = append(args, "--noencryptwallet")
+		args = append(args, "--noseedbackup")
 	}
 
 	if cfg.ExtraArgs != nil {

--- a/macaroons/README.md
+++ b/macaroons/README.md
@@ -26,7 +26,7 @@ In this DB the following two key/value pairs are stored:
   * The root key is symmetrically encrypted with the derived secret key, using
     the `secretbox` method of the library
     [btcsuite/golangcrypto](https://github.com/btcsuite/golangcrypto).
-  * If the option `--noencryptwallet` is used, then the default passphrase
+  * If the option `--noseedbackup` is used, then the default passphrase
     `hello` is used to encrypt the root key.
 
 ## Generated macaroons

--- a/sample-lnd.conf
+++ b/sample-lnd.conf
@@ -133,11 +133,6 @@
 ; network.
 ; nobootstrap=1
 
-; If set, your wallet will be encrypted with the default passphrase. This isn't
-; recommend, as if an attacker gains access to your wallet file, they'll be able
-; to decrypt it. This value is ONLY to be used in testing environments.
-; noencryptwallet=1
-
 ; The alias your node will use, which can be up to 32 UTF-8 characters in
 ; length.
 ; alias=My Lightning ☇

--- a/walletunlocker/service.go
+++ b/walletunlocker/service.go
@@ -309,7 +309,7 @@ func (u *UnlockerService) ChangePassword(ctx context.Context,
 	privatePw := in.CurrentPassword
 
 	// If the current password is blank, we'll assume the user is coming
-	// from a --noencryptwallet state, so we'll use the default passwords.
+	// from a --noseedbackup state, so we'll use the default passwords.
 	if len(in.CurrentPassword) == 0 {
 		publicPw = lnwallet.DefaultPublicPassphrase
 		privatePw = lnwallet.DefaultPrivatePassphrase


### PR DESCRIPTION
This PR begins the process of deprecating the confusing `noencryptwallet` flag, which has initially designed for testing purposes. As people have started to use this flag in the wild, it cannot be fully removed in one fell swoop due to backwards-compatibility requirements, though this will start the process of deprecating its use.

The primary change in this PR is to rename the flag to `noseedbackup`, as this the more critical information the user should be aware of when using this setting. The help description printed presents a more alarming tone than the prior message, and includes the caveat that no seed will be provided.

References to noencryptwallet have been migrated to noseedbackup in comments throughout the codebase. The section on disabling wallet encryption has also been removed from the install docs and `sample-lnd.conf`. Lastly, the docker start script has been changed to pass the `noseedbackup` flag instead.

NOTE: Any users that are actively using `noencryptwallet` will have to switch any scripts/confs to use`noseedbackup` as a result of this PR, though no further modification should be required.