### PR TITLE
Integration tests fixes and cleanups

### DIFF
--- a/lnd_test.go
+++ b/lnd_test.go
@@ -2269,7 +2269,10 @@ func testChannelForceClosure(net *lntest.NetworkHarness, t *harnessTest) {
 	// Send payments from Alice to Carol, since Carol is htlchodl mode, the
 	// htlc outputs should be left unsettled, and should be swept by the
 	// utxo nursery.
-	alicePayStream, err := net.Alice.SendPayment(ctxb)
+	ctx, cancel := context.WithCancel(ctxb)
+	defer cancel()
+
+	alicePayStream, err := net.Alice.SendPayment(ctx)
 	if err != nil {
 		t.Fatalf("unable to create payment stream for alice: %v", err)
 	}
@@ -7618,7 +7621,10 @@ out:
 	// Next we'll test an error that occurs mid-route due to an outgoing
 	// link having insufficient capacity. In order to do so, we'll first
 	// need to unbalance the link connecting Bob<->Carol.
-	bobPayStream, err := net.Bob.SendPayment(ctxb)
+	ctx, cancel := context.WithCancel(ctxb)
+	defer cancel()
+
+	bobPayStream, err := net.Bob.SendPayment(ctx)
 	if err != nil {
 		t.Fatalf("unable to create payment stream: %v", err)
 	}
@@ -8420,12 +8426,18 @@ func testBidirectionalAsyncPayments(net *lntest.NetworkHarness, t *harnessTest) 
 
 	// Open up a payment streams to Alice and to Bob, that we'll use to
 	// send payment between nodes.
-	alicePayStream, err := net.Alice.SendPayment(ctxb)
+	ctx, cancel := context.WithCancel(ctxb)
+	defer cancel()
+
+	alicePayStream, err := net.Alice.SendPayment(ctx)
 	if err != nil {
 		t.Fatalf("unable to create payment stream for alice: %v", err)
 	}
 
-	bobPayStream, err := net.Bob.SendPayment(ctxb)
+	ctx, cancel = context.WithCancel(ctxb)
+	defer cancel()
+
+	bobPayStream, err := net.Bob.SendPayment(ctx)
 	if err != nil {
 		t.Fatalf("unable to create payment stream for bob: %v", err)
 	}
@@ -8768,7 +8780,11 @@ func testMultiHopHtlcLocalTimeout(net *lntest.NetworkHarness, t *harnessTest) {
 		htlcAmt        = btcutil.Amount(30000)
 		finalCltvDelta = 40
 	)
-	alicePayStream, err := net.Alice.SendPayment(ctxb)
+
+	ctx, cancel := context.WithCancel(ctxb)
+	defer cancel()
+
+	alicePayStream, err := net.Alice.SendPayment(ctx)
 	if err != nil {
 		t.Fatalf("unable to create payment stream for alice: %v", err)
 	}
@@ -9002,7 +9018,10 @@ func testMultiHopReceiverChainClaim(net *lntest.NetworkHarness, t *harnessTest) 
 	// Now that we've created the invoice, we'll send a single payment from
 	// Alice to Carol. We won't wait for the response however, as Carol
 	// will not immediately settle the payment.
-	alicePayStream, err := net.Alice.SendPayment(ctxb)
+	ctx, cancel := context.WithCancel(ctxb)
+	defer cancel()
+
+	alicePayStream, err := net.Alice.SendPayment(ctx)
 	if err != nil {
 		t.Fatalf("unable to create payment stream for alice: %v", err)
 	}
@@ -9223,7 +9242,10 @@ func testMultiHopLocalForceCloseOnChainHtlcTimeout(net *lntest.NetworkHarness,
 		finalCltvDelta = 40
 		htlcAmt        = btcutil.Amount(30000)
 	)
-	alicePayStream, err := net.Alice.SendPayment(ctxb)
+	ctx, cancel := context.WithCancel(ctxb)
+	defer cancel()
+
+	alicePayStream, err := net.Alice.SendPayment(ctx)
 	if err != nil {
 		t.Fatalf("unable to create payment stream for alice: %v", err)
 	}
@@ -9478,7 +9500,11 @@ func testMultiHopRemoteForceCloseOnChainHtlcTimeout(net *lntest.NetworkHarness,
 		finalCltvDelta = 40
 		htlcAmt        = btcutil.Amount(30000)
 	)
-	alicePayStream, err := net.Alice.SendPayment(ctxb)
+
+	ctx, cancel := context.WithCancel(ctxb)
+	defer cancel()
+
+	alicePayStream, err := net.Alice.SendPayment(ctx)
 	if err != nil {
 		t.Fatalf("unable to create payment stream for alice: %v", err)
 	}
@@ -9693,7 +9719,10 @@ func testMultiHopHtlcLocalChainClaim(net *lntest.NetworkHarness, t *harnessTest)
 	// Now that we've created the invoice, we'll send a single payment from
 	// Alice to Carol. We won't wait for the response however, as Carol
 	// will not immediately settle the payment.
-	alicePayStream, err := net.Alice.SendPayment(ctxb)
+	ctx, cancel := context.WithCancel(ctxb)
+	defer cancel()
+
+	alicePayStream, err := net.Alice.SendPayment(ctx)
 	if err != nil {
 		t.Fatalf("unable to create payment stream for alice: %v", err)
 	}
@@ -10023,7 +10052,10 @@ func testMultiHopHtlcRemoteChainClaim(net *lntest.NetworkHarness, t *harnessTest
 	// Now that we've created the invoice, we'll send a single payment from
 	// Alice to Carol. We won't wait for the response however, as Carol
 	// will not immediately settle the payment.
-	alicePayStream, err := net.Alice.SendPayment(ctxb)
+	ctx, cancel := context.WithCancel(ctxb)
+	defer cancel()
+
+	alicePayStream, err := net.Alice.SendPayment(ctx)
 	if err != nil {
 		t.Fatalf("unable to create payment stream for alice: %v", err)
 	}

--- a/lnd_test.go
+++ b/lnd_test.go
@@ -6342,7 +6342,7 @@ func testRevokedCloseRetribution(net *lntest.NetworkHarness, t *harnessTest) {
 		t.Fatalf("justice tx wasn't mined")
 	}
 
-	assertNodeNumChannels(t, ctxb, carol, 0)
+	assertNodeNumChannels(t, carol, 0)
 }
 
 // testRevokedCloseRetributionZeroValueRemoteOutput tests that Dave is able
@@ -6584,7 +6584,7 @@ func testRevokedCloseRetributionZeroValueRemoteOutput(net *lntest.NetworkHarness
 		t.Fatalf("justice tx wasn't mined")
 	}
 
-	assertNodeNumChannels(t, ctxb, dave, 0)
+	assertNodeNumChannels(t, dave, 0)
 }
 
 // testRevokedCloseRetributionRemoteHodl tests that Dave properly responds to a
@@ -6991,7 +6991,7 @@ func testRevokedCloseRetributionRemoteHodl(net *lntest.NetworkHarness,
 	assertTxInBlock(t, block, justiceTxid)
 
 	// Dave should have no open channels.
-	assertNodeNumChannels(t, ctxb, dave, 0)
+	assertNodeNumChannels(t, dave, 0)
 }
 
 // assertNumPendingChannels checks that a PendingChannels response from the
@@ -7202,7 +7202,7 @@ func testDataLossProtection(net *lntest.NetworkHarness, t *harnessTest) {
 		if nodeChan.NumUpdates != stateNumPreCopy {
 			t.Fatalf("db copy failed: %v", nodeChan.NumUpdates)
 		}
-		assertNodeNumChannels(t, ctxb, node, 1)
+		assertNodeNumChannels(t, node, 1)
 
 		balReq := &lnrpc.WalletBalanceRequest{}
 		balResp, err := node.WalletBalance(ctxb, balReq)
@@ -7322,8 +7322,8 @@ func testDataLossProtection(net *lntest.NetworkHarness, t *harnessTest) {
 			carolBalance)
 	}
 
-	assertNodeNumChannels(t, ctxb, dave, 0)
-	assertNodeNumChannels(t, ctxb, carol, 0)
+	assertNodeNumChannels(t, dave, 0)
+	assertNodeNumChannels(t, carol, 0)
 
 	// As a second part of this test, we will test the the scenario where a
 	// channel is closed while Dave is offline, loses his state and comes
@@ -7379,7 +7379,7 @@ func testDataLossProtection(net *lntest.NetworkHarness, t *harnessTest) {
 			carolBalance)
 	}
 
-	assertNodeNumChannels(t, ctxb, carol, 0)
+	assertNodeNumChannels(t, carol, 0)
 
 	// When Dave comes online, he will reconnect to Carol, try to resync
 	// the channel, but it will already be closed. Carol should resend the
@@ -7397,7 +7397,7 @@ func testDataLossProtection(net *lntest.NetworkHarness, t *harnessTest) {
 	// Mine a block to confirm the sweep, and make sure Dave got his
 	// balance back.
 	mineBlocks(t, net, 1)
-	assertNodeNumChannels(t, ctxb, dave, 0)
+	assertNodeNumChannels(t, dave, 0)
 
 	daveBalResp, err = dave.WalletBalance(ctxb, balReq)
 	if err != nil {
@@ -7413,15 +7413,17 @@ func testDataLossProtection(net *lntest.NetworkHarness, t *harnessTest) {
 
 // assertNodeNumChannels polls the provided node's list channels rpc until it
 // reaches the desired number of total channels.
-func assertNodeNumChannels(t *harnessTest, ctxb context.Context,
-	node *lntest.HarnessNode, numChannels int) {
+func assertNodeNumChannels(t *harnessTest, node *lntest.HarnessNode,
+	numChannels int) {
+	ctxb := context.Background()
 
 	// Poll node for its list of channels.
 	req := &lnrpc.ListChannelsRequest{}
 
 	var predErr error
 	pred := func() bool {
-		chanInfo, err := node.ListChannels(ctxb, req)
+		ctxt, _ := context.WithTimeout(ctxb, defaultTimeout)
+		chanInfo, err := node.ListChannels(ctxt, req)
 		if err != nil {
 			predErr = fmt.Errorf("unable to query for node's "+
 				"channels: %v", err)

--- a/lnd_test.go
+++ b/lnd_test.go
@@ -432,8 +432,9 @@ func assertNumOpenChannelsPending(ctxt context.Context, t *harnessTest,
 }
 
 // assertNumConnections asserts number current connections between two peers.
-func assertNumConnections(ctxt context.Context, t *harnessTest,
-	alice, bob *lntest.HarnessNode, expected int) {
+func assertNumConnections(t *harnessTest, alice, bob *lntest.HarnessNode,
+	expected int) {
+	ctxb := context.Background()
 
 	const nPolls = 10
 
@@ -443,11 +444,14 @@ func assertNumConnections(ctxt context.Context, t *harnessTest,
 	for i := nPolls - 1; i >= 0; i-- {
 		select {
 		case <-tick.C:
+			ctxt, _ := context.WithTimeout(ctxb, defaultTimeout)
 			aNumPeers, err := alice.ListPeers(ctxt, &lnrpc.ListPeersRequest{})
 			if err != nil {
 				t.Fatalf("unable to fetch alice's node (%v) list peers %v",
 					alice.NodeID, err)
 			}
+
+			ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
 			bNumPeers, err := bob.ListPeers(ctxt, &lnrpc.ListPeersRequest{})
 			if err != nil {
 				t.Fatalf("unable to fetch bob's node (%v) list peers %v",
@@ -1741,7 +1745,7 @@ func testDisconnectingTargetPeer(net *lntest.NetworkHarness, t *harnessTest) {
 	ctxb := context.Background()
 
 	// Check existing connection.
-	assertNumConnections(ctxb, t, net.Alice, net.Bob, 1)
+	assertNumConnections(t, net.Alice, net.Bob, 1)
 
 	chanAmt := maxBtcFundingAmount
 	pushAmt := btcutil.Amount(0)
@@ -1772,7 +1776,7 @@ func testDisconnectingTargetPeer(net *lntest.NetworkHarness, t *harnessTest) {
 	time.Sleep(time.Millisecond * 300)
 
 	// Check existing connection.
-	assertNumConnections(ctxb, t, net.Alice, net.Bob, 1)
+	assertNumConnections(t, net.Alice, net.Bob, 1)
 
 	fundingTxID, err := chainhash.NewHash(pendingUpdate.Txid)
 	if err != nil {
@@ -1834,7 +1838,7 @@ func testDisconnectingTargetPeer(net *lntest.NetworkHarness, t *harnessTest) {
 	}
 
 	// Check existing connection.
-	assertNumConnections(ctxb, t, net.Alice, net.Bob, 1)
+	assertNumConnections(t, net.Alice, net.Bob, 1)
 
 	ctxt, _ = context.WithTimeout(ctxb, channelCloseTimeout)
 	closeChannelAndAssert(ctxt, t, net, net.Alice, chanPoint, true)
@@ -1855,7 +1859,7 @@ func testDisconnectingTargetPeer(net *lntest.NetworkHarness, t *harnessTest) {
 	}
 
 	// Check zero peer connections.
-	assertNumConnections(ctxb, t, net.Alice, net.Bob, 0)
+	assertNumConnections(t, net.Alice, net.Bob, 0)
 
 	// Finally, re-connect both nodes.
 	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
@@ -1864,7 +1868,7 @@ func testDisconnectingTargetPeer(net *lntest.NetworkHarness, t *harnessTest) {
 	}
 
 	// Check existing connection.
-	assertNumConnections(ctxb, t, net.Alice, net.Bob, 1)
+	assertNumConnections(t, net.Alice, net.Bob, 1)
 
 	// Cleanup by mining the force close and sweep transaction.
 	cleanupForceClose(t, net, net.Alice, chanPoint)

--- a/lnd_test.go
+++ b/lnd_test.go
@@ -161,6 +161,12 @@ func openChannelAndAssert(ctx context.Context, t *harnessTest,
 		t.Fatalf("unable to open channel: %v", err)
 	}
 
+	// Wait for the miner to have seen our funding tx.
+	_, err = waitForTxInMempool(net.Miner.Node, minerMempoolTimeout)
+	if err != nil {
+		t.Fatalf("unable to find funding tx in mempool: %v", err)
+	}
+
 	// Mine 6 blocks, then wait for Alice's node to notify us that the
 	// channel has been opened. The funding transaction should be found
 	// within the first newly mined block. We mine 6 blocks so that in the
@@ -238,6 +244,12 @@ func closeChannelAndAssert(ctx context.Context, t *harnessTest,
 	}
 	if !found {
 		t.Fatalf("channel not marked as waiting close")
+	}
+
+	// Wait for the miner to have seen the closing tx.
+	_, err = waitForTxInMempool(net.Miner.Node, minerMempoolTimeout)
+	if err != nil {
+		t.Fatalf("unable to find closing tx in mempool: %v", err)
 	}
 
 	// We'll now, generate a single block, wait for the final close status
@@ -850,6 +862,10 @@ func testUnconfirmedChannelFunding(net *lntest.NetworkHarness, t *harnessTest) {
 	if err != nil {
 		t.Fatalf("unable to send coins to carol: %v", err)
 	}
+	_, err = waitForTxInMempool(net.Miner.Node, minerMempoolTimeout)
+	if err != nil {
+		t.Fatalf("failed to find tx in miner mempool: %v", err)
+	}
 
 	// Now, we'll connect her to Alice so that they can open a channel
 	// together. The funding flow should select Carol's unconfirmed output
@@ -870,6 +886,13 @@ func testUnconfirmedChannelFunding(net *lntest.NetworkHarness, t *harnessTest) {
 	if err != nil {
 		t.Fatalf("unable to open channel between carol and alice: %v",
 			err)
+	}
+
+	// Two transactions should now be in the miner mempool, the unconfirmed
+	// spend and the funding tx.
+	_, err = waitForNTxsInMempool(net.Miner.Node, 2, minerMempoolTimeout)
+	if err != nil {
+		t.Fatalf("unable to find htlc timeout txns in mempool: %v", err)
 	}
 
 	// Confirm the channel and wait for it to be recognized by both parties.
@@ -1574,6 +1597,12 @@ func testOpenChannelAfterReorg(net *lntest.NetworkHarness, t *harnessTest) {
 		t.Fatalf("unable to open channel: %v", err)
 	}
 
+	// Wait for miner to have seen the funding tx.
+	_, err = waitForTxInMempool(net.Miner.Node, minerMempoolTimeout)
+	if err != nil {
+		t.Fatalf("failed to find funding tx in mempool: %v", err)
+	}
+
 	// At this point, the channel's funding transaction will have been
 	// broadcast, but not confirmed, and the channel should be pending.
 	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
@@ -1751,6 +1780,12 @@ func testDisconnectingTargetPeer(net *lntest.NetworkHarness, t *harnessTest) {
 			" %v", err)
 	}
 
+	// Wait for miner to have seen the funding tx.
+	_, err = waitForTxInMempool(net.Miner.Node, minerMempoolTimeout)
+	if err != nil {
+		t.Fatalf("failed to find funding tx in miner mempool: %v", err)
+	}
+
 	// Mine a block, then wait for Alice's node to notify us that the
 	// channel has been opened. The funding transaction should be found
 	// within the newly mined block.
@@ -1898,6 +1933,10 @@ func testChannelFundingPersistence(net *lntest.NetworkHarness, t *harnessTest) {
 	// Mine a block, then wait for Alice's node to notify us that the
 	// channel has been opened. The funding transaction should be found
 	// within the newly mined block.
+	_, err = waitForTxInMempool(net.Miner.Node, minerMempoolTimeout)
+	if err != nil {
+		t.Fatalf("failed to find funding tx in miner mempool: %v", err)
+	}
 	block := mineBlocks(t, net, 1)[0]
 	assertTxInBlock(t, block, fundingTxID)
 
@@ -2346,6 +2385,11 @@ func testChannelForceClosure(net *lntest.NetworkHarness, t *harnessTest) {
 
 	// Mine a block which should confirm the commitment transaction
 	// broadcast as a result of the force closure.
+	_, err = waitForTxInMempool(net.Miner.Node, minerMempoolTimeout)
+	if err != nil {
+		t.Fatalf("failed to find commitment in miner mempool: %v", err)
+	}
+
 	if _, err := net.Miner.Node.Generate(1); err != nil {
 		t.Fatalf("unable to generate block: %v", err)
 	}
@@ -2409,6 +2453,14 @@ func testChannelForceClosure(net *lntest.NetworkHarness, t *harnessTest) {
 	// (the "kindergarten" bucket.)
 	if err := net.RestartNode(net.Alice, nil); err != nil {
 		t.Fatalf("Node restart failed: %v", err)
+	}
+
+	// Carol's sweep tx should be in the mempool already, as her output is
+	// not timelocked.
+	_, err = waitForTxInMempool(net.Miner.Node, minerMempoolTimeout)
+	if err != nil {
+		t.Fatalf("failed to find Carol's sweep in miner mempool: %v",
+			err)
 	}
 
 	// Currently within the codebase, the default CSV is 4 relative blocks.
@@ -4248,6 +4300,12 @@ func testUnannouncedChannels(net *lntest.NetworkHarness, t *harnessTest) {
 		t.Fatalf("unable to open channel: %v", err)
 	}
 
+	// Wait for miner to have seen the funding tx.
+	_, err = waitForTxInMempool(net.Miner.Node, minerMempoolTimeout)
+	if err != nil {
+		t.Fatalf("failed to find funding tx in miner mempool: %v", err)
+	}
+
 	// Mine 2 blocks, and check that the channel is opened but not yet
 	// announced to the network.
 	mineBlocks(t, net, 2)
@@ -4498,6 +4556,10 @@ func testPrivateChannels(net *lntest.NetworkHarness, t *harnessTest) {
 
 	// One block is enough to make the channel ready for use, since the
 	// nodes have defaultNumConfs=1 set.
+	_, err = waitForTxInMempool(net.Miner.Node, minerMempoolTimeout)
+	if err != nil {
+		t.Fatalf("failed to get sweep tx from mempool: %v", err)
+	}
 	block := mineBlocks(t, net, 1)[0]
 	chanPointPrivate, err := net.WaitForChannelOpen(ctxb, chanOpenUpdate)
 	if err != nil {
@@ -5454,6 +5516,12 @@ func testMaxPendingChannels(net *lntest.NetworkHarness, t *harnessTest) {
 	// been opened. The funding transactions should be found within the
 	// first newly mined block. 6 blocks make sure the funding transaction
 	// has enough confirmations to be announced publicly.
+	_, err = waitForNTxsInMempool(net.Miner.Node, maxPendingChannels,
+		minerMempoolTimeout)
+	if err != nil {
+		t.Fatalf("expected transaction not found in mempool: %v", err)
+	}
+
 	block := mineBlocks(t, net, 6)[0]
 
 	chanPoints := make([]*lnrpc.ChannelPoint, maxPendingChannels)
@@ -5655,6 +5723,10 @@ func testFailingChannel(net *lntest.NetworkHarness, t *harnessTest) {
 	}
 
 	// Mine a block to confirm the broadcasted commitment.
+	_, err = waitForTxInMempool(net.Miner.Node, minerMempoolTimeout)
+	if err != nil {
+		t.Fatalf("unable to find Bob's breach tx in mempool: %v", err)
+	}
 	block := mineBlocks(t, net, 1)[0]
 	if len(block.Transactions) != 2 {
 		t.Fatalf("transaction wasn't mined")
@@ -9651,6 +9723,13 @@ func testMultiHopHtlcLocalChainClaim(net *lntest.NetworkHarness, t *harnessTest)
 	ctxt, _ := context.WithTimeout(ctxb, channelCloseTimeout)
 	bobForceClose := closeChannelAndAssert(ctxt, t, net, net.Bob,
 		aliceChanPoint, true)
+
+	// Alice will sweep her output immediately.
+	_, err = waitForTxInMempool(net.Miner.Node, minerMempoolTimeout)
+	if err != nil {
+		t.Fatalf("unable to find alice's sweep tx in miner mempool: %v",
+			err)
+	}
 
 	// We'll now mine enough blocks so Carol decides that she needs to go
 	// on-chain to claim the HTLC as Bob has been inactive.

--- a/lnd_test.go
+++ b/lnd_test.go
@@ -3434,13 +3434,15 @@ func testListPayments(net *lntest.NetworkHarness, t *harnessTest) {
 // assertAmountPaid checks that the ListChannels command of the provided
 // node list the total amount sent and received as expected for the
 // provided channel.
-func assertAmountPaid(t *harnessTest, ctxb context.Context, channelName string,
+func assertAmountPaid(t *harnessTest, channelName string,
 	node *lntest.HarnessNode, chanPoint wire.OutPoint, amountSent,
 	amountReceived int64) {
+	ctxb := context.Background()
 
 	checkAmountPaid := func() error {
 		listReq := &lnrpc.ListChannelsRequest{}
-		resp, err := node.ListChannels(ctxb, listReq)
+		ctxt, _ := context.WithTimeout(ctxb, defaultTimeout)
+		resp, err := node.ListChannels(ctxt, listReq)
 		if err != nil {
 			return fmt.Errorf("unable to for node's "+
 				"channels: %v", err)
@@ -3732,9 +3734,9 @@ func testMultiHopPayments(net *lntest.NetworkHarness, t *harnessTest) {
 	// The final node bob expects to get paid five times 1000 sat.
 	expectedAmountPaidAtoB := int64(5 * 1000)
 
-	assertAmountPaid(t, ctxb, "Alice(local) => Bob(remote)", net.Bob,
+	assertAmountPaid(t, "Alice(local) => Bob(remote)", net.Bob,
 		aliceFundPoint, int64(0), expectedAmountPaidAtoB)
-	assertAmountPaid(t, ctxb, "Alice(local) => Bob(remote)", net.Alice,
+	assertAmountPaid(t, "Alice(local) => Bob(remote)", net.Alice,
 		aliceFundPoint, expectedAmountPaidAtoB, int64(0))
 
 	// To forward a payment of 1000 sat, Alice is charging a fee of
@@ -3744,9 +3746,9 @@ func testMultiHopPayments(net *lntest.NetworkHarness, t *harnessTest) {
 	// Dave needs to pay what Alice pays plus Alice's fee.
 	expectedAmountPaidDtoA := expectedAmountPaidAtoB + expectedFeeAlice
 
-	assertAmountPaid(t, ctxb, "Dave(local) => Alice(remote)", net.Alice,
+	assertAmountPaid(t, "Dave(local) => Alice(remote)", net.Alice,
 		daveFundPoint, int64(0), expectedAmountPaidDtoA)
-	assertAmountPaid(t, ctxb, "Dave(local) => Alice(remote)", dave,
+	assertAmountPaid(t, "Dave(local) => Alice(remote)", dave,
 		daveFundPoint, expectedAmountPaidDtoA, int64(0))
 
 	// To forward a payment of 1101 sat, Dave is charging a fee of
@@ -3756,9 +3758,9 @@ func testMultiHopPayments(net *lntest.NetworkHarness, t *harnessTest) {
 	// Carol needs to pay what Dave pays plus Dave's fee.
 	expectedAmountPaidCtoD := expectedAmountPaidDtoA + expectedFeeDave
 
-	assertAmountPaid(t, ctxb, "Carol(local) => Dave(remote)", dave,
+	assertAmountPaid(t, "Carol(local) => Dave(remote)", dave,
 		carolFundPoint, int64(0), expectedAmountPaidCtoD)
-	assertAmountPaid(t, ctxb, "Carol(local) => Dave(remote)", carol,
+	assertAmountPaid(t, "Carol(local) => Dave(remote)", carol,
 		carolFundPoint, expectedAmountPaidCtoD, int64(0))
 
 	// Now that we know all the balances have been settled out properly,
@@ -3952,9 +3954,9 @@ func testSingleHopSendToRoute(net *lntest.NetworkHarness, t *harnessTest) {
 	// increasing of time is needed to embed the HTLC in commitment
 	// transaction, in channel Alice->Bob, order is Bob and then Alice.
 	const amountPaid = int64(5000)
-	assertAmountPaid(t, ctxb, "Alice(local) => Bob(remote)", net.Bob,
+	assertAmountPaid(t, "Alice(local) => Bob(remote)", net.Bob,
 		aliceFundPoint, int64(0), amountPaid)
-	assertAmountPaid(t, ctxb, "Alice(local) => Bob(remote)", net.Alice,
+	assertAmountPaid(t, "Alice(local) => Bob(remote)", net.Alice,
 		aliceFundPoint, amountPaid, int64(0))
 
 	ctxt, _ = context.WithTimeout(ctxb, channelCloseTimeout)
@@ -4140,13 +4142,13 @@ func testMultiHopSendToRoute(net *lntest.NetworkHarness, t *harnessTest) {
 	// transaction, in channel Alice->Bob->Carol, order is Carol, Bob,
 	// Alice.
 	const amountPaid = int64(5000)
-	assertAmountPaid(t, ctxb, "Bob(local) => Carol(remote)", carol,
+	assertAmountPaid(t, "Bob(local) => Carol(remote)", carol,
 		bobFundPoint, int64(0), amountPaid)
-	assertAmountPaid(t, ctxb, "Bob(local) => Carol(remote)", net.Bob,
+	assertAmountPaid(t, "Bob(local) => Carol(remote)", net.Bob,
 		bobFundPoint, amountPaid, int64(0))
-	assertAmountPaid(t, ctxb, "Alice(local) => Bob(remote)", net.Bob,
+	assertAmountPaid(t, "Alice(local) => Bob(remote)", net.Bob,
 		aliceFundPoint, int64(0), amountPaid+(baseFee*numPayments))
-	assertAmountPaid(t, ctxb, "Alice(local) => Bob(remote)", net.Alice,
+	assertAmountPaid(t, "Alice(local) => Bob(remote)", net.Alice,
 		aliceFundPoint, amountPaid+(baseFee*numPayments), int64(0))
 
 	ctxt, _ = context.WithTimeout(ctxb, channelCloseTimeout)
@@ -4622,35 +4624,35 @@ func testPrivateChannels(net *lntest.NetworkHarness, t *harnessTest) {
 	const baseFee = 1
 
 	// Bob should have received 140k satoshis from Alice.
-	assertAmountPaid(t, ctxb, "Alice(local) => Bob(remote)", net.Bob,
+	assertAmountPaid(t, "Alice(local) => Bob(remote)", net.Bob,
 		aliceFundPoint, int64(0), 2*paymentAmt)
 
 	// Alice sent 140k to Bob.
-	assertAmountPaid(t, ctxb, "Alice(local) => Bob(remote)", net.Alice,
+	assertAmountPaid(t, "Alice(local) => Bob(remote)", net.Alice,
 		aliceFundPoint, 2*paymentAmt, int64(0))
 
 	// Alice received 70k + fee from Dave.
-	assertAmountPaid(t, ctxb, "Dave(local) => Alice(remote)", net.Alice,
+	assertAmountPaid(t, "Dave(local) => Alice(remote)", net.Alice,
 		daveFundPoint, int64(0), paymentAmt+baseFee)
 
 	// Dave sent 70k+fee to Alice.
-	assertAmountPaid(t, ctxb, "Dave(local) => Alice(remote)", dave,
+	assertAmountPaid(t, "Dave(local) => Alice(remote)", dave,
 		daveFundPoint, paymentAmt+baseFee, int64(0))
 
 	// Dave received 70k+fee of two hops from Carol.
-	assertAmountPaid(t, ctxb, "Carol(local) => Dave(remote)", dave,
+	assertAmountPaid(t, "Carol(local) => Dave(remote)", dave,
 		carolFundPoint, int64(0), paymentAmt+baseFee*2)
 
 	// Carol sent 70k+fee of two hops to Dave.
-	assertAmountPaid(t, ctxb, "Carol(local) => Dave(remote)", carol,
+	assertAmountPaid(t, "Carol(local) => Dave(remote)", carol,
 		carolFundPoint, paymentAmt+baseFee*2, int64(0))
 
 	// Alice received 70k+fee from Carol.
-	assertAmountPaid(t, ctxb, "Carol(local) [private=>] Alice(remote)",
+	assertAmountPaid(t, "Carol(local) [private=>] Alice(remote)",
 		net.Alice, privateFundPoint, int64(0), paymentAmt+baseFee)
 
 	// Carol sent 70k+fee to Alice.
-	assertAmountPaid(t, ctxb, "Carol(local) [private=>] Alice(remote)",
+	assertAmountPaid(t, "Carol(local) [private=>] Alice(remote)",
 		carol, privateFundPoint, paymentAmt+baseFee, int64(0))
 
 	// Alice should also be able to route payments using this channel,
@@ -5155,27 +5157,27 @@ func testMultiHopOverPrivateChannels(net *lntest.NetworkHarness, t *harnessTest)
 	const baseFee = 1
 
 	// Dave should have received 20k satoshis from Carol.
-	assertAmountPaid(t, ctxb, "Carol(local) [private=>] Dave(remote)",
+	assertAmountPaid(t, "Carol(local) [private=>] Dave(remote)",
 		dave, carolFundPoint, 0, paymentAmt)
 
 	// Carol should have sent 20k satoshis to Dave.
-	assertAmountPaid(t, ctxb, "Carol(local) [private=>] Dave(remote)",
+	assertAmountPaid(t, "Carol(local) [private=>] Dave(remote)",
 		carol, carolFundPoint, paymentAmt, 0)
 
 	// Carol should have received 20k satoshis + fee for one hop from Bob.
-	assertAmountPaid(t, ctxb, "Bob(local) => Carol(remote)",
+	assertAmountPaid(t, "Bob(local) => Carol(remote)",
 		carol, bobFundPoint, 0, paymentAmt+baseFee)
 
 	// Bob should have sent 20k satoshis + fee for one hop to Carol.
-	assertAmountPaid(t, ctxb, "Bob(local) => Carol(remote)",
+	assertAmountPaid(t, "Bob(local) => Carol(remote)",
 		net.Bob, bobFundPoint, paymentAmt+baseFee, 0)
 
 	// Bob should have received 20k satoshis + fee for two hops from Alice.
-	assertAmountPaid(t, ctxb, "Alice(local) [private=>] Bob(remote)", net.Bob,
+	assertAmountPaid(t, "Alice(local) [private=>] Bob(remote)", net.Bob,
 		aliceFundPoint, 0, paymentAmt+baseFee*2)
 
 	// Alice should have sent 20k satoshis + fee for two hops to Bob.
-	assertAmountPaid(t, ctxb, "Alice(local) [private=>] Bob(remote)", net.Alice,
+	assertAmountPaid(t, "Alice(local) [private=>] Bob(remote)", net.Alice,
 		aliceFundPoint, paymentAmt+baseFee*2, 0)
 
 	// At this point, the payment was successful. We can now close all the
@@ -10526,17 +10528,17 @@ func testSwitchCircuitPersistence(net *lntest.NetworkHarness, t *harnessTest) {
 	// transaction, in channel Bob->Alice->David->Carol, order is Carol,
 	// David, Alice, Bob.
 	var amountPaid = int64(5000)
-	assertAmountPaid(t, ctxb, "Dave(local) => Carol(remote)", carol,
+	assertAmountPaid(t, "Dave(local) => Carol(remote)", carol,
 		carolFundPoint, int64(0), amountPaid)
-	assertAmountPaid(t, ctxb, "Dave(local) => Carol(remote)", dave,
+	assertAmountPaid(t, "Dave(local) => Carol(remote)", dave,
 		carolFundPoint, amountPaid, int64(0))
-	assertAmountPaid(t, ctxb, "Alice(local) => Dave(remote)", dave,
+	assertAmountPaid(t, "Alice(local) => Dave(remote)", dave,
 		daveFundPoint, int64(0), amountPaid+(baseFee*numPayments))
-	assertAmountPaid(t, ctxb, "Alice(local) => Dave(remote)", net.Alice,
+	assertAmountPaid(t, "Alice(local) => Dave(remote)", net.Alice,
 		daveFundPoint, amountPaid+(baseFee*numPayments), int64(0))
-	assertAmountPaid(t, ctxb, "Bob(local) => Alice(remote)", net.Alice,
+	assertAmountPaid(t, "Bob(local) => Alice(remote)", net.Alice,
 		aliceFundPoint, int64(0), amountPaid+((baseFee*numPayments)*2))
-	assertAmountPaid(t, ctxb, "Bob(local) => Alice(remote)", net.Bob,
+	assertAmountPaid(t, "Bob(local) => Alice(remote)", net.Bob,
 		aliceFundPoint, amountPaid+(baseFee*numPayments)*2, int64(0))
 
 	// Lastly, we will send one more payment to ensure all channels are
@@ -10561,17 +10563,17 @@ func testSwitchCircuitPersistence(net *lntest.NetworkHarness, t *harnessTest) {
 	}
 
 	amountPaid = int64(6000)
-	assertAmountPaid(t, ctxb, "Dave(local) => Carol(remote)", carol,
+	assertAmountPaid(t, "Dave(local) => Carol(remote)", carol,
 		carolFundPoint, int64(0), amountPaid)
-	assertAmountPaid(t, ctxb, "Dave(local) => Carol(remote)", dave,
+	assertAmountPaid(t, "Dave(local) => Carol(remote)", dave,
 		carolFundPoint, amountPaid, int64(0))
-	assertAmountPaid(t, ctxb, "Alice(local) => Dave(remote)", dave,
+	assertAmountPaid(t, "Alice(local) => Dave(remote)", dave,
 		daveFundPoint, int64(0), amountPaid+(baseFee*(numPayments+1)))
-	assertAmountPaid(t, ctxb, "Alice(local) => Dave(remote)", net.Alice,
+	assertAmountPaid(t, "Alice(local) => Dave(remote)", net.Alice,
 		daveFundPoint, amountPaid+(baseFee*(numPayments+1)), int64(0))
-	assertAmountPaid(t, ctxb, "Bob(local) => Alice(remote)", net.Alice,
+	assertAmountPaid(t, "Bob(local) => Alice(remote)", net.Alice,
 		aliceFundPoint, int64(0), amountPaid+((baseFee*(numPayments+1))*2))
-	assertAmountPaid(t, ctxb, "Bob(local) => Alice(remote)", net.Bob,
+	assertAmountPaid(t, "Bob(local) => Alice(remote)", net.Bob,
 		aliceFundPoint, amountPaid+(baseFee*(numPayments+1))*2, int64(0))
 
 	ctxt, _ = context.WithTimeout(ctxb, channelCloseTimeout)
@@ -10867,17 +10869,17 @@ func testSwitchOfflineDelivery(net *lntest.NetworkHarness, t *harnessTest) {
 	// transaction, in channel Bob->Alice->David->Carol, order is Carol,
 	// David, Alice, Bob.
 	var amountPaid = int64(5000)
-	assertAmountPaid(t, ctxb, "Dave(local) => Carol(remote)", carol,
+	assertAmountPaid(t, "Dave(local) => Carol(remote)", carol,
 		carolFundPoint, int64(0), amountPaid)
-	assertAmountPaid(t, ctxb, "Dave(local) => Carol(remote)", dave,
+	assertAmountPaid(t, "Dave(local) => Carol(remote)", dave,
 		carolFundPoint, amountPaid, int64(0))
-	assertAmountPaid(t, ctxb, "Alice(local) => Dave(remote)", dave,
+	assertAmountPaid(t, "Alice(local) => Dave(remote)", dave,
 		daveFundPoint, int64(0), amountPaid+(baseFee*numPayments))
-	assertAmountPaid(t, ctxb, "Alice(local) => Dave(remote)", net.Alice,
+	assertAmountPaid(t, "Alice(local) => Dave(remote)", net.Alice,
 		daveFundPoint, amountPaid+(baseFee*numPayments), int64(0))
-	assertAmountPaid(t, ctxb, "Bob(local) => Alice(remote)", net.Alice,
+	assertAmountPaid(t, "Bob(local) => Alice(remote)", net.Alice,
 		aliceFundPoint, int64(0), amountPaid+((baseFee*numPayments)*2))
-	assertAmountPaid(t, ctxb, "Bob(local) => Alice(remote)", net.Bob,
+	assertAmountPaid(t, "Bob(local) => Alice(remote)", net.Bob,
 		aliceFundPoint, amountPaid+(baseFee*numPayments)*2, int64(0))
 
 	// Lastly, we will send one more payment to ensure all channels are
@@ -10902,17 +10904,17 @@ func testSwitchOfflineDelivery(net *lntest.NetworkHarness, t *harnessTest) {
 	}
 
 	amountPaid = int64(6000)
-	assertAmountPaid(t, ctxb, "Dave(local) => Carol(remote)", carol,
+	assertAmountPaid(t, "Dave(local) => Carol(remote)", carol,
 		carolFundPoint, int64(0), amountPaid)
-	assertAmountPaid(t, ctxb, "Dave(local) => Carol(remote)", dave,
+	assertAmountPaid(t, "Dave(local) => Carol(remote)", dave,
 		carolFundPoint, amountPaid, int64(0))
-	assertAmountPaid(t, ctxb, "Alice(local) => Dave(remote)", dave,
+	assertAmountPaid(t, "Alice(local) => Dave(remote)", dave,
 		daveFundPoint, int64(0), amountPaid+(baseFee*(numPayments+1)))
-	assertAmountPaid(t, ctxb, "Alice(local) => Dave(remote)", net.Alice,
+	assertAmountPaid(t, "Alice(local) => Dave(remote)", net.Alice,
 		daveFundPoint, amountPaid+(baseFee*(numPayments+1)), int64(0))
-	assertAmountPaid(t, ctxb, "Bob(local) => Alice(remote)", net.Alice,
+	assertAmountPaid(t, "Bob(local) => Alice(remote)", net.Alice,
 		aliceFundPoint, int64(0), amountPaid+((baseFee*(numPayments+1))*2))
-	assertAmountPaid(t, ctxb, "Bob(local) => Alice(remote)", net.Bob,
+	assertAmountPaid(t, "Bob(local) => Alice(remote)", net.Bob,
 		aliceFundPoint, amountPaid+(baseFee*(numPayments+1))*2, int64(0))
 
 	ctxt, _ = context.WithTimeout(ctxb, channelCloseTimeout)
@@ -11207,17 +11209,17 @@ func testSwitchOfflineDeliveryPersistence(net *lntest.NetworkHarness, t *harness
 	// transaction, in channel Bob->Alice->David->Carol, order is Carol,
 	// David, Alice, Bob.
 	var amountPaid = int64(5000)
-	assertAmountPaid(t, ctxb, "Dave(local) => Carol(remote)", carol,
+	assertAmountPaid(t, "Dave(local) => Carol(remote)", carol,
 		carolFundPoint, int64(0), amountPaid)
-	assertAmountPaid(t, ctxb, "Dave(local) => Carol(remote)", dave,
+	assertAmountPaid(t, "Dave(local) => Carol(remote)", dave,
 		carolFundPoint, amountPaid, int64(0))
-	assertAmountPaid(t, ctxb, "Alice(local) => Dave(remote)", dave,
+	assertAmountPaid(t, "Alice(local) => Dave(remote)", dave,
 		daveFundPoint, int64(0), amountPaid+(baseFee*numPayments))
-	assertAmountPaid(t, ctxb, "Alice(local) => Dave(remote)", net.Alice,
+	assertAmountPaid(t, "Alice(local) => Dave(remote)", net.Alice,
 		daveFundPoint, amountPaid+(baseFee*numPayments), int64(0))
-	assertAmountPaid(t, ctxb, "Bob(local) => Alice(remote)", net.Alice,
+	assertAmountPaid(t, "Bob(local) => Alice(remote)", net.Alice,
 		aliceFundPoint, int64(0), amountPaid+((baseFee*numPayments)*2))
-	assertAmountPaid(t, ctxb, "Bob(local) => Alice(remote)", net.Bob,
+	assertAmountPaid(t, "Bob(local) => Alice(remote)", net.Bob,
 		aliceFundPoint, amountPaid+(baseFee*numPayments)*2, int64(0))
 
 	// Lastly, we will send one more payment to ensure all channels are
@@ -11250,17 +11252,17 @@ func testSwitchOfflineDeliveryPersistence(net *lntest.NetworkHarness, t *harness
 	}
 
 	amountPaid = int64(6000)
-	assertAmountPaid(t, ctxb, "Dave(local) => Carol(remote)", carol,
+	assertAmountPaid(t, "Dave(local) => Carol(remote)", carol,
 		carolFundPoint, int64(0), amountPaid)
-	assertAmountPaid(t, ctxb, "Dave(local) => Carol(remote)", dave,
+	assertAmountPaid(t, "Dave(local) => Carol(remote)", dave,
 		carolFundPoint, amountPaid, int64(0))
-	assertAmountPaid(t, ctxb, "Alice(local) => Dave(remote)", dave,
+	assertAmountPaid(t, "Alice(local) => Dave(remote)", dave,
 		daveFundPoint, int64(0), amountPaid+(baseFee*(numPayments+1)))
-	assertAmountPaid(t, ctxb, "Alice(local) => Dave(remote)", net.Alice,
+	assertAmountPaid(t, "Alice(local) => Dave(remote)", net.Alice,
 		daveFundPoint, amountPaid+(baseFee*(numPayments+1)), int64(0))
-	assertAmountPaid(t, ctxb, "Bob(local) => Alice(remote)", net.Alice,
+	assertAmountPaid(t, "Bob(local) => Alice(remote)", net.Alice,
 		aliceFundPoint, int64(0), amountPaid+((baseFee*(numPayments+1))*2))
-	assertAmountPaid(t, ctxb, "Bob(local) => Alice(remote)", net.Bob,
+	assertAmountPaid(t, "Bob(local) => Alice(remote)", net.Bob,
 		aliceFundPoint, amountPaid+(baseFee*(numPayments+1))*2, int64(0))
 
 	ctxt, _ = context.WithTimeout(ctxb, channelCloseTimeout)
@@ -11508,9 +11510,9 @@ func testSwitchOfflineDeliveryOutgoingOffline(
 	// The amount transferred should be exactly equal to the invoice total
 	// payment amount, 5k satsohis.
 	const amountPaid = int64(5000)
-	assertAmountPaid(t, ctxb, "Dave(local) => Carol(remote)", carol,
+	assertAmountPaid(t, "Dave(local) => Carol(remote)", carol,
 		carolFundPoint, int64(0), amountPaid)
-	assertAmountPaid(t, ctxb, "Dave(local) => Carol(remote)", dave,
+	assertAmountPaid(t, "Dave(local) => Carol(remote)", dave,
 		carolFundPoint, amountPaid, int64(0))
 
 	// Shutdown carol and leave her offline for the rest of the test. This
@@ -11559,13 +11561,13 @@ func testSwitchOfflineDeliveryOutgoingOffline(
 	// corresponds to increasing of time is needed to embed the HTLC in
 	// commitment transaction, in channel Bob->Alice->David, order is David,
 	// Alice, Bob.
-	assertAmountPaid(t, ctxb, "Alice(local) => Dave(remote)", dave,
+	assertAmountPaid(t, "Alice(local) => Dave(remote)", dave,
 		daveFundPoint, int64(0), amountPaid+(baseFee*numPayments))
-	assertAmountPaid(t, ctxb, "Alice(local) => Dave(remote)", net.Alice,
+	assertAmountPaid(t, "Alice(local) => Dave(remote)", net.Alice,
 		daveFundPoint, amountPaid+(baseFee*numPayments), int64(0))
-	assertAmountPaid(t, ctxb, "Bob(local) => Alice(remote)", net.Alice,
+	assertAmountPaid(t, "Bob(local) => Alice(remote)", net.Alice,
 		aliceFundPoint, int64(0), amountPaid+((baseFee*numPayments)*2))
-	assertAmountPaid(t, ctxb, "Bob(local) => Alice(remote)", net.Bob,
+	assertAmountPaid(t, "Bob(local) => Alice(remote)", net.Bob,
 		aliceFundPoint, amountPaid+(baseFee*numPayments)*2, int64(0))
 
 	ctxt, _ = context.WithTimeout(ctxb, channelCloseTimeout)


### PR DESCRIPTION
This PR is split off from #1621 (Split chain backend and miner).

It is a pure integration test change:
1. Extracting various `timeout` and `CSV` parameters into common constants
2. Fix up some usages of `context.Background` which would stall the tests in certain cases
3. Fixes a few flakes caused by transaction leftover from previous test cases. 
4. Make sure the tests don't fail because a chain backend is still syncing after a restart
5. Various small cleanups.

Builds on:
- [x] https://github.com/lightningnetwork/lnd/pull/2153
- [x] https://github.com/lightningnetwork/lnd/pull/2156
- [x] https://github.com/lightningnetwork/lnd/pull/2157
- [x] https://github.com/lightningnetwork/lnd/pull/2158
- [x] https://github.com/lightningnetwork/lnd/pull/2159
- [x] https://github.com/lightningnetwork/lnd/pull/2160
- [x] #2224 
- [x] #2225 
- [x] https://github.com/lightningnetwork/lnd/pull/2229
- [x] https://github.com/lightningnetwork/lnd/pull/2230