### PR TITLE
lnd_test: use child harness chan backup restore cases

### DIFF
--- a/lnd_test.go
+++ b/lnd_test.go
@@ -13847,8 +13847,9 @@ func testChannelBackupRestore(net *lntest.NetworkHarness, t *harnessTest) {
 	// ann is updated?
 
 	for _, testCase := range testCases {
-		success := t.t.Run(testCase.name, func(_ *testing.T) {
-			testChanRestoreScenario(t, net, &testCase, password)
+		success := t.t.Run(testCase.name, func(t *testing.T) {
+			h := newHarnessTest(t)
+			testChanRestoreScenario(h, net, &testCase, password)
 		})
 		if !success {
 			break


### PR DESCRIPTION
This prevents a panic during test failure due to a child test calling
FailNow on a parent test context. The sub tests now capture the
testing.T object provided in each closure as opposed to ignoring it and
using the parent context.

```
    --- FAIL: TestLightningNetworkDaemon/channel_backup_restore (81.16s)
        lnd_test.go:78: Failed: (channel backup restore): exited with error: 
            *errors.errorString Node restart failed: process did not exit
            /home/travis/gopath/src/github.com/lightningnetwork/lnd/lnd_test.go:7577 (0xce9082)
            	assertDLPExecuted: t.Fatalf("Node restart failed: %v", err)
            /home/travis/gopath/src/github.com/lightningnetwork/lnd/lnd_test.go:13647 (0xd0e544)
            	testChanRestoreScenario: assertDLPExecuted(
            /home/travis/gopath/src/github.com/lightningnetwork/lnd/lnd_test.go:13851 (0xd25717)
            	testChannelBackupRestore.func5: testChanRestoreScenario(t, net, &testCase, password)
            /home/travis/.gimme/versions/go1.12.1.linux.amd64/src/testing/testing.go:865 (0x4fb810)
            	tRunner: fn(t)
            /home/travis/.gimme/versions/go1.12.1.linux.amd64/src/runtime/asm_amd64.s:1337 (0x45e711)
            	goexit: BYTE	$0x90	// NOP
        --- FAIL: TestLightningNetworkDaemon/channel_backup_restore/restore_from_RPC_backup (81.16s)
            testing.go:820: test executed panic(nil) or runtime.Goexit: subtest may have called FailNow on a parent test
```