### PR TITLE
utxonursery: use baby expiry as height hint

### DIFF
--- a/utxonursery.go
+++ b/utxonursery.go
@@ -457,7 +457,7 @@ func (u *utxoNursery) IncubateOutputs(chanPoint wire.OutPoint,
 	// it. This may happen if the caller raced a block to call this method.
 	for _, babyOutput := range babyOutputs {
 		if uint32(bestHeight) >= babyOutput.expiry {
-			err = u.sweepCribOutput(uint32(bestHeight), &babyOutput)
+			err = u.sweepCribOutput(babyOutput.expiry, &babyOutput)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
Previously we would use the best known height as height hint, which
could lead to using a height hint above the actual block it confirms,
hence losing track of the confirmation.