### PR TITLE
Fix zlib empty short channel ids

### DIFF
--- a/lnwire/query_short_chan_ids.go
+++ b/lnwire/query_short_chan_ids.go
@@ -147,6 +147,9 @@ func decodeShortChanIDs(r io.Reader) (ShortChanIDEncoding, []ShortChannelID, err
 	// Before continuing, we'll snip off the first byte of the query body
 	// as that was just the encoding type.
 	queryBody = queryBody[1:]
+	if len(queryBody) == 0 {
+		return encodingType, nil, nil
+	}
 
 	// Otherwise, depending on the encoding type, we'll decode the encode
 	// short channel ID's in a different manner.
@@ -293,6 +296,13 @@ func encodeShortChanIDs(w io.Writer, encodingType ShortChanIDEncoding,
 			return shortChanIDs[i].ToUint64() <
 				shortChanIDs[j].ToUint64()
 		})
+	}
+
+	if len(shortChanIDs) == 0 {
+		if err := WriteElements(w, uint16(1)); err != nil {
+			return err
+		}
+		return WriteElements(w, encodingType)
 	}
 
 	switch encodingType {

--- a/lnwire/query_short_chan_ids_test.go
+++ b/lnwire/query_short_chan_ids_test.go
@@ -2,7 +2,11 @@ package lnwire
 
 import (
 	"bytes"
+	"encoding/hex"
+	"reflect"
 	"testing"
+
+	"github.com/davecgh/go-spew/spew"
 )
 
 type unsortedSidTest struct {
@@ -69,6 +73,55 @@ func TestQueryShortChanIDsUnsorted(t *testing.T) {
 			if _, ok := err.(ErrUnsortedSIDs); !ok {
 				t.Fatalf("expected ErrUnsortedSIDs, got: %T",
 					err)
+			}
+		})
+	}
+}
+
+func TestQueryShortChanIDsEmpty(t *testing.T) {
+	emptyChannelsTests := []struct {
+		name     string
+		encType  ShortChanIDEncoding
+		expected string
+	}{
+		{
+			name:     "plain",
+			encType:  EncodingSortedPlain,
+			expected: "0000000000000000000000000000000000000000000000000000000000000000000100",
+		},
+		{
+			name:     "zlib",
+			encType:  EncodingSortedZlib,
+			expected: "0000000000000000000000000000000000000000000000000000000000000000000101",
+		},
+	}
+
+	for _, test := range emptyChannelsTests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			req := QueryShortChanIDs{
+				EncodingType: test.encType,
+				ShortChanIDs: nil,
+			}
+
+			var b bytes.Buffer
+			err := req.Encode(&b, 0)
+			if err != nil {
+				t.Fatalf("unable to encode req: %v", err)
+			}
+			if hex.EncodeToString(b.Bytes()) != test.expected {
+				t.Fatalf("results don't match: expected %v got %v",
+					test.expected, hex.EncodeToString(b.Bytes()))
+			}
+
+			var req2 QueryShortChanIDs
+			err = req2.Decode(bytes.NewReader(b.Bytes()), 0)
+			if err != nil {
+				t.Fatalf("unable to decode req: %v", err)
+			}
+			if !reflect.DeepEqual(req, req2) {
+				t.Fatalf("requests don't match: expected %v got %v",
+					spew.Sdump(req), spew.Sdump(req2))
 			}
 		})
 	}


### PR DESCRIPTION
I noticed a weird issue with lnd's handling of `query_short_channel_ids` without any `short_channel_id`.
It looks like `var buf bytes.Buffer` initializes a buffer of size 11.
So if we don't have anything to add to it, we'll call zlib on that buffer containing 11 bytes `0` which isn't the output we expect.

It's a bit unclear in the spec if we should omit the `encoded_short_ids` field entirely in that case: that may be cleaner than a single byte representing the encoding followed by nothing.
I need to check what c-lightning does in that case (Eclair does what I implemented here, but it feels a bit weird). 