### PR TITLE
peer: break sendMessage on server quit

### DIFF
--- a/peer.go
+++ b/peer.go
@@ -2502,6 +2502,8 @@ func (p *peer) sendMessage(sync, priority bool, msgs ...lnwire.Message) error {
 			return err
 		case <-p.quit:
 			return lnpeer.ErrPeerExiting
+		case <-p.server.quit:
+			return lnpeer.ErrPeerExiting
 		}
 	}
 


### PR DESCRIPTION
This commit modifies sendMessage to break on the server's quit channel,
which allows synchronous callers of SendMessage or SendLazyMessage to
receive an error during server shutdown which can be independent of a
particular peer's shutdown.

As of https://github.com/lightningnetwork/lnd/pull/2916, all replies
made by gossip syncers were modified to be synchronous. In certain
cases, This would prevent the syncers from shutting down promptly, as
they would try to offload a batch a of messages that could not be
aborted. Now, an error will be propagated back to the caller, allowing
them to detect the error condition, and reevaluate their own quit
signals, releasing any waitgrouped goroutines and permitting a quick
shutdown.

Fixes #3048 
