### PR TITLE
routing: remove path finding shortcut

### DIFF
--- a/routing/errors.go
+++ b/routing/errors.go
@@ -7,14 +7,9 @@ import "github.com/go-errors/errors"
 type errorCode uint8
 
 const (
-	// ErrTargetNotInNetwork is returned when the target of a path-finding
-	// or payment attempt isn't known to be within the current version of
-	// the channel graph.
-	ErrTargetNotInNetwork errorCode = iota
-
 	// ErrOutdated is returned when the routing update already have
 	// been applied, or a newer update is already known.
-	ErrOutdated
+	ErrOutdated errorCode = iota
 
 	// ErrIgnored is returned when the update have been ignored because
 	// this update can't bring us something new, or because a node

--- a/routing/router.go
+++ b/routing/router.go
@@ -1407,15 +1407,6 @@ func (r *ChannelRouter) FindRoute(source, target route.Vertex,
 
 	log.Debugf("Searching for path to %v, sending %v", target, amt)
 
-	// We can short circuit the routing by opportunistically checking to
-	// see if the target vertex event exists in the current graph.
-	if _, exists, err := r.cfg.Graph.HasLightningNode(target); err != nil {
-		return nil, err
-	} else if !exists {
-		log.Debugf("Target %x is not in known graph", target)
-		return nil, newErrf(ErrTargetNotInNetwork, "target not found")
-	}
-
 	// We'll attempt to obtain a set of bandwidth hints that can help us
 	// eliminate certain routes early on in the path finding process.
 	bandwidthHints, err := generateBandwidthHints(


### PR DESCRIPTION
This shortcut does not work when the destination is a private node. We also don't have this shortcut for regular payments. This commit aligns the behavior between SendPayment and QueryRoutes.