### PR TITLE
lnd+queue: specify go 1.12 in all go.mod files

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -60,4 +60,4 @@ replace github.com/lightningnetwork/lnd/queue => ./queue
 
 replace git.schwanenlied.me/yawning/bsaes.git => github.com/Yawning/bsaes v0.0.0-20180720073208-c0276d75487e
 
-go 1.13
+go 1.12

--- a/queue/go.mod
+++ b/queue/go.mod
@@ -3,3 +3,5 @@ module github.com/lightningnetwork/lnd/queue
 require github.com/lightningnetwork/lnd/ticker v1.0.0
 
 replace github.com/lightningnetwork/lnd/ticker v1.0.0 => ../ticker
+
+go 1.12


### PR DESCRIPTION
In a `go.mod` file, you can specify the minimum version that is needed to compile the module.
At the moment we have three different values:
* root (lnd) -> `go 1.13`
* ticker -> `go 1.12`
* queue -> no go version

This PR adds version `1.12` to `queue` and downgrades the version in the root `go.mod` to `1.12`.
With these changes I was able to make the project using go `1.12` and the command `go mod tidy` didn't yield any more diffs.