### PR TITLE
lnrpc: update protobuf generation installation instructions.

### DIFF
--- a/lnrpc/README.md
+++ b/lnrpc/README.md
@@ -147,15 +147,22 @@ $ unzip protoc-3.4.0-osx-x86_64.zip -d protoc
 $ export PATH=$PWD/protoc/bin:$PATH
 ```
 
-2. Install `golang/protobuf` at commit `ab9f9a6dab164b7d1246e0e688b0ab7b94d8553e`.
+2. Install `golang/protobuf` at commit `bbd03ef6da3a115852eaf24c8a1c46aeb39aa175`.
 ```bash
 $ git clone https://github.com/golang/protobuf $GOPATH/src/github.com/golang/protobuf
 $ cd $GOPATH/src/github.com/golang/protobuf
-$ git reset --hard ab9f9a6dab164b7d1246e0e688b0ab7b94d8553e
+$ git reset --hard bbd03ef6da3a115852eaf24c8a1c46aeb39aa175
 $ make
 ```
 
-3. Install `grpc-ecosystem/grpc-gateway` at commit `f2862b476edcef83412c7af8687c9cd8e4097c0f`.
+3. Install 'genproto' at commit `a8101f21cf983e773d0c1133ebc5424792003214`.
+```bash
+$ go get google.golang.org/genproto
+$ cd $GOPATH/src/google.golang.org/genproto
+$ git reset --hard a8101f21cf983e773d0c1133ebc5424792003214
+```
+
+4. Install `grpc-ecosystem/grpc-gateway` at commit `f2862b476edcef83412c7af8687c9cd8e4097c0f`.
 ```bash
 $ git clone https://github.com/grpc-ecosystem/grpc-gateway $GOPATH/src/github.com/grpc-ecosystem/grpc-gateway
 $ cd $GOPATH/src/github.com/grpc-ecosystem/grpc-gateway
@@ -163,4 +170,4 @@ $ git reset --hard f2862b476edcef83412c7af8687c9cd8e4097c0f
 $ go install ./protoc-gen-grpc-gateway ./protoc-gen-swagger
 ```
 
-4. Run [`gen_protos.sh`](https://github.com/lightningnetwork/lnd/blob/master/lnrpc/gen_protos.sh) to generate new protobuf definitions.
+5. Run [`gen_protos.sh`](https://github.com/lightningnetwork/lnd/blob/master/lnrpc/gen_protos.sh) to generate new protobuf definitions.


### PR DESCRIPTION
The installation instructions for protobuf are no longer accurate, and if followed, would lead to creation of a different set of proto definitions on latest master, and errors in installations of the grpc-gateway tools. 

The two main reasons for the errors are:

1. Instructions for installation of the  google.golang.org/genproto package are not included in the README file. Installing the latest version cause failure when installing the grpc-gateway packages. That is, when running 'go install ./protoc-gen-grpc-gateway ./protoc-gen-swagger' the following errors appear:
../../../google.golang.org/genproto/googleapis/api/annotations/http.pb.go:63:26: undefined: proto.InternalMessageInfo

To fix this, instructions for installing the package were added to the last commit that was still based on protobuf: v3.4.0.

2. The 'golang/protobuf' installation includes running make. Running make with go version of 1.10 and up installs protoc-gen-go which slightly differs in fmt, leading to differences in generated proto definitions of the sort:
-type isPolicyUpdateRequest_Scope interface {
-	isPolicyUpdateRequest_Scope()
-}
+type isPolicyUpdateRequest_Scope interface{ isPolicyUpdateRequest_Scope() }
 
 To fix this without creating differences in the generated proto definitions, a newer commit was selected that addresses this specific issue. This is the commit message text:

commit bbd03ef6da3a115852eaf24c8a1c46aeb39aa175
Author: Chris Manghane <cmang@golang.org>
Date:   Fri Feb 2 10:43:18 2018 -0800

    proto, protoc-gen-go: fix vet and gofmt errors for Go 1.10 (#508)
    
    In Go 1.10, go vet and gofmt have changed their output in a way to breaks the current build and test cycle.
    
    gofmt turns a one-line definition of a single-method interface into three lines; this causes a golden
    comparison test to produce different results between Go 1.9 and Go 1.10.
    go vet is now run by default with go test, which uncovered a bad Stringer argument in extension_test.go.
    Tested on Go1.10rc1 and Go1.9.3.

Now when running make rpc on latest master the definitions stay as they are, apart from an additional comment which are automatically added to the new sub server.

It would be great if others would verify that the new instructions work.









