### PR TITLE
lncli addholdinvoice: allow specifying msat with --amt_msat

### DIFF
--- a/cmd/lncli/invoicesrpc_active.go
+++ b/cmd/lncli/invoicesrpc_active.go
@@ -160,6 +160,10 @@ var addHoldInvoiceCommand = cli.Command{
 			Name:  "amt",
 			Usage: "the amt of satoshis in this invoice",
 		},
+		cli.Int64Flag{
+			Name:  "amt_msat",
+			Usage: "the amt of millisatoshis in this invoice",
+		},
 		cli.StringFlag{
 			Name: "description_hash",
 			Usage: "SHA-256 hash of the description of the payment. " +
@@ -192,7 +196,6 @@ var addHoldInvoiceCommand = cli.Command{
 func addHoldInvoice(ctx *cli.Context) error {
 	var (
 		descHash []byte
-		amt      int64
 		err      error
 	)
 
@@ -212,12 +215,11 @@ func addHoldInvoice(ctx *cli.Context) error {
 
 	args = args.Tail()
 
-	switch {
-	case ctx.IsSet("amt"):
-		amt = ctx.Int64("amt")
-	case args.Present():
-		amt, err = strconv.ParseInt(args.First(), 10, 64)
+	amt := ctx.Int64("amt")
+	amtMsat := ctx.Int64("amt_msat")
 
+	if !ctx.IsSet("amt") && !ctx.IsSet("amt_msat") && args.Present() {
+		amt, err = strconv.ParseInt(args.First(), 10, 64)
 		if err != nil {
 			return fmt.Errorf("unable to decode amt argument: %v", err)
 		}
@@ -236,6 +238,7 @@ func addHoldInvoice(ctx *cli.Context) error {
 		Memo:            ctx.String("memo"),
 		Hash:            hash,
 		Value:           amt,
+		ValueMsat:       amtMsat,
 		DescriptionHash: descHash,
 		FallbackAddr:    ctx.String("fallback_addr"),
 		Expiry:          ctx.Int64("expiry"),


### PR DESCRIPTION
Make `lncli addholdinvoice` send value in millisatoshi (ValueMsat introduced by commit fcbf1bc07a032f1f95ecf64ba9a216dd229dfb59). 

New flag `--amt_msat` is introduced for this purpose, while `--amt` and unnamed command-line argument are still supposed to be in satoshi for backward compatibility.