### PR TITLE
rpcserver: ForwardingHistory end_time defaults to time.Now()

### DIFF
--- a/cmd/lncli/commands.go
+++ b/cmd/lncli/commands.go
@@ -3514,8 +3514,9 @@ var forwardingHistoryCommand = cli.Command{
 	Query the HTLC switch's internal forwarding log for all completed
 	payment circuits (HTLCs) over a particular time range (--start_time and
 	--end_time). The start and end times are meant to be expressed in
-	seconds since the Unix epoch. If a start and end time aren't provided,
-	then events over the past 24 hours are queried for.
+	seconds since the Unix epoch. If --start_time isn't provided,
+	then 24 hours ago is used.  If --end_time isn't provided,
+	then the current time is used.
 
 	The max number of events returned is 50k. The default number is 100,
 	callers can use the --max_events param to modify this value.

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -4600,14 +4600,19 @@ func (r *rpcServer) ForwardingHistory(ctx context.Context,
 		numEvents uint32
 	)
 
-	// If the start and end time were not set, then we'll just return the
-	// records over the past 24 hours.
-	if req.StartTime == 0 && req.EndTime == 0 {
+	// If the start time wasn't specified, we'll default to 24 hours ago.
+	if req.StartTime == 0 {
 		now := time.Now()
 		startTime = now.Add(-time.Hour * 24)
-		endTime = now
 	} else {
 		startTime = time.Unix(int64(req.StartTime), 0)
+	}
+
+	// If the end time wasn't specified, assume a default end time of now.
+	if req.EndTime == 0 {
+		now := time.Now()
+		endTime = now
+	} else {
 		endTime = time.Unix(int64(req.EndTime), 0)
 	}
 
@@ -4618,7 +4623,7 @@ func (r *rpcServer) ForwardingHistory(ctx context.Context,
 		numEvents = 100
 	}
 
-	// Next, we'll map the proto request into a format the is understood by
+	// Next, we'll map the proto request into a format that is understood by
 	// the forwarding log.
 	eventQuery := channeldb.ForwardingEventQuery{
 		StartTime:    startTime,


### PR DESCRIPTION
Closes simple version of #3240.

#### Pull Request Checklist

- [X] If this is your first time contributing, we recommend you read the [Code
  Contribution Guidelines](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md)
- [X] All changes are Go version 1.12 compliant
- [X] The code being submitted is commented according to [Code Documentation and Commenting](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#CodeDocumentation)
- [X] For new code: Code is accompanied by tests which exercise both
  the positive and negative (error paths) conditions (if applicable)
- [X] For bug fixes: Code is accompanied by new tests which trigger
  the bug being fixed to prevent regressions
- [X] Any new logging statements use an appropriate subsystem and
  logging level
- [X] Code has been formatted with `go fmt`
- [X] For code and documentation: lines are wrapped at 80 characters
  (the tab character should be counted as 8 characters, not 4, as some IDEs do
  per default)
- [X] Running `make check` does not fail any tests
- [X] Running `go vet` does not report any issues
- [X] Running `make lint` does not report any **new** issues that did not
  already exist
- [X] All commits build properly and pass tests. Only in exceptional
  cases it can be justifiable to violate this condition. In that case, the
  reason should be stated in the commit message.
- [X] Commits have a logical structure according to [Ideal Git Commit Structure](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#IdealGitCommitStructure)