### PR TITLE
Re-create forwardings after externalIP change

### DIFF
--- a/nat/pmp.go
+++ b/nat/pmp.go
@@ -65,10 +65,6 @@ func (p *PMP) AddPortMapping(port uint16) error {
 	p.forwardedPortsMtx.Lock()
 	defer p.forwardedPortsMtx.Unlock()
 
-	if _, exists := p.forwardedPorts[port]; exists {
-		return nil
-	}
-
 	_, err := p.client.AddPortMapping("tcp", int(port), int(port), 0)
 	if err != nil {
 		return err

--- a/nat/upnp.go
+++ b/nat/upnp.go
@@ -62,10 +62,6 @@ func (u *UPnP) AddPortMapping(port uint16) error {
 	u.forwardedPortsMtx.Lock()
 	defer u.forwardedPortsMtx.Unlock()
 
-	if _, exists := u.forwardedPorts[port]; exists {
-		return nil
-	}
-
 	if err := u.device.Forward(port, ""); err != nil {
 		return err
 	}

--- a/server.go
+++ b/server.go
@@ -1145,6 +1145,21 @@ out:
 				continue
 			}
 
+			// Periodically renew the NAT port forwarding.
+			for _, port := range forwardedPorts {
+				err := s.natTraversal.AddPortMapping(port)
+				if err != nil {
+					srvrLog.Warnf("Unable to automatically "+
+						"re-create port forwarding using %s: %v",
+						s.natTraversal.Name(), err)
+				} else {
+					srvrLog.Debugf("Automatically re-created "+
+						"forwarding for port %d using %s to "+
+						"advertise external IP",
+						port, s.natTraversal.Name())
+				}
+			}
+
 			if ip.Equal(s.lastDetectedIP) {
 				continue
 			}


### PR DESCRIPTION
I noticed that the `nat=true` feature works really well to detect when the external IP address of a NAT device has changed (in my case using UPnP). But this requires that `lnd` also takes over the creation of the port forwarding (e.g. `9735`). In my case after every IP change the port forwardings were gone. I assume my NAT device removes them when the line is disconnected and re-established. 

In `lnd` I found no code that would re-create the port forwardings in this case. Port forwardings are only setup in `newServer` at server start (`configurePortForwarding` in line 405).

This PR make sure that the forwardings are re-created after a change in the external IP is detected. 