### PR TITLE
Export function allowing ChainControl access from LND package

### DIFF
--- a/breacharbiter.go
+++ b/breacharbiter.go
@@ -99,7 +99,7 @@ type BreachConfig struct {
 
 	// Signer is used by the breach arbiter to generate sweep transactions,
 	// which move coins from previously open channels back to the user's
-	// wallet.
+	// Wallet.
 	Signer input.Signer
 
 	// Store is a persistent resource that maintains information regarding
@@ -249,7 +249,7 @@ func (b *breachArbiter) IsBreached(chanPoint *wire.OutPoint) (bool, error) {
 // contractcourt on the ContractBreaches channel. If a channel breach is
 // detected, then the contractObserver will execute the retribution logic
 // required to sweep ALL outputs from a contested channel into the daemon's
-// wallet.
+// Wallet.
 //
 // NOTE: This MUST be run as a goroutine.
 func (b *breachArbiter) contractObserver() {
@@ -493,7 +493,7 @@ func (b *breachArbiter) waitForSpendEvent(breachInfo *retributionInfo,
 // exactRetribution is a goroutine which is executed once a contract breach has
 // been detected by a breachObserver. This function is responsible for
 // punishing a counterparty for violating the channel contract by sweeping ALL
-// the lingering funds within the channel into the daemon's wallet.
+// the lingering funds within the channel into the daemon's Wallet.
 //
 // NOTE: This MUST be run as a goroutine.
 func (b *breachArbiter) exactRetribution(confChan *chainntnfs.ConfirmationEvent,
@@ -760,7 +760,7 @@ func (b *breachArbiter) handleBreachHandoff(breachEvent *ContractBreachEvent) {
 		return
 	}
 
-	// Using the breach information provided by the wallet and the
+	// Using the breach information provided by the Wallet and the
 	// channel snapshot, construct the retribution information that
 	// will be persisted to disk.
 	retInfo := newRetributionInfo(&chanPoint, breachInfo)
@@ -914,7 +914,7 @@ var _ input.Input = (*breachedOutput)(nil)
 // funds within a channel whose contract has been breached by the prior
 // counterparty. This struct is used to create the justice transaction which
 // spends all outputs of the commitment transaction into an output controlled
-// by the wallet.
+// by the Wallet.
 type retributionInfo struct {
 	commitHash   chainhash.Hash
 	chanPoint    wire.OutPoint
@@ -927,7 +927,7 @@ type retributionInfo struct {
 // newRetributionInfo constructs a retributionInfo containing all the
 // information required by the breach arbiter to recover funds from breached
 // channels.  The information is primarily populated using the BreachRetribution
-// delivered by the wallet when it detects a channel breach.
+// delivered by the Wallet when it detects a channel breach.
 func newRetributionInfo(chanPoint *wire.OutPoint,
 	breachInfo *lnwallet.BreachRetribution) *retributionInfo {
 
@@ -937,7 +937,7 @@ func newRetributionInfo(chanPoint *wire.OutPoint,
 	// Initialize a slice to hold the outputs we will attempt to sweep. The
 	// maximum capacity of the slice is set to 2+nHtlcs to handle the case
 	// where the local, remote, and all HTLCs are not dust outputs.  All
-	// HTLC outputs provided by the wallet are guaranteed to be non-dust,
+	// HTLC outputs provided by the Wallet are guaranteed to be non-dust,
 	// though the commitment outputs are conditionally added depending on
 	// the nil-ness of their sign descriptors.
 	breachedOutputs := make([]breachedOutput, 0, nHtlcs+2)
@@ -979,7 +979,7 @@ func newRetributionInfo(chanPoint *wire.OutPoint,
 
 	// Lastly, for each of the breached HTLC outputs, record each as a
 	// breached output with the appropriate witness type based on its
-	// directionality. All HTLC outputs provided by the wallet are assumed
+	// directionality. All HTLC outputs provided by the Wallet are assumed
 	// to be non-dust.
 	for i, breachedHtlc := range breachInfo.HtlcRetributions {
 		// Using the breachedHtlc's incoming flag, determine the
@@ -1084,7 +1084,7 @@ func (b *breachArbiter) createJusticeTx(
 func (b *breachArbiter) sweepSpendableOutputsTxn(txWeight int64,
 	inputs ...input.Input) (*wire.MsgTx, error) {
 
-	// First, we obtain a new public key script from the wallet which we'll
+	// First, we obtain a new public key script from the Wallet which we'll
 	// sweep the funds to.
 	// TODO(roasbeef): possibly create many outputs to minimize change in
 	// the future?
@@ -1100,7 +1100,7 @@ func (b *breachArbiter) sweepSpendableOutputsTxn(txWeight int64,
 	}
 
 	// We'll actually attempt to target inclusion within the next two
-	// blocks as we'd like to sweep these funds back into our wallet ASAP.
+	// blocks as we'd like to sweep these funds back into our Wallet ASAP.
 	feePerKw, err := b.cfg.Estimator.EstimateFeePerKW(2)
 	if err != nil {
 		return nil, err

--- a/config.go
+++ b/config.go
@@ -1104,7 +1104,7 @@ func loadConfig() (*config, error) {
 
 	// Finally, ensure that the user's color is correctly formatted,
 	// otherwise the server will not be able to start after the unlocking
-	// the wallet.
+	// the Wallet.
 	_, err = parseHexColor(cfg.Color)
 	if err != nil {
 		return nil, fmt.Errorf("Unable to parse node color: %v", err)

--- a/fundingmanager.go
+++ b/fundingmanager.go
@@ -350,14 +350,14 @@ type fundingConfig struct {
 	NotifyOpenChannelEvent func(wire.OutPoint)
 }
 
-// fundingManager acts as an orchestrator/bridge between the wallet's
+// fundingManager acts as an orchestrator/bridge between the Wallet's
 // 'ChannelReservation' workflow, and the wire protocol's funding initiation
 // messages. Any requests to initiate the funding workflow for a channel,
 // either kicked-off locally or remotely are handled by the funding manager.
 // Once a channel's funding workflow has been completed, any local callers, the
 // local peer, and possibly the remote peer are notified of the completion of
 // the channel workflow. Additionally, any temporary or permanent access
-// controls between the wallet and remote peers are enforced via the funding
+// controls between the Wallet and remote peers are enforced via the funding
 // manager.
 type fundingManager struct {
 	started sync.Once
@@ -897,7 +897,7 @@ func (f *fundingManager) failFundingFlow(peer lnpeer.Peer, tempChanID [32]byte,
 }
 
 // reservationCoordinator is the primary goroutine tasked with progressing the
-// funding workflow between the wallet, and any outside peers or local callers.
+// funding workflow between the Wallet, and any outside peers or local callers.
 //
 // NOTE: This MUST be run as a goroutine.
 func (f *fundingManager) reservationCoordinator() {
@@ -981,7 +981,7 @@ func (f *fundingManager) processFundingOpen(msg *lnwire.OpenChannel,
 	}
 }
 
-// handleFundingOpen creates an initial 'ChannelReservation' within the wallet,
+// handleFundingOpen creates an initial 'ChannelReservation' within the Wallet,
 // then responds to the source peer with an accept channel message progressing
 // the funding workflow.
 //
@@ -1034,7 +1034,7 @@ func (f *fundingManager) handleFundingOpen(fmsg *fundingOpenMsg) {
 	isSynced, _, err := f.cfg.Wallet.IsSynced()
 	if err != nil || !isSynced {
 		if err != nil {
-			fndgLog.Errorf("unable to query wallet: %v", err)
+			fndgLog.Errorf("unable to query Wallet: %v", err)
 		}
 		f.failFundingFlow(
 			fmsg.peer, fmsg.msg.PendingChannelID,
@@ -1077,7 +1077,7 @@ func (f *fundingManager) handleFundingOpen(fmsg *fundingOpenMsg) {
 		msg.CsvDelay, msg.PendingChannelID,
 		fmsg.peer.IdentityKey().SerializeCompressed())
 
-	// Attempt to initialize a reservation within the wallet. If the wallet
+	// Attempt to initialize a reservation within the Wallet. If the Wallet
 	// has insufficient resources to create the channel, then the
 	// reservation attempt may be rejected. Note that since we're on the
 	// responding side of a single funder workflow, we don't commit any
@@ -1928,7 +1928,7 @@ func (f *fundingManager) waitForFundingConfirmation(
 	var ok bool
 
 	// Wait until the specified number of confirmations has been reached,
-	// we get a cancel signal, or the wallet signals a shutdown.
+	// we get a cancel signal, or the Wallet signals a shutdown.
 	select {
 	case confDetails, ok = <-confNtfn.Confirmed:
 		// fallthrough
@@ -2317,7 +2317,7 @@ func (f *fundingManager) annAfterSixConfs(completeChan *channeldb.OpenChannel,
 				completeChan.FundingOutpoint, err)
 		}
 
-		// Wait until 6 confirmations has been reached or the wallet
+		// Wait until 6 confirmations has been reached or the Wallet
 		// signals a shutdown.
 		select {
 		case _, ok := <-confNtfn.Confirmed:
@@ -2755,7 +2755,7 @@ func (f *fundingManager) initFundingWorkflow(peer lnpeer.Peer, req *openChanReq)
 }
 
 // handleInitFundingMsg creates a channel reservation within the daemon's
-// wallet, then sends a funding request to the remote peer kicking off the
+// Wallet, then sends a funding request to the remote peer kicking off the
 // funding workflow.
 func (f *fundingManager) handleInitFundingMsg(msg *initFundingMsg) {
 	var (
@@ -2798,8 +2798,8 @@ func (f *fundingManager) handleInitFundingMsg(msg *initFundingMsg) {
 		channelFlags = lnwire.FFAnnounceChannel
 	}
 
-	// Initialize a funding reservation with the local wallet. If the
-	// wallet doesn't have enough funds to commit to this channel, then the
+	// Initialize a funding reservation with the local Wallet. If the
+	// Wallet doesn't have enough funds to commit to this channel, then the
 	// request will fail, and be aborted.
 	req := &lnwallet.InitFundingReserveMsg{
 		ChainHash:        &msg.chainHash,
@@ -2822,7 +2822,7 @@ func (f *fundingManager) handleInitFundingMsg(msg *initFundingMsg) {
 	}
 
 	// Now that we have successfully reserved funds for this channel in the
-	// wallet, we can fetch the final channel capacity. This is done at
+	// Wallet, we can fetch the final channel capacity. This is done at
 	// this point since the final capacity might change in case of
 	// SubtractFees=true.
 	capacity := reservation.Capacity()

--- a/fundingmanager_test.go
+++ b/fundingmanager_test.go
@@ -278,7 +278,7 @@ func createTestFundingManager(t *testing.T, privKey *btcec.PrivateKey,
 		estimator,
 	)
 	if err != nil {
-		t.Fatalf("unable to create test ln wallet: %v", err)
+		t.Fatalf("unable to create test ln Wallet: %v", err)
 	}
 
 	var chanIDSeed [32]byte
@@ -2814,12 +2814,12 @@ func TestFundingManagerMaxConfs(t *testing.T) {
 }
 
 // TestFundingManagerFundAll tests that we can initiate a funding request to
-// use the funds remaining in the wallet. This should produce a funding tx with
+// use the funds remaining in the Wallet. This should produce a funding tx with
 // no change output.
 func TestFundingManagerFundAll(t *testing.T) {
 	t.Parallel()
 
-	// We set up our mock wallet to control a list of UTXOs that sum to
+	// We set up our mock Wallet to control a list of UTXOs that sum to
 	// less than the max channel size.
 	allCoins := []*lnwallet.Utxo{
 		{
@@ -2851,7 +2851,7 @@ func TestFundingManagerFundAll(t *testing.T) {
 		change   bool
 	}{
 		{
-			// We will spend all the funds in the wallet, and
+			// We will spend all the funds in the Wallet, and
 			// expects no change output.
 			spendAmt: btcutil.Amount(
 				0.11 * btcutil.SatoshiPerBitcoin,
@@ -2859,7 +2859,7 @@ func TestFundingManagerFundAll(t *testing.T) {
 			change: false,
 		},
 		{
-			// We spend a little less than the funds in the wallet,
+			// We spend a little less than the funds in the Wallet,
 			// so a change output should be created.
 			spendAmt: btcutil.Amount(
 				0.10 * btcutil.SatoshiPerBitcoin,
@@ -2896,7 +2896,7 @@ func TestFundingManagerFundAll(t *testing.T) {
 				len(fundingTx.TxOut))
 		}
 
-		// Inputs should be all funds in the wallet.
+		// Inputs should be all funds in the Wallet.
 		if len(fundingTx.TxIn) != len(allCoins) {
 			t.Fatalf("Had %d inputs, expected %d",
 				len(fundingTx.TxIn), len(allCoins))

--- a/lnd.go
+++ b/lnd.go
@@ -93,6 +93,9 @@ var (
 	}
 )
 
+// InitDaemon initializes all services. Called from Main.
+// Can also be used by other packages to gain Chain access
+// while running LND
 func InitDaemon() (*chainControl, error) {
 	// Load the configuration, and parse any command line options. This
 	// function will also set up logging properly.

--- a/mock.go
+++ b/mock.go
@@ -59,7 +59,7 @@ func (m *mockSigner) SignOutputRaw(tx *wire.MsgTx,
 func (m *mockSigner) ComputeInputScript(tx *wire.MsgTx,
 	signDesc *input.SignDescriptor) (*input.Script, error) {
 
-	// TODO(roasbeef): expose tweaked signer from lnwallet so don't need to
+	// TODO(roasbeef): expose tweaked Signer from lnwallet so don't need to
 	// duplicate this code?
 
 	privKey := m.key
@@ -234,7 +234,7 @@ type mockWalletController struct {
 	utxos                 []*lnwallet.Utxo
 }
 
-// BackEnd returns "mock" to signify a mock wallet controller.
+// BackEnd returns "mock" to signify a mock Wallet controller.
 func (*mockWalletController) BackEnd() string {
 	return "mock"
 }
@@ -281,7 +281,7 @@ func (*mockWalletController) CreateSimpleTx(outputs []*wire.TxOut,
 	return nil, nil
 }
 
-// ListUnspentWitness is called by the wallet when doing coin selection. We just
+// ListUnspentWitness is called by the Wallet when doing coin selection. We just
 // need one unspent for the funding transaction.
 func (m *mockWalletController) ListUnspentWitness(minconfirms,
 	maxconfirms int32) ([]*lnwallet.Utxo, error) {

--- a/nursery_store.go
+++ b/nursery_store.go
@@ -82,7 +82,7 @@ import (
 type NurseryStore interface {
 	// Incubate registers a set of CSV delayed outputs (incoming HTLC's on
 	// our commitment transaction, or a commitment output), and a slice of
-	// outgoing htlc outputs to be swept back into the user's wallet. The
+	// outgoing htlc outputs to be swept back into the user's Wallet. The
 	// event is persisted to disk, such that the nursery can resume the
 	// incubation process after a potential crash.
 	Incubate([]kidOutput, []babyOutput) error
@@ -178,7 +178,7 @@ var (
 	// either from the commitment transaction, or a stage-one htlc
 	// transaction, whose maturity height has solidified. Outputs marked in
 	// this state are in their final stage of incubation within the nursery,
-	// and will be swept into the wallet after waiting out the relative
+	// and will be swept into the Wallet after waiting out the relative
 	// timelock.
 	kndrPrefix = []byte("kndr")
 
@@ -842,7 +842,7 @@ func (ns *nurseryStore) RemoveChannel(chanPoint *wire.OutPoint) error {
 // Helper Methods
 
 // enterCrib accepts a new htlc output that the nursery will incubate through
-// its two-stage process of sweeping funds back to the user's wallet. These
+// its two-stage process of sweeping funds back to the user's Wallet. These
 // outputs are persisted in the nursery store in the crib state, and will be
 // revisited after the first-stage output's CLTV has expired.
 func (ns *nurseryStore) enterCrib(tx *bbolt.Tx, baby *babyOutput) error {

--- a/pilot.go
+++ b/pilot.go
@@ -85,7 +85,7 @@ func (c *chanController) OpenChannel(target *btcec.PublicKey,
 
 	// With the connection established, we'll now establish our connection
 	// to the target peer, waiting for the first update before we exit.
-	feePerKw, err := c.server.cc.feeEstimator.EstimateFeePerKW(
+	feePerKw, err := c.server.cc.FeeEstimator.EstimateFeePerKW(
 		c.confTarget,
 	)
 	if err != nil {
@@ -177,7 +177,7 @@ func initAutoPilot(svr *server, cfg *autoPilotConfig) (*autopilot.ManagerCfg, er
 			confTarget: cfg.ConfTarget,
 		},
 		WalletBalance: func() (btcutil.Amount, error) {
-			return svr.cc.wallet.ConfirmedBalance(cfg.MinConfs)
+			return svr.cc.Wallet.ConfirmedBalance(cfg.MinConfs)
 		},
 		Graph:       autopilot.ChannelGraphFromDatabase(svr.chanDB.ChannelGraph()),
 		Constraints: atplConstraints,
@@ -267,7 +267,7 @@ func initAutoPilot(svr *server, cfg *autoPilotConfig) (*autopilot.ManagerCfg, er
 
 			return chanState, nil
 		},
-		SubscribeTransactions: svr.cc.wallet.SubscribeTransactions,
+		SubscribeTransactions: svr.cc.Wallet.SubscribeTransactions,
 		SubscribeTopology:     svr.chanRouter.SubscribeTopology,
 	}, nil
 }

--- a/subrpcserver_config.go
+++ b/subrpcserver_config.go
@@ -35,9 +35,9 @@ type subRPCServerConfigs struct {
 	SignRPC *signrpc.Config `group:"signrpc" namespace:"signrpc"`
 
 	// WalletKitRPC is a sub-RPC server that exposes functionality allowing
-	// a client to send transactions through a wallet, publish them, and
+	// a client to send transactions through a Wallet, publish them, and
 	// also requests keys and addresses under control of the backing
-	// wallet.
+	// Wallet.
 	WalletKitRPC *walletrpc.Config `group:"walletrpc" namespace:"walletrpc"`
 
 	// AutopilotRPC is a sub-RPC server that exposes methods on the running
@@ -117,7 +117,7 @@ func (s *subRPCServerConfigs) PopulateDependencies(cc *chainControl,
 				reflect.ValueOf(networkDir),
 			)
 			subCfgValue.FieldByName("Signer").Set(
-				reflect.ValueOf(cc.signer),
+				reflect.ValueOf(cc.Signer),
 			)
 
 		case *walletrpc.Config:
@@ -130,13 +130,13 @@ func (s *subRPCServerConfigs) PopulateDependencies(cc *chainControl,
 				reflect.ValueOf(macService),
 			)
 			subCfgValue.FieldByName("FeeEstimator").Set(
-				reflect.ValueOf(cc.feeEstimator),
+				reflect.ValueOf(cc.FeeEstimator),
 			)
 			subCfgValue.FieldByName("Wallet").Set(
-				reflect.ValueOf(cc.wallet),
+				reflect.ValueOf(cc.Wallet),
 			)
 			subCfgValue.FieldByName("KeyRing").Set(
-				reflect.ValueOf(cc.keyRing),
+				reflect.ValueOf(cc.KeyRing),
 			)
 			subCfgValue.FieldByName("Sweeper").Set(
 				reflect.ValueOf(sweeper),
@@ -159,7 +159,7 @@ func (s *subRPCServerConfigs) PopulateDependencies(cc *chainControl,
 				reflect.ValueOf(macService),
 			)
 			subCfgValue.FieldByName("ChainNotifier").Set(
-				reflect.ValueOf(cc.chainNotifier),
+				reflect.ValueOf(cc.ChainNotifier),
 			)
 
 		case *invoicesrpc.Config:

--- a/test_utils.go
+++ b/test_utils.go
@@ -329,10 +329,10 @@ func createTestPeer(notifier chainntnfs.ChainNotifier,
 		},
 	}
 	cc := &chainControl{
-		feeEstimator:  estimator,
-		chainIO:       chainIO,
-		chainNotifier: notifier,
-		wallet:        wallet,
+		FeeEstimator:  estimator,
+		ChainIO:       chainIO,
+		ChainNotifier: notifier,
+		Wallet:        wallet,
 	}
 
 	breachArbiter := &breachArbiter{}
@@ -352,7 +352,7 @@ func createTestPeer(notifier chainntnfs.ChainNotifier,
 		chainArb:      chainArb,
 	}
 
-	_, currentHeight, err := s.cc.chainIO.GetBestBlock()
+	_, currentHeight, err := s.cc.ChainIO.GetBestBlock()
 	if err != nil {
 		return nil, nil, nil, nil, err
 	}

--- a/utxonursery.go
+++ b/utxonursery.go
@@ -52,7 +52,7 @@ import (
 //  - CRIB (babyOutput) outputs are two-stage htlc outputs that are initially
 //    locked using a CLTV delay, followed by a CSV delay. The first stage of a
 //    crib output requires broadcasting a presigned htlc timeout txn generated
-//    by the wallet after an absolute expiry height. Since the timeout txns are
+//    by the Wallet after an absolute expiry height. Since the timeout txns are
 //    predetermined, they cannot be batched after-the-fact, meaning that all
 //    CRIB outputs are broadcast and confirmed independently. After the first
 //    stage is complete, a CRIB output is moved to the KNDR state, which will
@@ -72,7 +72,7 @@ import (
 //    using a single txn.
 //
 //  - GRAD (kidOutput) outputs are KNDR outputs that have successfully been
-//    swept into the user's wallet. A channel is considered mature once all of
+//    swept into the user's Wallet. A channel is considered mature once all of
 //    its outputs, including two-stage htlcs, have entered the GRAD state,
 //    indicating that it safe to mark the channel as fully closed.
 //
@@ -200,17 +200,17 @@ type NurseryConfig struct {
 	// maintained about the utxo nursery's incubating outputs.
 	Store NurseryStore
 
-	// Sweep sweeps an input back to the wallet.
+	// Sweep sweeps an input back to the Wallet.
 	SweepInput func(input.Input, sweep.FeePreference) (chan sweep.Result, error)
 }
 
 // utxoNursery is a system dedicated to incubating time-locked outputs created
 // by the broadcast of a commitment transaction either by us, or the remote
 // peer. The nursery accepts outputs and "incubates" them until they've reached
-// maturity, then sweep the outputs into the source wallet. An output is
+// maturity, then sweep the outputs into the source Wallet. An output is
 // considered mature after the relative time-lock within the pkScript has
 // passed. As outputs reach their maturity age, they're swept in batches into
-// the source wallet, returning the outputs so they can be used within future
+// the source Wallet, returning the outputs so they can be used within future
 // channels, or regular Bitcoin transactions.
 type utxoNursery struct {
 	started uint32 // To be used atomically.
@@ -328,7 +328,7 @@ func (u *utxoNursery) Stop() error {
 // IncubateOutputs sends a request to the utxoNursery to incubate a set of
 // outputs from an existing commitment transaction. Outputs need to incubate if
 // they're CLTV absolute time locked, or if they're CSV relative time locked.
-// Once all outputs reach maturity, they'll be swept back into the wallet.
+// Once all outputs reach maturity, they'll be swept back into the Wallet.
 func (u *utxoNursery) IncubateOutputs(chanPoint wire.OutPoint,
 	commitResolution *lnwallet.CommitOutputResolution,
 	outgoingHtlcs []lnwallet.OutgoingHtlcResolution,
@@ -586,7 +586,7 @@ func (u *utxoNursery) NurseryReport(
 
 			case bytes.HasPrefix(k, gradPrefix):
 				// Graduate outputs are those whose funds have
-				// been swept back into the wallet. Each output
+				// been swept back into the Wallet. Each output
 				// will contribute towards the recovered
 				// balance.
 				switch kid.WitnessType() {
@@ -801,8 +801,8 @@ func (u *utxoNursery) graduateClass(classHeight uint32) error {
 
 // sweepMatureOutputs generates and broadcasts the transaction that transfers
 // control of funds from a prior channel commitment transaction to the user's
-// wallet. The outputs swept were previously time locked (either absolute or
-// relative), but are not mature enough to sweep into the wallet.
+// Wallet. The outputs swept were previously time locked (either absolute or
+// relative), but are not mature enough to sweep into the Wallet.
 func (u *utxoNursery) sweepMatureOutputs(classHeight uint32,
 	kgtnOutputs []kidOutput) error {
 
@@ -1069,7 +1069,7 @@ type contractMaturityReport struct {
 	limboBalance btcutil.Amount
 
 	// recoveredBalance is the total value that has been successfully swept
-	// back to the user's wallet.
+	// back to the user's Wallet.
 	recoveredBalance btcutil.Amount
 
 	// maturityHeight is the absolute block height that this output will
@@ -1083,10 +1083,10 @@ type contractMaturityReport struct {
 // htlcMaturityReport provides a summary of a single htlc output, and is
 // embedded as party of the overarching contractMaturityReport
 type htlcMaturityReport struct {
-	// outpoint is the final output that will be swept back to the wallet.
+	// outpoint is the final output that will be swept back to the Wallet.
 	outpoint wire.OutPoint
 
-	// amount is the final value that will be swept in back to the wallet.
+	// amount is the final value that will be swept in back to the Wallet.
 	amount btcutil.Amount
 
 	// maturityHeight is the absolute block height that this output will
@@ -1311,7 +1311,7 @@ func (bo *babyOutput) Decode(r io.Reader) error {
 }
 
 // kidOutput represents an output that's waiting for a required blockheight
-// before its funds will be available to be moved into the user's wallet.  The
+// before its funds will be available to be moved into the user's Wallet.  The
 // struct includes a WitnessGenerator closure which will be used to generate
 // the witness required to sweep the output once it's mature.
 //

--- a/utxonursery_test.go
+++ b/utxonursery_test.go
@@ -793,7 +793,7 @@ func testNurseryOutgoingHtlcSuccessOnLocal(t *testing.T,
 	// Notify arrival of block where second level HTLC unlocks.
 	ctx.notifyEpoch(128)
 
-	// Check final sweep into wallet.
+	// Check final sweep into Wallet.
 	testSweepHtlc(t, ctx)
 
 	ctx.finish()
@@ -833,7 +833,7 @@ func testNurseryOutgoingHtlcSuccessOnRemote(t *testing.T,
 	// Notify arrival of block where HTLC CLTV expires.
 	ctx.notifyEpoch(125)
 
-	// Check final sweep into wallet.
+	// Check final sweep into Wallet.
 	testSweepHtlc(t, ctx)
 
 	ctx.finish()
@@ -883,7 +883,7 @@ func testNurseryCommitSuccessOnLocal(t *testing.T,
 	// Notify arrival of block where commit output CSV expires.
 	ctx.notifyEpoch(126)
 
-	// Check final sweep into wallet.
+	// Check final sweep into Wallet.
 	testSweep(t, ctx, func() {
 		// Check limbo balance after sweep publication
 		assertNurseryReport(t, ctx.nursery, 0, 0, 10000)


### PR DESCRIPTION
This PR creates a new exported LND method to allow full initialization of LND while returning a ChainControl pointer. This is to allow other go applications (which may wish to integrate LND) access to the underlying chain. The alternative is to run LND with neutrino, then run a separate instance of neutrino for the go application.