### PR TITLE
docs: bitcoind is required for unit tests

### DIFF
--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -158,6 +158,9 @@ To check that `lnd` was installed properly run the following command:
 make check
 ```
 
+This command requires `bitcoind` (almost any version should do) to be available
+in the system's `$PATH` variable. Otherwise some of the tests will fail.
+
 # Available Backend Operating Modes
 
 In order to run, `lnd` requires, that the user specify a chain backend. At the

--- a/docs/MAKEFILE.md
+++ b/docs/MAKEFILE.md
@@ -9,6 +9,10 @@ make check
 make install
 ```
 
+The command `make check` requires `bitcoind` (almost any version should do) to
+be available in the system's `$PATH` variable. Otherwise some of the tests will
+fail.
+
 Developers
 ==========
 


### PR DESCRIPTION
By just following the docs on how to run unit tests, most users would see failed tests because they don't have `bitcoind` on their `$PATH`. We should explicitly mention this to avoid getting more issues like #3681.