### PR TITLE
channeldb: write the CommitSig in CommitDiff in LN wire format

### DIFF
--- a/channeldb/channel.go
+++ b/channeldb/channel.go
@@ -1866,12 +1866,12 @@ func deserializeLogUpdates(r io.Reader) ([]LogUpdate, error) {
 	return logUpdates, nil
 }
 
-func serializeCommitDiff(w io.Writer, diff *CommitDiff) error {
+func serializeCommitDiff(w io.Writer, diff *CommitDiff) error { // nolint: dupl
 	if err := serializeChanCommit(w, &diff.Commitment); err != nil {
 		return err
 	}
 
-	if err := diff.CommitSig.Encode(w, 0); err != nil {
+	if err := WriteElements(w, diff.CommitSig); err != nil {
 		return err
 	}
 
@@ -1917,10 +1917,16 @@ func deserializeCommitDiff(r io.Reader) (*CommitDiff, error) {
 		return nil, err
 	}
 
-	d.CommitSig = &lnwire.CommitSig{}
-	if err := d.CommitSig.Decode(r, 0); err != nil {
+	var msg lnwire.Message
+	if err := ReadElements(r, &msg); err != nil {
 		return nil, err
 	}
+	commitSig, ok := msg.(*lnwire.CommitSig)
+	if !ok {
+		return nil, fmt.Errorf("expected lnwire.CommitSig, instead "+
+			"read: %T", msg)
+	}
+	d.CommitSig = commitSig
 
 	d.LogUpdates, err = deserializeLogUpdates(r)
 	if err != nil {

--- a/channeldb/codec.go
+++ b/channeldb/codec.go
@@ -1,6 +1,7 @@
 package channeldb
 
 import (
+	"bytes"
 	"encoding/binary"
 	"fmt"
 	"io"
@@ -178,7 +179,17 @@ func WriteElement(w io.Writer, element interface{}) error {
 		}
 
 	case lnwire.Message:
-		if _, err := lnwire.WriteMessage(w, e, 0); err != nil {
+		var msgBuf bytes.Buffer
+		if _, err := lnwire.WriteMessage(&msgBuf, e, 0); err != nil {
+			return err
+		}
+
+		msgLen := uint16(len(msgBuf.Bytes()))
+		if err := WriteElements(w, msgLen); err != nil {
+			return err
+		}
+
+		if _, err := w.Write(msgBuf.Bytes()); err != nil {
 			return err
 		}
 
@@ -394,7 +405,13 @@ func ReadElement(r io.Reader, element interface{}) error {
 		*e = bytes
 
 	case *lnwire.Message:
-		msg, err := lnwire.ReadMessage(r, 0)
+		var msgLen uint16
+		if err := ReadElement(r, &msgLen); err != nil {
+			return err
+		}
+
+		msgReader := io.LimitReader(r, int64(msgLen))
+		msg, err := lnwire.ReadMessage(msgReader, 0)
 		if err != nil {
 			return err
 		}

--- a/channeldb/db.go
+++ b/channeldb/db.go
@@ -170,6 +170,12 @@ var (
 			number:    18,
 			migration: mig.CreateTLB(peersBucket),
 		},
+		{
+			// Migrate to length prefixed wire messages everywhere
+			// in the database.
+			number:    19,
+			migration: migration19.MigrateDatabaseWireMessages,
+		},
 	}
 
 	// Big endian is the preferred byte order, due to cursor scans over

--- a/channeldb/migration19/enclosed_codec.go
+++ b/channeldb/migration19/enclosed_codec.go
@@ -1,0 +1,358 @@
+package migration19
+
+import (
+	"encoding/binary"
+	"fmt"
+	"io"
+
+	"github.com/btcsuite/btcd/btcec"
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"github.com/btcsuite/btcd/wire"
+	"github.com/btcsuite/btcutil"
+	"github.com/lightningnetwork/lnd/keychain"
+	"github.com/lightningnetwork/lnd/lnwire"
+)
+
+var (
+	// Big endian is the preferred byte order, due to cursor scans over
+	// integer keys iterating in order.
+	byteOrder = binary.BigEndian
+)
+
+// writeOutpoint writes an outpoint to the passed writer using the minimal
+// amount of bytes possible.
+func writeOutpoint(w io.Writer, o *wire.OutPoint) error {
+	if _, err := w.Write(o.Hash[:]); err != nil {
+		return err
+	}
+	if err := binary.Write(w, byteOrder, o.Index); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// readOutpoint reads an outpoint from the passed reader that was previously
+// written using the writeOutpoint struct.
+func readOutpoint(r io.Reader, o *wire.OutPoint) error {
+	if _, err := io.ReadFull(r, o.Hash[:]); err != nil {
+		return err
+	}
+	if err := binary.Read(r, byteOrder, &o.Index); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// UnknownElementType is an error returned when the codec is unable to encode or
+// decode a particular type.
+type UnknownElementType struct {
+	method  string
+	element interface{}
+}
+
+// NewUnknownElementType creates a new UnknownElementType error from the passed
+// method name and element.
+func NewUnknownElementType(method string, el interface{}) UnknownElementType {
+	return UnknownElementType{method: method, element: el}
+}
+
+// Error returns the name of the method that encountered the error, as well as
+// the type that was unsupported.
+func (e UnknownElementType) Error() string {
+	return fmt.Sprintf("Unknown type in %s: %T", e.method, e.element)
+}
+
+// WriteElement is a one-stop shop to write the big endian representation of
+// any element which is to be serialized for storage on disk. The passed
+// io.Writer should be backed by an appropriately sized byte slice, or be able
+// to dynamically expand to accommodate additional data.
+func WriteElement(w io.Writer, element interface{}) error {
+	switch e := element.(type) {
+	case keychain.KeyDescriptor:
+		if err := binary.Write(w, byteOrder, e.Family); err != nil {
+			return err
+		}
+		if err := binary.Write(w, byteOrder, e.Index); err != nil {
+			return err
+		}
+
+		if e.PubKey != nil {
+			if err := binary.Write(w, byteOrder, true); err != nil {
+				return fmt.Errorf("error writing serialized element: %s", err)
+			}
+
+			return WriteElement(w, e.PubKey)
+		}
+
+		return binary.Write(w, byteOrder, false)
+
+	case chainhash.Hash:
+		if _, err := w.Write(e[:]); err != nil {
+			return err
+		}
+
+	case ClosureType:
+		if err := binary.Write(w, byteOrder, e); err != nil {
+			return err
+		}
+
+	case wire.OutPoint:
+		return writeOutpoint(w, &e)
+
+	case lnwire.ShortChannelID:
+		if err := binary.Write(w, byteOrder, e.ToUint64()); err != nil {
+			return err
+		}
+
+	case lnwire.ChannelID:
+		if _, err := w.Write(e[:]); err != nil {
+			return err
+		}
+
+	case int64, uint64:
+		if err := binary.Write(w, byteOrder, e); err != nil {
+			return err
+		}
+
+	case uint32:
+		if err := binary.Write(w, byteOrder, e); err != nil {
+			return err
+		}
+
+	case int32:
+		if err := binary.Write(w, byteOrder, e); err != nil {
+			return err
+		}
+
+	case uint16:
+		if err := binary.Write(w, byteOrder, e); err != nil {
+			return err
+		}
+
+	case uint8:
+		if err := binary.Write(w, byteOrder, e); err != nil {
+			return err
+		}
+
+	case bool:
+		if err := binary.Write(w, byteOrder, e); err != nil {
+			return err
+		}
+
+	case btcutil.Amount:
+		if err := binary.Write(w, byteOrder, uint64(e)); err != nil {
+			return err
+		}
+
+	case lnwire.MilliSatoshi:
+		if err := binary.Write(w, byteOrder, uint64(e)); err != nil {
+			return err
+		}
+
+	case *btcec.PublicKey:
+		b := e.SerializeCompressed()
+		if _, err := w.Write(b); err != nil {
+			return err
+		}
+
+	case *wire.MsgTx:
+		return e.Serialize(w)
+
+	case [32]byte:
+		if _, err := w.Write(e[:]); err != nil {
+			return err
+		}
+
+	case []byte:
+		if err := wire.WriteVarBytes(w, 0, e); err != nil {
+			return err
+		}
+
+	case lnwire.Message:
+		if _, err := lnwire.WriteMessage(w, e, 0); err != nil {
+			return err
+		}
+
+	case lnwire.FundingFlag:
+		if err := binary.Write(w, byteOrder, e); err != nil {
+			return err
+		}
+
+	default:
+		return UnknownElementType{"WriteElement", e}
+	}
+
+	return nil
+}
+
+// WriteElements is writes each element in the elements slice to the passed
+// io.Writer using WriteElement.
+func WriteElements(w io.Writer, elements ...interface{}) error {
+	for _, element := range elements {
+		err := WriteElement(w, element)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// ReadElement is a one-stop utility function to deserialize any datastructure
+// encoded using the serialization format of the database.
+func ReadElement(r io.Reader, element interface{}) error {
+	switch e := element.(type) {
+	case *chainhash.Hash:
+		if _, err := io.ReadFull(r, e[:]); err != nil {
+			return err
+		}
+
+	case *wire.OutPoint:
+		return readOutpoint(r, e)
+
+	case *lnwire.ShortChannelID:
+		var a uint64
+		if err := binary.Read(r, byteOrder, &a); err != nil {
+			return err
+		}
+		*e = lnwire.NewShortChanIDFromInt(a)
+
+	case *lnwire.ChannelID:
+		if _, err := io.ReadFull(r, e[:]); err != nil {
+			return err
+		}
+
+	case *int64, *uint64:
+		if err := binary.Read(r, byteOrder, e); err != nil {
+			return err
+		}
+
+	case *uint32:
+		if err := binary.Read(r, byteOrder, e); err != nil {
+			return err
+		}
+
+	case *int32:
+		if err := binary.Read(r, byteOrder, e); err != nil {
+			return err
+		}
+
+	case *uint16:
+		if err := binary.Read(r, byteOrder, e); err != nil {
+			return err
+		}
+
+	case *uint8:
+		if err := binary.Read(r, byteOrder, e); err != nil {
+			return err
+		}
+
+	case *bool:
+		if err := binary.Read(r, byteOrder, e); err != nil {
+			return err
+		}
+
+	case *btcutil.Amount:
+		var a uint64
+		if err := binary.Read(r, byteOrder, &a); err != nil {
+			return err
+		}
+
+		*e = btcutil.Amount(a)
+
+	case *lnwire.MilliSatoshi:
+		var a uint64
+		if err := binary.Read(r, byteOrder, &a); err != nil {
+			return err
+		}
+
+		*e = lnwire.MilliSatoshi(a)
+
+	case **btcec.PublicKey:
+		var b [btcec.PubKeyBytesLenCompressed]byte
+		if _, err := io.ReadFull(r, b[:]); err != nil {
+			return err
+		}
+
+		pubKey, err := btcec.ParsePubKey(b[:], btcec.S256())
+		if err != nil {
+			return err
+		}
+		*e = pubKey
+
+	case **wire.MsgTx:
+		tx := wire.NewMsgTx(2)
+		if err := tx.Deserialize(r); err != nil {
+			return err
+		}
+
+		*e = tx
+
+	case *[32]byte:
+		if _, err := io.ReadFull(r, e[:]); err != nil {
+			return err
+		}
+
+	case *[]byte:
+		bytes, err := wire.ReadVarBytes(r, 0, 66000, "[]byte")
+		if err != nil {
+			return err
+		}
+
+		*e = bytes
+
+	case *lnwire.Message:
+		msg, err := lnwire.ReadMessage(r, 0)
+		if err != nil {
+			return err
+		}
+
+		*e = msg
+
+	case *lnwire.FundingFlag:
+		if err := binary.Read(r, byteOrder, e); err != nil {
+			return err
+		}
+
+	case *ClosureType:
+		if err := binary.Read(r, byteOrder, e); err != nil {
+			return err
+		}
+
+	case *keychain.KeyDescriptor:
+		if err := binary.Read(r, byteOrder, &e.Family); err != nil {
+			return err
+		}
+		if err := binary.Read(r, byteOrder, &e.Index); err != nil {
+			return err
+		}
+
+		var hasPubKey bool
+		if err := binary.Read(r, byteOrder, &hasPubKey); err != nil {
+			return err
+		}
+
+		if hasPubKey {
+			return ReadElement(r, &e.PubKey)
+		}
+
+	default:
+		return UnknownElementType{"ReadElement", e}
+	}
+
+	return nil
+}
+
+// ReadElements deserializes a variable number of elements into the passed
+// io.Reader, with each element being deserialized according to the ReadElement
+// function.
+func ReadElements(r io.Reader, elements ...interface{}) error {
+	for _, element := range elements {
+		err := ReadElement(r, element)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/channeldb/migration19/enclosed_types.go
+++ b/channeldb/migration19/enclosed_types.go
@@ -1,0 +1,541 @@
+package migration19
+
+import (
+	"encoding/binary"
+	"fmt"
+	"io"
+
+	"github.com/btcsuite/btcd/btcec"
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"github.com/btcsuite/btcd/wire"
+	"github.com/btcsuite/btcutil"
+	"github.com/lightningnetwork/lnd/keychain"
+	"github.com/lightningnetwork/lnd/lnwire"
+)
+
+var (
+	// ErrInvalidCircuitKeyLen signals that a circuit key could not be
+	// decoded because the byte slice is of an invalid length.
+	ErrInvalidCircuitKeyLen = fmt.Errorf(
+		"length of serialized circuit key must be 16 bytes")
+)
+
+// CircuitKey is used by a channel to uniquely identify the HTLCs it receives
+// from the switch, and is used to purge our in-memory state of HTLCs that have
+// already been processed by a link. Two list of CircuitKeys are included in
+// each CommitDiff to allow a link to determine which in-memory htlcs directed
+// the opening and closing of circuits in the switch's circuit map.
+type CircuitKey struct {
+	// ChanID is the short chanid indicating the HTLC's origin.
+	//
+	// NOTE: It is fine for this value to be blank, as this indicates a
+	// locally-sourced payment.
+	ChanID lnwire.ShortChannelID
+
+	// HtlcID is the unique htlc index predominately assigned by links,
+	// though can also be assigned by switch in the case of locally-sourced
+	// payments.
+	HtlcID uint64
+}
+
+// SetBytes deserializes the given bytes into this CircuitKey.
+func (k *CircuitKey) SetBytes(bs []byte) error {
+	if len(bs) != 16 {
+		return ErrInvalidCircuitKeyLen
+	}
+
+	k.ChanID = lnwire.NewShortChanIDFromInt(
+		binary.BigEndian.Uint64(bs[:8]))
+	k.HtlcID = binary.BigEndian.Uint64(bs[8:])
+
+	return nil
+}
+
+// Bytes returns the serialized bytes for this circuit key.
+func (k CircuitKey) Bytes() []byte {
+	var bs = make([]byte, 16)
+	binary.BigEndian.PutUint64(bs[:8], k.ChanID.ToUint64())
+	binary.BigEndian.PutUint64(bs[8:], k.HtlcID)
+	return bs
+}
+
+// Encode writes a CircuitKey to the provided io.Writer.
+func (k *CircuitKey) Encode(w io.Writer) error {
+	var scratch [16]byte
+	binary.BigEndian.PutUint64(scratch[:8], k.ChanID.ToUint64())
+	binary.BigEndian.PutUint64(scratch[8:], k.HtlcID)
+
+	_, err := w.Write(scratch[:])
+	return err
+}
+
+// Decode reads a CircuitKey from the provided io.Reader.
+func (k *CircuitKey) Decode(r io.Reader) error {
+	var scratch [16]byte
+
+	if _, err := io.ReadFull(r, scratch[:]); err != nil {
+		return err
+	}
+	k.ChanID = lnwire.NewShortChanIDFromInt(
+		binary.BigEndian.Uint64(scratch[:8]))
+	k.HtlcID = binary.BigEndian.Uint64(scratch[8:])
+
+	return nil
+}
+
+// String returns a string representation of the CircuitKey.
+func (k CircuitKey) String() string {
+	return fmt.Sprintf("(Chan ID=%s, HTLC ID=%d)", k.ChanID, k.HtlcID)
+}
+
+// HTLC is the on-disk representation of a hash time-locked contract. HTLCs are
+// contained within ChannelDeltas which encode the current state of the
+// commitment between state updates.
+//
+// TODO(roasbeef): save space by using smaller ints at tail end?
+type HTLC struct {
+	// Signature is the signature for the second level covenant transaction
+	// for this HTLC. The second level transaction is a timeout tx in the
+	// case that this is an outgoing HTLC, and a success tx in the case
+	// that this is an incoming HTLC.
+	//
+	// TODO(roasbeef): make [64]byte instead?
+	Signature []byte
+
+	// RHash is the payment hash of the HTLC.
+	RHash [32]byte
+
+	// Amt is the amount of milli-satoshis this HTLC escrows.
+	Amt lnwire.MilliSatoshi
+
+	// RefundTimeout is the absolute timeout on the HTLC that the sender
+	// must wait before reclaiming the funds in limbo.
+	RefundTimeout uint32
+
+	// OutputIndex is the output index for this particular HTLC output
+	// within the commitment transaction.
+	OutputIndex int32
+
+	// Incoming denotes whether we're the receiver or the sender of this
+	// HTLC.
+	Incoming bool
+
+	// OnionBlob is an opaque blob which is used to complete multi-hop
+	// routing.
+	OnionBlob []byte
+
+	// HtlcIndex is the HTLC counter index of this active, outstanding
+	// HTLC. This differs from the LogIndex, as the HtlcIndex is only
+	// incremented for each offered HTLC, while they LogIndex is
+	// incremented for each update (includes settle+fail).
+	HtlcIndex uint64
+
+	// LogIndex is the cumulative log index of this HTLC. This differs
+	// from the HtlcIndex as this will be incremented for each new log
+	// update added.
+	LogIndex uint64
+}
+
+// ChannelCommitment is a snapshot of the commitment state at a particular
+// point in the commitment chain. With each state transition, a snapshot of the
+// current state along with all non-settled HTLCs are recorded. These snapshots
+// detail the state of the _remote_ party's commitment at a particular state
+// number.  For ourselves (the local node) we ONLY store our most recent
+// (unrevoked) state for safety purposes.
+type ChannelCommitment struct {
+	// CommitHeight is the update number that this ChannelDelta represents
+	// the total number of commitment updates to this point. This can be
+	// viewed as sort of a "commitment height" as this number is
+	// monotonically increasing.
+	CommitHeight uint64
+
+	// LocalLogIndex is the cumulative log index index of the local node at
+	// this point in the commitment chain. This value will be incremented
+	// for each _update_ added to the local update log.
+	LocalLogIndex uint64
+
+	// LocalHtlcIndex is the current local running HTLC index. This value
+	// will be incremented for each outgoing HTLC the local node offers.
+	LocalHtlcIndex uint64
+
+	// RemoteLogIndex is the cumulative log index index of the remote node
+	// at this point in the commitment chain. This value will be
+	// incremented for each _update_ added to the remote update log.
+	RemoteLogIndex uint64
+
+	// RemoteHtlcIndex is the current remote running HTLC index. This value
+	// will be incremented for each outgoing HTLC the remote node offers.
+	RemoteHtlcIndex uint64
+
+	// LocalBalance is the current available settled balance within the
+	// channel directly spendable by us.
+	//
+	// NOTE: This is the balance *after* subtracting any commitment fee,
+	// AND anchor output values.
+	LocalBalance lnwire.MilliSatoshi
+
+	// RemoteBalance is the current available settled balance within the
+	// channel directly spendable by the remote node.
+	//
+	// NOTE: This is the balance *after* subtracting any commitment fee,
+	// AND anchor output values.
+	RemoteBalance lnwire.MilliSatoshi
+
+	// CommitFee is the amount calculated to be paid in fees for the
+	// current set of commitment transactions. The fee amount is persisted
+	// with the channel in order to allow the fee amount to be removed and
+	// recalculated with each channel state update, including updates that
+	// happen after a system restart.
+	CommitFee btcutil.Amount
+
+	// FeePerKw is the min satoshis/kilo-weight that should be paid within
+	// the commitment transaction for the entire duration of the channel's
+	// lifetime. This field may be updated during normal operation of the
+	// channel as on-chain conditions change.
+	//
+	// TODO(halseth): make this SatPerKWeight. Cannot be done atm because
+	// this will cause the import cycle lnwallet<->channeldb. Fee
+	// estimation stuff should be in its own package.
+	FeePerKw btcutil.Amount
+
+	// CommitTx is the latest version of the commitment state, broadcast
+	// able by us.
+	CommitTx *wire.MsgTx
+
+	// CommitSig is one half of the signature required to fully complete
+	// the script for the commitment transaction above. This is the
+	// signature signed by the remote party for our version of the
+	// commitment transactions.
+	CommitSig []byte
+
+	// Htlcs is the set of HTLC's that are pending at this particular
+	// commitment height.
+	Htlcs []HTLC
+
+	// TODO(roasbeef): pending commit pointer?
+	//  * lets just walk through
+}
+
+// LogUpdate represents a pending update to the remote commitment chain. The
+// log update may be an add, fail, or settle entry. We maintain this data in
+// order to be able to properly retransmit our proposed
+// state if necessary.
+type LogUpdate struct {
+	// LogIndex is the log index of this proposed commitment update entry.
+	LogIndex uint64
+
+	// UpdateMsg is the update message that was included within the our
+	// local update log. The LogIndex value denotes the log index of this
+	// update which will be used when restoring our local update log if
+	// we're left with a dangling update on restart.
+	UpdateMsg lnwire.Message
+}
+
+// Encode writes a log update to the provided io.Writer.
+func (l *LogUpdate) Encode(w io.Writer) error {
+	return WriteElements(w, l.LogIndex, l.UpdateMsg)
+}
+
+// Decode reads a log update from the provided io.Reader.
+func (l *LogUpdate) Decode(r io.Reader) error {
+	return ReadElements(r, &l.LogIndex, &l.UpdateMsg)
+}
+
+// AddRef is used to identify a particular Add in a FwdPkg. The short channel ID
+// is assumed to be that of the packager.
+type AddRef struct {
+	// Height is the remote commitment height that locked in the Add.
+	Height uint64
+
+	// Index is the index of the Add within the fwd pkg's Adds.
+	//
+	// NOTE: This index is static over the lifetime of a forwarding package.
+	Index uint16
+}
+
+// Encode serializes the AddRef to the given io.Writer.
+func (a *AddRef) Encode(w io.Writer) error {
+	if err := binary.Write(w, binary.BigEndian, a.Height); err != nil {
+		return err
+	}
+
+	return binary.Write(w, binary.BigEndian, a.Index)
+}
+
+// Decode deserializes the AddRef from the given io.Reader.
+func (a *AddRef) Decode(r io.Reader) error {
+	if err := binary.Read(r, binary.BigEndian, &a.Height); err != nil {
+		return err
+	}
+
+	return binary.Read(r, binary.BigEndian, &a.Index)
+}
+
+// SettleFailRef is used to locate a Settle/Fail in another channel's FwdPkg. A
+// channel does not remove its own Settle/Fail htlcs, so the source is provided
+// to locate a db bucket belonging to another channel.
+type SettleFailRef struct {
+	// Source identifies the outgoing link that locked in the settle or
+	// fail. This is then used by the *incoming* link to find the settle
+	// fail in another link's forwarding packages.
+	Source lnwire.ShortChannelID
+
+	// Height is the remote commitment height that locked in this
+	// Settle/Fail.
+	Height uint64
+
+	// Index is the index of the Add with the fwd pkg's SettleFails.
+	//
+	// NOTE: This index is static over the lifetime of a forwarding package.
+	Index uint16
+}
+
+// CommitDiff represents the delta needed to apply the state transition between
+// two subsequent commitment states. Given state N and state N+1, one is able
+// to apply the set of messages contained within the CommitDiff to N to arrive
+// at state N+1. Each time a new commitment is extended, we'll write a new
+// commitment (along with the full commitment state) to disk so we can
+// re-transmit the state in the case of a connection loss or message drop.
+type CommitDiff struct {
+	// ChannelCommitment is the full commitment state that one would arrive
+	// at by applying the set of messages contained in the UpdateDiff to
+	// the prior accepted commitment.
+	Commitment ChannelCommitment
+
+	// LogUpdates is the set of messages sent prior to the commitment state
+	// transition in question. Upon reconnection, if we detect that they
+	// don't have the commitment, then we re-send this along with the
+	// proper signature.
+	LogUpdates []LogUpdate
+
+	// CommitSig is the exact CommitSig message that should be sent after
+	// the set of LogUpdates above has been retransmitted. The signatures
+	// within this message should properly cover the new commitment state
+	// and also the HTLC's within the new commitment state.
+	CommitSig *lnwire.CommitSig
+
+	// OpenedCircuitKeys is a set of unique identifiers for any downstream
+	// Add packets included in this commitment txn. After a restart, this
+	// set of htlcs is acked from the link's incoming mailbox to ensure
+	// there isn't an attempt to re-add them to this commitment txn.
+	OpenedCircuitKeys []CircuitKey
+
+	// ClosedCircuitKeys records the unique identifiers for any settle/fail
+	// packets that were resolved by this commitment txn. After a restart,
+	// this is used to ensure those circuits are removed from the circuit
+	// map, and the downstream packets in the link's mailbox are removed.
+	ClosedCircuitKeys []CircuitKey
+
+	// AddAcks specifies the locations (commit height, pkg index) of any
+	// Adds that were failed/settled in this commit diff. This will ack
+	// entries in *this* channel's forwarding packages.
+	//
+	// NOTE: This value is not serialized, it is used to atomically mark the
+	// resolution of adds, such that they will not be reprocessed after a
+	// restart.
+	AddAcks []AddRef
+
+	// SettleFailAcks specifies the locations (chan id, commit height, pkg
+	// index) of any Settles or Fails that were locked into this commit
+	// diff, and originate from *another* channel, i.e. the outgoing link.
+	//
+	// NOTE: This value is not serialized, it is used to atomically acks
+	// settles and fails from the forwarding packages of other channels,
+	// such that they will not be reforwarded internally after a restart.
+	SettleFailAcks []SettleFailRef
+}
+
+// networkResult is the raw result received from the network after a payment
+// attempt has been made. Since the switch doesn't always have the necessary
+// data to decode the raw message, we store it together with some meta data,
+// and decode it when the router query for the final result.
+type networkResult struct {
+	// msg is the received result. This should be of type UpdateFulfillHTLC
+	// or UpdateFailHTLC.
+	msg lnwire.Message
+
+	// unencrypted indicates whether the failure encoded in the message is
+	// unencrypted, and hence doesn't need to be decrypted.
+	unencrypted bool
+
+	// isResolution indicates whether this is a resolution message, in
+	// which the failure reason might not be included.
+	isResolution bool
+}
+
+// ClosureType is an enum like structure that details exactly _how_ a channel
+// was closed. Three closure types are currently possible: none, cooperative,
+// local force close, remote force close, and (remote) breach.
+type ClosureType uint8
+
+// ChannelConstraints represents a set of constraints meant to allow a node to
+// limit their exposure, enact flow control and ensure that all HTLCs are
+// economically relevant. This struct will be mirrored for both sides of the
+// channel, as each side will enforce various constraints that MUST be adhered
+// to for the life time of the channel. The parameters for each of these
+// constraints are static for the duration of the channel, meaning the channel
+// must be torn down for them to change.
+type ChannelConstraints struct {
+	// DustLimit is the threshold (in satoshis) below which any outputs
+	// should be trimmed. When an output is trimmed, it isn't materialized
+	// as an actual output, but is instead burned to miner's fees.
+	DustLimit btcutil.Amount
+
+	// ChanReserve is an absolute reservation on the channel for the
+	// owner of this set of constraints. This means that the current
+	// settled balance for this node CANNOT dip below the reservation
+	// amount. This acts as a defense against costless attacks when
+	// either side no longer has any skin in the game.
+	ChanReserve btcutil.Amount
+
+	// MaxPendingAmount is the maximum pending HTLC value that the
+	// owner of these constraints can offer the remote node at a
+	// particular time.
+	MaxPendingAmount lnwire.MilliSatoshi
+
+	// MinHTLC is the minimum HTLC value that the owner of these
+	// constraints can offer the remote node. If any HTLCs below this
+	// amount are offered, then the HTLC will be rejected. This, in
+	// tandem with the dust limit allows a node to regulate the
+	// smallest HTLC that it deems economically relevant.
+	MinHTLC lnwire.MilliSatoshi
+
+	// MaxAcceptedHtlcs is the maximum number of HTLCs that the owner of
+	// this set of constraints can offer the remote node. This allows each
+	// node to limit their over all exposure to HTLCs that may need to be
+	// acted upon in the case of a unilateral channel closure or a contract
+	// breach.
+	MaxAcceptedHtlcs uint16
+
+	// CsvDelay is the relative time lock delay expressed in blocks. Any
+	// settled outputs that pay to the owner of this channel configuration
+	// MUST ensure that the delay branch uses this value as the relative
+	// time lock. Similarly, any HTLC's offered by this node should use
+	// this value as well.
+	CsvDelay uint16
+}
+
+// ChannelConfig is a struct that houses the various configuration opens for
+// channels. Each side maintains an instance of this configuration file as it
+// governs: how the funding and commitment transaction to be created, the
+// nature of HTLC's allotted, the keys to be used for delivery, and relative
+// time lock parameters.
+type ChannelConfig struct {
+	// ChannelConstraints is the set of constraints that must be upheld for
+	// the duration of the channel for the owner of this channel
+	// configuration. Constraints govern a number of flow control related
+	// parameters, also including the smallest HTLC that will be accepted
+	// by a participant.
+	ChannelConstraints
+
+	// MultiSigKey is the key to be used within the 2-of-2 output script
+	// for the owner of this channel config.
+	MultiSigKey keychain.KeyDescriptor
+
+	// RevocationBasePoint is the base public key to be used when deriving
+	// revocation keys for the remote node's commitment transaction. This
+	// will be combined along with a per commitment secret to derive a
+	// unique revocation key for each state.
+	RevocationBasePoint keychain.KeyDescriptor
+
+	// PaymentBasePoint is the base public key to be used when deriving
+	// the key used within the non-delayed pay-to-self output on the
+	// commitment transaction for a node. This will be combined with a
+	// tweak derived from the per-commitment point to ensure unique keys
+	// for each commitment transaction.
+	PaymentBasePoint keychain.KeyDescriptor
+
+	// DelayBasePoint is the base public key to be used when deriving the
+	// key used within the delayed pay-to-self output on the commitment
+	// transaction for a node. This will be combined with a tweak derived
+	// from the per-commitment point to ensure unique keys for each
+	// commitment transaction.
+	DelayBasePoint keychain.KeyDescriptor
+
+	// HtlcBasePoint is the base public key to be used when deriving the
+	// local HTLC key. The derived key (combined with the tweak derived
+	// from the per-commitment point) is used within the "to self" clause
+	// within any HTLC output scripts.
+	HtlcBasePoint keychain.KeyDescriptor
+}
+
+// ChannelCloseSummary contains the final state of a channel at the point it
+// was closed. Once a channel is closed, all the information pertaining to that
+// channel within the openChannelBucket is deleted, and a compact summary is
+// put in place instead.
+type ChannelCloseSummary struct {
+	// ChanPoint is the outpoint for this channel's funding transaction,
+	// and is used as a unique identifier for the channel.
+	ChanPoint wire.OutPoint
+
+	// ShortChanID encodes the exact location in the chain in which the
+	// channel was initially confirmed. This includes: the block height,
+	// transaction index, and the output within the target transaction.
+	ShortChanID lnwire.ShortChannelID
+
+	// ChainHash is the hash of the genesis block that this channel resides
+	// within.
+	ChainHash chainhash.Hash
+
+	// ClosingTXID is the txid of the transaction which ultimately closed
+	// this channel.
+	ClosingTXID chainhash.Hash
+
+	// RemotePub is the public key of the remote peer that we formerly had
+	// a channel with.
+	RemotePub *btcec.PublicKey
+
+	// Capacity was the total capacity of the channel.
+	Capacity btcutil.Amount
+
+	// CloseHeight is the height at which the funding transaction was
+	// spent.
+	CloseHeight uint32
+
+	// SettledBalance is our total balance settled balance at the time of
+	// channel closure. This _does not_ include the sum of any outputs that
+	// have been time-locked as a result of the unilateral channel closure.
+	SettledBalance btcutil.Amount
+
+	// TimeLockedBalance is the sum of all the time-locked outputs at the
+	// time of channel closure. If we triggered the force closure of this
+	// channel, then this value will be non-zero if our settled output is
+	// above the dust limit. If we were on the receiving side of a channel
+	// force closure, then this value will be non-zero if we had any
+	// outstanding outgoing HTLC's at the time of channel closure.
+	TimeLockedBalance btcutil.Amount
+
+	// CloseType details exactly _how_ the channel was closed. Five closure
+	// types are possible: cooperative, local force, remote force, breach
+	// and funding canceled.
+	CloseType ClosureType
+
+	// IsPending indicates whether this channel is in the 'pending close'
+	// state, which means the channel closing transaction has been
+	// confirmed, but not yet been fully resolved. In the case of a channel
+	// that has been cooperatively closed, it will go straight into the
+	// fully resolved state as soon as the closing transaction has been
+	// confirmed. However, for channels that have been force closed, they'll
+	// stay marked as "pending" until _all_ the pending funds have been
+	// swept.
+	IsPending bool
+
+	// RemoteCurrentRevocation is the current revocation for their
+	// commitment transaction. However, since this is the derived public key,
+	// we don't yet have the private key so we aren't yet able to verify
+	// that it's actually in the hash chain.
+	RemoteCurrentRevocation *btcec.PublicKey
+
+	// RemoteNextRevocation is the revocation key to be used for the *next*
+	// commitment transaction we create for the local node. Within the
+	// specification, this value is referred to as the
+	// per-commitment-point.
+	RemoteNextRevocation *btcec.PublicKey
+
+	// LocalChanCfg is the channel configuration for the local node.
+	LocalChanConfig ChannelConfig
+
+	// LastChanSyncMsg is the ChannelReestablish message for this channel
+	// for the state at the point where it was closed.
+	LastChanSyncMsg *lnwire.ChannelReestablish
+}

--- a/channeldb/migration19/legacy_decoding.go
+++ b/channeldb/migration19/legacy_decoding.go
@@ -1,0 +1,406 @@
+package migration19
+
+import (
+	"encoding/binary"
+	"errors"
+	"io"
+
+	"github.com/lightningnetwork/lnd/lnwire"
+)
+
+func deserializeHtlcsLegacy(r io.Reader) ([]HTLC, error) {
+	var numHtlcs uint16
+	if err := ReadElement(r, &numHtlcs); err != nil {
+		return nil, err
+	}
+
+	var htlcs []HTLC
+	if numHtlcs == 0 {
+		return htlcs, nil
+	}
+
+	htlcs = make([]HTLC, numHtlcs)
+	for i := uint16(0); i < numHtlcs; i++ {
+		if err := ReadElements(r,
+			&htlcs[i].Signature, &htlcs[i].RHash, &htlcs[i].Amt,
+			&htlcs[i].RefundTimeout, &htlcs[i].OutputIndex,
+			&htlcs[i].Incoming, &htlcs[i].OnionBlob,
+			&htlcs[i].HtlcIndex, &htlcs[i].LogIndex,
+		); err != nil {
+			return htlcs, err
+		}
+	}
+
+	return htlcs, nil
+}
+
+func deserializeLogUpdatesLegacy(r io.Reader) ([]LogUpdate, error) {
+	var numUpdates uint16
+	if err := binary.Read(r, byteOrder, &numUpdates); err != nil {
+		return nil, err
+	}
+
+	logUpdates := make([]LogUpdate, numUpdates)
+	for i := 0; i < int(numUpdates); i++ {
+		err := ReadElements(r,
+			&logUpdates[i].LogIndex, &logUpdates[i].UpdateMsg,
+		)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return logUpdates, nil
+}
+
+func deserializeChanCommitLegacy(r io.Reader) (ChannelCommitment, error) {
+	var c ChannelCommitment
+
+	err := ReadElements(r,
+		&c.CommitHeight, &c.LocalLogIndex, &c.LocalHtlcIndex, &c.RemoteLogIndex,
+		&c.RemoteHtlcIndex, &c.LocalBalance, &c.RemoteBalance,
+		&c.CommitFee, &c.FeePerKw, &c.CommitTx, &c.CommitSig,
+	)
+	if err != nil {
+		return c, err
+	}
+
+	c.Htlcs, err = deserializeHtlcsLegacy(r)
+	if err != nil {
+		return c, err
+	}
+
+	return c, nil
+}
+
+func deserializeCommitDiffLegacy(r io.Reader) (*CommitDiff, error) {
+	var (
+		d   CommitDiff
+		err error
+	)
+
+	d.Commitment, err = deserializeChanCommitLegacy(r)
+	if err != nil {
+		return nil, err
+	}
+
+	d.CommitSig = &lnwire.CommitSig{}
+	if err := d.CommitSig.Decode(r, 0); err != nil {
+		return nil, err
+	}
+
+	d.LogUpdates, err = deserializeLogUpdatesLegacy(r)
+	if err != nil {
+		return nil, err
+	}
+
+	var numOpenRefs uint16
+	if err := binary.Read(r, byteOrder, &numOpenRefs); err != nil {
+		return nil, err
+	}
+
+	d.OpenedCircuitKeys = make([]CircuitKey, numOpenRefs)
+	for i := 0; i < int(numOpenRefs); i++ {
+		err := ReadElements(r,
+			&d.OpenedCircuitKeys[i].ChanID,
+			&d.OpenedCircuitKeys[i].HtlcID)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	var numClosedRefs uint16
+	if err := binary.Read(r, byteOrder, &numClosedRefs); err != nil {
+		return nil, err
+	}
+
+	d.ClosedCircuitKeys = make([]CircuitKey, numClosedRefs)
+	for i := 0; i < int(numClosedRefs); i++ {
+		err := ReadElements(r,
+			&d.ClosedCircuitKeys[i].ChanID,
+			&d.ClosedCircuitKeys[i].HtlcID)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return &d, nil
+}
+
+func serializeHtlcsLegacy(b io.Writer, htlcs ...HTLC) error {
+	numHtlcs := uint16(len(htlcs))
+	if err := WriteElement(b, numHtlcs); err != nil {
+		return err
+	}
+
+	for _, htlc := range htlcs {
+		if err := WriteElements(b,
+			htlc.Signature, htlc.RHash, htlc.Amt, htlc.RefundTimeout,
+			htlc.OutputIndex, htlc.Incoming, htlc.OnionBlob,
+			htlc.HtlcIndex, htlc.LogIndex,
+		); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func serializeChanCommitLegacy(w io.Writer, c *ChannelCommitment) error {
+	if err := WriteElements(w,
+		c.CommitHeight, c.LocalLogIndex, c.LocalHtlcIndex,
+		c.RemoteLogIndex, c.RemoteHtlcIndex, c.LocalBalance,
+		c.RemoteBalance, c.CommitFee, c.FeePerKw, c.CommitTx,
+		c.CommitSig,
+	); err != nil {
+		return err
+	}
+
+	return serializeHtlcsLegacy(w, c.Htlcs...)
+}
+
+func serializeLogUpdatesLegacy(w io.Writer, logUpdates []LogUpdate) error {
+	numUpdates := uint16(len(logUpdates))
+	if err := binary.Write(w, byteOrder, numUpdates); err != nil {
+		return err
+	}
+
+	for _, diff := range logUpdates {
+		err := WriteElements(w, diff.LogIndex, diff.UpdateMsg)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func serializeCommitDiffLegacy(w io.Writer, diff *CommitDiff) error {
+	if err := serializeChanCommitLegacy(w, &diff.Commitment); err != nil {
+		return err
+	}
+
+	if err := diff.CommitSig.Encode(w, 0); err != nil {
+		return err
+	}
+
+	if err := serializeLogUpdatesLegacy(w, diff.LogUpdates); err != nil {
+		return err
+	}
+
+	numOpenRefs := uint16(len(diff.OpenedCircuitKeys))
+	if err := binary.Write(w, byteOrder, numOpenRefs); err != nil {
+		return err
+	}
+
+	for _, openRef := range diff.OpenedCircuitKeys {
+		err := WriteElements(w, openRef.ChanID, openRef.HtlcID)
+		if err != nil {
+			return err
+		}
+	}
+
+	numClosedRefs := uint16(len(diff.ClosedCircuitKeys))
+	if err := binary.Write(w, byteOrder, numClosedRefs); err != nil {
+		return err
+	}
+
+	for _, closedRef := range diff.ClosedCircuitKeys {
+		err := WriteElements(w, closedRef.ChanID, closedRef.HtlcID)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func deserializeNetworkResultLegacy(r io.Reader) (*networkResult, error) {
+	var (
+		err error
+	)
+
+	n := &networkResult{}
+
+	n.msg, err = lnwire.ReadMessage(r, 0)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := ReadElements(r,
+		&n.unencrypted, &n.isResolution,
+	); err != nil {
+		return nil, err
+	}
+
+	return n, nil
+}
+
+func serializeNetworkResultLegacy(w io.Writer, n *networkResult) error {
+	if _, err := lnwire.WriteMessage(w, n.msg, 0); err != nil {
+		return err
+	}
+
+	return WriteElements(w, n.unencrypted, n.isResolution)
+}
+
+func readChanConfigLegacy(b io.Reader, c *ChannelConfig) error { // nolint: dupl
+	return ReadElements(b,
+		&c.DustLimit, &c.MaxPendingAmount, &c.ChanReserve,
+		&c.MinHTLC, &c.MaxAcceptedHtlcs, &c.CsvDelay,
+		&c.MultiSigKey, &c.RevocationBasePoint,
+		&c.PaymentBasePoint, &c.DelayBasePoint,
+		&c.HtlcBasePoint,
+	)
+}
+
+func deserializeCloseChannelSummaryLegacy(r io.Reader) (*ChannelCloseSummary, error) { // nolint: dupl
+
+	c := &ChannelCloseSummary{}
+
+	err := ReadElements(r,
+		&c.ChanPoint, &c.ShortChanID, &c.ChainHash, &c.ClosingTXID,
+		&c.CloseHeight, &c.RemotePub, &c.Capacity, &c.SettledBalance,
+		&c.TimeLockedBalance, &c.CloseType, &c.IsPending,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	// We'll now check to see if the channel close summary was encoded with
+	// any of the additional optional fields.
+	var hasNewFields bool
+	err = ReadElements(r, &hasNewFields)
+	if err != nil {
+		return nil, err
+	}
+
+	// If fields are not present, we can return.
+	if !hasNewFields {
+		return c, nil
+	}
+
+	// Otherwise read the new fields.
+	if err := ReadElements(r, &c.RemoteCurrentRevocation); err != nil {
+		return nil, err
+	}
+
+	if err := readChanConfigLegacy(r, &c.LocalChanConfig); err != nil {
+		return nil, err
+	}
+
+	// Finally, we'll attempt to read the next unrevoked commitment point
+	// for the remote party. If we closed the channel before receiving a
+	// funding locked message then this might not be present. A boolean
+	// indicating whether the field is present will come first.
+	var hasRemoteNextRevocation bool
+	err = ReadElements(r, &hasRemoteNextRevocation)
+	if err != nil {
+		return nil, err
+	}
+
+	// If this field was written, read it.
+	if hasRemoteNextRevocation {
+		err = ReadElements(r, &c.RemoteNextRevocation)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	// Check if we have a channel sync message to read.
+	var hasChanSyncMsg bool
+	err = ReadElements(r, &hasChanSyncMsg)
+	if err == io.EOF {
+		return c, nil
+	} else if err != nil {
+		return nil, err
+	}
+
+	// If a chan sync message is present, read it.
+	if hasChanSyncMsg {
+		// We must pass in reference to a lnwire.Message for the codec
+		// to support it.
+		msg, err := lnwire.ReadMessage(r, 0)
+		if err != nil {
+			return nil, err
+		}
+
+		chanSync, ok := msg.(*lnwire.ChannelReestablish)
+		if !ok {
+			return nil, errors.New("unable cast db Message to " +
+				"ChannelReestablish")
+		}
+		c.LastChanSyncMsg = chanSync
+	}
+
+	return c, nil
+}
+
+func writeChanConfigLegacy(b io.Writer, c *ChannelConfig) error { // nolint: dupl
+	return WriteElements(b,
+		c.DustLimit, c.MaxPendingAmount, c.ChanReserve, c.MinHTLC,
+		c.MaxAcceptedHtlcs, c.CsvDelay, c.MultiSigKey,
+		c.RevocationBasePoint, c.PaymentBasePoint, c.DelayBasePoint,
+		c.HtlcBasePoint,
+	)
+}
+
+func serializeChannelCloseSummaryLegacy(w io.Writer, cs *ChannelCloseSummary) error {
+	err := WriteElements(w,
+		cs.ChanPoint, cs.ShortChanID, cs.ChainHash, cs.ClosingTXID,
+		cs.CloseHeight, cs.RemotePub, cs.Capacity, cs.SettledBalance,
+		cs.TimeLockedBalance, cs.CloseType, cs.IsPending,
+	)
+	if err != nil {
+		return err
+	}
+
+	// If this is a close channel summary created before the addition of
+	// the new fields, then we can exit here.
+	if cs.RemoteCurrentRevocation == nil {
+		return WriteElements(w, false)
+	}
+
+	// If fields are present, write boolean to indicate this, and continue.
+	if err := WriteElements(w, true); err != nil {
+		return err
+	}
+
+	if err := WriteElements(w, cs.RemoteCurrentRevocation); err != nil {
+		return err
+	}
+
+	if err := writeChanConfigLegacy(w, &cs.LocalChanConfig); err != nil {
+		return err
+	}
+
+	// The RemoteNextRevocation field is optional, as it's possible for a
+	// channel to be closed before we learn of the next unrevoked
+	// revocation point for the remote party. Write a boolen indicating
+	// whether this field is present or not.
+	if err := WriteElements(w, cs.RemoteNextRevocation != nil); err != nil {
+		return err
+	}
+
+	// Write the field, if present.
+	if cs.RemoteNextRevocation != nil {
+		if err = WriteElements(w, cs.RemoteNextRevocation); err != nil {
+			return err
+		}
+	}
+
+	// Write whether the channel sync message is present.
+	if err := WriteElements(w, cs.LastChanSyncMsg != nil); err != nil {
+		return err
+	}
+
+	// Write the channel sync message, if present.
+	if cs.LastChanSyncMsg != nil {
+		_, err = lnwire.WriteMessage(w, cs.LastChanSyncMsg, 0)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/channeldb/migration19/log.go
+++ b/channeldb/migration19/log.go
@@ -1,0 +1,14 @@
+package migration19
+
+import (
+	"github.com/btcsuite/btclog"
+)
+
+// log is a logger that is initialized as disabled.  This means the package will
+// not perform any logging by default until a logger is set.
+var log = btclog.Disabled
+
+// UseLogger uses a specified Logger to output package logging info.
+func UseLogger(logger btclog.Logger) {
+	log = logger
+}

--- a/channeldb/migration19/migration.go
+++ b/channeldb/migration19/migration.go
@@ -1,0 +1,242 @@
+package migration19
+
+import (
+	"bytes"
+	"fmt"
+
+	"github.com/lightningnetwork/lnd/channeldb/kvdb"
+)
+
+// MigrateDatabaseWireMessages performs a migration in all areas that we
+// currently store wire messages without length prefixes. This includes the
+// CommitDiff struct, ChannelCloseSummary, LogUpdates, and also the
+// networkResult struct as well.
+func MigrateDatabaseWireMessages(tx kvdb.RwTx) error {
+	openChanBucket := tx.ReadWriteBucket(openChannelBucket)
+	if openChanBucket == nil {
+		return nil
+	}
+
+	// The migration will proceed in three phases: we'll need to update any
+	// pending commit diffs, then any unsigned acked updates for all open
+	// channels, then finally we'll need to update all the current
+	// stored network results for payments in the switch.
+	//
+	// In this phase, we'll migrate the open channel data.
+	type channelPath struct {
+		nodePub   []byte
+		chainHash []byte
+		chanPoint []byte
+	}
+	var channelPaths []channelPath
+	err := openChanBucket.ForEach(func(nodePub, v []byte) error {
+		// Ensure that this is a key the same size as a pubkey, and
+		// also that it leads directly to a bucket.
+		if len(nodePub) != 33 || v != nil {
+			return nil
+		}
+
+		nodeChanBucket := openChanBucket.NestedReadBucket(nodePub)
+		if nodeChanBucket == nil {
+			return fmt.Errorf("no bucket for node %x", nodePub)
+		}
+
+		// The next layer down is all the chains that this node
+		// has channels on with us.
+		return nodeChanBucket.ForEach(func(chainHash, v []byte) error {
+			// If there's a value, it's not a bucket so
+			// ignore it.
+			if v != nil {
+				return nil
+			}
+
+			chainBucket := nodeChanBucket.NestedReadBucket(
+				chainHash,
+			)
+			if chainBucket == nil {
+				return fmt.Errorf("unable to read "+
+					"bucket for chain=%x", chainHash)
+			}
+
+			return chainBucket.ForEach(func(chanPoint, v []byte) error {
+				// If there's a value, it's not a bucket so
+				// ignore it.
+				if v != nil {
+					return nil
+				}
+
+				channelPaths = append(channelPaths, channelPath{
+					nodePub:   nodePub,
+					chainHash: chainHash,
+					chanPoint: chanPoint,
+				})
+
+				return nil
+			})
+		})
+	})
+	if err != nil {
+		return err
+	}
+
+	// Now that we have all the paths of the channel we need to migrate,
+	// we'll update all the state in a distinct step to avoid weird
+	// behavior from  modifying buckets in a ForEach statement.
+	for _, channelPath := range channelPaths {
+		// First, we'll extract it from the node's chain bucket.
+		nodeChanBucket := openChanBucket.NestedReadWriteBucket(
+			channelPath.nodePub,
+		)
+		chainBucket := nodeChanBucket.NestedReadWriteBucket(
+			channelPath.chainHash,
+		)
+		chanBucket := chainBucket.NestedReadWriteBucket(
+			channelPath.chanPoint,
+		)
+
+		// At this point, we have the channel bucket now, so we'll
+		// check to see if this channel has a pending commitment or
+		// not.
+		commitDiffBytes := chanBucket.Get(commitDiffKey)
+		if commitDiffBytes != nil {
+			// Now that we have the commit diff in the _old_
+			// encoding, we'll write it back to disk using the new
+			// encoding which has a length prefix in front of the
+			// CommitSig.
+			commitDiff, err := deserializeCommitDiffLegacy(
+				bytes.NewReader(commitDiffBytes),
+			)
+			if err != nil {
+				return err
+			}
+
+			var b bytes.Buffer
+			err = serializeCommitDiff(&b, commitDiff)
+			if err != nil {
+				return err
+			}
+
+			err = chanBucket.Put(commitDiffKey, b.Bytes())
+			if err != nil {
+				return err
+			}
+		}
+
+		// With the commit diff migrated, we'll now check to see if
+		// there're any un-acked updates we need to migrate as well.
+		updateBytes := chanBucket.Get(unsignedAckedUpdatesKey)
+		if updateBytes == nil {
+			return nil
+		}
+
+		// We have un-acked updates we need to migrate so we'll decode
+		// then re-encode them here using the new format.
+		legacyUnackedUpdates, err := deserializeLogUpdatesLegacy(
+			bytes.NewReader(updateBytes),
+		)
+		if err != nil {
+			return err
+		}
+
+		var ub bytes.Buffer
+		err = serializeLogUpdates(&ub, legacyUnackedUpdates)
+		if err != nil {
+			return err
+		}
+
+		err = chanBucket.Put(unsignedAckedUpdatesKey, ub.Bytes())
+		if err != nil {
+			return err
+		}
+	}
+
+	// Next, we'll update all the present close channel summaries as well.
+	type closedChan struct {
+		chanKey      []byte
+		summaryBytes []byte
+	}
+	var closedChans []closedChan
+
+	closedChanBucket := tx.ReadWriteBucket(closedChannelBucket)
+	if closedChannelBucket == nil {
+		return fmt.Errorf("no closed channels found")
+	}
+	err = closedChanBucket.ForEach(func(k, v []byte) error {
+		closedChans = append(closedChans, closedChan{
+			chanKey:      k,
+			summaryBytes: v,
+		})
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+
+	for _, closedChan := range closedChans {
+		oldSummary, err := deserializeCloseChannelSummaryLegacy(
+			bytes.NewReader(closedChan.summaryBytes),
+		)
+		if err != nil {
+			return err
+		}
+
+		var newSummaryBytes bytes.Buffer
+		err = serializeChannelCloseSummary(
+			&newSummaryBytes, oldSummary,
+		)
+		if err != nil {
+			return err
+		}
+
+		err = closedChanBucket.Put(
+			closedChan.chanKey, newSummaryBytes.Bytes(),
+		)
+		if err != nil {
+			return err
+		}
+	}
+
+	// Finally, we'll update the pending network results as well.
+	networkResults := tx.ReadWriteBucket(networkResultStoreBucketKey)
+	if networkResults == nil {
+		return nil
+	}
+
+	// Similar to the prior migrations, we'll do this one in two phases:
+	// we'll first grab all the keys we need to migrate in one loop, then
+	// update them all in another loop.
+	var netResultsToMigrate [][2][]byte
+	err = networkResults.ForEach(func(k, v []byte) error {
+		netResultsToMigrate = append(netResultsToMigrate, [2][]byte{
+			k, v,
+		})
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+
+	for _, netResult := range netResultsToMigrate {
+		resKey := netResult[0]
+		resBytes := netResult[1]
+		oldResult, err := deserializeNetworkResultLegacy(
+			bytes.NewReader(resBytes),
+		)
+		if err != nil {
+			return err
+		}
+
+		var newResultBuf bytes.Buffer
+		err = serializeNetworkResult(&newResultBuf, oldResult)
+		if err != nil {
+			return err
+		}
+
+		err = networkResults.Put(resKey, newResultBuf.Bytes())
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/channeldb/migration19/migration_test.go
+++ b/channeldb/migration19/migration_test.go
@@ -1,0 +1,358 @@
+package migration19
+
+import (
+	"bytes"
+	"fmt"
+	"math/big"
+	"reflect"
+	"testing"
+
+	"github.com/btcsuite/btcd/btcec"
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"github.com/btcsuite/btcd/wire"
+	"github.com/davecgh/go-spew/spew"
+	"github.com/lightningnetwork/lnd/channeldb/kvdb"
+	"github.com/lightningnetwork/lnd/channeldb/migtest"
+	"github.com/lightningnetwork/lnd/lnwire"
+)
+
+var (
+	key = [chainhash.HashSize]byte{
+		0x81, 0xb6, 0x37, 0xd8, 0xfc, 0xd2, 0xc6, 0xda,
+		0x68, 0x59, 0xe6, 0x96, 0x31, 0x13, 0xa1, 0x17,
+		0xd, 0xe7, 0x93, 0xe4, 0xb7, 0x25, 0xb8, 0x4d,
+		0x1e, 0xb, 0x4c, 0xf9, 0x9e, 0xc5, 0x8c, 0xe9,
+	}
+
+	_, pubKey = btcec.PrivKeyFromBytes(btcec.S256(), key[:])
+
+	wireSig, _ = lnwire.NewSigFromSignature(testSig)
+
+	testSig = &btcec.Signature{
+		R: new(big.Int),
+		S: new(big.Int),
+	}
+	_, _ = testSig.R.SetString("63724406601629180062774974542967536251589935445068131219452686511677818569431", 10)
+	_, _ = testSig.S.SetString("18801056069249825825291287104931333862866033135609736119018462340006816851118", 10)
+
+	testTx = &wire.MsgTx{
+		Version: 1,
+		TxIn: []*wire.TxIn{
+			{
+				PreviousOutPoint: wire.OutPoint{
+					Hash:  chainhash.Hash{},
+					Index: 0xffffffff,
+				},
+				SignatureScript: []byte{0x04, 0x31, 0xdc, 0x00, 0x1b, 0x01, 0x62},
+				Sequence:        0xffffffff,
+			},
+		},
+		TxOut: []*wire.TxOut{
+			{
+				Value: 5000000000,
+				PkScript: []byte{
+					0x41, // OP_DATA_65
+					0x04, 0xd6, 0x4b, 0xdf, 0xd0, 0x9e, 0xb1, 0xc5,
+					0xfe, 0x29, 0x5a, 0xbd, 0xeb, 0x1d, 0xca, 0x42,
+					0x81, 0xbe, 0x98, 0x8e, 0x2d, 0xa0, 0xb6, 0xc1,
+					0xc6, 0xa5, 0x9d, 0xc2, 0x26, 0xc2, 0x86, 0x24,
+					0xe1, 0x81, 0x75, 0xe8, 0x51, 0xc9, 0x6b, 0x97,
+					0x3d, 0x81, 0xb0, 0x1c, 0xc3, 0x1f, 0x04, 0x78,
+					0x34, 0xbc, 0x06, 0xd6, 0xd6, 0xed, 0xf6, 0x20,
+					0xd1, 0x84, 0x24, 0x1a, 0x6a, 0xed, 0x8b, 0x63,
+					0xa6, // 65-byte signature
+					0xac, // OP_CHECKSIG
+				},
+			},
+		},
+		LockTime: 5,
+	}
+
+	testCommitDiff = &CommitDiff{
+		Commitment: ChannelCommitment{
+			CommitTx:  testTx,
+			CommitSig: make([]byte, 0),
+		},
+		CommitSig: &lnwire.CommitSig{
+			ChanID:    lnwire.ChannelID(key),
+			CommitSig: wireSig,
+			HtlcSigs: []lnwire.Sig{
+				wireSig,
+				wireSig,
+			},
+		},
+		LogUpdates: []LogUpdate{
+			{
+				LogIndex: 1,
+				UpdateMsg: &lnwire.UpdateAddHTLC{
+					ID:     1,
+					Amount: lnwire.NewMSatFromSatoshis(100),
+					Expiry: 25,
+				},
+			},
+			{
+				LogIndex: 2,
+				UpdateMsg: &lnwire.UpdateAddHTLC{
+					ID:     2,
+					Amount: lnwire.NewMSatFromSatoshis(200),
+					Expiry: 50,
+				},
+			},
+		},
+		OpenedCircuitKeys: []CircuitKey{},
+		ClosedCircuitKeys: []CircuitKey{},
+	}
+
+	testNetworkResult = &networkResult{
+		msg:          testCommitDiff.CommitSig,
+		unencrypted:  true,
+		isResolution: true,
+	}
+
+	testChanCloseSummary = &ChannelCloseSummary{
+		RemotePub:               pubKey,
+		Capacity:                9,
+		RemoteCurrentRevocation: pubKey,
+		RemoteNextRevocation:    pubKey,
+		LastChanSyncMsg: &lnwire.ChannelReestablish{
+			LocalUnrevokedCommitPoint: pubKey,
+		},
+	}
+
+	netResultKey = []byte{3}
+)
+
+// TestMigrateDatabaseWireMessages tests that we're able to properly migrate
+// all the wire messages in the database which are written without a length
+// prefix in front of them. At the time this test was written we need to
+// migrate three areas: open channel commit diffs, open channel unacked updates,
+// and network results in the switch.
+func TestMigrateDatabaseWireMessages(t *testing.T) {
+
+	var pub [33]byte
+	copy(pub[:], key[:])
+
+	migtest.ApplyMigration(
+		t,
+		func(tx kvdb.RwTx) error {
+			t.Helper()
+
+			// First, we'll insert a new fake channel (well just
+			// the commitment diff) at the expected location
+			// on-disk.
+			openChanBucket, err := tx.CreateTopLevelBucket(
+				openChannelBucket,
+			)
+			if err != nil {
+				return err
+			}
+			nodeBucket, err := openChanBucket.CreateBucket(pub[:])
+			if err != nil {
+				return err
+			}
+			chainBucket, err := nodeBucket.CreateBucket(key[:])
+			if err != nil {
+				return err
+			}
+			chanBucket, err := chainBucket.CreateBucket(key[:])
+			if err != nil {
+				return err
+			}
+
+			var b bytes.Buffer
+			err = serializeCommitDiffLegacy(&b, testCommitDiff)
+			if err != nil {
+				return err
+			}
+
+			err = chanBucket.Put(commitDiffKey, b.Bytes())
+			if err != nil {
+				return err
+			}
+
+			var logUpdateBuf bytes.Buffer
+			err = serializeLogUpdatesLegacy(
+				&logUpdateBuf, testCommitDiff.LogUpdates,
+			)
+			if err != nil {
+				return err
+			}
+
+			// We'll re-use the same log updates to insert as a set
+			// of un-acked pending log updateas we well.
+			err = chanBucket.Put(
+				unsignedAckedUpdatesKey, logUpdateBuf.Bytes(),
+			)
+			if err != nil {
+				return err
+			}
+
+			// Next, we'll insert a sample closed channel summary
+			// for the 2nd part of our migration.
+			closedChanBucket, err := tx.CreateTopLevelBucket(
+				closedChannelBucket,
+			)
+			if err != nil {
+				return err
+			}
+
+			var summaryBuf bytes.Buffer
+			err = serializeChannelCloseSummaryLegacy(
+				&summaryBuf, testChanCloseSummary,
+			)
+			if err != nil {
+				return err
+			}
+
+			err = closedChanBucket.Put(key[:], summaryBuf.Bytes())
+			if err != nil {
+				return err
+			}
+
+			// Finally, we need to insert a sample network result
+			// as well for the final component of our migration.
+			var netResBuf bytes.Buffer
+			err = serializeNetworkResultLegacy(
+				&netResBuf, testNetworkResult,
+			)
+			if err != nil {
+				return err
+			}
+
+			networkResults, err := tx.CreateTopLevelBucket(
+				networkResultStoreBucketKey,
+			)
+			if err != nil {
+				return err
+			}
+
+			return networkResults.Put(
+				netResultKey, netResBuf.Bytes(),
+			)
+		},
+		func(tx kvdb.RwTx) error {
+			t.Helper()
+
+			// We'll now read the commit diff from disk using the
+			// _new_ decoding method. This should match the commit
+			// diff we inserted in the pre-migration step.
+			openChanBucket := tx.ReadWriteBucket(openChannelBucket)
+			nodeBucket := openChanBucket.NestedReadWriteBucket(
+				pub[:],
+			)
+			chainBucket := nodeBucket.NestedReadWriteBucket(key[:])
+			chanBucket := chainBucket.NestedReadWriteBucket(key[:])
+
+			commitDiffBytes := chanBucket.Get(commitDiffKey)
+			if commitDiffBytes == nil {
+				return fmt.Errorf("no commit diff found")
+			}
+
+			newCommitDiff, err := deserializeCommitDiff(
+				bytes.NewReader(commitDiffBytes),
+			)
+			if err != nil {
+				return fmt.Errorf("unable to decode commit "+
+					"diff: %v", err)
+			}
+
+			if !reflect.DeepEqual(newCommitDiff, testCommitDiff) {
+				return fmt.Errorf("diff mismatch: expected "+
+					"%v, got %v", spew.Sdump(testCommitDiff),
+					spew.Sdump(newCommitDiff))
+			}
+
+			// Next, we'll ensure that the un-acked updates match
+			// up as well.
+			updateBytes := chanBucket.Get(unsignedAckedUpdatesKey)
+			if updateBytes == nil {
+				return fmt.Errorf("no update bytes found")
+			}
+
+			newUpdates, err := deserializeLogUpdates(
+				bytes.NewReader(updateBytes),
+			)
+			if err != nil {
+				return err
+			}
+
+			if !reflect.DeepEqual(
+				newUpdates, testCommitDiff.LogUpdates,
+			) {
+				return fmt.Errorf("updates mismatch: expected "+
+					"%v, got %v",
+					spew.Sdump(testCommitDiff.LogUpdates),
+					spew.Sdump(newUpdates))
+			}
+
+			// Next, we'll ensure that the inserted close channel
+			// summary bytes also mach up with what we inserted in
+			// the prior step.
+			closedChanBucket := tx.ReadWriteBucket(
+				closedChannelBucket,
+			)
+			if closedChannelBucket == nil {
+				return fmt.Errorf("no closed channels found")
+			}
+
+			chanSummaryBytes := closedChanBucket.Get(key[:])
+			newChanCloseSummary, err := deserializeCloseChannelSummary(
+				bytes.NewReader(chanSummaryBytes),
+			)
+			if err != nil {
+				return err
+			}
+
+			testChanCloseSummary.RemotePub.Curve = nil
+			testChanCloseSummary.RemoteCurrentRevocation.Curve = nil
+			testChanCloseSummary.RemoteNextRevocation.Curve = nil
+			testChanCloseSummary.LastChanSyncMsg.LocalUnrevokedCommitPoint.Curve = nil
+
+			newChanCloseSummary.RemotePub.Curve = nil
+			newChanCloseSummary.RemoteCurrentRevocation.Curve = nil
+			newChanCloseSummary.RemoteNextRevocation.Curve = nil
+			newChanCloseSummary.LastChanSyncMsg.LocalUnrevokedCommitPoint.Curve = nil
+
+			if !reflect.DeepEqual(
+				newChanCloseSummary, testChanCloseSummary,
+			) {
+				return fmt.Errorf("summary mismatch: expected "+
+					"%v, got %v",
+					spew.Sdump(testChanCloseSummary),
+					spew.Sdump(newChanCloseSummary))
+			}
+
+			// Finally, we'll check the network results to ensure
+			// that was migrated properly as well.
+			networkResults := tx.ReadBucket(
+				networkResultStoreBucketKey,
+			)
+			if networkResults == nil {
+				return fmt.Errorf("no net results found")
+			}
+
+			netResBytes := networkResults.Get(netResultKey)
+			if netResBytes == nil {
+				return fmt.Errorf("no network res found")
+			}
+
+			newNetRes, err := deserializeNetworkResult(
+				bytes.NewReader(netResBytes),
+			)
+			if err != nil {
+				return err
+			}
+
+			if !reflect.DeepEqual(newNetRes, testNetworkResult) {
+				return fmt.Errorf("res mismatch: expected "+
+					"%v, got %v",
+					spew.Sdump(testNetworkResult),
+					spew.Sdump(newNetRes))
+			}
+
+			return nil
+		},
+		MigrateDatabaseWireMessages,
+		false,
+	)
+}

--- a/channeldb/migration19/new_encoding.go
+++ b/channeldb/migration19/new_encoding.go
@@ -1,0 +1,431 @@
+package migration19
+
+import (
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"io"
+
+	"github.com/lightningnetwork/lnd/lnwire"
+)
+
+var (
+	// openChanBucket stores all the currently open channels. This bucket
+	// has a second, nested bucket which is keyed by a node's ID. Within
+	// that node ID bucket, all attributes required to track, update, and
+	// close a channel are stored.
+	//
+	// openChan -> nodeID -> chanPoint
+	//
+	// TODO(roasbeef): flesh out comment
+	openChannelBucket = []byte("open-chan-bucket")
+
+	// commitDiffKey stores the current pending commitment state we've
+	// extended to the remote party (if any). Each time we propose a new
+	// state, we store the information necessary to reconstruct this state
+	// from the prior commitment. This allows us to resync the remote party
+	// to their expected state in the case of message loss.
+	//
+	// TODO(roasbeef): rename to commit chain?
+	commitDiffKey = []byte("commit-diff-key")
+
+	// unsignedAckedUpdatesKey is an entry in the channel bucket that
+	// contains the remote updates that we have acked, but not yet signed
+	// for in one of our remote commits.
+	unsignedAckedUpdatesKey = []byte("unsigned-acked-updates-key")
+
+	// networkResultStoreBucketKey is used for the root level bucket that
+	// stores the network result for each payment ID.
+	networkResultStoreBucketKey = []byte("network-result-store-bucket")
+
+	// closedChannelBucket stores summarization information concerning
+	// previously open, but now closed channels.
+	closedChannelBucket = []byte("closed-chan-bucket")
+)
+
+func serializeChanCommit(w io.Writer, c *ChannelCommitment) error { // nolint: dupl
+	if err := WriteElements(w,
+		c.CommitHeight, c.LocalLogIndex, c.LocalHtlcIndex,
+		c.RemoteLogIndex, c.RemoteHtlcIndex, c.LocalBalance,
+		c.RemoteBalance, c.CommitFee, c.FeePerKw, c.CommitTx,
+		c.CommitSig,
+	); err != nil {
+		return err
+	}
+
+	return serializeHtlcs(w, c.Htlcs...)
+}
+
+func serializeLogUpdates(w io.Writer, logUpdates []LogUpdate) error { // nolint: dupl
+	numUpdates := uint16(len(logUpdates))
+	if err := binary.Write(w, byteOrder, numUpdates); err != nil {
+		return err
+	}
+
+	for _, diff := range logUpdates {
+		err := WriteElements(w, diff.LogIndex, diff.UpdateMsg)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func serializeHtlcs(b io.Writer, htlcs ...HTLC) error { // nolint: dupl
+	numHtlcs := uint16(len(htlcs))
+	if err := WriteElement(b, numHtlcs); err != nil {
+		return err
+	}
+
+	for _, htlc := range htlcs {
+		if err := WriteElements(b,
+			htlc.Signature, htlc.RHash, htlc.Amt, htlc.RefundTimeout,
+			htlc.OutputIndex, htlc.Incoming, htlc.OnionBlob,
+			htlc.HtlcIndex, htlc.LogIndex,
+		); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func serializeCommitDiff(w io.Writer, diff *CommitDiff) error { // nolint: dupl
+	if err := serializeChanCommit(w, &diff.Commitment); err != nil {
+		return err
+	}
+
+	if err := WriteElements(w, diff.CommitSig); err != nil {
+		return err
+	}
+
+	if err := serializeLogUpdates(w, diff.LogUpdates); err != nil {
+		return err
+	}
+
+	numOpenRefs := uint16(len(diff.OpenedCircuitKeys))
+	if err := binary.Write(w, byteOrder, numOpenRefs); err != nil {
+		return err
+	}
+
+	for _, openRef := range diff.OpenedCircuitKeys {
+		err := WriteElements(w, openRef.ChanID, openRef.HtlcID)
+		if err != nil {
+			return err
+		}
+	}
+
+	numClosedRefs := uint16(len(diff.ClosedCircuitKeys))
+	if err := binary.Write(w, byteOrder, numClosedRefs); err != nil {
+		return err
+	}
+
+	for _, closedRef := range diff.ClosedCircuitKeys {
+		err := WriteElements(w, closedRef.ChanID, closedRef.HtlcID)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func deserializeHtlcs(r io.Reader) ([]HTLC, error) { // nolint: dupl
+	var numHtlcs uint16
+	if err := ReadElement(r, &numHtlcs); err != nil {
+		return nil, err
+	}
+
+	var htlcs []HTLC
+	if numHtlcs == 0 {
+		return htlcs, nil
+	}
+
+	htlcs = make([]HTLC, numHtlcs)
+	for i := uint16(0); i < numHtlcs; i++ {
+		if err := ReadElements(r,
+			&htlcs[i].Signature, &htlcs[i].RHash, &htlcs[i].Amt,
+			&htlcs[i].RefundTimeout, &htlcs[i].OutputIndex,
+			&htlcs[i].Incoming, &htlcs[i].OnionBlob,
+			&htlcs[i].HtlcIndex, &htlcs[i].LogIndex,
+		); err != nil {
+			return htlcs, err
+		}
+	}
+
+	return htlcs, nil
+}
+
+func deserializeChanCommit(r io.Reader) (ChannelCommitment, error) { // nolint: dupl
+	var c ChannelCommitment
+
+	err := ReadElements(r,
+		&c.CommitHeight, &c.LocalLogIndex, &c.LocalHtlcIndex, &c.RemoteLogIndex,
+		&c.RemoteHtlcIndex, &c.LocalBalance, &c.RemoteBalance,
+		&c.CommitFee, &c.FeePerKw, &c.CommitTx, &c.CommitSig,
+	)
+	if err != nil {
+		return c, err
+	}
+
+	c.Htlcs, err = deserializeHtlcs(r)
+	if err != nil {
+		return c, err
+	}
+
+	return c, nil
+}
+
+func deserializeLogUpdates(r io.Reader) ([]LogUpdate, error) { // nolint: dupl
+	var numUpdates uint16
+	if err := binary.Read(r, byteOrder, &numUpdates); err != nil {
+		return nil, err
+	}
+
+	logUpdates := make([]LogUpdate, numUpdates)
+	for i := 0; i < int(numUpdates); i++ {
+		err := ReadElements(r,
+			&logUpdates[i].LogIndex, &logUpdates[i].UpdateMsg,
+		)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return logUpdates, nil
+}
+
+func deserializeCommitDiff(r io.Reader) (*CommitDiff, error) { // nolint: dupl
+	var (
+		d   CommitDiff
+		err error
+	)
+
+	d.Commitment, err = deserializeChanCommit(r)
+	if err != nil {
+		return nil, err
+	}
+
+	var msg lnwire.Message
+	if err := ReadElements(r, &msg); err != nil {
+		return nil, err
+	}
+	commitSig, ok := msg.(*lnwire.CommitSig)
+	if !ok {
+		return nil, fmt.Errorf("expected lnwire.CommitSig, instead "+
+			"read: %T", msg)
+	}
+	d.CommitSig = commitSig
+
+	d.LogUpdates, err = deserializeLogUpdates(r)
+	if err != nil {
+		return nil, err
+	}
+
+	var numOpenRefs uint16
+	if err := binary.Read(r, byteOrder, &numOpenRefs); err != nil {
+		return nil, err
+	}
+
+	d.OpenedCircuitKeys = make([]CircuitKey, numOpenRefs)
+	for i := 0; i < int(numOpenRefs); i++ {
+		err := ReadElements(r,
+			&d.OpenedCircuitKeys[i].ChanID,
+			&d.OpenedCircuitKeys[i].HtlcID)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	var numClosedRefs uint16
+	if err := binary.Read(r, byteOrder, &numClosedRefs); err != nil {
+		return nil, err
+	}
+
+	d.ClosedCircuitKeys = make([]CircuitKey, numClosedRefs)
+	for i := 0; i < int(numClosedRefs); i++ {
+		err := ReadElements(r,
+			&d.ClosedCircuitKeys[i].ChanID,
+			&d.ClosedCircuitKeys[i].HtlcID)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return &d, nil
+}
+
+func serializeNetworkResult(w io.Writer, n *networkResult) error { // nolint: dupl
+	return WriteElements(w, n.msg, n.unencrypted, n.isResolution)
+}
+
+func deserializeNetworkResult(r io.Reader) (*networkResult, error) { // nolint: dupl
+	n := &networkResult{}
+
+	if err := ReadElements(r,
+		&n.msg, &n.unencrypted, &n.isResolution,
+	); err != nil {
+		return nil, err
+	}
+
+	return n, nil
+}
+
+func writeChanConfig(b io.Writer, c *ChannelConfig) error { // nolint: dupl
+	return WriteElements(b,
+		c.DustLimit, c.MaxPendingAmount, c.ChanReserve, c.MinHTLC,
+		c.MaxAcceptedHtlcs, c.CsvDelay, c.MultiSigKey,
+		c.RevocationBasePoint, c.PaymentBasePoint, c.DelayBasePoint,
+		c.HtlcBasePoint,
+	)
+}
+
+func serializeChannelCloseSummary(w io.Writer, cs *ChannelCloseSummary) error { // nolint: dupl
+	err := WriteElements(w,
+		cs.ChanPoint, cs.ShortChanID, cs.ChainHash, cs.ClosingTXID,
+		cs.CloseHeight, cs.RemotePub, cs.Capacity, cs.SettledBalance,
+		cs.TimeLockedBalance, cs.CloseType, cs.IsPending,
+	)
+	if err != nil {
+		return err
+	}
+
+	// If this is a close channel summary created before the addition of
+	// the new fields, then we can exit here.
+	if cs.RemoteCurrentRevocation == nil {
+		return WriteElements(w, false)
+	}
+
+	// If fields are present, write boolean to indicate this, and continue.
+	if err := WriteElements(w, true); err != nil {
+		return err
+	}
+
+	if err := WriteElements(w, cs.RemoteCurrentRevocation); err != nil {
+		return err
+	}
+
+	if err := writeChanConfig(w, &cs.LocalChanConfig); err != nil {
+		return err
+	}
+
+	// The RemoteNextRevocation field is optional, as it's possible for a
+	// channel to be closed before we learn of the next unrevoked
+	// revocation point for the remote party. Write a boolen indicating
+	// whether this field is present or not.
+	if err := WriteElements(w, cs.RemoteNextRevocation != nil); err != nil {
+		return err
+	}
+
+	// Write the field, if present.
+	if cs.RemoteNextRevocation != nil {
+		if err = WriteElements(w, cs.RemoteNextRevocation); err != nil {
+			return err
+		}
+	}
+
+	// Write whether the channel sync message is present.
+	if err := WriteElements(w, cs.LastChanSyncMsg != nil); err != nil {
+		return err
+	}
+
+	// Write the channel sync message, if present.
+	if cs.LastChanSyncMsg != nil {
+		if err := WriteElements(w, cs.LastChanSyncMsg); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func readChanConfig(b io.Reader, c *ChannelConfig) error {
+	return ReadElements(b,
+		&c.DustLimit, &c.MaxPendingAmount, &c.ChanReserve,
+		&c.MinHTLC, &c.MaxAcceptedHtlcs, &c.CsvDelay,
+		&c.MultiSigKey, &c.RevocationBasePoint,
+		&c.PaymentBasePoint, &c.DelayBasePoint,
+		&c.HtlcBasePoint,
+	)
+}
+
+func deserializeCloseChannelSummary(r io.Reader) (*ChannelCloseSummary, error) { // nolint: dupl
+	c := &ChannelCloseSummary{}
+
+	err := ReadElements(r,
+		&c.ChanPoint, &c.ShortChanID, &c.ChainHash, &c.ClosingTXID,
+		&c.CloseHeight, &c.RemotePub, &c.Capacity, &c.SettledBalance,
+		&c.TimeLockedBalance, &c.CloseType, &c.IsPending,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	// We'll now check to see if the channel close summary was encoded with
+	// any of the additional optional fields.
+	var hasNewFields bool
+	err = ReadElements(r, &hasNewFields)
+	if err != nil {
+		return nil, err
+	}
+
+	// If fields are not present, we can return.
+	if !hasNewFields {
+		return c, nil
+	}
+
+	// Otherwise read the new fields.
+	if err := ReadElements(r, &c.RemoteCurrentRevocation); err != nil {
+		return nil, err
+	}
+
+	if err := readChanConfig(r, &c.LocalChanConfig); err != nil {
+		return nil, err
+	}
+
+	// Finally, we'll attempt to read the next unrevoked commitment point
+	// for the remote party. If we closed the channel before receiving a
+	// funding locked message then this might not be present. A boolean
+	// indicating whether the field is present will come first.
+	var hasRemoteNextRevocation bool
+	err = ReadElements(r, &hasRemoteNextRevocation)
+	if err != nil {
+		return nil, err
+	}
+
+	// If this field was written, read it.
+	if hasRemoteNextRevocation {
+		err = ReadElements(r, &c.RemoteNextRevocation)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	// Check if we have a channel sync message to read.
+	var hasChanSyncMsg bool
+	err = ReadElements(r, &hasChanSyncMsg)
+	if err == io.EOF {
+		return c, nil
+	} else if err != nil {
+		return nil, err
+	}
+
+	// If a chan sync message is present, read it.
+	if hasChanSyncMsg {
+		// We must pass in reference to a lnwire.Message for the codec
+		// to support it.
+		var msg lnwire.Message
+		if err := ReadElements(r, &msg); err != nil {
+			return nil, err
+		}
+
+		chanSync, ok := msg.(*lnwire.ChannelReestablish)
+		if !ok {
+			return nil, errors.New("unable cast db Message to " +
+				"ChannelReestablish")
+		}
+		c.LastChanSyncMsg = chanSync
+	}
+
+	return c, nil
+}

--- a/channeldb/migtest/migtest.go
+++ b/channeldb/migtest/migtest.go
@@ -39,6 +39,8 @@ func ApplyMigration(t *testing.T,
 	beforeMigration, afterMigration, migrationFunc func(tx kvdb.RwTx) error,
 	shouldFail bool) {
 
+	t.Helper()
+
 	cdb, cleanUp, err := MakeDB()
 	defer cleanUp()
 	if err != nil {
@@ -53,6 +55,8 @@ func ApplyMigration(t *testing.T,
 	}
 
 	defer func() {
+		t.Helper()
+
 		if r := recover(); r != nil {
 			err = newError(r)
 		}

--- a/htlcswitch/payment_result.go
+++ b/htlcswitch/payment_result.go
@@ -61,28 +61,15 @@ type networkResult struct {
 
 // serializeNetworkResult serializes the networkResult.
 func serializeNetworkResult(w io.Writer, n *networkResult) error {
-	if _, err := lnwire.WriteMessage(w, n.msg, 0); err != nil {
-		return err
-	}
-
-	return channeldb.WriteElements(w, n.unencrypted, n.isResolution)
+	return channeldb.WriteElements(w, n.msg, n.unencrypted, n.isResolution)
 }
 
 // deserializeNetworkResult deserializes the networkResult.
 func deserializeNetworkResult(r io.Reader) (*networkResult, error) {
-	var (
-		err error
-	)
-
 	n := &networkResult{}
 
-	n.msg, err = lnwire.ReadMessage(r, 0)
-	if err != nil {
-		return nil, err
-	}
-
 	if err := channeldb.ReadElements(r,
-		&n.unencrypted, &n.isResolution,
+		&n.msg, &n.unencrypted, &n.isResolution,
 	); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
In this commit, we modify the way we write the CommitSIg in certain locations to match the way it's encoded on the wire. With this change, we'll now properly add a length prefix in front of the message, meaning we'll be able to read the extra data included (if present), and still be able to serialize content after this message.

We add a simple migration to migrate all the current pending commitments, along with a test. We opt to do the simple enclose-copy method for the migration, which results in a larger diff, but IMO an easier to understand migration test. 

This PR is needed for #3966  to pass the tests properly. 