### PR TITLE
cnct: fix error returning bug

### DIFF
--- a/contractcourt/commit_sweep_resolver.go
+++ b/contractcourt/commit_sweep_resolver.go
@@ -116,7 +116,7 @@ func (c *commitSweepResolver) Resolve() (ContractResolver, error) {
 				log.Errorf("%T(%v): unable to sweep input: %v",
 					c, c.chanPoint, sweepResult.Err)
 
-				return nil, err
+				return nil, sweepResult.Err
 			}
 
 			log.Infof("ChannelPoint(%v) commit tx is fully resolved by "+


### PR DESCRIPTION
The wrong error variable was returned, causing a resolution failure to
be interpreted by the channel arbitrator as a success.

Fixes #2687 