### PR TITLE
Add support for Tor authentication via password

### DIFF
--- a/config.go
+++ b/config.go
@@ -220,6 +220,7 @@ type torConfig struct {
 	StreamIsolation bool   `long:"streamisolation" description:"Enable Tor stream isolation by randomizing user credentials for each connection."`
 	Control         string `long:"control" description:"The host:port that Tor is listening on for Tor control connections"`
 	TargetIPAddress string `long:"targetipaddress" description:"IP address that Tor should use as the target of the hidden service"`
+	Password        string `long:"password" description:"Password for the control port. If provided it will be used instead of the SAFECOOKIE authentication method."`
 	V2              bool   `long:"v2" description:"Automatically set up a v2 onion service to listen for inbound connections"`
 	V3              bool   `long:"v3" description:"Automatically set up a v3 onion service to listen for inbound connections"`
 	PrivateKeyPath  string `long:"privatekeypath" description:"The path to the private key of the onion service being created"`

--- a/server.go
+++ b/server.go
@@ -578,7 +578,7 @@ func newServer(listenAddrs []net.Addr, chanDB *channeldb.DB,
 	// automatically create an onion service, we'll initiate our Tor
 	// controller and establish a connection to the Tor server.
 	if cfg.Tor.Active && (cfg.Tor.V2 || cfg.Tor.V3) {
-		s.torController = tor.NewController(cfg.Tor.Control, cfg.Tor.TargetIPAddress)
+		s.torController = tor.NewController(cfg.Tor.Control, cfg.Tor.TargetIPAddress, cfg.Tor.Password)
 	}
 
 	chanGraph := chanDB.ChannelGraph()


### PR DESCRIPTION
Currently lnd only supports tor authentication via cookie. This requires that lnd has filesystem access to the location where tor writes the cookie. If the user runs lnd and tor in docker containers then sharing the filesystem in this way may not be feasible. Thankfully tor also offers password authentication.

This pull request adds support for this password authentication. If a tor password (`--tor.password=X`) is provided, and the tor server supports password authentication, then it is tried before cookie authentication.
