### PR TITLE
itest: Shutdown final Dave node in testChanRestore

### DIFF
--- a/lntest/itest/lnd_test.go
+++ b/lntest/itest/lnd_test.go
@@ -13405,7 +13405,11 @@ func testChanRestoreScenario(t *harnessTest, net *lntest.NetworkHarness,
 	if err != nil {
 		t.Fatalf("unable to create new node: %v", err)
 	}
-	defer shutdownAndAssert(net, t, dave)
+	// Defer to a closure instead of to shutdownAndAssert due to the value
+	// of 'dave' changing throughout the test.
+	defer func() {
+		shutdownAndAssert(net, t, dave)
+	}()
 	carol, err := net.NewNode("carol", nil)
 	if err != nil {
 		t.Fatalf("unable to make new node: %v", err)


### PR DESCRIPTION
This changes the defer function in the test for channel backups to
correctly close over the 'dave' variable.

Without this closure, the shutdownAndAssert call would attempt to
shutdown the original (non-restored) dave instead of the most recently
created (restored) dave, causing a leak of a node during tests.

The simplest(ish) way to verify this is the case is by counting the number of online `lnd-itest` processes before and after the `channel_backup_restore` icase runs. After that test, there should be 4 additional online nodes without this fix.
