### PR TITLE
multi: move several wait group done calls to defer statements

### DIFF
--- a/chainntnfs/bitcoindnotify/bitcoind.go
+++ b/chainntnfs/bitcoindnotify/bitcoind.go
@@ -177,6 +177,8 @@ type blockNtfn struct {
 // notificationDispatcher is the primary goroutine which handles client
 // notification registrations, as well as notification dispatches.
 func (b *BitcoindNotifier) notificationDispatcher() {
+	defer b.wg.Done()
+
 out:
 	for {
 		select {
@@ -431,7 +433,6 @@ out:
 			break out
 		}
 	}
-	b.wg.Done()
 }
 
 // historicalConfDetails looks up whether a confirmation request (txid/output

--- a/chainntnfs/btcdnotify/btcd.go
+++ b/chainntnfs/btcdnotify/btcd.go
@@ -254,6 +254,8 @@ func (b *BtcdNotifier) onRedeemingTx(tx *btcutil.Tx, details *btcjson.BlockDetai
 // notificationDispatcher is the primary goroutine which handles client
 // notification registrations, as well as notification dispatches.
 func (b *BtcdNotifier) notificationDispatcher() {
+	defer b.wg.Done()
+
 out:
 	for {
 		select {
@@ -453,7 +455,6 @@ out:
 			break out
 		}
 	}
-	b.wg.Done()
 }
 
 // historicalConfDetails looks up whether a confirmation request (txid/output

--- a/lnwallet/btcwallet/btcwallet.go
+++ b/lnwallet/btcwallet/btcwallet.go
@@ -674,6 +674,8 @@ func (t *txSubscriptionClient) Cancel() {
 // wallet's notification client to a higher-level TransactionSubscription
 // client.
 func (t *txSubscriptionClient) notificationProxier() {
+	defer t.wg.Done()
+
 out:
 	for {
 		select {
@@ -721,8 +723,6 @@ out:
 			break out
 		}
 	}
-
-	t.wg.Done()
 }
 
 // SubscribeTransactions returns a TransactionSubscription client which

--- a/lnwallet/wallet.go
+++ b/lnwallet/wallet.go
@@ -368,6 +368,8 @@ func (l *LightningWallet) ActiveReservations() []*ChannelReservation {
 // requestHandler is the primary goroutine(s) responsible for handling, and
 // dispatching replies to all messages.
 func (l *LightningWallet) requestHandler() {
+	defer l.wg.Done()
+
 out:
 	for {
 		select {
@@ -391,8 +393,6 @@ out:
 			break out
 		}
 	}
-
-	l.wg.Done()
 }
 
 // InitChannelReservation kicks off the 3-step workflow required to successfully

--- a/peer.go
+++ b/peer.go
@@ -1474,6 +1474,8 @@ func (p *peer) writeMessage(msg lnwire.Message) error {
 //
 // NOTE: This method MUST be run as a goroutine.
 func (p *peer) writeHandler() {
+	defer p.wg.Done()
+
 	// We'll stop the timer after a new messages is sent, and also reset it
 	// after we process the next message.
 	idleTimer := time.AfterFunc(idleTimeout, func() {
@@ -1554,8 +1556,6 @@ out:
 			break out
 		}
 	}
-
-	p.wg.Done()
 
 	p.Disconnect(exitErr)
 


### PR DESCRIPTION
This change provides stronger guarantees that the wait group counter will be decremented when the goroutine returns or panics.