### PR TITLE
lnrpc: fix typos

### DIFF
--- a/lnrpc/invoicesrpc/invoices.pb.go
+++ b/lnrpc/invoicesrpc/invoices.pb.go
@@ -37,7 +37,7 @@ func (m *CancelInvoiceMsg) Reset()         { *m = CancelInvoiceMsg{} }
 func (m *CancelInvoiceMsg) String() string { return proto.CompactTextString(m) }
 func (*CancelInvoiceMsg) ProtoMessage()    {}
 func (*CancelInvoiceMsg) Descriptor() ([]byte, []int) {
-	return fileDescriptor_invoices_b95f8bc86c534ce9, []int{0}
+	return fileDescriptor_invoices_bb85468a9582e4cb, []int{0}
 }
 func (m *CancelInvoiceMsg) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_CancelInvoiceMsg.Unmarshal(m, b)
@@ -74,7 +74,7 @@ func (m *CancelInvoiceResp) Reset()         { *m = CancelInvoiceResp{} }
 func (m *CancelInvoiceResp) String() string { return proto.CompactTextString(m) }
 func (*CancelInvoiceResp) ProtoMessage()    {}
 func (*CancelInvoiceResp) Descriptor() ([]byte, []int) {
-	return fileDescriptor_invoices_b95f8bc86c534ce9, []int{1}
+	return fileDescriptor_invoices_bb85468a9582e4cb, []int{1}
 }
 func (m *CancelInvoiceResp) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_CancelInvoiceResp.Unmarshal(m, b)
@@ -131,7 +131,7 @@ func (m *AddHoldInvoiceRequest) Reset()         { *m = AddHoldInvoiceRequest{} }
 func (m *AddHoldInvoiceRequest) String() string { return proto.CompactTextString(m) }
 func (*AddHoldInvoiceRequest) ProtoMessage()    {}
 func (*AddHoldInvoiceRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_invoices_b95f8bc86c534ce9, []int{2}
+	return fileDescriptor_invoices_bb85468a9582e4cb, []int{2}
 }
 func (m *AddHoldInvoiceRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_AddHoldInvoiceRequest.Unmarshal(m, b)
@@ -229,7 +229,7 @@ func (m *AddHoldInvoiceResp) Reset()         { *m = AddHoldInvoiceResp{} }
 func (m *AddHoldInvoiceResp) String() string { return proto.CompactTextString(m) }
 func (*AddHoldInvoiceResp) ProtoMessage()    {}
 func (*AddHoldInvoiceResp) Descriptor() ([]byte, []int) {
-	return fileDescriptor_invoices_b95f8bc86c534ce9, []int{3}
+	return fileDescriptor_invoices_bb85468a9582e4cb, []int{3}
 }
 func (m *AddHoldInvoiceResp) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_AddHoldInvoiceResp.Unmarshal(m, b)
@@ -268,7 +268,7 @@ func (m *SettleInvoiceMsg) Reset()         { *m = SettleInvoiceMsg{} }
 func (m *SettleInvoiceMsg) String() string { return proto.CompactTextString(m) }
 func (*SettleInvoiceMsg) ProtoMessage()    {}
 func (*SettleInvoiceMsg) Descriptor() ([]byte, []int) {
-	return fileDescriptor_invoices_b95f8bc86c534ce9, []int{4}
+	return fileDescriptor_invoices_bb85468a9582e4cb, []int{4}
 }
 func (m *SettleInvoiceMsg) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_SettleInvoiceMsg.Unmarshal(m, b)
@@ -305,7 +305,7 @@ func (m *SettleInvoiceResp) Reset()         { *m = SettleInvoiceResp{} }
 func (m *SettleInvoiceResp) String() string { return proto.CompactTextString(m) }
 func (*SettleInvoiceResp) ProtoMessage()    {}
 func (*SettleInvoiceResp) Descriptor() ([]byte, []int) {
-	return fileDescriptor_invoices_b95f8bc86c534ce9, []int{5}
+	return fileDescriptor_invoices_bb85468a9582e4cb, []int{5}
 }
 func (m *SettleInvoiceResp) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_SettleInvoiceResp.Unmarshal(m, b)
@@ -337,7 +337,7 @@ func (m *SubscribeSingleInvoiceRequest) Reset()         { *m = SubscribeSingleIn
 func (m *SubscribeSingleInvoiceRequest) String() string { return proto.CompactTextString(m) }
 func (*SubscribeSingleInvoiceRequest) ProtoMessage()    {}
 func (*SubscribeSingleInvoiceRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_invoices_b95f8bc86c534ce9, []int{6}
+	return fileDescriptor_invoices_bb85468a9582e4cb, []int{6}
 }
 func (m *SubscribeSingleInvoiceRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_SubscribeSingleInvoiceRequest.Unmarshal(m, b)
@@ -602,10 +602,10 @@ var _Invoices_serviceDesc = grpc.ServiceDesc{
 }
 
 func init() {
-	proto.RegisterFile("invoicesrpc/invoices.proto", fileDescriptor_invoices_b95f8bc86c534ce9)
+	proto.RegisterFile("invoicesrpc/invoices.proto", fileDescriptor_invoices_bb85468a9582e4cb)
 }
 
-var fileDescriptor_invoices_b95f8bc86c534ce9 = []byte{
+var fileDescriptor_invoices_bb85468a9582e4cb = []byte{
 	// 509 bytes of a gzipped FileDescriptorProto
 	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0x7c, 0x53, 0x41, 0x6f, 0xd3, 0x4c,
 	0x10, 0x95, 0x93, 0x34, 0x4d, 0x26, 0x6d, 0xbf, 0x7c, 0x0b, 0x44, 0x96, 0x45, 0xc1, 0x58, 0x1c,

--- a/lnrpc/rpc.pb.go
+++ b/lnrpc/rpc.pb.go
@@ -55,7 +55,7 @@ func (x AddressType) String() string {
 	return proto.EnumName(AddressType_name, int32(x))
 }
 func (AddressType) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_rpc_ea34ec0435bf8f95, []int{0}
+	return fileDescriptor_rpc_5df37351f99d795c, []int{0}
 }
 
 type ChannelCloseSummary_ClosureType int32
@@ -90,7 +90,7 @@ func (x ChannelCloseSummary_ClosureType) String() string {
 	return proto.EnumName(ChannelCloseSummary_ClosureType_name, int32(x))
 }
 func (ChannelCloseSummary_ClosureType) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_rpc_ea34ec0435bf8f95, []int{41, 0}
+	return fileDescriptor_rpc_5df37351f99d795c, []int{41, 0}
 }
 
 type Peer_SyncType int32
@@ -122,7 +122,7 @@ func (x Peer_SyncType) String() string {
 	return proto.EnumName(Peer_SyncType_name, int32(x))
 }
 func (Peer_SyncType) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_rpc_ea34ec0435bf8f95, []int{44, 0}
+	return fileDescriptor_rpc_5df37351f99d795c, []int{44, 0}
 }
 
 type ChannelEventUpdate_UpdateType int32
@@ -151,7 +151,7 @@ func (x ChannelEventUpdate_UpdateType) String() string {
 	return proto.EnumName(ChannelEventUpdate_UpdateType_name, int32(x))
 }
 func (ChannelEventUpdate_UpdateType) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_rpc_ea34ec0435bf8f95, []int{62, 0}
+	return fileDescriptor_rpc_5df37351f99d795c, []int{62, 0}
 }
 
 type Invoice_InvoiceState int32
@@ -180,7 +180,7 @@ func (x Invoice_InvoiceState) String() string {
 	return proto.EnumName(Invoice_InvoiceState_name, int32(x))
 }
 func (Invoice_InvoiceState) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_rpc_ea34ec0435bf8f95, []int{92, 0}
+	return fileDescriptor_rpc_5df37351f99d795c, []int{92, 0}
 }
 
 type GenSeedRequest struct {
@@ -201,7 +201,7 @@ func (m *GenSeedRequest) Reset()         { *m = GenSeedRequest{} }
 func (m *GenSeedRequest) String() string { return proto.CompactTextString(m) }
 func (*GenSeedRequest) ProtoMessage()    {}
 func (*GenSeedRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_rpc_ea34ec0435bf8f95, []int{0}
+	return fileDescriptor_rpc_5df37351f99d795c, []int{0}
 }
 func (m *GenSeedRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_GenSeedRequest.Unmarshal(m, b)
@@ -256,7 +256,7 @@ func (m *GenSeedResponse) Reset()         { *m = GenSeedResponse{} }
 func (m *GenSeedResponse) String() string { return proto.CompactTextString(m) }
 func (*GenSeedResponse) ProtoMessage()    {}
 func (*GenSeedResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_rpc_ea34ec0435bf8f95, []int{1}
+	return fileDescriptor_rpc_5df37351f99d795c, []int{1}
 }
 func (m *GenSeedResponse) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_GenSeedResponse.Unmarshal(m, b)
@@ -329,7 +329,7 @@ func (m *InitWalletRequest) Reset()         { *m = InitWalletRequest{} }
 func (m *InitWalletRequest) String() string { return proto.CompactTextString(m) }
 func (*InitWalletRequest) ProtoMessage()    {}
 func (*InitWalletRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_rpc_ea34ec0435bf8f95, []int{2}
+	return fileDescriptor_rpc_5df37351f99d795c, []int{2}
 }
 func (m *InitWalletRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_InitWalletRequest.Unmarshal(m, b)
@@ -394,7 +394,7 @@ func (m *InitWalletResponse) Reset()         { *m = InitWalletResponse{} }
 func (m *InitWalletResponse) String() string { return proto.CompactTextString(m) }
 func (*InitWalletResponse) ProtoMessage()    {}
 func (*InitWalletResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_rpc_ea34ec0435bf8f95, []int{3}
+	return fileDescriptor_rpc_5df37351f99d795c, []int{3}
 }
 func (m *InitWalletResponse) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_InitWalletResponse.Unmarshal(m, b)
@@ -423,7 +423,7 @@ type UnlockWalletRequest struct {
 	// *
 	// recovery_window is an optional argument specifying the address lookahead
 	// when restoring a wallet seed. The recovery window applies to each
-	// invdividual branch of the BIP44 derivation paths. Supplying a recovery
+	// individual branch of the BIP44 derivation paths. Supplying a recovery
 	// window of zero indicates that no addresses should be recovered, such after
 	// the first initialization of the wallet.
 	RecoveryWindow int32 `protobuf:"varint,2,opt,name=recovery_window,json=recoveryWindow,proto3" json:"recovery_window,omitempty"`
@@ -444,7 +444,7 @@ func (m *UnlockWalletRequest) Reset()         { *m = UnlockWalletRequest{} }
 func (m *UnlockWalletRequest) String() string { return proto.CompactTextString(m) }
 func (*UnlockWalletRequest) ProtoMessage()    {}
 func (*UnlockWalletRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_rpc_ea34ec0435bf8f95, []int{4}
+	return fileDescriptor_rpc_5df37351f99d795c, []int{4}
 }
 func (m *UnlockWalletRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_UnlockWalletRequest.Unmarshal(m, b)
@@ -495,7 +495,7 @@ func (m *UnlockWalletResponse) Reset()         { *m = UnlockWalletResponse{} }
 func (m *UnlockWalletResponse) String() string { return proto.CompactTextString(m) }
 func (*UnlockWalletResponse) ProtoMessage()    {}
 func (*UnlockWalletResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_rpc_ea34ec0435bf8f95, []int{5}
+	return fileDescriptor_rpc_5df37351f99d795c, []int{5}
 }
 func (m *UnlockWalletResponse) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_UnlockWalletResponse.Unmarshal(m, b)
@@ -533,7 +533,7 @@ func (m *ChangePasswordRequest) Reset()         { *m = ChangePasswordRequest{} }
 func (m *ChangePasswordRequest) String() string { return proto.CompactTextString(m) }
 func (*ChangePasswordRequest) ProtoMessage()    {}
 func (*ChangePasswordRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_rpc_ea34ec0435bf8f95, []int{6}
+	return fileDescriptor_rpc_5df37351f99d795c, []int{6}
 }
 func (m *ChangePasswordRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_ChangePasswordRequest.Unmarshal(m, b)
@@ -577,7 +577,7 @@ func (m *ChangePasswordResponse) Reset()         { *m = ChangePasswordResponse{}
 func (m *ChangePasswordResponse) String() string { return proto.CompactTextString(m) }
 func (*ChangePasswordResponse) ProtoMessage()    {}
 func (*ChangePasswordResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_rpc_ea34ec0435bf8f95, []int{7}
+	return fileDescriptor_rpc_5df37351f99d795c, []int{7}
 }
 func (m *ChangePasswordResponse) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_ChangePasswordResponse.Unmarshal(m, b)
@@ -619,7 +619,7 @@ func (m *Utxo) Reset()         { *m = Utxo{} }
 func (m *Utxo) String() string { return proto.CompactTextString(m) }
 func (*Utxo) ProtoMessage()    {}
 func (*Utxo) Descriptor() ([]byte, []int) {
-	return fileDescriptor_rpc_ea34ec0435bf8f95, []int{8}
+	return fileDescriptor_rpc_5df37351f99d795c, []int{8}
 }
 func (m *Utxo) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_Utxo.Unmarshal(m, b)
@@ -707,7 +707,7 @@ func (m *Transaction) Reset()         { *m = Transaction{} }
 func (m *Transaction) String() string { return proto.CompactTextString(m) }
 func (*Transaction) ProtoMessage()    {}
 func (*Transaction) Descriptor() ([]byte, []int) {
-	return fileDescriptor_rpc_ea34ec0435bf8f95, []int{9}
+	return fileDescriptor_rpc_5df37351f99d795c, []int{9}
 }
 func (m *Transaction) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_Transaction.Unmarshal(m, b)
@@ -793,7 +793,7 @@ func (m *GetTransactionsRequest) Reset()         { *m = GetTransactionsRequest{}
 func (m *GetTransactionsRequest) String() string { return proto.CompactTextString(m) }
 func (*GetTransactionsRequest) ProtoMessage()    {}
 func (*GetTransactionsRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_rpc_ea34ec0435bf8f95, []int{10}
+	return fileDescriptor_rpc_5df37351f99d795c, []int{10}
 }
 func (m *GetTransactionsRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_GetTransactionsRequest.Unmarshal(m, b)
@@ -825,7 +825,7 @@ func (m *TransactionDetails) Reset()         { *m = TransactionDetails{} }
 func (m *TransactionDetails) String() string { return proto.CompactTextString(m) }
 func (*TransactionDetails) ProtoMessage()    {}
 func (*TransactionDetails) Descriptor() ([]byte, []int) {
-	return fileDescriptor_rpc_ea34ec0435bf8f95, []int{11}
+	return fileDescriptor_rpc_5df37351f99d795c, []int{11}
 }
 func (m *TransactionDetails) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_TransactionDetails.Unmarshal(m, b)
@@ -866,7 +866,7 @@ func (m *FeeLimit) Reset()         { *m = FeeLimit{} }
 func (m *FeeLimit) String() string { return proto.CompactTextString(m) }
 func (*FeeLimit) ProtoMessage()    {}
 func (*FeeLimit) Descriptor() ([]byte, []int) {
-	return fileDescriptor_rpc_ea34ec0435bf8f95, []int{12}
+	return fileDescriptor_rpc_5df37351f99d795c, []int{12}
 }
 func (m *FeeLimit) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_FeeLimit.Unmarshal(m, b)
@@ -1030,7 +1030,7 @@ func (m *SendRequest) Reset()         { *m = SendRequest{} }
 func (m *SendRequest) String() string { return proto.CompactTextString(m) }
 func (*SendRequest) ProtoMessage()    {}
 func (*SendRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_rpc_ea34ec0435bf8f95, []int{13}
+	return fileDescriptor_rpc_5df37351f99d795c, []int{13}
 }
 func (m *SendRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_SendRequest.Unmarshal(m, b)
@@ -1134,7 +1134,7 @@ func (m *SendResponse) Reset()         { *m = SendResponse{} }
 func (m *SendResponse) String() string { return proto.CompactTextString(m) }
 func (*SendResponse) ProtoMessage()    {}
 func (*SendResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_rpc_ea34ec0435bf8f95, []int{14}
+	return fileDescriptor_rpc_5df37351f99d795c, []int{14}
 }
 func (m *SendResponse) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_SendResponse.Unmarshal(m, b)
@@ -1198,7 +1198,7 @@ func (m *SendToRouteRequest) Reset()         { *m = SendToRouteRequest{} }
 func (m *SendToRouteRequest) String() string { return proto.CompactTextString(m) }
 func (*SendToRouteRequest) ProtoMessage()    {}
 func (*SendToRouteRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_rpc_ea34ec0435bf8f95, []int{15}
+	return fileDescriptor_rpc_5df37351f99d795c, []int{15}
 }
 func (m *SendToRouteRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_SendToRouteRequest.Unmarshal(m, b)
@@ -1255,7 +1255,7 @@ func (m *ChannelPoint) Reset()         { *m = ChannelPoint{} }
 func (m *ChannelPoint) String() string { return proto.CompactTextString(m) }
 func (*ChannelPoint) ProtoMessage()    {}
 func (*ChannelPoint) Descriptor() ([]byte, []int) {
-	return fileDescriptor_rpc_ea34ec0435bf8f95, []int{16}
+	return fileDescriptor_rpc_5df37351f99d795c, []int{16}
 }
 func (m *ChannelPoint) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_ChannelPoint.Unmarshal(m, b)
@@ -1401,7 +1401,7 @@ func (m *OutPoint) Reset()         { *m = OutPoint{} }
 func (m *OutPoint) String() string { return proto.CompactTextString(m) }
 func (*OutPoint) ProtoMessage()    {}
 func (*OutPoint) Descriptor() ([]byte, []int) {
-	return fileDescriptor_rpc_ea34ec0435bf8f95, []int{17}
+	return fileDescriptor_rpc_5df37351f99d795c, []int{17}
 }
 func (m *OutPoint) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_OutPoint.Unmarshal(m, b)
@@ -1456,7 +1456,7 @@ func (m *LightningAddress) Reset()         { *m = LightningAddress{} }
 func (m *LightningAddress) String() string { return proto.CompactTextString(m) }
 func (*LightningAddress) ProtoMessage()    {}
 func (*LightningAddress) Descriptor() ([]byte, []int) {
-	return fileDescriptor_rpc_ea34ec0435bf8f95, []int{18}
+	return fileDescriptor_rpc_5df37351f99d795c, []int{18}
 }
 func (m *LightningAddress) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_LightningAddress.Unmarshal(m, b)
@@ -1504,7 +1504,7 @@ func (m *EstimateFeeRequest) Reset()         { *m = EstimateFeeRequest{} }
 func (m *EstimateFeeRequest) String() string { return proto.CompactTextString(m) }
 func (*EstimateFeeRequest) ProtoMessage()    {}
 func (*EstimateFeeRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_rpc_ea34ec0435bf8f95, []int{19}
+	return fileDescriptor_rpc_5df37351f99d795c, []int{19}
 }
 func (m *EstimateFeeRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_EstimateFeeRequest.Unmarshal(m, b)
@@ -1552,7 +1552,7 @@ func (m *EstimateFeeResponse) Reset()         { *m = EstimateFeeResponse{} }
 func (m *EstimateFeeResponse) String() string { return proto.CompactTextString(m) }
 func (*EstimateFeeResponse) ProtoMessage()    {}
 func (*EstimateFeeResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_rpc_ea34ec0435bf8f95, []int{20}
+	return fileDescriptor_rpc_5df37351f99d795c, []int{20}
 }
 func (m *EstimateFeeResponse) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_EstimateFeeResponse.Unmarshal(m, b)
@@ -1602,7 +1602,7 @@ func (m *SendManyRequest) Reset()         { *m = SendManyRequest{} }
 func (m *SendManyRequest) String() string { return proto.CompactTextString(m) }
 func (*SendManyRequest) ProtoMessage()    {}
 func (*SendManyRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_rpc_ea34ec0435bf8f95, []int{21}
+	return fileDescriptor_rpc_5df37351f99d795c, []int{21}
 }
 func (m *SendManyRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_SendManyRequest.Unmarshal(m, b)
@@ -1655,7 +1655,7 @@ func (m *SendManyResponse) Reset()         { *m = SendManyResponse{} }
 func (m *SendManyResponse) String() string { return proto.CompactTextString(m) }
 func (*SendManyResponse) ProtoMessage()    {}
 func (*SendManyResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_rpc_ea34ec0435bf8f95, []int{22}
+	return fileDescriptor_rpc_5df37351f99d795c, []int{22}
 }
 func (m *SendManyResponse) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_SendManyResponse.Unmarshal(m, b)
@@ -1705,7 +1705,7 @@ func (m *SendCoinsRequest) Reset()         { *m = SendCoinsRequest{} }
 func (m *SendCoinsRequest) String() string { return proto.CompactTextString(m) }
 func (*SendCoinsRequest) ProtoMessage()    {}
 func (*SendCoinsRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_rpc_ea34ec0435bf8f95, []int{23}
+	return fileDescriptor_rpc_5df37351f99d795c, []int{23}
 }
 func (m *SendCoinsRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_SendCoinsRequest.Unmarshal(m, b)
@@ -1772,7 +1772,7 @@ func (m *SendCoinsResponse) Reset()         { *m = SendCoinsResponse{} }
 func (m *SendCoinsResponse) String() string { return proto.CompactTextString(m) }
 func (*SendCoinsResponse) ProtoMessage()    {}
 func (*SendCoinsResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_rpc_ea34ec0435bf8f95, []int{24}
+	return fileDescriptor_rpc_5df37351f99d795c, []int{24}
 }
 func (m *SendCoinsResponse) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_SendCoinsResponse.Unmarshal(m, b)
@@ -1813,7 +1813,7 @@ func (m *ListUnspentRequest) Reset()         { *m = ListUnspentRequest{} }
 func (m *ListUnspentRequest) String() string { return proto.CompactTextString(m) }
 func (*ListUnspentRequest) ProtoMessage()    {}
 func (*ListUnspentRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_rpc_ea34ec0435bf8f95, []int{25}
+	return fileDescriptor_rpc_5df37351f99d795c, []int{25}
 }
 func (m *ListUnspentRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_ListUnspentRequest.Unmarshal(m, b)
@@ -1859,7 +1859,7 @@ func (m *ListUnspentResponse) Reset()         { *m = ListUnspentResponse{} }
 func (m *ListUnspentResponse) String() string { return proto.CompactTextString(m) }
 func (*ListUnspentResponse) ProtoMessage()    {}
 func (*ListUnspentResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_rpc_ea34ec0435bf8f95, []int{26}
+	return fileDescriptor_rpc_5df37351f99d795c, []int{26}
 }
 func (m *ListUnspentResponse) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_ListUnspentResponse.Unmarshal(m, b)
@@ -1898,7 +1898,7 @@ func (m *NewAddressRequest) Reset()         { *m = NewAddressRequest{} }
 func (m *NewAddressRequest) String() string { return proto.CompactTextString(m) }
 func (*NewAddressRequest) ProtoMessage()    {}
 func (*NewAddressRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_rpc_ea34ec0435bf8f95, []int{27}
+	return fileDescriptor_rpc_5df37351f99d795c, []int{27}
 }
 func (m *NewAddressRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_NewAddressRequest.Unmarshal(m, b)
@@ -1937,7 +1937,7 @@ func (m *NewAddressResponse) Reset()         { *m = NewAddressResponse{} }
 func (m *NewAddressResponse) String() string { return proto.CompactTextString(m) }
 func (*NewAddressResponse) ProtoMessage()    {}
 func (*NewAddressResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_rpc_ea34ec0435bf8f95, []int{28}
+	return fileDescriptor_rpc_5df37351f99d795c, []int{28}
 }
 func (m *NewAddressResponse) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_NewAddressResponse.Unmarshal(m, b)
@@ -1976,7 +1976,7 @@ func (m *SignMessageRequest) Reset()         { *m = SignMessageRequest{} }
 func (m *SignMessageRequest) String() string { return proto.CompactTextString(m) }
 func (*SignMessageRequest) ProtoMessage()    {}
 func (*SignMessageRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_rpc_ea34ec0435bf8f95, []int{29}
+	return fileDescriptor_rpc_5df37351f99d795c, []int{29}
 }
 func (m *SignMessageRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_SignMessageRequest.Unmarshal(m, b)
@@ -2015,7 +2015,7 @@ func (m *SignMessageResponse) Reset()         { *m = SignMessageResponse{} }
 func (m *SignMessageResponse) String() string { return proto.CompactTextString(m) }
 func (*SignMessageResponse) ProtoMessage()    {}
 func (*SignMessageResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_rpc_ea34ec0435bf8f95, []int{30}
+	return fileDescriptor_rpc_5df37351f99d795c, []int{30}
 }
 func (m *SignMessageResponse) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_SignMessageResponse.Unmarshal(m, b)
@@ -2056,7 +2056,7 @@ func (m *VerifyMessageRequest) Reset()         { *m = VerifyMessageRequest{} }
 func (m *VerifyMessageRequest) String() string { return proto.CompactTextString(m) }
 func (*VerifyMessageRequest) ProtoMessage()    {}
 func (*VerifyMessageRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_rpc_ea34ec0435bf8f95, []int{31}
+	return fileDescriptor_rpc_5df37351f99d795c, []int{31}
 }
 func (m *VerifyMessageRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_VerifyMessageRequest.Unmarshal(m, b)
@@ -2104,7 +2104,7 @@ func (m *VerifyMessageResponse) Reset()         { *m = VerifyMessageResponse{} }
 func (m *VerifyMessageResponse) String() string { return proto.CompactTextString(m) }
 func (*VerifyMessageResponse) ProtoMessage()    {}
 func (*VerifyMessageResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_rpc_ea34ec0435bf8f95, []int{32}
+	return fileDescriptor_rpc_5df37351f99d795c, []int{32}
 }
 func (m *VerifyMessageResponse) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_VerifyMessageResponse.Unmarshal(m, b)
@@ -2153,7 +2153,7 @@ func (m *ConnectPeerRequest) Reset()         { *m = ConnectPeerRequest{} }
 func (m *ConnectPeerRequest) String() string { return proto.CompactTextString(m) }
 func (*ConnectPeerRequest) ProtoMessage()    {}
 func (*ConnectPeerRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_rpc_ea34ec0435bf8f95, []int{33}
+	return fileDescriptor_rpc_5df37351f99d795c, []int{33}
 }
 func (m *ConnectPeerRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_ConnectPeerRequest.Unmarshal(m, b)
@@ -2197,7 +2197,7 @@ func (m *ConnectPeerResponse) Reset()         { *m = ConnectPeerResponse{} }
 func (m *ConnectPeerResponse) String() string { return proto.CompactTextString(m) }
 func (*ConnectPeerResponse) ProtoMessage()    {}
 func (*ConnectPeerResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_rpc_ea34ec0435bf8f95, []int{34}
+	return fileDescriptor_rpc_5df37351f99d795c, []int{34}
 }
 func (m *ConnectPeerResponse) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_ConnectPeerResponse.Unmarshal(m, b)
@@ -2229,7 +2229,7 @@ func (m *DisconnectPeerRequest) Reset()         { *m = DisconnectPeerRequest{} }
 func (m *DisconnectPeerRequest) String() string { return proto.CompactTextString(m) }
 func (*DisconnectPeerRequest) ProtoMessage()    {}
 func (*DisconnectPeerRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_rpc_ea34ec0435bf8f95, []int{35}
+	return fileDescriptor_rpc_5df37351f99d795c, []int{35}
 }
 func (m *DisconnectPeerRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_DisconnectPeerRequest.Unmarshal(m, b)
@@ -2266,7 +2266,7 @@ func (m *DisconnectPeerResponse) Reset()         { *m = DisconnectPeerResponse{}
 func (m *DisconnectPeerResponse) String() string { return proto.CompactTextString(m) }
 func (*DisconnectPeerResponse) ProtoMessage()    {}
 func (*DisconnectPeerResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_rpc_ea34ec0435bf8f95, []int{36}
+	return fileDescriptor_rpc_5df37351f99d795c, []int{36}
 }
 func (m *DisconnectPeerResponse) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_DisconnectPeerResponse.Unmarshal(m, b)
@@ -2300,7 +2300,7 @@ func (m *HTLC) Reset()         { *m = HTLC{} }
 func (m *HTLC) String() string { return proto.CompactTextString(m) }
 func (*HTLC) ProtoMessage()    {}
 func (*HTLC) Descriptor() ([]byte, []int) {
-	return fileDescriptor_rpc_ea34ec0435bf8f95, []int{37}
+	return fileDescriptor_rpc_5df37351f99d795c, []int{37}
 }
 func (m *HTLC) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_HTLC.Unmarshal(m, b)
@@ -2404,7 +2404,7 @@ type Channel struct {
 	Private bool `protobuf:"varint,17,opt,name=private,proto3" json:"private,omitempty"`
 	// / True if we were the ones that created the channel.
 	Initiator bool `protobuf:"varint,18,opt,name=initiator,proto3" json:"initiator,omitempty"`
-	// / A set of flags showing the current state of the cahnnel.
+	// / A set of flags showing the current state of the channel.
 	ChanStatusFlags      string   `protobuf:"bytes,19,opt,name=chan_status_flags,proto3" json:"chan_status_flags,omitempty"`
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
 	XXX_unrecognized     []byte   `json:"-"`
@@ -2415,7 +2415,7 @@ func (m *Channel) Reset()         { *m = Channel{} }
 func (m *Channel) String() string { return proto.CompactTextString(m) }
 func (*Channel) ProtoMessage()    {}
 func (*Channel) Descriptor() ([]byte, []int) {
-	return fileDescriptor_rpc_ea34ec0435bf8f95, []int{38}
+	return fileDescriptor_rpc_5df37351f99d795c, []int{38}
 }
 func (m *Channel) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_Channel.Unmarshal(m, b)
@@ -2582,7 +2582,7 @@ func (m *ListChannelsRequest) Reset()         { *m = ListChannelsRequest{} }
 func (m *ListChannelsRequest) String() string { return proto.CompactTextString(m) }
 func (*ListChannelsRequest) ProtoMessage()    {}
 func (*ListChannelsRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_rpc_ea34ec0435bf8f95, []int{39}
+	return fileDescriptor_rpc_5df37351f99d795c, []int{39}
 }
 func (m *ListChannelsRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_ListChannelsRequest.Unmarshal(m, b)
@@ -2642,7 +2642,7 @@ func (m *ListChannelsResponse) Reset()         { *m = ListChannelsResponse{} }
 func (m *ListChannelsResponse) String() string { return proto.CompactTextString(m) }
 func (*ListChannelsResponse) ProtoMessage()    {}
 func (*ListChannelsResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_rpc_ea34ec0435bf8f95, []int{40}
+	return fileDescriptor_rpc_5df37351f99d795c, []int{40}
 }
 func (m *ListChannelsResponse) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_ListChannelsResponse.Unmarshal(m, b)
@@ -2699,7 +2699,7 @@ func (m *ChannelCloseSummary) Reset()         { *m = ChannelCloseSummary{} }
 func (m *ChannelCloseSummary) String() string { return proto.CompactTextString(m) }
 func (*ChannelCloseSummary) ProtoMessage()    {}
 func (*ChannelCloseSummary) Descriptor() ([]byte, []int) {
-	return fileDescriptor_rpc_ea34ec0435bf8f95, []int{41}
+	return fileDescriptor_rpc_5df37351f99d795c, []int{41}
 }
 func (m *ChannelCloseSummary) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_ChannelCloseSummary.Unmarshal(m, b)
@@ -2805,7 +2805,7 @@ func (m *ClosedChannelsRequest) Reset()         { *m = ClosedChannelsRequest{} }
 func (m *ClosedChannelsRequest) String() string { return proto.CompactTextString(m) }
 func (*ClosedChannelsRequest) ProtoMessage()    {}
 func (*ClosedChannelsRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_rpc_ea34ec0435bf8f95, []int{42}
+	return fileDescriptor_rpc_5df37351f99d795c, []int{42}
 }
 func (m *ClosedChannelsRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_ClosedChannelsRequest.Unmarshal(m, b)
@@ -2878,7 +2878,7 @@ func (m *ClosedChannelsResponse) Reset()         { *m = ClosedChannelsResponse{}
 func (m *ClosedChannelsResponse) String() string { return proto.CompactTextString(m) }
 func (*ClosedChannelsResponse) ProtoMessage()    {}
 func (*ClosedChannelsResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_rpc_ea34ec0435bf8f95, []int{43}
+	return fileDescriptor_rpc_5df37351f99d795c, []int{43}
 }
 func (m *ClosedChannelsResponse) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_ClosedChannelsResponse.Unmarshal(m, b)
@@ -2933,7 +2933,7 @@ func (m *Peer) Reset()         { *m = Peer{} }
 func (m *Peer) String() string { return proto.CompactTextString(m) }
 func (*Peer) ProtoMessage()    {}
 func (*Peer) Descriptor() ([]byte, []int) {
-	return fileDescriptor_rpc_ea34ec0435bf8f95, []int{44}
+	return fileDescriptor_rpc_5df37351f99d795c, []int{44}
 }
 func (m *Peer) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_Peer.Unmarshal(m, b)
@@ -3026,7 +3026,7 @@ func (m *ListPeersRequest) Reset()         { *m = ListPeersRequest{} }
 func (m *ListPeersRequest) String() string { return proto.CompactTextString(m) }
 func (*ListPeersRequest) ProtoMessage()    {}
 func (*ListPeersRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_rpc_ea34ec0435bf8f95, []int{45}
+	return fileDescriptor_rpc_5df37351f99d795c, []int{45}
 }
 func (m *ListPeersRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_ListPeersRequest.Unmarshal(m, b)
@@ -3058,7 +3058,7 @@ func (m *ListPeersResponse) Reset()         { *m = ListPeersResponse{} }
 func (m *ListPeersResponse) String() string { return proto.CompactTextString(m) }
 func (*ListPeersResponse) ProtoMessage()    {}
 func (*ListPeersResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_rpc_ea34ec0435bf8f95, []int{46}
+	return fileDescriptor_rpc_5df37351f99d795c, []int{46}
 }
 func (m *ListPeersResponse) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_ListPeersResponse.Unmarshal(m, b)
@@ -3095,7 +3095,7 @@ func (m *GetInfoRequest) Reset()         { *m = GetInfoRequest{} }
 func (m *GetInfoRequest) String() string { return proto.CompactTextString(m) }
 func (*GetInfoRequest) ProtoMessage()    {}
 func (*GetInfoRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_rpc_ea34ec0435bf8f95, []int{47}
+	return fileDescriptor_rpc_5df37351f99d795c, []int{47}
 }
 func (m *GetInfoRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_GetInfoRequest.Unmarshal(m, b)
@@ -3155,7 +3155,7 @@ func (m *GetInfoResponse) Reset()         { *m = GetInfoResponse{} }
 func (m *GetInfoResponse) String() string { return proto.CompactTextString(m) }
 func (*GetInfoResponse) ProtoMessage()    {}
 func (*GetInfoResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_rpc_ea34ec0435bf8f95, []int{48}
+	return fileDescriptor_rpc_5df37351f99d795c, []int{48}
 }
 func (m *GetInfoResponse) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_GetInfoResponse.Unmarshal(m, b)
@@ -3288,7 +3288,7 @@ func (m *Chain) Reset()         { *m = Chain{} }
 func (m *Chain) String() string { return proto.CompactTextString(m) }
 func (*Chain) ProtoMessage()    {}
 func (*Chain) Descriptor() ([]byte, []int) {
-	return fileDescriptor_rpc_ea34ec0435bf8f95, []int{49}
+	return fileDescriptor_rpc_5df37351f99d795c, []int{49}
 }
 func (m *Chain) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_Chain.Unmarshal(m, b)
@@ -3335,7 +3335,7 @@ func (m *ConfirmationUpdate) Reset()         { *m = ConfirmationUpdate{} }
 func (m *ConfirmationUpdate) String() string { return proto.CompactTextString(m) }
 func (*ConfirmationUpdate) ProtoMessage()    {}
 func (*ConfirmationUpdate) Descriptor() ([]byte, []int) {
-	return fileDescriptor_rpc_ea34ec0435bf8f95, []int{50}
+	return fileDescriptor_rpc_5df37351f99d795c, []int{50}
 }
 func (m *ConfirmationUpdate) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_ConfirmationUpdate.Unmarshal(m, b)
@@ -3387,7 +3387,7 @@ func (m *ChannelOpenUpdate) Reset()         { *m = ChannelOpenUpdate{} }
 func (m *ChannelOpenUpdate) String() string { return proto.CompactTextString(m) }
 func (*ChannelOpenUpdate) ProtoMessage()    {}
 func (*ChannelOpenUpdate) Descriptor() ([]byte, []int) {
-	return fileDescriptor_rpc_ea34ec0435bf8f95, []int{51}
+	return fileDescriptor_rpc_5df37351f99d795c, []int{51}
 }
 func (m *ChannelOpenUpdate) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_ChannelOpenUpdate.Unmarshal(m, b)
@@ -3426,7 +3426,7 @@ func (m *ChannelCloseUpdate) Reset()         { *m = ChannelCloseUpdate{} }
 func (m *ChannelCloseUpdate) String() string { return proto.CompactTextString(m) }
 func (*ChannelCloseUpdate) ProtoMessage()    {}
 func (*ChannelCloseUpdate) Descriptor() ([]byte, []int) {
-	return fileDescriptor_rpc_ea34ec0435bf8f95, []int{52}
+	return fileDescriptor_rpc_5df37351f99d795c, []int{52}
 }
 func (m *ChannelCloseUpdate) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_ChannelCloseUpdate.Unmarshal(m, b)
@@ -3481,7 +3481,7 @@ func (m *CloseChannelRequest) Reset()         { *m = CloseChannelRequest{} }
 func (m *CloseChannelRequest) String() string { return proto.CompactTextString(m) }
 func (*CloseChannelRequest) ProtoMessage()    {}
 func (*CloseChannelRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_rpc_ea34ec0435bf8f95, []int{53}
+	return fileDescriptor_rpc_5df37351f99d795c, []int{53}
 }
 func (m *CloseChannelRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_CloseChannelRequest.Unmarshal(m, b)
@@ -3543,7 +3543,7 @@ func (m *CloseStatusUpdate) Reset()         { *m = CloseStatusUpdate{} }
 func (m *CloseStatusUpdate) String() string { return proto.CompactTextString(m) }
 func (*CloseStatusUpdate) ProtoMessage()    {}
 func (*CloseStatusUpdate) Descriptor() ([]byte, []int) {
-	return fileDescriptor_rpc_ea34ec0435bf8f95, []int{54}
+	return fileDescriptor_rpc_5df37351f99d795c, []int{54}
 }
 func (m *CloseStatusUpdate) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_CloseStatusUpdate.Unmarshal(m, b)
@@ -3686,7 +3686,7 @@ func (m *PendingUpdate) Reset()         { *m = PendingUpdate{} }
 func (m *PendingUpdate) String() string { return proto.CompactTextString(m) }
 func (*PendingUpdate) ProtoMessage()    {}
 func (*PendingUpdate) Descriptor() ([]byte, []int) {
-	return fileDescriptor_rpc_ea34ec0435bf8f95, []int{55}
+	return fileDescriptor_rpc_5df37351f99d795c, []int{55}
 }
 func (m *PendingUpdate) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_PendingUpdate.Unmarshal(m, b)
@@ -3752,7 +3752,7 @@ func (m *OpenChannelRequest) Reset()         { *m = OpenChannelRequest{} }
 func (m *OpenChannelRequest) String() string { return proto.CompactTextString(m) }
 func (*OpenChannelRequest) ProtoMessage()    {}
 func (*OpenChannelRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_rpc_ea34ec0435bf8f95, []int{56}
+	return fileDescriptor_rpc_5df37351f99d795c, []int{56}
 }
 func (m *OpenChannelRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_OpenChannelRequest.Unmarshal(m, b)
@@ -3863,7 +3863,7 @@ func (m *OpenStatusUpdate) Reset()         { *m = OpenStatusUpdate{} }
 func (m *OpenStatusUpdate) String() string { return proto.CompactTextString(m) }
 func (*OpenStatusUpdate) ProtoMessage()    {}
 func (*OpenStatusUpdate) Descriptor() ([]byte, []int) {
-	return fileDescriptor_rpc_ea34ec0435bf8f95, []int{57}
+	return fileDescriptor_rpc_5df37351f99d795c, []int{57}
 }
 func (m *OpenStatusUpdate) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_OpenStatusUpdate.Unmarshal(m, b)
@@ -4019,7 +4019,7 @@ func (m *PendingHTLC) Reset()         { *m = PendingHTLC{} }
 func (m *PendingHTLC) String() string { return proto.CompactTextString(m) }
 func (*PendingHTLC) ProtoMessage()    {}
 func (*PendingHTLC) Descriptor() ([]byte, []int) {
-	return fileDescriptor_rpc_ea34ec0435bf8f95, []int{58}
+	return fileDescriptor_rpc_5df37351f99d795c, []int{58}
 }
 func (m *PendingHTLC) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_PendingHTLC.Unmarshal(m, b)
@@ -4091,7 +4091,7 @@ func (m *PendingChannelsRequest) Reset()         { *m = PendingChannelsRequest{}
 func (m *PendingChannelsRequest) String() string { return proto.CompactTextString(m) }
 func (*PendingChannelsRequest) ProtoMessage()    {}
 func (*PendingChannelsRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_rpc_ea34ec0435bf8f95, []int{59}
+	return fileDescriptor_rpc_5df37351f99d795c, []int{59}
 }
 func (m *PendingChannelsRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_PendingChannelsRequest.Unmarshal(m, b)
@@ -4131,7 +4131,7 @@ func (m *PendingChannelsResponse) Reset()         { *m = PendingChannelsResponse
 func (m *PendingChannelsResponse) String() string { return proto.CompactTextString(m) }
 func (*PendingChannelsResponse) ProtoMessage()    {}
 func (*PendingChannelsResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_rpc_ea34ec0435bf8f95, []int{60}
+	return fileDescriptor_rpc_5df37351f99d795c, []int{60}
 }
 func (m *PendingChannelsResponse) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_PendingChannelsResponse.Unmarshal(m, b)
@@ -4203,7 +4203,7 @@ func (m *PendingChannelsResponse_PendingChannel) Reset() {
 func (m *PendingChannelsResponse_PendingChannel) String() string { return proto.CompactTextString(m) }
 func (*PendingChannelsResponse_PendingChannel) ProtoMessage()    {}
 func (*PendingChannelsResponse_PendingChannel) Descriptor() ([]byte, []int) {
-	return fileDescriptor_rpc_ea34ec0435bf8f95, []int{60, 0}
+	return fileDescriptor_rpc_5df37351f99d795c, []int{60, 0}
 }
 func (m *PendingChannelsResponse_PendingChannel) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_PendingChannelsResponse_PendingChannel.Unmarshal(m, b)
@@ -4290,7 +4290,7 @@ func (m *PendingChannelsResponse_PendingOpenChannel) String() string {
 }
 func (*PendingChannelsResponse_PendingOpenChannel) ProtoMessage() {}
 func (*PendingChannelsResponse_PendingOpenChannel) Descriptor() ([]byte, []int) {
-	return fileDescriptor_rpc_ea34ec0435bf8f95, []int{60, 1}
+	return fileDescriptor_rpc_5df37351f99d795c, []int{60, 1}
 }
 func (m *PendingChannelsResponse_PendingOpenChannel) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_PendingChannelsResponse_PendingOpenChannel.Unmarshal(m, b)
@@ -4363,7 +4363,7 @@ func (m *PendingChannelsResponse_WaitingCloseChannel) String() string {
 }
 func (*PendingChannelsResponse_WaitingCloseChannel) ProtoMessage() {}
 func (*PendingChannelsResponse_WaitingCloseChannel) Descriptor() ([]byte, []int) {
-	return fileDescriptor_rpc_ea34ec0435bf8f95, []int{60, 2}
+	return fileDescriptor_rpc_5df37351f99d795c, []int{60, 2}
 }
 func (m *PendingChannelsResponse_WaitingCloseChannel) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_PendingChannelsResponse_WaitingCloseChannel.Unmarshal(m, b)
@@ -4411,7 +4411,7 @@ func (m *PendingChannelsResponse_ClosedChannel) Reset()         { *m = PendingCh
 func (m *PendingChannelsResponse_ClosedChannel) String() string { return proto.CompactTextString(m) }
 func (*PendingChannelsResponse_ClosedChannel) ProtoMessage()    {}
 func (*PendingChannelsResponse_ClosedChannel) Descriptor() ([]byte, []int) {
-	return fileDescriptor_rpc_ea34ec0435bf8f95, []int{60, 3}
+	return fileDescriptor_rpc_5df37351f99d795c, []int{60, 3}
 }
 func (m *PendingChannelsResponse_ClosedChannel) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_PendingChannelsResponse_ClosedChannel.Unmarshal(m, b)
@@ -4452,7 +4452,7 @@ type PendingChannelsResponse_ForceClosedChannel struct {
 	ClosingTxid string `protobuf:"bytes,2,opt,name=closing_txid,proto3" json:"closing_txid,omitempty"`
 	// / The balance in satoshis encumbered in this pending channel
 	LimboBalance int64 `protobuf:"varint,3,opt,name=limbo_balance,proto3" json:"limbo_balance,omitempty"`
-	// / The height at which funds can be sweeped into the wallet
+	// / The height at which funds can be swept into the wallet
 	MaturityHeight uint32 `protobuf:"varint,4,opt,name=maturity_height,proto3" json:"maturity_height,omitempty"`
 	//
 	// Remaining # of blocks until the commitment output can be swept.
@@ -4475,7 +4475,7 @@ func (m *PendingChannelsResponse_ForceClosedChannel) String() string {
 }
 func (*PendingChannelsResponse_ForceClosedChannel) ProtoMessage() {}
 func (*PendingChannelsResponse_ForceClosedChannel) Descriptor() ([]byte, []int) {
-	return fileDescriptor_rpc_ea34ec0435bf8f95, []int{60, 4}
+	return fileDescriptor_rpc_5df37351f99d795c, []int{60, 4}
 }
 func (m *PendingChannelsResponse_ForceClosedChannel) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_PendingChannelsResponse_ForceClosedChannel.Unmarshal(m, b)
@@ -4554,7 +4554,7 @@ func (m *ChannelEventSubscription) Reset()         { *m = ChannelEventSubscripti
 func (m *ChannelEventSubscription) String() string { return proto.CompactTextString(m) }
 func (*ChannelEventSubscription) ProtoMessage()    {}
 func (*ChannelEventSubscription) Descriptor() ([]byte, []int) {
-	return fileDescriptor_rpc_ea34ec0435bf8f95, []int{61}
+	return fileDescriptor_rpc_5df37351f99d795c, []int{61}
 }
 func (m *ChannelEventSubscription) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_ChannelEventSubscription.Unmarshal(m, b)
@@ -4591,7 +4591,7 @@ func (m *ChannelEventUpdate) Reset()         { *m = ChannelEventUpdate{} }
 func (m *ChannelEventUpdate) String() string { return proto.CompactTextString(m) }
 func (*ChannelEventUpdate) ProtoMessage()    {}
 func (*ChannelEventUpdate) Descriptor() ([]byte, []int) {
-	return fileDescriptor_rpc_ea34ec0435bf8f95, []int{62}
+	return fileDescriptor_rpc_5df37351f99d795c, []int{62}
 }
 func (m *ChannelEventUpdate) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_ChannelEventUpdate.Unmarshal(m, b)
@@ -4803,7 +4803,7 @@ func (m *WalletBalanceRequest) Reset()         { *m = WalletBalanceRequest{} }
 func (m *WalletBalanceRequest) String() string { return proto.CompactTextString(m) }
 func (*WalletBalanceRequest) ProtoMessage()    {}
 func (*WalletBalanceRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_rpc_ea34ec0435bf8f95, []int{63}
+	return fileDescriptor_rpc_5df37351f99d795c, []int{63}
 }
 func (m *WalletBalanceRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_WalletBalanceRequest.Unmarshal(m, b)
@@ -4839,7 +4839,7 @@ func (m *WalletBalanceResponse) Reset()         { *m = WalletBalanceResponse{} }
 func (m *WalletBalanceResponse) String() string { return proto.CompactTextString(m) }
 func (*WalletBalanceResponse) ProtoMessage()    {}
 func (*WalletBalanceResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_rpc_ea34ec0435bf8f95, []int{64}
+	return fileDescriptor_rpc_5df37351f99d795c, []int{64}
 }
 func (m *WalletBalanceResponse) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_WalletBalanceResponse.Unmarshal(m, b)
@@ -4890,7 +4890,7 @@ func (m *ChannelBalanceRequest) Reset()         { *m = ChannelBalanceRequest{} }
 func (m *ChannelBalanceRequest) String() string { return proto.CompactTextString(m) }
 func (*ChannelBalanceRequest) ProtoMessage()    {}
 func (*ChannelBalanceRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_rpc_ea34ec0435bf8f95, []int{65}
+	return fileDescriptor_rpc_5df37351f99d795c, []int{65}
 }
 func (m *ChannelBalanceRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_ChannelBalanceRequest.Unmarshal(m, b)
@@ -4924,7 +4924,7 @@ func (m *ChannelBalanceResponse) Reset()         { *m = ChannelBalanceResponse{}
 func (m *ChannelBalanceResponse) String() string { return proto.CompactTextString(m) }
 func (*ChannelBalanceResponse) ProtoMessage()    {}
 func (*ChannelBalanceResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_rpc_ea34ec0435bf8f95, []int{66}
+	return fileDescriptor_rpc_5df37351f99d795c, []int{66}
 }
 func (m *ChannelBalanceResponse) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_ChannelBalanceResponse.Unmarshal(m, b)
@@ -4990,7 +4990,7 @@ func (m *QueryRoutesRequest) Reset()         { *m = QueryRoutesRequest{} }
 func (m *QueryRoutesRequest) String() string { return proto.CompactTextString(m) }
 func (*QueryRoutesRequest) ProtoMessage()    {}
 func (*QueryRoutesRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_rpc_ea34ec0435bf8f95, []int{67}
+	return fileDescriptor_rpc_5df37351f99d795c, []int{67}
 }
 func (m *QueryRoutesRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_QueryRoutesRequest.Unmarshal(m, b)
@@ -5077,7 +5077,7 @@ func (m *EdgeLocator) Reset()         { *m = EdgeLocator{} }
 func (m *EdgeLocator) String() string { return proto.CompactTextString(m) }
 func (*EdgeLocator) ProtoMessage()    {}
 func (*EdgeLocator) Descriptor() ([]byte, []int) {
-	return fileDescriptor_rpc_ea34ec0435bf8f95, []int{68}
+	return fileDescriptor_rpc_5df37351f99d795c, []int{68}
 }
 func (m *EdgeLocator) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_EdgeLocator.Unmarshal(m, b)
@@ -5122,7 +5122,7 @@ func (m *QueryRoutesResponse) Reset()         { *m = QueryRoutesResponse{} }
 func (m *QueryRoutesResponse) String() string { return proto.CompactTextString(m) }
 func (*QueryRoutesResponse) ProtoMessage()    {}
 func (*QueryRoutesResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_rpc_ea34ec0435bf8f95, []int{69}
+	return fileDescriptor_rpc_5df37351f99d795c, []int{69}
 }
 func (m *QueryRoutesResponse) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_QueryRoutesResponse.Unmarshal(m, b)
@@ -5174,7 +5174,7 @@ func (m *Hop) Reset()         { *m = Hop{} }
 func (m *Hop) String() string { return proto.CompactTextString(m) }
 func (*Hop) ProtoMessage()    {}
 func (*Hop) Descriptor() ([]byte, []int) {
-	return fileDescriptor_rpc_ea34ec0435bf8f95, []int{70}
+	return fileDescriptor_rpc_5df37351f99d795c, []int{70}
 }
 func (m *Hop) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_Hop.Unmarshal(m, b)
@@ -5268,7 +5268,7 @@ type Route struct {
 	// *
 	// The sum of the fees paid at each hop within the final route.  In the case
 	// of a one-hop payment, this value will be zero as we don't need to pay a fee
-	// it ourself.
+	// to ourselves.
 	TotalFees int64 `protobuf:"varint,2,opt,name=total_fees,proto3" json:"total_fees,omitempty"` // Deprecated: Do not use.
 	// *
 	// The total amount of funds required to complete a payment over this route.
@@ -5295,7 +5295,7 @@ func (m *Route) Reset()         { *m = Route{} }
 func (m *Route) String() string { return proto.CompactTextString(m) }
 func (*Route) ProtoMessage()    {}
 func (*Route) Descriptor() ([]byte, []int) {
-	return fileDescriptor_rpc_ea34ec0435bf8f95, []int{71}
+	return fileDescriptor_rpc_5df37351f99d795c, []int{71}
 }
 func (m *Route) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_Route.Unmarshal(m, b)
@@ -5371,7 +5371,7 @@ func (m *NodeInfoRequest) Reset()         { *m = NodeInfoRequest{} }
 func (m *NodeInfoRequest) String() string { return proto.CompactTextString(m) }
 func (*NodeInfoRequest) ProtoMessage()    {}
 func (*NodeInfoRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_rpc_ea34ec0435bf8f95, []int{72}
+	return fileDescriptor_rpc_5df37351f99d795c, []int{72}
 }
 func (m *NodeInfoRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_NodeInfoRequest.Unmarshal(m, b)
@@ -5416,7 +5416,7 @@ func (m *NodeInfo) Reset()         { *m = NodeInfo{} }
 func (m *NodeInfo) String() string { return proto.CompactTextString(m) }
 func (*NodeInfo) ProtoMessage()    {}
 func (*NodeInfo) Descriptor() ([]byte, []int) {
-	return fileDescriptor_rpc_ea34ec0435bf8f95, []int{73}
+	return fileDescriptor_rpc_5df37351f99d795c, []int{73}
 }
 func (m *NodeInfo) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_NodeInfo.Unmarshal(m, b)
@@ -5477,7 +5477,7 @@ func (m *LightningNode) Reset()         { *m = LightningNode{} }
 func (m *LightningNode) String() string { return proto.CompactTextString(m) }
 func (*LightningNode) ProtoMessage()    {}
 func (*LightningNode) Descriptor() ([]byte, []int) {
-	return fileDescriptor_rpc_ea34ec0435bf8f95, []int{74}
+	return fileDescriptor_rpc_5df37351f99d795c, []int{74}
 }
 func (m *LightningNode) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_LightningNode.Unmarshal(m, b)
@@ -5544,7 +5544,7 @@ func (m *NodeAddress) Reset()         { *m = NodeAddress{} }
 func (m *NodeAddress) String() string { return proto.CompactTextString(m) }
 func (*NodeAddress) ProtoMessage()    {}
 func (*NodeAddress) Descriptor() ([]byte, []int) {
-	return fileDescriptor_rpc_ea34ec0435bf8f95, []int{75}
+	return fileDescriptor_rpc_5df37351f99d795c, []int{75}
 }
 func (m *NodeAddress) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_NodeAddress.Unmarshal(m, b)
@@ -5594,7 +5594,7 @@ func (m *RoutingPolicy) Reset()         { *m = RoutingPolicy{} }
 func (m *RoutingPolicy) String() string { return proto.CompactTextString(m) }
 func (*RoutingPolicy) ProtoMessage()    {}
 func (*RoutingPolicy) Descriptor() ([]byte, []int) {
-	return fileDescriptor_rpc_ea34ec0435bf8f95, []int{76}
+	return fileDescriptor_rpc_5df37351f99d795c, []int{76}
 }
 func (m *RoutingPolicy) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_RoutingPolicy.Unmarshal(m, b)
@@ -5684,7 +5684,7 @@ func (m *ChannelEdge) Reset()         { *m = ChannelEdge{} }
 func (m *ChannelEdge) String() string { return proto.CompactTextString(m) }
 func (*ChannelEdge) ProtoMessage()    {}
 func (*ChannelEdge) Descriptor() ([]byte, []int) {
-	return fileDescriptor_rpc_ea34ec0435bf8f95, []int{77}
+	return fileDescriptor_rpc_5df37351f99d795c, []int{77}
 }
 func (m *ChannelEdge) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_ChannelEdge.Unmarshal(m, b)
@@ -5775,7 +5775,7 @@ func (m *ChannelGraphRequest) Reset()         { *m = ChannelGraphRequest{} }
 func (m *ChannelGraphRequest) String() string { return proto.CompactTextString(m) }
 func (*ChannelGraphRequest) ProtoMessage()    {}
 func (*ChannelGraphRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_rpc_ea34ec0435bf8f95, []int{78}
+	return fileDescriptor_rpc_5df37351f99d795c, []int{78}
 }
 func (m *ChannelGraphRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_ChannelGraphRequest.Unmarshal(m, b)
@@ -5817,7 +5817,7 @@ func (m *ChannelGraph) Reset()         { *m = ChannelGraph{} }
 func (m *ChannelGraph) String() string { return proto.CompactTextString(m) }
 func (*ChannelGraph) ProtoMessage()    {}
 func (*ChannelGraph) Descriptor() ([]byte, []int) {
-	return fileDescriptor_rpc_ea34ec0435bf8f95, []int{79}
+	return fileDescriptor_rpc_5df37351f99d795c, []int{79}
 }
 func (m *ChannelGraph) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_ChannelGraph.Unmarshal(m, b)
@@ -5866,7 +5866,7 @@ func (m *ChanInfoRequest) Reset()         { *m = ChanInfoRequest{} }
 func (m *ChanInfoRequest) String() string { return proto.CompactTextString(m) }
 func (*ChanInfoRequest) ProtoMessage()    {}
 func (*ChanInfoRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_rpc_ea34ec0435bf8f95, []int{80}
+	return fileDescriptor_rpc_5df37351f99d795c, []int{80}
 }
 func (m *ChanInfoRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_ChanInfoRequest.Unmarshal(m, b)
@@ -5903,7 +5903,7 @@ func (m *NetworkInfoRequest) Reset()         { *m = NetworkInfoRequest{} }
 func (m *NetworkInfoRequest) String() string { return proto.CompactTextString(m) }
 func (*NetworkInfoRequest) ProtoMessage()    {}
 func (*NetworkInfoRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_rpc_ea34ec0435bf8f95, []int{81}
+	return fileDescriptor_rpc_5df37351f99d795c, []int{81}
 }
 func (m *NetworkInfoRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_NetworkInfoRequest.Unmarshal(m, b)
@@ -5943,7 +5943,7 @@ func (m *NetworkInfo) Reset()         { *m = NetworkInfo{} }
 func (m *NetworkInfo) String() string { return proto.CompactTextString(m) }
 func (*NetworkInfo) ProtoMessage()    {}
 func (*NetworkInfo) Descriptor() ([]byte, []int) {
-	return fileDescriptor_rpc_ea34ec0435bf8f95, []int{82}
+	return fileDescriptor_rpc_5df37351f99d795c, []int{82}
 }
 func (m *NetworkInfo) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_NetworkInfo.Unmarshal(m, b)
@@ -6043,7 +6043,7 @@ func (m *StopRequest) Reset()         { *m = StopRequest{} }
 func (m *StopRequest) String() string { return proto.CompactTextString(m) }
 func (*StopRequest) ProtoMessage()    {}
 func (*StopRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_rpc_ea34ec0435bf8f95, []int{83}
+	return fileDescriptor_rpc_5df37351f99d795c, []int{83}
 }
 func (m *StopRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_StopRequest.Unmarshal(m, b)
@@ -6073,7 +6073,7 @@ func (m *StopResponse) Reset()         { *m = StopResponse{} }
 func (m *StopResponse) String() string { return proto.CompactTextString(m) }
 func (*StopResponse) ProtoMessage()    {}
 func (*StopResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_rpc_ea34ec0435bf8f95, []int{84}
+	return fileDescriptor_rpc_5df37351f99d795c, []int{84}
 }
 func (m *StopResponse) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_StopResponse.Unmarshal(m, b)
@@ -6103,7 +6103,7 @@ func (m *GraphTopologySubscription) Reset()         { *m = GraphTopologySubscrip
 func (m *GraphTopologySubscription) String() string { return proto.CompactTextString(m) }
 func (*GraphTopologySubscription) ProtoMessage()    {}
 func (*GraphTopologySubscription) Descriptor() ([]byte, []int) {
-	return fileDescriptor_rpc_ea34ec0435bf8f95, []int{85}
+	return fileDescriptor_rpc_5df37351f99d795c, []int{85}
 }
 func (m *GraphTopologySubscription) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_GraphTopologySubscription.Unmarshal(m, b)
@@ -6136,7 +6136,7 @@ func (m *GraphTopologyUpdate) Reset()         { *m = GraphTopologyUpdate{} }
 func (m *GraphTopologyUpdate) String() string { return proto.CompactTextString(m) }
 func (*GraphTopologyUpdate) ProtoMessage()    {}
 func (*GraphTopologyUpdate) Descriptor() ([]byte, []int) {
-	return fileDescriptor_rpc_ea34ec0435bf8f95, []int{86}
+	return fileDescriptor_rpc_5df37351f99d795c, []int{86}
 }
 func (m *GraphTopologyUpdate) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_GraphTopologyUpdate.Unmarshal(m, b)
@@ -6191,7 +6191,7 @@ func (m *NodeUpdate) Reset()         { *m = NodeUpdate{} }
 func (m *NodeUpdate) String() string { return proto.CompactTextString(m) }
 func (*NodeUpdate) ProtoMessage()    {}
 func (*NodeUpdate) Descriptor() ([]byte, []int) {
-	return fileDescriptor_rpc_ea34ec0435bf8f95, []int{87}
+	return fileDescriptor_rpc_5df37351f99d795c, []int{87}
 }
 func (m *NodeUpdate) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_NodeUpdate.Unmarshal(m, b)
@@ -6259,7 +6259,7 @@ func (m *ChannelEdgeUpdate) Reset()         { *m = ChannelEdgeUpdate{} }
 func (m *ChannelEdgeUpdate) String() string { return proto.CompactTextString(m) }
 func (*ChannelEdgeUpdate) ProtoMessage()    {}
 func (*ChannelEdgeUpdate) Descriptor() ([]byte, []int) {
-	return fileDescriptor_rpc_ea34ec0435bf8f95, []int{88}
+	return fileDescriptor_rpc_5df37351f99d795c, []int{88}
 }
 func (m *ChannelEdgeUpdate) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_ChannelEdgeUpdate.Unmarshal(m, b)
@@ -6339,7 +6339,7 @@ func (m *ClosedChannelUpdate) Reset()         { *m = ClosedChannelUpdate{} }
 func (m *ClosedChannelUpdate) String() string { return proto.CompactTextString(m) }
 func (*ClosedChannelUpdate) ProtoMessage()    {}
 func (*ClosedChannelUpdate) Descriptor() ([]byte, []int) {
-	return fileDescriptor_rpc_ea34ec0435bf8f95, []int{89}
+	return fileDescriptor_rpc_5df37351f99d795c, []int{89}
 }
 func (m *ClosedChannelUpdate) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_ClosedChannelUpdate.Unmarshal(m, b)
@@ -6409,7 +6409,7 @@ func (m *HopHint) Reset()         { *m = HopHint{} }
 func (m *HopHint) String() string { return proto.CompactTextString(m) }
 func (*HopHint) ProtoMessage()    {}
 func (*HopHint) Descriptor() ([]byte, []int) {
-	return fileDescriptor_rpc_ea34ec0435bf8f95, []int{90}
+	return fileDescriptor_rpc_5df37351f99d795c, []int{90}
 }
 func (m *HopHint) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_HopHint.Unmarshal(m, b)
@@ -6478,7 +6478,7 @@ func (m *RouteHint) Reset()         { *m = RouteHint{} }
 func (m *RouteHint) String() string { return proto.CompactTextString(m) }
 func (*RouteHint) ProtoMessage()    {}
 func (*RouteHint) Descriptor() ([]byte, []int) {
-	return fileDescriptor_rpc_ea34ec0435bf8f95, []int{91}
+	return fileDescriptor_rpc_5df37351f99d795c, []int{91}
 }
 func (m *RouteHint) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_RouteHint.Unmarshal(m, b)
@@ -6593,7 +6593,7 @@ func (m *Invoice) Reset()         { *m = Invoice{} }
 func (m *Invoice) String() string { return proto.CompactTextString(m) }
 func (*Invoice) ProtoMessage()    {}
 func (*Invoice) Descriptor() ([]byte, []int) {
-	return fileDescriptor_rpc_ea34ec0435bf8f95, []int{92}
+	return fileDescriptor_rpc_5df37351f99d795c, []int{92}
 }
 func (m *Invoice) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_Invoice.Unmarshal(m, b)
@@ -6785,7 +6785,7 @@ func (m *AddInvoiceResponse) Reset()         { *m = AddInvoiceResponse{} }
 func (m *AddInvoiceResponse) String() string { return proto.CompactTextString(m) }
 func (*AddInvoiceResponse) ProtoMessage()    {}
 func (*AddInvoiceResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_rpc_ea34ec0435bf8f95, []int{93}
+	return fileDescriptor_rpc_5df37351f99d795c, []int{93}
 }
 func (m *AddInvoiceResponse) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_AddInvoiceResponse.Unmarshal(m, b)
@@ -6842,7 +6842,7 @@ func (m *PaymentHash) Reset()         { *m = PaymentHash{} }
 func (m *PaymentHash) String() string { return proto.CompactTextString(m) }
 func (*PaymentHash) ProtoMessage()    {}
 func (*PaymentHash) Descriptor() ([]byte, []int) {
-	return fileDescriptor_rpc_ea34ec0435bf8f95, []int{94}
+	return fileDescriptor_rpc_5df37351f99d795c, []int{94}
 }
 func (m *PaymentHash) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_PaymentHash.Unmarshal(m, b)
@@ -6898,7 +6898,7 @@ func (m *ListInvoiceRequest) Reset()         { *m = ListInvoiceRequest{} }
 func (m *ListInvoiceRequest) String() string { return proto.CompactTextString(m) }
 func (*ListInvoiceRequest) ProtoMessage()    {}
 func (*ListInvoiceRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_rpc_ea34ec0435bf8f95, []int{95}
+	return fileDescriptor_rpc_5df37351f99d795c, []int{95}
 }
 func (m *ListInvoiceRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_ListInvoiceRequest.Unmarshal(m, b)
@@ -6968,7 +6968,7 @@ func (m *ListInvoiceResponse) Reset()         { *m = ListInvoiceResponse{} }
 func (m *ListInvoiceResponse) String() string { return proto.CompactTextString(m) }
 func (*ListInvoiceResponse) ProtoMessage()    {}
 func (*ListInvoiceResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_rpc_ea34ec0435bf8f95, []int{96}
+	return fileDescriptor_rpc_5df37351f99d795c, []int{96}
 }
 func (m *ListInvoiceResponse) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_ListInvoiceResponse.Unmarshal(m, b)
@@ -7031,7 +7031,7 @@ func (m *InvoiceSubscription) Reset()         { *m = InvoiceSubscription{} }
 func (m *InvoiceSubscription) String() string { return proto.CompactTextString(m) }
 func (*InvoiceSubscription) ProtoMessage()    {}
 func (*InvoiceSubscription) Descriptor() ([]byte, []int) {
-	return fileDescriptor_rpc_ea34ec0435bf8f95, []int{97}
+	return fileDescriptor_rpc_5df37351f99d795c, []int{97}
 }
 func (m *InvoiceSubscription) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_InvoiceSubscription.Unmarshal(m, b)
@@ -7091,7 +7091,7 @@ func (m *Payment) Reset()         { *m = Payment{} }
 func (m *Payment) String() string { return proto.CompactTextString(m) }
 func (*Payment) ProtoMessage()    {}
 func (*Payment) Descriptor() ([]byte, []int) {
-	return fileDescriptor_rpc_ea34ec0435bf8f95, []int{98}
+	return fileDescriptor_rpc_5df37351f99d795c, []int{98}
 }
 func (m *Payment) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_Payment.Unmarshal(m, b)
@@ -7178,7 +7178,7 @@ func (m *ListPaymentsRequest) Reset()         { *m = ListPaymentsRequest{} }
 func (m *ListPaymentsRequest) String() string { return proto.CompactTextString(m) }
 func (*ListPaymentsRequest) ProtoMessage()    {}
 func (*ListPaymentsRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_rpc_ea34ec0435bf8f95, []int{99}
+	return fileDescriptor_rpc_5df37351f99d795c, []int{99}
 }
 func (m *ListPaymentsRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_ListPaymentsRequest.Unmarshal(m, b)
@@ -7210,7 +7210,7 @@ func (m *ListPaymentsResponse) Reset()         { *m = ListPaymentsResponse{} }
 func (m *ListPaymentsResponse) String() string { return proto.CompactTextString(m) }
 func (*ListPaymentsResponse) ProtoMessage()    {}
 func (*ListPaymentsResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_rpc_ea34ec0435bf8f95, []int{100}
+	return fileDescriptor_rpc_5df37351f99d795c, []int{100}
 }
 func (m *ListPaymentsResponse) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_ListPaymentsResponse.Unmarshal(m, b)
@@ -7247,7 +7247,7 @@ func (m *DeleteAllPaymentsRequest) Reset()         { *m = DeleteAllPaymentsReque
 func (m *DeleteAllPaymentsRequest) String() string { return proto.CompactTextString(m) }
 func (*DeleteAllPaymentsRequest) ProtoMessage()    {}
 func (*DeleteAllPaymentsRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_rpc_ea34ec0435bf8f95, []int{101}
+	return fileDescriptor_rpc_5df37351f99d795c, []int{101}
 }
 func (m *DeleteAllPaymentsRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_DeleteAllPaymentsRequest.Unmarshal(m, b)
@@ -7277,7 +7277,7 @@ func (m *DeleteAllPaymentsResponse) Reset()         { *m = DeleteAllPaymentsResp
 func (m *DeleteAllPaymentsResponse) String() string { return proto.CompactTextString(m) }
 func (*DeleteAllPaymentsResponse) ProtoMessage()    {}
 func (*DeleteAllPaymentsResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_rpc_ea34ec0435bf8f95, []int{102}
+	return fileDescriptor_rpc_5df37351f99d795c, []int{102}
 }
 func (m *DeleteAllPaymentsResponse) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_DeleteAllPaymentsResponse.Unmarshal(m, b)
@@ -7308,7 +7308,7 @@ func (m *AbandonChannelRequest) Reset()         { *m = AbandonChannelRequest{} }
 func (m *AbandonChannelRequest) String() string { return proto.CompactTextString(m) }
 func (*AbandonChannelRequest) ProtoMessage()    {}
 func (*AbandonChannelRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_rpc_ea34ec0435bf8f95, []int{103}
+	return fileDescriptor_rpc_5df37351f99d795c, []int{103}
 }
 func (m *AbandonChannelRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_AbandonChannelRequest.Unmarshal(m, b)
@@ -7345,7 +7345,7 @@ func (m *AbandonChannelResponse) Reset()         { *m = AbandonChannelResponse{}
 func (m *AbandonChannelResponse) String() string { return proto.CompactTextString(m) }
 func (*AbandonChannelResponse) ProtoMessage()    {}
 func (*AbandonChannelResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_rpc_ea34ec0435bf8f95, []int{104}
+	return fileDescriptor_rpc_5df37351f99d795c, []int{104}
 }
 func (m *AbandonChannelResponse) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_AbandonChannelResponse.Unmarshal(m, b)
@@ -7377,7 +7377,7 @@ func (m *DebugLevelRequest) Reset()         { *m = DebugLevelRequest{} }
 func (m *DebugLevelRequest) String() string { return proto.CompactTextString(m) }
 func (*DebugLevelRequest) ProtoMessage()    {}
 func (*DebugLevelRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_rpc_ea34ec0435bf8f95, []int{105}
+	return fileDescriptor_rpc_5df37351f99d795c, []int{105}
 }
 func (m *DebugLevelRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_DebugLevelRequest.Unmarshal(m, b)
@@ -7422,7 +7422,7 @@ func (m *DebugLevelResponse) Reset()         { *m = DebugLevelResponse{} }
 func (m *DebugLevelResponse) String() string { return proto.CompactTextString(m) }
 func (*DebugLevelResponse) ProtoMessage()    {}
 func (*DebugLevelResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_rpc_ea34ec0435bf8f95, []int{106}
+	return fileDescriptor_rpc_5df37351f99d795c, []int{106}
 }
 func (m *DebugLevelResponse) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_DebugLevelResponse.Unmarshal(m, b)
@@ -7461,7 +7461,7 @@ func (m *PayReqString) Reset()         { *m = PayReqString{} }
 func (m *PayReqString) String() string { return proto.CompactTextString(m) }
 func (*PayReqString) ProtoMessage()    {}
 func (*PayReqString) Descriptor() ([]byte, []int) {
-	return fileDescriptor_rpc_ea34ec0435bf8f95, []int{107}
+	return fileDescriptor_rpc_5df37351f99d795c, []int{107}
 }
 func (m *PayReqString) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_PayReqString.Unmarshal(m, b)
@@ -7508,7 +7508,7 @@ func (m *PayReq) Reset()         { *m = PayReq{} }
 func (m *PayReq) String() string { return proto.CompactTextString(m) }
 func (*PayReq) ProtoMessage()    {}
 func (*PayReq) Descriptor() ([]byte, []int) {
-	return fileDescriptor_rpc_ea34ec0435bf8f95, []int{108}
+	return fileDescriptor_rpc_5df37351f99d795c, []int{108}
 }
 func (m *PayReq) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_PayReq.Unmarshal(m, b)
@@ -7608,7 +7608,7 @@ func (m *FeeReportRequest) Reset()         { *m = FeeReportRequest{} }
 func (m *FeeReportRequest) String() string { return proto.CompactTextString(m) }
 func (*FeeReportRequest) ProtoMessage()    {}
 func (*FeeReportRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_rpc_ea34ec0435bf8f95, []int{109}
+	return fileDescriptor_rpc_5df37351f99d795c, []int{109}
 }
 func (m *FeeReportRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_FeeReportRequest.Unmarshal(m, b)
@@ -7646,7 +7646,7 @@ func (m *ChannelFeeReport) Reset()         { *m = ChannelFeeReport{} }
 func (m *ChannelFeeReport) String() string { return proto.CompactTextString(m) }
 func (*ChannelFeeReport) ProtoMessage()    {}
 func (*ChannelFeeReport) Descriptor() ([]byte, []int) {
-	return fileDescriptor_rpc_ea34ec0435bf8f95, []int{110}
+	return fileDescriptor_rpc_5df37351f99d795c, []int{110}
 }
 func (m *ChannelFeeReport) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_ChannelFeeReport.Unmarshal(m, b)
@@ -7712,7 +7712,7 @@ func (m *FeeReportResponse) Reset()         { *m = FeeReportResponse{} }
 func (m *FeeReportResponse) String() string { return proto.CompactTextString(m) }
 func (*FeeReportResponse) ProtoMessage()    {}
 func (*FeeReportResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_rpc_ea34ec0435bf8f95, []int{111}
+	return fileDescriptor_rpc_5df37351f99d795c, []int{111}
 }
 func (m *FeeReportResponse) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_FeeReportResponse.Unmarshal(m, b)
@@ -7780,7 +7780,7 @@ func (m *PolicyUpdateRequest) Reset()         { *m = PolicyUpdateRequest{} }
 func (m *PolicyUpdateRequest) String() string { return proto.CompactTextString(m) }
 func (*PolicyUpdateRequest) ProtoMessage()    {}
 func (*PolicyUpdateRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_rpc_ea34ec0435bf8f95, []int{112}
+	return fileDescriptor_rpc_5df37351f99d795c, []int{112}
 }
 func (m *PolicyUpdateRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_PolicyUpdateRequest.Unmarshal(m, b)
@@ -7941,7 +7941,7 @@ func (m *PolicyUpdateResponse) Reset()         { *m = PolicyUpdateResponse{} }
 func (m *PolicyUpdateResponse) String() string { return proto.CompactTextString(m) }
 func (*PolicyUpdateResponse) ProtoMessage()    {}
 func (*PolicyUpdateResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_rpc_ea34ec0435bf8f95, []int{113}
+	return fileDescriptor_rpc_5df37351f99d795c, []int{113}
 }
 func (m *PolicyUpdateResponse) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_PolicyUpdateResponse.Unmarshal(m, b)
@@ -7979,7 +7979,7 @@ func (m *ForwardingHistoryRequest) Reset()         { *m = ForwardingHistoryReque
 func (m *ForwardingHistoryRequest) String() string { return proto.CompactTextString(m) }
 func (*ForwardingHistoryRequest) ProtoMessage()    {}
 func (*ForwardingHistoryRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_rpc_ea34ec0435bf8f95, []int{114}
+	return fileDescriptor_rpc_5df37351f99d795c, []int{114}
 }
 func (m *ForwardingHistoryRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_ForwardingHistoryRequest.Unmarshal(m, b)
@@ -8051,7 +8051,7 @@ func (m *ForwardingEvent) Reset()         { *m = ForwardingEvent{} }
 func (m *ForwardingEvent) String() string { return proto.CompactTextString(m) }
 func (*ForwardingEvent) ProtoMessage()    {}
 func (*ForwardingEvent) Descriptor() ([]byte, []int) {
-	return fileDescriptor_rpc_ea34ec0435bf8f95, []int{115}
+	return fileDescriptor_rpc_5df37351f99d795c, []int{115}
 }
 func (m *ForwardingEvent) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_ForwardingEvent.Unmarshal(m, b)
@@ -8134,7 +8134,7 @@ func (m *ForwardingHistoryResponse) Reset()         { *m = ForwardingHistoryResp
 func (m *ForwardingHistoryResponse) String() string { return proto.CompactTextString(m) }
 func (*ForwardingHistoryResponse) ProtoMessage()    {}
 func (*ForwardingHistoryResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_rpc_ea34ec0435bf8f95, []int{116}
+	return fileDescriptor_rpc_5df37351f99d795c, []int{116}
 }
 func (m *ForwardingHistoryResponse) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_ForwardingHistoryResponse.Unmarshal(m, b)
@@ -8169,7 +8169,7 @@ func (m *ForwardingHistoryResponse) GetLastOffsetIndex() uint32 {
 }
 
 type ExportChannelBackupRequest struct {
-	// / The target chanenl point to obtain a back up for.
+	// / The target channel point to obtain a back up for.
 	ChanPoint            *ChannelPoint `protobuf:"bytes,1,opt,name=chan_point,json=chanPoint,proto3" json:"chan_point,omitempty"`
 	XXX_NoUnkeyedLiteral struct{}      `json:"-"`
 	XXX_unrecognized     []byte        `json:"-"`
@@ -8180,7 +8180,7 @@ func (m *ExportChannelBackupRequest) Reset()         { *m = ExportChannelBackupR
 func (m *ExportChannelBackupRequest) String() string { return proto.CompactTextString(m) }
 func (*ExportChannelBackupRequest) ProtoMessage()    {}
 func (*ExportChannelBackupRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_rpc_ea34ec0435bf8f95, []int{117}
+	return fileDescriptor_rpc_5df37351f99d795c, []int{117}
 }
 func (m *ExportChannelBackupRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_ExportChannelBackupRequest.Unmarshal(m, b)
@@ -8213,7 +8213,7 @@ type ChannelBackup struct {
 	ChanPoint *ChannelPoint `protobuf:"bytes,1,opt,name=chan_point,proto3" json:"chan_point,omitempty"`
 	// *
 	// Is an encrypted single-chan backup. this can be passed to
-	// RestoreChannelBackups, or the WalletUnlocker Innit and Unlock methods in
+	// RestoreChannelBackups, or the WalletUnlocker Init and Unlock methods in
 	// order to trigger the recovery protocol.
 	ChanBackup           []byte   `protobuf:"bytes,2,opt,name=chan_backup,proto3" json:"chan_backup,omitempty"`
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
@@ -8225,7 +8225,7 @@ func (m *ChannelBackup) Reset()         { *m = ChannelBackup{} }
 func (m *ChannelBackup) String() string { return proto.CompactTextString(m) }
 func (*ChannelBackup) ProtoMessage()    {}
 func (*ChannelBackup) Descriptor() ([]byte, []int) {
-	return fileDescriptor_rpc_ea34ec0435bf8f95, []int{118}
+	return fileDescriptor_rpc_5df37351f99d795c, []int{118}
 }
 func (m *ChannelBackup) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_ChannelBackup.Unmarshal(m, b)
@@ -8277,7 +8277,7 @@ func (m *MultiChanBackup) Reset()         { *m = MultiChanBackup{} }
 func (m *MultiChanBackup) String() string { return proto.CompactTextString(m) }
 func (*MultiChanBackup) ProtoMessage()    {}
 func (*MultiChanBackup) Descriptor() ([]byte, []int) {
-	return fileDescriptor_rpc_ea34ec0435bf8f95, []int{119}
+	return fileDescriptor_rpc_5df37351f99d795c, []int{119}
 }
 func (m *MultiChanBackup) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_MultiChanBackup.Unmarshal(m, b)
@@ -8321,7 +8321,7 @@ func (m *ChanBackupExportRequest) Reset()         { *m = ChanBackupExportRequest
 func (m *ChanBackupExportRequest) String() string { return proto.CompactTextString(m) }
 func (*ChanBackupExportRequest) ProtoMessage()    {}
 func (*ChanBackupExportRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_rpc_ea34ec0435bf8f95, []int{120}
+	return fileDescriptor_rpc_5df37351f99d795c, []int{120}
 }
 func (m *ChanBackupExportRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_ChanBackupExportRequest.Unmarshal(m, b)
@@ -8359,7 +8359,7 @@ func (m *ChanBackupSnapshot) Reset()         { *m = ChanBackupSnapshot{} }
 func (m *ChanBackupSnapshot) String() string { return proto.CompactTextString(m) }
 func (*ChanBackupSnapshot) ProtoMessage()    {}
 func (*ChanBackupSnapshot) Descriptor() ([]byte, []int) {
-	return fileDescriptor_rpc_ea34ec0435bf8f95, []int{121}
+	return fileDescriptor_rpc_5df37351f99d795c, []int{121}
 }
 func (m *ChanBackupSnapshot) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_ChanBackupSnapshot.Unmarshal(m, b)
@@ -8406,7 +8406,7 @@ func (m *ChannelBackups) Reset()         { *m = ChannelBackups{} }
 func (m *ChannelBackups) String() string { return proto.CompactTextString(m) }
 func (*ChannelBackups) ProtoMessage()    {}
 func (*ChannelBackups) Descriptor() ([]byte, []int) {
-	return fileDescriptor_rpc_ea34ec0435bf8f95, []int{122}
+	return fileDescriptor_rpc_5df37351f99d795c, []int{122}
 }
 func (m *ChannelBackups) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_ChannelBackups.Unmarshal(m, b)
@@ -8447,7 +8447,7 @@ func (m *RestoreChanBackupRequest) Reset()         { *m = RestoreChanBackupReque
 func (m *RestoreChanBackupRequest) String() string { return proto.CompactTextString(m) }
 func (*RestoreChanBackupRequest) ProtoMessage()    {}
 func (*RestoreChanBackupRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_rpc_ea34ec0435bf8f95, []int{123}
+	return fileDescriptor_rpc_5df37351f99d795c, []int{123}
 }
 func (m *RestoreChanBackupRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_RestoreChanBackupRequest.Unmarshal(m, b)
@@ -8584,7 +8584,7 @@ func (m *RestoreBackupResponse) Reset()         { *m = RestoreBackupResponse{} }
 func (m *RestoreBackupResponse) String() string { return proto.CompactTextString(m) }
 func (*RestoreBackupResponse) ProtoMessage()    {}
 func (*RestoreBackupResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_rpc_ea34ec0435bf8f95, []int{124}
+	return fileDescriptor_rpc_5df37351f99d795c, []int{124}
 }
 func (m *RestoreBackupResponse) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_RestoreBackupResponse.Unmarshal(m, b)
@@ -8614,7 +8614,7 @@ func (m *ChannelBackupSubscription) Reset()         { *m = ChannelBackupSubscrip
 func (m *ChannelBackupSubscription) String() string { return proto.CompactTextString(m) }
 func (*ChannelBackupSubscription) ProtoMessage()    {}
 func (*ChannelBackupSubscription) Descriptor() ([]byte, []int) {
-	return fileDescriptor_rpc_ea34ec0435bf8f95, []int{125}
+	return fileDescriptor_rpc_5df37351f99d795c, []int{125}
 }
 func (m *ChannelBackupSubscription) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_ChannelBackupSubscription.Unmarshal(m, b)
@@ -8644,7 +8644,7 @@ func (m *VerifyChanBackupResponse) Reset()         { *m = VerifyChanBackupRespon
 func (m *VerifyChanBackupResponse) String() string { return proto.CompactTextString(m) }
 func (*VerifyChanBackupResponse) ProtoMessage()    {}
 func (*VerifyChanBackupResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_rpc_ea34ec0435bf8f95, []int{126}
+	return fileDescriptor_rpc_5df37351f99d795c, []int{126}
 }
 func (m *VerifyChanBackupResponse) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_VerifyChanBackupResponse.Unmarshal(m, b)
@@ -9240,7 +9240,7 @@ type LightningClient interface {
 	// * lncli: `queryroutes`
 	// QueryRoutes attempts to query the daemon's Channel Router for a possible
 	// route to a target destination capable of carrying a specific amount of
-	// satoshis. The retuned route contains the full details required to craft and
+	// satoshis. The returned route contains the full details required to craft and
 	// send an HTLC, also including the necessary information that should be
 	// present within the Sphinx packet encapsulated within the HTLC.
 	QueryRoutes(ctx context.Context, in *QueryRoutesRequest, opts ...grpc.CallOption) (*QueryRoutesResponse, error)
@@ -10191,7 +10191,7 @@ type LightningServer interface {
 	// * lncli: `queryroutes`
 	// QueryRoutes attempts to query the daemon's Channel Router for a possible
 	// route to a target destination capable of carrying a specific amount of
-	// satoshis. The retuned route contains the full details required to craft and
+	// satoshis. The returned route contains the full details required to craft and
 	// send an HTLC, also including the necessary information that should be
 	// present within the Sphinx packet encapsulated within the HTLC.
 	QueryRoutes(context.Context, *QueryRoutesRequest) (*QueryRoutesResponse, error)
@@ -11436,9 +11436,9 @@ var _Lightning_serviceDesc = grpc.ServiceDesc{
 	Metadata: "rpc.proto",
 }
 
-func init() { proto.RegisterFile("rpc.proto", fileDescriptor_rpc_ea34ec0435bf8f95) }
+func init() { proto.RegisterFile("rpc.proto", fileDescriptor_rpc_5df37351f99d795c) }
 
-var fileDescriptor_rpc_ea34ec0435bf8f95 = []byte{
+var fileDescriptor_rpc_5df37351f99d795c = []byte{
 	// 7715 bytes of a gzipped FileDescriptorProto
 	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xbc, 0x7c, 0x5d, 0x6c, 0x24, 0xd9,
 	0x59, 0xa8, 0xab, 0x7f, 0xec, 0xee, 0xaf, 0xdb, 0x76, 0xfb, 0xf8, 0xaf, 0xa7, 0x67, 0x76, 0xd6,

--- a/lnrpc/rpc.proto
+++ b/lnrpc/rpc.proto
@@ -175,7 +175,7 @@ message UnlockWalletRequest {
     /**
     recovery_window is an optional argument specifying the address lookahead
     when restoring a wallet seed. The recovery window applies to each
-    invdividual branch of the BIP44 derivation paths. Supplying a recovery
+    individual branch of the BIP44 derivation paths. Supplying a recovery
     window of zero indicates that no addresses should be recovered, such after
     the first initialization of the wallet.
     */
@@ -621,7 +621,7 @@ service Lightning {
     /** lncli: `queryroutes`
     QueryRoutes attempts to query the daemon's Channel Router for a possible
     route to a target destination capable of carrying a specific amount of
-    satoshis. The retuned route contains the full details required to craft and
+    satoshis. The returned route contains the full details required to craft and
     send an HTLC, also including the necessary information that should be
     present within the Sphinx packet encapsulated within the HTLC.
     */
@@ -1156,7 +1156,7 @@ message Channel {
     /// True if we were the ones that created the channel.
     bool initiator = 18 [json_name = "initiator"];
 
-    /// A set of flags showing the current state of the cahnnel.
+    /// A set of flags showing the current state of the channel.
     string chan_status_flags = 19 [json_name = "chan_status_flags"];
 }
 
@@ -1517,7 +1517,7 @@ message PendingChannelsResponse {
         /// The balance in satoshis encumbered in this pending channel
         int64 limbo_balance = 3 [ json_name = "limbo_balance" ];
 
-        /// The height at which funds can be sweeped into the wallet
+        /// The height at which funds can be swept into the wallet
         uint32 maturity_height = 4 [ json_name = "maturity_height" ];
 
         /*
@@ -1688,7 +1688,7 @@ message Route {
     /**
     The sum of the fees paid at each hop within the final route.  In the case
     of a one-hop payment, this value will be zero as we don't need to pay a fee
-    it ourself.
+    to ourselves.
     */
     int64 total_fees = 2 [json_name = "total_fees", deprecated = true];
 
@@ -2288,7 +2288,7 @@ message ForwardingHistoryResponse {
 }
 
 message ExportChannelBackupRequest {
-    /// The target chanenl point to obtain a back up for.
+    /// The target channel point to obtain a back up for.
     ChannelPoint chan_point = 1;
 }
 
@@ -2300,7 +2300,7 @@ message ChannelBackup {
 
     /**
     Is an encrypted single-chan backup. this can be passed to
-    RestoreChannelBackups, or the WalletUnlocker Innit and Unlock methods in
+    RestoreChannelBackups, or the WalletUnlocker Init and Unlock methods in
     order to trigger the recovery protocol.
     */
     bytes chan_backup = 2 [ json_name = "chan_backup" ];

--- a/lnrpc/rpc.swagger.json
+++ b/lnrpc/rpc.swagger.json
@@ -649,7 +649,7 @@
     },
     "/v1/graph/routes/{pub_key}/{amt}": {
       "get": {
-        "summary": "* lncli: `queryroutes`\nQueryRoutes attempts to query the daemon's Channel Router for a possible\nroute to a target destination capable of carrying a specific amount of\nsatoshis. The retuned route contains the full details required to craft and\nsend an HTLC, also including the necessary information that should be\npresent within the Sphinx packet encapsulated within the HTLC.",
+        "summary": "* lncli: `queryroutes`\nQueryRoutes attempts to query the daemon's Channel Router for a possible\nroute to a target destination capable of carrying a specific amount of\nsatoshis. The returned route contains the full details required to craft and\nsend an HTLC, also including the necessary information that should be\npresent within the Sphinx packet encapsulated within the HTLC.",
         "operationId": "QueryRoutes",
         "responses": {
           "200": {
@@ -1339,7 +1339,7 @@
         "maturity_height": {
           "type": "integer",
           "format": "int64",
-          "title": "/ The height at which funds can be sweeped into the wallet"
+          "title": "/ The height at which funds can be swept into the wallet"
         },
         "blocks_til_maturity": {
           "type": "integer",
@@ -1597,7 +1597,7 @@
         },
         "chan_status_flags": {
           "type": "string",
-          "description": "/ A set of flags showing the current state of the cahnnel."
+          "description": "/ A set of flags showing the current state of the channel."
         }
       }
     },
@@ -1611,7 +1611,7 @@
         "chan_backup": {
           "type": "string",
           "format": "byte",
-          "description": "*\nIs an encrypted single-chan backup. this can be passed to\nRestoreChannelBackups, or the WalletUnlocker Innit and Unlock methods in\norder to trigger the recovery protocol."
+          "description": "*\nIs an encrypted single-chan backup. this can be passed to\nRestoreChannelBackups, or the WalletUnlocker Init and Unlock methods in\norder to trigger the recovery protocol."
         }
       }
     },
@@ -3019,7 +3019,7 @@
         "total_fees": {
           "type": "string",
           "format": "int64",
-          "description": "*\nThe sum of the fees paid at each hop within the final route.  In the case\nof a one-hop payment, this value will be zero as we don't need to pay a fee\nit ourself."
+          "description": "*\nThe sum of the fees paid at each hop within the final route.  In the case\nof a one-hop payment, this value will be zero as we don't need to pay a fee\nto ourselves."
         },
         "total_amt": {
           "type": "string",
@@ -3312,7 +3312,7 @@
         "recovery_window": {
           "type": "integer",
           "format": "int32",
-          "description": "*\nrecovery_window is an optional argument specifying the address lookahead\nwhen restoring a wallet seed. The recovery window applies to each\ninvdividual branch of the BIP44 derivation paths. Supplying a recovery\nwindow of zero indicates that no addresses should be recovered, such after\nthe first initialization of the wallet."
+          "description": "*\nrecovery_window is an optional argument specifying the address lookahead\nwhen restoring a wallet seed. The recovery window applies to each\nindividual branch of the BIP44 derivation paths. Supplying a recovery\nwindow of zero indicates that no addresses should be recovered, such after\nthe first initialization of the wallet."
         },
         "channel_backups": {
           "$ref": "#/definitions/lnrpcChanBackupSnapshot",


### PR DESCRIPTION
This fixes typos in the comments of the rpc proto definition.

These are what I came across when reading through the API documentation.