### PR TITLE
lnwallet: within ForceClose, mark the channel as borked, prevent mutations for borked channels

### DIFF
--- a/lnwallet/channel.go
+++ b/lnwallet/channel.go
@@ -3167,7 +3167,8 @@ func (lc *LightningChannel) SignNextCommitment() (lnwire.Sig, []lnwire.Sig, erro
 	if err != nil {
 		return sig, htlcSigs, err
 	}
-	if lc.channelState.AppendRemoteCommitChain(commitDiff); err != nil {
+	err = lc.channelState.AppendRemoteCommitChain(commitDiff)
+	if err != nil {
 		return sig, htlcSigs, err
 	}
 

--- a/lnwallet/channel.go
+++ b/lnwallet/channel.go
@@ -3067,8 +3067,9 @@ func (lc *LightningChannel) SignNextCommitment() (lnwire.Sig, []lnwire.Sig, erro
 	// ensure that we aren't violating any of the constraints the remote
 	// party set up when we initially set up the channel. If we are, then
 	// we'll abort this state transition.
-	err := lc.validateCommitmentSanity(remoteACKedIndex,
-		lc.localUpdateLog.logIndex, true, nil)
+	err := lc.validateCommitmentSanity(
+		remoteACKedIndex, lc.localUpdateLog.logIndex, true, nil,
+	)
 	if err != nil {
 		return sig, htlcSigs, err
 	}
@@ -3076,8 +3077,9 @@ func (lc *LightningChannel) SignNextCommitment() (lnwire.Sig, []lnwire.Sig, erro
 	// Grab the next commitment point for the remote party. This will be
 	// used within fetchCommitmentView to derive all the keys necessary to
 	// construct the commitment state.
-	keyRing := deriveCommitmentKeys(commitPoint, false, lc.localChanCfg,
-		lc.remoteChanCfg)
+	keyRing := deriveCommitmentKeys(
+		commitPoint, false, lc.localChanCfg, lc.remoteChanCfg,
+	)
 
 	// Create a new commitment view which will calculate the evaluated
 	// state of the remote node's new commitment including our latest added
@@ -4017,8 +4019,9 @@ func (lc *LightningChannel) ReceiveNewCommitment(commitSig lnwire.Sig,
 	// Ensure that this new local update from the remote node respects all
 	// the constraints we specified during initial channel setup. If not,
 	// then we'll abort the channel as they've violated our constraints.
-	err := lc.validateCommitmentSanity(lc.remoteUpdateLog.logIndex,
-		localACKedIndex, false, nil)
+	err := lc.validateCommitmentSanity(
+		lc.remoteUpdateLog.logIndex, localACKedIndex, false, nil,
+	)
 	if err != nil {
 		return err
 	}
@@ -4033,8 +4036,9 @@ func (lc *LightningChannel) ReceiveNewCommitment(commitSig lnwire.Sig,
 		return err
 	}
 	commitPoint := input.ComputeCommitmentPoint(commitSecret[:])
-	keyRing := deriveCommitmentKeys(commitPoint, true, lc.localChanCfg,
-		lc.remoteChanCfg)
+	keyRing := deriveCommitmentKeys(
+		commitPoint, true, lc.localChanCfg, lc.remoteChanCfg,
+	)
 
 	// With the current commitment point re-calculated, construct the new
 	// commitment view which includes all the entries (pending or committed)
@@ -4067,9 +4071,10 @@ func (lc *LightningChannel) ReceiveNewCommitment(commitSig lnwire.Sig,
 	localCommitTx := localCommitmentView.txn
 	multiSigScript := lc.signDesc.WitnessScript
 	hashCache := txscript.NewTxSigHashes(localCommitTx)
-	sigHash, err := txscript.CalcWitnessSigHash(multiSigScript, hashCache,
-		txscript.SigHashAll, localCommitTx, 0,
-		int64(lc.channelState.Capacity))
+	sigHash, err := txscript.CalcWitnessSigHash(
+		multiSigScript, hashCache, txscript.SigHashAll,
+		localCommitTx, 0, int64(lc.channelState.Capacity),
+	)
 	if err != nil {
 		// TODO(roasbeef): fetchview has already mutated the HTLCs...
 		//  * need to either roll-back, or make pure
@@ -4442,8 +4447,10 @@ func (lc *LightningChannel) ReceiveRevocation(revMsg *lnwire.RevokeAndAck) (
 	// As we've just completed a new state transition, attempt to see if we
 	// can remove any entries from the update log which have been removed
 	// from the PoV of both commitment chains.
-	compactLogs(lc.localUpdateLog, lc.remoteUpdateLog,
-		localChainTail, remoteChainTail)
+	compactLogs(
+		lc.localUpdateLog, lc.remoteUpdateLog, localChainTail,
+		remoteChainTail,
+	)
 
 	return fwdPkg, addsToForward, settleFailsToForward, nil
 }


### PR DESCRIPTION
In this PR, we ensure that it isn't possible for a state mutation to take place _after_ the force close process has began. Before this commit, it may have been possible for a link to trigger/accept a new state update concurrently while a channel was being updated. We'll now mark the channel as borked in the `ForceClose` method which will:
  * Prevent all channel database commitment mutation calls from going through 
  * Prevent the target link reconnecting 

Along the way, another bug was fixed that would cause an error in the state machine from silently passing through, in the event that a call to `SignNextCommitment` failed at the database update state. 