### PR TITLE
Makefile: don't format proto on Travis

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -178,7 +178,7 @@ rpc-format:
 	@$(call print, "Formatting protos.")
 	cd ./lnrpc; find . -name "*.proto" | xargs clang-format --style=file -i
 
-rpc-check: rpc-format rpc
+rpc-check: rpc
 	@$(call print, "Verifying protos.")
 	if test -n "$$(git describe --dirty | grep dirty)"; then echo "Protos not properly formatted or not compiled with v3.4.0"; git status; git diff; exit 1; fi
 


### PR DESCRIPTION
There are different versions of clang-format being installed on
different versions of ubuntu that apparently produce different
results when formatting the proto files. This is likely too much
of a hurdle for new contributors to also manually install the
correct version of a command line tool just to format stuff.
