### PR TITLE
peer+funding: revert link level payment clamps 

### DIFF
--- a/fundingmanager.go
+++ b/fundingmanager.go
@@ -2391,9 +2391,6 @@ func (f *fundingManager) annAfterSixConfs(completeChan *channeldb.OpenChannel,
 		if fwdMaxHTLC > capacityMSat {
 			fwdMaxHTLC = capacityMSat
 		}
-		if fwdMaxHTLC > MaxPaymentMSat {
-			fwdMaxHTLC = MaxPaymentMSat
-		}
 
 		// Create and broadcast the proofs required to make this channel
 		// public and usable for other nodes for routing.

--- a/peer.go
+++ b/peer.go
@@ -537,9 +537,6 @@ func (p *peer) loadActiveChannels(chans []*channeldb.OpenChannel) (
 				FeeRate:       selfPolicy.FeeProportionalMillionths,
 				TimeLockDelta: uint32(selfPolicy.TimeLockDelta),
 			}
-			if forwardingPolicy.MaxHTLC > MaxPaymentMSat {
-				forwardingPolicy.MaxHTLC = MaxPaymentMSat
-			}
 		} else {
 			peerLog.Warnf("Unable to find our forwarding policy "+
 				"for channel %v, using default values",
@@ -1870,9 +1867,6 @@ out:
 				BaseFee:       defaultPolicy.BaseFee,
 				FeeRate:       defaultPolicy.FeeRate,
 				TimeLockDelta: defaultPolicy.TimeLockDelta,
-			}
-			if forwardingPolicy.MaxHTLC > MaxPaymentMSat {
-				forwardingPolicy.MaxHTLC = MaxPaymentMSat
 			}
 
 			// Create the link and add it to the switch.


### PR DESCRIPTION
In this commit, we partially revert #3790 by leaving the current default max in flight and max htlc (chan update level) settings in place. We're planning on going wumbo sometime next year, so by leaving these in place, we ensure a more graceful update within the network, as only the end points and not the internal network needs to update. This upgrade path is more consistent with the end-to-end principle, and will allows users of the network to take advantage of the larger payments as soon as the end points are upgraded. 