### PR TITLE
server+tor: add support for Tor HASHEDPASSWORD authentication method

### DIFF
--- a/config.go
+++ b/config.go
@@ -221,6 +221,7 @@ type torConfig struct {
 	StreamIsolation bool   `long:"streamisolation" description:"Enable Tor stream isolation by randomizing user credentials for each connection."`
 	Control         string `long:"control" description:"The host:port that Tor is listening on for Tor control connections"`
 	TargetIPAddress string `long:"targetipaddress" description:"IP address that Tor should use as the target of the hidden service"`
+	Password        string `long:"password" description:"The password used to arrive at the HashedControlPassword for the control port. If provided, the HASHEDPASSWORD authentication method will be used instead of the SAFECOOKIE one."`
 	V2              bool   `long:"v2" description:"Automatically set up a v2 onion service to listen for inbound connections"`
 	V3              bool   `long:"v3" description:"Automatically set up a v3 onion service to listen for inbound connections"`
 	PrivateKeyPath  string `long:"privatekeypath" description:"The path to the private key of the onion service being created"`

--- a/docs/configuring_tor.md
+++ b/docs/configuring_tor.md
@@ -2,7 +2,8 @@
 1. [Overview](#overview)
 2. [Getting Started](#getting-started)
 3. [Tor Stream Isolation](#tor-stream-isolation)
-4. [Listening for Inbound Connections](#listening-for-inbound-connections)
+4. [Authentication](#authentication)
+5. [Listening for Inbound Connections](#listening-for-inbound-connections)
 
 ## Overview
 
@@ -78,6 +79,8 @@ Tor:
       --tor.dns=                                              The DNS server as host:port that Tor will use for SRV queries - NOTE must have TCP resolution enabled (default: soa.nodes.lightning.directory:53)
       --tor.streamisolation                                   Enable Tor stream isolation by randomizing user credentials for each connection.
       --tor.control=                                          The host:port that Tor is listening on for Tor control connections (default: localhost:9051)
+      --tor.targetipaddress=                                  IP address that Tor should use as the target of the hidden service
+      --tor.password=                                         The password used to arrive at the HashedControlPassword for the control port. If provided, the HASHEDPASSWORD authentication method will be used instead of the SAFECOOKIE one.
       --tor.v2                                                Automatically set up a v2 onion service to listen for inbound connections
       --tor.v3                                                Automatically set up a v3 onion service to listen for inbound connections
       --tor.privatekeypath=                                   The path to the private key of the onion service being created
@@ -132,6 +135,26 @@ specification of an additional argument:
 ```
 ⛰  ./lnd --tor.active --tor.streamisolation
 ```
+
+## Authentication
+
+In order for `lnd` to communicate with the Tor daemon securely, it must first
+establish an authenticated connection. `lnd` supports the following Tor control
+authentication methods (arguably, from most to least secure):
+
+* `SAFECOOKIE`: This authentication method relies on a cookie created and
+  stored by the Tor daemon and is the default assuming the Tor daemon supports
+  it by specifying `CookieAuthentication 1` in its configuration file.
+* `HASHEDPASSWORD`: This authentication method is stateless as it relies on a
+  password hash scheme and may be useful if the Tor daemon is operating under a
+  separate host from the `lnd` node. The password hash can be obtained through
+  the Tor daemon with `tor --hash-password PASSWORD`, which should then be
+  specified in Tor's configuration file with `HashedControlPassword
+  PASSWORD_HASH`. Finally, to use it within `lnd`, the `--tor.password` flag
+  should be provided with the corresponding password.
+* `NULL`: To bypass any authentication at all, this scheme can be used instead.
+  It doesn't require any additional flags to `lnd` or configuration options to
+  the Tor daemon.
 
 ## Listening for Inbound Connections
 

--- a/server.go
+++ b/server.go
@@ -586,7 +586,10 @@ func newServer(listenAddrs []net.Addr, chanDB *channeldb.DB,
 	// automatically create an onion service, we'll initiate our Tor
 	// controller and establish a connection to the Tor server.
 	if cfg.Tor.Active && (cfg.Tor.V2 || cfg.Tor.V3) {
-		s.torController = tor.NewController(cfg.Tor.Control, cfg.Tor.TargetIPAddress)
+		s.torController = tor.NewController(
+			cfg.Tor.Control, cfg.Tor.TargetIPAddress,
+			cfg.Tor.Password,
+		)
 	}
 
 	chanGraph := chanDB.ChannelGraph()

--- a/tor/README.md
+++ b/tor/README.md
@@ -8,8 +8,8 @@ Tor daemon. So far, supported functions include:
 * Routing DNS queries over Tor (A, AAAA, SRV).
 * Limited Tor Control functionality (synchronous messages only). So far, this
 includes:
-  * Support for SAFECOOKIE authentication only as a sane default.
-  * Creating v2 onion services.
+  * Support for SAFECOOKIE, HASHEDPASSWORD, and NULL authentication methods.
+  * Creating v2 and v3 onion services.
 
 In the future, the Tor Control functionality will be extended to support v3
 onion services, asynchronous messages, etc.


### PR DESCRIPTION
Tested and confirmed locally that all three authentication methods (`SAFECOOKIE`, `HASHEDPASSWORD`, `NULL`) work as intended. `SAFECOOKIE` remains as the default unless a control password is provided.

Replaces https://github.com/lightningnetwork/lnd/pull/2548.