### PR TITLE
lnd: close the wallet unlock grpc server

### DIFF
--- a/lnd.go
+++ b/lnd.go
@@ -879,6 +879,7 @@ func waitForWalletPassword(grpcEndpoints, restEndpoints []net.Addr,
 	// Set up a new PasswordService, which will listen for passwords
 	// provided over RPC.
 	grpcServer := grpc.NewServer(serverOpts...)
+	defer grpcServer.GracefulStop()
 
 	chainConfig := cfg.Bitcoin
 	if registeredChains.PrimaryChain() == litecoinChain {


### PR DESCRIPTION
The server was kept alive long after it stopped being used. This caused
problems for services using long-lived GRPC connections which might be
created before wallet unlocked. They got stuck connected to the wallet
unlock service needing a restart.

#### Pull Request Checklist

- [x] If this is your first time contributing, we recommend you read the [Code
  Contribution Guidelines](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md)
- [x] All changes are Go version 1.12 compliant
- [x] The code being submitted is commented according to [Code Documentation and Commenting](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#CodeDocumentation)
- [x] For new code: Code is accompanied by tests which exercise both
  the positive and negative (error paths) conditions (if applicable)
- [x] For bug fixes: Code is accompanied by new tests which trigger
  the bug being fixed to prevent regressions
- [x] Any new logging statements use an appropriate subsystem and
  logging level
- [x] Code has been formatted with `go fmt`
- [x] For code and documentation: lines are wrapped at 80 characters
  (the tab character should be counted as 8 characters, not 4, as some IDEs do
  per default)
- [x] Running `make check` does not fail any tests
- [x] Running `go vet` does not report any issues
- [x] Running `make lint` does not report any **new** issues that did not
  already exist
- [x] All commits build properly and pass tests. Only in exceptional
  cases it can be justifiable to violate this condition. In that case, the
  reason should be stated in the commit message.
- [x] Commits have a logical structure according to [Ideal Git Commit Structure](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#IdealGitCommitStructure)
