### PR TITLE
ticker+queue: run go mod tidy

### DIFF
--- a/queue/go.sum
+++ b/queue/go.sum
@@ -1,2 +1,0 @@
-github.com/lightningnetwork/lnd/ticker v1.0.0 h1:S1b60TEGoTtCe2A0yeB+ecoj/kkS4qpwh6l+AkQEZwU=
-github.com/lightningnetwork/lnd/ticker v1.0.0/go.mod h1:iaLXJiVgI1sPANIF2qYYUJXjoksPNvGNYowB8aRbpX0=

--- a/ticker/go.mod
+++ b/ticker/go.mod
@@ -1,1 +1,3 @@
 module github.com/lightningnetwork/lnd/ticker
+
+go 1.12


### PR DESCRIPTION
Apparently my IDE runs `go mod tidy` on all subfolders that have a `go.mod` in them.
This is quite annoying since it always changes my git working tree to dirty.
So the easiest fix would be to commit the changes, which I hereby suggest.
I know, I should probably use a "real" IDE that doesn't do stuff like this but I really like IntelliJ...