### PR TITLE
rpcserver: ensure server has started before CloseChannel

### DIFF
--- a/lntest/harness.go
+++ b/lntest/harness.go
@@ -13,17 +13,17 @@ import (
 	"sync"
 	"time"
 
-	"google.golang.org/grpc/grpclog"
-
 	"github.com/btcsuite/btcd/chaincfg"
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcd/integration/rpctest"
 	"github.com/btcsuite/btcd/txscript"
 	"github.com/btcsuite/btcd/wire"
 	"github.com/btcsuite/btcutil"
+	"github.com/lightningnetwork/lnd"
 	"github.com/lightningnetwork/lnd/lnrpc"
 	"github.com/lightningnetwork/lnd/lntest/wait"
 	"github.com/lightningnetwork/lnd/lnwire"
+	"google.golang.org/grpc/grpclog"
 )
 
 // DefaultCSV is the CSV delay (remotedelay) we will start our test nodes with.
@@ -395,7 +395,7 @@ func (n *NetworkHarness) connect(ctx context.Context,
 tryconnect:
 	if _, err := a.ConnectPeer(ctx, req); err != nil {
 		// If the chain backend is still syncing, retry.
-		if strings.Contains(err.Error(), "still syncing") {
+		if err == lnd.ErrServerNotActive {
 			select {
 			case <-time.After(100 * time.Millisecond):
 				goto tryconnect

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -1698,6 +1698,10 @@ func GetChanPointFundingTxid(chanPoint *lnrpc.ChannelPoint) (*chainhash.Hash, er
 func (r *rpcServer) CloseChannel(in *lnrpc.CloseChannelRequest,
 	updateStream lnrpc.Lightning_CloseChannelServer) error {
 
+	if !r.server.Started() {
+		return ErrServerNotActive
+	}
+
 	// If the user didn't specify a channel point, then we'll reject this
 	// request all together.
 	if in.GetChannelPoint() == nil {

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -1257,8 +1257,7 @@ func (r *rpcServer) ConnectPeer(ctx context.Context,
 	// The server hasn't yet started, so it won't be able to service any of
 	// our requests, so we'll bail early here.
 	if !r.server.Started() {
-		return nil, fmt.Errorf("chain backend is still syncing, server " +
-			"not active yet")
+		return nil, ErrServerNotActive
 	}
 
 	if in.Addr == nil {
@@ -1311,8 +1310,7 @@ func (r *rpcServer) DisconnectPeer(ctx context.Context,
 	rpcsLog.Debugf("[disconnectpeer] from peer(%s)", in.PubKey)
 
 	if !r.server.Started() {
-		return nil, fmt.Errorf("chain backend is still syncing, server " +
-			"not active yet")
+		return nil, ErrServerNotActive
 	}
 
 	// First we'll validate the string passed in within the request to
@@ -1398,8 +1396,7 @@ func (r *rpcServer) OpenChannel(in *lnrpc.OpenChannelRequest,
 		in.LocalFundingAmount, in.PushSat)
 
 	if !r.server.Started() {
-		return fmt.Errorf("chain backend is still syncing, server " +
-			"not active yet")
+		return ErrServerNotActive
 	}
 
 	localFundingAmt := btcutil.Amount(in.LocalFundingAmount)
@@ -1558,8 +1555,7 @@ func (r *rpcServer) OpenChannelSync(ctx context.Context,
 	// syncing, as otherwise we may not be able to obtain the relevant
 	// notifications.
 	if !r.server.Started() {
-		return nil, fmt.Errorf("chain backend is still syncing, server " +
-			"not active yet")
+		return nil, ErrServerNotActive
 	}
 
 	// Creation of channels before the wallet syncs up is currently
@@ -3205,8 +3201,7 @@ func (r *rpcServer) sendPayment(stream *paymentStream) error {
 	// syncing as we may be trying to sent a payment over a "stale"
 	// channel.
 	if !r.server.Started() {
-		return fmt.Errorf("chain backend is still syncing, server " +
-			"not active yet")
+		return ErrServerNotActive
 	}
 
 	// TODO(roasbeef): check payment filter to see if already used?
@@ -3396,8 +3391,7 @@ func (r *rpcServer) sendPaymentSync(ctx context.Context,
 	// syncing as we may be trying to sent a payment over a "stale"
 	// channel.
 	if !r.server.Started() {
-		return nil, fmt.Errorf("chain backend is still syncing, server " +
-			"not active yet")
+		return nil, ErrServerNotActive
 	}
 
 	// First we'll attempt to map the proto describing the next payment to

--- a/server.go
+++ b/server.go
@@ -89,6 +89,11 @@ var (
 	// given peer.
 	ErrPeerNotConnected = errors.New("peer is not connected")
 
+	// ErrServerNotActive indicates that the server has started but hasn't
+	// fully finished the startup process.
+	ErrServerNotActive = errors.New("server is still in the process of " +
+		"starting")
+
 	// ErrServerShuttingDown indicates that the server is in the process of
 	// gracefully exiting.
 	ErrServerShuttingDown = errors.New("server is shutting down")


### PR DESCRIPTION
We do this as a general sanity check to ensure channels cannot be closed while either the backend is still syncing or the server is still starting.