### PR TITLE
[trivial] routing/chainview: demote logging of new utxos for filter to Trace

### DIFF
--- a/routing/chainview/bitcoind.go
+++ b/routing/chainview/bitcoind.go
@@ -302,7 +302,7 @@ func (b *BitcoindFilteredChainView) chainFilterer() {
 			// First, we'll add all the new UTXO's to the set of
 			// watched UTXO's, eliminating any duplicates in the
 			// process.
-			log.Debugf("Updating chain filter with new UTXO's: %v",
+			log.Tracef("Updating chain filter with new UTXO's: %v",
 				update.newUtxos)
 
 			b.filterMtx.Lock()

--- a/routing/chainview/btcd.go
+++ b/routing/chainview/btcd.go
@@ -322,7 +322,7 @@ func (b *BtcdFilteredChainView) chainFilterer() {
 			// First, we'll add all the new UTXO's to the set of
 			// watched UTXO's, eliminating any duplicates in the
 			// process.
-			log.Debugf("Updating chain filter with new UTXO's: %v",
+			log.Tracef("Updating chain filter with new UTXO's: %v",
 				update.newUtxos)
 
 			b.filterMtx.Lock()

--- a/routing/chainview/neutrino.go
+++ b/routing/chainview/neutrino.go
@@ -318,7 +318,7 @@ func (c *CfFilteredChainView) FilterBlock(blockHash *chainhash.Hash) (*FilteredB
 func (c *CfFilteredChainView) UpdateFilter(ops []channeldb.EdgePoint,
 	updateHeight uint32) error {
 
-	log.Debugf("Updating chain filter with new UTXO's: %v", ops)
+	log.Tracef("Updating chain filter with new UTXO's: %v", ops)
 
 	// First, we'll update the current chain view, by adding any new
 	// UTXO's, ignoring duplicates in the process.


### PR DESCRIPTION
It was previously Debug, which would spam the logs at startup, and not
provide very useful (human-readable) information.