### PR TITLE
routing+zpay32: copy pubkeys before nilling Curve and spewing

### DIFF
--- a/routing/router.go
+++ b/routing/router.go
@@ -1465,9 +1465,11 @@ func generateSphinxPacket(rt *route.Route, paymentHash []byte,
 
 	log.Tracef("Constructed per-hop payloads for payment_hash=%x: %v",
 		paymentHash[:], newLogClosure(func() string {
-			path := sphinxPath[:sphinxPath.TrueRouteLength()]
+			path := make([]sphinx.OnionHop, sphinxPath.TrueRouteLength())
 			for i := range path {
-				path[i].NodePub.Curve = nil
+				hopCopy := sphinxPath[i]
+				hopCopy.NodePub.Curve = nil
+				path[i] = hopCopy
 			}
 			return spew.Sdump(path)
 		}),
@@ -1491,10 +1493,14 @@ func generateSphinxPacket(rt *route.Route, paymentHash []byte,
 
 	log.Tracef("Generated sphinx packet: %v",
 		newLogClosure(func() string {
-			// We unset the internal curve here in order to keep
-			// the logs from getting noisy.
-			sphinxPacket.EphemeralKey.Curve = nil
-			return spew.Sdump(sphinxPacket)
+			// We make a copy of the ephemeral key and unset the
+			// internal curve here in order to keep the logs from
+			// getting noisy.
+			key := *sphinxPacket.EphemeralKey
+			key.Curve = nil
+			packetCopy := *sphinxPacket
+			packetCopy.EphemeralKey = &key
+			return spew.Sdump(packetCopy)
 		}),
 	)
 
@@ -1719,12 +1725,21 @@ func (r *ChannelRouter) sendPayment(
 
 	log.Tracef("Dispatching route for lightning payment: %v",
 		newLogClosure(func() string {
+			// Make a copy of the payment with a nilled Curve
+			// before spewing.
+			var routeHints [][]zpay32.HopHint
 			for _, routeHint := range payment.RouteHints {
+				var hopHints []zpay32.HopHint
 				for _, hopHint := range routeHint {
-					hopHint.NodeID.Curve = nil
+					h := hopHint.Copy()
+					h.NodeID.Curve = nil
+					hopHints = append(hopHints, h)
 				}
+				routeHints = append(routeHints, hopHints)
 			}
-			return spew.Sdump(payment)
+			p := *payment
+			p.RouteHints = routeHints
+			return spew.Sdump(p)
 		}),
 	)
 

--- a/zpay32/hophint.go
+++ b/zpay32/hophint.go
@@ -29,3 +29,15 @@ type HopHint struct {
 	// CLTVExpiryDelta is the time-lock delta of the channel.
 	CLTVExpiryDelta uint16
 }
+
+// Copy returns a deep copy of the hop hint.
+func (h HopHint) Copy() HopHint {
+	nodeID := *h.NodeID
+	return HopHint{
+		NodeID:                    &nodeID,
+		ChannelID:                 h.ChannelID,
+		FeeBaseMSat:               h.FeeBaseMSat,
+		FeeProportionalMillionths: h.FeeProportionalMillionths,
+		CLTVExpiryDelta:           h.CLTVExpiryDelta,
+	}
+}


### PR DESCRIPTION
Since nilling the pubkey curve will lead to a nil-pointer exception if
the key is later used for signature verification, we make sure to make a
copy before nilling and spewing.

Fixes #3185