### PR TITLE
rpcserver: correct avg degree in GetNetworkInfo

### DIFF
--- a/rpcserver.go
+++ b/rpcserver.go
@@ -4033,7 +4033,7 @@ func (r *rpcServer) GetNetworkInfo(ctx context.Context,
 	//  * also add median channel size
 	netInfo := &lnrpc.NetworkInfo{
 		MaxOutDegree:         maxChanOut,
-		AvgOutDegree:         float64(numChannels) / float64(numNodes),
+		AvgOutDegree:         float64(2*numChannels) / float64(numNodes),
 		NumNodes:             numNodes,
 		NumChannels:          numChannels,
 		TotalNetworkCapacity: int64(totalNetworkCapacity),


### PR DESCRIPTION
AFAIK average degree of graph is calculated as twice the number of edges divided by number of vertices. Also now the value makes more sense, because now it means average number of channels connected to single node.

