### PR TITLE
sweep: additionally detect our sweep transactions with the wallet

### DIFF
--- a/sweep/backend_mock_test.go
+++ b/sweep/backend_mock_test.go
@@ -96,6 +96,10 @@ func (b *mockBackend) WithCoinSelectLock(f func() error) error {
 	return f()
 }
 
+func (b *mockBackend) FetchInputInfo(*wire.OutPoint) (*lnwallet.Utxo, error) {
+	return nil, lnwallet.ErrNotMine
+}
+
 func (b *mockBackend) deleteUnconfirmed(txHash chainhash.Hash) {
 	b.lock.Lock()
 	defer b.lock.Unlock()

--- a/sweep/interface.go
+++ b/sweep/interface.go
@@ -24,4 +24,10 @@ type Wallet interface {
 	// ability to execute a function closure under an exclusive coin
 	// selection lock.
 	WithCoinSelectLock(f func() error) error
+
+	// FetchInputInfo queries for the wallet's knowledge of the passed
+	// outpoint. If the wallet determines this output is under its control,
+	// then the corresponding output should be returned. Otherwise,
+	// lnwallet.ErrNotMine should be returned instead.
+	FetchInputInfo(prevOut *wire.OutPoint) (*lnwallet.Utxo, error)
 }


### PR DESCRIPTION
This is only useful for detecting the case where users have attempted to restore their channels multiple times and one of their earlier attempts was actually successful in sweeping their funds. Without this, outputs that have already been swept by us on-chain would never have their corresponding contract resolvers resolved, causing channels to remain as pending closed, even though its been fully resolved.

The transaction lookup in the wallet is done by checking if any of the outputs are under the wallet's control. Alternatively, we could just look up the transaction itself through its hash, but the current wallet interface does not expose this functionality.

Testing this is a bit involved, but here's how you can confirm the fix:

1. Open a channel from Alice to Bob.
2. Delete all of Alice's data except for their channel backup.
3. Restore Alice's channel backup running master and wait until the channel is fully resolved.
4. Attempt another restore attempt running master and note how the channel never fully resolves due to a remote spend error.
5. Attempt another restore with this PR and wait until the channel fully resolves.

Note: this fix may not be enough if the input is swept to a custom output (not currently supported) that is not under the wallet's control.

Fixes #3321.