### PR TITLE
chainntnfs/neutrinonotify/neutrino: remove height shadowing

### DIFF
--- a/chainntnfs/neutrinonotify/neutrino.go
+++ b/chainntnfs/neutrinonotify/neutrino.go
@@ -814,7 +814,7 @@ func (n *NeutrinoNotifier) RegisterSpendNtfn(outpoint *wire.OutPoint,
 	// may miss a notification dispatch.
 	for {
 		n.heightMtx.RLock()
-		currentHeight := n.bestHeight
+		currentHeight = n.bestHeight
 		n.heightMtx.RUnlock()
 
 		if currentHeight < heightHint {


### PR DESCRIPTION
This commit removes shadowing of the currentHeight
variable when registering for neutrino spend
notifications. Currently, a locally scoped variable
is used when determining if the backend is fully
synced before attempting to call GetUtxo, which
means that the variable won't be updated after
breaking out of the loop. As a result, this could
cause us to scan unnecessarily if the backend is
catching up, e.g. after being offline for some time.