### PR TITLE
lnrpc: format and fix typo for node metrics

### DIFF
--- a/lnrpc/rpc.pb.go
+++ b/lnrpc/rpc.pb.go
@@ -7622,7 +7622,7 @@ func (m *ChannelGraph) GetEdges() []*ChannelEdge {
 }
 
 type NodeMetricsRequest struct {
-	/// The requesteded node metrics.
+	/// The requested node metrics.
 	Types                []NodeMetricType `protobuf:"varint,1,rep,packed,name=types,proto3,enum=lnrpc.NodeMetricType" json:"types,omitempty"`
 	XXX_NoUnkeyedLiteral struct{}         `json:"-"`
 	XXX_unrecognized     []byte           `json:"-"`

--- a/lnrpc/rpc.proto
+++ b/lnrpc/rpc.proto
@@ -651,7 +651,6 @@ service Lightning {
         };
     }
 
-
     /** lncli: `getchaninfo`
     GetChanInfo returns the latest authenticated network announcement for the
     given channel identified by its channel ID: an 8-byte integer which
@@ -2527,13 +2526,11 @@ message ChannelGraph {
     repeated ChannelEdge edges = 2;
 }
 
-enum NodeMetricType {
-    BETWEENNESS_CENTRALITY = 0;
-}
+enum NodeMetricType { BETWEENNESS_CENTRALITY = 0; }
 
 message NodeMetricsRequest {
-  /// The requesteded node metrics.
-  repeated NodeMetricType types = 1;
+    /// The requested node metrics.
+    repeated NodeMetricType types = 1;
 }
 
 message NodeMetricsResponse {
@@ -2548,11 +2545,11 @@ message NodeMetricsResponse {
 }
 
 message FloatValue {
-  /// Arbitrary float value.
-  double value = 1;
+    /// Arbitrary float value.
+    double value = 1;
 
-  /// The value normalized to [0,1] or [-1,1].
-  double normalized_value = 2;
+    /// The value normalized to [0,1] or [-1,1].
+    double normalized_value = 2;
 }
 
 message ChanInfoRequest {

--- a/lnrpc/rpc.swagger.json
+++ b/lnrpc/rpc.swagger.json
@@ -733,7 +733,7 @@
         "parameters": [
           {
             "name": "types",
-            "description": "/ The requesteded node metrics.",
+            "description": "/ The requested node metrics.",
             "in": "query",
             "required": false,
             "type": "array",


### PR DESCRIPTION
Picking up some changes on master when I run `make rpc-format`, related to #3865 + fixed a typo. 

Also wondering whether we should update `NodeMetricType` enum to have `UNKNOWN =0` as a default value before this ships in 0.10?