### PR TITLE
htlcswitch: fix empty commit sig and no commit sig

### DIFF
--- a/htlcswitch/link.go
+++ b/htlcswitch/link.go
@@ -1103,7 +1103,7 @@ out:
 			// update in some time, check to see if we have any
 			// pending updates we need to commit due to our
 			// commitment chains being desynchronized.
-			if l.channel.FullySynced() {
+			if !l.channel.OweCommitment(true) {
 				continue
 			}
 
@@ -1808,7 +1808,7 @@ func (l *channelLink) handleUpstreamMsg(msg lnwire.Message) {
 		// If both commitment chains are fully synced from our PoV,
 		// then we don't need to reply with a signature as both sides
 		// already have a commitment with the latest accepted.
-		if l.channel.FullySynced() {
+		if !l.channel.OweCommitment(true) {
 			return
 		}
 

--- a/htlcswitch/link_test.go
+++ b/htlcswitch/link_test.go
@@ -5983,20 +5983,12 @@ func TestChannelLinkRevocationWindowRegular(t *testing.T) {
 	// At this point, Alice cannot send a new commit sig to bob because the
 	// revocation window is exhausted.
 
-	// Sleep to let the commit ticker expire. The revocation window is still
-	// exhausted.
-	time.Sleep(time.Second)
-
 	// Bob sends revocation and signs commit with htlc1 settled.
 	ctx.sendRevAndAckBobToAlice()
 
-	// Allow some time for the log commit ticker to trigger for Alice.
-	time.Sleep(time.Second)
-
-	// Now that Bob revoked, Alice should send the sig she owes.
-	//
-	// THIS SHOULD NOT HAPPEN.
-	ctx.assertNoMsgFromAlice(time.Second)
+	// After the revocation, it is again possible for Alice to send a commit
+	// sig with htlc2.
+	ctx.receiveCommitSigAliceToBob(1)
 }
 
 // TestChannelLinkRevocationWindowHodl asserts that htlcs paying to a hodl

--- a/htlcswitch/link_test.go
+++ b/htlcswitch/link_test.go
@@ -4699,11 +4699,10 @@ func TestChannelLinkNoEmptySig(t *testing.T) {
 	ctx.receiveRevAndAckAliceToBob()
 	ctx.sendRevAndAckBobToAlice()
 
-	// The situation now is that Alice still doesn't have her two htlcs on
-	// the local commit tx. Bob needs to send a new signature and Alice can
-	// only wait for that. However, Alice's log commit timer fires and Alice
-	// sends a commitment tx containing no updates. THIS SHOULD NOT HAPPEN!
-	ctx.receiveCommitSigAliceToBob(2)
+	// The commit txes are not in sync, but it is Bob's turn to send a new
+	// signature. We don't expect Alice to send out any message. This check
+	// allows some time for the log commit ticker to trigger for Alice.
+	ctx.assertNoMsgFromAlice(time.Second)
 }
 
 // TestChannelLinkBatchPreimageWrite asserts that a link will batch preimage
@@ -6109,9 +6108,8 @@ func TestChannelLinkReceiveEmptySig(t *testing.T) {
 	// Send RevokeAndAck Bob->Alice to ack the added htlc.
 	ctx.sendRevAndAckBobToAlice()
 
-	// No new updates to sign, Alice still sends out an empty sig. THIS
-	// SHOULD NOT HAPPEN!
-	ctx.receiveCommitSigAliceToBob(1)
+	// We received an empty commit sig, we accepted it, but there is nothing
+	// new to sign for us.
 
 	// No other messages are expected.
 	ctx.assertNoMsgFromAlice(time.Second)

--- a/lnwallet/channel.go
+++ b/lnwallet/channel.go
@@ -3535,7 +3535,7 @@ func (lc *LightningChannel) ProcessChanSyncMsg(
 		// but died before the signature was sent. We re-transmit our
 		// revocation, but also initiate a state transition to re-sync
 		// them.
-		if !lc.FullySynced() {
+		if lc.OweCommitment(true) {
 			commitSig, htlcSigs, _, err := lc.SignNextCommitment()
 			switch {
 
@@ -4223,26 +4223,6 @@ func (lc *LightningChannel) oweCommitment(local bool) bool {
 		localUpdatesPending, remoteUpdatesPending)
 
 	return oweCommitment
-}
-
-// FullySynced returns a boolean value reflecting if both commitment chains
-// (remote+local) are fully in sync. Both commitment chains are fully in sync
-// if the tip of each chain includes the latest committed changes from both
-// sides.
-func (lc *LightningChannel) FullySynced() bool {
-	lc.RLock()
-	defer lc.RUnlock()
-
-	lastLocalCommit := lc.localCommitChain.tip()
-	lastRemoteCommit := lc.remoteCommitChain.tip()
-
-	localUpdatesSynced := (lastLocalCommit.ourMessageIndex ==
-		lastRemoteCommit.ourMessageIndex)
-
-	remoteUpdatesSynced := (lastLocalCommit.theirMessageIndex ==
-		lastRemoteCommit.theirMessageIndex)
-
-	return localUpdatesSynced && remoteUpdatesSynced
 }
 
 // RevokeCurrentCommitment revokes the next lowest unrevoked commitment

--- a/lnwallet/channel.go
+++ b/lnwallet/channel.go
@@ -3233,6 +3233,14 @@ func (lc *LightningChannel) SignNextCommitment() (lnwire.Sig, []lnwire.Sig, []ch
 	lc.Lock()
 	defer lc.Unlock()
 
+	// Check for empty commit sig. This should never happen, but we don't
+	// dare to fail hard here. We assume peers can deal with the empty sig
+	// and continue channel operation. We log an error so that the bug
+	// causing this can be tracked down.
+	if !lc.oweCommitment(true) {
+		lc.log.Errorf("sending empty commit sig")
+	}
+
 	var (
 		sig      lnwire.Sig
 		htlcSigs []lnwire.Sig
@@ -3987,6 +3995,18 @@ func (lc *LightningChannel) ReceiveNewCommitment(commitSig lnwire.Sig,
 	lc.Lock()
 	defer lc.Unlock()
 
+	// Check for empty commit sig. Because of a previously existing bug, it
+	// is possible that we receive an empty commit sig from nodes running an
+	// older version. This is a relaxation of the spec, but it is still
+	// possible to handle it. To not break any channels with those older
+	// nodes, we just log the event. This check is also not totally
+	// reliable, because it could be that we've sent out a new sig, but the
+	// remote hasn't received it yet. We could then falsely assume that they
+	// should add our updates to their remote commitment tx.
+	if !lc.oweCommitment(false) {
+		lc.log.Warnf("empty commit sig message received")
+	}
+
 	// Determine the last update on the local log that has been locked in.
 	localACKedIndex := lc.remoteCommitChain.tail().ourMessageIndex
 	localHtlcIndex := lc.remoteCommitChain.tail().ourHtlcIndex
@@ -4138,6 +4158,71 @@ func (lc *LightningChannel) ReceiveNewCommitment(commitSig lnwire.Sig,
 	lc.localCommitChain.addCommitment(localCommitmentView)
 
 	return nil
+}
+
+// OweCommitment returns a boolean value reflecting whether we need to send
+// out a commitment signature because there are outstanding local updates and/or
+// updates in the local commit tx that aren't reflected in the remote commit tx
+// yet.
+func (lc *LightningChannel) OweCommitment(local bool) bool {
+	lc.RLock()
+	defer lc.RUnlock()
+
+	return lc.oweCommitment(local)
+}
+
+// oweCommitment is the internal version of OweCommitment. This function expects
+// to be executed with a lock held.
+func (lc *LightningChannel) oweCommitment(local bool) bool {
+	var (
+		remoteUpdatesPending, localUpdatesPending bool
+
+		lastLocalCommit  = lc.localCommitChain.tip()
+		lastRemoteCommit = lc.remoteCommitChain.tip()
+
+		perspective string
+	)
+
+	if local {
+		perspective = "local"
+
+		// There are local updates pending if our local update log is
+		// not in sync with our remote commitment tx.
+		localUpdatesPending = lc.localUpdateLog.logIndex !=
+			lastRemoteCommit.ourMessageIndex
+
+		// There are remote updates pending if their remote commitment
+		// tx (our local commitment tx) contains updates that we don't
+		// have added to our remote commitment tx yet.
+		remoteUpdatesPending = lastLocalCommit.theirMessageIndex !=
+			lastRemoteCommit.theirMessageIndex
+
+	} else {
+		perspective = "remote"
+
+		// There are local updates pending (local updates from the
+		// perspective of the remote party) if the remote party has
+		// updates to their remote tx pending for which they haven't
+		// signed yet.
+		localUpdatesPending = lc.remoteUpdateLog.logIndex !=
+			lastLocalCommit.theirMessageIndex
+
+		// There are remote updates pending (remote updates from the
+		// perspective of the remote party) if we have updates on our
+		// remote commitment tx that they haven't added to theirs yet.
+		remoteUpdatesPending = lastRemoteCommit.ourMessageIndex !=
+			lastLocalCommit.ourMessageIndex
+	}
+
+	// If any of the conditions above is true, we owe a commitment
+	// signature.
+	oweCommitment := localUpdatesPending || remoteUpdatesPending
+
+	lc.log.Tracef("%v owes commit: %v (local updates: %v, "+
+		"remote updates %v)", perspective, oweCommitment,
+		localUpdatesPending, remoteUpdatesPending)
+
+	return oweCommitment
 }
 
 // FullySynced returns a boolean value reflecting if both commitment chains

--- a/lnwallet/channel.go
+++ b/lnwallet/channel.go
@@ -4225,6 +4225,17 @@ func (lc *LightningChannel) oweCommitment(local bool) bool {
 	return oweCommitment
 }
 
+// PendingLocalUpdateCount returns the number of local updates that still need
+// to be applied to the remote commitment tx.
+func (lc *LightningChannel) PendingLocalUpdateCount() uint64 {
+	lc.RLock()
+	defer lc.RUnlock()
+
+	lastRemoteCommit := lc.remoteCommitChain.tip()
+
+	return lc.localUpdateLog.logIndex - lastRemoteCommit.ourMessageIndex
+}
+
 // RevokeCurrentCommitment revokes the next lowest unrevoked commitment
 // transaction in the local commitment chain. As a result the edge of our
 // revocation window is extended by one, and the tail of our local commitment


### PR DESCRIPTION
Builds on top of #3564.

This PR fixes two known bugs in the commitment tx update sequence:
* Sending an commit sig message that didn't sign any new updates ("empty commit sig")
* Not sending a commit sig message when it is expected.

In addition to that, several simplifications are carried through where values were tracked in the link that can also be obtained from the channel.