### PR TITLE
build: update release.sh to contain vendor archive + source code

### DIFF
--- a/release.sh
+++ b/release.sh
@@ -16,9 +16,21 @@ else
     TAG=$1
 fi
 
+go mod vendor
+tar -cvzf vendor.tar.gz vendor
+
 PACKAGE=lnd
 MAINDIR=$PACKAGE-$TAG
 mkdir -p $MAINDIR
+
+cp vendor.tar.gz $MAINDIR/
+rm vendor.tar.gz
+rm -r vendor
+
+PACKAGESRC="$MAINDIR/$PACKAGE-source-$TAG.tar"
+git archive -o $PACKAGESRC HEAD
+gzip -f $PACKAGESRC > "$PACKAGESRC.gz"
+
 cd $MAINDIR
 
 # If LNDBUILDSYS is set the default list is ignored. Useful to release
@@ -35,6 +47,7 @@ for i in $SYS; do
     OS=$(echo $i | cut -f1 -d-)
     ARCH=$(echo $i | cut -f2 -d-)
     ARM=
+
     if [[ $ARCH = "armv6" ]]; then
       ARCH=arm
       ARM=6
@@ -42,17 +55,21 @@ for i in $SYS; do
       ARCH=arm
       ARM=7
     fi
+
     mkdir $PACKAGE-$i-$TAG
     cd $PACKAGE-$i-$TAG
+
     echo "Building:" $OS $ARCH $ARM
     env GOOS=$OS GOARCH=$ARCH GOARM=$ARM go build -v -ldflags "$COMMITFLAGS" github.com/lightningnetwork/lnd
     env GOOS=$OS GOARCH=$ARCH GOARM=$ARM go build -v -ldflags "$COMMITFLAGS" github.com/lightningnetwork/lnd/cmd/lncli
     cd ..
+
     if [[ $OS = "windows" ]]; then
 	zip -r $PACKAGE-$i-$TAG.zip $PACKAGE-$i-$TAG
     else
 	tar -cvzf $PACKAGE-$i-$TAG.tar.gz $PACKAGE-$i-$TAG
     fi
+
     rm -r $PACKAGE-$i-$TAG
 done
 


### PR DESCRIPTION
In this commit, we update the release script to include a directory
containing all of our vendored dependencies. This makes out releases
more self contained as they can be built using `go build -mod=vendor`
without requiring any package fetching.

Additionally, we pacakge the entire source as well.

Fixes #1550.