### PR TITLE
htlcswitch+config+server: adding RejectHTLC flag

### DIFF
--- a/config.go
+++ b/config.go
@@ -311,6 +311,8 @@ type config struct {
 
 	RejectPush bool `long:"rejectpush" description:"If true, lnd will not accept channel opening requests with non-zero push amounts. This should prevent accidental pushes to merchant nodes."`
 
+	RejectHTLC bool `long:"rejecthtlc" description:"If true, lnd will not forward any HTLCs that are meant as onward payments. This option will still allow lnd to send HTLCs and receive HTLCs but lnd won't be used as a hop."`
+
 	StaggerInitialReconnect bool `long:"stagger-initial-reconnect" description:"If true, will apply a randomized staggering between 0s and 30s when reconnecting to persistent peers on startup. The first 10 reconnections will be attempted instantly, regardless of the flag's value"`
 
 	MaxOutgoingCltvExpiry uint32 `long:"max-cltv-expiry" description:"The maximum number of blocks funds could be locked up for when forwarding payments."`

--- a/server.go
+++ b/server.go
@@ -435,6 +435,7 @@ func newServer(listenAddrs []net.Addr, chanDB *channeldb.DB,
 		AckEventTicker:         ticker.New(htlcswitch.DefaultAckInterval),
 		NotifyActiveChannel:    s.channelNotifier.NotifyActiveChannelEvent,
 		NotifyInactiveChannel:  s.channelNotifier.NotifyInactiveChannelEvent,
+		RejectHTLC:             cfg.RejectHTLC,
 	}, uint32(currentHeight))
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
In this PR, we add a flag to the command line config `--rejecthtlc` and a 
field in the HTLC Switch config `RejectHTLC bool`.

The user should be able to start lnd with the `--rejecthtlc` flag which will
mean that lnd will reject any onward HTLCs. The switch will still allow receiving
HTLCs meant for the node and can still send HTLCs.

fixes #1298 and #2109

