### PR TITLE
make+lnd+config: fix Windows build and version string

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,10 +52,10 @@ include make/testing_flags.mk
 
 DEV_TAGS := $(if ${tags},$(DEV_TAGS) ${tags},$(DEV_TAGS))
 
-make_ldflags = $(shell echo -ldflags \"-X $(PKG)/build.Commit=$(COMMIT) \
+make_ldflags = -ldflags "$(shell echo -X $(PKG)/build.Commit=$(COMMIT) \
 	-X $(PKG)/build.CommitHash=$(COMMIT_HASH) \
 	-X $(PKG)/build.GoVersion=$(GOVERSION) \
-	-X $(PKG)/build.RawTags=$(shell echo $(1) | sed -e 's/ /,/g')\")
+	-X $(PKG)/build.RawTags=$(shell echo $(1) | sed -e 's/ /,/g'))"
 
 LDFLAGS := $(call make_ldflags, ${tags})
 DEV_LDFLAGS := $(call make_ldflags, $(DEV_TAGS))

--- a/cmd/lncli/main.go
+++ b/cmd/lncli/main.go
@@ -205,7 +205,7 @@ func extractPathArgs(ctx *cli.Context) (string, string, error) {
 func main() {
 	app := cli.NewApp()
 	app.Name = "lncli"
-	app.Version = build.Version()
+	app.Version = build.Version() + " commit=" + build.Commit
 	app.Usage = "control plane for your Lightning Network Daemon (lnd)"
 	app.Flags = []cli.Flag{
 		cli.StringFlag{

--- a/config.go
+++ b/config.go
@@ -478,7 +478,8 @@ func loadConfig() (*config, error) {
 	appName = strings.TrimSuffix(appName, filepath.Ext(appName))
 	usageMessage := fmt.Sprintf("Use %s -h to show usage", appName)
 	if preCfg.ShowVersion {
-		fmt.Println(appName, "version", build.Version())
+		fmt.Println(appName, "version", build.Version(),
+			"commit="+build.Commit)
 		os.Exit(0)
 	}
 

--- a/lnd.go
+++ b/lnd.go
@@ -170,8 +170,9 @@ func Main(lisCfg ListenerCfg) error {
 	}()
 
 	// Show version at startup.
-	ltndLog.Infof("Version: %s, build=%s, logging=%s",
-		build.Version(), build.Deployment, build.LoggingType)
+	ltndLog.Infof("Version: %s commit=%s, build=%s, logging=%s",
+		build.Version(), build.Commit, build.Deployment,
+		build.LoggingType)
 
 	var network string
 	switch {


### PR DESCRIPTION
#4163 changed the way the `-ldflags` are assembled in a way that the Windows shell doesn't like (escaping a quote doesn't work the same way as in any other _sane_ shell).

Also the `build.Version()` used to return the version and the commit. Currently when building master, the `--version` flag of both `lnd` and `lncli` don't show the commit anymore. This PR also fixes that problem.