### PR TITLE
build: update to latest neutrino build

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -29,7 +29,7 @@ require (
 	github.com/juju/utils v0.0.0-20180820210520-bf9cc5bdd62d // indirect
 	github.com/juju/version v0.0.0-20180108022336-b64dbd566305 // indirect
 	github.com/kkdai/bstream v0.0.0-20181106074824-b3251f7901ec
-	github.com/lightninglabs/neutrino v0.0.0-20190213031021-ae4583a89cfb
+	github.com/lightninglabs/neutrino v0.0.0-20190219013218-1a80fd3d0e92
 	github.com/lightningnetwork/lightning-onion v0.0.0-20180605012408-ac4d9da8f1d6
 	github.com/lightningnetwork/lnd/queue v1.0.0
 	github.com/lightningnetwork/lnd/ticker v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -99,6 +99,8 @@ github.com/lightninglabs/gozmq v0.0.0-20180324010646-462a8a753885/go.mod h1:KUh1
 github.com/lightninglabs/neutrino v0.0.0-20181017011010-4d6069299130/go.mod h1:KJq43Fu9ceitbJsSXMILcT4mGDNI/crKmPIkDOZXFyM=
 github.com/lightninglabs/neutrino v0.0.0-20190213031021-ae4583a89cfb h1:Bwqgn9JXHo7I19lb4zTH2Xb0bfHgNuAJugQE7s00xqA=
 github.com/lightninglabs/neutrino v0.0.0-20190213031021-ae4583a89cfb/go.mod h1:g6cMQd+hfAU8pQTJAdjm6/EQREhupyd22f+CL0qYFOE=
+github.com/lightninglabs/neutrino v0.0.0-20190219013218-1a80fd3d0e92 h1:sr+gYlO4n6NriBvCIxdCfc3iW5iG1WAz5k9cIWHdaRE=
+github.com/lightninglabs/neutrino v0.0.0-20190219013218-1a80fd3d0e92/go.mod h1:g6cMQd+hfAU8pQTJAdjm6/EQREhupyd22f+CL0qYFOE=
 github.com/lightningnetwork/lightning-onion v0.0.0-20180605012408-ac4d9da8f1d6 h1:ONLGrYJVQdbtP6CE/ff1KNWZtygRGEh12RzonTiCzPs=
 github.com/lightningnetwork/lightning-onion v0.0.0-20180605012408-ac4d9da8f1d6/go.mod h1:8EgEt4a/NUOVQd+3kk6n9aZCJ1Ssj96Pb6lCrci+6oc=
 github.com/lightningnetwork/lnd/queue v1.0.0 h1:eVUxXIzLm1IdLC5eGzs2z3NzgLYRapy44KCvsDZQ/HI=


### PR DESCRIPTION
In this commit, we update lnd to build against the latest version of
neutrino. This new version fixes a bug left behind as a result of the
btcd filter bug fix. When we were comparing filters in order to ban
invalid peers, we used the old OP_RETURN filtering rather than the new
one. As a result, we might've rejected a valid filter/block as we were
applying the old (incorrect) rules.

