### PR TITLE
Fix Formatting of *Wrong*

### DIFF
--- a/docs/code_contribution_guidelines.md
+++ b/docs/code_contribution_guidelines.md
@@ -424,6 +424,7 @@ statements and select statements.
 If one is forced to wrap lines of function arguments that exceed the 80
 character limit, then a new line should be inserted before the first stanza in
 the comment body.
+
 **WRONG**
 ```go
    func foo(a, b, c, 


### PR DESCRIPTION
There is a spacing issues, and thus a formatting 
issue, in the file, code_contribution_guidelines.md

#### Pull Request Checklist

- [ ] If this is your first time contributing, we recommend you read the [Code
  Contribution Guidelines](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md)
- [ ] All changes are Go version 1.12 compliant
- [ ] The code being submitted is commented according to [Code Documentation and Commenting](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#CodeDocumentation)
- [ ] For new code: Code is accompanied by tests which exercise both
  the positive and negative (error paths) conditions (if applicable)
- [ ] For bug fixes: Code is accompanied by new tests which trigger
  the bug being fixed to prevent regressions
- [ ] Any new logging statements use an appropriate subsystem and
  logging level
- [ ] Code has been formatted with `go fmt`
- [ ] For code and documentation: lines are wrapped at 80 characters
  (the tab character should be counted as 8 characters, not 4, as some IDEs do
  per default)
- [ ] Running `make check` does not fail any tests
- [ ] Running `go vet` does not report any issues
- [ ] Running `make lint` does not report any **new** issues that did not
  already exist
- [ ] All commits build properly and pass tests. Only in exceptional
  cases it can be justifiable to violate this condition. In that case, the
  reason should be stated in the commit message.
- [ ] Commits have a logical structure according to [Ideal Git Commit Structure](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#IdealGitCommitStructure)
