### PR TITLE
htlcswitch: stricter HasActiveLink

### DIFF
--- a/htlcswitch/switch.go
+++ b/htlcswitch/switch.go
@@ -1990,13 +1990,16 @@ func (s *Switch) getLinkByShortID(chanID lnwire.ShortChannelID) (ChannelLink, er
 }
 
 // HasActiveLink returns true if the given channel ID has a link in the link
-// index.
+// index AND the link is eligible to forward.
 func (s *Switch) HasActiveLink(chanID lnwire.ChannelID) bool {
 	s.indexMtx.RLock()
 	defer s.indexMtx.RUnlock()
 
-	_, ok := s.linkIndex[chanID]
-	return ok
+	if link, ok := s.linkIndex[chanID]; ok {
+		return link.EligibleToForward()
+	}
+
+	return false
 }
 
 // RemoveLink purges the switch of any link associated with chanID. If a pending


### PR DESCRIPTION
This PR modifies the behavior of the htlcswitch's `HasActiveLink`, such that it will only return true if 1) the channel is no longer pending (short channel id has confirmed) and 2) the link's `EligibleToForward` method returns true. This deviates from the prior behavior by requiring the second condition.

`HasActiveLink` is currently used by the server to determine whether or not its status has changed, and if it should passively send out a `ChannelUpdate` to enable to disable the channel. This same method will be used by the new `ChanStatusManager` in #2411. Adding the stricter behavior will ensure that we don't produce any false positives, since a link that can't send updates (isn't eligible to forward) has no business being enabled on the network.

A test has been added (which fails without the first commit) to ensure the new behavior meets these expectations.

Broken off from #2411 