### PR TITLE
Makefile: non-verbose unit tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ GOACC_COMMIT := ddc355013f90fea78d83d3a6c71f1d37ac07ecd5
 DEPGET := cd /tmp && GO111MODULE=on go get -v
 GOBUILD := GO111MODULE=on go build -v
 GOINSTALL := GO111MODULE=on go install -v
-GOTEST := GO111MODULE=on go test -v
+GOTEST := GO111MODULE=on go test 
 
 GOFILES_NOVENDOR = $(shell find . -type f -name '*.go' -not -path "./vendor/*")
 GOLIST := go list -deps $(PKG)/... | grep '$(PKG)'| grep -v '/vendor/'

--- a/make/testing_flags.mk
+++ b/make/testing_flags.mk
@@ -63,4 +63,4 @@ endif
 # Construct the integration test command with the added build flags.
 ITEST_TAGS := $(DEV_TAGS) rpctest chainrpc walletrpc signrpc invoicesrpc autopilotrpc routerrpc watchtowerrpc wtclientrpc $(backend)
 
-ITEST := rm lntest/itest/*.log; date; $(GOTEST) ./lntest/itest -tags="$(ITEST_TAGS)" $(TEST_FLAGS) -logoutput -goroutinedump
+ITEST := rm lntest/itest/*.log; date; $(GOTEST) -v ./lntest/itest -tags="$(ITEST_TAGS)" $(TEST_FLAGS) -logoutput -goroutinedump


### PR DESCRIPTION
Makes it easier to spot failures without scrolling through pages of
successful tests.