### PR TITLE
Server: make maximum backoff configurable

### DIFF
--- a/config.go
+++ b/config.go
@@ -53,6 +53,7 @@ const (
 	defaultInactiveChanTimeout = 20 * time.Minute
 	defaultMaxLogFiles         = 3
 	defaultMaxLogFileSize      = 10
+	defaultMaxBackoff          = time.Hour
 
 	defaultTorSOCKSPort            = 9050
 	defaultTorDNSHost              = "soa.nodes.lightning.directory"
@@ -194,8 +195,9 @@ type config struct {
 	RESTListeners    []net.Addr
 	Listeners        []net.Addr
 	ExternalIPs      []net.Addr
-	DisableListen    bool `long:"nolisten" description:"Disable listening for incoming peer connections"`
-	NAT              bool `long:"nat" description:"Toggle NAT traversal support (using either UPnP or NAT-PMP) to automatically advertise your external IP address to the network -- NOTE this does not support devices behind multiple NATs"`
+	DisableListen    bool          `long:"nolisten" description:"Disable listening for incoming peer connections"`
+	NAT              bool          `long:"nat" description:"Toggle NAT traversal support (using either UPnP or NAT-PMP) to automatically advertise your external IP address to the network -- NOTE this does not support devices behind multiple NATs"`
+	MaxBackoff       time.Duration `long:"maxbackoff" description:"Longest backoff when reconnecting to persistent peers. Valid time units are {s, m, h}."`
 
 	DebugLevel string `short:"d" long:"debuglevel" description:"Logging level for all subsystems {trace, debug, info, warn, error, critical} -- You may also specify <subsystem>=<level>,<subsystem2>=<level>,... to set the log level for individual subsystems -- Use show to list available subsystems"`
 
@@ -298,6 +300,7 @@ func loadConfig() (*config, error) {
 		},
 		MaxPendingChannels: defaultMaxPendingChannels,
 		NoSeedBackup:       defaultNoSeedBackup,
+		MaxBackoff:         defaultMaxBackoff,
 		SubRPCServers: &subRPCServerConfigs{
 			SignRPC: &signrpc.Config{},
 		},

--- a/server.go
+++ b/server.go
@@ -52,10 +52,6 @@ const (
 	// reconnecting to persistent peers.
 	defaultBackoff = time.Second
 
-	// maximumBackoff is the largest backoff we will permit when
-	// reattempting connections to persistent peers.
-	maximumBackoff = time.Hour
-
 	// defaultStableConnDuration is a floor under which all reconnection
 	// attempts will apply exponential randomized backoff. Connections
 	// durations exceeding this value will be eligible to have their
@@ -2853,8 +2849,8 @@ func parseHexColor(colorStr string) (color.RGBA, error) {
 func computeNextBackoff(currBackoff time.Duration) time.Duration {
 	// Double the current backoff, truncating if it exceeds our maximum.
 	nextBackoff := 2 * currBackoff
-	if nextBackoff > maximumBackoff {
-		nextBackoff = maximumBackoff
+	if nextBackoff > cfg.MaxBackoff {
+		nextBackoff = cfg.MaxBackoff
 	}
 
 	// Using 1/10 of our duration as a margin, compute a random offset to


### PR DESCRIPTION
In case of spotty wifi coverage a mobile device will rapidly switch from wifi to 4G and vice versa. In these cases the persistent peer will disconnect and the backoff period will increase exponentially. After a couple reconnects we are talking about minutes which makes for bad user experience.