### PR TITLE
discovery: skip chanann validation for assumechanvalid

### DIFF
--- a/server.go
+++ b/server.go
@@ -773,6 +773,7 @@ func newServer(listenAddrs []net.Addr, chanDB *channeldb.DB,
 		MinimumBatchSize:        10,
 		SubBatchDelay:           time.Second * 5,
 		IgnoreHistoricalFilters: cfg.IgnoreHistoricalGossipFilters,
+		AssumeChannelValid:      cfg.Routing.UseAssumeChannelValid(),
 	},
 		s.identityPriv.PubKey(),
 	)


### PR DESCRIPTION
AssumeChannelValid toggles whether or not the router will verify
signatures for incoming channel announcements. We skip this to increase
performance on low powered devices, and since we are not checking
unspentness of the channel in this mode, they are easily spoofed anyway.