### PR TITLE
rpcserver: retrieve Channel ChanId from OpenChannel record

### DIFF
--- a/rpcserver.go
+++ b/rpcserver.go
@@ -2488,11 +2488,6 @@ func createRPCOpenChannel(r *rpcServer, graph *channeldb.ChannelGraph,
 	nodeID := hex.EncodeToString(nodePub.SerializeCompressed())
 	chanPoint := dbChannel.FundingOutpoint
 
-	// With the channel point known, retrieve the network channel
-	// ID from the database.
-	var chanID uint64
-	chanID, _ = graph.ChannelID(&chanPoint)
-
 	// Next, we'll determine whether the channel is public or not.
 	isPublic := dbChannel.ChannelFlags&lnwire.FFAnnounceChannel != 0
 
@@ -2527,7 +2522,7 @@ func createRPCOpenChannel(r *rpcServer, graph *channeldb.ChannelGraph,
 		Private:               !isPublic,
 		RemotePubkey:          nodeID,
 		ChannelPoint:          chanPoint.String(),
-		ChanId:                chanID,
+		ChanId:                dbChannel.ShortChannelID.ToUint64(),
 		Capacity:              int64(dbChannel.Capacity),
 		LocalBalance:          int64(localBalance.ToSatoshis()),
 		RemoteBalance:         int64(remoteBalance.ToSatoshis()),


### PR DESCRIPTION
This is a better alternative than retrieving it from the graph as it's
possible that the channel is pruned from it doing to not having any
updates within the past two weeks.

Fixes https://github.com/lightningnetwork/lnd/issues/2823.