### PR TITLE
htlcswitch/link: increase channel reestablish timeout to 3m

### DIFF
--- a/htlcswitch/link.go
+++ b/htlcswitch/link.go
@@ -48,6 +48,12 @@ const (
 	// DefaultMaxLinkFeeUpdateTimeout represents the maximum interval in
 	// which a link should propose to update its commitment fee rate.
 	DefaultMaxLinkFeeUpdateTimeout = 60 * time.Minute
+
+	// chanReetablishTimeout represents the maximum duration we will wait
+	// for the remote peer to send us a channel reestablish message. This
+	// value is chosen to be high enough to account for peers which may be
+	// slow to write messages, e.g. under heavy contention during a restart.
+	chanReetablishTimeout = 3 * time.Minute
 )
 
 // ForwardingPolicy describes the set of constraints that a given ChannelLink
@@ -611,7 +617,7 @@ func (l *channelLink) syncChanStates() error {
 	// Next, we'll wait to receive the ChanSync message with a timeout
 	// period. The first message sent MUST be the ChanSync message,
 	// otherwise, we'll terminate the connection.
-	chanSyncDeadline := time.After(time.Second * 30)
+	chanSyncDeadline := time.After(chanReetablishTimeout)
 	select {
 	case msg := <-l.upstream:
 		remoteChanSyncMsg, ok := msg.(*lnwire.ChannelReestablish)


### PR DESCRIPTION
This commit increases our channel reestablish timeout from 30s to 3m.
In debugging with rusty we were able to repro a scenario where sending
reestablish takes much longer than the current timeout. Under a typical
restart, contention can cause this timeout to be exceeded and result in
a sync error. Bumping this allows us to more gracefully tolerate these
cases before giving up on the channel.

tHiS sHoUlD bE hIgH eNoUgH