### PR TITLE
build/release: update release script to handle multiple tags at head

### DIFF
--- a/build/release/release.sh
+++ b/build/release/release.sh
@@ -18,7 +18,7 @@ else
     TAG=$1
 
     # If a tag is specified, ensure that that tag is present and checked out.
-    if [[ $TAG != $(git tag -l --points-at HEAD) ]]; then
+    if [[ $TAG != $(git describe) ]]; then
         echo "tag $TAG not checked out"
         exit 1
     fi


### PR DESCRIPTION
In this commit, we change the release script slightly to return the
latest tag if there're multiple tags at head. Otherwise the release
script will fail if our final tag is at the same commit as the prior
release candidate tag.

