### PR TITLE
Invoices with --private marked as such on LookupInvoice

### DIFF
--- a/rpcserver.go
+++ b/rpcserver.go
@@ -2950,6 +2950,7 @@ func createRPCInvoice(invoice *channeldb.Invoice) (*lnrpc.Invoice, error) {
 		FallbackAddr:    fallbackAddr,
 		RouteHints:      routeHints,
 		AddIndex:        invoice.AddIndex,
+		Private:         len(routeHints) > 0,
 		SettleIndex:     invoice.SettleIndex,
 		AmtPaidSat:      int64(satAmtPaid),
 		AmtPaidMsat:     int64(invoice.AmtPaid),


### PR DESCRIPTION
When looking at invoices that were created with the private option on they do not reflect their private status correctly. This PR suggest a fix for that.
Fix for #2179.