### PR TITLE
lnwire: ensure we're able to decode legacy FailUnknownPaymentHash

### DIFF
--- a/lnwire/onion_error.go
+++ b/lnwire/onion_error.go
@@ -366,7 +366,20 @@ func (f FailUnknownPaymentHash) Error() string {
 //
 // NOTE: Part of the Serializable interface.
 func (f *FailUnknownPaymentHash) Decode(r io.Reader, pver uint32) error {
-	return ReadElement(r, &f.amount)
+	err := ReadElement(r, &f.amount)
+	switch {
+	// This is an optional tack on that was added later in the protocol. As
+	// a result, older nodes may not include this value. We'll account for
+	// this by checking for io.EOF here which means that no bytes were read
+	// at all.
+	case err == io.EOF:
+		return nil
+
+	case err != nil:
+		return err
+	}
+
+	return nil
 }
 
 // Encode writes the failure in bytes stream.


### PR DESCRIPTION
In this commit, we modify the decoding of the `FailUnknownPaymentHash`
message to ensure we're able to fully decode the legacy serialization of
the onion error. We do this by catching the `io.EOF` error as it's
returned when _no_ bytes are read. If this is the case, then only the
error type was serialized and not also the optional amount.

