### PR TITLE
chainntnfs: Always commit bitcoind spendhints

### DIFF
--- a/chainntnfs/bitcoindnotify/bitcoind.go
+++ b/chainntnfs/bitcoindnotify/bitcoind.go
@@ -228,7 +228,13 @@ out:
 						msg.StartHeight, msg.EndHeight,
 					)
 					if err != nil {
-						chainntnfs.Log.Error(err)
+						chainntnfs.Log.Errorf("Rescan to "+
+							"determine the conf "+
+							"details of %v within "+
+							"range %d-%d failed: %v",
+							msg.ConfRequest,
+							msg.StartHeight,
+							msg.EndHeight, err)
 						return
 					}
 
@@ -243,7 +249,10 @@ out:
 						msg.ConfRequest, confDetails,
 					)
 					if err != nil {
-						chainntnfs.Log.Error(err)
+						chainntnfs.Log.Errorf("Unable "+
+							"to update conf "+
+							"details of %v: %v",
+							msg.ConfRequest, err)
 					}
 				}()
 


### PR DESCRIPTION
This PR fixes a bug that would cause the
notifier not to commit spend hints for items
that are not found. This is done by calling
UpdateSpendDetails with a nil detail, permitting
the notifier to begin updating the spend hints
with new blocks that arrive at tip. The change
is designed to mimic the behavior for historical
confirmation dispatch.

The symptom of this bug is needing to do many
long rescans on startup, even if new blocks
arrive after the rescan had completed. With
this change, nodes will have to do the scans
once more before their hints will be properly
updated. Restarts from then on should not
have this behavior.