### PR TITLE
server: ensure each time we update a node ann we also update the on-disk version 

### DIFF
--- a/chan_series.go
+++ b/chan_series.go
@@ -89,7 +89,7 @@ func (c *chanSeries) UpdatesInHorizon(chain chainhash.Hash,
 		return nil, err
 	}
 	for _, nodeAnn := range nodeAnnsInHorizon {
-		nodeUpdate, err := makeNodeAnn(&nodeAnn)
+		nodeUpdate, err := nodeAnn.NodeAnnouncement(true)
 		if err != nil {
 			return nil, err
 		}
@@ -151,25 +151,6 @@ func (c *chanSeries) FilterChannelRange(chain chainhash.Hash,
 	return chanResp, nil
 }
 
-func makeNodeAnn(n *channeldb.LightningNode) (*lnwire.NodeAnnouncement, error) {
-	alias, _ := lnwire.NewNodeAlias(n.Alias)
-
-	wireSig, err := lnwire.NewSigFromRawSignature(n.AuthSigBytes)
-	if err != nil {
-		return nil, err
-	}
-	return &lnwire.NodeAnnouncement{
-		Signature:       wireSig,
-		Timestamp:       uint32(n.LastUpdate.Unix()),
-		Addresses:       n.Addresses,
-		NodeID:          n.PubKeyBytes,
-		Features:        n.Features.RawFeatureVector,
-		RGBColor:        n.Color,
-		Alias:           alias,
-		ExtraOpaqueData: n.ExtraOpaqueData,
-	}, nil
-}
-
 // FetchChanAnns returns a full set of channel announcements as well as their
 // updates that match the set of specified short channel ID's.  We'll use this
 // to reply to a QueryShortChanIDs message sent by a remote peer. The response
@@ -221,7 +202,7 @@ func (c *chanSeries) FetchChanAnns(chain chainhash.Hash,
 			nodePub := channel.Policy1.Node.PubKeyBytes
 			hasNodeAnn := channel.Policy1.Node.HaveNodeAnnouncement
 			if _, ok := nodePubsSent[nodePub]; !ok && hasNodeAnn {
-				nodeAnn, err := makeNodeAnn(channel.Policy1.Node)
+				nodeAnn, err := channel.Policy1.Node.NodeAnnouncement(true)
 				if err != nil {
 					return nil, err
 				}
@@ -238,7 +219,7 @@ func (c *chanSeries) FetchChanAnns(chain chainhash.Hash,
 			nodePub := channel.Policy2.Node.PubKeyBytes
 			hasNodeAnn := channel.Policy2.Node.HaveNodeAnnouncement
 			if _, ok := nodePubsSent[nodePub]; !ok && hasNodeAnn {
-				nodeAnn, err := makeNodeAnn(channel.Policy2.Node)
+				nodeAnn, err := channel.Policy2.Node.NodeAnnouncement(true)
 				if err != nil {
 					return nil, err
 				}

--- a/discovery/gossiper.go
+++ b/discovery/gossiper.go
@@ -270,27 +270,6 @@ func (d *AuthenticatedGossiper) SynchronizeNode(syncPeer lnpeer.Peer) error {
 	// containing all the messages to be sent to the target peer.
 	var announceMessages []lnwire.Message
 
-	makeNodeAnn := func(n *channeldb.LightningNode) (
-		*lnwire.NodeAnnouncement, error) {
-
-		alias, _ := lnwire.NewNodeAlias(n.Alias)
-
-		wireSig, err := lnwire.NewSigFromRawSignature(n.AuthSigBytes)
-		if err != nil {
-			return nil, err
-		}
-		return &lnwire.NodeAnnouncement{
-			Signature:       wireSig,
-			Timestamp:       uint32(n.LastUpdate.Unix()),
-			Addresses:       n.Addresses,
-			NodeID:          n.PubKeyBytes,
-			Features:        n.Features.RawFeatureVector,
-			RGBColor:        n.Color,
-			Alias:           alias,
-			ExtraOpaqueData: n.ExtraOpaqueData,
-		}, nil
-	}
-
 	// We'll use this map to ensure we don't send the same node
 	// announcement more than one time as one node may have many channel
 	// anns we'll need to send.
@@ -330,7 +309,7 @@ func (d *AuthenticatedGossiper) SynchronizeNode(syncPeer lnpeer.Peer) error {
 				nodePub := e1.Node.PubKeyBytes
 				hasNodeAnn := e1.Node.HaveNodeAnnouncement
 				if _, ok := nodePubsSent[nodePub]; !ok && hasNodeAnn {
-					nodeAnn, err := makeNodeAnn(e1.Node)
+					nodeAnn, err := e1.Node.NodeAnnouncement(true)
 					if err != nil {
 						return err
 					}
@@ -352,7 +331,7 @@ func (d *AuthenticatedGossiper) SynchronizeNode(syncPeer lnpeer.Peer) error {
 				nodePub := e2.Node.PubKeyBytes
 				hasNodeAnn := e2.Node.HaveNodeAnnouncement
 				if _, ok := nodePubsSent[nodePub]; !ok && hasNodeAnn {
-					nodeAnn, err := makeNodeAnn(e2.Node)
+					nodeAnn, err := e2.Node.NodeAnnouncement(true)
 					if err != nil {
 						return err
 					}

--- a/lnd_test.go
+++ b/lnd_test.go
@@ -7858,6 +7858,8 @@ func testNodeAnnouncement(net *lntest.NetworkHarness, t *harnessTest) {
 	advertisedAddrs := []string{
 		"192.168.1.1:8333",
 		"[2001:db8:85a3:8d3:1319:8a2e:370:7348]:8337",
+		"bkb6azqggsaiskzi.onion:9735",
+		"fomvuglh6h6vcag73xo5t5gv56ombih3zr2xvplkpbfd7wrog4swjwid.onion:1234",
 	}
 
 	var lndArgs []string

--- a/lnwallet/fee_estimator.go
+++ b/lnwallet/fee_estimator.go
@@ -229,7 +229,8 @@ func (b *BtcdFeeEstimator) fetchEstimate(confTarget uint32) (SatPerKWeight, erro
 	// Finally, we'll enforce our fee floor.
 	if satPerKw < b.minFeePerKW {
 		walletLog.Debugf("Estimated fee rate of %v sat/kw is too low, "+
-			"using fee floor of %v sat/kw instead", b.minFeePerKW)
+			"using fee floor of %v sat/kw instead", satPerKw,
+			b.minFeePerKW)
 		satPerKw = b.minFeePerKW
 	}
 


### PR DESCRIPTION
In this commit, we remedy the `genNodeAnnouncement` method to ensure that it also updates the on-disk node announcement. Before this commit, in both the Tor code, and the dynamic IP update code (for NAT traversal), we would fail to update the on-disk version of the node announcement. As a result, we would never propagate a new authenticated announcement to the network. 

Along the way, we clean up some duplicated node with the help of a new `LightningNode.NodeAnnouncement` method. 