### PR TITLE
config: fix litecoin simnet mode

### DIFF
--- a/config.go
+++ b/config.go
@@ -647,10 +647,6 @@ func loadConfig() (*config, error) {
 			numNets++
 			ltcParams = litecoinTestNetParams
 		}
-		if cfg.Litecoin.SimNet {
-			numNets++
-			ltcParams = litecoinSimNetParams
-		}
 		if cfg.Litecoin.RegTest {
 			numNets++
 			ltcParams = litecoinRegTestNetParams


### PR DESCRIPTION
This commit fixes a bug where it was impossible to run lnd in litecoin's simnet mode because of code duplication. As a result `numNets > 1` conditional was always true when running lnd with `cfg.Litecoin.SimNet` flag.