### PR TITLE
cmd/lncli: return error upon missing channel backup when parsing

### DIFF
--- a/cmd/lncli/commands.go
+++ b/cmd/lncli/commands.go
@@ -1567,12 +1567,12 @@ mnemonicCheck:
 		"RESTORE THE WALLET!!!")
 
 	// We'll also check to see if they provided any static channel backups,
-	// if so, then we'll also tack these onto the final innit wallet
-	// request.
+	// if so, then we'll also tack these onto the final init wallet request.
+	// We can ignore the errMissingChanBackup error as it's an optional
+	// field.
 	backups, err := parseChanBackups(ctx)
-	if err != nil {
-		return fmt.Errorf("unable to parse chan "+
-			"backups: %v", err)
+	if err != nil && err != errMissingChanBackup {
+		return fmt.Errorf("unable to parse chan backups: %v", err)
 	}
 
 	var chanBackups *lnrpc.ChanBackupSnapshot
@@ -3931,6 +3931,10 @@ var restoreChanBackupCommand = cli.Command{
 	Action: actionDecorator(restoreChanBackup),
 }
 
+// errMissingChanBackup is an error returned when we attempt to parse a channel
+// backup from a CLI command and it is missing.
+var errMissingChanBackup = errors.New("missing channel backup")
+
 func parseChanBackups(ctx *cli.Context) (*lnrpc.RestoreChanBackupRequest, error) {
 	switch {
 	case ctx.IsSet("single_backup"):
@@ -3983,7 +3987,7 @@ func parseChanBackups(ctx *cli.Context) (*lnrpc.RestoreChanBackupRequest, error)
 		}, nil
 
 	default:
-		return nil, nil
+		return nil, errMissingChanBackup
 	}
 }
 


### PR DESCRIPTION
Fixes https://github.com/lightningnetwork/lnd/issues/3452.