### PR TITLE
republish force and coop closes on startup

### DIFF
--- a/chancloser.go
+++ b/chancloser.go
@@ -439,7 +439,7 @@ func (c *channelCloser) ProcessCloseMsg(msg lnwire.Message) ([]lnwire.Message, b
 		// Before publishing the closing tx, we persist it to the
 		// database, such that it can be republished if something goes
 		// wrong.
-		err = c.cfg.channel.MarkCommitmentBroadcasted(closeTx)
+		err = c.cfg.channel.MarkCoopBroadcasted(closeTx)
 		if err != nil {
 			return nil, false, err
 		}
@@ -487,7 +487,6 @@ func (c *channelCloser) ProcessCloseMsg(msg lnwire.Message) ([]lnwire.Message, b
 // transaction for a channel based on the prior fee negotiations and our
 // current compromise fee.
 func (c *channelCloser) proposeCloseSigned(fee btcutil.Amount) (*lnwire.ClosingSigned, error) {
-
 	rawSig, _, _, err := c.cfg.channel.CreateCloseProposal(
 		fee, c.localDeliveryScript, c.remoteDeliveryScript,
 	)

--- a/contractcourt/chain_arbitrator_test.go
+++ b/contractcourt/chain_arbitrator_test.go
@@ -12,10 +12,10 @@ import (
 	"github.com/lightningnetwork/lnd/lnwallet"
 )
 
-// TestChainArbitratorRepulishCommitment testst that the chain arbitrator will
-// republish closing transactions for channels marked CommitementBroadcast in
-// the database at startup.
-func TestChainArbitratorRepublishCommitment(t *testing.T) {
+// TestChainArbitratorRepulishCloses tests that the chain arbitrator will
+// republish closing transactions for channels marked CommitementBroadcast or
+// CoopBroadcast in the database at startup.
+func TestChainArbitratorRepublishCloses(t *testing.T) {
 	t.Parallel()
 
 	tempPath, err := ioutil.TempDir("", "testdb")
@@ -65,17 +65,22 @@ func TestChainArbitratorRepublishCommitment(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
+
+		err = channels[i].MarkCoopBroadcasted(closeTx)
+		if err != nil {
+			t.Fatal(err)
+		}
 	}
 
 	// We keep track of the transactions published by the ChainArbitrator
 	// at startup.
-	published := make(map[chainhash.Hash]struct{})
+	published := make(map[chainhash.Hash]int)
 
 	chainArbCfg := ChainArbitratorConfig{
 		ChainIO:  &mockChainIO{},
 		Notifier: &mockNotifier{},
 		PublishTx: func(tx *wire.MsgTx) error {
-			published[tx.TxHash()] = struct{}{}
+			published[tx.TxHash()]++
 			return nil
 		},
 	}
@@ -103,9 +108,14 @@ func TestChainArbitratorRepublishCommitment(t *testing.T) {
 		closeTx := channels[i].FundingTxn.Copy()
 		closeTx.TxIn[0].PreviousOutPoint = channels[i].FundingOutpoint
 
-		_, ok := published[closeTx.TxHash()]
+		count, ok := published[closeTx.TxHash()]
 		if !ok {
 			t.Fatalf("closing tx not re-published")
+		}
+
+		// We expect one coop close and one force close.
+		if count != 2 {
+			t.Fatalf("expected 2 closing txns, only got %d", count)
 		}
 
 		delete(published, closeTx.TxHash())

--- a/lntest/itest/lnd_test.go
+++ b/lntest/itest/lnd_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/go-errors/errors"
 	"github.com/lightningnetwork/lnd"
 	"github.com/lightningnetwork/lnd/chanbackup"
+	"github.com/lightningnetwork/lnd/channeldb"
 	"github.com/lightningnetwork/lnd/lnrpc"
 	"github.com/lightningnetwork/lnd/lnrpc/invoicesrpc"
 	"github.com/lightningnetwork/lnd/lnrpc/routerrpc"
@@ -332,10 +333,33 @@ func assertChannelClosed(ctx context.Context, t *harnessTest,
 	}
 	chanPointStr := fmt.Sprintf("%v:%v", txid, fundingChanPoint.OutputIndex)
 
+	// If the channel appears in list channels, ensure that its state
+	// contains ChanStatusCoopBroadcasted.
+	ctxt, _ := context.WithTimeout(ctx, defaultTimeout)
+	listChansRequest := &lnrpc.ListChannelsRequest{}
+	listChansResp, err := node.ListChannels(ctxt, listChansRequest)
+	if err != nil {
+		t.Fatalf("unable to query for list channels: %v", err)
+	}
+	for _, channel := range listChansResp.Channels {
+		// Skip other channels.
+		if channel.ChannelPoint != chanPointStr {
+			continue
+		}
+
+		// Assert that the channel is in coop broadcasted.
+		if !strings.Contains(channel.ChanStatusFlags,
+			channeldb.ChanStatusCoopBroadcasted.String()) {
+			t.Fatalf("channel not coop broadcasted, "+
+				"got: %v", channel.ChanStatusFlags)
+		}
+	}
+
 	// At this point, the channel should now be marked as being in the
 	// state of "waiting close".
+	ctxt, _ = context.WithTimeout(ctx, defaultTimeout)
 	pendingChansRequest := &lnrpc.PendingChannelsRequest{}
-	pendingChanResp, err := node.PendingChannels(ctx, pendingChansRequest)
+	pendingChanResp, err := node.PendingChannels(ctxt, pendingChansRequest)
 	if err != nil {
 		t.Fatalf("unable to query for pending channels: %v", err)
 	}

--- a/lnwallet/channel.go
+++ b/lnwallet/channel.go
@@ -6382,6 +6382,16 @@ func (lc *LightningChannel) MarkCommitmentBroadcasted(tx *wire.MsgTx) error {
 	return lc.channelState.MarkCommitmentBroadcasted(tx)
 }
 
+// MarkCoopBroadcasted marks the channel as a cooperative close transaction has
+// been broadcast, and that we should watch the chain for it to confirm before
+// taking any further action.
+func (lc *LightningChannel) MarkCoopBroadcasted(tx *wire.MsgTx) error {
+	lc.Lock()
+	defer lc.Unlock()
+
+	return lc.channelState.MarkCoopBroadcasted(tx)
+}
+
 // MarkDataLoss marks sets the channel status to LocalDataLoss and stores the
 // passed commitPoint for use to retrieve funds in case the remote force closes
 // the channel.

--- a/peer.go
+++ b/peer.go
@@ -463,6 +463,8 @@ func (p *peer) loadActiveChannels(chans []*channeldb.OpenChannel) (
 			fallthrough
 		case dbChan.HasChanStatus(channeldb.ChanStatusCommitBroadcasted):
 			fallthrough
+		case dbChan.HasChanStatus(channeldb.ChanStatusCoopBroadcasted):
+			fallthrough
 		case dbChan.HasChanStatus(channeldb.ChanStatusLocalDataLoss):
 			peerLog.Warnf("ChannelPoint(%v) has status %v, won't "+
 				"start.", chanPoint, dbChan.ChanStatus())


### PR DESCRIPTION
This PR adds granularity to our internal tracking of closed channels, allowing us to store closing transactions for both unilateral and cooperative closures. In the case that a channel is unilaterally closed and then later force closed, the contractcourt is now able to reliably publish both until either confirm. We also fix a race condition in the rpc interface to make the coop close status externally consistent with the coop close requests.