### PR TITLE
discovery/sync_manager: restore lazy gossip sends

### DIFF
--- a/discovery/sync_manager.go
+++ b/discovery/sync_manager.go
@@ -629,7 +629,7 @@ func (m *SyncManager) InitSyncState(peer lnpeer.Peer) {
 		encodingType:  encoding,
 		chunkSize:     encodingTypeToChunkSize[encoding],
 		sendToPeer: func(msgs ...lnwire.Message) error {
-			return peer.SendMessage(false, msgs...)
+			return peer.SendMessageLazy(false, msgs...)
 		},
 	})
 


### PR DESCRIPTION
Restores use of lazy sending for gossip messages, which wasn't caught in reviewing #2740 