### PR TITLE
cnct: do not create an action for incoming dust htlcs

### DIFF
--- a/contractcourt/channel_arbitrator.go
+++ b/contractcourt/channel_arbitrator.go
@@ -1871,8 +1871,8 @@ func (c *ChannelArbitrator) resolveContract(currentContract ContractResolver) {
 				}
 
 				log.Errorf("ChannelArbitrator(%v): unable to "+
-					"progress resolver: %v",
-					c.cfg.ChanPoint, err)
+					"progress %T: %v",
+					c.cfg.ChanPoint, currentContract, err)
 				return
 			}
 

--- a/contractcourt/channel_arbitrator.go
+++ b/contractcourt/channel_arbitrator.go
@@ -1316,6 +1316,15 @@ func (c *ChannelArbitrator) checkCommitChainActions(height uint32,
 	// either learn of it eventually from the outgoing HTLC, or the sender
 	// will timeout the HTLC.
 	for _, htlc := range htlcs.incomingHTLCs {
+		// If the HTLC is dust, there is no action to be taken.
+		if htlc.OutputIndex < 0 {
+			log.Debugf("ChannelArbitrator(%v): no resolution "+
+				"needed for incoming dust htlc=%x",
+				c.cfg.ChanPoint, htlc.RHash[:])
+
+			continue
+		}
+
 		log.Tracef("ChannelArbitrator(%v): watching chain to decide "+
 			"action for incoming htlc=%x", c.cfg.ChanPoint,
 			htlc.RHash[:])

--- a/contractcourt/channel_arbitrator_test.go
+++ b/contractcourt/channel_arbitrator_test.go
@@ -527,8 +527,15 @@ func TestChannelArbitratorLocalForceClosePendingHtlc(t *testing.T) {
 		OutputIndex: -1,
 	}
 
+	incomingDustHtlc := channeldb.HTLC{
+		Incoming:    true,
+		Amt:         105,
+		HtlcIndex:   101,
+		OutputIndex: -1,
+	}
+
 	htlcSet := []channeldb.HTLC{
-		htlc, outgoingDustHtlc,
+		htlc, outgoingDustHtlc, incomingDustHtlc,
 	}
 
 	htlcUpdates <- &ContractUpdate{


### PR DESCRIPTION
Fixes the 'unable to find incoming resolution' error that occured when trying to resolve incoming htlcs below the dust limit that are not actually present on the commitment tx.