### PR TITLE
docker: updated lnd/Dockerfile

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -64,21 +64,21 @@ bitcoin into.
 $ export NETWORK="simnet" 
 
 # Run the "Alice" container and log into it:
-$ docker-compose run -d --name alice lnd_btc
-$ docker exec -i -t alice bash
+$ sudo -E docker-compose run -d --name alice lnd_btc
+$ sudo -E docker exec -i -t alice bash
 
 # Generate a new backward compatible nested p2sh address for Alice:
 alice$ lncli --network=simnet newaddress np2wkh 
 
 # Recreate "btcd" node and set Alice's address as mining address:
-$ MINING_ADDRESS=<alice_address> docker-compose up -d btcd
+$ sudo -E MINING_ADDRESS=<alice_address> docker-compose up -d btcd
 
 # Generate 400 blocks (we need at least "100 >=" blocks because of coinbase 
 # block maturity and "300 ~=" in order to activate segwit):
-$ docker-compose run btcctl generate 400
+$ sudo -E docker-compose run btcctl generate 400
 
 # Check that segwit is active:
-$ docker-compose run btcctl getblockchaininfo | grep -A 1 segwit
+$ sudo -E docker-compose run btcctl getblockchaininfo | grep -A 1 segwit
 ```
 
 Check `Alice` balance:
@@ -90,8 +90,8 @@ Connect `Bob` node to `Alice` node.
 
 ```bash
 # Run "Bob" node and log into it:
-$ docker-compose run -d --name bob lnd_btc
-$ docker exec -i -t bob bash
+$ sudo -E docker-compose run -d --name bob lnd_btc
+$ sudo -E docker exec -i -t bob bash
 
 # Get the identity pubkey of "Bob" node:
 bob$ lncli --network=simnet getinfo
@@ -113,7 +113,7 @@ bob$ lncli --network=simnet getinfo
 }
 
 # Get the IP address of "Bob" node:
-$ docker inspect bob | grep IPAddress
+$ sudo -E docker inspect bob | grep IPAddress
 
 # Connect "Alice" to the "Bob" node:
 alice$ lncli --network=simnet connect <bob_pubkey>@<bob_host>
@@ -159,7 +159,7 @@ Create the `Alice<->Bob` channel.
 alice$ lncli --network=simnet openchannel --node_key=<bob_identity_pubkey> --local_amt=1000000
 
 # Include funding transaction in block thereby opening the channel:
-$ docker-compose run btcctl generate 3
+$ sudo -E docker-compose run btcctl generate 3
 
 # Check that channel with "Bob" was opened:
 alice$ lncli --network=simnet listchannels
@@ -243,7 +243,7 @@ alice$ lncli --network=simnet listchannels
 alice$ lncli --network=simnet closechannel --funding_txid=<funding_txid> --output_index=<output_index>
 
 # Include close transaction in a block thereby closing the channel:
-$ docker-compose run btcctl generate 3
+$ sudo -E docker-compose run btcctl generate 3
 
 # Check "Alice" on-chain balance was credited by her settled amount in the channel:
 alice$ lncli --network=simnet walletbalance
@@ -294,11 +294,9 @@ bitcoins. The schema will be following:
 First of all you need to run `btcd` node in `testnet` and wait for it to be 
 synced with test network (`May the Force and Patience be with you`).
 ```bash 
-# Init bitcoin network env variable:
-$ export NETWORK="testnet"
-
 # Run "btcd" node:
-$ docker-compose up -d "btcd"
+$ NETWORK="testnet"
+$ sudo -E docker-compose up -d "btcd"
 ```
 
 After `btcd` synced, connect `Alice` to the `Faucet` node.
@@ -307,7 +305,7 @@ The `Faucet` node address can be found at the [Faucet Lightning Community webpag
 
 ```bash 
 # Run "Alice" container and log into it:
-$ docker-compose up -d "alice"; docker exec -i -t "alice" bash
+$ sudo -E docker-compose up -d "alice"; sudo -E docker exec -i -t "alice" bash
 
 # Connect "Alice" to the "Faucet" node:
 alice$ lncli --network=simnet connect <faucet_identity_address>@<faucet_host>
@@ -326,5 +324,5 @@ and send some amount of bitcoins to `Alice`.
 
 * How to see `alice` | `bob` | `btcd` logs?
 ```bash
-docker-compose logs <alice|bob|btcd>
+sudo -E docker-compose logs <alice|bob|btcd>
 ```

--- a/docker/btcd/start-btcd.sh
+++ b/docker/btcd/start-btcd.sh
@@ -44,8 +44,12 @@ RPCPASS=$(set_default "$RPCPASS" "devpass")
 DEBUG=$(set_default "$DEBUG" "info")
 NETWORK=$(set_default "$NETWORK" "simnet")
 
-PARAMS=$(echo \
-    "--$NETWORK" \
+PARAMS=""
+if [ "$NETWORK" != "mainnet" ]; then
+   PARAMS=$(echo --$NETWORK)
+fi
+
+PARAMS=$(echo $PARAMS \
     "--debuglevel=$DEBUG" \
     "--rpcuser=$RPCUSER" \
     "--rpcpass=$RPCPASS" \

--- a/docker/lnd/Dockerfile
+++ b/docker/lnd/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.10-alpine as builder
+FROM golang:1.11-alpine as builder
 
 MAINTAINER Olaoluwa Osuntokun <lightning.engineering>
 
@@ -11,6 +11,7 @@ ENV GODEBUG netdns=cgo
 
 # Install dependencies and install/build lnd.
 RUN apk add --no-cache \
+    build-base \
     git \
     make \
 &&  cd /go/src/github.com/lightningnetwork/lnd \

--- a/docker/ltcd/start-ltcd.sh
+++ b/docker/ltcd/start-ltcd.sh
@@ -44,7 +44,12 @@ RPCPASS=$(set_default "$RPCPASS" "devpass")
 DEBUG=$(set_default "$DEBUG" "info")
 NETWORK=$(set_default "$NETWORK" "simnet")
 
-PARAMS=$(echo \
+PARAMS=""
+if [ "$NETWORK" != "mainnet" ]; then
+   PARAMS=$(echo --$NETWORK)
+fi
+
+PARAMS=$(echo $PARAMS \
     "--$NETWORK" \
     "--debuglevel=$DEBUG" \
     "--rpcuser=$RPCUSER" \


### PR DESCRIPTION
This commit fixes an issue with the lnd/Dockerfile using golang 1.10 instead of the recommended 1.11 which results in the following error

```
Step 5/12 : RUN apk add --no-cache     git     make &&  cd /go/src/github.com/lightningnetwork/lnd &&  make &&  make install
 ---> Running in 8d04c3b0e864
fetch http://dl-cdn.alpinelinux.org/alpine/v3.8/main/x86_64/APKINDEX.tar.gz
fetch http://dl-cdn.alpinelinux.org/alpine/v3.8/community/x86_64/APKINDEX.tar.gz
(1/7) Installing nghttp2-libs (1.32.0-r0)
(2/7) Installing libssh2 (1.8.0-r3)
(3/7) Installing libcurl (7.61.1-r1)
(4/7) Installing expat (2.2.5-r0)
(5/7) Installing pcre2 (10.31-r0)
(6/7) Installing git (2.18.1-r0)
(7/7) Installing make (4.2.1-r2)
Executing busybox-1.28.4-r1.trigger
OK: 19 MiB in 21 packages
\033[0;32m Building debug lnd and lncli.\033[0m
GO111MODULE=on go build -v -tags="dev" -o lnd-debug -ldflags "-X github.com/lightningnetwork/lnd/build.Commit=v0.5.1-beta-191-g0fafd5e2fd824f38ec6a03a56488de9c0798f34f" github.com/lightningnetwork/lnd
nat/upnp.go:9:2: cannot find package "github.com/NebulousLabs/go-upnp" in any of:
        /usr/local/go/src/github.com/NebulousLabs/go-upnp (from $GOROOT)
        /go/src/github.com/NebulousLabs/go-upnp (from $GOPATH)
aezeed/cipherseed.go:12:2: cannot find package "github.com/Yawning/aez" in any of:
        /usr/local/go/src/github.com/Yawning/aez (from $GOROOT)
        /go/src/github.com/Yawning/aez (from $GOPATH)
breacharbiter.go:11:2: cannot find package "github.com/btcsuite/btcd/blockchain" in any of:
        /usr/local/go/src/github.com/btcsuite/btcd/blockchain (from $GOROOT)
        /go/src/github.com/btcsuite/btcd/blockchain (from $GOPATH)
fundingmanager.go:11:2: cannot find package "github.com/btcsuite/btcd/btcec" in any of:
        /usr/local/go/src/github.com/btcsuite/btcd/btcec (from $GOROOT)
        /go/src/github.com/btcsuite/btcd/btcec (from $GOPATH)
chainntnfs/interface.go:7:2: cannot find package "github.com/btcsuite/btcd/btcjson" in any of:
        /usr/local/go/src/github.com/btcsuite/btcd/btcjson (from $GOROOT)
        /go/src/github.com/btcsuite/btcd/btcjson (from $GOPATH)
chainparams.go:4:2: cannot find package "github.com/btcsuite/btcd/chaincfg" in any of:
        /usr/local/go/src/github.com/btcsuite/btcd/chaincfg (from $GOROOT)
        /go/src/github.com/btcsuite/btcd/chaincfg (from $GOPATH)
breacharbiter.go:12:2: cannot find package "github.com/btcsuite/btcd/chaincfg/chainhash" in any of:
Step 5/12 : RUN apk add --no-cache     git     make &&  cd /go/src/github.com/lightningnetwork/lnd &&  make &&  make install
 ---> Running in 8d04c3b0e864
fetch http://dl-cdn.alpinelinux.org/alpine/v3.8/main/x86_64/APKINDEX.tar.gz
fetch http://dl-cdn.alpinelinux.org/alpine/v3.8/community/x86_64/APKINDEX.tar.gz
(1/7) Installing nghttp2-libs (1.32.0-r0)
(2/7) Installing libssh2 (1.8.0-r3)
(3/7) Installing libcurl (7.61.1-r1)
(4/7) Installing expat (2.2.5-r0)
(5/7) Installing pcre2 (10.31-r0)
(6/7) Installing git (2.18.1-r0)
(7/7) Installing make (4.2.1-r2)
Executing busybox-1.28.4-r1.trigger
OK: 19 MiB in 21 packages
\033[0;32m Building debug lnd and lncli.\033[0m
GO111MODULE=on go build -v -tags="dev" -o lnd-debug -ldflags "-X github.com/lightningnetwork/lnd/build.Commit=v0.5.1-beta-191-g0fafd5e2fd824f38ec6a03a56488de9c0798f34f" github.com/lightningnetwork/lnd
nat/upnp.go:9:2: cannot find package "github.com/NebulousLabs/go-upnp" in any of:
        /usr/local/go/src/github.com/NebulousLabs/go-upnp (from $GOROOT)
        /go/src/github.com/NebulousLabs/go-upnp (from $GOPATH)
aezeed/cipherseed.go:12:2: cannot find package "github.com/Yawning/aez" in any of:
        /usr/local/go/src/github.com/Yawning/aez (from $GOROOT)
        /go/src/github.com/Yawning/aez (from $GOPATH)
breacharbiter.go:11:2: cannot find package "github.com/btcsuite/btcd/blockchain" in any of:
        /usr/local/go/src/github.com/btcsuite/btcd/blockchain (from $GOROOT)
        /go/src/github.com/btcsuite/btcd/blockchain (from $GOPATH)
fundingmanager.go:11:2: cannot find package "github.com/btcsuite/btcd/btcec" in any of:
        /usr/local/go/src/github.com/btcsuite/btcd/btcec (from $GOROOT)
        /go/src/github.com/btcsuite/btcd/btcec (from $GOPATH)
chainntnfs/interface.go:7:2: cannot find package "github.com/btcsuite/btcd/btcjson" in any of:
        /usr/local/go/src/github.com/btcsuite/btcd/btcjson (from $GOROOT)
        /go/src/github.com/btcsuite/btcd/btcjson (from $GOPATH)
chainparams.go:4:2: cannot find package "github.com/btcsuite/btcd/chaincfg" in any of:
        /usr/local/go/src/github.com/btcsuite/btcd/chaincfg (from $GOROOT)
        /go/src/github.com/btcsuite/btcd/chaincfg (from $GOPATH)
breacharbiter.go:12:2: cannot find package "github.com/btcsuite/btcd/chaincfg/chainhash" in any of:
[...]
macaroons/constraints.go:10:2: cannot find package "gopkg.in/macaroon-bakery.v2/bakery/checkers" in any of:
        /usr/local/go/src/gopkg.in/macaroon-bakery.v2/bakery/checkers (from $GOROOT)
        /go/src/gopkg.in/macaroon-bakery.v2/bakery/checkers (from $GOPATH)
macaroons/auth.go:8:2: cannot find package "gopkg.in/macaroon.v2" in any of:
        /usr/local/go/src/gopkg.in/macaroon.v2 (from $GOROOT)
        /go/src/gopkg.in/macaroon.v2 (from $GOPATH)
make: *** [Makefile:100: build] Error 1
ERROR: Service 'lnd' failed to build: The command '/bin/sh -c apk add --no-cache     git     make &&  cd /go/src/github.com/lightningnetwork/lnd &&  make &&  make install' returned a non-zero code: 2
```