### PR TITLE
wtpolicy+wtwire+wtserver: add base reward

### DIFF
--- a/watchtower/wtpolicy/policy.go
+++ b/watchtower/wtpolicy/policy.go
@@ -48,6 +48,11 @@ type Policy struct {
 	// for this session.
 	MaxUpdates uint16
 
+	// RewardBase is the fixed amount allocated to the tower when the
+	// policy's blob type specifies a reward for the tower. This is taken
+	// before adding the proportional reward.
+	RewardBase uint32
+
 	// RewardRate is the fraction of the total balance of the revoked
 	// commitment that the watchtower is entitled to. This value is
 	// expressed in millionths of the total balance.

--- a/watchtower/wtserver/server.go
+++ b/watchtower/wtserver/server.go
@@ -393,6 +393,7 @@ func (s *Server) handleCreateSession(peer Peer, id *wtdb.SessionID,
 		Policy: wtpolicy.Policy{
 			BlobType:     req.BlobType,
 			MaxUpdates:   req.MaxUpdates,
+			RewardBase:   req.RewardBase,
 			RewardRate:   req.RewardRate,
 			SweepFeeRate: req.SweepFeeRate,
 		},

--- a/watchtower/wtserver/server_test.go
+++ b/watchtower/wtserver/server_test.go
@@ -163,6 +163,7 @@ var createSessionTests = []createSessionTestCase{
 		createMsg: &wtwire.CreateSession{
 			BlobType:     blob.TypeDefault,
 			MaxUpdates:   1000,
+			RewardBase:   0,
 			RewardRate:   0,
 			SweepFeeRate: 1,
 		},
@@ -184,6 +185,7 @@ var createSessionTests = []createSessionTestCase{
 		createMsg: &wtwire.CreateSession{
 			BlobType:     0,
 			MaxUpdates:   1000,
+			RewardBase:   0,
 			RewardRate:   0,
 			SweepFeeRate: 1,
 		},
@@ -283,6 +285,7 @@ var stateUpdateTests = []stateUpdateTestCase{
 		createMsg: &wtwire.CreateSession{
 			BlobType:     blob.TypeDefault,
 			MaxUpdates:   3,
+			RewardBase:   0,
 			RewardRate:   0,
 			SweepFeeRate: 1,
 		},
@@ -312,6 +315,7 @@ var stateUpdateTests = []stateUpdateTestCase{
 		createMsg: &wtwire.CreateSession{
 			BlobType:     blob.TypeDefault,
 			MaxUpdates:   4,
+			RewardBase:   0,
 			RewardRate:   0,
 			SweepFeeRate: 1,
 		},
@@ -335,6 +339,7 @@ var stateUpdateTests = []stateUpdateTestCase{
 		createMsg: &wtwire.CreateSession{
 			BlobType:     blob.TypeDefault,
 			MaxUpdates:   4,
+			RewardBase:   0,
 			RewardRate:   0,
 			SweepFeeRate: 1,
 		},
@@ -362,6 +367,7 @@ var stateUpdateTests = []stateUpdateTestCase{
 		createMsg: &wtwire.CreateSession{
 			BlobType:     blob.TypeDefault,
 			MaxUpdates:   4,
+			RewardBase:   0,
 			RewardRate:   0,
 			SweepFeeRate: 1,
 		},
@@ -389,6 +395,7 @@ var stateUpdateTests = []stateUpdateTestCase{
 		createMsg: &wtwire.CreateSession{
 			BlobType:     blob.TypeDefault,
 			MaxUpdates:   4,
+			RewardBase:   0,
 			RewardRate:   0,
 			SweepFeeRate: 1,
 		},
@@ -418,6 +425,7 @@ var stateUpdateTests = []stateUpdateTestCase{
 		createMsg: &wtwire.CreateSession{
 			BlobType:     blob.TypeDefault,
 			MaxUpdates:   4,
+			RewardBase:   0,
 			RewardRate:   0,
 			SweepFeeRate: 1,
 		},
@@ -446,6 +454,7 @@ var stateUpdateTests = []stateUpdateTestCase{
 		createMsg: &wtwire.CreateSession{
 			BlobType:     blob.TypeDefault,
 			MaxUpdates:   3,
+			RewardBase:   0,
 			RewardRate:   0,
 			SweepFeeRate: 1,
 		},
@@ -475,6 +484,7 @@ var stateUpdateTests = []stateUpdateTestCase{
 		createMsg: &wtwire.CreateSession{
 			BlobType:     blob.TypeDefault,
 			MaxUpdates:   3,
+			RewardBase:   0,
 			RewardRate:   0,
 			SweepFeeRate: 1,
 		},

--- a/watchtower/wtwire/create_session.go
+++ b/watchtower/wtwire/create_session.go
@@ -20,6 +20,11 @@ type CreateSession struct {
 	// for this session.
 	MaxUpdates uint16
 
+	// RewardBase is the fixed amount allocated to the tower when the
+	// policy's blob type specifies a reward for the tower. This is taken
+	// before adding the proportional reward.
+	RewardBase uint32
+
 	// RewardRate is the fraction of the total balance of the revoked
 	// commitment that the watchtower is entitled to. This value is
 	// expressed in millionths of the total balance.
@@ -44,6 +49,7 @@ func (m *CreateSession) Decode(r io.Reader, pver uint32) error {
 	return ReadElements(r,
 		&m.BlobType,
 		&m.MaxUpdates,
+		&m.RewardBase,
 		&m.RewardRate,
 		&m.SweepFeeRate,
 	)
@@ -57,6 +63,7 @@ func (m *CreateSession) Encode(w io.Writer, pver uint32) error {
 	return WriteElements(w,
 		m.BlobType,
 		m.MaxUpdates,
+		m.RewardBase,
 		m.RewardRate,
 		m.SweepFeeRate,
 	)
@@ -75,5 +82,5 @@ func (m *CreateSession) MsgType() MessageType {
 //
 // This is part of the wtwire.Message interface.
 func (m *CreateSession) MaxPayloadLength(uint32) uint32 {
-	return 16
+	return 2 + 2 + 4 + 4 + 8 // 20
 }

--- a/watchtower/wtwire/summary.go
+++ b/watchtower/wtwire/summary.go
@@ -11,8 +11,9 @@ func MessageSummary(msg Message) string {
 
 	case *CreateSession:
 		return fmt.Sprintf("blob_type=%s, max_updates=%d "+
-			"reward_rate=%d sweep_fee_rate=%d", msg.BlobType,
-			msg.MaxUpdates, msg.RewardRate, msg.SweepFeeRate)
+			"reward_base=%d reward_rate=%d sweep_fee_rate=%d",
+			msg.BlobType, msg.MaxUpdates, msg.RewardBase,
+			msg.RewardRate, msg.SweepFeeRate)
 
 	case *CreateSessionReply:
 		return fmt.Sprintf("code=%d", msg.Code)


### PR DESCRIPTION
This PR extends session negotiation to include a `RewardBase` parameter, which is used in conjunction with the proportional `RewardRate` to give users and towers full mx+b control over the tower payouts. For example, the base can be set to a multiple of dust to ensure that the tower's output isn't too small to manifest on chain. With only a proportional reward, it could be the case that the tower receives nothing up until som threshold if the fee rate is low or the channel is small.