### PR TITLE
Add debug log to Auto Pilot on why no more channels are needed

### DIFF
--- a/autopilot/agent_constraints.go
+++ b/autopilot/agent_constraints.go
@@ -88,6 +88,9 @@ func (h *agentConstraints) ChannelBudget(channels []Channel,
 	// If we're already over our maximum allowed number of channels, then
 	// we'll instruct the controller not to create any more channels.
 	if len(channels) >= int(h.chanLimit) {
+                log.Debugf("No more channels needed because channel limit was reached. " +
+                        "Limit: %v. Current number of channels: %v",
+                        h.chanLimit, len(channels))
 		return 0, 0
 	}
 
@@ -116,6 +119,10 @@ func (h *agentConstraints) ChannelBudget(channels []Channel,
 	// of channels to attempt to open.
 	needMore := fundsFraction < h.allocation
 	if !needMore {
+                log.Debugf("No more channels needed because funds allocation " +
+                        "was reached. Funds total: %v. Funds allocated to channels: %v. " +
+                        "Current fraction (allocated divided by total): %v. Limit fraction: %v.",
+                        totalFunds, totalChanAllocation, fundsFraction, h.allocation)
 		return 0, 0
 	}
 


### PR DESCRIPTION
This is to address confusion I ran into in issue #1854

A test was to run LND with debug log enabled and 0 funds in the chain wallet:
```
2018-09-06 10:50:49.117 [INF] ATPL: Autopilot Agent starting
2018-09-06 10:50:49.119 [DBG] ATPL: Applying external balance state update
2018-09-06 10:50:49.123 [DBG] ATPL: Pending channels: (map[autopilot.NodeID]autopilot.Channel) {
}

2018-09-06 10:50:49.124 [DBG] ATPL: No more channels needed. Funds allocation reached. Total channel allocation: 0 BTC. Total funds: 0 BTC
```