### PR TITLE
lnwire: change error's MaxPayloadLength to 65535

### DIFF
--- a/lnwire/error.go
+++ b/lnwire/error.go
@@ -122,6 +122,6 @@ func (c *Error) MsgType() MessageType {
 //
 // This is part of the lnwire.Message interface.
 func (c *Error) MaxPayloadLength(uint32) uint32 {
-	// 32 + 2 + 655326
-	return 65536
+	// 32 + 2 + 65501
+	return 65535
 }


### PR DESCRIPTION
This commit changes the `MaxPayloadLength` function for error messages to return `65535` instead of `65536`.  Max message size is the former.