### PR TITLE
Allow user specify routing hints in private invoice.

### DIFF
--- a/lnrpc/invoicesrpc/addinvoice.go
+++ b/lnrpc/invoicesrpc/addinvoice.go
@@ -94,6 +94,10 @@ type AddInvoiceData struct {
 	// HodlInvoice signals that this invoice shouldn't be settled
 	// immediately upon receiving the payment.
 	HodlInvoice bool
+
+	// RouteHints are optional route hints that can each be individually used
+	// to assist in reaching the invoice's destination.
+	RouteHints [][]zpay32.HopHint
 }
 
 // AddInvoice attempts to add a new invoice to the invoice database. Any
@@ -246,6 +250,27 @@ func AddInvoice(ctx context.Context, cfg *AddInvoiceConfig,
 		options = append(options, zpay32.CLTVExpiry(uint64(defaultDelta)))
 	}
 
+	// We make sure that the given invoice routing hints number is within the
+	// valid range
+	if len(invoice.RouteHints) > 20 {
+		return nil, nil, fmt.Errorf("number of routing hints must not exceed " +
+			"maximum of 20")
+	}
+
+	// We continue by populating the requested routing hints indexing their
+	// corresponding channels so we won't duplicate them.
+	forcedHints := make(map[uint64]struct{})
+	for _, h := range invoice.RouteHints {
+		if len(h) == 0 {
+			return nil, nil, fmt.Errorf("number of hop hint within a route must " +
+				"be positive")
+		}
+		options = append(options, zpay32.RouteHint(h))
+
+		// Only this first hop is our direct channel.
+		forcedHints[h[0].ChannelID] = struct{}{}
+	}
+
 	// If we were requested to include routing hints in the invoice, then
 	// we'll fetch all of our available private channels and create routing
 	// hints for them.
@@ -256,11 +281,21 @@ func AddInvoice(ctx context.Context, cfg *AddInvoiceConfig,
 		}
 
 		if len(openChannels) > 0 {
+			// We filter the channels by excluding the ones that were specified by
+			// the caller and were already added.
+			var filteredChannels []*channeldb.OpenChannel
+			for _, c := range openChannels {
+				if _, ok := forcedHints[c.ShortChanID().ToUint64()]; ok {
+					continue
+				}
+				filteredChannels = append(filteredChannels, c)
+			}
+
 			// We'll restrict the number of individual route hints
 			// to 20 to avoid creating overly large invoices.
-			const numMaxHophints = 20
+			numMaxHophints := 20 - len(forcedHints)
 			hopHints := selectHopHints(
-				amtMSat, cfg, openChannels, numMaxHophints,
+				amtMSat, cfg, filteredChannels, numMaxHophints,
 			)
 
 			options = append(options, hopHints...)

--- a/lnrpc/invoicesrpc/invoices_server.go
+++ b/lnrpc/invoicesrpc/invoices_server.go
@@ -289,6 +289,11 @@ func (s *Server) AddHoldInvoice(ctx context.Context,
 		return nil, err
 	}
 
+	// Convert the passed routing hints to the required format.
+	routeHints, err := CreateZpay32HopHints(invoice.RouteHints)
+	if err != nil {
+		return nil, err
+	}
 	addInvoiceData := &AddInvoiceData{
 		Memo:            invoice.Memo,
 		Hash:            &hash,
@@ -300,6 +305,7 @@ func (s *Server) AddHoldInvoice(ctx context.Context,
 		Private:         invoice.Private,
 		HodlInvoice:     true,
 		Preimage:        nil,
+		RouteHints:      routeHints,
 	}
 
 	_, dbInvoice, err := AddInvoice(ctx, addInvoiceCfg, addInvoiceData)

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -4745,6 +4745,11 @@ func (r *rpcServer) AddInvoice(ctx context.Context,
 		return nil, err
 	}
 
+	// Convert the passed routing hints to the required format.
+	routeHints, err := invoicesrpc.CreateZpay32HopHints(invoice.RouteHints)
+	if err != nil {
+		return nil, err
+	}
 	addInvoiceData := &invoicesrpc.AddInvoiceData{
 		Memo:            invoice.Memo,
 		Value:           value,
@@ -4753,6 +4758,7 @@ func (r *rpcServer) AddInvoice(ctx context.Context,
 		FallbackAddr:    invoice.FallbackAddr,
 		CltvExpiry:      invoice.CltvExpiry,
 		Private:         invoice.Private,
+		RouteHints:      routeHints,
 	}
 
 	if invoice.RPreimage != nil {


### PR DESCRIPTION
This PR changes the `AddInvoice/AddHoldInvoice `RPC endpoints to be able to get routing hints and populate them in the resulted invoice.
In fact the `RoutingHints` already existed in both `lnrpc.Invoice` and `lnrpc.AddHoldInvoiceRequest` but were ignored and this change only adds them to the invoice.

This is useful in the following cases:
1. When ones want to expose specific private channels, or to get payment via them.
2. When the default routing hints logic skips some channels due to incomplete graph state (see issue https://github.com/lightningnetwork/lnd/issues/3660). This is specifically important to enable receiving funds on mobile wallets that just bootstrapped with a new channel.