### PR TITLE
Validate own node announcement, signature length

### DIFF
--- a/channeldb/graph.go
+++ b/channeldb/graph.go
@@ -2839,6 +2839,12 @@ func putLightningNode(nodeBucket *bbolt.Bucket, aliasBucket *bbolt.Bucket,
 		}
 	}
 
+	sigLen := len(node.AuthSigBytes)
+	if sigLen > 80 {
+		return fmt.Errorf("max sig len allowed is 80, had %v",
+			sigLen)
+	}
+
 	err = wire.WriteVarBytes(&b, 0, node.AuthSigBytes)
 	if err != nil {
 		return err

--- a/discovery/gossiper.go
+++ b/discovery/gossiper.go
@@ -1577,22 +1577,20 @@ func (d *AuthenticatedGossiper) processNetworkAnnouncement(
 	case *lnwire.NodeAnnouncement:
 		timestamp := time.Unix(int64(msg.Timestamp), 0)
 
-		if nMsg.isRemote {
-			// We'll quickly ask the router if it already has a
-			// newer update for this node so we can skip validating
-			// signatures if not required.
-			if d.cfg.Router.IsStaleNode(msg.NodeID, timestamp) {
-				nMsg.err <- nil
-				return nil
-			}
+		// We'll quickly ask the router if it already has a
+		// newer update for this node so we can skip validating
+		// signatures if not required.
+		if d.cfg.Router.IsStaleNode(msg.NodeID, timestamp) {
+			nMsg.err <- nil
+			return nil
+		}
 
-			if err := routing.ValidateNodeAnn(msg); err != nil {
-				err := fmt.Errorf("unable to validate "+
-					"node announcement: %v", err)
-				log.Error(err)
-				nMsg.err <- err
-				return nil
-			}
+		if err := routing.ValidateNodeAnn(msg); err != nil {
+			err := fmt.Errorf("unable to validate "+
+				"node announcement: %v", err)
+			log.Error(err)
+			nMsg.err <- err
+			return nil
 		}
 
 		features := lnwire.NewFeatureVector(


### PR DESCRIPTION
To avoid inserting invalid signatures into the DB.

Maybe maybe fixes #2016