### PR TITLE
lncli: do not hang on ctrl-c

### DIFF
--- a/lnd.go
+++ b/lnd.go
@@ -116,6 +116,9 @@ type rpcListeners func() ([]net.Listener, func(), []grpc.ServerOption, error)
 // created in the top-level scope of a main method aren't executed if os.Exit()
 // is called.
 func Main(lisCfg ListenerCfg) error {
+	// Hook interceptor for os signals.
+	signal.Intercept()
+
 	// Load the configuration, and parse any command line options. This
 	// function will also set up logging properly.
 	loadedConfig, err := loadConfig()

--- a/signal/signal.go
+++ b/signal/signal.go
@@ -26,7 +26,8 @@ var (
 	shutdownChannel = make(chan struct{})
 )
 
-func init() {
+// Intercept starts the interception of interrupt signals.
+func Intercept() {
 	signalsToCatch := []os.Signal{
 		os.Interrupt,
 		os.Kill,


### PR DESCRIPTION
If the lnd package is referenced, the interrupt signal handler will be initialized causing lncli to not properly exit on ctrl-c.

This commit prevents this by making the initialization of the interrupt interceptor an explicit action.