### PR TITLE
[WIP] add option to discover external NAT IP only 

### DIFF
--- a/config.go
+++ b/config.go
@@ -194,6 +194,7 @@ type config struct {
 	ExternalIPs      []net.Addr
 	DisableListen    bool `long:"nolisten" description:"Disable listening for incoming peer connections"`
 	NAT              bool `long:"nat" description:"Toggle NAT traversal support (using either UPnP or NAT-PMP) to automatically advertise your external IP address to the network -- NOTE this does not support devices behind multiple NATs"`
+	NATWatchOnly     bool `long:"nat-watch-only" description:"Use together with --nat: If true, then no port forwardings will be attempted. Either UPnP or NAT-PMP will only be used to discover external IP."`
 
 	DebugLevel string `short:"d" long:"debuglevel" description:"Logging level for all subsystems {trace, debug, info, warn, error, critical} -- You may also specify <subsystem>=<level>,<subsystem2>=<level>,... to set the log level for individual subsystems -- Use show to list available subsystems"`
 


### PR DESCRIPTION
In the discussion in PR #2014 it became clear that it would be desirable to give `lnd` users the option to use NAT discovery techniques (UPnP, NAT-PMP or may be also PCP) to learn about the external IP of the NAT router (in order to announce the external `host:port` combination on the p2p network) **without** having to allow port forwardings to be setup by `lnd`. Instead in this case the user would manually create the port forwarding.

I have started (but not finished) the implementation of this - but I would like to get some early feedback on the flag and the logic that results out of it. I see two different ways to introduce this change into `lnd` (wordings can be discussed.. ;-) ):

Option 1)

| ID# | Flag `nat`  | Flag `nat-watch-only` |  `lnd` behavior |
| --- | ------------- | ------------- | ------------- |
| 1.1 | false  | false | Will **not** scan for a NAT device; will **not** start NAT watcher; will **not** attempt to set up any port forwarding |
| 1.2 | false  | **true** | Will **not** scan for a NAT device; will **not** start NAT watcher; will **not** attempt to set up any port forwarding |
| 1.3 | **true**  | false | Will scan for a NAT device; will start NAT watcher; will attempt to set up port forwarding |
| 1.4 | **true**  | **true** | Will scan for a NAT device; will start NAT watcher; will **not** attempt to set up any port forwarding |


Option 2)

| ID# | Flag `nat-discover-ext-ip`  | Flag `nat-add-port-forwarding` |  `lnd` behavior |
| --- | ------------- | ------------- | ------------- |
| 2.1 | false  | false | Will **not** scan for a NAT device; will **not** start NAT watcher; will **not** attempt to set up any port forwarding |
| 2.2 | false  | **true** | **invalid** -> do same as 2.4 |
| 2.3 | **true**  | false | Will scan for a NAT device; will start NAT watcher |
| 2.4 | **true**  | **true** | Will scan for a NAT device; will start NAT watcher; will attempt to set up port forwarding |


Option 2) might be considered more clear - but would require to change the already introduced `--nat` flag.
