### PR TITLE
[trivial] make: default backend variable to btcd

### DIFF
--- a/make/testing_flags.mk
+++ b/make/testing_flags.mk
@@ -55,14 +55,12 @@ UNIT_RACE := $(UNIT) -race
 endif
 
 
-# Construct the integration test command with the added build flags.
-ITEST_TAGS := $(DEV_TAGS) rpctest chainrpc walletrpc signrpc invoicesrpc autopilotrpc routerrpc watchtowerrpc wtclientrpc
-
 # Default to btcd backend if not set.
-ifneq ($(backend),)
-ITEST_TAGS += ${backend}
-else
-ITEST_TAGS += btcd
+ifeq ($(backend),)
+backend = btcd
 endif
+
+# Construct the integration test command with the added build flags.
+ITEST_TAGS := $(DEV_TAGS) rpctest chainrpc walletrpc signrpc invoicesrpc autopilotrpc routerrpc watchtowerrpc wtclientrpc $(backend)
 
 ITEST := rm lntest/itest/*.log; date; $(GOTEST) ./lntest/itest -tags="$(ITEST_TAGS)" $(TEST_FLAGS) -logoutput -goroutinedump


### PR DESCRIPTION
This fixes the logging of used backend in the default (btcd) case.

Otherwise the `${backend}` variable would be left unset.
