### PR TITLE
Add rpclisten to start-lnd.sh

### DIFF
--- a/docker/lnd/start-lnd.sh
+++ b/docker/lnd/start-lnd.sh
@@ -59,5 +59,6 @@ exec lnd \
     "--$BACKEND.rpchost"="blockchain" \
     "--$BACKEND.rpcuser"="$RPCUSER" \
     "--$BACKEND.rpcpass"="$RPCPASS" \
+    "--rpclisten=0.0.0.0:10009" \
     --debuglevel="$DEBUG" \
     "$@"


### PR DESCRIPTION
To make it possible to communicate over gRPC with an instance running in Docker we need to expose the correct RPC interface.

See #3453 
