### PR TITLE
pool/worker: increase worker timeout to 90s

### DIFF
--- a/pool/worker.go
+++ b/pool/worker.go
@@ -13,7 +13,7 @@ var ErrWorkerPoolExiting = errors.New("worker pool exiting")
 // DefaultWorkerTimeout is the default duration after which a worker goroutine
 // will exit to free up resources after having received no newly submitted
 // tasks.
-const DefaultWorkerTimeout = 5 * time.Second
+const DefaultWorkerTimeout = 90 * time.Second
 
 type (
 	// WorkerState is an interface used by the Worker to abstract the


### PR DESCRIPTION
This commit increases the default worker timeout currently backing the
read and write pools. This allows the read and write pools to sustain
regular bursty traffic such as ping/pong without releasing their buffers
back to the underlying gc queue. In the future, jitter can be added to
our ping and/or gossip messages to reduce the concurrent usage of read
and write pools, which will make this change even more effective.