### PR TITLE
discovery: make batch size distinct from chunk size, reduce to 500

### DIFF
--- a/discovery/sync_manager.go
+++ b/discovery/sync_manager.go
@@ -628,6 +628,7 @@ func (m *SyncManager) InitSyncState(peer lnpeer.Peer) {
 		channelSeries: m.cfg.ChanSeries,
 		encodingType:  encoding,
 		chunkSize:     encodingTypeToChunkSize[encoding],
+		batchSize:     requestBatchSize,
 		sendToPeer: func(msgs ...lnwire.Message) error {
 			return peer.SendMessage(false, msgs...)
 		},

--- a/discovery/syncer_test.go
+++ b/discovery/syncer_test.go
@@ -125,6 +125,7 @@ func newTestSyncer(hID lnwire.ShortChannelID,
 		channelSeries: newMockChannelGraphTimeSeries(hID),
 		encodingType:  encodingType,
 		chunkSize:     chunkSize,
+		batchSize:     chunkSize,
 		sendToPeer: func(msgs ...lnwire.Message) error {
 			msgChan <- msgs
 			return nil


### PR DESCRIPTION
This commit reduces the number of channels a syncer will request from
the remote node in a single QueryShortChanIDs message. The current size
is derived from the chunkSize, which is meant to signal the maximum
number of short chan ids that can fit in a single ReplyChannelRange
message. For EncodingSortedPlain, this number is 8000, and we use the
same number to dictate the size of the batch from the remote peer.

We modify this by introducing a separately configurable batchSize, so
that both can be tuned independently. The value is chosen to reduce the
amount of buffering the remote party will perform, only requiring them
queue 500 responses, as opposed to 8000. In turn, this reduces larges
spikes in allocation on the remote node at the expense of a few extra
round trips for the control messages. However, will be negligible since
the control messages are much smaller than the messages being returned.
