### PR TITLE
htlcswitch: revert forwarding policy block delta requirements

### DIFF
--- a/config.go
+++ b/config.go
@@ -67,7 +67,11 @@ const (
 	defaultTorV2PrivateKeyFilename = "v2_onion_private_key"
 	defaultTorV3PrivateKeyFilename = "v3_onion_private_key"
 
-	defaultBroadcastDelta = 10
+	defaultIncomingBroadcastDelta = 20
+	defaultFinalCltvRejectDelta   = 2
+
+	defaultOutgoingBroadcastDelta  = 10
+	defaultOutgoingCltvRejectDelta = 0
 
 	// minTimeLockDelta is the minimum timelock we require for incoming
 	// HTLCs on our channels.

--- a/contractcourt/chain_arbitrator.go
+++ b/contractcourt/chain_arbitrator.go
@@ -53,13 +53,20 @@ type ChainArbitratorConfig struct {
 	// ChainHash is the chain that this arbitrator is to operate within.
 	ChainHash chainhash.Hash
 
-	// BroadcastDelta is the delta that we'll use to decide when to
-	// broadcast our commitment transaction.  This value should be set
-	// based on our current fee estimation of the commitment transaction.
-	// We use this to determine when we should broadcast instead of the
-	// just the HTLC timeout, as we want to ensure that the commitment
-	// transaction is already confirmed, by the time the HTLC expires.
-	BroadcastDelta uint32
+	// IncomingBroadcastDelta is the delta that we'll use to decide when to
+	// broadcast our commitment transaction if we have incoming htlcs. This
+	// value should be set based on our current fee estimation of the
+	// commitment transaction. We use this to determine when we should
+	// broadcast instead of the just the HTLC timeout, as we want to ensure
+	// that the commitment transaction is already confirmed, by the time the
+	// HTLC expires. Otherwise we may end up not settling the htlc on-chain
+	// because the other party managed to time it out.
+	IncomingBroadcastDelta uint32
+
+	// OutgoingBroadcastDelta is the delta that we'll use to decide when to
+	// broadcast our commitment transaction if there are active outgoing
+	// htlcs. This value can be lower than the incoming broadcast delta.
+	OutgoingBroadcastDelta uint32
 
 	// NewSweepAddr is a function that returns a new address under control
 	// by the wallet. We'll use this to sweep any no-delay outputs as a

--- a/contractcourt/channel_arbitrator.go
+++ b/contractcourt/channel_arbitrator.go
@@ -1106,7 +1106,8 @@ func (c *ChannelArbitrator) checkChainActions(height uint32,
 		// We'll need to go on-chain for an outgoing HTLC if it was
 		// never resolved downstream, and it's "close" to timing out.
 		haveChainActions = haveChainActions || c.shouldGoOnChain(
-			htlc.RefundTimeout, c.cfg.BroadcastDelta, height,
+			htlc.RefundTimeout, c.cfg.OutgoingBroadcastDelta,
+			height,
 		)
 	}
 	for _, htlc := range c.activeHTLCs.incomingHTLCs {
@@ -1124,7 +1125,8 @@ func (c *ChannelArbitrator) checkChainActions(height uint32,
 			continue
 		}
 		haveChainActions = haveChainActions || c.shouldGoOnChain(
-			htlc.RefundTimeout, c.cfg.BroadcastDelta, height,
+			htlc.RefundTimeout, c.cfg.IncomingBroadcastDelta,
+			height,
 		)
 	}
 
@@ -1162,7 +1164,8 @@ func (c *ChannelArbitrator) checkChainActions(height uint32,
 		// until the HTLC times out to see if we can also redeem it
 		// on-chain.
 		case !c.shouldGoOnChain(
-			htlc.RefundTimeout, c.cfg.BroadcastDelta, height,
+			htlc.RefundTimeout, c.cfg.OutgoingBroadcastDelta,
+			height,
 		):
 			// TODO(roasbeef): also need to be able to query
 			// circuit map to see if HTLC hasn't been fully

--- a/contractcourt/channel_arbitrator_test.go
+++ b/contractcourt/channel_arbitrator_test.go
@@ -165,7 +165,8 @@ func createTestChannelArbitrator(log ArbitratorLog) (*ChannelArbitrator,
 		DeliverResolutionMsg: func(...ResolutionMsg) error {
 			return nil
 		},
-		BroadcastDelta: 5,
+		OutgoingBroadcastDelta: 5,
+		IncomingBroadcastDelta: 5,
 		Notifier: &mockNotifier{
 			epochChan: make(chan *chainntnfs.BlockEpoch),
 			spendChan: make(chan *chainntnfs.SpendDetail),

--- a/htlcswitch/link.go
+++ b/htlcswitch/link.go
@@ -235,17 +235,18 @@ type ChannelLinkConfig struct {
 	MinFeeUpdateTimeout time.Duration
 	MaxFeeUpdateTimeout time.Duration
 
-	// ExpiryGraceDelta is the minimum difference between the current block
-	// height and the CLTV we require on 1) an outgoing HTLC in order to
-	// forward as an intermediary hop, or 2) an incoming HTLC to reveal the
-	// preimage as the final hop. We'll reject any HTLC's who's timeout minus
-	// this value is less than or equal to the current block height. We require
-	// this in order to ensure that we have sufficient time to claim or
-	// timeout an HTLC on chain.
-	//
-	// This MUST be greater than the maximum BroadcastDelta of the
-	// ChannelArbitrator for the outbound channel.
-	ExpiryGraceDelta uint32
+	// FinalCltvRejectDelta defines the number of blocks before the expiry
+	// of the htlc where we no longer settle it as an exit hop and instead
+	// cancel it back. Normally this value should be lower than the cltv
+	// expiry of any invoice we create and the code effectuating this should
+	// not be hit.
+	FinalCltvRejectDelta uint32
+
+	// OutgoingCltvRejectDelta defines the number of blocks before expiry of
+	// an htlc where we don't offer an htlc anymore. This should be at least
+	// the outgoing broadcast delta, because in any case we don't want to
+	// risk offering an htlc that triggers channel closure.
+	OutgoingCltvRejectDelta uint32
 }
 
 // channelLink is the service which drives a channel's commitment update
@@ -2156,7 +2157,7 @@ func (l *channelLink) HtlcSatifiesPolicy(payHash [32]byte,
 	// We want to avoid offering an HTLC which will expire in the near
 	// future, so we'll reject an HTLC if the outgoing expiration time is too
 	// close to the current height.
-	if outgoingTimeout-l.cfg.ExpiryGraceDelta <= heightNow {
+	if outgoingTimeout-l.cfg.OutgoingCltvRejectDelta <= heightNow {
 		l.errorf("htlc(%x) has an expiry that's too soon: "+
 			"outgoing_expiry=%v, best_height=%v", payHash[:],
 			outgoingTimeout, heightNow)
@@ -2679,7 +2680,7 @@ func (l *channelLink) processExitHop(pd *lnwallet.PaymentDescriptor,
 
 	// First, we'll check the expiry of the HTLC itself against, the current
 	// block height. If the timeout is too soon, then we'll reject the HTLC.
-	if pd.Timeout-l.cfg.ExpiryGraceDelta <= heightNow {
+	if pd.Timeout-l.cfg.FinalCltvRejectDelta <= heightNow {
 		log.Errorf("htlc(%x) has an expiry that's too soon: expiry=%v"+
 			", best_height=%v", pd.RHash[:], pd.Timeout, heightNow)
 

--- a/htlcswitch/link_test.go
+++ b/htlcswitch/link_test.go
@@ -179,7 +179,8 @@ func createInterceptorFunc(prefix, receiver string, messages []expectedMessage,
 func TestChannelLinkSingleHopPayment(t *testing.T) {
 	t.Parallel()
 
-	channels, cleanUp, _, err := createClusterChannels(
+	// Setup a alice-bob network.
+	aliceChannel, bobChannel, cleanUp, err := createTwoClusterChannels(
 		btcutil.SatoshiPerBitcoin*3,
 		btcutil.SatoshiPerBitcoin*5)
 	if err != nil {
@@ -187,15 +188,14 @@ func TestChannelLinkSingleHopPayment(t *testing.T) {
 	}
 	defer cleanUp()
 
-	n := newThreeHopNetwork(t, channels.aliceToBob, channels.bobToAlice,
-		channels.bobToCarol, channels.carolToBob, testStartingHeight)
+	n := newTwoHopNetwork(t, aliceChannel, bobChannel, testStartingHeight)
 	if err := n.start(); err != nil {
 		t.Fatal(err)
 	}
 	defer n.stop()
 
 	aliceBandwidthBefore := n.aliceChannelLink.Bandwidth()
-	bobBandwidthBefore := n.firstBobChannelLink.Bandwidth()
+	bobBandwidthBefore := n.bobChannelLink.Bandwidth()
 
 	debug := false
 	if debug {
@@ -205,12 +205,12 @@ func TestChannelLinkSingleHopPayment(t *testing.T) {
 
 		// Log message that bob receives.
 		n.bobServer.intersect(createLogFunc("bob",
-			n.firstBobChannelLink.ChanID()))
+			n.bobChannelLink.ChanID()))
 	}
 
 	amount := lnwire.NewMSatFromSatoshis(btcutil.SatoshiPerBitcoin)
 	htlcAmt, totalTimelock, hops := generateHops(amount, testStartingHeight,
-		n.firstBobChannelLink)
+		n.bobChannelLink)
 
 	// Wait for:
 	// * HTLC add request to be sent to bob.
@@ -219,7 +219,7 @@ func TestChannelLinkSingleHopPayment(t *testing.T) {
 	// * alice<->bob commitment state to be updated.
 	// * user notification to be sent.
 	receiver := n.bobServer
-	firstHop := n.firstBobChannelLink.ShortChanID()
+	firstHop := n.bobChannelLink.ShortChanID()
 	rhash, err := makePayment(
 		n.aliceServer, receiver, firstHop, hops, amount, htlcAmt,
 		totalTimelock,
@@ -248,10 +248,10 @@ func TestChannelLinkSingleHopPayment(t *testing.T) {
 			"amount")
 	}
 
-	if bobBandwidthBefore+amount != n.firstBobChannelLink.Bandwidth() {
+	if bobBandwidthBefore+amount != n.bobChannelLink.Bandwidth() {
 		t.Fatalf("bob bandwidth isn't match: expected %v, got %v",
 			bobBandwidthBefore+amount,
-			n.firstBobChannelLink.Bandwidth())
+			n.bobChannelLink.Bandwidth())
 	}
 }
 

--- a/htlcswitch/mock.go
+++ b/htlcswitch/mock.go
@@ -728,6 +728,8 @@ func newDB() (*channeldb.DB, func(), error) {
 	return cdb, cleanUp, nil
 }
 
+const testInvoiceCltvExpiry = 4
+
 type mockInvoiceRegistry struct {
 	settleChan chan lntypes.Hash
 
@@ -743,7 +745,7 @@ func newMockRegistry(minDelta uint32) *mockInvoiceRegistry {
 	}
 
 	decodeExpiry := func(invoice string) (uint32, error) {
-		return 3, nil
+		return testInvoiceCltvExpiry, nil
 	}
 
 	registry := invoices.NewRegistry(cdb, decodeExpiry)

--- a/htlcswitch/test_utils.go
+++ b/htlcswitch/test_utils.go
@@ -1019,7 +1019,6 @@ func (h *hopNetwork) createChannelLink(server, peer *mockServer,
 		fwdPkgTimeout       = 15 * time.Second
 		minFeeUpdateTimeout = 30 * time.Minute
 		maxFeeUpdateTimeout = 40 * time.Minute
-		expiryGraceDelta    = 3
 	)
 
 	link := NewChannelLink(
@@ -1041,15 +1040,16 @@ func (h *hopNetwork) createChannelLink(server, peer *mockServer,
 			UpdateContractSignals: func(*contractcourt.ContractSignals) error {
 				return nil
 			},
-			ChainEvents:         &contractcourt.ChainEventSubscription{},
-			SyncStates:          true,
-			BatchSize:           10,
-			BatchTicker:         ticker.NewForce(batchTimeout),
-			FwdPkgGCTicker:      ticker.NewForce(fwdPkgTimeout),
-			MinFeeUpdateTimeout: minFeeUpdateTimeout,
-			MaxFeeUpdateTimeout: maxFeeUpdateTimeout,
-			OnChannelFailure:    func(lnwire.ChannelID, lnwire.ShortChannelID, LinkFailureError) {},
-			ExpiryGraceDelta:    expiryGraceDelta,
+			ChainEvents:             &contractcourt.ChainEventSubscription{},
+			SyncStates:              true,
+			BatchSize:               10,
+			BatchTicker:             ticker.NewForce(batchTimeout),
+			FwdPkgGCTicker:          ticker.NewForce(fwdPkgTimeout),
+			MinFeeUpdateTimeout:     minFeeUpdateTimeout,
+			MaxFeeUpdateTimeout:     maxFeeUpdateTimeout,
+			OnChannelFailure:        func(lnwire.ChannelID, lnwire.ShortChannelID, LinkFailureError) {},
+			FinalCltvRejectDelta:    3,
+			OutgoingCltvRejectDelta: 3,
 		},
 		channel,
 	)

--- a/server.go
+++ b/server.go
@@ -728,8 +728,9 @@ func newServer(listenAddrs []net.Addr, chanDB *channeldb.DB, cc *chainControl,
 	contractBreaches := make(chan *ContractBreachEvent, 1)
 
 	s.chainArb = contractcourt.NewChainArbitrator(contractcourt.ChainArbitratorConfig{
-		ChainHash:      *activeNetParams.GenesisHash,
-		BroadcastDelta: defaultBroadcastDelta,
+		ChainHash:              *activeNetParams.GenesisHash,
+		IncomingBroadcastDelta: defaultIncomingBroadcastDelta,
+		OutgoingBroadcastDelta: defaultOutgoingBroadcastDelta,
 		NewSweepAddr: func() ([]byte, error) {
 			return newSweepPkScript(cc.wallet)
 		},
@@ -2475,14 +2476,16 @@ func (s *server) peerConnected(conn net.Conn, connReq *connmgr.ConnReq,
 	localFeatures.Set(lnwire.GossipQueriesOptional)
 
 	// Now that we've established a connection, create a peer, and it to the
-	// set of currently active peers. Configure the peer with a expiry grace
-	// delta greater than the broadcast delta, to prevent links from
-	// accepting htlcs that may trigger channel arbitrator force close the
-	// channel immediately.
+	// set of currently active peers. Configure the peer with the incoming
+	// and outgoing broadcast deltas to prevent htlcs from being accepted or
+	// offered that would trigger channel closure. In case of outgoing
+	// htlcs, an extra block is added to prevent the channel from being
+	// closed when the htlc is outstanding and a new block comes in.
 	p, err := newPeer(
 		conn, connReq, s, peerAddr, inbound, localFeatures,
 		cfg.ChanEnableTimeout,
-		defaultBroadcastDelta+extraExpiryGraceDelta,
+		defaultFinalCltvRejectDelta,
+		defaultOutgoingCltvRejectDelta,
 	)
 	if err != nil {
 		srvrLog.Errorf("unable to create peer %v", err)


### PR DESCRIPTION
After the merge of #2839, a minimum cltv delta of 14 blocks is enforced for outgoing htlcs. This is a problem when forwarding to the final node which has an invoice with a cltv < 14. This happens in the wild.

In this case, `lnd` doesn't forward and returns an `ExpiryTooSoon` failure to the sender.

This PR reverts the parameters to their original values. 

It does not fully revert #2839, but instead introduces a clearer way to configure the relevant parameters and sets them to their original values. It replaces the original `broadcastRedeemMultiplier` and `expiryGraceDelta`.

In follow up #2887 the parameters are tuned further to improve the go-to-chain behaviour and forwarding policies.