### PR TITLE
channeldb: return errors instead of nil 

### DIFF
--- a/channeldb/channel.go
+++ b/channeldb/channel.go
@@ -1870,7 +1870,7 @@ func (c *OpenChannel) CommitmentHeight() (uint64, error) {
 		return nil
 	})
 	if err != nil {
-		return 0, nil
+		return 0, err
 	}
 
 	return height, nil

--- a/channeldb/graph.go
+++ b/channeldb/graph.go
@@ -2256,7 +2256,7 @@ func (c *ChannelGraph) HasLightningNode(nodePub [33]byte) (time.Time, bool, erro
 		return nil
 	})
 	if err != nil {
-		return time.Time{}, exists, nil
+		return time.Time{}, exists, err
 	}
 
 	return updateTime, exists, nil

--- a/channeldb/invoices.go
+++ b/channeldb/invoices.go
@@ -372,7 +372,7 @@ func (d *DB) AddInvoice(newInvoice *Invoice, paymentHash lntypes.Hash) (
 			byteOrder.PutUint32(scratch[:], invoiceNum)
 			err := invoiceIndex.Put(numInvoicesKey, scratch[:])
 			if err != nil {
-				return nil
+				return err
 			}
 		} else {
 			invoiceNum = byteOrder.Uint32(invoiceCounter)

--- a/channeldb/payment_control.go
+++ b/channeldb/payment_control.go
@@ -138,7 +138,7 @@ func (p *PaymentControl) InitPayment(paymentHash lntypes.Hash,
 		return bucket.Delete(paymentFailInfoKey)
 	})
 	if err != nil {
-		return nil
+		return err
 	}
 
 	return updateErr


### PR DESCRIPTION
This PR fixes a bug where errors are checked, but not returned.