### PR TITLE
[make+mod] fetch correct btcd version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ BTCD_DIR :=${GOPATH}/src/$(BTCD_PKG)
 COMMIT := $(shell git describe --abbrev=40 --dirty)
 LDFLAGS := -ldflags "-X $(PKG)/build.Commit=$(COMMIT)"
 
-BTCD_COMMIT := $(shell cat go.sum | \
+BTCD_COMMIT := $(shell cat go.mod | \
 		grep $(BTCD_PKG) | \
 		tail -n1 | \
 		awk -F " " '{ print $$2 }' | \

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,6 @@ BTCD_COMMIT := $(shell cat go.mod | \
 		grep $(BTCD_PKG) | \
 		tail -n1 | \
 		awk -F " " '{ print $$2 }' | \
-		awk -F "-" '{ print $$3 }' | \
 		awk -F "/" '{ print $$1 }')
 
 GOBUILD := GO111MODULE=on go build -v
@@ -90,7 +89,7 @@ $(LINT_BIN):
 
 btcd:
 	@$(call print, "Installing btcd.")
-	GO111MODULE=on go get -v github.com/btcsuite/btcd/@v0.0.0-20180823030728-$(BTCD_COMMIT)
+	GO111MODULE=on go get -v github.com/btcsuite/btcd/@$(BTCD_COMMIT)
 
 # ============
 # INSTALLATION


### PR DESCRIPTION
I noticed that the `go.sum` file was changing when running unit tests. Fixed by not hardcoding the btcd dependency date, and  instead using the whole version string. 

Also gets the version string from `go.mod` instead of `go.sum`, as it will always hold the current dependency.