### PR TITLE
channeldb+invoices: fix what pending invoice means in ChannelDB

### DIFF
--- a/channeldb/invoice_test.go
+++ b/channeldb/invoice_test.go
@@ -52,6 +52,29 @@ func randInvoice(value lnwire.MilliSatoshi) (*Invoice, error) {
 	return i, nil
 }
 
+// Tests that pending invoices are those which are either in ContractOpen or
+// in ContractAccepted state.
+func TestInvoiceIsPending(t *testing.T) {
+	contractStates := []ContractState{
+		ContractOpen, ContractSettled, ContractCanceled, ContractAccepted,
+	}
+
+	for _, state := range contractStates {
+		invoice := Invoice{
+			State: state,
+		}
+
+		// We expect that an invoice is pending if it's either in ContractOpen
+		// or ContractAccepted state.
+		pending := (state == ContractOpen || state == ContractAccepted)
+
+		if invoice.IsPending() != pending {
+			t.Fatalf("expected pending: %v, got: %v, invoice: %v",
+				pending, invoice.IsPending(), invoice)
+		}
+	}
+}
+
 func TestInvoiceWorkflow(t *testing.T) {
 	t.Parallel()
 
@@ -436,7 +459,7 @@ func TestFetchAllInvoicesWithPaymentHash(t *testing.T) {
 		invoice.State = states[i%len(states)]
 		paymentHash := invoice.Terms.PaymentPreimage.Hash()
 
-		if invoice.State != ContractSettled && invoice.State != ContractCanceled {
+		if invoice.IsPending() {
 			testPendingInvoices[paymentHash] = invoice
 		}
 
@@ -576,6 +599,69 @@ func TestDuplicateSettleInvoice(t *testing.T) {
 	if !reflect.DeepEqual(dbInvoice, invoice) {
 		t.Fatalf("wrong invoice after second settle, expected %v got %v",
 			spew.Sdump(invoice), spew.Sdump(dbInvoice))
+	}
+}
+
+// TestFetchAllInvoices tests that FetchAllInvoices works as expected.
+func TestFetchAllInvoices(t *testing.T) {
+	t.Parallel()
+
+	db, cleanUp, err := makeTestDB()
+	defer cleanUp()
+	if err != nil {
+		t.Fatalf("unable to make test db: %v", err)
+	}
+
+	contractStates := []ContractState{
+		ContractOpen, ContractSettled, ContractCanceled, ContractAccepted,
+	}
+
+	numInvoices := len(contractStates) * 2
+
+	var expectedPendingInvoices []Invoice
+	var expectedAllInvoices []Invoice
+
+	for i := 1; i <= numInvoices; i++ {
+		invoice, err := randInvoice(lnwire.MilliSatoshi(i))
+
+		if err != nil {
+			t.Fatalf("unable to create invoice: %v", err)
+		}
+
+		invoice.AddIndex = uint64(i)
+		// Set the contract state of the next invoice such that there's an equal
+		// number for all possbile states.
+		invoice.State = contractStates[i%len(contractStates)]
+
+		paymentHash := invoice.Terms.PaymentPreimage.Hash()
+		if invoice.IsPending() {
+			expectedPendingInvoices = append(expectedPendingInvoices, *invoice)
+		}
+		expectedAllInvoices = append(expectedAllInvoices, *invoice)
+
+		if _, err := db.AddInvoice(invoice, paymentHash); err != nil {
+			t.Fatalf("unable to add invoice: %v", err)
+		}
+	}
+
+	pendingInvoices, err := db.FetchAllInvoices(true)
+	if err != nil {
+		t.Fatalf("unable to fetch all pending invoices: %v", err)
+	}
+
+	allInvoices, err := db.FetchAllInvoices(false)
+	if err != nil {
+		t.Fatalf("unable to fetch all non pending invoices: %v", err)
+	}
+
+	if !reflect.DeepEqual(pendingInvoices, expectedPendingInvoices) {
+		t.Fatalf("pending invoices: %v\n != \n expected einvoices: %v",
+			spew.Sdump(pendingInvoices), spew.Sdump(expectedPendingInvoices))
+	}
+
+	if !reflect.DeepEqual(allInvoices, expectedAllInvoices) {
+		t.Fatalf("pending + non pending: %v\n != \n expected: %v",
+			spew.Sdump(allInvoices), spew.Sdump(expectedAllInvoices))
 	}
 }
 

--- a/channeldb/invoice_test.go
+++ b/channeldb/invoice_test.go
@@ -2,7 +2,6 @@ package channeldb
 
 import (
 	"crypto/rand"
-	mrand "math/rand"
 	"reflect"
 	"testing"
 	"time"
@@ -416,23 +415,25 @@ func TestFetchAllInvoicesWithPaymentHash(t *testing.T) {
 		t.Fatalf("expected empty list as a result, got: %v", empty)
 	}
 
-	// Now populate the DB and check if we can get all invoices with their
-	// payment hashes as expected.
-	const numInvoices = 20
-	testPendingInvoices := make(map[lntypes.Hash]*Invoice)
-	testAllInvoices := make(map[lntypes.Hash]*Invoice)
-
 	states := []ContractState{
 		ContractOpen, ContractSettled, ContractCanceled, ContractAccepted,
 	}
 
-	for i := lnwire.MilliSatoshi(1); i <= numInvoices; i++ {
-		invoice, err := randInvoice(i)
+	numInvoices := len(states) * 2
+	testPendingInvoices := make(map[lntypes.Hash]*Invoice)
+	testAllInvoices := make(map[lntypes.Hash]*Invoice)
+
+	// Now populate the DB and check if we can get all invoices with their
+	// payment hashes as expected.
+	for i := 1; i <= numInvoices; i++ {
+		invoice, err := randInvoice(lnwire.MilliSatoshi(i))
 		if err != nil {
 			t.Fatalf("unable to create invoice: %v", err)
 		}
 
-		invoice.State = states[mrand.Intn(len(states))]
+		// Set the contract state of the next invoice such that there's an equal
+		// number for all possbile states.
+		invoice.State = states[i%len(states)]
 		paymentHash := invoice.Terms.PaymentPreimage.Hash()
 
 		if invoice.State != ContractSettled && invoice.State != ContractCanceled {

--- a/lnrpc/rpc.pb.go
+++ b/lnrpc/rpc.pb.go
@@ -7556,7 +7556,9 @@ func (m *PaymentHash) GetRHash() []byte {
 }
 
 type ListInvoiceRequest struct {
-	/// If set, only unsettled invoices will be returned in the response.
+	//*
+	//If set, only invoices that are not settled and not canceled will be returned
+	//in the response.
 	PendingOnly bool `protobuf:"varint,1,opt,name=pending_only,proto3" json:"pending_only,omitempty"`
 	//*
 	//The index of an invoice that will be used as either the start or end of a

--- a/lnrpc/rpc.proto
+++ b/lnrpc/rpc.proto
@@ -2450,7 +2450,10 @@ message PaymentHash {
 }
 
 message ListInvoiceRequest {
-    /// If set, only unsettled invoices will be returned in the response.
+    /**
+    If set, only invoices that are not settled and not canceled will be returned
+    in the response.
+    */
     bool pending_only = 1 [json_name = "pending_only"];
 
     /**

--- a/lnrpc/rpc.swagger.json
+++ b/lnrpc/rpc.swagger.json
@@ -896,7 +896,7 @@
         "parameters": [
           {
             "name": "pending_only",
-            "description": "/ If set, only unsettled invoices will be returned in the response.",
+            "description": "*\nIf set, only invoices that are not settled and not canceled will be returned\nin the response.",
             "in": "query",
             "required": false,
             "type": "boolean",


### PR DESCRIPTION
This pull request is a partial fix for issue lightningnetwork#1404 where part of the problem comes from
not being able to filter out expired invoices due to those not being canceled 
(fixed in PR lightningnetwork#3694) while also having a misleading definition of what pending invoice
state means.

The PR changes the meaning of the `pending_only` flag in `listinvoices`
RPC to list invoices that are either in `ContractOpen` or `ContractAccepted`
state. Previously when the `pending_only` flag was set the `listinvoices`
RPC returned all invoices that are not settled which equals to invoices in `ContractOpen`, `ContractAccepted` or `ContractCanceled` state.