### PR TITLE
chanbackup: add SCB support for anchor commitments

### DIFF
--- a/chanbackup/backup.go
+++ b/chanbackup/backup.go
@@ -62,12 +62,6 @@ func FetchBackupForChan(chanPoint wire.OutPoint,
 		return nil, fmt.Errorf("unable to find target channel")
 	}
 
-	// TODO(halseth): support chan backups for anchor types.
-	if targetChan.ChanType.HasAnchors() {
-		return nil, fmt.Errorf("channel type does not support " +
-			"backups yet")
-	}
-
 	// Once we have the target channel, we can assemble the backup using
 	// the source to obtain any extra information that we may need.
 	staticChanBackup, err := assembleChanBackup(chanSource, targetChan)
@@ -93,11 +87,6 @@ func FetchStaticChanBackups(chanSource LiveChannelSource) ([]Single, error) {
 	// channel.
 	staticChanBackups := make([]Single, 0, len(openChans))
 	for _, openChan := range openChans {
-		// TODO(halseth): support chan backups for anchor types.
-		if openChan.ChanType.HasAnchors() {
-			continue
-		}
-
 		chanBackup, err := assembleChanBackup(chanSource, openChan)
 		if err != nil {
 			return nil, err

--- a/chanbackup/pubsub.go
+++ b/chanbackup/pubsub.go
@@ -213,12 +213,6 @@ func (s *SubSwapper) backupUpdater() {
 			// For all new open channels, we'll create a new SCB
 			// given the required information.
 			for _, newChan := range chanUpdate.NewChans {
-				// TODO(halseth): support chan backups for
-				// anchor types.
-				if newChan.ChanType.HasAnchors() {
-					continue
-				}
-
 				log.Debugf("Adding channel %v to backup state",
 					newChan.FundingOutpoint)
 

--- a/chanbackup/single.go
+++ b/chanbackup/single.go
@@ -31,6 +31,11 @@ const (
 	// implicitly denotes that this channel uses the new tweakless commit
 	// format.
 	TweaklessCommitVersion = 1
+
+	// AnchorsCommitVersion is the third SCB version. This version
+	// implicitly denotes that this channel uses the new anchor commitment
+	// format.
+	AnchorsCommitVersion = 2
 )
 
 // Single is a static description of an existing channel that can be used for
@@ -157,9 +162,14 @@ func NewSingle(channel *channeldb.OpenChannel,
 		},
 	}
 
-	if channel.ChanType.IsTweakless() {
+	switch {
+	case channel.ChanType.HasAnchors():
+		single.Version = AnchorsCommitVersion
+
+	case channel.ChanType.IsTweakless():
 		single.Version = TweaklessCommitVersion
-	} else {
+
+	default:
 		single.Version = DefaultSingleVersion
 	}
 
@@ -174,6 +184,7 @@ func (s *Single) Serialize(w io.Writer) error {
 	switch s.Version {
 	case DefaultSingleVersion:
 	case TweaklessCommitVersion:
+	case AnchorsCommitVersion:
 	default:
 		return fmt.Errorf("unable to serialize w/ unknown "+
 			"version: %v", s.Version)
@@ -332,6 +343,7 @@ func (s *Single) Deserialize(r io.Reader) error {
 	switch s.Version {
 	case DefaultSingleVersion:
 	case TweaklessCommitVersion:
+	case AnchorsCommitVersion:
 	default:
 		return fmt.Errorf("unable to de-serialize w/ unknown "+
 			"version: %v", s.Version)

--- a/chanbackup/single_test.go
+++ b/chanbackup/single_test.go
@@ -229,9 +229,17 @@ func TestSinglePackUnpack(t *testing.T) {
 			valid:   true,
 		},
 
-		// The new tweakless version, should pack/unpack with no problem.
+		// The new tweakless version, should pack/unpack with no
+		// problem.
 		{
 			version: TweaklessCommitVersion,
+			valid:   true,
+		},
+
+		// The new anchor version, should pack/unpack with no
+		// problem.
+		{
+			version: AnchorsCommitVersion,
 			valid:   true,
 		},
 

--- a/chanrestore.go
+++ b/chanrestore.go
@@ -106,9 +106,16 @@ func (c *chanDBRestorer) openChannelShell(backup chanbackup.Single) (
 	case chanbackup.TweaklessCommitVersion:
 		chanType = channeldb.SingleFunderTweaklessBit
 
+	case chanbackup.AnchorsCommitVersion:
+		chanType = channeldb.AnchorOutputsBit
+		chanType |= channeldb.SingleFunderTweaklessBit
+
 	default:
 		return nil, fmt.Errorf("unknown Single version: %v", err)
 	}
+
+	ltndLog.Infof("SCB Recovery: created channel shell for ChannelPoint(%v), "+
+		"chan_type=%v", backup.FundingOutpoint, chanType)
 
 	chanShell := channeldb.ChannelShell{
 		NodeAddrs: backup.Addresses,

--- a/lncfg/protocol_legacy_on.go
+++ b/lncfg/protocol_legacy_on.go
@@ -19,7 +19,7 @@ type ProtocolOptions struct {
 
 	// Anchors should be set if we want to support opening or accepting
 	// channels having the anchor commitment type.
-	Anchors bool `long:"anchors" description:"EXPERIMENTAL: enable experimental support for anchor commitments. Won't work with watchtowers or static channel backups"`
+	Anchors bool `long:"anchors" description:"EXPERIMENTAL: enable experimental support for anchor commitments, won't work with watchtowers"`
 }
 
 // LegacyOnion returns true if the old legacy onion format should be used when

--- a/lncfg/protocol_legacy_on.go
+++ b/lncfg/protocol_legacy_on.go
@@ -35,7 +35,7 @@ func (l *ProtocolOptions) NoStaticRemoteKey() bool {
 	return l.CommitmentTweak
 }
 
-// AnchorCommitments returns true if support for the the anchor commitment type
+// AnchorCommitments returns true if support for the anchor commitment type
 // should be signaled.
 func (l *ProtocolOptions) AnchorCommitments() bool {
 	return l.Anchors

--- a/lnwallet/commitment.go
+++ b/lnwallet/commitment.go
@@ -309,7 +309,7 @@ func CommitScriptAnchors(localChanCfg,
 		return nil, nil, err
 	}
 
-	// And the anchor spemdable by the remote node.
+	// And the anchor spendable by the remote node.
 	remoteAnchor, err := anchorScript(remoteChanCfg.MultiSigKey.PubKey)
 	if err != nil {
 		return nil, nil, err


### PR DESCRIPTION
In this PR, we add SCB support for anchor commitments and update the integration tests to add a single case to cover SCB file recovery for anchor commitments. We only add a single case here in order to leave the more encompassing itest overhaul for all commitment types to: https://github.com/lightningnetwork/lnd/pull/4001