### PR TITLE
Bugfix: Chanfitness open time for offline peers

### DIFF
--- a/chanfitness/chanevent.go
+++ b/chanfitness/chanevent.go
@@ -60,14 +60,18 @@ type chanEventLog struct {
 	closedAt time.Time
 }
 
-func newEventLog(outpoint wire.OutPoint, peer route.Vertex,
+// newEventLog creates an event log for a channel with the openedAt time set.
+func newEventLog(channelPoint wire.OutPoint, peer route.Vertex,
 	now func() time.Time) *chanEventLog {
 
-	return &chanEventLog{
-		channelPoint: outpoint,
+	eventlog := &chanEventLog{
+		channelPoint: channelPoint,
 		peer:         peer,
 		now:          now,
+		openedAt:     now(),
 	}
+
+	return eventlog
 }
 
 // close sets the closing time for an event log.
@@ -90,13 +94,6 @@ func (e *chanEventLog) add(eventType eventType) {
 		eventType: eventType,
 	}
 	e.events = append(e.events, event)
-
-	// If the eventLog does not have an opened time set, set it to the timestamp
-	// of the event. This has the effect of setting the eventLog's open time to
-	// the timestamp of the first event added.
-	if e.openedAt.IsZero() {
-		e.openedAt = event.timestamp
-	}
 
 	log.Debugf("Channel %v recording event: %v", e.channelPoint, eventType)
 }

--- a/chanfitness/chanevent.go
+++ b/chanfitness/chanevent.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/btcsuite/btcd/wire"
 	"github.com/lightningnetwork/lnd/routing/route"
 )
 
@@ -36,8 +37,8 @@ type channelEvent struct {
 
 // chanEventLog stores all events that have occurred over a channel's lifetime.
 type chanEventLog struct {
-	// id is the uint64 of the short channel ID.
-	id uint64
+	// channelPoint is the outpoint for the channel's funding transaction.
+	channelPoint wire.OutPoint
 
 	// peer is the compressed public key of the peer being monitored.
 	peer route.Vertex
@@ -59,11 +60,13 @@ type chanEventLog struct {
 	closedAt time.Time
 }
 
-func newEventLog(id uint64, peer route.Vertex, now func() time.Time) *chanEventLog {
+func newEventLog(outpoint wire.OutPoint, peer route.Vertex,
+	now func() time.Time) *chanEventLog {
+
 	return &chanEventLog{
-		id:   id,
-		peer: peer,
-		now:  now,
+		channelPoint: outpoint,
+		peer:         peer,
+		now:          now,
 	}
 }
 
@@ -95,7 +98,7 @@ func (e *chanEventLog) add(eventType eventType) {
 		e.openedAt = event.timestamp
 	}
 
-	log.Debugf("Channel %v recording event: %v", e.id, eventType)
+	log.Debugf("Channel %v recording event: %v", e.channelPoint, eventType)
 }
 
 // onlinePeriod represents a period of time over which a peer was online.

--- a/chanfitness/chaneventstore.go
+++ b/chanfitness/chaneventstore.go
@@ -207,14 +207,8 @@ func (c *ChannelEventStore) addChannel(channelPoint wire.OutPoint,
 		return
 	}
 
+	// Create an event log for the channel.
 	eventLog := newEventLog(channelPoint, peer, time.Now)
-
-	// If the peer is online, add a peer online event to indicate its starting
-	// state.
-	online := c.peers[peer]
-	if online {
-		eventLog.add(peerOnlineEvent)
-	}
 
 	c.channels[channelPoint] = eventLog
 }

--- a/chanfitness/chaneventstore.go
+++ b/chanfitness/chaneventstore.go
@@ -15,6 +15,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/btcsuite/btcd/wire"
 	"github.com/lightningnetwork/lnd/channeldb"
 	"github.com/lightningnetwork/lnd/channelnotifier"
 	"github.com/lightningnetwork/lnd/peernotifier"
@@ -37,8 +38,8 @@ var (
 type ChannelEventStore struct {
 	cfg *Config
 
-	// channels maps short channel IDs to event logs.
-	channels map[uint64]*chanEventLog
+	// channels maps channel points to event logs.
+	channels map[wire.OutPoint]*chanEventLog
 
 	// peers tracks the current online status of peers based on online/offline
 	// events.
@@ -76,7 +77,7 @@ type Config struct {
 // channel's lifespan and a blocking response channel on which the result is
 // sent.
 type lifespanRequest struct {
-	channelID    uint64
+	channelPoint wire.OutPoint
 	responseChan chan lifespanResponse
 }
 
@@ -91,7 +92,7 @@ type lifespanResponse struct {
 // uptimeRequest contains the parameters required to query the store for a
 // channel's uptime and a blocking response channel on which the result is sent.
 type uptimeRequest struct {
-	channelID    uint64
+	channelPoint wire.OutPoint
 	startTime    time.Time
 	endTime      time.Time
 	responseChan chan uptimeResponse
@@ -110,7 +111,7 @@ type uptimeResponse struct {
 func NewChannelEventStore(config *Config) *ChannelEventStore {
 	store := &ChannelEventStore{
 		cfg:              config,
-		channels:         make(map[uint64]*chanEventLog),
+		channels:         make(map[wire.OutPoint]*chanEventLog),
 		peers:            make(map[route.Vertex]bool),
 		lifespanRequests: make(chan lifespanRequest),
 		uptimeRequests:   make(chan uptimeRequest),
@@ -167,7 +168,7 @@ func (c *ChannelEventStore) Start() error {
 
 		// Add existing channels to the channel store with an initial peer
 		// online or offline event.
-		c.addChannel(ch.ShortChanID().ToUint64(), peerKey)
+		c.addChannel(ch.FundingOutpoint, peerKey)
 	}
 
 	// Start a goroutine that consumes events from all subscriptions.
@@ -196,15 +197,17 @@ func (c *ChannelEventStore) Stop() {
 // already present in the map, the function returns early. This function should
 // be called to add existing channels on startup and when open channel events
 // are observed.
-func (c *ChannelEventStore) addChannel(channelID uint64, peer route.Vertex) {
+func (c *ChannelEventStore) addChannel(channelPoint wire.OutPoint,
+	peer route.Vertex) {
+
 	// Check for the unexpected case where the channel is already in the store.
-	_, ok := c.channels[channelID]
+	_, ok := c.channels[channelPoint]
 	if ok {
-		log.Errorf("Channel %v duplicated in channel store", channelID)
+		log.Errorf("Channel %v duplicated in channel store", channelPoint)
 		return
 	}
 
-	eventLog := newEventLog(channelID, peer, time.Now)
+	eventLog := newEventLog(channelPoint, peer, time.Now)
 
 	// If the peer is online, add a peer online event to indicate its starting
 	// state.
@@ -213,16 +216,16 @@ func (c *ChannelEventStore) addChannel(channelID uint64, peer route.Vertex) {
 		eventLog.add(peerOnlineEvent)
 	}
 
-	c.channels[channelID] = eventLog
+	c.channels[channelPoint] = eventLog
 }
 
 // closeChannel records a closed time for a channel, and returns early is the
 // channel is not known to the event store.
-func (c *ChannelEventStore) closeChannel(channelID uint64) {
+func (c *ChannelEventStore) closeChannel(channelPoint wire.OutPoint) {
 	// Check for the unexpected case where the channel is unknown to the store.
-	eventLog, ok := c.channels[channelID]
+	eventLog, ok := c.channels[channelPoint]
 	if !ok {
-		log.Errorf("Close channel %v unknown to store", channelID)
+		log.Errorf("Close channel %v unknown to store", channelPoint)
 		return
 	}
 
@@ -265,8 +268,6 @@ func (c *ChannelEventStore) consume(subscriptions *subscriptions) {
 			// A new channel has been opened, we must add the channel to the
 			// store and record a channel open event.
 			case channelnotifier.OpenChannelEvent:
-				chanID := event.Channel.ShortChanID().ToUint64()
-
 				peerKey, err := route.NewVertexFromBytes(
 					event.Channel.IdentityPub.SerializeCompressed(),
 				)
@@ -275,12 +276,12 @@ func (c *ChannelEventStore) consume(subscriptions *subscriptions) {
 						event.Channel.IdentityPub.SerializeCompressed())
 				}
 
-				c.addChannel(chanID, peerKey)
+				c.addChannel(event.Channel.FundingOutpoint, peerKey)
 
 			// A channel has been closed, we must remove the channel from the
 			// store and record a channel closed event.
 			case channelnotifier.ClosedChannelEvent:
-				c.closeChannel(event.CloseSummary.ShortChanID.ToUint64())
+				c.closeChannel(event.CloseSummary.ChanPoint)
 			}
 
 		// Process peer online and offline events.
@@ -301,7 +302,7 @@ func (c *ChannelEventStore) consume(subscriptions *subscriptions) {
 		case req := <-c.lifespanRequests:
 			var resp lifespanResponse
 
-			channel, ok := c.channels[req.channelID]
+			channel, ok := c.channels[req.channelPoint]
 			if !ok {
 				resp.err = ErrChannelNotFound
 			} else {
@@ -315,7 +316,7 @@ func (c *ChannelEventStore) consume(subscriptions *subscriptions) {
 		case req := <-c.uptimeRequests:
 			var resp uptimeResponse
 
-			channel, ok := c.channels[req.channelID]
+			channel, ok := c.channels[req.channelPoint]
 			if !ok {
 				resp.err = ErrChannelNotFound
 			} else {
@@ -336,9 +337,11 @@ func (c *ChannelEventStore) consume(subscriptions *subscriptions) {
 // GetLifespan returns the opening and closing time observed for a channel and
 // a boolean to indicate whether the channel is known the the event store. If
 // the channel is still open, a zero close time is returned.
-func (c *ChannelEventStore) GetLifespan(chanID uint64) (time.Time, time.Time, error) {
+func (c *ChannelEventStore) GetLifespan(
+	channelPoint wire.OutPoint) (time.Time, time.Time, error) {
+
 	request := lifespanRequest{
-		channelID:    chanID,
+		channelPoint: channelPoint,
 		responseChan: make(chan lifespanResponse),
 	}
 
@@ -364,11 +367,11 @@ func (c *ChannelEventStore) GetLifespan(chanID uint64) (time.Time, time.Time, er
 
 // GetUptime returns the uptime of a channel over a period and an error if the
 // channel cannot be found or the uptime calculation fails.
-func (c *ChannelEventStore) GetUptime(chanID uint64, startTime,
+func (c *ChannelEventStore) GetUptime(channelPoint wire.OutPoint, startTime,
 	endTime time.Time) (time.Duration, error) {
 
 	request := uptimeRequest{
-		channelID:    chanID,
+		channelPoint: channelPoint,
 		startTime:    startTime,
 		endTime:      endTime,
 		responseChan: make(chan uptimeResponse),

--- a/chanfitness/chaneventstore.go
+++ b/chanfitness/chaneventstore.go
@@ -12,7 +12,6 @@ package chanfitness
 
 import (
 	"errors"
-	"fmt"
 	"sync"
 	"time"
 
@@ -23,9 +22,15 @@ import (
 	"github.com/lightningnetwork/lnd/subscribe"
 )
 
-// errShuttingDown is returned when the store cannot respond to a query because
-// it has received the shutdown signal.
-var errShuttingDown = errors.New("channel event store shutting down")
+var (
+	// errShuttingDown is returned when the store cannot respond to a query because
+	// it has received the shutdown signal.
+	errShuttingDown = errors.New("channel event store shutting down")
+
+	// ErrChannelNotFound is returned when a query is made for a channel that
+	// the event store does not have knowledge of.
+	ErrChannelNotFound = errors.New("channel not found in event store")
+)
 
 // ChannelEventStore maintains a set of event logs for the node's channels to
 // provide insight into the performance and health of channels.
@@ -298,7 +303,7 @@ func (c *ChannelEventStore) consume(subscriptions *subscriptions) {
 
 			channel, ok := c.channels[req.channelID]
 			if !ok {
-				resp.err = fmt.Errorf("channel %v not found", req.channelID)
+				resp.err = ErrChannelNotFound
 			} else {
 				resp.start = channel.openedAt
 				resp.end = channel.closedAt
@@ -312,7 +317,7 @@ func (c *ChannelEventStore) consume(subscriptions *subscriptions) {
 
 			channel, ok := c.channels[req.channelID]
 			if !ok {
-				resp.err = fmt.Errorf("channel %v not found", req.channelID)
+				resp.err = ErrChannelNotFound
 			} else {
 				uptime, err := channel.uptime(req.startTime, req.endTime)
 				resp.uptime = uptime

--- a/chanfitness/chaneventstore_test.go
+++ b/chanfitness/chaneventstore_test.go
@@ -466,3 +466,26 @@ func TestGetUptime(t *testing.T) {
 		})
 	}
 }
+
+// TestAddChannel tests that channels are added to the event store with
+// appropriate timestamps. This test addresses a bug where offline channels
+// did not have an opened time set.
+func TestAddChannel(t *testing.T) {
+	_, vertex, chanPoint := getTestChannel(t)
+
+	store := NewChannelEventStore(&Config{})
+
+	// Add channel to the store.
+	store.addChannel(chanPoint, vertex)
+
+	// Check that the eventlog is successfully added.
+	eventlog, ok := store.channels[chanPoint]
+	if !ok {
+		t.Fatalf("channel should be in store")
+	}
+
+	// Ensure that open time is always set.
+	if eventlog.openedAt.IsZero() {
+		t.Fatalf("channel should have opened at set")
+	}
+}

--- a/chanfitness/chaneventstore_test.go
+++ b/chanfitness/chaneventstore_test.go
@@ -263,23 +263,23 @@ func TestGetLifetime(t *testing.T) {
 	now := time.Now()
 
 	tests := []struct {
-		name         string
-		channelFound bool
-		chanID       uint64
-		opened       time.Time
-		closed       time.Time
-		expectErr    bool
+		name          string
+		channelFound  bool
+		chanID        uint64
+		opened        time.Time
+		closed        time.Time
+		expectedError error
 	}{
 		{
-			name:         "Channel found",
-			channelFound: true,
-			opened:       now,
-			closed:       now.Add(time.Hour * -1),
-			expectErr:    false,
+			name:          "Channel found",
+			channelFound:  true,
+			opened:        now,
+			closed:        now.Add(time.Hour * -1),
+			expectedError: nil,
 		},
 		{
-			name:      "Channel not found",
-			expectErr: true,
+			name:          "Channel not found",
+			expectedError: ErrChannelNotFound,
 		},
 	}
 
@@ -311,11 +311,8 @@ func TestGetLifetime(t *testing.T) {
 			}
 
 			open, close, err := store.GetLifespan(test.chanID)
-			if test.expectErr && err == nil {
-				t.Fatal("Expected an error, got nil")
-			}
-			if !test.expectErr && err != nil {
-				t.Fatalf("Expected no error, got: %v", err)
+			if test.expectedError != err {
+				t.Fatalf("Expected: %v, got: %v", test.expectedError, err)
 			}
 
 			if open != test.opened {
@@ -367,13 +364,15 @@ func TestGetUptime(t *testing.T) {
 		endTime time.Time
 
 		expectedUptime time.Duration
-		expectErr      bool
+
+		expectedError error
 	}{
 		{
-			name:         "No events",
-			startTime:    twoHoursAgo,
-			endTime:      now,
-			channelFound: true,
+			name:          "No events",
+			startTime:     twoHoursAgo,
+			endTime:       now,
+			channelFound:  true,
+			expectedError: nil,
 		},
 		{
 			name: "50% Uptime",
@@ -392,6 +391,7 @@ func TestGetUptime(t *testing.T) {
 			startTime:      fourHoursAgo,
 			endTime:        now,
 			channelFound:   true,
+			expectedError:  nil,
 		},
 		{
 			name: "Zero start time",
@@ -405,13 +405,14 @@ func TestGetUptime(t *testing.T) {
 			expectedUptime: time.Hour * 4,
 			endTime:        now,
 			channelFound:   true,
+			expectedError:  nil,
 		},
 		{
-			name:         "Channel not found",
-			startTime:    twoHoursAgo,
-			endTime:      now,
-			channelFound: false,
-			expectErr:    true,
+			name:          "Channel not found",
+			startTime:     twoHoursAgo,
+			endTime:       now,
+			channelFound:  false,
+			expectedError: ErrChannelNotFound,
 		},
 	}
 
@@ -445,11 +446,8 @@ func TestGetUptime(t *testing.T) {
 			}
 
 			uptime, err := store.GetUptime(test.chanID, test.startTime, test.endTime)
-			if test.expectErr && err == nil {
-				t.Fatal("Expected an error, got nil")
-			}
-			if !test.expectErr && err != nil {
-				t.Fatalf("Expcted no error, got: %v", err)
+			if test.expectedError != err {
+				t.Fatalf("Expected: %v, got: %v", test.expectedError, err)
 			}
 
 			if uptime != test.expectedUptime {

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -2852,14 +2852,16 @@ func createRPCOpenChannel(r *rpcServer, graph *channeldb.ChannelGraph,
 		channel.UnsettledBalance += channel.PendingHtlcs[i].Amount
 	}
 
+	outpoint := dbChannel.FundingOutpoint
+
 	// Get the lifespan observed by the channel event store. If the channel is
 	// not known to the channel event store, return early because we cannot
 	// calculate any further uptime information.
-	startTime, endTime, err := r.server.chanEventStore.GetLifespan(channel.ChanId)
+	startTime, endTime, err := r.server.chanEventStore.GetLifespan(outpoint)
 	switch err {
 	case chanfitness.ErrChannelNotFound:
 		rpcsLog.Infof("channel: %v not found by channel event store",
-			channel.ChanId)
+			outpoint)
 
 		return channel, nil
 	case nil:
@@ -2880,7 +2882,7 @@ func createRPCOpenChannel(r *rpcServer, graph *channeldb.ChannelGraph,
 	// channel is known to the event store, so we can return any non-nil error
 	// that occurs.
 	uptime, err := r.server.chanEventStore.GetUptime(
-		channel.ChanId, startTime, endTime,
+		outpoint, startTime, endTime,
 	)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
This PR fixes a bug in the `chanfitness` subsystem which would not set the open time for channels with peers that are offline at startup. This open time (renamed to monitored since in this PR) is important because it indicates how long we have been monitoring the remote peer's offline status. 

Previously, open time would be set on the first event for a channel. For peers that are online at startup, this event would be immediately added to reflect the current state of the peer. Channels with peers that remain offline and do not have an event will not have their opened time set. 

This PR fixes this by setting `monitoredSince` for all channels on startup. 
It also switches `chanfitness` over to querying by channel outpoint, as this is preferred in lnd. 

This bug was first picked up in #3741 but I'd like to get the fix in while the form that 3741 should take is decided on.