### PR TITLE
LightningChannel start method

### DIFF
--- a/breacharbiter_test.go
+++ b/breacharbiter_test.go
@@ -1132,7 +1132,8 @@ func TestBreachHandoffFail(t *testing.T) {
 		alicesPrivKey)
 	aliceSigner := &mockSigner{aliceKeyPriv}
 
-	alice2, err := lnwallet.NewLightningChannel(aliceSigner, nil, alice.State())
+	alice2 := lnwallet.NewLightningChannel(aliceSigner, nil, alice.State())
+	err = alice2.Start()
 	if err != nil {
 		t.Fatalf("unable to create test channels: %v", err)
 	}
@@ -1570,15 +1571,17 @@ func createInitChannels(revocationWindow int) (*lnwallet.LightningChannel, *lnwa
 	aliceSigner := &mockSigner{aliceKeyPriv}
 	bobSigner := &mockSigner{bobKeyPriv}
 
-	channelAlice, err := lnwallet.NewLightningChannel(
+	channelAlice := lnwallet.NewLightningChannel(
 		aliceSigner, pCache, aliceChannelState,
 	)
+	err = channelAlice.Start()
 	if err != nil {
 		return nil, nil, nil, err
 	}
-	channelBob, err := lnwallet.NewLightningChannel(
+	channelBob := lnwallet.NewLightningChannel(
 		bobSigner, pCache, bobChannelState,
 	)
+	err = channelBob.Start()
 	if err != nil {
 		return nil, nil, nil, err
 	}

--- a/contractcourt/chain_arbitrator.go
+++ b/contractcourt/chain_arbitrator.go
@@ -236,12 +236,6 @@ func newActiveChannelArbitrator(channel *channeldb.OpenChannel,
 			chanMachine := lnwallet.NewLightningChannel(
 				c.cfg.Signer, c.cfg.PreimageDB, channel)
 
-			err = chanMachine.Start()
-			if err != nil {
-				return nil, err
-			}
-			chanMachine.Stop()
-
 			if err := c.cfg.MarkLinkInactive(chanPoint); err != nil {
 				log.Errorf("unable to mark link inactive: %v", err)
 			}

--- a/contractcourt/chain_arbitrator.go
+++ b/contractcourt/chain_arbitrator.go
@@ -233,8 +233,10 @@ func newActiveChannelArbitrator(channel *channeldb.OpenChannel,
 				return nil, fmt.Errorf("unable to find channel")
 			}
 
-			chanMachine, err := lnwallet.NewLightningChannel(
+			chanMachine := lnwallet.NewLightningChannel(
 				c.cfg.Signer, c.cfg.PreimageDB, channel)
+
+			err = chanMachine.Start()
 			if err != nil {
 				return nil, err
 			}

--- a/fundingmanager.go
+++ b/fundingmanager.go
@@ -1672,12 +1672,6 @@ func (f *fundingManager) handleFundingSigned(fmsg *fundingSignedMsg) {
 		lnChannel := lnwallet.NewLightningChannel(
 			nil, nil, completeChan,
 		)
-		err = lnChannel.Start()
-		if err != nil {
-			fndgLog.Errorf("failed creating lnChannel: %v", err)
-			return
-		}
-		defer lnChannel.Stop()
 
 		err = f.sendFundingLocked(
 			fmsg.peer, completeChan, lnChannel, shortChanID,
@@ -1963,17 +1957,12 @@ func (f *fundingManager) handleFundingConfirmation(peer lnpeer.Peer,
 	lnChannel := lnwallet.NewLightningChannel(
 		nil, nil, completeChan,
 	)
-	err := lnChannel.Start()
-	if err != nil {
-		return err
-	}
-	defer lnChannel.Stop()
 
 	chanID := lnwire.NewChanIDFromOutPoint(&completeChan.FundingOutpoint)
 
 	fndgLog.Debugf("ChannelID(%v) is now fully confirmed!", chanID)
 
-	err = f.sendFundingLocked(peer, completeChan, lnChannel, shortChanID)
+	err := f.sendFundingLocked(peer, completeChan, lnChannel, shortChanID)
 	if err != nil {
 		return fmt.Errorf("failed sending fundingLocked: %v", err)
 	}

--- a/fundingmanager.go
+++ b/fundingmanager.go
@@ -1669,9 +1669,10 @@ func (f *fundingManager) handleFundingSigned(fmsg *fundingSignedMsg) {
 
 		// Go on adding the channel to the channel graph, and crafting
 		// channel announcements.
-		lnChannel, err := lnwallet.NewLightningChannel(
+		lnChannel := lnwallet.NewLightningChannel(
 			nil, nil, completeChan,
 		)
+		err = lnChannel.Start()
 		if err != nil {
 			fndgLog.Errorf("failed creating lnChannel: %v", err)
 			return
@@ -1959,9 +1960,10 @@ func (f *fundingManager) handleFundingConfirmation(peer lnpeer.Peer,
 	shortChanID *lnwire.ShortChannelID) error {
 
 	// We create the state-machine object which wraps the database state.
-	lnChannel, err := lnwallet.NewLightningChannel(
+	lnChannel := lnwallet.NewLightningChannel(
 		nil, nil, completeChan,
 	)
+	err := lnChannel.Start()
 	if err != nil {
 		return err
 	}

--- a/fundingmanager_test.go
+++ b/fundingmanager_test.go
@@ -312,10 +312,13 @@ func createTestFundingManager(t *testing.T, privKey *btcec.PrivateKey,
 
 			for _, channel := range dbChannels {
 				if chanID.IsChanPoint(&channel.FundingOutpoint) {
-					return lnwallet.NewLightningChannel(
-						signer,
-						nil,
-						channel)
+					lc := lnwallet.NewLightningChannel(
+						signer, nil, channel,
+					)
+					if err := lc.Start(); err != nil {
+						return nil, err
+					}
+					return lc, nil
 				}
 			}
 

--- a/htlcswitch/test_utils.go
+++ b/htlcswitch/test_utils.go
@@ -369,15 +369,17 @@ func createTestChannel(alicePrivKey, bobPrivKey []byte,
 		preimageMap: make(map[[32]byte][]byte),
 	}
 
-	channelAlice, err := lnwallet.NewLightningChannel(
+	channelAlice := lnwallet.NewLightningChannel(
 		aliceSigner, pCache, aliceChannelState,
 	)
+	err = channelAlice.Start()
 	if err != nil {
 		return nil, nil, nil, nil, err
 	}
-	channelBob, err := lnwallet.NewLightningChannel(
+	channelBob := lnwallet.NewLightningChannel(
 		bobSigner, pCache, bobChannelState,
 	)
+	channelBob.Start()
 	if err != nil {
 		return nil, nil, nil, nil, err
 	}
@@ -434,8 +436,9 @@ func createTestChannel(alicePrivKey, bobPrivKey []byte,
 			return nil, nil, errors.New("unable to find stored alice channel")
 		}
 
-		newAliceChannel, err := lnwallet.NewLightningChannel(aliceSigner,
+		newAliceChannel := lnwallet.NewLightningChannel(aliceSigner,
 			nil, aliceStoredChannel)
+		err = newAliceChannel.Start()
 		if err != nil {
 			return nil, nil, errors.Errorf("unable to create new channel: %v",
 				err)
@@ -473,8 +476,9 @@ func createTestChannel(alicePrivKey, bobPrivKey []byte,
 			return nil, nil, errors.New("unable to find stored bob channel")
 		}
 
-		newBobChannel, err := lnwallet.NewLightningChannel(bobSigner,
+		newBobChannel := lnwallet.NewLightningChannel(bobSigner,
 			nil, bobStoredChannel)
+		err = newBobChannel.Start()
 		if err != nil {
 			return nil, nil, errors.Errorf("unable to create new channel: %v",
 				err)

--- a/lnwallet/channel_test.go
+++ b/lnwallet/channel_test.go
@@ -1444,15 +1444,17 @@ func TestStateUpdatePersistence(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unable to fetch channel: %v", err)
 	}
-	aliceChannelNew, err := NewLightningChannel(
+	aliceChannelNew := NewLightningChannel(
 		aliceChannel.Signer, nil, aliceChannels[0],
 	)
+	err = aliceChannelNew.Start()
 	if err != nil {
 		t.Fatalf("unable to create new channel: %v", err)
 	}
-	bobChannelNew, err := NewLightningChannel(
+	bobChannelNew := NewLightningChannel(
 		bobChannel.Signer, nil, bobChannels[0],
 	)
+	err = bobChannelNew.Start()
 	if err != nil {
 		t.Fatalf("unable to create new channel: %v", err)
 	}
@@ -2544,16 +2546,19 @@ func TestChanSyncFullySynced(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unable to fetch channel: %v", err)
 	}
-	aliceChannelNew, err := NewLightningChannel(
+	aliceChannelNew := NewLightningChannel(
 		aliceChannel.Signer, nil, aliceChannels[0],
 	)
+	err = aliceChannelNew.Start()
 	if err != nil {
 		t.Fatalf("unable to create new channel: %v", err)
 	}
 	defer aliceChannelNew.Stop()
-	bobChannelNew, err := NewLightningChannel(
+
+	bobChannelNew := NewLightningChannel(
 		bobChannel.Signer, nil, bobChannels[0],
 	)
+	err = bobChannelNew.Start()
 	if err != nil {
 		t.Fatalf("unable to create new channel: %v", err)
 	}
@@ -2574,9 +2579,10 @@ func restartChannel(channelOld *LightningChannel) (*LightningChannel, error) {
 		return nil, err
 	}
 
-	channelNew, err := NewLightningChannel(
+	channelNew := NewLightningChannel(
 		channelOld.Signer, channelOld.pCache, nodeChannels[0],
 	)
+	err = channelNew.Start()
 	if err != nil {
 		return nil, err
 	}
@@ -5578,17 +5584,19 @@ func TestChannelRestoreUpdateLogs(t *testing.T) {
 
 	// We now re-create the channels, mimicking a restart. This should sync
 	// the update logs up to the correct state set up above.
-	newAliceChannel, err := NewLightningChannel(
+	newAliceChannel := NewLightningChannel(
 		aliceChannel.Signer, nil, aliceChannel.channelState,
 	)
+	err = newAliceChannel.Start()
 	if err != nil {
 		t.Fatalf("unable to create new channel: %v", err)
 	}
 	defer newAliceChannel.Stop()
 
-	newBobChannel, err := NewLightningChannel(
+	newBobChannel := NewLightningChannel(
 		bobChannel.Signer, nil, bobChannel.channelState,
 	)
+	err = newBobChannel.Start()
 	if err != nil {
 		t.Fatalf("unable to create new channel: %v", err)
 	}
@@ -5659,9 +5667,10 @@ func assertInLogs(t *testing.T, channel *LightningChannel, numAddsLocal,
 // expected state.
 func restoreAndAssert(t *testing.T, channel *LightningChannel, numAddsLocal,
 	numFailsLocal, numAddsRemote, numFailsRemote int) {
-	newChannel, err := NewLightningChannel(
+	newChannel := NewLightningChannel(
 		channel.Signer, nil, channel.channelState,
 	)
+	err := newChannel.Start()
 	if err != nil {
 		t.Fatalf("unable to create new channel: %v", err)
 	}
@@ -5974,9 +5983,10 @@ func TestChannelRestoreCommitHeight(t *testing.T) {
 		expLocal, expRemote uint64) *LightningChannel {
 
 		channel.Stop()
-		newChannel, err := NewLightningChannel(
+		newChannel := NewLightningChannel(
 			channel.Signer, nil, channel.channelState,
 		)
+		err := newChannel.Start()
 		if err != nil {
 			t.Fatalf("unable to create new channel: %v", err)
 		}

--- a/lnwallet/test_utils.go
+++ b/lnwallet/test_utils.go
@@ -309,15 +309,18 @@ func CreateTestChannels() (*LightningChannel, *LightningChannel, func(), error) 
 	}
 
 	// TODO(roasbeef): make mock version of pre-image store
-	channelAlice, err := NewLightningChannel(
+	channelAlice := NewLightningChannel(
 		aliceSigner, pCache, aliceChannelState,
 	)
+	err = channelAlice.Start()
 	if err != nil {
 		return nil, nil, nil, err
 	}
-	channelBob, err := NewLightningChannel(
+
+	channelBob := NewLightningChannel(
 		bobSigner, pCache, bobChannelState,
 	)
+	err = channelBob.Start()
 	if err != nil {
 		return nil, nil, nil, err
 	}

--- a/peer.go
+++ b/peer.go
@@ -377,9 +377,10 @@ func (p *peer) QuitSignal() <-chan struct{} {
 func (p *peer) loadActiveChannels(chans []*channeldb.OpenChannel) error {
 	var activePublicChans []wire.OutPoint
 	for _, dbChan := range chans {
-		lnChan, err := lnwallet.NewLightningChannel(
+		lnChan := lnwallet.NewLightningChannel(
 			p.server.cc.signer, p.server.witnessBeacon, dbChan,
 		)
+		err := lnChan.Start()
 		if err != nil {
 			return err
 		}

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -1062,7 +1062,6 @@ func (r *rpcServer) CloseChannel(in *lnrpc.CloseChannelRequest,
 	if err != nil {
 		return err
 	}
-	channel.Stop()
 
 	// If a force closure was requested, then we'll handle all the details
 	// around the creation and broadcast of the unilateral closure
@@ -1226,13 +1225,9 @@ func (r *rpcServer) fetchActiveChannel(chanPoint wire.OutPoint) (*lnwallet.Light
 
 	// Otherwise, we create a fully populated channel state machine which
 	// uses the db channel as backing storage.
-	lc := lnwallet.NewLightningChannel(
+	return lnwallet.NewLightningChannel(
 		r.server.cc.wallet.Cfg.Signer, nil, dbChan,
-	)
-	if err := lc.Start(); err != nil {
-		return nil, err
-	}
-	return lc, nil
+	), nil
 }
 
 // GetInfo returns general information concerning the lightning node including

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -1226,9 +1226,13 @@ func (r *rpcServer) fetchActiveChannel(chanPoint wire.OutPoint) (*lnwallet.Light
 
 	// Otherwise, we create a fully populated channel state machine which
 	// uses the db channel as backing storage.
-	return lnwallet.NewLightningChannel(
+	lc := lnwallet.NewLightningChannel(
 		r.server.cc.wallet.Cfg.Signer, nil, dbChan,
 	)
+	if err := lc.Start(); err != nil {
+		return nil, err
+	}
+	return lc, nil
 }
 
 // GetInfo returns general information concerning the lightning node including

--- a/server.go
+++ b/server.go
@@ -751,14 +751,10 @@ func newServer(listenAddrs []net.Addr, chanDB *channeldb.DB, cc *chainControl,
 
 			for _, channel := range dbChannels {
 				if chanID.IsChanPoint(&channel.FundingOutpoint) {
-					lc := lnwallet.NewLightningChannel(
+					return lnwallet.NewLightningChannel(
 						cc.signer, s.witnessBeacon,
 						channel,
-					)
-					if err := lc.Start(); err != nil {
-						return nil, err
-					}
-					return lc, nil
+					), nil
 				}
 			}
 

--- a/server.go
+++ b/server.go
@@ -751,10 +751,14 @@ func newServer(listenAddrs []net.Addr, chanDB *channeldb.DB, cc *chainControl,
 
 			for _, channel := range dbChannels {
 				if chanID.IsChanPoint(&channel.FundingOutpoint) {
-					return lnwallet.NewLightningChannel(
+					lc := lnwallet.NewLightningChannel(
 						cc.signer, s.witnessBeacon,
 						channel,
 					)
+					if err := lc.Start(); err != nil {
+						return nil, err
+					}
+					return lc, nil
 				}
 			}
 

--- a/test_utils.go
+++ b/test_utils.go
@@ -298,15 +298,17 @@ func createTestPeer(notifier chainntnfs.ChainNotifier,
 	aliceSigner := &mockSigner{aliceKeyPriv}
 	bobSigner := &mockSigner{bobKeyPriv}
 
-	channelAlice, err := lnwallet.NewLightningChannel(
+	channelAlice := lnwallet.NewLightningChannel(
 		aliceSigner, nil, aliceChannelState,
 	)
+	err = channelAlice.Start()
 	if err != nil {
 		return nil, nil, nil, nil, err
 	}
-	channelBob, err := lnwallet.NewLightningChannel(
+	channelBob := lnwallet.NewLightningChannel(
 		bobSigner, nil, bobChannelState,
 	)
+	err = channelBob.Start()
 	if err != nil {
 		return nil, nil, nil, nil, err
 	}


### PR DESCRIPTION
This PR cleans up the the usage of `lnwallet.LightningChannel` by introducing a `Start` method. 

Previously the channel would be started automatically in the call to `NewLightningChannel`. This lead to situations where the channel struct was needed, but not an active channel machine, so one would need to immediately stop the channel after creating it.

This PR first refactors the codebase to use the `Start` method to mimic the previous behaviour, then one by one removes the few instances where starting the channel is not needed.

In doing this it also fixes #1575, but it can go in together with #1905, as they both adds an extra layer of security.