### PR TITLE
Update sample-lnd.conf - use lncli to show debug levels

### DIFF
--- a/sample-lnd.conf
+++ b/sample-lnd.conf
@@ -114,7 +114,7 @@
 ; Debug logging level.
 ; Valid levels are {trace, debug, info, warn, error, critical}
 ; You may also specify <subsystem>=<level>,<subsystem2>=<level>,... to set
-; log level for individual subsystems.  Use btcd --debuglevel=show to list
+; log level for individual subsystems.  Use lncli debuglevel --show to list
 ; available subsystems.
 ; debuglevel=info
 


### PR DESCRIPTION
This appears to be a copy&paste mistake?! For `lnd` it should be `lncli debuglevel --show`, right?

```
$ lncli debuglevel --show
{
    "sub_systems": "ARPC ATPL BRAR BTCN CHBU CHDB CHNF CMGR CNCT CRTR DISC FNDG HSWC INVC IRPC LNWL LTND NANN NTFN NTFR PEER RPCS RRPC SGNR SPHX SRVR SWPR UTXN WLKT WTWR"
}
```