### PR TITLE
channeldb: convert all Update calls to use Batch

### DIFF
--- a/channeldb/invoices.go
+++ b/channeldb/invoices.go
@@ -242,7 +242,9 @@ func (d *DB) AddInvoice(newInvoice *Invoice, paymentHash lntypes.Hash) (
 	}
 
 	var invoiceAddIndex uint64
-	err := d.Update(func(tx *bbolt.Tx) error {
+	err := d.Batch(func(tx *bbolt.Tx) error {
+		invoiceAddIndex = 0
+
 		invoices, err := tx.CreateBucketIfNotExists(invoiceBucket)
 		if err != nil {
 			return err
@@ -635,7 +637,9 @@ func (d *DB) AcceptOrSettleInvoice(paymentHash [32]byte,
 	amtPaid lnwire.MilliSatoshi) (*Invoice, error) {
 
 	var settledInvoice *Invoice
-	err := d.Update(func(tx *bbolt.Tx) error {
+	err := d.Batch(func(tx *bbolt.Tx) error {
+		settledInvoice = nil
+
 		invoices, err := tx.CreateBucketIfNotExists(invoiceBucket)
 		if err != nil {
 			return err
@@ -714,7 +718,9 @@ func (d *DB) SettleHoldInvoice(preimage lntypes.Preimage) (*Invoice, error) {
 // payment hash.
 func (d *DB) CancelInvoice(paymentHash lntypes.Hash) (*Invoice, error) {
 	var canceledInvoice *Invoice
-	err := d.Update(func(tx *bbolt.Tx) error {
+	err := d.Batch(func(tx *bbolt.Tx) error {
+		canceledInvoice = nil
+
 		invoices, err := tx.CreateBucketIfNotExists(invoiceBucket)
 		if err != nil {
 			return err


### PR DESCRIPTION
In this commit, we convert all the `Update` calls which are serial, to
use `Batch` calls which are optimistically batched together for
concurrent writers. This should increase performance slightly during the
initial graph sync, and also updates at tip as we can coalesce more of
these individual transactions into a single transaction.

