### PR TITLE
lnrpc: remove lncli subscribechannelevents

### DIFF
--- a/lnrpc/rpc.pb.go
+++ b/lnrpc/rpc.pb.go
@@ -9482,7 +9482,7 @@ type LightningClient interface {
 	//ListChannels returns a description of all the open channels that this node
 	//is a participant in.
 	ListChannels(ctx context.Context, in *ListChannelsRequest, opts ...grpc.CallOption) (*ListChannelsResponse, error)
-	//* lncli: `subscribechannelevents`
+	//*
 	//SubscribeChannelEvents creates a uni-directional stream from the server to
 	//the client in which any updates relevant to the state of the channels are
 	//sent over. Events include new active channels, inactive channels, and closed
@@ -10433,7 +10433,7 @@ type LightningServer interface {
 	//ListChannels returns a description of all the open channels that this node
 	//is a participant in.
 	ListChannels(context.Context, *ListChannelsRequest) (*ListChannelsResponse, error)
-	//* lncli: `subscribechannelevents`
+	//*
 	//SubscribeChannelEvents creates a uni-directional stream from the server to
 	//the client in which any updates relevant to the state of the channels are
 	//sent over. Events include new active channels, inactive channels, and closed

--- a/lnrpc/rpc.proto
+++ b/lnrpc/rpc.proto
@@ -389,7 +389,7 @@ service Lightning {
         };
     }
 
-    /** lncli: `subscribechannelevents`
+    /**
     SubscribeChannelEvents creates a uni-directional stream from the server to
     the client in which any updates relevant to the state of the channels are
     sent over. Events include new active channels, inactive channels, and closed


### PR DESCRIPTION
There is no shell command for:
`$ lncli subscribechannelevents`
```
No help topic for 'subscribechannelevents'
```
This leads to an error when regenerating the docs with https://github.com/lightninglabs/lightning-api.
The current documentation does not contain the shell command for lncli subscribechannelevents either for the same reason: https://api.lightning.community/?shell#subscribechannelevents

Fixed when removed from rpc.proto.