### PR TITLE
lnrpc: fix nanonsecond typo

### DIFF
--- a/lnrpc/rpc.pb.go
+++ b/lnrpc/rpc.pb.go
@@ -7846,10 +7846,10 @@ type HTLCAttempt struct {
 	Status HTLCAttempt_HTLCStatus `protobuf:"varint,1,opt,name=status,proto3,enum=lnrpc.HTLCAttempt_HTLCStatus" json:"status,omitempty"`
 	/// The route taken by this HTLC.
 	Route *Route `protobuf:"bytes,2,opt,name=route,proto3" json:"route,omitempty"`
-	/// The time in UNIX nanonseconds at which this HTLC was sent.
+	/// The time in UNIX nanoseconds at which this HTLC was sent.
 	AttemptTimeNs int64 `protobuf:"varint,3,opt,name=attempt_time_ns,proto3" json:"attempt_time_ns,omitempty"`
 	//*
-	//The time in UNIX nanonseconds at which this HTLC was settled or failed.
+	//The time in UNIX nanoseconds at which this HTLC was settled or failed.
 	//This value will not be set if the HTLC is still IN_FLIGHT.
 	ResolveTimeNs        int64    `protobuf:"varint,4,opt,name=resolve_time_ns,proto3" json:"resolve_time_ns,omitempty"`
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`

--- a/lnrpc/rpc.proto
+++ b/lnrpc/rpc.proto
@@ -2535,11 +2535,11 @@ message HTLCAttempt {
         /// The route taken by this HTLC.
         Route route = 2 [json_name = "route"];
 
-        /// The time in UNIX nanonseconds at which this HTLC was sent.
+        /// The time in UNIX nanoseconds at which this HTLC was sent.
         int64 attempt_time_ns = 3 [json_name = "attempt_time_ns"];
 
         /**
-        The time in UNIX nanonseconds at which this HTLC was settled or failed.
+        The time in UNIX nanoseconds at which this HTLC was settled or failed.
         This value will not be set if the HTLC is still IN_FLIGHT.
         */
         int64 resolve_time_ns = 4 [json_name = "resolve_time_ns"];

--- a/lnrpc/rpc.swagger.json
+++ b/lnrpc/rpc.swagger.json
@@ -2534,12 +2534,12 @@
         "attempt_time_ns": {
           "type": "string",
           "format": "int64",
-          "description": "/ The time in UNIX nanonseconds at which this HTLC was sent."
+          "description": "/ The time in UNIX nanoseconds at which this HTLC was sent."
         },
         "resolve_time_ns": {
           "type": "string",
           "format": "int64",
-          "description": "*\nThe time in UNIX nanonseconds at which this HTLC was settled or failed.\nThis value will not be set if the HTLC is still IN_FLIGHT."
+          "description": "*\nThe time in UNIX nanoseconds at which this HTLC was settled or failed.\nThis value will not be set if the HTLC is still IN_FLIGHT."
         }
       }
     },


### PR DESCRIPTION
Fixes a typo introduced in #3499 