### PR TITLE
lnwallet: absolute fee floor sanity check

### DIFF
--- a/lnwallet/chainfee/rates.go
+++ b/lnwallet/chainfee/rates.go
@@ -9,8 +9,13 @@ import (
 
 const (
 	// FeePerKwFloor is the lowest fee rate in sat/kw that we should use for
-	// determining transaction fees.
+	// estimating transaction fees before signing.
 	FeePerKwFloor SatPerKWeight = 253
+
+	// AbsoluteFeePerKwFloor is the lowest fee rate in sat/kw of a
+	// transaction that we should ever _create_. This is the the equivalent
+	// of 1 sat/byte in sat/kw.
+	AbsoluteFeePerKwFloor SatPerKWeight = 250
 )
 
 // SatPerKVByte represents a fee rate in sat/kb.

--- a/lnwallet/channel.go
+++ b/lnwallet/channel.go
@@ -2414,7 +2414,7 @@ func (lc *LightningChannel) fetchCommitmentView(remoteChain bool,
 		chainfee.SatPerKWeight(weight)
 	if effFeeRate < chainfee.FeePerKwFloor {
 		return nil, fmt.Errorf("height=%v, for ChannelPoint(%v) "+
-			"attempts to create commitment wigh feerate %v: %v",
+			"attempts to create commitment with feerate %v: %v",
 			nextHeight, lc.channelState.FundingOutpoint,
 			effFeeRate, spew.Sdump(commitTx))
 	}

--- a/lnwallet/channel.go
+++ b/lnwallet/channel.go
@@ -2412,7 +2412,7 @@ func (lc *LightningChannel) fetchCommitmentView(remoteChain bool,
 
 	effFeeRate := chainfee.SatPerKWeight(fee) * 1000 /
 		chainfee.SatPerKWeight(weight)
-	if effFeeRate < chainfee.FeePerKwFloor {
+	if effFeeRate < chainfee.AbsoluteFeePerKwFloor {
 		return nil, fmt.Errorf("height=%v, for ChannelPoint(%v) "+
 			"attempts to create commitment with feerate %v: %v",
 			nextHeight, lc.channelState.FundingOutpoint,


### PR DESCRIPTION
Fixes #4208

This enforces the _actualized_ fee rate of the  commitment transaction,
rather than the fee floor used for estimation. The new value of 250
sat/kw corresponds to 1 sat/byte, rather than 253 which is only rounded
up during estimation to account for the fact that BOLT 3 rounds down to
the nearest satoshi and that the vbyte fee estimation is lossy.

This check was added as part of #3821 to catch any bugs in the new
anchor commitment format. The bug is not present in any official
release of lnd, but does affect master,  0.10.0-beta.rc1, and
0.10.0-beta.rc2.

For affected users, restarting with this commit should return the channel to
normal operation unless any pending htlcs have already timed out and
caused the channel to go to chain.