### PR TITLE
docs: add terminal symbol to docker readme example commands

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -64,8 +64,8 @@ bitcoin into.
 $ export NETWORK="simnet" 
 
 # Create persistent volumes for alice and bob.
-docker volume create simnet_lnd_alice
-docker volume create simnet_lnd_bob
+$ docker volume create simnet_lnd_alice
+$ docker volume create simnet_lnd_bob
 
 # Run the "Alice" container and log into it:
 $ docker-compose run -d --name alice --volume simnet_lnd_alice:/root/.lnd lnd


### PR DESCRIPTION
This PR fixes a small typo in the docker docs.
