### PR TITLE
Re-enable TestLightningWallet tests

### DIFF
--- a/lnwallet/interface_test.go
+++ b/lnwallet/interface_test.go
@@ -2780,7 +2780,14 @@ func testSingleFunderExternalFundingTx(miner *rpctest.Harness,
 	bobShimIntent, err := chanfunding.NewCannedAssembler(
 		*chanPoint, btcutil.Amount(chanAmt), &bobFundingKey,
 		aliceFundingKey.PubKey, false,
-	).ProvisionChannel(nil)
+	).ProvisionChannel(&chanfunding.Request{
+		LocalAmt: btcutil.Amount(chanAmt),
+		MinConfs: 1,
+		FeeRate:  253,
+		ChangeAddr: func() (btcutil.Address, error) {
+			return bob.NewAddress(lnwallet.WitnessPubKey, true)
+		},
+	})
 	if err != nil {
 		t.Fatalf("unable to create shim intent for bob: %v", err)
 	}

--- a/lnwallet/interface_test.go
+++ b/lnwallet/interface_test.go
@@ -3147,7 +3147,6 @@ func runTests(t *testing.T, walletDriver *lnwallet.WalletDriver,
 				strings.Contains(walletTest.name, "dual funder") {
 				t.Skip("skipping dual funder tests for neutrino")
 			}
-			return
 
 			walletTest.test(miningNode, alice, bob, t)
 		})


### PR DESCRIPTION
You can verify they are not running by manually running `make unit case=TestLightningWallet pkg=lnwallet` and verifying they all take 0s to execute.

This also fixes a broken test in the TestLightningWallet test suite.