### PR TITLE
lnrpc: fix comment typo

### DIFF
--- a/lnrpc/rpc.pb.go
+++ b/lnrpc/rpc.pb.go
@@ -2127,7 +2127,7 @@ type Channel struct {
 	CsvDelay uint32 `protobuf:"varint,16,opt,name=csv_delay,proto3" json:"csv_delay,omitempty"`
 	// / Whether this channel is advertised to the network or not.
 	Private bool `protobuf:"varint,17,opt,name=private,proto3" json:"private,omitempty"`
-	// / True if we were the ones that creted the channel.
+	// / True if we were the ones that created the channel.
 	Initiator            bool     `protobuf:"varint,18,opt,name=initiator,proto3" json:"initiator,omitempty"`
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
 	XXX_unrecognized     []byte   `json:"-"`

--- a/lnrpc/rpc.proto
+++ b/lnrpc/rpc.proto
@@ -1013,7 +1013,7 @@ message Channel {
     /// Whether this channel is advertised to the network or not.
     bool private = 17 [json_name = "private"];
 
-    /// True if we were the ones that creted the channel.
+    /// True if we were the ones that created the channel.
     bool initiator = 18 [json_name = "initiator"];
 }
 

--- a/lnrpc/rpc.swagger.json
+++ b/lnrpc/rpc.swagger.json
@@ -1406,7 +1406,7 @@
         "initiator": {
           "type": "boolean",
           "format": "boolean",
-          "description": "/ True if we were the ones that creted the channel."
+          "description": "/ True if we were the ones that created the channel."
         }
       }
     },


### PR DESCRIPTION
i guess "creted" should be "created"