### PR TITLE
contractcourt: fix lingering contract after local breach

### DIFF
--- a/contractcourt/commit_sweep_resolver.go
+++ b/contractcourt/commit_sweep_resolver.go
@@ -248,7 +248,7 @@ func (c *commitSweepResolver) Resolve() (ContractResolver, error) {
 			// it's likely what we sent was actually a revoked
 			// commitment. Report the error and continue to wrap up
 			// the contract.
-			c.log.Errorf("local commitment output was swept by "+
+			c.log.Warnf("local commitment output was swept by "+
 				"remote party via %v", sweepResult.Tx.TxHash())
 			recovered = false
 		case nil:

--- a/contractcourt/commit_sweep_resolver_test.go
+++ b/contractcourt/commit_sweep_resolver_test.go
@@ -96,6 +96,7 @@ func (i *commitSweepResolverTestContext) waitForResult() {
 type mockSweeper struct {
 	sweptInputs   chan input.Input
 	updatedInputs chan wire.OutPoint
+	sweepErr      error
 }
 
 func newMockSweeper() *mockSweeper {
@@ -112,7 +113,8 @@ func (s *mockSweeper) SweepInput(input input.Input, params sweep.Params) (
 
 	result := make(chan sweep.Result, 1)
 	result <- sweep.Result{
-		Tx: &wire.MsgTx{},
+		Tx:  &wire.MsgTx{},
+		Err: s.sweepErr,
 	}
 	return result, nil
 }
@@ -242,5 +244,94 @@ func TestCommitSweepResolverDelay(t *testing.T) {
 		MaturityHeight:   testInitialBlockHeight + 2,
 	}) {
 		t.Fatal("unexpected resolver report")
+	}
+}
+
+// TestCommitSweepResolverLocalBreach tests resolution when the local node
+// publishes a breached output (one that is swept by the remote party).
+func TestCommitSweepResolverLocalBreach(t *testing.T) {
+	t.Parallel()
+	defer timeout(t)()
+
+	amt := int64(100)
+	outpoint := wire.OutPoint{
+		Index: 5,
+	}
+	res := lnwallet.CommitOutputResolution{
+		SelfOutputSignDesc: input.SignDescriptor{
+			Output: &wire.TxOut{
+				Value: amt,
+			},
+			WitnessScript: []byte{0},
+		},
+		MaturityDelay: 3,
+		SelfOutPoint:  outpoint,
+	}
+
+	ctx := newCommitSweepResolverTestContext(t, &res)
+
+	// Setup the sweeper so that it returns an error of the output being
+	// already swept.
+	ctx.sweeper.sweepErr = sweep.ErrRemoteSpend
+
+	report := ctx.resolver.report()
+	expectedReport := ContractReport{
+		Outpoint:     outpoint,
+		Type:         ReportOutputUnencumbered,
+		Amount:       btcutil.Amount(amt),
+		LimboBalance: btcutil.Amount(amt),
+	}
+	if *report != expectedReport {
+		t.Fatalf("unexpected resolver report. want=%v got=%v",
+			expectedReport, report)
+	}
+
+	ctx.resolve()
+
+	ctx.notifier.confChan <- &chainntnfs.TxConfirmation{
+		BlockHeight: testInitialBlockHeight - 1,
+	}
+
+	// Allow resolver to process confirmation.
+	time.Sleep(100 * time.Millisecond)
+
+	// Expect report to be updated.
+	report = ctx.resolver.report()
+	if report.MaturityHeight != testInitialBlockHeight+2 {
+		t.Fatal("report maturity height incorrect")
+	}
+
+	// Notify initial block height. The csv lock is still in effect, so we
+	// don't expect any sweep to happen yet.
+	ctx.notifyEpoch(testInitialBlockHeight)
+
+	select {
+	case <-ctx.sweeper.sweptInputs:
+		t.Fatal("no sweep expected")
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	// A new block arrives. The commit tx confirmed at height -1 and the csv
+	// is 3, so a spend will be valid in the first block after height +1.
+	ctx.notifyEpoch(testInitialBlockHeight + 1)
+
+	<-ctx.sweeper.sweptInputs
+
+	ctx.waitForResult()
+
+	report = ctx.resolver.report()
+	expectedReport = ContractReport{
+		Outpoint:       outpoint,
+		Type:           ReportOutputUnencumbered,
+		Amount:         btcutil.Amount(amt),
+		MaturityHeight: testInitialBlockHeight + 2,
+
+		// RecoveredBalance is zero due to the output having been swept
+		// by the remote party.
+		RecoveredBalance: 0,
+	}
+	if *report != expectedReport {
+		t.Fatalf("unexpected resolver report. want=%v got=%v",
+			expectedReport, report)
 	}
 }

--- a/lntest/itest/lnd_test.go
+++ b/lntest/itest/lnd_test.go
@@ -7586,6 +7586,15 @@ func testRevokedCloseRetribution(net *lntest.NetworkHarness, t *harnessTest) {
 	}
 
 	assertNodeNumChannels(t, carol, 0)
+
+	// Mine enough blocks for Bob's channel arbitrator to wrap up the
+	// references to the breached channel. The chanarb waits for commitment
+	// tx's confHeight+CSV-1 blocks and since we've already mined one that
+	// included the justice tx we only need to mine extra DefaultCSV-2
+	// blocks to unlock it.
+	mineBlocks(t, net, lntest.DefaultCSV-2, 0)
+
+	assertNumPendingChannels(t, net.Bob, 0, 0)
 }
 
 // testRevokedCloseRetributionZeroValueRemoteOutput tests that Dave is able


### PR DESCRIPTION
Fix an issue that started happening after commit 9acb2366656481c94f365e2e12d02f3129c4fb91.

After that commit, the commit sweeper for a channel arbitrator would no longer wait for a spend notification but rather for a specific number of blocks leaving open the possibility that a sweep by the remote party (such as when the channel was actually breached by the local party) would leave the channel forever in a pending state.

This fixes that by noticing that sweep errors where the sweep was not made by us should still cause the channel to be considered fully resolved.

The first commit surfaces the issue by verifying the state of pending channels after the testRevokedCloseRetribution integration test.