### PR TITLE
multi: always fail pending htlcs on commitment confirmation

### DIFF
--- a/breacharbiter_test.go
+++ b/breacharbiter_test.go
@@ -1946,7 +1946,7 @@ func createHTLC(data int, amount lnwire.MilliSatoshi) (*lnwire.UpdateAddHTLC, [3
 // pending updates.
 // TODO(conner) remove code duplication
 func forceStateTransition(chanA, chanB *lnwallet.LightningChannel) error {
-	aliceSig, aliceHtlcSigs, err := chanA.SignNextCommitment()
+	aliceSig, aliceHtlcSigs, _, err := chanA.SignNextCommitment()
 	if err != nil {
 		return err
 	}
@@ -1958,12 +1958,13 @@ func forceStateTransition(chanA, chanB *lnwallet.LightningChannel) error {
 	if err != nil {
 		return err
 	}
-	bobSig, bobHtlcSigs, err := chanB.SignNextCommitment()
+	bobSig, bobHtlcSigs, _, err := chanB.SignNextCommitment()
 	if err != nil {
 		return err
 	}
 
-	if _, _, _, err := chanA.ReceiveRevocation(bobRevocation); err != nil {
+	_, _, _, _, err = chanA.ReceiveRevocation(bobRevocation)
+	if err != nil {
 		return err
 	}
 	if err := chanA.ReceiveNewCommitment(bobSig, bobHtlcSigs); err != nil {
@@ -1974,7 +1975,8 @@ func forceStateTransition(chanA, chanB *lnwallet.LightningChannel) error {
 	if err != nil {
 		return err
 	}
-	if _, _, _, err := chanB.ReceiveRevocation(aliceRevocation); err != nil {
+	_, _, _, _, err = chanB.ReceiveRevocation(aliceRevocation)
+	if err != nil {
 		return err
 	}
 

--- a/contractcourt/briefcase_test.go
+++ b/contractcourt/briefcase_test.go
@@ -15,11 +15,8 @@ import (
 	"github.com/btcsuite/btcd/txscript"
 	"github.com/btcsuite/btcd/wire"
 	"github.com/coreos/bbolt"
-	"github.com/davecgh/go-spew/spew"
-	"github.com/lightningnetwork/lnd/channeldb"
 	"github.com/lightningnetwork/lnd/input"
 	"github.com/lightningnetwork/lnd/lnwallet"
-	"github.com/lightningnetwork/lnd/lnwire"
 )
 
 var (
@@ -562,133 +559,6 @@ func TestContractResolutionsStorage(t *testing.T) {
 	_, err = testLog.FetchContractResolutions()
 	if err != errScopeBucketNoExist {
 		t.Fatalf("unexpected error: %v", err)
-	}
-}
-
-// TestChainActionStorage tests that were able to properly store a set of chain
-// actions, and then retrieve the same set of chain actions from disk.
-func TestChainActionStorage(t *testing.T) {
-	t.Parallel()
-
-	// First, we'll create a test instance of the ArbitratorLog
-	// implementation backed by boltdb.
-	testLog, cleanUp, err := newTestBoltArbLog(
-		testChainHash, testChanPoint2,
-	)
-	if err != nil {
-		t.Fatalf("unable to create test log: %v", err)
-	}
-	defer cleanUp()
-
-	chainActions := ChainActionMap{
-		NoAction: []channeldb.HTLC{
-			{
-				RHash:         testPreimage,
-				Amt:           lnwire.MilliSatoshi(prand.Uint64()),
-				RefundTimeout: prand.Uint32(),
-				OutputIndex:   int32(prand.Uint32()),
-				Incoming:      true,
-				HtlcIndex:     prand.Uint64(),
-				LogIndex:      prand.Uint64(),
-				OnionBlob:     make([]byte, 0),
-				Signature:     make([]byte, 0),
-			},
-		},
-		HtlcTimeoutAction: []channeldb.HTLC{
-			{
-				RHash:         testPreimage,
-				Amt:           lnwire.MilliSatoshi(prand.Uint64()),
-				RefundTimeout: prand.Uint32(),
-				OutputIndex:   int32(prand.Uint32()),
-				Incoming:      true,
-				HtlcIndex:     prand.Uint64(),
-				LogIndex:      prand.Uint64(),
-				OnionBlob:     make([]byte, 0),
-				Signature:     make([]byte, 0),
-			},
-		},
-		HtlcClaimAction: []channeldb.HTLC{
-			{
-				RHash:         testPreimage,
-				Amt:           lnwire.MilliSatoshi(prand.Uint64()),
-				RefundTimeout: prand.Uint32(),
-				OutputIndex:   int32(prand.Uint32()),
-				Incoming:      true,
-				HtlcIndex:     prand.Uint64(),
-				LogIndex:      prand.Uint64(),
-				OnionBlob:     make([]byte, 0),
-				Signature:     make([]byte, 0),
-			},
-		},
-		HtlcFailNowAction: []channeldb.HTLC{
-			{
-				RHash:         testPreimage,
-				Amt:           lnwire.MilliSatoshi(prand.Uint64()),
-				RefundTimeout: prand.Uint32(),
-				OutputIndex:   int32(prand.Uint32()),
-				Incoming:      true,
-				HtlcIndex:     prand.Uint64(),
-				LogIndex:      prand.Uint64(),
-				OnionBlob:     make([]byte, 0),
-				Signature:     make([]byte, 0),
-			},
-		},
-		HtlcOutgoingWatchAction: []channeldb.HTLC{
-			{
-				RHash:         testPreimage,
-				Amt:           lnwire.MilliSatoshi(prand.Uint64()),
-				RefundTimeout: prand.Uint32(),
-				OutputIndex:   int32(prand.Uint32()),
-				Incoming:      true,
-				HtlcIndex:     prand.Uint64(),
-				LogIndex:      prand.Uint64(),
-				OnionBlob:     make([]byte, 0),
-				Signature:     make([]byte, 0),
-			},
-		},
-		HtlcIncomingWatchAction: []channeldb.HTLC{
-			{
-				RHash:         testPreimage,
-				Amt:           lnwire.MilliSatoshi(prand.Uint64()),
-				RefundTimeout: prand.Uint32(),
-				OutputIndex:   int32(prand.Uint32()),
-				Incoming:      true,
-				HtlcIndex:     prand.Uint64(),
-				LogIndex:      prand.Uint64(),
-				OnionBlob:     make([]byte, 0),
-				Signature:     make([]byte, 0),
-			},
-		},
-	}
-
-	// With our set of test chain actions constructed, we'll now insert
-	// them into the database, retrieve them, then assert equality with the
-	// set of chain actions create above.
-	if err := testLog.LogChainActions(chainActions); err != nil {
-		t.Fatalf("unable to write chain actions: %v", err)
-	}
-	diskActions, err := testLog.FetchChainActions()
-	if err != nil {
-		t.Fatalf("unable to read chain actions: %v", err)
-	}
-
-	for k, contracts := range chainActions {
-		diskContracts := diskActions[k]
-		if !reflect.DeepEqual(contracts, diskContracts) {
-			t.Fatalf("chain action mismatch: expected %v, got %v",
-				spew.Sdump(contracts), spew.Sdump(diskContracts))
-		}
-	}
-
-	// We'll now delete the state, then attempt to retrieve the set of
-	// chain actions, no resolutions should be found.
-	if err := testLog.WipeHistory(); err != nil {
-		t.Fatalf("unable to wipe log: %v", err)
-	}
-	actions, err := testLog.FetchChainActions()
-	if len(actions) != 0 {
-		t.Fatalf("expected no chain actions, instead found: %v",
-			len(actions))
 	}
 }
 

--- a/contractcourt/chain_arbitrator.go
+++ b/contractcourt/chain_arbitrator.go
@@ -463,7 +463,7 @@ func (c *ChainArbitrator) Start() error {
 
 		// We can also leave off the set of HTLC's here as since the
 		// channel is already in the process of being full resolved, no
-		// new HTLC's we be added.
+		// new HTLC's will be added.
 		c.activeChannels[chanPoint] = NewChannelArbitrator(
 			arbCfg, nil, chanLog,
 		)

--- a/contractcourt/chain_watcher.go
+++ b/contractcourt/chain_watcher.go
@@ -54,7 +54,7 @@ type RemoteUnilateralCloseInfo struct {
 	*lnwallet.UnilateralCloseSummary
 
 	// CommitSet is the set of known valid commitments at the time the
-	// remote party's commitemnt hit the chain.
+	// remote party's commitment hit the chain.
 	CommitSet CommitSet
 }
 

--- a/contractcourt/chain_watcher_test.go
+++ b/contractcourt/chain_watcher_test.go
@@ -104,7 +104,7 @@ func TestChainWatcherRemoteUnilateralClose(t *testing.T) {
 
 	// We should get a new spend event over the remote unilateral close
 	// event channel.
-	var uniClose *lnwallet.UnilateralCloseSummary
+	var uniClose *RemoteUnilateralCloseInfo
 	select {
 	case uniClose = <-chanEvents.RemoteUnilateralClosure:
 	case <-time.After(time.Second * 15):
@@ -186,7 +186,7 @@ func TestChainWatcherRemoteUnilateralClosePendingCommit(t *testing.T) {
 
 	// With the HTLC added, we'll now manually initiate a state transition
 	// from Alice to Bob.
-	_, _, err = aliceChannel.SignNextCommitment()
+	_, _, _, err = aliceChannel.SignNextCommitment()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -211,7 +211,7 @@ func TestChainWatcherRemoteUnilateralClosePendingCommit(t *testing.T) {
 
 	// We should get a new spend event over the remote unilateral close
 	// event channel.
-	var uniClose *lnwallet.UnilateralCloseSummary
+	var uniClose *RemoteUnilateralCloseInfo
 	select {
 	case uniClose = <-chanEvents.RemoteUnilateralClosure:
 	case <-time.After(time.Second * 15):
@@ -343,7 +343,7 @@ func TestChainWatcherDataLossProtect(t *testing.T) {
 
 		// We should get a new uni close resolution that indicates we
 		// processed the DLP scenario.
-		var uniClose *lnwallet.UnilateralCloseSummary
+		var uniClose *RemoteUnilateralCloseInfo
 		select {
 		case uniClose = <-chanEvents.RemoteUnilateralClosure:
 			// If we processed this as a DLP case, then the remote

--- a/contractcourt/channel_arbitrator.go
+++ b/contractcourt/channel_arbitrator.go
@@ -693,9 +693,6 @@ func (c *ChannelArbitrator) stateStep(
 			newLogClosure(func() string {
 				return spew.Sdump(chainActions)
 			}))
-		if err := c.log.LogChainActions(chainActions); err != nil {
-			return StateError, closeTx, err
-		}
 
 		// Depending on the type of trigger, we'll either "tunnel"
 		// through to a farther state, or just proceed linearly to the
@@ -838,11 +835,6 @@ func (c *ChannelArbitrator) stateStep(
 	case StateContractClosed:
 		// First, we'll fetch our chain actions, and both sets of
 		// resolutions so we can process them.
-		_, err := c.log.FetchChainActions()
-		if err != nil {
-			log.Errorf("unable to fetch chain actions: %v", err)
-			return StateError, closeTx, err
-		}
 		contractResolutions, err := c.log.FetchContractResolutions()
 		if err != nil {
 			log.Errorf("unable to fetch contract resolutions: %v",

--- a/contractcourt/channel_arbitrator.go
+++ b/contractcourt/channel_arbitrator.go
@@ -895,11 +895,14 @@ func (c *ChannelArbitrator) stateStep(
 
 		// With the commitment broadcast, we'll then send over all
 		// messages we can send immediately.
-		err = c.cfg.DeliverResolutionMsg(pktsToSend...)
-		if err != nil {
-			// TODO(roasbeef): make sure packet sends are idempotent
-			log.Errorf("unable to send pkts: %v", err)
-			return StateError, closeTx, err
+		if len(pktsToSend) != 0 {
+			err := c.cfg.DeliverResolutionMsg(pktsToSend...)
+			if err != nil {
+				// TODO(roasbeef): make sure packet sends are
+				// idempotent
+				log.Errorf("unable to send pkts: %v", err)
+				return StateError, closeTx, err
+			}
 		}
 
 		log.Debugf("ChannelArbitrator(%v): inserting %v contract "+

--- a/contractcourt/channel_arbitrator_test.go
+++ b/contractcourt/channel_arbitrator_test.go
@@ -26,6 +26,8 @@ type mockArbitratorLog struct {
 	chainActions    ChainActionMap
 	resolvers       map[ContractResolver]struct{}
 
+	commitSet *CommitSet
+
 	sync.Mutex
 }
 
@@ -106,6 +108,19 @@ func (b *mockArbitratorLog) FetchContractResolutions() (*ContractResolutions, er
 	}
 
 	return b.resolutions, nil
+}
+
+func (b *mockArbitratorLog) FetchChainActions() (ChainActionMap, error) {
+	return nil, nil
+}
+
+func (b *mockArbitratorLog) InsertConfirmedCommitSet(c *CommitSet) error {
+	b.commitSet = c
+	return nil
+}
+
+func (b *mockArbitratorLog) FetchConfirmedCommitSet() (*CommitSet, error) {
+	return b.commitSet, nil
 }
 
 func (b *mockArbitratorLog) WipeHistory() error {
@@ -1289,8 +1304,6 @@ func TestChannelArbitratorDanglingCommitForceClose(t *testing.T) {
 			}
 		}
 	}
-
-	fmt.Println(len(testCases))
 
 	for _, testCase := range testCases {
 		testCase := testCase

--- a/htlcswitch/link_test.go
+++ b/htlcswitch/link_test.go
@@ -1761,7 +1761,7 @@ func handleStateUpdate(link *channelLink,
 	}
 	link.HandleChannelUpdate(remoteRev)
 
-	remoteSig, remoteHtlcSigs, err := remoteChannel.SignNextCommitment()
+	remoteSig, remoteHtlcSigs, _, err := remoteChannel.SignNextCommitment()
 	if err != nil {
 		return err
 	}
@@ -1782,7 +1782,7 @@ func handleStateUpdate(link *channelLink,
 	if !ok {
 		return fmt.Errorf("expected RevokeAndAck got %T", msg)
 	}
-	_, _, _, err = remoteChannel.ReceiveRevocation(revoke)
+	_, _, _, _, err = remoteChannel.ReceiveRevocation(revoke)
 	if err != nil {
 		return fmt.Errorf("unable to receive "+
 			"revocation: %v", err)
@@ -1812,7 +1812,7 @@ func updateState(batchTick chan time.Time, link *channelLink,
 
 	// The remote is triggering the state update, emulate this by
 	// signing and sending CommitSig to the link.
-	remoteSig, remoteHtlcSigs, err := remoteChannel.SignNextCommitment()
+	remoteSig, remoteHtlcSigs, _, err := remoteChannel.SignNextCommitment()
 	if err != nil {
 		return err
 	}
@@ -1836,7 +1836,7 @@ func updateState(batchTick chan time.Time, link *channelLink,
 		return fmt.Errorf("expected RevokeAndAck got %T",
 			msg)
 	}
-	_, _, _, err = remoteChannel.ReceiveRevocation(revoke)
+	_, _, _, _, err = remoteChannel.ReceiveRevocation(revoke)
 	if err != nil {
 		return fmt.Errorf("unable to receive "+
 			"revocation: %v", err)
@@ -4397,7 +4397,7 @@ func sendCommitSigBobToAlice(t *testing.T, aliceLink ChannelLink,
 
 	t.Helper()
 
-	sig, htlcSigs, err := bobChannel.SignNextCommitment()
+	sig, htlcSigs, _, err := bobChannel.SignNextCommitment()
 	if err != nil {
 		t.Fatalf("error signing commitment: %v", err)
 	}
@@ -4435,7 +4435,7 @@ func receiveRevAndAckAliceToBob(t *testing.T, aliceMsgs chan lnwire.Message,
 		t.Fatalf("expected RevokeAndAck, got %T", msg)
 	}
 
-	_, _, _, err := bobChannel.ReceiveRevocation(rev)
+	_, _, _, _, err := bobChannel.ReceiveRevocation(rev)
 	if err != nil {
 		t.Fatalf("bob failed receiving revocation: %v", err)
 	}
@@ -5326,7 +5326,7 @@ func TestChannelLinkFail(t *testing.T) {
 
 				// Sign a commitment that will include
 				// signature for the HTLC just sent.
-				sig, htlcSigs, err :=
+				sig, htlcSigs, _, err :=
 					remoteChannel.SignNextCommitment()
 				if err != nil {
 					t.Fatalf("error signing commitment: %v",
@@ -5358,7 +5358,7 @@ func TestChannelLinkFail(t *testing.T) {
 
 				// Sign a commitment that will include
 				// signature for the HTLC just sent.
-				sig, htlcSigs, err :=
+				sig, htlcSigs, _, err :=
 					remoteChannel.SignNextCommitment()
 				if err != nil {
 					t.Fatalf("error signing commitment: %v",

--- a/lnwallet/channel.go
+++ b/lnwallet/channel.go
@@ -3035,8 +3035,10 @@ func (lc *LightningChannel) createCommitDiff(
 // The first return parameter is the signature for the commitment transaction
 // itself, while the second parameter is a slice of all HTLC signatures (if
 // any). The HTLC signatures are sorted according to the BIP 69 order of the
-// HTLC's on the commitment transaction.
-func (lc *LightningChannel) SignNextCommitment() (lnwire.Sig, []lnwire.Sig, error) {
+// HTLC's on the commitment transaction. Finally, the new set of pending HTLCs
+// for the remote party's commitment are also returned.
+func (lc *LightningChannel) SignNextCommitment() (lnwire.Sig, []lnwire.Sig, []channeldb.HTLC, error) {
+
 	lc.Lock()
 	defer lc.Unlock()
 
@@ -3052,7 +3054,7 @@ func (lc *LightningChannel) SignNextCommitment() (lnwire.Sig, []lnwire.Sig, erro
 	commitPoint := lc.channelState.RemoteNextRevocation
 	if lc.remoteCommitChain.hasUnackedCommitment() || commitPoint == nil {
 
-		return sig, htlcSigs, ErrNoWindow
+		return sig, htlcSigs, nil, ErrNoWindow
 	}
 
 	// Determine the last update on the remote log that has been locked in.
@@ -3067,7 +3069,7 @@ func (lc *LightningChannel) SignNextCommitment() (lnwire.Sig, []lnwire.Sig, erro
 		remoteACKedIndex, lc.localUpdateLog.logIndex, true, nil,
 	)
 	if err != nil {
-		return sig, htlcSigs, err
+		return sig, htlcSigs, nil, err
 	}
 
 	// Grab the next commitment point for the remote party. This will be
@@ -3089,7 +3091,7 @@ func (lc *LightningChannel) SignNextCommitment() (lnwire.Sig, []lnwire.Sig, erro
 		remoteACKedIndex, remoteHtlcIndex, keyRing,
 	)
 	if err != nil {
-		return sig, htlcSigs, err
+		return sig, htlcSigs, nil, err
 	}
 
 	walletLog.Tracef("ChannelPoint(%v): extending remote chain to height %v, "+
@@ -3114,7 +3116,7 @@ func (lc *LightningChannel) SignNextCommitment() (lnwire.Sig, []lnwire.Sig, erro
 		lc.localChanCfg, lc.remoteChanCfg, newCommitView,
 	)
 	if err != nil {
-		return sig, htlcSigs, err
+		return sig, htlcSigs, nil, err
 	}
 	lc.sigPool.SubmitSignBatch(sigBatch)
 
@@ -3125,12 +3127,12 @@ func (lc *LightningChannel) SignNextCommitment() (lnwire.Sig, []lnwire.Sig, erro
 	rawSig, err := lc.Signer.SignOutputRaw(newCommitView.txn, lc.signDesc)
 	if err != nil {
 		close(cancelChan)
-		return sig, htlcSigs, err
+		return sig, htlcSigs, nil, err
 	}
 	sig, err = lnwire.NewSigFromRawSignature(rawSig)
 	if err != nil {
 		close(cancelChan)
-		return sig, htlcSigs, err
+		return sig, htlcSigs, nil, err
 	}
 
 	// We'll need to send over the signatures to the remote party in the
@@ -3150,7 +3152,7 @@ func (lc *LightningChannel) SignNextCommitment() (lnwire.Sig, []lnwire.Sig, erro
 		// jobs.
 		if jobResp.Err != nil {
 			close(cancelChan)
-			return sig, htlcSigs, err
+			return sig, htlcSigs, nil, err
 		}
 
 		htlcSigs = append(htlcSigs, jobResp.Sig)
@@ -3161,11 +3163,11 @@ func (lc *LightningChannel) SignNextCommitment() (lnwire.Sig, []lnwire.Sig, erro
 	// can retransmit it if necessary.
 	commitDiff, err := lc.createCommitDiff(newCommitView, sig, htlcSigs)
 	if err != nil {
-		return sig, htlcSigs, err
+		return sig, htlcSigs, nil, err
 	}
 	err = lc.channelState.AppendRemoteCommitChain(commitDiff)
 	if err != nil {
-		return sig, htlcSigs, err
+		return sig, htlcSigs, nil, err
 	}
 
 	// TODO(roasbeef): check that one eclair bug
@@ -3176,7 +3178,7 @@ func (lc *LightningChannel) SignNextCommitment() (lnwire.Sig, []lnwire.Sig, erro
 	// latest commitment update.
 	lc.remoteCommitChain.addCommitment(newCommitView)
 
-	return sig, htlcSigs, nil
+	return sig, htlcSigs, commitDiff.Commitment.Htlcs, nil
 }
 
 // ProcessChanSyncMsg processes a ChannelReestablish message sent by the remote
@@ -3352,7 +3354,7 @@ func (lc *LightningChannel) ProcessChanSyncMsg(
 		// revocation, but also initiate a state transition to re-sync
 		// them.
 		if !lc.FullySynced() {
-			commitSig, htlcSigs, err := lc.SignNextCommitment()
+			commitSig, htlcSigs, _, err := lc.SignNextCommitment()
 			switch {
 
 			// If we signed this state, then we'll accumulate
@@ -4277,8 +4279,11 @@ func (lc *LightningChannel) RevokeCurrentCommitment() (*lnwire.RevokeAndAck, []c
 //      revocation.
 //   3. The PaymentDescriptor of any Settle/Fail HTLCs that were locked in by
 //      this revocation.
+//   4. The set of HTLCs present on the current valid commitment transaction
+//      for the remote party.
 func (lc *LightningChannel) ReceiveRevocation(revMsg *lnwire.RevokeAndAck) (
-	*channeldb.FwdPkg, []*PaymentDescriptor, []*PaymentDescriptor, error) {
+	*channeldb.FwdPkg, []*PaymentDescriptor, []*PaymentDescriptor,
+	[]channeldb.HTLC, error) {
 
 	lc.Lock()
 	defer lc.Unlock()
@@ -4287,10 +4292,10 @@ func (lc *LightningChannel) ReceiveRevocation(revMsg *lnwire.RevokeAndAck) (
 	store := lc.channelState.RevocationStore
 	revocation, err := chainhash.NewHash(revMsg.Revocation[:])
 	if err != nil {
-		return nil, nil, nil, err
+		return nil, nil, nil, nil, err
 	}
 	if err := store.AddNextEntry(revocation); err != nil {
-		return nil, nil, nil, err
+		return nil, nil, nil, nil, err
 	}
 
 	// Verify that if we use the commitment point computed based off of the
@@ -4299,7 +4304,7 @@ func (lc *LightningChannel) ReceiveRevocation(revMsg *lnwire.RevokeAndAck) (
 	currentCommitPoint := lc.channelState.RemoteCurrentRevocation
 	derivedCommitPoint := input.ComputeCommitmentPoint(revMsg.Revocation[:])
 	if !derivedCommitPoint.IsEqual(currentCommitPoint) {
-		return nil, nil, nil, fmt.Errorf("revocation key mismatch")
+		return nil, nil, nil, nil, fmt.Errorf("revocation key mismatch")
 	}
 
 	// Now that we've verified that the prior commitment has been properly
@@ -4470,7 +4475,7 @@ func (lc *LightningChannel) ReceiveRevocation(revMsg *lnwire.RevokeAndAck) (
 	// commitment chain.
 	err = lc.channelState.AdvanceCommitChainTail(fwdPkg)
 	if err != nil {
-		return nil, nil, nil, err
+		return nil, nil, nil, nil, err
 	}
 
 	// Since they revoked the current lowest height in their commitment
@@ -4485,7 +4490,9 @@ func (lc *LightningChannel) ReceiveRevocation(revMsg *lnwire.RevokeAndAck) (
 		remoteChainTail,
 	)
 
-	return fwdPkg, addsToForward, settleFailsToForward, nil
+	remoteHTLCs := lc.channelState.RemoteCommitment.Htlcs
+
+	return fwdPkg, addsToForward, settleFailsToForward, remoteHTLCs, nil
 }
 
 // LoadFwdPkgs loads any pending log updates from disk and returns the payment

--- a/lnwallet/channel_test.go
+++ b/lnwallet/channel_test.go
@@ -99,7 +99,7 @@ func TestSimpleAddSettleWorkflow(t *testing.T) {
 	// we expect the messages to be ordered, Bob will receive the HTLC we
 	// just sent before he receives this signature, so the signature will
 	// cover the HTLC.
-	aliceSig, aliceHtlcSigs, err := aliceChannel.SignNextCommitment()
+	aliceSig, aliceHtlcSigs, _, err := aliceChannel.SignNextCommitment()
 	if err != nil {
 		t.Fatalf("alice unable to sign commitment: %v", err)
 	}
@@ -123,7 +123,7 @@ func TestSimpleAddSettleWorkflow(t *testing.T) {
 	// This signature will cover the HTLC, since Bob will first send the
 	// revocation just created. The revocation also acks every received
 	// HTLC up to the point where Alice sent here signature.
-	bobSig, bobHtlcSigs, err := bobChannel.SignNextCommitment()
+	bobSig, bobHtlcSigs, _, err := bobChannel.SignNextCommitment()
 	if err != nil {
 		t.Fatalf("bob unable to sign alice's commitment: %v", err)
 	}
@@ -131,7 +131,7 @@ func TestSimpleAddSettleWorkflow(t *testing.T) {
 	// Alice then processes this revocation, sending her own revocation for
 	// her prior commitment transaction. Alice shouldn't have any HTLCs to
 	// forward since she's sending an outgoing HTLC.
-	fwdPkg, _, _, err := aliceChannel.ReceiveRevocation(bobRevocation)
+	fwdPkg, _, _, _, err := aliceChannel.ReceiveRevocation(bobRevocation)
 	if err != nil {
 		t.Fatalf("alice unable to process bob's revocation: %v", err)
 	}
@@ -162,7 +162,7 @@ func TestSimpleAddSettleWorkflow(t *testing.T) {
 	// is fully locked in within both commitment transactions. Bob should
 	// also be able to forward an HTLC now that the HTLC has been locked
 	// into both commitment transactions.
-	fwdPkg, _, _, err = bobChannel.ReceiveRevocation(aliceRevocation)
+	fwdPkg, _, _, _, err = bobChannel.ReceiveRevocation(aliceRevocation)
 	if err != nil {
 		t.Fatalf("bob unable to process alice's revocation: %v", err)
 	}
@@ -239,7 +239,7 @@ func TestSimpleAddSettleWorkflow(t *testing.T) {
 		t.Fatalf("alice unable to accept settle of outbound htlc: %v", err)
 	}
 
-	bobSig2, bobHtlcSigs2, err := bobChannel.SignNextCommitment()
+	bobSig2, bobHtlcSigs2, _, err := bobChannel.SignNextCommitment()
 	if err != nil {
 		t.Fatalf("bob unable to sign settle commitment: %v", err)
 	}
@@ -252,12 +252,12 @@ func TestSimpleAddSettleWorkflow(t *testing.T) {
 	if err != nil {
 		t.Fatalf("alice unable to generate revocation: %v", err)
 	}
-	aliceSig2, aliceHtlcSigs2, err := aliceChannel.SignNextCommitment()
+	aliceSig2, aliceHtlcSigs2, _, err := aliceChannel.SignNextCommitment()
 	if err != nil {
 		t.Fatalf("alice unable to sign new commitment: %v", err)
 	}
 
-	fwdPkg, _, _, err = bobChannel.ReceiveRevocation(aliceRevocation2)
+	fwdPkg, _, _, _, err = bobChannel.ReceiveRevocation(aliceRevocation2)
 	if err != nil {
 		t.Fatalf("bob unable to process alice's revocation: %v", err)
 	}
@@ -279,7 +279,7 @@ func TestSimpleAddSettleWorkflow(t *testing.T) {
 	if err != nil {
 		t.Fatalf("bob unable to revoke commitment: %v", err)
 	}
-	fwdPkg, _, _, err = aliceChannel.ReceiveRevocation(bobRevocation2)
+	fwdPkg, _, _, _, err = aliceChannel.ReceiveRevocation(bobRevocation2)
 	if err != nil {
 		t.Fatalf("alice unable to process bob's revocation: %v", err)
 	}
@@ -1106,7 +1106,7 @@ func TestHTLCSigNumber(t *testing.T) {
 		aboveDust)
 	defer cleanUp()
 
-	aliceSig, aliceHtlcSigs, err := aliceChannel.SignNextCommitment()
+	aliceSig, aliceHtlcSigs, _, err := aliceChannel.SignNextCommitment()
 	if err != nil {
 		t.Fatalf("Error signing next commitment: %v", err)
 	}
@@ -1130,7 +1130,7 @@ func TestHTLCSigNumber(t *testing.T) {
 	aliceChannel, bobChannel, cleanUp = createChanWithHTLC(aboveDust)
 	defer cleanUp()
 
-	aliceSig, aliceHtlcSigs, err = aliceChannel.SignNextCommitment()
+	aliceSig, aliceHtlcSigs, _, err = aliceChannel.SignNextCommitment()
 	if err != nil {
 		t.Fatalf("Error signing next commitment: %v", err)
 	}
@@ -1153,7 +1153,7 @@ func TestHTLCSigNumber(t *testing.T) {
 	aliceChannel, bobChannel, cleanUp = createChanWithHTLC(belowDust)
 	defer cleanUp()
 
-	aliceSig, aliceHtlcSigs, err = aliceChannel.SignNextCommitment()
+	aliceSig, aliceHtlcSigs, _, err = aliceChannel.SignNextCommitment()
 	if err != nil {
 		t.Fatalf("Error signing next commitment: %v", err)
 	}
@@ -1176,7 +1176,7 @@ func TestHTLCSigNumber(t *testing.T) {
 	aliceChannel, bobChannel, cleanUp = createChanWithHTLC(aboveDust)
 	defer cleanUp()
 
-	aliceSig, aliceHtlcSigs, err = aliceChannel.SignNextCommitment()
+	aliceSig, aliceHtlcSigs, _, err = aliceChannel.SignNextCommitment()
 	if err != nil {
 		t.Fatalf("Error signing next commitment: %v", err)
 	}
@@ -1203,7 +1203,7 @@ func TestHTLCSigNumber(t *testing.T) {
 
 	// Alice should produce only one signature, since one HTLC is below
 	// dust.
-	aliceSig, aliceHtlcSigs, err = aliceChannel.SignNextCommitment()
+	aliceSig, aliceHtlcSigs, _, err = aliceChannel.SignNextCommitment()
 	if err != nil {
 		t.Fatalf("Error signing next commitment: %v", err)
 	}
@@ -1989,7 +1989,7 @@ func TestUpdateFeeFail(t *testing.T) {
 
 	// Alice sends signature for commitment that does not cover any fee
 	// update.
-	aliceSig, aliceHtlcSigs, err := aliceChannel.SignNextCommitment()
+	aliceSig, aliceHtlcSigs, _, err := aliceChannel.SignNextCommitment()
 	if err != nil {
 		t.Fatalf("alice unable to sign commitment: %v", err)
 	}
@@ -2040,13 +2040,13 @@ func TestUpdateFeeConcurrentSig(t *testing.T) {
 	}
 
 	// Alice signs a commitment, and sends this to bob.
-	aliceSig, aliceHtlcSigs, err := aliceChannel.SignNextCommitment()
+	aliceSig, aliceHtlcSigs, _, err := aliceChannel.SignNextCommitment()
 	if err != nil {
 		t.Fatalf("alice unable to sign commitment: %v", err)
 	}
 
 	// At the same time, Bob signs a commitment.
-	bobSig, bobHtlcSigs, err := bobChannel.SignNextCommitment()
+	bobSig, bobHtlcSigs, _, err := bobChannel.SignNextCommitment()
 	if err != nil {
 		t.Fatalf("bob unable to sign alice's commitment: %v", err)
 	}
@@ -2127,7 +2127,7 @@ func TestUpdateFeeSenderCommits(t *testing.T) {
 	// Alice signs a commitment, which will cover everything sent to Bob
 	// (the HTLC and the fee update), and everything acked by Bob (nothing
 	// so far).
-	aliceSig, aliceHtlcSigs, err := aliceChannel.SignNextCommitment()
+	aliceSig, aliceHtlcSigs, _, err := aliceChannel.SignNextCommitment()
 	if err != nil {
 		t.Fatalf("alice unable to sign commitment: %v", err)
 	}
@@ -2157,7 +2157,7 @@ func TestUpdateFeeSenderCommits(t *testing.T) {
 
 	// Bob commits to all updates he has received from Alice. This includes
 	// the HTLC he received, and the fee update.
-	bobSig, bobHtlcSigs, err := bobChannel.SignNextCommitment()
+	bobSig, bobHtlcSigs, _, err := bobChannel.SignNextCommitment()
 	if err != nil {
 		t.Fatalf("bob unable to sign alice's commitment: %v", err)
 	}
@@ -2165,7 +2165,8 @@ func TestUpdateFeeSenderCommits(t *testing.T) {
 	// Alice receives the revocation of the old one, and can now assume
 	// that Bob's received everything up to the signature she sent,
 	// including the HTLC and fee update.
-	if _, _, _, err := aliceChannel.ReceiveRevocation(bobRevocation); err != nil {
+	_, _, _, _, err = aliceChannel.ReceiveRevocation(bobRevocation)
+	if err != nil {
 		t.Fatalf("alice unable to process bob's revocation: %v", err)
 	}
 
@@ -2192,7 +2193,8 @@ func TestUpdateFeeSenderCommits(t *testing.T) {
 	}
 
 	// Bob receives revocation from Alice.
-	if _, _, _, err := bobChannel.ReceiveRevocation(aliceRevocation); err != nil {
+	_, _, _, _, err = bobChannel.ReceiveRevocation(aliceRevocation)
+	if err != nil {
 		t.Fatalf("bob unable to process alice's revocation: %v", err)
 	}
 
@@ -2239,7 +2241,7 @@ func TestUpdateFeeReceiverCommits(t *testing.T) {
 	// Bob commits to every change he has sent since last time (none). He
 	// does not commit to the received HTLC and fee update, since Alice
 	// cannot know if he has received them.
-	bobSig, bobHtlcSigs, err := bobChannel.SignNextCommitment()
+	bobSig, bobHtlcSigs, _, err := bobChannel.SignNextCommitment()
 	if err != nil {
 		t.Fatalf("alice unable to sign commitment: %v", err)
 	}
@@ -2260,14 +2262,15 @@ func TestUpdateFeeReceiverCommits(t *testing.T) {
 	}
 
 	// Bob receives the revocation of the old commitment
-	if _, _, _, err := bobChannel.ReceiveRevocation(aliceRevocation); err != nil {
+	_, _, _, _, err = bobChannel.ReceiveRevocation(aliceRevocation)
+	if err != nil {
 		t.Fatalf("alice unable to process bob's revocation: %v", err)
 	}
 
 	// Alice will sign next commitment. Since she sent the revocation, she
 	// also ack'ed everything received, but in this case this is nothing.
 	// Since she sent the two updates, this signature will cover those two.
-	aliceSig, aliceHtlcSigs, err := aliceChannel.SignNextCommitment()
+	aliceSig, aliceHtlcSigs, _, err := aliceChannel.SignNextCommitment()
 	if err != nil {
 		t.Fatalf("bob unable to sign alice's commitment: %v", err)
 	}
@@ -2297,14 +2300,15 @@ func TestUpdateFeeReceiverCommits(t *testing.T) {
 
 	// Bob will send a new signature, which will cover what he just acked:
 	// the HTLC and fee update.
-	bobSig, bobHtlcSigs, err = bobChannel.SignNextCommitment()
+	bobSig, bobHtlcSigs, _, err = bobChannel.SignNextCommitment()
 	if err != nil {
 		t.Fatalf("alice unable to sign commitment: %v", err)
 	}
 
 	// Alice receives revocation from Bob, and can now be sure that Bob
 	// received the two updates, and they are considered locked in.
-	if _, _, _, err := aliceChannel.ReceiveRevocation(bobRevocation); err != nil {
+	_, _, _, _, err = aliceChannel.ReceiveRevocation(bobRevocation)
+	if err != nil {
 		t.Fatalf("bob unable to process alice's revocation: %v", err)
 	}
 
@@ -2331,7 +2335,8 @@ func TestUpdateFeeReceiverCommits(t *testing.T) {
 	}
 
 	// Bob receives revocation from Alice.
-	if _, _, _, err := bobChannel.ReceiveRevocation(aliceRevocation); err != nil {
+	_, _, _, _, err = bobChannel.ReceiveRevocation(aliceRevocation)
+	if err != nil {
 		t.Fatalf("bob unable to process alice's revocation: %v", err)
 	}
 }
@@ -2391,7 +2396,7 @@ func TestUpdateFeeMultipleUpdates(t *testing.T) {
 	// Alice signs a commitment, which will cover everything sent to Bob
 	// (the HTLC and the fee update), and everything acked by Bob (nothing
 	// so far).
-	aliceSig, aliceHtlcSigs, err := aliceChannel.SignNextCommitment()
+	aliceSig, aliceHtlcSigs, _, err := aliceChannel.SignNextCommitment()
 	if err != nil {
 		t.Fatalf("alice unable to sign commitment: %v", err)
 	}
@@ -2437,7 +2442,7 @@ func TestUpdateFeeMultipleUpdates(t *testing.T) {
 
 	// Bob commits to all updates he has received from Alice. This includes
 	// the HTLC he received, and the fee update.
-	bobSig, bobHtlcSigs, err := bobChannel.SignNextCommitment()
+	bobSig, bobHtlcSigs, _, err := bobChannel.SignNextCommitment()
 	if err != nil {
 		t.Fatalf("bob unable to sign alice's commitment: %v", err)
 	}
@@ -2445,7 +2450,8 @@ func TestUpdateFeeMultipleUpdates(t *testing.T) {
 	// Alice receives the revocation of the old one, and can now assume that
 	// Bob's received everything up to the signature she sent, including the
 	// HTLC and fee update.
-	if _, _, _, err := aliceChannel.ReceiveRevocation(bobRevocation); err != nil {
+	_, _, _, _, err = aliceChannel.ReceiveRevocation(bobRevocation)
+	if err != nil {
 		t.Fatalf("alice unable to process bob's revocation: %v", err)
 	}
 
@@ -2471,7 +2477,8 @@ func TestUpdateFeeMultipleUpdates(t *testing.T) {
 	}
 
 	// Bob receives revocation from Alice.
-	if _, _, _, err := bobChannel.ReceiveRevocation(aliceRevocation); err != nil {
+	_, _, _, _, err = bobChannel.ReceiveRevocation(aliceRevocation)
+	if err != nil {
 		t.Fatalf("bob unable to process alice's revocation: %v", err)
 	}
 }
@@ -2764,7 +2771,7 @@ func TestChanSyncOweCommitment(t *testing.T) {
 	// Now we'll begin the core of the test itself. Alice will extend a new
 	// commitment to Bob, but the connection drops before Bob can process
 	// it.
-	aliceSig, aliceHtlcSigs, err := aliceChannel.SignNextCommitment()
+	aliceSig, aliceHtlcSigs, _, err := aliceChannel.SignNextCommitment()
 	if err != nil {
 		t.Fatalf("unable to sign commitment: %v", err)
 	}
@@ -2892,11 +2899,11 @@ func TestChanSyncOweCommitment(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unable to revoke bob commitment: %v", err)
 	}
-	bobSig, bobHtlcSigs, err := bobChannel.SignNextCommitment()
+	bobSig, bobHtlcSigs, _, err := bobChannel.SignNextCommitment()
 	if err != nil {
 		t.Fatalf("bob unable to sign commitment: %v", err)
 	}
-	_, _, _, err = aliceChannel.ReceiveRevocation(bobRevocation)
+	_, _, _, _, err = aliceChannel.ReceiveRevocation(bobRevocation)
 	if err != nil {
 		t.Fatalf("alice unable to recv revocation: %v", err)
 	}
@@ -2908,7 +2915,8 @@ func TestChanSyncOweCommitment(t *testing.T) {
 	if err != nil {
 		t.Fatalf("alice unable to revoke commitment: %v", err)
 	}
-	if _, _, _, err := bobChannel.ReceiveRevocation(aliceRevocation); err != nil {
+	_, _, _, _, err = bobChannel.ReceiveRevocation(aliceRevocation)
+	if err != nil {
 		t.Fatalf("bob unable to recv revocation: %v", err)
 	}
 
@@ -3048,7 +3056,7 @@ func TestChanSyncOweRevocation(t *testing.T) {
 	//
 	// Alice signs the next state, then Bob receives and sends his
 	// revocation message.
-	aliceSig, aliceHtlcSigs, err := aliceChannel.SignNextCommitment()
+	aliceSig, aliceHtlcSigs, _, err := aliceChannel.SignNextCommitment()
 	if err != nil {
 		t.Fatalf("unable to sign commitment: %v", err)
 	}
@@ -3061,12 +3069,12 @@ func TestChanSyncOweRevocation(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unable to revoke bob commitment: %v", err)
 	}
-	bobSig, bobHtlcSigs, err := bobChannel.SignNextCommitment()
+	bobSig, bobHtlcSigs, _, err := bobChannel.SignNextCommitment()
 	if err != nil {
 		t.Fatalf("bob unable to sign commitment: %v", err)
 	}
 
-	_, _, _, err = aliceChannel.ReceiveRevocation(bobRevocation)
+	_, _, _, _, err = aliceChannel.ReceiveRevocation(bobRevocation)
 	if err != nil {
 		t.Fatalf("alice unable to recv revocation: %v", err)
 	}
@@ -3148,7 +3156,8 @@ func TestChanSyncOweRevocation(t *testing.T) {
 	// TODO(roasbeef): restart bob too???
 
 	// We'll continue by then allowing bob to process Alice's revocation message.
-	if _, _, _, err := bobChannel.ReceiveRevocation(aliceRevocation); err != nil {
+	_, _, _, _, err = bobChannel.ReceiveRevocation(aliceRevocation)
+	if err != nil {
 		t.Fatalf("bob unable to recv revocation: %v", err)
 	}
 
@@ -3230,7 +3239,7 @@ func TestChanSyncOweRevocationAndCommit(t *testing.T) {
 
 	// Progressing the exchange: Alice will send her signature, Bob will
 	// receive, send a revocation and also a signature for Alice's state.
-	aliceSig, aliceHtlcSigs, err := aliceChannel.SignNextCommitment()
+	aliceSig, aliceHtlcSigs, _, err := aliceChannel.SignNextCommitment()
 	if err != nil {
 		t.Fatalf("unable to sign commitment: %v", err)
 	}
@@ -3245,7 +3254,7 @@ func TestChanSyncOweRevocationAndCommit(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unable to revoke bob commitment: %v", err)
 	}
-	bobSig, bobHtlcSigs, err := bobChannel.SignNextCommitment()
+	bobSig, bobHtlcSigs, _, err := bobChannel.SignNextCommitment()
 	if err != nil {
 		t.Fatalf("bob unable to sign commitment: %v", err)
 	}
@@ -3326,7 +3335,7 @@ func TestChanSyncOweRevocationAndCommit(t *testing.T) {
 
 	// We'll now finish the state transition by having Alice process both
 	// messages, and send her final revocation.
-	_, _, _, err = aliceChannel.ReceiveRevocation(bobRevocation)
+	_, _, _, _, err = aliceChannel.ReceiveRevocation(bobRevocation)
 	if err != nil {
 		t.Fatalf("alice unable to recv revocation: %v", err)
 	}
@@ -3338,7 +3347,8 @@ func TestChanSyncOweRevocationAndCommit(t *testing.T) {
 	if err != nil {
 		t.Fatalf("alice unable to revoke commitment: %v", err)
 	}
-	if _, _, _, err := bobChannel.ReceiveRevocation(aliceRevocation); err != nil {
+	_, _, _, _, err = bobChannel.ReceiveRevocation(aliceRevocation)
+	if err != nil {
 		t.Fatalf("bob unable to recv revocation: %v", err)
 	}
 }
@@ -3407,7 +3417,7 @@ func TestChanSyncOweRevocationAndCommitForceTransition(t *testing.T) {
 	}
 
 	// Bob signs the new state update, and sends the signature to Alice.
-	bobSig, bobHtlcSigs, err := bobChannel.SignNextCommitment()
+	bobSig, bobHtlcSigs, _, err := bobChannel.SignNextCommitment()
 	if err != nil {
 		t.Fatalf("bob unable to sign commitment: %v", err)
 	}
@@ -3425,7 +3435,8 @@ func TestChanSyncOweRevocationAndCommitForceTransition(t *testing.T) {
 	if err != nil {
 		t.Fatalf("alice unable to revoke commitment: %v", err)
 	}
-	if _, _, _, err := bobChannel.ReceiveRevocation(aliceRevocation); err != nil {
+	_, _, _, _, err = bobChannel.ReceiveRevocation(aliceRevocation)
+	if err != nil {
 		t.Fatalf("bob unable to recv revocation: %v", err)
 	}
 
@@ -3442,7 +3453,7 @@ func TestChanSyncOweRevocationAndCommitForceTransition(t *testing.T) {
 
 	// Progressing the exchange: Alice will send her signature, with Bob
 	// processing the new state locally.
-	aliceSig, aliceHtlcSigs, err := aliceChannel.SignNextCommitment()
+	aliceSig, aliceHtlcSigs, _, err := aliceChannel.SignNextCommitment()
 	if err != nil {
 		t.Fatalf("unable to sign commitment: %v", err)
 	}
@@ -3554,7 +3565,7 @@ func TestChanSyncOweRevocationAndCommitForceTransition(t *testing.T) {
 	// Now, we'll continue the exchange, sending Bob's revocation and
 	// signature message to Alice, ending with Alice sending her revocation
 	// message to Bob.
-	_, _, _, err = aliceChannel.ReceiveRevocation(bobRevocation)
+	_, _, _, _, err = aliceChannel.ReceiveRevocation(bobRevocation)
 	if err != nil {
 		t.Fatalf("alice unable to recv revocation: %v", err)
 	}
@@ -3568,7 +3579,8 @@ func TestChanSyncOweRevocationAndCommitForceTransition(t *testing.T) {
 	if err != nil {
 		t.Fatalf("alice unable to revoke commitment: %v", err)
 	}
-	if _, _, _, err := bobChannel.ReceiveRevocation(aliceRevocation); err != nil {
+	_, _, _, _, err = bobChannel.ReceiveRevocation(aliceRevocation)
+	if err != nil {
 		t.Fatalf("bob unable to recv revocation: %v", err)
 	}
 }
@@ -3651,7 +3663,7 @@ func TestChanSyncFailure(t *testing.T) {
 			t.Fatalf("unable to recv bob's htlc: %v", err)
 		}
 
-		aliceSig, aliceHtlcSigs, err := aliceChannel.SignNextCommitment()
+		aliceSig, aliceHtlcSigs, _, err := aliceChannel.SignNextCommitment()
 		if err != nil {
 			t.Fatalf("unable to sign next commit: %v", err)
 		}
@@ -3883,7 +3895,7 @@ func TestChannelRetransmissionFeeUpdate(t *testing.T) {
 
 	// Now, Alice will send a new commitment to Bob, but we'll simulate a
 	// connection failure, so Bob doesn't get her signature.
-	aliceSig, aliceHtlcSigs, err := aliceChannel.SignNextCommitment()
+	aliceSig, aliceHtlcSigs, _, err := aliceChannel.SignNextCommitment()
 	if err != nil {
 		t.Fatalf("unable to sign commitment: %v", err)
 	}
@@ -3986,11 +3998,11 @@ func TestChannelRetransmissionFeeUpdate(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unable to revoke bob commitment: %v", err)
 	}
-	bobSig, bobHtlcSigs, err := bobChannel.SignNextCommitment()
+	bobSig, bobHtlcSigs, _, err := bobChannel.SignNextCommitment()
 	if err != nil {
 		t.Fatalf("bob unable to sign commitment: %v", err)
 	}
-	_, _, _, err = aliceChannel.ReceiveRevocation(bobRevocation)
+	_, _, _, _, err = aliceChannel.ReceiveRevocation(bobRevocation)
 	if err != nil {
 		t.Fatalf("alice unable to recv revocation: %v", err)
 	}
@@ -4002,7 +4014,8 @@ func TestChannelRetransmissionFeeUpdate(t *testing.T) {
 	if err != nil {
 		t.Fatalf("alice unable to revoke commitment: %v", err)
 	}
-	if _, _, _, err := bobChannel.ReceiveRevocation(aliceRevocation); err != nil {
+	_, _, _, _, err = bobChannel.ReceiveRevocation(aliceRevocation)
+	if err != nil {
 		t.Fatalf("bob unable to recv revocation: %v", err)
 	}
 
@@ -4131,7 +4144,7 @@ func TestFeeUpdateOldDiskFormat(t *testing.T) {
 
 	// Now, Alice will send a new commitment to Bob, but we'll simulate a
 	// connection failure, so Bob doesn't get the signature.
-	aliceSig, aliceHtlcSigs, err := aliceChannel.SignNextCommitment()
+	aliceSig, aliceHtlcSigs, _, err := aliceChannel.SignNextCommitment()
 	if err != nil {
 		t.Fatalf("unable to sign commitment: %v", err)
 	}
@@ -4198,11 +4211,11 @@ func TestFeeUpdateOldDiskFormat(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unable to revoke bob commitment: %v", err)
 	}
-	bobSig, bobHtlcSigs, err := bobChannel.SignNextCommitment()
+	bobSig, bobHtlcSigs, _, err := bobChannel.SignNextCommitment()
 	if err != nil {
 		t.Fatalf("bob unable to sign commitment: %v", err)
 	}
-	_, _, _, err = aliceChannel.ReceiveRevocation(bobRevocation)
+	_, _, _, _, err = aliceChannel.ReceiveRevocation(bobRevocation)
 	if err != nil {
 		t.Fatalf("alice unable to recv revocation: %v", err)
 	}
@@ -4214,7 +4227,7 @@ func TestFeeUpdateOldDiskFormat(t *testing.T) {
 	if err != nil {
 		t.Fatalf("alice unable to revoke commitment: %v", err)
 	}
-	_, _, _, err = bobChannel.ReceiveRevocation(aliceRevocation)
+	_, _, _, _, err = bobChannel.ReceiveRevocation(aliceRevocation)
 	if err != nil {
 		t.Fatalf("bob unable to recv revocation: %v", err)
 	}
@@ -4524,7 +4537,7 @@ func TestSignCommitmentFailNotLockedIn(t *testing.T) {
 
 	// If we now try to initiate a state update, then it should fail as
 	// Alice is unable to actually create a new state.
-	_, _, err = aliceChannel.SignNextCommitment()
+	_, _, _, err = aliceChannel.SignNextCommitment()
 	if err != ErrNoWindow {
 		t.Fatalf("expected ErrNoWindow, instead have: %v", err)
 	}
@@ -4563,7 +4576,7 @@ func TestLockedInHtlcForwardingSkipAfterRestart(t *testing.T) {
 
 	// We'll now manually initiate a state transition between Alice and
 	// bob.
-	aliceSig, aliceHtlcSigs, err := aliceChannel.SignNextCommitment()
+	aliceSig, aliceHtlcSigs, _, err := aliceChannel.SignNextCommitment()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -4577,7 +4590,7 @@ func TestLockedInHtlcForwardingSkipAfterRestart(t *testing.T) {
 	}
 
 	// Alice should detect that she doesn't need to forward any HTLC's.
-	fwdPkg, _, _, err := aliceChannel.ReceiveRevocation(bobRevocation)
+	fwdPkg, _, _, _, err := aliceChannel.ReceiveRevocation(bobRevocation)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -4592,7 +4605,7 @@ func TestLockedInHtlcForwardingSkipAfterRestart(t *testing.T) {
 
 	// Now, have Bob initiate a transition to lock in the Adds sent by
 	// Alice.
-	bobSig, bobHtlcSigs, err := bobChannel.SignNextCommitment()
+	bobSig, bobHtlcSigs, _, err := bobChannel.SignNextCommitment()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -4608,7 +4621,7 @@ func TestLockedInHtlcForwardingSkipAfterRestart(t *testing.T) {
 
 	// Bob should now detect that he now has 2 incoming HTLC's that he can
 	// forward along.
-	fwdPkg, _, _, err = bobChannel.ReceiveRevocation(aliceRevocation)
+	fwdPkg, _, _, _, err = bobChannel.ReceiveRevocation(aliceRevocation)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -4645,7 +4658,7 @@ func TestLockedInHtlcForwardingSkipAfterRestart(t *testing.T) {
 
 	// We'll now initiate another state transition, but this time Bob will
 	// lead.
-	bobSig, bobHtlcSigs, err = bobChannel.SignNextCommitment()
+	bobSig, bobHtlcSigs, _, err = bobChannel.SignNextCommitment()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -4661,7 +4674,7 @@ func TestLockedInHtlcForwardingSkipAfterRestart(t *testing.T) {
 	// At this point, Bob receives the revocation from Alice, which is now
 	// his signal to examine all the HTLC's that have been locked in to
 	// process.
-	fwdPkg, _, _, err = bobChannel.ReceiveRevocation(aliceRevocation)
+	fwdPkg, _, _, _, err = bobChannel.ReceiveRevocation(aliceRevocation)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -4680,7 +4693,7 @@ func TestLockedInHtlcForwardingSkipAfterRestart(t *testing.T) {
 
 	// Now, begin another state transition led by Alice, and fail the second
 	// HTLC part-way through the dance.
-	aliceSig, aliceHtlcSigs, err = aliceChannel.SignNextCommitment()
+	aliceSig, aliceHtlcSigs, _, err = aliceChannel.SignNextCommitment()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -4707,7 +4720,7 @@ func TestLockedInHtlcForwardingSkipAfterRestart(t *testing.T) {
 
 	// Alice should detect that she doesn't need to forward any Adds's, but
 	// that the Fail has been locked in an can be forwarded.
-	_, adds, settleFails, err := aliceChannel.ReceiveRevocation(bobRevocation)
+	_, adds, settleFails, _, err := aliceChannel.ReceiveRevocation(bobRevocation)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -4749,7 +4762,7 @@ func TestLockedInHtlcForwardingSkipAfterRestart(t *testing.T) {
 
 	// Have Alice initiate a state transition, which does not include the
 	// HTLCs just readded to the channel state.
-	aliceSig, aliceHtlcSigs, err = aliceChannel.SignNextCommitment()
+	aliceSig, aliceHtlcSigs, _, err = aliceChannel.SignNextCommitment()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -4764,7 +4777,7 @@ func TestLockedInHtlcForwardingSkipAfterRestart(t *testing.T) {
 
 	// Alice should detect that she doesn't need to forward any HTLC's, as
 	// the updates haven't been committed by Bob yet.
-	fwdPkg, _, _, err = aliceChannel.ReceiveRevocation(bobRevocation)
+	fwdPkg, _, _, _, err = aliceChannel.ReceiveRevocation(bobRevocation)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -4778,7 +4791,7 @@ func TestLockedInHtlcForwardingSkipAfterRestart(t *testing.T) {
 	}
 
 	// Now initiate a final update from Bob to lock in the final Fail.
-	bobSig, bobHtlcSigs, err = bobChannel.SignNextCommitment()
+	bobSig, bobHtlcSigs, _, err = bobChannel.SignNextCommitment()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -4795,7 +4808,7 @@ func TestLockedInHtlcForwardingSkipAfterRestart(t *testing.T) {
 
 	// Bob should detect that he has nothing to forward, as he hasn't
 	// received any HTLCs.
-	fwdPkg, _, _, err = bobChannel.ReceiveRevocation(aliceRevocation)
+	fwdPkg, _, _, _, err = bobChannel.ReceiveRevocation(aliceRevocation)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -4810,7 +4823,7 @@ func TestLockedInHtlcForwardingSkipAfterRestart(t *testing.T) {
 
 	// Finally, have Bob initiate a state transition that locks in the Fail
 	// added after the restart.
-	aliceSig, aliceHtlcSigs, err = aliceChannel.SignNextCommitment()
+	aliceSig, aliceHtlcSigs, _, err = aliceChannel.SignNextCommitment()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -4825,7 +4838,7 @@ func TestLockedInHtlcForwardingSkipAfterRestart(t *testing.T) {
 
 	// When Alice receives the revocation, she should detect that she
 	// can now forward the freshly locked-in Fail.
-	_, adds, settleFails, err = aliceChannel.ReceiveRevocation(bobRevocation)
+	_, adds, settleFails, _, err = aliceChannel.ReceiveRevocation(bobRevocation)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -4869,7 +4882,7 @@ func TestInvalidCommitSigError(t *testing.T) {
 	}
 
 	// Alice will now attempt to initiate a state transition.
-	aliceSig, aliceHtlcSigs, err := aliceChannel.SignNextCommitment()
+	aliceSig, aliceHtlcSigs, _, err := aliceChannel.SignNextCommitment()
 	if err != nil {
 		t.Fatalf("unable to sign new commit: %v", err)
 	}
@@ -5075,7 +5088,7 @@ func TestChannelUnilateralClosePendingCommit(t *testing.T) {
 
 	// With the HTLC added, we'll now manually initiate a state transition
 	// from Alice to Bob.
-	_, _, err = aliceChannel.SignNextCommitment()
+	_, _, _, err = aliceChannel.SignNextCommitment()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -5861,7 +5874,7 @@ func TestChannelRestoreUpdateLogs(t *testing.T) {
 	}
 
 	// Let Alice sign a new state, which will include the HTLC just sent.
-	aliceSig, aliceHtlcSigs, err := aliceChannel.SignNextCommitment()
+	aliceSig, aliceHtlcSigs, _, err := aliceChannel.SignNextCommitment()
 	if err != nil {
 		t.Fatalf("unable to sign commitment: %v", err)
 	}
@@ -5881,7 +5894,7 @@ func TestChannelRestoreUpdateLogs(t *testing.T) {
 	// sent. However her local commitment chain still won't include the
 	// state with the HTLC, since she hasn't received a new commitment
 	// signature from Bob yet.
-	_, _, _, err = aliceChannel.ReceiveRevocation(bobRevocation)
+	_, _, _, _, err = aliceChannel.ReceiveRevocation(bobRevocation)
 	if err != nil {
 		t.Fatalf("unable to recive revocation: %v", err)
 	}
@@ -5899,7 +5912,7 @@ func TestChannelRestoreUpdateLogs(t *testing.T) {
 	// and remote commit chains are updated in an async fashion. Since the
 	// remote chain was updated with the latest state (since Bob sent the
 	// revocation earlier) we can keep advancing the remote commit chain.
-	aliceSig, aliceHtlcSigs, err = aliceChannel.SignNextCommitment()
+	aliceSig, aliceHtlcSigs, _, err = aliceChannel.SignNextCommitment()
 	if err != nil {
 		t.Fatalf("unable to sign commitment: %v", err)
 	}
@@ -6064,7 +6077,7 @@ func TestChannelRestoreUpdateLogsFailedHTLC(t *testing.T) {
 	restoreAndAssert(t, aliceChannel, 1, 0, 0, 0)
 
 	// Bob sends a signature.
-	bobSig, bobHtlcSigs, err := bobChannel.SignNextCommitment()
+	bobSig, bobHtlcSigs, _, err := bobChannel.SignNextCommitment()
 	if err != nil {
 		t.Fatalf("unable to sign commitment: %v", err)
 	}
@@ -6083,7 +6096,7 @@ func TestChannelRestoreUpdateLogsFailedHTLC(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unable to revoke commitment: %v", err)
 	}
-	_, _, _, err = bobChannel.ReceiveRevocation(aliceRevocation)
+	_, _, _, _, err = bobChannel.ReceiveRevocation(aliceRevocation)
 	if err != nil {
 		t.Fatalf("bob unable to process alice's revocation: %v", err)
 	}
@@ -6097,7 +6110,7 @@ func TestChannelRestoreUpdateLogsFailedHTLC(t *testing.T) {
 
 	// Now send a signature from Alice. This will give Bob a new commitment
 	// where the HTLC is removed.
-	aliceSig, aliceHtlcSigs, err := aliceChannel.SignNextCommitment()
+	aliceSig, aliceHtlcSigs, _, err := aliceChannel.SignNextCommitment()
 	if err != nil {
 		t.Fatalf("unable to sign commitment: %v", err)
 	}
@@ -6119,7 +6132,7 @@ func TestChannelRestoreUpdateLogsFailedHTLC(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unable to revoke commitment: %v", err)
 	}
-	_, _, _, err = aliceChannel.ReceiveRevocation(bobRevocation)
+	_, _, _, _, err = aliceChannel.ReceiveRevocation(bobRevocation)
 	if err != nil {
 		t.Fatalf("unable to receive revocation: %v", err)
 	}
@@ -6177,7 +6190,7 @@ func TestDuplicateFailRejection(t *testing.T) {
 
 	// We'll now have Bob sign a new commitment to lock in the HTLC fail
 	// for Alice.
-	_, _, err = bobChannel.SignNextCommitment()
+	_, _, _, err = bobChannel.SignNextCommitment()
 	if err != nil {
 		t.Fatalf("unable to sign commit: %v", err)
 	}
@@ -6257,7 +6270,7 @@ func TestDuplicateSettleRejection(t *testing.T) {
 
 	// We'll now have Bob sign a new commitment to lock in the HTLC fail
 	// for Alice.
-	_, _, err = bobChannel.SignNextCommitment()
+	_, _, _, err = bobChannel.SignNextCommitment()
 	if err != nil {
 		t.Fatalf("unable to sign commit: %v", err)
 	}
@@ -6350,7 +6363,7 @@ func TestChannelRestoreCommitHeight(t *testing.T) {
 	}
 
 	// Let Alice sign a new state, which will include the HTLC just sent.
-	aliceSig, aliceHtlcSigs, err := aliceChannel.SignNextCommitment()
+	aliceSig, aliceHtlcSigs, _, err := aliceChannel.SignNextCommitment()
 	if err != nil {
 		t.Fatalf("unable to sign commitment: %v", err)
 	}
@@ -6376,7 +6389,7 @@ func TestChannelRestoreCommitHeight(t *testing.T) {
 	bobChannel = restoreAndAssertCommitHeights(t, bobChannel, true, 0, 1, 0)
 
 	// Alice receives the revocation, ACKing her pending commitment.
-	_, _, _, err = aliceChannel.ReceiveRevocation(bobRevocation)
+	_, _, _, _, err = aliceChannel.ReceiveRevocation(bobRevocation)
 	if err != nil {
 		t.Fatalf("unable to recive revocation: %v", err)
 	}
@@ -6388,7 +6401,7 @@ func TestChannelRestoreCommitHeight(t *testing.T) {
 
 	// Now let Bob send the commitment signature making the HTLC lock in on
 	// Alice's commitment.
-	bobSig, bobHtlcSigs, err := bobChannel.SignNextCommitment()
+	bobSig, bobHtlcSigs, _, err := bobChannel.SignNextCommitment()
 	if err != nil {
 		t.Fatalf("unable to sign commitment: %v", err)
 	}
@@ -6411,7 +6424,7 @@ func TestChannelRestoreCommitHeight(t *testing.T) {
 	aliceChannel = restoreAndAssertCommitHeights(t, aliceChannel, false,
 		0, 1, 1)
 
-	_, _, _, err = bobChannel.ReceiveRevocation(aliceRevocation)
+	_, _, _, _, err = bobChannel.ReceiveRevocation(aliceRevocation)
 	if err != nil {
 		t.Fatalf("unable to recive revocation: %v", err)
 	}
@@ -6433,7 +6446,7 @@ func TestChannelRestoreCommitHeight(t *testing.T) {
 
 	// Send a new signature from Alice to Bob, making Alice have a pending
 	// remote commitment.
-	aliceSig, aliceHtlcSigs, err = aliceChannel.SignNextCommitment()
+	aliceSig, aliceHtlcSigs, _, err = aliceChannel.SignNextCommitment()
 	if err != nil {
 		t.Fatalf("unable to sign commitment: %v", err)
 	}
@@ -6463,7 +6476,7 @@ func TestChannelRestoreCommitHeight(t *testing.T) {
 
 	// Sign a new state for Alice, making Bob have a pending remote
 	// commitment.
-	bobSig, bobHtlcSigs, err = bobChannel.SignNextCommitment()
+	bobSig, bobHtlcSigs, _, err = bobChannel.SignNextCommitment()
 	if err != nil {
 		t.Fatalf("unable to sign commitment: %v", err)
 	}
@@ -6519,7 +6532,7 @@ func TestForceCloseBorkedState(t *testing.T) {
 	// Do the commitment dance until Bob sends a revocation so Alice is
 	// able to receive the revocation, and then also make a new state
 	// herself.
-	aliceSigs, aliceHtlcSigs, err := aliceChannel.SignNextCommitment()
+	aliceSigs, aliceHtlcSigs, _, err := aliceChannel.SignNextCommitment()
 	if err != nil {
 		t.Fatalf("unable to sign commit: %v", err)
 	}
@@ -6531,7 +6544,7 @@ func TestForceCloseBorkedState(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unable to revoke bob commitment: %v", err)
 	}
-	bobSigs, bobHtlcSigs, err := bobChannel.SignNextCommitment()
+	bobSigs, bobHtlcSigs, _, err := bobChannel.SignNextCommitment()
 	if err != nil {
 		t.Fatalf("unable to sign commit: %v", err)
 	}
@@ -6563,7 +6576,7 @@ func TestForceCloseBorkedState(t *testing.T) {
 
 	// At this point, all channel mutating methods should now fail as they
 	// shouldn't be able to proceed if the channel is borked.
-	_, _, _, err = aliceChannel.ReceiveRevocation(revokeMsg)
+	_, _, _, _, err = aliceChannel.ReceiveRevocation(revokeMsg)
 	if err != channeldb.ErrChanBorked {
 		t.Fatalf("advance commitment tail should have failed")
 	}
@@ -6571,7 +6584,7 @@ func TestForceCloseBorkedState(t *testing.T) {
 	// We manually advance the commitment tail here since the above
 	// ReceiveRevocation call will fail before it's actually advanced.
 	aliceChannel.remoteCommitChain.advanceTail()
-	_, _, err = aliceChannel.SignNextCommitment()
+	_, _, _, err = aliceChannel.SignNextCommitment()
 	if err != channeldb.ErrChanBorked {
 		t.Fatalf("sign commitment should have failed: %v", err)
 	}

--- a/lnwallet/test_utils.go
+++ b/lnwallet/test_utils.go
@@ -496,7 +496,7 @@ func calcStaticFee(numHTLCs int) btcutil.Amount {
 // pending updates. This method is useful when testing interactions between two
 // live state machines.
 func ForceStateTransition(chanA, chanB *LightningChannel) error {
-	aliceSig, aliceHtlcSigs, err := chanA.SignNextCommitment()
+	aliceSig, aliceHtlcSigs, _, err := chanA.SignNextCommitment()
 	if err != nil {
 		return err
 	}
@@ -508,12 +508,12 @@ func ForceStateTransition(chanA, chanB *LightningChannel) error {
 	if err != nil {
 		return err
 	}
-	bobSig, bobHtlcSigs, err := chanB.SignNextCommitment()
+	bobSig, bobHtlcSigs, _, err := chanB.SignNextCommitment()
 	if err != nil {
 		return err
 	}
 
-	if _, _, _, err := chanA.ReceiveRevocation(bobRevocation); err != nil {
+	if _, _, _, _, err := chanA.ReceiveRevocation(bobRevocation); err != nil {
 		return err
 	}
 	if err := chanA.ReceiveNewCommitment(bobSig, bobHtlcSigs); err != nil {
@@ -524,7 +524,7 @@ func ForceStateTransition(chanA, chanB *LightningChannel) error {
 	if err != nil {
 		return err
 	}
-	if _, _, _, err := chanB.ReceiveRevocation(aliceRevocation); err != nil {
+	if _, _, _, _, err := chanB.ReceiveRevocation(aliceRevocation); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
In this commit, we address a TOOD, and end up fixing a lingering bug related to commitments on chain. Before this commit, it was possible that `lnd` would unnecessarily cause an incoming link to force close on chain if the outgoing link was in an indeterminate state. We fix this issue by always checking for HTLCs that we need to time out on the incoming link based on all valid commits. With this fix, we'll no longer go to chain unnecessarily which wastes chain fees and may also increase off-chain HTLC fail delays. 

Fixes #2045. 