### PR TITLE
Build LND subservers when building docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ RUN apk add --no-cache --update alpine-sdk \
 &&  git clone https://github.com/lightningnetwork/lnd /go/src/github.com/lightningnetwork/lnd \
 &&  cd /go/src/github.com/lightningnetwork/lnd \
 &&  make \
-&&  make install
+&&  make install tags="signrpc walletrpc chainrpc invoicesrpc"
 
 # Start a new, final image.
 FROM alpine as final

--- a/docker/lnd/Dockerfile
+++ b/docker/lnd/Dockerfile
@@ -15,7 +15,7 @@ RUN apk add --no-cache --update alpine-sdk \
     make \
 &&  cd /go/src/github.com/lightningnetwork/lnd \
 &&  make \
-&&  make install
+&&  make install tags="signrpc walletrpc chainrpc invoicesrpc"
 
 # Start a new, final image to reduce size.
 FROM alpine as final


### PR DESCRIPTION
Now that the official releases are built with subservers, can/should we build docker images with subservers by default too?

This one-line change is all I needed to do to build LND with subservers so loop would work with the docker image.

(Checklist not applicable - it's a one-line change to a docker file rather than a go file.)