### PR TITLE
update `make btcd` command with `GO111MODULE=on`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -94,9 +94,9 @@ $(LINT_BIN):
 	@$(call print, "Fetching gometalinter.v2")
 	GO111MODULE=off go get -u $(LINT_PKG)
 
-btcd: 
+btcd:
 	@$(call print, "Installing btcd.")
-	go get -v github.com/btcsuite/btcd/@v0.0.0-20180823030728-$(BTCD_COMMIT)
+	GO111MODULE=on go get -v github.com/btcsuite/btcd/@v0.0.0-20180823030728-$(BTCD_COMMIT)
 
 # ============
 # INSTALLATION
@@ -121,7 +121,7 @@ scratch: build
 
 check: unit itest
 
-itest-only: 
+itest-only:
 	@$(call print, "Running integration tests.")
 	$(ITEST)
 
@@ -135,7 +135,7 @@ unit-cover:
 	@$(call print, "Running unit coverage tests.")
 	echo "mode: count" > profile.cov
 	$(COVER)
-		
+
 unit-race:
 	@$(call print, "Running unit race tests.")
 	export CGO_ENABLED=1; env GORACE="history_size=7 halt_on_errors=1" $(UNIT_RACE)


### PR DESCRIPTION
While going through the [Installation tutorial](https://dev.lightning.community/guides/installation/), I'm getting the following error after running `make btcd` (on MacOS 10.14.1):

```sh
make btcd
 Installing btcd.
go get -v github.com/btcsuite/btcd/@v0.0.0-20180823030728-7d2daa5bfef28c5e282571bc06416516936115ee
go get: warning: modules disabled by GO111MODULE=auto in GOPATH/src;
	ignoring go.mod;
	see 'go help modules'
go: cannot use path@version syntax in GOPATH mode
make: *** [btcd] Error 1
```

This appears to be related to https://github.com/lightningnetwork/lnd/pull/2253 &mdash; which also needed to set `GO111MODULE=on` before installing `btcd`.

I should caution, though, that my experience with Go is nearly nonexistent, so if there's a better way to handle this, I'm all for it 😄.