### PR TITLE
channeldb: fix bucket creation hierarchy in createChannelDB

### DIFF
--- a/channeldb/channel.go
+++ b/channeldb/channel.go
@@ -70,12 +70,6 @@ var (
 	// channel closure. This key should be accessed from within the
 	// sub-bucket of a target channel, identified by its channel point.
 	revocationLogBucket = []byte("revocation-log-key")
-
-	// fwdPackageLogBucket is a bucket that stores the locked-in htlcs after
-	// having received a revocation from the remote party. The keys in this
-	// bucket represent the remote height at which these htlcs were
-	// accepted.
-	fwdPackageLogBucket = []byte("fwd-package-log-key")
 )
 
 var (

--- a/channeldb/db.go
+++ b/channeldb/db.go
@@ -201,8 +201,15 @@ func createChannelDB(dbPath string) error {
 		if _, err := tx.CreateBucket(openChannelBucket); err != nil {
 			return err
 		}
-
 		if _, err := tx.CreateBucket(closedChannelBucket); err != nil {
+			return err
+		}
+
+		if _, err := tx.CreateBucket(forwardingLogBucket); err != nil {
+			return err
+		}
+
+		if _, err := tx.CreateBucket(fwdPackagesKey); err != nil {
 			return err
 		}
 
@@ -210,20 +217,47 @@ func createChannelDB(dbPath string) error {
 			return err
 		}
 
+		if _, err := tx.CreateBucket(paymentBucket); err != nil {
+			return err
+		}
+
 		if _, err := tx.CreateBucket(nodeInfoBucket); err != nil {
 			return err
 		}
 
-		if _, err := tx.CreateBucket(nodeBucket); err != nil {
+		nodes, err := tx.CreateBucket(nodeBucket)
+		if err != nil {
 			return err
 		}
-		if _, err := tx.CreateBucket(edgeBucket); err != nil {
+		_, err = nodes.CreateBucket(aliasIndexBucket)
+		if err != nil {
 			return err
 		}
-		if _, err := tx.CreateBucket(edgeIndexBucket); err != nil {
+		_, err = nodes.CreateBucket(nodeUpdateIndexBucket)
+		if err != nil {
 			return err
 		}
-		if _, err := tx.CreateBucket(graphMetaBucket); err != nil {
+
+		edges, err := tx.CreateBucket(edgeBucket)
+		if err != nil {
+			return err
+		}
+		if _, err := edges.CreateBucket(edgeIndexBucket); err != nil {
+			return err
+		}
+		if _, err := edges.CreateBucket(edgeUpdateIndexBucket); err != nil {
+			return err
+		}
+		if _, err := edges.CreateBucket(channelPointBucket); err != nil {
+			return err
+		}
+
+		graphMeta, err := tx.CreateBucket(graphMetaBucket)
+		if err != nil {
+			return err
+		}
+		_, err = graphMeta.CreateBucket(pruneLogBucket)
+		if err != nil {
 			return err
 		}
 


### PR DESCRIPTION
In this PR, we fix a bug in the bucket creation code in
createChannelDB. This bug can cause migrations on older nodes to fail,
as we expect the bucket to already have been created. With this commit,
we ensure that all the buckets under the main node and edges bucket are
properly created. Otherwise, a set of the newer migrations will fail to
apply for nodes updating from 0.4.