### PR TITLE
watchtower/multi: send connection features + chain hash in Init

### DIFF
--- a/watchtower/wtserver/server_test.go
+++ b/watchtower/wtserver/server_test.go
@@ -27,6 +27,8 @@ var (
 	)
 
 	addrScript, _ = txscript.PayToAddrScript(addr)
+
+	testnetChainHash = *chaincfg.TestNet3Params.GenesisHash
 )
 
 // randPubKey generates a new secp keypair, and returns the public key.
@@ -59,6 +61,7 @@ func initServer(t *testing.T, db wtserver.DB,
 		NewAddress: func() (btcutil.Address, error) {
 			return addr, nil
 		},
+		ChainHash: testnetChainHash,
 	})
 	if err != nil {
 		t.Fatalf("unable to create server: %v", err)
@@ -91,7 +94,7 @@ func TestServerOnlyAcceptOnePeer(t *testing.T) {
 
 	// Serialize a Init message to be sent by both peers.
 	init := wtwire.NewInitMessage(
-		lnwire.NewRawFeatureVector(), lnwire.NewRawFeatureVector(),
+		lnwire.NewRawFeatureVector(), testnetChainHash,
 	)
 
 	var b bytes.Buffer
@@ -159,7 +162,7 @@ var createSessionTests = []createSessionTestCase{
 		name: "reject duplicate session create",
 		initMsg: wtwire.NewInitMessage(
 			lnwire.NewRawFeatureVector(),
-			lnwire.NewRawFeatureVector(),
+			testnetChainHash,
 		),
 		createMsg: &wtwire.CreateSession{
 			BlobType:     blob.TypeDefault,
@@ -181,7 +184,7 @@ var createSessionTests = []createSessionTestCase{
 		name: "reject unsupported blob type",
 		initMsg: wtwire.NewInitMessage(
 			lnwire.NewRawFeatureVector(),
-			lnwire.NewRawFeatureVector(),
+			testnetChainHash,
 		),
 		createMsg: &wtwire.CreateSession{
 			BlobType:     0,
@@ -279,10 +282,10 @@ var stateUpdateTests = []stateUpdateTestCase{
 	// Valid update sequence, send seqnum == lastapplied as last update.
 	{
 		name: "perm fail after sending seqnum equal lastapplied",
-		initMsg: &wtwire.Init{&lnwire.Init{
-			LocalFeatures:  lnwire.NewRawFeatureVector(),
-			GlobalFeatures: lnwire.NewRawFeatureVector(),
-		}},
+		initMsg: wtwire.NewInitMessage(
+			lnwire.NewRawFeatureVector(),
+			testnetChainHash,
+		),
 		createMsg: &wtwire.CreateSession{
 			BlobType:     blob.TypeDefault,
 			MaxUpdates:   3,
@@ -309,10 +312,10 @@ var stateUpdateTests = []stateUpdateTestCase{
 	// Send update that skips next expected sequence number.
 	{
 		name: "skip sequence number",
-		initMsg: &wtwire.Init{&lnwire.Init{
-			LocalFeatures:  lnwire.NewRawFeatureVector(),
-			GlobalFeatures: lnwire.NewRawFeatureVector(),
-		}},
+		initMsg: wtwire.NewInitMessage(
+			lnwire.NewRawFeatureVector(),
+			testnetChainHash,
+		),
 		createMsg: &wtwire.CreateSession{
 			BlobType:     blob.TypeDefault,
 			MaxUpdates:   4,
@@ -333,10 +336,10 @@ var stateUpdateTests = []stateUpdateTestCase{
 	// Send update that reverts to older sequence number.
 	{
 		name: "revert to older seqnum",
-		initMsg: &wtwire.Init{&lnwire.Init{
-			LocalFeatures:  lnwire.NewRawFeatureVector(),
-			GlobalFeatures: lnwire.NewRawFeatureVector(),
-		}},
+		initMsg: wtwire.NewInitMessage(
+			lnwire.NewRawFeatureVector(),
+			testnetChainHash,
+		),
 		createMsg: &wtwire.CreateSession{
 			BlobType:     blob.TypeDefault,
 			MaxUpdates:   4,
@@ -361,10 +364,10 @@ var stateUpdateTests = []stateUpdateTestCase{
 	// Send update echoing a last applied that is lower than previous value.
 	{
 		name: "revert to older lastapplied",
-		initMsg: &wtwire.Init{&lnwire.Init{
-			LocalFeatures:  lnwire.NewRawFeatureVector(),
-			GlobalFeatures: lnwire.NewRawFeatureVector(),
-		}},
+		initMsg: wtwire.NewInitMessage(
+			lnwire.NewRawFeatureVector(),
+			testnetChainHash,
+		),
 		createMsg: &wtwire.CreateSession{
 			BlobType:     blob.TypeDefault,
 			MaxUpdates:   4,
@@ -389,10 +392,10 @@ var stateUpdateTests = []stateUpdateTestCase{
 	// Client echos last applied as they are received.
 	{
 		name: "resume after disconnect",
-		initMsg: &wtwire.Init{&lnwire.Init{
-			LocalFeatures:  lnwire.NewRawFeatureVector(),
-			GlobalFeatures: lnwire.NewRawFeatureVector(),
-		}},
+		initMsg: wtwire.NewInitMessage(
+			lnwire.NewRawFeatureVector(),
+			testnetChainHash,
+		),
 		createMsg: &wtwire.CreateSession{
 			BlobType:     blob.TypeDefault,
 			MaxUpdates:   4,
@@ -419,10 +422,10 @@ var stateUpdateTests = []stateUpdateTestCase{
 	// Client doesn't echo last applied until last message.
 	{
 		name: "resume after disconnect lagging lastapplied",
-		initMsg: &wtwire.Init{&lnwire.Init{
-			LocalFeatures:  lnwire.NewRawFeatureVector(),
-			GlobalFeatures: lnwire.NewRawFeatureVector(),
-		}},
+		initMsg: wtwire.NewInitMessage(
+			lnwire.NewRawFeatureVector(),
+			testnetChainHash,
+		),
 		createMsg: &wtwire.CreateSession{
 			BlobType:     blob.TypeDefault,
 			MaxUpdates:   4,
@@ -448,10 +451,10 @@ var stateUpdateTests = []stateUpdateTestCase{
 	// Send update with sequence number that exceeds MaxUpdates.
 	{
 		name: "seqnum exceed maxupdates",
-		initMsg: &wtwire.Init{&lnwire.Init{
-			LocalFeatures:  lnwire.NewRawFeatureVector(),
-			GlobalFeatures: lnwire.NewRawFeatureVector(),
-		}},
+		initMsg: wtwire.NewInitMessage(
+			lnwire.NewRawFeatureVector(),
+			testnetChainHash,
+		),
 		createMsg: &wtwire.CreateSession{
 			BlobType:     blob.TypeDefault,
 			MaxUpdates:   3,
@@ -478,10 +481,10 @@ var stateUpdateTests = []stateUpdateTestCase{
 	// Ensure sequence number 0 causes permanent failure.
 	{
 		name: "perm fail after seqnum 0",
-		initMsg: &wtwire.Init{&lnwire.Init{
-			LocalFeatures:  lnwire.NewRawFeatureVector(),
-			GlobalFeatures: lnwire.NewRawFeatureVector(),
-		}},
+		initMsg: wtwire.NewInitMessage(
+			lnwire.NewRawFeatureVector(),
+			testnetChainHash,
+		),
 		createMsg: &wtwire.CreateSession{
 			BlobType:     blob.TypeDefault,
 			MaxUpdates:   3,

--- a/watchtower/wtwire/init.go
+++ b/watchtower/wtwire/init.go
@@ -1,21 +1,57 @@
 package wtwire
 
-import "github.com/lightningnetwork/lnd/lnwire"
+import (
+	"io"
+
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"github.com/lightningnetwork/lnd/lnwire"
+)
 
 // Init is the first message sent over the watchtower wire protocol, and
-// specifies features and level of requiredness maintained by the sending node.
-// The watchtower Init message is identical to the LN Init message, except it
-// uses a different message type to ensure the two are not conflated.
+// specifies connection features bits and level of requiredness maintained by
+// the sending node. The Init message also sends the chain hash identifying the
+// network that the sender is on.
 type Init struct {
-	*lnwire.Init
+	// ConnFeatures are the feature bits being advertised for the duration
+	// of a single connection with a peer.
+	ConnFeatures *lnwire.RawFeatureVector
+
+	// ChainHash is the genesis hash of the chain that the advertiser claims
+	// to be on.
+	ChainHash chainhash.Hash
 }
 
-// NewInitMessage generates a new Init message from raw global and local feature
-// vectors.
-func NewInitMessage(gf, lf *lnwire.RawFeatureVector) *Init {
+// NewInitMessage generates a new Init message from a raw connection feature
+// vector and chain hash.
+func NewInitMessage(connFeatures *lnwire.RawFeatureVector,
+	chainHash chainhash.Hash) *Init {
+
 	return &Init{
-		Init: lnwire.NewInitMessage(gf, lf),
+		ConnFeatures: connFeatures,
+		ChainHash:    chainHash,
 	}
+}
+
+// Encode serializes the target Init into the passed io.Writer observing the
+// protocol version specified.
+//
+// This is part of the wtwire.Message interface.
+func (msg *Init) Encode(w io.Writer, pver uint32) error {
+	return WriteElements(w,
+		msg.ConnFeatures,
+		msg.ChainHash,
+	)
+}
+
+// Decode deserializes a serialized Init message stored in the passed io.Reader
+// observing the specified protocol version.
+//
+// This is part of the wtwire.Message interface.
+func (msg *Init) Decode(r io.Reader, pver uint32) error {
+	return ReadElements(r,
+		&msg.ConnFeatures,
+		&msg.ChainHash,
+	)
 }
 
 // MsgType returns the integer uniquely identifying this message type on the
@@ -24,6 +60,14 @@ func NewInitMessage(gf, lf *lnwire.RawFeatureVector) *Init {
 // This is part of the wtwire.Message interface.
 func (msg *Init) MsgType() MessageType {
 	return MsgInit
+}
+
+// MaxPayloadLength returns the maximum allowed payload size for an Init
+// complete message observing the specified protocol version.
+//
+// This is part of the wtwire.Message interface.
+func (msg *Init) MaxPayloadLength(uint32) uint32 {
+	return MaxMessagePayload
 }
 
 // A compile-time constraint to ensure Init implements the Message interface.

--- a/watchtower/wtwire/message.go
+++ b/watchtower/wtwire/message.go
@@ -88,7 +88,7 @@ func makeEmptyMessage(msgType MessageType) (Message, error) {
 
 	switch msgType {
 	case MsgInit:
-		msg = &Init{&lnwire.Init{}}
+		msg = &Init{}
 	case MsgCreateSession:
 		msg = &CreateSession{}
 	case MsgCreateSessionReply:

--- a/watchtower/wtwire/wtwire_test.go
+++ b/watchtower/wtwire/wtwire_test.go
@@ -8,6 +8,7 @@ import (
 	"testing/quick"
 	"time"
 
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/davecgh/go-spew/spew"
 	"github.com/lightningnetwork/lnd/lnwire"
 	"github.com/lightningnetwork/lnd/watchtower/wtwire"
@@ -21,6 +22,12 @@ func randRawFeatureVector(r *rand.Rand) *lnwire.RawFeatureVector {
 		}
 	}
 	return featureVec
+}
+
+func randChainHash(r *rand.Rand) chainhash.Hash {
+	var hash chainhash.Hash
+	r.Read(hash[:])
+	return hash
 }
 
 // TestWatchtowerWireProtocol uses the testing/quick package to create a series
@@ -73,7 +80,7 @@ func TestWatchtowerWireProtocol(t *testing.T) {
 		wtwire.MsgInit: func(v []reflect.Value, r *rand.Rand) {
 			req := wtwire.NewInitMessage(
 				randRawFeatureVector(r),
-				randRawFeatureVector(r),
+				randChainHash(r),
 			)
 
 			v[0] = reflect.ValueOf(*req)


### PR DESCRIPTION
This PR modifies the `wtwire.Init` message to send only connection-level features and the chain hash of the chain that each client is on. The previous message sent local and global features to mimic the design of the `lnwire.Init` message, though there has been some rough consensus that we will move away from that in favor of an `Init` message of this form.

This change fixes two things:
 - The global features don't need to be advertised at the connection level, as they have no impact on the connection. The move to calling the "connection features" is supposed to be more indicative that the feature bits only impact the behavior of the protocol over the lifetime of the established connection.
 - Adding the chainhash ensures that a client doesn't accidentally back up its state to server on the wrong chain, e.g. litecoin or testnet. This ensures that the tower at a particular address isn't watching the proper chain, or if a server on a different chain takes over the endpoint, the client will discontinue communication with the tower.