### PR TITLE
github: add GitHub Actions configuration

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,271 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - "master"
+  pull_request:
+    branches:
+      - "*"
+
+defaults:
+  run:
+    shell: bash
+
+env:
+  # go needs absolute directories, using the $HOME variable doesn't work here.
+  GOCACHE: /home/runner/work/go/pkg/build
+  GOPATH: /home/runner/work/go
+  DOWNLOAD_CACHE: /home/runner/work/download_cache
+  BITCOIN_VERSION: 0.19.1
+  GO_VERSION: 1.13.10
+
+jobs:
+  ########################
+  # RPC compilation check
+  ########################
+  rpc-check:
+    name: RPC compilation check
+    runs-on: ubuntu-latest
+    steps:
+      - name: git checkout
+        uses: actions/checkout@v1
+
+      - name: go cache
+        uses: actions/cache@v1
+        with:
+          path: /home/runner/work/go
+          key: lnd-${{ runner.os }}-go-${{ env.GO_VERSION }}-${{ github.job }}-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            lnd-${{ runner.os }}-go-${{ env.GO_VERSION }}-${{ github.job }}-${{ hashFiles('**/go.sum') }}
+            lnd-${{ runner.os }}-go-${{ env.GO_VERSION }}-${{ github.job }}-
+            lnd-${{ runner.os }}-go-${{ env.GO_VERSION }}-
+            lnd-${{ runner.os }}-go-
+
+      - name: setup go ${{ env.GO_VERSION }}
+        uses: actions/setup-go@v2
+        with:
+          go-version: '~${{ env.GO_VERSION }}'
+
+      - name: download cache
+        uses: actions/cache@v1
+        with:
+          path: /home/runner/work/download_cache
+          key: lnd-${{ runner.os }}-download-${{ hashFiles('**/install_travis_proto.sh') }}
+          restore-keys: |
+            lnd-${{ runner.os }}-download-${{ hashFiles('**/install_travis_proto.sh') }}
+            lnd-${{ runner.os }}-download-
+
+      - name: install protoc and protobuf libraries
+        run: ./scripts/install_travis_proto.sh
+
+      - name: run check
+        run: make rpc-check
+
+  ########################
+  # compile unit tests
+  ########################
+  unit-compile:
+    name: compile unit tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: git checkout
+        uses: actions/checkout@v1
+
+      - name: go cache
+        uses: actions/cache@v1
+        with:
+          path: /home/runner/work/go
+          key: lnd-${{ runner.os }}-go-${{ env.GO_VERSION }}-${{ github.job }}-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            lnd-${{ runner.os }}-go-${{ env.GO_VERSION }}-${{ github.job }}-${{ hashFiles('**/go.sum') }}
+            lnd-${{ runner.os }}-go-${{ env.GO_VERSION }}-${{ github.job }}-
+            lnd-${{ runner.os }}-go-${{ env.GO_VERSION }}-
+            lnd-${{ runner.os }}-go-
+
+      - name: setup go ${{ env.GO_VERSION }}
+        uses: actions/setup-go@v2
+        with:
+          go-version: '~${{ env.GO_VERSION }}'
+
+      - name: compile
+        run: make unit pkg=... case=_NONE_
+
+  ########################
+  # lint code
+  ########################
+  lint:
+    name: lint code
+    runs-on: ubuntu-latest
+    steps:
+      - name: git checkout
+        uses: actions/checkout@v1
+
+      - name: go cache
+        uses: actions/cache@v1
+        with:
+          path: /home/runner/work/go
+          key: lnd-${{ runner.os }}-go-${{ env.GO_VERSION }}-${{ github.job }}-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            lnd-${{ runner.os }}-go-${{ env.GO_VERSION }}-${{ github.job }}-${{ hashFiles('**/go.sum') }}
+            lnd-${{ runner.os }}-go-${{ env.GO_VERSION }}-${{ github.job }}-
+            lnd-${{ runner.os }}-go-${{ env.GO_VERSION }}-
+            lnd-${{ runner.os }}-go-
+
+      - name: setup go ${{ env.GO_VERSION }}
+        uses: actions/setup-go@v2
+        with:
+          go-version: '~${{ env.GO_VERSION }}'
+
+      - name: lint
+        run: make lint
+
+  ########################
+  # cross compilation
+  ########################
+  cross-compile:
+    name: cross compilation
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        build_sys:
+          - windows-amd64
+          - freebsd-amd64
+          - solaris-amd64
+    steps:
+      - name: git checkout
+        uses: actions/checkout@v1
+
+      - name: go cache
+        uses: actions/cache@v1
+        with:
+          path: /home/runner/work/go
+          key: lnd-${{ runner.os }}-go-${{ env.GO_VERSION }}-${{ github.job }}-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            lnd-${{ runner.os }}-go-${{ env.GO_VERSION }}-${{ github.job }}-${{ hashFiles('**/go.sum') }}
+            lnd-${{ runner.os }}-go-${{ env.GO_VERSION }}-${{ github.job }}-
+            lnd-${{ runner.os }}-go-${{ env.GO_VERSION }}-
+            lnd-${{ runner.os }}-go-
+
+      - name: setup go ${{ env.GO_VERSION }}
+        uses: actions/setup-go@v2
+        with:
+          go-version: '~${{ env.GO_VERSION }}'
+
+      - name: build release for architecture
+        run: make release sys=${{ matrix.build_sys }}
+
+  ########################
+  # run unit tests
+  ########################
+  unit-test:
+    name: run unit tests
+    runs-on: ubuntu-latest
+    strategy:
+      # Allow other tests in the matrix to continue if one fails.
+      fail-fast: false
+      matrix:
+        unit_type:
+          - btcd unit-cover
+          - travis-race
+    steps:
+      - name: git checkout
+        uses: actions/checkout@v1
+
+      - name: go cache
+        uses: actions/cache@v1
+        with:
+          path: /home/runner/work/go
+          key: lnd-${{ runner.os }}-go-${{ env.GO_VERSION }}-${{ github.job }}-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            lnd-${{ runner.os }}-go-${{ env.GO_VERSION }}-${{ github.job }}-${{ hashFiles('**/go.sum') }}
+            lnd-${{ runner.os }}-go-${{ env.GO_VERSION }}-${{ github.job }}-
+            lnd-${{ runner.os }}-go-${{ env.GO_VERSION }}-
+            lnd-${{ runner.os }}-go-
+
+      - name: setup go ${{ env.GO_VERSION }}
+        uses: actions/setup-go@v2
+        with:
+          go-version: '~${{ env.GO_VERSION }}'
+
+      - name: bitcoin cache
+        uses: actions/cache@v1
+        with:
+          path: /home/runner/bitcoin/bitcoin-${{ env.BITCOIN_VERSION }}/bin
+          key: lnd-${{ runner.os }}-bitcoin-${{ env.BITCOIN_VERSION }}
+          restore-keys: |
+            lnd-${{ runner.os }}-bitcoin-${{ env.BITCOIN_VERSION }}
+
+      - name: install bitcoind
+        run: ./scripts/install_bitcoind.sh
+
+      - name: run ${{ matrix.unit_type }}
+        run: make ${{ matrix.unit_type }}
+
+      - name: Send coverage
+        uses: shogo82148/actions-goveralls@v1
+        if: matrix.unit_type == 'btcd unit-cover'
+        with:
+          path-to-profile: coverage.txt
+          parallel: true
+
+  ########################
+  # run integration tests
+  ########################
+  integration-test:
+    name: run integration tests
+    runs-on: ubuntu-latest
+    strategy:
+      # Allow other tests in the matrix to continue if one fails.
+      fail-fast: false
+      matrix:
+        backend:
+          - btcd
+          - bitcoind
+          - neutrino
+    steps:
+      - name: git checkout
+        uses: actions/checkout@v1
+
+      - name: go cache
+        uses: actions/cache@v1
+        with:
+          path: /home/runner/work/go
+          key: lnd-${{ runner.os }}-go-${{ env.GO_VERSION }}-${{ github.job }}-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            lnd-${{ runner.os }}-go-${{ env.GO_VERSION }}-${{ github.job }}-${{ hashFiles('**/go.sum') }}
+            lnd-${{ runner.os }}-go-${{ env.GO_VERSION }}-${{ github.job }}-
+            lnd-${{ runner.os }}-go-${{ env.GO_VERSION }}-
+            lnd-${{ runner.os }}-go-
+
+      - name: setup go ${{ env.GO_VERSION }}
+        uses: actions/setup-go@v2
+        with:
+          go-version: '~${{ env.GO_VERSION }}'
+
+      - name: bitcoin cache
+        uses: actions/cache@v1
+        with:
+          path: /home/runner/bitcoin/bitcoin-${{ env.BITCOIN_VERSION }}/bin
+          key: lnd-${{ runner.os }}-bitcoin-${{ env.BITCOIN_VERSION }}
+          restore-keys: |
+            lnd-${{ runner.os }}-bitcoin-${{ env.BITCOIN_VERSION }}
+
+      - name: install bitcoind
+        run: bash ./scripts/install_bitcoind.sh
+        if: matrix.backend == 'bitcoind'
+
+      - name: ${{ matrix.backend }} integration
+        run: make itest backend=${{ matrix.backend }}
+        continue-on-error: true
+
+      - name: package logfiles
+        run: tar -zcvf itest-logs-${{ matrix.backend }}.tar.gz lntest/itest/*.log
+        if: failure()
+
+      - name: upload logfiles
+        uses: actions/upload-artifact@v1
+        if: failure()
+        with:
+          name: itest-logs-${{ matrix.backend }}
+          path: itest-logs-${{ matrix.backend }}.tar.gz


### PR DESCRIPTION
This PR implements all actions currently running on Travis CI to be run as GitHub Actions.

It seems the actions in the main repository will only be executed once the PR is merged. [Preview the actions here.](https://github.com/guggero/lnd/actions)

A complete run seems to finish in `30m 23s`, not bad :tada:
It seems GitHub allows up to 10 jobs to run simultaneously, so this could be the starting point for parallelizing the integration tests more.