### PR TITLE
lnwallet: properly set the short chan ID for remote unilateral close …

### DIFF
--- a/lnwallet/channel.go
+++ b/lnwallet/channel.go
@@ -5109,6 +5109,7 @@ func NewUnilateralCloseSummary(chanState *channeldb.OpenChannel, signer Signer,
 		IsPending:               true,
 		RemoteCurrentRevocation: chanState.RemoteCurrentRevocation,
 		RemoteNextRevocation:    chanState.RemoteNextRevocation,
+		ShortChanID:             chanState.ShortChanID(),
 		LocalChanConfig:         chanState.LocalChanCfg,
 	}
 

--- a/lnwallet/channel_test.go
+++ b/lnwallet/channel_test.go
@@ -4805,6 +4805,16 @@ func TestChannelUnilateralClosePendingCommit(t *testing.T) {
 		t.Fatalf("unable to find alice's commit resolution")
 	}
 
+	// The proper short channel ID should also be set in Alice's close
+	// channel summary.
+	if aliceCloseSummary.ChannelCloseSummary.ShortChanID !=
+		aliceChannel.ShortChanID() {
+
+		t.Fatalf("wrong short chan ID, expected %v got %v",
+			aliceChannel.ShortChanID(),
+			aliceCloseSummary.ChannelCloseSummary.ShortChanID)
+	}
+
 	aliceSignDesc := aliceCloseSummary.CommitResolution.SelfOutputSignDesc
 
 	// Finally, we'll ensure that we're able to properly sweep our output


### PR DESCRIPTION
…summaries

In this commit, we fix an existing bug wherein we wouldn't set the short
channel ID for the close summary in the database in the case that the
remote party force closed. The fix is simple, ensure that within
NewUnilateralCloseSummary we properly set the short channel ID. A test
has also been added in this commit, which fails without the
modifications to lnwallet/channel.go.

Fixes #2072.