### PR TITLE
channeldb: ensure channel buckets are only created once

### DIFF
--- a/channeldb/error.go
+++ b/channeldb/error.go
@@ -43,6 +43,10 @@ var (
 	// specific identity can't be found.
 	ErrNodeNotFound = fmt.Errorf("link node with target identity not found")
 
+	// ErrChannelNotFound is returned when we attempt to locate a channel
+	// for a specific chain, but it is not found.
+	ErrChannelNotFound = fmt.Errorf("channel not found")
+
 	// ErrMetaNotFound is returned when meta bucket hasn't been
 	// created.
 	ErrMetaNotFound = fmt.Errorf("unable to locate meta information")

--- a/peer.go
+++ b/peer.go
@@ -505,9 +505,9 @@ func (p *peer) loadActiveChannels(chans []*channeldb.OpenChannel) error {
 			// ChannelUpdate. If this channel is already active,
 			// the update won't be sent.
 			err := p.server.announceChanStatus(chanPoint, false)
-			if err != nil {
-				peerLog.Errorf("unable to send out active "+
-					"channel update: %v", err)
+			if err != nil && err != channeldb.ErrEdgeNotFound {
+				srvrLog.Errorf("Unable to enable channel %v: %v",
+					chanPoint, err)
 			}
 		}
 	}()

--- a/peer.go
+++ b/peer.go
@@ -488,10 +488,12 @@ func (p *peer) loadActiveChannels(chans []*channeldb.OpenChannel) error {
 		p.activeChannels[chanID] = lnChan
 		p.activeChanMtx.Unlock()
 
-		// Only if the channel is public do we need to collect it for
-		// sending out a new enable update.
+		// To ensure we can route through this channel now that the peer
+		// is back online, we'll attempt to send an update to enable it.
+		// This will only be used for non-pending public channels, as
+		// they are the only ones capable of routing.
 		chanIsPublic := dbChan.ChannelFlags&lnwire.FFAnnounceChannel != 0
-		if chanIsPublic {
+		if chanIsPublic && !dbChan.IsPending {
 			activePublicChans = append(activePublicChans, *chanPoint)
 		}
 	}


### PR DESCRIPTION
In this PR, we ensure that we only create the sub-bucket for channels once: at the time of creation. We do this as otherwise it's possible that a method that mutates a channel's state is called after it has already been closed on-chain, leading to the channel bucket being recreated.

This PR also includes minor changes to prevent sending active/inactive channel updates for channels that have yet to be announced to the network. I noticed these while looking at the logs of the issue linked below.

Fixes #1917.