### PR TITLE
discovery: Traffic shaping of gossip query replies

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -417,6 +417,14 @@
   version = "v0.3.0"
 
 [[projects]]
+  branch = "master"
+  digest = "1:c9e7a4b4d47c0ed205d257648b0e5b0440880cb728506e318f8ac7cd36270bc4"
+  name = "golang.org/x/time"
+  packages = ["rate"]
+  pruneopts = "UT"
+  revision = "fbb02b2291d28baffd63558aa44b4b56f178d650"
+
+[[projects]]
   digest = "1:c2dee8dbcc504d1a7858f5dbaed7c8b256c512c5e9e81480158c30185bbd2792"
   name = "google.golang.org/genproto"
   packages = [
@@ -532,6 +540,7 @@
     "golang.org/x/crypto/ssh/terminal",
     "golang.org/x/net/context",
     "golang.org/x/net/proxy",
+    "golang.org/x/time/rate",
     "google.golang.org/genproto/googleapis/api/annotations",
     "google.golang.org/grpc",
     "google.golang.org/grpc/codes",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -99,6 +99,10 @@
   revision = "ebe1bf3edb3325c393447059974de898d5133eb8"
 
 [[constraint]]
+  name = "golang.org/x/time"
+  revision = "fbb02b2291d28baffd63558aa44b4b56f178d650"
+
+[[constraint]]
   name = "google.golang.org/genproto"
   revision = "df60624c1e9b9d2973e889c7a1cff73155da81c4"
 


### PR DESCRIPTION
This PR replaces the simplistic rate limiting
technique added in 557cb6e, to use the
golang.org/x/time's rate limiter. This has the
benefit of performing traffic shaping to meet a
target maximum rate, and yet tolerate bursts. Bursts
are expected during initial sync, though should become
more rare afterwards. Performing traffic shaping with
this mechanism should improve the ability of the gossip
syncer to detect sustained bursts from the remote peer,
and penalize them appropriately.

This commit also modifies the default parameters to
accept bursts of 10 queries, with a target maximum
rate of 1 reply every 5 seconds.