### PR TITLE
routing: payment splitting pre-check

### DIFF
--- a/channeldb/payments.go
+++ b/channeldb/payments.go
@@ -116,9 +116,6 @@ const (
 
 	// FailureReasonInsufficientBalance indicates that we didn't have enough
 	// balance to complete the payment.
-	//
-	// This reason isn't assigned anymore, but may still exist for older
-	// payments.
 	FailureReasonInsufficientBalance FailureReason = 4
 
 	// TODO(halseth): cancel state.

--- a/routing/integrated_routing_test.go
+++ b/routing/integrated_routing_test.go
@@ -107,7 +107,7 @@ func onePathGraph(g *mockGraph) {
 	g.addChannel(chanIm1Target, targetNodeID, im1NodeID, 100000)
 }
 
-func twoPathGraph(g *mockGraph) {
+func twoPathGraph(g *mockGraph, capacityOut, capacityIn btcutil.Amount) {
 	// Create the following network of nodes:
 	// source -> intermediate1 -> target
 	// source -> intermediate2 -> target
@@ -120,10 +120,10 @@ func twoPathGraph(g *mockGraph) {
 	intermediate2 := newMockNode(im2NodeID)
 	g.addNode(intermediate2)
 
-	g.addChannel(chanSourceIm1, sourceNodeID, im1NodeID, 200000)
-	g.addChannel(chanSourceIm2, sourceNodeID, im2NodeID, 200000)
-	g.addChannel(chanIm1Target, targetNodeID, im1NodeID, 100000)
-	g.addChannel(chanIm2Target, targetNodeID, im2NodeID, 100000)
+	g.addChannel(chanSourceIm1, sourceNodeID, im1NodeID, capacityOut)
+	g.addChannel(chanSourceIm2, sourceNodeID, im2NodeID, capacityOut)
+	g.addChannel(chanIm1Target, targetNodeID, im1NodeID, capacityIn)
+	g.addChannel(chanIm2Target, targetNodeID, im2NodeID, capacityIn)
 }
 
 var mppTestCases = []mppSendTestCase{
@@ -136,8 +136,10 @@ var mppTestCases = []mppSendTestCase{
 	// too. Mpp payment complete.
 	{
 
-		name:             "sufficient inbound",
-		graph:            twoPathGraph,
+		name: "sufficient inbound",
+		graph: func(g *mockGraph) {
+			twoPathGraph(g, 200000, 100000)
+		},
 		amt:              70000,
 		expectedAttempts: 5,
 		expectedSuccesses: []expectedHtlcSuccess{
@@ -155,8 +157,10 @@ var mppTestCases = []mppSendTestCase{
 
 	// Test that a cap on the max htlcs makes it impossible to pay.
 	{
-		name:              "no splitting",
-		graph:             twoPathGraph,
+		name: "no splitting",
+		graph: func(g *mockGraph) {
+			twoPathGraph(g, 200000, 100000)
+		},
 		amt:               70000,
 		expectedAttempts:  2,
 		expectedSuccesses: []expectedHtlcSuccess{},

--- a/routing/integrated_routing_test.go
+++ b/routing/integrated_routing_test.go
@@ -192,6 +192,19 @@ var mppTestCases = []mppSendTestCase{
 		expectedFailure: true,
 		maxShards:       1000,
 	},
+
+	// Test that no attempts are made if the total local balance is
+	// insufficient.
+	{
+		name: "insufficient total balance",
+		graph: func(g *mockGraph) {
+			twoPathGraph(g, 100000, 500000)
+		},
+		amt:              300000,
+		expectedAttempts: 0,
+		expectedFailure:  true,
+		maxShards:        10,
+	},
 }
 
 // TestMppSend tests that a payment can be completed using multiple shards.

--- a/routing/pathfind_test.go
+++ b/routing/pathfind_test.go
@@ -1768,7 +1768,7 @@ func TestPathInsufficientCapacity(t *testing.T) {
 		noRestrictions, testPathFindingConfig,
 		sourceNode.PubKeyBytes, target, payAmt, 0,
 	)
-	if err != errNoPathFound {
+	if err != errInsufficientBalance {
 		t.Fatalf("graph shouldn't be able to support payment: %v", err)
 	}
 }
@@ -2790,6 +2790,7 @@ type pathFindingTestContext struct {
 	t                 *testing.T
 	graph             *channeldb.ChannelGraph
 	restrictParams    RestrictParams
+	bandwidthHints    map[uint64]lnwire.MilliSatoshi
 	pathFindingConfig PathFindingConfig
 	testGraphInstance *testGraphInstance
 	source            route.Vertex
@@ -2844,8 +2845,8 @@ func (c *pathFindingTestContext) findPath(target route.Vertex,
 	error) {
 
 	return dbFindPath(
-		c.graph, nil, nil, &c.restrictParams, &c.pathFindingConfig,
-		c.source, target, amt, 0,
+		c.graph, nil, c.bandwidthHints, &c.restrictParams,
+		&c.pathFindingConfig, c.source, target, amt, 0,
 	)
 }
 


### PR DESCRIPTION
Splitting pre-check to see if the total balance is sufficient for the payment. Otherwise splitting won't ever result in a successful payment, but small shards may be held by the recipient until mpp timeout.