### PR TITLE
Makefile: ensure submodules are linted, covered, and tested

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,8 +30,8 @@ GOINSTALL := GO111MODULE=on go install -v
 GOTEST := GO111MODULE=on go test -v
 
 GOFILES_NOVENDOR = $(shell find . -type f -name '*.go' -not -path "./vendor/*")
-GOLIST := go list $(PKG)/... | grep -v '/vendor/'
-GOLISTCOVER := $(shell go list -f '{{.ImportPath}}' ./... | sed -e 's/^$(ESCPKG)/./')
+GOLIST := go list -deps $(PKG)/... | grep '$(PKG)'| grep -v '/vendor/'
+GOLISTCOVER := $(shell go list -deps -f '{{.ImportPath}}' ./... | grep '$(PKG)' | sed -e 's/^$(ESCPKG)/./')
 
 RM := rm -f
 CP := cp

--- a/make/testing_flags.mk
+++ b/make/testing_flags.mk
@@ -1,7 +1,7 @@
 DEV_TAGS = dev
 LOG_TAGS =
 TEST_FLAGS =
-COVER_PKG = $$(go list ./... | grep -v lnrpc)
+COVER_PKG = $$(go list -deps ./... | grep '$(PKG)' | grep -v lnrpc)
 
 # If specific package is being unit tested, construct the full name of the
 # subpackage.


### PR DESCRIPTION
Something about having submodules causes `go list` not to pick them up, so we edit the Makefile to restore tests, coverage, and linting