### PR TITLE
bitcoindnotify: add missing space in log message in bitcoind.go

### DIFF
--- a/chainntnfs/bitcoindnotify/bitcoind.go
+++ b/chainntnfs/bitcoindnotify/bitcoind.go
@@ -263,7 +263,7 @@ out:
 					}
 
 					chainntnfs.Log.Infof("Historical "+
-						"spend dispatch finished"+
+						"spend dispatch finished "+
 						"for request %v (start=%v "+
 						"end=%v) with details: %v",
 						msg.SpendRequest,


### PR DESCRIPTION
This PR was in response to issue #3807 and it adds a space after "finished" in a log message found in lnd/chainntnfs/bitcoindnotify/bitcoind.go 

Let me know if I have done anything incorrectly as this is my first PR ever