### PR TITLE
lnwallet: Add keyring and remote CSV delay to BreachRetribution

### DIFF
--- a/contractcourt/chain_watcher.go
+++ b/contractcourt/chain_watcher.go
@@ -747,13 +747,27 @@ func (c *chainWatcher) dispatchContractBreach(spendEvent *chainntnfs.SpendDetail
 		retribution.RemoteOutputSignDesc.DoubleTweak != nil {
 		retribution.RemoteOutputSignDesc.DoubleTweak.Curve = nil
 	}
+	if retribution.RemoteOutputSignDesc != nil &&
+		retribution.RemoteOutputSignDesc.KeyDesc.PubKey != nil {
+		retribution.RemoteOutputSignDesc.KeyDesc.PubKey.Curve = nil
+	}
 	if retribution.LocalOutputSignDesc != nil &&
 		retribution.LocalOutputSignDesc.DoubleTweak != nil {
 		retribution.LocalOutputSignDesc.DoubleTweak.Curve = nil
 	}
+	if retribution.LocalOutputSignDesc != nil &&
+		retribution.LocalOutputSignDesc.KeyDesc.PubKey != nil {
+		retribution.LocalOutputSignDesc.KeyDesc.PubKey.Curve = nil
+	}
 
 	log.Debugf("Punishment breach retribution created: %v",
 		newLogClosure(func() string {
+			retribution.KeyRing.CommitPoint.Curve = nil
+			retribution.KeyRing.LocalHtlcKey = nil
+			retribution.KeyRing.RemoteHtlcKey = nil
+			retribution.KeyRing.DelayKey = nil
+			retribution.KeyRing.NoDelayKey = nil
+			retribution.KeyRing.RevocationKey = nil
 			return spew.Sdump(retribution)
 		}))
 

--- a/lnwallet/channel.go
+++ b/lnwallet/channel.go
@@ -1891,6 +1891,15 @@ type BreachRetribution struct {
 	// HtlcRetributions is a slice of HTLC retributions for each output
 	// active HTLC output within the breached commitment transaction.
 	HtlcRetributions []HtlcRetribution
+
+	// KeyRing contains the derived public keys used to construct the
+	// breaching commitment transaction. This allows downstream clients to
+	// have access to the public keys used in the scripts.
+	KeyRing *CommitmentKeyRing
+
+	// RemoteDelay specifies the CSV delay applied to to-local scripts on
+	// the breaching commitment transaction.
+	RemoteDelay uint32
 }
 
 // NewBreachRetribution creates a new fully populated BreachRetribution for the
@@ -2099,6 +2108,8 @@ func NewBreachRetribution(chanState *channeldb.OpenChannel, stateNum uint64,
 		RemoteOutpoint:       remoteOutpoint,
 		RemoteOutputSignDesc: remoteSignDesc,
 		HtlcRetributions:     htlcRetributions,
+		KeyRing:              keyRing,
+		RemoteDelay:          remoteDelay,
 	}, nil
 }
 


### PR DESCRIPTION
This PR modifies `lnwallet.BreachRetribution` to expose the remote CSV and commitment key ring.
This information is currently only accessible from the existing interface by manually parsing the scripts in the sign descriptors, which is cumbersome and error prone. In addition, we fix an existing issue wrt to not nilling curves before spewing in the cnct, which show up on trace.

In the context of the watchtower client, the `RemoteDelay`, `DelayKey`, `NoDelayKey` and `RevocationKey` are to be readily embedded in the justice kits sent to the watchtowers.