### PR TITLE
lncli: improve last_hop help message

### DIFF
--- a/cmd/lncli/commands.go
+++ b/cmd/lncli/commands.go
@@ -2087,8 +2087,9 @@ var (
 	}
 
 	lastHopFlag = cli.StringFlag{
-		Name:  "last_hop",
-		Usage: "pubkey of the last hop to use for this payment",
+		Name: "last_hop",
+		Usage: "pubkey of the last hop (penultimate node in the path) " +
+			"to route through for this payment",
 	}
 )
 


### PR DESCRIPTION
Clarifies that last_hop is not the destination, but the penultimate node
in the path, i.e. the last intermediary.