### PR TITLE
Documentation only: Update recovery.md

### DIFF
--- a/docs/recovery.md
+++ b/docs/recovery.md
@@ -240,7 +240,7 @@ process.
 There are multiple ways of obtaining SCBs from `lnd`. The most commonly used
 method will likely be via the `channels.backup` file that's stored on-disk
 alongside the rest of the chain data. This is a special file that contains SCB
-entries for _all_ currently open channels. Each time a channel is opened or
+entries for _all_ currently open channels. Each time a channel is opened, changed, or
 closed, this file is updated on disk in a safe manner (atomic file rename). As
 a result, unlike the `channel.db` file, it's _always_ safe to copy this file
 for backup at ones desired location. The default location on Linux is: 


### PR DESCRIPTION
The original text says that the SCB file is only updated on open/close of a channel.

But observed behavior is that it is also updated when a channel 'changes' - typically when funds move from one end to the other as an HTLC passes through without closing the channel.

Am I correct?

#### Pull Request Checklist

- [x] If this is your first time contributing, we recommend you read the [Code
  Contribution Guidelines](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md)
- [x] All changes are Go version 1.12 compliant
- [x] The code being submitted is commented according to [Code Documentation and Commenting](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#CodeDocumentation)
- [x] For new code: Code is accompanied by tests which exercise both
  the positive and negative (error paths) conditions (if applicable)
- [x] For bug fixes: Code is accompanied by new tests which trigger
  the bug being fixed to prevent regressions
- [x] Any new logging statements use an appropriate subsystem and
  logging level
- [x] Code has been formatted with `go fmt`
- [x] For code and documentation: lines are wrapped at 80 characters
  (the tab character should be counted as 8 characters, not 4, as some IDEs do
  per default)
- [x] Running `make check` does not fail any tests
- [x] Running `go vet` does not report any issues
- [x] Running `make lint` does not report any **new** issues that did not
  already exist
- [x] All commits build properly and pass tests. Only in exceptional
  cases it can be justifiable to violate this condition. In that case, the
  reason should be stated in the commit message.
- [x] Commits have a logical structure according to [Ideal Git Commit Structure](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#IdealGitCommitStructure)
