### PR TITLE
peer: send reenable updates after 20m

### DIFF
--- a/config.go
+++ b/config.go
@@ -31,28 +31,28 @@ import (
 )
 
 const (
-	defaultConfigFilename      = "lnd.conf"
-	defaultDataDirname         = "data"
-	defaultChainSubDirname     = "chain"
-	defaultGraphSubDirname     = "graph"
-	defaultTLSCertFilename     = "tls.cert"
-	defaultTLSKeyFilename      = "tls.key"
-	defaultAdminMacFilename    = "admin.macaroon"
-	defaultReadMacFilename     = "readonly.macaroon"
-	defaultInvoiceMacFilename  = "invoice.macaroon"
-	defaultLogLevel            = "info"
-	defaultLogDirname          = "logs"
-	defaultLogFilename         = "lnd.log"
-	defaultRPCPort             = 10009
-	defaultRESTPort            = 8080
-	defaultPeerPort            = 9735
-	defaultRPCHost             = "localhost"
-	defaultMaxPendingChannels  = 1
-	defaultNoSeedBackup        = false
-	defaultTrickleDelay        = 30 * 1000
-	defaultInactiveChanTimeout = 20 * time.Minute
-	defaultMaxLogFiles         = 3
-	defaultMaxLogFileSize      = 10
+	defaultConfigFilename     = "lnd.conf"
+	defaultDataDirname        = "data"
+	defaultChainSubDirname    = "chain"
+	defaultGraphSubDirname    = "graph"
+	defaultTLSCertFilename    = "tls.cert"
+	defaultTLSKeyFilename     = "tls.key"
+	defaultAdminMacFilename   = "admin.macaroon"
+	defaultReadMacFilename    = "readonly.macaroon"
+	defaultInvoiceMacFilename = "invoice.macaroon"
+	defaultLogLevel           = "info"
+	defaultLogDirname         = "logs"
+	defaultLogFilename        = "lnd.log"
+	defaultRPCPort            = 10009
+	defaultRESTPort           = 8080
+	defaultPeerPort           = 9735
+	defaultRPCHost            = "localhost"
+	defaultMaxPendingChannels = 1
+	defaultNoSeedBackup       = false
+	defaultTrickleDelay       = 30 * 1000
+	defaultChanStatusInterval = 20 * time.Minute
+	defaultMaxLogFiles        = 3
+	defaultMaxLogFileSize     = 10
 
 	defaultTorSOCKSPort            = 9050
 	defaultTorDNSHost              = "soa.nodes.lightning.directory"
@@ -229,8 +229,8 @@ type config struct {
 
 	NoSeedBackup bool `long:"noseedbackup" description:"If true, NO SEED WILL BE EXPOSED AND THE WALLET WILL BE ENCRYPTED USING THE DEFAULT PASSPHRASE -- EVER. THIS FLAG IS ONLY FOR TESTING AND IS BEING DEPRECATED."`
 
-	TrickleDelay        int           `long:"trickledelay" description:"Time in milliseconds between each release of announcements to the network"`
-	InactiveChanTimeout time.Duration `long:"inactivechantimeout" description:"If a channel has been inactive for the set time, send a ChannelUpdate disabling it."`
+	TrickleDelay       int           `long:"trickledelay" description:"Time in milliseconds between each release of announcements to the network"`
+	ChanStatusInterval time.Duration `long:"chanstatusinterval" description:"The duration that should elapse between detecting that a channel has been enabled or disabled and announcing the updated status to the network."`
 
 	Alias       string `long:"alias" description:"The node alias. Used as a moniker by peers and intelligence services"`
 	Color       string `long:"color" description:"The color of the node in hex format (i.e. '#3399FF'). Used to customize node appearance in intelligence services"`
@@ -307,11 +307,11 @@ func loadConfig() (*config, error) {
 			MinChannelSize: int64(minChanFundingSize),
 			MaxChannelSize: int64(maxFundingAmount),
 		},
-		TrickleDelay:        defaultTrickleDelay,
-		InactiveChanTimeout: defaultInactiveChanTimeout,
-		Alias:               defaultAlias,
-		Color:               defaultColor,
-		MinChanSize:         int64(minChanFundingSize),
+		TrickleDelay:       defaultTrickleDelay,
+		ChanStatusInterval: defaultChanStatusInterval,
+		Alias:              defaultAlias,
+		Color:              defaultColor,
+		MinChanSize:        int64(minChanFundingSize),
 		Tor: &torConfig{
 			SOCKS:   defaultTorSOCKS,
 			DNS:     defaultTorDNS,

--- a/lnd_test.go
+++ b/lnd_test.go
@@ -12015,7 +12015,7 @@ func testSendUpdateDisableChannel(net *lntest.NetworkHarness, t *harnessTest) {
 	// We create a new node Eve that has an inactive channel timeout of
 	// just 2 seconds (down from the default 20m). It will be used to test
 	// channel updates for channels going inactive.
-	eve, err := net.NewNode("Eve", []string{"--inactivechantimeout=2s"})
+	eve, err := net.NewNode("Eve", []string{"--chanstatusinterval=2s"})
 	if err != nil {
 		t.Fatalf("unable to create eve's node: %v", err)
 	}

--- a/server.go
+++ b/server.go
@@ -3082,7 +3082,7 @@ func (s *server) watchChannelStatus() {
 	status := make(map[wire.OutPoint]activeStatus)
 
 	// We'll check in on the channel statuses every 1/4 of the timeout.
-	unchangedTimeout := cfg.InactiveChanTimeout
+	unchangedTimeout := cfg.ChanStatusInterval
 	tickerTimeout := unchangedTimeout / 4
 
 	if unchangedTimeout == 0 || tickerTimeout == 0 {


### PR DESCRIPTION
This commit adds a short delay before sending
out channel reenable messages. The aim is to
prevent flooding the network if we have
flapping peers. The approach ensures that
reenabling will only occur within a peer's
lifecycle, which can prevent lingering
goroutines from interfering with
enable/disable attempts across different
connections with the same peer.