### PR TITLE
cmd/lncli: remove unused time_limit flag

### DIFF
--- a/cmd/lncli/commands.go
+++ b/cmd/lncli/commands.go
@@ -838,7 +838,7 @@ var closeChannelCommand = cli.Command{
 	To view which funding_txids/output_indexes can be used for a channel close,
 	see the channel_point values within the listchannels command output.
 	The format for a channel_point is 'funding_txid:output_index'.`,
-	ArgsUsage: "funding_txid [output_index [time_limit]]",
+	ArgsUsage: "funding_txid [output_index]",
 	Flags: []cli.Flag{
 		cli.StringFlag{
 			Name:  "funding_txid",
@@ -849,15 +849,9 @@ var closeChannelCommand = cli.Command{
 			Usage: "the output index for the funding output of the funding " +
 				"transaction",
 		},
-		cli.StringFlag{
-			Name: "time_limit",
-			Usage: "a relative deadline afterwhich the attempt should be " +
-				"abandoned",
-		},
 		cli.BoolFlag{
-			Name: "force",
-			Usage: "after the time limit has passed, attempt an " +
-				"uncooperative closure",
+			Name:  "force",
+			Usage: "attempt an uncooperative closure",
 		},
 		cli.BoolFlag{
 			Name:  "block",


### PR DESCRIPTION
Removes the unused `time_limit` flag from the `closechannel` command that appeared to be leftover from a [previous refactor](https://github.com/lightningnetwork/lnd/pull/120#discussion_r100228100).

Resolves this confusion from Slack: https://lightningcommunity.slack.com/archives/C6BKD3RKR/p1555259641159800