### PR TITLE
multi: fix panic bug in chan series, itest test flake, update neutrino to latest version

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -265,7 +265,7 @@
   revision = "462a8a75388506b68f76661af8d649f0b88e5301"
 
 [[projects]]
-  digest = "1:b87ab48ac3bdfcf8d90c51f9c1a4061660dcb2e1c3c12822ccfc131f5a898578"
+  digest = "1:dba95a15051bdc8ff8373f9c76cf2b63945b896e4302b77e869ea9b9d0dfbee2"
   name = "github.com/lightninglabs/neutrino"
   packages = [
     ".",
@@ -276,7 +276,7 @@
     "headerlist",
   ]
   pruneopts = "UT"
-  revision = "cccdda0fbb69281c17de496da88e956c300511e2"
+  revision = "07e32eee63e2a6f16acbc8df85c6530972015a44"
 
 [[projects]]
   digest = "1:58ab6d6525898cbeb86dc29a68f8e9bfe95254b9032134eb9458779574872260"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -44,7 +44,7 @@
 
 [[constraint]]
   name = "github.com/lightninglabs/neutrino"
-  revision = "cccdda0fbb69281c17de496da88e956c300511e2"
+  revision = "07e32eee63e2a6f16acbc8df85c6530972015a44"
 
 [[constraint]]
   name = "github.com/lightningnetwork/lightning-onion"

--- a/chan_series.go
+++ b/chan_series.go
@@ -297,7 +297,7 @@ func (c *chanSeries) FetchChanUpdates(chain chainhash.Hash,
 			HtlcMinimumMsat: e2.MinHTLC,
 			BaseFee:         uint32(e2.FeeBaseMSat),
 			FeeRate:         uint32(e2.FeeProportionalMillionths),
-			ExtraOpaqueData: e1.ExtraOpaqueData,
+			ExtraOpaqueData: e2.ExtraOpaqueData,
 		}
 		chanUpdate.Signature, err = lnwire.NewSigFromRawSignature(e2.SigBytes)
 		if err != nil {


### PR DESCRIPTION

In this PR, we fix an existing but that would cause the daemon to at
times crash. Before this commit, we access the wrong edge, which would
possibly actually be nil, leading to a panic. In this commit we fix this
by ensuring we access the proper edge which is known to be non-nil at
this point in the control flow.

We also improve the error logging in the `lntest` framework when a node
fails to recognize the full balance. 

We also fix a flake in the link node garbage collection test
by ensuring the channels have been fully closed on both sides before we
attempt to restart and ensure that they don't actually establish
connections. Without this check, it's possible that either side hasn't
yet processed all the blocks, so they'll still reconnect to each other on
start up.