### PR TITLE
CODEOWNERS: create initial code owners config

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,81 @@
+* @roasbeef @cfromknecht @valentinewallace @joostjager @wpaulino @halseth
+
+azeeed/* @roasbeef @cfromknecht
+
+autopilot/* @halseth @roasbeef
+
+brontide/* @roasbeef @cfromknecht
+
+buffer/* @cfromknecht
+
+build/* @cfromknecht
+
+chainntnfs/* @halseth @wpaulino
+
+chanbackup/* @roasbeef
+
+channeldb/channel.go @roasbeef
+
+channeldb/forwarding_log.go @roasbeef
+
+channeldb/graph.go @roasbeef @halseth
+
+channeldb/invoices.go @roasbeef @joostjager
+
+channeldb/payment_control.go @halseth @joostjager
+
+channeldb/payments.go @halseth @joostjager
+
+channeldb/reject_cache.go @cfromknecht
+
+channelnotifier/* @valentinewallace
+
+contractcourt/* @roasbeef @joostjager
+
+discovery/* @halseth @wpaulino
+
+htlcswitch/* @roasbeef @cfromknecht
+
+input/* @joostjager @roasbeef
+
+keychain/* @roasbeef
+
+lnwallet/* @roasbeef @halseth
+
+macaroons/* @roasbeef
+
+monitoring/* @valentinewallace
+
+nat/* @wpaulino
+
+pool/* @cfromknecht
+
+queue/* @cfromknecht
+
+routing/* @joostjager @roasbeef
+
+sweep/* @joostjager
+
+tor/* @wpaulino
+
+walletunlocker/* @roasbeef
+
+watchtower/* @cfromknecht @roasbeef
+
+zpay32/* @halseth @roasbeef
+
+breacharbiter.go @cfromknecht @roasbeef
+
+chanrestore.go @roasbeef
+
+fundingmanager.go @halseth @roasbeef
+
+nursery_store.go @cfromknecht
+
+peer.go @cfromknecht @roasbeef
+
+pilot.go @halseth @roasbeef
+
+server.go @cfromknecht @roasbeef
+
+utxonursery.go @cfromknecht @roasbeef


### PR DESCRIPTION
In this commit, we create the initial CODEOWNERS file for `lnd`. This
file is a new-ish feature of Github that allows the maintains of a
project to define the individuals who are deemed to be experts of a
particular section of the codebase. Automated review assignment systems
can then use this file to generate required reviewers for a section of
the project. The CODEOWNERS file isn't meant to be a strict guideline,
but instead can be used to ease the burden of finding reviewers for a
particular section of the codebase.

It's also possible to enforce that the CODEOWNERS for a particular
file/package sign-off on relevant changes, thereby blocking review
unless they're involved. However, for now we'll simply use it to guide
the review assignment project, leaving creating blocking review
constraints until a later point if deemed useful.

