### PR TITLE
watchtower/wtserver: add DeleteSession request

### DIFF
--- a/watchtower/wtserver/create_session.go
+++ b/watchtower/wtserver/create_session.go
@@ -1,0 +1,136 @@
+package wtserver
+
+import (
+	"github.com/btcsuite/btcd/txscript"
+	"github.com/lightningnetwork/lnd/watchtower/blob"
+	"github.com/lightningnetwork/lnd/watchtower/wtdb"
+	"github.com/lightningnetwork/lnd/watchtower/wtpolicy"
+	"github.com/lightningnetwork/lnd/watchtower/wtwire"
+)
+
+// handleCreateSession processes a CreateSession message from the peer, and returns
+// a CreateSessionReply in response. This method will only succeed if no existing
+// session info is known about the session id. If an existing session is found,
+// the reward address is returned in case the client lost our reply.
+func (s *Server) handleCreateSession(peer Peer, id *wtdb.SessionID,
+	req *wtwire.CreateSession) error {
+
+	// TODO(conner): validate accept against policy
+
+	// Query the db for session info belonging to the client's session id.
+	existingInfo, err := s.cfg.DB.GetSessionInfo(id)
+	switch {
+
+	// We already have a session corresponding to this session id, return an
+	// error signaling that it already exists in our database. We return the
+	// reward address to the client in case they were not able to process
+	// our reply earlier.
+	case err == nil:
+		log.Debugf("Already have session for %s", id)
+		return s.replyCreateSession(
+			peer, id, wtwire.CreateSessionCodeAlreadyExists,
+			existingInfo.RewardAddress,
+		)
+
+	// Some other database error occurred, return a temporary failure.
+	case err != wtdb.ErrSessionNotFound:
+		log.Errorf("unable to load session info for %s", id)
+		return s.replyCreateSession(
+			peer, id, wtwire.CodeTemporaryFailure, nil,
+		)
+	}
+
+	// Now that we've established that this session does not exist in the
+	// database, retrieve the sweep address that will be given to the
+	// client. This address is to be included by the client when signing
+	// sweep transactions destined for this tower, if its negotiated output
+	// is not dust.
+	rewardAddress, err := s.cfg.NewAddress()
+	if err != nil {
+		log.Errorf("unable to generate reward addr for %s", id)
+		return s.replyCreateSession(
+			peer, id, wtwire.CodeTemporaryFailure, nil,
+		)
+	}
+
+	// Construct the pkscript the client should pay to when signing justice
+	// transactions for this session.
+	rewardScript, err := txscript.PayToAddrScript(rewardAddress)
+	if err != nil {
+		log.Errorf("unable to generate reward script for %s", id)
+		return s.replyCreateSession(
+			peer, id, wtwire.CodeTemporaryFailure, nil,
+		)
+	}
+
+	// Ensure that the requested blob type is supported by our tower.
+	if !blob.IsSupportedType(req.BlobType) {
+		log.Debugf("Rejecting CreateSession from %s, unsupported blob "+
+			"type %s", id, req.BlobType)
+		return s.replyCreateSession(
+			peer, id, wtwire.CreateSessionCodeRejectBlobType, nil,
+		)
+	}
+
+	// TODO(conner): create invoice for upfront payment
+
+	// Assemble the session info using the agreed upon parameters, reward
+	// address, and session id.
+	info := wtdb.SessionInfo{
+		ID: *id,
+		Policy: wtpolicy.Policy{
+			BlobType:     req.BlobType,
+			MaxUpdates:   req.MaxUpdates,
+			RewardBase:   req.RewardBase,
+			RewardRate:   req.RewardRate,
+			SweepFeeRate: req.SweepFeeRate,
+		},
+		RewardAddress: rewardScript,
+	}
+
+	// Insert the session info into the watchtower's database. If
+	// successful, the session will now be ready for use.
+	err = s.cfg.DB.InsertSessionInfo(&info)
+	if err != nil {
+		log.Errorf("unable to create session for %s", id)
+		return s.replyCreateSession(
+			peer, id, wtwire.CodeTemporaryFailure, nil,
+		)
+	}
+
+	log.Infof("Accepted session for %s", id)
+
+	return s.replyCreateSession(
+		peer, id, wtwire.CodeOK, rewardScript,
+	)
+}
+
+// replyCreateSession sends a response to a CreateSession from a client. If the
+// status code in the reply is OK, the error from the write will be bubbled up.
+// Otherwise, this method returns a connection error to ensure we don't continue
+// communication with the client.
+func (s *Server) replyCreateSession(peer Peer, id *wtdb.SessionID,
+	code wtwire.ErrorCode, data []byte) error {
+
+	msg := &wtwire.CreateSessionReply{
+		Code: code,
+		Data: data,
+	}
+
+	err := s.sendMessage(peer, msg)
+	if err != nil {
+		log.Errorf("unable to send CreateSessionReply to %s", id)
+	}
+
+	// Return the write error if the request succeeded.
+	if code == wtwire.CodeOK {
+		return err
+	}
+
+	// Otherwise the request failed, return a connection failure to
+	// disconnect the client.
+	return &connFailure{
+		ID:   *id,
+		Code: uint16(code),
+	}
+}

--- a/watchtower/wtserver/delete_session.go
+++ b/watchtower/wtserver/delete_session.go
@@ -1,0 +1,57 @@
+package wtserver
+
+import (
+	"github.com/lightningnetwork/lnd/watchtower/wtdb"
+	"github.com/lightningnetwork/lnd/watchtower/wtwire"
+)
+
+// handleDeleteSession processes a DeleteSession request for a client with given
+// SessionID. The id is assumed to have been previously authenticated by the
+// brontide connection.
+func (s *Server) handleDeleteSession(peer Peer, id *wtdb.SessionID) error {
+	var failCode wtwire.DeleteSessionCode
+
+	// Delete all session data associated with id.
+	err := s.cfg.DB.DeleteSession(*id)
+	switch {
+	case err == nil:
+		failCode = wtwire.CodeOK
+
+		log.Debugf("Session %s deleted", id)
+
+	case err == wtdb.ErrSessionNotFound:
+		failCode = wtwire.DeleteSessionCodeNotFound
+
+	default:
+		failCode = wtwire.CodeTemporaryFailure
+	}
+
+	return s.replyDeleteSession(peer, id, failCode)
+}
+
+// replyDeleteSession sends a DeleteSessionReply back to the peer containing the
+// error code resulting from processes a DeleteSession request.
+func (s *Server) replyDeleteSession(peer Peer, id *wtdb.SessionID,
+	code wtwire.DeleteSessionCode) error {
+
+	msg := &wtwire.DeleteSessionReply{
+		Code: code,
+	}
+
+	err := s.sendMessage(peer, msg)
+	if err != nil {
+		log.Errorf("Unable to send DeleteSessionReply to %s", id)
+	}
+
+	// Return the write error if the request succeeded.
+	if code == wtwire.CodeOK {
+		return err
+	}
+
+	// Otherwise the request failed, return a connection failure to
+	// disconnect the client.
+	return &connFailure{
+		ID:   *id,
+		Code: uint16(code),
+	}
+}

--- a/watchtower/wtserver/interface.go
+++ b/watchtower/wtserver/interface.go
@@ -63,4 +63,8 @@ type DB interface {
 	// validates the update against the current SessionInfo stored under the
 	// update's session id..
 	InsertStateUpdate(*wtdb.SessionStateUpdate) (uint16, error)
+
+	// DeleteSession removes all data associated with a particular session
+	// id from the tower's database.
+	DeleteSession(wtdb.SessionID) error
 }

--- a/watchtower/wtserver/server.go
+++ b/watchtower/wtserver/server.go
@@ -11,12 +11,9 @@ import (
 	"github.com/btcsuite/btcd/btcec"
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcd/connmgr"
-	"github.com/btcsuite/btcd/txscript"
 	"github.com/btcsuite/btcutil"
 	"github.com/lightningnetwork/lnd/lnwire"
-	"github.com/lightningnetwork/lnd/watchtower/blob"
 	"github.com/lightningnetwork/lnd/watchtower/wtdb"
-	"github.com/lightningnetwork/lnd/watchtower/wtpolicy"
 	"github.com/lightningnetwork/lnd/watchtower/wtwire"
 )
 
@@ -24,6 +21,10 @@ var (
 	// ErrPeerAlreadyConnected signals that a peer with the same session id
 	// is already active within the server.
 	ErrPeerAlreadyConnected = errors.New("peer already connected")
+
+	// ErrServerExiting signals that a request could not be processed
+	// because the server has been requested to shut down.
+	ErrServerExiting = errors.New("server shutting down")
 )
 
 // Config abstracts the primary components and dependencies of the server.
@@ -242,241 +243,33 @@ func (s *Server) handleClient(peer Peer) {
 		return
 	}
 
-	// stateUpdateOnlyMode will become true if the client's first message is
-	// a StateUpdate. If instead, it is a CreateSession, this method will exit
-	// immediately after replying. We track this to ensure that the client
-	// can't send a CreateSession after having already sent a StateUpdate.
-	var stateUpdateOnlyMode bool
-	for {
-		select {
-		case <-s.quit:
-			return
-		default:
-		}
+	nextMsg, err := s.readMessage(peer)
+	if err != nil {
+		log.Errorf("Unable to read watchtower msg from %s: %v",
+			id, err)
+		return
+	}
 
-		nextMsg, err := s.readMessage(peer)
+	switch msg := nextMsg.(type) {
+	case *wtwire.CreateSession:
+		// Attempt to open a new session for this client.
+		err = s.handleCreateSession(peer, &id, msg)
 		if err != nil {
-			log.Errorf("Unable to read watchtower msg from %x: %v",
-				id[:], err)
-			return
+			log.Errorf("Unable to handle CreateSession "+
+				"from %s: %v", id, err)
 		}
 
-		// Process the request according to the message's type.
-		switch msg := nextMsg.(type) {
-
-		// A CreateSession indicates a request to establish a new session
-		// with our watchtower.
-		case *wtwire.CreateSession:
-			// Ensure CreateSession can only be sent as the first
-			// message.
-			if stateUpdateOnlyMode {
-				log.Errorf("client %x sent CreateSession after "+
-					"StateUpdate", id)
-				return
-			}
-
-			// Attempt to open a new session for this client.
-			err := s.handleCreateSession(peer, &id, msg)
-			if err != nil {
-				log.Errorf("Unable to handle CreateSession "+
-					"from %s: %v", id, err)
-			}
-
-			// Exit after replying to CreateSession.
-			return
-
-		// A StateUpdate indicates an existing client attempting to
-		// back-up a revoked commitment state.
-		case *wtwire.StateUpdate:
-			// Try to accept the state update from the client.
-			err := s.handleStateUpdate(peer, &id, msg)
-			if err != nil {
-				log.Errorf("unable to handle StateUpdate "+
-					"from %s: %v", id, err)
-				return
-			}
-
-			// If the client signals that this is last StateUpdate
-			// message, we can disconnect the client.
-			if msg.IsComplete == 1 {
-				return
-			}
-
-			// The client has signaled that more StateUpdates are
-			// yet to come. Enter state-update-only mode to disallow
-			// future sends of CreateSession messages.
-			stateUpdateOnlyMode = true
-
-		default:
-			log.Errorf("received unsupported message type: %T "+
-				"from %s", nextMsg, id)
-			return
+	case *wtwire.StateUpdate:
+		err = s.handleStateUpdates(peer, &id, msg)
+		if err != nil {
+			log.Errorf("Unable to handle StateUpdate "+
+				"from %s: %v", id, err)
 		}
-	}
-}
-
-// handleCreateSession processes a CreateSession message from the peer, and returns
-// a CreateSessionReply in response. This method will only succeed if no existing
-// session info is known about the session id. If an existing session is found,
-// the reward address is returned in case the client lost our reply.
-func (s *Server) handleCreateSession(peer Peer, id *wtdb.SessionID,
-	req *wtwire.CreateSession) error {
-
-	// TODO(conner): validate accept against policy
-
-	// Query the db for session info belonging to the client's session id.
-	existingInfo, err := s.cfg.DB.GetSessionInfo(id)
-	switch {
-
-	// We already have a session corresponding to this session id, return an
-	// error signaling that it already exists in our database. We return the
-	// reward address to the client in case they were not able to process
-	// our reply earlier.
-	case err == nil:
-		log.Debugf("Already have session for %s", id)
-		return s.replyCreateSession(
-			peer, id, wtwire.CreateSessionCodeAlreadyExists,
-			existingInfo.RewardAddress,
-		)
-
-	// Some other database error occurred, return a temporary failure.
-	case err != wtdb.ErrSessionNotFound:
-		log.Errorf("unable to load session info for %s", id)
-		return s.replyCreateSession(
-			peer, id, wtwire.CodeTemporaryFailure, nil,
-		)
-	}
-
-	// Now that we've established that this session does not exist in the
-	// database, retrieve the sweep address that will be given to the
-	// client. This address is to be included by the client when signing
-	// sweep transactions destined for this tower, if its negotiated output
-	// is not dust.
-	rewardAddress, err := s.cfg.NewAddress()
-	if err != nil {
-		log.Errorf("unable to generate reward addr for %s", id)
-		return s.replyCreateSession(
-			peer, id, wtwire.CodeTemporaryFailure, nil,
-		)
-	}
-
-	// Construct the pkscript the client should pay to when signing justice
-	// transactions for this session.
-	rewardScript, err := txscript.PayToAddrScript(rewardAddress)
-	if err != nil {
-		log.Errorf("unable to generate reward script for %s", id)
-		return s.replyCreateSession(
-			peer, id, wtwire.CodeTemporaryFailure, nil,
-		)
-	}
-
-	// Ensure that the requested blob type is supported by our tower.
-	if !blob.IsSupportedType(req.BlobType) {
-		log.Debugf("Rejecting CreateSession from %s, unsupported blob "+
-			"type %s", id, req.BlobType)
-		return s.replyCreateSession(
-			peer, id, wtwire.CreateSessionCodeRejectBlobType, nil,
-		)
-	}
-
-	// TODO(conner): create invoice for upfront payment
-
-	// Assemble the session info using the agreed upon parameters, reward
-	// address, and session id.
-	info := wtdb.SessionInfo{
-		ID: *id,
-		Policy: wtpolicy.Policy{
-			BlobType:     req.BlobType,
-			MaxUpdates:   req.MaxUpdates,
-			RewardBase:   req.RewardBase,
-			RewardRate:   req.RewardRate,
-			SweepFeeRate: req.SweepFeeRate,
-		},
-		RewardAddress: rewardScript,
-	}
-
-	// Insert the session info into the watchtower's database. If
-	// successful, the session will now be ready for use.
-	err = s.cfg.DB.InsertSessionInfo(&info)
-	if err != nil {
-		log.Errorf("unable to create session for %s", id)
-		return s.replyCreateSession(
-			peer, id, wtwire.CodeTemporaryFailure, nil,
-		)
-	}
-
-	log.Infof("Accepted session for %s", id)
-
-	return s.replyCreateSession(
-		peer, id, wtwire.CodeOK, rewardScript,
-	)
-}
-
-// handleStateUpdate processes a StateUpdate message request from a client. An
-// attempt will be made to insert the update into the db, where it is validated
-// against the client's session. The possible errors are then mapped back to
-// StateUpdateCodes specified by the watchtower wire protocol, and sent back
-// using a StateUpdateReply message.
-func (s *Server) handleStateUpdate(peer Peer, id *wtdb.SessionID,
-	update *wtwire.StateUpdate) error {
-
-	var (
-		lastApplied uint16
-		failCode    wtwire.ErrorCode
-		err         error
-	)
-
-	sessionUpdate := wtdb.SessionStateUpdate{
-		ID:            *id,
-		Hint:          update.Hint,
-		SeqNum:        update.SeqNum,
-		LastApplied:   update.LastApplied,
-		EncryptedBlob: update.EncryptedBlob,
-	}
-
-	lastApplied, err = s.cfg.DB.InsertStateUpdate(&sessionUpdate)
-	switch {
-	case err == nil:
-		log.Debugf("State update %d accepted for %s",
-			update.SeqNum, id)
-
-		failCode = wtwire.CodeOK
-
-	// Return a permanent failure if a client tries to send an update for
-	// which we have no session.
-	case err == wtdb.ErrSessionNotFound:
-		failCode = wtwire.CodePermanentFailure
-
-	case err == wtdb.ErrSeqNumAlreadyApplied:
-		failCode = wtwire.CodePermanentFailure
-
-		// TODO(conner): remove session state for protocol
-		// violation. Could also double as clean up method for
-		// session-related state.
-
-	case err == wtdb.ErrLastAppliedReversion:
-		failCode = wtwire.StateUpdateCodeClientBehind
-
-	case err == wtdb.ErrSessionConsumed:
-		failCode = wtwire.StateUpdateCodeMaxUpdatesExceeded
-
-	case err == wtdb.ErrUpdateOutOfOrder:
-		failCode = wtwire.StateUpdateCodeSeqNumOutOfOrder
 
 	default:
-		failCode = wtwire.CodeTemporaryFailure
+		log.Errorf("Received unsupported message type: %T "+
+			"from %s", nextMsg, id)
 	}
-
-	if s.cfg.NoAckUpdates {
-		return &connFailure{
-			ID:   *id,
-			Code: uint16(failCode),
-		}
-	}
-
-	return s.replyStateUpdate(
-		peer, id, failCode, lastApplied,
-	)
 }
 
 // connFailure is a default error used when a request failed with a non-zero
@@ -491,66 +284,6 @@ func (f *connFailure) Error() string {
 	return fmt.Sprintf("connection with %s failed with code=%v",
 		f.ID, f.Code,
 	)
-}
-
-// replyCreateSession sends a response to a CreateSession from a client. If the
-// status code in the reply is OK, the error from the write will be bubbled up.
-// Otherwise, this method returns a connection error to ensure we don't continue
-// communication with the client.
-func (s *Server) replyCreateSession(peer Peer, id *wtdb.SessionID,
-	code wtwire.ErrorCode, data []byte) error {
-
-	msg := &wtwire.CreateSessionReply{
-		Code: code,
-		Data: data,
-	}
-
-	err := s.sendMessage(peer, msg)
-	if err != nil {
-		log.Errorf("unable to send CreateSessionReply to %s", id)
-	}
-
-	// Return the write error if the request succeeded.
-	if code == wtwire.CodeOK {
-		return err
-	}
-
-	// Otherwise the request failed, return a connection failure to
-	// disconnect the client.
-	return &connFailure{
-		ID:   *id,
-		Code: uint16(code),
-	}
-}
-
-// replyStateUpdate sends a response to a StateUpdate from a client. If the
-// status code in the reply is OK, the error from the write will be bubbled up.
-// Otherwise, this method returns a connection error to ensure we don't continue
-// communication with the client.
-func (s *Server) replyStateUpdate(peer Peer, id *wtdb.SessionID,
-	code wtwire.StateUpdateCode, lastApplied uint16) error {
-
-	msg := &wtwire.StateUpdateReply{
-		Code:        code,
-		LastApplied: lastApplied,
-	}
-
-	err := s.sendMessage(peer, msg)
-	if err != nil {
-		log.Errorf("unable to send StateUpdateReply to %s", id)
-	}
-
-	// Return the write error if the request succeeded.
-	if code == wtwire.CodeOK {
-		return err
-	}
-
-	// Otherwise the request failed, return a connection failure to
-	// disconnect the client.
-	return &connFailure{
-		ID:   *id,
-		Code: uint16(code),
-	}
 }
 
 // readMessage receives and parses the next message from the given Peer. An

--- a/watchtower/wtserver/server.go
+++ b/watchtower/wtserver/server.go
@@ -259,6 +259,13 @@ func (s *Server) handleClient(peer Peer) {
 				"from %s: %v", id, err)
 		}
 
+	case *wtwire.DeleteSession:
+		err = s.handleDeleteSession(peer, &id)
+		if err != nil {
+			log.Errorf("Unable to handle DeleteSession "+
+				"from %s: %v", id, err)
+		}
+
 	case *wtwire.StateUpdate:
 		err = s.handleStateUpdates(peer, &id, msg)
 		if err != nil {

--- a/watchtower/wtserver/state_update.go
+++ b/watchtower/wtserver/state_update.go
@@ -1,0 +1,157 @@
+package wtserver
+
+import (
+	"fmt"
+
+	"github.com/lightningnetwork/lnd/watchtower/wtdb"
+	"github.com/lightningnetwork/lnd/watchtower/wtwire"
+)
+
+// handleStateUpdates processes a stream of StateUpdate requests from the
+// client. The provided update should be the first such update read, subsequent
+// updates will be consumed if the peer does not signal IsComplete on a
+// particular update.
+func (s *Server) handleStateUpdates(peer Peer, id *wtdb.SessionID,
+	update *wtwire.StateUpdate) error {
+
+	// Set the current update to the first update read off the wire.
+	// Additional updates will be read if this value is set to nil after
+	// processing the first.
+	var curUpdate = update
+	for {
+		// If this is not the first update, read the next state update
+		// from the peer.
+		if curUpdate == nil {
+			nextMsg, err := s.readMessage(peer)
+			if err != nil {
+				return err
+			}
+
+			var ok bool
+			curUpdate, ok = nextMsg.(*wtwire.StateUpdate)
+			if !ok {
+				return fmt.Errorf("client sent %T after "+
+					"StateUpdate", nextMsg)
+			}
+		}
+
+		// Try to accept the state update from the client.
+		err := s.handleStateUpdate(peer, id, curUpdate)
+		if err != nil {
+			return err
+		}
+
+		// If the client signals that this is last StateUpdate
+		// message, we can disconnect the client.
+		if curUpdate.IsComplete == 1 {
+			return nil
+		}
+
+		// Reset the current update to read subsequent updates in the
+		// stream.
+		curUpdate = nil
+
+		select {
+		case <-s.quit:
+			return ErrServerExiting
+		default:
+		}
+	}
+}
+
+// handleStateUpdate processes a StateUpdate message request from a client. An
+// attempt will be made to insert the update into the db, where it is validated
+// against the client's session. The possible errors are then mapped back to
+// StateUpdateCodes specified by the watchtower wire protocol, and sent back
+// using a StateUpdateReply message.
+func (s *Server) handleStateUpdate(peer Peer, id *wtdb.SessionID,
+	update *wtwire.StateUpdate) error {
+
+	var (
+		lastApplied uint16
+		failCode    wtwire.ErrorCode
+		err         error
+	)
+
+	sessionUpdate := wtdb.SessionStateUpdate{
+		ID:            *id,
+		Hint:          update.Hint,
+		SeqNum:        update.SeqNum,
+		LastApplied:   update.LastApplied,
+		EncryptedBlob: update.EncryptedBlob,
+	}
+
+	lastApplied, err = s.cfg.DB.InsertStateUpdate(&sessionUpdate)
+	switch {
+	case err == nil:
+		log.Debugf("State update %d accepted for %s",
+			update.SeqNum, id)
+
+		failCode = wtwire.CodeOK
+
+	// Return a permanent failure if a client tries to send an update for
+	// which we have no session.
+	case err == wtdb.ErrSessionNotFound:
+		failCode = wtwire.CodePermanentFailure
+
+	case err == wtdb.ErrSeqNumAlreadyApplied:
+		failCode = wtwire.CodePermanentFailure
+
+		// TODO(conner): remove session state for protocol
+		// violation. Could also double as clean up method for
+		// session-related state.
+
+	case err == wtdb.ErrLastAppliedReversion:
+		failCode = wtwire.StateUpdateCodeClientBehind
+
+	case err == wtdb.ErrSessionConsumed:
+		failCode = wtwire.StateUpdateCodeMaxUpdatesExceeded
+
+	case err == wtdb.ErrUpdateOutOfOrder:
+		failCode = wtwire.StateUpdateCodeSeqNumOutOfOrder
+
+	default:
+		failCode = wtwire.CodeTemporaryFailure
+	}
+
+	if s.cfg.NoAckUpdates {
+		return &connFailure{
+			ID:   *id,
+			Code: uint16(failCode),
+		}
+	}
+
+	return s.replyStateUpdate(
+		peer, id, failCode, lastApplied,
+	)
+}
+
+// replyStateUpdate sends a response to a StateUpdate from a client. If the
+// status code in the reply is OK, the error from the write will be bubbled up.
+// Otherwise, this method returns a connection error to ensure we don't continue
+// communication with the client.
+func (s *Server) replyStateUpdate(peer Peer, id *wtdb.SessionID,
+	code wtwire.StateUpdateCode, lastApplied uint16) error {
+
+	msg := &wtwire.StateUpdateReply{
+		Code:        code,
+		LastApplied: lastApplied,
+	}
+
+	err := s.sendMessage(peer, msg)
+	if err != nil {
+		log.Errorf("unable to send StateUpdateReply to %s", id)
+	}
+
+	// Return the write error if the request succeeded.
+	if code == wtwire.CodeOK {
+		return err
+	}
+
+	// Otherwise the request failed, return a connection failure to
+	// disconnect the client.
+	return &connFailure{
+		ID:   *id,
+		Code: uint16(code),
+	}
+}

--- a/watchtower/wtwire/delete_session.go
+++ b/watchtower/wtwire/delete_session.go
@@ -1,0 +1,45 @@
+package wtwire
+
+import "io"
+
+// DeleteSession is sent from the client to the tower to signal that the tower
+// can delete all session state for the session key used to authenticate the
+// brontide connection. This should be done by the client once all channels that
+// have state updates in the session have been resolved on-chain.
+type DeleteSession struct{}
+
+// Compile-time constraint to ensure DeleteSession implements the wtwire.Message
+// interface.
+var _ Message = (*DeleteSession)(nil)
+
+// Decode deserializes a serialized DeleteSession message stored in the passed
+// io.Reader observing the specified protocol version.
+//
+// This is part of the wtwire.Message interface.
+func (m *DeleteSession) Decode(r io.Reader, pver uint32) error {
+	return nil
+}
+
+// Encode serializes the target DeleteSession message into the passed io.Writer
+// observing the specified protocol version.
+//
+// This is part of the wtwire.Message interface.
+func (m *DeleteSession) Encode(w io.Writer, pver uint32) error {
+	return nil
+}
+
+// MsgType returns the integer uniquely identifying this message type on the
+// wire.
+//
+// This is part of the wtwire.Message interface.
+func (m *DeleteSession) MsgType() MessageType {
+	return MsgDeleteSession
+}
+
+// MaxPayloadLength returns the maximum allowed payload size for a DeleteSession
+// message observing the specified protocol version.
+//
+// This is part of the wtwire.Message interface.
+func (m *DeleteSession) MaxPayloadLength(uint32) uint32 {
+	return 0
+}

--- a/watchtower/wtwire/delete_session_reply.go
+++ b/watchtower/wtwire/delete_session_reply.go
@@ -1,0 +1,66 @@
+package wtwire
+
+import "io"
+
+// DeleteSessionCode is an error code returned by a watchtower in response to a
+// DeleteSession message.
+type DeleteSessionCode = ErrorCode
+
+const (
+	// DeleteSessionCodeNotFound is returned when the watchtower does not
+	// know of the requested session. This may indicate an error on the
+	// client side, or that the tower had already deleted the session in a
+	// prior request that the client may not have received.
+	DeleteSessionCodeNotFound DeleteSessionCode = 80
+
+	// TODO(conner): add String method after wtclient is merged
+)
+
+// DeleteSessionReply is a message sent in response to a client's DeleteSession
+// request. The message indicates whether or not the deletion was a success or
+// failure.
+type DeleteSessionReply struct {
+	// Code will be non-zero if the watchtower was not able to delete the
+	// requested session.
+	Code DeleteSessionCode
+}
+
+// A compile time check to ensure DeleteSessionReply implements the
+// wtwire.Message interface.
+var _ Message = (*DeleteSessionReply)(nil)
+
+// Decode deserializes a serialized DeleteSessionReply message stored in the
+// passed io.Reader observing the specified protocol version.
+//
+// This is part of the wtwire.Message interface.
+func (m *DeleteSessionReply) Decode(r io.Reader, pver uint32) error {
+	return ReadElements(r,
+		&m.Code,
+	)
+}
+
+// Encode serializes the target DeleteSessionReply into the passed io.Writer
+// observing the protocol version specified.
+//
+// This is part of the wtwire.Message interface.
+func (m *DeleteSessionReply) Encode(w io.Writer, pver uint32) error {
+	return WriteElements(w,
+		m.Code,
+	)
+}
+
+// MsgType returns the integer uniquely identifying this message type on the
+// wire.
+//
+// This is part of the wtwire.Message interface.
+func (m *DeleteSessionReply) MsgType() MessageType {
+	return MsgDeleteSessionReply
+}
+
+// MaxPayloadLength returns the maximum allowed payload size for a
+// DeleteSessionReply complete message observing the specified protocol version.
+//
+// This is part of the wtwire.Message interface.
+func (m *DeleteSessionReply) MaxPayloadLength(uint32) uint32 {
+	return 2
+}

--- a/watchtower/wtwire/message.go
+++ b/watchtower/wtwire/message.go
@@ -40,6 +40,13 @@ const (
 
 	// MsgStateUpdateReply identifies an encoded StateUpdateReply message.
 	MsgStateUpdateReply MessageType = 305
+
+	// MsgDeleteSession identifies an encoded DeleteSession message.
+	MsgDeleteSession MessageType = 306
+
+	// MsgDeleteSessionReply identifies an encoded DeleteSessionReply
+	// message.
+	MsgDeleteSessionReply MessageType = 307
 )
 
 // String returns a human readable description of the message type.
@@ -55,6 +62,10 @@ func (m MessageType) String() string {
 		return "MsgStateUpdate"
 	case MsgStateUpdateReply:
 		return "MsgStateUpdateReply"
+	case MsgDeleteSession:
+		return "MsgDeleteSession"
+	case MsgDeleteSessionReply:
+		return "MsgDeleteSessionReply"
 	case MsgError:
 		return "Error"
 	default:
@@ -97,6 +108,10 @@ func makeEmptyMessage(msgType MessageType) (Message, error) {
 		msg = &StateUpdate{}
 	case MsgStateUpdateReply:
 		msg = &StateUpdateReply{}
+	case MsgDeleteSession:
+		msg = &DeleteSession{}
+	case MsgDeleteSessionReply:
+		msg = &DeleteSessionReply{}
 	case MsgError:
 		msg = &Error{}
 	default:

--- a/watchtower/wtwire/wtwire_test.go
+++ b/watchtower/wtwire/wtwire_test.go
@@ -127,6 +127,18 @@ func TestWatchtowerWireProtocol(t *testing.T) {
 			},
 		},
 		{
+			msgType: wtwire.MsgDeleteSession,
+			scenario: func(m wtwire.DeleteSession) bool {
+				return mainScenario(&m)
+			},
+		},
+		{
+			msgType: wtwire.MsgDeleteSessionReply,
+			scenario: func(m wtwire.DeleteSessionReply) bool {
+				return mainScenario(&m)
+			},
+		},
+		{
 			msgType: wtwire.MsgError,
 			scenario: func(m wtwire.Error) bool {
 				return mainScenario(&m)


### PR DESCRIPTION
This PR adds a new handler to the watchtower server, allowing a client to delete an active session. The new `wtwire.DeleteSession` message can be sent to by the client, instructing the server to remove the session corresponding to the public key used in the brontide handshake. The tower then responds with a `wtwire.DeleteSessionReply` to return the result. In the short term, this request will not be used by the wtclient package. We plan to do so after implementing the appropriate heuristics as to when exactly the client should delete a particular session. However, implementing this on the server-side allows us to retroactively add session deletion in the client without needing to introduce any additional feature bits or negotiation.