### PR TITLE
lnrpc: Add macaroon entry for peers subscription

### DIFF
--- a/rpcserver.go
+++ b/rpcserver.go
@@ -436,6 +436,10 @@ func mainRPCServerPermissions() map[string][]bakery.Op {
 			Entity: "macaroon",
 			Action: "generate",
 		}},
+		"/lnrpc.Lightning/SubscribePeerEvents": {{
+			Entity: "peers",
+			Action: "read",
+		}},
 	}
 }
 


### PR DESCRIPTION
Require peers read access to subscribe to peer events