### PR TITLE
channeldb: Replace fetchChannels pending/waiting bools with optional filters

### DIFF
--- a/channeldb/channel_test.go
+++ b/channeldb/channel_test.go
@@ -187,6 +187,13 @@ func fundingPointOption(chanPoint wire.OutPoint) testChannelOption {
 	}
 }
 
+// channelIDOption is an option which sets the short channel ID of the channel.
+var channelIDOption = func(chanID lnwire.ShortChannelID) testChannelOption {
+	return func(params *testChannelParams) {
+		params.channel.ShortChannelID = chanID
+	}
+}
+
 // createTestChannel writes a test channel to the database. It takes a set of
 // functional options which can be used to overwrite the default of creating
 // a pending channel that was broadcast at height 100.


### PR DESCRIPTION
The first commit is just a change to tests, replacing boiler plate channel setup with a default channel which can be overridden with functional options. 

In this PR, the booleans in `fetchChannels` are replaces with optional filters. This change allows us to decrease the number of calls we need to fetch certain sets of channels (`FetchAllOpenChannels` and `FetchWaitingCloseChannels`) and generally allows for more flexibility in channel queries. 

This is also a first step in investigating the addition of a `RequiresExport` flag that would allow channels to remain in the open channels bucket after close so that we can export accounting data. If we do go with this approach, we would need to filter these channels out somewhere (so they are not included with open channels calls), and this PR paves the path to that. If we don't go with this approach, it's still a nice cleanup.  