### PR TITLE
routing+watchtower/wtclient: prints stats once per minute

### DIFF
--- a/routing/router.go
+++ b/routing/router.go
@@ -42,7 +42,7 @@ const (
 	// defaultStatInterval governs how often the router will log non-empty
 	// stats related to processing new channels, updates, or node
 	// announcements.
-	defaultStatInterval = 30 * time.Second
+	defaultStatInterval = time.Minute
 )
 
 var (

--- a/watchtower/wtclient/client.go
+++ b/watchtower/wtclient/client.go
@@ -28,7 +28,7 @@ const (
 
 	// DefaultStatInterval specifies the default interval between logging
 	// metrics about the client's operation.
-	DefaultStatInterval = 30 * time.Second
+	DefaultStatInterval = time.Minute
 
 	// DefaultForceQuitDelay specifies the default duration after which the
 	// client should abandon any pending updates or session negotiations


### PR DESCRIPTION
Reduces the stat tickers in the wtclient and router from 30s to one minute to reduce spammy-ness.