### PR TITLE
build: Prepend newline to first byte slice logged using LogWriter Write method

### DIFF
--- a/build/log.go
+++ b/build/log.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io"
 	"strings"
+	"sync"
 
 	"github.com/btcsuite/btclog"
 )
@@ -45,6 +46,12 @@ type LogWriter struct {
 	// is written to by the Write method of the LogWriter type. This only
 	// needs to be set if neither the stdlog or nolog builds are set.
 	RotatorPipe *io.PipeWriter
+
+	// startNewline is used in the LogWriter’s Write function to prepend a
+	// newline to the first byte slice that is logged. This is required to start
+	// logging on a new line on restart, rather than appending to the last log
+	// written
+	startNewLine sync.Once
 }
 
 // NewSubLogger constructs a new subsystem log from the current LogWriter

--- a/build/log_default.go
+++ b/build/log_default.go
@@ -12,6 +12,14 @@ const LoggingType = LogTypeDefault
 func (w *LogWriter) Write(b []byte) (int, error) {
 	os.Stdout.Write(b)
 	if w.RotatorPipe != nil {
+
+		// A new line is appended to the first byte slice that is logged. This is required
+		// so that logging starts on a new line on restart, rather than appending to the
+		// last log written
+		w.startNewLine.Do(func() {
+			b = []byte("\n" + string(b))
+		})
+
 		w.RotatorPipe.Write(b)
 	}
 	return len(b), nil


### PR DESCRIPTION
This PR fixes #3801. It results in a newline being written to the log for the first byte slice written.

The problem reported was that lnd logged the "Shutdown complete" message without a trailing newline. 
However, after further investigation it was found that the `err := logWriter.Close()` line in the 
lnd.go Main function was to blame for this as it trims any new lines in the log file.

The fix was to change the LogWriter Write function so that it adds a newline to the first byte
slice to be written to the log

