### PR TITLE
[watchtower/blob] variable length sweep addr

### DIFF
--- a/watchtower/blob/justice_kit_test.go
+++ b/watchtower/blob/justice_kit_test.go
@@ -27,7 +27,7 @@ func makeSig(i int) lnwire.Sig {
 	return sig
 }
 
-var descriptorTests = []struct {
+type descriptorTest struct {
 	name                 string
 	encVersion           uint16
 	decVersion           uint16
@@ -40,7 +40,9 @@ var descriptorTests = []struct {
 	commitToRemoteSig    lnwire.Sig
 	encErr               error
 	decErr               error
-}{
+}
+
+var descriptorTests = []descriptorTest{
 	{
 		name:             "to-local only",
 		encVersion:       0,
@@ -89,82 +91,80 @@ var descriptorTests = []struct {
 // when passed invalid combinations, and that all successfully encrypted blobs
 // are of constant size.
 func TestBlobJusticeKitEncryptDecrypt(t *testing.T) {
-	for i, test := range descriptorTests {
-		boj := &blob.JusticeKit{
-			RevocationPubKey:     test.revPubKey,
-			LocalDelayPubKey:     test.delayPubKey,
-			CSVDelay:             test.csvDelay,
-			CommitToLocalSig:     test.commitToLocalSig,
-			CommitToRemotePubKey: test.commitToRemotePubKey,
-			CommitToRemoteSig:    test.commitToRemoteSig,
-		}
+	for _, test := range descriptorTests {
+		t.Run(test.name, func(t *testing.T) {
+			testBlobJusticeKitEncryptDecrypt(t, test)
+		})
+	}
+}
 
-		// Generate a random encryption key for the blob. The key is
-		// sized at 32 byte, as in practice we will be using the remote
-		// party's commitment txid as the key.
-		key := make([]byte, blob.KeySize)
-		_, err := io.ReadFull(rand.Reader, key)
-		if err != nil {
-			t.Fatalf("test #%d %s -- unable to generate blob "+
-				"encryption key: %v", i, test.name, err)
-		}
+func testBlobJusticeKitEncryptDecrypt(t *testing.T, test descriptorTest) {
+	boj := &blob.JusticeKit{
+		RevocationPubKey:     test.revPubKey,
+		LocalDelayPubKey:     test.delayPubKey,
+		CSVDelay:             test.csvDelay,
+		CommitToLocalSig:     test.commitToLocalSig,
+		CommitToRemotePubKey: test.commitToRemotePubKey,
+		CommitToRemoteSig:    test.commitToRemoteSig,
+	}
 
-		nonce := make([]byte, blob.NonceSize)
-		_, err = io.ReadFull(rand.Reader, nonce)
-		if err != nil {
-			t.Fatalf("test #%d %s -- unable to generate nonce "+
-				"nonce: %v", i, test.name, err)
-		}
+	// Generate a random encryption key for the blob. The key is
+	// sized at 32 byte, as in practice we will be using the remote
+	// party's commitment txid as the key.
+	key := make([]byte, blob.KeySize)
+	_, err := io.ReadFull(rand.Reader, key)
+	if err != nil {
+		t.Fatalf("unable to generate blob encryption key: %v", err)
+	}
 
-		// Encrypt the blob plaintext using the generated key and
-		// target version for this test.
-		ctxt, err := boj.Encrypt(nonce, key, test.encVersion)
-		if err != test.encErr {
-			t.Fatalf("test #%d %s -- unable to encrypt blob: %v",
-				i, test.name, err)
-		} else if test.encErr != nil {
-			// If the test expected an encryption failure, we can
-			// continue to the next test.
-			continue
-		}
+	nonce := make([]byte, blob.NonceSize)
+	_, err = io.ReadFull(rand.Reader, nonce)
+	if err != nil {
+		t.Fatalf("unable to generate nonce nonce: %v", err)
+	}
 
-		// Ensure that all encrypted blobs are padded out to the same
-		// size: 282 bytes for version 0.
-		if len(ctxt) != blob.Size(test.encVersion) {
-			t.Fatalf("test #%d %s -- expected blob to have "+
-				"size %d, got %d instead", i, test.name,
-				blob.Size(test.encVersion), len(ctxt))
+	// Encrypt the blob plaintext using the generated key and
+	// target version for this test.
+	ctxt, err := boj.Encrypt(nonce, key, test.encVersion)
+	if err != test.encErr {
+		t.Fatalf("unable to encrypt blob: %v", err)
+	} else if test.encErr != nil {
+		// If the test expected an encryption failure, we can
+		// continue to the next test.
+		return
+	}
 
-		}
+	// Ensure that all encrypted blobs are padded out to the same
+	// size: 282 bytes for version 0.
+	if len(ctxt) != blob.Size(test.encVersion) {
+		t.Fatalf("expected blob to have size %d, got %d instead",
+			blob.Size(test.encVersion), len(ctxt))
 
-		// Decrypt the encrypted blob, reconstructing the original
-		// blob plaintext from the decrypted contents. We use the target
-		// decryption version specified by this test case.
-		boj2, err := blob.Decrypt(nonce, key, ctxt, test.decVersion)
-		if err != test.decErr {
-			t.Fatalf("test #%d %s -- unable to decrypt blob: %v",
-				i, test.name, err)
-		} else if test.decErr != nil {
-			// If the test expected an decryption failure, we can
-			// continue to the next test.
-			continue
-		}
+	}
 
-		// Check that the decrypted blob properly reports whether it has
-		// a to-remote output or not.
-		if boj2.HasCommitToRemoteOutput() != test.hasCommitToRemote {
-			t.Fatalf("test #%d %s -- expected blob has_to_remote "+
-				"to be %v, got %v", i, test.name,
-				test.hasCommitToRemote,
-				boj2.HasCommitToRemoteOutput())
-		}
+	// Decrypt the encrypted blob, reconstructing the original
+	// blob plaintext from the decrypted contents. We use the target
+	// decryption version specified by this test case.
+	boj2, err := blob.Decrypt(nonce, key, ctxt, test.decVersion)
+	if err != test.decErr {
+		t.Fatalf("unable to decrypt blob: %v", err)
+	} else if test.decErr != nil {
+		// If the test expected an decryption failure, we can
+		// continue to the next test.
+		return
+	}
 
-		// Check that the original blob plaintext matches the
-		// one reconstructed from the encrypted blob.
-		if !reflect.DeepEqual(boj, boj2) {
-			t.Fatalf("test #%d %s -- decrypted plaintext does not "+
-				"match original, want: %v, got %v",
-				i, test.name, boj, boj2)
-		}
+	// Check that the decrypted blob properly reports whether it has
+	// a to-remote output or not.
+	if boj2.HasCommitToRemoteOutput() != test.hasCommitToRemote {
+		t.Fatalf("expected blob has_to_remote to be %v, got %v",
+			test.hasCommitToRemote, boj2.HasCommitToRemoteOutput())
+	}
+
+	// Check that the original blob plaintext matches the
+	// one reconstructed from the encrypted blob.
+	if !reflect.DeepEqual(boj, boj2) {
+		t.Fatalf("decrypted plaintext does not match original, "+
+			"want: %v, got %v", boj, boj2)
 	}
 }


### PR DESCRIPTION
This PR fixes an oversight in the previous
design of the watchtower blob, by introducing
a length byte for sweep addresses. The previous
format supposed that addresses would be padded
to 42 bytes, but had no indication of the
address's actual length.

To remedy this, we introduce a single byte
indicating the actual size of the address,
such that the padding can be removed upon
decoding.

In addition, the watchtower/blob unit tests are
modified to use ` t.Run` so that the unit test
names are properly displayed in logs.