### PR TITLE
Makefile: actually install btcd w/ make btcd

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -82,7 +82,9 @@ $(GOACC_BIN):
 
 btcd:
 	@$(call print, "Installing btcd.")
-	GO111MODULE=on go get -v github.com/btcsuite/btcd/@$(BTCD_COMMIT)
+	GO111MODULE=on go get -v $(BTCD_PKG)@$(BTCD_COMMIT)
+	$(GOINSTALL) $(BTCD_PKG)
+	$(GOINSTALL) $(BTCD_PKG)/cmd/btcctl
 
 # ============
 # INSTALLATION


### PR DESCRIPTION
Actually install btcd when running `make btcd`...