### PR TITLE
keychain: extend DerivePrivKey to derive based on pubkey+KeyFamily

### DIFF
--- a/keychain/derivation.go
+++ b/keychain/derivation.go
@@ -1,6 +1,10 @@
 package keychain
 
-import "github.com/btcsuite/btcd/btcec"
+import (
+	"fmt"
+
+	"github.com/btcsuite/btcd/btcec"
+)
 
 const (
 	// KeyDerivationVersion is the version of the key derivation schema
@@ -18,6 +22,18 @@ const (
 	//
 	// NOTE: BRICK SQUUUUUAD.
 	BIP0043Purpose = 1017
+)
+
+var (
+	// MaxKeyRangeScan is the maximum number of keys that we'll attempt to
+	// scan with if a caller knows the public key, but not the KeyLocator
+	// and wishes to derive a private key.
+	MaxKeyRangeScan = 100000
+
+	// ErrCannotDerivePrivKey is returned when DerivePrivKey is unable to
+	// derive a private key given only the public key and target key
+	// family.
+	ErrCannotDerivePrivKey = fmt.Errorf("unable to derive private key")
 )
 
 // KeyFamily represents a "family" of keys that will be used within various
@@ -141,7 +157,10 @@ type SecretKeyRing interface {
 	KeyRing
 
 	// DerivePrivKey attempts to derive the private key that corresponds to
-	// the passed key descriptor.
+	// the passed key descriptor.  If the public key is set, then this
+	// method will perform an in-order scan over the key set, with a max of
+	// MaxKeyRangeScan keys. In order for this to work, the caller MUST set
+	// the KeyFamily within the partially populated KeyLocator.
 	DerivePrivKey(keyDesc KeyDescriptor) (*btcec.PrivateKey, error)
 
 	// ScalarMult performs a scalar multiplication (ECDH-like operation)


### PR DESCRIPTION
In this commit, we extend the DerivePrivKey method to allow callers that
don't know the full KeyLocator information to attempt to derive a
private key via a brute force mechanism. If we don't now the full
KeyLoactor, then given the KeyFamily, we can walk down the derivation
path and compare keys one by one. In order to ensure we don' t enter an
infinite loop when given an unknown public key, we cap the number of
keys derived at 100k.

An upcoming feature to lnd that adds static channel backups will utilize
this feature, as we need to derive the shachain root given only the
public key and key family, as we don't currently store this KeyLocator
on disk.

Split off of #2313.
