### PR TITLE
peer: resume partial writes due to timeouts

### DIFF
--- a/brontide/noise.go
+++ b/brontide/noise.go
@@ -31,6 +31,10 @@ const (
 	// length of a message payload.
 	lengthHeaderSize = 2
 
+	// encHeaderSize is the number of bytes required to hold an encrypted
+	// header and it's MAC.
+	encHeaderSize = lengthHeaderSize + macSize
+
 	// keyRotationInterval is the number of messages sent on a single
 	// cipher stream before the keys are rotated forwards.
 	keyRotationInterval = 1000
@@ -370,7 +374,7 @@ type Machine struct {
 	// nextCipherHeader is a static buffer that we'll use to read in the
 	// next ciphertext header from the wire. The header is a 2 byte length
 	// (of the next ciphertext), followed by a 16 byte MAC.
-	nextCipherHeader [lengthHeaderSize + macSize]byte
+	nextCipherHeader [encHeaderSize]byte
 
 	// nextHeaderSend holds a reference to the remaining header bytes to
 	// write out for a pending message. This allows us to tolerate timeout

--- a/brontide/noise_test.go
+++ b/brontide/noise_test.go
@@ -220,11 +220,9 @@ func TestMaxPayloadLength(t *testing.T) {
 	// payload length.
 	payloadToReject := make([]byte, math.MaxUint16+1)
 
-	var buf bytes.Buffer
-
 	// A write of the payload generated above to the state machine should
 	// be rejected as it's over the max payload length.
-	err := b.WriteMessage(&buf, payloadToReject)
+	err := b.WriteMessage(payloadToReject)
 	if err != ErrMaxMessageLengthExceeded {
 		t.Fatalf("payload is over the max allowed length, the write " +
 			"should have been rejected")
@@ -233,7 +231,7 @@ func TestMaxPayloadLength(t *testing.T) {
 	// Generate another payload which should be accepted as a valid
 	// payload.
 	payloadToAccept := make([]byte, math.MaxUint16-1)
-	if err := b.WriteMessage(&buf, payloadToAccept); err != nil {
+	if err := b.WriteMessage(payloadToAccept); err != nil {
 		t.Fatalf("write for payload was rejected, should have been " +
 			"accepted")
 	}
@@ -243,7 +241,7 @@ func TestMaxPayloadLength(t *testing.T) {
 	payloadToReject = make([]byte, math.MaxUint16+1)
 
 	// This payload should be rejected.
-	err = b.WriteMessage(&buf, payloadToReject)
+	err = b.WriteMessage(payloadToReject)
 	if err != ErrMaxMessageLengthExceeded {
 		t.Fatalf("payload is over the max allowed length, the write " +
 			"should have been rejected")
@@ -502,9 +500,13 @@ func TestBolt0008TestVectors(t *testing.T) {
 	var buf bytes.Buffer
 
 	for i := 0; i < 1002; i++ {
-		err = initiator.WriteMessage(&buf, payload)
+		err = initiator.WriteMessage(payload)
 		if err != nil {
 			t.Fatalf("could not write message %s", payload)
+		}
+		_, err = initiator.Flush(&buf)
+		if err != nil {
+			t.Fatalf("could not flush message: %v", err)
 		}
 		if val, ok := transportMessageVectors[i]; ok {
 			binaryVal, err := hex.DecodeString(val)

--- a/brontide/noise_test.go
+++ b/brontide/noise_test.go
@@ -269,6 +269,8 @@ func TestWriteMessageChunking(t *testing.T) {
 	var wg sync.WaitGroup
 	wg.Add(1)
 	go func() {
+		defer wg.Done()
+
 		bytesWritten, err := localConn.Write(largeMessage)
 		if err != nil {
 			t.Fatalf("unable to write message: %v", err)
@@ -280,7 +282,6 @@ func TestWriteMessageChunking(t *testing.T) {
 			t.Fatalf("bytes not fully written!")
 		}
 
-		wg.Done()
 	}()
 
 	// Attempt to read the entirety of the message generated above.

--- a/lncfg/workers.go
+++ b/lncfg/workers.go
@@ -9,7 +9,7 @@ const (
 
 	// DefaultWriteWorkers is the default maximum number of concurrent
 	// workers used by the daemon's write pool.
-	DefaultWriteWorkers = 100
+	DefaultWriteWorkers = 8
 
 	// DefaultSigWorkers is the default maximum number of concurrent workers
 	// used by the daemon's sig pool.
@@ -20,13 +20,13 @@ const (
 // pools.
 type Workers struct {
 	// Read is the maximum number of concurrent read pool workers.
-	Read int `long:"read" description:"Maximum number of concurrent read pool workers."`
+	Read int `long:"read" description:"Maximum number of concurrent read pool workers. This number should be proportional to the number of peers."`
 
 	// Write is the maximum number of concurrent write pool workers.
-	Write int `long:"write" description:"Maximum number of concurrent write pool workers."`
+	Write int `long:"write" description:"Maximum number of concurrent write pool workers. This number should be proportional to the number of CPUs on the host. "`
 
 	// Sig is the maximum number of concurrent sig pool workers.
-	Sig int `long:"sig" description:"Maximum number of concurrent sig pool workers."`
+	Sig int `long:"sig" description:"Maximum number of concurrent sig pool workers. This number should be proportional to the number of CPUs on the host."`
 }
 
 // Validate checks the Workers configuration to ensure that the input values are


### PR DESCRIPTION
This PR modifies the behavior of the peer writes messages to the wire, such that we are able to gracefully handle timeout errors and resume partially sent messages. As of #2819, if a message is partially written to the wire due to a timeout error, we will try to write the full message again. In turn, this will produce an authentication error on the remote side (after it is able to read the number of bytes specified in the header) since the middle of the latter ciphertext will not pass as the MAC check.

We resolve this by splitting the `Write` call into two subroutines, `WriteMessage`  and `Flush`. `WriteMessage` encrypts the plaintext and buffers the ciphertext on the underlying connection. A subsequent call to `Flush` will then attempt to write the bytes out on the wire. If a timeout error is encountered during flush, we can safely resume the byte stream by calling `Flush` again. In addition to being able to resume partial writes, this also has a _yuge_ benefit in not blocking the write pool with network operations. This fully decouples the number of write pool workers from the number of peers, since the blocking operations now take place in each peer.

This is an alternative, and more complete fix, to #2901, which only offers the ability to fail faster if a partial write takes place.