### PR TITLE
lntest/timeout: split into darwin and non-darwin timeouts

### DIFF
--- a/lnd_test.go
+++ b/lnd_test.go
@@ -625,9 +625,8 @@ func makeFakePayHash(t *harnessTest) []byte {
 
 // createPayReqs is a helper method that will create a slice of payment
 // requests for the given node.
-func createPayReqs(ctx context.Context, node *lntest.HarnessNode,
-	paymentAmt btcutil.Amount, numInvoices int) ([]string, [][]byte,
-	[]*lnrpc.Invoice, error) {
+func createPayReqs(node *lntest.HarnessNode, paymentAmt btcutil.Amount,
+	numInvoices int) ([]string, [][]byte, []*lnrpc.Invoice, error) {
 
 	payReqs := make([]string, numInvoices)
 	rHashes := make([][]byte, numInvoices)
@@ -644,7 +643,10 @@ func createPayReqs(ctx context.Context, node *lntest.HarnessNode,
 			RPreimage: preimage,
 			Value:     int64(paymentAmt),
 		}
-		resp, err := node.AddInvoice(ctx, invoice)
+		ctxt, _ := context.WithTimeout(
+			context.Background(), defaultTimeout,
+		)
+		resp, err := node.AddInvoice(ctxt, invoice)
 		if err != nil {
 			return nil, nil, nil, fmt.Errorf("unable to add "+
 				"invoice: %v", err)
@@ -4045,9 +4047,8 @@ func testMultiHopPayments(net *lntest.NetworkHarness, t *harnessTest) {
 	// satoshis with a different preimage each time.
 	const numPayments = 5
 	const paymentAmt = 1000
-	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
 	payReqs, _, _, err := createPayReqs(
-		ctxt, net.Bob, paymentAmt, numPayments,
+		net.Bob, paymentAmt, numPayments,
 	)
 	if err != nil {
 		t.Fatalf("unable to create pay reqs: %v", err)
@@ -4270,9 +4271,8 @@ func testSingleHopSendToRoute(net *lntest.NetworkHarness, t *harnessTest) {
 	// Create 5 invoices for Bob, which expect a payment from Alice for 1k
 	// satoshis with a different preimage each time.
 	const numPayments = 5
-	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
 	_, rHashes, _, err := createPayReqs(
-		ctxt, net.Bob, paymentAmt, numPayments,
+		net.Bob, paymentAmt, numPayments,
 	)
 	if err != nil {
 		t.Fatalf("unable to create pay reqs: %v", err)
@@ -4455,9 +4455,8 @@ func testMultiHopSendToRoute(net *lntest.NetworkHarness, t *harnessTest) {
 	// Create 5 invoices for Carol, which expect a payment from Alice for 1k
 	// satoshis with a different preimage each time.
 	const numPayments = 5
-	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
 	_, rHashes, _, err := createPayReqs(
-		ctxt, carol, paymentAmt, numPayments,
+		carol, paymentAmt, numPayments,
 	)
 	if err != nil {
 		t.Fatalf("unable to create pay reqs: %v", err)
@@ -4982,9 +4981,8 @@ func testPrivateChannels(net *lntest.NetworkHarness, t *harnessTest) {
 	// by only using one of the channels.
 	const numPayments = 2
 	const paymentAmt = 70000
-	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
 	payReqs, _, _, err := createPayReqs(
-		ctxt, net.Bob, paymentAmt, numPayments,
+		net.Bob, paymentAmt, numPayments,
 	)
 	if err != nil {
 		t.Fatalf("unable to create pay reqs: %v", err)
@@ -5039,9 +5037,8 @@ func testPrivateChannels(net *lntest.NetworkHarness, t *harnessTest) {
 	// Alice should also be able to route payments using this channel,
 	// so send two payments of 60k back to Carol.
 	const paymentAmt60k = 60000
-	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
 	payReqs, _, _, err = createPayReqs(
-		ctxt, carol, paymentAmt60k, numPayments,
+		carol, paymentAmt60k, numPayments,
 	)
 	if err != nil {
 		t.Fatalf("unable to create pay reqs: %v", err)
@@ -5702,9 +5699,8 @@ func testInvoiceSubscriptions(net *lntest.NetworkHarness, t *harnessTest) {
 
 	// We'll now add 3 more invoices to Bob's invoice registry.
 	const numInvoices = 3
-	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
 	payReqs, _, newInvoices, err := createPayReqs(
-		ctxt, net.Bob, paymentAmt, numInvoices,
+		net.Bob, paymentAmt, numInvoices,
 	)
 	if err != nil {
 		t.Fatalf("unable to create pay reqs: %v", err)
@@ -6720,9 +6716,8 @@ func testRevokedCloseRetribution(net *lntest.NetworkHarness, t *harnessTest) {
 
 	// With the channel open, we'll create a few invoices for Bob that
 	// Carol will pay to in order to advance the state of the channel.
-	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
 	bobPayReqs, _, _, err := createPayReqs(
-		ctxt, net.Bob, paymentAmt, numInvoices,
+		net.Bob, paymentAmt, numInvoices,
 	)
 	if err != nil {
 		t.Fatalf("unable to create pay reqs: %v", err)
@@ -6984,9 +6979,8 @@ func testRevokedCloseRetributionZeroValueRemoteOutput(net *lntest.NetworkHarness
 
 	// With the channel open, we'll create a few invoices for Carol that
 	// Dave will pay to in order to advance the state of the channel.
-	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
 	carolPayReqs, _, _, err := createPayReqs(
-		ctxt, carol, paymentAmt, numInvoices,
+		carol, paymentAmt, numInvoices,
 	)
 	if err != nil {
 		t.Fatalf("unable to create pay reqs: %v", err)
@@ -7236,9 +7230,8 @@ func testRevokedCloseRetributionRemoteHodl(net *lntest.NetworkHarness,
 
 	// With the channel open, we'll create a few invoices for Carol that
 	// Dave will pay to in order to advance the state of the channel.
-	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
 	carolPayReqs, _, _, err := createPayReqs(
-		ctxt, carol, paymentAmt, numInvoices,
+		carol, paymentAmt, numInvoices,
 	)
 	if err != nil {
 		t.Fatalf("unable to create pay reqs: %v", err)
@@ -7299,9 +7292,8 @@ func testRevokedCloseRetributionRemoteHodl(net *lntest.NetworkHarness,
 	// At this point, we'll also send over a set of HTLC's from Carol to
 	// Dave. This ensures that the final revoked transaction has HTLC's in
 	// both directions.
-	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
 	davePayReqs, _, _, err := createPayReqs(
-		ctxt, dave, paymentAmt, numInvoices,
+		dave, paymentAmt, numInvoices,
 	)
 	if err != nil {
 		t.Fatalf("unable to create pay reqs: %v", err)
@@ -7690,9 +7682,8 @@ func testDataLossProtection(net *lntest.NetworkHarness, t *harnessTest) {
 		// the channel.
 		// TODO(halseth): have dangling HTLCs on the commitment, able to
 		// retrive funds?
-		ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
 		payReqs, _, _, err := createPayReqs(
-			ctxt, node, paymentAmt, numInvoices,
+			node, paymentAmt, numInvoices,
 		)
 		if err != nil {
 			t.Fatalf("unable to create pay reqs: %v", err)
@@ -8878,9 +8869,8 @@ func testAsyncPayments(net *lntest.NetworkHarness, t *harnessTest) {
 
 	// With the channel open, we'll create invoices for Bob that Alice
 	// will pay to in order to advance the state of the channel.
-	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
 	bobPayReqs, _, _, err := createPayReqs(
-		ctxt, net.Bob, paymentAmt, numInvoices,
+		net.Bob, paymentAmt, numInvoices,
 	)
 	if err != nil {
 		t.Fatalf("unable to create pay reqs: %v", err)
@@ -9030,9 +9020,8 @@ func testBidirectionalAsyncPayments(net *lntest.NetworkHarness, t *harnessTest) 
 
 	// With the channel open, we'll create invoices for Bob that Alice
 	// will pay to in order to advance the state of the channel.
-	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
 	bobPayReqs, _, _, err := createPayReqs(
-		ctxt, net.Bob, paymentAmt, numInvoices,
+		net.Bob, paymentAmt, numInvoices,
 	)
 	if err != nil {
 		t.Fatalf("unable to create pay reqs: %v", err)
@@ -9040,9 +9029,8 @@ func testBidirectionalAsyncPayments(net *lntest.NetworkHarness, t *harnessTest) 
 
 	// With the channel open, we'll create invoices for Alice that Bob
 	// will pay to in order to advance the state of the channel.
-	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
 	alicePayReqs, _, _, err := createPayReqs(
-		ctxt, net.Alice, paymentAmt, numInvoices,
+		net.Alice, paymentAmt, numInvoices,
 	)
 	if err != nil {
 		t.Fatalf("unable to create pay reqs: %v", err)
@@ -11143,9 +11131,8 @@ func testSwitchCircuitPersistence(net *lntest.NetworkHarness, t *harnessTest) {
 	// satoshis with a different preimage each time.
 	const numPayments = 5
 	const paymentAmt = 1000
-	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
 	payReqs, _, _, err := createPayReqs(
-		ctxt, carol, paymentAmt, numPayments,
+		carol, paymentAmt, numPayments,
 	)
 	if err != nil {
 		t.Fatalf("unable to create pay reqs: %v", err)
@@ -11483,9 +11470,8 @@ func testSwitchOfflineDelivery(net *lntest.NetworkHarness, t *harnessTest) {
 	// satoshis with a different preimage each time.
 	const numPayments = 5
 	const paymentAmt = 1000
-	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
 	payReqs, _, _, err := createPayReqs(
-		ctxt, carol, paymentAmt, numPayments,
+		carol, paymentAmt, numPayments,
 	)
 	if err != nil {
 		t.Fatalf("unable to create pay reqs: %v", err)
@@ -11831,9 +11817,8 @@ func testSwitchOfflineDeliveryPersistence(net *lntest.NetworkHarness, t *harness
 	// satoshis with a different preimage each time.
 	const numPayments = 5
 	const paymentAmt = 1000
-	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
 	payReqs, _, _, err := createPayReqs(
-		ctxt, carol, paymentAmt, numPayments,
+		carol, paymentAmt, numPayments,
 	)
 	if err != nil {
 		t.Fatalf("unable to create pay reqs: %v", err)
@@ -12182,9 +12167,8 @@ func testSwitchOfflineDeliveryOutgoingOffline(
 	// satoshis with a different preimage each time.
 	const numPayments = 5
 	const paymentAmt = 1000
-	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
 	payReqs, _, _, err := createPayReqs(
-		ctxt, carol, paymentAmt, numPayments,
+		carol, paymentAmt, numPayments,
 	)
 	if err != nil {
 		t.Fatalf("unable to create pay reqs: %v", err)

--- a/lnd_test.go
+++ b/lnd_test.go
@@ -8887,7 +8887,7 @@ func testAsyncPayments(net *lntest.NetworkHarness, t *harnessTest) {
 	// Open up a payment stream to Alice that we'll use to send payment to
 	// Bob. We also create a small helper function to send payments to Bob,
 	// consuming the payment hashes we generated above.
-	ctxt, _ = context.WithTimeout(ctxb, time.Minute)
+	ctxt, _ = context.WithTimeout(ctxb, lntest.AsyncBenchmarkTimeout)
 	alicePayStream, err := net.Alice.SendPayment(ctxt)
 	if err != nil {
 		t.Fatalf("unable to create payment stream for alice: %v", err)

--- a/lntest/harness.go
+++ b/lntest/harness.go
@@ -24,27 +24,8 @@ import (
 	"github.com/lightningnetwork/lnd/lnwire"
 )
 
-const (
-	// DefaultCSV is the CSV delay (remotedelay) we will start our test
-	// nodes with.
-	DefaultCSV = 4
-
-	// MinerMempoolTimeout is the max time we will wait for a transaction
-	// to propagate to the mining node's mempool.
-	MinerMempoolTimeout = time.Second * 30
-
-	// ChannelOpenTimeout is the max time we will wait before a channel to
-	// be considered opened.
-	ChannelOpenTimeout = time.Second * 30
-
-	// ChannelCloseTimeout is the max time we will wait before a channel is
-	// considered closed.
-	ChannelCloseTimeout = time.Second * 30
-
-	// DefaultTimeout is a timeout that will be used for various wait
-	// scenarios where no custom timeout value is defined.
-	DefaultTimeout = time.Second * 30
-)
+// DefaultCSV is the CSV delay (remotedelay) we will start our test nodes with.
+const DefaultCSV = 4
 
 // NetworkHarness is an integration testing harness for the lightning network.
 // The harness by default is created with two active nodes on the network:

--- a/lntest/timeouts.go
+++ b/lntest/timeouts.go
@@ -1,0 +1,27 @@
+// +build !darwin
+
+package lntest
+
+import "time"
+
+const (
+	// MinerMempoolTimeout is the max time we will wait for a transaction
+	// to propagate to the mining node's mempool.
+	MinerMempoolTimeout = time.Second * 30
+
+	// ChannelOpenTimeout is the max time we will wait before a channel to
+	// be considered opened.
+	ChannelOpenTimeout = time.Second * 30
+
+	// ChannelCloseTimeout is the max time we will wait before a channel is
+	// considered closed.
+	ChannelCloseTimeout = time.Second * 30
+
+	// DefaultTimeout is a timeout that will be used for various wait
+	// scenarios where no custom timeout value is defined.
+	DefaultTimeout = time.Second * 30
+
+	// AsyncBenchmarkTimeout is the timeout used when running the async
+	// payments benchmark.
+	AsyncBenchmarkTimeout = time.Minute
+)

--- a/lntest/timeouts_darwin.go
+++ b/lntest/timeouts_darwin.go
@@ -1,0 +1,28 @@
+// +build darwin
+
+package lntest
+
+import "time"
+
+const (
+	// MinerMempoolTimeout is the max time we will wait for a transaction
+	// to propagate to the mining node's mempool.
+	MinerMempoolTimeout = time.Second * 30
+
+	// ChannelOpenTimeout is the max time we will wait before a channel to
+	// be considered opened.
+	ChannelOpenTimeout = time.Second * 30
+
+	// ChannelCloseTimeout is the max time we will wait before a channel is
+	// considered closed.
+	ChannelCloseTimeout = time.Second * 30
+
+	// DefaultTimeout is a timeout that will be used for various wait
+	// scenarios where no custom timeout value is defined.
+	DefaultTimeout = time.Second * 30
+
+	// AsyncBenchmarkTimeout is the timeout used when running the async
+	// payments benchmark. This timeout takes considerably longer on darwin
+	// after go1.12 corrected its use of fsync.
+	AsyncBenchmarkTimeout = time.Minute * 3
+)


### PR DESCRIPTION
Splits out the `lntest` timeout constants into darwin and non-darwin variants. This is required for the `async_payment_benchmark` to pass reliably, as it suffers from a regression starting with go1.12+darwin after correcting the standard library's usage of fsync. See https://github.com/golang/go/issues/26650 and https://github.com/golang/go/issues/27415.