### PR TITLE
Revert "peer: reduce write timeout to 10s"

### DIFF
--- a/peer.go
+++ b/peer.go
@@ -44,8 +44,8 @@ const (
 	// idleTimeout is the duration of inactivity before we time out a peer.
 	idleTimeout = 5 * time.Minute
 
-	// writeMessageTimeout is the timeout used when writing a message to a peer.
-	writeMessageTimeout = 10 * time.Second
+	// writeMessageTimeout is the timeout used when writing a message to peer.
+	writeMessageTimeout = 50 * time.Second
 
 	// readMessageTimeout is the timeout used when reading a message from a
 	// peer.


### PR DESCRIPTION
This reverts commit db2c104111c3c12e1651120fe5a51ce03dad8c58.

In #2474, a commit was added to reduce the write timeout from 50s to 5s as the existing timeout is rather long in the context of TCP. An issue arises when the remote peer is unable to validate gossip messages as quickly as we are sending them, causing 1) the remote peer's discovery message stream to backup, and 2) the backpressure to be applied to the sender side after any connection level buffers are also full. The result is that the sender disconnects prematurely, and causes connection loops when large amounts of gossip traffic need to be sent (e.g. on initial sync or if node is offline for a bit).

As a temporary measure, this PR reverts the commit and restores the 50s timeout. As of #2474, this 50s timeout is owned by the write pool instead of the peer, which can lead to less-than-optimal utilization of the available write buffers.

The longer-term solution I have in mind is to handle write timeout errors in the peer, and introduce a backoff procedure to dynamically tune the write load to the remote peer's message throughput. This will allow us to move back to a short write timeout at the connection level, ensuring the write pool maintains good utilization w/ less blocking and prevent the premature disconnections observed in master currently.