### PR TITLE
keychain: fix comment about derivation path

### DIFF
--- a/keychain/derivation.go
+++ b/keychain/derivation.go
@@ -45,7 +45,7 @@ var (
 // The key derivation in this file follows the following hierarchy based on
 // BIP43:
 //
-//   * m/1017'/coinType'/keyFamily/0/index
+//   * m/1017'/coinType'/keyFamily'/0/index
 type KeyFamily uint32
 
 const (
@@ -110,9 +110,9 @@ const (
 // Version 0 of our key derivation schema uses the following BIP43-like
 // derivation:
 //
-//   * m/201'/coinType'/keyFamily/0/index
+//   * m/1017'/coinType'/keyFamily'/0/index
 //
-// Our purpose is 201 (chosen arbitrary for now), and the coin type will vary
+// Our purpose is 1017 (chosen arbitrary for now), and the coin type will vary
 // based on which coin/chain the channels are being created on. The key family
 // are actually just individual "accounts" in the nomenclature of BIP43. By
 // default we assume a branch of 0 (external). Finally, the key index (which


### PR DESCRIPTION
According to [this](https://github.com/lightningnetwork/lnd/blob/master/keychain/derivation.go#L24) and [this](https://github.com/btcsuite/btcwallet/blob/master/waddrmgr/manager.go#L1348) the derivation path for "special" keys is not `201'` and the `keyFamily` is always hardened.
Fixed this because it confused me when trying to find out how keys are really derived.