### PR TITLE
route: return 0 fee from TotalFees for empty route.

### DIFF
--- a/routing/route/route.go
+++ b/routing/route/route.go
@@ -103,6 +103,10 @@ func (r *Route) HopFee(hopIndex int) lnwire.MilliSatoshi {
 // the case of a one-hop payment, this value will be zero as we don't need to
 // pay a fee to ourself.
 func (r *Route) TotalFees() lnwire.MilliSatoshi {
+	if len(r.Hops) == 0 {
+		return 0
+	}
+
 	return r.TotalAmount - r.Hops[len(r.Hops)-1].AmtToForward
 }
 

--- a/routing/route/route_test.go
+++ b/routing/route/route_test.go
@@ -1,0 +1,58 @@
+package route
+
+import (
+	"testing"
+
+	"github.com/lightningnetwork/lnd/lnwire"
+)
+
+// TestRouteTotalFees checks that a route reports the expected total fee.
+func TestRouteTotalFees(t *testing.T) {
+	t.Parallel()
+
+	// Make sure empty route returns a 0 fee.
+	r := &Route{}
+	if r.TotalFees() != 0 {
+		t.Fatalf("expected 0 fees, got %v", r.TotalFees())
+	}
+
+	// For one-hop routes the fee should be 0, since the last node will
+	// receive the full amount.
+	amt := lnwire.MilliSatoshi(1000)
+	hops := []*Hop{
+		{
+			PubKeyBytes:      Vertex{},
+			ChannelID:        1,
+			OutgoingTimeLock: 44,
+			AmtToForward:     amt,
+		},
+	}
+	r, err := NewRouteFromHops(amt, 100, Vertex{}, hops)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if r.TotalFees() != 0 {
+		t.Fatalf("expected 0 fees, got %v", r.TotalFees())
+	}
+
+	// Append the route with a node, making the first one take a fee.
+	fee := lnwire.MilliSatoshi(100)
+	hops = append(hops, &Hop{
+		PubKeyBytes:      Vertex{},
+		ChannelID:        2,
+		OutgoingTimeLock: 33,
+		AmtToForward:     amt - fee,
+	},
+	)
+
+	r, err = NewRouteFromHops(amt, 100, Vertex{}, hops)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if r.TotalFees() != fee {
+		t.Fatalf("expected %v fees, got %v", fee, r.TotalFees())
+	}
+
+}


### PR DESCRIPTION
Also adds a simple unit test for the TotalFees method.

This fixes a crash that could happen if the `rpcserver` tried to list a payment that didn't have any payment attempt recorded: https://github.com/lightningnetwork/lnd/blob/28fdf9712d88c104ca039dc56d5242d3822c00d0/rpcserver.go#L4150