### PR TITLE
signal: don't attempt to catch SIGSTOP

### DIFF
--- a/signal/signal.go
+++ b/signal/signal.go
@@ -32,7 +32,6 @@ func init() {
 		os.Kill,
 		syscall.SIGABRT,
 		syscall.SIGTERM,
-		syscall.SIGSTOP,
 		syscall.SIGQUIT,
 	}
 	signal.Notify(interruptChannel, signalsToCatch...)


### PR DESCRIPTION
In this commit, we modify the set of default signals we attempt to catch in
order to execute a graceful shutdown. Before this commit, we would attempt
to catch/register for `SIGSTOP`. There're two issues with this

  1. `SIGSTOP` is meant to be used in combination with `SIGCONCT` to allow a
  process to be paused/resumed. Therefore, our action of shutting down once
  received was incorrect.

  2. `SIGSTOP` doesn't exist on windows, so users aren't able to compile on
  this platform without modifying the codebase.

