### PR TITLE
config: Experimental support for Litecoin/simnet

### DIFF
--- a/chainparams.go
+++ b/chainparams.go
@@ -54,6 +54,14 @@ var bitcoinSimNetParams = bitcoinNetParams{
 	CoinType: keychain.CoinTypeTestnet,
 }
 
+// litecoinSimNetParams contains parameters specific to the simulation test
+// network.
+var litecoinSimNetParams = litecoinNetParams{
+	Params:   &litecoinCfg.SimNetParams,
+	rpcPort:  "18556",
+	CoinType: keychain.CoinTypeTestnet,
+}
+
 // litecoinTestNetParams contains parameters specific to the 4th version of the
 // test network.
 var litecoinTestNetParams = litecoinNetParams{

--- a/config.go
+++ b/config.go
@@ -541,10 +541,6 @@ func loadConfig() (*config, error) {
 			"litecoin.active must be set to 1 (true)", funcName)
 
 	case cfg.Litecoin.Active:
-		if cfg.Litecoin.SimNet {
-			str := "%s: simnet mode for litecoin not currently supported"
-			return nil, fmt.Errorf(str, funcName)
-		}
 		if cfg.Litecoin.RegTest {
 			str := "%s: regnet mode for litecoin not currently supported"
 			return nil, fmt.Errorf(str, funcName)
@@ -567,6 +563,10 @@ func loadConfig() (*config, error) {
 		if cfg.Litecoin.TestNet3 {
 			numNets++
 			ltcParams = litecoinTestNetParams
+		}
+		if cfg.Litecoin.SimNet {
+			numNets++
+			ltcParams = litecoinSimNetParams
 		}
 		if numNets > 1 {
 			str := "%s: The mainnet, testnet, and simnet params " +

--- a/lnd.go
+++ b/lnd.go
@@ -123,7 +123,7 @@ func lndMain() error {
 	case cfg.Bitcoin.MainNet || cfg.Litecoin.MainNet:
 		network = "mainnet"
 
-	case cfg.Bitcoin.SimNet:
+	case cfg.Bitcoin.SimNet || cfg.Litecoin.SimNet:
 		network = "simnet"
 
 	case cfg.Bitcoin.RegTest:


### PR DESCRIPTION
This PR adds the configuration needed to run LND with Litecoin on simnet. The change is minimal and has no impact for users that don't enable this mode. When using this configuration, the user is being warned that this mode is not officially supported.

Fixes #1830.