### PR TITLE
Improve 'updating' instructions

### DIFF
--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -93,7 +93,7 @@ commands:
 ```
 cd $GOPATH/src/github.com/lightningnetwork/lnd
 git pull
-make && make install
+make clean && make && make install
 ```
 
 On FreeBSD, use gmake instead of make.


### PR DESCRIPTION
Every time I try to update lnd by following these instructions it fails. Most recently like this:

    $ make
     Compiling dependencies.
    dep ensure -v
    # Bringing vendor into sync
    grouped write of manifest, lock and vendor: failed to export github.com/lightninglabs/neutrino: fatal: failed to unpack tree object 838f7ba74d217d188efc223604bd280b4e3f0238
    : exit status 128
    Makefile:116: recipe for target 'dep' failed
    make: *** [dep] Error 1

I found that if I `make clean` before running `make` then it doesn't fail.