### PR TITLE
peer: prune persistent peer connection on zero on-disk channels

### DIFF
--- a/test_utils.go
+++ b/test_utils.go
@@ -272,21 +272,21 @@ func createTestPeer(notifier chainntnfs.ChainNotifier,
 		Packager:                channeldb.NewChannelPackager(shortChanID),
 	}
 
-	addr := &net.TCPAddr{
+	aliceAddr := &net.TCPAddr{
 		IP:   net.ParseIP("127.0.0.1"),
 		Port: 18555,
 	}
 
-	if err := aliceChannelState.SyncPending(addr, 0); err != nil {
+	if err := aliceChannelState.SyncPending(aliceAddr, 0); err != nil {
 		return nil, nil, nil, nil, err
 	}
 
-	addr = &net.TCPAddr{
+	bobAddr := &net.TCPAddr{
 		IP:   net.ParseIP("127.0.0.1"),
 		Port: 18556,
 	}
 
-	if err := bobChannelState.SyncPending(addr, 0); err != nil {
+	if err := bobChannelState.SyncPending(bobAddr, 0); err != nil {
 		return nil, nil, nil, nil, err
 	}
 
@@ -363,6 +363,11 @@ func createTestPeer(notifier chainntnfs.ChainNotifier,
 	s.htlcSwitch.Start()
 
 	alicePeer := &peer{
+		addr: &lnwire.NetAddress{
+			IdentityKey: aliceKeyPub,
+			Address:     aliceAddr,
+		},
+
 		server:        s,
 		sendQueue:     make(chan outgoingMsg, 1),
 		outgoingQueue: make(chan outgoingMsg, outgoingQueueLen),


### PR DESCRIPTION
In this commit, we fix a small bug with regards to the persistent peer
connection pruning logic. Before this commit, it'd be the case that we'd
prune a persistent connection to a peer if all links happen to be
inactive. This isn't ideal, as the channels are still open, so we should
always be atttempting to connect to them. We fix this by looking at the
set of channels on-disk instead and prune the persistent connection if
there aren't any.