### PR TITLE
Fix problems finding bitcoind auth cookie on Windows

### DIFF
--- a/config.go
+++ b/config.go
@@ -1282,7 +1282,7 @@ func extractBitcoindRPCParams(bitcoindConfigPath string) (string, string, string
 	// Next, we'll try to find an auth cookie. We need to detect the chain
 	// by seeing if one is specified in the configuration file.
 	dataDir := filepath.Dir(bitcoindConfigPath)
-	dataDirRE, err := regexp.Compile(`(?m)^\s*datadir\s*=\s*([^\s]+)`)
+	dataDirRE, err := regexp.Compile(`(?m)^\s*datadir\s*=\s*([\S ]+?)\s*$`)
 	if err != nil {
 		return "", "", "", "", err
 	}

--- a/config.go
+++ b/config.go
@@ -83,8 +83,8 @@ var (
 	defaultLtcdDir         = btcutil.AppDataDir("ltcd", false)
 	defaultLtcdRPCCertFile = filepath.Join(defaultLtcdDir, "rpc.cert")
 
-	defaultBitcoindDir  = btcutil.AppDataDir("bitcoin", false)
-	defaultLitecoindDir = btcutil.AppDataDir("litecoin", false)
+	defaultBitcoindDir  = btcutil.AppDataDir("bitcoin", true)
+	defaultLitecoindDir = btcutil.AppDataDir("litecoin", true)
 
 	defaultTorSOCKS   = net.JoinHostPort("localhost", strconv.Itoa(defaultTorSOCKSPort))
 	defaultTorDNS     = net.JoinHostPort(defaultTorDNSHost, strconv.Itoa(defaultTorDNSPort))

--- a/config.go
+++ b/config.go
@@ -11,7 +11,6 @@ import (
 	"net"
 	"os"
 	"os/user"
-	"path"
 	"path/filepath"
 	"regexp"
 	"sort"
@@ -1282,7 +1281,7 @@ func extractBitcoindRPCParams(bitcoindConfigPath string) (string, string, string
 
 	// Next, we'll try to find an auth cookie. We need to detect the chain
 	// by seeing if one is specified in the configuration file.
-	dataDir := path.Dir(bitcoindConfigPath)
+	dataDir := filepath.Dir(bitcoindConfigPath)
 	dataDirRE, err := regexp.Compile(`(?m)^\s*datadir\s*=\s*([^\s]+)`)
 	if err != nil {
 		return "", "", "", "", err


### PR DESCRIPTION
Fix for some problems I encountered when trying to get lnd to find the bitcoind auth cookie file on a Windows machine:

- An improper use of `path.Dir` rather than `filepath.Dir`, which meant that it didn't work with backslashes and so it was just returning `'.'`. The `filepath` package seems to be properly used everywhere else, just not in this one small instance.
- When reading bitcoind's `datadir` from `bitcoin.conf`, the regex didn't allow for spaces in the path name.
- When `bitcoind.dir` isn't present in `lnd.conf`, it uses a default dir of `AppData\Local\Bitcoin` on Windows, but this should be `AppData\Roaming\Bitcoin`. The fix also corrects this for `litecoind`.