### PR TITLE
fundingmanager: bump max non-initiator funding timeout to 2 weeks

### DIFF
--- a/fundingmanager.go
+++ b/fundingmanager.go
@@ -49,9 +49,9 @@ const (
 	maxLtcRemoteDelay uint16 = 8064
 
 	// maxWaitNumBlocksFundingConf is the maximum number of blocks to wait
-	// for the funding transaction to be confirmed before forgetting about
-	// the channel. 288 blocks is ~48 hrs
-	maxWaitNumBlocksFundingConf = 288
+	// for the funding transaction to be confirmed before forgetting
+	// channels that aren't initiated by us. 2016 blocks is ~2 weeks.
+	maxWaitNumBlocksFundingConf = 2016
 
 	// minChanFundingSize is the smallest channel that we'll allow to be
 	// created over the RPC interface.

--- a/fundingmanager_test.go
+++ b/fundingmanager_test.go
@@ -1597,17 +1597,17 @@ func TestFundingManagerFundingTimeout(t *testing.T) {
 			len(pendingChannels))
 	}
 
-	// We expect Bob to forget the channel after 288 blocks (48 hours), so
-	// mine 287, and check that it is still pending.
+	// We expect Bob to forget the channel after 2016 blocks (2 weeks), so
+	// mine 2016-1, and check that it is still pending.
 	bob.mockNotifier.epochChan <- &chainntnfs.BlockEpoch{
-		Height: fundingBroadcastHeight + 287,
+		Height: fundingBroadcastHeight + maxWaitNumBlocksFundingConf - 1,
 	}
 
 	// Bob should still be waiting for the channel to open.
 	assertNumPendingChannelsRemains(t, bob, 1)
 
 	bob.mockNotifier.epochChan <- &chainntnfs.BlockEpoch{
-		Height: fundingBroadcastHeight + 288,
+		Height: fundingBroadcastHeight + maxWaitNumBlocksFundingConf,
 	}
 
 	// Bob should have sent an Error message to Alice.


### PR DESCRIPTION
The previous value was set to two days, which may not be enough to
handle large fee spikes where users still which to submit channels with
a low fee and don't mind lowering their time preference. Since the
timeout is only applied to channels that we don't initiate, there's real
downside since it's not our funds that are locked up.