### PR TITLE
Demo Automated Docker Hub Builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,7 @@
-FROM golang:alpine as builder
+ARG BASE_BUILDER_IMAGE="golang:alpine"
+ARG BASE_IMAGE="alpine"
+
+FROM ${BASE_BUILDER_IMAGE} as builder
 
 # Force Go to use the cgo based DNS resolver. This is required to ensure DNS
 # queries required to connect to linked containers succeed.
@@ -14,7 +17,7 @@ RUN apk add --no-cache \
 &&  make install
 
 # Start a new, final image.
-FROM alpine as final
+FROM ${BASE_IMAGE} as final
 
 # Define a root volume for data persistence.
 VOLUME /root/.lnd

--- a/hooks/build
+++ b/hooks/build
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+baseImage="${DOCKER_TAG%%-*}"
+baseBuilderImage="golang:$baseImage"
+
+echo "Building $IMAGE_NAME from '$baseBuilderImage' to create image from '$baseImage'."
+
+docker build \
+  --build-arg BASE_BUILDER_IMAGE="$baseBuilderImage" \
+  --build-arg BASE_IMAGE="$baseImage" \
+  -t "$IMAGE_NAME" .

--- a/hooks/post_push
+++ b/hooks/post_push
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+baseImage="${DOCKER_TAG%%-*}"
+vcsRef=$(git rev-parse --short HEAD)
+
+commitHashTag="$DOCKER_REPO:$baseImage-$vcsRef"
+docker tag "$IMAGE_NAME" "$commitHashTag"
+docker push "$commitHashTag"
+
+latestTag="$DOCKER_REPO:$baseImage-latest"
+docker tag "$IMAGE_NAME" "$latestTag"
+docker push "$latestTag"


### PR DESCRIPTION
I was looking for the latest docker images under the docker hub orgs [lightningnetwork](https://hub.docker.com/u/lightningnetwork/) and [lightninglabs](https://hub.docker.com/r/lightninglabs/lnd/), but I couldn't find anything for the latest release.  Apologies for the noise if they are hosted somewhere else or if this is already a work in progress.

This PR:
* Demonstrates automating Docker image releases from git tag release triggers.
* Tags images with the patterns: `base_image-release_version`, `base_image-latest` and `base_image-short_git_hash`.  Where `base_image` would be alpine for example.
* Adds build args and a `build` hook script to allow this Dockerfile to be used to build from multiple versions of Alpine.  With a bit more work can be extended to support other operating systems such as Debian, see [github.com/comodal/lnd-docker](https://github.com/comodal/lnd-docker) for an example.

Corresponding hub.docker.com automated build settings:
![dockerhub_build_settings](https://user-images.githubusercontent.com/5894272/45922639-59290600-be97-11e8-96c9-862b26d9e503.png)

See [tags produced](https://hub.docker.com/r/comodal/lnd/tags/) from release tag [v0.5-beta-autobuild2](https://github.com/comodal/lnd/releases/tag/v0.5-beta-autobuild2).  Note that the commit hash reference corresponds to the commit that triggered the build from this fork, `comodal/lnd`, and not the latest commit from `lightningnetwork/lnd`.

... Adding a `build` hook would also allow the re-use or positioning of any Dockerfile's under `./docker/` rather than here in the root directory, as you can correctly apply the relative build context from the `build` script.  



