### PR TITLE
enable btcd and btcctl mainnet to be invoked from docker

### DIFF
--- a/docker/btcd/start-btcctl.sh
+++ b/docker/btcd/start-btcctl.sh
@@ -43,10 +43,17 @@ RPCUSER=$(set_default "$RPCUSER" "devuser")
 RPCPASS=$(set_default "$RPCPASS" "devpass")
 NETWORK=$(set_default "$NETWORK" "simnet")
 
-exec btcctl \
-    "--$NETWORK" \
-    --rpccert="/rpc/rpc.cert" \
-    --rpcuser="$RPCUSER" \
-    --rpcpass="$RPCPASS" \
-    --rpcserver="rpcserver" \
-    "$@"
+PARAMS=""
+if [ "$NETWORK" != "mainnet" ]; then
+    PARAMS=$(echo --$NETWORK)
+fi
+
+PARAMS=$(echo $PARAMS \
+    "--rpccert=/rpc/rpc.cert" \
+    "--rpcuser=$RPCUSER" \
+    "--rpcpass=$RPCPASS" \
+    "--rpcserver=rpcserver" \
+)
+
+PARAMS="$PARAMS $@"
+exec btcctl $PARAMS

--- a/docker/btcd/start-btcd.sh
+++ b/docker/btcd/start-btcd.sh
@@ -44,8 +44,12 @@ RPCPASS=$(set_default "$RPCPASS" "devpass")
 DEBUG=$(set_default "$DEBUG" "info")
 NETWORK=$(set_default "$NETWORK" "simnet")
 
-PARAMS=$(echo \
-    "--$NETWORK" \
+PARAMS=""
+if [ "$NETWORK" != "mainnet" ]; then
+   PARAMS=$(echo --$NETWORK)
+fi
+
+PARAMS=$(echo $PARAMS \
     "--debuglevel=$DEBUG" \
     "--rpcuser=$RPCUSER" \
     "--rpcpass=$RPCPASS" \


### PR DESCRIPTION
The default network for both btcr and btcctl is mainnet which requires no network to be defined when passing command line arguments.

https://github.com/btcsuite/btcd/blob/master/chaincfg/doc.go#L34
https://github.com/btcsuite/btcutil/blob/master/doc.go#L38

This PR allows no network argument to be passed when running the btc docker containers.  Simnet is left as default and both `testnet` and `mainnet` can passed as arguments to docker.

for example:
`sudo NETWORK="mainnet" docker-compose run btcd`
`sudo NETWORK="mainnet" docker-compose run btcctl getblockchaininfo`


Fixes #2237 