### PR TITLE
Move daemon from main to lnd package

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -92,17 +92,17 @@ btcd:
 
 build:
 	@$(call print, "Building debug lnd and lncli.")
-	$(GOBUILD) -tags="$(DEV_TAGS)" -o lnd-debug $(LDFLAGS) $(PKG)
+	$(GOBUILD) -tags="$(DEV_TAGS)" -o lnd-debug $(LDFLAGS) $(PKG)/cmd/lnd
 	$(GOBUILD) -tags="$(DEV_TAGS)" -o lncli-debug $(LDFLAGS) $(PKG)/cmd/lncli
 
 build-itest:
 	@$(call print, "Building itest lnd and lncli.")
-	$(GOBUILD) -tags="$(ITEST_TAGS)" -o lnd-itest $(LDFLAGS) $(PKG)
+	$(GOBUILD) -tags="$(ITEST_TAGS)" -o lnd-itest $(LDFLAGS) $(PKG)/cmd/lnd
 	$(GOBUILD) -tags="$(ITEST_TAGS)" -o lncli-itest $(LDFLAGS) $(PKG)/cmd/lncli
 
 install:
 	@$(call print, "Installing lnd and lncli.")
-	$(GOINSTALL) -tags="${tags}" $(LDFLAGS) $(PKG)
+	$(GOINSTALL) -tags="${tags}" $(LDFLAGS) $(PKG)/cmd/lnd
 	$(GOINSTALL) -tags="${tags}" $(LDFLAGS) $(PKG)/cmd/lncli
 
 scratch: build

--- a/breacharbiter.go
+++ b/breacharbiter.go
@@ -1,4 +1,4 @@
-package main
+package lnd
 
 import (
 	"bytes"

--- a/breacharbiter_test.go
+++ b/breacharbiter_test.go
@@ -1,6 +1,6 @@
 // +build !rpctest
 
-package main
+package lnd
 
 import (
 	"bytes"

--- a/chainparams.go
+++ b/chainparams.go
@@ -1,4 +1,4 @@
-package main
+package lnd
 
 import (
 	"github.com/btcsuite/btcd/chaincfg"

--- a/chainregistry.go
+++ b/chainregistry.go
@@ -1,4 +1,4 @@
-package main
+package lnd
 
 import (
 	"encoding/hex"

--- a/chancloser.go
+++ b/chancloser.go
@@ -1,4 +1,4 @@
-package main
+package lnd
 
 import (
 	"fmt"

--- a/channel_notifier.go
+++ b/channel_notifier.go
@@ -1,4 +1,4 @@
-package main
+package lnd
 
 import (
 	"fmt"

--- a/chanrestore.go
+++ b/chanrestore.go
@@ -1,4 +1,4 @@
-package main
+package lnd
 
 import (
 	"fmt"

--- a/cmd/lnd/main.go
+++ b/cmd/lnd/main.go
@@ -1,0 +1,21 @@
+package main
+
+import (
+	"fmt"
+	"os"
+
+	flags "github.com/jessevdk/go-flags"
+	"github.com/lightningnetwork/lnd"
+)
+
+func main() {
+	// Call the "real" main in a nested manner so the defers will properly
+	// be executed in the case of a graceful shutdown.
+	if err := lnd.Main(); err != nil {
+		if e, ok := err.(*flags.Error); ok && e.Type == flags.ErrHelp {
+		} else {
+			fmt.Fprintln(os.Stderr, err)
+		}
+		os.Exit(1)
+	}
+}

--- a/config.go
+++ b/config.go
@@ -2,7 +2,7 @@
 // Copyright (c) 2015-2016 The Decred developers
 // Copyright (C) 2015-2017 The Lightning Network Developers
 
-package main
+package lnd
 
 import (
 	"errors"

--- a/doc.go
+++ b/doc.go
@@ -1,1 +1,1 @@
-package main
+package lnd

--- a/fundingmanager.go
+++ b/fundingmanager.go
@@ -1,4 +1,4 @@
-package main
+package lnd
 
 import (
 	"bytes"

--- a/fundingmanager_test.go
+++ b/fundingmanager_test.go
@@ -1,6 +1,6 @@
 // +build !rpctest
 
-package main
+package lnd
 
 import (
 	"errors"

--- a/lnd.go
+++ b/lnd.go
@@ -18,13 +18,15 @@ import (
 	"math/big"
 	"net"
 	"net/http"
-	_ "net/http/pprof"
 	"os"
 	"path/filepath"
 	"runtime/pprof"
 	"strings"
 	"sync"
 	"time"
+
+	// Blank import to set up profiling HTTP handlers.
+	_ "net/http/pprof"
 
 	"gopkg.in/macaroon-bakery.v2/bakery"
 
@@ -36,7 +38,6 @@ import (
 	"github.com/btcsuite/btcd/btcec"
 	"github.com/btcsuite/btcwallet/wallet"
 	proxy "github.com/grpc-ecosystem/grpc-gateway/runtime"
-	flags "github.com/jessevdk/go-flags"
 	"github.com/lightninglabs/neutrino"
 
 	"github.com/lightningnetwork/lnd/autopilot"
@@ -89,10 +90,10 @@ var (
 	}
 )
 
-// lndMain is the true entry point for lnd. This function is required since
-// defers created in the top-level scope of a main method aren't executed if
-// os.Exit() is called.
-func lndMain() error {
+// Main is the true entry point for lnd. This function is required since defers
+// created in the top-level scope of a main method aren't executed if os.Exit()
+// is called.
+func Main() error {
 	// Load the configuration, and parse any command line options. This
 	// function will also set up logging properly.
 	loadedConfig, err := loadConfig()
@@ -466,18 +467,6 @@ func getTLSConfig(cfg *config) (*tls.Config, *credentials.TransportCredentials,
 	}
 
 	return tlsCfg, &restCreds, restProxyDest, nil
-}
-
-func main() {
-	// Call the "real" main in a nested manner so the defers will properly
-	// be executed in the case of a graceful shutdown.
-	if err := lndMain(); err != nil {
-		if e, ok := err.(*flags.Error); ok && e.Type == flags.ErrHelp {
-		} else {
-			fmt.Fprintln(os.Stderr, err)
-		}
-		os.Exit(1)
-	}
 }
 
 // fileExists reports whether the named file or directory exists.

--- a/lnd.go
+++ b/lnd.go
@@ -2,7 +2,7 @@
 // Copyright (c) 2015-2016 The Decred developers
 // Copyright (C) 2015-2017 The Lightning Network Developers
 
-package main
+package lnd
 
 import (
 	"bytes"

--- a/lnd_test.go
+++ b/lnd_test.go
@@ -1,6 +1,6 @@
 // +build rpctest
 
-package main
+package lnd
 
 import (
 	"bytes"

--- a/log.go
+++ b/log.go
@@ -1,4 +1,4 @@
-package main
+package lnd
 
 import (
 	"fmt"

--- a/mock.go
+++ b/mock.go
@@ -1,4 +1,4 @@
-package main
+package lnd
 
 import (
 	"fmt"

--- a/nursery_store.go
+++ b/nursery_store.go
@@ -1,4 +1,4 @@
-package main
+package lnd
 
 import (
 	"bytes"

--- a/nursery_store_test.go
+++ b/nursery_store_test.go
@@ -1,6 +1,6 @@
 // +build !rpctest
 
-package main
+package lnd
 
 import (
 	"io/ioutil"

--- a/peer.go
+++ b/peer.go
@@ -1,4 +1,4 @@
-package main
+package lnd
 
 import (
 	"bytes"

--- a/peer_test.go
+++ b/peer_test.go
@@ -1,6 +1,6 @@
 // +build !rpctest
 
-package main
+package lnd
 
 import (
 	"testing"

--- a/pilot.go
+++ b/pilot.go
@@ -1,4 +1,4 @@
-package main
+package lnd
 
 import (
 	"errors"

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -1,4 +1,4 @@
-package main
+package lnd
 
 import (
 	"bytes"

--- a/server.go
+++ b/server.go
@@ -1,4 +1,4 @@
-package main
+package lnd
 
 import (
 	"bytes"

--- a/server_test.go
+++ b/server_test.go
@@ -1,6 +1,6 @@
 // +build !rpctest
 
-package main
+package lnd
 
 import "testing"
 

--- a/subrpcserver_config.go
+++ b/subrpcserver_config.go
@@ -1,4 +1,4 @@
-package main
+package lnd
 
 import (
 	"fmt"

--- a/test_utils.go
+++ b/test_utils.go
@@ -1,4 +1,4 @@
-package main
+package lnd
 
 import (
 	"bytes"

--- a/utxonursery.go
+++ b/utxonursery.go
@@ -1,4 +1,4 @@
-package main
+package lnd
 
 import (
 	"bytes"

--- a/utxonursery_test.go
+++ b/utxonursery_test.go
@@ -1,6 +1,6 @@
 // +build !rpctest
 
-package main
+package lnd
 
 import (
 	"bytes"

--- a/witness_beacon.go
+++ b/witness_beacon.go
@@ -1,4 +1,4 @@
-package main
+package lnd
 
 import (
 	"sync"


### PR DESCRIPTION
This PR renames the `main` package to `lnd`, and moves the `lnd` entry point into `cmd/lnd`.

This intends to make `lnd` suitable for use as a library, for instance within in other apps. This is also a prerequisite for using `lnd` with `gomobile`.