### PR TITLE
htlcswitch: log fixes

### DIFF
--- a/channeldb/channel.go
+++ b/channeldb/channel.go
@@ -2171,7 +2171,7 @@ func (c *OpenChannel) AdvanceCommitChainTail(fwdPkg *FwdPkg) error {
 // NextLocalHtlcIndex returns the next unallocated local htlc index. To ensure
 // this always returns the next index that has been not been allocated, this
 // will first try to examine any pending commitments, before falling back to the
-// last locked-in local commitment.
+// last locked-in remote commitment.
 func (c *OpenChannel) NextLocalHtlcIndex() (uint64, error) {
 	// First, load the most recent commit diff that we initiated for the
 	// remote party. If no pending commit is found, this is not treated as
@@ -2187,8 +2187,8 @@ func (c *OpenChannel) NextLocalHtlcIndex() (uint64, error) {
 		return pendingRemoteCommit.Commitment.LocalHtlcIndex, nil
 	}
 
-	// Otherwise, fallback to using the local htlc index of our commitment.
-	return c.LocalCommitment.LocalHtlcIndex, nil
+	// Otherwise, fallback to using the local htlc index of their commitment.
+	return c.RemoteCommitment.LocalHtlcIndex, nil
 }
 
 // LoadFwdPkgs scans the forwarding log for any packages that haven't been

--- a/htlcswitch/link.go
+++ b/htlcswitch/link.go
@@ -2060,6 +2060,10 @@ func (l *channelLink) updateCommitTx() error {
 		return err
 	}
 
+	if err := l.ackDownStreamPackets(); err != nil {
+		return err
+	}
+
 	// The remote party now has a new pending commitment, so we'll update
 	// the contract court to be aware of this new set (the prior old remote
 	// pending).
@@ -2069,11 +2073,7 @@ func (l *channelLink) updateCommitTx() error {
 		Htlcs:   pendingHTLCs,
 	}:
 	case <-l.quit:
-		return nil
-	}
-
-	if err := l.ackDownStreamPackets(); err != nil {
-		return err
+		return ErrLinkShuttingDown
 	}
 
 	commitSig := &lnwire.CommitSig{

--- a/htlcswitch/switch_test.go
+++ b/htlcswitch/switch_test.go
@@ -761,8 +761,8 @@ func TestSwitchForwardSettleAfterFullAdd(t *testing.T) {
 	}
 
 	// Send the settle packet again, which should fail.
-	if err := s2.forward(settle); err == nil {
-		t.Fatalf("expected failure when sending duplicate settle " +
+	if err := s2.forward(settle); err != nil {
+		t.Fatalf("expected success when sending duplicate settle " +
 			"with no pending circuit")
 	}
 }


### PR DESCRIPTION
This PR fixes the error log intro'd in #3143 when pipelining settles to the switch, and makes logging less spammy and more informative.  The PR breakdown is as follows:

- First commit changes the fallback in `NextLocalHtlcIndex` to `RemoteCommitment` since `LocalCommitment` lags behind for the `LocalHtlcIndex` field. Without this bug fix, open circuits could get prematurely trimmed, resulting in more error logs. A test case is included to check that the fix works.
- Second commit returns `ErrLinkShuttingDown` so that the link logs when it's getting shut down. Also changes the order of the `ackDownStreamPackets` and check-if-link-quit call for consistency since the packets should be ACKed before going down.
- Final commit changes the switch to only log an error if a `update_fail_htlc` comes in and `closeCircuit` returns `ErrUnknownCircuit`. Rationale being that only settles should hit this code path, anything else is a result of a link flap.

Closes #3656 