### PR TITLE
lnwallet+interface_test: Returning destination addresses of Unconfirmed Transactions

### DIFF
--- a/lnwallet/btcwallet/btcwallet.go
+++ b/lnwallet/btcwallet/btcwallet.go
@@ -554,10 +554,8 @@ func minedTransactionsToDetails(
 
 // unminedTransactionsToDetail is a helper function which converts a summary
 // for an unconfirmed transaction to a transaction detail.
-func unminedTransactionsToDetail(
-	summary base.TransactionSummary,
-) (*lnwallet.TransactionDetail, error) {
-
+func unminedTransactionsToDetail(summary base.TransactionSummary,
+	chainParams *chaincfg.Params) (*lnwallet.TransactionDetail, error) {
 	wireTx := &wire.MsgTx{}
 	txReader := bytes.NewReader(summary.Transaction)
 
@@ -565,11 +563,25 @@ func unminedTransactionsToDetail(
 		return nil, err
 	}
 
+	// Iterate over all the transaction outputs and extract the Public Key
+	// of the destination address.
+	var destAddresses []btcutil.Address
+	for _, txOut := range wireTx.TxOut {
+		_, outAddresses, _, err := txscript.ExtractPkScriptAddrs(
+			txOut.PkScript, chainParams,
+		)
+		if err != nil {
+			return nil, err
+		}
+
+		destAddresses = append(destAddresses, outAddresses...)
+	}
+
 	txDetail := &lnwallet.TransactionDetail{
-		Hash:      *summary.Hash,
-		TotalFees: int64(summary.Fee),
-		Timestamp: summary.Timestamp,
-		RawTx:     summary.Transaction,
+		Hash:          *summary.Hash,
+		TotalFees:     int64(summary.Fee),
+		Timestamp:     summary.Timestamp,
+		DestAddresses: destAddresses,
 	}
 
 	balanceDelta, err := extractBalanceDelta(summary, wireTx)
@@ -618,7 +630,7 @@ func (b *BtcWallet) ListTransactionDetails() ([]*lnwallet.TransactionDetail, err
 		txDetails = append(txDetails, details...)
 	}
 	for _, tx := range txns.UnminedTransactions {
-		detail, err := unminedTransactionsToDetail(tx)
+		detail, err := unminedTransactionsToDetail(tx, b.netParams)
 		if err != nil {
 			return nil, err
 		}
@@ -705,7 +717,9 @@ out:
 			// notifications for any newly unconfirmed transactions.
 			go func() {
 				for _, tx := range txNtfn.UnminedTransactions {
-					detail, err := unminedTransactionsToDetail(tx)
+					detail, err := unminedTransactionsToDetail(
+						tx, t.w.ChainParams(),
+					)
 					if err != nil {
 						continue
 					}

--- a/lnwallet/interface_test.go
+++ b/lnwallet/interface_test.go
@@ -1181,9 +1181,11 @@ func testListTransactionDetails(miner *rpctest.Harness,
 
 	// Next create a transaction paying to an output which isn't under the
 	// wallet's control.
-	b := txscript.NewScriptBuilder()
-	b.AddOp(txscript.OP_0)
-	outputScript, err := b.Script()
+	minerAddr, err := miner.NewAddress()
+	if err != nil {
+		t.Fatalf("unable to generate addrress: %v", err)
+	}
+	outputScript, err := txscript.PayToAddrScript(minerAddr)
 	if err != nil {
 		t.Fatalf("unable to make output script: %v", err)
 	}
@@ -1226,6 +1228,20 @@ func testListTransactionDetails(miner *rpctest.Harness,
 		if txDetail.NumConfirmations != 0 {
 			t.Fatalf("num confs incorrect, got %v expected %v",
 				txDetail.NumConfirmations, 0)
+		}
+
+		// We test that each txDetail has destination addresses. This ensures
+		// that even when we have 0 confirmation transactions, the destination
+		// addresses are returned.
+		var match bool
+		for _, addr := range txDetail.DestAddresses {
+			if addr.String() == minerAddr.String() {
+				match = true
+				break
+			}
+		}
+		if match != true {
+			t.Fatalf("minerAddr: %v should have been a dest addr", minerAddr)
 		}
 	}
 	if !mempoolTxFound {


### PR DESCRIPTION
fixes #2442 

This PR refactors the helper function `unminedTransactionsToDetail` to return the destination addresses of unconfirmed transactions from the transaction summary.