### PR TITLE
config: Add norest config for disabling REST API

### DIFF
--- a/config.go
+++ b/config.go
@@ -259,6 +259,7 @@ type config struct {
 	Listeners        []net.Addr
 	ExternalIPs      []net.Addr
 	DisableListen    bool          `long:"nolisten" description:"Disable listening for incoming peer connections"`
+	DisableRest      bool          `long:"norest" description:"Disable REST API"`
 	NAT              bool          `long:"nat" description:"Toggle NAT traversal support (using either UPnP or NAT-PMP) to automatically advertise your external IP address to the network -- NOTE this does not support devices behind multiple NATs"`
 	MinBackoff       time.Duration `long:"minbackoff" description:"Shortest backoff when reconnecting to persistent peers. Valid time units are {s, m, h}."`
 	MaxBackoff       time.Duration `long:"maxbackoff" description:"Longest backoff when reconnecting to persistent peers. Valid time units are {s, m, h}."`
@@ -1031,11 +1032,17 @@ func loadConfig() (*config, error) {
 	if err != nil {
 		return nil, err
 	}
-	err = lncfg.EnforceSafeAuthentication(
-		cfg.RESTListeners, !cfg.NoMacaroons,
-	)
-	if err != nil {
-		return nil, err
+
+	if cfg.DisableRest {
+		ltndLog.Infof("REST API is disabled!")
+		cfg.RESTListeners = nil
+	} else {
+		err = lncfg.EnforceSafeAuthentication(
+			cfg.RESTListeners, !cfg.NoMacaroons,
+		)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	// Remove the listening addresses specified if listening is disabled.

--- a/mobile/sample_lnd.conf
+++ b/mobile/sample_lnd.conf
@@ -3,6 +3,7 @@ debuglevel=info
 no-macaroons=1
 maxbackoff=2s
 nolisten=1
+norest=1
 
 [Routing]
 routing.assumechanvalid=1


### PR DESCRIPTION
This pull request adds a new config `norest` that disables the REST gRPC proxy API.  
The rationale behind it is that lndmobile projects (https://github.com/lightningnetwork/lnd/pull/3282)  do not need the TCP REST API as they're using in-mem gGRPC, but it could be useful for other applications and projects as well.  
Disabling it also makes sure that two different wallets do not collide with each other as they otherwise would do if they're both listening on the same interface/port:

```
[ERR] LTND: Unable to set up wallet password listeners: listen tcp4 127.0.0.1:8080: bind: address already in use
...
[INF] LTND: Shutdown complete
```

#### Pull Request Checklist

- [x] If this is your first time contributing, we recommend you read the [Code
  Contribution Guidelines](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md)
- [x] All changes are Go version 1.12 compliant
- [x] The code being submitted is commented according to [Code Documentation and Commenting](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#CodeDocumentation)
- [ ] For new code: Code is accompanied by tests which exercise both
  the positive and negative (error paths) conditions (if applicable)
- [ ] For bug fixes: Code is accompanied by new tests which trigger
  the bug being fixed to prevent regressions
- [x] Any new logging statements use an appropriate subsystem and
  logging level
- [x] Code has been formatted with `go fmt`
- [x] For code and documentation: lines are wrapped at 80 characters
  (the tab character should be counted as 8 characters, not 4, as some IDEs do
  per default)
- [ ] Running `make check` does not fail any tests
- [x] Running `go vet` does not report any issues
- [x] Running `make lint` does not report any **new** issues that did not
  already exist
- [x] All commits build properly and pass tests. Only in exceptional
  cases it can be justifiable to violate this condition. In that case, the
  reason should be stated in the commit message.
- [x] Commits have a logical structure according to [Ideal Git Commit Structure](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#IdealGitCommitStructure)
