### PR TITLE
make+build: call release script from make

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,7 +43,7 @@ jobs:
         - make unit pkg=... case=_NONE_
         - make lint workers=1
         - make btcd
-        - LNDBUILDSYS=windows-amd64 bash ./build/release/release.sh
+        - make release sys=windows-amd64
     - stage: Test
       script: make travis-cover
       name: Unit Cover

--- a/build/release/README.md
+++ b/build/release/README.md
@@ -19,8 +19,7 @@ the release binaries following these steps:
 
 1. `git clone https://github.com/lightningnetwork/lnd.git`
 2. `cd lnd`
-3. `./build/release/release.sh <TAG> # <TAG> is the name of the next
-   release/tag`
+3. `make release tag=<TAG> # <TAG> is the name of the next release/tag`
 
 This will then create a directory of the form `lnd-<TAG>` containing archives
 of the release binaries for each supported operating system and architecture,
@@ -64,7 +63,7 @@ and `go` (matching the same version used in the release):
    release with `git checkout <TAG>`.
 7. Proceed to verify the tag with `git verify-tag <TAG>` and compile the
    binaries from source for the intended operating system and architecture with
-   `LNDBUILDSYS=OS-ARCH ./build/release/release.sh <TAG>`.
+   `make release sys=OS-ARCH tag=<TAG>`.
 8. Extract the archive found in the `lnd-<TAG>` directory created by the
    release script and recompute the `SHA256` hash of the release binaries (lnd
    and lncli) with `shasum -a 256 <filename>`. These should match __exactly__

--- a/make/release_flags.mk
+++ b/make/release_flags.mk
@@ -1,0 +1,55 @@
+VERSION_TAG = $(shell date +%Y%m%d)-01
+VERSION_CHECK = @$(call print, "Building master with date version tag")
+
+BUILD_SYSTEM = darwin-386 \
+darwin-amd64 \
+dragonfly-amd64 \
+freebsd-386 \
+freebsd-amd64 \
+freebsd-arm \
+illumos-amd64 \
+linux-386 \
+linux-amd64 \
+linux-armv6 \
+linux-armv7 \
+linux-arm64 \
+linux-ppc64 \
+linux-ppc64le \
+linux-mips \
+linux-mipsle \
+linux-mips64 \
+linux-mips64le \
+linux-s390x \
+netbsd-386 \
+netbsd-amd64 \
+netbsd-arm \
+netbsd-arm64 \
+openbsd-386 \
+openbsd-amd64 \
+openbsd-arm \
+openbsd-arm64 \
+solaris-amd64 \
+windows-386 \
+windows-amd64 \
+windows-arm
+
+RELEASE_TAGS = autopilotrpc signrpc walletrpc chainrpc invoicesrpc watchtowerrpc
+
+# One can either specify a git tag as the version suffix or one is generated
+# from the current date.
+ifneq ($(tag),)
+VERSION_TAG = $(tag)
+VERSION_CHECK = ./build/release/release.sh check-tag "$(VERSION_TAG)"
+endif
+
+# By default we will build all systems. But with the 'sys' tag, a specific
+# system can be specified. This is useful to release for a subset of
+# systems/architectures.
+ifneq ($(sys),)
+BUILD_SYSTEM = $(sys)
+endif
+
+# Use all build tags by default but allow them to be overwritten.
+ifneq ($(tags),)
+RELEASE_TAGS = $(tags)
+endif


### PR DESCRIPTION
This PR unifies the make commands and the release script.
This is necessary to make use of the new `-ldflags` assembled by the `Makefile`.

New usage:
```bash
# Release master for all systems:
make release

# Release a specific tag:
make release tag=v0.10.0-beta.rc3

# Build only for a certain system:
make release sys=linux-amd64
```