### PR TITLE
updated guide to include cleaning go module cache

### DIFF
--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -106,6 +106,11 @@ related dependencies run the following commands:
 ```
 go get -d github.com/lightningnetwork/lnd
 cd $GOPATH/src/github.com/lightningnetwork/lnd
+```
+
+Then clean the module cache and make install:
+```
+go clean -modcache
 make && make install
 ```
 
@@ -138,6 +143,7 @@ commands:
 ```
 cd $GOPATH/src/github.com/lightningnetwork/lnd
 git pull
+go clean -modcache
 make clean && make && make install
 ```
 
@@ -148,6 +154,7 @@ used directly:
 ```
 cd $GOPATH/src/github.com/lightningnetwork/lnd
 git pull
+go clean -modcache
 GO111MODULE=on go install -v ./...
 ```
 


### PR DESCRIPTION
I had a problem with compiling (#3492) that was fixed by clearing the module cache. I added `go clean -modcach` to the guide with the thought that it would be good practice to prevent issues.

#### Pull Request Checklist

- [ ] If this is your first time contributing, we recommend you read the [Code
  Contribution Guidelines](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md)
- [ ] All changes are Go version 1.12 compliant
- [ ] The code being submitted is commented according to [Code Documentation and Commenting](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#CodeDocumentation)
- [ ] For new code: Code is accompanied by tests which exercise both
  the positive and negative (error paths) conditions (if applicable)
- [ ] For bug fixes: Code is accompanied by new tests which trigger
  the bug being fixed to prevent regressions
- [ ] Any new logging statements use an appropriate subsystem and
  logging level
- [ ] Code has been formatted with `go fmt`
- [ ] For code and documentation: lines are wrapped at 80 characters
  (the tab character should be counted as 8 characters, not 4, as some IDEs do
  per default)
- [ ] Running `make check` does not fail any tests
- [ ] Running `go vet` does not report any issues
- [ ] Running `make lint` does not report any **new** issues that did not
  already exist
- [ ] All commits build properly and pass tests. Only in exceptional
  cases it can be justifiable to violate this condition. In that case, the
  reason should be stated in the commit message.
- [ ] Commits have a logical structure according to [Ideal Git Commit Structure](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#IdealGitCommitStructure)
