### PR TITLE
Allow unit-cover target for make to filter by package

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -126,7 +126,8 @@ unit: btcd
 
 unit-cover: $(GOACC_BIN)
 	@$(call print, "Running unit coverage tests.")
-	$(GOACC_BIN) $$(go list ./... | grep -v lnrpc) -- -test.tags="$(DEV_TAGS) $(LOG_TAGS)"
+	$(GOACC_BIN) $(COVER_PKG) -- -test.tags="$(DEV_TAGS) $(LOG_TAGS)"
+
 
 unit-race:
 	@$(call print, "Running unit race tests.")

--- a/make/testing_flags.mk
+++ b/make/testing_flags.mk
@@ -1,12 +1,14 @@
 DEV_TAGS = dev
 LOG_TAGS =
 TEST_FLAGS =
+COVER_PKG = $$(go list ./... | grep -v lnrpc)
 
 # If specific package is being unit tested, construct the full name of the
 # subpackage.
 ifneq ($(pkg),)
 UNITPKG := $(PKG)/$(pkg)
 UNIT_TARGETED = yes
+COVER_PKG = $(PKG)/$(pkg)
 endif
 
 # If a specific unit test case is being target, construct test.run filter.


### PR DESCRIPTION
Previous to this commit, running `make unit-cover pkg=xx`
would ignore the selected package and run unit tests and
coverage for all packages.
After this commit, the package selected with pkg= is the
only one that is tested and coverage output generated for.

Note: I kept the lnrpc filter for this case too (not 100% sure I understand it), also I think it's a bit suboptimal using `grep` here, so if someone prefers to make a better version than this I'm all for it! :)