### PR TITLE
contractcourt: settle invoice when claiming HTLC on-chain

### DIFF
--- a/contractcourt/chain_arbitrator.go
+++ b/contractcourt/chain_arbitrator.go
@@ -6,8 +6,6 @@ import (
 	"sync"
 	"sync/atomic"
 
-	"github.com/lightningnetwork/lnd/sweep"
-
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcd/wire"
 	"github.com/btcsuite/btcutil"
@@ -15,6 +13,7 @@ import (
 	"github.com/lightningnetwork/lnd/channeldb"
 	"github.com/lightningnetwork/lnd/lnwallet"
 	"github.com/lightningnetwork/lnd/lnwire"
+	"github.com/lightningnetwork/lnd/sweep"
 )
 
 // ErrChainArbExiting signals that the chain arbitrator is shutting down.
@@ -135,6 +134,11 @@ type ChainArbitratorConfig struct {
 
 	// Sweeper allows resolvers to sweep their final outputs.
 	Sweeper *sweep.UtxoSweeper
+
+	// SettleInvoice attempts to settle an existing invoice on-chain with
+	// the given payment hash. ErrInvoiceNotFound is returned if an invoice
+	// is not found.
+	SettleInvoice func(chainhash.Hash, lnwire.MilliSatoshi) error
 }
 
 // ChainArbitrator is a sub-system that oversees the on-chain resolution of all

--- a/contractcourt/channel_arbitrator.go
+++ b/contractcourt/channel_arbitrator.go
@@ -1084,33 +1084,11 @@ func (c *ChannelArbitrator) prepContractResolutions(htlcActions ChainActionMap,
 	inResolutionMap := make(map[wire.OutPoint]lnwallet.IncomingHtlcResolution)
 	for i := 0; i < len(incomingResolutions); i++ {
 		inRes := incomingResolutions[i]
-
-		// If we have a success transaction, then the htlc's outpoint
-		// is the transaction's only input. Otherwise, it's the claim
-		// point.
-		var htlcPoint wire.OutPoint
-		if inRes.SignedSuccessTx != nil {
-			htlcPoint = inRes.SignedSuccessTx.TxIn[0].PreviousOutPoint
-		} else {
-			htlcPoint = inRes.ClaimOutpoint
-		}
-
-		inResolutionMap[htlcPoint] = inRes
+		inResolutionMap[inRes.HtlcPoint()] = inRes
 	}
 	for i := 0; i < len(outgoingResolutions); i++ {
 		outRes := outgoingResolutions[i]
-
-		// If we have a timeout transaction, then the htlc's outpoint
-		// is the transaction's only input. Otherwise, it's the claim
-		// point.
-		var htlcPoint wire.OutPoint
-		if outRes.SignedTimeoutTx != nil {
-			htlcPoint = outRes.SignedTimeoutTx.TxIn[0].PreviousOutPoint
-		} else {
-			htlcPoint = outRes.ClaimOutpoint
-		}
-
-		outResolutionMap[htlcPoint] = outRes
+		outResolutionMap[outRes.HtlcPoint()] = outRes
 	}
 
 	// We'll create the resolver kit that we'll be cloning for each

--- a/contractcourt/channel_arbitrator_test.go
+++ b/contractcourt/channel_arbitrator_test.go
@@ -175,6 +175,9 @@ func createTestChannelArbitrator(log ArbitratorLog) (*ChannelArbitrator,
 			*lnwallet.IncomingHtlcResolution, uint32) error {
 			return nil
 		},
+		SettleInvoice: func(chainhash.Hash, lnwire.MilliSatoshi) error {
+			return nil
+		},
 	}
 
 	// We'll use the resolvedChan to synchronize on call to

--- a/contractcourt/htlc_success_resolver.go
+++ b/contractcourt/htlc_success_resolver.go
@@ -3,8 +3,10 @@ package contractcourt
 import (
 	"encoding/binary"
 	"fmt"
-	"github.com/lightningnetwork/lnd/lnwire"
 	"io"
+
+	"github.com/lightningnetwork/lnd/channeldb"
+	"github.com/lightningnetwork/lnd/lnwire"
 
 	"github.com/btcsuite/btcd/wire"
 	"github.com/davecgh/go-spew/spew"
@@ -174,6 +176,14 @@ func (h *htlcSuccessResolver) Resolve() (ContractResolver, error) {
 			return nil, fmt.Errorf("quitting")
 		}
 
+		// With the HTLC claimed, we can attempt to settle its
+		// corresponding invoice if we were the original destination.
+		err = h.SettleInvoice(h.payHash, h.htlcAmt)
+		if err != nil && err != channeldb.ErrInvoiceNotFound {
+			log.Errorf("Unable to settle invoice with payment "+
+				"hash %x: %v", h.payHash, err)
+		}
+
 		// Once the transaction has received a sufficient number of
 		// confirmations, we'll mark ourselves as fully resolved and exit.
 		h.resolved = true
@@ -237,6 +247,14 @@ func (h *htlcSuccessResolver) Resolve() (ContractResolver, error) {
 
 	case <-h.Quit:
 		return nil, fmt.Errorf("quitting")
+	}
+
+	// With the HTLC claimed, we can attempt to settle its corresponding
+	// invoice if we were the original destination.
+	err = h.SettleInvoice(h.payHash, h.htlcAmt)
+	if err != nil && err != channeldb.ErrInvoiceNotFound {
+		log.Errorf("Unable to settle invoice with payment "+
+			"hash %x: %v", h.payHash, err)
 	}
 
 	h.resolved = true

--- a/contractcourt/htlc_success_resolver.go
+++ b/contractcourt/htlc_success_resolver.go
@@ -3,6 +3,7 @@ package contractcourt
 import (
 	"encoding/binary"
 	"fmt"
+	"github.com/lightningnetwork/lnd/lnwire"
 	"io"
 
 	"github.com/btcsuite/btcd/wire"
@@ -45,6 +46,10 @@ type htlcSuccessResolver struct {
 	//
 	// TODO(roasbeef): send off to utxobundler
 	sweepTx *wire.MsgTx
+
+	// htlcAmt is the original amount of the htlc, not taking into
+	// account any fees that may have to be paid if it goes on chain.
+	htlcAmt lnwire.MilliSatoshi
 
 	ResolverKit
 }

--- a/contractcourt/htlc_timeout_resolver.go
+++ b/contractcourt/htlc_timeout_resolver.go
@@ -40,6 +40,10 @@ type htlcTimeoutResolver struct {
 	// additional commitment state machine.
 	htlcIndex uint64
 
+	// htlcAmt is the original amount of the htlc, not taking into
+	// account any fees that may have to be paid if it goes on chain.
+	htlcAmt lnwire.MilliSatoshi
+
 	ResolverKit
 }
 

--- a/lnwallet/channel.go
+++ b/lnwallet/channel.go
@@ -5499,6 +5499,30 @@ func newIncomingHtlcResolution(signer Signer, localChanCfg *channeldb.ChannelCon
 	}, nil
 }
 
+// HtlcPoint returns the htlc's outpoint on the commitment tx.
+func (r *IncomingHtlcResolution) HtlcPoint() wire.OutPoint {
+	// If we have a success transaction, then the htlc's outpoint
+	// is the transaction's only input. Otherwise, it's the claim
+	// point.
+	if r.SignedSuccessTx != nil {
+		return r.SignedSuccessTx.TxIn[0].PreviousOutPoint
+	}
+
+	return r.ClaimOutpoint
+}
+
+// HtlcPoint returns the htlc's outpoint on the commitment tx.
+func (r *OutgoingHtlcResolution) HtlcPoint() wire.OutPoint {
+	// If we have a timeout transaction, then the htlc's outpoint
+	// is the transaction's only input. Otherwise, it's the claim
+	// point.
+	if r.SignedTimeoutTx != nil {
+		return r.SignedTimeoutTx.TxIn[0].PreviousOutPoint
+	}
+
+	return r.ClaimOutpoint
+}
+
 // extractHtlcResolutions creates a series of outgoing HTLC resolutions, and
 // the local key used when generating the HTLC scrips. This function is to be
 // used in two cases: force close, or a unilateral close.

--- a/server.go
+++ b/server.go
@@ -728,7 +728,8 @@ func newServer(listenAddrs []net.Addr, chanDB *channeldb.DB, cc *chainControl,
 		DisableChannel: func(op wire.OutPoint) error {
 			return s.announceChanStatus(op, true)
 		},
-		Sweeper: s.sweeper,
+		Sweeper:       s.sweeper,
+		SettleInvoice: s.invoices.SettleInvoice,
 	}, chanDB)
 
 	s.breachArbiter = newBreachArbiter(&BreachConfig{


### PR DESCRIPTION
In this PR, we extend the `htlcSuccessResolver` to settle the invoice,
if any, of the corresponding on-chain HTLC sweep. This ensures that the
invoice state is consistent as when claiming the HTLC "off-chain".

Partly addresses #2032 (the receiver side).