### PR TITLE
Add --notls to disable TLS for REST endpoint

### DIFF
--- a/config.go
+++ b/config.go
@@ -190,6 +190,7 @@ type config struct {
 	RawRESTListeners []string `long:"restlisten" description:"Add an interface/port/socket to listen for REST connections"`
 	RawListeners     []string `long:"listen" description:"Add an interface/port to listen for peer connections"`
 	RawExternalIPs   []string `long:"externalip" description:"Add an ip:port to the list of local addresses we claim to listen on to peers. If a port is not specified, the default (9735) will be used regardless of other parameters"`
+	DisableTLS       bool     `long:"notls" description:"Disable TLS for RPC connetions"`
 	RPCListeners     []net.Addr
 	RESTListeners    []net.Addr
 	Listeners        []net.Addr

--- a/lnd.go
+++ b/lnd.go
@@ -713,7 +713,15 @@ func waitForWalletPassword(grpcEndpoints, restEndpoints []net.Addr,
 	srv := &http.Server{Handler: mux}
 
 	for _, restEndpoint := range restEndpoints {
-		lis, err := lncfg.TLSListenOnAddress(restEndpoint, tlsConf)
+		var (
+			lis net.Listener
+			err error
+		)
+		if !cfg.DisableTLS {
+			lis, err = lncfg.TLSListenOnAddress(restEndpoint, tlsConf)
+		} else {
+			lis, err = net.Listen("tcp", restEndpoint.String())
+		}
 		if err != nil {
 			ltndLog.Errorf(
 				"password gRPC proxy unable to listen on %s",


### PR DESCRIPTION
Make it possible to disable TLS for REST endpoint.

I need it inside BTCPay because in the internal network, LND and BTCPay communicate together.

Internal network
```
BTCPAY <-> LND
```

For internet requests, I use HTTPS dispensed by NGINX.

Internet 
```
LND <-> NGINX <-> Internet request
```

Now, both BTCPay and NGINX complain if TLS is activated at LND level because the certificate is untrusted. Making both of them trust this certificate is significant work, so I am just disabling TLS with this commit on my fork.