### PR TITLE
zpay32: Fix broken last tagged field

### DIFF
--- a/zpay32/invoice.go
+++ b/zpay32/invoice.go
@@ -86,6 +86,10 @@ var (
 
 	// ErrInvoiceTooLarge is returned when an invoice exceeds maxInvoiceLength.
 	ErrInvoiceTooLarge = errors.New("invoice is too large")
+
+	// ErrInvalidFieldLength is returned when a tagged field was specified
+	// with a length larger than the left over bytes of the data field.
+	ErrInvalidFieldLength = errors.New("invalid field length")
 )
 
 // MessageSigner is passed to the Encode method to provide a signature
@@ -617,7 +621,7 @@ func parseTaggedFields(invoice *Invoice, fields []byte, net *chaincfg.Params) er
 		// If we don't have enough field data left to read this length,
 		// return error.
 		if len(fields) < index+3+int(dataLength) {
-			return fmt.Errorf("invalid field length")
+			return ErrInvalidFieldLength
 		}
 		base32Data := fields[index+3 : index+3+int(dataLength)]
 


### PR DESCRIPTION
This fixes an issue with bech32 decoding where inserting a specific character in the checksum might generate a valid signature albeit with a different destination node than the original invoice.

This fixes the issue by ensuring that the last tagged field has all the required data instead of silently discarding a partial field, such as a field with only a type element but no length elements.

I tested this behavior in other implementations. c-lightning and lightning-payencode (python) fail to decode invoices with a partial field. Bolt11 (node) accepts it.

This should probably be clarified in BOLT-11 so that the behavior is consistent across implementations.

For context: https://github.com/sipa/bech32/issues/51