### PR TITLE
discovery: don't send private chan updates to wider network

### DIFF
--- a/discovery/gossiper.go
+++ b/discovery/gossiper.go
@@ -1292,6 +1292,12 @@ func (d *AuthenticatedGossiper) processChanPolicyUpdate(
 			return nil, err
 		}
 
+		// We'll avoid broadcasting any updates for private channels to
+		// avoid directly giving away their existence.
+		if edgeInfo.info.AuthProof == nil {
+			continue
+		}
+
 		// We set ourselves as the source of this message to indicate
 		// that we shouldn't skip any peers when sending this message.
 		chanUpdates = append(chanUpdates, networkMsg{

--- a/discovery/gossiper.go
+++ b/discovery/gossiper.go
@@ -1293,8 +1293,22 @@ func (d *AuthenticatedGossiper) processChanPolicyUpdate(
 		}
 
 		// We'll avoid broadcasting any updates for private channels to
-		// avoid directly giving away their existence.
+		// avoid directly giving away their existence. Instead, we'll
+		// send the update directly to the remote party.
 		if edgeInfo.info.AuthProof == nil {
+			remotePubKey := remotePubFromChanInfo(
+				edgeInfo.info, chanUpdate.ChannelFlags,
+			)
+			err := d.reliableSender.sendMessage(
+				chanUpdate, remotePubKey,
+			)
+			if err != nil {
+				log.Errorf("Unable to reliably send %v for "+
+					"channel=%v to peer=%x: %v",
+					chanUpdate.MsgType(),
+					chanUpdate.ShortChannelID,
+					remotePubKey, err)
+			}
 			continue
 		}
 
@@ -1928,13 +1942,9 @@ func (d *AuthenticatedGossiper) processNetworkAnnouncement(
 		// so we'll try sending the update directly to the remote peer.
 		if !nMsg.isRemote && chanInfo.AuthProof == nil {
 			// Get our peer's public key.
-			var remotePubKey [33]byte
-			switch {
-			case msg.ChannelFlags&lnwire.ChanUpdateDirection == 0:
-				remotePubKey = chanInfo.NodeKey2Bytes
-			case msg.ChannelFlags&lnwire.ChanUpdateDirection == 1:
-				remotePubKey = chanInfo.NodeKey1Bytes
-			}
+			remotePubKey := remotePubFromChanInfo(
+				chanInfo, msg.ChannelFlags,
+			)
 
 			// Now, we'll attempt to send the channel update message
 			// reliably to the remote peer in the background, so

--- a/discovery/gossiper_test.go
+++ b/discovery/gossiper_test.go
@@ -730,6 +730,7 @@ func createTestCtx(startHeight uint32) (*testCtx, func(), error) {
 		HistoricalSyncTicker:      ticker.NewForce(DefaultHistoricalSyncInterval),
 		ActiveSyncerTimeoutTicker: ticker.NewForce(DefaultActiveSyncerTimeout),
 		NumActiveSyncers:          3,
+		AnnSigner:                 &mockSigner{nodeKeyPriv1},
 	}, nodeKeyPub1)
 
 	if err := gossiper.Start(); err != nil {

--- a/discovery/gossiper_test.go
+++ b/discovery/gossiper_test.go
@@ -471,12 +471,10 @@ func createAnnouncements(blockHeight uint32) (*annBatch, error) {
 		return nil, err
 	}
 
-	batch.localProofAnn = &lnwire.AnnounceSignatures{
-		NodeSignature:    batch.remoteChanAnn.NodeSig1,
-		BitcoinSignature: batch.remoteChanAnn.BitcoinSig1,
-	}
-
 	batch.remoteProofAnn = &lnwire.AnnounceSignatures{
+		ShortChannelID: lnwire.ShortChannelID{
+			BlockHeight: blockHeight,
+		},
 		NodeSignature:    batch.remoteChanAnn.NodeSig2,
 		BitcoinSignature: batch.remoteChanAnn.BitcoinSig2,
 	}
@@ -484,6 +482,14 @@ func createAnnouncements(blockHeight uint32) (*annBatch, error) {
 	batch.localChanAnn, err = createRemoteChannelAnnouncement(blockHeight)
 	if err != nil {
 		return nil, err
+	}
+
+	batch.localProofAnn = &lnwire.AnnounceSignatures{
+		ShortChannelID: lnwire.ShortChannelID{
+			BlockHeight: blockHeight,
+		},
+		NodeSignature:    batch.localChanAnn.NodeSig1,
+		BitcoinSignature: batch.localChanAnn.BitcoinSig1,
 	}
 
 	batch.chanUpdAnn1, err = createUpdateAnnouncement(

--- a/discovery/utils.go
+++ b/discovery/utils.go
@@ -146,3 +146,19 @@ func SignAnnouncement(signer lnwallet.MessageSigner, pubKey *btcec.PublicKey,
 
 	return signer.SignMessage(pubKey, data)
 }
+
+// remotePubFromChanInfo returns the public key of the remote peer given a
+// ChannelEdgeInfo that describe a channel we have with them.
+func remotePubFromChanInfo(chanInfo *channeldb.ChannelEdgeInfo,
+	chanFlags lnwire.ChanUpdateChanFlags) [33]byte {
+
+	var remotePubKey [33]byte
+	switch {
+	case chanFlags&lnwire.ChanUpdateDirection == 0:
+		remotePubKey = chanInfo.NodeKey2Bytes
+	case chanFlags&lnwire.ChanUpdateDirection == 1:
+		remotePubKey = chanInfo.NodeKey1Bytes
+	}
+
+	return remotePubKey
+}


### PR DESCRIPTION
In this PR, we add a new test case to exercise a recent bug fix to
ensure that we no longer broadcast private channel policy changes. Along
the way, a few helper functions were added to slim down the test to the
core logic compared to some of the existing tests in this package. In
the future, these new helper functions should be utilized more widely for
tests in this package in order to cut down on some of the duplicated
logic.


Fixes #2904. 
Fixes #2907. 