### PR TITLE
add volume to lnd to persist chain state across container changes

### DIFF
--- a/docker/lnd/Dockerfile
+++ b/docker/lnd/Dockerfile
@@ -2,6 +2,9 @@ FROM golang:1.11-alpine as builder
 
 MAINTAINER Olaoluwa Osuntokun <lightning.engineering>
 
+# Persistant volume store for lnd data
+VOLUME /root/.lnd/data
+
 # Copy in the local repository to build from.
 COPY . /go/src/github.com/lightningnetwork/lnd
 


### PR DESCRIPTION
This PR adds a volume to the lnd `Dockerfile` to persist chain state.  I considered adding this to `docker-compose.yml` instead however the volume is only needed for use by `lnd` and isn't shared with other services.  The functionality can be verified by restarting the `lnd` container and observe it no longer needs to catch up to a particular chain height.