### PR TITLE
github: add PR contribution checklist

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,19 @@
+#### Pull Request Checklist
+
+- [ ] All changes are Go version 1.11 compliant
+- [ ]  The code being submitted is commented according to the
+  [Code Documentation and Commenting](#CodeDocumentation) section
+- [ ]  For new code: Code is accompanied by tests which exercise both
+  the positive and negative (error paths) conditions (if applicable)
+- [ ]  For bug fixes: Code is accompanied by new tests which trigger
+  the bug being fixed to prevent regressions
+- [ ]  Any new logging statements use an appropriate subsystem and
+  logging level
+- [ ]  Code has been formatted with `go fmt`
+- [ ]  For code and documentation: lines are wrapped at 80 characters
+  (the tab character should be counted as 8 characters, not 4, as some IDEs do
+  per default)
+- [ ]  Running `make check` does not fail any tests
+- [ ]  Running `go vet` does not report any issues
+- [ ]  Running `make lint` does not report any **new** issues that did not
+  already exist


### PR DESCRIPTION
In this PR, we add a PR template which will insert this PR contribution checklist for all new PR's. It's more or less the checklist at the bottom of our contribution guidelines. However, since that's buried at the bottom, it's easy for new contributors to miss it. Making a template ensures that all contributors that propose a PR (after this is in) will see and (hopefully) adhere to the checklist. 