### PR TITLE
build: more reliable coverage using go-acc

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,11 +4,13 @@ ESCPKG := github.com\/lightningnetwork\/lnd
 BTCD_PKG := github.com/btcsuite/btcd
 GOVERALLS_PKG := github.com/mattn/goveralls
 LINT_PKG := gopkg.in/alecthomas/gometalinter.v2
+GOACC_PKG := github.com/ory/go-acc
 
 GO_BIN := ${GOPATH}/bin
 BTCD_BIN := $(GO_BIN)/btcd
 GOVERALLS_BIN := $(GO_BIN)/goveralls
 LINT_BIN := $(GO_BIN)/gometalinter.v2
+GOACC_BIN := $(GO_BIN)/go-acc
 
 BTCD_DIR :=${GOPATH}/src/$(BTCD_PKG)
 
@@ -20,6 +22,8 @@ BTCD_COMMIT := $(shell cat go.mod | \
 		tail -n1 | \
 		awk -F " " '{ print $$2 }' | \
 		awk -F "/" '{ print $$1 }')
+
+GOACC_COMMIT := ddc355013f90fea78d83d3a6c71f1d37ac07ecd5
 
 GOBUILD := GO111MODULE=on go build -v
 GOINSTALL := GO111MODULE=on go install -v
@@ -38,23 +42,6 @@ XARGS := xargs -L 1
 include make/testing_flags.mk
 
 DEV_TAGS := $(if ${tags},$(DEV_TAGS) ${tags},$(DEV_TAGS))
-
-COVER = for dir in $(GOLISTCOVER); do \
-		$(GOTEST) -tags="$(DEV_TAGS) $(LOG_TAGS)" \
-			-covermode=count \
-			-coverprofile=$$dir/profile.tmp $$dir; \
-		\
-		if [ $$? != 0 ] ; \
-		then \
-			exit 1; \
-		fi ; \
-		\
-		if [ -f $$dir/profile.tmp ]; then \
-			cat $$dir/profile.tmp | \
-				tail -n +2 >> profile.cov; \
-			$(RM) $$dir/profile.tmp; \
-		fi \
-	done
 
 LINT = $(LINT_BIN) \
 	--disable-all \
@@ -87,6 +74,11 @@ $(GOVERALLS_BIN):
 $(LINT_BIN):
 	@$(call print, "Fetching gometalinter.v2")
 	GO111MODULE=off go get -u $(LINT_PKG)
+
+$(GOACC_BIN):
+	@$(call print, "Fetching go-acc")
+	go get -u -v $(GOACC_PKG)@$(GOACC_COMMIT)
+	$(GOINSTALL) $(GOACC_PKG)
 
 btcd:
 	@$(call print, "Installing btcd.")
@@ -130,10 +122,9 @@ unit: btcd
 	@$(call print, "Running unit tests.")
 	$(UNIT)
 
-unit-cover:
+unit-cover: $(GOACC_BIN)
 	@$(call print, "Running unit coverage tests.")
-	echo "mode: count" > profile.cov
-	$(COVER)
+	$(GOACC_BIN) $$(go list ./... | grep -v lnrpc) -- -test.tags="$(DEV_TAGS) $(LOG_TAGS)"
 
 unit-race:
 	@$(call print, "Running unit race tests.")
@@ -141,7 +132,7 @@ unit-race:
 
 goveralls: $(GOVERALLS_BIN)
 	@$(call print, "Sending coverage report.")
-	$(GOVERALLS_BIN) -coverprofile=profile.cov -service=travis-ci
+	$(GOVERALLS_BIN) -coverprofile=coverage.txt -service=travis-ci
 
 travis-race: btcd unit-race
 


### PR DESCRIPTION
Testing out a different method of computing coverage results that hopefully is more accurate. The current script used by `unit-cover` does not correctly account for cross-package coverage. I found that https://github.com/ory/go-acc properly accounts for areas of code base that I know to be tested indirectly. As a result, our coverage gets a nice 2.6% bump.

This will allow us to make refactorings like #2481 simpler, and not have to worry as much about our code's location relative to the testing files. I would be interested in seeing how the coverage changes on that PR while using this as the coverage tool.