### PR TITLE
travis cache

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,12 @@
 language: go
-matrix:
-  include:
-  - go: "1.11.x"
-    env: RACE=true LINT=true
-  - go: "1.11.x"
-    env: ITEST=true COVER=true LINT=true
+go:
+  - "1.11.x"
+
+env:
+  matrix:
+    - RACE=true LINT=true
+    - ITEST=true
+    - COVER=true
 
 sudo: required
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,15 +9,17 @@ matrix:
     env: RACE=TRUE USE_LINT=FALSE
   - go: "1.10.x"
     env: RACE=FALSE USE_LINT=FALSE
+
 sudo: required
 install:
   - sudo add-apt-repository -y ppa:bitcoin/bitcoin -y
   - sudo apt-get update -q
   - sudo apt-get install bitcoind -y
   - export PATH=$PATH:$PWD/linux-amd64/
+
 script:
-  - export PATH=$PATH:$GOPATH/bin
   - make travis
+
 after_script:
   - echo "Uploading to termbin.com..." && find *.log | xargs -I{} sh -c "cat {} | nc termbin.com 9999 | xargs -r0 printf '{} uploaded to %s'"
   - echo "Uploading to file.io..." && tar -zcvO *.log | curl -s -F 'file=@-;filename=logs.tar.gz' https://file.io | xargs -r0 printf 'logs.tar.gz uploaded to %s\n'

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,10 +5,6 @@ matrix:
     env: RACE=true LINT=true
   - go: "1.11.x"
     env: ITEST=true COVER=true LINT=true
-  - go: "1.10.x"
-    env: RACE=true LINT=false
-  - go: "1.10.x"
-    env: ITEST=true COVER=true LINT=false
 
 sudo: required
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,18 @@
 language: go
+cache:
+  directories:
+    - vendor/
+    - $GOCACHE
+    - $GOPATH/src/github.com/btcsuite
+    - $GOPATH/src/github.com/golang
+    - $GOPATH/src/gopkg.in/alecthomas
+
 go:
   - "1.11.x"
 
 env:
+  global:
+    - GOCACHE=$HOME/.go-build
   matrix:
     - RACE=true LINT=true
     - ITEST=true

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,13 +2,13 @@ language: go
 matrix:
   include:
   - go: "1.11.x"
-    env: RACE=TRUE USE_LINT=TRUE
+    env: RACE=true LINT=true
   - go: "1.11.x"
-    env: RACE=FALSE USE_LINT=TRUE
+    env: ITEST=true COVER=true LINT=true
   - go: "1.10.x"
-    env: RACE=TRUE USE_LINT=FALSE
+    env: RACE=true LINT=false
   - go: "1.10.x"
-    env: RACE=FALSE USE_LINT=FALSE
+    env: ITEST=true COVER=true LINT=false
 
 sudo: required
 install:
@@ -18,7 +18,23 @@ install:
   - export PATH=$PATH:$PWD/linux-amd64/
 
 script:
-  - make travis
+  # Common for all builds.
+  - make dep
+  - make btcd
+
+  # Run linter if LINT=true.
+  - 'if [ "$LINT" = true ]; then make lint ; fi'
+
+  # Run unit tests with race condition detector.
+  - 'if [ "$RACE" = true ]; then make unit-race ; fi'
+
+  # Run integration tests.
+  - 'if [ "$ITEST" = true ]; then make build ; fi'
+  - 'if [ "$ITEST" = true ]; then make itest-only ; fi'
+
+  # Run unit tests and generate coverage report.
+  - 'if [ "$COVER" = true ]; then make unit-cover; fi'
+  - 'if [ "$COVER" = true ]; then make goveralls; fi'
 
 after_script:
   - echo "Uploading to termbin.com..." && find *.log | xargs -I{} sh -c "cat {} | nc termbin.com 9999 | xargs -r0 printf '{} uploaded to %s'"

--- a/Makefile
+++ b/Makefile
@@ -186,26 +186,6 @@ flake-unit:
 	GOTRACEBACK=all $(UNIT) -count=1
 	while [ $$? -eq 0 ]; do /bin/sh -c "GOTRACEBACK=all $(UNIT) -count=1"; done
 
-# ======
-# TRAVIS
-# ======
-
-ifeq ($(RACE)$(USE_LINT), FALSETRUE)
-travis: dep lint build itest unit-cover goveralls
-endif
-
-ifeq ($(RACE)$(USE_LINT), FALSEFALSE)
-travis: dep build itest unit-cover goveralls
-endif
-
-ifeq ($(RACE)$(USE_LINT), TRUETRUE)
-travis: dep lint btcd unit-race
-endif
-
-ifeq ($(RACE)$(USE_LINT), TRUEFALSE)
-travis: dep btcd unit-race
-endif
-
 # =========
 # UTILITIES
 # =========
@@ -252,7 +232,6 @@ clean:
 	goveralls \
 	flakehunter \
 	flake-unit \
-	travis \
 	fmt \
 	lint \
 	list \

--- a/Makefile
+++ b/Makefile
@@ -110,7 +110,6 @@ $(GOVERALLS_BIN):
 $(LINT_BIN):
 	@$(call print, "Fetching gometalinter.v2")
 	go get -u $(LINT_PKG)
-	$(GOINSTALL) $(LINT_PKG)
 
 dep: $(DEP_BIN)
 	@$(call print, "Compiling dependencies.")

--- a/Makefile
+++ b/Makefile
@@ -149,9 +149,11 @@ scratch: dep build
 
 check: unit itest
 
-itest: btcd build
+itest-only: 
 	@$(call print, "Running integration tests.")
 	$(ITEST)
+
+itest: btcd build itest-only
 
 unit: btcd
 	@$(call print, "Running unit tests.")
@@ -242,6 +244,7 @@ clean:
 	install \
 	scratch \
 	check \
+	itest-only \
 	itest \
 	unit \
 	unit-cover \

--- a/Makefile
+++ b/Makefile
@@ -167,6 +167,10 @@ unit-race:
 	export CGO_ENABLED=1; env GORACE="history_size=7 halt_on_errors=1" $(UNIT_RACE)
 	export CGO_ENABLED=$(CGO_STATUS_QUO)
 
+goveralls: $(GOVERALLS_BIN)
+	@$(call print, "Sending coverage report.")
+	$(GOVERALLS_BIN) -coverprofile=profile.cov -service=travis-ci
+
 # =============
 # FLAKE HUNTING
 # =============
@@ -185,15 +189,11 @@ flake-unit:
 # ======
 
 ifeq ($(RACE)$(USE_LINT), FALSETRUE)
-travis: dep lint build itest unit-cover $(GOVERALLS_BIN)
-	@$(call print, "Sending coverage report.")
-	$(GOVERALLS_BIN) -coverprofile=profile.cov -service=travis-ci
+travis: dep lint build itest unit-cover goveralls
 endif
 
 ifeq ($(RACE)$(USE_LINT), FALSEFALSE)
-travis: dep build itest unit-cover $(GOVERALLS_BIN)
-	@$(call print, "Sending coverage report.")
-	$(GOVERALLS_BIN) -coverprofile=profile.cov -service=travis-ci
+travis: dep build itest unit-cover goveralls
 endif
 
 ifeq ($(RACE)$(USE_LINT), TRUETRUE)
@@ -246,6 +246,7 @@ clean:
 	unit \
 	unit-cover \
 	unit-race \
+	goveralls \
 	flakehunter \
 	flake-unit \
 	travis \


### PR DESCRIPTION
## UPDATED
This PR restructures the Travis build pipeline to speed up the existing build, and prepare for multibackend integration test builds.

* The builds using `go 1.10` are removed. We only run on `go 1.11.x` now.
* The integration test and unit-coverage build is separated into two builds. 
* The build directories are cached, which makes building as well as the unit-race runs significantly faster.

Overall the longest build is now about 16 minutes if a cache exists. This is down from about 28 minutes.

### Original
This PR adds caching for a few directories used by Travis, to speed up the bulid process. 

|            | go 1.9.4 | go 1.10 | go 1.9.4 (cache) | go 1.10 (cache) |
|------------|----------|---------|------------------|-----------------|
| race=false | 28m 31s  | 23m 46s | 27m 36s          | 21m 08s         |
| race=true  | 31m 39s  | 27m 24s | 31m 28s          | 12m 01s         |

(https://travis-ci.org/lightningnetwork/lnd/builds/428112578 and https://travis-ci.org/lightningnetwork/lnd/builds/428125178)

Most notably is the caching of the `$GOCACHE` dir, reduces the `unit-race` test build for `go 1.10` from 27m to 12m! This is a result of test results now being cached. Also the other runs are sped up a bit, but not by as much.

The next step would be to break up the `race=false` test into separate tests for `itest` and `unit-cover`, as they both are long, and independent. This together with `go 1.10+` should make the longest running build about 12-14m.