### PR TITLE
Fix build failures on docker-compose.

### DIFF
--- a/docker/lnd/Dockerfile
+++ b/docker/lnd/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.10-alpine as builder
+FROM golang:1.11-alpine as builder
 
 MAINTAINER Olaoluwa Osuntokun <lightning.engineering>
 

--- a/docker/lnd/Dockerfile
+++ b/docker/lnd/Dockerfile
@@ -12,7 +12,7 @@ ENV GODEBUG netdns=cgo
 # Install dependencies and install/build lnd.
 RUN apk add --no-cache \
     git \
-    make \
+    make gcc musl-dev \
 &&  cd /go/src/github.com/lightningnetwork/lnd \
 &&  make \
 &&  make install


### PR DESCRIPTION
This PR is not for any Golang code. So I omited `Pull Request Checklist`

`docker/lnd/Dockerfile` haven't been updated even though lnd was moved to Golang 1.11.
This will fix it.