### PR TITLE
[htlcnotifier 3/4]: Add HTLC Notifier

### DIFF
--- a/htlcswitch/htlcnotifier.go
+++ b/htlcswitch/htlcnotifier.go
@@ -289,6 +289,8 @@ type SettleEvent struct {
 
 // NotifyForwardingEvent notifies the HtlcNotifier than a htlc has been
 // forwarded.
+//
+// Note this is part of the htlcNotifier interface.
 func (h *HtlcNotifier) NotifyForwardingEvent(key HtlcKey, info HtlcInfo,
 	eventType HtlcEventType) {
 
@@ -309,6 +311,8 @@ func (h *HtlcNotifier) NotifyForwardingEvent(key HtlcKey, info HtlcInfo,
 
 // NotifyLinkFailEvent notifies that a htlc has failed on our incoming
 // or outgoing link.
+//
+// Note this is part of the htlcNotifier interface.
 func (h *HtlcNotifier) NotifyLinkFailEvent(key HtlcKey, info HtlcInfo,
 	eventType HtlcEventType, linkErr *LinkError, incoming bool) {
 
@@ -331,6 +335,8 @@ func (h *HtlcNotifier) NotifyLinkFailEvent(key HtlcKey, info HtlcInfo,
 
 // NotifyForwardingFailEvent notifies the HtlcNotifier that a htlc we
 // forwarded has failed down the line.
+//
+// Note this is part of the htlcNotifier interface.
 func (h *HtlcNotifier) NotifyForwardingFailEvent(key HtlcKey,
 	eventType HtlcEventType) {
 
@@ -350,6 +356,8 @@ func (h *HtlcNotifier) NotifyForwardingFailEvent(key HtlcKey,
 
 // NotifySettleEvent notifies the HtlcNotifier that a htlc that we committed
 // to as part of a forward or a receive to our node has been settled.
+//
+// Note this is part of the htlcNotifier interface.
 func (h *HtlcNotifier) NotifySettleEvent(key HtlcKey, eventType HtlcEventType) {
 	event := &SettleEvent{
 		HtlcKey:       key,

--- a/htlcswitch/htlcnotifier.go
+++ b/htlcswitch/htlcnotifier.go
@@ -1,0 +1,365 @@
+package htlcswitch
+
+import (
+	"fmt"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/lightningnetwork/lnd/channeldb"
+	"github.com/lightningnetwork/lnd/htlcswitch/hop"
+	"github.com/lightningnetwork/lnd/lnwire"
+	"github.com/lightningnetwork/lnd/subscribe"
+)
+
+// HtlcNotifier notifies clients of htlc forwards, failures and settles for
+// htlcs that the switch handles. It takes subscriptions for its events and
+// notifies them when htlc events occur. These are served on a best-effort
+// basis; events are not persisted, delivery is not guaranteed (in the event
+// of a crash in the switch, forward events may be lost) and some events may
+// be replayed upon restart. Events consumed from this package should be
+// de-duplicated by the htlc's unique combination of incoming+outgoing circuit
+// and not relied upon for critical operations.
+//
+// The htlc notifier sends the following kinds of events:
+// Forwarding Event:
+// - Represents a htlc which is forwarded onward from our node.
+// - Present for htlc forwards through our node and local sends.
+//
+// Link Failure Event:
+// - Indicates that a htlc has failed on our incoming or outgoing link,
+//   with an incoming boolean which indicates where the failure occurred.
+// - Incoming link failures are present for failed attempts to pay one of
+//   our invoices (insufficient amount or mpp timeout, for example) and for
+//   forwards that we cannot decode to forward onwards.
+// - Outgoing link failures are present for forwards or local payments that
+//   do not meet our outgoing link's policy (insufficient fees, for example)
+//   and when we fail to forward the payment on (insufficient outgoing
+//   capacity, or an unknown outgoing link).
+//
+// Forwarding Failure Event:
+// - Forwarding failures indicate that a htlc we forwarded has failed at
+//   another node down the route.
+// - Present for local sends and htlc forwards which fail after they left
+//   our node.
+//
+// Settle event:
+// - Settle events are present when a htlc which we added is settled through
+//   the release of a preimage.
+// - Present for local receives, and successful local sends or forwards.
+//
+// Each htlc is identified by its incoming and outgoing circuit key. Htlcs,
+// and their subsequent settles or fails, can be identified by the combination
+// of incoming and outgoing circuits. Note that receives to our node will
+// have a zero outgoing circuit key because the htlc terminates at our
+// node, and sends from our node will have a zero incoming circuit key because
+// the send originates at our node.
+type HtlcNotifier struct {
+	started sync.Once
+	stopped sync.Once
+
+	// now returns the current time, it is set in the htlcnotifier to allow
+	// for timestamp mocking in tests.
+	now func() time.Time
+
+	ntfnServer *subscribe.Server
+}
+
+// NewHtlcNotifier creates a new HtlcNotifier which gets htlc forwarded,
+// failed and settled events from links our node has established with peers
+// and sends notifications to subscribing clients.
+func NewHtlcNotifier(now func() time.Time) *HtlcNotifier {
+	return &HtlcNotifier{
+		now:        now,
+		ntfnServer: subscribe.NewServer(),
+	}
+}
+
+// Start starts the HtlcNotifier and all goroutines it needs to consume
+// events and provide subscriptions to clients.
+func (h *HtlcNotifier) Start() error {
+	var err error
+	h.started.Do(func() {
+		log.Trace("HtlcNotifier starting")
+		err = h.ntfnServer.Start()
+	})
+	return err
+}
+
+// Stop signals the notifier for a graceful shutdown.
+func (h *HtlcNotifier) Stop() {
+	h.stopped.Do(func() {
+		if err := h.ntfnServer.Stop(); err != nil {
+			log.Warnf("error stopping htlc notifier: %v", err)
+		}
+	})
+}
+
+// SubscribeHtlcEvents returns a subscribe.Client that will receive updates
+// any time the server is made aware of a new event.
+func (h *HtlcNotifier) SubscribeHtlcEvents() (*subscribe.Client, error) {
+	return h.ntfnServer.Subscribe()
+}
+
+// HtlcKey uniquely identifies the htlc.
+type HtlcKey struct {
+	// IncomingCircuit is the channel an htlc id of the incoming htlc.
+	IncomingCircuit channeldb.CircuitKey
+
+	// OutgoingCircuit is the channel and htlc id of the outgoing htlc.
+	OutgoingCircuit channeldb.CircuitKey
+}
+
+// String returns a string representation of a htlc key.
+func (k HtlcKey) String() string {
+	switch {
+	case k.IncomingCircuit.ChanID == hop.Source:
+		return k.OutgoingCircuit.String()
+
+	case k.OutgoingCircuit.ChanID == hop.Exit:
+		return k.IncomingCircuit.String()
+
+	default:
+		return fmt.Sprintf("%v -> %v", k.IncomingCircuit,
+			k.OutgoingCircuit)
+	}
+}
+
+// HtlcInfo provides the details of a htlc that our node has processed. For
+// forwards, incoming and outgoing values are set, whereas sends and receives
+// will only have outgoing or incoming details set.
+type HtlcInfo struct {
+	// IncomingTimelock is the time lock of the htlc on our incoming
+	// channel.
+	IncomingTimeLock uint32
+
+	// OutgoingTimelock is the time lock the htlc on our outgoing channel.
+	OutgoingTimeLock uint32
+
+	// IncomingAmt is the amount of the htlc on our incoming channel.
+	IncomingAmt lnwire.MilliSatoshi
+
+	// OutgoingAmt is the amount of the htlc on our outgoing channel.
+	OutgoingAmt lnwire.MilliSatoshi
+}
+
+// String returns a string representation of a htlc.
+func (h HtlcInfo) String() string {
+	var details []string
+
+	// If the incoming information is not zero, as is the case for a send,
+	// we include the incoming amount and timelock.
+	if h.IncomingAmt != 0 || h.IncomingTimeLock != 0 {
+		str := fmt.Sprintf("incoming amount: %v, "+
+			"incoming timelock: %v", h.IncomingAmt,
+			h.IncomingTimeLock)
+
+		details = append(details, str)
+	}
+
+	// If the outgoing information is not zero, as is the case for a
+	// receive, we include the outgoing amount and timelock.
+	if h.OutgoingAmt != 0 || h.OutgoingTimeLock != 0 {
+		str := fmt.Sprintf("outgoing amount: %v, "+
+			"outgoing timelock: %v", h.OutgoingAmt,
+			h.OutgoingTimeLock)
+
+		details = append(details, str)
+	}
+
+	return strings.Join(details, ", ")
+}
+
+// HtlcEventType represents the type of event that a htlc was part of.
+type HtlcEventType int
+
+const (
+	// HtlcEventTypeSend represents a htlc that was part of a send from
+	// our node.
+	HtlcEventTypeSend HtlcEventType = iota
+
+	// HtlcEventTypeReceive represents a htlc that was part of a receive
+	// to our node.
+	HtlcEventTypeReceive
+
+	// HtlcEventTypeForward represents a htlc that was forwarded through
+	// our node.
+	HtlcEventTypeForward
+)
+
+// String returns a string representation of a htlc event type.
+func (h HtlcEventType) String() string {
+	switch h {
+	case HtlcEventTypeSend:
+		return "send"
+
+	case HtlcEventTypeReceive:
+		return "receive"
+
+	case HtlcEventTypeForward:
+		return "forward"
+
+	default:
+		return "unknown"
+	}
+}
+
+// ForwardingEvent represents a htlc that was forwarded onwards from our node.
+// Sends which originate from our node will report forward events with zero
+// incoming circuits in their htlc key.
+type ForwardingEvent struct {
+	// HtlcKey uniquely identifies the htlc, and can be used to match the
+	// forwarding event with subsequent settle/fail events.
+	HtlcKey
+
+	// HtlcInfo contains details about the htlc.
+	HtlcInfo
+
+	// HtlcEventType classifies the event as part of a local send or
+	// receive, or as part of a forward.
+	HtlcEventType
+
+	// Timestamp is the time when this htlc was forwarded.
+	Timestamp time.Time
+}
+
+// LinkFailEvent describes a htlc that failed on our incoming or outgoing
+// link. The incoming bool is true for failures on incoming links, and false
+// for failures on outgoing links. The failure reason is provided by a lnwire
+// failure message which is enriched with a failure detail in the cases where
+// the wire failure message does not contain full information about the
+// failure.
+type LinkFailEvent struct {
+	// HtlcKey uniquely identifies the htlc.
+	HtlcKey
+
+	// HtlcInfo contains details about the htlc.
+	HtlcInfo
+
+	// HtlcEventType classifies the event as part of a local send or
+	// receive, or as part of a forward.
+	HtlcEventType
+
+	// LinkError is the reason that we failed the htlc.
+	LinkError *LinkError
+
+	// Incoming is true if the htlc was failed on an incoming link.
+	// If it failed on the outgoing link, it is false.
+	Incoming bool
+
+	// Timestamp is the time when the link failure occurred.
+	Timestamp time.Time
+}
+
+// ForwardingFailEvent represents a htlc failure which occurred down the line
+// after we forwarded a htlc onwards. An error is not included in this event
+// because errors returned down the route are encrypted. HtlcInfo is not
+// reliably available for forwarding failures, so it is omitted. These events
+// should be matched with their corresponding forward event to obtain this
+// information.
+type ForwardingFailEvent struct {
+	// HtlcKey uniquely identifies the htlc, and can be used to match the
+	// htlc with its corresponding forwarding event.
+	HtlcKey
+
+	// HtlcEventType classifies the event as part of a local send or
+	// receive, or as part of a forward.
+	HtlcEventType
+
+	// Timestamp is the time when the forwarding failure was received.
+	Timestamp time.Time
+}
+
+// SettleEvent represents a htlc that was settled. HtlcInfo is not reliably
+// available for forwarding failures, so it is omitted. These events should
+// be matched with corresponding forward events or invoices (for receives)
+// to obtain additional information about the htlc.
+type SettleEvent struct {
+	// HtlcKey uniquely identifies the htlc, and can be used to match
+	// forwards with their corresponding forwarding event.
+	HtlcKey
+
+	// HtlcEventType classifies the event as part of a local send or
+	// receive, or as part of a forward.
+	HtlcEventType
+
+	// Timestamp is the time when this htlc was settled.
+	Timestamp time.Time
+}
+
+// NotifyForwardingEvent notifies the HtlcNotifier than a htlc has been
+// forwarded.
+func (h *HtlcNotifier) NotifyForwardingEvent(key HtlcKey, info HtlcInfo,
+	eventType HtlcEventType) {
+
+	event := &ForwardingEvent{
+		HtlcKey:       key,
+		HtlcInfo:      info,
+		HtlcEventType: eventType,
+		Timestamp:     h.now(),
+	}
+
+	log.Tracef("Notifying forward event: %v over %v, %v", eventType, key,
+		info)
+
+	if err := h.ntfnServer.SendUpdate(event); err != nil {
+		log.Warnf("Unable to send forwarding event: %v", err)
+	}
+}
+
+// NotifyLinkFailEvent notifies that a htlc has failed on our incoming
+// or outgoing link.
+func (h *HtlcNotifier) NotifyLinkFailEvent(key HtlcKey, info HtlcInfo,
+	eventType HtlcEventType, linkErr *LinkError, incoming bool) {
+
+	event := &LinkFailEvent{
+		HtlcKey:       key,
+		HtlcInfo:      info,
+		HtlcEventType: eventType,
+		LinkError:     linkErr,
+		Incoming:      incoming,
+		Timestamp:     h.now(),
+	}
+
+	log.Tracef("Notifying link failure event: %v over %v, %v", eventType,
+		key, info)
+
+	if err := h.ntfnServer.SendUpdate(event); err != nil {
+		log.Warnf("Unable to send link fail event: %v", err)
+	}
+}
+
+// NotifyForwardingFailEvent notifies the HtlcNotifier that a htlc we
+// forwarded has failed down the line.
+func (h *HtlcNotifier) NotifyForwardingFailEvent(key HtlcKey,
+	eventType HtlcEventType) {
+
+	event := &ForwardingFailEvent{
+		HtlcKey:       key,
+		HtlcEventType: eventType,
+		Timestamp:     h.now(),
+	}
+
+	log.Tracef("Notifying forwarding failure event: %v over %v", eventType,
+		key)
+
+	if err := h.ntfnServer.SendUpdate(event); err != nil {
+		log.Warnf("Unable to send forwarding fail event: %v", err)
+	}
+}
+
+// NotifySettleEvent notifies the HtlcNotifier that a htlc that we committed
+// to as part of a forward or a receive to our node has been settled.
+func (h *HtlcNotifier) NotifySettleEvent(key HtlcKey, eventType HtlcEventType) {
+	event := &SettleEvent{
+		HtlcKey:       key,
+		HtlcEventType: eventType,
+		Timestamp:     h.now(),
+	}
+
+	log.Tracef("Notifying settle event: %v over %v", eventType, key)
+
+	if err := h.ntfnServer.SendUpdate(event); err != nil {
+		log.Warnf("Unable to send settle event: %v", err)
+	}
+}

--- a/htlcswitch/interfaces.go
+++ b/htlcswitch/interfaces.go
@@ -180,3 +180,29 @@ type TowerClient interface {
 	// isTweakless should be true.
 	BackupState(*lnwire.ChannelID, *lnwallet.BreachRetribution, bool) error
 }
+
+// htlcNotifier is an interface which represents the input side of the
+// HtlcNotifier which htlc events are piped through. This interface is intended
+// to allow for mocking of the htlcNotifier in tests, so is unexported because
+// it is not needed outside of the htlcSwitch package.
+type htlcNotifier interface {
+	// NotifyForwardingEvent notifies the HtlcNotifier than a htlc has been
+	// forwarded.
+	NotifyForwardingEvent(key HtlcKey, info HtlcInfo,
+		eventType HtlcEventType)
+
+	// NotifyIncomingLinkFailEvent notifies that a htlc has failed on our
+	// incoming link. It takes an isReceive bool to differentiate between
+	// our node's receives and forwards.
+	NotifyLinkFailEvent(key HtlcKey, info HtlcInfo,
+		eventType HtlcEventType, linkErr *LinkError, incoming bool)
+
+	// NotifyForwardingFailEvent notifies the HtlcNotifier that a htlc we
+	// forwarded has failed down the line.
+	NotifyForwardingFailEvent(key HtlcKey, eventType HtlcEventType)
+
+	// NotifySettleEvent notifies the HtlcNotifier that a htlc that we
+	// committed to as part of a forward or a receive to our node has been
+	// settled.
+	NotifySettleEvent(key HtlcKey, eventType HtlcEventType)
+}

--- a/htlcswitch/link.go
+++ b/htlcswitch/link.go
@@ -1224,8 +1224,7 @@ func (l *channelLink) processHtlcResolution(resolution invoices.HtlcResolution,
 		failure := getResolutionFailure(res, htlc.pd.Amount)
 
 		l.sendHTLCError(
-			htlc.pd.HtlcIndex, failure,
-			htlc.obfuscator, htlc.pd.SourceRef,
+			htlc.pd, failure, htlc.obfuscator, true,
 		)
 		return nil
 
@@ -2696,9 +2695,7 @@ func (l *channelLink) processRemoteAdds(fwdPkg *channeldb.FwdPkg,
 			// later date
 			failure := lnwire.NewInvalidOnionPayload(failedType, 0)
 			l.sendHTLCError(
-				pd.HtlcIndex,
-				NewLinkError(failure),
-				obfuscator, pd.SourceRef,
+				pd, NewLinkError(failure), obfuscator, false,
 			)
 
 			l.log.Errorf("unable to decode forwarding "+
@@ -2811,10 +2808,7 @@ func (l *channelLink) processRemoteAdds(fwdPkg *channeldb.FwdPkg,
 				)
 
 				l.sendHTLCError(
-					pd.HtlcIndex,
-					NewLinkError(failure),
-					obfuscator,
-					pd.SourceRef,
+					pd, NewLinkError(failure), obfuscator, false,
 				)
 				continue
 			}
@@ -2900,7 +2894,7 @@ func (l *channelLink) processExitHop(pd *lnwallet.PaymentDescriptor,
 		failure := NewLinkError(
 			lnwire.NewFinalIncorrectHtlcAmount(pd.Amount),
 		)
-		l.sendHTLCError(pd.HtlcIndex, failure, obfuscator, pd.SourceRef)
+		l.sendHTLCError(pd, failure, obfuscator, true)
 
 		return nil
 	}
@@ -2915,7 +2909,7 @@ func (l *channelLink) processExitHop(pd *lnwallet.PaymentDescriptor,
 		failure := NewLinkError(
 			lnwire.NewFinalIncorrectCltvExpiry(pd.Timeout),
 		)
-		l.sendHTLCError(pd.HtlcIndex, failure, obfuscator, pd.SourceRef)
+		l.sendHTLCError(pd, failure, obfuscator, true)
 
 		return nil
 	}
@@ -3031,8 +3025,8 @@ func (l *channelLink) handleBatchFwdErrs(errChan chan error) {
 
 // sendHTLCError functions cancels HTLC and send cancel message back to the
 // peer from which HTLC was received.
-func (l *channelLink) sendHTLCError(htlcIndex uint64, failure *LinkError,
-	e hop.ErrorEncrypter, sourceRef *channeldb.AddRef) {
+func (l *channelLink) sendHTLCError(pd *lnwallet.PaymentDescriptor,
+	failure *LinkError, e hop.ErrorEncrypter, isReceive bool) {
 
 	reason, err := e.EncryptFirstHop(failure.WireMessage())
 	if err != nil {
@@ -3040,7 +3034,7 @@ func (l *channelLink) sendHTLCError(htlcIndex uint64, failure *LinkError,
 		return
 	}
 
-	err = l.channel.FailHTLC(htlcIndex, reason, sourceRef, nil, nil)
+	err = l.channel.FailHTLC(pd.HtlcIndex, reason, pd.SourceRef, nil, nil)
 	if err != nil {
 		l.log.Errorf("unable cancel htlc: %v", err)
 		return
@@ -3048,9 +3042,35 @@ func (l *channelLink) sendHTLCError(htlcIndex uint64, failure *LinkError,
 
 	l.cfg.Peer.SendMessage(false, &lnwire.UpdateFailHTLC{
 		ChanID: l.ChanID(),
-		ID:     htlcIndex,
+		ID:     pd.HtlcIndex,
 		Reason: reason,
 	})
+
+	// Notify a link failure on our incoming link. Outgoing htlc information
+	// is not available at this point, because we have not decrypted the
+	// onion, so it is excluded.
+	var eventType HtlcEventType
+	if isReceive {
+		eventType = HtlcEventTypeReceive
+	} else {
+		eventType = HtlcEventTypeForward
+	}
+
+	l.cfg.HtlcNotifier.NotifyLinkFailEvent(
+		HtlcKey{
+			IncomingCircuit: channeldb.CircuitKey{
+				ChanID: l.ShortChanID(),
+				HtlcID: pd.HtlcIndex,
+			},
+		},
+		HtlcInfo{
+			IncomingTimeLock: pd.Timeout,
+			IncomingAmt:      pd.Amount,
+		},
+		eventType,
+		failure,
+		true,
+	)
 }
 
 // sendMalformedHTLCError helper function which sends the malformed HTLC update

--- a/htlcswitch/link.go
+++ b/htlcswitch/link.go
@@ -272,6 +272,10 @@ type ChannelLinkConfig struct {
 	// NotifyInactiveChannel allows the switch to tell the ChannelNotifier
 	// when channels become inactive.
 	NotifyInactiveChannel func(wire.OutPoint)
+
+	// HtlcNotifier is an instance of a htlcNotifier which we will pipe htlc
+	// events through.
+	HtlcNotifier htlcNotifier
 }
 
 // channelLink is the service which drives a channel's commitment update

--- a/htlcswitch/link_test.go
+++ b/htlcswitch/link_test.go
@@ -1750,6 +1750,7 @@ func newSingleLinkTestHarness(chanAmt, chanReserve btcutil.Amount) (
 		MaxFeeAllocation:      DefaultMaxLinkFeeAllocation,
 		NotifyActiveChannel:   func(wire.OutPoint) {},
 		NotifyInactiveChannel: func(wire.OutPoint) {},
+		HtlcNotifier:          aliceSwitch.cfg.HtlcNotifier,
 	}
 
 	aliceLink := NewChannelLink(aliceCfg, aliceLc.channel)
@@ -4313,6 +4314,7 @@ func (h *persistentLinkHarness) restartLink(
 		MaxFeeAllocation:      DefaultMaxLinkFeeAllocation,
 		NotifyActiveChannel:   func(wire.OutPoint) {},
 		NotifyInactiveChannel: func(wire.OutPoint) {},
+		HtlcNotifier:          aliceSwitch.cfg.HtlcNotifier,
 	}
 
 	aliceLink := NewChannelLink(aliceCfg, aliceChannel)
@@ -5523,6 +5525,7 @@ func TestCheckHtlcForward(t *testing.T) {
 			},
 			FetchLastChannelUpdate: fetchLastChannelUpdate,
 			MaxOutgoingCltvExpiry:  DefaultMaxOutgoingCltvExpiry,
+			HtlcNotifier:           &mockHTLCNotifier{},
 		},
 		log:           log,
 		channel:       testChannel.channel,

--- a/htlcswitch/mock.go
+++ b/htlcswitch/mock.go
@@ -176,6 +176,7 @@ func initSwitchWithDB(startingHeight uint32, db *channeldb.DB) (*Switch, error) 
 		FwdEventTicker: ticker.NewForce(DefaultFwdEventInterval),
 		LogEventTicker: ticker.NewForce(DefaultLogInterval),
 		AckEventTicker: ticker.NewForce(DefaultAckInterval),
+		HtlcNotifier:   &mockHTLCNotifier{},
 	}
 
 	return New(cfg, startingHeight)
@@ -1008,4 +1009,23 @@ func (m *mockOnionErrorDecryptor) DecryptError(encryptedData []byte) (
 		SenderIdx: m.sourceIdx,
 		Message:   m.message,
 	}, m.err
+}
+
+var _ htlcNotifier = (*mockHTLCNotifier)(nil)
+
+type mockHTLCNotifier struct{}
+
+func (h *mockHTLCNotifier) NotifyForwardingEvent(key HtlcKey, info HtlcInfo,
+	eventType HtlcEventType) {
+}
+
+func (h *mockHTLCNotifier) NotifyLinkFailEvent(key HtlcKey, info HtlcInfo,
+	eventType HtlcEventType, linkErr *LinkError, incoming bool) {
+}
+
+func (h *mockHTLCNotifier) NotifyForwardingFailEvent(key HtlcKey,
+	eventType HtlcEventType) {
+}
+
+func (h *mockHTLCNotifier) NotifySettleEvent(key HtlcKey, eventType HtlcEventType) {
 }

--- a/htlcswitch/switch.go
+++ b/htlcswitch/switch.go
@@ -1256,12 +1256,21 @@ func (s *Switch) failAddPacket(packet *htlcPacket, failure *LinkError) error {
 
 	log.Error(failure.Error())
 
+	// Create a failure packet for this htlc. The the full set of
+	// information about the htlc failure is included so that they can
+	// be included in link failure notifications.
 	failPkt := &htlcPacket{
-		sourceRef:      packet.sourceRef,
-		incomingChanID: packet.incomingChanID,
-		incomingHTLCID: packet.incomingHTLCID,
-		circuit:        packet.circuit,
-		linkFailure:    failure,
+		sourceRef:       packet.sourceRef,
+		incomingChanID:  packet.incomingChanID,
+		incomingHTLCID:  packet.incomingHTLCID,
+		outgoingChanID:  packet.outgoingChanID,
+		outgoingHTLCID:  packet.outgoingHTLCID,
+		incomingAmount:  packet.incomingAmount,
+		amount:          packet.amount,
+		incomingTimeout: packet.incomingTimeout,
+		outgoingTimeout: packet.outgoingTimeout,
+		circuit:         packet.circuit,
+		linkFailure:     failure,
 		htlc: &lnwire.UpdateFailHTLC{
 			Reason: reason,
 		},

--- a/htlcswitch/switch.go
+++ b/htlcswitch/switch.go
@@ -898,6 +898,18 @@ func (s *Switch) handleLocalResponse(pkt *htlcPacket) {
 			pkt.inKey(), err)
 		return
 	}
+
+	// Finally, notify on the htlc failure or success that has been handled.
+	key := newHtlcKey(pkt)
+	eventType := getEventType(pkt)
+
+	switch pkt.htlc.(type) {
+	case *lnwire.UpdateFulfillHTLC:
+		s.cfg.HtlcNotifier.NotifySettleEvent(key, eventType)
+
+	case *lnwire.UpdateFailHTLC:
+		s.cfg.HtlcNotifier.NotifyForwardingFailEvent(key, eventType)
+	}
 }
 
 // extractResult uses the given deobfuscator to extract the payment result from

--- a/htlcswitch/switch.go
+++ b/htlcswitch/switch.go
@@ -770,6 +770,20 @@ func (s *Switch) handleLocalDispatch(pkt *htlcPacket) error {
 	if htlc, ok := pkt.htlc.(*lnwire.UpdateAddHTLC); ok {
 		link, err := s.handleLocalAddHTLC(pkt, htlc)
 		if err != nil {
+			// Notify the htlc notifier of a link failure on our
+			// outgoing link. Incoming timelock/amount values are
+			// not set because they are not present for local sends.
+			s.cfg.HtlcNotifier.NotifyLinkFailEvent(
+				newHtlcKey(pkt),
+				HtlcInfo{
+					OutgoingTimeLock: htlc.Expiry,
+					OutgoingAmt:      htlc.Amount,
+				},
+				HtlcEventTypeSend,
+				err,
+				false,
+			)
+
 			return err
 		}
 

--- a/htlcswitch/switch.go
+++ b/htlcswitch/switch.go
@@ -150,6 +150,10 @@ type Config struct {
 	// the switch when a new block has arrived.
 	Notifier chainntnfs.ChainNotifier
 
+	// HtlcNotifier is an instance of a htlcNotifier which we will pipe htlc
+	// events through.
+	HtlcNotifier htlcNotifier
+
 	// FwdEventTicker is a signal that instructs the htlcswitch to flush any
 	// pending forwarding events.
 	FwdEventTicker ticker.Ticker

--- a/htlcswitch/test_utils.go
+++ b/htlcswitch/test_utils.go
@@ -1139,6 +1139,7 @@ func (h *hopNetwork) createChannelLink(server, peer *mockServer,
 			MaxFeeAllocation:        DefaultMaxLinkFeeAllocation,
 			NotifyActiveChannel:     func(wire.OutPoint) {},
 			NotifyInactiveChannel:   func(wire.OutPoint) {},
+			HtlcNotifier:            server.htlcSwitch.cfg.HtlcNotifier,
 		},
 		channel,
 	)

--- a/htlcswitch/test_utils.go
+++ b/htlcswitch/test_utils.go
@@ -966,9 +966,11 @@ func createClusterChannels(aliceToBob, bobToCarol btcutil.Amount) (
 // alice                   first bob    second bob              carol
 // channel link	    	  channel link   channel link		channel link
 //
+// This function takes server options which can be used to apply custom
+// settings to alice, bob and carol.
 func newThreeHopNetwork(t testing.TB, aliceChannel, firstBobChannel,
 	secondBobChannel, carolChannel *lnwallet.LightningChannel,
-	startingHeight uint32) *threeHopNetwork {
+	startingHeight uint32, opts ...serverOption) *threeHopNetwork {
 
 	aliceDb := aliceChannel.State().Db
 	bobDb := firstBobChannel.State().Db
@@ -994,6 +996,12 @@ func newThreeHopNetwork(t testing.TB, aliceChannel, firstBobChannel,
 	)
 	if err != nil {
 		t.Fatalf("unable to create carol server: %v", err)
+	}
+
+	// Apply all additional functional options to the servers before
+	// creating any links.
+	for _, option := range opts {
+		option(aliceServer, bobServer, carolServer)
 	}
 
 	// Create mock decoder instead of sphinx one in order to mock the route
@@ -1042,6 +1050,34 @@ func newThreeHopNetwork(t testing.TB, aliceChannel, firstBobChannel,
 		carolOnionDecoder: carolDecoder,
 
 		hopNetwork: *hopNetwork,
+	}
+}
+
+// serverOption is a function which alters the three servers created for
+// a three hop network to allow custom settings on each server.
+type serverOption func(aliceServer, bobServer, carolServer *mockServer)
+
+// serverOptionWithHtlcNotifier is a functional option for the creation of
+// three hop network servers which allows setting of htlc notifiers.
+// Note that these notifiers should be started and stopped by the calling
+// function.
+func serverOptionWithHtlcNotifier(alice, bob,
+	carol *HtlcNotifier) serverOption {
+
+	return func(aliceServer, bobServer, carolServer *mockServer) {
+		aliceServer.htlcSwitch.cfg.HtlcNotifier = alice
+		bobServer.htlcSwitch.cfg.HtlcNotifier = bob
+		carolServer.htlcSwitch.cfg.HtlcNotifier = carol
+	}
+}
+
+// serverOptionRejectHtlc is the functional option for setting the reject
+// htlc config option in each server's switch.
+func serverOptionRejectHtlc(alice, bob, carol bool) serverOption {
+	return func(aliceServer, bobServer, carolServer *mockServer) {
+		aliceServer.htlcSwitch.cfg.RejectHTLC = alice
+		bobServer.htlcSwitch.cfg.RejectHTLC = bob
+		carolServer.htlcSwitch.cfg.RejectHTLC = carol
 	}
 }
 

--- a/peer.go
+++ b/peer.go
@@ -636,6 +636,7 @@ func (p *peer) addLink(chanPoint *wire.OutPoint,
 		MaxFeeAllocation:        cfg.MaxChannelFeeAllocation,
 		NotifyActiveChannel:     p.server.channelNotifier.NotifyActiveChannelEvent,
 		NotifyInactiveChannel:   p.server.channelNotifier.NotifyInactiveChannelEvent,
+		HtlcNotifier:            p.server.htlcNotifier,
 	}
 
 	link := htlcswitch.NewChannelLink(linkCfg, lnChan)


### PR DESCRIPTION
This PR is change 3 of 4 proposed to add a htlc event notifier to lnd.
1: #3843
2: #3844
3: This PR
4: #3848 

Since the PR is dependent on the preceding PRs, it has been rebased on #3844.
**Only the last 9 commits are eligible for review.**

--------------

This PR adds a `htlcnotifier` to the `htlcswitch` which provides a stream of notifications with the following types of events:
- Forwards: when we forward a HTLC or initiate a send from our node
- Forward Failures: when a HTLC we forwarded fails down the line
- Settles: when a HTLC we forwarded is settled, or we receive a payment
- Link Failures: when we fail a HTLC on our incoming or outgoing link