### PR TITLE
chainntnfs/interface_test: lower mempool spend check timeout

### DIFF
--- a/chainntnfs/interface_test.go
+++ b/chainntnfs/interface_test.go
@@ -320,11 +320,7 @@ func testSpendNotification(miner *rpctest.Harness,
 	// Make sure notifications are not yet sent. We launch a go routine for
 	// all the spend clients, such that we can wait for them all in
 	// parallel.
-	//
-	// Since bitcoind is at times very slow at notifying about txs in the
-	// mempool, we use a quite large timeout of 10 seconds.
-	// TODO(halseth): change this when mempool spends are removed.
-	mempoolSpendTimeout := 10 * time.Second
+	mempoolSpendTimeout := 2 * chainntnfs.TrickleInterval
 	mempoolSpends := make(chan *chainntnfs.SpendDetail, numClients)
 	for _, c := range spendClients {
 		go func(client *chainntnfs.SpendEvent) {

--- a/chainntnfs/test_utils.go
+++ b/chainntnfs/test_utils.go
@@ -27,10 +27,10 @@ import (
 )
 
 var (
-	// trickleInterval is the interval at which the miner should trickle
+	// TrickleInterval is the interval at which the miner should trickle
 	// transactions to its peers. We'll set it small to ensure the miner
 	// propagates transactions quickly in the tests.
-	trickleInterval = 10 * time.Millisecond
+	TrickleInterval = 10 * time.Millisecond
 )
 
 var (
@@ -78,7 +78,7 @@ func GetTestTxidAndScript(h *rpctest.Harness) (*chainhash.Hash, []byte, error) {
 // WaitForMempoolTx waits for the txid to be seen in the miner's mempool.
 func WaitForMempoolTx(miner *rpctest.Harness, txid *chainhash.Hash) error {
 	timeout := time.After(10 * time.Second)
-	trickle := time.After(2 * trickleInterval)
+	trickle := time.After(2 * TrickleInterval)
 	for {
 		// Check for the harness' knowledge of the txid.
 		tx, err := miner.Node.GetRawTransaction(txid)
@@ -174,7 +174,7 @@ func NewMiner(t *testing.T, extraArgs []string, createChain bool,
 	t.Helper()
 
 	// Add the trickle interval argument to the extra args.
-	trickle := fmt.Sprintf("--trickleinterval=%v", trickleInterval)
+	trickle := fmt.Sprintf("--trickleinterval=%v", TrickleInterval)
 	extraArgs = append(extraArgs, trickle)
 
 	node, err := rpctest.New(NetParams, nil, extraArgs)


### PR DESCRIPTION
In this commit, we lower the mempool spend check timeout to be twice as
long as the trickle interval of the miner node, which will greatly
improve the execution time of this specific test. We're able to do this
now since we can specify custom trickle intervals for our test
harnesses.