### PR TITLE
htlcswitch/mock: decrease interval fwd+log tickers

### DIFF
--- a/htlcswitch/mock.go
+++ b/htlcswitch/mock.go
@@ -158,8 +158,8 @@ func initSwitchWithDB(startingHeight uint32, db *channeldb.DB) (*Switch, error) 
 			return nil, nil
 		},
 		Notifier:       &mockNotifier{},
-		FwdEventTicker: ticker.MockNew(DefaultFwdEventInterval),
-		LogEventTicker: ticker.MockNew(DefaultLogInterval),
+		FwdEventTicker: ticker.MockNew(2 * time.Second),
+		LogEventTicker: ticker.MockNew(2 * time.Second),
 	}
 
 	return New(cfg, startingHeight)


### PR DESCRIPTION
Allows more reliable coverage results for
the htlcswitch package. Initially pointed
out by @offerm in #1641.