### PR TITLE
wtwire: add CheckRemoteInit helper

### DIFF
--- a/watchtower/config.go
+++ b/watchtower/config.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/btcsuite/btcd/btcec"
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcd/wire"
 	"github.com/btcsuite/btcutil"
 	"github.com/lightningnetwork/lnd/tor"
@@ -35,6 +36,11 @@ var (
 // All nil-able elements with the Config must be set in order for the Watchtower
 // to function properly.
 type Config struct {
+	// ChainHash identifies the chain that the watchtower will be monitoring
+	// for breaches and that will be advertised in the server's Init message
+	// to inbound clients.
+	ChainHash chainhash.Hash
+
 	// BlockFetcher supports the ability to fetch blocks from the network by
 	// hash.
 	BlockFetcher lookout.BlockFetcher

--- a/watchtower/standalone.go
+++ b/watchtower/standalone.go
@@ -78,6 +78,7 @@ func New(cfg *Config) (*Standalone, error) {
 
 	// Initialize the server with its required resources.
 	server, err := wtserver.New(&wtserver.Config{
+		ChainHash:    cfg.ChainHash,
 		DB:           cfg.DB,
 		NodePrivKey:  cfg.NodePrivKey,
 		Listeners:    listeners,

--- a/watchtower/wtserver/server.go
+++ b/watchtower/wtserver/server.go
@@ -306,7 +306,7 @@ func (s *Server) handleInit(localInit, remoteInit *wtwire.Init) error {
 	}
 
 	remoteConnFeatures := lnwire.NewFeatureVector(
-		remoteInit.ConnFeatures, wtwire.LocalFeatures,
+		remoteInit.ConnFeatures, wtwire.FeatureNames,
 	)
 
 	unknownLocalFeatures := remoteConnFeatures.UnknownRequiredFeatures()

--- a/watchtower/wtwire/features.go
+++ b/watchtower/wtwire/features.go
@@ -2,13 +2,9 @@ package wtwire
 
 import "github.com/lightningnetwork/lnd/lnwire"
 
-// GlobalFeatures holds the globally advertised feature bits understood by
-// watchtower implementations.
-var GlobalFeatures map[lnwire.FeatureBit]string
-
-// LocalFeatures holds the locally advertised feature bits understood by
-// watchtower implementations.
-var LocalFeatures = map[lnwire.FeatureBit]string{
+// FeatureNames holds a mapping from each feature bit understood by this
+// implementation to its common name.
+var FeatureNames = map[lnwire.FeatureBit]string{
 	WtSessionsRequired: "wt-sessions",
 	WtSessionsOptional: "wt-sessions",
 }

--- a/watchtower/wtwire/init_test.go
+++ b/watchtower/wtwire/init_test.go
@@ -1,0 +1,106 @@
+package wtwire_test
+
+import (
+	"testing"
+
+	"github.com/btcsuite/btcd/chaincfg"
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"github.com/lightningnetwork/lnd/lnwire"
+	"github.com/lightningnetwork/lnd/watchtower/wtwire"
+)
+
+var (
+	testnetChainHash = *chaincfg.TestNet3Params.GenesisHash
+	mainnetChainHash = *chaincfg.MainNetParams.GenesisHash
+)
+
+type checkRemoteInitTest struct {
+	name      string
+	lFeatures *lnwire.RawFeatureVector
+	lHash     chainhash.Hash
+	rFeatures *lnwire.RawFeatureVector
+	rHash     chainhash.Hash
+	expErr    error
+}
+
+var checkRemoteInitTests = []checkRemoteInitTest{
+	{
+		name:      "same chain, local-optional remote-required",
+		lFeatures: lnwire.NewRawFeatureVector(wtwire.WtSessionsOptional),
+		lHash:     testnetChainHash,
+		rFeatures: lnwire.NewRawFeatureVector(wtwire.WtSessionsRequired),
+		rHash:     testnetChainHash,
+	},
+	{
+		name:      "same chain, local-required remote-optional",
+		lFeatures: lnwire.NewRawFeatureVector(wtwire.WtSessionsRequired),
+		lHash:     testnetChainHash,
+		rFeatures: lnwire.NewRawFeatureVector(wtwire.WtSessionsOptional),
+		rHash:     testnetChainHash,
+	},
+	{
+		name:      "different chain, local-optional remote-required",
+		lFeatures: lnwire.NewRawFeatureVector(wtwire.WtSessionsOptional),
+		lHash:     testnetChainHash,
+		rFeatures: lnwire.NewRawFeatureVector(wtwire.WtSessionsRequired),
+		rHash:     mainnetChainHash,
+		expErr:    wtwire.NewErrUnknownChainHash(mainnetChainHash),
+	},
+	{
+		name:      "different chain, local-required remote-optional",
+		lFeatures: lnwire.NewRawFeatureVector(wtwire.WtSessionsOptional),
+		lHash:     testnetChainHash,
+		rFeatures: lnwire.NewRawFeatureVector(wtwire.WtSessionsRequired),
+		rHash:     mainnetChainHash,
+		expErr:    wtwire.NewErrUnknownChainHash(mainnetChainHash),
+	},
+	{
+		name:      "same chain, remote-unknown-required",
+		lFeatures: lnwire.NewRawFeatureVector(wtwire.WtSessionsOptional),
+		lHash:     testnetChainHash,
+		rFeatures: lnwire.NewRawFeatureVector(lnwire.GossipQueriesRequired),
+		rHash:     testnetChainHash,
+		expErr: wtwire.NewErrUnknownRequiredFeatures(
+			lnwire.GossipQueriesRequired,
+		),
+	},
+}
+
+// TestCheckRemoteInit asserts the behavior of CheckRemoteInit when called with
+// the remote party's Init message and the default wtwire.Features. We assert
+// the validity of advertised features from the perspective of both client and
+// server, as well as failure cases such as differing chain hashes or unknown
+// required features.
+func TestCheckRemoteInit(t *testing.T) {
+	for _, test := range checkRemoteInitTests {
+		t.Run(test.name, func(t *testing.T) {
+			testCheckRemoteInit(t, test)
+		})
+	}
+}
+
+func testCheckRemoteInit(t *testing.T, test checkRemoteInitTest) {
+	localInit := wtwire.NewInitMessage(test.lFeatures, test.lHash)
+	remoteInit := wtwire.NewInitMessage(test.rFeatures, test.rHash)
+
+	err := localInit.CheckRemoteInit(remoteInit, wtwire.FeatureNames)
+	switch {
+
+	// Both non-nil, pass.
+	case err == nil && test.expErr == nil:
+		return
+
+	// One is nil and one is non-nil, fail.
+	default:
+		t.Fatalf("error mismatch, want: %v, got: %v", test.expErr, err)
+
+	// Both non-nil, assert same error type.
+	case err != nil && test.expErr != nil:
+	}
+
+	// Compare error strings to assert same type.
+	if err.Error() != test.expErr.Error() {
+		t.Fatalf("error mismatch, want: %v, got: %v",
+			test.expErr.Error(), err.Error())
+	}
+}


### PR DESCRIPTION
This PR is an extension of #2606 and #2605, adding a `CheckRemoteInit` helper method to the `wtwire.Init` message. Once the client is merged, this will checked in three different places with in the code base, so it makes sense to centralize this logic. We also add unit tests to ensure that the combination of features bits proposed via client and server will work together from the perspective of both the client and server.

Depends on:
 - [x] #2605 
 - [x] #2606