### PR TITLE
macaroons: Test Improvements

### DIFF
--- a/macaroons/service_test.go
+++ b/macaroons/service_test.go
@@ -61,18 +61,19 @@ func TestNewService(t *testing.T) {
 	// Second, create the new service instance, unlock it and pass in a
 	// checker that we expect it to add to the bakery.
 	service, err := macaroons.NewService(tempDir, macaroons.IPLockChecker)
-	defer service.Close()
 	if err != nil {
 		t.Fatalf("Error creating new service: %v", err)
 	}
+	defer service.Close()
 	err = service.CreateUnlock(&defaultPw)
 	if err != nil {
 		t.Fatalf("Error unlocking root key storage: %v", err)
 	}
 
 	// Third, check if the created service can bake macaroons.
-	macaroon, err := service.Oven.NewMacaroon(nil, bakery.LatestVersion,
-		nil, testOperation)
+	macaroon, err := service.Oven.NewMacaroon(
+		context.TODO(), bakery.LatestVersion, nil, testOperation,
+	)
 	if err != nil {
 		t.Fatalf("Error creating macaroon from service: %v", err)
 	}
@@ -104,18 +105,20 @@ func TestValidateMacaroon(t *testing.T) {
 	tempDir := setupTestRootKeyStorage(t)
 	defer os.RemoveAll(tempDir)
 	service, err := macaroons.NewService(tempDir, macaroons.IPLockChecker)
-	defer service.Close()
 	if err != nil {
 		t.Fatalf("Error creating new service: %v", err)
 	}
+	defer service.Close()
+
 	err = service.CreateUnlock(&defaultPw)
 	if err != nil {
 		t.Fatalf("Error unlocking root key storage: %v", err)
 	}
 
 	// Then, create a new macaroon that we can serialize.
-	macaroon, err := service.Oven.NewMacaroon(nil, bakery.LatestVersion,
-		nil, testOperation)
+	macaroon, err := service.Oven.NewMacaroon(
+		context.TODO(), bakery.LatestVersion, nil, testOperation,
+	)
 	if err != nil {
 		t.Fatalf("Error creating macaroon from service: %v", err)
 	}

--- a/macaroons/store_test.go
+++ b/macaroons/store_test.go
@@ -2,6 +2,7 @@ package macaroons_test
 
 import (
 	"bytes"
+	"context"
 	"io/ioutil"
 	"os"
 	"path"
@@ -34,12 +35,12 @@ func TestStore(t *testing.T) {
 	}
 	defer store.Close()
 
-	key, id, err := store.RootKey(nil)
+	_, _, err = store.RootKey(context.TODO())
 	if err != macaroons.ErrStoreLocked {
 		t.Fatalf("Received %v instead of ErrStoreLocked", err)
 	}
 
-	key, err = store.Get(nil, nil)
+	_, err = store.Get(context.TODO(), nil)
 	if err != macaroons.ErrStoreLocked {
 		t.Fatalf("Received %v instead of ErrStoreLocked", err)
 	}
@@ -50,13 +51,13 @@ func TestStore(t *testing.T) {
 		t.Fatalf("Error creating store encryption key: %v", err)
 	}
 
-	key, id, err = store.RootKey(nil)
+	key, id, err := store.RootKey(context.TODO())
 	if err != nil {
 		t.Fatalf("Error getting root key from store: %v", err)
 	}
 	rootID := id
 
-	key2, err := store.Get(nil, id)
+	key2, err := store.Get(context.TODO(), id)
 	if err != nil {
 		t.Fatalf("Error getting key with ID %s: %v", string(id), err)
 	}
@@ -97,12 +98,12 @@ func TestStore(t *testing.T) {
 		t.Fatalf("Received %v instead of ErrPasswordRequired", err)
 	}
 
-	key, id, err = store.RootKey(nil)
+	_, _, err = store.RootKey(context.TODO())
 	if err != macaroons.ErrStoreLocked {
 		t.Fatalf("Received %v instead of ErrStoreLocked", err)
 	}
 
-	key, err = store.Get(nil, nil)
+	_, err = store.Get(context.TODO(), nil)
 	if err != macaroons.ErrStoreLocked {
 		t.Fatalf("Received %v instead of ErrStoreLocked", err)
 	}
@@ -112,7 +113,7 @@ func TestStore(t *testing.T) {
 		t.Fatalf("Error unlocking root key store: %v", err)
 	}
 
-	key, err = store.Get(nil, rootID)
+	key, err = store.Get(context.TODO(), rootID)
 	if err != nil {
 		t.Fatalf("Error getting key with ID %s: %v",
 			string(rootID), err)
@@ -122,7 +123,7 @@ func TestStore(t *testing.T) {
 			key2, key)
 	}
 
-	key, id, err = store.RootKey(nil)
+	key, id, err = store.RootKey(context.TODO())
 	if err != nil {
 		t.Fatalf("Error getting root key from store: %v", err)
 	}


### PR DESCRIPTION
macaroons: defer service.Close() after error check in tests
macaroons: explicitly drop unneeded variables in tests