### PR TITLE
docker: fix ltcd ports

### DIFF
--- a/docker/btcd/start-btcctl.sh
+++ b/docker/btcd/start-btcctl.sh
@@ -45,7 +45,7 @@ NETWORK=$(set_default "$NETWORK" "simnet")
 
 PARAMS=""
 if [ "$NETWORK" != "mainnet" ]; then
-    PARAMS=$(echo --$NETWORK)
+    PARAMS="--$NETWORK"
 fi
 
 PARAMS=$(echo $PARAMS \

--- a/docker/btcd/start-btcd.sh
+++ b/docker/btcd/start-btcd.sh
@@ -46,7 +46,7 @@ NETWORK=$(set_default "$NETWORK" "simnet")
 
 PARAMS=""
 if [ "$NETWORK" != "mainnet" ]; then
-   PARAMS=$(echo --$NETWORK)
+   PARAMS="--$NETWORK"
 fi
 
 PARAMS=$(echo $PARAMS \
@@ -72,4 +72,3 @@ PARAMS="$PARAMS $@"
 # Print command and start bitcoin node.
 echo "Command: btcd $PARAMS"
 exec btcd $PARAMS
-

--- a/docker/ltcd/Dockerfile
+++ b/docker/ltcd/Dockerfile
@@ -14,16 +14,13 @@ RUN GO111MODULE=on go install . ./cmd/ltcctl ./cmd/gencerts
 FROM alpine as final
 
 # Expose mainnet ports (server, rpc)
-EXPOSE 8333 8334
+EXPOSE 9333 9334
 
 # Expose testnet ports (server, rpc)
-EXPOSE 18333 18334
+EXPOSE 19334 19335
 
 # Expose simnet ports (server, rpc)
 EXPOSE 18555 18556
-
-# Expose segnet ports (server, rpc)
-EXPOSE 28901 28902
 
 # Copy the compiled binaries from the builder image.
 COPY --from=builder /go/bin/ltcctl /bin/

--- a/docker/ltcd/start-ltcctl.sh
+++ b/docker/ltcd/start-ltcctl.sh
@@ -43,10 +43,17 @@ RPCUSER=$(set_default "$RPCUSER" "devuser")
 RPCPASS=$(set_default "$RPCPASS" "devpass")
 NETWORK=$(set_default "$NETWORK" "simnet")
 
-exec ltcctl \
-    "--$NETWORK" \
-    --rpccert="/rpc/rpc.cert" \
-    --rpcuser="$RPCUSER" \
-    --rpcpass="$RPCPASS" \
-    --rpcserver="rpcserver" \
-    "$@"
+PARAMS=""
+if [ "$NETWORK" != "mainnet" ]; then
+    PARAMS="--$NETWORK"
+fi
+
+PARAMS=$(echo $PARAMS \
+    "--rpccert=/rpc/rpc.cert" \
+    "--rpcuser=$RPCUSER" \
+    "--rpcpass=$RPCPASS" \
+    "--rpcserver=rpcserver" \
+)
+
+PARAMS="$PARAMS $@"
+exec ltcctl $PARAMS

--- a/docker/ltcd/start-ltcd.sh
+++ b/docker/ltcd/start-ltcd.sh
@@ -44,8 +44,12 @@ RPCPASS=$(set_default "$RPCPASS" "devpass")
 DEBUG=$(set_default "$DEBUG" "info")
 NETWORK=$(set_default "$NETWORK" "simnet")
 
-PARAMS=$(echo \
-    "--$NETWORK" \
+PARAMS=""
+if [ "$NETWORK" != "mainnet" ]; then
+   PARAMS="--$NETWORK"
+fi
+
+PARAMS=$(echo $PARAMS \
     "--debuglevel=$DEBUG" \
     "--rpcuser=$RPCUSER" \
     "--rpcpass=$RPCPASS" \
@@ -68,4 +72,3 @@ PARAMS="$PARAMS $@"
 # Print command and start bitcoin node.
 echo "Command: ltcd $PARAMS"
 exec ltcd $PARAMS
-


### PR DESCRIPTION
# Fixes `ltcd` ports inside the Dockerfile

The ports exposed in the Dockerfile for Litecoin `ltcd` are wrong. It is therefore not possible to connect to the `ltcd` container from another container without this fix.

The Litecoin ports are as follows:

* Mainnet: Server `9333` and RPC `9334`
* Testnet: Server `19335` and RPC `19334`
* Simnet: Server `18555` and RPC `18556`

Those ports can easily be verified by starting the docker-container for `ltcd` (`NETWORK="testnet" docker-up -d ltcd`) and check the log (`docker logs ltcd`). 

Further, the Litecoin "segnet" has apparently been merged into the "testnet" and the network options has been changed accordingly inside the start scripts `start-ltcd.sh` and `start-ltcctl.sh` (follows the start script for `btcd`). There is not option to set network to "segnet" for `ltcd` anymore.