### PR TITLE
server: ignore reconnection for unadvertised inbound peers over Tor

### DIFF
--- a/server.go
+++ b/server.go
@@ -3002,15 +3002,37 @@ func (s *server) peerTerminationWatcher(p *peer, ready chan struct{}) {
 		//
 		// TODO(roasbeef): use them all?
 		if p.inbound {
-			advertisedAddr, err := s.fetchNodeAdvertisedAddr(
-				pubKey,
-			)
-			if err != nil {
-				srvrLog.Errorf("Unable to retrieve advertised "+
-					"address for node %x: %v",
-					pubKey.SerializeCompressed(), err)
-			} else {
+			advertisedAddr, err := s.fetchNodeAdvertisedAddr(pubKey)
+			switch {
+			// We found an advertised address, so use it.
+			case err == nil:
 				p.addr.Address = advertisedAddr
+
+			// The peer doesn't have an advertised address.
+			case err == errNoAdvertisedAddr:
+				// Fall back to the existing peer address if
+				// we're not accepting connections over Tor.
+				if s.torController == nil {
+					break
+				}
+
+				// If we are, the peer's address won't be known
+				// to us (we'll see a private address, which is
+				// the address used by our onion service to dial
+				// to lnd), so we don't have enough information
+				// to attempt a reconnect.
+				srvrLog.Debugf("Ignoring reconnection attempt "+
+					"to inbound peer %v without "+
+					"advertised address", p)
+				return
+
+			// We came across an error retrieving an advertised
+			// address, log it, and fall back to the existing peer
+			// address.
+			default:
+				srvrLog.Errorf("Unable to retrieve advertised "+
+					"address for node %x: %v", p.PubKey(),
+					err)
 			}
 		}
 
@@ -3408,6 +3430,10 @@ func computeNextBackoff(currBackoff time.Duration) time.Duration {
 	return nextBackoff + (time.Duration(wiggle.Uint64()) - margin/2)
 }
 
+// errNoAdvertisedAddr is an error returned when we attempt to retrieve the
+// advertised address of a node, but they don't have one.
+var errNoAdvertisedAddr = errors.New("no advertised address found")
+
 // fetchNodeAdvertisedAddr attempts to fetch an advertised address of a node.
 func (s *server) fetchNodeAdvertisedAddr(pub *btcec.PublicKey) (net.Addr, error) {
 	vertex, err := route.NewVertexFromBytes(pub.SerializeCompressed())
@@ -3421,7 +3447,7 @@ func (s *server) fetchNodeAdvertisedAddr(pub *btcec.PublicKey) (net.Addr, error)
 	}
 
 	if len(node.Addresses) == 0 {
-		return nil, errors.New("no advertised addresses found")
+		return nil, errNoAdvertisedAddr
 	}
 
 	return node.Addresses[0], nil


### PR DESCRIPTION
A peer's remote address isn't known to us if we accepted the connection over Tor, instead we know the address the onion service used to dial to lnd. If said peer also doesn't have any advertised addresses, then we don't have enough information to attempt a reconnect, so we avoid doing so. Allowing the reconnection to happen isn't necessarily an issue, but not allowing it prevents the configured SOCKS proxy from dialing to private addresses.

Fixes https://github.com/lightningnetwork/lnd/issues/4191.