### PR TITLE
 invoices: fix synchronization issue with single invoice subscribers

### DIFF
--- a/invoices/invoiceregistry.go
+++ b/invoices/invoiceregistry.go
@@ -226,13 +226,7 @@ func (i *InvoiceRegistry) dispatchToSingleClients(event *invoiceEvent) {
 			continue
 		}
 
-		select {
-		case client.ntfnQueue.ChanIn() <- &invoiceEvent{
-			invoice: event.invoice,
-		}:
-		case <-i.quit:
-			return
-		}
+		client.notify(event)
 	}
 }
 

--- a/invoices/invoiceregistry.go
+++ b/invoices/invoiceregistry.go
@@ -36,6 +36,10 @@ var (
 	// ErrInvoiceAmountTooLow is returned  when an invoice is attempted to be
 	// accepted or settled with an amount that is too low.
 	ErrInvoiceAmountTooLow = errors.New("paid amount less than invoice amount")
+
+	// ErrShuttingDown is returned when an operation failed because the
+	// invoice registry is shutting down.
+	ErrShuttingDown = errors.New("invoice registry shutting down")
 )
 
 // HodlEvent describes how an htlc should be resolved. If HodlEvent.Preimage is
@@ -330,7 +334,7 @@ func (i *InvoiceRegistry) deliverBacklogEvents(client *InvoiceSubscription) erro
 			invoice: &addEvent,
 		}:
 		case <-i.quit:
-			return fmt.Errorf("registry shutting down")
+			return ErrShuttingDown
 		}
 	}
 
@@ -344,7 +348,7 @@ func (i *InvoiceRegistry) deliverBacklogEvents(client *InvoiceSubscription) erro
 			invoice: &settleEvent,
 		}:
 		case <-i.quit:
-			return fmt.Errorf("registry shutting down")
+			return ErrShuttingDown
 		}
 	}
 
@@ -801,7 +805,7 @@ func (i *invoiceSubscriptionKit) notify(event *invoiceEvent) error {
 	select {
 	case i.ntfnQueue.ChanIn() <- event:
 	case <-i.inv.quit:
-		return fmt.Errorf("registry shutting down")
+		return ErrShuttingDown
 	}
 
 	return nil

--- a/invoices/invoiceregistry_test.go
+++ b/invoices/invoiceregistry_test.go
@@ -71,7 +71,10 @@ func TestSettleInvoice(t *testing.T) {
 	defer allSubscriptions.Cancel()
 
 	// Subscribe to the not yet existing invoice.
-	subscription := registry.SubscribeSingleInvoice(hash)
+	subscription, err := registry.SubscribeSingleInvoice(hash)
+	if err != nil {
+		t.Fatal(err)
+	}
 	defer subscription.Cancel()
 
 	if subscription.hash != hash {
@@ -225,7 +228,10 @@ func TestCancelInvoice(t *testing.T) {
 	}
 
 	// Subscribe to the not yet existing invoice.
-	subscription := registry.SubscribeSingleInvoice(hash)
+	subscription, err := registry.SubscribeSingleInvoice(hash)
+	if err != nil {
+		t.Fatal(err)
+	}
 	defer subscription.Cancel()
 
 	if subscription.hash != hash {
@@ -329,7 +335,10 @@ func TestHoldInvoice(t *testing.T) {
 	defer allSubscriptions.Cancel()
 
 	// Subscribe to the not yet existing invoice.
-	subscription := registry.SubscribeSingleInvoice(hash)
+	subscription, err := registry.SubscribeSingleInvoice(hash)
+	if err != nil {
+		t.Fatal(err)
+	}
 	defer subscription.Cancel()
 
 	if subscription.hash != hash {

--- a/lnrpc/invoicesrpc/invoices_server.go
+++ b/lnrpc/invoicesrpc/invoices_server.go
@@ -178,7 +178,10 @@ func (s *Server) SubscribeSingleInvoice(req *SubscribeSingleInvoiceRequest,
 		return err
 	}
 
-	invoiceClient := s.cfg.InvoiceRegistry.SubscribeSingleInvoice(hash)
+	invoiceClient, err := s.cfg.InvoiceRegistry.SubscribeSingleInvoice(hash)
+	if err != nil {
+		return err
+	}
 	defer invoiceClient.Cancel()
 
 	for {


### PR DESCRIPTION
Fixes a synchronization issue where a single invoice subscriber could receive duplicate and/or out of order invoice updates.

Modification required in master to reliably reproduce the test `TestHoldInvoice` failing:
```
case newClient := <-i.newSingleSubscriptions:
   // DEBUG: To trigger test fail, remove.
   time.Sleep(time.Second)

   err := i.deliverSingleBacklogEvents(newClient)
```