### PR TITLE
lnwire/lnwire_test: assert nil 0-length sid reply msg

### DIFF
--- a/lnwire/lnwire_test.go
+++ b/lnwire/lnwire_test.go
@@ -711,7 +711,6 @@ func TestLightningWireProtocol(t *testing.T) {
 			}
 
 			numChanIDs := rand.Int31n(5000)
-
 			for i := int32(0); i < numChanIDs; i++ {
 				req.ShortChanIDs = append(req.ShortChanIDs,
 					NewShortChanIDFromInt(uint64(r.Int63())))
@@ -743,12 +742,9 @@ func TestLightningWireProtocol(t *testing.T) {
 			}
 
 			numChanIDs := rand.Int31n(5000)
-
-			req.ShortChanIDs = make([]ShortChannelID, numChanIDs)
 			for i := int32(0); i < numChanIDs; i++ {
-				req.ShortChanIDs[i] = NewShortChanIDFromInt(
-					uint64(r.Int63()),
-				)
+				req.ShortChanIDs = append(req.ShortChanIDs,
+					NewShortChanIDFromInt(uint64(r.Int63())))
 			}
 
 			v[0] = reflect.ValueOf(req)


### PR DESCRIPTION
Thank you to @offerm for pointing this out, our tests would incorrectly allocate a zero-length short chan id array when checking via quick tests.

Replaces #1592 