### PR TITLE
travis: remove git clone depth limitation to fix linter

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,11 @@ cache:
     - $GOPATH/src/github.com/golang
     - $GOPATH/src/gopkg.in/alecthomas
 
+# Remove Travis' default flag --depth=50 from the git clone command to make sure
+# we have the whole git history, including the commit we lint against.
+git:
+  depth: false
+
 go:
   - "1.13.x"
 


### PR DESCRIPTION
By default, Travis-CI does `git clone --depth=50` which limits the
repo to the last 50 commits. Because we do linting against an old
commit, it cannot be found any more. We remove the limit completely
to not run into this problem again.
