### PR TITLE
rpc+server: ensure we don't leak unadvertised nodes within invoice routing hints

### DIFF
--- a/channeldb/graph.go
+++ b/channeldb/graph.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"crypto/sha256"
 	"encoding/binary"
+	"errors"
 	"fmt"
 	"image/color"
 	"io"
@@ -1804,6 +1805,47 @@ func (l *LightningNode) NodeAnnouncement(signed bool) (*lnwire.NodeAnnouncement,
 	return nodeAnn, nil
 }
 
+// isPublic determines whether the node is seen as public within the graph from
+// the source node's point of view. An existing database transaction can also be
+// specified.
+func (l *LightningNode) isPublic(tx *bolt.Tx, sourcePubKey []byte) (bool, error) {
+	// In order to determine whether this node is publicly advertised within
+	// the graph, we'll need to look at all of its edges and check whether
+	// they extend to any other node than the source node. errDone will be
+	// used to terminate the check early.
+	nodeIsPublic := false
+	errDone := errors.New("done")
+	err := l.ForEachChannel(tx, func(_ *bolt.Tx, info *ChannelEdgeInfo,
+		_, _ *ChannelEdgePolicy) error {
+
+		// If this edge doesn't extend to the source node, we'll
+		// terminate our search as we can now conclude that the node is
+		// publicly advertised within the graph due to the local node
+		// knowing of the current edge.
+		if !bytes.Equal(info.NodeKey1Bytes[:], sourcePubKey) &&
+			!bytes.Equal(info.NodeKey2Bytes[:], sourcePubKey) {
+
+			nodeIsPublic = true
+			return errDone
+		}
+
+		// Since the edge _does_ extend to the source node, we'll also
+		// need to ensure that this is a public edge.
+		if info.AuthProof != nil {
+			nodeIsPublic = true
+			return errDone
+		}
+
+		// Otherwise, we'll continue our search.
+		return nil
+	})
+	if err != nil && err != errDone {
+		return false, err
+	}
+
+	return nodeIsPublic, nil
+}
+
 // FetchLightningNode attempts to look up a target node by its identity public
 // key. If the node isn't found in the database, then ErrGraphNodeNotFound is
 // returned.
@@ -2564,6 +2606,35 @@ func (c *ChannelGraph) FetchChannelEdgesByID(chanID uint64) (*ChannelEdgeInfo, *
 	}
 
 	return edgeInfo, policy1, policy2, nil
+}
+
+// IsPublicNode is a helper method that determines whether the node with the
+// given public key is seen as a public node in the graph from the graph's
+// source node's point of view.
+func (c *ChannelGraph) IsPublicNode(pubKey [33]byte) (bool, error) {
+	var nodeIsPublic bool
+	err := c.db.View(func(tx *bolt.Tx) error {
+		nodes := tx.Bucket(nodeBucket)
+		if nodes == nil {
+			return ErrGraphNodesNotFound
+		}
+		ourPubKey := nodes.Get(sourceKey)
+		if ourPubKey == nil {
+			return ErrSourceNodeNotSet
+		}
+		node, err := fetchLightningNode(nodes, pubKey[:])
+		if err != nil {
+			return err
+		}
+
+		nodeIsPublic, err = node.isPublic(tx, ourPubKey)
+		return err
+	})
+	if err != nil {
+		return false, err
+	}
+
+	return nodeIsPublic, nil
 }
 
 // genMultiSigP2WSH generates the p2wsh'd multisig script for 2 of 2 pubkeys.

--- a/fundingmanager.go
+++ b/fundingmanager.go
@@ -15,9 +15,6 @@ import (
 	"github.com/coreos/bbolt"
 	"github.com/davecgh/go-spew/spew"
 	"github.com/go-errors/errors"
-	"golang.org/x/crypto/salsa20"
-	"google.golang.org/grpc"
-
 	"github.com/lightningnetwork/lnd/chainntnfs"
 	"github.com/lightningnetwork/lnd/channeldb"
 	"github.com/lightningnetwork/lnd/htlcswitch"
@@ -27,6 +24,8 @@ import (
 	"github.com/lightningnetwork/lnd/lnwallet"
 	"github.com/lightningnetwork/lnd/lnwire"
 	"github.com/lightningnetwork/lnd/routing"
+	"golang.org/x/crypto/salsa20"
+	"google.golang.org/grpc"
 )
 
 const (
@@ -2149,16 +2148,44 @@ func (f *fundingManager) addToRouterGraph(completeChan *channeldb.OpenChannel,
 func (f *fundingManager) annAfterSixConfs(completeChan *channeldb.OpenChannel,
 	shortChanID *lnwire.ShortChannelID) error {
 
-	// If this channel is meant to be announced to the greater network,
-	// wait until the funding tx has reached 6 confirmations before
-	// announcing it.
+	// If this channel is not meant to be announced to the greater network,
+	// we'll only send our NodeAnnouncement to our counterparty to ensure we
+	// don't leak any of our information.
 	announceChan := completeChan.ChannelFlags&lnwire.FFAnnounceChannel != 0
 	if !announceChan {
 		fndgLog.Debugf("Will not announce private channel %v.",
 			shortChanID.ToUint64())
+
+		peerChan := make(chan lnpeer.Peer, 1)
+		f.cfg.NotifyWhenOnline(completeChan.IdentityPub, peerChan)
+
+		var peer lnpeer.Peer
+		select {
+		case peer = <-peerChan:
+		case <-f.quit:
+			return ErrFundingManagerShuttingDown
+		}
+
+		nodeAnn, err := f.cfg.CurrentNodeAnnouncement()
+		if err != nil {
+			return fmt.Errorf("unable to retrieve current node "+
+				"announcement: %v", err)
+		}
+
+		chanID := lnwire.NewChanIDFromOutPoint(
+			&completeChan.FundingOutpoint,
+		)
+		pubKey := peer.PubKey()
+		fndgLog.Debugf("Sending our NodeAnnouncement for "+
+			"ChannelID(%v) to %x", chanID, pubKey)
+
+		if err := peer.SendMessage(true, &nodeAnn); err != nil {
+			return fmt.Errorf("unable to send node announcement "+
+				"to peer %x: %v", pubKey, err)
+		}
 	} else {
-		// Register with the ChainNotifier for a notification once the
-		// funding transaction reaches at least 6 confirmations.
+		// Otherwise, we'll wait until the funding transaction has
+		// reached 6 confirmations before announcing it.
 		numConfs := uint32(completeChan.NumConfsRequired)
 		if numConfs < 6 {
 			numConfs = 6
@@ -2176,8 +2203,11 @@ func (f *fundingManager) annAfterSixConfs(completeChan *channeldb.OpenChannel,
 				completeChan.FundingOutpoint, err)
 		}
 
+		// Register with the ChainNotifier for a notification once the
+		// funding transaction reaches at least 6 confirmations.
 		confNtfn, err := f.cfg.Notifier.RegisterConfirmationsNtfn(
-			&txid, fundingScript, numConfs, completeChan.FundingBroadcastHeight,
+			&txid, fundingScript, numConfs,
+			completeChan.FundingBroadcastHeight,
 		)
 		if err != nil {
 			return fmt.Errorf("Unable to register for "+

--- a/routing/router.go
+++ b/routing/router.go
@@ -72,6 +72,10 @@ type ChannelGraphSource interface {
 	// the target node.
 	IsStaleNode(node Vertex, timestamp time.Time) bool
 
+	// IsPublicNode determines whether the given vertex is seen as a public
+	// node in the graph from the graph's source node's point of view.
+	IsPublicNode(node Vertex) (bool, error)
+
 	// IsKnownEdge returns true if the graph source already knows of the
 	// passed channel ID.
 	IsKnownEdge(chanID lnwire.ShortChannelID) bool
@@ -2220,6 +2224,14 @@ func (r *ChannelRouter) IsStaleNode(node Vertex, timestamp time.Time) bool {
 	// If our attempt to assert that the node announcement is fresh fails,
 	// then we know that this is actually a stale announcement.
 	return r.assertNodeAnnFreshness(node, timestamp) != nil
+}
+
+// IsPublicNode determines whether the given vertex is seen as a public node in
+// the graph from the graph's source node's point of view.
+//
+// NOTE: This method is part of the ChannelGraphSource interface.
+func (r *ChannelRouter) IsPublicNode(node Vertex) (bool, error) {
+	return r.cfg.Graph.IsPublicNode(node)
 }
 
 // IsKnownEdge returns true if the graph source already knows of the passed


### PR DESCRIPTION
In this commit, we ensure that we don't include routing hints for
unadvertised nodes at the time of invoice creation. Otherwise, this
would lead us to leak these unadvertised nodes to anyone who can get
their hands on the invoice being created. To prevent this, we'll now
look at the network graph and ensure that the node in unadvertised if
all of their edges are unadvertised and only extend to us.