### PR TITLE
watchtower/multi: fix logging in wtclient

### DIFF
--- a/watchtower/wtclient/client.go
+++ b/watchtower/wtclient/client.go
@@ -738,7 +738,7 @@ func (c *TowerClient) taskRejected(task *backupTask, curStatus reserveStatus) {
 	case reserveExhausted:
 		c.stats.sessionExhausted()
 
-		log.Debugf("Session %v exhausted, %s queued for next session",
+		log.Debugf("Session %v exhausted, %v queued for next session",
 			c.sessionQueue.ID(), task.id)
 
 		// Cache the task that we pulled off, so that we can process it

--- a/watchtower/wtclient/session_queue.go
+++ b/watchtower/wtclient/session_queue.go
@@ -199,7 +199,7 @@ func (q *sessionQueue) AcceptTask(task *backupTask) (reserveStatus, bool) {
 
 	numPending := uint32(q.pendingQueue.Len())
 	maxUpdates := q.cfg.ClientSession.Policy.MaxUpdates
-	log.Debugf("SessionQueue(%x) deciding to accept %v seqnum=%d "+
+	log.Debugf("SessionQueue(%s) deciding to accept %v seqnum=%d "+
 		"pending=%d max-updates=%d",
 		q.ID(), task.id, q.seqNum, numPending, maxUpdates)
 

--- a/watchtower/wtdb/client_session.go
+++ b/watchtower/wtdb/client_session.go
@@ -162,7 +162,7 @@ func (b *BackupID) Decode(r io.Reader) error {
 }
 
 // String returns a human-readable encoding of a BackupID.
-func (b *BackupID) String() string {
+func (b BackupID) String() string {
 	return fmt.Sprintf("backup(%x, %d)", b.ChanID, b.CommitHeight)
 }
 


### PR DESCRIPTION
Tidies up some log messages that I've noticed were incorrect. Almost all of the BackupIDs were being improperly formatted because the of the pointer receiver on `String()`, when they are passed in by value to log functions.