### PR TITLE
peer: link updater refactor

### DIFF
--- a/lnwire/commit_sig.go
+++ b/lnwire/commit_sig.go
@@ -1,6 +1,8 @@
 package lnwire
 
-import "io"
+import (
+	"io"
+)
 
 // CommitSig is sent by either side to stage any pending HTLC's in the
 // receiver's pending set into a new commitment state.  Implicitly, the new
@@ -82,4 +84,12 @@ func (c *CommitSig) MsgType() MessageType {
 func (c *CommitSig) MaxPayloadLength(uint32) uint32 {
 	// 32 + 64 + 2 + max_allowed_htlcs
 	return MaxMessagePayload
+}
+
+// TargetChanID returns the channel id of the link for which this message is
+// intended.
+//
+// NOTE: Part of lnd.LinkUpdater interface.
+func (c *CommitSig) TargetChanID() ChannelID {
+	return c.ChanID
 }

--- a/lnwire/revoke_and_ack.go
+++ b/lnwire/revoke_and_ack.go
@@ -81,3 +81,11 @@ func (c *RevokeAndAck) MaxPayloadLength(uint32) uint32 {
 	// 32 + 32 + 33
 	return 97
 }
+
+// TargetChanID returns the channel id of the link for which this message is
+// intended.
+//
+// NOTE: Part of lnd.LinkUpdater interface.
+func (c *RevokeAndAck) TargetChanID() ChannelID {
+	return c.ChanID
+}

--- a/lnwire/update_add_htlc.go
+++ b/lnwire/update_add_htlc.go
@@ -1,6 +1,8 @@
 package lnwire
 
-import "io"
+import (
+	"io"
+)
 
 // OnionPacketSize is the size of the serialized Sphinx onion packet included
 // in each UpdateAddHTLC message. The breakdown of the onion packet is as
@@ -106,4 +108,12 @@ func (c *UpdateAddHTLC) MsgType() MessageType {
 func (c *UpdateAddHTLC) MaxPayloadLength(uint32) uint32 {
 	// 1450
 	return 32 + 8 + 4 + 8 + 32 + 1366
+}
+
+// TargetChanID returns the channel id of the link for which this message is
+// intended.
+//
+// NOTE: Part of lnd.LinkUpdater interface.
+func (c *UpdateAddHTLC) TargetChanID() ChannelID {
+	return c.ChanID
 }

--- a/lnwire/update_fail_htlc.go
+++ b/lnwire/update_fail_htlc.go
@@ -1,6 +1,8 @@
 package lnwire
 
-import "io"
+import (
+	"io"
+)
 
 // OpaqueReason is an opaque encrypted byte slice that encodes the exact
 // failure reason and additional some supplemental data. The contents of this
@@ -82,4 +84,12 @@ func (c *UpdateFailHTLC) MaxPayloadLength(uint32) uint32 {
 	length += 292
 
 	return length
+}
+
+// TargetChanID returns the channel id of the link for which this message is
+// intended.
+//
+// NOTE: Part of lnd.LinkUpdater interface.
+func (c *UpdateFailHTLC) TargetChanID() ChannelID {
+	return c.ChanID
 }

--- a/lnwire/update_fail_malformed_htlc.go
+++ b/lnwire/update_fail_malformed_htlc.go
@@ -73,3 +73,11 @@ func (c *UpdateFailMalformedHTLC) MaxPayloadLength(uint32) uint32 {
 	// 32 +  8 + 32 + 2
 	return 74
 }
+
+// TargetChanID returns the channel id of the link for which this message is
+// intended.
+//
+// NOTE: Part of lnd.LinkUpdater interface.
+func (c *UpdateFailMalformedHTLC) TargetChanID() ChannelID {
+	return c.ChanID
+}

--- a/lnwire/update_fee.go
+++ b/lnwire/update_fee.go
@@ -68,3 +68,11 @@ func (c *UpdateFee) MaxPayloadLength(uint32) uint32 {
 	// 32 + 4
 	return 36
 }
+
+// TargetChanID returns the channel id of the link for which this message is
+// intended.
+//
+// NOTE: Part of lnd.LinkUpdater interface.
+func (c *UpdateFee) TargetChanID() ChannelID {
+	return c.ChanID
+}

--- a/lnwire/update_fulfill_htlc.go
+++ b/lnwire/update_fulfill_htlc.go
@@ -1,6 +1,8 @@
 package lnwire
 
-import "io"
+import (
+	"io"
+)
 
 // UpdateFulfillHTLC is sent by Alice to Bob when she wishes to settle a
 // particular HTLC referenced by its HTLCKey within a specific active channel
@@ -75,4 +77,12 @@ func (c *UpdateFulfillHTLC) MsgType() MessageType {
 func (c *UpdateFulfillHTLC) MaxPayloadLength(uint32) uint32 {
 	// 32 + 8 + 32
 	return 72
+}
+
+// TargetChanID returns the channel id of the link for which this message is
+// intended.
+//
+// NOTE: Part of lnd.LinkUpdater interface.
+func (c *UpdateFulfillHTLC) TargetChanID() ChannelID {
+	return c.ChanID
 }


### PR DESCRIPTION
This PR fixes a long standing TODO, creating a minimal interface for messages that are destined for links. This allows a much simpler method of extracting the channel id rather than type switching every message individually. Several PRs in the future will build on this as we begin to refactor the peer and make it easier to test.