### PR TITLE
lnwallet/btcwallet: remove invalid transactions from the wallet when broadcast fails

### DIFF
--- a/contractcourt/htlc_success_resolver.go
+++ b/contractcourt/htlc_success_resolver.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/btcsuite/btcd/wire"
 	"github.com/davecgh/go-spew/spew"
-
 	"github.com/lightningnetwork/lnd/channeldb"
 	"github.com/lightningnetwork/lnd/input"
 	"github.com/lightningnetwork/lnd/lntypes"
@@ -148,7 +147,7 @@ func (h *htlcSuccessResolver) Resolve() (ContractResolver, error) {
 		// constructed, we'll broadcast the sweep transaction to the
 		// network.
 		err := h.PublishTx(h.sweepTx)
-		if err != nil && err != lnwallet.ErrDoubleSpend {
+		if err != nil {
 			log.Infof("%T(%x): unable to publish tx: %v",
 				h, h.payHash[:], err)
 			return nil, err
@@ -200,7 +199,7 @@ func (h *htlcSuccessResolver) Resolve() (ContractResolver, error) {
 	//
 	// TODO(roasbeef): after changing sighashes send to tx bundler
 	err := h.PublishTx(h.htlcResolution.SignedSuccessTx)
-	if err != nil && err != lnwallet.ErrDoubleSpend {
+	if err != nil {
 		return nil, err
 	}
 

--- a/fundingmanager.go
+++ b/fundingmanager.go
@@ -508,7 +508,7 @@ func (f *fundingManager) Start() error {
 			channel.IsInitiator {
 
 			err := f.cfg.PublishTransaction(channel.FundingTxn)
-			if err != nil && err != lnwallet.ErrDoubleSpend {
+			if err != nil {
 				fndgLog.Errorf("Unable to rebroadcast funding "+
 					"tx for ChannelPoint(%v): %v",
 					channel.FundingOutpoint, err)

--- a/utxonursery.go
+++ b/utxonursery.go
@@ -894,7 +894,7 @@ func (u *utxoNursery) sweepCribOutput(classHeight uint32, baby *babyOutput) erro
 	// We'll now broadcast the HTLC transaction, then wait for it to be
 	// confirmed before transitioning it to kindergarten.
 	err := u.cfg.PublishTransaction(baby.timeoutTx)
-	if err != nil && err != lnwallet.ErrDoubleSpend {
+	if err != nil {
 		utxnLog.Errorf("Unable to broadcast baby tx: "+
 			"%v, %v", err, spew.Sdump(baby.timeoutTx))
 		return err

--- a/watchtower/lookout/punisher.go
+++ b/watchtower/lookout/punisher.go
@@ -2,7 +2,6 @@ package lookout
 
 import (
 	"github.com/btcsuite/btcd/wire"
-	"github.com/lightningnetwork/lnd/lnwallet"
 )
 
 // PunisherConfig houses the resources required by the Punisher.
@@ -44,7 +43,7 @@ func (p *BreachPunisher) Punish(desc *JusticeDescriptor, quit <-chan struct{}) e
 		desc.SessionInfo.ID, justiceTxn.TxHash())
 
 	err = p.cfg.PublishTx(justiceTxn)
-	if err != nil && err != lnwallet.ErrDoubleSpend {
+	if err != nil {
 		log.Errorf("Unable to publish justice txn for client=%s"+
 			"with breach-txid=%s: %v",
 			desc.SessionInfo.ID, desc.BreachedCommitTx.TxHash(), err)


### PR DESCRIPTION
In this PR, we update our btcwallet dependency to the latest version, which includes some minor improvements to our error handling when broadcasting transactions.

Along the way, we also address a lingering issue within some subsystems that are responsible for broadcasting transactions. Previously, ErrDoubleSpend indicated that a transaction was already included in the mempool/chain. This error was then modified to actually be returned for conflicting transactions, but its callers were not modified accordingly. This would lead to conflicting transactions to be interpreted as valid, when they shouldn't be.

Depends on https://github.com/btcsuite/btcwallet/pull/597.
Fixes #2657.