### PR TITLE
Fix channel range queries with empty results

### DIFF
--- a/lnwire/query_short_chan_ids.go
+++ b/lnwire/query_short_chan_ids.go
@@ -132,7 +132,7 @@ func decodeShortChanIDs(r io.Reader) (ShortChanIDEncoding, []ShortChannelID, err
 	}
 
 	if numBytesResp == 0 {
-		return 0, nil, fmt.Errorf("No encoding type specified")
+		return 0, nil, nil
 	}
 
 	queryBody := make([]byte, numBytesResp)
@@ -147,6 +147,9 @@ func decodeShortChanIDs(r io.Reader) (ShortChanIDEncoding, []ShortChannelID, err
 	// Before continuing, we'll snip off the first byte of the query body
 	// as that was just the encoding type.
 	queryBody = queryBody[1:]
+	if len(queryBody) == 0 {
+		return encodingType, nil, nil
+	}
 
 	// Otherwise, depending on the encoding type, we'll decode the encode
 	// short channel ID's in a different manner.
@@ -293,6 +296,18 @@ func encodeShortChanIDs(w io.Writer, encodingType ShortChanIDEncoding,
 			return shortChanIDs[i].ToUint64() <
 				shortChanIDs[j].ToUint64()
 		})
+	}
+
+	if len(shortChanIDs) == 0 {
+		// If the list is empty, the spec is a bit unclear; we could either set
+		// numBytesBody to 0 and stop writing, or set it to 1 and write only our
+		// desired encoding. Other implementations currently do the former, so we
+		// stick with that for compatibility.
+		numBytesBody := uint16(1)
+		if err := WriteElements(w, numBytesBody); err != nil {
+			return err
+		}
+		return WriteElements(w, encodingType)
 	}
 
 	switch encodingType {

--- a/lnwire/reply_channel_range_test.go
+++ b/lnwire/reply_channel_range_test.go
@@ -2,7 +2,11 @@ package lnwire
 
 import (
 	"bytes"
+	"encoding/hex"
+	"reflect"
 	"testing"
+
+	"github.com/davecgh/go-spew/spew"
 )
 
 // TestReplyChannelRangeUnsorted tests that decoding a ReplyChannelRange request
@@ -28,6 +32,63 @@ func TestReplyChannelRangeUnsorted(t *testing.T) {
 			if _, ok := err.(ErrUnsortedSIDs); !ok {
 				t.Fatalf("expected ErrUnsortedSIDs, got: %T",
 					err)
+			}
+		})
+	}
+}
+
+// TestReplyChannelRangeEmpty tests encoding and decoding a ReplyChannelRange
+// that doesn't contain any channel results.
+func TestReplyChannelRangeEmpty(t *testing.T) {
+	emptyChannelsTests := []struct {
+		name       string
+		encType    ShortChanIDEncoding
+		encodedHex string
+	}{
+		{
+			name:       "empty plain encoding",
+			encType:    EncodingSortedPlain,
+			encodedHex: "0000000000000000000000000000000000000000000000000000000000000000000000010000000201000100",
+		},
+		{
+			name:       "empty zlib encoding",
+			encType:    EncodingSortedZlib,
+			encodedHex: "0000000000000000000000000000000000000000000000000000000000000000000000010000000201000101",
+		},
+	}
+
+	for _, test := range emptyChannelsTests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			req := ReplyChannelRange{
+				QueryChannelRange: QueryChannelRange{
+					FirstBlockHeight: 1,
+					NumBlocks:        2,
+				},
+				Complete:     1,
+				EncodingType: test.encType,
+				ShortChanIDs: nil,
+			}
+
+			var req2 ReplyChannelRange
+			b, _ := hex.DecodeString(test.encodedHex)
+			err := req2.Decode(bytes.NewReader(b), 0)
+			if err != nil {
+				t.Fatalf("unable to decode req: %v", err)
+			}
+			if !reflect.DeepEqual(req, req2) {
+				t.Fatalf("requests don't match: expected %v got %v",
+					spew.Sdump(req), spew.Sdump(req2))
+			}
+
+			var b2 bytes.Buffer
+			err = req.Encode(&b2, 0)
+			if err != nil {
+				t.Fatalf("unable to encode req: %v", err)
+			}
+			if !bytes.Equal(b, b2.Bytes()) {
+				t.Fatalf("encoded requests don't match: expected %x got %x",
+					b, b2.Bytes())
 			}
 		})
 	}


### PR DESCRIPTION
The spec is a bit unclear on how to encode empty `encoded_short_ids`.
It can either be done with `len` set to `0000` or `len` set to `0001` followed by only the encoding `00` or `01` (this is the current behavior in lnd, eclair and c-lightning).

I'm fixing the following issues in this PR:

* Decoding an empty list with the zlib encoding doesn't work ("unexpected EOF")
* Encoding an empty list with zlib produces unexpected bytes because an empty `bytes.Buffer` is in fact initialized with 11 0-value bytes
* Decoding a `len` set to `0000` should work: no need to force the sender to provide an encoding when nothing is actually encoded :thinking: 