### PR TITLE
itest: use fast scrypt options for aezeed, macaroons DB and wallet DB

### DIFF
--- a/aezeed/cipherseed_rpctest.go
+++ b/aezeed/cipherseed_rpctest.go
@@ -1,0 +1,13 @@
+// +build rpctest
+
+package aezeed
+
+import "github.com/btcsuite/btcwallet/waddrmgr"
+
+func init() {
+	// For the purposes of our itest, we'll crank down the scrypt params a
+	// bit.
+	scryptN = waddrmgr.FastScryptOptions.N
+	scryptR = waddrmgr.FastScryptOptions.R
+	scryptP = waddrmgr.FastScryptOptions.P
+}

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/btcsuite/btcd v0.20.1-beta
 	github.com/btcsuite/btclog v0.0.0-20170628155309-84c8d2346e9f
 	github.com/btcsuite/btcutil v0.0.0-20190425235716-9e5f4b9a998d
-	github.com/btcsuite/btcwallet v0.11.1-0.20200219004649-ae9416ad7623
+	github.com/btcsuite/btcwallet v0.11.1-0.20200323235326-015c045a3bb7
 	github.com/btcsuite/btcwallet/wallet/txauthor v1.0.0
 	github.com/btcsuite/btcwallet/wallet/txrules v1.0.0
 	github.com/btcsuite/btcwallet/walletdb v1.2.0

--- a/go.sum
+++ b/go.sum
@@ -26,8 +26,8 @@ github.com/btcsuite/btclog v0.0.0-20170628155309-84c8d2346e9f h1:bAs4lUbRJpnnkd9
 github.com/btcsuite/btclog v0.0.0-20170628155309-84c8d2346e9f/go.mod h1:TdznJufoqS23FtqVCzL0ZqgP5MqXbb4fg/WgDys70nA=
 github.com/btcsuite/btcutil v0.0.0-20190425235716-9e5f4b9a998d h1:yJzD/yFppdVCf6ApMkVy8cUxV0XrxdP9rVf6D87/Mng=
 github.com/btcsuite/btcutil v0.0.0-20190425235716-9e5f4b9a998d/go.mod h1:+5NJ2+qvTyV9exUAL/rxXi3DcLg2Ts+ymUAY5y4NvMg=
-github.com/btcsuite/btcwallet v0.11.1-0.20200219004649-ae9416ad7623 h1:ZuJRjucNsTmlrbZncsqzD0z3EaXrOobCx2I4lc12R4g=
-github.com/btcsuite/btcwallet v0.11.1-0.20200219004649-ae9416ad7623/go.mod h1:1O1uRHMPXHdwA4/od8nqYqrgclVKp+wtfXUAqHmeRvE=
+github.com/btcsuite/btcwallet v0.11.1-0.20200323235326-015c045a3bb7 h1:ubYJYIi13atgwPCX7FZQZV2mytkaRHWPycDFdF28U0o=
+github.com/btcsuite/btcwallet v0.11.1-0.20200323235326-015c045a3bb7/go.mod h1:1O1uRHMPXHdwA4/od8nqYqrgclVKp+wtfXUAqHmeRvE=
 github.com/btcsuite/btcwallet/wallet/txauthor v1.0.0 h1:KGHMW5sd7yDdDMkCZ/JpP0KltolFsQcB973brBnfj4c=
 github.com/btcsuite/btcwallet/wallet/txauthor v1.0.0/go.mod h1:VufDts7bd/zs3GV13f/lXc/0lXrPnvxD/NvmpG/FEKU=
 github.com/btcsuite/btcwallet/wallet/txrules v1.0.0 h1:2VsfS0sBedcM5KmDzRMT3+b6xobqWveZGvjb+jFez5w=

--- a/htlcswitch/link.go
+++ b/htlcswitch/link.go
@@ -627,7 +627,7 @@ func (l *channelLink) syncChanStates() error {
 
 	if err := l.cfg.Peer.SendMessage(true, localChanSyncMsg); err != nil {
 		return fmt.Errorf("Unable to send chan sync message for "+
-			"ChannelPoint(%v)", l.channel.ChannelPoint())
+			"ChannelPoint(%v): %v", l.channel.ChannelPoint(), err)
 	}
 
 	var msgsToReSend []lnwire.Message
@@ -3121,7 +3121,7 @@ func (l *channelLink) fail(linkErr LinkFailureError,
 		return
 	}
 
-	l.log.Errorf("failing link: %s", reason)
+	l.log.Errorf("failing link: %s with error: %v", reason, linkErr)
 
 	// Set failed, such that we won't process any more updates, and notify
 	// the peer about the failure.

--- a/lntest/timeouts.go
+++ b/lntest/timeouts.go
@@ -23,5 +23,5 @@ const (
 
 	// AsyncBenchmarkTimeout is the timeout used when running the async
 	// payments benchmark.
-	AsyncBenchmarkTimeout = time.Minute
+	AsyncBenchmarkTimeout = 2 * time.Minute
 )

--- a/lnwallet/btcwallet/btcwallet_rpctest.go
+++ b/lnwallet/btcwallet/btcwallet_rpctest.go
@@ -1,0 +1,23 @@
+// +build rpctest
+
+package btcwallet
+
+import (
+	"github.com/btcsuite/btcwallet/snacl"
+	"github.com/btcsuite/btcwallet/waddrmgr"
+)
+
+func init() {
+	// Instruct waddrmgr to use the cranked down scrypt parameters when
+	// creating new wallet encryption keys. This will speed up the itests
+	// considerably.
+	fastScrypt := waddrmgr.FastScryptOptions
+	keyGen := func(passphrase *[]byte, config *waddrmgr.ScryptOptions) (
+		*snacl.SecretKey, error) {
+
+		return snacl.NewSecretKey(
+			passphrase, fastScrypt.N, fastScrypt.R, fastScrypt.P,
+		)
+	}
+	waddrmgr.SetSecretKeyGen(keyGen)
+}

--- a/macaroons/security.go
+++ b/macaroons/security.go
@@ -1,0 +1,13 @@
+// +build !rpctest
+
+package macaroons
+
+import "github.com/btcsuite/btcwallet/snacl"
+
+var (
+	// Below are the default scrypt parameters that are used when creating
+	// the encryption key for the macaroon database with snacl.NewSecretKey.
+	scryptN = snacl.DefaultN
+	scryptR = snacl.DefaultR
+	scryptP = snacl.DefaultP
+)

--- a/macaroons/security_rpctest.go
+++ b/macaroons/security_rpctest.go
@@ -1,0 +1,14 @@
+// +build rpctest
+
+package macaroons
+
+import "github.com/btcsuite/btcwallet/waddrmgr"
+
+var (
+	// Below are the reduced scrypt parameters that are used when creating
+	// the encryption key for the macaroon database with snacl.NewSecretKey.
+	// We use very low values for our itest/rpctest to speed things up.
+	scryptN = waddrmgr.FastScryptOptions.N
+	scryptR = waddrmgr.FastScryptOptions.R
+	scryptP = waddrmgr.FastScryptOptions.P
+)

--- a/macaroons/security_test.go
+++ b/macaroons/security_test.go
@@ -1,0 +1,12 @@
+package macaroons
+
+import "github.com/btcsuite/btcwallet/waddrmgr"
+
+func init() {
+	// Below are the reduced scrypt parameters that are used when creating
+	// the encryption key for the macaroon database with snacl.NewSecretKey.
+	// We use very low values for our itest/rpctest to speed things up.
+	scryptN = waddrmgr.FastScryptOptions.N
+	scryptR = waddrmgr.FastScryptOptions.R
+	scryptP = waddrmgr.FastScryptOptions.P
+}

--- a/macaroons/store.go
+++ b/macaroons/store.go
@@ -106,8 +106,9 @@ func (r *RootKeyStorage) CreateUnlock(password *[]byte) error {
 		}
 
 		// We haven't yet stored a key, so create a new one.
-		encKey, err := snacl.NewSecretKey(password, snacl.DefaultN,
-			snacl.DefaultR, snacl.DefaultP)
+		encKey, err := snacl.NewSecretKey(
+			password, scryptN, scryptR, scryptP,
+		)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
This PR modifies the `aezeed`, `macaroons` and `lnwallet/btcwallet` packages to use fast scrypt options when compiled with the itest build tag to speed up the node creation/startup in the integration tests.

The faster wallet unlock also brought to light some flakes in the itests that have been addressed.