### PR TITLE
htlcswitch+routing: handle unknown failure source

### DIFF
--- a/htlcswitch/failure.go
+++ b/htlcswitch/failure.go
@@ -6,7 +6,7 @@ import (
 	"io"
 
 	"github.com/btcsuite/btcd/btcec"
-	"github.com/lightningnetwork/lightning-onion"
+	sphinx "github.com/lightningnetwork/lightning-onion"
 	"github.com/lightningnetwork/lnd/lnwire"
 )
 
@@ -30,10 +30,10 @@ type ForwardingError struct {
 // returned.
 func (f *ForwardingError) Error() string {
 	if f.ExtraMsg == "" {
-		return f.FailureMessage.Error()
+		return fmt.Sprintf("%v", f.FailureMessage)
 	}
 
-	return fmt.Sprintf("%v: %v", f.FailureMessage.Error(), f.ExtraMsg)
+	return fmt.Sprintf("%v: %v", f.FailureMessage, f.ExtraMsg)
 }
 
 // ErrorDecrypter is an interface that is used to decrypt the onion encrypted

--- a/htlcswitch/switch.go
+++ b/htlcswitch/switch.go
@@ -997,9 +997,8 @@ func (s *Switch) parseFailedPayment(payment *pendingPayment, pkt *htlcPacket,
 		userErr := fmt.Sprintf("error decryptor for payment " +
 			"could not be located, likely due to restart")
 		failure = &ForwardingError{
-			ErrorSource:    s.cfg.SelfKey,
-			ExtraMsg:       userErr,
-			FailureMessage: lnwire.NewTemporaryChannelFailure(nil),
+			ErrorSource: nil,
+			ExtraMsg:    userErr,
 		}
 
 	// A regular multi-hop payment error that we'll need to
@@ -1015,9 +1014,8 @@ func (s *Switch) parseFailedPayment(payment *pendingPayment, pkt *htlcPacket,
 				pkt.circuit.PaymentHash[:], err)
 			log.Error(userErr)
 			failure = &ForwardingError{
-				ErrorSource:    s.cfg.SelfKey,
-				ExtraMsg:       userErr,
-				FailureMessage: lnwire.NewTemporaryChannelFailure(nil),
+				ErrorSource: nil,
+				ExtraMsg:    userErr,
 			}
 		}
 	}

--- a/htlcswitch/switch_test.go
+++ b/htlcswitch/switch_test.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
-	"strings"
 	"testing"
 	"time"
 
@@ -1817,9 +1816,13 @@ func TestSwitchSendPayment(t *testing.T) {
 
 	select {
 	case err := <-errChan:
-		if !strings.Contains(err.Error(), lnwire.CodeUnknownPaymentHash.String()) {
-			t.Fatalf("expected %v got %v", err,
-				lnwire.CodeUnknownPaymentHash)
+		fErr, ok := err.(*ForwardingError)
+		if !ok {
+			t.Fatal("expected ForwardingError")
+		}
+
+		if _, ok := fErr.FailureMessage.(*lnwire.FailUnknownPaymentHash); !ok {
+			t.Fatalf("expected UnknownPaymentHash got %v", fErr)
 		}
 	case <-time.After(time.Second):
 		t.Fatal("err wasn't received")

--- a/routing/pathfind_test.go
+++ b/routing/pathfind_test.go
@@ -379,7 +379,9 @@ type testGraphInstance struct {
 // a deterministical way and added to the channel graph. A list of nodes is
 // not required and derived from the channel data. The goal is to keep
 // instantiating a test channel graph as light weight as possible.
-func createTestGraphFromChannels(testChannels []*testChannel) (*testGraphInstance, error) {
+func createTestGraphFromChannels(testChannels []*testChannel, source string) (
+	*testGraphInstance, error) {
+
 	// We'll use this fake address for the IP address of all the nodes in
 	// our tests. This value isn't needed for path finding so it doesn't
 	// need to be unique.
@@ -437,13 +439,13 @@ func createTestGraphFromChannels(testChannels []*testChannel) (*testGraphInstanc
 		return dbNode, nil
 	}
 
-	var source *channeldb.LightningNode
-	if source, err = addNodeWithAlias("roasbeef"); err != nil {
+	// Add the source node.
+	dbNode, err := addNodeWithAlias(source)
+	if err != nil {
 		return nil, err
 	}
 
-	// Set the source node
-	if err := graph.SetSourceNode(source); err != nil {
+	if err = graph.SetSourceNode(dbNode); err != nil {
 		return nil, err
 	}
 
@@ -457,7 +459,10 @@ func createTestGraphFromChannels(testChannels []*testChannel) (*testGraphInstanc
 
 			_, exists := aliasMap[alias]
 			if !exists {
-				addNodeWithAlias(alias)
+				_, err := addNodeWithAlias(alias)
+				if err != nil {
+					return nil, err
+				}
 			}
 		}
 
@@ -602,7 +607,9 @@ func TestFindLowestFeePath(t *testing.T) {
 		}),
 	}
 
-	testGraphInstance, err := createTestGraphFromChannels(testChannels)
+	testGraphInstance, err := createTestGraphFromChannels(
+		testChannels, "roasbeef",
+	)
 	if err != nil {
 		t.Fatalf("unable to create graph: %v", err)
 	}
@@ -1420,7 +1427,7 @@ func TestRouteFailMaxHTLC(t *testing.T) {
 		}),
 	}
 
-	graph, err := createTestGraphFromChannels(testChannels)
+	graph, err := createTestGraphFromChannels(testChannels, "roasbeef")
 	if err != nil {
 		t.Fatalf("unable to create graph: %v", err)
 	}
@@ -1989,7 +1996,9 @@ func TestRestrictOutgoingChannel(t *testing.T) {
 		}),
 	}
 
-	testGraphInstance, err := createTestGraphFromChannels(testChannels)
+	testGraphInstance, err := createTestGraphFromChannels(
+		testChannels, "roasbeef",
+	)
 	if err != nil {
 		t.Fatalf("unable to create graph: %v", err)
 	}
@@ -2083,7 +2092,9 @@ func testCltvLimit(t *testing.T, limit uint32, expectedChannel uint64) {
 		}),
 	}
 
-	testGraphInstance, err := createTestGraphFromChannels(testChannels)
+	testGraphInstance, err := createTestGraphFromChannels(
+		testChannels, "roasbeef",
+	)
 	if err != nil {
 		t.Fatalf("unable to create graph: %v", err)
 	}

--- a/routing/router.go
+++ b/routing/router.go
@@ -1786,6 +1786,17 @@ func (r *ChannelRouter) processSendError(paySession *paymentSession,
 	}
 
 	errSource := fErr.ErrorSource
+
+	// It can be that no error source is available. In that case we report
+	// the route to mission control and continue path finding.
+	if errSource == nil {
+		log.Tracef("Unknown failure source reported when sending htlc")
+
+		paySession.ReportRouteFailure(rt)
+
+		return false
+	}
+
 	errVertex := route.NewVertex(errSource)
 
 	log.Tracef("node=%x reported failure when sending htlc", errVertex)

--- a/routing/router_test.go
+++ b/routing/router_test.go
@@ -18,6 +18,7 @@ import (
 	sphinx "github.com/lightningnetwork/lightning-onion"
 	"github.com/lightningnetwork/lnd/channeldb"
 	"github.com/lightningnetwork/lnd/htlcswitch"
+	"github.com/lightningnetwork/lnd/lntypes"
 	"github.com/lightningnetwork/lnd/lnwire"
 	"github.com/lightningnetwork/lnd/routing/route"
 	"github.com/lightningnetwork/lnd/zpay32"
@@ -2527,6 +2528,91 @@ func TestEmptyRoutesGenerateSphinxPacket(t *testing.T) {
 	_, _, err := generateSphinxPacket(emptyRoute, testHash[:])
 	if err != route.ErrNoRouteHopsProvided {
 		t.Fatalf("expected empty hops error: instead got: %v", err)
+	}
+}
+
+// TestUnknownErrorSource tests that if the source of an error is unknown, all
+// edges along the route will be pruned.
+func TestUnknownErrorSource(t *testing.T) {
+	t.Parallel()
+
+	// Setup a network. It contains two paths to c: a->b->c and a detour
+	// a->d->b->c.
+	chanCapSat := btcutil.Amount(100000)
+	testChannels := []*testChannel{
+		symmetricTestChannel("a", "b", chanCapSat, &testChannelPolicy{
+			Expiry:  144,
+			FeeRate: 400,
+			MinHTLC: 1,
+			MaxHTLC: lnwire.NewMSatFromSatoshis(chanCapSat),
+		}, 1),
+		symmetricTestChannel("b", "c", chanCapSat, &testChannelPolicy{
+			Expiry:  144,
+			FeeRate: 400,
+			MinHTLC: 1,
+			MaxHTLC: lnwire.NewMSatFromSatoshis(chanCapSat),
+		}),
+		symmetricTestChannel("a", "d", chanCapSat, &testChannelPolicy{
+			Expiry:  144,
+			FeeRate: 400,
+			MinHTLC: 1,
+			MaxHTLC: lnwire.NewMSatFromSatoshis(chanCapSat),
+		}, 2),
+		symmetricTestChannel("d", "b", chanCapSat, &testChannelPolicy{
+			Expiry:  144,
+			FeeRate: 400,
+			MinHTLC: 1,
+			MaxHTLC: lnwire.NewMSatFromSatoshis(chanCapSat),
+		}),
+	}
+
+	testGraph, err := createTestGraphFromChannels(testChannels, "a")
+	defer testGraph.cleanUp()
+	if err != nil {
+		t.Fatalf("unable to create graph: %v", err)
+	}
+
+	const startingBlockHeight = 101
+
+	ctx, cleanUp, err := createTestCtxFromGraphInstance(startingBlockHeight,
+		testGraph)
+
+	defer cleanUp()
+	if err != nil {
+		t.Fatalf("unable to create router: %v", err)
+	}
+
+	// Create a payment to node c.
+	payment := LightningPayment{
+		Target:      ctx.aliases["c"],
+		Amount:      lnwire.NewMSatFromSatoshis(1000),
+		FeeLimit:    noFeeLimit,
+		PaymentHash: lntypes.Hash{},
+	}
+
+	// We'll modify the SendToSwitch method so that it simulates hop b as a
+	// node that returns an unparsable failure if approached via the a->b
+	// channel.
+	ctx.router.cfg.SendToSwitch = func(firstHop lnwire.ShortChannelID,
+		_ *lnwire.UpdateAddHTLC, _ *sphinx.Circuit) ([32]byte, error) {
+
+		// If channel a->b is used, return an error without source and
+		// message. The sender won't know the origin of the error.
+		if firstHop.ToUint64() == 1 {
+			return [32]byte{}, &htlcswitch.ForwardingError{}
+		}
+
+		// Otherwise the payment succeeds.
+		return lntypes.Preimage{}, nil
+	}
+
+	// Send off the payment request to the router. The expectation is that
+	// the route a->b->c is tried first. Because b returns an unparsable
+	// error, it is expected that both a->b and b->c are pruned, thereby
+	// closing off the alternative route a->d->b->c too.
+	_, _, err = ctx.router.SendPayment(&payment)
+	if err == nil {
+		t.Fatalf("expected payment to fail")
 	}
 }
 

--- a/routing/router_test.go
+++ b/routing/router_test.go
@@ -382,7 +382,7 @@ func TestChannelUpdateValidation(t *testing.T) {
 		}, 2),
 	}
 
-	testGraph, err := createTestGraphFromChannels(testChannels)
+	testGraph, err := createTestGraphFromChannels(testChannels, "a")
 	defer testGraph.cleanUp()
 	if err != nil {
 		t.Fatalf("unable to create graph: %v", err)
@@ -1075,7 +1075,9 @@ func TestIgnoreChannelEdgePolicyForUnknownChannel(t *testing.T) {
 
 	// Setup an initially empty network.
 	testChannels := []*testChannel{}
-	testGraph, err := createTestGraphFromChannels(testChannels)
+	testGraph, err := createTestGraphFromChannels(
+		testChannels, "roasbeef",
+	)
 	if err != nil {
 		t.Fatalf("unable to create graph: %v", err)
 	}
@@ -2071,7 +2073,7 @@ func TestPruneChannelGraphStaleEdges(t *testing.T) {
 
 	// We'll create our test graph and router backed with these test
 	// channels we've created.
-	testGraph, err := createTestGraphFromChannels(testChannels)
+	testGraph, err := createTestGraphFromChannels(testChannels, "a")
 	if err != nil {
 		t.Fatalf("unable to create test graph: %v", err)
 	}
@@ -2108,6 +2110,14 @@ func TestPruneChannelGraphDoubleDisabled(t *testing.T) {
 	// according to that heuristic.
 	timestamp := time.Now()
 	testChannels := []*testChannel{
+		// Channel from self shouldn't be pruned.
+		symmetricTestChannel(
+			"self", "a", 100000, &testChannelPolicy{
+				LastUpdate: timestamp,
+				Disabled:   true,
+			}, 99,
+		),
+
 		// No edges.
 		{
 			Node1:     &testChannelEnd{Alias: "a"},
@@ -2179,7 +2189,7 @@ func TestPruneChannelGraphDoubleDisabled(t *testing.T) {
 
 	// We'll create our test graph and router backed with these test
 	// channels we've created.
-	testGraph, err := createTestGraphFromChannels(testChannels)
+	testGraph, err := createTestGraphFromChannels(testChannels, "self")
 	if err != nil {
 		t.Fatalf("unable to create test graph: %v", err)
 	}


### PR DESCRIPTION
This PR modifies the switch to properly signal the case where the error source is unknown. Previously the self node was reported as the source of the error.

Handling of an unknown error source in router is modified to prune all channel edges along the route, as the cause of this error could be any node.