### PR TITLE
lnwallet: apply BIP69+CLTV tie-break to HTLC signature order

### DIFF
--- a/lnwallet/channel.go
+++ b/lnwallet/channel.go
@@ -67,6 +67,10 @@ var (
 	ErrBelowMinHTLC = fmt.Errorf("proposed HTLC value is below minimum " +
 		"allowed HTLC value")
 
+	// ErrInvalidHTLCAmt signals that a proposed HTLC has a value that is
+	// not positive.
+	ErrInvalidHTLCAmt = fmt.Errorf("proposed HTLC value must be positive")
+
 	// ErrCannotSyncCommitChains is returned if, upon receiving a ChanSync
 	// message, the state machine deems that is unable to properly
 	// synchronize states with the remote peer. In this case we should fail
@@ -3233,6 +3237,11 @@ func (lc *LightningChannel) validateCommitmentSanity(theirLogCounter,
 				// number and amount in flight.
 				amtInFlight += entry.Amount
 				numInFlight++
+
+				// Check that the HTLC amount is positive.
+				if entry.Amount == 0 {
+					return ErrInvalidHTLCAmt
+				}
 
 				// Check that the value of the HTLC they added
 				// is above our minimum.

--- a/lnwallet/commitment.go
+++ b/lnwallet/commitment.go
@@ -382,6 +382,10 @@ type unsignedCommitmentTx struct {
 	// balances before creating the commitment transaction as one party must
 	// pay the commitment fee.
 	theirBalance lnwire.MilliSatoshi
+
+	// cltvs is a sorted list of CLTV deltas for each HTLC on the commitment
+	// transaction. Any non-htlc outputs will have a CLTV delay of zero.
+	cltvs []uint32
 }
 
 // createUnsignedCommitmentTx generates the unsigned commitment transaction for
@@ -562,6 +566,7 @@ func (cb *CommitmentBuilder) createUnsignedCommitmentTx(ourBalance,
 		fee:          commitFee,
 		ourBalance:   ourBalance,
 		theirBalance: theirBalance,
+		cltvs:        cltvs,
 	}, nil
 }
 

--- a/lnwallet/commitment.go
+++ b/lnwallet/commitment.go
@@ -371,11 +371,16 @@ type unsignedCommitmentTx struct {
 	// fee is the total fee of the commitment transaction.
 	fee btcutil.Amount
 
-	// ourBalance|theirBalance are the balances of this commitment *after*
-	// subtracting commitment fees and anchor outputs. This can be
-	// different than the balances before creating the commitment
-	// transaction as one party must pay the commitment fee.
-	ourBalance   lnwire.MilliSatoshi
+	// ourBalance is our balance on this commitment *after* subtracting
+	// commitment fees and anchor outputs. This can be different than the
+	// balances before creating the commitment transaction as one party must
+	// pay the commitment fee.
+	ourBalance lnwire.MilliSatoshi
+
+	// theirBalance is their balance of this commitment *after* subtracting
+	// commitment fees and anchor outputs. This can be different than the
+	// balances before creating the commitment transaction as one party must
+	// pay the commitment fee.
 	theirBalance lnwire.MilliSatoshi
 }
 


### PR DESCRIPTION
Fixes #4118 

This PR fixes an issue in which HTLC signatures sent to the remote peer could be improperly ordered. This can occur when multiple HTLCs share the identical payment hashes and amounts, but have differing CLTV values. In particular, if these HTLCs are added in such a way that subsequence has descending CLTVs, the HTLC signatures would not reflect the HTLC tie-breaker used to sort the commitment.

#3412 partially fixed the issue, by ensuring that we properly sort the actual commitment and second-level transaction refer to the proper txid in their previous outpoint, however it failed to apply this sorting when generating the signing jobs and hence the final ordering that is sent on the wire.