### PR TITLE
netann: Add NANN subsystem logger

### DIFF
--- a/log.go
+++ b/log.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"fmt"
-	"github.com/lightningnetwork/lnd/invoices"
 	"io"
 	"os"
 	"path/filepath"
@@ -20,10 +19,12 @@ import (
 	"github.com/lightningnetwork/lnd/contractcourt"
 	"github.com/lightningnetwork/lnd/discovery"
 	"github.com/lightningnetwork/lnd/htlcswitch"
+	"github.com/lightningnetwork/lnd/invoices"
 	"github.com/lightningnetwork/lnd/lnrpc/autopilotrpc"
 	"github.com/lightningnetwork/lnd/lnrpc/signrpc"
 	"github.com/lightningnetwork/lnd/lnrpc/walletrpc"
 	"github.com/lightningnetwork/lnd/lnwallet"
+	"github.com/lightningnetwork/lnd/netann"
 	"github.com/lightningnetwork/lnd/routing"
 	"github.com/lightningnetwork/lnd/signal"
 	"github.com/lightningnetwork/lnd/sweep"
@@ -73,6 +74,7 @@ var (
 	wlktLog = build.NewSubLogger("WLKT", backendLog.Logger)
 	arpcLog = build.NewSubLogger("ARPC", backendLog.Logger)
 	invcLog = build.NewSubLogger("INVC", backendLog.Logger)
+	nannLog = build.NewSubLogger("NANN", backendLog.Logger)
 )
 
 // Initialize package-global logger variables.
@@ -94,6 +96,7 @@ func init() {
 	walletrpc.UseLogger(wlktLog)
 	autopilotrpc.UseLogger(arpcLog)
 	invoices.UseLogger(invcLog)
+	netann.UseLogger(nannLog)
 }
 
 // subsystemLoggers maps each subsystem identifier to its associated logger.
@@ -121,6 +124,7 @@ var subsystemLoggers = map[string]btclog.Logger{
 	"WLKT": wlktLog,
 	"ARPC": arpcLog,
 	"INVC": invcLog,
+	"NANN": nannLog,
 }
 
 // initLogRotator initializes the logging rotator to write logs to logFile and

--- a/netann/log.go
+++ b/netann/log.go
@@ -1,0 +1,45 @@
+package netann
+
+import (
+	"github.com/btcsuite/btclog"
+	"github.com/lightningnetwork/lnd/build"
+)
+
+// log is a logger that is initialized with no output filters.  This means the
+// package will not perform any logging by default until the caller requests
+// it.
+var log btclog.Logger
+
+// The default amount of logging is none.
+func init() {
+	UseLogger(build.NewSubLogger("NANN", nil))
+}
+
+// DisableLog disables all library log output.  Logging output is disabled by
+// by default until UseLogger is called.
+func DisableLog() {
+	UseLogger(btclog.Disabled)
+}
+
+// UseLogger uses a specified Logger to output package logging info.  This
+// should be used in preference to SetLogWriter if the caller is also using
+// btclog.
+func UseLogger(logger btclog.Logger) {
+	log = logger
+}
+
+// logClosure is used to provide a closure over expensive logging operations so
+// don't have to be performed when the logging level doesn't warrant it.
+type logClosure func() string
+
+// String invokes the underlying function and returns the result.
+func (c logClosure) String() string {
+	return c()
+}
+
+// newLogClosure returns a new closure over a function that returns a string
+// which itself provides a Stringer interface so that it can be used with the
+// logging system.
+func newLogClosure(c func() string) logClosure {
+	return logClosure(c)
+}


### PR DESCRIPTION
In preparation for #2411, this PR introduces the NANN subsystem logger and tidies the imports in `log.go`