### PR TITLE
lncfg: parse network for TCP addresses to listen on correct interface

### DIFF
--- a/config.go
+++ b/config.go
@@ -919,22 +919,6 @@ func loadConfig() (*config, error) {
 		cfg.RawListeners = append(cfg.RawListeners, addr)
 	}
 
-	// For each of the RPC listeners (REST+gRPC), we'll ensure that users
-	// have specified a safe combo for authentication. If not, we'll bail
-	// out with an error.
-	err = lncfg.EnforceSafeAuthentication(
-		cfg.RPCListeners, !cfg.NoMacaroons,
-	)
-	if err != nil {
-		return nil, err
-	}
-	err = lncfg.EnforceSafeAuthentication(
-		cfg.RESTListeners, !cfg.NoMacaroons,
-	)
-	if err != nil {
-		return nil, err
-	}
-
 	// Add default port to all RPC listener addresses if needed and remove
 	// duplicate addresses.
 	cfg.RPCListeners, err = lncfg.NormalizeAddresses(
@@ -950,6 +934,22 @@ func loadConfig() (*config, error) {
 	cfg.RESTListeners, err = lncfg.NormalizeAddresses(
 		cfg.RawRESTListeners, strconv.Itoa(defaultRESTPort),
 		cfg.net.ResolveTCPAddr,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	// For each of the RPC listeners (REST+gRPC), we'll ensure that users
+	// have specified a safe combo for authentication. If not, we'll bail
+	// out with an error.
+	err = lncfg.EnforceSafeAuthentication(
+		cfg.RPCListeners, !cfg.NoMacaroons,
+	)
+	if err != nil {
+		return nil, err
+	}
+	err = lncfg.EnforceSafeAuthentication(
+		cfg.RESTListeners, !cfg.NoMacaroons,
 	)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
TCP addresses resolved through `net.ResolveTCPAddr` give a default network of "tcp", so we map back the correct network for the given address. This ensures that we can listen on the correct interface (IPv4 vs IPv6).

Fixes https://github.com/lightningnetwork/lnd/issues/2776.
Related: https://github.com/golang/go/issues/17615#issuecomment-256445349