### PR TITLE
release: Add ARMv6 platform to release.sh

### DIFF
--- a/release.sh
+++ b/release.sh
@@ -21,7 +21,7 @@ MAINDIR=$PACKAGE-$TAG
 mkdir -p $MAINDIR
 cd $MAINDIR
 
-SYS="windows-386 windows-amd64 openbsd-386 openbsd-amd64 linux-386 linux-amd64 linux-arm linux-arm64 darwin-386 darwin-amd64 dragonfly-amd64 freebsd-386 freebsd-amd64 freebsd-arm netbsd-386 netbsd-amd64 linux-mips64 linux-mips64le linux-ppc64 linux-arm64"
+SYS="windows-386 windows-amd64 openbsd-386 openbsd-amd64 linux-386 linux-amd64 linux-armv6 linux-armv7 linux-arm64 darwin-386 darwin-amd64 dragonfly-amd64 freebsd-386 freebsd-amd64 freebsd-arm netbsd-386 netbsd-amd64 linux-mips64 linux-mips64le linux-ppc64"
 
 # Use the first element of $GOPATH in the case where GOPATH is a list
 # (something that is totally allowed).
@@ -31,11 +31,19 @@ COMMITFLAGS="-X main.Commit=$(git rev-parse HEAD)"
 for i in $SYS; do
     OS=$(echo $i | cut -f1 -d-)
     ARCH=$(echo $i | cut -f2 -d-)
+    ARM=
+    if [[ $ARCH = "armv6" ]]; then
+      ARCH=arm
+      ARM=6
+    elif [[ $ARCH = "armv7" ]]; then
+      ARCH=arm
+      ARM=7
+    fi
     mkdir $PACKAGE-$i-$TAG
     cd $PACKAGE-$i-$TAG
-    echo "Building:" $OS $ARCH
-    env GOOS=$OS GOARCH=$ARCH go build -v -ldflags "$COMMITFLAGS" github.com/lightningnetwork/lnd
-    env GOOS=$OS GOARCH=$ARCH go build -v -ldflags "$COMMITFLAGS" github.com/lightningnetwork/lnd/cmd/lncli
+    echo "Building:" $OS $ARCH $ARM
+    env GOOS=$OS GOARCH=$ARCH GOARM=$ARM go build -v -ldflags "$COMMITFLAGS" github.com/lightningnetwork/lnd
+    env GOOS=$OS GOARCH=$ARCH GOARM=$ARM go build -v -ldflags "$COMMITFLAGS" github.com/lightningnetwork/lnd/cmd/lncli
     cd ..
     if [[ $OS = "windows" ]]; then
 	zip -r $PACKAGE-$i-$TAG.zip $PACKAGE-$i-$TAG


### PR DESCRIPTION
This PR adds a build for the `ARMv6` platform to `release.sh`. That's the platform that the *Raspberry Pi Zero* and the *Raspberry Pi Zero W* are built on. It does that by [providing `GOARM=6`](https://github.com/golang/go/wiki/GoArm#supported-architectures) to the `go build`.

This generates an entirely new package `lnd-linux-armv6-XYZ.tar.gz`.
For consistency, it also changes the release name of the previous `linux-arm` build to `lnd-linux-armv7-XYZ.tar.gz`.

It would be fantastic to have `Linux ARMv6` included, so that Pi Zero hackers (like me) don't have to build the released binaries ourselves or don't have to rely on unofficial releases.