### PR TITLE
travis+lncli: fix windows build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,6 +43,7 @@ jobs:
         - make unit pkg=... case=_NONE_
         - make lint
         - make btcd
+        - LNDBUILDSYS=windows-amd64 bash ./build/release/release.sh
     - stage: Test
       script: make travis-cover
       name: Unit Cover

--- a/cmd/lncli/commands.go
+++ b/cmd/lncli/commands.go
@@ -1807,7 +1807,11 @@ func unlock(ctx *cli.Context) error {
 	// lncli.
 	default:
 		fmt.Printf("Input wallet password: ")
-		pw, err = terminal.ReadPassword(syscall.Stdin)
+
+		// The variable syscall.Stdin is of a different type in the
+		// Windows API that's why we need the explicit cast. And of
+		// course the linter doesn't like it either.
+		pw, err = terminal.ReadPassword(int(syscall.Stdin)) // nolint:unconvert
 		fmt.Println()
 	}
 	if err != nil {


### PR DESCRIPTION
Fixes a compilation issue introduced in #4066 that is only present when compiling for windows.
To catch bugs like that in the future, this PR also adds windows cross-compilation to the Travis build.