### PR TITLE
routing: remove route cache

### DIFF
--- a/routing/pathfind_test.go
+++ b/routing/pathfind_test.go
@@ -1778,7 +1778,6 @@ func TestPathFindSpecExample(t *testing.T) {
 	}
 
 	// We'll now request a route from A -> B -> C.
-	ctx.router.routeCache = make(map[routeTuple][]*Route)
 	routes, err = ctx.router.FindRoutes(
 		source.PubKeyBytes, carol, amt, noRestrictions, 100,
 	)


### PR DESCRIPTION
This commit removes the QueryRoutes route cache. It is causing wrong
routes to be returned because not all of the request parameters are
stored.

The cache allowed high frequency QueryRoutes calls to the same
destination and with the same amount to be returned fast. This behaviour
can also be achieved by caching the request on the client side. In case
a route is invalidated because of for example a channel update,
the subsequent SendToRoute call will fail. This is a trigger to call
QueryRoutes again for a fresh route.
