### PR TITLE
lntest: Don't leak node's grpc conn

### DIFF
--- a/lntest/node.go
+++ b/lntest/node.go
@@ -272,6 +272,9 @@ type HarnessNode struct {
 
 	invoicesrpc.InvoicesClient
 
+	// conn is the underlying connection to the grpc endpoint of the node.
+	conn *grpc.ClientConn
+
 	// RouterClient, WalletKitClient, WatchtowerClient cannot be embedded,
 	// because a name collision would occur with LightningClient.
 	RouterClient     routerrpc.RouterClient
@@ -552,6 +555,7 @@ func (hn *HarnessNode) Unlock(ctx context.Context,
 func (hn *HarnessNode) initLightningClient(conn *grpc.ClientConn) error {
 	// Construct the LightningClient that will allow us to use the
 	// HarnessNode directly for normal rpc operations.
+	hn.conn = conn
 	hn.LightningClient = lnrpc.NewLightningClient(conn)
 	hn.InvoicesClient = invoicesrpc.NewInvoicesClient(conn)
 	hn.RouterClient = routerrpc.NewRouterClient(conn)
@@ -790,6 +794,15 @@ func (hn *HarnessNode) stop() error {
 	hn.WalletUnlockerClient = nil
 	hn.Watchtower = nil
 	hn.WatchtowerClient = nil
+
+	// Close any attempts at further grpc connections.
+	if hn.conn != nil {
+		err := hn.conn.Close()
+		if err != nil {
+			return fmt.Errorf("error attempting to stop grpc client: %v", err)
+		}
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
This changes the HarnessNode structure to hold onto the client grpc
connection made during startup so that it can close it during shutdown.

This is needed because the grpc.Dial function spins a new goroutine that
attempts to maintain an open connection to the target endpoint and
without calling Close() in the connection while shutting down the node
we leak this goroutine to the rest of the tests.

The easiest way to verify this is the case is by running an interactive profile of the test binary during `make itest` and noticing a large number of goroutines stuck in the grpc lib.