### PR TITLE
sample-lnd.conf: remove deprecated wtclient option

### DIFF
--- a/sample-lnd.conf
+++ b/sample-lnd.conf
@@ -381,7 +381,7 @@ litecoin.node=ltcd
 
 [wtclient]
 ; Activate Watchtower Client. To get more information or configure watchtowers
-; run `lncli wtclient -h`
+; run `lncli wtclient -h`.
 ; wtclient.active=true
 
 ; Specify the fee rate with which justice transactions will be signed. This fee

--- a/sample-lnd.conf
+++ b/sample-lnd.conf
@@ -380,12 +380,9 @@ litecoin.node=ltcd
 ; watchtower.writetimeout=15s
 
 [wtclient]
-; Configure the private tower to which lnd will connect to backup encrypted
-; justice transactions. The format should be pubkey@host:port, where the port is
-; optional and assumed to be 9911 otherwise. At most one private tower URI is
-; supported at this time; if none are provided then the watchtower client will
-; be inactive.
-; wtclient.private-tower-uris=
+; Activate Watchtower Client. To get more information or configure watchtowers
+; run `lncli wtclient -h`
+; wtclient.active=true
 
 ; Specify the fee rate with which justice transactions will be signed. This fee
 ; rate should be chosen as a maximum fee rate one is willing to pay in order to


### PR DESCRIPTION
removed wtclient.private-tower-uris due it was replaced by wtclient.active