### PR TITLE
cnct: do not log resolver shutting down as error

### DIFF
--- a/contractcourt/channel_arbitrator.go
+++ b/contractcourt/channel_arbitrator.go
@@ -1866,6 +1866,10 @@ func (c *ChannelArbitrator) resolveContract(currentContract ContractResolver) {
 			// contract.
 			nextContract, err := currentContract.Resolve()
 			if err != nil {
+				if err == errResolverShuttingDown {
+					return
+				}
+
 				log.Errorf("ChannelArbitrator(%v): unable to "+
 					"progress resolver: %v",
 					c.cfg.ChanPoint, err)

--- a/contractcourt/contract_resolvers.go
+++ b/contractcourt/contract_resolvers.go
@@ -2,6 +2,7 @@ package contractcourt
 
 import (
 	"encoding/binary"
+	"errors"
 	"io"
 )
 
@@ -83,3 +84,9 @@ type ResolverKit struct {
 
 	Quit chan struct{}
 }
+
+var (
+	// errResolverShuttingDown is returned when the resolver stops
+	// progressing because it received the quit signal.
+	errResolverShuttingDown = errors.New("resolver shutting down")
+)

--- a/contractcourt/htlc_incoming_contest_resolver.go
+++ b/contractcourt/htlc_incoming_contest_resolver.go
@@ -3,7 +3,6 @@ package contractcourt
 import (
 	"encoding/binary"
 	"errors"
-	"fmt"
 	"io"
 
 	"github.com/lightningnetwork/lnd/channeldb"
@@ -66,11 +65,11 @@ func (h *htlcIncomingContestResolver) Resolve() (ContractResolver, error) {
 	select {
 	case newBlock, ok := <-blockEpochs.Epochs:
 		if !ok {
-			return nil, fmt.Errorf("quitting")
+			return nil, errResolverShuttingDown
 		}
 		currentHeight = newBlock.Height
 	case <-h.Quit:
-		return nil, fmt.Errorf("resolver stopped")
+		return nil, errResolverShuttingDown
 	}
 
 	// We'll first check if this HTLC has been timed out, if so, we can
@@ -224,7 +223,7 @@ func (h *htlcIncomingContestResolver) Resolve() (ContractResolver, error) {
 
 		case newBlock, ok := <-blockEpochs.Epochs:
 			if !ok {
-				return nil, fmt.Errorf("quitting")
+				return nil, errResolverShuttingDown
 			}
 
 			// If this new height expires the HTLC, then this means
@@ -241,7 +240,7 @@ func (h *htlcIncomingContestResolver) Resolve() (ContractResolver, error) {
 			}
 
 		case <-h.Quit:
-			return nil, fmt.Errorf("resolver stopped")
+			return nil, errResolverShuttingDown
 		}
 	}
 }

--- a/contractcourt/htlc_outgoing_contest_resolver.go
+++ b/contractcourt/htlc_outgoing_contest_resolver.go
@@ -65,7 +65,7 @@ func (h *htlcOutgoingContestResolver) Resolve() (ContractResolver, error) {
 	// sweep the pre-image from the output.
 	case commitSpend, ok := <-spendNtfn.Spend:
 		if !ok {
-			return nil, fmt.Errorf("quitting")
+			return nil, errResolverShuttingDown
 		}
 
 		// TODO(roasbeef): Checkpoint?
@@ -122,7 +122,7 @@ func (h *htlcOutgoingContestResolver) Resolve() (ContractResolver, error) {
 		// HTLC expiration.
 		case newBlock, ok := <-blockEpochs.Epochs:
 			if !ok {
-				return nil, fmt.Errorf("quitting")
+				return nil, errResolverShuttingDown
 			}
 
 			// If this new height expires the HTLC, then we can
@@ -142,7 +142,7 @@ func (h *htlcOutgoingContestResolver) Resolve() (ContractResolver, error) {
 		// revealed on-chain.
 		case commitSpend, ok := <-spendNtfn.Spend:
 			if !ok {
-				return nil, fmt.Errorf("quitting")
+				return nil, errResolverShuttingDown
 			}
 
 			// The only way this output can be spent by the remote

--- a/contractcourt/htlc_success_resolver.go
+++ b/contractcourt/htlc_success_resolver.go
@@ -2,7 +2,6 @@ package contractcourt
 
 import (
 	"encoding/binary"
-	"fmt"
 	"io"
 
 	"github.com/btcsuite/btcd/wire"
@@ -171,11 +170,11 @@ func (h *htlcSuccessResolver) Resolve() (ContractResolver, error) {
 		select {
 		case _, ok := <-confNtfn.Confirmed:
 			if !ok {
-				return nil, fmt.Errorf("quitting")
+				return nil, errResolverShuttingDown
 			}
 
 		case <-h.Quit:
-			return nil, fmt.Errorf("quitting")
+			return nil, errResolverShuttingDown
 		}
 
 		// Once the transaction has received a sufficient number of
@@ -236,11 +235,11 @@ func (h *htlcSuccessResolver) Resolve() (ContractResolver, error) {
 	select {
 	case _, ok := <-spendNtfn.Spend:
 		if !ok {
-			return nil, fmt.Errorf("quitting")
+			return nil, errResolverShuttingDown
 		}
 
 	case <-h.Quit:
-		return nil, fmt.Errorf("quitting")
+		return nil, errResolverShuttingDown
 	}
 
 	h.resolved = true

--- a/contractcourt/htlc_timeout_resolver.go
+++ b/contractcourt/htlc_timeout_resolver.go
@@ -271,11 +271,11 @@ func (h *htlcTimeoutResolver) Resolve() (ContractResolver, error) {
 		select {
 		case _, ok := <-spendNtfn.Spend:
 			if !ok {
-				return fmt.Errorf("notifier quit")
+				return errResolverShuttingDown
 			}
 
 		case <-h.Quit:
-			return fmt.Errorf("quitting")
+			return errResolverShuttingDown
 		}
 
 		return nil
@@ -309,11 +309,11 @@ func (h *htlcTimeoutResolver) Resolve() (ContractResolver, error) {
 	select {
 	case spend, ok = <-spendNtfn.Spend:
 		if !ok {
-			return nil, fmt.Errorf("quitting")
+			return nil, errResolverShuttingDown
 		}
 
 	case <-h.Quit:
-		return nil, fmt.Errorf("quitting")
+		return nil, errResolverShuttingDown
 	}
 
 	// If the spend reveals the pre-image, then we'll enter the clean up


### PR DESCRIPTION
Small change that contributes to the end goal of being able to run the integration tests without errors.