### PR TITLE
config: increase default trickle delay from 30s to 1m30s

### DIFF
--- a/config.go
+++ b/config.go
@@ -49,7 +49,7 @@ const (
 	defaultRPCHost             = "localhost"
 	defaultMaxPendingChannels  = 1
 	defaultNoSeedBackup        = false
-	defaultTrickleDelay        = 30 * 1000
+	defaultTrickleDelay        = 90 * 1000
 	defaultInactiveChanTimeout = 20 * time.Minute
 	defaultMaxLogFiles         = 3
 	defaultMaxLogFileSize      = 10


### PR DESCRIPTION
In this commit, we increase the default trickle delay from 30s to 1m30s.
We do this as before we implement the new INV gossip mechanism, we want
to de-emphasise the quick propagation of updates through the network
which eats up bandwidth.
