### PR TITLE
discovery/gossiper: fix logging on failed channel update

### DIFF
--- a/discovery/gossiper.go
+++ b/discovery/gossiper.go
@@ -2048,7 +2048,8 @@ func (d *AuthenticatedGossiper) processNetworkAnnouncement(
 			if err != nil {
 				log.Errorf("unable to send channel update -- "+
 					"could not find peer %x: %v",
-					remotePub, err)
+					remotePub.SerializeCompressed(),
+					err)
 			} else {
 				// Send ChannelUpdate directly to remotePeer.
 				// TODO(halseth): make reliable send?


### PR DESCRIPTION
Currently logs e.g.:
> [ERR] DISC: unable to send channel update -- could not find peer &{17c36a0 79c22ed7a068d10dc1a38ae66d2d6461e269226c60258c021b1ddcdfe4b00bc4 ec91a238a2f
0c097359a0f9fc5a8a64a2bfd2666fd559dd95df91cd39e71b270}: peer is not connected