### PR TITLE
queryroutes: set queryroutes numRoutes param default to 10

### DIFF
--- a/cmd/lncli/commands.go
+++ b/cmd/lncli/commands.go
@@ -2671,7 +2671,7 @@ var queryRoutesCommand = cli.Command{
 		},
 		cli.Int64Flag{
 			Name:  "num_max_routes",
-			Usage: "the max number of routes to be returned (default: 10)",
+			Usage: "the max number of routes to be returned",
 			Value: 10,
 		},
 		cli.Int64Flag{


### PR DESCRIPTION
## Problem

When calling `queryroutes` from gRPC, the default value for the `num_routes` parameter  is set to zero. Having a default value of zero is confusing as there would be little point of making the call if you wanted to fetch zero results. Additionally, the documentation states that the default should be 10.

This is inconsistent with the CLI, where the default of 10 is correctly applied.

Also, the documentation for the cli `queryroutes` command has bad output which this PR addresses as below:

**Output from  `lncli queryroutes --help` (before changes):**

```
--num_max_routes value     the max number of routes to be returned (default: 10) (default: 10)
```

## Solution
Set the default value as `10` when no value is provided by the caller.

**Updated output from  `lncli queryroutes --help` (after changes):**
```
--num_max_routes value     the max number of routes to be returned (default: 10)
```