### PR TITLE
Mark channels borked in case of remote error

### DIFF
--- a/htlcswitch/link.go
+++ b/htlcswitch/link.go
@@ -1900,9 +1900,14 @@ func (l *channelLink) handleUpstreamMsg(msg lnwire.Message) {
 		// Error received from remote, MUST fail channel, but should
 		// only print the contents of the error message if all
 		// characters are printable ASCII.
-		l.fail(LinkFailureError{code: ErrRemoteError},
+		l.fail(
+			LinkFailureError{
+				code:             ErrRemoteError,
+				PermanentFailure: true,
+			},
 			"ChannelPoint(%v): received error from peer: %v",
-			l.channel.ChannelPoint(), msg.Error())
+			l.channel.ChannelPoint(), msg.Error(),
+		)
 	default:
 		l.log.Warnf("received unknown message of type %T", msg)
 	}

--- a/htlcswitch/linkfailure.go
+++ b/htlcswitch/linkfailure.go
@@ -57,6 +57,10 @@ type LinkFailureError struct {
 	// because of this error.
 	ForceClose bool
 
+	// PermanentFailure indicates whether this failure is permanent, and
+	// the channel should not be attempted loaded again.
+	PermanentFailure bool
+
 	// SendData is a byte slice that will be sent to the peer. If nil a
 	// generic error will be sent.
 	SendData []byte


### PR DESCRIPTION
According to BOLT#1, a when receiving an error from the remote, we MUST fail the targeted channel: https://github.com/lightningnetwork/lightning-rfc/blob/master/01-messaging.md#the-error-message

This PR implements this behavior by marking the channel `Borked` in cases like this. We don't automatically force close, to avoid the remote tricking us into force closing.