### PR TITLE
cnct+chancloser: disable channel before closing

### DIFF
--- a/chancloser.go
+++ b/chancloser.go
@@ -427,6 +427,14 @@ func (c *channelCloser) ProcessCloseMsg(msg lnwire.Message) ([]lnwire.Message, b
 		}
 		c.closingTx = closeTx
 
+		// Before closing, we'll attempt to send a disable update for
+		// the channel. We do so before closing the channel as otherwise
+		// the current edge policy won't be retrievable from the graph.
+		if err := c.cfg.disableChannel(c.chanPoint); err != nil {
+			peerLog.Warnf("Unable to disable channel %v on "+
+				"close: %v", c.chanPoint, err)
+		}
+
 		// With the closing transaction crafted, we'll now broadcast it
 		// to the network.
 		peerLog.Infof("Broadcasting cooperative close tx: %v",
@@ -439,16 +447,6 @@ func (c *channelCloser) ProcessCloseMsg(msg lnwire.Message) ([]lnwire.Message, b
 		if err := c.cfg.channel.MarkCommitmentBroadcasted(); err != nil {
 			return nil, false, err
 		}
-
-		// We'll attempt to disable the channel in the background to
-		// avoid blocking due to sending the update message to all
-		// active peers.
-		go func() {
-			if err := c.cfg.disableChannel(c.chanPoint); err != nil {
-				peerLog.Errorf("Unable to disable channel %v on "+
-					"close: %v", c.chanPoint, err)
-			}
-		}()
 
 		// Finally, we'll transition to the closeFinished state, and
 		// also return the final close signed message we sent.

--- a/netann/chan_status_manager.go
+++ b/netann/chan_status_manager.go
@@ -466,6 +466,18 @@ func (m *ChanStatusManager) disableInactiveChannels() {
 		if err != nil {
 			log.Errorf("Unable to sign update disabling "+
 				"channel(%v): %v", outpoint, err)
+
+			// If the edge was not found, this is a likely indicator
+			// that the channel has been closed. Thus we remove the
+			// outpoint from the set of tracked outpoints to prevent
+			// further attempts.
+			if err == channeldb.ErrEdgeNotFound {
+				log.Debugf("Removing channel(%v) from "+
+					"consideration for passive disabling",
+					outpoint)
+				delete(m.chanStates, outpoint)
+			}
+
 			continue
 		}
 

--- a/test_utils.go
+++ b/test_utils.go
@@ -392,6 +392,9 @@ func createTestPeer(notifier chainntnfs.ChainNotifier,
 	if err != nil {
 		return nil, nil, nil, nil, err
 	}
+	if err = chanStatusMgr.Start(); err != nil {
+		return nil, nil, nil, nil, err
+	}
 	s.chanStatusMgr = chanStatusMgr
 
 	alicePeer := &peer{


### PR DESCRIPTION
This PR reorders logic when closing channels to sign the disabling update before closing the channel in the database. Currently the disable is attempted asynchronously after the close, after which the channel may be removed from the graph and leads to logs generated in #2696.

The fix is simply to do the disables synchronously before closing the channels either cooperatively or unilaterally. The integration test framework has been updated to assert that a disable message is always sent after closing if the channel policy indicates it was enabled at the time of the closure.

The one exception to this was the reorg channel funding itest, for which this cannot happen because the channel has been removed from the channel graph. A separate assertion that ignores the disable assertion is added to handle this case.

Fixes #2696 