### PR TITLE
channeldb: correct HasChanStatus for ChanStatusDefault, fix rpc channel status

### DIFF
--- a/channeldb/channel.go
+++ b/channeldb/channel.go
@@ -475,7 +475,6 @@ var chanStatusStrings = map[ChannelStatus]string{
 
 // orderedChanStatusFlags is an in-order list of all that channel status flags.
 var orderedChanStatusFlags = []ChannelStatus{
-	ChanStatusDefault,
 	ChanStatusBorked,
 	ChanStatusCommitBroadcasted,
 	ChanStatusLocalDataLoss,
@@ -488,7 +487,7 @@ var orderedChanStatusFlags = []ChannelStatus{
 // String returns a human-readable representation of the ChannelStatus.
 func (c ChannelStatus) String() string {
 	// If no flags are set, then this is the default case.
-	if c == 0 {
+	if c == ChanStatusDefault {
 		return chanStatusStrings[ChanStatusDefault]
 	}
 

--- a/channeldb/channel.go
+++ b/channeldb/channel.go
@@ -711,6 +711,12 @@ func (c *OpenChannel) HasChanStatus(status ChannelStatus) bool {
 }
 
 func (c *OpenChannel) hasChanStatus(status ChannelStatus) bool {
+	// Special case ChanStatusDefualt since it isn't actually flag, but a
+	// particular combination (or lack-there-of) of flags.
+	if status == ChanStatusDefault {
+		return c.chanStatus == ChanStatusDefault
+	}
+
 	return c.chanStatus&status == status
 }
 

--- a/peer.go
+++ b/peer.go
@@ -504,13 +504,9 @@ func (p *peer) loadActiveChannels(chans []*channeldb.OpenChannel) (
 		// Skip adding any permanently irreconcilable channels to the
 		// htlcswitch.
 		switch {
-		case dbChan.HasChanStatus(channeldb.ChanStatusBorked):
-			fallthrough
-		case dbChan.HasChanStatus(channeldb.ChanStatusCommitBroadcasted):
-			fallthrough
-		case dbChan.HasChanStatus(channeldb.ChanStatusCoopBroadcasted):
-			fallthrough
-		case dbChan.HasChanStatus(channeldb.ChanStatusLocalDataLoss):
+		case !dbChan.HasChanStatus(channeldb.ChanStatusDefault) &&
+			!dbChan.HasChanStatus(channeldb.ChanStatusRestored):
+
 			peerLog.Warnf("ChannelPoint(%v) has status %v, won't "+
 				"start.", chanPoint, dbChan.ChanStatus())
 


### PR DESCRIPTION
See commit messages for more details, summary:
 - fixes bug where `HasChanStatus` always returns true
 - fixes bug where `ChannelStatus` string always reported `ChanStatusDefault`, which is displayed over rpc
 - changes from blacklist to whitelist when filtering channels to load into the switch since the former is brittle