### PR TITLE
[trivial] cleanup subserver imports

### DIFF
--- a/lnrpc/autopilotrpc/autopilot_server.go
+++ b/lnrpc/autopilotrpc/autopilot_server.go
@@ -5,7 +5,6 @@ package autopilotrpc
 import (
 	"context"
 	"encoding/hex"
-	"os"
 	"sync/atomic"
 
 	"github.com/btcsuite/btcd/btcec"

--- a/lnrpc/invoicesrpc/invoices_server.go
+++ b/lnrpc/invoicesrpc/invoices_server.go
@@ -4,14 +4,14 @@ package invoicesrpc
 
 import (
 	"context"
-	"google.golang.org/grpc"
-	"gopkg.in/macaroon-bakery.v2/bakery"
 	"io/ioutil"
 	"os"
 	"path/filepath"
 
 	"github.com/lightningnetwork/lnd/lnrpc"
 	"github.com/lightningnetwork/lnd/lntypes"
+	"google.golang.org/grpc"
+	"gopkg.in/macaroon-bakery.v2/bakery"
 )
 
 const (

--- a/lnrpc/walletrpc/walletkit_server.go
+++ b/lnrpc/walletrpc/walletkit_server.go
@@ -4,7 +4,7 @@ package walletrpc
 
 import (
 	"bytes"
-	fmt "fmt"
+	"fmt"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -12,10 +12,10 @@ import (
 	"github.com/btcsuite/btcd/wire"
 	"github.com/lightningnetwork/lnd/keychain"
 	"github.com/lightningnetwork/lnd/lnrpc"
-	signrpc "github.com/lightningnetwork/lnd/lnrpc/signrpc"
+	"github.com/lightningnetwork/lnd/lnrpc/signrpc"
 	"github.com/lightningnetwork/lnd/lnwallet"
-	context "golang.org/x/net/context"
-	grpc "google.golang.org/grpc"
+	"golang.org/x/net/context"
+	"google.golang.org/grpc"
 	"gopkg.in/macaroon-bakery.v2/bakery"
 )
 


### PR DESCRIPTION
1. Remove unused "os" import from lnrpc/autopilotrpc. This would cause the build to fail since the import is not used. It was not detected since the file is under a build flag.

2. Cleanup other subserver imports by running `goimports`