### PR TITLE
htlcswitch: Eliminate misleading log statement

### DIFF
--- a/htlcswitch/switch.go
+++ b/htlcswitch/switch.go
@@ -1669,13 +1669,6 @@ out:
 				continue
 			}
 
-			// Otherwise, we'll log this diff, then accumulate the
-			// new stats into the running total.
-			log.Infof("Sent %d satoshis and received %d satoshis "+
-				"in the last 10 seconds (%f tx/sec)",
-				diffSatSent, diffSatRecv,
-				float64(diffNumUpdates)/10)
-
 			totalNumUpdates += diffNumUpdates
 			totalSatSent += diffSatSent
 			totalSatRecv += diffSatRecv


### PR DESCRIPTION
Eliminate incorrect log statement that announces sending and receiving of satoshis with inaccurate totals.