### PR TITLE
[reliable payments] persist htlcswitch pending payments

### DIFF
--- a/htlcswitch/link_test.go
+++ b/htlcswitch/link_test.go
@@ -1118,7 +1118,7 @@ func TestChannelLinkMultiHopUnknownPaymentHash(t *testing.T) {
 	}
 
 	resultChan, err := n.aliceServer.htlcSwitch.GetPaymentResult(
-		pid, newMockDeobfuscator(),
+		pid, htlc.PaymentHash, newMockDeobfuscator(),
 	)
 	if err != nil {
 		t.Fatalf("unable to get payment result: %v", err)
@@ -3898,7 +3898,7 @@ func TestChannelLinkAcceptDuplicatePayment(t *testing.T) {
 	}
 
 	resultChan, err := n.aliceServer.htlcSwitch.GetPaymentResult(
-		pid, newMockDeobfuscator(),
+		pid, htlc.PaymentHash, newMockDeobfuscator(),
 	)
 	if err != nil {
 		t.Fatalf("unable to get payment result: %v", err)

--- a/htlcswitch/link_test.go
+++ b/htlcswitch/link_test.go
@@ -3909,8 +3909,8 @@ func TestChannelLinkAcceptDuplicatePayment(t *testing.T) {
 	err = n.aliceServer.htlcSwitch.SendHTLC(
 		n.firstBobChannelLink.ShortChanID(), pid, htlc,
 	)
-	if err != ErrPaymentIDAlreadyExists {
-		t.Fatalf("ErrPaymentIDAlreadyExists should have been "+
+	if err != ErrDuplicateAdd {
+		t.Fatalf("ErrDuplicateAdd should have been "+
 			"received got: %v", err)
 	}
 

--- a/htlcswitch/mock.go
+++ b/htlcswitch/mock.go
@@ -916,3 +916,58 @@ func (m *mockNotifier) RegisterSpendNtfn(outpoint *wire.OutPoint, _ []byte,
 		Spend: make(chan *chainntnfs.SpendDetail),
 	}, nil
 }
+
+type mockCircuitMap struct {
+	lookup chan *PaymentCircuit
+}
+
+var _ CircuitMap = (*mockCircuitMap)(nil)
+
+func (m *mockCircuitMap) OpenCircuits(...Keystone) error {
+	return nil
+}
+
+func (m *mockCircuitMap) TrimOpenCircuits(chanID lnwire.ShortChannelID,
+	start uint64) error {
+	return nil
+}
+
+func (m *mockCircuitMap) DeleteCircuits(inKeys ...CircuitKey) error {
+	return nil
+}
+
+func (m *mockCircuitMap) CommitCircuits(
+	circuit ...*PaymentCircuit) (*CircuitFwdActions, error) {
+
+	return nil, nil
+}
+
+func (m *mockCircuitMap) CloseCircuit(outKey CircuitKey) (*PaymentCircuit,
+	error) {
+	return nil, nil
+}
+
+func (m *mockCircuitMap) FailCircuit(inKey CircuitKey) (*PaymentCircuit,
+	error) {
+	return nil, nil
+}
+
+func (m *mockCircuitMap) LookupCircuit(inKey CircuitKey) *PaymentCircuit {
+	return <-m.lookup
+}
+
+func (m *mockCircuitMap) LookupOpenCircuit(outKey CircuitKey) *PaymentCircuit {
+	return nil
+}
+
+func (m *mockCircuitMap) LookupByPaymentHash(hash [32]byte) []*PaymentCircuit {
+	return nil
+}
+
+func (m *mockCircuitMap) NumPending() int {
+	return 0
+}
+
+func (m *mockCircuitMap) NumOpen() int {
+	return 0
+}

--- a/htlcswitch/mock.go
+++ b/htlcswitch/mock.go
@@ -163,7 +163,10 @@ func initSwitchWithDB(startingHeight uint32, db *channeldb.DB) (*Switch, error) 
 		}
 	}
 
+	priv, _ := btcec.NewPrivateKey(btcec.S256())
+	pubkey := priv.PubKey()
 	cfg := Config{
+		SelfKey:        pubkey,
 		DB:             db,
 		SwitchPackager: channeldb.NewSwitchPackager(),
 		FwdingLog: &mockForwardingLog{
@@ -390,7 +393,11 @@ func (o *mockDeobfuscator) DecryptError(reason lnwire.OpaqueReason) (*Forwarding
 		return nil, err
 	}
 
+	priv, _ := btcec.NewPrivateKey(btcec.S256())
+	pubkey := priv.PubKey()
+
 	return &ForwardingError{
+		ErrorSource:    pubkey,
 		FailureMessage: failure,
 	}, nil
 }

--- a/htlcswitch/payment_result.go
+++ b/htlcswitch/payment_result.go
@@ -1,14 +1,24 @@
 package htlcswitch
 
 import (
+	"bytes"
+	"encoding/binary"
 	"errors"
 	"io"
+	"sync"
 
+	"github.com/coreos/bbolt"
 	"github.com/lightningnetwork/lnd/channeldb"
 	"github.com/lightningnetwork/lnd/lnwire"
+	"github.com/lightningnetwork/lnd/multimutex"
 )
 
 var (
+
+	// networkResultStoreBucketKey is used for the root level bucket that
+	// stores the network result for each payment ID.
+	networkResultStoreBucketKey = []byte("network-result-store-bucket")
+
 	// ErrPaymentIDNotFound is an error returned if the given paymentID is
 	// not found.
 	ErrPaymentIDNotFound = errors.New("paymentID not found")
@@ -78,4 +88,173 @@ func deserializeNetworkResult(r io.Reader) (*networkResult, error) {
 	}
 
 	return n, nil
+}
+
+// networkResultStore is a persistent store that stores any results of HTLCs in
+// flight on the network. Since payment results are inherently asynchronous, it
+// is used as a common access point for senders of HTLCs, to know when a result
+// is back. The Switch will checkpoint any received result to the store, and
+// the store will keep results and notify the callers about them.
+type networkResultStore struct {
+	db *channeldb.DB
+
+	// results is a map from paymentIDs to channels where subscribers to
+	// payment results will be notified.
+	results    map[uint64][]chan *networkResult
+	resultsMtx sync.Mutex
+
+	// paymentIDMtx is a multimutex used to make sure the database and
+	// result subscribers map is consistent for each payment ID in case of
+	// concurrent callers.
+	paymentIDMtx *multimutex.Mutex
+}
+
+func newNetworkResultStore(db *channeldb.DB) *networkResultStore {
+	return &networkResultStore{
+		db:           db,
+		results:      make(map[uint64][]chan *networkResult),
+		paymentIDMtx: multimutex.NewMutex(),
+	}
+}
+
+// storeResult stores the networkResult for the given paymentID, and
+// notifies any subscribers.
+func (store *networkResultStore) storeResult(paymentID uint64,
+	result *networkResult) error {
+
+	// We get a mutex for this payment ID. This is needed to ensure
+	// consistency between the database state and the subscribers in case
+	// of concurrent calls.
+	store.paymentIDMtx.Lock(paymentID)
+	defer store.paymentIDMtx.Unlock(paymentID)
+
+	// Serialize the payment result.
+	var b bytes.Buffer
+	if err := serializeNetworkResult(&b, result); err != nil {
+		return err
+	}
+
+	var paymentIDBytes [8]byte
+	binary.BigEndian.PutUint64(paymentIDBytes[:], paymentID)
+
+	err := store.db.Batch(func(tx *bbolt.Tx) error {
+		networkResults, err := tx.CreateBucketIfNotExists(
+			networkResultStoreBucketKey,
+		)
+		if err != nil {
+			return err
+		}
+
+		return networkResults.Put(paymentIDBytes[:], b.Bytes())
+	})
+	if err != nil {
+		return err
+	}
+
+	// Now that the result is stored in the database, we can notify any
+	// active subscribers.
+	store.resultsMtx.Lock()
+	for _, res := range store.results[paymentID] {
+		res <- result
+	}
+	delete(store.results, paymentID)
+	store.resultsMtx.Unlock()
+
+	return nil
+}
+
+// subscribeResult is used to get the payment result for the given
+// payment ID. It returns a channel on which the result will be delivered when
+// ready.
+func (store *networkResultStore) subscribeResult(paymentID uint64) (
+	<-chan *networkResult, error) {
+
+	// We get a mutex for this payment ID. This is needed to ensure
+	// consistency between the database state and the subscribers in case
+	// of concurrent calls.
+	store.paymentIDMtx.Lock(paymentID)
+	defer store.paymentIDMtx.Unlock(paymentID)
+
+	var (
+		result     *networkResult
+		resultChan = make(chan *networkResult, 1)
+	)
+
+	err := store.db.View(func(tx *bbolt.Tx) error {
+		var err error
+		result, err = fetchResult(tx, paymentID)
+		switch {
+
+		// Result not yet available, we will notify once a result is
+		// available.
+		case err == ErrPaymentIDNotFound:
+			return nil
+
+		case err != nil:
+			return err
+
+		// The result was found, and will be returned immediately.
+		default:
+			return nil
+		}
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	// If the result was found, we can send it on the result channel
+	// imemdiately.
+	if result != nil {
+		resultChan <- result
+		return resultChan, nil
+	}
+
+	// Otherwise we store the result channel for when the result is
+	// available.
+	store.resultsMtx.Lock()
+	store.results[paymentID] = append(
+		store.results[paymentID], resultChan,
+	)
+	store.resultsMtx.Unlock()
+
+	return resultChan, nil
+}
+
+// getResult attempts to immediately fetch the result for the given pid from
+// the store. If no result is available, ErrPaymentIDNotFound is returned.
+func (store *networkResultStore) getResult(pid uint64) (
+	*networkResult, error) {
+
+	var result *networkResult
+	err := store.db.View(func(tx *bbolt.Tx) error {
+		var err error
+		result, err = fetchResult(tx, pid)
+		return err
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return result, nil
+}
+
+func fetchResult(tx *bbolt.Tx, pid uint64) (*networkResult, error) {
+	var paymentIDBytes [8]byte
+	binary.BigEndian.PutUint64(paymentIDBytes[:], pid)
+
+	networkResults := tx.Bucket(networkResultStoreBucketKey)
+	if networkResults == nil {
+		return nil, ErrPaymentIDNotFound
+	}
+
+	// Check whether a result is already available.
+	resultBytes := networkResults.Get(paymentIDBytes[:])
+	if resultBytes == nil {
+		return nil, ErrPaymentIDNotFound
+	}
+
+	// Decode the result we found.
+	r := bytes.NewReader(resultBytes)
+
+	return deserializeNetworkResult(r)
 }

--- a/htlcswitch/payment_result_test.go
+++ b/htlcswitch/payment_result_test.go
@@ -1,0 +1,90 @@
+package htlcswitch
+
+import (
+	"bytes"
+	"math/rand"
+	"reflect"
+	"testing"
+
+	"github.com/davecgh/go-spew/spew"
+	"github.com/lightningnetwork/lnd/lntypes"
+	"github.com/lightningnetwork/lnd/lnwire"
+)
+
+// TestNetworkResultSerialization checks that NetworkResults are properly
+// (de)serialized.
+func TestNetworkResultSerialization(t *testing.T) {
+	t.Parallel()
+
+	var preimage lntypes.Preimage
+	if _, err := rand.Read(preimage[:]); err != nil {
+		t.Fatalf("unable gen rand preimag: %v", err)
+	}
+
+	var chanID lnwire.ChannelID
+	if _, err := rand.Read(chanID[:]); err != nil {
+		t.Fatalf("unable gen rand chanid: %v", err)
+	}
+
+	var reason [256]byte
+	if _, err := rand.Read(reason[:]); err != nil {
+		t.Fatalf("unable gen rand reason: %v", err)
+	}
+
+	settle := &lnwire.UpdateFulfillHTLC{
+		ChanID:          chanID,
+		ID:              2,
+		PaymentPreimage: preimage,
+	}
+
+	fail := &lnwire.UpdateFailHTLC{
+		ChanID: chanID,
+		ID:     1,
+		Reason: []byte{},
+	}
+
+	fail2 := &lnwire.UpdateFailHTLC{
+		ChanID: chanID,
+		ID:     1,
+		Reason: reason[:],
+	}
+
+	testCases := []*networkResult{
+		{
+			msg: settle,
+		},
+		{
+			msg:          fail,
+			unencrypted:  false,
+			isResolution: false,
+		},
+		{
+			msg:          fail,
+			unencrypted:  false,
+			isResolution: true,
+		},
+		{
+			msg:          fail2,
+			unencrypted:  true,
+			isResolution: false,
+		},
+	}
+
+	for _, p := range testCases {
+		var buf bytes.Buffer
+		if err := serializeNetworkResult(&buf, p); err != nil {
+			t.Fatalf("serialize failed: %v", err)
+		}
+
+		r := bytes.NewReader(buf.Bytes())
+		p1, err := deserializeNetworkResult(r)
+		if err != nil {
+			t.Fatalf("unable to deserizlize: %v", err)
+		}
+
+		if !reflect.DeepEqual(p, p1) {
+			t.Fatalf("not equal. %v vs %v", spew.Sdump(p),
+				spew.Sdump(p1))
+		}
+	}
+}

--- a/htlcswitch/payment_result_test.go
+++ b/htlcswitch/payment_result_test.go
@@ -2,11 +2,14 @@ package htlcswitch
 
 import (
 	"bytes"
+	"io/ioutil"
 	"math/rand"
 	"reflect"
 	"testing"
+	"time"
 
 	"github.com/davecgh/go-spew/spew"
+	"github.com/lightningnetwork/lnd/channeldb"
 	"github.com/lightningnetwork/lnd/lntypes"
 	"github.com/lightningnetwork/lnd/lnwire"
 )
@@ -85,6 +88,105 @@ func TestNetworkResultSerialization(t *testing.T) {
 		if !reflect.DeepEqual(p, p1) {
 			t.Fatalf("not equal. %v vs %v", spew.Sdump(p),
 				spew.Sdump(p1))
+		}
+	}
+}
+
+// TestNetworkResultStore tests that the networkResult store behaves as
+// expected, and that we can store, get and subscribe to results.
+func TestNetworkResultStore(t *testing.T) {
+	t.Parallel()
+
+	const numResults = 4
+
+	tempDir, err := ioutil.TempDir("", "testdb")
+	db, err := channeldb.Open(tempDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	store := newNetworkResultStore(db)
+
+	var results []*networkResult
+	for i := 0; i < numResults; i++ {
+		n := &networkResult{
+			msg:          &lnwire.UpdateAddHTLC{},
+			unencrypted:  true,
+			isResolution: true,
+		}
+		results = append(results, n)
+	}
+
+	// Subscribe to 2 of them.
+	var subs []<-chan *networkResult
+	for i := uint64(0); i < 2; i++ {
+		sub, err := store.subscribeResult(i)
+		if err != nil {
+			t.Fatalf("unable to subscribe: %v", err)
+		}
+		subs = append(subs, sub)
+	}
+
+	// Store three of them.
+	for i := uint64(0); i < 3; i++ {
+		err := store.storeResult(i, results[i])
+		if err != nil {
+			t.Fatalf("unable to store result: %v", err)
+		}
+	}
+
+	// The two subscribers should be notified.
+	for _, sub := range subs {
+		select {
+		case <-sub:
+		case <-time.After(1 * time.Second):
+			t.Fatalf("no result received")
+		}
+	}
+
+	// Let the third one subscribe now. THe result should be received
+	// immediately.
+	sub, err := store.subscribeResult(2)
+	if err != nil {
+		t.Fatalf("unable to subscribe: %v", err)
+	}
+	select {
+	case <-sub:
+	case <-time.After(1 * time.Second):
+		t.Fatalf("no result received")
+	}
+
+	// Try fetching the result directly for the non-stored one. This should
+	// fail.
+	_, err = store.getResult(3)
+	if err != ErrPaymentIDNotFound {
+		t.Fatalf("expected ErrPaymentIDNotFound, got %v", err)
+	}
+
+	// Add the result and try again.
+	err = store.storeResult(3, results[3])
+	if err != nil {
+		t.Fatalf("unable to store result: %v", err)
+	}
+
+	_, err = store.getResult(3)
+	if err != nil {
+		t.Fatalf("unable to get result: %v", err)
+	}
+
+	// Since we don't delete results from the store (yet), make sure we
+	// will get subscriptions for all of them.
+	// TODO(halseth): check deletion when we have reliable handoff.
+	for i := uint64(0); i < numResults; i++ {
+		sub, err := store.subscribeResult(i)
+		if err != nil {
+			t.Fatalf("unable to subscribe: %v", err)
+		}
+
+		select {
+		case <-sub:
+		case <-time.After(1 * time.Second):
+			t.Fatalf("no result received")
 		}
 	}
 }

--- a/htlcswitch/switch.go
+++ b/htlcswitch/switch.go
@@ -342,7 +342,7 @@ func (s *Switch) ProcessContractResolution(msg contractcourt.ResolutionMsg) erro
 // result is received on the channel, the HTLC is guaranteed to no longer be in
 // flight. The switch shutting down is signaled by closing the channel. If the
 // paymentID is unknown, ErrPaymentIDNotFound will be returned.
-func (s *Switch) GetPaymentResult(paymentID uint64,
+func (s *Switch) GetPaymentResult(paymentID uint64, paymentHash lntypes.Hash,
 	deobfuscator ErrorDecrypter) (<-chan *PaymentResult, error) {
 
 	s.pendingMutex.Lock()
@@ -375,7 +375,7 @@ func (s *Switch) GetPaymentResult(paymentID uint64,
 
 		// Extract the result and pass it to the result channel.
 		result, err := s.extractResult(
-			deobfuscator, n, paymentID, payment.paymentHash,
+			deobfuscator, n, paymentID, paymentHash,
 		)
 		if err != nil {
 			e := fmt.Errorf("Unable to extract result: %v", err)

--- a/htlcswitch/switch_test.go
+++ b/htlcswitch/switch_test.go
@@ -1743,7 +1743,7 @@ func TestSwitchSendPayment(t *testing.T) {
 	// First check that the switch will correctly respond that this payment
 	// ID is unknown.
 	_, err = s.GetPaymentResult(
-		paymentID, newMockDeobfuscator(),
+		paymentID, rhash, newMockDeobfuscator(),
 	)
 	if err != ErrPaymentIDNotFound {
 		t.Fatalf("expected ErrPaymentIDNotFound, got %v", err)
@@ -1761,7 +1761,7 @@ func TestSwitchSendPayment(t *testing.T) {
 		}
 
 		resultChan, err := s.GetPaymentResult(
-			paymentID, newMockDeobfuscator(),
+			paymentID, rhash, newMockDeobfuscator(),
 		)
 		if err != nil {
 			errChan <- err

--- a/htlcswitch/test_utils.go
+++ b/htlcswitch/test_utils.go
@@ -801,7 +801,7 @@ func preparePayment(sendingPeer, receivingPeer lnpeer.Peer,
 			return err
 		}
 		resultChan, err := sender.htlcSwitch.GetPaymentResult(
-			pid, newMockDeobfuscator(),
+			pid, hash, newMockDeobfuscator(),
 		)
 		if err != nil {
 			return err
@@ -1289,7 +1289,7 @@ func (n *twoHopNetwork) makeHoldPayment(sendingPeer, receivingPeer lnpeer.Peer,
 		}
 
 		resultChan, err := sender.htlcSwitch.GetPaymentResult(
-			pid, newMockDeobfuscator(),
+			pid, rhash, newMockDeobfuscator(),
 		)
 		if err != nil {
 			paymentErr <- err

--- a/routing/mock_test.go
+++ b/routing/mock_test.go
@@ -52,7 +52,8 @@ func (m *mockPaymentAttemptDispatcher) SendHTLC(firstHop lnwire.ShortChannelID,
 }
 
 func (m *mockPaymentAttemptDispatcher) GetPaymentResult(paymentID uint64,
-	_ htlcswitch.ErrorDecrypter) (<-chan *htlcswitch.PaymentResult, error) {
+	_ lntypes.Hash, _ htlcswitch.ErrorDecrypter) (
+	<-chan *htlcswitch.PaymentResult, error) {
 
 	c := make(chan *htlcswitch.PaymentResult, 1)
 	res, ok := m.results[paymentID]
@@ -139,8 +140,8 @@ func (m *mockPayer) SendHTLC(_ lnwire.ShortChannelID,
 
 }
 
-func (m *mockPayer) GetPaymentResult(paymentID uint64, _ htlcswitch.ErrorDecrypter) (
-	<-chan *htlcswitch.PaymentResult, error) {
+func (m *mockPayer) GetPaymentResult(paymentID uint64, _ lntypes.Hash,
+	_ htlcswitch.ErrorDecrypter) (<-chan *htlcswitch.PaymentResult, error) {
 
 	select {
 	case res := <-m.paymentResult:

--- a/routing/payment_lifecycle.go
+++ b/routing/payment_lifecycle.go
@@ -95,7 +95,7 @@ func (p *paymentLifecycle) resumePayment() ([32]byte, *route.Route, error) {
 		// Now ask the switch to return the result of the payment when
 		// available.
 		resultChan, err := p.router.cfg.Payer.GetPaymentResult(
-			p.attempt.PaymentID, errorDecryptor,
+			p.attempt.PaymentID, p.payment.PaymentHash, errorDecryptor,
 		)
 		switch {
 

--- a/routing/router.go
+++ b/routing/router.go
@@ -138,7 +138,8 @@ type PaymentAttemptDispatcher interface {
 	// HTLC is guaranteed to no longer be in flight. The switch shutting
 	// down is signaled by closing the channel. If the paymentID is
 	// unknown, ErrPaymentIDNotFound will be returned.
-	GetPaymentResult(paymentID uint64, deobfuscator htlcswitch.ErrorDecrypter) (
+	GetPaymentResult(paymentID uint64, paymentHash lntypes.Hash,
+		deobfuscator htlcswitch.ErrorDecrypter) (
 		<-chan *htlcswitch.PaymentResult, error)
 }
 


### PR DESCRIPTION
This PR is a follow-up from #2761. It adds a persistent `pendingPaymentStore` to the `Switch`, needed to store payment results when the `router` is not available to handle them.

### Problem
After a restart, there is no connection between an HTLC in flight on the network and the `router` payment flow that initially sent the HTLC. The `router` will eventually call `GetPaymentResult` to retrieve the result of the HTLC, but we have no guarantees this will be done before the result is received. This can lead to the result getting dropped, which is not ideal.

### Solution
We introduce a `pendingPayementStore` which has two primary functions:
1. It stores `PaymentResult`s when they are received, regardless of whether there are any subscribers (the `ChannelRouter`) to the corresponding HTLC. This ensures that the `router` gets handed the result when it calls `GetPaymentResult`.
2. It stores the information necessary to identify and handle a result that comes back after a restart. This is the `chanID` and `paymentID`, used to identify the payment in the circuit map.
3. On restarts it syncs the pending payments with the `CircuitMap`. We use the circuit map as the source of truth whether a payment is in flight on the network. Syncing it at startup, before we start handling HTLCs, is necessary to be able to decide whether an HTLC was successfully forwarded.

Builds on #2761 
Replaces #2265 