### PR TITLE
lnwire/features: static_remote_key bits, 10/11 -> 12/13

### DIFF
--- a/lnwire/features.go
+++ b/lnwire/features.go
@@ -58,12 +58,12 @@ const (
 	// StaticRemoteKeyRequired is a required feature bit that signals that
 	// within one's commitment transaction, the key used for the remote
 	// party's non-delay output should not be tweaked.
-	StaticRemoteKeyRequired FeatureBit = 10
+	StaticRemoteKeyRequired FeatureBit = 12
 
 	// StaticRemoteKeyOptional is an optional feature bit that signals that
 	// within one's commitment transaction, the key used for the remote
 	// party's non-delay output should not be tweaked.
-	StaticRemoteKeyOptional FeatureBit = 11
+	StaticRemoteKeyOptional FeatureBit = 13
 
 	// maxAllowedSize is a maximum allowed size of feature vector.
 	//


### PR DESCRIPTION
Final version of spec allocated 12/13 to option_static_remote_key.
https://github.com/lightningnetwork/lightning-rfc/blob/master/09-features.md