### PR TITLE
Fixed dockerfile by adding version numbers to base containers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:alpine as builder
+FROM golang:1.13-alpine as builder
 
 # Force Go to use the cgo based DNS resolver. This is required to ensure DNS
 # queries required to connect to linked containers succeed.
@@ -34,4 +34,3 @@ EXPOSE 9735 10009
 
 # Specify the start command and entrypoint as the lnd daemon.
 ENTRYPOINT ["lnd"]
-CMD ["lnd"]


### PR DESCRIPTION
The latest golang docker images is based on golang 13. lnd does not compile with golang 13 docker image. It is a good practice to specify version information in the Dockerfile. This ensures, that the correct docker image is used. I also removed the CMD, because in this case it is redundant to ENTRYPOINT.

If possible it would be great, to have the latest images available at docker hub as well. ATM there is a very old image at Docker hub, that did not worked for me.

/legacycode