### PR TITLE
contractcourt: supplement resolvers with confirmed commit set HTLCs

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -45,6 +45,16 @@ linters:
   # trigger funlen problems that we may not want to solve at that time.
   - funlen
 
+  # Disable for now as we haven't yet tuned the sensitivity to our codebase
+  # yet.  Enabling by default for example, would also force new contributors to
+  # potentially extensively refactor code, when they want to smaller change to
+  # land.
+  - gocyclo
+
+  # Instances of table driven tests that don't pre-allocate shouldn't trigger
+  # the linter.
+  - prealloc
+
 issues:
   # Only show newly introduced problems.
   new-from-rev: 01f696afce2f9c0d4ed854edefa3846891d01d8a


### PR DESCRIPTION
In this commit, we fix an existing bug in the package, causing
resolutions to be restarted without their required supplementary
information. This can happen if a distinct HTLC set gets confirmed
compared to the HTLCs that we may have had our commitment at time of
close. Due to this bug, on restart certain HTLCS would be rejected as
they would present their state to the invoice registry, but be rejected
due to checks such as amount value.

To fix this, we'll now pass in the set of confirmed HTLCs into the
resolvers when we re-launch them, giving us access to all the
information we need to supplement the HTLCS.

