### PR TITLE
rpcserver: startTime defaults to the unix epoch

### DIFF
--- a/cmd/lncli/commands.go
+++ b/cmd/lncli/commands.go
@@ -15,6 +15,7 @@ import (
 	"strings"
 	"sync"
 	"syscall"
+	"time"
 
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcd/wire"
@@ -3532,7 +3533,7 @@ var forwardingHistoryCommand = cli.Command{
 	payment circuits (HTLCs) over a particular time range (--start_time and
 	--end_time). The start and end times are meant to be expressed in
 	seconds since the Unix epoch. If --start_time isn't provided,
-	then the Unix epoch (01-01-1970) is used.  If --end_time isn't provided,
+	then 24 hours ago is used.  If --end_time isn't provided,
 	then the current time is used.
 
 	The max number of events returned is 50k. The default number is 100,
@@ -3586,6 +3587,9 @@ func forwardingHistory(ctx *cli.Context) error {
 			return fmt.Errorf("unable to decode start_time %v", err)
 		}
 		args = args.Tail()
+	default:
+		now := time.Now()
+		startTime = uint64(now.Add(-time.Hour * 24).Unix())
 	}
 
 	switch {

--- a/cmd/lncli/commands.go
+++ b/cmd/lncli/commands.go
@@ -3532,7 +3532,7 @@ var forwardingHistoryCommand = cli.Command{
 	payment circuits (HTLCs) over a particular time range (--start_time and
 	--end_time). The start and end times are meant to be expressed in
 	seconds since the Unix epoch. If --start_time isn't provided,
-	then 24 hours ago is used.  If --end_time isn't provided,
+	then the Unix epoch (01-01-1970) is used.  If --end_time isn't provided,
 	then the current time is used.
 
 	The max number of events returned is 50k. The default number is 100,

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -4637,13 +4637,8 @@ func (r *rpcServer) ForwardingHistory(ctx context.Context,
 		numEvents uint32
 	)
 
-	// If the start time wasn't specified, we'll default to 24 hours ago.
-	if req.StartTime == 0 {
-		now := time.Now()
-		startTime = now.Add(-time.Hour * 24)
-	} else {
-		startTime = time.Unix(int64(req.StartTime), 0)
-	}
+	// startTime defaults to the Unix epoch (0 unixtime, or midnight 01-01-1970).
+	startTime = time.Unix(int64(req.StartTime), 0)
 
 	// If the end time wasn't specified, assume a default end time of now.
 	if req.EndTime == 0 {


### PR DESCRIPTION
Closes https://github.com/lightningnetwork/lnd/issues/3357.  When
start_time isn't specified, its default value is 0.  This meant when
users explicitly specified a start_time of 0, we would incorrectly set
start_time to 24 hours in the past.  Now, n0 means n0.

#### Pull Request Checklist

- [X] If this is your first time contributing, we recommend you read the [Code
  Contribution Guidelines](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md)
- [X] All changes are Go version 1.12 compliant
- [X] The code being submitted is commented according to [Code Documentation and Commenting](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#CodeDocumentation)
- [X] For new code: Code is accompanied by tests which exercise both
  the positive and negative (error paths) conditions (if applicable)
- [X] For bug fixes: Code is accompanied by new tests which trigger
  the bug being fixed to prevent regressions
- [X] Any new logging statements use an appropriate subsystem and
  logging level
- [X] Code has been formatted with `go fmt`
- [X] For code and documentation: lines are wrapped at 80 characters
  (the tab character should be counted as 8 characters, not 4, as some IDEs do
  per default)
- [X] Running `make check` does not fail any tests
- [X] Running `go vet` does not report any issues
- [X] Running `make lint` does not report any **new** issues that did not
  already exist
- [X] All commits build properly and pass tests. Only in exceptional
  cases it can be justifiable to violate this condition. In that case, the
  reason should be stated in the commit message.
- [X] Commits have a logical structure according to [Ideal Git Commit Structure](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#IdealGitCommitStructure)
