### PR TITLE
Fundingmanager state machine cleanup

### DIFF
--- a/fundingmanager.go
+++ b/fundingmanager.go
@@ -1792,6 +1792,14 @@ func (f *fundingManager) handleFundingSigned(fmsg *fundingSignedMsg) {
 			}
 		}
 
+		err = f.handleFundingConfirmation(completeChan, *shortChanID)
+		if err != nil {
+			fndgLog.Errorf("unable to handle funding confirmation "+
+				"for ChannelPoint(%v): %v",
+				completeChan.FundingOutpoint, err)
+			return
+		}
+
 		fndgLog.Debugf("Channel with ShortChanID %v now confirmed",
 			shortChanID.ToUint64())
 
@@ -1870,6 +1878,16 @@ func (f *fundingManager) waitForFundingWithTimeout(completeChan *channeldb.OpenC
 				// Failed waiting for confirmation, close
 				// confChan to indicate failure.
 				close(confChan)
+				return
+			}
+
+			err = f.handleFundingConfirmation(
+				completeChan, *shortChanID,
+			)
+			if err != nil {
+				fndgLog.Errorf("unable to handle funding "+
+					"confirmation for ChannelPoint(%v): %v",
+					completeChan.FundingOutpoint, err)
 				return
 			}
 
@@ -1988,12 +2006,6 @@ func (f *fundingManager) waitForFundingConfirmation(
 		BlockHeight: confDetails.BlockHeight,
 		TxIndex:     confDetails.TxIndex,
 		TxPosition:  uint16(fundingPoint.Index),
-	}
-
-	err = f.handleFundingConfirmation(completeChan, shortChanID)
-	if err != nil {
-		fndgLog.Errorf("Unable to handle funding confirmation: %v", err)
-		return
 	}
 
 	select {

--- a/fundingmanager.go
+++ b/fundingmanager.go
@@ -851,23 +851,7 @@ func (f *fundingManager) stateStep(channel *channeldb.OpenChannel,
 	// The funding transaction was confirmed, but we did not successfully
 	// send the fundingLocked message to the peer, so let's do that now.
 	case markedOpen:
-		peerChan := make(chan lnpeer.Peer, 1)
-
-		var peerKey [33]byte
-		copy(peerKey[:], channel.IdentityPub.SerializeCompressed())
-
-		f.cfg.NotifyWhenOnline(peerKey, peerChan)
-
-		var peer lnpeer.Peer
-		select {
-		case peer = <-peerChan:
-		case <-f.quit:
-			return ErrFundingManagerShuttingDown
-		}
-
-		err := f.sendFundingLocked(
-			peer, channel, lnChannel, shortChanID,
-		)
+		err := f.sendFundingLocked(channel, lnChannel, shortChanID)
 		if err != nil {
 			return fmt.Errorf("failed sending fundingLocked: %v",
 				err)
@@ -2057,7 +2041,7 @@ func (f *fundingManager) handleFundingConfirmation(
 // sendFundingLocked creates and sends the fundingLocked message.
 // This should be called after the funding transaction has been confirmed,
 // and the channelState is 'markedOpen'.
-func (f *fundingManager) sendFundingLocked(peer lnpeer.Peer,
+func (f *fundingManager) sendFundingLocked(
 	completeChan *channeldb.OpenChannel, channel *lnwallet.LightningChannel,
 	shortChanID *lnwire.ShortChannelID) error {
 
@@ -2088,8 +2072,18 @@ func (f *fundingManager) sendFundingLocked(peer lnpeer.Peer,
 	// send fundingLocked until we succeed, or the fundingManager is shut
 	// down.
 	for {
-		fndgLog.Debugf("Sending FundingLocked for ChannelID(%v) to "+
-			"peer %x", chanID, peerKey)
+		connected := make(chan lnpeer.Peer, 1)
+		f.cfg.NotifyWhenOnline(peerKey, connected)
+
+		var peer lnpeer.Peer
+		select {
+		case peer = <-connected:
+		case <-f.quit:
+			return ErrFundingManagerShuttingDown
+		}
+
+		fndgLog.Infof("Peer(%x) is online, sending FundingLocked "+
+			"for ChannelID(%v)", peerKey, chanID)
 
 		if err := peer.SendMessage(false, fundingLockedMsg); err == nil {
 			// Sending succeeded, we can break out and continue the
@@ -2099,20 +2093,6 @@ func (f *fundingManager) sendFundingLocked(peer lnpeer.Peer,
 
 		fndgLog.Warnf("Unable to send fundingLocked to peer %x: %v. "+
 			"Will retry when online", peerKey, err)
-
-		connected := make(chan lnpeer.Peer, 1)
-		f.cfg.NotifyWhenOnline(peerKey, connected)
-
-		select {
-		case <-connected:
-			fndgLog.Infof("Peer(%x) came back online, will retry "+
-				"sending FundingLocked for ChannelID(%v)",
-				peerKey, chanID)
-
-			// Retry sending.
-		case <-f.quit:
-			return ErrFundingManagerShuttingDown
-		}
 	}
 
 	return nil

--- a/fundingmanager.go
+++ b/fundingmanager.go
@@ -807,6 +807,12 @@ func (f *fundingManager) advanceFundingState(channel *channeldb.OpenChannel,
 			// Channel not in fundingManager's opening database,
 			// meaning it was successfully announced to the
 			// network.
+			// TODO(halseth): could do graph consistency check
+			// here, and re-add the edge if missing.
+			fndgLog.Debugf("ChannlPoint(%v) with chanID=%v not "+
+				"found in opening database, assuming already "+
+				"announced to the network",
+				channel.FundingOutpoint, pendingChanID)
 			return
 		} else if err != nil {
 			fndgLog.Errorf("Unable to query database for "+

--- a/fundingmanager.go
+++ b/fundingmanager.go
@@ -532,12 +532,8 @@ func (f *fundingManager) start() error {
 
 		// We will restart the funding state machine for all channels,
 		// which will wait for the channel's funding transaction to be
-		// confirmed on the blockchain, and retransmit the messages
+		// confirmed on the blockchain, and transmit the messages
 		// necessary for the channel to be operational.
-		// TODO(halseth): retransmission of messages to make the
-		// channel operational is only done on restart atm, but should
-		// also be done if a peer that disappeared during the opening
-		// process reconnects.
 		f.wg.Add(1)
 		go f.advanceFundingState(channel, chanID, nil)
 	}
@@ -2244,6 +2240,9 @@ func (f *fundingManager) annAfterSixConfs(completeChan *channeldb.OpenChannel,
 		fndgLog.Debugf("Sending our NodeAnnouncement for "+
 			"ChannelID(%v) to %x", chanID, pubKey)
 
+		// TODO(halseth): make reliable. If the peer is not online this
+		// will fail, and the opening process will stop. Should instead
+		// block here, waiting for the peer to come online.
 		if err := peer.SendMessage(true, &nodeAnn); err != nil {
 			return fmt.Errorf("unable to send node announcement "+
 				"to peer %x: %v", pubKey, err)

--- a/fundingmanager.go
+++ b/fundingmanager.go
@@ -571,6 +571,14 @@ func (f *fundingManager) start() error {
 			fndgLog.Debugf("ChannelID(%v) is now fully confirmed! "+
 				"(shortChanID=%v)", chanID, shortChanID)
 
+			err = f.handleFundingConfirmation(ch, *shortChanID)
+			if err != nil {
+				fndgLog.Errorf("unable to handle funding "+
+					"confirmation for ChannelPoint(%v): %v",
+					ch.FundingOutpoint, err)
+				return
+			}
+
 			f.wg.Add(1)
 			go f.advanceFundingState(ch, nil)
 		}(channel)
@@ -1635,6 +1643,14 @@ func (f *fundingManager) handleFundingCreated(fmsg *fundingCreatedMsg) {
 		fndgLog.Debugf("ChannelID(%v) is now fully confirmed! "+
 			"(shortChanID=%v)", channelID, shortChanID)
 
+		err = f.handleFundingConfirmation(completeChan, *shortChanID)
+		if err != nil {
+			fndgLog.Errorf("unable to handle funding "+
+				"confirmation for ChannelPoint(%v): %v",
+				completeChan.FundingOutpoint, err)
+			return
+		}
+
 		f.wg.Add(1)
 		go f.advanceFundingState(completeChan, nil)
 
@@ -1878,16 +1894,6 @@ func (f *fundingManager) waitForFundingWithTimeout(completeChan *channeldb.OpenC
 				// Failed waiting for confirmation, close
 				// confChan to indicate failure.
 				close(confChan)
-				return
-			}
-
-			err = f.handleFundingConfirmation(
-				completeChan, *shortChanID,
-			)
-			if err != nil {
-				fndgLog.Errorf("unable to handle funding "+
-					"confirmation for ChannelPoint(%v): %v",
-					completeChan.FundingOutpoint, err)
 				return
 			}
 

--- a/fundingmanager.go
+++ b/fundingmanager.go
@@ -613,17 +613,6 @@ func (f *fundingManager) start() error {
 		fndgLog.Debugf("channel (%v) with opening state %v found",
 			chanID, channelState)
 
-		if channel.IsPending {
-			// Set up the channel barriers again, to make sure
-			// waitUntilChannelOpen correctly waits until the
-			// opening process is completely over.
-			f.barrierMtx.Lock()
-			fndgLog.Tracef("Loading pending ChannelPoint(%v), "+
-				"creating chan barrier", channel.FundingOutpoint)
-			f.newChanBarriers[chanID] = make(chan struct{})
-			f.barrierMtx.Unlock()
-		}
-
 		// If we did find the channel in the opening state database, we
 		// have seen the funding transaction being confirmed, but we
 		// did not finish the rest of the setup procedure before we shut

--- a/fundingmanager_test.go
+++ b/fundingmanager_test.go
@@ -243,7 +243,7 @@ func createTestFundingManager(t *testing.T, privKey *btcec.PrivateKey,
 	chainNotifier := &mockNotifier{
 		oneConfChannel: make(chan *chainntnfs.TxConfirmation, 1),
 		sixConfChannel: make(chan *chainntnfs.TxConfirmation, 1),
-		epochChan:      make(chan *chainntnfs.BlockEpoch, 1),
+		epochChan:      make(chan *chainntnfs.BlockEpoch, 2),
 	}
 
 	sentMessages := make(chan lnwire.Message)
@@ -1741,7 +1741,7 @@ func TestFundingManagerFundingNotTimeoutInitiator(t *testing.T) {
 		t.Fatalf("alice did not publish funding tx")
 	}
 
-	// Increase the height to 1 minus the maxWaitNumBlocksFundingConf height
+	// Increase the height to 1 minus the maxWaitNumBlocksFundingConf height.
 	alice.mockNotifier.epochChan <- &chainntnfs.BlockEpoch{
 		Height: fundingBroadcastHeight + maxWaitNumBlocksFundingConf - 1,
 	}
@@ -1750,12 +1750,12 @@ func TestFundingManagerFundingNotTimeoutInitiator(t *testing.T) {
 		Height: fundingBroadcastHeight + maxWaitNumBlocksFundingConf - 1,
 	}
 
-	// Assert both and Alice and Bob still have 1 pending channels
+	// Assert both and Alice and Bob still have 1 pending channels.
 	assertNumPendingChannelsRemains(t, alice, 1)
 
 	assertNumPendingChannelsRemains(t, bob, 1)
 
-	// Increase both Alice and Bob to maxWaitNumBlocksFundingConf height
+	// Increase both Alice and Bob to maxWaitNumBlocksFundingConf height.
 	alice.mockNotifier.epochChan <- &chainntnfs.BlockEpoch{
 		Height: fundingBroadcastHeight + maxWaitNumBlocksFundingConf,
 	}
@@ -1764,13 +1764,13 @@ func TestFundingManagerFundingNotTimeoutInitiator(t *testing.T) {
 		Height: fundingBroadcastHeight + maxWaitNumBlocksFundingConf,
 	}
 
-	// Since Alice was the initiator, the channel should not have timed out
+	// Since Alice was the initiator, the channel should not have timed out.
 	assertNumPendingChannelsRemains(t, alice, 1)
 
 	// Bob should have sent an Error message to Alice.
 	assertErrorSent(t, bob.msgChan)
 
-	// Since Bob was not the initiator, the channel should timeout
+	// Since Bob was not the initiator, the channel should timeout.
 	assertNumPendingChannelsBecomes(t, bob, 0)
 }
 

--- a/fundingmanager_test.go
+++ b/fundingmanager_test.go
@@ -394,7 +394,7 @@ func createTestFundingManager(t *testing.T, privKey *btcec.PrivateKey,
 	f.cfg.NotifyWhenOnline = func(peer [33]byte,
 		connectedChan chan<- lnpeer.Peer) {
 
-		connectedChan <- testNode
+		connectedChan <- testNode.remotePeer
 	}
 
 	return testNode, nil

--- a/fundingmanager_test.go
+++ b/fundingmanager_test.go
@@ -672,6 +672,8 @@ func fundChannel(t *testing.T, alice, bob *testNode, localFundingAmt,
 }
 
 func assertErrorNotSent(t *testing.T, msgChan chan lnwire.Message) {
+	t.Helper()
+
 	select {
 	case <-msgChan:
 		t.Fatalf("error sent unexpectedly")
@@ -681,6 +683,8 @@ func assertErrorNotSent(t *testing.T, msgChan chan lnwire.Message) {
 }
 
 func assertErrorSent(t *testing.T, msgChan chan lnwire.Message) {
+	t.Helper()
+
 	var msg lnwire.Message
 	select {
 	case msg = <-msgChan:
@@ -741,6 +745,8 @@ func assertFundingMsgSent(t *testing.T, msgChan chan lnwire.Message,
 
 func assertNumPendingReservations(t *testing.T, node *testNode,
 	peerPubKey *btcec.PublicKey, expectedNum int) {
+	t.Helper()
+
 	serializedPubKey := newSerializedKey(peerPubKey)
 	actualNum := len(node.fundingMgr.activeReservations[serializedPubKey])
 	if actualNum == expectedNum {
@@ -753,6 +759,8 @@ func assertNumPendingReservations(t *testing.T, node *testNode,
 }
 
 func assertNumPendingChannelsBecomes(t *testing.T, node *testNode, expectedNum int) {
+	t.Helper()
+
 	var numPendingChans int
 	for i := 0; i < testPollNumTries; i++ {
 		// If this is not the first try, sleep before retrying.
@@ -777,6 +785,8 @@ func assertNumPendingChannelsBecomes(t *testing.T, node *testNode, expectedNum i
 }
 
 func assertNumPendingChannelsRemains(t *testing.T, node *testNode, expectedNum int) {
+	t.Helper()
+
 	var numPendingChans int
 	for i := 0; i < 5; i++ {
 		// If this is not the first try, sleep before retrying.
@@ -800,6 +810,7 @@ func assertNumPendingChannelsRemains(t *testing.T, node *testNode, expectedNum i
 
 func assertDatabaseState(t *testing.T, node *testNode,
 	fundingOutPoint *wire.OutPoint, expectedState channelOpeningState) {
+	t.Helper()
 
 	var state channelOpeningState
 	var err error
@@ -832,18 +843,24 @@ func assertDatabaseState(t *testing.T, node *testNode,
 
 func assertMarkedOpen(t *testing.T, alice, bob *testNode,
 	fundingOutPoint *wire.OutPoint) {
+	t.Helper()
+
 	assertDatabaseState(t, alice, fundingOutPoint, markedOpen)
 	assertDatabaseState(t, bob, fundingOutPoint, markedOpen)
 }
 
 func assertFundingLockedSent(t *testing.T, alice, bob *testNode,
 	fundingOutPoint *wire.OutPoint) {
+	t.Helper()
+
 	assertDatabaseState(t, alice, fundingOutPoint, fundingLockedSent)
 	assertDatabaseState(t, bob, fundingOutPoint, fundingLockedSent)
 }
 
 func assertAddedToRouterGraph(t *testing.T, alice, bob *testNode,
 	fundingOutPoint *wire.OutPoint) {
+	t.Helper()
+
 	assertDatabaseState(t, alice, fundingOutPoint, addedToRouterGraph)
 	assertDatabaseState(t, bob, fundingOutPoint, addedToRouterGraph)
 }
@@ -950,6 +967,8 @@ func assertChannelAnnouncements(t *testing.T, alice, bob *testNode,
 }
 
 func assertAnnouncementSignatures(t *testing.T, alice, bob *testNode) {
+	t.Helper()
+
 	// After the FundingLocked message is sent and six confirmations have
 	// been reached, the channel will be announced to the greater network
 	// by having the nodes exchange announcement signatures.
@@ -1006,6 +1025,7 @@ func waitForOpenUpdate(t *testing.T, updateChan chan *lnrpc.OpenStatusUpdate) {
 
 func assertNoChannelState(t *testing.T, alice, bob *testNode,
 	fundingOutPoint *wire.OutPoint) {
+	t.Helper()
 
 	assertErrChannelNotFound(t, alice, fundingOutPoint)
 	assertErrChannelNotFound(t, bob, fundingOutPoint)
@@ -1013,6 +1033,7 @@ func assertNoChannelState(t *testing.T, alice, bob *testNode,
 
 func assertErrChannelNotFound(t *testing.T, node *testNode,
 	fundingOutPoint *wire.OutPoint) {
+	t.Helper()
 
 	var state channelOpeningState
 	var err error
@@ -1036,6 +1057,8 @@ func assertErrChannelNotFound(t *testing.T, node *testNode,
 }
 
 func assertHandleFundingLocked(t *testing.T, alice, bob *testNode) {
+	t.Helper()
+
 	// They should both send the new channel state to their peer.
 	select {
 	case c := <-alice.newChannels:


### PR DESCRIPTION
This PR contains a set of commit to clean up the `fundingmanager` state machine. We now share a common codepath between all funding flows, both as initiator and responder. We also reuse this codepath at restart, greatly reducing the number of cases we handle.