### PR TITLE
chanrestore: assume height hint for unconfirmed channels in SCBs

### DIFF
--- a/chanrestore.go
+++ b/chanrestore.go
@@ -2,9 +2,11 @@ package lnd
 
 import (
 	"fmt"
+	"math"
 	"net"
 
 	"github.com/btcsuite/btcd/btcec"
+	"github.com/btcsuite/btcd/chaincfg"
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/lightningnetwork/lnd/chanbackup"
 	"github.com/lightningnetwork/lnd/channeldb"
@@ -12,6 +14,18 @@ import (
 	"github.com/lightningnetwork/lnd/keychain"
 	"github.com/lightningnetwork/lnd/lnwire"
 	"github.com/lightningnetwork/lnd/shachain"
+)
+
+const (
+	// mainnetSCBLaunchBlock is the approximate block height of the bitcoin
+	// mainnet chain of the date when SCBs first were released in lnd
+	// (v0.6.0-beta). The block date is 4/15/2019, 10:54 PM UTC.
+	mainnetSCBLaunchBlock = 571800
+
+	// testnetSCBLaunchBlock is the approximate block height of the bitcoin
+	// testnet3 chain of the date when SCBs first were released in lnd
+	// (v0.6.0-beta). The block date is 4/16/2019, 08:04 AM UTC.
+	testnetSCBLaunchBlock = 1489300
 )
 
 // chanDBRestorer is an implementation of the chanbackup.ChannelRestorer
@@ -126,13 +140,52 @@ func (c *chanDBRestorer) openChannelShell(backup chanbackup.Single) (
 // NOTE: Part of the chanbackup.ChannelRestorer interface.
 func (c *chanDBRestorer) RestoreChansFromSingles(backups ...chanbackup.Single) error {
 	channelShells := make([]*channeldb.ChannelShell, 0, len(backups))
+	firstChanHeight := uint32(math.MaxUint32)
 	for _, backup := range backups {
 		chanShell, err := c.openChannelShell(backup)
 		if err != nil {
 			return err
 		}
 
+		// Find the block height of the earliest channel in this backup.
+		chanHeight := chanShell.Chan.ShortChanID().BlockHeight
+		if chanHeight != 0 && chanHeight < firstChanHeight {
+			firstChanHeight = chanHeight
+		}
+
 		channelShells = append(channelShells, chanShell)
+	}
+
+	// In case there were only unconfirmed channels, we will have to scan
+	// the chain beginning from the launch date of SCBs.
+	if firstChanHeight == math.MaxUint32 {
+		chainHash := channelShells[0].Chan.ChainHash
+		switch {
+		case chainHash.IsEqual(chaincfg.MainNetParams.GenesisHash):
+			firstChanHeight = mainnetSCBLaunchBlock
+
+		case chainHash.IsEqual(chaincfg.TestNet3Params.GenesisHash):
+			firstChanHeight = testnetSCBLaunchBlock
+
+		default:
+			// Worst case: We have no height hint and start at
+			// block 1. Should only happen for SCBs in regtest,
+			// simnet and litecoin.
+			firstChanHeight = 1
+		}
+	}
+
+	// If there were channels in the backup that were not confirmed at the
+	// time of the backup creation, they won't have a block height in the
+	// ShortChanID which would lead to an error in the chain watcher. Since
+	// we have no other height hint available for these channels, the best
+	// we can do is give them a FundingBroadcastHeight that corresponds to
+	// the lowest block height of the confirmed channels, hoping that they
+	// in fact were opened before those unconfirmed.
+	for _, chanShell := range channelShells {
+		if chanShell.Chan.ShortChanID().BlockHeight == 0 {
+			chanShell.Chan.FundingBroadcastHeight = firstChanHeight
+		}
 	}
 
 	ltndLog.Infof("Inserting %v SCB channel shells into DB",


### PR DESCRIPTION
This is an attempt at fixing #3444 and #3539. This issue also came up in #2468.

The `chainWatcher` will take the height hint to register spend notifications from `ShortChanID`, which will be 0 for unconfirmed channels. As a fall back, it then takes the `FundingBroadcastHeight` of the channel. But this value is also 0 in case of a channel shell restored from an SCB.

So for unconfirmed channels in SCBs we have no idea what height hint to use. We can't use 0 because of a restriction in `chainntnfs` introduced in #3405.

This PR tries to use the block height of the earliest confirmed channel in the backup passed to it as a height hint. If there is no unconfirmed channel, it falls back to a static block height which corresponds to the launch date of SCBs in lnd.

Maybe there is a more elegant way to solve this, suggestions are very welcome.
