### PR TITLE
htlcswitch/hop: new package for hop payload parsing/encapsulation

### DIFF
--- a/htlcswitch/circuit_map.go
+++ b/htlcswitch/circuit_map.go
@@ -9,6 +9,7 @@ import (
 	"github.com/davecgh/go-spew/spew"
 	"github.com/go-errors/errors"
 	"github.com/lightningnetwork/lnd/channeldb"
+	"github.com/lightningnetwork/lnd/htlcswitch/hop"
 	"github.com/lightningnetwork/lnd/lnwire"
 )
 
@@ -311,7 +312,7 @@ func (cm *circuitMap) restoreMemState() error {
 			// documented case of stray keystones emerges for
 			// forwarded payments, this check should be removed, but
 			// with extreme caution.
-			if strayKeystone.OutKey.ChanID != sourceHop {
+			if strayKeystone.OutKey.ChanID != hop.Source {
 				continue
 			}
 
@@ -396,9 +397,9 @@ func (cm *circuitMap) trimAllOpenCircuits() error {
 
 		// First, skip any channels that have not been assigned their
 		// final channel identifier, otherwise we would try to trim
-		// htlcs belonging to the all-zero, sourceHop ID.
+		// htlcs belonging to the all-zero, hop.Source ID.
 		chanID := activeChannel.ShortChanID()
-		if chanID == sourceHop {
+		if chanID == hop.Source {
 			continue
 		}
 

--- a/htlcswitch/hop/forwarding_info.go
+++ b/htlcswitch/hop/forwarding_info.go
@@ -1,0 +1,29 @@
+package hop
+
+import (
+	"github.com/lightningnetwork/lnd/lnwire"
+)
+
+// ForwardingInfo contains all the information that is necessary to forward and
+// incoming HTLC to the next hop encoded within a valid HopIterator instance.
+// Forwarding links are to use this information to authenticate the information
+// received within the incoming HTLC, to ensure that the prior hop didn't
+// tamper with the end-to-end routing information at all.
+type ForwardingInfo struct {
+	// Network is the target blockchain network that the HTLC will travel
+	// over next.
+	Network Network
+
+	// NextHop is the channel ID of the next hop. The received HTLC should
+	// be forwarded to this particular channel in order to continue the
+	// end-to-end route.
+	NextHop lnwire.ShortChannelID
+
+	// AmountToForward is the amount of milli-satoshis that the receiving
+	// node should forward to the next hop.
+	AmountToForward lnwire.MilliSatoshi
+
+	// OutgoingCTLV is the specified value of the CTLV timelock to be used
+	// in the outgoing HTLC.
+	OutgoingCTLV uint32
+}

--- a/htlcswitch/hop/network.go
+++ b/htlcswitch/hop/network.go
@@ -1,0 +1,28 @@
+package hop
+
+// Network indicates the blockchain network that is intended to be the next hop
+// for a forwarded HTLC. The existence of this field within the ForwardingInfo
+// struct enables the ability for HTLC to cross chain-boundaries at will.
+type Network uint8
+
+const (
+	// BitcoinNetwork denotes that an HTLC is to be forwarded along the
+	// Bitcoin link with the specified short channel ID.
+	BitcoinNetwork Network = iota
+
+	// LitecoinNetwork denotes that an HTLC is to be forwarded along the
+	// Litecoin link with the specified short channel ID.
+	LitecoinNetwork
+)
+
+// String returns the string representation of the target Network.
+func (c Network) String() string {
+	switch c {
+	case BitcoinNetwork:
+		return "Bitcoin"
+	case LitecoinNetwork:
+		return "Litecoin"
+	default:
+		return "Kekcoin"
+	}
+}

--- a/htlcswitch/hop/payload.go
+++ b/htlcswitch/hop/payload.go
@@ -1,0 +1,75 @@
+package hop
+
+import (
+	"encoding/binary"
+	"io"
+
+	"github.com/lightningnetwork/lightning-onion"
+	"github.com/lightningnetwork/lnd/lnwire"
+	"github.com/lightningnetwork/lnd/record"
+	"github.com/lightningnetwork/lnd/tlv"
+)
+
+// Payload encapsulates all information delivered to a hop in an onion payload.
+// A Hop can represent either a TLV or legacy payload. The primary forwarding
+// instruction can be accessed via ForwardingInfo, and additional records can be
+// accessed by other member functions.
+type Payload struct {
+	// FwdInfo holds the basic parameters required for HTLC forwarding, e.g.
+	// amount, cltv, and next hop.
+	FwdInfo ForwardingInfo
+}
+
+// NewLegacyPayload builds a Payload from the amount, cltv, and next hop
+// parameters provided by leegacy onion payloads.
+func NewLegacyPayload(f *sphinx.HopData) *Payload {
+	nextHop := binary.BigEndian.Uint64(f.NextAddress[:])
+
+	return &Payload{
+		FwdInfo: ForwardingInfo{
+			Network:         BitcoinNetwork,
+			NextHop:         lnwire.NewShortChanIDFromInt(nextHop),
+			AmountToForward: lnwire.MilliSatoshi(f.ForwardAmount),
+			OutgoingCTLV:    f.OutgoingCltv,
+		},
+	}
+}
+
+// NewPayloadFromReader builds a new Hop from the passed io.Reader. The reader
+// should correspond to the bytes encapsulated in a TLV onion payload.
+func NewPayloadFromReader(r io.Reader) (*Payload, error) {
+	var (
+		cid  uint64
+		amt  uint64
+		cltv uint32
+	)
+
+	tlvStream, err := tlv.NewStream(
+		record.NewAmtToFwdRecord(&amt),
+		record.NewLockTimeRecord(&cltv),
+		record.NewNextHopIDRecord(&cid),
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	err = tlvStream.Decode(r)
+	if err != nil {
+		return nil, err
+	}
+
+	return &Payload{
+		FwdInfo: ForwardingInfo{
+			Network:         BitcoinNetwork,
+			NextHop:         lnwire.NewShortChanIDFromInt(cid),
+			AmountToForward: lnwire.MilliSatoshi(amt),
+			OutgoingCTLV:    cltv,
+		},
+	}, nil
+}
+
+// ForwardingInfo returns the basic parameters required for HTLC forwarding,
+// e.g. amount, cltv, and next hop.
+func (h *Payload) ForwardingInfo() ForwardingInfo {
+	return h.FwdInfo
+}

--- a/htlcswitch/hop/type.go
+++ b/htlcswitch/hop/type.go
@@ -1,0 +1,13 @@
+package hop
+
+import "github.com/lightningnetwork/lnd/lnwire"
+
+var (
+	// Exit is a special "hop" denoting that an incoming HTLC is meant to
+	// pay finally to the receiving node.
+	Exit lnwire.ShortChannelID
+
+	// Source is a sentinel "hop" denoting that an incoming HTLC is
+	// initiated by our own switch.
+	Source lnwire.ShortChannelID
+)

--- a/htlcswitch/iterator.go
+++ b/htlcswitch/iterator.go
@@ -2,7 +2,6 @@ package htlcswitch
 
 import (
 	"bytes"
-	"encoding/binary"
 	"fmt"
 	"io"
 
@@ -10,8 +9,6 @@ import (
 	"github.com/lightningnetwork/lightning-onion"
 	"github.com/lightningnetwork/lnd/htlcswitch/hop"
 	"github.com/lightningnetwork/lnd/lnwire"
-	"github.com/lightningnetwork/lnd/record"
-	"github.com/lightningnetwork/lnd/tlv"
 )
 
 // HopIterator is an interface that abstracts away the routing information
@@ -85,64 +82,32 @@ func (r *sphinxHopIterator) EncodeNextHop(w io.Writer) error {
 func (r *sphinxHopIterator) ForwardingInstructions() (
 	hop.ForwardingInfo, error) {
 
-	var (
-		nextHop lnwire.ShortChannelID
-		amt     uint64
-		cltv    uint32
-	)
-
 	switch r.processedPacket.Payload.Type {
 	// If this is the legacy payload, then we'll extract the information
 	// directly from the pre-populated ForwardingInstructions field.
 	case sphinx.PayloadLegacy:
 		fwdInst := r.processedPacket.ForwardingInstructions
+		p := hop.NewLegacyPayload(fwdInst)
 
-		switch r.processedPacket.Action {
-		case sphinx.ExitNode:
-			nextHop = hop.Exit
-		case sphinx.MoreHops:
-			s := binary.BigEndian.Uint64(fwdInst.NextAddress[:])
-			nextHop = lnwire.NewShortChanIDFromInt(s)
-		}
-
-		amt = fwdInst.ForwardAmount
-		cltv = fwdInst.OutgoingCltv
+		return p.ForwardingInfo(), nil
 
 	// Otherwise, if this is the TLV payload, then we'll make a new stream
 	// to decode only what we need to make routing decisions.
 	case sphinx.PayloadTLV:
-		var cid uint64
-
-		tlvStream, err := tlv.NewStream(
-			record.NewAmtToFwdRecord(&amt),
-			record.NewLockTimeRecord(&cltv),
-			record.NewNextHopIDRecord(&cid),
-		)
-		if err != nil {
-			return hop.ForwardingInfo{}, err
-		}
-
-		err = tlvStream.Decode(bytes.NewReader(
+		p, err := hop.NewPayloadFromReader(bytes.NewReader(
 			r.processedPacket.Payload.Payload,
 		))
 		if err != nil {
 			return hop.ForwardingInfo{}, err
 		}
 
-		nextHop = lnwire.NewShortChanIDFromInt(cid)
+		return p.ForwardingInfo(), nil
 
 	default:
 		return hop.ForwardingInfo{}, fmt.Errorf("unknown "+
 			"sphinx payload type: %v",
 			r.processedPacket.Payload.Type)
 	}
-
-	return hop.ForwardingInfo{
-		Network:         hop.BitcoinNetwork,
-		NextHop:         nextHop,
-		AmountToForward: lnwire.MilliSatoshi(amt),
-		OutgoingCTLV:    cltv,
-	}, nil
 }
 
 // ExtraOnionBlob returns the additional EOB data (if available).

--- a/htlcswitch/iterator.go
+++ b/htlcswitch/iterator.go
@@ -14,16 +14,6 @@ import (
 	"github.com/lightningnetwork/lnd/tlv"
 )
 
-var (
-	// exitHop is a special "hop" which denotes that an incoming HTLC is
-	// meant to pay finally to the receiving node.
-	exitHop lnwire.ShortChannelID
-
-	// sourceHop is a sentinel value denoting that an incoming HTLC is
-	// initiated by our own switch.
-	sourceHop lnwire.ShortChannelID
-)
-
 // HopIterator is an interface that abstracts away the routing information
 // included in HTLC's which includes the entirety of the payment path of an
 // HTLC. This interface provides two basic method which carry out: how to
@@ -109,7 +99,7 @@ func (r *sphinxHopIterator) ForwardingInstructions() (
 
 		switch r.processedPacket.Action {
 		case sphinx.ExitNode:
-			nextHop = exitHop
+			nextHop = hop.Exit
 		case sphinx.MoreHops:
 			s := binary.BigEndian.Uint64(fwdInst.NextAddress[:])
 			nextHop = lnwire.NewShortChanIDFromInt(s)

--- a/htlcswitch/iterator.go
+++ b/htlcswitch/iterator.go
@@ -8,38 +8,11 @@ import (
 
 	"github.com/btcsuite/btcd/btcec"
 	"github.com/lightningnetwork/lightning-onion"
+	"github.com/lightningnetwork/lnd/htlcswitch/hop"
 	"github.com/lightningnetwork/lnd/lnwire"
 	"github.com/lightningnetwork/lnd/record"
 	"github.com/lightningnetwork/lnd/tlv"
 )
-
-// NetworkHop indicates the blockchain network that is intended to be the next
-// hop for a forwarded HTLC. The existence of this field within the
-// ForwardingInfo struct enables the ability for HTLC to cross chain-boundaries
-// at will.
-type NetworkHop uint8
-
-const (
-	// BitcoinHop denotes that an HTLC is to be forwarded along the Bitcoin
-	// link with the specified short channel ID.
-	BitcoinHop NetworkHop = iota
-
-	// LitecoinHop denotes that an HTLC is to be forwarded along the
-	// Litecoin link with the specified short channel ID.
-	LitecoinHop
-)
-
-// String returns the string representation of the target NetworkHop.
-func (c NetworkHop) String() string {
-	switch c {
-	case BitcoinHop:
-		return "Bitcoin"
-	case LitecoinHop:
-		return "Litecoin"
-	default:
-		return "Kekcoin"
-	}
-}
 
 var (
 	// exitHop is a special "hop" which denotes that an incoming HTLC is
@@ -59,7 +32,7 @@ var (
 type ForwardingInfo struct {
 	// Network is the target blockchain network that the HTLC will travel
 	// over next.
-	Network NetworkHop
+	Network hop.Network
 
 	// NextHop is the channel ID of the next hop. The received HTLC should
 	// be forwarded to this particular channel in order to continue the
@@ -199,7 +172,7 @@ func (r *sphinxHopIterator) ForwardingInstructions() (ForwardingInfo, error) {
 	}
 
 	return ForwardingInfo{
-		Network:         BitcoinHop,
+		Network:         hop.BitcoinNetwork,
 		NextHop:         nextHop,
 		AmountToForward: lnwire.MilliSatoshi(amt),
 		OutgoingCTLV:    cltv,

--- a/htlcswitch/iterator_test.go
+++ b/htlcswitch/iterator_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/davecgh/go-spew/spew"
 	sphinx "github.com/lightningnetwork/lightning-onion"
+	"github.com/lightningnetwork/lnd/htlcswitch/hop"
 	"github.com/lightningnetwork/lnd/lnwire"
 	"github.com/lightningnetwork/lnd/record"
 	"github.com/lightningnetwork/lnd/tlv"
@@ -29,7 +30,7 @@ func TestSphinxHopIteratorForwardingInstructions(t *testing.T) {
 	// Next, we'll make the hop forwarding information that we should
 	// extract each type, no matter the payload type.
 	nextAddrInt := binary.BigEndian.Uint64(hopData.NextAddress[:])
-	expectedFwdInfo := ForwardingInfo{
+	expectedFwdInfo := hop.ForwardingInfo{
 		NextHop:         lnwire.NewShortChanIDFromInt(nextAddrInt),
 		AmountToForward: lnwire.MilliSatoshi(hopData.ForwardAmount),
 		OutgoingCTLV:    hopData.OutgoingCltv,
@@ -53,7 +54,7 @@ func TestSphinxHopIteratorForwardingInstructions(t *testing.T) {
 
 	var testCases = []struct {
 		sphinxPacket    *sphinx.ProcessedPacket
-		expectedFwdInfo ForwardingInfo
+		expectedFwdInfo hop.ForwardingInfo
 	}{
 		// A regular legacy payload that signals more hops.
 		{

--- a/htlcswitch/link.go
+++ b/htlcswitch/link.go
@@ -16,6 +16,7 @@ import (
 	"github.com/lightningnetwork/lnd/channeldb"
 	"github.com/lightningnetwork/lnd/contractcourt"
 	"github.com/lightningnetwork/lnd/htlcswitch/hodl"
+	"github.com/lightningnetwork/lnd/htlcswitch/hop"
 	"github.com/lightningnetwork/lnd/input"
 	"github.com/lightningnetwork/lnd/invoices"
 	"github.com/lightningnetwork/lnd/lnpeer"
@@ -2849,7 +2850,7 @@ func (l *channelLink) processRemoteAdds(fwdPkg *channeldb.FwdPkg,
 // processExitHop handles an htlc for which this link is the exit hop. It
 // returns a boolean indicating whether the commitment tx needs an update.
 func (l *channelLink) processExitHop(pd *lnwallet.PaymentDescriptor,
-	obfuscator ErrorEncrypter, fwdInfo ForwardingInfo,
+	obfuscator ErrorEncrypter, fwdInfo hop.ForwardingInfo,
 	heightNow uint32, eob []byte) (bool, error) {
 
 	// If hodl.ExitSettle is requested, we will not validate the final hop's

--- a/htlcswitch/link.go
+++ b/htlcswitch/link.go
@@ -437,8 +437,8 @@ func (l *channelLink) Start() error {
 	// off point, since all indexes below that are committed. This action
 	// is only performed if the link's final short channel ID has been
 	// assigned, otherwise we would try to trim the htlcs belonging to the
-	// all-zero, sourceHop ID.
-	if l.ShortChanID() != sourceHop {
+	// all-zero, hop.Source ID.
+	if l.ShortChanID() != hop.Source {
 		localHtlcIndex, err := l.channel.NextLocalHtlcIndex()
 		if err != nil {
 			return fmt.Errorf("unable to retrieve next local "+
@@ -536,7 +536,7 @@ func (l *channelLink) WaitForShutdown() {
 // the all-zero source ID, meaning that the channel has had its ID finalized.
 func (l *channelLink) EligibleToForward() bool {
 	return l.channel.RemoteNextRevocation() != nil &&
-		l.ShortChanID() != sourceHop
+		l.ShortChanID() != hop.Source
 }
 
 // sampleNetworkFee samples the current fee rate on the network to get into the
@@ -962,7 +962,7 @@ func (l *channelLink) htlcManager() {
 	// only attempt to resolve packages if our short chan id indicates that
 	// the channel is not pending, otherwise we should have no htlcs to
 	// reforward.
-	if l.ShortChanID() != sourceHop {
+	if l.ShortChanID() != hop.Source {
 		if err := l.resolveFwdPkgs(); err != nil {
 			l.fail(LinkFailureError{code: ErrInternalError},
 				"unable to resolve fwd pkgs: %v", err)
@@ -2076,7 +2076,7 @@ func (l *channelLink) UpdateShortChanID() (lnwire.ShortChannelID, error) {
 	if err != nil {
 		l.errorf("unable to refresh short_chan_id for chan_id=%v: %v",
 			chanID, err)
-		return sourceHop, err
+		return hop.Source, err
 	}
 
 	sid := l.channel.ShortChanID()
@@ -2675,7 +2675,7 @@ func (l *channelLink) processRemoteAdds(fwdPkg *channeldb.FwdPkg,
 		}
 
 		switch fwdInfo.NextHop {
-		case exitHop:
+		case hop.Exit:
 			updated, err := l.processExitHop(
 				pd, obfuscator, fwdInfo, heightNow,
 				chanIterator.ExtraOnionBlob(),

--- a/htlcswitch/link_test.go
+++ b/htlcswitch/link_test.go
@@ -4308,7 +4308,7 @@ func generateHtlcAndInvoice(t *testing.T,
 
 	htlcAmt := lnwire.NewMSatFromSatoshis(10000)
 	htlcExpiry := testStartingHeight + testInvoiceCltvExpiry
-	hops := []ForwardingInfo{
+	hops := []hop.ForwardingInfo{
 		{
 			Network:         hop.BitcoinNetwork,
 			NextHop:         exitHop,

--- a/htlcswitch/link_test.go
+++ b/htlcswitch/link_test.go
@@ -1937,7 +1937,7 @@ func TestChannelLinkBandwidthConsistency(t *testing.T) {
 	}
 	addPkt := htlcPacket{
 		htlc:           htlc,
-		incomingChanID: sourceHop,
+		incomingChanID: hop.Source,
 		incomingHTLCID: 0,
 		obfuscator:     NewMockObfuscator(),
 	}
@@ -2017,7 +2017,7 @@ func TestChannelLinkBandwidthConsistency(t *testing.T) {
 	}
 	addPkt = htlcPacket{
 		htlc:           htlc,
-		incomingChanID: sourceHop,
+		incomingChanID: hop.Source,
 		incomingHTLCID: 1,
 		obfuscator:     NewMockObfuscator(),
 	}
@@ -2535,7 +2535,7 @@ func genAddsAndCircuits(numHtlcs int, htlc *lnwire.UpdateAddHTLC) (
 	for i := 0; i < numHtlcs; i++ {
 		addPkt := htlcPacket{
 			htlc:           htlc,
-			incomingChanID: sourceHop,
+			incomingChanID: hop.Source,
 			incomingHTLCID: uint64(i),
 			obfuscator:     NewMockObfuscator(),
 		}
@@ -4311,7 +4311,7 @@ func generateHtlcAndInvoice(t *testing.T,
 	hops := []hop.ForwardingInfo{
 		{
 			Network:         hop.BitcoinNetwork,
-			NextHop:         exitHop,
+			NextHop:         hop.Exit,
 			AmountToForward: htlcAmt,
 			OutgoingCTLV:    uint32(htlcExpiry),
 		},

--- a/htlcswitch/link_test.go
+++ b/htlcswitch/link_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/lightningnetwork/lnd/channeldb"
 	"github.com/lightningnetwork/lnd/contractcourt"
 	"github.com/lightningnetwork/lnd/htlcswitch/hodl"
+	"github.com/lightningnetwork/lnd/htlcswitch/hop"
 	"github.com/lightningnetwork/lnd/input"
 	"github.com/lightningnetwork/lnd/lnpeer"
 	"github.com/lightningnetwork/lnd/lntypes"
@@ -4309,7 +4310,7 @@ func generateHtlcAndInvoice(t *testing.T,
 	htlcExpiry := testStartingHeight + testInvoiceCltvExpiry
 	hops := []ForwardingInfo{
 		{
-			Network:         BitcoinHop,
+			Network:         hop.BitcoinNetwork,
 			NextHop:         exitHop,
 			AmountToForward: htlcAmt,
 			OutgoingCTLV:    uint32(htlcExpiry),

--- a/htlcswitch/mock.go
+++ b/htlcswitch/mock.go
@@ -23,6 +23,7 @@ import (
 	"github.com/lightningnetwork/lnd/chainntnfs"
 	"github.com/lightningnetwork/lnd/channeldb"
 	"github.com/lightningnetwork/lnd/contractcourt"
+	"github.com/lightningnetwork/lnd/htlcswitch/hop"
 	"github.com/lightningnetwork/lnd/input"
 	"github.com/lightningnetwork/lnd/invoices"
 	"github.com/lightningnetwork/lnd/lnpeer"
@@ -485,7 +486,7 @@ func (f *ForwardingInfo) decode(r io.Reader) error {
 	if _, err := r.Read(net[:]); err != nil {
 		return err
 	}
-	f.Network = NetworkHop(net[0])
+	f.Network = hop.Network(net[0])
 
 	if err := binary.Read(r, binary.BigEndian, &f.NextHop); err != nil {
 		return err

--- a/htlcswitch/test_utils.go
+++ b/htlcswitch/test_utils.go
@@ -648,7 +648,7 @@ func generateHops(payAmt lnwire.MilliSatoshi, startingHeight uint32,
 	for i := len(path) - 1; i >= 0; i-- {
 		// If this is the last hop, then the next hop is the special
 		// "exit node". Otherwise, we look to the "prior" hop.
-		nextHop := exitHop
+		nextHop := hop.Exit
 		if i != len(path)-1 {
 			nextHop = path[i+1].channel.ShortChanID()
 		}

--- a/htlcswitch/test_utils.go
+++ b/htlcswitch/test_utils.go
@@ -25,6 +25,7 @@ import (
 	"github.com/go-errors/errors"
 	"github.com/lightningnetwork/lnd/channeldb"
 	"github.com/lightningnetwork/lnd/contractcourt"
+	"github.com/lightningnetwork/lnd/htlcswitch/hop"
 	"github.com/lightningnetwork/lnd/input"
 	"github.com/lightningnetwork/lnd/keychain"
 	"github.com/lightningnetwork/lnd/lnpeer"
@@ -680,7 +681,7 @@ func generateHops(payAmt lnwire.MilliSatoshi, startingHeight uint32,
 		}
 
 		hops[i] = ForwardingInfo{
-			Network:         BitcoinHop,
+			Network:         hop.BitcoinNetwork,
 			NextHop:         nextHop,
 			AmountToForward: amount,
 			OutgoingCTLV:    timeLock,

--- a/htlcswitch/test_utils.go
+++ b/htlcswitch/test_utils.go
@@ -597,7 +597,9 @@ func generatePayment(invoiceAmt, htlcAmt lnwire.MilliSatoshi, timelock uint32,
 }
 
 // generateRoute generates the path blob by given array of peers.
-func generateRoute(hops ...ForwardingInfo) ([lnwire.OnionPacketSize]byte, error) {
+func generateRoute(hops ...hop.ForwardingInfo) (
+	[lnwire.OnionPacketSize]byte, error) {
+
 	var blob [lnwire.OnionPacketSize]byte
 	if len(hops) == 0 {
 		return blob, errors.New("empty path")
@@ -636,12 +638,13 @@ type threeHopNetwork struct {
 // also the time lock value needed to route an HTLC with the target amount over
 // the specified path.
 func generateHops(payAmt lnwire.MilliSatoshi, startingHeight uint32,
-	path ...*channelLink) (lnwire.MilliSatoshi, uint32, []ForwardingInfo) {
+	path ...*channelLink) (lnwire.MilliSatoshi, uint32,
+	[]hop.ForwardingInfo) {
 
 	totalTimelock := startingHeight
 	runningAmt := payAmt
 
-	hops := make([]ForwardingInfo, len(path))
+	hops := make([]hop.ForwardingInfo, len(path))
 	for i := len(path) - 1; i >= 0; i-- {
 		// If this is the last hop, then the next hop is the special
 		// "exit node". Otherwise, we look to the "prior" hop.
@@ -680,7 +683,7 @@ func generateHops(payAmt lnwire.MilliSatoshi, startingHeight uint32,
 			amount = runningAmt - fee
 		}
 
-		hops[i] = ForwardingInfo{
+		hops[i] = hop.ForwardingInfo{
 			Network:         hop.BitcoinNetwork,
 			NextHop:         nextHop,
 			AmountToForward: amount,
@@ -732,7 +735,7 @@ func waitForPayFuncResult(payFunc func() error, d time.Duration) error {
 // * from Alice to Carol through the Bob
 // * from Alice to some another peer through the Bob
 func makePayment(sendingPeer, receivingPeer lnpeer.Peer,
-	firstHop lnwire.ShortChannelID, hops []ForwardingInfo,
+	firstHop lnwire.ShortChannelID, hops []hop.ForwardingInfo,
 	invoiceAmt, htlcAmt lnwire.MilliSatoshi,
 	timelock uint32) *paymentResponse {
 
@@ -766,7 +769,7 @@ func makePayment(sendingPeer, receivingPeer lnpeer.Peer,
 // preparePayment creates an invoice at the receivingPeer and returns a function
 // that, when called, launches the payment from the sendingPeer.
 func preparePayment(sendingPeer, receivingPeer lnpeer.Peer,
-	firstHop lnwire.ShortChannelID, hops []ForwardingInfo,
+	firstHop lnwire.ShortChannelID, hops []hop.ForwardingInfo,
 	invoiceAmt, htlcAmt lnwire.MilliSatoshi,
 	timelock uint32) (*channeldb.Invoice, func() error, error) {
 
@@ -1247,7 +1250,7 @@ func (n *twoHopNetwork) stop() {
 }
 
 func (n *twoHopNetwork) makeHoldPayment(sendingPeer, receivingPeer lnpeer.Peer,
-	firstHop lnwire.ShortChannelID, hops []ForwardingInfo,
+	firstHop lnwire.ShortChannelID, hops []hop.ForwardingInfo,
 	invoiceAmt, htlcAmt lnwire.MilliSatoshi,
 	timelock uint32, preimage lntypes.Preimage) chan error {
 


### PR DESCRIPTION
Builds on #3441 

This PR begins the process of moving our hop payload processing within lnd into its own subpackage, `htlcswitch/hop`. This will allow the processing to be imported into the `htlcswitch` and `contractcourt`, and also have a single `hop.Payload` object that can be shared with the invoice registry. The last four commits are predominately a code move, but it will be nice to make progress on the more trivial things so we can do less rebasing on #3442 

This will also allow @joostjager to add his follow up in moving the `HopIterator` components into this package, and establish a stable base to continue mpp/amp development