### PR TITLE
htlcswitch: settle invoices behind switch [WIP]

### DIFF
--- a/htlcswitch/invoice_settler.go
+++ b/htlcswitch/invoice_settler.go
@@ -1,0 +1,243 @@
+package htlcswitch
+
+import (
+	"github.com/lightningnetwork/lnd/contractcourt"
+)
+
+// InvoiceSettler handles settling and failing of invoices.
+type InvoiceSettler struct {
+	// Registry is a sub-system which responsible for managing the invoices
+	// in thread-safe manner.
+	Registry InvoiceDatabase
+
+	// ResolutionMsgs is the channel that the switch is listening to for
+	// invoice resolutions. InvoiceSettler isn't calling switch directly
+	// because this would create a circular dependency.
+	ResolutionMsgs chan resolutionMsg
+}
+
+// NewInvoiceSettler returns a new invoice settler instance.
+func NewInvoiceSettler(Registry InvoiceDatabase) *InvoiceSettler {
+	return &InvoiceSettler{
+		Registry:       Registry,
+		ResolutionMsgs: make(chan resolutionMsg),
+	}
+}
+
+// Settle settles the (hold) invoice corresponding to the given preimage.
+// TO BE IMPLEMENTED.
+func (i *InvoiceSettler) Settle(preimage [32]byte) error {
+
+	return nil
+}
+
+// Fail fails the (hold) invoice corresponding to the given hash.
+// TO BE IMPLEMENTED.
+func (i *InvoiceSettler) Fail(hash []byte) error {
+	return nil
+}
+
+// handleIncoming is called from switch when a htlc comes in for which we are
+// the exit hop.
+func (i *InvoiceSettler) handleIncoming(pkt *htlcPacket) error {
+	// We're the designated payment destination.  Therefore
+	// we attempt to see if we have an invoice locally
+	// which'll allow us to settle this htlc.
+	invoiceHash := pkt.circuit.PaymentHash
+	invoice, _, err := i.Registry.LookupInvoice(
+		invoiceHash,
+	)
+
+	// TODO: Return errors below synchronously or use async flow for
+	// all cases?
+
+	/*if err != nil {
+		log.Errorf("unable to query invoice registry: "+
+			" %v", err)
+		failure := lnwire.FailUnknownPaymentHash{}
+
+		i.ResolutionMsgs <- contractcourt.ResolutionMsg{
+			SourceChan: exitHop,
+			Failure:    failure,
+		}
+		l.sendHTLCError(
+			pd.HtlcIndex, failure, obfuscator, pd.SourceRef,
+		)
+
+		needUpdate = true
+		return
+	}*/
+
+	// If the invoice is already settled, we choose to
+	// accept the payment to simplify failure recovery.
+	//
+	// NOTE: Though our recovery and forwarding logic is
+	// predominately batched, settling invoices happens
+	// iteratively. We may reject one of two payments
+	// for the same rhash at first, but then restart and
+	// reject both after seeing that the invoice has been
+	// settled. Without any record of which one settles
+	// first, it is ambiguous as to which one actually
+	// settled the invoice. Thus, by accepting all
+	// payments, we eliminate the race condition that can
+	// lead to this inconsistency.
+	//
+	// TODO(conner): track ownership of settlements to
+	// properly recover from failures? or add batch invoice
+	// settlement
+
+	/*if invoice.Terms.Settled {
+		log.Warnf("Accepting duplicate payment for "+
+			"hash=%x", invoiceHash)
+	}*/
+
+	// If we're not currently in debug mode, and the
+	// extended htlc doesn't meet the value requested, then
+	// we'll fail the htlc.  Otherwise, we settle this htlc
+	// within our local state update log, then send the
+	// update entry to the remote party.
+	//
+	// NOTE: We make an exception when the value requested
+	// by the invoice is zero. This means the invoice
+	// allows the payee to specify the amount of satoshis
+	// they wish to send.  So since we expect the htlc to
+	// have a different amount, we should not fail.
+	/*if !l.cfg.DebugHTLC && invoice.Terms.Value > 0 &&
+		pd.Amount < invoice.Terms.Value {
+
+		log.Errorf("rejecting htlc due to incorrect "+
+			"amount: expected %v, received %v",
+			invoice.Terms.Value, pd.Amount)
+
+		failure := lnwire.FailIncorrectPaymentAmount{}
+		l.sendHTLCError(
+			pd.HtlcIndex, failure, obfuscator, pd.SourceRef,
+		)
+
+		needUpdate = true
+		return
+	}*/
+
+	// As we're the exit hop, we'll double check the
+	// hop-payload included in the HTLC to ensure that it
+	// was crafted correctly by the sender and matches the
+	// HTLC we were extended.
+	//
+	// NOTE: We make an exception when the value requested
+	// by the invoice is zero. This means the invoice
+	// allows the payee to specify the amount of satoshis
+	// they wish to send.  So since we expect the htlc to
+	// have a different amount, we should not fail.
+	/*if !l.cfg.DebugHTLC && invoice.Terms.Value > 0 &&
+		fwdInfo.AmountToForward < invoice.Terms.Value {
+
+		log.Errorf("Onion payload of incoming htlc(%x) "+
+			"has incorrect value: expected %v, "+
+			"got %v", pd.RHash, invoice.Terms.Value,
+			fwdInfo.AmountToForward)
+
+		failure := lnwire.FailIncorrectPaymentAmount{}
+		l.sendHTLCError(
+			pd.HtlcIndex, failure, obfuscator, pd.SourceRef,
+		)
+
+		needUpdate = true
+		return
+	}*/
+
+	// We'll also ensure that our time-lock value has been
+	// computed correctly.
+
+	/*expectedHeight := heightNow + minCltvDelta
+	switch {
+
+	case !l.cfg.DebugHTLC && fwdInfo.OutgoingCTLV < expectedHeight:
+		log.Errorf("Onion payload of incoming "+
+			"htlc(%x) has incorrect time-lock: "+
+			"expected %v, got %v",
+			pd.RHash[:], expectedHeight,
+			fwdInfo.OutgoingCTLV)
+
+		failure := lnwire.NewFinalIncorrectCltvExpiry(
+			fwdInfo.OutgoingCTLV,
+		)
+		l.sendHTLCError(
+			pd.HtlcIndex, failure, obfuscator, pd.SourceRef,
+		)
+
+		needUpdate = true
+		return
+
+	case !l.cfg.DebugHTLC && pd.Timeout != fwdInfo.OutgoingCTLV:
+		log.Errorf("HTLC(%x) has incorrect "+
+			"time-lock: expected %v, got %v",
+			pd.RHash[:], pd.Timeout,
+			fwdInfo.OutgoingCTLV)
+
+		failure := lnwire.NewFinalIncorrectCltvExpiry(
+			fwdInfo.OutgoingCTLV,
+		)
+		l.sendHTLCError(
+			pd.HtlcIndex, failure, obfuscator, pd.SourceRef,
+		)
+
+		needUpdate = true
+		return
+	}
+	*/
+	preimage := invoice.Terms.PaymentPreimage
+
+	// TODO: Mark the invoice as accepted here
+
+	// Execute sending resolution message in a go routine to prevent
+	// deadlock. Eventually InvoiceSettler may need its own main loop to
+	// receive events from the switch and rpcserver.
+	//
+	// Resolution is only possible when the preimage is known. Otherwise do
+	// nothing yet and wait for InvoiceSettler.Settle to be called with the
+	// preimage.
+	go func() {
+		done := make(chan struct{})
+
+		// TODO: This does not work, because the switch cannot look up
+		// the incoming channel. Outgoing HtlcIndex hasn't been
+		// committed to the circuit map.
+		i.ResolutionMsgs <- resolutionMsg{
+			ResolutionMsg: contractcourt.ResolutionMsg{
+				SourceChan: exitHop,
+				HtlcIndex:  invoice.AddIndex,
+				PreImage:   &preimage,
+			},
+			doneChan: done,
+		}
+
+		<-done
+
+		// Notify the invoiceRegistry of the invoices we just
+		// settled (with the amount accepted at settle time)
+		// with this latest commitment update.
+		err = i.Registry.SettleInvoice(
+			invoiceHash, pkt.incomingAmount,
+		)
+		if err != nil {
+			log.Errorf("unable to settle invoice: %v", err)
+		}
+
+		log.Infof("settling %x as exit hop", invoiceHash)
+
+		// If the link is in hodl.BogusSettle mode, replace the
+		// preimage with a fake one before sending it to the
+		// peer.
+		//
+		// TODO: This isn't the place anymore?
+
+		/*if l.cfg.DebugHTLC &&
+			l.cfg.HodlMask.Active(hodl.BogusSettle) {
+			l.warnf(hodl.BogusSettle.Warning())
+			preimage = [32]byte{}
+			copy(preimage[:], bytes.Repeat([]byte{2}, 32))
+		}*/
+	}()
+
+	return nil
+}

--- a/htlcswitch/link_test.go
+++ b/htlcswitch/link_test.go
@@ -1535,7 +1535,7 @@ func newSingleLinkTestHarness(chanAmt, chanReserve btcutil.Amount) (
 	}
 
 	aliceDb := aliceChannel.State().Db
-	aliceSwitch, err := initSwitchWithDB(testStartingHeight, aliceDb)
+	aliceSwitch, err := initSwitchWithDB(testStartingHeight, aliceDb, invoiceRegistry)
 	if err != nil {
 		return nil, nil, nil, nil, nil, nil, err
 	}
@@ -4044,7 +4044,8 @@ func restartLink(aliceChannel *lnwallet.LightningChannel, aliceSwitch *Switch,
 
 	if aliceSwitch == nil {
 		var err error
-		aliceSwitch, err = initSwitchWithDB(testStartingHeight, aliceDb)
+		aliceSwitch, err = initSwitchWithDB(testStartingHeight, aliceDb,
+			invoiceRegistry)
 		if err != nil {
 			return nil, nil, nil, err
 		}

--- a/htlcswitch/mock.go
+++ b/htlcswitch/mock.go
@@ -138,7 +138,9 @@ func initDB() (*channeldb.DB, error) {
 	return db, err
 }
 
-func initSwitchWithDB(startingHeight uint32, db *channeldb.DB) (*Switch, error) {
+func initSwitchWithDB(startingHeight uint32, db *channeldb.DB,
+	registry InvoiceDatabase) (*Switch, error) {
+
 	var err error
 
 	if db == nil {
@@ -160,6 +162,7 @@ func initSwitchWithDB(startingHeight uint32, db *channeldb.DB) (*Switch, error) 
 		Notifier:       &mockNotifier{},
 		FwdEventTicker: ticker.MockNew(DefaultFwdEventInterval),
 		LogEventTicker: ticker.MockNew(DefaultLogInterval),
+		InvoiceSettler: NewInvoiceSettler(registry),
 	}
 
 	return New(cfg, startingHeight)
@@ -172,7 +175,9 @@ func newMockServer(t testing.TB, name string, startingHeight uint32,
 	h := sha256.Sum256([]byte(name))
 	copy(id[:], h[:])
 
-	htlcSwitch, err := initSwitchWithDB(startingHeight, db)
+	registry := newMockRegistry(defaultDelta)
+
+	htlcSwitch, err := initSwitchWithDB(startingHeight, db, registry)
 	if err != nil {
 		return nil, err
 	}
@@ -183,7 +188,7 @@ func newMockServer(t testing.TB, name string, startingHeight uint32,
 		name:             name,
 		messages:         make(chan lnwire.Message, 3000),
 		quit:             make(chan struct{}),
-		registry:         newMockRegistry(defaultDelta),
+		registry:         registry,
 		htlcSwitch:       htlcSwitch,
 		interceptorFuncs: make([]messageInterceptor, 0),
 	}, nil

--- a/htlcswitch/switch_test.go
+++ b/htlcswitch/switch_test.go
@@ -36,7 +36,7 @@ func TestSwitchAddDuplicateLink(t *testing.T) {
 		t.Fatalf("unable to create alice server: %v", err)
 	}
 
-	s, err := initSwitchWithDB(testStartingHeight, nil)
+	s, err := initSwitchWithDB(testStartingHeight, nil, nil)
 	if err != nil {
 		t.Fatalf("unable to init switch: %v", err)
 	}
@@ -92,7 +92,7 @@ func TestSwitchSendPending(t *testing.T) {
 		t.Fatalf("unable to create alice server: %v", err)
 	}
 
-	s, err := initSwitchWithDB(testStartingHeight, nil)
+	s, err := initSwitchWithDB(testStartingHeight, nil, alicePeer.registry)
 	if err != nil {
 		t.Fatalf("unable to init switch: %v", err)
 	}
@@ -191,7 +191,7 @@ func TestSwitchForward(t *testing.T) {
 		t.Fatalf("unable to create bob server: %v", err)
 	}
 
-	s, err := initSwitchWithDB(testStartingHeight, nil)
+	s, err := initSwitchWithDB(testStartingHeight, nil, nil)
 	if err != nil {
 		t.Fatalf("unable to init switch: %v", err)
 	}
@@ -306,7 +306,7 @@ func TestSwitchForwardFailAfterFullAdd(t *testing.T) {
 		t.Fatalf("unable to open channeldb: %v", err)
 	}
 
-	s, err := initSwitchWithDB(testStartingHeight, cdb)
+	s, err := initSwitchWithDB(testStartingHeight, cdb, nil)
 	if err != nil {
 		t.Fatalf("unable to init switch: %v", err)
 	}
@@ -401,7 +401,7 @@ func TestSwitchForwardFailAfterFullAdd(t *testing.T) {
 		t.Fatalf("unable to reopen channeldb: %v", err)
 	}
 
-	s2, err := initSwitchWithDB(testStartingHeight, cdb2)
+	s2, err := initSwitchWithDB(testStartingHeight, cdb2, nil)
 	if err != nil {
 		t.Fatalf("unable reinit switch: %v", err)
 	}
@@ -497,7 +497,7 @@ func TestSwitchForwardSettleAfterFullAdd(t *testing.T) {
 		t.Fatalf("unable to open channeldb: %v", err)
 	}
 
-	s, err := initSwitchWithDB(testStartingHeight, cdb)
+	s, err := initSwitchWithDB(testStartingHeight, cdb, nil)
 	if err != nil {
 		t.Fatalf("unable to init switch: %v", err)
 	}
@@ -592,7 +592,7 @@ func TestSwitchForwardSettleAfterFullAdd(t *testing.T) {
 		t.Fatalf("unable to reopen channeldb: %v", err)
 	}
 
-	s2, err := initSwitchWithDB(testStartingHeight, cdb2)
+	s2, err := initSwitchWithDB(testStartingHeight, cdb2, nil)
 	if err != nil {
 		t.Fatalf("unable reinit switch: %v", err)
 	}
@@ -691,7 +691,7 @@ func TestSwitchForwardDropAfterFullAdd(t *testing.T) {
 		t.Fatalf("unable to open channeldb: %v", err)
 	}
 
-	s, err := initSwitchWithDB(testStartingHeight, cdb)
+	s, err := initSwitchWithDB(testStartingHeight, cdb, nil)
 	if err != nil {
 		t.Fatalf("unable to init switch: %v", err)
 	}
@@ -778,7 +778,7 @@ func TestSwitchForwardDropAfterFullAdd(t *testing.T) {
 		t.Fatalf("unable to reopen channeldb: %v", err)
 	}
 
-	s2, err := initSwitchWithDB(testStartingHeight, cdb2)
+	s2, err := initSwitchWithDB(testStartingHeight, cdb2, nil)
 	if err != nil {
 		t.Fatalf("unable reinit switch: %v", err)
 	}
@@ -854,7 +854,7 @@ func TestSwitchForwardFailAfterHalfAdd(t *testing.T) {
 		t.Fatalf("unable to open channeldb: %v", err)
 	}
 
-	s, err := initSwitchWithDB(testStartingHeight, cdb)
+	s, err := initSwitchWithDB(testStartingHeight, cdb, nil)
 	if err != nil {
 		t.Fatalf("unable to init switch: %v", err)
 	}
@@ -936,7 +936,7 @@ func TestSwitchForwardFailAfterHalfAdd(t *testing.T) {
 		t.Fatalf("unable to reopen channeldb: %v", err)
 	}
 
-	s2, err := initSwitchWithDB(testStartingHeight, cdb2)
+	s2, err := initSwitchWithDB(testStartingHeight, cdb2, nil)
 	if err != nil {
 		t.Fatalf("unable reinit switch: %v", err)
 	}
@@ -1012,7 +1012,7 @@ func TestSwitchForwardCircuitPersistence(t *testing.T) {
 		t.Fatalf("unable to open channeldb: %v", err)
 	}
 
-	s, err := initSwitchWithDB(testStartingHeight, cdb)
+	s, err := initSwitchWithDB(testStartingHeight, cdb, nil)
 	if err != nil {
 		t.Fatalf("unable to init switch: %v", err)
 	}
@@ -1093,7 +1093,7 @@ func TestSwitchForwardCircuitPersistence(t *testing.T) {
 		t.Fatalf("unable to reopen channeldb: %v", err)
 	}
 
-	s2, err := initSwitchWithDB(testStartingHeight, cdb2)
+	s2, err := initSwitchWithDB(testStartingHeight, cdb2, nil)
 	if err != nil {
 		t.Fatalf("unable reinit switch: %v", err)
 	}
@@ -1186,7 +1186,7 @@ func TestSwitchForwardCircuitPersistence(t *testing.T) {
 		t.Fatalf("unable to reopen channeldb: %v", err)
 	}
 
-	s3, err := initSwitchWithDB(testStartingHeight, cdb3)
+	s3, err := initSwitchWithDB(testStartingHeight, cdb3, nil)
 	if err != nil {
 		t.Fatalf("unable reinit switch: %v", err)
 	}
@@ -1233,7 +1233,7 @@ func TestSkipIneligibleLinksMultiHopForward(t *testing.T) {
 		t.Fatalf("unable to create bob server: %v", err)
 	}
 
-	s, err := initSwitchWithDB(testStartingHeight, nil)
+	s, err := initSwitchWithDB(testStartingHeight, nil, nil)
 	if err != nil {
 		t.Fatalf("unable to init switch: %v", err)
 	}
@@ -1299,7 +1299,7 @@ func TestSkipIneligibleLinksLocalForward(t *testing.T) {
 		t.Fatalf("unable to create alice server: %v", err)
 	}
 
-	s, err := initSwitchWithDB(testStartingHeight, nil)
+	s, err := initSwitchWithDB(testStartingHeight, nil, nil)
 	if err != nil {
 		t.Fatalf("unable to init switch: %v", err)
 	}
@@ -1354,7 +1354,7 @@ func TestSwitchCancel(t *testing.T) {
 		t.Fatalf("unable to create bob server: %v", err)
 	}
 
-	s, err := initSwitchWithDB(testStartingHeight, nil)
+	s, err := initSwitchWithDB(testStartingHeight, nil, nil)
 	if err != nil {
 		t.Fatalf("unable to init switch: %v", err)
 	}
@@ -1467,7 +1467,7 @@ func TestSwitchAddSamePayment(t *testing.T) {
 		t.Fatalf("unable to create bob server: %v", err)
 	}
 
-	s, err := initSwitchWithDB(testStartingHeight, nil)
+	s, err := initSwitchWithDB(testStartingHeight, nil, nil)
 	if err != nil {
 		t.Fatalf("unable to init switch: %v", err)
 	}
@@ -1622,7 +1622,7 @@ func TestSwitchSendPayment(t *testing.T) {
 		t.Fatalf("unable to create alice server: %v", err)
 	}
 
-	s, err := initSwitchWithDB(testStartingHeight, nil)
+	s, err := initSwitchWithDB(testStartingHeight, nil, nil)
 	if err != nil {
 		t.Fatalf("unable to init switch: %v", err)
 	}


### PR DESCRIPTION
This PR is an exploration of what would happen when we move invoice settling behind the switch instead of inside the channel link.

Goals:
- Leverage CircuitMap to store the link between the final htlc and an invoice (proposal: outgoingchannelid=exithop, outgoinghtlcidx=invoice addindex). This link can be used when hold invoices are settled/failed over rpc.
- Prepare for amp. With amp, invoices are settled via multiple channel links. Therefore the invoice settling needs to be lifted out of the link level.

Implementation:
- Remove the complete 'if exithop' case from the link
- Have the switch match exithop with the outgoing channel id and forward to a new struct InvoiceSettler.
- InvoiceSettler is managing the interaction with the invoice database.