### PR TITLE
fundingmanager: send out active channel ntfn on FundingLocked

### DIFF
--- a/channelnotifier/channelnotifier.go
+++ b/channelnotifier/channelnotifier.go
@@ -45,9 +45,9 @@ type ClosedChannelEvent struct {
 	CloseSummary *channeldb.ChannelCloseSummary
 }
 
-// New creates a new channel notifier. The ChannelNotifier gets channel
-// events from peers and from the chain arbitrator, and dispatches them to
-// its clients.
+// New creates a new channel notifier. The ChannelNotifier gets channel events
+// from peers and from the chain arbitrator, and dispatches them to its
+// clients.
 func New(chanDB *channeldb.DB) *ChannelNotifier {
 	return &ChannelNotifier{
 		ntfnServer: subscribe.NewServer(),
@@ -55,13 +55,14 @@ func New(chanDB *channeldb.DB) *ChannelNotifier {
 	}
 }
 
-// Start starts the ChannelNotifier and all goroutines it needs to carry out its task.
+// Start starts the ChannelNotifier and all goroutines it needs to carry out
+// its task.
 func (c *ChannelNotifier) Start() error {
 	if !atomic.CompareAndSwapUint32(&c.started, 0, 1) {
 		return nil
 	}
 
-	log.Tracef("ChannelNotifier %v starting", c)
+	log.Tracef("ChannelNotifier starting")
 
 	if err := c.ntfnServer.Start(); err != nil {
 		return err
@@ -108,7 +109,8 @@ func (c *ChannelNotifier) NotifyClosedChannelEvent(chanPoint wire.OutPoint) {
 	// Fetch the relevant closed channel from the database.
 	closeSummary, err := c.chanDB.FetchClosedChannel(&chanPoint)
 	if err != nil {
-		log.Warnf("Unable to fetch closed channel summary from the db: %v", err)
+		log.Warnf("Unable to fetch closed channel summary from "+
+			"the db: %v", err)
 	}
 
 	// Send the closed event to all channel event subscribers.
@@ -127,8 +129,8 @@ func (c *ChannelNotifier) NotifyActiveChannelEvent(chanPoint wire.OutPoint) {
 	}
 }
 
-// NotifyInactiveChannelEvent notifies the channelEventNotifier goroutine that a
-// channel is inactive.
+// NotifyInactiveChannelEvent notifies the channelEventNotifier goroutine that
+// a channel is inactive.
 func (c *ChannelNotifier) NotifyInactiveChannelEvent(chanPoint wire.OutPoint) {
 	event := InactiveChannelEvent{ChannelPoint: &chanPoint}
 	if err := c.ntfnServer.SendUpdate(event); err != nil {

--- a/fundingmanager_test.go
+++ b/fundingmanager_test.go
@@ -353,9 +353,10 @@ func createTestFundingManager(t *testing.T, privKey *btcec.PrivateKey,
 			publTxChan <- txn
 			return nil
 		},
-		ZombieSweeperInterval:  1 * time.Hour,
-		ReservationTimeout:     1 * time.Nanosecond,
-		NotifyOpenChannelEvent: func(wire.OutPoint) {},
+		ZombieSweeperInterval:   1 * time.Hour,
+		ReservationTimeout:      1 * time.Nanosecond,
+		NotifyOpenChannelEvent:  func(wire.OutPoint) {},
+		NotifyReadyChannelEvent: func(wire.OutPoint) {},
 	})
 	if err != nil {
 		t.Fatalf("failed creating fundingManager: %v", err)
@@ -440,8 +441,10 @@ func recreateAliceFundingManager(t *testing.T, alice *testNode) {
 			publishChan <- txn
 			return nil
 		},
-		ZombieSweeperInterval: oldCfg.ZombieSweeperInterval,
-		ReservationTimeout:    oldCfg.ReservationTimeout,
+		ZombieSweeperInterval:   oldCfg.ZombieSweeperInterval,
+		ReservationTimeout:      oldCfg.ReservationTimeout,
+		NotifyOpenChannelEvent:  func(wire.OutPoint) {},
+		NotifyReadyChannelEvent: func(wire.OutPoint) {},
 	})
 	if err != nil {
 		t.Fatalf("failed recreating aliceFundingManager: %v", err)

--- a/server.go
+++ b/server.go
@@ -930,10 +930,11 @@ func newServer(listenAddrs []net.Addr, chanDB *channeldb.DB, cc *chainControl,
 			// channel bandwidth.
 			return uint16(input.MaxHTLCNumber / 2)
 		},
-		ZombieSweeperInterval:  1 * time.Minute,
-		ReservationTimeout:     10 * time.Minute,
-		MinChanSize:            btcutil.Amount(cfg.MinChanSize),
-		NotifyOpenChannelEvent: s.channelNotifier.NotifyOpenChannelEvent,
+		ZombieSweeperInterval:   1 * time.Minute,
+		ReservationTimeout:      10 * time.Minute,
+		MinChanSize:             btcutil.Amount(cfg.MinChanSize),
+		NotifyOpenChannelEvent:  s.channelNotifier.NotifyOpenChannelEvent,
+		NotifyReadyChannelEvent: s.channelNotifier.NotifyActiveChannelEvent,
 	})
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
In this commit, we fix a small gap in the existing notification logic.
Before this commit, if by the time we added a link to the switch, we
hadn't yet processed the `FundingLocked` message, then we wouldn't mark
the link as fully active. To remedy that, we extend the role of the
`fundingManager` to notify once the channel is "ready".

It's worth noting that with this fix, we can emit duplicate active
channel notifications. However, as this RPC is meant to be used primary
for UIs, I think it's an acceptable tradeoff, we can extend the
`ChannelNotifier` to maintain state to suppress duplicate notifications.
