### PR TITLE
[WIP] channeldb+routing+switch: move payment tracking from rpcserver to router+switch

### DIFF
--- a/channeldb/error.go
+++ b/channeldb/error.go
@@ -39,6 +39,14 @@ var (
 	// created.
 	ErrNoPaymentsCreated = fmt.Errorf("there are no existing payments")
 
+	// ErrDuplicatePayment is returned when a payment with the target payment
+	// hash already exists.
+	ErrDuplicatePayment = fmt.Errorf("payment with payment hash already exists")
+
+	// ErrPaymentNotFound is returned when a payment with the target payment
+	// hash can't be found.
+	ErrPaymentNotFound = fmt.Errorf("unable to locate payment with that hash")
+
 	// ErrNodeNotFound is returned when node bucket exists, but node with
 	// specific identity can't be found.
 	ErrNodeNotFound = fmt.Errorf("link node with target identity not found")

--- a/htlcswitch/switch.go
+++ b/htlcswitch/switch.go
@@ -282,7 +282,7 @@ type Switch struct {
 // New creates the new instance of htlc switch.
 func New(cfg Config, currentHeight uint32) (*Switch, error) {
 	circuitMap, err := NewCircuitMap(&CircuitMapConfig{
-		DB:                    cfg.DB,
+		DB: cfg.DB,
 		ExtractErrorEncrypter: cfg.ExtractErrorEncrypter,
 	})
 	if err != nil {
@@ -889,6 +889,16 @@ func (s *Switch) handleLocalResponse(pkt *htlcPacket) {
 		}
 
 		preimage = htlc.PaymentPreimage
+
+		// Update this payment's record with the preimage now that
+		// we have it. This will allow us to retrieve the preimage
+		// if the payment is attempted in the future.
+		err = s.cfg.DB.UpdatePaymentPreimage(preimage)
+		if err != nil {
+			log.Warnf("Unable to persist payment preimage %x: %v",
+				pkt.circuit.PaymentHash, err)
+			return
+		}
 
 	// We've received a fail update which means we can finalize the user
 	// payment and return fail response.

--- a/routing/router.go
+++ b/routing/router.go
@@ -146,6 +146,10 @@ type ChannelPolicy struct {
 // the configuration MUST be non-nil for the ChannelRouter to carry out its
 // duties.
 type Config struct {
+	// DB is the database that the ChannelRouter will use to store
+	// payments when they are initiated.
+	DB *channeldb.DB
+
 	// Graph is the channel graph that the ChannelRouter will use to gather
 	// metrics from and also to carry out path finding queries.
 	// TODO(roasbeef): make into an interface
@@ -1654,6 +1658,13 @@ func (r *ChannelRouter) sendPayment(payment *LightningPayment,
 		return [32]byte{}, nil, err
 	}
 
+	// We save the payment in the database before attempting any payments
+	// so that we will have a record of its' existence despite the outcome.
+	err := r.savePayment(payment)
+	if err != nil {
+		return preImage, nil, err
+	}
+
 	var finalCLTVDelta uint16
 	if payment.FinalCLTVDelta == nil {
 		finalCLTVDelta = DefaultFinalCLTVDelta
@@ -1714,6 +1725,13 @@ func (r *ChannelRouter) sendPayment(payment *LightningPayment,
 				return spew.Sdump(route)
 			}),
 		)
+
+		// Update the payment's route so that if it succeeds
+		// we know what path it took and what the fees were.
+		err := r.addPaymentRoute(payment, route)
+		if err != nil {
+			return preImage, nil, err
+		}
 
 		// Generate the raw encoded sphinx packet to be included along
 		// with the htlcAdd message that we send directly to the
@@ -1989,6 +2007,32 @@ func (r *ChannelRouter) sendPayment(payment *LightningPayment,
 
 		return preImage, route, nil
 	}
+}
+
+// savePayment saves a payment before any attempts have taken place
+// in the router.
+func (r *ChannelRouter) savePayment(payment *LightningPayment) error {
+	return r.cfg.DB.AddPayment(payment.paymentHash, payment.Amount)
+}
+
+// addPaymentRoute updates an existing payment with a particular route
+// for a given routing attempt.
+func (r *ChannelRouter) addPaymentRoute(payment *LightningPayment,
+	route *Route) error {
+
+	paymentPath := make([][33]byte, len(route.Hops))
+	for i, hop := range route.Hops {
+		hopPub := hop.PubKeyBytes
+		copy(paymentPath[i][:], hopPub[:])
+	}
+
+	r := &channeldb.OutgoingPaymentRoute{
+		Path:           paymentPath,
+		Fee:            route.TotalFees,
+		TimeLockLength: route.TotalTimeLock,
+	}
+
+	return r.cfg.DB.UpdatePaymentRoute(payment.PaymentHash, r)
 }
 
 // pruneVertexFailure will attempt to prune a vertex from the current available

--- a/server.go
+++ b/server.go
@@ -509,6 +509,7 @@ func newServer(listenAddrs []net.Addr, chanDB *channeldb.DB, cc *chainControl,
 	s.currentNodeAnn = nodeAnn
 
 	s.chanRouter, err = routing.New(routing.Config{
+		DB:        chanDB,
 		Graph:     chanGraph,
 		Chain:     cc.chainIO,
 		ChainView: cc.chainView,


### PR DESCRIPTION
This change moves responsibility for creating payments in the database
from the rpcserver and the original sender of the payment to the router
and the switch.

Previously, anytime the original sender was no longer available (e.g.
because lnd restarted or the client closed the stream) the payment would
not be saved in the database, and the preimage would not be available.

Now, the payment is originally created in the router before any payment
attempts are created, but is saved without a preimage. When a payment is
attempted, the payment in the database is updated with the route being attempted.
When the payment is finally complete and a preimage is available, the payment
is updated in the database with the preimage by the switch, which is guaranteed
to be alive when the payment completes.

Making this change required creating a new index for the payments by their
hash so that they can be retrieved and updated without knowing the order
in which they were inserted.

Specific changes include:
- Add an index for payments by payment hash
- Require a payment hash when adding a payment
- Add UpdatePaymentRoute function to the DB
- Add UpdatePaymentPreimage function to the DB
- Create payments in the Router, add Preimages in the Switch

This is in response to the first two items listed in https://github.com/lightningnetwork/lnd/issues/2183 and should fix https://github.com/lightningnetwork/lnd/issues/2032 (although I haven't tested it).

This PR is **work in progress** and does not contain any updates to test cases. I'm posting it now for early feedback about the direction this PR is taking prior to going any further.