### PR TITLE
lnwallet/fee_estimator: shorten TLS + dial timeouts for web API fee e…

### DIFF
--- a/lnwallet/fee_estimator.go
+++ b/lnwallet/fee_estimator.go
@@ -711,12 +711,12 @@ func (w *WebAPIFeeEstimator) updateFeeEstimates() {
 	// overloaded, we can exit early and use our default fee.
 	netTransport := &http.Transport{
 		Dial: (&net.Dialer{
-			Timeout: 5 * time.Second,
+			Timeout: 1 * time.Second,
 		}).Dial,
-		TLSHandshakeTimeout: 5 * time.Second,
+		TLSHandshakeTimeout: 1 * time.Second,
 	}
 	netClient := &http.Client{
-		Timeout:   time.Second * 10,
+		Timeout:   time.Second * 5,
 		Transport: netTransport,
 	}
 


### PR DESCRIPTION
…stimator

The current long timeouts can cause problems on devices that tend to have
internet connection flappiness, e.g. mobile devices. Fee estimation failures
can happen when devices switch from 4G to wifi, vice versa, and during other
such disruptions.
