### PR TITLE
lnwire: assert sorted short channel ids

### DIFF
--- a/lnwire/query_short_chan_ids_test.go
+++ b/lnwire/query_short_chan_ids_test.go
@@ -1,0 +1,75 @@
+package lnwire
+
+import (
+	"bytes"
+	"testing"
+)
+
+type unsortedSidTest struct {
+	name    string
+	encType ShortChanIDEncoding
+	sids    []ShortChannelID
+}
+
+var (
+	unsortedSids = []ShortChannelID{
+		NewShortChanIDFromInt(4),
+		NewShortChanIDFromInt(3),
+	}
+
+	duplicateSids = []ShortChannelID{
+		NewShortChanIDFromInt(3),
+		NewShortChanIDFromInt(3),
+	}
+
+	unsortedSidTests = []unsortedSidTest{
+		{
+			name:    "plain unsorted",
+			encType: EncodingSortedPlain,
+			sids:    unsortedSids,
+		},
+		{
+			name:    "plain duplicate",
+			encType: EncodingSortedPlain,
+			sids:    duplicateSids,
+		},
+		{
+			name:    "zlib unsorted",
+			encType: EncodingSortedZlib,
+			sids:    unsortedSids,
+		},
+		{
+			name:    "zlib duplicate",
+			encType: EncodingSortedZlib,
+			sids:    duplicateSids,
+		},
+	}
+)
+
+// TestQueryShortChanIDsUnsorted tests that decoding a QueryShortChanID request
+// that contains duplicate or unsorted ids returns an ErrUnsortedSIDs failure.
+func TestQueryShortChanIDsUnsorted(t *testing.T) {
+	for _, test := range unsortedSidTests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			req := &QueryShortChanIDs{
+				EncodingType: test.encType,
+				ShortChanIDs: test.sids,
+				noSort:       true,
+			}
+
+			var b bytes.Buffer
+			err := req.Encode(&b, 0)
+			if err != nil {
+				t.Fatalf("unable to encode req: %v", err)
+			}
+
+			var req2 QueryShortChanIDs
+			err = req2.Decode(bytes.NewReader(b.Bytes()), 0)
+			if _, ok := err.(ErrUnsortedSIDs); !ok {
+				t.Fatalf("expected ErrUnsortedSIDs, got: %T",
+					err)
+			}
+		})
+	}
+}

--- a/lnwire/reply_channel_range.go
+++ b/lnwire/reply_channel_range.go
@@ -64,7 +64,7 @@ func (c *ReplyChannelRange) Encode(w io.Writer, pver uint32) error {
 		return err
 	}
 
-	return encodeShortChanIDs(w, c.EncodingType, c.ShortChanIDs)
+	return encodeShortChanIDs(w, c.EncodingType, c.ShortChanIDs, false)
 }
 
 // MsgType returns the integer uniquely identifying this message type on the

--- a/lnwire/reply_channel_range.go
+++ b/lnwire/reply_channel_range.go
@@ -21,6 +21,12 @@ type ReplyChannelRange struct {
 
 	// ShortChanIDs is a slice of decoded short channel ID's.
 	ShortChanIDs []ShortChannelID
+
+	// noSort indicates whether or not to sort the short channel ids before
+	// writing them out.
+	//
+	// NOTE: This should only be used for testing.
+	noSort bool
 }
 
 // NewReplyChannelRange creates a new empty ReplyChannelRange message.
@@ -64,7 +70,7 @@ func (c *ReplyChannelRange) Encode(w io.Writer, pver uint32) error {
 		return err
 	}
 
-	return encodeShortChanIDs(w, c.EncodingType, c.ShortChanIDs, false)
+	return encodeShortChanIDs(w, c.EncodingType, c.ShortChanIDs, c.noSort)
 }
 
 // MsgType returns the integer uniquely identifying this message type on the

--- a/lnwire/reply_channel_range_test.go
+++ b/lnwire/reply_channel_range_test.go
@@ -1,0 +1,34 @@
+package lnwire
+
+import (
+	"bytes"
+	"testing"
+)
+
+// TestReplyChannelRangeUnsorted tests that decoding a ReplyChannelRange request
+// that contains duplicate or unsorted ids returns an ErrUnsortedSIDs failure.
+func TestReplyChannelRangeUnsorted(t *testing.T) {
+	for _, test := range unsortedSidTests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			req := &ReplyChannelRange{
+				EncodingType: test.encType,
+				ShortChanIDs: test.sids,
+				noSort:       true,
+			}
+
+			var b bytes.Buffer
+			err := req.Encode(&b, 0)
+			if err != nil {
+				t.Fatalf("unable to encode req: %v", err)
+			}
+
+			var req2 ReplyChannelRange
+			err = req2.Decode(bytes.NewReader(b.Bytes()), 0)
+			if _, ok := err.(ErrUnsortedSIDs); !ok {
+				t.Fatalf("expected ErrUnsortedSIDs, got: %T",
+					err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This PR modifies our decoding of short channel id arrays to also assert that the decoded ids are in order for the plain encodings. We already do so for the zlib encoding, though this isn't tested directly. Here we correct the decoding make this assertion for plain encodings, and add unit tests to both `QueryShortChanIDs` and `ReplyChannelRange` to ensure that they fail with this error when presented with duplicate or unsorted channel ids for either plain or zlib.