### PR TITLE
chainntnfs: skip catch up re-org test for neutrino temporarily

### DIFF
--- a/chainntnfs/interface_test.go
+++ b/chainntnfs/interface_test.go
@@ -1567,6 +1567,13 @@ func testCatchUpOnMissedBlocks(miner *rpctest.Harness,
 func testCatchUpOnMissedBlocksWithReorg(miner1 *rpctest.Harness,
 	notifier chainntnfs.TestChainNotifier, t *testing.T) {
 
+	// If this is the neutrino notifier, then we'll skip this test for now
+	// as we're missing functionality required to ensure the test passes
+	// reliably.
+	if _, ok := notifier.(*neutrinonotify.NeutrinoNotifier); ok {
+		t.Skip("skipping re-org test for neutrino")
+	}
+
 	const numBlocks = 10
 	const numClients = 5
 	var wg sync.WaitGroup


### PR DESCRIPTION
In this commit, we modify the main interface-level tests for neutrino to
skip the block catch up re-org test. We do this, as the test itself is
very unstable and only passes occasionally by the grace of RNGesus.
What's needed to ensure it passes reliably is to extend neutrino with a
cache of the last N blocks disconnected. Sample output of the affected
test when run:
```
   --- SKIP: TestInterfaces/neutrino_test_catch_up_on_missed_blocks_w/_reorged_best_block (0.00s)
        interface_test.go:1574: skipping re-org test for neutrino
```
