### PR TITLE
Add OptionUpfront Shutdown

### DIFF
--- a/chancloser_test.go
+++ b/chancloser_test.go
@@ -1,0 +1,77 @@
+package lnd
+
+import (
+	"math/rand"
+	"testing"
+
+	"github.com/lightningnetwork/lnd/lnwire"
+)
+
+// randDeliveryAddress generates a random delivery address for testing.
+func randDeliveryAddress(t *testing.T) lnwire.DeliveryAddress {
+	// Generate an address of maximum length.
+	da := lnwire.DeliveryAddress(make([]byte, 34))
+
+	_, err := rand.Read(da)
+	if err != nil {
+		t.Fatalf("cannot generate random address: %v", err)
+	}
+
+	return da
+}
+
+// TestCheckRemoteDeliveryAddress tests that the checkRemoteDeliveryAddress
+// errors appropriately when shutdown is set and the address provided does not
+// match, and does not error in any other case.
+func TestCheckRemoteDeliveryAddress(t *testing.T) {
+	addr1 := randDeliveryAddress(t)
+	addr2 := randDeliveryAddress(t)
+
+	tests := []struct {
+		name         string
+		shutdownAddr lnwire.DeliveryAddress
+		upfrontAddr  lnwire.DeliveryAddress
+		expectErr    bool
+	}{
+		{
+			name:         "No shutdown set, address ok",
+			shutdownAddr: addr1,
+			upfrontAddr:  []byte{},
+			expectErr:    false,
+		},
+		{
+			name:         "Shutdown set, address ok",
+			shutdownAddr: addr1,
+			upfrontAddr:  addr1,
+			expectErr:    false,
+		},
+		{
+			name:         "Shutdown set, address not ok",
+			shutdownAddr: addr1,
+			upfrontAddr:  addr2,
+			expectErr:    true,
+		},
+		{
+			// This case is not expected, since shutdown messages must include
+			// an address, but it is included for completeness because failure
+			// of this function results in disconnection from a peer.
+			name:         "No shutdown set, address not ok",
+			shutdownAddr: []byte{},
+			upfrontAddr:  []byte{},
+			expectErr:    false,
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+
+		t.Run(test.name, func(t *testing.T) {
+			err := checkRemoteDeliveryAddress(
+				test.upfrontAddr, test.shutdownAddr,
+			)
+			if (err != nil) != (test.expectErr) {
+				t.Fatalf("Error: %v, expected error: %v", err, test.expectErr)
+			}
+		})
+	}
+}

--- a/channeldb/channel.go
+++ b/channeldb/channel.go
@@ -532,6 +532,16 @@ type OpenChannel struct {
 	// for which we are the initiator.
 	FundingTxn *wire.MsgTx
 
+	// LocalShutdownScript is set to a pre-set script if the channel was opened
+	// by the local node with option_upfront_shutdown_script set. If the option
+	// was not set, the field is empty.
+	LocalShutdownScript lnwire.DeliveryAddress
+
+	// RemoteShutdownScript is set to a pre-set script if the channel was opened
+	// by the remote node with option_upfront_shutdown_script set. If the option
+	// was not set, the field is empty.
+	RemoteShutdownScript lnwire.DeliveryAddress
+
 	// TODO(roasbeef): eww
 	Db *DB
 

--- a/channeldb/channel_test.go
+++ b/channeldb/channel_test.go
@@ -345,6 +345,104 @@ func TestOpenChannelPutGetDelete(t *testing.T) {
 	}
 }
 
+// TestOptionalShutdown tests the reading and writing of channels with and
+// without optional shutdown script fields.
+func TestOptionalShutdown(t *testing.T) {
+	local := lnwire.DeliveryAddress(make([]byte, 30))
+	if _, err := rand.Read(local); err != nil {
+		t.Fatalf("Could not create random script: %v", err)
+	}
+
+	remote := lnwire.DeliveryAddress(make([]byte, 30))
+	if _, err := rand.Read(remote); err != nil {
+		t.Fatalf("Could not create random script: %v", err)
+	}
+
+	tests := []struct {
+		name           string
+		modifyChannel  func(channel *OpenChannel)
+		expectedLocal  lnwire.DeliveryAddress
+		expectedRemote lnwire.DeliveryAddress
+	}{
+		{
+			name:          "No shutdown scripts",
+			modifyChannel: func(channel *OpenChannel) {},
+		},
+		{
+			name: "Local shutdown script",
+			modifyChannel: func(channel *OpenChannel) {
+				channel.LocalShutdownScript = local
+			},
+			expectedLocal: local,
+		},
+		{
+			name: "Remote shutdown script",
+			modifyChannel: func(channel *OpenChannel) {
+				channel.RemoteShutdownScript = remote
+			},
+			expectedRemote: remote,
+		},
+		{
+			name: "Both scripts set",
+			modifyChannel: func(channel *OpenChannel) {
+				channel.LocalShutdownScript = local
+				channel.RemoteShutdownScript = remote
+			},
+			expectedLocal:  local,
+			expectedRemote: remote,
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+
+		t.Run(test.name, func(t *testing.T) {
+			cdb, cleanUp, err := makeTestDB()
+			if err != nil {
+				t.Fatalf("unable to make test database: %v", err)
+			}
+			defer cleanUp()
+
+			// Create the test channel state, then add an additional fake HTLC
+			// before syncing to disk.
+			state, err := createTestChannelState(cdb)
+			if err != nil {
+				t.Fatalf("unable to create channel state: %v", err)
+			}
+
+			test.modifyChannel(state)
+
+			// Write channels to Db.
+			addr := &net.TCPAddr{
+				IP:   net.ParseIP("127.0.0.1"),
+				Port: 18556,
+			}
+			if err := state.SyncPending(addr, 101); err != nil {
+				t.Fatalf("unable to save and serialize channel state: %v", err)
+			}
+
+			openChannels, err := cdb.FetchOpenChannels(state.IdentityPub)
+			if err != nil {
+				t.Fatalf("unable to fetch open channel: %v", err)
+			}
+
+			if len(openChannels) != 1 {
+				t.Fatalf("Expected one channel open, got: %v", len(openChannels))
+			}
+
+			if !bytes.Equal(openChannels[0].LocalShutdownScript, test.expectedLocal) {
+				t.Fatalf("Expected local: %x, got: %x", test.expectedLocal,
+					openChannels[0].LocalShutdownScript)
+			}
+
+			if !bytes.Equal(openChannels[0].RemoteShutdownScript, test.expectedRemote) {
+				t.Fatalf("Expected remote: %x, got: %x", test.expectedRemote,
+					openChannels[0].RemoteShutdownScript)
+			}
+		})
+	}
+}
+
 func assertCommitmentEqual(t *testing.T, a, b *ChannelCommitment) {
 	if !reflect.DeepEqual(a, b) {
 		_, _, line, _ := runtime.Caller(1)

--- a/channeldb/codec.go
+++ b/channeldb/codec.go
@@ -213,6 +213,9 @@ func WriteElement(w io.Writer, element interface{}) error {
 			}
 		}
 
+	case lnwire.DeliveryAddress:
+		return WriteElement(w, []byte(e))
+
 	default:
 		return UnknownElementType{"WriteElement", e}
 	}
@@ -432,6 +435,12 @@ func ReadElement(r io.Reader, element interface{}) error {
 			}
 			(*e)[i] = addr
 		}
+	case *lnwire.DeliveryAddress:
+		var addr []byte
+		if err := ReadElement(r, &addr); err != nil {
+			return err
+		}
+		*e = addr
 
 	default:
 		return UnknownElementType{"ReadElement", e}

--- a/htlcswitch/mock.go
+++ b/htlcswitch/mock.go
@@ -608,6 +608,14 @@ func (s *mockServer) RemoteGlobalFeatures() *lnwire.FeatureVector {
 	return nil
 }
 
+func (s *mockServer) RemoteLocalFeatures() *lnwire.FeatureVector {
+	return nil
+}
+
+func (s *mockServer) LocalLocalFeatures() *lnwire.FeatureVector {
+	return nil
+}
+
 func (s *mockServer) Stop() error {
 	if !atomic.CompareAndSwapInt32(&s.shutdown, 0, 1) {
 		return nil

--- a/htlcswitch/mock.go
+++ b/htlcswitch/mock.go
@@ -590,6 +590,10 @@ func (s *mockServer) Address() net.Addr {
 	return nil
 }
 
+func (s *mockServer) GenDeliveryScript() ([]byte, error) {
+	return nil, nil
+}
+
 func (s *mockServer) AddNewChannel(channel *channeldb.OpenChannel,
 	cancel <-chan struct{}) error {
 

--- a/lnpeer/peer.go
+++ b/lnpeer/peer.go
@@ -58,4 +58,14 @@ type Peer interface {
 	// this interface to gate their behavior off the set of negotiated
 	// feature bits.
 	RemoteGlobalFeatures() *lnwire.FeatureVector
+
+	// RemoteGlobalFeatures returns the set of local features that has been
+	// advertised by the remote node. This allows sub-systems that use this
+	// interface to gate their behavior off the set of negotiated feature bits.
+	RemoteLocalFeatures() *lnwire.FeatureVector
+
+	// LocalLocalFeatures returns the set of local features that has been
+	// advertised by the local node. This allows sub-systems that use this
+	// interface to gate their behavior off the set of negotiated feature bits.
+	LocalLocalFeatures() *lnwire.FeatureVector
 }

--- a/lnpeer/peer.go
+++ b/lnpeer/peer.go
@@ -41,6 +41,10 @@ type Peer interface {
 	// Address returns the network address of the remote peer.
 	Address() net.Addr
 
+	// GenDeliveryScript returns a new script to be used to send our funds to in
+	// the case of a cooperative channel close negotiation.
+	GenDeliveryScript() ([]byte, error)
+
 	// QuitSignal is a method that should return a channel which will be
 	// sent upon or closed once the backing peer exits. This allows callers
 	// using the interface to cancel any processing in the event the backing

--- a/lnwallet/channel.go
+++ b/lnwallet/channel.go
@@ -4840,6 +4840,18 @@ func (lc *LightningChannel) ShortChanID() lnwire.ShortChannelID {
 	return lc.channelState.ShortChanID()
 }
 
+// LocalUpfrontShutdownScript returns the local upfront shutdown script for the
+// channel. If it was not set, an empty byte array is returned.
+func (lc *LightningChannel) LocalUpfrontShutdownScript() lnwire.DeliveryAddress {
+	return lc.channelState.LocalShutdownScript
+}
+
+// RemoteUpfrontShutdownScript returns the remote upfront shutdown script for the
+// channel. If it was not set, an empty byte array is returned.
+func (lc *LightningChannel) RemoteUpfrontShutdownScript() lnwire.DeliveryAddress {
+	return lc.channelState.RemoteShutdownScript
+}
+
 // genHtlcScript generates the proper P2WSH public key scripts for the HTLC
 // output modified by two-bits denoting if this is an incoming HTLC, and if the
 // HTLC is being applied to their commitment transaction or ours.

--- a/lnwire/accept_channel_test.go
+++ b/lnwire/accept_channel_test.go
@@ -1,0 +1,76 @@
+package lnwire
+
+import (
+	"bytes"
+	"math/rand"
+	"reflect"
+	"testing"
+
+	"github.com/btcsuite/btcd/btcec"
+)
+
+// TestDecodeAcceptChannel tests decoding of an accept channel wire message with
+// and without the optional upfront shutdown address.
+func TestDecodeAcceptChannel(t *testing.T) {
+	addr, err := randDeliveryAddress(rand.New(rand.NewSource(123)))
+	if err != nil {
+		t.Fatalf("cannot create random addresss: %v", err)
+	}
+	tests := []struct {
+		name     string
+		shutdown DeliveryAddress
+	}{
+		{
+			name:     "No upfront shutdown",
+			shutdown: nil,
+		},
+		{
+			name:     "Upfront shutdown set",
+			shutdown: addr,
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+
+		t.Run(test.name, func(t *testing.T) {
+			priv, err := btcec.NewPrivateKey(btcec.S256())
+			if err != nil {
+				t.Fatalf("cannot create privkey: %v", err)
+			}
+			pk := priv.PubKey()
+
+			withField := &AcceptChannel{
+				PendingChannelID:      [32]byte{},
+				FundingKey:            pk,
+				RevocationPoint:       pk,
+				PaymentPoint:          pk,
+				DelayedPaymentPoint:   pk,
+				HtlcPoint:             pk,
+				FirstCommitmentPoint:  pk,
+				UpfrontShutdownScript: test.shutdown,
+			}
+
+			var b []byte
+			buf := bytes.NewBuffer(b)
+			if _, err := WriteMessage(buf, withField, 0); err != nil {
+				t.Fatalf("cannot write message: %v", err)
+			}
+
+			msg, err := ReadMessage(buf, 0)
+			if err != nil {
+				t.Fatalf("cannot read message: %v", err)
+			}
+
+			switch e := msg.(type) {
+			case *AcceptChannel:
+				if !reflect.DeepEqual(e, withField) {
+					t.Fatalf("decoded message: %v does not equal encoded message: %v",
+						e, withField)
+				}
+			default:
+				t.Fatalf("did not decode accept channel messge")
+			}
+		})
+	}
+}

--- a/lnwire/features.go
+++ b/lnwire/features.go
@@ -35,6 +35,11 @@ const (
 	// connection is established.
 	InitialRoutingSync FeatureBit = 3
 
+	// UpfrontShutdownScript indicates that the node supports committing upfront
+	// to the shutdown script when opening channels.  This prevents a node that
+	// has been compromised from having all the channel funds stolen.
+	UpfrontShutdownScript FeatureBit = 5
+
 	// GossipQueriesRequired is a feature bit that indicates that the
 	// receiving peer MUST know of the set of features that allows nodes to
 	// more efficiently query the network view of peers on the network for
@@ -89,6 +94,7 @@ var LocalFeatures = map[FeatureBit]string{
 	InitialRoutingSync:      "initial-routing-sync",
 	GossipQueriesRequired:   "gossip-queries",
 	GossipQueriesOptional:   "gossip-queries",
+	UpfrontShutdownScript:   "option-upfront-shutdown-script",
 }
 
 // GlobalFeatures is a mapping of known global feature bits to a descriptive

--- a/lnwire/lnwire.go
+++ b/lnwire/lnwire.go
@@ -401,6 +401,11 @@ func WriteElement(w io.Writer, element interface{}) error {
 		}
 
 	case DeliveryAddress:
+		// If there is no delivery address, do not write anything.
+		if len(e) == 0 {
+			return nil
+		}
+
 		var length [2]byte
 		binary.BigEndian.PutUint16(length[:], uint16(len(e)))
 		if _, err := w.Write(length[:]); err != nil {

--- a/lnwire/lnwire_test.go
+++ b/lnwire/lnwire_test.go
@@ -67,6 +67,15 @@ func randRawKey() ([33]byte, error) {
 	return n, nil
 }
 
+func randDeliveryAddress(r *rand.Rand) (DeliveryAddress, error) {
+	// Generate size minimum one. Empty scripts should be tested specifically.
+	size := r.Intn(deliveryAddressMaxSize) + 1
+	da := DeliveryAddress(make([]byte, size))
+
+	_, err := r.Read(da)
+	return da, err
+}
+
 func randRawFeatureVector(r *rand.Rand) *RawFeatureVector {
 	featureVec := NewRawFeatureVector()
 	for i := 0; i < 10000; i++ {
@@ -241,6 +250,9 @@ func TestEmptyMessageUnknownType(t *testing.T) {
 // TestLightningWireProtocol uses the testing/quick package to create a series
 // of fuzz tests to attempt to break a primary scenario which is implemented as
 // property based testing scenario.
+//
+// Debug help: when the message payload can reach a size larger than the return
+// value of MaxPayloadLength, the test can panic without a helpful message.
 func TestLightningWireProtocol(t *testing.T) {
 	t.Parallel()
 
@@ -353,6 +365,17 @@ func TestLightningWireProtocol(t *testing.T) {
 				return
 			}
 
+			// 1/2 chance empty upfront shutdown address
+			if r.Intn(2) == 0 {
+				req.UpfrontShutdownScript, err = randDeliveryAddress(r)
+				if err != nil {
+					t.Fatalf("unable to generate delivery address: %v", err)
+					return
+				}
+			} else {
+				req.UpfrontShutdownScript = []byte{}
+			}
+
 			v[0] = reflect.ValueOf(req)
 		},
 		MsgAcceptChannel: func(v []reflect.Value, r *rand.Rand) {
@@ -401,6 +424,17 @@ func TestLightningWireProtocol(t *testing.T) {
 			if err != nil {
 				t.Fatalf("unable to generate key: %v", err)
 				return
+			}
+
+			// 1/2 chance empty upfront shutdown address
+			if r.Intn(2) == 0 {
+				req.UpfrontShutdownScript, err = randDeliveryAddress(r)
+				if err != nil {
+					t.Fatalf("unable to generate delivery address: %v", err)
+					return
+				}
+			} else {
+				req.UpfrontShutdownScript = []byte{}
 			}
 
 			v[0] = reflect.ValueOf(req)
@@ -986,23 +1020,28 @@ func TestLightningWireProtocol(t *testing.T) {
 			},
 		},
 	}
-	for _, test := range tests {
-		var config *quick.Config
+	for _, tst := range tests {
+		test := tst
+		t.Run(test.msgType.String(), func(t *testing.T) {
+			t.Parallel()
 
-		// If the type defined is within the custom type gen map above,
-		// then we'll modify the default config to use this Value
-		// function that knows how to generate the proper types.
-		if valueGen, ok := customTypeGen[test.msgType]; ok {
-			config = &quick.Config{
-				Values: valueGen,
+			var config *quick.Config
+
+			// If the type defined is within the custom type gen map above,
+			// then we'll modify the default config to use this Value
+			// function that knows how to generate the proper types.
+			if valueGen, ok := customTypeGen[test.msgType]; ok {
+				config = &quick.Config{
+					Values: valueGen,
+				}
 			}
-		}
 
-		t.Logf("Running fuzz tests for msgType=%v", test.msgType)
-		if err := quick.Check(test.scenario, config); err != nil {
-			t.Fatalf("fuzz checks for msg=%v failed: %v",
-				test.msgType, err)
-		}
+			t.Logf("Running fuzz tests for msgType=%v", test.msgType)
+			if err := quick.Check(test.scenario, config); err != nil {
+				t.Fatalf("fuzz checks for msg=%v failed: %v",
+					test.msgType, err)
+			}
+		})
 	}
 
 }

--- a/lnwire/msat.go
+++ b/lnwire/msat.go
@@ -6,9 +6,15 @@ import (
 	"github.com/btcsuite/btcutil"
 )
 
-// mSatScale is a value that's used to scale satoshis to milli-satoshis, and
-// the other way around.
-const mSatScale uint64 = 1000
+const (
+	// mSatScale is a value that's used to scale satoshis to milli-satoshis, and
+	// the other way around.
+	mSatScale uint64 = 1000
+
+	// MaxMilliSatoshi is the maximum number of msats that can be expressed
+	// in this data type.
+	MaxMilliSatoshi = ^MilliSatoshi(0)
+)
 
 // MilliSatoshi are the native unit of the Lightning Network. A milli-satoshi
 // is simply 1/1000th of a satoshi. There are 1000 milli-satoshis in a single

--- a/lnwire/shutdown.go
+++ b/lnwire/shutdown.go
@@ -22,6 +22,15 @@ type Shutdown struct {
 // p2wpkh.
 type DeliveryAddress []byte
 
+// deliveryAddressMaxSize is the maximum expected size in bytes of a
+// DeliveryAddress based on the types of scripts we know.
+// Following are the known scripts and their sizes in bytes.
+// - pay to witness script hash: 34
+// - pay to pubkey hash: 25
+// - pay to script hash: 22
+// - pay to witness pubkey hash: 22.
+const deliveryAddressMaxSize = 34
+
 // NewShutdown creates a new Shutdown message.
 func NewShutdown(cid ChannelID, addr DeliveryAddress) *Shutdown {
 	return &Shutdown{
@@ -71,11 +80,8 @@ func (s *Shutdown) MaxPayloadLength(pver uint32) uint32 {
 	// Len - 2 bytes
 	length += 2
 
-	// ScriptPubKey - 34 bytes for pay to witness script hash
-	length += 34
-
-	// NOTE: pay to pubkey hash is 25 bytes, pay to script hash is 22
-	// bytes, and pay to witness pubkey hash is 22 bytes in length.
+	// ScriptPubKey
+	length += deliveryAddressMaxSize
 
 	return length
 }

--- a/peer.go
+++ b/peer.go
@@ -2437,6 +2437,24 @@ func (p *peer) RemoteGlobalFeatures() *lnwire.FeatureVector {
 	return p.remoteGlobalFeatures
 }
 
+// RemoteGlobalFeatures returns the set of local features that has been
+// advertised by the remote node. This allows sub-systems that use this
+// interface to gate their behavior off the set of negotiated feature bits.
+//
+// NOTE: Part of the lnpeer.Peer interface.
+func (p *peer) RemoteLocalFeatures() *lnwire.FeatureVector {
+	return p.remoteLocalFeatures
+}
+
+// LocalLocalFeatures returns the set of local features that has been
+// advertised by the local node. This allows sub-systems that use this
+// interface to gate their behavior off the set of negotiated feature bits.
+//
+// NOTE: Part of the lnpeer.Peer interface.
+func (p *peer) LocalLocalFeatures() *lnwire.FeatureVector {
+	return lnwire.NewFeatureVector(p.localFeatures, lnwire.LocalFeatures)
+}
+
 // sendInitMsg sends init message to remote peer which contains our currently
 // supported local and global features.
 func (p *peer) sendInitMsg() error {

--- a/peer.go
+++ b/peer.go
@@ -1728,9 +1728,11 @@ func (p *peer) ChannelSnapshots() []*channeldb.ChannelSnapshot {
 	return snapshots
 }
 
-// genDeliveryScript returns a new script to be used to send our funds to in
+// GenDeliveryScript returns a new script to be used to send our funds to in
 // the case of a cooperative channel close negotiation.
-func (p *peer) genDeliveryScript() ([]byte, error) {
+//
+// NOTE: Part of the lnpeer.Peer interface.
+func (p *peer) GenDeliveryScript() ([]byte, error) {
 	deliveryAddr, err := p.server.cc.wallet.NewAddress(
 		lnwallet.WitnessPubKey, false,
 	)
@@ -2048,7 +2050,7 @@ func (p *peer) getLocalDeliveryScript(upfront lnwire.DeliveryAddress) (lnwire.De
 
 	// If the local node did not set an upfront shutdown script, create a new
 	// delivery script.
-	return p.genDeliveryScript()
+	return p.GenDeliveryScript()
 }
 
 // fetchActiveChanCloser attempts to fetch the active chan closer state machine

--- a/routing/router.go
+++ b/routing/router.go
@@ -2254,90 +2254,6 @@ func generateBandwidthHints(sourceNode *channeldb.LightningNode,
 	return bandwidthHints, nil
 }
 
-// runningAmounts keeps running amounts while the route is traversed.
-type runningAmounts struct {
-	// amt is the intended amount to send via the route.
-	amt lnwire.MilliSatoshi
-
-	// max is the running maximum that the route can carry.
-	max lnwire.MilliSatoshi
-}
-
-// prependChannel returns a new set of running amounts that would result from
-// prepending the given channel to the route. If canIncreaseAmt is set, the
-// amount may be increased if it is too small to satisfy the channel's minimum
-// htlc amount.
-func (r *runningAmounts) prependChannel(policy *channeldb.ChannelEdgePolicy,
-	capacity btcutil.Amount, localChan bool, canIncreaseAmt bool) (
-	runningAmounts, error) {
-
-	// Determine max htlc value.
-	maxHtlc := lnwire.NewMSatFromSatoshis(capacity)
-	if policy.MessageFlags.HasMaxHtlc() {
-		maxHtlc = policy.MaxHTLC
-	}
-
-	amt := r.amt
-
-	// If we have a specific amount for which we are building the route,
-	// validate it against the channel constraints and return the new
-	// running amount.
-	if !canIncreaseAmt {
-		if amt < policy.MinHTLC || amt > maxHtlc {
-			return runningAmounts{}, fmt.Errorf("channel htlc "+
-				"constraints [%v - %v] violated with amt %v",
-				policy.MinHTLC, maxHtlc, amt)
-		}
-
-		// Update running amount by adding the fee for non-local
-		// channels.
-		if !localChan {
-			amt += policy.ComputeFee(amt)
-		}
-
-		return runningAmounts{
-			amt: amt,
-		}, nil
-	}
-
-	// Adapt the minimum amount to what this channel allows.
-	if policy.MinHTLC > r.amt {
-		amt = policy.MinHTLC
-	}
-
-	// Update the maximum amount too to be able to detect incompatible
-	// channels.
-	max := r.max
-	if maxHtlc < r.max {
-		max = maxHtlc
-	}
-
-	// If we get in the situation that the minimum amount exceeds the
-	// maximum amount (enforced further down stream), we have incompatible
-	// channel policies.
-	//
-	// There is possibility with pubkey addressing that we should have
-	// selected a different channel downstream, but we don't backtrack to
-	// try to fix that. It would complicate path finding while we expect
-	// this situation to be rare. The spec recommends to keep all policies
-	// towards a peer identical. If that is the case, there isn't a better
-	// channel that we should have selected.
-	if amt > max {
-		return runningAmounts{},
-			fmt.Errorf("incompatible channel policies: %v "+
-				"exceeds %v", amt, max)
-	}
-
-	// Add fees to the running amounts. Skip the source node fees as
-	// those do not need to be paid.
-	if !localChan {
-		amt += policy.ComputeFee(amt)
-		max += policy.ComputeFee(max)
-	}
-
-	return runningAmounts{amt: amt, max: max}, nil
-}
-
 // ErrNoChannel is returned when a route cannot be built because there are no
 // channels that satisfy all requirements.
 type ErrNoChannel struct {
@@ -2374,24 +2290,21 @@ func (r *ChannelRouter) BuildRoute(amt *lnwire.MilliSatoshi,
 		return nil, err
 	}
 
-	// Allocate a list that will contain the selected channels for this
+	// Allocate a list that will contain the unified policies for this
 	// route.
-	edges := make([]*channeldb.ChannelEdgePolicy, len(hops))
+	edges := make([]*unifiedPolicy, len(hops))
 
-	// Keep a running amount and the maximum for this route.
-	amts := runningAmounts{
-		max: lnwire.MilliSatoshi(^uint64(0)),
-	}
+	var runningAmt lnwire.MilliSatoshi
 	if useMinAmt {
 		// For minimum amount routes, aim to deliver at least 1 msat to
 		// the destination. There are nodes in the wild that have a
 		// min_htlc channel policy of zero, which could lead to a zero
 		// amount payment being made.
-		amts.amt = 1
+		runningAmt = 1
 	} else {
 		// If an amount is specified, we need to build a route that
 		// delivers exactly this amount to the final destination.
-		amts.amt = *amt
+		runningAmt = *amt
 	}
 
 	// Traverse hops backwards to accumulate fees in the running amounts.
@@ -2408,142 +2321,85 @@ func (r *ChannelRouter) BuildRoute(amt *lnwire.MilliSatoshi,
 
 		localChan := i == 0
 
-		// Iterate over candidate channels to select the channel
-		// to use for the final route.
-		var (
-			bestEdge      *channeldb.ChannelEdgePolicy
-			bestAmts      *runningAmounts
-			bestBandwidth lnwire.MilliSatoshi
-		)
+		// Build unified policies for this hop based on the channels
+		// known in the graph.
+		u := newUnifiedPolicies(source, toNode, outgoingChan)
 
-		cb := func(tx *bbolt.Tx,
-			edgeInfo *channeldb.ChannelEdgeInfo,
-			_, inEdge *channeldb.ChannelEdgePolicy) error {
-
-			chanID := edgeInfo.ChannelID
-
-			// Apply outgoing channel restriction is active.
-			if localChan && outgoingChan != nil &&
-				chanID != *outgoingChan {
-
-				return nil
-			}
-
-			// No unknown policy channels.
-			if inEdge == nil {
-				return nil
-			}
-
-			// Before we can process the edge, we'll need to
-			// fetch the node on the _other_ end of this
-			// channel as we may later need to iterate over
-			// the incoming edges of this node if we explore
-			// it further.
-			chanFromNode, err := edgeInfo.FetchOtherNode(
-				tx, toNode[:],
-			)
-			if err != nil {
-				return err
-			}
-
-			// Continue searching if this channel doesn't
-			// connect with the previous hop.
-			if chanFromNode.PubKeyBytes != fromNode {
-				return nil
-			}
-
-			// Validate whether this channel's policy is satisfied
-			// and obtain the new running amounts if this channel
-			// was to be selected.
-			newAmts, err := amts.prependChannel(
-				inEdge, edgeInfo.Capacity, localChan,
-				useMinAmt,
-			)
-			if err != nil {
-				log.Tracef("Skipping chan %v: %v",
-					inEdge.ChannelID, err)
-
-				return nil
-			}
-
-			// If we already have a best edge, check whether this
-			// edge is better.
-			bandwidth := bandwidthHints[chanID]
-			if bestEdge != nil {
-				if localChan {
-					// For local channels, better is defined
-					// as having more bandwidth. We try to
-					// maximize the chance that the returned
-					// route succeeds.
-					if bandwidth < bestBandwidth {
-						return nil
-					}
-				} else {
-					// For other channels, better is defined
-					// as lower fees for the amount to send.
-					// Normally all channels between two
-					// nodes should have the same policy,
-					// but in case not we minimize our cost
-					// here. Regular path finding would do
-					// the same.
-					if newAmts.amt > bestAmts.amt {
-						return nil
-					}
-				}
-			}
-
-			// If we get here, the current edge is better. Replace
-			// the best.
-			bestEdge = inEdge
-			bestAmts = &newAmts
-			bestBandwidth = bandwidth
-
-			return nil
-		}
-
-		err := r.cfg.Graph.ForEachNodeChannel(nil, toNode[:], cb)
+		err := u.addGraphPolicies(r.cfg.Graph, nil)
 		if err != nil {
 			return nil, err
 		}
 
-		// There is no matching channel. Stop building the route here.
-		if bestEdge == nil {
+		// Exit if there are no channels.
+		unifiedPolicy, ok := u.policies[fromNode]
+		if !ok {
 			return nil, ErrNoChannel{
 				fromNode: fromNode,
 				position: i,
 			}
 		}
 
-		log.Tracef("Select channel %v at position %v", bestEdge.ChannelID, i)
+		// If using min amt, increase amt if needed.
+		if useMinAmt {
+			min := unifiedPolicy.minAmt()
+			if min > runningAmt {
+				runningAmt = min
+			}
+		}
 
-		edges[i] = bestEdge
-		amts = *bestAmts
+		// Get a forwarding policy for the specific amount that we want
+		// to forward.
+		policy := unifiedPolicy.getPolicy(runningAmt, bandwidthHints)
+		if policy == nil {
+			return nil, ErrNoChannel{
+				fromNode: fromNode,
+				position: i,
+			}
+		}
+
+		// Add fee for this hop.
+		if !localChan {
+			runningAmt += policy.ComputeFee(runningAmt)
+		}
+
+		log.Tracef("Select channel %v at position %v", policy.ChannelID, i)
+
+		edges[i] = unifiedPolicy
 	}
 
+	// Now that we arrived at the start of the route and found out the route
+	// total amount, we make a forward pass. Because the amount may have
+	// been increased in the backward pass, fees need to be recalculated and
+	// amount ranges re-checked.
+	var pathEdges []*channeldb.ChannelEdgePolicy
+	receiverAmt := runningAmt
+	for i, edge := range edges {
+		policy := edge.getPolicy(receiverAmt, bandwidthHints)
+		if policy == nil {
+			return nil, ErrNoChannel{
+				fromNode: hops[i-1],
+				position: i,
+			}
+		}
+
+		if i > 0 {
+			// Decrease the amount to send while going forward.
+			receiverAmt -= policy.ComputeFeeFromIncoming(
+				receiverAmt,
+			)
+		}
+
+		pathEdges = append(pathEdges, policy)
+	}
+
+	// Build and return the final route.
 	_, height, err := r.cfg.Chain.GetBestBlock()
 	if err != nil {
 		return nil, err
 	}
 
-	var receiverAmt lnwire.MilliSatoshi
-	if useMinAmt {
-		// We've calculated the minimum amount for the htlc that the
-		// source node hands out. The newRoute call below expects the
-		// amount that must reach the receiver after subtraction of fees
-		// along the way. Iterate over all edges to calculate the
-		// receiver amount.
-		receiverAmt = amts.amt
-		for _, edge := range edges[1:] {
-			receiverAmt -= edge.ComputeFeeFromIncoming(receiverAmt)
-		}
-	} else {
-		// Deliver the specified amount to the receiver.
-		receiverAmt = *amt
-	}
-
-	// Build and return the final route.
 	return newRoute(
-		receiverAmt, source, edges, uint32(height),
+		receiverAmt, source, pathEdges, uint32(height),
 		uint16(finalCltvDelta), nil,
 	)
 }

--- a/routing/router_test.go
+++ b/routing/router_test.go
@@ -3410,6 +3410,8 @@ func TestBuildRoute(t *testing.T) {
 	defer cleanUp()
 
 	checkHops := func(rt *route.Route, expected []uint64) {
+		t.Helper()
+
 		if len(rt.Hops) != len(expected) {
 			t.Fatal("hop count mismatch")
 		}

--- a/routing/router_test.go
+++ b/routing/router_test.go
@@ -3439,10 +3439,10 @@ func TestBuildRoute(t *testing.T) {
 	}
 
 	// Check that we get the expected route back. The total amount should be
-	// the amount to deliver to hop c (100 sats) plus the fee for hop b (5
-	// sats).
-	checkHops(rt, []uint64{1, 2})
-	if rt.TotalAmount != 105000 {
+	// the amount to deliver to hop c (100 sats) plus the max fee for the
+	// connection b->c (6 sats).
+	checkHops(rt, []uint64{1, 7})
+	if rt.TotalAmount != 106000 {
 		t.Fatalf("unexpected total amount %v", rt.TotalAmount)
 	}
 
@@ -3455,11 +3455,11 @@ func TestBuildRoute(t *testing.T) {
 	}
 
 	// Check that we get the expected route back. The minimum that we can
-	// send from b to c is 20 sats. Hop b charges 1 sat for the forwarding.
-	// The channel between hop a and b can carry amounts in the range [5,
-	// 100], so 21 sats is the minimum amount for this route.
-	checkHops(rt, []uint64{1, 2})
-	if rt.TotalAmount != 21000 {
+	// send from b to c is 20 sats. Hop b charges 1200 msat for the
+	// forwarding. The channel between hop a and b can carry amounts in the
+	// range [5, 100], so 21200 msats is the minimum amount for this route.
+	checkHops(rt, []uint64{1, 7})
+	if rt.TotalAmount != 21200 {
 		t.Fatalf("unexpected total amount %v", rt.TotalAmount)
 	}
 

--- a/routing/unified_policies.go
+++ b/routing/unified_policies.go
@@ -267,3 +267,15 @@ func (u *unifiedPolicy) getPolicyNetwork(
 
 	return &modifiedPolicy
 }
+
+// minAmt returns the minimum amount that can be forwarded on this connection.
+func (u *unifiedPolicy) minAmt() lnwire.MilliSatoshi {
+	min := lnwire.MaxMilliSatoshi
+	for _, edge := range u.edges {
+		if edge.policy.MinHTLC < min {
+			min = edge.policy.MinHTLC
+		}
+	}
+
+	return min
+}

--- a/routing/unified_policies.go
+++ b/routing/unified_policies.go
@@ -1,0 +1,269 @@
+package routing
+
+import (
+	"github.com/btcsuite/btcutil"
+	"github.com/coreos/bbolt"
+	"github.com/lightningnetwork/lnd/channeldb"
+	"github.com/lightningnetwork/lnd/lnwire"
+	"github.com/lightningnetwork/lnd/routing/route"
+)
+
+// unifiedPolicies holds all unified policies for connections towards a node.
+type unifiedPolicies struct {
+	// policies contains a unified policy for every from node.
+	policies map[route.Vertex]*unifiedPolicy
+
+	// sourceNode is the sender of a payment. The rules to pick the final
+	// policy are different for local channels.
+	sourceNode route.Vertex
+
+	// toNode is the node for which the unified policies are instantiated.
+	toNode route.Vertex
+
+	// outChanRestr is an optional outgoing channel restriction for the
+	// local channel to use.
+	outChanRestr *uint64
+}
+
+// newUnifiedPolicies instantiates a new unifiedPolicies object. Channel
+// policies can be added to this object.
+func newUnifiedPolicies(sourceNode, toNode route.Vertex,
+	outChanRestr *uint64) *unifiedPolicies {
+
+	return &unifiedPolicies{
+		policies:     make(map[route.Vertex]*unifiedPolicy),
+		toNode:       toNode,
+		sourceNode:   sourceNode,
+		outChanRestr: outChanRestr,
+	}
+}
+
+// addPolicy adds a single channel policy. Capacity may be zero if unknown
+// (light clients).
+func (u *unifiedPolicies) addPolicy(fromNode route.Vertex,
+	edge *channeldb.ChannelEdgePolicy, capacity btcutil.Amount) {
+
+	localChan := fromNode == u.sourceNode
+
+	// Skip channels if there is an outgoing channel restriction.
+	if localChan && u.outChanRestr != nil &&
+		*u.outChanRestr != edge.ChannelID {
+
+		return
+	}
+
+	// Update the policies map.
+	policy, ok := u.policies[fromNode]
+	if !ok {
+		policy = &unifiedPolicy{
+			localChan: localChan,
+		}
+		u.policies[fromNode] = policy
+	}
+
+	policy.edges = append(policy.edges, &unifiedPolicyEdge{
+		policy:   edge,
+		capacity: capacity,
+	})
+}
+
+// addGraphPolicies adds all policies that are known for the toNode in the
+// graph.
+func (u *unifiedPolicies) addGraphPolicies(g *channeldb.ChannelGraph,
+	tx *bbolt.Tx) error {
+
+	cb := func(_ *bbolt.Tx, edgeInfo *channeldb.ChannelEdgeInfo, _,
+		inEdge *channeldb.ChannelEdgePolicy) error {
+
+		// If there is no edge policy for this candidate node, skip.
+		// Note that we are searching backwards so this node would have
+		// come prior to the pivot node in the route.
+		if inEdge == nil {
+			return nil
+		}
+
+		// The node on the other end of this channel is the from node.
+		fromNode, err := edgeInfo.OtherNodeKeyBytes(u.toNode[:])
+		if err != nil {
+			return err
+		}
+
+		// Add this policy to the unified policies map.
+		u.addPolicy(fromNode, inEdge, edgeInfo.Capacity)
+
+		return nil
+	}
+
+	// Iterate over all channels of the to node.
+	return g.ForEachNodeChannel(tx, u.toNode[:], cb)
+}
+
+// unifiedPolicyEdge is the individual channel data that is kept inside an
+// unifiedPolicy object.
+type unifiedPolicyEdge struct {
+	policy   *channeldb.ChannelEdgePolicy
+	capacity btcutil.Amount
+}
+
+// amtInRange checks whether an amount falls within the valid range for a
+// channel.
+func (u *unifiedPolicyEdge) amtInRange(amt lnwire.MilliSatoshi) bool {
+	// If the capacity is available (non-light clients), skip channels that
+	// are too small.
+	if u.capacity > 0 &&
+		amt > lnwire.NewMSatFromSatoshis(u.capacity) {
+
+		return false
+	}
+
+	// Skip channels for which this htlc is too large.
+	if u.policy.MessageFlags.HasMaxHtlc() &&
+		amt > u.policy.MaxHTLC {
+
+		return false
+	}
+
+	// Skip channels for which this htlc is too small.
+	if amt < u.policy.MinHTLC {
+		return false
+	}
+
+	return true
+}
+
+// unifiedPolicy is the unified policy that covers all channels between a pair
+// of nodes.
+type unifiedPolicy struct {
+	edges     []*unifiedPolicyEdge
+	localChan bool
+}
+
+// getPolicy returns the optimal policy to use for this connection given a
+// specific amount to send. It differentiates between local and network
+// channels.
+func (u *unifiedPolicy) getPolicy(amt lnwire.MilliSatoshi,
+	bandwidthHints map[uint64]lnwire.MilliSatoshi) *channeldb.ChannelEdgePolicy {
+
+	if u.localChan {
+		return u.getPolicyLocal(amt, bandwidthHints)
+	}
+
+	return u.getPolicyNetwork(amt)
+}
+
+// getPolicyLocal returns the optimal policy to use for this local connection
+// given a specific amount to send.
+func (u *unifiedPolicy) getPolicyLocal(amt lnwire.MilliSatoshi,
+	bandwidthHints map[uint64]lnwire.MilliSatoshi) *channeldb.ChannelEdgePolicy {
+
+	var (
+		bestPolicy   *channeldb.ChannelEdgePolicy
+		maxBandwidth lnwire.MilliSatoshi
+	)
+
+	for _, edge := range u.edges {
+		// Check valid amount range for the channel.
+		if !edge.amtInRange(amt) {
+			continue
+		}
+
+		// For local channels, there is no fee to pay or an extra time
+		// lock. We only consider the currently available bandwidth for
+		// channel selection. The disabled flag is ignored for local
+		// channels.
+
+		// Retrieve bandwidth for this local channel. If not
+		// available, assume this channel has enough bandwidth.
+		//
+		// TODO(joostjager): Possibly change to skipping this
+		// channel. The bandwidth hint is expected to be
+		// available.
+		bandwidth, ok := bandwidthHints[edge.policy.ChannelID]
+		if !ok {
+			bandwidth = lnwire.MaxMilliSatoshi
+		}
+
+		// Skip channels that can't carry the payment.
+		if amt > bandwidth {
+			continue
+		}
+
+		// We pick the local channel with the highest available
+		// bandwidth, to maximize the success probability. It
+		// can be that the channel state changes between
+		// querying the bandwidth hints and sending out the
+		// htlc.
+		if bandwidth < maxBandwidth {
+			continue
+		}
+		maxBandwidth = bandwidth
+
+		// Update best policy.
+		bestPolicy = edge.policy
+	}
+
+	return bestPolicy
+}
+
+// getPolicyNetwork returns the optimal policy to use for this connection given
+// a specific amount to send. The goal is to return a policy that maximizes the
+// probability of a successful forward in a non-strict forwarding context.
+func (u *unifiedPolicy) getPolicyNetwork(
+	amt lnwire.MilliSatoshi) *channeldb.ChannelEdgePolicy {
+
+	var (
+		bestPolicy  *channeldb.ChannelEdgePolicy
+		maxFee      lnwire.MilliSatoshi
+		maxTimelock uint16
+	)
+
+	for _, edge := range u.edges {
+		// Check valid amount range for the channel.
+		if !edge.amtInRange(amt) {
+			continue
+		}
+
+		// For network channels, skip the disabled ones.
+		edgeFlags := edge.policy.ChannelFlags
+		isDisabled := edgeFlags&lnwire.ChanUpdateDisabled != 0
+		if isDisabled {
+			continue
+		}
+
+		// Track the maximum time lock of all channels that are
+		// candidate for non-strict forwarding at the routing node.
+		if edge.policy.TimeLockDelta > maxTimelock {
+			maxTimelock = edge.policy.TimeLockDelta
+		}
+
+		// Use the policy that results in the highest fee for this
+		// specific amount.
+		fee := edge.policy.ComputeFee(amt)
+		if fee < maxFee {
+			continue
+		}
+		maxFee = fee
+
+		bestPolicy = edge.policy
+	}
+
+	// Return early if no channel matches.
+	if bestPolicy == nil {
+		return nil
+	}
+
+	// We have already picked the highest fee that could be required for
+	// non-strict forwarding. To also cover the case where a lower fee
+	// channel requires a longer time lock, we modify the policy by setting
+	// the maximum encountered time lock. Note that this results in a
+	// synthetic policy that is not actually present on the routing node.
+	//
+	// The reason we do this, is that we try to maximize the chance that we
+	// get forwarded. Because we penalize pair-wise, there won't be a second
+	// chance for this node pair. But this is all only needed for nodes that
+	// have distinct policies for channels to the same peer.
+	modifiedPolicy := *bestPolicy
+	modifiedPolicy.TimeLockDelta = maxTimelock
+
+	return &modifiedPolicy
+}

--- a/routing/unified_policies_test.go
+++ b/routing/unified_policies_test.go
@@ -1,0 +1,91 @@
+package routing
+
+import (
+	"testing"
+
+	"github.com/lightningnetwork/lnd/channeldb"
+	"github.com/lightningnetwork/lnd/lnwire"
+	"github.com/lightningnetwork/lnd/routing/route"
+)
+
+// TestUnifiedPolicies tests the composition of unified policies for nodes that
+// have multiple channels between them.
+func TestUnifiedPolicies(t *testing.T) {
+	source := route.Vertex{1}
+	toNode := route.Vertex{2}
+	fromNode := route.Vertex{3}
+
+	bandwidthHints := map[uint64]lnwire.MilliSatoshi{}
+
+	u := newUnifiedPolicies(source, toNode, nil)
+
+	// Add two channels between the pair of nodes.
+	p1 := channeldb.ChannelEdgePolicy{
+		FeeProportionalMillionths: 100000,
+		FeeBaseMSat:               30,
+		TimeLockDelta:             60,
+		MessageFlags:              lnwire.ChanUpdateOptionMaxHtlc,
+		MaxHTLC:                   500,
+		MinHTLC:                   100,
+	}
+	p2 := channeldb.ChannelEdgePolicy{
+		FeeProportionalMillionths: 190000,
+		FeeBaseMSat:               10,
+		TimeLockDelta:             40,
+		MessageFlags:              lnwire.ChanUpdateOptionMaxHtlc,
+		MaxHTLC:                   400,
+		MinHTLC:                   100,
+	}
+	u.addPolicy(fromNode, &p1, 7)
+	u.addPolicy(fromNode, &p2, 7)
+
+	checkPolicy := func(policy *channeldb.ChannelEdgePolicy,
+		feeBase lnwire.MilliSatoshi, feeRate lnwire.MilliSatoshi,
+		timeLockDelta uint16) {
+
+		t.Helper()
+
+		if policy.FeeBaseMSat != feeBase {
+			t.Fatalf("expected fee base %v, got %v",
+				feeBase, policy.FeeBaseMSat)
+		}
+
+		if policy.TimeLockDelta != timeLockDelta {
+			t.Fatalf("expected fee base %v, got %v",
+				timeLockDelta, policy.TimeLockDelta)
+		}
+
+		if policy.FeeProportionalMillionths != feeRate {
+			t.Fatalf("expected fee rate %v, got %v",
+				feeRate, policy.FeeProportionalMillionths)
+		}
+	}
+
+	policy := u.policies[fromNode].getPolicy(50, bandwidthHints)
+	if policy != nil {
+		t.Fatal("expected no policy for amt below min htlc")
+	}
+
+	policy = u.policies[fromNode].getPolicy(550, bandwidthHints)
+	if policy != nil {
+		t.Fatal("expected no policy for amt above max htlc")
+	}
+
+	// For 200 sat, p1 yields the highest fee. Use that policy to forward,
+	// because it will also match p2 in case p1 does not have enough
+	// balance.
+	policy = u.policies[fromNode].getPolicy(200, bandwidthHints)
+	checkPolicy(
+		policy, p1.FeeBaseMSat, p1.FeeProportionalMillionths,
+		p1.TimeLockDelta,
+	)
+
+	// For 400 sat, p2 yields the highest fee. Use that policy to forward,
+	// because it will also match p1 in case p2 does not have enough
+	// balance. In order to match p1, it needs to have p1's time lock delta.
+	policy = u.policies[fromNode].getPolicy(400, bandwidthHints)
+	checkPolicy(
+		policy, p2.FeeBaseMSat, p2.FeeProportionalMillionths,
+		p1.TimeLockDelta,
+	)
+}

--- a/server.go
+++ b/server.go
@@ -2735,6 +2735,9 @@ func (s *server) peerConnected(conn net.Conn, connReq *connmgr.ConnReq,
 	localFeatures.Set(lnwire.DataLossProtectRequired)
 	localFeatures.Set(lnwire.GossipQueriesOptional)
 
+	// Signal that we understand option upfront shutdown script.
+	localFeatures.Set(lnwire.UpfrontShutdownScript)
+
 	// Now that we've established a connection, create a peer, and it to the
 	// set of currently active peers. Configure the peer with the incoming
 	// and outgoing broadcast deltas to prevent htlcs from being accepted or


### PR DESCRIPTION
This PR adds support for [`option_upfront_shutdown_commitment`](https://github.com/lightningnetwork/lightning-rfc/blob/master/02-peer-protocol.md#the-open_channel-message), which allows nodes to specify a script to which funds should be paid out in the event of a cooperative close during channel negotiation. 

It adds a command line flag to `lncli` and a field to `lnrpc` which can be used to set this upfront script if the remote peer supports the feature. If the peer does not support the feature, it errors to manage user expectations of enforcement.