### PR TITLE
lnd test: fix csv mempool sweep time

### DIFF
--- a/lntest/itest/lnd_test.go
+++ b/lntest/itest/lnd_test.go
@@ -3186,10 +3186,10 @@ func testChannelForceClosure(net *lntest.NetworkHarness, t *harnessTest) {
 	}
 
 	// Currently within the codebase, the default CSV is 4 relative blocks.
-	// For the persistence test, we generate three blocks, then trigger
+	// For the persistence test, we generate two blocks, then trigger
 	// a restart and then generate the final block that should trigger
 	// the creation of the sweep transaction.
-	if _, err := net.Miner.Node.Generate(defaultCSV - 1); err != nil {
+	if _, err := net.Miner.Node.Generate(defaultCSV - 2); err != nil {
 		t.Fatalf("unable to mine blocks: %v", err)
 	}
 
@@ -3225,12 +3225,12 @@ func testChannelForceClosure(net *lntest.NetworkHarness, t *harnessTest) {
 		}
 
 		// At this point, the nursery should show that the commitment
-		// output has 1 block left before its CSV delay expires. In
+		// output has 2 block left before its CSV delay expires. In
 		// total, we have mined exactly defaultCSV blocks, so the htlc
 		// outputs should also reflect that this many blocks have
 		// passed.
 		err = checkCommitmentMaturity(
-			forceClose, commCsvMaturityHeight, 1,
+			forceClose, commCsvMaturityHeight, 2,
 		)
 		if err != nil {
 			return err
@@ -3258,9 +3258,9 @@ func testChannelForceClosure(net *lntest.NetworkHarness, t *harnessTest) {
 		t.Fatalf("unable to mine blocks: %v", err)
 	}
 
-	// At this point, the sweeping transaction should now be broadcast. So
-	// we fetch the node's mempool to ensure it has been properly
-	// broadcast.
+	// At this point, the CSV will expire in the next block, meaning that
+	// the sweeping transaction should now be broadcast. So we fetch the
+	// node's mempool to ensure it has been properly broadcast.
 	sweepingTXID, err := waitForTxInMempool(net.Miner.Node, minerMempoolTimeout)
 	if err != nil {
 		t.Fatalf("failed to get sweep tx from mempool: %v", err)
@@ -3361,7 +3361,7 @@ func testChannelForceClosure(net *lntest.NetworkHarness, t *harnessTest) {
 	// of blocks we have generated since adding it to the nursery, and take
 	// an additional block off so that we end up one block shy of the expiry
 	// height, and add the block padding.
-	cltvHeightDelta := padCLTV(defaultCLTV - defaultCSV - 2 - 1)
+	cltvHeightDelta := padCLTV(defaultCLTV - defaultCSV - 1 - 1)
 
 	// Advance the blockchain until just before the CLTV expires, nothing
 	// exciting should have happened during this time.


### PR DESCRIPTION
Since CSV locked outputs specifies the first block where they are
allowed to be included, they can actually be added one block earlier
into the mempool.

This led to a flake, where the sweep tx was already in the mempool at
the time we mined the last block, causing the next mempool check to
fail.

Fixes 
```
    --- FAIL: TestLightningNetworkDaemon/channel_force_closure (49.83s)
        lnd_test.go:100: Failed: (channel force closure): exited with error: 
            *errors.errorString failed to get sweep tx from mempool: wanted 1, found 0 txs in mempool: []
            /home/travis/gopath/src/github.com/lightningnetwork/lnd/lntest/itest/lnd_test.go:3266 (0xd993f9)
            	testChannelForceClosure: t.Fatalf("failed to get sweep tx from mempool: %v", err)
            /home/travis/gopath/src/github.com/lightningnetwork/lnd/lntest/itest/lnd_test.go:123 (0xd884da)
            	(*harnessTest).RunTestCase: testCase.test(h.lndHarness, h)
            /home/travis/gopath/src/github.com/lightningnetwork/lnd/lntest/itest/lnd_test.go:15298 (0xdf6d2c)
            	TestLightningNetworkDaemon.func4: ht.RunTestCase(testCase)
            /home/travis/.gimme/versions/go1.13.5.linux.amd64/src/testing/testing.go:909 (0x50af09)
            	tRunner: fn(t)
            /home/travis/.gimme/versions/go1.13.5.linux.amd64/src/runtime/asm_amd64.s:1357 (0x4610e1)
            	goexit: BYTE	$0x90	// NOP
FAIL
FAIL	github.com/lightningnetwork/lnd/lntest/itest	253.229s
FAIL
```