### PR TITLE
invoices: fix htlc timer deadlock

### DIFF
--- a/invoices/invoiceregistry.go
+++ b/invoices/invoiceregistry.go
@@ -693,8 +693,7 @@ func (i *InvoiceRegistry) cancelSingleHtlc(hash lntypes.Hash,
 
 // processKeySend just-in-time inserts an invoice if this htlc is a keysend
 // htlc.
-func (i *InvoiceRegistry) processKeySend(ctx invoiceUpdateCtx,
-	hash lntypes.Hash) error {
+func (i *InvoiceRegistry) processKeySend(ctx invoiceUpdateCtx) error {
 
 	// Retrieve keysend record if present.
 	preimageSlice, ok := ctx.customRecords[record.KeySendType]
@@ -704,7 +703,7 @@ func (i *InvoiceRegistry) processKeySend(ctx invoiceUpdateCtx,
 
 	// Cancel htlc is preimage is invalid.
 	preimage, err := lntypes.MakePreimage(preimageSlice)
-	if err != nil || preimage.Hash() != hash {
+	if err != nil || preimage.Hash() != ctx.hash {
 		return errors.New("invalid keysend preimage")
 	}
 
@@ -751,7 +750,7 @@ func (i *InvoiceRegistry) processKeySend(ctx invoiceUpdateCtx,
 
 	// Insert invoice into database. Ignore duplicates, because this
 	// may be a replay.
-	_, err = i.AddInvoice(invoice, hash)
+	_, err = i.AddInvoice(invoice, ctx.hash)
 	if err != nil && err != channeldb.ErrDuplicateInvoice {
 		return err
 	}
@@ -789,6 +788,7 @@ func (i *InvoiceRegistry) NotifyExitHopHtlc(rHash lntypes.Hash,
 	// Create the update context containing the relevant details of the
 	// incoming htlc.
 	updateCtx := invoiceUpdateCtx{
+		hash:                 rHash,
 		circuitKey:           circuitKey,
 		amtPaid:              amtPaid,
 		expiry:               expiry,
@@ -802,7 +802,7 @@ func (i *InvoiceRegistry) NotifyExitHopHtlc(rHash lntypes.Hash,
 	// AddInvoice obtains its own lock. This is no problem, because the
 	// operation is idempotent.
 	if i.cfg.AcceptKeySend {
-		err := i.processKeySend(updateCtx, rHash)
+		err := i.processKeySend(updateCtx)
 		if err != nil {
 			debugLog(fmt.Sprintf("keysend error: %v", err))
 

--- a/invoices/invoiceregistry.go
+++ b/invoices/invoiceregistry.go
@@ -780,11 +780,6 @@ func (i *InvoiceRegistry) NotifyExitHopHtlc(rHash lntypes.Hash,
 
 	mpp := payload.MultiPath()
 
-	debugLog := func(s string) {
-		log.Debugf("Invoice(%x): %v, amt=%v, expiry=%v, circuit=%v, "+
-			"mpp=%v", rHash[:], s, amtPaid, expiry, circuitKey, mpp)
-	}
-
 	// Create the update context containing the relevant details of the
 	// incoming htlc.
 	updateCtx := invoiceUpdateCtx{
@@ -804,7 +799,7 @@ func (i *InvoiceRegistry) NotifyExitHopHtlc(rHash lntypes.Hash,
 	if i.cfg.AcceptKeySend {
 		err := i.processKeySend(updateCtx)
 		if err != nil {
-			debugLog(fmt.Sprintf("keysend error: %v", err))
+			updateCtx.log(fmt.Sprintf("keysend error: %v", err))
 
 			return NewFailureResolution(
 				circuitKey, currentHeight, ResultKeySendError,
@@ -852,11 +847,11 @@ func (i *InvoiceRegistry) NotifyExitHopHtlc(rHash lntypes.Hash,
 	case nil:
 
 	default:
-		debugLog(err.Error())
+		updateCtx.log(err.Error())
 		return nil, err
 	}
 
-	debugLog(result.String())
+	updateCtx.log(result.String())
 
 	if updateSubscribers {
 		i.notifyClients(rHash, invoice, invoice.State)

--- a/invoices/update.go
+++ b/invoices/update.go
@@ -180,6 +180,12 @@ type invoiceUpdateCtx struct {
 	mpp                  *record.MPP
 }
 
+// log logs a message specific to this update context.
+func (i *invoiceUpdateCtx) log(s string) {
+	log.Debugf("Invoice(%x): %v, amt=%v, expiry=%v, circuit=%v, mpp=%v",
+		i.hash[:], s, i.amtPaid, i.expiry, i.circuitKey, i.mpp)
+}
+
 // updateInvoice is a callback for DB.UpdateInvoice that contains the invoice
 // settlement logic.
 func updateInvoice(ctx *invoiceUpdateCtx, inv *channeldb.Invoice) (

--- a/invoices/update.go
+++ b/invoices/update.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 
 	"github.com/lightningnetwork/lnd/channeldb"
+	"github.com/lightningnetwork/lnd/lntypes"
 	"github.com/lightningnetwork/lnd/lnwire"
 	"github.com/lightningnetwork/lnd/record"
 )
@@ -169,6 +170,7 @@ func (u ResolutionResult) String() string {
 // invoiceUpdateCtx is an object that describes the context for the invoice
 // update to be carried out.
 type invoiceUpdateCtx struct {
+	hash                 lntypes.Hash
 	circuitKey           channeldb.CircuitKey
 	amtPaid              lnwire.MilliSatoshi
 	expiry               uint32


### PR DESCRIPTION
Fixes a possible deadlock caused by sending on a channel inside a lock.