### PR TITLE
lnrpc: let's encrypt certificates

### DIFF
--- a/lnd.go
+++ b/lnd.go
@@ -11,6 +11,7 @@ import (
 	"io/ioutil"
 	"net"
 	"net/http"
+	_ "net/http/pprof" // Blank import to set up profiling HTTP handlers.
 	"os"
 	"path/filepath"
 	"runtime/pprof"
@@ -18,19 +19,14 @@ import (
 	"sync"
 	"time"
 
-	// Blank import to set up profiling HTTP handlers.
-	_ "net/http/pprof"
-
-	"gopkg.in/macaroon-bakery.v2/bakery"
-	"gopkg.in/macaroon.v2"
-
-	"google.golang.org/grpc"
-	"google.golang.org/grpc/credentials"
-
 	"github.com/btcsuite/btcutil"
 	"github.com/btcsuite/btcwallet/wallet"
 	proxy "github.com/grpc-ecosystem/grpc-gateway/runtime"
 	"github.com/lightninglabs/neutrino"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials"
+	"gopkg.in/macaroon-bakery.v2/bakery"
+	"gopkg.in/macaroon.v2"
 
 	"github.com/lightningnetwork/lnd/autopilot"
 	"github.com/lightningnetwork/lnd/build"

--- a/lnd.go
+++ b/lnd.go
@@ -23,6 +23,7 @@ import (
 	"github.com/btcsuite/btcwallet/wallet"
 	proxy "github.com/grpc-ecosystem/grpc-gateway/runtime"
 	"github.com/lightninglabs/neutrino"
+	"golang.org/x/crypto/acme/autocert"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
 	"gopkg.in/macaroon-bakery.v2/bakery"
@@ -264,12 +265,14 @@ func Main(cfg *Config, lisCfg ListenerCfg, shutdownChan <-chan struct{}) error {
 	defer cleanUp()
 
 	// Only process macaroons if --no-macaroons isn't set.
-	tlsCfg, restCreds, restProxyDest, err := getTLSConfig(cfg)
+	tlsCfg, restCreds, restProxyDest, cleanUp, err := getTLSConfig(cfg)
 	if err != nil {
 		err := fmt.Errorf("unable to load TLS credentials: %v", err)
 		ltndLog.Error(err)
 		return err
 	}
+
+	defer cleanUp()
 
 	serverCreds := credentials.NewTLS(tlsCfg)
 	serverOpts := []grpc.ServerOption{grpc.Creds(serverCreds)}
@@ -748,7 +751,7 @@ func Main(cfg *Config, lisCfg ListenerCfg, shutdownChan <-chan struct{}) error {
 // getTLSConfig returns a TLS configuration for the gRPC server and credentials
 // and a proxy destination for the REST reverse proxy.
 func getTLSConfig(cfg *Config) (*tls.Config, *credentials.TransportCredentials,
-	string, error) {
+	string, func(), error) {
 
 	// Ensure we create TLS key and certificate if they don't exist.
 	if !fileExists(cfg.TLSCertPath) && !fileExists(cfg.TLSKeyPath) {
@@ -759,7 +762,7 @@ func getTLSConfig(cfg *Config) (*tls.Config, *credentials.TransportCredentials,
 			cfg.TLSDisableAutofill, cert.DefaultAutogenValidity,
 		)
 		if err != nil {
-			return nil, nil, "", err
+			return nil, nil, "", nil, err
 		}
 		rpcsLog.Infof("Done generating TLS certificates")
 	}
@@ -768,7 +771,7 @@ func getTLSConfig(cfg *Config) (*tls.Config, *credentials.TransportCredentials,
 		cfg.TLSCertPath, cfg.TLSKeyPath,
 	)
 	if err != nil {
-		return nil, nil, "", err
+		return nil, nil, "", nil, err
 	}
 
 	// We check whether the certifcate we have on disk match the IPs and
@@ -782,7 +785,7 @@ func getTLSConfig(cfg *Config) (*tls.Config, *credentials.TransportCredentials,
 			cfg.TLSExtraDomains, cfg.TLSDisableAutofill,
 		)
 		if err != nil {
-			return nil, nil, "", err
+			return nil, nil, "", nil, err
 		}
 	}
 
@@ -794,12 +797,12 @@ func getTLSConfig(cfg *Config) (*tls.Config, *credentials.TransportCredentials,
 
 		err := os.Remove(cfg.TLSCertPath)
 		if err != nil {
-			return nil, nil, "", err
+			return nil, nil, "", nil, err
 		}
 
 		err = os.Remove(cfg.TLSKeyPath)
 		if err != nil {
-			return nil, nil, "", err
+			return nil, nil, "", nil, err
 		}
 
 		rpcsLog.Infof("Renewing TLS certificates...")
@@ -809,7 +812,7 @@ func getTLSConfig(cfg *Config) (*tls.Config, *credentials.TransportCredentials,
 			cfg.TLSDisableAutofill, cert.DefaultAutogenValidity,
 		)
 		if err != nil {
-			return nil, nil, "", err
+			return nil, nil, "", nil, err
 		}
 		rpcsLog.Infof("Done renewing TLS certificates")
 
@@ -818,14 +821,15 @@ func getTLSConfig(cfg *Config) (*tls.Config, *credentials.TransportCredentials,
 			cfg.TLSCertPath, cfg.TLSKeyPath,
 		)
 		if err != nil {
-			return nil, nil, "", err
+			return nil, nil, "", nil, err
 		}
 	}
 
 	tlsCfg := cert.TLSConfFromCert(certData)
+
 	restCreds, err := credentials.NewClientTLSFromFile(cfg.TLSCertPath, "")
 	if err != nil {
-		return nil, nil, "", err
+		return nil, nil, "", nil, err
 	}
 
 	restProxyDest := cfg.RPCListeners[0].String()
@@ -841,7 +845,65 @@ func getTLSConfig(cfg *Config) (*tls.Config, *credentials.TransportCredentials,
 		)
 	}
 
-	return tlsCfg, &restCreds, restProxyDest, nil
+	// If Let's Encrypt is enabled, instantiate autocert to request/renew
+	// the certificates.
+	cleanUp := func() {}
+	if cfg.LetsEncryptDomain != "" {
+		ltndLog.Infof("Using Let's Encrypt certificate for domain %v",
+			cfg.LetsEncryptDomain)
+
+		manager := autocert.Manager{
+			Cache:      autocert.DirCache(cfg.LetsEncryptDir),
+			Prompt:     autocert.AcceptTOS,
+			HostPolicy: autocert.HostWhitelist(cfg.LetsEncryptDomain),
+		}
+
+		addr := fmt.Sprintf(":%v", cfg.LetsEncryptPort)
+		srv := &http.Server{
+			Addr:    addr,
+			Handler: manager.HTTPHandler(nil),
+		}
+		shutdownCompleted := make(chan struct{})
+		cleanUp = func() {
+			err := srv.Shutdown(context.Background())
+			if err != nil {
+				ltndLog.Errorf("Autocert listener shutdown "+
+					" error: %v", err)
+
+				return
+			}
+			<-shutdownCompleted
+			ltndLog.Infof("Autocert challenge listener stopped")
+		}
+
+		go func() {
+			ltndLog.Infof("Autocert challenge listener started "+
+				"at %v", addr)
+
+			err := srv.ListenAndServe()
+			if err != http.ErrServerClosed {
+				ltndLog.Errorf("autocert http: %v", err)
+			}
+			close(shutdownCompleted)
+		}()
+
+		getCertificate := func(h *tls.ClientHelloInfo) (
+			*tls.Certificate, error) {
+
+			lecert, err := manager.GetCertificate(h)
+			if err != nil {
+				ltndLog.Errorf("GetCertificate: %v", err)
+				return &certData, nil
+			}
+
+			return lecert, err
+		}
+
+		// The self-signed tls.cert remains available as fallback.
+		tlsCfg.GetCertificate = getCertificate
+	}
+
+	return tlsCfg, &restCreds, restProxyDest, cleanUp, nil
 }
 
 // fileExists reports whether the named file or directory exists.

--- a/sample-lnd.conf
+++ b/sample-lnd.conf
@@ -50,6 +50,20 @@
 ; or want to expose the node at a domain.
 ; externalhosts=my-node-domain.com
 
+; Sets the directory to store Let's Encrypt certificates within
+; letsencryptdir=~/.lnd/letsencrypt
+
+; Sets the port on which lnd will listen for Let's Encrypt challenges. Let's 
+; Encrypt will always try to contact on port 80. Often non-root processes are
+; not allowed to bind to ports lower than 1024. This configuration option allows
+; a different port to be used, but must be used in combination with port
+; forwarding from port 80.
+; letsencryptport=8080
+
+; Request a Let's Encrypt certificate for this domain. Note that the certicate
+; is only requested and stored when the first rpc connection comes in.
+; letsencryptdomain=example.com
+
 ; Disable macaroon authentication. Macaroons are used are bearer credentials to
 ; authenticate all RPC access. If one wishes to opt out of macaroons, uncomment
 ; the line below.

--- a/server_test.go
+++ b/server_test.go
@@ -119,10 +119,11 @@ func TestTLSAutoRegeneration(t *testing.T) {
 		TLSKeyPath:   keyPath,
 		RPCListeners: rpcListeners,
 	}
-	_, _, _, err = getTLSConfig(cfg)
+	_, _, _, cleanUp, err := getTLSConfig(cfg)
 	if err != nil {
 		t.Fatalf("couldn't retrieve TLS config")
 	}
+	defer cleanUp()
 
 	// Grab the certificate to test that getTLSConfig did its job correctly
 	// and generated a new cert.


### PR DESCRIPTION
This commit enables lnd to request and renew a Let's Encrypt certificate. This certificate is used both for the grpc as well as the rest listeners. It allows clients to connect without having a copy of the (public) server certificate.

In addition to this, it fixes a bug where wildcard ip instantiation (introduced in https://github.com/lightningnetwork/lnd/pull/2247) wasn't carried out for the wallet unlocker service.

## Configuration

Most important: the `lnd` instance must be reachable via a domain name. Let's Encrypt certificates are tied to domain names.

New flags added to the `lnd` command line and `lnd.conf`:

* `--letsencryptport`
The port on which lnd will listen for Let's Encrypt challenges. Let's Encrypt will always try to contact on port 80. Often non-root processes are not allowed to bind to ports lower than 1024. This configuration option allows a different port to be used, but must be used in combination with port forwarding from port 80.

* `--letsencryptdir`
The directory to store Let's Encrypt certificates within. By default this is `.lnd/letsencrypt`.

* `--letsencryptdomain`
Request a Let's Encrypt certificate for the domain specified using this flag.

The `lnd` instance must be reachable from outside on port 80. Either directly or through port forwarding to `letsencryptport`.

## lncli

When `lncli` cannot find a `tls.cert` file, it will assume the server has a valid (Let's Encrypt) certificate. It is important to pass the domain name as a command line flag to `lncli`:

`lncli --rpcserver my.domain.org:10009`

This is necessary as well when connecting to `localhost`.

