### PR TITLE
channeldb: cache HasChannelEdge queries

### DIFF
--- a/channeldb/db.go
+++ b/channeldb/db.go
@@ -114,6 +114,7 @@ var bufPool = &sync.Pool{
 type DB struct {
 	*bbolt.DB
 	dbPath string
+	graph  *ChannelGraph
 }
 
 // Open opens an existing channeldb. Any necessary schemas migrations due to
@@ -136,6 +137,7 @@ func Open(dbPath string) (*DB, error) {
 		DB:     bdb,
 		dbPath: dbPath,
 	}
+	chanDB.graph = NewChannelGraph(chanDB)
 
 	// Synchronize the version of database and apply migrations if needed.
 	if err := chanDB.syncVersions(dbVersions); err != nil {
@@ -1100,7 +1102,7 @@ func (d *DB) syncVersions(versions []version) error {
 
 // ChannelGraph returns a new instance of the directed channel graph.
 func (d *DB) ChannelGraph() *ChannelGraph {
-	return &ChannelGraph{d}
+	return d.graph
 }
 
 func getLatestDBVersion(versions []version) uint32 {

--- a/channeldb/db.go
+++ b/channeldb/db.go
@@ -899,7 +899,7 @@ type ChannelShell struct {
 // well. This method is idempotent, so repeated calls with the same set of
 // channel shells won't modify the database after the initial call.
 func (d *DB) RestoreChannelShells(channelShells ...*ChannelShell) error {
-	chanGraph := ChannelGraph{d}
+	chanGraph := d.ChannelGraph()
 
 	return d.Update(func(tx *bbolt.Tx) error {
 		for _, channelShell := range channelShells {

--- a/channeldb/edge_cache.go
+++ b/channeldb/edge_cache.go
@@ -1,0 +1,58 @@
+package channeldb
+
+// edgeCacheEntry caches frequently accessed information about a channel,
+// including the timestamps of its latest edge policies and whether or not the
+// channel exists in the graph.
+type edgeCacheEntry struct {
+	upd1Time uint32
+	upd2Time uint32
+	exists   bool
+}
+
+// edgeCache is an in-memory cache used to improve the performance of
+// HasChannelEdge. It caches information about the whether or channel exists, as
+// well as the most recent timestamps for each policy (if they exists).
+type edgeCache struct {
+	n     int
+	edges map[uint64]edgeCacheEntry
+}
+
+// newEdgeCache creates a new edgeCache with maximum capacity of n entries.
+func newEdgeCache(n int) *edgeCache {
+	return &edgeCache{
+		n:     n,
+		edges: make(map[uint64]edgeCacheEntry, n),
+	}
+}
+
+// get returns the entry from the cache for chanid, if it exists.
+func (c *edgeCache) get(chanid uint64) (edgeCacheEntry, bool) {
+	entry, ok := c.edges[chanid]
+	return entry, ok
+}
+
+// insert adds the entry to the edge cache. If an entry for chanid already
+// exists, it will be replaced with the new entry. If the entry doesn't exists,
+// it will be inserted to the cache, performing a random eviction if the cache
+// is at capacity.
+func (c *edgeCache) insert(chanid uint64, entry edgeCacheEntry) {
+	// If entry exists, replace it.
+	if _, ok := c.edges[chanid]; ok {
+		c.edges[chanid] = entry
+		return
+	}
+
+	// Otherwise, evict an entry at random and insert.
+	if len(c.edges) == c.n {
+		for id := range c.edges {
+			delete(c.edges, id)
+			break
+		}
+	}
+	c.edges[chanid] = entry
+}
+
+// remove deletes an entry for chanid from the cache, if it exists.
+func (c *edgeCache) remove(chanid uint64) {
+	delete(c.edges, chanid)
+}

--- a/channeldb/edge_cache_internal_test.go
+++ b/channeldb/edge_cache_internal_test.go
@@ -1,0 +1,105 @@
+package channeldb
+
+import (
+	"reflect"
+	"testing"
+)
+
+// TestEdgeCache checks the behavior of the edgeCache with respect to insertion,
+// eviction, and removal of cache entries.
+func TestEdgeCache(t *testing.T) {
+	const cacheSize = 100
+
+	// Create a new edge cache with the configured max size.
+	c := newEdgeCache(cacheSize)
+
+	// As a sanity check, assert that querying the empty cache does not
+	// return an entry.
+	_, ok := c.get(0)
+	if ok {
+		t.Fatalf("edge cache should be empty")
+	}
+
+	// Now, fill up the cache entirely.
+	for i := uint64(0); i < cacheSize; i++ {
+		c.insert(i, entryForInt(i))
+	}
+
+	// Assert that the cache has all of the entries just inserted, since no
+	// eviction should occur until we try to surpass the max size.
+	assertHasEntries(t, c, 0, cacheSize)
+
+	// Now, insert a new element that causes the cache to evict an element.
+	c.insert(cacheSize, entryForInt(cacheSize))
+
+	// Assert that the cache has this last entry, as the cache should evict
+	// some prior element and not the newly inserted one.
+	assertHasEntries(t, c, cacheSize, cacheSize)
+
+	// Iterate over all inserted elements and construct a set of the evicted
+	// elements.
+	evicted := make(map[uint64]struct{})
+	for i := uint64(0); i < cacheSize+1; i++ {
+		_, ok := c.get(i)
+		if !ok {
+			evicted[i] = struct{}{}
+		}
+	}
+
+	// Assert that exactly one element has been evicted.
+	numEvicted := len(evicted)
+	if numEvicted != 1 {
+		t.Fatalf("expected one evicted entry, got: %d", numEvicted)
+	}
+
+	// Remove the highest item which initially caused the eviction and
+	// reinsert the element that was evicted prior.
+	c.remove(cacheSize)
+	for i := range evicted {
+		c.insert(i, entryForInt(i))
+	}
+
+	// Since the removal created an extra slot, the last insertion should
+	// not have caused an eviction and the entries for all channels in the
+	// original set that filled the cache should be present.
+	assertHasEntries(t, c, 0, cacheSize)
+
+	// Finally, reinsert the existing set back into the cache and test that
+	// the cache still has all the entries. If the randomized eviction were
+	// happening on inserts for existing cache items, we expect this to fail
+	// with high probability.
+	for i := uint64(0); i < cacheSize; i++ {
+		c.insert(i, entryForInt(i))
+	}
+	assertHasEntries(t, c, 0, cacheSize)
+
+}
+
+// assertHasEntries queries the edge cache for all channels in the range [start,
+// end), asserting that they exist and their value matches the entry produced by
+// entryForInt.
+func assertHasEntries(t *testing.T, c *edgeCache, start, end uint64) {
+	t.Helper()
+
+	for i := start; i < end; i++ {
+		entry, ok := c.get(i)
+		if !ok {
+			t.Fatalf("edge cache should contain chan %d", i)
+		}
+
+		expEntry := entryForInt(i)
+		if !reflect.DeepEqual(entry, expEntry) {
+			t.Fatalf("entry mismatch, want: %v, got: %v",
+				expEntry, entry)
+		}
+	}
+}
+
+// entryForInt generates a unique edgeCacheEntry given an integer.
+func entryForInt(i uint64) edgeCacheEntry {
+	return edgeCacheEntry{
+		upd1Time: uint32(2 * i),
+		upd2Time: uint32(2*i + 1),
+		exists:   i%2 == 0,
+	}
+}

--- a/channeldb/graph.go
+++ b/channeldb/graph.go
@@ -154,6 +154,14 @@ type ChannelGraph struct {
 	//  * LRU cache for edges?
 }
 
+// NewChannelGraph allocates a new ChannelGraph backed by a DB instance. The
+// returned instance has its own unique edge cache.
+func NewChannelGraph(db *DB) *ChannelGraph {
+	return &ChannelGraph{
+		db: db,
+	}
+}
+
 // Database returns a pointer to the underlying database.
 func (c *ChannelGraph) Database() *DB {
 	return c.db


### PR DESCRIPTION
Adds a small cache in front of `ChannelGraph.HasChannelEdge` in order to improve the performance of graph validation. This avoids hitting the database to check if an edge policy is stale, as well as a number of places in which `HasChannelEdge` is called as a subroutine to obtain the latest policy timestamps and check edge existence. `HasChannelEdge` is one of the primary CPU bottlenecks that remains on my node after merging the latest buffer pool optimizations. After running this PoC on my node, `HasChannelEdge` no longer appears on the flame graphs.