### PR TITLE
build/release: create new release package for reproducible builds

### DIFF
--- a/build/release/README.md
+++ b/build/release/README.md
@@ -1,0 +1,34 @@
+# lnd's Reproducible Build System
+
+This package contains the buidl script that the `lnd` project uses in order to
+build binaries for each new release. As of Go 1.13, with some new build flags,
+binaries are now reproducible, allowing developers to build the binary on
+distinct machines, and end up with a byte-for-byte identical binary.  However,
+this wasn't _fully_ solved in Go 1.13, as the build system still includes the
+directory the binary is built into the binary itself. As a result, our scripts
+utilize a work around needed until Go 1.13.2.  
+
+## Building a New Release
+
+### MacOS/Linux/Windows (WSL)
+
+No prior set up is needed on Linux or MacOS is required in order to build the
+release binaries.  However, on Windows, the only way to build the binaries atm
+is using the Windows Subsystem Linux. One can build the release binaries from
+one's `lnd` directory, no matter where it's located.  One can download `lnd` to
+
+```
+git clone https://github.com/lightningnetwork/lnd.git
+```
+
+Afterwards, the release manager/verifier simply needs to run:
+`./build/release/release.sh <TAG>` (from the top-level `lnd` directory) , where
+`<TAG>` is the name of the next release/tag.
+
+## Verifying a Release
+
+With Go 1.13, it's now possible for third parties to verify a release binary.
+Before this release, one had to trust that release manager to build the proper
+binary. With this new system, third parties can now _independently_ run the
+release process, and verify that all the hashes in the final `manifest.txt`
+match up.

--- a/build/release/release.sh
+++ b/build/release/release.sh
@@ -7,6 +7,8 @@
 # Use of this source code is governed by the ISC
 # license.
 
+set -e
+
 # If no tag specified, use date + version otherwise use tag.
 if [[ $1x = x ]]; then
     DATE=`date +%Y%m%d`
@@ -60,8 +62,8 @@ for i in $SYS; do
     cd $PACKAGE-$i-$TAG
 
     echo "Building:" $OS $ARCH $ARM
-    env GOOS=$OS GOARCH=$ARCH GOARM=$ARM go build -v -trimpath -ldflags "$COMMITFLAGS" -tags="autopilotrpc signrpc walletrpc chainrpc invoicesrpc routerrpc watchtowerrpc" github.com/lightningnetwork/lnd/cmd/lnd
-    env GOOS=$OS GOARCH=$ARCH GOARM=$ARM go build -v -trimpath -ldflags "$COMMITFLAGS" -tags="autopilotrpc invoicesrpc walletrpc routerrpc watchtowerrpc" github.com/lightningnetwork/lnd/cmd/lncli
+    env CGO_ENABLED=0 GOOS=$OS GOARCH=$ARCH GOARM=$ARM go build -v -trimpath -ldflags="-s -w -buildid= $COMMITFLAGS" -tags="autopilotrpc signrpc walletrpc chainrpc invoicesrpc routerrpc watchtowerrpc" github.com/lightningnetwork/lnd/cmd/lnd
+    env CGO_ENABLED=0 GOOS=$OS GOARCH=$ARCH GOARM=$ARM go build -v -trimpath -ldflags="-s -w -buildid= $COMMITFLAGS" -tags="autopilotrpc invoicesrpc walletrpc routerrpc watchtowerrpc" github.com/lightningnetwork/lnd/cmd/lncli
     cd ..
 
     if [[ $OS = "windows" ]]; then


### PR DESCRIPTION
In this commit, we create a new `build/release` package which houses the
container and scripts that we need to do deterministic builds across
Windows, Linux, and MacOS. As a result, all builds of `lnd` will now
take place from within this container environment. The container will
mount to the local `lnd` directory, resulting in all the build artifacts
being present in the host's cwd.

With this new system, it's now possible for all `lnd` developers, as
well as users to verify the posted build binaries. This wasn't possible
in prior release as only in Go 1.13 did deterministic builds becomes
easier/possible. See the new `README.md` for further details.

