### PR TITLE
[contractcourt] Republish close tx on startup

### DIFF
--- a/chancloser.go
+++ b/chancloser.go
@@ -444,7 +444,9 @@ func (c *channelCloser) ProcessCloseMsg(msg lnwire.Message) ([]lnwire.Message, b
 		if err := c.cfg.broadcastTx(closeTx); err != nil {
 			return nil, false, err
 		}
-		if err := c.cfg.channel.MarkCommitmentBroadcasted(); err != nil {
+
+		err = c.cfg.channel.MarkCommitmentBroadcasted(closeTx)
+		if err != nil {
 			return nil, false, err
 		}
 

--- a/channeldb/channel.go
+++ b/channeldb/channel.go
@@ -514,16 +514,6 @@ type OpenChannel struct {
 	sync.RWMutex
 }
 
-// FullSync serializes, and writes to disk the *full* channel state, using
-// both the active channel bucket to store the prefixed column fields, and the
-// remote node's ID to store the remainder of the channel state.
-func (c *OpenChannel) FullSync() error {
-	c.Lock()
-	defer c.Unlock()
-
-	return c.Db.Update(c.fullSync)
-}
-
 // ShortChanID returns the current ShortChannelID of this channel.
 func (c *OpenChannel) ShortChanID() lnwire.ShortChannelID {
 	c.RLock()
@@ -648,9 +638,8 @@ func fetchChanBucket(tx *bbolt.Tx, nodeKey *btcec.PublicKey,
 	return chanBucket, nil
 }
 
-// fullSync is an internal version of the FullSync method which allows callers
-// to sync the contents of an OpenChannel while re-using an existing database
-// transaction.
+// fullSync syncs the contents of an OpenChannel while re-using an existing
+// database transaction.
 func (c *OpenChannel) fullSync(tx *bbolt.Tx) error {
 	// First fetch the top level bucket which stores all data related to
 	// current, active channels.

--- a/channeldb/channel.go
+++ b/channeldb/channel.go
@@ -803,13 +803,10 @@ func (c *OpenChannel) MarkBorked() error {
 //   3. We didn't get the last RevokeAndAck message they sent, so they'll
 //      re-send it.
 //
-// The isRestoredChan bool indicates if we need to craft a chan sync message
-// for a channel that's been restored. If this is a restored channel, then
-// we'll modify our typical chan sync  message to ensure they force close even
-// if we're on the very first state.
-func (c *OpenChannel) ChanSyncMsg(
-	isRestoredChan bool) (*lnwire.ChannelReestablish, error) {
-
+// If this is a restored channel, having status ChanStatusRestored, then we'll
+// modify our typical chan sync message to ensure they force close even if
+// we're on the very first state.
+func (c *OpenChannel) ChanSyncMsg() (*lnwire.ChannelReestablish, error) {
 	c.Lock()
 	defer c.Unlock()
 
@@ -853,7 +850,7 @@ func (c *OpenChannel) ChanSyncMsg(
 	// If we've restored this channel, then we'll purposefully give them an
 	// invalid LocalUnrevokedCommitPoint so they'll force close the channel
 	// allowing us to sweep our funds.
-	if isRestoredChan {
+	if c.hasChanStatus(ChanStatusRestored) {
 		currentCommitSecret[0] ^= 1
 	}
 

--- a/channeldb/channel_test.go
+++ b/channeldb/channel_test.go
@@ -263,7 +263,12 @@ func TestOpenChannelPutGetDelete(t *testing.T) {
 			OnionBlob:     []byte("onionblob"),
 		},
 	}
-	if err := state.FullSync(); err != nil {
+
+	addr := &net.TCPAddr{
+		IP:   net.ParseIP("127.0.0.1"),
+		Port: 18556,
+	}
+	if err := state.SyncPending(addr, 101); err != nil {
 		t.Fatalf("unable to save and serialize channel state: %v", err)
 	}
 
@@ -363,7 +368,12 @@ func TestChannelStateTransition(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unable to create channel state: %v", err)
 	}
-	if err := channel.FullSync(); err != nil {
+
+	addr := &net.TCPAddr{
+		IP:   net.ParseIP("127.0.0.1"),
+		Port: 18556,
+	}
+	if err := channel.SyncPending(addr, 101); err != nil {
 		t.Fatalf("unable to save and serialize channel state: %v", err)
 	}
 

--- a/channeldb/channel_test.go
+++ b/channeldb/channel_test.go
@@ -891,7 +891,8 @@ func TestFetchWaitingCloseChannels(t *testing.T) {
 	// This would happen in the event of a force close and should make the
 	// channels enter a state of waiting close.
 	for _, channel := range channels {
-		if err := channel.MarkCommitmentBroadcasted(); err != nil {
+		closeTx := &wire.MsgTx{}
+		if err := channel.MarkCommitmentBroadcasted(closeTx); err != nil {
 			t.Fatalf("unable to mark commitment broadcast: %v", err)
 		}
 	}

--- a/channeldb/db_test.go
+++ b/channeldb/db_test.go
@@ -110,7 +110,12 @@ func TestFetchClosedChannelForID(t *testing.T) {
 	for i := uint32(0); i < numChans; i++ {
 		// Save the open channel to disk.
 		state.FundingOutpoint.Index = i
-		if err := state.FullSync(); err != nil {
+
+		addr := &net.TCPAddr{
+			IP:   net.ParseIP("127.0.0.1"),
+			Port: 18556,
+		}
+		if err := state.SyncPending(addr, 101); err != nil {
 			t.Fatalf("unable to save and serialize channel "+
 				"state: %v", err)
 		}

--- a/contractcourt/chain_arbitrator_test.go
+++ b/contractcourt/chain_arbitrator_test.go
@@ -1,1 +1,117 @@
 package contractcourt
+
+import (
+	"io/ioutil"
+	"net"
+	"os"
+	"testing"
+
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"github.com/btcsuite/btcd/wire"
+	"github.com/lightningnetwork/lnd/channeldb"
+	"github.com/lightningnetwork/lnd/lnwallet"
+)
+
+// TestChainArbitratorRepulishCommitment testst that the chain arbitrator will
+// republish closing transactions for channels marked CommitementBroadcast in
+// the database at startup.
+func TestChainArbitratorRepublishCommitment(t *testing.T) {
+	t.Parallel()
+
+	tempPath, err := ioutil.TempDir("", "testdb")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tempPath)
+
+	db, err := channeldb.Open(tempPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+
+	// Create 10 test channels and sync them to the database.
+	const numChans = 10
+	var channels []*channeldb.OpenChannel
+	for i := 0; i < numChans; i++ {
+		lChannel, _, cleanup, err := lnwallet.CreateTestChannels()
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer cleanup()
+
+		channel := lChannel.State()
+
+		// We manually set the db here to make sure all channels are
+		// synced to the same db.
+		channel.Db = db
+
+		addr := &net.TCPAddr{
+			IP:   net.ParseIP("127.0.0.1"),
+			Port: 18556,
+		}
+		if err := channel.SyncPending(addr, 101); err != nil {
+			t.Fatal(err)
+		}
+
+		channels = append(channels, channel)
+	}
+
+	// Mark half of the channels as commitment broadcasted.
+	for i := 0; i < numChans/2; i++ {
+		closeTx := channels[i].FundingTxn.Copy()
+		closeTx.TxIn[0].PreviousOutPoint = channels[i].FundingOutpoint
+		err := channels[i].MarkCommitmentBroadcasted(closeTx)
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// We keep track of the transactions published by the ChainArbitrator
+	// at startup.
+	published := make(map[chainhash.Hash]struct{})
+
+	chainArbCfg := ChainArbitratorConfig{
+		ChainIO:  &mockChainIO{},
+		Notifier: &mockNotifier{},
+		PublishTx: func(tx *wire.MsgTx) error {
+			published[tx.TxHash()] = struct{}{}
+			return nil
+		},
+	}
+	chainArb := NewChainArbitrator(
+		chainArbCfg, db,
+	)
+
+	if err := chainArb.Start(); err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		if err := chainArb.Stop(); err != nil {
+			t.Fatal(err)
+		}
+	}()
+
+	// Half of the channels should have had their closing tx re-published.
+	if len(published) != numChans/2 {
+		t.Fatalf("expected %d re-published transactions, got %d",
+			numChans/2, len(published))
+	}
+
+	// And make sure the published transactions are correct, and unique.
+	for i := 0; i < numChans/2; i++ {
+		closeTx := channels[i].FundingTxn.Copy()
+		closeTx.TxIn[0].PreviousOutPoint = channels[i].FundingOutpoint
+
+		_, ok := published[closeTx.TxHash()]
+		if !ok {
+			t.Fatalf("closing tx not re-published")
+		}
+
+		delete(published, closeTx.TxHash())
+	}
+
+	if len(published) != 0 {
+		t.Fatalf("unexpected tx published")
+	}
+}

--- a/contractcourt/chain_watcher.go
+++ b/contractcourt/chain_watcher.go
@@ -731,8 +731,7 @@ func (c *chainWatcher) dispatchCooperativeClose(commitSpend *chainntnfs.SpendDet
 	}
 
 	// Attempt to add a channel sync message to the close summary.
-	chanSync, err := lnwallet.ChanSyncMsg(
-		c.cfg.chanState,
+	chanSync, err := c.cfg.chanState.ChanSyncMsg(
 		c.cfg.chanState.HasChanStatus(channeldb.ChanStatusRestored),
 	)
 	if err != nil {
@@ -811,8 +810,7 @@ func (c *chainWatcher) dispatchLocalForceClose(
 	}
 
 	// Attempt to add a channel sync message to the close summary.
-	chanSync, err := lnwallet.ChanSyncMsg(
-		c.cfg.chanState,
+	chanSync, err := c.cfg.chanState.ChanSyncMsg(
 		c.cfg.chanState.HasChanStatus(channeldb.ChanStatusRestored),
 	)
 	if err != nil {
@@ -998,8 +996,7 @@ func (c *chainWatcher) dispatchContractBreach(spendEvent *chainntnfs.SpendDetail
 	}
 
 	// Attempt to add a channel sync message to the close summary.
-	chanSync, err := lnwallet.ChanSyncMsg(
-		c.cfg.chanState,
+	chanSync, err := c.cfg.chanState.ChanSyncMsg(
 		c.cfg.chanState.HasChanStatus(channeldb.ChanStatusRestored),
 	)
 	if err != nil {

--- a/contractcourt/chain_watcher.go
+++ b/contractcourt/chain_watcher.go
@@ -731,9 +731,7 @@ func (c *chainWatcher) dispatchCooperativeClose(commitSpend *chainntnfs.SpendDet
 	}
 
 	// Attempt to add a channel sync message to the close summary.
-	chanSync, err := c.cfg.chanState.ChanSyncMsg(
-		c.cfg.chanState.HasChanStatus(channeldb.ChanStatusRestored),
-	)
+	chanSync, err := c.cfg.chanState.ChanSyncMsg()
 	if err != nil {
 		log.Errorf("ChannelPoint(%v): unable to create channel sync "+
 			"message: %v", c.cfg.chanState.FundingOutpoint, err)
@@ -810,9 +808,7 @@ func (c *chainWatcher) dispatchLocalForceClose(
 	}
 
 	// Attempt to add a channel sync message to the close summary.
-	chanSync, err := c.cfg.chanState.ChanSyncMsg(
-		c.cfg.chanState.HasChanStatus(channeldb.ChanStatusRestored),
-	)
+	chanSync, err := c.cfg.chanState.ChanSyncMsg()
 	if err != nil {
 		log.Errorf("ChannelPoint(%v): unable to create channel sync "+
 			"message: %v", c.cfg.chanState.FundingOutpoint, err)
@@ -996,9 +992,7 @@ func (c *chainWatcher) dispatchContractBreach(spendEvent *chainntnfs.SpendDetail
 	}
 
 	// Attempt to add a channel sync message to the close summary.
-	chanSync, err := c.cfg.chanState.ChanSyncMsg(
-		c.cfg.chanState.HasChanStatus(channeldb.ChanStatusRestored),
-	)
+	chanSync, err := c.cfg.chanState.ChanSyncMsg()
 	if err != nil {
 		log.Errorf("ChannelPoint(%v): unable to create channel sync "+
 			"message: %v", c.cfg.chanState.FundingOutpoint, err)

--- a/contractcourt/channel_arbitrator.go
+++ b/contractcourt/channel_arbitrator.go
@@ -821,6 +821,16 @@ func (c *ChannelArbitrator) stateStep(
 		}
 		closeTx = closeSummary.CloseTx
 
+		// Before publishing the transaction, we store it to the
+		// database, such that we can re-publish later in case it
+		// didn't propagate.
+		if err := c.cfg.MarkCommitmentBroadcasted(closeTx); err != nil {
+			log.Errorf("ChannelArbitrator(%v): unable to "+
+				"mark commitment broadcasted: %v",
+				c.cfg.ChanPoint, err)
+			return StateError, closeTx, err
+		}
+
 		// With the close transaction in hand, broadcast the
 		// transaction to the network, thereby entering the post
 		// channel resolution state.
@@ -838,12 +848,6 @@ func (c *ChannelArbitrator) stateStep(
 			if err != lnwallet.ErrDoubleSpend {
 				return StateError, closeTx, err
 			}
-		}
-
-		if err := c.cfg.MarkCommitmentBroadcasted(closeTx); err != nil {
-			log.Errorf("ChannelArbitrator(%v): unable to "+
-				"mark commitment broadcasted: %v",
-				c.cfg.ChanPoint, err)
 		}
 
 		// We go to the StateCommitmentBroadcasted state, where we'll

--- a/contractcourt/channel_arbitrator.go
+++ b/contractcourt/channel_arbitrator.go
@@ -97,7 +97,7 @@ type ChannelArbitratorConfig struct {
 
 	// MarkCommitmentBroadcasted should mark the channel as the commitment
 	// being broadcast, and we are waiting for the commitment to confirm.
-	MarkCommitmentBroadcasted func() error
+	MarkCommitmentBroadcasted func(*wire.MsgTx) error
 
 	// MarkChannelClosed marks the channel closed in the database, with the
 	// passed close summary. After this method successfully returns we can
@@ -840,7 +840,7 @@ func (c *ChannelArbitrator) stateStep(
 			}
 		}
 
-		if err := c.cfg.MarkCommitmentBroadcasted(); err != nil {
+		if err := c.cfg.MarkCommitmentBroadcasted(closeTx); err != nil {
 			log.Errorf("ChannelArbitrator(%v): unable to "+
 				"mark commitment broadcasted: %v",
 				c.cfg.ChanPoint, err)

--- a/contractcourt/channel_arbitrator_test.go
+++ b/contractcourt/channel_arbitrator_test.go
@@ -213,7 +213,7 @@ func createTestChannelArbitrator(log ArbitratorLog) (*ChannelArbitrator,
 			}
 			return summary, nil
 		},
-		MarkCommitmentBroadcasted: func() error {
+		MarkCommitmentBroadcasted: func(_ *wire.MsgTx) error {
 			return nil
 		},
 		MarkChannelClosed: func(*channeldb.ChannelCloseSummary) error {

--- a/htlcswitch/link.go
+++ b/htlcswitch/link.go
@@ -609,8 +609,7 @@ func (l *channelLink) syncChanStates() error {
 	// side. Based on this message, the remote party will decide if they
 	// need to retransmit any data or not.
 	chanState := l.channel.State()
-	localChanSyncMsg, err := lnwallet.ChanSyncMsg(
-		chanState,
+	localChanSyncMsg, err := chanState.ChanSyncMsg(
 		chanState.HasChanStatus(channeldb.ChanStatusRestored),
 	)
 	if err != nil {

--- a/htlcswitch/link.go
+++ b/htlcswitch/link.go
@@ -922,12 +922,12 @@ func (l *channelLink) htlcManager() {
 			// what they sent us before.
 			// TODO(halseth): ban peer?
 			case err == lnwallet.ErrInvalidLocalUnrevokedCommitPoint:
-				err = l.channel.MarkBorked()
-				if err != nil {
-					log.Errorf("Unable to mark channel "+
-						"borked: %v", err)
-				}
-
+				// We'll fail the link and tell the peer to
+				// force close the channel. Note that the
+				// database state is not updated here, but will
+				// be updated when the close transaction is
+				// ready to avoid that we go down before
+				// storing the transaction in the db.
 				l.fail(
 					LinkFailureError{
 						code:       ErrSyncError,

--- a/htlcswitch/link.go
+++ b/htlcswitch/link.go
@@ -897,7 +897,7 @@ func (l *channelLink) htlcManager() {
 		if err != nil {
 			log.Warnf("Error when syncing channel states: %v", err)
 
-			_, localDataLoss :=
+			errDataLoss, localDataLoss :=
 				err.(*lnwallet.ErrCommitSyncLocalDataLoss)
 
 			switch {
@@ -922,6 +922,12 @@ func (l *channelLink) htlcManager() {
 			// what they sent us before.
 			// TODO(halseth): ban peer?
 			case err == lnwallet.ErrInvalidLocalUnrevokedCommitPoint:
+				err = l.channel.MarkBorked()
+				if err != nil {
+					log.Errorf("Unable to mark channel "+
+						"borked: %v", err)
+				}
+
 				l.fail(
 					LinkFailureError{
 						code:       ErrSyncError,
@@ -935,13 +941,18 @@ func (l *channelLink) htlcManager() {
 			// We have lost state and cannot safely force close the
 			// channel. Fail the channel and wait for the remote to
 			// hopefully force close it. The remote has sent us its
-			// latest unrevoked commitment point, that we stored in
-			// the database, that we can use to retrieve the funds
-			// when the remote closes the channel.
-			// TODO(halseth): mark this, such that we prevent
-			// channel from being force closed by the user or
-			// contractcourt etc.
+			// latest unrevoked commitment point, and we'll store
+			// it in the database, such that we can attempt to
+			// recover the funds if the remote force closes the
+			// channel.
 			case localDataLoss:
+				err := l.channel.MarkDataLoss(
+					errDataLoss.CommitPoint,
+				)
+				if err != nil {
+					log.Errorf("Unable to mark channel "+
+						"data loss: %v", err)
+				}
 
 			// We determined the commit chains were not possible to
 			// sync. We cautiously fail the channel, but don't
@@ -949,6 +960,10 @@ func (l *channelLink) htlcManager() {
 			// TODO(halseth): can we safely force close in any
 			// cases where this error is returned?
 			case err == lnwallet.ErrCannotSyncCommitChains:
+				if err := l.channel.MarkBorked(); err != nil {
+					log.Errorf("Unable to mark channel "+
+						"borked: %v", err)
+				}
 
 			// Other, unspecified error.
 			default:

--- a/htlcswitch/link.go
+++ b/htlcswitch/link.go
@@ -615,21 +615,6 @@ func (l *channelLink) syncChanStates() error {
 			"ChannelPoint(%v)", l.channel.ChannelPoint())
 	}
 
-	// If we have a restored channel, we'll delay sending our channel
-	// reestablish message briefly to ensure we first have a stable
-	// connection. Sending the message will cause the remote peer to force
-	// close the channel, which currently may not be resumed reliably if the
-	// connection is being torn down simultaneously. This delay can be
-	// removed after the force close is reliable, but in the meantime it
-	// improves the reliability of successfully closing out the channel.
-	if chanState.HasChanStatus(channeldb.ChanStatusRestored) {
-		select {
-		case <-time.After(5 * time.Second):
-		case <-l.quit:
-			return ErrLinkShuttingDown
-		}
-	}
-
 	if err := l.cfg.Peer.SendMessage(true, localChanSyncMsg); err != nil {
 		return fmt.Errorf("Unable to send chan sync message for "+
 			"ChannelPoint(%v)", l.channel.ChannelPoint())

--- a/htlcswitch/link.go
+++ b/htlcswitch/link.go
@@ -609,9 +609,7 @@ func (l *channelLink) syncChanStates() error {
 	// side. Based on this message, the remote party will decide if they
 	// need to retransmit any data or not.
 	chanState := l.channel.State()
-	localChanSyncMsg, err := chanState.ChanSyncMsg(
-		chanState.HasChanStatus(channeldb.ChanStatusRestored),
-	)
+	localChanSyncMsg, err := chanState.ChanSyncMsg()
 	if err != nil {
 		return fmt.Errorf("unable to generate chan sync message for "+
 			"ChannelPoint(%v)", l.channel.ChannelPoint())

--- a/htlcswitch/link.go
+++ b/htlcswitch/link.go
@@ -895,6 +895,11 @@ func (l *channelLink) htlcManager() {
 	if l.cfg.SyncStates {
 		err := l.syncChanStates()
 		if err != nil {
+			log.Warnf("Error when syncing channel states: %v", err)
+
+			_, localDataLoss :=
+				err.(*lnwallet.ErrCommitSyncLocalDataLoss)
+
 			switch {
 			case err == ErrLinkShuttingDown:
 				log.Debugf("unable to sync channel states, " +
@@ -936,7 +941,7 @@ func (l *channelLink) htlcManager() {
 			// TODO(halseth): mark this, such that we prevent
 			// channel from being force closed by the user or
 			// contractcourt etc.
-			case err == lnwallet.ErrCommitSyncLocalDataLoss:
+			case localDataLoss:
 
 			// We determined the commit chains were not possible to
 			// sync. We cautiously fail the channel, but don't

--- a/lnwallet/channel.go
+++ b/lnwallet/channel.go
@@ -5089,9 +5089,7 @@ func NewUnilateralCloseSummary(chanState *channeldb.OpenChannel, signer input.Si
 	}
 
 	// Attempt to add a channel sync message to the close summary.
-	chanSync, err := chanState.ChanSyncMsg(
-		chanState.HasChanStatus(channeldb.ChanStatusRestored),
-	)
+	chanSync, err := chanState.ChanSyncMsg()
 	if err != nil {
 		walletLog.Errorf("ChannelPoint(%v): unable to create channel sync "+
 			"message: %v", chanState.FundingOutpoint, err)

--- a/lnwallet/channel.go
+++ b/lnwallet/channel.go
@@ -3527,85 +3527,6 @@ func (lc *LightningChannel) ProcessChanSyncMsg(
 	return updates, openedCircuits, closedCircuits, nil
 }
 
-// ChanSyncMsg returns the ChannelReestablish message that should be sent upon
-// reconnection with the remote peer that we're maintaining this channel with.
-// The information contained within this message is necessary to re-sync our
-// commitment chains in the case of a last or only partially processed message.
-// When the remote party receiver this message one of three things may happen:
-//
-//   1. We're fully synced and no messages need to be sent.
-//   2. We didn't get the last CommitSig message they sent, to they'll re-send
-//      it.
-//   3. We didn't get the last RevokeAndAck message they sent, so they'll
-//      re-send it.
-//
-// The isRestoredChan bool indicates if we need to craft a chan sync message
-// for a channel that's been restored. If this is a restored channel, then
-// we'll modify our typical chan sync  message to ensure they force close even
-// if we're on the very first state.
-func ChanSyncMsg(c *channeldb.OpenChannel,
-	isRestoredChan bool) (*lnwire.ChannelReestablish, error) {
-
-	c.Lock()
-	defer c.Unlock()
-
-	// The remote commitment height that we'll send in the
-	// ChannelReestablish message is our current commitment height plus
-	// one. If the receiver thinks that our commitment height is actually
-	// *equal* to this value, then they'll re-send the last commitment that
-	// they sent but we never fully processed.
-	localHeight := c.LocalCommitment.CommitHeight
-	nextLocalCommitHeight := localHeight + 1
-
-	// The second value we'll send is the height of the remote commitment
-	// from our PoV. If the receiver thinks that their height is actually
-	// *one plus* this value, then they'll re-send their last revocation.
-	remoteChainTipHeight := c.RemoteCommitment.CommitHeight
-
-	// If this channel has undergone a commitment update, then in order to
-	// prove to the remote party our knowledge of their prior commitment
-	// state, we'll also send over the last commitment secret that the
-	// remote party sent.
-	var lastCommitSecret [32]byte
-	if remoteChainTipHeight != 0 {
-		remoteSecret, err := c.RevocationStore.LookUp(
-			remoteChainTipHeight - 1,
-		)
-		if err != nil {
-			return nil, err
-		}
-		lastCommitSecret = [32]byte(*remoteSecret)
-	}
-
-	// Additionally, we'll send over the current unrevoked commitment on
-	// our local commitment transaction.
-	currentCommitSecret, err := c.RevocationProducer.AtIndex(
-		localHeight,
-	)
-	if err != nil {
-		return nil, err
-	}
-
-	// If we've restored this channel, then we'll purposefully give them an
-	// invalid LocalUnrevokedCommitPoint so they'll force close the channel
-	// allowing us to sweep our funds.
-	if isRestoredChan {
-		currentCommitSecret[0] ^= 1
-	}
-
-	return &lnwire.ChannelReestablish{
-		ChanID: lnwire.NewChanIDFromOutPoint(
-			&c.FundingOutpoint,
-		),
-		NextLocalCommitHeight:  nextLocalCommitHeight,
-		RemoteCommitTailHeight: remoteChainTipHeight,
-		LastRemoteCommitSecret: lastCommitSecret,
-		LocalUnrevokedCommitPoint: input.ComputeCommitmentPoint(
-			currentCommitSecret[:],
-		),
-	}, nil
-}
-
 // computeView takes the given htlcView, and calculates the balances, filtered
 // view (settling unsettled HTLCs), commitment weight and feePerKw, after
 // applying the HTLCs to the latest commitment. The returned balances are the
@@ -5187,8 +5108,7 @@ func NewUnilateralCloseSummary(chanState *channeldb.OpenChannel, signer input.Si
 	}
 
 	// Attempt to add a channel sync message to the close summary.
-	chanSync, err := ChanSyncMsg(
-		chanState,
+	chanSync, err := chanState.ChanSyncMsg(
 		chanState.HasChanStatus(channeldb.ChanStatusRestored),
 	)
 	if err != nil {

--- a/lnwallet/channel.go
+++ b/lnwallet/channel.go
@@ -6259,11 +6259,11 @@ func (lc *LightningChannel) State() *channeldb.OpenChannel {
 // MarkCommitmentBroadcasted marks the channel as a commitment transaction has
 // been broadcast, either our own or the remote, and we should watch the chain
 // for it to confirm before taking any further action.
-func (lc *LightningChannel) MarkCommitmentBroadcasted() error {
+func (lc *LightningChannel) MarkCommitmentBroadcasted(tx *wire.MsgTx) error {
 	lc.Lock()
 	defer lc.Unlock()
 
-	return lc.channelState.MarkCommitmentBroadcasted()
+	return lc.channelState.MarkCommitmentBroadcasted(tx)
 }
 
 // ActiveHtlcs returns a slice of HTLC's which are currently active on *both*

--- a/lnwallet/channel_test.go
+++ b/lnwallet/channel_test.go
@@ -3688,7 +3688,7 @@ func TestChanSyncFailure(t *testing.T) {
 
 		// Alice should detect from Bob's message that she lost state.
 		_, _, _, err = aliceOld.ProcessChanSyncMsg(bobSyncMsg)
-		if err != ErrCommitSyncLocalDataLoss {
+		if _, ok := err.(*ErrCommitSyncLocalDataLoss); !ok {
 			t.Fatalf("wrong error, expected "+
 				"ErrCommitSyncLocalDataLoss instead got: %v",
 				err)
@@ -4377,7 +4377,7 @@ func TestChanSyncInvalidLastSecret(t *testing.T) {
 	// Alice's former self should conclude that she possibly lost data as
 	// Bob is sending a valid commit secret for the latest state.
 	_, _, _, err = aliceOld.ProcessChanSyncMsg(bobChanSync)
-	if err != ErrCommitSyncLocalDataLoss {
+	if _, ok := err.(*ErrCommitSyncLocalDataLoss); !ok {
 		t.Fatalf("wrong error, expected ErrCommitSyncLocalDataLoss "+
 			"instead got: %v", err)
 	}

--- a/lnwallet/channel_test.go
+++ b/lnwallet/channel_test.go
@@ -2530,7 +2530,7 @@ func assertNoChanSyncNeeded(t *testing.T, aliceChannel *LightningChannel,
 
 	_, _, line, _ := runtime.Caller(1)
 
-	aliceChanSyncMsg, err := aliceChannel.channelState.ChanSyncMsg(false)
+	aliceChanSyncMsg, err := aliceChannel.channelState.ChanSyncMsg()
 	if err != nil {
 		t.Fatalf("line #%v: unable to produce chan sync msg: %v",
 			line, err)
@@ -2545,7 +2545,7 @@ func assertNoChanSyncNeeded(t *testing.T, aliceChannel *LightningChannel,
 			"instead wants to send: %v", line, spew.Sdump(bobMsgsToSend))
 	}
 
-	bobChanSyncMsg, err := bobChannel.channelState.ChanSyncMsg(false)
+	bobChanSyncMsg, err := bobChannel.channelState.ChanSyncMsg()
 	if err != nil {
 		t.Fatalf("line #%v: unable to produce chan sync msg: %v",
 			line, err)
@@ -2778,11 +2778,11 @@ func TestChanSyncOweCommitment(t *testing.T) {
 	// Bob doesn't get this message so upon reconnection, they need to
 	// synchronize. Alice should conclude that she owes Bob a commitment,
 	// while Bob should think he's properly synchronized.
-	aliceSyncMsg, err := aliceChannel.channelState.ChanSyncMsg(false)
+	aliceSyncMsg, err := aliceChannel.channelState.ChanSyncMsg()
 	if err != nil {
 		t.Fatalf("unable to produce chan sync msg: %v", err)
 	}
-	bobSyncMsg, err := bobChannel.channelState.ChanSyncMsg(false)
+	bobSyncMsg, err := bobChannel.channelState.ChanSyncMsg()
 	if err != nil {
 		t.Fatalf("unable to produce chan sync msg: %v", err)
 	}
@@ -3092,11 +3092,11 @@ func TestChanSyncOweRevocation(t *testing.T) {
 	// If we fetch the channel sync messages at this state, then Alice
 	// should report that she owes Bob a revocation message, while Bob
 	// thinks they're fully in sync.
-	aliceSyncMsg, err := aliceChannel.channelState.ChanSyncMsg(false)
+	aliceSyncMsg, err := aliceChannel.channelState.ChanSyncMsg()
 	if err != nil {
 		t.Fatalf("unable to produce chan sync msg: %v", err)
 	}
-	bobSyncMsg, err := bobChannel.channelState.ChanSyncMsg(false)
+	bobSyncMsg, err := bobChannel.channelState.ChanSyncMsg()
 	if err != nil {
 		t.Fatalf("unable to produce chan sync msg: %v", err)
 	}
@@ -3261,11 +3261,11 @@ func TestChanSyncOweRevocationAndCommit(t *testing.T) {
 	// If we now attempt to resync, then Alice should conclude that she
 	// doesn't need any further updates, while Bob concludes that he needs
 	// to re-send both his revocation and commit sig message.
-	aliceSyncMsg, err := aliceChannel.channelState.ChanSyncMsg(false)
+	aliceSyncMsg, err := aliceChannel.channelState.ChanSyncMsg()
 	if err != nil {
 		t.Fatalf("unable to produce chan sync msg: %v", err)
 	}
-	bobSyncMsg, err := bobChannel.channelState.ChanSyncMsg(false)
+	bobSyncMsg, err := bobChannel.channelState.ChanSyncMsg()
 	if err != nil {
 		t.Fatalf("unable to produce chan sync msg: %v", err)
 	}
@@ -3472,11 +3472,11 @@ func TestChanSyncOweRevocationAndCommitForceTransition(t *testing.T) {
 	// Now if we attempt to synchronize states at this point, Alice should
 	// detect that she owes nothing, while Bob should re-send both his
 	// RevokeAndAck as well as his commitment message.
-	aliceSyncMsg, err := aliceChannel.channelState.ChanSyncMsg(false)
+	aliceSyncMsg, err := aliceChannel.channelState.ChanSyncMsg()
 	if err != nil {
 		t.Fatalf("unable to produce chan sync msg: %v", err)
 	}
-	bobSyncMsg, err := bobChannel.channelState.ChanSyncMsg(false)
+	bobSyncMsg, err := bobChannel.channelState.ChanSyncMsg()
 	if err != nil {
 		t.Fatalf("unable to produce chan sync msg: %v", err)
 	}
@@ -3677,11 +3677,11 @@ func TestChanSyncFailure(t *testing.T) {
 	assertLocalDataLoss := func(aliceOld *LightningChannel) {
 		t.Helper()
 
-		aliceSyncMsg, err := aliceOld.channelState.ChanSyncMsg(false)
+		aliceSyncMsg, err := aliceOld.channelState.ChanSyncMsg()
 		if err != nil {
 			t.Fatalf("unable to produce chan sync msg: %v", err)
 		}
-		bobSyncMsg, err := bobChannel.channelState.ChanSyncMsg(false)
+		bobSyncMsg, err := bobChannel.channelState.ChanSyncMsg()
 		if err != nil {
 			t.Fatalf("unable to produce chan sync msg: %v", err)
 		}
@@ -3755,7 +3755,7 @@ func TestChanSyncFailure(t *testing.T) {
 	// If we remove the recovery options from Bob's message, Alice cannot
 	// tell if she lost state, since Bob might be lying. She still should
 	// be able to detect that chains cannot be synced.
-	bobSyncMsg, err := bobChannel.channelState.ChanSyncMsg(false)
+	bobSyncMsg, err := bobChannel.channelState.ChanSyncMsg()
 	if err != nil {
 		t.Fatalf("unable to produce chan sync msg: %v", err)
 	}
@@ -3769,7 +3769,7 @@ func TestChanSyncFailure(t *testing.T) {
 	// If Bob lies about the NextLocalCommitHeight, making it greater than
 	// what Alice expect, she cannot tell for sure whether she lost state,
 	// but should detect the desync.
-	bobSyncMsg, err = bobChannel.channelState.ChanSyncMsg(false)
+	bobSyncMsg, err = bobChannel.channelState.ChanSyncMsg()
 	if err != nil {
 		t.Fatalf("unable to produce chan sync msg: %v", err)
 	}
@@ -3782,7 +3782,7 @@ func TestChanSyncFailure(t *testing.T) {
 
 	// If Bob's NextLocalCommitHeight is lower than what Alice expects, Bob
 	// probably lost state.
-	bobSyncMsg, err = bobChannel.channelState.ChanSyncMsg(false)
+	bobSyncMsg, err = bobChannel.channelState.ChanSyncMsg()
 	if err != nil {
 		t.Fatalf("unable to produce chan sync msg: %v", err)
 	}
@@ -3795,7 +3795,7 @@ func TestChanSyncFailure(t *testing.T) {
 
 	// If Alice and Bob's states are in sync, but Bob is sending the wrong
 	// LocalUnrevokedCommitPoint, Alice should detect this.
-	bobSyncMsg, err = bobChannel.channelState.ChanSyncMsg(false)
+	bobSyncMsg, err = bobChannel.channelState.ChanSyncMsg()
 	if err != nil {
 		t.Fatalf("unable to produce chan sync msg: %v", err)
 	}
@@ -3824,7 +3824,7 @@ func TestChanSyncFailure(t *testing.T) {
 	// when there's a pending remote commit.
 	halfAdvance()
 
-	bobSyncMsg, err = bobChannel.channelState.ChanSyncMsg(false)
+	bobSyncMsg, err = bobChannel.channelState.ChanSyncMsg()
 	if err != nil {
 		t.Fatalf("unable to produce chan sync msg: %v", err)
 	}
@@ -3912,11 +3912,11 @@ func TestChannelRetransmissionFeeUpdate(t *testing.T) {
 	// Bob doesn't get this message so upon reconnection, they need to
 	// synchronize. Alice should conclude that she owes Bob a commitment,
 	// while Bob should think he's properly synchronized.
-	aliceSyncMsg, err := aliceChannel.channelState.ChanSyncMsg(false)
+	aliceSyncMsg, err := aliceChannel.channelState.ChanSyncMsg()
 	if err != nil {
 		t.Fatalf("unable to produce chan sync msg: %v", err)
 	}
-	bobSyncMsg, err := bobChannel.channelState.ChanSyncMsg(false)
+	bobSyncMsg, err := bobChannel.channelState.ChanSyncMsg()
 	if err != nil {
 		t.Fatalf("unable to produce chan sync msg: %v", err)
 	}
@@ -4361,11 +4361,11 @@ func TestChanSyncInvalidLastSecret(t *testing.T) {
 	}
 
 	// Next, we'll produce the ChanSync messages for both parties.
-	aliceChanSync, err := aliceChannel.channelState.ChanSyncMsg(false)
+	aliceChanSync, err := aliceChannel.channelState.ChanSyncMsg()
 	if err != nil {
 		t.Fatalf("unable to generate chan sync msg: %v", err)
 	}
-	bobChanSync, err := bobChannel.channelState.ChanSyncMsg(false)
+	bobChanSync, err := bobChannel.channelState.ChanSyncMsg()
 	if err != nil {
 		t.Fatalf("unable to generate chan sync msg: %v", err)
 	}

--- a/lnwallet/channel_test.go
+++ b/lnwallet/channel_test.go
@@ -2530,7 +2530,7 @@ func assertNoChanSyncNeeded(t *testing.T, aliceChannel *LightningChannel,
 
 	_, _, line, _ := runtime.Caller(1)
 
-	aliceChanSyncMsg, err := ChanSyncMsg(aliceChannel.channelState, false)
+	aliceChanSyncMsg, err := aliceChannel.channelState.ChanSyncMsg(false)
 	if err != nil {
 		t.Fatalf("line #%v: unable to produce chan sync msg: %v",
 			line, err)
@@ -2545,7 +2545,7 @@ func assertNoChanSyncNeeded(t *testing.T, aliceChannel *LightningChannel,
 			"instead wants to send: %v", line, spew.Sdump(bobMsgsToSend))
 	}
 
-	bobChanSyncMsg, err := ChanSyncMsg(bobChannel.channelState, false)
+	bobChanSyncMsg, err := bobChannel.channelState.ChanSyncMsg(false)
 	if err != nil {
 		t.Fatalf("line #%v: unable to produce chan sync msg: %v",
 			line, err)
@@ -2778,11 +2778,11 @@ func TestChanSyncOweCommitment(t *testing.T) {
 	// Bob doesn't get this message so upon reconnection, they need to
 	// synchronize. Alice should conclude that she owes Bob a commitment,
 	// while Bob should think he's properly synchronized.
-	aliceSyncMsg, err := ChanSyncMsg(aliceChannel.channelState, false)
+	aliceSyncMsg, err := aliceChannel.channelState.ChanSyncMsg(false)
 	if err != nil {
 		t.Fatalf("unable to produce chan sync msg: %v", err)
 	}
-	bobSyncMsg, err := ChanSyncMsg(bobChannel.channelState, false)
+	bobSyncMsg, err := bobChannel.channelState.ChanSyncMsg(false)
 	if err != nil {
 		t.Fatalf("unable to produce chan sync msg: %v", err)
 	}
@@ -3092,11 +3092,11 @@ func TestChanSyncOweRevocation(t *testing.T) {
 	// If we fetch the channel sync messages at this state, then Alice
 	// should report that she owes Bob a revocation message, while Bob
 	// thinks they're fully in sync.
-	aliceSyncMsg, err := ChanSyncMsg(aliceChannel.channelState, false)
+	aliceSyncMsg, err := aliceChannel.channelState.ChanSyncMsg(false)
 	if err != nil {
 		t.Fatalf("unable to produce chan sync msg: %v", err)
 	}
-	bobSyncMsg, err := ChanSyncMsg(bobChannel.channelState, false)
+	bobSyncMsg, err := bobChannel.channelState.ChanSyncMsg(false)
 	if err != nil {
 		t.Fatalf("unable to produce chan sync msg: %v", err)
 	}
@@ -3261,11 +3261,11 @@ func TestChanSyncOweRevocationAndCommit(t *testing.T) {
 	// If we now attempt to resync, then Alice should conclude that she
 	// doesn't need any further updates, while Bob concludes that he needs
 	// to re-send both his revocation and commit sig message.
-	aliceSyncMsg, err := ChanSyncMsg(aliceChannel.channelState, false)
+	aliceSyncMsg, err := aliceChannel.channelState.ChanSyncMsg(false)
 	if err != nil {
 		t.Fatalf("unable to produce chan sync msg: %v", err)
 	}
-	bobSyncMsg, err := ChanSyncMsg(bobChannel.channelState, false)
+	bobSyncMsg, err := bobChannel.channelState.ChanSyncMsg(false)
 	if err != nil {
 		t.Fatalf("unable to produce chan sync msg: %v", err)
 	}
@@ -3472,11 +3472,11 @@ func TestChanSyncOweRevocationAndCommitForceTransition(t *testing.T) {
 	// Now if we attempt to synchronize states at this point, Alice should
 	// detect that she owes nothing, while Bob should re-send both his
 	// RevokeAndAck as well as his commitment message.
-	aliceSyncMsg, err := ChanSyncMsg(aliceChannel.channelState, false)
+	aliceSyncMsg, err := aliceChannel.channelState.ChanSyncMsg(false)
 	if err != nil {
 		t.Fatalf("unable to produce chan sync msg: %v", err)
 	}
-	bobSyncMsg, err := ChanSyncMsg(bobChannel.channelState, false)
+	bobSyncMsg, err := bobChannel.channelState.ChanSyncMsg(false)
 	if err != nil {
 		t.Fatalf("unable to produce chan sync msg: %v", err)
 	}
@@ -3677,11 +3677,11 @@ func TestChanSyncFailure(t *testing.T) {
 	assertLocalDataLoss := func(aliceOld *LightningChannel) {
 		t.Helper()
 
-		aliceSyncMsg, err := ChanSyncMsg(aliceOld.channelState, false)
+		aliceSyncMsg, err := aliceOld.channelState.ChanSyncMsg(false)
 		if err != nil {
 			t.Fatalf("unable to produce chan sync msg: %v", err)
 		}
-		bobSyncMsg, err := ChanSyncMsg(bobChannel.channelState, false)
+		bobSyncMsg, err := bobChannel.channelState.ChanSyncMsg(false)
 		if err != nil {
 			t.Fatalf("unable to produce chan sync msg: %v", err)
 		}
@@ -3755,7 +3755,7 @@ func TestChanSyncFailure(t *testing.T) {
 	// If we remove the recovery options from Bob's message, Alice cannot
 	// tell if she lost state, since Bob might be lying. She still should
 	// be able to detect that chains cannot be synced.
-	bobSyncMsg, err := ChanSyncMsg(bobChannel.channelState, false)
+	bobSyncMsg, err := bobChannel.channelState.ChanSyncMsg(false)
 	if err != nil {
 		t.Fatalf("unable to produce chan sync msg: %v", err)
 	}
@@ -3769,7 +3769,7 @@ func TestChanSyncFailure(t *testing.T) {
 	// If Bob lies about the NextLocalCommitHeight, making it greater than
 	// what Alice expect, she cannot tell for sure whether she lost state,
 	// but should detect the desync.
-	bobSyncMsg, err = ChanSyncMsg(bobChannel.channelState, false)
+	bobSyncMsg, err = bobChannel.channelState.ChanSyncMsg(false)
 	if err != nil {
 		t.Fatalf("unable to produce chan sync msg: %v", err)
 	}
@@ -3782,7 +3782,7 @@ func TestChanSyncFailure(t *testing.T) {
 
 	// If Bob's NextLocalCommitHeight is lower than what Alice expects, Bob
 	// probably lost state.
-	bobSyncMsg, err = ChanSyncMsg(bobChannel.channelState, false)
+	bobSyncMsg, err = bobChannel.channelState.ChanSyncMsg(false)
 	if err != nil {
 		t.Fatalf("unable to produce chan sync msg: %v", err)
 	}
@@ -3795,7 +3795,7 @@ func TestChanSyncFailure(t *testing.T) {
 
 	// If Alice and Bob's states are in sync, but Bob is sending the wrong
 	// LocalUnrevokedCommitPoint, Alice should detect this.
-	bobSyncMsg, err = ChanSyncMsg(bobChannel.channelState, false)
+	bobSyncMsg, err = bobChannel.channelState.ChanSyncMsg(false)
 	if err != nil {
 		t.Fatalf("unable to produce chan sync msg: %v", err)
 	}
@@ -3824,7 +3824,7 @@ func TestChanSyncFailure(t *testing.T) {
 	// when there's a pending remote commit.
 	halfAdvance()
 
-	bobSyncMsg, err = ChanSyncMsg(bobChannel.channelState, false)
+	bobSyncMsg, err = bobChannel.channelState.ChanSyncMsg(false)
 	if err != nil {
 		t.Fatalf("unable to produce chan sync msg: %v", err)
 	}
@@ -3912,11 +3912,11 @@ func TestChannelRetransmissionFeeUpdate(t *testing.T) {
 	// Bob doesn't get this message so upon reconnection, they need to
 	// synchronize. Alice should conclude that she owes Bob a commitment,
 	// while Bob should think he's properly synchronized.
-	aliceSyncMsg, err := ChanSyncMsg(aliceChannel.channelState, false)
+	aliceSyncMsg, err := aliceChannel.channelState.ChanSyncMsg(false)
 	if err != nil {
 		t.Fatalf("unable to produce chan sync msg: %v", err)
 	}
-	bobSyncMsg, err := ChanSyncMsg(bobChannel.channelState, false)
+	bobSyncMsg, err := bobChannel.channelState.ChanSyncMsg(false)
 	if err != nil {
 		t.Fatalf("unable to produce chan sync msg: %v", err)
 	}
@@ -4361,11 +4361,11 @@ func TestChanSyncInvalidLastSecret(t *testing.T) {
 	}
 
 	// Next, we'll produce the ChanSync messages for both parties.
-	aliceChanSync, err := ChanSyncMsg(aliceChannel.channelState, false)
+	aliceChanSync, err := aliceChannel.channelState.ChanSyncMsg(false)
 	if err != nil {
 		t.Fatalf("unable to generate chan sync msg: %v", err)
 	}
-	bobChanSync, err := ChanSyncMsg(bobChannel.channelState, false)
+	bobChanSync, err := bobChannel.channelState.ChanSyncMsg(false)
 	if err != nil {
 		t.Fatalf("unable to generate chan sync msg: %v", err)
 	}

--- a/lnwallet/test_utils.go
+++ b/lnwallet/test_utils.go
@@ -7,6 +7,7 @@ import (
 	"encoding/hex"
 	"io"
 	"io/ioutil"
+	prand "math/rand"
 	"net"
 	"os"
 
@@ -102,7 +103,7 @@ func CreateTestChannels() (*LightningChannel, *LightningChannel, func(), error) 
 
 	prevOut := &wire.OutPoint{
 		Hash:  chainhash.Hash(testHdSeed),
-		Index: 0,
+		Index: prand.Uint32(),
 	}
 	fundingTxIn := wire.NewTxIn(prevOut, nil, nil)
 

--- a/lnwallet/test_utils.go
+++ b/lnwallet/test_utils.go
@@ -7,6 +7,7 @@ import (
 	"encoding/hex"
 	"io"
 	"io/ioutil"
+	"net"
 	"os"
 
 	"github.com/btcsuite/btcd/btcec"
@@ -334,10 +335,20 @@ func CreateTestChannels() (*LightningChannel, *LightningChannel, func(), error) 
 		return nil, nil, nil, err
 	}
 
-	if err := channelAlice.channelState.FullSync(); err != nil {
+	addr := &net.TCPAddr{
+		IP:   net.ParseIP("127.0.0.1"),
+		Port: 18556,
+	}
+	if err := channelAlice.channelState.SyncPending(addr, 101); err != nil {
 		return nil, nil, nil, err
 	}
-	if err := channelBob.channelState.FullSync(); err != nil {
+
+	addr = &net.TCPAddr{
+		IP:   net.ParseIP("127.0.0.1"),
+		Port: 18555,
+	}
+
+	if err := channelBob.channelState.SyncPending(addr, 101); err != nil {
 		return nil, nil, nil, err
 	}
 

--- a/peer.go
+++ b/peer.go
@@ -454,7 +454,7 @@ func (p *peer) loadActiveChannels(chans []*channeldb.OpenChannel) (
 			// channel reestablish message sent from the peer, but
 			// that's okay since the assumption is that we did when
 			// marking the channel borked.
-			chanSync, err := dbChan.ChanSyncMsg(false)
+			chanSync, err := dbChan.ChanSyncMsg()
 			if err != nil {
 				peerLog.Errorf("Unable to create channel "+
 					"reestablish message for channel %v: "+


### PR DESCRIPTION
This PR makes us store the closing TX we propose to the database, such that the ChainArbitrator can re-publish them at startup for channels in state `waiting close`.

This is meant to handle the case were we attempt to close the channel, but go down before the tx has propagated to the network. Now we'll instead store this tx the moment it is ready, such that we can re-publish it.

Builds on https://github.com/lightningnetwork/lnd/pull/3510