### PR TITLE
channeldb: remove FetchAllInvoices which was test only and unused

### DIFF
--- a/channeldb/invoice_test.go
+++ b/channeldb/invoice_test.go
@@ -14,6 +14,7 @@ import (
 
 var (
 	emptyFeatures = lnwire.NewFeatureVector(nil, lnwire.Features)
+	testNow       = time.Unix(1, 0)
 )
 
 func randInvoice(value lnwire.MilliSatoshi) (*Invoice, error) {
@@ -23,9 +24,7 @@ func randInvoice(value lnwire.MilliSatoshi) (*Invoice, error) {
 	}
 
 	i := &Invoice{
-		// Use single second precision to avoid false positive test
-		// failures due to the monotonic time component.
-		CreationDate: time.Unix(time.Now().Unix(), 0),
+		CreationDate: testNow,
 		Terms: ContractTerm{
 			Expiry:          4000,
 			PaymentPreimage: pre,
@@ -87,9 +86,7 @@ func TestInvoiceWorkflow(t *testing.T) {
 	// Create a fake invoice which we'll use several times in the tests
 	// below.
 	fakeInvoice := &Invoice{
-		// Use single second precision to avoid false positive test
-		// failures due to the monotonic time component.
-		CreationDate: time.Unix(time.Now().Unix(), 0),
+		CreationDate: testNow,
 		Htlcs:        map[CircuitKey]*InvoiceHTLC{},
 	}
 	fakeInvoice.Memo = []byte("memo")
@@ -285,6 +282,7 @@ func TestInvoiceAddTimeSeries(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unable to make test db: %v", err)
 	}
+	db.Now = func() time.Time { return testNow }
 
 	// We'll start off by creating 20 random invoices, and inserting them
 	// into the database.
@@ -537,7 +535,7 @@ func TestDuplicateSettleInvoice(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unable to make test db: %v", err)
 	}
-	db.Now = func() time.Time { return time.Unix(1, 0) }
+	db.Now = func() time.Time { return testNow }
 
 	// We'll start out by creating an invoice and writing it to the DB.
 	amt := lnwire.NewMSatFromSatoshis(1000)
@@ -675,6 +673,7 @@ func TestQueryInvoices(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unable to make test db: %v", err)
 	}
+	db.Now = func() time.Time { return testNow }
 
 	// To begin the test, we'll add 50 invoices to the database. We'll
 	// assume that the index of the invoice within the database is the same

--- a/channeldb/invoices.go
+++ b/channeldb/invoices.go
@@ -1327,6 +1327,19 @@ func copySlice(src []byte) []byte {
 	return dest
 }
 
+// copyInvoiceHTLC makes a deep copy of the supplied invoice HTLC.
+func copyInvoiceHTLC(src *InvoiceHTLC) *InvoiceHTLC {
+	result := *src
+
+	// Make a copy of the CustomSet map.
+	result.CustomRecords = make(record.CustomSet)
+	for k, v := range src.CustomRecords {
+		result.CustomRecords[k] = v
+	}
+
+	return &result
+}
+
 // copyInvoice makes a deep copy of the supplied invoice.
 func copyInvoice(src *Invoice) *Invoice {
 	dest := Invoice{
@@ -1347,7 +1360,7 @@ func copyInvoice(src *Invoice) *Invoice {
 	dest.Terms.Features = src.Terms.Features.Clone()
 
 	for k, v := range src.Htlcs {
-		dest.Htlcs[k] = v
+		dest.Htlcs[k] = copyInvoiceHTLC(v)
 	}
 
 	return &dest


### PR DESCRIPTION
This PR removes channeldb.FetchAllInvoices which was only used in tests to prepare expectation sets. The refactor also changes expectation set creation to be independent from the DB.