### PR TITLE
Dry run migration

### DIFF
--- a/channeldb/db_test.go
+++ b/channeldb/db_test.go
@@ -45,6 +45,16 @@ func TestOpenWithCreate(t *testing.T) {
 	if !fileExists(dbPath) {
 		t.Fatalf("channeldb failed to create data directory")
 	}
+
+	// Now, reopen the same db in dry run migration mode. Since we have not
+	// applied any migrations, this should ignore the flag and not fail.
+	cdb, err = Open(dbPath, OptionDryRunMigration(true))
+	if err != nil {
+		t.Fatalf("unable to create channeldb: %v", err)
+	}
+	if err := cdb.Close(); err != nil {
+		t.Fatalf("unable to close channeldb: %v", err)
+	}
 }
 
 // TestWipe tests that the database wipe operation completes successfully

--- a/channeldb/options.go
+++ b/channeldb/options.go
@@ -31,6 +31,10 @@ type Options struct {
 
 	// clock is the time source used by the database.
 	clock clock.Clock
+
+	// dryRun will fail to commit a successful migration when opening the
+	// database if set to true.
+	dryRun bool
 }
 
 // DefaultOptions returns an Options populated with default values.
@@ -71,5 +75,13 @@ func OptionSetSyncFreelist(b bool) OptionModifier {
 func OptionClock(clock clock.Clock) OptionModifier {
 	return func(o *Options) {
 		o.clock = clock
+	}
+}
+
+// OptionDryRunMigration controls whether or not to intentially fail to commit a
+// successful migration that occurs when opening the database.
+func OptionDryRunMigration(dryRun bool) OptionModifier {
+	return func(o *Options) {
+		o.dryRun = dryRun
 	}
 }

--- a/config.go
+++ b/config.go
@@ -340,6 +340,8 @@ type config struct {
 
 	MaxChannelFeeAllocation float64 `long:"max-channel-fee-allocation" description:"The maximum percentage of total funds that can be allocated to a channel's commitment fee. This only applies for the initiator of the channel. Valid values are within [0.1, 1]."`
 
+	DryRunMigration bool `long:"dry-run-migration" description:"If true, lnd will abort committing a migration if it would otherwise have been successful. This leaves the database unmodified, and still compatible with the previously active version of lnd."`
+
 	net tor.Net
 
 	EnableUpfrontShutdown bool `long:"enable-upfront-shutdown" description:"If true, option upfront shutdown script will be enabled. If peers that we open channels with support this feature, we will automatically set the script to which cooperative closes should be paid out to on channel open. This offers the partial protection of a channel peer disconnecting from us if cooperative close is attempted with a different script."`

--- a/lnd.go
+++ b/lnd.go
@@ -235,10 +235,15 @@ func Main(lisCfg ListenerCfg) error {
 		channeldb.OptionSetRejectCacheSize(cfg.Caches.RejectCacheSize),
 		channeldb.OptionSetChannelCacheSize(cfg.Caches.ChannelCacheSize),
 		channeldb.OptionSetSyncFreelist(cfg.SyncFreelist),
+		channeldb.OptionDryRunMigration(cfg.DryRunMigration),
 	)
-	if err != nil {
-		err := fmt.Errorf("unable to open channeldb: %v", err)
-		ltndLog.Error(err)
+	switch {
+	case err == channeldb.ErrDryRunMigrationOK:
+		ltndLog.Info("%v, exiting", err)
+		return nil
+
+	case err != nil:
+		ltndLog.Errorf("Unable to open channeldb: %v", err)
 		return err
 	}
 	defer chanDB.Close()


### PR DESCRIPTION
This PR adds an additional configuration option, `dry-run-migration`, which if true will abort any attempt to do a migration. The intention is that users running on master can leave this option on in their config, and will be alerted anytime pulling in new changes will cause a migration from which they cannot revert.

This is also useful for testers willing to try out a migration in order to find bugs before the migrations are merged into master. Testers can use this setting to confirm that migrations are otherwise successful and don't have performance issues as we've seen with some migrations historically.

The setting can be overridden when starting lnd after confirming the dry run is successful by passing `--dry-run-migration=0` to start lnd and commit the migration w/o having to modify the config file, and keep this behavior for subsequent migrations.