### PR TITLE
Use stdlib "context" Package

### DIFF
--- a/cmd/lncli/commands.go
+++ b/cmd/lncli/commands.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bufio"
 	"bytes"
+	"context"
 	"encoding/hex"
 	"encoding/json"
 	"errors"
@@ -25,7 +26,6 @@ import (
 	"github.com/lightningnetwork/lnd/walletunlocker"
 	"github.com/urfave/cli"
 	"golang.org/x/crypto/ssh/terminal"
-	"golang.org/x/net/context"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )

--- a/lnd.go
+++ b/lnd.go
@@ -6,6 +6,7 @@ package lnd
 
 import (
 	"bytes"
+	"context"
 	"crypto/ecdsa"
 	"crypto/elliptic"
 	"crypto/rand"
@@ -29,8 +30,6 @@ import (
 	_ "net/http/pprof"
 
 	"gopkg.in/macaroon-bakery.v2/bakery"
-
-	"golang.org/x/net/context"
 
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"

--- a/lnrpc/routerrpc/router_backend.go
+++ b/lnrpc/routerrpc/router_backend.go
@@ -1,6 +1,7 @@
 package routerrpc
 
 import (
+	"context"
 	"encoding/hex"
 	"errors"
 	"fmt"
@@ -16,7 +17,6 @@ import (
 	"github.com/lightningnetwork/lnd/routing/route"
 	"github.com/lightningnetwork/lnd/tlv"
 	"github.com/lightningnetwork/lnd/zpay32"
-	context "golang.org/x/net/context"
 )
 
 // RouterBackend contains the backend implementation of the router rpc sub

--- a/lnrpc/walletrpc/walletkit_server.go
+++ b/lnrpc/walletrpc/walletkit_server.go
@@ -4,6 +4,7 @@ package walletrpc
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"fmt"
 	"io/ioutil"
@@ -19,7 +20,6 @@ import (
 	"github.com/lightningnetwork/lnd/lnrpc/signrpc"
 	"github.com/lightningnetwork/lnd/lnwallet"
 	"github.com/lightningnetwork/lnd/sweep"
-	"golang.org/x/net/context"
 	"google.golang.org/grpc"
 	"gopkg.in/macaroon-bakery.v2/bakery"
 )

--- a/lntest/harness.go
+++ b/lntest/harness.go
@@ -1,6 +1,7 @@
 package lntest
 
 import (
+	"context"
 	"encoding/hex"
 	"errors"
 	"fmt"
@@ -12,7 +13,6 @@ import (
 	"sync"
 	"time"
 
-	"golang.org/x/net/context"
 	"google.golang.org/grpc/grpclog"
 
 	"github.com/btcsuite/btcd/chaincfg"

--- a/lntest/itest/lnd_test.go
+++ b/lntest/itest/lnd_test.go
@@ -4,6 +4,7 @@ package itest
 
 import (
 	"bytes"
+	"context"
 	"crypto/rand"
 	"crypto/sha256"
 	"encoding/hex"
@@ -41,7 +42,6 @@ import (
 	"github.com/lightningnetwork/lnd/lntypes"
 	"github.com/lightningnetwork/lnd/lnwire"
 	"github.com/lightningnetwork/lnd/routing"
-	"golang.org/x/net/context"
 )
 
 var (

--- a/lntest/node.go
+++ b/lntest/node.go
@@ -2,6 +2,7 @@ package lntest
 
 import (
 	"bytes"
+	"context"
 	"encoding/hex"
 	"flag"
 	"fmt"
@@ -29,7 +30,6 @@ import (
 	"github.com/lightningnetwork/lnd/lnrpc/wtclientrpc"
 	"github.com/lightningnetwork/lnd/lntest/wait"
 	"github.com/lightningnetwork/lnd/macaroons"
-	"golang.org/x/net/context"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
 	"gopkg.in/macaroon.v2"

--- a/macaroons/auth.go
+++ b/macaroons/auth.go
@@ -1,9 +1,8 @@
 package macaroons
 
 import (
+	"context"
 	"encoding/hex"
-
-	"golang.org/x/net/context"
 
 	macaroon "gopkg.in/macaroon.v2"
 )

--- a/macaroons/constraints.go
+++ b/macaroons/constraints.go
@@ -1,6 +1,7 @@
 package macaroons
 
 import (
+	"context"
 	"fmt"
 	"net"
 	"time"
@@ -9,8 +10,6 @@ import (
 
 	"gopkg.in/macaroon-bakery.v2/bakery/checkers"
 	macaroon "gopkg.in/macaroon.v2"
-
-	"golang.org/x/net/context"
 )
 
 // Constraint type adds a layer of indirection over macaroon caveats.

--- a/macaroons/service.go
+++ b/macaroons/service.go
@@ -1,6 +1,7 @@
 package macaroons
 
 import (
+	"context"
 	"encoding/hex"
 	"fmt"
 	"os"
@@ -13,8 +14,6 @@ import (
 	"gopkg.in/macaroon-bakery.v2/bakery"
 	"gopkg.in/macaroon-bakery.v2/bakery/checkers"
 	macaroon "gopkg.in/macaroon.v2"
-
-	"golang.org/x/net/context"
 )
 
 var (

--- a/macaroons/store.go
+++ b/macaroons/store.go
@@ -1,11 +1,10 @@
 package macaroons
 
 import (
+	"context"
 	"crypto/rand"
 	"fmt"
 	"io"
-
-	"golang.org/x/net/context"
 
 	"github.com/coreos/bbolt"
 

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -2,6 +2,7 @@ package lnd
 
 import (
 	"bytes"
+	"context"
 	"crypto/tls"
 	"encoding/hex"
 	"errors"
@@ -55,7 +56,6 @@ import (
 	"github.com/lightningnetwork/lnd/sweep"
 	"github.com/lightningnetwork/lnd/zpay32"
 	"github.com/tv42/zbase32"
-	"golang.org/x/net/context"
 	"google.golang.org/grpc"
 	"gopkg.in/macaroon-bakery.v2/bakery"
 )

--- a/walletunlocker/service.go
+++ b/walletunlocker/service.go
@@ -1,6 +1,7 @@
 package walletunlocker
 
 import (
+	"context"
 	"crypto/rand"
 	"errors"
 	"fmt"
@@ -15,7 +16,6 @@ import (
 	"github.com/lightningnetwork/lnd/lnrpc"
 	"github.com/lightningnetwork/lnd/lnwallet"
 	"github.com/lightningnetwork/lnd/lnwallet/btcwallet"
-	"golang.org/x/net/context"
 )
 
 // ChannelsToRecover wraps any set of packed (serialized+encrypted) channel

--- a/walletunlocker/service_test.go
+++ b/walletunlocker/service_test.go
@@ -2,6 +2,7 @@ package walletunlocker_test
 
 import (
 	"bytes"
+	"context"
 	"io/ioutil"
 	"os"
 	"strings"
@@ -15,7 +16,6 @@ import (
 	"github.com/lightningnetwork/lnd/lnrpc"
 	"github.com/lightningnetwork/lnd/lnwallet/btcwallet"
 	"github.com/lightningnetwork/lnd/walletunlocker"
-	"golang.org/x/net/context"
 )
 
 var (


### PR DESCRIPTION
This PR changes packages across the project to use the standard library `context` package instead of the old `golang.org/x/net/context`.