### PR TITLE
Update Go version from 1.11 to 1.12

### DIFF
--- a/docker/btcd/Dockerfile
+++ b/docker/btcd/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.11-alpine as builder
+FROM golang:1.12-alpine as builder
 
 MAINTAINER Olaoluwa Osuntokun <laolu@lightning.network>
 

--- a/docker/lnd/Dockerfile
+++ b/docker/lnd/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.11-alpine as builder
+FROM golang:1.12-alpine as builder
 
 MAINTAINER Olaoluwa Osuntokun <lightning.engineering>
 

--- a/docker/ltcd/Dockerfile
+++ b/docker/ltcd/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.11-alpine as builder
+FROM golang:1.12-alpine as builder
 
 MAINTAINER Olaoluwa Osuntokun <lightning.engineering>
 

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -26,46 +26,46 @@
   * **Go:** `lnd` is written in Go. To install, run one of the following commands:
 
 
-    **Note**: The minimum version of Go supported is Go 1.11. We recommend that
+    **Note**: The minimum version of Go supported is Go 1.12. We recommend that
     users use the latest version of Go, which at the time of writing is
-    [`1.11`](https://blog.golang.org/go1.11).
+    [`1.12`](https://blog.golang.org/go1.12).
 
 
     On Linux:
 
     (x86-64)
     ```
-    wget https://dl.google.com/go/go1.11.5.linux-amd64.tar.gz
-    sha256sum go1.11.5.linux-amd64.tar.gz | awk -F " " '{ print $1 }'
+    wget https://dl.google.com/go/go1.12.3.linux-amd64.tar.gz
+    sha256sum go1.12.3.linux-amd64.tar.gz | awk -F " " '{ print $1 }'
     ```
 
     The final output of the command above should be
-    `ff54aafedff961eb94792487e827515da683d61a5f9482f668008832631e5d25`. If it
+    `3924819eed16e55114f02d25d03e77c916ec40b7fd15c8acb5838b63135b03df`. If it
     isn't, then the target REPO HAS BEEN MODIFIED, and you shouldn't install
     this version of Go. If it matches, then proceed to install Go:
     ```
-    tar -C /usr/local -xzf go1.11.5.linux-amd64.tar.gz
+    tar -C /usr/local -xzf go1.12.3.linux-amd64.tar.gz
     export PATH=$PATH:/usr/local/go/bin
     ```
 
     (ARMv6)
     ```
-    wget https://dl.google.com/go/go1.11.5.linux-armv6l.tar.gz
-    sha256sum go1.11.5.linux-armv6l.tar.gz | awk -F " " '{ print $1 }'
+    wget https://dl.google.com/go/go1.12.3.linux-armv6l.tar.gz
+    sha256sum go1.12.3.linux-armv6l.tar.gz | awk -F " " '{ print $1 }'
     ```
 
     The final output of the command above should be
-    `b26b53c94923f78955236386fee0725ef4e76b6cb47e0df0ed0c0c4724e7b198`. If it
+    `efce59fac5ebc7302263ca1093fe2c3252c1b936f5b1ae08afc328eea0403c79`. If it
     isn't, then the target REPO HAS BEEN MODIFIED, and you shouldn't install
     this version of Go. If it matches, then proceed to install Go:
     ```
-    tar -C /usr/local -xzf go1.11.5.linux-armv6l.tar.gz
+    tar -C /usr/local -xzf go1.12.3.linux-armv6l.tar.gz
     export PATH=$PATH:/usr/local/go/bin
     ```
 
     On Mac OS X:
     ```
-    brew install go@1.11
+    brew install go@1.12
     ```
 
     On FreeBSD:
@@ -74,9 +74,9 @@
     ```
 
     Alternatively, one can download the pre-compiled binaries hosted on the
-    [golang download page](https://golang.org/dl/). If one seeks to install
+    [Golang download page](https://golang.org/dl/). If one seeks to install
     from source, then more detailed installation instructions can be found
-    [here](http://golang.org/doc/install).
+    [here](https://golang.org/doc/install).
 
     At this point, you should set your `$GOPATH` environment variable, which
     represents the path to your workspace. By default, `$GOPATH` is set to
@@ -91,10 +91,10 @@
     We recommend placing the above in your .bashrc or in a setup script so that
     you can avoid typing this every time you open a new terminal window.
 
-  * **go modules:** This project uses [go modules](https://github.com/golang/go/wiki/Modules) 
+  * **Go modules:** This project uses [Go modules](https://github.com/golang/go/wiki/Modules) 
     to manage dependencies as well as to provide *reproducible builds*.
 
-    Usage of go modules (with go 1.11) means that you no longer need to clone
+    Usage of Go modules (with Go 1.12) means that you no longer need to clone
     `lnd` into your `$GOPATH` for development purposes. Instead, your `lnd`
     repo can now live anywhere!
 
@@ -109,7 +109,7 @@ make && make install
 ```
 
 **NOTE**: Our instructions still use the `$GOPATH` directory from prior
-versions of Go, but with go 1.11, it's now possible for `lnd` to live
+versions of Go, but with Go 1.12, it's now possible for `lnd` to live
 _anywhere_ on your file system.
 
 For Windows WSL users, make will need to be referenced directly via
@@ -268,7 +268,7 @@ btcctl --testnet --rpcuser=REPLACEME --rpcpass=REPLACEME getpeerinfo | more
 If you are on testnet, run this command after `btcd` has finished syncing.
 Otherwise, replace `--bitcoin.testnet` with `--bitcoin.simnet`. If you are
 installing `lnd` in preparation for the
-[tutorial](http://dev.lightning.community/tutorial), you may skip this step.
+[tutorial](https://dev.lightning.community/tutorial), you may skip this step.
 ```
 lnd --bitcoin.active --bitcoin.testnet --debuglevel=debug --btcd.rpcuser=kek --btcd.rpcpass=kek --externalip=X.X.X.X
 ```


### PR DESCRIPTION
This is a follow-up PR to #2830, which already updated the Go version in the contribution checklist.

Pinging @cfromknecht, who mentioned in [this PR comment](https://github.com/lightningnetwork/lnd/pull/2830#pullrequestreview-223480557) that it would be nice to also have the installation docs updated before the final 0.6 release.

A few things to note here:

1. I'm not sure about the macOS installation. On https://formulae.brew.sh/formula/go it's mentioned that the `go` package is "also known as `go@1.12`", but while https://formulae.brew.sh/formula/go@1.11 is a valid URL, https://formulae.brew.sh/formula/go@1.12 is not. So maybe someone with a Mac can test that `brew install go@1.12` works at all?
2. Similar to a Mac, I don't have a FreeBSD installation, so I can't test that either. I didn't change the docs for FreeBSD and when searching for a Go package with https://www.freebsd.org/cgi/ports.cgi?query=%5Ego&stype=name&sektion=lang there's only `go-1.12.2,1`. I'm not sure if `go` works as an alias for that package though.

Another option would be to not advise to use a package manager at all, and use https://dl.google.com/go/go1.12.3.darwin-amd64.pkg for macOS and https://dl.google.com/go/go1.12.3.freebsd-amd64.tar.gz for FreeBSD instead, or even just point to https://golang.org/doc/install for both.

#### Pull Request Checklist

- [x] If this is your first time contributing, we recommend you read the [Code
  Contribution Guidelines](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md)
- [x] All changes are Go version 1.12 compliant
- [x] The code being submitted is commented according to [Code Documentation and Commenting](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#CodeDocumentation)
- [x] For new code: Code is accompanied by tests which exercise both
  the positive and negative (error paths) conditions (if applicable)
- [x] For bug fixes: Code is accompanied by new tests which trigger
  the bug being fixed to prevent regressions
- [x] Any new logging statements use an appropriate subsystem and
  logging level
- [x] Code has been formatted with `go fmt`
- [x] For code and documentation: lines are wrapped at 80 characters
  (the tab character should be counted as 8 characters, not 4, as some IDEs do
  per default)
- [x] Running `make check` does not fail any tests
- [x] Running `go vet` does not report any issues
- [x] Running `make lint` does not report any **new** issues that did not
  already exist
- [x] All commits build properly and pass tests. Only in exceptional
  cases it can be justifiable to violate this condition. In that case, the
  reason should be stated in the commit message.
- [x] Commits have a logical structure according to [Ideal Git Commit Structure](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#IdealGitCommitStructure)
