### PR TITLE
lnwire: query_short_chan_ids index out of bounds

### DIFF
--- a/lnwire/query_short_chan_ids.go
+++ b/lnwire/query_short_chan_ids.go
@@ -112,7 +112,7 @@ func decodeShortChanIDs(r io.Reader) (ShortChanIDEncoding, []ShortChannelID, err
 		return 0, nil, err
 	}
 
-	if (numBytesResp == 0) {
+	if numBytesResp == 0 {
 		return 0, nil, fmt.Errorf("No encoding type specified")
 	}
 

--- a/lnwire/query_short_chan_ids.go
+++ b/lnwire/query_short_chan_ids.go
@@ -112,6 +112,10 @@ func decodeShortChanIDs(r io.Reader) (ShortChanIDEncoding, []ShortChannelID, err
 		return 0, nil, err
 	}
 
+	if (numBytesResp == 0) {
+		return 0, nil, fmt.Errorf("No encoding type specified")
+	}
+
 	queryBody := make([]byte, numBytesResp)
 	if _, err := io.ReadFull(r, queryBody); err != nil {
 		return 0, nil, err


### PR DESCRIPTION
This commit fixes a bug that go-fuzz found when fuzzing the lnwire protocol messages.  If an EncodingType is not set in the QueryShortChanIDs / ReplyChannelRange message, then the receiving peer's lnd instance will crash with an index out of range error because no check is done for an unset EncodingType.