### PR TITLE
amount paid should be in satoshies as other fields used for amount

### DIFF
--- a/rpcserver.go
+++ b/rpcserver.go
@@ -2766,6 +2766,7 @@ func createRPCInvoice(invoice *channeldb.Invoice) (*lnrpc.Invoice, error) {
 
 	preimage := invoice.Terms.PaymentPreimage
 	satAmt := invoice.Terms.Value.ToSatoshis()
+	amtPaid := invoice.AmtPaid.ToSatoshis()
 
 	return &lnrpc.Invoice{
 		Memo:            string(invoice.Memo[:]),
@@ -2784,7 +2785,7 @@ func createRPCInvoice(invoice *channeldb.Invoice) (*lnrpc.Invoice, error) {
 		RouteHints:      routeHints,
 		AddIndex:        invoice.AddIndex,
 		SettleIndex:     invoice.SettleIndex,
-		AmtPaid:         int64(invoice.AmtPaid),
+		AmtPaid:         int64(amtPaid),
 	}, nil
 }
 


### PR DESCRIPTION
All fields including: 
* lnrpc.Invoice.Value 
* lnrpc.Payment.Value
are showing amount in satoshies and only lnrpc.Invoice.AmtPaid is assigned with the milli satoshies value.
This PR fixes this inconsistency.