### PR TITLE
contractcourt: keep channels with timed-out initiated htlcs.

### DIFF
--- a/config.go
+++ b/config.go
@@ -58,15 +58,16 @@ const (
 	// pending channels permitted per peer.
 	DefaultMaxPendingChannels = 1
 
-	defaultNoSeedBackup             = false
-	defaultTrickleDelay             = 90 * 1000
-	defaultChanStatusSampleInterval = time.Minute
-	defaultChanEnableTimeout        = 19 * time.Minute
-	defaultChanDisableTimeout       = 20 * time.Minute
-	defaultMaxLogFiles              = 3
-	defaultMaxLogFileSize           = 10
-	defaultMinBackoff               = time.Second
-	defaultMaxBackoff               = time.Hour
+	defaultNoSeedBackup                  = false
+	defaultPaymentsExpirationGracePeriod = time.Duration(0)
+	defaultTrickleDelay                  = 90 * 1000
+	defaultChanStatusSampleInterval      = time.Minute
+	defaultChanEnableTimeout             = 19 * time.Minute
+	defaultChanDisableTimeout            = 20 * time.Minute
+	defaultMaxLogFiles                   = 3
+	defaultMaxLogFileSize                = 10
+	defaultMinBackoff                    = time.Second
+	defaultMaxBackoff                    = time.Hour
 
 	defaultTorSOCKSPort            = 9050
 	defaultTorDNSHost              = "soa.nodes.lightning.directory"
@@ -298,10 +299,11 @@ type config struct {
 
 	NoSeedBackup bool `long:"noseedbackup" description:"If true, NO SEED WILL BE EXPOSED AND THE WALLET WILL BE ENCRYPTED USING THE DEFAULT PASSPHRASE -- EVER. THIS FLAG IS ONLY FOR TESTING AND IS BEING DEPRECATED."`
 
-	TrickleDelay             int           `long:"trickledelay" description:"Time in milliseconds between each release of announcements to the network"`
-	ChanEnableTimeout        time.Duration `long:"chan-enable-timeout" description:"The duration that a peer connection must be stable before attempting to send a channel update to reenable or cancel a pending disables of the peer's channels on the network (default: 19m)."`
-	ChanDisableTimeout       time.Duration `long:"chan-disable-timeout" description:"The duration that must elapse after first detecting that an already active channel is actually inactive and sending channel update disabling it to the network. The pending disable can be canceled if the peer reconnects and becomes stable for chan-enable-timeout before the disable update is sent. (default: 20m)"`
-	ChanStatusSampleInterval time.Duration `long:"chan-status-sample-interval" description:"The polling interval between attempts to detect if an active channel has become inactive due to its peer going offline. (default: 1m)"`
+	PaymentsExpirationGracePeriod time.Duration `long:"payments-expiration-grace-period" description:"A period to wait before force closing channels with outgoing htlcs that have timed-out and are a result of this node initiated payments."`
+	TrickleDelay                  int           `long:"trickledelay" description:"Time in milliseconds between each release of announcements to the network"`
+	ChanEnableTimeout             time.Duration `long:"chan-enable-timeout" description:"The duration that a peer connection must be stable before attempting to send a channel update to reenable or cancel a pending disables of the peer's channels on the network (default: 19m)."`
+	ChanDisableTimeout            time.Duration `long:"chan-disable-timeout" description:"The duration that must elapse after first detecting that an already active channel is actually inactive and sending channel update disabling it to the network. The pending disable can be canceled if the peer reconnects and becomes stable for chan-enable-timeout before the disable update is sent. (default: 20m)"`
+	ChanStatusSampleInterval      time.Duration `long:"chan-status-sample-interval" description:"The polling interval between attempts to detect if an active channel has become inactive due to its peer going offline. (default: 1m)"`
 
 	Alias       string `long:"alias" description:"The node alias. Used as a moniker by peers and intelligence services"`
 	Color       string `long:"color" description:"The color of the node in hex format (i.e. '#3399FF'). Used to customize node appearance in intelligence services"`
@@ -416,15 +418,16 @@ func loadConfig() (*config, error) {
 				"preferential": 1.0,
 			},
 		},
-		TrickleDelay:             defaultTrickleDelay,
-		ChanStatusSampleInterval: defaultChanStatusSampleInterval,
-		ChanEnableTimeout:        defaultChanEnableTimeout,
-		ChanDisableTimeout:       defaultChanDisableTimeout,
-		Alias:                    defaultAlias,
-		Color:                    defaultColor,
-		MinChanSize:              int64(minChanFundingSize),
-		NumGraphSyncPeers:        defaultMinPeers,
-		HistoricalSyncInterval:   discovery.DefaultHistoricalSyncInterval,
+		PaymentsExpirationGracePeriod: defaultPaymentsExpirationGracePeriod,
+		TrickleDelay:                  defaultTrickleDelay,
+		ChanStatusSampleInterval:      defaultChanStatusSampleInterval,
+		ChanEnableTimeout:             defaultChanEnableTimeout,
+		ChanDisableTimeout:            defaultChanDisableTimeout,
+		Alias:                         defaultAlias,
+		Color:                         defaultColor,
+		MinChanSize:                   int64(minChanFundingSize),
+		NumGraphSyncPeers:             defaultMinPeers,
+		HistoricalSyncInterval:        discovery.DefaultHistoricalSyncInterval,
 		Tor: &torConfig{
 			SOCKS:   defaultTorSOCKS,
 			DNS:     defaultTorDNS,

--- a/contractcourt/chain_arbitrator.go
+++ b/contractcourt/chain_arbitrator.go
@@ -5,12 +5,14 @@ import (
 	"fmt"
 	"sync"
 	"sync/atomic"
+	"time"
 
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcd/wire"
 	"github.com/btcsuite/btcutil"
 	"github.com/lightningnetwork/lnd/chainntnfs"
 	"github.com/lightningnetwork/lnd/channeldb"
+	"github.com/lightningnetwork/lnd/clock"
 	"github.com/lightningnetwork/lnd/input"
 	"github.com/lightningnetwork/lnd/lnwallet"
 	"github.com/lightningnetwork/lnd/lnwallet/chainfee"
@@ -153,6 +155,19 @@ type ChainArbitratorConfig struct {
 	// OnionProcessor is used to decode onion payloads for on-chain
 	// resolution.
 	OnionProcessor OnionProcessor
+
+	// PaymentsExpirationGracePeriod indicates is a time window we let the
+	// other node to cancel an outgoing htlc that our node has initiated and
+	// has timed out.
+	PaymentsExpirationGracePeriod time.Duration
+
+	// IsForwardedHTLC checks for a given htlc, identified by channel id and
+	// htlcIndex, if it is a forwarded one.
+	IsForwardedHTLC func(chanID lnwire.ShortChannelID, htlcIndex uint64) bool
+
+	// Clock is the clock implementation that ChannelArbitrator uses.
+	// It is useful for testing.
+	Clock clock.Clock
 }
 
 // ChainArbitrator is a sub-system that oversees the on-chain resolution of all

--- a/contractcourt/chain_arbitrator_test.go
+++ b/contractcourt/chain_arbitrator_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcd/wire"
 	"github.com/lightningnetwork/lnd/channeldb"
+	"github.com/lightningnetwork/lnd/clock"
 	"github.com/lightningnetwork/lnd/lnwallet"
 )
 
@@ -83,6 +84,7 @@ func TestChainArbitratorRepublishCloses(t *testing.T) {
 			published[tx.TxHash()]++
 			return nil
 		},
+		Clock: clock.NewDefaultClock(),
 	}
 	chainArb := NewChainArbitrator(
 		chainArbCfg, db,
@@ -171,6 +173,7 @@ func TestResolveContract(t *testing.T) {
 		PublishTx: func(tx *wire.MsgTx) error {
 			return nil
 		},
+		Clock: clock.NewDefaultClock(),
 	}
 	chainArb := NewChainArbitrator(
 		chainArbCfg, db,

--- a/htlcswitch/switch.go
+++ b/htlcswitch/switch.go
@@ -460,6 +460,18 @@ func (s *Switch) UpdateForwardingPolicies(
 	s.indexMtx.RUnlock()
 }
 
+// IsForwardedHTLC checks for a given channel and htlc index if it is related
+// to an opened circuit that represents a forwarded payment.
+func (s *Switch) IsForwardedHTLC(chanID lnwire.ShortChannelID,
+	htlcIndex uint64) bool {
+
+	circuit := s.circuits.LookupOpenCircuit(channeldb.CircuitKey{
+		ChanID: chanID,
+		HtlcID: htlcIndex,
+	})
+	return circuit != nil && circuit.Incoming.ChanID != hop.Source
+}
+
 // forward is used in order to find next channel link and apply htlc update.
 // Also this function is used by channel links itself in order to forward the
 // update after it has been included in the channel.

--- a/htlcswitch/switch_test.go
+++ b/htlcswitch/switch_test.go
@@ -322,6 +322,10 @@ func TestSwitchForward(t *testing.T) {
 		t.Fatal("wrong amount of circuits")
 	}
 
+	if !s.IsForwardedHTLC(bobChannelLink.ShortChanID(), 0) {
+		t.Fatal("htlc should be identified as forwarded")
+	}
+
 	// Create settle request pretending that bob link handled the add htlc
 	// request and sent the htlc settle request back. This request should
 	// be forwarder back to Alice link.
@@ -1892,6 +1896,9 @@ func TestSwitchSendPayment(t *testing.T) {
 		t.Fatalf("unable obfuscate failure: %v", err)
 	}
 
+	if s.IsForwardedHTLC(aliceChannelLink.ShortChanID(), update.ID) {
+		t.Fatal("htlc should be identified as not forwarded")
+	}
 	packet := &htlcPacket{
 		outgoingChanID: aliceChannelLink.ShortChanID(),
 		outgoingHTLCID: 0,

--- a/server.go
+++ b/server.go
@@ -915,11 +915,14 @@ func newServer(listenAddrs []net.Addr, chanDB *channeldb.DB,
 				return ErrServerShuttingDown
 			}
 		},
-		DisableChannel:      s.chanStatusMgr.RequestDisable,
-		Sweeper:             s.sweeper,
-		Registry:            s.invoices,
-		NotifyClosedChannel: s.channelNotifier.NotifyClosedChannelEvent,
-		OnionProcessor:      s.sphinx,
+		DisableChannel:                s.chanStatusMgr.RequestDisable,
+		Sweeper:                       s.sweeper,
+		Registry:                      s.invoices,
+		NotifyClosedChannel:           s.channelNotifier.NotifyClosedChannelEvent,
+		OnionProcessor:                s.sphinx,
+		PaymentsExpirationGracePeriod: cfg.PaymentsExpirationGracePeriod,
+		IsForwardedHTLC:               s.htlcSwitch.IsForwardedHTLC,
+		Clock:                         clock.NewDefaultClock(),
 	}, chanDB)
 
 	s.breachArbiter = newBreachArbiter(&BreachConfig{

--- a/test_utils.go
+++ b/test_utils.go
@@ -17,6 +17,7 @@ import (
 	"github.com/btcsuite/btcutil"
 	"github.com/lightningnetwork/lnd/chainntnfs"
 	"github.com/lightningnetwork/lnd/channeldb"
+	"github.com/lightningnetwork/lnd/clock"
 	"github.com/lightningnetwork/lnd/contractcourt"
 	"github.com/lightningnetwork/lnd/htlcswitch"
 	"github.com/lightningnetwork/lnd/input"
@@ -360,6 +361,12 @@ func createTestPeer(notifier chainntnfs.ChainNotifier, publTx chan *wire.MsgTx,
 		contractcourt.ChainArbitratorConfig{
 			Notifier: notifier,
 			ChainIO:  chainIO,
+			IsForwardedHTLC: func(chanID lnwire.ShortChannelID,
+				htlcIndex uint64) bool {
+
+				return true
+			},
+			Clock: clock.NewDefaultClock(),
 		}, dbAlice,
 	)
 	chainArb.WatchNewChannel(aliceChannelState)


### PR DESCRIPTION
This PR main goal is to reduce force closed channels in a mobile node.
In case of an outgoing pending htlc, a forwarding node needs to make sure it is either cancelled or resolved on-chain after timeout.
While for an online node it is more likely that its counterpart peer will send `update_fail_htlc` before it will need to use the timeout transaction, in mobile node it is a bit different.
By its nature, mobile node is most of the time not online, which in case of pending htlc it is likely to miss the time slot for getting the `update_fail_htlc` and when comes online it will close the channel on-chain.
While in a forwarding payment the timeout transaction should be used immediately to eliminate the risk in loosing funds, it looks to me that in an initiated payment it is not risky to keep the channel at this situation. The advantage is that when the mobile node is online it will have a chance to receive the `udpate_fail_htlc`, preventing the channel from being closed.
This behavior also makes paying hold invoices in mobile a lot more practical. Assuming the hold invoice is waiting for some external info to be resolved, it can take time in which the mobile goes offline.
If the counterpart peer misbehaves and doesn't send the `udpate_fail_htlc`, then the user can always force close the channel by himself.

A flag was added to the configuration to be able to explicitly specify this behavior and in such case for every outgoing htlc that is closed to timeout and beyond the code doesn't take on-chain action if the htlc is associated with a direct payment of the user node.
