### PR TITLE
feature: add transitive feature bit validation

### DIFF
--- a/feature/deps.go
+++ b/feature/deps.go
@@ -1,0 +1,124 @@
+package feature
+
+import (
+	"fmt"
+
+	"github.com/lightningnetwork/lnd/lnwire"
+)
+
+type (
+	// featureSet contains a set of feature bits.
+	featureSet map[lnwire.FeatureBit]struct{}
+
+	// supportedFeatures maps the feature bit from a feature vector to a
+	// boolean indicating if this features dependencies have already been
+	// verified. This allows us to short circuit verification if multiple
+	// features have common dependencies, or map traversal starts verifying
+	// from the bottom up.
+	supportedFeatures map[lnwire.FeatureBit]bool
+
+	// depDesc maps a features to its set of dependent features, which must
+	// also be present for the vector to be valid. This can be used to
+	// recursively check the dependency chain for features in a feature
+	// vector.
+	depDesc map[lnwire.FeatureBit]featureSet
+)
+
+// ErrMissingFeatureDep is an error signaling that a transitive dependency in a
+// feature vector is not set properly.
+type ErrMissingFeatureDep struct {
+	dep lnwire.FeatureBit
+}
+
+// Error returns a human-readable description of the missing dep error.
+func (e ErrMissingFeatureDep) Error() string {
+	return fmt.Sprintf("missing feature dependency: %v", e.dep)
+}
+
+// deps is the default set of dependencies for assigned feature bits. If a
+// feature is not present in the depDesc it is assumed to have no dependencies.
+//
+// NOTE: For proper functioning, only the optional variant of feature bits
+// should be used in the following descriptor. In the future it may be necessary
+// to distinguish the dependencies for optional and required bits, but for now
+// the validation code maps required bits to optional ones since it simplifies
+// the number of constraints.
+var deps = depDesc{
+	lnwire.PaymentAddrOptional: {
+		lnwire.TLVOnionPayloadOptional: {},
+	},
+	lnwire.MPPOptional: {
+		lnwire.PaymentAddrOptional: {},
+	},
+}
+
+// ValidateDeps asserts that a feature vector sets all features and their
+// transitive dependencies properly. It assumes that the dependencies between
+// optional and required features are identical, e.g. if a feature is required
+// but its dependency is optional, that is sufficient.
+func ValidateDeps(fv *lnwire.FeatureVector) error {
+	features := fv.Features()
+	supported := initSupported(features)
+
+	return validateDeps(features, supported)
+}
+
+// validateDeps is a subroutine that recursively checks that the passed features
+// have all of their associated dependencies in the supported map.
+func validateDeps(features featureSet, supported supportedFeatures) error {
+	for bit := range features {
+		// Convert any required bits to optional.
+		bit = mapToOptional(bit)
+
+		// If the supported features doesn't contain the dependency, this
+		// vector is invalid.
+		checked, ok := supported[bit]
+		if !ok {
+			return ErrMissingFeatureDep{bit}
+		}
+
+		// Alternatively, if we know that this depdendency is valid, we
+		// can short circuit and continue verifying other bits.
+		if checked {
+			continue
+		}
+
+		// Recursively validate dependencies, since this method ranges
+		// over the subDeps. This method will return true even if
+		// subDeps is nil.
+		subDeps := deps[bit]
+		if err := validateDeps(subDeps, supported); err != nil {
+			return err
+		}
+
+		// Once we've confirmed that this feature's dependencies, if
+		// any, are sound, we record this so other paths taken through
+		// `bit` return early when inspecting the supported map.
+		supported[bit] = true
+	}
+
+	return nil
+}
+
+// initSupported sets all bits from the feature vector as supported but not
+// checked. This signals that the validity of their dependencies has not been
+// verified. All required bits are mapped to optional to simplify the DAG.
+func initSupported(features featureSet) supportedFeatures {
+	supported := make(supportedFeatures)
+	for bit := range features {
+		bit = mapToOptional(bit)
+		supported[bit] = false
+	}
+
+	return supported
+}
+
+// mapToOptional returns the optional variant of a given feature bit pair. Our
+// dependendency graph is described using only optional feature bits, which
+// reduces the number of constraints we need to express in the descriptor.
+func mapToOptional(bit lnwire.FeatureBit) lnwire.FeatureBit {
+	if bit.IsRequired() {
+		bit ^= 0x01
+	}
+	return bit
+}

--- a/feature/deps_test.go
+++ b/feature/deps_test.go
@@ -1,0 +1,167 @@
+package feature
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/lightningnetwork/lnd/lnwire"
+)
+
+type depTest struct {
+	name   string
+	raw    *lnwire.RawFeatureVector
+	expErr error
+}
+
+var depTests = []depTest{
+	{
+		name: "empty",
+		raw:  lnwire.NewRawFeatureVector(),
+	},
+	{
+		name: "no deps optional",
+		raw: lnwire.NewRawFeatureVector(
+			lnwire.GossipQueriesOptional,
+		),
+	},
+	{
+		name: "no deps required",
+		raw: lnwire.NewRawFeatureVector(
+			lnwire.TLVOnionPayloadRequired,
+		),
+	},
+	{
+		name: "one dep optional",
+		raw: lnwire.NewRawFeatureVector(
+			lnwire.TLVOnionPayloadOptional,
+			lnwire.PaymentAddrOptional,
+		),
+	},
+	{
+		name: "one dep required",
+		raw: lnwire.NewRawFeatureVector(
+			lnwire.TLVOnionPayloadRequired,
+			lnwire.PaymentAddrRequired,
+		),
+	},
+	{
+		name: "one missing optional",
+		raw: lnwire.NewRawFeatureVector(
+			lnwire.PaymentAddrOptional,
+		),
+		expErr: ErrMissingFeatureDep{lnwire.TLVOnionPayloadOptional},
+	},
+	{
+		name: "one missing required",
+		raw: lnwire.NewRawFeatureVector(
+			lnwire.PaymentAddrRequired,
+		),
+		expErr: ErrMissingFeatureDep{lnwire.TLVOnionPayloadOptional},
+	},
+	{
+		name: "two dep optional",
+		raw: lnwire.NewRawFeatureVector(
+			lnwire.TLVOnionPayloadOptional,
+			lnwire.PaymentAddrOptional,
+			lnwire.MPPOptional,
+		),
+	},
+	{
+		name: "two dep required",
+		raw: lnwire.NewRawFeatureVector(
+			lnwire.TLVOnionPayloadRequired,
+			lnwire.PaymentAddrRequired,
+			lnwire.MPPRequired,
+		),
+	},
+	{
+		name: "two dep last missing optional",
+		raw: lnwire.NewRawFeatureVector(
+			lnwire.PaymentAddrOptional,
+			lnwire.MPPOptional,
+		),
+		expErr: ErrMissingFeatureDep{lnwire.TLVOnionPayloadOptional},
+	},
+	{
+		name: "two dep last missing required",
+		raw: lnwire.NewRawFeatureVector(
+			lnwire.PaymentAddrRequired,
+			lnwire.MPPRequired,
+		),
+		expErr: ErrMissingFeatureDep{lnwire.TLVOnionPayloadOptional},
+	},
+	{
+		name: "two dep first missing optional",
+		raw: lnwire.NewRawFeatureVector(
+			lnwire.TLVOnionPayloadOptional,
+			lnwire.MPPOptional,
+		),
+		expErr: ErrMissingFeatureDep{lnwire.PaymentAddrOptional},
+	},
+	{
+		name: "two dep first missing required",
+		raw: lnwire.NewRawFeatureVector(
+			lnwire.TLVOnionPayloadRequired,
+			lnwire.MPPRequired,
+		),
+		expErr: ErrMissingFeatureDep{lnwire.PaymentAddrOptional},
+	},
+	{
+		name: "forest optional",
+		raw: lnwire.NewRawFeatureVector(
+			lnwire.GossipQueriesOptional,
+			lnwire.TLVOnionPayloadOptional,
+			lnwire.PaymentAddrOptional,
+			lnwire.MPPOptional,
+		),
+	},
+	{
+		name: "forest required",
+		raw: lnwire.NewRawFeatureVector(
+			lnwire.GossipQueriesRequired,
+			lnwire.TLVOnionPayloadRequired,
+			lnwire.PaymentAddrRequired,
+			lnwire.MPPRequired,
+		),
+	},
+	{
+		name: "broken forest optional",
+		raw: lnwire.NewRawFeatureVector(
+			lnwire.GossipQueriesOptional,
+			lnwire.TLVOnionPayloadOptional,
+			lnwire.MPPOptional,
+		),
+		expErr: ErrMissingFeatureDep{lnwire.PaymentAddrOptional},
+	},
+	{
+		name: "broken forest required",
+		raw: lnwire.NewRawFeatureVector(
+			lnwire.GossipQueriesRequired,
+			lnwire.TLVOnionPayloadRequired,
+			lnwire.MPPRequired,
+		),
+		expErr: ErrMissingFeatureDep{lnwire.PaymentAddrOptional},
+	},
+}
+
+// TestValidateDeps tests that ValidateDeps correctly asserts whether or not the
+// set features constitute a valid feature chain when accounting for transititve
+// dependencies.
+func TestValidateDeps(t *testing.T) {
+	for _, test := range depTests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			testValidateDeps(t, test)
+		})
+	}
+}
+
+func testValidateDeps(t *testing.T, test depTest) {
+	fv := lnwire.NewFeatureVector(test.raw, lnwire.Features)
+	err := ValidateDeps(fv)
+	if !reflect.DeepEqual(err, test.expErr) {
+		t.Fatalf("validation mismatch, want: %v, got: %v",
+			test.expErr, err)
+
+	}
+}

--- a/feature/manager.go
+++ b/feature/manager.go
@@ -63,14 +63,27 @@ func newManager(cfg Config, desc setDesc) (*Manager, error) {
 	}
 
 	// Now, remove any features as directed by the config.
-	for _, fv := range fsets {
+	for set, raw := range fsets {
 		if cfg.NoTLVOnion {
-			fv.Unset(lnwire.TLVOnionPayloadOptional)
-			fv.Unset(lnwire.TLVOnionPayloadRequired)
+			raw.Unset(lnwire.TLVOnionPayloadOptional)
+			raw.Unset(lnwire.TLVOnionPayloadRequired)
+			raw.Unset(lnwire.PaymentAddrOptional)
+			raw.Unset(lnwire.PaymentAddrRequired)
+			raw.Unset(lnwire.MPPOptional)
+			raw.Unset(lnwire.MPPRequired)
 		}
 		if cfg.NoStaticRemoteKey {
-			fv.Unset(lnwire.StaticRemoteKeyOptional)
-			fv.Unset(lnwire.StaticRemoteKeyRequired)
+			raw.Unset(lnwire.StaticRemoteKeyOptional)
+			raw.Unset(lnwire.StaticRemoteKeyRequired)
+		}
+
+		// Ensure that all of our feature sets properly set any
+		// dependent features.
+		fv := lnwire.NewFeatureVector(raw, lnwire.Features)
+		err := ValidateDeps(fv)
+		if err != nil {
+			return nil, fmt.Errorf("invalid feature set %v: %v",
+				set, err)
 		}
 	}
 

--- a/lnwire/features.go
+++ b/lnwire/features.go
@@ -81,6 +81,26 @@ const (
 	// party's non-delay output should not be tweaked.
 	StaticRemoteKeyOptional FeatureBit = 13
 
+	// PaymentAddrRequired is a required feature bit that signals that a
+	// node requires payment addresses, which are used to mitigate probing
+	// attacks on the receiver of a payment.
+	PaymentAddrRequired FeatureBit = 14
+
+	// PaymentAddrOptional is an optional feature bit that signals that a
+	// node supports payment addresses, which are used to mitigate probing
+	// attacks on the receiver of a payment.
+	PaymentAddrOptional FeatureBit = 15
+
+	// MPPOptional is a required feature bit that signals that the receiver
+	// of a payment requires settlement of an invoice with more than one
+	// HTLC.
+	MPPRequired FeatureBit = 16
+
+	// MPPOptional is an optional feature bit that signals that the receiver
+	// of a payment supports settlement of an invoice with more than one
+	// HTLC.
+	MPPOptional FeatureBit = 17
+
 	// maxAllowedSize is a maximum allowed size of feature vector.
 	//
 	// NOTE: Within the protocol, the maximum allowed message size is 65535

--- a/peer.go
+++ b/peer.go
@@ -22,6 +22,7 @@ import (
 	"github.com/lightningnetwork/lnd/chainntnfs"
 	"github.com/lightningnetwork/lnd/channeldb"
 	"github.com/lightningnetwork/lnd/contractcourt"
+	"github.com/lightningnetwork/lnd/feature"
 	"github.com/lightningnetwork/lnd/htlcswitch"
 	"github.com/lightningnetwork/lnd/lnpeer"
 	"github.com/lightningnetwork/lnd/lnwallet"
@@ -2474,6 +2475,14 @@ func (p *peer) handleInitMsg(msg *lnwire.Init) error {
 		err := fmt.Errorf("peer set unknown feature bits: %v",
 			unknownFeatures)
 		return err
+	}
+
+	// Ensure the remote party's feature vector contains all transistive
+	// dependencies. We know ours are are correct since they are validated
+	// during the feature manager's instantiation.
+	err = feature.ValidateDeps(p.remoteFeatures)
+	if err != nil {
+		return fmt.Errorf("peer set invalid feature vector: %v", err)
 	}
 
 	// Now that we know we understand their requirements, we'll check to


### PR DESCRIPTION
Split off from #3679

This PR adds a new `feature.ValidateDeps` method to the `feature` package, which can be used to ensure that all transitive dependencies of a given feature are advertised in the feature vector. With base amp, for example, the dependency chain is `option_mpp` -> `option_payment_addr` -> `option_onion_tlv`. When validating, we want to fail if `option_mpp` is set but either of two dependencies are not. As more feature bits are added, these chains could become several layers deep. Things like AMP or extended gossip queries will continue to add to these constraints, and this gives a simple way of expressing and validating these relations.

We then add this transitive validation to remote init features and when parsing BOLT11 invoices, additionally verifying that the payment address is set if the corresponding feature bit is advertised.