### PR TITLE
WIP: Add internal error for internal errors

### DIFF
--- a/htlcswitch/failures.go
+++ b/htlcswitch/failures.go
@@ -1,0 +1,104 @@
+package htlcswitch
+
+import (
+	"fmt"
+
+	"github.com/lightningnetwork/lnd/lntypes"
+	"github.com/lightningnetwork/lnd/lnwire"
+)
+
+var _ SwitchError = (*SwitchErrorWrapWire)(nil)
+
+// SwitchErrorWrapWire directly wraps a wire message in a SwitchError with
+// no metadata.
+type SwitchErrorWrapWire struct {
+	Msg lnwire.FailureMessage
+}
+
+func (sf *SwitchErrorWrapWire) GetWireFailure() lnwire.FailureMessage {
+	return sf.Msg
+}
+
+func (sf *SwitchErrorWrapWire) Error() string {
+	return sf.Msg.Error()
+}
+
+// newSwitchError returns a SwitchError which wraps a wire message without
+// metadata.
+func newSwitchError(msg lnwire.FailureMessage) SwitchError {
+	return &SwitchErrorWrapWire{Msg: msg}
+}
+
+// getWrappedWireMessage is a helper function which creates a wire failure that
+// contains a channel update.
+func getWrappedWireMessage(getUpdate updateFunction,
+	wrap wrapUpdate) lnwire.FailureMessage {
+
+	update, err := getUpdate()
+	if err != nil {
+		return &lnwire.FailTemporaryNodeFailure{}
+	}
+	return wrap(update)
+}
+
+// SwitchErrorOnChainTimeout is used when a payment times out on chain
+// and is cancelled back.
+type SwitchErrorOnChainTimeout struct {
+	paymentHash lntypes.Hash
+	paymentID   uint64
+}
+
+func (sf *SwitchErrorOnChainTimeout) GetWireFailure() lnwire.FailureMessage {
+	return &lnwire.FailPermanentChannelFailure{}
+}
+
+func (sf *SwitchErrorOnChainTimeout) Error() string {
+	return sf.GetWireFailure().Error()
+}
+
+// updateFunction is a function that returns an update for a channel.
+type updateFunction func() (*lnwire.ChannelUpdate, error)
+
+// wrapUpdate wraps a channel update in a wire message. It is used to produce
+// wire messages that contain channel upates.
+type wrapUpdate func(update *lnwire.ChannelUpdate) lnwire.FailureMessage
+
+// wrapTempChannel is a wrapUpdate function which is commonly used,
+// declared here for brevity.
+var wrapTempChannel = func(update *lnwire.ChannelUpdate) lnwire.FailureMessage {
+	return lnwire.NewTemporaryChannelFailure(update)
+}
+
+// SwitchErrorOnionDecode is used when we cannot decode an onion
+// failure.
+type SwitchErrorOnionDecode struct {
+	paymentHash lntypes.Hash
+	paymentID   uint64
+	err         error
+	update      *lnwire.ChannelUpdate
+}
+
+func (sf *SwitchErrorOnionDecode) GetWireFailure() lnwire.FailureMessage {
+	return wrapTempChannel(sf.update)
+}
+
+func (sf *SwitchErrorOnionDecode) Error() string {
+	return fmt.Sprintf("unable to decode onion failure "+
+		"(hash=%v, pid=%d): %v", sf.paymentHash, sf.paymentID, sf.err)
+}
+
+// SwitchFailureLinkNotEligible is used when a link is not eligible for
+// forwarding.
+type SwitchFailureLinkNotEligible struct {
+	channelID lnwire.ShortChannelID
+	update    updateFunction
+}
+
+func (sf *SwitchFailureLinkNotEligible) GetWireFailure() lnwire.FailureMessage {
+	return getWrappedWireMessage(sf.update, wrapTempChannel)
+}
+
+func (sf *SwitchFailureLinkNotEligible) Error() string {
+	return fmt.Sprintf("link %v is not available to forward",
+		sf.channelID)
+}

--- a/htlcswitch/link_test.go
+++ b/htlcswitch/link_test.go
@@ -574,9 +574,9 @@ func TestExitNodeTimelockPayloadMismatch(t *testing.T) {
 		t.Fatalf("payment should have failed but didn't")
 	}
 
-	ferr, ok := err.(*ForwardingError)
+	ferr, ok := err.(*SwitchError)
 	if !ok {
-		t.Fatalf("expected a ForwardingError, instead got: %T", err)
+		t.Fatalf("expected a SwitchError, instead got: %T", err)
 	}
 
 	switch ferr.FailureMessage.(type) {
@@ -674,9 +674,9 @@ func TestLinkForwardTimelockPolicyMismatch(t *testing.T) {
 		t.Fatalf("payment should have failed but didn't")
 	}
 
-	ferr, ok := err.(*ForwardingError)
+	ferr, ok := err.(*SwitchError)
 	if !ok {
-		t.Fatalf("expected a ForwardingError, instead got: %T", err)
+		t.Fatalf("expected a SwitchError, instead got: %T", err)
 	}
 
 	switch ferr.FailureMessage.(type) {
@@ -732,9 +732,9 @@ func TestLinkForwardFeePolicyMismatch(t *testing.T) {
 		t.Fatalf("payment should have failed but didn't")
 	}
 
-	ferr, ok := err.(*ForwardingError)
+	ferr, ok := err.(*SwitchError)
 	if !ok {
-		t.Fatalf("expected a ForwardingError, instead got: %T", err)
+		t.Fatalf("expected a SwitchError, instead got: %T", err)
 	}
 
 	switch ferr.FailureMessage.(type) {
@@ -790,9 +790,9 @@ func TestLinkForwardMinHTLCPolicyMismatch(t *testing.T) {
 		t.Fatalf("payment should have failed but didn't")
 	}
 
-	ferr, ok := err.(*ForwardingError)
+	ferr, ok := err.(*SwitchError)
 	if !ok {
-		t.Fatalf("expected a ForwardingError, instead got: %T", err)
+		t.Fatalf("expected a SwitchError, instead got: %T", err)
 	}
 
 	switch ferr.FailureMessage.(type) {
@@ -857,9 +857,9 @@ func TestLinkForwardMaxHTLCPolicyMismatch(t *testing.T) {
 		t.Fatalf("payment should have failed but didn't")
 	}
 
-	ferr, ok := err.(*ForwardingError)
+	ferr, ok := err.(*SwitchError)
 	if !ok {
-		t.Fatalf("expected a ForwardingError, instead got: %T", err)
+		t.Fatalf("expected a SwitchError, instead got: %T", err)
 	}
 
 	switch ferr.FailureMessage.(type) {
@@ -964,9 +964,9 @@ func TestUpdateForwardingPolicy(t *testing.T) {
 		t.Fatalf("payment should've been rejected")
 	}
 
-	ferr, ok := err.(*ForwardingError)
+	ferr, ok := err.(*SwitchError)
 	if !ok {
-		t.Fatalf("expected a ForwardingError, instead got (%T): %v", err, err)
+		t.Fatalf("expected a SwitchError, instead got (%T): %v", err, err)
 	}
 	switch ferr.FailureMessage.(type) {
 	case *lnwire.FailFeeInsufficient:
@@ -1003,9 +1003,9 @@ func TestUpdateForwardingPolicy(t *testing.T) {
 		t.Fatalf("payment should've been rejected")
 	}
 
-	ferr, ok = err.(*ForwardingError)
+	ferr, ok = err.(*SwitchError)
 	if !ok {
-		t.Fatalf("expected a ForwardingError, instead got (%T): %v",
+		t.Fatalf("expected a SwitchError, instead got (%T): %v",
 			err, err)
 	}
 	switch ferr.FailureMessage.(type) {
@@ -1249,9 +1249,9 @@ func TestChannelLinkMultiHopUnknownNextHop(t *testing.T) {
 	if err == nil {
 		t.Fatal("error haven't been received")
 	}
-	fErr, ok := err.(*ForwardingError)
+	fErr, ok := err.(*SwitchError)
 	if !ok {
-		t.Fatalf("expected ForwardingError")
+		t.Fatalf("expected SwitchError")
 	}
 	if _, ok = fErr.FailureMessage.(*lnwire.FailUnknownNextPeer); !ok {
 		t.Fatalf("wrong error has been received: %T",
@@ -1364,9 +1364,9 @@ func TestChannelLinkMultiHopDecodeError(t *testing.T) {
 		t.Fatal("error haven't been received")
 	}
 
-	ferr, ok := err.(*ForwardingError)
+	ferr, ok := err.(*SwitchError)
 	if !ok {
-		t.Fatalf("expected a ForwardingError, instead got: %T", err)
+		t.Fatalf("expected a SwitchError, instead got: %T", err)
 	}
 
 	switch ferr.FailureMessage.(type) {
@@ -1456,9 +1456,9 @@ func TestChannelLinkExpiryTooSoonExitNode(t *testing.T) {
 			"time lock value")
 	}
 
-	ferr, ok := err.(*ForwardingError)
+	ferr, ok := err.(*SwitchError)
 	if !ok {
-		t.Fatalf("expected a ForwardingError, instead got: %T %v",
+		t.Fatalf("expected a SwitchError, instead got: %T %v",
 			err, err)
 	}
 
@@ -1519,9 +1519,9 @@ func TestChannelLinkExpiryTooSoonMidNode(t *testing.T) {
 			"time lock value")
 	}
 
-	ferr, ok := err.(*ForwardingError)
+	ferr, ok := err.(*SwitchError)
 	if !ok {
-		t.Fatalf("expected a ForwardingError, instead got: %T: %v", err, err)
+		t.Fatalf("expected a SwitchError, instead got: %T: %v", err, err)
 	}
 
 	switch ferr.FailureMessage.(type) {
@@ -5632,9 +5632,9 @@ func TestChannelLinkCanceledInvoice(t *testing.T) {
 
 	// Because the invoice is canceled, we expect an unknown payment hash
 	// result.
-	fErr, ok := err.(*ForwardingError)
+	fErr, ok := err.(*SwitchError)
 	if !ok {
-		t.Fatalf("expected ForwardingError, but got %v", err)
+		t.Fatalf("expected SwitchError, but got %v", err)
 	}
 	_, ok = fErr.FailureMessage.(*lnwire.FailIncorrectDetails)
 	if !ok {
@@ -6213,12 +6213,12 @@ func TestChannelLinkReceiveEmptySig(t *testing.T) {
 	aliceLink.Stop()
 }
 
-// assertFailureCode asserts that an error is of type ForwardingError and that
+// assertFailureCode asserts that an error is of type SwitchError and that
 // the failure code is as expected.
 func assertFailureCode(t *testing.T, err error, code lnwire.FailCode) {
-	fErr, ok := err.(*ForwardingError)
+	fErr, ok := err.(*SwitchError)
 	if !ok {
-		t.Fatalf("expected ForwardingError but got %T", err)
+		t.Fatalf("expected SwitchError but got %T", err)
 	}
 
 	if fErr.FailureMessage.Code() != code {

--- a/htlcswitch/mock.go
+++ b/htlcswitch/mock.go
@@ -391,7 +391,7 @@ func newMockDeobfuscator() ErrorDecrypter {
 	return &mockDeobfuscator{}
 }
 
-func (o *mockDeobfuscator) DecryptError(reason lnwire.OpaqueReason) (*ForwardingError, error) {
+func (o *mockDeobfuscator) DecryptError(reason lnwire.OpaqueReason) (SwitchError, error) {
 
 	r := bytes.NewReader(reason)
 	failure, err := lnwire.DecodeFailure(r, 0)
@@ -401,7 +401,7 @@ func (o *mockDeobfuscator) DecryptError(reason lnwire.OpaqueReason) (*Forwarding
 
 	return &ForwardingError{
 		FailureSourceIdx: 1,
-		FailureMessage:   failure,
+		SwitchError:      newSwitchError(failure),
 	}, nil
 }
 

--- a/htlcswitch/payment_result.go
+++ b/htlcswitch/payment_result.go
@@ -37,7 +37,7 @@ type PaymentResult struct {
 
 	// Error is non-nil in case a HTLC send failed, and the HTLC is now
 	// irrevocably canceled. If the payment failed during forwarding, this
-	// error will be a *ForwardingError.
+	// error will be a SwitchError.
 	Error error
 }
 

--- a/htlcswitch/switch_test.go
+++ b/htlcswitch/switch_test.go
@@ -2178,7 +2178,7 @@ func TestUpdateFailMalformedHTLCErrorConversion(t *testing.T) {
 			t.Fatalf("unable to send payment: %v", err)
 		}
 
-		fwdingErr := err.(*ForwardingError)
+		fwdingErr := err.(*SwitchError)
 		failureMsg := fwdingErr.FailureMessage
 		if _, ok := failureMsg.(*lnwire.FailInvalidOnionKey); !ok {
 			t.Fatalf("expected onion failure instead got: %v",
@@ -2441,9 +2441,9 @@ func TestInvalidFailure(t *testing.T) {
 
 	select {
 	case result := <-resultChan:
-		fErr, ok := result.Error.(*ForwardingError)
+		fErr, ok := result.Error.(*SwitchError)
 		if !ok {
-			t.Fatal("expected ForwardingError")
+			t.Fatal("expected SwitchError")
 		}
 		if fErr.FailureSourceIdx != 2 {
 			t.Fatal("unexpected error source index")

--- a/lnrpc/routerrpc/router_server.go
+++ b/lnrpc/routerrpc/router_server.go
@@ -326,12 +326,13 @@ func marshallError(sendError error) (*Failure, error) {
 		return response, nil
 	}
 
+	// TODO(carla): check this.
 	fErr, ok := sendError.(*htlcswitch.ForwardingError)
 	if !ok {
 		return nil, sendError
 	}
 
-	switch onionErr := fErr.FailureMessage.(type) {
+	switch onionErr := fErr.GetWireFailure().(type) {
 
 	case *lnwire.FailIncorrectDetails:
 		response.Code = Failure_INCORRECT_OR_UNKNOWN_PAYMENT_DETAILS

--- a/routing/mock_test.go
+++ b/routing/mock_test.go
@@ -35,7 +35,7 @@ func (m *mockPaymentAttemptDispatcher) SendHTLC(firstHop lnwire.ShortChannelID,
 	var result *htlcswitch.PaymentResult
 	preimage, err := m.onPayment(firstHop)
 	if err != nil {
-		fwdErr, ok := err.(*htlcswitch.ForwardingError)
+		fwdErr, ok := err.(*htlcswitch.SwitchError)
 		if !ok {
 			return err
 		}

--- a/routing/router.go
+++ b/routing/router.go
@@ -1899,12 +1899,13 @@ func (r *ChannelRouter) processSendError(paymentID uint64, rt *route.Route,
 	}
 	// If an internal, non-forwarding error occurred, we can stop
 	// trying.
+	// TODO(carla): check up on where forwarding errors were previously used.
 	fErr, ok := sendErr.(*htlcswitch.ForwardingError)
 	if !ok {
 		return &internalErrorReason
 	}
 
-	failureMessage := fErr.FailureMessage
+	failureMessage := fErr.GetWireFailure()
 	failureSourceIdx := fErr.FailureSourceIdx
 
 	// Apply channel update if the error contains one. For unknown

--- a/routing/router_test.go
+++ b/routing/router_test.go
@@ -288,7 +288,7 @@ func TestSendPaymentRouteFailureFallback(t *testing.T) {
 
 			roasbeefSongoku := lnwire.NewShortChanIDFromInt(12345)
 			if firstHop == roasbeefSongoku {
-				return [32]byte{}, &htlcswitch.ForwardingError{
+				return [32]byte{}, &htlcswitch.SwitchError{
 					FailureSourceIdx: 1,
 					// TODO(roasbeef): temp node failure should be?
 					FailureMessage: &lnwire.FailTemporaryChannelFailure{},
@@ -420,7 +420,7 @@ func TestChannelUpdateValidation(t *testing.T) {
 	// The unsigned channel update is attached to the failure message.
 	ctx.router.cfg.Payer.(*mockPaymentAttemptDispatcher).setPaymentResult(
 		func(firstHop lnwire.ShortChannelID) ([32]byte, error) {
-			return [32]byte{}, &htlcswitch.ForwardingError{
+			return [32]byte{}, &htlcswitch.SwitchError{
 				FailureSourceIdx: 1,
 				FailureMessage: &lnwire.FailFeeInsufficient{
 					Update: errChanUpdate,
@@ -542,7 +542,7 @@ func TestSendPaymentErrorRepeatedFeeInsufficient(t *testing.T) {
 
 			roasbeefSongoku := lnwire.NewShortChanIDFromInt(chanID)
 			if firstHop == roasbeefSongoku {
-				return [32]byte{}, &htlcswitch.ForwardingError{
+				return [32]byte{}, &htlcswitch.SwitchError{
 					FailureSourceIdx: 1,
 
 					// Within our error, we'll add a channel update
@@ -646,7 +646,7 @@ func TestSendPaymentErrorNonFinalTimeLockErrors(t *testing.T) {
 		func(firstHop lnwire.ShortChannelID) ([32]byte, error) {
 
 			if firstHop == roasbeefSongoku {
-				return [32]byte{}, &htlcswitch.ForwardingError{
+				return [32]byte{}, &htlcswitch.SwitchError{
 					FailureSourceIdx: 1,
 					FailureMessage: &lnwire.FailExpiryTooSoon{
 						Update: errChanUpdate,
@@ -700,7 +700,7 @@ func TestSendPaymentErrorNonFinalTimeLockErrors(t *testing.T) {
 		func(firstHop lnwire.ShortChannelID) ([32]byte, error) {
 
 			if firstHop == roasbeefSongoku {
-				return [32]byte{}, &htlcswitch.ForwardingError{
+				return [32]byte{}, &htlcswitch.SwitchError{
 					FailureSourceIdx: 1,
 					FailureMessage: &lnwire.FailIncorrectCltvExpiry{
 						Update: errChanUpdate,
@@ -724,7 +724,7 @@ func TestSendPaymentErrorNonFinalTimeLockErrors(t *testing.T) {
 }
 
 // TestSendPaymentErrorPathPruning tests that the send of candidate routes
-// properly gets pruned in response to ForwardingError response from the
+// properly gets pruned in response to SwitchError response from the
 // underlying SendToSwitch function.
 func TestSendPaymentErrorPathPruning(t *testing.T) {
 	t.Parallel()
@@ -763,7 +763,7 @@ func TestSendPaymentErrorPathPruning(t *testing.T) {
 				// We'll first simulate an error from the first
 				// hop to simulate the channel from songoku to
 				// sophon not having enough capacity.
-				return [32]byte{}, &htlcswitch.ForwardingError{
+				return [32]byte{}, &htlcswitch.SwitchError{
 					FailureSourceIdx: 1,
 					FailureMessage:   &lnwire.FailTemporaryChannelFailure{},
 				}
@@ -773,7 +773,7 @@ func TestSendPaymentErrorPathPruning(t *testing.T) {
 			// indicate that the sophon node is not longer online,
 			// which should prune out the rest of the routes.
 			if firstHop == roasbeefPhanNuwen {
-				return [32]byte{}, &htlcswitch.ForwardingError{
+				return [32]byte{}, &htlcswitch.SwitchError{
 					FailureSourceIdx: 1,
 					FailureMessage:   &lnwire.FailUnknownNextPeer{},
 				}
@@ -805,7 +805,7 @@ func TestSendPaymentErrorPathPruning(t *testing.T) {
 		func(firstHop lnwire.ShortChannelID) ([32]byte, error) {
 
 			if firstHop == roasbeefSongoku {
-				return [32]byte{}, &htlcswitch.ForwardingError{
+				return [32]byte{}, &htlcswitch.SwitchError{
 					FailureSourceIdx: 1,
 					FailureMessage:   &lnwire.FailUnknownNextPeer{},
 				}
@@ -851,7 +851,7 @@ func TestSendPaymentErrorPathPruning(t *testing.T) {
 				// We'll first simulate an error from the first
 				// outgoing link to simulate the channel from luo ji to
 				// roasbeef not having enough capacity.
-				return [32]byte{}, &htlcswitch.ForwardingError{
+				return [32]byte{}, &htlcswitch.SwitchError{
 					FailureSourceIdx: 1,
 					FailureMessage:   &lnwire.FailTemporaryChannelFailure{},
 				}
@@ -2539,7 +2539,7 @@ func TestUnknownErrorSource(t *testing.T) {
 			// couldn't be decoded (FailureMessage is nil).
 			if firstHop.ToUint64() == 2 {
 				return [32]byte{},
-					&htlcswitch.ForwardingError{
+					&htlcswitch.SwitchError{
 						FailureSourceIdx: 1,
 					}
 			}
@@ -3105,7 +3105,7 @@ func TestRouterPaymentStateMachine(t *testing.T) {
 			// called, and we respond with a forwarding error
 			case sendToSwitchResultFailure:
 				select {
-				case sendResult <- &htlcswitch.ForwardingError{
+				case sendResult <- &htlcswitch.SwitchError{
 					FailureSourceIdx: 1,
 					FailureMessage:   &lnwire.FailTemporaryChannelFailure{},
 				}:
@@ -3131,7 +3131,7 @@ func TestRouterPaymentStateMachine(t *testing.T) {
 			case getPaymentResultFailure:
 				select {
 				case getPaymentResult <- &htlcswitch.PaymentResult{
-					Error: &htlcswitch.ForwardingError{
+					Error: &htlcswitch.SwitchError{
 						FailureSourceIdx: 1,
 						FailureMessage:   &lnwire.FailTemporaryChannelFailure{},
 					},
@@ -3302,7 +3302,7 @@ func TestSendToRouteStructuredError(t *testing.T) {
 	// The unsigned channel update is attached to the failure message.
 	ctx.router.cfg.Payer.(*mockPaymentAttemptDispatcher).setPaymentResult(
 		func(firstHop lnwire.ShortChannelID) ([32]byte, error) {
-			return [32]byte{}, &htlcswitch.ForwardingError{
+			return [32]byte{}, &htlcswitch.SwitchError{
 				FailureSourceIdx: 1,
 				FailureMessage: &lnwire.FailFeeInsufficient{
 					Update: lnwire.ChannelUpdate{},
@@ -3319,7 +3319,7 @@ func TestSendToRouteStructuredError(t *testing.T) {
 	// router and ignored because it is missing a valid signature.
 	_, err = ctx.router.SendToRoute(payment, rt)
 
-	fErr, ok := err.(*htlcswitch.ForwardingError)
+	fErr, ok := err.(*htlcswitch.SwitchError)
 	if !ok {
 		t.Fatalf("expected forwarding error")
 	}


### PR DESCRIPTION
This PR is a PoC for adding a `SwitchError` interface to `htlcSwitch` which wraps wire messages with additional metadata. 

The goals of adding this error are:
1. To enrich failures with metadata for HTLCNotifier/ other systems which require more detailed failures
2. To prevent bugs sneaking in with the current `ForwardingError` type which embeds the  `lnwire.FailureMessage` struct but obscures the wire messages implementaions of the `lnwire.Serializable` interface because it is not implemented on `ForwardingError`. 
  -> Other solutions would be to implement `lnwire.Serializable` on `ForwardingError` or specifically unwrap wire `FailureMessages`when leaving the switch