### PR TITLE
chainnrnfs/neutrino: return on historicalConf error

### DIFF
--- a/chainntnfs/neutrinonotify/neutrino.go
+++ b/chainntnfs/neutrinonotify/neutrino.go
@@ -315,6 +315,7 @@ out:
 					)
 					if err != nil {
 						chainntnfs.Log.Error(err)
+						return
 					}
 
 					// If the historical dispatch finished


### PR DESCRIPTION
Would otherwise update height hint cache even on error during rescan.