### PR TITLE
fixed 1-line errant docker-compose command in instructions

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -307,7 +307,7 @@ The `Faucet` node address can be found at the [Faucet Lightning Community webpag
 
 ```bash 
 # Run "Alice" container and log into it:
-$ docker-compose up -d "alice"; docker exec -i -t "alice" bash
+$ docker-compose run -d --name alice lnd_btc; docker exec -i -t "alice" bash
 
 # Connect "Alice" to the "Faucet" node:
 alice$ lncli --network=testnet connect <faucet_identity_address>@<faucet_host>


### PR DESCRIPTION
This instruction did not get updated when the docker-compose file removed the `alice` service. This changes makes the command work and is consistent with the instructions in the previous section.

Fixes https://github.com/lightningnetwork/lnd/issues/3408