### PR TITLE
rpcserver: add connectpeer log, fix existing formatting

### DIFF
--- a/rpcserver.go
+++ b/rpcserver.go
@@ -989,8 +989,11 @@ func (r *rpcServer) ConnectPeer(ctx context.Context,
 		ChainNet:    activeNetParams.Net,
 	}
 
+	rpcsLog.Debugf("[connectpeer] requested connection to %x@%s",
+		peerAddr.IdentityKey.SerializeCompressed(), peerAddr.Address)
+
 	if err := r.server.ConnectToPeer(peerAddr, in.Perm); err != nil {
-		rpcsLog.Errorf("(connectpeer): error connecting to peer: %v", err)
+		rpcsLog.Errorf("[connectpeer]: error connecting to peer: %v", err)
 		return nil, err
 	}
 


### PR DESCRIPTION
Noticed in testing that we don't print anything when receiving an RPC request to connect to peer. This PR adds this, and fixes the use of parentheses in another logging state to match the use of brackets elsewhere.