### PR TITLE
build+lnd: refactor reusable log file rotator code into build package

### DIFF
--- a/build/log.go
+++ b/build/log.go
@@ -1,7 +1,9 @@
 package build
 
 import (
+	"fmt"
 	"io"
+	"strings"
 
 	"github.com/btcsuite/btclog"
 )
@@ -92,4 +94,107 @@ func NewSubLogger(subsystem string,
 
 	// For any other configurations, we'll disable logging.
 	return btclog.Disabled
+}
+
+// SubLoggers is a type that holds a map of subsystem loggers keyed by their
+// subsystem name.
+type SubLoggers map[string]btclog.Logger
+
+// LeveledSubLogger provides the ability to retrieve the subsystem loggers of
+// a logger and set their log levels individually or all at once.
+type LeveledSubLogger interface {
+	// SubLoggers returns the map of all registered subsystem loggers.
+	SubLoggers() SubLoggers
+
+	// SupportedSubsystems returns a slice of strings containing the names
+	// of the supported subsystems. Should ideally correspond to the keys
+	// of the subsystem logger map and be sorted.
+	SupportedSubsystems() []string
+
+	// SetLogLevel assigns an individual subsystem logger a new log level.
+	SetLogLevel(subsystemID string, logLevel string)
+
+	// SetLogLevels assigns all subsystem loggers the same new log level.
+	SetLogLevels(logLevel string)
+}
+
+// ParseAndSetDebugLevels attempts to parse the specified debug level and set
+// the levels accordingly on the given logger. An appropriate error is returned
+// if anything is invalid.
+func ParseAndSetDebugLevels(level string, logger LeveledSubLogger) error {
+	// When the specified string doesn't have any delimiters, treat it as
+	// the log level for all subsystems.
+	if !strings.Contains(level, ",") && !strings.Contains(level, "=") {
+		// Validate debug log level.
+		if !validLogLevel(level) {
+			str := "the specified debug level [%v] is invalid"
+			return fmt.Errorf(str, level)
+		}
+
+		// Change the logging level for all subsystems.
+		logger.SetLogLevels(level)
+
+		return nil
+	}
+
+	// Split the specified string into subsystem/level pairs while detecting
+	// issues and update the log levels accordingly.
+	for _, logLevelPair := range strings.Split(level, ",") {
+		if !strings.Contains(logLevelPair, "=") {
+			str := "the specified debug level contains an " +
+				"invalid subsystem/level pair [%v]"
+			return fmt.Errorf(str, logLevelPair)
+		}
+
+		// Extract the specified subsystem and log level.
+		fields := strings.Split(logLevelPair, "=")
+		if len(fields) != 2 {
+			str := "the specified debug level has an invalid " +
+				"format [%v] -- use format subsystem1=level1," +
+				"subsystem2=level2"
+			return fmt.Errorf(str, logLevelPair)
+		}
+		subsysID, logLevel := fields[0], fields[1]
+		subLoggers := logger.SubLoggers()
+
+		// Validate subsystem.
+		if _, exists := subLoggers[subsysID]; !exists {
+			str := "the specified subsystem [%v] is invalid -- " +
+				"supported subsystems are %v"
+			return fmt.Errorf(
+				str, subsysID, logger.SupportedSubsystems(),
+			)
+		}
+
+		// Validate log level.
+		if !validLogLevel(logLevel) {
+			str := "the specified debug level [%v] is invalid"
+			return fmt.Errorf(str, logLevel)
+		}
+
+		logger.SetLogLevel(subsysID, logLevel)
+	}
+
+	return nil
+}
+
+// validLogLevel returns whether or not logLevel is a valid debug log level.
+func validLogLevel(logLevel string) bool {
+	switch logLevel {
+	case "trace":
+		fallthrough
+	case "debug":
+		fallthrough
+	case "info":
+		fallthrough
+	case "warn":
+		fallthrough
+	case "error":
+		fallthrough
+	case "critical":
+		fallthrough
+	case "off":
+		return true
+	}
+	return false
 }

--- a/build/logrotator.go
+++ b/build/logrotator.go
@@ -1,0 +1,151 @@
+package build
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+
+	"github.com/btcsuite/btclog"
+	"github.com/jrick/logrotate/rotator"
+)
+
+// RotatingLogWriter is a wrapper around the LogWriter that supports log file
+// rotation.
+type RotatingLogWriter struct {
+	// GenSubLogger is a function that returns a new logger for a subsystem
+	// belonging to the current RotatingLogWriter.
+	GenSubLogger func(string) btclog.Logger
+
+	logWriter *LogWriter
+
+	backendLog *btclog.Backend
+
+	logRotator *rotator.Rotator
+
+	subsystemLoggers SubLoggers
+}
+
+// A compile time check to ensure RotatingLogWriter implements the
+// LeveledSubLogger interface.
+var _ LeveledSubLogger = (*RotatingLogWriter)(nil)
+
+// NewRotatingLogWriter creates a new file rotating log writer.
+//
+// NOTE: `InitLogRotator` must be called to set up log rotation after creating
+// the writer.
+func NewRotatingLogWriter() *RotatingLogWriter {
+	logWriter := &LogWriter{}
+	backendLog := btclog.NewBackend(logWriter)
+	return &RotatingLogWriter{
+		GenSubLogger:     backendLog.Logger,
+		logWriter:        logWriter,
+		backendLog:       backendLog,
+		subsystemLoggers: SubLoggers{},
+	}
+}
+
+// RegisterSubLogger registers a new subsystem logger.
+func (r *RotatingLogWriter) RegisterSubLogger(subsystem string,
+	logger btclog.Logger) {
+
+	r.subsystemLoggers[subsystem] = logger
+}
+
+// InitLogRotator initializes the log file rotator to write logs to logFile and
+// create roll files in the same directory. It should be called as early on
+// startup and possible and must be closed on shutdown by calling `Close`.
+func (r *RotatingLogWriter) InitLogRotator(logFile string, maxLogFileSize int,
+	maxLogFiles int) error {
+
+	logDir, _ := filepath.Split(logFile)
+	err := os.MkdirAll(logDir, 0700)
+	if err != nil {
+		return fmt.Errorf("failed to create log directory: %v", err)
+	}
+	r.logRotator, err = rotator.New(
+		logFile, int64(maxLogFileSize*1024), false, maxLogFiles,
+	)
+	if err != nil {
+		return fmt.Errorf("failed to create file rotator: %v", err)
+	}
+
+	// Run rotator as a goroutine now but make sure we catch any errors
+	// that happen in case something with the rotation goes wrong during
+	// runtime (like running out of disk space or not being allowed to
+	// create a new logfile for whatever reason).
+	pr, pw := io.Pipe()
+	go func() {
+		err := r.logRotator.Run(pr)
+		if err != nil {
+			_, _ = fmt.Fprintf(os.Stderr,
+				"failed to run file rotator: %v\n", err)
+		}
+	}()
+
+	r.logWriter.RotatorPipe = pw
+	return nil
+}
+
+// Close closes the underlying log rotator if it has already been created.
+func (r *RotatingLogWriter) Close() error {
+	if r.logRotator != nil {
+		return r.logRotator.Close()
+	}
+	return nil
+}
+
+// SubLoggers returns all currently registered subsystem loggers for this log
+// writer.
+//
+// NOTE: This is part of the LeveledSubLogger interface.
+func (r *RotatingLogWriter) SubLoggers() SubLoggers {
+	return r.subsystemLoggers
+}
+
+// SupportedSubsystems returns a sorted string slice of all keys in the
+// subsystems map, corresponding to the names of the subsystems.
+//
+// NOTE: This is part of the LeveledSubLogger interface.
+func (r *RotatingLogWriter) SupportedSubsystems() []string {
+	// Convert the subsystemLoggers map keys to a string slice.
+	subsystems := make([]string, 0, len(r.subsystemLoggers))
+	for subsysID := range r.subsystemLoggers {
+		subsystems = append(subsystems, subsysID)
+	}
+
+	// Sort the subsystems for stable display.
+	sort.Strings(subsystems)
+	return subsystems
+}
+
+// SetLogLevel sets the logging level for provided subsystem. Invalid
+// subsystems are ignored. Uninitialized subsystems are dynamically created as
+// needed.
+//
+// NOTE: This is part of the LeveledSubLogger interface.
+func (r *RotatingLogWriter) SetLogLevel(subsystemID string, logLevel string) {
+	// Ignore invalid subsystems.
+	logger, ok := r.subsystemLoggers[subsystemID]
+	if !ok {
+		return
+	}
+
+	// Defaults to info if the log level is invalid.
+	level, _ := btclog.LevelFromString(logLevel)
+	logger.SetLevel(level)
+}
+
+// SetLogLevels sets the log level for all subsystem loggers to the passed
+// level. It also dynamically creates the subsystem loggers as needed, so it
+// can be used to initialize the logging system.
+//
+// NOTE: This is part of the LeveledSubLogger interface.
+func (r *RotatingLogWriter) SetLogLevels(logLevel string) {
+	// Configure all sub-systems with the new logging level. Dynamically
+	// create loggers as needed.
+	for subsystemID := range r.subsystemLoggers {
+		r.SetLogLevel(subsystemID, logLevel)
+	}
+}

--- a/config.go
+++ b/config.go
@@ -951,27 +951,32 @@ func loadConfig() (*config, error) {
 		normalizeNetwork(activeNetParams.Name))
 
 	// Special show command to list supported subsystems and exit.
-	/*TODO(guggero) fix
 	if cfg.DebugLevel == "show" {
-		fmt.Println("Supported subsystems", supportedSubsystems())
+		fmt.Println("Supported subsystems",
+			logWriter.SupportedSubsystems())
 		os.Exit(0)
-	}*/
+	}
 
 	// Initialize logging at the default logging level.
-	/*TODO(guggero) fix
-	initLogRotator(
+	err = logWriter.InitLogRotator(
 		filepath.Join(cfg.LogDir, defaultLogFilename),
 		cfg.MaxLogFileSize, cfg.MaxLogFiles,
-	)*/
+	)
+	if err != nil {
+		str := "%s: log rotation setup failed: %v"
+		err = fmt.Errorf(str, funcName, err.Error())
+		fmt.Fprintln(os.Stderr, err)
+		return nil, err
+	}
 
 	// Parse, validate, and set debug log level(s).
-	/*TODO(guggero) fix
-	if err := parseAndSetDebugLevels(cfg.DebugLevel); err != nil {
-		err := fmt.Errorf("%s: %v", funcName, err.Error())
+	err = build.ParseAndSetDebugLevels(cfg.DebugLevel, logWriter)
+	if err != nil {
+		err = fmt.Errorf("%s: %v", funcName, err.Error())
 		fmt.Fprintln(os.Stderr, err)
 		fmt.Fprintln(os.Stderr, usageMessage)
 		return nil, err
-	}*/
+	}
 
 	// At least one RPCListener is required. So listen on localhost per
 	// default.

--- a/config.go
+++ b/config.go
@@ -958,10 +958,11 @@ func loadConfig() (*config, error) {
 	}*/
 
 	// Initialize logging at the default logging level.
+	/*TODO(guggero) fix
 	initLogRotator(
 		filepath.Join(cfg.LogDir, defaultLogFilename),
 		cfg.MaxLogFileSize, cfg.MaxLogFiles,
-	)
+	)*/
 
 	// Parse, validate, and set debug log level(s).
 	/*TODO(guggero) fix

--- a/config.go
+++ b/config.go
@@ -14,7 +14,6 @@ import (
 	"path"
 	"path/filepath"
 	"regexp"
-	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -952,10 +951,11 @@ func loadConfig() (*config, error) {
 		normalizeNetwork(activeNetParams.Name))
 
 	// Special show command to list supported subsystems and exit.
+	/*TODO(guggero) fix
 	if cfg.DebugLevel == "show" {
 		fmt.Println("Supported subsystems", supportedSubsystems())
 		os.Exit(0)
-	}
+	}*/
 
 	// Initialize logging at the default logging level.
 	initLogRotator(
@@ -964,12 +964,13 @@ func loadConfig() (*config, error) {
 	)
 
 	// Parse, validate, and set debug log level(s).
+	/*TODO(guggero) fix
 	if err := parseAndSetDebugLevels(cfg.DebugLevel); err != nil {
 		err := fmt.Errorf("%s: %v", funcName, err.Error())
 		fmt.Fprintln(os.Stderr, err)
 		fmt.Fprintln(os.Stderr, usageMessage)
 		return nil, err
-	}
+	}*/
 
 	// At least one RPCListener is required. So listen on localhost per
 	// default.
@@ -1138,92 +1139,6 @@ func cleanAndExpandPath(path string) string {
 	// NOTE: The os.ExpandEnv doesn't work with Windows-style %VARIABLE%,
 	// but the variables can still be expanded via POSIX-style $VARIABLE.
 	return filepath.Clean(os.ExpandEnv(path))
-}
-
-// parseAndSetDebugLevels attempts to parse the specified debug level and set
-// the levels accordingly. An appropriate error is returned if anything is
-// invalid.
-func parseAndSetDebugLevels(debugLevel string) error {
-	// When the specified string doesn't have any delimiters, treat it as
-	// the log level for all subsystems.
-	if !strings.Contains(debugLevel, ",") && !strings.Contains(debugLevel, "=") {
-		// Validate debug log level.
-		if !validLogLevel(debugLevel) {
-			str := "The specified debug level [%v] is invalid"
-			return fmt.Errorf(str, debugLevel)
-		}
-
-		// Change the logging level for all subsystems.
-		setLogLevels(debugLevel)
-
-		return nil
-	}
-
-	// Split the specified string into subsystem/level pairs while detecting
-	// issues and update the log levels accordingly.
-	for _, logLevelPair := range strings.Split(debugLevel, ",") {
-		if !strings.Contains(logLevelPair, "=") {
-			str := "The specified debug level contains an invalid " +
-				"subsystem/level pair [%v]"
-			return fmt.Errorf(str, logLevelPair)
-		}
-
-		// Extract the specified subsystem and log level.
-		fields := strings.Split(logLevelPair, "=")
-		subsysID, logLevel := fields[0], fields[1]
-
-		// Validate subsystem.
-		if _, exists := subsystemLoggers[subsysID]; !exists {
-			str := "The specified subsystem [%v] is invalid -- " +
-				"supported subsystems %v"
-			return fmt.Errorf(str, subsysID, supportedSubsystems())
-		}
-
-		// Validate log level.
-		if !validLogLevel(logLevel) {
-			str := "The specified debug level [%v] is invalid"
-			return fmt.Errorf(str, logLevel)
-		}
-
-		setLogLevel(subsysID, logLevel)
-	}
-
-	return nil
-}
-
-// validLogLevel returns whether or not logLevel is a valid debug log level.
-func validLogLevel(logLevel string) bool {
-	switch logLevel {
-	case "trace":
-		fallthrough
-	case "debug":
-		fallthrough
-	case "info":
-		fallthrough
-	case "warn":
-		fallthrough
-	case "error":
-		fallthrough
-	case "critical":
-		fallthrough
-	case "off":
-		return true
-	}
-	return false
-}
-
-// supportedSubsystems returns a sorted slice of the supported subsystems for
-// logging purposes.
-func supportedSubsystems() []string {
-	// Convert the subsystemLoggers map keys to a slice.
-	subsystems := make([]string, 0, len(subsystemLoggers))
-	for subsysID := range subsystemLoggers {
-		subsystems = append(subsystems, subsysID)
-	}
-
-	// Sort the subsystems for stable display.
-	sort.Strings(subsystems)
-	return subsystems
 }
 
 func parseRPCParams(cConfig *chainConfig, nodeConfig interface{}, net chainCode,

--- a/lnd.go
+++ b/lnd.go
@@ -124,10 +124,11 @@ func Main(lisCfg ListenerCfg) error {
 	}
 	cfg = loadedConfig
 	defer func() {
+		ltndLog.Info("Shutdown complete")
+		/* TODO(guggero) fix after refactor
 		if logRotator != nil {
-			ltndLog.Info("Shutdown complete")
 			logRotator.Close()
-		}
+		}*/
 	}()
 
 	// Show version at startup.

--- a/lnd.go
+++ b/lnd.go
@@ -125,10 +125,10 @@ func Main(lisCfg ListenerCfg) error {
 	cfg = loadedConfig
 	defer func() {
 		ltndLog.Info("Shutdown complete")
-		/* TODO(guggero) fix after refactor
-		if logRotator != nil {
-			logRotator.Close()
-		}*/
+		err := logWriter.Close()
+		if err != nil {
+			ltndLog.Errorf("Could not close log rotator: %v", err)
+		}
 	}()
 
 	// Show version at startup.

--- a/log.go
+++ b/log.go
@@ -2,10 +2,6 @@ package lnd
 
 import (
 	"context"
-	"fmt"
-	"io"
-	"os"
-	"path/filepath"
 
 	"github.com/btcsuite/btcd/connmgr"
 	"github.com/btcsuite/btclog"
@@ -171,55 +167,6 @@ var subsystemLoggers = map[string]btclog.Logger{
 	"PROM": promLog,
 	"WTCL": wtclLog,
 	"PRNF": prnfLog,
-}
-
-// initLogRotator initializes the logging rotator to write logs to logFile and
-// create roll files in the same directory.  It must be called before the
-// package-global log rotator variables are used.
-func initLogRotator(logFile string, MaxLogFileSize int, MaxLogFiles int) {
-	logDir, _ := filepath.Split(logFile)
-	err := os.MkdirAll(logDir, 0700)
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "failed to create log directory: %v\n", err)
-		os.Exit(1)
-	}
-	r, err := rotator.New(logFile, int64(MaxLogFileSize*1024), false, MaxLogFiles)
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "failed to create file rotator: %v\n", err)
-		os.Exit(1)
-	}
-
-	pr, pw := io.Pipe()
-	go r.Run(pr)
-
-	logWriter.RotatorPipe = pw
-	logRotator = r
-}
-
-// setLogLevel sets the logging level for provided subsystem.  Invalid
-// subsystems are ignored.  Uninitialized subsystems are dynamically created as
-// needed.
-func setLogLevel(subsystemID string, logLevel string) {
-	// Ignore invalid subsystems.
-	logger, ok := subsystemLoggers[subsystemID]
-	if !ok {
-		return
-	}
-
-	// Defaults to info if the log level is invalid.
-	level, _ := btclog.LevelFromString(logLevel)
-	logger.SetLevel(level)
-}
-
-// setLogLevels sets the log level for all subsystem loggers to the passed
-// level. It also dynamically creates the subsystem loggers as needed, so it
-// can be used to initialize the logging system.
-func setLogLevels(logLevel string) {
-	// Configure all sub-systems with the new logging level.  Dynamically
-	// create loggers as needed.
-	for subsystemID := range subsystemLoggers {
-		setLogLevel(subsystemID, logLevel)
-	}
 }
 
 // logClosure is used to provide a closure over expensive logging operations so

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -12,7 +12,6 @@ import (
 	"net"
 	"net/http"
 	"sort"
-	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -4343,7 +4342,7 @@ func (r *rpcServer) DebugLevel(ctx context.Context,
 	// sub-systems.
 	if req.Show {
 		return &lnrpc.DebugLevelResponse{
-			SubSystems: strings.Join(supportedSubsystems(), " "),
+			SubSystems: "", //TODO(guggero) fix strings.Join(supportedSubsystems(), " "),
 		}, nil
 	}
 
@@ -4351,9 +4350,11 @@ func (r *rpcServer) DebugLevel(ctx context.Context,
 
 	// Otherwise, we'll attempt to set the logging level using the
 	// specified level spec.
+	/*TODO(guggero) fix
 	if err := parseAndSetDebugLevels(req.LevelSpec); err != nil {
 		return nil, err
 	}
+	*/
 
 	return &lnrpc.DebugLevelResponse{}, nil
 }

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -12,6 +12,7 @@ import (
 	"net"
 	"net/http"
 	"sort"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -4342,7 +4343,9 @@ func (r *rpcServer) DebugLevel(ctx context.Context,
 	// sub-systems.
 	if req.Show {
 		return &lnrpc.DebugLevelResponse{
-			SubSystems: "", //TODO(guggero) fix strings.Join(supportedSubsystems(), " "),
+			SubSystems: strings.Join(
+				logWriter.SupportedSubsystems(), " ",
+			),
 		}, nil
 	}
 
@@ -4350,11 +4353,10 @@ func (r *rpcServer) DebugLevel(ctx context.Context,
 
 	// Otherwise, we'll attempt to set the logging level using the
 	// specified level spec.
-	/*TODO(guggero) fix
-	if err := parseAndSetDebugLevels(req.LevelSpec); err != nil {
+	err := build.ParseAndSetDebugLevels(req.LevelSpec, logWriter)
+	if err != nil {
 		return nil, err
 	}
-	*/
 
 	return &lnrpc.DebugLevelResponse{}, nil
 }


### PR DESCRIPTION
Since we want to use persistent logging with log file rotation in other projects like loop as well, it would be nice if we could reuse the code directly instead of copy/pasting it.

This PR moves most of the log file rotation code and the code used for parsing and setting the log level into the `build` package.