### PR TITLE
invoicesrpc: fix route hint off-by-one-error

### DIFF
--- a/lnrpc/invoicesrpc/addinvoice.go
+++ b/lnrpc/invoicesrpc/addinvoice.go
@@ -268,7 +268,7 @@ func AddInvoice(ctx context.Context, cfg *AddInvoiceConfig,
 		for _, channel := range openChannels {
 			// We'll restrict the number of individual route hints
 			// to 20 to avoid creating overly large invoices.
-			if numHints > 20 {
+			if numHints >= 20 {
 				break
 			}
 


### PR DESCRIPTION
right now it is possible to add 21 route hints which results in an error.

closes #3305