### PR TITLE
invoices: fix slow startup with many expired invoices

### DIFF
--- a/invoices/invoiceregistry.go
+++ b/invoices/invoiceregistry.go
@@ -198,12 +198,8 @@ func (i *InvoiceRegistry) populateExpiryWatcher() error {
 		return err
 	}
 
-	for idx := range pendingInvoices {
-		i.expiryWatcher.AddInvoice(
-			pendingInvoices[idx].PaymentHash, &pendingInvoices[idx].Invoice,
-		)
-	}
-
+	log.Debugf("Adding %v pending invoices to the expiry watcher")
+	i.expiryWatcher.AddInvoices(pendingInvoices)
 	return nil
 }
 


### PR DESCRIPTION
This PR intends to fix slow first startup time when there are many
invoices that need to be canceled. The slowdown is caused by a combination
of adding invoices to the expiry watcher one-by-one and slow
cancellation. Due to slow cancellation and the unbuffered channel which
we use to pass invoices to the expiry watcher blocks the registry.
With this fix we'll instead batch add invoices to the expiry watcher and
thereby won't block the registry startup.
