### PR TITLE
funding: cap the max_htlc value at channel capacity

### DIFF
--- a/fundingmanager.go
+++ b/fundingmanager.go
@@ -2111,10 +2111,12 @@ func (f *fundingManager) addToRouterGraph(completeChan *channeldb.OpenChannel,
 
 	// We'll obtain the max HTLC value we can forward in our direction, as
 	// we'll use this value within our ChannelUpdate. This value must be <=
-	// channel capacity and <= the maximum in-flight msats set by the peer, so
-	// we default to max in-flight msats as this value will always be <=
-	// channel capacity.
+	// channel capacity and <= the maximum in-flight msats set by the peer.
 	fwdMaxHTLC := completeChan.LocalChanCfg.MaxPendingAmount
+	capacityMSat := lnwire.NewMSatFromSatoshis(completeChan.Capacity)
+	if fwdMaxHTLC > capacityMSat {
+		fwdMaxHTLC = capacityMSat
+	}
 
 	ann, err := f.newChanAnnouncement(
 		f.cfg.IDKey, completeChan.IdentityPub,
@@ -2285,12 +2287,15 @@ func (f *fundingManager) annAfterSixConfs(completeChan *channeldb.OpenChannel,
 		// HTLC it deems economically relevant.
 		fwdMinHTLC := completeChan.LocalChanCfg.MinHTLC
 
-		// We'll obtain the max HTLC value we can forward in our direction, as
-		// we'll use this value within our ChannelUpdate. This value must be <=
-		// channel capacity and <= the maximum in-flight msats set by the peer,
-		// so we default to max in-flight msats as this value will always be <=
-		// channel capacity.
+		// We'll obtain the max HTLC value we can forward in our
+		// direction, as we'll use this value within our ChannelUpdate.
+		// This value must be <= channel capacity and <= the maximum
+		// in-flight msats set by the peer.
 		fwdMaxHTLC := completeChan.LocalChanCfg.MaxPendingAmount
+		capacityMSat := lnwire.NewMSatFromSatoshis(completeChan.Capacity)
+		if fwdMaxHTLC > capacityMSat {
+			fwdMaxHTLC = capacityMSat
+		}
 
 		// Create and broadcast the proofs required to make this channel
 		// public and usable for other nodes for routing.


### PR DESCRIPTION
We are not longer validating the max_value_in_flight field set by the
remote peer, so it is not always less than the channel capacity anymore.
We therefore make sure to cap it before advertising it.