### PR TITLE
conctractcourt: check sweep sanity + reliable publication

### DIFF
--- a/contractcourt/contract_resolvers.go
+++ b/contractcourt/contract_resolvers.go
@@ -171,6 +171,7 @@ func (h *htlcTimeoutResolver) Resolve() (ContractResolver, error) {
 
 		if err := h.Checkpoint(h); err != nil {
 			log.Errorf("unable to Checkpoint: %v", err)
+			return nil, err
 		}
 	}
 
@@ -485,6 +486,7 @@ func (h *htlcSuccessResolver) Resolve() (ContractResolver, error) {
 			// Checkpoint our state.
 			if err := h.Checkpoint(h); err != nil {
 				log.Errorf("unable to Checkpoint: %v", err)
+				return nil, err
 			}
 		}
 
@@ -559,6 +561,7 @@ func (h *htlcSuccessResolver) Resolve() (ContractResolver, error) {
 
 		if err := h.Checkpoint(h); err != nil {
 			log.Errorf("unable to Checkpoint: %v", err)
+			return nil, err
 		}
 	}
 
@@ -1323,6 +1326,7 @@ func (c *commitSweepResolver) Resolve() (ContractResolver, error) {
 
 			if err := c.Checkpoint(c); err != nil {
 				log.Errorf("unable to Checkpoint: %v", err)
+				return nil, err
 			}
 		case <-c.Quit:
 			return nil, fmt.Errorf("quitting")

--- a/contractcourt/contract_resolvers.go
+++ b/contractcourt/contract_resolvers.go
@@ -535,7 +535,8 @@ func (h *htlcSuccessResolver) Resolve() (ContractResolver, error) {
 	// the claiming process.
 	//
 	// TODO(roasbeef): after changing sighashes send to tx bundler
-	if err := h.PublishTx(h.htlcResolution.SignedSuccessTx); err != nil {
+	err := h.PublishTx(h.htlcResolution.SignedSuccessTx)
+	if err != nil && err != lnwallet.ErrDoubleSpend {
 		return nil, err
 	}
 

--- a/contractcourt/contract_resolvers.go
+++ b/contractcourt/contract_resolvers.go
@@ -1258,18 +1258,33 @@ func (c *commitSweepResolver) Resolve() (ContractResolver, error) {
 		log.Infof("%T(%v): sweeping commit output with tx=%v", c,
 			c.chanPoint, spew.Sdump(c.sweepTx))
 
-		// Finally, we'll broadcast the sweep transaction to the
-		// network.
-		if err := c.PublishTx(c.sweepTx); err != nil {
+		// With the sweep transaction constructed, we'll now Checkpoint
+		// our state.
+		if err := c.Checkpoint(c); err != nil {
+			log.Errorf("unable to Checkpoint: %v", err)
+			return nil, err
+		}
+
+		// With the sweep transaction checkpointed, we'll now publish
+		// the transaction. Upon restart, the resolver will immediately
+		// take the case below since the sweep tx is checkpointed.
+		err := c.PublishTx(c.sweepTx)
+		if err != nil && err != lnwallet.ErrDoubleSpend {
 			log.Errorf("%T(%v): unable to publish sweep tx: %v",
 				c, c.chanPoint, err)
 			return nil, err
 		}
 
-		// With the sweep transaction confirmed, we'll now Checkpoint
-		// our state.
-		if err := c.Checkpoint(c); err != nil {
-			log.Errorf("unable to Checkpoint: %v", err)
+	// If the sweep transaction has been generated, and the remote party
+	// broadcast the commit transaction, we'll republish it for reliability
+	// to ensure it confirms. The resolver will enter this case after
+	// checkpointing in the case above, ensuring we reliably on restarts.
+	case c.sweepTx != nil && !isLocalCommitTx:
+		err := c.PublishTx(c.sweepTx)
+		if err != nil && err != lnwallet.ErrDoubleSpend {
+			log.Errorf("%T(%v): unable to publish sweep tx: %v",
+				c, c.chanPoint, err)
+			return nil, err
 		}
 
 	// Otherwise, this is our commitment transaction, So we'll obtain the


### PR DESCRIPTION
This PR modifies the signing and sweeping of commit to-remote sweeps and htlc success sweeps, such that we validate the generated transaction's sanity before publication. It also ensures that the resolvers checkpoint the transaction before publishing. This ensures that we will watch for the same txid after a restart in case a crash happens between publication and checkpointing. If such a crash happens, both will attempt to publish the sweep transaction again in order to ensure the transaction propagates.

In addition, we return an error if checkpointing fails from a number of places within the contract resovlers, and also ignore errors that can arise from duplicate publications of the same htlc success transaction.

Note: would like to add some unit tests exercising this behavior, though this brings the resolvers in line with the intended behavior of other subsystems performing similar functions.