### PR TITLE
lnwire: ensure even/odd features have the same base name

### DIFF
--- a/lnwire/features.go
+++ b/lnwire/features.go
@@ -67,11 +67,11 @@ const (
 // not advertised to the entire network. A full description of these feature
 // bits is provided in the BOLT-09 specification.
 var LocalFeatures = map[FeatureBit]string{
-	DataLossProtectRequired: "data-loss-protect-required",
-	DataLossProtectOptional: "data-loss-protect-optional",
+	DataLossProtectRequired: "data-loss-protect",
+	DataLossProtectOptional: "data-loss-protect",
 	InitialRoutingSync:      "initial-routing-sync",
-	GossipQueriesRequired:   "gossip-queries-required",
-	GossipQueriesOptional:   "gossip-queries-optional",
+	GossipQueriesRequired:   "gossip-queries",
+	GossipQueriesOptional:   "gossip-queries",
 }
 
 // GlobalFeatures is a mapping of known global feature bits to a descriptive


### PR DESCRIPTION
In this commit, we fix a bug in the way we defined our even/odd features
for a particular feature. The check for if a feature bit is part of a
pair assumes that the pair bit has the exact same name as the bit being
queried. The way we defined our feature map didn't take note of this
assumption, as a result, any attempts to require a new bit moving from
optional to required would fail since the bit would be found, but the
names differed.

