### PR TITLE
utxonursery: remove nursery [DO NOT REVIEW]

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -175,8 +175,8 @@ flakehunter: build
 
 flake-unit:
 	@$(call print, "Flake hunting unit tests.")
-	$(UNIT) -count=1
-	while [ $$? -eq 0 ]; do /bin/sh -c "$(UNIT) -count=1"; done
+	GOTRACEBACK=all $(UNIT) -count=1
+	while [ $$? -eq 0 ]; do /bin/sh -c "GOTRACEBACK=all $(UNIT) -count=1"; done
 
 # ======
 # TRAVIS

--- a/contractcourt/briefcase.go
+++ b/contractcourt/briefcase.go
@@ -355,8 +355,6 @@ func (b *boltArbitratorLog) writeResolver(contractBucket *bolt.Bucket,
 		rType = resolverTimeout
 	case *htlcSuccessResolver:
 		rType = resolverSuccess
-	case *htlcOutgoingContestResolver:
-		rType = resolverOutgoingContest
 	case *htlcIncomingContestResolver:
 		rType = resolverIncomingContest
 	case *commitSweepResolver:
@@ -466,16 +464,6 @@ func (b *boltArbitratorLog) FetchUnresolvedContracts() ([]ContractResolver, erro
 				}
 
 				res = successRes
-
-			case resolverOutgoingContest:
-				outContestRes := &htlcOutgoingContestResolver{
-					htlcTimeoutResolver: htlcTimeoutResolver{},
-				}
-				if err := outContestRes.Decode(resReader); err != nil {
-					return err
-				}
-
-				res = outContestRes
 
 			case resolverIncomingContest:
 				inContestRes := &htlcIncomingContestResolver{

--- a/contractcourt/channel_arbitrator.go
+++ b/contractcourt/channel_arbitrator.go
@@ -1155,7 +1155,7 @@ func (c *ChannelArbitrator) prepContractResolutions(htlcActions ChainActionMap,
 		// If we can timeout the HTLC directly, then we'll create the
 		// proper resolver to do so, who will then cancel the packet
 		// backwards.
-		case HtlcTimeoutAction:
+		case HtlcTimeoutAction, HtlcOutgoingWatchAction:
 			for _, htlc := range htlcs {
 				htlcOp := wire.OutPoint{
 					Hash:  commitHash,
@@ -1207,36 +1207,6 @@ func (c *ChannelArbitrator) prepContractResolutions(htlcActions ChainActionMap,
 						htlcResolution:  resolution,
 						broadcastHeight: height,
 						payHash:         htlc.RHash,
-						ResolverKit:     resKit,
-					},
-				}
-				htlcResolvers = append(htlcResolvers, resolver)
-			}
-
-		// Finally, if this is an outgoing HTLC we've sent, then we'll
-		// launch a resolver to watch for the pre-image (and settle
-		// backwards), or just timeout.
-		case HtlcOutgoingWatchAction:
-			for _, htlc := range htlcs {
-				htlcOp := wire.OutPoint{
-					Hash:  commitHash,
-					Index: uint32(htlc.OutputIndex),
-				}
-
-				resolution, ok := outResolutionMap[htlcOp]
-				if !ok {
-					log.Errorf("ChannelArbitrator(%v) unable to find "+
-						"outgoing resolution: %v",
-						c.cfg.ChanPoint, htlcOp)
-					continue
-				}
-
-				resKit.Quit = make(chan struct{})
-				resolver := &htlcOutgoingContestResolver{
-					htlcTimeoutResolver{
-						htlcResolution:  resolution,
-						broadcastHeight: height,
-						htlcIndex:       htlc.HtlcIndex,
 						ResolverKit:     resKit,
 					},
 				}

--- a/contractcourt/contract_resolvers.go
+++ b/contractcourt/contract_resolvers.go
@@ -134,140 +134,267 @@ func (h *htlcTimeoutResolver) ResolverKey() []byte {
 	return key[:]
 }
 
-// Resolve kicks off full resolution of an outgoing HTLC output. If it's our
-// commitment, it isn't resolved until we see the second level HTLC txn
-// confirmed. If it's the remote party's commitment, we don't resolve until we
-// see a direct sweep via the timeout clause.
+type outgoingState uint8
+
+const (
+	cltvWait uint8 = iota
+	secondLevelConf
+	csvWait
+	sweepWait
+)
+
+// Resolve commences the resolution of this contract. As this contract hasn't
+// yet timed out, we'll wait for one of two things to happen
 //
-// NOTE: Part of the ContractResolver interface.
+//   1. The HTLC expires. In this case, we'll sweep the funds and send a clean
+//      up cancel message to outside sub-systems.
+//
+//   2. The remote party sweeps this HTLC on-chain, in which case we'll add the
+//      pre-image to our global cache, then send a clean up settle message
+//      backwards.
+//
+// When either of these two things happens, we'll create a new resolver which
+// is able to handle the final resolution of the contract. We're only the pivot
+// point.
 func (h *htlcTimeoutResolver) Resolve() (ContractResolver, error) {
-	// If we're already resolved, then we can exit early.
+	// If we're already full resolved, then we don't have anything further
+	// to do.
 	if h.resolved {
 		return nil, nil
 	}
 
-	// If we haven't already sent the output to the utxo nursery, then
-	// we'll do so now.
-	if !h.outputIncubating {
-		log.Tracef("%T(%v): incubating htlc output", h,
-			h.htlcResolution.ClaimOutpoint)
+	// claimCleanUp is a helper function that's called once the HTLC output
+	// is spent by the remote party. It'll extract the preimage, add it to
+	// the global cache, and finally send the appropriate clean up message.
+	claimCleanUp := func(commitSpend *chainntnfs.SpendDetail) (ContractResolver, error) {
+		// Depending on if this is our commitment or not, then we'll be
+		// looking for a different witness pattern.
+		spenderIndex := commitSpend.SpenderInputIndex
+		spendingInput := commitSpend.SpendingTx.TxIn[spenderIndex]
 
-		err := h.IncubateOutputs(h.ChanPoint, nil, &h.htlcResolution, nil)
+		log.Infof("%T(%v): extracting preimage! remote party spent "+
+			"HTLC with tx=%v", h, h.htlcResolution.ClaimOutpoint,
+			spew.Sdump(commitSpend.SpendingTx))
+
+		// If this is the remote party's commitment, then we'll be
+		// looking for them to spend using the second-level success
+		// transaction.
+		var preimage [32]byte
+		if h.htlcResolution.SignedTimeoutTx == nil {
+			// The witness stack when the remote party sweeps the
+			// output to them looks like:
+			//
+			//  * <sender sig> <recvr sig> <preimage> <witness script>
+			copy(preimage[:], spendingInput.Witness[3])
+		} else {
+			// Otherwise, they'll be spending directly from our
+			// commitment output. In which case the witness stack
+			// looks like:
+			//
+			//  * <sig> <preimage> <witness script>
+			copy(preimage[:], spendingInput.Witness[1])
+		}
+
+		log.Infof("%T(%v): extracting preimage=%x from on-chain "+
+			"spend!", h, h.htlcResolution.ClaimOutpoint, preimage[:])
+
+		// With the preimage obtained, we can now add it to the global
+		// cache.
+		if err := h.PreimageDB.AddPreimage(preimage[:]); err != nil {
+			log.Errorf("%T(%v): unable to add witness to cache",
+				h, h.htlcResolution.ClaimOutpoint)
+		}
+
+		// Finally, we'll send the clean up message, mark ourselves as
+		// resolved, then exit.
+		if err := h.DeliverResolutionMsg(ResolutionMsg{
+			SourceChan: h.ShortChanID,
+			HtlcIndex:  h.htlcIndex,
+			PreImage:   &preimage,
+		}); err != nil {
+			return nil, err
+		}
+		h.resolved = true
+		return nil, h.Checkpoint(h)
+	}
+
+	// Otherwise, we'll watch for two external signals to decide if we'll
+	// morph into another resolver, or fully resolve the contract.
+
+	// The output we'll be watching for is the *direct* spend from the HTLC
+	// output. If this isn't our commitment transaction, it'll be right on
+	// the resolution. Otherwise, we fetch this pointer from the input of
+	// the time out transaction.
+	var (
+		outPointToWatch      wire.OutPoint
+		scriptToWatch        []byte
+		err                  error
+		secondLevelSpendChan <-chan *chainntnfs.SpendDetail
+	)
+	if h.htlcResolution.SignedTimeoutTx == nil {
+		outPointToWatch = h.htlcResolution.ClaimOutpoint
+		scriptToWatch = h.htlcResolution.SweepSignDesc.Output.PkScript
+
+		// Create dummy channel that will never receive a notification.
+		secondLevelSpendChan = make(chan *chainntnfs.SpendDetail)
+	} else {
+		// If this is the remote party's commitment, then we'll need to
+		// grab watch the output that our timeout transaction points
+		// to. We can directly grab the outpoint, then also extract the
+		// witness script (the last element of the witness stack) to
+		// re-construct the pkScipt we need to watch.
+		outPointToWatch = h.htlcResolution.SignedTimeoutTx.TxIn[0].PreviousOutPoint
+		witness := h.htlcResolution.SignedTimeoutTx.TxIn[0].Witness
+		scriptToWatch, err = lnwallet.WitnessScriptHash(
+			witness[len(witness)-1],
+		)
 		if err != nil {
 			return nil, err
 		}
 
-		h.outputIncubating = true
-
-		if err := h.Checkpoint(h); err != nil {
-			log.Errorf("unable to Checkpoint: %v", err)
-		}
-	}
-
-	// waitForOutputResolution waits for the HTLC output to be fully
-	// resolved. The output is considered fully resolved once it has been
-	// spent, and the spending transaction has been fully confirmed.
-	waitForOutputResolution := func() error {
-		// We first need to register to see when the HTLC output itself
-		// has been spent by a confirmed transaction.
-		spendNtfn, err := h.Notifier.RegisterSpendNtfn(
-			&h.htlcResolution.ClaimOutpoint,
-			h.htlcResolution.SweepSignDesc.Output.PkScript,
-			h.broadcastHeight,
+		secondLevelOutPointToWatch := h.htlcResolution.ClaimOutpoint
+		secondLevelScriptToWatch := h.htlcResolution.SweepSignDesc.Output.PkScript
+		secondLevelSpendNtfn, err := h.Notifier.RegisterSpendNtfn(
+			&secondLevelOutPointToWatch, secondLevelScriptToWatch, h.broadcastHeight,
 		)
 		if err != nil {
-			return err
+			return nil, err
 		}
+		secondLevelSpendChan = secondLevelSpendNtfn.Spend
+	}
 
-		select {
-		case _, ok := <-spendNtfn.Spend:
-			if !ok {
-				return fmt.Errorf("notifier quit")
+	// First, we'll register for a spend notification for this output. If
+	// the remote party sweeps with the pre-image, we'll be notified.
+	spendNtfn, err := h.Notifier.RegisterSpendNtfn(
+		&outPointToWatch, scriptToWatch, h.broadcastHeight,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	// TODO: Cancel spend notifications on quit?
+
+	_, currentHeight, err := h.ChainIO.GetBestBlock()
+	if err != nil {
+		return nil, err
+	}
+
+	state := cltvWait
+	var secondLevelExpiry int32
+
+	evaluateHeight := func() {
+		switch {
+		case state == cltvWait &&
+			uint32(currentHeight) >= h.htlcResolution.Expiry-1:
+
+			if h.htlcResolution.SignedTimeoutTx == nil {
+				// Start sweep
+
+				state = sweepWait
+			} else {
+				// Publish timeout tx
+
+				state = secondLevelConf
 			}
 
-		case <-h.Quit:
-			return fmt.Errorf("quitting")
+		case state == csvWait && currentHeight >= secondLevelExpiry-1:
+			// Start sweep
+
+			state = sweepWait
 		}
 
-		return nil
 	}
 
-	// With the output sent to the nursery, we'll now wait until the output
-	// has been fully resolved before sending the clean up message.
-	//
-	// TODO(roasbeef): need to be able to cancel nursery?
-	//  * if they pull on-chain while we're waiting
+	// Evaluate current height in case cltv has already expired.
+	evaluateHeight()
 
-	// If we don't have a second layer transaction, then this is a remote
-	// party's commitment, so we'll watch for a direct spend.
-	if h.htlcResolution.SignedTimeoutTx == nil {
-		// We'll block until: the HTLC output has been spent, and the
-		// transaction spending that output is sufficiently confirmed.
-		log.Infof("%T(%v): waiting for nursery to spend CLTV-locked "+
-			"output", h, h.htlcResolution.ClaimOutpoint)
-		if err := waitForOutputResolution(); err != nil {
-			return nil, err
-		}
-	} else {
-		// Otherwise, this is our commitment, so we'll watch for the
-		// second-level transaction to be sufficiently confirmed.
-		secondLevelTXID := h.htlcResolution.SignedTimeoutTx.TxHash()
-		sweepScript := h.htlcResolution.SignedTimeoutTx.TxOut[0].PkScript
-		confNtfn, err := h.Notifier.RegisterConfirmationsNtfn(
-			&secondLevelTXID, sweepScript, 1, h.broadcastHeight,
-		)
-		if err != nil {
-			return nil, err
-		}
+	// If we reach this point, then we can't fully act yet, so we'll await
+	// either of our signals triggering: the HTLC expires, or we learn of
+	// the preimage.
+	blockEpochs, err := h.Notifier.RegisterBlockEpochNtfn(nil)
+	if err != nil {
+		return nil, err
+	}
+	defer blockEpochs.Cancel()
 
-		log.Infof("%T(%v): waiting second-level tx (txid=%v) to be "+
-			"fully confirmed", h, h.htlcResolution.ClaimOutpoint,
-			secondLevelTXID)
-
+loop:
+	for {
 		select {
-		case _, ok := <-confNtfn.Confirmed:
+
+		// A new block has arrived, we'll check to see if this leads to
+		// HTLC expiration.
+		case newBlock, ok := <-blockEpochs.Epochs:
 			if !ok {
 				return nil, fmt.Errorf("quitting")
 			}
 
+			// If this new height expires the HTLC, then we can
+			// exit early and create a resolver that's capable of
+			// handling the time locked output.
+			currentHeight = newBlock.Height
+			evaluateHeight()
+
+		// The output has been spent! This means the preimage has been
+		// revealed on-chain.
+		case commitSpend, ok := <-spendNtfn.Spend:
+			if !ok {
+				return nil, fmt.Errorf("quitting")
+			}
+
+			// The only way this output can be spent by the remote
+			// party is by revealing the preimage. So we'll perform
+			// our duties to clean up the contract once it has been
+			// claimed.
+			var isRemoteSpend bool
+			if h.htlcResolution.SignedTimeoutTx != nil {
+				timeoutTxHash := h.htlcResolution.SignedTimeoutTx.TxHash()
+
+				// If spend not by our own timeout tx, it must
+				// be a remote spend.
+				isRemoteSpend = !bytes.Equal(commitSpend.SpenderTxHash[:],
+					timeoutTxHash[:])
+			} else {
+				// Detect remote success tx by witness length.
+				isRemoteSpend = len(commitSpend.SpendingTx.TxIn[0].Witness) == 5
+			}
+
+			if isRemoteSpend {
+				return claimCleanUp(commitSpend)
+			}
+
+			// At this point, the second-level transaction is sufficiently
+			// confirmed, or a transaction directly spending the output is.
+			// Therefore, we can now send back our clean up message.
+			failureMsg := &lnwire.FailPermanentChannelFailure{}
+			if err := h.DeliverResolutionMsg(ResolutionMsg{
+				SourceChan: h.ShortChanID,
+				HtlcIndex:  h.htlcIndex,
+				Failure:    failureMsg,
+			}); err != nil {
+				return nil, err
+			}
+
+			if state == secondLevelConf {
+				state = csvWait
+				secondLevelExpiry = currentHeight +
+					int32(h.htlcResolution.CsvDelay)
+
+				evaluateHeight()
+			} else {
+				break loop
+			}
+
+		case _, ok := <-secondLevelSpendChan:
+			if !ok {
+				return nil, fmt.Errorf("quitting")
+			}
+			break loop
+
 		case <-h.Quit:
-			return nil, fmt.Errorf("quitting")
+			return nil, fmt.Errorf("resolver cancelled")
 		}
+
 	}
-
-	// TODO(roasbeef): need to watch for remote party sweeping with pre-image?
-	//  * have another waiting on spend above, will check the type, if it's
-	//    pre-image, then we'll cancel, and send a clean up back with
-	//    pre-image, also add to preimage cache
-
-	log.Infof("%T(%v): resolving htlc with incoming fail msg, fully "+
-		"confirmed", h, h.htlcResolution.ClaimOutpoint)
-
-	// At this point, the second-level transaction is sufficiently
-	// confirmed, or a transaction directly spending the output is.
-	// Therefore, we can now send back our clean up message.
-	failureMsg := &lnwire.FailPermanentChannelFailure{}
-	if err := h.DeliverResolutionMsg(ResolutionMsg{
-		SourceChan: h.ShortChanID,
-		HtlcIndex:  h.htlcIndex,
-		Failure:    failureMsg,
-	}); err != nil {
-		return nil, err
-	}
-
-	// Finally, if this was an output on our commitment transaction, we'll
-	// for the second-level HTLC output to be spent, and for that
-	// transaction itself to confirm.
-	if h.htlcResolution.SignedTimeoutTx != nil {
-		log.Infof("%T(%v): waiting for nursery to spend CSV delayed "+
-			"output", h, h.htlcResolution.ClaimOutpoint)
-		if err := waitForOutputResolution(); err != nil {
-			return nil, err
-		}
-	}
-
-	// With the clean up message sent, we'll now mark the contract
-	// resolved, and wait.
 	h.resolved = true
 	return nil, h.Checkpoint(h)
 }
@@ -692,327 +819,6 @@ func (h *htlcSuccessResolver) AttachResolverKit(r ResolverKit) {
 // A compile time assertion to ensure htlcSuccessResolver meets the
 // ContractResolver interface.
 var _ ContractResolver = (*htlcSuccessResolver)(nil)
-
-// htlcOutgoingContestResolver is a ContractResolver that's able to resolve an
-// outgoing HTLC that is still contested. An HTLC is still contested, if at the
-// time that we broadcast the commitment transaction, it isn't able to be fully
-// resolved. In this case, we'll either wait for the HTLC to timeout, or for
-// us to learn of the preimage.
-type htlcOutgoingContestResolver struct {
-	// htlcTimeoutResolver is the inner solver that this resolver may turn
-	// into. This only happens if the HTLC expires on-chain.
-	htlcTimeoutResolver
-}
-
-type outgoingState uint8
-
-const (
-	cltvWait uint8 = iota
-	secondLevelConf
-	csvWait
-	sweepWait
-)
-
-// Resolve commences the resolution of this contract. As this contract hasn't
-// yet timed out, we'll wait for one of two things to happen
-//
-//   1. The HTLC expires. In this case, we'll sweep the funds and send a clean
-//      up cancel message to outside sub-systems.
-//
-//   2. The remote party sweeps this HTLC on-chain, in which case we'll add the
-//      pre-image to our global cache, then send a clean up settle message
-//      backwards.
-//
-// When either of these two things happens, we'll create a new resolver which
-// is able to handle the final resolution of the contract. We're only the pivot
-// point.
-func (h *htlcOutgoingContestResolver) Resolve() (ContractResolver, error) {
-	// If we're already full resolved, then we don't have anything further
-	// to do.
-	if h.resolved {
-		return nil, nil
-	}
-
-	// claimCleanUp is a helper function that's called once the HTLC output
-	// is spent by the remote party. It'll extract the preimage, add it to
-	// the global cache, and finally send the appropriate clean up message.
-	claimCleanUp := func(commitSpend *chainntnfs.SpendDetail) (ContractResolver, error) {
-		// Depending on if this is our commitment or not, then we'll be
-		// looking for a different witness pattern.
-		spenderIndex := commitSpend.SpenderInputIndex
-		spendingInput := commitSpend.SpendingTx.TxIn[spenderIndex]
-
-		log.Infof("%T(%v): extracting preimage! remote party spent "+
-			"HTLC with tx=%v", h, h.htlcResolution.ClaimOutpoint,
-			spew.Sdump(commitSpend.SpendingTx))
-
-		// If this is the remote party's commitment, then we'll be
-		// looking for them to spend using the second-level success
-		// transaction.
-		var preimage [32]byte
-		if h.htlcResolution.SignedTimeoutTx == nil {
-			// The witness stack when the remote party sweeps the
-			// output to them looks like:
-			//
-			//  * <sender sig> <recvr sig> <preimage> <witness script>
-			copy(preimage[:], spendingInput.Witness[3])
-		} else {
-			// Otherwise, they'll be spending directly from our
-			// commitment output. In which case the witness stack
-			// looks like:
-			//
-			//  * <sig> <preimage> <witness script>
-			copy(preimage[:], spendingInput.Witness[1])
-		}
-
-		log.Infof("%T(%v): extracting preimage=%x from on-chain "+
-			"spend!", h, h.htlcResolution.ClaimOutpoint, preimage[:])
-
-		// With the preimage obtained, we can now add it to the global
-		// cache.
-		if err := h.PreimageDB.AddPreimage(preimage[:]); err != nil {
-			log.Errorf("%T(%v): unable to add witness to cache",
-				h, h.htlcResolution.ClaimOutpoint)
-		}
-
-		// Finally, we'll send the clean up message, mark ourselves as
-		// resolved, then exit.
-		if err := h.DeliverResolutionMsg(ResolutionMsg{
-			SourceChan: h.ShortChanID,
-			HtlcIndex:  h.htlcIndex,
-			PreImage:   &preimage,
-		}); err != nil {
-			return nil, err
-		}
-		h.resolved = true
-		return nil, h.Checkpoint(h)
-	}
-
-	// Otherwise, we'll watch for two external signals to decide if we'll
-	// morph into another resolver, or fully resolve the contract.
-
-	// The output we'll be watching for is the *direct* spend from the HTLC
-	// output. If this isn't our commitment transaction, it'll be right on
-	// the resolution. Otherwise, we fetch this pointer from the input of
-	// the time out transaction.
-	var (
-		outPointToWatch      wire.OutPoint
-		scriptToWatch        []byte
-		err                  error
-		secondLevelSpendChan <-chan *chainntnfs.SpendDetail
-	)
-	if h.htlcResolution.SignedTimeoutTx == nil {
-		outPointToWatch = h.htlcResolution.ClaimOutpoint
-		scriptToWatch = h.htlcResolution.SweepSignDesc.Output.PkScript
-
-		// Create dummy channel that will never receive a notification.
-		secondLevelSpendChan = make(chan *chainntnfs.SpendDetail)
-	} else {
-		// If this is the remote party's commitment, then we'll need to
-		// grab watch the output that our timeout transaction points
-		// to. We can directly grab the outpoint, then also extract the
-		// witness script (the last element of the witness stack) to
-		// re-construct the pkScipt we need to watch.
-		outPointToWatch = h.htlcResolution.SignedTimeoutTx.TxIn[0].PreviousOutPoint
-		witness := h.htlcResolution.SignedTimeoutTx.TxIn[0].Witness
-		scriptToWatch, err = lnwallet.WitnessScriptHash(
-			witness[len(witness)-1],
-		)
-		if err != nil {
-			return nil, err
-		}
-
-		secondLevelOutPointToWatch := h.htlcResolution.ClaimOutpoint
-		secondLevelScriptToWatch := h.htlcResolution.SweepSignDesc.Output.PkScript
-		secondLevelSpendNtfn, err := h.Notifier.RegisterSpendNtfn(
-			&secondLevelOutPointToWatch, secondLevelScriptToWatch, h.broadcastHeight,
-		)
-		if err != nil {
-			return nil, err
-		}
-		secondLevelSpendChan = secondLevelSpendNtfn.Spend
-	}
-
-	// First, we'll register for a spend notification for this output. If
-	// the remote party sweeps with the pre-image, we'll be notified.
-	spendNtfn, err := h.Notifier.RegisterSpendNtfn(
-		&outPointToWatch, scriptToWatch, h.broadcastHeight,
-	)
-	if err != nil {
-		return nil, err
-	}
-
-	// TODO: Cancel spend notifications on quit?
-
-	_, currentHeight, err := h.ChainIO.GetBestBlock()
-	if err != nil {
-		return nil, err
-	}
-
-	state := cltvWait
-	var secondLevelExpiry int32
-
-	evaluateHeight := func() {
-		switch {
-		case state == cltvWait &&
-			uint32(currentHeight) >= h.htlcResolution.Expiry-1:
-
-			if h.htlcResolution.SignedTimeoutTx == nil {
-				// Start sweep
-
-				state = sweepWait
-			} else {
-				// Publish timeout tx
-
-				state = secondLevelConf
-			}
-
-		case state == csvWait && currentHeight >= secondLevelExpiry-1:
-			// Start sweep
-
-			state = sweepWait
-		}
-
-	}
-
-	// Evaluate current height in case cltv has already expired.
-	evaluateHeight()
-
-	// If we reach this point, then we can't fully act yet, so we'll await
-	// either of our signals triggering: the HTLC expires, or we learn of
-	// the preimage.
-	blockEpochs, err := h.Notifier.RegisterBlockEpochNtfn(nil)
-	if err != nil {
-		return nil, err
-	}
-	defer blockEpochs.Cancel()
-
-loop:
-	for {
-		select {
-
-		// A new block has arrived, we'll check to see if this leads to
-		// HTLC expiration.
-		case newBlock, ok := <-blockEpochs.Epochs:
-			if !ok {
-				return nil, fmt.Errorf("quitting")
-			}
-
-			// If this new height expires the HTLC, then we can
-			// exit early and create a resolver that's capable of
-			// handling the time locked output.
-			currentHeight = newBlock.Height
-			evaluateHeight()
-
-		// The output has been spent! This means the preimage has been
-		// revealed on-chain.
-		case commitSpend, ok := <-spendNtfn.Spend:
-			if !ok {
-				return nil, fmt.Errorf("quitting")
-			}
-
-			// The only way this output can be spent by the remote
-			// party is by revealing the preimage. So we'll perform
-			// our duties to clean up the contract once it has been
-			// claimed.
-			var isRemoteSpend bool
-			if h.htlcResolution.SignedTimeoutTx != nil {
-				timeoutTxHash := h.htlcResolution.SignedTimeoutTx.TxHash()
-
-				// If spend not by our own timeout tx, it must
-				// be a remote spend.
-				isRemoteSpend = !bytes.Equal(commitSpend.SpenderTxHash[:],
-					timeoutTxHash[:])
-			} else {
-				// Detect remote success tx by witness length.
-				isRemoteSpend = len(commitSpend.SpendingTx.TxIn[0].Witness) == 5
-			}
-
-			if isRemoteSpend {
-				return claimCleanUp(commitSpend)
-			}
-
-			// At this point, the second-level transaction is sufficiently
-			// confirmed, or a transaction directly spending the output is.
-			// Therefore, we can now send back our clean up message.
-			failureMsg := &lnwire.FailPermanentChannelFailure{}
-			if err := h.DeliverResolutionMsg(ResolutionMsg{
-				SourceChan: h.ShortChanID,
-				HtlcIndex:  h.htlcIndex,
-				Failure:    failureMsg,
-			}); err != nil {
-				return nil, err
-			}
-
-			if state == secondLevelConf {
-				state = csvWait
-				secondLevelExpiry = currentHeight +
-					int32(h.htlcResolution.CsvDelay)
-
-				evaluateHeight()
-			} else {
-				break loop
-			}
-
-		case _, ok := <-secondLevelSpendChan:
-			if !ok {
-				return nil, fmt.Errorf("quitting")
-			}
-			break loop
-
-		case <-h.Quit:
-			return nil, fmt.Errorf("resolver cancelled")
-		}
-
-	}
-	h.resolved = true
-	return nil, h.Checkpoint(h)
-}
-
-// Stop signals the resolver to cancel any current resolution processes, and
-// suspend.
-//
-// NOTE: Part of the ContractResolver interface.
-func (h *htlcOutgoingContestResolver) Stop() {
-	close(h.Quit)
-}
-
-// IsResolved returns true if the stored state in the resolve is fully
-// resolved. In this case the target output can be forgotten.
-//
-// NOTE: Part of the ContractResolver interface.
-func (h *htlcOutgoingContestResolver) IsResolved() bool {
-	return h.resolved
-}
-
-// Encode writes an encoded version of the ContractResolver into the passed
-// Writer.
-//
-// NOTE: Part of the ContractResolver interface.
-func (h *htlcOutgoingContestResolver) Encode(w io.Writer) error {
-	return h.htlcTimeoutResolver.Encode(w)
-}
-
-// Decode attempts to decode an encoded ContractResolver from the passed Reader
-// instance, returning an active ContractResolver instance.
-//
-// NOTE: Part of the ContractResolver interface.
-func (h *htlcOutgoingContestResolver) Decode(r io.Reader) error {
-	return h.htlcTimeoutResolver.Decode(r)
-}
-
-// AttachResolverKit should be called once a resolved is successfully decoded
-// from its stored format. This struct delivers a generic tool kit that
-// resolvers need to complete their duty.
-//
-// NOTE: Part of the ContractResolver interface.
-func (h *htlcOutgoingContestResolver) AttachResolverKit(r ResolverKit) {
-	h.ResolverKit = r
-}
-
-// A compile time assertion to ensure htlcOutgoingContestResolver meets the
-// ContractResolver interface.
-var _ ContractResolver = (*htlcOutgoingContestResolver)(nil)
 
 // htlcIncomingContestResolver is a ContractResolver that's able to resolve an
 // incoming HTLC that is still contested. An HTLC is still contested, if at the

--- a/contractcourt/sweeper.go
+++ b/contractcourt/sweeper.go
@@ -1,0 +1,86 @@
+package contractcourt
+
+import (
+	"github.com/btcsuite/btcd/wire"
+	"github.com/lightningnetwork/lnd/chainntnfs"
+)
+
+// Sweeper is responsible for sweeping outputs back into the wallet
+type Sweeper struct {
+	Notifier chainntnfs.ChainNotifier
+	quit     chan struct{}
+}
+
+// Start starts the process of constructing and publish sweep txes.
+func (s *Sweeper) Start() error {
+	s.quit = make(chan struct{})
+
+	newBlockChan, err := s.Notifier.RegisterBlockEpochNtfn(nil)
+	if err != nil {
+		return err
+	}
+
+	go s.collector(newBlockChan)
+
+	return nil
+}
+
+func (s *Sweeper) collector(newBlockChan *chainntnfs.BlockEpochEvent) {
+	defer newBlockChan.Cancel()
+
+	for {
+		select {
+		case _, ok := <-newBlockChan.Epochs:
+			// If the epoch channel has been closed, then the
+			// ChainNotifier is exiting which means the daemon is
+			// as well. Therefore, we exit early also in order to
+			// ensure the daemon shuts down gracefully, yet
+			// swiftly.
+			if !ok {
+				return
+			}
+
+			// Fetch all input channel from priority queue that have
+			// min target height <= epoch + 1
+
+			// Read outpoints from input channels. If channel is
+			// closed, ignore. This means the sweep for that output
+			// has been cancelled.
+
+			// Construct sweep tx with the outputs.
+
+			// Publish sweep tx.
+
+			// Process publish error (double spend) -> ?
+
+			// Remove from priority queue
+
+			// Log in database outputs that are currently part of an
+			// unconfirmed sweep tx. This is to prevent republishing
+			// in a new sweep tx after restart.
+
+		case <-s.quit:
+			return
+		}
+	}
+
+}
+
+// AnnounceSweep schedules a sweep for a specific minimum target height. The
+// return value is a channel that is expected to provide the outpoint to sweep
+// by the time the block height is high enough. The reason to use a blocking
+// channel is that we want to make sure we collected all inputs before
+// constructing the sweep tx. Otherwise, if block events would reach sweeper and
+// the providers of sweep inputs (like resolvers) in the wrong order, inputs
+// would be unnecessarily delayed until the next block.
+//
+// TODO: Maybe we can already pass in the outpoint at this moment?
+func (s *Sweeper) AnnounceSweep(minTargetHeight int32) chan wire.OutPoint {
+	inputChan := make(chan wire.OutPoint)
+
+	// Insert channel into priority queue keyed with minTargetHeight
+
+	// TODO: publish sweep immediately sometimes?
+
+	return inputChan
+}

--- a/contractcourt/sweeper.go
+++ b/contractcourt/sweeper.go
@@ -25,6 +25,25 @@ func (s *Sweeper) Start() error {
 	return nil
 }
 
+// SweepInput is what is pushed to the sweeper to describe the input to sweep.
+type SweepInput struct {
+	OutPoint   wire.OutPoint
+	ResultChan chan struct{}
+}
+
+// SweeperCall is push in the channel to collect sweep inputs.
+type SweeperCall struct {
+	InputChan    chan SweepInput
+	TargetHeight int32
+}
+
+// RegisterForCalls returns a channel on which the caller can listen for sweeper
+// events.
+func (s *Sweeper) RegisterForCalls() chan SweeperCall {
+
+	return make(chan SweeperCall)
+}
+
 func (s *Sweeper) collector(newBlockChan *chainntnfs.BlockEpochEvent) {
 	defer newBlockChan.Cancel()
 

--- a/nursery_store.go
+++ b/nursery_store.go
@@ -1457,6 +1457,7 @@ func (ns *nurseryStore) getLastGraduatedHeight(tx *bolt.Tx) (uint32, error) {
 // the last graduated height key.
 func (ns *nurseryStore) putLastGraduatedHeight(tx *bolt.Tx, height uint32) error {
 
+	utxnLog.Infof("Log last graduated height at %v", height)
 	// Ensure that the chain bucket for this nursery store exists.
 	chainBucket, err := tx.CreateBucketIfNotExists(ns.pfxChainKey)
 	if err != nil {

--- a/utxonursery.go
+++ b/utxonursery.go
@@ -548,11 +548,18 @@ func (u *utxoNursery) NurseryReport(
 				case lnwallet.CommitmentTimeLock:
 					report.AddLimboCommitment(&kid)
 
-				// An HTLC output on our commitment transaction
-				// where the second-layer transaction hasn't
-				// yet confirmed.
 				case lnwallet.HtlcAcceptedSuccessSecondLevel:
+					// An HTLC output on our commitment transaction
+					// where the second-layer transaction hasn't
+					// yet confirmed.
 					report.AddLimboStage1SuccessHtlc(&kid)
+
+				case lnwallet.HtlcOfferedRemoteTimeout:
+					// This is an HTLC output on the
+					// commitment transaction of the remote
+					// party. We are waiting for the CLTV
+					// timelock expire.
+					report.AddLimboDirectHtlc(&kid)
 				}
 
 			case bytes.HasPrefix(k, kndrPrefix):
@@ -1510,7 +1517,7 @@ func (c *contractMaturityReport) AddLimboStage1TimeoutHtlc(baby *babyOutput) {
 
 // AddLimboDirectHtlc adds a direct HTLC on the commitment transaction of the
 // remote party to the maturity report. This a CLTV time-locked output that
-// hasn't yet expired.
+// has or hasn't expired yet.
 func (c *contractMaturityReport) AddLimboDirectHtlc(kid *kidOutput) {
 	c.limboBalance += kid.Amount()
 

--- a/utxonursery_test.go
+++ b/utxonursery_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"github.com/lightningnetwork/lnd/channeldb"
 	"io/ioutil"
+	"math"
 	"os"
 	"reflect"
 	"testing"
@@ -531,6 +532,25 @@ func (ctx *nurseryTestContext) finish() {
 	case <-ctx.publishChan:
 		ctx.t.Fatalf("unexpected transactions published")
 	default:
+	}
+
+	// Assert that the database is empty. All channels removed and height
+	// index cleared.
+	nurseryChannels, err := ctx.nursery.cfg.Store.ListChannels()
+	if err != nil {
+		ctx.t.Fatal(err)
+	}
+	if len(nurseryChannels) > 0 {
+		ctx.t.Fatalf("Expected all channels to be removed from store")
+	}
+
+	activeHeights, err := ctx.nursery.cfg.Store.HeightsBelowOrEqual(
+		math.MaxUint32)
+	if err != nil {
+		ctx.t.Fatal(err)
+	}
+	if len(activeHeights) > 0 {
+		ctx.t.Fatalf("Expected height index to be empty")
 	}
 }
 

--- a/utxonursery_test.go
+++ b/utxonursery_test.go
@@ -501,6 +501,28 @@ func (ctx *nurseryTestContext) finish() {
 	// Add a final restart point in this state
 	ctx.restart()
 
+	// We assume that when finish is called, nursery has finished all its
+	// goroutines. This implies that the waitgroup is empty.
+	signalChan := make(chan struct{})
+	go func() {
+		ctx.nursery.wg.Wait()
+		close(signalChan)
+	}()
+
+	// The only goroutine that is still expected to be running is
+	// incubator(). Simulate exit of this goroutine.
+	ctx.nursery.wg.Done()
+
+	// We now expect the Wait to succeed.
+	select {
+	case <-signalChan:
+	case <-time.After(time.Second):
+		ctx.t.Fatalf("lingering goroutines detected after test is finished")
+	}
+
+	// Restore waitgroup state to what it was before.
+	ctx.nursery.wg.Add(1)
+
 	ctx.nursery.Stop()
 
 	// We should have consumed and asserted all published transactions in

--- a/utxonursery_test.go
+++ b/utxonursery_test.go
@@ -574,12 +574,7 @@ func incubateTestOutput(t *testing.T, nursery *utxoNursery,
 	if onLocalCommitment {
 		expectedStage = 1
 	}
-
-	// TODO(joostjager): Nursery is currently not reporting this limbo
-	// balance.
-	if onLocalCommitment {
-		assertNurseryReport(t, nursery, 1, expectedStage)
-	}
+	assertNurseryReport(t, nursery, 1, expectedStage)
 
 	return outgoingRes
 }

--- a/utxonursery_test.go
+++ b/utxonursery_test.go
@@ -600,11 +600,9 @@ func incubateTestOutput(t *testing.T, nursery *utxoNursery,
 	outgoingRes := createOutgoingRes(onLocalCommitment)
 
 	// Hand off to nursery.
-	err := nursery.IncubateOutputs(
+	err := nursery.IncubateOutgoingHtlcOutput(
 		testChanPoint,
-		nil,
-		[]lnwallet.OutgoingHtlcResolution{*outgoingRes},
-		nil,
+		*outgoingRes,
 	)
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
This PR builds on top of the sweeper PR #1960. It refactors the resolvers to use the sweeper directly instead of handing off outputs to nursery. This gets rid of code duplication between resolvers and nursery, as both contained code to wait for CSV/CLTV timeouts.

Current state of the PR is that it:
- contains code that is already partially merged
- contains nursery refactoring that has become obsolete after this PR (remote spend handling)
- just shows the idea of how the resolvers can be refactored
- is unfinished

