### PR TITLE
[Makefile] Define `make imports`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ GOINSTALL := GO111MODULE=on go install -v
 GOTEST := GO111MODULE=on go test 
 
 GOVERSION := $(shell go version | awk '{print $$3}')
-GOFILES_NOVENDOR = $(shell find . -type f -name '*.go' -not -path "./vendor/*")
+GOFILES_NOVENDOR = $(shell find . -type f -name '*.go' -not -path "./vendor/*" -not -name "*pb.go" -not -name "*pb.gw.go")
 
 RM := rm -f
 CP := cp

--- a/Makefile
+++ b/Makefile
@@ -232,7 +232,9 @@ fuzz-run: $(GOFUZZ_BIN)
 # UTILITIES
 # =========
 
-fmt:
+fmt: goimports
+	@$(call print, "Fixing imports.")
+	goimports -w $(GOFILES_NOVENDOR)
 	@$(call print, "Formatting source.")
 	gofmt -l -w -s $(GOFILES_NOVENDOR)
 

--- a/monitoring/monitoring_on.go
+++ b/monitoring/monitoring_on.go
@@ -8,7 +8,7 @@ import (
 
 	"google.golang.org/grpc"
 
-	"github.com/grpc-ecosystem/go-grpc-prometheus"
+	grpc_prometheus "github.com/grpc-ecosystem/go-grpc-prometheus"
 	"github.com/lightningnetwork/lnd/lncfg"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 )


### PR DESCRIPTION
This PR defines `make imports` for running `goimports` on the source. It also enables it for the linter and formats the affected files.