### PR TITLE
lnwire: features "maxAllowedSize" fix

### DIFF
--- a/lnwire/features.go
+++ b/lnwire/features.go
@@ -49,16 +49,14 @@ const (
 	// maxAllowedSize is a maximum allowed size of feature vector.
 	//
 	// NOTE: Within the protocol, the maximum allowed message size is 65535
-	// bytes. Adding the overhead from the crypto protocol (the 2-byte
-	// packet length and 16-byte MAC), we arrive at 65569 bytes. Accounting
-	// for the overhead within the feature message to signal the type of
-	// the message, that leaves 65567 bytes for the init message itself.
-	// Next, we reserve 4-bytes to encode the lengths of both the local and
-	// global feature vectors, so 65563 for the global and local features.
-	// Knocking off one byte for the sake of the calculation, that leads to
-	// a max allowed size of 32781 bytes for each feature vector, or 131124
-	// different features.
-	maxAllowedSize = 32781
+	// bytes for all messages. Accounting for the overhead within the feature
+	// message to signal the type of message, that leaves us with 65533 bytes
+	// for the init message itself.  Next, we reserve 4 bytes to encode the
+	// lengths of both the local and global feature vectors, so 65529 bytes
+	// for the local and global features.  Knocking off one byte for the sake
+	// of the calculation, that leads us to 32764 bytes for each feature
+	// vector, or 131056 different features.
+	maxAllowedSize = 32764
 )
 
 // LocalFeatures is a mapping of known connection-local feature bits to a

--- a/lnwire/init_message.go
+++ b/lnwire/init_message.go
@@ -63,5 +63,5 @@ func (msg *Init) MsgType() MessageType {
 //
 // This is part of the lnwire.Message interface.
 func (msg *Init) MaxPayloadLength(uint32) uint32 {
-	return 2 + maxAllowedSize + 2 + maxAllowedSize
+	return 2 + 2 + maxAllowedSize + 2 + maxAllowedSize
 }


### PR DESCRIPTION
This commit fixes an incorrectly calculated `maxAllowedSize` for feature vectors that also affected the maximum payload length of the `init` message.  The maximum message size for any message is `65535` bytes, yet the old `maxAllowedSize` added the brontide MACs (???) to the overall "usable" size and calculated the length of the feature vectors from that.  Anyways, fixed that here.
