### PR TITLE
htlcswitch: Limit low-signal tps log statement to debug log

### DIFF
--- a/htlcswitch/switch.go
+++ b/htlcswitch/switch.go
@@ -1671,7 +1671,7 @@ out:
 
 			// Otherwise, we'll log this diff, then accumulate the
 			// new stats into the running total.
-			log.Infof("Sent %d satoshis and received %d satoshis "+
+			log.Debugf("Sent %d satoshis and received %d satoshis "+
 				"in the last 10 seconds (%f tx/sec)",
 				diffSatSent, diffSatRecv,
 				float64(diffNumUpdates)/10)


### PR DESCRIPTION
TPS log statement that announces sending and receiving of satoshis with inaccurate totals is intended as a limited, low signal log statement and should not print to the standard log level.

