### PR TITLE
lntest: use filepath.Abs for lnd binary path

### DIFF
--- a/lntest/node.go
+++ b/lntest/node.go
@@ -345,7 +345,11 @@ func (hn *HarnessNode) start(lndError chan<- error) error {
 	hn.quit = make(chan struct{})
 
 	args := hn.cfg.genArgs()
-	hn.cmd = exec.Command("../../lnd-itest", args...)
+	binaryPath, err := filepath.Abs("../../lnd-itest")
+	if err != nil {
+		return err
+	}
+	hn.cmd = exec.Command(binaryPath, args...)
 
 	// Redirect stderr output to buffer
 	var errb bytes.Buffer


### PR DESCRIPTION
In this commit, we fix a bug that meant the integration tests weren't
able to be run on windows platforms. Before this commit, we manually
constructed a file path, using the regular unix based file path
delimiters. As a result, this wasn't done in a portable way , meaning
that the tests would only run on unix based systems. We resolve this by
using `filepath.Join` which will produce the proper path depending on
the host operating system.
