### PR TITLE
build+lnwallet: notify wallet upon relevant transaction confirmation

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -106,7 +106,7 @@
   revision = "ab6388e0c60ae4834a1f57511e20c17b5f78be4b"
 
 [[projects]]
-  digest = "1:2995aa2bcb95d13a8df309e1dcb6ac20786acb90df5a090bf5e07c2086219ce8"
+  digest = "1:014bf3112e2bc78db2409f1d7b328c642fe27f2e0b5983595b240bf12578f335"
   name = "github.com/btcsuite/btcwallet"
   packages = [
     "chain",
@@ -127,7 +127,7 @@
     "wtxmgr",
   ]
   pruneopts = "UT"
-  revision = "6d43b2e29b5eef0f000a301ee6fbd146db75d118"
+  revision = "4c01c0878c4ea6ff80711dbfe49e49199ca07607"
 
 [[projects]]
   branch = "master"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -72,7 +72,7 @@
 
 [[constraint]]
   name = "github.com/btcsuite/btcwallet"
-  revision = "6d43b2e29b5eef0f000a301ee6fbd146db75d118"
+  revision = "4c01c0878c4ea6ff80711dbfe49e49199ca07607"
 
 [[constraint]]
   name = "github.com/tv42/zbase32"

--- a/lnwallet/btcwallet/btcwallet.go
+++ b/lnwallet/btcwallet/btcwallet.go
@@ -714,6 +714,11 @@ func (b *BtcWallet) SubscribeTransactions() (lnwallet.TransactionSubscription, e
 //
 // This is a part of the WalletController interface.
 func (b *BtcWallet) IsSynced() (bool, int64, error) {
+	// First, we'll ensure the wallet is not currently undergoing a rescan.
+	if !b.wallet.ChainSynced() {
+		return false, 0, nil
+	}
+
 	// Grab the best chain state the wallet is currently aware of.
 	syncState := b.wallet.Manager.SyncedTo()
 

--- a/lnwallet/btcwallet/btcwallet.go
+++ b/lnwallet/btcwallet/btcwallet.go
@@ -153,26 +153,13 @@ func (b *BtcWallet) InternalWallet() *base.Wallet {
 //
 // This is a part of the WalletController interface.
 func (b *BtcWallet) Start() error {
-	// Establish an RPC connection in addition to starting the goroutines
-	// in the underlying wallet.
-	if err := b.chain.Start(); err != nil {
-		return err
-	}
-
-	// Start the underlying btcwallet core.
-	b.wallet.Start()
-
-	// Pass the rpc client into the wallet so it can sync up to the
-	// current main chain.
-	b.wallet.SynchronizeRPC(b.chain)
-
+	// We'll start by unlocking the wallet and ensuring that the KeyScope:
+	// (1017, 1) exists within the internal waddrmgr. We'll need this in
+	// order to properly generate the keys required for signing various
+	// contracts.
 	if err := b.wallet.Unlock(b.cfg.PrivatePass, nil); err != nil {
 		return err
 	}
-
-	// We'll now ensure that the KeyScope: (1017, 1) exists within the
-	// internal waddrmgr. We'll need this in order to properly generate the
-	// keys required for signing various contracts.
 	_, err := b.wallet.Manager.FetchScopedKeyManager(b.chainKeyScope)
 	if err != nil {
 		// If the scope hasn't yet been created (it wouldn't been
@@ -190,6 +177,19 @@ func (b *BtcWallet) Start() error {
 			return err
 		}
 	}
+
+	// Establish an RPC connection in addition to starting the goroutines
+	// in the underlying wallet.
+	if err := b.chain.Start(); err != nil {
+		return err
+	}
+
+	// Start the underlying btcwallet core.
+	b.wallet.Start()
+
+	// Pass the rpc client into the wallet so it can sync up to the
+	// current main chain.
+	b.wallet.SynchronizeRPC(b.chain)
 
 	return nil
 }


### PR DESCRIPTION
In this PR, we update our `btcwallet` dependency to include the latest changes that aim to address the recently discovered `SendOutputs` issue. This issue was caused by the wallet no longer requesting to be notified of when a transaction that pays to a change address confirms on-chain. This has been addressed by the dependent `btcwallet` PRs listed below.

This PR also includes fixes for minor issues that arose once addressing the original issue. Descriptions for those can be found in their respective commit in-line.

Depends on #2175, https://github.com/btcsuite/btcwallet/pull/571, https://github.com/btcsuite/btcwallet/pull/573.

Fixes #2011.