### PR TITLE
tlv+htlcswitch: validate presence/omission of parsed onion payload types

### DIFF
--- a/htlcswitch/hop/payload.go
+++ b/htlcswitch/hop/payload.go
@@ -53,7 +53,7 @@ func NewPayloadFromReader(r io.Reader) (*Payload, error) {
 		return nil, err
 	}
 
-	err = tlvStream.Decode(r)
+	_, err = tlvStream.DecodeWithParsedTypes(r)
 	if err != nil {
 		return nil, err
 	}

--- a/htlcswitch/hop/payload.go
+++ b/htlcswitch/hop/payload.go
@@ -2,6 +2,7 @@ package hop
 
 import (
 	"encoding/binary"
+	"fmt"
 	"io"
 
 	"github.com/lightningnetwork/lightning-onion"
@@ -9,6 +10,37 @@ import (
 	"github.com/lightningnetwork/lnd/record"
 	"github.com/lightningnetwork/lnd/tlv"
 )
+
+// ErrInvalidPayload is an error returned when a parsed onion payload either
+// included or omitted incorrect records for a particular hop type.
+type ErrInvalidPayload struct {
+	// Type the record's type that cause the violation.
+	Type tlv.Type
+
+	// Ommitted if true, signals that the sender did not include the record.
+	// Otherwise, the sender included the record when it shouldn't have.
+	Omitted bool
+
+	// FinalHop if true, indicates that the violation is for the final hop
+	// in the route (identified by next hop id), otherwise the violation is
+	// for an intermediate hop.
+	FinalHop bool
+}
+
+// Error returns a human-readable description of the invalid payload error.
+func (e ErrInvalidPayload) Error() string {
+	hopType := "intermediate"
+	if e.FinalHop {
+		hopType = "final"
+	}
+	violation := "included"
+	if e.Omitted {
+		violation = "omitted"
+	}
+
+	return fmt.Sprintf("onion payload for %s hop %s record with type %d",
+		hopType, violation, e.Type)
+}
 
 // Payload encapsulates all information delivered to a hop in an onion payload.
 // A Hop can represent either a TLV or legacy payload. The primary forwarding
@@ -53,7 +85,16 @@ func NewPayloadFromReader(r io.Reader) (*Payload, error) {
 		return nil, err
 	}
 
-	_, err = tlvStream.DecodeWithParsedTypes(r)
+	parsedTypes, err := tlvStream.DecodeWithParsedTypes(r)
+	if err != nil {
+		return nil, err
+	}
+
+	nextHop := lnwire.NewShortChanIDFromInt(cid)
+
+	// Validate whether the sender properly included or omitted tlv records
+	// in accordance with BOLT 04.
+	err = ValidateParsedPayloadTypes(parsedTypes, nextHop)
 	if err != nil {
 		return nil, err
 	}
@@ -61,7 +102,7 @@ func NewPayloadFromReader(r io.Reader) (*Payload, error) {
 	return &Payload{
 		FwdInfo: ForwardingInfo{
 			Network:         BitcoinNetwork,
-			NextHop:         lnwire.NewShortChanIDFromInt(cid),
+			NextHop:         nextHop,
 			AmountToForward: lnwire.MilliSatoshi(amt),
 			OutgoingCTLV:    cltv,
 		},
@@ -72,4 +113,49 @@ func NewPayloadFromReader(r io.Reader) (*Payload, error) {
 // e.g. amount, cltv, and next hop.
 func (h *Payload) ForwardingInfo() ForwardingInfo {
 	return h.FwdInfo
+}
+
+// ValidateParsedPayloadTypes checks the types parsed from a hop payload to
+// ensure that the proper fields are either included or omitted. The finalHop
+// boolean should be true if the payload was parsed for an exit hop. The
+// requirements for this method are described in BOLT 04.
+func ValidateParsedPayloadTypes(parsedTypes tlv.TypeSet,
+	nextHop lnwire.ShortChannelID) error {
+
+	isFinalHop := nextHop == Exit
+
+	_, hasAmt := parsedTypes[record.AmtOnionType]
+	_, hasLockTime := parsedTypes[record.LockTimeOnionType]
+	_, hasNextHop := parsedTypes[record.NextHopOnionType]
+
+	switch {
+
+	// All hops must include an amount to forward.
+	case !hasAmt:
+		return ErrInvalidPayload{
+			Type:     record.AmtOnionType,
+			Omitted:  true,
+			FinalHop: isFinalHop,
+		}
+
+	// All hops must include a cltv expiry.
+	case !hasLockTime:
+		return ErrInvalidPayload{
+			Type:     record.LockTimeOnionType,
+			Omitted:  true,
+			FinalHop: isFinalHop,
+		}
+
+	// The exit hop should omit the next hop id. If nextHop != Exit, the
+	// sender must have included a record, so we don't need to test for its
+	// inclusion at intermediate hops directly.
+	case isFinalHop && hasNextHop:
+		return ErrInvalidPayload{
+			Type:     record.NextHopOnionType,
+			Omitted:  false,
+			FinalHop: true,
+		}
+	}
+
+	return nil
 }

--- a/htlcswitch/hop/payload_test.go
+++ b/htlcswitch/hop/payload_test.go
@@ -1,0 +1,89 @@
+package hop_test
+
+import (
+	"bytes"
+	"reflect"
+	"testing"
+
+	"github.com/lightningnetwork/lnd/htlcswitch/hop"
+	"github.com/lightningnetwork/lnd/record"
+)
+
+type decodePayloadTest struct {
+	name    string
+	payload []byte
+	expErr  error
+}
+
+var decodePayloadTests = []decodePayloadTest{
+	{
+		name:    "final hop no amount",
+		payload: []byte{0x04, 0x00},
+		expErr: hop.ErrInvalidPayload{
+			Type:     record.AmtOnionType,
+			Omitted:  true,
+			FinalHop: true,
+		},
+	},
+	{
+		name: "intermediate hop no amount",
+		payload: []byte{0x04, 0x00, 0x06, 0x08, 0x01, 0x00, 0x00, 0x00,
+			0x00, 0x00, 0x00, 0x00,
+		},
+		expErr: hop.ErrInvalidPayload{
+			Type:     record.AmtOnionType,
+			Omitted:  true,
+			FinalHop: false,
+		},
+	},
+	{
+		name:    "final hop no expiry",
+		payload: []byte{0x02, 0x00},
+		expErr: hop.ErrInvalidPayload{
+			Type:     record.LockTimeOnionType,
+			Omitted:  true,
+			FinalHop: true,
+		},
+	},
+	{
+		name: "intermediate hop no expiry",
+		payload: []byte{0x02, 0x00, 0x06, 0x08, 0x01, 0x00, 0x00, 0x00,
+			0x00, 0x00, 0x00, 0x00,
+		},
+		expErr: hop.ErrInvalidPayload{
+			Type:     record.LockTimeOnionType,
+			Omitted:  true,
+			FinalHop: false,
+		},
+	},
+	{
+		name: "final hop next sid present",
+		payload: []byte{0x02, 0x00, 0x04, 0x00, 0x06, 0x08, 0x00, 0x00,
+			0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+		},
+		expErr: hop.ErrInvalidPayload{
+			Type:     record.NextHopOnionType,
+			Omitted:  false,
+			FinalHop: true,
+		},
+	},
+}
+
+// TestDecodeHopPayloadRecordValidation asserts that parsing the payloads in the
+// tests yields the expected errors depending on whether the proper fields were
+// included or omitted.
+func TestDecodeHopPayloadRecordValidation(t *testing.T) {
+	for _, test := range decodePayloadTests {
+		t.Run(test.name, func(t *testing.T) {
+			testDecodeHopPayloadValidation(t, test)
+		})
+	}
+}
+
+func testDecodeHopPayloadValidation(t *testing.T, test decodePayloadTest) {
+	_, err := hop.NewPayloadFromReader(bytes.NewReader(test.payload))
+	if !reflect.DeepEqual(test.expErr, err) {
+		t.Fatalf("expected error mismatch, want: %v, got: %v",
+			test.expErr, err)
+	}
+}

--- a/tlv/record.go
+++ b/tlv/record.go
@@ -12,6 +12,9 @@ import (
 // Type is an 64-bit identifier for a TLV Record.
 type Type uint64
 
+// TypeSet is an unordered set of Types.
+type TypeSet map[Type]struct{}
+
 // Encoder is a signature for methods that can encode TLV values. An error
 // should be returned if the Encoder cannot support the underlying type of val.
 // The provided scratch buffer must be non-nil.

--- a/tlv/stream_test.go
+++ b/tlv/stream_test.go
@@ -1,0 +1,51 @@
+package tlv_test
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/lightningnetwork/lnd/tlv"
+)
+
+// TestParsedTypes asserts that a Stream will properly return the set of types
+// that it encounters when the type is known-and-decoded or unknown-and-ignored.
+func TestParsedTypes(t *testing.T) {
+	const (
+		knownType   = 1
+		unknownType = 3
+	)
+
+	// Construct a stream that will encode two types, one that will be known
+	// to the decoder and another that will be unknown.
+	encStream := tlv.MustNewStream(
+		tlv.MakePrimitiveRecord(knownType, new(uint64)),
+		tlv.MakePrimitiveRecord(unknownType, new(uint64)),
+	)
+
+	var b bytes.Buffer
+	if err := encStream.Encode(&b); err != nil {
+		t.Fatalf("unable to encode stream: %v", err)
+	}
+
+	// Create a stream that will parse only the known type.
+	decStream := tlv.MustNewStream(
+		tlv.MakePrimitiveRecord(knownType, new(uint64)),
+	)
+
+	parsedTypes, err := decStream.DecodeWithParsedTypes(
+		bytes.NewReader(b.Bytes()),
+	)
+	if err != nil {
+		t.Fatalf("unable to decode stream: %v", err)
+	}
+
+	// Assert that both the known and unknown types are included in the set
+	// of parsed types.
+	if _, ok := parsedTypes[knownType]; !ok {
+		t.Fatalf("known type %d should be in parsed types", knownType)
+	}
+	if _, ok := parsedTypes[unknownType]; !ok {
+		t.Fatalf("unknown type %d should be in parsed types",
+			unknownType)
+	}
+}


### PR DESCRIPTION
Builds on #3441 

This commit adds an additional return value to `Stream.Decode`, which
returns the set of types that were encountered during decoding. The set
will contain all known types that were decoded, as well as unknown odd
types that were ignored.

The rationale for the return value (rather than an internal member) is
so that the stream remains stateless.

This return value can be used by callers during decoding to make
assertions as to whether specific types were included in the stream.
This is need, for example, when parsing onion payloads where certain
fields must be included/omitted depending on the hop type.