### PR TITLE
sweep: add support for multiple fee preferences to UtxoSweeper

### DIFF
--- a/contractcourt/commit_sweep_resolver.go
+++ b/contractcourt/commit_sweep_resolver.go
@@ -5,10 +5,16 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/lightningnetwork/lnd/input"
-
 	"github.com/btcsuite/btcd/wire"
+	"github.com/lightningnetwork/lnd/input"
 	"github.com/lightningnetwork/lnd/lnwallet"
+	"github.com/lightningnetwork/lnd/sweep"
+)
+
+const (
+	// commitOutputConfTarget is the default confirmation target we'll use
+	// for sweeps of commit outputs that belong to us.
+	commitOutputConfTarget = 6
 )
 
 // commitSweepResolver is a resolver that will attempt to sweep the commitment
@@ -98,7 +104,8 @@ func (c *commitSweepResolver) Resolve() (ContractResolver, error) {
 		// sweeper.
 		log.Infof("%T(%v): sweeping commit output", c, c.chanPoint)
 
-		resultChan, err := c.Sweeper.SweepInput(&inp)
+		feePref := sweep.FeePreference{ConfTarget: commitOutputConfTarget}
+		resultChan, err := c.Sweeper.SweepInput(&inp, feePref)
 		if err != nil {
 			log.Errorf("%T(%v): unable to sweep input: %v",
 				c, c.chanPoint, err)

--- a/lnwallet/fee_estimator.go
+++ b/lnwallet/fee_estimator.go
@@ -54,6 +54,11 @@ func (s SatPerKVByte) FeePerKWeight() SatPerKWeight {
 	return SatPerKWeight(s / blockchain.WitnessScaleFactor)
 }
 
+// String returns a human-readable string of the fee rate.
+func (s SatPerKVByte) String() string {
+	return fmt.Sprintf("%v sat/kb", int64(s))
+}
+
 // SatPerKWeight represents a fee rate in sat/kw.
 type SatPerKWeight btcutil.Amount
 
@@ -67,6 +72,11 @@ func (s SatPerKWeight) FeeForWeight(wu int64) btcutil.Amount {
 // FeePerKVByte converts the current fee rate from sat/kw to sat/kb.
 func (s SatPerKWeight) FeePerKVByte() SatPerKVByte {
 	return SatPerKVByte(s * blockchain.WitnessScaleFactor)
+}
+
+// String returns a human-readable string of the fee rate.
+func (s SatPerKWeight) String() string {
+	return fmt.Sprintf("%v sat/kw", int64(s))
 }
 
 // FeeEstimator provides the ability to estimate on-chain transaction fees for

--- a/server.go
+++ b/server.go
@@ -717,13 +717,14 @@ func newServer(listenAddrs []net.Addr, chanDB *channeldb.DB, cc *chainControl,
 		NewBatchTimer: func() <-chan time.Time {
 			return time.NewTimer(sweep.DefaultBatchWindowDuration).C
 		},
-		SweepTxConfTarget:    6,
 		Notifier:             cc.chainNotifier,
 		ChainIO:              cc.chainIO,
 		Store:                sweeperStore,
 		MaxInputsPerTx:       sweep.DefaultMaxInputsPerTx,
 		MaxSweepAttempts:     sweep.DefaultMaxSweepAttempts,
 		NextAttemptDeltaFunc: sweep.DefaultNextAttemptDeltaFunc,
+		MaxFeeRate:           sweep.DefaultMaxFeeRate,
+		FeeRateBucketSize:    sweep.DefaultFeeRateBucketSize,
 	})
 
 	s.utxoNursery = newUtxoNursery(&NurseryConfig{

--- a/sweep/fee_estimator_mock_test.go
+++ b/sweep/fee_estimator_mock_test.go
@@ -16,6 +16,10 @@ type mockFeeEstimator struct {
 
 	blocksToFee map[uint32]lnwallet.SatPerKWeight
 
+	// A closure that when set is used instead of the
+	// mockFeeEstimator.EstimateFeePerKW method.
+	estimateFeePerKW func(numBlocks uint32) (lnwallet.SatPerKWeight, error)
+
 	lock sync.Mutex
 }
 
@@ -44,6 +48,10 @@ func (e *mockFeeEstimator) EstimateFeePerKW(numBlocks uint32) (
 
 	e.lock.Lock()
 	defer e.lock.Unlock()
+
+	if e.estimateFeePerKW != nil {
+		return e.estimateFeePerKW(numBlocks)
+	}
 
 	if fee, ok := e.blocksToFee[numBlocks]; ok {
 		return fee, nil

--- a/sweep/walletsweep.go
+++ b/sweep/walletsweep.go
@@ -30,6 +30,14 @@ type FeePreference struct {
 	FeeRate lnwallet.SatPerKWeight
 }
 
+// String returns a human-readable string of the fee preference.
+func (p FeePreference) String() string {
+	if p.ConfTarget != 0 {
+		return fmt.Sprintf("%v blocks", p.ConfTarget)
+	}
+	return p.FeeRate.String()
+}
+
 // DetermineFeePerKw will determine the fee in sat/kw that should be paid given
 // an estimator, a confirmation target, and a manual value for sat/byte. A
 // value is chosen based on the two free parameters as one, or both of them can

--- a/utxonursery.go
+++ b/utxonursery.go
@@ -155,6 +155,12 @@ import (
 
 var byteOrder = binary.BigEndian
 
+const (
+	// kgtnOutputConfTarget is the default confirmation target we'll use for
+	// sweeps of CSV delayed outputs.
+	kgtnOutputConfTarget = 6
+)
+
 var (
 	// ErrContractNotFound is returned when the nursery is unable to
 	// retrieve information about a queried contract.
@@ -196,7 +202,7 @@ type NurseryConfig struct {
 	Store NurseryStore
 
 	// Sweep sweeps an input back to the wallet.
-	SweepInput func(input input.Input) (chan sweep.Result, error)
+	SweepInput func(input.Input, sweep.FeePreference) (chan sweep.Result, error)
 }
 
 // utxoNursery is a system dedicated to incubating time-locked outputs created
@@ -804,12 +810,13 @@ func (u *utxoNursery) sweepMatureOutputs(classHeight uint32,
 	utxnLog.Infof("Sweeping %v CSV-delayed outputs with sweep tx for "+
 		"height %v", len(kgtnOutputs), classHeight)
 
+	feePref := sweep.FeePreference{ConfTarget: kgtnOutputConfTarget}
 	for _, output := range kgtnOutputs {
 		// Create local copy to prevent pointer to loop variable to be
 		// passed in with disastrous consequences.
 		local := output
 
-		resultChan, err := u.cfg.SweepInput(&local)
+		resultChan, err := u.cfg.SweepInput(&local, feePref)
 		if err != nil {
 			return err
 		}

--- a/utxonursery_test.go
+++ b/utxonursery_test.go
@@ -1051,7 +1051,9 @@ func newMockSweeper(t *testing.T) *mockSweeper {
 	}
 }
 
-func (s *mockSweeper) sweepInput(input input.Input) (chan sweep.Result, error) {
+func (s *mockSweeper) sweepInput(input input.Input,
+	_ sweep.FeePreference) (chan sweep.Result, error) {
+
 	utxnLog.Debugf("mockSweeper sweepInput called for %v", *input.OutPoint())
 
 	select {


### PR DESCRIPTION
In this PR, we introduce support for arbitrary client fee preferences when accepting input sweep requests. This is possible with the addition of fee rate buckets. Fee rate buckets are buckets that contain inputs with similar fee rates within a specific range, e.g., 1-10 sat/vbyte, 11-20 sat/vbyte, etc. Having these buckets allows us to batch and sweep inputs from different clients with similar fee rates within a single transaction, allowing us to save on chain fees. Implementing these fee rate buckets also lays down the groundwork required for being able to bump the fee rates for particular inputs.

We also get rid of the UtxoSweeper's default fee preference. Any clients using it to sweep inputs specify the same default fee preference to not change their behavior. Each of these can be fine-tuned later on given their use cases.