### PR TITLE
Increase block size to 200 gigamegs!

### DIFF
--- a/cmd/lncli/main.go
+++ b/cmd/lncli/main.go
@@ -39,8 +39,8 @@ var (
 	defaultTLSCertPath = filepath.Join(defaultLndDir, defaultTLSCertFilename)
 
 	// maxMsgRecvSize is the largest message our client will receive. We
-	// set this to ~50Mb atm.
-	maxMsgRecvSize = grpc.MaxCallRecvMsgSize(1 * 1024 * 1024 * 50)
+	// set this to 200MiB atm.
+	maxMsgRecvSize = grpc.MaxCallRecvMsgSize(1 * 1024 * 1024 * 200)
 )
 
 func fatal(err error) {


### PR DESCRIPTION
This PR increases the gRPC max receive size again, this time from 50MiB to 200MiB.
The operation that hits the maximum is `lncli listchaintxns` with about 2.6k transactions on testnet (see https://github.com/lightninglabs/lndmon/issues/48).
As mentioned in #2374, this only affects `lncli`, users of the gRPC API need to set this value on the client side.