### PR TITLE
sweep: add exclusive groups

### DIFF
--- a/sweep/bucket_list.go
+++ b/sweep/bucket_list.go
@@ -1,0 +1,45 @@
+package sweep
+
+// bucket contains a set of inputs that are not mutually exclusive.
+type bucket pendingInputs
+
+// tryAdd tries to add a new input to this bucket.
+func (b bucket) tryAdd(input *pendingInput) bool {
+	exclusiveGroup := input.params.ExclusiveGroup
+	if exclusiveGroup != nil {
+		for _, input := range b {
+			existingGroup := input.params.ExclusiveGroup
+			if existingGroup != nil &&
+				*existingGroup == *exclusiveGroup {
+
+				return false
+			}
+		}
+	}
+
+	b[*input.OutPoint()] = input
+
+	return true
+}
+
+// bucketList is a list of buckets that contain non-mutually exclusive inputs.
+type bucketList struct {
+	buckets []bucket
+}
+
+// add adds a new input. If the input is not accepted by any of the existing
+// buckets, a new bucket will be created.
+func (b *bucketList) add(input *pendingInput) {
+	for _, existingBucket := range b.buckets {
+		if existingBucket.tryAdd(input) {
+			return
+		}
+	}
+
+	// Create a new bucket and add the input. It is not necessary to check
+	// the return value of tryAdd because it will always succeed on an empty
+	// bucket.
+	newBucket := make(bucket)
+	newBucket.tryAdd(input)
+	b.buckets = append(b.buckets, newBucket)
+}

--- a/sweep/sweeper.go
+++ b/sweep/sweeper.go
@@ -402,10 +402,9 @@ func (s *UtxoSweeper) SweepInput(input input.Input,
 	}
 
 	log.Infof("Sweep request received: out_point=%v, witness_type=%v, "+
-		"time_lock=%v, amount=%v, fee_preference=%v, force=%v",
+		"time_lock=%v, amount=%v, params=(%v)",
 		input.OutPoint(), input.WitnessType(), input.BlocksToMaturity(),
-		btcutil.Amount(input.SignDesc().Output.Value),
-		params.Fee, params.Force)
+		btcutil.Amount(input.SignDesc().Output.Value), params)
 
 	sweeperInput := &sweepInputMessage{
 		input:      input,


### PR DESCRIPTION
Allows certain sweep inputs to be kept in separate transactions at all times. This is a preparation for anchor outputs. Before the commitment tx confirms, there are three potential anchors that can be cpfp'ed. We want to cpfp them all, but if done in the same transaction, the transaction would guaranteed to be invalid.

Exponential backoff would eventually get the txes published too, but having exclusive groups makes the process faster.