### PR TITLE
multi: add secondary DNS seed for bootstrap, add exponential back off to initial bootstrap

### DIFF
--- a/chainregistry.go
+++ b/chainregistry.go
@@ -576,6 +576,9 @@ var (
 				"nodes.lightning.directory",
 				"soa.nodes.lightning.directory",
 			},
+			{
+				"lseed.bitcoinstats.com",
+			},
 		},
 
 		bitcoinTestnetGenesis: {

--- a/server.go
+++ b/server.go
@@ -1719,7 +1719,6 @@ func (s *server) peerBootstrapper(numTargetPeers uint32,
 func (s *server) initialPeerBootstrap(ignore map[autopilot.NodeID]struct{},
 	numTargetPeers uint32, bootstrappers []discovery.NetworkPeerBootstrapper) {
 
-	var wg sync.WaitGroup
 
 	for {
 		// Check if the server has been requested to shut down in order
@@ -1752,6 +1751,7 @@ func (s *server) initialPeerBootstrap(ignore map[autopilot.NodeID]struct{},
 
 		// Then, we'll attempt to establish a connection to the
 		// different peer addresses retrieved by our bootstrappers.
+		var wg sync.WaitGroup
 		for _, bootstrapAddr := range bootstrapAddrs {
 			wg.Add(1)
 			go func(addr *lnwire.NetAddress) {

--- a/server.go
+++ b/server.go
@@ -1600,7 +1600,6 @@ func (s *server) peerBootstrapper(numTargetPeers uint32,
 	//
 	// We'll use a 15 second backoff, and double the time every time an
 	// epoch fails up to a ceiling.
-	const backOffCeiling = time.Minute * 5
 	backOff := time.Second * 15
 
 	// We'll create a new ticker to wake us up every 15 seconds so we can
@@ -1643,8 +1642,8 @@ func (s *server) peerBootstrapper(numTargetPeers uint32,
 				sampleTicker.Stop()
 
 				backOff *= 2
-				if backOff > backOffCeiling {
-					backOff = backOffCeiling
+				if backOff > bootstrapBackOffCeiling {
+					backOff = bootstrapBackOffCeiling
 				}
 
 				srvrLog.Debugf("Backing off peer bootstrapper to "+
@@ -1712,6 +1711,11 @@ func (s *server) peerBootstrapper(numTargetPeers uint32,
 		}
 	}
 }
+
+// bootstrapBackOffCeiling is the maximum amount of time we'll wait between
+// failed attempts to locate a set of bootstrap peers. We'll slowly double our
+// query back off each time we encounter a failure.
+const bootstrapBackOffCeiling = time.Minute * 5
 
 // initialPeerBootstrap attempts to continuously connect to peers on startup
 // until the target number of peers has been reached. This ensures that nodes

--- a/watchtower/wtclient/session_queue.go
+++ b/watchtower/wtclient/session_queue.go
@@ -316,8 +316,8 @@ func (q *sessionQueue) drainBackups() {
 		// before attempting to dequeue any pending updates.
 		stateUpdate, isPending, backupID, err := q.nextStateUpdate()
 		if err != nil {
-			log.Errorf("SessionQueue(%s) unable to get next state "+
-				"update: %v", err)
+			log.Errorf("SessionQueue(%v) unable to get next state "+
+				"update: %v", q.ID(), err)
 			return
 		}
 
@@ -557,7 +557,7 @@ func (q *sessionQueue) sendStateUpdate(conn wtserver.Peer,
 		// TODO(conner): borked watchtower
 		err = fmt.Errorf("unable to ack seqnum=%d: %v",
 			stateUpdate.SeqNum, err)
-		log.Errorf("SessionQueue(%s) failed to ack update: %v", err)
+		log.Errorf("SessionQueue(%v) failed to ack update: %v", q.ID(), err)
 		return err
 
 	case err == wtdb.ErrLastAppliedReversion:


### PR DESCRIPTION
In this commit we add a second DNS seed to make lnd's process of bootstrapping an initial set of peers more robust. Along the way, we modify the primary DNS `SampleNodeAddrs` method to no longer retry, and also simply try the next seed if it fails to connect to one. Additionally, it is now no longer required that a DNS seed uses our "secondary fall back" mechanism. 

Reviewers can test that this PR will fall back to the newly added seed if the primary is down by modifying the domain in `chainregistry.go`, and ensuring that a new `lnd` instance is still able to find peers. 