### PR TITLE
Fix make rpc generating diffs on chainrpc.

### DIFF
--- a/lnrpc/chainrpc/chainnotifier.proto
+++ b/lnrpc/chainrpc/chainnotifier.proto
@@ -2,6 +2,8 @@ syntax = "proto3";
 
 package chainrpc;
 
+option go_package = "github.com/lightningnetwork/lnd/lnrpc/chainrpc";
+
 message ConfRequest {
     /*
     The transaction hash for which we should request a confirmation notification


### PR DESCRIPTION
At least on my machine make rpc on master would created proto diffs on chainrpc. Adding the go_package option seems to fix it (and align with other sub services proto files all including this option)