### PR TITLE
[build, tooling] change linter gometalinter->golangci-lint

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,18 @@
+run:
+  # timeout for analysis
+  deadline: 4m
+
+linters-settings:
+  govet:
+    # Don't report about shadowed variables
+    check-shadowing: false
+  gofmt:
+    # simplify code: gofmt with `-s` option, true by default
+    simplify: true
+
+linters:
+  disable-all: true
+  enable:
+    - gofmt
+    - golint
+    - govet

--- a/Makefile
+++ b/Makefile
@@ -3,13 +3,13 @@ ESCPKG := github.com\/lightningnetwork\/lnd
 
 BTCD_PKG := github.com/btcsuite/btcd
 GOVERALLS_PKG := github.com/mattn/goveralls
-LINT_PKG := gopkg.in/alecthomas/gometalinter.v2
+LINT_PKG := github.com/golangci/golangci-lint/cmd/golangci-lint
 GOACC_PKG := github.com/ory/go-acc
 
 GO_BIN := ${GOPATH}/bin
 BTCD_BIN := $(GO_BIN)/btcd
 GOVERALLS_BIN := $(GO_BIN)/goveralls
-LINT_BIN := $(GO_BIN)/gometalinter.v2
+LINT_BIN := $(GO_BIN)/golangci-lint
 GOACC_BIN := $(GO_BIN)/go-acc
 
 BTCD_DIR :=${GOPATH}/src/$(BTCD_PKG)
@@ -32,7 +32,6 @@ GOTEST := GO111MODULE=on go test -v
 GOFILES_NOVENDOR = $(shell find . -type f -name '*.go' -not -path "./vendor/*")
 GOLIST := go list $(PKG)/... | grep -v '/vendor/'
 GOLISTCOVER := $(shell go list -f '{{.ImportPath}}' ./... | sed -e 's/^$(ESCPKG)/./')
-GOLISTLINT := $(shell go list -f '{{.Dir}}' ./... | grep -v 'lnrpc')
 
 RM := rm -f
 CP := cp
@@ -43,15 +42,7 @@ include make/testing_flags.mk
 
 DEV_TAGS := $(if ${tags},$(DEV_TAGS) ${tags},$(DEV_TAGS))
 
-LINT = $(LINT_BIN) \
-	--disable-all \
-	--enable=gofmt \
-	--enable=vet \
-	--enable=golint \
-	--line-length=72 \
-	--deadline=4m $(GOLISTLINT) 2>&1 | \
-	grep -v 'ALL_CAPS\|OP_' 2>&1 | \
-	tee /dev/stderr
+LINT = $(LINT_BIN) run
 
 GREEN := "\\033[0;32m"
 NC := "\\033[0m"
@@ -72,7 +63,7 @@ $(GOVERALLS_BIN):
 	go get -u $(GOVERALLS_PKG)
 
 $(LINT_BIN):
-	@$(call print, "Fetching gometalinter.v2")
+	@$(call print, "Fetching linter")
 	GO111MODULE=off go get -u $(LINT_PKG)
 
 $(GOACC_BIN):
@@ -166,8 +157,7 @@ fmt:
 
 lint: $(LINT_BIN)
 	@$(call print, "Linting source.")
-	GO111MODULE=off $(LINT_BIN) --install 1> /dev/null
-	test -z "$$($(LINT))"
+	$(LINT)
 
 list:
 	@$(call print, "Listing commands.")

--- a/channeldb/channel.go
+++ b/channeldb/channel.go
@@ -1790,7 +1790,8 @@ func (c *OpenChannel) RemoveFwdPkg(height uint64) error {
 
 // RevocationLogTail returns the "tail", or the end of the current revocation
 // log. This entry represents the last previous state for the remote node's
-// commitment chain. The ChannelDelta returned by this method will always lag one state behind the most current (unrevoked) state of the remote node's
+// commitment chain. The ChannelDelta returned by this method will always lag
+// one state behind the most current (unrevoked) state of the remote node's
 // commitment chain.
 func (c *OpenChannel) RevocationLogTail() (*ChannelCommitment, error) {
 	c.RLock()

--- a/htlcswitch/switch.go
+++ b/htlcswitch/switch.go
@@ -1194,11 +1194,7 @@ func (s *Switch) handlePacketForward(packet *htlcPacket) error {
 				fail.Reason = circuit.ErrorEncrypter.EncryptMalformedError(
 					fail.Reason,
 				)
-				if err != nil {
-					err = fmt.Errorf("unable to obfuscate "+
-						"error: %v", err)
-					log.Error(err)
-				}
+
 			default:
 				// Otherwise, it's a forwarded error, so we'll perform a
 				// wrapper encryption as normal.

--- a/macaroons/constraints_test.go
+++ b/macaroons/constraints_test.go
@@ -11,14 +11,14 @@ import (
 
 var (
 	testRootKey                 = []byte("dummyRootKey")
-	testId                      = []byte("dummyId")
+	testID                      = []byte("dummyId")
 	testLocation                = "lnd"
 	testVersion                 = macaroon.LatestVersion
 	expectedTimeCaveatSubstring = "time-before " + string(time.Now().Year())
 )
 
 func createDummyMacaroon(t *testing.T) *macaroon.Macaroon {
-	dummyMacaroon, err := macaroon.New(testRootKey, testId,
+	dummyMacaroon, err := macaroon.New(testRootKey, testID,
 		testLocation, testVersion)
 	if err != nil {
 		t.Fatalf("Error creating initial macaroon: %v", err)

--- a/watchtower/wtdb/client_db.go
+++ b/watchtower/wtdb/client_db.go
@@ -665,7 +665,7 @@ func (c *ClientDB) RegisterChannel(chanID lnwire.ChannelID,
 		case err == ErrChannelNotRegistered:
 
 		// Unexpected error.
-		case err != nil:
+		default:
 			return err
 		}
 

--- a/watchtower/wtdb/codec.go
+++ b/watchtower/wtdb/codec.go
@@ -22,7 +22,7 @@ func ReadElement(r io.Reader, element interface{}) error {
 		return nil
 
 	// Fail if error is not UnknownElementType.
-	case err != nil:
+	default:
 		if _, ok := err.(UnknownElementType); !ok {
 			return err
 		}
@@ -80,7 +80,7 @@ func WriteElement(w io.Writer, element interface{}) error {
 		return nil
 
 	// Fail if error is not UnknownElementType.
-	case err != nil:
+	default:
 		if _, ok := err.(UnknownElementType); !ok {
 			return err
 		}


### PR DESCRIPTION
`gometalinter` has been deprecated: https://github.com/alecthomas/gometalinter/issues/590

Line length check is NOT enabled, since it will fail many places throughout the codebase. It looks like it was never working properly with the old linter.