### PR TITLE
server: update on-disk state upon new self node announcement changes

### DIFF
--- a/lnd_test.go
+++ b/lnd_test.go
@@ -7726,6 +7726,8 @@ func testNodeAnnouncement(net *lntest.NetworkHarness, t *harnessTest) {
 	advertisedAddrs := []string{
 		"192.168.1.1:8333",
 		"[2001:db8:85a3:8d3:1319:8a2e:370:7348]:8337",
+		"bkb6azqggsaiskzi.onion:9735",
+		"fomvuglh6h6vcag73xo5t5gv56ombih3zr2xvplkpbfd7wrog4swjwid.onion:1234",
 	}
 
 	var lndArgs []string

--- a/server.go
+++ b/server.go
@@ -734,7 +734,7 @@ func newServer(listenAddrs []net.Addr, chanDB *channeldb.DB, cc *chainControl,
 			return cc.msgSigner.SignMessage(pubKey, msg)
 		},
 		CurrentNodeAnnouncement: func() (lnwire.NodeAnnouncement, error) {
-			return s.genNodeAnnouncement(true)
+			return s.genNodeAnnouncement(false)
 		},
 		SendAnnouncement: func(msg lnwire.Message) chan error {
 			return s.authGossiper.ProcessLocalAnnouncement(


### PR DESCRIPTION
In this PR, we extend genNodeAnnouncement to also update our node's on-disk state within the graph to account for the new changes. We do this to ensure the changes reflect in our graph immediately, rather than waiting for them to be processed by the gossiper/router.

We also modify the CurrentNodeAnnouncement closure used within the funding manager to return the currently signed node announcement, rather than creating a new one and re-signing it every time. This is safe to do as we always re-sign the node announcement upon modifying it. By doing so, we also send less useless updates to our peers.