### PR TITLE
Fix typo in "query" rpc for autopilot.

### DIFF
--- a/cmd/lncli/autopilotrpc_active.go
+++ b/cmd/lncli/autopilotrpc_active.go
@@ -96,7 +96,7 @@ func disable(ctx *cli.Context) error {
 
 var queryScoresCommand = cli.Command{
 	Name:        "query",
-	Usage:       "Query the autopilot heuristcs for nodes' scores.",
+	Usage:       "Query the autopilot heuristics for nodes' scores.",
 	ArgsUsage:   "[flags] <pubkey> <pubkey> <pubkey> ...",
 	Description: "",
 	Action:      actionDecorator(queryScores),


### PR DESCRIPTION
This commit fixes a typo in the NAME descriptor for `lncli autopilot query`. Prior to this commit:

```
$ lncli autopilot query -h
NAME:
   lncli autopilot query - Query the autopilot heuristcs for nodes' scores.

USAGE:
   lncli autopilot query [command options] [flags] <pubkey> <pubkey> <pubkey> ...

OPTIONS:
   --ignorelocalstate, -i  Ignore local channel state when calculating scores.

```

The word "heuristics" is misspelled as "heuristcs". After this commit:

```
$ lncli autopilot query -h
NAME:
   lncli autopilot query - Query the autopilot heuristics for nodes' scores.

USAGE:
   lncli autopilot query [command options] [flags] <pubkey> <pubkey> <pubkey> ...

OPTIONS:
   --ignorelocalstate, -i  Ignore local channel state when calculating scores.

``` 