### PR TITLE
multi: deprecate IncorrectHtlcAmount 

### DIFF
--- a/htlcswitch/link.go
+++ b/htlcswitch/link.go
@@ -2318,7 +2318,9 @@ func (l *channelLink) processRemoteAdds(fwdPkg *channeldb.FwdPkg,
 			if err != nil {
 				log.Errorf("unable to query invoice registry: "+
 					" %v", err)
-				failure := lnwire.FailUnknownPaymentHash{}
+				failure := lnwire.NewFailUnknownPaymentHash(
+					pd.Amount,
+				)
 				l.sendHTLCError(
 					pd.HtlcIndex, failure, obfuscator, pd.SourceRef,
 				)
@@ -2367,7 +2369,9 @@ func (l *channelLink) processRemoteAdds(fwdPkg *channeldb.FwdPkg,
 					"amount: expected %v, received %v",
 					invoice.Terms.Value, pd.Amount)
 
-				failure := lnwire.FailIncorrectPaymentAmount{}
+				failure := lnwire.NewFailUnknownPaymentHash(
+					pd.Amount,
+				)
 				l.sendHTLCError(
 					pd.HtlcIndex, failure, obfuscator, pd.SourceRef,
 				)
@@ -2394,7 +2398,9 @@ func (l *channelLink) processRemoteAdds(fwdPkg *channeldb.FwdPkg,
 					"got %v", pd.RHash, invoice.Terms.Value,
 					fwdInfo.AmountToForward)
 
-				failure := lnwire.FailIncorrectPaymentAmount{}
+				failure := lnwire.NewFailUnknownPaymentHash(
+					pd.Amount,
+				)
 				l.sendHTLCError(
 					pd.HtlcIndex, failure, obfuscator, pd.SourceRef,
 				)

--- a/htlcswitch/link_test.go
+++ b/htlcswitch/link_test.go
@@ -587,11 +587,11 @@ func TestExitNodeAmountPayloadMismatch(t *testing.T) {
 	).Wait(30 * time.Second)
 	if err == nil {
 		t.Fatalf("payment should have failed but didn't")
-	} else if err.Error() != lnwire.CodeIncorrectPaymentAmount.String() {
+	} else if !strings.Contains(err.Error(), lnwire.CodeUnknownPaymentHash.String()) {
 		// TODO(roasbeef): use proper error after error propagation is
 		// in
-		t.Fatalf("incorrect error, expected insufficient value, "+
-			"instead have: %v", err)
+		t.Fatalf("expected %v got %v", err,
+			lnwire.CodeUnknownPaymentHash)
 	}
 }
 
@@ -1017,8 +1017,9 @@ func TestChannelLinkMultiHopUnknownPaymentHash(t *testing.T) {
 		n.firstBobChannelLink.ShortChanID(), htlc,
 		newMockDeobfuscator(),
 	)
-	if err.Error() != lnwire.CodeUnknownPaymentHash.String() {
-		t.Fatal("error haven't been received")
+	if !strings.Contains(err.Error(), lnwire.CodeUnknownPaymentHash.String()) {
+		t.Fatalf("expected %v got %v", err,
+			lnwire.CodeUnknownPaymentHash)
 	}
 
 	// Wait for Alice to receive the revocation.

--- a/lnd_test.go
+++ b/lnd_test.go
@@ -7878,10 +7878,11 @@ out:
 
 	// Next, we'll test the case of a recognized payHash but, an incorrect
 	// value on the extended HTLC.
+	htlcAmt := lnwire.NewMSatFromSatoshis(1000)
 	sendReq = &lnrpc.SendRequest{
 		PaymentHashString: hex.EncodeToString(carolInvoice.RHash),
 		DestString:        hex.EncodeToString(carol.PubKey[:]),
-		Amt:               1000, // 10k satoshis are expected.
+		Amt:               int64(htlcAmt.ToSatoshis()), // 10k satoshis are expected.
 	}
 	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
 	resp, err = net.Alice.SendPaymentSync(ctxt, sendReq)
@@ -7895,10 +7896,17 @@ out:
 		t.Fatalf("payment should have been rejected due to wrong " +
 			"HTLC amount")
 	}
-	expectedErrorCode = lnwire.CodeIncorrectPaymentAmount.String()
+	expectedErrorCode = lnwire.CodeUnknownPaymentHash.String()
 	if !strings.Contains(resp.PaymentError, expectedErrorCode) {
 		t.Fatalf("payment should have failed due to wrong amount, "+
 			"instead failed due to: %v", resp.PaymentError)
+	}
+
+	// We'll also ensure that the encoded error includes the invlaid HTLC
+	// amount.
+	if !strings.Contains(resp.PaymentError, htlcAmt.String()) {
+		t.Fatalf("error didn't include expected payment amt of %v: "+
+			"%v", htlcAmt, resp.PaymentError)
 	}
 
 	// The balances of all parties should be the same as initially since

--- a/lnwire/onion_error.go
+++ b/lnwire/onion_error.go
@@ -359,7 +359,7 @@ func (f FailUnknownPaymentHash) Code() FailCode {
 //
 // NOTE: Implements the error interface.
 func (f FailUnknownPaymentHash) Error() string {
-	return f.Code().String()
+	return fmt.Sprintf("UnknownPaymentHash(amt=%v)", f.amount)
 }
 
 // Decode decodes the failure from bytes stream.

--- a/routing/router.go
+++ b/routing/router.go
@@ -1843,8 +1843,9 @@ func (r *ChannelRouter) sendPayment(payment *LightningPayment,
 			}
 
 			switch onionErr := fErr.FailureMessage.(type) {
-			// If the end destination didn't know they payment
-			// hash, then we'll terminate immediately.
+			// If the end destination didn't know the payment
+			// hash or we sent the wrong payment amount to the
+			// destination, then we'll terminate immediately.
 			case *lnwire.FailUnknownPaymentHash:
 				return preImage, nil, sendError
 


### PR DESCRIPTION
Fixes #2321 (see issue for details). 

One implementation level thing to note is that we'll still expect this error on the network when decoding and during routing retry attempts. Otherwise, we won't be able to parse the errors from nodes in the wild that haven't upgraded to this new version. 

Replaces #2363. 