### PR TITLE
channeldb/graph: skip unknown edges in FetchChanInfos

### DIFF
--- a/channeldb/graph.go
+++ b/channeldb/graph.go
@@ -3065,36 +3065,6 @@ func (c *ChannelGraph) NewChannelEdgePolicy() *ChannelEdgePolicy {
 	return &ChannelEdgePolicy{db: c.db}
 }
 
-// MarkEdgeZombie marks an edge as a zombie within the graph's zombie index.
-// The public keys should represent the node public keys of the two parties
-// involved in the edge.
-func (c *ChannelGraph) MarkEdgeZombie(chanID uint64, pubKey1,
-	pubKey2 [33]byte) error {
-
-	c.cacheMu.Lock()
-	defer c.cacheMu.Unlock()
-
-	err := c.db.Update(func(tx *bbolt.Tx) error {
-		edges := tx.Bucket(edgeBucket)
-		if edges == nil {
-			return ErrGraphNoEdgesFound
-		}
-		zombieIndex, err := edges.CreateBucketIfNotExists(zombieBucket)
-		if err != nil {
-			return err
-		}
-		return markEdgeZombie(zombieIndex, chanID, pubKey1, pubKey2)
-	})
-	if err != nil {
-		return err
-	}
-
-	c.rejectCache.remove(chanID)
-	c.chanCache.remove(chanID)
-
-	return nil
-}
-
 // markEdgeZombie marks an edge as a zombie within our zombie index. The public
 // keys should represent the node public keys of the two parties involved in the
 // edge.

--- a/channeldb/graph_test.go
+++ b/channeldb/graph_test.go
@@ -2006,6 +2006,24 @@ func TestFetchChanInfos(t *testing.T) {
 		edgeQuery = append(edgeQuery, chanID.ToUint64())
 	}
 
+	// Add an additional edge that does not exist. The query should skip
+	// this channel and return only infos for the edges that exist.
+	edgeQuery = append(edgeQuery, 500)
+
+	// Add an another edge to the query that has been marked as a zombie
+	// edge. The query should also skip this channel.
+	zombieChan, zombieChanID := createEdge(
+		666, 0, 0, 0, node1, node2,
+	)
+	if err := graph.AddChannelEdge(&zombieChan); err != nil {
+		t.Fatalf("unable to create channel edge: %v", err)
+	}
+	err = graph.DeleteChannelEdge(&zombieChan.ChannelPoint)
+	if err != nil {
+		t.Fatalf("unable to delete and mark edge zombie: %v", err)
+	}
+	edgeQuery = append(edgeQuery, zombieChanID.ToUint64())
+
 	// We'll now attempt to query for the range of channel ID's we just
 	// inserted into the database. We should get the exact same set of
 	// edges back.

--- a/channeldb/graph_test.go
+++ b/channeldb/graph_test.go
@@ -1750,9 +1750,8 @@ func TestFilterKnownChanIDs(t *testing.T) {
 		if err := graph.AddChannelEdge(&channel); err != nil {
 			t.Fatalf("unable to create channel edge: %v", err)
 		}
-		if err := graph.MarkEdgeZombie(
-			chanID.ToUint64(), node1.PubKeyBytes, node2.PubKeyBytes,
-		); err != nil {
+		err := graph.DeleteChannelEdge(&channel.ChannelPoint)
+		if err != nil {
 			t.Fatalf("unable to mark edge zombie: %v", err)
 		}
 
@@ -2864,20 +2863,28 @@ func TestGraphZombieIndex(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unable to create test vertex: %v", err)
 	}
-	edge, _, _ := createChannelEdge(db, node1, node2)
 
-	// If the graph is not aware of the edge, then it should not be a
-	// zombie.
+	// Swap the nodes if the second's pubkey is smaller than the first.
+	// Without this, the comparisons at the end will fail probabilistically.
+	if bytes.Compare(node2.PubKeyBytes[:], node1.PubKeyBytes[:]) < 0 {
+		node1, node2 = node2, node1
+	}
+
+	edge, _, _ := createChannelEdge(db, node1, node2)
+	if err := graph.AddChannelEdge(edge); err != nil {
+		t.Fatalf("unable to create channel edge: %v", err)
+	}
+
+	// Since the edge is known the graph and it isn't a zombie, IsZombieEdge
+	// should not report the channel as a zombie.
 	isZombie, _, _ := graph.IsZombieEdge(edge.ChannelID)
 	if isZombie {
 		t.Fatal("expected edge to not be marked as zombie")
 	}
 
-	// If we mark the edge as a zombie, then we should expect to see it
-	// within the index.
-	err = graph.MarkEdgeZombie(
-		edge.ChannelID, node1.PubKeyBytes, node2.PubKeyBytes,
-	)
+	// If we delete the edge and mark it as a zombie, then we should expect
+	// to see it within the index.
+	err = graph.DeleteChannelEdge(&edge.ChannelPoint)
 	if err != nil {
 		t.Fatalf("unable to mark edge as zombie: %v", err)
 	}


### PR DESCRIPTION
This commit modifies FetchChanInfos to skip any channels that are not in
the graph at the time of the call. Currently the entire call will fail
if the edge is not found, which stalls a gossip sync in the following
scenario:

 1. Remote peer queries for a channel range
 2. We return the set of channel ids in that range
 3. A channel from that set is removed from the graph, e.g. via close.
 4. Remote peer queries for removed edge, causing the query to fail.

To remedy this, we will now skip any edges that are not known in the
database at the time of the query. This prevents the syncer state
machines from halting, which otherwise could only be resolved by
disconnecting and reconnecting.