### PR TITLE
Copy InputIndex into the underlying SignDescriptor struct

### DIFF
--- a/lnrpc/signrpc/signer_server.go
+++ b/lnrpc/signrpc/signer_server.go
@@ -373,8 +373,9 @@ func (s *Server) ComputeInputScript(ctx context.Context,
 				Value:    signDesc.Output.Value,
 				PkScript: signDesc.Output.PkScript,
 			},
-			HashType:  txscript.SigHashType(signDesc.Sighash),
-			SigHashes: sigHashCache,
+			HashType:   txscript.SigHashType(signDesc.Sighash),
+			SigHashes:  sigHashCache,
+			InputIndex: int(signDesc.InputIndex),
 		})
 	}
 


### PR DESCRIPTION
When the InputIndex is not 0, the index is not currently copied into the
underlying SignDescriptor structure and the signature generated is not
valid.