### PR TITLE
routing: fix race condition when resuming payments

### DIFF
--- a/routing/router.go
+++ b/routing/router.go
@@ -533,7 +533,7 @@ func (r *ChannelRouter) Start() error {
 				PaymentHash: payment.Info.PaymentHash,
 			}
 
-			_, _, err = r.sendPayment(payment.Attempt, lPayment, paySession)
+			_, _, err := r.sendPayment(payment.Attempt, lPayment, paySession)
 			if err != nil {
 				log.Errorf("Resuming payment with hash %v "+
 					"failed: %v.", payment.Info.PaymentHash, err)


### PR DESCRIPTION
Found while running the integration tests with `-race`. Reuse of `err` variable when resuming payments in goroutines.

```
==================
WARNING: DATA RACE
Write at 0x00c000a680f0 by goroutine 147:
  github.com/lightningnetwork/lnd/routing.(*ChannelRouter).Start.func1()
      /Users/nsa/go/src/github.com/lightningnetwork/lnd/routing/router.go:536 +0x251

Previous write at 0x00c000a680f0 by goroutine 143:
  github.com/lightningnetwork/lnd/routing.(*ChannelRouter).Start.func1()
      /Users/nsa/go/src/github.com/lightningnetwork/lnd/routing/router.go:536 +0x251

Goroutine 147 (running) created at:
  github.com/lightningnetwork/lnd/routing.(*ChannelRouter).Start()
      /Users/nsa/go/src/github.com/lightningnetwork/lnd/routing/router.go:521 +0x42c
  github.com/lightningnetwork/lnd.(*server).Start.func1()
      /Users/nsa/go/src/github.com/lightningnetwork/lnd/server.go:1283 +0xaa0
  sync.(*Once).doSlow()
      /usr/local/Cellar/go/1.13/libexec/src/sync/once.go:66 +0x100
  sync.(*Once).Do()
      /usr/local/Cellar/go/1.13/libexec/src/sync/once.go:57 +0x68
  github.com/lightningnetwork/lnd.(*server).Start()
      /Users/nsa/go/src/github.com/lightningnetwork/lnd/server.go:1207 +0x7d
  github.com/lightningnetwork/lnd.Main()
      /Users/nsa/go/src/github.com/lightningnetwork/lnd/lnd.go:624 +0x29d3
  main.main()
      /Users/nsa/go/src/github.com/lightningnetwork/lnd/cmd/lnd/main.go:14 +0x3f

Goroutine 143 (running) created at:
  github.com/lightningnetwork/lnd/routing.(*ChannelRouter).Start()
      /Users/nsa/go/src/github.com/lightningnetwork/lnd/routing/router.go:521 +0x42c
  github.com/lightningnetwork/lnd.(*server).Start.func1()
      /Users/nsa/go/src/github.com/lightningnetwork/lnd/server.go:1283 +0xaa0
  sync.(*Once).doSlow()
      /usr/local/Cellar/go/1.13/libexec/src/sync/once.go:66 +0x100
  sync.(*Once).Do()
      /usr/local/Cellar/go/1.13/libexec/src/sync/once.go:57 +0x68
  github.com/lightningnetwork/lnd.(*server).Start()
      /Users/nsa/go/src/github.com/lightningnetwork/lnd/server.go:1207 +0x7d
  github.com/lightningnetwork/lnd.Main()
      /Users/nsa/go/src/github.com/lightningnetwork/lnd/lnd.go:624 +0x29d3
  main.main()
      /Users/nsa/go/src/github.com/lightningnetwork/lnd/cmd/lnd/main.go:14 +0x3f
==================
```