### PR TITLE
channeldb: add reject and channel caches

### DIFF
--- a/channeldb/channel.go
+++ b/channeldb/channel.go
@@ -1027,7 +1027,7 @@ func (c *OpenChannel) UpdateCommitment(newCommitment *ChannelCommitment) error {
 		return ErrNoRestoredChannelMutation
 	}
 
-	err := c.Db.Batch(func(tx *bbolt.Tx) error {
+	err := c.Db.Update(func(tx *bbolt.Tx) error {
 		chanBucket, err := fetchChanBucket(
 			tx, c.IdentityPub, &c.FundingOutpoint, c.ChainHash,
 		)
@@ -1465,7 +1465,7 @@ func (c *OpenChannel) AppendRemoteCommitChain(diff *CommitDiff) error {
 		return ErrNoRestoredChannelMutation
 	}
 
-	return c.Db.Batch(func(tx *bbolt.Tx) error {
+	return c.Db.Update(func(tx *bbolt.Tx) error {
 		// First, we'll grab the writable bucket where this channel's
 		// data resides.
 		chanBucket, err := fetchChanBucket(
@@ -1608,9 +1608,7 @@ func (c *OpenChannel) AdvanceCommitChainTail(fwdPkg *FwdPkg) error {
 
 	var newRemoteCommit *ChannelCommitment
 
-	err := c.Db.Batch(func(tx *bbolt.Tx) error {
-		newRemoteCommit = nil
-
+	err := c.Db.Update(func(tx *bbolt.Tx) error {
 		chanBucket, err := fetchChanBucket(
 			tx, c.IdentityPub, &c.FundingOutpoint, c.ChainHash,
 		)
@@ -1748,7 +1746,7 @@ func (c *OpenChannel) AckAddHtlcs(addRefs ...AddRef) error {
 	c.Lock()
 	defer c.Unlock()
 
-	return c.Db.Batch(func(tx *bbolt.Tx) error {
+	return c.Db.Update(func(tx *bbolt.Tx) error {
 		return c.Packager.AckAddHtlcs(tx, addRefs...)
 	})
 }
@@ -1761,7 +1759,7 @@ func (c *OpenChannel) AckSettleFails(settleFailRefs ...SettleFailRef) error {
 	c.Lock()
 	defer c.Unlock()
 
-	return c.Db.Batch(func(tx *bbolt.Tx) error {
+	return c.Db.Update(func(tx *bbolt.Tx) error {
 		return c.Packager.AckSettleFails(tx, settleFailRefs...)
 	})
 }
@@ -1772,7 +1770,7 @@ func (c *OpenChannel) SetFwdFilter(height uint64, fwdFilter *PkgFilter) error {
 	c.Lock()
 	defer c.Unlock()
 
-	return c.Db.Batch(func(tx *bbolt.Tx) error {
+	return c.Db.Update(func(tx *bbolt.Tx) error {
 		return c.Packager.SetFwdFilter(tx, height, fwdFilter)
 	})
 }
@@ -1785,15 +1783,14 @@ func (c *OpenChannel) RemoveFwdPkg(height uint64) error {
 	c.Lock()
 	defer c.Unlock()
 
-	return c.Db.Batch(func(tx *bbolt.Tx) error {
+	return c.Db.Update(func(tx *bbolt.Tx) error {
 		return c.Packager.RemovePkg(tx, height)
 	})
 }
 
 // RevocationLogTail returns the "tail", or the end of the current revocation
 // log. This entry represents the last previous state for the remote node's
-// commitment chain. The ChannelDelta returned by this method will always lag
-// one state behind the most current (unrevoked) state of the remote node's
+// commitment chain. The ChannelDelta returned by this method will always lag one state behind the most current (unrevoked) state of the remote node's
 // commitment chain.
 func (c *OpenChannel) RevocationLogTail() (*ChannelCommitment, error) {
 	c.RLock()

--- a/channeldb/channel_cache.go
+++ b/channeldb/channel_cache.go
@@ -1,0 +1,50 @@
+package channeldb
+
+// channelCache is an in-memory cache used to improve the performance of
+// ChanUpdatesInHorizon. It caches the chan info and edge policies for a
+// particular channel.
+type channelCache struct {
+	n        int
+	channels map[uint64]ChannelEdge
+}
+
+// newChannelCache creates a new channelCache with maximum capacity of n
+// channels.
+func newChannelCache(n int) *channelCache {
+	return &channelCache{
+		n:        n,
+		channels: make(map[uint64]ChannelEdge),
+	}
+}
+
+// get returns the channel from the cache, if it exists.
+func (c *channelCache) get(chanid uint64) (ChannelEdge, bool) {
+	channel, ok := c.channels[chanid]
+	return channel, ok
+}
+
+// insert adds the entry to the channel cache. If an entry for chanid already
+// exists, it will be replaced with the new entry. If the entry doesn't exist,
+// it will be inserted to the cache, performing a random eviction if the cache
+// is at capacity.
+func (c *channelCache) insert(chanid uint64, channel ChannelEdge) {
+	// If entry exists, replace it.
+	if _, ok := c.channels[chanid]; ok {
+		c.channels[chanid] = channel
+		return
+	}
+
+	// Otherwise, evict an entry at random and insert.
+	if len(c.channels) == c.n {
+		for id := range c.channels {
+			delete(c.channels, id)
+			break
+		}
+	}
+	c.channels[chanid] = channel
+}
+
+// remove deletes an edge for chanid from the cache, if it exists.
+func (c *channelCache) remove(chanid uint64) {
+	delete(c.channels, chanid)
+}

--- a/channeldb/channel_cache_test.go
+++ b/channeldb/channel_cache_test.go
@@ -1,0 +1,105 @@
+package channeldb
+
+import (
+	"reflect"
+	"testing"
+)
+
+// TestChannelCache checks the behavior of the channelCache with respect to
+// insertion, eviction, and removal of cache entries.
+func TestChannelCache(t *testing.T) {
+	const cacheSize = 100
+
+	// Create a new channel cache with the configured max size.
+	c := newChannelCache(cacheSize)
+
+	// As a sanity check, assert that querying the empty cache does not
+	// return an entry.
+	_, ok := c.get(0)
+	if ok {
+		t.Fatalf("channel cache should be empty")
+	}
+
+	// Now, fill up the cache entirely.
+	for i := uint64(0); i < cacheSize; i++ {
+		c.insert(i, channelForInt(i))
+	}
+
+	// Assert that the cache has all of the entries just inserted, since no
+	// eviction should occur until we try to surpass the max size.
+	assertHasChanEntries(t, c, 0, cacheSize)
+
+	// Now, insert a new element that causes the cache to evict an element.
+	c.insert(cacheSize, channelForInt(cacheSize))
+
+	// Assert that the cache has this last entry, as the cache should evict
+	// some prior element and not the newly inserted one.
+	assertHasChanEntries(t, c, cacheSize, cacheSize)
+
+	// Iterate over all inserted elements and construct a set of the evicted
+	// elements.
+	evicted := make(map[uint64]struct{})
+	for i := uint64(0); i < cacheSize+1; i++ {
+		_, ok := c.get(i)
+		if !ok {
+			evicted[i] = struct{}{}
+		}
+	}
+
+	// Assert that exactly one element has been evicted.
+	numEvicted := len(evicted)
+	if numEvicted != 1 {
+		t.Fatalf("expected one evicted entry, got: %d", numEvicted)
+	}
+
+	// Remove the highest item which initially caused the eviction and
+	// reinsert the element that was evicted prior.
+	c.remove(cacheSize)
+	for i := range evicted {
+		c.insert(i, channelForInt(i))
+	}
+
+	// Since the removal created an extra slot, the last insertion should
+	// not have caused an eviction and the entries for all channels in the
+	// original set that filled the cache should be present.
+	assertHasChanEntries(t, c, 0, cacheSize)
+
+	// Finally, reinsert the existing set back into the cache and test that
+	// the cache still has all the entries. If the randomized eviction were
+	// happening on inserts for existing cache items, we expect this to fail
+	// with high probability.
+	for i := uint64(0); i < cacheSize; i++ {
+		c.insert(i, channelForInt(i))
+	}
+	assertHasChanEntries(t, c, 0, cacheSize)
+
+}
+
+// assertHasEntries queries the edge cache for all channels in the range [start,
+// end), asserting that they exist and their value matches the entry produced by
+// entryForInt.
+func assertHasChanEntries(t *testing.T, c *channelCache, start, end uint64) {
+	t.Helper()
+
+	for i := start; i < end; i++ {
+		entry, ok := c.get(i)
+		if !ok {
+			t.Fatalf("channel cache should contain chan %d", i)
+		}
+
+		expEntry := channelForInt(i)
+		if !reflect.DeepEqual(entry, expEntry) {
+			t.Fatalf("entry mismatch, want: %v, got: %v",
+				expEntry, entry)
+		}
+	}
+}
+
+// channelForInt generates a unique ChannelEdge given an integer.
+func channelForInt(i uint64) ChannelEdge {
+	return ChannelEdge{
+		Info: &ChannelEdgeInfo{
+			ChannelID: i,
+		},
+	}
+}

--- a/channeldb/db.go
+++ b/channeldb/db.go
@@ -992,7 +992,7 @@ func (d *DB) RestoreChannelShells(channelShells ...*ChannelShell) error {
 				chanEdge.ChannelFlags |= lnwire.ChanUpdateDirection
 			}
 
-			err = updateEdgePolicy(tx, &chanEdge)
+			_, err = updateEdgePolicy(tx, &chanEdge)
 			if err != nil {
 				return err
 			}

--- a/channeldb/db.go
+++ b/channeldb/db.go
@@ -7,7 +7,6 @@ import (
 	"net"
 	"os"
 	"path/filepath"
-	"sync"
 	"time"
 
 	"github.com/btcsuite/btcd/btcec"
@@ -103,10 +102,6 @@ var (
 	// integer keys iterating in order.
 	byteOrder = binary.BigEndian
 )
-
-var bufPool = &sync.Pool{
-	New: func() interface{} { return new(bytes.Buffer) },
-}
 
 // DB is the primary datastore for the lnd daemon. The database stores
 // information related to nodes, routing data, open/closed channels, fee

--- a/channeldb/graph.go
+++ b/channeldb/graph.go
@@ -165,11 +165,11 @@ type ChannelGraph struct {
 
 // newChannelGraph allocates a new ChannelGraph backed by a DB instance. The
 // returned instance has its own unique reject cache and channel cache.
-func newChannelGraph(db *DB) *ChannelGraph {
+func newChannelGraph(db *DB, rejectCacheSize, chanCacheSize int) *ChannelGraph {
 	return &ChannelGraph{
 		db:          db,
-		rejectCache: newRejectCache(50000),
-		chanCache:   newChannelCache(20000),
+		rejectCache: newRejectCache(rejectCacheSize),
+		chanCache:   newChannelCache(chanCacheSize),
 	}
 }
 

--- a/channeldb/graph.go
+++ b/channeldb/graph.go
@@ -334,7 +334,7 @@ func (c *ChannelGraph) sourceNode(nodes *bbolt.Bucket) (*LightningNode, error) {
 func (c *ChannelGraph) SetSourceNode(node *LightningNode) error {
 	nodePubBytes := node.PubKeyBytes[:]
 
-	return c.db.Batch(func(tx *bbolt.Tx) error {
+	return c.db.Update(func(tx *bbolt.Tx) error {
 		// First grab the nodes bucket which stores the mapping from
 		// pubKey to node information.
 		nodes, err := tx.CreateBucketIfNotExists(nodeBucket)
@@ -363,7 +363,7 @@ func (c *ChannelGraph) SetSourceNode(node *LightningNode) error {
 //
 // TODO(roasbeef): also need sig of announcement
 func (c *ChannelGraph) AddLightningNode(node *LightningNode) error {
-	return c.db.Batch(func(tx *bbolt.Tx) error {
+	return c.db.Update(func(tx *bbolt.Tx) error {
 		return addLightningNode(tx, node)
 	})
 }
@@ -427,7 +427,7 @@ func (c *ChannelGraph) LookupAlias(pub *btcec.PublicKey) (string, error) {
 // from the database according to the node's public key.
 func (c *ChannelGraph) DeleteLightningNode(nodePub *btcec.PublicKey) error {
 	// TODO(roasbeef): ensure dangling edges are removed...
-	return c.db.Batch(func(tx *bbolt.Tx) error {
+	return c.db.Update(func(tx *bbolt.Tx) error {
 		nodes := tx.Bucket(nodeBucket)
 		if nodes == nil {
 			return ErrGraphNodeNotFound
@@ -491,7 +491,7 @@ func (c *ChannelGraph) deleteLightningNode(nodes *bbolt.Bucket,
 // the channel supports. The chanPoint and chanID are used to uniquely identify
 // the edge globally within the database.
 func (c *ChannelGraph) AddChannelEdge(edge *ChannelEdgeInfo) error {
-	return c.db.Batch(func(tx *bbolt.Tx) error {
+	return c.db.Update(func(tx *bbolt.Tx) error {
 		return c.addChannelEdge(tx, edge)
 	})
 }
@@ -675,7 +675,7 @@ func (c *ChannelGraph) UpdateChannelEdge(edge *ChannelEdgeInfo) error {
 	var chanKey [8]byte
 	binary.BigEndian.PutUint64(chanKey[:], edge.ChannelID)
 
-	return c.db.Batch(func(tx *bbolt.Tx) error {
+	return c.db.Update(func(tx *bbolt.Tx) error {
 		edges := tx.Bucket(edgeBucket)
 		if edge == nil {
 			return ErrEdgeNotFound
@@ -715,9 +715,7 @@ func (c *ChannelGraph) PruneGraph(spentOutputs []*wire.OutPoint,
 
 	var chansClosed []*ChannelEdgeInfo
 
-	err := c.db.Batch(func(tx *bbolt.Tx) error {
-		chansClosed = nil
-
+	err := c.db.Update(func(tx *bbolt.Tx) error {
 		// First grab the edges bucket which houses the information
 		// we'd like to delete
 		edges, err := tx.CreateBucketIfNotExists(edgeBucket)
@@ -826,7 +824,7 @@ func (c *ChannelGraph) PruneGraph(spentOutputs []*wire.OutPoint,
 // that we only maintain a graph of reachable nodes. In the event that a pruned
 // node gains more channels, it will be re-added back to the graph.
 func (c *ChannelGraph) PruneGraphNodes() error {
-	return c.db.Batch(func(tx *bbolt.Tx) error {
+	return c.db.Update(func(tx *bbolt.Tx) error {
 		nodes := tx.Bucket(nodeBucket)
 		if nodes == nil {
 			return ErrGraphNodesNotFound
@@ -971,9 +969,7 @@ func (c *ChannelGraph) DisconnectBlockAtHeight(height uint32) ([]*ChannelEdgeInf
 	// Keep track of the channels that are removed from the graph.
 	var removedChans []*ChannelEdgeInfo
 
-	if err := c.db.Batch(func(tx *bbolt.Tx) error {
-		removedChans = nil
-
+	if err := c.db.Update(func(tx *bbolt.Tx) error {
 		edges, err := tx.CreateBucketIfNotExists(edgeBucket)
 		if err != nil {
 			return err
@@ -1103,7 +1099,7 @@ func (c *ChannelGraph) DeleteChannelEdge(chanPoint *wire.OutPoint) error {
 	// channels
 	// TODO(roasbeef): don't delete both edges?
 
-	return c.db.Batch(func(tx *bbolt.Tx) error {
+	return c.db.Update(func(tx *bbolt.Tx) error {
 		// First grab the edges bucket which houses the information
 		// we'd like to delete
 		edges := tx.Bucket(edgeBucket)
@@ -1696,7 +1692,7 @@ func delChannelByEdge(edges, edgeIndex, chanIndex, zombieIndex,
 // determined by the lexicographical ordering of the identity public keys of
 // the nodes on either side of the channel.
 func (c *ChannelGraph) UpdateEdgePolicy(edge *ChannelEdgePolicy) error {
-	return c.db.Batch(func(tx *bbolt.Tx) error {
+	return c.db.Update(func(tx *bbolt.Tx) error {
 		return updateEdgePolicy(tx, edge)
 	})
 }

--- a/channeldb/graph.go
+++ b/channeldb/graph.go
@@ -162,6 +162,13 @@ type ChannelGraph struct {
 	//  * LRU cache for edges?
 }
 
+// newChannelGraph allocates a new ChannelGraph backed by a DB instance.
+func newChannelGraph(db *DB) *ChannelGraph {
+	return &ChannelGraph{
+		db: db,
+	}
+}
+
 // Database returns a pointer to the underlying database.
 func (c *ChannelGraph) Database() *DB {
 	return c.db

--- a/channeldb/invoices.go
+++ b/channeldb/invoices.go
@@ -242,9 +242,7 @@ func (d *DB) AddInvoice(newInvoice *Invoice, paymentHash lntypes.Hash) (
 	}
 
 	var invoiceAddIndex uint64
-	err := d.Batch(func(tx *bbolt.Tx) error {
-		invoiceAddIndex = 0
-
+	err := d.Update(func(tx *bbolt.Tx) error {
 		invoices, err := tx.CreateBucketIfNotExists(invoiceBucket)
 		if err != nil {
 			return err
@@ -637,9 +635,7 @@ func (d *DB) AcceptOrSettleInvoice(paymentHash [32]byte,
 	amtPaid lnwire.MilliSatoshi) (*Invoice, error) {
 
 	var settledInvoice *Invoice
-	err := d.Batch(func(tx *bbolt.Tx) error {
-		settledInvoice = nil
-
+	err := d.Update(func(tx *bbolt.Tx) error {
 		invoices, err := tx.CreateBucketIfNotExists(invoiceBucket)
 		if err != nil {
 			return err
@@ -718,9 +714,7 @@ func (d *DB) SettleHoldInvoice(preimage lntypes.Preimage) (*Invoice, error) {
 // payment hash.
 func (d *DB) CancelInvoice(paymentHash lntypes.Hash) (*Invoice, error) {
 	var canceledInvoice *Invoice
-	err := d.Batch(func(tx *bbolt.Tx) error {
-		canceledInvoice = nil
-
+	err := d.Update(func(tx *bbolt.Tx) error {
 		invoices, err := tx.CreateBucketIfNotExists(invoiceBucket)
 		if err != nil {
 			return err

--- a/channeldb/migrations.go
+++ b/channeldb/migrations.go
@@ -564,7 +564,7 @@ func migratePruneEdgeUpdateIndex(tx *bbolt.Tx) error {
 			return err
 		}
 
-		err = updateEdgePolicy(tx, edgePolicy)
+		_, err = updateEdgePolicy(tx, edgePolicy)
 		if err != nil {
 			return err
 		}

--- a/channeldb/options.go
+++ b/channeldb/options.go
@@ -1,0 +1,49 @@
+package channeldb
+
+const (
+	// DefaultRejectCacheSize is the default number of rejectCacheEntries to
+	// cache for use in the rejection cache of incoming gossip traffic. This
+	// produces a cache size of around 1MB.
+	DefaultRejectCacheSize = 50000
+
+	// DefaultChannelCacheSize is the default number of ChannelEdges cached
+	// in order to reply to gossip queries. This produces a cache size of
+	// around 40MB.
+	DefaultChannelCacheSize = 20000
+)
+
+// Options holds parameters for tuning and customizing a channeldb.DB.
+type Options struct {
+	// RejectCacheSize is the maximum number of rejectCacheEntries to hold
+	// in the rejection cache.
+	RejectCacheSize int
+
+	// ChannelCacheSize is the maximum number of ChannelEdges to hold in the
+	// channel cache.
+	ChannelCacheSize int
+}
+
+// DefaultOptions returns an Options populated with default values.
+func DefaultOptions() Options {
+	return Options{
+		RejectCacheSize:  DefaultRejectCacheSize,
+		ChannelCacheSize: DefaultChannelCacheSize,
+	}
+}
+
+// OptionModifier is a function signature for modifying the default Options.
+type OptionModifier func(*Options)
+
+// OptionSetRejectCacheSize sets the RejectCacheSize to n.
+func OptionSetRejectCacheSize(n int) OptionModifier {
+	return func(o *Options) {
+		o.RejectCacheSize = n
+	}
+}
+
+// OptionSetChannelCacheSize sets the ChannelCacheSize to n.
+func OptionSetChannelCacheSize(n int) OptionModifier {
+	return func(o *Options) {
+		o.ChannelCacheSize = n
+	}
+}

--- a/channeldb/reject_cache.go
+++ b/channeldb/reject_cache.go
@@ -1,0 +1,95 @@
+package channeldb
+
+// rejectFlags is a compact representation of various metadata stored by the
+// reject cache about a particular channel.
+type rejectFlags uint8
+
+const (
+	// rejectFlagExists is a flag indicating whether the channel exists,
+	// i.e. the channel is open and has a recent channel update. If this
+	// flag is not set, the channel is either a zombie or unknown.
+	rejectFlagExists rejectFlags = 1 << iota
+
+	// rejectFlagZombie is a flag indicating whether the channel is a
+	// zombie, i.e. the channel is open but has no recent channel updates.
+	rejectFlagZombie
+)
+
+// packRejectFlags computes the rejectFlags corresponding to the passed boolean
+// values indicating whether the edge exists or is a zombie.
+func packRejectFlags(exists, isZombie bool) rejectFlags {
+	var flags rejectFlags
+	if exists {
+		flags |= rejectFlagExists
+	}
+	if isZombie {
+		flags |= rejectFlagZombie
+	}
+
+	return flags
+}
+
+// unpack returns the booleans packed into the rejectFlags. The first indicates
+// if the edge exists in our graph, the second indicates if the edge is a
+// zombie.
+func (f rejectFlags) unpack() (bool, bool) {
+	return f&rejectFlagExists == rejectFlagExists,
+		f&rejectFlagZombie == rejectFlagZombie
+}
+
+// rejectCacheEntry caches frequently accessed information about a channel,
+// including the timestamps of its latest edge policies and whether or not the
+// channel exists in the graph.
+type rejectCacheEntry struct {
+	upd1Time int64
+	upd2Time int64
+	flags    rejectFlags
+}
+
+// rejectCache is an in-memory cache used to improve the performance of
+// HasChannelEdge. It caches information about the whether or channel exists, as
+// well as the most recent timestamps for each policy (if they exists).
+type rejectCache struct {
+	n     int
+	edges map[uint64]rejectCacheEntry
+}
+
+// newRejectCache creates a new rejectCache with maximum capacity of n entries.
+func newRejectCache(n int) *rejectCache {
+	return &rejectCache{
+		n:     n,
+		edges: make(map[uint64]rejectCacheEntry, n),
+	}
+}
+
+// get returns the entry from the cache for chanid, if it exists.
+func (c *rejectCache) get(chanid uint64) (rejectCacheEntry, bool) {
+	entry, ok := c.edges[chanid]
+	return entry, ok
+}
+
+// insert adds the entry to the reject cache. If an entry for chanid already
+// exists, it will be replaced with the new entry. If the entry doesn't exists,
+// it will be inserted to the cache, performing a random eviction if the cache
+// is at capacity.
+func (c *rejectCache) insert(chanid uint64, entry rejectCacheEntry) {
+	// If entry exists, replace it.
+	if _, ok := c.edges[chanid]; ok {
+		c.edges[chanid] = entry
+		return
+	}
+
+	// Otherwise, evict an entry at random and insert.
+	if len(c.edges) == c.n {
+		for id := range c.edges {
+			delete(c.edges, id)
+			break
+		}
+	}
+	c.edges[chanid] = entry
+}
+
+// remove deletes an entry for chanid from the cache, if it exists.
+func (c *rejectCache) remove(chanid uint64) {
+	delete(c.edges, chanid)
+}

--- a/channeldb/reject_cache_test.go
+++ b/channeldb/reject_cache_test.go
@@ -1,0 +1,107 @@
+package channeldb
+
+import (
+	"reflect"
+	"testing"
+)
+
+// TestRejectCache checks the behavior of the rejectCache with respect to insertion,
+// eviction, and removal of cache entries.
+func TestRejectCache(t *testing.T) {
+	const cacheSize = 100
+
+	// Create a new reject cache with the configured max size.
+	c := newRejectCache(cacheSize)
+
+	// As a sanity check, assert that querying the empty cache does not
+	// return an entry.
+	_, ok := c.get(0)
+	if ok {
+		t.Fatalf("reject cache should be empty")
+	}
+
+	// Now, fill up the cache entirely.
+	for i := uint64(0); i < cacheSize; i++ {
+		c.insert(i, entryForInt(i))
+	}
+
+	// Assert that the cache has all of the entries just inserted, since no
+	// eviction should occur until we try to surpass the max size.
+	assertHasEntries(t, c, 0, cacheSize)
+
+	// Now, insert a new element that causes the cache to evict an element.
+	c.insert(cacheSize, entryForInt(cacheSize))
+
+	// Assert that the cache has this last entry, as the cache should evict
+	// some prior element and not the newly inserted one.
+	assertHasEntries(t, c, cacheSize, cacheSize)
+
+	// Iterate over all inserted elements and construct a set of the evicted
+	// elements.
+	evicted := make(map[uint64]struct{})
+	for i := uint64(0); i < cacheSize+1; i++ {
+		_, ok := c.get(i)
+		if !ok {
+			evicted[i] = struct{}{}
+		}
+	}
+
+	// Assert that exactly one element has been evicted.
+	numEvicted := len(evicted)
+	if numEvicted != 1 {
+		t.Fatalf("expected one evicted entry, got: %d", numEvicted)
+	}
+
+	// Remove the highest item which initially caused the eviction and
+	// reinsert the element that was evicted prior.
+	c.remove(cacheSize)
+	for i := range evicted {
+		c.insert(i, entryForInt(i))
+	}
+
+	// Since the removal created an extra slot, the last insertion should
+	// not have caused an eviction and the entries for all channels in the
+	// original set that filled the cache should be present.
+	assertHasEntries(t, c, 0, cacheSize)
+
+	// Finally, reinsert the existing set back into the cache and test that
+	// the cache still has all the entries. If the randomized eviction were
+	// happening on inserts for existing cache items, we expect this to fail
+	// with high probability.
+	for i := uint64(0); i < cacheSize; i++ {
+		c.insert(i, entryForInt(i))
+	}
+	assertHasEntries(t, c, 0, cacheSize)
+
+}
+
+// assertHasEntries queries the reject cache for all channels in the range [start,
+// end), asserting that they exist and their value matches the entry produced by
+// entryForInt.
+func assertHasEntries(t *testing.T, c *rejectCache, start, end uint64) {
+	t.Helper()
+
+	for i := start; i < end; i++ {
+		entry, ok := c.get(i)
+		if !ok {
+			t.Fatalf("reject cache should contain chan %d", i)
+		}
+
+		expEntry := entryForInt(i)
+		if !reflect.DeepEqual(entry, expEntry) {
+			t.Fatalf("entry mismatch, want: %v, got: %v",
+				expEntry, entry)
+		}
+	}
+}
+
+// entryForInt generates a unique rejectCacheEntry given an integer.
+func entryForInt(i uint64) rejectCacheEntry {
+	exists := i%2 == 0
+	isZombie := i%3 == 0
+	return rejectCacheEntry{
+		upd1Time: int64(2 * i),
+		upd2Time: int64(2*i + 1),
+		flags:    packRejectFlags(exists, isZombie),
+	}
+}

--- a/config.go
+++ b/config.go
@@ -23,6 +23,7 @@ import (
 	flags "github.com/jessevdk/go-flags"
 	"github.com/lightningnetwork/lnd/build"
 	"github.com/lightningnetwork/lnd/chanbackup"
+	"github.com/lightningnetwork/lnd/channeldb"
 	"github.com/lightningnetwork/lnd/htlcswitch/hodl"
 	"github.com/lightningnetwork/lnd/lncfg"
 	"github.com/lightningnetwork/lnd/lnrpc/signrpc"
@@ -256,6 +257,8 @@ type config struct {
 	Routing *routing.Conf `group:"routing" namespace:"routing"`
 
 	Workers *lncfg.Workers `group:"workers" namespace:"workers"`
+
+	Caches *lncfg.Caches `group:"caches" namespace:"caches"`
 }
 
 // loadConfig initializes and parses the config using a config file and command
@@ -342,6 +345,10 @@ func loadConfig() (*config, error) {
 			Read:  lncfg.DefaultReadWorkers,
 			Write: lncfg.DefaultWriteWorkers,
 			Sig:   lncfg.DefaultSigWorkers,
+		},
+		Caches: &lncfg.Caches{
+			RejectCacheSize:  channeldb.DefaultRejectCacheSize,
+			ChannelCacheSize: channeldb.DefaultChannelCacheSize,
 		},
 	}
 
@@ -985,9 +992,12 @@ func loadConfig() (*config, error) {
 			"minbackoff")
 	}
 
-	// Assert that all worker pools will have a positive number of
-	// workers, otherwise the pools will rendered useless.
-	if err := cfg.Workers.Validate(); err != nil {
+	// Validate the subconfigs for workers and caches.
+	err = lncfg.Validate(
+		cfg.Workers,
+		cfg.Caches,
+	)
+	if err != nil {
 		return nil, err
 	}
 

--- a/lncfg/caches.go
+++ b/lncfg/caches.go
@@ -1,0 +1,45 @@
+package lncfg
+
+import "fmt"
+
+const (
+	// MinRejectCacheSize is a floor on the maximum capacity allowed for
+	// channeldb's reject cache. This amounts to roughly 125 KB when full.
+	MinRejectCacheSize = 5000
+
+	// MinChannelCacheSize is a floor on the maximum capacity allowed for
+	// channeldb's channel cache. This amounts to roughly 2 MB when full.
+	MinChannelCacheSize = 1000
+)
+
+// Caches holds the configuration for various caches within lnd.
+type Caches struct {
+	// RejectCacheSize is the maximum number of entries stored in lnd's
+	// reject cache, which is used for efficiently rejecting gossip updates.
+	// Memory usage is roughly 25b per entry.
+	RejectCacheSize int `long:"reject-cache-size" description:"Maximum number of entries contained in the reject cache, which is used to speed up filtering of new channel announcements and channel updates from peers. Each entry requires 25 bytes."`
+
+	// ChannelCacheSize is the maximum number of entries stored in lnd's
+	// channel cache, which is used reduce memory allocations in reply to
+	// peers querying for gossip traffic. Memory usage is roughly 2Kb per
+	// entry.
+	ChannelCacheSize int `long:"channel-cache-size" description:"Maximum number of entries contained in the channel cache, which is used to reduce memory allocations from gossip queries from peers. Each entry requires roughly 2Kb."`
+}
+
+// Validate checks the Caches configuration for values that are too small to be
+// sane.
+func (c *Caches) Validate() error {
+	if c.RejectCacheSize < MinRejectCacheSize {
+		return fmt.Errorf("reject cache size %d is less than min: %d",
+			c.RejectCacheSize, MinRejectCacheSize)
+	}
+	if c.ChannelCacheSize < MinChannelCacheSize {
+		return fmt.Errorf("channel cache size %d is less than min: %d",
+			c.ChannelCacheSize, MinChannelCacheSize)
+	}
+
+	return nil
+}
+
+// Compile-time constraint to ensure Caches implements the Validator interface.
+var _ Validator = (*Caches)(nil)

--- a/lncfg/interface.go
+++ b/lncfg/interface.go
@@ -1,0 +1,21 @@
+package lncfg
+
+// Validator is a generic interface for validating sub configurations.
+type Validator interface {
+	// Validate returns an error if a particular configuration is invalid or
+	// insane.
+	Validate() error
+}
+
+// Validate accepts a variadic list of Validators and checks that each one
+// passes its Validate method. An error is returned from the first Validator
+// that fails.
+func Validate(validators ...Validator) error {
+	for _, validator := range validators {
+		if err := validator.Validate(); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/lncfg/workers.go
+++ b/lncfg/workers.go
@@ -47,3 +47,6 @@ func (w *Workers) Validate() error {
 
 	return nil
 }
+
+// Compile-time constraint to ensure Workers implements the Validator interface.
+var _ Validator = (*Workers)(nil)

--- a/lnd.go
+++ b/lnd.go
@@ -161,7 +161,11 @@ func lndMain() error {
 
 	// Open the channeldb, which is dedicated to storing channel, and
 	// network related metadata.
-	chanDB, err := channeldb.Open(graphDir)
+	chanDB, err := channeldb.Open(
+		graphDir,
+		channeldb.OptionSetRejectCacheSize(cfg.Caches.RejectCacheSize),
+		channeldb.OptionSetChannelCacheSize(cfg.Caches.ChannelCacheSize),
+	)
 	if err != nil {
 		ltndLog.Errorf("unable to open channeldb: %v", err)
 		return err


### PR DESCRIPTION
This PR adds two caches housed within the channeldb to optimize two existing hot spots related to gossip traffic.

## Reject Cache

The first is dubbed a _reject cache_, whose entries contain a small amount of information critical to determining if we should spend resources validating a particular channel announcement or channel update. This improves the performance of [`HasChannelEdge`](https://github.com/lightningnetwork/lnd/blob/master/channeldb/graph.go#L601), which is a subroutine of [`KnownEdge`](https://github.com/lightningnetwork/lnd/blob/master/routing/router.go#L2272) and [`IsStaleEdgePolicy`](https://github.com/lightningnetwork/lnd/blob/master/routing/router.go#L2281).

Each entry in the reject cache stores the following:
```golang
type rejectCacheEntry struct {
    upd1Time int64
    upd2Time int64
    flags    rejectFlags
}
```
where `flags` is packed bitfield containing, for now, the `exists` and `isZombie` booleans. We store the time as an unix integer as opposed to the `time.Time` directly, since `time.Time`'s [internal pointer](https://golang.org/src/time/time.go#L147) for storing timezone info would force the garbage collector to traverse these long-lived entries. They are subsequently reconstructed during calls to `HasChannelEdge` using the integral value.

The addition of the reject cache greatly improves LND's ability to efficiently filter gossip traffic, and results in a significantly lower number of database accesses for this purpose. Users should notice the gossip syncers terminating much quicker (due to the absence of db hits) and overall result in snappier connections.

## Channel Cache
The second is _channel cache_ which caches `ChannelEdge` values, and used to reduce memory allocations stemming from [`ChanUpdatesInHorizon`](https://github.com/lightningnetwork/lnd/blob/master/channeldb/graph.go#L1236). A `ChannelEdge` has the following structure:
```golang
type ChannelEdge struct {
    Info    *ChannelEdgeInfo
    Policy1 *ChannelEdgePolicy
    Policy2 *ChannelEdgePolicy
}
```
Currently, each call to `ChanUpdatesInHorizon` will seek and deserialize all `ChannelEdge` values in the requested range. When connected to large number of peers, this can result an excessive amount of memory that must be 1) allocated, and 2) cleaned up by the garbage collector. The values are intended to be read only, and are discarded as soon as the relevant information is written out on the wire to the peers.

As a result, the channel cache can greatly reduce the amount of wasted allocations, especially if a large percentage of the requested range is held in memory or peers request similar time slices of the graph.

## Eviction
Both caches employ randomized eviction when inserting an element would cause the cache to exceed its configured capacity. The rationale stems from the fact that the access pattern for these caches is dictated entirely by our peers. Assuming the entire working set cannot fit in memory, a deterministic caching strategy would ease a malicious peer's ability to craft access patterns that incur a worst-case hit frequency (close-to-or-equal-to 0%). The resulting effect would that we equivalent to having no cache at all, and force us to hit disk for each rejection check and/or deserialize each requested `ChannelEdge`. The randomized eviction strategy thus provides some level of DOS protection, while also being simple to and efficient to implement in go (because map iteration is randomized by default).

## Lazy Consistency
For some cases, keeping the cache in sync with the on-disk state requires reading and deserializing extra data from the db that is not deducible from the inputs. However, at the time the entry is modified, it's not certain that the entry will be accessed again, meaning that extraneous allocations and deserializations may be performed, even though the entry could be evicted before that data is ever used.

For this reason, both the reject and channel caches remove entries from cache whenever an operation dirties an entry and then lazily loads them on the next access. The lone exception is `UpdateChannelPolicy`, where we write through info to the caches if those entries are already present because it is the most frequently used operation. If the entries are not present, then they are lazily loaded on the next access for the reasons stated above.

There are other possible places we could add write through, though removing the entry is by far the safest alternative. We can proceed in doing so in other places if they prove to be a bottleneck.

## CLI configuration
Each cache can be configured by way of the new `lncfg.Caches` subconfig, allowing users to set the maximum number of cache entries for both the reject and channel caches. The configuration options appear as:
```
caches:
      --caches.reject-cache-size=    Maximum number of entries contained in the reject cache, which is used to speed up filtering of new channel announcements and channel updates from peers. Each entry requires 25 bytes. (default: 50000)
      --caches.channel-cache-size=   Maximum number of entries contained in the channel cache, which is used to reduce memory allocations from gossip queries from peers. Each entry requires 2Kb. (default: 20000)
```

At the default values provided, the reject cache occupies 1.2MB and easily holds an entry for today's entire graph. The channel cache occupies about 40MB, holding about half of the channels in memory. The majority of peers query for values near the tip of the graph, allowing gossip queries to be satisfied almost entirely from the in-memory contents.

There are certain peers that request a full dump of all known channels, which will require going to disk (unless of course the channel cache is configured to hold the entire graph in memory). AFAIK, CL currently queries for the entire range on each connection, and after #2740 LND nodes will begin doing so roughly once every six hours to a random peer to ensure that any holes in its routing table are filled. Inherently no caching algorithm can be optimal under such circumstances, though empirically, the channel cache quickly converges back to having most of the elements at tip for subsequent queries on the hot spots.

I'm open to other opinions on the default cache sizes, please discuss if people have others they prefer!

Depends on:
 - [x] #2846 