### PR TITLE
invoices: streamline key send cltv delta picking and validation

### DIFF
--- a/invoices/invoiceregistry.go
+++ b/invoices/invoiceregistry.go
@@ -736,6 +736,12 @@ func (i *InvoiceRegistry) processKeySend(ctx invoiceUpdateCtx,
 	// Use the minimum block delta that we require for settling htlcs.
 	finalCltvDelta := i.cfg.FinalCltvRejectDelta
 
+	// Pre-check expiry here to prevent inserting an invoice that will not
+	// be settled.
+	if ctx.expiry < uint32(ctx.currentHeight+finalCltvDelta) {
+		return errors.New("final expiry too soon")
+	}
+
 	// Create placeholder invoice.
 	invoice := &channeldb.Invoice{
 		CreationDate: i.cfg.Clock.Now(),

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -3535,7 +3535,11 @@ func (r *rpcServer) extractPaymentIntent(rpcPayReq *rpcPaymentRequest) (rpcPayme
 	if rpcPayReq.FinalCltvDelta != 0 {
 		payIntent.cltvDelta = uint16(rpcPayReq.FinalCltvDelta)
 	} else {
-		payIntent.cltvDelta = zpay32.DefaultFinalCLTVDelta
+		// If no final cltv delta is given, assume the default that we
+		// use when creating an invoice. We do not assume the default of
+		// 9 blocks that is defined in BOLT-11, because this is never
+		// enough for other lnd nodes.
+		payIntent.cltvDelta = uint16(cfg.Bitcoin.TimeLockDelta)
 	}
 
 	// If the user is manually specifying payment details, then the payment


### PR DESCRIPTION
This PR:
* Does a pre-check for key send htlc expiry values to prevent empty invoices filling up the database.
* Increases the default final cltv delta that payment RPCs use so that a receiver running `lnd` won't reject it. This allows key send payments via `lncli` without specifying the `final_cltv_delta` flag.