### PR TITLE
cert: define ExtendedKeyUsage as required by macOS 10.15/iOS 13.

### DIFF
--- a/cert/selfsigned.go
+++ b/cert/selfsigned.go
@@ -228,6 +228,7 @@ func GenCertPair(org, certFile, keyFile string, tlsExtraIPs,
 
 		KeyUsage: x509.KeyUsageKeyEncipherment |
 			x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,
+		ExtKeyUsage: []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
 		IsCA:                  true, // so can sign self.
 		BasicConstraintsValid: true,
 


### PR DESCRIPTION
Fixes  #4201.

It seems macOS 10.15 and iOS 13 [have new requirements for TLS certificates](https://support.apple.com/en-us/HT210176) that also apply to self-signed certs. If these requirements aren't met, the certificate is rejected, even if the self-signed CA is added to the list of trusted authorities (or when adding an "exception for this certificate" in a browser).

This PR adds the required

> TLS server certificates must contain an ExtendedKeyUsage (EKU) extension containing the id-kp-serverAuth OID.

to the self-signed certificates.

NOTE: After merging this PR, we must tag the `cert` submodule with a new version!