### PR TITLE
Update routing hints upon insufficient fees failure.

### DIFF
--- a/routing/ann_validation.go
+++ b/routing/ann_validation.go
@@ -129,7 +129,7 @@ func ValidateNodeAnn(a *lnwire.NodeAnnouncement) error {
 func ValidateChannelUpdateAnn(pubKey *btcec.PublicKey, capacity btcutil.Amount,
 	a *lnwire.ChannelUpdate) error {
 
-	if err := validateOptionalFields(capacity, a); err != nil {
+	if err := ValidateOptionalFields(capacity, a); err != nil {
 		return err
 	}
 
@@ -160,9 +160,9 @@ func VerifyChannelUpdateSignature(msg *lnwire.ChannelUpdate,
 	return nil
 }
 
-// validateOptionalFields validates a channel update's message flags and
+// ValidateOptionalFields validates a channel update's message flags and
 // corresponding update fields.
-func validateOptionalFields(capacity btcutil.Amount,
+func ValidateOptionalFields(capacity btcutil.Amount,
 	msg *lnwire.ChannelUpdate) error {
 
 	if msg.MessageFlags.HasMaxHtlc() {

--- a/routing/missioncontrol.go
+++ b/routing/missioncontrol.go
@@ -1,6 +1,8 @@
 package routing
 
 import (
+	"bytes"
+	"fmt"
 	"sync"
 	"time"
 
@@ -188,6 +190,11 @@ func (m *missionControl) NewPaymentSession(routeHints [][]zpay32.HopHint,
 			// Finally, create the channel edge from the hop hint
 			// and add it to list of edges corresponding to the node
 			// at the start of the channel.
+			v := NewVertex(hopHint.NodeID)
+			var flags lnwire.ChanUpdateFlag
+			if bytes.Compare(v[:], endNode.PubKeyBytes[:]) == 1 {
+				flags |= lnwire.ChanUpdateDirection
+			}
 			edge := &channeldb.ChannelEdgePolicy{
 				Node:      endNode,
 				ChannelID: hopHint.ChannelID,
@@ -198,9 +205,9 @@ func (m *missionControl) NewPaymentSession(routeHints [][]zpay32.HopHint,
 					hopHint.FeeProportionalMillionths,
 				),
 				TimeLockDelta: hopHint.CLTVExpiryDelta,
+				Flags:         flags,
 			}
 
-			v := NewVertex(hopHint.NodeID)
 			edges[v] = append(edges[v], edge)
 		}
 	}

--- a/routing/missioncontrol.go
+++ b/routing/missioncontrol.go
@@ -2,7 +2,6 @@ package routing
 
 import (
 	"bytes"
-	"fmt"
 	"sync"
 	"time"
 
@@ -191,7 +190,7 @@ func (m *missionControl) NewPaymentSession(routeHints [][]zpay32.HopHint,
 			// and add it to list of edges corresponding to the node
 			// at the start of the channel.
 			v := NewVertex(hopHint.NodeID)
-			var flags lnwire.ChanUpdateFlag
+			var flags lnwire.ChanUpdateChanFlags
 			if bytes.Compare(v[:], endNode.PubKeyBytes[:]) == 1 {
 				flags |= lnwire.ChanUpdateDirection
 			}
@@ -205,7 +204,7 @@ func (m *missionControl) NewPaymentSession(routeHints [][]zpay32.HopHint,
 					hopHint.FeeProportionalMillionths,
 				),
 				TimeLockDelta: hopHint.CLTVExpiryDelta,
-				Flags:         flags,
+				ChannelFlags:  flags,
 			}
 
 			edges[v] = append(edges[v], edge)

--- a/routing/pathfind.go
+++ b/routing/pathfind.go
@@ -138,6 +138,18 @@ type Route struct {
 	Hops []*Hop
 }
 
+// containsChannel returns true if a channel is present in the target route,
+// and false otherwise. The passed chanID should be the converted uint64 form
+// of lnwire.ShortChannelID.
+func (r *Route) containsChannel(chanID uint64) bool {
+	for _, hop := range r.Hops {
+		if hop.ChannelID == chanID {
+			return true
+		}
+	}
+	return false
+}
+
 // HopFee returns the fee charged by the route hop indicated by hopIndex.
 func (r *Route) HopFee(hopIndex int) lnwire.MilliSatoshi {
 	var incomingAmt lnwire.MilliSatoshi

--- a/routing/pathfind_test.go
+++ b/routing/pathfind_test.go
@@ -208,7 +208,9 @@ func parseTestGraph(path string) (*testGraphInstance, error) {
 			key, derivedPub := btcec.PrivKeyFromBytes(btcec.S256(),
 				privBytes)
 
-			if !pub.IsEqual(derivedPub) {
+			if !bytes.Equal(dbNode.PubKeyBytes[:],
+				derivedPub.SerializeCompressed()) {
+
 				return nil, fmt.Errorf("%s public key and "+
 					"private key are inconsistent",
 					node.Alias)

--- a/routing/payment_session.go
+++ b/routing/payment_session.go
@@ -39,10 +39,10 @@ type paymentSession struct {
 
 // edgeLocatorOfEdgePolicy returns the edge locator corresponding to
 // the channel edge policy
-func edgeLocatorOfEdgePolicy(ep *channeldb.ChannelEdgePolicy) *edgeLocator {
-	return &edgeLocator{
-		channelID: ep.ChannelID,
-		direction: edgePolicyDirection(ep),
+func edgeLocatorOfEdgePolicy(ep *channeldb.ChannelEdgePolicy) *EdgeLocator {
+	return &EdgeLocator{
+		ChannelID: ep.ChannelID,
+		Direction: edgePolicyDirection(ep),
 	}
 }
 
@@ -67,7 +67,7 @@ func updateEdgePolicy(up *lnwire.ChannelUpdate,
 
 // UpdateEdgePolicy updates edge policy of the routing hints kept in the
 // payment session.
-func (p *paymentSession) UpdateEdgePolicy(el *edgeLocator,
+func (p *paymentSession) UpdateEdgePolicy(el *EdgeLocator,
 	update *lnwire.ChannelUpdate) {
 
 	log.Debugf("Updating edge %v policy in Mission Control", el)

--- a/routing/router.go
+++ b/routing/router.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"crypto/sha256"
 	"fmt"
+	"math"
 	"runtime"
 	"sort"
 	"sync"
@@ -1208,15 +1209,19 @@ func (r *ChannelRouter) processUpdate(msg interface{}) error {
 		// Now that we know this isn't a stale update, we'll apply the
 		// new edge policy to the proper directional edge within the
 		// channel graph.
-		if err = r.cfg.Graph.UpdateEdgePolicy(msg); err != nil {
-			err := errors.Errorf("unable to add channel: %v", err)
-			log.Error(err)
-			return err
-		}
+		if exists {
+			err = r.cfg.Graph.UpdateEdgePolicy(msg)
+			if err != nil {
+				err := errors.Errorf("unable to update "+
+					"channel policy: %v", err)
+				log.Error(err)
+				return err
+			}
 
-		invalidateCache = true
-		log.Tracef("New channel update applied: %v",
-			newLogClosure(func() string { return spew.Sdump(msg) }))
+			invalidateCache = true
+			log.Tracef("New channel update applied: %v",
+				newLogClosure(func() string { return spew.Sdump(msg) }))
+		}
 
 	default:
 		return errors.Errorf("wrong routing update message type")
@@ -1837,8 +1842,13 @@ func (r *ChannelRouter) processSendError(paySession *paymentSession,
 			paySession.ReportEdgeFailure(
 				failedEdge,
 			)
+			return
 		}
 
+		// Update routing hints.
+		paySession.UpdateEdgePolicy(failedEdge, update)
+
+		// Report edge policy failure.
 		paySession.ReportEdgePolicyFailure(
 			NewVertex(errSource), failedEdge,
 		)
@@ -2060,13 +2070,21 @@ func (r *ChannelRouter) applyChannelUpdate(msg *lnwire.ChannelUpdate,
 		return true
 	}
 
-	ch, _, _, err := r.GetChannelByID(msg.ShortChannelID)
-	if err != nil {
-		log.Errorf("Unable to retrieve channel by id: %v", err)
+	// Verify update signature validates.
+	if err := ValidateChannelUpdateAnn(pubKey, math.MaxInt64, msg); err != nil {
+		log.Errorf("Failed to validate channel update: %v", err)
 		return false
 	}
 
-	if err := ValidateChannelUpdateAnn(pubKey, ch.Capacity, msg); err != nil {
+	// If channel is in database, do further checks. Else, the
+	// update is for an additional private edge added by hints.
+	ch, _, _, err := r.GetChannelByID(msg.ShortChannelID)
+	if err != nil {
+		log.Errorf("Unable to retrieve channel by id: %v", err)
+		return true
+	}
+
+	if err := ValidateOptionalFields(ch.Capacity, msg); err != nil {
 		log.Errorf("Unable to validate channel update: %v", err)
 		return false
 	}

--- a/routing/router_test.go
+++ b/routing/router_test.go
@@ -33,6 +33,8 @@ type testCtx struct {
 
 	aliases map[string]Vertex
 
+	privKeys map[string]*btcec.PrivateKey
+
 	chain *mockChain
 
 	chainView *mockChainView
@@ -112,6 +114,7 @@ func createTestCtxFromGraphInstance(startingHeight uint32, graphInstance *testGr
 		router:    router,
 		graph:     graphInstance.graph,
 		aliases:   graphInstance.aliasMap,
+		privKeys:  graphInstance.privKeyMap,
 		chain:     chain,
 		chainView: chainView,
 	}

--- a/routing/testdata/basic_graph.json
+++ b/routing/testdata/basic_graph.json
@@ -39,7 +39,8 @@
         }, 
         {
             "source": false, 
-            "pubkey": "032b480de5d002f1a8fd1fe1bbf0a0f1b07760f65f052e66d56f15d71097c01add", 
+            "pubkey": "026c43a8ac1cd8519985766e90748e1e06871dab0ff6b8af27e8c1a61640481318",
+            "privkey": "82b266f659bd83a976bac11b2cc442baec5508e84e61085d7ec2b0fc52156c87",
             "alias": "songoku" 
         }, 
         {
@@ -154,7 +155,7 @@
             "capacity": 120000
         },
         {
-            "node_1": "032b480de5d002f1a8fd1fe1bbf0a0f1b07760f65f052e66d56f15d71097c01add",
+            "node_1": "026c43a8ac1cd8519985766e90748e1e06871dab0ff6b8af27e8c1a61640481318",
             "node_2": "0367cec75158a4129177bfb8b269cb586efe93d751b43800d456485e81c2620ca6",
             "channel_id": 12345, 
             "channel_point": "89dc56859c6a082d15ba1a7f6cb6be3fea62e1746e2cb8497b1189155c21a233:0", 
@@ -168,7 +169,7 @@
             "capacity": 100000
         },
         {
-            "node_1": "032b480de5d002f1a8fd1fe1bbf0a0f1b07760f65f052e66d56f15d71097c01add",
+            "node_1": "026c43a8ac1cd8519985766e90748e1e06871dab0ff6b8af27e8c1a61640481318",
             "node_2": "0367cec75158a4129177bfb8b269cb586efe93d751b43800d456485e81c2620ca6",
             "channel_id": 12345, 
             "channel_point": "89dc56859c6a082d15ba1a7f6cb6be3fea62e1746e2cb8497b1189155c21a233:0", 
@@ -182,7 +183,7 @@
             "capacity": 100000
         },
         {
-            "node_1": "032b480de5d002f1a8fd1fe1bbf0a0f1b07760f65f052e66d56f15d71097c01add",
+            "node_1": "026c43a8ac1cd8519985766e90748e1e06871dab0ff6b8af27e8c1a61640481318",
             "node_2": "036264734b40c9e91d3d990a8cdfbbe23b5b0b7ad3cd0e080a25dcd05d39eeb7eb",
             "channel_id": 3495345, 
             "channel_point": "9f155756b33a0a6827713965babbd561b55f9520444ac5db0cf7cb2eb0deb5bc:0", 
@@ -196,7 +197,7 @@
             "capacity": 110000
         },
         {
-            "node_1": "032b480de5d002f1a8fd1fe1bbf0a0f1b07760f65f052e66d56f15d71097c01add",
+            "node_1": "026c43a8ac1cd8519985766e90748e1e06871dab0ff6b8af27e8c1a61640481318",
             "node_2": "036264734b40c9e91d3d990a8cdfbbe23b5b0b7ad3cd0e080a25dcd05d39eeb7eb",
             "channel_id": 3495345, 
             "channel_point": "9f155756b33a0a6827713965babbd561b55f9520444ac5db0cf7cb2eb0deb5bc:0", 


### PR DESCRIPTION
This pull request address issue #2066 

Reconstruct the problem:
Setup composed of 3 nodes, A -> B -> C, where B -> C is private.
Create an invoice on C   (C:addinvoice with private flag)
Increase fee on B->C   (B:updatechanpolicy to a higher fee)
Attempt to pay invoice from A  (A:sendpayment --pay_req=xxx)
Receive payment error ("unable to route payment to destination: FeeInsufficient ... ")

After the fix the payment goes through.

A unit test on the 'basic graph' was added. The test adds a private channel between son goku and elst, with lower fees compared with the alternative routes from roasbeef to elst. A fee error is returned on first attempt to route through the private channel, with a higher fee, but still better compared with the alternative routes. The test checks that the after the update the payment is still routed through the private channel but with the updated higher fees.

A bug in the existing test TestSendPaymentErrorRepeatedFeeInsufficient was fixed too. I did a minimal fix. I believe this test can be further improved. The major issue was that the simulated error returned was rejected due to signature failure, and hence didn't simulate correctly the insufficient fees error as intended. In order to correctly sign the errors, an optional private key attribute was added to the basic graph and its parser. 


