### PR TITLE
specify a tag, branch or commit during docker prod build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,11 @@ FROM golang:1.13-alpine as builder
 # queries required to connect to linked containers succeed.
 ENV GODEBUG netdns=cgo
 
+# Pass a tag, branch or a commit using build-arg.  This allows a docker
+# image to be built from a specified Git state.  The default image
+# will use the Git tip of master by default.
+ARG checkout="master"
+
 # Install dependencies and build the binaries.
 RUN apk add --no-cache --update alpine-sdk \
     git \
@@ -11,6 +16,7 @@ RUN apk add --no-cache --update alpine-sdk \
     gcc \
 &&  git clone https://github.com/lightningnetwork/lnd /go/src/github.com/lightningnetwork/lnd \
 &&  cd /go/src/github.com/lightningnetwork/lnd \
+&&  git checkout $checkout \
 &&  make \
 &&  make install tags="signrpc walletrpc chainrpc invoicesrpc routerrpc"
 

--- a/docs/DOCKER.md
+++ b/docs/DOCKER.md
@@ -65,3 +65,30 @@ $ docker logs lnd-testnet
 
 This is a simple example, it is possible to use any command-line options necessary
 to expose RPC ports, use `btcd` or `bitcoind`, or add additional chains.
+
+## LND Development and Testing
+
+To test the Docker production image locally, run the following from
+the project root:
+
+```
+$ docker build . -t lnd:master
+```
+
+To choose a specific branch or tag instead, use the "checkout" build-arg.  For example, to build the latest commits in master:
+
+```
+$ docker build . --build-arg checkout=v0.8.0-beta -t lnd:v0.8.0-beta
+```
+
+To build the image using the most current tag:
+
+```
+$ docker build . --build-arg checkout=$(git describe --tags `git rev-list --tags --max-count=1`) -t lnd:latest-tag
+```
+
+Once the image has been built and tagged locally, start the container:
+
+```
+docker run --name=lnd-testnet -it lnd:1.0 --bitcoin.active --bitcoin.testnet --bitcoin.node=neutrino --neutrino.connect=faucet.lightning.community
+```


### PR DESCRIPTION
Add `build-arg` to docker for choosing which branch, tag or commit to run during build time.
