### PR TITLE
channeldb: specify freelist bbolt options by default

### DIFF
--- a/channeldb/db.go
+++ b/channeldb/db.go
@@ -135,7 +135,14 @@ func Open(dbPath string, modifiers ...OptionModifier) (*DB, error) {
 		modifier(&opts)
 	}
 
-	bdb, err := bbolt.Open(path, dbFilePermission, nil)
+	// Specify bbolt freelist options to reduce heap pressure in case the
+	// freelist grows to be very large.
+	options := &bbolt.Options{
+		NoFreelistSync: true,
+		FreelistType:   bbolt.FreelistMapType,
+	}
+
+	bdb, err := bbolt.Open(path, dbFilePermission, options)
 	if err != nil {
 		return nil, err
 	}

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/btcsuite/btcutil v0.0.0-20190425235716-9e5f4b9a998d
 	github.com/btcsuite/btcwallet v0.0.0-20190628225330-4a9774585e57
 	github.com/btcsuite/fastsha256 v0.0.0-20160815193821-637e65642941
-	github.com/coreos/bbolt v1.3.2
+	github.com/coreos/bbolt v1.3.3
 	github.com/davecgh/go-spew v1.1.1
 	github.com/go-errors/errors v1.0.1
 	github.com/golang/protobuf v1.3.1

--- a/go.sum
+++ b/go.sum
@@ -64,6 +64,8 @@ github.com/coreos/bbolt v0.0.0-20180223184059-7ee3ded59d4835e10f3e7d0f7603c42aa5
 github.com/coreos/bbolt v0.0.0-20180223184059-7ee3ded59d4835e10f3e7d0f7603c42aa5e83820/go.mod h1:iRUV2dpdMOn7Bo10OQBFzIJO9kkE559Wcmn+qkEiiKk=
 github.com/coreos/bbolt v1.3.2 h1:wZwiHHUieZCquLkDL0B8UhzreNWsPHooDAG3q34zk0s=
 github.com/coreos/bbolt v1.3.2/go.mod h1:iRUV2dpdMOn7Bo10OQBFzIJO9kkE559Wcmn+qkEiiKk=
+github.com/coreos/bbolt v1.3.3 h1:n6AiVyVRKQFNb6mJlwESEvvLoDyiTzXX7ORAUlkeBdY=
+github.com/coreos/bbolt v1.3.3/go.mod h1:iRUV2dpdMOn7Bo10OQBFzIJO9kkE559Wcmn+qkEiiKk=
 github.com/davecgh/go-spew v0.0.0-20171005155431-ecdeabc65495/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/watchtower/wtdb/db_common.go
+++ b/watchtower/wtdb/db_common.go
@@ -63,7 +63,14 @@ func createDBIfNotExist(dbPath, name string) (*bbolt.DB, bool, error) {
 		}
 	}
 
-	bdb, err := bbolt.Open(path, dbFilePermission, nil)
+	// Specify bbolt freelist options to reduce heap pressure in case the
+	// freelist grows to be very large.
+	options := &bbolt.Options{
+		NoFreelistSync: true,
+		FreelistType:   bbolt.FreelistMapType,
+	}
+
+	bdb, err := bbolt.Open(path, dbFilePermission, options)
 	if err != nil {
 		return nil, false, err
 	}


### PR DESCRIPTION
Fixes #3241.

These options could really be specified anywhere that bbolt is opened, so if that's of interest I can also do that.  But the only other large database I had on my machine was `wallet.db` which is the `btcwallet` repo.  Perhaps watchtowers might use a lot of space, or there could be some design parameters that change in the future where the other databases start using more space (macaroons.db etc).  Should I add these options to all the tests so they reflect the new behavior?

Updated bbolt dependency to v1.3.3 per https://github.com/etcd-io/bbolt/pull/153
The only downside is that if the db txn has to be rolled back in case of failure, the freelist must be built again temporarily which can be heavy with big databases.  I think this is an acceptable tradeoff since this shouldn't be happening too often.