### PR TITLE
routing: do not split payment if destination does not support mpp

### DIFF
--- a/routing/payment_session.go
+++ b/routing/payment_session.go
@@ -126,6 +126,30 @@ type paymentSession struct {
 	minShardAmt lnwire.MilliSatoshi
 }
 
+// newPaymentSession instantiates a new payment session.
+func newPaymentSession(p *LightningPayment,
+	getBandwidthHints func() (map[uint64]lnwire.MilliSatoshi, error),
+	getRoutingGraph func() (routingGraph, func(), error),
+	missionControl MissionController, pathFindingConfig PathFindingConfig) (
+	*paymentSession, error) {
+
+	edges, err := RouteHintsToEdges(p.RouteHints, p.Target)
+	if err != nil {
+		return nil, err
+	}
+
+	return &paymentSession{
+		additionalEdges:   edges,
+		getBandwidthHints: getBandwidthHints,
+		payment:           p,
+		pathFinder:        findPath,
+		getRoutingGraph:   getRoutingGraph,
+		pathFindingConfig: pathFindingConfig,
+		missionControl:    missionControl,
+		minShardAmt:       DefaultShardMinAmt,
+	}, nil
+}
+
 // RequestRoute returns a route which is likely to be capable for successfully
 // routing the specified HTLC payment to the target node. Initially the first
 // set of paths returned from this method may encounter routing failure along

--- a/routing/payment_session.go
+++ b/routing/payment_session.go
@@ -1,6 +1,10 @@
 package routing
 
 import (
+	"fmt"
+
+	"github.com/btcsuite/btclog"
+	"github.com/lightningnetwork/lnd/build"
 	"github.com/lightningnetwork/lnd/channeldb"
 	"github.com/lightningnetwork/lnd/lnwire"
 	"github.com/lightningnetwork/lnd/routing/route"
@@ -124,6 +128,9 @@ type paymentSession struct {
 	// specified in the payment is one, under no circumstances splitting
 	// will happen and this value remains unused.
 	minShardAmt lnwire.MilliSatoshi
+
+	// log is a payment session-specific logger.
+	log btclog.Logger
 }
 
 // newPaymentSession instantiates a new payment session.
@@ -138,6 +145,8 @@ func newPaymentSession(p *LightningPayment,
 		return nil, err
 	}
 
+	logPrefix := fmt.Sprintf("PaymentSession(%x):", p.PaymentHash)
+
 	return &paymentSession{
 		additionalEdges:   edges,
 		getBandwidthHints: getBandwidthHints,
@@ -147,6 +156,7 @@ func newPaymentSession(p *LightningPayment,
 		pathFindingConfig: pathFindingConfig,
 		missionControl:    missionControl,
 		minShardAmt:       DefaultShardMinAmt,
+		log:               build.NewPrefixLog(logPrefix, log),
 	}, nil
 }
 
@@ -206,8 +216,7 @@ func (p *paymentSession) RequestRoute(maxAmt, feeLimit lnwire.MilliSatoshi,
 			return nil, err
 		}
 
-		log.Debugf("PaymentSession for %x: trying pathfinding with %v",
-			p.payment.PaymentHash, maxAmt)
+		p.log.Debugf("pathfinding for amt=%v", maxAmt)
 
 		// Get a routing graph.
 		routingGraph, cleanup, err := p.getRoutingGraph()
@@ -237,6 +246,10 @@ func (p *paymentSession) RequestRoute(maxAmt, feeLimit lnwire.MilliSatoshi,
 			// No splitting if this is the last shard.
 			isLastShard := activeShards+1 >= p.payment.MaxShards
 			if isLastShard {
+				p.log.Debugf("not splitting because shard "+
+					"limit %v has been reached",
+					p.payment.MaxShards)
+
 				return nil, errNoPathFound
 			}
 
@@ -246,6 +259,10 @@ func (p *paymentSession) RequestRoute(maxAmt, feeLimit lnwire.MilliSatoshi,
 
 			// Put a lower bound on the minimum shard size.
 			if maxAmt < p.minShardAmt {
+				p.log.Debugf("not splitting because minimum "+
+					"shard amount %v has been reached",
+					p.minShardAmt)
+
 				return nil, errNoPathFound
 			}
 

--- a/routing/payment_session.go
+++ b/routing/payment_session.go
@@ -243,6 +243,15 @@ func (p *paymentSession) RequestRoute(maxAmt, feeLimit lnwire.MilliSatoshi,
 
 		switch {
 		case err == errNoPathFound:
+			// Don't split if this is a legacy payment without mpp
+			// record.
+			if p.payment.PaymentAddr == nil {
+				p.log.Debugf("not splitting because payment " +
+					"address is unspecified")
+
+				return nil, errNoPathFound
+			}
+
 			// No splitting if this is the last shard.
 			isLastShard := activeShards+1 >= p.payment.MaxShards
 			if isLastShard {

--- a/routing/payment_session_source.go
+++ b/routing/payment_session_source.go
@@ -62,11 +62,6 @@ func (m *SessionSource) getRoutingGraph() (routingGraph, func(), error) {
 func (m *SessionSource) NewPaymentSession(p *LightningPayment) (
 	PaymentSession, error) {
 
-	edges, err := RouteHintsToEdges(p.RouteHints, p.Target)
-	if err != nil {
-		return nil, err
-	}
-
 	sourceNode, err := m.Graph.SourceNode()
 	if err != nil {
 		return nil, err
@@ -78,16 +73,15 @@ func (m *SessionSource) NewPaymentSession(p *LightningPayment) (
 		return generateBandwidthHints(sourceNode, m.QueryBandwidth)
 	}
 
-	return &paymentSession{
-		additionalEdges:   edges,
-		getBandwidthHints: getBandwidthHints,
-		payment:           p,
-		pathFinder:        findPath,
-		getRoutingGraph:   m.getRoutingGraph,
-		pathFindingConfig: m.PathFindingConfig,
-		missionControl:    m.MissionControl,
-		minShardAmt:       DefaultShardMinAmt,
-	}, nil
+	session, err := newPaymentSession(
+		p, getBandwidthHints, m.getRoutingGraph,
+		m.MissionControl, m.PathFindingConfig,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	return session, nil
 }
 
 // NewPaymentSessionEmpty creates a new paymentSession instance that is empty,


### PR DESCRIPTION
Problems can occur for legacy payments or keysend payments (which are also non-mpp).