### PR TITLE
lncli: returning non 0 exit code when paying invoice fails

### DIFF
--- a/cmd/lncli/commands.go
+++ b/cmd/lncli/commands.go
@@ -2176,6 +2176,13 @@ func sendPaymentRequest(client lnrpc.LightningClient, req *lnrpc.SendRequest) er
 		R: resp.PaymentRoute,
 	})
 
+	// If we get a payment error back, we pass an error
+	// up to main which eventually calls fatal() and returns
+	// with a non-zero exit code.
+	if resp.PaymentError != "" {
+		return errors.New(resp.PaymentError)
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
Closes #2647 

Still calling `printJSON()` here as it was in the past, but now am returning an error back up to `main()` where `fatal()` is called if an error is returned which returns the correct error code and prints the error to stderr.

`sendPaymentRequest` isn't tested anywhere right now, hence why no tests were added. I can add tests if you'd like, though I'm probably not the right person to properly test this properly from scratch, and it's probably out of scope a bit.

#### Pull Request Checklist

- [X] If this is your first time contributing, we recommend you read the [Code
  Contribution Guidelines](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md)
- [X] All changes are Go version 1.11 compliant
- [X]  The code being submitted is commented according to the
  [Code Documentation and Commenting](#CodeDocumentation) section
- [ ]  For new code: Code is accompanied by tests which exercise both
  the positive and negative (error paths) conditions (if applicable)
- [ ]  For bug fixes: Code is accompanied by new tests which trigger
  the bug being fixed to prevent regressions
- [ ]  Any new logging statements use an appropriate subsystem and
  logging level
- [X]  Code has been formatted with `go fmt`
- [X]  For code and documentation: lines are wrapped at 80 characters
  (the tab character should be counted as 8 characters, not 4, as some IDEs do
  per default)
- [X]  Running `make check` does not fail any tests
- [ ]  Running `go vet` does not report any issues
- [ ]  Running `make lint` does not report any **new** issues that did not
  already exist
- [X] All commits build properly and pass tests. Only in exceptional
  cases it can be justifiable to violate this condition. In that case, the
  reason should be stated in the commit message.
- [X] Commits have a logical structure ([see section 4.5, of the Code Contribution Guidelines])
