### PR TITLE
chainntnfs: re-enable height hint cache

### DIFF
--- a/chainntnfs/bitcoindnotify/bitcoind_test.go
+++ b/chainntnfs/bitcoindnotify/bitcoind_test.go
@@ -25,7 +25,7 @@ func initHintCache(t *testing.T) *chainntnfs.HeightHintCache {
 	if err != nil {
 		t.Fatalf("unable to create db: %v", err)
 	}
-	hintCache, err := chainntnfs.NewHeightHintCache(db, true)
+	hintCache, err := chainntnfs.NewHeightHintCache(db)
 	if err != nil {
 		t.Fatalf("unable to create hint cache: %v", err)
 	}

--- a/chainntnfs/btcdnotify/btcd_test.go
+++ b/chainntnfs/btcdnotify/btcd_test.go
@@ -23,7 +23,7 @@ func initHintCache(t *testing.T) *chainntnfs.HeightHintCache {
 	if err != nil {
 		t.Fatalf("unable to create db: %v", err)
 	}
-	hintCache, err := chainntnfs.NewHeightHintCache(db, true)
+	hintCache, err := chainntnfs.NewHeightHintCache(db)
 	if err != nil {
 		t.Fatalf("unable to create hint cache: %v", err)
 	}

--- a/chainntnfs/interface_test.go
+++ b/chainntnfs/interface_test.go
@@ -1758,7 +1758,7 @@ func TestInterfaces(t *testing.T) {
 		if err != nil {
 			t.Fatalf("unable to create db: %v", err)
 		}
-		hintCache, err := chainntnfs.NewHeightHintCache(db, true)
+		hintCache, err := chainntnfs.NewHeightHintCache(db)
 		if err != nil {
 			t.Fatalf("unable to create height hint cache: %v", err)
 		}

--- a/chainregistry.go
+++ b/chainregistry.go
@@ -181,8 +181,8 @@ func newChainControlFromConfig(cfg *config, chanDB *channeldb.DB,
 		cleanUp func()
 	)
 
-	// Initialize disabled height hint cache within the chain directory.
-	hintCache, err := chainntnfs.NewHeightHintCache(chanDB, true)
+	// Initialize the height hint cache within the chain directory.
+	hintCache, err := chainntnfs.NewHeightHintCache(chanDB)
 	if err != nil {
 		return nil, nil, fmt.Errorf("unable to initialize height hint "+
 			"cache: %v", err)

--- a/lnwallet/interface_test.go
+++ b/lnwallet/interface_test.go
@@ -2153,7 +2153,7 @@ func TestLightningWallet(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unable to create db: %v", err)
 	}
-	hintCache, err := chainntnfs.NewHeightHintCache(db, true)
+	hintCache, err := chainntnfs.NewHeightHintCache(db)
 	if err != nil {
 		t.Fatalf("unable to create height hint cache: %v", err)
 	}


### PR DESCRIPTION
In this PR, we attempt to re-enable the height hint cache for the different `ChainNotifier` implementations. This will lead to performance improvements upon startup when running a full node backend without `txindex` or when running as a light client, like Neutrino.

~~Depends on #1787 and #2004.~~