### PR TITLE
Cancel long-running Neutrino GetUTXO calls on quit

### DIFF
--- a/chainntnfs/neutrinonotify/neutrino.go
+++ b/chainntnfs/neutrinonotify/neutrino.go
@@ -764,6 +764,7 @@ func (n *NeutrinoNotifier) RegisterSpendNtfn(outpoint *wire.OutPoint,
 		neutrino.EndBlock(&waddrmgr.BlockStamp{
 			Height: int32(historicalDispatch.EndHeight),
 		}),
+		neutrino.QuitChan(n.quit),
 	)
 	if err != nil && !strings.Contains(err.Error(), "not found") {
 		return nil, err

--- a/contractcourt/channel_arbitrator_test.go
+++ b/contractcourt/channel_arbitrator_test.go
@@ -124,6 +124,8 @@ func (b *mockArbitratorLog) WipeHistory() error {
 
 type mockChainIO struct{}
 
+var _ lnwallet.BlockChainIO = (*mockChainIO)(nil)
+
 func (*mockChainIO) GetBestBlock() (*chainhash.Hash, int32, error) {
 	return nil, 0, nil
 }

--- a/contractcourt/channel_arbitrator_test.go
+++ b/contractcourt/channel_arbitrator_test.go
@@ -131,7 +131,7 @@ func (*mockChainIO) GetBestBlock() (*chainhash.Hash, int32, error) {
 }
 
 func (*mockChainIO) GetUtxo(op *wire.OutPoint, _ []byte,
-	heightHint uint32) (*wire.TxOut, error) {
+	heightHint uint32, _ <-chan struct{}) (*wire.TxOut, error) {
 	return nil, nil
 }
 

--- a/lnwallet/btcwallet/blockchain.go
+++ b/lnwallet/btcwallet/blockchain.go
@@ -51,6 +51,7 @@ func (b *BtcWallet) GetUtxo(op *wire.OutPoint, pkScript []byte,
 			neutrino.StartBlock(&waddrmgr.BlockStamp{
 				Height: int32(heightHint),
 			}),
+			neutrino.QuitChan(cancel),
 		)
 		if err != nil {
 			return nil, err

--- a/lnwallet/btcwallet/blockchain.go
+++ b/lnwallet/btcwallet/blockchain.go
@@ -38,7 +38,7 @@ func (b *BtcWallet) GetBestBlock() (*chainhash.Hash, int32, error) {
 //
 // This method is a part of the lnwallet.BlockChainIO interface.
 func (b *BtcWallet) GetUtxo(op *wire.OutPoint, pkScript []byte,
-	heightHint uint32) (*wire.TxOut, error) {
+	heightHint uint32, cancel <-chan struct{}) (*wire.TxOut, error) {
 
 	switch backend := b.chain.(type) {
 

--- a/lnwallet/btcwallet/btcwallet.go
+++ b/lnwallet/btcwallet/btcwallet.go
@@ -67,8 +67,9 @@ type BtcWallet struct {
 }
 
 // A compile time check to ensure that BtcWallet implements the
-// WalletController interface.
+// WalletController and BlockChainIO interfaces.
 var _ lnwallet.WalletController = (*BtcWallet)(nil)
+var _ lnwallet.BlockChainIO = (*BtcWallet)(nil)
 
 // New returns a new fully initialized instance of BtcWallet given a valid
 // configuration struct.

--- a/lnwallet/interface.go
+++ b/lnwallet/interface.go
@@ -268,8 +268,10 @@ type BlockChainIO interface {
 	// script that the outpoint creates. In the case that the output is in
 	// the UTXO set, then the output corresponding to that output is
 	// returned.  Otherwise, a non-nil error will be returned.
-	GetUtxo(op *wire.OutPoint, pkScript []byte,
-		heightHint uint32) (*wire.TxOut, error)
+	// As for some backends this call can initiate a rescan, the passed
+	// cancel channel can be closed to abort the call.
+	GetUtxo(op *wire.OutPoint, pkScript []byte, heightHint uint32,
+		cancel <-chan struct{}) (*wire.TxOut, error)
 
 	// GetBlockHash returns the hash of the block in the best blockchain
 	// at the given height.

--- a/lnwallet/wallet.go
+++ b/lnwallet/wallet.go
@@ -974,7 +974,7 @@ func (l *LightningWallet) handleFundingCounterPartySigs(msg *addCounterPartySigs
 			}
 			output, err := l.Cfg.ChainIO.GetUtxo(
 				&txin.PreviousOutPoint,
-				pkScript, 0,
+				pkScript, 0, l.quit,
 			)
 			if output == nil {
 				msg.err <- fmt.Errorf("input to funding tx "+

--- a/lnwallet/wallet.go
+++ b/lnwallet/wallet.go
@@ -971,7 +971,12 @@ func (l *LightningWallet) handleFundingCounterPartySigs(msg *addCounterPartySigs
 				txin.Witness[len(txin.Witness)-1],
 			)
 			if err != nil {
+				msg.err <- fmt.Errorf("cannot create script: "+
+					"%v", err)
+				msg.completeChan <- nil
+				return
 			}
+
 			output, err := l.Cfg.ChainIO.GetUtxo(
 				&txin.PreviousOutPoint,
 				pkScript, 0, l.quit,

--- a/mock.go
+++ b/mock.go
@@ -205,6 +205,8 @@ type mockChainIO struct {
 	bestHeight int32
 }
 
+var _ lnwallet.BlockChainIO = (*mockChainIO)(nil)
+
 func (m *mockChainIO) GetBestBlock() (*chainhash.Hash, int32, error) {
 	return activeNetParams.GenesisHash, m.bestHeight, nil
 }

--- a/mock.go
+++ b/mock.go
@@ -212,7 +212,7 @@ func (m *mockChainIO) GetBestBlock() (*chainhash.Hash, int32, error) {
 }
 
 func (*mockChainIO) GetUtxo(op *wire.OutPoint, _ []byte,
-	heightHint uint32) (*wire.TxOut, error) {
+	heightHint uint32, _ <-chan struct{}) (*wire.TxOut, error) {
 	return nil, nil
 }
 

--- a/routing/notifications_test.go
+++ b/routing/notifications_test.go
@@ -181,7 +181,8 @@ func (m *mockChain) addUtxo(op wire.OutPoint, out *wire.TxOut) {
 	m.utxos[op] = *out
 	m.Unlock()
 }
-func (m *mockChain) GetUtxo(op *wire.OutPoint, _ []byte, _ uint32) (*wire.TxOut, error) {
+func (m *mockChain) GetUtxo(op *wire.OutPoint, _ []byte, _ uint32,
+	_ <-chan struct{}) (*wire.TxOut, error) {
 	m.RLock()
 	defer m.RUnlock()
 

--- a/routing/router.go
+++ b/routing/router.go
@@ -1113,6 +1113,7 @@ func (r *ChannelRouter) processUpdate(msg interface{}) error {
 		// been closed so we'll ignore it.
 		chanUtxo, err := r.cfg.Chain.GetUtxo(
 			fundingPoint, fundingPkScript, channelID.BlockHeight,
+			r.quit,
 		)
 		if err != nil {
 			r.rejectMtx.Lock()

--- a/sweep/test_utils.go
+++ b/sweep/test_utils.go
@@ -245,7 +245,7 @@ func (m *mockChainIO) GetBestBlock() (*chainhash.Hash, int32, error) {
 }
 
 func (m *mockChainIO) GetUtxo(op *wire.OutPoint, pkScript []byte,
-	heightHint uint32) (*wire.TxOut, error) {
+	heightHint uint32, _ <-chan struct{}) (*wire.TxOut, error) {
 
 	return nil, nil
 }

--- a/sweep/test_utils.go
+++ b/sweep/test_utils.go
@@ -10,6 +10,7 @@ import (
 	"github.com/btcsuite/btcd/wire"
 	"github.com/lightningnetwork/lnd/chainntnfs"
 	"github.com/lightningnetwork/lnd/input"
+	"github.com/lightningnetwork/lnd/lnwallet"
 )
 
 var (
@@ -236,6 +237,8 @@ func (m *MockNotifier) RegisterSpendNtfn(outpoint *wire.OutPoint,
 }
 
 type mockChainIO struct{}
+
+var _ lnwallet.BlockChainIO = (*mockChainIO)(nil)
 
 func (m *mockChainIO) GetBestBlock() (*chainhash.Hash, int32, error) {
 	return nil, mockChainIOHeight, nil


### PR DESCRIPTION
This PR makes sure long running calls to `GetUTXO` gets cancelled in case we are shutting down.

This is done by adding a `quit` channel to `BtcWallet`, and cancelling the call in case of shutdown.

Fixes #2300. 

Replaces https://github.com/lightningnetwork/lnd/pull/1781