### PR TITLE
remove the need for lnwallet to have access to the private key

### DIFF
--- a/lnwallet/btcwallet/btcwallet.go
+++ b/lnwallet/btcwallet/btcwallet.go
@@ -255,15 +255,16 @@ func (b *BtcWallet) NewAddress(t lnwallet.AddressType, change bool) (btcutil.Add
 	return b.wallet.NewAddress(defaultAccount, keyScope)
 }
 
-// GetPrivKey retrieves the underlying private key associated with the passed
-// address. If the we're unable to locate the proper private key, then a
-// non-nil error will be returned.
+// IsOurAddress checks if the passed address belongs to this wallet
 //
 // This is a part of the WalletController interface.
-func (b *BtcWallet) GetPrivKey(a btcutil.Address) (*btcec.PrivateKey, error) {
-	// Using the ID address, request the private key corresponding to the
-	// address from the wallet's address manager.
-	return b.wallet.PrivKeyForAddress(a)
+func (b *BtcWallet) IsOurAddress(a btcutil.Address) (bool) {
+	result, err := b.wallet.HaveAddress(a)
+	if result && err == nil {
+		return true
+	} else {
+		return false
+	}
 }
 
 // SendOutputs funds, signs, and broadcasts a Bitcoin transaction paying out to

--- a/lnwallet/btcwallet/btcwallet.go
+++ b/lnwallet/btcwallet/btcwallet.go
@@ -258,13 +258,9 @@ func (b *BtcWallet) NewAddress(t lnwallet.AddressType, change bool) (btcutil.Add
 // IsOurAddress checks if the passed address belongs to this wallet
 //
 // This is a part of the WalletController interface.
-func (b *BtcWallet) IsOurAddress(a btcutil.Address) (bool) {
+func (b *BtcWallet) IsOurAddress(a btcutil.Address) bool {
 	result, err := b.wallet.HaveAddress(a)
-	if result && err == nil {
-		return true
-	} else {
-		return false
-	}
+	return result && (err == nil)
 }
 
 // SendOutputs funds, signs, and broadcasts a Bitcoin transaction paying out to

--- a/lnwallet/btcwallet/btcwallet.go
+++ b/lnwallet/btcwallet/btcwallet.go
@@ -9,7 +9,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/btcsuite/btcd/btcec"
 	"github.com/btcsuite/btcd/chaincfg"
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcd/txscript"

--- a/lnwallet/interface.go
+++ b/lnwallet/interface.go
@@ -148,11 +148,8 @@ type WalletController interface {
 	// p2wsh, etc.
 	NewAddress(addrType AddressType, change bool) (btcutil.Address, error)
 
-	// GetPrivKey retrieves the underlying private key associated with the
-	// passed address. If the wallet is unable to locate this private key
-	// due to the address not being under control of the wallet, then an
-	// error should be returned.
-	GetPrivKey(a btcutil.Address) (*btcec.PrivateKey, error)
+	// IsOurAddress checks if the passed address belongs to this wallet
+	IsOurAddress(a btcutil.Address) (bool)
 
 	// SendOutputs funds, signs, and broadcasts a Bitcoin transaction paying
 	// out to the specified outputs. In the case the wallet has insufficient

--- a/lnwallet/interface.go
+++ b/lnwallet/interface.go
@@ -149,7 +149,7 @@ type WalletController interface {
 	NewAddress(addrType AddressType, change bool) (btcutil.Address, error)
 
 	// IsOurAddress checks if the passed address belongs to this wallet
-	IsOurAddress(a btcutil.Address) (bool)
+	IsOurAddress(a btcutil.Address) bool
 
 	// SendOutputs funds, signs, and broadcasts a Bitcoin transaction paying
 	// out to the specified outputs. In the case the wallet has insufficient

--- a/mock.go
+++ b/mock.go
@@ -222,7 +222,7 @@ func (m *mockWalletController) NewAddress(addrType lnwallet.AddressType,
 		m.rootKey.PubKey().SerializeCompressed(), &chaincfg.MainNetParams)
 	return addr, nil
 }
-func (*mockWalletController) IsOurAddress(a btcutil.Address) (bool) {
+func (*mockWalletController) IsOurAddress(a btcutil.Address) bool {
 	return false
 }
 

--- a/mock.go
+++ b/mock.go
@@ -222,8 +222,8 @@ func (m *mockWalletController) NewAddress(addrType lnwallet.AddressType,
 		m.rootKey.PubKey().SerializeCompressed(), &chaincfg.MainNetParams)
 	return addr, nil
 }
-func (*mockWalletController) GetPrivKey(a btcutil.Address) (*btcec.PrivateKey, error) {
-	return nil, nil
+func (*mockWalletController) IsOurAddress(a btcutil.Address) (bool) {
+	return false
 }
 
 func (*mockWalletController) SendOutputs(outputs []*wire.TxOut,

--- a/server.go
+++ b/server.go
@@ -655,10 +655,7 @@ func newServer(listenAddrs []net.Addr, chanDB *channeldb.DB, cc *chainControl,
 			s.htlcSwitch.RemoveLink(chanID)
 			return nil
 		},
-		IsOurAddress: func(addr btcutil.Address) bool {
-			_, err := cc.wallet.GetPrivKey(addr)
-			return err == nil
-		},
+		IsOurAddress: cc.wallet.IsOurAddress,
 		ContractBreach: func(chanPoint wire.OutPoint,
 			breachRet *lnwallet.BreachRetribution) error {
 			event := &ContractBreachEvent{


### PR DESCRIPTION
This paves the way for lnd to work with hardware wallets, in which case it will not have access to the private key