### PR TITLE
lnpeer+brontide: reduce memory footprint using read/write pools for message encode/decode

### DIFF
--- a/brontide/conn.go
+++ b/brontide/conn.go
@@ -104,11 +104,32 @@ func Dial(localPriv *btcec.PrivateKey, netAddr *lnwire.NetAddress,
 	return b, nil
 }
 
-// ReadNextMessage uses the connection in a message-oriented instructing it to
-// read the next _full_ message with the brontide stream. This function will
-// block until the read succeeds.
+// ReadNextMessage uses the connection in a message-oriented manner, instructing
+// it to read the next _full_ message with the brontide stream. This function
+// will block until the read of the header and body succeeds.
+//
+// NOTE: This method SHOULD NOT be used in the case that the connection may be
+// adversarial and induce long delays. If the caller needs to set read deadlines
+// appropriately, it is preferred that they use the split ReadNextHeader and
+// ReadNextBody methods so that the deadlines can be set appropriately on each.
 func (c *Conn) ReadNextMessage() ([]byte, error) {
 	return c.noise.ReadMessage(c.conn)
+}
+
+// ReadNextHeader uses the connection to read the next header from the brontide
+// stream. This function will block until the read of the header succeeds and
+// return the packet length (including MAC overhead) that is expected from the
+// subsequent call to ReadNextBody.
+func (c *Conn) ReadNextHeader() (uint32, error) {
+	return c.noise.ReadHeader(c.conn)
+}
+
+// ReadNextBody uses the connection to read the next message body from the
+// brontide stream. This function will block until the read of the body succeeds
+// and return the decrypted payload. The provided buffer MUST be the packet
+// length returned by the preceding call to ReadNextHeader.
+func (c *Conn) ReadNextBody(buf []byte) ([]byte, error) {
+	return c.noise.ReadBody(c.conn, buf)
 }
 
 // Read reads data from the connection.  Read can be made to time out and

--- a/peer.go
+++ b/peer.go
@@ -44,8 +44,8 @@ const (
 	// idleTimeout is the duration of inactivity before we time out a peer.
 	idleTimeout = 5 * time.Minute
 
-	// writeMessageTimeout is the timeout used when writing a message to peer.
-	writeMessageTimeout = 50 * time.Second
+	// writeMessageTimeout is the timeout used when writing a message to a peer.
+	writeMessageTimeout = 10 * time.Second
 
 	// readMessageTimeout is the timeout used when reading a message from a
 	// peer.

--- a/pool/read.go
+++ b/pool/read.go
@@ -1,0 +1,87 @@
+package pool
+
+import (
+	"time"
+
+	"github.com/lightningnetwork/lnd/buffer"
+)
+
+// Read is a worker pool specifically designed for sharing access to buffer.Read
+// objects amongst a set of worker goroutines. This enables an application to
+// limit the total number of buffer.Read objects allocated at any given time.
+type Read struct {
+	workerPool *Worker
+	bufferPool *ReadBuffer
+}
+
+// NewRead creates a new Read pool, using an underlying ReadBuffer pool to
+// recycle buffer.Read objects across the lifetime of the Read pool's workers.
+func NewRead(readBufferPool *ReadBuffer, numWorkers int,
+	workerTimeout time.Duration) *Read {
+
+	r := &Read{
+		bufferPool: readBufferPool,
+	}
+	r.workerPool = NewWorker(&WorkerConfig{
+		NewWorkerState: r.newWorkerState,
+		NumWorkers:     numWorkers,
+		WorkerTimeout:  workerTimeout,
+	})
+
+	return r
+}
+
+// Start safely spins up the Read pool.
+func (r *Read) Start() error {
+	return r.workerPool.Start()
+}
+
+// Stop safely shuts down the Read pool.
+func (r *Read) Stop() error {
+	return r.workerPool.Stop()
+}
+
+// Submit accepts a function closure that provides access to the fresh
+// buffer.Read object. The function's execution will be allocated to one of the
+// underlying Worker pool's goroutines.
+func (r *Read) Submit(inner func(*buffer.Read) error) error {
+	return r.workerPool.Submit(func(s WorkerState) error {
+		state := s.(*readWorkerState)
+		return inner(state.readBuf)
+	})
+}
+
+// readWorkerState is the per-goroutine state maintained by a Read pool's
+// goroutines.
+type readWorkerState struct {
+	// bufferPool is the pool to which the readBuf will be returned when the
+	// goroutine exits.
+	bufferPool *ReadBuffer
+
+	// readBuf is a buffer taken from the bufferPool on initialization,
+	// which will be cleaned and provided to any tasks that the goroutine
+	// processes before exiting.
+	readBuf *buffer.Read
+}
+
+// newWorkerState initializes a new readWorkerState, which will be called
+// whenever a new goroutine is allocated to begin processing read tasks.
+func (r *Read) newWorkerState() WorkerState {
+	return &readWorkerState{
+		bufferPool: r.bufferPool,
+		readBuf:    r.bufferPool.Take(),
+	}
+}
+
+// Cleanup returns the readBuf to the underlying buffer pool, and removes the
+// goroutine's reference to the readBuf.
+func (r *readWorkerState) Cleanup() {
+	r.bufferPool.Return(r.readBuf)
+	r.readBuf = nil
+}
+
+// Reset recycles the readBuf to make it ready for any subsequent tasks the
+// goroutine may process.
+func (r *readWorkerState) Reset() {
+	r.readBuf.Recycle()
+}

--- a/pool/worker.go
+++ b/pool/worker.go
@@ -1,0 +1,250 @@
+package pool
+
+import (
+	"errors"
+	"sync"
+	"time"
+)
+
+// ErrWorkerPoolExiting signals that a shutdown of the Worker has been
+// requested.
+var ErrWorkerPoolExiting = errors.New("worker pool exiting")
+
+// DefaultWorkerTimeout is the default duration after which a worker goroutine
+// will exit to free up resources after having received no newly submitted
+// tasks.
+const DefaultWorkerTimeout = 5 * time.Second
+
+type (
+	// WorkerState is an interface used by the Worker to abstract the
+	// lifecycle of internal state used by a worker goroutine.
+	WorkerState interface {
+		// Reset clears any internal state that may have been dirtied in
+		// processing a prior task.
+		Reset()
+
+		// Cleanup releases any shared state before a worker goroutine
+		// exits.
+		Cleanup()
+	}
+
+	// WorkerConfig parameterizes the behavior of a Worker pool.
+	WorkerConfig struct {
+		// NewWorkerState allocates a new state for a worker goroutine.
+		// This method is called each time a new worker goroutine is
+		// spawned by the pool.
+		NewWorkerState func() WorkerState
+
+		// NumWorkers is the maximum number of workers the Worker pool
+		// will permit to be allocated. Once the maximum number is
+		// reached, any newly submitted tasks are forced to be processed
+		// by existing worker goroutines.
+		NumWorkers int
+
+		// WorkerTimeout is the duration after which a worker goroutine
+		// will exit after having received no newly submitted tasks.
+		WorkerTimeout time.Duration
+	}
+
+	// Worker maintains a pool of goroutines that process submitted function
+	// closures, and enable more efficient reuse of expensive state.
+	Worker struct {
+		started sync.Once
+		stopped sync.Once
+
+		cfg *WorkerConfig
+
+		// requests is a channel where new tasks are submitted. Tasks
+		// submitted through this channel may cause a new worker
+		// goroutine to be allocated.
+		requests chan *request
+
+		// work is a channel where new tasks are submitted, but is only
+		// read by active worker gorotuines.
+		work chan *request
+
+		// workerSem is a channel-based sempahore that is used to limit
+		// the total number of worker goroutines to the number
+		// prescribed by the WorkerConfig.
+		workerSem chan struct{}
+
+		wg   sync.WaitGroup
+		quit chan struct{}
+	}
+
+	// request is a tuple of task closure and error channel that is used to
+	// both submit a task to the pool and respond with any errors
+	// encountered during the task's execution.
+	request struct {
+		fn      func(WorkerState) error
+		errChan chan error
+	}
+)
+
+// NewWorker initializes a new Worker pool using the provided WorkerConfig.
+func NewWorker(cfg *WorkerConfig) *Worker {
+	return &Worker{
+		cfg:       cfg,
+		requests:  make(chan *request),
+		workerSem: make(chan struct{}, cfg.NumWorkers),
+		work:      make(chan *request),
+		quit:      make(chan struct{}),
+	}
+}
+
+// Start safely spins up the Worker pool.
+func (w *Worker) Start() error {
+	w.started.Do(func() {
+		w.wg.Add(1)
+		go w.requestHandler()
+	})
+	return nil
+}
+
+// Stop safely shuts down the Worker pool.
+func (w *Worker) Stop() error {
+	w.stopped.Do(func() {
+		close(w.quit)
+		w.wg.Wait()
+	})
+	return nil
+}
+
+// Submit accepts a function closure to the worker pool. The returned error will
+// be either the result of the closure's execution or an ErrWorkerPoolExiting if
+// a shutdown is requested.
+func (w *Worker) Submit(fn func(WorkerState) error) error {
+	req := &request{
+		fn:      fn,
+		errChan: make(chan error, 1),
+	}
+
+	select {
+
+	// Send request to requestHandler, where either a new worker is spawned
+	// or the task will be handed to an existing worker.
+	case w.requests <- req:
+
+	// Fast path directly to existing worker.
+	case w.work <- req:
+
+	case <-w.quit:
+		return ErrWorkerPoolExiting
+	}
+
+	select {
+
+	// Wait for task to be processed.
+	case err := <-req.errChan:
+		return err
+
+	case <-w.quit:
+		return ErrWorkerPoolExiting
+	}
+}
+
+// requestHandler processes incoming tasks by either allocating new worker
+// goroutines to process the incoming tasks, or by feeding a submitted task to
+// an already running worker goroutine.
+func (w *Worker) requestHandler() {
+	defer w.wg.Done()
+
+	for {
+		select {
+		case req := <-w.requests:
+			select {
+
+			// If we have not reached our maximum number of workers,
+			// spawn one to process the submitted request.
+			case w.workerSem <- struct{}{}:
+				w.wg.Add(1)
+				go w.spawnWorker(req)
+
+			// Otherwise, submit the task to any of the active
+			// workers.
+			case w.work <- req:
+
+			case <-w.quit:
+				return
+			}
+
+		case <-w.quit:
+			return
+		}
+	}
+}
+
+// spawnWorker is used when the Worker pool wishes to create a new worker
+// goroutine. The worker's state is initialized by calling the config's
+// NewWorkerState method, and will continue to process incoming tasks until the
+// pool is shut down or no new tasks are received before the worker's timeout
+// elapses.
+//
+// NOTE: This method MUST be run as a goroutine.
+func (w *Worker) spawnWorker(req *request) {
+	defer w.wg.Done()
+	defer func() { <-w.workerSem }()
+
+	state := w.cfg.NewWorkerState()
+	defer state.Cleanup()
+
+	req.errChan <- req.fn(state)
+
+	// We'll use a timer to implement the worker timeouts, as this reduces
+	// the number of total allocations that would otherwise be necessary
+	// with time.After.
+	var t *time.Timer
+	for {
+		// Before processing another request, we'll reset the worker
+		// state to that each request is processed against a clean
+		// state.
+		state.Reset()
+
+		select {
+
+		// Process any new requests that get submitted. We use a
+		// non-blocking case first so that under high load we can spare
+		// allocating a timeout.
+		case req := <-w.work:
+			req.errChan <- req.fn(state)
+			continue
+
+		case <-w.quit:
+			return
+
+		default:
+		}
+
+		// There were no new requests that could be taken immediately
+		// from the work channel. Initialize or reset the timeout, which
+		// will fire if the worker doesn't receive a new task before
+		// needing to exit.
+		if t != nil {
+			t.Reset(w.cfg.WorkerTimeout)
+		} else {
+			t = time.NewTimer(w.cfg.WorkerTimeout)
+		}
+
+		select {
+
+		// Process any new requests that get submitted.
+		case req := <-w.work:
+			req.errChan <- req.fn(state)
+
+			// Stop the timer, draining the timer's channel if a
+			// notification was already delivered.
+			if !t.Stop() {
+				<-t.C
+			}
+
+		// The timeout has elapsed, meaning the worker did not receive
+		// any new tasks. Exit to allow the worker to return and free
+		// its resources.
+		case <-t.C:
+			return
+
+		case <-w.quit:
+			return
+		}
+	}
+}

--- a/pool/worker_test.go
+++ b/pool/worker_test.go
@@ -1,0 +1,353 @@
+package pool_test
+
+import (
+	"bytes"
+	crand "crypto/rand"
+	"fmt"
+	"io"
+	"math/rand"
+	"testing"
+	"time"
+
+	"github.com/lightningnetwork/lnd/buffer"
+	"github.com/lightningnetwork/lnd/pool"
+)
+
+type workerPoolTest struct {
+	name       string
+	newPool    func() interface{}
+	numWorkers int
+}
+
+// TestConcreteWorkerPools asserts the behavior of any concrete implementations
+// of worker pools provided by the pool package. Currently this tests the
+// pool.Read and pool.Write instances.
+func TestConcreteWorkerPools(t *testing.T) {
+	const (
+		gcInterval     = time.Second
+		expiryInterval = 250 * time.Millisecond
+		numWorkers     = 5
+		workerTimeout  = 500 * time.Millisecond
+	)
+
+	tests := []workerPoolTest{
+		{
+			name: "write pool",
+			newPool: func() interface{} {
+				bp := pool.NewWriteBuffer(
+					gcInterval, expiryInterval,
+				)
+
+				return pool.NewWrite(
+					bp, numWorkers, workerTimeout,
+				)
+			},
+			numWorkers: numWorkers,
+		},
+		{
+			name: "read pool",
+			newPool: func() interface{} {
+				bp := pool.NewReadBuffer(
+					gcInterval, expiryInterval,
+				)
+
+				return pool.NewRead(
+					bp, numWorkers, workerTimeout,
+				)
+			},
+			numWorkers: numWorkers,
+		},
+	}
+
+	for _, test := range tests {
+		testWorkerPool(t, test)
+	}
+}
+
+func testWorkerPool(t *testing.T, test workerPoolTest) {
+	t.Run(test.name+" non blocking", func(t *testing.T) {
+		t.Parallel()
+
+		p := test.newPool()
+		startGeneric(t, p)
+		defer stopGeneric(t, p)
+
+		submitNonblockingGeneric(t, p, test.numWorkers)
+	})
+
+	t.Run(test.name+" blocking", func(t *testing.T) {
+		t.Parallel()
+
+		p := test.newPool()
+		startGeneric(t, p)
+		defer stopGeneric(t, p)
+
+		submitBlockingGeneric(t, p, test.numWorkers)
+	})
+
+	t.Run(test.name+" partial blocking", func(t *testing.T) {
+		t.Parallel()
+
+		p := test.newPool()
+		startGeneric(t, p)
+		defer stopGeneric(t, p)
+
+		submitPartialBlockingGeneric(t, p, test.numWorkers)
+	})
+}
+
+// submitNonblockingGeneric asserts that queueing tasks to the worker pool and
+// allowing them all to unblock simultaneously results in all of the tasks being
+// completed in a timely manner.
+func submitNonblockingGeneric(t *testing.T, p interface{}, nWorkers int) {
+	// We'll submit 2*nWorkers tasks that will all be unblocked
+	// simultaneously.
+	nUnblocked := 2 * nWorkers
+
+	// First we'll queue all of the tasks for the pool.
+	errChan := make(chan error)
+	semChan := make(chan struct{})
+	for i := 0; i < nUnblocked; i++ {
+		go func() { errChan <- submitGeneric(p, semChan) }()
+	}
+
+	// Since we haven't signaled the semaphore, none of the them should
+	// complete.
+	pullNothing(t, errChan)
+
+	// Now, unblock them all simultaneously. All of the tasks should then be
+	// processed in parallel. Afterward, no more errors should come through.
+	close(semChan)
+	pullParllel(t, nUnblocked, errChan)
+	pullNothing(t, errChan)
+}
+
+// submitBlockingGeneric asserts that submitting blocking tasks to the pool and
+// unblocking each sequentially results in a single task being processed at a
+// time.
+func submitBlockingGeneric(t *testing.T, p interface{}, nWorkers int) {
+	// We'll submit 2*nWorkers tasks that will be unblocked sequentially.
+	nBlocked := 2 * nWorkers
+
+	// First, queue all of the blocking tasks for the pool.
+	errChan := make(chan error)
+	semChan := make(chan struct{})
+	for i := 0; i < nBlocked; i++ {
+		go func() { errChan <- submitGeneric(p, semChan) }()
+	}
+
+	// Since we haven't signaled the semaphore, none of them should
+	// complete.
+	pullNothing(t, errChan)
+
+	// Now, pull each blocking task sequentially from the pool. Afterwards,
+	// no more errors should come through.
+	pullSequntial(t, nBlocked, errChan, semChan)
+	pullNothing(t, errChan)
+
+}
+
+// submitPartialBlockingGeneric tests that so long as one worker is not blocked,
+// any other non-blocking submitted tasks can still be processed.
+func submitPartialBlockingGeneric(t *testing.T, p interface{}, nWorkers int) {
+	// We'll submit nWorkers-1 tasks that will be initially blocked, the
+	// remainder will all be unblocked simultaneously. After the unblocked
+	// tasks have finished, we will sequentially unblock the nWorkers-1
+	// tasks that were first submitted.
+	nBlocked := nWorkers - 1
+	nUnblocked := 2*nWorkers - nBlocked
+
+	// First, submit all of the blocking tasks to the pool.
+	errChan := make(chan error)
+	semChan := make(chan struct{})
+	for i := 0; i < nBlocked; i++ {
+		go func() { errChan <- submitGeneric(p, semChan) }()
+	}
+
+	// Since these are all blocked, no errors should be returned yet.
+	pullNothing(t, errChan)
+
+	// Now, add all of the non-blocking task to the pool.
+	semChanNB := make(chan struct{})
+	for i := 0; i < nUnblocked; i++ {
+		go func() { errChan <- submitGeneric(p, semChanNB) }()
+	}
+
+	// Since we haven't unblocked the second batch, we again expect no tasks
+	// to finish.
+	pullNothing(t, errChan)
+
+	// Now, unblock the unblocked task and pull all of them. After they have
+	// been pulled, we should see no more tasks.
+	close(semChanNB)
+	pullParllel(t, nUnblocked, errChan)
+	pullNothing(t, errChan)
+
+	// Finally, unblock each the blocked tasks we added initially, and
+	// assert that no further errors come through.
+	pullSequntial(t, nBlocked, errChan, semChan)
+	pullNothing(t, errChan)
+}
+
+func pullNothing(t *testing.T, errChan chan error) {
+	t.Helper()
+
+	select {
+	case err := <-errChan:
+		t.Fatalf("received unexpected error before semaphore "+
+			"release: %v", err)
+
+	case <-time.After(time.Second):
+	}
+}
+
+func pullParllel(t *testing.T, n int, errChan chan error) {
+	t.Helper()
+
+	for i := 0; i < n; i++ {
+		select {
+		case err := <-errChan:
+			if err != nil {
+				t.Fatal(err)
+			}
+
+		case <-time.After(time.Second):
+			t.Fatalf("task %d was not processed in time", i)
+		}
+	}
+}
+
+func pullSequntial(t *testing.T, n int, errChan chan error, semChan chan struct{}) {
+	t.Helper()
+
+	for i := 0; i < n; i++ {
+		// Signal for another task to unblock.
+		select {
+		case semChan <- struct{}{}:
+		case <-time.After(time.Second):
+			t.Fatalf("task %d was not unblocked", i)
+		}
+
+		// Wait for the error to arrive, we expect it to be non-nil.
+		select {
+		case err := <-errChan:
+			if err != nil {
+				t.Fatal(err)
+			}
+
+		case <-time.After(time.Second):
+			t.Fatalf("task %d was not processed in time", i)
+		}
+	}
+}
+
+func startGeneric(t *testing.T, p interface{}) {
+	t.Helper()
+
+	var err error
+	switch pp := p.(type) {
+	case *pool.Write:
+		err = pp.Start()
+
+	case *pool.Read:
+		err = pp.Start()
+
+	default:
+		t.Fatalf("unknown worker pool type: %T", p)
+	}
+
+	if err != nil {
+		t.Fatalf("unable to start worker pool: %v", err)
+	}
+}
+
+func stopGeneric(t *testing.T, p interface{}) {
+	t.Helper()
+
+	var err error
+	switch pp := p.(type) {
+	case *pool.Write:
+		err = pp.Stop()
+
+	case *pool.Read:
+		err = pp.Stop()
+
+	default:
+		t.Fatalf("unknown worker pool type: %T", p)
+	}
+
+	if err != nil {
+		t.Fatalf("unable to stop worker pool: %v", err)
+	}
+}
+
+func submitGeneric(p interface{}, sem <-chan struct{}) error {
+	var err error
+	switch pp := p.(type) {
+	case *pool.Write:
+		err = pp.Submit(func(buf *bytes.Buffer) error {
+			// Verify that the provided buffer has been reset to be
+			// zero length.
+			if buf.Len() != 0 {
+				return fmt.Errorf("buf should be length zero, "+
+					"instead has length %d", buf.Len())
+			}
+
+			// Verify that the capacity of the buffer has the
+			// correct underlying size of a buffer.WriteSize.
+			if buf.Cap() != buffer.WriteSize {
+				return fmt.Errorf("buf should have capacity "+
+					"%d, instead has capacity %d",
+					buffer.WriteSize, buf.Cap())
+			}
+
+			// Sample some random bytes that we'll use to dirty the
+			// buffer.
+			b := make([]byte, rand.Intn(buf.Cap()))
+			_, err := io.ReadFull(crand.Reader, b)
+			if err != nil {
+				return err
+			}
+
+			// Write the random bytes the buffer.
+			_, err = buf.Write(b)
+
+			// Wait until this task is signaled to exit.
+			<-sem
+
+			return err
+		})
+
+	case *pool.Read:
+		err = pp.Submit(func(buf *buffer.Read) error {
+			// Assert that all of the bytes in the provided array
+			// are zero, indicating that the buffer was reset
+			// between uses.
+			for i := range buf[:] {
+				if buf[i] != 0x00 {
+					return fmt.Errorf("byte %d of "+
+						"buffer.Read should be "+
+						"0, instead is %d", i, buf[i])
+				}
+			}
+
+			// Sample some random bytes to read into the buffer.
+			_, err := io.ReadFull(crand.Reader, buf[:])
+
+			// Wait until this task is signaled to exit.
+			<-sem
+
+			return err
+
+		})
+
+	default:
+		return fmt.Errorf("unknown worker pool type: %T", p)
+	}
+
+	if err != nil {
+		return fmt.Errorf("unable to submit task: %v", err)
+	}
+
+	return nil
+}

--- a/pool/write.go
+++ b/pool/write.go
@@ -1,0 +1,100 @@
+package pool
+
+import (
+	"bytes"
+	"time"
+
+	"github.com/lightningnetwork/lnd/buffer"
+)
+
+// Write is a worker pool specifically designed for sharing access to
+// buffer.Write objects amongst a set of worker goroutines. This enables an
+// application to limit the total number of buffer.Write objects allocated at
+// any given time.
+type Write struct {
+	workerPool *Worker
+	bufferPool *WriteBuffer
+}
+
+// NewWrite creates a Write pool, using an underlying Writebuffer pool to
+// recycle buffer.Write objects accross the lifetime of the Write pool's
+// workers.
+func NewWrite(writeBufferPool *WriteBuffer, numWorkers int,
+	workerTimeout time.Duration) *Write {
+
+	w := &Write{
+		bufferPool: writeBufferPool,
+	}
+	w.workerPool = NewWorker(&WorkerConfig{
+		NewWorkerState: w.newWorkerState,
+		NumWorkers:     numWorkers,
+		WorkerTimeout:  workerTimeout,
+	})
+
+	return w
+}
+
+// Start safely spins up the Write pool.
+func (w *Write) Start() error {
+	return w.workerPool.Start()
+}
+
+// Stop safely shuts down the Write pool.
+func (w *Write) Stop() error {
+	return w.workerPool.Stop()
+}
+
+// Submit accepts a function closure that provides access to a fresh
+// bytes.Buffer backed by a buffer.Write object. The function's execution will
+// be allocated to one of the underlying Worker pool's goroutines.
+func (w *Write) Submit(inner func(*bytes.Buffer) error) error {
+	return w.workerPool.Submit(func(s WorkerState) error {
+		state := s.(*writeWorkerState)
+		return inner(state.buf)
+	})
+}
+
+// writeWorkerState is the per-goroutine state maintained by a Write pool's
+// goroutines.
+type writeWorkerState struct {
+	// bufferPool is the pool to which the writeBuf will be returned when
+	// the goroutine exits.
+	bufferPool *WriteBuffer
+
+	// writeBuf is the buffer taken from the bufferPool on initialization,
+	// which will be used to back the buf object provided to any tasks that
+	// the goroutine processes before exiting.
+	writeBuf *buffer.Write
+
+	// buf is a buffer backed by writeBuf, that can be written to by tasks
+	// submitted to the Write pool. The buf will be reset between each task
+	// processed by a goroutine before exiting, and allows the task
+	// submitters to interact with the writeBuf as if it were an io.Writer.
+	buf *bytes.Buffer
+}
+
+// newWorkerState initializes a new writeWorkerState, which will be called
+// whenever a new goroutine is allocated to begin processing write tasks.
+func (w *Write) newWorkerState() WorkerState {
+	writeBuf := w.bufferPool.Take()
+
+	return &writeWorkerState{
+		bufferPool: w.bufferPool,
+		writeBuf:   writeBuf,
+		buf:        bytes.NewBuffer(writeBuf[0:0:len(writeBuf)]),
+	}
+}
+
+// Cleanup returns the writeBuf to the underlying buffer pool, and removes the
+// goroutine's reference to the readBuf and encapsulating buf.
+func (w *writeWorkerState) Cleanup() {
+	w.bufferPool.Return(w.writeBuf)
+	w.writeBuf = nil
+	w.buf = nil
+}
+
+// Reset resets the bytes.Buffer so that it is zero-length and has the capacity
+// of the underlying buffer.Write.k
+func (w *writeWorkerState) Reset() {
+	w.buf.Reset()
+}


### PR DESCRIPTION
This PR is a follow up to #2419 and #2385, introducing an `lnpeer.WritePool` and `brontide.ReadPool`.  Requests to read/write messages are submitted to the respective pool, which maintains a set of workers that handle the encoding/decoding. This builds on the prior PRs, since each pool is backed by a `lnpeer.WriteBufferPool` and `brontide.ReadBufferPool`, ensuring that buffer used in each are efficiently reused before being returned to the runtime. 

With #2419 and #2385, the total memory that will be allocated is linear in the number of peers/connections maintained by the daemon. With the read and write pools, we modify that to be at most linear in the _number of specified workers_. More importantly, these changes completely decouple read and write buffer allocations from the peer/connection lifecycle, allowing LND to tolerate flapping peers with minimal overhead.

Nodes that have a large number of peers will see the most drastic benefit. In testing, I was able to connect (w/o gossip queries) to nearly 900 unique nodes, all while keeping LNDs total memory under 15 MB. This configuration could have easily connected to more nodes, though that was all that reachable via the bootstrapper.

This same test used between 90-100MB on master, and continues to grow as more connections are established. In contrast, the memory used with read/write pools remains constant even as more peers are added.

Note that of the 15MB, only about 1MB is actually from the read/write pools, the remaining overhead is created by other subsystems operating in LND, and is reflected in both measurements. Coupled with more efficient recycling of unused buffers, I'd expect the reduction in memory related to read/write buffers to be one or two orders of magnitude for most nodes.

Depends on:
 - [x] #2385 
 - [x] #2419
