### PR TITLE
[lntest] remove rpctest build flag

### DIFF
--- a/breacharbiter_test.go
+++ b/breacharbiter_test.go
@@ -1,5 +1,3 @@
-// +build !rpctest
-
 package lnd
 
 import (

--- a/fundingmanager_test.go
+++ b/fundingmanager_test.go
@@ -1,5 +1,3 @@
-// +build !rpctest
-
 package lnd
 
 import (

--- a/lncfg/address_test.go
+++ b/lncfg/address_test.go
@@ -1,5 +1,3 @@
-// +build !rpctest
-
 package lncfg
 
 import (

--- a/lntest/btcd.go
+++ b/lntest/btcd.go
@@ -1,4 +1,4 @@
-// +build btcd
+// +build !neutrino
 
 package lntest
 

--- a/lntest/itest/lnd_multi-hop_htlc_local_chain_claim_test.go
+++ b/lntest/itest/lnd_multi-hop_htlc_local_chain_claim_test.go
@@ -1,5 +1,3 @@
-// +build rpctest
-
 package itest
 
 import (

--- a/lntest/itest/lnd_multi-hop_htlc_local_chain_claim_test.go
+++ b/lntest/itest/lnd_multi-hop_htlc_local_chain_claim_test.go
@@ -90,7 +90,8 @@ func testMultiHopHtlcLocalChainClaim(net *lntest.NetworkHarness, t *harnessTest)
 
 	// At this point, Bob decides that he wants to exit the channel
 	// immediately, so he force closes his commitment transaction.
-	ctxt, _ = context.WithTimeout(ctxb, channelCloseTimeout)
+	ctxt, cancel = context.WithTimeout(ctxb, channelCloseTimeout)
+	defer cancel()
 	bobForceClose := closeChannelAndAssert(ctxt, t, net, net.Bob,
 		aliceChanPoint, true)
 
@@ -228,7 +229,8 @@ func testMultiHopHtlcLocalChainClaim(net *lntest.NetworkHarness, t *harnessTest)
 	// transaction, and should have sent it to the nursery for incubation.
 	pendingChansRequest := &lnrpc.PendingChannelsRequest{}
 	err = lntest.WaitPredicate(func() bool {
-		ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
+		ctxt, cancel = context.WithTimeout(ctxb, defaultTimeout)
+		defer cancel()
 		pendingChanResp, err := net.Bob.PendingChannels(
 			ctxt, pendingChansRequest,
 		)
@@ -320,7 +322,8 @@ func testMultiHopHtlcLocalChainClaim(net *lntest.NetworkHarness, t *harnessTest)
 	assertTxInBlock(t, block, bobSweep)
 
 	err = lntest.WaitPredicate(func() bool {
-		ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
+		ctxt, cancel = context.WithTimeout(ctxb, defaultTimeout)
+		defer cancel()
 		pendingChanResp, err := net.Bob.PendingChannels(
 			ctxt, pendingChansRequest,
 		)
@@ -335,7 +338,8 @@ func testMultiHopHtlcLocalChainClaim(net *lntest.NetworkHarness, t *harnessTest)
 			return false
 		}
 		req := &lnrpc.ListChannelsRequest{}
-		ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
+		ctxt, cancel = context.WithTimeout(ctxb, defaultTimeout)
+		defer cancel()
 		chanInfo, err := net.Bob.ListChannels(ctxt, req)
 		if err != nil {
 			predErr = fmt.Errorf("unable to query for open "+
@@ -356,7 +360,8 @@ func testMultiHopHtlcLocalChainClaim(net *lntest.NetworkHarness, t *harnessTest)
 
 	// Also Carol should have no channels left (open nor pending).
 	err = lntest.WaitPredicate(func() bool {
-		ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
+		ctxt, cancel = context.WithTimeout(ctxb, defaultTimeout)
+		defer cancel()
 		pendingChanResp, err := carol.PendingChannels(
 			ctxt, pendingChansRequest,
 		)
@@ -372,7 +377,8 @@ func testMultiHopHtlcLocalChainClaim(net *lntest.NetworkHarness, t *harnessTest)
 		}
 
 		req := &lnrpc.ListChannelsRequest{}
-		ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
+		ctxt, cancel = context.WithTimeout(ctxb, defaultTimeout)
+		defer cancel()
 		chanInfo, err := carol.ListChannels(ctxt, req)
 		if err != nil {
 			predErr = fmt.Errorf("unable to query for open "+

--- a/lntest/itest/lnd_multi-hop_htlc_receiver_chain_claim_test.go
+++ b/lntest/itest/lnd_multi-hop_htlc_receiver_chain_claim_test.go
@@ -1,5 +1,3 @@
-// +build rpctest
-
 package itest
 
 import (

--- a/lntest/itest/lnd_multi-hop_htlc_receiver_chain_claim_test.go
+++ b/lntest/itest/lnd_multi-hop_htlc_receiver_chain_claim_test.go
@@ -200,7 +200,8 @@ func testMultiHopReceiverChainClaim(net *lntest.NetworkHarness, t *harnessTest) 
 	// limbo: her commitment output, as well as the second-layer claim
 	// output.
 	pendingChansRequest := &lnrpc.PendingChannelsRequest{}
-	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
+	ctxt, cancel = context.WithTimeout(ctxb, defaultTimeout)
+	defer cancel()
 	pendingChanResp, err := carol.PendingChannels(ctxt, pendingChansRequest)
 	if err != nil {
 		t.Fatalf("unable to query for pending channels: %v", err)
@@ -258,7 +259,8 @@ func testMultiHopReceiverChainClaim(net *lntest.NetworkHarness, t *harnessTest) 
 		t.Fatalf("unable to mine block: %v", err)
 	}
 	err = lntest.WaitPredicate(func() bool {
-		ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
+		ctxt, cancel = context.WithTimeout(ctxb, defaultTimeout)
+		defer cancel()
 		pendingChanResp, err = carol.PendingChannels(ctxt, pendingChansRequest)
 		if err != nil {
 			predErr = fmt.Errorf("unable to query for pending channels: %v", err)
@@ -297,6 +299,7 @@ func testMultiHopReceiverChainClaim(net *lntest.NetworkHarness, t *harnessTest) 
 
 	// We'll close out the channel between Alice and Bob, then shutdown
 	// carol to conclude the test.
-	ctxt, _ = context.WithTimeout(ctxb, channelCloseTimeout)
+	ctxt, cancel = context.WithTimeout(ctxb, channelCloseTimeout)
+	defer cancel()
 	closeChannelAndAssert(ctxt, t, net, net.Alice, aliceChanPoint, false)
 }

--- a/lntest/itest/lnd_multi-hop_htlc_remote_chain_claim_test.go
+++ b/lntest/itest/lnd_multi-hop_htlc_remote_chain_claim_test.go
@@ -1,5 +1,3 @@
-// +build rpctest
-
 package itest
 
 import (

--- a/lntest/itest/lnd_multi-hop_htlc_remote_chain_claim_test.go
+++ b/lntest/itest/lnd_multi-hop_htlc_remote_chain_claim_test.go
@@ -90,12 +90,14 @@ func testMultiHopHtlcRemoteChainClaim(net *lntest.NetworkHarness, t *harnessTest
 	// Next, Alice decides that she wants to exit the channel, so she'll
 	// immediately force close the channel by broadcast her commitment
 	// transaction.
-	ctxt, _ = context.WithTimeout(ctxb, channelCloseTimeout)
+	ctxt, cancel = context.WithTimeout(ctxb, channelCloseTimeout)
+	defer cancel()
 	aliceForceClose := closeChannelAndAssert(ctxt, t, net, net.Alice,
 		aliceChanPoint, true)
 
 	// Wait for the channel to be marked pending force close.
-	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
+	ctxt, cancel = context.WithTimeout(ctxb, defaultTimeout)
+	defer cancel()
 	err = waitForChannelPendingForceClose(ctxt, net.Alice, aliceChanPoint)
 	if err != nil {
 		t.Fatalf("channel not pending force close: %v", err)
@@ -251,7 +253,8 @@ func testMultiHopHtlcRemoteChainClaim(net *lntest.NetworkHarness, t *harnessTest
 	// pending close channels.
 	pendingChansRequest := &lnrpc.PendingChannelsRequest{}
 	err = lntest.WaitPredicate(func() bool {
-		ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
+		ctxt, cancel = context.WithTimeout(ctxb, defaultTimeout)
+		defer cancel()
 		pendingChanResp, err := net.Bob.PendingChannels(
 			ctxt, pendingChansRequest,
 		)
@@ -290,7 +293,8 @@ func testMultiHopHtlcRemoteChainClaim(net *lntest.NetworkHarness, t *harnessTest
 
 	pendingChansRequest = &lnrpc.PendingChannelsRequest{}
 	err = lntest.WaitPredicate(func() bool {
-		ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
+		ctxt, cancel = context.WithTimeout(ctxb, defaultTimeout)
+		defer cancel()
 		pendingChanResp, err := carol.PendingChannels(
 			ctxt, pendingChansRequest,
 		)

--- a/lntest/itest/lnd_test.go
+++ b/lntest/itest/lnd_test.go
@@ -1,5 +1,3 @@
-// +build rpctest
-
 package itest
 
 import (

--- a/lntest/itest/onchain_test.go
+++ b/lntest/itest/onchain_test.go
@@ -1,5 +1,3 @@
-// +build rpctest
-
 package itest
 
 import (

--- a/lntest/itest/onchain_test.go
+++ b/lntest/itest/onchain_test.go
@@ -27,7 +27,8 @@ func testCPFP(net *lntest.NetworkHarness, t *harnessTest) {
 	// We'll start the test by sending Alice some coins, which she'll use to
 	// send to Bob.
 	ctxb := context.Background()
-	ctxt, _ := context.WithTimeout(ctxb, defaultTimeout)
+	ctxt, cancel := context.WithTimeout(ctxb, defaultTimeout)
+	defer cancel()
 	err := net.SendCoins(ctxt, btcutil.SatoshiPerBitcoin, net.Alice)
 	if err != nil {
 		t.Fatalf("unable to send coins to alice: %v", err)
@@ -37,7 +38,8 @@ func testCPFP(net *lntest.NetworkHarness, t *harnessTest) {
 	addrReq := &lnrpc.NewAddressRequest{
 		Type: lnrpc.AddressType_WITNESS_PUBKEY_HASH,
 	}
-	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
+	ctxt, cancel = context.WithTimeout(ctxb, defaultTimeout)
+	defer cancel()
 	resp, err := net.Bob.NewAddress(ctxt, addrReq)
 	if err != nil {
 		t.Fatalf("unable to get new address for bob: %v", err)
@@ -49,7 +51,8 @@ func testCPFP(net *lntest.NetworkHarness, t *harnessTest) {
 		Addr:   resp.Address,
 		Amount: btcutil.SatoshiPerBitcoin,
 	}
-	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
+	ctxt, cancel = context.WithTimeout(ctxb, defaultTimeout)
+	defer cancel()
 	if _, err = net.Alice.SendCoins(ctxt, sendReq); err != nil {
 		t.Fatalf("unable to send coins to bob: %v", err)
 	}
@@ -93,7 +96,8 @@ func testCPFP(net *lntest.NetworkHarness, t *harnessTest) {
 		Outpoint:   op,
 		SatPerByte: uint32(sweep.DefaultMaxFeeRate.FeePerKVByte() / 1000),
 	}
-	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
+	ctxt, cancel = context.WithTimeout(ctxb, defaultTimeout)
+	defer cancel()
 	_, err = net.Bob.WalletKitClient.BumpFee(ctxt, bumpFeeReq)
 	if err != nil {
 		t.Fatalf("unable to bump fee: %v", err)
@@ -109,7 +113,8 @@ func testCPFP(net *lntest.NetworkHarness, t *harnessTest) {
 	// We should also expect to see the output being swept by the
 	// UtxoSweeper. We'll ensure it's using the fee rate specified.
 	pendingSweepsReq := &walletrpc.PendingSweepsRequest{}
-	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
+	ctxt, cancel = context.WithTimeout(ctxb, defaultTimeout)
+	defer cancel()
 	pendingSweepsResp, err := net.Bob.WalletKitClient.PendingSweeps(
 		ctxt, pendingSweepsReq,
 	)
@@ -140,7 +145,8 @@ func testCPFP(net *lntest.NetworkHarness, t *harnessTest) {
 	// The input used to CPFP should no longer be pending.
 	err = lntest.WaitNoError(func() error {
 		req := &walletrpc.PendingSweepsRequest{}
-		ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
+		ctxt, cancel = context.WithTimeout(ctxb, defaultTimeout)
+		defer cancel()
 		resp, err := net.Bob.WalletKitClient.PendingSweeps(ctxt, req)
 		if err != nil {
 			return fmt.Errorf("unable to retrieve bob's pending "+

--- a/make/testing_flags.mk
+++ b/make/testing_flags.mk
@@ -54,15 +54,12 @@ UNIT := $(GOLIST) | $(XARGS) env $(GOTEST) -tags="$(DEV_TAGS) $(LOG_TAGS)" $(TES
 UNIT_RACE := $(UNIT) -race
 endif
 
+# Default to btcd backend if not set.
+ifeq ($(backend),)
+backend = btcd
+endif
 
 # Construct the integration test command with the added build flags.
-ITEST_TAGS := $(DEV_TAGS) rpctest chainrpc walletrpc signrpc invoicesrpc autopilotrpc routerrpc watchtowerrpc
-
-# Default to btcd backend if not set.
-ifneq ($(backend),)
-ITEST_TAGS += ${backend}
-else
-ITEST_TAGS += btcd
-endif
+ITEST_TAGS := $(DEV_TAGS) rpctest chainrpc walletrpc signrpc invoicesrpc autopilotrpc routerrpc watchtowerrpc $(backend)
 
 ITEST := rm lntest/itest/output*.log; date; $(GOTEST) ./lntest/itest -tags="$(ITEST_TAGS)" $(TEST_FLAGS) -logoutput

--- a/nursery_store_test.go
+++ b/nursery_store_test.go
@@ -1,5 +1,3 @@
-// +build !rpctest
-
 package lnd
 
 import (

--- a/peer_test.go
+++ b/peer_test.go
@@ -1,5 +1,3 @@
-// +build !rpctest
-
 package lnd
 
 import (

--- a/server_test.go
+++ b/server_test.go
@@ -1,5 +1,3 @@
-// +build !rpctest
-
 package lnd
 
 import "testing"

--- a/utxonursery_test.go
+++ b/utxonursery_test.go
@@ -1,5 +1,3 @@
-// +build !rpctest
-
 package lnd
 
 import (


### PR DESCRIPTION
Now that the itests are in a separate package, we can remove the rpctest
build flag. This makes code completion and syntax checking work since
the files are no longer "hidden" behind the flag.

To make the tools able to properly compile the whole package without any
build flag, we also change the btcd backend compile when !neutrino is
active, instead of requiring the btcd flag.