### PR TITLE
[trivial] lntest: don't return from ensureConnected on non-error

### DIFF
--- a/lntest/harness.go
+++ b/lntest/harness.go
@@ -460,11 +460,11 @@ func (n *NetworkHarness) EnsureConnected(ctx context.Context, a, b *HarnessNode)
 		// can exit early.
 		return nil
 
-	case aErr != errConnectionRequested:
+	case aErr != nil && aErr != errConnectionRequested:
 		// Return any critical errors returned by either alice.
 		return aErr
 
-	case bErr != errConnectionRequested:
+	case bErr != nil && bErr != errConnectionRequested:
 		// Return any critical errors returned by either bob.
 		return bErr
 


### PR DESCRIPTION
This would cause the method to return before the peer list check was
performed.