### PR TITLE
Initialize addressType to UnknownAddressType

### DIFF
--- a/lnwallet/btcwallet/btcwallet.go
+++ b/lnwallet/btcwallet/btcwallet.go
@@ -378,7 +378,7 @@ func (b *BtcWallet) ListUnspentWitness(minConfs, maxConfs int32) (
 			return nil, err
 		}
 
-		var addressType lnwallet.AddressType
+		addressType := lnwallet.UnknownAddressType
 		if txscript.IsPayToWitnessPubKeyHash(pkScript) {
 			addressType = lnwallet.WitnessPubKey
 		} else if txscript.IsPayToScriptHash(pkScript) {


### PR DESCRIPTION
Initialize addressType to UnknownAddressType instead of the default (null value) which is lnwallet.WitnessPubKey.
Without this change, if both IsPayToWitnessPubKeyHash and IsPayToScriptHash returns false, the address is considered to be WitnessPubKey which is obviously false.
