### PR TITLE
multi: move Route to sub-pkg routing/route

### DIFF
--- a/discovery/chan_series.go
+++ b/discovery/chan_series.go
@@ -6,7 +6,7 @@ import (
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/lightningnetwork/lnd/channeldb"
 	"github.com/lightningnetwork/lnd/lnwire"
-	"github.com/lightningnetwork/lnd/routing"
+	"github.com/lightningnetwork/lnd/routing/route"
 )
 
 // ChannelGraphTimeSeries is an interface that provides time and block based
@@ -247,7 +247,7 @@ func (c *ChanSeries) FetchChanAnns(chain chainhash.Hash,
 	// We'll use this map to ensure we don't send the same node
 	// announcement more than one time as one node may have many channel
 	// anns we'll need to send.
-	nodePubsSent := make(map[routing.Vertex]struct{})
+	nodePubsSent := make(map[route.Vertex]struct{})
 
 	chanAnns := make([]lnwire.Message, 0, len(channels)*3)
 	for _, channel := range channels {

--- a/lnrpc/routerrpc/router_backend_test.go
+++ b/lnrpc/routerrpc/router_backend_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/btcsuite/btcutil"
 	"github.com/lightningnetwork/lnd/lnwire"
 	"github.com/lightningnetwork/lnd/routing"
+	"github.com/lightningnetwork/lnd/routing/route"
 
 	"github.com/lightningnetwork/lnd/lnrpc"
 )
@@ -19,7 +20,7 @@ const (
 )
 
 var (
-	sourceKey = routing.Vertex{1, 2, 3}
+	sourceKey = route.Vertex{1, 2, 3}
 )
 
 // TestQueryRoutes asserts that query routes rpc parameters are properly parsed
@@ -30,7 +31,7 @@ func TestQueryRoutes(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	var ignoreNodeVertex routing.Vertex
+	var ignoreNodeVertex route.Vertex
 	copy(ignoreNodeVertex[:], ignoreNodeBytes)
 
 	destNodeBytes, err := hex.DecodeString(destKey)
@@ -55,12 +56,12 @@ func TestQueryRoutes(t *testing.T) {
 		}},
 	}
 
-	route := &routing.Route{}
+	rt := &route.Route{}
 
-	findRoutes := func(source, target routing.Vertex,
+	findRoutes := func(source, target route.Vertex,
 		amt lnwire.MilliSatoshi, restrictions *routing.RestrictParams,
 		numPaths uint32, finalExpiry ...uint16) (
-		[]*routing.Route, error) {
+		[]*route.Route, error) {
 
 		if int64(amt) != request.Amt*1000 {
 			t.Fatal("unexpected amount")
@@ -100,15 +101,15 @@ func TestQueryRoutes(t *testing.T) {
 			t.Fatal("unexpected ignored node")
 		}
 
-		return []*routing.Route{
-			route,
+		return []*route.Route{
+			rt,
 		}, nil
 	}
 
 	backend := &RouterBackend{
 		MaxPaymentMSat: lnwire.NewMSatFromSatoshis(1000000),
 		FindRoutes:     findRoutes,
-		SelfNode:       routing.Vertex{1, 2, 3},
+		SelfNode:       route.Vertex{1, 2, 3},
 		FetchChannelCapacity: func(chanID uint64) (
 			btcutil.Amount, error) {
 

--- a/lnrpc/routerrpc/router_server.go
+++ b/lnrpc/routerrpc/router_server.go
@@ -15,6 +15,7 @@ import (
 	"github.com/lightningnetwork/lnd/lnrpc"
 	"github.com/lightningnetwork/lnd/lnwire"
 	"github.com/lightningnetwork/lnd/routing"
+	"github.com/lightningnetwork/lnd/routing/route"
 	"github.com/lightningnetwork/lnd/zpay32"
 	"google.golang.org/grpc"
 	"gopkg.in/macaroon-bakery.v2/bakery"
@@ -190,7 +191,7 @@ func (s *Server) SendPayment(ctx context.Context,
 		return nil, fmt.Errorf("zero value invoices are not supported")
 	}
 
-	var destination routing.Vertex
+	var destination route.Vertex
 	copy(destination[:], payReq.Destination.SerializeCompressed())
 
 	// Now that all the information we need has been parsed, we'll map this
@@ -232,7 +233,7 @@ func (s *Server) EstimateRouteFee(ctx context.Context,
 	if len(req.Dest) != 33 {
 		return nil, errors.New("invalid length destination key")
 	}
-	var destNode routing.Vertex
+	var destNode route.Vertex
 	copy(destNode[:], req.Dest)
 
 	// Next, we'll convert the amount in satoshis to mSAT, which are the

--- a/routing/notifications_test.go
+++ b/routing/notifications_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/lightningnetwork/lnd/lnwallet"
 	"github.com/lightningnetwork/lnd/lnwire"
 	"github.com/lightningnetwork/lnd/routing/chainview"
+	"github.com/lightningnetwork/lnd/routing/route"
 )
 
 var (
@@ -460,9 +461,9 @@ func TestEdgeUpdateNotification(t *testing.T) {
 
 	// Create lookup map for notifications we are intending to receive. Entries
 	// are removed from the map when the anticipated notification is received.
-	var waitingFor = map[Vertex]int{
-		Vertex(node1.PubKeyBytes): 1,
-		Vertex(node2.PubKeyBytes): 2,
+	var waitingFor = map[route.Vertex]int{
+		route.Vertex(node1.PubKeyBytes): 1,
+		route.Vertex(node2.PubKeyBytes): 2,
 	}
 
 	node1Pub, err := node1.PubKey()
@@ -486,7 +487,7 @@ func TestEdgeUpdateNotification(t *testing.T) {
 			}
 
 			edgeUpdate := ntfn.ChannelEdgeUpdates[0]
-			nodeVertex := NewVertex(edgeUpdate.AdvertisingNode)
+			nodeVertex := route.NewVertex(edgeUpdate.AdvertisingNode)
 
 			if idx, ok := waitingFor[nodeVertex]; ok {
 				switch idx {
@@ -630,9 +631,9 @@ func TestNodeUpdateNotification(t *testing.T) {
 
 	// Create lookup map for notifications we are intending to receive. Entries
 	// are removed from the map when the anticipated notification is received.
-	var waitingFor = map[Vertex]int{
-		Vertex(node1.PubKeyBytes): 1,
-		Vertex(node2.PubKeyBytes): 2,
+	var waitingFor = map[route.Vertex]int{
+		route.Vertex(node1.PubKeyBytes): 1,
+		route.Vertex(node2.PubKeyBytes): 2,
 	}
 
 	// Exactly two notifications should be sent, each corresponding to the
@@ -649,7 +650,7 @@ func TestNodeUpdateNotification(t *testing.T) {
 			}
 
 			nodeUpdate := ntfn.NodeUpdates[0]
-			nodeVertex := NewVertex(nodeUpdate.IdentityKey)
+			nodeVertex := route.NewVertex(nodeUpdate.IdentityKey)
 			if idx, ok := waitingFor[nodeVertex]; ok {
 				switch idx {
 				case 1:

--- a/routing/payment_session_test.go
+++ b/routing/payment_session_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/lightningnetwork/lnd/channeldb"
 	"github.com/lightningnetwork/lnd/lnwire"
+	"github.com/lightningnetwork/lnd/routing/route"
 )
 
 func TestRequestRoute(t *testing.T) {
@@ -13,7 +14,7 @@ func TestRequestRoute(t *testing.T) {
 	)
 
 	findPath := func(g *graphParams, r *RestrictParams,
-		source, target Vertex, amt lnwire.MilliSatoshi) (
+		source, target route.Vertex, amt lnwire.MilliSatoshi) (
 		[]*channeldb.ChannelEdgePolicy, error) {
 
 		// We expect find path to receive a cltv limit excluding the

--- a/routing/route/route.go
+++ b/routing/route/route.go
@@ -1,0 +1,165 @@
+package route
+
+import (
+	"encoding/binary"
+	"fmt"
+
+	"github.com/btcsuite/btcd/btcec"
+	sphinx "github.com/lightningnetwork/lightning-onion"
+	"github.com/lightningnetwork/lnd/lnwire"
+)
+
+// ErrNoRouteHopsProvided is returned when a caller attempts to construct a new
+// sphinx packet, but provides an empty set of hops for each route.
+var ErrNoRouteHopsProvided = fmt.Errorf("empty route hops provided")
+
+// Vertex is a simple alias for the serialization of a compressed Bitcoin
+// public key.
+type Vertex [33]byte
+
+// NewVertex returns a new Vertex given a public key.
+func NewVertex(pub *btcec.PublicKey) Vertex {
+	var v Vertex
+	copy(v[:], pub.SerializeCompressed())
+	return v
+}
+
+// String returns a human readable version of the Vertex which is the
+// hex-encoding of the serialized compressed public key.
+func (v Vertex) String() string {
+	return fmt.Sprintf("%x", v[:])
+}
+
+// Hop represents an intermediate or final node of the route. This naming
+// is in line with the definition given in BOLT #4: Onion Routing Protocol.
+// The struct houses the channel along which this hop can be reached and
+// the values necessary to create the HTLC that needs to be sent to the
+// next hop. It is also used to encode the per-hop payload included within
+// the Sphinx packet.
+type Hop struct {
+	// PubKeyBytes is the raw bytes of the public key of the target node.
+	PubKeyBytes Vertex
+
+	// ChannelID is the unique channel ID for the channel. The first 3
+	// bytes are the block height, the next 3 the index within the block,
+	// and the last 2 bytes are the output index for the channel.
+	ChannelID uint64
+
+	// OutgoingTimeLock is the timelock value that should be used when
+	// crafting the _outgoing_ HTLC from this hop.
+	OutgoingTimeLock uint32
+
+	// AmtToForward is the amount that this hop will forward to the next
+	// hop. This value is less than the value that the incoming HTLC
+	// carries as a fee will be subtracted by the hop.
+	AmtToForward lnwire.MilliSatoshi
+}
+
+// Route represents a path through the channel graph which runs over one or
+// more channels in succession. This struct carries all the information
+// required to craft the Sphinx onion packet, and send the payment along the
+// first hop in the path. A route is only selected as valid if all the channels
+// have sufficient capacity to carry the initial payment amount after fees are
+// accounted for.
+type Route struct {
+	// TotalTimeLock is the cumulative (final) time lock across the entire
+	// route. This is the CLTV value that should be extended to the first
+	// hop in the route. All other hops will decrement the time-lock as
+	// advertised, leaving enough time for all hops to wait for or present
+	// the payment preimage to complete the payment.
+	TotalTimeLock uint32
+
+	// TotalFees is the sum of the fees paid at each hop within the final
+	// route. In the case of a one-hop payment, this value will be zero as
+	// we don't need to pay a fee to ourself.
+	TotalFees lnwire.MilliSatoshi
+
+	// TotalAmount is the total amount of funds required to complete a
+	// payment over this route. This value includes the cumulative fees at
+	// each hop. As a result, the HTLC extended to the first-hop in the
+	// route will need to have at least this many satoshis, otherwise the
+	// route will fail at an intermediate node due to an insufficient
+	// amount of fees.
+	TotalAmount lnwire.MilliSatoshi
+
+	// SourcePubKey is the pubkey of the node where this route originates
+	// from.
+	SourcePubKey Vertex
+
+	// Hops contains details concerning the specific forwarding details at
+	// each hop.
+	Hops []*Hop
+}
+
+// HopFee returns the fee charged by the route hop indicated by hopIndex.
+func (r *Route) HopFee(hopIndex int) lnwire.MilliSatoshi {
+	var incomingAmt lnwire.MilliSatoshi
+	if hopIndex == 0 {
+		incomingAmt = r.TotalAmount
+	} else {
+		incomingAmt = r.Hops[hopIndex-1].AmtToForward
+	}
+
+	// Fee is calculated as difference between incoming and outgoing amount.
+	return incomingAmt - r.Hops[hopIndex].AmtToForward
+}
+
+// ToHopPayloads converts a complete route into the series of per-hop payloads
+// that is to be encoded within each HTLC using an opaque Sphinx packet.
+func (r *Route) ToHopPayloads() []sphinx.HopData {
+	hopPayloads := make([]sphinx.HopData, len(r.Hops))
+
+	// For each hop encoded within the route, we'll convert the hop struct
+	// to the matching per-hop payload struct as used by the sphinx
+	// package.
+	for i, hop := range r.Hops {
+		hopPayloads[i] = sphinx.HopData{
+			// TODO(roasbeef): properly set realm, make sphinx type
+			// an enum actually?
+			Realm:         0,
+			ForwardAmount: uint64(hop.AmtToForward),
+			OutgoingCltv:  hop.OutgoingTimeLock,
+		}
+
+		// As a base case, the next hop is set to all zeroes in order
+		// to indicate that the "last hop" as no further hops after it.
+		nextHop := uint64(0)
+
+		// If we aren't on the last hop, then we set the "next address"
+		// field to be the channel that directly follows it.
+		if i != len(r.Hops)-1 {
+			nextHop = r.Hops[i+1].ChannelID
+		}
+
+		binary.BigEndian.PutUint64(hopPayloads[i].NextAddress[:],
+			nextHop)
+	}
+
+	return hopPayloads
+}
+
+// NewRouteFromHops creates a new Route structure from the minimally required
+// information to perform the payment. It infers fee amounts and populates the
+// node, chan and prev/next hop maps.
+func NewRouteFromHops(amtToSend lnwire.MilliSatoshi, timeLock uint32,
+	sourceVertex Vertex, hops []*Hop) (*Route, error) {
+
+	if len(hops) == 0 {
+		return nil, ErrNoRouteHopsProvided
+	}
+
+	// First, we'll create a route struct and populate it with the fields
+	// for which the values are provided as arguments of this function.
+	// TotalFees is determined based on the difference between the amount
+	// that is send from the source and the final amount that is received
+	// by the destination.
+	route := &Route{
+		SourcePubKey:  sourceVertex,
+		Hops:          hops,
+		TotalTimeLock: timeLock,
+		TotalAmount:   amtToSend,
+		TotalFees:     amtToSend - hops[len(hops)-1].AmtToForward,
+	}
+
+	return route, nil
+}

--- a/server.go
+++ b/server.go
@@ -44,6 +44,7 @@ import (
 	"github.com/lightningnetwork/lnd/netann"
 	"github.com/lightningnetwork/lnd/pool"
 	"github.com/lightningnetwork/lnd/routing"
+	"github.com/lightningnetwork/lnd/routing/route"
 	"github.com/lightningnetwork/lnd/sweep"
 	"github.com/lightningnetwork/lnd/ticker"
 	"github.com/lightningnetwork/lnd/tor"
@@ -2063,7 +2064,7 @@ func (s *server) prunePersistentPeerConnection(compressedPubKey [33]byte) {
 // the target peers.
 //
 // NOTE: This function is safe for concurrent access.
-func (s *server) BroadcastMessage(skips map[routing.Vertex]struct{},
+func (s *server) BroadcastMessage(skips map[route.Vertex]struct{},
 	msgs ...lnwire.Message) error {
 
 	srvrLog.Debugf("Broadcasting %v messages", len(msgs))


### PR DESCRIPTION
Moves types `Route`, `Hop` and `Vertex` to a new package `routing/route`, to decouple the type from the `routing` package.

A pre-requisite for reliable payments, where we want to have access to the `Route` struct from `channeldb` in order to serialize and store it.