### PR TITLE
lnrpc: clarify block padding requirement for QueryRoutes

### DIFF
--- a/lnrpc/rpc.pb.go
+++ b/lnrpc/rpc.pb.go
@@ -5197,7 +5197,12 @@ type QueryRoutesRequest struct {
 	//
 	//The fields amt and amt_msat are mutually exclusive.
 	AmtMsat int64 `protobuf:"varint,12,opt,name=amt_msat,json=amtMsat,proto3" json:"amt_msat,omitempty"`
-	/// An optional CLTV delta from the current height that should be used for the timelock of the final hop
+	//*
+	//An optional CLTV delta from the current height that should be used for the
+	//timelock of the final hop. Note that unlike SendPayment, QueryRoutes does
+	//not add any additional block padding on top of final_ctlv_delta. This
+	//padding of a few blocks needs to be added manually or otherwise failures may
+	//happen when a block comes in while the payment is in flight.
 	FinalCltvDelta int32 `protobuf:"varint,4,opt,name=final_cltv_delta,json=finalCltvDelta,proto3" json:"final_cltv_delta,omitempty"`
 	//*
 	//The maximum number of satoshis that will be paid as a fee of the payment.

--- a/lnrpc/rpc.proto
+++ b/lnrpc/rpc.proto
@@ -1821,7 +1821,13 @@ message QueryRoutesRequest {
 
     reserved 3;
 
-    /// An optional CLTV delta from the current height that should be used for the timelock of the final hop
+    /**
+    An optional CLTV delta from the current height that should be used for the
+    timelock of the final hop. Note that unlike SendPayment, QueryRoutes does
+    not add any additional block padding on top of final_ctlv_delta. This
+    padding of a few blocks needs to be added manually or otherwise failures may
+    happen when a block comes in while the payment is in flight.
+    */
     int32 final_cltv_delta = 4;
 
     /**

--- a/lnrpc/rpc.swagger.json
+++ b/lnrpc/rpc.swagger.json
@@ -748,7 +748,7 @@
           },
           {
             "name": "final_cltv_delta",
-            "description": "/ An optional CLTV delta from the current height that should be used for the timelock of the final hop.",
+            "description": "*\nAn optional CLTV delta from the current height that should be used for the\ntimelock of the final hop. Note that unlike SendPayment, QueryRoutes does\nnot add any additional block padding on top of final_ctlv_delta. This\npadding of a few blocks needs to be added manually or otherwise failures may\nhappen when a block comes in while the payment is in flight.",
             "in": "query",
             "required": false,
             "type": "integer",


### PR DESCRIPTION
Block padding is added for `SendPayment`, but if some applications decide to manually roll their payment loop using `QueryRoutes` in combination with `use_mc`, they may run into this issue.