### PR TITLE
htlcswitch: promote log level of revocation window exhaustion

### DIFF
--- a/htlcswitch/link.go
+++ b/htlcswitch/link.go
@@ -1898,7 +1898,9 @@ func (l *channelLink) updateCommitTx() error {
 		CommitSig: theirCommitSig,
 		HtlcSigs:  htlcSigs,
 	}
-	l.cfg.Peer.SendMessage(false, commitSig)
+	if err := l.cfg.Peer.SendMessage(false, commitSig); err != nil {
+		return err
+	}
 
 	// We've just initiated a state transition, attempt to stop the
 	// logCommitTimer. If the timer already ticked, then we'll consume the

--- a/htlcswitch/link.go
+++ b/htlcswitch/link.go
@@ -1875,7 +1875,7 @@ func (l *channelLink) updateCommitTx() error {
 
 	theirCommitSig, htlcSigs, err := l.channel.SignNextCommitment()
 	if err == lnwallet.ErrNoWindow {
-		l.tracef("revocation window exhausted, unable to send: %v, "+
+		l.debugf("revocation window exhausted, unable to send: %v, "+
 			"dangling_opens=%v, dangling_closes%v",
 			l.batchCounter, newLogClosure(func() string {
 				return spew.Sdump(l.openedCircuits)


### PR DESCRIPTION
Without a log message, the situation where no commitment txes are signed anymore would be hard to debug.