### PR TITLE
Tor option to override target IP address

### DIFF
--- a/config.go
+++ b/config.go
@@ -219,6 +219,7 @@ type torConfig struct {
 	DNS             string `long:"dns" description:"The DNS server as host:port that Tor will use for SRV queries - NOTE must have TCP resolution enabled"`
 	StreamIsolation bool   `long:"streamisolation" description:"Enable Tor stream isolation by randomizing user credentials for each connection."`
 	Control         string `long:"control" description:"The host:port that Tor is listening on for Tor control connections"`
+	TargetIPAddress string `long:"targetipaddress" description:"IP address that Tor should use as the target of the hidden service"`
 	V2              bool   `long:"v2" description:"Automatically set up a v2 onion service to listen for inbound connections"`
 	V3              bool   `long:"v3" description:"Automatically set up a v3 onion service to listen for inbound connections"`
 	PrivateKeyPath  string `long:"privatekeypath" description:"The path to the private key of the onion service being created"`

--- a/server.go
+++ b/server.go
@@ -542,7 +542,7 @@ func newServer(listenAddrs []net.Addr, chanDB *channeldb.DB,
 	// automatically create an onion service, we'll initiate our Tor
 	// controller and establish a connection to the Tor server.
 	if cfg.Tor.Active && (cfg.Tor.V2 || cfg.Tor.V3) {
-		s.torController = tor.NewController(cfg.Tor.Control)
+		s.torController = tor.NewController(cfg.Tor.Control, cfg.Tor.TargetIPAddress)
 	}
 
 	chanGraph := chanDB.ChannelGraph()


### PR DESCRIPTION
This option is required when the Tor server is not running on the same host as lnd. Otherwise peers can't connect to lnd through the onion service.

For example let's say you have a Kubernetes cluster and have a single Tor server which can be used by all the internal services. Then you can start lnd with `--tor.active --tor.v3 --tor.sock=tor:9050 --tor.control=tor:9051 --tor.targetipaddress=$MY_POD_ID`.
