### PR TITLE
lntest/itest: select anchor commitment format and sweeping itests

### DIFF
--- a/contractcourt/channel_arbitrator.go
+++ b/contractcourt/channel_arbitrator.go
@@ -842,8 +842,9 @@ func (c *ChannelArbitrator) stateStep(
 		// With the close transaction in hand, broadcast the
 		// transaction to the network, thereby entering the post
 		// channel resolution state.
-		log.Infof("Broadcasting force close transaction, "+
-			"ChannelPoint(%v): %v", c.cfg.ChanPoint,
+		log.Infof("Broadcasting force close transaction %v, "+
+			"ChannelPoint(%v): %v", closeTx.TxHash(),
+			c.cfg.ChanPoint,
 			newLogClosure(func() string {
 				return spew.Sdump(closeTx)
 			}))

--- a/lntest/itest/lnd_multi-hop_remote_force_close_on_chain_htlc_timeout_test.go
+++ b/lntest/itest/lnd_multi-hop_remote_force_close_on_chain_htlc_timeout_test.go
@@ -81,9 +81,13 @@ func testMultiHopRemoteForceCloseOnChainHtlcTimeout(net *lntest.NetworkHarness,
 
 	// At this point, we'll now instruct Carol to force close the
 	// transaction. This will let us exercise that Bob is able to sweep the
-	// expired HTLC on Carol's version of the commitment transaction.
+	// expired HTLC on Carol's version of the commitment transaction. If
+	// Carol has an anchor, it will be swept too.
 	ctxt, _ := context.WithTimeout(ctxb, channelCloseTimeout)
-	closeChannelAndAssert(ctxt, t, net, carol, bobChanPoint, true)
+	closeChannelAndAssertType(
+		ctxt, t, net, carol, bobChanPoint, c == commitTypeAnchors,
+		true,
+	)
 
 	// At this point, Bob should have a pending force close channel as
 	// Carol has gone directly to chain.
@@ -110,11 +114,18 @@ func testMultiHopRemoteForceCloseOnChainHtlcTimeout(net *lntest.NetworkHarness,
 		t.Fatalf(predErr.Error())
 	}
 
-	// Bob can sweep his output immediately.
-	_, err = waitForTxInMempool(net.Miner.Node, minerMempoolTimeout)
+	// Bob can sweep his output immediately. If there is an anchor, Bob will
+	// sweep that as well.
+	expectedTxes := 1
+	if c == commitTypeAnchors {
+		expectedTxes = 2
+	}
+
+	_, err = waitForNTxsInMempool(
+		net.Miner.Node, expectedTxes, minerMempoolTimeout,
+	)
 	if err != nil {
-		t.Fatalf("unable to find bob's funding output sweep tx: %v",
-			err)
+		t.Fatalf("failed to find txes in miner mempool: %v", err)
 	}
 
 	// Next, we'll mine enough blocks for the HTLC to expire. At this
@@ -232,7 +243,10 @@ func testMultiHopRemoteForceCloseOnChainHtlcTimeout(net *lntest.NetworkHarness,
 
 	// We'll close out the test by closing the channel from Alice to Bob,
 	// and then shutting down the new node we created as its no longer
-	// needed.
+	// needed. Coop close, no anchors.
 	ctxt, _ = context.WithTimeout(ctxb, channelCloseTimeout)
-	closeChannelAndAssert(ctxt, t, net, alice, aliceChanPoint, false)
+	closeChannelAndAssertType(
+		ctxt, t, net, alice, aliceChanPoint, false,
+		false,
+	)
 }

--- a/lntest/itest/lnd_test.go
+++ b/lntest/itest/lnd_test.go
@@ -43,6 +43,7 @@ import (
 	"github.com/lightningnetwork/lnd/lntest"
 	"github.com/lightningnetwork/lnd/lntest/wait"
 	"github.com/lightningnetwork/lnd/lntypes"
+	"github.com/lightningnetwork/lnd/lnwallet/chainfee"
 	"github.com/lightningnetwork/lnd/lnwire"
 	"github.com/lightningnetwork/lnd/routing"
 )
@@ -607,13 +608,13 @@ func shutdownAndAssert(net *lntest.NetworkHarness, t *harnessTest,
 // TODO(bvu): Refactor when dynamic fee estimation is added.
 // TODO(conner) remove code duplication
 func calcStaticFee(numHTLCs int) btcutil.Amount {
-	const (
-		commitWeight = btcutil.Amount(724)
-		htlcWeight   = 172
-		feePerKw     = btcutil.Amount(50 * 1000 / 4)
+	const htlcWeight = input.HTLCWeight
+	var (
+		feePerKw     = chainfee.SatPerKVByte(50000).FeePerKWeight()
+		commitWeight = input.CommitWeight
 	)
-	return feePerKw * (commitWeight +
-		btcutil.Amount(htlcWeight*numHTLCs)) / 1000
+
+	return feePerKw.FeeForWeight(int64(commitWeight + htlcWeight*numHTLCs))
 }
 
 // completePaymentRequests sends payments from a lightning node to complete all

--- a/lntest/itest/lnd_test.go
+++ b/lntest/itest/lnd_test.go
@@ -6850,6 +6850,27 @@ func waitForNTxsInMempool(miner *rpcclient.Client, n int,
 	}
 }
 
+// getNTxsFromMempool polls until finding the desired number of transactions in
+// the provided miner's mempool and returns the full transactions to the caller.
+func getNTxsFromMempool(miner *rpcclient.Client, n int,
+	timeout time.Duration) ([]*wire.MsgTx, error) {
+
+	txids, err := waitForNTxsInMempool(miner, n, timeout)
+	if err != nil {
+		return nil, err
+	}
+
+	var txes []*wire.MsgTx
+	for _, txid := range txids {
+		tx, err := miner.GetRawTransaction(txid)
+		if err != nil {
+			return nil, err
+		}
+		txes = append(txes, tx.MsgTx())
+	}
+	return txes, nil
+}
+
 // testFailingChannel tests that we will fail the channel by force closing ii
 // in the case where a counterparty tries to settle an HTLC with the wrong
 // preimage.
@@ -10568,7 +10589,16 @@ func assertNumActiveHtlcs(nodes []*lntest.HarnessNode, numHtlcs int) error {
 }
 
 func assertSpendingTxInMempool(t *harnessTest, miner *rpcclient.Client,
-	timeout time.Duration, chanPoint wire.OutPoint) {
+	timeout time.Duration, chanPoint wire.OutPoint) chainhash.Hash {
+
+	tx := getSpendingTxInMempool(t, miner, timeout, chanPoint)
+	return tx.TxHash()
+}
+
+// getSpendingTxInMempool waits for a transaction spending the given outpoint to
+// appear in the mempool and returns that tx in full.
+func getSpendingTxInMempool(t *harnessTest, miner *rpcclient.Client,
+	timeout time.Duration, chanPoint wire.OutPoint) *wire.MsgTx {
 
 	breakTimeout := time.After(timeout)
 	ticker := time.NewTicker(50 * time.Millisecond)
@@ -10594,9 +10624,10 @@ func assertSpendingTxInMempool(t *harnessTest, miner *rpcclient.Client,
 					t.Fatalf("unable to fetch tx: %v", err)
 				}
 
-				for _, txIn := range tx.MsgTx().TxIn {
+				msgTx := tx.MsgTx()
+				for _, txIn := range msgTx.TxIn {
 					if txIn.PreviousOutPoint == chanPoint {
-						return
+						return msgTx
 					}
 				}
 			}

--- a/lntest/itest/lnd_test.go
+++ b/lntest/itest/lnd_test.go
@@ -3081,6 +3081,7 @@ func testChannelForceClosure(net *lntest.NetworkHarness, t *harnessTest) {
 	// outputs can be swept.
 	commitTypes := []commitType{
 		commitTypeLegacy,
+		commitTypeAnchors,
 	}
 
 	for _, channelType := range commitTypes {
@@ -3120,7 +3121,19 @@ func testChannelForceClosure(net *lntest.NetworkHarness, t *harnessTest) {
 					err)
 			}
 
-			channelForceClosureTest(net, ht, alice, carol)
+			// Also give Carol some coins to allow her to sweep her
+			// anchor.
+			err = net.SendCoins(
+				ctxt, btcutil.SatoshiPerBitcoin, carol,
+			)
+			if err != nil {
+				t.Fatalf("unable to send coins to Alice: %v",
+					err)
+			}
+
+			channelForceClosureTest(
+				net, ht, alice, carol, channelType,
+			)
 		})
 		if !success {
 			return
@@ -3129,7 +3142,7 @@ func testChannelForceClosure(net *lntest.NetworkHarness, t *harnessTest) {
 }
 
 func channelForceClosureTest(net *lntest.NetworkHarness, t *harnessTest,
-	alice, carol *lntest.HarnessNode) {
+	alice, carol *lntest.HarnessNode, channelType commitType) {
 
 	ctxb := context.Background()
 
@@ -3305,8 +3318,16 @@ func channelForceClosureTest(net *lntest.NetworkHarness, t *harnessTest,
 	}
 
 	// Mine a block which should confirm the commitment transaction
-	// broadcast as a result of the force closure.
-	_, err = waitForTxInMempool(net.Miner.Node, minerMempoolTimeout)
+	// broadcast as a result of the force closure. If there are anchors, we
+	// also expect the anchor sweep tx to be in the mempool.
+	expectedTxes := 1
+	if channelType == commitTypeAnchors {
+		expectedTxes = 2
+	}
+
+	_, err = waitForNTxsInMempool(
+		net.Miner.Node, expectedTxes, minerMempoolTimeout,
+	)
 	if err != nil {
 		t.Fatalf("failed to find commitment in miner mempool: %v", err)
 	}
@@ -3347,12 +3368,17 @@ func channelForceClosureTest(net *lntest.NetworkHarness, t *harnessTest,
 		}
 
 		// None of our outputs have been swept, so they should all be in
-		// limbo.
+		// limbo. For anchors, we expect the anchor amount to be
+		// recovered.
 		if forceClose.LimboBalance == 0 {
 			return errors.New("all funds should still be in " +
 				"limbo")
 		}
-		if forceClose.RecoveredBalance != 0 {
+		expectedRecoveredBalance := int64(0)
+		if channelType == commitTypeAnchors {
+			expectedRecoveredBalance = anchorSize
+		}
+		if forceClose.RecoveredBalance != expectedRecoveredBalance {
 			return errors.New("no funds should yet be shown " +
 				"as recovered")
 		}
@@ -3372,8 +3398,11 @@ func channelForceClosureTest(net *lntest.NetworkHarness, t *harnessTest,
 	}
 
 	// Carol's sweep tx should be in the mempool already, as her output is
-	// not timelocked.
-	_, err = waitForTxInMempool(net.Miner.Node, minerMempoolTimeout)
+	// not timelocked. If there are anchors, we also expect Carol's anchor
+	// sweep now.
+	_, err = waitForNTxsInMempool(
+		net.Miner.Node, expectedTxes, minerMempoolTimeout,
+	)
 	if err != nil {
 		t.Fatalf("failed to find Carol's sweep in miner mempool: %v",
 			err)
@@ -3435,7 +3464,11 @@ func channelForceClosureTest(net *lntest.NetworkHarness, t *harnessTest,
 			return errors.New("all funds should still be in " +
 				"limbo")
 		}
-		if forceClose.RecoveredBalance != 0 {
+		expectedRecoveredBalance := int64(0)
+		if channelType == commitTypeAnchors {
+			expectedRecoveredBalance = anchorSize
+		}
+		if forceClose.RecoveredBalance != expectedRecoveredBalance {
 			return errors.New("no funds should yet be shown " +
 				"as recovered")
 		}

--- a/sweep/txgenerator_test.go
+++ b/sweep/txgenerator_test.go
@@ -3,6 +3,7 @@ package sweep
 import (
 	"testing"
 
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcd/wire"
 	"github.com/lightningnetwork/lnd/input"
 )
@@ -15,9 +16,10 @@ var (
 		input.WitnessKeyHash,
 	}
 	expectedWeight  = int64(1462)
-	expectedSummary = "1 CommitmentTimeLock, 1 " +
-		"HtlcAcceptedSuccessSecondLevel, 1 HtlcOfferedRemoteTimeout, " +
-		"1 WitnessKeyHash"
+	expectedSummary = "0000000000000000000000000000000000000000000000000000000000000000:10 (CommitmentTimeLock), " +
+		"0000000000000000000000000000000000000000000000000000000000000001:11 (HtlcAcceptedSuccessSecondLevel), " +
+		"0000000000000000000000000000000000000000000000000000000000000002:12 (HtlcOfferedRemoteTimeout), " +
+		"0000000000000000000000000000000000000000000000000000000000000003:13 (WitnessKeyHash)"
 )
 
 // TestWeightEstimate tests that the estimated weight and number of CSVs/CLTVs
@@ -27,9 +29,12 @@ func TestWeightEstimate(t *testing.T) {
 	t.Parallel()
 
 	var inputs []input.Input
-	for _, witnessType := range witnessTypes {
+	for i, witnessType := range witnessTypes {
 		inputs = append(inputs, input.NewBaseInput(
-			&wire.OutPoint{}, witnessType,
+			&wire.OutPoint{
+				Hash:  chainhash.Hash{byte(i)},
+				Index: uint32(i) + 10,
+			}, witnessType,
 			&input.SignDescriptor{}, 0,
 		))
 	}


### PR DESCRIPTION
This PR adds integration tests for a select set of integration tests with the channel type set to anchor:

basic funding flow
channel force closure
test multi-hop htlc local force close immediate expiry
test multi-hop htlc receiver chain claim
test multi-hop local force close on-chain htlc timeout
test multi-hop remote force close on-chain htlc timeout
test multi-hop htlc local chain claim
test multi-hop htlc remote chain claim
These are selected since they together test establishing channels of this new type in combination with the previous channel types, sweeping of commitment outputs, and HTLC sweep scenarios.

The goal is to later enable the whole integration test suite for this channel type, but it requires changes to most notably the channel backup format and watchtower.

[desc copied from #4001]

Builds on #4103