### PR TITLE
server: require the DLP bit for all incoming/outgoing connections

### DIFF
--- a/server.go
+++ b/server.go
@@ -2368,7 +2368,7 @@ func (s *server) peerConnected(conn net.Conn, connReq *connmgr.ConnReq,
 
 	// We'll signal that we understand the data loss protection feature,
 	// and also that we support the new gossip query features.
-	localFeatures.Set(lnwire.DataLossProtectOptional)
+	localFeatures.Set(lnwire.DataLossProtectRequired)
 	localFeatures.Set(lnwire.GossipQueriesOptional)
 
 	// Now that we've established a connection, create a peer, and it to


### PR DESCRIPTION
In this commit, we modify our default local feature bits to require the
Data Loss Protection (DLP) feature to be active. Once full Static
Channel Backups are implemented, if we connect to a peer that doesn't
follow the DLP protocol, then the SCBs are useless, as we may not be
able to recover funds. As a result, in prep for full SCB deployment,
we'll now ensure that any peer we connect to, knows of the DLP bit. This
could be a bit more relaxed and allow _connections_ to non-DLP peers,
but reject channel requests to/from them. However, this implementation is
much simpler.

