### PR TITLE
ticker: add tickerMtx to prevent data race

### DIFF
--- a/routing/router.go
+++ b/routing/router.go
@@ -852,7 +852,6 @@ func (r *ChannelRouter) networkHandler() {
 	graphPruneTicker := time.NewTicker(r.cfg.GraphPruneInterval)
 	defer graphPruneTicker.Stop()
 
-	r.statTicker.Resume()
 	defer r.statTicker.Stop()
 
 	r.stats.Reset()
@@ -862,6 +861,12 @@ func (r *ChannelRouter) networkHandler() {
 	validationBarrier := NewValidationBarrier(runtime.NumCPU()*4, r.quit)
 
 	for {
+
+		// If there are stats, resume the statTicker.
+		if !r.stats.Empty() {
+			r.statTicker.Resume()
+		}
+
 		select {
 		// A new fully validated network update has just arrived. As a
 		// result we'll modify the channel graph accordingly depending
@@ -1343,8 +1348,6 @@ func (r *ChannelRouter) processUpdate(msg interface{}) error {
 	default:
 		return errors.Errorf("wrong routing update message type")
 	}
-
-	r.statTicker.Resume()
 
 	return nil
 }


### PR DESCRIPTION
Running lnd with thread sanitizer found the following:

```
==================
WARNING: DATA RACE
Write at 0x00c000797568 by goroutine 21:
  github.com/lightningnetwork/lnd/ticker.(*T).Pause()
      /Users/nsa/go/src/github.com/lightningnetwork/lnd/ticker/ticker.go:115 +0x96
  github.com/lightningnetwork/lnd/routing.(*ChannelRouter).networkHandler()
      /Users/nsa/go/src/github.com/lightningnetwork/lnd/routing/router.go:1067 +0x12d7

Previous read at 0x00c000797568 by goroutine 150:
  github.com/lightningnetwork/lnd/ticker.(*T).Resume()
      /Users/nsa/go/src/github.com/lightningnetwork/lnd/ticker/ticker.go:103 +0x47
  github.com/lightningnetwork/lnd/routing.(*ChannelRouter).processUpdate()
      /Users/nsa/go/src/github.com/lightningnetwork/lnd/routing/router.go:1347 +0x8d4
  github.com/lightningnetwork/lnd/routing.(*ChannelRouter).networkHandler.func1()
      /Users/nsa/go/src/github.com/lightningnetwork/lnd/routing/router.go:900 +0x2e3

Goroutine 21 (running) created at:
  github.com/lightningnetwork/lnd/routing.(*ChannelRouter).Start()
      /Users/nsa/go/src/github.com/lightningnetwork/lnd/routing/router.go:549 +0x58d
  github.com/lightningnetwork/lnd.(*server).Start.func1()
      /Users/nsa/go/src/github.com/lightningnetwork/lnd/server.go:1255 +0xaa6
  sync.(*Once).doSlow()
      /usr/local/Cellar/go/1.13/libexec/src/sync/once.go:66 +0x100
  sync.(*Once).Do()
      /usr/local/Cellar/go/1.13/libexec/src/sync/once.go:57 +0x68
  github.com/lightningnetwork/lnd.(*server).Start()
      /Users/nsa/go/src/github.com/lightningnetwork/lnd/server.go:1179 +0x7d
  github.com/lightningnetwork/lnd.Main()
      /Users/nsa/go/src/github.com/lightningnetwork/lnd/lnd.go:621 +0x29ce
  main.main()
      /Users/nsa/go/src/github.com/lightningnetwork/lnd/cmd/lnd/main.go:14 +0x3f

Goroutine 150 (finished) created at:
  github.com/lightningnetwork/lnd/routing.(*ChannelRouter).networkHandler()
      /Users/nsa/go/src/github.com/lightningnetwork/lnd/routing/router.go:876 +0x19c3
```

Adding a mutex in the `ticker` fixes this