### PR TITLE
Remote Tor server support

### DIFF
--- a/config.go
+++ b/config.go
@@ -935,8 +935,8 @@ func loadConfig() (*config, error) {
 	}
 
 	// Finally, ensure that we are only listening on localhost if Tor
-	// inbound support is enabled.
-	if cfg.Tor.V2 || cfg.Tor.V3 {
+	// inbound support via Tor on localhost is enabled.
+	if (cfg.Tor.V2 || cfg.Tor.V3) && lncfg.IsLoopback(cfg.Tor.SOCKS) {
 		for _, addr := range cfg.Listeners {
 			if lncfg.IsLoopback(addr.String()) {
 				continue
@@ -944,7 +944,7 @@ func loadConfig() (*config, error) {
 
 			return nil, errors.New("lnd must *only* be listening " +
 				"on localhost when running with Tor inbound " +
-				"support enabled")
+				"support enabled, and Tor on localhost")
 		}
 	}
 

--- a/server.go
+++ b/server.go
@@ -1513,7 +1513,7 @@ func (s *server) initTorController() error {
 	// Now that the onion service has been created, we'll add the onion
 	// address it can be reached at to our list of advertised addresses.
 	s.currentNodeAnn.Addresses = append(s.currentNodeAnn.Addresses, addr)
-	srvrLog.Infof("added tor service %v mapping to %v", addr, listeners)
+
 	return nil
 }
 

--- a/server.go
+++ b/server.go
@@ -1483,19 +1483,19 @@ func (s *server) initTorController() error {
 	// Determine the different ports the server is listening on. The onion
 	// service's virtual port will map to these ports and one will be picked
 	// at random when the onion service is being accessed.
-	listenPorts := make([]int, 0, len(s.listenAddrs))
+	listeners := make([]string, 0, len(s.listenAddrs))
 	for _, listenAddr := range s.listenAddrs {
-		port := listenAddr.(*net.TCPAddr).Port
-		listenPorts = append(listenPorts, port)
+		listener := listenAddr.(*net.TCPAddr).String()
+		listeners = append(listeners, listener)
 	}
 
 	// Once the port mapping has been set, we can go ahead and automatically
 	// create our onion service. The service's private key will be saved to
 	// disk in order to regain access to this service when restarting `lnd`.
 	onionCfg := tor.AddOnionConfig{
-		VirtualPort:    defaultPeerPort,
-		TargetPorts:    listenPorts,
-		PrivateKeyPath: cfg.Tor.PrivateKeyPath,
+		VirtualPort:     defaultPeerPort,
+		TargetListeners: listeners,
+		PrivateKeyPath:  cfg.Tor.PrivateKeyPath,
 	}
 
 	switch {
@@ -1513,7 +1513,7 @@ func (s *server) initTorController() error {
 	// Now that the onion service has been created, we'll add the onion
 	// address it can be reached at to our list of advertised addresses.
 	s.currentNodeAnn.Addresses = append(s.currentNodeAnn.Addresses, addr)
-
+	srvrLog.Infof("added tor service %v mapping to %v", addr, listeners)
 	return nil
 }
 

--- a/tor/controller.go
+++ b/tor/controller.go
@@ -163,7 +163,8 @@ func parseTorReply(reply string) map[string]string {
 }
 
 // authenticate authenticates the connection between the controller and the
-// Tor server using the SAFECOOKIE authentication method.
+// Tor server using the SAFECOOKIE or HASHEDCONTROLPASSWORD authentication
+// method.
 func (c *Controller) authenticate() error {
 	// Before proceeding to authenticate the connection, we'll retrieve
 	// the authentication cookie of the Tor server. This will be used
@@ -412,13 +413,13 @@ type AddOnionConfig struct {
 	// VirtualPort is the externally reachable port of the onion address.
 	VirtualPort int
 
-	// TargetPorts is the set of ports that the service will be listening on
-	// locally. The Tor server will use choose a random port from this set
-	// to forward the traffic from the virtual port.
+	// TargetListeners is the set of Listeners that the service will be
+	// listening on locally. The Tor server will use choose a random port
+	// from this set to forward the traffic from the virtual port.
 	//
 	// NOTE: If nil/empty, the virtual port will be used as the only target
 	// port.
-	TargetPorts []int
+	TargetListeners []string
 
 	// PrivateKeyPath is the full path to where the onion service's private
 	// key is stored. This can be used to restore an existing onion service.
@@ -462,13 +463,13 @@ func (c *Controller) AddOnion(cfg AddOnionConfig) (*OnionAddr, error) {
 	// port. If no target ports were specified, we'll use the virtual port
 	// to provide a one-to-one mapping.
 	var portParam string
-	if len(cfg.TargetPorts) == 0 {
+	if len(cfg.TargetListeners) == 0 {
 		portParam += fmt.Sprintf("Port=%d,%d ", cfg.VirtualPort,
 			cfg.VirtualPort)
 	} else {
-		for _, targetPort := range cfg.TargetPorts {
-			portParam += fmt.Sprintf("Port=%d,%d ", cfg.VirtualPort,
-				targetPort)
+		for _, targetListener := range cfg.TargetListeners {
+			portParam += fmt.Sprintf("Port=%d,%v ", cfg.VirtualPort,
+				targetListener)
 		}
 	}
 


### PR DESCRIPTION
Enables configurations where Tor is running on a remote server by 

a) allowing non-localhost listeners if Tor is not on localhost
b) including the IP of the listener in onion-setup

 As requested in #2073 a partial pr for this functionality only