### PR TITLE
lnrpc/walletrpc: reject nil outpoints as args

### DIFF
--- a/lnrpc/walletrpc/walletkit_server.go
+++ b/lnrpc/walletrpc/walletkit_server.go
@@ -420,6 +420,10 @@ func (w *WalletKit) PendingSweeps(ctx context.Context,
 // unmarshallOutPoint converts an outpoint from its lnrpc type to its canonical
 // type.
 func unmarshallOutPoint(op *lnrpc.OutPoint) (*wire.OutPoint, error) {
+	if op == nil {
+		return nil, fmt.Errorf("empty outpoint provided")
+	}
+
 	var hash chainhash.Hash
 	switch {
 	case len(op.TxidBytes) == 0 && len(op.TxidStr) == 0:


### PR DESCRIPTION
In this commit, we modify the parsing of user provided outpoints to
ensure that we catch a nil (empty) output early. Otherwise, passing a
set of incorrect arguments would cause `lnd` to crash.

