### PR TITLE
lnd: implement "safe mode" node stand up

### DIFF
--- a/config.go
+++ b/config.go
@@ -273,6 +273,7 @@ type config struct {
 
 	UnsafeDisconnect   bool   `long:"unsafe-disconnect" description:"Allows the rpcserver to intentionally disconnect from peers with open channels. USED FOR TESTING ONLY."`
 	UnsafeReplay       bool   `long:"unsafe-replay" description:"Causes a link to replay the adds on its commitment txn after starting up, this enables testing of the sphinx replay logic."`
+	SafeMode           bool   `long:"safemode" description:"Start in safe mode that forbids broadcasting of all commitment transactions"`
 	MaxPendingChannels int    `long:"maxpendingchannels" description:"The maximum number of incoming pending channels permitted per peer."`
 	BackupFilePath     string `long:"backupfilepath" description:"The target location of the channel backup file"`
 

--- a/lnd.go
+++ b/lnd.go
@@ -130,6 +130,11 @@ func Main(lisCfg ListenerCfg) error {
 		}
 	}()
 
+	if cfg.SafeMode {
+		ltndLog.Infof("Starting LND in safe mode." +
+			"All commitment transactions are forbidden in this state.")
+	}
+
 	// Show version at startup.
 	ltndLog.Infof("Version: %s, build=%s, logging=%s",
 		build.Version(), build.Deployment, build.LoggingType)

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -1745,6 +1745,10 @@ func (r *rpcServer) CloseChannel(in *lnrpc.CloseChannelRequest,
 	// transaction here rather than going to the switch as we don't require
 	// interaction from the peer.
 	if force {
+		if cfg.SafeMode {
+			return fmt.Errorf("cannot force close channel in safe mode")
+		}
+
 		_, bestHeight, err := r.server.cc.chainIO.GetBestBlock()
 		if err != nil {
 			return err

--- a/server.go
+++ b/server.go
@@ -887,6 +887,7 @@ func newServer(listenAddrs []net.Addr, chanDB *channeldb.DB,
 		Sweeper:             s.sweeper,
 		Registry:            s.invoices,
 		NotifyClosedChannel: s.channelNotifier.NotifyClosedChannelEvent,
+		SafeMode:            cfg.SafeMode,
 	}, chanDB)
 
 	s.breachArbiter = newBreachArbiter(&BreachConfig{


### PR DESCRIPTION
This PR implements `safe mode` for `lnd` by disabling all RPC and automated force close requests, as described in the original issue here: https://github.com/lightningnetwork/lnd/issues/3287

- [x] Add new --safemode config parameter to the lnd binary.

- [x] If safe mode is enabled, reject all RPC level force close requests.

- [x] If safe mode is enabled, reject all automated force close requests by channel arbitrators.