### PR TITLE
lnrpc: fix sendtoroute marshall code payment hash parsing

### DIFF
--- a/rpcserver.go
+++ b/rpcserver.go
@@ -2719,7 +2719,8 @@ func unmarshallSendToRouteRequest(req *lnrpc.SendToRouteRequest,
 
 	return &rpcPaymentRequest{
 		SendRequest: &lnrpc.SendRequest{
-			PaymentHash: req.PaymentHash,
+			PaymentHash:       req.PaymentHash,
+			PaymentHashString: req.PaymentHashString,
 		},
 		routes: routes,
 	}, nil


### PR DESCRIPTION
Fixes a regression introduced in #2521

It should be noted that before that PR, parsing of the payment hash was already inconsistent between the async and the sync sendtoroute call.

This fixes both cases.