### PR TITLE
REST: increase max msg size for REST proxy

### DIFF
--- a/lnd.go
+++ b/lnd.go
@@ -197,7 +197,15 @@ func Main() error {
 	serverCreds := credentials.NewTLS(tlsCfg)
 	serverOpts := []grpc.ServerOption{grpc.Creds(serverCreds)}
 
-	restDialOpts := []grpc.DialOption{grpc.WithTransportCredentials(*restCreds)}
+	// For our REST dial options, we'll still use TLS, but also increase
+	// the max message size that we'll decode to allow clients to hit
+	// endpoints which return more data such as the DescribeGraph call.
+	restDialOpts := []grpc.DialOption{
+		grpc.WithTransportCredentials(*restCreds),
+		grpc.WithDefaultCallOptions(
+			grpc.MaxCallRecvMsgSize(1 * 1024 * 1024 * 50),
+		),
+	}
 
 	// Before starting the wallet, we'll create and start our Neutrino
 	// light client instance, if enabled, in order to allow it to sync


### PR DESCRIPTION
Some time ago, we modified `lncli` to accept larger responses from the
server, up to 50MB. However, we failed to update the REST proxy, which
is in a sense, a client to the regular RPC server. As a result, users
can't currently hit the `/v1/graph` endpoint, as it'll fail with an
error.

In this PR, we update the proxy's dial options to allow it to receive
larger responses from the actual gRPC server. This is only a temporary
measure however, as we'll eventually want to expose some sort of
pagination for the end client.

