### PR TITLE
[reliable payments] channeldb/graph: don't nil curve of returned PubKey

### DIFF
--- a/channeldb/graph.go
+++ b/channeldb/graph.go
@@ -1982,7 +1982,6 @@ func (l *LightningNode) PubKey() (*btcec.PublicKey, error) {
 		return nil, err
 	}
 	l.pubKey = key
-	l.pubKey.Curve = nil
 
 	return key, nil
 }


### PR DESCRIPTION
Nilling the key would cause signature verification to crash if the
returned key was used.

A test to exercise the behavior is added.

Split off from #3063 