### PR TITLE
log: gRPC and REST were swapped

### DIFF
--- a/lnd.go
+++ b/lnd.go
@@ -344,7 +344,7 @@ func lndMain() error {
 		}
 		defer lis.Close()
 		go func() {
-			rpcsLog.Infof("RPC server listening on %s", lis.Addr())
+			rpcsLog.Infof("gRPC proxy listening on %s", lis.Addr())
 			grpcServer.Serve(lis)
 		}()
 	}
@@ -368,7 +368,7 @@ func lndMain() error {
 		}
 		defer lis.Close()
 		go func() {
-			rpcsLog.Infof("gRPC proxy started at %s", lis.Addr())
+			rpcsLog.Infof("REST server listening on %s", lis.Addr())
 			http.Serve(lis, mux)
 		}()
 	}


### PR DESCRIPTION
When starting, the lnd daemon seems to print misleading messages, swapping the REST and gRPC host/ports.

This change swaps back the log messages and unifies the wording.


Before this PR:
<pre><code>[...] RPCS: <b>RPC</b> server listening on 127.0.0.1:<b>10009</b> <-- isn't 10009 the <b>gRPC</b> port?
[...] RPCS: <b>gRPC</b> proxy started at 127.0.0.1:<b>8080</b>    <-- isn't 8080  the <b>REST</b> port?
</code></pre>


After this PR:
<pre><code>[...] RPCS: <b>gRPC proxy</b> listening on 127.0.0.1:<b>10009</b>
[...] RPCS: <b>REST server</b> listening on 127.0.0.1:<b>8080</b>
</code></pre>
