### PR TITLE
trivial: fix typo in config.go

### DIFF
--- a/config.go
+++ b/config.go
@@ -1508,7 +1508,7 @@ func extractBitcoindRPCParams(bitcoindConfigPath string) (string, string, string
 // ZMQ rawblock and rawtx notifications are different.
 func checkZMQOptions(zmqBlockHost, zmqTxHost string) error {
 	if zmqBlockHost == zmqTxHost {
-		return errors.New("zmqpubrawblock and zmqpubrawtx must be set" +
+		return errors.New("zmqpubrawblock and zmqpubrawtx must be set " +
 			"to different addresses")
 	}
 


### PR DESCRIPTION
Fix a trivial typo in config.go:

"setto" -> "set to"