### PR TITLE
rpc+cnct: update AbandonChannel to also remove cnct and channel graph state 

### DIFF
--- a/channeldb/db.go
+++ b/channeldb/db.go
@@ -1094,6 +1094,54 @@ func (d *DB) AddrsForNode(nodePub *btcec.PublicKey) ([]net.Addr, error) {
 	return dedupedAddrs, nil
 }
 
+// AbandonChannel attempts to remove the target channel from the open channel
+// database. If the channel was already removed (has a closed channel entry),
+// then we'll return a nil error. Otherwise, we'll insert a new close summary
+// into the database.
+func (d *DB) AbandonChannel(chanPoint *wire.OutPoint, bestHeight uint32) error {
+	// With the chanPoint constructed, we'll attempt to find the target
+	// channel in the database. If we can't find the channel, then we'll
+	// return the error back to the caller.
+	dbChan, err := d.FetchChannel(*chanPoint)
+	switch {
+	// If the channel wasn't found, then it's possible that it was already
+	// abandoned from the database.
+	case err == ErrChannelNotFound:
+		_, closedErr := d.FetchClosedChannel(chanPoint)
+		if closedErr != nil {
+			return closedErr
+		}
+
+		// If the channel was already closed, then we don't return an
+		// error as we'd like fro this step to be repeatable.
+		return nil
+	case err != nil:
+		return err
+	}
+
+	// Now that we've found the channel, we'll populate a close summary for
+	// the channel, so we can store as much information for this abounded
+	// channel as possible. We also ensure that we set Pending to false, to
+	// indicate that this channel has been "fully" closed.
+	summary := &ChannelCloseSummary{
+		CloseType:               Abandoned,
+		ChanPoint:               *chanPoint,
+		ChainHash:               dbChan.ChainHash,
+		CloseHeight:             bestHeight,
+		RemotePub:               dbChan.IdentityPub,
+		Capacity:                dbChan.Capacity,
+		SettledBalance:          dbChan.LocalCommitment.LocalBalance.ToSatoshis(),
+		ShortChanID:             dbChan.ShortChanID(),
+		RemoteCurrentRevocation: dbChan.RemoteCurrentRevocation,
+		RemoteNextRevocation:    dbChan.RemoteNextRevocation,
+		LocalChanConfig:         dbChan.LocalChanCfg,
+	}
+
+	// Finally, we'll close the channel in the DB, and return back to the
+	// caller.
+	return dbChan.CloseChannel(summary)
+}
+
 // syncVersions function is used for safe db version synchronization. It
 // applies migration functions to the current database and recovers the
 // previous state of db if at least one error/panic appeared during migration.

--- a/contractcourt/chain_arbitrator_test.go
+++ b/contractcourt/chain_arbitrator_test.go
@@ -115,3 +115,105 @@ func TestChainArbitratorRepublishCommitment(t *testing.T) {
 		t.Fatalf("unexpected tx published")
 	}
 }
+
+// TestResolveContract tests that if we have an active channel being watched by
+// the chain arb, then a call to ResolveContract will mark the channel as fully
+// closed in the database, and also clean up all arbitrator state.
+func TestResolveContract(t *testing.T) {
+	t.Parallel()
+
+	// To start with, we'll create a new temp DB for the duration of this
+	// test.
+	tempPath, err := ioutil.TempDir("", "testdb")
+	if err != nil {
+		t.Fatalf("unable to make temp dir: %v", err)
+	}
+	defer os.RemoveAll(tempPath)
+	db, err := channeldb.Open(tempPath)
+	if err != nil {
+		t.Fatalf("unable to open db: %v", err)
+	}
+	defer db.Close()
+
+	// With the DB created, we'll make a new channel, and mark it as
+	// pending open within the database.
+	newChannel, _, cleanup, err := lnwallet.CreateTestChannels(true)
+	if err != nil {
+		t.Fatalf("unable to make new test channel: %v", err)
+	}
+	defer cleanup()
+	channel := newChannel.State()
+	channel.Db = db
+	addr := &net.TCPAddr{
+		IP:   net.ParseIP("127.0.0.1"),
+		Port: 18556,
+	}
+	if err := channel.SyncPending(addr, 101); err != nil {
+		t.Fatalf("unable to write channel to db: %v", err)
+	}
+
+	// With the channel inserted into the database, we'll now create a new
+	// chain arbitrator that should pick up these new channels and launch
+	// resolver for them.
+	chainArbCfg := ChainArbitratorConfig{
+		ChainIO:  &mockChainIO{},
+		Notifier: &mockNotifier{},
+		PublishTx: func(tx *wire.MsgTx) error {
+			return nil
+		},
+	}
+	chainArb := NewChainArbitrator(
+		chainArbCfg, db,
+	)
+	if err := chainArb.Start(); err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		if err := chainArb.Stop(); err != nil {
+			t.Fatal(err)
+		}
+	}()
+
+	channelArb := chainArb.activeChannels[channel.FundingOutpoint]
+
+	// While the resolver are active, we'll now remove the channel from the
+	// database (mark is as closed).
+	err = db.AbandonChannel(&channel.FundingOutpoint, 4)
+	if err != nil {
+		t.Fatalf("unable to remove channel: %v", err)
+	}
+
+	// With the channel removed, we'll now manually call ResolveContract.
+	// This stimulates needing to remove a channel from the chain arb due
+	// to any possible external consistency issues.
+	err = chainArb.ResolveContract(channel.FundingOutpoint)
+	if err != nil {
+		t.Fatalf("unable to resolve contract: %v", err)
+	}
+
+	// The shouldn't be an active chain watcher or channel arb for this
+	// channel.
+	if len(chainArb.activeChannels) != 0 {
+		t.Fatalf("expected zero active channels, instead have %v",
+			len(chainArb.activeChannels))
+	}
+	if len(chainArb.activeWatchers) != 0 {
+		t.Fatalf("expected zero active watchers, instead have %v",
+			len(chainArb.activeWatchers))
+	}
+
+	// At this point, the channel's arbitrator log should also be empty as
+	// well.
+	_, err = channelArb.log.FetchContractResolutions()
+	if err != errScopeBucketNoExist {
+		t.Fatalf("channel arb log state should have been "+
+			"removed: %v", err)
+	}
+
+	// If we attempt to call this method again, then we should get a nil
+	// error, as there is no more state to be cleaned up.
+	err = chainArb.ResolveContract(channel.FundingOutpoint)
+	if err != nil {
+		t.Fatalf("second resolve call shouldn't fail: %v", err)
+	}
+}


### PR DESCRIPTION
In this commit, we update the `AbandonChannel` method to also remove the
state from the countract court as well as the channel graph. Abandoning
a channel is now a three step process: remove from the open hannel
state, remove from the graph, remove from the contract court. Between
any step it's possible that the users restarts the process all over
again. As a result, each of the steps below are intended to be
idempotent. The final step will always fail once the log of the channel
arbitrator has been clead up, giving the user a signal that all channel
state has been removed.

We also update the integration test to assert that no channel is found
in the graph any longer. Before this commit, this test would fail as the
channel was still found in the graph, which can cause other issues for
an operational daemon.

Fixes #3716.