### PR TITLE
lnd: fix gosimple linter failure

### DIFF
--- a/lnd.go
+++ b/lnd.go
@@ -241,7 +241,7 @@ func Main(lisCfg ListenerCfg) error {
 	}
 	defer chanDB.Close()
 
-	openTime := time.Now().Sub(startOpenTime)
+	openTime := time.Since(startOpenTime)
 	ltndLog.Infof("Database now open (time_to_open=%v)!", openTime)
 
 	// Only process macaroons if --no-macaroons isn't set.


### PR DESCRIPTION
Linter is failing for `openTime := time.Now().Sub(startOpenTime)`, update it to use `time.Since` to appease the lintergods.