### PR TITLE
lnd_test.go: fixing node typo

### DIFF
--- a/lnd_test.go
+++ b/lnd_test.go
@@ -3396,7 +3396,7 @@ func testMultiHopPayments(net *lntest.NetworkHarness, t *harnessTest) {
 	}
 
 	// As preliminary setup, we'll create two new nodes: Carol and Dave,
-	// such that we now have a 4 ndoe, 3 channel topology. Dave will make
+	// such that we now have a 4 node, 3 channel topology. Dave will make
 	// a channel with Alice, and Carol with Dave. After this setup, the
 	// network topology should now look like:
 	//     Carol -> Dave -> Alice -> Bob


### PR DESCRIPTION
Was going through some of the tests in `lnd_test.go` and noticed a very minor typo.