### PR TITLE
rpcserver: handle unconfirmed TX properly when listing all transactions

### DIFF
--- a/rpcserver.go
+++ b/rpcserver.go
@@ -3014,11 +3014,18 @@ func (r *rpcServer) GetTransactions(ctx context.Context,
 			destAddresses = append(destAddresses, destAddress.EncodeAddress())
 		}
 
+		// We also get unconfirmed transactions, so BlockHash can be
+		// nil.
+		blockHash := ""
+		if tx.BlockHash != nil {
+			blockHash = tx.BlockHash.String()
+		}
+
 		txDetails.Transactions[i] = &lnrpc.Transaction{
 			TxHash:           tx.Hash.String(),
 			Amount:           int64(tx.Value),
 			NumConfirmations: tx.NumConfirmations,
-			BlockHash:        tx.BlockHash.String(),
+			BlockHash:        blockHash,
 			BlockHeight:      tx.BlockHeight,
 			TimeStamp:        tx.Timestamp,
 			TotalFees:        tx.TotalFees,


### PR DESCRIPTION
Fixes #1915

Since we also get unconfirmed transactions from `r.server.cc.wallet.ListTransactionDetails()` in `GetTransactions` of `rpcserver.go`, we need to check if `tx.BlockHash` might be nil.