### PR TITLE
Extend ListPayments response by original invoice memo (#2420)

### DIFF
--- a/lnrpc/rpc.pb.go
+++ b/lnrpc/rpc.pb.go
@@ -6423,10 +6423,12 @@ type Payment struct {
 	Fee int64 `protobuf:"varint,5,opt,name=fee,proto3" json:"fee,omitempty"`
 	// / The payment preimage
 	PaymentPreimage string `protobuf:"bytes,6,opt,name=payment_preimage,proto3" json:"payment_preimage,omitempty"`
+	// / The memo from the invoice the payment was based on
+	Memo string `protobuf:"bytes,7,opt,name=memo,proto3" json:"memo,omitempty"`
 	// / The value of the payment in satoshis
-	ValueSat int64 `protobuf:"varint,7,opt,name=value_sat,proto3" json:"value_sat,omitempty"`
+	ValueSat int64 `protobuf:"varint,8,opt,name=value_sat,proto3" json:"value_sat,omitempty"`
 	// / The value of the payment in milli-satoshis
-	ValueMsat            int64    `protobuf:"varint,8,opt,name=value_msat,proto3" json:"value_msat,omitempty"`
+	ValueMsat            int64    `protobuf:"varint,9,opt,name=value_msat,proto3" json:"value_msat,omitempty"`
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
 	XXX_unrecognized     []byte   `json:"-"`
 	XXX_sizecache        int32    `json:"-"`
@@ -6495,6 +6497,13 @@ func (m *Payment) GetFee() int64 {
 func (m *Payment) GetPaymentPreimage() string {
 	if m != nil {
 		return m.PaymentPreimage
+	}
+	return ""
+}
+
+func (m *Payment) GetMemo() string {
+	if m != nil {
+		return m.Memo
 	}
 	return ""
 }

--- a/lnrpc/rpc.proto
+++ b/lnrpc/rpc.proto
@@ -1910,7 +1910,7 @@ message Payment {
     /// The payment preimage
     string payment_preimage = 6 [json_name = "payment_preimage"];
 
-    /// The memo from the invoice the payment is based on
+    /// The memo from the invoice the payment was based on
     string memo = 7 [json_name = "memo"];
 
     /// The value of the payment in satoshis

--- a/lnrpc/rpc.proto
+++ b/lnrpc/rpc.proto
@@ -1910,11 +1910,14 @@ message Payment {
     /// The payment preimage
     string payment_preimage = 6 [json_name = "payment_preimage"];
 
+    /// The memo from the invoice the payment is based on
+    string memo = 7 [json_name = "memo"];
+
     /// The value of the payment in satoshis
-    int64 value_sat = 7 [json_name = "value_sat"];
+    int64 value_sat = 8 [json_name = "value_sat"];
 
     /// The value of the payment in milli-satoshis
-    int64 value_msat = 8 [json_name = "value_msat"];
+    int64 value_msat = 9 [json_name = "value_msat"];
 }
 
 message ListPaymentsRequest {

--- a/lnrpc/rpc.swagger.json
+++ b/lnrpc/rpc.swagger.json
@@ -2503,6 +2503,10 @@
           "type": "string",
           "title": "/ The payment preimage"
         },
+        "memo": {
+          "type": "string",
+          "description": "/ The optional memo from the invoice the payment was based on."
+        },
         "value_sat": {
           "type": "string",
           "format": "int64",


### PR DESCRIPTION
Pull request extends grpc ListPayments api by `memo` from the invoice the payment is based on. See [2420](https://github.com/lightningnetwork/lnd/issues/2420) for proposal reasoning and details.
