### PR TITLE
cnct: decode onion for incoming contest resolver

### DIFF
--- a/contractcourt/briefcase_test.go
+++ b/contractcourt/briefcase_test.go
@@ -161,9 +161,9 @@ func assertResolversEqual(t *testing.T, originalResolver ContractResolver,
 			t.Fatalf("expected %v, got %v",
 				ogRes.broadcastHeight, diskRes.broadcastHeight)
 		}
-		if ogRes.htlcIndex != diskRes.htlcIndex {
-			t.Fatalf("expected %v, got %v", ogRes.htlcIndex,
-				diskRes.htlcIndex)
+		if ogRes.htlc.HtlcIndex != diskRes.htlc.HtlcIndex {
+			t.Fatalf("expected %v, got %v", ogRes.htlc.HtlcIndex,
+				diskRes.htlc.HtlcIndex)
 		}
 	}
 
@@ -184,9 +184,9 @@ func assertResolversEqual(t *testing.T, originalResolver ContractResolver,
 			t.Fatalf("expected %v, got %v",
 				ogRes.broadcastHeight, diskRes.broadcastHeight)
 		}
-		if ogRes.payHash != diskRes.payHash {
-			t.Fatalf("expected %v, got %v", ogRes.payHash,
-				diskRes.payHash)
+		if ogRes.htlc.RHash != diskRes.htlc.RHash {
+			t.Fatalf("expected %v, got %v", ogRes.htlc.RHash,
+				diskRes.htlc.RHash)
 		}
 	}
 
@@ -265,7 +265,9 @@ func TestContractInsertionRetrieval(t *testing.T) {
 		outputIncubating: true,
 		resolved:         true,
 		broadcastHeight:  102,
-		htlcIndex:        12,
+		htlc: channeldb.HTLC{
+			HtlcIndex: 12,
+		},
 	}
 	successResolver := htlcSuccessResolver{
 		htlcResolution: lnwallet.IncomingHtlcResolution{
@@ -278,8 +280,10 @@ func TestContractInsertionRetrieval(t *testing.T) {
 		outputIncubating: true,
 		resolved:         true,
 		broadcastHeight:  109,
-		payHash:          testPreimage,
-		sweepTx:          nil,
+		htlc: channeldb.HTLC{
+			RHash: testPreimage,
+		},
+		sweepTx: nil,
 	}
 	resolvers := []ContractResolver{
 		&timeoutResolver,
@@ -395,7 +399,9 @@ func TestContractResolution(t *testing.T) {
 		outputIncubating: true,
 		resolved:         true,
 		broadcastHeight:  192,
-		htlcIndex:        9912,
+		htlc: channeldb.HTLC{
+			HtlcIndex: 9912,
+		},
 	}
 
 	// First, we'll insert the resolver into the database and ensure that
@@ -454,7 +460,9 @@ func TestContractSwapping(t *testing.T) {
 		outputIncubating: true,
 		resolved:         true,
 		broadcastHeight:  102,
-		htlcIndex:        12,
+		htlc: channeldb.HTLC{
+			HtlcIndex: 12,
+		},
 	}
 	contestResolver := &htlcOutgoingContestResolver{
 		htlcTimeoutResolver: timeoutResolver,

--- a/contractcourt/chain_arbitrator.go
+++ b/contractcourt/chain_arbitrator.go
@@ -151,6 +151,10 @@ type ChainArbitratorConfig struct {
 	// NotifyClosedChannel is a function closure that the ChainArbitrator
 	// will use to notify the ChannelNotifier about a newly closed channel.
 	NotifyClosedChannel func(wire.OutPoint)
+
+	// OnionProcessor is used to decode onion payloads for on-chain
+	// resolution.
+	OnionProcessor OnionProcessor
 }
 
 // ChainArbitrator is a sub-system that oversees the on-chain resolution of all

--- a/contractcourt/channel_arbitrator.go
+++ b/contractcourt/channel_arbitrator.go
@@ -1647,6 +1647,8 @@ func (c *ChannelArbitrator) prepContractResolutions(
 		// claim the HTLC (second-level or directly), then add the pre
 		case HtlcClaimAction:
 			for _, htlc := range htlcs {
+				htlc := htlc
+
 				htlcOp := wire.OutPoint{
 					Hash:  commitHash,
 					Index: uint32(htlc.OutputIndex),
@@ -1662,8 +1664,7 @@ func (c *ChannelArbitrator) prepContractResolutions(
 				}
 
 				resolver := newSuccessResolver(
-					resolution, height,
-					htlc.RHash, htlc.Amt, resolverCfg,
+					resolution, height, htlc, resolverCfg,
 				)
 				htlcResolvers = append(htlcResolvers, resolver)
 			}
@@ -1673,6 +1674,8 @@ func (c *ChannelArbitrator) prepContractResolutions(
 		// backwards.
 		case HtlcTimeoutAction:
 			for _, htlc := range htlcs {
+				htlc := htlc
+
 				htlcOp := wire.OutPoint{
 					Hash:  commitHash,
 					Index: uint32(htlc.OutputIndex),
@@ -1686,8 +1689,7 @@ func (c *ChannelArbitrator) prepContractResolutions(
 				}
 
 				resolver := newTimeoutResolver(
-					resolution, height, htlc.HtlcIndex,
-					htlc.Amt, resolverCfg,
+					resolution, height, htlc, resolverCfg,
 				)
 				htlcResolvers = append(htlcResolvers, resolver)
 			}
@@ -1697,6 +1699,8 @@ func (c *ChannelArbitrator) prepContractResolutions(
 		// learn of the pre-image, or let the remote party time out.
 		case HtlcIncomingWatchAction:
 			for _, htlc := range htlcs {
+				htlc := htlc
+
 				htlcOp := wire.OutPoint{
 					Hash:  commitHash,
 					Index: uint32(htlc.OutputIndex),
@@ -1713,15 +1717,9 @@ func (c *ChannelArbitrator) prepContractResolutions(
 					continue
 				}
 
-				circuitKey := channeldb.CircuitKey{
-					HtlcID: htlc.HtlcIndex,
-					ChanID: c.cfg.ShortChanID,
-				}
-
 				resolver := newIncomingContestResolver(
-					htlc.RefundTimeout, circuitKey,
-					resolution, height, htlc.RHash,
-					htlc.Amt, resolverCfg,
+					resolution, height, htlc,
+					resolverCfg,
 				)
 				htlcResolvers = append(htlcResolvers, resolver)
 			}
@@ -1731,6 +1729,8 @@ func (c *ChannelArbitrator) prepContractResolutions(
 		// backwards), or just timeout.
 		case HtlcOutgoingWatchAction:
 			for _, htlc := range htlcs {
+				htlc := htlc
+
 				htlcOp := wire.OutPoint{
 					Hash:  commitHash,
 					Index: uint32(htlc.OutputIndex),
@@ -1745,8 +1745,7 @@ func (c *ChannelArbitrator) prepContractResolutions(
 				}
 
 				resolver := newOutgoingContestResolver(
-					resolution, height, htlc.HtlcIndex,
-					htlc.Amt, resolverCfg,
+					resolution, height, htlc, resolverCfg,
 				)
 				htlcResolvers = append(htlcResolvers, resolver)
 			}

--- a/contractcourt/channel_arbitrator.go
+++ b/contractcourt/channel_arbitrator.go
@@ -1152,8 +1152,10 @@ func (c *ChannelArbitrator) checkCommitChainActions(height uint32,
 	//  * race condition if adding and we broadcast, etc
 	//  * or would make each instance sync?
 
-	log.Debugf("ChannelArbitrator(%v): checking chain actions at "+
-		"height=%v", c.cfg.ChanPoint, height)
+	log.Debugf("ChannelArbitrator(%v): checking commit chain actions at "+
+		"height=%v, in_htlc_count=%v, out_htlc_count=%v",
+		c.cfg.ChanPoint, height,
+		len(htlcs.incomingHTLCs), len(htlcs.outgoingHTLCs))
 
 	actionMap := make(ChainActionMap)
 

--- a/contractcourt/channel_arbitrator_test.go
+++ b/contractcourt/channel_arbitrator_test.go
@@ -858,10 +858,10 @@ func TestChannelArbitratorLocalForceClosePendingHtlc(t *testing.T) {
 			resolver)
 	}
 
-	// The resolver should have its htlcAmt field populated as it.
-	if int64(outgoingResolver.htlcAmt) != int64(htlcAmt) {
+	// The resolver should have its htlc amt field populated as it.
+	if int64(outgoingResolver.htlc.Amt) != int64(htlcAmt) {
 		t.Fatalf("wrong htlc amount: expected %v, got %v,",
-			htlcAmt, int64(outgoingResolver.htlcAmt))
+			htlcAmt, int64(outgoingResolver.htlc.Amt))
 	}
 
 	// htlcOutgoingContestResolver is now active and waiting for the HTLC to

--- a/contractcourt/channel_arbitrator_test.go
+++ b/contractcourt/channel_arbitrator_test.go
@@ -308,6 +308,7 @@ func createTestChannelArbitrator(t *testing.T, log ArbitratorLog) (*chanArbTestC
 			incubateChan <- struct{}{}
 			return nil
 		},
+		OnionProcessor: &mockOnionProcessor{},
 	}
 
 	// We'll use the resolvedChan to synchronize on call to

--- a/contractcourt/contract_resolvers.go
+++ b/contractcourt/contract_resolvers.go
@@ -4,6 +4,9 @@ import (
 	"encoding/binary"
 	"errors"
 	"io"
+
+	"github.com/btcsuite/btcd/wire"
+	"github.com/lightningnetwork/lnd/channeldb"
 )
 
 var (
@@ -49,6 +52,18 @@ type ContractResolver interface {
 	// Stop signals the resolver to cancel any current resolution
 	// processes, and suspend.
 	Stop()
+}
+
+// htlcContractResolver is the required interface for htlc resolvers.
+type htlcContractResolver interface {
+	ContractResolver
+
+	// HtlcPoint returns the htlc's outpoint on the commitment tx.
+	HtlcPoint() wire.OutPoint
+
+	// Supplement adds additional information to the resolver that is
+	// required before Resolve() is called.
+	Supplement(htlc channeldb.HTLC)
 }
 
 // reportingContractResolver is a ContractResolver that also exposes a report on

--- a/contractcourt/htlc_incoming_contest_resolver.go
+++ b/contractcourt/htlc_incoming_contest_resolver.go
@@ -338,6 +338,18 @@ func newIncomingContestResolverFromReader(r io.Reader, resCfg ResolverConfig) (
 	return h, nil
 }
 
+// Supplement adds additional information to the resolver that is required
+// before Resolve() is called.
+//
+// NOTE: Part of the htlcContractResolver interface.
+func (h *htlcIncomingContestResolver) Supplement(htlc channeldb.HTLC) {
+	h.htlcAmt = htlc.Amt
+	h.circuitKey = channeldb.CircuitKey{
+		ChanID: h.ShortChanID,
+		HtlcID: htlc.HtlcIndex,
+	}
+}
+
 // A compile time assertion to ensure htlcIncomingContestResolver meets the
 // ContractResolver interface.
-var _ ContractResolver = (*htlcIncomingContestResolver)(nil)
+var _ htlcContractResolver = (*htlcIncomingContestResolver)(nil)

--- a/contractcourt/htlc_incoming_resolver_test.go
+++ b/contractcourt/htlc_incoming_resolver_test.go
@@ -210,7 +210,9 @@ func newIncomingResolverTestContext(t *testing.T) *incomingResolverTestContext {
 		htlcSuccessResolver: htlcSuccessResolver{
 			contractResolverKit: *newContractResolverKit(cfg),
 			htlcResolution:      lnwallet.IncomingHtlcResolution{},
-			payHash:             testResHash,
+			htlc: channeldb.HTLC{
+				RHash: testResHash,
+			},
 		},
 		htlcExpiry: testHtlcExpiry,
 	}

--- a/contractcourt/htlc_incoming_resolver_test.go
+++ b/contractcourt/htlc_incoming_resolver_test.go
@@ -2,9 +2,12 @@ package contractcourt
 
 import (
 	"bytes"
+	"io"
+	"io/ioutil"
 	"testing"
 
 	"github.com/lightningnetwork/lnd/channeldb"
+	"github.com/lightningnetwork/lnd/htlcswitch/hop"
 	"github.com/lightningnetwork/lnd/invoices"
 	"github.com/lightningnetwork/lnd/lnwallet"
 
@@ -21,6 +24,7 @@ var (
 	testResPreimage   = lntypes.Preimage{1, 2, 3}
 	testResHash       = testResPreimage.Hash()
 	testResCircuitKey = channeldb.CircuitKey{}
+	testOnionBlob     = []byte{4, 5, 6}
 )
 
 // TestHtlcIncomingResolverFwdPreimageKnown tests resolution of a forwarded htlc
@@ -107,6 +111,12 @@ func TestHtlcIncomingResolverExitSettle(t *testing.T) {
 	}
 
 	ctx.waitForResult(true)
+
+	if !bytes.Equal(
+		ctx.onionProcessor.offeredOnionBlob, testOnionBlob,
+	) {
+		t.Fatal("unexpected onion blob")
+	}
 }
 
 // TestHtlcIncomingResolverExitCancel tests resolution of an exit hop htlc for
@@ -168,14 +178,39 @@ func TestHtlcIncomingResolverExitCancelHodl(t *testing.T) {
 	ctx.waitForResult(false)
 }
 
+type mockHopIterator struct {
+	hop.Iterator
+}
+
+func (h *mockHopIterator) HopPayload() (*hop.Payload, error) {
+	return nil, nil
+}
+
+type mockOnionProcessor struct {
+	offeredOnionBlob []byte
+}
+
+func (o *mockOnionProcessor) ReconstructHopIterator(r io.Reader, rHash []byte) (
+	hop.Iterator, error) {
+
+	data, err := ioutil.ReadAll(r)
+	if err != nil {
+		return nil, err
+	}
+	o.offeredOnionBlob = data
+
+	return &mockHopIterator{}, nil
+}
+
 type incomingResolverTestContext struct {
-	registry      *mockRegistry
-	witnessBeacon *mockWitnessBeacon
-	resolver      *htlcIncomingContestResolver
-	notifier      *mockNotifier
-	resolveErr    chan error
-	nextResolver  ContractResolver
-	t             *testing.T
+	registry       *mockRegistry
+	witnessBeacon  *mockWitnessBeacon
+	resolver       *htlcIncomingContestResolver
+	notifier       *mockNotifier
+	onionProcessor *mockOnionProcessor
+	resolveErr     chan error
+	nextResolver   ContractResolver
+	t              *testing.T
 }
 
 func newIncomingResolverTestContext(t *testing.T) *incomingResolverTestContext {
@@ -189,13 +224,16 @@ func newIncomingResolverTestContext(t *testing.T) *incomingResolverTestContext {
 		notifyChan: make(chan notifyExitHopData, 1),
 	}
 
+	onionProcessor := &mockOnionProcessor{}
+
 	checkPointChan := make(chan struct{}, 1)
 
 	chainCfg := ChannelArbitratorConfig{
 		ChainArbitratorConfig: ChainArbitratorConfig{
-			Notifier:   notifier,
-			PreimageDB: witnessBeacon,
-			Registry:   registry,
+			Notifier:       notifier,
+			PreimageDB:     witnessBeacon,
+			Registry:       registry,
+			OnionProcessor: onionProcessor,
 		},
 	}
 
@@ -211,18 +249,20 @@ func newIncomingResolverTestContext(t *testing.T) *incomingResolverTestContext {
 			contractResolverKit: *newContractResolverKit(cfg),
 			htlcResolution:      lnwallet.IncomingHtlcResolution{},
 			htlc: channeldb.HTLC{
-				RHash: testResHash,
+				RHash:     testResHash,
+				OnionBlob: testOnionBlob,
 			},
 		},
 		htlcExpiry: testHtlcExpiry,
 	}
 
 	return &incomingResolverTestContext{
-		registry:      registry,
-		witnessBeacon: witnessBeacon,
-		resolver:      resolver,
-		notifier:      notifier,
-		t:             t,
+		registry:       registry,
+		witnessBeacon:  witnessBeacon,
+		resolver:       resolver,
+		notifier:       notifier,
+		onionProcessor: onionProcessor,
+		t:              t,
 	}
 }
 

--- a/contractcourt/htlc_outgoing_contest_resolver.go
+++ b/contractcourt/htlc_outgoing_contest_resolver.go
@@ -215,4 +215,4 @@ func newOutgoingContestResolverFromReader(r io.Reader, resCfg ResolverConfig) (
 
 // A compile time assertion to ensure htlcOutgoingContestResolver meets the
 // ContractResolver interface.
-var _ ContractResolver = (*htlcOutgoingContestResolver)(nil)
+var _ htlcContractResolver = (*htlcOutgoingContestResolver)(nil)

--- a/contractcourt/htlc_outgoing_contest_resolver.go
+++ b/contractcourt/htlc_outgoing_contest_resolver.go
@@ -5,8 +5,8 @@ import (
 	"io"
 
 	"github.com/btcsuite/btcutil"
+	"github.com/lightningnetwork/lnd/channeldb"
 	"github.com/lightningnetwork/lnd/lnwallet"
-	"github.com/lightningnetwork/lnd/lnwire"
 )
 
 // htlcOutgoingContestResolver is a ContractResolver that's able to resolve an
@@ -23,11 +23,11 @@ type htlcOutgoingContestResolver struct {
 // newOutgoingContestResolver instantiates a new outgoing contested htlc
 // resolver.
 func newOutgoingContestResolver(res lnwallet.OutgoingHtlcResolution,
-	broadcastHeight uint32, htlcIndex uint64, htlcAmt lnwire.MilliSatoshi,
+	broadcastHeight uint32, htlc channeldb.HTLC,
 	resCfg ResolverConfig) *htlcOutgoingContestResolver {
 
 	timeout := newTimeoutResolver(
-		res, broadcastHeight, htlcIndex, htlcAmt, resCfg,
+		res, broadcastHeight, htlc, resCfg,
 	)
 
 	return &htlcOutgoingContestResolver{
@@ -157,7 +157,7 @@ func (h *htlcOutgoingContestResolver) Resolve() (ContractResolver, error) {
 func (h *htlcOutgoingContestResolver) report() *ContractReport {
 	// No locking needed as these values are read-only.
 
-	finalAmt := h.htlcAmt.ToSatoshis()
+	finalAmt := h.htlc.Amt.ToSatoshis()
 	if h.htlcResolution.SignedTimeoutTx != nil {
 		finalAmt = btcutil.Amount(
 			h.htlcResolution.SignedTimeoutTx.TxOut[0].Value,

--- a/contractcourt/htlc_outgoing_contest_resolver_test.go
+++ b/contractcourt/htlc_outgoing_contest_resolver_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/btcsuite/btcd/wire"
 	"github.com/lightningnetwork/lnd/chainntnfs"
+	"github.com/lightningnetwork/lnd/channeldb"
 	"github.com/lightningnetwork/lnd/input"
 	"github.com/lightningnetwork/lnd/lntypes"
 	"github.com/lightningnetwork/lnd/lnwallet"
@@ -98,6 +99,8 @@ func newOutgoingResolverTestContext(t *testing.T) *outgoingResolverTestContext {
 
 	preimageDB := newMockWitnessBeacon()
 
+	onionProcessor := &mockOnionProcessor{}
+
 	chainCfg := ChannelArbitratorConfig{
 		ChainArbitratorConfig: ChainArbitratorConfig{
 			Notifier:   notifier,
@@ -112,6 +115,7 @@ func newOutgoingResolverTestContext(t *testing.T) *outgoingResolverTestContext {
 				resolutionChan <- msgs[0]
 				return nil
 			},
+			OnionProcessor: onionProcessor,
 		},
 	}
 
@@ -134,6 +138,10 @@ func newOutgoingResolverTestContext(t *testing.T) *outgoingResolverTestContext {
 		htlcTimeoutResolver: htlcTimeoutResolver{
 			contractResolverKit: *newContractResolverKit(cfg),
 			htlcResolution:      outgoingRes,
+			htlc: channeldb.HTLC{
+				RHash:     testResHash,
+				OnionBlob: testOnionBlob,
+			},
 		},
 	}
 

--- a/contractcourt/htlc_success_resolver.go
+++ b/contractcourt/htlc_success_resolver.go
@@ -8,9 +8,7 @@ import (
 	"github.com/davecgh/go-spew/spew"
 	"github.com/lightningnetwork/lnd/channeldb"
 	"github.com/lightningnetwork/lnd/input"
-	"github.com/lightningnetwork/lnd/lntypes"
 	"github.com/lightningnetwork/lnd/lnwallet"
-	"github.com/lightningnetwork/lnd/lnwire"
 	"github.com/lightningnetwork/lnd/sweep"
 )
 
@@ -39,9 +37,6 @@ type htlcSuccessResolver struct {
 	// historical queries to the chain for spends/confirmations.
 	broadcastHeight uint32
 
-	// payHash is the payment hash of the original HTLC extended to us.
-	payHash lntypes.Hash
-
 	// sweepTx will be non-nil if we've already crafted a transaction to
 	// sweep a direct HTLC output. This is only a concern if we're sweeping
 	// from the commitment transaction of the remote party.
@@ -49,25 +44,22 @@ type htlcSuccessResolver struct {
 	// TODO(roasbeef): send off to utxobundler
 	sweepTx *wire.MsgTx
 
-	// htlcAmt is the original amount of the htlc, not taking into
-	// account any fees that may have to be paid if it goes on chain.
-	htlcAmt lnwire.MilliSatoshi
+	// htlc contains information on the htlc that we are resolving on-chain.
+	htlc channeldb.HTLC
 
 	contractResolverKit
 }
 
 // newSuccessResolver instanties a new htlc success resolver.
 func newSuccessResolver(res lnwallet.IncomingHtlcResolution,
-	broadcastHeight uint32, payHash lntypes.Hash,
-	htlcAmt lnwire.MilliSatoshi,
+	broadcastHeight uint32, htlc channeldb.HTLC,
 	resCfg ResolverConfig) *htlcSuccessResolver {
 
 	return &htlcSuccessResolver{
 		contractResolverKit: *newContractResolverKit(resCfg),
 		htlcResolution:      res,
 		broadcastHeight:     broadcastHeight,
-		payHash:             payHash,
-		htlcAmt:             htlcAmt,
+		htlc:                htlc,
 	}
 }
 
@@ -115,7 +107,7 @@ func (h *htlcSuccessResolver) Resolve() (ContractResolver, error) {
 		if h.sweepTx == nil {
 			log.Infof("%T(%x): crafting sweep tx for "+
 				"incoming+remote htlc confirmed", h,
-				h.payHash[:])
+				h.htlc.RHash[:])
 
 			// Before we can craft out sweeping transaction, we
 			// need to create an input which contains all the items
@@ -149,7 +141,7 @@ func (h *htlcSuccessResolver) Resolve() (ContractResolver, error) {
 			}
 
 			log.Infof("%T(%x): crafted sweep tx=%v", h,
-				h.payHash[:], spew.Sdump(h.sweepTx))
+				h.htlc.RHash[:], spew.Sdump(h.sweepTx))
 
 			// With the sweep transaction signed, we'll now
 			// Checkpoint our state.
@@ -165,7 +157,7 @@ func (h *htlcSuccessResolver) Resolve() (ContractResolver, error) {
 		err := h.PublishTx(h.sweepTx)
 		if err != nil {
 			log.Infof("%T(%x): unable to publish tx: %v",
-				h, h.payHash[:], err)
+				h, h.htlc.RHash[:], err)
 			return nil, err
 		}
 
@@ -181,7 +173,7 @@ func (h *htlcSuccessResolver) Resolve() (ContractResolver, error) {
 		}
 
 		log.Infof("%T(%x): waiting for sweep tx (txid=%v) to be "+
-			"confirmed", h, h.payHash[:], sweepTXID)
+			"confirmed", h, h.htlc.RHash[:], sweepTXID)
 
 		select {
 		case _, ok := <-confNtfn.Confirmed:
@@ -200,7 +192,7 @@ func (h *htlcSuccessResolver) Resolve() (ContractResolver, error) {
 	}
 
 	log.Infof("%T(%x): broadcasting second-layer transition tx: %v",
-		h, h.payHash[:], spew.Sdump(h.htlcResolution.SignedSuccessTx))
+		h, h.htlc.RHash[:], spew.Sdump(h.htlcResolution.SignedSuccessTx))
 
 	// We'll now broadcast the second layer transaction so we can kick off
 	// the claiming process.
@@ -216,7 +208,7 @@ func (h *htlcSuccessResolver) Resolve() (ContractResolver, error) {
 	// done so.
 	if !h.outputIncubating {
 		log.Infof("%T(%x): incubating incoming htlc output",
-			h, h.payHash[:])
+			h, h.htlc.RHash[:])
 
 		err := h.IncubateOutputs(
 			h.ChanPoint, nil, nil, &h.htlcResolution,
@@ -246,7 +238,7 @@ func (h *htlcSuccessResolver) Resolve() (ContractResolver, error) {
 	}
 
 	log.Infof("%T(%x): waiting for second-level HTLC output to be spent "+
-		"after csv_delay=%v", h, h.payHash[:], h.htlcResolution.CsvDelay)
+		"after csv_delay=%v", h, h.htlc.RHash[:], h.htlcResolution.CsvDelay)
 
 	select {
 	case _, ok := <-spendNtfn.Spend:
@@ -299,7 +291,7 @@ func (h *htlcSuccessResolver) Encode(w io.Writer) error {
 	if err := binary.Write(w, endian, h.broadcastHeight); err != nil {
 		return err
 	}
-	if _, err := w.Write(h.payHash[:]); err != nil {
+	if _, err := w.Write(h.htlc.RHash[:]); err != nil {
 		return err
 	}
 
@@ -332,7 +324,7 @@ func newSuccessResolverFromReader(r io.Reader, resCfg ResolverConfig) (
 	if err := binary.Read(r, endian, &h.broadcastHeight); err != nil {
 		return nil, err
 	}
-	if _, err := io.ReadFull(r, h.payHash[:]); err != nil {
+	if _, err := io.ReadFull(r, h.htlc.RHash[:]); err != nil {
 		return nil, err
 	}
 
@@ -344,7 +336,7 @@ func newSuccessResolverFromReader(r io.Reader, resCfg ResolverConfig) (
 //
 // NOTE: Part of the htlcContractResolver interface.
 func (h *htlcSuccessResolver) Supplement(htlc channeldb.HTLC) {
-	h.htlcAmt = htlc.Amt
+	h.htlc = htlc
 }
 
 // HtlcPoint returns the htlc's outpoint on the commitment tx.

--- a/contractcourt/htlc_success_resolver.go
+++ b/contractcourt/htlc_success_resolver.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/btcsuite/btcd/wire"
 	"github.com/davecgh/go-spew/spew"
+	"github.com/lightningnetwork/lnd/channeldb"
 	"github.com/lightningnetwork/lnd/input"
 	"github.com/lightningnetwork/lnd/lntypes"
 	"github.com/lightningnetwork/lnd/lnwallet"
@@ -338,6 +339,21 @@ func newSuccessResolverFromReader(r io.Reader, resCfg ResolverConfig) (
 	return h, nil
 }
 
+// Supplement adds additional information to the resolver that is required
+// before Resolve() is called.
+//
+// NOTE: Part of the htlcContractResolver interface.
+func (h *htlcSuccessResolver) Supplement(htlc channeldb.HTLC) {
+	h.htlcAmt = htlc.Amt
+}
+
+// HtlcPoint returns the htlc's outpoint on the commitment tx.
+//
+// NOTE: Part of the htlcContractResolver interface.
+func (h *htlcSuccessResolver) HtlcPoint() wire.OutPoint {
+	return h.htlcResolution.HtlcPoint()
+}
+
 // A compile time assertion to ensure htlcSuccessResolver meets the
 // ContractResolver interface.
-var _ ContractResolver = (*htlcSuccessResolver)(nil)
+var _ htlcContractResolver = (*htlcSuccessResolver)(nil)

--- a/contractcourt/htlc_timeout_resolver.go
+++ b/contractcourt/htlc_timeout_resolver.go
@@ -8,6 +8,7 @@ import (
 	"github.com/btcsuite/btcd/wire"
 	"github.com/davecgh/go-spew/spew"
 	"github.com/lightningnetwork/lnd/chainntnfs"
+	"github.com/lightningnetwork/lnd/channeldb"
 	"github.com/lightningnetwork/lnd/input"
 	"github.com/lightningnetwork/lnd/lntypes"
 	"github.com/lightningnetwork/lnd/lnwallet"
@@ -456,6 +457,21 @@ func newTimeoutResolverFromReader(r io.Reader, resCfg ResolverConfig) (
 	return h, nil
 }
 
+// Supplement adds additional information to the resolver that is required
+// before Resolve() is called.
+//
+// NOTE: Part of the htlcContractResolver interface.
+func (h *htlcTimeoutResolver) Supplement(htlc channeldb.HTLC) {
+	h.htlcAmt = htlc.Amt
+}
+
+// HtlcPoint returns the htlc's outpoint on the commitment tx.
+//
+// NOTE: Part of the htlcContractResolver interface.
+func (h *htlcTimeoutResolver) HtlcPoint() wire.OutPoint {
+	return h.htlcResolution.HtlcPoint()
+}
+
 // A compile time assertion to ensure htlcTimeoutResolver meets the
 // ContractResolver interface.
-var _ ContractResolver = (*htlcTimeoutResolver)(nil)
+var _ htlcContractResolver = (*htlcTimeoutResolver)(nil)

--- a/contractcourt/htlc_timeout_resolver.go
+++ b/contractcourt/htlc_timeout_resolver.go
@@ -41,29 +41,22 @@ type htlcTimeoutResolver struct {
 	// TODO(roasbeef): wrap above into definite resolution embedding?
 	broadcastHeight uint32
 
-	// htlcIndex is the index of this HTLC within the trace of the
-	// additional commitment state machine.
-	htlcIndex uint64
-
-	// htlcAmt is the original amount of the htlc, not taking into
-	// account any fees that may have to be paid if it goes on chain.
-	htlcAmt lnwire.MilliSatoshi
+	// htlc contains information on the htlc that we are resolving on-chain.
+	htlc channeldb.HTLC
 
 	contractResolverKit
 }
 
 // newTimeoutResolver instantiates a new timeout htlc resolver.
 func newTimeoutResolver(res lnwallet.OutgoingHtlcResolution,
-	broadcastHeight uint32, htlcIndex uint64,
-	htlcAmt lnwire.MilliSatoshi,
+	broadcastHeight uint32, htlc channeldb.HTLC,
 	resCfg ResolverConfig) *htlcTimeoutResolver {
 
 	return &htlcTimeoutResolver{
 		contractResolverKit: *newContractResolverKit(resCfg),
 		htlcResolution:      res,
 		broadcastHeight:     broadcastHeight,
-		htlcIndex:           htlcIndex,
-		htlcAmt:             htlcAmt,
+		htlc:                htlc,
 	}
 }
 
@@ -158,7 +151,7 @@ func (h *htlcTimeoutResolver) claimCleanUp(
 	// resolved, then exit.
 	if err := h.DeliverResolutionMsg(ResolutionMsg{
 		SourceChan: h.ShortChanID,
-		HtlcIndex:  h.htlcIndex,
+		HtlcIndex:  h.htlc.HtlcIndex,
 		PreImage:   &pre,
 	}); err != nil {
 		return nil, err
@@ -353,7 +346,7 @@ func (h *htlcTimeoutResolver) Resolve() (ContractResolver, error) {
 	failureMsg := &lnwire.FailPermanentChannelFailure{}
 	if err := h.DeliverResolutionMsg(ResolutionMsg{
 		SourceChan: h.ShortChanID,
-		HtlcIndex:  h.htlcIndex,
+		HtlcIndex:  h.htlc.HtlcIndex,
 		Failure:    failureMsg,
 	}); err != nil {
 		return nil, err
@@ -415,7 +408,7 @@ func (h *htlcTimeoutResolver) Encode(w io.Writer) error {
 		return err
 	}
 
-	if err := binary.Write(w, endian, h.htlcIndex); err != nil {
+	if err := binary.Write(w, endian, h.htlc.HtlcIndex); err != nil {
 		return err
 	}
 
@@ -450,7 +443,7 @@ func newTimeoutResolverFromReader(r io.Reader, resCfg ResolverConfig) (
 		return nil, err
 	}
 
-	if err := binary.Read(r, endian, &h.htlcIndex); err != nil {
+	if err := binary.Read(r, endian, &h.htlc.HtlcIndex); err != nil {
 		return nil, err
 	}
 
@@ -462,7 +455,7 @@ func newTimeoutResolverFromReader(r io.Reader, resCfg ResolverConfig) (
 //
 // NOTE: Part of the htlcContractResolver interface.
 func (h *htlcTimeoutResolver) Supplement(htlc channeldb.HTLC) {
-	h.htlcAmt = htlc.Amt
+	h.htlc = htlc
 }
 
 // HtlcPoint returns the htlc's outpoint on the commitment tx.

--- a/contractcourt/interfaces.go
+++ b/contractcourt/interfaces.go
@@ -1,7 +1,10 @@
 package contractcourt
 
 import (
+	"io"
+
 	"github.com/lightningnetwork/lnd/channeldb"
+	"github.com/lightningnetwork/lnd/htlcswitch/hop"
 	"github.com/lightningnetwork/lnd/invoices"
 	"github.com/lightningnetwork/lnd/lntypes"
 	"github.com/lightningnetwork/lnd/lnwire"
@@ -25,4 +28,11 @@ type Registry interface {
 
 	// HodlUnsubscribeAll unsubscribes from all hodl events.
 	HodlUnsubscribeAll(subscriber chan<- interface{})
+}
+
+// OnionProcessor is an interface used to decode onion blobs.
+type OnionProcessor interface {
+	// ReconstructHopIterator attempts to decode a valid sphinx packet from
+	// the passed io.Reader instance.
+	ReconstructHopIterator(r io.Reader, rHash []byte) (hop.Iterator, error)
 }

--- a/server.go
+++ b/server.go
@@ -906,6 +906,7 @@ func newServer(listenAddrs []net.Addr, chanDB *channeldb.DB,
 		Sweeper:             s.sweeper,
 		Registry:            s.invoices,
 		NotifyClosedChannel: s.channelNotifier.NotifyClosedChannelEvent,
+		OnionProcessor:      s.sphinx,
 	}, chanDB)
 
 	s.breachArbiter = newBreachArbiter(&BreachConfig{


### PR DESCRIPTION
Also for on-chain resolution, we may require access to the onion payload. An example of this is the resolution of an mpp shard. We need the mpp fields in order to properly offer the htlc to the invoice registry.
