### PR TITLE
discovery: check nil policy within isMsgStale

### DIFF
--- a/discovery/gossiper.go
+++ b/discovery/gossiper.go
@@ -2361,6 +2361,12 @@ func (d *AuthenticatedGossiper) isMsgStale(msg lnwire.Message) bool {
 			p = p2
 		}
 
+		// If the policy is still unknown, then we can consider this
+		// policy fresh.
+		if p == nil {
+			return false
+		}
+
 		timestamp := time.Unix(int64(msg.Timestamp), 0)
 		return p.LastUpdate.After(timestamp)
 


### PR DESCRIPTION
If both policies don't exist, then this would result in a panic. Since they don't exist, we can assume the policy we're currently evaluating is fresh.