### PR TITLE
lnd: prevent panic on nil neutrino cleanup

### DIFF
--- a/chainregistry.go
+++ b/chainregistry.go
@@ -713,6 +713,7 @@ func initNeutrinoBackend(chainDir string) (*neutrino.ChainService, func(), error
 		cfg.NeutrinoMode.AssertFilterHeader,
 	)
 	if err != nil {
+		db.Close()
 		return nil, nil, err
 	}
 
@@ -754,6 +755,7 @@ func initNeutrinoBackend(chainDir string) (*neutrino.ChainService, func(), error
 
 	neutrinoCS, err := neutrino.NewChainService(config)
 	if err != nil {
+		db.Close()
 		return nil, nil, fmt.Errorf("unable to create neutrino light "+
 			"client: %v", err)
 	}

--- a/lnd.go
+++ b/lnd.go
@@ -203,10 +203,10 @@ func Main() error {
 		neutrinoBackend, neutrinoCleanUp, err := initNeutrinoBackend(
 			mainChain.ChainDir,
 		)
-		defer neutrinoCleanUp()
 		if err != nil {
 			return err
 		}
+		defer neutrinoCleanUp()
 		neutrinoCS = neutrinoBackend
 	}
 


### PR DESCRIPTION
A cleanup closure is not included when an error is returned, causing the defer to execute and triggering the following panic:

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x105da38]

goroutine 1 [running]:
github.com/lightningnetwork/lnd.Main(0x2083e40, 0xc0004f6db0)
	/home/user/lnd/lnd.go:208 +0x2bfa
main.main()
	/home/user/lnd/cmd/lnd/main.go:14 +0x26
```

Fixes https://github.com/lightningnetwork/lnd/issues/3308.