### PR TITLE
[mobile] Set walletunlocker TLS credentials

### DIFF
--- a/lnd.go
+++ b/lnd.go
@@ -60,6 +60,25 @@ var (
 	networkDir string
 )
 
+// WalletUnlockerAuthOptions returns a list of DialOptions that can be used to
+// authenticate with the wallet unlocker service.
+//
+// NOTE: This should only be called after the WalletUnlocker listener has
+// signaled it is ready.
+func WalletUnlockerAuthOptions() ([]grpc.DialOption, error) {
+	creds, err := credentials.NewClientTLSFromFile(cfg.TLSCertPath, "")
+	if err != nil {
+		return nil, fmt.Errorf("unable to read TLS cert: %v", err)
+	}
+
+	// Create a dial options array with the TLS credentials.
+	opts := []grpc.DialOption{
+		grpc.WithTransportCredentials(creds),
+	}
+
+	return opts, nil
+}
+
 // AdminAuthOptions returns a list of DialOptions that can be used to
 // authenticate with the RPC server with admin capabilities.
 //

--- a/mobile/bindings.go
+++ b/mobile/bindings.go
@@ -20,6 +20,10 @@ import (
 // The unlockerReady callback is called when the WalletUnlocker service is
 // ready, and rpcReady is called after the wallet has been unlocked and lnd is
 // ready to accept RPC calls.
+//
+// NOTE: On mobile platforms the '--lnddir` argument should be set to the
+// current app directory in order to ensure lnd has the permissions needed to
+// write to it.
 func Start(extraArgs string, unlockerReady, rpcReady Callback) {
 	// Split the argument string on "--" to get separated command line
 	// arguments.

--- a/mobile/bindings.go
+++ b/mobile/bindings.go
@@ -74,6 +74,18 @@ func Start(extraArgs string, unlockerReady, rpcReady Callback) {
 	// callbacks when the RPC servers are ready to accept calls.
 	go func() {
 		<-unlockerListening
+
+		// We must set the TLS certificates in order to properly
+		// authenticate with the wallet unlocker service.
+		auth, err := lnd.WalletUnlockerAuthOptions()
+		if err != nil {
+			unlockerReady.OnError(err)
+			return
+		}
+
+		// Add the auth options to the listener's dial options.
+		addWalletUnlockerLisDialOption(auth...)
+
 		unlockerReady.OnResponse([]byte{})
 	}()
 


### PR DESCRIPTION
This PR fixes a regression from #3783, where TLS support was added on mobile, but we forgot to add the TLS credentials also to the wallet unlocker client.

Fixes #3905