### PR TITLE
lnrpc: update ListInvoices documentation

### DIFF
--- a/lnrpc/rpc.pb.go
+++ b/lnrpc/rpc.pb.go
@@ -49,7 +49,7 @@ func (x AddressType) String() string {
 	return proto.EnumName(AddressType_name, int32(x))
 }
 func (AddressType) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_rpc_665fbe676d0b2b6b, []int{0}
+	return fileDescriptor_rpc_a99508824120e315, []int{0}
 }
 
 type ChannelCloseSummary_ClosureType int32
@@ -84,7 +84,7 @@ func (x ChannelCloseSummary_ClosureType) String() string {
 	return proto.EnumName(ChannelCloseSummary_ClosureType_name, int32(x))
 }
 func (ChannelCloseSummary_ClosureType) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_rpc_665fbe676d0b2b6b, []int{38, 0}
+	return fileDescriptor_rpc_a99508824120e315, []int{38, 0}
 }
 
 type Invoice_InvoiceState int32
@@ -107,7 +107,7 @@ func (x Invoice_InvoiceState) String() string {
 	return proto.EnumName(Invoice_InvoiceState_name, int32(x))
 }
 func (Invoice_InvoiceState) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_rpc_665fbe676d0b2b6b, []int{86, 0}
+	return fileDescriptor_rpc_a99508824120e315, []int{86, 0}
 }
 
 type GenSeedRequest struct {
@@ -128,7 +128,7 @@ func (m *GenSeedRequest) Reset()         { *m = GenSeedRequest{} }
 func (m *GenSeedRequest) String() string { return proto.CompactTextString(m) }
 func (*GenSeedRequest) ProtoMessage()    {}
 func (*GenSeedRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_rpc_665fbe676d0b2b6b, []int{0}
+	return fileDescriptor_rpc_a99508824120e315, []int{0}
 }
 func (m *GenSeedRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_GenSeedRequest.Unmarshal(m, b)
@@ -183,7 +183,7 @@ func (m *GenSeedResponse) Reset()         { *m = GenSeedResponse{} }
 func (m *GenSeedResponse) String() string { return proto.CompactTextString(m) }
 func (*GenSeedResponse) ProtoMessage()    {}
 func (*GenSeedResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_rpc_665fbe676d0b2b6b, []int{1}
+	return fileDescriptor_rpc_a99508824120e315, []int{1}
 }
 func (m *GenSeedResponse) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_GenSeedResponse.Unmarshal(m, b)
@@ -248,7 +248,7 @@ func (m *InitWalletRequest) Reset()         { *m = InitWalletRequest{} }
 func (m *InitWalletRequest) String() string { return proto.CompactTextString(m) }
 func (*InitWalletRequest) ProtoMessage()    {}
 func (*InitWalletRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_rpc_665fbe676d0b2b6b, []int{2}
+	return fileDescriptor_rpc_a99508824120e315, []int{2}
 }
 func (m *InitWalletRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_InitWalletRequest.Unmarshal(m, b)
@@ -306,7 +306,7 @@ func (m *InitWalletResponse) Reset()         { *m = InitWalletResponse{} }
 func (m *InitWalletResponse) String() string { return proto.CompactTextString(m) }
 func (*InitWalletResponse) ProtoMessage()    {}
 func (*InitWalletResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_rpc_665fbe676d0b2b6b, []int{3}
+	return fileDescriptor_rpc_a99508824120e315, []int{3}
 }
 func (m *InitWalletResponse) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_InitWalletResponse.Unmarshal(m, b)
@@ -348,7 +348,7 @@ func (m *UnlockWalletRequest) Reset()         { *m = UnlockWalletRequest{} }
 func (m *UnlockWalletRequest) String() string { return proto.CompactTextString(m) }
 func (*UnlockWalletRequest) ProtoMessage()    {}
 func (*UnlockWalletRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_rpc_665fbe676d0b2b6b, []int{4}
+	return fileDescriptor_rpc_a99508824120e315, []int{4}
 }
 func (m *UnlockWalletRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_UnlockWalletRequest.Unmarshal(m, b)
@@ -392,7 +392,7 @@ func (m *UnlockWalletResponse) Reset()         { *m = UnlockWalletResponse{} }
 func (m *UnlockWalletResponse) String() string { return proto.CompactTextString(m) }
 func (*UnlockWalletResponse) ProtoMessage()    {}
 func (*UnlockWalletResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_rpc_665fbe676d0b2b6b, []int{5}
+	return fileDescriptor_rpc_a99508824120e315, []int{5}
 }
 func (m *UnlockWalletResponse) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_UnlockWalletResponse.Unmarshal(m, b)
@@ -430,7 +430,7 @@ func (m *ChangePasswordRequest) Reset()         { *m = ChangePasswordRequest{} }
 func (m *ChangePasswordRequest) String() string { return proto.CompactTextString(m) }
 func (*ChangePasswordRequest) ProtoMessage()    {}
 func (*ChangePasswordRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_rpc_665fbe676d0b2b6b, []int{6}
+	return fileDescriptor_rpc_a99508824120e315, []int{6}
 }
 func (m *ChangePasswordRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_ChangePasswordRequest.Unmarshal(m, b)
@@ -474,7 +474,7 @@ func (m *ChangePasswordResponse) Reset()         { *m = ChangePasswordResponse{}
 func (m *ChangePasswordResponse) String() string { return proto.CompactTextString(m) }
 func (*ChangePasswordResponse) ProtoMessage()    {}
 func (*ChangePasswordResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_rpc_665fbe676d0b2b6b, []int{7}
+	return fileDescriptor_rpc_a99508824120e315, []int{7}
 }
 func (m *ChangePasswordResponse) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_ChangePasswordResponse.Unmarshal(m, b)
@@ -518,7 +518,7 @@ func (m *Utxo) Reset()         { *m = Utxo{} }
 func (m *Utxo) String() string { return proto.CompactTextString(m) }
 func (*Utxo) ProtoMessage()    {}
 func (*Utxo) Descriptor() ([]byte, []int) {
-	return fileDescriptor_rpc_665fbe676d0b2b6b, []int{8}
+	return fileDescriptor_rpc_a99508824120e315, []int{8}
 }
 func (m *Utxo) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_Utxo.Unmarshal(m, b)
@@ -606,7 +606,7 @@ func (m *Transaction) Reset()         { *m = Transaction{} }
 func (m *Transaction) String() string { return proto.CompactTextString(m) }
 func (*Transaction) ProtoMessage()    {}
 func (*Transaction) Descriptor() ([]byte, []int) {
-	return fileDescriptor_rpc_665fbe676d0b2b6b, []int{9}
+	return fileDescriptor_rpc_a99508824120e315, []int{9}
 }
 func (m *Transaction) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_Transaction.Unmarshal(m, b)
@@ -692,7 +692,7 @@ func (m *GetTransactionsRequest) Reset()         { *m = GetTransactionsRequest{}
 func (m *GetTransactionsRequest) String() string { return proto.CompactTextString(m) }
 func (*GetTransactionsRequest) ProtoMessage()    {}
 func (*GetTransactionsRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_rpc_665fbe676d0b2b6b, []int{10}
+	return fileDescriptor_rpc_a99508824120e315, []int{10}
 }
 func (m *GetTransactionsRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_GetTransactionsRequest.Unmarshal(m, b)
@@ -724,7 +724,7 @@ func (m *TransactionDetails) Reset()         { *m = TransactionDetails{} }
 func (m *TransactionDetails) String() string { return proto.CompactTextString(m) }
 func (*TransactionDetails) ProtoMessage()    {}
 func (*TransactionDetails) Descriptor() ([]byte, []int) {
-	return fileDescriptor_rpc_665fbe676d0b2b6b, []int{11}
+	return fileDescriptor_rpc_a99508824120e315, []int{11}
 }
 func (m *TransactionDetails) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_TransactionDetails.Unmarshal(m, b)
@@ -765,7 +765,7 @@ func (m *FeeLimit) Reset()         { *m = FeeLimit{} }
 func (m *FeeLimit) String() string { return proto.CompactTextString(m) }
 func (*FeeLimit) ProtoMessage()    {}
 func (*FeeLimit) Descriptor() ([]byte, []int) {
-	return fileDescriptor_rpc_665fbe676d0b2b6b, []int{12}
+	return fileDescriptor_rpc_a99508824120e315, []int{12}
 }
 func (m *FeeLimit) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_FeeLimit.Unmarshal(m, b)
@@ -921,7 +921,7 @@ func (m *SendRequest) Reset()         { *m = SendRequest{} }
 func (m *SendRequest) String() string { return proto.CompactTextString(m) }
 func (*SendRequest) ProtoMessage()    {}
 func (*SendRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_rpc_665fbe676d0b2b6b, []int{13}
+	return fileDescriptor_rpc_a99508824120e315, []int{13}
 }
 func (m *SendRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_SendRequest.Unmarshal(m, b)
@@ -1011,7 +1011,7 @@ func (m *SendResponse) Reset()         { *m = SendResponse{} }
 func (m *SendResponse) String() string { return proto.CompactTextString(m) }
 func (*SendResponse) ProtoMessage()    {}
 func (*SendResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_rpc_665fbe676d0b2b6b, []int{14}
+	return fileDescriptor_rpc_a99508824120e315, []int{14}
 }
 func (m *SendResponse) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_SendResponse.Unmarshal(m, b)
@@ -1075,7 +1075,7 @@ func (m *SendToRouteRequest) Reset()         { *m = SendToRouteRequest{} }
 func (m *SendToRouteRequest) String() string { return proto.CompactTextString(m) }
 func (*SendToRouteRequest) ProtoMessage()    {}
 func (*SendToRouteRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_rpc_665fbe676d0b2b6b, []int{15}
+	return fileDescriptor_rpc_a99508824120e315, []int{15}
 }
 func (m *SendToRouteRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_SendToRouteRequest.Unmarshal(m, b)
@@ -1132,7 +1132,7 @@ func (m *ChannelPoint) Reset()         { *m = ChannelPoint{} }
 func (m *ChannelPoint) String() string { return proto.CompactTextString(m) }
 func (*ChannelPoint) ProtoMessage()    {}
 func (*ChannelPoint) Descriptor() ([]byte, []int) {
-	return fileDescriptor_rpc_665fbe676d0b2b6b, []int{16}
+	return fileDescriptor_rpc_a99508824120e315, []int{16}
 }
 func (m *ChannelPoint) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_ChannelPoint.Unmarshal(m, b)
@@ -1276,7 +1276,7 @@ func (m *LightningAddress) Reset()         { *m = LightningAddress{} }
 func (m *LightningAddress) String() string { return proto.CompactTextString(m) }
 func (*LightningAddress) ProtoMessage()    {}
 func (*LightningAddress) Descriptor() ([]byte, []int) {
-	return fileDescriptor_rpc_665fbe676d0b2b6b, []int{17}
+	return fileDescriptor_rpc_a99508824120e315, []int{17}
 }
 func (m *LightningAddress) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_LightningAddress.Unmarshal(m, b)
@@ -1326,7 +1326,7 @@ func (m *SendManyRequest) Reset()         { *m = SendManyRequest{} }
 func (m *SendManyRequest) String() string { return proto.CompactTextString(m) }
 func (*SendManyRequest) ProtoMessage()    {}
 func (*SendManyRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_rpc_665fbe676d0b2b6b, []int{18}
+	return fileDescriptor_rpc_a99508824120e315, []int{18}
 }
 func (m *SendManyRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_SendManyRequest.Unmarshal(m, b)
@@ -1379,7 +1379,7 @@ func (m *SendManyResponse) Reset()         { *m = SendManyResponse{} }
 func (m *SendManyResponse) String() string { return proto.CompactTextString(m) }
 func (*SendManyResponse) ProtoMessage()    {}
 func (*SendManyResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_rpc_665fbe676d0b2b6b, []int{19}
+	return fileDescriptor_rpc_a99508824120e315, []int{19}
 }
 func (m *SendManyResponse) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_SendManyResponse.Unmarshal(m, b)
@@ -1429,7 +1429,7 @@ func (m *SendCoinsRequest) Reset()         { *m = SendCoinsRequest{} }
 func (m *SendCoinsRequest) String() string { return proto.CompactTextString(m) }
 func (*SendCoinsRequest) ProtoMessage()    {}
 func (*SendCoinsRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_rpc_665fbe676d0b2b6b, []int{20}
+	return fileDescriptor_rpc_a99508824120e315, []int{20}
 }
 func (m *SendCoinsRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_SendCoinsRequest.Unmarshal(m, b)
@@ -1496,7 +1496,7 @@ func (m *SendCoinsResponse) Reset()         { *m = SendCoinsResponse{} }
 func (m *SendCoinsResponse) String() string { return proto.CompactTextString(m) }
 func (*SendCoinsResponse) ProtoMessage()    {}
 func (*SendCoinsResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_rpc_665fbe676d0b2b6b, []int{21}
+	return fileDescriptor_rpc_a99508824120e315, []int{21}
 }
 func (m *SendCoinsResponse) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_SendCoinsResponse.Unmarshal(m, b)
@@ -1537,7 +1537,7 @@ func (m *ListUnspentRequest) Reset()         { *m = ListUnspentRequest{} }
 func (m *ListUnspentRequest) String() string { return proto.CompactTextString(m) }
 func (*ListUnspentRequest) ProtoMessage()    {}
 func (*ListUnspentRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_rpc_665fbe676d0b2b6b, []int{22}
+	return fileDescriptor_rpc_a99508824120e315, []int{22}
 }
 func (m *ListUnspentRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_ListUnspentRequest.Unmarshal(m, b)
@@ -1583,7 +1583,7 @@ func (m *ListUnspentResponse) Reset()         { *m = ListUnspentResponse{} }
 func (m *ListUnspentResponse) String() string { return proto.CompactTextString(m) }
 func (*ListUnspentResponse) ProtoMessage()    {}
 func (*ListUnspentResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_rpc_665fbe676d0b2b6b, []int{23}
+	return fileDescriptor_rpc_a99508824120e315, []int{23}
 }
 func (m *ListUnspentResponse) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_ListUnspentResponse.Unmarshal(m, b)
@@ -1622,7 +1622,7 @@ func (m *NewAddressRequest) Reset()         { *m = NewAddressRequest{} }
 func (m *NewAddressRequest) String() string { return proto.CompactTextString(m) }
 func (*NewAddressRequest) ProtoMessage()    {}
 func (*NewAddressRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_rpc_665fbe676d0b2b6b, []int{24}
+	return fileDescriptor_rpc_a99508824120e315, []int{24}
 }
 func (m *NewAddressRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_NewAddressRequest.Unmarshal(m, b)
@@ -1661,7 +1661,7 @@ func (m *NewAddressResponse) Reset()         { *m = NewAddressResponse{} }
 func (m *NewAddressResponse) String() string { return proto.CompactTextString(m) }
 func (*NewAddressResponse) ProtoMessage()    {}
 func (*NewAddressResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_rpc_665fbe676d0b2b6b, []int{25}
+	return fileDescriptor_rpc_a99508824120e315, []int{25}
 }
 func (m *NewAddressResponse) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_NewAddressResponse.Unmarshal(m, b)
@@ -1700,7 +1700,7 @@ func (m *SignMessageRequest) Reset()         { *m = SignMessageRequest{} }
 func (m *SignMessageRequest) String() string { return proto.CompactTextString(m) }
 func (*SignMessageRequest) ProtoMessage()    {}
 func (*SignMessageRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_rpc_665fbe676d0b2b6b, []int{26}
+	return fileDescriptor_rpc_a99508824120e315, []int{26}
 }
 func (m *SignMessageRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_SignMessageRequest.Unmarshal(m, b)
@@ -1739,7 +1739,7 @@ func (m *SignMessageResponse) Reset()         { *m = SignMessageResponse{} }
 func (m *SignMessageResponse) String() string { return proto.CompactTextString(m) }
 func (*SignMessageResponse) ProtoMessage()    {}
 func (*SignMessageResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_rpc_665fbe676d0b2b6b, []int{27}
+	return fileDescriptor_rpc_a99508824120e315, []int{27}
 }
 func (m *SignMessageResponse) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_SignMessageResponse.Unmarshal(m, b)
@@ -1780,7 +1780,7 @@ func (m *VerifyMessageRequest) Reset()         { *m = VerifyMessageRequest{} }
 func (m *VerifyMessageRequest) String() string { return proto.CompactTextString(m) }
 func (*VerifyMessageRequest) ProtoMessage()    {}
 func (*VerifyMessageRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_rpc_665fbe676d0b2b6b, []int{28}
+	return fileDescriptor_rpc_a99508824120e315, []int{28}
 }
 func (m *VerifyMessageRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_VerifyMessageRequest.Unmarshal(m, b)
@@ -1828,7 +1828,7 @@ func (m *VerifyMessageResponse) Reset()         { *m = VerifyMessageResponse{} }
 func (m *VerifyMessageResponse) String() string { return proto.CompactTextString(m) }
 func (*VerifyMessageResponse) ProtoMessage()    {}
 func (*VerifyMessageResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_rpc_665fbe676d0b2b6b, []int{29}
+	return fileDescriptor_rpc_a99508824120e315, []int{29}
 }
 func (m *VerifyMessageResponse) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_VerifyMessageResponse.Unmarshal(m, b)
@@ -1877,7 +1877,7 @@ func (m *ConnectPeerRequest) Reset()         { *m = ConnectPeerRequest{} }
 func (m *ConnectPeerRequest) String() string { return proto.CompactTextString(m) }
 func (*ConnectPeerRequest) ProtoMessage()    {}
 func (*ConnectPeerRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_rpc_665fbe676d0b2b6b, []int{30}
+	return fileDescriptor_rpc_a99508824120e315, []int{30}
 }
 func (m *ConnectPeerRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_ConnectPeerRequest.Unmarshal(m, b)
@@ -1921,7 +1921,7 @@ func (m *ConnectPeerResponse) Reset()         { *m = ConnectPeerResponse{} }
 func (m *ConnectPeerResponse) String() string { return proto.CompactTextString(m) }
 func (*ConnectPeerResponse) ProtoMessage()    {}
 func (*ConnectPeerResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_rpc_665fbe676d0b2b6b, []int{31}
+	return fileDescriptor_rpc_a99508824120e315, []int{31}
 }
 func (m *ConnectPeerResponse) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_ConnectPeerResponse.Unmarshal(m, b)
@@ -1953,7 +1953,7 @@ func (m *DisconnectPeerRequest) Reset()         { *m = DisconnectPeerRequest{} }
 func (m *DisconnectPeerRequest) String() string { return proto.CompactTextString(m) }
 func (*DisconnectPeerRequest) ProtoMessage()    {}
 func (*DisconnectPeerRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_rpc_665fbe676d0b2b6b, []int{32}
+	return fileDescriptor_rpc_a99508824120e315, []int{32}
 }
 func (m *DisconnectPeerRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_DisconnectPeerRequest.Unmarshal(m, b)
@@ -1990,7 +1990,7 @@ func (m *DisconnectPeerResponse) Reset()         { *m = DisconnectPeerResponse{}
 func (m *DisconnectPeerResponse) String() string { return proto.CompactTextString(m) }
 func (*DisconnectPeerResponse) ProtoMessage()    {}
 func (*DisconnectPeerResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_rpc_665fbe676d0b2b6b, []int{33}
+	return fileDescriptor_rpc_a99508824120e315, []int{33}
 }
 func (m *DisconnectPeerResponse) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_DisconnectPeerResponse.Unmarshal(m, b)
@@ -2024,7 +2024,7 @@ func (m *HTLC) Reset()         { *m = HTLC{} }
 func (m *HTLC) String() string { return proto.CompactTextString(m) }
 func (*HTLC) ProtoMessage()    {}
 func (*HTLC) Descriptor() ([]byte, []int) {
-	return fileDescriptor_rpc_665fbe676d0b2b6b, []int{34}
+	return fileDescriptor_rpc_a99508824120e315, []int{34}
 }
 func (m *HTLC) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_HTLC.Unmarshal(m, b)
@@ -2138,7 +2138,7 @@ func (m *Channel) Reset()         { *m = Channel{} }
 func (m *Channel) String() string { return proto.CompactTextString(m) }
 func (*Channel) ProtoMessage()    {}
 func (*Channel) Descriptor() ([]byte, []int) {
-	return fileDescriptor_rpc_665fbe676d0b2b6b, []int{35}
+	return fileDescriptor_rpc_a99508824120e315, []int{35}
 }
 func (m *Channel) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_Channel.Unmarshal(m, b)
@@ -2298,7 +2298,7 @@ func (m *ListChannelsRequest) Reset()         { *m = ListChannelsRequest{} }
 func (m *ListChannelsRequest) String() string { return proto.CompactTextString(m) }
 func (*ListChannelsRequest) ProtoMessage()    {}
 func (*ListChannelsRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_rpc_665fbe676d0b2b6b, []int{36}
+	return fileDescriptor_rpc_a99508824120e315, []int{36}
 }
 func (m *ListChannelsRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_ListChannelsRequest.Unmarshal(m, b)
@@ -2358,7 +2358,7 @@ func (m *ListChannelsResponse) Reset()         { *m = ListChannelsResponse{} }
 func (m *ListChannelsResponse) String() string { return proto.CompactTextString(m) }
 func (*ListChannelsResponse) ProtoMessage()    {}
 func (*ListChannelsResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_rpc_665fbe676d0b2b6b, []int{37}
+	return fileDescriptor_rpc_a99508824120e315, []int{37}
 }
 func (m *ListChannelsResponse) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_ListChannelsResponse.Unmarshal(m, b)
@@ -2415,7 +2415,7 @@ func (m *ChannelCloseSummary) Reset()         { *m = ChannelCloseSummary{} }
 func (m *ChannelCloseSummary) String() string { return proto.CompactTextString(m) }
 func (*ChannelCloseSummary) ProtoMessage()    {}
 func (*ChannelCloseSummary) Descriptor() ([]byte, []int) {
-	return fileDescriptor_rpc_665fbe676d0b2b6b, []int{38}
+	return fileDescriptor_rpc_a99508824120e315, []int{38}
 }
 func (m *ChannelCloseSummary) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_ChannelCloseSummary.Unmarshal(m, b)
@@ -2521,7 +2521,7 @@ func (m *ClosedChannelsRequest) Reset()         { *m = ClosedChannelsRequest{} }
 func (m *ClosedChannelsRequest) String() string { return proto.CompactTextString(m) }
 func (*ClosedChannelsRequest) ProtoMessage()    {}
 func (*ClosedChannelsRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_rpc_665fbe676d0b2b6b, []int{39}
+	return fileDescriptor_rpc_a99508824120e315, []int{39}
 }
 func (m *ClosedChannelsRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_ClosedChannelsRequest.Unmarshal(m, b)
@@ -2594,7 +2594,7 @@ func (m *ClosedChannelsResponse) Reset()         { *m = ClosedChannelsResponse{}
 func (m *ClosedChannelsResponse) String() string { return proto.CompactTextString(m) }
 func (*ClosedChannelsResponse) ProtoMessage()    {}
 func (*ClosedChannelsResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_rpc_665fbe676d0b2b6b, []int{40}
+	return fileDescriptor_rpc_a99508824120e315, []int{40}
 }
 func (m *ClosedChannelsResponse) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_ClosedChannelsResponse.Unmarshal(m, b)
@@ -2647,7 +2647,7 @@ func (m *Peer) Reset()         { *m = Peer{} }
 func (m *Peer) String() string { return proto.CompactTextString(m) }
 func (*Peer) ProtoMessage()    {}
 func (*Peer) Descriptor() ([]byte, []int) {
-	return fileDescriptor_rpc_665fbe676d0b2b6b, []int{41}
+	return fileDescriptor_rpc_a99508824120e315, []int{41}
 }
 func (m *Peer) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_Peer.Unmarshal(m, b)
@@ -2733,7 +2733,7 @@ func (m *ListPeersRequest) Reset()         { *m = ListPeersRequest{} }
 func (m *ListPeersRequest) String() string { return proto.CompactTextString(m) }
 func (*ListPeersRequest) ProtoMessage()    {}
 func (*ListPeersRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_rpc_665fbe676d0b2b6b, []int{42}
+	return fileDescriptor_rpc_a99508824120e315, []int{42}
 }
 func (m *ListPeersRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_ListPeersRequest.Unmarshal(m, b)
@@ -2765,7 +2765,7 @@ func (m *ListPeersResponse) Reset()         { *m = ListPeersResponse{} }
 func (m *ListPeersResponse) String() string { return proto.CompactTextString(m) }
 func (*ListPeersResponse) ProtoMessage()    {}
 func (*ListPeersResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_rpc_665fbe676d0b2b6b, []int{43}
+	return fileDescriptor_rpc_a99508824120e315, []int{43}
 }
 func (m *ListPeersResponse) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_ListPeersResponse.Unmarshal(m, b)
@@ -2802,7 +2802,7 @@ func (m *GetInfoRequest) Reset()         { *m = GetInfoRequest{} }
 func (m *GetInfoRequest) String() string { return proto.CompactTextString(m) }
 func (*GetInfoRequest) ProtoMessage()    {}
 func (*GetInfoRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_rpc_665fbe676d0b2b6b, []int{44}
+	return fileDescriptor_rpc_a99508824120e315, []int{44}
 }
 func (m *GetInfoRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_GetInfoRequest.Unmarshal(m, b)
@@ -2862,7 +2862,7 @@ func (m *GetInfoResponse) Reset()         { *m = GetInfoResponse{} }
 func (m *GetInfoResponse) String() string { return proto.CompactTextString(m) }
 func (*GetInfoResponse) ProtoMessage()    {}
 func (*GetInfoResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_rpc_665fbe676d0b2b6b, []int{45}
+	return fileDescriptor_rpc_a99508824120e315, []int{45}
 }
 func (m *GetInfoResponse) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_GetInfoResponse.Unmarshal(m, b)
@@ -2995,7 +2995,7 @@ func (m *Chain) Reset()         { *m = Chain{} }
 func (m *Chain) String() string { return proto.CompactTextString(m) }
 func (*Chain) ProtoMessage()    {}
 func (*Chain) Descriptor() ([]byte, []int) {
-	return fileDescriptor_rpc_665fbe676d0b2b6b, []int{46}
+	return fileDescriptor_rpc_a99508824120e315, []int{46}
 }
 func (m *Chain) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_Chain.Unmarshal(m, b)
@@ -3042,7 +3042,7 @@ func (m *ConfirmationUpdate) Reset()         { *m = ConfirmationUpdate{} }
 func (m *ConfirmationUpdate) String() string { return proto.CompactTextString(m) }
 func (*ConfirmationUpdate) ProtoMessage()    {}
 func (*ConfirmationUpdate) Descriptor() ([]byte, []int) {
-	return fileDescriptor_rpc_665fbe676d0b2b6b, []int{47}
+	return fileDescriptor_rpc_a99508824120e315, []int{47}
 }
 func (m *ConfirmationUpdate) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_ConfirmationUpdate.Unmarshal(m, b)
@@ -3094,7 +3094,7 @@ func (m *ChannelOpenUpdate) Reset()         { *m = ChannelOpenUpdate{} }
 func (m *ChannelOpenUpdate) String() string { return proto.CompactTextString(m) }
 func (*ChannelOpenUpdate) ProtoMessage()    {}
 func (*ChannelOpenUpdate) Descriptor() ([]byte, []int) {
-	return fileDescriptor_rpc_665fbe676d0b2b6b, []int{48}
+	return fileDescriptor_rpc_a99508824120e315, []int{48}
 }
 func (m *ChannelOpenUpdate) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_ChannelOpenUpdate.Unmarshal(m, b)
@@ -3133,7 +3133,7 @@ func (m *ChannelCloseUpdate) Reset()         { *m = ChannelCloseUpdate{} }
 func (m *ChannelCloseUpdate) String() string { return proto.CompactTextString(m) }
 func (*ChannelCloseUpdate) ProtoMessage()    {}
 func (*ChannelCloseUpdate) Descriptor() ([]byte, []int) {
-	return fileDescriptor_rpc_665fbe676d0b2b6b, []int{49}
+	return fileDescriptor_rpc_a99508824120e315, []int{49}
 }
 func (m *ChannelCloseUpdate) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_ChannelCloseUpdate.Unmarshal(m, b)
@@ -3188,7 +3188,7 @@ func (m *CloseChannelRequest) Reset()         { *m = CloseChannelRequest{} }
 func (m *CloseChannelRequest) String() string { return proto.CompactTextString(m) }
 func (*CloseChannelRequest) ProtoMessage()    {}
 func (*CloseChannelRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_rpc_665fbe676d0b2b6b, []int{50}
+	return fileDescriptor_rpc_a99508824120e315, []int{50}
 }
 func (m *CloseChannelRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_CloseChannelRequest.Unmarshal(m, b)
@@ -3250,7 +3250,7 @@ func (m *CloseStatusUpdate) Reset()         { *m = CloseStatusUpdate{} }
 func (m *CloseStatusUpdate) String() string { return proto.CompactTextString(m) }
 func (*CloseStatusUpdate) ProtoMessage()    {}
 func (*CloseStatusUpdate) Descriptor() ([]byte, []int) {
-	return fileDescriptor_rpc_665fbe676d0b2b6b, []int{51}
+	return fileDescriptor_rpc_a99508824120e315, []int{51}
 }
 func (m *CloseStatusUpdate) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_CloseStatusUpdate.Unmarshal(m, b)
@@ -3393,7 +3393,7 @@ func (m *PendingUpdate) Reset()         { *m = PendingUpdate{} }
 func (m *PendingUpdate) String() string { return proto.CompactTextString(m) }
 func (*PendingUpdate) ProtoMessage()    {}
 func (*PendingUpdate) Descriptor() ([]byte, []int) {
-	return fileDescriptor_rpc_665fbe676d0b2b6b, []int{52}
+	return fileDescriptor_rpc_a99508824120e315, []int{52}
 }
 func (m *PendingUpdate) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_PendingUpdate.Unmarshal(m, b)
@@ -3459,7 +3459,7 @@ func (m *OpenChannelRequest) Reset()         { *m = OpenChannelRequest{} }
 func (m *OpenChannelRequest) String() string { return proto.CompactTextString(m) }
 func (*OpenChannelRequest) ProtoMessage()    {}
 func (*OpenChannelRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_rpc_665fbe676d0b2b6b, []int{53}
+	return fileDescriptor_rpc_a99508824120e315, []int{53}
 }
 func (m *OpenChannelRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_OpenChannelRequest.Unmarshal(m, b)
@@ -3570,7 +3570,7 @@ func (m *OpenStatusUpdate) Reset()         { *m = OpenStatusUpdate{} }
 func (m *OpenStatusUpdate) String() string { return proto.CompactTextString(m) }
 func (*OpenStatusUpdate) ProtoMessage()    {}
 func (*OpenStatusUpdate) Descriptor() ([]byte, []int) {
-	return fileDescriptor_rpc_665fbe676d0b2b6b, []int{54}
+	return fileDescriptor_rpc_a99508824120e315, []int{54}
 }
 func (m *OpenStatusUpdate) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_OpenStatusUpdate.Unmarshal(m, b)
@@ -3726,7 +3726,7 @@ func (m *PendingHTLC) Reset()         { *m = PendingHTLC{} }
 func (m *PendingHTLC) String() string { return proto.CompactTextString(m) }
 func (*PendingHTLC) ProtoMessage()    {}
 func (*PendingHTLC) Descriptor() ([]byte, []int) {
-	return fileDescriptor_rpc_665fbe676d0b2b6b, []int{55}
+	return fileDescriptor_rpc_a99508824120e315, []int{55}
 }
 func (m *PendingHTLC) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_PendingHTLC.Unmarshal(m, b)
@@ -3798,7 +3798,7 @@ func (m *PendingChannelsRequest) Reset()         { *m = PendingChannelsRequest{}
 func (m *PendingChannelsRequest) String() string { return proto.CompactTextString(m) }
 func (*PendingChannelsRequest) ProtoMessage()    {}
 func (*PendingChannelsRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_rpc_665fbe676d0b2b6b, []int{56}
+	return fileDescriptor_rpc_a99508824120e315, []int{56}
 }
 func (m *PendingChannelsRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_PendingChannelsRequest.Unmarshal(m, b)
@@ -3838,7 +3838,7 @@ func (m *PendingChannelsResponse) Reset()         { *m = PendingChannelsResponse
 func (m *PendingChannelsResponse) String() string { return proto.CompactTextString(m) }
 func (*PendingChannelsResponse) ProtoMessage()    {}
 func (*PendingChannelsResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_rpc_665fbe676d0b2b6b, []int{57}
+	return fileDescriptor_rpc_a99508824120e315, []int{57}
 }
 func (m *PendingChannelsResponse) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_PendingChannelsResponse.Unmarshal(m, b)
@@ -3910,7 +3910,7 @@ func (m *PendingChannelsResponse_PendingChannel) Reset() {
 func (m *PendingChannelsResponse_PendingChannel) String() string { return proto.CompactTextString(m) }
 func (*PendingChannelsResponse_PendingChannel) ProtoMessage()    {}
 func (*PendingChannelsResponse_PendingChannel) Descriptor() ([]byte, []int) {
-	return fileDescriptor_rpc_665fbe676d0b2b6b, []int{57, 0}
+	return fileDescriptor_rpc_a99508824120e315, []int{57, 0}
 }
 func (m *PendingChannelsResponse_PendingChannel) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_PendingChannelsResponse_PendingChannel.Unmarshal(m, b)
@@ -3997,7 +3997,7 @@ func (m *PendingChannelsResponse_PendingOpenChannel) String() string {
 }
 func (*PendingChannelsResponse_PendingOpenChannel) ProtoMessage() {}
 func (*PendingChannelsResponse_PendingOpenChannel) Descriptor() ([]byte, []int) {
-	return fileDescriptor_rpc_665fbe676d0b2b6b, []int{57, 1}
+	return fileDescriptor_rpc_a99508824120e315, []int{57, 1}
 }
 func (m *PendingChannelsResponse_PendingOpenChannel) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_PendingChannelsResponse_PendingOpenChannel.Unmarshal(m, b)
@@ -4070,7 +4070,7 @@ func (m *PendingChannelsResponse_WaitingCloseChannel) String() string {
 }
 func (*PendingChannelsResponse_WaitingCloseChannel) ProtoMessage() {}
 func (*PendingChannelsResponse_WaitingCloseChannel) Descriptor() ([]byte, []int) {
-	return fileDescriptor_rpc_665fbe676d0b2b6b, []int{57, 2}
+	return fileDescriptor_rpc_a99508824120e315, []int{57, 2}
 }
 func (m *PendingChannelsResponse_WaitingCloseChannel) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_PendingChannelsResponse_WaitingCloseChannel.Unmarshal(m, b)
@@ -4118,7 +4118,7 @@ func (m *PendingChannelsResponse_ClosedChannel) Reset()         { *m = PendingCh
 func (m *PendingChannelsResponse_ClosedChannel) String() string { return proto.CompactTextString(m) }
 func (*PendingChannelsResponse_ClosedChannel) ProtoMessage()    {}
 func (*PendingChannelsResponse_ClosedChannel) Descriptor() ([]byte, []int) {
-	return fileDescriptor_rpc_665fbe676d0b2b6b, []int{57, 3}
+	return fileDescriptor_rpc_a99508824120e315, []int{57, 3}
 }
 func (m *PendingChannelsResponse_ClosedChannel) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_PendingChannelsResponse_ClosedChannel.Unmarshal(m, b)
@@ -4182,7 +4182,7 @@ func (m *PendingChannelsResponse_ForceClosedChannel) String() string {
 }
 func (*PendingChannelsResponse_ForceClosedChannel) ProtoMessage() {}
 func (*PendingChannelsResponse_ForceClosedChannel) Descriptor() ([]byte, []int) {
-	return fileDescriptor_rpc_665fbe676d0b2b6b, []int{57, 4}
+	return fileDescriptor_rpc_a99508824120e315, []int{57, 4}
 }
 func (m *PendingChannelsResponse_ForceClosedChannel) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_PendingChannelsResponse_ForceClosedChannel.Unmarshal(m, b)
@@ -4261,7 +4261,7 @@ func (m *WalletBalanceRequest) Reset()         { *m = WalletBalanceRequest{} }
 func (m *WalletBalanceRequest) String() string { return proto.CompactTextString(m) }
 func (*WalletBalanceRequest) ProtoMessage()    {}
 func (*WalletBalanceRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_rpc_665fbe676d0b2b6b, []int{58}
+	return fileDescriptor_rpc_a99508824120e315, []int{58}
 }
 func (m *WalletBalanceRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_WalletBalanceRequest.Unmarshal(m, b)
@@ -4297,7 +4297,7 @@ func (m *WalletBalanceResponse) Reset()         { *m = WalletBalanceResponse{} }
 func (m *WalletBalanceResponse) String() string { return proto.CompactTextString(m) }
 func (*WalletBalanceResponse) ProtoMessage()    {}
 func (*WalletBalanceResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_rpc_665fbe676d0b2b6b, []int{59}
+	return fileDescriptor_rpc_a99508824120e315, []int{59}
 }
 func (m *WalletBalanceResponse) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_WalletBalanceResponse.Unmarshal(m, b)
@@ -4348,7 +4348,7 @@ func (m *ChannelBalanceRequest) Reset()         { *m = ChannelBalanceRequest{} }
 func (m *ChannelBalanceRequest) String() string { return proto.CompactTextString(m) }
 func (*ChannelBalanceRequest) ProtoMessage()    {}
 func (*ChannelBalanceRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_rpc_665fbe676d0b2b6b, []int{60}
+	return fileDescriptor_rpc_a99508824120e315, []int{60}
 }
 func (m *ChannelBalanceRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_ChannelBalanceRequest.Unmarshal(m, b)
@@ -4382,7 +4382,7 @@ func (m *ChannelBalanceResponse) Reset()         { *m = ChannelBalanceResponse{}
 func (m *ChannelBalanceResponse) String() string { return proto.CompactTextString(m) }
 func (*ChannelBalanceResponse) ProtoMessage()    {}
 func (*ChannelBalanceResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_rpc_665fbe676d0b2b6b, []int{61}
+	return fileDescriptor_rpc_a99508824120e315, []int{61}
 }
 func (m *ChannelBalanceResponse) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_ChannelBalanceResponse.Unmarshal(m, b)
@@ -4440,7 +4440,7 @@ func (m *QueryRoutesRequest) Reset()         { *m = QueryRoutesRequest{} }
 func (m *QueryRoutesRequest) String() string { return proto.CompactTextString(m) }
 func (*QueryRoutesRequest) ProtoMessage()    {}
 func (*QueryRoutesRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_rpc_665fbe676d0b2b6b, []int{62}
+	return fileDescriptor_rpc_a99508824120e315, []int{62}
 }
 func (m *QueryRoutesRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_QueryRoutesRequest.Unmarshal(m, b)
@@ -4506,7 +4506,7 @@ func (m *QueryRoutesResponse) Reset()         { *m = QueryRoutesResponse{} }
 func (m *QueryRoutesResponse) String() string { return proto.CompactTextString(m) }
 func (*QueryRoutesResponse) ProtoMessage()    {}
 func (*QueryRoutesResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_rpc_665fbe676d0b2b6b, []int{63}
+	return fileDescriptor_rpc_a99508824120e315, []int{63}
 }
 func (m *QueryRoutesResponse) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_QueryRoutesResponse.Unmarshal(m, b)
@@ -4558,7 +4558,7 @@ func (m *Hop) Reset()         { *m = Hop{} }
 func (m *Hop) String() string { return proto.CompactTextString(m) }
 func (*Hop) ProtoMessage()    {}
 func (*Hop) Descriptor() ([]byte, []int) {
-	return fileDescriptor_rpc_665fbe676d0b2b6b, []int{64}
+	return fileDescriptor_rpc_a99508824120e315, []int{64}
 }
 func (m *Hop) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_Hop.Unmarshal(m, b)
@@ -4679,7 +4679,7 @@ func (m *Route) Reset()         { *m = Route{} }
 func (m *Route) String() string { return proto.CompactTextString(m) }
 func (*Route) ProtoMessage()    {}
 func (*Route) Descriptor() ([]byte, []int) {
-	return fileDescriptor_rpc_665fbe676d0b2b6b, []int{65}
+	return fileDescriptor_rpc_a99508824120e315, []int{65}
 }
 func (m *Route) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_Route.Unmarshal(m, b)
@@ -4755,7 +4755,7 @@ func (m *NodeInfoRequest) Reset()         { *m = NodeInfoRequest{} }
 func (m *NodeInfoRequest) String() string { return proto.CompactTextString(m) }
 func (*NodeInfoRequest) ProtoMessage()    {}
 func (*NodeInfoRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_rpc_665fbe676d0b2b6b, []int{66}
+	return fileDescriptor_rpc_a99508824120e315, []int{66}
 }
 func (m *NodeInfoRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_NodeInfoRequest.Unmarshal(m, b)
@@ -4800,7 +4800,7 @@ func (m *NodeInfo) Reset()         { *m = NodeInfo{} }
 func (m *NodeInfo) String() string { return proto.CompactTextString(m) }
 func (*NodeInfo) ProtoMessage()    {}
 func (*NodeInfo) Descriptor() ([]byte, []int) {
-	return fileDescriptor_rpc_665fbe676d0b2b6b, []int{67}
+	return fileDescriptor_rpc_a99508824120e315, []int{67}
 }
 func (m *NodeInfo) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_NodeInfo.Unmarshal(m, b)
@@ -4861,7 +4861,7 @@ func (m *LightningNode) Reset()         { *m = LightningNode{} }
 func (m *LightningNode) String() string { return proto.CompactTextString(m) }
 func (*LightningNode) ProtoMessage()    {}
 func (*LightningNode) Descriptor() ([]byte, []int) {
-	return fileDescriptor_rpc_665fbe676d0b2b6b, []int{68}
+	return fileDescriptor_rpc_a99508824120e315, []int{68}
 }
 func (m *LightningNode) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_LightningNode.Unmarshal(m, b)
@@ -4928,7 +4928,7 @@ func (m *NodeAddress) Reset()         { *m = NodeAddress{} }
 func (m *NodeAddress) String() string { return proto.CompactTextString(m) }
 func (*NodeAddress) ProtoMessage()    {}
 func (*NodeAddress) Descriptor() ([]byte, []int) {
-	return fileDescriptor_rpc_665fbe676d0b2b6b, []int{69}
+	return fileDescriptor_rpc_a99508824120e315, []int{69}
 }
 func (m *NodeAddress) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_NodeAddress.Unmarshal(m, b)
@@ -4977,7 +4977,7 @@ func (m *RoutingPolicy) Reset()         { *m = RoutingPolicy{} }
 func (m *RoutingPolicy) String() string { return proto.CompactTextString(m) }
 func (*RoutingPolicy) ProtoMessage()    {}
 func (*RoutingPolicy) Descriptor() ([]byte, []int) {
-	return fileDescriptor_rpc_665fbe676d0b2b6b, []int{70}
+	return fileDescriptor_rpc_a99508824120e315, []int{70}
 }
 func (m *RoutingPolicy) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_RoutingPolicy.Unmarshal(m, b)
@@ -5060,7 +5060,7 @@ func (m *ChannelEdge) Reset()         { *m = ChannelEdge{} }
 func (m *ChannelEdge) String() string { return proto.CompactTextString(m) }
 func (*ChannelEdge) ProtoMessage()    {}
 func (*ChannelEdge) Descriptor() ([]byte, []int) {
-	return fileDescriptor_rpc_665fbe676d0b2b6b, []int{71}
+	return fileDescriptor_rpc_a99508824120e315, []int{71}
 }
 func (m *ChannelEdge) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_ChannelEdge.Unmarshal(m, b)
@@ -5151,7 +5151,7 @@ func (m *ChannelGraphRequest) Reset()         { *m = ChannelGraphRequest{} }
 func (m *ChannelGraphRequest) String() string { return proto.CompactTextString(m) }
 func (*ChannelGraphRequest) ProtoMessage()    {}
 func (*ChannelGraphRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_rpc_665fbe676d0b2b6b, []int{72}
+	return fileDescriptor_rpc_a99508824120e315, []int{72}
 }
 func (m *ChannelGraphRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_ChannelGraphRequest.Unmarshal(m, b)
@@ -5193,7 +5193,7 @@ func (m *ChannelGraph) Reset()         { *m = ChannelGraph{} }
 func (m *ChannelGraph) String() string { return proto.CompactTextString(m) }
 func (*ChannelGraph) ProtoMessage()    {}
 func (*ChannelGraph) Descriptor() ([]byte, []int) {
-	return fileDescriptor_rpc_665fbe676d0b2b6b, []int{73}
+	return fileDescriptor_rpc_a99508824120e315, []int{73}
 }
 func (m *ChannelGraph) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_ChannelGraph.Unmarshal(m, b)
@@ -5242,7 +5242,7 @@ func (m *ChanInfoRequest) Reset()         { *m = ChanInfoRequest{} }
 func (m *ChanInfoRequest) String() string { return proto.CompactTextString(m) }
 func (*ChanInfoRequest) ProtoMessage()    {}
 func (*ChanInfoRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_rpc_665fbe676d0b2b6b, []int{74}
+	return fileDescriptor_rpc_a99508824120e315, []int{74}
 }
 func (m *ChanInfoRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_ChanInfoRequest.Unmarshal(m, b)
@@ -5279,7 +5279,7 @@ func (m *NetworkInfoRequest) Reset()         { *m = NetworkInfoRequest{} }
 func (m *NetworkInfoRequest) String() string { return proto.CompactTextString(m) }
 func (*NetworkInfoRequest) ProtoMessage()    {}
 func (*NetworkInfoRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_rpc_665fbe676d0b2b6b, []int{75}
+	return fileDescriptor_rpc_a99508824120e315, []int{75}
 }
 func (m *NetworkInfoRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_NetworkInfoRequest.Unmarshal(m, b)
@@ -5318,7 +5318,7 @@ func (m *NetworkInfo) Reset()         { *m = NetworkInfo{} }
 func (m *NetworkInfo) String() string { return proto.CompactTextString(m) }
 func (*NetworkInfo) ProtoMessage()    {}
 func (*NetworkInfo) Descriptor() ([]byte, []int) {
-	return fileDescriptor_rpc_665fbe676d0b2b6b, []int{76}
+	return fileDescriptor_rpc_a99508824120e315, []int{76}
 }
 func (m *NetworkInfo) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_NetworkInfo.Unmarshal(m, b)
@@ -5411,7 +5411,7 @@ func (m *StopRequest) Reset()         { *m = StopRequest{} }
 func (m *StopRequest) String() string { return proto.CompactTextString(m) }
 func (*StopRequest) ProtoMessage()    {}
 func (*StopRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_rpc_665fbe676d0b2b6b, []int{77}
+	return fileDescriptor_rpc_a99508824120e315, []int{77}
 }
 func (m *StopRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_StopRequest.Unmarshal(m, b)
@@ -5441,7 +5441,7 @@ func (m *StopResponse) Reset()         { *m = StopResponse{} }
 func (m *StopResponse) String() string { return proto.CompactTextString(m) }
 func (*StopResponse) ProtoMessage()    {}
 func (*StopResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_rpc_665fbe676d0b2b6b, []int{78}
+	return fileDescriptor_rpc_a99508824120e315, []int{78}
 }
 func (m *StopResponse) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_StopResponse.Unmarshal(m, b)
@@ -5471,7 +5471,7 @@ func (m *GraphTopologySubscription) Reset()         { *m = GraphTopologySubscrip
 func (m *GraphTopologySubscription) String() string { return proto.CompactTextString(m) }
 func (*GraphTopologySubscription) ProtoMessage()    {}
 func (*GraphTopologySubscription) Descriptor() ([]byte, []int) {
-	return fileDescriptor_rpc_665fbe676d0b2b6b, []int{79}
+	return fileDescriptor_rpc_a99508824120e315, []int{79}
 }
 func (m *GraphTopologySubscription) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_GraphTopologySubscription.Unmarshal(m, b)
@@ -5504,7 +5504,7 @@ func (m *GraphTopologyUpdate) Reset()         { *m = GraphTopologyUpdate{} }
 func (m *GraphTopologyUpdate) String() string { return proto.CompactTextString(m) }
 func (*GraphTopologyUpdate) ProtoMessage()    {}
 func (*GraphTopologyUpdate) Descriptor() ([]byte, []int) {
-	return fileDescriptor_rpc_665fbe676d0b2b6b, []int{80}
+	return fileDescriptor_rpc_a99508824120e315, []int{80}
 }
 func (m *GraphTopologyUpdate) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_GraphTopologyUpdate.Unmarshal(m, b)
@@ -5559,7 +5559,7 @@ func (m *NodeUpdate) Reset()         { *m = NodeUpdate{} }
 func (m *NodeUpdate) String() string { return proto.CompactTextString(m) }
 func (*NodeUpdate) ProtoMessage()    {}
 func (*NodeUpdate) Descriptor() ([]byte, []int) {
-	return fileDescriptor_rpc_665fbe676d0b2b6b, []int{81}
+	return fileDescriptor_rpc_a99508824120e315, []int{81}
 }
 func (m *NodeUpdate) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_NodeUpdate.Unmarshal(m, b)
@@ -5627,7 +5627,7 @@ func (m *ChannelEdgeUpdate) Reset()         { *m = ChannelEdgeUpdate{} }
 func (m *ChannelEdgeUpdate) String() string { return proto.CompactTextString(m) }
 func (*ChannelEdgeUpdate) ProtoMessage()    {}
 func (*ChannelEdgeUpdate) Descriptor() ([]byte, []int) {
-	return fileDescriptor_rpc_665fbe676d0b2b6b, []int{82}
+	return fileDescriptor_rpc_a99508824120e315, []int{82}
 }
 func (m *ChannelEdgeUpdate) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_ChannelEdgeUpdate.Unmarshal(m, b)
@@ -5707,7 +5707,7 @@ func (m *ClosedChannelUpdate) Reset()         { *m = ClosedChannelUpdate{} }
 func (m *ClosedChannelUpdate) String() string { return proto.CompactTextString(m) }
 func (*ClosedChannelUpdate) ProtoMessage()    {}
 func (*ClosedChannelUpdate) Descriptor() ([]byte, []int) {
-	return fileDescriptor_rpc_665fbe676d0b2b6b, []int{83}
+	return fileDescriptor_rpc_a99508824120e315, []int{83}
 }
 func (m *ClosedChannelUpdate) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_ClosedChannelUpdate.Unmarshal(m, b)
@@ -5777,7 +5777,7 @@ func (m *HopHint) Reset()         { *m = HopHint{} }
 func (m *HopHint) String() string { return proto.CompactTextString(m) }
 func (*HopHint) ProtoMessage()    {}
 func (*HopHint) Descriptor() ([]byte, []int) {
-	return fileDescriptor_rpc_665fbe676d0b2b6b, []int{84}
+	return fileDescriptor_rpc_a99508824120e315, []int{84}
 }
 func (m *HopHint) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_HopHint.Unmarshal(m, b)
@@ -5846,7 +5846,7 @@ func (m *RouteHint) Reset()         { *m = RouteHint{} }
 func (m *RouteHint) String() string { return proto.CompactTextString(m) }
 func (*RouteHint) ProtoMessage()    {}
 func (*RouteHint) Descriptor() ([]byte, []int) {
-	return fileDescriptor_rpc_665fbe676d0b2b6b, []int{85}
+	return fileDescriptor_rpc_a99508824120e315, []int{85}
 }
 func (m *RouteHint) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_RouteHint.Unmarshal(m, b)
@@ -5961,7 +5961,7 @@ func (m *Invoice) Reset()         { *m = Invoice{} }
 func (m *Invoice) String() string { return proto.CompactTextString(m) }
 func (*Invoice) ProtoMessage()    {}
 func (*Invoice) Descriptor() ([]byte, []int) {
-	return fileDescriptor_rpc_665fbe676d0b2b6b, []int{86}
+	return fileDescriptor_rpc_a99508824120e315, []int{86}
 }
 func (m *Invoice) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_Invoice.Unmarshal(m, b)
@@ -6153,7 +6153,7 @@ func (m *AddInvoiceResponse) Reset()         { *m = AddInvoiceResponse{} }
 func (m *AddInvoiceResponse) String() string { return proto.CompactTextString(m) }
 func (*AddInvoiceResponse) ProtoMessage()    {}
 func (*AddInvoiceResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_rpc_665fbe676d0b2b6b, []int{87}
+	return fileDescriptor_rpc_a99508824120e315, []int{87}
 }
 func (m *AddInvoiceResponse) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_AddInvoiceResponse.Unmarshal(m, b)
@@ -6210,7 +6210,7 @@ func (m *PaymentHash) Reset()         { *m = PaymentHash{} }
 func (m *PaymentHash) String() string { return proto.CompactTextString(m) }
 func (*PaymentHash) ProtoMessage()    {}
 func (*PaymentHash) Descriptor() ([]byte, []int) {
-	return fileDescriptor_rpc_665fbe676d0b2b6b, []int{88}
+	return fileDescriptor_rpc_a99508824120e315, []int{88}
 }
 func (m *PaymentHash) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_PaymentHash.Unmarshal(m, b)
@@ -6266,7 +6266,7 @@ func (m *ListInvoiceRequest) Reset()         { *m = ListInvoiceRequest{} }
 func (m *ListInvoiceRequest) String() string { return proto.CompactTextString(m) }
 func (*ListInvoiceRequest) ProtoMessage()    {}
 func (*ListInvoiceRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_rpc_665fbe676d0b2b6b, []int{89}
+	return fileDescriptor_rpc_a99508824120e315, []int{89}
 }
 func (m *ListInvoiceRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_ListInvoiceRequest.Unmarshal(m, b)
@@ -6336,7 +6336,7 @@ func (m *ListInvoiceResponse) Reset()         { *m = ListInvoiceResponse{} }
 func (m *ListInvoiceResponse) String() string { return proto.CompactTextString(m) }
 func (*ListInvoiceResponse) ProtoMessage()    {}
 func (*ListInvoiceResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_rpc_665fbe676d0b2b6b, []int{90}
+	return fileDescriptor_rpc_a99508824120e315, []int{90}
 }
 func (m *ListInvoiceResponse) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_ListInvoiceResponse.Unmarshal(m, b)
@@ -6399,7 +6399,7 @@ func (m *InvoiceSubscription) Reset()         { *m = InvoiceSubscription{} }
 func (m *InvoiceSubscription) String() string { return proto.CompactTextString(m) }
 func (*InvoiceSubscription) ProtoMessage()    {}
 func (*InvoiceSubscription) Descriptor() ([]byte, []int) {
-	return fileDescriptor_rpc_665fbe676d0b2b6b, []int{91}
+	return fileDescriptor_rpc_a99508824120e315, []int{91}
 }
 func (m *InvoiceSubscription) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_InvoiceSubscription.Unmarshal(m, b)
@@ -6459,7 +6459,7 @@ func (m *Payment) Reset()         { *m = Payment{} }
 func (m *Payment) String() string { return proto.CompactTextString(m) }
 func (*Payment) ProtoMessage()    {}
 func (*Payment) Descriptor() ([]byte, []int) {
-	return fileDescriptor_rpc_665fbe676d0b2b6b, []int{92}
+	return fileDescriptor_rpc_a99508824120e315, []int{92}
 }
 func (m *Payment) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_Payment.Unmarshal(m, b)
@@ -6546,7 +6546,7 @@ func (m *ListPaymentsRequest) Reset()         { *m = ListPaymentsRequest{} }
 func (m *ListPaymentsRequest) String() string { return proto.CompactTextString(m) }
 func (*ListPaymentsRequest) ProtoMessage()    {}
 func (*ListPaymentsRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_rpc_665fbe676d0b2b6b, []int{93}
+	return fileDescriptor_rpc_a99508824120e315, []int{93}
 }
 func (m *ListPaymentsRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_ListPaymentsRequest.Unmarshal(m, b)
@@ -6578,7 +6578,7 @@ func (m *ListPaymentsResponse) Reset()         { *m = ListPaymentsResponse{} }
 func (m *ListPaymentsResponse) String() string { return proto.CompactTextString(m) }
 func (*ListPaymentsResponse) ProtoMessage()    {}
 func (*ListPaymentsResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_rpc_665fbe676d0b2b6b, []int{94}
+	return fileDescriptor_rpc_a99508824120e315, []int{94}
 }
 func (m *ListPaymentsResponse) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_ListPaymentsResponse.Unmarshal(m, b)
@@ -6615,7 +6615,7 @@ func (m *DeleteAllPaymentsRequest) Reset()         { *m = DeleteAllPaymentsReque
 func (m *DeleteAllPaymentsRequest) String() string { return proto.CompactTextString(m) }
 func (*DeleteAllPaymentsRequest) ProtoMessage()    {}
 func (*DeleteAllPaymentsRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_rpc_665fbe676d0b2b6b, []int{95}
+	return fileDescriptor_rpc_a99508824120e315, []int{95}
 }
 func (m *DeleteAllPaymentsRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_DeleteAllPaymentsRequest.Unmarshal(m, b)
@@ -6645,7 +6645,7 @@ func (m *DeleteAllPaymentsResponse) Reset()         { *m = DeleteAllPaymentsResp
 func (m *DeleteAllPaymentsResponse) String() string { return proto.CompactTextString(m) }
 func (*DeleteAllPaymentsResponse) ProtoMessage()    {}
 func (*DeleteAllPaymentsResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_rpc_665fbe676d0b2b6b, []int{96}
+	return fileDescriptor_rpc_a99508824120e315, []int{96}
 }
 func (m *DeleteAllPaymentsResponse) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_DeleteAllPaymentsResponse.Unmarshal(m, b)
@@ -6676,7 +6676,7 @@ func (m *AbandonChannelRequest) Reset()         { *m = AbandonChannelRequest{} }
 func (m *AbandonChannelRequest) String() string { return proto.CompactTextString(m) }
 func (*AbandonChannelRequest) ProtoMessage()    {}
 func (*AbandonChannelRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_rpc_665fbe676d0b2b6b, []int{97}
+	return fileDescriptor_rpc_a99508824120e315, []int{97}
 }
 func (m *AbandonChannelRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_AbandonChannelRequest.Unmarshal(m, b)
@@ -6713,7 +6713,7 @@ func (m *AbandonChannelResponse) Reset()         { *m = AbandonChannelResponse{}
 func (m *AbandonChannelResponse) String() string { return proto.CompactTextString(m) }
 func (*AbandonChannelResponse) ProtoMessage()    {}
 func (*AbandonChannelResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_rpc_665fbe676d0b2b6b, []int{98}
+	return fileDescriptor_rpc_a99508824120e315, []int{98}
 }
 func (m *AbandonChannelResponse) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_AbandonChannelResponse.Unmarshal(m, b)
@@ -6745,7 +6745,7 @@ func (m *DebugLevelRequest) Reset()         { *m = DebugLevelRequest{} }
 func (m *DebugLevelRequest) String() string { return proto.CompactTextString(m) }
 func (*DebugLevelRequest) ProtoMessage()    {}
 func (*DebugLevelRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_rpc_665fbe676d0b2b6b, []int{99}
+	return fileDescriptor_rpc_a99508824120e315, []int{99}
 }
 func (m *DebugLevelRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_DebugLevelRequest.Unmarshal(m, b)
@@ -6790,7 +6790,7 @@ func (m *DebugLevelResponse) Reset()         { *m = DebugLevelResponse{} }
 func (m *DebugLevelResponse) String() string { return proto.CompactTextString(m) }
 func (*DebugLevelResponse) ProtoMessage()    {}
 func (*DebugLevelResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_rpc_665fbe676d0b2b6b, []int{100}
+	return fileDescriptor_rpc_a99508824120e315, []int{100}
 }
 func (m *DebugLevelResponse) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_DebugLevelResponse.Unmarshal(m, b)
@@ -6829,7 +6829,7 @@ func (m *PayReqString) Reset()         { *m = PayReqString{} }
 func (m *PayReqString) String() string { return proto.CompactTextString(m) }
 func (*PayReqString) ProtoMessage()    {}
 func (*PayReqString) Descriptor() ([]byte, []int) {
-	return fileDescriptor_rpc_665fbe676d0b2b6b, []int{101}
+	return fileDescriptor_rpc_a99508824120e315, []int{101}
 }
 func (m *PayReqString) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_PayReqString.Unmarshal(m, b)
@@ -6876,7 +6876,7 @@ func (m *PayReq) Reset()         { *m = PayReq{} }
 func (m *PayReq) String() string { return proto.CompactTextString(m) }
 func (*PayReq) ProtoMessage()    {}
 func (*PayReq) Descriptor() ([]byte, []int) {
-	return fileDescriptor_rpc_665fbe676d0b2b6b, []int{102}
+	return fileDescriptor_rpc_a99508824120e315, []int{102}
 }
 func (m *PayReq) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_PayReq.Unmarshal(m, b)
@@ -6976,7 +6976,7 @@ func (m *FeeReportRequest) Reset()         { *m = FeeReportRequest{} }
 func (m *FeeReportRequest) String() string { return proto.CompactTextString(m) }
 func (*FeeReportRequest) ProtoMessage()    {}
 func (*FeeReportRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_rpc_665fbe676d0b2b6b, []int{103}
+	return fileDescriptor_rpc_a99508824120e315, []int{103}
 }
 func (m *FeeReportRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_FeeReportRequest.Unmarshal(m, b)
@@ -7014,7 +7014,7 @@ func (m *ChannelFeeReport) Reset()         { *m = ChannelFeeReport{} }
 func (m *ChannelFeeReport) String() string { return proto.CompactTextString(m) }
 func (*ChannelFeeReport) ProtoMessage()    {}
 func (*ChannelFeeReport) Descriptor() ([]byte, []int) {
-	return fileDescriptor_rpc_665fbe676d0b2b6b, []int{104}
+	return fileDescriptor_rpc_a99508824120e315, []int{104}
 }
 func (m *ChannelFeeReport) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_ChannelFeeReport.Unmarshal(m, b)
@@ -7080,7 +7080,7 @@ func (m *FeeReportResponse) Reset()         { *m = FeeReportResponse{} }
 func (m *FeeReportResponse) String() string { return proto.CompactTextString(m) }
 func (*FeeReportResponse) ProtoMessage()    {}
 func (*FeeReportResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_rpc_665fbe676d0b2b6b, []int{105}
+	return fileDescriptor_rpc_a99508824120e315, []int{105}
 }
 func (m *FeeReportResponse) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_FeeReportResponse.Unmarshal(m, b)
@@ -7148,7 +7148,7 @@ func (m *PolicyUpdateRequest) Reset()         { *m = PolicyUpdateRequest{} }
 func (m *PolicyUpdateRequest) String() string { return proto.CompactTextString(m) }
 func (*PolicyUpdateRequest) ProtoMessage()    {}
 func (*PolicyUpdateRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_rpc_665fbe676d0b2b6b, []int{106}
+	return fileDescriptor_rpc_a99508824120e315, []int{106}
 }
 func (m *PolicyUpdateRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_PolicyUpdateRequest.Unmarshal(m, b)
@@ -7309,7 +7309,7 @@ func (m *PolicyUpdateResponse) Reset()         { *m = PolicyUpdateResponse{} }
 func (m *PolicyUpdateResponse) String() string { return proto.CompactTextString(m) }
 func (*PolicyUpdateResponse) ProtoMessage()    {}
 func (*PolicyUpdateResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_rpc_665fbe676d0b2b6b, []int{107}
+	return fileDescriptor_rpc_a99508824120e315, []int{107}
 }
 func (m *PolicyUpdateResponse) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_PolicyUpdateResponse.Unmarshal(m, b)
@@ -7347,7 +7347,7 @@ func (m *ForwardingHistoryRequest) Reset()         { *m = ForwardingHistoryReque
 func (m *ForwardingHistoryRequest) String() string { return proto.CompactTextString(m) }
 func (*ForwardingHistoryRequest) ProtoMessage()    {}
 func (*ForwardingHistoryRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_rpc_665fbe676d0b2b6b, []int{108}
+	return fileDescriptor_rpc_a99508824120e315, []int{108}
 }
 func (m *ForwardingHistoryRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_ForwardingHistoryRequest.Unmarshal(m, b)
@@ -7419,7 +7419,7 @@ func (m *ForwardingEvent) Reset()         { *m = ForwardingEvent{} }
 func (m *ForwardingEvent) String() string { return proto.CompactTextString(m) }
 func (*ForwardingEvent) ProtoMessage()    {}
 func (*ForwardingEvent) Descriptor() ([]byte, []int) {
-	return fileDescriptor_rpc_665fbe676d0b2b6b, []int{109}
+	return fileDescriptor_rpc_a99508824120e315, []int{109}
 }
 func (m *ForwardingEvent) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_ForwardingEvent.Unmarshal(m, b)
@@ -7502,7 +7502,7 @@ func (m *ForwardingHistoryResponse) Reset()         { *m = ForwardingHistoryResp
 func (m *ForwardingHistoryResponse) String() string { return proto.CompactTextString(m) }
 func (*ForwardingHistoryResponse) ProtoMessage()    {}
 func (*ForwardingHistoryResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_rpc_665fbe676d0b2b6b, []int{110}
+	return fileDescriptor_rpc_a99508824120e315, []int{110}
 }
 func (m *ForwardingHistoryResponse) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_ForwardingHistoryResponse.Unmarshal(m, b)
@@ -8032,10 +8032,8 @@ type LightningClient interface {
 	// paginated responses, allowing users to query for specific invoices through
 	// their add_index. This can be done by using either the first_index_offset or
 	// last_index_offset fields included in the response as the index_offset of the
-	// next request. The reversed flag is set by default in order to paginate
-	// backwards. If you wish to paginate forwards, you must explicitly set the
-	// flag to false. If none of the parameters are specified, then the last 100
-	// invoices will be returned.
+	// next request. By default, the first 100 invoices created will be returned.
+	// Backwards pagination is also supported through the Reversed flag.
 	ListInvoices(ctx context.Context, in *ListInvoiceRequest, opts ...grpc.CallOption) (*ListInvoiceResponse, error)
 	// * lncli: `lookupinvoice`
 	// LookupInvoice attempts to look up an invoice according to its payment hash.
@@ -8831,10 +8829,8 @@ type LightningServer interface {
 	// paginated responses, allowing users to query for specific invoices through
 	// their add_index. This can be done by using either the first_index_offset or
 	// last_index_offset fields included in the response as the index_offset of the
-	// next request. The reversed flag is set by default in order to paginate
-	// backwards. If you wish to paginate forwards, you must explicitly set the
-	// flag to false. If none of the parameters are specified, then the last 100
-	// invoices will be returned.
+	// next request. By default, the first 100 invoices created will be returned.
+	// Backwards pagination is also supported through the Reversed flag.
 	ListInvoices(context.Context, *ListInvoiceRequest) (*ListInvoiceResponse, error)
 	// * lncli: `lookupinvoice`
 	// LookupInvoice attempts to look up an invoice according to its payment hash.
@@ -9932,9 +9928,9 @@ var _Lightning_serviceDesc = grpc.ServiceDesc{
 	Metadata: "rpc.proto",
 }
 
-func init() { proto.RegisterFile("rpc.proto", fileDescriptor_rpc_665fbe676d0b2b6b) }
+func init() { proto.RegisterFile("rpc.proto", fileDescriptor_rpc_a99508824120e315) }
 
-var fileDescriptor_rpc_665fbe676d0b2b6b = []byte{
+var fileDescriptor_rpc_a99508824120e315 = []byte{
 	// 6754 bytes of a gzipped FileDescriptorProto
 	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xbc, 0x7c, 0x5d, 0x6c, 0x24, 0xd9,
 	0x55, 0xff, 0x54, 0xbb, 0xdb, 0xee, 0x3e, 0xdd, 0xb6, 0xdb, 0xd7, 0x5f, 0x3d, 0xbd, 0xb3, 0xb3,

--- a/lnrpc/rpc.proto
+++ b/lnrpc/rpc.proto
@@ -478,10 +478,8 @@ service Lightning {
     paginated responses, allowing users to query for specific invoices through
     their add_index. This can be done by using either the first_index_offset or
     last_index_offset fields included in the response as the index_offset of the
-    next request. The reversed flag is set by default in order to paginate
-    backwards. If you wish to paginate forwards, you must explicitly set the
-    flag to false. If none of the parameters are specified, then the last 100
-    invoices will be returned.
+    next request. By default, the first 100 invoices created will be returned.
+    Backwards pagination is also supported through the Reversed flag.
     */
     rpc ListInvoices (ListInvoiceRequest) returns (ListInvoiceResponse) {
         option (google.api.http) = {

--- a/lnrpc/rpc.swagger.json
+++ b/lnrpc/rpc.swagger.json
@@ -663,7 +663,7 @@
     },
     "/v1/invoices": {
       "get": {
-        "summary": "* lncli: `listinvoices`\nListInvoices returns a list of all the invoices currently stored within the\ndatabase. Any active debug invoices are ignored. It has full support for\npaginated responses, allowing users to query for specific invoices through\ntheir add_index. This can be done by using either the first_index_offset or\nlast_index_offset fields included in the response as the index_offset of the\nnext request. The reversed flag is set by default in order to paginate\nbackwards. If you wish to paginate forwards, you must explicitly set the\nflag to false. If none of the parameters are specified, then the last 100\ninvoices will be returned.",
+        "summary": "* lncli: `listinvoices`\nListInvoices returns a list of all the invoices currently stored within the\ndatabase. Any active debug invoices are ignored. It has full support for\npaginated responses, allowing users to query for specific invoices through\ntheir add_index. This can be done by using either the first_index_offset or\nlast_index_offset fields included in the response as the index_offset of the\nnext request. By default, the first 100 invoices created will be returned.\nBackwards pagination is also supported through the Reversed flag.",
         "operationId": "ListInvoices",
         "responses": {
           "200": {


### PR DESCRIPTION
Currently, the documentation includes details for `lncli`. This commit
modifies it to reflect the behavior of the RPC interface instead, as it
should.