### PR TITLE
mobile: run goimports on generated files

### DIFF
--- a/mobile/gen_bindings.sh
+++ b/mobile/gen_bindings.sh
@@ -72,3 +72,6 @@ do
            --proto_path=${DIRECTORY} \
            ${file}
 done
+
+# Run goimports to resolve any dependencies among the sub-servers.
+goimports -w ./*_generated.go


### PR DESCRIPTION
Subservers might depend on each other (notably walletrpc depends on
signrpc) so running goimports ensures they properly import each other.
