### PR TITLE
[integration tests] Fix flake in persistent connection pruning test

### DIFF
--- a/lnd_test.go
+++ b/lnd_test.go
@@ -5676,6 +5676,17 @@ func testGarbageCollectLinkNodes(net *lntest.NetworkHarness, t *harnessTest) {
 	// reestablished her connection with Dave, as they still have an open
 	// channel together.
 	testReconnection := func(node *lntest.HarnessNode) {
+		// Restart both nodes, to trigger the pruning logic.
+		if err := net.RestartNode(node, nil); err != nil {
+			t.Fatalf("unable to restart %v's node: %v",
+				node.Name(), err)
+		}
+
+		if err := net.RestartNode(net.Alice, nil); err != nil {
+			t.Fatalf("unable to restart alice's node: %v", err)
+		}
+
+		// Now restart both nodes and make sure they don't reconnect.
 		if err := net.RestartNode(node, nil); err != nil {
 			t.Fatalf("unable to restart %v's node: %v", node.Name(),
 				err)


### PR DESCRIPTION
This fixes a flake within `testGarbageCollectLinkNodes` where we wouldn't properly check reconnection, since we were asserting the nodes didn't connect using a wait predicate. This led to the test passing in certain cases, since the predicate would be satisfied before the nodes had reconnected.

This PR changes this to a `WaitInvariant` to ensure we stay disconnected for 5 seconds.

Since we will prune the persistent connections only on peer connection, we must also do an extra restart to trigger the pruning logic, to make the test reliably pass.