### PR TITLE
rpc: fix regression in SendToRouteSync payment hash parsing

### DIFF
--- a/rpcserver.go
+++ b/rpcserver.go
@@ -2719,7 +2719,8 @@ func unmarshallSendToRouteRequest(req *lnrpc.SendToRouteRequest,
 
 	return &rpcPaymentRequest{
 		SendRequest: &lnrpc.SendRequest{
-			PaymentHash: req.PaymentHash,
+			PaymentHash:       req.PaymentHash,
+			PaymentHashString: req.PaymentHashString,
 		},
 		routes: routes,
 	}, nil


### PR DESCRIPTION
A recent change in this area of the codebase refactored some code to
make way for the deprecation of the streaming multi-route `SendToRoute`
method. Along the way, it removed the parsing of the `PaymentHashString`
field for the sync `SendToRouteSync` which is meant to be used via the
REST interface. In this commit, we fix this by populating _both_
`PaymentHash` and `PaymentHashString`. This is OK, as
`extractPaymentIntent` will check both values to extract the hex-encoded
payment hash if it's specified.

