### PR TITLE
Update INSTALL.md to include first wallet creation

### DIFF
--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -12,6 +12,7 @@
     * [Running lnd using the btcd backend](#running-lnd-using-the-btcd-backend)
   * [Using Neutrino](#using-neutrino)
   * [Using bitcoind or litecoind](#using-bitcoind-or-litecoind)
+* [Creating a Wallet](#creating-a-wallet)
 * [Macaroons](#macaroons)
 * [Network Reachability](#network-reachability)
 * [Simnet vs. Testnet Development](#simnet-vs-testnet-development)
@@ -363,6 +364,20 @@ lnd --bitcoin.active --bitcoin.testnet --debuglevel=debug --bitcoin.node=bitcoin
   the default `bitcoind` settings, having more than one instance of `lnd`, or
   `lnd` plus any application that consumes the RPC could cause `lnd` to miss
   crucial updates from the backend.
+
+
+# Creating a wallet
+If `lnd` is being run for the first time, create a new wallet with:
+```
+lncli create
+```
+This will prompt for a wallet password, and optionally a cipher seed
+passphrase.
+
+`lnd` will then print a 24 word cipher seed mnemonic, which can be used to
+recover the wallet in case of data loss. The user should write this down and
+keep in a safe place.
+
 
 # Macaroons
 


### PR DESCRIPTION
Add 'Creating a wallet' section, explaining that 'lncli create' must be run
with a new instance. Also describe the password prompt and mnemonic this
command presents to the user.