### PR TITLE
htlcswitch: enforce fee floor on max fee allocation

### DIFF
--- a/lnwallet/channel.go
+++ b/lnwallet/channel.go
@@ -5,6 +5,7 @@ import (
 	"container/list"
 	"crypto/sha256"
 	"fmt"
+	"math"
 	"sort"
 	"sync"
 
@@ -6239,7 +6240,10 @@ func (lc *LightningChannel) MaxFeeRate(maxAllocation float64) SatPerKWeight {
 		balance.ToSatoshis() + lc.channelState.LocalCommitment.CommitFee,
 	)
 	maxFee := feeBalance * maxAllocation
-	return SatPerKWeight(maxFee / (float64(weight) / 1000))
+
+	// Ensure the fee rate doesn't dip below the fee floor.
+	maxFeeRate := maxFee / (float64(weight) / 1000)
+	return SatPerKWeight(math.Max(maxFeeRate, float64(FeePerKwFloor)))
 }
 
 // RemoteNextRevocation returns the channelState's RemoteNextRevocation.


### PR DESCRIPTION
Without this, it was possible for a combination of our balance and max fee allocation to result in a fee rate below the fee floor causing the remote party to reject the update and close the channel.