### PR TITLE
rpcserver: add cors support

### DIFF
--- a/config.go
+++ b/config.go
@@ -254,6 +254,7 @@ type config struct {
 	RawRESTListeners []string `long:"restlisten" description:"Add an interface/port/socket to listen for REST connections"`
 	RawListeners     []string `long:"listen" description:"Add an interface/port to listen for peer connections"`
 	RawExternalIPs   []string `long:"externalip" description:"Add an ip:port to the list of local addresses we claim to listen on to peers. If a port is not specified, the default (9735) will be used regardless of other parameters"`
+	RestCORS   		 []string `long:"restcors" description:"Add an ip:port/hostname to allow cross origin access from. To allow all origins, set as \"*\"."`
 	RPCListeners     []net.Addr
 	RESTListeners    []net.Addr
 	Listeners        []net.Addr

--- a/config.go
+++ b/config.go
@@ -254,7 +254,7 @@ type config struct {
 	RawRESTListeners []string `long:"restlisten" description:"Add an interface/port/socket to listen for REST connections"`
 	RawListeners     []string `long:"listen" description:"Add an interface/port to listen for peer connections"`
 	RawExternalIPs   []string `long:"externalip" description:"Add an ip:port to the list of local addresses we claim to listen on to peers. If a port is not specified, the default (9735) will be used regardless of other parameters"`
-	RestCORS   		 []string `long:"restcors" description:"Add an ip:port/hostname to allow cross origin access from. To allow all origins, set as \"*\"."`
+	RestCORS         []string `long:"restcors" description:"Add an ip:port/hostname to allow cross origin access from. To allow all origins, set as \"*\"."`
 	RPCListeners     []net.Addr
 	RESTListeners    []net.Addr
 	Listeners        []net.Addr

--- a/lnd.go
+++ b/lnd.go
@@ -880,7 +880,7 @@ func waitForWalletPassword(grpcEndpoints, restEndpoints []net.Addr,
 		return nil, err
 	}
 
-	srv := &http.Server{Handler: mux}
+	srv := &http.Server{Handler: allowCORS(mux)}
 
 	for _, restEndpoint := range restEndpoints {
 		lis, err := lncfg.TLSListenOnAddress(restEndpoint, tlsConf)

--- a/lnd.go
+++ b/lnd.go
@@ -880,7 +880,7 @@ func waitForWalletPassword(grpcEndpoints, restEndpoints []net.Addr,
 		return nil, err
 	}
 
-	// Check for CORS configurations before starting REST proxy
+	// Check for CORS configurations before starting REST proxy.
 	var srv *http.Server
 
 	if len(cfg.RestCORS) == 0 {

--- a/lnd.go
+++ b/lnd.go
@@ -880,7 +880,14 @@ func waitForWalletPassword(grpcEndpoints, restEndpoints []net.Addr,
 		return nil, err
 	}
 
-	srv := &http.Server{Handler: allowCORS(mux)}
+	// Check for CORS configurations before starting REST proxy
+	var srv *http.Server
+
+	if len(cfg.RestCORS) == 0 {
+		srv = &http.Server{Handler: mux}
+	} else {
+		srv = &http.Server{Handler: checkCors(mux)}
+	}
 
 	for _, restEndpoint := range restEndpoints {
 		lis, err := lncfg.TLSListenOnAddress(restEndpoint, tlsConf)

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -697,7 +697,7 @@ func allowCORS(h http.Handler) http.Handler {
 			w.Header().Set("Access-Control-Allow-Headers",
 				"Content-Type, Accept, grpc-metadata-macaroon")
 			w.Header().Set("Access-Control-Allow-Methods",
-				"GET, POST")
+				"GET, POST, DELETE")
 			return
 		}
 

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -695,23 +695,24 @@ func checkCors(h http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		origin := r.Header.Get("Origin")
 
-		// Skip CORS check if request did not send origin
+		// Skip CORS check if request did not send origin.
 		if origin != "" {
-			// Check if all origins are allowed or requested origin is in list
+			// Check if all origins are allowed or requested origin is in list.
 			for _, allowedOrigin := range cfg.RestCORS {
 				if allowedOrigin == "*" || origin == allowedOrigin {
-					// Only set ACAO header for requested origin
+					// Only set ACAO header for requested origin.
 					w.Header().Set("Access-Control-Allow-Origin", origin)
 
-					// Set necessary headers for preflight requests
+					// Set necessary headers for preflight requests.
 					if r.Method == "OPTIONS" &&
 						r.Header.Get("Access-Control-Request-Method") != "" {
+
 						w.Header().Set("Access-Control-Allow-Headers",
 							"Content-Type, Accept, grpc-metadata-macaroon")
 						w.Header().Set("Access-Control-Allow-Methods",
 							"GET, POST, DELETE")
 
-						// Nothing else needs to be served for OPTIONS
+						// Nothing else needs to be served for OPTIONS.
 						return
 					}
 					break

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -696,26 +696,26 @@ func checkCors(h http.Handler) http.Handler {
 		origin := r.Header.Get("Origin")
 
 		// Skip CORS check if request did not send origin
-		if origin == "" {
-			return
-		}
+		if origin != "" {
+			// Check if all origins are allowed or requested origin is in list
+			for _, allowedOrigin := range cfg.RestCORS {
+				if allowedOrigin == "*" || origin == allowedOrigin {
+					// Only set ACAO header for requested origin
+					w.Header().Set("Access-Control-Allow-Origin", origin)
 
-		// Check if all origins are allowed or if requested origin matches list
-		for _, allowedOrigin := range cfg.RestCORS {
-			if allowedOrigin == "*" || origin == allowedOrigin {
-				// Only set ACAO header for requested origin
-				w.Header().Set("Access-Control-Allow-Origin", origin)
+					// Set necessary headers for preflight requests
+					if r.Method == "OPTIONS" &&
+						r.Header.Get("Access-Control-Request-Method") != "" {
+						w.Header().Set("Access-Control-Allow-Headers",
+							"Content-Type, Accept, grpc-metadata-macaroon")
+						w.Header().Set("Access-Control-Allow-Methods",
+							"GET, POST, DELETE")
 
-				// Set necessary headers for preflight requests
-				if r.Method == "OPTIONS" &&
-					r.Header.Get("Access-Control-Request-Method") != "" {
-					w.Header().Set("Access-Control-Allow-Headers",
-						"Content-Type, Accept, grpc-metadata-macaroon")
-					w.Header().Set("Access-Control-Allow-Methods",
-						"GET, POST, DELETE")
-					return
+						// Nothing else needs to be served for OPTIONS
+						return
+					}
+					break
 				}
-				break
 			}
 		}
 


### PR DESCRIPTION
This adds cors support to the LND http proxy, ticket created on it here: https://github.com/lightningnetwork/lnd/issues/2344

Basing it off of this stale PR: https://github.com/lightningnetwork/lnd/pull/1433
Key differences: 
-cors automatically
-doing so without pulling in a separate library

This should allow browser based wallets to access LND nodes via http, since browsers cannot access via grcp. Otherwise, browsers need to run with security disabled which do not check cors. 