### PR TITLE
docs/MAKEFILE: Remove mention of dep and Glide

### DIFF
--- a/docs/MAKEFILE.md
+++ b/docs/MAKEFILE.md
@@ -52,8 +52,7 @@ Compiles, tests, and installs `lnd` and `lncli`. Equivalent to
 
 `btcd`
 ------
-Ensures that [`github.com/Masterminds/glide`][glide] is installed, and
-that the [`github.com/btcsuite/btcd`][btcd] repository is checked out
+Ensures that the [`github.com/btcsuite/btcd`][btcd] repository is checked out
 locally. Lastly, installs the version of 
 [`github.com/btcsuite/btcd`][btcd] specified in `Gopkg.toml`
 
@@ -134,7 +133,7 @@ Compiles the `lnrpc` proto files.
 `scratch`
 ---------
 Compiles all dependencies and builds the `./lnd` and `./lncli` binaries.
-Equivalent to [`lint`](#lint) [`dep`](#dep) [`btcd`](#btcd)
+Equivalent to [`lint`](#lint) [`btcd`](#btcd)
 [`unit-race`](#unit-race).
 
 `unit`
@@ -176,7 +175,5 @@ Arguments:
 Related: [`unit`](#unit)
 
 [btcd]: https://github.com/btcsuite/btcd (github.com/btcsuite/btcd")
-[glide]: https://github.com/Masterminds/glide (github.com/Masterminds/glide)
 [gometalinter]: https://gopkg.in/alecthomas/gometalinter.v1 (gopkg.in/alecthomas/gometalinter.v1)
-[dep]: https://github.com/golang/dep/cmd/dep (github.com/golang/dep/cmd/dep)
 [goveralls]: https://github.com/mattn/goveralls (github.com/mattn/goveralls)


### PR DESCRIPTION
Commit ca28c0b removed the dep section,
so it shouldn't be mentioned as a target in other targets.
Also, Glide doesn't seem to be used anymore as well.

#### Pull Request Checklist

- [x] If this is your first time contributing, we recommend you read the [Code
  Contribution Guidelines](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md)
- [x] All changes are Go version 1.11 compliant
- [x]  The code being submitted is commented according to the
  [Code Documentation and Commenting](#CodeDocumentation) section
- [x]  For new code: Code is accompanied by tests which exercise both
  the positive and negative (error paths) conditions (if applicable)
- [x]  For bug fixes: Code is accompanied by new tests which trigger
  the bug being fixed to prevent regressions
- [x]  Any new logging statements use an appropriate subsystem and
  logging level
- [x]  Code has been formatted with `go fmt`
- [x]  For code and documentation: lines are wrapped at 80 characters
  (the tab character should be counted as 8 characters, not 4, as some IDEs do
  per default)
- [x]  Running `make check` does not fail any tests
- [x]  Running `go vet` does not report any issues
- [x]  Running `make lint` does not report any **new** issues that did not
  already exist
- [x] All commits build properly and pass tests. Only in exceptional
  cases it can be justifiable to violate this condition. In that case, the
  reason should be stated in the commit message.
- [x] Commits have a logical structure ([see section 4.5, of the Code Contribution Guidelines])
