### PR TITLE
routing+htlcswitch: improve failed payment logging

### DIFF
--- a/htlcswitch/failure.go
+++ b/htlcswitch/failure.go
@@ -30,10 +30,14 @@ type ForwardingError struct {
 // returned.
 func (f *ForwardingError) Error() string {
 	if f.ExtraMsg == "" {
-		return fmt.Sprintf("%v", f.FailureMessage)
+		return fmt.Sprintf(
+			"%v@%v", f.FailureMessage, f.FailureSourceIdx,
+		)
 	}
 
-	return fmt.Sprintf("%v: %v", f.FailureMessage, f.ExtraMsg)
+	return fmt.Sprintf(
+		"%v@%v: %v", f.FailureMessage, f.FailureSourceIdx, f.ExtraMsg,
+	)
 }
 
 // ErrorDecrypter is an interface that is used to decrypt the onion encrypted

--- a/htlcswitch/link_test.go
+++ b/htlcswitch/link_test.go
@@ -1248,8 +1248,14 @@ func TestChannelLinkMultiHopUnknownNextHop(t *testing.T) {
 		totalTimelock).Wait(30 * time.Second)
 	if err == nil {
 		t.Fatal("error haven't been received")
-	} else if err.Error() != lnwire.CodeUnknownNextPeer.String() {
-		t.Fatalf("wrong error have been received: %v", err)
+	}
+	fErr, ok := err.(*ForwardingError)
+	if !ok {
+		t.Fatalf("expected ForwardingError")
+	}
+	if _, ok = fErr.FailureMessage.(*lnwire.FailUnknownNextPeer); !ok {
+		t.Fatalf("wrong error has been received: %T",
+			fErr.FailureMessage)
 	}
 
 	// Wait for Alice to receive the revocation.

--- a/routing/payment_lifecycle.go
+++ b/routing/payment_lifecycle.go
@@ -341,8 +341,8 @@ func (p *paymentLifecycle) sendPaymentAttempt(firstHop lnwire.ShortChannelID,
 		return err
 	}
 
-	log.Debugf("Payment %x (pid=%v) successfully sent to switch",
-		p.payment.PaymentHash, p.attempt.PaymentID)
+	log.Debugf("Payment %x (pid=%v) successfully sent to switch, route: %v",
+		p.payment.PaymentHash, p.attempt.PaymentID, &p.attempt.Route)
 
 	return nil
 }

--- a/routing/route/route.go
+++ b/routing/route/route.go
@@ -340,15 +340,19 @@ func (r *Route) ToSphinxPath() (*sphinx.PaymentPath, error) {
 func (r *Route) String() string {
 	var b strings.Builder
 
+	amt := r.TotalAmount
 	for i, hop := range r.Hops {
 		if i > 0 {
-			b.WriteString(",")
+			b.WriteString(" -> ")
 		}
-		b.WriteString(strconv.FormatUint(hop.ChannelID, 10))
+		b.WriteString(fmt.Sprintf("%v (%v)",
+			strconv.FormatUint(hop.ChannelID, 10),
+			amt,
+		))
+		amt = hop.AmtToForward
 	}
 
-	return fmt.Sprintf("amt=%v, fees=%v, tl=%v, chans=%v",
-		r.TotalAmount-r.TotalFees(), r.TotalFees(), r.TotalTimeLock,
-		b.String(),
+	return fmt.Sprintf("%v, cltv %v",
+		b.String(), r.TotalTimeLock,
 	)
 }


### PR DESCRIPTION
This pr contains several changes to improve the information that is logged when a payment attempt fails, which will hopefully help us in debugging routing/mission control related issues.