### PR TITLE
netann: channel status manager

### DIFF
--- a/config.go
+++ b/config.go
@@ -31,30 +31,32 @@ import (
 )
 
 const (
-	defaultConfigFilename      = "lnd.conf"
-	defaultDataDirname         = "data"
-	defaultChainSubDirname     = "chain"
-	defaultGraphSubDirname     = "graph"
-	defaultTLSCertFilename     = "tls.cert"
-	defaultTLSKeyFilename      = "tls.key"
-	defaultAdminMacFilename    = "admin.macaroon"
-	defaultReadMacFilename     = "readonly.macaroon"
-	defaultInvoiceMacFilename  = "invoice.macaroon"
-	defaultLogLevel            = "info"
-	defaultLogDirname          = "logs"
-	defaultLogFilename         = "lnd.log"
-	defaultRPCPort             = 10009
-	defaultRESTPort            = 8080
-	defaultPeerPort            = 9735
-	defaultRPCHost             = "localhost"
-	defaultMaxPendingChannels  = 1
-	defaultNoSeedBackup        = false
-	defaultTrickleDelay        = 90 * 1000
-	defaultInactiveChanTimeout = 20 * time.Minute
-	defaultMaxLogFiles         = 3
-	defaultMaxLogFileSize      = 10
-	defaultMinBackoff          = time.Second
-	defaultMaxBackoff          = time.Hour
+	defaultConfigFilename           = "lnd.conf"
+	defaultDataDirname              = "data"
+	defaultChainSubDirname          = "chain"
+	defaultGraphSubDirname          = "graph"
+	defaultTLSCertFilename          = "tls.cert"
+	defaultTLSKeyFilename           = "tls.key"
+	defaultAdminMacFilename         = "admin.macaroon"
+	defaultReadMacFilename          = "readonly.macaroon"
+	defaultInvoiceMacFilename       = "invoice.macaroon"
+	defaultLogLevel                 = "info"
+	defaultLogDirname               = "logs"
+	defaultLogFilename              = "lnd.log"
+	defaultRPCPort                  = 10009
+	defaultRESTPort                 = 8080
+	defaultPeerPort                 = 9735
+	defaultRPCHost                  = "localhost"
+	defaultMaxPendingChannels       = 1
+	defaultNoSeedBackup             = false
+	defaultTrickleDelay             = 90 * 1000
+	defaultChanStatusSampleInterval = time.Minute
+	defaultChanEnableTimeout        = 19 * time.Minute
+	defaultChanDisableTimeout       = 20 * time.Minute
+	defaultMaxLogFiles              = 3
+	defaultMaxLogFileSize           = 10
+	defaultMinBackoff               = time.Second
+	defaultMaxBackoff               = time.Hour
 
 	defaultTorSOCKSPort            = 9050
 	defaultTorDNSHost              = "soa.nodes.lightning.directory"
@@ -234,8 +236,10 @@ type config struct {
 
 	NoSeedBackup bool `long:"noseedbackup" description:"If true, NO SEED WILL BE EXPOSED AND THE WALLET WILL BE ENCRYPTED USING THE DEFAULT PASSPHRASE -- EVER. THIS FLAG IS ONLY FOR TESTING AND IS BEING DEPRECATED."`
 
-	TrickleDelay        int           `long:"trickledelay" description:"Time in milliseconds between each release of announcements to the network"`
-	InactiveChanTimeout time.Duration `long:"inactivechantimeout" description:"If a channel has been inactive for the set time, send a ChannelUpdate disabling it."`
+	TrickleDelay             int           `long:"trickledelay" description:"Time in milliseconds between each release of announcements to the network"`
+	ChanEnableTimeout        time.Duration `long:"chan-enable-timeout" description:"The duration that a peer connection must be stable before attempting to send a channel update to reenable or cancel a pending disables of the peer's channels on the network (default: 19m)."`
+	ChanDisableTimeout       time.Duration `long:"chan-disable-timeout" description:"The duration that must elapse after first detecting that an already active channel is actually inactive and sending channel update disabling it to the network. The pending disable can be canceled if the peer reconnects and becomes stable for chan-enable-timeout before the disable update is sent. (default: 20m)"`
+	ChanStatusSampleInterval time.Duration `long:"chan-status-sample-interval" description:"The polling interval between attempts to detect if an active channel has become inactive due to its peer going offline. (default: 1m)"`
 
 	Alias       string `long:"alias" description:"The node alias. Used as a moniker by peers and intelligence services"`
 	Color       string `long:"color" description:"The color of the node in hex format (i.e. '#3399FF'). Used to customize node appearance in intelligence services"`
@@ -317,11 +321,13 @@ func loadConfig() (*config, error) {
 				"preferential": 1.0,
 			},
 		},
-		TrickleDelay:        defaultTrickleDelay,
-		InactiveChanTimeout: defaultInactiveChanTimeout,
-		Alias:               defaultAlias,
-		Color:               defaultColor,
-		MinChanSize:         int64(minChanFundingSize),
+		TrickleDelay:             defaultTrickleDelay,
+		ChanStatusSampleInterval: defaultChanStatusSampleInterval,
+		ChanEnableTimeout:        defaultChanEnableTimeout,
+		ChanDisableTimeout:       defaultChanDisableTimeout,
+		Alias:                    defaultAlias,
+		Color:                    defaultColor,
+		MinChanSize:              int64(minChanFundingSize),
 		Tor: &torConfig{
 			SOCKS:   defaultTorSOCKS,
 			DNS:     defaultTorDNS,

--- a/lnd_test.go
+++ b/lnd_test.go
@@ -12755,7 +12755,7 @@ func testSendUpdateDisableChannel(net *lntest.NetworkHarness, t *harnessTest) {
 	// We create a new node Eve that has an inactive channel timeout of
 	// just 2 seconds (down from the default 20m). It will be used to test
 	// channel updates for channels going inactive.
-	eve, err := net.NewNode("Eve", []string{"--inactivechantimeout=2s"})
+	eve, err := net.NewNode("Eve", []string{"--chan-disable-timeout=2s"})
 	if err != nil {
 		t.Fatalf("unable to create eve's node: %v", err)
 	}

--- a/netann/chan_status_manager.go
+++ b/netann/chan_status_manager.go
@@ -1,0 +1,595 @@
+package netann
+
+import (
+	"errors"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/btcsuite/btcd/btcec"
+	"github.com/btcsuite/btcd/wire"
+	"github.com/lightningnetwork/lnd/channeldb"
+	"github.com/lightningnetwork/lnd/lnwallet"
+	"github.com/lightningnetwork/lnd/lnwire"
+)
+
+var (
+	// ErrChanStatusManagerExiting signals that a shutdown of the
+	// ChanStatusManager has already been requested.
+	ErrChanStatusManagerExiting = errors.New("chan status manager exiting")
+
+	// ErrInvalidTimeoutConstraints signals that the ChanStatusManager could
+	// not be initialized because the timeouts and sample intervals were
+	// malformed.
+	ErrInvalidTimeoutConstraints = errors.New("active_timeout + " +
+		"sample_interval must be less than or equal to " +
+		"inactive_timeout and be positive integers")
+
+	// ErrEnableInactiveChan signals that a request to enable a channel
+	// could not be completed because the channel isn't actually active at
+	// the time of the request.
+	ErrEnableInactiveChan = errors.New("unable to enable channel which " +
+		"is not currently active")
+)
+
+// ChanStatusConfig holds parameters and resources required by the
+// ChanStatusManager to perform its duty.
+type ChanStatusConfig struct {
+	// OurPubKey is the public key identifying this node on the network.
+	OurPubKey *btcec.PublicKey
+
+	// MessageSigner signs messages that validate under OurPubKey.
+	MessageSigner lnwallet.MessageSigner
+
+	// IsChannelActive checks whether the channel identified by the provided
+	// ChannelID is considered active. This should only return true if the
+	// channel has been sufficiently confirmed, the channel has received
+	// FundingLocked, and the remote peer is online.
+	IsChannelActive func(lnwire.ChannelID) bool
+
+	// ApplyChannelUpdate processes new ChannelUpdates signed by our node by
+	// updating our local routing table and broadcasting the update to our
+	// peers.
+	ApplyChannelUpdate func(*lnwire.ChannelUpdate) error
+
+	// DB stores the set of channels that are to be monitored.
+	DB DB
+
+	// Graph stores the channel info and policies for channels in DB.
+	Graph ChannelGraph
+
+	// ChanEnableTimeout is the duration a peer's connect must remain stable
+	// before attempting to reenable the channel.
+	//
+	// NOTE: This value is only used to verify that the relation between
+	// itself, ChanDisableTimeout, and ChanStatusSampleInterval is correct.
+	// The user is still responsible for ensuring that the same duration
+	// elapses before attempting to reenable a channel.
+	ChanEnableTimeout time.Duration
+
+	// ChanDisableTimeout is the duration the manager will wait after
+	// detecting that a channel has become inactive before broadcasting an
+	// update to disable the channel.
+	ChanDisableTimeout time.Duration
+
+	// ChanStatusSampleInterval is the long-polling interval used by the
+	// manager to check if the channels being monitored have become
+	// inactive.
+	ChanStatusSampleInterval time.Duration
+}
+
+// ChanStatusManager facilitates requests to enable or disable a channel via a
+// network announcement that sets the disable bit on the ChannelUpdate
+// accordingly. The manager will periodically sample to detect cases where a
+// link has become inactive, and facilitate the process of disabling the channel
+// passively. The ChanStatusManager state machine is designed to reduce the
+// likelihood of spamming the network with updates for flapping peers.
+type ChanStatusManager struct {
+	started uint32 // to be used atomically
+	stopped uint32 // to be used atomically
+
+	cfg *ChanStatusConfig
+
+	// ourPubKeyBytes is the serialized compressed pubkey of our node.
+	ourPubKeyBytes []byte
+
+	// chanStates contains the set of channels being monitored for status
+	// updates. Access to the map is serialized by the statusManager's event
+	// loop.
+	chanStates channelStates
+
+	// enableRequests pipes external requests to enable a channel into the
+	// primary event loop.
+	enableRequests chan statusRequest
+
+	// disableRequests pipes external requests to disable a channel into the
+	// primary event loop.
+	disableRequests chan statusRequest
+
+	// statusSampleTicker fires at the interval prescribed by
+	// ChanStatusSampleInterval to check if channels in chanStates have
+	// become inactive.
+	statusSampleTicker *time.Ticker
+
+	wg   sync.WaitGroup
+	quit chan struct{}
+}
+
+// NewChanStatusManager initializes a new ChanStatusManager using the given
+// configuration. An error is returned if the timeouts and sample interval fail
+// to meet do not satisfy the equation:
+//   ChanEnableTimeout + ChanStatusSampleInterval > ChanDisableTimeout.
+func NewChanStatusManager(cfg *ChanStatusConfig) (*ChanStatusManager, error) {
+	// Assert that the config timeouts are properly formed. We require the
+	// enable_timeout + sample_interval to be less than or equal to the
+	// disable_timeout and that all are positive values. A peer that
+	// disconnects and reconnects quickly may cause a disable update to be
+	// sent, shortly followed by a reenable. Ensuring a healthy separation
+	// helps dampen the possibility of spamming updates that toggle the
+	// disable bit for such events.
+	if cfg.ChanStatusSampleInterval <= 0 {
+		return nil, ErrInvalidTimeoutConstraints
+	}
+	if cfg.ChanEnableTimeout <= 0 {
+		return nil, ErrInvalidTimeoutConstraints
+	}
+	if cfg.ChanDisableTimeout <= 0 {
+		return nil, ErrInvalidTimeoutConstraints
+	}
+	if cfg.ChanEnableTimeout+cfg.ChanStatusSampleInterval >
+		cfg.ChanDisableTimeout {
+		return nil, ErrInvalidTimeoutConstraints
+
+	}
+
+	return &ChanStatusManager{
+		cfg:                cfg,
+		ourPubKeyBytes:     cfg.OurPubKey.SerializeCompressed(),
+		chanStates:         make(channelStates),
+		statusSampleTicker: time.NewTicker(cfg.ChanStatusSampleInterval),
+		enableRequests:     make(chan statusRequest),
+		disableRequests:    make(chan statusRequest),
+		quit:               make(chan struct{}),
+	}, nil
+}
+
+// Start safely starts the ChanStatusManager.
+func (m *ChanStatusManager) Start() error {
+	if !atomic.CompareAndSwapUint32(&m.started, 0, 1) {
+		return nil
+	}
+
+	channels, err := m.fetchChannels()
+	if err != nil {
+		return err
+	}
+
+	// Populate the initial states of all confirmed, public channels.
+	for _, c := range channels {
+		_, err := m.getOrInitChanStatus(c.FundingOutpoint)
+		switch {
+
+		// If we can't retrieve the edge info for this channel, it may
+		// have been pruned from the channel graph but not yet from our
+		// set of channels. We'll skip it as we can't determine its
+		// initial state.
+		case err == channeldb.ErrEdgeNotFound:
+			log.Warnf("Unable to find channel policies for %v, "+
+				"skipping. This is typical if the channel is "+
+				"in the process of closing.", c.FundingOutpoint)
+			continue
+
+		case err != nil:
+			return err
+		}
+	}
+
+	m.wg.Add(1)
+	go m.statusManager()
+
+	return nil
+}
+
+// Stop safely shuts down the ChanStatusManager.
+func (m *ChanStatusManager) Stop() error {
+	if !atomic.CompareAndSwapUint32(&m.stopped, 0, 1) {
+		return nil
+	}
+
+	close(m.quit)
+	m.wg.Wait()
+
+	return nil
+}
+
+// RequestEnable submits a request to immediately enable a channel identified by
+// the provided outpoint. If the channel is already enabled, no action will be
+// taken. If the channel is marked pending-disable the channel will be returned
+// to an active status as the scheduled disable was never sent. Otherwise if the
+// channel is found to be disabled, a new announcement will be signed with the
+// disabled bit cleared and broadcast to the network.
+//
+// NOTE: RequestEnable should only be called after a stable connection with the
+// channel's peer has lasted at least the ChanEnableTimeout. Failure to do so
+// may result in behavior that deviates from the expected behavior of the state
+// machine.
+func (m *ChanStatusManager) RequestEnable(outpoint wire.OutPoint) error {
+	return m.submitRequest(m.enableRequests, outpoint)
+}
+
+// RequestDisable submits a request to immediately disable a channel identified
+// by the provided outpoint. If the channel is already disabled, no action will
+// be taken. Otherwise, a new announcement will be signed with the disabled bit
+// set and broadcast to the network.
+func (m *ChanStatusManager) RequestDisable(outpoint wire.OutPoint) error {
+	return m.submitRequest(m.disableRequests, outpoint)
+}
+
+// statusRequest is passed to the statusManager to request a change in status
+// for a particular channel point.  The exact action is governed by passing the
+// request through one of the enableRequests or disableRequests channels.
+type statusRequest struct {
+	outpoint wire.OutPoint
+	errChan  chan error
+}
+
+// submitRequest sends a request for either enabling or disabling a particular
+// outpoint and awaits an error response. The request type is dictated by the
+// reqChan passed in, which can be either of the enableRequests or
+// disableRequests channels.
+func (m *ChanStatusManager) submitRequest(reqChan chan statusRequest,
+	outpoint wire.OutPoint) error {
+
+	req := statusRequest{
+		outpoint: outpoint,
+		errChan:  make(chan error, 1),
+	}
+
+	select {
+	case reqChan <- req:
+	case <-m.quit:
+		return ErrChanStatusManagerExiting
+	}
+
+	select {
+	case err := <-req.errChan:
+		return err
+	case <-m.quit:
+		return ErrChanStatusManagerExiting
+	}
+}
+
+// statusManager is the primary event loop for the ChanStatusManager, providing
+// the necessary synchronization primitive to protect access to the chanStates
+// map. All requests to explicitly enable or disable a channel are processed
+// within this method. The statusManager will also periodically poll the active
+// status of channels within the htlcswitch to see if a disable announcement
+// should be scheduled or broadcast.
+//
+// NOTE: This method MUST be run as a goroutine.
+func (m *ChanStatusManager) statusManager() {
+	defer m.wg.Done()
+
+	for {
+		select {
+
+		// Process any requests to mark channel as enabled.
+		case req := <-m.enableRequests:
+			req.errChan <- m.processEnableRequest(req.outpoint)
+
+		// Process any requests to mark channel as disabled.
+		case req := <-m.disableRequests:
+			req.errChan <- m.processDisableRequest(req.outpoint)
+
+		// Use long-polling to detect when channels become inactive.
+		case <-m.statusSampleTicker.C:
+			// First, do a sweep and mark any ChanStatusEnabled
+			// channels that are not active within the htlcswitch as
+			// ChanStatusPendingDisabled. The channel will then be
+			// disabled if no request to enable is received before
+			// the ChanDisableTimeout expires.
+			m.markPendingInactiveChannels()
+
+			// Now, do another sweep to disable any channels that
+			// were marked in a prior iteration as pending inactive
+			// if the inactive chan timeout has elapsed.
+			m.disableInactiveChannels()
+
+		case <-m.quit:
+			return
+		}
+	}
+}
+
+// processEnableRequest attempts to enable the given outpoint. If the method
+// returns nil, the status of the channel in chanStates will be
+// ChanStatusEnabled. If the channel is not active at the time of the request,
+// ErrEnableInactiveChan will be returned. An update will be broadcast only if
+// the channel is currently disabled, otherwise no update will be sent on the
+// network.
+func (m *ChanStatusManager) processEnableRequest(outpoint wire.OutPoint) error {
+	curState, err := m.getOrInitChanStatus(outpoint)
+	if err != nil {
+		return err
+	}
+
+	// Quickly check to see if the requested channel is active within the
+	// htlcswitch and return an error if it isn't.
+	chanID := lnwire.NewChanIDFromOutPoint(&outpoint)
+	if !m.cfg.IsChannelActive(chanID) {
+		return ErrEnableInactiveChan
+	}
+
+	switch curState.Status {
+
+	// Channel is already enabled, nothing to do.
+	case ChanStatusEnabled:
+		return nil
+
+	// The channel is enabled, though we are now canceling the scheduled
+	// disable.
+	case ChanStatusPendingDisabled:
+		log.Debugf("Channel(%v) already enabled, canceling scheduled "+
+			"disable", outpoint)
+
+	// We'll sign a new update if the channel is still disabled.
+	case ChanStatusDisabled:
+		log.Infof("Announcing channel(%v) enabled", outpoint)
+
+		err := m.signAndSendNextUpdate(outpoint, false)
+		if err != nil {
+			return err
+		}
+	}
+
+	m.chanStates.markEnabled(outpoint)
+
+	return nil
+}
+
+// processDisableRequest attempts to disable the given outpoint. If the method
+// returns nil, the status of the channel in chanStates will be
+// ChanStatusDisabled. An update will only be sent if the channel has a status
+// other than ChanStatusEnabled, otherwise no update will be sent on the
+// network.
+func (m *ChanStatusManager) processDisableRequest(outpoint wire.OutPoint) error {
+	curState, err := m.getOrInitChanStatus(outpoint)
+	if err != nil {
+		return err
+	}
+
+	switch curState.Status {
+
+	// Channel is already disabled, nothing to do.
+	case ChanStatusDisabled:
+		return nil
+
+	// We'll sign a new update disabling the channel if the current status
+	// is enabled or pending-inactive.
+	case ChanStatusEnabled, ChanStatusPendingDisabled:
+		log.Infof("Announcing channel(%v) disabled [requested]",
+			outpoint)
+
+		err := m.signAndSendNextUpdate(outpoint, true)
+		if err != nil {
+			return err
+		}
+	}
+
+	// If the disable was requested via the manager's public interface, we
+	// will remove the output from our map of channel states. Typically this
+	// signals that the channel is being closed, so this frees up the space
+	// in the map. If for some reason the channel isn't closed, the state
+	// will be repopulated on subsequent calls to RequestEnable or
+	// RequestDisable via a db lookup, or on startup.
+	delete(m.chanStates, outpoint)
+
+	return nil
+}
+
+// markPendingInactiveChannels performs a sweep of the database's active
+// channels and determines which, if any, should have a disable announcement
+// scheduled. Once an active channel is determined to be pending-inactive, one
+// of two transitions can follow. Either the channel is disabled because no
+// request to enable is received before the scheduled disable is broadcast, or
+// the channel is successfully reenabled and channel is returned to an active
+// state from the POV of the ChanStatusManager.
+func (m *ChanStatusManager) markPendingInactiveChannels() {
+	channels, err := m.fetchChannels()
+	if err != nil {
+		log.Errorf("Unable to load active channels: %v", err)
+		return
+	}
+
+	for _, c := range channels {
+		// Determine the initial status of the active channel, and
+		// populate the entry in the chanStates map.
+		curState, err := m.getOrInitChanStatus(c.FundingOutpoint)
+		if err != nil {
+			log.Errorf("Unable to retrieve chan status for "+
+				"Channel(%v): %v", c.FundingOutpoint, err)
+			continue
+		}
+
+		// If the channel's status is not ChanStatusEnabled, we are
+		// done.  Either it is already disabled, or it has been marked
+		// ChanStatusPendingDisable meaning that we have already
+		// scheduled the time at which it will be disabled.
+		if curState.Status != ChanStatusEnabled {
+			continue
+		}
+
+		// If our bookkeeping shows the channel as active, sample the
+		// htlcswitch to see if it believes the link is also active. If
+		// so, we will skip marking it as ChanStatusPendingDisabled.
+		chanID := lnwire.NewChanIDFromOutPoint(&c.FundingOutpoint)
+		if m.cfg.IsChannelActive(chanID) {
+			continue
+		}
+
+		// Otherwise, we discovered that this link was inactive within
+		// the switch. Compute the time at which we will send out a
+		// disable if the peer is unable to reestablish a stable
+		// connection.
+		disableTime := time.Now().Add(m.cfg.ChanDisableTimeout)
+
+		log.Debugf("Marking channel(%v) pending-inactive",
+			c.FundingOutpoint)
+
+		m.chanStates.markPendingDisabled(c.FundingOutpoint, disableTime)
+	}
+}
+
+// disableInactiveChannels scans through the set of monitored channels, and
+// broadcast a disable update for any pending inactive channels whose
+// SendDisableTime has been superseded by the current time.
+func (m *ChanStatusManager) disableInactiveChannels() {
+	// Now, disable any channels whose inactive chan timeout has elapsed.
+	now := time.Now()
+	for outpoint, state := range m.chanStates {
+		// Ignore statuses that are not in the pending-inactive state.
+		if state.Status != ChanStatusPendingDisabled {
+			continue
+		}
+
+		// Ignore statuses for which the disable timeout has not
+		// expired.
+		if state.SendDisableTime.After(now) {
+			continue
+		}
+
+		log.Infof("Announcing channel(%v) disabled "+
+			"[detected]", outpoint)
+
+		// Sign an update disabling the channel.
+		err := m.signAndSendNextUpdate(outpoint, true)
+		if err != nil {
+			log.Errorf("Unable to sign update disabling "+
+				"channel(%v): %v", outpoint, err)
+			continue
+		}
+
+		// Record that the channel has now been disabled.
+		m.chanStates.markDisabled(outpoint)
+	}
+}
+
+// fetchChannels returns the working set of channels managed by the
+// ChanStatusManager. The returned channels are filtered to only contain public
+// channels.
+func (m *ChanStatusManager) fetchChannels() ([]*channeldb.OpenChannel, error) {
+	allChannels, err := m.cfg.DB.FetchAllOpenChannels()
+	if err != nil {
+		return nil, err
+	}
+
+	// Filter out private channels.
+	var channels []*channeldb.OpenChannel
+	for _, c := range allChannels {
+		// We'll skip any private channels, as they aren't used for
+		// routing within the network by other nodes.
+		if c.ChannelFlags&lnwire.FFAnnounceChannel == 0 {
+			continue
+		}
+
+		channels = append(channels, c)
+	}
+
+	return channels, nil
+}
+
+// signAndSendNextUpdate computes and signs a valid update for the passed
+// outpoint, with the ability to toggle the disabled bit. The new update will
+// use the current time as the update's timestamp, or increment the old
+// timestamp by 1 to ensure the update can propagate. If signing is successful,
+// the new update will be sent out on the network.
+func (m *ChanStatusManager) signAndSendNextUpdate(outpoint wire.OutPoint,
+	disabled bool) error {
+
+	// Retrieve the latest update for this channel. We'll use this
+	// as our starting point to send the new update.
+	chanUpdate, err := m.fetchLastChanUpdateByOutPoint(outpoint)
+	if err != nil {
+		return err
+	}
+
+	err = SignChannelUpdate(
+		m.cfg.MessageSigner, m.cfg.OurPubKey, chanUpdate,
+		ChannelUpdateSetDisable(disabled),
+	)
+	if err != nil {
+		return err
+	}
+
+	return m.cfg.ApplyChannelUpdate(chanUpdate)
+}
+
+// fetchLastChanUpdateByOutPoint fetches the latest policy for our direction of
+// a channel, and crafts a new ChannelUpdate with this policy. Returns an error
+// in case our ChannelEdgePolicy is not found in the database.
+func (m *ChanStatusManager) fetchLastChanUpdateByOutPoint(op wire.OutPoint) (
+	*lnwire.ChannelUpdate, error) {
+
+	// Get the edge info and policies for this channel from the graph.
+	info, edge1, edge2, err := m.cfg.Graph.FetchChannelEdgesByOutpoint(&op)
+	if err != nil {
+		return nil, err
+	}
+
+	return ExtractChannelUpdate(m.ourPubKeyBytes, info, edge1, edge2)
+}
+
+// loadInitialChanState determines the initial ChannelState for a particular
+// outpoint. The initial ChanStatus for a given outpoint will either be
+// ChanStatusEnabled or ChanStatusDisabled, determined by inspecting the bits on
+// the most recent announcement. An error is returned if the latest update could
+// not be retrieved.
+func (m *ChanStatusManager) loadInitialChanState(
+	outpoint *wire.OutPoint) (ChannelState, error) {
+
+	lastUpdate, err := m.fetchLastChanUpdateByOutPoint(*outpoint)
+	if err != nil {
+		return ChannelState{}, err
+	}
+
+	// Determine the channel's starting status by inspecting the disable bit
+	// on last announcement we sent out.
+	var initialStatus ChanStatus
+	if lastUpdate.ChannelFlags&lnwire.ChanUpdateDisabled == 0 {
+		initialStatus = ChanStatusEnabled
+	} else {
+		initialStatus = ChanStatusDisabled
+	}
+
+	return ChannelState{
+		Status: initialStatus,
+	}, nil
+}
+
+// getOrInitChanStatus retrieves the current ChannelState for a particular
+// outpoint. If the chanStates map already contains an entry for the outpoint,
+// the value in the map is returned. Otherwise, the outpoint's initial status is
+// computed and updated in the chanStates map before being returned.
+func (m *ChanStatusManager) getOrInitChanStatus(
+	outpoint wire.OutPoint) (ChannelState, error) {
+
+	// Return the current ChannelState from the chanStates map if it is
+	// already known to the ChanStatusManager.
+	if curState, ok := m.chanStates[outpoint]; ok {
+		return curState, nil
+	}
+
+	// Otherwise, determine the initial state based on the last update we
+	// sent for the outpoint.
+	initialState, err := m.loadInitialChanState(&outpoint)
+	if err != nil {
+		return ChannelState{}, err
+	}
+
+	// Finally, store the initial state in the chanStates map. This will
+	// serve as are up-to-date view of the outpoint's current status, in
+	// addition to making the channel eligible for detecting inactivity.
+	m.chanStates[outpoint] = initialState
+
+	return initialState, nil
+}

--- a/netann/chan_status_manager_test.go
+++ b/netann/chan_status_manager_test.go
@@ -1,0 +1,816 @@
+package netann_test
+
+import (
+	"bytes"
+	"crypto/rand"
+	"encoding/binary"
+	"fmt"
+	"io"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/btcsuite/btcd/btcec"
+	"github.com/btcsuite/btcd/wire"
+	"github.com/lightningnetwork/lnd/channeldb"
+	"github.com/lightningnetwork/lnd/lnwire"
+	"github.com/lightningnetwork/lnd/netann"
+)
+
+// randOutpoint creates a random wire.Outpoint.
+func randOutpoint(t *testing.T) wire.OutPoint {
+	t.Helper()
+
+	var buf [36]byte
+	_, err := io.ReadFull(rand.Reader, buf[:])
+	if err != nil {
+		t.Fatalf("unable to generate random outpoint: %v", err)
+	}
+
+	op := wire.OutPoint{}
+	copy(op.Hash[:], buf[:32])
+	op.Index = binary.BigEndian.Uint32(buf[32:])
+
+	return op
+}
+
+var shortChanIDs uint64
+
+// createChannel generates a channeldb.OpenChannel with a random chanpoint and
+// short channel id.
+func createChannel(t *testing.T) *channeldb.OpenChannel {
+	t.Helper()
+
+	sid := atomic.AddUint64(&shortChanIDs, 1)
+
+	return &channeldb.OpenChannel{
+		ShortChannelID:  lnwire.NewShortChanIDFromInt(sid),
+		ChannelFlags:    lnwire.FFAnnounceChannel,
+		FundingOutpoint: randOutpoint(t),
+	}
+}
+
+// createEdgePolicies generates an edge info and two directional edge policies.
+// The remote party's public key is generated randomly, and then sorted against
+// our `pubkey` with the direction bit set appropriately in the policies. Our
+// update will be created with the disabled bit set if startEnabled is false.
+func createEdgePolicies(t *testing.T, channel *channeldb.OpenChannel,
+	pubkey *btcec.PublicKey, startEnabled bool) (*channeldb.ChannelEdgeInfo,
+	*channeldb.ChannelEdgePolicy, *channeldb.ChannelEdgePolicy) {
+
+	var (
+		pubkey1 [33]byte
+		pubkey2 [33]byte
+		dir1    lnwire.ChanUpdateChanFlags
+		dir2    lnwire.ChanUpdateChanFlags
+	)
+
+	// Set pubkey1 to OUR pubkey.
+	copy(pubkey1[:], pubkey.SerializeCompressed())
+
+	// Set the disabled bit appropriately on our update.
+	if !startEnabled {
+		dir1 |= lnwire.ChanUpdateDisabled
+	}
+
+	// Generate and set pubkey2 for THEIR pubkey.
+	privKey2, err := btcec.NewPrivateKey(btcec.S256())
+	if err != nil {
+		t.Fatalf("unable to generate key pair: %v", err)
+	}
+	copy(pubkey2[:], privKey2.PubKey().SerializeCompressed())
+
+	// Set pubkey1 to the lower of the two pubkeys.
+	if bytes.Compare(pubkey2[:], pubkey1[:]) < 0 {
+		pubkey1, pubkey2 = pubkey2, pubkey1
+		dir1, dir2 = dir2, dir1
+	}
+
+	// Now that the ordering has been established, set pubkey2's direction
+	// bit.
+	dir2 |= lnwire.ChanUpdateDirection
+
+	return &channeldb.ChannelEdgeInfo{
+			ChannelPoint:  channel.FundingOutpoint,
+			NodeKey1Bytes: pubkey1,
+			NodeKey2Bytes: pubkey2,
+		},
+		&channeldb.ChannelEdgePolicy{
+			ChannelID:    channel.ShortChanID().ToUint64(),
+			ChannelFlags: dir1,
+			LastUpdate:   time.Now(),
+			SigBytes:     make([]byte, 64),
+		},
+		&channeldb.ChannelEdgePolicy{
+			ChannelID:    channel.ShortChanID().ToUint64(),
+			ChannelFlags: dir2,
+			LastUpdate:   time.Now(),
+			SigBytes:     make([]byte, 64),
+		}
+}
+
+type mockGraph struct {
+	pubKey    *btcec.PublicKey
+	mu        sync.Mutex
+	channels  []*channeldb.OpenChannel
+	chanInfos map[wire.OutPoint]*channeldb.ChannelEdgeInfo
+	chanPols1 map[wire.OutPoint]*channeldb.ChannelEdgePolicy
+	chanPols2 map[wire.OutPoint]*channeldb.ChannelEdgePolicy
+	sidToCid  map[lnwire.ShortChannelID]wire.OutPoint
+
+	updates chan *lnwire.ChannelUpdate
+}
+
+func newMockGraph(t *testing.T, numChannels int,
+	startActive, startEnabled bool, pubKey *btcec.PublicKey) *mockGraph {
+
+	g := &mockGraph{
+		channels:  make([]*channeldb.OpenChannel, 0, numChannels),
+		chanInfos: make(map[wire.OutPoint]*channeldb.ChannelEdgeInfo),
+		chanPols1: make(map[wire.OutPoint]*channeldb.ChannelEdgePolicy),
+		chanPols2: make(map[wire.OutPoint]*channeldb.ChannelEdgePolicy),
+		sidToCid:  make(map[lnwire.ShortChannelID]wire.OutPoint),
+		updates:   make(chan *lnwire.ChannelUpdate, 2*numChannels),
+	}
+
+	for i := 0; i < numChannels; i++ {
+		c := createChannel(t)
+
+		info, pol1, pol2 := createEdgePolicies(
+			t, c, pubKey, startEnabled,
+		)
+
+		g.addChannel(c)
+		g.addEdgePolicy(c, info, pol1, pol2)
+	}
+
+	return g
+}
+
+func (g *mockGraph) FetchAllOpenChannels() ([]*channeldb.OpenChannel, error) {
+	return g.chans(), nil
+}
+
+func (g *mockGraph) FetchChannelEdgesByOutpoint(
+	op *wire.OutPoint) (*channeldb.ChannelEdgeInfo,
+	*channeldb.ChannelEdgePolicy, *channeldb.ChannelEdgePolicy, error) {
+
+	g.mu.Lock()
+	defer g.mu.Unlock()
+
+	info, ok := g.chanInfos[*op]
+	if !ok {
+		return nil, nil, nil, channeldb.ErrEdgeNotFound
+	}
+
+	pol1 := g.chanPols1[*op]
+	pol2 := g.chanPols2[*op]
+
+	return info, pol1, pol2, nil
+}
+
+func (g *mockGraph) ApplyChannelUpdate(update *lnwire.ChannelUpdate) error {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+
+	outpoint, ok := g.sidToCid[update.ShortChannelID]
+	if !ok {
+		return fmt.Errorf("unknown short channel id: %v",
+			update.ShortChannelID)
+	}
+
+	pol1 := g.chanPols1[outpoint]
+	pol2 := g.chanPols2[outpoint]
+
+	// Determine which policy we should update by making the flags on the
+	// policies and updates, and seeing which match up.
+	var update1 bool
+	switch {
+	case update.ChannelFlags&lnwire.ChanUpdateDirection ==
+		pol1.ChannelFlags&lnwire.ChanUpdateDirection:
+		update1 = true
+
+	case update.ChannelFlags&lnwire.ChanUpdateDirection ==
+		pol2.ChannelFlags&lnwire.ChanUpdateDirection:
+		update1 = false
+
+	default:
+		return fmt.Errorf("unable to find policy to update")
+	}
+
+	timestamp := time.Unix(int64(update.Timestamp), 0)
+
+	policy := &channeldb.ChannelEdgePolicy{
+		ChannelID:    update.ShortChannelID.ToUint64(),
+		ChannelFlags: update.ChannelFlags,
+		LastUpdate:   timestamp,
+		SigBytes:     make([]byte, 64),
+	}
+
+	if update1 {
+		g.chanPols1[outpoint] = policy
+	} else {
+		g.chanPols2[outpoint] = policy
+	}
+
+	// Send the update to network. This channel should be sufficiently
+	// buffered to avoid deadlocking.
+	g.updates <- update
+
+	return nil
+}
+
+func (g *mockGraph) chans() []*channeldb.OpenChannel {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+
+	channels := make([]*channeldb.OpenChannel, 0, len(g.channels))
+	for _, channel := range g.channels {
+		channels = append(channels, channel)
+	}
+
+	return channels
+}
+
+func (g *mockGraph) addChannel(channel *channeldb.OpenChannel) {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+
+	g.channels = append(g.channels, channel)
+}
+
+func (g *mockGraph) addEdgePolicy(c *channeldb.OpenChannel,
+	info *channeldb.ChannelEdgeInfo,
+	pol1, pol2 *channeldb.ChannelEdgePolicy) {
+
+	g.mu.Lock()
+	defer g.mu.Unlock()
+
+	g.chanInfos[c.FundingOutpoint] = info
+	g.chanPols1[c.FundingOutpoint] = pol1
+	g.chanPols2[c.FundingOutpoint] = pol2
+	g.sidToCid[c.ShortChanID()] = c.FundingOutpoint
+}
+
+func (g *mockGraph) removeChannel(channel *channeldb.OpenChannel) {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+
+	for i, c := range g.channels {
+		if c.FundingOutpoint != channel.FundingOutpoint {
+			continue
+		}
+
+		g.channels = append(g.channels[:i], g.channels[i+1:]...)
+		delete(g.chanInfos, c.FundingOutpoint)
+		delete(g.chanPols1, c.FundingOutpoint)
+		delete(g.chanPols2, c.FundingOutpoint)
+		delete(g.sidToCid, c.ShortChanID())
+		return
+	}
+}
+
+type mockSwitch struct {
+	mu       sync.Mutex
+	isActive map[lnwire.ChannelID]bool
+}
+
+func newMockSwitch() *mockSwitch {
+	return &mockSwitch{
+		isActive: make(map[lnwire.ChannelID]bool),
+	}
+}
+
+func (s *mockSwitch) HasActiveLink(chanID lnwire.ChannelID) bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	// If the link is found, we will returns it's active status. In the
+	// real switch, it returns EligibleToForward().
+	active, ok := s.isActive[chanID]
+	if ok {
+		return active
+	}
+
+	return false
+}
+
+func (s *mockSwitch) SetStatus(chanID lnwire.ChannelID, active bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.isActive[chanID] = active
+}
+
+func newManagerCfg(t *testing.T, numChannels int,
+	startEnabled bool) (*netann.ChanStatusConfig, *mockGraph, *mockSwitch) {
+
+	t.Helper()
+
+	privKey, err := btcec.NewPrivateKey(btcec.S256())
+	if err != nil {
+		t.Fatalf("unable to generate key pair: %v", err)
+	}
+
+	graph := newMockGraph(
+		t, numChannels, startEnabled, startEnabled, privKey.PubKey(),
+	)
+	htlcSwitch := newMockSwitch()
+
+	cfg := &netann.ChanStatusConfig{
+		ChanStatusSampleInterval: 50 * time.Millisecond,
+		ChanEnableTimeout:        500 * time.Millisecond,
+		ChanDisableTimeout:       time.Second,
+		OurPubKey:                privKey.PubKey(),
+		MessageSigner:            netann.NewNodeSigner(privKey),
+		IsChannelActive:          htlcSwitch.HasActiveLink,
+		ApplyChannelUpdate:       graph.ApplyChannelUpdate,
+		DB:                       graph,
+		Graph:                    graph,
+	}
+
+	return cfg, graph, htlcSwitch
+}
+
+type testHarness struct {
+	t                  *testing.T
+	numChannels        int
+	graph              *mockGraph
+	htlcSwitch         *mockSwitch
+	mgr                *netann.ChanStatusManager
+	ourPubKey          *btcec.PublicKey
+	safeDisableTimeout time.Duration
+}
+
+// newHarness returns a new testHarness for testing a ChanStatusManager. The
+// mockGraph will be populated with numChannels channels. The startActive and
+// startEnabled govern the initial state of the channels wrt the htlcswitch and
+// the network, respectively.
+func newHarness(t *testing.T, numChannels int,
+	startActive, startEnabled bool) testHarness {
+
+	cfg, graph, htlcSwitch := newManagerCfg(t, numChannels, startEnabled)
+
+	mgr, err := netann.NewChanStatusManager(cfg)
+	if err != nil {
+		t.Fatalf("unable to create chan status manager: %v", err)
+	}
+
+	err = mgr.Start()
+	if err != nil {
+		t.Fatalf("unable to start chan status manager: %v", err)
+	}
+
+	h := testHarness{
+		t:                  t,
+		numChannels:        numChannels,
+		graph:              graph,
+		htlcSwitch:         htlcSwitch,
+		mgr:                mgr,
+		ourPubKey:          cfg.OurPubKey,
+		safeDisableTimeout: (3 * cfg.ChanDisableTimeout) / 2, // 1.5x
+	}
+
+	// Initialize link status as requested.
+	if startActive {
+		h.markActive(h.graph.channels)
+	} else {
+		h.markInactive(h.graph.channels)
+	}
+
+	return h
+}
+
+// markActive updates the active status of the passed channels within the mock
+// switch to active.
+func (h *testHarness) markActive(channels []*channeldb.OpenChannel) {
+	h.t.Helper()
+
+	for _, channel := range channels {
+		chanID := lnwire.NewChanIDFromOutPoint(&channel.FundingOutpoint)
+		h.htlcSwitch.SetStatus(chanID, true)
+	}
+}
+
+// markInactive updates the active status of the passed channels within the mock
+// switch to inactive.
+func (h *testHarness) markInactive(channels []*channeldb.OpenChannel) {
+	h.t.Helper()
+
+	for _, channel := range channels {
+		chanID := lnwire.NewChanIDFromOutPoint(&channel.FundingOutpoint)
+		h.htlcSwitch.SetStatus(chanID, false)
+	}
+}
+
+// assertEnables requests enables for all of the passed channels, and asserts
+// that the errors returned from RequestEnable matches expErr.
+func (h *testHarness) assertEnables(channels []*channeldb.OpenChannel, expErr error) {
+	h.t.Helper()
+
+	for _, channel := range channels {
+		h.assertEnable(channel.FundingOutpoint, expErr)
+	}
+}
+
+// assertDisables requests disables for all of the passed channels, and asserts
+// that the errors returned from RequestDisable matches expErr.
+func (h *testHarness) assertDisables(channels []*channeldb.OpenChannel, expErr error) {
+	h.t.Helper()
+
+	for _, channel := range channels {
+		h.assertDisable(channel.FundingOutpoint, expErr)
+	}
+}
+
+// assertEnable requests an enable for the given outpoint, and asserts that the
+// returned error matches expErr.
+func (h *testHarness) assertEnable(outpoint wire.OutPoint, expErr error) {
+	h.t.Helper()
+
+	err := h.mgr.RequestEnable(outpoint)
+	if err != expErr {
+		h.t.Fatalf("expected enable error: %v, got %v", expErr, err)
+	}
+}
+
+// assertDisable requests a disable for the given outpoint, and asserts that the
+// returned error matches expErr.
+func (h *testHarness) assertDisable(outpoint wire.OutPoint, expErr error) {
+	h.t.Helper()
+
+	err := h.mgr.RequestDisable(outpoint)
+	if err != expErr {
+		h.t.Fatalf("expected disable error: %v, got %v", expErr, err)
+	}
+}
+
+// assertNoUpdates waits for the specified duration, and asserts that no updates
+// are announced on the network.
+func (h *testHarness) assertNoUpdates(duration time.Duration) {
+	h.t.Helper()
+
+	h.assertUpdates(nil, false, duration)
+}
+
+// assertUpdates waits for the specified duration, asserting that an update
+// are receive on the network for each of the passed OpenChannels, and that all
+// of their disable bits are set to match expEnabled. The expEnabled parameter
+// is ignored if channels is nil.
+func (h *testHarness) assertUpdates(channels []*channeldb.OpenChannel,
+	expEnabled bool, duration time.Duration) {
+
+	h.t.Helper()
+
+	// Compute an index of the expected short channel ids for which we want
+	// to received updates.
+	expSids := sidsFromChans(channels)
+
+	timeout := time.After(duration)
+	recvdSids := make(map[lnwire.ShortChannelID]struct{})
+	for {
+		select {
+		case upd := <-h.graph.updates:
+			// Assert that the received short channel id is one that
+			// we expect. If no updates were expected, this will
+			// always fail on the first update received.
+			if _, ok := expSids[upd.ShortChannelID]; !ok {
+				h.t.Fatalf("received update for unexpected "+
+					"short chan id: %v", upd.ShortChannelID)
+			}
+
+			// Assert that the disabled bit is set properly.
+			enabled := upd.ChannelFlags&lnwire.ChanUpdateDisabled !=
+				lnwire.ChanUpdateDisabled
+			if expEnabled != enabled {
+				h.t.Fatalf("expected enabled: %v, actual: %v",
+					expEnabled, enabled)
+			}
+
+			recvdSids[upd.ShortChannelID] = struct{}{}
+
+		case <-timeout:
+			// Time is up, assert that the correct number of unique
+			// updates was received.
+			if len(recvdSids) == len(channels) {
+				return
+			}
+
+			h.t.Fatalf("expected %d updates, got %d",
+				len(channels), len(recvdSids))
+		}
+	}
+}
+
+// sidsFromChans returns an index contain the short channel ids of each channel
+// provided in the list of OpenChannels.
+func sidsFromChans(
+	channels []*channeldb.OpenChannel) map[lnwire.ShortChannelID]struct{} {
+
+	sids := make(map[lnwire.ShortChannelID]struct{})
+	for _, channel := range channels {
+		sids[channel.ShortChanID()] = struct{}{}
+	}
+	return sids
+}
+
+type stateMachineTest struct {
+	name         string
+	startEnabled bool
+	startActive  bool
+	fn           func(testHarness)
+}
+
+var stateMachineTests = []stateMachineTest{
+	{
+		name:         "active and enabled is stable",
+		startActive:  true,
+		startEnabled: true,
+		fn: func(h testHarness) {
+			// No updates should be sent because being active and
+			// enabled should be a stable state.
+			h.assertNoUpdates(h.safeDisableTimeout)
+		},
+	},
+	{
+		name:         "inactive and disabled is stable",
+		startActive:  false,
+		startEnabled: false,
+		fn: func(h testHarness) {
+			// No updates should be sent because being inactive and
+			// disabled should be a stable state.
+			h.assertNoUpdates(h.safeDisableTimeout)
+		},
+	},
+	{
+		name:         "start disabled request enable",
+		startActive:  true, // can't request enable unless active
+		startEnabled: false,
+		fn: func(h testHarness) {
+			// Request enables for all channels.
+			h.assertEnables(h.graph.chans(), nil)
+			// Expect to see them all enabled on the network.
+			h.assertUpdates(
+				h.graph.chans(), true, h.safeDisableTimeout,
+			)
+		},
+	},
+	{
+		name:         "start enabled request disable",
+		startActive:  true,
+		startEnabled: true,
+		fn: func(h testHarness) {
+			// Request disables for all channels.
+			h.assertDisables(h.graph.chans(), nil)
+			// Expect to see them all disabled on the network.
+			h.assertUpdates(
+				h.graph.chans(), false, h.safeDisableTimeout,
+			)
+		},
+	},
+	{
+		name:         "request enable already enabled",
+		startActive:  true,
+		startEnabled: true,
+		fn: func(h testHarness) {
+			// Request enables for already enabled channels.
+			h.assertEnables(h.graph.chans(), nil)
+			// Manager shouldn't send out any updates.
+			h.assertNoUpdates(h.safeDisableTimeout)
+		},
+	},
+	{
+		name:         "request disabled already disabled",
+		startActive:  false,
+		startEnabled: false,
+		fn: func(h testHarness) {
+			// Request disables for already enabled channels.
+			h.assertDisables(h.graph.chans(), nil)
+			// Manager shouldn't sent out any updates.
+			h.assertNoUpdates(h.safeDisableTimeout)
+		},
+	},
+	{
+		name:         "detect and disable inactive",
+		startActive:  true,
+		startEnabled: true,
+		fn: func(h testHarness) {
+			// Simulate disconnection and have links go inactive.
+			h.markInactive(h.graph.chans())
+			// Should see all channels passively disabled.
+			h.assertUpdates(
+				h.graph.chans(), false, h.safeDisableTimeout,
+			)
+		},
+	},
+	{
+		name:         "quick flap stays active",
+		startActive:  true,
+		startEnabled: true,
+		fn: func(h testHarness) {
+			// Simulate disconnection and have links go inactive.
+			h.markInactive(h.graph.chans())
+			// Allow 2 sample intervals to pass, but not long
+			// enough for a disable to occur.
+			time.Sleep(100 * time.Millisecond)
+			// Simulate reconnect by making channels active.
+			h.markActive(h.graph.chans())
+			// Request that all channels be reenabled.
+			h.assertEnables(h.graph.chans(), nil)
+			// Pending disable should have been canceled, and
+			// no updates sent. Channels remain enabled on the
+			// network.
+			h.assertNoUpdates(h.safeDisableTimeout)
+		},
+	},
+	{
+		name:         "no passive enable from becoming active",
+		startActive:  false,
+		startEnabled: false,
+		fn: func(h testHarness) {
+			// Simulate reconnect by making channels active.
+			h.markActive(h.graph.chans())
+			// No updates should be sent without explicit enable.
+			h.assertNoUpdates(h.safeDisableTimeout)
+		},
+	},
+	{
+		name:         "enable inactive channel fails",
+		startActive:  false,
+		startEnabled: false,
+		fn: func(h testHarness) {
+			// Request enable of inactive channels, expect error
+			// indicating that channel was not active.
+			h.assertEnables(
+				h.graph.chans(), netann.ErrEnableInactiveChan,
+			)
+			// No updates should be sent as a result of the failure.
+			h.assertNoUpdates(h.safeDisableTimeout)
+		},
+	},
+	{
+		name:         "enable unknown channel fails",
+		startActive:  false,
+		startEnabled: false,
+		fn: func(h testHarness) {
+			// Create channels unknown to the graph.
+			unknownChans := []*channeldb.OpenChannel{
+				createChannel(h.t),
+				createChannel(h.t),
+				createChannel(h.t),
+			}
+			// Request that they be enabled, which should return an
+			// error as the graph doesn't have an edge for them.
+			h.assertEnables(
+				unknownChans, channeldb.ErrEdgeNotFound,
+			)
+			// No updates should be sent as a result of the failure.
+			h.assertNoUpdates(h.safeDisableTimeout)
+		},
+	},
+	{
+		name:         "disable unknown channel fails",
+		startActive:  false,
+		startEnabled: false,
+		fn: func(h testHarness) {
+			// Create channels unknown to the graph.
+			unknownChans := []*channeldb.OpenChannel{
+				createChannel(h.t),
+				createChannel(h.t),
+				createChannel(h.t),
+			}
+			// Request that they be disabled, which should return an
+			// error as the graph doesn't have an edge for them.
+			h.assertDisables(
+				unknownChans, channeldb.ErrEdgeNotFound,
+			)
+			// No updates should be sent as a result of the failure.
+			h.assertNoUpdates(h.safeDisableTimeout)
+		},
+	},
+	{
+		name:         "add new channels",
+		startActive:  false,
+		startEnabled: false,
+		fn: func(h testHarness) {
+			// Allow the manager to enter a steady state for the
+			// initial channel set.
+			h.assertNoUpdates(h.safeDisableTimeout)
+
+			// Add a new channels to the graph, but don't yet add
+			// the edge policies. We should see no updates sent
+			// since the manager can't access the policies.
+			newChans := []*channeldb.OpenChannel{
+				createChannel(h.t),
+				createChannel(h.t),
+				createChannel(h.t),
+			}
+			for _, c := range newChans {
+				h.graph.addChannel(c)
+			}
+			h.assertNoUpdates(h.safeDisableTimeout)
+
+			// Check that trying to enable the channel with unknown
+			// edges results in a failure.
+			h.assertEnables(newChans, channeldb.ErrEdgeNotFound)
+
+			// Now, insert edge policies for the channel into the
+			// graph, starting with the channel enabled, and mark
+			// the link active.
+			for _, c := range newChans {
+				info, pol1, pol2 := createEdgePolicies(
+					h.t, c, h.ourPubKey, true,
+				)
+				h.graph.addEdgePolicy(c, info, pol1, pol2)
+			}
+			h.markActive(newChans)
+
+			// We expect no updates to be sent since the channel is
+			// enabled and active.
+			h.assertNoUpdates(h.safeDisableTimeout)
+
+			// Finally, assert that enabling the channel doesn't
+			// return an error now that everything is in place.
+			h.assertEnables(newChans, nil)
+		},
+	},
+	{
+		name:         "remove channels then disable",
+		startActive:  true,
+		startEnabled: true,
+		fn: func(h testHarness) {
+			// Allow the manager to enter a steady state for the
+			// initial channel set.
+			h.assertNoUpdates(h.safeDisableTimeout)
+
+			// Select half of the current channels to remove.
+			channels := h.graph.chans()
+			rmChans := channels[:len(channels)/2]
+
+			// Mark the channel inactive and remove them from the
+			// graph. This should trigger the manager to attempt a
+			// mark the channel disabled, but will unable to do so
+			// because it can't find the edge policies.
+			h.markInactive(rmChans)
+			for _, c := range rmChans {
+				h.graph.removeChannel(c)
+			}
+			h.assertNoUpdates(h.safeDisableTimeout)
+
+			// Check that trying to enable the channel with unknown
+			// edges results in a failure.
+			h.assertDisables(rmChans, channeldb.ErrEdgeNotFound)
+		},
+	},
+	{
+		name:         "disable channels then remove",
+		startActive:  true,
+		startEnabled: true,
+		fn: func(h testHarness) {
+			// Allow the manager to enter a steady state for the
+			// initial channel set.
+			h.assertNoUpdates(h.safeDisableTimeout)
+
+			// Select half of the current channels to remove.
+			channels := h.graph.chans()
+			rmChans := channels[:len(channels)/2]
+
+			// Check that trying to enable the channel with unknown
+			// edges results in a failure.
+			h.assertDisables(rmChans, nil)
+
+			// Since the channels are still in the graph, we expect
+			// these channels to be disabled on the network.
+			h.assertUpdates(rmChans, false, h.safeDisableTimeout)
+
+			// Finally, remove  the channels from the graph and
+			// assert no more updates are sent.
+			for _, c := range rmChans {
+				h.graph.removeChannel(c)
+			}
+			h.assertNoUpdates(h.safeDisableTimeout)
+		},
+	},
+}
+
+// TestChanStatusManagerStateMachine tests the possible state transitions that
+// can be taken by the ChanStatusManager.
+func TestChanStatusManagerStateMachine(t *testing.T) {
+	t.Parallel()
+
+	for _, test := range stateMachineTests {
+		tc := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			const numChannels = 10
+			h := newHarness(
+				t, numChannels, tc.startActive, tc.startEnabled,
+			)
+			defer h.mgr.Stop()
+
+			tc.fn(h)
+		})
+	}
+}

--- a/netann/channel_state.go
+++ b/netann/channel_state.go
@@ -1,0 +1,75 @@
+package netann
+
+import (
+	"time"
+
+	"github.com/btcsuite/btcd/wire"
+)
+
+// ChanStatus is a type that enumerates the possible states a ChanStatusManager
+// tracks for its known channels.
+type ChanStatus uint8
+
+const (
+	// ChanStatusEnabled indicates that the channel's last announcement has
+	// the disabled bit cleared.
+	ChanStatusEnabled ChanStatus = iota
+
+	// ChanStatusPendingDisabled indicates that the channel's last
+	// announcement has the disabled bit cleared, but that the channel was
+	// detected in an inactive state. Channels in this state will have a
+	// disabling announcement sent after the ChanInactiveTimeout expires
+	// from the time of the first detection--unless the channel is
+	// explicitly reenabled before the disabling occurs.
+	ChanStatusPendingDisabled
+
+	// ChanStatusDisabled indicates that the channel's last announcement has
+	// the disabled bit set.
+	ChanStatusDisabled
+)
+
+// ChannelState describes the ChanStatusManager's view of a channel, and
+// describes the current state the channel's disabled status on the network.
+type ChannelState struct {
+	// Status is the channel's current ChanStatus from the POV of the
+	// ChanStatusManager.
+	Status ChanStatus
+
+	// SendDisableTime is the earliest time at which the ChanStatusManager
+	// will passively send a new disable announcement on behalf of this
+	// channel.
+	//
+	// NOTE: This field is only non-zero if status is
+	// ChanStatusPendingDisabled.
+	SendDisableTime time.Time
+}
+
+// channelStates is a map of channel outpoints to their channelState. All
+// changes made after setting an entry initially should be made using receiver
+// methods below.
+type channelStates map[wire.OutPoint]ChannelState
+
+// markEnabled creates a channelState using ChanStatusEnabled.
+func (s *channelStates) markEnabled(outpoint wire.OutPoint) {
+	(*s)[outpoint] = ChannelState{
+		Status: ChanStatusEnabled,
+	}
+}
+
+// markDisabled creates a channelState using ChanStatusDisabled.
+func (s *channelStates) markDisabled(outpoint wire.OutPoint) {
+	(*s)[outpoint] = ChannelState{
+		Status: ChanStatusDisabled,
+	}
+}
+
+// markPendingDisabled creates a channelState using ChanStatusPendingDisabled
+// and sets the ChannelState's SendDisableTime to sendDisableTime.
+func (s *channelStates) markPendingDisabled(outpoint wire.OutPoint,
+	sendDisableTime time.Time) {
+
+	(*s)[outpoint] = ChannelState{
+		Status:          ChanStatusPendingDisabled,
+		SendDisableTime: sendDisableTime,
+	}
+}

--- a/netann/channel_update.go
+++ b/netann/channel_update.go
@@ -1,0 +1,141 @@
+package netann
+
+import (
+	"bytes"
+	"fmt"
+	"time"
+
+	"github.com/btcsuite/btcd/btcec"
+	"github.com/lightningnetwork/lnd/channeldb"
+	"github.com/lightningnetwork/lnd/lnwallet"
+	"github.com/lightningnetwork/lnd/lnwire"
+)
+
+// ChannelUpdateModifier is a closure that makes in-place modifications to an
+// lnwire.ChannelUpdate.
+type ChannelUpdateModifier func(*lnwire.ChannelUpdate)
+
+// ChannelUpdateSetDisable sets the disabled channel flag if disabled is true,
+// and clears the bit otherwise.
+func ChannelUpdateSetDisable(disabled bool) ChannelUpdateModifier {
+	return func(update *lnwire.ChannelUpdate) {
+		if disabled {
+			// Set the bit responsible for marking a channel as
+			// disabled.
+			update.ChannelFlags |= lnwire.ChanUpdateDisabled
+		} else {
+			// Clear the bit responsible for marking a channel as
+			// disabled.
+			update.ChannelFlags &= ^lnwire.ChanUpdateDisabled
+		}
+	}
+}
+
+// SignChannelUpdate applies the given modifiers to the passed
+// lnwire.ChannelUpdate, then signs the resulting update. The provided update
+// should be the most recent, valid update, otherwise the timestamp may not
+// monotonically increase from the prior.
+//
+// NOTE: This method modifies the given update.
+func SignChannelUpdate(signer lnwallet.MessageSigner, pubKey *btcec.PublicKey,
+	update *lnwire.ChannelUpdate, mods ...ChannelUpdateModifier) error {
+
+	// Apply the requested changes to the channel update.
+	for _, modifier := range mods {
+		modifier(update)
+	}
+
+	// Update the message's timestamp to the current time. If the update's
+	// current time is already in the future, we increment the prior value
+	// to ensure the timestamps monotonically increase, otherwise the
+	// update won't propagate.
+	newTimestamp := uint32(time.Now().Unix())
+	if newTimestamp <= update.Timestamp {
+		newTimestamp = update.Timestamp + 1
+	}
+	update.Timestamp = newTimestamp
+
+	chanUpdateMsg, err := update.DataToSign()
+	if err != nil {
+		return err
+	}
+
+	// Create the DER-encoded ECDSA signature over the message digest.
+	sig, err := signer.SignMessage(pubKey, chanUpdateMsg)
+	if err != nil {
+		return err
+	}
+
+	// Parse the DER-encoded signature into a fixed-size 64-byte array.
+	update.Signature, err = lnwire.NewSigFromSignature(sig)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// ExtractChannelUpdate attempts to retrieve a lnwire.ChannelUpdate message from
+// an edge's info and a set of routing policies.
+//
+// NOTE: The passed policies can be nil.
+func ExtractChannelUpdate(ownerPubKey []byte,
+	info *channeldb.ChannelEdgeInfo,
+	policies ...*channeldb.ChannelEdgePolicy) (
+	*lnwire.ChannelUpdate, error) {
+
+	// Helper function to extract the owner of the given policy.
+	owner := func(edge *channeldb.ChannelEdgePolicy) []byte {
+		var pubKey *btcec.PublicKey
+		if edge.ChannelFlags&lnwire.ChanUpdateDirection == 0 {
+			pubKey, _ = info.NodeKey1()
+		} else {
+			pubKey, _ = info.NodeKey2()
+		}
+
+		// If pubKey was not found, just return nil.
+		if pubKey == nil {
+			return nil
+		}
+
+		return pubKey.SerializeCompressed()
+	}
+
+	// Extract the channel update from the policy we own, if any.
+	for _, edge := range policies {
+		if edge != nil && bytes.Equal(ownerPubKey, owner(edge)) {
+			return ChannelUpdateFromEdge(info, edge)
+		}
+	}
+
+	return nil, fmt.Errorf("unable to extract ChannelUpdate for channel %v",
+		info.ChannelPoint)
+}
+
+// ChannelUpdateFromEdge reconstructs a signed ChannelUpdate from the given edge
+// info and policy.
+func ChannelUpdateFromEdge(info *channeldb.ChannelEdgeInfo,
+	policy *channeldb.ChannelEdgePolicy) (*lnwire.ChannelUpdate, error) {
+
+	update := &lnwire.ChannelUpdate{
+		ChainHash:       info.ChainHash,
+		ShortChannelID:  lnwire.NewShortChanIDFromInt(policy.ChannelID),
+		Timestamp:       uint32(policy.LastUpdate.Unix()),
+		ChannelFlags:    policy.ChannelFlags,
+		MessageFlags:    policy.MessageFlags,
+		TimeLockDelta:   policy.TimeLockDelta,
+		HtlcMinimumMsat: policy.MinHTLC,
+		HtlcMaximumMsat: policy.MaxHTLC,
+		BaseFee:         uint32(policy.FeeBaseMSat),
+		FeeRate:         uint32(policy.FeeProportionalMillionths),
+		ExtraOpaqueData: policy.ExtraOpaqueData,
+	}
+
+	var err error
+	update.Signature, err = lnwire.NewSigFromRawSignature(policy.SigBytes)
+	if err != nil {
+		return nil, err
+	}
+
+	return update, nil
+}

--- a/netann/channel_update_test.go
+++ b/netann/channel_update_test.go
@@ -1,0 +1,189 @@
+package netann_test
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/btcsuite/btcd/btcec"
+	"github.com/lightningnetwork/lnd/lnwallet"
+	"github.com/lightningnetwork/lnd/lnwire"
+	"github.com/lightningnetwork/lnd/netann"
+	"github.com/lightningnetwork/lnd/routing"
+)
+
+type mockSigner struct {
+	err error
+}
+
+func (m *mockSigner) SignMessage(pk *btcec.PublicKey,
+	msg []byte) (*btcec.Signature, error) {
+
+	if m.err != nil {
+		return nil, m.err
+	}
+
+	return nil, nil
+}
+
+var _ lnwallet.MessageSigner = (*mockSigner)(nil)
+
+var (
+	privKey, _ = btcec.NewPrivateKey(btcec.S256())
+
+	pubKey = privKey.PubKey()
+
+	errFailedToSign = errors.New("unable to sign message")
+)
+
+type updateDisableTest struct {
+	name         string
+	startEnabled bool
+	disable      bool
+	startTime    time.Time
+	signer       lnwallet.MessageSigner
+	expErr       error
+}
+
+var updateDisableTests = []updateDisableTest{
+	{
+		name:         "working signer enabled to disabled",
+		startEnabled: true,
+		disable:      true,
+		startTime:    time.Now(),
+		signer:       netann.NewNodeSigner(privKey),
+	},
+	{
+		name:         "working signer enabled to enabled",
+		startEnabled: true,
+		disable:      false,
+		startTime:    time.Now(),
+		signer:       netann.NewNodeSigner(privKey),
+	},
+	{
+		name:         "working signer disabled to enabled",
+		startEnabled: false,
+		disable:      false,
+		startTime:    time.Now(),
+		signer:       netann.NewNodeSigner(privKey),
+	},
+	{
+		name:         "working signer disabled to disabled",
+		startEnabled: false,
+		disable:      true,
+		startTime:    time.Now(),
+		signer:       netann.NewNodeSigner(privKey),
+	},
+	{
+		name:         "working signer future monotonicity",
+		startEnabled: true,
+		disable:      true,
+		startTime:    time.Now().Add(time.Hour), // must increment
+		signer:       netann.NewNodeSigner(privKey),
+	},
+	{
+		name:      "failing signer",
+		startTime: time.Now(),
+		signer:    &mockSigner{err: errFailedToSign},
+		expErr:    errFailedToSign,
+	},
+	{
+		name:      "invalid sig from signer",
+		startTime: time.Now(),
+		signer:    &mockSigner{}, // returns a nil signature
+		expErr:    errors.New("cannot decode empty signature"),
+	},
+}
+
+// TestUpdateDisableFlag checks the behavior of UpdateDisableFlag, asserting
+// that the proper channel flags are set, the timestamp always increases
+// monotonically, and that the correct errors are returned in the event that the
+// signer is unable to produce a signature.
+func TestUpdateDisableFlag(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range updateDisableTests {
+		t.Run(tc.name, func(t *testing.T) {
+			// Create the initial update, the only fields we are
+			// concerned with in this test are the timestamp and the
+			// channel flags.
+			ogUpdate := &lnwire.ChannelUpdate{
+				Timestamp: uint32(tc.startTime.Unix()),
+			}
+			if !tc.startEnabled {
+				ogUpdate.ChannelFlags |= lnwire.ChanUpdateDisabled
+			}
+
+			// Create new update to sign using the same fields as
+			// the original. UpdateDisableFlag will mutate the
+			// passed channel update, so we keep the old one to test
+			// against.
+			newUpdate := &lnwire.ChannelUpdate{
+				Timestamp:    ogUpdate.Timestamp,
+				ChannelFlags: ogUpdate.ChannelFlags,
+			}
+
+			// Attempt to update and sign the new update, specifying
+			// disabled or enabled as prescribed in the test case.
+			err := netann.SignChannelUpdate(
+				tc.signer, pubKey, newUpdate,
+				netann.ChannelUpdateSetDisable(tc.disable),
+			)
+
+			var fail bool
+			switch {
+
+			// Both nil, pass.
+			case tc.expErr == nil && err == nil:
+
+			// Both non-nil, compare error strings since some
+			// methods don't return concrete error types.
+			case tc.expErr != nil && err != nil:
+				if err.Error() != tc.expErr.Error() {
+					fail = true
+				}
+
+			// Otherwise, one is nil and one is non-nil.
+			default:
+				fail = true
+			}
+
+			if fail {
+				t.Fatalf("expected error: %v, got %v",
+					tc.expErr, err)
+			}
+
+			// Exit early if the test expected a failure.
+			if tc.expErr != nil {
+				return
+			}
+
+			// Verify that the timestamp has increased from the
+			// original update.
+			if newUpdate.Timestamp <= ogUpdate.Timestamp {
+				t.Fatalf("update timestamp should be "+
+					"monotonically increasing, "+
+					"original: %d, new %d",
+					ogUpdate.Timestamp, newUpdate.Timestamp)
+			}
+
+			// Verify that the disabled flag is properly set.
+			disabled := newUpdate.ChannelFlags&
+				lnwire.ChanUpdateDisabled != 0
+			if disabled != tc.disable {
+				t.Fatalf("expected disable:%v, found:%v",
+					tc.disable, disabled)
+			}
+
+			// Finally, validate the signature using the router's
+			// verification logic.
+			err = routing.ValidateChannelUpdateAnn(
+				pubKey, 0, newUpdate,
+			)
+			if err != nil {
+				t.Fatalf("channel update failed to "+
+					"validate: %v", err)
+			}
+		})
+	}
+}

--- a/netann/interface.go
+++ b/netann/interface.go
@@ -1,0 +1,23 @@
+package netann
+
+import (
+	"github.com/btcsuite/btcd/wire"
+	"github.com/lightningnetwork/lnd/channeldb"
+)
+
+// DB abstracts the required database functionality needed by the
+// ChanStatusManager.
+type DB interface {
+	// FetchAllOpenChannels returns a slice of all open channels known to
+	// the daemon. This may include private or pending channels.
+	FetchAllOpenChannels() ([]*channeldb.OpenChannel, error)
+}
+
+// ChannelGraph abstracts the required channel graph queries used by the
+// ChanStatusManager.
+type ChannelGraph interface {
+	// FetchChannelEdgesByOutpoint returns the channel edge info and most
+	// recent channel edge policies for a given outpoint.
+	FetchChannelEdgesByOutpoint(*wire.OutPoint) (*channeldb.ChannelEdgeInfo,
+		*channeldb.ChannelEdgePolicy, *channeldb.ChannelEdgePolicy, error)
+}

--- a/server.go
+++ b/server.go
@@ -3105,7 +3105,7 @@ func (s *server) watchChannelStatus() {
 	status := make(map[wire.OutPoint]activeStatus)
 
 	// We'll check in on the channel statuses every 1/4 of the timeout.
-	unchangedTimeout := cfg.InactiveChanTimeout
+	unchangedTimeout := cfg.ChanDisableTimeout
 	tickerTimeout := unchangedTimeout / 4
 
 	if unchangedTimeout == 0 || tickerTimeout == 0 {

--- a/test_utils.go
+++ b/test_utils.go
@@ -394,6 +394,7 @@ func createTestPeer(notifier chainntnfs.ChainNotifier,
 	chanID := lnwire.NewChanIDFromOutPoint(channelAlice.ChannelPoint())
 	alicePeer.activeChannels[chanID] = channelAlice
 
+	alicePeer.wg.Add(1)
 	go alicePeer.channelManager()
 
 	return alicePeer, channelAlice, channelBob, cleanUpFunc, nil


### PR DESCRIPTION
In this PR, we introduce a new subsystem called the `netann.ChanStatusManager` responsible for managing the announcement of channel updates which toggle a channel's disabled bit. Most of the logic has been moved into a new `netann` package, which offers greater unit testability of the subsystem's behavior.

The `netann.ChanStatusManager` exposes two methods:
```golang
func RequestEnable(outpoint wire.OutPoint) error {}
func RequestDisable(outpoint wire.OutPoint) error {}
```

Together, these allow other subsystems to request a toggle in a particular direction. The `netann.ChanStatusManager` then handles the task of dropping duplicate requests, and also ensuring that it's network behavior follows a well-defined state machine.

## State Machine Description

At any point, the `netann.ChanStatusManager` categorizes known channels into three distinct `ChanStatus` states:
```golang
type ChanStatus uint8

const (
    // ChanStatusActive indicates that the channel's last announcement has
    // the disabled bit cleared.
    ChanStatusActive ChanStatus = iota

    // ChanStatusPendingInactive indicates that the channel's last
    // announcement has the disabled bit cleared, but that the channel was
    // detected in an inactive state. Channels in this state will have a
    // disabling announcement sent after the ChanInactiveTimeout expires
    // from the time of the first detection--unless the channel is explicitly
    // reenabled before the disabling occurs.
    ChanStatusPendingInactive

    // ChanStatusInactive indicates that the channel's last announcement has
    // the disabled bit set.
    ChanStatusInactive
)
```

Channels will always start in either `ChanStatusActive` or `ChanStatusInactive` on startup or after we detect a new outpoint (perhaps for a newly created channel) by examining the last channel update we have on disk. 

One key distinction from the existing design is that the `netann.ChanStatusManager` only uses long polling to detect inactive channels, meaning that channels can ONLY be reenabled via an explict call to `RequestEnable` for an outpoint. This allows us to use a more accurate metric for enabling channels: connection duration.

Once a channel has been detected as inactive within the switch, presumably because of a disconnection, this kicks off a timed progression from `ChanStatusActive` -> `ChanStatusPendingInactive` -> `ChanStatusInactive`.

If `RequestEnable` is not received before the progression terminates, a new announcement setting the disable bit will be broadcast to the network.

Otherwise, any call to `RequestEnable` before the progression finishes will cancel the disable from being sent, and leaves the channel in the its still-enabled state on the network. This allows the `netann.ChanStatusManager` to tolerate short-lived reconnections, without causing the node to spam the network with channel updates.

Using the exposed configurations, users can tune this to a specific threshold, e.g. require ~95% uptime over a 20 minute interval, in order for the channel to remain enabled. 

Supersedes #2080 

Depends on:
 - [x] #2417 
 - [x] #2416 
 - [x] #2445 
 - [x] #2418 
 - [x] #2452 