### PR TITLE
fix glide build error with docker ltcd

### DIFF
--- a/docker/ltcd/Dockerfile
+++ b/docker/ltcd/Dockerfile
@@ -1,15 +1,14 @@
-FROM golang:1.10-alpine as builder
+FROM golang:1.11-alpine as builder
 
 MAINTAINER Olaoluwa Osuntokun <lightning.engineering>
 
 # Grab and install the latest version of roasbeef's fork of ltcd and all
 # related dependencies.
 WORKDIR $GOPATH/src/github.com/ltcsuite/ltcd
-RUN apk add --no-cache git \
-&&  git clone https://github.com/ltcsuite/ltcd ./ \
-&&  go get -u github.com/Masterminds/glide \
-&&  glide install \
-&&  go install . ./cmd/ltcctl ./cmd/gencerts
+RUN apk add --no-cache --update alpine-sdk git
+RUN git clone https://github.com/ltcsuite/ltcd ./
+RUN GO111MODULE=on go install -v . ./cmd/...
+RUN GO111MODULE=on go install . ./cmd/ltcctl ./cmd/gencerts
 
 # Start a new image
 FROM alpine as final


### PR DESCRIPTION
This PR fixes the build error with the ltc dockerfile https://github.com/lightningnetwork/lnd/issues/2623.  This is the same issue that was resolved for btcd here: https://github.com/lightningnetwork/lnd/pull/2253.

I also split out the seperate instructions using `RUN` instead of stringing them together with `&&` because with `RUN` it's easy to see which execution statement failed.  Not using `RUN` will result in smaller image sizes, but since this `Dockerfile` uses a multistage build, the net result is the same.

Fixes #2623 