### PR TITLE
contractcourt: wait one extra block before sweeping commit

### DIFF
--- a/contractcourt/commit_sweep_resolver.go
+++ b/contractcourt/commit_sweep_resolver.go
@@ -164,9 +164,11 @@ func (c *commitSweepResolver) Resolve() (ContractResolver, error) {
 		c.log.Debugf("waiting for csv lock to expire at height %v",
 			unlockHeight)
 
-		// We only need to wait for the block before the block that
-		// unlocks the spend path.
-		err := c.waitForHeight(unlockHeight - 1)
+		// We really only need to wait for the block before the block
+		// that unlocks the spend path, but we wait one extra block to
+		// ensure propagation and to keep the old behavior from when
+		// the utxonursery did the commit sweep.
+		err := c.waitForHeight(unlockHeight)
 		if err != nil {
 			return nil, err
 		}

--- a/contractcourt/commit_sweep_resolver_test.go
+++ b/contractcourt/commit_sweep_resolver_test.go
@@ -204,9 +204,11 @@ func TestCommitSweepResolverDelay(t *testing.T) {
 	case <-time.After(100 * time.Millisecond):
 	}
 
-	// A new block arrives. The commit tx confirmed at height -1 and the csv
-	// is 3, so a spend will be valid in the first block after height +1.
-	ctx.notifyEpoch(testInitialBlockHeight + 1)
+	// A new block arrives. The commit tx confirmed at height -1 and the
+	// csv is 3, so a spend will be valid in the first block after height
+	// +1. Note that the resolver waits for +2  before publishing
+	// regardless, since this is legacy behavior from the nursery era.
+	ctx.notifyEpoch(testInitialBlockHeight + 2)
 
 	<-ctx.sweeper.sweptInputs
 


### PR DESCRIPTION
The integration tests are written with the assumption, since this was
the old bahavior before removal of the utxo nursery.

Alternative to #3847 