### PR TITLE
Remove unneeded backend config

### DIFF
--- a/lnwallet/btcwallet/driver.go
+++ b/lnwallet/btcwallet/driver.go
@@ -3,8 +3,7 @@ package btcwallet
 import (
 	"fmt"
 
-	"github.com/btcsuite/btcwallet/chain"
-	"github.com/lightningnetwork/lnd/lnwallet"
+		"github.com/lightningnetwork/lnd/lnwallet"
 )
 
 const (
@@ -37,7 +36,6 @@ func init() {
 	driver := &lnwallet.WalletDriver{
 		WalletType: walletType,
 		New:        createNewWallet,
-		BackEnds:   chain.BackEnds,
 	}
 
 	if err := lnwallet.RegisterWallet(driver); err != nil {

--- a/lnwallet/btcwallet/driver.go
+++ b/lnwallet/btcwallet/driver.go
@@ -3,7 +3,7 @@ package btcwallet
 import (
 	"fmt"
 
-		"github.com/lightningnetwork/lnd/lnwallet"
+	"github.com/lightningnetwork/lnd/lnwallet"
 )
 
 const (

--- a/lnwallet/interface.go
+++ b/lnwallet/interface.go
@@ -317,10 +317,6 @@ type WalletDriver struct {
 	// initialization flexibility, thereby accommodating several potential
 	// WalletController implementations.
 	New func(args ...interface{}) (WalletController, error)
-
-	// BackEnds returns a list of available chain service drivers for the
-	// wallet driver. This could be e.g. bitcoind, btcd, neutrino, etc.
-	BackEnds func() []string
 }
 
 var (

--- a/lnwallet/interface_test.go
+++ b/lnwallet/interface_test.go
@@ -2371,7 +2371,7 @@ func TestLightningWallet(t *testing.T) {
 	}
 
 	for _, walletDriver := range lnwallet.RegisteredWallets() {
-		for _, backEnd := range walletDriver.BackEnds() {
+		for _, backEnd := range chain.BackEnds() {
 			runTests(t, walletDriver, backEnd, miningNode,
 				rpcConfig, chainNotifier)
 		}


### PR DESCRIPTION
Since the chain source is abstracted there seems to be no reason that all wallet drivers shouldn't work with every backend. So there is no need for each wallet driver to specify which backends it supports.