### PR TITLE
routing: clean up locking on topology change

### DIFF
--- a/routing/notifications.go
+++ b/routing/notifications.go
@@ -118,10 +118,9 @@ type topologyClient struct {
 // graph topology in a non-blocking.
 func (r *ChannelRouter) notifyTopologyChange(topologyDiff *TopologyChange) {
 	r.RLock()
-	numClients := len(r.topologyClients)
-	r.RUnlock()
+	defer r.RUnlock()
 
-	// Do not reacquire the lock twice unnecessarily.
+	numClients := len(r.topologyClients)
 	if numClients == 0 {
 		return
 	}
@@ -133,7 +132,6 @@ func (r *ChannelRouter) notifyTopologyChange(topologyDiff *TopologyChange) {
 		}),
 	)
 
-	r.RLock()
 	for _, client := range r.topologyClients {
 		client.wg.Add(1)
 
@@ -157,7 +155,6 @@ func (r *ChannelRouter) notifyTopologyChange(topologyDiff *TopologyChange) {
 			}
 		}(client)
 	}
-	r.RUnlock()
 }
 
 // TopologyChange represents a new set of modifications to the channel graph.


### PR DESCRIPTION
routing: clean up locking on topology change

This is a trivial code clean up to avoid acquiring the reader lock twice. Fixes a race condition where the topologyClients could have changed while releasing the reader lock resulting in a wrongly logged count or worst case, return from the function.
