### PR TITLE
routing/router: avoid naked spew of channel policies

### DIFF
--- a/routing/router.go
+++ b/routing/router.go
@@ -1211,7 +1211,8 @@ func (r *ChannelRouter) processUpdate(msg interface{}) error {
 		}
 
 		invalidateCache = true
-		log.Tracef("New channel update applied: %v", spew.Sdump(msg))
+		log.Tracef("New channel update applied: %v",
+			newLogClosure(func() string { return spew.Sdump(msg) }))
 
 	default:
 		return errors.Errorf("wrong routing update message type")


### PR DESCRIPTION
Noticed in profiling that this log message generates a ton of garbage (about 5% of my nodes resident memory), which is unnecessary when not running with trace logs. Wrapping this in a log closure should help slim down the memory requirements of validating gossip traffic.