### PR TITLE
channeldb Error Handling Fixes

### DIFF
--- a/channeldb/codec.go
+++ b/channeldb/codec.go
@@ -76,6 +76,7 @@ func WriteElement(w io.Writer, element interface{}) error {
 
 		if e.PubKey != nil {
 			if err := binary.Write(w, byteOrder, true); err != nil {
+				return fmt.Errorf("error writing serialized element: %s", err)
 			}
 
 			return WriteElement(w, e.PubKey)

--- a/channeldb/migrations.go
+++ b/channeldb/migrations.go
@@ -515,6 +515,9 @@ func migratePruneEdgeUpdateIndex(tx *bbolt.Tx) error {
 	// already exist given the assumption that the buckets above do as
 	// well.
 	edgeIndex, err := edges.CreateBucketIfNotExists(edgeIndexBucket)
+	if err != nil {
+		return fmt.Errorf("error creating edge index bucket: %s", err)
+	}
 	if edgeIndex == nil {
 		return fmt.Errorf("unable to create/fetch edge index " +
 			"bucket")

--- a/channeldb/migrations_test.go
+++ b/channeldb/migrations_test.go
@@ -839,6 +839,9 @@ func TestPaymentRouteSerialization(t *testing.T) {
 					payHashBucket, err = paymentsBucket.CreateBucket(
 						payInfo.PaymentHash[:],
 					)
+					if err != nil {
+						t.Fatalf("unable to create payments bucket: %v", err)
+					}
 				} else {
 					payHashBucket = paymentsBucket.Bucket(
 						payInfo.PaymentHash[:],

--- a/channeldb/waitingproof_test.go
+++ b/channeldb/waitingproof_test.go
@@ -16,7 +16,7 @@ func TestWaitingProofStore(t *testing.T) {
 
 	db, cleanup, err := makeTestDB()
 	if err != nil {
-
+		t.Fatalf("failed to make test database: %s", err)
 	}
 	defer cleanup()
 


### PR DESCRIPTION
channeldb: Fix dropped error and wrap with context
channeldb: Fix empty error condition in waitingproof test
channeldb: Fix empty error condition in codec
channeldb: Fix dropped error in migrations test

Some of these errors were previously dropped through the omission of `if err != nil...` blocks, others look to have been intentionally short-circuited at some point. 