### PR TITLE
cmd/lncli: increase default recovery window to 2.5k

### DIFF
--- a/cmd/lncli/commands.go
+++ b/cmd/lncli/commands.go
@@ -33,7 +33,7 @@ import (
 
 // TODO(roasbeef): expose all fee conf targets
 
-const defaultRecoveryWindow int32 = 250
+const defaultRecoveryWindow int32 = 2500
 
 func printJSON(resp interface{}) {
 	b, err := json.Marshal(resp)


### PR DESCRIPTION
Increases the default window from 250 to 25k. Many
users have reported attempting recovery with the
default value only to find an empty wallet. This
change should help ensure that the first recovery
attempt succeeds for the majority of nodes that
have modest load. It might prudent to consider
increasing this value further in the future if
the issue persists or average node age increases.