### PR TITLE
signal: catch all termination signals by default

### DIFF
--- a/signal/signal.go
+++ b/signal/signal.go
@@ -8,6 +8,7 @@ package signal
 import (
 	"os"
 	"os/signal"
+	"syscall"
 )
 
 var (
@@ -26,7 +27,15 @@ var (
 )
 
 func init() {
-	signal.Notify(interruptChannel, os.Interrupt)
+	signalsToCatch := []os.Signal{
+		os.Interrupt,
+		os.Kill,
+		syscall.SIGABRT,
+		syscall.SIGTERM,
+		syscall.SIGSTOP,
+		syscall.SIGQUIT,
+	}
+	signal.Notify(interruptChannel, signalsToCatch...)
 	go mainInterruptHandler()
 }
 
@@ -60,8 +69,8 @@ func mainInterruptHandler() {
 
 	for {
 		select {
-		case <-interruptChannel:
-			log.Infof("Received SIGINT (Ctrl+C).")
+		case signal := <-interruptChannel:
+			log.Infof("Received %v", signal)
 			shutdown()
 
 		case <-shutdownRequestChannel:


### PR DESCRIPTION
In this commit, we modify the primary `signal` package to instead catch
all signals. Before this commit, it would only catch the interrupt
signal sent from the kernel. With this new commit, we'll now also catch
(or attempt to catch): `SIGABRT`, `SIGTERM`, `SIGSTOP`, and `SIGQUIT`.

