### PR TITLE
multi: modify sweeper.CreateSweepTx to accept conf target, style changes

### DIFF
--- a/server.go
+++ b/server.go
@@ -6,7 +6,6 @@ import (
 	"crypto/rand"
 	"encoding/hex"
 	"fmt"
-	"github.com/lightningnetwork/lnd/sweep"
 	"image/color"
 	"math/big"
 	"net"
@@ -15,6 +14,8 @@ import (
 	"sync"
 	"sync/atomic"
 	"time"
+
+	"github.com/lightningnetwork/lnd/sweep"
 
 	"github.com/btcsuite/btcd/btcec"
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
@@ -59,10 +60,6 @@ const (
 	// durations exceeding this value will be eligible to have their
 	// backoffs reduced.
 	defaultStableConnDuration = 10 * time.Minute
-
-	// sweepTxConfirmationTarget assigns a confirmation target for sweep
-	// txes on which the fee calculation will be based.
-	sweepTxConfirmationTarget = 6
 )
 
 var (
@@ -591,13 +588,13 @@ func newServer(listenAddrs []net.Addr, chanDB *channeldb.DB, cc *chainControl,
 		GenSweepScript: func() ([]byte, error) {
 			return newSweepPkScript(cc.wallet)
 		},
-		Signer:     cc.wallet.Cfg.Signer,
-		ConfTarget: sweepTxConfirmationTarget,
+		Signer: cc.wallet.Cfg.Signer,
 	})
 
 	s.utxoNursery = newUtxoNursery(&NurseryConfig{
 		ChainIO:             cc.chainIO,
 		ConfDepth:           1,
+		SweepTxConfTarget:   6,
 		FetchClosedChannels: chanDB.FetchClosedChannels,
 		FetchClosedChannel:  chanDB.FetchClosedChannel,
 		Notifier:            cc.chainNotifier,

--- a/sweep/input.go
+++ b/sweep/input.go
@@ -16,9 +16,9 @@ type Input interface {
 	// be generated in order to spend this output.
 	WitnessType() lnwallet.WitnessType
 
-	// SignDesc returns a reference to a spendable output's sign descriptor,
-	// which is used during signing to compute a valid witness that spends
-	// this output.
+	// SignDesc returns a reference to a spendable output's sign
+	// descriptor, which is used during signing to compute a valid witness
+	// that spends this output.
 	SignDesc() *lnwallet.SignDescriptor
 
 	// BuildWitness returns a valid witness allowing this output to be
@@ -41,8 +41,8 @@ type inputKit struct {
 	signDesc    lnwallet.SignDescriptor
 }
 
-// OutPoint returns the breached output's identifier that is to be included as a
-// transaction input.
+// OutPoint returns the breached output's identifier that is to be included as
+// a transaction input.
 func (i *inputKit) OutPoint() *wire.OutPoint {
 	return &i.outpoint
 }
@@ -67,8 +67,7 @@ type BaseInput struct {
 
 // MakeBaseInput assembles a new BaseInput that can be used to construct a
 // sweep transaction.
-func MakeBaseInput(outpoint *wire.OutPoint,
-	witnessType lnwallet.WitnessType,
+func MakeBaseInput(outpoint *wire.OutPoint, witnessType lnwallet.WitnessType,
 	signDescriptor *lnwallet.SignDescriptor) BaseInput {
 
 	return BaseInput{
@@ -82,8 +81,8 @@ func MakeBaseInput(outpoint *wire.OutPoint,
 
 // BuildWitness computes a valid witness that allows us to spend from the
 // breached output. It does so by generating the witness generation function,
-// which is parameterized primarily by the witness type and sign descriptor. The
-// method then returns the witness computed by invoking this function.
+// which is parameterized primarily by the witness type and sign descriptor.
+// The method then returns the witness computed by invoking this function.
 func (bi *BaseInput) BuildWitness(signer lnwallet.Signer, txn *wire.MsgTx,
 	hashCache *txscript.TxSigHashes, txinIdx int) ([][]byte, error) {
 
@@ -102,8 +101,8 @@ func (bi *BaseInput) BlocksToMaturity() uint32 {
 }
 
 // HtlcSucceedInput constitutes a sweep input that needs a pre-image. The input
-// is expected to reside on the commitment tx of the remote party and should not
-// be a second level tx output.
+// is expected to reside on the commitment tx of the remote party and should
+// not be a second level tx output.
 type HtlcSucceedInput struct {
 	inputKit
 
@@ -127,8 +126,8 @@ func MakeHtlcSucceedInput(outpoint *wire.OutPoint,
 }
 
 // BuildWitness computes a valid witness that allows us to spend from the
-// breached output. For HtlcSpendInput it will need to make the preimage part of
-// the witness.
+// breached output. For HtlcSpendInput it will need to make the preimage part
+// of the witness.
 func (h *HtlcSucceedInput) BuildWitness(signer lnwallet.Signer, txn *wire.MsgTx,
 	hashCache *txscript.TxSigHashes, txinIdx int) ([][]byte, error) {
 
@@ -149,6 +148,7 @@ func (h *HtlcSucceedInput) BlocksToMaturity() uint32 {
 	return 0
 }
 
-// Add compile-time constraint ensuring input structs implement Input interface.
+// Compile-time constraints to ensure each input struct implement the Input
+// interface.
 var _ Input = (*BaseInput)(nil)
 var _ Input = (*HtlcSucceedInput)(nil)

--- a/sweep/log.go
+++ b/sweep/log.go
@@ -5,9 +5,9 @@ import (
 	"github.com/lightningnetwork/lnd/build"
 )
 
-// log is a logger that is initialized with no output filters.  This
-// means the package will not perform any logging by default until the caller
-// requests it.
+// log is a logger that is initialized with no output filters.  This means the
+// package will not perform any logging by default until the caller requests
+// it.
 var log btclog.Logger
 
 // The default amount of logging is none.
@@ -15,15 +15,15 @@ func init() {
 	UseLogger(build.NewSubLogger("SWPR", nil))
 }
 
-// DisableLog disables all library log output.  Logging output is disabled
-// by default until UseLogger is called.
+// DisableLog disables all library log output.  Logging output is disabled by
+// default until UseLogger is called.
 func DisableLog() {
 	UseLogger(btclog.Disabled)
 }
 
-// UseLogger uses a specified Logger to output package logging info.
-// This should be used in preference to SetLogWriter if the caller is also
-// using btclog.
+// UseLogger uses a specified Logger to output package logging info.  This
+// should be used in preference to SetLogWriter if the caller is also using
+// btclog.
 func UseLogger(logger btclog.Logger) {
 	log = logger
 }


### PR DESCRIPTION
In this commit, we modify the newly introduced UtxoSweeper.CreateSweepTx
to accept the confirmation target as a param of the method rather than a
struct level variable. We do this as this allows each caller to decide
at sweep time, what the fee rate should be, rather than using a global
value that is meant to work in all scenarios. For example, anytime
we're sweeping an output with a CLTV lock that's has a dependant
transaction we need to sweep/cancel, we may require a higher fee rate
than a regular force close with a CSV output.