### PR TITLE
Update API documentation for listInvoices

### DIFF
--- a/lnrpc/rpc.proto
+++ b/lnrpc/rpc.proto
@@ -480,7 +480,7 @@ service Lightning {
     last_index_offset fields included in the response as the index_offset of the
     next request. The reversed flag is set by default in order to paginate
     backwards. If you wish to paginate forwards, you must explicitly set the
-    flag to false. If none of the parameters are specified, then the last 100
+    flag to false. If none of the parameters are specified, then the first 100
     invoices will be returned.
     */
     rpc ListInvoices (ListInvoiceRequest) returns (ListInvoiceResponse) {


### PR DESCRIPTION
From my testing, if none of the parameters are specified, then the *first* 100 invoices will be returned. i.e. the *oldest* invoices

I'm still unsure why it says that "The reversed flag is set by default in order to paginate backwards". Perhaps this is only true if you have set one of the offset fields.

#### Pull Request Checklist

- [ ] If this is your first time contributing, we recommend you read the [Code
  Contribution Guidelines](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md)
- [ ] All changes are Go version 1.11 compliant
- [ ]  The code being submitted is commented according to the
  [Code Documentation and Commenting](#CodeDocumentation) section
- [ ]  For new code: Code is accompanied by tests which exercise both
  the positive and negative (error paths) conditions (if applicable)
- [ ]  For bug fixes: Code is accompanied by new tests which trigger
  the bug being fixed to prevent regressions
- [ ]  Any new logging statements use an appropriate subsystem and
  logging level
- [ ]  Code has been formatted with `go fmt`
- [ ]  For code and documentation: lines are wrapped at 80 characters
  (the tab character should be counted as 8 characters, not 4, as some IDEs do
  per default)
- [ ]  Running `make check` does not fail any tests
- [ ]  Running `go vet` does not report any issues
- [ ]  Running `make lint` does not report any **new** issues that did not
  already exist
- [ ] All commits build properly and pass tests. Only in exceptional
  cases it can be justifiable to violate this condition. In that case, the
  reason should be stated in the commit message.
- [ ] Commits have a logical structure ([see section 4.5, of the Code Contribution Guidelines])
