### PR TITLE
[trivial] lnrpc: make BumpFee doc start with RPC name

### DIFF
--- a/lnrpc/walletrpc/walletkit.pb.go
+++ b/lnrpc/walletrpc/walletkit.pb.go
@@ -903,14 +903,14 @@ type WalletKitClient interface {
 	//the UtxoSweeper, so things may change.
 	PendingSweeps(ctx context.Context, in *PendingSweepsRequest, opts ...grpc.CallOption) (*PendingSweepsResponse, error)
 	//
-	//Bump the fee of an arbitrary input within a transaction. This RPC takes a
-	//different approach than bitcoind's bumpfee command. lnd has a central
-	//batching engine in which inputs with similar fee rates are batched together
-	//to save on transaction fees. Due to this, we cannot rely on bumping the fee
-	//on a specific transaction, since transactions can change at any point with
-	//the addition of new inputs. The list of inputs that currently exist within
-	//lnd's central batching engine can be retrieved through the PendingSweeps
-	//RPC.
+	//BumpFee bumps the fee of an arbitrary input within a transaction. This RPC
+	//takes a different approach than bitcoind's bumpfee command. lnd has a
+	//central batching engine in which inputs with similar fee rates are batched
+	//together to save on transaction fees. Due to this, we cannot rely on
+	//bumping the fee on a specific transaction, since transactions can change at
+	//any point with the addition of new inputs. The list of inputs that
+	//currently exist within lnd's central batching engine can be retrieved
+	//through the PendingSweeps RPC.
 	//
 	//When bumping the fee of an input that currently exists within lnd's central
 	//batching engine, a higher fee transaction will be created that replaces the
@@ -1052,14 +1052,14 @@ type WalletKitServer interface {
 	//the UtxoSweeper, so things may change.
 	PendingSweeps(context.Context, *PendingSweepsRequest) (*PendingSweepsResponse, error)
 	//
-	//Bump the fee of an arbitrary input within a transaction. This RPC takes a
-	//different approach than bitcoind's bumpfee command. lnd has a central
-	//batching engine in which inputs with similar fee rates are batched together
-	//to save on transaction fees. Due to this, we cannot rely on bumping the fee
-	//on a specific transaction, since transactions can change at any point with
-	//the addition of new inputs. The list of inputs that currently exist within
-	//lnd's central batching engine can be retrieved through the PendingSweeps
-	//RPC.
+	//BumpFee bumps the fee of an arbitrary input within a transaction. This RPC
+	//takes a different approach than bitcoind's bumpfee command. lnd has a
+	//central batching engine in which inputs with similar fee rates are batched
+	//together to save on transaction fees. Due to this, we cannot rely on
+	//bumping the fee on a specific transaction, since transactions can change at
+	//any point with the addition of new inputs. The list of inputs that
+	//currently exist within lnd's central batching engine can be retrieved
+	//through the PendingSweeps RPC.
 	//
 	//When bumping the fee of an input that currently exists within lnd's central
 	//batching engine, a higher fee transaction will be created that replaces the

--- a/lnrpc/walletrpc/walletkit.proto
+++ b/lnrpc/walletrpc/walletkit.proto
@@ -274,14 +274,14 @@ service WalletKit {
     rpc PendingSweeps(PendingSweepsRequest) returns (PendingSweepsResponse);
 
     /*
-    Bump the fee of an arbitrary input within a transaction. This RPC takes a
-    different approach than bitcoind's bumpfee command. lnd has a central
-    batching engine in which inputs with similar fee rates are batched together
-    to save on transaction fees. Due to this, we cannot rely on bumping the fee
-    on a specific transaction, since transactions can change at any point with
-    the addition of new inputs. The list of inputs that currently exist within
-    lnd's central batching engine can be retrieved through the PendingSweeps
-    RPC.
+    BumpFee bumps the fee of an arbitrary input within a transaction. This RPC
+    takes a different approach than bitcoind's bumpfee command. lnd has a
+    central batching engine in which inputs with similar fee rates are batched
+    together to save on transaction fees. Due to this, we cannot rely on
+    bumping the fee on a specific transaction, since transactions can change at
+    any point with the addition of new inputs. The list of inputs that
+    currently exist within lnd's central batching engine can be retrieved
+    through the PendingSweeps RPC.
 
     When bumping the fee of an input that currently exists within lnd's central
     batching engine, a higher fee transaction will be created that replaces the


### PR DESCRIPTION
Keep docs consistent and also needed for proper mobile RPC doc parsing.