### PR TITLE
[anchors] Pluggable commitments

### DIFF
--- a/breacharbiter_test.go
+++ b/breacharbiter_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/lightningnetwork/lnd/lntest/wait"
 	"github.com/lightningnetwork/lnd/lnwallet"
 	"github.com/lightningnetwork/lnd/lnwallet/chainfee"
+	"github.com/lightningnetwork/lnd/lnwallet/commitmenttx"
 	"github.com/lightningnetwork/lnd/lnwire"
 	"github.com/lightningnetwork/lnd/shachain"
 )
@@ -1799,7 +1800,7 @@ func createInitChannels(revocationWindow int) (*lnwallet.LightningChannel, *lnwa
 
 	aliceCommitTx, bobCommitTx, err := lnwallet.CreateCommitmentTxns(
 		channelBal, channelBal, &aliceCfg, &bobCfg, aliceCommitPoint,
-		bobCommitPoint, *fundingTxIn, true,
+		bobCommitPoint, *fundingTxIn, &commitmenttx.Tweakless{},
 	)
 	if err != nil {
 		return nil, nil, nil, err

--- a/contractcourt/chain_watcher.go
+++ b/contractcourt/chain_watcher.go
@@ -17,6 +17,7 @@ import (
 	"github.com/lightningnetwork/lnd/channeldb"
 	"github.com/lightningnetwork/lnd/input"
 	"github.com/lightningnetwork/lnd/lnwallet"
+	"github.com/lightningnetwork/lnd/lnwallet/commitmenttx"
 	"github.com/lightningnetwork/lnd/shachain"
 )
 
@@ -344,7 +345,7 @@ func isOurCommitment(localChanCfg, remoteChanCfg channeldb.ChannelConfig,
 	// Now that we have the commit point, we'll derive the tweaked local
 	// and remote keys for this state. We use our point as only we can
 	// revoke our own commitment.
-	commitKeyRing := lnwallet.DeriveCommitmentKeys(
+	commitKeyRing := commitmenttx.DeriveCommitmentKeys(
 		commitPoint, true, tweakless, &localChanCfg, &remoteChanCfg,
 	)
 

--- a/htlcswitch/test_utils.go
+++ b/htlcswitch/test_utils.go
@@ -34,6 +34,7 @@ import (
 	"github.com/lightningnetwork/lnd/lntypes"
 	"github.com/lightningnetwork/lnd/lnwallet"
 	"github.com/lightningnetwork/lnd/lnwallet/chainfee"
+	"github.com/lightningnetwork/lnd/lnwallet/commitmenttx"
 	"github.com/lightningnetwork/lnd/lnwire"
 	"github.com/lightningnetwork/lnd/shachain"
 	"github.com/lightningnetwork/lnd/ticker"
@@ -262,7 +263,7 @@ func createTestChannel(alicePrivKey, bobPrivKey []byte,
 
 	aliceCommitTx, bobCommitTx, err := lnwallet.CreateCommitmentTxns(
 		aliceAmount, bobAmount, &aliceCfg, &bobCfg, aliceCommitPoint,
-		bobCommitPoint, *fundingTxIn, true,
+		bobCommitPoint, *fundingTxIn, &commitmenttx.Tweakless{},
 	)
 	if err != nil {
 		return nil, nil, nil, err

--- a/lnwallet/channel.go
+++ b/lnwallet/channel.go
@@ -1965,13 +1965,6 @@ func NewBreachRetribution(chanState *channeldb.OpenChannel, stateNum uint64,
 			},
 			HashType: txscript.SigHashAll,
 		}
-
-		// If this is a tweakless commitment, then we can safely blank
-		// out the SingleTweak value as it isn't needed.
-		tweaklessCommit := chanState.ChanType.IsTweakless()
-		if tweaklessCommit {
-			localSignDesc.SingleTweak = nil
-		}
 	}
 
 	// Similarly, if the remote balance exceeds the remote party's dust
@@ -5079,13 +5072,6 @@ func NewUnilateralCloseSummary(chanState *channeldb.OpenChannel, signer input.Si
 				HashType: txscript.SigHashAll,
 			},
 			MaturityDelay: 0,
-		}
-
-		// If this is a tweakless commitment, then we can safely blank
-		// out the SingleTweak value as it isn't needed.
-		tweaklessCommit := chanState.ChanType.IsTweakless()
-		if tweaklessCommit {
-			commitResolution.SelfOutputSignDesc.SingleTweak = nil
 		}
 	}
 

--- a/lnwallet/commitmenttx/commitment_type.go
+++ b/lnwallet/commitmenttx/commitment_type.go
@@ -1,0 +1,77 @@
+package commitmenttx
+
+import (
+	"github.com/btcsuite/btcd/btcec"
+	"github.com/lightningnetwork/lnd/channeldb"
+)
+
+// CommitmentType is an interface that abstracts the various ways of
+// constructing commitment transactions, and can be used to derive keys,
+// scripts and outputs depending on the channel's commitment type.
+type CommitmentType interface {
+	// DeriveCommitmentKeys generates a new commitment key set using the
+	// base points and commitment point. The keys are derived differently
+	// depending whether the commitment transaction is ours or the remote
+	// peer's.
+	DeriveCommitmentKeys(commitPoint *btcec.PublicKey, isOurCommit bool,
+		localChanCfg, remoteChanCfg *channeldb.ChannelConfig) *KeyRing
+}
+
+// CommitmentFromChanType returns the channel's CommitmentType based on the
+// ChannelType.
+func CommitmentFromChanType(t channeldb.ChannelType) CommitmentType {
+	switch t {
+	case channeldb.SingleFunderBit:
+		return &Original{}
+
+	case channeldb.DualFunderBit:
+		return &Original{}
+
+	case channeldb.SingleFunderTweaklessBit:
+		return &Tweakless{}
+	}
+
+	panic("unknown chan type")
+}
+
+// Original is the basic channel type.
+type Original struct{}
+
+// A compile-time assertion to ensure that Original meets the CommitmentType
+// interface.
+var _ CommitmentType = (*Original)(nil)
+
+// DeriveCommitmentKeys generates a new commitment key set using the base
+// points and commitment point for the Original commitment type.
+func (s *Original) DeriveCommitmentKeys(commitPoint *btcec.PublicKey,
+	isOurCommit bool, localChanCfg,
+	remoteChanCfg *channeldb.ChannelConfig) *KeyRing {
+
+	// Return commitment keys with tweaklessCommit=false.
+	return deriveCommitmentKeys(
+		commitPoint, isOurCommit, false, localChanCfg, remoteChanCfg,
+	)
+}
+
+// Tweakless is a commitment type equivalent to Original, except that the
+// remote commitment key won't be tweaked.
+type Tweakless struct {
+	Original
+}
+
+// A compile-time assertion to ensure that Tweakless meets the CommitmentType
+// interface.
+var _ CommitmentType = (*Tweakless)(nil)
+
+// DeriveCommitmentKeys generates a new commitment key set using the base
+// points and commitment point for the Tweakless commitment type.  The returned
+// keys differs from Original in that the remote key won't be tweaked.
+func (s *Tweakless) DeriveCommitmentKeys(commitPoint *btcec.PublicKey,
+	isOurCommit bool, localChanCfg,
+	remoteChanCfg *channeldb.ChannelConfig) *KeyRing {
+
+	// Return commitment keys with tweaklessCommit=true.
+	return deriveCommitmentKeys(
+		commitPoint, isOurCommit, true, localChanCfg, remoteChanCfg,
+	)
+}

--- a/lnwallet/commitmenttx/keyring.go
+++ b/lnwallet/commitmenttx/keyring.go
@@ -1,0 +1,122 @@
+package commitmenttx
+
+import (
+	"github.com/btcsuite/btcd/btcec"
+	"github.com/lightningnetwork/lnd/channeldb"
+	"github.com/lightningnetwork/lnd/input"
+)
+
+// KeyRing holds all derived keys needed to construct commitment and
+// HTLC transactions. The keys are derived differently depending whether the
+// commitment transaction is ours or the remote peer's. Private keys associated
+// with each key may belong to the commitment owner or the "other party" which
+// is referred to in the field comments, regardless of which is local and which
+// is remote.
+type KeyRing struct {
+	// commitPoint is the "per commitment point" used to derive the tweak
+	// for each base point.
+	CommitPoint *btcec.PublicKey
+
+	// LocalCommitKeyTweak is the tweak used to derive the local public key
+	// from the local payment base point or the local private key from the
+	// base point secret. This may be included in a SignDescriptor to
+	// generate signatures for the local payment key.
+	LocalCommitKeyTweak []byte
+
+	// TODO(roasbeef): need delay tweak as well?
+
+	// LocalHtlcKeyTweak is the teak used to derive the local HTLC key from
+	// the local HTLC base point. This value is needed in order to
+	// derive the final key used within the HTLC scripts in the commitment
+	// transaction.
+	LocalHtlcKeyTweak []byte
+
+	// LocalHtlcKey is the key that will be used in the "to self" clause of
+	// any HTLC scripts within the commitment transaction for this key ring
+	// set.
+	LocalHtlcKey *btcec.PublicKey
+
+	// RemoteHtlcKey is the key that will be used in clauses within the
+	// HTLC script that send money to the remote party.
+	RemoteHtlcKey *btcec.PublicKey
+
+	// DelayKey is the commitment transaction owner's key which is included
+	// in HTLC success and timeout transaction scripts.
+	DelayKey *btcec.PublicKey
+
+	// NoDelayKey is the other party's payment key in the commitment tx.
+	// This is the key used to generate the unencumbered output within the
+	// commitment transaction.
+	NoDelayKey *btcec.PublicKey
+
+	// RevocationKey is the key that can be used by the other party to
+	// redeem outputs from a revoked commitment transaction if it were to
+	// be published.
+	RevocationKey *btcec.PublicKey
+}
+
+// DeriveCommitmentKey generates a new commitment key set using the base points
+// and commitment point. The keys are derived differently depending whether the
+// commitment transaction is ours or the remote peer's.
+func DeriveCommitmentKeys(commitPoint *btcec.PublicKey,
+	isOurCommit, tweaklessCommit bool,
+	localChanCfg, remoteChanCfg *channeldb.ChannelConfig) *KeyRing {
+
+	// First, we'll derive all the keys that don't depend on the context of
+	// whose commitment transaction this is.
+	keyRing := &KeyRing{
+		CommitPoint: commitPoint,
+
+		LocalCommitKeyTweak: input.SingleTweakBytes(
+			commitPoint, localChanCfg.PaymentBasePoint.PubKey,
+		),
+		LocalHtlcKeyTweak: input.SingleTweakBytes(
+			commitPoint, localChanCfg.HtlcBasePoint.PubKey,
+		),
+		LocalHtlcKey: input.TweakPubKey(
+			localChanCfg.HtlcBasePoint.PubKey, commitPoint,
+		),
+		RemoteHtlcKey: input.TweakPubKey(
+			remoteChanCfg.HtlcBasePoint.PubKey, commitPoint,
+		),
+	}
+
+	// We'll now compute the delay, no delay, and revocation key based on
+	// the current commitment point. All keys are tweaked each state in
+	// order to ensure the keys from each state are unlinkable. To create
+	// the revocation key, we take the opposite party's revocation base
+	// point and combine that with the current commitment point.
+	var (
+		delayBasePoint      *btcec.PublicKey
+		noDelayBasePoint    *btcec.PublicKey
+		revocationBasePoint *btcec.PublicKey
+	)
+	if isOurCommit {
+		delayBasePoint = localChanCfg.DelayBasePoint.PubKey
+		noDelayBasePoint = remoteChanCfg.PaymentBasePoint.PubKey
+		revocationBasePoint = remoteChanCfg.RevocationBasePoint.PubKey
+	} else {
+		delayBasePoint = remoteChanCfg.DelayBasePoint.PubKey
+		noDelayBasePoint = localChanCfg.PaymentBasePoint.PubKey
+		revocationBasePoint = localChanCfg.RevocationBasePoint.PubKey
+	}
+
+	// With the base points assigned, we can now derive the actual keys
+	// using the base point, and the current commitment tweak.
+	keyRing.DelayKey = input.TweakPubKey(delayBasePoint, commitPoint)
+	keyRing.RevocationKey = input.DeriveRevocationPubkey(
+		revocationBasePoint, commitPoint,
+	)
+
+	// If this commitment should omit the tweak for the remote point, then
+	// we'll use that directly, and ignore the commitPoint tweak.
+	if tweaklessCommit {
+		keyRing.NoDelayKey = noDelayBasePoint
+	} else {
+		keyRing.NoDelayKey = input.TweakPubKey(
+			noDelayBasePoint, commitPoint,
+		)
+	}
+
+	return keyRing
+}

--- a/lnwallet/commitmenttx/keyring.go
+++ b/lnwallet/commitmenttx/keyring.go
@@ -55,10 +55,10 @@ type KeyRing struct {
 	RevocationKey *btcec.PublicKey
 }
 
-// DeriveCommitmentKey generates a new commitment key set using the base points
+// deriveCommitmentKeys generates a new commitment key set using the base points
 // and commitment point. The keys are derived differently depending whether the
 // commitment transaction is ours or the remote peer's.
-func DeriveCommitmentKeys(commitPoint *btcec.PublicKey,
+func deriveCommitmentKeys(commitPoint *btcec.PublicKey,
 	isOurCommit, tweaklessCommit bool,
 	localChanCfg, remoteChanCfg *channeldb.ChannelConfig) *KeyRing {
 

--- a/lnwallet/commitmenttx/keyring.go
+++ b/lnwallet/commitmenttx/keyring.go
@@ -112,6 +112,12 @@ func deriveCommitmentKeys(commitPoint *btcec.PublicKey,
 	// we'll use that directly, and ignore the commitPoint tweak.
 	if tweaklessCommit {
 		keyRing.NoDelayKey = noDelayBasePoint
+
+		// If this is a tweakless remote commitment, then we can safely
+		// blank out the SingleTweak value as it isn't needed.
+		if !isOurCommit {
+			keyRing.LocalCommitKeyTweak = nil
+		}
 	} else {
 		keyRing.NoDelayKey = input.TweakPubKey(
 			noDelayBasePoint, commitPoint,

--- a/lnwallet/test_utils.go
+++ b/lnwallet/test_utils.go
@@ -19,6 +19,7 @@ import (
 	"github.com/lightningnetwork/lnd/input"
 	"github.com/lightningnetwork/lnd/keychain"
 	"github.com/lightningnetwork/lnd/lnwallet/chainfee"
+	"github.com/lightningnetwork/lnd/lnwallet/commitmenttx"
 	"github.com/lightningnetwork/lnd/lnwire"
 	"github.com/lightningnetwork/lnd/shachain"
 )
@@ -206,9 +207,14 @@ func CreateTestChannels(tweaklessCommits bool) (
 	}
 	aliceCommitPoint := input.ComputeCommitmentPoint(aliceFirstRevoke[:])
 
+	var commitType commitmenttx.CommitmentType = &commitmenttx.Original{}
+	if tweaklessCommits {
+		commitType = &commitmenttx.Tweakless{}
+	}
+
 	aliceCommitTx, bobCommitTx, err := CreateCommitmentTxns(
 		channelBal, channelBal, &aliceCfg, &bobCfg, aliceCommitPoint,
-		bobCommitPoint, *fundingTxIn, tweaklessCommits,
+		bobCommitPoint, *fundingTxIn, commitType,
 	)
 	if err != nil {
 		return nil, nil, nil, err

--- a/lnwallet/transactions_test.go
+++ b/lnwallet/transactions_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/lightningnetwork/lnd/input"
 	"github.com/lightningnetwork/lnd/keychain"
 	"github.com/lightningnetwork/lnd/lnwallet/chainfee"
+	"github.com/lightningnetwork/lnd/lnwallet/commitmenttx"
 	"github.com/lightningnetwork/lnd/lnwire"
 	"github.com/lightningnetwork/lnd/shachain"
 )
@@ -435,7 +436,7 @@ func TestCommitmentAndHTLCTransactions(t *testing.T) {
 	// The commitmentPoint is technically hidden in the spec, but we need it to
 	// generate the correct tweak.
 	tweak := input.SingleTweakBytes(tc.commitmentPoint, tc.localPaymentBasePoint)
-	keys := &CommitmentKeyRing{
+	keys := &commitmenttx.KeyRing{
 		CommitPoint:         tc.commitmentPoint,
 		LocalCommitKeyTweak: tweak,
 		LocalHtlcKeyTweak:   tweak,
@@ -1059,7 +1060,7 @@ func testSpendValidation(t *testing.T, tweakless bool) {
 	// This is Alice's commitment transaction, so she must wait a CSV delay
 	// of 5 blocks before sweeping the output, while bob can spend
 	// immediately with either the revocation key, or his regular key.
-	keyRing := &CommitmentKeyRing{
+	keyRing := &commitmenttx.KeyRing{
 		DelayKey:      aliceDelayKey,
 		RevocationKey: revokePubKey,
 		NoDelayKey:    bobPayKey,

--- a/lnwallet/wallet.go
+++ b/lnwallet/wallet.go
@@ -665,16 +665,14 @@ func (l *LightningWallet) handleFundingCancelRequest(req *fundingReserveCancelMs
 func CreateCommitmentTxns(localBalance, remoteBalance btcutil.Amount,
 	ourChanCfg, theirChanCfg *channeldb.ChannelConfig,
 	localCommitPoint, remoteCommitPoint *btcec.PublicKey,
-	fundingTxIn wire.TxIn,
-	tweaklessCommit bool) (*wire.MsgTx, *wire.MsgTx, error) {
+	fundingTxIn wire.TxIn, commitType commitmenttx.CommitmentType) (
+	*wire.MsgTx, *wire.MsgTx, error) {
 
-	localCommitmentKeys := commitmenttx.DeriveCommitmentKeys(
-		localCommitPoint, true, tweaklessCommit, ourChanCfg,
-		theirChanCfg,
+	localCommitmentKeys := commitType.DeriveCommitmentKeys(
+		localCommitPoint, true, ourChanCfg, theirChanCfg,
 	)
-	remoteCommitmentKeys := commitmenttx.DeriveCommitmentKeys(
-		remoteCommitPoint, false, tweaklessCommit, ourChanCfg,
-		theirChanCfg,
+	remoteCommitmentKeys := commitType.DeriveCommitmentKeys(
+		remoteCommitPoint, false, ourChanCfg, theirChanCfg,
 	)
 
 	ourCommitTx, err := CreateCommitTx(fundingTxIn, localCommitmentKeys,
@@ -842,13 +840,15 @@ func (l *LightningWallet) handleContributionMsg(req *addContributionMsg) {
 	// With the funding tx complete, create both commitment transactions.
 	localBalance := pendingReservation.partialState.LocalCommitment.LocalBalance.ToSatoshis()
 	remoteBalance := pendingReservation.partialState.LocalCommitment.RemoteBalance.ToSatoshis()
-	tweaklessCommits := pendingReservation.partialState.ChanType.IsTweakless()
+	commitType := commitmenttx.CommitmentFromChanType(
+		pendingReservation.partialState.ChanType,
+	)
 	ourCommitTx, theirCommitTx, err := CreateCommitmentTxns(
 		localBalance, remoteBalance, ourContribution.ChannelConfig,
 		theirContribution.ChannelConfig,
 		ourContribution.FirstCommitmentPoint,
 		theirContribution.FirstCommitmentPoint, fundingTxIn,
-		tweaklessCommits,
+		commitType,
 	)
 	if err != nil {
 		req.err <- err
@@ -1168,14 +1168,16 @@ func (l *LightningWallet) handleSingleFunderSigs(req *addSingleFunderSigsMsg) {
 	// remote node's commitment transactions.
 	localBalance := pendingReservation.partialState.LocalCommitment.LocalBalance.ToSatoshis()
 	remoteBalance := pendingReservation.partialState.LocalCommitment.RemoteBalance.ToSatoshis()
-	tweaklessCommits := pendingReservation.partialState.ChanType.IsTweakless()
+	commitType := commitmenttx.CommitmentFromChanType(
+		pendingReservation.partialState.ChanType,
+	)
 	ourCommitTx, theirCommitTx, err := CreateCommitmentTxns(
 		localBalance, remoteBalance,
 		pendingReservation.ourContribution.ChannelConfig,
 		pendingReservation.theirContribution.ChannelConfig,
 		pendingReservation.ourContribution.FirstCommitmentPoint,
 		pendingReservation.theirContribution.FirstCommitmentPoint,
-		*fundingTxIn, tweaklessCommits,
+		*fundingTxIn, commitType,
 	)
 	if err != nil {
 		req.err <- err

--- a/lnwallet/wallet.go
+++ b/lnwallet/wallet.go
@@ -23,6 +23,7 @@ import (
 	"github.com/lightningnetwork/lnd/keychain"
 	"github.com/lightningnetwork/lnd/lnwallet/chainfee"
 	"github.com/lightningnetwork/lnd/lnwallet/chanvalidate"
+	"github.com/lightningnetwork/lnd/lnwallet/commitmenttx"
 	"github.com/lightningnetwork/lnd/lnwire"
 	"github.com/lightningnetwork/lnd/shachain"
 )
@@ -667,11 +668,11 @@ func CreateCommitmentTxns(localBalance, remoteBalance btcutil.Amount,
 	fundingTxIn wire.TxIn,
 	tweaklessCommit bool) (*wire.MsgTx, *wire.MsgTx, error) {
 
-	localCommitmentKeys := DeriveCommitmentKeys(
+	localCommitmentKeys := commitmenttx.DeriveCommitmentKeys(
 		localCommitPoint, true, tweaklessCommit, ourChanCfg,
 		theirChanCfg,
 	)
-	remoteCommitmentKeys := DeriveCommitmentKeys(
+	remoteCommitmentKeys := commitmenttx.DeriveCommitmentKeys(
 		remoteCommitPoint, false, tweaklessCommit, ourChanCfg,
 		theirChanCfg,
 	)

--- a/test_utils.go
+++ b/test_utils.go
@@ -23,6 +23,7 @@ import (
 	"github.com/lightningnetwork/lnd/keychain"
 	"github.com/lightningnetwork/lnd/lnwallet"
 	"github.com/lightningnetwork/lnd/lnwallet/chainfee"
+	"github.com/lightningnetwork/lnd/lnwallet/commitmenttx"
 	"github.com/lightningnetwork/lnd/lnwire"
 	"github.com/lightningnetwork/lnd/netann"
 	"github.com/lightningnetwork/lnd/shachain"
@@ -189,7 +190,7 @@ func createTestPeer(notifier chainntnfs.ChainNotifier,
 
 	aliceCommitTx, bobCommitTx, err := lnwallet.CreateCommitmentTxns(
 		channelBal, channelBal, &aliceCfg, &bobCfg, aliceCommitPoint,
-		bobCommitPoint, *fundingTxIn, true,
+		bobCommitPoint, *fundingTxIn, &commitmenttx.Tweakless{},
 	)
 	if err != nil {
 		return nil, nil, nil, nil, err

--- a/watchtower/wtclient/backup_task_internal_test.go
+++ b/watchtower/wtclient/backup_task_internal_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/lightningnetwork/lnd/keychain"
 	"github.com/lightningnetwork/lnd/lnwallet"
 	"github.com/lightningnetwork/lnd/lnwallet/chainfee"
+	"github.com/lightningnetwork/lnd/lnwallet/commitmenttx"
 	"github.com/lightningnetwork/lnd/lnwire"
 	"github.com/lightningnetwork/lnd/watchtower/blob"
 	"github.com/lightningnetwork/lnd/watchtower/wtdb"
@@ -119,7 +120,7 @@ func genTaskTest(
 	breachInfo := &lnwallet.BreachRetribution{
 		RevokedStateNum:   stateNum,
 		BreachTransaction: breachTxn,
-		KeyRing: &lnwallet.CommitmentKeyRing{
+		KeyRing: &commitmenttx.KeyRing{
 			RevocationKey: revPK,
 			DelayKey:      toLocalPK,
 			NoDelayKey:    toRemotePK,

--- a/watchtower/wtclient/client_test.go
+++ b/watchtower/wtclient/client_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/lightningnetwork/lnd/input"
 	"github.com/lightningnetwork/lnd/keychain"
 	"github.com/lightningnetwork/lnd/lnwallet"
+	"github.com/lightningnetwork/lnd/lnwallet/commitmenttx"
 	"github.com/lightningnetwork/lnd/lnwire"
 	"github.com/lightningnetwork/lnd/watchtower/blob"
 	"github.com/lightningnetwork/lnd/watchtower/wtclient"
@@ -289,7 +290,7 @@ func (c *mockChannel) createRemoteCommitTx(t *testing.T) {
 		outputIndex++
 	}
 
-	commitKeyRing := &lnwallet.CommitmentKeyRing{
+	commitKeyRing := &commitmenttx.KeyRing{
 		RevocationKey: c.revPK,
 		NoDelayKey:    c.toLocalPK,
 		DelayKey:      c.toRemotePK,


### PR DESCRIPTION
As a preparation for the anchor output commitment type, we abstract the current (tweak/tweakless) commitment types behind an interface to make it easier to work with in the channel state machine. 