### PR TITLE
Makefile: fix unit test flakehunter when running on specific package

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -151,8 +151,7 @@ flakehunter: build-itest
 
 flake-unit:
 	@$(call print, "Flake hunting unit tests.")
-	GOTRACEBACK=all $(UNIT) -count=1
-	while [ $$? -eq 0 ]; do /bin/sh -c "GOTRACEBACK=all $(UNIT) -count=1"; done
+	while [ $$? -eq 0 ]; do GOTRACEBACK=all $(UNIT) -count=1; done
 
 # =========
 # UTILITIES


### PR DESCRIPTION
When using the unit test flakehunter and specifying a package, after the
first successful run, all of the tests would be run, rather than just
the ones within the specified package.