### PR TITLE
Avoid modifying bucket during ForEach loop, and Cursor traversal

### DIFF
--- a/channeldb/channel.go
+++ b/channeldb/channel.go
@@ -2087,10 +2087,6 @@ func (c *OpenChannel) CloseChannel(summary *ChannelCloseSummary) error {
 		// information stored within the revocation log.
 		logBucket := chanBucket.Bucket(revocationLogBucket)
 		if logBucket != nil {
-			err := wipeChannelLogEntries(logBucket)
-			if err != nil {
-				return err
-			}
 			err = chanBucket.DeleteBucket(revocationLogBucket)
 			if err != nil {
 				return err
@@ -2712,17 +2708,4 @@ func fetchChannelLogEntry(log *bbolt.Bucket,
 
 	commitReader := bytes.NewReader(commitBytes)
 	return deserializeChanCommit(commitReader)
-}
-
-func wipeChannelLogEntries(log *bbolt.Bucket) error {
-	// TODO(roasbeef): comment
-
-	logCursor := log.Cursor()
-	for k, _ := logCursor.First(); k != nil; k, _ = logCursor.Next() {
-		if err := logCursor.Delete(); err != nil {
-			return err
-		}
-	}
-
-	return nil
 }

--- a/contractcourt/briefcase.go
+++ b/contractcourt/briefcase.go
@@ -853,20 +853,9 @@ func (b *boltArbitratorLog) WipeHistory() error {
 		}
 
 		// Next, we'll delete any lingering contract state within the
-		// contracts bucket, and the bucket itself once we're done
-		// clearing it out.
-		contractBucket, err := scopeBucket.CreateBucketIfNotExists(
-			contractsBucketKey,
-		)
-		if err != nil {
-			return err
-		}
-		if err := contractBucket.ForEach(func(resKey, _ []byte) error {
-			return contractBucket.Delete(resKey)
-		}); err != nil {
-			return err
-		}
-		if err := scopeBucket.DeleteBucket(contractsBucketKey); err != nil {
+		// contracts bucket by removing the bucket itself.
+		err = scopeBucket.DeleteBucket(contractsBucketKey)
+		if err != nil && err != bbolt.ErrBucketNotFound {
 			return err
 		}
 
@@ -876,20 +865,10 @@ func (b *boltArbitratorLog) WipeHistory() error {
 			return err
 		}
 
-		// Before we delta the enclosing bucket itself, we'll delta any
-		// chain actions that are still stored.
-		actionsBucket, err := scopeBucket.CreateBucketIfNotExists(
-			actionsBucketKey,
-		)
-		if err != nil {
-			return err
-		}
-		if err := actionsBucket.ForEach(func(resKey, _ []byte) error {
-			return actionsBucket.Delete(resKey)
-		}); err != nil {
-			return err
-		}
-		if err := scopeBucket.DeleteBucket(actionsBucketKey); err != nil {
+		// We'll delete any chain actions that are still stored by
+		// removing the enclosing bucket.
+		err = scopeBucket.DeleteBucket(actionsBucketKey)
+		if err != nil && err != bbolt.ErrBucketNotFound {
 			return err
 		}
 


### PR DESCRIPTION
bbolt documentation states that this is not safe and leads to undefined
behavior.

`channeldb/migrations` and `contractcourt/briefcase` are the only places in the codebase where the `ForEach` modification was done. `

`channeldb` had a few cases of cursor modification.