### PR TITLE
gRPC ruby doc updates

### DIFF
--- a/docs/grpc/ruby.md
+++ b/docs/grpc/ruby.md
@@ -128,7 +128,7 @@ macaroon = macaroon_binary.each_byte.map { |b| b.to_s(16).rjust(2,'0') }.join
 The simplest approach to use the macaroon is to include the metadata in each request as shown below.
 
 ```ruby
-stub.get_info(Lnrpc::GetInfoRequest.new, metadata: {metadata: macaroon})
+stub.get_info(Lnrpc::GetInfoRequest.new, metadata: {macaroon: macaroon})
 ```
 
 However, this can get tiresome to do for each request. We can use gRPC interceptors to add this metadata to each request automatically. Our interceptor class would look like this.

--- a/docs/grpc/ruby.md
+++ b/docs/grpc/ruby.md
@@ -146,6 +146,11 @@ class MacaroonInterceptor < GRPC::ClientInterceptor
     metadata['macaroon'] = macaroon
     yield
   end
+
+  def server_streamer(request:, call:, method:, metadata:)
+    metadata['macaroon'] = macaroon
+    yield
+  end
 end
 ```
 


### PR DESCRIPTION
Fixed a typo in the documentation.

Also the Interceptor class example only worked with simple request/response calls like GetInfo.

I've updated it to work with server streaming calls like SubscribeChannelGraph.

The Interceptor class can also be updated to work with client streaming and bidirectional streaming calls but AFAIK LND doesn't have such calls.