### PR TITLE
discovery: prevent broadcast of anns received during initial graph sync

### DIFF
--- a/discovery/gossiper.go
+++ b/discovery/gossiper.go
@@ -913,6 +913,12 @@ func (d *AuthenticatedGossiper) networkHandler() {
 			policyUpdate.errResp <- nil
 
 		case announcement := <-d.networkMsgs:
+			// We should only broadcast this message forward if it
+			// originated from us or it wasn't received as part of
+			// our initial historical sync.
+			shouldBroadcast := !announcement.isRemote ||
+				d.syncMgr.IsGraphSynced()
+
 			switch announcement.msg.(type) {
 			// Channel announcement signatures are amongst the only
 			// messages that we'll process serially.
@@ -981,12 +987,16 @@ func (d *AuthenticatedGossiper) networkHandler() {
 				// the emitted announcements to our announce
 				// batch to be broadcast once the trickle timer
 				// ticks gain.
-				if emittedAnnouncements != nil {
+				if emittedAnnouncements != nil && shouldBroadcast {
 					// TODO(roasbeef): exclude peer that
 					// sent.
 					announcements.AddMsgs(
 						emittedAnnouncements...,
 					)
+				} else if emittedAnnouncements != nil {
+					log.Trace("Skipping broadcast of " +
+						"announcements received " +
+						"during initial graph sync")
 				}
 
 			}()


### PR DESCRIPTION
There's no need to broadcast these as we assume that online nodes have already received them. For nodes that were offline, they should receive them as part of their initial graph sync.

Depends on #3355.