### PR TITLE
INSTALL.md : bump to go.1.11.5 on Linux

### DIFF
--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -35,31 +35,31 @@
 
     (x86-64)
     ```
-    wget https://dl.google.com/go/go1.11.4.linux-amd64.tar.gz
-    sha256sum go1.11.4.linux-amd64.tar.gz | awk -F " " '{ print $1 }'
+    wget https://dl.google.com/go/go1.11.5.linux-amd64.tar.gz
+    sha256sum go1.11.5.linux-amd64.tar.gz | awk -F " " '{ print $1 }'
     ```
 
     The final output of the command above should be
-    `fb26c30e6a04ad937bbc657a1b5bba92f80096af1e8ee6da6430c045a8db3a5b`. If it
+    `ff54aafedff961eb94792487e827515da683d61a5f9482f668008832631e5d25`. If it
     isn't, then the target REPO HAS BEEN MODIFIED, and you shouldn't install
     this version of Go. If it matches, then proceed to install Go:
     ```
-    tar -C /usr/local -xzf go1.11.4.linux-amd64.tar.gz
+    tar -C /usr/local -xzf go1.11.5.linux-amd64.tar.gz
     export PATH=$PATH:/usr/local/go/bin
     ```
 
     (ARMv6)
     ```
-    wget https://dl.google.com/go/go1.11.4.linux-armv6l.tar.gz
-    sha256sum go1.11.4.linux-armv6l.tar.gz | awk -F " " '{ print $1 }'
+    wget https://dl.google.com/go/go1.11.5.linux-armv6l.tar.gz
+    sha256sum go1.11.5.linux-armv6l.tar.gz | awk -F " " '{ print $1 }'
     ```
 
     The final output of the command above should be
-    `9f7a71d27fef69f654a93e265560c8d9db1a2ca3f1dcdbe5288c46facfde5821`. If it
+    `b26b53c94923f78955236386fee0725ef4e76b6cb47e0df0ed0c0c4724e7b198`. If it
     isn't, then the target REPO HAS BEEN MODIFIED, and you shouldn't install
     this version of Go. If it matches, then proceed to install Go:
     ```
-    tar -C /usr/local -xzf go1.11.4.linux-armv6l.tar.gz
+    tar -C /usr/local -xzf go1.11.5.linux-armv6l.tar.gz
     export PATH=$PATH:/usr/local/go/bin
     ```
 


### PR DESCRIPTION
This PR is about bumping go1.11.4 to 1.11.5 in the Linux part of the INSTALL.md file because 1.11.5 is now the last stable release. It modifies the package name from 1.11.4 to 1.11.5 and the hashes associated with them. 

This was initially an Issue but Roasbeef commented that I should turn this into a PR.  