### PR TITLE
chancloser: unregister channel before db modification

### DIFF
--- a/chancloser.go
+++ b/chancloser.go
@@ -223,6 +223,10 @@ func (c *channelCloser) initChanShutdown() (*lnwire.Shutdown, error) {
 			"close: %v", c.chanPoint, err)
 	}
 
+	// Before returning the shutdown message, we'll unregister the channel
+	// to ensure that it isn't seen as usable within the system.
+	c.cfg.unregisterChannel(c.cid)
+
 	// Before continuing, mark the channel as cooperatively closed with a
 	// nil txn. Even though we haven't negotiated the final txn, this
 	// guarantees that our listchannels rpc will be externally consistent,
@@ -232,12 +236,6 @@ func (c *channelCloser) initChanShutdown() (*lnwire.Shutdown, error) {
 	if err != nil {
 		return nil, err
 	}
-
-	// Before returning the shutdown message, we'll unregister the channel
-	// to ensure that it isn't seen as usable within the system.
-	//
-	// TODO(roasbeef): fail if err?
-	c.cfg.unregisterChannel(c.cid)
 
 	peerLog.Infof("ChannelPoint(%v): sending shutdown message", c.chanPoint)
 


### PR DESCRIPTION
This fixes a race during channel closing, where the last channel state
update was still not finished when we set the channel close bit in the
database. This lead to a flake during integration tests, where the last
state update would not finish, and the channel wasn't closes
successfully.

We fix it by first unregistering the channel, making sure it is removed
fully from the link before doing the db modification.

Fixes 
```
--- FAIL: TestLightningNetworkDaemon (74.86s)
    lnd_test.go:15365: Running 61 integration tests
    --- FAIL: TestLightningNetworkDaemon/route_fee_cutoff (51.38s)
        lnd_test.go:103: Failed: (route fee cutoff): exited with error:
            *errors.errorString unable to close channel: timeout reached before channel close initiated
            /github.com/lightningnetwork/lnd-worktree/lntest/itest/lnd_test.go:287 (0x199fca7)
            	closeChannelAndAssert: t.Fatalf("unable to close channel: %v", err)
            /github.com/lightningnetwork/lnd-worktree/lntest/itest/lnd_test.go:13019 (0x19eaccd)
            	testRouteFeeCutoff: closeChannelAndAssert(ctxt, t, net, net.Alice, chanPointAliceBob, false)
            /github.com/lightningnetwork/lnd-worktree/lntest/itest/lnd_test.go:126 (0x199ee6a)
            	(*harnessTest).RunTestCase: testCase.test(h.lndHarness, h)
            /github.com/lightningnetwork/lnd-worktree/lntest/itest/lnd_test.go:15386 (0x1a0deec)
            	TestLightningNetworkDaemon.func4: ht.RunTestCase(testCase)
            /usr/local/Cellar/go/1.13.8/libexec/src/testing/testing.go:909 (0x1107eb9)
            	tRunner: fn(t)
            /usr/local/Cellar/go/1.13.8/libexec/src/runtime/asm_amd64.s:1357 (0x10612e1)
            	goexit: BYTE	$0x90	// NOP
FAIL
```