### PR TITLE
channeldb: ensure test for migration 9 is fully enclosed

### DIFF
--- a/channeldb/migrations_test.go
+++ b/channeldb/migrations_test.go
@@ -626,7 +626,7 @@ func TestOutgoingPaymentsMigration(t *testing.T) {
 			t.Fatal("migration 'paymentStatusesMigration' wasn't applied")
 		}
 
-		sentPayments, err := d.FetchPayments()
+		sentPayments, err := d.fetchPaymentsMigration9()
 		if err != nil {
 			t.Fatalf("unable to fetch sent payments: %v", err)
 		}


### PR DESCRIPTION
In this commit, we ensure that the test for migration 9 uses the same
encoding/decoding functions as was present in the repo when the
migration was first added. Otherwise, the test will fail as it'll try to
use the decoding functions of master (migration 10 and onwards) rather
than the decoding function of migration 9.

