### PR TITLE
discovery: only replace stale active syncer if disconnected

### DIFF
--- a/discovery/sync_manager.go
+++ b/discovery/sync_manager.go
@@ -286,6 +286,13 @@ func (m *SyncManager) roundRobinHandler() {
 		current = m.nextPendingActiveSyncer()
 		m.Unlock()
 		for current != nil {
+			// Ensure we properly handle a shutdown signal.
+			select {
+			case <-m.quit:
+				return
+			default:
+			}
+
 			// We'll avoid performing the transition with the lock
 			// as it can potentially stall the SyncManager due to
 			// the syncTransitionTimeout.
@@ -531,6 +538,13 @@ func (m *SyncManager) forceHistoricalSync() {
 	candidatesChosen := make(map[routing.Vertex]struct{})
 	s := m.chooseRandomSyncer(candidatesChosen, true)
 	for s != nil {
+		// Ensure we properly handle a shutdown signal.
+		select {
+		case <-m.quit:
+			return
+		default:
+		}
+
 		// Blacklist the candidate to ensure it's not chosen again.
 		candidatesChosen[s.cfg.peerPub] = struct{}{}
 

--- a/discovery/sync_manager.go
+++ b/discovery/sync_manager.go
@@ -353,19 +353,20 @@ func (m *SyncManager) roundRobinHandler() {
 			// the set of inactive syncers.
 			if staleActiveSyncer.transitioned {
 				m.inactiveSyncers[s.cfg.peerPub] = s
+			} else {
+				// Otherwise, since the peer is disconnecting,
+				// we'll attempt to find a passive syncer that
+				// can replace it.
+				newActiveSyncer := m.chooseRandomSyncer(nil, false)
+				if newActiveSyncer != nil {
+					m.queueActiveSyncer(newActiveSyncer)
+				}
 			}
 
 			// Remove the internal active syncer references for this
 			// peer.
 			delete(m.pendingActiveSyncers, s.cfg.peerPub)
 			delete(m.activeSyncers, s.cfg.peerPub)
-
-			// We'll then attempt to find a passive syncer that can
-			// replace the stale active syncer.
-			newActiveSyncer := m.chooseRandomSyncer(nil, false)
-			if newActiveSyncer != nil {
-				m.queueActiveSyncer(newActiveSyncer)
-			}
 			m.Unlock()
 
 			// Signal to the caller that they can now proceed since


### PR DESCRIPTION
In this commit, we address a bug where we'd attempt to replace the
stale active syncer when it transitioned to a passive syncer. This
replacement logic is only intended to happen when the active syncer
disconnects, as rotateActiveSyncerCandidate chooses and queues its own
replacement.