### PR TITLE
routerrpc: register router sub server logger

### DIFF
--- a/lnrpc/routerrpc/log.go
+++ b/lnrpc/routerrpc/log.go
@@ -10,9 +10,12 @@ import (
 // requests it.
 var log btclog.Logger
 
+// Subsystem defines the logging code for this subsystem.
+const Subsystem = "RRPC"
+
 // The default amount of logging is none.
 func init() {
-	UseLogger(build.NewSubLogger("RRPC", nil))
+	UseLogger(build.NewSubLogger(Subsystem, nil))
 }
 
 // DisableLog disables all library log output.  Logging output is disabled

--- a/log.go
+++ b/log.go
@@ -10,7 +10,7 @@ import (
 	"github.com/btcsuite/btclog"
 	"github.com/jrick/logrotate/rotator"
 	"github.com/lightninglabs/neutrino"
-	"github.com/lightningnetwork/lightning-onion"
+	sphinx "github.com/lightningnetwork/lightning-onion"
 	"github.com/lightningnetwork/lnd/autopilot"
 	"github.com/lightningnetwork/lnd/build"
 	"github.com/lightningnetwork/lnd/chainntnfs"
@@ -23,6 +23,7 @@ import (
 	"github.com/lightningnetwork/lnd/lnrpc/autopilotrpc"
 	"github.com/lightningnetwork/lnd/lnrpc/chainrpc"
 	"github.com/lightningnetwork/lnd/lnrpc/invoicesrpc"
+	"github.com/lightningnetwork/lnd/lnrpc/routerrpc"
 	"github.com/lightningnetwork/lnd/lnrpc/signrpc"
 	"github.com/lightningnetwork/lnd/lnrpc/walletrpc"
 	"github.com/lightningnetwork/lnd/lnwallet"
@@ -108,6 +109,16 @@ func init() {
 	chainrpc.UseLogger(ntfrLog)
 	invoicesrpc.UseLogger(irpcLog)
 	channelnotifier.UseLogger(chnfLog)
+
+	addSubLogger(routerrpc.Subsystem, routerrpc.UseLogger)
+}
+
+// addSubLogger is a helper method to conveniently register the logger of a sub
+// system.
+func addSubLogger(subsystem string, useLogger func(btclog.Logger)) {
+	logger := build.NewSubLogger(subsystem, backendLog.Logger)
+	useLogger(logger)
+	subsystemLoggers[subsystem] = logger
 }
 
 // subsystemLoggers maps each subsystem identifier to its associated logger.


### PR DESCRIPTION
This PR register the `routerrpc` sub server logger so that its log level can be set.