### PR TITLE
discovery: use block ranges from ReplyChannelRange to determine end marker

### DIFF
--- a/discovery/sync_manager_test.go
+++ b/discovery/sync_manager_test.go
@@ -529,12 +529,16 @@ func assertSyncerStatus(t *testing.T, s *GossipSyncer, syncState syncerState,
 func assertTransitionToChansSynced(t *testing.T, s *GossipSyncer, peer *mockPeer) {
 	t.Helper()
 
-	assertMsgSent(t, peer, &lnwire.QueryChannelRange{
+	query := &lnwire.QueryChannelRange{
 		FirstBlockHeight: 0,
 		NumBlocks:        math.MaxUint32,
-	})
+	}
+	assertMsgSent(t, peer, query)
 
-	s.ProcessQueryMsg(&lnwire.ReplyChannelRange{Complete: 1}, nil)
+	s.ProcessQueryMsg(&lnwire.ReplyChannelRange{
+		QueryChannelRange: *query,
+		Complete:          1,
+	}, nil)
 
 	chanSeries := s.cfg.channelSeries.(*mockChannelGraphTimeSeries)
 

--- a/discovery/syncer.go
+++ b/discovery/syncer.go
@@ -298,6 +298,17 @@ type GossipSyncer struct {
 	// received over, these will be read by the replyHandler.
 	queryMsgs chan lnwire.Message
 
+	// curQueryRangeMsg keeps track of the latest QueryChannelRange message
+	// we've sent to a peer to ensure we've consumed all expected replies.
+	// This field is primarily used within the waitingQueryChanReply state.
+	curQueryRangeMsg *lnwire.QueryChannelRange
+
+	// prevReplyChannelRange keeps track of the previous ReplyChannelRange
+	// message we've received from a peer to ensure they've fully replied to
+	// our query by ensuring they covered our requested block range. This
+	// field is primarily used within the waitingQueryChanReply state.
+	prevReplyChannelRange *lnwire.ReplyChannelRange
+
 	// bufferedChanRangeReplies is used in the waitingQueryChanReply to
 	// buffer all the chunked response to our query.
 	bufferedChanRangeReplies []lnwire.ShortChannelID
@@ -666,10 +677,64 @@ func (g *GossipSyncer) synchronizeChanIDs() (bool, error) {
 	return false, err
 }
 
+// isLegacyReplyChannelRange determines where a ReplyChannelRange message is
+// considered legacy. There was a point where lnd used to include the same query
+// over multiple replies, rather than including the portion of the query the
+// reply is handling. We'll use this as a way of detecting whether we are
+// communicating with a legacy node so we can properly sync with them.
+func isLegacyReplyChannelRange(query *lnwire.QueryChannelRange,
+	reply *lnwire.ReplyChannelRange) bool {
+
+	return reply.QueryChannelRange == *query
+}
+
 // processChanRangeReply is called each time the GossipSyncer receives a new
 // reply to the initial range query to discover new channels that it didn't
 // previously know of.
 func (g *GossipSyncer) processChanRangeReply(msg *lnwire.ReplyChannelRange) error {
+	// If we're not communicating with a legacy node, we'll apply some
+	// further constraints on their reply to ensure it satisfies our query.
+	if !isLegacyReplyChannelRange(g.curQueryRangeMsg, msg) {
+		// The first block should be within our original request.
+		if msg.FirstBlockHeight < g.curQueryRangeMsg.FirstBlockHeight {
+			return fmt.Errorf("reply includes channels for height "+
+				"%v prior to query %v", msg.FirstBlockHeight,
+				g.curQueryRangeMsg.FirstBlockHeight)
+		}
+
+		// The last block should also be. We don't need to check the
+		// intermediate ones because they should already be in sorted
+		// order.
+		replyLastHeight := msg.QueryChannelRange.LastBlockHeight()
+		queryLastHeight := g.curQueryRangeMsg.LastBlockHeight()
+		if replyLastHeight > queryLastHeight {
+			return fmt.Errorf("reply includes channels for height "+
+				"%v after query %v", replyLastHeight,
+				queryLastHeight)
+		}
+
+		// If we've previously received a reply for this query, look at
+		// its last block to ensure the current reply properly follows
+		// it.
+		if g.prevReplyChannelRange != nil {
+			prevReply := g.prevReplyChannelRange
+			prevReplyLastHeight := prevReply.LastBlockHeight()
+
+			// The current reply can either start from the previous
+			// reply's last block, if there are still more channels
+			// for the same block, or the block after.
+			if msg.FirstBlockHeight != prevReplyLastHeight &&
+				msg.FirstBlockHeight != prevReplyLastHeight+1 {
+
+				return fmt.Errorf("first block of reply %v "+
+					"does not continue from last block of "+
+					"previous %v", msg.FirstBlockHeight,
+					prevReplyLastHeight)
+			}
+		}
+	}
+
+	g.prevReplyChannelRange = msg
 	g.bufferedChanRangeReplies = append(
 		g.bufferedChanRangeReplies, msg.ShortChanIDs...,
 	)
@@ -679,8 +744,25 @@ func (g *GossipSyncer) processChanRangeReply(msg *lnwire.ReplyChannelRange) erro
 
 	// If this isn't the last response, then we can exit as we've already
 	// buffered the latest portion of the streaming reply.
-	if msg.Complete == 0 {
-		return nil
+	switch {
+	// If we're communicating with a legacy node, we'll need to look at the
+	// complete field.
+	case isLegacyReplyChannelRange(g.curQueryRangeMsg, msg):
+		if msg.Complete == 0 {
+			return nil
+		}
+
+	// Otherwise, we'll look at the reply's height range.
+	default:
+		replyLastHeight := msg.QueryChannelRange.LastBlockHeight()
+		queryLastHeight := g.curQueryRangeMsg.LastBlockHeight()
+
+		// TODO(wilmer): This might require some padding if the remote
+		// node is not aware of the last height we sent them, i.e., is
+		// behind a few blocks from us.
+		if replyLastHeight < queryLastHeight {
+			return nil
+		}
 	}
 
 	log.Infof("GossipSyncer(%x): filtering through %v chans",
@@ -696,8 +778,10 @@ func (g *GossipSyncer) processChanRangeReply(msg *lnwire.ReplyChannelRange) erro
 	}
 
 	// As we've received the entirety of the reply, we no longer need to
-	// hold on to the set of buffered replies, so we'll let that be garbage
-	// collected now.
+	// hold on to the set of buffered replies or the original query that
+	// prompted the replies, so we'll let that be garbage collected now.
+	g.curQueryRangeMsg = nil
+	g.prevReplyChannelRange = nil
 	g.bufferedChanRangeReplies = nil
 
 	// If there aren't any channels that we don't know of, then we can
@@ -757,11 +841,14 @@ func (g *GossipSyncer) genChanRangeQuery(
 	// Finally, we'll craft the channel range query, using our starting
 	// height, then asking for all known channels to the foreseeable end of
 	// the main chain.
-	return &lnwire.QueryChannelRange{
+	query := &lnwire.QueryChannelRange{
 		ChainHash:        g.cfg.chainHash,
 		FirstBlockHeight: startHeight,
 		NumBlocks:        math.MaxUint32 - startHeight,
-	}, nil
+	}
+	g.curQueryRangeMsg = query
+
+	return query, nil
 }
 
 // replyPeerQueries is called in response to any query by the remote peer.

--- a/discovery/syncer.go
+++ b/discovery/syncer.go
@@ -814,8 +814,9 @@ func (g *GossipSyncer) replyChanRangeQuery(query *lnwire.QueryChannelRange) erro
 	// Next, we'll consult the time series to obtain the set of known
 	// channel ID's that match their query.
 	startBlock := query.FirstBlockHeight
+	endBlock := startBlock + query.NumBlocks - 1
 	channelRange, err := g.cfg.channelSeries.FilterChannelRange(
-		query.ChainHash, startBlock, startBlock+query.NumBlocks,
+		query.ChainHash, startBlock, endBlock,
 	)
 	if err != nil {
 		return err

--- a/discovery/syncer_test.go
+++ b/discovery/syncer_test.go
@@ -709,10 +709,12 @@ func TestGossipSyncerReplyChanRangeQuery(t *testing.T) {
 
 	// Next, we'll craft a query to ask for all the new chan ID's after
 	// block 100.
-	const startingBlockHeight int = 100
+	const startingBlockHeight = 100
+	const numBlocks = 50
+	const endingBlockHeight = startingBlockHeight + numBlocks - 1
 	query := &lnwire.QueryChannelRange{
 		FirstBlockHeight: uint32(startingBlockHeight),
-		NumBlocks:        50,
+		NumBlocks:        uint32(numBlocks),
 	}
 
 	// We'll then launch a goroutine to reply to the query with a set of 5
@@ -744,8 +746,11 @@ func TestGossipSyncerReplyChanRangeQuery(t *testing.T) {
 			return
 		case filterReq := <-chanSeries.filterRangeReqs:
 			// We should be querying for block 100 to 150.
-			if filterReq.startHeight != 100 && filterReq.endHeight != 150 {
-				errCh <- fmt.Errorf("wrong height range: %v", spew.Sdump(filterReq))
+			if filterReq.startHeight != startingBlockHeight &&
+				filterReq.endHeight != endingBlockHeight {
+
+				errCh <- fmt.Errorf("wrong height range: %v",
+					spew.Sdump(filterReq))
 				return
 			}
 

--- a/lnwire/query_channel_range.go
+++ b/lnwire/query_channel_range.go
@@ -2,6 +2,7 @@ package lnwire
 
 import (
 	"io"
+	"math"
 
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 )
@@ -74,4 +75,15 @@ func (q *QueryChannelRange) MsgType() MessageType {
 func (q *QueryChannelRange) MaxPayloadLength(uint32) uint32 {
 	// 32 + 4 + 4
 	return 40
+}
+
+// LastBlockHeight returns the last block height covered by the range of a
+// QueryChannelRange message.
+func (q *QueryChannelRange) LastBlockHeight() uint32 {
+	// Handle overflows by casting to uint64.
+	lastBlockHeight := uint64(q.FirstBlockHeight) + uint64(q.NumBlocks) - 1
+	if lastBlockHeight > math.MaxUint32 {
+		return math.MaxUint32
+	}
+	return uint32(lastBlockHeight)
 }

--- a/peer.go
+++ b/peer.go
@@ -1336,8 +1336,10 @@ func messageSummary(msg lnwire.Message) string {
 			msg.Complete)
 
 	case *lnwire.ReplyChannelRange:
-		return fmt.Sprintf("complete=%v, encoding=%v, num_chans=%v",
-			msg.Complete, msg.EncodingType, len(msg.ShortChanIDs))
+		return fmt.Sprintf("start_height=%v, end_height=%v, "+
+			"num_chans=%v, encoding=%v", msg.FirstBlockHeight,
+			msg.LastBlockHeight(), len(msg.ShortChanIDs),
+			msg.EncodingType)
 
 	case *lnwire.QueryShortChanIDs:
 		return fmt.Sprintf("chain_hash=%v, encoding=%v, num_chans=%v",
@@ -1345,8 +1347,8 @@ func messageSummary(msg lnwire.Message) string {
 
 	case *lnwire.QueryChannelRange:
 		return fmt.Sprintf("chain_hash=%v, start_height=%v, "+
-			"num_blocks=%v", msg.ChainHash, msg.FirstBlockHeight,
-			msg.NumBlocks)
+			"end_height=%v", msg.ChainHash, msg.FirstBlockHeight,
+			msg.LastBlockHeight())
 
 	case *lnwire.GossipTimestampRange:
 		return fmt.Sprintf("chain_hash=%v, first_stamp=%v, "+


### PR DESCRIPTION
In this PR, we make a series of changes to properly adhere to the specification with the `QueryChannelRange` and `ReplyChannelRange` messages. Previously, we'd look at the `Complete` field of a `ReplyChannelRange` message to determine if we had received all replies to a query. This isn't the use of the field however, and instead we should be inspecting the block range of each `ReplyChannelRange` message to determine this.

One of the main takeaways that motivates most of the changes outlined in this PR is the following:

```
  - MUST respond with one or more `reply_channel_range` whose combined range
	cover the requested `first_blocknum` to `first_blocknum` plus
	`number_of_blocks` minus one.
```

Due to the large number of nodes out there that rely on the previous mechanism for graph sync, we still maintain it for backwards compatibility. In the future, once most nodes have upgraded, we can consider removing this.

I did a series of graph sync tests and I was able to successfully sync against other `lnd` nodes with and without this change, and `c-lightning` nodes. Syncs against `eclair` failed as they don't adhere to the point above, their responses don't cover the complete requested range.

This is a follow-up of https://github.com/lightningnetwork/lnd/pull/3785 and fixes https://github.com/lightningnetwork/lnd/issues/3728.