### PR TITLE
docker: pin down btcd version

### DIFF
--- a/docker/btcd/Dockerfile
+++ b/docker/btcd/Dockerfile
@@ -7,8 +7,12 @@ RUN apk add --no-cache git gcc musl-dev
 
 WORKDIR $GOPATH/src/github.com/btcsuite/btcd
 
+# Pin down btcd to a version that we know works with lnd.
+ARG BTCD_VERSION=v0.20.1-beta
+
 # Grab and install the latest version of of btcd and all related dependencies.
 RUN git clone https://github.com/btcsuite/btcd.git . \
+    && git checkout $BTCD_VERSION \
     &&  GO111MODULE=on go install -v . ./cmd/...
 
 # Start a new image


### PR DESCRIPTION
There was a recent change merged into btcd that isn't backward
compatible with older RPC clients. To make sure our docker quick
start example still works, we need to pin down btcd to the version
that is still compatible with lnd.

Fixes the problem that was described in #4076.