### PR TITLE
channeldb: fix migration bug due to interplay between migration #9 an…

### DIFF
--- a/channeldb/migrations.go
+++ b/channeldb/migrations.go
@@ -845,7 +845,7 @@ func migrateOutgoingPayments(tx *bbolt.Tx) error {
 		}
 
 		var attemptBuf bytes.Buffer
-		if err := serializePaymentAttemptInfo(&attemptBuf, s); err != nil {
+		if err := serializePaymentAttemptInfoMigration9(&attemptBuf, s); err != nil {
 			return err
 		}
 


### PR DESCRIPTION
…d #10

In this commit, we fix an issue that was recently introduced as a result
of migration #10. The new TLV format ended up modifying the
serialization functions called in `serializePaymentAttemptInfo`.
Migration #9, also used this `serializePaymentAttemptInfo` method to
serialize the _new_ (pre TLV, but new payment attempt structure) routes
into the database during its migration. However, migration #10 failed to
copy over the existing unmodified `serializePaymentAttemptInfo` method
into the legacy serialization for migration #9. As a result, once
migration #9 was run, the routes/payments were serialized using the
_new_ format, rather than the format used for v0.7.1. This then lead to
de-serialization either failing, or causing partial payment corruption
as migration #10 was expecting the "legacy" format (no TLV info).

We fix this issue by adding a new fully enclosed
`serializePaymentAttemptInfoMigration9`method that will be used for
migration #9. Note that our tests didn't catch this, as they test the
migration in isolation, rather than in series which is how users will
encounter the migrations.
