### PR TITLE
channeldb: relax bucket assumptions for latest db migration

### DIFF
--- a/channeldb/migrations.go
+++ b/channeldb/migrations.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"crypto/sha256"
 	"encoding/binary"
-	"errors"
 	"fmt"
 
 	"github.com/coreos/bbolt"
@@ -474,20 +473,24 @@ func migratePruneEdgeUpdateIndex(tx *bolt.Tx) error {
 	if edges == nil {
 		return nil
 	}
-	edgeUpdateIndex := edges.Bucket(edgeUpdateIndexBucket)
-	if edgeUpdateIndex == nil {
-		return nil
+	edgeUpdateIndex, err := edges.CreateBucketIfNotExists(
+		edgeUpdateIndexBucket,
+	)
+	if err != nil {
+		return fmt.Errorf("unable to create/fetch edge update " +
+			"index bucket")
 	}
 
 	// Retrieve some buckets that will be needed later on. These should
 	// already exist given the assumption that the buckets above do as well.
-	edgeIndex := edges.Bucket(edgeIndexBucket)
+	edgeIndex, err := edges.CreateBucketIfNotExists(edgeIndexBucket)
 	if edgeIndex == nil {
-		return errors.New("edge index should exist but does not")
+		return fmt.Errorf("unable to create/fetch edge index " +
+			"bucket")
 	}
-	nodes := tx.Bucket(nodeBucket)
-	if nodes == nil {
-		return errors.New("node bucket should exist but does not")
+	nodes, err := tx.CreateBucketIfNotExists(nodeBucket)
+	if err != nil {
+		return fmt.Errorf("unable to make node bucket")
 	}
 
 	log.Info("Migrating database to properly prune edge update index")
@@ -496,7 +499,7 @@ func migratePruneEdgeUpdateIndex(tx *bolt.Tx) error {
 	// update index. To do so, we'll gather all of the existing policies
 	// within the graph to re-populate them later on.
 	var edgeKeys [][]byte
-	err := edges.ForEach(func(edgeKey, edgePolicyBytes []byte) error {
+	err = edges.ForEach(func(edgeKey, edgePolicyBytes []byte) error {
 		// All valid entries are indexed by a public key (33 bytes)
 		// followed by a channel ID (8 bytes), so we'll skip any entries
 		// with keys that do not match this.


### PR DESCRIPTION
In this commit, we no longer assume that the bucket hierarchy has been
created properly when applying the latest DB migration. On older nodes
that never obtained a channel graph, or updated _before_ the query sync
stuff was added, then they're missing buckets that the migration expects
them to have.

We fix this by simply creating the buckets as we go, if needed.