### PR TITLE
[trivial] fundingmanager: don't spew log shortChanID

### DIFF
--- a/fundingmanager.go
+++ b/fundingmanager.go
@@ -2287,7 +2287,7 @@ func (f *fundingManager) annAfterSixConfs(completeChan *channeldb.OpenChannel,
 		chanID := lnwire.NewChanIDFromOutPoint(&fundingPoint)
 
 		fndgLog.Infof("Announcing ChannelPoint(%v), short_chan_id=%v",
-			&fundingPoint, spew.Sdump(shortChanID))
+			&fundingPoint, shortChanID)
 
 		// We'll obtain the min HTLC value we can forward in our
 		// direction, as we'll use this value within our ChannelUpdate.
@@ -2319,7 +2319,7 @@ func (f *fundingManager) annAfterSixConfs(completeChan *channeldb.OpenChannel,
 		}
 
 		fndgLog.Debugf("Channel with ChannelPoint(%v), short_chan_id=%v "+
-			"announced", &fundingPoint, spew.Sdump(shortChanID))
+			"announced", &fundingPoint, shortChanID)
 	}
 
 	// We delete the channel opening state from our internal database


### PR DESCRIPTION
gives unnecessary output such as

```
2019-02-06 11:26:45.338 [INF] FNDG: Announcing ChannelPoint(cf659a58d68f206531136bf19dea82863a488937f9f4c3d489c450ad81c1724e:0), short_chan_id=(*lnwire.ShortChannelID)(0xc000670a60)(1977:1:0)
```