### PR TITLE
Save integration tests backend logs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,7 +29,9 @@ lnd-debug
 lncli
 lncli-debug
 
+# Integration test log files
 output*.log
+/.backendlogs
 
 cmd/cmd
 *.key

--- a/lnd_test.go
+++ b/lnd_test.go
@@ -12516,7 +12516,13 @@ func TestLightningNetworkDaemon(t *testing.T) {
 	// setting of accepting non-standard transactions on simnet to reject them.
 	// Transactions on the lightning network should always be standard to get
 	// better guarantees of getting included in to blocks.
-	args := []string{"--rejectnonstd", "--txindex"}
+	logDir := "./.backendlogs"
+	args := []string{
+		"--rejectnonstd",
+		"--txindex",
+		"--debuglevel=debug",
+		"--logdir=" + logDir,
+	}
 	handlers := &rpcclient.NotificationHandlers{
 		OnTxAccepted: func(hash *chainhash.Hash, amt btcutil.Amount) {
 			lndHarness.OnTxAccepted(hash)
@@ -12526,7 +12532,21 @@ func TestLightningNetworkDaemon(t *testing.T) {
 	if err != nil {
 		ht.Fatalf("unable to create mining node: %v", err)
 	}
-	defer btcdHarness.TearDown()
+	defer func() {
+		btcdHarness.TearDown()
+
+		// After shutting down the chain backend, we'll make a copy of
+		// the log file before deleting the temporary log dir.
+		logFile := logDir + "/" + harnessNetParams.Name + "/btcd.log"
+		err := lntest.CopyFile("./output_btcd_chainbackend.log",
+			logFile)
+		if err != nil {
+			fmt.Printf("unable to copy file: %v\n", err)
+		}
+		if err = os.RemoveAll(logDir); err != nil {
+			fmt.Printf("Cannot remove dir %s: %v\n", logDir, err)
+		}
+	}()
 
 	// First create the network harness to gain access to its
 	// 'OnTxAccepted' call back.

--- a/lnd_test.go
+++ b/lnd_test.go
@@ -5522,26 +5522,6 @@ func testMaxPendingChannels(net *lntest.NetworkHarness, t *harnessTest) {
 	}
 }
 
-func copyFile(dest, src string) error {
-	s, err := os.Open(src)
-	if err != nil {
-		return err
-	}
-	defer s.Close()
-
-	d, err := os.Create(dest)
-	if err != nil {
-		return err
-	}
-
-	if _, err := io.Copy(d, s); err != nil {
-		d.Close()
-		return err
-	}
-
-	return d.Close()
-}
-
 // waitForTxInMempool polls until finding one transaction in the provided
 // miner's mempool. An error is returned if *one* transaction isn't found within
 // the given timeout.
@@ -6154,7 +6134,7 @@ func testRevokedCloseRetribution(net *lntest.NetworkHarness, t *harnessTest) {
 	// With the temporary file created, copy Bob's current state into the
 	// temporary file we created above. Later after more updates, we'll
 	// restore this state.
-	if err := copyFile(bobTempDbFile, net.Bob.DBPath()); err != nil {
+	if err := lntest.CopyFile(bobTempDbFile, net.Bob.DBPath()); err != nil {
 		t.Fatalf("unable to copy database files: %v", err)
 	}
 
@@ -6394,7 +6374,7 @@ func testRevokedCloseRetributionZeroValueRemoteOutput(net *lntest.NetworkHarness
 	// With the temporary file created, copy Carol's current state into the
 	// temporary file we created above. Later after more updates, we'll
 	// restore this state.
-	if err := copyFile(carolTempDbFile, carol.DBPath()); err != nil {
+	if err := lntest.CopyFile(carolTempDbFile, carol.DBPath()); err != nil {
 		t.Fatalf("unable to copy database files: %v", err)
 	}
 
@@ -6710,7 +6690,7 @@ func testRevokedCloseRetributionRemoteHodl(net *lntest.NetworkHarness,
 	// With the temporary file created, copy Carol's current state into the
 	// temporary file we created above. Later after more updates, we'll
 	// restore this state.
-	if err := copyFile(carolTempDbFile, carol.DBPath()); err != nil {
+	if err := lntest.CopyFile(carolTempDbFile, carol.DBPath()); err != nil {
 		t.Fatalf("unable to copy database files: %v", err)
 	}
 
@@ -7110,7 +7090,7 @@ func testDataLossProtection(net *lntest.NetworkHarness, t *harnessTest) {
 		// With the temporary file created, copy the current state into
 		// the temporary file we created above. Later after more
 		// updates, we'll restore this state.
-		if err := copyFile(tempDbFile, node.DBPath()); err != nil {
+		if err := lntest.CopyFile(tempDbFile, node.DBPath()); err != nil {
 			t.Fatalf("unable to copy database files: %v", err)
 		}
 

--- a/lntest/harness.go
+++ b/lntest/harness.go
@@ -3,7 +3,9 @@ package lntest
 import (
 	"errors"
 	"fmt"
+	"io"
 	"io/ioutil"
+	"os"
 	"strings"
 	"sync"
 	"time"
@@ -1265,4 +1267,25 @@ func (n *NetworkHarness) sendCoins(ctx context.Context, amt btcutil.Amount,
 
 	expectedBalance := initialBalance.ConfirmedBalance + int64(amt)
 	return target.WaitForBalance(expectedBalance, true)
+}
+
+// CopyFile copies the file src to dest.
+func CopyFile(dest, src string) error {
+	s, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer s.Close()
+
+	d, err := os.Create(dest)
+	if err != nil {
+		return err
+	}
+
+	if _, err := io.Copy(d, s); err != nil {
+		d.Close()
+		return err
+	}
+
+	return d.Close()
 }


### PR DESCRIPTION
Split off from https://github.com/lightningnetwork/lnd/pull/1621.

This PR saves the `btcd` chainbackend/miner debug logs from a test run, which is useful when debugging integration test failures.