### PR TITLE
lnwire: export ReadElements and WriteElements

### DIFF
--- a/lnwire/accept_channel.go
+++ b/lnwire/accept_channel.go
@@ -98,7 +98,7 @@ var _ Message = (*AcceptChannel)(nil)
 //
 // This is part of the lnwire.Message interface.
 func (a *AcceptChannel) Encode(w io.Writer, pver uint32) error {
-	return writeElements(w,
+	return WriteElements(w,
 		a.PendingChannelID[:],
 		a.DustLimit,
 		a.MaxValueInFlight,
@@ -122,7 +122,7 @@ func (a *AcceptChannel) Encode(w io.Writer, pver uint32) error {
 //
 // This is part of the lnwire.Message interface.
 func (a *AcceptChannel) Decode(r io.Reader, pver uint32) error {
-	return readElements(r,
+	return ReadElements(r,
 		a.PendingChannelID[:],
 		&a.DustLimit,
 		&a.MaxValueInFlight,

--- a/lnwire/announcement_signatures.go
+++ b/lnwire/announcement_signatures.go
@@ -52,7 +52,7 @@ var _ Message = (*AnnounceSignatures)(nil)
 //
 // This is part of the lnwire.Message interface.
 func (a *AnnounceSignatures) Decode(r io.Reader, pver uint32) error {
-	err := readElements(r,
+	err := ReadElements(r,
 		&a.ChannelID,
 		&a.ShortChannelID,
 		&a.NodeSignature,
@@ -82,7 +82,7 @@ func (a *AnnounceSignatures) Decode(r io.Reader, pver uint32) error {
 //
 // This is part of the lnwire.Message interface.
 func (a *AnnounceSignatures) Encode(w io.Writer, pver uint32) error {
-	return writeElements(w,
+	return WriteElements(w,
 		a.ChannelID,
 		a.ShortChannelID,
 		a.NodeSignature,

--- a/lnwire/channel_announcement.go
+++ b/lnwire/channel_announcement.go
@@ -68,7 +68,7 @@ var _ Message = (*ChannelAnnouncement)(nil)
 //
 // This is part of the lnwire.Message interface.
 func (a *ChannelAnnouncement) Decode(r io.Reader, pver uint32) error {
-	err := readElements(r,
+	err := ReadElements(r,
 		&a.NodeSig1,
 		&a.NodeSig2,
 		&a.BitcoinSig1,
@@ -105,7 +105,7 @@ func (a *ChannelAnnouncement) Decode(r io.Reader, pver uint32) error {
 //
 // This is part of the lnwire.Message interface.
 func (a *ChannelAnnouncement) Encode(w io.Writer, pver uint32) error {
-	return writeElements(w,
+	return WriteElements(w,
 		a.NodeSig1,
 		a.NodeSig2,
 		a.BitcoinSig1,
@@ -142,7 +142,7 @@ func (a *ChannelAnnouncement) MaxPayloadLength(pver uint32) uint32 {
 func (a *ChannelAnnouncement) DataToSign() ([]byte, error) {
 	// We should not include the signatures itself.
 	var w bytes.Buffer
-	err := writeElements(&w,
+	err := WriteElements(&w,
 		a.Features,
 		a.ChainHash[:],
 		a.ShortChannelID,

--- a/lnwire/channel_reestablish.go
+++ b/lnwire/channel_reestablish.go
@@ -71,7 +71,7 @@ var _ Message = (*ChannelReestablish)(nil)
 //
 // This is part of the lnwire.Message interface.
 func (a *ChannelReestablish) Encode(w io.Writer, pver uint32) error {
-	err := writeElements(w,
+	err := WriteElements(w,
 		a.ChanID,
 		a.NextLocalCommitHeight,
 		a.RemoteCommitTailHeight,
@@ -87,7 +87,7 @@ func (a *ChannelReestablish) Encode(w io.Writer, pver uint32) error {
 	}
 
 	// Otherwise, we'll write out the remaining elements.
-	return writeElements(w, a.LastRemoteCommitSecret[:],
+	return WriteElements(w, a.LastRemoteCommitSecret[:],
 		a.LocalUnrevokedCommitPoint)
 }
 
@@ -96,7 +96,7 @@ func (a *ChannelReestablish) Encode(w io.Writer, pver uint32) error {
 //
 // This is part of the lnwire.Message interface.
 func (a *ChannelReestablish) Decode(r io.Reader, pver uint32) error {
-	err := readElements(r,
+	err := ReadElements(r,
 		&a.ChanID,
 		&a.NextLocalCommitHeight,
 		&a.RemoteCommitTailHeight,
@@ -129,7 +129,7 @@ func (a *ChannelReestablish) Decode(r io.Reader, pver uint32) error {
 	// We'll conclude by parsing out the commitment point. We don't check
 	// the error in this case, as it hey included the commit secret, then
 	// they MUST also include the commit point.
-	return readElement(r, &a.LocalUnrevokedCommitPoint)
+	return ReadElement(r, &a.LocalUnrevokedCommitPoint)
 }
 
 // MsgType returns the integer uniquely identifying this message type on the

--- a/lnwire/channel_update.go
+++ b/lnwire/channel_update.go
@@ -93,7 +93,7 @@ var _ Message = (*ChannelUpdate)(nil)
 //
 // This is part of the lnwire.Message interface.
 func (a *ChannelUpdate) Decode(r io.Reader, pver uint32) error {
-	err := readElements(r,
+	err := ReadElements(r,
 		&a.Signature,
 		a.ChainHash[:],
 		&a.ShortChannelID,
@@ -128,7 +128,7 @@ func (a *ChannelUpdate) Decode(r io.Reader, pver uint32) error {
 //
 // This is part of the lnwire.Message interface.
 func (a *ChannelUpdate) Encode(w io.Writer, pver uint32) error {
-	return writeElements(w,
+	return WriteElements(w,
 		a.Signature,
 		a.ChainHash[:],
 		a.ShortChannelID,
@@ -164,7 +164,7 @@ func (a *ChannelUpdate) DataToSign() ([]byte, error) {
 
 	// We should not include the signatures itself.
 	var w bytes.Buffer
-	err := writeElements(&w,
+	err := WriteElements(&w,
 		a.ChainHash[:],
 		a.ShortChannelID,
 		a.Timestamp,

--- a/lnwire/closing_signed.go
+++ b/lnwire/closing_signed.go
@@ -49,7 +49,7 @@ var _ Message = (*ClosingSigned)(nil)
 //
 // This is part of the lnwire.Message interface.
 func (c *ClosingSigned) Decode(r io.Reader, pver uint32) error {
-	return readElements(r, &c.ChannelID, &c.FeeSatoshis, &c.Signature)
+	return ReadElements(r, &c.ChannelID, &c.FeeSatoshis, &c.Signature)
 }
 
 // Encode serializes the target ClosingSigned into the passed io.Writer
@@ -57,7 +57,7 @@ func (c *ClosingSigned) Decode(r io.Reader, pver uint32) error {
 //
 // This is part of the lnwire.Message interface.
 func (c *ClosingSigned) Encode(w io.Writer, pver uint32) error {
-	return writeElements(w, c.ChannelID, c.FeeSatoshis, c.Signature)
+	return WriteElements(w, c.ChannelID, c.FeeSatoshis, c.Signature)
 }
 
 // MsgType returns the integer uniquely identifying this message type on the

--- a/lnwire/commit_sig.go
+++ b/lnwire/commit_sig.go
@@ -48,7 +48,7 @@ var _ Message = (*CommitSig)(nil)
 //
 // This is part of the lnwire.Message interface.
 func (c *CommitSig) Decode(r io.Reader, pver uint32) error {
-	return readElements(r,
+	return ReadElements(r,
 		&c.ChanID,
 		&c.CommitSig,
 		&c.HtlcSigs,
@@ -60,7 +60,7 @@ func (c *CommitSig) Decode(r io.Reader, pver uint32) error {
 //
 // This is part of the lnwire.Message interface.
 func (c *CommitSig) Encode(w io.Writer, pver uint32) error {
-	return writeElements(w,
+	return WriteElements(w,
 		c.ChanID,
 		c.CommitSig,
 		c.HtlcSigs,

--- a/lnwire/error.go
+++ b/lnwire/error.go
@@ -92,7 +92,7 @@ var _ Message = (*Error)(nil)
 //
 // This is part of the lnwire.Message interface.
 func (c *Error) Decode(r io.Reader, pver uint32) error {
-	return readElements(r,
+	return ReadElements(r,
 		&c.ChanID,
 		&c.Data,
 	)
@@ -103,7 +103,7 @@ func (c *Error) Decode(r io.Reader, pver uint32) error {
 //
 // This is part of the lnwire.Message interface.
 func (c *Error) Encode(w io.Writer, pver uint32) error {
-	return writeElements(w,
+	return WriteElements(w,
 		c.ChanID,
 		c.Data,
 	)

--- a/lnwire/funding_created.go
+++ b/lnwire/funding_created.go
@@ -36,7 +36,7 @@ var _ Message = (*FundingCreated)(nil)
 //
 // This is part of the lnwire.Message interface.
 func (f *FundingCreated) Encode(w io.Writer, pver uint32) error {
-	return writeElements(w, f.PendingChannelID[:], f.FundingPoint, f.CommitSig)
+	return WriteElements(w, f.PendingChannelID[:], f.FundingPoint, f.CommitSig)
 }
 
 // Decode deserializes the serialized FundingCreated stored in the passed
@@ -45,7 +45,7 @@ func (f *FundingCreated) Encode(w io.Writer, pver uint32) error {
 //
 // This is part of the lnwire.Message interface.
 func (f *FundingCreated) Decode(r io.Reader, pver uint32) error {
-	return readElements(r, f.PendingChannelID[:], &f.FundingPoint, &f.CommitSig)
+	return ReadElements(r, f.PendingChannelID[:], &f.FundingPoint, &f.CommitSig)
 }
 
 // MsgType returns the uint32 code which uniquely identifies this message as a

--- a/lnwire/funding_locked.go
+++ b/lnwire/funding_locked.go
@@ -40,7 +40,7 @@ var _ Message = (*FundingLocked)(nil)
 //
 // This is part of the lnwire.Message interface.
 func (c *FundingLocked) Decode(r io.Reader, pver uint32) error {
-	return readElements(r,
+	return ReadElements(r,
 		&c.ChanID,
 		&c.NextPerCommitmentPoint)
 }
@@ -51,7 +51,7 @@ func (c *FundingLocked) Decode(r io.Reader, pver uint32) error {
 //
 // This is part of the lnwire.Message interface.
 func (c *FundingLocked) Encode(w io.Writer, pver uint32) error {
-	return writeElements(w,
+	return WriteElements(w,
 		c.ChanID,
 		c.NextPerCommitmentPoint)
 }

--- a/lnwire/funding_signed.go
+++ b/lnwire/funding_signed.go
@@ -25,7 +25,7 @@ var _ Message = (*FundingSigned)(nil)
 //
 // This is part of the lnwire.Message interface.
 func (f *FundingSigned) Encode(w io.Writer, pver uint32) error {
-	return writeElements(w, f.ChanID, f.CommitSig)
+	return WriteElements(w, f.ChanID, f.CommitSig)
 }
 
 // Decode deserializes the serialized FundingSigned stored in the passed
@@ -34,7 +34,7 @@ func (f *FundingSigned) Encode(w io.Writer, pver uint32) error {
 //
 // This is part of the lnwire.Message interface.
 func (f *FundingSigned) Decode(r io.Reader, pver uint32) error {
-	return readElements(r, &f.ChanID, &f.CommitSig)
+	return ReadElements(r, &f.ChanID, &f.CommitSig)
 }
 
 // MsgType returns the uint32 code which uniquely identifies this message as a

--- a/lnwire/gossip_timestamp_range.go
+++ b/lnwire/gossip_timestamp_range.go
@@ -40,7 +40,7 @@ var _ Message = (*GossipTimestampRange)(nil)
 //
 // This is part of the lnwire.Message interface.
 func (g *GossipTimestampRange) Decode(r io.Reader, pver uint32) error {
-	return readElements(r,
+	return ReadElements(r,
 		g.ChainHash[:],
 		&g.FirstTimestamp,
 		&g.TimestampRange,
@@ -52,7 +52,7 @@ func (g *GossipTimestampRange) Decode(r io.Reader, pver uint32) error {
 //
 // This is part of the lnwire.Message interface.
 func (g *GossipTimestampRange) Encode(w io.Writer, pver uint32) error {
-	return writeElements(w,
+	return WriteElements(w,
 		g.ChainHash[:],
 		g.FirstTimestamp,
 		g.TimestampRange,

--- a/lnwire/init_message.go
+++ b/lnwire/init_message.go
@@ -33,7 +33,7 @@ var _ Message = (*Init)(nil)
 //
 // This is part of the lnwire.Message interface.
 func (msg *Init) Decode(r io.Reader, pver uint32) error {
-	return readElements(r,
+	return ReadElements(r,
 		&msg.GlobalFeatures,
 		&msg.LocalFeatures,
 	)
@@ -44,7 +44,7 @@ func (msg *Init) Decode(r io.Reader, pver uint32) error {
 //
 // This is part of the lnwire.Message interface.
 func (msg *Init) Encode(w io.Writer, pver uint32) error {
-	return writeElements(w,
+	return WriteElements(w,
 		msg.GlobalFeatures,
 		msg.LocalFeatures,
 	)

--- a/lnwire/lnwire_test.go
+++ b/lnwire/lnwire_test.go
@@ -175,7 +175,7 @@ func TestMaxOutPointIndex(t *testing.T) {
 	}
 
 	var b bytes.Buffer
-	if err := writeElement(&b, op); err == nil {
+	if err := WriteElement(&b, op); err == nil {
 		t.Fatalf("write of outPoint should fail, index exceeds 16-bits")
 	}
 }

--- a/lnwire/node_announcement.go
+++ b/lnwire/node_announcement.go
@@ -111,7 +111,7 @@ var _ Message = (*NodeAnnouncement)(nil)
 //
 // This is part of the lnwire.Message interface.
 func (a *NodeAnnouncement) Decode(r io.Reader, pver uint32) error {
-	err := readElements(r,
+	err := ReadElements(r,
 		&a.Signature,
 		&a.Features,
 		&a.Timestamp,
@@ -143,7 +143,7 @@ func (a *NodeAnnouncement) Decode(r io.Reader, pver uint32) error {
 // observing the protocol version specified.
 //
 func (a *NodeAnnouncement) Encode(w io.Writer, pver uint32) error {
-	return writeElements(w,
+	return WriteElements(w,
 		a.Signature,
 		a.Features,
 		a.Timestamp,
@@ -176,7 +176,7 @@ func (a *NodeAnnouncement) DataToSign() ([]byte, error) {
 
 	// We should not include the signatures itself.
 	var w bytes.Buffer
-	err := writeElements(&w,
+	err := WriteElements(&w,
 		a.Features,
 		a.Timestamp,
 		a.NodeID,

--- a/lnwire/onion_error.go
+++ b/lnwire/onion_error.go
@@ -390,14 +390,14 @@ func (f *FailInvalidOnionVersion) Code() FailCode {
 //
 // NOTE: Part of the Serializable interface.
 func (f *FailInvalidOnionVersion) Decode(r io.Reader, pver uint32) error {
-	return readElement(r, f.OnionSHA256[:])
+	return ReadElement(r, f.OnionSHA256[:])
 }
 
 // Encode writes the failure in bytes stream.
 //
 // NOTE: Part of the Serializable interface.
 func (f *FailInvalidOnionVersion) Encode(w io.Writer, pver uint32) error {
-	return writeElement(w, f.OnionSHA256[:])
+	return WriteElement(w, f.OnionSHA256[:])
 }
 
 // FailInvalidOnionHmac is return if the onion HMAC is incorrect.
@@ -424,14 +424,14 @@ func (f *FailInvalidOnionHmac) Code() FailCode {
 //
 // NOTE: Part of the Serializable interface.
 func (f *FailInvalidOnionHmac) Decode(r io.Reader, pver uint32) error {
-	return readElement(r, f.OnionSHA256[:])
+	return ReadElement(r, f.OnionSHA256[:])
 }
 
 // Encode writes the failure in bytes stream.
 //
 // NOTE: Part of the Serializable interface.
 func (f *FailInvalidOnionHmac) Encode(w io.Writer, pver uint32) error {
-	return writeElement(w, f.OnionSHA256[:])
+	return WriteElement(w, f.OnionSHA256[:])
 }
 
 // Returns a human readable string describing the target FailureMessage.
@@ -466,14 +466,14 @@ func (f *FailInvalidOnionKey) Code() FailCode {
 //
 // NOTE: Part of the Serializable interface.
 func (f *FailInvalidOnionKey) Decode(r io.Reader, pver uint32) error {
-	return readElement(r, f.OnionSHA256[:])
+	return ReadElement(r, f.OnionSHA256[:])
 }
 
 // Encode writes the failure in bytes stream.
 //
 // NOTE: Part of the Serializable interface.
 func (f *FailInvalidOnionKey) Encode(w io.Writer, pver uint32) error {
-	return writeElement(w, f.OnionSHA256[:])
+	return WriteElement(w, f.OnionSHA256[:])
 }
 
 // Returns a human readable string describing the target FailureMessage.
@@ -563,7 +563,7 @@ func (f FailTemporaryChannelFailure) Error() string {
 // NOTE: Part of the Serializable interface.
 func (f *FailTemporaryChannelFailure) Decode(r io.Reader, pver uint32) error {
 	var length uint16
-	err := readElement(r, &length)
+	err := ReadElement(r, &length)
 	if err != nil {
 		return err
 	}
@@ -591,7 +591,7 @@ func (f *FailTemporaryChannelFailure) Encode(w io.Writer, pver uint32) error {
 		payload = bw.Bytes()
 	}
 
-	if err := writeElement(w, uint16(len(payload))); err != nil {
+	if err := WriteElement(w, uint16(len(payload))); err != nil {
 		return err
 	}
 
@@ -642,12 +642,12 @@ func (f FailAmountBelowMinimum) Error() string {
 //
 // NOTE: Part of the Serializable interface.
 func (f *FailAmountBelowMinimum) Decode(r io.Reader, pver uint32) error {
-	if err := readElement(r, &f.HtlcMsat); err != nil {
+	if err := ReadElement(r, &f.HtlcMsat); err != nil {
 		return err
 	}
 
 	var length uint16
-	if err := readElement(r, &length); err != nil {
+	if err := ReadElement(r, &length); err != nil {
 		return err
 	}
 
@@ -661,11 +661,11 @@ func (f *FailAmountBelowMinimum) Decode(r io.Reader, pver uint32) error {
 //
 // NOTE: Part of the Serializable interface.
 func (f *FailAmountBelowMinimum) Encode(w io.Writer, pver uint32) error {
-	if err := writeElement(w, f.HtlcMsat); err != nil {
+	if err := WriteElement(w, f.HtlcMsat); err != nil {
 		return err
 	}
 
-	err := writeElement(w, uint16(f.Update.MaxPayloadLength(pver)))
+	err := WriteElement(w, uint16(f.Update.MaxPayloadLength(pver)))
 	if err != nil {
 		return err
 	}
@@ -715,12 +715,12 @@ func (f FailFeeInsufficient) Error() string {
 //
 // NOTE: Part of the Serializable interface.
 func (f *FailFeeInsufficient) Decode(r io.Reader, pver uint32) error {
-	if err := readElement(r, &f.HtlcMsat); err != nil {
+	if err := ReadElement(r, &f.HtlcMsat); err != nil {
 		return err
 	}
 
 	var length uint16
-	if err := readElement(r, &length); err != nil {
+	if err := ReadElement(r, &length); err != nil {
 		return err
 	}
 
@@ -734,11 +734,11 @@ func (f *FailFeeInsufficient) Decode(r io.Reader, pver uint32) error {
 //
 // NOTE: Part of the Serializable interface.
 func (f *FailFeeInsufficient) Encode(w io.Writer, pver uint32) error {
-	if err := writeElement(w, f.HtlcMsat); err != nil {
+	if err := WriteElement(w, f.HtlcMsat); err != nil {
 		return err
 	}
 
-	err := writeElement(w, uint16(f.Update.MaxPayloadLength(pver)))
+	err := WriteElement(w, uint16(f.Update.MaxPayloadLength(pver)))
 	if err != nil {
 		return err
 	}
@@ -788,12 +788,12 @@ func (f *FailIncorrectCltvExpiry) Error() string {
 //
 // NOTE: Part of the Serializable interface.
 func (f *FailIncorrectCltvExpiry) Decode(r io.Reader, pver uint32) error {
-	if err := readElement(r, &f.CltvExpiry); err != nil {
+	if err := ReadElement(r, &f.CltvExpiry); err != nil {
 		return err
 	}
 
 	var length uint16
-	if err := readElement(r, &length); err != nil {
+	if err := ReadElement(r, &length); err != nil {
 		return err
 	}
 
@@ -807,11 +807,11 @@ func (f *FailIncorrectCltvExpiry) Decode(r io.Reader, pver uint32) error {
 //
 // NOTE: Part of the Serializable interface.
 func (f *FailIncorrectCltvExpiry) Encode(w io.Writer, pver uint32) error {
-	if err := writeElement(w, f.CltvExpiry); err != nil {
+	if err := WriteElement(w, f.CltvExpiry); err != nil {
 		return err
 	}
 
-	err := writeElement(w, uint16(f.Update.MaxPayloadLength(pver)))
+	err := WriteElement(w, uint16(f.Update.MaxPayloadLength(pver)))
 	if err != nil {
 		return err
 	}
@@ -855,7 +855,7 @@ func (f *FailExpiryTooSoon) Error() string {
 // NOTE: Part of the Serializable interface.
 func (f *FailExpiryTooSoon) Decode(r io.Reader, pver uint32) error {
 	var length uint16
-	if err := readElement(r, &length); err != nil {
+	if err := ReadElement(r, &length); err != nil {
 		return err
 	}
 
@@ -869,7 +869,7 @@ func (f *FailExpiryTooSoon) Decode(r io.Reader, pver uint32) error {
 //
 // NOTE: Part of the Serializable interface.
 func (f *FailExpiryTooSoon) Encode(w io.Writer, pver uint32) error {
-	err := writeElement(w, uint16(f.Update.MaxPayloadLength(pver)))
+	err := WriteElement(w, uint16(f.Update.MaxPayloadLength(pver)))
 	if err != nil {
 		return err
 	}
@@ -919,12 +919,12 @@ func (f FailChannelDisabled) Error() string {
 //
 // NOTE: Part of the Serializable interface.
 func (f *FailChannelDisabled) Decode(r io.Reader, pver uint32) error {
-	if err := readElement(r, &f.Flags); err != nil {
+	if err := ReadElement(r, &f.Flags); err != nil {
 		return err
 	}
 
 	var length uint16
-	if err := readElement(r, &length); err != nil {
+	if err := ReadElement(r, &length); err != nil {
 		return err
 	}
 
@@ -938,11 +938,11 @@ func (f *FailChannelDisabled) Decode(r io.Reader, pver uint32) error {
 //
 // NOTE: Part of the Serializable interface.
 func (f *FailChannelDisabled) Encode(w io.Writer, pver uint32) error {
-	if err := writeElement(w, f.Flags); err != nil {
+	if err := WriteElement(w, f.Flags); err != nil {
 		return err
 	}
 
-	err := writeElement(w, uint16(f.Update.MaxPayloadLength(pver)))
+	err := WriteElement(w, uint16(f.Update.MaxPayloadLength(pver)))
 	if err != nil {
 		return err
 	}
@@ -986,14 +986,14 @@ func (f *FailFinalIncorrectCltvExpiry) Code() FailCode {
 //
 // NOTE: Part of the Serializable interface.
 func (f *FailFinalIncorrectCltvExpiry) Decode(r io.Reader, pver uint32) error {
-	return readElement(r, &f.CltvExpiry)
+	return ReadElement(r, &f.CltvExpiry)
 }
 
 // Encode writes the failure in bytes stream.
 //
 // NOTE: Part of the Serializable interface.
 func (f *FailFinalIncorrectCltvExpiry) Encode(w io.Writer, pver uint32) error {
-	return writeElement(w, f.CltvExpiry)
+	return WriteElement(w, f.CltvExpiry)
 }
 
 // FailFinalIncorrectHtlcAmount is returned if the amt_to_forward is higher
@@ -1032,14 +1032,14 @@ func (f *FailFinalIncorrectHtlcAmount) Code() FailCode {
 //
 // NOTE: Part of the Serializable interface.
 func (f *FailFinalIncorrectHtlcAmount) Decode(r io.Reader, pver uint32) error {
-	return readElement(r, &f.IncomingHTLCAmount)
+	return ReadElement(r, &f.IncomingHTLCAmount)
 }
 
 // Encode writes the failure in bytes stream.
 //
 // NOTE: Part of the Serializable interface.
 func (f *FailFinalIncorrectHtlcAmount) Encode(w io.Writer, pver uint32) error {
-	return writeElement(w, f.IncomingHTLCAmount)
+	return WriteElement(w, f.IncomingHTLCAmount)
 }
 
 // FailExpiryTooFar is returned if the CLTV expiry in the HTLC is too far in the
@@ -1068,7 +1068,7 @@ func DecodeFailure(r io.Reader, pver uint32) (FailureMessage, error) {
 	// First, we'll parse out the encapsulated failure message itself. This
 	// is a 2 byte length followed by the payload itself.
 	var failureLength uint16
-	if err := readElement(r, &failureLength); err != nil {
+	if err := ReadElement(r, &failureLength); err != nil {
 		return nil, fmt.Errorf("unable to read error len: %v", err)
 	}
 	if failureLength > failureMessageLength {
@@ -1149,7 +1149,7 @@ func EncodeFailure(w io.Writer, failure FailureMessage, pver uint32) error {
 	// messages are fixed size.
 	pad := make([]byte, failureMessageLength-len(failureMessage))
 
-	return writeElements(w,
+	return WriteElements(w,
 		uint16(len(failureMessage)),
 		failureMessage,
 		uint16(len(pad)),

--- a/lnwire/open_channel.go
+++ b/lnwire/open_channel.go
@@ -134,7 +134,7 @@ var _ Message = (*OpenChannel)(nil)
 //
 // This is part of the lnwire.Message interface.
 func (o *OpenChannel) Encode(w io.Writer, pver uint32) error {
-	return writeElements(w,
+	return WriteElements(w,
 		o.ChainHash[:],
 		o.PendingChannelID[:],
 		o.FundingAmount,
@@ -162,7 +162,7 @@ func (o *OpenChannel) Encode(w io.Writer, pver uint32) error {
 //
 // This is part of the lnwire.Message interface.
 func (o *OpenChannel) Decode(r io.Reader, pver uint32) error {
-	return readElements(r,
+	return ReadElements(r,
 		o.ChainHash[:],
 		o.PendingChannelID[:],
 		&o.FundingAmount,

--- a/lnwire/ping.go
+++ b/lnwire/ping.go
@@ -35,7 +35,7 @@ var _ Message = (*Ping)(nil)
 //
 // This is part of the lnwire.Message interface.
 func (p *Ping) Decode(r io.Reader, pver uint32) error {
-	return readElements(r,
+	return ReadElements(r,
 		&p.NumPongBytes,
 		&p.PaddingBytes)
 }
@@ -45,7 +45,7 @@ func (p *Ping) Decode(r io.Reader, pver uint32) error {
 //
 // This is part of the lnwire.Message interface.
 func (p *Ping) Encode(w io.Writer, pver uint32) error {
-	return writeElements(w,
+	return WriteElements(w,
 		p.NumPongBytes,
 		p.PaddingBytes)
 }

--- a/lnwire/pong.go
+++ b/lnwire/pong.go
@@ -31,7 +31,7 @@ var _ Message = (*Pong)(nil)
 //
 // This is part of the lnwire.Message interface.
 func (p *Pong) Decode(r io.Reader, pver uint32) error {
-	return readElements(r,
+	return ReadElements(r,
 		&p.PongBytes,
 	)
 }
@@ -41,7 +41,7 @@ func (p *Pong) Decode(r io.Reader, pver uint32) error {
 //
 // This is part of the lnwire.Message interface.
 func (p *Pong) Encode(w io.Writer, pver uint32) error {
-	return writeElements(w,
+	return WriteElements(w,
 		p.PongBytes,
 	)
 }

--- a/lnwire/query_channel_range.go
+++ b/lnwire/query_channel_range.go
@@ -40,7 +40,7 @@ var _ Message = (*QueryChannelRange)(nil)
 //
 // This is part of the lnwire.Message interface.
 func (q *QueryChannelRange) Decode(r io.Reader, pver uint32) error {
-	return readElements(r,
+	return ReadElements(r,
 		q.ChainHash[:],
 		&q.FirstBlockHeight,
 		&q.NumBlocks,
@@ -52,7 +52,7 @@ func (q *QueryChannelRange) Decode(r io.Reader, pver uint32) error {
 //
 // This is part of the lnwire.Message interface.
 func (q *QueryChannelRange) Encode(w io.Writer, pver uint32) error {
-	return writeElements(w,
+	return WriteElements(w,
 		q.ChainHash[:],
 		q.FirstBlockHeight,
 		q.NumBlocks,

--- a/lnwire/reply_channel_range.go
+++ b/lnwire/reply_channel_range.go
@@ -42,7 +42,7 @@ func (c *ReplyChannelRange) Decode(r io.Reader, pver uint32) error {
 		return err
 	}
 
-	if err := readElements(r, &c.Complete); err != nil {
+	if err := ReadElements(r, &c.Complete); err != nil {
 		return err
 	}
 
@@ -60,7 +60,7 @@ func (c *ReplyChannelRange) Encode(w io.Writer, pver uint32) error {
 		return err
 	}
 
-	if err := writeElements(w, c.Complete); err != nil {
+	if err := WriteElements(w, c.Complete); err != nil {
 		return err
 	}
 

--- a/lnwire/reply_short_chan_ids_end.go
+++ b/lnwire/reply_short_chan_ids_end.go
@@ -38,7 +38,7 @@ var _ Message = (*ReplyShortChanIDsEnd)(nil)
 //
 // This is part of the lnwire.Message interface.
 func (c *ReplyShortChanIDsEnd) Decode(r io.Reader, pver uint32) error {
-	return readElements(r,
+	return ReadElements(r,
 		c.ChainHash[:],
 		&c.Complete,
 	)
@@ -49,7 +49,7 @@ func (c *ReplyShortChanIDsEnd) Decode(r io.Reader, pver uint32) error {
 //
 // This is part of the lnwire.Message interface.
 func (c *ReplyShortChanIDsEnd) Encode(w io.Writer, pver uint32) error {
-	return writeElements(w,
+	return WriteElements(w,
 		c.ChainHash[:],
 		c.Complete,
 	)

--- a/lnwire/revoke_and_ack.go
+++ b/lnwire/revoke_and_ack.go
@@ -46,7 +46,7 @@ var _ Message = (*RevokeAndAck)(nil)
 //
 // This is part of the lnwire.Message interface.
 func (c *RevokeAndAck) Decode(r io.Reader, pver uint32) error {
-	return readElements(r,
+	return ReadElements(r,
 		&c.ChanID,
 		c.Revocation[:],
 		&c.NextRevocationKey,
@@ -58,7 +58,7 @@ func (c *RevokeAndAck) Decode(r io.Reader, pver uint32) error {
 //
 // This is part of the lnwire.Message interface.
 func (c *RevokeAndAck) Encode(w io.Writer, pver uint32) error {
-	return writeElements(w,
+	return WriteElements(w,
 		c.ChanID,
 		c.Revocation[:],
 		c.NextRevocationKey,

--- a/lnwire/shutdown.go
+++ b/lnwire/shutdown.go
@@ -39,7 +39,7 @@ var _ Message = (*Shutdown)(nil)
 //
 // This is part of the lnwire.Message interface.
 func (s *Shutdown) Decode(r io.Reader, pver uint32) error {
-	return readElements(r, &s.ChannelID, &s.Address)
+	return ReadElements(r, &s.ChannelID, &s.Address)
 }
 
 // Encode serializes the target Shutdown into the passed io.Writer observing
@@ -47,7 +47,7 @@ func (s *Shutdown) Decode(r io.Reader, pver uint32) error {
 //
 // This is part of the lnwire.Message interface.
 func (s *Shutdown) Encode(w io.Writer, pver uint32) error {
-	return writeElements(w, s.ChannelID, s.Address)
+	return WriteElements(w, s.ChannelID, s.Address)
 }
 
 // MsgType returns the integer uniquely identifying this message type on the

--- a/lnwire/update_add_htlc.go
+++ b/lnwire/update_add_htlc.go
@@ -66,7 +66,7 @@ var _ Message = (*UpdateAddHTLC)(nil)
 //
 // This is part of the lnwire.Message interface.
 func (c *UpdateAddHTLC) Decode(r io.Reader, pver uint32) error {
-	return readElements(r,
+	return ReadElements(r,
 		&c.ChanID,
 		&c.ID,
 		&c.Amount,
@@ -81,7 +81,7 @@ func (c *UpdateAddHTLC) Decode(r io.Reader, pver uint32) error {
 //
 // This is part of the lnwire.Message interface.
 func (c *UpdateAddHTLC) Encode(w io.Writer, pver uint32) error {
-	return writeElements(w,
+	return WriteElements(w,
 		c.ChanID,
 		c.ID,
 		c.Amount,

--- a/lnwire/update_fail_htlc.go
+++ b/lnwire/update_fail_htlc.go
@@ -35,7 +35,7 @@ var _ Message = (*UpdateFailHTLC)(nil)
 //
 // This is part of the lnwire.Message interface.
 func (c *UpdateFailHTLC) Decode(r io.Reader, pver uint32) error {
-	return readElements(r,
+	return ReadElements(r,
 		&c.ChanID,
 		&c.ID,
 		&c.Reason,
@@ -47,7 +47,7 @@ func (c *UpdateFailHTLC) Decode(r io.Reader, pver uint32) error {
 //
 // This is part of the lnwire.Message interface.
 func (c *UpdateFailHTLC) Encode(w io.Writer, pver uint32) error {
-	return writeElements(w,
+	return WriteElements(w,
 		c.ChanID,
 		c.ID,
 		c.Reason,

--- a/lnwire/update_fail_malformed_htlc.go
+++ b/lnwire/update_fail_malformed_htlc.go
@@ -35,7 +35,7 @@ var _ Message = (*UpdateFailMalformedHTLC)(nil)
 //
 // This is part of the lnwire.Message interface.
 func (c *UpdateFailMalformedHTLC) Decode(r io.Reader, pver uint32) error {
-	return readElements(r,
+	return ReadElements(r,
 		&c.ChanID,
 		&c.ID,
 		c.ShaOnionBlob[:],
@@ -48,7 +48,7 @@ func (c *UpdateFailMalformedHTLC) Decode(r io.Reader, pver uint32) error {
 //
 // This is part of the lnwire.Message interface.
 func (c *UpdateFailMalformedHTLC) Encode(w io.Writer, pver uint32) error {
-	return writeElements(w,
+	return WriteElements(w,
 		c.ChanID,
 		c.ID,
 		c.ShaOnionBlob[:],

--- a/lnwire/update_fee.go
+++ b/lnwire/update_fee.go
@@ -35,7 +35,7 @@ var _ Message = (*UpdateFee)(nil)
 //
 // This is part of the lnwire.Message interface.
 func (c *UpdateFee) Decode(r io.Reader, pver uint32) error {
-	return readElements(r,
+	return ReadElements(r,
 		&c.ChanID,
 		&c.FeePerKw,
 	)
@@ -46,7 +46,7 @@ func (c *UpdateFee) Decode(r io.Reader, pver uint32) error {
 //
 // This is part of the lnwire.Message interface.
 func (c *UpdateFee) Encode(w io.Writer, pver uint32) error {
-	return writeElements(w,
+	return WriteElements(w,
 		c.ChanID,
 		c.FeePerKw,
 	)

--- a/lnwire/update_fulfill_htlc.go
+++ b/lnwire/update_fulfill_htlc.go
@@ -41,7 +41,7 @@ var _ Message = (*UpdateFulfillHTLC)(nil)
 //
 // This is part of the lnwire.Message interface.
 func (c *UpdateFulfillHTLC) Decode(r io.Reader, pver uint32) error {
-	return readElements(r,
+	return ReadElements(r,
 		&c.ChanID,
 		&c.ID,
 		c.PaymentPreimage[:],
@@ -53,7 +53,7 @@ func (c *UpdateFulfillHTLC) Decode(r io.Reader, pver uint32) error {
 //
 // This is part of the lnwire.Message interface.
 func (c *UpdateFulfillHTLC) Encode(w io.Writer, pver uint32) error {
-	return writeElements(w,
+	return WriteElements(w,
 		c.ChanID,
 		c.ID,
 		c.PaymentPreimage[:],


### PR DESCRIPTION
In this PR, we export the ReadElements and WriteElements functions.
We do this as exporting these functions makes it possible for outside
packages to define serializations which use the BOLT 1.0 wire format.


Split off of #2313. 

