### PR TITLE
discovery: replace buffered channel with ConcurrentQueue in syncer

### DIFF
--- a/chainntnfs/bitcoindnotify/bitcoind.go
+++ b/chainntnfs/bitcoindnotify/bitcoind.go
@@ -1022,7 +1022,7 @@ func (b *BitcoindNotifier) RegisterBlockEpochNtfn(
 	bestBlock *chainntnfs.BlockEpoch) (*chainntnfs.BlockEpochEvent, error) {
 
 	reg := &blockEpochRegistration{
-		epochQueue: queue.NewConcurrentQueue(20),
+		epochQueue: queue.New(20),
 		epochChan:  make(chan *chainntnfs.BlockEpoch, 20),
 		cancelChan: make(chan struct{}),
 		epochID:    atomic.AddUint64(&b.epochClientCounter, 1),

--- a/chainntnfs/btcdnotify/btcd.go
+++ b/chainntnfs/btcdnotify/btcd.go
@@ -116,8 +116,8 @@ func New(config *rpcclient.ConnConfig, spendHintCache chainntnfs.SpendHintCache,
 
 		spendNotifications: make(map[wire.OutPoint]map[uint64]*spendNotification),
 
-		chainUpdates: queue.NewConcurrentQueue(10),
-		txUpdates:    queue.NewConcurrentQueue(10),
+		chainUpdates: queue.New(10),
+		txUpdates:    queue.New(10),
 
 		spendHintCache:   spendHintCache,
 		confirmHintCache: confirmHintCache,
@@ -1082,7 +1082,7 @@ func (b *BtcdNotifier) RegisterBlockEpochNtfn(
 	bestBlock *chainntnfs.BlockEpoch) (*chainntnfs.BlockEpochEvent, error) {
 
 	reg := &blockEpochRegistration{
-		epochQueue: queue.NewConcurrentQueue(20),
+		epochQueue: queue.New(20),
 		epochChan:  make(chan *chainntnfs.BlockEpoch, 20),
 		cancelChan: make(chan struct{}),
 		epochID:    atomic.AddUint64(&b.epochClientCounter, 1),

--- a/chainntnfs/neutrinonotify/neutrino.go
+++ b/chainntnfs/neutrinonotify/neutrino.go
@@ -115,7 +115,7 @@ func New(node *neutrino.ChainService, spendHintCache chainntnfs.SpendHintCache,
 
 		rescanErr: make(chan error),
 
-		chainUpdates: queue.NewConcurrentQueue(10),
+		chainUpdates: queue.New(10),
 
 		spendHintCache:   spendHintCache,
 		confirmHintCache: confirmHintCache,
@@ -994,7 +994,7 @@ func (n *NeutrinoNotifier) RegisterBlockEpochNtfn(
 	bestBlock *chainntnfs.BlockEpoch) (*chainntnfs.BlockEpochEvent, error) {
 
 	reg := &blockEpochRegistration{
-		epochQueue: queue.NewConcurrentQueue(20),
+		epochQueue: queue.New(20),
 		epochChan:  make(chan *chainntnfs.BlockEpoch, 20),
 		cancelChan: make(chan struct{}),
 		epochID:    atomic.AddUint64(&n.epochClientCounter, 1),

--- a/discovery/syncer_test.go
+++ b/discovery/syncer_test.go
@@ -1066,7 +1066,7 @@ func TestGossipSyncerDelayDOS(t *testing.T) {
 			case <-time.After(time.Second * 2):
 				t.Fatalf("node 2 didn't read msg")
 
-			case syncer2.gossipMsgs <- msg:
+			case syncer2.gossipMsgs.ChanIn() <- msg:
 
 			}
 		}
@@ -1088,7 +1088,7 @@ func TestGossipSyncerDelayDOS(t *testing.T) {
 			case <-time.After(time.Second * 2):
 				t.Fatalf("node 2 didn't read msg")
 
-			case syncer1.gossipMsgs <- msg:
+			case syncer1.gossipMsgs.ChanIn() <- msg:
 
 			}
 		}
@@ -1135,7 +1135,7 @@ func TestGossipSyncerDelayDOS(t *testing.T) {
 				case <-time.After(time.Second * 2):
 					t.Fatalf("node 2 didn't read msg")
 
-				case syncer2.gossipMsgs <- msg:
+				case syncer2.gossipMsgs.ChanIn() <- msg:
 				}
 			}
 		}
@@ -1157,7 +1157,7 @@ func TestGossipSyncerDelayDOS(t *testing.T) {
 				case <-time.After(time.Second * 2):
 					t.Fatalf("node 2 didn't read msg")
 
-				case syncer1.gossipMsgs <- msg:
+				case syncer1.gossipMsgs.ChanIn() <- msg:
 				}
 			}
 		}
@@ -1204,7 +1204,7 @@ func TestGossipSyncerDelayDOS(t *testing.T) {
 				case <-time.After(time.Second * 2):
 					t.Fatalf("node 2 didn't read msg")
 
-				case syncer2.gossipMsgs <- msg:
+				case syncer2.gossipMsgs.ChanIn() <- msg:
 
 				}
 			}
@@ -1226,7 +1226,7 @@ func TestGossipSyncerDelayDOS(t *testing.T) {
 				case <-time.After(time.Second * 2):
 					t.Fatalf("node 2 didn't read msg")
 
-				case syncer1.gossipMsgs <- msg:
+				case syncer1.gossipMsgs.ChanIn() <- msg:
 
 				}
 			}
@@ -1348,7 +1348,7 @@ func TestGossipSyncerDelayDOS(t *testing.T) {
 				case <-time.After(time.Second * 2):
 					t.Fatalf("node 2 didn't read msg")
 
-				case syncer2.gossipMsgs <- msg:
+				case syncer2.gossipMsgs.ChanIn() <- msg:
 
 				}
 			}
@@ -1370,7 +1370,7 @@ func TestGossipSyncerDelayDOS(t *testing.T) {
 				case <-time.After(time.Second * 2):
 					t.Fatalf("node 2 didn't read msg")
 
-				case syncer1.gossipMsgs <- msg:
+				case syncer1.gossipMsgs.ChanIn() <- msg:
 
 				}
 			}
@@ -1439,7 +1439,7 @@ func TestGossipSyncerRoutineSync(t *testing.T) {
 			case <-time.After(time.Second * 2):
 				t.Fatalf("node 2 didn't read msg")
 
-			case syncer2.gossipMsgs <- msg:
+			case syncer2.gossipMsgs.ChanIn() <- msg:
 
 			}
 		}
@@ -1461,7 +1461,7 @@ func TestGossipSyncerRoutineSync(t *testing.T) {
 			case <-time.After(time.Second * 2):
 				t.Fatalf("node 2 didn't read msg")
 
-			case syncer1.gossipMsgs <- msg:
+			case syncer1.gossipMsgs.ChanIn() <- msg:
 
 			}
 		}
@@ -1508,7 +1508,7 @@ func TestGossipSyncerRoutineSync(t *testing.T) {
 				case <-time.After(time.Second * 2):
 					t.Fatalf("node 2 didn't read msg")
 
-				case syncer2.gossipMsgs <- msg:
+				case syncer2.gossipMsgs.ChanIn() <- msg:
 				}
 			}
 		}
@@ -1531,7 +1531,7 @@ func TestGossipSyncerRoutineSync(t *testing.T) {
 				case <-time.After(time.Second * 2):
 					t.Fatalf("node 2 didn't read msg")
 
-				case syncer1.gossipMsgs <- msg:
+				case syncer1.gossipMsgs.ChanIn() <- msg:
 				}
 			}
 		}
@@ -1578,7 +1578,7 @@ func TestGossipSyncerRoutineSync(t *testing.T) {
 				case <-time.After(time.Second * 2):
 					t.Fatalf("node 2 didn't read msg")
 
-				case syncer2.gossipMsgs <- msg:
+				case syncer2.gossipMsgs.ChanIn() <- msg:
 
 				}
 			}
@@ -1600,7 +1600,7 @@ func TestGossipSyncerRoutineSync(t *testing.T) {
 				case <-time.After(time.Second * 2):
 					t.Fatalf("node 2 didn't read msg")
 
-				case syncer1.gossipMsgs <- msg:
+				case syncer1.gossipMsgs.ChanIn() <- msg:
 
 				}
 			}
@@ -1642,7 +1642,7 @@ func TestGossipSyncerRoutineSync(t *testing.T) {
 				case <-time.After(time.Second * 2):
 					t.Fatalf("node 2 didn't read msg")
 
-				case syncer2.gossipMsgs <- msg:
+				case syncer2.gossipMsgs.ChanIn() <- msg:
 
 				}
 			}
@@ -1664,7 +1664,7 @@ func TestGossipSyncerRoutineSync(t *testing.T) {
 				case <-time.After(time.Second * 2):
 					t.Fatalf("node 2 didn't read msg")
 
-				case syncer1.gossipMsgs <- msg:
+				case syncer1.gossipMsgs.ChanIn() <- msg:
 
 				}
 			}
@@ -1690,7 +1690,7 @@ func TestGossipSyncerRoutineSync(t *testing.T) {
 			case <-time.After(time.Second * 2):
 				t.Fatalf("node 2 didn't read msg")
 
-			case syncer2.gossipMsgs <- msg:
+			case syncer2.gossipMsgs.ChanIn() <- msg:
 
 			}
 		}
@@ -1712,7 +1712,7 @@ func TestGossipSyncerRoutineSync(t *testing.T) {
 			case <-time.After(time.Second * 2):
 				t.Fatalf("node 2 didn't read msg")
 
-			case syncer1.gossipMsgs <- msg:
+			case syncer1.gossipMsgs.ChanIn() <- msg:
 
 			}
 		}
@@ -1779,7 +1779,7 @@ func TestGossipSyncerAlreadySynced(t *testing.T) {
 			case <-time.After(time.Second * 2):
 				t.Fatalf("node 2 didn't read msg")
 
-			case syncer2.gossipMsgs <- msg:
+			case syncer2.gossipMsgs.ChanIn() <- msg:
 
 			}
 		}
@@ -1801,7 +1801,7 @@ func TestGossipSyncerAlreadySynced(t *testing.T) {
 			case <-time.After(time.Second * 2):
 				t.Fatalf("node 2 didn't read msg")
 
-			case syncer1.gossipMsgs <- msg:
+			case syncer1.gossipMsgs.ChanIn() <- msg:
 
 			}
 		}
@@ -1847,7 +1847,7 @@ func TestGossipSyncerAlreadySynced(t *testing.T) {
 				case <-time.After(time.Second * 2):
 					t.Fatalf("node 2 didn't read msg")
 
-				case syncer2.gossipMsgs <- msg:
+				case syncer2.gossipMsgs.ChanIn() <- msg:
 				}
 			}
 		}
@@ -1870,7 +1870,7 @@ func TestGossipSyncerAlreadySynced(t *testing.T) {
 				case <-time.After(time.Second * 2):
 					t.Fatalf("node 2 didn't read msg")
 
-				case syncer1.gossipMsgs <- msg:
+				case syncer1.gossipMsgs.ChanIn() <- msg:
 				}
 			}
 		}
@@ -1913,7 +1913,7 @@ func TestGossipSyncerAlreadySynced(t *testing.T) {
 			case <-time.After(time.Second * 2):
 				t.Fatalf("node 2 didn't read msg")
 
-			case syncer2.gossipMsgs <- msg:
+			case syncer2.gossipMsgs.ChanIn() <- msg:
 
 			}
 		}
@@ -1935,7 +1935,7 @@ func TestGossipSyncerAlreadySynced(t *testing.T) {
 			case <-time.After(time.Second * 2):
 				t.Fatalf("node 2 didn't read msg")
 
-			case syncer1.gossipMsgs <- msg:
+			case syncer1.gossipMsgs.ChanIn() <- msg:
 
 			}
 		}

--- a/invoiceregistry.go
+++ b/invoiceregistry.go
@@ -456,7 +456,7 @@ func (i *invoiceRegistry) SubscribeNotifications(addIndex, settleIndex uint64) *
 		addIndex:        addIndex,
 		settleIndex:     settleIndex,
 		inv:             i,
-		ntfnQueue:       queue.NewConcurrentQueue(20),
+		ntfnQueue:       queue.New(20),
 		cancelChan:      make(chan struct{}),
 	}
 	client.ntfnQueue.Start()


### PR DESCRIPTION
In this commit, we fix an issue due to the rate limiting that could
cause us to stop reading ALL messages from a peer all together, rather
than just rate limiting the number of gossip query messages that we'll
process for that peer. In order to fix this, we now introduce a
potentially unbounded queue (that'll use a buffer amount then switch to
the greater queue) for each gossip syncer. With this change, we ensure
that we won't block the entire read handler just to throttle the
messages of a particular peer.

A longer term fix for this is a proper DoS engine.

Possibly related to #2045.