### PR TITLE
build/release: update release targets

### DIFF
--- a/build/release/release.sh
+++ b/build/release/release.sh
@@ -37,7 +37,28 @@ cd $MAINDIR
 
 # If LNDBUILDSYS is set the default list is ignored. Useful to release
 # for a subset of systems/architectures.
-SYS=${LNDBUILDSYS:-"windows-386 windows-amd64 openbsd-386 openbsd-amd64 linux-386 linux-amd64 linux-armv6 linux-armv7 linux-arm64 darwin-386 darwin-amd64 dragonfly-amd64 freebsd-386 freebsd-amd64 freebsd-arm netbsd-386 netbsd-amd64 linux-mips64 linux-mips64le linux-ppc64"}
+SYS=${LNDBUILDSYS:-"
+        darwin-386
+        darwin-amd64
+        dragonfly-amd64
+        freebsd-386
+        freebsd-amd64
+        freebsd-arm
+        linux-386
+        linux-amd64
+        linux-armv6
+        linux-armv7
+        linux-arm64
+        linux-ppc64
+        linux-mips64
+        linux-mips64le
+        netbsd-386
+        netbsd-amd64
+        openbsd-386
+        openbsd-amd64
+        windows-386
+        windows-amd64
+"}
 
 # Use the first element of $GOPATH in the case where GOPATH is a list
 # (something that is totally allowed).

--- a/build/release/release.sh
+++ b/build/release/release.sh
@@ -40,24 +40,37 @@ cd $MAINDIR
 SYS=${LNDBUILDSYS:-"
         darwin-386
         darwin-amd64
+        darwin-arm
+        darwin-arm64
         dragonfly-amd64
         freebsd-386
         freebsd-amd64
         freebsd-arm
+        illumos-amd64
         linux-386
         linux-amd64
         linux-armv6
         linux-armv7
         linux-arm64
         linux-ppc64
+        linux-ppc64le
+        linux-mips
+        linux-mipsle
         linux-mips64
         linux-mips64le
+        linux-s390x
         netbsd-386
         netbsd-amd64
+        netbsd-arm
+        netbsd-arm64
         openbsd-386
         openbsd-amd64
+        openbsd-arm
+        openbsd-arm64
+        solaris-amd64
         windows-386
         windows-amd64
+        windows-arm
 "}
 
 # Use the first element of $GOPATH in the case where GOPATH is a list


### PR DESCRIPTION
Notably, solaris/amd64 and illumos/amd64 were added in go1.13. The
others were have been supported previously but were not build targets