### PR TITLE
[utxonursery] Use kidoutput broadcast height as height hint

### DIFF
--- a/contractcourt/chain_arbitrator.go
+++ b/contractcourt/chain_arbitrator.go
@@ -105,7 +105,7 @@ type ChainArbitratorConfig struct {
 	// absolute/relative item block.
 	IncubateOutputs func(wire.OutPoint, *lnwallet.CommitOutputResolution,
 		*lnwallet.OutgoingHtlcResolution,
-		*lnwallet.IncomingHtlcResolution) error
+		*lnwallet.IncomingHtlcResolution, uint32) error
 
 	// PreimageDB is a global store of all known pre-images. We'll use this
 	// to decide if we should broadcast a commitment transaction to claim

--- a/contractcourt/channel_arbitrator.go
+++ b/contractcourt/channel_arbitrator.go
@@ -648,7 +648,7 @@ func (c *ChannelArbitrator) stateStep(triggerHeight uint32,
 
 			err = c.cfg.IncubateOutputs(
 				c.cfg.ChanPoint, commitRes,
-				nil, nil,
+				nil, nil, triggerHeight,
 			)
 			if err != nil {
 				// TODO(roasbeef): check for AlreadyExists errors

--- a/contractcourt/contract_resolvers.go
+++ b/contractcourt/contract_resolvers.go
@@ -152,7 +152,10 @@ func (h *htlcTimeoutResolver) Resolve() (ContractResolver, error) {
 		log.Tracef("%T(%v): incubating htlc output", h,
 			h.htlcResolution.ClaimOutpoint)
 
-		err := h.IncubateOutputs(h.ChanPoint, nil, &h.htlcResolution, nil)
+		err := h.IncubateOutputs(
+			h.ChanPoint, nil, &h.htlcResolution, nil,
+			h.broadcastHeight,
+		)
 		if err != nil {
 			return nil, err
 		}
@@ -568,7 +571,10 @@ func (h *htlcSuccessResolver) Resolve() (ContractResolver, error) {
 		log.Infof("%T(%x): incubating incoming htlc output",
 			h, h.payHash[:])
 
-		err := h.IncubateOutputs(h.ChanPoint, nil, nil, &h.htlcResolution)
+		err := h.IncubateOutputs(
+			h.ChanPoint, nil, nil, &h.htlcResolution,
+			h.broadcastHeight,
+		)
 		if err != nil {
 			return nil, err
 		}

--- a/server.go
+++ b/server.go
@@ -628,7 +628,8 @@ func newServer(listenAddrs []net.Addr, chanDB *channeldb.DB, cc *chainControl,
 		IncubateOutputs: func(chanPoint wire.OutPoint,
 			commitRes *lnwallet.CommitOutputResolution,
 			outHtlcRes *lnwallet.OutgoingHtlcResolution,
-			inHtlcRes *lnwallet.IncomingHtlcResolution) error {
+			inHtlcRes *lnwallet.IncomingHtlcResolution,
+			broadcastHeight uint32) error {
 
 			var (
 				inRes  []lnwallet.IncomingHtlcResolution

--- a/server.go
+++ b/server.go
@@ -644,6 +644,7 @@ func newServer(listenAddrs []net.Addr, chanDB *channeldb.DB, cc *chainControl,
 
 			return s.utxoNursery.IncubateOutputs(
 				chanPoint, commitRes, outRes, inRes,
+				broadcastHeight,
 			)
 		},
 		PreimageDB:   s.witnessBeacon,

--- a/utxonursery.go
+++ b/utxonursery.go
@@ -343,7 +343,8 @@ func (u *utxoNursery) Stop() error {
 func (u *utxoNursery) IncubateOutputs(chanPoint wire.OutPoint,
 	commitResolution *lnwallet.CommitOutputResolution,
 	outgoingHtlcs []lnwallet.OutgoingHtlcResolution,
-	incomingHtlcs []lnwallet.IncomingHtlcResolution) error {
+	incomingHtlcs []lnwallet.IncomingHtlcResolution,
+	broadcastHeight uint32) error {
 
 	numHtlcs := len(incomingHtlcs) + len(outgoingHtlcs)
 	var (
@@ -469,7 +470,9 @@ func (u *utxoNursery) IncubateOutputs(chanPoint wire.OutPoint,
 	// kindergarten bucket.
 	if len(kidOutputs) != 0 {
 		for _, kidOutput := range kidOutputs {
-			err := u.registerPreschoolConf(&kidOutput, u.bestHeight)
+			err := u.registerPreschoolConf(
+				&kidOutput, broadcastHeight,
+			)
 			if err != nil {
 				return err
 			}

--- a/utxonursery_test.go
+++ b/utxonursery_test.go
@@ -336,6 +336,8 @@ func init() {
 }
 
 func TestKidOutputSerialization(t *testing.T) {
+	t.Parallel()
+
 	for i, kid := range kidOutputs {
 		var b bytes.Buffer
 		if err := kid.Encode(&b); err != nil {
@@ -358,6 +360,8 @@ func TestKidOutputSerialization(t *testing.T) {
 }
 
 func TestBabyOutputSerialization(t *testing.T) {
+	t.Parallel()
+
 	for i, baby := range babyOutputs {
 		var b bytes.Buffer
 		if err := baby.Encode(&b); err != nil {


### PR DESCRIPTION
This commit fixes an issue within the utxo nursery, where we would use
the best height as height hint when registering for confirmation
notifications for kid outputs.

This would in many cases not be correct, as the output could be
confirmed deeper, leading to failure of getting confirmations on
backends where a height hint is required.