### PR TITLE
Add instructions and docker-compose file for docker LND Development

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,4 @@
+STATE=bitcoin.active
+NETWORK=bitcoin.testnet
+BITCOIN_NODE=neutrino
+NEUTRINO_CONNECT=faucet.lightning.community

--- a/docker/docker-compose.dev.yml
+++ b/docker/docker-compose.dev.yml
@@ -1,0 +1,26 @@
+version: '3'
+services:
+  lnd:
+    container_name: lnd
+    build:
+      context: ../
+      dockerfile: docker/lnd/Dockerfile
+    volumes:
+      # mount the root lnd directory into the container for development.
+      # changes can be made on the local machine
+      # and then rebuilt inside the running container
+      - ..:/go/src/github.com/lightningnetwork/lnd
+      # create a mount to persist the container's .lnd directory
+      - lnd:/root/.lnd
+    entrypoint:
+      - lnd
+      - --${STATE}
+      - --${NETWORK}
+      - --bitcoin.node=${BITCOIN_NODE}
+      - --neutrino.connect=${NEUTRINO_CONNECT}
+
+volumes:
+# lnd volume is used for persisting lnd application data and chain state
+# during container lifecycle
+  lnd:
+    driver: local

--- a/docs/DOCKER.md
+++ b/docs/DOCKER.md
@@ -65,3 +65,34 @@ $ docker logs lnd-testnet
 
 This is a simple example, it is possible to use any command-line options necessary
 to expose RPC ports, use `btcd` or `bitcoind`, or add additional chains.
+
+## LND Development
+
+For lnd development, a docker-compose file is provided for rapidly testing and developing changes in a containerized LND environment.
+
+To build the environment:
+
+```
+$ cd ./docker 
+$ docker-compose -f docker-compose.dev.yml build
+```
+
+Docker-compose will mount your local environment to: `/go/src/github.com/lightningnetwork/lnd` inside the container.
+  Changes to your local environment will result in changes to the aforementioned directory inside the container.
+
+Once the environment is built, start LND:
+
+```
+$ docker-compose -f docker-compose.dev.yml up
+```
+
+To change the parameters of lnd, modify once the file `.env` and then bring `up` the containers.
+
+
+To execute instructions after starting LND docker, run exec on the `lnd` container.  For example, to create a wallet:
+
+```
+docker exec -it lnd lncli --network=testnet create
+```
+
+Happy Hacking =]


### PR DESCRIPTION
Add `docker-compose` which allows for running an lnd docker development environment.  This should allow the dev team to use Docker as part of the normal day to day development process by allowing changes to be directly accessible inside the running container.

The `docker-compose` file points to `docker/lnd/Dockerfile` which copies local files into the container at build time.   I think this is preferable to `/Dockerfile` which pulls from Github since we want the current state of the dev environment when the container is created.  The compose file also persists two volumes, one for the local development root (for development changes going forward) and the other for the running lnd application files at `/root/.lnd`.