### PR TITLE
docs/INSTALL.md: update Go installation options for Linux

### DIFF
--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -32,12 +32,35 @@
 
 
     On Linux:
+
+    (x86-64)
     ```
-    sudo apt-get install golang-1.11-go
+    wget https://dl.google.com/go/go1.11.4.linux-amd64.tar.gz
+    sha256sum go1.11.4.linux-amd64.tar.gz | awk -F " " '{ print $1 }'
     ```
-    > Note that golang-1.11-go puts binaries in /usr/lib/go-1.11/bin. If you want them on your PATH, you need to make that change yourself. Alternatively, you can run:
+
+    The final output of the command above should be
+    `fb26c30e6a04ad937bbc657a1b5bba92f80096af1e8ee6da6430c045a8db3a5b`. If it
+    isn't, then the target REPO HAS BEEN MODIFIED, and you shouldn't install
+    this version of Go. If it matches, then proceed to install Go:
     ```
-    sudo ln -s /usr/lib/go-1.11/bin/go /usr/local/bin/go
+    tar -C /usr/local -xzf go1.11.4.linux-amd64.tar.gz
+    export PATH=$PATH:/usr/local/go/bin
+    ```
+
+    (ARMv6)
+    ```
+    wget https://dl.google.com/go/go1.11.4.linux-armv6l.tar.gz
+    sha256sum go1.11.4.linux-armv6l.tar.gz | awk -F " " '{ print $1 }'
+    ```
+
+    The final output of the command above should be
+    `9f7a71d27fef69f654a93e265560c8d9db1a2ca3f1dcdbe5288c46facfde5821`. If it
+    isn't, then the target REPO HAS BEEN MODIFIED, and you shouldn't install
+    this version of Go. If it matches, then proceed to install Go:
+    ```
+    tar -C /usr/local -xzf go1.11.4.linux-armv6l.tar.gz
+    export PATH=$PATH:/usr/local/go/bin
     ```
 
     On Mac OS X:

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -65,7 +65,7 @@
 
     On Mac OS X:
     ```
-    brew install go
+    brew install go@1.11
     ```
 
     On FreeBSD:


### PR DESCRIPTION
In this commit, we modify the Linux installation instructions to use the
pre-built archives rather than install from the ppa. We do this as
typically the ppa lags behind the latest releases, and also by
downloading it in this new manner, we're able to verify the sha256 sum
of the installed Go release.

