### PR TITLE
build: update to latest version of btcwallet

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -106,7 +106,7 @@
   revision = "ab6388e0c60ae4834a1f57511e20c17b5f78be4b"
 
 [[projects]]
-  digest = "1:014bf3112e2bc78db2409f1d7b328c642fe27f2e0b5983595b240bf12578f335"
+  digest = "1:bed8f5cb3fd6e9eabcb32cfa6c550538e8181d45eb57d91f0d52c97ac679cb61"
   name = "github.com/btcsuite/btcwallet"
   packages = [
     "chain",
@@ -127,7 +127,7 @@
     "wtxmgr",
   ]
   pruneopts = "UT"
-  revision = "4c01c0878c4ea6ff80711dbfe49e49199ca07607"
+  revision = "55c7c63993216f15d57f0118e86e3fe832e37f15"
 
 [[projects]]
   branch = "master"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -72,7 +72,7 @@
 
 [[constraint]]
   name = "github.com/btcsuite/btcwallet"
-  revision = "4c01c0878c4ea6ff80711dbfe49e49199ca07607"
+  revision = "55c7c63993216f15d57f0118e86e3fe832e37f15"
 
 [[constraint]]
   name = "github.com/tv42/zbase32"


### PR DESCRIPTION
In this commit, we update to the latest version of btcwallet. This
version includes a bug fix which ensures that the wallet birthday sanity
check only executes once and not each time the deamon is restarted.