### PR TITLE
travis: format, compile and verify protos

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -11,6 +11,8 @@
 - [ ] Any new logging statements use an appropriate subsystem and
   logging level
 - [ ] Code has been formatted with `go fmt`
+- [ ] Protobuf files (`lnrpc/**/*.proto`) have been formatted with
+  `make rpc-format` and compiled with `make rpc`
 - [ ] For code and documentation: lines are wrapped at 80 characters
   (the tab character should be counted as 8 characters, not 4, as some IDEs do
   per default)

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,11 +2,14 @@ language: go
 cache:
   directories:
     - ~/bitcoin/bitcoin-0.19.0.1/bin
+    - $DOWNLOAD_CACHE
     - $GOCACHE
     - $GOPATH/pkg/mod
     - $GOPATH/src/github.com/btcsuite
     - $GOPATH/src/github.com/golang
+    - $GOPATH/src/github.com/grpc-ecosystem
     - $GOPATH/src/gopkg.in/alecthomas
+    - $GOPATH/src/google.golang.org
 
 # Remove Travis' default flag --depth=50 from the git clone command to make sure
 # we have the whole git history, including the commit we lint against.
@@ -19,18 +22,27 @@ go:
 env:
   global:
     - GOCACHE=$HOME/.go-build
+    - DOWNLOAD_CACHE=$HOME/download_cache
 
 sudo: required
 
-before_script: bash ./scripts/install_bitcoind.sh
+addons:
+  apt:
+    packages:
+      - clang-format
+
+before_script:
+  - bash ./scripts/install_travis_proto.sh
+  - bash ./scripts/install_bitcoind.sh
 
 jobs:
   include:
     - stage: Build
-      script: 
-      - make unit pkg=... case=_NONE_ 
-      - make lint
-      - make btcd
+      script:
+        - make rpc-check
+        - make unit pkg=... case=_NONE_
+        - make lint
+        - make btcd
     - stage: Test
       script: make travis-cover
       name: Unit Cover

--- a/Makefile
+++ b/Makefile
@@ -174,6 +174,14 @@ rpc:
 	@$(call print, "Compiling protos.")
 	cd ./lnrpc; ./gen_protos.sh
 
+rpc-format:
+	@$(call print, "Formatting protos.")
+	cd ./lnrpc; find . -name "*.proto" | xargs clang-format --style=file -i
+
+rpc-check: rpc-format rpc
+	@$(call print, "Verifying protos.")
+	if test -n "$$(git describe --dirty | grep dirty)"; then echo "Protos not properly formatted or not compiled with v3.4.0"; git status; git diff; exit 1; fi
+
 mobile-rpc:
 	@$(call print, "Creating mobile RPC from protos.")
 	cd ./mobile; ./gen_bindings.sh
@@ -223,6 +231,8 @@ clean:
 	lint \
 	list \
 	rpc \
+	rpc-format \
+	rpc-check \
 	mobile-rpc \
 	vendor \
 	ios \

--- a/lnrpc/.clang-format
+++ b/lnrpc/.clang-format
@@ -1,0 +1,7 @@
+---
+Language: Proto
+BasedOnStyle: Google
+IndentWidth: 4
+AllowShortFunctionsOnASingleLine: None
+SpaceBeforeParens: Always
+CompactNamespaces: false

--- a/lnrpc/README.md
+++ b/lnrpc/README.md
@@ -146,6 +146,17 @@ $ go get -u github.com/lightningnetwork/lnd/lnrpc
 
 ## Generate protobuf definitions
 
+### Linux
+
+For linux there is an easy install script that is also used for the Travis CI
+build. Just run the following command (requires `sudo` permissions and the tools
+`make`, `go`, `wget` and `unzip` to be installed) from the repository's root
+folder:
+
+`./scripts/install_travis_proto.sh`
+
+### MacOS / Unix like systems
+
 1. Download [v.3.4.0](https://github.com/google/protobuf/releases/tag/v3.4.0) of
 `protoc` for your operating system and add it to your `PATH`.
 For example, if using macOS:
@@ -178,4 +189,24 @@ $ git reset --hard v1.8.6
 $ go install ./protoc-gen-grpc-gateway ./protoc-gen-swagger
 ```
 
-5. Run [`gen_protos.sh`](https://github.com/lightningnetwork/lnd/blob/master/lnrpc/gen_protos.sh) to generate new protobuf definitions.
+5. Run [`gen_protos.sh`](https://github.com/lightningnetwork/lnd/blob/master/lnrpc/gen_protos.sh)
+or `make rpc` to generate new protobuf definitions.
+
+## Format .proto files
+
+We use `clang-format` to make sure the `.proto` files are formatted correctly.
+You can install the formatter on Ubuntu by running `apt install clang-format`.
+
+Consult [this page](http://releases.llvm.org/download.html) to find binaries
+for other operating systems or distributions.
+
+## Makefile commands
+
+The following commands are available with `make`:
+
+* `rpc`: Compile `.proto` files (calls `lnrpc/gen_protos.sh`).
+* `rpc-format`: Formats all `.proto` files according to our formatting rules.
+  Requires `clang-format`, see previous chapter.
+* `rpc-check`: Runs both previous commands and makes sure the git work tree is
+  not dirty. This can be used to check that the `.proto` files are formatted
+  and compiled properly.

--- a/lnrpc/chainrpc/chainnotifier.pb.go
+++ b/lnrpc/chainrpc/chainnotifier.pb.go
@@ -106,7 +106,8 @@ type ConfDetails struct {
 	RawTx []byte `protobuf:"bytes,1,opt,name=raw_tx,json=rawTx,proto3" json:"raw_tx,omitempty"`
 	// The hash of the block in which the confirmed transaction was included in.
 	BlockHash []byte `protobuf:"bytes,2,opt,name=block_hash,json=blockHash,proto3" json:"block_hash,omitempty"`
-	// The height of the block in which the confirmed transaction was included in.
+	// The height of the block in which the confirmed transaction was included
+	// in.
 	BlockHeight uint32 `protobuf:"varint,3,opt,name=block_height,json=blockHeight,proto3" json:"block_height,omitempty"`
 	// The index of the confirmed transaction within the transaction.
 	TxIndex              uint32   `protobuf:"varint,4,opt,name=tx_index,json=txIndex,proto3" json:"tx_index,omitempty"`

--- a/lnrpc/chainrpc/chainnotifier.proto
+++ b/lnrpc/chainrpc/chainnotifier.proto
@@ -39,7 +39,8 @@ message ConfDetails {
     // The hash of the block in which the confirmed transaction was included in.
     bytes block_hash = 2;
 
-    // The height of the block in which the confirmed transaction was included in.
+    // The height of the block in which the confirmed transaction was included
+    // in.
     uint32 block_height = 3;
 
     // The index of the confirmed transaction within the transaction.

--- a/lnrpc/invoicesrpc/invoices.pb.go
+++ b/lnrpc/invoicesrpc/invoices.pb.go
@@ -275,7 +275,8 @@ func (m *AddHoldInvoiceResp) GetPaymentRequest() string {
 }
 
 type SettleInvoiceMsg struct {
-	/// Externally discovered pre-image that should be used to settle the hold invoice.
+	/// Externally discovered pre-image that should be used to settle the hold
+	/// invoice.
 	Preimage             []byte   `protobuf:"bytes,1,opt,name=preimage,proto3" json:"preimage,omitempty"`
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
 	XXX_unrecognized     []byte   `json:"-"`

--- a/lnrpc/invoicesrpc/invoices.proto
+++ b/lnrpc/invoicesrpc/invoices.proto
@@ -15,10 +15,11 @@ service Invoices {
     to notify the client of state transitions of the specified invoice.
     Initially the current invoice state is always sent out.
     */
-    rpc SubscribeSingleInvoice (SubscribeSingleInvoiceRequest) returns (stream lnrpc.Invoice);
+    rpc SubscribeSingleInvoice (SubscribeSingleInvoiceRequest)
+        returns (stream lnrpc.Invoice);
 
     /**
-    CancelInvoice cancels a currently open invoice. If the invoice is already 
+    CancelInvoice cancels a currently open invoice. If the invoice is already
     canceled, this call will succeed. If the invoice is already settled, it will
     fail.
     */
@@ -106,7 +107,8 @@ message AddHoldInvoiceResp {
 }
 
 message SettleInvoiceMsg {
-    /// Externally discovered pre-image that should be used to settle the hold invoice.
+    /// Externally discovered pre-image that should be used to settle the hold
+    /// invoice.
     bytes preimage = 1;
 }
 

--- a/lnrpc/routerrpc/router.proto
+++ b/lnrpc/routerrpc/router.proto
@@ -19,7 +19,7 @@ message SendPaymentRequest {
 
     /**
     Number of millisatoshis to send.
-    
+
     The fields amt and amt_msat are mutually exclusive.
     */
     int64 amt_msat = 12;
@@ -61,14 +61,14 @@ message SendPaymentRequest {
     int64 fee_limit_sat = 7;
 
     /**
-   The maximum number of millisatoshis that will be paid as a fee of the
-   payment. If this field is left to the default value of 0, only zero-fee
-   routes will be considered. This usually means single hop routes connecting
-   directly to the destination. To send the payment without a fee limit, use
-   max int here.
-   
-   The fields fee_limit_sat and fee_limit_msat are mutually exclusive.
-   */
+    The maximum number of millisatoshis that will be paid as a fee of the
+    payment. If this field is left to the default value of 0, only zero-fee
+    routes will be considered. This usually means single hop routes connecting
+    directly to the destination. To send the payment without a fee limit, use
+    max int here.
+
+    The fields fee_limit_sat and fee_limit_msat are mutually exclusive.
+    */
     int64 fee_limit_msat = 13;
 
     /**
@@ -82,7 +82,7 @@ message SendPaymentRequest {
     */
     bytes last_hop_pubkey = 14;
 
-    /** 
+    /**
     An optional maximum total time lock for the route. This should not exceed
     lnd's `--max-cltv-expiry` setting. If zero, then the value of
     `--max-cltv-expiry` is enforced.
@@ -94,7 +94,7 @@ message SendPaymentRequest {
     */
     repeated lnrpc.RouteHint route_hints = 10;
 
-    /** 
+    /**
     An optional field that can be used to pass an arbitrary set of TLV records
     to a peer which understands the new records. This can be used to pass
     application specific data during the payment attempt. Record types are
@@ -160,7 +160,6 @@ enum PaymentState {
     FAILED_INSUFFICIENT_BALANCE = 6;
 }
 
-
 message PaymentStatus {
     /// Current state the payment is in.
     PaymentState state = 1;
@@ -180,7 +179,6 @@ message PaymentStatus {
     */
     repeated lnrpc.HTLCAttempt htlcs = 4;
 }
-
 
 message RouteFeeRequest {
     /**
@@ -366,19 +364,22 @@ service Router {
     ResetMissionControl clears all mission control state and starts with a clean
     slate.
     */
-    rpc ResetMissionControl (ResetMissionControlRequest) returns (ResetMissionControlResponse);
+    rpc ResetMissionControl (ResetMissionControlRequest)
+        returns (ResetMissionControlResponse);
 
     /**
     QueryMissionControl exposes the internal mission control state to callers.
     It is a development feature.
     */
-    rpc QueryMissionControl (QueryMissionControlRequest) returns (QueryMissionControlResponse);
+    rpc QueryMissionControl (QueryMissionControlRequest)
+        returns (QueryMissionControlResponse);
 
     /**
     QueryProbability returns the current success probability estimate for a
     given node pair and amount.
     */
-    rpc QueryProbability (QueryProbabilityRequest) returns (QueryProbabilityResponse);
+    rpc QueryProbability (QueryProbabilityRequest)
+        returns (QueryProbabilityResponse);
 
     /**
     BuildRoute builds a fully specified route based on a list of hop public

--- a/lnrpc/rpc.pb.go
+++ b/lnrpc/rpc.pb.go
@@ -1648,27 +1648,32 @@ type ChannelAcceptRequest struct {
 	ChainHash []byte `protobuf:"bytes,2,opt,name=chain_hash,json=chainHash,proto3" json:"chain_hash,omitempty"`
 	/// The pending channel id.
 	PendingChanId []byte `protobuf:"bytes,3,opt,name=pending_chan_id,json=pendingChanId,proto3" json:"pending_chan_id,omitempty"`
-	/// The funding amount in satoshis that initiator wishes to use in the channel.
+	/// The funding amount in satoshis that initiator wishes to use in the
+	/// channel.
 	FundingAmt uint64 `protobuf:"varint,4,opt,name=funding_amt,json=fundingAmt,proto3" json:"funding_amt,omitempty"`
 	/// The push amount of the proposed channel in millisatoshis.
 	PushAmt uint64 `protobuf:"varint,5,opt,name=push_amt,json=pushAmt,proto3" json:"push_amt,omitempty"`
 	/// The dust limit of the initiator's commitment tx.
 	DustLimit uint64 `protobuf:"varint,6,opt,name=dust_limit,json=dustLimit,proto3" json:"dust_limit,omitempty"`
-	/// The maximum amount of coins in millisatoshis that can be pending in this channel.
+	/// The maximum amount of coins in millisatoshis that can be pending in this
+	/// channel.
 	MaxValueInFlight uint64 `protobuf:"varint,7,opt,name=max_value_in_flight,json=maxValueInFlight,proto3" json:"max_value_in_flight,omitempty"`
-	/// The minimum amount of satoshis the initiator requires us to have at all times.
+	/// The minimum amount of satoshis the initiator requires us to have at all
+	/// times.
 	ChannelReserve uint64 `protobuf:"varint,8,opt,name=channel_reserve,json=channelReserve,proto3" json:"channel_reserve,omitempty"`
 	/// The smallest HTLC in millisatoshis that the initiator will accept.
 	MinHtlc uint64 `protobuf:"varint,9,opt,name=min_htlc,json=minHtlc,proto3" json:"min_htlc,omitempty"`
-	/// The initial fee rate that the initiator suggests for both commitment transactions.
+	/// The initial fee rate that the initiator suggests for both commitment
+	/// transactions.
 	FeePerKw uint64 `protobuf:"varint,10,opt,name=fee_per_kw,json=feePerKw,proto3" json:"fee_per_kw,omitempty"`
 	//*
-	//The number of blocks to use for the relative time lock in the pay-to-self output
-	//of both commitment transactions.
+	//The number of blocks to use for the relative time lock in the pay-to-self
+	//output of both commitment transactions.
 	CsvDelay uint32 `protobuf:"varint,11,opt,name=csv_delay,json=csvDelay,proto3" json:"csv_delay,omitempty"`
 	/// The total number of incoming HTLC's that the initiator will accept.
 	MaxAcceptedHtlcs uint32 `protobuf:"varint,12,opt,name=max_accepted_htlcs,json=maxAcceptedHtlcs,proto3" json:"max_accepted_htlcs,omitempty"`
-	/// A bit-field which the initiator uses to specify proposed channel behavior.
+	/// A bit-field which the initiator uses to specify proposed channel
+	/// behavior.
 	ChannelFlags         uint32   `protobuf:"varint,13,opt,name=channel_flags,json=channelFlags,proto3" json:"channel_flags,omitempty"`
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
 	XXX_unrecognized     []byte   `json:"-"`
@@ -1990,7 +1995,8 @@ func (m *OutPoint) GetOutputIndex() uint32 {
 type LightningAddress struct {
 	/// The identity pubkey of the Lightning node
 	Pubkey string `protobuf:"bytes,1,opt,name=pubkey,proto3" json:"pubkey,omitempty"`
-	/// The network location of the lightning node, e.g. `69.69.69.69:1337` or `localhost:10011`
+	/// The network location of the lightning node, e.g. `69.69.69.69:1337` or
+	/// `localhost:10011`
 	Host                 string   `protobuf:"bytes,2,opt,name=host,proto3" json:"host,omitempty"`
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
 	XXX_unrecognized     []byte   `json:"-"`
@@ -2039,7 +2045,8 @@ func (m *LightningAddress) GetHost() string {
 type EstimateFeeRequest struct {
 	/// The map from addresses to amounts for the transaction.
 	AddrToAmount map[string]int64 `protobuf:"bytes,1,rep,name=AddrToAmount,proto3" json:"AddrToAmount,omitempty" protobuf_key:"bytes,1,opt,name=key,proto3" protobuf_val:"varint,2,opt,name=value,proto3"`
-	/// The target number of blocks that this transaction should be confirmed by.
+	/// The target number of blocks that this transaction should be confirmed
+	/// by.
 	TargetConf           int32    `protobuf:"varint,2,opt,name=target_conf,json=targetConf,proto3" json:"target_conf,omitempty"`
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
 	XXX_unrecognized     []byte   `json:"-"`
@@ -2137,9 +2144,11 @@ func (m *EstimateFeeResponse) GetFeerateSatPerByte() int64 {
 type SendManyRequest struct {
 	/// The map from addresses to amounts
 	AddrToAmount map[string]int64 `protobuf:"bytes,1,rep,name=AddrToAmount,proto3" json:"AddrToAmount,omitempty" protobuf_key:"bytes,1,opt,name=key,proto3" protobuf_val:"varint,2,opt,name=value,proto3"`
-	/// The target number of blocks that this transaction should be confirmed by.
+	/// The target number of blocks that this transaction should be confirmed
+	/// by.
 	TargetConf int32 `protobuf:"varint,3,opt,name=target_conf,json=targetConf,proto3" json:"target_conf,omitempty"`
-	/// A manual fee rate set in sat/byte that should be used when crafting the transaction.
+	/// A manual fee rate set in sat/byte that should be used when crafting the
+	/// transaction.
 	SatPerByte           int64    `protobuf:"varint,5,opt,name=sat_per_byte,json=satPerByte,proto3" json:"sat_per_byte,omitempty"`
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
 	XXX_unrecognized     []byte   `json:"-"`
@@ -2237,9 +2246,11 @@ type SendCoinsRequest struct {
 	Addr string `protobuf:"bytes,1,opt,name=addr,proto3" json:"addr,omitempty"`
 	/// The amount in satoshis to send
 	Amount int64 `protobuf:"varint,2,opt,name=amount,proto3" json:"amount,omitempty"`
-	/// The target number of blocks that this transaction should be confirmed by.
+	/// The target number of blocks that this transaction should be confirmed
+	/// by.
 	TargetConf int32 `protobuf:"varint,3,opt,name=target_conf,json=targetConf,proto3" json:"target_conf,omitempty"`
-	/// A manual fee rate set in sat/byte that should be used when crafting the transaction.
+	/// A manual fee rate set in sat/byte that should be used when crafting the
+	/// transaction.
 	SatPerByte int64 `protobuf:"varint,5,opt,name=sat_per_byte,json=satPerByte,proto3" json:"sat_per_byte,omitempty"`
 	//*
 	//If set, then the amount field will be ignored, and lnd will attempt to
@@ -2993,7 +3004,8 @@ type Channel struct {
 	Lifetime int64 `protobuf:"varint,23,opt,name=lifetime,proto3" json:"lifetime,omitempty"`
 	//*
 	//The number of seconds that the remote peer has been observed as being online
-	//by the channel scoring system over the lifetime of the channel [EXPERIMENTAL].
+	//by the channel scoring system over the lifetime of the channel
+	//[EXPERIMENTAL].
 	Uptime int64 `protobuf:"varint,24,opt,name=uptime,proto3" json:"uptime,omitempty"`
 	//*
 	//Close address is the address that we will enforce payout to on cooperative
@@ -4273,11 +4285,14 @@ type CloseChannelRequest struct {
 	//will be able to generate a signature for Alice's version of the commitment
 	//transaction.
 	ChannelPoint *ChannelPoint `protobuf:"bytes,1,opt,name=channel_point,json=channelPoint,proto3" json:"channel_point,omitempty"`
-	/// If true, then the channel will be closed forcibly. This means the current commitment transaction will be signed and broadcast.
+	/// If true, then the channel will be closed forcibly. This means the
+	/// current commitment transaction will be signed and broadcast.
 	Force bool `protobuf:"varint,2,opt,name=force,proto3" json:"force,omitempty"`
-	/// The target number of blocks that the closure transaction should be confirmed by.
+	/// The target number of blocks that the closure transaction should be
+	/// confirmed by.
 	TargetConf int32 `protobuf:"varint,3,opt,name=target_conf,json=targetConf,proto3" json:"target_conf,omitempty"`
-	/// A manual fee rate set in sat/byte that should be used when crafting the closure transaction.
+	/// A manual fee rate set in sat/byte that should be used when crafting the
+	/// closure transaction.
 	SatPerByte int64 `protobuf:"varint,4,opt,name=sat_per_byte,json=satPerByte,proto3" json:"sat_per_byte,omitempty"`
 	//
 	//An optional address to send funds to in the case of a cooperative close.
@@ -4488,21 +4503,29 @@ type OpenChannelRequest struct {
 	NodePubkeyString string `protobuf:"bytes,3,opt,name=node_pubkey_string,json=nodePubkeyString,proto3" json:"node_pubkey_string,omitempty"` // Deprecated: Do not use.
 	/// The number of satoshis the wallet should commit to the channel
 	LocalFundingAmount int64 `protobuf:"varint,4,opt,name=local_funding_amount,json=localFundingAmount,proto3" json:"local_funding_amount,omitempty"`
-	/// The number of satoshis to push to the remote side as part of the initial commitment state
+	/// The number of satoshis to push to the remote side as part of the initial
+	/// commitment state
 	PushSat int64 `protobuf:"varint,5,opt,name=push_sat,json=pushSat,proto3" json:"push_sat,omitempty"`
-	/// The target number of blocks that the funding transaction should be confirmed by.
+	/// The target number of blocks that the funding transaction should be
+	/// confirmed by.
 	TargetConf int32 `protobuf:"varint,6,opt,name=target_conf,json=targetConf,proto3" json:"target_conf,omitempty"`
-	/// A manual fee rate set in sat/byte that should be used when crafting the funding transaction.
+	/// A manual fee rate set in sat/byte that should be used when crafting the
+	/// funding transaction.
 	SatPerByte int64 `protobuf:"varint,7,opt,name=sat_per_byte,json=satPerByte,proto3" json:"sat_per_byte,omitempty"`
-	/// Whether this channel should be private, not announced to the greater network.
+	/// Whether this channel should be private, not announced to the greater
+	/// network.
 	Private bool `protobuf:"varint,8,opt,name=private,proto3" json:"private,omitempty"`
-	/// The minimum value in millisatoshi we will require for incoming HTLCs on the channel.
+	/// The minimum value in millisatoshi we will require for incoming HTLCs on
+	/// the channel.
 	MinHtlcMsat int64 `protobuf:"varint,9,opt,name=min_htlc_msat,json=minHtlcMsat,proto3" json:"min_htlc_msat,omitempty"`
-	/// The delay we require on the remote's commitment transaction. If this is not set, it will be scaled automatically with the channel size.
+	/// The delay we require on the remote's commitment transaction. If this is
+	/// not set, it will be scaled automatically with the channel size.
 	RemoteCsvDelay uint32 `protobuf:"varint,10,opt,name=remote_csv_delay,json=remoteCsvDelay,proto3" json:"remote_csv_delay,omitempty"`
-	/// The minimum number of confirmations each one of your outputs used for the funding transaction must satisfy.
+	/// The minimum number of confirmations each one of your outputs used for
+	/// the funding transaction must satisfy.
 	MinConfs int32 `protobuf:"varint,11,opt,name=min_confs,json=minConfs,proto3" json:"min_confs,omitempty"`
-	/// Whether unconfirmed outputs should be used as inputs for the funding transaction.
+	/// Whether unconfirmed outputs should be used as inputs for the funding
+	/// transaction.
 	SpendUnconfirmed bool `protobuf:"varint,12,opt,name=spend_unconfirmed,json=spendUnconfirmed,proto3" json:"spend_unconfirmed,omitempty"`
 	//
 	//Close address is an optional address which specifies the address to which
@@ -5333,7 +5356,8 @@ type PendingChannelsResponse_PendingChannel struct {
 	Capacity      int64  `protobuf:"varint,3,opt,name=capacity,proto3" json:"capacity,omitempty"`
 	LocalBalance  int64  `protobuf:"varint,4,opt,name=local_balance,json=localBalance,proto3" json:"local_balance,omitempty"`
 	RemoteBalance int64  `protobuf:"varint,5,opt,name=remote_balance,json=remoteBalance,proto3" json:"remote_balance,omitempty"`
-	/// The minimum satoshis this node is required to reserve in its balance.
+	/// The minimum satoshis this node is required to reserve in its
+	/// balance.
 	LocalChanReserveSat int64 `protobuf:"varint,6,opt,name=local_chan_reserve_sat,json=localChanReserveSat,proto3" json:"local_chan_reserve_sat,omitempty"`
 	//*
 	//The minimum satoshis the other node is required to reserve in its
@@ -9485,9 +9509,11 @@ type ChannelFeeReport struct {
 	ChannelPoint string `protobuf:"bytes,1,opt,name=channel_point,json=channelPoint,proto3" json:"channel_point,omitempty"`
 	/// The base fee charged regardless of the number of milli-satoshis sent.
 	BaseFeeMsat int64 `protobuf:"varint,2,opt,name=base_fee_msat,json=baseFeeMsat,proto3" json:"base_fee_msat,omitempty"`
-	/// The amount charged per milli-satoshis transferred expressed in millionths of a satoshi.
+	/// The amount charged per milli-satoshis transferred expressed in
+	/// millionths of a satoshi.
 	FeePerMil int64 `protobuf:"varint,3,opt,name=fee_per_mil,json=feePerMil,proto3" json:"fee_per_mil,omitempty"`
-	/// The effective fee rate in milli-satoshis. Computed by dividing the fee_per_mil value by 1 million.
+	/// The effective fee rate in milli-satoshis. Computed by dividing the
+	/// fee_per_mil value by 1 million.
 	FeeRate              float64  `protobuf:"fixed64,4,opt,name=fee_rate,json=feeRate,proto3" json:"fee_rate,omitempty"`
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
 	XXX_unrecognized     []byte   `json:"-"`
@@ -9555,13 +9581,17 @@ func (m *ChannelFeeReport) GetFeeRate() float64 {
 }
 
 type FeeReportResponse struct {
-	/// An array of channel fee reports which describes the current fee schedule for each channel.
+	/// An array of channel fee reports which describes the current fee schedule
+	/// for each channel.
 	ChannelFees []*ChannelFeeReport `protobuf:"bytes,1,rep,name=channel_fees,json=channelFees,proto3" json:"channel_fees,omitempty"`
-	/// The total amount of fee revenue (in satoshis) the switch has collected over the past 24 hrs.
+	/// The total amount of fee revenue (in satoshis) the switch has collected
+	/// over the past 24 hrs.
 	DayFeeSum uint64 `protobuf:"varint,2,opt,name=day_fee_sum,json=dayFeeSum,proto3" json:"day_fee_sum,omitempty"`
-	/// The total amount of fee revenue (in satoshis) the switch has collected over the past 1 week.
+	/// The total amount of fee revenue (in satoshis) the switch has collected
+	/// over the past 1 week.
 	WeekFeeSum uint64 `protobuf:"varint,3,opt,name=week_fee_sum,json=weekFeeSum,proto3" json:"week_fee_sum,omitempty"`
-	/// The total amount of fee revenue (in satoshis) the switch has collected over the past 1 month.
+	/// The total amount of fee revenue (in satoshis) the switch has collected
+	/// over the past 1 month.
 	MonthFeeSum          uint64   `protobuf:"varint,4,opt,name=month_fee_sum,json=monthFeeSum,proto3" json:"month_fee_sum,omitempty"`
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
 	XXX_unrecognized     []byte   `json:"-"`
@@ -9628,13 +9658,16 @@ type PolicyUpdateRequest struct {
 	Scope isPolicyUpdateRequest_Scope `protobuf_oneof:"scope"`
 	/// The base fee charged regardless of the number of milli-satoshis sent.
 	BaseFeeMsat int64 `protobuf:"varint,3,opt,name=base_fee_msat,json=baseFeeMsat,proto3" json:"base_fee_msat,omitempty"`
-	/// The effective fee rate in milli-satoshis. The precision of this value goes up to 6 decimal places, so 1e-6.
+	/// The effective fee rate in milli-satoshis. The precision of this value
+	/// goes up to 6 decimal places, so 1e-6.
 	FeeRate float64 `protobuf:"fixed64,4,opt,name=fee_rate,json=feeRate,proto3" json:"fee_rate,omitempty"`
 	/// The required timelock delta for HTLCs forwarded over the channel.
 	TimeLockDelta uint32 `protobuf:"varint,5,opt,name=time_lock_delta,json=timeLockDelta,proto3" json:"time_lock_delta,omitempty"`
-	/// If set, the maximum HTLC size in milli-satoshis. If unset, the maximum HTLC will be unchanged.
+	/// If set, the maximum HTLC size in milli-satoshis. If unset, the maximum
+	/// HTLC will be unchanged.
 	MaxHtlcMsat uint64 `protobuf:"varint,6,opt,name=max_htlc_msat,json=maxHtlcMsat,proto3" json:"max_htlc_msat,omitempty"`
-	/// The minimum HTLC size in milli-satoshis. Only applied if min_htlc_msat_specified is true.
+	/// The minimum HTLC size in milli-satoshis. Only applied if
+	/// min_htlc_msat_specified is true.
 	MinHtlcMsat uint64 `protobuf:"varint,7,opt,name=min_htlc_msat,json=minHtlcMsat,proto3" json:"min_htlc_msat,omitempty"`
 	/// If true, min_htlc_msat is applied.
 	MinHtlcMsatSpecified bool     `protobuf:"varint,8,opt,name=min_htlc_msat_specified,json=minHtlcMsatSpecified,proto3" json:"min_htlc_msat_specified,omitempty"`
@@ -9787,11 +9820,17 @@ func (m *PolicyUpdateResponse) XXX_DiscardUnknown() {
 var xxx_messageInfo_PolicyUpdateResponse proto.InternalMessageInfo
 
 type ForwardingHistoryRequest struct {
-	/// Start time is the starting point of the forwarding history request. All records beyond this point will be included, respecting the end time, and the index offset.
+	/// Start time is the starting point of the forwarding history request. All
+	/// records beyond this point will be included, respecting the end time, and
+	/// the index offset.
 	StartTime uint64 `protobuf:"varint,1,opt,name=start_time,json=startTime,proto3" json:"start_time,omitempty"`
-	/// End time is the end point of the forwarding history request. The response will carry at most 50k records between the start time and the end time. The index offset can be used to implement pagination.
+	/// End time is the end point of the forwarding history request. The
+	/// response will carry at most 50k records between the start time and the
+	/// end time. The index offset can be used to implement pagination.
 	EndTime uint64 `protobuf:"varint,2,opt,name=end_time,json=endTime,proto3" json:"end_time,omitempty"`
-	/// Index offset is the offset in the time series to start at. As each response can only contain 50k records, callers can use this to skip around within a packed time series.
+	/// Index offset is the offset in the time series to start at. As each
+	/// response can only contain 50k records, callers can use this to skip
+	/// around within a packed time series.
 	IndexOffset uint32 `protobuf:"varint,3,opt,name=index_offset,json=indexOffset,proto3" json:"index_offset,omitempty"`
 	/// The max number of events to return in the response to this query.
 	NumMaxEvents         uint32   `protobuf:"varint,4,opt,name=num_max_events,json=numMaxEvents,proto3" json:"num_max_events,omitempty"`
@@ -9854,23 +9893,29 @@ func (m *ForwardingHistoryRequest) GetNumMaxEvents() uint32 {
 }
 
 type ForwardingEvent struct {
-	/// Timestamp is the time (unix epoch offset) that this circuit was completed.
+	/// Timestamp is the time (unix epoch offset) that this circuit was
+	/// completed.
 	Timestamp uint64 `protobuf:"varint,1,opt,name=timestamp,proto3" json:"timestamp,omitempty"`
 	/// The incoming channel ID that carried the HTLC that created the circuit.
 	ChanIdIn uint64 `protobuf:"varint,2,opt,name=chan_id_in,json=chanIdIn,proto3" json:"chan_id_in,omitempty"`
-	/// The outgoing channel ID that carried the preimage that completed the circuit.
+	/// The outgoing channel ID that carried the preimage that completed the
+	/// circuit.
 	ChanIdOut uint64 `protobuf:"varint,4,opt,name=chan_id_out,json=chanIdOut,proto3" json:"chan_id_out,omitempty"`
-	/// The total amount (in satoshis) of the incoming HTLC that created half the circuit.
+	/// The total amount (in satoshis) of the incoming HTLC that created half
+	/// the circuit.
 	AmtIn uint64 `protobuf:"varint,5,opt,name=amt_in,json=amtIn,proto3" json:"amt_in,omitempty"`
-	/// The total amount (in satoshis) of the outgoing HTLC that created the second half of the circuit.
+	/// The total amount (in satoshis) of the outgoing HTLC that created the
+	/// second half of the circuit.
 	AmtOut uint64 `protobuf:"varint,6,opt,name=amt_out,json=amtOut,proto3" json:"amt_out,omitempty"`
 	/// The total fee (in satoshis) that this payment circuit carried.
 	Fee uint64 `protobuf:"varint,7,opt,name=fee,proto3" json:"fee,omitempty"`
 	/// The total fee (in milli-satoshis) that this payment circuit carried.
 	FeeMsat uint64 `protobuf:"varint,8,opt,name=fee_msat,json=feeMsat,proto3" json:"fee_msat,omitempty"`
-	/// The total amount (in milli-satoshis) of the incoming HTLC that created half the circuit.
+	/// The total amount (in milli-satoshis) of the incoming HTLC that created
+	/// half the circuit.
 	AmtInMsat uint64 `protobuf:"varint,9,opt,name=amt_in_msat,json=amtInMsat,proto3" json:"amt_in_msat,omitempty"`
-	/// The total amount (in milli-satoshis) of the outgoing HTLC that created the second half of the circuit.
+	/// The total amount (in milli-satoshis) of the outgoing HTLC that created
+	/// the second half of the circuit.
 	AmtOutMsat           uint64   `protobuf:"varint,10,opt,name=amt_out_msat,json=amtOutMsat,proto3" json:"amt_out_msat,omitempty"`
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
 	XXX_unrecognized     []byte   `json:"-"`
@@ -9966,9 +10011,11 @@ func (m *ForwardingEvent) GetAmtOutMsat() uint64 {
 }
 
 type ForwardingHistoryResponse struct {
-	/// A list of forwarding events from the time slice of the time series specified in the request.
+	/// A list of forwarding events from the time slice of the time series
+	/// specified in the request.
 	ForwardingEvents []*ForwardingEvent `protobuf:"bytes,1,rep,name=forwarding_events,json=forwardingEvents,proto3" json:"forwarding_events,omitempty"`
-	/// The index of the last time in the set of returned forwarding events. Can be used to seek further, pagination style.
+	/// The index of the last time in the set of returned forwarding events. Can
+	/// be used to seek further, pagination style.
 	LastOffsetIndex      uint32   `protobuf:"varint,2,opt,name=last_offset_index,json=lastOffsetIndex,proto3" json:"last_offset_index,omitempty"`
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
 	XXX_unrecognized     []byte   `json:"-"`

--- a/lnrpc/rpc.proto
+++ b/lnrpc/rpc.proto
@@ -10,19 +10,19 @@ option go_package = "github.com/lightningnetwork/lnd/lnrpc";
  * Comments in this file will be directly parsed into the API
  * Documentation as descriptions of the associated method, message, or field.
  * These descriptions should go right above the definition of the object, and
- * can be in either block or /// comment format. 
- * 
+ * can be in either block or /// comment format.
+ *
  * One edge case exists where a // comment followed by a /// comment in the
  * next line will cause the description not to show up in the documentation. In
  * that instance, simply separate the two comments with a blank line.
- * 
+ *
  * An RPC method can be matched to an lncli command by placing a line in the
  * beginning of the description in exactly the following format:
  * lncli: `methodname`
- * 
+ *
  * Failure to specify the exact name of the command will cause documentation
  * generation to fail.
- * 
+ *
  * More information on how exactly the gRPC documentation is generated from
  * this proto file can be found here:
  * https://github.com/lightninglabs/lightning-api
@@ -47,7 +47,7 @@ service WalletUnlocker {
         };
     }
 
-    /** 
+    /**
     InitWallet is used when lnd is starting up for the first time to fully
     initialize the daemon and its internal wallet. At the very least a wallet
     password must be provided. This will be used to encrypt sensitive material
@@ -83,7 +83,8 @@ service WalletUnlocker {
     ChangePassword changes the password of the encrypted wallet. This will
     automatically unlock the wallet database if successful.
     */
-    rpc ChangePassword (ChangePasswordRequest) returns (ChangePasswordResponse) {
+    rpc ChangePassword (ChangePasswordRequest)
+        returns (ChangePasswordResponse) {
         option (google.api.http) = {
             post: "/v1/changepassword"
             body: "*"
@@ -230,7 +231,8 @@ service Lightning {
     ChannelBalance returns the total funds available across all open channels
     in satoshis.
     */
-    rpc ChannelBalance (ChannelBalanceRequest) returns (ChannelBalanceResponse) {
+    rpc ChannelBalance (ChannelBalanceRequest)
+        returns (ChannelBalanceResponse) {
         option (google.api.http) = {
             get: "/v1/balance/channels"
         };
@@ -272,7 +274,7 @@ service Lightning {
 
     /** lncli: `listunspent`
     ListUnspent returns a list of all utxos spendable by the wallet with a
-	number of confirmations between the specified minimum and maximum.
+        number of confirmations between the specified minimum and maximum.
     */
     rpc ListUnspent (ListUnspentRequest) returns (ListUnspentResponse) {
         option (google.api.http) = {
@@ -285,7 +287,8 @@ service Lightning {
     the client in which any newly discovered transactions relevant to the
     wallet are sent over.
     */
-    rpc SubscribeTransactions (GetTransactionsRequest) returns (stream Transaction);
+    rpc SubscribeTransactions (GetTransactionsRequest)
+        returns (stream Transaction);
 
     /** lncli: `sendmany`
     SendMany handles a request for a transaction that creates multiple specified
@@ -346,7 +349,8 @@ service Lightning {
     given pubKey. In the case that we currently have a pending or active channel
     with the target peer, then this action will be not be allowed.
     */
-    rpc DisconnectPeer (DisconnectPeerRequest) returns (DisconnectPeerResponse) {
+    rpc DisconnectPeer (DisconnectPeerRequest)
+        returns (DisconnectPeerResponse) {
         option (google.api.http) = {
             delete: "/v1/peers/{pub_key}"
         };
@@ -386,9 +390,10 @@ service Lightning {
     workflow and is waiting for confirmations for the funding txn, or is in the
     process of closure, either initiated cooperatively or non-cooperatively.
     */
-    rpc PendingChannels (PendingChannelsRequest) returns (PendingChannelsResponse) {
+    rpc PendingChannels (PendingChannelsRequest)
+        returns (PendingChannelsResponse) {
         option (google.api.http) = {
-           get: "/v1/channels/pending"
+            get: "/v1/channels/pending"
         };
     }
 
@@ -408,13 +413,15 @@ service Lightning {
     sent over. Events include new active channels, inactive channels, and closed
     channels.
     */
-    rpc SubscribeChannelEvents (ChannelEventSubscription) returns (stream ChannelEventUpdate);
+    rpc SubscribeChannelEvents (ChannelEventSubscription)
+        returns (stream ChannelEventUpdate);
 
     /** lncli: `closedchannels`
     ClosedChannels returns a description of all the closed channels that
     this node was a participant in.
     */
-    rpc ClosedChannels (ClosedChannelsRequest) returns (ClosedChannelsResponse) {
+    rpc ClosedChannels (ClosedChannelsRequest)
+        returns (ClosedChannelsResponse) {
         option (google.api.http) = {
             get: "/v1/channels/closed"
         };
@@ -464,7 +471,8 @@ service Lightning {
     node operators to specify their own criteria for accepting inbound channels
     through a single persistent connection.
     */
-    rpc ChannelAcceptor (stream ChannelAcceptResponse) returns (stream ChannelAcceptRequest);
+    rpc ChannelAcceptor (stream ChannelAcceptResponse)
+        returns (stream ChannelAcceptRequest);
 
     /** lncli: `closechannel`
     CloseChannel attempts to close an active channel identified by its channel
@@ -487,7 +495,8 @@ service Lightning {
     channels due to bugs fixed in newer versions of lnd. Only available
     when in debug builds of lnd.
     */
-    rpc AbandonChannel (AbandonChannelRequest) returns (AbandonChannelResponse) {
+    rpc AbandonChannel (AbandonChannelRequest)
+        returns (AbandonChannelResponse) {
         option (google.api.http) = {
             delete: "/v1/channels/abandon/{channel_point.funding_txid_str}/{channel_point.output_index}"
         };
@@ -611,7 +620,8 @@ service Lightning {
     /**
     DeleteAllPayments deletes all outgoing payments from DB.
     */
-    rpc DeleteAllPayments (DeleteAllPaymentsRequest) returns (DeleteAllPaymentsResponse) {
+    rpc DeleteAllPayments (DeleteAllPaymentsRequest)
+        returns (DeleteAllPaymentsResponse) {
         option (google.api.http) = {
             delete: "/v1/payments"
         };
@@ -690,7 +700,8 @@ service Lightning {
     channels being advertised, updates in the routing policy for a directional
     channel edge, and when channels are closed on-chain.
     */
-    rpc SubscribeChannelGraph (GraphTopologySubscription) returns (stream GraphTopologyUpdate);
+    rpc SubscribeChannelGraph (GraphTopologySubscription)
+        returns (stream GraphTopologyUpdate);
 
     /** lncli: `debuglevel`
     DebugLevel allows a caller to programmatically set the logging verbosity of
@@ -714,7 +725,8 @@ service Lightning {
     UpdateChannelPolicy allows the caller to update the fee schedule and
     channel policies for all channels globally, or a particular channel.
     */
-    rpc UpdateChannelPolicy (PolicyUpdateRequest) returns (PolicyUpdateResponse) {
+    rpc UpdateChannelPolicy (PolicyUpdateRequest)
+        returns (PolicyUpdateResponse) {
         option (google.api.http) = {
             post: "/v1/chanpolicy"
             body: "*"
@@ -733,7 +745,8 @@ service Lightning {
     the index offset of the last entry. The index offset can be provided to the
     request to allow the caller to skip a series of records.
     */
-    rpc ForwardingHistory (ForwardingHistoryRequest) returns (ForwardingHistoryResponse) {
+    rpc ForwardingHistory (ForwardingHistoryRequest)
+        returns (ForwardingHistoryResponse) {
         option (google.api.http) = {
             post: "/v1/switch"
             body: "*"
@@ -748,7 +761,8 @@ service Lightning {
     method once lnd is running, or via the InitWallet and UnlockWallet methods
     from the WalletUnlocker service.
     */
-    rpc ExportChannelBackup (ExportChannelBackupRequest) returns (ChannelBackup) {
+    rpc ExportChannelBackup (ExportChannelBackupRequest)
+        returns (ChannelBackup) {
         option (google.api.http) = {
             get: "/v1/channels/backup/{chan_point.funding_txid_str}/{chan_point.output_index}"
         };
@@ -761,7 +775,8 @@ service Lightning {
     as well, which contains a single encrypted blob containing the backups of
     each channel.
     */
-    rpc ExportAllChannelBackups (ChanBackupExportRequest) returns (ChanBackupSnapshot) {
+    rpc ExportAllChannelBackups (ChanBackupExportRequest)
+        returns (ChanBackupSnapshot) {
         option (google.api.http) = {
             get: "/v1/channels/backup"
         };
@@ -772,7 +787,8 @@ service Lightning {
     snapshot. This method will accept either a packed Single or a packed Multi.
     Specifying both will result in an error.
     */
-    rpc VerifyChanBackup (ChanBackupSnapshot) returns (VerifyChanBackupResponse) {
+    rpc VerifyChanBackup (ChanBackupSnapshot)
+        returns (VerifyChanBackupResponse) {
         option (google.api.http) = {
             post: "/v1/channels/backup/verify"
             body: "*"
@@ -785,7 +801,8 @@ service Lightning {
     remaining within the channel. If we are able to unpack the backup, then the
     new channel will be shown under listchannels, as well as pending channels.
     */
-    rpc RestoreChannelBackups (RestoreChanBackupRequest) returns (RestoreBackupResponse) {
+    rpc RestoreChannelBackups (RestoreChanBackupRequest)
+        returns (RestoreBackupResponse) {
         option (google.api.http) = {
             post: "/v1/channels/backup/restore"
             body: "*"
@@ -801,7 +818,8 @@ service Lightning {
     ups, but the updated set of encrypted multi-chan backups with the closed
     channel(s) removed.
     */
-    rpc SubscribeChannelBackups (ChannelBackupSubscription) returns (stream ChanBackupSnapshot) {
+    rpc SubscribeChannelBackups (ChannelBackupSubscription)
+        returns (stream ChanBackupSnapshot) {
     };
 
     /** lncli: `bakemacaroon`
@@ -853,7 +871,7 @@ message Transaction {
     /// The height of the block this transaction was included in
     int32 block_height = 5;
 
-    /// Timestamp of this transaction 
+    /// Timestamp of this transaction
     int64 time_stamp = 6;
 
     /// Fees paid for this transaction
@@ -964,14 +982,14 @@ message SendRequest {
     */
     bytes last_hop_pubkey = 13;
 
-    /** 
+    /**
     An optional maximum total time lock for the route. This should not exceed
     lnd's `--max-cltv-expiry` setting. If zero, then the value of
     `--max-cltv-expiry` is enforced.
     */
     uint32 cltv_limit = 10;
 
-    /** 
+    /**
     An optional field that can be used to pass an arbitrary set of TLV records
     to a peer which understands the new records. This can be used to pass
     application specific data during the payment attempt. Record types are
@@ -1029,7 +1047,8 @@ message ChannelAcceptRequest {
     /// The pending channel id.
     bytes pending_chan_id = 3;
 
-    /// The funding amount in satoshis that initiator wishes to use in the channel.
+    /// The funding amount in satoshis that initiator wishes to use in the
+    /// channel.
     uint64 funding_amt = 4;
 
     /// The push amount of the proposed channel in millisatoshis.
@@ -1038,28 +1057,32 @@ message ChannelAcceptRequest {
     /// The dust limit of the initiator's commitment tx.
     uint64 dust_limit = 6;
 
-    /// The maximum amount of coins in millisatoshis that can be pending in this channel.
+    /// The maximum amount of coins in millisatoshis that can be pending in this
+    /// channel.
     uint64 max_value_in_flight = 7;
 
-    /// The minimum amount of satoshis the initiator requires us to have at all times.
+    /// The minimum amount of satoshis the initiator requires us to have at all
+    /// times.
     uint64 channel_reserve = 8;
 
     /// The smallest HTLC in millisatoshis that the initiator will accept.
     uint64 min_htlc = 9;
 
-    /// The initial fee rate that the initiator suggests for both commitment transactions.
+    /// The initial fee rate that the initiator suggests for both commitment
+    /// transactions.
     uint64 fee_per_kw = 10;
 
     /**
-    The number of blocks to use for the relative time lock in the pay-to-self output
-    of both commitment transactions.
+    The number of blocks to use for the relative time lock in the pay-to-self
+    output of both commitment transactions.
     */
     uint32 csv_delay = 11;
 
     /// The total number of incoming HTLC's that the initiator will accept.
     uint32 max_accepted_htlcs = 12;
 
-    /// A bit-field which the initiator uses to specify proposed channel behavior.
+    /// A bit-field which the initiator uses to specify proposed channel
+    /// behavior.
     uint32 channel_flags = 13;
 }
 
@@ -1105,7 +1128,8 @@ message LightningAddress {
     /// The identity pubkey of the Lightning node
     string pubkey = 1;
 
-    /// The network location of the lightning node, e.g. `69.69.69.69:1337` or `localhost:10011`
+    /// The network location of the lightning node, e.g. `69.69.69.69:1337` or
+    /// `localhost:10011`
     string host = 2;
 }
 
@@ -1113,7 +1137,8 @@ message EstimateFeeRequest {
     /// The map from addresses to amounts for the transaction.
     map<string, int64> AddrToAmount = 1;
 
-    /// The target number of blocks that this transaction should be confirmed by.
+    /// The target number of blocks that this transaction should be confirmed
+    /// by.
     int32 target_conf = 2;
 }
 
@@ -1129,10 +1154,12 @@ message SendManyRequest {
     /// The map from addresses to amounts
     map<string, int64> AddrToAmount = 1;
 
-    /// The target number of blocks that this transaction should be confirmed by.
+    /// The target number of blocks that this transaction should be confirmed
+    /// by.
     int32 target_conf = 3;
 
-    /// A manual fee rate set in sat/byte that should be used when crafting the transaction.
+    /// A manual fee rate set in sat/byte that should be used when crafting the
+    /// transaction.
     int64 sat_per_byte = 5;
 }
 message SendManyResponse {
@@ -1141,16 +1168,18 @@ message SendManyResponse {
 }
 
 message SendCoinsRequest {
-    /// The address to send coins to 
+    /// The address to send coins to
     string addr = 1;
 
     /// The amount in satoshis to send
     int64 amount = 2;
 
-    /// The target number of blocks that this transaction should be confirmed by.
+    /// The target number of blocks that this transaction should be confirmed
+    /// by.
     int32 target_conf = 3;
 
-    /// A manual fee rate set in sat/byte that should be used when crafting the transaction.
+    /// A manual fee rate set in sat/byte that should be used when crafting the
+    /// transaction.
     int64 sat_per_byte = 5;
 
     /**
@@ -1177,7 +1206,7 @@ message ListUnspentResponse {
     repeated Utxo utxos = 1;
 }
 
-/** 
+/**
 `AddressType` has to be one of:
 
 - `p2wkh`: Pay to witness key hash (`WITNESS_PUBKEY_HASH` = 0)
@@ -1352,7 +1381,7 @@ message Channel {
     If true, then this channel uses the modern commitment format where the key
     in the output of the remote party does not change each state. This makes
     back up and recovery easier as when the channel is closed, the funds go
-    directly to that key. 
+    directly to that key.
     */
     bool static_remote_key = 22;
 
@@ -1365,7 +1394,8 @@ message Channel {
 
     /**
     The number of seconds that the remote peer has been observed as being online
-    by the channel scoring system over the lifetime of the channel [EXPERIMENTAL].
+    by the channel scoring system over the lifetime of the channel
+    [EXPERIMENTAL].
     */
     int64 uptime = 24;
 
@@ -1378,7 +1408,6 @@ message Channel {
     */
     string close_address = 25;
 }
-
 
 message ListChannelsRequest {
     bool active_only = 1;
@@ -1398,10 +1427,10 @@ message ListChannelsResponse {
 }
 
 message ChannelCloseSummary {
-    /// The outpoint (txid:index) of the funding transaction. 
+    /// The outpoint (txid:index) of the funding transaction.
     string channel_point = 1;
 
-    ///  The unique channel ID for the channel. 
+    ///  The unique channel ID for the channel.
     uint64 chan_id = 2 [jstype = JS_STRING];
 
     /// The hash of the genesis block that this channel resides within.
@@ -1548,7 +1577,6 @@ message PeerEvent {
 message GetInfoRequest {
 }
 message GetInfoResponse {
-
     /// The version of the LND software that the node is running.
     string version = 14;
 
@@ -1588,9 +1616,9 @@ message GetInfoResponse {
     // Whether we consider ourselves synced with the public channel graph.
     bool synced_to_graph = 18;
 
-    /** 
-    Whether the current node is connected to testnet. This field is 
-    deprecated and the network field should be used instead 
+    /**
+    Whether the current node is connected to testnet. This field is
+    deprecated and the network field should be used instead
     **/
     bool testnet = 10 [deprecated = true];
 
@@ -1642,13 +1670,16 @@ message CloseChannelRequest {
     */
     ChannelPoint channel_point = 1;
 
-    /// If true, then the channel will be closed forcibly. This means the current commitment transaction will be signed and broadcast.
+    /// If true, then the channel will be closed forcibly. This means the
+    /// current commitment transaction will be signed and broadcast.
     bool force = 2;
 
-    /// The target number of blocks that the closure transaction should be confirmed by.
+    /// The target number of blocks that the closure transaction should be
+    /// confirmed by.
     int32 target_conf = 3;
 
-    /// A manual fee rate set in sat/byte that should be used when crafting the closure transaction.
+    /// A manual fee rate set in sat/byte that should be used when crafting the
+    /// closure transaction.
     int64 sat_per_byte = 4;
 
     /*
@@ -1688,28 +1719,36 @@ message OpenChannelRequest {
     /// The number of satoshis the wallet should commit to the channel
     int64 local_funding_amount = 4;
 
-    /// The number of satoshis to push to the remote side as part of the initial commitment state
+    /// The number of satoshis to push to the remote side as part of the initial
+    /// commitment state
     int64 push_sat = 5;
 
-    /// The target number of blocks that the funding transaction should be confirmed by.
+    /// The target number of blocks that the funding transaction should be
+    /// confirmed by.
     int32 target_conf = 6;
 
-    /// A manual fee rate set in sat/byte that should be used when crafting the funding transaction.
+    /// A manual fee rate set in sat/byte that should be used when crafting the
+    /// funding transaction.
     int64 sat_per_byte = 7;
 
-    /// Whether this channel should be private, not announced to the greater network.
+    /// Whether this channel should be private, not announced to the greater
+    /// network.
     bool private = 8;
 
-    /// The minimum value in millisatoshi we will require for incoming HTLCs on the channel.
+    /// The minimum value in millisatoshi we will require for incoming HTLCs on
+    /// the channel.
     int64 min_htlc_msat = 9;
 
-    /// The delay we require on the remote's commitment transaction. If this is not set, it will be scaled automatically with the channel size.
+    /// The delay we require on the remote's commitment transaction. If this is
+    /// not set, it will be scaled automatically with the channel size.
     uint32 remote_csv_delay = 10;
 
-    /// The minimum number of confirmations each one of your outputs used for the funding transaction must satisfy.
+    /// The minimum number of confirmations each one of your outputs used for
+    /// the funding transaction must satisfy.
     int32 min_confs = 11;
 
-    /// Whether unconfirmed outputs should be used as inputs for the funding transaction.
+    /// Whether unconfirmed outputs should be used as inputs for the funding
+    /// transaction.
     bool spend_unconfirmed = 12;
 
     /*
@@ -1756,12 +1795,12 @@ message KeyLocator {
 
 message KeyDescriptor {
     /**
-    The raw bytes of the key being identified. 
+    The raw bytes of the key being identified.
     */
     bytes raw_key_bytes = 1;
 
-    /** 
-    The key locator that identifies which key to use for signing. 
+    /**
+    The key locator that identifies which key to use for signing.
     */
     KeyLocator key_loc = 2;
 }
@@ -1820,7 +1859,6 @@ message FundingStateStepResp {
 }
 
 message PendingHTLC {
-
     /// The direction within the channel that the htlc was sent
     bool incoming = 1;
 
@@ -1856,7 +1894,8 @@ message PendingChannelsResponse {
         int64 local_balance = 4;
         int64 remote_balance = 5;
 
-        /// The minimum satoshis this node is required to reserve in its balance.
+        /// The minimum satoshis this node is required to reserve in its
+        /// balance.
         int64 local_chan_reserve_sat = 6;
 
         /**
@@ -2062,14 +2101,14 @@ message QueryRoutesRequest {
     */
     repeated NodePair ignored_pairs = 10;
 
-    /** 
+    /**
     An optional maximum total time lock for the route. If the source is empty or
     ourselves, this should not exceed lnd's `--max-cltv-expiry` setting. If
     zero, then the value of `--max-cltv-expiry` is used as the limit.
     */
     uint32 cltv_limit = 11;
 
-    /** 
+    /**
     An optional field that can be used to pass an arbitrary set of TLV records
     to a peer which understands the new records. This can be used to pass
     application specific data during the payment attempt. If the destination
@@ -2166,7 +2205,7 @@ message Hop {
     */
     string pub_key = 8;
 
-    /** 
+    /**
     If set to true, then this hop will be encoded using the new variable length
     TLV format. Note that if any custom tlv_records below are specified, then
     this field MUST be set to true for them to be encoded properly.
@@ -2215,7 +2254,6 @@ route is only selected as valid if all the channels have sufficient capacity to
 carry the initial payment amount after fees are accounted for.
 */
 message Route {
-
     /**
     The cumulative (final) time lock across the entire route. This is the CLTV
     value that should be extended to the first hop in the route. All other hops
@@ -2257,7 +2295,7 @@ message Route {
 }
 
 message NodeInfoRequest {
-    /// The 33-byte hex-encoded compressed public of the target node 
+    /// The 33-byte hex-encoded compressed public of the target node
     string pub_key = 1;
 
     /// If true, will include all known channels associated with the node.
@@ -2265,7 +2303,6 @@ message NodeInfoRequest {
 }
 
 message NodeInfo {
-
     /**
     An individual vertex/node within the channel graph. A node is
     connected to other nodes by one or more channel edges emanating from it. As
@@ -2322,7 +2359,6 @@ stored. The other portions relevant to routing policy of a channel are stored
 within a ChannelEdgePolicy for each direction of the channel.
 */
 message ChannelEdge {
-
     /**
     The unique channel ID for the channel. The first 3 bytes are the block
     height, the next 3 the index within the block, and the last 2 bytes are the
@@ -2746,7 +2782,6 @@ message InvoiceSubscription {
     uint64 settle_index = 2;
 }
 
-
 message Payment {
     /// The payment hash
     string payment_hash = 1;
@@ -2851,7 +2886,6 @@ message AbandonChannelRequest {
 message AbandonChannelResponse {
 }
 
-
 message DebugLevelRequest {
     bool show = 1;
     string level_spec = 2;
@@ -2918,23 +2952,29 @@ message ChannelFeeReport {
     /// The base fee charged regardless of the number of milli-satoshis sent.
     int64 base_fee_msat = 2;
 
-    /// The amount charged per milli-satoshis transferred expressed in millionths of a satoshi.
+    /// The amount charged per milli-satoshis transferred expressed in
+    /// millionths of a satoshi.
     int64 fee_per_mil = 3;
 
-    /// The effective fee rate in milli-satoshis. Computed by dividing the fee_per_mil value by 1 million.
+    /// The effective fee rate in milli-satoshis. Computed by dividing the
+    /// fee_per_mil value by 1 million.
     double fee_rate = 4;
 }
 message FeeReportResponse {
-    /// An array of channel fee reports which describes the current fee schedule for each channel.
+    /// An array of channel fee reports which describes the current fee schedule
+    /// for each channel.
     repeated ChannelFeeReport channel_fees = 1;
 
-    /// The total amount of fee revenue (in satoshis) the switch has collected over the past 24 hrs.
+    /// The total amount of fee revenue (in satoshis) the switch has collected
+    /// over the past 24 hrs.
     uint64 day_fee_sum = 2;
 
-    /// The total amount of fee revenue (in satoshis) the switch has collected over the past 1 week.
+    /// The total amount of fee revenue (in satoshis) the switch has collected
+    /// over the past 1 week.
     uint64 week_fee_sum = 3;
 
-    /// The total amount of fee revenue (in satoshis) the switch has collected over the past 1 month.
+    /// The total amount of fee revenue (in satoshis) the switch has collected
+    /// over the past 1 month.
     uint64 month_fee_sum = 4;
 }
 
@@ -2950,16 +2990,19 @@ message PolicyUpdateRequest {
     /// The base fee charged regardless of the number of milli-satoshis sent.
     int64 base_fee_msat = 3;
 
-    /// The effective fee rate in milli-satoshis. The precision of this value goes up to 6 decimal places, so 1e-6.
+    /// The effective fee rate in milli-satoshis. The precision of this value
+    /// goes up to 6 decimal places, so 1e-6.
     double fee_rate = 4;
 
     /// The required timelock delta for HTLCs forwarded over the channel.
     uint32 time_lock_delta = 5;
 
-    /// If set, the maximum HTLC size in milli-satoshis. If unset, the maximum HTLC will be unchanged.
+    /// If set, the maximum HTLC size in milli-satoshis. If unset, the maximum
+    /// HTLC will be unchanged.
     uint64 max_htlc_msat = 6;
 
-    /// The minimum HTLC size in milli-satoshis. Only applied if min_htlc_msat_specified is true.
+    /// The minimum HTLC size in milli-satoshis. Only applied if
+    /// min_htlc_msat_specified is true.
     uint64 min_htlc_msat = 7;
 
     /// If true, min_htlc_msat is applied.
@@ -2969,32 +3012,42 @@ message PolicyUpdateResponse {
 }
 
 message ForwardingHistoryRequest {
-    /// Start time is the starting point of the forwarding history request. All records beyond this point will be included, respecting the end time, and the index offset.
+    /// Start time is the starting point of the forwarding history request. All
+    /// records beyond this point will be included, respecting the end time, and
+    /// the index offset.
     uint64 start_time = 1;
 
-    /// End time is the end point of the forwarding history request. The response will carry at most 50k records between the start time and the end time. The index offset can be used to implement pagination.
+    /// End time is the end point of the forwarding history request. The
+    /// response will carry at most 50k records between the start time and the
+    /// end time. The index offset can be used to implement pagination.
     uint64 end_time = 2;
 
-    /// Index offset is the offset in the time series to start at. As each response can only contain 50k records, callers can use this to skip around within a packed time series.
+    /// Index offset is the offset in the time series to start at. As each
+    /// response can only contain 50k records, callers can use this to skip
+    /// around within a packed time series.
     uint32 index_offset = 3;
 
     /// The max number of events to return in the response to this query.
     uint32 num_max_events = 4;
 }
 message ForwardingEvent {
-    /// Timestamp is the time (unix epoch offset) that this circuit was completed.
+    /// Timestamp is the time (unix epoch offset) that this circuit was
+    /// completed.
     uint64 timestamp = 1;
 
     /// The incoming channel ID that carried the HTLC that created the circuit.
     uint64 chan_id_in = 2 [jstype = JS_STRING];
 
-    /// The outgoing channel ID that carried the preimage that completed the circuit.
+    /// The outgoing channel ID that carried the preimage that completed the
+    /// circuit.
     uint64 chan_id_out = 4 [jstype = JS_STRING];
 
-    /// The total amount (in satoshis) of the incoming HTLC that created half the circuit.
+    /// The total amount (in satoshis) of the incoming HTLC that created half
+    /// the circuit.
     uint64 amt_in = 5;
 
-    /// The total amount (in satoshis) of the outgoing HTLC that created the second half of the circuit.
+    /// The total amount (in satoshis) of the outgoing HTLC that created the
+    /// second half of the circuit.
     uint64 amt_out = 6;
 
     /// The total fee (in satoshis) that this payment circuit carried.
@@ -3003,10 +3056,12 @@ message ForwardingEvent {
     /// The total fee (in milli-satoshis) that this payment circuit carried.
     uint64 fee_msat = 8;
 
-    /// The total amount (in milli-satoshis) of the incoming HTLC that created half the circuit.
+    /// The total amount (in milli-satoshis) of the incoming HTLC that created
+    /// half the circuit.
     uint64 amt_in_msat = 9;
 
-    /// The total amount (in milli-satoshis) of the outgoing HTLC that created the second half of the circuit.
+    /// The total amount (in milli-satoshis) of the outgoing HTLC that created
+    /// the second half of the circuit.
     uint64 amt_out_msat = 10;
 
     // TODO(roasbeef): add settlement latency?
@@ -3014,10 +3069,12 @@ message ForwardingEvent {
     //  * also list failures?
 }
 message ForwardingHistoryResponse {
-    /// A list of forwarding events from the time slice of the time series specified in the request.
+    /// A list of forwarding events from the time slice of the time series
+    /// specified in the request.
     repeated ForwardingEvent forwarding_events = 1;
 
-    /// The index of the last time in the set of returned forwarding events. Can be used to seek further, pagination style.
+    /// The index of the last time in the set of returned forwarding events. Can
+    /// be used to seek further, pagination style.
     uint32 last_offset_index = 2;
 }
 
@@ -3118,7 +3175,6 @@ message BakeMacaroonResponse {
     string macaroon = 1;
 }
 
-
 message Failure {
     enum FailureCode {
         /**
@@ -3198,7 +3254,6 @@ message Failure {
     /// A failure type-dependent block height.
     uint32 height = 9;
 }
-
 
 message ChannelUpdate {
     /**

--- a/lnrpc/rpc.swagger.json
+++ b/lnrpc/rpc.swagger.json
@@ -481,7 +481,7 @@
           },
           {
             "name": "force",
-            "description": "/ If true, then the channel will be closed forcibly. This means the current commitment transaction will be signed and broadcast.",
+            "description": "/ If true, then the channel will be closed forcibly. This means the\n/ current commitment transaction will be signed and broadcast.",
             "in": "query",
             "required": false,
             "type": "boolean",
@@ -489,7 +489,7 @@
           },
           {
             "name": "target_conf",
-            "description": "/ The target number of blocks that the closure transaction should be confirmed by.",
+            "description": "/ The target number of blocks that the closure transaction should be\n/ confirmed by.",
             "in": "query",
             "required": false,
             "type": "integer",
@@ -497,7 +497,7 @@
           },
           {
             "name": "sat_per_byte",
-            "description": "/ A manual fee rate set in sat/byte that should be used when crafting the closure transaction.",
+            "description": "/ A manual fee rate set in sat/byte that should be used when crafting the\n/ closure transaction.",
             "in": "query",
             "required": false,
             "type": "string",
@@ -815,7 +815,7 @@
           },
           {
             "name": "cltv_limit",
-            "description": "* \nAn optional maximum total time lock for the route. If the source is empty or\nourselves, this should not exceed lnd's `--max-cltv-expiry` setting. If\nzero, then the value of `--max-cltv-expiry` is used as the limit.",
+            "description": "*\nAn optional maximum total time lock for the route. If the source is empty or\nourselves, this should not exceed lnd's `--max-cltv-expiry` setting. If\nzero, then the value of `--max-cltv-expiry` is used as the limit.",
             "in": "query",
             "required": false,
             "type": "integer",
@@ -875,7 +875,7 @@
     },
     "/v1/initwallet": {
       "post": {
-        "summary": "* \nInitWallet is used when lnd is starting up for the first time to fully\ninitialize the daemon and its internal wallet. At the very least a wallet\npassword must be provided. This will be used to encrypt sensitive material\non disk.",
+        "summary": "*\nInitWallet is used when lnd is starting up for the first time to fully\ninitialize the daemon and its internal wallet. At the very least a wallet\npassword must be provided. This will be used to encrypt sensitive material\non disk.",
         "description": "In the case of a recovery scenario, the user can also specify their aezeed\nmnemonic and passphrase. If set, then the daemon will use this prior state\nto initialize its internal wallet.\n\nAlternatively, this can be used along with the GenSeed RPC to obtain a\nseed, then present it to the user. Once it has been verified by the user,\nthe seed can be fed into this RPC in order to commit the new wallet.",
         "operationId": "InitWallet",
         "responses": {
@@ -1354,7 +1354,7 @@
         "parameters": [
           {
             "name": "target_conf",
-            "description": "/ The target number of blocks that this transaction should be confirmed by.",
+            "description": "/ The target number of blocks that this transaction should be confirmed\n/ by.",
             "in": "query",
             "required": false,
             "type": "integer",
@@ -1647,7 +1647,7 @@
         "local_chan_reserve_sat": {
           "type": "string",
           "format": "int64",
-          "description": "/ The minimum satoshis this node is required to reserve in its balance."
+          "description": "/ The minimum satoshis this node is required to reserve in its\n/ balance."
         },
         "remote_chan_reserve_sat": {
           "type": "string",
@@ -1730,7 +1730,7 @@
       ],
       "default": "WITNESS_PUBKEY_HASH",
       "description": "- `p2wkh`: Pay to witness key hash (`WITNESS_PUBKEY_HASH` = 0)\n- `np2wkh`: Pay to nested witness key hash (`NESTED_PUBKEY_HASH` = 1)",
-      "title": "* \n`AddressType` has to be one of:"
+      "title": "*\n`AddressType` has to be one of:"
     },
     "lnrpcBakeMacaroonRequest": {
       "type": "object",
@@ -1945,7 +1945,7 @@
         "uptime": {
           "type": "string",
           "format": "int64",
-          "description": "*\nThe number of seconds that the remote peer has been observed as being online\nby the channel scoring system over the lifetime of the channel [EXPERIMENTAL]."
+          "description": "*\nThe number of seconds that the remote peer has been observed as being online\nby the channel scoring system over the lifetime of the channel\n[EXPERIMENTAL]."
         },
         "close_address": {
           "type": "string",
@@ -1974,7 +1974,7 @@
         "funding_amt": {
           "type": "string",
           "format": "uint64",
-          "description": "/ The funding amount in satoshis that initiator wishes to use in the channel."
+          "description": "/ The funding amount in satoshis that initiator wishes to use in the\n/ channel."
         },
         "push_amt": {
           "type": "string",
@@ -1989,12 +1989,12 @@
         "max_value_in_flight": {
           "type": "string",
           "format": "uint64",
-          "description": "/ The maximum amount of coins in millisatoshis that can be pending in this channel."
+          "description": "/ The maximum amount of coins in millisatoshis that can be pending in this\n/ channel."
         },
         "channel_reserve": {
           "type": "string",
           "format": "uint64",
-          "description": "/ The minimum amount of satoshis the initiator requires us to have at all times."
+          "description": "/ The minimum amount of satoshis the initiator requires us to have at all\n/ times."
         },
         "min_htlc": {
           "type": "string",
@@ -2004,12 +2004,12 @@
         "fee_per_kw": {
           "type": "string",
           "format": "uint64",
-          "description": "/ The initial fee rate that the initiator suggests for both commitment transactions."
+          "description": "/ The initial fee rate that the initiator suggests for both commitment\n/ transactions."
         },
         "csv_delay": {
           "type": "integer",
           "format": "int64",
-          "description": "*\nThe number of blocks to use for the relative time lock in the pay-to-self output\nof both commitment transactions."
+          "description": "*\nThe number of blocks to use for the relative time lock in the pay-to-self\noutput of both commitment transactions."
         },
         "max_accepted_htlcs": {
           "type": "integer",
@@ -2019,7 +2019,7 @@
         "channel_flags": {
           "type": "integer",
           "format": "int64",
-          "description": "/ A bit-field which the initiator uses to specify proposed channel behavior."
+          "description": "/ A bit-field which the initiator uses to specify proposed channel\n/ behavior."
         }
       }
     },
@@ -2238,12 +2238,12 @@
         "fee_per_mil": {
           "type": "string",
           "format": "int64",
-          "description": "/ The amount charged per milli-satoshis transferred expressed in millionths of a satoshi."
+          "description": "/ The amount charged per milli-satoshis transferred expressed in\n/ millionths of a satoshi."
         },
         "fee_rate": {
           "type": "number",
           "format": "double",
-          "description": "/ The effective fee rate in milli-satoshis. Computed by dividing the fee_per_mil value by 1 million."
+          "description": "/ The effective fee rate in milli-satoshis. Computed by dividing the\n/ fee_per_mil value by 1 million."
         }
       }
     },
@@ -2573,22 +2573,22 @@
           "items": {
             "$ref": "#/definitions/lnrpcChannelFeeReport"
           },
-          "description": "/ An array of channel fee reports which describes the current fee schedule for each channel."
+          "description": "/ An array of channel fee reports which describes the current fee schedule\n/ for each channel."
         },
         "day_fee_sum": {
           "type": "string",
           "format": "uint64",
-          "description": "/ The total amount of fee revenue (in satoshis) the switch has collected over the past 24 hrs."
+          "description": "/ The total amount of fee revenue (in satoshis) the switch has collected\n/ over the past 24 hrs."
         },
         "week_fee_sum": {
           "type": "string",
           "format": "uint64",
-          "description": "/ The total amount of fee revenue (in satoshis) the switch has collected over the past 1 week."
+          "description": "/ The total amount of fee revenue (in satoshis) the switch has collected\n/ over the past 1 week."
         },
         "month_fee_sum": {
           "type": "string",
           "format": "uint64",
-          "description": "/ The total amount of fee revenue (in satoshis) the switch has collected over the past 1 month."
+          "description": "/ The total amount of fee revenue (in satoshis) the switch has collected\n/ over the past 1 month."
         }
       }
     },
@@ -2598,7 +2598,7 @@
         "timestamp": {
           "type": "string",
           "format": "uint64",
-          "description": "/ Timestamp is the time (unix epoch offset) that this circuit was completed."
+          "description": "/ Timestamp is the time (unix epoch offset) that this circuit was\n/ completed."
         },
         "chan_id_in": {
           "type": "string",
@@ -2608,17 +2608,17 @@
         "chan_id_out": {
           "type": "string",
           "format": "uint64",
-          "description": "/ The outgoing channel ID that carried the preimage that completed the circuit."
+          "description": "/ The outgoing channel ID that carried the preimage that completed the\n/ circuit."
         },
         "amt_in": {
           "type": "string",
           "format": "uint64",
-          "description": "/ The total amount (in satoshis) of the incoming HTLC that created half the circuit."
+          "description": "/ The total amount (in satoshis) of the incoming HTLC that created half\n/ the circuit."
         },
         "amt_out": {
           "type": "string",
           "format": "uint64",
-          "description": "/ The total amount (in satoshis) of the outgoing HTLC that created the second half of the circuit."
+          "description": "/ The total amount (in satoshis) of the outgoing HTLC that created the\n/ second half of the circuit."
         },
         "fee": {
           "type": "string",
@@ -2633,12 +2633,12 @@
         "amt_in_msat": {
           "type": "string",
           "format": "uint64",
-          "description": "/ The total amount (in milli-satoshis) of the incoming HTLC that created half the circuit."
+          "description": "/ The total amount (in milli-satoshis) of the incoming HTLC that created\n/ half the circuit."
         },
         "amt_out_msat": {
           "type": "string",
           "format": "uint64",
-          "description": "/ The total amount (in milli-satoshis) of the outgoing HTLC that created the second half of the circuit."
+          "description": "/ The total amount (in milli-satoshis) of the outgoing HTLC that created\n/ the second half of the circuit."
         }
       }
     },
@@ -2648,17 +2648,17 @@
         "start_time": {
           "type": "string",
           "format": "uint64",
-          "description": "/ Start time is the starting point of the forwarding history request. All records beyond this point will be included, respecting the end time, and the index offset."
+          "description": "/ Start time is the starting point of the forwarding history request. All\n/ records beyond this point will be included, respecting the end time, and\n/ the index offset."
         },
         "end_time": {
           "type": "string",
           "format": "uint64",
-          "description": "/ End time is the end point of the forwarding history request. The response will carry at most 50k records between the start time and the end time. The index offset can be used to implement pagination."
+          "description": "/ End time is the end point of the forwarding history request. The\n/ response will carry at most 50k records between the start time and the\n/ end time. The index offset can be used to implement pagination."
         },
         "index_offset": {
           "type": "integer",
           "format": "int64",
-          "description": "/ Index offset is the offset in the time series to start at. As each response can only contain 50k records, callers can use this to skip around within a packed time series."
+          "description": "/ Index offset is the offset in the time series to start at. As each\n/ response can only contain 50k records, callers can use this to skip\n/ around within a packed time series."
         },
         "num_max_events": {
           "type": "integer",
@@ -2675,12 +2675,12 @@
           "items": {
             "$ref": "#/definitions/lnrpcForwardingEvent"
           },
-          "description": "/ A list of forwarding events from the time slice of the time series specified in the request."
+          "description": "/ A list of forwarding events from the time slice of the time series\n/ specified in the request."
         },
         "last_offset_index": {
           "type": "integer",
           "format": "int64",
-          "description": "/ The index of the last time in the set of returned forwarding events. Can be used to seek further, pagination style."
+          "description": "/ The index of the last time in the set of returned forwarding events. Can\n/ be used to seek further, pagination style."
         }
       }
     },
@@ -2788,7 +2788,7 @@
         "testnet": {
           "type": "boolean",
           "format": "boolean",
-          "title": "* \nWhether the current node is connected to testnet. This field is \ndeprecated and the network field should be used instead"
+          "title": "*\nWhether the current node is connected to testnet. This field is\ndeprecated and the network field should be used instead"
         },
         "chains": {
           "type": "array",
@@ -2923,7 +2923,7 @@
         "tlv_payload": {
           "type": "boolean",
           "format": "boolean",
-          "description": "* \nIf set to true, then this hop will be encoded using the new variable length\nTLV format. Note that if any custom tlv_records below are specified, then\nthis field MUST be set to true for them to be encoded properly."
+          "description": "*\nIf set to true, then this hop will be encoded using the new variable length\nTLV format. Note that if any custom tlv_records below are specified, then\nthis field MUST be set to true for them to be encoded properly."
         },
         "mpp_record": {
           "$ref": "#/definitions/lnrpcMPPRecord",
@@ -3208,7 +3208,7 @@
         },
         "key_loc": {
           "$ref": "#/definitions/lnrpcKeyLocator",
-          "description": "* \nThe key locator that identifies which key to use for signing."
+          "description": "*\nThe key locator that identifies which key to use for signing."
         }
       }
     },
@@ -3236,7 +3236,7 @@
         },
         "host": {
           "type": "string",
-          "title": "/ The network location of the lightning node, e.g. `69.69.69.69:1337` or `localhost:10011`"
+          "title": "/ The network location of the lightning node, e.g. `69.69.69.69:1337` or\n/ `localhost:10011`"
         }
       }
     },
@@ -3541,42 +3541,42 @@
         "push_sat": {
           "type": "string",
           "format": "int64",
-          "title": "/ The number of satoshis to push to the remote side as part of the initial commitment state"
+          "title": "/ The number of satoshis to push to the remote side as part of the initial\n/ commitment state"
         },
         "target_conf": {
           "type": "integer",
           "format": "int32",
-          "description": "/ The target number of blocks that the funding transaction should be confirmed by."
+          "description": "/ The target number of blocks that the funding transaction should be\n/ confirmed by."
         },
         "sat_per_byte": {
           "type": "string",
           "format": "int64",
-          "description": "/ A manual fee rate set in sat/byte that should be used when crafting the funding transaction."
+          "description": "/ A manual fee rate set in sat/byte that should be used when crafting the\n/ funding transaction."
         },
         "private": {
           "type": "boolean",
           "format": "boolean",
-          "description": "/ Whether this channel should be private, not announced to the greater network."
+          "description": "/ Whether this channel should be private, not announced to the greater\n/ network."
         },
         "min_htlc_msat": {
           "type": "string",
           "format": "int64",
-          "description": "/ The minimum value in millisatoshi we will require for incoming HTLCs on the channel."
+          "description": "/ The minimum value in millisatoshi we will require for incoming HTLCs on\n/ the channel."
         },
         "remote_csv_delay": {
           "type": "integer",
           "format": "int64",
-          "description": "/ The delay we require on the remote's commitment transaction. If this is not set, it will be scaled automatically with the channel size."
+          "description": "/ The delay we require on the remote's commitment transaction. If this is\n/ not set, it will be scaled automatically with the channel size."
         },
         "min_confs": {
           "type": "integer",
           "format": "int32",
-          "description": "/ The minimum number of confirmations each one of your outputs used for the funding transaction must satisfy."
+          "description": "/ The minimum number of confirmations each one of your outputs used for\n/ the funding transaction must satisfy."
         },
         "spend_unconfirmed": {
           "type": "boolean",
           "format": "boolean",
-          "description": "/ Whether unconfirmed outputs should be used as inputs for the funding transaction."
+          "description": "/ Whether unconfirmed outputs should be used as inputs for the funding\n/ transaction."
         },
         "close_address": {
           "type": "string",
@@ -3925,7 +3925,7 @@
         "fee_rate": {
           "type": "number",
           "format": "double",
-          "description": "/ The effective fee rate in milli-satoshis. The precision of this value goes up to 6 decimal places, so 1e-6."
+          "description": "/ The effective fee rate in milli-satoshis. The precision of this value\n/ goes up to 6 decimal places, so 1e-6."
         },
         "time_lock_delta": {
           "type": "integer",
@@ -3935,12 +3935,12 @@
         "max_htlc_msat": {
           "type": "string",
           "format": "uint64",
-          "description": "/ If set, the maximum HTLC size in milli-satoshis. If unset, the maximum HTLC will be unchanged."
+          "description": "/ If set, the maximum HTLC size in milli-satoshis. If unset, the maximum\n/ HTLC will be unchanged."
         },
         "min_htlc_msat": {
           "type": "string",
           "format": "uint64",
-          "description": "/ The minimum HTLC size in milli-satoshis. Only applied if min_htlc_msat_specified is true."
+          "description": "/ The minimum HTLC size in milli-satoshis. Only applied if\n/ min_htlc_msat_specified is true."
         },
         "min_htlc_msat_specified": {
           "type": "boolean",
@@ -4084,12 +4084,12 @@
         "target_conf": {
           "type": "integer",
           "format": "int32",
-          "description": "/ The target number of blocks that this transaction should be confirmed by."
+          "description": "/ The target number of blocks that this transaction should be confirmed\n/ by."
         },
         "sat_per_byte": {
           "type": "string",
           "format": "int64",
-          "description": "/ A manual fee rate set in sat/byte that should be used when crafting the transaction."
+          "description": "/ A manual fee rate set in sat/byte that should be used when crafting the\n/ transaction."
         },
         "send_all": {
           "type": "boolean",
@@ -4173,7 +4173,7 @@
         "cltv_limit": {
           "type": "integer",
           "format": "int64",
-          "description": "* \nAn optional maximum total time lock for the route. This should not exceed\nlnd's `--max-cltv-expiry` setting. If zero, then the value of\n`--max-cltv-expiry` is enforced."
+          "description": "*\nAn optional maximum total time lock for the route. This should not exceed\nlnd's `--max-cltv-expiry` setting. If zero, then the value of\n`--max-cltv-expiry` is enforced."
         },
         "dest_custom_records": {
           "type": "object",
@@ -4181,7 +4181,7 @@
             "type": "string",
             "format": "byte"
           },
-          "description": "* \nAn optional field that can be used to pass an arbitrary set of TLV records\nto a peer which understands the new records. This can be used to pass\napplication specific data during the payment attempt. Record types are\nrequired to be in the custom range \u003e= 65536. When using REST, the values\nmust be encoded as base64."
+          "description": "*\nAn optional field that can be used to pass an arbitrary set of TLV records\nto a peer which understands the new records. This can be used to pass\napplication specific data during the payment attempt. Record types are\nrequired to be in the custom range \u003e= 65536. When using REST, the values\nmust be encoded as base64."
         },
         "allow_self_payment": {
           "type": "boolean",

--- a/lnrpc/signrpc/signer.pb.go
+++ b/lnrpc/signrpc/signer.pb.go
@@ -202,7 +202,8 @@ type SignDescriptor struct {
 	//only be populated if a p2wsh or a p2sh output is being signed.
 	WitnessScript []byte `protobuf:"bytes,4,opt,name=witness_script,json=witnessScript,proto3" json:"witness_script,omitempty"`
 	//*
-	//A description of the output being spent. The value and script MUST be provided.
+	//A description of the output being spent. The value and script MUST be
+	//provided.
 	Output *TxOut `protobuf:"bytes,5,opt,name=output,proto3" json:"output,omitempty"`
 	//*
 	//The target sighash type that should be used when generating the final

--- a/lnrpc/signrpc/signer.proto
+++ b/lnrpc/signrpc/signer.proto
@@ -19,7 +19,7 @@ message KeyDescriptor {
     */
     bytes raw_key_bytes = 1;
 
-    /** 
+    /**
     The key locator that identifies which key to use for signing. Either this
     or the raw bytes of the target key must be specified.
     */
@@ -58,7 +58,7 @@ message SignDescriptor {
     commitment secret from a previously revoked commitment transaction. This
     value is in combination with two hash values, and the original private key
     to derive the private key to be used when signing.
-   
+
      * k = (privKey*sha256(pubKey || tweakPub) +
            tweakPriv*sha256(tweakPub || pubKey)) mod N
     */
@@ -71,7 +71,8 @@ message SignDescriptor {
     bytes witness_script = 4;
 
     /**
-    A description of the output being spent. The value and script MUST be provided.
+    A description of the output being spent. The value and script MUST be
+    provided.
     */
     TxOut output = 5;
 
@@ -173,8 +174,8 @@ service Signer {
     set of inputs/outputs to a transaction. Each request specifies details
     concerning how the outputs should be signed, which keys they should be
     signed with, and also any optional tweaks. The return value is a fixed
-    64-byte signature (the same format as we use on the wire in Lightning). 
-    
+    64-byte signature (the same format as we use on the wire in Lightning).
+
     If we are  unable to sign using the specified keys, then an error will be
     returned.
     */
@@ -197,7 +198,7 @@ service Signer {
     /**
     SignMessage signs a message with the key specified in the key locator. The
     returned signature is fixed-size LN wire format encoded.
-    
+
     The main difference to SignMessage in the main RPC is that a specific key is
     used to sign the message instead of the node identity private key.
     */
@@ -206,7 +207,7 @@ service Signer {
     /**
     VerifyMessage verifies a signature over a message using the public key
     provided. The signature must be fixed-size LN wire format encoded.
-    
+
     The main difference to VerifyMessage in the main RPC is that the public key
     used to sign the message does not have to be a node known to the network.
     */
@@ -218,7 +219,7 @@ service Signer {
     key specified in the key_loc parameter (or the node's identity private key
     if no key locator is specified):
         P_shared = privKeyNode * ephemeralPubkey
-    The resulting shared public key is serialized in the compressed format and 
+    The resulting shared public key is serialized in the compressed format and
     hashed with sha256, resulting in the final key length of 256bit.
     */
     rpc DeriveSharedKey (SharedKeyRequest) returns (SharedKeyResponse);

--- a/lnrpc/walletrpc/walletkit.proto
+++ b/lnrpc/walletrpc/walletkit.proto
@@ -248,7 +248,7 @@ service WalletKit {
 
     /**
     DeriveKey attempts to derive an arbitrary key specified by the passed
-    KeyLocator. 
+    KeyLocator.
     */
     rpc DeriveKey (signrpc.KeyLocator) returns (signrpc.KeyDescriptor);
 

--- a/lnrpc/watchtowerrpc/watchtower.pb.go
+++ b/lnrpc/watchtowerrpc/watchtower.pb.go
@@ -150,7 +150,7 @@ const _ = grpc.SupportPackageIsVersion4
 type WatchtowerClient interface {
 	//* lncli: tower info
 	//GetInfo returns general information concerning the companion watchtower
-	//including it's public key and URIs where the server is currently
+	//including its public key and URIs where the server is currently
 	//listening for clients.
 	GetInfo(ctx context.Context, in *GetInfoRequest, opts ...grpc.CallOption) (*GetInfoResponse, error)
 }
@@ -176,7 +176,7 @@ func (c *watchtowerClient) GetInfo(ctx context.Context, in *GetInfoRequest, opts
 type WatchtowerServer interface {
 	//* lncli: tower info
 	//GetInfo returns general information concerning the companion watchtower
-	//including it's public key and URIs where the server is currently
+	//including its public key and URIs where the server is currently
 	//listening for clients.
 	GetInfo(context.Context, *GetInfoRequest) (*GetInfoResponse, error)
 }

--- a/lnrpc/watchtowerrpc/watchtower.proto
+++ b/lnrpc/watchtowerrpc/watchtower.proto
@@ -7,7 +7,7 @@ option go_package = "github.com/lightningnetwork/lnd/lnrpc/watchtowerrpc";
 service Watchtower {
     /** lncli: tower info
     GetInfo returns general information concerning the companion watchtower
-    including it's public key and URIs where the server is currently
+    including its public key and URIs where the server is currently
     listening for clients.
     */
     rpc GetInfo (GetInfoRequest) returns (GetInfoResponse);

--- a/lnrpc/wtclientrpc/wtclient.proto
+++ b/lnrpc/wtclientrpc/wtclient.proto
@@ -151,7 +151,7 @@ service WatchtowerClient {
     */
     rpc RemoveTower (RemoveTowerRequest) returns (RemoveTowerResponse);
 
-    // ListTowers returns the list of watchtowers registered with the client. 
+    // ListTowers returns the list of watchtowers registered with the client.
     rpc ListTowers (ListTowersRequest) returns (ListTowersResponse);
 
     // GetTowerInfo retrieves information for a registered watchtower.

--- a/scripts/install_travis_proto.sh
+++ b/scripts/install_travis_proto.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+
+# Abort on error (-e) and print commands (-v).
+set -ev
+
+# See README.md in lnrpc why we need these specific versions/commits.
+PROTOC_VERSION=3.4.0
+PROTOBUF_VERSION="b5d812f8a3706043e23a9cd5babf2e5423744d30"
+GENPROTO_VERSION="a8101f21cf983e773d0c1133ebc5424792003214"
+GRPC_GATEWAY_VERSION="v1.8.6"
+
+# This script is specific to Travis CI so we only need to support linux x64.
+PROTOC_URL="https://github.com/protocolbuffers/protobuf/releases/download/v${PROTOC_VERSION}/protoc-${PROTOC_VERSION}-linux-x86_64.zip"
+PROTOC_DL_CACHE_DIR="${DOWNLOAD_CACHE:-/tmp/download_cache}/protoc"
+
+# install_protoc copies the cached protoc binary to the $PATH or downloads it
+# if no cached version is found.
+install_protoc() {
+  if [ -f "${PROTOC_DL_CACHE_DIR}/bin/protoc" ]; then
+    echo "Using cached version of protoc"
+  else
+    wget -O /tmp/protoc.zip $PROTOC_URL
+    mkdir -p "${PROTOC_DL_CACHE_DIR}"
+    unzip -o /tmp/protoc.zip -d "${PROTOC_DL_CACHE_DIR}"
+    chmod -R a+rx "${PROTOC_DL_CACHE_DIR}/"
+  fi
+  sudo cp "${PROTOC_DL_CACHE_DIR}/bin/protoc" /usr/local/bin
+  sudo cp -r "${PROTOC_DL_CACHE_DIR}/include" /usr/local
+}
+
+# install_protobuf downloads and compiles the Golang protobuf library that
+# encodes/decodes all protobuf messages from/to Go structs.
+install_protobuf() {
+  local install_path="$GOPATH/src/github.com/golang/protobuf"
+  if [ ! -d "$install_path" ]; then
+    git clone https://github.com/golang/protobuf "$install_path"
+  fi
+  pushd "$install_path"
+  git reset --hard $PROTOBUF_VERSION
+  make
+  popd
+}
+
+# install_genproto downloads the Golang protobuf generator that converts the
+# .proto files into Go interface stubs.
+install_genproto() {
+  local install_path="$GOPATH/src/google.golang.org/genproto"
+  if [ ! -d "$install_path" ]; then
+    git clone https://github.com/google/go-genproto "$install_path"
+  fi
+  pushd "$install_path"
+  git reset --hard $GENPROTO_VERSION
+  popd
+}
+
+# install_grpc_gateway downloads and installs the gRPC gateway that converts
+# .proto files into REST gateway code.
+install_grpc_gateway() {
+  local install_path="$GOPATH/src/github.com/grpc-ecosystem/grpc-gateway"
+  if [ ! -d "$install_path" ]; then
+    git clone https://github.com/grpc-ecosystem/grpc-gateway "$install_path"
+  fi
+  pushd "$install_path"
+  git reset --hard $GRPC_GATEWAY_VERSION
+  GO111MODULE=on go install ./protoc-gen-grpc-gateway ./protoc-gen-swagger
+  popd
+}
+
+install_protoc
+install_protobuf
+install_genproto
+install_grpc_gateway


### PR DESCRIPTION
Replaces/continues #3112/#3110 by @cfromknecht.

This PR installs/compiles the `protoc`, `protobuf`, `genproto` and `grpc-gateway` libraries/binaries in the exact version as specified in `lnrpc/README.md` on Travis and then compiles all `.proto` files.
If the git worktree becomes dirty in the process, that means the protos weren't compiled correctly or with a wrong version and the CI build is failed.

The build process also makes sure the protos are properly formatted, using `clang-format` with custom rules (`lnrpc/.clang-format`) to do so.

Fixes #3094