### PR TITLE
add named volume to lnd service for persisting data accross container…

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -63,8 +63,12 @@ bitcoin into.
 # Init bitcoin network env variable:
 $ export NETWORK="simnet" 
 
+# Create persistent volumes for alice and bob.
+docker volume create simnet_lnd_alice
+docker volume create simnet_lnd_bob
+
 # Run the "Alice" container and log into it:
-$ docker-compose run -d --name alice lnd_btc
+$ docker-compose run -d --name alice --volume simnet_lnd_alice:/root/.lnd lnd_btc
 $ docker exec -i -t alice bash
 
 # Generate a new backward compatible nested p2sh address for Alice:
@@ -90,7 +94,7 @@ Connect `Bob` node to `Alice` node.
 
 ```bash
 # Run "Bob" node and log into it:
-$ docker-compose run -d --name bob lnd_btc
+$ docker-compose run -d --name bob --volume simnet_lnd_bob:/root/.lnd lnd_btc
 $ docker exec -i -t bob bash
 
 # Get the identity pubkey of "Bob" node:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -9,8 +9,8 @@ services:
       build:
         context: btcd/
       volumes:
-            - shared:/rpc
-            - bitcoin:/data
+        - shared:/rpc
+        - bitcoin:/data
       environment:
         - RPCUSER
         - RPCPASS
@@ -41,8 +41,8 @@ services:
       build:
         context: ltcd/
       volumes:
-            - shared:/rpc
-            - litecoin:/data
+        - shared:/rpc
+        - litecoin:/data
       environment:
         - RPCUSER
         - RPCPASS
@@ -76,7 +76,8 @@ services:
           - CHAIN
           - DEBUG
         volumes:
-            - shared:/rpc
+          - shared:/rpc
+          - lnd:/root/.lnd
         entrypoint: ["./start-lnd.sh"]
 
     lnd_ltc:
@@ -100,6 +101,11 @@ volumes:
   # bitcoin volume is needed for maintaining blockchain persistence
   # during btcd container recreation.
   bitcoin:
+    driver: local
+
+  # lnd volume is used for persisting lnd application data and chain state
+  # during container lifecycle.
+  lnd:
     driver: local
 
   # litecoin volume is needed for maintaining blockchain persistence

--- a/docker/lnd/start-lnd.sh
+++ b/docker/lnd/start-lnd.sh
@@ -51,7 +51,6 @@ fi
 
 exec lnd \
     --noseedbackup \
-    --logdir="/data" \
     "--$CHAIN.active" \
     "--$CHAIN.$NETWORK" \
     "--$CHAIN.node"="btcd" \


### PR DESCRIPTION
Add a named volume to `docker-compose.yml` for persisting lnd application volume state.  Without this volume, if the container is brought down (for example using `docker-compose down`) the state is lost, and lnd needs to resync, eg:

`lnd_btc    | 2019-01-18 16:38:41.154 [INF] LNWL: Caught up to height 10000`

Adding this volume will persist the state along with `btc` similar to how a local install would work.  The new volume can be inspected using `docker volume inspect docker_lnd `.  Using a named volume in `docker-compose` allows `docker` to re-attach to the named volume during `docker up`.  This is preferable to an anonymous volume which isn't recognized by `docker-compose` and so this PR replaces [#2507](https://github.com/lightningnetwork/lnd/pull/2507)

