### PR TITLE
sweep: add wallet inputs to reach dust limit

### DIFF
--- a/chainregistry.go
+++ b/chainregistry.go
@@ -58,6 +58,10 @@ const (
 	// expressed in sat/kw.
 	defaultBitcoinStaticFeePerKW = chainfee.SatPerKWeight(12500)
 
+	// defaultBitcoinStaticMinRelayFeeRate is the min relay fee used for
+	// static estimators.
+	defaultBitcoinStaticMinRelayFeeRate = chainfee.FeePerKwFloor
+
 	// defaultLitecoinStaticFeePerKW is the fee rate of 200 sat/vbyte
 	// expressed in sat/kw.
 	defaultLitecoinStaticFeePerKW = chainfee.SatPerKWeight(50000)
@@ -163,7 +167,8 @@ func newChainControlFromConfig(cfg *config, chanDB *channeldb.DB,
 			TimeLockDelta: cfg.Bitcoin.TimeLockDelta,
 		}
 		cc.feeEstimator = chainfee.NewStaticEstimator(
-			defaultBitcoinStaticFeePerKW, 0,
+			defaultBitcoinStaticFeePerKW,
+			defaultBitcoinStaticMinRelayFeeRate,
 		)
 	case litecoinChain:
 		cc.routingPolicy = htlcswitch.ForwardingPolicy{

--- a/contractcourt/commit_sweep_resolver.go
+++ b/contractcourt/commit_sweep_resolver.go
@@ -206,7 +206,7 @@ func (c *commitSweepResolver) Resolve() (ContractResolver, error) {
 	c.log.Infof("sweeping commit output")
 
 	feePref := sweep.FeePreference{ConfTarget: commitOutputConfTarget}
-	resultChan, err := c.Sweeper.SweepInput(inp, feePref)
+	resultChan, err := c.Sweeper.SweepInput(inp, sweep.Params{Fee: feePref})
 	if err != nil {
 		c.log.Errorf("unable to sweep input: %v", err)
 

--- a/contractcourt/commit_sweep_resolver_test.go
+++ b/contractcourt/commit_sweep_resolver_test.go
@@ -102,8 +102,8 @@ func newMockSweeper() *mockSweeper {
 	}
 }
 
-func (s *mockSweeper) SweepInput(input input.Input,
-	feePreference sweep.FeePreference) (chan sweep.Result, error) {
+func (s *mockSweeper) SweepInput(input input.Input, params sweep.Params) (
+	chan sweep.Result, error) {
 
 	s.sweptInputs <- input
 

--- a/contractcourt/interfaces.go
+++ b/contractcourt/interfaces.go
@@ -43,8 +43,8 @@ type OnionProcessor interface {
 // UtxoSweeper defines the sweep functions that contract court requires.
 type UtxoSweeper interface {
 	// SweepInput sweeps inputs back into the wallet.
-	SweepInput(input input.Input,
-		feePreference sweep.FeePreference) (chan sweep.Result, error)
+	SweepInput(input input.Input, params sweep.Params) (chan sweep.Result,
+		error)
 
 	// CreateSweepTx accepts a list of inputs and signs and generates a txn
 	// that spends from them. This method also makes an accurate fee

--- a/lnrpc/walletrpc/walletkit_server.go
+++ b/lnrpc/walletrpc/walletkit_server.go
@@ -536,7 +536,7 @@ func (w *WalletKit) BumpFee(ctx context.Context,
 	}
 
 	input := input.NewBaseInput(op, witnessType, signDesc, uint32(currentHeight))
-	if _, err = w.cfg.Sweeper.SweepInput(input, feePreference); err != nil {
+	if _, err = w.cfg.Sweeper.SweepInput(input, sweep.Params{Fee: feePreference}); err != nil {
 		return nil, err
 	}
 

--- a/server.go
+++ b/server.go
@@ -792,10 +792,10 @@ func newServer(listenAddrs []net.Addr, chanDB *channeldb.DB,
 	}
 
 	s.sweeper = sweep.New(&sweep.UtxoSweeperConfig{
-		FeeEstimator:       cc.feeEstimator,
-		GenSweepScript:     newSweepPkScriptGen(cc.wallet),
-		Signer:             cc.wallet.Cfg.Signer,
-		PublishTransaction: cc.wallet.PublishTransaction,
+		FeeEstimator:   cc.feeEstimator,
+		GenSweepScript: newSweepPkScriptGen(cc.wallet),
+		Signer:         cc.wallet.Cfg.Signer,
+		Wallet:         cc.wallet,
 		NewBatchTimer: func() <-chan time.Time {
 			return time.NewTimer(sweep.DefaultBatchWindowDuration).C
 		},

--- a/sweep/backend_mock_test.go
+++ b/sweep/backend_mock_test.go
@@ -25,6 +25,8 @@ type mockBackend struct {
 	unconfirmedSpendInputs map[wire.OutPoint]struct{}
 
 	publishChan chan wire.MsgTx
+
+	walletUtxos []*lnwallet.Utxo
 }
 
 func newMockBackend(t *testing.T, notifier *MockNotifier) *mockBackend {
@@ -82,6 +84,16 @@ func (b *mockBackend) PublishTransaction(tx *wire.MsgTx) error {
 		b.t.Fatalf("unexpected tx published")
 	}
 	return err
+}
+
+func (b *mockBackend) ListUnspentWitness(minconfirms, maxconfirms int32) (
+	[]*lnwallet.Utxo, error) {
+
+	return b.walletUtxos, nil
+}
+
+func (b *mockBackend) WithCoinSelectLock(f func() error) error {
+	return f()
 }
 
 func (b *mockBackend) deleteUnconfirmed(txHash chainhash.Hash) {

--- a/sweep/interface.go
+++ b/sweep/interface.go
@@ -2,6 +2,7 @@ package sweep
 
 import (
 	"github.com/btcsuite/btcd/wire"
+	"github.com/lightningnetwork/lnd/lnwallet"
 )
 
 // Wallet contains all wallet related functionality required by sweeper.
@@ -9,4 +10,18 @@ type Wallet interface {
 	// PublishTransaction performs cursory validation (dust checks, etc) and
 	// broadcasts the passed transaction to the Bitcoin network.
 	PublishTransaction(tx *wire.MsgTx) error
+
+	// ListUnspentWitness returns all unspent outputs which are version 0
+	// witness programs. The 'minconfirms' and 'maxconfirms' parameters
+	// indicate the minimum and maximum number of confirmations an output
+	// needs in order to be returned by this method.
+	ListUnspentWitness(minconfirms, maxconfirms int32) ([]*lnwallet.Utxo,
+		error)
+
+	// WithCoinSelectLock will execute the passed function closure in a
+	// synchronized manner preventing any coin selection operations from
+	// proceeding while the closure if executing. This can be seen as the
+	// ability to execute a function closure under an exclusive coin
+	// selection lock.
+	WithCoinSelectLock(f func() error) error
 }

--- a/sweep/interface.go
+++ b/sweep/interface.go
@@ -1,0 +1,12 @@
+package sweep
+
+import (
+	"github.com/btcsuite/btcd/wire"
+)
+
+// Wallet contains all wallet related functionality required by sweeper.
+type Wallet interface {
+	// PublishTransaction performs cursory validation (dust checks, etc) and
+	// broadcasts the passed transaction to the Bitcoin network.
+	PublishTransaction(tx *wire.MsgTx) error
+}

--- a/sweep/sweeper.go
+++ b/sweep/sweeper.go
@@ -210,9 +210,8 @@ type UtxoSweeperConfig struct {
 	// transaction.
 	FeeEstimator chainfee.Estimator
 
-	// PublishTransaction facilitates the process of broadcasting a signed
-	// transaction to the appropriate network.
-	PublishTransaction func(*wire.MsgTx) error
+	// Wallet contains the wallet functions that sweeper requires.
+	Wallet Wallet
 
 	// NewBatchTimer creates a channel that will be sent on when a certain
 	// time window has passed. During this time window, new inputs can still
@@ -321,7 +320,7 @@ func (s *UtxoSweeper) Start() error {
 
 		// Error can be ignored. Because we are starting up, there are
 		// no pending inputs to update based on the publish result.
-		err := s.cfg.PublishTransaction(lastTx)
+		err := s.cfg.Wallet.PublishTransaction(lastTx)
 		if err != nil && err != lnwallet.ErrDoubleSpend {
 			log.Errorf("last tx publish: %v", err)
 		}
@@ -886,7 +885,7 @@ func (s *UtxoSweeper) sweep(inputs inputSet, feeRate chainfee.SatPerKWeight,
 		}),
 	)
 
-	err = s.cfg.PublishTransaction(tx)
+	err = s.cfg.Wallet.PublishTransaction(tx)
 
 	// In case of an unexpected error, don't try to recover.
 	if err != nil && err != lnwallet.ErrDoubleSpend {

--- a/sweep/sweeper.go
+++ b/sweep/sweeper.go
@@ -3,7 +3,6 @@ package sweep
 import (
 	"errors"
 	"fmt"
-	"math"
 	"math/rand"
 	"sort"
 	"sync"
@@ -246,8 +245,8 @@ type UtxoSweeperConfig struct {
 	// of 10 would result in the following fee rate buckets up to the
 	// maximum fee rate:
 	//
-	//   #1: min = 1 sat/vbyte, max = 10 sat/vbyte
-	//   #2: min = 11 sat/vbyte, max = 20 sat/vbyte...
+	//   #1: min = 1 sat/vbyte, max (exclusive) = 11 sat/vbyte
+	//   #2: min = 11 sat/vbyte, max (exclusive) = 21 sat/vbyte...
 	FeeRateBucketSize int
 }
 
@@ -640,8 +639,7 @@ func (s *UtxoSweeper) collector(blockEpochs <-chan *chainntnfs.BlockEpoch) {
 func (s *UtxoSweeper) bucketForFeeRate(
 	feeRate chainfee.SatPerKWeight) int {
 
-	minBucket := s.relayFeeRate + chainfee.SatPerKWeight(s.cfg.FeeRateBucketSize)
-	return int(math.Ceil(float64(feeRate) / float64(minBucket)))
+	return int(feeRate-s.relayFeeRate) / s.cfg.FeeRateBucketSize
 }
 
 // clusterBySweepFeeRate takes the set of pending inputs within the UtxoSweeper

--- a/sweep/sweeper.go
+++ b/sweep/sweeper.go
@@ -70,15 +70,14 @@ type Params struct {
 }
 
 // pendingInput is created when an input reaches the main loop for the first
-// time. It tracks all relevant state that is needed for sweeping.
+// time. It wraps the input and tracks all relevant state that is needed for
+// sweeping.
 type pendingInput struct {
+	input.Input
+
 	// listeners is a list of channels over which the final outcome of the
 	// sweep needs to be broadcasted.
 	listeners []chan Result
-
-	// input is the original struct that contains the input and sign
-	// descriptor.
-	input input.Input
 
 	// ntfnRegCancel is populated with a function that cancels the chain
 	// notifier spend registration.
@@ -474,7 +473,7 @@ func (s *UtxoSweeper) collector(blockEpochs <-chan *chainntnfs.BlockEpoch) {
 			// channel will be appended to this slice.
 			pendInput = &pendingInput{
 				listeners:        []chan Result{input.resultChan},
-				input:            input.input,
+				Input:            input.input,
 				minPublishHeight: bestHeight,
 				params:           input.params,
 			}
@@ -800,9 +799,9 @@ func (s *UtxoSweeper) getInputLists(cluster inputCluster,
 
 		// Add input to the either one of the lists.
 		if input.publishAttempts == 0 {
-			newInputs = append(newInputs, input.input)
+			newInputs = append(newInputs, input)
 		} else {
-			retryInputs = append(retryInputs, input.input)
+			retryInputs = append(retryInputs, input)
 		}
 	}
 
@@ -1002,12 +1001,12 @@ func (s *UtxoSweeper) handlePendingSweepsReq(
 	for _, pendingInput := range s.pendingInputs {
 		// Only the exported fields are set, as we expect the response
 		// to only be consumed externally.
-		op := *pendingInput.input.OutPoint()
+		op := *pendingInput.OutPoint()
 		pendingInputs[op] = &PendingInput{
 			OutPoint:    op,
-			WitnessType: pendingInput.input.WitnessType(),
+			WitnessType: pendingInput.WitnessType(),
 			Amount: btcutil.Amount(
-				pendingInput.input.SignDesc().Output.Value,
+				pendingInput.SignDesc().Output.Value,
 			),
 			LastFeeRate:         pendingInput.lastFeeRate,
 			BroadcastAttempts:   pendingInput.publishAttempts,

--- a/sweep/sweeper.go
+++ b/sweep/sweeper.go
@@ -99,6 +99,13 @@ type pendingInput struct {
 	lastFeeRate chainfee.SatPerKWeight
 }
 
+// parameters returns the sweep parameters for this input.
+//
+// NOTE: Part of the txInput interface.
+func (p *pendingInput) parameters() Params {
+	return p.params
+}
+
 // pendingInputs is a type alias for a set of pending inputs.
 type pendingInputs = map[wire.OutPoint]*pendingInput
 
@@ -789,7 +796,7 @@ func (s *UtxoSweeper) getInputLists(cluster inputCluster,
 	// contain inputs that failed before. Therefore we also add sets
 	// consisting of only new inputs to the list, to make sure that new
 	// inputs are given a good, isolated chance of being published.
-	var newInputs, retryInputs []input.Input
+	var newInputs, retryInputs []txInput
 	for _, input := range cluster.inputs {
 		// Skip inputs that have a minimum publish height that is not
 		// yet reached.

--- a/sweep/sweeper_test.go
+++ b/sweep/sweeper_test.go
@@ -25,7 +25,7 @@ var (
 
 	testMaxInputsPerTx = 3
 
-	defaultFeePref = FeePreference{ConfTarget: 1}
+	defaultFeePref = Params{Fee: FeePreference{ConfTarget: 1}}
 )
 
 type sweeperTestContext struct {
@@ -354,7 +354,7 @@ func TestSuccess(t *testing.T) {
 	ctx := createSweeperTestContext(t)
 
 	// Sweeping an input without a fee preference should result in an error.
-	_, err := ctx.sweeper.SweepInput(spendableInputs[0], FeePreference{})
+	_, err := ctx.sweeper.SweepInput(spendableInputs[0], Params{})
 	if err != ErrNoFeePreference {
 		t.Fatalf("expected ErrNoFeePreference, got %v", err)
 	}
@@ -1003,17 +1003,23 @@ func TestDifferentFeePreferences(t *testing.T) {
 	ctx.estimator.blocksToFee[highFeePref.ConfTarget] = highFeeRate
 
 	input1 := spendableInputs[0]
-	resultChan1, err := ctx.sweeper.SweepInput(input1, highFeePref)
+	resultChan1, err := ctx.sweeper.SweepInput(
+		input1, Params{Fee: highFeePref},
+	)
 	if err != nil {
 		t.Fatal(err)
 	}
 	input2 := spendableInputs[1]
-	resultChan2, err := ctx.sweeper.SweepInput(input2, highFeePref)
+	resultChan2, err := ctx.sweeper.SweepInput(
+		input2, Params{Fee: highFeePref},
+	)
 	if err != nil {
 		t.Fatal(err)
 	}
 	input3 := spendableInputs[2]
-	resultChan3, err := ctx.sweeper.SweepInput(input3, lowFeePref)
+	resultChan3, err := ctx.sweeper.SweepInput(
+		input3, Params{Fee: lowFeePref},
+	)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1067,16 +1073,23 @@ func TestPendingInputs(t *testing.T) {
 	ctx.estimator.blocksToFee[highFeePref.ConfTarget] = highFeeRate
 
 	input1 := spendableInputs[0]
-	resultChan1, err := ctx.sweeper.SweepInput(input1, highFeePref)
+	resultChan1, err := ctx.sweeper.SweepInput(
+		input1, Params{Fee: highFeePref},
+	)
 	if err != nil {
 		t.Fatal(err)
 	}
 	input2 := spendableInputs[1]
-	if _, err := ctx.sweeper.SweepInput(input2, highFeePref); err != nil {
+	_, err = ctx.sweeper.SweepInput(
+		input2, Params{Fee: highFeePref},
+	)
+	if err != nil {
 		t.Fatal(err)
 	}
 	input3 := spendableInputs[2]
-	resultChan3, err := ctx.sweeper.SweepInput(input3, lowFeePref)
+	resultChan3, err := ctx.sweeper.SweepInput(
+		input3, Params{Fee: lowFeePref},
+	)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1132,7 +1145,9 @@ func TestBumpFeeRBF(t *testing.T) {
 	input := createTestInput(
 		btcutil.SatoshiPerBitcoin, input.CommitmentTimeLock,
 	)
-	sweepResult, err := ctx.sweeper.SweepInput(&input, lowFeePref)
+	sweepResult, err := ctx.sweeper.SweepInput(
+		&input, Params{Fee: lowFeePref},
+	)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/sweep/sweeper_test.go
+++ b/sweep/sweeper_test.go
@@ -98,14 +98,13 @@ func createSweeperTestContext(t *testing.T) *sweeperTestContext {
 
 	store := NewMockSweeperStore()
 
-	backend := newMockBackend(notifier)
+	backend := newMockBackend(t, notifier)
 
 	estimator := newMockFeeEstimator(10000, chainfee.FeePerKwFloor)
 
-	publishChan := make(chan wire.MsgTx, 2)
 	ctx := &sweeperTestContext{
 		notifier:    notifier,
-		publishChan: publishChan,
+		publishChan: backend.publishChan,
 		t:           t,
 		estimator:   estimator,
 		backend:     backend,
@@ -116,16 +115,7 @@ func createSweeperTestContext(t *testing.T) *sweeperTestContext {
 	var outputScriptCount byte
 	ctx.sweeper = New(&UtxoSweeperConfig{
 		Notifier: notifier,
-		PublishTransaction: func(tx *wire.MsgTx) error {
-			log.Tracef("Publishing tx %v", tx.TxHash())
-			err := backend.publishTransaction(tx)
-			select {
-			case publishChan <- *tx:
-			case <-time.After(defaultTestTimeout):
-				t.Fatalf("unexpected tx published")
-			}
-			return err
-		},
+		Wallet:   backend,
 		NewBatchTimer: func() <-chan time.Time {
 			c := make(chan time.Time, 1)
 			ctx.timeoutChan <- c

--- a/sweep/tx_input_set.go
+++ b/sweep/tx_input_set.go
@@ -1,0 +1,132 @@
+package sweep
+
+import (
+	"github.com/btcsuite/btcutil"
+	"github.com/btcsuite/btcwallet/wallet/txrules"
+	"github.com/lightningnetwork/lnd/input"
+	"github.com/lightningnetwork/lnd/lnwallet/chainfee"
+)
+
+// txInputSet is an object that accumulates tx inputs and keeps running counters
+// on various properties of the tx.
+type txInputSet struct {
+	// weightEstimate is the (worst case) tx weight with the current set of
+	// inputs.
+	weightEstimate input.TxWeightEstimator
+
+	// inputTotal is the total value of all inputs.
+	inputTotal btcutil.Amount
+
+	// outputValue is the value of the tx output.
+	outputValue btcutil.Amount
+
+	// feePerKW is the fee rate used to calculate the tx fee.
+	feePerKW chainfee.SatPerKWeight
+
+	// inputs is the set of tx inputs.
+	inputs []input.Input
+
+	// dustLimit is the minimum output value of the tx.
+	dustLimit btcutil.Amount
+
+	// maxInputs is the maximum number of inputs that will be accepted in
+	// the set.
+	maxInputs int
+}
+
+// newTxInputSet constructs a new, empty input set.
+func newTxInputSet(feePerKW, relayFee chainfee.SatPerKWeight,
+	maxInputs int) *txInputSet {
+
+	dustLimit := txrules.GetDustThreshold(
+		input.P2WPKHSize,
+		btcutil.Amount(relayFee.FeePerKVByte()),
+	)
+
+	b := txInputSet{
+		feePerKW:  feePerKW,
+		dustLimit: dustLimit,
+		maxInputs: maxInputs,
+	}
+
+	// Add the sweep tx output to the weight estimate.
+	b.weightEstimate.AddP2WKHOutput()
+
+	return &b
+}
+
+// dustLimitReached returns true if we've accumulated enough inputs to meet the
+// dust limit.
+func (t *txInputSet) dustLimitReached() bool {
+	return t.outputValue >= t.dustLimit
+}
+
+// add adds a new input to the set. It returns a bool indicating whether the
+// input was added to the set. An input is rejected if it decreases the tx
+// output value after paying fees.
+func (t *txInputSet) add(input input.Input) bool {
+	// Stop if max inputs is reached.
+	if len(t.inputs) == t.maxInputs {
+		return false
+	}
+
+	// Can ignore error, because it has already been checked when
+	// calculating the yields.
+	size, isNestedP2SH, _ := input.WitnessType().SizeUpperBound()
+
+	// Add weight of this new candidate input to a copy of the weight
+	// estimator.
+	newWeightEstimate := t.weightEstimate
+	if isNestedP2SH {
+		newWeightEstimate.AddNestedP2WSHInput(size)
+	} else {
+		newWeightEstimate.AddWitnessInput(size)
+	}
+
+	value := btcutil.Amount(input.SignDesc().Output.Value)
+	newInputTotal := t.inputTotal + value
+
+	weight := newWeightEstimate.Weight()
+	fee := t.feePerKW.FeeForWeight(int64(weight))
+
+	// Calculate the output value if the current input would be
+	// added to the set.
+	newOutputValue := newInputTotal - fee
+
+	// If adding this input makes the total output value of the set
+	// decrease, this is a negative yield input. We don't add the input to
+	// the set and return the outcome.
+	if newOutputValue <= t.outputValue {
+		return false
+	}
+
+	// Update running values.
+	t.inputTotal = newInputTotal
+	t.outputValue = newOutputValue
+	t.inputs = append(t.inputs, input)
+	t.weightEstimate = newWeightEstimate
+
+	return true
+}
+
+// addPositiveYieldInputs adds sweepableInputs that have a positive yield to the
+// input set. This function assumes that the list of inputs is sorted descending
+// by yield.
+//
+// TODO(roasbeef): Consider including some negative yield inputs too to clean
+// up the utxo set even if it costs us some fees up front.  In the spirit of
+// minimizing any negative externalities we cause for the Bitcoin system as a
+// whole.
+func (t *txInputSet) addPositiveYieldInputs(sweepableInputs []txInput) {
+	for _, input := range sweepableInputs {
+		// Try to add the input to the transaction. If that doesn't
+		// succeed because it wouldn't increase the output value,
+		// return. Assuming inputs are sorted by yield, any further
+		// inputs wouldn't increase the output value either.
+		if !t.add(input) {
+			return
+		}
+	}
+
+	// We managed to add all inputs to the set.
+}

--- a/sweep/tx_input_set_test.go
+++ b/sweep/tx_input_set_test.go
@@ -1,0 +1,62 @@
+package sweep
+
+import (
+	"testing"
+
+	"github.com/btcsuite/btcutil"
+	"github.com/lightningnetwork/lnd/input"
+)
+
+// TestTxInputSet tests adding various sized inputs to the set.
+func TestTxInputSet(t *testing.T) {
+	const (
+		feeRate   = 1000
+		relayFee  = 300
+		maxInputs = 10
+	)
+	set := newTxInputSet(feeRate, relayFee, maxInputs)
+
+	if set.dustLimit != 537 {
+		t.Fatalf("incorrect dust limit")
+	}
+
+	// Create a 300 sat input. The fee to sweep this input to a P2WKH output
+	// is 439 sats. That means that this input yields -139 sats and we
+	// expect it not to be added.
+	if set.add(createP2WKHInput(300)) {
+		t.Fatal("expected add of negatively yielding input to fail")
+	}
+
+	// A 700 sat input should be accepted into the set, because it yields
+	// positively.
+	if !set.add(createP2WKHInput(700)) {
+		t.Fatal("expected add of positively yielding input to succeed")
+	}
+
+	// The tx output should now be 700-439 = 261 sats. The dust limit isn't
+	// reached yet.
+	if set.outputValue != 261 {
+		t.Fatal("unexpected output value")
+	}
+	if set.dustLimitReached() {
+		t.Fatal("expected dust limit not yet to be reached")
+	}
+
+	// Add a 1000 sat input. This increases the tx fee to 712 sats. The tx
+	// output should now be 1000+700 - 712 = 988 sats.
+	if !set.add(createP2WKHInput(1000)) {
+		t.Fatal("expected add of positively yielding input to succeed")
+	}
+	if set.outputValue != 988 {
+		t.Fatal("unexpected output value")
+	}
+	if !set.dustLimitReached() {
+		t.Fatal("expected dust limit to be reached")
+	}
+}
+
+// createP2WKHInput returns a P2WKH test input with the specified amount.
+func createP2WKHInput(amt btcutil.Amount) input.Input {
+	input := createTestInput(int64(amt), input.WitnessKeyHash)
+	return &input
+}

--- a/sweep/tx_input_set_test.go
+++ b/sweep/tx_input_set_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/btcsuite/btcutil"
 	"github.com/lightningnetwork/lnd/input"
+	"github.com/lightningnetwork/lnd/lnwallet"
 )
 
 // TestTxInputSet tests adding various sized inputs to the set.
@@ -14,7 +15,7 @@ func TestTxInputSet(t *testing.T) {
 		relayFee  = 300
 		maxInputs = 10
 	)
-	set := newTxInputSet(feeRate, relayFee, maxInputs)
+	set := newTxInputSet(nil, feeRate, relayFee, maxInputs)
 
 	if set.dustLimit != 537 {
 		t.Fatalf("incorrect dust limit")
@@ -23,13 +24,13 @@ func TestTxInputSet(t *testing.T) {
 	// Create a 300 sat input. The fee to sweep this input to a P2WKH output
 	// is 439 sats. That means that this input yields -139 sats and we
 	// expect it not to be added.
-	if set.add(createP2WKHInput(300)) {
+	if set.add(createP2WKHInput(300), false) {
 		t.Fatal("expected add of negatively yielding input to fail")
 	}
 
 	// A 700 sat input should be accepted into the set, because it yields
 	// positively.
-	if !set.add(createP2WKHInput(700)) {
+	if !set.add(createP2WKHInput(700), false) {
 		t.Fatal("expected add of positively yielding input to succeed")
 	}
 
@@ -44,7 +45,7 @@ func TestTxInputSet(t *testing.T) {
 
 	// Add a 1000 sat input. This increases the tx fee to 712 sats. The tx
 	// output should now be 1000+700 - 712 = 988 sats.
-	if !set.add(createP2WKHInput(1000)) {
+	if !set.add(createP2WKHInput(1000), false) {
 		t.Fatal("expected add of positively yielding input to succeed")
 	}
 	if set.outputValue != 988 {
@@ -55,8 +56,54 @@ func TestTxInputSet(t *testing.T) {
 	}
 }
 
+// TestTxInputSetFromWallet tests adding a wallet input to a TxInputSet to reach
+// the dust limit.
+func TestTxInputSetFromWallet(t *testing.T) {
+	const (
+		feeRate   = 500
+		relayFee  = 300
+		maxInputs = 10
+	)
+
+	wallet := &mockWallet{}
+	set := newTxInputSet(wallet, feeRate, relayFee, maxInputs)
+
+	// Add a 700 sat input to the set. It yields positively, but doesn't
+	// reach the output dust limit.
+	if !set.add(createP2WKHInput(700), false) {
+		t.Fatal("expected add of positively yielding input to succeed")
+	}
+	if set.dustLimitReached() {
+		t.Fatal("expected dust limit not yet to be reached")
+	}
+
+	err := set.tryAddWalletInputsIfNeeded()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !set.dustLimitReached() {
+		t.Fatal("expected dust limit to be reached")
+	}
+}
+
 // createP2WKHInput returns a P2WKH test input with the specified amount.
 func createP2WKHInput(amt btcutil.Amount) input.Input {
 	input := createTestInput(int64(amt), input.WitnessKeyHash)
 	return &input
+}
+
+type mockWallet struct {
+	Wallet
+}
+
+func (m *mockWallet) ListUnspentWitness(minconfirms, maxconfirms int32) (
+	[]*lnwallet.Utxo, error) {
+
+	return []*lnwallet.Utxo{
+		{
+			AddressType: lnwallet.WitnessPubKey,
+			Value:       10000,
+		},
+	}, nil
 }

--- a/sweep/txgenerator.go
+++ b/sweep/txgenerator.go
@@ -9,7 +9,6 @@ import (
 	"github.com/btcsuite/btcd/txscript"
 	"github.com/btcsuite/btcd/wire"
 	"github.com/btcsuite/btcutil"
-	"github.com/btcsuite/btcwallet/wallet/txrules"
 	"github.com/lightningnetwork/lnd/input"
 	"github.com/lightningnetwork/lnd/lnwallet/chainfee"
 )
@@ -21,6 +20,13 @@ var (
 	DefaultMaxInputsPerTx = 100
 )
 
+// txInput is an interface that provides the input data required for tx
+// generation.
+type txInput interface {
+	input.Input
+	parameters() Params
+}
+
 // inputSet is a set of inputs that can be used as the basis to generate a tx
 // on.
 type inputSet []input.Input
@@ -30,16 +36,9 @@ type inputSet []input.Input
 // contains up to the configured maximum number of inputs. Negative yield
 // inputs are skipped. No input sets with a total value after fees below the
 // dust limit are returned.
-func generateInputPartitionings(sweepableInputs []input.Input,
+func generateInputPartitionings(sweepableInputs []txInput,
 	relayFeePerKW, feePerKW chainfee.SatPerKWeight,
 	maxInputsPerTx int) ([]inputSet, error) {
-
-	// Calculate dust limit based on the P2WPKH output script of the sweep
-	// txes.
-	dustLimit := txrules.GetDustThreshold(
-		input.P2WPKHSize,
-		btcutil.Amount(relayFeePerKW.FeePerKVByte()),
-	)
 
 	// Sort input by yield. We will start constructing input sets starting
 	// with the highest yield inputs. This is to prevent the construction
@@ -75,15 +74,21 @@ func generateInputPartitionings(sweepableInputs []input.Input,
 	// Select blocks of inputs up to the configured maximum number.
 	var sets []inputSet
 	for len(sweepableInputs) > 0 {
-		// Get the maximum number of inputs from sweepableInputs that
-		// we can use to create a positive yielding set from.
-		count, outputValue := getPositiveYieldInputs(
-			sweepableInputs, maxInputsPerTx, feePerKW,
+		// Start building a set of positive-yield tx inputs under the
+		// condition that the tx will be published with the specified
+		// fee rate.
+		txInputs := newTxInputSet(
+			feePerKW, relayFeePerKW, maxInputsPerTx,
 		)
 
-		// If there are no positive yield inputs left, we can stop
-		// here.
-		if count == 0 {
+		// From the set of sweepable inputs, keep adding inputs to the
+		// input set until the tx output value no longer goes up or the
+		// maximum number of inputs is reached.
+		txInputs.addPositiveYieldInputs(sweepableInputs)
+
+		// If there are no positive yield inputs, we can stop here.
+		inputCount := len(txInputs.inputs)
+		if inputCount == 0 {
 			return sets, nil
 		}
 
@@ -91,80 +96,20 @@ func generateInputPartitionings(sweepableInputs []input.Input,
 		// the dust limit, stop sweeping. Because of the sorting,
 		// continuing with the remaining inputs will only lead to sets
 		// with a even lower output value.
-		if outputValue < dustLimit {
+		if !txInputs.dustLimitReached() {
 			log.Debugf("Set value %v below dust limit of %v",
-				outputValue, dustLimit)
+				txInputs.outputValue, txInputs.dustLimit)
 			return sets, nil
 		}
 
 		log.Infof("Candidate sweep set of size=%v, has yield=%v",
-			count, outputValue)
+			inputCount, txInputs.outputValue)
 
-		sets = append(sets, sweepableInputs[:count])
-		sweepableInputs = sweepableInputs[count:]
+		sets = append(sets, txInputs.inputs)
+		sweepableInputs = sweepableInputs[inputCount:]
 	}
 
 	return sets, nil
-}
-
-// getPositiveYieldInputs returns the maximum of a number n for which holds
-// that the inputs [0,n) of sweepableInputs have a positive yield.
-// Additionally, the total values of these inputs minus the fee is returned.
-//
-// TODO(roasbeef): Consider including some negative yield inputs too to clean
-// up the utxo set even if it costs us some fees up front.  In the spirit of
-// minimizing any negative externalities we cause for the Bitcoin system as a
-// whole.
-func getPositiveYieldInputs(sweepableInputs []input.Input, maxInputs int,
-	feePerKW chainfee.SatPerKWeight) (int, btcutil.Amount) {
-
-	var weightEstimate input.TxWeightEstimator
-
-	// Add the sweep tx output to the weight estimate.
-	weightEstimate.AddP2WKHOutput()
-
-	var total, outputValue btcutil.Amount
-	for idx, input := range sweepableInputs {
-		// Can ignore error, because it has already been checked when
-		// calculating the yields.
-		size, isNestedP2SH, _ := input.WitnessType().SizeUpperBound()
-
-		// Keep a running weight estimate of the input set.
-		if isNestedP2SH {
-			weightEstimate.AddNestedP2WSHInput(size)
-		} else {
-			weightEstimate.AddWitnessInput(size)
-		}
-
-		newTotal := total + btcutil.Amount(input.SignDesc().Output.Value)
-
-		weight := weightEstimate.Weight()
-		fee := feePerKW.FeeForWeight(int64(weight))
-
-		// Calculate the output value if the current input would be
-		// added to the set.
-		newOutputValue := newTotal - fee
-
-		// If adding this input makes the total output value of the set
-		// decrease, this is a negative yield input. It shouldn't be
-		// added to the set. We return the current index as the number
-		// of inputs, so the current input is being excluded.
-		if newOutputValue <= outputValue {
-			return idx, outputValue
-		}
-
-		// Update running values.
-		total = newTotal
-		outputValue = newOutputValue
-
-		// Stop if max inputs is reached.
-		if idx == maxInputs-1 {
-			return maxInputs, outputValue
-		}
-	}
-
-	// We could add all inputs to the set, so return them all.
-	return len(sweepableInputs), outputValue
 }
 
 // createSweepTx builds a signed tx spending the inputs to a the output script.

--- a/utxonursery.go
+++ b/utxonursery.go
@@ -201,7 +201,7 @@ type NurseryConfig struct {
 	Store NurseryStore
 
 	// Sweep sweeps an input back to the wallet.
-	SweepInput func(input.Input, sweep.FeePreference) (chan sweep.Result, error)
+	SweepInput func(input.Input, sweep.Params) (chan sweep.Result, error)
 }
 
 // utxoNursery is a system dedicated to incubating time-locked outputs created
@@ -778,7 +778,9 @@ func (u *utxoNursery) sweepMatureOutputs(classHeight uint32,
 		// passed in with disastrous consequences.
 		local := output
 
-		resultChan, err := u.cfg.SweepInput(&local, feePref)
+		resultChan, err := u.cfg.SweepInput(
+			&local, sweep.Params{Fee: feePref},
+		)
 		if err != nil {
 			return err
 		}

--- a/utxonursery_test.go
+++ b/utxonursery_test.go
@@ -983,7 +983,7 @@ func newMockSweeper(t *testing.T) *mockSweeper {
 }
 
 func (s *mockSweeper) sweepInput(input input.Input,
-	_ sweep.FeePreference) (chan sweep.Result, error) {
+	_ sweep.Params) (chan sweep.Result, error) {
 
 	utxnLog.Debugf("mockSweeper sweepInput called for %v", *input.OutPoint())
 


### PR DESCRIPTION
This PR enables the sweeper to sweep inputs that are positively-yielding, but by itself wouldn't reach the dust limit for the sweep transaction output value at the chosen fee rate.

They way to deal with this is to attach additional wallet input(s) to bring up the output value of the transaction.

This is a preparation for sweeping anchor outputs that are too small to reach the dust limit of the sweep tx output.

There are also a few commits in this PR that aren't strictly necessary for the functionality that this PR adds, but are included anyway to prevent touching the code again in the follow-up.

Next step after this PR is to add forced sweeping of negatively yielding inputs.