### PR TITLE
aezeed: publicly export the `word` field  in `ErrUnknownMnenomicWord`

### DIFF
--- a/aezeed/cipherseed.go
+++ b/aezeed/cipherseed.go
@@ -510,10 +510,13 @@ func (m *Mnemonic) Decipher(pass []byte) ([DecipheredCipherSeedSize]byte, error)
 	// Before we attempt to map the mnemonic back to the original
 	// ciphertext, we'll ensure that all the word are actually a part of
 	// the current default word list.
-	for _, word := range m {
+	for i, word := range m {
 		if !strings.Contains(englishWordList, word) {
 			emptySeed := [DecipheredCipherSeedSize]byte{}
-			return emptySeed, ErrUnknownMnenomicWord{word}
+			return emptySeed, ErrUnknownMnenomicWord{
+				Word:  word,
+				Index: uint8(i),
+			}
 		}
 	}
 

--- a/aezeed/cipherseed_test.go
+++ b/aezeed/cipherseed_test.go
@@ -543,8 +543,12 @@ func TestDecipherUnknownMnenomicWord(t *testing.T) {
 		t.Fatalf("expected ErrUnknownMnenomicWord instead got %T", err)
 	}
 
-	if wordErr.word != "kek" {
-		t.Fatalf("word mismatch: expected %v, got %v", "kek", wordErr.word)
+	if wordErr.Word != "kek" {
+		t.Fatalf("word mismatch: expected %v, got %v", "kek", wordErr.Word)
+	}
+	if int32(wordErr.Index) != randIndex {
+		t.Fatalf("wrong index detected: expected %v, got %v",
+			randIndex, wordErr.Index)
 	}
 }
 

--- a/aezeed/errors.go
+++ b/aezeed/errors.go
@@ -21,10 +21,16 @@ var (
 // ErrUnknownMnenomicWord is returned when attempting to decipher and
 // enciphered mnemonic, but a word encountered isn't a member of our word list.
 type ErrUnknownMnenomicWord struct {
-	word string
+	// Word is the unknown word in the mnemonic phrase.
+	Word string
+
+	// Index is the index (starting from zero) within the slice of strings
+	// that makes up the mnemonic that points to the incorrect word.
+	Index uint8
 }
 
 // Error returns a human readable string describing the error.
 func (e ErrUnknownMnenomicWord) Error() string {
-	return fmt.Sprintf("word %v isn't a part of default word list", e.word)
+	return fmt.Sprintf("word %v isn't a part of default word list "+
+		"(index=%v)", e.Word, e.Index)
 }


### PR DESCRIPTION
In this commit, we publicly export the `word` field as it makes it
easier to programmatically interact with the package when attempting to
re-derive proper `cipherseed` instances.
