### PR TITLE
[MPP] "slow settle" for TrackPayment

### DIFF
--- a/channeldb/payment_control.go
+++ b/channeldb/payment_control.go
@@ -213,16 +213,15 @@ func (p *PaymentControl) SettleAttempt(hash lntypes.Hash,
 
 // FailAttempt marks the given payment attempt failed.
 func (p *PaymentControl) FailAttempt(hash lntypes.Hash,
-	attemptID uint64, failInfo *HTLCFailInfo) error {
+	attemptID uint64, failInfo *HTLCFailInfo) (*MPPayment, error) {
 
 	var b bytes.Buffer
 	if err := serializeHTLCFailInfo(&b, failInfo); err != nil {
-		return err
+		return nil, err
 	}
 	failBytes := b.Bytes()
 
-	_, err := p.updateHtlcKey(hash, attemptID, htlcFailInfoKey, failBytes)
-	return err
+	return p.updateHtlcKey(hash, attemptID, htlcFailInfoKey, failBytes)
 }
 
 // updateHtlcKey updates a database key for the specified htlc.

--- a/channeldb/payment_control_test.go
+++ b/channeldb/payment_control_test.go
@@ -125,7 +125,7 @@ func TestPaymentControlSwitchFail(t *testing.T) {
 		t.Fatalf("unable to register attempt: %v", err)
 	}
 
-	err = pControl.FailAttempt(
+	_, err = pControl.FailAttempt(
 		info.PaymentHash, 2, &HTLCFailInfo{
 			Reason: HTLCFailUnreadable,
 		},
@@ -362,7 +362,7 @@ func TestPaymentControlDeleteNonInFligt(t *testing.T) {
 
 		if p.failed {
 			// Fail the payment attempt.
-			err := pControl.FailAttempt(
+			_, err := pControl.FailAttempt(
 				info.PaymentHash, attempt.AttemptID,
 				&HTLCFailInfo{
 					Reason: HTLCFailUnreadable,

--- a/routing/control_tower.go
+++ b/routing/control_tower.go
@@ -129,7 +129,8 @@ func (p *controlTower) SettleAttempt(paymentHash lntypes.Hash,
 func (p *controlTower) FailAttempt(paymentHash lntypes.Hash,
 	attemptID uint64, failInfo *channeldb.HTLCFailInfo) error {
 
-	return p.db.FailAttempt(paymentHash, attemptID, failInfo)
+	_, err := p.db.FailAttempt(paymentHash, attemptID, failInfo)
+	return err
 }
 
 // createSuccessResult creates a success result to send to subscribers.


### PR DESCRIPTION
Similar to what is done currently for `ListPayments`, we only report the `Success/Failed` state of a payment when there is no longer any payment shards in flight.