### PR TITLE
Improve enforcement of CLTV too soon rejects

### DIFF
--- a/contractcourt/channel_arbitrator.go
+++ b/contractcourt/channel_arbitrator.go
@@ -13,15 +13,6 @@ import (
 	"github.com/lightningnetwork/lnd/lnwire"
 )
 
-const (
-	// broadcastRedeemMultiplier is the additional factor that we'll scale
-	// the normal broadcastDelta by when deciding whether or not to
-	// broadcast a commitment to claim an HTLC on-chain. We use a scaled
-	// value, as when redeeming we want to ensure that we have enough time
-	// to redeem the HTLC, well before it times out.
-	broadcastRedeemMultiplier = 2
-)
-
 var (
 	// errAlreadyForceClosed is an error returned when we attempt to force
 	// close a channel that's already in the process of doing so.
@@ -910,7 +901,6 @@ func (c *ChannelArbitrator) checkChainActions(height uint32,
 		"height=%v", c.cfg.ChanPoint, height)
 
 	actionMap := make(ChainActionMap)
-	redeemCutoff := c.cfg.BroadcastDelta * broadcastRedeemMultiplier
 
 	// First, we'll make an initial pass over the set of incoming and
 	// outgoing HTLC's to decide if we need to go on chain at all.
@@ -943,7 +933,7 @@ func (c *ChannelArbitrator) checkChainActions(height uint32,
 			continue
 		}
 		haveChainActions = haveChainActions || c.shouldGoOnChain(
-			htlc.RefundTimeout, redeemCutoff, height,
+			htlc.RefundTimeout, c.cfg.BroadcastDelta, height,
 		)
 	}
 

--- a/htlcswitch/link.go
+++ b/htlcswitch/link.go
@@ -237,6 +237,18 @@ type ChannelLinkConfig struct {
 	// fee rate. A random timeout will be selected between these values.
 	MinFeeUpdateTimeout time.Duration
 	MaxFeeUpdateTimeout time.Duration
+
+	// ExpiryGraceDelta is the minimum difference between the current block
+	// height and the CLTV we require on 1) an outgoing HTLC in order to
+	// forward as an intermediary hop, or 2) an incoming HTLC to reveal the
+	// preimage as the final hop. We'll reject any HTLC's who's timeout minus
+	// this value is less than or equal to the current block height. We require
+	// this in order to ensure that we have sufficient time to claim or
+	// timeout an HTLC on chain.
+	//
+	// This MUST be greater than the maximum BroadcastDelta of the
+	// ChannelArbitrator for the outbound channel.
+	ExpiryGraceDelta uint32
 }
 
 // channelLink is the service which drives a channel's commitment update

--- a/htlcswitch/link_test.go
+++ b/htlcswitch/link_test.go
@@ -1278,10 +1278,11 @@ func TestChannelLinkExpiryTooSoonExitNode(t *testing.T) {
 
 	amount := lnwire.NewMSatFromSatoshis(btcutil.SatoshiPerBitcoin)
 
-	// We'll craft an HTLC packet, but set the starting height to 10 blocks
-	// before the current true height.
+	// We'll craft an HTLC packet, but set the final hop CLTV to only 1 block
+	// after the current true height.
+	lastHopDelta := n.firstBobChannelLink.cfg.FwrdingPolicy.TimeLockDelta
 	htlcAmt, totalTimelock, hops := generateHops(amount,
-		startingHeight-10, n.firstBobChannelLink)
+		startingHeight+1-lastHopDelta, n.firstBobChannelLink)
 
 	// Now we'll send out the payment from Alice to Bob.
 	firstHop := n.firstBobChannelLink.ShortChanID()

--- a/htlcswitch/test_utils.go
+++ b/htlcswitch/test_utils.go
@@ -890,6 +890,7 @@ func newThreeHopNetwork(t testing.TB, aliceChannel, firstBobChannel,
 		fwdPkgTimeout       = 15 * time.Second
 		minFeeUpdateTimeout = 30 * time.Minute
 		maxFeeUpdateTimeout = 40 * time.Minute
+		expiryGraceDelta    = 3
 	)
 
 	pCache := &mockPreimageCache{
@@ -931,6 +932,7 @@ func newThreeHopNetwork(t testing.TB, aliceChannel, firstBobChannel,
 			MinFeeUpdateTimeout: minFeeUpdateTimeout,
 			MaxFeeUpdateTimeout: maxFeeUpdateTimeout,
 			OnChannelFailure:    func(lnwire.ChannelID, lnwire.ShortChannelID, LinkFailureError) {},
+			ExpiryGraceDelta:    expiryGraceDelta,
 		},
 		aliceChannel,
 	)
@@ -974,6 +976,7 @@ func newThreeHopNetwork(t testing.TB, aliceChannel, firstBobChannel,
 			MinFeeUpdateTimeout: minFeeUpdateTimeout,
 			MaxFeeUpdateTimeout: maxFeeUpdateTimeout,
 			OnChannelFailure:    func(lnwire.ChannelID, lnwire.ShortChannelID, LinkFailureError) {},
+			ExpiryGraceDelta:    expiryGraceDelta,
 		},
 		firstBobChannel,
 	)
@@ -1017,6 +1020,7 @@ func newThreeHopNetwork(t testing.TB, aliceChannel, firstBobChannel,
 			MinFeeUpdateTimeout: minFeeUpdateTimeout,
 			MaxFeeUpdateTimeout: maxFeeUpdateTimeout,
 			OnChannelFailure:    func(lnwire.ChannelID, lnwire.ShortChannelID, LinkFailureError) {},
+			ExpiryGraceDelta:    expiryGraceDelta,
 		},
 		secondBobChannel,
 	)
@@ -1060,6 +1064,7 @@ func newThreeHopNetwork(t testing.TB, aliceChannel, firstBobChannel,
 			MinFeeUpdateTimeout: minFeeUpdateTimeout,
 			MaxFeeUpdateTimeout: maxFeeUpdateTimeout,
 			OnChannelFailure:    func(lnwire.ChannelID, lnwire.ShortChannelID, LinkFailureError) {},
+			ExpiryGraceDelta:    expiryGraceDelta,
 		},
 		carolChannel,
 	)

--- a/lnd_test.go
+++ b/lnd_test.go
@@ -7746,6 +7746,12 @@ out:
 		t.Fatalf("unable to generate carol invoice: %v", err)
 	}
 
+	carolPayReq, err := carol.DecodePayReq(ctxb,
+		&lnrpc.PayReqString{carolInvoice.PaymentRequest})
+	if err != nil {
+		t.Fatalf("unable to decode generated payment request: %v", err)
+	}
+
 	// Before we send the payment, ensure that the announcement of the new
 	// channel has been processed by Alice.
 	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
@@ -7762,6 +7768,7 @@ out:
 		PaymentHashString: hex.EncodeToString(makeFakePayHash(t)),
 		DestString:        hex.EncodeToString(carol.PubKey[:]),
 		Amt:               payAmt,
+		FinalCltvDelta:    int32(carolPayReq.CltvExpiry),
 	}
 	resp, err := net.Alice.SendPaymentSync(ctxt, sendReq)
 	if err != nil {
@@ -7791,6 +7798,7 @@ out:
 		PaymentHashString: hex.EncodeToString(carolInvoice.RHash),
 		DestString:        hex.EncodeToString(carol.PubKey[:]),
 		Amt:               1000, // 10k satoshis are expected.
+		FinalCltvDelta:    int32(carolPayReq.CltvExpiry),
 	}
 	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
 	resp, err = net.Alice.SendPaymentSync(ctxt, sendReq)

--- a/peer.go
+++ b/peer.go
@@ -52,6 +52,13 @@ const (
 	// messages to be sent across the wire, requested by objects outside
 	// this struct.
 	outgoingQueueLen = 50
+
+	// extraExpiryGraceDelta is the additional number of blocks required by the
+	// ExpiryGraceDelta of the forwarding policy beyond the maximum broadcast
+	// delta. This is the minimum number of blocks between the expiry on an
+	// accepted or offered HTLC and the block height at which we will go to
+	// chain.
+	extraExpiryGraceDelta = 3
 )
 
 // outgoingMsg packages an lnwire.Message to be sent out on the wire, along with
@@ -582,6 +589,7 @@ func (p *peer) addLink(chanPoint *wire.OutPoint,
 		UnsafeReplay:        cfg.UnsafeReplay,
 		MinFeeUpdateTimeout: htlcswitch.DefaultMinLinkFeeUpdateTimeout,
 		MaxFeeUpdateTimeout: htlcswitch.DefaultMaxLinkFeeUpdateTimeout,
+		ExpiryGraceDelta:    defaultBroadcastDelta + extraExpiryGraceDelta,
 	}
 
 	link := htlcswitch.NewChannelLink(linkCfg, lnChan)

--- a/server.go
+++ b/server.go
@@ -2371,7 +2371,8 @@ func (s *server) peerConnected(conn net.Conn, connReq *connmgr.ConnReq,
 
 	// Now that we've established a connection, create a peer, and it to
 	// the set of currently active peers.
-	p, err := newPeer(conn, connReq, s, peerAddr, inbound, localFeatures)
+	p, err := newPeer(conn, connReq, s, peerAddr, inbound, localFeatures,
+		defaultBroadcastDelta+extraExpiryGraceDelta)
 	if err != nil {
 		srvrLog.Errorf("unable to create peer %v", err)
 		return

--- a/server.go
+++ b/server.go
@@ -652,9 +652,7 @@ func newServer(listenAddrs []net.Addr, chanDB *channeldb.DB, cc *chainControl,
 	contractBreaches := make(chan *ContractBreachEvent, 1)
 
 	s.chainArb = contractcourt.NewChainArbitrator(contractcourt.ChainArbitratorConfig{
-		ChainHash: *activeNetParams.GenesisHash,
-		// TODO(roasbeef): properly configure
-		//  * needs to be << or specified final hop time delta
+		ChainHash:      *activeNetParams.GenesisHash,
 		BroadcastDelta: defaultBroadcastDelta,
 		NewSweepAddr: func() ([]byte, error) {
 			return newSweepPkScript(cc.wallet)


### PR DESCRIPTION
As explained in #2144, the CLTV too soon failure checks need to enforce longer periods between HTLCs accepted/offered and the current block height. Currently, the grace period for forwarded HTLCs is 0 blocks and only 2 blocks when we are the final hop. However, the default broadcast delta is 10 blocks. This means that we might forward an HTLC and add it on an outbound channel, then immediately go to chain to close unilaterally because the CLTV is within the broadcast delta from the current block height.

This PR sets ExpiryGraceDelta as a configuration on links, and the server sets it so that it is greater than the broadcast delta.