### PR TITLE
channeldb: safe invoice migration

### DIFF
--- a/channeldb/meta_test.go
+++ b/channeldb/meta_test.go
@@ -70,6 +70,9 @@ func applyMigration(t *testing.T, beforeMigration, afterMigration func(d *DB),
 
 	// Sync with the latest version - applying migration function.
 	err = cdb.syncVersions(versions)
+	if err != nil {
+		log.Error(err)
+	}
 }
 
 // TestVersionFetchPut checks the propernces of fetch/put methods

--- a/channeldb/migration_11_invoices.go
+++ b/channeldb/migration_11_invoices.go
@@ -69,6 +69,11 @@ func migrateInvoices(tx *bbolt.Tx) error {
 			return err
 		}
 
+		if invoice.Terms.State == ContractAccepted {
+			return fmt.Errorf("cannot upgrade with invoice(s) " +
+				"in accepted state, see release notes")
+		}
+
 		// Try to decode the payment request for every possible net to
 		// avoid passing a the active network to channeldb. This would
 		// be a layering violation, while this migration is only running

--- a/channeldb/migration_11_invoices_test.go
+++ b/channeldb/migration_11_invoices_test.go
@@ -127,6 +127,32 @@ func TestMigrateInvoices(t *testing.T) {
 		false)
 }
 
+// TestMigrateInvoicesHodl checks that a hodl invoice in the accepted state
+// fails the migration.
+func TestMigrateInvoicesHodl(t *testing.T) {
+	t.Parallel()
+
+	payReqBtc, err := getPayReq(&bitcoinCfg.MainNetParams)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	invoices := []Invoice{
+		{
+			PaymentRequest: []byte(payReqBtc),
+			Terms: ContractTerm{
+				State: ContractAccepted,
+			},
+		},
+	}
+
+	applyMigration(t,
+		func(d *DB) { beforeMigrationFuncV11(t, d, invoices) },
+		func(d *DB) {},
+		migrateInvoices,
+		true)
+}
+
 // signDigestCompact generates a test signature to be used in the generation of
 // test payment requests.
 func signDigestCompact(hash []byte) ([]byte, error) {

--- a/channeldb/migration_11_invoices_test.go
+++ b/channeldb/migration_11_invoices_test.go
@@ -24,6 +24,43 @@ var (
 	testCltvDelta = int32(50)
 )
 
+// beforeMigrationFuncV11 insert the test invoices in the database.
+func beforeMigrationFuncV11(t *testing.T, d *DB, invoices []Invoice) {
+	err := d.Update(func(tx *bbolt.Tx) error {
+		invoicesBucket, err := tx.CreateBucketIfNotExists(
+			invoiceBucket,
+		)
+		if err != nil {
+			return err
+		}
+
+		invoiceNum := uint32(1)
+		for _, invoice := range invoices {
+			var invoiceKey [4]byte
+			byteOrder.PutUint32(invoiceKey[:], invoiceNum)
+			invoiceNum++
+
+			var buf bytes.Buffer
+			err := serializeInvoiceLegacy(&buf, &invoice) // nolint:scopelint
+			if err != nil {
+				return err
+			}
+
+			err = invoicesBucket.Put(
+				invoiceKey[:], buf.Bytes(),
+			)
+			if err != nil {
+				return err
+			}
+		}
+
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
 // TestMigrateInvoices checks that invoices are migrated correctly.
 func TestMigrateInvoices(t *testing.T) {
 	t.Parallel()
@@ -47,42 +84,6 @@ func TestMigrateInvoices(t *testing.T) {
 		{
 			PaymentRequest: []byte(payReqLtc),
 		},
-	}
-
-	beforeMigrationFunc := func(d *DB) {
-		err := d.Update(func(tx *bbolt.Tx) error {
-			invoicesBucket, err := tx.CreateBucketIfNotExists(
-				invoiceBucket,
-			)
-			if err != nil {
-				return err
-			}
-
-			invoiceNum := uint32(1)
-			for _, invoice := range invoices {
-				var invoiceKey [4]byte
-				byteOrder.PutUint32(invoiceKey[:], invoiceNum)
-				invoiceNum++
-
-				var buf bytes.Buffer
-				err := serializeInvoiceLegacy(&buf, &invoice)
-				if err != nil {
-					return err
-				}
-
-				err = invoicesBucket.Put(
-					invoiceKey[:], buf.Bytes(),
-				)
-				if err != nil {
-					return err
-				}
-			}
-
-			return nil
-		})
-		if err != nil {
-			t.Fatal(err)
-		}
 	}
 
 	// Verify that all invoices were migrated.
@@ -120,7 +121,7 @@ func TestMigrateInvoices(t *testing.T) {
 	}
 
 	applyMigration(t,
-		beforeMigrationFunc,
+		func(d *DB) { beforeMigrationFuncV11(t, d, invoices) },
 		afterMigrationFunc,
 		migrateInvoices,
 		false)


### PR DESCRIPTION
If the db migration is performed while there are accepted hodl invoices, held htlcs may be released on startup. 

Now that all invoice htlcs are tracked in the database, we are able to keep apart replays from new htlcs. For invoices that were accepted while running the previous version, there is no htlc entry present in the database. The consequence of this is that the htlc is evaluated as new and that it should again match the final cltv delta requirement, which may not necessarily be the case anymore. If it doesn't match, the held htlc is released and the node does not get paid.