### PR TITLE
Data loss protect resending

### DIFF
--- a/channeldb/channel_test.go
+++ b/channeldb/channel_test.go
@@ -248,10 +248,10 @@ func TestOpenChannelPutGetDelete(t *testing.T) {
 	t.Parallel()
 
 	cdb, cleanUp, err := makeTestDB()
-	defer cleanUp()
 	if err != nil {
 		t.Fatalf("unable to make test database: %v", err)
 	}
+	defer cleanUp()
 
 	// Create the test channel state, then add an additional fake HTLC
 	// before syncing to disk.
@@ -368,10 +368,10 @@ func TestChannelStateTransition(t *testing.T) {
 	t.Parallel()
 
 	cdb, cleanUp, err := makeTestDB()
-	defer cleanUp()
 	if err != nil {
 		t.Fatalf("unable to make test database: %v", err)
 	}
+	defer cleanUp()
 
 	// First create a minimal channel, then perform a full sync in order to
 	// persist the data.

--- a/channeldb/db.go
+++ b/channeldb/db.go
@@ -12,6 +12,7 @@ import (
 	"github.com/btcsuite/btcd/wire"
 	"github.com/coreos/bbolt"
 	"github.com/go-errors/errors"
+	"github.com/lightningnetwork/lnd/lnwire"
 )
 
 const (
@@ -609,6 +610,54 @@ func (d *DB) FetchClosedChannel(chanID *wire.OutPoint) (*ChannelCloseSummary, er
 		chanSummary, err = deserializeCloseChannelSummary(summaryReader)
 
 		return err
+	}); err != nil {
+		return nil, err
+	}
+
+	return chanSummary, nil
+}
+
+// FetchClosedChannelForID queries for a channel close summary using the
+// channel ID of the channel in question.
+func (d *DB) FetchClosedChannelForID(cid lnwire.ChannelID) (
+	*ChannelCloseSummary, error) {
+
+	var chanSummary *ChannelCloseSummary
+	if err := d.View(func(tx *bolt.Tx) error {
+		closeBucket := tx.Bucket(closedChannelBucket)
+		if closeBucket == nil {
+			return ErrClosedChannelNotFound
+		}
+
+		// The first 30 bytes of the channel ID and outpoint will be
+		// equal.
+		cursor := closeBucket.Cursor()
+		op, c := cursor.Seek(cid[:30])
+
+		// We scan over all possible candidates for this channel ID.
+		for ; op != nil && bytes.Compare(cid[:30], op[:30]) <= 0; op, c = cursor.Next() {
+			var outPoint wire.OutPoint
+			err := readOutpoint(bytes.NewReader(op), &outPoint)
+			if err != nil {
+				return err
+			}
+
+			// If the found outpoint does not correspond to this
+			// channel ID, we continue.
+			if !cid.IsChanPoint(&outPoint) {
+				continue
+			}
+
+			// Deserialize the close summary and return.
+			r := bytes.NewReader(c)
+			chanSummary, err = deserializeCloseChannelSummary(r)
+			if err != nil {
+				return err
+			}
+
+			return nil
+		}
+		return ErrClosedChannelNotFound
 	}); err != nil {
 		return nil, err
 	}

--- a/channeldb/db.go
+++ b/channeldb/db.go
@@ -80,6 +80,13 @@ var (
 			number:    6,
 			migration: migratePruneEdgeUpdateIndex,
 		},
+		{
+			// The DB version that migrates the ChannelCloseSummary
+			// to a format where optional fields are indicated with
+			// boolean flags.
+			number:    7,
+			migration: migrateOptionalChannelCloseSummaryFields,
+		},
 	}
 
 	// Big endian is the preferred byte order, due to cursor scans over

--- a/channeldb/db_test.go
+++ b/channeldb/db_test.go
@@ -5,6 +5,9 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/btcsuite/btcutil"
+	"github.com/lightningnetwork/lnd/lnwire"
 )
 
 func TestOpenWithCreate(t *testing.T) {
@@ -69,5 +72,78 @@ func TestWipe(t *testing.T) {
 	if err != ErrNoClosedChannels {
 		t.Fatalf("fetching closed channels: expected '%v' instead got '%v'",
 			ErrNoClosedChannels, err)
+	}
+}
+
+// TestFetchClosedChannelForID tests that we are able to properly retrieve a
+// ChannelCloseSummary from the DB given a ChannelID.
+func TestFetchClosedChannelForID(t *testing.T) {
+	t.Parallel()
+
+	const numChans = 101
+
+	cdb, cleanUp, err := makeTestDB()
+	if err != nil {
+		t.Fatalf("unable to make test database: %v", err)
+	}
+	defer cleanUp()
+
+	// Create the test channel state, that we will mutate the index of the
+	// funding point.
+	state, err := createTestChannelState(cdb)
+	if err != nil {
+		t.Fatalf("unable to create channel state: %v", err)
+	}
+
+	// Now run through the number of channels, and modify the outpoint index
+	// to create new channel IDs.
+	for i := uint32(0); i < numChans; i++ {
+		// Save the open channel to disk.
+		state.FundingOutpoint.Index = i
+		if err := state.FullSync(); err != nil {
+			t.Fatalf("unable to save and serialize channel "+
+				"state: %v", err)
+		}
+
+		// Close the channel. To make sure we retrieve the correct
+		// summary later, we make them differ in the SettledBalance.
+		closeSummary := &ChannelCloseSummary{
+			ChanPoint:      state.FundingOutpoint,
+			RemotePub:      state.IdentityPub,
+			SettledBalance: btcutil.Amount(500 + i),
+		}
+		if err := state.CloseChannel(closeSummary); err != nil {
+			t.Fatalf("unable to close channel: %v", err)
+		}
+	}
+
+	// Now run though them all again and make sure we are able to retrieve
+	// summaries from the DB.
+	for i := uint32(0); i < numChans; i++ {
+		state.FundingOutpoint.Index = i
+
+		// We calculate the ChannelID and use it to fetch the summary.
+		cid := lnwire.NewChanIDFromOutPoint(&state.FundingOutpoint)
+		fetchedSummary, err := cdb.FetchClosedChannelForID(cid)
+		if err != nil {
+			t.Fatalf("unable to fetch close summary: %v", err)
+		}
+
+		// Make sure we retrieved the correct one by checking the
+		// SettledBalance.
+		if fetchedSummary.SettledBalance != btcutil.Amount(500+i) {
+			t.Fatalf("summaries don't match: expected %v got %v",
+				btcutil.Amount(500+i),
+				fetchedSummary.SettledBalance)
+		}
+	}
+
+	// As a final test we make sure that we get ErrClosedChannelNotFound
+	// for a ChannelID we didn't add to the DB.
+	state.FundingOutpoint.Index++
+	cid := lnwire.NewChanIDFromOutPoint(&state.FundingOutpoint)
+	_, err = cdb.FetchClosedChannelForID(cid)
+	if err != ErrClosedChannelNotFound {
+		t.Fatalf("expected ErrClosedChannelNotFound, instead got: %v", err)
 	}
 }

--- a/channeldb/legacy_serialization.go
+++ b/channeldb/legacy_serialization.go
@@ -1,0 +1,53 @@
+package channeldb
+
+import "io"
+
+// deserializeCloseChannelSummaryV6 reads the v6 database format for
+// ChannelCloseSummary.
+//
+// NOTE: deprecated, only for migration.
+func deserializeCloseChannelSummaryV6(r io.Reader) (*ChannelCloseSummary, error) {
+	c := &ChannelCloseSummary{}
+
+	err := ReadElements(r,
+		&c.ChanPoint, &c.ShortChanID, &c.ChainHash, &c.ClosingTXID,
+		&c.CloseHeight, &c.RemotePub, &c.Capacity, &c.SettledBalance,
+		&c.TimeLockedBalance, &c.CloseType, &c.IsPending,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	// We'll now check to see if the channel close summary was encoded with
+	// any of the additional optional fields.
+	err = ReadElements(r, &c.RemoteCurrentRevocation)
+	switch {
+	case err == io.EOF:
+		return c, nil
+
+	// If we got a non-eof error, then we know there's an actually issue.
+	// Otherwise, it may have been the case that this summary didn't have
+	// the set of optional fields.
+	case err != nil:
+		return nil, err
+	}
+
+	if err := readChanConfig(r, &c.LocalChanConfig); err != nil {
+		return nil, err
+	}
+
+	// Finally, we'll attempt to read the next unrevoked commitment point
+	// for the remote party. If we closed the channel before receiving a
+	// funding locked message, then this can be nil. As a result, we'll use
+	// the same technique to read the field, only if there's still data
+	// left in the buffer.
+	err = ReadElements(r, &c.RemoteNextRevocation)
+	if err != nil && err != io.EOF {
+		// If we got a non-eof error, then we know there's an actually
+		// issue. Otherwise, it may have been the case that this
+		// summary didn't have the set of optional fields.
+		return nil, err
+	}
+
+	return c, nil
+}

--- a/contractcourt/chain_watcher.go
+++ b/contractcourt/chain_watcher.go
@@ -522,6 +522,15 @@ func (c *chainWatcher) dispatchCooperativeClose(commitSpend *chainntnfs.SpendDet
 		LocalChanConfig:         c.cfg.chanState.LocalChanCfg,
 	}
 
+	// Attempt to add a channel sync message to the close summary.
+	chanSync, err := lnwallet.ChanSyncMsg(c.cfg.chanState)
+	if err != nil {
+		log.Errorf("ChannelPoint(%v): unable to create channel sync "+
+			"message: %v", c.cfg.chanState.FundingOutpoint, err)
+	} else {
+		closeSummary.LastChanSyncMsg = chanSync
+	}
+
 	// Create a summary of all the information needed to handle the
 	// cooperative closure.
 	closeInfo := &CooperativeCloseInfo{
@@ -588,6 +597,15 @@ func (c *chainWatcher) dispatchLocalForceClose(
 	for _, htlc := range forceClose.HtlcResolutions.OutgoingHTLCs {
 		htlcValue := btcutil.Amount(htlc.SweepSignDesc.Output.Value)
 		closeSummary.TimeLockedBalance += htlcValue
+	}
+
+	// Attempt to add a channel sync message to the close summary.
+	chanSync, err := lnwallet.ChanSyncMsg(c.cfg.chanState)
+	if err != nil {
+		log.Errorf("ChannelPoint(%v): unable to create channel sync "+
+			"message: %v", c.cfg.chanState.FundingOutpoint, err)
+	} else {
+		closeSummary.LastChanSyncMsg = chanSync
 	}
 
 	// With the event processed, we'll now notify all subscribers of the
@@ -747,6 +765,15 @@ func (c *chainWatcher) dispatchContractBreach(spendEvent *chainntnfs.SpendDetail
 		RemoteCurrentRevocation: c.cfg.chanState.RemoteCurrentRevocation,
 		RemoteNextRevocation:    c.cfg.chanState.RemoteNextRevocation,
 		LocalChanConfig:         c.cfg.chanState.LocalChanCfg,
+	}
+
+	// Attempt to add a channel sync message to the close summary.
+	chanSync, err := lnwallet.ChanSyncMsg(c.cfg.chanState)
+	if err != nil {
+		log.Errorf("ChannelPoint(%v): unable to create channel sync "+
+			"message: %v", c.cfg.chanState.FundingOutpoint, err)
+	} else {
+		closeSummary.LastChanSyncMsg = chanSync
 	}
 
 	if err := c.cfg.chanState.CloseChannel(&closeSummary); err != nil {

--- a/htlcswitch/link.go
+++ b/htlcswitch/link.go
@@ -516,7 +516,7 @@ func (l *channelLink) syncChanStates() error {
 	// First, we'll generate our ChanSync message to send to the other
 	// side. Based on this message, the remote party will decide if they
 	// need to retransmit any data or not.
-	localChanSyncMsg, err := l.channel.ChanSyncMsg()
+	localChanSyncMsg, err := lnwallet.ChanSyncMsg(l.channel.State())
 	if err != nil {
 		return fmt.Errorf("unable to generate chan sync message for "+
 			"ChannelPoint(%v)", l.channel.ChannelPoint())

--- a/htlcswitch/link.go
+++ b/htlcswitch/link.go
@@ -789,9 +789,6 @@ func (l *channelLink) htlcManager() {
 			// We failed syncing the commit chains, probably
 			// because the remote has lost state. We should force
 			// close the channel.
-			// TODO(halseth): store sent chanSync message to
-			// database, such that it can be resent to peer in case
-			// it tries to sync the channel again.
 			case err == lnwallet.ErrCommitSyncRemoteDataLoss:
 				fallthrough
 

--- a/lnd_test.go
+++ b/lnd_test.go
@@ -20,7 +20,6 @@ import (
 
 	"crypto/rand"
 	"crypto/sha256"
-	prand "math/rand"
 
 	"github.com/btcsuite/btcd/chaincfg"
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
@@ -8202,9 +8201,6 @@ func testAsyncPayments(net *lntest.NetworkHarness, t *harnessTest) {
 	// Send one more payment in order to cause insufficient capacity error.
 	numInvoices++
 
-	// Initialize seed random in order to generate invoices.
-	prand.Seed(time.Now().UnixNano())
-
 	// With the channel open, we'll create invoices for Bob that Alice
 	// will pay to in order to advance the state of the channel.
 	bobPayReqs := make([]string, numInvoices)
@@ -8384,9 +8380,6 @@ func testBidirectionalAsyncPayments(net *lntest.NetworkHarness, t *harnessTest) 
 	// at the end balances should remain the same.
 	aliceAmt := info.LocalBalance
 	bobAmt := info.RemoteBalance
-
-	// Initialize seed random in order to generate invoices.
-	prand.Seed(time.Now().UnixNano())
 
 	// With the channel open, we'll create invoices for Bob that Alice
 	// will pay to in order to advance the state of the channel.

--- a/lnwallet/channel.go
+++ b/lnwallet/channel.go
@@ -5116,6 +5116,15 @@ func NewUnilateralCloseSummary(chanState *channeldb.OpenChannel, signer Signer,
 		LocalChanConfig:         chanState.LocalChanCfg,
 	}
 
+	// Attempt to add a channel sync message to the close summary.
+	chanSync, err := ChanSyncMsg(chanState)
+	if err != nil {
+		walletLog.Errorf("ChannelPoint(%v): unable to create channel sync "+
+			"message: %v", chanState.FundingOutpoint, err)
+	} else {
+		closeSummary.LastChanSyncMsg = chanSync
+	}
+
 	return &UnilateralCloseSummary{
 		SpendDetail:         commitSpend,
 		ChannelCloseSummary: closeSummary,

--- a/peer.go
+++ b/peer.go
@@ -874,7 +874,33 @@ func newChanMsgStream(p *peer, cid lnwire.ChannelID) *msgStream {
 			// active goroutine dedicated to this channel.
 			if chanLink == nil {
 				link, err := p.server.htlcSwitch.GetLink(cid)
-				if err != nil {
+				switch {
+
+				// If we failed to find the link in question,
+				// and the message received was a channel sync
+				// message, then this might be a peer trying to
+				// resync closed channel. In this case we'll
+				// try to resend our last channel sync message,
+				// such that the peer can recover funds from
+				// the closed channel.
+				case err != nil && isChanSyncMsg:
+					peerLog.Debugf("Unable to find "+
+						"link(%v) to handle channel "+
+						"sync, attempting to resend "+
+						"last ChanSync message", cid)
+
+					err := p.resendChanSyncMsg(cid)
+					if err != nil {
+						// TODO(halseth): send error to
+						// peer?
+						peerLog.Errorf(
+							"resend failed: %v",
+							err,
+						)
+					}
+					return
+
+				case err != nil:
 					peerLog.Errorf("recv'd update for "+
 						"unknown channel %v from %v: "+
 						"%v", cid, p, err)
@@ -2142,6 +2168,35 @@ func (p *peer) sendInitMsg() error {
 	)
 
 	return p.writeMessage(msg)
+}
+
+// resendChanSyncMsg will attempt to find a channel sync message for the closed
+// channel and resend it to our peer.
+func (p *peer) resendChanSyncMsg(cid lnwire.ChannelID) error {
+	// Check if we have any channel sync messages stored for this channel.
+	c, err := p.server.chanDB.FetchClosedChannelForID(cid)
+	if err != nil {
+		return fmt.Errorf("unable to fetch channel sync messages for "+
+			"peer %v: %v", p, err)
+	}
+
+	if c.LastChanSyncMsg == nil {
+		return fmt.Errorf("no chan sync message stored for channel %v",
+			cid)
+	}
+
+	peerLog.Debugf("Re-sending channel sync message for channel %v to "+
+		"peer %v", cid, p)
+
+	if err := p.SendMessage(true, c.LastChanSyncMsg); err != nil {
+		return fmt.Errorf("Failed resending channel sync "+
+			"message to peer %v: %v", p, err)
+	}
+
+	peerLog.Debugf("Re-sent channel sync message for channel %v to peer "+
+		"%v", cid, p)
+
+	return nil
 }
 
 // SendMessage sends a variadic number of message to remote peer. The first

--- a/peer.go
+++ b/peer.go
@@ -836,11 +836,11 @@ func newChanMsgStream(p *peer, cid lnwire.ChannelID) *msgStream {
 		fmt.Sprintf("Update stream for ChannelID(%x) exiting", cid[:]),
 		1000,
 		func(msg lnwire.Message) {
-			_, isChanSycMsg := msg.(*lnwire.ChannelReestablish)
+			_, isChanSyncMsg := msg.(*lnwire.ChannelReestablish)
 
 			// If this is the chanSync message, then we'll deliver
 			// it immediately to the active link.
-			if !isChanSycMsg {
+			if !isChanSyncMsg {
 				// We'll send a message to the funding manager
 				// and wait iff an active funding process for
 				// this channel hasn't yet completed.  We do
@@ -875,8 +875,9 @@ func newChanMsgStream(p *peer, cid lnwire.ChannelID) *msgStream {
 			if chanLink == nil {
 				link, err := p.server.htlcSwitch.GetLink(cid)
 				if err != nil {
-					peerLog.Errorf("recv'd update for unknown "+
-						"channel %v from %v", cid, p)
+					peerLog.Errorf("recv'd update for "+
+						"unknown channel %v from %v: "+
+						"%v", cid, p, err)
 					return
 				}
 				chanLink = link


### PR DESCRIPTION
This PR makes the latest channel reestablishment message being stored as part of the channel close summary, such that it can be sent even when a channel ahs been closed.

This makes it possible for nodes to recover from the case where they have been offline, lost state, and comes back online, attempting to reseync the channel.

Note: This PR contains a DB migration. To ensure deserialization code is not changed in the future, and breaking old migrations, a versioned copy of the current deserialization logic is added to the file `legacy_serialization.go`. Backwards compatible addition of the new field turned out to be complex because of the presence of optional fields (see the now removed commit https://github.com/lightningnetwork/lnd/commit/14648b236fa5f203a76e876d75026735f2356d1f).

TODO:
- [x] Unit test for `FetchClosedChannelForID`