### PR TITLE
[reliable payments] Move payment error deobfuscation to router

### DIFF
--- a/htlcswitch/link_test.go
+++ b/htlcswitch/link_test.go
@@ -54,6 +54,8 @@ func newConcurrentTester(t *testing.T) *concurrentTester {
 }
 
 func (c *concurrentTester) Fatalf(format string, args ...interface{}) {
+	c.T.Helper()
+
 	c.mtx.Lock()
 	defer c.mtx.Unlock()
 
@@ -1108,13 +1110,30 @@ func TestChannelLinkMultiHopUnknownPaymentHash(t *testing.T) {
 	}
 
 	// Send payment and expose err channel.
-	_, err = n.aliceServer.htlcSwitch.SendHTLC(
+	err = n.aliceServer.htlcSwitch.SendHTLC(
 		n.firstBobChannelLink.ShortChanID(), pid, htlc,
 		newMockDeobfuscator(),
 	)
-	if !strings.Contains(err.Error(), lnwire.CodeUnknownPaymentHash.String()) {
-		t.Fatalf("expected %v got %v", err,
-			lnwire.CodeUnknownPaymentHash)
+	if err != nil {
+		t.Fatalf("unable to get send payment: %v", err)
+	}
+
+	resultChan, err := n.aliceServer.htlcSwitch.GetPaymentResult(pid)
+	if err != nil {
+		t.Fatalf("unable to get payment result: %v", err)
+	}
+
+	var result *PaymentResult
+	select {
+
+	case result = <-resultChan:
+	case <-time.After(5 * time.Second):
+		t.Fatalf("no result arrive")
+	}
+
+	fErr := result.Error
+	if !strings.Contains(fErr.Error(), lnwire.CodeUnknownPaymentHash.String()) {
+		t.Fatalf("expected %v got %v", lnwire.CodeUnknownPaymentHash, fErr)
 	}
 
 	// Wait for Alice to receive the revocation.
@@ -3867,7 +3886,7 @@ func TestChannelLinkAcceptDuplicatePayment(t *testing.T) {
 	// With the invoice now added to Carol's registry, we'll send the
 	// payment. It should succeed w/o any issues as it has been crafted
 	// properly.
-	_, err = n.aliceServer.htlcSwitch.SendHTLC(
+	err = n.aliceServer.htlcSwitch.SendHTLC(
 		n.firstBobChannelLink.ShortChanID(), pid, htlc,
 		newMockDeobfuscator(),
 	)
@@ -3875,9 +3894,23 @@ func TestChannelLinkAcceptDuplicatePayment(t *testing.T) {
 		t.Fatalf("unable to send payment to carol: %v", err)
 	}
 
+	resultChan, err := n.aliceServer.htlcSwitch.GetPaymentResult(pid)
+	if err != nil {
+		t.Fatalf("unable to get payment result: %v", err)
+	}
+
+	select {
+	case result := <-resultChan:
+		if result.Error != nil {
+			t.Fatalf("payment failed: %v", result.Error)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatalf("payment result did not arrive")
+	}
+
 	// Now, if we attempt to send the payment *again* it should be rejected
 	// as it's a duplicate request.
-	_, err = n.aliceServer.htlcSwitch.SendHTLC(
+	err = n.aliceServer.htlcSwitch.SendHTLC(
 		n.firstBobChannelLink.ShortChanID(), pid, htlc,
 		newMockDeobfuscator(),
 	)

--- a/htlcswitch/payment_result.go
+++ b/htlcswitch/payment_result.go
@@ -1,0 +1,25 @@
+package htlcswitch
+
+import "errors"
+
+var (
+	// ErrPaymentIDNotFound is an error returned if the given paymentID is
+	// not found.
+	ErrPaymentIDNotFound = errors.New("paymentID not found")
+
+	// ErrPaymentIDAlreadyExists is returned if we try to write a pending
+	// payment whose paymentID already exists.
+	ErrPaymentIDAlreadyExists = errors.New("paymentID already exists")
+)
+
+// PaymentResult wraps a result received from the network after a payment
+// attempt was made.
+type PaymentResult struct {
+	// Preimage is set by the switch in case a sent HTLC was settled.
+	Preimage [32]byte
+
+	// Error is non-nil in case a HTLC send failed, and the HTLC is now
+	// irrevocably cancelled. If the payment failed during forwarding, this
+	// error will be a *ForwardingError.
+	Error error
+}

--- a/htlcswitch/payment_result.go
+++ b/htlcswitch/payment_result.go
@@ -1,6 +1,10 @@
 package htlcswitch
 
-import "errors"
+import (
+	"errors"
+
+	"github.com/lightningnetwork/lnd/lnwire"
+)
 
 var (
 	// ErrPaymentIDNotFound is an error returned if the given paymentID is
@@ -12,8 +16,9 @@ var (
 	ErrPaymentIDAlreadyExists = errors.New("paymentID already exists")
 )
 
-// PaymentResult wraps a result received from the network after a payment
-// attempt was made.
+// PaymentResult wraps a decoded result received from the network after a
+// payment attempt was made. This is what is eventually handed to the router
+// for processing.
 type PaymentResult struct {
 	// Preimage is set by the switch in case a sent HTLC was settled.
 	Preimage [32]byte
@@ -22,4 +27,22 @@ type PaymentResult struct {
 	// irrevocably cancelled. If the payment failed during forwarding, this
 	// error will be a *ForwardingError.
 	Error error
+}
+
+// networkResult is the raw result received from the network after a payment
+// attempt has been made. Since the switch doesn't always have the necessary
+// data to decode the raw message, we store it together with some meta data,
+// and decode it when the router query for the final result.
+type networkResult struct {
+	// msg is the received result. This should be of type UpdateFulfillHTLC
+	// or UpdateFailHTLC.
+	msg lnwire.Message
+
+	// unencrypted indicates whether the failure encoded in the message is
+	// unencrypted, and hence doesn't need to be decrypted.
+	unencrypted bool
+
+	// isResolution indicates whether this is a resolution message, in
+	// which the failure reason might not be included.
+	isResolution bool
 }

--- a/htlcswitch/switch.go
+++ b/htlcswitch/switch.go
@@ -213,8 +213,6 @@ type Switch struct {
 	pendingPayments map[uint64]*pendingPayment
 	pendingMutex    sync.RWMutex
 
-	paymentSequencer Sequencer
-
 	// control provides verification of sending htlc mesages
 	control ControlTower
 
@@ -293,16 +291,10 @@ func New(cfg Config, currentHeight uint32) (*Switch, error) {
 		return nil, err
 	}
 
-	sequencer, err := NewPersistentSequencer(cfg.DB)
-	if err != nil {
-		return nil, err
-	}
-
 	return &Switch{
 		bestHeight:        currentHeight,
 		cfg:               &cfg,
 		circuits:          circuitMap,
-		paymentSequencer:  sequencer,
 		control:           NewPaymentControl(false, cfg.DB),
 		linkIndex:         make(map[lnwire.ChannelID]ChannelLink),
 		mailOrchestrator:  newMailOrchestrator(),
@@ -354,8 +346,9 @@ func (s *Switch) ProcessContractResolution(msg contractcourt.ResolutionMsg) erro
 }
 
 // SendHTLC is used by other subsystems which aren't belong to htlc switch
-// package in order to send the htlc update.
-func (s *Switch) SendHTLC(firstHop lnwire.ShortChannelID,
+// package in order to send the htlc update. The paymentID used MUST be unique
+// for this HTLC, otherwise the switch might reject it.
+func (s *Switch) SendHTLC(firstHop lnwire.ShortChannelID, paymentID uint64,
 	htlc *lnwire.UpdateAddHTLC,
 	deobfuscator ErrorDecrypter) ([sha256.Size]byte, error) {
 
@@ -374,11 +367,6 @@ func (s *Switch) SendHTLC(firstHop lnwire.ShortChannelID,
 		paymentHash:  htlc.PaymentHash,
 		amount:       htlc.Amount,
 		deobfuscator: deobfuscator,
-	}
-
-	paymentID, err := s.paymentSequencer.NextID()
-	if err != nil {
-		return zeroPreimage, err
 	}
 
 	s.pendingMutex.Lock()
@@ -407,6 +395,7 @@ func (s *Switch) SendHTLC(firstHop lnwire.ShortChannelID,
 	// Returns channels so that other subsystem might wait/skip the
 	// waiting of handling of payment.
 	var preimage [sha256.Size]byte
+	var err error
 
 	select {
 	case e := <-payment.err:

--- a/htlcswitch/switch.go
+++ b/htlcswitch/switch.go
@@ -348,7 +348,8 @@ func (s *Switch) ProcessContractResolution(msg contractcourt.ResolutionMsg) erro
 
 // SendHTLC is used by other subsystems which aren't belong to htlc switch
 // package in order to send the htlc update. The paymentID used MUST be unique
-// for this HTLC, otherwise the switch might reject it.
+// for this HTLC, and MUST be used only once, otherwise the switch might reject
+// it.
 func (s *Switch) SendHTLC(firstHop lnwire.ShortChannelID, paymentID uint64,
 	htlc *lnwire.UpdateAddHTLC,
 	deobfuscator ErrorDecrypter) ([sha256.Size]byte, error) {

--- a/htlcswitch/switch.go
+++ b/htlcswitch/switch.go
@@ -2206,15 +2206,6 @@ func (s *Switch) CircuitModifier() CircuitModifier {
 	return s.circuits
 }
 
-// numPendingPayments is helper function which returns the overall number of
-// pending user payments.
-func (s *Switch) numPendingPayments() int {
-	s.pendingMutex.RLock()
-	defer s.pendingMutex.RUnlock()
-
-	return len(s.pendingPayments)
-}
-
 // commitCircuits persistently adds a circuit to the switch's circuit map.
 func (s *Switch) commitCircuits(circuits ...*PaymentCircuit) (
 	*CircuitFwdActions, error) {

--- a/htlcswitch/switch_test.go
+++ b/htlcswitch/switch_test.go
@@ -1417,7 +1417,7 @@ func testSkipLinkLocalForward(t *testing.T, eligible bool,
 	// We'll attempt to send out a new HTLC that has Alice as the first
 	// outgoing link. This should fail as Alice isn't yet able to forward
 	// any active HTLC's.
-	_, err = s.SendHTLC(aliceChannelLink.ShortChanID(), addMsg, nil)
+	_, err = s.SendHTLC(aliceChannelLink.ShortChanID(), 0, addMsg, nil)
 	if err == nil {
 		t.Fatalf("local forward should fail due to inactive link")
 	}
@@ -1743,7 +1743,7 @@ func TestSwitchSendPayment(t *testing.T) {
 	errChan := make(chan error)
 	go func() {
 		_, err := s.SendHTLC(
-			aliceChannelLink.ShortChanID(), update,
+			aliceChannelLink.ShortChanID(), 0, update,
 			newMockDeobfuscator())
 		errChan <- err
 	}()
@@ -1752,7 +1752,7 @@ func TestSwitchSendPayment(t *testing.T) {
 		// Send the payment with the same payment hash and same
 		// amount and check that it will be propagated successfully
 		_, err := s.SendHTLC(
-			aliceChannelLink.ShortChanID(), update,
+			aliceChannelLink.ShortChanID(), 0, update,
 			newMockDeobfuscator(),
 		)
 		errChan <- err

--- a/htlcswitch/switch_test.go
+++ b/htlcswitch/switch_test.go
@@ -1798,10 +1798,6 @@ func TestSwitchSendPayment(t *testing.T) {
 	case <-time.After(time.Second):
 		t.Fatal("err wasn't received")
 	}
-
-	if s.numPendingPayments() != 0 {
-		t.Fatal("wrong amount of pending payments")
-	}
 }
 
 // TestLocalPaymentNoForwardingEvents tests that if we send a series of locally

--- a/htlcswitch/test_utils.go
+++ b/htlcswitch/test_utils.go
@@ -543,7 +543,7 @@ func getChanID(msg lnwire.Message) (lnwire.ChannelID, error) {
 func generatePaymentWithPreimage(invoiceAmt, htlcAmt lnwire.MilliSatoshi,
 	timelock uint32, blob [lnwire.OnionPacketSize]byte,
 	preimage, rhash [32]byte) (*channeldb.Invoice, *lnwire.UpdateAddHTLC,
-	error) {
+	uint64, error) {
 
 	// Create the db invoice. Normally the payment requests needs to be set,
 	// because it is decoded in InvoiceRegistry to obtain the cltv expiry.
@@ -566,18 +566,25 @@ func generatePaymentWithPreimage(invoiceAmt, htlcAmt lnwire.MilliSatoshi,
 		OnionBlob:   blob,
 	}
 
-	return invoice, htlc, nil
+	pid, err := generateRandomBytes(8)
+	if err != nil {
+		return nil, nil, 0, err
+	}
+	paymentID := binary.BigEndian.Uint64(pid)
+
+	return invoice, htlc, paymentID, nil
 }
 
 // generatePayment generates the htlc add request by given path blob and
 // invoice which should be added by destination peer.
 func generatePayment(invoiceAmt, htlcAmt lnwire.MilliSatoshi, timelock uint32,
-	blob [lnwire.OnionPacketSize]byte) (*channeldb.Invoice, *lnwire.UpdateAddHTLC, error) {
+	blob [lnwire.OnionPacketSize]byte) (*channeldb.Invoice,
+	*lnwire.UpdateAddHTLC, uint64, error) {
 
 	var preimage [sha256.Size]byte
 	r, err := generateRandomBytes(sha256.Size)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, 0, err
 	}
 	copy(preimage[:], r)
 
@@ -772,7 +779,9 @@ func preparePayment(sendingPeer, receivingPeer lnpeer.Peer,
 	}
 
 	// Generate payment: invoice and htlc.
-	invoice, htlc, err := generatePayment(invoiceAmt, htlcAmt, timelock, blob)
+	invoice, htlc, pid, err := generatePayment(
+		invoiceAmt, htlcAmt, timelock, blob,
+	)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -786,7 +795,7 @@ func preparePayment(sendingPeer, receivingPeer lnpeer.Peer,
 	// Send payment and expose err channel.
 	return invoice, func() error {
 		_, err := sender.htlcSwitch.SendHTLC(
-			firstHop, htlc, newMockDeobfuscator(),
+			firstHop, pid, htlc, newMockDeobfuscator(),
 		)
 		return err
 	}, nil
@@ -1235,8 +1244,10 @@ func (n *twoHopNetwork) makeHoldPayment(sendingPeer, receivingPeer lnpeer.Peer,
 	rhash := preimage.Hash()
 
 	// Generate payment: invoice and htlc.
-	invoice, htlc, err := generatePaymentWithPreimage(invoiceAmt, htlcAmt, timelock, blob,
-		channeldb.UnknownPreimage, rhash)
+	invoice, htlc, pid, err := generatePaymentWithPreimage(
+		invoiceAmt, htlcAmt, timelock, blob,
+		channeldb.UnknownPreimage, rhash,
+	)
 	if err != nil {
 		paymentErr <- err
 		return paymentErr
@@ -1251,7 +1262,7 @@ func (n *twoHopNetwork) makeHoldPayment(sendingPeer, receivingPeer lnpeer.Peer,
 	// Send payment and expose err channel.
 	go func() {
 		_, err := sender.htlcSwitch.SendHTLC(
-			firstHop, htlc, newMockDeobfuscator(),
+			firstHop, pid, htlc, newMockDeobfuscator(),
 		)
 		paymentErr <- err
 	}()

--- a/routing/mock_test.go
+++ b/routing/mock_test.go
@@ -14,8 +14,7 @@ var _ PaymentAttemptDispatcher = (*mockPaymentAttemptDispatcher)(nil)
 
 func (m *mockPaymentAttemptDispatcher) SendHTLC(firstHop lnwire.ShortChannelID,
 	pid uint64,
-	_ *lnwire.UpdateAddHTLC,
-	_ htlcswitch.ErrorDecrypter) error {
+	_ *lnwire.UpdateAddHTLC) error {
 
 	if m.onPayment == nil {
 		return nil
@@ -44,8 +43,8 @@ func (m *mockPaymentAttemptDispatcher) SendHTLC(firstHop lnwire.ShortChannelID,
 	return nil
 }
 
-func (m *mockPaymentAttemptDispatcher) GetPaymentResult(paymentID uint64) (
-	<-chan *htlcswitch.PaymentResult, error) {
+func (m *mockPaymentAttemptDispatcher) GetPaymentResult(paymentID uint64,
+	_ htlcswitch.ErrorDecrypter) (<-chan *htlcswitch.PaymentResult, error) {
 
 	c := make(chan *htlcswitch.PaymentResult, 1)
 	res, ok := m.results[paymentID]

--- a/routing/mock_test.go
+++ b/routing/mock_test.go
@@ -14,6 +14,7 @@ type mockPaymentAttemptDispatcher struct {
 var _ PaymentAttemptDispatcher = (*mockPaymentAttemptDispatcher)(nil)
 
 func (m *mockPaymentAttemptDispatcher) SendHTLC(firstHop lnwire.ShortChannelID,
+	_ uint64,
 	_ *lnwire.UpdateAddHTLC,
 	_ htlcswitch.ErrorDecrypter) ([sha256.Size]byte, error) {
 

--- a/routing/mock_test.go
+++ b/routing/mock_test.go
@@ -1,0 +1,31 @@
+package routing
+
+import (
+	"crypto/sha256"
+
+	"github.com/lightningnetwork/lnd/htlcswitch"
+	"github.com/lightningnetwork/lnd/lnwire"
+)
+
+type mockPaymentAttemptDispatcher struct {
+	onPayment func(firstHop lnwire.ShortChannelID) ([32]byte, error)
+}
+
+var _ PaymentAttemptDispatcher = (*mockPaymentAttemptDispatcher)(nil)
+
+func (m *mockPaymentAttemptDispatcher) SendHTLC(firstHop lnwire.ShortChannelID,
+	_ *lnwire.UpdateAddHTLC,
+	_ htlcswitch.ErrorDecrypter) ([sha256.Size]byte, error) {
+
+	if m.onPayment != nil {
+		return m.onPayment(firstHop)
+	}
+
+	return [sha256.Size]byte{}, nil
+}
+
+func (m *mockPaymentAttemptDispatcher) setPaymentResult(
+	f func(firstHop lnwire.ShortChannelID) ([32]byte, error)) {
+
+	m.onPayment = f
+}

--- a/routing/mock_test.go
+++ b/routing/mock_test.go
@@ -1,28 +1,61 @@
 package routing
 
 import (
-	"crypto/sha256"
-
 	"github.com/lightningnetwork/lnd/htlcswitch"
 	"github.com/lightningnetwork/lnd/lnwire"
 )
 
 type mockPaymentAttemptDispatcher struct {
 	onPayment func(firstHop lnwire.ShortChannelID) ([32]byte, error)
+	results   map[uint64]*htlcswitch.PaymentResult
 }
 
 var _ PaymentAttemptDispatcher = (*mockPaymentAttemptDispatcher)(nil)
 
 func (m *mockPaymentAttemptDispatcher) SendHTLC(firstHop lnwire.ShortChannelID,
-	_ uint64,
+	pid uint64,
 	_ *lnwire.UpdateAddHTLC,
-	_ htlcswitch.ErrorDecrypter) ([sha256.Size]byte, error) {
+	_ htlcswitch.ErrorDecrypter) error {
 
-	if m.onPayment != nil {
-		return m.onPayment(firstHop)
+	if m.onPayment == nil {
+		return nil
 	}
 
-	return [sha256.Size]byte{}, nil
+	if m.results == nil {
+		m.results = make(map[uint64]*htlcswitch.PaymentResult)
+	}
+
+	var result *htlcswitch.PaymentResult
+	preimage, err := m.onPayment(firstHop)
+	if err != nil {
+		fwdErr, ok := err.(*htlcswitch.ForwardingError)
+		if !ok {
+			return err
+		}
+		result = &htlcswitch.PaymentResult{
+			Error: fwdErr,
+		}
+	} else {
+		result = &htlcswitch.PaymentResult{Preimage: preimage}
+	}
+
+	m.results[pid] = result
+
+	return nil
+}
+
+func (m *mockPaymentAttemptDispatcher) GetPaymentResult(paymentID uint64) (
+	<-chan *htlcswitch.PaymentResult, error) {
+
+	c := make(chan *htlcswitch.PaymentResult, 1)
+	res, ok := m.results[paymentID]
+	if !ok {
+		return nil, htlcswitch.ErrPaymentIDNotFound
+	}
+	c <- res
+
+	return c, nil
+
 }
 
 func (m *mockPaymentAttemptDispatcher) setPaymentResult(

--- a/routing/router.go
+++ b/routing/router.go
@@ -134,6 +134,7 @@ type PaymentAttemptDispatcher interface {
 	// denoted by its public key. A non-nil error is to be returned if the
 	// payment was unsuccessful.
 	SendHTLC(firstHop lnwire.ShortChannelID,
+		paymentID uint64,
 		htlcAdd *lnwire.UpdateAddHTLC,
 		deobfuscator htlcswitch.ErrorDecrypter) ([sha256.Size]byte, error)
 }
@@ -207,6 +208,12 @@ type Config struct {
 	// date knowledge of the available bandwidth of the link should be
 	// returned.
 	QueryBandwidth func(edge *channeldb.ChannelEdgeInfo) lnwire.MilliSatoshi
+
+	// NextPaymentID is a method that guarantees to return a new, unique ID
+	// each time it is called. This is used by the router to generate a
+	// unique payment ID for each payment it attempts to send, such that
+	// the switch can properly handle the HTLC.
+	NextPaymentID func() (uint64, error)
 
 	// AssumeChannelValid toggles whether or not the router will check for
 	// spentness of channel outpoints. For neutrino, this saves long rescans
@@ -1715,8 +1722,15 @@ func (r *ChannelRouter) sendToSwitch(route *route.Route, paymentHash [32]byte) (
 		OnionErrorDecrypter: sphinx.NewOnionErrorDecrypter(circuit),
 	}
 
+	// We generate a new, unique payment ID that we will use for
+	// this HTLC.
+	paymentID, err := r.cfg.NextPaymentID()
+	if err != nil {
+		return [32]byte{}, err
+	}
+
 	return r.cfg.Payer.SendHTLC(
-		firstHop, htlcAdd, errorDecryptor,
+		firstHop, paymentID, htlcAdd, errorDecryptor,
 	)
 }
 

--- a/routing/router_test.go
+++ b/routing/router_test.go
@@ -15,7 +15,6 @@ import (
 	"github.com/btcsuite/btcutil"
 	"github.com/davecgh/go-spew/spew"
 
-	sphinx "github.com/lightningnetwork/lightning-onion"
 	"github.com/lightningnetwork/lnd/channeldb"
 	"github.com/lightningnetwork/lnd/htlcswitch"
 	"github.com/lightningnetwork/lnd/lntypes"
@@ -44,13 +43,10 @@ func (c *testCtx) RestartRouter() error {
 	// With the chainView reset, we'll now re-create the router itself, and
 	// start it.
 	router, err := New(Config{
-		Graph:     c.graph,
-		Chain:     c.chain,
-		ChainView: c.chainView,
-		SendToSwitch: func(_ lnwire.ShortChannelID,
-			_ *lnwire.UpdateAddHTLC, _ *sphinx.Circuit) ([32]byte, error) {
-			return [32]byte{}, nil
-		},
+		Graph:              c.graph,
+		Chain:              c.chain,
+		ChainView:          c.chainView,
+		Payer:              &mockPaymentAttemptDispatcher{},
 		ChannelPruneExpiry: time.Hour * 24,
 		GraphPruneInterval: time.Hour * 2,
 	})
@@ -85,14 +81,10 @@ func createTestCtxFromGraphInstance(startingHeight uint32, graphInstance *testGr
 	chain := newMockChain(startingHeight)
 	chainView := newMockChainView(chain)
 	router, err := New(Config{
-		Graph:     graphInstance.graph,
-		Chain:     chain,
-		ChainView: chainView,
-		SendToSwitch: func(_ lnwire.ShortChannelID,
-			_ *lnwire.UpdateAddHTLC, _ *sphinx.Circuit) ([32]byte, error) {
-
-			return [32]byte{}, nil
-		},
+		Graph:              graphInstance.graph,
+		Chain:              chain,
+		ChainView:          chainView,
+		Payer:              &mockPaymentAttemptDispatcher{},
 		ChannelPruneExpiry: time.Hour * 24,
 		GraphPruneInterval: time.Hour * 2,
 		QueryBandwidth: func(e *channeldb.ChannelEdgeInfo) lnwire.MilliSatoshi {
@@ -250,24 +242,24 @@ func TestSendPaymentRouteFailureFallback(t *testing.T) {
 	// router's configuration to ignore the path that has luo ji as the
 	// first hop. This should force the router to instead take the
 	// available two hop path (through satoshi).
-	ctx.router.cfg.SendToSwitch = func(firstHop lnwire.ShortChannelID,
-		_ *lnwire.UpdateAddHTLC, _ *sphinx.Circuit) ([32]byte, error) {
+	ctx.router.cfg.Payer.(*mockPaymentAttemptDispatcher).setPaymentResult(
+		func(firstHop lnwire.ShortChannelID) ([32]byte, error) {
 
-		roasbeefLuoji := lnwire.NewShortChanIDFromInt(689530843)
-		if firstHop == roasbeefLuoji {
-			pub, err := sourceNode.PubKey()
-			if err != nil {
-				return preImage, err
+			roasbeefLuoji := lnwire.NewShortChanIDFromInt(689530843)
+			if firstHop == roasbeefLuoji {
+				pub, err := sourceNode.PubKey()
+				if err != nil {
+					return preImage, err
+				}
+				return [32]byte{}, &htlcswitch.ForwardingError{
+					ErrorSource: pub,
+					// TODO(roasbeef): temp node failure should be?
+					FailureMessage: &lnwire.FailTemporaryChannelFailure{},
+				}
 			}
-			return [32]byte{}, &htlcswitch.ForwardingError{
-				ErrorSource: pub,
-				// TODO(roasbeef): temp node failure should be?
-				FailureMessage: &lnwire.FailTemporaryChannelFailure{},
-			}
-		}
 
-		return preImage, nil
-	}
+			return preImage, nil
+		})
 
 	// Send off the payment request to the router, route through satoshi
 	// should've been selected as a fall back and succeeded correctly.
@@ -387,24 +379,24 @@ func TestChannelUpdateValidation(t *testing.T) {
 	// We'll modify the SendToSwitch method so that it simulates a failed
 	// payment with an error originating from the first hop of the route.
 	// The unsigned channel update is attached to the failure message.
-	ctx.router.cfg.SendToSwitch = func(firstHop lnwire.ShortChannelID,
-		_ *lnwire.UpdateAddHTLC, _ *sphinx.Circuit) ([32]byte, error) {
+	ctx.router.cfg.Payer.(*mockPaymentAttemptDispatcher).setPaymentResult(
+		func(firstHop lnwire.ShortChannelID) ([32]byte, error) {
 
-		v := ctx.aliases["b"]
-		source, err := btcec.ParsePubKey(
-			v[:], btcec.S256(),
-		)
-		if err != nil {
-			t.Fatal(err)
-		}
+			v := ctx.aliases["b"]
+			source, err := btcec.ParsePubKey(
+				v[:], btcec.S256(),
+			)
+			if err != nil {
+				t.Fatal(err)
+			}
 
-		return [32]byte{}, &htlcswitch.ForwardingError{
-			ErrorSource: source,
-			FailureMessage: &lnwire.FailFeeInsufficient{
-				Update: errChanUpdate,
-			},
-		}
-	}
+			return [32]byte{}, &htlcswitch.ForwardingError{
+				ErrorSource: source,
+				FailureMessage: &lnwire.FailFeeInsufficient{
+					Update: errChanUpdate,
+				},
+			}
+		})
 
 	// The payment parameter is mostly redundant in SendToRoute. Can be left
 	// empty for this test.
@@ -518,32 +510,32 @@ func TestSendPaymentErrorRepeatedFeeInsufficient(t *testing.T) {
 	// We'll now modify the SendToSwitch method to return an error for the
 	// outgoing channel to Son goku. This will be a fee related error, so
 	// it should only cause the edge to be pruned after the second attempt.
-	ctx.router.cfg.SendToSwitch = func(firstHop lnwire.ShortChannelID,
-		_ *lnwire.UpdateAddHTLC, _ *sphinx.Circuit) ([32]byte, error) {
+	ctx.router.cfg.Payer.(*mockPaymentAttemptDispatcher).setPaymentResult(
+		func(firstHop lnwire.ShortChannelID) ([32]byte, error) {
 
-		roasbeefSongoku := lnwire.NewShortChanIDFromInt(chanID)
-		if firstHop == roasbeefSongoku {
-			sourceKey, err := btcec.ParsePubKey(
-				sourceNode[:], btcec.S256(),
-			)
-			if err != nil {
-				t.Fatal(err)
+			roasbeefSongoku := lnwire.NewShortChanIDFromInt(chanID)
+			if firstHop == roasbeefSongoku {
+				sourceKey, err := btcec.ParsePubKey(
+					sourceNode[:], btcec.S256(),
+				)
+				if err != nil {
+					t.Fatal(err)
+				}
+
+				return [32]byte{}, &htlcswitch.ForwardingError{
+					ErrorSource: sourceKey,
+
+					// Within our error, we'll add a channel update
+					// which is meant to reflect he new fee
+					// schedule for the node/channel.
+					FailureMessage: &lnwire.FailFeeInsufficient{
+						Update: errChanUpdate,
+					},
+				}
 			}
 
-			return [32]byte{}, &htlcswitch.ForwardingError{
-				ErrorSource: sourceKey,
-
-				// Within our error, we'll add a channel update
-				// which is meant to reflect he new fee
-				// schedule for the node/channel.
-				FailureMessage: &lnwire.FailFeeInsufficient{
-					Update: errChanUpdate,
-				},
-			}
-		}
-
-		return preImage, nil
-	}
+			return preImage, nil
+		})
 
 	// Send off the payment request to the router, route through satoshi
 	// should've been selected as a fall back and succeeded correctly.
@@ -633,27 +625,27 @@ func TestSendPaymentErrorNonFinalTimeLockErrors(t *testing.T) {
 	// outgoing channel to son goku. Since this is a time lock related
 	// error, we should fail the payment flow all together, as Goku is the
 	// only channel to Sophon.
-	ctx.router.cfg.SendToSwitch = func(firstHop lnwire.ShortChannelID,
-		_ *lnwire.UpdateAddHTLC, _ *sphinx.Circuit) ([32]byte, error) {
+	ctx.router.cfg.Payer.(*mockPaymentAttemptDispatcher).setPaymentResult(
+		func(firstHop lnwire.ShortChannelID) ([32]byte, error) {
 
-		if firstHop == roasbeefSongoku {
-			sourceKey, err := btcec.ParsePubKey(
-				sourceNode[:], btcec.S256(),
-			)
-			if err != nil {
-				t.Fatal(err)
+			if firstHop == roasbeefSongoku {
+				sourceKey, err := btcec.ParsePubKey(
+					sourceNode[:], btcec.S256(),
+				)
+				if err != nil {
+					t.Fatal(err)
+				}
+
+				return [32]byte{}, &htlcswitch.ForwardingError{
+					ErrorSource: sourceKey,
+					FailureMessage: &lnwire.FailExpiryTooSoon{
+						Update: errChanUpdate,
+					},
+				}
 			}
 
-			return [32]byte{}, &htlcswitch.ForwardingError{
-				ErrorSource: sourceKey,
-				FailureMessage: &lnwire.FailExpiryTooSoon{
-					Update: errChanUpdate,
-				},
-			}
-		}
-
-		return preImage, nil
-	}
+			return preImage, nil
+		})
 
 	// assertExpectedPath is a helper function that asserts the returned
 	// route properly routes around the failure we've introduced in the
@@ -694,27 +686,27 @@ func TestSendPaymentErrorNonFinalTimeLockErrors(t *testing.T) {
 	// We'll now modify the error return an IncorrectCltvExpiry error
 	// instead, this should result in the same behavior of roasbeef routing
 	// around the faulty Son Goku node.
-	ctx.router.cfg.SendToSwitch = func(firstHop lnwire.ShortChannelID,
-		_ *lnwire.UpdateAddHTLC, _ *sphinx.Circuit) ([32]byte, error) {
+	ctx.router.cfg.Payer.(*mockPaymentAttemptDispatcher).setPaymentResult(
+		func(firstHop lnwire.ShortChannelID) ([32]byte, error) {
 
-		if firstHop == roasbeefSongoku {
-			sourceKey, err := btcec.ParsePubKey(
-				sourceNode[:], btcec.S256(),
-			)
-			if err != nil {
-				t.Fatal(err)
+			if firstHop == roasbeefSongoku {
+				sourceKey, err := btcec.ParsePubKey(
+					sourceNode[:], btcec.S256(),
+				)
+				if err != nil {
+					t.Fatal(err)
+				}
+
+				return [32]byte{}, &htlcswitch.ForwardingError{
+					ErrorSource: sourceKey,
+					FailureMessage: &lnwire.FailIncorrectCltvExpiry{
+						Update: errChanUpdate,
+					},
+				}
 			}
 
-			return [32]byte{}, &htlcswitch.ForwardingError{
-				ErrorSource: sourceKey,
-				FailureMessage: &lnwire.FailIncorrectCltvExpiry{
-					Update: errChanUpdate,
-				},
-			}
-		}
-
-		return preImage, nil
-	}
+			return preImage, nil
+		})
 
 	// Once again, Roasbeef should route around Goku since they disagree
 	// w.r.t to the block height, and instead go through Pham Nuwen.
@@ -771,40 +763,40 @@ func TestSendPaymentErrorPathPruning(t *testing.T) {
 	//
 	// TODO(roasbeef): filtering should be intelligent enough so just not
 	// go through satoshi at all at this point.
-	ctx.router.cfg.SendToSwitch = func(firstHop lnwire.ShortChannelID,
-		_ *lnwire.UpdateAddHTLC, _ *sphinx.Circuit) ([32]byte, error) {
+	ctx.router.cfg.Payer.(*mockPaymentAttemptDispatcher).setPaymentResult(
+		func(firstHop lnwire.ShortChannelID) ([32]byte, error) {
 
-		if firstHop == roasbeefLuoji {
-			// We'll first simulate an error from the first
-			// outgoing link to simulate the channel from luo ji to
-			// roasbeef not having enough capacity.
-			return [32]byte{}, &htlcswitch.ForwardingError{
-				ErrorSource:    sourcePub,
-				FailureMessage: &lnwire.FailTemporaryChannelFailure{},
-			}
-		}
-
-		// Next, we'll create an error from satoshi to indicate
-		// that the luoji node is not longer online, which should
-		// prune out the rest of the routes.
-		roasbeefSatoshi := lnwire.NewShortChanIDFromInt(2340213491)
-		if firstHop == roasbeefSatoshi {
-			vertex := ctx.aliases["satoshi"]
-			key, err := btcec.ParsePubKey(
-				vertex[:], btcec.S256(),
-			)
-			if err != nil {
-				t.Fatal(err)
+			if firstHop == roasbeefLuoji {
+				// We'll first simulate an error from the first
+				// outgoing link to simulate the channel from luo ji to
+				// roasbeef not having enough capacity.
+				return [32]byte{}, &htlcswitch.ForwardingError{
+					ErrorSource:    sourcePub,
+					FailureMessage: &lnwire.FailTemporaryChannelFailure{},
+				}
 			}
 
-			return [32]byte{}, &htlcswitch.ForwardingError{
-				ErrorSource:    key,
-				FailureMessage: &lnwire.FailUnknownNextPeer{},
-			}
-		}
+			// Next, we'll create an error from satoshi to indicate
+			// that the luoji node is not longer online, which should
+			// prune out the rest of the routes.
+			roasbeefSatoshi := lnwire.NewShortChanIDFromInt(2340213491)
+			if firstHop == roasbeefSatoshi {
+				vertex := ctx.aliases["satoshi"]
+				key, err := btcec.ParsePubKey(
+					vertex[:], btcec.S256(),
+				)
+				if err != nil {
+					t.Fatal(err)
+				}
 
-		return preImage, nil
-	}
+				return [32]byte{}, &htlcswitch.ForwardingError{
+					ErrorSource:    key,
+					FailureMessage: &lnwire.FailUnknownNextPeer{},
+				}
+			}
+
+			return preImage, nil
+		})
 
 	ctx.router.missionControl.ResetHistory()
 
@@ -826,18 +818,18 @@ func TestSendPaymentErrorPathPruning(t *testing.T) {
 	// Next, we'll modify the SendToSwitch method to indicate that luo ji
 	// wasn't originally online. This should also halt the send all
 	// together as all paths contain luoji and he can't be reached.
-	ctx.router.cfg.SendToSwitch = func(firstHop lnwire.ShortChannelID,
-		_ *lnwire.UpdateAddHTLC, _ *sphinx.Circuit) ([32]byte, error) {
+	ctx.router.cfg.Payer.(*mockPaymentAttemptDispatcher).setPaymentResult(
+		func(firstHop lnwire.ShortChannelID) ([32]byte, error) {
 
-		if firstHop == roasbeefLuoji {
-			return [32]byte{}, &htlcswitch.ForwardingError{
-				ErrorSource:    sourcePub,
-				FailureMessage: &lnwire.FailUnknownNextPeer{},
+			if firstHop == roasbeefLuoji {
+				return [32]byte{}, &htlcswitch.ForwardingError{
+					ErrorSource:    sourcePub,
+					FailureMessage: &lnwire.FailUnknownNextPeer{},
+				}
 			}
-		}
 
-		return preImage, nil
-	}
+			return preImage, nil
+		})
 
 	// This shouldn't return an error, as we'll make a payment attempt via
 	// the satoshi channel based on the assumption that there might be an
@@ -869,20 +861,20 @@ func TestSendPaymentErrorPathPruning(t *testing.T) {
 	// Finally, we'll modify the SendToSwitch function to indicate that the
 	// roasbeef -> luoji channel has insufficient capacity. This should
 	// again cause us to instead go via the satoshi route.
-	ctx.router.cfg.SendToSwitch = func(firstHop lnwire.ShortChannelID,
-		_ *lnwire.UpdateAddHTLC, _ *sphinx.Circuit) ([32]byte, error) {
+	ctx.router.cfg.Payer.(*mockPaymentAttemptDispatcher).setPaymentResult(
+		func(firstHop lnwire.ShortChannelID) ([32]byte, error) {
 
-		if firstHop == roasbeefLuoji {
-			// We'll first simulate an error from the first
-			// outgoing link to simulate the channel from luo ji to
-			// roasbeef not having enough capacity.
-			return [32]byte{}, &htlcswitch.ForwardingError{
-				ErrorSource:    sourcePub,
-				FailureMessage: &lnwire.FailTemporaryChannelFailure{},
+			if firstHop == roasbeefLuoji {
+				// We'll first simulate an error from the first
+				// outgoing link to simulate the channel from luo ji to
+				// roasbeef not having enough capacity.
+				return [32]byte{}, &htlcswitch.ForwardingError{
+					ErrorSource:    sourcePub,
+					FailureMessage: &lnwire.FailTemporaryChannelFailure{},
+				}
 			}
-		}
-		return preImage, nil
-	}
+			return preImage, nil
+		})
 
 	paymentPreImage, rt, err = ctx.router.SendPayment(&payment)
 	if err != nil {
@@ -1525,13 +1517,10 @@ func TestWakeUpOnStaleBranch(t *testing.T) {
 
 	// Create new router with same graph database.
 	router, err := New(Config{
-		Graph:     ctx.graph,
-		Chain:     ctx.chain,
-		ChainView: ctx.chainView,
-		SendToSwitch: func(_ lnwire.ShortChannelID,
-			_ *lnwire.UpdateAddHTLC, _ *sphinx.Circuit) ([32]byte, error) {
-			return [32]byte{}, nil
-		},
+		Graph:              ctx.graph,
+		Chain:              ctx.chain,
+		ChainView:          ctx.chainView,
+		Payer:              &mockPaymentAttemptDispatcher{},
 		ChannelPruneExpiry: time.Hour * 24,
 		GraphPruneInterval: time.Hour * 2,
 	})

--- a/routing/router_test.go
+++ b/routing/router_test.go
@@ -2442,8 +2442,9 @@ func TestIsStaleEdgePolicy(t *testing.T) {
 func TestEmptyRoutesGenerateSphinxPacket(t *testing.T) {
 	t.Parallel()
 
+	sessionKey, _ := btcec.NewPrivateKey(btcec.S256())
 	emptyRoute := &route.Route{}
-	_, _, err := generateSphinxPacket(emptyRoute, testHash[:])
+	_, _, err := generateSphinxPacket(emptyRoute, testHash[:], sessionKey)
 	if err != route.ErrNoRouteHopsProvided {
 		t.Fatalf("expected empty hops error: instead got: %v", err)
 	}

--- a/routing/router_test.go
+++ b/routing/router_test.go
@@ -6,6 +6,7 @@ import (
 	"image/color"
 	"math/rand"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -22,6 +23,8 @@ import (
 	"github.com/lightningnetwork/lnd/routing/route"
 	"github.com/lightningnetwork/lnd/zpay32"
 )
+
+var uniquePaymentID uint64 = 1 // to be used atomically
 
 type testCtx struct {
 	router *ChannelRouter
@@ -89,6 +92,10 @@ func createTestCtxFromGraphInstance(startingHeight uint32, graphInstance *testGr
 		GraphPruneInterval: time.Hour * 2,
 		QueryBandwidth: func(e *channeldb.ChannelEdgeInfo) lnwire.MilliSatoshi {
 			return lnwire.NewMSatFromSatoshis(e.Capacity)
+		},
+		NextPaymentID: func() (uint64, error) {
+			next := atomic.AddUint64(&uniquePaymentID, 1)
+			return next, nil
 		},
 	})
 	if err != nil {

--- a/server.go
+++ b/server.go
@@ -609,6 +609,13 @@ func newServer(listenAddrs []net.Addr, chanDB *channeldb.DB, cc *chainControl,
 	}
 	s.currentNodeAnn = nodeAnn
 
+	// The router will get access to the payment ID sequencer, such that it
+	// can generate unique payment IDs.
+	sequencer, err := htlcswitch.NewPersistentSequencer(chanDB)
+	if err != nil {
+		return nil, err
+	}
+
 	s.chanRouter, err = routing.New(routing.Config{
 		Graph:              chanGraph,
 		Chain:              cc.chainIO,
@@ -646,6 +653,7 @@ func newServer(listenAddrs []net.Addr, chanDB *channeldb.DB, cc *chainControl,
 			return link.Bandwidth()
 		},
 		AssumeChannelValid: cfg.Routing.UseAssumeChannelValid(),
+		NextPaymentID:      sequencer.NextID,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("can't create router: %v", err)

--- a/server.go
+++ b/server.go
@@ -610,24 +610,10 @@ func newServer(listenAddrs []net.Addr, chanDB *channeldb.DB, cc *chainControl,
 	s.currentNodeAnn = nodeAnn
 
 	s.chanRouter, err = routing.New(routing.Config{
-		Graph:     chanGraph,
-		Chain:     cc.chainIO,
-		ChainView: cc.chainView,
-		SendToSwitch: func(firstHop lnwire.ShortChannelID,
-			htlcAdd *lnwire.UpdateAddHTLC,
-			circuit *sphinx.Circuit) ([32]byte, error) {
-
-			// Using the created circuit, initialize the error
-			// decrypter so we can parse+decode any failures
-			// incurred by this payment within the switch.
-			errorDecryptor := &htlcswitch.SphinxErrorDecrypter{
-				OnionErrorDecrypter: sphinx.NewOnionErrorDecrypter(circuit),
-			}
-
-			return s.htlcSwitch.SendHTLC(
-				firstHop, htlcAdd, errorDecryptor,
-			)
-		},
+		Graph:              chanGraph,
+		Chain:              cc.chainIO,
+		ChainView:          cc.chainView,
+		Payer:              s.htlcSwitch,
 		ChannelPruneExpiry: routing.DefaultChannelPruneExpiry,
 		GraphPruneInterval: time.Duration(time.Hour),
 		QueryBandwidth: func(edge *channeldb.ChannelEdgeInfo) lnwire.MilliSatoshi {


### PR DESCRIPTION
This PR consists of two important pieces of #2761: 

### Make `router`<->`switch` interaction async
We define `PaymentResult` and the  method `GetPaymentResult`
exposed by the `switch`.

This lets us distinguish an critical error from a actual payment result
(success or failure). This is important since we know that we can only
attempt another payment when a final result from the previous payment
attempt is received.

In order to achieve this we let the `router` handling generating `paymentID`s,
since they are used to later query the `switch` for the final result.

### Move payment error deobfuscation
In this commit we move handing the deobfuscator from the router to the
switch from when the payment is initiated, to when the result is
queried.

We do this because only the router can recreate the deobfuscator after a
restart, and we are preparing for being able to handle results across
restarts.

Since the deobfuscator cannot be nil anymore, we can also get rid of
that special case.

Split off from #2761 