### PR TITLE
build+test+make: modify travis make directive to also compile sub-ser…

### DIFF
--- a/make/testing_flags.mk
+++ b/make/testing_flags.mk
@@ -54,5 +54,5 @@ endif
 
 
 # Construct the integration test command with the added build flags.
-ITEST_TAGS := $(DEV_TAGS) rpctest
+ITEST_TAGS := $(DEV_TAGS) rpctest chainrpc walletrpc signrpc invoicesrpc autopilotrpc
 ITEST := rm output*.log; date; $(GOTEST) -tags="$(ITEST_TAGS)" $(TEST_FLAGS) -logoutput


### PR DESCRIPTION
…vers

In this commit, we modify the travis make directive to also compile all
the sub-severs using build flags. We do this as otherwise, we can only
detect mistakes in the build process of a sub-server via a manual
process. In this commit, we adapt travis to also cover this case