### PR TITLE
htlcswitch+lnwallet+channeldb: invalid sig fix

### DIFF
--- a/channeldb/channel.go
+++ b/channeldb/channel.go
@@ -1239,11 +1239,11 @@ func syncNewChannel(tx *bbolt.Tx, c *OpenChannel, addrs []net.Addr) error {
 	return putLinkNode(nodeInfoBucket, linkNode)
 }
 
-// UpdateCommitment updates the commitment state for the specified party
-// (remote or local). The commitment stat completely describes the balance
-// state at this point in the commitment chain. This method its to be called on
-// two occasions: when we revoke our prior commitment state, and when the
-// remote party revokes their prior commitment state.
+// UpdateCommitment updates the local commitment state. It locks in the pending
+// local updates that were received by us from the remote party. The commitment
+// state completely describes the balance state at this point in the commitment
+// chain. This method its to be called when we revoke our prior commitment
+// state.
 func (c *OpenChannel) UpdateCommitment(newCommitment *ChannelCommitment) error {
 	c.Lock()
 	defer c.Unlock()

--- a/channeldb/db_test.go
+++ b/channeldb/db_test.go
@@ -403,7 +403,7 @@ func TestRestoreChannelShells(t *testing.T) {
 	// Ensure that it isn't possible to modify the commitment state machine
 	// of this restored channel.
 	channel := nodeChans[0]
-	err = channel.UpdateCommitment(nil)
+	err = channel.UpdateCommitment(nil, nil)
 	if err != ErrNoRestoredChannelMutation {
 		t.Fatalf("able to mutate restored channel")
 	}

--- a/lnwallet/channel.go
+++ b/lnwallet/channel.go
@@ -1564,6 +1564,7 @@ func (lc *LightningChannel) logUpdateToPayDesc(logUpdate *channeldb.LogUpdate,
 
 		pd = &PaymentDescriptor{
 			Amount:                   ogHTLC.Amount,
+			RHash:                    ogHTLC.RHash,
 			RPreimage:                wireMsg.PaymentPreimage,
 			LogIndex:                 logUpdate.LogIndex,
 			ParentIndex:              ogHTLC.HtlcIndex,

--- a/lnwallet/channel_test.go
+++ b/lnwallet/channel_test.go
@@ -3151,10 +3151,9 @@ func TestChanSyncOweCommitmentPendingRemote(t *testing.T) {
 		t.Fatalf("unable to sign commitment: %v", err)
 	}
 
-	// This commitment is expected to contain no htlcs anymore, but because
-	// of a bug it is still present. THIS IS NOT CORRECT!
-	if len(bobHtlcSigs) != 2 {
-		t.Fatal("expected htlc to still be pending")
+	// This commitment is expected to contain no htlcs anymore.
+	if len(bobHtlcSigs) != 0 {
+		t.Fatalf("no htlcs expected, but got %v", len(bobHtlcSigs))
 	}
 }
 
@@ -6289,11 +6288,8 @@ func TestChannelRestoreUpdateLogsFailedHTLC(t *testing.T) {
 	// sent a new signature yet. If we'd now restart and restore, the htlc
 	// failure update should still be waiting for inclusion in Alice's next
 	// signature. Otherwise the produced signature would be invalid.
-	//
-	// THIS IS NOT HAPPENING. The update log entry is dropped after a
-	// restart!
 	assertInLogs(t, aliceChannel, 1, 0, 0, 1)
-	restoreAndAssert(t, aliceChannel, 1, 0, 0, 0)
+	restoreAndAssert(t, aliceChannel, 1, 0, 0, 1)
 
 	// Now send a signature from Alice. This will give Bob a new commitment
 	// where the HTLC is removed.

--- a/lnwallet/channel_test.go
+++ b/lnwallet/channel_test.go
@@ -6178,7 +6178,12 @@ func TestChannelRestoreUpdateLogsFailedHTLC(t *testing.T) {
 	// At this point Alice has advanced her local commitment chain to a
 	// commitment with no HTLCs left. The current state on her remote
 	// commitment chain, however, still has the HTLC active, as she hasn't
-	// sent a new signature yet.
+	// sent a new signature yet. If we'd now restart and restore, the htlc
+	// failure update should still be waiting for inclusion in Alice's next
+	// signature. Otherwise the produced signature would be invalid.
+	//
+	// THIS IS NOT HAPPENING. The update log entry is dropped after a
+	// restart!
 	assertInLogs(t, aliceChannel, 1, 0, 0, 1)
 	restoreAndAssert(t, aliceChannel, 1, 0, 0, 0)
 

--- a/lnwallet/channel_test.go
+++ b/lnwallet/channel_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/lightningnetwork/lnd/chainntnfs"
 	"github.com/lightningnetwork/lnd/channeldb"
 	"github.com/lightningnetwork/lnd/input"
+	"github.com/lightningnetwork/lnd/lntypes"
 	"github.com/lightningnetwork/lnd/lnwallet/chainfee"
 	"github.com/lightningnetwork/lnd/lnwire"
 )
@@ -3047,6 +3048,113 @@ func TestChanSyncOweCommitment(t *testing.T) {
 	if bobChannel.channelState.TotalMSatReceived != htlcAmt {
 		t.Fatalf("wrong value for msat recv: expected %v, got %v",
 			htlcAmt, bobChannel.channelState.TotalMSatReceived)
+	}
+}
+
+// TestChanSyncOweCommitmentPendingRemote asserts that local updates are applied
+// to the remote commit across restarts.
+func TestChanSyncOweCommitmentPendingRemote(t *testing.T) {
+	t.Parallel()
+
+	// Create a test channel which will be used for the duration of this
+	// unittest.
+	aliceChannel, bobChannel, cleanUp, err := CreateTestChannels(true)
+	if err != nil {
+		t.Fatalf("unable to create test channels: %v", err)
+	}
+	defer cleanUp()
+
+	var fakeOnionBlob [lnwire.OnionPacketSize]byte
+	copy(fakeOnionBlob[:], bytes.Repeat([]byte{0x05}, lnwire.OnionPacketSize))
+
+	// We'll start off the scenario where Bob send two htlcs to Alice in a
+	// single state update.
+	var preimages []lntypes.Preimage
+	const numHtlcs = 2
+	for id := byte(0); id < numHtlcs; id++ {
+		htlcAmt := lnwire.NewMSatFromSatoshis(20000)
+		var bobPreimage [32]byte
+		copy(bobPreimage[:], bytes.Repeat([]byte{id}, 32))
+		rHash := sha256.Sum256(bobPreimage[:])
+		h := &lnwire.UpdateAddHTLC{
+			PaymentHash: rHash,
+			Amount:      htlcAmt,
+			Expiry:      uint32(10),
+			OnionBlob:   fakeOnionBlob,
+		}
+
+		htlcIndex, err := bobChannel.AddHTLC(h, nil)
+		if err != nil {
+			t.Fatalf("unable to add bob's htlc: %v", err)
+		}
+
+		h.ID = htlcIndex
+		if _, err := aliceChannel.ReceiveHTLC(h); err != nil {
+			t.Fatalf("unable to recv bob's htlc: %v", err)
+		}
+
+		preimages = append(preimages, bobPreimage)
+	}
+
+	// With the HTLCs applied to both update logs, we'll initiate a state
+	// transition from Bob.
+	if err := ForceStateTransition(bobChannel, aliceChannel); err != nil {
+		t.Fatalf("unable to complete bob's state transition: %v", err)
+	}
+
+	// Next, Alice settles the HTLCs from Bob in distinct state updates.
+	for i := 0; i < numHtlcs; i++ {
+		err = aliceChannel.SettleHTLC(preimages[i], uint64(i), nil, nil, nil)
+		if err != nil {
+			t.Fatalf("unable to settle htlc: %v", err)
+		}
+		err = bobChannel.ReceiveHTLCSettle(preimages[i], uint64(i))
+		if err != nil {
+			t.Fatalf("unable to settle htlc: %v", err)
+		}
+
+		aliceSig, aliceHtlcSigs, _, err := aliceChannel.SignNextCommitment()
+		if err != nil {
+			t.Fatalf("unable to sign commitment: %v", err)
+		}
+
+		err = bobChannel.ReceiveNewCommitment(aliceSig, aliceHtlcSigs)
+		if err != nil {
+			t.Fatalf("unable to receive commitment: %v", err)
+		}
+
+		// Bob revokes his current commitment. After this call
+		// completes, the htlc is settled on the local commitment
+		// transaction. Bob still owes Alice a signature to also settle
+		// the htlc on her local commitment transaction.
+		bobRevoke, _, err := bobChannel.RevokeCurrentCommitment()
+		if err != nil {
+			t.Fatalf("unable to revoke commitment: %v", err)
+		}
+
+		_, _, _, _, err = aliceChannel.ReceiveRevocation(bobRevoke)
+		if err != nil {
+			t.Fatalf("unable to revoke commitment: %v", err)
+		}
+	}
+
+	// We restart Bob. This should have no impact on further message that
+	// are generated.
+	bobChannel, err = restartChannel(bobChannel)
+	if err != nil {
+		t.Fatalf("unable to restart bob: %v", err)
+	}
+
+	// Bob signs the commitment he owes.
+	_, bobHtlcSigs, _, err := bobChannel.SignNextCommitment()
+	if err != nil {
+		t.Fatalf("unable to sign commitment: %v", err)
+	}
+
+	// This commitment is expected to contain no htlcs anymore, but because
+	// of a bug it is still present. THIS IS NOT CORRECT!
+	if len(bobHtlcSigs) != 2 {
+		t.Fatal("expected htlc to still be pending")
 	}
 }
 


### PR DESCRIPTION
This PR persistently stores updates received from the remote party until we've produced a signature that includes these updates. Previously those updates were only stored in memory and dropped across restarts. This lead to the production of an invalid signature and channel force closure.

Fixes #3822 
Fixes #3126 
