### PR TITLE
multi: store fwdpkg locked-in time [wip] [no review]

### DIFF
--- a/breacharbiter_test.go
+++ b/breacharbiter_test.go
@@ -1963,7 +1963,9 @@ func forceStateTransition(chanA, chanB *lnwallet.LightningChannel) error {
 		return err
 	}
 
-	_, _, _, _, err = chanA.ReceiveRevocation(bobRevocation)
+	_, _, _, _, err = chanA.ReceiveRevocation(
+		bobRevocation, channeldb.LockedInTime{},
+	)
 	if err != nil {
 		return err
 	}
@@ -1975,7 +1977,9 @@ func forceStateTransition(chanA, chanB *lnwallet.LightningChannel) error {
 	if err != nil {
 		return err
 	}
-	_, _, _, _, err = chanB.ReceiveRevocation(aliceRevocation)
+	_, _, _, _, err = chanB.ReceiveRevocation(
+		aliceRevocation, channeldb.LockedInTime{},
+	)
 	if err != nil {
 		return err
 	}

--- a/channeldb/channel_test.go
+++ b/channeldb/channel_test.go
@@ -9,6 +9,7 @@ import (
 	"reflect"
 	"runtime"
 	"testing"
+	"time"
 
 	"github.com/btcsuite/btcd/btcec"
 	"github.com/btcsuite/btcd/chaincfg"
@@ -84,6 +85,11 @@ var (
 	privKey, pubKey = btcec.PrivKeyFromBytes(btcec.S256(), key[:])
 
 	wireSig, _ = lnwire.NewSigFromSignature(testSig)
+
+	TestLockedInTime = LockedInTime{
+		BlockHeight: 1,
+		Timestamp:   time.Unix(1, 0),
+	}
 )
 
 // makeTestDB creates a new instance of the ChannelDB for testing purposes. A
@@ -535,7 +541,7 @@ func TestChannelStateTransition(t *testing.T) {
 	channel.RemoteNextRevocation = newPriv.PubKey()
 
 	fwdPkg := NewFwdPkg(channel.ShortChanID(), oldRemoteCommit.CommitHeight,
-		diskCommitDiff.LogUpdates, nil)
+		TestLockedInTime, diskCommitDiff.LogUpdates, nil)
 
 	err = channel.AdvanceCommitChainTail(fwdPkg)
 	if err != nil {
@@ -583,7 +589,8 @@ func TestChannelStateTransition(t *testing.T) {
 		t.Fatalf("unable to add to commit chain: %v", err)
 	}
 
-	fwdPkg = NewFwdPkg(channel.ShortChanID(), oldRemoteCommit.CommitHeight, nil, nil)
+	fwdPkg = NewFwdPkg(channel.ShortChanID(), oldRemoteCommit.CommitHeight,
+		TestLockedInTime, nil, nil)
 
 	err = channel.AdvanceCommitChainTail(fwdPkg)
 	if err != nil {

--- a/channeldb/codec.go
+++ b/channeldb/codec.go
@@ -108,7 +108,7 @@ func WriteElement(w io.Writer, element interface{}) error {
 			return err
 		}
 
-	case uint64:
+	case int64, uint64:
 		if err := binary.Write(w, byteOrder, e); err != nil {
 			return err
 		}
@@ -280,7 +280,7 @@ func ReadElement(r io.Reader, element interface{}) error {
 			return err
 		}
 
-	case *uint64:
+	case *int64, *uint64:
 		if err := binary.Read(r, byteOrder, e); err != nil {
 			return err
 		}

--- a/channeldb/db.go
+++ b/channeldb/db.go
@@ -103,6 +103,11 @@ var (
 			number:    9,
 			migration: migrateOutgoingPayments,
 		},
+		{
+			// Adds locked-in time to forwarding packages.
+			number:    10,
+			migration: migrateLockedInTime,
+		},
 	}
 
 	// Big endian is the preferred byte order, due to cursor scans over

--- a/channeldb/forwarding_package_test.go
+++ b/channeldb/forwarding_package_test.go
@@ -205,7 +205,9 @@ func TestPackagerEmptyFwdPkg(t *testing.T) {
 	}
 
 	// Next, create and write a new forwarding package with no htlcs.
-	fwdPkg := channeldb.NewFwdPkg(shortChanID, 0, nil, nil)
+	fwdPkg := channeldb.NewFwdPkg(
+		shortChanID, 0, channeldb.TestLockedInTime, nil, nil,
+	)
 
 	if err := db.Update(func(tx *bbolt.Tx) error {
 		return packager.AddFwdPkg(tx, fwdPkg)
@@ -275,7 +277,9 @@ func TestPackagerOnlyAdds(t *testing.T) {
 
 	// Next, create and write a new forwarding package that only has add
 	// htlcs.
-	fwdPkg := channeldb.NewFwdPkg(shortChanID, 0, adds, nil)
+	fwdPkg := channeldb.NewFwdPkg(
+		shortChanID, 0, channeldb.TestLockedInTime, adds, nil,
+	)
 
 	nAdds := len(adds)
 
@@ -377,7 +381,9 @@ func TestPackagerOnlySettleFails(t *testing.T) {
 
 	// Next, create and write a new forwarding package that only has add
 	// htlcs.
-	fwdPkg := channeldb.NewFwdPkg(shortChanID, 0, nil, settleFails)
+	fwdPkg := channeldb.NewFwdPkg(
+		shortChanID, 0, channeldb.TestLockedInTime, nil, settleFails,
+	)
 
 	nSettleFails := len(settleFails)
 
@@ -481,7 +487,9 @@ func TestPackagerAddsThenSettleFails(t *testing.T) {
 
 	// Next, create and write a new forwarding package that only has add
 	// htlcs.
-	fwdPkg := channeldb.NewFwdPkg(shortChanID, 0, adds, settleFails)
+	fwdPkg := channeldb.NewFwdPkg(
+		shortChanID, 0, channeldb.TestLockedInTime, adds, settleFails,
+	)
 
 	nAdds := len(adds)
 	nSettleFails := len(settleFails)
@@ -614,7 +622,9 @@ func TestPackagerSettleFailsThenAdds(t *testing.T) {
 
 	// Next, create and write a new forwarding package that has both add
 	// and settle/fail htlcs.
-	fwdPkg := channeldb.NewFwdPkg(shortChanID, 0, adds, settleFails)
+	fwdPkg := channeldb.NewFwdPkg(
+		shortChanID, 0, channeldb.TestLockedInTime, adds, settleFails,
+	)
 
 	nAdds := len(adds)
 	nSettleFails := len(settleFails)

--- a/channeldb/migration_10_locked_in_time.go
+++ b/channeldb/migration_10_locked_in_time.go
@@ -1,0 +1,51 @@
+package channeldb
+
+import (
+	"time"
+
+	"github.com/coreos/bbolt"
+)
+
+func migrateLockedInTime(tx *bbolt.Tx) error {
+	log.Infof("Migrating forwarding packages locked-in time")
+
+	fwdPkgBkt := tx.Bucket(fwdPackagesKey)
+	if fwdPkgBkt == nil {
+		return nil
+	}
+
+	if err := fwdPkgBkt.ForEach(func(sourceKey, _ []byte) error {
+		sourceBkt := fwdPkgBkt.Bucket(sourceKey[:])
+		if sourceBkt == nil {
+			return ErrCorruptedFwdPkg
+		}
+
+		return sourceBkt.ForEach(func(heightKey, _ []byte) error {
+			heightBkt := sourceBkt.Bucket(heightKey[:])
+			if heightBkt == nil {
+				return ErrCorruptedFwdPkg
+			}
+
+			lockedInTime := LockedInTime{
+				// Set accepted block height to zero. This is
+				// obviously not the real locked-in time, but
+				// this way any accepted htlcs for potential
+				// hodl invoices won't be canceled back.
+				BlockHeight: 0,
+
+				// Set timestamp to current time. This is not
+				// the real locked-in time, but it is our best
+				// guess.
+				Timestamp: time.Now(),
+			}
+
+			return putLockedInTime(heightBkt, lockedInTime)
+		})
+	}); err != nil {
+		return err
+	}
+
+	log.Infof("Migration of forwarding packages locked-in time completed!")
+
+	return nil
+}

--- a/contractcourt/htlc_incoming_contest_resolver.go
+++ b/contractcourt/htlc_incoming_contest_resolver.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"time"
 
 	"github.com/lightningnetwork/lnd/channeldb"
 	"github.com/lightningnetwork/lnd/invoices"
@@ -164,8 +165,15 @@ func (h *htlcIncomingContestResolver) Resolve() (ContractResolver, error) {
 	// on-chain. If this HTLC indeed pays to an existing invoice, the
 	// invoice registry will tell us what to do with the HTLC. This is
 	// identical to HTLC resolution in the link.
+	//
+	// TODO(joostjager): Set this to the original accepted height. Read the
+	// fwd pkg?
+	lockedInTime := channeldb.LockedInTime{
+		BlockHeight: currentHeight,
+		Timestamp:   time.Now(),
+	}
 	event, err := h.Registry.NotifyExitHopHtlc(
-		h.payHash, h.htlcAmt, h.htlcExpiry, currentHeight,
+		h.payHash, h.htlcAmt, h.htlcExpiry, lockedInTime,
 		hodlChan,
 	)
 	switch err {

--- a/contractcourt/htlc_incoming_resolver_test.go
+++ b/contractcourt/htlc_incoming_resolver_test.go
@@ -101,7 +101,7 @@ func TestHtlcIncomingResolverExitSettle(t *testing.T) {
 	if data.expiry != testHtlcExpiry {
 		t.Fatal("incorrect expiry")
 	}
-	if data.currentHeight != testInitialBlockHeight {
+	if data.lockedInTime.BlockHeight != testInitialBlockHeight {
 		t.Fatal("incorrect block height")
 	}
 

--- a/contractcourt/interfaces.go
+++ b/contractcourt/interfaces.go
@@ -21,7 +21,7 @@ type Registry interface {
 	// htlc should be resolved. If the htlc cannot be resolved immediately,
 	// the resolution is sent on the passed in hodlChan later.
 	NotifyExitHopHtlc(payHash lntypes.Hash, paidAmount lnwire.MilliSatoshi,
-		expiry uint32, currentHeight int32,
+		expiry uint32, lockedInTime channeldb.LockedInTime,
 		hodlChan chan<- interface{}) (*invoices.HodlEvent, error)
 
 	// HodlUnsubscribeAll unsubscribes from all hodl events.

--- a/contractcourt/mock_registry_test.go
+++ b/contractcourt/mock_registry_test.go
@@ -8,11 +8,11 @@ import (
 )
 
 type notifyExitHopData struct {
-	payHash       lntypes.Hash
-	paidAmount    lnwire.MilliSatoshi
-	hodlChan      chan<- interface{}
-	expiry        uint32
-	currentHeight int32
+	payHash      lntypes.Hash
+	paidAmount   lnwire.MilliSatoshi
+	hodlChan     chan<- interface{}
+	expiry       uint32
+	lockedInTime channeldb.LockedInTime
 }
 
 type mockRegistry struct {
@@ -22,15 +22,16 @@ type mockRegistry struct {
 }
 
 func (r *mockRegistry) NotifyExitHopHtlc(payHash lntypes.Hash,
-	paidAmount lnwire.MilliSatoshi, expiry uint32, currentHeight int32,
-	hodlChan chan<- interface{}) (*invoices.HodlEvent, error) {
+	paidAmount lnwire.MilliSatoshi, expiry uint32,
+	lockedInTime channeldb.LockedInTime, hodlChan chan<- interface{}) (
+	*invoices.HodlEvent, error) {
 
 	r.notifyChan <- notifyExitHopData{
-		hodlChan:      hodlChan,
-		payHash:       payHash,
-		paidAmount:    paidAmount,
-		expiry:        expiry,
-		currentHeight: currentHeight,
+		hodlChan:     hodlChan,
+		payHash:      payHash,
+		paidAmount:   paidAmount,
+		expiry:       expiry,
+		lockedInTime: lockedInTime,
 	}
 
 	return r.notifyEvent, r.notifyErr

--- a/htlcswitch/interfaces.go
+++ b/htlcswitch/interfaces.go
@@ -25,7 +25,7 @@ type InvoiceDatabase interface {
 	// htlc should be resolved. If the htlc cannot be resolved immediately,
 	// the resolution is sent on the passed in hodlChan later.
 	NotifyExitHopHtlc(payHash lntypes.Hash, paidAmount lnwire.MilliSatoshi,
-		expiry uint32, currentHeight int32,
+		expiry uint32, lockedInTime channeldb.LockedInTime,
 		hodlChan chan<- interface{}) (*invoices.HodlEvent, error)
 
 	// CancelInvoice attempts to cancel the invoice corresponding to the

--- a/htlcswitch/link_test.go
+++ b/htlcswitch/link_test.go
@@ -1783,7 +1783,9 @@ func handleStateUpdate(link *channelLink,
 	if !ok {
 		return fmt.Errorf("expected RevokeAndAck got %T", msg)
 	}
-	_, _, _, _, err = remoteChannel.ReceiveRevocation(revoke)
+	_, _, _, _, err = remoteChannel.ReceiveRevocation(
+		revoke, channeldb.LockedInTime{},
+	)
 	if err != nil {
 		return fmt.Errorf("unable to receive "+
 			"revocation: %v", err)
@@ -1837,7 +1839,9 @@ func updateState(batchTick chan time.Time, link *channelLink,
 		return fmt.Errorf("expected RevokeAndAck got %T",
 			msg)
 	}
-	_, _, _, _, err = remoteChannel.ReceiveRevocation(revoke)
+	_, _, _, _, err = remoteChannel.ReceiveRevocation(
+		revoke, channeldb.LockedInTime{},
+	)
 	if err != nil {
 		return fmt.Errorf("unable to receive "+
 			"revocation: %v", err)
@@ -4438,7 +4442,9 @@ func receiveRevAndAckAliceToBob(t *testing.T, aliceMsgs chan lnwire.Message,
 		t.Fatalf("expected RevokeAndAck, got %T", msg)
 	}
 
-	_, _, _, _, err := bobChannel.ReceiveRevocation(rev)
+	_, _, _, _, err := bobChannel.ReceiveRevocation(
+		rev, channeldb.LockedInTime{},
+	)
 	if err != nil {
 		t.Fatalf("bob failed receiving revocation: %v", err)
 	}

--- a/htlcswitch/mock.go
+++ b/htlcswitch/mock.go
@@ -788,11 +788,12 @@ func (i *mockInvoiceRegistry) SettleHodlInvoice(preimage lntypes.Preimage) error
 }
 
 func (i *mockInvoiceRegistry) NotifyExitHopHtlc(rhash lntypes.Hash,
-	amt lnwire.MilliSatoshi, expiry uint32, currentHeight int32,
-	hodlChan chan<- interface{}) (*invoices.HodlEvent, error) {
+	amt lnwire.MilliSatoshi, expiry uint32,
+	lockedInTime channeldb.LockedInTime, hodlChan chan<- interface{}) (
+	*invoices.HodlEvent, error) {
 
 	event, err := i.registry.NotifyExitHopHtlc(
-		rhash, amt, expiry, currentHeight, hodlChan,
+		rhash, amt, expiry, lockedInTime, hodlChan,
 	)
 	if err != nil {
 		return nil, err

--- a/invoices/invoiceregistry.go
+++ b/invoices/invoiceregistry.go
@@ -578,15 +578,16 @@ func (i *InvoiceRegistry) checkHtlcParameters(invoice *channeldb.Invoice,
 // the channel is either buffered or received on from another goroutine to
 // prevent deadlock.
 func (i *InvoiceRegistry) NotifyExitHopHtlc(rHash lntypes.Hash,
-	amtPaid lnwire.MilliSatoshi, expiry uint32, currentHeight int32,
-	hodlChan chan<- interface{}) (*HodlEvent, error) {
+	amtPaid lnwire.MilliSatoshi, expiry uint32,
+	lockedInTime channeldb.LockedInTime, hodlChan chan<- interface{}) (
+	*HodlEvent, error) {
 
 	i.Lock()
 	defer i.Unlock()
 
 	debugLog := func(s string) {
-		log.Debugf("Invoice(%x): %v, amt=%v, expiry=%v",
-			rHash[:], s, amtPaid, expiry)
+		log.Debugf("Invoice(%x): %v, amt=%v, expiry=%v, lockedIn=%v",
+			rHash[:], s, amtPaid, expiry, lockedInTime)
 	}
 	// First check the in-memory debug invoice index to see if this is an
 	// existing invoice added for debugging.
@@ -607,7 +608,7 @@ func (i *InvoiceRegistry) NotifyExitHopHtlc(rHash lntypes.Hash,
 		rHash, amtPaid,
 		func(inv *channeldb.Invoice) error {
 			return i.checkHtlcParameters(
-				inv, amtPaid, expiry, currentHeight,
+				inv, amtPaid, expiry, lockedInTime.BlockHeight,
 			)
 		},
 	)

--- a/invoices/invoiceregistry.go
+++ b/invoices/invoiceregistry.go
@@ -532,10 +532,10 @@ func (i *InvoiceRegistry) checkHtlcParameters(invoice *channeldb.Invoice,
 		return channeldb.ErrInvoiceAlreadyCanceled
 	}
 
-	// If a payment has already been made, we only accept more payments if
-	// the amount is the exact same. This prevents probing with small
-	// amounts on settled invoices to find out the receiver node.
-	if invoice.AmtPaid != 0 && amtPaid != invoice.AmtPaid {
+	// If an invoice amount is specified, check that enough is paid. Also
+	// check this for duplicate payments if the invoice is already settled
+	// or accepted.
+	if invoice.Terms.Value > 0 && amtPaid < invoice.Terms.Value {
 		return ErrInvoiceAmountTooLow
 	}
 
@@ -561,11 +561,6 @@ func (i *InvoiceRegistry) checkHtlcParameters(invoice *channeldb.Invoice,
 
 	if htlcExpiry < uint32(currentHeight)+expiry {
 		return ErrInvoiceExpiryTooSoon
-	}
-
-	// If an invoice amount is specified, check that enough is paid.
-	if invoice.Terms.Value > 0 && amtPaid < invoice.Terms.Value {
-		return ErrInvoiceAmountTooLow
 	}
 
 	return nil

--- a/invoices/invoiceregistry_test.go
+++ b/invoices/invoiceregistry_test.go
@@ -160,9 +160,9 @@ func TestSettleInvoice(t *testing.T) {
 		t.Fatal("expected settle event")
 	}
 
-	// Try to settle again with a higher amount. This should result in a
-	// cancel event because after a restart the amount should still be the
-	// same. New HTLCs with a different amount should be rejected.
+	// Try to settle again with a higher amount. This payment should also be
+	// accepted, to prevent any change in behaviour for a paid invoice that
+	// may open up a probe vector.
 	event, err = registry.NotifyExitHopHtlc(
 		hash, amtPaid+600, testInvoiceExpiry, testCurrentHeight,
 		hodlChan,
@@ -170,12 +170,12 @@ func TestSettleInvoice(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected NotifyExitHopHtlc error: %v", err)
 	}
-	if event.Preimage != nil {
-		t.Fatal("expected cancel event")
+	if event.Preimage == nil {
+		t.Fatal("expected settle event")
 	}
 
-	// Try to settle again with a lower amount. This should show the same
-	// behaviour as settling with a higher amount.
+	// Try to settle again with a lower amount. This should fail just as it
+	// would have failed if it were the first payment.
 	event, err = registry.NotifyExitHopHtlc(
 		hash, amtPaid-600, testInvoiceExpiry, testCurrentHeight,
 		hodlChan,

--- a/lnwallet/channel.go
+++ b/lnwallet/channel.go
@@ -4289,9 +4289,9 @@ func (lc *LightningChannel) RevokeCurrentCommitment() (*lnwire.RevokeAndAck, []c
 //      this revocation.
 //   4. The set of HTLCs present on the current valid commitment transaction
 //      for the remote party.
-func (lc *LightningChannel) ReceiveRevocation(revMsg *lnwire.RevokeAndAck) (
-	*channeldb.FwdPkg, []*PaymentDescriptor, []*PaymentDescriptor,
-	[]channeldb.HTLC, error) {
+func (lc *LightningChannel) ReceiveRevocation(revMsg *lnwire.RevokeAndAck,
+	time channeldb.LockedInTime) (*channeldb.FwdPkg, []*PaymentDescriptor,
+	[]*PaymentDescriptor, []channeldb.HTLC, error) {
 
 	lc.Lock()
 	defer lc.Unlock()
@@ -4473,7 +4473,8 @@ func (lc *LightningChannel) ReceiveRevocation(revMsg *lnwire.RevokeAndAck) (
 	// type, construct a forwarding package using the height that the remote
 	// commitment chain will be extended after persisting the revocation.
 	fwdPkg := channeldb.NewFwdPkg(
-		source, remoteChainTail, addUpdates, settleFailUpdates,
+		source, remoteChainTail, time, addUpdates,
+		settleFailUpdates,
 	)
 
 	// At this point, the revocation has been accepted, and we've rotated

--- a/lnwallet/channel_test.go
+++ b/lnwallet/channel_test.go
@@ -131,7 +131,9 @@ func TestSimpleAddSettleWorkflow(t *testing.T) {
 	// Alice then processes this revocation, sending her own revocation for
 	// her prior commitment transaction. Alice shouldn't have any HTLCs to
 	// forward since she's sending an outgoing HTLC.
-	fwdPkg, _, _, _, err := aliceChannel.ReceiveRevocation(bobRevocation)
+	fwdPkg, _, _, _, err := aliceChannel.ReceiveRevocation(
+		bobRevocation, channeldb.LockedInTime{},
+	)
 	if err != nil {
 		t.Fatalf("alice unable to process bob's revocation: %v", err)
 	}
@@ -162,7 +164,9 @@ func TestSimpleAddSettleWorkflow(t *testing.T) {
 	// is fully locked in within both commitment transactions. Bob should
 	// also be able to forward an HTLC now that the HTLC has been locked
 	// into both commitment transactions.
-	fwdPkg, _, _, _, err = bobChannel.ReceiveRevocation(aliceRevocation)
+	fwdPkg, _, _, _, err = bobChannel.ReceiveRevocation(
+		aliceRevocation, channeldb.LockedInTime{},
+	)
 	if err != nil {
 		t.Fatalf("bob unable to process alice's revocation: %v", err)
 	}
@@ -257,7 +261,9 @@ func TestSimpleAddSettleWorkflow(t *testing.T) {
 		t.Fatalf("alice unable to sign new commitment: %v", err)
 	}
 
-	fwdPkg, _, _, _, err = bobChannel.ReceiveRevocation(aliceRevocation2)
+	fwdPkg, _, _, _, err = bobChannel.ReceiveRevocation(
+		aliceRevocation2, channeldb.LockedInTime{},
+	)
 	if err != nil {
 		t.Fatalf("bob unable to process alice's revocation: %v", err)
 	}
@@ -279,7 +285,9 @@ func TestSimpleAddSettleWorkflow(t *testing.T) {
 	if err != nil {
 		t.Fatalf("bob unable to revoke commitment: %v", err)
 	}
-	fwdPkg, _, _, _, err = aliceChannel.ReceiveRevocation(bobRevocation2)
+	fwdPkg, _, _, _, err = aliceChannel.ReceiveRevocation(
+		bobRevocation2, channeldb.LockedInTime{},
+	)
 	if err != nil {
 		t.Fatalf("alice unable to process bob's revocation: %v", err)
 	}
@@ -2165,7 +2173,9 @@ func TestUpdateFeeSenderCommits(t *testing.T) {
 	// Alice receives the revocation of the old one, and can now assume
 	// that Bob's received everything up to the signature she sent,
 	// including the HTLC and fee update.
-	_, _, _, _, err = aliceChannel.ReceiveRevocation(bobRevocation)
+	_, _, _, _, err = aliceChannel.ReceiveRevocation(
+		bobRevocation, channeldb.LockedInTime{},
+	)
 	if err != nil {
 		t.Fatalf("alice unable to process bob's revocation: %v", err)
 	}
@@ -2193,7 +2203,9 @@ func TestUpdateFeeSenderCommits(t *testing.T) {
 	}
 
 	// Bob receives revocation from Alice.
-	_, _, _, _, err = bobChannel.ReceiveRevocation(aliceRevocation)
+	_, _, _, _, err = bobChannel.ReceiveRevocation(
+		aliceRevocation, channeldb.LockedInTime{},
+	)
 	if err != nil {
 		t.Fatalf("bob unable to process alice's revocation: %v", err)
 	}
@@ -2262,7 +2274,9 @@ func TestUpdateFeeReceiverCommits(t *testing.T) {
 	}
 
 	// Bob receives the revocation of the old commitment
-	_, _, _, _, err = bobChannel.ReceiveRevocation(aliceRevocation)
+	_, _, _, _, err = bobChannel.ReceiveRevocation(
+		aliceRevocation, channeldb.LockedInTime{},
+	)
 	if err != nil {
 		t.Fatalf("alice unable to process bob's revocation: %v", err)
 	}
@@ -2307,7 +2321,9 @@ func TestUpdateFeeReceiverCommits(t *testing.T) {
 
 	// Alice receives revocation from Bob, and can now be sure that Bob
 	// received the two updates, and they are considered locked in.
-	_, _, _, _, err = aliceChannel.ReceiveRevocation(bobRevocation)
+	_, _, _, _, err = aliceChannel.ReceiveRevocation(
+		bobRevocation, channeldb.LockedInTime{},
+	)
 	if err != nil {
 		t.Fatalf("bob unable to process alice's revocation: %v", err)
 	}
@@ -2335,7 +2351,9 @@ func TestUpdateFeeReceiverCommits(t *testing.T) {
 	}
 
 	// Bob receives revocation from Alice.
-	_, _, _, _, err = bobChannel.ReceiveRevocation(aliceRevocation)
+	_, _, _, _, err = bobChannel.ReceiveRevocation(
+		aliceRevocation, channeldb.LockedInTime{},
+	)
 	if err != nil {
 		t.Fatalf("bob unable to process alice's revocation: %v", err)
 	}
@@ -2450,7 +2468,9 @@ func TestUpdateFeeMultipleUpdates(t *testing.T) {
 	// Alice receives the revocation of the old one, and can now assume that
 	// Bob's received everything up to the signature she sent, including the
 	// HTLC and fee update.
-	_, _, _, _, err = aliceChannel.ReceiveRevocation(bobRevocation)
+	_, _, _, _, err = aliceChannel.ReceiveRevocation(
+		bobRevocation, channeldb.LockedInTime{},
+	)
 	if err != nil {
 		t.Fatalf("alice unable to process bob's revocation: %v", err)
 	}
@@ -2477,7 +2497,9 @@ func TestUpdateFeeMultipleUpdates(t *testing.T) {
 	}
 
 	// Bob receives revocation from Alice.
-	_, _, _, _, err = bobChannel.ReceiveRevocation(aliceRevocation)
+	_, _, _, _, err = bobChannel.ReceiveRevocation(
+		aliceRevocation, channeldb.LockedInTime{},
+	)
 	if err != nil {
 		t.Fatalf("bob unable to process alice's revocation: %v", err)
 	}
@@ -2903,7 +2925,9 @@ func TestChanSyncOweCommitment(t *testing.T) {
 	if err != nil {
 		t.Fatalf("bob unable to sign commitment: %v", err)
 	}
-	_, _, _, _, err = aliceChannel.ReceiveRevocation(bobRevocation)
+	_, _, _, _, err = aliceChannel.ReceiveRevocation(
+		bobRevocation, channeldb.LockedInTime{},
+	)
 	if err != nil {
 		t.Fatalf("alice unable to recv revocation: %v", err)
 	}
@@ -2915,7 +2939,9 @@ func TestChanSyncOweCommitment(t *testing.T) {
 	if err != nil {
 		t.Fatalf("alice unable to revoke commitment: %v", err)
 	}
-	_, _, _, _, err = bobChannel.ReceiveRevocation(aliceRevocation)
+	_, _, _, _, err = bobChannel.ReceiveRevocation(
+		aliceRevocation, channeldb.LockedInTime{},
+	)
 	if err != nil {
 		t.Fatalf("bob unable to recv revocation: %v", err)
 	}
@@ -3074,7 +3100,9 @@ func TestChanSyncOweRevocation(t *testing.T) {
 		t.Fatalf("bob unable to sign commitment: %v", err)
 	}
 
-	_, _, _, _, err = aliceChannel.ReceiveRevocation(bobRevocation)
+	_, _, _, _, err = aliceChannel.ReceiveRevocation(
+		bobRevocation, channeldb.LockedInTime{},
+	)
 	if err != nil {
 		t.Fatalf("alice unable to recv revocation: %v", err)
 	}
@@ -3156,7 +3184,9 @@ func TestChanSyncOweRevocation(t *testing.T) {
 	// TODO(roasbeef): restart bob too???
 
 	// We'll continue by then allowing bob to process Alice's revocation message.
-	_, _, _, _, err = bobChannel.ReceiveRevocation(aliceRevocation)
+	_, _, _, _, err = bobChannel.ReceiveRevocation(
+		aliceRevocation, channeldb.LockedInTime{},
+	)
 	if err != nil {
 		t.Fatalf("bob unable to recv revocation: %v", err)
 	}
@@ -3335,7 +3365,9 @@ func TestChanSyncOweRevocationAndCommit(t *testing.T) {
 
 	// We'll now finish the state transition by having Alice process both
 	// messages, and send her final revocation.
-	_, _, _, _, err = aliceChannel.ReceiveRevocation(bobRevocation)
+	_, _, _, _, err = aliceChannel.ReceiveRevocation(
+		bobRevocation, channeldb.LockedInTime{},
+	)
 	if err != nil {
 		t.Fatalf("alice unable to recv revocation: %v", err)
 	}
@@ -3347,7 +3379,9 @@ func TestChanSyncOweRevocationAndCommit(t *testing.T) {
 	if err != nil {
 		t.Fatalf("alice unable to revoke commitment: %v", err)
 	}
-	_, _, _, _, err = bobChannel.ReceiveRevocation(aliceRevocation)
+	_, _, _, _, err = bobChannel.ReceiveRevocation(
+		aliceRevocation, channeldb.LockedInTime{},
+	)
 	if err != nil {
 		t.Fatalf("bob unable to recv revocation: %v", err)
 	}
@@ -3435,7 +3469,9 @@ func TestChanSyncOweRevocationAndCommitForceTransition(t *testing.T) {
 	if err != nil {
 		t.Fatalf("alice unable to revoke commitment: %v", err)
 	}
-	_, _, _, _, err = bobChannel.ReceiveRevocation(aliceRevocation)
+	_, _, _, _, err = bobChannel.ReceiveRevocation(
+		aliceRevocation, channeldb.LockedInTime{},
+	)
 	if err != nil {
 		t.Fatalf("bob unable to recv revocation: %v", err)
 	}
@@ -3565,7 +3601,9 @@ func TestChanSyncOweRevocationAndCommitForceTransition(t *testing.T) {
 	// Now, we'll continue the exchange, sending Bob's revocation and
 	// signature message to Alice, ending with Alice sending her revocation
 	// message to Bob.
-	_, _, _, _, err = aliceChannel.ReceiveRevocation(bobRevocation)
+	_, _, _, _, err = aliceChannel.ReceiveRevocation(
+		bobRevocation, channeldb.LockedInTime{},
+	)
 	if err != nil {
 		t.Fatalf("alice unable to recv revocation: %v", err)
 	}
@@ -3579,7 +3617,9 @@ func TestChanSyncOweRevocationAndCommitForceTransition(t *testing.T) {
 	if err != nil {
 		t.Fatalf("alice unable to revoke commitment: %v", err)
 	}
-	_, _, _, _, err = bobChannel.ReceiveRevocation(aliceRevocation)
+	_, _, _, _, err = bobChannel.ReceiveRevocation(
+		aliceRevocation, channeldb.LockedInTime{},
+	)
 	if err != nil {
 		t.Fatalf("bob unable to recv revocation: %v", err)
 	}
@@ -4002,7 +4042,9 @@ func TestChannelRetransmissionFeeUpdate(t *testing.T) {
 	if err != nil {
 		t.Fatalf("bob unable to sign commitment: %v", err)
 	}
-	_, _, _, _, err = aliceChannel.ReceiveRevocation(bobRevocation)
+	_, _, _, _, err = aliceChannel.ReceiveRevocation(
+		bobRevocation, channeldb.LockedInTime{},
+	)
 	if err != nil {
 		t.Fatalf("alice unable to recv revocation: %v", err)
 	}
@@ -4014,7 +4056,9 @@ func TestChannelRetransmissionFeeUpdate(t *testing.T) {
 	if err != nil {
 		t.Fatalf("alice unable to revoke commitment: %v", err)
 	}
-	_, _, _, _, err = bobChannel.ReceiveRevocation(aliceRevocation)
+	_, _, _, _, err = bobChannel.ReceiveRevocation(
+		aliceRevocation, channeldb.LockedInTime{},
+	)
 	if err != nil {
 		t.Fatalf("bob unable to recv revocation: %v", err)
 	}
@@ -4215,7 +4259,9 @@ func TestFeeUpdateOldDiskFormat(t *testing.T) {
 	if err != nil {
 		t.Fatalf("bob unable to sign commitment: %v", err)
 	}
-	_, _, _, _, err = aliceChannel.ReceiveRevocation(bobRevocation)
+	_, _, _, _, err = aliceChannel.ReceiveRevocation(
+		bobRevocation, channeldb.LockedInTime{},
+	)
 	if err != nil {
 		t.Fatalf("alice unable to recv revocation: %v", err)
 	}
@@ -4227,7 +4273,9 @@ func TestFeeUpdateOldDiskFormat(t *testing.T) {
 	if err != nil {
 		t.Fatalf("alice unable to revoke commitment: %v", err)
 	}
-	_, _, _, _, err = bobChannel.ReceiveRevocation(aliceRevocation)
+	_, _, _, _, err = bobChannel.ReceiveRevocation(
+		aliceRevocation, channeldb.LockedInTime{},
+	)
 	if err != nil {
 		t.Fatalf("bob unable to recv revocation: %v", err)
 	}
@@ -4590,7 +4638,9 @@ func TestLockedInHtlcForwardingSkipAfterRestart(t *testing.T) {
 	}
 
 	// Alice should detect that she doesn't need to forward any HTLC's.
-	fwdPkg, _, _, _, err := aliceChannel.ReceiveRevocation(bobRevocation)
+	fwdPkg, _, _, _, err := aliceChannel.ReceiveRevocation(
+		bobRevocation, channeldb.LockedInTime{},
+	)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -4621,7 +4671,9 @@ func TestLockedInHtlcForwardingSkipAfterRestart(t *testing.T) {
 
 	// Bob should now detect that he now has 2 incoming HTLC's that he can
 	// forward along.
-	fwdPkg, _, _, _, err = bobChannel.ReceiveRevocation(aliceRevocation)
+	fwdPkg, _, _, _, err = bobChannel.ReceiveRevocation(
+		aliceRevocation, channeldb.LockedInTime{},
+	)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -4674,7 +4726,9 @@ func TestLockedInHtlcForwardingSkipAfterRestart(t *testing.T) {
 	// At this point, Bob receives the revocation from Alice, which is now
 	// his signal to examine all the HTLC's that have been locked in to
 	// process.
-	fwdPkg, _, _, _, err = bobChannel.ReceiveRevocation(aliceRevocation)
+	fwdPkg, _, _, _, err = bobChannel.ReceiveRevocation(
+		aliceRevocation, channeldb.LockedInTime{},
+	)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -4720,7 +4774,9 @@ func TestLockedInHtlcForwardingSkipAfterRestart(t *testing.T) {
 
 	// Alice should detect that she doesn't need to forward any Adds's, but
 	// that the Fail has been locked in an can be forwarded.
-	_, adds, settleFails, _, err := aliceChannel.ReceiveRevocation(bobRevocation)
+	_, adds, settleFails, _, err := aliceChannel.ReceiveRevocation(
+		bobRevocation, channeldb.LockedInTime{},
+	)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -4777,7 +4833,9 @@ func TestLockedInHtlcForwardingSkipAfterRestart(t *testing.T) {
 
 	// Alice should detect that she doesn't need to forward any HTLC's, as
 	// the updates haven't been committed by Bob yet.
-	fwdPkg, _, _, _, err = aliceChannel.ReceiveRevocation(bobRevocation)
+	fwdPkg, _, _, _, err = aliceChannel.ReceiveRevocation(
+		bobRevocation, channeldb.LockedInTime{},
+	)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -4808,7 +4866,9 @@ func TestLockedInHtlcForwardingSkipAfterRestart(t *testing.T) {
 
 	// Bob should detect that he has nothing to forward, as he hasn't
 	// received any HTLCs.
-	fwdPkg, _, _, _, err = bobChannel.ReceiveRevocation(aliceRevocation)
+	fwdPkg, _, _, _, err = bobChannel.ReceiveRevocation(
+		aliceRevocation, channeldb.LockedInTime{},
+	)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -4838,7 +4898,9 @@ func TestLockedInHtlcForwardingSkipAfterRestart(t *testing.T) {
 
 	// When Alice receives the revocation, she should detect that she
 	// can now forward the freshly locked-in Fail.
-	_, adds, settleFails, _, err = aliceChannel.ReceiveRevocation(bobRevocation)
+	_, adds, settleFails, _, err = aliceChannel.ReceiveRevocation(
+		bobRevocation, channeldb.LockedInTime{},
+	)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -5894,7 +5956,9 @@ func TestChannelRestoreUpdateLogs(t *testing.T) {
 	// sent. However her local commitment chain still won't include the
 	// state with the HTLC, since she hasn't received a new commitment
 	// signature from Bob yet.
-	_, _, _, _, err = aliceChannel.ReceiveRevocation(bobRevocation)
+	_, _, _, _, err = aliceChannel.ReceiveRevocation(
+		bobRevocation, channeldb.LockedInTime{},
+	)
 	if err != nil {
 		t.Fatalf("unable to recive revocation: %v", err)
 	}
@@ -6096,7 +6160,9 @@ func TestChannelRestoreUpdateLogsFailedHTLC(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unable to revoke commitment: %v", err)
 	}
-	_, _, _, _, err = bobChannel.ReceiveRevocation(aliceRevocation)
+	_, _, _, _, err = bobChannel.ReceiveRevocation(
+		aliceRevocation, channeldb.LockedInTime{},
+	)
 	if err != nil {
 		t.Fatalf("bob unable to process alice's revocation: %v", err)
 	}
@@ -6132,7 +6198,9 @@ func TestChannelRestoreUpdateLogsFailedHTLC(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unable to revoke commitment: %v", err)
 	}
-	_, _, _, _, err = aliceChannel.ReceiveRevocation(bobRevocation)
+	_, _, _, _, err = aliceChannel.ReceiveRevocation(
+		bobRevocation, channeldb.LockedInTime{},
+	)
 	if err != nil {
 		t.Fatalf("unable to receive revocation: %v", err)
 	}
@@ -6389,7 +6457,9 @@ func TestChannelRestoreCommitHeight(t *testing.T) {
 	bobChannel = restoreAndAssertCommitHeights(t, bobChannel, true, 0, 1, 0)
 
 	// Alice receives the revocation, ACKing her pending commitment.
-	_, _, _, _, err = aliceChannel.ReceiveRevocation(bobRevocation)
+	_, _, _, _, err = aliceChannel.ReceiveRevocation(
+		bobRevocation, channeldb.LockedInTime{},
+	)
 	if err != nil {
 		t.Fatalf("unable to recive revocation: %v", err)
 	}
@@ -6424,7 +6494,9 @@ func TestChannelRestoreCommitHeight(t *testing.T) {
 	aliceChannel = restoreAndAssertCommitHeights(t, aliceChannel, false,
 		0, 1, 1)
 
-	_, _, _, _, err = bobChannel.ReceiveRevocation(aliceRevocation)
+	_, _, _, _, err = bobChannel.ReceiveRevocation(
+		aliceRevocation, channeldb.LockedInTime{},
+	)
 	if err != nil {
 		t.Fatalf("unable to recive revocation: %v", err)
 	}
@@ -6576,7 +6648,9 @@ func TestForceCloseBorkedState(t *testing.T) {
 
 	// At this point, all channel mutating methods should now fail as they
 	// shouldn't be able to proceed if the channel is borked.
-	_, _, _, _, err = aliceChannel.ReceiveRevocation(revokeMsg)
+	_, _, _, _, err = aliceChannel.ReceiveRevocation(
+		revokeMsg, channeldb.LockedInTime{},
+	)
 	if err != channeldb.ErrChanBorked {
 		t.Fatalf("advance commitment tail should have failed")
 	}

--- a/lnwallet/test_utils.go
+++ b/lnwallet/test_utils.go
@@ -513,9 +513,13 @@ func ForceStateTransition(chanA, chanB *LightningChannel) error {
 		return err
 	}
 
-	if _, _, _, _, err := chanA.ReceiveRevocation(bobRevocation); err != nil {
+	_, _, _, _, err = chanA.ReceiveRevocation(
+		bobRevocation, channeldb.LockedInTime{},
+	)
+	if err != nil {
 		return err
 	}
+
 	if err := chanA.ReceiveNewCommitment(bobSig, bobHtlcSigs); err != nil {
 		return err
 	}
@@ -524,7 +528,10 @@ func ForceStateTransition(chanA, chanB *LightningChannel) error {
 	if err != nil {
 		return err
 	}
-	if _, _, _, _, err := chanB.ReceiveRevocation(aliceRevocation); err != nil {
+	_, _, _, _, err = chanB.ReceiveRevocation(
+		aliceRevocation, channeldb.LockedInTime{},
+	)
+	if err != nil {
 		return err
 	}
 


### PR DESCRIPTION
This PR stores the block height and wall clock time when a forwarding package was locked in. The locked-in time of an htlc add is useful for at least the following fixes/improvements:
* #3186 where the accepted block height needs to be reported for the extended `incorrect_or_unknown_payment_details` failure message. The accepted height needs to be consistent across restarts.
* Multi-path payments where a maximum (wall clock) hold duration will be implemented.