### PR TITLE
utxonursery: handle remote spends [DO NOT REVIEW]

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -175,8 +175,8 @@ flakehunter: build
 
 flake-unit:
 	@$(call print, "Flake hunting unit tests.")
-	$(UNIT) -count=1
-	while [ $$? -eq 0 ]; do /bin/sh -c "$(UNIT) -count=1"; done
+	GOTRACEBACK=all $(UNIT) -count=1
+	while [ $$? -eq 0 ]; do /bin/sh -c "GOTRACEBACK=all $(UNIT) -count=1"; done
 
 # ======
 # TRAVIS

--- a/nursery_store.go
+++ b/nursery_store.go
@@ -1457,6 +1457,7 @@ func (ns *nurseryStore) getLastGraduatedHeight(tx *bolt.Tx) (uint32, error) {
 // the last graduated height key.
 func (ns *nurseryStore) putLastGraduatedHeight(tx *bolt.Tx, height uint32) error {
 
+	utxnLog.Infof("Log last graduated height at %v", height)
 	// Ensure that the chain bucket for this nursery store exists.
 	chainBucket, err := tx.CreateBucketIfNotExists(ns.pfxChainKey)
 	if err != nil {

--- a/utxonursery.go
+++ b/utxonursery.go
@@ -548,11 +548,18 @@ func (u *utxoNursery) NurseryReport(
 				case lnwallet.CommitmentTimeLock:
 					report.AddLimboCommitment(&kid)
 
-				// An HTLC output on our commitment transaction
-				// where the second-layer transaction hasn't
-				// yet confirmed.
 				case lnwallet.HtlcAcceptedSuccessSecondLevel:
+					// An HTLC output on our commitment transaction
+					// where the second-layer transaction hasn't
+					// yet confirmed.
 					report.AddLimboStage1SuccessHtlc(&kid)
+
+				case lnwallet.HtlcOfferedRemoteTimeout:
+					// This is an HTLC output on the
+					// commitment transaction of the remote
+					// party. We are waiting for the CLTV
+					// timelock expire.
+					report.AddLimboDirectHtlc(&kid)
 				}
 
 			case bytes.HasPrefix(k, kndrPrefix):
@@ -1510,7 +1517,7 @@ func (c *contractMaturityReport) AddLimboStage1TimeoutHtlc(baby *babyOutput) {
 
 // AddLimboDirectHtlc adds a direct HTLC on the commitment transaction of the
 // remote party to the maturity report. This a CLTV time-locked output that
-// hasn't yet expired.
+// has or hasn't expired yet.
 func (c *contractMaturityReport) AddLimboDirectHtlc(kid *kidOutput) {
 	c.limboBalance += kid.Amount()
 

--- a/utxonursery_test.go
+++ b/utxonursery_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"github.com/lightningnetwork/lnd/channeldb"
 	"io/ioutil"
+	"math"
 	"os"
 	"reflect"
 	"testing"
@@ -531,6 +532,25 @@ func (ctx *nurseryTestContext) finish() {
 	case <-ctx.publishChan:
 		ctx.t.Fatalf("unexpected transactions published")
 	default:
+	}
+
+	// Assert that the database is empty. All channels removed and height
+	// index cleared.
+	nurseryChannels, err := ctx.nursery.cfg.Store.ListChannels()
+	if err != nil {
+		ctx.t.Fatal(err)
+	}
+	if len(nurseryChannels) > 0 {
+		ctx.t.Fatalf("Expected all channels to be removed from store")
+	}
+
+	activeHeights, err := ctx.nursery.cfg.Store.HeightsBelowOrEqual(
+		math.MaxUint32)
+	if err != nil {
+		ctx.t.Fatal(err)
+	}
+	if len(activeHeights) > 0 {
+		ctx.t.Fatalf("Expected height index to be empty")
 	}
 }
 

--- a/utxonursery_test.go
+++ b/utxonursery_test.go
@@ -501,6 +501,28 @@ func (ctx *nurseryTestContext) finish() {
 	// Add a final restart point in this state
 	ctx.restart()
 
+	// We assume that when finish is called, nursery has finished all its
+	// goroutines. This implies that the waitgroup is empty.
+	signalChan := make(chan struct{})
+	go func() {
+		ctx.nursery.wg.Wait()
+		close(signalChan)
+	}()
+
+	// The only goroutine that is still expected to be running is
+	// incubator(). Simulate exit of this goroutine.
+	ctx.nursery.wg.Done()
+
+	// We now expect the Wait to succeed.
+	select {
+	case <-signalChan:
+	case <-time.After(time.Second):
+		ctx.t.Fatalf("lingering goroutines detected after test is finished")
+	}
+
+	// Restore waitgroup state to what it was before.
+	ctx.nursery.wg.Add(1)
+
 	ctx.nursery.Stop()
 
 	// We should have consumed and asserted all published transactions in

--- a/utxonursery_test.go
+++ b/utxonursery_test.go
@@ -574,12 +574,7 @@ func incubateTestOutput(t *testing.T, nursery *utxoNursery,
 	if onLocalCommitment {
 		expectedStage = 1
 	}
-
-	// TODO(joostjager): Nursery is currently not reporting this limbo
-	// balance.
-	if onLocalCommitment {
-		assertNurseryReport(t, nursery, 1, expectedStage)
-	}
+	assertNurseryReport(t, nursery, 1, expectedStage)
 
 	return outgoingRes
 }

--- a/utxonursery_test.go
+++ b/utxonursery_test.go
@@ -600,11 +600,9 @@ func incubateTestOutput(t *testing.T, nursery *utxoNursery,
 	outgoingRes := createOutgoingRes(onLocalCommitment)
 
 	// Hand off to nursery.
-	err := nursery.IncubateOutputs(
+	err := nursery.IncubateOutgoingHtlcOutput(
 		testChanPoint,
-		nil,
-		[]lnwallet.OutgoingHtlcResolution{*outgoingRes},
-		nil,
+		*outgoingRes,
 	)
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
**PR will probably be abandoned, as we are on track to eventually remove nursery (#2000)**

In this PR, utxonursery is made aware of the possibility that the remote party can spent outputs with the payment hash pre-image. 

Currently, outgoing htlcs are sometimes handed off from resolvers to nursery when they are still contested. This can happen when:
- In the broadcast delta period. This instantiates a timeout resolver that is not watching for remote spends.
- Between expiry of the CTLV lock (that is when hand off to nursery takes place) and confirmation of the timeout tx (local commitment published) or sweep tx (remote commitment published).

Possible consequences of a remote spend after hand-off are:

1. Incorrect htlc status reported in the `pendingchannels` rpc call.
2. Trying to include a spent output in the sweep tx, making the sweep fail and losing the other mature outputs on that height.
3. Not registering the pre-image, causing potential loss of funds by not being able to claim upstream.

This PR addresses issue 1 and part of issue 2. When a remote spend is detected, nursery moves the output into a seperate `spnd` bucket and removes it from the height index. It will not be included anymore in the subsequent sweep tx, unless the sweep tx was already constructed (*). When outputs are moved to the spnd bucket, they will be reported as "stage 0" in the htlc maturity report and also not count towards limbo balance anymore.

(*) This problem is to be solved in a follow-up PR. Possible fix could be to reconstruct the sweep tx when the height index is changed.

For issue 3, the ground work is laid by detecting the remote spend. One possible way to build this out is to extract the pre-image and signal it to the pre-image cache. 

Now that nursery has a broader view on the status of the outputs that it is managing, the road is opened to broadcasting relevant output events (in particular the final states graduated and remote spend) to the contract resolvers. This will remove the duplication of tracking code that is present in the resolvers.

