### PR TITLE
rpcserver: Prevent SendCoins to Pubkey

### DIFF
--- a/rpcserver.go
+++ b/rpcserver.go
@@ -913,6 +913,15 @@ func (r *rpcServer) SendCoins(ctx context.Context,
 			activeNetParams.Params.Name)
 	}
 
+	// If the destination address parses to a valid pubkey, we assume the user
+	// accidently tried to send funds to a bare pubkey address. This check is
+	// here to prevent unintended transfers.
+	decodedAddr, _ := hex.DecodeString(in.Addr)
+	_, err = btcec.ParsePubKey(decodedAddr, btcec.S256())
+	if err == nil {
+		return nil, fmt.Errorf("cannot send coins to pubkeys")
+	}
+
 	var txid *chainhash.Hash
 
 	wallet := r.server.cc.wallet


### PR DESCRIPTION
fixes #2920

This an early PR, this updates SendCoins in `rpcserver.go` to prevent an onchain transaction to a users own Pubkey. 

Updated to check all use of pubkeys in SendCoins.