### PR TITLE
lnwire: create new ExtraOpaqueData type for parsing TLV extensions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,8 @@ lntest/itest/output*.log
 lntest/itest/pprof*.log
 lntest/itest/.backendlogs
 lntest/itest/.minerlogs
+lntest/itest/lnd-itest
+lntest/itest/.logs-*
 
 cmd/cmd
 *.key

--- a/.travis.yml
+++ b/.travis.yml
@@ -50,32 +50,30 @@ jobs:
     - stage: Integration Test
       name: Btcd Integration
       script:
-        - make itest
+        - make itest-parallel
 
     - name: Bitcoind Integration (txindex enabled)
       script:
         - bash ./scripts/install_bitcoind.sh
-        - make itest backend=bitcoind
+        - make itest-parallel backend=bitcoind
 
     - name: Bitcoind Integration (txindex disabled)
       script:
         - bash ./scripts/install_bitcoind.sh
-        - make itest backend="bitcoind notxindex"
+        - make itest-parallel backend="bitcoind notxindex"
 
     - name: Neutrino Integration
       script:
-        - make itest backend=neutrino
+        - make itest-parallel backend=neutrino
 
     - name: Btcd Integration ARM
       script:
-        - GOARM=7 GOARCH=arm GOOS=linux CGO_ENABLED=0 make btcd build-itest
-        - file lnd-itest
-        - GOARM=7 GOARCH=arm GOOS=linux CGO_ENABLED=0 make itest-only
+        - GOARM=7 GOARCH=arm GOOS=linux make itest-parallel
       arch: arm64
 
     - name: Btcd Integration Windows
       script:
-        - make itest-windows
+        - make itest-parallel-windows
       os: windows
       before_install:
         - choco upgrade --no-progress -y make netcat curl findutils
@@ -85,7 +83,8 @@ jobs:
           case $TRAVIS_OS_NAME in
             windows)
               echo "Uploading to termbin.com..."
-              for f in ./lntest/itest/*.log; do cat $f | nc termbin.com 9999 | xargs -r0 printf "$f"' uploaded to %s'; done
+              LOG_FILES=$(find ./lntest/itest -name '*.log')
+              for f in $LOG_FILES; do echo -n $f; cat $f | nc termbin.com 9999 | xargs -r0 printf ' uploaded to %s'; done
               ;;
           esac
 
@@ -97,8 +96,8 @@ after_failure:
         ;;
 
       *)
-        LOG_FILES=./lntest/itest/*.log
-        echo "Uploading to termbin.com..." && find $LOG_FILES | xargs -I{} sh -c "cat {} | nc termbin.com 9999 | xargs -r0 printf '{} uploaded to %s'"
+        LOG_FILES=$(find ./lntest/itest -name '*.log')
+        echo "Uploading to termbin.com..." && for f in $LOG_FILES; do echo -n $f; cat $f | nc termbin.com 9999 | xargs -r0 printf ' uploaded to %s'; done
         echo "Uploading to file.io..." && tar -zcvO $LOG_FILES | curl -s -F 'file=@-;filename=logs.tar.gz' https://file.io | xargs -r0 printf 'logs.tar.gz uploaded to %s\n'
         ;;
     esac

--- a/Makefile
+++ b/Makefile
@@ -175,6 +175,27 @@ itest-only:
 
 itest: btcd build-itest itest-only
 
+itest-parallel: btcd
+	@$(call print, "Building lnd binary")
+	CGO_ENABLED=0 $(GOBUILD) -tags="$(ITEST_TAGS)" -o lntest/itest/lnd-itest $(ITEST_LDFLAGS) $(PKG)/cmd/lnd
+
+	@$(call print, "Building itest binary for $(backend) backend")
+	CGO_ENABLED=0 $(GOTEST) -v ./lntest/itest -tags="$(DEV_TAGS) $(RPC_TAGS) rpctest $(backend)" -logoutput -goroutinedump -c -o lntest/itest/itest.test
+
+	@$(call print, "Running tests")
+	rm -rf lntest/itest/*.log lntest/itest/.logs-*
+	echo -n "$$(seq 0 $$(expr $(NUM_ITEST_TRANCHES) - 1))" | xargs -P $(NUM_ITEST_TRANCHES) -n 1 -I {} scripts/itest_part.sh {} $(NUM_ITEST_TRANCHES) $(TEST_FLAGS)
+
+itest-parallel-windows: btcd
+	@$(call print, "Building lnd binary")
+	CGO_ENABLED=0 $(GOBUILD) -tags="$(ITEST_TAGS)" -o lntest/itest/lnd-itest.exe $(ITEST_LDFLAGS) $(PKG)/cmd/lnd
+
+	@$(call print, "Building itest binary for $(backend) backend")
+	CGO_ENABLED=0 $(GOTEST) -v ./lntest/itest -tags="$(DEV_TAGS) $(RPC_TAGS) rpctest $(backend)" -logoutput -goroutinedump -c -o lntest/itest/itest.test.exe
+
+	@$(call print, "Running tests")
+	EXEC_SUFFIX=".exe" echo -n "$$(seq 0 $$(expr $(NUM_ITEST_TRANCHES) - 1))" | xargs -P $(NUM_ITEST_TRANCHES) -n 1 -I {} scripts/itest_part.sh {} $(NUM_ITEST_TRANCHES) $(TEST_FLAGS)
+
 itest-windows: btcd build-itest-windows itest-only
 
 unit: btcd

--- a/chanbackup/multi.go
+++ b/chanbackup/multi.go
@@ -63,7 +63,9 @@ func (m Multi) PackToWriter(w io.Writer, keyRing keychain.KeyRing) error {
 	var multiBackupBuffer bytes.Buffer
 
 	// First, we'll write out the version of this multi channel baackup.
-	err := lnwire.WriteElements(&multiBackupBuffer, byte(m.Version))
+	err := lnwire.WriteElements(
+		&multiBackupBuffer, lnwire.ProtocolVersionTLV, byte(m.Version),
+	)
 	if err != nil {
 		return err
 	}
@@ -111,7 +113,9 @@ func (m *Multi) UnpackFromReader(r io.Reader, keyRing keychain.KeyRing) error {
 	// First, we'll need to read the version of this multi-back up so we
 	// can know how to unpack each of the individual SCB's.
 	var multiVersion byte
-	err = lnwire.ReadElements(backupReader, &multiVersion)
+	err = lnwire.ReadElements(
+		backupReader, lnwire.ProtocolVersionTLV, &multiVersion,
+	)
 	if err != nil {
 		return err
 	}
@@ -127,7 +131,9 @@ func (m *Multi) UnpackFromReader(r io.Reader, keyRing keychain.KeyRing) error {
 		// backup is the same size, so we can continue until we've
 		// parsed out everything.
 		var numBackups uint32
-		err = lnwire.ReadElements(backupReader, &numBackups)
+		err = lnwire.ReadElements(
+			backupReader, lnwire.ProtocolVersionTLV, &numBackups,
+		)
 		if err != nil {
 			return err
 		}

--- a/channeldb/channel.go
+++ b/channeldb/channel.go
@@ -1871,7 +1871,8 @@ func serializeCommitDiff(w io.Writer, diff *CommitDiff) error {
 		return err
 	}
 
-	if err := diff.CommitSig.Encode(w, 0); err != nil {
+	err := diff.CommitSig.Encode(w, lnwire.ProtocolVersionTLV)
+	if err != nil {
 		return err
 	}
 
@@ -1918,7 +1919,7 @@ func deserializeCommitDiff(r io.Reader) (*CommitDiff, error) {
 	}
 
 	d.CommitSig = &lnwire.CommitSig{}
-	if err := d.CommitSig.Decode(r, 0); err != nil {
+	if err := d.CommitSig.Decode(r, lnwire.ProtocolVersionTLV); err != nil {
 		return nil, err
 	}
 

--- a/channeldb/channel_test.go
+++ b/channeldb/channel_test.go
@@ -639,7 +639,8 @@ func TestChannelStateTransition(t *testing.T) {
 		{
 			LogIndex: 2,
 			UpdateMsg: &lnwire.UpdateAddHTLC{
-				ChanID: lnwire.ChannelID{1, 2, 3},
+				ChanID:    lnwire.ChannelID{1, 2, 3},
+				ExtraData: make([]byte, 0),
 			},
 		},
 	}
@@ -660,7 +661,9 @@ func TestChannelStateTransition(t *testing.T) {
 	if !reflect.DeepEqual(
 		dbUnsignedAckedUpdates[0], unsignedAckedUpdates[0],
 	) {
-		t.Fatalf("unexpected update")
+		t.Fatalf("unexpected update: expected %v, got %v",
+			spew.Sdump(unsignedAckedUpdates[0]),
+			spew.Sdump(dbUnsignedAckedUpdates))
 	}
 
 	// The balances, new update, the HTLCs and the changes to the fake
@@ -702,22 +705,25 @@ func TestChannelStateTransition(t *testing.T) {
 				wireSig,
 				wireSig,
 			},
+			ExtraData: make([]byte, 0),
 		},
 		LogUpdates: []LogUpdate{
 			{
 				LogIndex: 1,
 				UpdateMsg: &lnwire.UpdateAddHTLC{
-					ID:     1,
-					Amount: lnwire.NewMSatFromSatoshis(100),
-					Expiry: 25,
+					ID:        1,
+					Amount:    lnwire.NewMSatFromSatoshis(100),
+					Expiry:    25,
+					ExtraData: make([]byte, 0),
 				},
 			},
 			{
 				LogIndex: 2,
 				UpdateMsg: &lnwire.UpdateAddHTLC{
-					ID:     2,
-					Amount: lnwire.NewMSatFromSatoshis(200),
-					Expiry: 50,
+					ID:        2,
+					Amount:    lnwire.NewMSatFromSatoshis(200),
+					Expiry:    50,
+					ExtraData: make([]byte, 0),
 				},
 			},
 		},

--- a/channeldb/codec.go
+++ b/channeldb/codec.go
@@ -178,7 +178,8 @@ func WriteElement(w io.Writer, element interface{}) error {
 		}
 
 	case lnwire.Message:
-		if _, err := lnwire.WriteMessage(w, e, 0); err != nil {
+		_, err := lnwire.WriteMessage(w, e, lnwire.ProtocolVersionTLV)
+		if err != nil {
 			return err
 		}
 
@@ -394,7 +395,7 @@ func ReadElement(r io.Reader, element interface{}) error {
 		*e = bytes
 
 	case *lnwire.Message:
-		msg, err := lnwire.ReadMessage(r, 0)
+		msg, err := lnwire.ReadMessage(r, lnwire.ProtocolVersionTLV)
 		if err != nil {
 			return err
 		}

--- a/channeldb/migration_01_to_11/codec.go
+++ b/channeldb/migration_01_to_11/codec.go
@@ -172,7 +172,8 @@ func WriteElement(w io.Writer, element interface{}) error {
 		}
 
 	case lnwire.Message:
-		if _, err := lnwire.WriteMessage(w, e, 0); err != nil {
+		_, err := lnwire.WriteMessage(w, e, lnwire.ProtocolVersionLegacy)
+		if err != nil {
 			return err
 		}
 
@@ -383,7 +384,7 @@ func ReadElement(r io.Reader, element interface{}) error {
 		*e = bytes
 
 	case *lnwire.Message:
-		msg, err := lnwire.ReadMessage(r, 0)
+		msg, err := lnwire.ReadMessage(r, lnwire.ProtocolVersionLegacy)
 		if err != nil {
 			return err
 		}

--- a/channeldb/migration_01_to_11/migrations.go
+++ b/channeldb/migration_01_to_11/migrations.go
@@ -724,7 +724,8 @@ func MigrateGossipMessageStoreKeys(tx kvdb.RwTx) error {
 
 		// Serialize the message with its wire encoding.
 		var b bytes.Buffer
-		if _, err := lnwire.WriteMessage(&b, msg, 0); err != nil {
+		_, err := lnwire.WriteMessage(&b, msg, lnwire.ProtocolVersionTLV)
+		if err != nil {
 			return err
 		}
 

--- a/channeldb/migration_01_to_11/migrations_test.go
+++ b/channeldb/migration_01_to_11/migrations_test.go
@@ -464,7 +464,10 @@ func TestMigrateGossipMessageStoreKeys(t *testing.T) {
 	// Construct the message which we'll use to test the migration, along
 	// with its old and new key formats.
 	shortChanID := lnwire.ShortChannelID{BlockHeight: 10}
-	msg := &lnwire.AnnounceSignatures{ShortChannelID: shortChanID}
+	msg := &lnwire.AnnounceSignatures{
+		ShortChannelID:  shortChanID,
+		ExtraOpaqueData: make([]byte, 0),
+	}
 
 	var oldMsgKey [33 + 8]byte
 	copy(oldMsgKey[:33], pubKey.SerializeCompressed())

--- a/channeldb/migration_01_to_11/migrations_test.go
+++ b/channeldb/migration_01_to_11/migrations_test.go
@@ -529,7 +529,9 @@ func TestMigrateGossipMessageStoreKeys(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		gotMsg, err := lnwire.ReadMessage(bytes.NewReader(rawMsg), 0)
+		gotMsg, err := lnwire.ReadMessage(
+			bytes.NewReader(rawMsg), lnwire.ProtocolVersionLegacy,
+		)
 		if err != nil {
 			t.Fatalf("unable to deserialize raw message: %v", err)
 		}

--- a/channeldb/waitingproof.go
+++ b/channeldb/waitingproof.go
@@ -227,7 +227,8 @@ func (p *WaitingProof) Encode(w io.Writer) error {
 		return err
 	}
 
-	if err := p.AnnounceSignatures.Encode(w, 0); err != nil {
+	err := p.AnnounceSignatures.Encode(w, lnwire.ProtocolVersionTLV)
+	if err != nil {
 		return err
 	}
 
@@ -242,7 +243,7 @@ func (p *WaitingProof) Decode(r io.Reader) error {
 	}
 
 	msg := &lnwire.AnnounceSignatures{}
-	if err := msg.Decode(r, 0); err != nil {
+	if err := msg.Decode(r, lnwire.ProtocolVersionTLV); err != nil {
 		return err
 	}
 

--- a/channeldb/waitingproof_test.go
+++ b/channeldb/waitingproof_test.go
@@ -5,6 +5,7 @@ import (
 
 	"reflect"
 
+	"github.com/davecgh/go-spew/spew"
 	"github.com/go-errors/errors"
 	"github.com/lightningnetwork/lnd/lnwire"
 )
@@ -23,6 +24,7 @@ func TestWaitingProofStore(t *testing.T) {
 	proof1 := NewWaitingProof(true, &lnwire.AnnounceSignatures{
 		NodeSignature:    wireSig,
 		BitcoinSignature: wireSig,
+		ExtraOpaqueData:  make([]byte, 0),
 	})
 
 	store, err := NewWaitingProofStore(db)
@@ -40,7 +42,8 @@ func TestWaitingProofStore(t *testing.T) {
 		t.Fatalf("unable retrieve proof from storage: %v", err)
 	}
 	if !reflect.DeepEqual(proof1, proof2) {
-		t.Fatal("wrong proof retrieved")
+		t.Fatalf("wrong proof retrieved: expected %v, got %v",
+			spew.Sdump(proof1), spew.Sdump(proof2))
 	}
 
 	if _, err := store.Get(proof1.OppositeKey()); err != ErrWaitingProofNotFound {

--- a/discovery/message_store.go
+++ b/discovery/message_store.go
@@ -120,7 +120,8 @@ func (s *MessageStore) AddMessage(msg lnwire.Message, peerPubKey [33]byte) error
 
 	// Serialize the message with its wire encoding.
 	var b bytes.Buffer
-	if _, err := lnwire.WriteMessage(&b, msg, 0); err != nil {
+	_, err = lnwire.WriteMessage(&b, msg, lnwire.ProtocolVersionTLV)
+	if err != nil {
 		return err
 	}
 
@@ -163,7 +164,9 @@ func (s *MessageStore) DeleteMessage(msg lnwire.Message,
 				return nil
 			}
 
-			dbMsg, err := lnwire.ReadMessage(bytes.NewReader(v), 0)
+			dbMsg, err := lnwire.ReadMessage(
+				bytes.NewReader(v), lnwire.ProtocolVersionTLV,
+			)
 			if err != nil {
 				return err
 			}
@@ -182,7 +185,9 @@ func (s *MessageStore) DeleteMessage(msg lnwire.Message,
 // readMessage reads a message from its serialized form and ensures its
 // supported by the current version of the message store.
 func readMessage(msgBytes []byte) (lnwire.Message, error) {
-	msg, err := lnwire.ReadMessage(bytes.NewReader(msgBytes), 0)
+	msg, err := lnwire.ReadMessage(
+		bytes.NewReader(msgBytes), lnwire.ProtocolVersionTLV,
+	)
 	if err != nil {
 		return nil, err
 	}

--- a/discovery/message_store_test.go
+++ b/discovery/message_store_test.go
@@ -64,13 +64,15 @@ func randCompressedPubKey(t *testing.T) [33]byte {
 
 func randAnnounceSignatures() *lnwire.AnnounceSignatures {
 	return &lnwire.AnnounceSignatures{
-		ShortChannelID: lnwire.NewShortChanIDFromInt(rand.Uint64()),
+		ShortChannelID:  lnwire.NewShortChanIDFromInt(rand.Uint64()),
+		ExtraOpaqueData: make([]byte, 0),
 	}
 }
 
 func randChannelUpdate() *lnwire.ChannelUpdate {
 	return &lnwire.ChannelUpdate{
-		ShortChannelID: lnwire.NewShortChanIDFromInt(rand.Uint64()),
+		ShortChannelID:  lnwire.NewShortChanIDFromInt(rand.Uint64()),
+		ExtraOpaqueData: make([]byte, 0),
 	}
 }
 

--- a/discovery/sync_manager_test.go
+++ b/discovery/sync_manager_test.go
@@ -536,8 +536,9 @@ func assertTransitionToChansSynced(t *testing.T, s *GossipSyncer, peer *mockPeer
 	assertMsgSent(t, peer, query)
 
 	s.ProcessQueryMsg(&lnwire.ReplyChannelRange{
-		QueryChannelRange: *query,
-		Complete:          1,
+		FirstBlockHeight: 0,
+		NumBlocks:        math.MaxUint32,
+		Complete:         1,
 	}, nil)
 
 	chanSeries := s.cfg.channelSeries.(*mockChannelGraphTimeSeries)

--- a/fundingmanager.go
+++ b/fundingmanager.go
@@ -1437,7 +1437,9 @@ func (f *fundingManager) handleFundingOpen(peer lnpeer.Peer,
 				PubKey: copyPubKey(msg.HtlcPoint),
 			},
 		},
-		UpfrontShutdown: msg.UpfrontShutdownScript,
+		UpfrontShutdown: lnwire.DeliveryAddress(
+			msg.UpfrontShutdownScript,
+		),
 	}
 	err = reservation.ProcessSingleContribution(remoteContribution)
 	if err != nil {
@@ -1455,21 +1457,23 @@ func (f *fundingManager) handleFundingOpen(peer lnpeer.Peer,
 	// contribution in the next message of the workflow.
 	ourContribution := reservation.OurContribution()
 	fundingAccept := lnwire.AcceptChannel{
-		PendingChannelID:      msg.PendingChannelID,
-		DustLimit:             ourContribution.DustLimit,
-		MaxValueInFlight:      remoteMaxValue,
-		ChannelReserve:        chanReserve,
-		MinAcceptDepth:        uint32(numConfsReq),
-		HtlcMinimum:           minHtlc,
-		CsvDelay:              remoteCsvDelay,
-		MaxAcceptedHTLCs:      maxHtlcs,
-		FundingKey:            ourContribution.MultiSigKey.PubKey,
-		RevocationPoint:       ourContribution.RevocationBasePoint.PubKey,
-		PaymentPoint:          ourContribution.PaymentBasePoint.PubKey,
-		DelayedPaymentPoint:   ourContribution.DelayBasePoint.PubKey,
-		HtlcPoint:             ourContribution.HtlcBasePoint.PubKey,
-		FirstCommitmentPoint:  ourContribution.FirstCommitmentPoint,
-		UpfrontShutdownScript: ourContribution.UpfrontShutdown,
+		PendingChannelID:     msg.PendingChannelID,
+		DustLimit:            ourContribution.DustLimit,
+		MaxValueInFlight:     remoteMaxValue,
+		ChannelReserve:       chanReserve,
+		MinAcceptDepth:       uint32(numConfsReq),
+		HtlcMinimum:          minHtlc,
+		CsvDelay:             remoteCsvDelay,
+		MaxAcceptedHTLCs:     maxHtlcs,
+		FundingKey:           ourContribution.MultiSigKey.PubKey,
+		RevocationPoint:      ourContribution.RevocationBasePoint.PubKey,
+		PaymentPoint:         ourContribution.PaymentBasePoint.PubKey,
+		DelayedPaymentPoint:  ourContribution.DelayBasePoint.PubKey,
+		HtlcPoint:            ourContribution.HtlcBasePoint.PubKey,
+		FirstCommitmentPoint: ourContribution.FirstCommitmentPoint,
+		UpfrontShutdownScript: lnwire.TypedDeliveryAddress(
+			ourContribution.UpfrontShutdown,
+		),
 	}
 
 	if err := peer.SendMessage(true, &fundingAccept); err != nil {
@@ -1568,7 +1572,9 @@ func (f *fundingManager) handleFundingAccept(peer lnpeer.Peer,
 				PubKey: copyPubKey(msg.HtlcPoint),
 			},
 		},
-		UpfrontShutdown: msg.UpfrontShutdownScript,
+		UpfrontShutdown: lnwire.DeliveryAddress(
+			msg.UpfrontShutdownScript,
+		),
 	}
 	err = resCtx.reservation.ProcessContribution(remoteContribution)
 
@@ -3255,7 +3261,7 @@ func (f *fundingManager) handleInitFundingMsg(msg *initFundingMsg) {
 		DelayedPaymentPoint:   ourContribution.DelayBasePoint.PubKey,
 		FirstCommitmentPoint:  ourContribution.FirstCommitmentPoint,
 		ChannelFlags:          channelFlags,
-		UpfrontShutdownScript: shutdown,
+		UpfrontShutdownScript: lnwire.TypedDeliveryAddress(shutdown),
 	}
 	if err := msg.peer.SendMessage(true, &fundingOpen); err != nil {
 		e := fmt.Errorf("unable to send funding request message: %v",

--- a/htlcswitch/payment_result.go
+++ b/htlcswitch/payment_result.go
@@ -76,7 +76,7 @@ func deserializeNetworkResult(r io.Reader) (*networkResult, error) {
 
 	n := &networkResult{}
 
-	n.msg, err = lnwire.ReadMessage(r, 0)
+	n.msg, err = lnwire.ReadMessage(r, lnwire.ProtocolVersionTLV)
 	if err != nil {
 		return nil, err
 	}

--- a/htlcswitch/payment_result_test.go
+++ b/htlcswitch/payment_result_test.go
@@ -39,18 +39,21 @@ func TestNetworkResultSerialization(t *testing.T) {
 		ChanID:          chanID,
 		ID:              2,
 		PaymentPreimage: preimage,
+		ExtraData:       make([]byte, 0),
 	}
 
 	fail := &lnwire.UpdateFailHTLC{
-		ChanID: chanID,
-		ID:     1,
-		Reason: []byte{},
+		ChanID:    chanID,
+		ID:        1,
+		Reason:    []byte{},
+		ExtraData: make([]byte, 0),
 	}
 
 	fail2 := &lnwire.UpdateFailHTLC{
-		ChanID: chanID,
-		ID:     1,
-		Reason: reason[:],
+		ChanID:    chanID,
+		ID:        1,
+		Reason:    reason[:],
+		ExtraData: make([]byte, 0),
 	}
 
 	testCases := []*networkResult{

--- a/lntest/bitcoind_common.go
+++ b/lntest/bitcoind_common.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"io/ioutil"
-	"math/rand"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -93,10 +92,10 @@ func newBackend(miner string, netParams *chaincfg.Params, extraArgs []string) (
 			fmt.Errorf("unable to create temp directory: %v", err)
 	}
 
-	zmqBlockPath := "ipc:///" + tempBitcoindDir + "/blocks.socket"
-	zmqTxPath := "ipc:///" + tempBitcoindDir + "/txs.socket"
-	rpcPort := rand.Int()%(65536-1024) + 1024
-	p2pPort := rand.Int()%(65536-1024) + 1024
+	zmqBlockAddr := fmt.Sprintf("tcp://127.0.0.1:%d", nextAvailablePort())
+	zmqTxAddr := fmt.Sprintf("tcp://127.0.0.1:%d", nextAvailablePort())
+	rpcPort := nextAvailablePort()
+	p2pPort := nextAvailablePort()
 
 	cmdArgs := []string{
 		"-datadir=" + tempBitcoindDir,
@@ -106,8 +105,8 @@ func newBackend(miner string, netParams *chaincfg.Params, extraArgs []string) (
 			"220110063096c221be9933c82d38e1",
 		fmt.Sprintf("-rpcport=%d", rpcPort),
 		fmt.Sprintf("-port=%d", p2pPort),
-		"-zmqpubrawblock=" + zmqBlockPath,
-		"-zmqpubrawtx=" + zmqTxPath,
+		"-zmqpubrawblock=" + zmqBlockAddr,
+		"-zmqpubrawtx=" + zmqTxAddr,
 		"-debuglogfile=" + logFile,
 	}
 	cmdArgs = append(cmdArgs, extraArgs...)
@@ -178,8 +177,8 @@ func newBackend(miner string, netParams *chaincfg.Params, extraArgs []string) (
 		rpcHost:      rpcHost,
 		rpcUser:      rpcUser,
 		rpcPass:      rpcPass,
-		zmqBlockPath: zmqBlockPath,
-		zmqTxPath:    zmqTxPath,
+		zmqBlockPath: zmqBlockAddr,
+		zmqTxPath:    zmqTxAddr,
 		p2pPort:      p2pPort,
 		rpcClient:    client,
 		minerAddr:    miner,

--- a/lntest/fee_service.go
+++ b/lntest/fee_service.go
@@ -16,9 +16,6 @@ const (
 	// is returned. Requests for higher confirmation targets will fall back
 	// to this.
 	feeServiceTarget = 2
-
-	// feeServicePort is the tcp port on which the service runs.
-	feeServicePort = 16534
 )
 
 // feeService runs a web service that provides fee estimation information.
@@ -40,16 +37,15 @@ type feeEstimates struct {
 
 // startFeeService spins up a go-routine to serve fee estimates.
 func startFeeService() *feeService {
+	port := nextAvailablePort()
 	f := feeService{
-		url: fmt.Sprintf(
-			"http://localhost:%v/fee-estimates.json", feeServicePort,
-		),
+		url: fmt.Sprintf("http://localhost:%v/fee-estimates.json", port),
 	}
 
 	// Initialize default fee estimate.
 	f.Fees = map[uint32]uint32{feeServiceTarget: 50000}
 
-	listenAddr := fmt.Sprintf(":%v", feeServicePort)
+	listenAddr := fmt.Sprintf(":%v", port)
 	f.srv = &http.Server{
 		Addr: listenAddr,
 	}

--- a/lntest/itest/lnd_channel_backup_test.go
+++ b/lntest/itest/lnd_channel_backup_test.go
@@ -1012,6 +1012,10 @@ func testChanRestoreScenario(t *harnessTest, net *lntest.NetworkHarness,
 	require.Contains(t.t, err.Error(), "cannot close channel with state: ")
 	require.Contains(t.t, err.Error(), "ChanStatusRestored")
 
+	// Increase the fee estimate so that the following force close tx will
+	// be cpfp'ed in case of anchor commitments.
+	net.SetFeeEstimate(30000)
+
 	// Now that we have ensured that the channels restored by the backup are
 	// in the correct state even without the remote peer telling us so,
 	// let's start up Carol again.

--- a/lntest/itest/lnd_multi-hop_htlc_remote_chain_claim_test.go
+++ b/lntest/itest/lnd_multi-hop_htlc_remote_chain_claim_test.go
@@ -101,15 +101,17 @@ func testMultiHopHtlcRemoteChainClaim(net *lntest.NetworkHarness, t *harnessTest
 	// bob will attempt to redeem his anchor commitment (if the channel
 	// type is of that type).
 	if c == commitTypeAnchors {
-		_, err = waitForNTxsInMempool(net.Miner.Node, 1, minerMempoolTimeout)
+		_, err = waitForNTxsInMempool(
+			net.Miner.Node, 1, minerMempoolTimeout,
+		)
 		if err != nil {
-			t.Fatalf("unable to find bob's anchor commit sweep: %v", err)
-
+			t.Fatalf("unable to find bob's anchor commit sweep: %v",
+				err)
 		}
 	}
 
 	// Mine enough blocks for Alice to sweep her funds from the force
-	// closed channel. closeCHannelAndAssertType() already mined a block
+	// closed channel. closeChannelAndAssertType() already mined a block
 	// containing the commitment tx and the commit sweep tx will be
 	// broadcast immediately before it can be included in a block, so mine
 	// one less than defaultCSV in order to perform mempool assertions.

--- a/lntest/itest/lnd_test.go
+++ b/lntest/itest/lnd_test.go
@@ -2435,7 +2435,7 @@ func testOpenChannelAfterReorg(net *lntest.NetworkHarness, t *harnessTest) {
 	)
 
 	// Set up a new miner that we can use to cause a reorg.
-	tempLogDir := "./.tempminerlogs"
+	tempLogDir := fmt.Sprintf("%s/.tempminerlogs", lntest.GetLogDir())
 	logFilename := "output-open_channel_reorg-temp_miner.log"
 	tempMiner, tempMinerCleanUp, err := lntest.NewMiner(
 		tempLogDir, logFilename,
@@ -14158,6 +14158,8 @@ func TestLightningNetworkDaemon(t *testing.T) {
 	}
 
 	// Parse testing flags that influence our test execution.
+	logDir := lntest.GetLogDir()
+	require.NoError(t, os.MkdirAll(logDir, 0700))
 	testCases, trancheIndex, trancheOffset := getTestCaseSplitTranche()
 	lntest.ApplyPortOffset(uint32(trancheIndex) * 1000)
 
@@ -14176,7 +14178,7 @@ func TestLightningNetworkDaemon(t *testing.T) {
 	// guarantees of getting included in to blocks.
 	//
 	// We will also connect it to our chain backend.
-	minerLogDir := "./.minerlogs"
+	minerLogDir := fmt.Sprintf("%s/.minerlogs", logDir)
 	miner, minerCleanUp, err := lntest.NewMiner(
 		minerLogDir, "output_btcd_miner.log",
 		harnessNetParams, &rpcclient.NotificationHandlers{},

--- a/lntest/itest/lnd_test.go
+++ b/lntest/itest/lnd_test.go
@@ -6,6 +6,7 @@ import (
 	"crypto/rand"
 	"crypto/sha256"
 	"encoding/hex"
+	"flag"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -52,6 +53,60 @@ import (
 	"github.com/lightningnetwork/lnd/routing"
 	"github.com/stretchr/testify/require"
 )
+
+const (
+	// defaultSplitTranches is the default number of tranches we split the
+	// test cases into.
+	defaultSplitTranches uint = 1
+
+	// defaultRunTranche is the default index of the test cases tranche that
+	// we run.
+	defaultRunTranche uint = 0
+)
+
+var (
+	// testCasesSplitParts is the number of tranches the test cases should
+	// be split into. By default this is set to 1, so no splitting happens.
+	// If this value is increased, then the -runtranche flag must be
+	// specified as well to indicate which part should be run in the current
+	// invocation.
+	testCasesSplitTranches = flag.Uint(
+		"splittranches", defaultSplitTranches, "split the test cases "+
+			"in this many tranches and run the tranche at "+
+			"0-based index specified by the -runtranche flag",
+	)
+
+	// testCasesRunTranche is the 0-based index of the split test cases
+	// tranche to run in the current invocation.
+	testCasesRunTranche = flag.Uint(
+		"runtranche", defaultRunTranche, "run the tranche of the "+
+			"split test cases with the given (0-based) index",
+	)
+)
+
+// getTestCaseSplitTranche returns the sub slice of the test cases that should
+// be run as the current split tranche as well as the index and slice offset of
+// the tranche.
+func getTestCaseSplitTranche() ([]*testCase, uint, uint) {
+	numTranches := defaultSplitTranches
+	if testCasesSplitTranches != nil {
+		numTranches = *testCasesSplitTranches
+	}
+	runTranche := defaultRunTranche
+	if testCasesRunTranche != nil {
+		runTranche = *testCasesRunTranche
+	}
+
+	numCases := uint(len(allTestCases))
+	testsPerTranche := numCases / numTranches
+	trancheOffset := runTranche * testsPerTranche
+	trancheEnd := trancheOffset + testsPerTranche
+	if trancheEnd > numCases || runTranche == numTranches-1 {
+		trancheEnd = numCases
+	}
+
+	return allTestCases[trancheOffset:trancheEnd], runTranche, trancheOffset
+}
 
 func rpcPointToWirePoint(t *harnessTest, chanPoint *lnrpc.ChannelPoint) wire.OutPoint {
 	txid, err := lnd.GetChanPointFundingTxid(chanPoint)
@@ -14098,9 +14153,13 @@ func getPaymentResult(stream routerrpc.Router_SendPaymentV2Client) (
 // programmatically driven network of lnd nodes.
 func TestLightningNetworkDaemon(t *testing.T) {
 	// If no tests are registered, then we can exit early.
-	if len(testsCases) == 0 {
+	if len(allTestCases) == 0 {
 		t.Skip("integration tests not selected with flag 'rpctest'")
 	}
+
+	// Parse testing flags that influence our test execution.
+	testCases, trancheIndex, trancheOffset := getTestCaseSplitTranche()
+	lntest.ApplyPortOffset(uint32(trancheIndex) * 1000)
 
 	ht := newHarnessTest(t, nil)
 
@@ -14149,8 +14208,7 @@ func TestLightningNetworkDaemon(t *testing.T) {
 
 	// Connect chainbackend to miner.
 	require.NoError(
-		t, chainBackend.ConnectMiner(),
-		"failed to connect to miner",
+		t, chainBackend.ConnectMiner(), "failed to connect to miner",
 	)
 
 	binary := itestLndBinary
@@ -14187,7 +14245,8 @@ func TestLightningNetworkDaemon(t *testing.T) {
 				if !more {
 					return
 				}
-				ht.Logf("lnd finished with error (stderr):\n%v", err)
+				ht.Logf("lnd finished with error (stderr):\n%v",
+					err)
 			}
 		}
 	}()
@@ -14210,8 +14269,9 @@ func TestLightningNetworkDaemon(t *testing.T) {
 		ht.Fatalf("unable to set up test lightning network: %v", err)
 	}
 
-	t.Logf("Running %v integration tests", len(testsCases))
-	for _, testCase := range testsCases {
+	// Run the subset of the test cases selected in this tranche.
+	for idx, testCase := range testCases {
+		testCase := testCase
 		logLine := fmt.Sprintf("STARTING ============ %v ============\n",
 			testCase.name)
 
@@ -14232,7 +14292,10 @@ func TestLightningNetworkDaemon(t *testing.T) {
 		// Start every test with the default static fee estimate.
 		lndHarness.SetFeeEstimate(12500)
 
-		success := t.Run(testCase.name, func(t1 *testing.T) {
+		name := fmt.Sprintf("%02d-of-%d/%s/%s",
+			trancheOffset+uint(idx)+1, len(allTestCases),
+			chainBackend.Name(), testCase.name)
+		success := t.Run(name, func(t1 *testing.T) {
 			ht := newHarnessTest(t1, lndHarness)
 			ht.RunTestCase(testCase)
 		})
@@ -14242,8 +14305,9 @@ func TestLightningNetworkDaemon(t *testing.T) {
 		if !success {
 			// Log failure time to help relate the lnd logs to the
 			// failure.
-			t.Logf("Failure time: %v",
-				time.Now().Format("2006-01-02 15:04:05.000"))
+			t.Logf("Failure time: %v", time.Now().Format(
+				"2006-01-02 15:04:05.000",
+			))
 			break
 		}
 	}

--- a/lntest/itest/lnd_test.go
+++ b/lntest/itest/lnd_test.go
@@ -14,7 +14,6 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
-	"runtime"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -14213,23 +14212,9 @@ func TestLightningNetworkDaemon(t *testing.T) {
 		t, chainBackend.ConnectMiner(), "failed to connect to miner",
 	)
 
-	binary := itestLndBinary
-	if runtime.GOOS == "windows" {
-		// Windows (even in a bash like environment like git bash as on
-		// Travis) doesn't seem to like relative paths to exe files...
-		currentDir, err := os.Getwd()
-		if err != nil {
-			ht.Fatalf("unable to get working directory: %v", err)
-		}
-		targetPath := filepath.Join(currentDir, "../../lnd-itest.exe")
-		binary, err = filepath.Abs(targetPath)
-		if err != nil {
-			ht.Fatalf("unable to get absolute path: %v", err)
-		}
-	}
-
 	// Now we can set up our test harness (LND instance), with the chain
 	// backend we just created.
+	binary := ht.getLndBinary()
 	lndHarness, err = lntest.NewNetworkHarness(miner, chainBackend, binary)
 	if err != nil {
 		ht.Fatalf("unable to create lightning network harness: %v", err)

--- a/lntest/itest/lnd_test_list_off_test.go
+++ b/lntest/itest/lnd_test_list_off_test.go
@@ -2,4 +2,4 @@
 
 package itest
 
-var testsCases = []*testCase{}
+var allTestCases = []*testCase{}

--- a/lntest/itest/lnd_test_list_on_test.go
+++ b/lntest/itest/lnd_test_list_on_test.go
@@ -4,6 +4,10 @@ package itest
 
 var allTestCases = []*testCase{
 	{
+		name: "test multi-hop htlc",
+		test: testMultiHopHtlcClaims,
+	},
+	{
 		name: "sweep coins",
 		test: testSweepAllCoins,
 	},
@@ -143,10 +147,6 @@ var allTestCases = []*testCase{
 	{
 		name: "async bidirectional payments",
 		test: testBidirectionalAsyncPayments,
-	},
-	{
-		name: "test multi-hop htlc",
-		test: testMultiHopHtlcClaims,
 	},
 	{
 		name: "switch circuit persistence",

--- a/lntest/itest/lnd_test_list_on_test.go
+++ b/lntest/itest/lnd_test_list_on_test.go
@@ -2,7 +2,7 @@
 
 package itest
 
-var testsCases = []*testCase{
+var allTestCases = []*testCase{
 	{
 		name: "sweep coins",
 		test: testSweepAllCoins,

--- a/lntest/node.go
+++ b/lntest/node.go
@@ -70,6 +70,10 @@ var (
 	logOutput = flag.Bool("logoutput", false,
 		"log output from node n to file output-n.log")
 
+	// logSubDir is the default directory where the logs are written to if
+	// logOutput is true.
+	logSubDir = flag.String("logdir", ".", "default dir to write logs to")
+
 	// goroutineDump is a flag that can be set to dump the active
 	// goroutines of test nodes on failure.
 	goroutineDump = flag.Bool("goroutinedump", false,
@@ -108,6 +112,15 @@ func nextAvailablePort() int {
 // possible to run the tests in parallel without colliding on the same ports.
 func ApplyPortOffset(offset uint32) {
 	_ = atomic.AddUint32(&lastPort, offset)
+}
+
+// GetLogDir returns the passed --logdir flag or the default value if it wasn't
+// set.
+func GetLogDir() string {
+	if logSubDir != nil && *logSubDir != "" {
+		return *logSubDir
+	}
+	return "."
 }
 
 // generateListeningPorts returns four ints representing ports to listen on
@@ -392,11 +405,9 @@ func NewMiner(logDir, logFilename string, netParams *chaincfg.Params,
 
 		// After shutting down the miner, we'll make a copy of the log
 		// file before deleting the temporary log dir.
-		logFile := fmt.Sprintf(
-			"%s/%s/btcd.log", logDir, netParams.Name,
-		)
-		copyPath := fmt.Sprintf("./%s", logFilename)
-		err := CopyFile(copyPath, logFile)
+		logFile := fmt.Sprintf("%s/%s/btcd.log", logDir, netParams.Name)
+		copyPath := fmt.Sprintf("%s/../%s", logDir, logFilename)
+		err := CopyFile(filepath.Clean(copyPath), logFile)
 		if err != nil {
 			return fmt.Errorf("unable to copy file: %v", err)
 		}
@@ -481,24 +492,28 @@ func (hn *HarnessNode) start(lndBinary string, lndError chan<- error) error {
 	// If the logoutput flag is passed, redirect output from the nodes to
 	// log files.
 	if *logOutput {
-		fileName := fmt.Sprintf("output-%d-%s-%s.log", hn.NodeID,
+		dir := GetLogDir()
+		fileName := fmt.Sprintf("%s/output-%d-%s-%s.log", dir, hn.NodeID,
 			hn.Cfg.Name, hex.EncodeToString(hn.PubKey[:logPubKeyBytes]))
 
 		// If the node's PubKey is not yet initialized, create a temporary
 		// file name. Later, after the PubKey has been initialized, the
 		// file can be moved to its final name with the PubKey included.
 		if bytes.Equal(hn.PubKey[:4], []byte{0, 0, 0, 0}) {
-			fileName = fmt.Sprintf("output-%d-%s-tmp__.log", hn.NodeID,
-				hn.Cfg.Name)
+			fileName = fmt.Sprintf("%s/output-%d-%s-tmp__.log",
+				dir, hn.NodeID, hn.Cfg.Name)
 
 			// Once the node has done its work, the log file can be renamed.
 			finalizeLogfile = func() {
 				if hn.logFile != nil {
 					hn.logFile.Close()
 
-					newFileName := fmt.Sprintf("output-%d-%s-%s.log",
-						hn.NodeID, hn.Cfg.Name,
-						hex.EncodeToString(hn.PubKey[:logPubKeyBytes]))
+					pubKeyHex := hex.EncodeToString(
+						hn.PubKey[:logPubKeyBytes],
+					)
+					newFileName := fmt.Sprintf("%s/output"+
+						"-%d-%s-%s.log", dir, hn.NodeID,
+						hn.Cfg.Name, pubKeyHex)
 					err := os.Rename(fileName, newFileName)
 					if err != nil {
 						fmt.Printf("could not rename "+

--- a/lntest/node.go
+++ b/lntest/node.go
@@ -43,7 +43,7 @@ const (
 	// defaultNodePort is the start of the range for listening ports of
 	// harness nodes. Ports are monotonically increasing starting from this
 	// number and are determined by the results of nextAvailablePort().
-	defaultNodePort = 19555
+	defaultNodePort = 5555
 
 	// logPubKeyBytes is the number of bytes of the node's PubKey that will
 	// be appended to the log file name. The whole PubKey is too long and
@@ -102,6 +102,12 @@ func nextAvailablePort() int {
 
 	// No ports available? Must be a mistake.
 	panic("no ports available for listening")
+}
+
+// ApplyPortOffset adds the given offset to the lastPort variable, making it
+// possible to run the tests in parallel without colliding on the same ports.
+func ApplyPortOffset(offset uint32) {
+	_ = atomic.AddUint32(&lastPort, offset)
 }
 
 // generateListeningPorts returns four ints representing ports to listen on

--- a/lnwallet/channel_test.go
+++ b/lnwallet/channel_test.go
@@ -3176,6 +3176,7 @@ func TestChanSyncOweCommitment(t *testing.T) {
 			Amount:      htlcAmt,
 			Expiry:      uint32(10),
 			OnionBlob:   fakeOnionBlob,
+			ExtraData:   make([]byte, 0),
 		}
 
 		htlcIndex, err := bobChannel.AddHTLC(h, nil)
@@ -3220,6 +3221,7 @@ func TestChanSyncOweCommitment(t *testing.T) {
 		Amount:      htlcAmt,
 		Expiry:      uint32(10),
 		OnionBlob:   fakeOnionBlob,
+		ExtraData:   make([]byte, 0),
 	}
 	aliceHtlcIndex, err := aliceChannel.AddHTLC(aliceHtlc, nil)
 	if err != nil {

--- a/lnwire/accept_channel.go
+++ b/lnwire/accept_channel.go
@@ -110,6 +110,7 @@ var _ Message = (*AcceptChannel)(nil)
 // This is part of the lnwire.Message interface.
 func (a *AcceptChannel) Encode(w io.Writer, pver uint32) error {
 	return WriteElements(w,
+		pver,
 		a.PendingChannelID[:],
 		a.DustLimit,
 		a.MaxValueInFlight,
@@ -137,6 +138,7 @@ func (a *AcceptChannel) Encode(w io.Writer, pver uint32) error {
 func (a *AcceptChannel) Decode(r io.Reader, pver uint32) error {
 	// Read all the mandatory fields in the accept message.
 	return ReadElements(r,
+		pver,
 		a.PendingChannelID[:],
 		&a.DustLimit,
 		&a.MaxValueInFlight,

--- a/lnwire/accept_channel_test.go
+++ b/lnwire/accept_channel_test.go
@@ -12,7 +12,7 @@ import (
 func TestDecodeAcceptChannel(t *testing.T) {
 	tests := []struct {
 		name           string
-		shutdownScript DeliveryAddress
+		shutdownScript TypedDeliveryAddress
 	}{
 		{
 			name:           "no upfront shutdown script",

--- a/lnwire/announcement_signatures.go
+++ b/lnwire/announcement_signatures.go
@@ -52,6 +52,7 @@ var _ Message = (*AnnounceSignatures)(nil)
 // This is part of the lnwire.Message interface.
 func (a *AnnounceSignatures) Decode(r io.Reader, pver uint32) error {
 	return ReadElements(r,
+		pver,
 		&a.ChannelID,
 		&a.ShortChannelID,
 		&a.NodeSignature,
@@ -66,6 +67,7 @@ func (a *AnnounceSignatures) Decode(r io.Reader, pver uint32) error {
 // This is part of the lnwire.Message interface.
 func (a *AnnounceSignatures) Encode(w io.Writer, pver uint32) error {
 	return WriteElements(w,
+		pver,
 		a.ChannelID,
 		a.ShortChannelID,
 		a.NodeSignature,

--- a/lnwire/announcement_signatures.go
+++ b/lnwire/announcement_signatures.go
@@ -2,7 +2,6 @@ package lnwire
 
 import (
 	"io"
-	"io/ioutil"
 )
 
 // AnnounceSignatures this is a direct message between two endpoints of a
@@ -40,7 +39,7 @@ type AnnounceSignatures struct {
 	// properly validate the set of signatures that cover these new fields,
 	// and ensure we're able to make upgrades to the network in a forwards
 	// compatible manner.
-	ExtraOpaqueData []byte
+	ExtraOpaqueData ExtraOpaqueData
 }
 
 // A compile time check to ensure AnnounceSignatures implements the
@@ -52,29 +51,13 @@ var _ Message = (*AnnounceSignatures)(nil)
 //
 // This is part of the lnwire.Message interface.
 func (a *AnnounceSignatures) Decode(r io.Reader, pver uint32) error {
-	err := ReadElements(r,
+	return ReadElements(r,
 		&a.ChannelID,
 		&a.ShortChannelID,
 		&a.NodeSignature,
 		&a.BitcoinSignature,
+		&a.ExtraOpaqueData,
 	)
-	if err != nil {
-		return err
-	}
-
-	// Now that we've read out all the fields that we explicitly know of,
-	// we'll collect the remainder into the ExtraOpaqueData field. If there
-	// aren't any bytes, then we'll snip off the slice to avoid carrying
-	// around excess capacity.
-	a.ExtraOpaqueData, err = ioutil.ReadAll(r)
-	if err != nil {
-		return err
-	}
-	if len(a.ExtraOpaqueData) == 0 {
-		a.ExtraOpaqueData = nil
-	}
-
-	return nil
 }
 
 // Encode serializes the target AnnounceSignatures into the passed io.Writer
@@ -104,5 +87,5 @@ func (a *AnnounceSignatures) MsgType() MessageType {
 //
 // This is part of the lnwire.Message interface.
 func (a *AnnounceSignatures) MaxPayloadLength(pver uint32) uint32 {
-	return 65533
+	return MaxMsgBody
 }

--- a/lnwire/channel_announcement.go
+++ b/lnwire/channel_announcement.go
@@ -68,6 +68,7 @@ var _ Message = (*ChannelAnnouncement)(nil)
 // This is part of the lnwire.Message interface.
 func (a *ChannelAnnouncement) Decode(r io.Reader, pver uint32) error {
 	return ReadElements(r,
+		pver,
 		&a.NodeSig1,
 		&a.NodeSig2,
 		&a.BitcoinSig1,
@@ -89,6 +90,7 @@ func (a *ChannelAnnouncement) Decode(r io.Reader, pver uint32) error {
 // This is part of the lnwire.Message interface.
 func (a *ChannelAnnouncement) Encode(w io.Writer, pver uint32) error {
 	return WriteElements(w,
+		pver,
 		a.NodeSig1,
 		a.NodeSig2,
 		a.BitcoinSig1,
@@ -126,6 +128,10 @@ func (a *ChannelAnnouncement) DataToSign() ([]byte, error) {
 	// We should not include the signatures itself.
 	var w bytes.Buffer
 	err := WriteElements(&w,
+		// We always use the modern protocol version here as we always
+		// need to include any optional data in the signature digest
+		// for forwards compatibility.
+		ProtocolVersionTLV,
 		a.Features,
 		a.ChainHash[:],
 		a.ShortChannelID,

--- a/lnwire/channel_reestablish.go
+++ b/lnwire/channel_reestablish.go
@@ -60,6 +60,11 @@ type ChannelReestablish struct {
 	// LocalUnrevokedCommitPoint is the commitment point used in the
 	// current un-revoked commitment transaction of the sending party.
 	LocalUnrevokedCommitPoint *btcec.PublicKey
+
+	// ExtraData is the set of data that was appended to this message to
+	// fill out the full maximum transport message size. These fields can
+	// be used to specify optional data such as custom TLV fields.
+	ExtraData ExtraOpaqueData
 }
 
 // A compile time check to ensure ChannelReestablish implements the
@@ -83,12 +88,20 @@ func (a *ChannelReestablish) Encode(w io.Writer, pver uint32) error {
 	// If the commit point wasn't sent, then we won't write out any of the
 	// remaining fields as they're optional.
 	if a.LocalUnrevokedCommitPoint == nil {
-		return nil
+		// However, we'll still write out the extra data if it's
+		// present.
+		//
+		// NOTE: This is here primarily for the quickcheck tests, in
+		// practice, we'll always populate this field.
+		return WriteElements(w, a.ExtraData)
 	}
 
 	// Otherwise, we'll write out the remaining elements.
-	return WriteElements(w, a.LastRemoteCommitSecret[:],
-		a.LocalUnrevokedCommitPoint)
+	return WriteElements(w,
+		a.LastRemoteCommitSecret[:],
+		a.LocalUnrevokedCommitPoint,
+		a.ExtraData,
+	)
 }
 
 // Decode deserializes a serialized ChannelReestablish stored in the passed
@@ -118,6 +131,9 @@ func (a *ChannelReestablish) Decode(r io.Reader, pver uint32) error {
 	var buf [32]byte
 	_, err = io.ReadFull(r, buf[:32])
 	if err == io.EOF {
+		// If there aren't any more bytes, then we'll emplace an empty
+		// extra data to make our quickcheck tests happy.
+		a.ExtraData = make([]byte, 0)
 		return nil
 	} else if err != nil {
 		return err
@@ -127,9 +143,13 @@ func (a *ChannelReestablish) Decode(r io.Reader, pver uint32) error {
 	copy(a.LastRemoteCommitSecret[:], buf[:])
 
 	// We'll conclude by parsing out the commitment point. We don't check
-	// the error in this case, as it hey included the commit secret, then
+	// the error in this case, as it they included the commit secret, then
 	// they MUST also include the commit point.
-	return ReadElement(r, &a.LocalUnrevokedCommitPoint)
+	if err = ReadElement(r, &a.LocalUnrevokedCommitPoint); err != nil {
+		return err
+	}
+
+	return a.ExtraData.Decode(r)
 }
 
 // MsgType returns the integer uniquely identifying this message type on the
@@ -145,22 +165,5 @@ func (a *ChannelReestablish) MsgType() MessageType {
 //
 // This is part of the lnwire.Message interface.
 func (a *ChannelReestablish) MaxPayloadLength(pver uint32) uint32 {
-	var length uint32
-
-	// ChanID - 32 bytes
-	length += 32
-
-	// NextLocalCommitHeight - 8 bytes
-	length += 8
-
-	// RemoteCommitTailHeight - 8 bytes
-	length += 8
-
-	// LastRemoteCommitSecret - 32 bytes
-	length += 32
-
-	// LocalUnrevokedCommitPoint - 33 bytes
-	length += 33
-
-	return length
+	return MaxMsgBody
 }

--- a/lnwire/channel_reestablish.go
+++ b/lnwire/channel_reestablish.go
@@ -77,6 +77,7 @@ var _ Message = (*ChannelReestablish)(nil)
 // This is part of the lnwire.Message interface.
 func (a *ChannelReestablish) Encode(w io.Writer, pver uint32) error {
 	err := WriteElements(w,
+		pver,
 		a.ChanID,
 		a.NextLocalCommitHeight,
 		a.RemoteCommitTailHeight,
@@ -93,11 +94,12 @@ func (a *ChannelReestablish) Encode(w io.Writer, pver uint32) error {
 		//
 		// NOTE: This is here primarily for the quickcheck tests, in
 		// practice, we'll always populate this field.
-		return WriteElements(w, a.ExtraData)
+		return WriteElements(w, pver, a.ExtraData)
 	}
 
 	// Otherwise, we'll write out the remaining elements.
 	return WriteElements(w,
+		pver,
 		a.LastRemoteCommitSecret[:],
 		a.LocalUnrevokedCommitPoint,
 		a.ExtraData,
@@ -110,6 +112,7 @@ func (a *ChannelReestablish) Encode(w io.Writer, pver uint32) error {
 // This is part of the lnwire.Message interface.
 func (a *ChannelReestablish) Decode(r io.Reader, pver uint32) error {
 	err := ReadElements(r,
+		pver,
 		&a.ChanID,
 		&a.NextLocalCommitHeight,
 		&a.RemoteCommitTailHeight,
@@ -145,11 +148,11 @@ func (a *ChannelReestablish) Decode(r io.Reader, pver uint32) error {
 	// We'll conclude by parsing out the commitment point. We don't check
 	// the error in this case, as it they included the commit secret, then
 	// they MUST also include the commit point.
-	if err = ReadElement(r, &a.LocalUnrevokedCommitPoint); err != nil {
+	if err = ReadElement(r, pver, &a.LocalUnrevokedCommitPoint); err != nil {
 		return err
 	}
 
-	return a.ExtraData.Decode(r)
+	return a.ExtraData.Decode(r, pver)
 }
 
 // MsgType returns the integer uniquely identifying this message type on the

--- a/lnwire/channel_update.go
+++ b/lnwire/channel_update.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"io/ioutil"
 
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 )
@@ -110,13 +109,10 @@ type ChannelUpdate struct {
 	// HtlcMaximumMsat is the maximum HTLC value which will be accepted.
 	HtlcMaximumMsat MilliSatoshi
 
-	// ExtraOpaqueData is the set of data that was appended to this
-	// message, some of which we may not actually know how to iterate or
-	// parse. By holding onto this data, we ensure that we're able to
-	// properly validate the set of signatures that cover these new fields,
-	// and ensure we're able to make upgrades to the network in a forwards
-	// compatible manner.
-	ExtraOpaqueData []byte
+	// ExtraData is the set of data that was appended to this message to
+	// fill out the full maximum transport message size. These fields can
+	// be used to specify optional data such as custom TLV fields.
+	ExtraOpaqueData ExtraOpaqueData
 }
 
 // A compile time check to ensure ChannelUpdate implements the lnwire.Message
@@ -151,19 +147,7 @@ func (a *ChannelUpdate) Decode(r io.Reader, pver uint32) error {
 		}
 	}
 
-	// Now that we've read out all the fields that we explicitly know of,
-	// we'll collect the remainder into the ExtraOpaqueData field. If there
-	// aren't any bytes, then we'll snip off the slice to avoid carrying
-	// around excess capacity.
-	a.ExtraOpaqueData, err = ioutil.ReadAll(r)
-	if err != nil {
-		return err
-	}
-	if len(a.ExtraOpaqueData) == 0 {
-		a.ExtraOpaqueData = nil
-	}
-
-	return nil
+	return a.ExtraOpaqueData.Decode(r)
 }
 
 // Encode serializes the target ChannelUpdate into the passed io.Writer
@@ -196,7 +180,7 @@ func (a *ChannelUpdate) Encode(w io.Writer, pver uint32) error {
 	}
 
 	// Finally, append any extra opaque data.
-	return WriteElements(w, a.ExtraOpaqueData)
+	return a.ExtraOpaqueData.Encode(w)
 }
 
 // MsgType returns the integer uniquely identifying this message type on the
@@ -212,7 +196,7 @@ func (a *ChannelUpdate) MsgType() MessageType {
 //
 // This is part of the lnwire.Message interface.
 func (a *ChannelUpdate) MaxPayloadLength(pver uint32) uint32 {
-	return 65533
+	return MaxMsgBody
 }
 
 // DataToSign is used to retrieve part of the announcement message which should
@@ -245,7 +229,7 @@ func (a *ChannelUpdate) DataToSign() ([]byte, error) {
 	}
 
 	// Finally, append any extra opaque data.
-	if err := WriteElements(&w, a.ExtraOpaqueData); err != nil {
+	if err := a.ExtraOpaqueData.Encode(&w); err != nil {
 		return nil, err
 	}
 

--- a/lnwire/channel_update.go
+++ b/lnwire/channel_update.go
@@ -125,6 +125,7 @@ var _ Message = (*ChannelUpdate)(nil)
 // This is part of the lnwire.Message interface.
 func (a *ChannelUpdate) Decode(r io.Reader, pver uint32) error {
 	err := ReadElements(r,
+		pver,
 		&a.Signature,
 		a.ChainHash[:],
 		&a.ShortChannelID,
@@ -142,12 +143,12 @@ func (a *ChannelUpdate) Decode(r io.Reader, pver uint32) error {
 
 	// Now check whether the max HTLC field is present and read it if so.
 	if a.MessageFlags.HasMaxHtlc() {
-		if err := ReadElements(r, &a.HtlcMaximumMsat); err != nil {
+		if err := ReadElements(r, pver, &a.HtlcMaximumMsat); err != nil {
 			return err
 		}
 	}
 
-	return a.ExtraOpaqueData.Decode(r)
+	return a.ExtraOpaqueData.Decode(r, pver)
 }
 
 // Encode serializes the target ChannelUpdate into the passed io.Writer
@@ -156,6 +157,7 @@ func (a *ChannelUpdate) Decode(r io.Reader, pver uint32) error {
 // This is part of the lnwire.Message interface.
 func (a *ChannelUpdate) Encode(w io.Writer, pver uint32) error {
 	err := WriteElements(w,
+		pver,
 		a.Signature,
 		a.ChainHash[:],
 		a.ShortChannelID,
@@ -174,13 +176,13 @@ func (a *ChannelUpdate) Encode(w io.Writer, pver uint32) error {
 	// Now append optional fields if they are set. Currently, the only
 	// optional field is max HTLC.
 	if a.MessageFlags.HasMaxHtlc() {
-		if err := WriteElements(w, a.HtlcMaximumMsat); err != nil {
+		if err := WriteElements(w, pver, a.HtlcMaximumMsat); err != nil {
 			return err
 		}
 	}
 
 	// Finally, append any extra opaque data.
-	return a.ExtraOpaqueData.Encode(w)
+	return a.ExtraOpaqueData.Encode(w, pver)
 }
 
 // MsgType returns the integer uniquely identifying this message type on the
@@ -202,10 +204,10 @@ func (a *ChannelUpdate) MaxPayloadLength(pver uint32) uint32 {
 // DataToSign is used to retrieve part of the announcement message which should
 // be signed.
 func (a *ChannelUpdate) DataToSign() ([]byte, error) {
-
 	// We should not include the signatures itself.
 	var w bytes.Buffer
 	err := WriteElements(&w,
+		ProtocolVersionTLV,
 		a.ChainHash[:],
 		a.ShortChannelID,
 		a.Timestamp,
@@ -223,13 +225,18 @@ func (a *ChannelUpdate) DataToSign() ([]byte, error) {
 	// Now append optional fields if they are set. Currently, the only
 	// optional field is max HTLC.
 	if a.MessageFlags.HasMaxHtlc() {
-		if err := WriteElements(&w, a.HtlcMaximumMsat); err != nil {
+		err := WriteElements(
+			&w, ProtocolVersionTLV, a.HtlcMaximumMsat,
+		)
+		if err != nil {
 			return nil, err
 		}
 	}
 
-	// Finally, append any extra opaque data.
-	if err := a.ExtraOpaqueData.Encode(&w); err != nil {
+	// Finally, append any extra opaque data. We always pass in the modern
+	// protocol version here as we always need to include any extra bytes
+	// in the signature digest.
+	if err := a.ExtraOpaqueData.Encode(&w, ProtocolVersionTLV); err != nil {
 		return nil, err
 	}
 

--- a/lnwire/closing_signed.go
+++ b/lnwire/closing_signed.go
@@ -27,6 +27,11 @@ type ClosingSigned struct {
 
 	// Signature is for the proposed channel close transaction.
 	Signature Sig
+
+	// ExtraData is the set of data that was appended to this message to
+	// fill out the full maximum transport message size. These fields can
+	// be used to specify optional data such as custom TLV fields.
+	ExtraData ExtraOpaqueData
 }
 
 // NewClosingSigned creates a new empty ClosingSigned message.
@@ -49,7 +54,9 @@ var _ Message = (*ClosingSigned)(nil)
 //
 // This is part of the lnwire.Message interface.
 func (c *ClosingSigned) Decode(r io.Reader, pver uint32) error {
-	return ReadElements(r, &c.ChannelID, &c.FeeSatoshis, &c.Signature)
+	return ReadElements(
+		r, &c.ChannelID, &c.FeeSatoshis, &c.Signature, &c.ExtraData,
+	)
 }
 
 // Encode serializes the target ClosingSigned into the passed io.Writer
@@ -57,7 +64,9 @@ func (c *ClosingSigned) Decode(r io.Reader, pver uint32) error {
 //
 // This is part of the lnwire.Message interface.
 func (c *ClosingSigned) Encode(w io.Writer, pver uint32) error {
-	return WriteElements(w, c.ChannelID, c.FeeSatoshis, c.Signature)
+	return WriteElements(
+		w, c.ChannelID, c.FeeSatoshis, c.Signature, c.ExtraData,
+	)
 }
 
 // MsgType returns the integer uniquely identifying this message type on the
@@ -73,16 +82,5 @@ func (c *ClosingSigned) MsgType() MessageType {
 //
 // This is part of the lnwire.Message interface.
 func (c *ClosingSigned) MaxPayloadLength(uint32) uint32 {
-	var length uint32
-
-	// ChannelID - 32 bytes
-	length += 32
-
-	// FeeSatoshis - 8 bytes
-	length += 8
-
-	// Signature - 64 bytes
-	length += 64
-
-	return length
+	return MaxMsgBody
 }

--- a/lnwire/closing_signed.go
+++ b/lnwire/closing_signed.go
@@ -55,7 +55,8 @@ var _ Message = (*ClosingSigned)(nil)
 // This is part of the lnwire.Message interface.
 func (c *ClosingSigned) Decode(r io.Reader, pver uint32) error {
 	return ReadElements(
-		r, &c.ChannelID, &c.FeeSatoshis, &c.Signature, &c.ExtraData,
+		r, pver, &c.ChannelID, &c.FeeSatoshis, &c.Signature,
+		&c.ExtraData,
 	)
 }
 
@@ -65,7 +66,7 @@ func (c *ClosingSigned) Decode(r io.Reader, pver uint32) error {
 // This is part of the lnwire.Message interface.
 func (c *ClosingSigned) Encode(w io.Writer, pver uint32) error {
 	return WriteElements(
-		w, c.ChannelID, c.FeeSatoshis, c.Signature, c.ExtraData,
+		w, pver, c.ChannelID, c.FeeSatoshis, c.Signature, c.ExtraData,
 	)
 }
 

--- a/lnwire/commit_sig.go
+++ b/lnwire/commit_sig.go
@@ -34,11 +34,18 @@ type CommitSig struct {
 	// should be signed, for each incoming HTLC the HTLC timeout
 	// transaction should be signed.
 	HtlcSigs []Sig
+
+	// ExtraData is the set of data that was appended to this message to
+	// fill out the full maximum transport message size. These fields can
+	// be used to specify optional data such as custom TLV fields.
+	ExtraData ExtraOpaqueData
 }
 
 // NewCommitSig creates a new empty CommitSig message.
 func NewCommitSig() *CommitSig {
-	return &CommitSig{}
+	return &CommitSig{
+		ExtraData: make([]byte, 0),
+	}
 }
 
 // A compile time check to ensure CommitSig implements the lnwire.Message
@@ -54,6 +61,7 @@ func (c *CommitSig) Decode(r io.Reader, pver uint32) error {
 		&c.ChanID,
 		&c.CommitSig,
 		&c.HtlcSigs,
+		&c.ExtraData,
 	)
 }
 
@@ -66,6 +74,7 @@ func (c *CommitSig) Encode(w io.Writer, pver uint32) error {
 		c.ChanID,
 		c.CommitSig,
 		c.HtlcSigs,
+		c.ExtraData,
 	)
 }
 
@@ -82,8 +91,7 @@ func (c *CommitSig) MsgType() MessageType {
 //
 // This is part of the lnwire.Message interface.
 func (c *CommitSig) MaxPayloadLength(uint32) uint32 {
-	// 32 + 64 + 2 + max_allowed_htlcs
-	return MaxMessagePayload
+	return MaxMsgBody
 }
 
 // TargetChanID returns the channel id of the link for which this message is

--- a/lnwire/commit_sig.go
+++ b/lnwire/commit_sig.go
@@ -58,6 +58,7 @@ var _ Message = (*CommitSig)(nil)
 // This is part of the lnwire.Message interface.
 func (c *CommitSig) Decode(r io.Reader, pver uint32) error {
 	return ReadElements(r,
+		pver,
 		&c.ChanID,
 		&c.CommitSig,
 		&c.HtlcSigs,
@@ -71,6 +72,7 @@ func (c *CommitSig) Decode(r io.Reader, pver uint32) error {
 // This is part of the lnwire.Message interface.
 func (c *CommitSig) Encode(w io.Writer, pver uint32) error {
 	return WriteElements(w,
+		pver,
 		c.ChanID,
 		c.CommitSig,
 		c.HtlcSigs,

--- a/lnwire/error.go
+++ b/lnwire/error.go
@@ -123,8 +123,7 @@ func (c *Error) MsgType() MessageType {
 //
 // This is part of the lnwire.Message interface.
 func (c *Error) MaxPayloadLength(uint32) uint32 {
-	// 32 + 2 + 65501
-	return 65535
+	return MaxMsgBody
 }
 
 // isASCII is a helper method that checks whether all bytes in `data` would be

--- a/lnwire/error.go
+++ b/lnwire/error.go
@@ -94,6 +94,7 @@ func (c *Error) Error() string {
 // This is part of the lnwire.Message interface.
 func (c *Error) Decode(r io.Reader, pver uint32) error {
 	return ReadElements(r,
+		pver,
 		&c.ChanID,
 		&c.Data,
 	)
@@ -105,6 +106,7 @@ func (c *Error) Decode(r io.Reader, pver uint32) error {
 // This is part of the lnwire.Message interface.
 func (c *Error) Encode(w io.Writer, pver uint32) error {
 	return WriteElements(w,
+		pver,
 		c.ChanID,
 		c.Data,
 	)

--- a/lnwire/extra_bytes.go
+++ b/lnwire/extra_bytes.go
@@ -1,0 +1,84 @@
+package lnwire
+
+import (
+	"bytes"
+	"io"
+	"io/ioutil"
+
+	"github.com/lightningnetwork/lnd/tlv"
+)
+
+// ExtraOpaqueData is the set of data that was appended to this message, some
+// of which we may not actually know how to iterate or parse. By holding onto
+// this data, we ensure that we're able to properly validate the set of
+// signatures that cover these new fields, and ensure we're able to make
+// upgrades to the network in a forwards compatible manner.
+type ExtraOpaqueData []byte
+
+// Encode attempts to encode the raw extra bytes into the passed io.Writer.
+func (e *ExtraOpaqueData) Encode(w io.Writer) error {
+	eBytes := []byte((*e)[:])
+	if err := WriteElements(w, eBytes); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// Decode attempts to unpack the raw bytes encoded in the passed io.Reader as a
+// set of extra opaque data.
+func (e *ExtraOpaqueData) Decode(r io.Reader) error {
+	// First, we'll attempt to read a set of bytes contained within the
+	// passed io.Reader (if any exist).
+	rawBytes, err := ioutil.ReadAll(r)
+	if err != nil {
+		return err
+	}
+
+	// If we _do_ have some bytes, then we'll swap out our backing pointer.
+	// This ensures that any struct that embeds this type will properly
+	// store the bytes once this method exits.
+	if len(rawBytes) > 0 {
+		*e = ExtraOpaqueData(rawBytes)
+	} else {
+		*e = make([]byte, 0)
+	}
+
+	return nil
+}
+
+// PackRecords attempts to encode the set of tlv records into the target
+// ExtraOpaqueData instance. The records will be encoded as a raw TLV stream
+// and stored within the backing slice pointer.
+func (e *ExtraOpaqueData) PackRecords(records []tlv.Record) error {
+	tlvStream, err := tlv.NewStream(records...)
+	if err != nil {
+		return err
+	}
+
+	var extraBytesWriter bytes.Buffer
+	if err := tlvStream.Encode(&extraBytesWriter); err != nil {
+		return err
+	}
+
+	*e = ExtraOpaqueData(extraBytesWriter.Bytes())
+
+	return nil
+}
+
+// ExtractRecords attempts to decode any types in the internal raw bytes as if
+// it were a tlv stream. The set of raw parsed types is returned, and any
+// passed records (if found in the stream) will be parsed into the proper
+// tlv.Record.
+func (e *ExtraOpaqueData) ExtractRecords(records ...tlv.Record) (
+	tlv.TypeMap, error) {
+
+	extraBytesReader := bytes.NewReader(*e)
+
+	tlvStream, err := tlv.NewStream(records...)
+	if err != nil {
+		return nil, err
+	}
+
+	return tlvStream.DecodeWithParsedTypes(extraBytesReader)
+}

--- a/lnwire/extra_bytes_test.go
+++ b/lnwire/extra_bytes_test.go
@@ -1,0 +1,147 @@
+package lnwire
+
+import (
+	"bytes"
+	"math/rand"
+	"reflect"
+	"testing"
+	"testing/quick"
+
+	"github.com/lightningnetwork/lnd/tlv"
+)
+
+// TestExtraOpaqueDataEncodeDecode tests that we're able to encode/decode
+// arbitrary payloads.
+func TestExtraOpaqueDataEncodeDecode(t *testing.T) {
+	t.Parallel()
+
+	type testCase struct {
+		// emptyBytes indicates if we should try to encode empty bytes
+		// or not.
+		emptyBytes bool
+
+		// inputBytes if emptyBytes is false, then we'll read in this
+		// set of bytes instead.
+		inputBytes []byte
+	}
+
+	// We should be able to read in an arbitrary set of bytes as an
+	// ExtraOpaqueData, then encode those new bytes into a new instance.
+	// The final two instances should be identical.
+	scenario := func(test testCase) bool {
+		var (
+			extraData ExtraOpaqueData
+			b         bytes.Buffer
+		)
+
+		copy(extraData[:], test.inputBytes)
+
+		if err := extraData.Encode(&b); err != nil {
+			t.Fatalf("unable to encode extra data: %v", err)
+			return false
+		}
+
+		var newBytes ExtraOpaqueData
+		if err := newBytes.Decode(&b); err != nil {
+			t.Fatalf("unable to decode extra bytes: %v", err)
+			return false
+		}
+
+		if !bytes.Equal(extraData[:], newBytes[:]) {
+			t.Fatalf("expected %x, got %x", extraData,
+				newBytes)
+			return false
+		}
+
+		return true
+	}
+
+	// We'll make a function to generate random test data. Half of the
+	// time, we'll actually feed in blank bytes.
+	quickCfg := &quick.Config{
+		Values: func(v []reflect.Value, r *rand.Rand) {
+
+			var newTestCase testCase
+			if r.Int31()%2 == 0 {
+				newTestCase.emptyBytes = true
+			}
+
+			if !newTestCase.emptyBytes {
+				numBytes := r.Int31n(1000)
+				newTestCase.inputBytes = make([]byte, numBytes)
+
+				_, err := r.Read(newTestCase.inputBytes)
+				if err != nil {
+					t.Fatalf("unable to gen random bytes: %v", err)
+					return
+				}
+			}
+
+			v[0] = reflect.ValueOf(newTestCase)
+		},
+	}
+
+	if err := quick.Check(scenario, quickCfg); err != nil {
+		t.Fatalf("encode+decode test failed: %v", err)
+	}
+}
+
+// TestExtraOpaqueDataPackUnpackRecords tests that we're able to pack a set of
+// tlv.Records into a stream, and unpack them on the other side to obtain the
+// same set of records.
+func TestExtraOpaqueDataPackUnpackRecords(t *testing.T) {
+	t.Parallel()
+
+	var (
+		type1 tlv.Type = 1
+		type2 tlv.Type = 2
+
+		channelType1 uint8 = 2
+		channelType2 uint8
+
+		hop1 uint32 = 99
+		hop2 uint32
+	)
+	testRecords := []tlv.Record{
+		tlv.MakePrimitiveRecord(type1, &channelType1),
+		tlv.MakePrimitiveRecord(type2, &hop1),
+	}
+
+	// Now that we have our set of sample records and types, we'll encode
+	// them into the passed ExtraOpaqueData instance.
+	var extraBytes ExtraOpaqueData
+	if err := extraBytes.PackRecords(testRecords); err != nil {
+		t.Fatalf("unable to pack records: %v", err)
+	}
+
+	// We'll now simulate decoding these types _back_ into records on the
+	// other side.
+	newRecords := []tlv.Record{
+		tlv.MakePrimitiveRecord(type1, &channelType2),
+		tlv.MakePrimitiveRecord(type2, &hop2),
+	}
+	typeMap, err := extraBytes.ExtractRecords(newRecords...)
+	if err != nil {
+		t.Fatalf("unable to extract record: %v", err)
+	}
+
+	// We should find that the new backing values have been populated with
+	// the proper value.
+	switch {
+	case channelType1 != channelType2:
+		t.Fatalf("wrong record for channel type: expected %v, got %v",
+			channelType1, channelType2)
+
+	case hop1 != hop2:
+		t.Fatalf("wrong record for hop: expected %v, got %v", hop1,
+			hop2)
+	}
+
+	// Both types we created above should be found in the type map.
+	if _, ok := typeMap[type1]; !ok {
+		t.Fatalf("type1 not found in typeMap")
+	}
+	if _, ok := typeMap[type2]; !ok {
+		t.Fatalf("type2 not found in typeMap")
+	}
+}

--- a/lnwire/funding_created.go
+++ b/lnwire/funding_created.go
@@ -24,6 +24,11 @@ type FundingCreated struct {
 	// CommitSig is Alice's signature from Bob's version of the commitment
 	// transaction.
 	CommitSig Sig
+
+	// ExtraData is the set of data that was appended to this message to
+	// fill out the full maximum transport message size. These fields can
+	// be used to specify optional data such as custom TLV fields.
+	ExtraData ExtraOpaqueData
 }
 
 // A compile time check to ensure FundingCreated implements the lnwire.Message
@@ -36,7 +41,10 @@ var _ Message = (*FundingCreated)(nil)
 //
 // This is part of the lnwire.Message interface.
 func (f *FundingCreated) Encode(w io.Writer, pver uint32) error {
-	return WriteElements(w, f.PendingChannelID[:], f.FundingPoint, f.CommitSig)
+	return WriteElements(
+		w, f.PendingChannelID[:], f.FundingPoint, f.CommitSig,
+		f.ExtraData,
+	)
 }
 
 // Decode deserializes the serialized FundingCreated stored in the passed
@@ -45,7 +53,10 @@ func (f *FundingCreated) Encode(w io.Writer, pver uint32) error {
 //
 // This is part of the lnwire.Message interface.
 func (f *FundingCreated) Decode(r io.Reader, pver uint32) error {
-	return ReadElements(r, f.PendingChannelID[:], &f.FundingPoint, &f.CommitSig)
+	return ReadElements(
+		r, f.PendingChannelID[:], &f.FundingPoint, &f.CommitSig,
+		&f.ExtraData,
+	)
 }
 
 // MsgType returns the uint32 code which uniquely identifies this message as a
@@ -61,6 +72,5 @@ func (f *FundingCreated) MsgType() MessageType {
 //
 // This is part of the lnwire.Message interface.
 func (f *FundingCreated) MaxPayloadLength(uint32) uint32 {
-	// 32 + 32 + 2 + 64
-	return 130
+	return MaxMsgBody
 }

--- a/lnwire/funding_created.go
+++ b/lnwire/funding_created.go
@@ -42,7 +42,7 @@ var _ Message = (*FundingCreated)(nil)
 // This is part of the lnwire.Message interface.
 func (f *FundingCreated) Encode(w io.Writer, pver uint32) error {
 	return WriteElements(
-		w, f.PendingChannelID[:], f.FundingPoint, f.CommitSig,
+		w, pver, f.PendingChannelID[:], f.FundingPoint, f.CommitSig,
 		f.ExtraData,
 	)
 }
@@ -54,7 +54,7 @@ func (f *FundingCreated) Encode(w io.Writer, pver uint32) error {
 // This is part of the lnwire.Message interface.
 func (f *FundingCreated) Decode(r io.Reader, pver uint32) error {
 	return ReadElements(
-		r, f.PendingChannelID[:], &f.FundingPoint, &f.CommitSig,
+		r, pver, f.PendingChannelID[:], &f.FundingPoint, &f.CommitSig,
 		&f.ExtraData,
 	)
 }

--- a/lnwire/funding_locked.go
+++ b/lnwire/funding_locked.go
@@ -19,6 +19,11 @@ type FundingLocked struct {
 	// NextPerCommitmentPoint is the secret that can be used to revoke the
 	// next commitment transaction for the channel.
 	NextPerCommitmentPoint *btcec.PublicKey
+
+	// ExtraData is the set of data that was appended to this message to
+	// fill out the full maximum transport message size. These fields can
+	// be used to specify optional data such as custom TLV fields.
+	ExtraData ExtraOpaqueData
 }
 
 // NewFundingLocked creates a new FundingLocked message, populating it with the
@@ -27,6 +32,7 @@ func NewFundingLocked(cid ChannelID, npcp *btcec.PublicKey) *FundingLocked {
 	return &FundingLocked{
 		ChanID:                 cid,
 		NextPerCommitmentPoint: npcp,
+		ExtraData:              make([]byte, 0),
 	}
 }
 
@@ -42,7 +48,9 @@ var _ Message = (*FundingLocked)(nil)
 func (c *FundingLocked) Decode(r io.Reader, pver uint32) error {
 	return ReadElements(r,
 		&c.ChanID,
-		&c.NextPerCommitmentPoint)
+		&c.NextPerCommitmentPoint,
+		&c.ExtraData,
+	)
 }
 
 // Encode serializes the target FundingLocked message into the passed io.Writer
@@ -53,7 +61,9 @@ func (c *FundingLocked) Decode(r io.Reader, pver uint32) error {
 func (c *FundingLocked) Encode(w io.Writer, pver uint32) error {
 	return WriteElements(w,
 		c.ChanID,
-		c.NextPerCommitmentPoint)
+		c.NextPerCommitmentPoint,
+		c.ExtraData,
+	)
 }
 
 // MsgType returns the uint32 code which uniquely identifies this message as a
@@ -70,14 +80,5 @@ func (c *FundingLocked) MsgType() MessageType {
 //
 // This is part of the lnwire.Message interface.
 func (c *FundingLocked) MaxPayloadLength(uint32) uint32 {
-	var length uint32
-
-	// ChanID - 32 bytes
-	length += 32
-
-	// NextPerCommitmentPoint - 33 bytes
-	length += 33
-
-	// 65 bytes
-	return length
+	return MaxMsgBody
 }

--- a/lnwire/funding_locked.go
+++ b/lnwire/funding_locked.go
@@ -47,6 +47,7 @@ var _ Message = (*FundingLocked)(nil)
 // This is part of the lnwire.Message interface.
 func (c *FundingLocked) Decode(r io.Reader, pver uint32) error {
 	return ReadElements(r,
+		pver,
 		&c.ChanID,
 		&c.NextPerCommitmentPoint,
 		&c.ExtraData,
@@ -60,6 +61,7 @@ func (c *FundingLocked) Decode(r io.Reader, pver uint32) error {
 // This is part of the lnwire.Message interface.
 func (c *FundingLocked) Encode(w io.Writer, pver uint32) error {
 	return WriteElements(w,
+		pver,
 		c.ChanID,
 		c.NextPerCommitmentPoint,
 		c.ExtraData,

--- a/lnwire/funding_signed.go
+++ b/lnwire/funding_signed.go
@@ -13,6 +13,11 @@ type FundingSigned struct {
 	// CommitSig is Bob's signature for Alice's version of the commitment
 	// transaction.
 	CommitSig Sig
+
+	// ExtraData is the set of data that was appended to this message to
+	// fill out the full maximum transport message size. These fields can
+	// be used to specify optional data such as custom TLV fields.
+	ExtraData ExtraOpaqueData
 }
 
 // A compile time check to ensure FundingSigned implements the lnwire.Message
@@ -25,7 +30,7 @@ var _ Message = (*FundingSigned)(nil)
 //
 // This is part of the lnwire.Message interface.
 func (f *FundingSigned) Encode(w io.Writer, pver uint32) error {
-	return WriteElements(w, f.ChanID, f.CommitSig)
+	return WriteElements(w, f.ChanID, f.CommitSig, f.ExtraData)
 }
 
 // Decode deserializes the serialized FundingSigned stored in the passed
@@ -34,7 +39,7 @@ func (f *FundingSigned) Encode(w io.Writer, pver uint32) error {
 //
 // This is part of the lnwire.Message interface.
 func (f *FundingSigned) Decode(r io.Reader, pver uint32) error {
-	return ReadElements(r, &f.ChanID, &f.CommitSig)
+	return ReadElements(r, &f.ChanID, &f.CommitSig, &f.ExtraData)
 }
 
 // MsgType returns the uint32 code which uniquely identifies this message as a
@@ -50,6 +55,5 @@ func (f *FundingSigned) MsgType() MessageType {
 //
 // This is part of the lnwire.Message interface.
 func (f *FundingSigned) MaxPayloadLength(uint32) uint32 {
-	// 32 + 64
-	return 96
+	return MaxMsgBody
 }

--- a/lnwire/funding_signed.go
+++ b/lnwire/funding_signed.go
@@ -30,7 +30,7 @@ var _ Message = (*FundingSigned)(nil)
 //
 // This is part of the lnwire.Message interface.
 func (f *FundingSigned) Encode(w io.Writer, pver uint32) error {
-	return WriteElements(w, f.ChanID, f.CommitSig, f.ExtraData)
+	return WriteElements(w, pver, f.ChanID, f.CommitSig, f.ExtraData)
 }
 
 // Decode deserializes the serialized FundingSigned stored in the passed
@@ -39,7 +39,7 @@ func (f *FundingSigned) Encode(w io.Writer, pver uint32) error {
 //
 // This is part of the lnwire.Message interface.
 func (f *FundingSigned) Decode(r io.Reader, pver uint32) error {
-	return ReadElements(r, &f.ChanID, &f.CommitSig, &f.ExtraData)
+	return ReadElements(r, pver, &f.ChanID, &f.CommitSig, &f.ExtraData)
 }
 
 // MsgType returns the uint32 code which uniquely identifies this message as a

--- a/lnwire/gossip_timestamp_range.go
+++ b/lnwire/gossip_timestamp_range.go
@@ -24,6 +24,11 @@ type GossipTimestampRange struct {
 	// NOT send any announcements that have a timestamp greater than
 	// FirstTimestamp + TimestampRange.
 	TimestampRange uint32
+
+	// ExtraData is the set of data that was appended to this message to
+	// fill out the full maximum transport message size. These fields can
+	// be used to specify optional data such as custom TLV fields.
+	ExtraData ExtraOpaqueData
 }
 
 // NewGossipTimestampRange creates a new empty GossipTimestampRange message.
@@ -44,6 +49,7 @@ func (g *GossipTimestampRange) Decode(r io.Reader, pver uint32) error {
 		g.ChainHash[:],
 		&g.FirstTimestamp,
 		&g.TimestampRange,
+		&g.ExtraData,
 	)
 }
 
@@ -56,6 +62,7 @@ func (g *GossipTimestampRange) Encode(w io.Writer, pver uint32) error {
 		g.ChainHash[:],
 		g.FirstTimestamp,
 		g.TimestampRange,
+		g.ExtraData,
 	)
 }
 
@@ -73,8 +80,5 @@ func (g *GossipTimestampRange) MsgType() MessageType {
 //
 // This is part of the lnwire.Message interface.
 func (g *GossipTimestampRange) MaxPayloadLength(uint32) uint32 {
-	// 32 + 4 + 4
-	//
-	// TODO(roasbeef): update to 8 byte timestmaps?
-	return 40
+	return MaxMsgBody
 }

--- a/lnwire/gossip_timestamp_range.go
+++ b/lnwire/gossip_timestamp_range.go
@@ -46,6 +46,7 @@ var _ Message = (*GossipTimestampRange)(nil)
 // This is part of the lnwire.Message interface.
 func (g *GossipTimestampRange) Decode(r io.Reader, pver uint32) error {
 	return ReadElements(r,
+		pver,
 		g.ChainHash[:],
 		&g.FirstTimestamp,
 		&g.TimestampRange,
@@ -59,6 +60,7 @@ func (g *GossipTimestampRange) Decode(r io.Reader, pver uint32) error {
 // This is part of the lnwire.Message interface.
 func (g *GossipTimestampRange) Encode(w io.Writer, pver uint32) error {
 	return WriteElements(w,
+		pver,
 		g.ChainHash[:],
 		g.FirstTimestamp,
 		g.TimestampRange,

--- a/lnwire/init_message.go
+++ b/lnwire/init_message.go
@@ -20,6 +20,11 @@ type Init struct {
 	// message, any GlobalFeatures should be merged into the unified
 	// Features field.
 	Features *RawFeatureVector
+
+	// ExtraData is the set of data that was appended to this message to
+	// fill out the full maximum transport message size. These fields can
+	// be used to specify optional data such as custom TLV fields.
+	ExtraData ExtraOpaqueData
 }
 
 // NewInitMessage creates new instance of init message object.
@@ -27,6 +32,7 @@ func NewInitMessage(gf *RawFeatureVector, f *RawFeatureVector) *Init {
 	return &Init{
 		GlobalFeatures: gf,
 		Features:       f,
+		ExtraData:      make([]byte, 0),
 	}
 }
 
@@ -42,6 +48,7 @@ func (msg *Init) Decode(r io.Reader, pver uint32) error {
 	return ReadElements(r,
 		&msg.GlobalFeatures,
 		&msg.Features,
+		&msg.ExtraData,
 	)
 }
 
@@ -53,6 +60,7 @@ func (msg *Init) Encode(w io.Writer, pver uint32) error {
 	return WriteElements(w,
 		msg.GlobalFeatures,
 		msg.Features,
+		msg.ExtraData,
 	)
 }
 
@@ -69,5 +77,5 @@ func (msg *Init) MsgType() MessageType {
 //
 // This is part of the lnwire.Message interface.
 func (msg *Init) MaxPayloadLength(uint32) uint32 {
-	return 2 + 2 + maxAllowedSize + 2 + maxAllowedSize
+	return MaxMsgBody
 }

--- a/lnwire/init_message.go
+++ b/lnwire/init_message.go
@@ -46,6 +46,7 @@ var _ Message = (*Init)(nil)
 // This is part of the lnwire.Message interface.
 func (msg *Init) Decode(r io.Reader, pver uint32) error {
 	return ReadElements(r,
+		pver,
 		&msg.GlobalFeatures,
 		&msg.Features,
 		&msg.ExtraData,
@@ -58,6 +59,7 @@ func (msg *Init) Decode(r io.Reader, pver uint32) error {
 // This is part of the lnwire.Message interface.
 func (msg *Init) Encode(w io.Writer, pver uint32) error {
 	return WriteElements(w,
+		pver,
 		msg.GlobalFeatures,
 		msg.Features,
 		msg.ExtraData,

--- a/lnwire/lnwire.go
+++ b/lnwire/lnwire.go
@@ -18,9 +18,16 @@ import (
 	"github.com/lightningnetwork/lnd/tor"
 )
 
-// MaxSliceLength is the maximum allowed length for any opaque byte slices in
-// the wire protocol.
-const MaxSliceLength = 65535
+const (
+	// MaxSliceLength is the maximum allowed length for any opaque byte
+	// slices in the wire protocol.
+	MaxSliceLength = 65535
+
+	// MaxMsgBody is the largest payload any message is allowed to provide.
+	// This is two less than the MaxSliceLength as each message has a 2
+	// byte type that precedes the message body.
+	MaxMsgBody = 65533
+)
 
 // PkScript is simple type definition which represents a raw serialized public
 // key script.
@@ -418,6 +425,10 @@ func WriteElement(w io.Writer, element interface{}) error {
 		if _, err := w.Write(b[:]); err != nil {
 			return err
 		}
+
+	case ExtraOpaqueData:
+		return e.Encode(w)
+
 	default:
 		return fmt.Errorf("unknown type in WriteElement: %T", e)
 	}
@@ -824,6 +835,10 @@ func ReadElement(r io.Reader, element interface{}) error {
 			return err
 		}
 		*e = addrBytes[:length]
+
+	case *ExtraOpaqueData:
+		return e.Decode(r)
+
 	default:
 		return fmt.Errorf("unknown type in ReadElement: %T", e)
 	}

--- a/lnwire/lnwire.go
+++ b/lnwire/lnwire.go
@@ -429,6 +429,9 @@ func WriteElement(w io.Writer, element interface{}) error {
 	case ExtraOpaqueData:
 		return e.Encode(w)
 
+	case TypedDeliveryAddress:
+		return e.Encode(w)
+
 	default:
 		return fmt.Errorf("unknown type in WriteElement: %T", e)
 	}
@@ -837,6 +840,9 @@ func ReadElement(r io.Reader, element interface{}) error {
 		*e = addrBytes[:length]
 
 	case *ExtraOpaqueData:
+		return e.Decode(r)
+
+	case *TypedDeliveryAddress:
 		return e.Decode(r)
 
 	default:

--- a/lnwire/lnwire_test.go
+++ b/lnwire/lnwire_test.go
@@ -810,10 +810,8 @@ func TestLightningWireProtocol(t *testing.T) {
 		},
 		MsgReplyChannelRange: func(v []reflect.Value, r *rand.Rand) {
 			req := ReplyChannelRange{
-				QueryChannelRange: QueryChannelRange{
-					FirstBlockHeight: uint32(r.Int31()),
-					NumBlocks:        uint32(r.Int31()),
-				},
+				FirstBlockHeight: uint32(r.Int31()),
+				NumBlocks:        uint32(r.Int31()),
 			}
 
 			if _, err := rand.Read(req.ChainHash[:]); err != nil {

--- a/lnwire/lnwire_test.go
+++ b/lnwire/lnwire_test.go
@@ -67,10 +67,10 @@ func randRawKey() ([33]byte, error) {
 	return n, nil
 }
 
-func randDeliveryAddress(r *rand.Rand) (DeliveryAddress, error) {
+func randDeliveryAddress(r *rand.Rand) (TypedDeliveryAddress, error) {
 	// Generate size minimum one. Empty scripts should be tested specifically.
 	size := r.Intn(deliveryAddressMaxSize) + 1
-	da := DeliveryAddress(make([]byte, size))
+	da := TypedDeliveryAddress(make([]byte, size))
 
 	_, err := r.Read(da)
 	return da, err

--- a/lnwire/lnwire_test.go
+++ b/lnwire/lnwire_test.go
@@ -232,7 +232,7 @@ func TestMaxOutPointIndex(t *testing.T) {
 	}
 
 	var b bytes.Buffer
-	if err := WriteElement(&b, op); err == nil {
+	if err := WriteElement(&b, ProtocolVersionTLV, op); err == nil {
 		t.Fatalf("write of outPoint should fail, index exceeds 16-bits")
 	}
 }
@@ -265,7 +265,8 @@ func TestLightningWireProtocol(t *testing.T) {
 		// Give a new message, we'll serialize the message into a new
 		// bytes buffer.
 		var b bytes.Buffer
-		if _, err := WriteMessage(&b, msg, 0); err != nil {
+		_, err := WriteMessage(&b, msg, ProtocolVersionTLV)
+		if err != nil {
 			t.Fatalf("unable to write msg: %v", err)
 			return false
 		}
@@ -282,7 +283,7 @@ func TestLightningWireProtocol(t *testing.T) {
 
 		// Finally, we'll deserialize the message from the written
 		// buffer, and finally assert that the messages are equal.
-		newMsg, err := ReadMessage(&b, 0)
+		newMsg, err := ReadMessage(&b, ProtocolVersionTLV)
 		if err != nil {
 			t.Fatalf("unable to read msg: %v", err)
 			return false

--- a/lnwire/lnwire_test.go
+++ b/lnwire/lnwire_test.go
@@ -321,6 +321,7 @@ func TestLightningWireProtocol(t *testing.T) {
 				CsvDelay:         uint16(r.Int31()),
 				MaxAcceptedHTLCs: uint16(r.Int31()),
 				ChannelFlags:     FundingFlag(uint8(r.Int31())),
+				ExtraData:        make([]byte, 0),
 			}
 
 			if _, err := r.Read(req.ChainHash[:]); err != nil {
@@ -387,6 +388,7 @@ func TestLightningWireProtocol(t *testing.T) {
 				HtlcMinimum:      MilliSatoshi(r.Int31()),
 				CsvDelay:         uint16(r.Int31()),
 				MaxAcceptedHTLCs: uint16(r.Int31()),
+				ExtraData:        make([]byte, 0),
 			}
 
 			if _, err := r.Read(req.PendingChannelID[:]); err != nil {
@@ -440,7 +442,9 @@ func TestLightningWireProtocol(t *testing.T) {
 			v[0] = reflect.ValueOf(req)
 		},
 		MsgFundingCreated: func(v []reflect.Value, r *rand.Rand) {
-			req := FundingCreated{}
+			req := FundingCreated{
+				ExtraData: make([]byte, 0),
+			}
 
 			if _, err := r.Read(req.PendingChannelID[:]); err != nil {
 				t.Fatalf("unable to generate pending chan id: %v", err)
@@ -471,7 +475,8 @@ func TestLightningWireProtocol(t *testing.T) {
 			}
 
 			req := FundingSigned{
-				ChanID: ChannelID(c),
+				ChanID:    ChannelID(c),
+				ExtraData: make([]byte, 0),
 			}
 			req.CommitSig, err = NewSigFromSignature(testSig)
 			if err != nil {
@@ -502,6 +507,7 @@ func TestLightningWireProtocol(t *testing.T) {
 		MsgClosingSigned: func(v []reflect.Value, r *rand.Rand) {
 			req := ClosingSigned{
 				FeeSatoshis: btcutil.Amount(r.Int63()),
+				ExtraData:   make([]byte, 0),
 			}
 			var err error
 			req.Signature, err = NewSigFromSignature(testSig)
@@ -570,8 +576,9 @@ func TestLightningWireProtocol(t *testing.T) {
 		MsgChannelAnnouncement: func(v []reflect.Value, r *rand.Rand) {
 			var err error
 			req := ChannelAnnouncement{
-				ShortChannelID: NewShortChanIDFromInt(uint64(r.Int63())),
-				Features:       randRawFeatureVector(r),
+				ShortChannelID:  NewShortChanIDFromInt(uint64(r.Int63())),
+				Features:        randRawFeatureVector(r),
+				ExtraOpaqueData: make([]byte, 0),
 			}
 			req.NodeSig1, err = NewSigFromSignature(testSig)
 			if err != nil {
@@ -643,6 +650,7 @@ func TestLightningWireProtocol(t *testing.T) {
 					G: uint8(r.Int31()),
 					B: uint8(r.Int31()),
 				},
+				ExtraOpaqueData: make([]byte, 0),
 			}
 			req.Signature, err = NewSigFromSignature(testSig)
 			if err != nil {
@@ -698,6 +706,7 @@ func TestLightningWireProtocol(t *testing.T) {
 				HtlcMaximumMsat: maxHtlc,
 				BaseFee:         uint32(r.Int31()),
 				FeeRate:         uint32(r.Int31()),
+				ExtraOpaqueData: make([]byte, 0),
 			}
 			req.Signature, err = NewSigFromSignature(testSig)
 			if err != nil {
@@ -726,7 +735,8 @@ func TestLightningWireProtocol(t *testing.T) {
 		MsgAnnounceSignatures: func(v []reflect.Value, r *rand.Rand) {
 			var err error
 			req := AnnounceSignatures{
-				ShortChannelID: NewShortChanIDFromInt(uint64(r.Int63())),
+				ShortChannelID:  NewShortChanIDFromInt(uint64(r.Int63())),
+				ExtraOpaqueData: make([]byte, 0),
 			}
 
 			req.NodeSignature, err = NewSigFromSignature(testSig)
@@ -763,6 +773,7 @@ func TestLightningWireProtocol(t *testing.T) {
 			req := ChannelReestablish{
 				NextLocalCommitHeight:  uint64(r.Int63()),
 				RemoteCommitTailHeight: uint64(r.Int63()),
+				ExtraData:              make([]byte, 0),
 			}
 
 			// With a 50/50 probability, we'll include the
@@ -785,7 +796,9 @@ func TestLightningWireProtocol(t *testing.T) {
 			v[0] = reflect.ValueOf(req)
 		},
 		MsgQueryShortChanIDs: func(v []reflect.Value, r *rand.Rand) {
-			req := QueryShortChanIDs{}
+			req := QueryShortChanIDs{
+				ExtraData: make([]byte, 0),
+			}
 
 			// With a 50/50 change, we'll either use zlib encoding,
 			// or regular encoding.
@@ -812,6 +825,7 @@ func TestLightningWireProtocol(t *testing.T) {
 			req := ReplyChannelRange{
 				FirstBlockHeight: uint32(r.Int31()),
 				NumBlocks:        uint32(r.Int31()),
+				ExtraData:        make([]byte, 0),
 			}
 
 			if _, err := rand.Read(req.ChainHash[:]); err != nil {

--- a/lnwire/message.go
+++ b/lnwire/message.go
@@ -56,6 +56,20 @@ const (
 	MsgGossipTimestampRange                = 265
 )
 
+const (
+	// ProtocolVersionLegacy is the legacy protocol version. When reading
+	// or writing messages using this protocol version, any optional fields
+	// appended to the end of the message will be ignored.
+	ProtocolVersionLegacy uint32 = 0
+
+	// ProtocolVersionTLV is the current modern protocol version. When
+	// reading/writing messages with this version, decoding will continue
+	// until the entire payload has been ready. When writing with this
+	// version, any optional fields appended to the end of the main message
+	// will also be written out.
+	ProtocolVersionTLV uint32 = 1
+)
+
 // String return the string representation of message type.
 func (t MessageType) String() string {
 	switch t {

--- a/lnwire/node_announcement.go
+++ b/lnwire/node_announcement.go
@@ -110,6 +110,7 @@ var _ Message = (*NodeAnnouncement)(nil)
 // This is part of the lnwire.Message interface.
 func (a *NodeAnnouncement) Decode(r io.Reader, pver uint32) error {
 	return ReadElements(r,
+		pver,
 		&a.Signature,
 		&a.Features,
 		&a.Timestamp,
@@ -126,6 +127,7 @@ func (a *NodeAnnouncement) Decode(r io.Reader, pver uint32) error {
 //
 func (a *NodeAnnouncement) Encode(w io.Writer, pver uint32) error {
 	return WriteElements(w,
+		pver,
 		a.Signature,
 		a.Features,
 		a.Timestamp,
@@ -159,6 +161,9 @@ func (a *NodeAnnouncement) DataToSign() ([]byte, error) {
 	// We should not include the signatures itself.
 	var w bytes.Buffer
 	err := WriteElements(&w,
+		// We always use the modern protocol version as we need to
+		// include all data for forawrds compatability.
+		ProtocolVersionTLV,
 		a.Features,
 		a.Timestamp,
 		a.NodeID,

--- a/lnwire/onion_error.go
+++ b/lnwire/onion_error.go
@@ -389,7 +389,7 @@ func (f *FailIncorrectDetails) Error() string {
 //
 // NOTE: Part of the Serializable interface.
 func (f *FailIncorrectDetails) Decode(r io.Reader, pver uint32) error {
-	err := ReadElement(r, &f.amount)
+	err := ReadElement(r, pver, &f.amount)
 	switch {
 	// This is an optional tack on that was added later in the protocol. As
 	// a result, older nodes may not include this value. We'll account for
@@ -404,7 +404,7 @@ func (f *FailIncorrectDetails) Decode(r io.Reader, pver uint32) error {
 
 	// At a later stage, the height field was also tacked on. We need to
 	// check for io.EOF here as well.
-	err = ReadElement(r, &f.height)
+	err = ReadElement(r, pver, &f.height)
 	switch {
 	case err == io.EOF:
 		return nil
@@ -420,7 +420,7 @@ func (f *FailIncorrectDetails) Decode(r io.Reader, pver uint32) error {
 //
 // NOTE: Part of the Serializable interface.
 func (f *FailIncorrectDetails) Encode(w io.Writer, pver uint32) error {
-	return WriteElements(w, f.amount, f.height)
+	return WriteElements(w, pver, f.amount, f.height)
 }
 
 // FailFinalExpiryTooSoon is returned if the cltv_expiry is too low, the final
@@ -479,14 +479,14 @@ func (f *FailInvalidOnionVersion) Code() FailCode {
 //
 // NOTE: Part of the Serializable interface.
 func (f *FailInvalidOnionVersion) Decode(r io.Reader, pver uint32) error {
-	return ReadElement(r, f.OnionSHA256[:])
+	return ReadElement(r, pver, f.OnionSHA256[:])
 }
 
 // Encode writes the failure in bytes stream.
 //
 // NOTE: Part of the Serializable interface.
 func (f *FailInvalidOnionVersion) Encode(w io.Writer, pver uint32) error {
-	return WriteElement(w, f.OnionSHA256[:])
+	return WriteElement(w, pver, f.OnionSHA256[:])
 }
 
 // FailInvalidOnionHmac is return if the onion HMAC is incorrect.
@@ -513,14 +513,14 @@ func (f *FailInvalidOnionHmac) Code() FailCode {
 //
 // NOTE: Part of the Serializable interface.
 func (f *FailInvalidOnionHmac) Decode(r io.Reader, pver uint32) error {
-	return ReadElement(r, f.OnionSHA256[:])
+	return ReadElement(r, pver, f.OnionSHA256[:])
 }
 
 // Encode writes the failure in bytes stream.
 //
 // NOTE: Part of the Serializable interface.
 func (f *FailInvalidOnionHmac) Encode(w io.Writer, pver uint32) error {
-	return WriteElement(w, f.OnionSHA256[:])
+	return WriteElement(w, pver, f.OnionSHA256[:])
 }
 
 // Returns a human readable string describing the target FailureMessage.
@@ -555,14 +555,14 @@ func (f *FailInvalidOnionKey) Code() FailCode {
 //
 // NOTE: Part of the Serializable interface.
 func (f *FailInvalidOnionKey) Decode(r io.Reader, pver uint32) error {
-	return ReadElement(r, f.OnionSHA256[:])
+	return ReadElement(r, pver, f.OnionSHA256[:])
 }
 
 // Encode writes the failure in bytes stream.
 //
 // NOTE: Part of the Serializable interface.
 func (f *FailInvalidOnionKey) Encode(w io.Writer, pver uint32) error {
-	return WriteElement(w, f.OnionSHA256[:])
+	return WriteElement(w, pver, f.OnionSHA256[:])
 }
 
 // Returns a human readable string describing the target FailureMessage.
@@ -652,7 +652,7 @@ func (f *FailTemporaryChannelFailure) Error() string {
 // NOTE: Part of the Serializable interface.
 func (f *FailTemporaryChannelFailure) Decode(r io.Reader, pver uint32) error {
 	var length uint16
-	err := ReadElement(r, &length)
+	err := ReadElement(r, pver, &length)
 	if err != nil {
 		return err
 	}
@@ -680,7 +680,7 @@ func (f *FailTemporaryChannelFailure) Encode(w io.Writer, pver uint32) error {
 		payload = bw.Bytes()
 	}
 
-	if err := WriteElement(w, uint16(len(payload))); err != nil {
+	if err := WriteElement(w, pver, uint16(len(payload))); err != nil {
 		return err
 	}
 
@@ -731,12 +731,12 @@ func (f *FailAmountBelowMinimum) Error() string {
 //
 // NOTE: Part of the Serializable interface.
 func (f *FailAmountBelowMinimum) Decode(r io.Reader, pver uint32) error {
-	if err := ReadElement(r, &f.HtlcMsat); err != nil {
+	if err := ReadElement(r, pver, &f.HtlcMsat); err != nil {
 		return err
 	}
 
 	var length uint16
-	if err := ReadElement(r, &length); err != nil {
+	if err := ReadElement(r, pver, &length); err != nil {
 		return err
 	}
 
@@ -750,7 +750,7 @@ func (f *FailAmountBelowMinimum) Decode(r io.Reader, pver uint32) error {
 //
 // NOTE: Part of the Serializable interface.
 func (f *FailAmountBelowMinimum) Encode(w io.Writer, pver uint32) error {
-	if err := WriteElement(w, f.HtlcMsat); err != nil {
+	if err := WriteElement(w, pver, f.HtlcMsat); err != nil {
 		return err
 	}
 
@@ -799,12 +799,12 @@ func (f *FailFeeInsufficient) Error() string {
 //
 // NOTE: Part of the Serializable interface.
 func (f *FailFeeInsufficient) Decode(r io.Reader, pver uint32) error {
-	if err := ReadElement(r, &f.HtlcMsat); err != nil {
+	if err := ReadElement(r, pver, &f.HtlcMsat); err != nil {
 		return err
 	}
 
 	var length uint16
-	if err := ReadElement(r, &length); err != nil {
+	if err := ReadElement(r, pver, &length); err != nil {
 		return err
 	}
 
@@ -818,7 +818,7 @@ func (f *FailFeeInsufficient) Decode(r io.Reader, pver uint32) error {
 //
 // NOTE: Part of the Serializable interface.
 func (f *FailFeeInsufficient) Encode(w io.Writer, pver uint32) error {
-	if err := WriteElement(w, f.HtlcMsat); err != nil {
+	if err := WriteElement(w, pver, f.HtlcMsat); err != nil {
 		return err
 	}
 
@@ -867,12 +867,12 @@ func (f *FailIncorrectCltvExpiry) Error() string {
 //
 // NOTE: Part of the Serializable interface.
 func (f *FailIncorrectCltvExpiry) Decode(r io.Reader, pver uint32) error {
-	if err := ReadElement(r, &f.CltvExpiry); err != nil {
+	if err := ReadElement(r, pver, &f.CltvExpiry); err != nil {
 		return err
 	}
 
 	var length uint16
-	if err := ReadElement(r, &length); err != nil {
+	if err := ReadElement(r, pver, &length); err != nil {
 		return err
 	}
 
@@ -886,7 +886,7 @@ func (f *FailIncorrectCltvExpiry) Decode(r io.Reader, pver uint32) error {
 //
 // NOTE: Part of the Serializable interface.
 func (f *FailIncorrectCltvExpiry) Encode(w io.Writer, pver uint32) error {
-	if err := WriteElement(w, f.CltvExpiry); err != nil {
+	if err := WriteElement(w, pver, f.CltvExpiry); err != nil {
 		return err
 	}
 
@@ -929,7 +929,7 @@ func (f *FailExpiryTooSoon) Error() string {
 // NOTE: Part of the Serializable interface.
 func (f *FailExpiryTooSoon) Decode(r io.Reader, pver uint32) error {
 	var length uint16
-	if err := ReadElement(r, &length); err != nil {
+	if err := ReadElement(r, pver, &length); err != nil {
 		return err
 	}
 
@@ -988,12 +988,12 @@ func (f *FailChannelDisabled) Error() string {
 //
 // NOTE: Part of the Serializable interface.
 func (f *FailChannelDisabled) Decode(r io.Reader, pver uint32) error {
-	if err := ReadElement(r, &f.Flags); err != nil {
+	if err := ReadElement(r, pver, &f.Flags); err != nil {
 		return err
 	}
 
 	var length uint16
-	if err := ReadElement(r, &length); err != nil {
+	if err := ReadElement(r, pver, &length); err != nil {
 		return err
 	}
 
@@ -1007,7 +1007,7 @@ func (f *FailChannelDisabled) Decode(r io.Reader, pver uint32) error {
 //
 // NOTE: Part of the Serializable interface.
 func (f *FailChannelDisabled) Encode(w io.Writer, pver uint32) error {
-	if err := WriteElement(w, f.Flags); err != nil {
+	if err := WriteElement(w, pver, f.Flags); err != nil {
 		return err
 	}
 
@@ -1050,14 +1050,14 @@ func (f *FailFinalIncorrectCltvExpiry) Code() FailCode {
 //
 // NOTE: Part of the Serializable interface.
 func (f *FailFinalIncorrectCltvExpiry) Decode(r io.Reader, pver uint32) error {
-	return ReadElement(r, &f.CltvExpiry)
+	return ReadElement(r, pver, &f.CltvExpiry)
 }
 
 // Encode writes the failure in bytes stream.
 //
 // NOTE: Part of the Serializable interface.
 func (f *FailFinalIncorrectCltvExpiry) Encode(w io.Writer, pver uint32) error {
-	return WriteElement(w, f.CltvExpiry)
+	return WriteElement(w, pver, f.CltvExpiry)
 }
 
 // FailFinalIncorrectHtlcAmount is returned if the amt_to_forward is higher
@@ -1096,14 +1096,14 @@ func (f *FailFinalIncorrectHtlcAmount) Code() FailCode {
 //
 // NOTE: Part of the Serializable interface.
 func (f *FailFinalIncorrectHtlcAmount) Decode(r io.Reader, pver uint32) error {
-	return ReadElement(r, &f.IncomingHTLCAmount)
+	return ReadElement(r, pver, &f.IncomingHTLCAmount)
 }
 
 // Encode writes the failure in bytes stream.
 //
 // NOTE: Part of the Serializable interface.
 func (f *FailFinalIncorrectHtlcAmount) Encode(w io.Writer, pver uint32) error {
-	return WriteElement(w, f.IncomingHTLCAmount)
+	return WriteElement(w, pver, f.IncomingHTLCAmount)
 }
 
 // FailExpiryTooFar is returned if the CLTV expiry in the HTLC is too far in the
@@ -1171,7 +1171,7 @@ func (f *InvalidOnionPayload) Decode(r io.Reader, pver uint32) error {
 	}
 	f.Type = typ
 
-	return ReadElements(r, &f.Offset)
+	return ReadElements(r, pver, &f.Offset)
 }
 
 // Encode writes the failure in bytes stream.
@@ -1183,7 +1183,7 @@ func (f *InvalidOnionPayload) Encode(w io.Writer, pver uint32) error {
 		return err
 	}
 
-	return WriteElements(w, f.Offset)
+	return WriteElements(w, pver, f.Offset)
 }
 
 // FailMPPTimeout is returned if the complete amount for a multi part payment
@@ -1212,7 +1212,7 @@ func DecodeFailure(r io.Reader, pver uint32) (FailureMessage, error) {
 	// First, we'll parse out the encapsulated failure message itself. This
 	// is a 2 byte length followed by the payload itself.
 	var failureLength uint16
-	if err := ReadElement(r, &failureLength); err != nil {
+	if err := ReadElement(r, pver, &failureLength); err != nil {
 		return nil, fmt.Errorf("unable to read error len: %v", err)
 	}
 	if failureLength > FailureMessageLength {
@@ -1284,6 +1284,7 @@ func EncodeFailure(w io.Writer, failure FailureMessage, pver uint32) error {
 	pad := make([]byte, FailureMessageLength-len(failureMessage))
 
 	return WriteElements(w,
+		pver,
 		uint16(len(failureMessage)),
 		failureMessage,
 		uint16(len(pad)),
@@ -1414,7 +1415,7 @@ func writeOnionErrorChanUpdate(w io.Writer, chanUpdate *ChannelUpdate,
 	// Now that we know the size, we can write the length out in the main
 	// writer.
 	updateLen := b.Len()
-	if err := WriteElement(w, uint16(updateLen)); err != nil {
+	if err := WriteElement(w, pver, uint16(updateLen)); err != nil {
 		return err
 	}
 

--- a/lnwire/onion_error_test.go
+++ b/lnwire/onion_error_test.go
@@ -20,11 +20,12 @@ var (
 	testOffset        = uint16(24)
 	sig, _            = NewSigFromSignature(testSig)
 	testChannelUpdate = ChannelUpdate{
-		Signature:      sig,
-		ShortChannelID: NewShortChanIDFromInt(1),
-		Timestamp:      1,
-		MessageFlags:   0,
-		ChannelFlags:   1,
+		Signature:       sig,
+		ShortChannelID:  NewShortChanIDFromInt(1),
+		Timestamp:       1,
+		MessageFlags:    0,
+		ChannelFlags:    1,
+		ExtraOpaqueData: make([]byte, 0),
 	}
 )
 

--- a/lnwire/onion_error_test.go
+++ b/lnwire/onion_error_test.go
@@ -63,12 +63,13 @@ func TestEncodeDecodeCode(t *testing.T) {
 	for _, failure1 := range onionFailures {
 		var b bytes.Buffer
 
-		if err := EncodeFailure(&b, failure1, 0); err != nil {
+		err := EncodeFailure(&b, failure1, ProtocolVersionTLV)
+		if err != nil {
 			t.Fatalf("unable to encode failure code(%v): %v",
 				failure1.Code(), err)
 		}
 
-		failure2, err := DecodeFailure(&b, 0)
+		failure2, err := DecodeFailure(&b, ProtocolVersionTLV)
 		if err != nil {
 			t.Fatalf("unable to decode failure code(%v): %v",
 				failure1.Code(), err)
@@ -90,7 +91,7 @@ func TestChannelUpdateCompatabilityParsing(t *testing.T) {
 	// We'll start by taking out test channel update, and encoding it into
 	// a set of raw bytes.
 	var b bytes.Buffer
-	if err := testChannelUpdate.Encode(&b, 0); err != nil {
+	if err := testChannelUpdate.Encode(&b, ProtocolVersionTLV); err != nil {
 		t.Fatalf("unable to encode chan update: %v", err)
 	}
 
@@ -99,7 +100,7 @@ func TestChannelUpdateCompatabilityParsing(t *testing.T) {
 	// encoded channel update message.
 	var newChanUpdate ChannelUpdate
 	err := parseChannelUpdateCompatabilityMode(
-		bufio.NewReader(&b), &newChanUpdate, 0,
+		bufio.NewReader(&b), &newChanUpdate, ProtocolVersionTLV,
 	)
 	if err != nil {
 		t.Fatalf("unable to parse channel update: %v", err)
@@ -120,7 +121,7 @@ func TestChannelUpdateCompatabilityParsing(t *testing.T) {
 	var tByte [2]byte
 	binary.BigEndian.PutUint16(tByte[:], MsgChannelUpdate)
 	b.Write(tByte[:])
-	if err := testChannelUpdate.Encode(&b, 0); err != nil {
+	if err := testChannelUpdate.Encode(&b, ProtocolVersionTLV); err != nil {
 		t.Fatalf("unable to encode chan update: %v", err)
 	}
 
@@ -128,7 +129,7 @@ func TestChannelUpdateCompatabilityParsing(t *testing.T) {
 	// message even with the extra two bytes.
 	var newChanUpdate2 ChannelUpdate
 	err = parseChannelUpdateCompatabilityMode(
-		bufio.NewReader(&b), &newChanUpdate2, 0,
+		bufio.NewReader(&b), &newChanUpdate2, ProtocolVersionTLV,
 	)
 	if err != nil {
 		t.Fatalf("unable to parse channel update: %v", err)
@@ -165,7 +166,7 @@ func TestWriteOnionErrorChanUpdate(t *testing.T) {
 	// Finally, read the length encoded and ensure that it matches the raw
 	// length.
 	var encodedLen uint16
-	if err := ReadElement(&errorBuf, &encodedLen); err != nil {
+	if err := ReadElement(&errorBuf, ProtocolVersionTLV, &encodedLen); err != nil {
 		t.Fatalf("unable to read len: %v", err)
 	}
 	if uint16(trueUpdateLength) != encodedLen {
@@ -276,5 +277,5 @@ func (f *mockFailIncorrectDetailsNoHeight) Decode(r io.Reader, pver uint32) erro
 }
 
 func (f *mockFailIncorrectDetailsNoHeight) Encode(w io.Writer, pver uint32) error {
-	return WriteElement(w, f.amount)
+	return WriteElement(w, ProtocolVersionTLV, f.amount)
 }

--- a/lnwire/open_channel.go
+++ b/lnwire/open_channel.go
@@ -146,6 +146,7 @@ var _ Message = (*OpenChannel)(nil)
 // This is part of the lnwire.Message interface.
 func (o *OpenChannel) Encode(w io.Writer, pver uint32) error {
 	return WriteElements(w,
+		pver,
 		o.ChainHash[:],
 		o.PendingChannelID[:],
 		o.FundingAmount,
@@ -176,6 +177,7 @@ func (o *OpenChannel) Encode(w io.Writer, pver uint32) error {
 // This is part of the lnwire.Message interface.
 func (o *OpenChannel) Decode(r io.Reader, pver uint32) error {
 	return ReadElements(r,
+		pver,
 		o.ChainHash[:],
 		o.PendingChannelID[:],
 		&o.FundingAmount,

--- a/lnwire/open_channel.go
+++ b/lnwire/open_channel.go
@@ -127,7 +127,7 @@ type OpenChannel struct {
 	// be paid when mutually closing the channel. This field is optional, and
 	// and has a length prefix, so a zero will be written if it is not set
 	// and its length followed by the script will be written if it is set.
-	UpfrontShutdownScript DeliveryAddress
+	UpfrontShutdownScript TypedDeliveryAddress
 
 	// ExtraData is the set of data that was appended to this message to
 	// fill out the full maximum transport message size. These fields can
@@ -175,7 +175,7 @@ func (o *OpenChannel) Encode(w io.Writer, pver uint32) error {
 //
 // This is part of the lnwire.Message interface.
 func (o *OpenChannel) Decode(r io.Reader, pver uint32) error {
-	if err := ReadElements(r,
+	return ReadElements(r,
 		o.ChainHash[:],
 		o.PendingChannelID[:],
 		&o.FundingAmount,
@@ -194,18 +194,9 @@ func (o *OpenChannel) Decode(r io.Reader, pver uint32) error {
 		&o.HtlcPoint,
 		&o.FirstCommitmentPoint,
 		&o.ChannelFlags,
-	); err != nil {
-		return err
-	}
-
-	// Check for the optional upfront shutdown script field. If it is not there,
-	// silence the EOF error.
-	err := ReadElement(r, &o.UpfrontShutdownScript)
-	if err != nil && err != io.EOF {
-		return err
-	}
-
-	return ReadElement(r, &o.ExtraData)
+		&o.UpfrontShutdownScript,
+		&o.ExtraData,
+	)
 }
 
 // MsgType returns the MessageType code which uniquely identifies this message

--- a/lnwire/ping.go
+++ b/lnwire/ping.go
@@ -36,6 +36,7 @@ var _ Message = (*Ping)(nil)
 // This is part of the lnwire.Message interface.
 func (p *Ping) Decode(r io.Reader, pver uint32) error {
 	return ReadElements(r,
+		pver,
 		&p.NumPongBytes,
 		&p.PaddingBytes)
 }
@@ -46,6 +47,7 @@ func (p *Ping) Decode(r io.Reader, pver uint32) error {
 // This is part of the lnwire.Message interface.
 func (p *Ping) Encode(w io.Writer, pver uint32) error {
 	return WriteElements(w,
+		pver,
 		p.NumPongBytes,
 		p.PaddingBytes)
 }

--- a/lnwire/pong.go
+++ b/lnwire/pong.go
@@ -32,7 +32,7 @@ var _ Message = (*Pong)(nil)
 // This is part of the lnwire.Message interface.
 func (p *Pong) Decode(r io.Reader, pver uint32) error {
 	return ReadElements(r,
-		&p.PongBytes,
+		pver, &p.PongBytes,
 	)
 }
 
@@ -42,7 +42,7 @@ func (p *Pong) Decode(r io.Reader, pver uint32) error {
 // This is part of the lnwire.Message interface.
 func (p *Pong) Encode(w io.Writer, pver uint32) error {
 	return WriteElements(w,
-		p.PongBytes,
+		pver, p.PongBytes,
 	)
 }
 

--- a/lnwire/query_channel_range.go
+++ b/lnwire/query_channel_range.go
@@ -25,6 +25,11 @@ type QueryChannelRange struct {
 	// NumBlocks is the number of blocks beyond the first block that short
 	// channel ID's should be sent for.
 	NumBlocks uint32
+
+	// ExtraData is the set of data that was appended to this message to
+	// fill out the full maximum transport message size. These fields can
+	// be used to specify optional data such as custom TLV fields.
+	ExtraData ExtraOpaqueData
 }
 
 // NewQueryChannelRange creates a new empty QueryChannelRange message.
@@ -45,6 +50,7 @@ func (q *QueryChannelRange) Decode(r io.Reader, pver uint32) error {
 		q.ChainHash[:],
 		&q.FirstBlockHeight,
 		&q.NumBlocks,
+		&q.ExtraData,
 	)
 }
 
@@ -57,6 +63,7 @@ func (q *QueryChannelRange) Encode(w io.Writer, pver uint32) error {
 		q.ChainHash[:],
 		q.FirstBlockHeight,
 		q.NumBlocks,
+		q.ExtraData,
 	)
 }
 
@@ -73,8 +80,7 @@ func (q *QueryChannelRange) MsgType() MessageType {
 //
 // This is part of the lnwire.Message interface.
 func (q *QueryChannelRange) MaxPayloadLength(uint32) uint32 {
-	// 32 + 4 + 4
-	return 40
+	return MaxMsgBody
 }
 
 // LastBlockHeight returns the last block height covered by the range of a

--- a/lnwire/query_channel_range.go
+++ b/lnwire/query_channel_range.go
@@ -47,6 +47,7 @@ var _ Message = (*QueryChannelRange)(nil)
 // This is part of the lnwire.Message interface.
 func (q *QueryChannelRange) Decode(r io.Reader, pver uint32) error {
 	return ReadElements(r,
+		pver,
 		q.ChainHash[:],
 		&q.FirstBlockHeight,
 		&q.NumBlocks,
@@ -60,6 +61,7 @@ func (q *QueryChannelRange) Decode(r io.Reader, pver uint32) error {
 // This is part of the lnwire.Message interface.
 func (q *QueryChannelRange) Encode(w io.Writer, pver uint32) error {
 	return WriteElements(w,
+		pver,
 		q.ChainHash[:],
 		q.FirstBlockHeight,
 		q.NumBlocks,

--- a/lnwire/reply_channel_range.go
+++ b/lnwire/reply_channel_range.go
@@ -64,6 +64,7 @@ var _ Message = (*ReplyChannelRange)(nil)
 // This is part of the lnwire.Message interface.
 func (c *ReplyChannelRange) Decode(r io.Reader, pver uint32) error {
 	err := ReadElements(r,
+		pver,
 		c.ChainHash[:],
 		&c.FirstBlockHeight,
 		&c.NumBlocks,
@@ -73,12 +74,12 @@ func (c *ReplyChannelRange) Decode(r io.Reader, pver uint32) error {
 		return err
 	}
 
-	c.EncodingType, c.ShortChanIDs, err = decodeShortChanIDs(r)
+	c.EncodingType, c.ShortChanIDs, err = decodeShortChanIDs(r, pver)
 	if err != nil {
 		return err
 	}
 
-	return c.ExtraData.Decode(r)
+	return c.ExtraData.Decode(r, pver)
 }
 
 // Encode serializes the target ReplyChannelRange into the passed io.Writer
@@ -87,6 +88,7 @@ func (c *ReplyChannelRange) Decode(r io.Reader, pver uint32) error {
 // This is part of the lnwire.Message interface.
 func (c *ReplyChannelRange) Encode(w io.Writer, pver uint32) error {
 	err := WriteElements(w,
+		pver,
 		c.ChainHash[:],
 		c.FirstBlockHeight,
 		c.NumBlocks,
@@ -96,12 +98,14 @@ func (c *ReplyChannelRange) Encode(w io.Writer, pver uint32) error {
 		return err
 	}
 
-	err = encodeShortChanIDs(w, c.EncodingType, c.ShortChanIDs, c.noSort)
+	err = encodeShortChanIDs(
+		w, c.EncodingType, c.ShortChanIDs, c.noSort, pver,
+	)
 	if err != nil {
 		return err
 	}
 
-	return c.ExtraData.Encode(w)
+	return c.ExtraData.Encode(w, pver)
 }
 
 // MsgType returns the integer uniquely identifying this message type on the

--- a/lnwire/reply_channel_range.go
+++ b/lnwire/reply_channel_range.go
@@ -1,14 +1,29 @@
 package lnwire
 
-import "io"
+import (
+	"io"
+	"math"
+
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
+)
 
 // ReplyChannelRange is the response to the QueryChannelRange message. It
 // includes the original query, and the next streaming chunk of encoded short
 // channel ID's as the response. We'll also include a byte that indicates if
 // this is the last query in the message.
 type ReplyChannelRange struct {
-	// QueryChannelRange is the corresponding query to this response.
-	QueryChannelRange
+	// ChainHash denotes the target chain that we're trying to synchronize
+	// channel graph state for.
+	ChainHash chainhash.Hash
+
+	// FirstBlockHeight is the first block in the query range. The
+	// responder should send all new short channel IDs from this block
+	// until this block plus the specified number of blocks.
+	FirstBlockHeight uint32
+
+	// NumBlocks is the number of blocks beyond the first block that short
+	// channel ID's should be sent for.
+	NumBlocks uint32
 
 	// Complete denotes if this is the conclusion of the set of streaming
 	// responses to the original query.
@@ -43,16 +58,20 @@ var _ Message = (*ReplyChannelRange)(nil)
 //
 // This is part of the lnwire.Message interface.
 func (c *ReplyChannelRange) Decode(r io.Reader, pver uint32) error {
-	err := c.QueryChannelRange.Decode(r, pver)
+	err := ReadElements(r,
+		c.ChainHash[:],
+		&c.FirstBlockHeight,
+		&c.NumBlocks,
+		&c.Complete,
+	)
 	if err != nil {
 		return err
 	}
 
-	if err := ReadElements(r, &c.Complete); err != nil {
+	c.EncodingType, c.ShortChanIDs, err = decodeShortChanIDs(r)
+	if err != nil {
 		return err
 	}
-
-	c.EncodingType, c.ShortChanIDs, err = decodeShortChanIDs(r)
 
 	return err
 }
@@ -62,15 +81,21 @@ func (c *ReplyChannelRange) Decode(r io.Reader, pver uint32) error {
 //
 // This is part of the lnwire.Message interface.
 func (c *ReplyChannelRange) Encode(w io.Writer, pver uint32) error {
-	if err := c.QueryChannelRange.Encode(w, pver); err != nil {
+	err := WriteElements(w,
+		c.ChainHash[:],
+		c.FirstBlockHeight,
+		c.NumBlocks,
+		c.Complete,
+	)
+	if err != nil {
 		return err
 	}
 
-	if err := WriteElements(w, c.Complete); err != nil {
+	err = encodeShortChanIDs(w, c.EncodingType, c.ShortChanIDs, c.noSort)
+	if err != nil {
 		return err
 	}
 
-	return encodeShortChanIDs(w, c.EncodingType, c.ShortChanIDs, c.noSort)
 }
 
 // MsgType returns the integer uniquely identifying this message type on the
@@ -87,4 +112,14 @@ func (c *ReplyChannelRange) MsgType() MessageType {
 // This is part of the lnwire.Message interface.
 func (c *ReplyChannelRange) MaxPayloadLength(uint32) uint32 {
 	return MaxMessagePayload
+
+// LastBlockHeight returns the last block height covered by the range of a
+// QueryChannelRange message.
+func (c *ReplyChannelRange) LastBlockHeight() uint32 {
+	// Handle overflows by casting to uint64.
+	lastBlockHeight := uint64(c.FirstBlockHeight) + uint64(c.NumBlocks) - 1
+	if lastBlockHeight > math.MaxUint32 {
+		return math.MaxUint32
+	}
+	return uint32(lastBlockHeight)
 }

--- a/lnwire/reply_channel_range.go
+++ b/lnwire/reply_channel_range.go
@@ -37,6 +37,11 @@ type ReplyChannelRange struct {
 	// ShortChanIDs is a slice of decoded short channel ID's.
 	ShortChanIDs []ShortChannelID
 
+	// ExtraData is the set of data that was appended to this message to
+	// fill out the full maximum transport message size. These fields can
+	// be used to specify optional data such as custom TLV fields.
+	ExtraData ExtraOpaqueData
+
 	// noSort indicates whether or not to sort the short channel ids before
 	// writing them out.
 	//
@@ -73,7 +78,7 @@ func (c *ReplyChannelRange) Decode(r io.Reader, pver uint32) error {
 		return err
 	}
 
-	return err
+	return c.ExtraData.Decode(r)
 }
 
 // Encode serializes the target ReplyChannelRange into the passed io.Writer
@@ -96,6 +101,7 @@ func (c *ReplyChannelRange) Encode(w io.Writer, pver uint32) error {
 		return err
 	}
 
+	return c.ExtraData.Encode(w)
 }
 
 // MsgType returns the integer uniquely identifying this message type on the
@@ -111,7 +117,8 @@ func (c *ReplyChannelRange) MsgType() MessageType {
 //
 // This is part of the lnwire.Message interface.
 func (c *ReplyChannelRange) MaxPayloadLength(uint32) uint32 {
-	return MaxMessagePayload
+	return MaxMsgBody
+}
 
 // LastBlockHeight returns the last block height covered by the range of a
 // QueryChannelRange message.

--- a/lnwire/reply_channel_range_test.go
+++ b/lnwire/reply_channel_range_test.go
@@ -72,6 +72,7 @@ func TestReplyChannelRangeEmpty(t *testing.T) {
 				Complete:         1,
 				EncodingType:     test.encType,
 				ShortChanIDs:     nil,
+				ExtraData:        make([]byte, 0),
 			}
 
 			// First decode the hex string in the test case into a

--- a/lnwire/reply_channel_range_test.go
+++ b/lnwire/reply_channel_range_test.go
@@ -30,7 +30,7 @@ func TestReplyChannelRangeUnsorted(t *testing.T) {
 			var req2 ReplyChannelRange
 			err = req2.Decode(bytes.NewReader(b.Bytes()), 0)
 			if _, ok := err.(ErrUnsortedSIDs); !ok {
-				t.Fatalf("expected ErrUnsortedSIDs, got: %T",
+				t.Fatalf("expected ErrUnsortedSIDs, got: %v",
 					err)
 			}
 		})
@@ -67,13 +67,11 @@ func TestReplyChannelRangeEmpty(t *testing.T) {
 		test := test
 		t.Run(test.name, func(t *testing.T) {
 			req := ReplyChannelRange{
-				QueryChannelRange: QueryChannelRange{
-					FirstBlockHeight: 1,
-					NumBlocks:        2,
-				},
-				Complete:     1,
-				EncodingType: test.encType,
-				ShortChanIDs: nil,
+				FirstBlockHeight: 1,
+				NumBlocks:        2,
+				Complete:         1,
+				EncodingType:     test.encType,
+				ShortChanIDs:     nil,
 			}
 
 			// First decode the hex string in the test case into a

--- a/lnwire/reply_channel_range_test.go
+++ b/lnwire/reply_channel_range_test.go
@@ -80,7 +80,9 @@ func TestReplyChannelRangeEmpty(t *testing.T) {
 			// identical to the one created above.
 			var req2 ReplyChannelRange
 			b, _ := hex.DecodeString(test.encodedHex)
-			err := req2.Decode(bytes.NewReader(b), 0)
+			err := req2.Decode(
+				bytes.NewReader(b), ProtocolVersionTLV,
+			)
 			if err != nil {
 				t.Fatalf("unable to decode req: %v", err)
 			}
@@ -93,7 +95,7 @@ func TestReplyChannelRangeEmpty(t *testing.T) {
 			// request created above, and assert that it matches
 			// the raw byte encoding.
 			var b2 bytes.Buffer
-			err = req.Encode(&b2, 0)
+			err = req.Encode(&b2, ProtocolVersionTLV)
 			if err != nil {
 				t.Fatalf("unable to encode req: %v", err)
 			}

--- a/lnwire/reply_short_chan_ids_end.go
+++ b/lnwire/reply_short_chan_ids_end.go
@@ -22,6 +22,11 @@ type ReplyShortChanIDsEnd struct {
 	// set of short chan ID's in the corresponding QueryShortChanIDs
 	// message.
 	Complete uint8
+
+	// ExtraData is the set of data that was appended to this message to
+	// fill out the full maximum transport message size. These fields can
+	// be used to specify optional data such as custom TLV fields.
+	ExtraData ExtraOpaqueData
 }
 
 // NewReplyShortChanIDsEnd creates a new empty ReplyShortChanIDsEnd message.
@@ -41,6 +46,7 @@ func (c *ReplyShortChanIDsEnd) Decode(r io.Reader, pver uint32) error {
 	return ReadElements(r,
 		c.ChainHash[:],
 		&c.Complete,
+		&c.ExtraData,
 	)
 }
 
@@ -52,6 +58,7 @@ func (c *ReplyShortChanIDsEnd) Encode(w io.Writer, pver uint32) error {
 	return WriteElements(w,
 		c.ChainHash[:],
 		c.Complete,
+		c.ExtraData,
 	)
 }
 
@@ -69,6 +76,5 @@ func (c *ReplyShortChanIDsEnd) MsgType() MessageType {
 //
 // This is part of the lnwire.Message interface.
 func (c *ReplyShortChanIDsEnd) MaxPayloadLength(uint32) uint32 {
-	// 32 (chain hash) + 1 (complete)
-	return 33
+	return MaxMsgBody
 }

--- a/lnwire/reply_short_chan_ids_end.go
+++ b/lnwire/reply_short_chan_ids_end.go
@@ -44,6 +44,7 @@ var _ Message = (*ReplyShortChanIDsEnd)(nil)
 // This is part of the lnwire.Message interface.
 func (c *ReplyShortChanIDsEnd) Decode(r io.Reader, pver uint32) error {
 	return ReadElements(r,
+		pver,
 		c.ChainHash[:],
 		&c.Complete,
 		&c.ExtraData,
@@ -56,6 +57,7 @@ func (c *ReplyShortChanIDsEnd) Decode(r io.Reader, pver uint32) error {
 // This is part of the lnwire.Message interface.
 func (c *ReplyShortChanIDsEnd) Encode(w io.Writer, pver uint32) error {
 	return WriteElements(w,
+		pver,
 		c.ChainHash[:],
 		c.Complete,
 		c.ExtraData,

--- a/lnwire/revoke_and_ack.go
+++ b/lnwire/revoke_and_ack.go
@@ -30,11 +30,18 @@ type RevokeAndAck struct {
 	// create the proper revocation key used within the commitment
 	// transaction.
 	NextRevocationKey *btcec.PublicKey
+
+	// ExtraData is the set of data that was appended to this message to
+	// fill out the full maximum transport message size. These fields can
+	// be used to specify optional data such as custom TLV fields.
+	ExtraData ExtraOpaqueData
 }
 
 // NewRevokeAndAck creates a new RevokeAndAck message.
 func NewRevokeAndAck() *RevokeAndAck {
-	return &RevokeAndAck{}
+	return &RevokeAndAck{
+		ExtraData: make([]byte, 0),
+	}
 }
 
 // A compile time check to ensure RevokeAndAck implements the lnwire.Message
@@ -50,6 +57,7 @@ func (c *RevokeAndAck) Decode(r io.Reader, pver uint32) error {
 		&c.ChanID,
 		c.Revocation[:],
 		&c.NextRevocationKey,
+		&c.ExtraData,
 	)
 }
 
@@ -62,6 +70,7 @@ func (c *RevokeAndAck) Encode(w io.Writer, pver uint32) error {
 		c.ChanID,
 		c.Revocation[:],
 		c.NextRevocationKey,
+		c.ExtraData,
 	)
 }
 
@@ -78,8 +87,7 @@ func (c *RevokeAndAck) MsgType() MessageType {
 //
 // This is part of the lnwire.Message interface.
 func (c *RevokeAndAck) MaxPayloadLength(uint32) uint32 {
-	// 32 + 32 + 33
-	return 97
+	return MaxMsgBody
 }
 
 // TargetChanID returns the channel id of the link for which this message is

--- a/lnwire/revoke_and_ack.go
+++ b/lnwire/revoke_and_ack.go
@@ -54,6 +54,7 @@ var _ Message = (*RevokeAndAck)(nil)
 // This is part of the lnwire.Message interface.
 func (c *RevokeAndAck) Decode(r io.Reader, pver uint32) error {
 	return ReadElements(r,
+		pver,
 		&c.ChanID,
 		c.Revocation[:],
 		&c.NextRevocationKey,
@@ -67,6 +68,7 @@ func (c *RevokeAndAck) Decode(r io.Reader, pver uint32) error {
 // This is part of the lnwire.Message interface.
 func (c *RevokeAndAck) Encode(w io.Writer, pver uint32) error {
 	return WriteElements(w,
+		pver,
 		c.ChanID,
 		c.Revocation[:],
 		c.NextRevocationKey,

--- a/lnwire/shutdown.go
+++ b/lnwire/shutdown.go
@@ -15,6 +15,11 @@ type Shutdown struct {
 
 	// Address is the script to which the channel funds will be paid.
 	Address DeliveryAddress
+
+	// ExtraData is the set of data that was appended to this message to
+	// fill out the full maximum transport message size. These fields can
+	// be used to specify optional data such as custom TLV fields.
+	ExtraData ExtraOpaqueData
 }
 
 // DeliveryAddress is used to communicate the address to which funds from a
@@ -48,7 +53,7 @@ var _ Message = (*Shutdown)(nil)
 //
 // This is part of the lnwire.Message interface.
 func (s *Shutdown) Decode(r io.Reader, pver uint32) error {
-	return ReadElements(r, &s.ChannelID, &s.Address)
+	return ReadElements(r, &s.ChannelID, &s.Address, &s.ExtraData)
 }
 
 // Encode serializes the target Shutdown into the passed io.Writer observing
@@ -56,7 +61,7 @@ func (s *Shutdown) Decode(r io.Reader, pver uint32) error {
 //
 // This is part of the lnwire.Message interface.
 func (s *Shutdown) Encode(w io.Writer, pver uint32) error {
-	return WriteElements(w, s.ChannelID, s.Address)
+	return WriteElements(w, s.ChannelID, s.Address, s.ExtraData)
 }
 
 // MsgType returns the integer uniquely identifying this message type on the
@@ -72,16 +77,5 @@ func (s *Shutdown) MsgType() MessageType {
 //
 // This is part of the lnwire.Message interface.
 func (s *Shutdown) MaxPayloadLength(pver uint32) uint32 {
-	var length uint32
-
-	// ChannelID - 32bytes
-	length += 32
-
-	// Len - 2 bytes
-	length += 2
-
-	// ScriptPubKey - maximum delivery address size.
-	length += deliveryAddressMaxSize
-
-	return length
+	return MaxMsgBody
 }

--- a/lnwire/shutdown.go
+++ b/lnwire/shutdown.go
@@ -53,7 +53,7 @@ var _ Message = (*Shutdown)(nil)
 //
 // This is part of the lnwire.Message interface.
 func (s *Shutdown) Decode(r io.Reader, pver uint32) error {
-	return ReadElements(r, &s.ChannelID, &s.Address, &s.ExtraData)
+	return ReadElements(r, pver, &s.ChannelID, &s.Address, &s.ExtraData)
 }
 
 // Encode serializes the target Shutdown into the passed io.Writer observing
@@ -61,7 +61,7 @@ func (s *Shutdown) Decode(r io.Reader, pver uint32) error {
 //
 // This is part of the lnwire.Message interface.
 func (s *Shutdown) Encode(w io.Writer, pver uint32) error {
-	return WriteElements(w, s.ChannelID, s.Address, s.ExtraData)
+	return WriteElements(w, pver, s.ChannelID, s.Address, s.ExtraData)
 }
 
 // MsgType returns the integer uniquely identifying this message type on the

--- a/lnwire/typed_delivery_addr.go
+++ b/lnwire/typed_delivery_addr.go
@@ -1,0 +1,65 @@
+package lnwire
+
+import (
+	"io"
+
+	"github.com/lightningnetwork/lnd/tlv"
+)
+
+const (
+	// DeliveryAddrType is the TLV record type for delivery addreses within
+	// the name space of the OpenChannel and AcceptChannel messages.
+	DeliveryAddrType = 0
+)
+
+// TypedDeliveryAddress is similar to the DeliveryAddrType type, but it's
+// encoded using a mini TLV stream. This tyupe was intorudced in order to allow
+// the OpenChannel/AcceptChannel messages to properly be extended with TLV types.
+type TypedDeliveryAddress []byte
+
+// Encode encodes the target TypedDeliveryAddress into the target io.Writer
+// using a TLV stream.
+func (t *TypedDeliveryAddress) Encode(w io.Writer) error {
+	addrBytes := []byte((*t)[:])
+
+	records := []tlv.Record{
+		tlv.MakeDynamicRecord(
+			DeliveryAddrType, &addrBytes,
+			func() uint64 {
+				return uint64(len(addrBytes))
+			},
+			tlv.EVarBytes, tlv.DVarBytes,
+		),
+	}
+	tlvStream, err := tlv.NewStream(records...)
+	if err != nil {
+		return err
+	}
+
+	return tlvStream.Encode(w)
+}
+
+// Decode decodes a set of bytes from the targer io.Reader into the target
+// TypedDeliveryAddress.
+func (t *TypedDeliveryAddress) Decode(r io.Reader) error {
+	addrBytes := []byte((*t)[:])
+
+	records := []tlv.Record{
+		tlv.MakeDynamicRecord(
+			DeliveryAddrType, &addrBytes, nil,
+			tlv.EVarBytes, tlv.DVarBytes,
+		),
+	}
+
+	tlvStream, err := tlv.NewStream(records...)
+	if err != nil {
+		return err
+	}
+	if err := tlvStream.Decode(r); err != nil {
+		return err
+	}
+
+	*t = addrBytes
+
+	return nil
+}

--- a/lnwire/typed_delivery_addr_test.go
+++ b/lnwire/typed_delivery_addr_test.go
@@ -1,0 +1,31 @@
+package lnwire
+
+import (
+	"bytes"
+	"testing"
+)
+
+// TestTypedDeliveryAddressEncodeDecode tests that we're able to properly
+// encode and decode typed delivery addresses.
+func TestTypedDeliveryAddressEncodeDecode(t *testing.T) {
+	t.Parallel()
+
+	addr := TypedDeliveryAddress(
+		bytes.Repeat([]byte("a"), deliveryAddressMaxSize),
+	)
+
+	var b bytes.Buffer
+	if err := addr.Encode(&b); err != nil {
+		t.Fatalf("unable to encode addr: %v", err)
+	}
+
+	var addr2 TypedDeliveryAddress
+	if err := addr2.Decode(&b); err != nil {
+		t.Fatalf("unable to decode addr: %v", err)
+	}
+
+	if !bytes.Equal(addr, addr2) {
+		t.Fatalf("addr mismatch: expected %x, got %x", addr[:],
+			addr2[:])
+	}
+}

--- a/lnwire/update_add_htlc.go
+++ b/lnwire/update_add_htlc.go
@@ -52,6 +52,11 @@ type UpdateAddHTLC struct {
 	// should strip off a layer of encryption, exposing the next hop to be
 	// used in the subsequent UpdateAddHTLC message.
 	OnionBlob [OnionPacketSize]byte
+
+	// ExtraData is the set of data that was appended to this message to
+	// fill out the full maximum transport message size. These fields can
+	// be used to specify optional data such as custom TLV fields.
+	ExtraData ExtraOpaqueData
 }
 
 // NewUpdateAddHTLC returns a new empty UpdateAddHTLC message.
@@ -75,6 +80,7 @@ func (c *UpdateAddHTLC) Decode(r io.Reader, pver uint32) error {
 		c.PaymentHash[:],
 		&c.Expiry,
 		c.OnionBlob[:],
+		&c.ExtraData,
 	)
 }
 
@@ -90,6 +96,7 @@ func (c *UpdateAddHTLC) Encode(w io.Writer, pver uint32) error {
 		c.PaymentHash[:],
 		c.Expiry,
 		c.OnionBlob[:],
+		c.ExtraData,
 	)
 }
 
@@ -106,8 +113,7 @@ func (c *UpdateAddHTLC) MsgType() MessageType {
 //
 // This is part of the lnwire.Message interface.
 func (c *UpdateAddHTLC) MaxPayloadLength(uint32) uint32 {
-	// 1450
-	return 32 + 8 + 4 + 8 + 32 + 1366
+	return MaxMsgBody
 }
 
 // TargetChanID returns the channel id of the link for which this message is

--- a/lnwire/update_add_htlc.go
+++ b/lnwire/update_add_htlc.go
@@ -74,6 +74,7 @@ var _ Message = (*UpdateAddHTLC)(nil)
 // This is part of the lnwire.Message interface.
 func (c *UpdateAddHTLC) Decode(r io.Reader, pver uint32) error {
 	return ReadElements(r,
+		pver,
 		&c.ChanID,
 		&c.ID,
 		&c.Amount,
@@ -90,6 +91,7 @@ func (c *UpdateAddHTLC) Decode(r io.Reader, pver uint32) error {
 // This is part of the lnwire.Message interface.
 func (c *UpdateAddHTLC) Encode(w io.Writer, pver uint32) error {
 	return WriteElements(w,
+		pver,
 		c.ChanID,
 		c.ID,
 		c.Amount,

--- a/lnwire/update_fail_htlc.go
+++ b/lnwire/update_fail_htlc.go
@@ -26,6 +26,11 @@ type UpdateFailHTLC struct {
 	// failed. This blob is only fully decryptable by the initiator of the
 	// HTLC message.
 	Reason OpaqueReason
+
+	// ExtraData is the set of data that was appended to this message to
+	// fill out the full maximum transport message size. These fields can
+	// be used to specify optional data such as custom TLV fields.
+	ExtraData ExtraOpaqueData
 }
 
 // A compile time check to ensure UpdateFailHTLC implements the lnwire.Message
@@ -41,6 +46,7 @@ func (c *UpdateFailHTLC) Decode(r io.Reader, pver uint32) error {
 		&c.ChanID,
 		&c.ID,
 		&c.Reason,
+		&c.ExtraData,
 	)
 }
 
@@ -53,6 +59,7 @@ func (c *UpdateFailHTLC) Encode(w io.Writer, pver uint32) error {
 		c.ChanID,
 		c.ID,
 		c.Reason,
+		c.ExtraData,
 	)
 }
 
@@ -69,21 +76,7 @@ func (c *UpdateFailHTLC) MsgType() MessageType {
 //
 // This is part of the lnwire.Message interface.
 func (c *UpdateFailHTLC) MaxPayloadLength(uint32) uint32 {
-	var length uint32
-
-	// Length of the ChanID
-	length += 32
-
-	// Length of the ID
-	length += 8
-
-	// Length of the length opaque reason
-	length += 2
-
-	// Length of the Reason
-	length += 292
-
-	return length
+	return MaxMsgBody
 }
 
 // TargetChanID returns the channel id of the link for which this message is

--- a/lnwire/update_fail_htlc.go
+++ b/lnwire/update_fail_htlc.go
@@ -43,6 +43,7 @@ var _ Message = (*UpdateFailHTLC)(nil)
 // This is part of the lnwire.Message interface.
 func (c *UpdateFailHTLC) Decode(r io.Reader, pver uint32) error {
 	return ReadElements(r,
+		pver,
 		&c.ChanID,
 		&c.ID,
 		&c.Reason,
@@ -56,6 +57,7 @@ func (c *UpdateFailHTLC) Decode(r io.Reader, pver uint32) error {
 // This is part of the lnwire.Message interface.
 func (c *UpdateFailHTLC) Encode(w io.Writer, pver uint32) error {
 	return WriteElements(w,
+		pver,
 		c.ChanID,
 		c.ID,
 		c.Reason,

--- a/lnwire/update_fail_malformed_htlc.go
+++ b/lnwire/update_fail_malformed_htlc.go
@@ -24,6 +24,11 @@ type UpdateFailMalformedHTLC struct {
 
 	// FailureCode the exact reason why onion blob haven't been parsed.
 	FailureCode FailCode
+
+	// ExtraData is the set of data that was appended to this message to
+	// fill out the full maximum transport message size. These fields can
+	// be used to specify optional data such as custom TLV fields.
+	ExtraData ExtraOpaqueData
 }
 
 // A compile time check to ensure UpdateFailMalformedHTLC implements the
@@ -40,6 +45,7 @@ func (c *UpdateFailMalformedHTLC) Decode(r io.Reader, pver uint32) error {
 		&c.ID,
 		c.ShaOnionBlob[:],
 		&c.FailureCode,
+		&c.ExtraData,
 	)
 }
 
@@ -53,6 +59,7 @@ func (c *UpdateFailMalformedHTLC) Encode(w io.Writer, pver uint32) error {
 		c.ID,
 		c.ShaOnionBlob[:],
 		c.FailureCode,
+		c.ExtraData,
 	)
 }
 
@@ -70,8 +77,7 @@ func (c *UpdateFailMalformedHTLC) MsgType() MessageType {
 //
 // This is part of the lnwire.Message interface.
 func (c *UpdateFailMalformedHTLC) MaxPayloadLength(uint32) uint32 {
-	// 32 +  8 + 32 + 2
-	return 74
+	return MaxMsgBody
 }
 
 // TargetChanID returns the channel id of the link for which this message is

--- a/lnwire/update_fail_malformed_htlc.go
+++ b/lnwire/update_fail_malformed_htlc.go
@@ -41,6 +41,7 @@ var _ Message = (*UpdateFailMalformedHTLC)(nil)
 // This is part of the lnwire.Message interface.
 func (c *UpdateFailMalformedHTLC) Decode(r io.Reader, pver uint32) error {
 	return ReadElements(r,
+		pver,
 		&c.ChanID,
 		&c.ID,
 		c.ShaOnionBlob[:],
@@ -55,6 +56,7 @@ func (c *UpdateFailMalformedHTLC) Decode(r io.Reader, pver uint32) error {
 // This is part of the lnwire.Message interface.
 func (c *UpdateFailMalformedHTLC) Encode(w io.Writer, pver uint32) error {
 	return WriteElements(w,
+		pver,
 		c.ChanID,
 		c.ID,
 		c.ShaOnionBlob[:],

--- a/lnwire/update_fee.go
+++ b/lnwire/update_fee.go
@@ -16,6 +16,11 @@ type UpdateFee struct {
 	// TODO(halseth): make SatPerKWeight when fee estimation is moved to
 	// own package. Currently this will cause an import cycle.
 	FeePerKw uint32
+
+	// ExtraData is the set of data that was appended to this message to
+	// fill out the full maximum transport message size. These fields can
+	// be used to specify optional data such as custom TLV fields.
+	ExtraData ExtraOpaqueData
 }
 
 // NewUpdateFee creates a new UpdateFee message.
@@ -38,6 +43,7 @@ func (c *UpdateFee) Decode(r io.Reader, pver uint32) error {
 	return ReadElements(r,
 		&c.ChanID,
 		&c.FeePerKw,
+		&c.ExtraData,
 	)
 }
 
@@ -49,6 +55,7 @@ func (c *UpdateFee) Encode(w io.Writer, pver uint32) error {
 	return WriteElements(w,
 		c.ChanID,
 		c.FeePerKw,
+		c.ExtraData,
 	)
 }
 
@@ -65,8 +72,7 @@ func (c *UpdateFee) MsgType() MessageType {
 //
 // This is part of the lnwire.Message interface.
 func (c *UpdateFee) MaxPayloadLength(uint32) uint32 {
-	// 32 + 4
-	return 36
+	return MaxMsgBody
 }
 
 // TargetChanID returns the channel id of the link for which this message is

--- a/lnwire/update_fee.go
+++ b/lnwire/update_fee.go
@@ -41,6 +41,7 @@ var _ Message = (*UpdateFee)(nil)
 // This is part of the lnwire.Message interface.
 func (c *UpdateFee) Decode(r io.Reader, pver uint32) error {
 	return ReadElements(r,
+		pver,
 		&c.ChanID,
 		&c.FeePerKw,
 		&c.ExtraData,
@@ -53,6 +54,7 @@ func (c *UpdateFee) Decode(r io.Reader, pver uint32) error {
 // This is part of the lnwire.Message interface.
 func (c *UpdateFee) Encode(w io.Writer, pver uint32) error {
 	return WriteElements(w,
+		pver,
 		c.ChanID,
 		c.FeePerKw,
 		c.ExtraData,

--- a/lnwire/update_fulfill_htlc.go
+++ b/lnwire/update_fulfill_htlc.go
@@ -21,6 +21,11 @@ type UpdateFulfillHTLC struct {
 	// PaymentPreimage is the R-value preimage required to fully settle an
 	// HTLC.
 	PaymentPreimage [32]byte
+
+	// ExtraData is the set of data that was appended to this message to
+	// fill out the full maximum transport message size. These fields can
+	// be used to specify optional data such as custom TLV fields.
+	ExtraData ExtraOpaqueData
 }
 
 // NewUpdateFulfillHTLC returns a new empty UpdateFulfillHTLC.
@@ -47,6 +52,7 @@ func (c *UpdateFulfillHTLC) Decode(r io.Reader, pver uint32) error {
 		&c.ChanID,
 		&c.ID,
 		c.PaymentPreimage[:],
+		&c.ExtraData,
 	)
 }
 
@@ -59,6 +65,7 @@ func (c *UpdateFulfillHTLC) Encode(w io.Writer, pver uint32) error {
 		c.ChanID,
 		c.ID,
 		c.PaymentPreimage[:],
+		c.ExtraData,
 	)
 }
 
@@ -75,8 +82,7 @@ func (c *UpdateFulfillHTLC) MsgType() MessageType {
 //
 // This is part of the lnwire.Message interface.
 func (c *UpdateFulfillHTLC) MaxPayloadLength(uint32) uint32 {
-	// 32 + 8 + 32
-	return 72
+	return MaxMsgBody
 }
 
 // TargetChanID returns the channel id of the link for which this message is

--- a/lnwire/update_fulfill_htlc.go
+++ b/lnwire/update_fulfill_htlc.go
@@ -49,6 +49,7 @@ var _ Message = (*UpdateFulfillHTLC)(nil)
 // This is part of the lnwire.Message interface.
 func (c *UpdateFulfillHTLC) Decode(r io.Reader, pver uint32) error {
 	return ReadElements(r,
+		pver,
 		&c.ChanID,
 		&c.ID,
 		c.PaymentPreimage[:],
@@ -62,6 +63,7 @@ func (c *UpdateFulfillHTLC) Decode(r io.Reader, pver uint32) error {
 // This is part of the lnwire.Message interface.
 func (c *UpdateFulfillHTLC) Encode(w io.Writer, pver uint32) error {
 	return WriteElements(w,
+		pver,
 		c.ChanID,
 		c.ID,
 		c.PaymentPreimage[:],

--- a/make/testing_flags.mk
+++ b/make/testing_flags.mk
@@ -3,10 +3,16 @@ RPC_TAGS = autopilotrpc chainrpc invoicesrpc routerrpc signrpc verrpc walletrpc 
 LOG_TAGS =
 TEST_FLAGS =
 COVER_PKG = $$(go list -deps ./... | grep '$(PKG)' | grep -v lnrpc)
+NUM_ITEST_TRANCHES = 6
 
 # If rpc option is set also add all extra RPC tags to DEV_TAGS
 ifneq ($(with-rpc),)
 DEV_TAGS += $(RPC_TAGS)
+endif
+
+# Scale the number of parallel running itest tranches.
+ifneq ($(tranches),)
+NUM_ITEST_TRANCHES = $(tranches)
 endif
 
 # If specific package is being unit tested, construct the full name of the
@@ -25,7 +31,7 @@ endif
 
 # Define the integration test.run filter if the icase argument was provided.
 ifneq ($(icase),)
-TEST_FLAGS += -test.run=TestLightningNetworkDaemon/$(icase)
+TEST_FLAGS += -test.run="TestLightningNetworkDaemon/.*-of-.*/.*/$(icase)"
 endif
 
 ifneq ($(tags),)

--- a/peer/brontide.go
+++ b/peer/brontide.go
@@ -919,7 +919,7 @@ func (p *Brontide) readNextMessage() (lnwire.Message, error) {
 	// Next, create a new io.Reader implementation from the raw message,
 	// and use this to decode the message directly from.
 	msgReader := bytes.NewReader(rawMsg)
-	nextMsg, err := lnwire.ReadMessage(msgReader, 0)
+	nextMsg, err := lnwire.ReadMessage(msgReader, lnwire.ProtocolVersionTLV)
 	if err != nil {
 		return nil, err
 	}

--- a/routing/ann_validation.go
+++ b/routing/ann_validation.go
@@ -110,7 +110,10 @@ func ValidateNodeAnn(a *lnwire.NodeAnnouncement) error {
 	dataHash := chainhash.DoubleHashB(data)
 	if !nodeSig.Verify(dataHash, nodeKey) {
 		var msgBuf bytes.Buffer
-		if _, err := lnwire.WriteMessage(&msgBuf, a, 0); err != nil {
+		_, err := lnwire.WriteMessage(
+			&msgBuf, a, lnwire.ProtocolVersionTLV,
+		)
+		if err != nil {
 			return err
 		}
 

--- a/scripts/itest_part.sh
+++ b/scripts/itest_part.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+# Let's work with absolute paths only, we run in the itest directory itself.
+WORKDIR=$(pwd)/lntest/itest
+
+TRANCHE=$1
+NUM_TRANCHES=$2
+
+# Shift the passed parameters by two, giving us all remaining testing flags in
+# the $@ special variable.
+shift
+shift
+
+# Windows insists on having the .exe suffix for an executable, we need to add
+# that here if necessary.
+EXEC="$WORKDIR"/itest.test"$EXEC_SUFFIX"
+LND_EXEC="$WORKDIR"/lnd-itest"$EXEC_SUFFIX"
+echo $EXEC -test.v "$@" -logoutput -goroutinedump -logdir=.logs-tranche$TRANCHE -lndexec=$LND_EXEC -splittranches=$NUM_TRANCHES -runtranche=$TRANCHE
+
+# Exit code 255 causes the parallel jobs to abort, so if one part fails the
+# other is aborted too.
+cd "$WORKDIR" || exit 255
+$EXEC -test.v "$@" -logoutput -goroutinedump -logdir=.logs-tranche$TRANCHE -lndexec=$LND_EXEC -splittranches=$NUM_TRANCHES -runtranche=$TRANCHE || exit 255


### PR DESCRIPTION
In this Pr, we create a new `ExtraOpaqueData` based on the field with the same name that's present in all the announcement related messages. In later commits, we'll embed this new type in each message, so we'll have a generic way to add/parse TLV extensions from messages.

We then convert all the current known messages to include this new field, and parse it accordignly. The new `ExtraOpaqueData` also comes with some propsective helper methods for TLV encoding/decoding. I envision these will be used either _within_ the top-level `Encode/Decode` methods, or by callers to populate new (optional) pointer fields that get added in the wire messages similar to the structs in `htlcswitch/hop`. 