### PR TITLE
trivial: fix log message in initAutoPilot

### DIFF
--- a/pilot.go
+++ b/pilot.go
@@ -141,10 +141,10 @@ var _ autopilot.ChannelController = (*chanController)(nil)
 // and all interfaces needed to drive it won't be launched before the Manager's
 // StartAgent method is called.
 func initAutoPilot(svr *server, cfg *autoPilotConfig) (*autopilot.ManagerCfg, error) {
-	atplLog.Infof("Instantiating autopilot with max_channels=%d, "+
-		"allocation=%f, min_chan_size=%d, max_chan_size=%d, "+
-		"private=%t, min_confs=%d, conf_target=%d", cfg.MaxChannels,
-		cfg.MinChannelSize, cfg.Private, cfg.MinConfs, cfg.ConfTarget)
+	atplLog.Infof("Instantiating autopilot with max_channels=%d, allocation=%f, "+
+		"min_chan_size=%d, max_chan_size=%d, private=%t, min_confs=%d, "+
+		"conf_target=%d", cfg.MaxChannels, cfg.Allocation, cfg.MinChannelSize,
+		cfg.MaxChannelSize, cfg.Private, cfg.MinConfs, cfg.ConfTarget)
 
 	// Set up the constraints the autopilot heuristics must adhere to.
 	atplConstraints := autopilot.NewConstraints(


### PR DESCRIPTION
This PR adds a couple of missing variables in log message in initAutoPilot method.