### PR TITLE
Allow listening on non-localhost if TOR is enabled

### DIFF
--- a/config.go
+++ b/config.go
@@ -962,20 +962,6 @@ func loadConfig() (*config, error) {
 		}
 	}
 
-	// Ensure that we are only listening on localhost if Tor inbound support
-	// is enabled.
-	if cfg.Tor.V2 || cfg.Tor.V3 {
-		for _, addr := range cfg.Listeners {
-			if lncfg.IsLoopback(addr.String()) {
-				continue
-			}
-
-			return nil, errors.New("lnd must *only* be listening " +
-				"on localhost when running with Tor inbound " +
-				"support enabled")
-		}
-	}
-
 	// Ensure that the specified minimum backoff is below or equal to the
 	// maximum backoff.
 	if cfg.MinBackoff > cfg.MaxBackoff {


### PR DESCRIPTION
There is good reasons to allow both TOR and non localhost P2P connection.

* when you care about TOR to be compatible with other TOR nodes.
* when you care about TOR only as a solution for firewall punching