### PR TITLE
 discovery/gossiper: send node anns when constructing full chan proof

### DIFF
--- a/discovery/gossiper.go
+++ b/discovery/gossiper.go
@@ -1642,6 +1642,9 @@ func (d *AuthenticatedGossiper) processNetworkAnnouncement(
 				source: nMsg.source,
 				msg:    msg,
 			})
+		} else {
+			log.Tracef("Skipping broadcasting node announcement "+
+				"for %x due to being unadvertised", msg.NodeID)
 		}
 
 		nMsg.err <- nil

--- a/discovery/gossiper_test.go
+++ b/discovery/gossiper_test.go
@@ -196,6 +196,18 @@ func (r *mockGraphSource) GetChannelByID(chanID lnwire.ShortChannelID) (
 	return chanInfo, edges[0], edges[1], nil
 }
 
+func (r *mockGraphSource) FetchLightningNode(
+	nodePub routing.Vertex) (*channeldb.LightningNode, error) {
+
+	for _, node := range r.nodes {
+		if bytes.Equal(nodePub[:], node.PubKeyBytes[:]) {
+			return node, nil
+		}
+	}
+
+	return nil, channeldb.ErrGraphNodeNotFound
+}
+
 // IsStaleNode returns true if the graph source has a node announcement for the
 // target node with a more recent timestamp.
 func (r *mockGraphSource) IsStaleNode(nodePub routing.Vertex, timestamp time.Time) bool {

--- a/discovery/gossiper_test.go
+++ b/discovery/gossiper_test.go
@@ -818,7 +818,9 @@ func TestSignatureAnnouncementLocalFirst(t *testing.T) {
 	ctx.gossiper.cfg.FindPeer = func(target *btcec.PublicKey) (lnpeer.Peer, error) {
 		return &mockPeer{target, sentMsgs, ctx.gossiper.quit}, nil
 	}
-	ctx.gossiper.cfg.SendToPeer = func(target *btcec.PublicKey, msg ...lnwire.Message) error {
+	ctx.gossiper.cfg.SendToPeer = func(target *btcec.PublicKey,
+		msg ...lnwire.Message) error {
+
 		select {
 		case sentMsgs <- msg[0]:
 		case <-ctx.gossiper.quit:
@@ -845,13 +847,14 @@ func TestSignatureAnnouncementLocalFirst(t *testing.T) {
 	// Recreate lightning network topology. Initialize router with channel
 	// between two nodes.
 	select {
-	case err = <-ctx.gossiper.ProcessLocalAnnouncement(batch.localChanAnn,
-		localKey):
+	case err = <-ctx.gossiper.ProcessLocalAnnouncement(
+		batch.localChanAnn, localKey,
+	):
 	case <-time.After(2 * time.Second):
 		t.Fatal("did not process local announcement")
 	}
 	if err != nil {
-		t.Fatalf("unable to process :%v", err)
+		t.Fatalf("unable to process channel ann: %v", err)
 	}
 	select {
 	case <-ctx.broadcastedMessage:
@@ -860,18 +863,34 @@ func TestSignatureAnnouncementLocalFirst(t *testing.T) {
 	}
 
 	select {
-	case err = <-ctx.gossiper.ProcessLocalAnnouncement(batch.chanUpdAnn1,
-		localKey):
+	case err = <-ctx.gossiper.ProcessLocalAnnouncement(
+		batch.chanUpdAnn1, localKey,
+	):
 	case <-time.After(2 * time.Second):
 		t.Fatal("did not process local announcement")
 	}
 	if err != nil {
-		t.Fatalf("unable to process :%v", err)
+		t.Fatalf("unable to process channel update: %v", err)
 	}
-
 	select {
 	case <-ctx.broadcastedMessage:
 		t.Fatal("channel update announcement was broadcast")
+	case <-time.After(2 * trickleDelay):
+	}
+
+	select {
+	case err = <-ctx.gossiper.ProcessLocalAnnouncement(
+		batch.nodeAnn1, localKey,
+	):
+	case <-time.After(2 * time.Second):
+		t.Fatal("did not process local announcement")
+	}
+	if err != nil {
+		t.Fatalf("unable to process node ann: %v", err)
+	}
+	select {
+	case <-ctx.broadcastedMessage:
+		t.Fatal("node announcement was broadcast")
 	case <-time.After(2 * trickleDelay):
 	}
 
@@ -888,13 +907,14 @@ func TestSignatureAnnouncementLocalFirst(t *testing.T) {
 	}
 
 	select {
-	case err = <-ctx.gossiper.ProcessRemoteAnnouncement(batch.chanUpdAnn2,
-		remotePeer):
+	case err = <-ctx.gossiper.ProcessRemoteAnnouncement(
+		batch.chanUpdAnn2, remotePeer,
+	):
 	case <-time.After(2 * time.Second):
 		t.Fatal("did not process remote announcement")
 	}
 	if err != nil {
-		t.Fatalf("unable to process :%v", err)
+		t.Fatalf("unable to process channel update: %v", err)
 	}
 	select {
 	case <-ctx.broadcastedMessage:
@@ -902,16 +922,33 @@ func TestSignatureAnnouncementLocalFirst(t *testing.T) {
 	case <-time.After(2 * trickleDelay):
 	}
 
-	// Pretending that we receive local channel announcement from funding
-	// manager, thereby kick off the announcement exchange process.
 	select {
-	case err = <-ctx.gossiper.ProcessLocalAnnouncement(batch.localProofAnn,
-		localKey):
+	case err = <-ctx.gossiper.ProcessRemoteAnnouncement(
+		batch.nodeAnn2, remotePeer,
+	):
 	case <-time.After(2 * time.Second):
 		t.Fatal("did not process remote announcement")
 	}
 	if err != nil {
-		t.Fatalf("unable to process :%v", err)
+		t.Fatalf("unable to process node ann: %v", err)
+	}
+	select {
+	case <-ctx.broadcastedMessage:
+		t.Fatal("node announcement was broadcast")
+	case <-time.After(2 * trickleDelay):
+	}
+
+	// Pretending that we receive local channel announcement from funding
+	// manager, thereby kick off the announcement exchange process.
+	select {
+	case err = <-ctx.gossiper.ProcessLocalAnnouncement(
+		batch.localProofAnn, localKey,
+	):
+	case <-time.After(2 * time.Second):
+		t.Fatal("did not process remote announcement")
+	}
+	if err != nil {
+		t.Fatalf("unable to process local proof: %v", err)
 	}
 
 	select {
@@ -935,16 +972,17 @@ func TestSignatureAnnouncementLocalFirst(t *testing.T) {
 	}
 
 	select {
-	case err = <-ctx.gossiper.ProcessRemoteAnnouncement(batch.remoteProofAnn,
-		remotePeer):
+	case err = <-ctx.gossiper.ProcessRemoteAnnouncement(
+		batch.remoteProofAnn, remotePeer,
+	):
 	case <-time.After(2 * time.Second):
 		t.Fatal("did not process remote announcement")
 	}
 	if err != nil {
-		t.Fatalf("unable to process :%v", err)
+		t.Fatalf("unable to process remote proof: %v", err)
 	}
 
-	for i := 0; i < 3; i++ {
+	for i := 0; i < 5; i++ {
 		select {
 		case <-ctx.broadcastedMessage:
 		case <-time.After(time.Second):
@@ -1071,6 +1109,22 @@ func TestOrphanSignatureAnnouncement(t *testing.T) {
 	case <-time.After(2 * trickleDelay):
 	}
 
+	select {
+	case err = <-ctx.gossiper.ProcessLocalAnnouncement(
+		batch.nodeAnn1, localKey,
+	):
+	case <-time.After(2 * time.Second):
+		t.Fatal("did not process local announcement")
+	}
+	if err != nil {
+		t.Fatalf("unable to process node ann: %v", err)
+	}
+	select {
+	case <-ctx.broadcastedMessage:
+		t.Fatal("node announcement was broadcast")
+	case <-time.After(2 * trickleDelay):
+	}
+
 	// The local ChannelUpdate should now be sent directly to the remote peer,
 	// such that the edge can be used for routing, regardless if this channel
 	// is announced or not (private channel).
@@ -1090,11 +1144,27 @@ func TestOrphanSignatureAnnouncement(t *testing.T) {
 		t.Fatal("did not process remote announcement")
 	}
 	if err != nil {
-		t.Fatalf("unable to process: %v", err)
+		t.Fatalf("unable to process node ann: %v", err)
 	}
 	select {
 	case <-ctx.broadcastedMessage:
 		t.Fatal("channel update announcement was broadcast")
+	case <-time.After(2 * trickleDelay):
+	}
+
+	select {
+	case err = <-ctx.gossiper.ProcessRemoteAnnouncement(
+		batch.nodeAnn2, remotePeer,
+	):
+	case <-time.After(2 * time.Second):
+		t.Fatal("did not process remote announcement")
+	}
+	if err != nil {
+		t.Fatalf("unable to process: %v", err)
+	}
+	select {
+	case <-ctx.broadcastedMessage:
+		t.Fatal("node announcement announcement was broadcast")
 	case <-time.After(2 * trickleDelay):
 	}
 
@@ -1122,7 +1192,7 @@ func TestOrphanSignatureAnnouncement(t *testing.T) {
 
 	// And since both remote and local announcements are processed, we
 	// should be broadcasting the final channel announcements.
-	for i := 0; i < 3; i++ {
+	for i := 0; i < 5; i++ {
 		select {
 		case <-ctx.broadcastedMessage:
 		case <-time.After(time.Second):
@@ -1174,13 +1244,14 @@ func TestSignatureAnnouncementRetry(t *testing.T) {
 	// Recreate lightning network topology. Initialize router with channel
 	// between two nodes.
 	select {
-	case err = <-ctx.gossiper.ProcessLocalAnnouncement(batch.localChanAnn,
-		localKey):
+	case err = <-ctx.gossiper.ProcessLocalAnnouncement(
+		batch.localChanAnn, localKey,
+	):
 	case <-time.After(2 * time.Second):
 		t.Fatal("did not process local announcement")
 	}
 	if err != nil {
-		t.Fatalf("unable to process :%v", err)
+		t.Fatalf("unable to process channel ann: %v", err)
 	}
 	select {
 	case <-ctx.broadcastedMessage:
@@ -1189,13 +1260,14 @@ func TestSignatureAnnouncementRetry(t *testing.T) {
 	}
 
 	select {
-	case err = <-ctx.gossiper.ProcessLocalAnnouncement(batch.chanUpdAnn1,
-		localKey):
+	case err = <-ctx.gossiper.ProcessLocalAnnouncement(
+		batch.chanUpdAnn1, localKey,
+	):
 	case <-time.After(2 * time.Second):
 		t.Fatal("did not process local announcement")
 	}
 	if err != nil {
-		t.Fatalf("unable to process :%v", err)
+		t.Fatalf("unable to process channel update: %v", err)
 	}
 	select {
 	case <-ctx.broadcastedMessage:
@@ -1204,17 +1276,50 @@ func TestSignatureAnnouncementRetry(t *testing.T) {
 	}
 
 	select {
-	case err = <-ctx.gossiper.ProcessRemoteAnnouncement(batch.chanUpdAnn2,
-		remotePeer):
+	case err = <-ctx.gossiper.ProcessLocalAnnouncement(
+		batch.nodeAnn1, localKey,
+	):
+	case <-time.After(2 * time.Second):
+		t.Fatal("did not process local announcement")
+	}
+	if err != nil {
+		t.Fatalf("unable to process node ann: %v", err)
+	}
+	select {
+	case <-ctx.broadcastedMessage:
+		t.Fatal("node announcement was broadcast")
+	case <-time.After(2 * trickleDelay):
+	}
+
+	select {
+	case err = <-ctx.gossiper.ProcessRemoteAnnouncement(
+		batch.chanUpdAnn2, remotePeer,
+	):
 	case <-time.After(2 * time.Second):
 		t.Fatal("did not process remote announcement")
 	}
 	if err != nil {
-		t.Fatalf("unable to process :%v", err)
+		t.Fatalf("unable to process channel update: %v", err)
 	}
 	select {
 	case <-ctx.broadcastedMessage:
 		t.Fatal("channel update announcement was broadcast")
+	case <-time.After(2 * trickleDelay):
+	}
+
+	select {
+	case err = <-ctx.gossiper.ProcessRemoteAnnouncement(
+		batch.nodeAnn2, remotePeer,
+	):
+	case <-time.After(2 * time.Second):
+		t.Fatal("did not process remote announcement")
+	}
+	if err != nil {
+		t.Fatalf("unable to process node ann: %v", err)
+	}
+	select {
+	case <-ctx.broadcastedMessage:
+		t.Fatal("node announcement was broadcast")
 	case <-time.After(2 * trickleDelay):
 	}
 
@@ -1236,13 +1341,14 @@ func TestSignatureAnnouncementRetry(t *testing.T) {
 	// Pretending that we receive local channel announcement from funding
 	// manager, thereby kick off the announcement exchange process.
 	select {
-	case err = <-ctx.gossiper.ProcessLocalAnnouncement(batch.localProofAnn,
-		localKey):
+	case err = <-ctx.gossiper.ProcessLocalAnnouncement(
+		batch.localProofAnn, localKey,
+	):
 	case <-time.After(2 * time.Second):
 		t.Fatal("did not process local announcement")
 	}
 	if err != nil {
-		t.Fatalf("unable to process :%v", err)
+		t.Fatalf("unable to process local proof: %v", err)
 	}
 
 	// Since sending this local announcement proof to the remote will fail,
@@ -1301,16 +1407,17 @@ func TestSignatureAnnouncementRetry(t *testing.T) {
 	// Now give the gossiper the remote proof. This should trigger a
 	// broadcast of 3 messages (ChannelAnnouncement + 2 ChannelUpdate).
 	select {
-	case err = <-ctx.gossiper.ProcessRemoteAnnouncement(batch.remoteProofAnn,
-		remotePeer):
+	case err = <-ctx.gossiper.ProcessRemoteAnnouncement(
+		batch.remoteProofAnn, remotePeer,
+	):
 	case <-time.After(2 * time.Second):
 		t.Fatal("did not process local announcement")
 	}
 	if err != nil {
-		t.Fatalf("unable to process :%v", err)
+		t.Fatalf("unable to process remote proof: %v", err)
 	}
 
-	for i := 0; i < 3; i++ {
+	for i := 0; i < 5; i++ {
 		select {
 		case <-ctx.broadcastedMessage:
 		case <-time.After(time.Second):
@@ -1363,13 +1470,14 @@ func TestSignatureAnnouncementRetryAtStartup(t *testing.T) {
 	// Recreate lightning network topology. Initialize router with channel
 	// between two nodes.
 	select {
-	case err = <-ctx.gossiper.ProcessLocalAnnouncement(batch.localChanAnn,
-		localKey):
+	case err = <-ctx.gossiper.ProcessLocalAnnouncement(
+		batch.localChanAnn, localKey,
+	):
 	case <-time.After(2 * time.Second):
 		t.Fatal("did not process local announcement")
 	}
 	if err != nil {
-		t.Fatalf("unable to process :%v", err)
+		t.Fatalf("unable to process channel ann: %v", err)
 	}
 	select {
 	case <-ctx.broadcastedMessage:
@@ -1378,13 +1486,14 @@ func TestSignatureAnnouncementRetryAtStartup(t *testing.T) {
 	}
 
 	select {
-	case err = <-ctx.gossiper.ProcessLocalAnnouncement(batch.chanUpdAnn1,
-		localKey):
+	case err = <-ctx.gossiper.ProcessLocalAnnouncement(
+		batch.chanUpdAnn1, localKey,
+	):
 	case <-time.After(2 * time.Second):
 		t.Fatal("did not process local announcement")
 	}
 	if err != nil {
-		t.Fatalf("unable to process :%v", err)
+		t.Fatalf("unable to process channel update: %v", err)
 	}
 	select {
 	case <-ctx.broadcastedMessage:
@@ -1393,17 +1502,50 @@ func TestSignatureAnnouncementRetryAtStartup(t *testing.T) {
 	}
 
 	select {
-	case err = <-ctx.gossiper.ProcessRemoteAnnouncement(batch.chanUpdAnn2,
-		remotePeer):
+	case err = <-ctx.gossiper.ProcessLocalAnnouncement(
+		batch.nodeAnn1, localKey,
+	):
+	case <-time.After(2 * time.Second):
+		t.Fatal("did not process local announcement")
+	}
+	if err != nil {
+		t.Fatalf("unable to process node ann: %v", err)
+	}
+	select {
+	case <-ctx.broadcastedMessage:
+		t.Fatal("node announcement was broadcast")
+	case <-time.After(2 * trickleDelay):
+	}
+
+	select {
+	case err = <-ctx.gossiper.ProcessRemoteAnnouncement(
+		batch.chanUpdAnn2, remotePeer,
+	):
 	case <-time.After(2 * time.Second):
 		t.Fatal("did not process remote announcement")
 	}
 	if err != nil {
-		t.Fatalf("unable to process :%v", err)
+		t.Fatalf("unable to process channel update: %v", err)
 	}
 	select {
 	case <-ctx.broadcastedMessage:
 		t.Fatal("channel update announcement was broadcast")
+	case <-time.After(2 * trickleDelay):
+	}
+
+	select {
+	case err = <-ctx.gossiper.ProcessRemoteAnnouncement(
+		batch.nodeAnn2, remotePeer,
+	):
+	case <-time.After(2 * time.Second):
+		t.Fatal("did not process local announcement")
+	}
+	if err != nil {
+		t.Fatalf("unable to process node ann: %v", err)
+	}
+	select {
+	case <-ctx.broadcastedMessage:
+		t.Fatal("node announcement was broadcast")
 	case <-time.After(2 * trickleDelay):
 	}
 
@@ -1526,8 +1668,9 @@ func TestSignatureAnnouncementRetryAtStartup(t *testing.T) {
 	// Now exchanging the remote channel proof, the channel announcement
 	// broadcast should continue as normal.
 	select {
-	case err = <-ctx.gossiper.ProcessRemoteAnnouncement(batch.remoteProofAnn,
-		remotePeer):
+	case err = <-ctx.gossiper.ProcessRemoteAnnouncement(
+		batch.remoteProofAnn, remotePeer,
+	):
 	case <-time.After(2 * time.Second):
 		t.Fatal("did not process remote announcement")
 	}
@@ -1535,7 +1678,7 @@ func TestSignatureAnnouncementRetryAtStartup(t *testing.T) {
 		t.Fatalf("unable to process :%v", err)
 	}
 
-	for i := 0; i < 3; i++ {
+	for i := 0; i < 5; i++ {
 		select {
 		case <-ctx.broadcastedMessage:
 		case <-time.After(time.Second):
@@ -1589,13 +1732,14 @@ func TestSignatureAnnouncementFullProofWhenRemoteProof(t *testing.T) {
 	// Recreate lightning network topology. Initialize router with channel
 	// between two nodes.
 	select {
-	case err = <-ctx.gossiper.ProcessLocalAnnouncement(batch.localChanAnn,
-		localKey):
+	case err = <-ctx.gossiper.ProcessLocalAnnouncement(
+		batch.localChanAnn, localKey,
+	):
 	case <-time.After(2 * time.Second):
 		t.Fatal("did not process local announcement")
 	}
 	if err != nil {
-		t.Fatalf("unable to process :%v", err)
+		t.Fatalf("unable to process channel ann: %v", err)
 	}
 	select {
 	case <-ctx.broadcastedMessage:
@@ -1604,13 +1748,14 @@ func TestSignatureAnnouncementFullProofWhenRemoteProof(t *testing.T) {
 	}
 
 	select {
-	case err = <-ctx.gossiper.ProcessLocalAnnouncement(batch.chanUpdAnn1,
-		localKey):
+	case err = <-ctx.gossiper.ProcessLocalAnnouncement(
+		batch.chanUpdAnn1, localKey,
+	):
 	case <-time.After(2 * time.Second):
 		t.Fatal("did not process local announcement")
 	}
 	if err != nil {
-		t.Fatalf("unable to process :%v", err)
+		t.Fatalf("unable to process channel update: %v", err)
 	}
 	select {
 	case <-ctx.broadcastedMessage:
@@ -1619,19 +1764,53 @@ func TestSignatureAnnouncementFullProofWhenRemoteProof(t *testing.T) {
 	}
 
 	select {
-	case err = <-ctx.gossiper.ProcessRemoteAnnouncement(batch.chanUpdAnn2,
-		remotePeer):
+	case err = <-ctx.gossiper.ProcessLocalAnnouncement(
+		batch.nodeAnn1, localKey,
+	):
+	case <-time.After(2 * time.Second):
+		t.Fatal("did not process local announcement")
+	}
+	if err != nil {
+		t.Fatalf("unable to process node ann:%v", err)
+	}
+	select {
+	case <-ctx.broadcastedMessage:
+		t.Fatal("node announcement was broadcast")
+	case <-time.After(2 * trickleDelay):
+	}
+
+	select {
+	case err = <-ctx.gossiper.ProcessRemoteAnnouncement(
+		batch.chanUpdAnn2, remotePeer,
+	):
 	case <-time.After(2 * time.Second):
 		t.Fatal("did not process remote announcement")
 	}
 	if err != nil {
-		t.Fatalf("unable to process :%v", err)
+		t.Fatalf("unable to process channel update: %v", err)
 	}
 	select {
 	case <-ctx.broadcastedMessage:
 		t.Fatal("channel update announcement was broadcast")
 	case <-time.After(2 * trickleDelay):
 	}
+
+	select {
+	case err = <-ctx.gossiper.ProcessRemoteAnnouncement(
+		batch.nodeAnn2, remotePeer,
+	):
+	case <-time.After(2 * time.Second):
+		t.Fatal("did not process remote announcement")
+	}
+	if err != nil {
+		t.Fatalf("unable to process node ann: %v", err)
+	}
+	select {
+	case <-ctx.broadcastedMessage:
+		t.Fatal("node announcement was broadcast")
+	case <-time.After(2 * trickleDelay):
+	}
+
 	// Set up a channel we can use to inspect messages sent by the
 	// gossiper to the remote peer.
 	sentToPeer := make(chan lnwire.Message, 1)
@@ -1656,23 +1835,25 @@ func TestSignatureAnnouncementFullProofWhenRemoteProof(t *testing.T) {
 	// Pretending that we receive local channel announcement from funding
 	// manager, thereby kick off the announcement exchange process.
 	select {
-	case err = <-ctx.gossiper.ProcessLocalAnnouncement(batch.localProofAnn,
-		localKey):
+	case err = <-ctx.gossiper.ProcessLocalAnnouncement(
+		batch.localProofAnn, localKey,
+	):
 	case <-time.After(2 * time.Second):
 		t.Fatal("did not process local announcement")
 	}
 	if err != nil {
-		t.Fatalf("unable to process :%v", err)
+		t.Fatalf("unable to process local proof: %v", err)
 	}
 
 	select {
-	case err = <-ctx.gossiper.ProcessRemoteAnnouncement(batch.remoteProofAnn,
-		remotePeer):
+	case err = <-ctx.gossiper.ProcessRemoteAnnouncement(
+		batch.remoteProofAnn, remotePeer,
+	):
 	case <-time.After(2 * time.Second):
 		t.Fatal("did not process local announcement")
 	}
 	if err != nil {
-		t.Fatalf("unable to process :%v", err)
+		t.Fatalf("unable to process remote proof: %v", err)
 	}
 
 	// We expect the gossiper to send this message to the remote peer.
@@ -1685,8 +1866,8 @@ func TestSignatureAnnouncementFullProofWhenRemoteProof(t *testing.T) {
 		t.Fatal("did not send local proof to peer")
 	}
 
-	// And all channel announcements should be broadcast.
-	for i := 0; i < 3; i++ {
+	// All channel and node announcements should be broadcast.
+	for i := 0; i < 5; i++ {
 		select {
 		case <-ctx.broadcastedMessage:
 		case <-time.After(time.Second):
@@ -1711,13 +1892,14 @@ func TestSignatureAnnouncementFullProofWhenRemoteProof(t *testing.T) {
 	// Now give the gossiper the remote proof yet again. This should
 	// trigger a send of the full ChannelAnnouncement.
 	select {
-	case err = <-ctx.gossiper.ProcessRemoteAnnouncement(batch.remoteProofAnn,
-		remotePeer):
+	case err = <-ctx.gossiper.ProcessRemoteAnnouncement(
+		batch.remoteProofAnn, remotePeer,
+	):
 	case <-time.After(2 * time.Second):
 		t.Fatal("did not process local announcement")
 	}
 	if err != nil {
-		t.Fatalf("unable to process :%v", err)
+		t.Fatalf("unable to process remote proof: %v", err)
 	}
 
 	// We expect the gossiper to send this message to the remote peer.
@@ -1730,7 +1912,6 @@ func TestSignatureAnnouncementFullProofWhenRemoteProof(t *testing.T) {
 	case <-time.After(2 * time.Second):
 		t.Fatal("did not send local proof to peer")
 	}
-
 }
 
 // TestDeDuplicatedAnnouncements ensures that the deDupedAnnouncements struct
@@ -2152,11 +2333,22 @@ func TestReceiveRemoteChannelUpdateFirst(t *testing.T) {
 	// Recreate the case where the remote node is sending us its ChannelUpdate
 	// before we have been able to process our own ChannelAnnouncement and
 	// ChannelUpdate.
-	errRemoteAnn := ctx.gossiper.ProcessRemoteAnnouncement(batch.chanUpdAnn2, remotePeer)
-
+	errRemoteAnn := ctx.gossiper.ProcessRemoteAnnouncement(
+		batch.chanUpdAnn2, remotePeer,
+	)
 	select {
 	case <-ctx.broadcastedMessage:
 		t.Fatal("channel update announcement was broadcast")
+	case <-time.After(2 * trickleDelay):
+	}
+
+	err = <-ctx.gossiper.ProcessRemoteAnnouncement(batch.nodeAnn2, remotePeer)
+	if err != nil {
+		t.Fatalf("unable to process node ann: %v", err)
+	}
+	select {
+	case <-ctx.broadcastedMessage:
+		t.Fatal("node announcement was broadcast")
 	case <-time.After(2 * trickleDelay):
 	}
 
@@ -2200,6 +2392,16 @@ func TestReceiveRemoteChannelUpdateFirst(t *testing.T) {
 	case <-time.After(2 * trickleDelay):
 	}
 
+	err = <-ctx.gossiper.ProcessLocalAnnouncement(batch.nodeAnn1, localKey)
+	if err != nil {
+		t.Fatalf("unable to process :%v", err)
+	}
+	select {
+	case <-ctx.broadcastedMessage:
+		t.Fatal("node announcement was broadcast")
+	case <-time.After(2 * trickleDelay):
+	}
+
 	// The local ChannelUpdate should now be sent directly to the remote peer,
 	// such that the edge can be used for routing, regardless if this channel
 	// is announced or not (private channel).
@@ -2224,7 +2426,9 @@ func TestReceiveRemoteChannelUpdateFirst(t *testing.T) {
 	}
 
 	// Check that the ChannelEdgePolicy was added to the graph.
-	chanInfo, e1, e2, err = ctx.router.GetChannelByID(batch.chanUpdAnn1.ShortChannelID)
+	chanInfo, e1, e2, err = ctx.router.GetChannelByID(
+		batch.chanUpdAnn1.ShortChannelID,
+	)
 	if err != nil {
 		t.Fatalf("unable to get channel from router: %v", err)
 	}
@@ -2240,7 +2444,9 @@ func TestReceiveRemoteChannelUpdateFirst(t *testing.T) {
 
 	// Pretending that we receive local channel announcement from funding
 	// manager, thereby kick off the announcement exchange process.
-	err = <-ctx.gossiper.ProcessLocalAnnouncement(batch.localProofAnn, localKey)
+	err = <-ctx.gossiper.ProcessLocalAnnouncement(
+		batch.localProofAnn, localKey,
+	)
 	if err != nil {
 		t.Fatalf("unable to process :%v", err)
 	}
@@ -2265,12 +2471,14 @@ func TestReceiveRemoteChannelUpdateFirst(t *testing.T) {
 		t.Fatal("wrong number of objects in storage")
 	}
 
-	err = <-ctx.gossiper.ProcessRemoteAnnouncement(batch.remoteProofAnn, remotePeer)
+	err = <-ctx.gossiper.ProcessRemoteAnnouncement(
+		batch.remoteProofAnn, remotePeer,
+	)
 	if err != nil {
 		t.Fatalf("unable to process :%v", err)
 	}
 
-	for i := 0; i < 3; i++ {
+	for i := 0; i < 5; i++ {
 		select {
 		case <-ctx.broadcastedMessage:
 		case <-time.After(time.Second):


### PR DESCRIPTION
In this PR, we allow the gossiper to also broadcast the corresponding node announcements, if we know of them, of a channel when constructing its full proof. We do this to ensure peers (other than our
remote peer) receive all the relevant announcements for a channel.

This also addresses an existing flake in the integration test `testNodeAnnouncement`. This problem arose due to the node announcement being sent before the connection between Dave (node announcement sender) and Alice (node announcement receiver) was initiated and the full channel proof was constructed.