### PR TITLE
routing: use distinct probability estimation for local channels

### DIFF
--- a/routing/missioncontrol.go
+++ b/routing/missioncontrol.go
@@ -118,6 +118,9 @@ type MissionControlConfig struct {
 	// probability completely and only base the probability on historical
 	// results, unless there are none available.
 	AprioriWeight float64
+
+	// SelfNode is our own pubkey.
+	SelfNode route.Vertex
 }
 
 // TimedPairResult describes a timestamped pair result.
@@ -260,6 +263,11 @@ func (m *MissionControl) GetProbability(fromNode, toNode route.Vertex,
 
 	now := m.now()
 	results := m.lastPairResult[fromNode]
+
+	// Use a distinct probability estimation function for local channels.
+	if fromNode == m.cfg.SelfNode {
+		return m.estimator.getLocalPairProbability(now, results, toNode)
+	}
 
 	return m.estimator.getPairProbability(now, results, toNode, amt)
 }

--- a/routing/probability_estimator.go
+++ b/routing/probability_estimator.go
@@ -123,6 +123,22 @@ func (p *probabilityEstimator) getPairProbability(
 	)
 }
 
+// getLocalPairProbability estimates the probability of successfully traversing
+// our own local channels to toNode.
+func (p *probabilityEstimator) getLocalPairProbability(
+	now time.Time, results NodeResults, toNode route.Vertex) float64 {
+
+	// For local channels that have never been tried before, we assume them
+	// to be successful. We have accurate balance and online status
+	// information on our own channels, so when we select them in a route it
+	// is close to certain that those channels will work.
+	nodeProbability := p.prevSuccessProbability
+
+	return p.calculateProbability(
+		now, results, nodeProbability, toNode, lnwire.MaxMilliSatoshi,
+	)
+}
+
 // calculateProbability estimates the probability of successfully traversing to
 // toNode based on historical payment outcomes and a fall-back node probability.
 func (p *probabilityEstimator) calculateProbability(

--- a/server.go
+++ b/server.go
@@ -672,6 +672,7 @@ func newServer(listenAddrs []net.Addr, chanDB *channeldb.DB,
 			PenaltyHalfLife:       routingConfig.PenaltyHalfLife,
 			MaxMcHistory:          routingConfig.MaxMcHistory,
 			AprioriWeight:         routingConfig.AprioriWeight,
+			SelfNode:              selfNode.PubKeyBytes,
 		},
 	)
 	if err != nil {


### PR DESCRIPTION
Previously we used the a priori probability also for our own untried channels. This led to local channels that had seen a success already being prioritized over untried local channels. In some cases,  depending
on the configured payment attempt cost, this could lead to the payment taking a two hop route while a direct payment was also possible.