### PR TITLE
Added simnet support for litecoind

### DIFF
--- a/chainparams.go
+++ b/chainparams.go
@@ -70,6 +70,14 @@ var litecoinMainNetParams = litecoinNetParams{
 	CoinType: keychain.CoinTypeLitecoin,
 }
 
+// litecoinSimNetParams contains parameters specific to the simulation test
+// network.
+var litecoinSimNetParams = litecoinNetParams{
+	Params:   &litecoinCfg.SimNetParams,
+	rpcPort:  "18556",
+	CoinType: keychain.CoinTypeTestnet,
+}
+
 // regTestNetParams contains parameters specific to a local regtest network.
 var regTestNetParams = bitcoinNetParams{
 	Params:   &bitcoinCfg.RegressionNetParams,

--- a/config.go
+++ b/config.go
@@ -544,10 +544,6 @@ func loadConfig() (*config, error) {
 			"litecoin.active must be set to 1 (true)", funcName)
 
 	case cfg.Litecoin.Active:
-		if cfg.Litecoin.SimNet {
-			str := "%s: simnet mode for litecoin not currently supported"
-			return nil, fmt.Errorf(str, funcName)
-		}
 		if cfg.Litecoin.RegTest {
 			str := "%s: regnet mode for litecoin not currently supported"
 			return nil, fmt.Errorf(str, funcName)
@@ -563,6 +559,10 @@ func loadConfig() (*config, error) {
 		// while we're at it.
 		numNets := 0
 		var ltcParams litecoinNetParams
+		if cfg.Litecoin.SimNet {
+			numNets++
+			ltcParams = litecoinSimNetParams
+		}
 		if cfg.Litecoin.MainNet {
 			numNets++
 			ltcParams = litecoinMainNetParams
@@ -611,10 +611,6 @@ func loadConfig() (*config, error) {
 				return nil, err
 			}
 		case "litecoind":
-			if cfg.Litecoin.SimNet {
-				return nil, fmt.Errorf("%s: litecoind does not "+
-					"support simnet", funcName)
-			}
 			err := parseRPCParams(cfg.Litecoin, cfg.LitecoindMode,
 				litecoinChain, funcName)
 			if err != nil {

--- a/lnd.go
+++ b/lnd.go
@@ -117,7 +117,7 @@ func lndMain() error {
 	case cfg.Bitcoin.MainNet || cfg.Litecoin.MainNet:
 		network = "mainnet"
 
-	case cfg.Bitcoin.SimNet:
+	case cfg.Bitcoin.SimNet || cfg.Litecoin.SimNet:
 		network = "simnet"
 
 	case cfg.Bitcoin.RegTest:


### PR DESCRIPTION
This PR adds support of simnet of litecoind. 
There is PR in [litecoind](https://github.com/litecoin-project/litecoin/pull/559) that adds support of simnet based on ltcd implementation. 