### PR TITLE
travis: staged builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,33 +14,29 @@ go:
 env:
   global:
     - GOCACHE=$HOME/.go-build
-  matrix:
-    - RACE=true
-    - ITEST=true
-    - NEUTRINO_ITEST=true
-    - BITCOIND_ITEST=true
-    - COVER=true 
 
 sudo: required
 
-script:
-  - export GO111MODULE=on
-  - bash ./scripts/install_bitcoind.sh
+before_script: bash ./scripts/install_bitcoind.sh
 
-  # Run unit tests with race condition detector.
-  - 'if [ "$RACE" = true ]; then make travis-race ; fi'
-
-  # Run btcd integration tests.
-  - 'if [ "$ITEST" = true ]; then make travis-itest; fi'
-
-  # Run neutrino integration tests.
-  - 'if [ "$NEUTRINO_ITEST" = true ]; then make travis-itest backend=neutrino; fi'
-
-  # Run bitcoind integration tests.
-  - 'if [ "$BITCOIND_ITEST" = true ]; then make travis-itest backend=bitcoind; fi'
-
-  # Run unit tests and generate coverage report.
-  - 'if [ "$COVER" = true ]; then make travis-cover; fi'
+jobs:
+  include:
+    - stage: Build
+      script: 
+      - make unit pkg=... case=_NONE_ 
+      - make lint
+      - make btcd
+    - stage: Test
+      script: make travis-cover
+      name: Unit Cover
+    - script: make travis-race
+      name: Unit Race
+    - script: make itest
+      name: Btcd Integration
+    - script: make itest backend=bitcoind
+      name: Bitcoind Integration
+    - script: make itest backend=neutrino
+      name: Neutrino Integration
 
 after_script:
   - LOG_FILES=./lntest/itest/*.log

--- a/Makefile
+++ b/Makefile
@@ -135,11 +135,9 @@ goveralls: $(GOVERALLS_BIN)
 	$(GOVERALLS_BIN) -coverprofile=coverage.txt -service=travis-ci
 
 
-travis-race: lint btcd unit-race
+travis-race: btcd unit-race
 
-travis-cover: lint btcd unit-cover goveralls
-
-travis-itest: lint itest
+travis-cover: btcd unit-cover goveralls
 
 # =============
 # FLAKE HUNTING


### PR DESCRIPTION
This PR introduces staging to our travis pipeline. Currently all instances perform:
 - compilation of lnd
 - linting
 - compilation and installation of btcd binaries
 - installation of bitcoind binaries

In total this adds about 3 minutes to each of our 5 instances, resulting in roughly 12 minutes of redundant execution time. Additionally, if if a build fails to compile or lint we detect this 5 separate times, consuming precious instances from other builds.

We alleviate this by adding an initial `Build` phase, which runs a single instance performing the actions above. This has the benefit of quickly sanity checking the pr before moving on to the more expensive unit or integration test suites, and failing faster for common mistakes. It also warms up the build caches for the `Test` stage in one fell swoop.

For instance, if 5 people push changes at the same time, they can all get immediate feedback regarding compilation or linting issues, and potentially save hours waiting for other people's test to finish or fail before finding out they had a spelling error. This doesn't alleviate all possible issues, e.g. the 5 instances may already be consumed by test suites, but it does make a sizable step towards minimizing time-to-failure in common scenarios.