### PR TITLE
chanfitness: Bugfix save initial peer online event

### DIFF
--- a/chanfitness/chaneventstore.go
+++ b/chanfitness/chaneventstore.go
@@ -210,6 +210,12 @@ func (c *ChannelEventStore) addChannel(channelPoint wire.OutPoint,
 	// Create an event log for the channel.
 	eventLog := newEventLog(channelPoint, peer, time.Now)
 
+	// If the peer is already online, add a peer online event to record
+	// the starting state of the peer.
+	if c.peers[peer] {
+		eventLog.add(peerOnlineEvent)
+	}
+
 	c.channels[channelPoint] = eventLog
 }
 


### PR DESCRIPTION
Uptime calculations rely on an initial online event to determine peer state which was removed in #3799. The change was appropriate for channel that are offline at start (since an event will be recorded if the peer comes online), but it introduces a race between peers coming online and existing channels being added to the store. If the peer comes online before the channel is added to the store, no online event is added (and the channel with an online peer appears to be offline). This change re-adds the channel online event in `addChannel` so that channels with already online peers have an initial online event.  

This edge case of needing a first online event seems unavoidable, and buggy, so I am going to follow up with a refactor of the unit tests to better cover this code. The issue here is that it's difficult to test a whole set of events, so I'm going to add an interface for `Subscribe.Client` and test a full event flow. 

For now, tested all possible scenarios with a local node:
On restart:
- Existing channels with online peers: lifetime equals time since restart, uptime potentially less than lifetime if the peer takes long to reconnect
- Existing channels with offline peers: lifetime equals time since restart, uptime is zero

New channels:
- New channel with online peer: uptime and lifetime equal time since open
- New channel with offline peer: zero uptime, lifetime set to time since open

Peer flaps:
- Peer goes offline: lifetime continues to increase, offline stops increasing
- Peer comes online: uptime and lifetime increase