### PR TITLE
[trivial] rpcserver+router: log terminal sendPayment error

### DIFF
--- a/routing/payment_lifecycle.go
+++ b/routing/payment_lifecycle.go
@@ -218,6 +218,9 @@ func (p *paymentLifecycle) createNewPaymentAttempt() (lnwire.ShortChannelID,
 		p.payment, uint32(p.currentHeight), p.finalCLTVDelta,
 	)
 	if err != nil {
+		log.Errorf("Failed to find route for payment %x: %v",
+			p.payment.PaymentHash, err)
+
 		// If we're unable to successfully make a payment using
 		// any of the routes we've found, then mark the payment
 		// as permanently failed.

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -3121,6 +3121,8 @@ func (r *rpcServer) dispatchPaymentIntent(
 	// If the route failed, then we'll return a nil save err, but a non-nil
 	// routing err.
 	if routerErr != nil {
+		rpcsLog.Errorf("Unable to send payment: %v", routerErr)
+
 		return &paymentIntentResponse{
 			Err: routerErr,
 		}, nil


### PR DESCRIPTION
Increase visibility into why payments fail, especially in the app logs.