### PR TITLE
watchtower: automatically create tor hidden service if enabled

### DIFF
--- a/config.go
+++ b/config.go
@@ -221,16 +221,17 @@ type autoPilotConfig struct {
 }
 
 type torConfig struct {
-	Active          bool   `long:"active" description:"Allow outbound and inbound connections to be routed through Tor"`
-	SOCKS           string `long:"socks" description:"The host:port that Tor's exposed SOCKS5 proxy is listening on"`
-	DNS             string `long:"dns" description:"The DNS server as host:port that Tor will use for SRV queries - NOTE must have TCP resolution enabled"`
-	StreamIsolation bool   `long:"streamisolation" description:"Enable Tor stream isolation by randomizing user credentials for each connection."`
-	Control         string `long:"control" description:"The host:port that Tor is listening on for Tor control connections"`
-	TargetIPAddress string `long:"targetipaddress" description:"IP address that Tor should use as the target of the hidden service"`
-	Password        string `long:"password" description:"The password used to arrive at the HashedControlPassword for the control port. If provided, the HASHEDPASSWORD authentication method will be used instead of the SAFECOOKIE one."`
-	V2              bool   `long:"v2" description:"Automatically set up a v2 onion service to listen for inbound connections"`
-	V3              bool   `long:"v3" description:"Automatically set up a v3 onion service to listen for inbound connections"`
-	PrivateKeyPath  string `long:"privatekeypath" description:"The path to the private key of the onion service being created"`
+	Active            bool   `long:"active" description:"Allow outbound and inbound connections to be routed through Tor"`
+	SOCKS             string `long:"socks" description:"The host:port that Tor's exposed SOCKS5 proxy is listening on"`
+	DNS               string `long:"dns" description:"The DNS server as host:port that Tor will use for SRV queries - NOTE must have TCP resolution enabled"`
+	StreamIsolation   bool   `long:"streamisolation" description:"Enable Tor stream isolation by randomizing user credentials for each connection."`
+	Control           string `long:"control" description:"The host:port that Tor is listening on for Tor control connections"`
+	TargetIPAddress   string `long:"targetipaddress" description:"IP address that Tor should use as the target of the hidden service"`
+	Password          string `long:"password" description:"The password used to arrive at the HashedControlPassword for the control port. If provided, the HASHEDPASSWORD authentication method will be used instead of the SAFECOOKIE one."`
+	V2                bool   `long:"v2" description:"Automatically set up a v2 onion service to listen for inbound connections"`
+	V3                bool   `long:"v3" description:"Automatically set up a v3 onion service to listen for inbound connections"`
+	PrivateKeyPath    string `long:"privatekeypath" description:"The path to the private key of the onion service being created"`
+	WatchtowerKeyPath string `long:"watchtowerkeypath" description:"The path to the private key of the watchtower onion service being created"`
 }
 
 // config defines the configuration options for lnd.
@@ -567,6 +568,7 @@ func loadConfig() (*config, error) {
 	cfg.BitcoindMode.Dir = cleanAndExpandPath(cfg.BitcoindMode.Dir)
 	cfg.LitecoindMode.Dir = cleanAndExpandPath(cfg.LitecoindMode.Dir)
 	cfg.Tor.PrivateKeyPath = cleanAndExpandPath(cfg.Tor.PrivateKeyPath)
+	cfg.Tor.WatchtowerKeyPath = cleanAndExpandPath(cfg.Tor.WatchtowerKeyPath)
 	cfg.Watchtower.TowerDir = cleanAndExpandPath(cfg.Watchtower.TowerDir)
 
 	// Ensure that the user didn't attempt to specify negative values for
@@ -678,6 +680,19 @@ func loadConfig() (*config, error) {
 		case cfg.Tor.V3:
 			cfg.Tor.PrivateKeyPath = filepath.Join(
 				lndDir, defaultTorV3PrivateKeyFilename,
+			)
+		}
+	}
+
+	if cfg.Tor.WatchtowerKeyPath == "" {
+		switch {
+		case cfg.Tor.V2:
+			cfg.Tor.WatchtowerKeyPath = filepath.Join(
+				cfg.Watchtower.TowerDir, defaultTorV2PrivateKeyFilename,
+			)
+		case cfg.Tor.V3:
+			cfg.Tor.WatchtowerKeyPath = filepath.Join(
+				cfg.Watchtower.TowerDir, defaultTorV3PrivateKeyFilename,
 			)
 		}
 	}

--- a/docs/watchtower.md
+++ b/docs/watchtower.md
@@ -102,6 +102,24 @@ If the watchtower's clients will need remote access, be sure to either:
  - Use a proxy to direct traffic from an open port to the watchtower's listening
    address.
 
+### Tor Hidden Services
+
+Watchtowers have tor hidden service support and can automatically generate a
+hidden service on startup with the following flags:
+
+```
+🏔 lnd --tor.active --tor.v3 --watchtower.active
+```
+
+The onion address is then shown in the "uris" field when queried with `lncli tower info`:
+
+```
+...
+"uris": [
+        "03281d603b2c5e19b8893a484eb938d7377179a9ef1a6bca4c0bcbbfc291657b63@bn2kxggzjysvsd5o3uqe4h7655u7v2ydhxzy7ea2fx26duaixlwuguad.onion:9911"
+]
+```
+
 Note: *The watchtower’s public key is distinct from `lnd`’s node public key. For
 now this acts as a soft whitelist as it requires clients to know the tower’s
 public key in order to use it for backups before more advanced whitelisting

--- a/server.go
+++ b/server.go
@@ -322,7 +322,8 @@ func newServer(listenAddrs []net.Addr, chanDB *channeldb.DB,
 	towerClientDB *wtdb.ClientDB, cc *chainControl,
 	privKey *btcec.PrivateKey,
 	chansToRestore walletunlocker.ChannelsToRecover,
-	chanPredicate chanacceptor.ChannelAcceptor) (*server, error) {
+	chanPredicate chanacceptor.ChannelAcceptor,
+	torController *tor.Controller) (*server, error) {
 
 	var err error
 
@@ -427,6 +428,8 @@ func newServer(listenAddrs []net.Addr, chanDB *channeldb.DB,
 		// TODO(roasbeef): derive proper onion key based on rotation
 		// schedule
 		sphinx: hop.NewOnionProcessor(sphinxRouter),
+
+		torController: torController,
 
 		persistentPeers:         make(map[string]bool),
 		persistentPeersBackoff:  make(map[string]time.Duration),
@@ -596,16 +599,6 @@ func newServer(listenAddrs []net.Addr, chanDB *channeldb.DB,
 	selfAddrs := make([]net.Addr, 0, len(externalIPs))
 	for _, ip := range externalIPs {
 		selfAddrs = append(selfAddrs, ip)
-	}
-
-	// If we were requested to route connections through Tor and to
-	// automatically create an onion service, we'll initiate our Tor
-	// controller and establish a connection to the Tor server.
-	if cfg.Tor.Active && (cfg.Tor.V2 || cfg.Tor.V3) {
-		s.torController = tor.NewController(
-			cfg.Tor.Control, cfg.Tor.TargetIPAddress,
-			cfg.Tor.Password,
-		)
 	}
 
 	chanGraph := chanDB.ChannelGraph()
@@ -1251,7 +1244,7 @@ func (s *server) Start() error {
 	var startErr error
 	s.start.Do(func() {
 		if s.torController != nil {
-			if err := s.initTorController(); err != nil {
+			if err := s.createNewHiddenService(); err != nil {
 				startErr = err
 				return
 			}
@@ -1441,10 +1434,6 @@ func (s *server) Stop() error {
 		atomic.StoreInt32(&s.stopping, 1)
 
 		close(s.quit)
-
-		if s.torController != nil {
-			s.torController.Stop()
-		}
 
 		// Shutdown the wallet, funding manager, and the rpc server.
 		s.chanStatusMgr.Stop()
@@ -1965,14 +1954,9 @@ func (s *server) initialPeerBootstrap(ignore map[autopilot.NodeID]struct{},
 	}
 }
 
-// initTorController initiliazes the Tor controller backed by lnd and
-// automatically sets up a v2 onion service in order to listen for inbound
-// connections over Tor.
-func (s *server) initTorController() error {
-	if err := s.torController.Start(); err != nil {
-		return err
-	}
-
+// createNewHiddenService automatically sets up a v2 or v3 onion service in
+// order to listen for inbound connections over Tor.
+func (s *server) createNewHiddenService() error {
 	// Determine the different ports the server is listening on. The onion
 	// service's virtual port will map to these ports and one will be picked
 	// at random when the onion service is being accessed.

--- a/watchtower/config.go
+++ b/watchtower/config.go
@@ -34,8 +34,8 @@ var (
 )
 
 // Config defines the resources and parameters used to configure a Watchtower.
-// All nil-able elements with the Config must be set in order for the Watchtower
-// to function properly.
+// All nil-able elements besides tor-related ones must be set in order for the
+// Watchtower to function properly.
 type Config struct {
 	// ChainHash identifies the chain that the watchtower will be monitoring
 	// for breaches and that will be advertised in the server's Init message
@@ -89,4 +89,16 @@ type Config struct {
 	// message from the other end, if the connection has stopped buffering
 	// the server's replies.
 	WriteTimeout time.Duration
+
+	// TorController allows the watchtower to optionally setup an onion hidden
+	// service.
+	TorController *tor.Controller
+
+	// WatchtowerKeyPath allows the watchtower to specify where the private key
+	// for a watchtower hidden service should be stored.
+	WatchtowerKeyPath string
+
+	// Type specifies the hidden service type (V2 or V3) that the watchtower
+	// will create.
+	Type tor.OnionType
 }

--- a/watchtower/standalone.go
+++ b/watchtower/standalone.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/btcsuite/btcd/btcec"
 	"github.com/lightningnetwork/lnd/brontide"
+	"github.com/lightningnetwork/lnd/tor"
 	"github.com/lightningnetwork/lnd/watchtower/lookout"
 	"github.com/lightningnetwork/lnd/watchtower/wtserver"
 )
@@ -112,6 +113,15 @@ func (w *Standalone) Start() error {
 
 	log.Infof("Starting watchtower")
 
+	// If a tor controller exists in the config, then automatically create a
+	// hidden service for the watchtower to accept inbound connections from.
+	if w.cfg.TorController != nil {
+		log.Infof("Creating watchtower hidden service")
+		if err := w.createNewHiddenService(); err != nil {
+			return err
+		}
+	}
+
 	if err := w.lookout.Start(); err != nil {
 		return err
 	}
@@ -138,6 +148,39 @@ func (w *Standalone) Stop() error {
 	w.lookout.Stop()
 
 	log.Infof("Watchtower stopped successfully")
+
+	return nil
+}
+
+// createNewHiddenService automatically sets up a v2 or v3 onion service in
+// order to listen for inbound connections over Tor.
+func (w *Standalone) createNewHiddenService() error {
+	// Get all the ports the watchtower is listening on. These will be used to
+	// map the hidden service's virtual port.
+	listenPorts := make([]int, 0, len(w.listeners))
+	for _, listener := range w.listeners {
+		port := listener.Addr().(*net.TCPAddr).Port
+		listenPorts = append(listenPorts, port)
+	}
+
+	// Once we've created the port mapping, we can automatically create the
+	// hidden service. The service's private key will be saved on disk in order
+	// to persistently have access to this hidden service across restarts.
+	onionCfg := tor.AddOnionConfig{
+		VirtualPort: DefaultPeerPort,
+		TargetPorts: listenPorts,
+		Store:       tor.NewOnionFile(w.cfg.WatchtowerKeyPath, 0600),
+		Type:        w.cfg.Type,
+	}
+
+	addr, err := w.cfg.TorController.AddOnion(onionCfg)
+	if err != nil {
+		return err
+	}
+
+	// Append this address to ExternalIPs so that it will be exposed in
+	// tower info calls.
+	w.cfg.ExternalIPs = append(w.cfg.ExternalIPs, addr)
 
 	return nil
 }


### PR DESCRIPTION
Picks up where https://github.com/lightningnetwork/lnd/pull/3613 left off. I think I gave credit correctly to @orbitalturtle by adding them as a Co-author in the first commit message. The old PR created two `TorContoller`s, one in the `server`, one in the watchtower server. Now, a `TorController` is instead created in `lnd.go` and passed to both subsystems to avoid creating multiple connections to Tor's ControlPort.

Closes #3302