### PR TITLE
Add `debughtlc` option to `sample-lnd.conf`.

### DIFF
--- a/config.go
+++ b/config.go
@@ -205,7 +205,7 @@ type config struct {
 
 	Profile string `long:"profile" description:"Enable HTTP profiling on given port -- NOTE port must be between 1024 and 65535"`
 
-	DebugHTLC          bool `long:"debughtlc" description:"Activate the debug htlc mode. With the debug HTLC mode, all payments sent use a pre-determined R-Hash. Additionally, all HTLCs sent to a node with the debug HTLC R-Hash are immediately settled in the next available state transition."`
+	DebugHTLC          bool `long:"debughtlc" description:"Activate the debug HTLC mode. With the debug HTLC mode, all payments sent use a pre-determined R-Hash. Additionally, all HTLCs sent to a node with the debug HTLC R-Hash are immediately settled in the next available state transition."`
 	UnsafeDisconnect   bool `long:"unsafe-disconnect" description:"Allows the rpcserver to intentionally disconnect from peers with open channels. USED FOR TESTING ONLY."`
 	UnsafeReplay       bool `long:"unsafe-replay" description:"Causes a link to replay the adds on its commitment txn after starting up, this enables testing of the sphinx replay logic."`
 	MaxPendingChannels int  `long:"maxpendingchannels" description:"The maximum number of incoming pending channels permitted per peer."`

--- a/sample-lnd.conf
+++ b/sample-lnd.conf
@@ -118,6 +118,13 @@
 ; available subsystems.
 ; debuglevel=info
 
+; Activate the debug HTLC mode.
+; With the debug HTLC mode, all payments sent use a pre-determined R-Hash.
+; Additionally, all HTLCs sent to a node with the debug HTLC R-Hash are
+; immediately settled in the next available state transition.
+; debughtlc=true
+
+
 ; Write CPU profile to the specified file.
 ; cpuprofile=
 


### PR DESCRIPTION
I saw the `debughtlc` option being [used in the tutorial](https://dev.lightning.community/tutorial/01-lncli/index.html#configuring-lndconf) and noticed it wasn't a part of the sample config. 

Figured it would be useful 😄.