### PR TITLE
tlv: fix panic with large length

### DIFF
--- a/tlv/stream.go
+++ b/tlv/stream.go
@@ -6,11 +6,17 @@ import (
 	"io"
 	"io/ioutil"
 	"math"
+
+	"github.com/lightningnetwork/lnd/lnwire"
 )
 
 // ErrStreamNotCanonical signals that a decoded stream does not contain records
 // sorting by monotonically-increasing type.
 var ErrStreamNotCanonical = errors.New("tlv stream is not canonical")
+
+// ErrRecordTooLarge signals that a decoded record has a length that is too
+// long to parse.
+var ErrRecordTooLarge = errors.New("record is too large")
 
 // ErrUnknownRequiredType is an error returned when decoding an unknown and even
 // type from a Stream.
@@ -181,6 +187,10 @@ func (s *Stream) Decode(r io.Reader) error {
 		// Other unexpected errors.
 		case err != nil:
 			return err
+		}
+
+		if length > lnwire.MaxMessagePayload {
+			return ErrRecordTooLarge
 		}
 
 		// Search the records known to the stream for this type. We'll


### PR DESCRIPTION
This commit fixes a panic where a very large length (i.e. 3472328296227680304) in a `*[]byte` record could cause the `DVarBytes` function to fail to allocate a byte slice:
```
panic: runtime error: makeslice: len out of range

goroutine 1 [running]:
github.com/lightningnetwork/lnd/tlv.DVarBytes(0x128db80, 0xc000072180, 0x1116b80, 0xc0000bc0a0, 0xc00000cb78, 0x3030303030303030, 0x0, 0xc000010200)
	/var/folders/hd/zc89l1qn4h10b3hmg4nm4pzh0000gn/T/go-fuzz-build482742472/gopath/src/github.com/lightningnetwork/lnd/tlv/primitive.go:304 +0xac
github.com/lightningnetwork/lnd/tlv.(*Stream).Decode(0xc00000cb60, 0x128db80, 0xc000072180, 0xc00000cb60, 0xc0000bc0a0)
	/var/folders/hd/zc89l1qn4h10b3hmg4nm4pzh0000gn/T/go-fuzz-build482742472/gopath/src/github.com/lightningnetwork/lnd/tlv/stream.go:197 +0x519
github.com/lightningnetwork/lnd/fuzz/tlv.Fuzz(0x4010000, 0xa, 0x200000, 0xc0000adf58)
	/var/folders/hd/zc89l1qn4h10b3hmg4nm4pzh0000gn/T/go-fuzz-build482742472/gopath/src/github.com/lightningnetwork/lnd/fuzz/tlv/serialization.go:59 +0x81c
go-fuzz-dep.Main(0x1271a30)
	/var/folders/hd/zc89l1qn4h10b3hmg4nm4pzh0000gn/T/go-fuzz-build482742472/goroot/src/go-fuzz-dep/main.go:54 +0xb6
main.main()
	/var/folders/hd/zc89l1qn4h10b3hmg4nm4pzh0000gn/T/go-fuzz-build482742472/gopath/src/github.com/lightningnetwork/lnd/fuzz/tlv/go.fuzz.main/main.go:10 +0x2d
```

I also found that with large, but acceptable, length values specified, making the byte slice could take a long time (~138 seconds on my machine with length `14297912573952`) so this should mitigate that since a sane value is now required.