### PR TITLE
channeldb: prepatory modifications for full SCB implementation 

### DIFF
--- a/breacharbiter_test.go
+++ b/breacharbiter_test.go
@@ -1580,18 +1580,12 @@ func createInitChannels(revocationWindow int) (*lnwallet.LightningChannel, *lnwa
 	if err := channelAlice.State().SyncPending(addr, 101); err != nil {
 		return nil, nil, nil, err
 	}
-	if err := channelAlice.State().FullSync(); err != nil {
-		return nil, nil, nil, err
-	}
 
 	addr = &net.TCPAddr{
 		IP:   net.ParseIP("127.0.0.1"),
 		Port: 18555,
 	}
 	if err := channelBob.State().SyncPending(addr, 101); err != nil {
-		return nil, nil, nil, err
-	}
-	if err := channelBob.State().FullSync(); err != nil {
 		return nil, nil, nil, err
 	}
 

--- a/channeldb/channel.go
+++ b/channeldb/channel.go
@@ -316,8 +316,8 @@ var (
 	// channel.
 	ChanStatusLocalDataLoss ChannelStatus = 1 << 2
 
-	// ChanStatusRestored is a status flag that signals that the chanel has
-	// been restored, and doesn't have all the fields a typical channel
+	// ChanStatusRestored is a status flag that signals that the channel
+	// has been restored, and doesn't have all the fields a typical channel
 	// will have.
 	ChanStatusRestored ChannelStatus = 1 << 3
 )
@@ -529,6 +529,28 @@ func (c *OpenChannel) ChanStatus() ChannelStatus {
 	defer c.RUnlock()
 
 	return c.chanStatus
+}
+
+// ApplyChanStatus allows the caller to modify the internal channel state in a
+// thead-safe manner.
+func (c *OpenChannel) ApplyChanStatus(status ChannelStatus) error {
+	c.Lock()
+	defer c.Unlock()
+
+	return c.putChanStatus(status)
+}
+
+// HasChanStatus returns true if the internal bitfield channel status of the
+// target channel has the specified status bit set.
+func (c *OpenChannel) HasChanStatus(status ChannelStatus) bool {
+	c.RLock()
+	defer c.RUnlock()
+
+	return c.hasChanStatus(status)
+}
+
+func (c *OpenChannel) hasChanStatus(status ChannelStatus) bool {
+	return c.chanStatus&status == status
 }
 
 // RefreshShortChanID updates the in-memory short channel ID using the latest

--- a/channeldb/db.go
+++ b/channeldb/db.go
@@ -531,7 +531,7 @@ func fetchChannels(d *DB, pending, waitingClose bool) ([]*OpenChannel, error) {
 					// than Default, then it means it is
 					// waiting to be closed.
 					channelWaitingClose :=
-						channel.ChanStatus() != Default
+						channel.ChanStatus() != ChanStatusDefault
 
 					// Only include it if we requested
 					// channels with the same waitingClose

--- a/channeldb/db_test.go
+++ b/channeldb/db_test.go
@@ -395,6 +395,22 @@ func TestRestoreChannelShells(t *testing.T) {
 			"pubkey: %v", err)
 	}
 
+	// Ensure that it isn't possible to modify the commitment state machine
+	// of this restored channel.
+	channel := nodeChans[0]
+	err = channel.UpdateCommitment(nil)
+	if err != ErrNoRestoredChannelMutation {
+		t.Fatalf("able to mutate restored channel")
+	}
+	err = channel.AppendRemoteCommitChain(nil)
+	if err != ErrNoRestoredChannelMutation {
+		t.Fatalf("able to mutate restored channel")
+	}
+	err = channel.AdvanceCommitChainTail(nil)
+	if err != ErrNoRestoredChannelMutation {
+		t.Fatalf("able to mutate restored channel")
+	}
+
 	// That single channel should have the proper channel point, and also
 	// the expected set of flags to indicate that it was a restored
 	// channel.

--- a/channeldb/error.go
+++ b/channeldb/error.go
@@ -103,6 +103,11 @@ var (
 	// indicate it should be.
 	ErrEdgePolicyOptionalFieldNotFound = fmt.Errorf("optional field not " +
 		"present")
+
+	// ErrChanAlreadyExists is return when the caller attempts to create a
+	// channel with a channel point that is already present in the
+	// database.
+	ErrChanAlreadyExists = fmt.Errorf("channel already exists")
 )
 
 // ErrTooManyExtraOpaqueBytes creates an error which should be returned if the

--- a/channeldb/migrations.go
+++ b/channeldb/migrations.go
@@ -563,7 +563,7 @@ func migratePruneEdgeUpdateIndex(tx *bbolt.Tx) error {
 			return err
 		}
 
-		err = updateEdgePolicy(edges, edgeIndex, nodes, edgePolicy)
+		err = updateEdgePolicy(tx, edgePolicy)
 		if err != nil {
 			return err
 		}

--- a/channeldb/nodes.go
+++ b/channeldb/nodes.go
@@ -62,13 +62,13 @@ type LinkNode struct {
 // NewLinkNode creates a new LinkNode from the provided parameters, which is
 // backed by an instance of channeldb.
 func (db *DB) NewLinkNode(bitNet wire.BitcoinNet, pub *btcec.PublicKey,
-	addr net.Addr) *LinkNode {
+	addrs ...net.Addr) *LinkNode {
 
 	return &LinkNode{
 		Network:     bitNet,
 		IdentityPub: pub,
 		LastSeen:    time.Now(),
-		Addresses:   []net.Addr{addr},
+		Addresses:   addrs,
 		db:          db,
 	}
 }
@@ -149,39 +149,43 @@ func (db *DB) deleteLinkNode(tx *bbolt.Tx, identity *btcec.PublicKey) error {
 // identity public key. If a particular LinkNode for the passed identity public
 // key cannot be found, then ErrNodeNotFound if returned.
 func (db *DB) FetchLinkNode(identity *btcec.PublicKey) (*LinkNode, error) {
-	var (
-		node *LinkNode
-		err  error
-	)
-
-	err = db.View(func(tx *bbolt.Tx) error {
-		// First fetch the bucket for storing node metadata, bailing
-		// out early if it hasn't been created yet.
-		nodeMetaBucket := tx.Bucket(nodeInfoBucket)
-		if nodeMetaBucket == nil {
-			return ErrLinkNodesNotFound
+	var linkNode *LinkNode
+	err := db.View(func(tx *bbolt.Tx) error {
+		node, err := fetchLinkNode(tx, identity)
+		if err != nil {
+			return err
 		}
 
-		// If a link node for that particular public key cannot be
-		// located, then exit early with an ErrNodeNotFound.
-		pubKey := identity.SerializeCompressed()
-		nodeBytes := nodeMetaBucket.Get(pubKey)
-		if nodeBytes == nil {
-			return ErrNodeNotFound
-		}
-
-		// Finally, decode an allocate a fresh LinkNode object to be
-		// returned to the caller.
-		nodeReader := bytes.NewReader(nodeBytes)
-		node, err = deserializeLinkNode(nodeReader)
-		return err
+		linkNode = node
+		return nil
 	})
-	if err != nil {
-		return nil, err
+
+	return linkNode, err
+}
+
+func fetchLinkNode(tx *bbolt.Tx, targetPub *btcec.PublicKey) (*LinkNode, error) {
+	// First fetch the bucket for storing node metadata, bailing out early
+	// if it hasn't been created yet.
+	nodeMetaBucket := tx.Bucket(nodeInfoBucket)
+	if nodeMetaBucket == nil {
+		return nil, ErrLinkNodesNotFound
 	}
 
-	return node, nil
+	// If a link node for that particular public key cannot be located,
+	// then exit early with an ErrNodeNotFound.
+	pubKey := targetPub.SerializeCompressed()
+	nodeBytes := nodeMetaBucket.Get(pubKey)
+	if nodeBytes == nil {
+		return nil, ErrNodeNotFound
+	}
+
+	// Finally, decode and allocate a fresh LinkNode object to be returned
+	// to the caller.
+	nodeReader := bytes.NewReader(nodeBytes)
+	return deserializeLinkNode(nodeReader)
 }
+
+// TODO(roasbeef): update link node addrs in server upon connection
 
 // FetchAllLinkNodes starts a new database transaction to fetch all nodes with
 // whom we have active channels with.

--- a/contractcourt/chain_arbitrator.go
+++ b/contractcourt/chain_arbitrator.go
@@ -224,22 +224,9 @@ func newActiveChannelArbitrator(channel *channeldb.OpenChannel,
 			// With the channels fetched, attempt to locate
 			// the target channel according to its channel
 			// point.
-			dbChannels, err := c.chanSource.FetchAllChannels()
+			channel, err := c.chanSource.FetchChannel(chanPoint)
 			if err != nil {
 				return nil, err
-			}
-			var channel *channeldb.OpenChannel
-			for _, dbChannel := range dbChannels {
-				if dbChannel.FundingOutpoint == chanPoint {
-					channel = dbChannel
-					break
-				}
-			}
-
-			// If the channel cannot be located, then we
-			// exit with an error to the channel.
-			if channel == nil {
-				return nil, fmt.Errorf("unable to find channel")
 			}
 
 			chanMachine, err := lnwallet.NewLightningChannel(

--- a/peer.go
+++ b/peer.go
@@ -409,7 +409,7 @@ func (p *peer) loadActiveChannels(chans []*channeldb.OpenChannel) error {
 
 		// Skip adding any permanently irreconcilable channels to the
 		// htlcswitch.
-		if dbChan.ChanStatus() != channeldb.Default {
+		if dbChan.ChanStatus() != channeldb.ChanStatusDefault {
 			peerLog.Warnf("ChannelPoint(%v) has status %v, won't "+
 				"start.", chanPoint, dbChan.ChanStatus())
 			continue


### PR DESCRIPTION
In this PR, we add number of methods that will be used for the final SBC implementation. Along the way we refactor some core functionality within the package to ensure that we're able to properly re-use database transactions at higher levels. See the commits for further details along with the parent PR to this. 


Broken off of #2313. 