### PR TITLE
htlcswitch: batch preimage writes/consistency fix

### DIFF
--- a/breacharbiter_test.go
+++ b/breacharbiter_test.go
@@ -1548,10 +1548,7 @@ func createInitChannels(revocationWindow int) (*lnwallet.LightningChannel, *lnwa
 		Packager:                channeldb.NewChannelPackager(shortChanID),
 	}
 
-	pCache := &mockPreimageCache{
-		// hash -> preimage
-		preimageMap: make(map[[32]byte][]byte),
-	}
+	pCache := newMockPreimageCache()
 
 	aliceSigner := &mockSigner{aliceKeyPriv}
 	bobSigner := &mockSigner{bobKeyPriv}

--- a/channeldb/witness_cache_test.go
+++ b/channeldb/witness_cache_test.go
@@ -25,7 +25,7 @@ func TestWitnessCacheRetrieval(t *testing.T) {
 	witnessKey := sha256.Sum256(witness)
 
 	// First, we'll attempt to add the witness to the database.
-	err = wCache.AddWitness(Sha256HashWitness, witness)
+	err = wCache.AddWitnesses(Sha256HashWitness, witness)
 	if err != nil {
 		t.Fatalf("unable to add witness: %v", err)
 	}
@@ -59,13 +59,13 @@ func TestWitnessCacheDeletion(t *testing.T) {
 	// We'll start by adding two witnesses to the cache.
 	witness1 := rev[:]
 	witness1Key := sha256.Sum256(witness1)
-	if err := wCache.AddWitness(Sha256HashWitness, witness1); err != nil {
+	if err := wCache.AddWitnesses(Sha256HashWitness, witness1); err != nil {
 		t.Fatalf("unable to add witness: %v", err)
 	}
 
 	witness2 := key[:]
 	witness2Key := sha256.Sum256(witness2)
-	if err := wCache.AddWitness(Sha256HashWitness, witness2); err != nil {
+	if err := wCache.AddWitnesses(Sha256HashWitness, witness2); err != nil {
 		t.Fatalf("unable to add witness: %v", err)
 	}
 
@@ -107,7 +107,7 @@ func TestWitnessCacheUnknownWitness(t *testing.T) {
 
 	// We'll attempt to add a new, undefined witness type to the database.
 	// We should get an error.
-	err = wCache.AddWitness(234, key[:])
+	err = wCache.AddWitnesses(234, key[:])
 	if err != ErrUnknownWitnessType {
 		t.Fatalf("expected ErrUnknownWitnessType, got %v", err)
 	}

--- a/channeldb/witness_cache_test.go
+++ b/channeldb/witness_cache_test.go
@@ -19,27 +19,38 @@ func TestWitnessCacheRetrieval(t *testing.T) {
 
 	wCache := cdb.NewWitnessCache()
 
-	// We'll be attempting to add then lookup a d simple hash witness
+	// We'll be attempting to add then lookup two simple hash witnesses
 	// within this test.
-	witness := rev[:]
-	witnessKey := sha256.Sum256(witness)
+	witness1 := rev[:]
+	witness1Key := sha256.Sum256(witness1)
 
-	// First, we'll attempt to add the witness to the database.
-	err = wCache.AddWitnesses(Sha256HashWitness, witness)
+	witness2 := key[:]
+	witness2Key := sha256.Sum256(witness2)
+
+	witnesses := [][]byte{witness1, witness2}
+	keys := [][]byte{witness1Key[:], witness2Key[:]}
+
+	// First, we'll attempt to add the witnesses to the database.
+	err = wCache.AddWitnesses(Sha256HashWitness, witnesses...)
 	if err != nil {
 		t.Fatalf("unable to add witness: %v", err)
 	}
 
-	// With the witness stored, we'll now attempt to look it up. We should
-	// get back the *exact* same witness as we originally stored.
-	dbWitness, err := wCache.LookupWitness(Sha256HashWitness, witnessKey[:])
-	if err != nil {
-		t.Fatalf("unable to look up witness: %v", err)
-	}
+	// With the witnesses stored, we'll now attempt to look them up.
+	for i, key := range keys {
+		witness := witnesses[i]
 
-	if !reflect.DeepEqual(witness, dbWitness[:]) {
-		t.Fatalf("witnesses don't match: expected %x, got %x",
-			witness[:], dbWitness[:])
+		// We should get back the *exact* same witness as we originally
+		// stored.
+		dbWitness, err := wCache.LookupWitness(Sha256HashWitness, key)
+		if err != nil {
+			t.Fatalf("unable to look up witness: %v", err)
+		}
+
+		if !reflect.DeepEqual(witness, dbWitness[:]) {
+			t.Fatalf("witnesses don't match: expected %x, got %x",
+				witness[:], dbWitness[:])
+		}
 	}
 }
 
@@ -59,12 +70,14 @@ func TestWitnessCacheDeletion(t *testing.T) {
 	// We'll start by adding two witnesses to the cache.
 	witness1 := rev[:]
 	witness1Key := sha256.Sum256(witness1)
+
 	if err := wCache.AddWitnesses(Sha256HashWitness, witness1); err != nil {
 		t.Fatalf("unable to add witness: %v", err)
 	}
 
 	witness2 := key[:]
 	witness2Key := sha256.Sum256(witness2)
+
 	if err := wCache.AddWitnesses(Sha256HashWitness, witness2); err != nil {
 		t.Fatalf("unable to add witness: %v", err)
 	}

--- a/channeldb/witness_cache_test.go
+++ b/channeldb/witness_cache_test.go
@@ -1,17 +1,15 @@
 package channeldb
 
 import (
-	"bytes"
 	"crypto/sha256"
-	"reflect"
 	"testing"
 
 	"github.com/lightningnetwork/lnd/lntypes"
 )
 
-// TestWitnessCacheRetrieval tests that we're able to add and lookup new
-// witnesses to the witness cache.
-func TestWitnessCacheRetrieval(t *testing.T) {
+// TestWitnessCacheSha256Retrieval tests that we're able to add and lookup new
+// sha256 preimages to the witness cache.
+func TestWitnessCacheSha256Retrieval(t *testing.T) {
 	t.Parallel()
 
 	cdb, cleanUp, err := makeTestDB()
@@ -22,44 +20,41 @@ func TestWitnessCacheRetrieval(t *testing.T) {
 
 	wCache := cdb.NewWitnessCache()
 
-	// We'll be attempting to add then lookup two simple hash witnesses
+	// We'll be attempting to add then lookup two simple sha256 preimages
 	// within this test.
-	witness1 := rev[:]
-	witness1Key := sha256.Sum256(witness1)
+	preimage1 := lntypes.Preimage(rev)
+	preimage2 := lntypes.Preimage(key)
 
-	witness2 := key[:]
-	witness2Key := sha256.Sum256(witness2)
+	preimages := []lntypes.Preimage{preimage1, preimage2}
+	hashes := []lntypes.Hash{preimage1.Hash(), preimage2.Hash()}
 
-	witnesses := [][]byte{witness1, witness2}
-	keys := [][]byte{witness1Key[:], witness2Key[:]}
-
-	// First, we'll attempt to add the witnesses to the database.
-	err = wCache.AddWitnesses(Sha256HashWitness, witnesses...)
+	// First, we'll attempt to add the preimages to the database.
+	err = wCache.AddSha256Witnesses(preimages...)
 	if err != nil {
 		t.Fatalf("unable to add witness: %v", err)
 	}
 
-	// With the witnesses stored, we'll now attempt to look them up.
-	for i, key := range keys {
-		witness := witnesses[i]
+	// With the preimages stored, we'll now attempt to look them up.
+	for i, hash := range hashes {
+		preimage := preimages[i]
 
-		// We should get back the *exact* same witness as we originally
+		// We should get back the *exact* same preimage as we originally
 		// stored.
-		dbWitness, err := wCache.LookupWitness(Sha256HashWitness, key)
+		dbPreimage, err := wCache.LookupSha256Witness(hash)
 		if err != nil {
 			t.Fatalf("unable to look up witness: %v", err)
 		}
 
-		if !reflect.DeepEqual(witness, dbWitness[:]) {
+		if preimage != dbPreimage {
 			t.Fatalf("witnesses don't match: expected %x, got %x",
-				witness[:], dbWitness[:])
+				preimage[:], dbPreimage[:])
 		}
 	}
 }
 
-// TestWitnessCacheDeletion tests that we're able to delete a single witness,
-// and also a class of witnesses from the cache.
-func TestWitnessCacheDeletion(t *testing.T) {
+// TestWitnessCacheSha256Deletion tests that we're able to delete a single
+// sha256 preimage, and also a class of witnesses from the cache.
+func TestWitnessCacheSha256Deletion(t *testing.T) {
 	t.Parallel()
 
 	cdb, cleanUp, err := makeTestDB()
@@ -70,39 +65,39 @@ func TestWitnessCacheDeletion(t *testing.T) {
 
 	wCache := cdb.NewWitnessCache()
 
-	// We'll start by adding two witnesses to the cache.
-	witness1 := rev[:]
-	witness1Key := sha256.Sum256(witness1)
+	// We'll start by adding two preimages to the cache.
+	preimage1 := lntypes.Preimage(key)
+	hash1 := preimage1.Hash()
 
-	if err := wCache.AddWitnesses(Sha256HashWitness, witness1); err != nil {
+	preimage2 := lntypes.Preimage(rev)
+	hash2 := preimage2.Hash()
+
+	if err := wCache.AddSha256Witnesses(preimage1); err != nil {
 		t.Fatalf("unable to add witness: %v", err)
 	}
 
-	witness2 := key[:]
-	witness2Key := sha256.Sum256(witness2)
-
-	if err := wCache.AddWitnesses(Sha256HashWitness, witness2); err != nil {
+	if err := wCache.AddSha256Witnesses(preimage2); err != nil {
 		t.Fatalf("unable to add witness: %v", err)
 	}
 
-	// We'll now delete the first witness. If we attempt to look it up, we
+	// We'll now delete the first preimage. If we attempt to look it up, we
 	// should get ErrNoWitnesses.
-	err = wCache.DeleteWitness(Sha256HashWitness, witness1Key[:])
+	err = wCache.DeleteSha256Witness(hash1)
 	if err != nil {
 		t.Fatalf("unable to delete witness: %v", err)
 	}
-	_, err = wCache.LookupWitness(Sha256HashWitness, witness1Key[:])
+	_, err = wCache.LookupSha256Witness(hash1)
 	if err != ErrNoWitnesses {
 		t.Fatalf("expected ErrNoWitnesses instead got: %v", err)
 	}
 
 	// Next, we'll attempt to delete the entire witness class itself. When
-	// we try to lookup the second witness, we should again get
+	// we try to lookup the second preimage, we should again get
 	// ErrNoWitnesses.
 	if err := wCache.DeleteWitnessClass(Sha256HashWitness); err != nil {
 		t.Fatalf("unable to delete witness class: %v", err)
 	}
-	_, err = wCache.LookupWitness(Sha256HashWitness, witness2Key[:])
+	_, err = wCache.LookupSha256Witness(hash2)
 	if err != ErrNoWitnesses {
 		t.Fatalf("expected ErrNoWitnesses instead got: %v", err)
 	}
@@ -123,7 +118,7 @@ func TestWitnessCacheUnknownWitness(t *testing.T) {
 
 	// We'll attempt to add a new, undefined witness type to the database.
 	// We should get an error.
-	err = wCache.AddWitnesses(234, key[:])
+	err = wCache.legacyAddWitnesses(234, key[:])
 	if err != ErrUnknownWitnessType {
 		t.Fatalf("expected ErrUnknownWitnessType, got %v", err)
 	}
@@ -143,41 +138,41 @@ func TestAddSha256Witnesses(t *testing.T) {
 	// We'll start by adding a witnesses to the cache using the generic
 	// AddWitnesses method.
 	witness1 := rev[:]
-	witness1Key := sha256.Sum256(witness1)
+	preimage1 := lntypes.Preimage(rev)
+	hash1 := preimage1.Hash()
 
 	witness2 := key[:]
-	witness2Key := sha256.Sum256(witness2)
+	preimage2 := lntypes.Preimage(key)
+	hash2 := preimage2.Hash()
 
 	var (
-		preimages = []lntypes.Preimage{rev, key}
 		witnesses = [][]byte{witness1, witness2}
-		keys      = [][]byte{witness1Key[:], witness2Key[:]}
+		preimages = []lntypes.Preimage{preimage1, preimage2}
+		hashes    = []lntypes.Hash{hash1, hash2}
 	)
 
-	err = wCache.AddWitnesses(Sha256HashWitness, witnesses...)
+	err = wCache.legacyAddWitnesses(Sha256HashWitness, witnesses...)
 	if err != nil {
 		t.Fatalf("unable to add witness: %v", err)
 	}
 
-	for i, key := range keys {
-		witness := witnesses[i]
+	for i, hash := range hashes {
+		preimage := preimages[i]
 
-		dbWitness, err := wCache.LookupWitness(
-			Sha256HashWitness, key,
-		)
+		dbPreimage, err := wCache.LookupSha256Witness(hash)
 		if err != nil {
 			t.Fatalf("unable to lookup witness: %v", err)
 		}
 
 		// Assert that the retrieved witness matches the original.
-		if bytes.Compare(dbWitness, witness) != 0 {
+		if dbPreimage != preimage {
 			t.Fatalf("retrieved witness mismatch, want: %x, "+
-				"got: %x", witness, dbWitness)
+				"got: %x", preimage, dbPreimage)
 		}
 
 		// We'll now delete the witness, as we'll be reinserting it
 		// using the specialized AddSha256Witnesses method.
-		err = wCache.DeleteWitness(Sha256HashWitness, key)
+		err = wCache.DeleteSha256Witness(hash)
 		if err != nil {
 			t.Fatalf("unable to delete witness: %v", err)
 		}
@@ -193,20 +188,51 @@ func TestAddSha256Witnesses(t *testing.T) {
 	// Finally, iterate over the keys and assert that the returned witnesses
 	// match the original witnesses. This asserts that the specialized
 	// insertion method behaves identically to the generalized interface.
-	for i, key := range keys {
-		witness := witnesses[i]
+	for i, hash := range hashes {
+		preimage := preimages[i]
 
-		dbWitness, err := wCache.LookupWitness(
-			Sha256HashWitness, key,
-		)
+		dbPreimage, err := wCache.LookupSha256Witness(hash)
 		if err != nil {
 			t.Fatalf("unable to lookup witness: %v", err)
 		}
 
 		// Assert that the retrieved witness matches the original.
-		if bytes.Compare(dbWitness, witness) != 0 {
+		if dbPreimage != preimage {
 			t.Fatalf("retrieved witness mismatch, want: %x, "+
-				"got: %x", witness, dbWitness)
+				"got: %x", preimage, dbPreimage)
 		}
 	}
+}
+
+// legacyAddWitnesses adds a batch of new witnesses of wType to the witness
+// cache. The type of the witness will be used to map each witness to the key
+// that will be used to look it up. All witnesses should be of the same
+// WitnessType.
+//
+// NOTE: Previously this method exposed a generic interface for adding
+// witnesses, which has since been deprecated in favor of a strongly typed
+// interface for each witness class. We keep this method around to assert the
+// correctness of specialized witness adding methods.
+func (w *WitnessCache) legacyAddWitnesses(wType WitnessType,
+	witnesses ...[]byte) error {
+
+	// Optimistically compute the witness keys before attempting to start
+	// the db transaction.
+	entries := make([]witnessEntry, 0, len(witnesses))
+	for _, witness := range witnesses {
+		// Map each witness to its key by applying the appropriate
+		// transformation for the given witness type.
+		switch wType {
+		case Sha256HashWitness:
+			key := sha256.Sum256(witness)
+			entries = append(entries, witnessEntry{
+				key:     key[:],
+				witness: witness,
+			})
+		default:
+			return ErrUnknownWitnessType
+		}
+	}
+
+	return w.addWitnessEntries(wType, entries)
 }

--- a/contractcourt/channel_arbitrator.go
+++ b/contractcourt/channel_arbitrator.go
@@ -64,8 +64,10 @@ type WitnessBeacon interface {
 	// True is returned for the second argument if the preimage is found.
 	LookupPreimage(payhash []byte) ([]byte, bool)
 
-	// AddPreImage adds a newly discovered preimage to the global cache.
-	AddPreimage(pre []byte) error
+	// AddPreimages adds a batch of newly discovered preimages to the global
+	// cache, and also signals any subscribers of the newly discovered
+	// witness.
+	AddPreimages(preimages ...[]byte) error
 }
 
 // ChannelArbitratorConfig contains all the functionality that the

--- a/contractcourt/channel_arbitrator.go
+++ b/contractcourt/channel_arbitrator.go
@@ -11,6 +11,7 @@ import (
 	"github.com/davecgh/go-spew/spew"
 	"github.com/lightningnetwork/lnd/chainntnfs"
 	"github.com/lightningnetwork/lnd/channeldb"
+	"github.com/lightningnetwork/lnd/lntypes"
 	"github.com/lightningnetwork/lnd/lnwallet"
 	"github.com/lightningnetwork/lnd/lnwire"
 )
@@ -40,7 +41,7 @@ type WitnessSubscription struct {
 	// sent over.
 	//
 	// TODO(roasbeef): couple with WitnessType?
-	WitnessUpdates <-chan []byte
+	WitnessUpdates <-chan lntypes.Preimage
 
 	// CancelSubscription is a function closure that should be used by a
 	// client to cancel the subscription once they are no longer interested
@@ -62,12 +63,12 @@ type WitnessBeacon interface {
 
 	// LookupPreImage attempts to lookup a preimage in the global cache.
 	// True is returned for the second argument if the preimage is found.
-	LookupPreimage(payhash []byte) ([]byte, bool)
+	LookupPreimage(payhash lntypes.Hash) (lntypes.Preimage, bool)
 
 	// AddPreimages adds a batch of newly discovered preimages to the global
 	// cache, and also signals any subscribers of the newly discovered
 	// witness.
-	AddPreimages(preimages ...[]byte) error
+	AddPreimages(preimages ...lntypes.Preimage) error
 }
 
 // ChannelArbitratorConfig contains all the functionality that the
@@ -1129,7 +1130,7 @@ func (c *ChannelArbitrator) checkChainActions(height uint32,
 		// know the pre-image and it's close to timing out. We need to
 		// ensure that we claim the funds that our rightfully ours
 		// on-chain.
-		if _, ok := c.cfg.PreimageDB.LookupPreimage(htlc.RHash[:]); !ok {
+		if _, ok := c.cfg.PreimageDB.LookupPreimage(htlc.RHash); !ok {
 			continue
 		}
 		haveChainActions = haveChainActions || c.shouldGoOnChain(
@@ -1206,13 +1207,12 @@ func (c *ChannelArbitrator) checkChainActions(height uint32,
 	// either learn of it eventually from the outgoing HTLC, or the sender
 	// will timeout the HTLC.
 	for _, htlc := range c.activeHTLCs.incomingHTLCs {
-		payHash := htlc.RHash
-
 		// If we have the pre-image, then we should go on-chain to
 		// redeem the HTLC immediately.
-		if _, ok := c.cfg.PreimageDB.LookupPreimage(payHash[:]); ok {
+		if _, ok := c.cfg.PreimageDB.LookupPreimage(htlc.RHash); ok {
 			log.Tracef("ChannelArbitrator(%v): preimage for "+
-				"htlc=%x is known!", c.cfg.ChanPoint, payHash[:])
+				"htlc=%x is known!", c.cfg.ChanPoint,
+				htlc.RHash[:])
 
 			actionMap[HtlcClaimAction] = append(
 				actionMap[HtlcClaimAction], htlc,
@@ -1222,7 +1222,7 @@ func (c *ChannelArbitrator) checkChainActions(height uint32,
 
 		log.Tracef("ChannelArbitrator(%v): watching chain to decide "+
 			"action for incoming htlc=%x", c.cfg.ChanPoint,
-			payHash[:])
+			htlc.RHash[:])
 
 		// Otherwise, we don't yet have the pre-image, but should watch
 		// on-chain to see if either: the remote party times out the

--- a/contractcourt/htlc_outgoing_contest_resolver.go
+++ b/contractcourt/htlc_outgoing_contest_resolver.go
@@ -79,7 +79,7 @@ func (h *htlcOutgoingContestResolver) Resolve() (ContractResolver, error) {
 
 		// With the preimage obtained, we can now add it to the global
 		// cache.
-		if err := h.PreimageDB.AddPreimage(preimage[:]); err != nil {
+		if err := h.PreimageDB.AddPreimages(preimage[:]); err != nil {
 			log.Errorf("%T(%v): unable to add witness to cache",
 				h, h.htlcResolution.ClaimOutpoint)
 		}

--- a/contractcourt/htlc_success_resolver.go
+++ b/contractcourt/htlc_success_resolver.go
@@ -3,15 +3,16 @@ package contractcourt
 import (
 	"encoding/binary"
 	"fmt"
-	"github.com/lightningnetwork/lnd/input"
 	"io"
-
-	"github.com/lightningnetwork/lnd/channeldb"
-	"github.com/lightningnetwork/lnd/lnwire"
 
 	"github.com/btcsuite/btcd/wire"
 	"github.com/davecgh/go-spew/spew"
+
+	"github.com/lightningnetwork/lnd/channeldb"
+	"github.com/lightningnetwork/lnd/input"
+	"github.com/lightningnetwork/lnd/lntypes"
 	"github.com/lightningnetwork/lnd/lnwallet"
+	"github.com/lightningnetwork/lnd/lnwire"
 	"github.com/lightningnetwork/lnd/sweep"
 )
 
@@ -41,7 +42,7 @@ type htlcSuccessResolver struct {
 	broadcastHeight uint32
 
 	// payHash is the payment hash of the original HTLC extended to us.
-	payHash [32]byte
+	payHash lntypes.Hash
 
 	// sweepTx will be non-nil if we've already crafted a transaction to
 	// sweep a direct HTLC output. This is only a concern if we're sweeping

--- a/htlcswitch/link.go
+++ b/htlcswitch/link.go
@@ -1417,7 +1417,7 @@ func (l *channelLink) handleUpstreamMsg(msg lnwire.Message) {
 		// any contested contracts watched by any on-chain arbitrators
 		// can now sweep this HTLC on-chain.
 		go func() {
-			err := l.cfg.PreimageCache.AddPreimages(pre[:])
+			err := l.cfg.PreimageCache.AddPreimages(pre)
 			if err != nil {
 				l.errorf("unable to add preimage=%x to "+
 					"cache", pre[:])

--- a/htlcswitch/link.go
+++ b/htlcswitch/link.go
@@ -1417,7 +1417,7 @@ func (l *channelLink) handleUpstreamMsg(msg lnwire.Message) {
 		// any contested contracts watched by any on-chain arbitrators
 		// can now sweep this HTLC on-chain.
 		go func() {
-			err := l.cfg.PreimageCache.AddPreimage(pre[:])
+			err := l.cfg.PreimageCache.AddPreimages(pre[:])
 			if err != nil {
 				l.errorf("unable to add preimage=%x to "+
 					"cache", pre[:])

--- a/htlcswitch/link_test.go
+++ b/htlcswitch/link_test.go
@@ -1532,10 +1532,7 @@ func newSingleLinkTestHarness(chanAmt, chanReserve btcutil.Amount) (
 		invoiceRegistry = newMockRegistry(globalPolicy.TimeLockDelta)
 	)
 
-	pCache := &mockPreimageCache{
-		// hash -> preimage
-		preimageMap: make(map[[32]byte][]byte),
-	}
+	pCache := newMockPreimageCache()
 
 	aliceDb := aliceChannel.State().Db
 	aliceSwitch, err := initSwitchWithDB(testStartingHeight, aliceDb)
@@ -4042,10 +4039,7 @@ func restartLink(aliceChannel *lnwallet.LightningChannel, aliceSwitch *Switch,
 
 		invoiceRegistry = newMockRegistry(globalPolicy.TimeLockDelta)
 
-		pCache = &mockPreimageCache{
-			// hash -> preimage
-			preimageMap: make(map[[32]byte][]byte),
-		}
+		pCache = newMockPreimageCache()
 	)
 
 	aliceDb := aliceChannel.State().Db

--- a/htlcswitch/mock.go
+++ b/htlcswitch/mock.go
@@ -32,26 +32,31 @@ import (
 
 type mockPreimageCache struct {
 	sync.Mutex
-	preimageMap map[[32]byte][]byte
+	preimageMap map[lntypes.Hash]lntypes.Preimage
 }
 
-func (m *mockPreimageCache) LookupPreimage(hash []byte) ([]byte, bool) {
+func newMockPreimageCache() *mockPreimageCache {
+	return &mockPreimageCache{
+		preimageMap: make(map[lntypes.Hash]lntypes.Preimage),
+	}
+}
+
+func (m *mockPreimageCache) LookupPreimage(
+	hash lntypes.Hash) (lntypes.Preimage, bool) {
+
 	m.Lock()
 	defer m.Unlock()
 
-	var h [32]byte
-	copy(h[:], hash)
-
-	p, ok := m.preimageMap[h]
+	p, ok := m.preimageMap[hash]
 	return p, ok
 }
 
-func (m *mockPreimageCache) AddPreimages(preimages ...[]byte) error {
+func (m *mockPreimageCache) AddPreimages(preimages ...lntypes.Preimage) error {
 	m.Lock()
 	defer m.Unlock()
 
 	for _, preimage := range preimages {
-		m.preimageMap[sha256.Sum256(preimage)] = preimage
+		m.preimageMap[preimage.Hash()] = preimage
 	}
 
 	return nil

--- a/htlcswitch/mock.go
+++ b/htlcswitch/mock.go
@@ -46,11 +46,13 @@ func (m *mockPreimageCache) LookupPreimage(hash []byte) ([]byte, bool) {
 	return p, ok
 }
 
-func (m *mockPreimageCache) AddPreimage(preimage []byte) error {
+func (m *mockPreimageCache) AddPreimages(preimages ...[]byte) error {
 	m.Lock()
 	defer m.Unlock()
 
-	m.preimageMap[sha256.Sum256(preimage[:])] = preimage
+	for _, preimage := range preimages {
+		m.preimageMap[sha256.Sum256(preimage)] = preimage
+	}
 
 	return nil
 }

--- a/htlcswitch/test_utils.go
+++ b/htlcswitch/test_utils.go
@@ -367,10 +367,7 @@ func createTestChannel(alicePrivKey, bobPrivKey []byte,
 	aliceSigner := &mockSigner{aliceKeyPriv}
 	bobSigner := &mockSigner{bobKeyPriv}
 
-	pCache := &mockPreimageCache{
-		// hash -> preimage
-		preimageMap: make(map[[32]byte][]byte),
-	}
+	pCache := newMockPreimageCache()
 
 	alicePool := lnwallet.NewSigPool(runtime.NumCPU(), aliceSigner)
 	channelAlice, err := lnwallet.NewLightningChannel(
@@ -982,10 +979,7 @@ type hopNetwork struct {
 func newHopNetwork() *hopNetwork {
 	defaultDelta := uint32(6)
 
-	pCache := &mockPreimageCache{
-		// hash -> preimage
-		preimageMap: make(map[[32]byte][]byte),
-	}
+	pCache := newMockPreimageCache()
 
 	globalPolicy := ForwardingPolicy{
 		MinHTLC:       lnwire.NewMSatFromSatoshis(5),

--- a/invoices/invoiceregistry.go
+++ b/invoices/invoiceregistry.go
@@ -23,7 +23,7 @@ var (
 	// All nodes initialized with the flag active will immediately settle
 	// any incoming HTLC whose rHash corresponds with the debug
 	// preimage.
-	DebugPre, _ = lntypes.NewPreimage(bytes.Repeat([]byte{1}, 32))
+	DebugPre, _ = lntypes.MakePreimage(bytes.Repeat([]byte{1}, 32))
 
 	// DebugHash is the hash of the default preimage.
 	DebugHash = DebugPre.Hash()

--- a/lntypes/preimage.go
+++ b/lntypes/preimage.go
@@ -9,8 +9,8 @@ import (
 // PreimageSize of array used to store preimagees.
 const PreimageSize = 32
 
-// Preimage is used in several of the lightning messages and common structures. It
-// represents a payment preimage.
+// Preimage is used in several of the lightning messages and common structures.
+// It represents a payment preimage.
 type Preimage [PreimageSize]byte
 
 // String returns the Preimage as a hexadecimal string.
@@ -18,35 +18,35 @@ func (p Preimage) String() string {
 	return hex.EncodeToString(p[:])
 }
 
-// NewPreimage returns a new Preimage from a byte slice.  An error is returned if
-// the number of bytes passed in is not PreimageSize.
-func NewPreimage(newPreimage []byte) (*Preimage, error) {
+// MakePreimage returns a new Preimage from a bytes slice. An error is returned
+// if the number of bytes passed in is not PreimageSize.
+func MakePreimage(newPreimage []byte) (Preimage, error) {
 	nhlen := len(newPreimage)
 	if nhlen != PreimageSize {
-		return nil, fmt.Errorf("invalid preimage length of %v, want %v",
-			nhlen, PreimageSize)
+		return Preimage{}, fmt.Errorf("invalid preimage length of %v, "+
+			"want %v", nhlen, PreimageSize)
 	}
 
 	var preimage Preimage
 	copy(preimage[:], newPreimage)
 
-	return &preimage, nil
+	return preimage, nil
 }
 
-// NewPreimageFromStr creates a Preimage from a hex preimage string.
-func NewPreimageFromStr(newPreimage string) (*Preimage, error) {
+// MakePreimageFromStr creates a Preimage from a hex preimage string.
+func MakePreimageFromStr(newPreimage string) (Preimage, error) {
 	// Return error if preimage string is of incorrect length.
 	if len(newPreimage) != PreimageSize*2 {
-		return nil, fmt.Errorf("invalid preimage string length of %v, "+
-			"want %v", len(newPreimage), PreimageSize*2)
+		return Preimage{}, fmt.Errorf("invalid preimage string length "+
+			"of %v, want %v", len(newPreimage), PreimageSize*2)
 	}
 
 	preimage, err := hex.DecodeString(newPreimage)
 	if err != nil {
-		return nil, err
+		return Preimage{}, err
 	}
 
-	return NewPreimage(preimage)
+	return MakePreimage(preimage)
 }
 
 // Hash returns the sha256 hash of the preimage.

--- a/lnwallet/channel.go
+++ b/lnwallet/channel.go
@@ -5577,12 +5577,12 @@ func extractHtlcResolutions(feePerKw SatPerKWeight, ourCommit bool,
 			// We'll now query the preimage cache for the preimage
 			// for this HTLC. If it's present then we can fully
 			// populate this resolution.
-			preimage, _ := pCache.LookupPreimage(htlc.RHash[:])
+			preimage, _ := pCache.LookupPreimage(htlc.RHash)
 
 			// Otherwise, we'll create an incoming HTLC resolution
 			// as we can satisfy the contract.
 			var pre [32]byte
-			copy(pre[:], preimage)
+			copy(pre[:], preimage[:])
 			ihr, err := newIncomingHtlcResolution(
 				signer, localChanCfg, commitHash, &htlc, keyRing,
 				feePerKw, dustLimit, uint32(csvDelay), ourCommit,

--- a/lnwallet/channel_test.go
+++ b/lnwallet/channel_test.go
@@ -584,7 +584,7 @@ func TestForceClose(t *testing.T) {
 
 	// Before we force close Alice's channel, we'll add the pre-image of
 	// Bob's HTLC to her preimage cache.
-	aliceChannel.pCache.AddPreimage(preimageBob[:])
+	aliceChannel.pCache.AddPreimages(preimageBob[:])
 
 	// With the cache populated, we'll now attempt the force close
 	// initiated by Alice.
@@ -4953,7 +4953,7 @@ func TestChannelUnilateralCloseHtlcResolution(t *testing.T) {
 	// Now that Bob has force closed, we'll modify Alice's pre image cache
 	// such that she now gains the ability to also settle the incoming HTLC
 	// from Bob.
-	aliceChannel.pCache.AddPreimage(preimageBob[:])
+	aliceChannel.pCache.AddPreimages(preimageBob[:])
 
 	// We'll then use Bob's transaction to trigger a spend notification for
 	// Alice.

--- a/lnwallet/channel_test.go
+++ b/lnwallet/channel_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/lightningnetwork/lnd/chainntnfs"
 	"github.com/lightningnetwork/lnd/channeldb"
 	"github.com/lightningnetwork/lnd/input"
+	"github.com/lightningnetwork/lnd/lntypes"
 	"github.com/lightningnetwork/lnd/lnwire"
 )
 
@@ -584,7 +585,7 @@ func TestForceClose(t *testing.T) {
 
 	// Before we force close Alice's channel, we'll add the pre-image of
 	// Bob's HTLC to her preimage cache.
-	aliceChannel.pCache.AddPreimages(preimageBob[:])
+	aliceChannel.pCache.AddPreimages(lntypes.Preimage(preimageBob))
 
 	// With the cache populated, we'll now attempt the force close
 	// initiated by Alice.
@@ -4953,7 +4954,7 @@ func TestChannelUnilateralCloseHtlcResolution(t *testing.T) {
 	// Now that Bob has force closed, we'll modify Alice's pre image cache
 	// such that she now gains the ability to also settle the incoming HTLC
 	// from Bob.
-	aliceChannel.pCache.AddPreimages(preimageBob[:])
+	aliceChannel.pCache.AddPreimages(lntypes.Preimage(preimageBob))
 
 	// We'll then use Bob's transaction to trigger a spend notification for
 	// Alice.

--- a/lnwallet/interface.go
+++ b/lnwallet/interface.go
@@ -274,9 +274,13 @@ type PreimageCache interface {
 	// argument. Otherwise, it'll return false.
 	LookupPreimage(hash []byte) ([]byte, bool)
 
-	// AddPreimage attempts to add a new preimage to the global cache. If
-	// successful a nil error will be returned.
-	AddPreimage(preimage []byte) error
+	// AddPreimages adds a batch of newly discovered preimages to the global
+	// cache, and also signals any subscribers of the newly discovered
+	// witness.
+	//
+	// NOTE: The backing slice of MUST NOT be modified, otherwise the
+	// subscribers may be notified of the incorrect preimages.
+	AddPreimages(preimages ...[]byte) error
 }
 
 // WalletDriver represents a "driver" for a particular concrete

--- a/lnwallet/interface.go
+++ b/lnwallet/interface.go
@@ -9,6 +9,7 @@ import (
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcd/wire"
 	"github.com/btcsuite/btcutil"
+	"github.com/lightningnetwork/lnd/lntypes"
 )
 
 // AddressType is an enum-like type which denotes the possible address types
@@ -272,15 +273,12 @@ type PreimageCache interface {
 	// LookupPreimage attempts to look up a preimage according to its hash.
 	// If found, the preimage is returned along with true for the second
 	// argument. Otherwise, it'll return false.
-	LookupPreimage(hash []byte) ([]byte, bool)
+	LookupPreimage(hash lntypes.Hash) (lntypes.Preimage, bool)
 
 	// AddPreimages adds a batch of newly discovered preimages to the global
 	// cache, and also signals any subscribers of the newly discovered
 	// witness.
-	//
-	// NOTE: The backing slice of MUST NOT be modified, otherwise the
-	// subscribers may be notified of the incorrect preimages.
-	AddPreimages(preimages ...[]byte) error
+	AddPreimages(preimages ...lntypes.Preimage) error
 }
 
 // WalletDriver represents a "driver" for a particular concrete

--- a/lnwallet/test_utils.go
+++ b/lnwallet/test_utils.go
@@ -3,7 +3,6 @@ package lnwallet
 import (
 	"bytes"
 	"crypto/rand"
-	"crypto/sha256"
 	"encoding/binary"
 	"encoding/hex"
 	"io"
@@ -18,6 +17,7 @@ import (
 	"github.com/lightningnetwork/lnd/channeldb"
 	"github.com/lightningnetwork/lnd/input"
 	"github.com/lightningnetwork/lnd/keychain"
+	"github.com/lightningnetwork/lnd/lntypes"
 	"github.com/lightningnetwork/lnd/lnwire"
 	"github.com/lightningnetwork/lnd/shachain"
 )
@@ -301,10 +301,7 @@ func CreateTestChannels() (*LightningChannel, *LightningChannel, func(), error) 
 	aliceSigner := &input.MockSigner{Privkeys: aliceKeys}
 	bobSigner := &input.MockSigner{Privkeys: bobKeys}
 
-	pCache := &mockPreimageCache{
-		// hash -> preimage
-		preimageMap: make(map[[32]byte][]byte),
-	}
+	pCache := newMockPreimageCache()
 
 	// TODO(roasbeef): make mock version of pre-image store
 
@@ -389,26 +386,36 @@ func initRevocationWindows(chanA, chanB *LightningChannel) error {
 
 type mockPreimageCache struct {
 	sync.Mutex
-	preimageMap map[[32]byte][]byte
+	preimageMap map[lntypes.Hash]lntypes.Preimage
 }
 
-func (m *mockPreimageCache) LookupPreimage(hash []byte) ([]byte, bool) {
+func newMockPreimageCache() *mockPreimageCache {
+	return &mockPreimageCache{
+		preimageMap: make(map[lntypes.Hash]lntypes.Preimage),
+	}
+}
+
+func (m *mockPreimageCache) LookupPreimage(
+	hash lntypes.Hash) (lntypes.Preimage, bool) {
+
 	m.Lock()
 	defer m.Unlock()
 
-	var h [32]byte
-	copy(h[:], hash)
-
-	p, ok := m.preimageMap[h]
+	p, ok := m.preimageMap[hash]
 	return p, ok
 }
 
-func (m *mockPreimageCache) AddPreimages(preimages ...[]byte) error {
+func (m *mockPreimageCache) AddPreimages(preimages ...lntypes.Preimage) error {
+	preimageCopies := make([]lntypes.Preimage, 0, len(preimages))
+	for _, preimage := range preimages {
+		preimageCopies = append(preimageCopies, preimage)
+	}
+
 	m.Lock()
 	defer m.Unlock()
 
-	for _, preimage := range preimages {
-		m.preimageMap[sha256.Sum256(preimage)] = preimage
+	for _, preimage := range preimageCopies {
+		m.preimageMap[preimage.Hash()] = preimage
 	}
 
 	return nil

--- a/lnwallet/test_utils.go
+++ b/lnwallet/test_utils.go
@@ -403,11 +403,13 @@ func (m *mockPreimageCache) LookupPreimage(hash []byte) ([]byte, bool) {
 	return p, ok
 }
 
-func (m *mockPreimageCache) AddPreimage(preimage []byte) error {
+func (m *mockPreimageCache) AddPreimages(preimages ...[]byte) error {
 	m.Lock()
 	defer m.Unlock()
 
-	m.preimageMap[sha256.Sum256(preimage[:])] = preimage
+	for _, preimage := range preimages {
+		m.preimageMap[sha256.Sum256(preimage)] = preimage
+	}
 
 	return nil
 }

--- a/lnwallet/transactions_test.go
+++ b/lnwallet/transactions_test.go
@@ -780,10 +780,7 @@ func TestCommitmentAndHTLCTransactions(t *testing.T) {
 		},
 	}
 
-	pCache := &mockPreimageCache{
-		// hash -> preimage
-		preimageMap: make(map[[32]byte][]byte),
-	}
+	pCache := newMockPreimageCache()
 
 	for i, test := range testCases {
 		expectedCommitmentTx, err := txFromHex(test.expectedCommitmentTxHex)

--- a/mock.go
+++ b/mock.go
@@ -317,11 +317,13 @@ func (m *mockPreimageCache) LookupPreimage(hash []byte) ([]byte, bool) {
 	return p, ok
 }
 
-func (m *mockPreimageCache) AddPreimage(preimage []byte) error {
+func (m *mockPreimageCache) AddPreimages(preimages ...[]byte) error {
 	m.Lock()
 	defer m.Unlock()
 
-	m.preimageMap[sha256.Sum256(preimage[:])] = preimage
+	for _, preimage := range preimages {
+		m.preimageMap[sha256.Sum256(preimage)] = preimage
+	}
 
 	return nil
 }

--- a/server.go
+++ b/server.go
@@ -318,7 +318,7 @@ func newServer(listenAddrs []net.Addr, chanDB *channeldb.DB, cc *chainControl,
 	// HTLCs with the debug R-Hash immediately settled.
 	if cfg.DebugHTLC {
 		kiloCoin := btcutil.Amount(btcutil.SatoshiPerBitcoin * 1000)
-		s.invoices.AddDebugInvoice(kiloCoin, *invoices.DebugPre)
+		s.invoices.AddDebugInvoice(kiloCoin, invoices.DebugPre)
 		srvrLog.Debugf("Debug HTLC invoice inserted, preimage=%x, hash=%x",
 			invoices.DebugPre[:], invoices.DebugHash[:])
 	}

--- a/witness_beacon.go
+++ b/witness_beacon.go
@@ -90,17 +90,9 @@ func (p *preimageBeacon) LookupPreimage(
 	}
 
 	// Otherwise, we'll perform a final check using the witness cache.
-	preimageBytes, err := p.wCache.LookupWitness(
-		channeldb.Sha256HashWitness, payHash[:],
-	)
+	preimage, err := p.wCache.LookupSha256Witness(payHash)
 	if err != nil {
 		ltndLog.Errorf("Unable to lookup witness: %v", err)
-		return lntypes.Preimage{}, false
-	}
-
-	preimage, err := lntypes.MakePreimage(preimageBytes)
-	if err != nil {
-		ltndLog.Errorf("Unable to build witness: %v", err)
 		return lntypes.Preimage{}, false
 	}
 


### PR DESCRIPTION
This PR adds batched writes for witnesses discovered in HTLC forwarding. At the same time, we correct a nuanced consistency issue related to a lack of synchronization with the channel state machine. Forcing the individual preimage writes to be synchronized with the link incurs a heavy performance penalty (about 80% from my measurements). Batching these allows us to minimize the number of db transactions required to write the preimages, allowing us to reinsert the batched write into the link's critical path and resolve the possible inconsistency. In fact, the benchmarks actually showed a slight performance improvement, even with the extra write in the critical path.

See commit messages for more details.