### PR TITLE
multi: peer related SCB fixes 

### DIFF
--- a/chanrestore.go
+++ b/chanrestore.go
@@ -171,7 +171,16 @@ func (s *server) ConnectPeer(nodePub *btcec.PublicKey, addrs []net.Addr) error {
 		// Attempt to connect to the peer using this full address. If
 		// we're unable to connect to them, then we'll try the next
 		// address in place of it.
-		if err := s.ConnectToPeer(netAddr, true); err != nil {
+		err := s.ConnectToPeer(netAddr, true)
+
+		// If we're already connected to this peer, then we don't
+		// consider this an erorr, so we'll exit here.
+		if _, ok := err.(*errPeerAlreadyConnected); ok {
+			return nil
+
+		} else if err != nil {
+			// Otherwise, something else happened, so we'll try the
+			// next address.
 			ltndLog.Errorf("unable to connect to %v to "+
 				"complete SCB restore: %v", netAddr, err)
 			continue

--- a/htlcswitch/link.go
+++ b/htlcswitch/link.go
@@ -574,7 +574,7 @@ func (l *channelLink) syncChanStates() error {
 		return fmt.Errorf("unable to generate chan sync message for "+
 			"ChannelPoint(%v)", l.channel.ChannelPoint())
 	}
-	if err := l.cfg.Peer.SendMessage(false, localChanSyncMsg); err != nil {
+	if err := l.cfg.Peer.SendMessage(true, localChanSyncMsg); err != nil {
 		return fmt.Errorf("Unable to send chan sync message for "+
 			"ChannelPoint(%v)", l.channel.ChannelPoint())
 	}


### PR DESCRIPTION
In this PR, we fix a few issues that would cause the itests for the new SCB system to fail randomly based on timing:
  1. Ensure we send the chan sync message in a synchronous manner to the remote peer. Otherwise, if we fail early, then we'll exit w/o ever sending the message to the peer. 
  2. Don't exit during the restoration process if we're already connected to the remote peer. 
