### PR TITLE
docker-compose up

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -68,7 +68,7 @@ docker volume create simnet_lnd_alice
 docker volume create simnet_lnd_bob
 
 # Run the "Alice" container and log into it:
-$ docker-compose run -d --name alice --volume simnet_lnd_alice:/root/.lnd lnd_btc
+$ docker-compose run -d --name alice --volume simnet_lnd_alice:/root/.lnd lnd
 $ docker exec -i -t alice bash
 
 # Generate a new backward compatible nested p2sh address for Alice:
@@ -79,10 +79,10 @@ $ MINING_ADDRESS=<alice_address> docker-compose up -d btcd
 
 # Generate 400 blocks (we need at least "100 >=" blocks because of coinbase 
 # block maturity and "300 ~=" in order to activate segwit):
-$ docker-compose run btcctl generate 400
+$ docker exec -it btcd /start-btcctl.sh generate 400
 
 # Check that segwit is active:
-$ docker-compose run btcctl getblockchaininfo | grep -A 1 segwit
+$ docker exec -it btcd /start-btcctl.sh getblockchaininfo | grep -A 1 segwit
 ```
 
 Check `Alice` balance:
@@ -94,7 +94,7 @@ Connect `Bob` node to `Alice` node.
 
 ```bash
 # Run "Bob" node and log into it:
-$ docker-compose run -d --name bob --volume simnet_lnd_bob:/root/.lnd lnd_btc
+$ docker-compose run -d --name bob --volume simnet_lnd_bob:/root/.lnd lnd
 $ docker exec -i -t bob bash
 
 # Get the identity pubkey of "Bob" node:
@@ -163,7 +163,7 @@ Create the `Alice<->Bob` channel.
 alice$ lncli --network=simnet openchannel --node_key=<bob_identity_pubkey> --local_amt=1000000
 
 # Include funding transaction in block thereby opening the channel:
-$ docker-compose run btcctl generate 3
+$ docker exec -it btcd /start-btcctl.sh generate 3
 
 # Check that channel with "Bob" was opened:
 alice$ lncli --network=simnet listchannels
@@ -247,7 +247,7 @@ alice$ lncli --network=simnet listchannels
 alice$ lncli --network=simnet closechannel --funding_txid=<funding_txid> --output_index=<output_index>
 
 # Include close transaction in a block thereby closing the channel:
-$ docker-compose run btcctl generate 3
+$ docker exec -it btcd /start-btcctl.sh generate 3
 
 # Check "Alice" on-chain balance was credited by her settled amount in the channel:
 alice$ lncli --network=simnet walletbalance
@@ -299,10 +299,7 @@ First of all you need to run `btcd` node in `testnet` and wait for it to be
 synced with test network (`May the Force and Patience be with you`).
 ```bash 
 # Init bitcoin network env variable:
-$ export NETWORK="testnet"
-
-# Run "btcd" node:
-$ docker-compose up -d "btcd"
+$ NETWORK="testnet" docker-compose up
 ```
 
 After `btcd` synced, connect `Alice` to the `Faucet` node.

--- a/docker/btcd/start-btcctl.sh
+++ b/docker/btcd/start-btcctl.sh
@@ -52,7 +52,7 @@ PARAMS=$(echo $PARAMS \
     "--rpccert=/rpc/rpc.cert" \
     "--rpcuser=$RPCUSER" \
     "--rpcpass=$RPCPASS" \
-    "--rpcserver=rpcserver" \
+    "--rpcserver=localhost" \
 )
 
 PARAMS="$PARAMS $@"

--- a/docker/docker-compose.ltc.yml
+++ b/docker/docker-compose.ltc.yml
@@ -1,27 +1,27 @@
 version: '2'
 services:
-    # btc is an image of bitcoin node which used as base image for btcd and
-    # btccli. The environment variables default values determined on stage of
+    # ltc is an image of litecoin node which used as base image for ltcd and
+    # ltcctl. The environment variables default values determined on stage of
     # container start within starting script.
-    btcd:
-      image: btcd
-      container_name: btcd
+    ltcd:
+      image: ltcd
+      container_name: ltcd
       build:
-        context: btcd/
+        context: ltcd/
       volumes:
         - shared:/rpc
-        - bitcoin:/data
+        - litecoin:/data
       environment:
         - RPCUSER
         - RPCPASS
         - NETWORK
         - DEBUG
         - MINING_ADDRESS
-      entrypoint: ["./start-btcd.sh"]
+      entrypoint: ["./start-ltcd.sh"]
 
     lnd:
       image: lnd
-      container_name: lnd
+      container_name: lnd_ltc
       build:
         context: ../
         dockerfile: docker/lnd/Dockerfile
@@ -33,23 +33,23 @@ services:
         - DEBUG
       volumes:
         - shared:/rpc
-        - lnd:/root/.lnd
+        - lnd_ltc:/root/.lnd
       entrypoint: ["./start-lnd.sh"]
       links:
-        - "btcd:blockchain"
+        - "ltcd:blockchain"
 
 volumes:
   # shared volume is need to store the btcd rpc certificates and use it within
-  # btcctl and lnd containers.
+  # ltcctl and lnd containers.
   shared:
     driver: local
 
-  # bitcoin volume is needed for maintaining blockchain persistence
-  # during btcd container recreation.
-  bitcoin:
+  # litecoin volume is needed for maintaining blockchain persistence
+  # during ltcd container recreation.
+  litecoin:
     driver: local
 
   # lnd volume is used for persisting lnd application data and chain state
   # during container lifecycle.
-  lnd:
+  lnd_ltc:
     driver: local

--- a/docker/ltcd/start-ltcctl.sh
+++ b/docker/ltcd/start-ltcctl.sh
@@ -52,7 +52,7 @@ PARAMS=$(echo $PARAMS \
     "--rpccert=/rpc/rpc.cert" \
     "--rpcuser=$RPCUSER" \
     "--rpcpass=$RPCPASS" \
-    "--rpcserver=rpcserver" \
+    "--rpcserver=localhost" \
 )
 
 PARAMS="$PARAMS $@"


### PR DESCRIPTION
https://i.gifer.com/52an.gif

https://github.com/lightningnetwork/lnd/issues/2509

build and start both `lnd` and the `btcd` backend with a single command `docker-compose up`.  In order to enable docker-compose to bring up the services, I removed service definitions that aren't needed for running the environment.  The docs have been updated with new instructions for how to run `btcctl` now that it's not a separate service.

Also, this PR Moves `ltc` to a separate docker-compose file.  A future PR can allow `ltc` to be brought up with a single command and inherit from `docker-compose.yml`.
