### PR TITLE
lnd: add litecoin support for Neutrino

### DIFF
--- a/chainparams.go
+++ b/chainparams.go
@@ -105,6 +105,34 @@ func applyLitecoinParams(params *bitcoinNetParams, litecoinParams *litecoinNetPa
 	params.CoinbaseMaturity = litecoinParams.CoinbaseMaturity
 
 	copy(params.GenesisHash[:], litecoinParams.GenesisHash[:])
+	copy(params.GenesisBlock.Header.MerkleRoot[:],
+		litecoinParams.GenesisBlock.Header.MerkleRoot[:])
+	params.GenesisBlock.Header.Version =
+		litecoinParams.GenesisBlock.Header.Version
+	params.GenesisBlock.Header.Timestamp =
+		litecoinParams.GenesisBlock.Header.Timestamp
+	params.GenesisBlock.Header.Bits =
+		litecoinParams.GenesisBlock.Header.Bits
+	params.GenesisBlock.Header.Nonce =
+		litecoinParams.GenesisBlock.Header.Nonce
+	params.GenesisBlock.Transactions[0].Version =
+		litecoinParams.GenesisBlock.Transactions[0].Version
+	params.GenesisBlock.Transactions[0].LockTime =
+		litecoinParams.GenesisBlock.Transactions[0].LockTime
+	params.GenesisBlock.Transactions[0].TxIn[0].Sequence =
+		litecoinParams.GenesisBlock.Transactions[0].TxIn[0].Sequence
+	params.GenesisBlock.Transactions[0].TxIn[0].PreviousOutPoint.Index =
+		litecoinParams.GenesisBlock.Transactions[0].TxIn[0].PreviousOutPoint.Index
+	copy(params.GenesisBlock.Transactions[0].TxIn[0].SignatureScript[:],
+		litecoinParams.GenesisBlock.Transactions[0].TxIn[0].SignatureScript[:])
+	copy(params.GenesisBlock.Transactions[0].TxOut[0].PkScript[:],
+		litecoinParams.GenesisBlock.Transactions[0].TxOut[0].PkScript[:])
+	params.GenesisBlock.Transactions[0].TxOut[0].Value =
+		litecoinParams.GenesisBlock.Transactions[0].TxOut[0].Value
+	params.GenesisBlock.Transactions[0].TxIn[0].PreviousOutPoint.Hash =
+		chainhash.Hash{}
+	params.PowLimitBits = litecoinParams.PowLimitBits
+	params.PowLimit = litecoinParams.PowLimit
 
 	// Address encoding magics
 	params.PubKeyHashAddrID = litecoinParams.PubKeyHashAddrID

--- a/config.go
+++ b/config.go
@@ -707,9 +707,12 @@ func loadConfig() (*config, error) {
 					"credentials for litecoind: %v", err)
 				return nil, err
 			}
+		case "neutrino":
+			// No need to get RPC parameters.
+
 		default:
-			str := "%s: only ltcd and litecoind mode supported for " +
-				"litecoin at this time"
+			str := "%s: only ltcd, litecoind, and neutrino mode " +
+				"supported for litecoin at this time"
 			return nil, fmt.Errorf(str, funcName)
 		}
 


### PR DESCRIPTION
Please could you review the following proposal for enabling litecoin support in LND/Neutrino :

LND/config.go :
allow the configuration of litecoin.node=neutrino

LND/chainparams.go/applyLitecoinParams :
apply some litecoin chainparams settings that were missed in the original implementation, namely:
GenesisBlock information
PowLimitBits and PowLimit

Ref: lightninglabs/neutrino#142