### PR TITLE
channeldb: custom records sanity check

### DIFF
--- a/channeldb/payments.go
+++ b/channeldb/payments.go
@@ -607,6 +607,15 @@ func serializeHop(w io.Writer, h *route.Hop) error {
 		records = append(records, h.MPP.Record())
 	}
 
+	// Final sanity check to absolutely rule out custom records that are not
+	// custom and write into the standard range.
+	if err := h.CustomRecords.Validate(); err != nil {
+		return err
+	}
+
+	// Convert custom records to tlv and add to the record list.
+	// MapToRecords sorts the list, so adding it here will keep the list
+	// canonical.
 	tlvRecords := tlv.MapToRecords(h.CustomRecords)
 	records = append(records, tlvRecords...)
 

--- a/channeldb/payments_test.go
+++ b/channeldb/payments_test.go
@@ -28,8 +28,8 @@ var (
 		OutgoingTimeLock: 111,
 		AmtToForward:     555,
 		CustomRecords: record.CustomSet{
-			1: []byte{},
-			2: []byte{},
+			65536: []byte{},
+			80001: []byte{},
 		},
 		MPP: record.NewMPP(32, [32]byte{0x42}),
 	}

--- a/record/custom_records.go
+++ b/record/custom_records.go
@@ -1,5 +1,7 @@
 package record
 
+import "fmt"
+
 const (
 	// CustomTypeStart is the start of the custom tlv type range as defined
 	// in BOLT 01.
@@ -8,3 +10,15 @@ const (
 
 // CustomSet stores a set of custom key/value pairs.
 type CustomSet map[uint64][]byte
+
+// Validate checks that all custom records are in the custom type range.
+func (c CustomSet) Validate() error {
+	for key := range c {
+		if key < CustomTypeStart {
+			return fmt.Errorf("no custom records with types "+
+				"below %v allowed", CustomTypeStart)
+		}
+	}
+
+	return nil
+}

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -3162,13 +3162,11 @@ func (r *rpcServer) extractPaymentIntent(rpcPayReq *rpcPaymentRequest) (rpcPayme
 	}
 	payIntent.cltvLimit = cltvLimit
 
-	err = routerrpc.ValidateCustomRecords(
-		rpcPayReq.DestCustomRecords,
-	)
-	if err != nil {
+	customRecords := record.CustomSet(rpcPayReq.DestCustomRecords)
+	if err := customRecords.Validate(); err != nil {
 		return payIntent, err
 	}
-	payIntent.destCustomRecords = rpcPayReq.DestCustomRecords
+	payIntent.destCustomRecords = customRecords
 
 	validateDest := func(dest route.Vertex) error {
 		if rpcPayReq.AllowSelfPayment {


### PR DESCRIPTION
This PR adds a sanity check right before serializing the custom records hop data. It should never happen that this check fails because we check custom records at every entry point. Only because the consequences of a bad record slipping through could be bad, we think that a sanity check here is justified.