### PR TITLE
htlcswitch/hop: fix logging

### DIFF
--- a/htlcswitch/log.go
+++ b/htlcswitch/log.go
@@ -16,7 +16,6 @@ func init() {
 	logger := build.NewSubLogger("HSWC", nil)
 
 	UseLogger(logger)
-	hop.UseLogger(logger)
 }
 
 // DisableLog disables all library log output.  Logging output is disabled
@@ -30,6 +29,7 @@ func DisableLog() {
 // using btclog.
 func UseLogger(logger btclog.Logger) {
 	log = logger
+	hop.UseLogger(logger)
 }
 
 // logClosure is used to provide a closure over expensive logging operations so


### PR DESCRIPTION
Logging for the hop package is controlled via the parent htlcswitch
package. Unfortunately the parent package only controlled the
initialization, but didn't enable the logger when the log level came
in from the main lnd package.