### PR TITLE
[mobile] make Ready signal for custom listeners

### DIFF
--- a/rpcserver.go
+++ b/rpcserver.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 	"io"
 	"math"
-	"net"
 	"net/http"
 	"sort"
 	"strings"
@@ -456,7 +455,7 @@ type rpcServer struct {
 	// listeners is a list of listeners to use when starting the grpc
 	// server. We make it configurable such that the grpc server can listen
 	// on custom interfaces.
-	listeners []net.Listener
+	listeners []*ListenerWithSignal
 
 	// listenerCleanUp are a set of closures functions that will allow this
 	// main RPC server to clean up all the listening socket created for the
@@ -706,8 +705,11 @@ func (r *rpcServer) Start() error {
 	// With all the sub-servers started, we'll spin up the listeners for
 	// the main RPC server itself.
 	for _, lis := range r.listeners {
-		go func(lis net.Listener) {
+		go func(lis *ListenerWithSignal) {
 			rpcsLog.Infof("RPC server listening on %s", lis.Addr())
+
+			// Close the ready chan to indicate we are listening.
+			close(lis.Ready)
 			r.grpcServer.Serve(lis)
 		}(lis)
 	}


### PR DESCRIPTION
This allows the caller to know when lnd is ready to accept RPC calls,
which is important for mobile applications where everything happens in
process.

Fixes #3614