### PR TITLE
lnrpc+lncli: add send support for custom data records

### DIFF
--- a/cmd/lncli/commands.go
+++ b/cmd/lncli/commands.go
@@ -2091,6 +2091,14 @@ var (
 		Usage: "pubkey of the last hop (penultimate node in the path) " +
 			"to route through for this payment",
 	}
+
+	dataFlag = cli.StringFlag{
+		Name: "data",
+		Usage: "attach custom data to the payment. The required " +
+			"format is: <record_id>=<hex_value>,<record_id>=" +
+			"<hex_value>,.. For example: --data 3438382=0a21ff. " +
+			"Custom record ids start from 65536.",
+	}
 )
 
 // paymentFlags returns common flags for sendpayment and payinvoice.
@@ -2127,6 +2135,7 @@ func paymentFlags() []cli.Flag {
 			Name:  "allow_self_payment",
 			Usage: "allow sending a circular payment to self",
 		},
+		dataFlag,
 	}
 }
 
@@ -2270,8 +2279,9 @@ func sendPayment(ctx *cli.Context) error {
 	}
 
 	req := &lnrpc.SendRequest{
-		Dest: destNode,
-		Amt:  amount,
+		Dest:              destNode,
+		Amt:               amount,
+		DestCustomRecords: make(map[uint64][]byte),
 	}
 
 	var rHash []byte
@@ -2286,9 +2296,10 @@ func sendPayment(ctx *cli.Context) error {
 			return err
 		}
 
-		req.DestCustomRecords = map[uint64][]byte{
-			record.KeySendType: preimage[:],
-		}
+		// Set the preimage. If the user supplied a preimage with the
+		// data flag, the preimage that is set here will be overwritten
+		// later.
+		req.DestCustomRecords[record.KeySendType] = preimage[:]
 
 		hash := preimage.Hash()
 		rHash = hash[:]
@@ -2354,6 +2365,33 @@ func sendPaymentRequest(ctx *cli.Context, req *lnrpc.SendRequest) error {
 	req.CltvLimit = uint32(ctx.Int(cltvLimitFlag.Name))
 
 	req.AllowSelfPayment = ctx.Bool("allow_self_payment")
+
+	// Parse custom data records.
+	data := ctx.String(dataFlag.Name)
+	if data != "" {
+		records := strings.Split(data, ",")
+		for _, r := range records {
+			kv := strings.Split(r, "=")
+			if len(kv) != 2 {
+				return errors.New("invalid data format: " +
+					"multiple equal signs in record")
+			}
+
+			recordID, err := strconv.ParseUint(kv[0], 10, 64)
+			if err != nil {
+				return fmt.Errorf("invalid data format: %v",
+					err)
+			}
+
+			hexValue, err := hex.DecodeString(kv[1])
+			if err != nil {
+				return fmt.Errorf("invalid data format: %v",
+					err)
+			}
+
+			req.DestCustomRecords[recordID] = hexValue
+		}
+	}
 
 	amt := req.Amt
 
@@ -2434,8 +2472,9 @@ func payInvoice(ctx *cli.Context) error {
 	}
 
 	req := &lnrpc.SendRequest{
-		PaymentRequest: payReq,
-		Amt:            ctx.Int64("amt"),
+		PaymentRequest:    payReq,
+		Amt:               ctx.Int64("amt"),
+		DestCustomRecords: make(map[uint64][]byte),
 	}
 
 	return sendPaymentRequest(ctx, req)


### PR DESCRIPTION
With the introduction of custom record sending and receiving, it became possible to attach arbitrary data to a payment. One obvious use case is attaching a human-readable message to a payment. Especially in the case of spontaneous key send payments, this can give the receiver some context on the payment.

For example: tipping. Usually people sending a tip would want to include some information on who they are or what the tip is for. For Lightning this may be even more desired than for other payment methods, because payments are anonymous by default. 

Attaching and retrieving the message was already possible before, but this PR makes it easier to do so by introducing an additional `lncli` flag `--data` to attach one or more custom records:

`lncli sendpayment -d 0274e7fb33eafd74fe1acb6db7680bb4aa78e9c839a6e954e38abfad680f645ef7 -a 100 --key_send --data 323442=00,3234556=ffff080812`

To specify a string value, the standard command line tool `xxd` can be used (the example record id here is the 3-byte ascii string 'tip' converted to an integer):

`--data 7629168=$(echo -n "Thank you!" | xxd -pu -c 10000)`

(The `-c` parameter is to prevent `xxd` from inserting line breaks)

Note: The available onion blob space of 1300 bytes is used for routing info and custom records. The bigger the size of the custom records, the fewer bytes remain for routing info and the shorter the maximum route length will be.