### PR TITLE
path finding: Disable bit decoupling

### DIFF
--- a/routing/missioncontrol.go
+++ b/routing/missioncontrol.go
@@ -406,9 +406,17 @@ func (p *paymentSession) RequestRoute(payment *LightningPayment,
 	// to our destination, respecting the recommendations from
 	// missionControl.
 	path, err := findPath(
-		nil, p.mc.graph, p.additionalEdges, p.mc.selfNode,
-		payment.Target, pruneView.vertexes, pruneView.edges,
-		payment.Amount, payment.FeeLimit, p.bandwidthHints,
+		&graphParams{
+			graph:           p.mc.graph,
+			additionalEdges: p.additionalEdges,
+			bandwidthHints:  p.bandwidthHints,
+		},
+		&restrictParams{
+			ignoredNodes: pruneView.vertexes,
+			ignoredEdges: pruneView.edges,
+			feeLimit:     payment.FeeLimit,
+		},
+		p.mc.selfNode, payment.Target, payment.Amount,
 	)
 	if err != nil {
 		return nil, err

--- a/routing/pathfind_test.go
+++ b/routing/pathfind_test.go
@@ -556,10 +556,10 @@ func TestFindLowestFeePath(t *testing.T) {
 	}
 
 	testGraphInstance, err := createTestGraphFromChannels(testChannels)
-	defer testGraphInstance.cleanUp()
 	if err != nil {
 		t.Fatalf("unable to create graph: %v", err)
 	}
+	defer testGraphInstance.cleanUp()
 
 	sourceNode, err := testGraphInstance.graph.SourceNode()
 	if err != nil {
@@ -683,10 +683,10 @@ func TestBasicGraphPathFinding(t *testing.T) {
 	t.Parallel()
 
 	testGraphInstance, err := parseTestGraph(basicGraphFilePath)
-	defer testGraphInstance.cleanUp()
 	if err != nil {
 		t.Fatalf("unable to create graph: %v", err)
 	}
+	defer testGraphInstance.cleanUp()
 
 	// With the test graph loaded, we'll test some basic path finding using
 	// the pre-generated graph. Consult the testdata/basic_graph.json file
@@ -872,10 +872,10 @@ func TestPathFindingWithAdditionalEdges(t *testing.T) {
 	t.Parallel()
 
 	graph, err := parseTestGraph(basicGraphFilePath)
-	defer graph.cleanUp()
 	if err != nil {
 		t.Fatalf("unable to create graph: %v", err)
 	}
+	defer graph.cleanUp()
 
 	sourceNode, err := graph.graph.SourceNode()
 	if err != nil {
@@ -941,10 +941,10 @@ func TestKShortestPathFinding(t *testing.T) {
 	t.Parallel()
 
 	graph, err := parseTestGraph(basicGraphFilePath)
-	defer graph.cleanUp()
 	if err != nil {
 		t.Fatalf("unable to create graph: %v", err)
 	}
+	defer graph.cleanUp()
 
 	sourceNode, err := graph.graph.SourceNode()
 	if err != nil {
@@ -1266,10 +1266,10 @@ func TestNewRoutePathTooLong(t *testing.T) {
 	// Ensure that potential paths which are over the maximum hop-limit are
 	// rejected.
 	graph, err := parseTestGraph(excessiveHopsGraphFilePath)
-	defer graph.cleanUp()
 	if err != nil {
 		t.Fatalf("unable to create graph: %v", err)
 	}
+	defer graph.cleanUp()
 
 	sourceNode, err := graph.graph.SourceNode()
 	if err != nil {
@@ -1325,10 +1325,10 @@ func TestPathNotAvailable(t *testing.T) {
 	t.Parallel()
 
 	graph, err := parseTestGraph(basicGraphFilePath)
-	defer graph.cleanUp()
 	if err != nil {
 		t.Fatalf("unable to create graph: %v", err)
 	}
+	defer graph.cleanUp()
 
 	sourceNode, err := graph.graph.SourceNode()
 	if err != nil {
@@ -1371,10 +1371,10 @@ func TestPathInsufficientCapacity(t *testing.T) {
 	t.Parallel()
 
 	graph, err := parseTestGraph(basicGraphFilePath)
-	defer graph.cleanUp()
 	if err != nil {
 		t.Fatalf("unable to create graph: %v", err)
 	}
+	defer graph.cleanUp()
 
 	sourceNode, err := graph.graph.SourceNode()
 	if err != nil {
@@ -1416,10 +1416,10 @@ func TestRouteFailMinHTLC(t *testing.T) {
 	t.Parallel()
 
 	graph, err := parseTestGraph(basicGraphFilePath)
-	defer graph.cleanUp()
 	if err != nil {
 		t.Fatalf("unable to create graph: %v", err)
 	}
+	defer graph.cleanUp()
 
 	sourceNode, err := graph.graph.SourceNode()
 	if err != nil {
@@ -1458,10 +1458,10 @@ func TestRouteFailDisabledEdge(t *testing.T) {
 	t.Parallel()
 
 	graph, err := parseTestGraph(basicGraphFilePath)
-	defer graph.cleanUp()
 	if err != nil {
 		t.Fatalf("unable to create graph: %v", err)
 	}
+	defer graph.cleanUp()
 
 	sourceNode, err := graph.graph.SourceNode()
 	if err != nil {
@@ -1558,10 +1558,10 @@ func TestPathSourceEdgesBandwidth(t *testing.T) {
 	t.Parallel()
 
 	graph, err := parseTestGraph(basicGraphFilePath)
-	defer graph.cleanUp()
 	if err != nil {
 		t.Fatalf("unable to create graph: %v", err)
 	}
+	defer graph.cleanUp()
 
 	sourceNode, err := graph.graph.SourceNode()
 	if err != nil {
@@ -1695,10 +1695,10 @@ func TestPathFindSpecExample(t *testing.T) {
 	// height.
 	const startingHeight = 100
 	ctx, cleanUp, err := createTestCtxFromFile(startingHeight, specExampleFilePath)
-	defer cleanUp()
 	if err != nil {
 		t.Fatalf("unable to create router: %v", err)
 	}
+	defer cleanUp()
 
 	const (
 		aliceFinalCLTV = 10

--- a/routing/pathfind_test.go
+++ b/routing/pathfind_test.go
@@ -578,8 +578,15 @@ func TestFindLowestFeePath(t *testing.T) {
 	paymentAmt := lnwire.NewMSatFromSatoshis(100)
 	target := testGraphInstance.aliasMap["target"]
 	path, err := findPath(
-		nil, testGraphInstance.graph, nil, sourceNode, target,
-		ignoredVertexes, ignoredEdges, paymentAmt, noFeeLimit, nil,
+		&graphParams{
+			graph: testGraphInstance.graph,
+		},
+		&restrictParams{
+			ignoredNodes: ignoredVertexes,
+			ignoredEdges: ignoredEdges,
+			feeLimit:     noFeeLimit,
+		},
+		sourceNode, target, paymentAmt,
 	)
 	if err != nil {
 		t.Fatalf("unable to find path: %v", err)
@@ -717,8 +724,15 @@ func testBasicGraphPathFindingCase(t *testing.T, graphInstance *testGraphInstanc
 	paymentAmt := lnwire.NewMSatFromSatoshis(test.paymentAmt)
 	target := graphInstance.aliasMap[test.target]
 	path, err := findPath(
-		nil, graphInstance.graph, nil, sourceNode, target,
-		ignoredVertexes, ignoredEdges, paymentAmt, test.feeLimit, nil,
+		&graphParams{
+			graph: graphInstance.graph,
+		},
+		&restrictParams{
+			ignoredNodes: ignoredVertexes,
+			ignoredEdges: ignoredEdges,
+			feeLimit:     test.feeLimit,
+		},
+		sourceNode, target, paymentAmt,
 	)
 	if test.expectFailureNoPath {
 		if err == nil {
@@ -905,8 +919,14 @@ func TestPathFindingWithAdditionalEdges(t *testing.T) {
 
 	// We should now be able to find a path from roasbeef to doge.
 	path, err := findPath(
-		nil, graph.graph, additionalEdges, sourceNode, dogePubKey, nil, nil,
-		paymentAmt, noFeeLimit, nil,
+		&graphParams{
+			graph:           graph.graph,
+			additionalEdges: additionalEdges,
+		},
+		&restrictParams{
+			feeLimit: noFeeLimit,
+		},
+		sourceNode, dogePubKey, paymentAmt,
 	)
 	if err != nil {
 		t.Fatalf("unable to find private path to doge: %v", err)
@@ -1261,12 +1281,19 @@ func TestNewRoutePathTooLong(t *testing.T) {
 
 	paymentAmt := lnwire.NewMSatFromSatoshis(100)
 
-	// We start by confirming that routing a payment 20 hops away is possible.
-	// Alice should be able to find a valid route to ursula.
+	// We start by confirming that routing a payment 20 hops away is
+	// possible. Alice should be able to find a valid route to ursula.
 	target := graph.aliasMap["ursula"]
 	_, err = findPath(
-		nil, graph.graph, nil, sourceNode, target, ignoredVertexes,
-		ignoredEdges, paymentAmt, noFeeLimit, nil,
+		&graphParams{
+			graph: graph.graph,
+		},
+		&restrictParams{
+			ignoredNodes: ignoredVertexes,
+			ignoredEdges: ignoredEdges,
+			feeLimit:     noFeeLimit,
+		},
+		sourceNode, target, paymentAmt,
 	)
 	if err != nil {
 		t.Fatalf("path should have been found")
@@ -1276,8 +1303,15 @@ func TestNewRoutePathTooLong(t *testing.T) {
 	// presented to Alice.
 	target = graph.aliasMap["vincent"]
 	path, err := findPath(
-		nil, graph.graph, nil, sourceNode, target, ignoredVertexes,
-		ignoredEdges, paymentAmt, noFeeLimit, nil,
+		&graphParams{
+			graph: graph.graph,
+		},
+		&restrictParams{
+			ignoredNodes: ignoredVertexes,
+			ignoredEdges: ignoredEdges,
+			feeLimit:     noFeeLimit,
+		},
+		sourceNode, target, paymentAmt,
 	)
 	if err == nil {
 		t.Fatalf("should not have been able to find path, supposed to be "+
@@ -1318,8 +1352,15 @@ func TestPathNotAvailable(t *testing.T) {
 	}
 
 	_, err = findPath(
-		nil, graph.graph, nil, sourceNode, unknownNode, ignoredVertexes,
-		ignoredEdges, 100, noFeeLimit, nil,
+		&graphParams{
+			graph: graph.graph,
+		},
+		&restrictParams{
+			ignoredNodes: ignoredVertexes,
+			ignoredEdges: ignoredEdges,
+			feeLimit:     noFeeLimit,
+		},
+		sourceNode, unknownNode, 100,
 	)
 	if !IsError(err, ErrNoPathFound) {
 		t.Fatalf("path shouldn't have been found: %v", err)
@@ -1354,8 +1395,15 @@ func TestPathInsufficientCapacity(t *testing.T) {
 
 	payAmt := lnwire.NewMSatFromSatoshis(btcutil.SatoshiPerBitcoin)
 	_, err = findPath(
-		nil, graph.graph, nil, sourceNode, target, ignoredVertexes,
-		ignoredEdges, payAmt, noFeeLimit, nil,
+		&graphParams{
+			graph: graph.graph,
+		},
+		&restrictParams{
+			ignoredNodes: ignoredVertexes,
+			ignoredEdges: ignoredEdges,
+			feeLimit:     noFeeLimit,
+		},
+		sourceNode, target, payAmt,
 	)
 	if !IsError(err, ErrNoPathFound) {
 		t.Fatalf("graph shouldn't be able to support payment: %v", err)
@@ -1386,8 +1434,15 @@ func TestRouteFailMinHTLC(t *testing.T) {
 	target := graph.aliasMap["songoku"]
 	payAmt := lnwire.MilliSatoshi(10)
 	_, err = findPath(
-		nil, graph.graph, nil, sourceNode, target, ignoredVertexes,
-		ignoredEdges, payAmt, noFeeLimit, nil,
+		&graphParams{
+			graph: graph.graph,
+		},
+		&restrictParams{
+			ignoredNodes: ignoredVertexes,
+			ignoredEdges: ignoredEdges,
+			feeLimit:     noFeeLimit,
+		},
+		sourceNode, target, payAmt,
 	)
 	if !IsError(err, ErrNoPathFound) {
 		t.Fatalf("graph shouldn't be able to support payment: %v", err)
@@ -1418,8 +1473,15 @@ func TestRouteFailDisabledEdge(t *testing.T) {
 	target := graph.aliasMap["sophon"]
 	payAmt := lnwire.NewMSatFromSatoshis(105000)
 	_, err = findPath(
-		nil, graph.graph, nil, sourceNode, target, ignoredVertexes,
-		ignoredEdges, payAmt, noFeeLimit, nil,
+		&graphParams{
+			graph: graph.graph,
+		},
+		&restrictParams{
+			ignoredNodes: ignoredVertexes,
+			ignoredEdges: ignoredEdges,
+			feeLimit:     noFeeLimit,
+		},
+		sourceNode, target, payAmt,
 	)
 	if err != nil {
 		t.Fatalf("unable to find path: %v", err)
@@ -1439,8 +1501,15 @@ func TestRouteFailDisabledEdge(t *testing.T) {
 	// Now, if we attempt to route through that edge, we should get a
 	// failure as it is no longer eligible.
 	_, err = findPath(
-		nil, graph.graph, nil, sourceNode, target, ignoredVertexes,
-		ignoredEdges, payAmt, noFeeLimit, nil,
+		&graphParams{
+			graph: graph.graph,
+		},
+		&restrictParams{
+			ignoredNodes: ignoredVertexes,
+			ignoredEdges: ignoredEdges,
+			feeLimit:     noFeeLimit,
+		},
+		sourceNode, target, payAmt,
 	)
 	if !IsError(err, ErrNoPathFound) {
 		t.Fatalf("graph shouldn't be able to support payment: %v", err)

--- a/routing/router_test.go
+++ b/routing/router_test.go
@@ -1872,8 +1872,15 @@ func TestFindPathFeeWeighting(t *testing.T) {
 	// the edge weighting, we should select the direct path over the 2 hop
 	// path even though the direct path has a higher potential time lock.
 	path, err := findPath(
-		nil, ctx.graph, nil, sourceNode, target, ignoreVertex,
-		ignoreEdge, amt, noFeeLimit, nil,
+		&graphParams{
+			graph: ctx.graph,
+		},
+		&restrictParams{
+			ignoredNodes: ignoreVertex,
+			ignoredEdges: ignoreEdge,
+			feeLimit:     noFeeLimit,
+		},
+		sourceNode, target, amt,
 	)
 	if err != nil {
 		t.Fatalf("unable to find path: %v", err)


### PR DESCRIPTION
This PR consist of the first part of #2091 (Strict channel enabling):

1. The path finding algorithm is modified to ignore the disable bit for local channels, allowing us to send payments on these channels even though they are publicly disabled. The assumption is that bandwidth hints of local channels will be set to a value reflecting their active status.

This essentially decouples the graph's disabled status from the local path finding, as the local channel status will be more up-to-date than what is found in the graph. 