### PR TITLE
channeldb: inject clock into database

### DIFF
--- a/channeldb/channel_test.go
+++ b/channeldb/channel_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/btcsuite/btcutil"
 	_ "github.com/btcsuite/btcwallet/walletdb/bdb"
 	"github.com/davecgh/go-spew/spew"
+	"github.com/lightningnetwork/lnd/clock"
 	"github.com/lightningnetwork/lnd/keychain"
 	"github.com/lightningnetwork/lnd/lnwire"
 	"github.com/lightningnetwork/lnd/shachain"
@@ -68,6 +69,8 @@ var (
 	privKey, pubKey = btcec.PrivKeyFromBytes(btcec.S256(), key[:])
 
 	wireSig, _ = lnwire.NewSigFromSignature(testSig)
+
+	testClock = clock.NewTestClock(testNow)
 )
 
 // makeTestDB creates a new instance of the ChannelDB for testing purposes. A
@@ -82,7 +85,7 @@ func makeTestDB() (*DB, func(), error) {
 	}
 
 	// Next, create channeldb for the first time.
-	cdb, err := Open(tempDirName)
+	cdb, err := Open(tempDirName, OptionClock(testClock))
 	if err != nil {
 		return nil, nil, err
 	}

--- a/channeldb/db.go
+++ b/channeldb/db.go
@@ -15,6 +15,7 @@ import (
 	"github.com/go-errors/errors"
 	"github.com/lightningnetwork/lnd/channeldb/migration12"
 	"github.com/lightningnetwork/lnd/channeldb/migration_01_to_11"
+	"github.com/lightningnetwork/lnd/clock"
 	"github.com/lightningnetwork/lnd/lnwire"
 )
 
@@ -137,8 +138,7 @@ type DB struct {
 	*bbolt.DB
 	dbPath string
 	graph  *ChannelGraph
-
-	Now func() time.Time
+	clock  clock.Clock
 }
 
 // Open opens an existing channeldb. Any necessary schemas migrations due to
@@ -172,7 +172,7 @@ func Open(dbPath string, modifiers ...OptionModifier) (*DB, error) {
 	chanDB := &DB{
 		DB:     bdb,
 		dbPath: dbPath,
-		Now:    time.Now,
+		clock:  opts.clock,
 	}
 	chanDB.graph = newChannelGraph(
 		chanDB, opts.RejectCacheSize, opts.ChannelCacheSize,

--- a/channeldb/invoice_test.go
+++ b/channeldb/invoice_test.go
@@ -304,7 +304,6 @@ func TestInvoiceAddTimeSeries(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unable to make test db: %v", err)
 	}
-	db.Now = func() time.Time { return testNow }
 
 	// We'll start off by creating 20 random invoices, and inserting them
 	// into the database.
@@ -556,7 +555,6 @@ func TestDuplicateSettleInvoice(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unable to make test db: %v", err)
 	}
-	db.Now = func() time.Time { return testNow }
 
 	// We'll start out by creating an invoice and writing it to the DB.
 	amt := lnwire.NewMSatFromSatoshis(1000)
@@ -631,7 +629,6 @@ func TestQueryInvoices(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unable to make test db: %v", err)
 	}
-	db.Now = func() time.Time { return testNow }
 
 	// To begin the test, we'll add 50 invoices to the database. We'll
 	// assume that the index of the invoice within the database is the same

--- a/channeldb/invoices.go
+++ b/channeldb/invoices.go
@@ -1348,7 +1348,7 @@ func (d *DB) updateInvoice(hash lntypes.Hash, invoices, settleIndex *bbolt.Bucke
 		return &invoice, nil
 	}
 
-	now := d.Now()
+	now := d.clock.Now()
 
 	// Update invoice state if the update descriptor indicates an invoice
 	// state change.

--- a/channeldb/options.go
+++ b/channeldb/options.go
@@ -1,5 +1,7 @@
 package channeldb
 
+import "github.com/lightningnetwork/lnd/clock"
+
 const (
 	// DefaultRejectCacheSize is the default number of rejectCacheEntries to
 	// cache for use in the rejection cache of incoming gossip traffic. This
@@ -26,6 +28,9 @@ type Options struct {
 	// freelist to disk, resulting in improved performance at the expense of
 	// increased startup time.
 	NoFreelistSync bool
+
+	// clock is the time source used by the database.
+	clock clock.Clock
 }
 
 // DefaultOptions returns an Options populated with default values.
@@ -34,6 +39,7 @@ func DefaultOptions() Options {
 		RejectCacheSize:  DefaultRejectCacheSize,
 		ChannelCacheSize: DefaultChannelCacheSize,
 		NoFreelistSync:   true,
+		clock:            clock.NewDefaultClock(),
 	}
 }
 
@@ -58,5 +64,12 @@ func OptionSetChannelCacheSize(n int) OptionModifier {
 func OptionSetSyncFreelist(b bool) OptionModifier {
 	return func(o *Options) {
 		o.NoFreelistSync = !b
+	}
+}
+
+// OptionClock sets a non-default clock dependency.
+func OptionClock(clock clock.Clock) OptionModifier {
+	return func(o *Options) {
+		o.clock = clock
 	}
 }

--- a/invoices/invoiceregistry_test.go
+++ b/invoices/invoiceregistry_test.go
@@ -317,7 +317,7 @@ func TestCancelInvoice(t *testing.T) {
 func TestSettleHoldInvoice(t *testing.T) {
 	defer timeout()()
 
-	cdb, cleanup, err := newTestChannelDB()
+	cdb, cleanup, err := newTestChannelDB(clock.NewTestClock(time.Time{}))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -497,7 +497,7 @@ func TestSettleHoldInvoice(t *testing.T) {
 func TestCancelHoldInvoice(t *testing.T) {
 	defer timeout()()
 
-	cdb, cleanup, err := newTestChannelDB()
+	cdb, cleanup, err := newTestChannelDB(clock.NewTestClock(time.Time{}))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -798,7 +798,7 @@ func TestMppPayment(t *testing.T) {
 func TestInvoiceExpiryWithRegistry(t *testing.T) {
 	t.Parallel()
 
-	cdb, cleanup, err := newTestChannelDB()
+	cdb, cleanup, err := newTestChannelDB(clock.NewTestClock(time.Time{}))
 	defer cleanup()
 
 	if err != nil {

--- a/invoices/test_utils_test.go
+++ b/invoices/test_utils_test.go
@@ -110,7 +110,7 @@ var (
 	}
 )
 
-func newTestChannelDB() (*channeldb.DB, func(), error) {
+func newTestChannelDB(clock clock.Clock) (*channeldb.DB, func(), error) {
 	// First, create a temporary directory to be used for the duration of
 	// this test.
 	tempDirName, err := ioutil.TempDir("", "channeldb")
@@ -119,7 +119,9 @@ func newTestChannelDB() (*channeldb.DB, func(), error) {
 	}
 
 	// Next, create channeldb for the first time.
-	cdb, err := channeldb.Open(tempDirName)
+	cdb, err := channeldb.Open(
+		tempDirName, channeldb.OptionClock(clock),
+	)
 	if err != nil {
 		os.RemoveAll(tempDirName)
 		return nil, nil, err
@@ -145,11 +147,10 @@ type testContext struct {
 func newTestContext(t *testing.T) *testContext {
 	clock := clock.NewTestClock(testTime)
 
-	cdb, cleanup, err := newTestChannelDB()
+	cdb, cleanup, err := newTestChannelDB(clock)
 	if err != nil {
 		t.Fatal(err)
 	}
-	cdb.Now = clock.Now
 
 	expiryWatcher := NewInvoiceExpiryWatcher(clock)
 


### PR DESCRIPTION
This PR fixes a leftover of the mpp invoice registry pr #3415. There we took a shortcut to expose `Now` as a public field on the database in order to unblock the stack of dependent prs. This is now converted to a proper `clock.Clock` dependency.