### PR TITLE
lncli+docs: add safety warning about not publishing PSBT manually

### DIFF
--- a/cmd/lncli/cmd_open_channel.go
+++ b/cmd/lncli/cmd_open_channel.go
@@ -33,6 +33,10 @@ If you are using a wallet that can fund a PSBT directly (currently not possible
 with bitcoind), you can use this PSBT that contains the same address and amount:
 %s
 
+!!! WARNING !!!
+DO NOT PUBLISH the finished transaction by yourself or with another tool.
+lnd MUST publish it in the proper funding flow order OR THE FUNDS CAN BE LOST!
+
 Paste the funded PSBT here to continue the funding flow.
 Base64 encoded PSBT: `
 

--- a/docs/psbt.md
+++ b/docs/psbt.md
@@ -34,6 +34,15 @@ about the pending channel. If the remote node is an `lnd` node, we know it's
 after 10 minutes. **So as long as the whole process takes less than 10 minutes,
 everything should work fine.**
 
+### Safety warning
+
+**DO NOT PUBLISH** the finished transaction by yourself or with another tool.
+lnd MUST publish it in the proper funding flow order **OR THE FUNDS CAN BE
+LOST**!
+
+This is very important to remember when using wallets like `Wasabi` for
+instance, where the "publish" button is very easy to hit by accident.
+
 ### 1. Use the new `--psbt` flag in `lncli openchannel`
 
 The new `--psbt` flag in the `openchannel` command starts an interactive dialog
@@ -201,7 +210,15 @@ $ bitcoin-cli walletprocesspsbt cHNidP8BAH0CAAAAAbxLLf9+AYfqfF69QAQuETnL6cas7GDi
 ```
 
 Interpreting the output, we now have a complete, final, and signed transaction
-inside the PSBT. Let's give it to `lncli` to continue:
+inside the PSBT.
+
+**!!! WARNING !!!**
+
+**DO NOT PUBLISH** the finished transaction by yourself or with another tool.
+lnd MUST publish it in the proper funding flow order **OR THE FUNDS CAN BE
+LOST**!
+
+Let's give it to `lncli` to continue:
 
 ```bash
 ...


### PR DESCRIPTION
It was previously not stated clearly enough that the transaction created for the PSBT channel funding flow **must not** be published outside of `lnd`'s channel funding flow.
It appears especially with Wasabi Wallet it is very easy to click the wrong button and publish the finished PSBT by accident. This can lead to loss of funds if `lnd` doesn't accept the transaction because the amount was wrong (as happened in  #4223).
It is also possible the funding flow fails even _if_ `lnd` accepts the PSBT after it's al ready been published.