### PR TITLE
lnd_test: give peers more time to successfully attempt connection

### DIFF
--- a/lntest/harness.go
+++ b/lntest/harness.go
@@ -435,44 +435,61 @@ func (n *NetworkHarness) EnsureConnected(ctx context.Context, a, b *HarnessNode)
 			},
 		}
 
-		ctxt, _ = context.WithTimeout(ctx, 15*time.Second)
-		err = n.connect(ctxt, req, a)
-		switch {
+		var predErr error
+		err = wait.Predicate(func() bool {
+			ctx, cancel := context.WithTimeout(ctx, 15*time.Second)
+			defer cancel()
 
-		// Request was successful, wait for both to display the
-		// connection.
-		case err == nil:
-			return errConnectionRequested
+			err := n.connect(ctx, req, a)
+			switch {
 
-		// If the two are already connected, we return early with no
-		// error.
-		case strings.Contains(err.Error(), "already connected to peer"):
-			return nil
+			// Request was successful, wait for both to display the
+			// connection.
+			case err == nil:
+				predErr = errConnectionRequested
+				return true
 
-		default:
-			return err
+			// If the two are already connected, we return early
+			// with no error.
+			case strings.Contains(
+				err.Error(), "already connected to peer",
+			):
+				predErr = nil
+				return true
+
+			default:
+				predErr = err
+				return false
+			}
+
+		}, DefaultTimeout)
+		if err != nil {
+			return fmt.Errorf("connection not succeeded within 15 "+
+				"seconds: %v", predErr)
 		}
+
+		return predErr
 	}
 
 	aErr := tryConnect(a, b)
 	bErr := tryConnect(b, a)
 	switch {
+	// If both reported already being connected to each other, we can exit
+	// early.
 	case aErr == nil && bErr == nil:
-		// If both reported already being connected to each other, we
-		// can exit early.
 		return nil
 
+	// Return any critical errors returned by either alice.
 	case aErr != nil && aErr != errConnectionRequested:
-		// Return any critical errors returned by either alice.
 		return aErr
 
+	// Return any critical errors returned by either bob.
 	case bErr != nil && bErr != errConnectionRequested:
-		// Return any critical errors returned by either bob.
 		return bErr
 
+	// Otherwise one or both requested a connection, so we wait for the
+	// peers lists to reflect the connection.
 	default:
-		// Otherwise one or both requested a connection, so we wait for
-		// the peers lists to reflect the connection.
 	}
 
 	findSelfInPeerList := func(a, b *HarnessNode) bool {


### PR DESCRIPTION
We might hit a connection refused error in cases where the peer connects
to us exactly as we try to connect to it. We retry the connection within
a wait predicat, as it should be the case that the other peer
establishes the connection, and the two peers actually connects.

Should resolve the flake
```
   --- FAIL: TestLightningNetworkDaemon/data_loss_protection (12.68s)
        lnd_test.go:99: Failed: (data loss protection): exited with error: 
            *errors.errorString unable to connect Dave to carol: rpc error: code = Unknown desc = dial tcp 127.0.0.1:19799: connect: connection refused
            /home/travis/gopath/src/github.com/lightningnetwork/lnd/lntest/itest/lnd_test.go:8239 (0xd4e2c3)
            	testDataLossProtection.func1: t.Fatalf("unable to connect %v to carol: %v",
            /home/travis/gopath/src/github.com/lightningnetwork/lnd/lntest/itest/lnd_test.go:8385 (0xd1afe6)
            	testDataLossProtection: restartDave, _, daveStartingBalance, err := timeTravel(dave)
            /home/travis/gopath/src/github.com/lightningnetwork/lnd/lntest/itest/lnd_test.go:123 (0xced56a)
            	(*harnessTest).RunTestCase: testCase.test(h.lndHarness, h)
            /home/travis/gopath/src/github.com/lightningnetwork/lnd/lntest/itest/lnd_test.go:14533 (0xd55e8c)
            	TestLightningNetworkDaemon.func4: ht.RunTestCase(testCase)
            /home/travis/.gimme/versions/go1.13.linux.amd64/src/testing/testing.go:909 (0x509a19)
            	tRunner: fn(t)
            /home/travis/.gimme/versions/go1.13.linux.amd64/src/runtime/asm_amd64.s:1357 (0x460e81)
            	goexit: BYTE	$0x90	// NOP
FAIL
FAIL	github.com/lightningnetwork/lnd/lntest/itest	993.451s
```