### PR TITLE
[autopilot] Fee aware autopilot

### DIFF
--- a/autopilot/agent_test.go
+++ b/autopilot/agent_test.go
@@ -122,6 +122,7 @@ type openChanIntent struct {
 type mockChanController struct {
 	openChanSignals chan openChanIntent
 	private         bool
+	feeEstimate     btcutil.Amount
 }
 
 func (m *mockChanController) OpenChannel(target *btcec.PublicKey,
@@ -146,6 +147,11 @@ func (m *mockChanController) SpliceIn(chanPoint *wire.OutPoint,
 func (m *mockChanController) SpliceOut(chanPoint *wire.OutPoint,
 	amt btcutil.Amount) (*Channel, error) {
 	return nil, nil
+}
+
+func (m *mockChanController) FeeEstimate(chanSize []btcutil.Amount) (
+	btcutil.Amount, error) {
+	return m.feeEstimate, nil
 }
 
 var _ ChannelController = (*mockChanController)(nil)
@@ -349,6 +355,11 @@ func (m *mockFailingChanController) SpliceIn(chanPoint *wire.OutPoint,
 func (m *mockFailingChanController) SpliceOut(chanPoint *wire.OutPoint,
 	amt btcutil.Amount) (*Channel, error) {
 	return nil, nil
+}
+
+func (m *mockFailingChanController) FeeEstimate(chanSize []btcutil.Amount) (
+	btcutil.Amount, error) {
+	return 0, nil
 }
 
 var _ ChannelController = (*mockFailingChanController)(nil)

--- a/autopilot/agent_test.go
+++ b/autopilot/agent_test.go
@@ -1207,7 +1207,7 @@ func TestAgentChannelSizeAllocation(t *testing.T) {
 	t.Parallel()
 
 	// Total number of nodes in our mock graph.
-	const numNodes = 10
+	const numNodes = 20
 
 	testCtx, cleanup := setup(t, nil)
 	defer cleanup()
@@ -1241,6 +1241,11 @@ func TestAgentChannelSizeAllocation(t *testing.T) {
 		t.Fatalf("heuristic wasn't queried in time")
 	}
 
+	// We set the chan controller to return a static fee estimate.
+	fee := btcutil.Amount(1000)
+	chanController := testCtx.chanController.(*mockChanController)
+	chanController.feeEstimate = fee
+
 	// We'll return a response telling the agent to open 5 channels, with a
 	// total channel budget of 5 BTC.
 	var channelBudget btcutil.Amount = 5 * btcutil.SatoshiPerBitcoin
@@ -1251,7 +1256,11 @@ func TestAgentChannelSizeAllocation(t *testing.T) {
 		numNewChannels, nodeScores,
 	)
 
-	expectedAllocation := testCtx.constraints.MaxChanSize() * btcutil.Amount(numNewChannels)
+	// We expect the autopilot to have allocated all funds towards
+	// channels, except 3 times the estimated fee, to ensure there's enough
+	// to pay fees.
+	expectedAllocation := testCtx.constraints.MaxChanSize()*
+		btcutil.Amount(numNewChannels) - 3*fee
 	nodes := checkChannelOpens(
 		t, testCtx, expectedAllocation, numNewChannels,
 	)
@@ -1325,5 +1334,30 @@ func TestAgentChannelSizeAllocation(t *testing.T) {
 
 	// To stay within the budget, we expect the autopilot to open 2
 	// channels.
-	checkChannelOpens(t, testCtx, channelBudget, 2)
+	expectedAllocation = channelBudget - 3*fee
+	nodes = checkChannelOpens(t, testCtx, expectedAllocation, 2)
+	numExistingChannels = 7
+
+	for _, node := range nodes {
+		delete(nodeScores, node)
+	}
+
+	waitForNumChans(numExistingChannels)
+
+	// Finally check that we make maximum channels if we are well within
+	// our budget.
+	channelBudget = btcutil.SatoshiPerBitcoin * 5
+	numNewChannels = 2
+	respondWithScores(
+		t, testCtx, channelBudget, numExistingChannels,
+		numNewChannels, nodeScores,
+	)
+
+	// We now expect the autopilot to open 2 channels, and since it has
+	// more than enough balance within the budget to cover the fees, they
+	// should both be of maximum size.
+	expectedAllocation = testCtx.constraints.MaxChanSize() *
+		btcutil.Amount(numNewChannels)
+
+	checkChannelOpens(t, testCtx, expectedAllocation, numNewChannels)
 }

--- a/autopilot/agent_test.go
+++ b/autopilot/agent_test.go
@@ -1270,34 +1270,40 @@ func TestAgentChannelSizeAllocation(t *testing.T) {
 	waitForNumChans := func(expChans int) {
 		t.Helper()
 
+		var (
+			numChans int
+			balance  btcutil.Amount
+		)
+
 	Loop:
 		for {
 			select {
 			case arg := <-testCtx.constraints.moreChanArgs:
+				numChans = len(arg.chans)
+				balance = arg.balance
+
 				// As long as the number of existing channels
 				// is below our expected number of channels,
-				// we'll keep responding with "no more
-				// channels".
-				if len(arg.chans) != expChans {
-					select {
-					case testCtx.constraints.moreChansResps <- moreChansResp{0, 0}:
-					case <-time.After(time.Second * 3):
-						t.Fatalf("heuristic wasn't " +
-							"queried in time")
-					}
-					continue
+				// and the balance is not what we expect, we'll
+				// keep responding with "no more channels".
+				if numChans == expChans &&
+					balance == testCtx.walletBalance {
+					break Loop
 				}
 
-				if arg.balance != testCtx.walletBalance {
-					t.Fatalf("expectd agent to have %v "+
-						"balance, had %v",
-						testCtx.walletBalance,
-						arg.balance)
+				select {
+				case testCtx.constraints.moreChansResps <- moreChansResp{0, 0}:
+				case <-time.After(time.Second * 3):
+					t.Fatalf("heuristic wasn't queried " +
+						"in time")
 				}
-				break Loop
 
 			case <-time.After(time.Second * 3):
-				t.Fatalf("heuristic wasn't queried in time")
+				t.Fatalf("did not receive expected "+
+					"channels(%d) and balance(%d), "+
+					"instead got %d and %d", expChans,
+					testCtx.walletBalance, numChans,
+					balance)
 			}
 		}
 	}

--- a/autopilot/interface.go
+++ b/autopilot/interface.go
@@ -203,4 +203,8 @@ type ChannelController interface {
 	// splice out mechanism. The removed funds from the channel should be
 	// returned to an output under the control of the backing wallet.
 	SpliceOut(chanPoint *wire.OutPoint, amt btcutil.Amount) (*Channel, error)
+
+	// FeeEstimate returns the total estimated fee needed for the autopilot
+	// to open channels of the given sizes.
+	FeeEstimate(chanSize []btcutil.Amount) (btcutil.Amount, error)
 }

--- a/pilot.go
+++ b/pilot.go
@@ -14,6 +14,11 @@ import (
 	"github.com/lightningnetwork/lnd/tor"
 )
 
+// targetConf is the confirmation target for autopilot channels.
+// TODO(halseth): make configurable? possibly dynamic, going aggressive->lax as
+// more channels are opened.
+const targetConf = 3
+
 // validateAtplConfig is a helper method that makes sure the passed
 // configuration is sane. Currently it checks that the heuristic configuration
 // makes sense. In case the config is valid, it will return a list of
@@ -84,7 +89,7 @@ func (c *chanController) OpenChannel(target *btcec.PublicKey,
 
 	// With the connection established, we'll now establish our connection
 	// to the target peer, waiting for the first update before we exit.
-	feePerKw, err := c.server.cc.feeEstimator.EstimateFeePerKW(3)
+	feePerKw, err := c.server.cc.feeEstimator.EstimateFeePerKW(targetConf)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Previously the autopilot wouldn't take fees into account when opening
channels, causing it to have insufficient funds when trying to utilize
close to all funds in the wallet.

This commit uses the FeeEstimate method to get a rough estimate (we
allow some wiggle room) for the fees needed to open the channels. Since
the total fee will change with the number of channels being opened
(potentially we can open channels in the same tx in the future), we
re-calculate the total fee each time we find a new potential channel
candidate, and resize the last channel to fit it within the budget with
the fee.

Fixes https://github.com/lightningnetwork/lnd/issues/986

TODO:
- [x] unit test for autopilot agent 