### PR TITLE
sweep: prepare for sweeper

### DIFF
--- a/contractcourt/chain_arbitrator.go
+++ b/contractcourt/chain_arbitrator.go
@@ -3,6 +3,7 @@ package contractcourt
 import (
 	"errors"
 	"fmt"
+	"github.com/lightningnetwork/lnd/sweep"
 	"sync"
 	"sync/atomic"
 
@@ -130,6 +131,9 @@ type ChainArbitratorConfig struct {
 	// DisableChannel disables a channel, resulting in it not being able to
 	// forward payments.
 	DisableChannel func(wire.OutPoint) error
+
+	// Sweeper allows resolvers to sweep their final outputs.
+	Sweeper *sweep.UtxoSweeper
 }
 
 // ChainArbitrator is a sub-system that oversees the on-chain resolution of all

--- a/log.go
+++ b/log.go
@@ -1,11 +1,9 @@
 package main
 
 import (
-	"os"
-
-	"io"
-
 	"fmt"
+	"io"
+	"os"
 	"path/filepath"
 
 	"github.com/btcsuite/btcd/connmgr"
@@ -24,6 +22,7 @@ import (
 	"github.com/lightningnetwork/lnd/lnwallet"
 	"github.com/lightningnetwork/lnd/routing"
 	"github.com/lightningnetwork/lnd/signal"
+	"github.com/lightningnetwork/lnd/sweep"
 )
 
 // Loggers per subsystem.  A single backend logger is created and all subsystem
@@ -65,6 +64,7 @@ var (
 	atplLog = build.NewSubLogger("ATPL", backendLog.Logger)
 	cnctLog = build.NewSubLogger("CNCT", backendLog.Logger)
 	sphxLog = build.NewSubLogger("SPHX", backendLog.Logger)
+	swprLog = build.NewSubLogger("SWPR", backendLog.Logger)
 )
 
 // Initialize package-global logger variables.
@@ -81,6 +81,7 @@ func init() {
 	contractcourt.UseLogger(cnctLog)
 	sphinx.UseLogger(sphxLog)
 	signal.UseLogger(ltndLog)
+	sweep.UseLogger(swprLog)
 }
 
 // subsystemLoggers maps each subsystem identifier to its associated logger.
@@ -103,6 +104,7 @@ var subsystemLoggers = map[string]btclog.Logger{
 	"ATPL": atplLog,
 	"CNCT": cnctLog,
 	"SPHX": sphxLog,
+	"SWPR": swprLog,
 }
 
 // initLogRotator initializes the logging rotator to write logs to logFile and

--- a/server.go
+++ b/server.go
@@ -695,6 +695,7 @@ func newServer(listenAddrs []net.Addr, chanDB *channeldb.DB, cc *chainControl,
 		DisableChannel: func(op wire.OutPoint) error {
 			return s.announceChanStatus(op, true)
 		},
+		Sweeper: sweeper,
 	}, chanDB)
 
 	s.breachArbiter = newBreachArbiter(&BreachConfig{

--- a/sweep/input.go
+++ b/sweep/input.go
@@ -1,0 +1,58 @@
+package sweep
+
+import (
+	"github.com/btcsuite/btcd/txscript"
+	"github.com/btcsuite/btcd/wire"
+	"github.com/btcsuite/btcutil"
+	"github.com/lightningnetwork/lnd/lnwallet"
+)
+
+// SpendableOutput an interface which can be used by the breach arbiter to
+// construct a transaction spending from outputs we control.
+type SpendableOutput interface {
+	// Amount returns the number of satoshis contained within the output.
+	Amount() btcutil.Amount
+
+	// Outpoint returns the reference to the output being spent, used to
+	// construct the corresponding transaction input.
+	OutPoint() *wire.OutPoint
+
+	// WitnessType returns an enum specifying the type of witness that must
+	// be generated in order to spend this output.
+	WitnessType() lnwallet.WitnessType
+
+	// SignDesc returns a reference to a spendable output's sign descriptor,
+	// which is used during signing to compute a valid witness that spends
+	// this output.
+	SignDesc() *lnwallet.SignDescriptor
+
+	// BuildWitness returns a valid witness allowing this output to be
+	// spent, the witness should be attached to the transaction at the
+	// location determined by the given `txinIdx`.
+	BuildWitness(signer lnwallet.Signer, txn *wire.MsgTx,
+		hashCache *txscript.TxSigHashes,
+		txinIdx int) ([][]byte, error)
+}
+
+// CsvSpendableOutput is a SpendableOutput that contains all of the information
+// necessary to construct, sign, and sweep an output locked with a CSV delay.
+type CsvSpendableOutput interface {
+	SpendableOutput
+
+	// ConfHeight returns the height at which this output was confirmed.
+	// A zero value indicates that the output has not been confirmed.
+	ConfHeight() uint32
+
+	// SetConfHeight marks the height at which the output is confirmed in
+	// the chain.
+	SetConfHeight(height uint32)
+
+	// BlocksToMaturity returns the relative timelock, as a number of
+	// blocks, that must be built on top of the confirmation height before
+	// the output can be spent.
+	BlocksToMaturity() uint32
+
+	// OriginChanPoint returns the outpoint of the channel from which this
+	// output is derived.
+	OriginChanPoint() *wire.OutPoint
+}

--- a/sweep/log.go
+++ b/sweep/log.go
@@ -1,0 +1,45 @@
+package sweep
+
+import (
+	"github.com/btcsuite/btclog"
+	"github.com/lightningnetwork/lnd/build"
+)
+
+// log is a logger that is initialized with no output filters.  This
+// means the package will not perform any logging by default until the caller
+// requests it.
+var log btclog.Logger
+
+// The default amount of logging is none.
+func init() {
+	UseLogger(build.NewSubLogger("SWPR", nil))
+}
+
+// DisableLog disables all library log output.  Logging output is disabled
+// by default until UseLogger is called.
+func DisableLog() {
+	UseLogger(btclog.Disabled)
+}
+
+// UseLogger uses a specified Logger to output package logging info.
+// This should be used in preference to SetLogWriter if the caller is also
+// using btclog.
+func UseLogger(logger btclog.Logger) {
+	log = logger
+}
+
+// logClosure is used to provide a closure over expensive logging operations so
+// don't have to be performed when the logging level doesn't warrant it.
+type logClosure func() string
+
+// String invokes the underlying function and returns the result.
+func (c logClosure) String() string {
+	return c()
+}
+
+// newLogClosure returns a new closure over a function that returns a string
+// which itself provides a Stringer interface so that it can be used with the
+// logging system.
+func newLogClosure(c func() string) logClosure {
+	return logClosure(c)
+}

--- a/sweep/sweeper.go
+++ b/sweep/sweeper.go
@@ -118,6 +118,13 @@ func (s *UtxoSweeper) CreateSweepTx(inputs []Input,
 			)
 			cltvCount++
 
+		// An HTLC on the commitment transaction of the remote party,
+		// that can be swept with the preimage.
+		case lnwallet.HtlcAcceptedRemoteSuccess:
+			weightEstimate.AddWitnessInput(
+				lnwallet.OfferedHtlcSuccessWitnessSize,
+			)
+
 		default:
 			unknownCount++
 			log.Warnf("kindergarten output in nursery store "+

--- a/sweep/sweeper.go
+++ b/sweep/sweeper.go
@@ -1,0 +1,249 @@
+package sweep
+
+import (
+	"github.com/btcsuite/btcd/blockchain"
+	"github.com/btcsuite/btcd/txscript"
+	"github.com/btcsuite/btcd/wire"
+	"github.com/btcsuite/btcutil"
+	"github.com/lightningnetwork/lnd/lnwallet"
+)
+
+// UtxoSweeper provides the functionality to generate sweep txes. The plan is to
+// extend UtxoSweeper in the future to also manage the actual sweeping process
+// by itself.
+type UtxoSweeper struct {
+	cfg *UtxoSweeperConfig
+}
+
+// UtxoSweeperConfig contains dependencies of UtxoSweeper.
+type UtxoSweeperConfig struct {
+	// GenSweepScript generates a P2WKH script belonging to the wallet where
+	// funds can be swept.
+	GenSweepScript func() ([]byte, error)
+
+	// Estimator is used when crafting sweep transactions to estimate the
+	// necessary fee relative to the expected size of the sweep transaction.
+	Estimator lnwallet.FeeEstimator
+
+	// Signer is used by the sweeper to generate valid witnesses at the
+	// time the incubated outputs need to be spent.
+	Signer lnwallet.Signer
+
+	// ConfTarget specifies a target for the number of blocks until an
+	// initial confirmation.
+	ConfTarget uint32
+}
+
+// New returns a new UtxoSweeper instance.
+func New(cfg *UtxoSweeperConfig) *UtxoSweeper {
+	return &UtxoSweeper{
+		cfg: cfg,
+	}
+}
+
+// CreateSweepTx accepts a list of outputs and signs and generates a txn that
+// spends from them. This method also makes an accurate fee estimate before
+// generating the required witnesses.
+//
+// The value of currentBlockHeight argument will be set as the tx locktime. This
+// function assumes that all CLTV inputs will be unlocked after
+// currentBlockHeight. Reasons not to use the maximum of all actual CLTV expiry
+// values of the inputs:
+//
+// - Make handling re-orgs easier.
+// - Thwart future possible fee sniping attempts.
+// - Make us blend in with the bitcoind wallet.
+func (s *UtxoSweeper) CreateSweepTx(inputs []CsvSpendableOutput,
+	currentBlockHeight uint32) (*wire.MsgTx, error) {
+
+	// Create a transaction which sweeps all the newly mature outputs into
+	// an output controlled by the wallet.
+
+	// TODO(roasbeef): can be more intelligent about buffering outputs to
+	// be more efficient on-chain.
+
+	// Assemble the inputs into a slice csv spendable outputs, and also a
+	// set of regular spendable outputs. The set of regular outputs are CLTV
+	// locked outputs that have had their timelocks expire.
+	var (
+		csvOutputs     []CsvSpendableOutput
+		cltvOutputs    []SpendableOutput
+		weightEstimate lnwallet.TxWeightEstimator
+	)
+
+	// Allocate enough room for both types of outputs.
+	csvOutputs = make([]CsvSpendableOutput, 0, len(inputs))
+	cltvOutputs = make([]SpendableOutput, 0, len(inputs))
+
+	// Our sweep transaction will pay to a single segwit p2wkh address,
+	// ensure it contributes to our weight estimate.
+	weightEstimate.AddP2WKHOutput()
+
+	// For each output, use its witness type to determine the estimate
+	// weight of its witness, and add it to the proper set of spendable
+	// outputs.
+	for i := range inputs {
+		input := inputs[i]
+
+		switch input.WitnessType() {
+
+		// Outputs on a past commitment transaction that pay directly
+		// to us.
+		case lnwallet.CommitmentTimeLock:
+			weightEstimate.AddWitnessInput(
+				lnwallet.ToLocalTimeoutWitnessSize,
+			)
+			csvOutputs = append(csvOutputs, input)
+
+		// Outgoing second layer HTLC's that have confirmed within the
+		// chain, and the output they produced is now mature enough to
+		// sweep.
+		case lnwallet.HtlcOfferedTimeoutSecondLevel:
+			weightEstimate.AddWitnessInput(
+				lnwallet.ToLocalTimeoutWitnessSize,
+			)
+			csvOutputs = append(csvOutputs, input)
+
+		// Incoming second layer HTLC's that have confirmed within the
+		// chain, and the output they produced is now mature enough to
+		// sweep.
+		case lnwallet.HtlcAcceptedSuccessSecondLevel:
+			weightEstimate.AddWitnessInput(
+				lnwallet.ToLocalTimeoutWitnessSize,
+			)
+			csvOutputs = append(csvOutputs, input)
+
+		// An HTLC on the commitment transaction of the remote party,
+		// that has had its absolute timelock expire.
+		case lnwallet.HtlcOfferedRemoteTimeout:
+			weightEstimate.AddWitnessInput(
+				lnwallet.AcceptedHtlcTimeoutWitnessSize,
+			)
+			cltvOutputs = append(cltvOutputs, input)
+
+		default:
+			log.Warnf("kindergarten output in nursery store "+
+				"contains unexpected witness type: %v",
+				input.WitnessType())
+			continue
+		}
+	}
+
+	log.Infof("Creating sweep transaction for %v CSV inputs, %v CLTV "+
+		"inputs", len(csvOutputs), len(cltvOutputs))
+
+	txWeight := int64(weightEstimate.Weight())
+	return s.populateSweepTx(txWeight, currentBlockHeight, csvOutputs, cltvOutputs)
+}
+
+// populateSweepTx populate the final sweeping transaction with all witnesses
+// in place for all inputs using the provided txn fee. The created transaction
+// has a single output sending all the funds back to the source wallet, after
+// accounting for the fee estimate.
+func (s *UtxoSweeper) populateSweepTx(txWeight int64, currentBlockHeight uint32,
+	csvInputs []CsvSpendableOutput,
+	cltvInputs []SpendableOutput) (*wire.MsgTx, error) {
+
+	// Generate the receiving script to which the funds will be swept.
+	pkScript, err := s.cfg.GenSweepScript()
+	if err != nil {
+		return nil, err
+	}
+
+	// Sum up the total value contained in the inputs.
+	var totalSum btcutil.Amount
+	for _, o := range csvInputs {
+		totalSum += o.Amount()
+	}
+	for _, o := range cltvInputs {
+		totalSum += o.Amount()
+	}
+
+	// Using the txn weight estimate, compute the required txn fee.
+	feePerKw, err := s.cfg.Estimator.EstimateFeePerKW(s.cfg.ConfTarget)
+	if err != nil {
+		return nil, err
+	}
+
+	log.Debugf("Using %v sat/kw for sweep tx", int64(feePerKw))
+
+	txFee := feePerKw.FeeForWeight(txWeight)
+
+	// Sweep as much possible, after subtracting txn fees.
+	sweepAmt := int64(totalSum - txFee)
+
+	// Create the sweep transaction that we will be building. We use
+	// version 2 as it is required for CSV. The txn will sweep the amount
+	// after fees to the pkscript generated above.
+	sweepTx := wire.NewMsgTx(2)
+	sweepTx.AddTxOut(&wire.TxOut{
+		PkScript: pkScript,
+		Value:    sweepAmt,
+	})
+
+	// We'll also ensure that the transaction has the required lock time if
+	// we're sweeping any cltvInputs.
+	if len(cltvInputs) > 0 {
+		sweepTx.LockTime = currentBlockHeight
+	}
+
+	// Add all inputs to the sweep transaction. Ensure that for each
+	// csvInput, we set the sequence number properly.
+	for _, input := range csvInputs {
+		sweepTx.AddTxIn(&wire.TxIn{
+			PreviousOutPoint: *input.OutPoint(),
+			Sequence:         input.BlocksToMaturity(),
+		})
+	}
+	for _, input := range cltvInputs {
+		sweepTx.AddTxIn(&wire.TxIn{
+			PreviousOutPoint: *input.OutPoint(),
+		})
+	}
+
+	// Before signing the transaction, check to ensure that it meets some
+	// basic validity requirements.
+	// TODO(conner): add more control to sanity checks, allowing us to delay
+	// spending "problem" outputs, e.g. possibly batching with other classes
+	// if fees are too low.
+	btx := btcutil.NewTx(sweepTx)
+	if err := blockchain.CheckTransactionSanity(btx); err != nil {
+		return nil, err
+	}
+
+	hashCache := txscript.NewTxSigHashes(sweepTx)
+
+	// With all the inputs in place, use each output's unique witness
+	// function to generate the final witness required for spending.
+	addWitness := func(idx int, tso SpendableOutput) error {
+		witness, err := tso.BuildWitness(
+			s.cfg.Signer, sweepTx, hashCache, idx,
+		)
+		if err != nil {
+			return err
+		}
+
+		sweepTx.TxIn[idx].Witness = witness
+
+		return nil
+	}
+
+	// Finally we'll attach a valid witness to each csv and cltv input
+	// within the sweeping transaction.
+	for i, input := range csvInputs {
+		if err := addWitness(i, input); err != nil {
+			return nil, err
+		}
+	}
+
+	// Add offset to relative indexes so cltv witnesses don't overwrite csv
+	// witnesses.
+	offset := len(csvInputs)
+	for i, input := range cltvInputs {
+		if err := addWitness(offset+i, input); err != nil {
+			return nil, err
+		}
+	}
+
+	return sweepTx, nil
+}

--- a/utxonursery.go
+++ b/utxonursery.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/binary"
 	"fmt"
+	"github.com/lightningnetwork/lnd/sweep"
 	"io"
 	"sync"
 	"sync/atomic"
@@ -953,14 +954,14 @@ func (u *utxoNursery) createSweepTx(kgtnOutputs []kidOutput,
 	// outputs are CLTV locked outputs that have had their timelocks
 	// expire.
 	var (
-		csvOutputs     []CsvSpendableOutput
-		cltvOutputs    []SpendableOutput
+		csvOutputs     []sweep.CsvSpendableOutput
+		cltvOutputs    []sweep.SpendableOutput
 		weightEstimate lnwallet.TxWeightEstimator
 	)
 
 	// Allocate enough room for both types of kindergarten outputs.
-	csvOutputs = make([]CsvSpendableOutput, 0, len(kgtnOutputs))
-	cltvOutputs = make([]SpendableOutput, 0, len(kgtnOutputs))
+	csvOutputs = make([]sweep.CsvSpendableOutput, 0, len(kgtnOutputs))
+	cltvOutputs = make([]sweep.SpendableOutput, 0, len(kgtnOutputs))
 
 	// Our sweep transaction will pay to a single segwit p2wkh address,
 	// ensure it contributes to our weight estimate.
@@ -1028,8 +1029,8 @@ func (u *utxoNursery) createSweepTx(kgtnOutputs []kidOutput,
 // has a single output sending all the funds back to the source wallet, after
 // accounting for the fee estimate.
 func (u *utxoNursery) populateSweepTx(txWeight int64, classHeight uint32,
-	csvInputs []CsvSpendableOutput,
-	cltvInputs []SpendableOutput) (*wire.MsgTx, error) {
+	csvInputs []sweep.CsvSpendableOutput,
+	cltvInputs []sweep.SpendableOutput) (*wire.MsgTx, error) {
 
 	// Generate the receiving script to which the funds will be swept.
 	pkScript, err := u.cfg.GenSweepScript()
@@ -1099,7 +1100,7 @@ func (u *utxoNursery) populateSweepTx(txWeight int64, classHeight uint32,
 
 	// With all the inputs in place, use each output's unique witness
 	// function to generate the final witness required for spending.
-	addWitness := func(idx int, tso SpendableOutput) error {
+	addWitness := func(idx int, tso sweep.SpendableOutput) error {
 		witness, err := tso.BuildWitness(
 			u.cfg.Signer, sweepTx, hashCache, idx,
 		)
@@ -1635,29 +1636,6 @@ func newSweepPkScript(wallet lnwallet.WalletController) ([]byte, error) {
 	return txscript.PayToAddrScript(sweepAddr)
 }
 
-// CsvSpendableOutput is a SpendableOutput that contains all of the information
-// necessary to construct, sign, and sweep an output locked with a CSV delay.
-type CsvSpendableOutput interface {
-	SpendableOutput
-
-	// ConfHeight returns the height at which this output was confirmed.
-	// A zero value indicates that the output has not been confirmed.
-	ConfHeight() uint32
-
-	// SetConfHeight marks the height at which the output is confirmed in
-	// the chain.
-	SetConfHeight(height uint32)
-
-	// BlocksToMaturity returns the relative timelock, as a number of
-	// blocks, that must be built on top of the confirmation height before
-	// the output can be spent.
-	BlocksToMaturity() uint32
-
-	// OriginChanPoint returns the outpoint of the channel from which this
-	// output is derived.
-	OriginChanPoint() *wire.OutPoint
-}
-
 // babyOutput represents a two-stage CSV locked output, and is used to track
 // htlc outputs through incubation. The first stage requires broadcasting a
 // presigned timeout txn that spends from the CLTV locked output on the
@@ -1971,5 +1949,5 @@ func readTxOut(r io.Reader, txo *wire.TxOut) error {
 
 // Compile-time constraint to ensure kidOutput and babyOutput implement the
 // CsvSpendableOutput interface.
-var _ CsvSpendableOutput = (*kidOutput)(nil)
-var _ CsvSpendableOutput = (*babyOutput)(nil)
+var _ sweep.CsvSpendableOutput = (*kidOutput)(nil)
+var _ sweep.CsvSpendableOutput = (*babyOutput)(nil)

--- a/utxonursery.go
+++ b/utxonursery.go
@@ -871,14 +871,14 @@ func (u *utxoNursery) graduateClass(classHeight uint32) error {
 		// generated a sweep txn for this height. Generate one if there
 		// are kindergarten outputs or cltv crib outputs to be spent.
 		if len(kgtnOutputs) > 0 {
-			csvSpendableOutputs := make([]sweep.CsvSpendableOutput,
+			sweepInputs := make([]sweep.Input,
 				len(kgtnOutputs))
 			for i := range kgtnOutputs {
-				csvSpendableOutputs[i] = &kgtnOutputs[i]
+				sweepInputs[i] = &kgtnOutputs[i]
 			}
 
 			finalTx, err = u.cfg.Sweeper.CreateSweepTx(
-				csvSpendableOutputs, classHeight)
+				sweepInputs, classHeight)
 
 			if err != nil {
 				utxnLog.Errorf("Failed to create sweep txn at "+
@@ -1749,7 +1749,7 @@ func readTxOut(r io.Reader, txo *wire.TxOut) error {
 	return nil
 }
 
-// Compile-time constraint to ensure kidOutput and babyOutput implement the
-// CsvSpendableOutput interface.
-var _ sweep.CsvSpendableOutput = (*kidOutput)(nil)
-var _ sweep.CsvSpendableOutput = (*babyOutput)(nil)
+// Compile-time constraint to ensure kidOutput implements the
+// Input interface.
+
+var _ sweep.Input = (*kidOutput)(nil)

--- a/utxonursery_test.go
+++ b/utxonursery_test.go
@@ -6,6 +6,7 @@ import (
 	"bytes"
 	"fmt"
 	"github.com/lightningnetwork/lnd/channeldb"
+	"github.com/lightningnetwork/lnd/sweep"
 	"io/ioutil"
 	"math"
 	"reflect"
@@ -431,6 +432,14 @@ func createNurseryTestContext(t *testing.T,
 
 	notifier := newNurseryMockNotifier(t)
 
+	sweeper := sweep.New(&sweep.UtxoSweeperConfig{
+		GenSweepScript: func() ([]byte, error) {
+			return []byte{}, nil
+		},
+		Estimator: &mockFeeEstimator{},
+		Signer:    &nurseryMockSigner{},
+	})
+
 	cfg := NurseryConfig{
 		Notifier: notifier,
 		FetchClosedChannels: func(pendingOnly bool) (
@@ -445,11 +454,7 @@ func createNurseryTestContext(t *testing.T,
 		},
 		Store:   storeIntercepter,
 		ChainIO: &mockChainIO{},
-		GenSweepScript: func() ([]byte, error) {
-			return []byte{}, nil
-		},
-		Estimator: &mockFeeEstimator{},
-		Signer:    &nurseryMockSigner{},
+		Sweeper: sweeper,
 	}
 
 	publishChan := make(chan wire.MsgTx, 1)


### PR DESCRIPTION
This PR makes changes that prepare for the new Sweeper struct.
- Create new subsystem for sweeping
- Move sweep tx generation code to sweep subsystem.
- Clean up SpendableOutput and CsvSpendableOutput structs.
- Make Cltv expiry part of a sweep input.
- Remove duplicated sweep tx generation code from Success and Commit resolvers

A follow PR is #1960, which builds the sweeper around the sweep tx generation and uses that from `utxonursery`.