### PR TITLE
build: update to new btcwallet to set birthday for bitcoind backend

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -106,7 +106,7 @@
   revision = "ab6388e0c60ae4834a1f57511e20c17b5f78be4b"
 
 [[projects]]
-  digest = "1:012039cbb6694894aa9e9890645e6ade8a5aff5a02c279714779eff3eae53bc2"
+  digest = "1:316f670e7f97526601bfa2104f7df2569440223f4b5730f2d0deaab5ec634dab"
   name = "github.com/btcsuite/btcwallet"
   packages = [
     "chain",
@@ -126,7 +126,8 @@
     "wtxmgr",
   ]
   pruneopts = "UT"
-  revision = "f4ae41ce5f5834eb67ab64cdeed74c74fc95638c"
+  revision = "ed47296c885c2512e1fe54dd67020b551a113e89"
+  source = "github.com/wpaulino/btcwallet"
 
 [[projects]]
   branch = "master"
@@ -417,7 +418,6 @@
   version = "v0.3.0"
 
 [[projects]]
-  branch = "master"
   digest = "1:c9e7a4b4d47c0ed205d257648b0e5b0440880cb728506e318f8ac7cd36270bc4"
   name = "golang.org/x/time"
   packages = ["rate"]

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -72,7 +72,8 @@
 
 [[constraint]]
   name = "github.com/btcsuite/btcwallet"
-  revision = "f4ae41ce5f5834eb67ab64cdeed74c74fc95638c"
+  revision = "ed47296c885c2512e1fe54dd67020b551a113e89"
+  source = "github.com/wpaulino/btcwallet"
 
 [[constraint]]
   name = "github.com/tv42/zbase32"

--- a/chainntnfs/bitcoindnotify/bitcoind.go
+++ b/chainntnfs/bitcoindnotify/bitcoind.go
@@ -6,7 +6,6 @@ import (
 	"strings"
 	"sync"
 	"sync/atomic"
-	"time"
 
 	"github.com/btcsuite/btcd/btcjson"
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
@@ -115,7 +114,7 @@ func New(chainConn *chain.BitcoindConn, spendHintCache chainntnfs.SpendHintCache
 		quit: make(chan struct{}),
 	}
 
-	notifier.chainConn = chainConn.NewBitcoindClient(time.Unix(0, 0))
+	notifier.chainConn = chainConn.NewBitcoindClient()
 
 	return notifier
 }

--- a/chainregistry.go
+++ b/chainregistry.go
@@ -335,7 +335,7 @@ func newChainControlFromConfig(cfg *config, chanDB *channeldb.DB,
 			bitcoindConn, hintCache, hintCache,
 		)
 		cc.chainView = chainview.NewBitcoindFilteredChainView(bitcoindConn)
-		walletConfig.ChainSource = bitcoindConn.NewBitcoindClient(birthday)
+		walletConfig.ChainSource = bitcoindConn.NewBitcoindClient()
 
 		// If we're not in regtest mode, then we'll attempt to use a
 		// proper fee estimator for testnet.

--- a/lnwallet/interface_test.go
+++ b/lnwallet/interface_test.go
@@ -2278,8 +2278,8 @@ func runTests(t *testing.T, walletDriver *lnwallet.WalletDriver,
 
 			// Create a btcwallet bitcoind client for both Alice and
 			// Bob.
-			aliceClient = chainConn.NewBitcoindClient(time.Unix(0, 0))
-			bobClient = chainConn.NewBitcoindClient(time.Unix(0, 0))
+			aliceClient = chainConn.NewBitcoindClient()
+			bobClient = chainConn.NewBitcoindClient()
 		default:
 			t.Fatalf("unknown chain driver: %v", backEnd)
 		}

--- a/routing/chainview/bitcoind.go
+++ b/routing/chainview/bitcoind.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"sync"
 	"sync/atomic"
-	"time"
 
 	"github.com/btcsuite/btcd/btcjson"
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
@@ -71,7 +70,7 @@ func NewBitcoindFilteredChainView(
 		quit:            make(chan struct{}),
 	}
 
-	chainView.chainClient = chainConn.NewBitcoindClient(time.Unix(0, 0))
+	chainView.chainClient = chainConn.NewBitcoindClient()
 	chainView.blockQueue = newBlockEventQueue()
 
 	return chainView


### PR DESCRIPTION
In this PR, we update our `btcwallet` dependency in order to correctly set the wallet's backing chain client's birthday correctly when running with a bitcoind backend. This problem arose due to https://github.com/lightningnetwork/lnd/commit/1ac1092aaab3b8712e9612df283300689a79ec3e. When running `lnd` with `--noencryptwallet`, this would pass the default birthday of `time.Now()` into the `BitcoindClient` used in the wallet, causing us to ignore blocks that were mined while we were offline.

Depends on https://github.com/btcsuite/btcwallet/pull/542.