### PR TITLE
invoiceregistry+htlcswitch: Introduce resolution types and add link errors

### DIFF
--- a/contractcourt/htlc_incoming_resolver_test.go
+++ b/contractcourt/htlc_incoming_resolver_test.go
@@ -35,7 +35,7 @@ func TestHtlcIncomingResolverFwdPreimageKnown(t *testing.T) {
 	defer timeout(t)()
 
 	ctx := newIncomingResolverTestContext(t)
-	ctx.registry.notifyResolution = invoices.NewFailureResolution(
+	ctx.registry.notifyResolution = invoices.NewFailResolution(
 		testResCircuitKey, testHtlcExpiry,
 		invoices.ResultInvoiceNotFound,
 	)
@@ -52,7 +52,7 @@ func TestHtlcIncomingResolverFwdContestedSuccess(t *testing.T) {
 	defer timeout(t)()
 
 	ctx := newIncomingResolverTestContext(t)
-	ctx.registry.notifyResolution = invoices.NewFailureResolution(
+	ctx.registry.notifyResolution = invoices.NewFailResolution(
 		testResCircuitKey, testHtlcExpiry,
 		invoices.ResultInvoiceNotFound,
 	)
@@ -72,7 +72,7 @@ func TestHtlcIncomingResolverFwdContestedTimeout(t *testing.T) {
 	defer timeout(t)()
 
 	ctx := newIncomingResolverTestContext(t)
-	ctx.registry.notifyResolution = invoices.NewFailureResolution(
+	ctx.registry.notifyResolution = invoices.NewFailResolution(
 		testResCircuitKey, testHtlcExpiry,
 		invoices.ResultInvoiceNotFound,
 	)
@@ -91,7 +91,7 @@ func TestHtlcIncomingResolverFwdTimeout(t *testing.T) {
 	defer timeout(t)()
 
 	ctx := newIncomingResolverTestContext(t)
-	ctx.registry.notifyResolution = invoices.NewFailureResolution(
+	ctx.registry.notifyResolution = invoices.NewFailResolution(
 		testResCircuitKey, testHtlcExpiry,
 		invoices.ResultInvoiceNotFound,
 	)
@@ -139,7 +139,7 @@ func TestHtlcIncomingResolverExitCancel(t *testing.T) {
 	defer timeout(t)()
 
 	ctx := newIncomingResolverTestContext(t)
-	ctx.registry.notifyResolution = invoices.NewFailureResolution(
+	ctx.registry.notifyResolution = invoices.NewFailResolution(
 		testResCircuitKey, testAcceptHeight,
 		invoices.ResultInvoiceAlreadyCanceled,
 	)
@@ -158,7 +158,7 @@ func TestHtlcIncomingResolverExitSettleHodl(t *testing.T) {
 	ctx.resolve()
 
 	notifyData := <-ctx.registry.notifyChan
-	notifyData.hodlChan <- *invoices.NewSettleResolution(
+	notifyData.hodlChan <- invoices.NewSettleResolution(
 		testResPreimage, testResCircuitKey, testAcceptHeight,
 		invoices.ResultSettled,
 	)
@@ -187,7 +187,7 @@ func TestHtlcIncomingResolverExitCancelHodl(t *testing.T) {
 	ctx := newIncomingResolverTestContext(t)
 	ctx.resolve()
 	notifyData := <-ctx.registry.notifyChan
-	notifyData.hodlChan <- *invoices.NewFailureResolution(
+	notifyData.hodlChan <- invoices.NewFailResolution(
 		testResCircuitKey, testAcceptHeight, invoices.ResultCanceled,
 	)
 

--- a/contractcourt/interfaces.go
+++ b/contractcourt/interfaces.go
@@ -27,7 +27,7 @@ type Registry interface {
 	NotifyExitHopHtlc(payHash lntypes.Hash, paidAmount lnwire.MilliSatoshi,
 		expiry uint32, currentHeight int32,
 		circuitKey channeldb.CircuitKey, hodlChan chan<- interface{},
-		payload invoices.Payload) (*invoices.HtlcResolution, error)
+		payload invoices.Payload) (invoices.HtlcResolution, error)
 
 	// HodlUnsubscribeAll unsubscribes from all htlc resolutions.
 	HodlUnsubscribeAll(subscriber chan<- interface{})

--- a/contractcourt/mock_registry_test.go
+++ b/contractcourt/mock_registry_test.go
@@ -18,13 +18,13 @@ type notifyExitHopData struct {
 type mockRegistry struct {
 	notifyChan       chan notifyExitHopData
 	notifyErr        error
-	notifyResolution *invoices.HtlcResolution
+	notifyResolution invoices.HtlcResolution
 }
 
 func (r *mockRegistry) NotifyExitHopHtlc(payHash lntypes.Hash,
 	paidAmount lnwire.MilliSatoshi, expiry uint32, currentHeight int32,
 	circuitKey channeldb.CircuitKey, hodlChan chan<- interface{},
-	payload invoices.Payload) (*invoices.HtlcResolution, error) {
+	payload invoices.Payload) (invoices.HtlcResolution, error) {
 
 	r.notifyChan <- notifyExitHopData{
 		hodlChan:      hodlChan,

--- a/htlcswitch/failure.go
+++ b/htlcswitch/failure.go
@@ -34,8 +34,8 @@ type LinkError struct {
 	// node.
 	msg lnwire.FailureMessage
 
-	// OutgoingFailure enriches the wire error with additional information.
-	OutgoingFailure
+	// FailureDetail enriches the wire error with additional information.
+	FailureDetail
 }
 
 // NewLinkError returns a LinkError with the failure message provided.
@@ -48,11 +48,11 @@ func NewLinkError(msg lnwire.FailureMessage) *LinkError {
 // NewDetailedLinkError returns a link error that enriches a wire message with
 // a failure detail.
 func NewDetailedLinkError(msg lnwire.FailureMessage,
-	detail OutgoingFailure) *LinkError {
+	detail FailureDetail) *LinkError {
 
 	return &LinkError{
-		msg:             msg,
-		OutgoingFailure: detail,
+		msg:           msg,
+		FailureDetail: detail,
 	}
 }
 
@@ -72,11 +72,11 @@ func (l *LinkError) WireMessage() lnwire.FailureMessage {
 func (l *LinkError) Error() string {
 	// If the link error has no failure detail, return the wire message's
 	// error.
-	if l.OutgoingFailure == OutgoingFailureNone {
+	if l.FailureDetail == nil {
 		return l.msg.Error()
 	}
 
-	return fmt.Sprintf("%v: %v", l.msg.Error(), l.OutgoingFailure)
+	return fmt.Sprintf("%v: %v", l.msg.Error(), l.FailureDetail)
 }
 
 // ForwardingError wraps an lnwire.FailureMessage in a struct that also

--- a/htlcswitch/failure.go
+++ b/htlcswitch/failure.go
@@ -76,7 +76,7 @@ func (l *LinkError) Error() string {
 		return l.msg.Error()
 	}
 
-	return fmt.Sprintf("%v: %v", l.msg.Error(), l.FailureDetail)
+	return l.FailureDetail.FailureString()
 }
 
 // ForwardingError wraps an lnwire.FailureMessage in a struct that also

--- a/htlcswitch/failure.go
+++ b/htlcswitch/failure.go
@@ -34,8 +34,8 @@ type LinkError struct {
 	// node.
 	msg lnwire.FailureMessage
 
-	// FailureDetail enriches the wire error with additional information.
-	FailureDetail
+	// OutgoingFailure enriches the wire error with additional information.
+	OutgoingFailure
 }
 
 // NewLinkError returns a LinkError with the failure message provided.
@@ -48,11 +48,11 @@ func NewLinkError(msg lnwire.FailureMessage) *LinkError {
 // NewDetailedLinkError returns a link error that enriches a wire message with
 // a failure detail.
 func NewDetailedLinkError(msg lnwire.FailureMessage,
-	detail FailureDetail) *LinkError {
+	detail OutgoingFailure) *LinkError {
 
 	return &LinkError{
-		msg:           msg,
-		FailureDetail: detail,
+		msg:             msg,
+		OutgoingFailure: detail,
 	}
 }
 
@@ -72,11 +72,11 @@ func (l *LinkError) WireMessage() lnwire.FailureMessage {
 func (l *LinkError) Error() string {
 	// If the link error has no failure detail, return the wire message's
 	// error.
-	if l.FailureDetail == FailureDetailNone {
+	if l.OutgoingFailure == OutgoingFailureNone {
 		return l.msg.Error()
 	}
 
-	return fmt.Sprintf("%v: %v", l.msg.Error(), l.FailureDetail)
+	return fmt.Sprintf("%v: %v", l.msg.Error(), l.OutgoingFailure)
 }
 
 // ForwardingError wraps an lnwire.FailureMessage in a struct that also

--- a/htlcswitch/failure_detail.go
+++ b/htlcswitch/failure_detail.go
@@ -1,5 +1,13 @@
 package htlcswitch
 
+// FailureDetail is an interface implemented by failures that occur on
+// our incoming or outgoing link, or within the switch itself.
+type FailureDetail interface {
+	// FailureString returns the string representation of a failure
+	// detail.
+	FailureString() string
+}
+
 // OutgoingFailure is an enum which is used to enrich failures which occur in
 // the switch or on our outgoing link with additional metadata.
 type OutgoingFailure int
@@ -36,8 +44,10 @@ const (
 	OutgoingFailureCircularRoute
 )
 
-// String returns the string representation of a failure detail.
-func (fd OutgoingFailure) String() string {
+// FailureString returns the string representation of a failure detail.
+//
+// Note: it is part of the FailureDetail interface.
+func (fd OutgoingFailure) FailureString() string {
 	switch fd {
 	case OutgoingFailureNone:
 		return "no failure detail"

--- a/htlcswitch/failure_detail.go
+++ b/htlcswitch/failure_detail.go
@@ -42,6 +42,18 @@ const (
 	// to forward a htlc through our node which arrives and leaves on the
 	// same channel.
 	OutgoingFailureCircularRoute
+
+	// OutgoingFailureIncompleteForward is returned when we cancel an incomplete
+	// forward.
+	OutgoingFailureIncompleteForward
+
+	// OutgoingFailureDownstreamHtlcAdd is returned when we fail to add a
+	// downstream htlc to our outgoing link.
+	OutgoingFailureDownstreamHtlcAdd
+
+	// OutgoingFailureForwardsDisabled is returned when the switch is
+	// configured to disallow forwards.
+	OutgoingFailureForwardsDisabled
 )
 
 // FailureString returns the string representation of a failure detail.
@@ -69,6 +81,15 @@ func (fd OutgoingFailure) FailureString() string {
 
 	case OutgoingFailureCircularRoute:
 		return "same incoming and outgoing channel"
+
+	case OutgoingFailureIncompleteForward:
+		return "failed after detecting incomplete forward"
+
+	case OutgoingFailureDownstreamHtlcAdd:
+		return "could not add downstream htlc"
+
+	case OutgoingFailureForwardsDisabled:
+		return "node configured to disallow forwards"
 
 	default:
 		return "unknown failure detail"

--- a/htlcswitch/failure_detail.go
+++ b/htlcswitch/failure_detail.go
@@ -1,63 +1,63 @@
 package htlcswitch
 
-// FailureDetail is an enum which is used to enrich failures with
-// additional information.
-type FailureDetail int
+// OutgoingFailure is an enum which is used to enrich failures which occur in
+// the switch or on our outgoing link with additional metadata.
+type OutgoingFailure int
 
 const (
-	// FailureDetailNone is returned when the wire message contains
+	// OutgoingFailureNone is returned when the wire message contains
 	// sufficient information.
-	FailureDetailNone = iota
+	OutgoingFailureNone OutgoingFailure = iota
 
-	// FailureDetailOnionDecode indicates that we could not decode an
-	// onion error.
-	FailureDetailOnionDecode
+	// OutgoingFailureDecodeError indicates that we could not decode the
+	// failure reason provided for a failed payment.
+	OutgoingFailureDecodeError
 
-	// FailureDetailLinkNotEligible indicates that a routing attempt was
+	// OutgoingFailureLinkNotEligible indicates that a routing attempt was
 	// made over a link that is not eligible for routing.
-	FailureDetailLinkNotEligible
+	OutgoingFailureLinkNotEligible
 
-	// FailureDetailOnChainTimeout indicates that a payment had to be timed
-	// out on chain before it got past the first hop by us or the remote
-	// party.
-	FailureDetailOnChainTimeout
+	// OutgoingFailureOnChainTimeout indicates that a payment had to be
+	// timed out on chain before it got past the first hop by us or the
+	// remote party.
+	OutgoingFailureOnChainTimeout
 
-	// FailureDetailHTLCExceedsMax is returned when a htlc exceeds our
+	// OutgoingFailureHTLCExceedsMax is returned when a htlc exceeds our
 	// policy's maximum htlc amount.
-	FailureDetailHTLCExceedsMax
+	OutgoingFailureHTLCExceedsMax
 
-	// FailureDetailInsufficientBalance is returned when we cannot route a
+	// OutgoingFailureInsufficientBalance is returned when we cannot route a
 	// htlc due to insufficient outgoing capacity.
-	FailureDetailInsufficientBalance
+	OutgoingFailureInsufficientBalance
 
-	// FailureDetailCircularRoute is returned when an attempt is made
+	// OutgoingFailureCircularRoute is returned when an attempt is made
 	// to forward a htlc through our node which arrives and leaves on the
 	// same channel.
-	FailureDetailCircularRoute
+	OutgoingFailureCircularRoute
 )
 
 // String returns the string representation of a failure detail.
-func (fd FailureDetail) String() string {
+func (fd OutgoingFailure) String() string {
 	switch fd {
-	case FailureDetailNone:
+	case OutgoingFailureNone:
 		return "no failure detail"
 
-	case FailureDetailOnionDecode:
-		return "could not decode onion"
+	case OutgoingFailureDecodeError:
+		return "could not decode wire failure"
 
-	case FailureDetailLinkNotEligible:
+	case OutgoingFailureLinkNotEligible:
 		return "link not eligible"
 
-	case FailureDetailOnChainTimeout:
+	case OutgoingFailureOnChainTimeout:
 		return "payment was resolved on-chain, then canceled back"
 
-	case FailureDetailHTLCExceedsMax:
+	case OutgoingFailureHTLCExceedsMax:
 		return "htlc exceeds maximum policy amount"
 
-	case FailureDetailInsufficientBalance:
+	case OutgoingFailureInsufficientBalance:
 		return "insufficient bandwidth to route htlc"
 
-	case FailureDetailCircularRoute:
+	case OutgoingFailureCircularRoute:
 		return "same incoming and outgoing channel"
 
 	default:

--- a/htlcswitch/interfaces.go
+++ b/htlcswitch/interfaces.go
@@ -27,7 +27,7 @@ type InvoiceDatabase interface {
 	NotifyExitHopHtlc(payHash lntypes.Hash, paidAmount lnwire.MilliSatoshi,
 		expiry uint32, currentHeight int32,
 		circuitKey channeldb.CircuitKey, hodlChan chan<- interface{},
-		payload invoices.Payload) (*invoices.HtlcResolution, error)
+		payload invoices.Payload) (invoices.HtlcResolution, error)
 
 	// CancelInvoice attempts to cancel the invoice corresponding to the
 	// passed payment hash.

--- a/htlcswitch/link.go
+++ b/htlcswitch/link.go
@@ -2284,7 +2284,7 @@ func (l *channelLink) canSendHtlc(policy ForwardingPolicy,
 				return lnwire.NewTemporaryChannelFailure(upd)
 			},
 		)
-		return NewDetailedLinkError(failure, FailureDetailHTLCExceedsMax)
+		return NewDetailedLinkError(failure, OutgoingFailureHTLCExceedsMax)
 	}
 
 	// We want to avoid offering an HTLC which will expire in the near
@@ -2319,7 +2319,7 @@ func (l *channelLink) canSendHtlc(policy ForwardingPolicy,
 			},
 		)
 		return NewDetailedLinkError(
-			failure, FailureDetailInsufficientBalance,
+			failure, OutgoingFailureInsufficientBalance,
 		)
 	}
 

--- a/htlcswitch/mock.go
+++ b/htlcswitch/mock.go
@@ -816,7 +816,7 @@ func (i *mockInvoiceRegistry) SettleHodlInvoice(preimage lntypes.Preimage) error
 func (i *mockInvoiceRegistry) NotifyExitHopHtlc(rhash lntypes.Hash,
 	amt lnwire.MilliSatoshi, expiry uint32, currentHeight int32,
 	circuitKey channeldb.CircuitKey, hodlChan chan<- interface{},
-	payload invoices.Payload) (*invoices.HtlcResolution, error) {
+	payload invoices.Payload) (invoices.HtlcResolution, error) {
 
 	event, err := i.registry.NotifyExitHopHtlc(
 		rhash, amt, expiry, currentHeight, circuitKey, hodlChan,

--- a/htlcswitch/packet.go
+++ b/htlcswitch/packet.go
@@ -54,6 +54,11 @@ type htlcPacket struct {
 	// encrypted with any shared secret.
 	localFailure bool
 
+	// linkFailure is non-nil for htlcs that fail at our node. This may
+	// occur for our own payments which fail on the outgoing link,
+	// or for forwards which fail in the switch or on the outgoing link.
+	linkFailure *LinkError
+
 	// convertedError is set to true if this is an HTLC fail that was
 	// created using an UpdateFailMalformedHTLC from the remote party. If
 	// this is true, then when forwarding this failure packet, we'll need

--- a/htlcswitch/switch.go
+++ b/htlcswitch/switch.go
@@ -45,11 +45,6 @@ var (
 	// through the switch and is locked into another commitment txn.
 	ErrDuplicateAdd = errors.New("duplicate add HTLC detected")
 
-	// ErrIncompleteForward is used when an htlc was already forwarded
-	// through the switch, but did not get locked into another commitment
-	// txn.
-	ErrIncompleteForward = errors.New("incomplete forward detected")
-
 	// ErrUnknownErrorDecryptor signals that we were unable to locate the
 	// error decryptor for this payment. This is likely due to restarting
 	// the daemon.
@@ -496,9 +491,12 @@ func (s *Switch) forward(packet *htlcPacket) error {
 			} else {
 				failure = lnwire.NewTemporaryChannelFailure(update)
 			}
-			addErr := ErrIncompleteForward
 
-			return s.failAddPacket(packet, failure, addErr)
+			linkError := NewDetailedLinkError(
+				failure, OutgoingFailureIncompleteForward,
+			)
+
+			return s.failAddPacket(packet, linkError)
 		}
 
 		packet.circuit = circuit
@@ -647,14 +645,14 @@ func (s *Switch) ForwardPackets(linkQuit chan struct{},
 		} else {
 			failure = lnwire.NewTemporaryChannelFailure(update)
 		}
+		linkError := NewDetailedLinkError(
+			failure, OutgoingFailureIncompleteForward,
+		)
 
 		for _, packet := range failedPackets {
-			addErr := errors.New("failing packet after " +
-				"detecting incomplete forward")
-
 			// We don't handle the error here since this method
 			// always returns an error.
-			s.failAddPacket(packet, failure, addErr)
+			_ = s.failAddPacket(packet, linkError)
 		}
 	}
 
@@ -979,10 +977,12 @@ func (s *Switch) handlePacketForward(packet *htlcPacket) error {
 		// Check if the node is set to reject all onward HTLCs and also make
 		// sure that HTLC is not from the source node.
 		if s.cfg.RejectHTLC && packet.incomingChanID != hop.Source {
-			failure := &lnwire.FailChannelDisabled{}
-			addErr := fmt.Errorf("unable to forward any htlcs")
+			failure := NewDetailedLinkError(
+				&lnwire.FailChannelDisabled{},
+				OutgoingFailureForwardsDisabled,
+			)
 
-			return s.failAddPacket(packet, failure, addErr)
+			return s.failAddPacket(packet, failure)
 		}
 
 		if packet.incomingChanID == hop.Source {
@@ -1002,9 +1002,7 @@ func (s *Switch) handlePacketForward(packet *htlcPacket) error {
 			s.cfg.AllowCircularRoute, htlc.PaymentHash,
 		)
 		if linkErr != nil {
-			return s.failAddPacket(
-				packet, linkErr.WireMessage(), linkErr,
-			)
+			return s.failAddPacket(packet, linkErr)
 		}
 
 		s.indexMtx.RLock()
@@ -1012,14 +1010,17 @@ func (s *Switch) handlePacketForward(packet *htlcPacket) error {
 		if err != nil {
 			s.indexMtx.RUnlock()
 
+			log.Debugf("unable to find link with "+
+				"destination %v", packet.outgoingChanID)
+
 			// If packet was forwarded from another channel link
 			// than we should notify this link that some error
 			// occurred.
-			failure := &lnwire.FailUnknownNextPeer{}
-			addErr := fmt.Errorf("unable to find link with "+
-				"destination %v", packet.outgoingChanID)
+			linkError := NewLinkError(
+				&lnwire.FailUnknownNextPeer{},
+			)
 
-			return s.failAddPacket(packet, failure, addErr)
+			return s.failAddPacket(packet, linkError)
 		}
 		targetPeerKey := targetLink.Peer().PubKey()
 		interfaceLinks, _ := s.getLinks(targetPeerKey)
@@ -1088,12 +1089,12 @@ func (s *Switch) handlePacketForward(packet *htlcPacket) error {
 					}))
 			}
 
-			addErr := fmt.Errorf("incoming HTLC(%x) violated "+
+			log.Tracef("incoming HTLC(%x) violated "+
 				"target outgoing link (id=%v) policy: %v",
 				htlc.PaymentHash[:], packet.outgoingChanID,
 				linkErr)
 
-			return s.failAddPacket(packet, linkErr.WireMessage(), addErr)
+			return s.failAddPacket(packet, linkErr)
 		}
 
 		// Send the packet to the destination channel link which
@@ -1225,13 +1226,11 @@ func checkCircularForward(incoming, outgoing lnwire.ShortChannelID,
 // failAddPacket encrypts a fail packet back to an add packet's source.
 // The ciphertext will be derived from the failure message proivded by context.
 // This method returns the failErr if all other steps complete successfully.
-func (s *Switch) failAddPacket(packet *htlcPacket,
-	failure lnwire.FailureMessage, failErr error) error {
-
+func (s *Switch) failAddPacket(packet *htlcPacket, failure *LinkError) error {
 	// Encrypt the failure so that the sender will be able to read the error
 	// message. Since we failed this packet, we use EncryptFirstHop to
 	// obfuscate the failure for their eyes only.
-	reason, err := packet.obfuscator.EncryptFirstHop(failure)
+	reason, err := packet.obfuscator.EncryptFirstHop(failure.WireMessage())
 	if err != nil {
 		err := fmt.Errorf("unable to obfuscate "+
 			"error: %v", err)
@@ -1239,13 +1238,14 @@ func (s *Switch) failAddPacket(packet *htlcPacket,
 		return err
 	}
 
-	log.Error(failErr)
+	log.Error(failure.Error())
 
 	failPkt := &htlcPacket{
 		sourceRef:      packet.sourceRef,
 		incomingChanID: packet.incomingChanID,
 		incomingHTLCID: packet.incomingHTLCID,
 		circuit:        packet.circuit,
+		linkFailure:    failure,
 		htlc: &lnwire.UpdateFailHTLC{
 			Reason: reason,
 		},
@@ -1261,7 +1261,7 @@ func (s *Switch) failAddPacket(packet *htlcPacket,
 		return err
 	}
 
-	return failErr
+	return failure
 }
 
 // closeCircuit accepts a settle or fail htlc and the associated htlc packet and
@@ -1869,8 +1869,11 @@ func (s *Switch) reforwardSettleFails(fwdPkgs []*channeldb.FwdPkg) {
 			// commitment state, so we'll forward this to the switch so the
 			// backwards undo can continue.
 			case lnwallet.Fail:
-				// Fetch the reason the HTLC was canceled so we can
-				// continue to propagate it.
+				// Fetch the reason the HTLC was canceled so
+				// we can continue to propagate it. This
+				// failure originated from another node, so
+				// the linkFailure field is not set on this
+				// packet.
 				failPacket := &htlcPacket{
 					outgoingChanID: fwdPkg.Source,
 					outgoingHTLCID: pd.ParentIndex,

--- a/htlcswitch/switch.go
+++ b/htlcswitch/switch.go
@@ -771,7 +771,7 @@ func (s *Switch) handleLocalDispatch(pkt *htlcPacket) error {
 			// will be returned back to the router.
 			return NewDetailedLinkError(
 				lnwire.NewTemporaryChannelFailure(nil),
-				FailureDetailLinkNotEligible,
+				OutgoingFailureLinkNotEligible,
 			)
 		}
 
@@ -919,11 +919,11 @@ func (s *Switch) parseFailedPayment(deobfuscator ErrorDecrypter,
 				// need to apply an update here since it goes
 				// directly to the router.
 				lnwire.NewTemporaryChannelFailure(nil),
-				FailureDetailOnionDecode,
+				OutgoingFailureDecodeError,
 			)
 
 			log.Errorf("%v: (hash=%v, pid=%d): %v",
-				linkError.FailureDetail, paymentHash, paymentID,
+				linkError.OutgoingFailure, paymentHash, paymentID,
 				err)
 
 			return linkError
@@ -939,10 +939,10 @@ func (s *Switch) parseFailedPayment(deobfuscator ErrorDecrypter,
 	case isResolution && htlc.Reason == nil:
 		linkError := NewDetailedLinkError(
 			&lnwire.FailPermanentChannelFailure{},
-			FailureDetailOnChainTimeout,
+			OutgoingFailureOnChainTimeout,
 		)
 
-		log.Info("%v: hash=%v, pid=%d", linkError.FailureDetail,
+		log.Info("%v: hash=%v, pid=%d", linkError.OutgoingFailure,
 			paymentHash, paymentID)
 
 		return linkError
@@ -1041,7 +1041,7 @@ func (s *Switch) handlePacketForward(packet *htlcPacket) error {
 			if !link.EligibleToForward() {
 				failure = NewDetailedLinkError(
 					&lnwire.FailUnknownNextPeer{},
-					FailureDetailLinkNotEligible,
+					OutgoingFailureLinkNotEligible,
 				)
 			} else {
 				// We'll ensure that the HTLC satisfies the
@@ -1217,7 +1217,7 @@ func checkCircularForward(incoming, outgoing lnwire.ShortChannelID,
 	// node, so we do not include a channel update.
 	return NewDetailedLinkError(
 		lnwire.NewTemporaryChannelFailure(nil),
-		FailureDetailCircularRoute,
+		OutgoingFailureCircularRoute,
 	)
 }
 

--- a/htlcswitch/switch.go
+++ b/htlcswitch/switch.go
@@ -923,8 +923,8 @@ func (s *Switch) parseFailedPayment(deobfuscator ErrorDecrypter,
 			)
 
 			log.Errorf("%v: (hash=%v, pid=%d): %v",
-				linkError.OutgoingFailure, paymentHash, paymentID,
-				err)
+				linkError.FailureDetail.FailureString(),
+				paymentHash, paymentID, err)
 
 			return linkError
 		}
@@ -942,7 +942,8 @@ func (s *Switch) parseFailedPayment(deobfuscator ErrorDecrypter,
 			OutgoingFailureOnChainTimeout,
 		)
 
-		log.Info("%v: hash=%v, pid=%d", linkError.OutgoingFailure,
+		log.Info("%v: hash=%v, pid=%d",
+			linkError.FailureDetail.FailureString(),
 			paymentHash, paymentID)
 
 		return linkError

--- a/htlcswitch/switch_test.go
+++ b/htlcswitch/switch_test.go
@@ -1348,7 +1348,7 @@ func TestCircularForwards(t *testing.T) {
 			allowCircularPayment: false,
 			expectedErr: NewDetailedLinkError(
 				lnwire.NewTemporaryChannelFailure(nil),
-				FailureDetailCircularRoute,
+				OutgoingFailureCircularRoute,
 			),
 		},
 	}
@@ -1465,7 +1465,7 @@ func TestCheckCircularForward(t *testing.T) {
 			outgoingLink:  lnwire.NewShortChanIDFromInt(123),
 			expectedErr: NewDetailedLinkError(
 				lnwire.NewTemporaryChannelFailure(nil),
-				FailureDetailCircularRoute,
+				OutgoingFailureCircularRoute,
 			),
 		},
 	}
@@ -1527,7 +1527,7 @@ func TestSkipIneligibleLinksMultiHopForward(t *testing.T) {
 			eligible1: true,
 			failure1: NewDetailedLinkError(
 				lnwire.NewTemporaryChannelFailure(nil),
-				FailureDetailInsufficientBalance,
+				OutgoingFailureInsufficientBalance,
 			),
 			eligible2: true,
 			failure2: NewLinkError(

--- a/htlcswitch/switch_test.go
+++ b/htlcswitch/switch_test.go
@@ -211,10 +211,13 @@ func TestSwitchSendPending(t *testing.T) {
 	// Send the ADD packet, this should not be forwarded out to the link
 	// since there are no eligible links.
 	err = s.forward(packet)
-	expErr := fmt.Sprintf("unable to find link with destination %v",
-		aliceChanID)
-	if err != nil && err.Error() != expErr {
-		t.Fatalf("expected forward failure: %v", err)
+	linkErr, ok := err.(*LinkError)
+	if !ok {
+		t.Fatalf("expected link error, got: %T", err)
+	}
+	if linkErr.WireMessage().Code() != lnwire.CodeUnknownNextPeer {
+		t.Fatalf("expected fail unknown next peer, got: %T",
+			linkErr.WireMessage().Code())
 	}
 
 	// No message should be sent, since the packet was failed.
@@ -1070,9 +1073,13 @@ func TestSwitchForwardFailAfterHalfAdd(t *testing.T) {
 	// Resend the failed htlc, it should be returned to alice since the
 	// switch will detect that it has been half added previously.
 	err = s2.forward(ogPacket)
-	if err != ErrIncompleteForward {
-		t.Fatal("unexpected error when reforwarding a "+
-			"failed packet", err)
+	linkErr, ok := err.(*LinkError)
+	if !ok {
+		t.Fatalf("expected link error, got: %T", err)
+	}
+	if linkErr.FailureDetail != OutgoingFailureIncompleteForward {
+		t.Fatalf("expected incomplete forward, got: %v",
+			linkErr.FailureDetail)
 	}
 
 	// After detecting an incomplete forward, the fail packet should have

--- a/invoices/invoiceregistry.go
+++ b/invoices/invoiceregistry.go
@@ -565,7 +565,7 @@ func (i *InvoiceRegistry) startHtlcTimer(hash lntypes.Hash,
 // a resolution result which will be used to notify subscribed links and
 // resolvers of the details of the htlc cancellation.
 func (i *InvoiceRegistry) cancelSingleHtlc(hash lntypes.Hash,
-	key channeldb.CircuitKey, result ResolutionResult) error {
+	key channeldb.CircuitKey, result FailResolutionResult) error {
 
 	i.Lock()
 	defer i.Unlock()

--- a/invoices/resolution.go
+++ b/invoices/resolution.go
@@ -23,13 +23,13 @@ type HtlcFailResolution struct {
 	// AcceptHeight is the original height at which the htlc was accepted.
 	AcceptHeight int32
 
-	// outcome indicates the outcome of the invoice registry update.
-	Outcome ResolutionResult
+	// Outcome indicates the outcome of the invoice registry update.
+	Outcome FailResolutionResult
 }
 
 // NewFailResolution returns a htlc failure resolution.
 func NewFailResolution(key channeldb.CircuitKey,
-	acceptHeight int32, outcome ResolutionResult) *HtlcFailResolution {
+	acceptHeight int32, outcome FailResolutionResult) *HtlcFailResolution {
 
 	return &HtlcFailResolution{
 		circuitKey:   key,
@@ -59,13 +59,14 @@ type HtlcSettleResolution struct {
 	AcceptHeight int32
 
 	// Outcome indicates the outcome of the invoice registry update.
-	Outcome ResolutionResult
+	Outcome SettleResolutionResult
 }
 
 // NewSettleResolution returns a htlc resolution which is associated with a
 // settle.
-func NewSettleResolution(preimage lntypes.Preimage, key channeldb.CircuitKey,
-	acceptHeight int32, outcome ResolutionResult) *HtlcSettleResolution {
+func NewSettleResolution(preimage lntypes.Preimage,
+	key channeldb.CircuitKey, acceptHeight int32,
+	outcome SettleResolutionResult) *HtlcSettleResolution {
 
 	return &HtlcSettleResolution{
 		Preimage:     preimage,
@@ -101,13 +102,13 @@ type htlcAcceptResolution struct {
 	acceptTime time.Time
 
 	// outcome indicates the outcome of the invoice registry update.
-	outcome ResolutionResult
+	outcome acceptResolutionResult
 }
 
 // newAcceptResolution returns a htlc resolution which is associated with a
 // htlc accept.
 func newAcceptResolution(key channeldb.CircuitKey,
-	outcome ResolutionResult) *htlcAcceptResolution {
+	outcome acceptResolutionResult) *htlcAcceptResolution {
 
 	return &htlcAcceptResolution{
 		circuitKey: key,

--- a/invoices/resolution.go
+++ b/invoices/resolution.go
@@ -1,0 +1,124 @@
+package invoices
+
+import (
+	"time"
+
+	"github.com/lightningnetwork/lnd/channeldb"
+	"github.com/lightningnetwork/lnd/lntypes"
+)
+
+// HtlcResolution describes how an htlc should be resolved.
+type HtlcResolution interface {
+	// CircuitKey returns the circuit key for the htlc that we have a
+	// resolution for.
+	CircuitKey() channeldb.CircuitKey
+}
+
+// HtlcFailResolution is an implementation of the HtlcResolution interface
+// which is returned when a htlc is failed.
+type HtlcFailResolution struct {
+	// circuitKey is the key of the htlc for which we have a resolution.
+	circuitKey channeldb.CircuitKey
+
+	// AcceptHeight is the original height at which the htlc was accepted.
+	AcceptHeight int32
+
+	// outcome indicates the outcome of the invoice registry update.
+	Outcome ResolutionResult
+}
+
+// NewFailResolution returns a htlc failure resolution.
+func NewFailResolution(key channeldb.CircuitKey,
+	acceptHeight int32, outcome ResolutionResult) *HtlcFailResolution {
+
+	return &HtlcFailResolution{
+		circuitKey:   key,
+		AcceptHeight: acceptHeight,
+		Outcome:      outcome,
+	}
+}
+
+// CircuitKey returns the circuit key for the htlc that we have a
+// resolution for.
+//
+// Note: it is part of the HtlcResolution interface.
+func (f *HtlcFailResolution) CircuitKey() channeldb.CircuitKey {
+	return f.circuitKey
+}
+
+// HtlcSettleResolution is an implementation of the HtlcResolution interface
+// which is returned when a htlc is settled.
+type HtlcSettleResolution struct {
+	// Preimage is the htlc preimage. Its value is nil in case of a cancel.
+	Preimage lntypes.Preimage
+
+	// circuitKey is the key of the htlc for which we have a resolution.
+	circuitKey channeldb.CircuitKey
+
+	// acceptHeight is the original height at which the htlc was accepted.
+	AcceptHeight int32
+
+	// Outcome indicates the outcome of the invoice registry update.
+	Outcome ResolutionResult
+}
+
+// NewSettleResolution returns a htlc resolution which is associated with a
+// settle.
+func NewSettleResolution(preimage lntypes.Preimage, key channeldb.CircuitKey,
+	acceptHeight int32, outcome ResolutionResult) *HtlcSettleResolution {
+
+	return &HtlcSettleResolution{
+		Preimage:     preimage,
+		circuitKey:   key,
+		AcceptHeight: acceptHeight,
+		Outcome:      outcome,
+	}
+}
+
+// CircuitKey returns the circuit key for the htlc that we have a
+// resolution for.
+//
+// Note: it is part of the HtlcResolution interface.
+func (s *HtlcSettleResolution) CircuitKey() channeldb.CircuitKey {
+	return s.circuitKey
+}
+
+// htlcAcceptResolution is an implementation of the HtlcResolution interface
+// which is returned when a htlc is accepted. This struct is not exported
+// because the codebase uses a nil resolution to indicate that a htlc was
+// accepted. This struct is used internally in the invoice registry to
+// surface accept resolution results. When an invoice update returns an
+// acceptResolution, a nil resolution should be surfaced.
+type htlcAcceptResolution struct {
+	// circuitKey is the key of the htlc for which we have a resolution.
+	circuitKey channeldb.CircuitKey
+
+	// autoRelease signals that the htlc should be automatically released
+	// after a timeout.
+	autoRelease bool
+
+	// acceptTime is the time at which this htlc was accepted.
+	acceptTime time.Time
+
+	// outcome indicates the outcome of the invoice registry update.
+	outcome ResolutionResult
+}
+
+// newAcceptResolution returns a htlc resolution which is associated with a
+// htlc accept.
+func newAcceptResolution(key channeldb.CircuitKey,
+	outcome ResolutionResult) *htlcAcceptResolution {
+
+	return &htlcAcceptResolution{
+		circuitKey: key,
+		outcome:    outcome,
+	}
+}
+
+// CircuitKey returns the circuit key for the htlc that we have a
+// resolution for.
+//
+// Note: it is part of the HtlcResolution interface.
+func (a *htlcAcceptResolution) CircuitKey() channeldb.CircuitKey {
+	return a.circuitKey
+}

--- a/invoices/resolution_result.go
+++ b/invoices/resolution_result.go
@@ -1,0 +1,200 @@
+package invoices
+
+// acceptResolutionResult provides metadata which about a htlc that was
+// accepted by the registry.
+type acceptResolutionResult uint8
+
+const (
+	resultInvalidAccept acceptResolutionResult = iota
+
+	// resultReplayToAccepted is returned when we replay an accepted
+	// invoice.
+	resultReplayToAccepted
+
+	// resultDuplicateToAccepted is returned when we accept a duplicate
+	// htlc.
+	resultDuplicateToAccepted
+
+	// resultAccepted is returned when we accept a hodl invoice.
+	resultAccepted
+
+	// resultPartialAccepted is returned when we have partially received
+	// payment.
+	resultPartialAccepted
+)
+
+// String returns a string representation of the result.
+func (a acceptResolutionResult) String() string {
+	switch a {
+	case resultInvalidAccept:
+		return "invalid accept result"
+
+	case resultReplayToAccepted:
+		return "replayed htlc to accepted invoice"
+
+	case resultDuplicateToAccepted:
+		return "accepting duplicate payment to accepted invoice"
+
+	case resultAccepted:
+		return "accepted"
+
+	case resultPartialAccepted:
+		return "partial payment accepted"
+
+	default:
+		return "unknown accept resolution result"
+	}
+}
+
+// FailResolutionResult provides metadata about a htlc that was failed by
+// the registry. It can be used to take custom actions on resolution of the
+// htlc.
+type FailResolutionResult uint8
+
+const (
+	resultInvalidFailure FailResolutionResult = iota
+
+	// ResultReplayToCanceled is returned when we replay a canceled invoice.
+	ResultReplayToCanceled
+
+	// ResultInvoiceAlreadyCanceled is returned when trying to pay an
+	// invoice that is already canceled.
+	ResultInvoiceAlreadyCanceled
+
+	// ResultAmountTooLow is returned when an invoice is underpaid.
+	ResultAmountTooLow
+
+	// ResultExpiryTooSoon is returned when we do not accept an invoice
+	// payment because it expires too soon.
+	ResultExpiryTooSoon
+
+	// ResultCanceled is returned when we cancel an invoice and its
+	// associated htlcs.
+	ResultCanceled
+
+	// ResultInvoiceNotOpen is returned when a mpp invoice is not open.
+	ResultInvoiceNotOpen
+
+	// ResultMppTimeout is returned when an invoice paid with multiple
+	// partial payments times out before it is fully paid.
+	ResultMppTimeout
+
+	// ResultAddressMismatch is returned when the payment address for a mpp
+	// invoice does not match.
+	ResultAddressMismatch
+
+	// ResultHtlcSetTotalMismatch is returned when the amount paid by a
+	// htlc does not match its set total.
+	ResultHtlcSetTotalMismatch
+
+	// ResultHtlcSetTotalTooLow is returned when a mpp set total is too low
+	// for an invoice.
+	ResultHtlcSetTotalTooLow
+
+	// ResultHtlcSetOverpayment is returned when a mpp set is overpaid.
+	ResultHtlcSetOverpayment
+
+	// ResultInvoiceNotFound is returned when an attempt is made to pay an
+	// invoice that is unknown to us.
+	ResultInvoiceNotFound
+
+	// ResultKeySendError is returned when we receive invalid keysend
+	// parameters.
+	ResultKeySendError
+
+	// ResultMppInProgress is returned when we are busy receiving a mpp
+	// payment.
+	ResultMppInProgress
+)
+
+// String returns a string representation of the result.
+func (f FailResolutionResult) String() string {
+	switch f {
+	case resultInvalidFailure:
+		return "invalid failure result"
+
+	case ResultReplayToCanceled:
+		return "replayed htlc to canceled invoice"
+
+	case ResultInvoiceAlreadyCanceled:
+		return "invoice already canceled"
+
+	case ResultAmountTooLow:
+		return "amount too low"
+
+	case ResultExpiryTooSoon:
+		return "expiry too soon"
+
+	case ResultCanceled:
+		return "canceled"
+
+	case ResultInvoiceNotOpen:
+		return "invoice no longer open"
+
+	case ResultMppTimeout:
+		return "mpp timeout"
+
+	case ResultAddressMismatch:
+		return "payment address mismatch"
+
+	case ResultHtlcSetTotalMismatch:
+		return "htlc total amt doesn't match set total"
+
+	case ResultHtlcSetTotalTooLow:
+		return "set total too low for invoice"
+
+	case ResultHtlcSetOverpayment:
+		return "mpp is overpaying set total"
+
+	case ResultInvoiceNotFound:
+		return "invoice not found"
+
+	case ResultKeySendError:
+		return "invalid keysend parameters"
+
+	case ResultMppInProgress:
+		return "mpp reception in progress"
+
+	default:
+		return "unknown failure resolution result"
+	}
+}
+
+// SettleResolutionResult provides metadata which about a htlc that was failed
+// by the registry. It can be used to take custom actions on resolution of the
+// htlc.
+type SettleResolutionResult uint8
+
+const (
+	resultInvalidSettle SettleResolutionResult = iota
+
+	// ResultSettled is returned when we settle an invoice.
+	ResultSettled
+
+	// ResultReplayToSettled is returned when we replay a settled invoice.
+	ResultReplayToSettled
+
+	// ResultDuplicateToSettled is returned when we settle an invoice which
+	// has already been settled at least once.
+	ResultDuplicateToSettled
+)
+
+// String returns a string representation of the result.
+func (s SettleResolutionResult) String() string {
+	switch s {
+	case resultInvalidSettle:
+		return "invalid settle result"
+
+	case ResultSettled:
+		return "settled"
+
+	case ResultReplayToSettled:
+		return "replayed htlc to settled invoice"
+
+	case ResultDuplicateToSettled:
+		return "accepting duplicate payment to settled invoice"
+
+	default:
+		return "unknown settle resolution result"
+	}
+}

--- a/invoices/resolution_result.go
+++ b/invoices/resolution_result.go
@@ -107,8 +107,10 @@ const (
 	ResultMppInProgress
 )
 
-// String returns a string representation of the result.
-func (f FailResolutionResult) String() string {
+// FailureString returns a string representation of the result.
+//
+// Note: it is part of the FailureDetail interface.
+func (f FailResolutionResult) FailureString() string {
 	switch f {
 	case resultInvalidFailure:
 		return "invalid failure result"

--- a/invoices/update.go
+++ b/invoices/update.go
@@ -9,164 +9,6 @@ import (
 	"github.com/lightningnetwork/lnd/record"
 )
 
-// ResolutionResult provides metadata which about an invoice update which can
-// be used to take custom actions on resolution of the htlc. Only results which
-// are actionable by the link are exported.
-type ResolutionResult uint8
-
-const (
-	resultInvalid ResolutionResult = iota
-
-	// ResultReplayToCanceled is returned when we replay a canceled invoice.
-	ResultReplayToCanceled
-
-	// ResultReplayToAccepted is returned when we replay an accepted invoice.
-	ResultReplayToAccepted
-
-	// ResultReplayToSettled is returned when we replay a settled invoice.
-	ResultReplayToSettled
-
-	// ResultInvoiceAlreadyCanceled is returned when trying to pay an invoice
-	// that is already canceled.
-	ResultInvoiceAlreadyCanceled
-
-	// ResultAmountTooLow is returned when an invoice is underpaid.
-	ResultAmountTooLow
-
-	// ResultExpiryTooSoon is returned when we do not accept an invoice payment
-	// because it expires too soon.
-	ResultExpiryTooSoon
-
-	// ResultDuplicateToAccepted is returned when we accept a duplicate htlc.
-	ResultDuplicateToAccepted
-
-	// ResultDuplicateToSettled is returned when we settle an invoice which has
-	// already been settled at least once.
-	ResultDuplicateToSettled
-
-	// ResultAccepted is returned when we accept a hodl invoice.
-	ResultAccepted
-
-	// ResultSettled is returned when we settle an invoice.
-	ResultSettled
-
-	// ResultCanceled is returned when we cancel an invoice and its associated
-	// htlcs.
-	ResultCanceled
-
-	// ResultInvoiceNotOpen is returned when a mpp invoice is not open.
-	ResultInvoiceNotOpen
-
-	// ResultPartialAccepted is returned when we have partially received
-	// payment.
-	ResultPartialAccepted
-
-	// ResultMppInProgress is returned when we are busy receiving a mpp payment.
-	ResultMppInProgress
-
-	// ResultMppTimeout is returned when an invoice paid with multiple partial
-	// payments times out before it is fully paid.
-	ResultMppTimeout
-
-	// ResultAddressMismatch is returned when the payment address for a mpp
-	// invoice does not match.
-	ResultAddressMismatch
-
-	// ResultHtlcSetTotalMismatch is returned when the amount paid by a htlc
-	// does not match its set total.
-	ResultHtlcSetTotalMismatch
-
-	// ResultHtlcSetTotalTooLow is returned when a mpp set total is too low for
-	// an invoice.
-	ResultHtlcSetTotalTooLow
-
-	// ResultHtlcSetOverpayment is returned when a mpp set is overpaid.
-	ResultHtlcSetOverpayment
-
-	// ResultInvoiceNotFound is returned when an attempt is made to pay an
-	// invoice that is unknown to us.
-	ResultInvoiceNotFound
-
-	// ResultKeySendError is returned when we receive invalid keysend
-	// parameters.
-	ResultKeySendError
-)
-
-// String returns a human-readable representation of the invoice update result.
-func (u ResolutionResult) String() string {
-	switch u {
-
-	case resultInvalid:
-		return "invalid"
-
-	case ResultReplayToCanceled:
-		return "replayed htlc to canceled invoice"
-
-	case ResultReplayToAccepted:
-		return "replayed htlc to accepted invoice"
-
-	case ResultReplayToSettled:
-		return "replayed htlc to settled invoice"
-
-	case ResultInvoiceAlreadyCanceled:
-		return "invoice already canceled"
-
-	case ResultAmountTooLow:
-		return "amount too low"
-
-	case ResultExpiryTooSoon:
-		return "expiry too soon"
-
-	case ResultDuplicateToAccepted:
-		return "accepting duplicate payment to accepted invoice"
-
-	case ResultDuplicateToSettled:
-		return "accepting duplicate payment to settled invoice"
-
-	case ResultAccepted:
-		return "accepted"
-
-	case ResultSettled:
-		return "settled"
-
-	case ResultCanceled:
-		return "canceled"
-
-	case ResultInvoiceNotOpen:
-		return "invoice no longer open"
-
-	case ResultPartialAccepted:
-		return "partial payment accepted"
-
-	case ResultMppInProgress:
-		return "mpp reception in progress"
-
-	case ResultMppTimeout:
-		return "mpp timeout"
-
-	case ResultAddressMismatch:
-		return "payment address mismatch"
-
-	case ResultHtlcSetTotalMismatch:
-		return "htlc total amt doesn't match set total"
-
-	case ResultHtlcSetTotalTooLow:
-		return "set total too low for invoice"
-
-	case ResultHtlcSetOverpayment:
-		return "mpp is overpaying set total"
-
-	case ResultKeySendError:
-		return "invalid keysend parameters"
-
-	case ResultInvoiceNotFound:
-		return "invoice not found"
-
-	default:
-		return "unknown"
-	}
-}
-
 // invoiceUpdateCtx is an object that describes the context for the invoice
 // update to be carried out.
 type invoiceUpdateCtx struct {
@@ -187,16 +29,17 @@ func (i *invoiceUpdateCtx) log(s string) {
 }
 
 // failRes is a helper function which creates a failure resolution with
-// the information contained in the invoiceUpdateCtx and the outcome provided.
-func (i invoiceUpdateCtx) failRes(outcome ResolutionResult) *HtlcFailResolution {
+// the information contained in the invoiceUpdateCtx and the fail resolution
+// result provided.
+func (i invoiceUpdateCtx) failRes(outcome FailResolutionResult) *HtlcFailResolution {
 	return NewFailResolution(i.circuitKey, i.currentHeight, outcome)
 }
 
 // settleRes is a helper function which creates a settle resolution with
 // the information contained in the invoiceUpdateCtx and the preimage and
-// outcome provided.
+// the settle resolution result provided.
 func (i invoiceUpdateCtx) settleRes(preimage lntypes.Preimage,
-	outcome ResolutionResult) *HtlcSettleResolution {
+	outcome SettleResolutionResult) *HtlcSettleResolution {
 
 	return NewSettleResolution(
 		preimage, i.circuitKey, i.currentHeight, outcome,
@@ -204,8 +47,9 @@ func (i invoiceUpdateCtx) settleRes(preimage lntypes.Preimage,
 }
 
 // acceptRes is a helper function which creates an accept resolution with
-// the information contained in the invoiceUpdateCtx and the outcome provided.
-func (i invoiceUpdateCtx) acceptRes(outcome ResolutionResult) *htlcAcceptResolution {
+// the information contained in the invoiceUpdateCtx and the accept resolution
+// result provided.
+func (i invoiceUpdateCtx) acceptRes(outcome acceptResolutionResult) *htlcAcceptResolution {
 	return newAcceptResolution(i.circuitKey, outcome)
 }
 
@@ -223,7 +67,7 @@ func updateInvoice(ctx *invoiceUpdateCtx, inv *channeldb.Invoice) (
 			return nil, ctx.failRes(ResultReplayToCanceled), nil
 
 		case channeldb.HtlcStateAccepted:
-			return nil, ctx.acceptRes(ResultReplayToAccepted), nil
+			return nil, ctx.acceptRes(resultReplayToAccepted), nil
 
 		case channeldb.HtlcStateSettled:
 			return nil, ctx.settleRes(
@@ -328,7 +172,7 @@ func updateMpp(ctx *invoiceUpdateCtx,
 	// If the invoice cannot be settled yet, only record the htlc.
 	setComplete := newSetTotal == ctx.mpp.TotalMsat()
 	if !setComplete {
-		return &update, ctx.acceptRes(ResultPartialAccepted), nil
+		return &update, ctx.acceptRes(resultPartialAccepted), nil
 	}
 
 	// Check to see if we can settle or this is an hold invoice and
@@ -338,7 +182,7 @@ func updateMpp(ctx *invoiceUpdateCtx,
 		update.State = &channeldb.InvoiceStateUpdateDesc{
 			NewState: channeldb.ContractAccepted,
 		}
-		return &update, ctx.acceptRes(ResultAccepted), nil
+		return &update, ctx.acceptRes(resultAccepted), nil
 	}
 
 	update.State = &channeldb.InvoiceStateUpdateDesc{
@@ -411,7 +255,7 @@ func updateLegacy(ctx *invoiceUpdateCtx,
 	// We do accept or settle the HTLC.
 	switch inv.State {
 	case channeldb.ContractAccepted:
-		return &update, ctx.acceptRes(ResultDuplicateToAccepted), nil
+		return &update, ctx.acceptRes(resultDuplicateToAccepted), nil
 
 	case channeldb.ContractSettled:
 		return &update, ctx.settleRes(
@@ -427,7 +271,7 @@ func updateLegacy(ctx *invoiceUpdateCtx,
 			NewState: channeldb.ContractAccepted,
 		}
 
-		return &update, ctx.acceptRes(ResultAccepted), nil
+		return &update, ctx.acceptRes(resultAccepted), nil
 	}
 
 	update.State = &channeldb.InvoiceStateUpdateDesc{


### PR DESCRIPTION
This PR is change 2 of 4 proposed to add a htlc event notifier to lnd.
~1: #3843~
2: This PR
3: #3781
4: #3848 

--------------
Some refactoring is done in the invoice registry:
- The `HtlcResolution` struct is replaced with an interface implemented by settle and fail resolutions.
- Resolution results are split up into separate enums for settles, fails and accepts
- The callback we use in `NotifyExitHopHtlc` is updated to return a `HtlcResolution` rather than just a resolution result so that we do not need to switch on enum type in multiple places
- A side effect of this is that the resolution result for accepts cannot be logged by the caller because a nil resolution is returned. Temporary logging is added to surface these accept results, with the intention of future refactors introducing a `HtlcAcceptResolution` implementation of the `HtlcResoltion` interface so that htlc accepts do not need to be identified by nil resolutions.

The purpose of this refactoring is to control pairing of resolution types with results on a compiler level (so that a  `HtlcFailResonlution` cannot be created with`SettleResult`). Restricting these results allows us to use failure results to enrich switch errors.

A `linkFailure` field is added to `htlcPacket` to track failures that occur within the switch/ on the outgoing link. This field is not applicable for receives and failures on our incoming link because they are handled separately in the codebase, and do not use the `htlcPacket` type. This is required for notifying link failures in a single place in follow up PRs (in `handledownstreampacket`). 

This PR continues preparation for the addition of a htlcnotifier which provides a subscription of htlc settles, forwards, link failures and forwarding errors. 