### PR TITLE
Cross-Project Sweep to Fix Dropped Test Errors

### DIFF
--- a/breacharbiter_test.go
+++ b/breacharbiter_test.go
@@ -1762,12 +1762,20 @@ func createInitChannels(revocationWindow int) (*lnwallet.LightningChannel, *lnwa
 	}
 
 	alicePath, err := ioutil.TempDir("", "alicedb")
+	if err != nil {
+		return nil, nil, nil, err
+	}
+
 	dbAlice, err := channeldb.Open(alicePath)
 	if err != nil {
 		return nil, nil, nil, err
 	}
 
 	bobPath, err := ioutil.TempDir("", "bobdb")
+	if err != nil {
+		return nil, nil, nil, err
+	}
+
 	dbBob, err := channeldb.Open(bobPath)
 	if err != nil {
 		return nil, nil, nil, err

--- a/contractcourt/briefcase_test.go
+++ b/contractcourt/briefcase_test.go
@@ -358,6 +358,9 @@ func TestContractInsertionRetrieval(t *testing.T) {
 		t.Fatalf("unable to wipe log: %v", err)
 	}
 	diskResolvers, err = testLog.FetchUnresolvedContracts()
+	if err != nil {
+		t.Fatalf("unable to fetch unresolved contracts: %v", err)
+	}
 	if len(diskResolvers) != 0 {
 		t.Fatalf("no resolvers should be found, instead %v were",
 			len(diskResolvers))
@@ -611,6 +614,9 @@ func TestStateMutation(t *testing.T) {
 	// If we try to query for the state again, we should get the default
 	// state again.
 	arbState, err = testLog.CurrentState()
+	if err != nil {
+		t.Fatalf("unable to query current state: %v", err)
+	}
 	if arbState != StateDefault {
 		t.Fatalf("state mismatch: expected %v, got %v", StateDefault,
 			arbState)

--- a/htlcswitch/payment_result_test.go
+++ b/htlcswitch/payment_result_test.go
@@ -100,6 +100,10 @@ func TestNetworkResultStore(t *testing.T) {
 	const numResults = 4
 
 	tempDir, err := ioutil.TempDir("", "testdb")
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	db, err := channeldb.Open(tempDir)
 	if err != nil {
 		t.Fatal(err)

--- a/htlcswitch/test_utils.go
+++ b/htlcswitch/test_utils.go
@@ -264,12 +264,20 @@ func createTestChannel(alicePrivKey, bobPrivKey []byte,
 	}
 
 	alicePath, err := ioutil.TempDir("", "alicedb")
+	if err != nil {
+		return nil, nil, nil, err
+	}
+
 	dbAlice, err := channeldb.Open(alicePath)
 	if err != nil {
 		return nil, nil, nil, err
 	}
 
 	bobPath, err := ioutil.TempDir("", "bobdb")
+	if err != nil {
+		return nil, nil, nil, err
+	}
+
 	dbBob, err := channeldb.Open(bobPath)
 	if err != nil {
 		return nil, nil, nil, err

--- a/invoices/invoiceregistry_test.go
+++ b/invoices/invoiceregistry_test.go
@@ -329,6 +329,9 @@ func TestHoldInvoice(t *testing.T) {
 	defer timeout(t)()
 
 	cdb, cleanup, err := newDB()
+	if err != nil {
+		t.Fatal(err)
+	}
 	defer cleanup()
 
 	// Instantiate and start the invoice registry.

--- a/lnwallet/test_utils.go
+++ b/lnwallet/test_utils.go
@@ -208,12 +208,20 @@ func CreateTestChannels() (*LightningChannel, *LightningChannel, func(), error) 
 	}
 
 	alicePath, err := ioutil.TempDir("", "alicedb")
+	if err != nil {
+		return nil, nil, nil, err
+	}
+
 	dbAlice, err := channeldb.Open(alicePath)
 	if err != nil {
 		return nil, nil, nil, err
 	}
 
 	bobPath, err := ioutil.TempDir("", "bobdb")
+	if err != nil {
+		return nil, nil, nil, err
+	}
+
 	dbBob, err := channeldb.Open(bobPath)
 	if err != nil {
 		return nil, nil, nil, err

--- a/macaroons/service_test.go
+++ b/macaroons/service_test.go
@@ -45,6 +45,9 @@ func setupTestRootKeyStorage(t *testing.T) string {
 	}
 	defer store.Close()
 	err = store.CreateUnlock(&defaultPw)
+	if err != nil {
+		t.Fatalf("error creating unlock: %v", err)
+	}
 	return tempDir
 }
 

--- a/routing/pathfind_test.go
+++ b/routing/pathfind_test.go
@@ -1421,6 +1421,9 @@ func TestRouteFailMaxHTLC(t *testing.T) {
 	// Next, update the middle edge policy to only allow payments up to 100k
 	// msat.
 	_, midEdge, _, err := graph.graph.FetchChannelEdgesByID(firstToSecondID)
+	if err != nil {
+		t.Fatalf("unable to fetch channel edges by ID: %v", err)
+	}
 	midEdge.MessageFlags = 1
 	midEdge.MaxHTLC = payAmt - 1
 	if err := graph.graph.UpdateEdgePolicy(midEdge); err != nil {

--- a/routing/router_test.go
+++ b/routing/router_test.go
@@ -941,6 +941,9 @@ func TestAddProof(t *testing.T) {
 	}
 
 	info, _, _, err := ctx.router.GetChannelByID(*chanID)
+	if err != nil {
+		t.Fatalf("unable to get channel: %v", err)
+	}
 	if info.AuthProof == nil {
 		t.Fatal("proof have been updated")
 	}

--- a/test_utils.go
+++ b/test_utils.go
@@ -194,12 +194,20 @@ func createTestPeer(notifier chainntnfs.ChainNotifier,
 	}
 
 	alicePath, err := ioutil.TempDir("", "alicedb")
+	if err != nil {
+		return nil, nil, nil, nil, err
+	}
+
 	dbAlice, err := channeldb.Open(alicePath)
 	if err != nil {
 		return nil, nil, nil, nil, err
 	}
 
 	bobPath, err := ioutil.TempDir("", "bobdb")
+	if err != nil {
+		return nil, nil, nil, nil, err
+	}
+
 	dbBob, err := channeldb.Open(bobPath)
 	if err != nil {
 		return nil, nil, nil, nil, err


### PR DESCRIPTION
lnd: Fix dropped errors in tests.
routing: Fix dropped errors in tests.
contractcourt: Fix dropped errors in tests.
htlcswitch: Fix dropped errors in tests.
invoices: Fix dropped error in tests.
lnwallet: Fix dropped errors in tests.
macaroons: Fix dropped error in tests.

This PR fixes dropped error variables in tests across the project.