### PR TITLE
htlcswitch: fix non-strict forwarding failures

### DIFF
--- a/htlcswitch/interfaces.go
+++ b/htlcswitch/interfaces.go
@@ -100,22 +100,21 @@ type ChannelLink interface {
 	// policy to govern if it an incoming HTLC should be forwarded or not.
 	UpdateForwardingPolicy(ForwardingPolicy)
 
-	// HtlcSatifiesPolicy should return a nil error if the passed HTLC
-	// details satisfy the current forwarding policy fo the target link.
-	// Otherwise, a valid protocol failure message should be returned in
-	// order to signal to the source of the HTLC, the policy consistency
-	// issue.
-	HtlcSatifiesPolicy(payHash [32]byte, incomingAmt lnwire.MilliSatoshi,
+	// CheckHtlcForward should return a nil error if the passed HTLC details
+	// satisfy the current forwarding policy fo the target link. Otherwise,
+	// a valid protocol failure message should be returned in order to
+	// signal to the source of the HTLC, the policy consistency issue.
+	CheckHtlcForward(payHash [32]byte, incomingAmt lnwire.MilliSatoshi,
 		amtToForward lnwire.MilliSatoshi,
 		incomingTimeout, outgoingTimeout uint32,
 		heightNow uint32) lnwire.FailureMessage
 
-	// HtlcSatifiesPolicyLocal should return a nil error if the passed HTLC
-	// details satisfy the current channel policy.  Otherwise, a valid
-	// protocol failure message should be returned in order to signal the
-	// violation. This call is intended to be used for locally initiated
-	// payments for which there is no corresponding incoming htlc.
-	HtlcSatifiesPolicyLocal(payHash [32]byte, amt lnwire.MilliSatoshi,
+	// CheckHtlcTransit should return a nil error if the passed HTLC details
+	// satisfy the current channel policy.  Otherwise, a valid protocol
+	// failure message should be returned in order to signal the violation.
+	// This call is intended to be used for locally initiated payments for
+	// which there is no corresponding incoming htlc.
+	CheckHtlcTransit(payHash [32]byte, amt lnwire.MilliSatoshi,
 		timeout uint32, heightNow uint32) lnwire.FailureMessage
 
 	// Bandwidth returns the amount of milli-satoshis which current link

--- a/htlcswitch/link.go
+++ b/htlcswitch/link.go
@@ -2338,7 +2338,7 @@ func (l *channelLink) htlcSatifiesPolicyOutgoing(policy ForwardingPolicy,
 			l.ShortChanID(),
 		)
 		if err != nil {
-			failure = lnwire.NewTemporaryChannelFailure(update)
+			failure = &lnwire.FailTemporaryNodeFailure{}
 		} else {
 			failure = lnwire.NewExpiryTooSoon(*update)
 		}

--- a/htlcswitch/link.go
+++ b/htlcswitch/link.go
@@ -2341,6 +2341,15 @@ func (l *channelLink) canSendHtlc(policy ForwardingPolicy,
 		return &lnwire.FailExpiryTooFar{}
 	}
 
+	// Check to see if there is enough balance in this channel.
+	if amt > l.Bandwidth() {
+		return l.createFailureWithUpdate(
+			func(upd *lnwire.ChannelUpdate) lnwire.FailureMessage {
+				return lnwire.NewTemporaryChannelFailure(upd)
+			},
+		)
+	}
+
 	return nil
 }
 

--- a/htlcswitch/link_test.go
+++ b/htlcswitch/link_test.go
@@ -5396,9 +5396,9 @@ func TestForwardingAsymmetricTimeLockPolicies(t *testing.T) {
 	}
 }
 
-// TestHtlcSatisfyPolicy tests that a link is properly enforcing the HTLC
+// TestCheckHtlcForward tests that a link is properly enforcing the HTLC
 // forwarding policy.
-func TestHtlcSatisfyPolicy(t *testing.T) {
+func TestCheckHtlcForward(t *testing.T) {
 
 	fetchLastChannelUpdate := func(lnwire.ShortChannelID) (
 		*lnwire.ChannelUpdate, error) {
@@ -5423,7 +5423,7 @@ func TestHtlcSatisfyPolicy(t *testing.T) {
 	var hash [32]byte
 
 	t.Run("satisfied", func(t *testing.T) {
-		result := link.HtlcSatifiesPolicy(hash, 1500, 1000,
+		result := link.CheckHtlcForward(hash, 1500, 1000,
 			200, 150, 0)
 		if result != nil {
 			t.Fatalf("expected policy to be satisfied")
@@ -5431,7 +5431,7 @@ func TestHtlcSatisfyPolicy(t *testing.T) {
 	})
 
 	t.Run("below minhtlc", func(t *testing.T) {
-		result := link.HtlcSatifiesPolicy(hash, 100, 50,
+		result := link.CheckHtlcForward(hash, 100, 50,
 			200, 150, 0)
 		if _, ok := result.(*lnwire.FailAmountBelowMinimum); !ok {
 			t.Fatalf("expected FailAmountBelowMinimum failure code")
@@ -5439,7 +5439,7 @@ func TestHtlcSatisfyPolicy(t *testing.T) {
 	})
 
 	t.Run("above maxhtlc", func(t *testing.T) {
-		result := link.HtlcSatifiesPolicy(hash, 1500, 1200,
+		result := link.CheckHtlcForward(hash, 1500, 1200,
 			200, 150, 0)
 		if _, ok := result.(*lnwire.FailTemporaryChannelFailure); !ok {
 			t.Fatalf("expected FailTemporaryChannelFailure failure code")
@@ -5447,7 +5447,7 @@ func TestHtlcSatisfyPolicy(t *testing.T) {
 	})
 
 	t.Run("insufficient fee", func(t *testing.T) {
-		result := link.HtlcSatifiesPolicy(hash, 1005, 1000,
+		result := link.CheckHtlcForward(hash, 1005, 1000,
 			200, 150, 0)
 		if _, ok := result.(*lnwire.FailFeeInsufficient); !ok {
 			t.Fatalf("expected FailFeeInsufficient failure code")
@@ -5455,7 +5455,7 @@ func TestHtlcSatisfyPolicy(t *testing.T) {
 	})
 
 	t.Run("expiry too soon", func(t *testing.T) {
-		result := link.HtlcSatifiesPolicy(hash, 1500, 1000,
+		result := link.CheckHtlcForward(hash, 1500, 1000,
 			200, 150, 190)
 		if _, ok := result.(*lnwire.FailExpiryTooSoon); !ok {
 			t.Fatalf("expected FailExpiryTooSoon failure code")
@@ -5463,7 +5463,7 @@ func TestHtlcSatisfyPolicy(t *testing.T) {
 	})
 
 	t.Run("incorrect cltv expiry", func(t *testing.T) {
-		result := link.HtlcSatifiesPolicy(hash, 1500, 1000,
+		result := link.CheckHtlcForward(hash, 1500, 1000,
 			200, 190, 0)
 		if _, ok := result.(*lnwire.FailIncorrectCltvExpiry); !ok {
 			t.Fatalf("expected FailIncorrectCltvExpiry failure code")
@@ -5473,7 +5473,7 @@ func TestHtlcSatisfyPolicy(t *testing.T) {
 
 	t.Run("cltv expiry too far in the future", func(t *testing.T) {
 		// Check that expiry isn't too far in the future.
-		result := link.HtlcSatifiesPolicy(hash, 1500, 1000,
+		result := link.CheckHtlcForward(hash, 1500, 1000,
 			10200, 10100, 0)
 		if _, ok := result.(*lnwire.FailExpiryTooFar); !ok {
 			t.Fatalf("expected FailExpiryTooFar failure code")

--- a/htlcswitch/link_test.go
+++ b/htlcswitch/link_test.go
@@ -5406,6 +5406,15 @@ func TestCheckHtlcForward(t *testing.T) {
 		return &lnwire.ChannelUpdate{}, nil
 	}
 
+	testChannel, _, fCleanUp, err := createTestChannel(
+		alicePrivKey, bobPrivKey, 100000, 100000,
+		1000, 1000, lnwire.ShortChannelID{},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer fCleanUp()
+
 	link := channelLink{
 		cfg: ChannelLinkConfig{
 			FwrdingPolicy: ForwardingPolicy{
@@ -5417,7 +5426,9 @@ func TestCheckHtlcForward(t *testing.T) {
 			FetchLastChannelUpdate: fetchLastChannelUpdate,
 			MaxOutgoingCltvExpiry:  DefaultMaxOutgoingCltvExpiry,
 		},
-		log: log,
+		log:           log,
+		channel:       testChannel.channel,
+		overflowQueue: newPacketQueue(input.MaxHTLCNumber / 2),
 	}
 
 	var hash [32]byte

--- a/htlcswitch/mock.go
+++ b/htlcswitch/mock.go
@@ -334,6 +334,7 @@ var _ hop.Iterator = (*mockHopIterator)(nil)
 // encodes the failure and do not makes any onion obfuscation.
 type mockObfuscator struct {
 	ogPacket *sphinx.OnionPacket
+	failure  lnwire.FailureMessage
 }
 
 // NewMockObfuscator initializes a dummy mockObfuscator used for testing.
@@ -365,6 +366,8 @@ func (o *mockObfuscator) Reextract(
 
 func (o *mockObfuscator) EncryptFirstHop(failure lnwire.FailureMessage) (
 	lnwire.OpaqueReason, error) {
+
+	o.failure = failure
 
 	var b bytes.Buffer
 	if err := lnwire.EncodeFailure(&b, failure, 0); err != nil {

--- a/htlcswitch/mock.go
+++ b/htlcswitch/mock.go
@@ -640,7 +640,9 @@ type mockChannelLink struct {
 
 	htlcID uint64
 
-	htlcSatifiesPolicyLocalResult lnwire.FailureMessage
+	checkHtlcTransitResult lnwire.FailureMessage
+
+	checkHtlcForwardResult lnwire.FailureMessage
 }
 
 // completeCircuit is a helper method for adding the finalized payment circuit
@@ -701,14 +703,15 @@ func (f *mockChannelLink) UpdateForwardingPolicy(_ ForwardingPolicy) {
 }
 func (f *mockChannelLink) CheckHtlcForward([32]byte, lnwire.MilliSatoshi,
 	lnwire.MilliSatoshi, uint32, uint32, uint32) lnwire.FailureMessage {
-	return nil
+
+	return f.checkHtlcForwardResult
 }
 
 func (f *mockChannelLink) CheckHtlcTransit(payHash [32]byte,
 	amt lnwire.MilliSatoshi, timeout uint32,
 	heightNow uint32) lnwire.FailureMessage {
 
-	return f.htlcSatifiesPolicyLocalResult
+	return f.checkHtlcTransitResult
 }
 
 func (f *mockChannelLink) Stats() (uint64, lnwire.MilliSatoshi, lnwire.MilliSatoshi) {

--- a/htlcswitch/mock.go
+++ b/htlcswitch/mock.go
@@ -696,12 +696,12 @@ func (f *mockChannelLink) HandleChannelUpdate(lnwire.Message) {
 
 func (f *mockChannelLink) UpdateForwardingPolicy(_ ForwardingPolicy) {
 }
-func (f *mockChannelLink) HtlcSatifiesPolicy([32]byte, lnwire.MilliSatoshi,
+func (f *mockChannelLink) CheckHtlcForward([32]byte, lnwire.MilliSatoshi,
 	lnwire.MilliSatoshi, uint32, uint32, uint32) lnwire.FailureMessage {
 	return nil
 }
 
-func (f *mockChannelLink) HtlcSatifiesPolicyLocal(payHash [32]byte,
+func (f *mockChannelLink) CheckHtlcTransit(payHash [32]byte,
 	amt lnwire.MilliSatoshi, timeout uint32,
 	heightNow uint32) lnwire.FailureMessage {
 

--- a/htlcswitch/switch.go
+++ b/htlcswitch/switch.go
@@ -775,7 +775,7 @@ func (s *Switch) handleLocalDispatch(pkt *htlcPacket) error {
 
 		// Ensure that the htlc satisfies the outgoing channel policy.
 		currentHeight := atomic.LoadUint32(&s.bestHeight)
-		htlcErr := link.HtlcSatifiesPolicyLocal(
+		htlcErr := link.CheckHtlcTransit(
 			htlc.PaymentHash,
 			htlc.Amount,
 			htlc.Expiry, currentHeight,
@@ -1050,7 +1050,7 @@ func (s *Switch) handlePacketForward(packet *htlcPacket) error {
 			// that the HTLC satisfies the current forwarding
 			// policy of this target link.
 			currentHeight := atomic.LoadUint32(&s.bestHeight)
-			err := link.HtlcSatifiesPolicy(
+			err := link.CheckHtlcForward(
 				htlc.PaymentHash, packet.incomingAmount,
 				packet.amount, packet.incomingTimeout,
 				packet.outgoingTimeout, currentHeight,

--- a/htlcswitch/switch.go
+++ b/htlcswitch/switch.go
@@ -1036,13 +1036,7 @@ func (s *Switch) handlePacketForward(packet *htlcPacket) error {
 		for _, link := range interfaceLinks {
 			// We'll skip any links that aren't yet eligible for
 			// forwarding.
-			switch {
-			case !link.EligibleToForward():
-				continue
-
-			// If the link doesn't yet have a source chan ID, then
-			// we'll skip it as well.
-			case link.ShortChanID() == hop.Source:
+			if !link.EligibleToForward() {
 				continue
 			}
 

--- a/htlcswitch/switch_test.go
+++ b/htlcswitch/switch_test.go
@@ -1405,7 +1405,7 @@ func testSkipLinkLocalForward(t *testing.T, eligible bool,
 	aliceChannelLink := newMockChannelLink(
 		s, chanID1, aliceChanID, alicePeer, eligible,
 	)
-	aliceChannelLink.htlcSatifiesPolicyLocalResult = policyResult
+	aliceChannelLink.checkHtlcTransitResult = policyResult
 	if err := s.AddLink(aliceChannelLink); err != nil {
 		t.Fatalf("unable to add alice link: %v", err)
 	}

--- a/htlcswitch/switch_test.go
+++ b/htlcswitch/switch_test.go
@@ -1299,10 +1299,10 @@ type multiHopFwdTest struct {
 // to forward any HTLC's.
 func TestSkipIneligibleLinksMultiHopForward(t *testing.T) {
 	tests := []multiHopFwdTest{
-		// None of the channels is eligible or has enough bandwidth.
+		// None of the channels is eligible.
 		{
 			name:          "not eligible",
-			expectedReply: lnwire.CodeTemporaryChannelFailure,
+			expectedReply: lnwire.CodeUnknownNextPeer,
 		},
 
 		// Channel one has a policy failure and the other channel isn't
@@ -1314,25 +1314,23 @@ func TestSkipIneligibleLinksMultiHopForward(t *testing.T) {
 			expectedReply: lnwire.CodeFinalIncorrectCltvExpiry,
 		},
 
-		// The requested channel is not eligible or has insufficient
-		// bandwidth, but the packet is forwarded through the other
-		// channel.
+		// The requested channel is not eligible, but the packet is
+		// forwarded through the other channel.
 		{
 			name:          "non-strict success",
 			eligible2:     true,
 			expectedReply: lnwire.CodeNone,
 		},
 
-		// The requested channel is not eligible or has insufficient
-		// bandwidth and the other channel's policy isn't satisfied.
-		//
-		// NOTE: We expect a temporary channel failure here, but don't
-		// receive it!
+		// The requested channel has insufficient bandwidth and the
+		// other channel's policy isn't satisfied.
 		{
 			name:          "non-strict policy fail",
+			eligible1:     true,
+			failure1:      lnwire.NewTemporaryChannelFailure(nil),
 			eligible2:     true,
 			failure2:      lnwire.NewFinalIncorrectCltvExpiry(0),
-			expectedReply: lnwire.CodeUnknownNextPeer,
+			expectedReply: lnwire.CodeTemporaryChannelFailure,
 		},
 	}
 

--- a/htlcswitch/test_utils.go
+++ b/htlcswitch/test_utils.go
@@ -92,27 +92,28 @@ var (
 
 var idSeqNum uint64
 
-func genIDs() (lnwire.ChannelID, lnwire.ChannelID, lnwire.ShortChannelID,
-	lnwire.ShortChannelID) {
-
-	id := atomic.AddUint64(&idSeqNum, 2)
+// genID generates a unique tuple to identify a test channel.
+func genID() (lnwire.ChannelID, lnwire.ShortChannelID) {
+	id := atomic.AddUint64(&idSeqNum, 1)
 
 	var scratch [8]byte
 
 	binary.BigEndian.PutUint64(scratch[:], id)
 	hash1, _ := chainhash.NewHash(bytes.Repeat(scratch[:], 4))
 
-	binary.BigEndian.PutUint64(scratch[:], id+1)
-	hash2, _ := chainhash.NewHash(bytes.Repeat(scratch[:], 4))
-
 	chanPoint1 := wire.NewOutPoint(hash1, uint32(id))
-	chanPoint2 := wire.NewOutPoint(hash2, uint32(id+1))
-
 	chanID1 := lnwire.NewChanIDFromOutPoint(chanPoint1)
-	chanID2 := lnwire.NewChanIDFromOutPoint(chanPoint2)
-
 	aliceChanID := lnwire.NewShortChanIDFromInt(id)
-	bobChanID := lnwire.NewShortChanIDFromInt(id + 1)
+
+	return chanID1, aliceChanID
+}
+
+// genIDs generates ids for two test channels.
+func genIDs() (lnwire.ChannelID, lnwire.ChannelID, lnwire.ShortChannelID,
+	lnwire.ShortChannelID) {
+
+	chanID1, aliceChanID := genID()
+	chanID2, bobChanID := genID()
 
 	return chanID1, chanID2, aliceChanID, bobChanID
 }


### PR DESCRIPTION
This PR fixes inconsistencies in the returned failure messages when forwarding non-strict.