### PR TITLE
WIP: Surface Update Reason for Exit Hop HTLCs

### DIFF
--- a/contractcourt/htlc_incoming_contest_resolver.go
+++ b/contractcourt/htlc_incoming_contest_resolver.go
@@ -201,7 +201,7 @@ func (h *htlcIncomingContestResolver) Resolve() (ContractResolver, error) {
 		HtlcID: h.htlc.HtlcIndex,
 	}
 
-	event, err := h.Registry.NotifyExitHopHtlc(
+	event, _, err := h.Registry.NotifyExitHopHtlc(
 		h.htlc.RHash, h.htlc.Amt, h.htlcExpiry, currentHeight,
 		circuitKey, hodlChan, payload,
 	)

--- a/contractcourt/interfaces.go
+++ b/contractcourt/interfaces.go
@@ -27,7 +27,7 @@ type Registry interface {
 	NotifyExitHopHtlc(payHash lntypes.Hash, paidAmount lnwire.MilliSatoshi,
 		expiry uint32, currentHeight int32,
 		circuitKey channeldb.CircuitKey, hodlChan chan<- interface{},
-		payload invoices.Payload) (*invoices.HodlEvent, error)
+		payload invoices.Payload) (*invoices.HodlEvent, invoices.UpdateResult, error)
 
 	// HodlUnsubscribeAll unsubscribes from all hodl events.
 	HodlUnsubscribeAll(subscriber chan<- interface{})

--- a/contractcourt/mock_registry_test.go
+++ b/contractcourt/mock_registry_test.go
@@ -24,7 +24,7 @@ type mockRegistry struct {
 func (r *mockRegistry) NotifyExitHopHtlc(payHash lntypes.Hash,
 	paidAmount lnwire.MilliSatoshi, expiry uint32, currentHeight int32,
 	circuitKey channeldb.CircuitKey, hodlChan chan<- interface{},
-	payload invoices.Payload) (*invoices.HodlEvent, error) {
+	payload invoices.Payload) (*invoices.HodlEvent, invoices.UpdateResult, error) {
 
 	r.notifyChan <- notifyExitHopData{
 		hodlChan:      hodlChan,
@@ -34,7 +34,8 @@ func (r *mockRegistry) NotifyExitHopHtlc(payHash lntypes.Hash,
 		currentHeight: currentHeight,
 	}
 
-	return r.notifyEvent, r.notifyErr
+	// TODO(carla): investigate this
+	return r.notifyEvent, 0, r.notifyErr
 }
 
 func (r *mockRegistry) HodlUnsubscribeAll(subscriber chan<- interface{}) {}

--- a/htlcswitch/interfaces.go
+++ b/htlcswitch/interfaces.go
@@ -27,7 +27,7 @@ type InvoiceDatabase interface {
 	NotifyExitHopHtlc(payHash lntypes.Hash, paidAmount lnwire.MilliSatoshi,
 		expiry uint32, currentHeight int32,
 		circuitKey channeldb.CircuitKey, hodlChan chan<- interface{},
-		payload invoices.Payload) (*invoices.HodlEvent, error)
+		payload invoices.Payload) (*invoices.HodlEvent, invoices.UpdateResult, error)
 
 	// CancelInvoice attempts to cancel the invoice corresponding to the
 	// passed payment hash.

--- a/htlcswitch/mock.go
+++ b/htlcswitch/mock.go
@@ -814,20 +814,20 @@ func (i *mockInvoiceRegistry) SettleHodlInvoice(preimage lntypes.Preimage) error
 func (i *mockInvoiceRegistry) NotifyExitHopHtlc(rhash lntypes.Hash,
 	amt lnwire.MilliSatoshi, expiry uint32, currentHeight int32,
 	circuitKey channeldb.CircuitKey, hodlChan chan<- interface{},
-	payload invoices.Payload) (*invoices.HodlEvent, error) {
+	payload invoices.Payload) (*invoices.HodlEvent, invoices.UpdateResult, error) {
 
-	event, err := i.registry.NotifyExitHopHtlc(
+	event, update, err := i.registry.NotifyExitHopHtlc(
 		rhash, amt, expiry, currentHeight, circuitKey, hodlChan,
 		payload,
 	)
 	if err != nil {
-		return nil, err
+		return nil, 0, err
 	}
 	if i.settleChan != nil {
 		i.settleChan <- rhash
 	}
 
-	return event, nil
+	return event, update, nil
 }
 
 func (i *mockInvoiceRegistry) CancelInvoice(payHash lntypes.Hash) error {


### PR DESCRIPTION
This PR updates `processExitHopHTLC` to take action based on the `updateResult` returned by `NotifyExitHopHTLC`. 

Reasons for the change:
1. More understandable handler code: as is, invoice errors such as invoice underpaid and expiry fall through to `processHODLEvent` and would present as if they were hodl invoice cancels (we log that we're cancelling a hodl event) and hodl acceptances are inferred by the presence of a nil hodl event, which is not clear on first read of the code.
2. Better unit tests: surfacing the update result allows for unit testing of specific outcomes
3. HTLCNotifier will be able to notify events with their specific failure reasons. 

Disadvantage of change:
1. Update to an interface which is widely used in lnd
2. Potential for bugs/behaviour change (further unit tests to follow after discussion of this change)