### PR TITLE
channeldb/channel: migrate byte to varint chanstatus

### DIFF
--- a/channeldb/channel.go
+++ b/channeldb/channel.go
@@ -372,7 +372,7 @@ type ChannelCommitment struct {
 
 // ChannelStatus is a bit vector used to indicate whether an OpenChannel is in
 // the default usable state, or a state where it shouldn't be used.
-type ChannelStatus uint8
+type ChannelStatus uint64
 
 var (
 	// ChanStatusDefault is the normal state of an open channel.

--- a/channeldb/codec.go
+++ b/channeldb/codec.go
@@ -13,6 +13,7 @@ import (
 	"github.com/lightningnetwork/lnd/keychain"
 	"github.com/lightningnetwork/lnd/lnwire"
 	"github.com/lightningnetwork/lnd/shachain"
+	"github.com/lightningnetwork/lnd/tlv"
 )
 
 // writeOutpoint writes an outpoint to the passed writer using the minimal
@@ -183,7 +184,8 @@ func WriteElement(w io.Writer, element interface{}) error {
 		}
 
 	case ChannelStatus:
-		if err := binary.Write(w, byteOrder, e); err != nil {
+		var buf [8]byte
+		if err := tlv.WriteVarInt(w, uint64(e), &buf); err != nil {
 			return err
 		}
 
@@ -397,9 +399,13 @@ func ReadElement(r io.Reader, element interface{}) error {
 		*e = msg
 
 	case *ChannelStatus:
-		if err := binary.Read(r, byteOrder, e); err != nil {
+		var buf [8]byte
+		status, err := tlv.ReadVarInt(r, &buf)
+		if err != nil {
 			return err
 		}
+
+		*e = ChannelStatus(status)
 
 	case *ClosureType:
 		if err := binary.Read(r, byteOrder, e); err != nil {


### PR DESCRIPTION
This PR converts the `channeldb.ChannelStatus` from a `uint8` to a `uint64` **w/o needing a migration**.

If in the future we need to allocate more than 8 `ChannelStatus` flags, this provides an easy way of expanding the width of the bitfield. The main premise is to replace the existing single-byte encoding with a TLV-varint, aka BigSize.

BigSize encodes values less than 253 (`0xfe`) as their direct byte encoding; since we have yet to allocate the highest bit in the chan status field, it's safe to assume that all current values are less than `0xfe`. This changes allows us to reinterpret the future encodings of the field, w/o needing to migrate any existing data. With this new interpretation, the on-disk representation will automatically grow to the required width as chan status flags are written back to the db.

There are a number of other places in the codebase where a `bool` became a `uint8`, applying this technique gives us YA opportunity grow them into `uint64` fields w/o needing migrations 🎉