### PR TITLE
make: ensure make fmt is run with -s flag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,6 +36,7 @@ GOBUILD := go build -v
 GOINSTALL := go install -v
 GOTEST := go test -v
 
+GOFILES_NOVENDOR = $(shell find . -type f -name '*.go' -not -path "./vendor/*")
 GOLIST := go list $(PKG)/... | grep -v '/vendor/'
 GOLISTCOVER := $(shell go list -f '{{.ImportPath}}' ./... | sed -e 's/^$(ESCPKG)/./')
 GOLISTLINT := $(shell go list -f '{{.Dir}}' ./... | grep -v 'lnrpc')
@@ -211,7 +212,7 @@ endif
 
 fmt:
 	@$(call print, "Formatting source.")
-	$(GOLIST) | $(XARGS) go fmt -x
+	gofmt -l -w -s $(GOFILES_NOVENDOR)
 
 lint: $(LINT_BIN)
 	@$(call print, "Linting source.")


### PR DESCRIPTION
Another attempt at https://github.com/lightningnetwork/lnd/pull/2092. The previous one would fail travis because of the removal of `XARGS` and `GOLIST` (used by `testing_flags.mk`).

Linting will fail if code is not formatted with the -s flag, so make
sure we always use it when formatting.