### PR TITLE
routing: tracking visited nodes in findPath

### DIFF
--- a/channeldb/graph.go
+++ b/channeldb/graph.go
@@ -236,6 +236,28 @@ func (c *ChannelGraph) ForEachChannel(cb func(*ChannelEdgeInfo, *ChannelEdgePoli
 	})
 }
 
+// ForEachNodeChannel iterates through all channels of a given node, executing the
+// passed callback with an edge info structure and the policies of each end
+// of the channel. The first edge policy is the outgoing edge *to* the
+// the connecting node, while the second is the incoming edge *from* the
+// connecting node. If the callback returns an error, then the iteration is
+// halted with the error propagated back up to the caller.
+//
+// Unknown policies are passed into the callback as nil values.
+//
+// If the caller wishes to re-use an existing boltdb transaction, then it
+// should be passed as the first argument.  Otherwise the first argument should
+// be nil and a fresh transaction will be created to execute the graph
+// traversal.
+func (c *ChannelGraph) ForEachNodeChannel(tx *bbolt.Tx, nodePub []byte,
+	cb func(*bbolt.Tx, *ChannelEdgeInfo, *ChannelEdgePolicy,
+		*ChannelEdgePolicy) error) error {
+
+	db := c.db
+
+	return nodeTraversal(tx, nodePub, db, cb)
+}
+
 // ForEachNode iterates through all the stored vertices/nodes in the graph,
 // executing the passed callback with each node encountered. If the callback
 // returns an error, then the transaction is aborted and the iteration stops
@@ -2183,23 +2205,10 @@ func (c *ChannelGraph) HasLightningNode(nodePub [33]byte) (time.Time, bool, erro
 	return updateTime, exists, nil
 }
 
-// ForEachChannel iterates through all channels of this node, executing the
-// passed callback with an edge info structure and the policies of each end
-// of the channel. The first edge policy is the outgoing edge *to* the
-// the connecting node, while the second is the incoming edge *from* the
-// connecting node. If the callback returns an error, then the iteration is
-// halted with the error propagated back up to the caller.
-//
-// Unknown policies are passed into the callback as nil values.
-//
-// If the caller wishes to re-use an existing boltdb transaction, then it
-// should be passed as the first argument.  Otherwise the first argument should
-// be nil and a fresh transaction will be created to execute the graph
-// traversal.
-func (l *LightningNode) ForEachChannel(tx *bbolt.Tx,
+// nodeTraversal is used to traverse all channels of a node given by its
+// public key and passes channel information into the specified callback.
+func nodeTraversal(tx *bbolt.Tx, nodePub []byte, db *DB,
 	cb func(*bbolt.Tx, *ChannelEdgeInfo, *ChannelEdgePolicy, *ChannelEdgePolicy) error) error {
-
-	nodePub := l.PubKeyBytes[:]
 
 	traversal := func(tx *bbolt.Tx) error {
 		nodes := tx.Bucket(nodeBucket)
@@ -2241,7 +2250,7 @@ func (l *LightningNode) ForEachChannel(tx *bbolt.Tx,
 			if err != nil {
 				return err
 			}
-			edgeInfo.db = l.db
+			edgeInfo.db = db
 
 			outgoingPolicy, err := fetchChanEdgePolicy(
 				edges, chanID, nodePub, nodes,
@@ -2256,7 +2265,7 @@ func (l *LightningNode) ForEachChannel(tx *bbolt.Tx,
 			}
 
 			incomingPolicy, err := fetchChanEdgePolicy(
-				edges, chanID, otherNode, nodes,
+				edges, chanID, otherNode[:], nodes,
 			)
 			if err != nil {
 				return err
@@ -2275,12 +2284,34 @@ func (l *LightningNode) ForEachChannel(tx *bbolt.Tx,
 	// If no transaction was provided, then we'll create a new transaction
 	// to execute the transaction within.
 	if tx == nil {
-		return l.db.View(traversal)
+		return db.View(traversal)
 	}
 
 	// Otherwise, we re-use the existing transaction to execute the graph
 	// traversal.
 	return traversal(tx)
+}
+
+// ForEachChannel iterates through all channels of this node, executing the
+// passed callback with an edge info structure and the policies of each end
+// of the channel. The first edge policy is the outgoing edge *to* the
+// the connecting node, while the second is the incoming edge *from* the
+// connecting node. If the callback returns an error, then the iteration is
+// halted with the error propagated back up to the caller.
+//
+// Unknown policies are passed into the callback as nil values.
+//
+// If the caller wishes to re-use an existing boltdb transaction, then it
+// should be passed as the first argument.  Otherwise the first argument should
+// be nil and a fresh transaction will be created to execute the graph
+// traversal.
+func (l *LightningNode) ForEachChannel(tx *bbolt.Tx,
+	cb func(*bbolt.Tx, *ChannelEdgeInfo, *ChannelEdgePolicy, *ChannelEdgePolicy) error) error {
+
+	nodePub := l.PubKeyBytes[:]
+	db := l.db
+
+	return nodeTraversal(tx, nodePub, db, cb)
 }
 
 // ChannelEdgeInfo represents a fully authenticated channel along with all its
@@ -2450,15 +2481,15 @@ func (c *ChannelEdgeInfo) BitcoinKey2() (*btcec.PublicKey, error) {
 // OtherNodeKeyBytes returns the node key bytes of the other end of
 // the channel.
 func (c *ChannelEdgeInfo) OtherNodeKeyBytes(thisNodeKey []byte) (
-	[]byte, error) {
+	[33]byte, error) {
 
 	switch {
 	case bytes.Equal(c.NodeKey1Bytes[:], thisNodeKey):
-		return c.NodeKey2Bytes[:], nil
+		return c.NodeKey2Bytes, nil
 	case bytes.Equal(c.NodeKey2Bytes[:], thisNodeKey):
-		return c.NodeKey1Bytes[:], nil
+		return c.NodeKey1Bytes, nil
 	default:
-		return nil, fmt.Errorf("node not participating in this channel")
+		return [33]byte{}, fmt.Errorf("node not participating in this channel")
 	}
 }
 

--- a/routing/heap.go
+++ b/routing/heap.go
@@ -3,6 +3,7 @@ package routing
 import (
 	"github.com/lightningnetwork/lnd/channeldb"
 	"github.com/lightningnetwork/lnd/lnwire"
+	"github.com/lightningnetwork/lnd/routing/route"
 )
 
 // nodeWithDist is a helper struct that couples the distance from the current
@@ -12,9 +13,9 @@ type nodeWithDist struct {
 	// current context.
 	dist int64
 
-	// node is the vertex itself. This pointer can be used to explore all
-	// the outgoing edges (channels) emanating from a node.
-	node *channeldb.LightningNode
+	// node is the vertex itself. This can be used to explore all the
+	// outgoing edges (channels) emanating from a node.
+	node route.Vertex
 
 	// amountToReceive is the amount that should be received by this node.
 	// Either as final payment to the final node or as an intermediate

--- a/routing/heap.go
+++ b/routing/heap.go
@@ -1,6 +1,8 @@
 package routing
 
 import (
+	"container/heap"
+
 	"github.com/lightningnetwork/lnd/channeldb"
 	"github.com/lightningnetwork/lnd/lnwire"
 	"github.com/lightningnetwork/lnd/routing/route"
@@ -40,6 +42,21 @@ type nodeWithDist struct {
 // algorithm to keep track of the "closest" node to our source node.
 type distanceHeap struct {
 	nodes []nodeWithDist
+
+	// pubkeyIndices maps public keys of nodes to their respective index in
+	// the heap. This is used as a way to avoid db lookups by using heap.Fix
+	// instead of having duplicate entries on the heap.
+	pubkeyIndices map[route.Vertex]int
+}
+
+// newDistanceHeap initializes a new distance heap. This is required because
+// we must initialize the pubkeyIndices map for path-finding optimizations.
+func newDistanceHeap() distanceHeap {
+	distHeap := distanceHeap{
+		pubkeyIndices: make(map[route.Vertex]int),
+	}
+
+	return distHeap
 }
 
 // Len returns the number of nodes in the priority queue.
@@ -60,13 +77,17 @@ func (d *distanceHeap) Less(i, j int) bool {
 // NOTE: This is part of the heap.Interface implementation.
 func (d *distanceHeap) Swap(i, j int) {
 	d.nodes[i], d.nodes[j] = d.nodes[j], d.nodes[i]
+	d.pubkeyIndices[d.nodes[i].node] = i
+	d.pubkeyIndices[d.nodes[j].node] = j
 }
 
 // Push pushes the passed item onto the priority queue.
 //
 // NOTE: This is part of the heap.Interface implementation.
 func (d *distanceHeap) Push(x interface{}) {
-	d.nodes = append(d.nodes, x.(nodeWithDist))
+	n := x.(nodeWithDist)
+	d.nodes = append(d.nodes, n)
+	d.pubkeyIndices[n.node] = len(d.nodes) - 1
 }
 
 // Pop removes the highest priority item (according to Less) from the priority
@@ -77,7 +98,27 @@ func (d *distanceHeap) Pop() interface{} {
 	n := len(d.nodes)
 	x := d.nodes[n-1]
 	d.nodes = d.nodes[0 : n-1]
+	delete(d.pubkeyIndices, x.node)
 	return x
+}
+
+// PushOrFix attempts to adjust the position of a given node in the heap.
+// If the vertex already exists in the heap, then we must call heap.Fix to
+// modify its position and reorder the heap. If the vertex does not already
+// exist in the heap, then it is pushed onto the heap. Otherwise, we will end
+// up performing more db lookups on the same node in the pathfinding algorithm.
+func (d *distanceHeap) PushOrFix(dist nodeWithDist) {
+	index, ok := d.pubkeyIndices[dist.node]
+	if !ok {
+		heap.Push(d, dist)
+		return
+	}
+
+	// Change the value at the specified index.
+	d.nodes[index] = dist
+
+	// Call heap.Fix to reorder the heap.
+	heap.Fix(d, index)
 }
 
 // path represents an ordered set of edges which forms an available path from a

--- a/routing/pathfind.go
+++ b/routing/pathfind.go
@@ -300,7 +300,7 @@ func findPath(g *graphParams, r *RestrictParams, source, target route.Vertex,
 	// First we'll initialize an empty heap which'll help us to quickly
 	// locate the next edge we should visit next during our graph
 	// traversal.
-	var nodeHeap distanceHeap
+	nodeHeap := newDistanceHeap()
 
 	// For each node in the graph, we create an entry in the distance map
 	// for the node set with a distance of "infinity". graph.ForEachNode
@@ -527,9 +527,10 @@ func findPath(g *graphParams, r *RestrictParams, source, target route.Vertex,
 
 		next[fromVertex] = edge
 
-		// Add this new node to our heap as we'd like to further
-		// explore backwards through this edge.
-		heap.Push(&nodeHeap, distance[fromVertex])
+		// Either push distance[fromVertex] onto the heap if the node
+		// represented by fromVertex is not already on the heap OR adjust
+		// its position within the heap via heap.Fix.
+		nodeHeap.PushOrFix(distance[fromVertex])
 	}
 
 	// TODO(roasbeef): also add path caching


### PR DESCRIPTION
These commits add a `visitedNodes` map that tracks if the Djikstra's algorithm in `findPath` has already visited this node before.  Previously, when evaluating the best node, we would look at all of the incoming edges and repeat the `processEdge` flow for already visited nodes.  The second commit enables the `TestNewRoutePathTooLong` test by fixing the excessive hops graph to correctly be parsed.