### PR TITLE
config: default autopilot min confs to 1

### DIFF
--- a/config.go
+++ b/config.go
@@ -391,6 +391,7 @@ func loadConfig() (*config, error) {
 			Allocation:     0.6,
 			MinChannelSize: int64(minChanFundingSize),
 			MaxChannelSize: int64(MaxFundingAmount),
+			MinConfs:       1,
 			ConfTarget:     autopilot.DefaultConfTarget,
 			Heuristic: map[string]float64{
 				"preferential": 1.0,


### PR DESCRIPTION
This prevents spending unconfirmed funds by default. Users will have to explicitly set this to 0 in order to do so.