### PR TITLE
[trivial] log: correct NTFR -> ntfrLog mapping

### DIFF
--- a/log.go
+++ b/log.go
@@ -159,7 +159,7 @@ var subsystemLoggers = map[string]btclog.Logger{
 	"INVC": invcLog,
 	"NANN": nannLog,
 	"WTWR": wtwrLog,
-	"NTFR": ntfnLog,
+	"NTFR": ntfrLog,
 	"IRPC": irpcLog,
 	"CHNF": chnfLog,
 	"CHBU": chbuLog,


### PR DESCRIPTION
Most likely because of a typo, NTFR was mapping to ntfnLog instead of
ntfrLog.

Originally added in 59e2be5306a77fff24bf2e8be1ba335247ef5beb