### PR TITLE
htlcswitch: only perform CLTV checks for HTLCs with open invoices

### DIFF
--- a/htlcswitch/link.go
+++ b/htlcswitch/link.go
@@ -2792,7 +2792,7 @@ func (l *channelLink) processExitHop(pd *lnwallet.PaymentDescriptor,
 	expectedHeight := heightNow + minCltvDelta
 	switch {
 	case !l.cfg.DebugHTLC &&
-		invoice.Terms.State != channeldb.ContractAccepted &&
+		invoice.Terms.State == channeldb.ContractOpen &&
 		pd.Timeout < expectedHeight:
 
 		log.Errorf("Incoming htlc(%x) has an expiration that is too "+


### PR DESCRIPTION
In this commit, we fix a bug that would cause a node with a hodl HTLC to
cancel back the HTLC upon restart if the invoice has been settled, but
the HTLC is still present on the commitment transaction. A fix for the
HTLC still being present (not triggering a new commitment) has been
fixed recently. However, for older nodes with a lingering HTLC, on
restart it would be failed back.

In this commit, we make the check stricter by only performing these
checks for HTLCs that are in the open state. This ensures that we'll
only check this constraints the first time around, before the HTLC has
been transitioned to the accepted state.

