### PR TITLE
lnwallet: Remove breach txn from NewBreachRetribution

### DIFF
--- a/breacharbiter_test.go
+++ b/breacharbiter_test.go
@@ -1181,7 +1181,7 @@ func TestBreachSecondLevelTransfer(t *testing.T) {
 
 	// Notify the breach arbiter about the breach.
 	retribution, err := lnwallet.NewBreachRetribution(
-		alice.State(), height, forceCloseTx, 1)
+		alice.State(), height, 1)
 	if err != nil {
 		t.Fatalf("unable to create breach retribution: %v", err)
 	}

--- a/contractcourt/chain_watcher.go
+++ b/contractcourt/chain_watcher.go
@@ -725,18 +725,14 @@ func (c *chainWatcher) dispatchContractBreach(spendEvent *chainntnfs.SpendDetail
 		return fmt.Errorf("unable to mark channel as borked: %v", err)
 	}
 
-	var (
-		commitTxBroadcast = spendEvent.SpendingTx
-		spendHeight       = uint32(spendEvent.SpendingHeight)
-	)
+	spendHeight := uint32(spendEvent.SpendingHeight)
 
 	// Create a new reach retribution struct which contains all the data
 	// needed to swiftly bring the cheating peer to justice.
 	//
 	// TODO(roasbeef): move to same package
 	retribution, err := lnwallet.NewBreachRetribution(
-		c.cfg.chanState, broadcastStateNum, commitTxBroadcast,
-		spendHeight,
+		c.cfg.chanState, broadcastStateNum, spendHeight,
 	)
 	if err != nil {
 		return fmt.Errorf("unable to create breach retribution: %v", err)

--- a/lnwallet/channel_test.go
+++ b/lnwallet/channel_test.go
@@ -5389,7 +5389,6 @@ func TestNewBreachRetributionSkipsDustHtlcs(t *testing.T) {
 
 	// At this point, we'll capture the current state number, as well as
 	// the current commitment.
-	revokedCommit := bobChannel.channelState.LocalCommitment.CommitTx
 	revokedStateNum := aliceChannel.channelState.LocalCommitment.CommitHeight
 
 	// We'll now have Bob settle those HTLC's to Alice and then advance
@@ -5411,7 +5410,7 @@ func TestNewBreachRetributionSkipsDustHtlcs(t *testing.T) {
 	// At this point, we'll now simulate a contract breach by Bob using the
 	// NewBreachRetribution method.
 	breachRet, err := NewBreachRetribution(
-		aliceChannel.channelState, revokedStateNum, revokedCommit, 100,
+		aliceChannel.channelState, revokedStateNum, 100,
 	)
 	if err != nil {
 		t.Fatalf("unable to create breach retribution: %v", err)


### PR DESCRIPTION
In this PR, we remove the passed `breachTxn` argument from `NewBreachRetribution`. We already store the transaction on disk, which we retrieve via the state number. Currently, we pull values from both the argument and the transaction loaded from disk, which is unnecessary since they should both be the same.

We modify this method to only inspect the on-disk transaction, as this allows `NewBreachRetribution` to be queried for a specific state number w/o needing to have the breach transaction itself.

This is a preliminary step to adding the watchtower client, which may need to be able to retroactively sign justice transactions for any particular revoked state. This also implies that the client/links don't have to do any bookkeeping/recording of breach transactions outside the wallet.

