### PR TITLE
multi: make SendToRoute consistent with other payment RPC

### DIFF
--- a/fundingmanager.go
+++ b/fundingmanager.go
@@ -2359,6 +2359,9 @@ func (f *fundingManager) annAfterSixConfs(completeChan *channeldb.OpenChannel,
 		if fwdMaxHTLC > capacityMSat {
 			fwdMaxHTLC = capacityMSat
 		}
+		if fwdMaxHTLC > MaxPaymentMSat {
+			fwdMaxHTLC = MaxPaymentMSat
+		}
 
 		// Create and broadcast the proofs required to make this channel
 		// public and usable for other nodes for routing.

--- a/htlcswitch/link.go
+++ b/htlcswitch/link.go
@@ -257,9 +257,9 @@ type ChannelLinkConfig struct {
 	// configured set of watchtowers.
 	TowerClient TowerClient
 
-	// MaxCltvExpiry is the maximum outgoing timelock that the link should
-	// accept for a forwarded HTLC. The value is relative to the current
-	// block height.
+	// MaxOutgoingCltvExpiry is the maximum outgoing timelock that the link
+	// should accept for a forwarded HTLC. The value is relative to the
+	// current block height.
 	MaxOutgoingCltvExpiry uint32
 
 	// MaxFeeAllocation is the highest allocation we'll allow a channel's

--- a/lnrpc/routerrpc/router_backend.go
+++ b/lnrpc/routerrpc/router_backend.go
@@ -470,6 +470,13 @@ func (r *RouterBackend) UnmarshallRoute(rpcroute *lnrpc.Route) (
 			return nil, err
 		}
 
+		if routeHop.AmtToForward > r.MaxPaymentMSat {
+			return nil, fmt.Errorf("payment of %v is too large, "+
+				"max payment allowed is %v",
+				routeHop.AmtToForward,
+				r.MaxPaymentMSat.ToSatoshis())
+		}
+
 		hops[i] = routeHop
 
 		prevNodePubKey = routeHop.PubKeyBytes

--- a/peer.go
+++ b/peer.go
@@ -535,6 +535,9 @@ func (p *peer) loadActiveChannels(chans []*channeldb.OpenChannel) (
 				FeeRate:       selfPolicy.FeeProportionalMillionths,
 				TimeLockDelta: uint32(selfPolicy.TimeLockDelta),
 			}
+			if forwardingPolicy.MaxHTLC > MaxPaymentMSat {
+				forwardingPolicy.MaxHTLC = MaxPaymentMSat
+			}
 		} else {
 			peerLog.Warnf("Unable to find our forwarding policy "+
 				"for channel %v, using default values",
@@ -1865,6 +1868,9 @@ out:
 				BaseFee:       defaultPolicy.BaseFee,
 				FeeRate:       defaultPolicy.FeeRate,
 				TimeLockDelta: defaultPolicy.TimeLockDelta,
+			}
+			if forwardingPolicy.MaxHTLC > MaxPaymentMSat {
+				forwardingPolicy.MaxHTLC = MaxPaymentMSat
 			}
 
 			// Create the link and add it to the switch.


### PR DESCRIPTION
In this PR, we make the `SendToRoute` RPC call consistent with
all the other payment RPCs which will properly adhere to the current max
payment sat limit. This is a prep commit for the future wumbo soft cap
that will eventually land in lnd. Along the we also add some additional consistency 
checks to ensure our externally advertised `MaxHTLC` routing policy is consistent 
with this value. 