### PR TITLE
watchtower/wtwire/features: make wtwire features uniform

### DIFF
--- a/watchtower/wtwire/features.go
+++ b/watchtower/wtwire/features.go
@@ -9,8 +9,8 @@ var GlobalFeatures map[lnwire.FeatureBit]string
 // LocalFeatures holds the locally advertised feature bits understood by
 // watchtower implementations.
 var LocalFeatures = map[lnwire.FeatureBit]string{
-	WtSessionsRequired: "wt-sessions-required",
-	WtSessionsOptional: "wt-sessions-optional",
+	WtSessionsRequired: "wt-sessions",
+	WtSessionsOptional: "wt-sessions",
 }
 
 const (


### PR DESCRIPTION
In light of #2570, this PR ensures that the local names of wtwire feature bits are uniform between even/odd features. This ensures that `Has` properly returns true if the feature vector supports optional or required for a given feature bit