### PR TITLE
sample-lnd.conf dir update

### DIFF
--- a/sample-lnd.conf
+++ b/sample-lnd.conf
@@ -2,7 +2,7 @@
 
 ; The directory that lnd stores all wallet, chain, and channel related data
 ; within The default is ~/.lnd/data on POSIX OSes, $LOCALAPPDATA/Lnd/data on
-; Windows, ~/Library/Application Support/Lnd/data on Mac OS, and $home/lnd/data
+; Windows, ~/Library/Application Support/Lnd on Mac OS, and $home/lnd/data
 ; on Plan9.  Environment variables are expanded so they may be used.  NOTE:
 ; Windows environment variables are typically %VARIABLE%, but they must be
 ; accessed with $VARIABLE here.  Also, ~ is expanded to $LOCALAPPDATA on Windows.


### PR DESCRIPTION
**Documentation fix:**

On macOS the default directory seems to be `~/Library/Application Support/Lnd` instead of `~/Library/Application Support/Lnd/data`

Requested change implemented are just updating documentation.