### PR TITLE
tlv: limit decoded record size

### DIFF
--- a/tlv/stream.go
+++ b/tlv/stream.go
@@ -6,11 +6,17 @@ import (
 	"io"
 	"io/ioutil"
 	"math"
+
+	"github.com/lightningnetwork/lnd/lnwire"
 )
 
 // ErrStreamNotCanonical signals that a decoded stream does not contain records
 // sorting by monotonically-increasing type.
 var ErrStreamNotCanonical = errors.New("tlv stream is not canonical")
+
+// ErrRecordTooLarge signals that a decoded record has a length that is too
+// long to parse.
+var ErrRecordTooLarge = errors.New("record is too large")
 
 // ErrUnknownRequiredType is an error returned when decoding an unknown and even
 // type from a Stream.
@@ -181,6 +187,10 @@ func (s *Stream) Decode(r io.Reader) error {
 		// Other unexpected errors.
 		case err != nil:
 			return err
+		}
+
+		if length > lnwire.MaxMessagePayload {
+			return ErrRecordTooLarge
 		}
 
 		// Search the records known to the stream for this type. We'll

--- a/tlv/tlv_test.go
+++ b/tlv/tlv_test.go
@@ -49,6 +49,8 @@ type N1 struct {
 	nodeAmts  nodeAmts
 	cltvDelta uint16
 
+	alias []byte
+
 	stream *tlv.Stream
 }
 
@@ -66,6 +68,7 @@ func NewN1() *N1 {
 		tlv.MakePrimitiveRecord(2, &n.scid),
 		tlv.MakeStaticRecord(3, &n.nodeAmts, 49, ENodeAmts, DNodeAmts),
 		tlv.MakePrimitiveRecord(254, &n.cltvDelta),
+		tlv.MakePrimitiveRecord(401, &n.alias),
 	)
 
 	return n
@@ -395,6 +398,12 @@ var tlvDecodingFailureTests = []struct {
 		name:   "type wraparound",
 		bytes:  []byte{0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0x00, 0x00},
 		expErr: tlv.ErrStreamNotCanonical,
+	},
+	{
+		name:   "absurd record length",
+		bytes:  []byte{0xfd, 0x01, 0x91, 0xfe, 0xff, 0xff, 0xff, 0xff},
+		expErr: tlv.ErrRecordTooLarge,
+		skipN2: true,
 	},
 }
 


### PR DESCRIPTION
Builds on #3407, which contains the original report and fix by @Crypt-iQ. Primary difference is the addition of a test that confirms the fix works.

Supercedes #3407 