### PR TITLE
Add source after installing apk packages to avoid breaking docker cache

### DIFF
--- a/docker/lnd/Dockerfile
+++ b/docker/lnd/Dockerfile
@@ -2,9 +2,6 @@ FROM golang:1.11-alpine as builder
 
 MAINTAINER Olaoluwa Osuntokun <lightning.engineering>
 
-# Copy in the local repository to build from.
-COPY . /go/src/github.com/lightningnetwork/lnd
-
 # Force Go to use the cgo based DNS resolver. This is required to ensure DNS
 # queries required to connect to linked containers succeed.
 ENV GODEBUG netdns=cgo
@@ -12,8 +9,12 @@ ENV GODEBUG netdns=cgo
 # Install dependencies and install/build lnd.
 RUN apk add --no-cache --update alpine-sdk \
     git \
-    make \
-&&  cd /go/src/github.com/lightningnetwork/lnd \
+    make 
+
+# Copy in the local repository to build from.
+COPY . /go/src/github.com/lightningnetwork/lnd
+
+RUN cd /go/src/github.com/lightningnetwork/lnd \
 &&  make \
 &&  make install
 


### PR DESCRIPTION
Currently, changing the source code causes the docker layer cache to break the caching of package installation (make, git, etc). This makes rebuilds of the container due to source code changes unnecessarily expensive.

If we execute the source COPY command as an individual command, _after the installation of the OS packages_, then rebuilds of the container will be much quicker.

#### Pull Request Checklist

- [ x] If this is your first time contributing, we recommend you read the [Code
  Contribution Guidelines](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md)
- [ x] All changes are Go version 1.11 compliant
- [ x]  The code being submitted is commented according to the
  [Code Documentation and Commenting](#CodeDocumentation) section
- [ x]  For new code: Code is accompanied by tests which exercise both
  the positive and negative (error paths) conditions (if applicable)
- [ x]  For bug fixes: Code is accompanied by new tests which trigger
  the bug being fixed to prevent regressions
- [ x]  Any new logging statements use an appropriate subsystem and
  logging level
- [ x]  Code has been formatted with `go fmt`
- [ x]  For code and documentation: lines are wrapped at 80 characters
  (the tab character should be counted as 8 characters, not 4, as some IDEs do
  per default)
- [ x]  Running `make check` does not fail any tests
- [ x]  Running `go vet` does not report any issues
- [ x]  Running `make lint` does not report any **new** issues that did not
  already exist
- [ x] All commits build properly and pass tests. Only in exceptional
  cases it can be justifiable to violate this condition. In that case, the
  reason should be stated in the commit message.
- [ x] Commits have a logical structure ([see section 4.5, of the Code Contribution Guidelines])
