### PR TITLE
zpay32: ensure feature vector is always populated

### DIFF
--- a/zpay32/invoice_test.go
+++ b/zpay32/invoice_test.go
@@ -105,6 +105,8 @@ var (
 		},
 	}
 
+	emptyFeatures = lnwire.NewFeatureVector(nil, lnwire.Features)
+
 	// Must be initialized in init().
 	testDescriptionHash [32]byte
 
@@ -190,6 +192,7 @@ func TestDecodeEncode(t *testing.T) {
 					Timestamp:       time.Unix(1496314658, 0),
 					DescriptionHash: &testDescriptionHash,
 					Destination:     testPubKey,
+					Features:        emptyFeatures,
 				}
 			},
 		},
@@ -206,6 +209,7 @@ func TestDecodeEncode(t *testing.T) {
 					Description:     &testPleaseConsider,
 					DescriptionHash: &testDescriptionHash,
 					Destination:     testPubKey,
+					Features:        emptyFeatures,
 				}
 			},
 		},
@@ -220,6 +224,7 @@ func TestDecodeEncode(t *testing.T) {
 					Timestamp:   time.Unix(1496314658, 0),
 					PaymentHash: &testPaymentHash,
 					Destination: testPubKey,
+					Features:    emptyFeatures,
 				}
 			},
 		},
@@ -235,6 +240,7 @@ func TestDecodeEncode(t *testing.T) {
 					PaymentHash: &testPaymentHash,
 					Description: &testPleaseConsider,
 					Destination: testPubKey,
+					Features:    emptyFeatures,
 				}
 			},
 			skipEncoding: true, // Skip encoding since we don't have the unknown fields to encode.
@@ -251,6 +257,7 @@ func TestDecodeEncode(t *testing.T) {
 					PaymentHash:     &testPaymentHash,
 					DescriptionHash: &testDescriptionHash,
 					Destination:     testPubKey,
+					Features:        emptyFeatures,
 				}
 			},
 			skipEncoding: true, // Skip encoding since we don't have the unknown fields to encode.
@@ -267,6 +274,7 @@ func TestDecodeEncode(t *testing.T) {
 					PaymentHash:     &testPaymentHash,
 					Destination:     testPubKey,
 					DescriptionHash: &testDescriptionHash,
+					Features:        emptyFeatures,
 				}
 			},
 			skipEncoding: true, // Skip encoding since we don't have the unknown fields to encode.
@@ -282,6 +290,7 @@ func TestDecodeEncode(t *testing.T) {
 					PaymentHash: &testPaymentHash,
 					Description: &testCupOfCoffee,
 					Destination: testPubKey,
+					Features:    emptyFeatures,
 				}
 			},
 			beforeEncoding: func(i *Invoice) {
@@ -302,6 +311,7 @@ func TestDecodeEncode(t *testing.T) {
 					PaymentHash: &testPaymentHash,
 					Description: &testPleaseConsider,
 					Destination: testPubKey,
+					Features:    emptyFeatures,
 				}
 			},
 			beforeEncoding: func(i *Invoice) {
@@ -323,6 +333,7 @@ func TestDecodeEncode(t *testing.T) {
 					PaymentHash: &testPaymentHash,
 					Destination: testPubKey,
 					Description: &testEmptyString,
+					Features:    emptyFeatures,
 				}
 			},
 		},
@@ -382,6 +393,7 @@ func TestDecodeEncode(t *testing.T) {
 					PaymentHash:     &testPaymentHash,
 					DescriptionHash: &testDescriptionHash,
 					Destination:     testPubKey,
+					Features:        emptyFeatures,
 				}
 			},
 			beforeEncoding: func(i *Invoice) {
@@ -404,6 +416,7 @@ func TestDecodeEncode(t *testing.T) {
 					DescriptionHash: &testDescriptionHash,
 					Destination:     testPubKey,
 					FallbackAddr:    testAddrTestnet,
+					Features:        emptyFeatures,
 				}
 			},
 			beforeEncoding: func(i *Invoice) {
@@ -427,6 +440,7 @@ func TestDecodeEncode(t *testing.T) {
 					Destination:     testPubKey,
 					FallbackAddr:    testRustyAddr,
 					RouteHints:      [][]HopHint{testSingleHop},
+					Features:        emptyFeatures,
 				}
 			},
 			beforeEncoding: func(i *Invoice) {
@@ -450,6 +464,7 @@ func TestDecodeEncode(t *testing.T) {
 					Destination:     testPubKey,
 					FallbackAddr:    testRustyAddr,
 					RouteHints:      [][]HopHint{testDoubleHop},
+					Features:        emptyFeatures,
 				}
 			},
 			beforeEncoding: func(i *Invoice) {
@@ -472,6 +487,7 @@ func TestDecodeEncode(t *testing.T) {
 					DescriptionHash: &testDescriptionHash,
 					Destination:     testPubKey,
 					FallbackAddr:    testAddrMainnetP2SH,
+					Features:        emptyFeatures,
 				}
 			},
 			beforeEncoding: func(i *Invoice) {
@@ -547,6 +563,7 @@ func TestDecodeEncode(t *testing.T) {
 					DescriptionHash: &testDescriptionHash,
 					Destination:     testPubKey,
 					FallbackAddr:    testAddrMainnetP2WPKH,
+					Features:        emptyFeatures,
 				}
 			},
 			beforeEncoding: func(i *Invoice) {
@@ -569,6 +586,7 @@ func TestDecodeEncode(t *testing.T) {
 					DescriptionHash: &testDescriptionHash,
 					Destination:     testPubKey,
 					FallbackAddr:    testAddrMainnetP2WSH,
+					Features:        emptyFeatures,
 				}
 			},
 			beforeEncoding: func(i *Invoice) {
@@ -628,6 +646,7 @@ func TestDecodeEncode(t *testing.T) {
 					PaymentHash: &testPaymentHash,
 					Destination: testPubKey,
 					Description: &testEmptyString,
+					Features:    emptyFeatures,
 				}
 			},
 			skipEncoding: true, // Skip encoding since we were given the wrong net
@@ -645,6 +664,7 @@ func TestDecodeEncode(t *testing.T) {
 					PaymentHash:     &testPaymentHash,
 					DescriptionHash: &testDescriptionHash,
 					Destination:     testPubKey,
+					Features:        emptyFeatures,
 				}
 			},
 		},
@@ -660,6 +680,7 @@ func TestDecodeEncode(t *testing.T) {
 					PaymentHash:     &testPaymentHash,
 					DescriptionHash: &testDescriptionHash,
 					Destination:     testPubKey,
+					Features:        emptyFeatures,
 				}
 			},
 		},
@@ -983,7 +1004,7 @@ func compareInvoices(expected, actual *Invoice) error {
 
 	if !reflect.DeepEqual(expected.Features, actual.Features) {
 		return fmt.Errorf("expected features %v, got %v",
-			expected.Features.RawFeatureVector, actual.Features.RawFeatureVector)
+			expected.Features, actual.Features)
 	}
 
 	return nil


### PR DESCRIPTION
Fixes #3823, this is split out from #3679 so that this can be fixed faster in master.