### PR TITLE
utxonursery: fix bound variable bug

### DIFF
--- a/utxonursery.go
+++ b/utxonursery.go
@@ -807,7 +807,7 @@ func (u *utxoNursery) sweepMatureOutputs(classHeight uint32,
 			return err
 		}
 		u.wg.Add(1)
-		go u.waitForSweepConf(classHeight, &output, resultChan)
+		go u.waitForSweepConf(classHeight, &local, resultChan)
 	}
 
 	return nil


### PR DESCRIPTION
A pointer to the loop variable was passed to the waitForSweepConf
goroutine, causing the wrong output to be graduated from
kindergarten.