### PR TITLE
chainregistry: stop Neutrino before closing DB

### DIFF
--- a/chainregistry.go
+++ b/chainregistry.go
@@ -730,13 +730,14 @@ func initNeutrinoBackend(chainDir string) (*neutrino.ChainService, func(), error
 			"client: %v", err)
 	}
 
+	if err := neutrinoCS.Start(); err != nil {
+		db.Close()
+		return nil, nil, err
+	}
+
 	cleanUp := func() {
 		db.Close()
 		neutrinoCS.Stop()
-	}
-	if err := neutrinoCS.Start(); err != nil {
-		cleanUp()
-		return nil, nil, err
 	}
 
 	return neutrinoCS, cleanUp, nil

--- a/chainregistry.go
+++ b/chainregistry.go
@@ -736,8 +736,8 @@ func initNeutrinoBackend(chainDir string) (*neutrino.ChainService, func(), error
 	}
 
 	cleanUp := func() {
-		db.Close()
 		neutrinoCS.Stop()
+		db.Close()
 	}
 
 	return neutrinoCS, cleanUp, nil


### PR DESCRIPTION
To avoid the ChainService still attempting to access the database when
it gets closed, re-order the stop order such that the Chainservice gets
stopped before closing the DB.