### PR TITLE
[watchtower] add wtpolicy.Policy and wtserver message logging

### DIFF
--- a/watchtower/wtserver/server.go
+++ b/watchtower/wtserver/server.go
@@ -191,6 +191,12 @@ func (s *Server) handleClient(peer Peer) {
 	defer s.removePeer(&id, peer.RemoteAddr())
 
 	msg, err := s.readMessage(peer)
+	if err != nil {
+		log.Errorf("Unable to read message from client %s@%s: %v",
+			id, peer.RemoteAddr(), err)
+		return
+	}
+
 	remoteInit, ok := msg.(*wtwire.Init)
 	if !ok {
 		log.Errorf("Client %s@%s did not send Init msg as first "+

--- a/watchtower/wtwire/summary.go
+++ b/watchtower/wtwire/summary.go
@@ -1,0 +1,35 @@
+package wtwire
+
+import "fmt"
+
+// MessageSummary creates a human-readable description of a given Message. If
+// the type is unknown, an empty string is returned.
+func MessageSummary(msg Message) string {
+	switch msg := msg.(type) {
+	case *Init:
+		return ""
+
+	case *CreateSession:
+		return fmt.Sprintf("blob_type=%s, max_updates=%d "+
+			"reward_rate=%d sweep_fee_rate=%d", msg.BlobType,
+			msg.MaxUpdates, msg.RewardRate, msg.SweepFeeRate)
+
+	case *CreateSessionReply:
+		return fmt.Sprintf("code=%d", msg.Code)
+
+	case *StateUpdate:
+		return fmt.Sprintf("seqnum=%d last_applied=%d is_complete=%d "+
+			"hint=%x", msg.SeqNum, msg.LastApplied, msg.IsComplete,
+			msg.Hint)
+
+	case *StateUpdateReply:
+		return fmt.Sprintf("code=%d last_applied=%d", msg.Code,
+			msg.LastApplied)
+
+	case *Error:
+		return fmt.Sprintf("code=%d", msg.Code)
+
+	default:
+		return ""
+	}
+}


### PR DESCRIPTION
This PR makes some preliminary changes in advance of the watchtower client and watchtower capstone integrations.

The primary additions are the `wtpolicy.Policy`, which bundles up the negotiable watchtower parameters with the aim of later exposing them via command line. Since the same policy is shared between client and server, the struct is placed in it's own `wtpolicy` package. We also define `blob.Type` which allows for further negotiation at the session level (see #2439 for more info).

In addition, this PR adds log messages for wtserver messages that are sent and received, doing so with a `MessageSummary` method in `wtwire`. This code can then be shared across client and server, to ensure both sides see mirrored log messages. This final top-level PR is predominately this change.

Finally, we fix some broken log messages in the `lookout` package, which would apply hex formatting to the real value twice. We now serialize those values using the txid's string representation (see #2433).

Depends on:
 - [x] #2433 
 - [x] #2439 