### PR TITLE
lnwire: Adjust Stringer to standard chan id format

### DIFF
--- a/lnwire/short_channel_id.go
+++ b/lnwire/short_channel_id.go
@@ -44,5 +44,5 @@ func (c ShortChannelID) ToUint64() uint64 {
 
 // String generates a human-readable representation of the channel ID.
 func (c ShortChannelID) String() string {
-	return fmt.Sprintf("%d:%d:%d", c.BlockHeight, c.TxIndex, c.TxPosition)
+	return fmt.Sprintf("%dx%dx%d", c.BlockHeight, c.TxIndex, c.TxPosition)
 }


### PR DESCRIPTION
This would adjust logging output to use a more easily selectable short channel id components string

