### PR TITLE
routerrpc: allow dest_features graph fallback

### DIFF
--- a/lnrpc/routerrpc/router.pb.go
+++ b/lnrpc/routerrpc/router.pb.go
@@ -258,7 +258,9 @@ type SendPaymentRequest struct {
 	//*
 	//Features assumed to be supported by the final node. All transitive feature
 	//depdencies must also be set properly. For a given feature bit pair, either
-	//optional or remote may be set, but not both.
+	//optional or remote may be set, but not both. If this field is nil or empty,
+	//the router will try to load destination features from the graph as a
+	//fallback.
 	DestFeatures         []lnrpc.FeatureBit `protobuf:"varint,16,rep,packed,name=dest_features,json=destFeatures,proto3,enum=lnrpc.FeatureBit" json:"dest_features,omitempty"`
 	XXX_NoUnkeyedLiteral struct{}           `json:"-"`
 	XXX_unrecognized     []byte             `json:"-"`

--- a/lnrpc/routerrpc/router.proto
+++ b/lnrpc/routerrpc/router.proto
@@ -109,7 +109,9 @@ message SendPaymentRequest {
     /**
     Features assumed to be supported by the final node. All transitive feature
     depdencies must also be set properly. For a given feature bit pair, either
-    optional or remote may be set, but not both.
+    optional or remote may be set, but not both. If this field is nil or empty,
+    the router will try to load destination features from the graph as a
+    fallback.
     */
     repeated lnrpc.FeatureBit dest_features = 16;
 }

--- a/lnrpc/routerrpc/router_backend.go
+++ b/lnrpc/routerrpc/router_backend.go
@@ -710,7 +710,15 @@ func unmarshallHopHint(rpcHint *lnrpc.HopHint) (zpay32.HopHint, error) {
 // UnmarshalFeatures converts a list of uint32's into a valid feature vector.
 // This method checks that feature bit pairs aren't assigned toegether, and
 // validates transitive depdencies.
-func UnmarshalFeatures(rpcFeatures []lnrpc.FeatureBit) (*lnwire.FeatureVector, error) {
+func UnmarshalFeatures(
+	rpcFeatures []lnrpc.FeatureBit) (*lnwire.FeatureVector, error) {
+
+	// If no destination features are specified we'll return nil to signal
+	// that the router should try to use the graph as a fallback.
+	if rpcFeatures == nil {
+		return nil, nil
+	}
+
 	raw := lnwire.NewRawFeatureVector()
 	for _, bit := range rpcFeatures {
 		err := raw.SafeSet(lnwire.FeatureBit(bit))

--- a/lnrpc/rpc.pb.go
+++ b/lnrpc/rpc.pb.go
@@ -1229,7 +1229,9 @@ type SendRequest struct {
 	//*
 	//Features assumed to be supported by the final node. All transitive feature
 	//depdencies must also be set properly. For a given feature bit pair, either
-	//optional or remote may be set, but not both.
+	//optional or remote may be set, but not both. If this field is nil or empty,
+	//the router will try to load destination features from the graph as a
+	//fallback.
 	DestFeatures         []FeatureBit `protobuf:"varint,15,rep,packed,name=dest_features,json=destFeatures,proto3,enum=lnrpc.FeatureBit" json:"dest_features,omitempty"`
 	XXX_NoUnkeyedLiteral struct{}     `json:"-"`
 	XXX_unrecognized     []byte       `json:"-"`

--- a/lnrpc/rpc.proto
+++ b/lnrpc/rpc.proto
@@ -971,7 +971,9 @@ message SendRequest {
     /**
     Features assumed to be supported by the final node. All transitive feature
     depdencies must also be set properly. For a given feature bit pair, either
-    optional or remote may be set, but not both.
+    optional or remote may be set, but not both. If this field is nil or empty,
+    the router will try to load destination features from the graph as a
+    fallback.
     */
     repeated FeatureBit dest_features = 15;
 }

--- a/lnrpc/rpc.swagger.json
+++ b/lnrpc/rpc.swagger.json
@@ -3874,7 +3874,7 @@
           "items": {
             "$ref": "#/definitions/lnrpcFeatureBit"
           },
-          "description": "*\nFeatures assumed to be supported by the final node. All transitive feature\ndepdencies must also be set properly. For a given feature bit pair, either\noptional or remote may be set, but not both."
+          "description": "*\nFeatures assumed to be supported by the final node. All transitive feature\ndepdencies must also be set properly. For a given feature bit pair, either\noptional or remote may be set, but not both. If this field is nil or empty,\nthe router will try to load destination features from the graph as a\nfallback."
         }
       }
     },


### PR DESCRIPTION
Alternative to #3859 

Primary distinction is that `nil` or empty features will fall back to using the graph, rather than
needing an extra bool to override in the case of empty features. In practice, it seems unlikely that one would need to override with empty features since most things going forward will at least be built on `var_onion_optin`.