### PR TITLE
input/size: correct NP2WKH and NP2SH input count

### DIFF
--- a/input/size.go
+++ b/input/size.go
@@ -25,11 +25,21 @@ const (
 	//	- PublicKeyHASH160: 20 bytes
 	P2WPKHSize = 1 + 1 + 20
 
+	// NestedP2WPKHSize 23 bytes
+	//      - OP_DATA: 1 byte (P2WPKHSize)
+	//      - P2WPKHWitnessProgram: 22 bytes
+	NestedP2WPKHSize = 1 + P2WPKHSize
+
 	// P2WSHSize 34 bytes
 	//	- OP_0: 1 byte
 	//	- OP_DATA: 1 byte (WitnessScriptSHA256 length)
 	//	- WitnessScriptSHA256: 32 bytes
 	P2WSHSize = 1 + 1 + 32
+
+	// NestedP2WSHSize 35 bytes
+	//      - OP_DATA: 1 byte (P2WSHSize)
+	//      - P2WSHWitnessProgram: 35 bytes
+	NestedP2WSHSize = 1 + P2WSHSize
 
 	// P2PKHOutputSize 34 bytes
 	//      - value: 8 bytes
@@ -417,9 +427,9 @@ func (twe *TxWeightEstimator) AddWitnessInput(witnessSize int) *TxWeightEstimato
 // AddNestedP2WKHInput updates the weight estimate to account for an additional
 // input spending a P2SH output with a nested P2WKH redeem script.
 func (twe *TxWeightEstimator) AddNestedP2WKHInput() *TxWeightEstimator {
-	twe.inputSize += InputSize + P2WPKHSize
+	twe.inputSize += InputSize + NestedP2WPKHSize
 	twe.inputWitnessSize += P2WKHWitnessSize
-	twe.inputSize++
+	twe.inputCount++
 	twe.hasWitness = true
 
 	return twe
@@ -428,9 +438,9 @@ func (twe *TxWeightEstimator) AddNestedP2WKHInput() *TxWeightEstimator {
 // AddNestedP2WSHInput updates the weight estimate to account for an additional
 // input spending a P2SH output with a nested P2WSH redeem script.
 func (twe *TxWeightEstimator) AddNestedP2WSHInput(witnessSize int) *TxWeightEstimator {
-	twe.inputSize += InputSize + P2WSHSize
+	twe.inputSize += InputSize + NestedP2WSHSize
 	twe.inputWitnessSize += witnessSize
-	twe.inputSize++
+	twe.inputCount++
 	twe.hasWitness = true
 
 	return twe

--- a/input/size_test.go
+++ b/input/size_test.go
@@ -1,4 +1,4 @@
-package lnwallet_test
+package input_test
 
 import (
 	"testing"

--- a/lnwallet/size_test.go
+++ b/lnwallet/size_test.go
@@ -68,6 +68,68 @@ func TestTxWeightEstimator(t *testing.T) {
 		numP2WSHOutputs      int
 		numP2SHOutputs       int
 	}{
+		// Assert base txn size.
+		{},
+
+		// Assert single input/output sizes.
+		{
+			numP2PKHInputs: 1,
+		},
+		{
+			numP2WKHInputs: 1,
+		},
+		{
+			numP2WSHInputs: 1,
+		},
+		{
+			numNestedP2WKHInputs: 1,
+		},
+		{
+			numNestedP2WSHInputs: 1,
+		},
+		{
+			numP2WKHOutputs: 1,
+		},
+		{
+			numP2PKHOutputs: 1,
+		},
+		{
+			numP2WSHOutputs: 1,
+		},
+		{
+			numP2SHOutputs: 1,
+		},
+
+		// Assert each input/output increments input/output counts.
+		{
+			numP2PKHInputs: 253,
+		},
+		{
+			numP2WKHInputs: 253,
+		},
+		{
+			numP2WSHInputs: 253,
+		},
+		{
+			numNestedP2WKHInputs: 253,
+		},
+		{
+			numNestedP2WSHInputs: 253,
+		},
+		{
+			numP2WKHOutputs: 253,
+		},
+		{
+			numP2PKHOutputs: 253,
+		},
+		{
+			numP2WSHOutputs: 253,
+		},
+		{
+			numP2SHOutputs: 253,
+		},
+
+		// Assert basic combinations of inputs and outputs.
 		{
 			numP2PKHInputs:  1,
 			numP2PKHOutputs: 2,
@@ -97,12 +159,41 @@ func TestTxWeightEstimator(t *testing.T) {
 			numP2SHOutputs: 1,
 		},
 		{
-			numNestedP2WKHInputs: 253,
+			numNestedP2WKHInputs: 1,
 			numP2WKHOutputs:      1,
 		},
 		{
-			numNestedP2WSHInputs: 253,
+			numNestedP2WSHInputs: 1,
 			numP2WKHOutputs:      1,
+		},
+
+		// Assert disparate input/output types increment total
+		// input/output counts.
+		{
+			numP2PKHInputs:       50,
+			numP2WKHInputs:       50,
+			numP2WSHInputs:       51,
+			numNestedP2WKHInputs: 51,
+			numNestedP2WSHInputs: 51,
+			numP2WKHOutputs:      1,
+		},
+		{
+			numP2WKHInputs:  1,
+			numP2WKHOutputs: 63,
+			numP2PKHOutputs: 63,
+			numP2WSHOutputs: 63,
+			numP2SHOutputs:  64,
+		},
+		{
+			numP2PKHInputs:       50,
+			numP2WKHInputs:       50,
+			numP2WSHInputs:       51,
+			numNestedP2WKHInputs: 51,
+			numNestedP2WSHInputs: 51,
+			numP2WKHOutputs:      63,
+			numP2PKHOutputs:      63,
+			numP2WSHOutputs:      63,
+			numP2SHOutputs:       64,
 		},
 	}
 

--- a/lnwallet/size_test.go
+++ b/lnwallet/size_test.go
@@ -97,11 +97,11 @@ func TestTxWeightEstimator(t *testing.T) {
 			numP2SHOutputs: 1,
 		},
 		{
-			numNestedP2WKHInputs: 1,
+			numNestedP2WKHInputs: 253,
 			numP2WKHOutputs:      1,
 		},
 		{
-			numNestedP2WSHInputs: 1,
+			numNestedP2WSHInputs: 253,
 			numP2WKHOutputs:      1,
 		},
 	}


### PR DESCRIPTION
This PR corrects a bug in TxWeightEstimator that could result in
underestimations for transactions involving NestedP2WPKH and NestedP2WSH
inputs. The scriptSig data push is now accounted for in a proper size
constant, and the input count is now incremented in both. This would
only be detectable in the event that the number of non-nested inputs and
the total number of inputs straddle the discontinuities in the
CompactSize encoding, e.g. 253, 2^16-1, or 2^32-1.

Fortunately this doesn’t impact any critical LN fee calculations (that could result
in invalid commitment signatures and a force close) since we don’t use these input
types.