### PR TITLE
CODEOWNERS: fix aezeed typo

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,6 +1,6 @@
 * @roasbeef @cfromknecht @valentinewallace @joostjager @wpaulino @halseth
 
-azeeed/* @roasbeef @cfromknecht
+aezeed/* @roasbeef @cfromknecht
 
 autopilot/* @halseth @roasbeef
 


### PR DESCRIPTION
pointed out by @Crypt-iQ https://github.com/lightningnetwork/lnd/pull/3269#discussion_r301823625