### PR TITLE
wtclient: session private key derivation

### DIFF
--- a/keychain/derivation.go
+++ b/keychain/derivation.go
@@ -90,6 +90,12 @@ const (
 	// a payment, or self stored on disk in a single file containing all
 	// the static channel backups.
 	KeyFamilyStaticBackup KeyFamily = 7
+
+	// KeyFamilyTowerSession is the family of keys that will be used to
+	// derive session keys when negotiating sessions with watchtowers. The
+	// session keys are limited to the lifetime of the session and are used
+	// to increase privacy in the watchtower protocol.
+	KeyFamilyTowerSession KeyFamily = 8
 )
 
 // KeyLocator is a two-tuple that can be used to derive *any* key that has ever

--- a/watchtower/wtclient/client.go
+++ b/watchtower/wtclient/client.go
@@ -9,7 +9,6 @@ import (
 	"github.com/btcsuite/btcd/btcec"
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/lightningnetwork/lnd/input"
-	"github.com/lightningnetwork/lnd/keychain"
 	"github.com/lightningnetwork/lnd/lnwallet"
 	"github.com/lightningnetwork/lnd/lnwire"
 	"github.com/lightningnetwork/lnd/watchtower/wtdb"
@@ -77,7 +76,7 @@ type Config struct {
 	// SecretKeyRing is used to derive the session keys used to communicate
 	// with the tower. The client only stores the KeyLocators internally so
 	// that we never store private keys on disk.
-	SecretKeyRing keychain.SecretKeyRing
+	SecretKeyRing SecretKeyRing
 
 	// Dial connects to an addr using the specified net and returns the
 	// connection object.
@@ -201,15 +200,16 @@ func New(config *Config) (*TowerClient, error) {
 		forceQuit:      make(chan struct{}),
 	}
 	c.negotiator = newSessionNegotiator(&NegotiatorConfig{
-		DB:          cfg.DB,
-		Policy:      cfg.Policy,
-		ChainHash:   cfg.ChainHash,
-		SendMessage: c.sendMessage,
-		ReadMessage: c.readMessage,
-		Dial:        c.dial,
-		Candidates:  newTowerListIterator(tower),
-		MinBackoff:  cfg.MinBackoff,
-		MaxBackoff:  cfg.MaxBackoff,
+		DB:            cfg.DB,
+		SecretKeyRing: cfg.SecretKeyRing,
+		Policy:        cfg.Policy,
+		ChainHash:     cfg.ChainHash,
+		SendMessage:   c.sendMessage,
+		ReadMessage:   c.readMessage,
+		Dial:          c.dial,
+		Candidates:    newTowerListIterator(tower),
+		MinBackoff:    cfg.MinBackoff,
+		MaxBackoff:    cfg.MaxBackoff,
 	})
 
 	// Next, load all active sessions from the db into the client. We will
@@ -222,14 +222,25 @@ func New(config *Config) (*TowerClient, error) {
 	}
 
 	// Reload any towers from disk using the tower IDs contained in each
-	// candidate session.
+	// candidate session. We will also rederive any session keys needed to
+	// be able to communicate with the towers and authenticate session
+	// requests. This prevents us from having to store the private keys on
+	// disk.
 	for _, s := range c.candidateSessions {
 		tower, err := c.cfg.DB.LoadTower(s.TowerID)
 		if err != nil {
 			return nil, err
 		}
 
+		sessionPriv, err := DeriveSessionKey(
+			c.cfg.SecretKeyRing, s.KeyIndex,
+		)
+		if err != nil {
+			return nil, err
+		}
+
 		s.Tower = tower
+		s.SessionPrivKey = sessionPriv
 	}
 
 	// Finally, load the sweep pkscripts that have been generated for all

--- a/watchtower/wtclient/client.go
+++ b/watchtower/wtclient/client.go
@@ -221,6 +221,17 @@ func New(config *Config) (*TowerClient, error) {
 		return nil, err
 	}
 
+	// Reload any towers from disk using the tower IDs contained in each
+	// candidate session.
+	for _, s := range c.candidateSessions {
+		tower, err := c.cfg.DB.LoadTower(s.TowerID)
+		if err != nil {
+			return nil, err
+		}
+
+		s.Tower = tower
+	}
+
 	// Finally, load the sweep pkscripts that have been generated for all
 	// previously registered channels.
 	c.sweepPkScripts, err = c.cfg.DB.FetchChanPkScripts()

--- a/watchtower/wtclient/client_test.go
+++ b/watchtower/wtclient/client_test.go
@@ -430,10 +430,11 @@ func newHarness(t *testing.T, cfg harnessCfg) *testHarness {
 		Dial: func(string, string) (net.Conn, error) {
 			return nil, nil
 		},
-		DB:           clientDB,
-		AuthDial:     mockNet.AuthDial,
-		PrivateTower: towerAddr,
-		Policy:       cfg.policy,
+		DB:            clientDB,
+		AuthDial:      mockNet.AuthDial,
+		SecretKeyRing: wtmock.NewSecretKeyRing(),
+		PrivateTower:  towerAddr,
+		Policy:        cfg.policy,
 		NewAddress: func() ([]byte, error) {
 			return addrScript, nil
 		},

--- a/watchtower/wtclient/derivation.go
+++ b/watchtower/wtclient/derivation.go
@@ -1,0 +1,24 @@
+package wtclient
+
+import (
+	"github.com/btcsuite/btcd/btcec"
+	"github.com/lightningnetwork/lnd/keychain"
+)
+
+// DeriveSessionKey accepts an session key index for an existing session and
+// derives the HD private key to be used to authenticate the brontide transport
+// and authenticate requests sent to the tower. The key will use the
+// keychain.KeyFamilyTowerSession and the provided index, giving a BIP43
+// derivation path of:
+//
+//  * m/1017'/coinType'/8/0/index
+func DeriveSessionKey(keyRing SecretKeyRing,
+	index uint32) (*btcec.PrivateKey, error) {
+
+	return keyRing.DerivePrivKey(keychain.KeyDescriptor{
+		KeyLocator: keychain.KeyLocator{
+			Family: keychain.KeyFamilyTowerSession,
+			Index:  index,
+		},
+	})
+}

--- a/watchtower/wtclient/interface.go
+++ b/watchtower/wtclient/interface.go
@@ -23,6 +23,14 @@ type DB interface {
 	// LoadTower retrieves a tower by its tower ID.
 	LoadTower(uint64) (*wtdb.Tower, error)
 
+	// NextSessionKeyIndex reserves a new session key derivation index for a
+	// particular tower id. The index is reserved for that tower until
+	// CreateClientSession is invoked for that tower and index, at which
+	// point a new index for that tower can be reserved. Multiple calls to
+	// this method before CreateClientSession is invoked should return the
+	// same index.
+	NextSessionKeyIndex(uint64) (uint32, error)
+
 	// CreateClientSession saves a newly negotiated client session to the
 	// client's database. This enables the session to be used across
 	// restarts.

--- a/watchtower/wtclient/interface.go
+++ b/watchtower/wtclient/interface.go
@@ -19,6 +19,9 @@ type DB interface {
 	// sessions.
 	CreateTower(*lnwire.NetAddress) (*wtdb.Tower, error)
 
+	// LoadTower retrieves a tower by its tower ID.
+	LoadTower(uint64) (*wtdb.Tower, error)
+
 	// CreateClientSession saves a newly negotiated client session to the
 	// client's database. This enables the session to be used across
 	// restarts.

--- a/watchtower/wtclient/interface.go
+++ b/watchtower/wtclient/interface.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/btcsuite/btcd/btcec"
 	"github.com/lightningnetwork/lnd/brontide"
+	"github.com/lightningnetwork/lnd/keychain"
 	"github.com/lightningnetwork/lnd/lnwire"
 	"github.com/lightningnetwork/lnd/watchtower/wtdb"
 	"github.com/lightningnetwork/lnd/watchtower/wtserver"
@@ -76,4 +77,12 @@ func AuthDial(localPriv *btcec.PrivateKey, netAddr *lnwire.NetAddress,
 	dialer func(string, string) (net.Conn, error)) (wtserver.Peer, error) {
 
 	return brontide.Dial(localPriv, netAddr, dialer)
+}
+
+// SecretKeyRing abstracts the ability to derive HD private keys given a
+// description of the derivation path.
+type SecretKeyRing interface {
+	// DerivePrivKey derives the private key from the root seed using a
+	// key descriptor specifying the key's derivation path.
+	DerivePrivKey(loc keychain.KeyDescriptor) (*btcec.PrivateKey, error)
 }

--- a/watchtower/wtclient/session_negotiator.go
+++ b/watchtower/wtclient/session_negotiator.go
@@ -42,6 +42,10 @@ type NegotiatorConfig struct {
 	// negotiated sessions.
 	DB DB
 
+	// SecretKeyRing allows the client to derive new session private keys
+	// when attempting to negotiate session with a tower.
+	SecretKeyRing SecretKeyRing
+
 	// Candidates is an abstract set of tower candidates that the negotiator
 	// will traverse serially when attempting to negotiate a new session.
 	Candidates TowerCandidateIterator
@@ -255,12 +259,23 @@ retryWithBackoff:
 			goto retryWithBackoff
 		}
 
+		towerPub := tower.IdentityKey.SerializeCompressed()
 		log.Debugf("Attempting session negotiation with tower=%x",
-			tower.IdentityKey.SerializeCompressed())
+			towerPub)
+
+		// Before proceeding, we will reserve a session key index to use
+		// with this specific tower. If one is already reserved, the
+		// existing index will be returned.
+		keyIndex, err := n.cfg.DB.NextSessionKeyIndex(tower.ID)
+		if err != nil {
+			log.Debugf("Unable to reserve session key index "+
+				"for tower=%x: %v", towerPub, err)
+			continue
+		}
 
 		// We'll now attempt the CreateSession dance with the tower to
 		// get a new session, trying all addresses if necessary.
-		err = n.createSession(tower)
+		err = n.createSession(tower, keyIndex)
 		if err != nil {
 			log.Debugf("Session negotiation with tower=%x "+
 				"failed, trying again -- reason: %v",
@@ -277,22 +292,21 @@ retryWithBackoff:
 // its stored addresses. This method returns after the first successful
 // negotiation, or after all addresses have failed with ErrFailedNegotiation. If
 // the tower has no addresses, ErrNoTowerAddrs is returned.
-func (n *sessionNegotiator) createSession(tower *wtdb.Tower) error {
+func (n *sessionNegotiator) createSession(tower *wtdb.Tower,
+	keyIndex uint32) error {
+
 	// If the tower has no addresses, there's nothing we can do.
 	if len(tower.Addresses) == 0 {
 		return ErrNoTowerAddrs
 	}
 
-	// TODO(conner): create with hdkey at random index
-	sessionPrivKey, err := btcec.NewPrivateKey(btcec.S256())
+	sessionPriv, err := DeriveSessionKey(n.cfg.SecretKeyRing, keyIndex)
 	if err != nil {
 		return err
 	}
 
-	// TODO(conner): write towerAddr+privkey
-
 	for _, lnAddr := range tower.LNAddrs() {
-		err = n.tryAddress(sessionPrivKey, tower, lnAddr)
+		err = n.tryAddress(sessionPriv, keyIndex, tower, lnAddr)
 		switch {
 		case err == ErrPermanentTowerFailure:
 			// TODO(conner): report to iterator? can then be reset
@@ -318,7 +332,7 @@ func (n *sessionNegotiator) createSession(tower *wtdb.Tower) error {
 // returns true if all steps succeed and the new session has been persisted, and
 // fails otherwise.
 func (n *sessionNegotiator) tryAddress(privKey *btcec.PrivateKey,
-	tower *wtdb.Tower, lnAddr *lnwire.NetAddress) error {
+	keyIndex uint32, tower *wtdb.Tower, lnAddr *lnwire.NetAddress) error {
 
 	// Connect to the tower address using our generated session key.
 	conn, err := n.cfg.Dial(privKey, lnAddr)
@@ -394,7 +408,8 @@ func (n *sessionNegotiator) tryAddress(privKey *btcec.PrivateKey,
 		clientSession := &wtdb.ClientSession{
 			TowerID:        tower.ID,
 			Tower:          tower,
-			SessionPrivKey: privKey, // remove after using HD keys
+			KeyIndex:       keyIndex,
+			SessionPrivKey: privKey,
 			ID:             sessionID,
 			Policy:         n.cfg.Policy,
 			SeqNum:         0,

--- a/watchtower/wtdb/client_session.go
+++ b/watchtower/wtdb/client_session.go
@@ -29,6 +29,15 @@ var (
 	// LastApplied value greater than any allocated sequence number.
 	ErrUnallocatedLastApplied = errors.New("tower echoed last appiled " +
 		"greater than allocated seqnum")
+
+	// ErrNoReservedKeyIndex signals that a client session could not be
+	// created because no session key index was reserved.
+	ErrNoReservedKeyIndex = errors.New("key index not reserved")
+
+	// ErrIncorrectKeyIndex signals that the client session could not be
+	// created because session key index differs from the reserved key
+	// index.
+	ErrIncorrectKeyIndex = errors.New("incorrect key index")
 )
 
 // ClientSession encapsulates a SessionInfo returned from a successful

--- a/watchtower/wtdb/client_session.go
+++ b/watchtower/wtdb/client_session.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 
 	"github.com/btcsuite/btcd/btcec"
-	"github.com/lightningnetwork/lnd/keychain"
 	"github.com/lightningnetwork/lnd/lnwire"
 	"github.com/lightningnetwork/lnd/watchtower/wtpolicy"
 )
@@ -57,14 +56,17 @@ type ClientSession struct {
 	// tower with TowerID.
 	Tower *Tower
 
-	// SessionKeyDesc is the key descriptor used to derive the client's
+	// KeyIndex is the index of key locator used to derive the client's
 	// session key so that it can authenticate with the tower to update its
-	// session.
-	SessionKeyDesc keychain.KeyLocator
+	// session. In order to rederive the private key, the key locator should
+	// use the keychain.KeyFamilyTowerSession key family.
+	KeyIndex uint32
 
 	// SessionPrivKey is the ephemeral secret key used to connect to the
 	// watchtower.
-	// TODO(conner): remove after HD keys
+	//
+	// NOTE: This value is not serialized. It is derived using the KeyIndex
+	// on startup to avoid storing private keys on disk.
 	SessionPrivKey *btcec.PrivateKey
 
 	// Policy holds the negotiated session parameters.

--- a/watchtower/wtdb/mock.go
+++ b/watchtower/wtdb/mock.go
@@ -61,7 +61,8 @@ func (db *MockDB) InsertSessionInfo(info *SessionInfo) error {
 	db.mu.Lock()
 	defer db.mu.Unlock()
 
-	if _, ok := db.sessions[info.ID]; ok {
+	dbInfo, ok := db.sessions[info.ID]
+	if ok && dbInfo.LastApplied > 0 {
 		return ErrSessionAlreadyExists
 	}
 

--- a/watchtower/wtdb/tower.go
+++ b/watchtower/wtdb/tower.go
@@ -1,11 +1,18 @@
 package wtdb
 
 import (
+	"errors"
 	"net"
 	"sync"
 
 	"github.com/btcsuite/btcd/btcec"
 	"github.com/lightningnetwork/lnd/lnwire"
+)
+
+var (
+	// ErrTowerNotFound signals that the target tower was not found in the
+	// database.
+	ErrTowerNotFound = errors.New("tower not found")
 )
 
 // Tower holds the necessary components required to connect to a remote tower.

--- a/watchtower/wtmock/client_db.go
+++ b/watchtower/wtmock/client_db.go
@@ -109,7 +109,6 @@ func (m *ClientDB) CreateClientSession(session *wtdb.ClientSession) error {
 	m.activeSessions[session.ID] = &wtdb.ClientSession{
 		TowerID:          session.TowerID,
 		KeyIndex:         session.KeyIndex,
-		SessionPrivKey:   session.SessionPrivKey,
 		ID:               session.ID,
 		Policy:           session.Policy,
 		SeqNum:           session.SeqNum,

--- a/watchtower/wtmock/client_db.go
+++ b/watchtower/wtmock/client_db.go
@@ -110,7 +110,7 @@ func (m *ClientDB) CreateClientSession(session *wtdb.ClientSession) error {
 		Policy:           session.Policy,
 		SeqNum:           session.SeqNum,
 		TowerLastApplied: session.TowerLastApplied,
-		RewardPkScript:   session.RewardPkScript,
+		RewardPkScript:   cloneBytes(session.RewardPkScript),
 		CommittedUpdates: make(map[uint16]*wtdb.CommittedUpdate),
 		AckedUpdates:     make(map[uint16]wtdb.BackupID),
 	}
@@ -228,7 +228,12 @@ func (m *ClientDB) AddChanPkScript(chanID lnwire.ChannelID, pkScript []byte) err
 }
 
 func cloneBytes(b []byte) []byte {
+	if b == nil {
+		return nil
+	}
+
 	bb := make([]byte, len(b))
 	copy(bb, b)
+
 	return bb
 }

--- a/watchtower/wtmock/client_db.go
+++ b/watchtower/wtmock/client_db.go
@@ -104,7 +104,7 @@ func (m *ClientDB) CreateClientSession(session *wtdb.ClientSession) error {
 
 	m.activeSessions[session.ID] = &wtdb.ClientSession{
 		TowerID:          session.TowerID,
-		SessionKeyDesc:   session.SessionKeyDesc,
+		KeyIndex:         session.KeyIndex,
 		SessionPrivKey:   session.SessionPrivKey,
 		ID:               session.ID,
 		Policy:           session.Policy,

--- a/watchtower/wtmock/client_db.go
+++ b/watchtower/wtmock/client_db.go
@@ -64,6 +64,18 @@ func (m *ClientDB) CreateTower(lnAddr *lnwire.NetAddress) (*wtdb.Tower, error) {
 	return tower, nil
 }
 
+// LoadTower retrieves a tower by its tower ID.
+func (m *ClientDB) LoadTower(towerID uint64) (*wtdb.Tower, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if tower, ok := m.towers[towerID]; ok {
+		return tower, nil
+	}
+
+	return nil, wtdb.ErrTowerNotFound
+}
+
 // MarkBackupIneligible records that particular commit height is ineligible for
 // backup. This allows the client to track which updates it should not attempt
 // to retry after startup.
@@ -92,7 +104,6 @@ func (m *ClientDB) CreateClientSession(session *wtdb.ClientSession) error {
 
 	m.activeSessions[session.ID] = &wtdb.ClientSession{
 		TowerID:          session.TowerID,
-		Tower:            session.Tower,
 		SessionKeyDesc:   session.SessionKeyDesc,
 		SessionPrivKey:   session.SessionPrivKey,
 		ID:               session.ID,

--- a/watchtower/wtmock/keyring.go
+++ b/watchtower/wtmock/keyring.go
@@ -1,0 +1,44 @@
+package wtmock
+
+import (
+	"sync"
+
+	"github.com/btcsuite/btcd/btcec"
+	"github.com/lightningnetwork/lnd/keychain"
+)
+
+// SecretKeyRing is a mock, in-memory implementation for deriving private keys.
+type SecretKeyRing struct {
+	mu   sync.Mutex
+	keys map[keychain.KeyLocator]*btcec.PrivateKey
+}
+
+// NewSecretKeyRing creates a new mock SecretKeyRing.
+func NewSecretKeyRing() *SecretKeyRing {
+	return &SecretKeyRing{
+		keys: make(map[keychain.KeyLocator]*btcec.PrivateKey),
+	}
+}
+
+// DerivePrivKey derives the private key for a given key descriptor. If
+// this method is called twice with the same argument, it will return the same
+// private key.
+func (m *SecretKeyRing) DerivePrivKey(
+	desc keychain.KeyDescriptor) (*btcec.PrivateKey, error) {
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if key, ok := m.keys[desc.KeyLocator]; ok {
+		return key, nil
+	}
+
+	privKey, err := btcec.NewPrivateKey(btcec.S256())
+	if err != nil {
+		return nil, err
+	}
+
+	m.keys[desc.KeyLocator] = privKey
+
+	return privKey, nil
+}

--- a/watchtower/wtserver/create_session.go
+++ b/watchtower/wtserver/create_session.go
@@ -40,6 +40,15 @@ func (s *Server) handleCreateSession(peer Peer, id *wtdb.SessionID,
 		)
 	}
 
+	// Ensure that the requested blob type is supported by our tower.
+	if !blob.IsSupportedType(req.BlobType) {
+		log.Debugf("Rejecting CreateSession from %s, unsupported blob "+
+			"type %s", id, req.BlobType)
+		return s.replyCreateSession(
+			peer, id, wtwire.CreateSessionCodeRejectBlobType, nil,
+		)
+	}
+
 	// Now that we've established that this session does not exist in the
 	// database, retrieve the sweep address that will be given to the
 	// client. This address is to be included by the client when signing
@@ -60,15 +69,6 @@ func (s *Server) handleCreateSession(peer Peer, id *wtdb.SessionID,
 		log.Errorf("unable to generate reward script for %s", id)
 		return s.replyCreateSession(
 			peer, id, wtwire.CodeTemporaryFailure, nil,
-		)
-	}
-
-	// Ensure that the requested blob type is supported by our tower.
-	if !blob.IsSupportedType(req.BlobType) {
-		log.Debugf("Rejecting CreateSession from %s, unsupported blob "+
-			"type %s", id, req.BlobType)
-		return s.replyCreateSession(
-			peer, id, wtwire.CreateSessionCodeRejectBlobType, nil,
 		)
 	}
 

--- a/watchtower/wtserver/create_session.go
+++ b/watchtower/wtserver/create_session.go
@@ -122,6 +122,13 @@ func (s *Server) handleCreateSession(peer Peer, id *wtdb.SessionID,
 func (s *Server) replyCreateSession(peer Peer, id *wtdb.SessionID,
 	code wtwire.ErrorCode, lastApplied uint16, data []byte) error {
 
+	if s.cfg.NoAckCreateSession {
+		return &connFailure{
+			ID:   *id,
+			Code: code,
+		}
+	}
+
 	msg := &wtwire.CreateSessionReply{
 		Code:        code,
 		LastApplied: lastApplied,

--- a/watchtower/wtserver/create_session.go
+++ b/watchtower/wtserver/create_session.go
@@ -142,6 +142,6 @@ func (s *Server) replyCreateSession(peer Peer, id *wtdb.SessionID,
 	// disconnect the client.
 	return &connFailure{
 		ID:   *id,
-		Code: uint16(code),
+		Code: code,
 	}
 }

--- a/watchtower/wtserver/delete_session.go
+++ b/watchtower/wtserver/delete_session.go
@@ -52,6 +52,6 @@ func (s *Server) replyDeleteSession(peer Peer, id *wtdb.SessionID,
 	// disconnect the client.
 	return &connFailure{
 		ID:   *id,
-		Code: uint16(code),
+		Code: code,
 	}
 }

--- a/watchtower/wtserver/server.go
+++ b/watchtower/wtserver/server.go
@@ -56,6 +56,10 @@ type Config struct {
 	// ChainHash identifies the network that the server is watching.
 	ChainHash chainhash.Hash
 
+	// NoAckCreateSession causes the server to not reply to create session
+	// requests, this should only be used for testing.
+	NoAckCreateSession bool
+
 	// NoAckUpdates causes the server to not acknowledge state updates, this
 	// should only be used for testing.
 	NoAckUpdates bool

--- a/watchtower/wtserver/server.go
+++ b/watchtower/wtserver/server.go
@@ -283,12 +283,12 @@ func (s *Server) handleClient(peer Peer) {
 // error code.
 type connFailure struct {
 	ID   wtdb.SessionID
-	Code uint16
+	Code wtwire.ErrorCode
 }
 
 // Error displays the SessionID and Code that caused the connection failure.
 func (f *connFailure) Error() string {
-	return fmt.Sprintf("connection with %s failed with code=%v",
+	return fmt.Sprintf("connection with %s failed with code=%s",
 		f.ID, f.Code,
 	)
 }

--- a/watchtower/wtserver/server_test.go
+++ b/watchtower/wtserver/server_test.go
@@ -29,6 +29,8 @@ var (
 	addrScript, _ = txscript.PayToAddrScript(addr)
 
 	testnetChainHash = *chaincfg.TestNet3Params.GenesisHash
+
+	rewardType = (blob.FlagCommitOutputs | blob.FlagReward).Type()
 )
 
 // randPubKey generates a new secp keypair, and returns the public key.
@@ -152,16 +154,17 @@ func TestServerOnlyAcceptOnePeer(t *testing.T) {
 }
 
 type createSessionTestCase struct {
-	name        string
-	initMsg     *wtwire.Init
-	createMsg   *wtwire.CreateSession
-	expReply    *wtwire.CreateSessionReply
-	expDupReply *wtwire.CreateSessionReply
+	name            string
+	initMsg         *wtwire.Init
+	createMsg       *wtwire.CreateSession
+	expReply        *wtwire.CreateSessionReply
+	expDupReply     *wtwire.CreateSessionReply
+	sendStateUpdate bool
 }
 
 var createSessionTests = []createSessionTestCase{
 	{
-		name: "reject duplicate session create",
+		name: "duplicate session create",
 		initMsg: wtwire.NewInitMessage(
 			lnwire.NewRawFeatureVector(),
 			testnetChainHash,
@@ -175,10 +178,56 @@ var createSessionTests = []createSessionTestCase{
 		},
 		expReply: &wtwire.CreateSessionReply{
 			Code: wtwire.CodeOK,
+			Data: []byte{},
+		},
+		expDupReply: &wtwire.CreateSessionReply{
+			Code: wtwire.CodeOK,
+			Data: []byte{},
+		},
+	},
+	{
+		name: "duplicate session create after use",
+		initMsg: wtwire.NewInitMessage(
+			lnwire.NewRawFeatureVector(),
+			testnetChainHash,
+		),
+		createMsg: &wtwire.CreateSession{
+			BlobType:     blob.TypeDefault,
+			MaxUpdates:   1000,
+			RewardBase:   0,
+			RewardRate:   0,
+			SweepFeeRate: 1,
+		},
+		expReply: &wtwire.CreateSessionReply{
+			Code: wtwire.CodeOK,
+			Data: []byte{},
+		},
+		expDupReply: &wtwire.CreateSessionReply{
+			Code:        wtwire.CreateSessionCodeAlreadyExists,
+			LastApplied: 1,
+			Data:        []byte{},
+		},
+		sendStateUpdate: true,
+	},
+	{
+		name: "duplicate session create reward",
+		initMsg: wtwire.NewInitMessage(
+			lnwire.NewRawFeatureVector(),
+			testnetChainHash,
+		),
+		createMsg: &wtwire.CreateSession{
+			BlobType:     rewardType,
+			MaxUpdates:   1000,
+			RewardBase:   0,
+			RewardRate:   0,
+			SweepFeeRate: 1,
+		},
+		expReply: &wtwire.CreateSessionReply{
+			Code: wtwire.CodeOK,
 			Data: addrScript,
 		},
 		expDupReply: &wtwire.CreateSessionReply{
-			Code: wtwire.CreateSessionCodeAlreadyExists,
+			Code: wtwire.CodeOK,
 			Data: addrScript,
 		},
 	},
@@ -249,6 +298,18 @@ func testServerCreateSession(t *testing.T, i int, test createSessionTestCase) {
 	// continue to the next test.
 	if test.expDupReply == nil {
 		return
+	}
+
+	if test.sendStateUpdate {
+		peer = wtmock.NewMockPeer(localPub, peerPub, nil, 0)
+		connect(t, s, peer, test.initMsg, timeoutDuration)
+		update := &wtwire.StateUpdate{
+			SeqNum:     1,
+			IsComplete: 1,
+		}
+		sendMsg(t, update, peer, timeoutDuration)
+
+		assertConnClosed(t, peer, 2*timeoutDuration)
 	}
 
 	// Simulate a peer with the same session id connection to the server
@@ -705,7 +766,7 @@ func TestServerDeleteSession(t *testing.T) {
 			send: createSession,
 			recv: &wtwire.CreateSessionReply{
 				Code: wtwire.CodeOK,
-				Data: addrScript,
+				Data: []byte{},
 			},
 			assert: func(t *testing.T) {
 				// Both peers should have sessions.

--- a/watchtower/wtserver/state_update.go
+++ b/watchtower/wtserver/state_update.go
@@ -117,7 +117,7 @@ func (s *Server) handleStateUpdate(peer Peer, id *wtdb.SessionID,
 	if s.cfg.NoAckUpdates {
 		return &connFailure{
 			ID:   *id,
-			Code: uint16(failCode),
+			Code: failCode,
 		}
 	}
 
@@ -152,6 +152,6 @@ func (s *Server) replyStateUpdate(peer Peer, id *wtdb.SessionID,
 	// disconnect the client.
 	return &connFailure{
 		ID:   *id,
-		Code: uint16(code),
+		Code: code,
 	}
 }

--- a/watchtower/wtwire/create_session_reply.go
+++ b/watchtower/wtwire/create_session_reply.go
@@ -43,6 +43,12 @@ type CreateSessionReply struct {
 	// Code will be non-zero if the watchtower rejected the session init.
 	Code CreateSessionCode
 
+	// LastApplied is the tower's last accepted sequence number for the
+	// session. This is useful when the session already exists but the
+	// client doesn't realize it's already used the session, such as after a
+	// restoration.
+	LastApplied uint16
+
 	// Data is a byte slice returned the caller of the message, and is to be
 	// interpreted according to the error Code. When the response is
 	// CreateSessionCodeOK, data encodes the reward address to be included in
@@ -63,6 +69,7 @@ var _ Message = (*CreateSessionReply)(nil)
 func (m *CreateSessionReply) Decode(r io.Reader, pver uint32) error {
 	return ReadElements(r,
 		&m.Code,
+		&m.LastApplied,
 		&m.Data,
 	)
 }
@@ -74,6 +81,7 @@ func (m *CreateSessionReply) Decode(r io.Reader, pver uint32) error {
 func (m *CreateSessionReply) Encode(w io.Writer, pver uint32) error {
 	return WriteElements(w,
 		m.Code,
+		m.LastApplied,
 		m.Data,
 	)
 }

--- a/watchtower/wtwire/delete_session_reply.go
+++ b/watchtower/wtwire/delete_session_reply.go
@@ -12,8 +12,6 @@ const (
 	// client side, or that the tower had already deleted the session in a
 	// prior request that the client may not have received.
 	DeleteSessionCodeNotFound DeleteSessionCode = 80
-
-	// TODO(conner): add String method after wtclient is merged
 )
 
 // DeleteSessionReply is a message sent in response to a client's DeleteSession

--- a/watchtower/wtwire/error_code.go
+++ b/watchtower/wtwire/error_code.go
@@ -46,6 +46,8 @@ func (c ErrorCode) String() string {
 		return "StateUpdateCodeMaxUpdatesExceeded"
 	case StateUpdateCodeSeqNumOutOfOrder:
 		return "StateUpdateCodeSeqNumOutOfOrder"
+	case DeleteSessionCodeNotFound:
+		return "DeleteSessionCodeNotFound"
 	default:
 		return fmt.Sprintf("UnknownErrorCode: %d", c)
 	}


### PR DESCRIPTION
In this PR, we address some of the last major architectural changes planned for the `wtclient` before it is ready to be integrated with its database and into the lnd daemon.  The primary component is encompassed by deriving the session private keys from the user's seed, which are used to encrypt brontide traffic with the tower and authenticate requests. To do so, we add a new key family:
```golang
 	// KeyFamilyTowerSession is the family of keys that will be used to
	// derive session keys when negotiation sessions with watchtowers. The
	// session keys are limited to the lifetime of the session and are used
	// to increase privacy in the watchtower protocol.
	KeyFamilyTowerSession KeyFamily = 8
```

The initial version of the wtclient #2618 generated these randomly and stored them in plaintext in the mock database to keep the scope of the initial PR from growing too much. Here we resolve this, ensuring we don't need to store the private keys on disk.

In addition, we also improve the `CreateSession` flow, namely by:
 1. Returning the current `LastApplied` value for the session if it exists and has a non-zero number of updates.
 1. Allowing clients to overwrite an existing session if the session has no submitted updates

The first improvement is useful in detecting cases of data loss, where a client tries to create a session with the same tower but that session already has updates. When keys are generated randomly, the probability of this occurring is negligible. However with deterministic derivation, this could happen if the client uses the same tower and the indexes collide. 

The rationale behind the second is more subtle, but it permits more asynchrony between the client and server during session creation, and permits the client to tolerate edge cases with less persistent state.

The current flow will reject if a session already exists. However, if the client is unable to receive the `CreateSessionReply`, the client must remember what policy and session key indexes it used so that it can continue using the session if the tower says it already exists. Doing so requires that the client store a tuple of (tower, session key index, policy). If the tower claims the session already exists and the `LastApplied` value is zero, then the client would continue using the tower.

The difficulty here is that failure to use the exact same policy would result in the signatures in the updates being invalid, and only detectable at the time of the broadcast. By allowing the session to be overwritten while the session has no updates, the tower is able to use first state update as an acknowledgment that the client has successfully persisted the session. This allows the client to only store a (tower, session key index) tuple for each attempted session, as the policy will implicitly resolve to whichever it uses last since the tower will return `CodeOK` for the new session. This is true even if the client crashes and is restarted with a different policy, assuming the new policy is also supported by the tower. Furthermore, the client only ever has to reserve one session key index at a time for a given tower, as opposed to one for each (tower, policy) pair.

Along the way, we make some miscellaneous improvements:
 1. Checking blob type before attempting to create a reward address on the tower side
 2. Printing error codes with their human readable name instead of their number on the tower side
 3. Add the `DeleteSessionCodeNotFound` string to the `wtwire.ErrorCode` list, as a follow up from #2779 
 4. Remove storage of the `Tower` and `SessionPrivKey` from the mock db, since these are now generated on startup. The existing unit tests in the client package assert that they are regenerated on startup during the client restart test
 5. Fix a bug that could cause the client not to force quit during session creation.

NOTE: If #2783 is merged before this, the `wtdb.TowerDB` unit tests will be need modified to test the session overwriting.
