### PR TITLE
fix bug which prevents btcd from starting different networks using en…

### DIFF
--- a/docker/.env
+++ b/docker/.env
@@ -1,0 +1,6 @@
+# modify these values locally to change the behavior of btcd
+
+RPCUSER=devuser
+RPCPASS=devpass
+NETWORK=simnet
+DEBUG=info

--- a/docker/README.md
+++ b/docker/README.md
@@ -294,9 +294,8 @@ bitcoins. The schema will be following:
 First of all you need to run `btcd` node in `testnet` and wait for it to be 
 synced with test network (`May the Force and Patience be with you`).
 ```bash 
-
 # Run "btcd" and set environment variable to testnet:
-$ docker-compose run -d -e NETWORK=testnet "btcd"
+$ NETWORK="testnet" docker-compose run -d btcd
 ```
 
 After `btcd` synced, connect `Alice` to the `Faucet` node.

--- a/docker/README.md
+++ b/docker/README.md
@@ -294,11 +294,9 @@ bitcoins. The schema will be following:
 First of all you need to run `btcd` node in `testnet` and wait for it to be 
 synced with test network (`May the Force and Patience be with you`).
 ```bash 
-# Init bitcoin network env variable:
-$ export NETWORK="testnet"
 
-# Run "btcd" node:
-$ docker-compose up -d "btcd"
+# Run "btcd" and set environment variable to testnet:
+$ docker-compose run -d -e NETWORK=testnet "btcd"
 ```
 
 After `btcd` synced, connect `Alice` to the `Faucet` node.

--- a/docker/README.md
+++ b/docker/README.md
@@ -7,8 +7,8 @@ automatically by their `docker-compose` config file.
 ### Prerequisites
 Name  | Version 
 --------|---------
-docker-compose | 1.9.0
-docker | 1.13.0
+docker-compose | 1.23.1
+docker | 18.06.1-ce
   
 ### Table of content
  * [Create lightning network cluster](#create-lightning-network-cluster)

--- a/docker/btcd/start-btcctl.sh
+++ b/docker/btcd/start-btcctl.sh
@@ -38,11 +38,6 @@ set_default() {
    return "$VARIABLE"
 }
 
-# Set default variables if needed.
-RPCUSER=$(set_default "$RPCUSER" "devuser")
-RPCPASS=$(set_default "$RPCPASS" "devpass")
-NETWORK=$(set_default "$NETWORK" "simnet")
-
 exec btcctl \
     "--$NETWORK" \
     --rpccert="/rpc/rpc.cert" \

--- a/docker/btcd/start-btcd.sh
+++ b/docker/btcd/start-btcd.sh
@@ -38,24 +38,34 @@ set_default() {
    return "$VARIABLE"
 }
 
-# Set default variables if needed.
-RPCUSER=$(set_default "$RPCUSER" "devuser")
-RPCPASS=$(set_default "$RPCPASS" "devpass")
-DEBUG=$(set_default "$DEBUG" "info")
-NETWORK=$(set_default "$NETWORK" "simnet")
+if [ -z "$NETWORK" ] || [ "$NETWORK" == "mainnet" ]
+then
+  PARAMS=$(echo \
+      "--debuglevel=$DEBUG" \
+      "--rpcuser=$RPCUSER" \
+      "--rpcpass=$RPCPASS" \
+      "--datadir=/data" \
+      "--logdir=/data" \
+      "--rpccert=/rpc/rpc.cert" \
+      "--rpckey=/rpc/rpc.key" \
+      "--rpclisten=0.0.0.0" \
+      "--txindex"
+  )
+else
+  PARAMS=$(echo \
+      "--$NETWORK" \
+      "--debuglevel=$DEBUG" \
+      "--rpcuser=$RPCUSER" \
+      "--rpcpass=$RPCPASS" \
+      "--datadir=/data" \
+      "--logdir=/data" \
+      "--rpccert=/rpc/rpc.cert" \
+      "--rpckey=/rpc/rpc.key" \
+      "--rpclisten=0.0.0.0" \
+      "--txindex"
+  )
+fi
 
-PARAMS=$(echo \
-    "--$NETWORK" \
-    "--debuglevel=$DEBUG" \
-    "--rpcuser=$RPCUSER" \
-    "--rpcpass=$RPCPASS" \
-    "--datadir=/data" \
-    "--logdir=/data" \
-    "--rpccert=/rpc/rpc.cert" \
-    "--rpckey=/rpc/rpc.key" \
-    "--rpclisten=0.0.0.0" \
-    "--txindex"
-)
 
 # Set the mining flag only if address is non empty.
 if [[ -n "$MINING_ADDRESS" ]]; then

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,6 +1,5 @@
 version: '2'
 services:
-
     # btc is an image of bitcoin node which used as base image for btcd and
     # btccli. The environment variables default values determined on stage of
     # container start within starting script.
@@ -9,20 +8,20 @@ services:
       build:
         context: btcd/
       volumes:
-            - shared:/rpc
-            - bitcoin:/data
+        - shared:/rpc
+        - bitcoin:/data
       environment:
-        - RPCUSER
-        - RPCPASS
-        - NETWORK
+        RPCUSER: $RPCUSER
+        RPCPASS: $RPCPASS
+        NETWORK: $NETWORK
 
     btcd:
-        extends: btc
-        container_name: btcd
-        environment:
-          - DEBUG
-          - MINING_ADDRESS
-        entrypoint: ["./start-btcd.sh"]
+      extends: btc
+      container_name: btcd
+      entrypoint: ["./start-btcd.sh"]
+      environment:
+        DEBUG: $DEBUG
+        MINING_ADDRESS: $MINING_ADDRESS
 
     btcctl:
         extends: btc
@@ -30,7 +29,6 @@ services:
         links:
             - "btcd:rpcserver"
         entrypoint: ["./start-btcctl.sh"]
-
 
     # ltc is an image of litecoin node which used as base image for ltcd and
     # ltcctl. The environment variables default values determined on stage of
@@ -40,8 +38,8 @@ services:
       build:
         context: ltcd/
       volumes:
-            - shared:/rpc
-            - litecoin:/data
+        - shared:/rpc
+        - litecoin:/data
       environment:
         - RPCUSER
         - RPCPASS


### PR DESCRIPTION
PR for issue: https://github.com/lightningnetwork/lnd/issues/1792#issuecomment-416408260

to run btcd using mainnet, there should be no network defined.  I added an additional check for if the network `mainnet` is defined also.  In addition, I removed the default value setters in the `.sh` scripts instead setting the default values using `.env`.  I think the docker setup could be simplified further by just removing `start-btcctl.sh` and `start-btcd.sh` and just set the entrypoint to `btcctl` and `btcd` respectively.