### PR TITLE
htlcswitch: sync local payment hand-off to link

### DIFF
--- a/htlcswitch/interfaces.go
+++ b/htlcswitch/interfaces.go
@@ -70,6 +70,10 @@ type ChannelLink interface {
 	// possible).
 	HandleSwitchPacket(*htlcPacket) error
 
+	// HandleLocalAddPacket handles a locally-initiated UpdateAddHTLC
+	// packet. It will be processed synchronously.
+	HandleLocalAddPacket(*htlcPacket) error
+
 	// HandleChannelUpdate handles the htlc requests as settle/add/fail
 	// which sent to us from remote peer we have a channel with.
 	//

--- a/htlcswitch/link.go
+++ b/htlcswitch/link.go
@@ -1097,9 +1097,7 @@ func (l *channelLink) htlcManager() {
 			// including all the currently pending entries. If the
 			// send was unsuccessful, then abandon the update,
 			// waiting for the revocation window to open up.
-			if err := l.updateCommitTx(); err != nil {
-				l.fail(LinkFailureError{code: ErrInternalError},
-					"unable to update commitment: %v", err)
+			if !l.updateCommitTxOrFail() {
 				return
 			}
 
@@ -1476,9 +1474,7 @@ func (l *channelLink) handleDownstreamPkt(pkt *htlcPacket) {
 	if l.channel.PendingLocalUpdateCount() >= uint64(l.cfg.BatchSize) ||
 		isSettle {
 
-		if err := l.updateCommitTx(); err != nil {
-			l.fail(LinkFailureError{code: ErrInternalError},
-				"unable to update commitment: %v", err)
+		if !l.updateCommitTxOrFail() {
 			return
 		}
 	}
@@ -1753,9 +1749,7 @@ func (l *channelLink) handleUpstreamMsg(msg lnwire.Message) {
 		// Otherwise, the remote party initiated the state transition,
 		// so we'll reply with a signature to provide them with their
 		// version of the latest commitment.
-		if err := l.updateCommitTx(); err != nil {
-			l.fail(LinkFailureError{code: ErrInternalError},
-				"unable to update commitment: %v", err)
+		if !l.updateCommitTxOrFail() {
 			return
 		}
 
@@ -1832,9 +1826,7 @@ func (l *channelLink) handleUpstreamMsg(msg lnwire.Message) {
 		// but there are still remote updates that are not in the remote
 		// commit tx yet, send out an update.
 		if l.channel.OweCommitment(true) {
-			if err := l.updateCommitTx(); err != nil {
-				l.fail(LinkFailureError{code: ErrInternalError},
-					"unable to update commitment: %v", err)
+			if !l.updateCommitTxOrFail() {
 				return
 			}
 		}
@@ -1916,6 +1908,18 @@ func (l *channelLink) ackDownStreamPackets() error {
 	l.closedCircuits = l.closedCircuits[:0]
 
 	return nil
+}
+
+// updateCommitTxOrFail updates the commitment tx and if that fails, it fails
+// the link.
+func (l *channelLink) updateCommitTxOrFail() bool {
+	if err := l.updateCommitTx(); err != nil {
+		l.fail(LinkFailureError{code: ErrInternalError},
+			"unable to update commitment: %v", err)
+		return false
+	}
+
+	return true
 }
 
 // updateCommitTx signs, then sends an update to the remote peer adding a new

--- a/htlcswitch/mock.go
+++ b/htlcswitch/mock.go
@@ -702,6 +702,11 @@ func (f *mockChannelLink) HandleSwitchPacket(pkt *htlcPacket) error {
 	return nil
 }
 
+func (f *mockChannelLink) HandleLocalAddPacket(pkt *htlcPacket) error {
+	_ = f.mailBox.AddPacket(pkt)
+	return nil
+}
+
 func (f *mockChannelLink) HandleChannelUpdate(lnwire.Message) {
 }
 

--- a/htlcswitch/switch.go
+++ b/htlcswitch/switch.go
@@ -476,7 +476,7 @@ func (s *Switch) SendHTLC(firstHop lnwire.ShortChannelID, paymentID uint64,
 
 	// User has created the htlc update therefore we should find the
 	// appropriate channel link and send the payment over this link.
-	link, linkErr := s.handleLocalAddHTLC(packet, htlc)
+	link, linkErr := s.getLocalLink(packet, htlc)
 	if linkErr != nil {
 		// Notify the htlc notifier of a link failure on our
 		// outgoing link. Incoming timelock/amount values are
@@ -750,12 +750,11 @@ func (s *Switch) routeAsync(packet *htlcPacket, errChan chan error,
 	}
 }
 
-// handleLocalAddHTLC handles the addition of a htlc for a send that
-// originates from our node. It returns the link that the htlc should
-// be forwarded outwards on, and a link error if the htlc cannot be
-// forwarded.
-func (s *Switch) handleLocalAddHTLC(pkt *htlcPacket,
-	htlc *lnwire.UpdateAddHTLC) (ChannelLink, *LinkError) {
+// getLocalLink handles the addition of a htlc for a send that originates from
+// our node. It returns the link that the htlc should be forwarded outwards on,
+// and a link error if the htlc cannot be forwarded.
+func (s *Switch) getLocalLink(pkt *htlcPacket, htlc *lnwire.UpdateAddHTLC) (
+	ChannelLink, *LinkError) {
 
 	// Try to find links by node destination.
 	s.indexMtx.RLock()

--- a/htlcswitch/switch.go
+++ b/htlcswitch/switch.go
@@ -491,7 +491,7 @@ func (s *Switch) SendHTLC(firstHop lnwire.ShortChannelID, paymentID uint64,
 		return linkErr
 	}
 
-	return link.HandleSwitchPacket(packet)
+	return link.HandleLocalAddPacket(packet)
 }
 
 // UpdateForwardingPolicies sends a message to the switch to update the

--- a/htlcswitch/switch.go
+++ b/htlcswitch/switch.go
@@ -67,6 +67,10 @@ var (
 	// ErrUnreadableFailureMessage is returned when the failure message
 	// cannot be decrypted.
 	ErrUnreadableFailureMessage = errors.New("unreadable failure message")
+
+	// ErrLocalAddFailed signals that the ADD htlc for a local payment
+	// failed to be processed.
+	ErrLocalAddFailed = errors.New("local add HTLC failed")
 )
 
 // plexPacket encapsulates switch packet and adds error channel to receive
@@ -464,7 +468,7 @@ func (s *Switch) SendHTLC(firstHop lnwire.ShortChannelID, paymentID uint64,
 		return ErrDuplicateAdd
 
 	case len(actions.Fails) == 1:
-		return err
+		return ErrLocalAddFailed
 	}
 
 	// Send packet to link.

--- a/lntest/itest/log_error_whitelist.txt
+++ b/lntest/itest/log_error_whitelist.txt
@@ -24,6 +24,7 @@
 <time> [ERR] CRTR: Channel update of ourselves received
 <time> [ERR] CRTR: Error collecting result for shard <number> for payment <hex>: shard handler exiting
 <time> [ERR] CRTR: Error encountered during rescan: rescan exited
+<time> [ERR] CRTR: Failed sending attempt <number> for payment <hex> to switch: could not add downstream htlc
 <time> [ERR] CRTR: Failed sending attempt <number> for payment <hex> to switch: insufficient bandwidth to route htlc
 <time> [ERR] CRTR: Failed sending attempt <number> for payment <hex> to switch: UnknownNextPeer
 <time> [ERR] CRTR: out of order block: expecting height=<height>, got height=<height>
@@ -80,6 +81,7 @@
 <time> [ERR] HSWC: ChannelLink(<chan>): link failed, exiting htlcManager
 <time> [ERR] HSWC: ChannelLink(<chan>): outgoing htlc(<hex>) has insufficient fee: expected 575000, got 1075
 <time> [ERR] HSWC: ChannelLink(<chan>): outgoing htlc(<hex>) is too small: min_htlc=<amt>, htlc_value=<amt>
+<time> [ERR] HSWC: ChannelLink(<chan>): unable to cancel incoming HTLC for circuit-key=(Chan ID=<chan>, HTLC ID=0): HTLC with ID 0 has already been failed
 <time> [ERR] HSWC: ChannelLink(<chan>): unable to decode onion hop iterator: TemporaryChannelFailure
 <time> [ERR] HSWC: ChannelLink(<chan>): unhandled error while forwarding htlc packet over htlcswitch: AmountBelowMinimum(amt=4000 mSAT, update=(lnwire.ChannelUpdate) {
 <time> [ERR] HSWC: ChannelLink(<chan>): unhandled error while forwarding htlc packet over htlcswitch: circuit has already been closed


### PR DESCRIPTION
Experiment to see how synchronous hand-off to the link could work.

Tried it out on the mpp send payment itest. To make sure that the async hand-off would lead to an extra payment attempt, I added a 100 ms sleep in the link before adding the htlc to the channel.

This is the original timing diagram, which shows the temp. chan failure originating from ourselves (@ 0)

![image](https://user-images.githubusercontent.com/4638168/79316313-73f11e80-7f04-11ea-908f-596070e616df.png)

With sync hand-off, it looks like this:

![image](https://user-images.githubusercontent.com/4638168/79316428-95eaa100-7f04-11ea-824f-fec75edd63be.png)

Fixes #4181