### PR TITLE
channeldb/db: prevent filtering channels with unconfirmed close txs

### DIFF
--- a/channeldb/channel_test.go
+++ b/channeldb/channel_test.go
@@ -205,7 +205,7 @@ func createTestChannelState(cdb *DB) (*OpenChannel, error) {
 	return &OpenChannel{
 		ChanType:          SingleFunder,
 		ChainHash:         key,
-		FundingOutpoint:   *testOutpoint,
+		FundingOutpoint:   wire.OutPoint{Hash: key, Index: rand.Uint32()},
 		ShortChannelID:    chanID,
 		IsInitiator:       true,
 		IsPending:         true,

--- a/channeldb/db.go
+++ b/channeldb/db.go
@@ -450,9 +450,20 @@ func (d *DB) FetchPendingChannels() ([]*OpenChannel, error) {
 }
 
 // FetchWaitingCloseChannels will return all channels that have been opened,
-// but now is waiting for a closing transaction to be confirmed.
+// but are now waiting for a closing transaction to be confirmed.
+//
+// NOTE: This includes channels that are also pending to be opened.
 func (d *DB) FetchWaitingCloseChannels() ([]*OpenChannel, error) {
-	return fetchChannels(d, false, true)
+	waitingClose, err := fetchChannels(d, false, true)
+	if err != nil {
+		return nil, err
+	}
+	pendingWaitingClose, err := fetchChannels(d, true, true)
+	if err != nil {
+		return nil, err
+	}
+
+	return append(waitingClose, pendingWaitingClose...), nil
 }
 
 // fetchChannels attempts to retrieve channels currently stored in the


### PR DESCRIPTION
In this commit, we address an issue with the FetchWaitingCloseChannels
method where it would not properly return channels that are unconfirmed
and also have an unconfirmed closing transaction because they were
filtered out. We fix this by modifying the filtering logic to only apply
when the channel has already confirmed.

Related to #2217.