### PR TITLE
Update Dockerfile go version to 1.13

### DIFF
--- a/docker/lnd/Dockerfile
+++ b/docker/lnd/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.12-alpine as builder
+FROM golang:1.13-alpine as builder
 
 MAINTAINER Olaoluwa Osuntokun <lightning.engineering>
 


### PR DESCRIPTION
New go minimum version required is 1.13 as per [this](https://github.com/lightningnetwork/lnd/pull/34589) change.
Docker build will fail due to missing trimpath.
