### PR TITLE
autopilot: fix memChannelGraph channel edge addition

### DIFF
--- a/autopilot/graph.go
+++ b/autopilot/graph.go
@@ -307,7 +307,7 @@ func (d *databaseChannelGraph) addRandNode() (*btcec.PublicKey, error) {
 // memChannelGraph is an implementation of the autopilot.ChannelGraph backed by
 // an in-memory graph.
 type memChannelGraph struct {
-	graph map[NodeID]memNode
+	graph map[NodeID]*memNode
 }
 
 // A compile time assertion to ensure memChannelGraph meets the
@@ -318,7 +318,7 @@ var _ ChannelGraph = (*memChannelGraph)(nil)
 // implementation.
 func newMemChannelGraph() *memChannelGraph {
 	return &memChannelGraph{
-		graph: make(map[NodeID]memNode),
+		graph: make(map[NodeID]*memNode),
 	}
 }
 
@@ -360,14 +360,14 @@ func (m *memChannelGraph) addRandChannel(node1, node2 *btcec.PublicKey,
 	capacity btcutil.Amount) (*ChannelEdge, *ChannelEdge, error) {
 
 	var (
-		vertex1, vertex2 memNode
+		vertex1, vertex2 *memNode
 		ok               bool
 	)
 
 	if node1 != nil {
 		vertex1, ok = m.graph[NewNodeID(node1)]
 		if !ok {
-			vertex1 = memNode{
+			vertex1 = &memNode{
 				pub: node1,
 				addrs: []net.Addr{
 					&net.TCPAddr{
@@ -381,7 +381,7 @@ func (m *memChannelGraph) addRandChannel(node1, node2 *btcec.PublicKey,
 		if err != nil {
 			return nil, nil, err
 		}
-		vertex1 = memNode{
+		vertex1 = &memNode{
 			pub: newPub,
 			addrs: []net.Addr{
 				&net.TCPAddr{
@@ -394,7 +394,7 @@ func (m *memChannelGraph) addRandChannel(node1, node2 *btcec.PublicKey,
 	if node2 != nil {
 		vertex2, ok = m.graph[NewNodeID(node2)]
 		if !ok {
-			vertex2 = memNode{
+			vertex2 = &memNode{
 				pub: node2,
 				addrs: []net.Addr{
 					&net.TCPAddr{
@@ -408,7 +408,7 @@ func (m *memChannelGraph) addRandChannel(node1, node2 *btcec.PublicKey,
 		if err != nil {
 			return nil, nil, err
 		}
-		vertex2 = memNode{
+		vertex2 = &memNode{
 			pub: newPub,
 			addrs: []net.Addr{
 				&net.TCPAddr{
@@ -446,7 +446,7 @@ func (m *memChannelGraph) addRandNode() (*btcec.PublicKey, error) {
 	if err != nil {
 		return nil, err
 	}
-	vertex := memNode{
+	vertex := &memNode{
 		pub: newPub,
 		addrs: []net.Addr{
 			&net.TCPAddr{


### PR DESCRIPTION
This PR fixes an issue that happens when adding a new channel edge
between two nodes in a memChannelGraph. Originally a channel edge held a
node value which made the graph different when iterating from the two
endpoints of an edge. This is simply fixed by holding pointers instead.