### PR TITLE
chanrestore: return error instead of nil if failed derivation

### DIFF
--- a/chanrestore.go
+++ b/chanrestore.go
@@ -41,7 +41,7 @@ func (c *chanDBRestorer) openChannelShell(backup chanbackup.Single) (
 	// shachain...
 	privKey, err := c.secretKeys.DerivePrivKey(backup.ShaChainRootDesc)
 	if err != nil {
-		return nil, nil
+		return nil, fmt.Errorf("unable to derive shachain root key: %v", err)
 	}
 	revRoot, err := chainhash.NewHash(privKey.Serialize())
 	if err != nil {


### PR DESCRIPTION
Fixes the panic in #3180