### PR TITLE
discovery: make gossip replies synchronous

### DIFF
--- a/discovery/sync_manager.go
+++ b/discovery/sync_manager.go
@@ -386,6 +386,9 @@ func (m *SyncManager) createGossipSyncer(peer lnpeer.Peer) *GossipSyncer {
 		sendToPeer: func(msgs ...lnwire.Message) error {
 			return peer.SendMessageLazy(false, msgs...)
 		},
+		sendToPeerSync: func(msgs ...lnwire.Message) error {
+			return peer.SendMessageLazy(true, msgs...)
+		},
 	})
 
 	// Gossip syncers are initialized by default in a PassiveSync type

--- a/discovery/syncer_test.go
+++ b/discovery/syncer_test.go
@@ -1070,8 +1070,10 @@ func TestGossipSyncerDelayDOS(t *testing.T) {
 	numUndelayedQueries := syncer1.cfg.maxUndelayedQueryReplies
 
 	// We will send enough queries to exhaust the undelayed responses, and
-	// then send two more queries which should be delayed.
-	numQueryResponses := numUndelayedQueries + numDelayedQueries
+	// then send two more queries which should be delayed. An additional one
+	// is subtracted from the total since undelayed message will be consumed
+	// by the initial QueryChannelRange.
+	numQueryResponses := numUndelayedQueries + numDelayedQueries - 1
 
 	// The total number of responses must include the initial reply each
 	// syncer will make to QueryChannelRange.
@@ -1081,10 +1083,11 @@ func TestGossipSyncerDelayDOS(t *testing.T) {
 	// scaled by the chunk size being used.
 	numTotalChans := numQueryResponses * chunkSize
 
-	// Although both nodes are at the same height, they'll have a
-	// completely disjoint set of chan ID's that they know of.
+	// Construct enough channels so that all of the queries will have enough
+	// channels. Since syncer1 won't know of any channels, their sets are
+	// inherently disjoint.
 	var syncer2Chans []lnwire.ShortChannelID
-	for i := numTotalChans; i < numTotalChans+numTotalChans; i++ {
+	for i := 0; i < numTotalChans; i++ {
 		syncer2Chans = append(
 			syncer2Chans, lnwire.NewShortChanIDFromInt(uint64(i)),
 		)

--- a/lnpeer/errors.go
+++ b/lnpeer/errors.go
@@ -1,0 +1,8 @@
+package lnpeer
+
+import "fmt"
+
+var (
+	// ErrPeerExiting signals that the peer received a disconnect request.
+	ErrPeerExiting = fmt.Errorf("peer exiting")
+)

--- a/peer.go
+++ b/peer.go
@@ -32,9 +32,6 @@ import (
 
 var (
 	numNodes int32
-
-	// ErrPeerExiting signals that the peer received a disconnect request.
-	ErrPeerExiting = fmt.Errorf("peer exiting")
 )
 
 const (
@@ -1411,7 +1408,7 @@ func (p *peer) logWireMessage(msg lnwire.Message, read bool) {
 func (p *peer) writeMessage(msg lnwire.Message) error {
 	// Simply exit if we're shutting down.
 	if atomic.LoadInt32(&p.disconnect) != 0 {
-		return ErrPeerExiting
+		return lnpeer.ErrPeerExiting
 	}
 
 	// Only log the message on the first attempt.
@@ -1559,7 +1556,7 @@ out:
 			}
 
 		case <-p.quit:
-			exitErr = ErrPeerExiting
+			exitErr = lnpeer.ErrPeerExiting
 			break out
 		}
 	}
@@ -1691,7 +1688,7 @@ func (p *peer) queue(priority bool, msg lnwire.Message, errChan chan error) {
 	case <-p.quit:
 		peerLog.Tracef("Peer shutting down, could not enqueue msg.")
 		if errChan != nil {
-			errChan <- ErrPeerExiting
+			errChan <- lnpeer.ErrPeerExiting
 		}
 	}
 }
@@ -2504,7 +2501,7 @@ func (p *peer) sendMessage(sync, priority bool, msgs ...lnwire.Message) error {
 		case err := <-errChan:
 			return err
 		case <-p.quit:
-			return ErrPeerExiting
+			return lnpeer.ErrPeerExiting
 		}
 	}
 
@@ -2550,7 +2547,7 @@ func (p *peer) AddNewChannel(channel *channeldb.OpenChannel,
 	case <-cancel:
 		return errors.New("canceled adding new channel")
 	case <-p.quit:
-		return ErrPeerExiting
+		return lnpeer.ErrPeerExiting
 	}
 
 	// We pause here to wait for the peer to recognize the new channel
@@ -2559,7 +2556,7 @@ func (p *peer) AddNewChannel(channel *channeldb.OpenChannel,
 	case err := <-errChan:
 		return err
 	case <-p.quit:
-		return ErrPeerExiting
+		return lnpeer.ErrPeerExiting
 	}
 }
 


### PR DESCRIPTION
This PR modifies the `discovery.GossipSyncer` to send all replies and and gossip filter backlogs synchronously. This serves to throttle the rate at which the serving node writes messages to the wire, which has been observed to result to a disconnect if the remote node's discovery stream is filled up. Testing on my node has shown overall more stable connections, as this helps in more closely aligning our sending rate to the throughput of the other node. 

In the process, we make a pair of syncer's state machines totally isolated, which facilitates a nice removal of duplicate test code in `discovery/syncer_test.go` since the requesting side can now be tested independently of the remote peer's state machine.

See commit messages for more details.