### PR TITLE
[autopilot] make confirmation target configurable

### DIFF
--- a/autopilot/interface.go
+++ b/autopilot/interface.go
@@ -9,6 +9,11 @@ import (
 	"github.com/lightningnetwork/lnd/lnwire"
 )
 
+// DefaultConfTarget is the default confirmation target for autopilot channels.
+// TODO(halseth): possibly make dynamic, going aggressive->lax as more channels
+// are opened.
+const DefaultConfTarget = 3
+
 // Node node is an interface which represents n abstract vertex within the
 // channel graph. All nodes should have at least a single edge to/from them
 // within the graph.

--- a/pilot.go
+++ b/pilot.go
@@ -84,7 +84,9 @@ func (c *chanController) OpenChannel(target *btcec.PublicKey,
 
 	// With the connection established, we'll now establish our connection
 	// to the target peer, waiting for the first update before we exit.
-	feePerKw, err := c.server.cc.feeEstimator.EstimateFeePerKW(3)
+	feePerKw, err := c.server.cc.feeEstimator.EstimateFeePerKW(
+		autopilot.DefaultConfTarget,
+	)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This PR adds a new configuration option `conftarget` for channels opened by autopilot.