### PR TITLE
[trivial] Update output log file location to itest package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,7 +32,7 @@ _testmain.go
 /lncli-itest
 
 # Integration test log files
-output*.log
+lntest/itest/output*.log
 lntest/itest/.backendlogs
 lntest/itest/.minerlogs
 

--- a/make/testing_flags.mk
+++ b/make/testing_flags.mk
@@ -65,4 +65,4 @@ else
 ITEST_TAGS += btcd
 endif
 
-ITEST := rm output*.log; date; $(GOTEST) ./lntest/itest -tags="$(ITEST_TAGS)" $(TEST_FLAGS) -logoutput
+ITEST := rm lntest/itest/output*.log; date; $(GOTEST) ./lntest/itest -tags="$(ITEST_TAGS)" $(TEST_FLAGS) -logoutput


### PR DESCRIPTION
`output.log` file paths were moved in #3087 