### PR TITLE
cnct: keep open channel data after channel commitment tx confirms

### DIFF
--- a/channeldb/channel.go
+++ b/channeldb/channel.go
@@ -37,6 +37,11 @@ var (
 	// TODO(roasbeef): flesh out comment
 	openChannelBucket = []byte("open-chan-bucket")
 
+	// historicalChannelBucket stores all channels that have seen their
+	// commitment tx confirm. All information from their previous open state
+	// is retained.
+	historicalChannelBucket = []byte("historical-chan-bucket")
+
 	// chanInfoKey can be accessed within the bucket for a channel
 	// (identified by its chanPoint). This key stores all the static
 	// information for a channel which is decided at the end of  the
@@ -2229,7 +2234,8 @@ func (c *OpenChannel) CloseChannel(summary *ChannelCloseSummary) error {
 		if err != nil {
 			return err
 		}
-		chanBucket := chainBucket.Bucket(chanPointBuf.Bytes())
+		chanKey := chanPointBuf.Bytes()
+		chanBucket := chainBucket.Bucket(chanKey)
 		if chanBucket == nil {
 			return ErrNoActiveChannels
 		}
@@ -2262,6 +2268,25 @@ func (c *OpenChannel) CloseChannel(summary *ChannelCloseSummary) error {
 		}
 
 		err = chainBucket.DeleteBucket(chanPointBuf.Bytes())
+		if err != nil {
+			return err
+		}
+
+		// Add channel state to the historical channel bucket.
+		historicalBucket, err := tx.CreateBucketIfNotExists(
+			historicalChannelBucket,
+		)
+		if err != nil {
+			return err
+		}
+
+		historicalChanBucket, err :=
+			historicalBucket.CreateBucketIfNotExists(chanKey)
+		if err != nil {
+			return err
+		}
+
+		err = putOpenChannel(historicalChanBucket, chanState)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
This PR is a preparation for the addition of the anchor resolver. By keeping the open channel data around, we can avoid persisting the anchor resolutions in the database. This simplifies the implementation and reduces the number of execution paths (especially after a restart of `lnd`).

It also opens up the possibility to convert other resolvers to exist in memory only, although this is a long term goal - if it is a goal at all.

In general, having the channel data available allows for more flexibility in implementations.