### PR TITLE
[funding+autopilot] Make the funding manager and autopilot fee aware

### DIFF
--- a/autopilot/agent.go
+++ b/autopilot/agent.go
@@ -584,6 +584,7 @@ func (a *Agent) openChans(availableFunds btcutil.Amount, numChans uint32,
 
 	// Use the heuristic to calculate a score for each node in the
 	// graph.
+	log.Debugf("Scoring %d nodes for chan_size=%v", len(nodes), chanSize)
 	scores, err := a.cfg.Heuristic.NodeScores(
 		a.cfg.Graph, totalChans, chanSize, nodes,
 	)

--- a/autopilot/interface.go
+++ b/autopilot/interface.go
@@ -188,10 +188,11 @@ func init() {
 // open a channel within the graph to a target peer, close targeted channels,
 // or add/remove funds from existing channels via a splice in/out mechanisms.
 type ChannelController interface {
-	// OpenChannel opens a channel to a target peer, with a capacity of the
-	// specified amount. This function should un-block immediately after
-	// the funding transaction that marks the channel open has been
-	// broadcast.
+	// OpenChannel opens a channel to a target peer, using at most amt
+	// funds. This means that the resulting channel capacity might be
+	// slightly less to account for fees. This function should un-block
+	// immediately after the funding transaction that marks the channel
+	// open has been broadcast.
 	OpenChannel(target *btcec.PublicKey, amt btcutil.Amount) error
 
 	// CloseChannel attempts to close out the target channel.

--- a/fundingmanager.go
+++ b/fundingmanager.go
@@ -1084,16 +1084,16 @@ func (f *fundingManager) handleFundingOpen(fmsg *fundingOpenMsg) {
 	// funds to the channel ourselves.
 	chainHash := chainhash.Hash(msg.ChainHash)
 	req := &lnwallet.InitFundingReserveMsg{
-		ChainHash:       &chainHash,
-		NodeID:          fmsg.peer.IdentityKey(),
-		NodeAddr:        fmsg.peer.Address(),
-		FundingAmount:   0,
-		Capacity:        amt,
-		CommitFeePerKw:  lnwallet.SatPerKWeight(msg.FeePerKiloWeight),
-		FundingFeePerKw: 0,
-		PushMSat:        msg.PushAmount,
-		Flags:           msg.ChannelFlags,
-		MinConfs:        1,
+		ChainHash:        &chainHash,
+		NodeID:           fmsg.peer.IdentityKey(),
+		NodeAddr:         fmsg.peer.Address(),
+		LocalFundingAmt:  0,
+		RemoteFundingAmt: amt,
+		CommitFeePerKw:   lnwallet.SatPerKWeight(msg.FeePerKiloWeight),
+		FundingFeePerKw:  0,
+		PushMSat:         msg.PushAmount,
+		Flags:            msg.ChannelFlags,
+		MinConfs:         1,
 	}
 
 	reservation, err := f.cfg.Wallet.InitChannelReservation(req)
@@ -2783,16 +2783,16 @@ func (f *fundingManager) handleInitFundingMsg(msg *initFundingMsg) {
 	// wallet doesn't have enough funds to commit to this channel, then the
 	// request will fail, and be aborted.
 	req := &lnwallet.InitFundingReserveMsg{
-		ChainHash:       &msg.chainHash,
-		NodeID:          peerKey,
-		NodeAddr:        msg.peer.Address(),
-		FundingAmount:   localAmt,
-		Capacity:        capacity,
-		CommitFeePerKw:  commitFeePerKw,
-		FundingFeePerKw: msg.fundingFeePerKw,
-		PushMSat:        msg.pushAmt,
-		Flags:           channelFlags,
-		MinConfs:        msg.minConfs,
+		ChainHash:        &msg.chainHash,
+		NodeID:           peerKey,
+		NodeAddr:         msg.peer.Address(),
+		LocalFundingAmt:  localAmt,
+		RemoteFundingAmt: 0,
+		CommitFeePerKw:   commitFeePerKw,
+		FundingFeePerKw:  msg.fundingFeePerKw,
+		PushMSat:         msg.pushAmt,
+		Flags:            channelFlags,
+		MinConfs:         msg.minConfs,
 	}
 
 	reservation, err := f.cfg.Wallet.InitChannelReservation(req)

--- a/fundingmanager.go
+++ b/fundingmanager.go
@@ -337,6 +337,14 @@ type fundingConfig struct {
 	// due to fees.
 	MinChanSize btcutil.Amount
 
+	// MaxPendingChannels is the maximum number of pending channels we
+	// allow for each peer.
+	MaxPendingChannels int
+
+	// RejectPush is set true if the fundingmanager should reject any
+	// incoming channels having a non-zero push amount.
+	RejectPush bool
+
 	// NotifyOpenChannelEvent informs the ChannelNotifier when channels
 	// transition from pending open to open.
 	NotifyOpenChannelEvent func(wire.OutPoint)
@@ -1012,7 +1020,7 @@ func (f *fundingManager) handleFundingOpen(fmsg *fundingOpenMsg) {
 
 	// TODO(roasbeef): modify to only accept a _single_ pending channel per
 	// block unless white listed
-	if numPending >= cfg.MaxPendingChannels {
+	if numPending >= f.cfg.MaxPendingChannels {
 		f.failFundingFlow(
 			fmsg.peer, fmsg.msg.PendingChannelID,
 			lnwire.ErrMaxPendingChannels,
@@ -1057,7 +1065,7 @@ func (f *fundingManager) handleFundingOpen(fmsg *fundingOpenMsg) {
 
 	// If request specifies non-zero push amount and 'rejectpush' is set,
 	// signal an error.
-	if cfg.RejectPush && msg.PushAmount > 0 {
+	if f.cfg.RejectPush && msg.PushAmount > 0 {
 		f.failFundingFlow(
 			fmsg.peer, fmsg.msg.PendingChannelID,
 			lnwallet.ErrNonZeroPushAmount())

--- a/fundingmanager.go
+++ b/fundingmanager.go
@@ -2742,8 +2742,7 @@ func (f *fundingManager) handleInitFundingMsg(msg *initFundingMsg) {
 	var (
 		peerKey        = msg.peer.IdentityKey()
 		localAmt       = msg.localFundingAmt
-		remoteAmt      = msg.remoteFundingAmt
-		capacity       = localAmt + remoteAmt
+		capacity       = localAmt
 		minHtlc        = msg.minHtlc
 		remoteCsvDelay = msg.remoteCsvDelay
 	)

--- a/fundingmanager.go
+++ b/fundingmanager.go
@@ -1722,8 +1722,8 @@ func (f *fundingManager) handleFundingSigned(fmsg *fundingSignedMsg) {
 			return
 		case shortChanID, ok = <-confChan:
 			if !ok {
-				fndgLog.Errorf("waiting for funding confirmation" +
-					" failed")
+				fndgLog.Errorf("waiting for funding " +
+					"confirmation failed")
 				return
 			}
 		}
@@ -1893,8 +1893,9 @@ func makeFundingScript(channel *channeldb.OpenChannel) ([]byte, error) {
 // when a channel has become active for lightning transactions.
 // The wait can be canceled by closing the cancelChan. In case of success,
 // a *lnwire.ShortChannelID will be passed to confChan.
-func (f *fundingManager) waitForFundingConfirmation(completeChan *channeldb.OpenChannel,
-	cancelChan <-chan struct{}, confChan chan<- *lnwire.ShortChannelID) {
+func (f *fundingManager) waitForFundingConfirmation(
+	completeChan *channeldb.OpenChannel, cancelChan <-chan struct{},
+	confChan chan<- *lnwire.ShortChannelID) {
 
 	defer close(confChan)
 
@@ -1904,16 +1905,19 @@ func (f *fundingManager) waitForFundingConfirmation(completeChan *channeldb.Open
 	fundingScript, err := makeFundingScript(completeChan)
 	if err != nil {
 		fndgLog.Errorf("unable to create funding script for "+
-			"ChannelPoint(%v): %v", completeChan.FundingOutpoint, err)
+			"ChannelPoint(%v): %v", completeChan.FundingOutpoint,
+			err)
 		return
 	}
 	numConfs := uint32(completeChan.NumConfsRequired)
 	confNtfn, err := f.cfg.Notifier.RegisterConfirmationsNtfn(
-		&txid, fundingScript, numConfs, completeChan.FundingBroadcastHeight,
+		&txid, fundingScript, numConfs,
+		completeChan.FundingBroadcastHeight,
 	)
 	if err != nil {
 		fndgLog.Errorf("Unable to register for confirmation of "+
-			"ChannelPoint(%v): %v", completeChan.FundingOutpoint, err)
+			"ChannelPoint(%v): %v", completeChan.FundingOutpoint,
+			err)
 		return
 	}
 
@@ -1928,14 +1932,17 @@ func (f *fundingManager) waitForFundingConfirmation(completeChan *channeldb.Open
 	select {
 	case confDetails, ok = <-confNtfn.Confirmed:
 		// fallthrough
+
 	case <-cancelChan:
 		fndgLog.Warnf("canceled waiting for funding confirmation, "+
 			"stopping funding flow for ChannelPoint(%v)",
 			completeChan.FundingOutpoint)
 		return
+
 	case <-f.quit:
 		fndgLog.Warnf("fundingManager shutting down, stopping funding "+
-			"flow for ChannelPoint(%v)", completeChan.FundingOutpoint)
+			"flow for ChannelPoint(%v)",
+			completeChan.FundingOutpoint)
 		return
 	}
 
@@ -1948,6 +1955,18 @@ func (f *fundingManager) waitForFundingConfirmation(completeChan *channeldb.Open
 
 	fundingPoint := completeChan.FundingOutpoint
 	chanID := lnwire.NewChanIDFromOutPoint(&fundingPoint)
+	if int(fundingPoint.Index) >= len(confDetails.Tx.TxOut) {
+		fndgLog.Warnf("Funding point index does not exist for "+
+			"ChannelPoint(%v)", completeChan.FundingOutpoint)
+		return
+	}
+
+	outputAmt := btcutil.Amount(confDetails.Tx.TxOut[fundingPoint.Index].Value)
+	if outputAmt != completeChan.Capacity {
+		fndgLog.Warnf("Invalid output value for ChannelPoint(%v)",
+			completeChan.FundingOutpoint)
+		return
+	}
 
 	fndgLog.Infof("ChannelPoint(%v) is now active: ChannelID(%x)",
 		fundingPoint, chanID[:])
@@ -2742,7 +2761,6 @@ func (f *fundingManager) handleInitFundingMsg(msg *initFundingMsg) {
 	var (
 		peerKey        = msg.peer.IdentityKey()
 		localAmt       = msg.localFundingAmt
-		capacity       = localAmt
 		minHtlc        = msg.minHtlc
 		remoteCsvDelay = msg.remoteCsvDelay
 	)
@@ -2756,10 +2774,11 @@ func (f *fundingManager) handleInitFundingMsg(msg *initFundingMsg) {
 		ourDustLimit = defaultLitecoinDustLimit
 	}
 
-	fndgLog.Infof("Initiating fundingRequest(localAmt=%v, remoteAmt=%v, "+
-		"capacity=%v, chainhash=%v, peer=%x, dustLimit=%v, min_confs=%v)",
-		localAmt, msg.pushAmt, capacity, msg.chainHash,
-		peerKey.SerializeCompressed(), ourDustLimit, msg.minConfs)
+	fndgLog.Infof("Initiating fundingRequest(local_amt=%v "+
+		"(subtract_fees=%v), push_amt=%v, chain_hash=%v, peer=%x, "+
+		"dust_limit=%v, min_confs=%v)", localAmt, msg.subtractFees,
+		msg.pushAmt, msg.chainHash, peerKey.SerializeCompressed(),
+		ourDustLimit, msg.minConfs)
 
 	// First, we'll query the fee estimator for a fee that should get the
 	// commitment transaction confirmed by the next few blocks (conf target
@@ -2786,6 +2805,7 @@ func (f *fundingManager) handleInitFundingMsg(msg *initFundingMsg) {
 		ChainHash:        &msg.chainHash,
 		NodeID:           peerKey,
 		NodeAddr:         msg.peer.Address(),
+		SubtractFees:     msg.subtractFees,
 		LocalFundingAmt:  localAmt,
 		RemoteFundingAmt: 0,
 		CommitFeePerKw:   commitFeePerKw,
@@ -2800,6 +2820,12 @@ func (f *fundingManager) handleInitFundingMsg(msg *initFundingMsg) {
 		msg.err <- err
 		return
 	}
+
+	// Now that we have successfully reserved funds for this channel in the
+	// wallet, we can fetch the final channel capacity. This is done at
+	// this point since the final capacity might change in case of
+	// SubtractFees=true.
+	capacity := reservation.Capacity()
 
 	// Obtain a new pending channel ID which is used to track this
 	// reservation throughout its lifetime.

--- a/fundingmanager_test.go
+++ b/fundingmanager_test.go
@@ -682,6 +682,8 @@ func assertErrorSent(t *testing.T, msgChan chan lnwire.Message) {
 
 func assertFundingMsgSent(t *testing.T, msgChan chan lnwire.Message,
 	msgType string) lnwire.Message {
+	t.Helper()
+
 	var msg lnwire.Message
 	select {
 	case msg = <-msgChan:
@@ -1037,6 +1039,8 @@ func assertHandleFundingLocked(t *testing.T, alice, bob *testNode) {
 }
 
 func TestFundingManagerNormalWorkflow(t *testing.T) {
+	t.Parallel()
+
 	alice, bob := setupFundingManagers(t)
 	defer tearDownFundingManagers(t, alice, bob)
 
@@ -1110,6 +1114,8 @@ func TestFundingManagerNormalWorkflow(t *testing.T) {
 }
 
 func TestFundingManagerRestartBehavior(t *testing.T) {
+	t.Parallel()
+
 	alice, bob := setupFundingManagers(t)
 	defer tearDownFundingManagers(t, alice, bob)
 
@@ -1248,6 +1254,8 @@ func TestFundingManagerRestartBehavior(t *testing.T) {
 // server to notify when the peer comes online, in case sending the
 // fundingLocked message fails the first time.
 func TestFundingManagerOfflinePeer(t *testing.T) {
+	t.Parallel()
+
 	alice, bob := setupFundingManagers(t)
 	defer tearDownFundingManagers(t, alice, bob)
 
@@ -1382,6 +1390,8 @@ func TestFundingManagerOfflinePeer(t *testing.T) {
 // will properly clean up a zombie reservation that times out after the
 // initFundingMsg has been handled.
 func TestFundingManagerPeerTimeoutAfterInitFunding(t *testing.T) {
+	t.Parallel()
+
 	alice, bob := setupFundingManagers(t)
 	defer tearDownFundingManagers(t, alice, bob)
 
@@ -1442,6 +1452,8 @@ func TestFundingManagerPeerTimeoutAfterInitFunding(t *testing.T) {
 // will properly clean up a zombie reservation that times out after the
 // fundingOpenMsg has been handled.
 func TestFundingManagerPeerTimeoutAfterFundingOpen(t *testing.T) {
+	t.Parallel()
+
 	alice, bob := setupFundingManagers(t)
 	defer tearDownFundingManagers(t, alice, bob)
 
@@ -1511,6 +1523,8 @@ func TestFundingManagerPeerTimeoutAfterFundingOpen(t *testing.T) {
 // will properly clean up a zombie reservation that times out after the
 // fundingAcceptMsg has been handled.
 func TestFundingManagerPeerTimeoutAfterFundingAccept(t *testing.T) {
+	t.Parallel()
+
 	alice, bob := setupFundingManagers(t)
 	defer tearDownFundingManagers(t, alice, bob)
 
@@ -1585,6 +1599,8 @@ func TestFundingManagerPeerTimeoutAfterFundingAccept(t *testing.T) {
 }
 
 func TestFundingManagerFundingTimeout(t *testing.T) {
+	t.Parallel()
+
 	alice, bob := setupFundingManagers(t)
 	defer tearDownFundingManagers(t, alice, bob)
 
@@ -1629,6 +1645,7 @@ func TestFundingManagerFundingTimeout(t *testing.T) {
 // TestFundingManagerFundingNotTimeoutInitiator checks that if the user was
 // the channel initiator, that it does not timeout when the lnd restarts.
 func TestFundingManagerFundingNotTimeoutInitiator(t *testing.T) {
+	t.Parallel()
 
 	alice, bob := setupFundingManagers(t)
 	defer tearDownFundingManagers(t, alice, bob)
@@ -1697,6 +1714,8 @@ func TestFundingManagerFundingNotTimeoutInitiator(t *testing.T) {
 // continues to operate as expected in case we receive a duplicate fundingLocked
 // message.
 func TestFundingManagerReceiveFundingLockedTwice(t *testing.T) {
+	t.Parallel()
+
 	alice, bob := setupFundingManagers(t)
 	defer tearDownFundingManagers(t, alice, bob)
 
@@ -1789,6 +1808,8 @@ func TestFundingManagerReceiveFundingLockedTwice(t *testing.T) {
 // handles receiving a fundingLocked after the its own fundingLocked and channel
 // announcement is sent and gets restarted.
 func TestFundingManagerRestartAfterChanAnn(t *testing.T) {
+	t.Parallel()
+
 	alice, bob := setupFundingManagers(t)
 	defer tearDownFundingManagers(t, alice, bob)
 
@@ -1866,6 +1887,8 @@ func TestFundingManagerRestartAfterChanAnn(t *testing.T) {
 // fundingManager continues to operate as expected after it has received
 // fundingLocked and then gets restarted.
 func TestFundingManagerRestartAfterReceivingFundingLocked(t *testing.T) {
+	t.Parallel()
+
 	alice, bob := setupFundingManagers(t)
 	defer tearDownFundingManagers(t, alice, bob)
 
@@ -1939,6 +1962,8 @@ func TestFundingManagerRestartAfterReceivingFundingLocked(t *testing.T) {
 // (a channel not supposed to be announced to the rest of the network),
 // the announcementSignatures nor the nodeAnnouncement messages are sent.
 func TestFundingManagerPrivateChannel(t *testing.T) {
+	t.Parallel()
+
 	alice, bob := setupFundingManagers(t)
 	defer tearDownFundingManagers(t, alice, bob)
 
@@ -2041,6 +2066,8 @@ func TestFundingManagerPrivateChannel(t *testing.T) {
 // announcement signatures nor the node announcement messages are sent upon
 // restart.
 func TestFundingManagerPrivateRestart(t *testing.T) {
+	t.Parallel()
+
 	alice, bob := setupFundingManagers(t)
 	defer tearDownFundingManagers(t, alice, bob)
 
@@ -2163,6 +2190,8 @@ func TestFundingManagerPrivateRestart(t *testing.T) {
 // TestFundingManagerCustomChannelParameters checks that custom requirements we
 // specify during the channel funding flow is preserved correcly on both sides.
 func TestFundingManagerCustomChannelParameters(t *testing.T) {
+	t.Parallel()
+
 	alice, bob := setupFundingManagers(t)
 	defer tearDownFundingManagers(t, alice, bob)
 
@@ -2391,6 +2420,8 @@ func TestFundingManagerCustomChannelParameters(t *testing.T) {
 // TestFundingManagerMaxPendingChannels checks that trying to open another
 // channel with the same peer when MaxPending channels are pending fails.
 func TestFundingManagerMaxPendingChannels(t *testing.T) {
+	t.Parallel()
+
 	const maxPending = 4
 
 	alice, bob := setupFundingManagers(
@@ -2556,6 +2587,8 @@ func TestFundingManagerMaxPendingChannels(t *testing.T) {
 // TestFundingManagerRejectPush checks behaviour of 'rejectpush'
 // option, namely that non-zero incoming push amounts are disabled.
 func TestFundingManagerRejectPush(t *testing.T) {
+	t.Parallel()
+
 	// Enable 'rejectpush' option and initialize funding managers.
 	alice, bob := setupFundingManagers(
 		t, func(cfg *fundingConfig) {

--- a/lnwallet/interface_test.go
+++ b/lnwallet/interface_test.go
@@ -753,9 +753,9 @@ func testCancelNonExistentReservation(miner *rpctest.Harness,
 func testReservationInitiatorBalanceBelowDustCancel(miner *rpctest.Harness,
 	alice, _ *lnwallet.LightningWallet, t *testing.T) {
 
-	// We'll attempt to create a new reservation with an extremely high fee
-	// rate. This should push our balance into the negative and result in a
-	// failure to create the reservation.
+	// We'll attempt to create a new reservation with an extremely high
+	// commitment fee rate. This should push our balance into the negative
+	// and result in a failure to create the reservation.
 	const numBTC = 4
 	fundingAmount, err := btcutil.NewAmount(numBTC)
 	if err != nil {
@@ -772,7 +772,7 @@ func testReservationInitiatorBalanceBelowDustCancel(miner *rpctest.Harness,
 		LocalFundingAmt:  fundingAmount,
 		RemoteFundingAmt: 0,
 		CommitFeePerKw:   feePerKw,
-		FundingFeePerKw:  feePerKw,
+		FundingFeePerKw:  1000,
 		PushMSat:         0,
 		Flags:            lnwire.FFAnnounceChannel,
 	}

--- a/lnwallet/interface_test.go
+++ b/lnwallet/interface_test.go
@@ -415,15 +415,15 @@ func testDualFundingReservationWorkflow(miner *rpctest.Harness,
 		t.Fatalf("unable to query fee estimator: %v", err)
 	}
 	aliceReq := &lnwallet.InitFundingReserveMsg{
-		ChainHash:       chainHash,
-		NodeID:          bobPub,
-		NodeAddr:        bobAddr,
-		FundingAmount:   fundingAmount,
-		Capacity:        fundingAmount * 2,
-		CommitFeePerKw:  feePerKw,
-		FundingFeePerKw: feePerKw,
-		PushMSat:        0,
-		Flags:           lnwire.FFAnnounceChannel,
+		ChainHash:        chainHash,
+		NodeID:           bobPub,
+		NodeAddr:         bobAddr,
+		LocalFundingAmt:  fundingAmount,
+		RemoteFundingAmt: fundingAmount,
+		CommitFeePerKw:   feePerKw,
+		FundingFeePerKw:  feePerKw,
+		PushMSat:         0,
+		Flags:            lnwire.FFAnnounceChannel,
 	}
 	aliceChanReservation, err := alice.InitChannelReservation(aliceReq)
 	if err != nil {
@@ -458,15 +458,15 @@ func testDualFundingReservationWorkflow(miner *rpctest.Harness,
 	// receives' Alice's contribution, and consumes that so we can continue
 	// the funding process.
 	bobReq := &lnwallet.InitFundingReserveMsg{
-		ChainHash:       chainHash,
-		NodeID:          alicePub,
-		NodeAddr:        aliceAddr,
-		FundingAmount:   fundingAmount,
-		Capacity:        fundingAmount * 2,
-		CommitFeePerKw:  feePerKw,
-		FundingFeePerKw: feePerKw,
-		PushMSat:        0,
-		Flags:           lnwire.FFAnnounceChannel,
+		ChainHash:        chainHash,
+		NodeID:           alicePub,
+		NodeAddr:         aliceAddr,
+		LocalFundingAmt:  fundingAmount,
+		RemoteFundingAmt: fundingAmount,
+		CommitFeePerKw:   feePerKw,
+		FundingFeePerKw:  feePerKw,
+		PushMSat:         0,
+		Flags:            lnwire.FFAnnounceChannel,
 	}
 	bobChanReservation, err := bob.InitChannelReservation(bobReq)
 	if err != nil {
@@ -618,15 +618,15 @@ func testFundingTransactionLockedOutputs(miner *rpctest.Harness,
 		t.Fatalf("unable to query fee estimator: %v", err)
 	}
 	req := &lnwallet.InitFundingReserveMsg{
-		ChainHash:       chainHash,
-		NodeID:          bobPub,
-		NodeAddr:        bobAddr,
-		FundingAmount:   fundingAmount,
-		Capacity:        fundingAmount,
-		CommitFeePerKw:  feePerKw,
-		FundingFeePerKw: feePerKw,
-		PushMSat:        0,
-		Flags:           lnwire.FFAnnounceChannel,
+		ChainHash:        chainHash,
+		NodeID:           bobPub,
+		NodeAddr:         bobAddr,
+		LocalFundingAmt:  fundingAmount,
+		RemoteFundingAmt: 0,
+		CommitFeePerKw:   feePerKw,
+		FundingFeePerKw:  feePerKw,
+		PushMSat:         0,
+		Flags:            lnwire.FFAnnounceChannel,
 	}
 	if _, err := alice.InitChannelReservation(req); err != nil {
 		t.Fatalf("unable to initialize funding reservation 1: %v", err)
@@ -640,15 +640,15 @@ func testFundingTransactionLockedOutputs(miner *rpctest.Harness,
 		t.Fatalf("unable to create amt: %v", err)
 	}
 	failedReq := &lnwallet.InitFundingReserveMsg{
-		ChainHash:       chainHash,
-		NodeID:          bobPub,
-		NodeAddr:        bobAddr,
-		FundingAmount:   amt,
-		Capacity:        amt,
-		CommitFeePerKw:  feePerKw,
-		FundingFeePerKw: feePerKw,
-		PushMSat:        0,
-		Flags:           lnwire.FFAnnounceChannel,
+		ChainHash:        chainHash,
+		NodeID:           bobPub,
+		NodeAddr:         bobAddr,
+		LocalFundingAmt:  amt,
+		RemoteFundingAmt: 0,
+		CommitFeePerKw:   feePerKw,
+		FundingFeePerKw:  feePerKw,
+		PushMSat:         0,
+		Flags:            lnwire.FFAnnounceChannel,
 	}
 	failedReservation, err := alice.InitChannelReservation(failedReq)
 	if err == nil {
@@ -676,15 +676,15 @@ func testFundingCancellationNotEnoughFunds(miner *rpctest.Harness,
 		t.Fatalf("unable to create amt: %v", err)
 	}
 	req := &lnwallet.InitFundingReserveMsg{
-		ChainHash:       chainHash,
-		NodeID:          bobPub,
-		NodeAddr:        bobAddr,
-		FundingAmount:   fundingAmount,
-		Capacity:        fundingAmount,
-		CommitFeePerKw:  feePerKw,
-		FundingFeePerKw: feePerKw,
-		PushMSat:        0,
-		Flags:           lnwire.FFAnnounceChannel,
+		ChainHash:        chainHash,
+		NodeID:           bobPub,
+		NodeAddr:         bobAddr,
+		LocalFundingAmt:  fundingAmount,
+		RemoteFundingAmt: 0,
+		CommitFeePerKw:   feePerKw,
+		FundingFeePerKw:  feePerKw,
+		PushMSat:         0,
+		Flags:            lnwire.FFAnnounceChannel,
 	}
 	chanReservation, err := alice.InitChannelReservation(req)
 	if err != nil {
@@ -766,15 +766,15 @@ func testReservationInitiatorBalanceBelowDustCancel(miner *rpctest.Harness,
 		numBTC * numBTC * btcutil.SatoshiPerBitcoin,
 	)
 	req := &lnwallet.InitFundingReserveMsg{
-		ChainHash:       chainHash,
-		NodeID:          bobPub,
-		NodeAddr:        bobAddr,
-		FundingAmount:   fundingAmount,
-		Capacity:        fundingAmount,
-		CommitFeePerKw:  feePerKw,
-		FundingFeePerKw: feePerKw,
-		PushMSat:        0,
-		Flags:           lnwire.FFAnnounceChannel,
+		ChainHash:        chainHash,
+		NodeID:           bobPub,
+		NodeAddr:         bobAddr,
+		LocalFundingAmt:  fundingAmount,
+		RemoteFundingAmt: 0,
+		CommitFeePerKw:   feePerKw,
+		FundingFeePerKw:  feePerKw,
+		PushMSat:         0,
+		Flags:            lnwire.FFAnnounceChannel,
 	}
 	_, err = alice.InitChannelReservation(req)
 	switch {
@@ -847,15 +847,15 @@ func testSingleFunderReservationWorkflow(miner *rpctest.Harness,
 		t.Fatalf("unable to query fee estimator: %v", err)
 	}
 	aliceReq := &lnwallet.InitFundingReserveMsg{
-		ChainHash:       chainHash,
-		NodeID:          bobPub,
-		NodeAddr:        bobAddr,
-		FundingAmount:   fundingAmt,
-		Capacity:        fundingAmt,
-		CommitFeePerKw:  feePerKw,
-		FundingFeePerKw: feePerKw,
-		PushMSat:        pushAmt,
-		Flags:           lnwire.FFAnnounceChannel,
+		ChainHash:        chainHash,
+		NodeID:           bobPub,
+		NodeAddr:         bobAddr,
+		LocalFundingAmt:  fundingAmt,
+		RemoteFundingAmt: 0,
+		CommitFeePerKw:   feePerKw,
+		FundingFeePerKw:  feePerKw,
+		PushMSat:         pushAmt,
+		Flags:            lnwire.FFAnnounceChannel,
 	}
 	aliceChanReservation, err := alice.InitChannelReservation(aliceReq)
 	if err != nil {
@@ -890,15 +890,15 @@ func testSingleFunderReservationWorkflow(miner *rpctest.Harness,
 	// Next, Bob receives the initial request, generates a corresponding
 	// reservation initiation, then consume Alice's contribution.
 	bobReq := &lnwallet.InitFundingReserveMsg{
-		ChainHash:       chainHash,
-		NodeID:          alicePub,
-		NodeAddr:        aliceAddr,
-		FundingAmount:   0,
-		Capacity:        fundingAmt,
-		CommitFeePerKw:  feePerKw,
-		FundingFeePerKw: feePerKw,
-		PushMSat:        pushAmt,
-		Flags:           lnwire.FFAnnounceChannel,
+		ChainHash:        chainHash,
+		NodeID:           alicePub,
+		NodeAddr:         aliceAddr,
+		LocalFundingAmt:  0,
+		RemoteFundingAmt: fundingAmt,
+		CommitFeePerKw:   feePerKw,
+		FundingFeePerKw:  feePerKw,
+		PushMSat:         pushAmt,
+		Flags:            lnwire.FFAnnounceChannel,
 	}
 	bobChanReservation, err := bob.InitChannelReservation(bobReq)
 	if err != nil {

--- a/lnwallet/reservation.go
+++ b/lnwallet/reservation.go
@@ -127,7 +127,7 @@ type ChannelReservation struct {
 // used only internally by lnwallet. In order to concurrent safety, the
 // creation of all channel reservations should be carried out via the
 // lnwallet.InitChannelReservation interface.
-func NewChannelReservation(capacity, fundingAmt btcutil.Amount,
+func NewChannelReservation(capacity, localFundingAmt btcutil.Amount,
 	commitFeePerKw SatPerKWeight, wallet *LightningWallet,
 	id uint64, pushMSat lnwire.MilliSatoshi, chainHash *chainhash.Hash,
 	flags lnwire.FundingFlag) (*ChannelReservation, error) {
@@ -139,14 +139,16 @@ func NewChannelReservation(capacity, fundingAmt btcutil.Amount,
 	)
 
 	commitFee := commitFeePerKw.FeeForWeight(input.CommitWeight)
-	fundingMSat := lnwire.NewMSatFromSatoshis(fundingAmt)
+	localFundingMSat := lnwire.NewMSatFromSatoshis(localFundingAmt)
+	// TODO(halseth): make method take remote funding amount direcly
+	// instead of inferring it from capacity and local amt.
 	capacityMSat := lnwire.NewMSatFromSatoshis(capacity)
 	feeMSat := lnwire.NewMSatFromSatoshis(commitFee)
 
 	// If we're the responder to a single-funder reservation, then we have
 	// no initial balance in the channel unless the remote party is pushing
 	// some funds to us within the first commitment state.
-	if fundingAmt == 0 {
+	if localFundingAmt == 0 {
 		ourBalance = pushMSat
 		theirBalance = capacityMSat - feeMSat - pushMSat
 		initiator = false
@@ -163,7 +165,7 @@ func NewChannelReservation(capacity, fundingAmt btcutil.Amount,
 		// TODO(roasbeef): need to rework fee structure in general and
 		// also when we "unlock" dual funder within the daemon
 
-		if capacity == fundingAmt {
+		if capacity == localFundingAmt {
 			// If we're initiating a single funder workflow, then
 			// we pay all the initial fees within the commitment
 			// transaction. We also deduct our balance by the
@@ -174,8 +176,8 @@ func NewChannelReservation(capacity, fundingAmt btcutil.Amount,
 			// Otherwise, this is a dual funder workflow where both
 			// slides split the amount funded and the commitment
 			// fee.
-			ourBalance = fundingMSat - (feeMSat / 2)
-			theirBalance = capacityMSat - fundingMSat - (feeMSat / 2) + pushMSat
+			ourBalance = localFundingMSat - (feeMSat / 2)
+			theirBalance = capacityMSat - localFundingMSat - (feeMSat / 2) + pushMSat
 		}
 
 		initiator = true

--- a/lnwallet/reservation.go
+++ b/lnwallet/reservation.go
@@ -515,6 +515,13 @@ func (r *ChannelReservation) FundingOutpoint() *wire.OutPoint {
 	return &r.partialState.FundingOutpoint
 }
 
+// Capacity returns the channel capacity for this reservation.
+func (r *ChannelReservation) Capacity() btcutil.Amount {
+	r.RLock()
+	defer r.RUnlock()
+	return r.partialState.Capacity
+}
+
 // Cancel abandons this channel reservation. This method should be called in
 // the scenario that communications with the counterparty break down. Upon
 // cancellation, all resources previously reserved for this pending payment

--- a/lnwallet/wallet.go
+++ b/lnwallet/wallet.go
@@ -1428,6 +1428,8 @@ func coinSelect(feeRate SatPerKWeight, amt btcutil.Amount,
 		//
 		// TODO: Handle wallets that generate non-witness change
 		// addresses.
+		// TODO(halseth): make coinSelect not estimate change output
+		// for dust change.
 		weightEstimate.AddP2WKHOutput()
 
 		// The difference between the selected amount and the amount

--- a/lnwallet/wallet.go
+++ b/lnwallet/wallet.go
@@ -1455,7 +1455,7 @@ func coinSelect(feeRate SatPerKWeight, amt btcutil.Amount,
 			case NestedWitnessPubKey:
 				weightEstimate.AddNestedP2WKHInput()
 			default:
-				return nil, 0, fmt.Errorf("Unsupported address type: %v",
+				return nil, 0, fmt.Errorf("unsupported address type: %v",
 					utxo.AddressType)
 			}
 		}
@@ -1493,4 +1493,96 @@ func coinSelect(feeRate SatPerKWeight, amt btcutil.Amount,
 
 		return selectedUtxos, changeAmt, nil
 	}
+}
+
+// coinSelectSubtractFees attempts to select coins such that we'll spend up to
+// amt in total after fees, adhering to the specified fee rate. The selected
+// coins, the final output and change values are returned.
+func coinSelectSubtractFees(feeRate SatPerKWeight, amt,
+	dustLimit btcutil.Amount, coins []*Utxo) ([]*Utxo, btcutil.Amount,
+	btcutil.Amount, error) {
+
+	// First perform an initial round of coin selection to estimate
+	// the required fee.
+	totalSat, selectedUtxos, err := selectInputs(amt, coins)
+	if err != nil {
+		return nil, 0, 0, err
+	}
+
+	var weightEstimate input.TxWeightEstimator
+	for _, utxo := range selectedUtxos {
+		switch utxo.AddressType {
+		case WitnessPubKey:
+			weightEstimate.AddP2WKHInput()
+		case NestedWitnessPubKey:
+			weightEstimate.AddNestedP2WKHInput()
+		default:
+			return nil, 0, 0, fmt.Errorf("unsupported "+
+				"address type: %v", utxo.AddressType)
+		}
+	}
+
+	// Channel funding multisig output is P2WSH.
+	weightEstimate.AddP2WSHOutput()
+
+	// At this point we've got two possibilities, either create a
+	// change output, or not. We'll first try without creating a
+	// change output.
+	//
+	// Estimate the fee required for a transaction without a change
+	// output.
+	totalWeight := int64(weightEstimate.Weight())
+	requiredFee := feeRate.FeeForWeight(totalWeight)
+
+	// For a transaction without a change output, we'll let everything go
+	// to our multi-sig output after subtracting fees.
+	outputAmt := totalSat - requiredFee
+	changeAmt := btcutil.Amount(0)
+
+	// If the the output is too small after subtracting the fee, the coin
+	// selection cannot be performed with an amount this small.
+	if outputAmt <= dustLimit {
+		return nil, 0, 0, fmt.Errorf("output amount(%v) after "+
+			"subtracting fees(%v) below dust limit(%v)", outputAmt,
+			requiredFee, dustLimit)
+	}
+
+	// We were able to create a transaction with no change from the
+	// selected inputs. We'll remember the resulting values for
+	// now, while we try to add a change output. Assume that change output
+	// is a P2WKH output.
+	weightEstimate.AddP2WKHOutput()
+
+	// Now that we have added the change output, redo the fee
+	// estimate.
+	totalWeight = int64(weightEstimate.Weight())
+	requiredFee = feeRate.FeeForWeight(totalWeight)
+
+	// For a transaction with a change output, everything we don't spend
+	// will go to change.
+	newChange := totalSat - amt
+	newOutput := amt - requiredFee
+
+	// If adding a change output leads to both outputs being above
+	// the dust limit, we'll add the change output. Otherwise we'll
+	// go with the no change tx we originally found.
+	if newChange > dustLimit && newOutput > dustLimit {
+		outputAmt = newOutput
+		changeAmt = newChange
+	}
+
+	// Sanity check the resulting output values to make sure we
+	// don't burn a great part to fees.
+	totalOut := outputAmt + changeAmt
+	fee := totalSat - totalOut
+
+	// Fail if more than 20% goes to fees.
+	// TODO(halseth): smarter fee limit. Make configurable or dynamic wrt
+	// total funding size?
+	if fee > totalOut/5 {
+		return nil, 0, 0, fmt.Errorf("fee %v on total output"+
+			"value %v", fee, totalOut)
+	}
+
+	return selectedUtxos, outputAmt, changeAmt, nil
 }

--- a/lnwallet/wallet.go
+++ b/lnwallet/wallet.go
@@ -477,15 +477,16 @@ func (l *LightningWallet) handleFundingReserveRequest(req *InitFundingReserveMsg
 	if req.LocalFundingAmt != 0 {
 		// Coin selection is done on the basis of sat/kw, so we'll use
 		// the fee rate passed in to perform coin selection.
-		err := l.selectCoinsAndChange(
+		selected, err := l.selectCoinsAndChange(
 			req.FundingFeePerKw, req.LocalFundingAmt, req.MinConfs,
-			reservation.ourContribution,
 		)
 		if err != nil {
 			req.err <- err
 			req.resp <- nil
 			return
 		}
+		reservation.ourContribution.Inputs = selected.coins
+		reservation.ourContribution.ChangeOutputs = selected.change
 	}
 
 	// Next, we'll grab a series of keys from the wallet which will be used
@@ -1273,14 +1274,21 @@ func (l *LightningWallet) WithCoinSelectLock(f func() error) error {
 	return f()
 }
 
+// coinSelection holds the result from selectCoinsAndChange.
+type coinSelection struct {
+	coins       []*wire.TxIn
+	change      []*wire.TxOut
+	unlockCoins func()
+}
+
 // selectCoinsAndChange performs coin selection in order to obtain witness
-// outputs which sum to at least 'numCoins' amount of satoshis. If coin
-// selection is successful/possible, then the selected coins are available
-// within the passed contribution's inputs. If necessary, a change address will
-// also be generated.
+// outputs which sum to at least 'amt' amount of satoshis. If necessary,
+// a change address will also be generated. If coin selection is
+// successful/possible, then the selected coins and change outputs are
+// returned. This method locks the selected outputs, and a function closure to
+// unlock them in case of an error is returned.
 func (l *LightningWallet) selectCoinsAndChange(feeRate SatPerKWeight,
-	amt btcutil.Amount, minConfs int32,
-	contribution *ChannelContribution) error {
+	amt btcutil.Amount, minConfs int32) (*coinSelection, error) {
 
 	// We hold the coin select mutex while querying for outputs, and
 	// performing coin selection in order to avoid inadvertent double
@@ -1295,7 +1303,7 @@ func (l *LightningWallet) selectCoinsAndChange(feeRate SatPerKWeight,
 	// number of confirmations required.
 	coins, err := l.ListUnspentWitness(minConfs, math.MaxInt32)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	// Perform coin selection over our available, unlocked unspent outputs
@@ -1303,13 +1311,34 @@ func (l *LightningWallet) selectCoinsAndChange(feeRate SatPerKWeight,
 	// requirements.
 	selectedCoins, changeAmt, err := coinSelect(feeRate, amt, coins)
 	if err != nil {
-		return err
+		return nil, err
+	}
+
+	// Record any change output(s) generated as a result of the coin
+	// selection, but only if the addition of the output won't lead to the
+	// creation of dust.
+	var changeOutputs []*wire.TxOut
+	if changeAmt != 0 && changeAmt > DefaultDustLimit() {
+		changeAddr, err := l.NewAddress(WitnessPubKey, true)
+		if err != nil {
+			return nil, err
+		}
+		changeScript, err := txscript.PayToAddrScript(changeAddr)
+		if err != nil {
+			return nil, err
+		}
+
+		changeOutputs = make([]*wire.TxOut, 1)
+		changeOutputs[0] = &wire.TxOut{
+			Value:    int64(changeAmt),
+			PkScript: changeScript,
+		}
 	}
 
 	// Lock the selected coins. These coins are now "reserved", this
 	// prevents concurrent funding requests from referring to and this
 	// double-spending the same set of coins.
-	contribution.Inputs = make([]*wire.TxIn, len(selectedCoins))
+	inputs := make([]*wire.TxIn, len(selectedCoins))
 	for i, coin := range selectedCoins {
 		outpoint := &coin.OutPoint
 		l.lockedOutPoints[*outpoint] = struct{}{}
@@ -1317,30 +1346,25 @@ func (l *LightningWallet) selectCoinsAndChange(feeRate SatPerKWeight,
 
 		// Empty sig script, we'll actually sign if this reservation is
 		// queued up to be completed (the other side accepts).
-		contribution.Inputs[i] = wire.NewTxIn(outpoint, nil, nil)
+		inputs[i] = wire.NewTxIn(outpoint, nil, nil)
 	}
 
-	// Record any change output(s) generated as a result of the coin
-	// selection, but only if the addition of the output won't lead to the
-	// creation of dust.
-	if changeAmt != 0 && changeAmt > DefaultDustLimit() {
-		changeAddr, err := l.NewAddress(WitnessPubKey, true)
-		if err != nil {
-			return err
-		}
-		changeScript, err := txscript.PayToAddrScript(changeAddr)
-		if err != nil {
-			return err
-		}
+	unlock := func() {
+		l.coinSelectMtx.Lock()
+		defer l.coinSelectMtx.Unlock()
 
-		contribution.ChangeOutputs = make([]*wire.TxOut, 1)
-		contribution.ChangeOutputs[0] = &wire.TxOut{
-			Value:    int64(changeAmt),
-			PkScript: changeScript,
+		for _, coin := range selectedCoins {
+			outpoint := &coin.OutPoint
+			delete(l.lockedOutPoints, *outpoint)
+			l.UnlockOutpoint(*outpoint)
 		}
 	}
 
-	return nil
+	return &coinSelection{
+		coins:       inputs,
+		change:      changeOutputs,
+		unlockCoins: unlock,
+	}, nil
 }
 
 // DeriveStateHintObfuscator derives the bytes to be used for obfuscating the

--- a/lnwallet/wallet.go
+++ b/lnwallet/wallet.go
@@ -69,6 +69,13 @@ type InitFundingReserveMsg struct {
 	// workflow.
 	NodeAddr net.Addr
 
+	// SubtractFees should be set if we intend to spend exactly
+	// LocalFundingAmt when opening the channel, subtracting the fees from
+	// the funding output. This can be used for instance to use all our
+	// remaining funds to open the channel, since it will take fees into
+	// account.
+	SubtractFees bool
+
 	// LocalFundingAmt is the amount of funds requested from us for this
 	// channel.
 	LocalFundingAmt btcutil.Amount
@@ -450,7 +457,6 @@ func (l *LightningWallet) handleFundingReserveRequest(req *InitFundingReserveMsg
 		return
 	}
 
-	capacity := req.LocalFundingAmt + req.RemoteFundingAmt
 	localFundingAmt := req.LocalFundingAmt
 
 	var (
@@ -468,13 +474,20 @@ func (l *LightningWallet) handleFundingReserveRequest(req *InitFundingReserveMsg
 		var err error
 		selected, err = l.selectCoinsAndChange(
 			req.FundingFeePerKw, req.LocalFundingAmt, req.MinConfs,
+			req.SubtractFees,
 		)
 		if err != nil {
 			req.err <- err
 			req.resp <- nil
 			return
 		}
+
+		localFundingAmt = selected.fundingAmt
 	}
+
+	// The total channel capacity will be the size of the funding output we
+	// created plus the remote contribution.
+	capacity := localFundingAmt + req.RemoteFundingAmt
 
 	id := atomic.AddUint64(&l.nextFundingID, 1)
 	reservation, err := NewChannelReservation(
@@ -1289,6 +1302,7 @@ func (l *LightningWallet) WithCoinSelectLock(f func() error) error {
 type coinSelection struct {
 	coins       []*wire.TxIn
 	change      []*wire.TxOut
+	fundingAmt  btcutil.Amount
 	unlockCoins func()
 }
 
@@ -1296,10 +1310,12 @@ type coinSelection struct {
 // outputs which sum to at least 'amt' amount of satoshis. If necessary,
 // a change address will also be generated. If coin selection is
 // successful/possible, then the selected coins and change outputs are
-// returned. This method locks the selected outputs, and a function closure to
-// unlock them in case of an error is returned.
+// returned, and the value of the resulting funding output. This method locks
+// the selected outputs, and a function closure to unlock them in case of an
+// error is returned.
 func (l *LightningWallet) selectCoinsAndChange(feeRate SatPerKWeight,
-	amt btcutil.Amount, minConfs int32) (*coinSelection, error) {
+	amt btcutil.Amount, minConfs int32, subtractFees bool) (
+	*coinSelection, error) {
 
 	// We hold the coin select mutex while querying for outputs, and
 	// performing coin selection in order to avoid inadvertent double
@@ -1317,12 +1333,36 @@ func (l *LightningWallet) selectCoinsAndChange(feeRate SatPerKWeight,
 		return nil, err
 	}
 
+	var (
+		selectedCoins []*Utxo
+		fundingAmt    btcutil.Amount
+		changeAmt     btcutil.Amount
+	)
+
 	// Perform coin selection over our available, unlocked unspent outputs
 	// in order to find enough coins to meet the funding amount
 	// requirements.
-	selectedCoins, changeAmt, err := coinSelect(feeRate, amt, coins)
-	if err != nil {
-		return nil, err
+	switch {
+	// In case this request want the fees subtracted from the local amount,
+	// we'll call the specialized method for that. This ensures that we
+	// won't deduct more that the specified balance from our wallet.
+	case subtractFees:
+		dustLimit := l.Cfg.DefaultConstraints.DustLimit
+		selectedCoins, fundingAmt, changeAmt, err = coinSelectSubtractFees(
+			feeRate, amt, dustLimit, coins,
+		)
+		if err != nil {
+			return nil, err
+		}
+
+	// Ótherwise do a normal coin selection where we target a given funding
+	// amount.
+	default:
+		fundingAmt = amt
+		selectedCoins, changeAmt, err = coinSelect(feeRate, amt, coins)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	// Record any change output(s) generated as a result of the coin
@@ -1374,6 +1414,7 @@ func (l *LightningWallet) selectCoinsAndChange(feeRate SatPerKWeight,
 	return &coinSelection{
 		coins:       inputs,
 		change:      changeOutputs,
+		fundingAmt:  fundingAmt,
 		unlockCoins: unlock,
 	}, nil
 }

--- a/lnwallet/wallet_test.go
+++ b/lnwallet/wallet_test.go
@@ -1,0 +1,180 @@
+package lnwallet
+
+import (
+	"testing"
+
+	"github.com/btcsuite/btcutil"
+	"github.com/lightningnetwork/lnd/input"
+)
+
+// fundingFee is a helper method that returns the fee estimate used for a tx
+// with the given number of inputs and the optional change output. This matches
+// the estimate done by the wallet.
+func fundingFee(feeRate SatPerKWeight, numInput int, change bool) btcutil.Amount {
+	var weightEstimate input.TxWeightEstimator
+
+	// All inputs.
+	for i := 0; i < numInput; i++ {
+		weightEstimate.AddP2WKHInput()
+	}
+
+	// The multisig funding output.
+	weightEstimate.AddP2WSHOutput()
+
+	// Optionally count a change output.
+	if change {
+		weightEstimate.AddP2WKHOutput()
+	}
+
+	totalWeight := int64(weightEstimate.Weight())
+	return feeRate.FeeForWeight(totalWeight)
+}
+
+// TestCoinSelect tests that we pick coins adding up to the expected amount
+// when creating a funding transaction, and that the calculated change is the
+// expected amount.
+//
+// NOTE: coinSelect will always attempt to add a change output, so we must
+// account for this in the tests.
+func TestCoinSelect(t *testing.T) {
+	t.Parallel()
+
+	const feeRate = SatPerKWeight(100)
+	const dust = btcutil.Amount(100)
+
+	type testCase struct {
+		name        string
+		outputValue btcutil.Amount
+		coins       []*Utxo
+
+		expectedInput  []btcutil.Amount
+		expectedChange btcutil.Amount
+		expectErr      bool
+	}
+
+	testCases := []testCase{
+		{
+			// We have 1.0 BTC available, and wants to send 0.5.
+			// This will obviously lead to a change output of
+			// almost 0.5 BTC.
+			name: "big change",
+			coins: []*Utxo{
+				{
+					AddressType: WitnessPubKey,
+					Value:       1 * btcutil.SatoshiPerBitcoin,
+				},
+			},
+			outputValue: 0.5 * btcutil.SatoshiPerBitcoin,
+
+			// The one and only input will be selected.
+			expectedInput: []btcutil.Amount{
+				1 * btcutil.SatoshiPerBitcoin,
+			},
+			// Change will be what's left minus the fee.
+			expectedChange: 0.5*btcutil.SatoshiPerBitcoin - fundingFee(feeRate, 1, true),
+		},
+		{
+			// We have 1 BTC available, and we want to send 1 BTC.
+			// This should lead to an error, as we don't have
+			// enough funds to pay the fee.
+			name: "nothing left for fees",
+			coins: []*Utxo{
+				{
+					AddressType: WitnessPubKey,
+					Value:       1 * btcutil.SatoshiPerBitcoin,
+				},
+			},
+			outputValue: 1 * btcutil.SatoshiPerBitcoin,
+			expectErr:   true,
+		},
+		{
+			// We have a 1 BTC input, and want to create an output
+			// as big as possible, such that the remaining change
+			// will be dust.
+			name: "dust change",
+			coins: []*Utxo{
+				{
+					AddressType: WitnessPubKey,
+					Value:       1 * btcutil.SatoshiPerBitcoin,
+				},
+			},
+			// We tune the output value by subtracting the expected
+			// fee and a small dust amount.
+			outputValue: 1*btcutil.SatoshiPerBitcoin - fundingFee(feeRate, 1, true) - dust,
+
+			expectedInput: []btcutil.Amount{
+				1 * btcutil.SatoshiPerBitcoin,
+			},
+
+			// Change will the dust.
+			expectedChange: dust,
+		},
+		{
+			// We have a 1 BTC input, and want to create an output
+			// as big as possible, such that there is nothing left
+			// for change.
+			name: "no change",
+			coins: []*Utxo{
+				{
+					AddressType: WitnessPubKey,
+					Value:       1 * btcutil.SatoshiPerBitcoin,
+				},
+			},
+			// We tune the output value to be the maximum amount
+			// possible, leaving just enough for fees.
+			outputValue: 1*btcutil.SatoshiPerBitcoin - fundingFee(feeRate, 1, true),
+
+			expectedInput: []btcutil.Amount{
+				1 * btcutil.SatoshiPerBitcoin,
+			},
+			// We have just enough left to pay the fee, so there is
+			// nothing left for change.
+			// TODO(halseth): currently coinselect estimates fees
+			// assuming a change output.
+			expectedChange: 0,
+		},
+	}
+
+	for _, test := range testCases {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			selected, changeAmt, err := coinSelect(
+				feeRate, test.outputValue, test.coins,
+			)
+			if !test.expectErr && err != nil {
+				t.Fatalf(err.Error())
+			}
+
+			if test.expectErr && err == nil {
+				t.Fatalf("expected error")
+			}
+
+			// If we got an expected error, there is nothing more to test.
+			if test.expectErr {
+				return
+			}
+
+			// Check that the selected inputs match what we expect.
+			if len(selected) != len(test.expectedInput) {
+				t.Fatalf("expected %v inputs, got %v",
+					len(test.expectedInput), len(selected))
+			}
+
+			for i, coin := range selected {
+				if coin.Value != test.expectedInput[i] {
+					t.Fatalf("expected input %v to have value %v, "+
+						"had %v", i, test.expectedInput[i],
+						coin.Value)
+				}
+			}
+
+			// Assert we got the expected change amount.
+			if changeAmt != test.expectedChange {
+				t.Fatalf("expected %v change amt, got %v",
+					test.expectedChange, changeAmt)
+			}
+		})
+	}
+}

--- a/mock.go
+++ b/mock.go
@@ -231,6 +231,7 @@ type mockWalletController struct {
 	prevAddres            btcutil.Address
 	publishedTransactions chan *wire.MsgTx
 	index                 uint32
+	utxos                 []*lnwallet.Utxo
 }
 
 // BackEnd returns "mock" to signify a mock wallet controller.
@@ -284,6 +285,13 @@ func (*mockWalletController) CreateSimpleTx(outputs []*wire.TxOut,
 // need one unspent for the funding transaction.
 func (m *mockWalletController) ListUnspentWitness(minconfirms,
 	maxconfirms int32) ([]*lnwallet.Utxo, error) {
+
+	// If the mock already has a list of utxos, return it.
+	if m.utxos != nil {
+		return m.utxos, nil
+	}
+
+	// Otherwise create one to return.
 	utxo := &lnwallet.Utxo{
 		AddressType: lnwallet.WitnessPubKey,
 		Value:       btcutil.Amount(10 * btcutil.SatoshiPerBitcoin),

--- a/pilot.go
+++ b/pilot.go
@@ -100,6 +100,7 @@ func (c *chanController) OpenChannel(target *btcec.PublicKey,
 	req := &openChanReq{
 		targetPubkey:    target,
 		chainHash:       *activeNetParams.GenesisHash,
+		subtractFees:    true,
 		localFundingAmt: amt,
 		pushAmt:         0,
 		minHtlc:         minHtlc,

--- a/server.go
+++ b/server.go
@@ -2979,6 +2979,7 @@ type openChanReq struct {
 
 	chainHash chainhash.Hash
 
+	subtractFees    bool
 	localFundingAmt btcutil.Amount
 
 	pushAmt lnwire.MilliSatoshi

--- a/server.go
+++ b/server.go
@@ -2979,8 +2979,7 @@ type openChanReq struct {
 
 	chainHash chainhash.Hash
 
-	localFundingAmt  btcutil.Amount
-	remoteFundingAmt btcutil.Amount
+	localFundingAmt btcutil.Amount
 
 	pushAmt lnwire.MilliSatoshi
 

--- a/server.go
+++ b/server.go
@@ -1051,6 +1051,8 @@ func newServer(listenAddrs []net.Addr, chanDB *channeldb.DB,
 		ZombieSweeperInterval:  1 * time.Minute,
 		ReservationTimeout:     10 * time.Minute,
 		MinChanSize:            btcutil.Amount(cfg.MinChanSize),
+		MaxPendingChannels:     cfg.MaxPendingChannels,
+		RejectPush:             cfg.RejectPush,
 		NotifyOpenChannelEvent: s.channelNotifier.NotifyOpenChannelEvent,
 	})
 	if err != nil {


### PR DESCRIPTION
This is an alternative to #3017.

Since the funding manager and wallet can't know up front the how much it will cost us in fees to fund a channel, it will always cost us more than `chanSize` in total. This makes it hard to spend all the funds remaining in the wallet into a channel, since we won't have enough to cover the additional fee.

This PR attempts to fix this by letting one specify a "spend amount" instead of a "channel size" when opening a channel. This makes the wallet do coin selection that results in a decrease in balance equal to this spend amount, instead of spending `chanSize+fees`.

We make the autopilot use this new option, making it better at staying within its budget, and also able to open channels that utilizes the whole wallet balance.

Fixes #986