### PR TITLE
cnct: use sweeper in commit resolver

### DIFF
--- a/contractcourt/briefcase_test.go
+++ b/contractcourt/briefcase_test.go
@@ -294,7 +294,6 @@ func TestContractInsertionRetrieval(t *testing.T) {
 			resolved:        false,
 			broadcastHeight: 109,
 			chanPoint:       testChanPoint1,
-			sweepTx:         nil,
 		},
 	}
 


### PR DESCRIPTION
Now that the sweeper is available, it isn't necessary anymore for the
commit resolver to craft its own sweep tx. Instead it can offer its
input to the sweeper and wait for the outcome.

When this PR is merged, a follow up is to use sweeper in `htlcSuccessResolver` too.