### PR TITLE
Fix crash when ChainNotifier is being accessed too early.

### DIFF
--- a/chainntnfs/btcdnotify/btcd.go
+++ b/chainntnfs/btcdnotify/btcd.go
@@ -53,7 +53,7 @@ type txUpdate struct {
 type BtcdNotifier struct {
 	epochClientCounter uint64 // To be used atomically.
 
-	started int32 // To be used atomically.
+	start   sync.Once
 	stopped int32 // To be used atomically.
 
 	chainConn   *rpcclient.Client
@@ -134,11 +134,44 @@ func New(config *rpcclient.ConnConfig, chainParams *chaincfg.Params,
 // Start connects to the running btcd node over websockets, registers for block
 // notifications, and finally launches all related helper goroutines.
 func (b *BtcdNotifier) Start() error {
-	// Already started?
-	if atomic.AddInt32(&b.started, 1) != 1 {
+	var startErr error
+	b.start.Do(func() {
+		startErr = b.startNotifier()
+	})
+	return startErr
+}
+
+// Stop shutsdown the BtcdNotifier.
+func (b *BtcdNotifier) Stop() error {
+	// Already shutting down?
+	if atomic.AddInt32(&b.stopped, 1) != 1 {
 		return nil
 	}
 
+	// Shutdown the rpc client, this gracefully disconnects from btcd, and
+	// cleans up all related resources.
+	b.chainConn.Shutdown()
+
+	close(b.quit)
+	b.wg.Wait()
+
+	b.chainUpdates.Stop()
+	b.txUpdates.Stop()
+
+	// Notify all pending clients of our shutdown by closing the related
+	// notification channels.
+	for _, epochClient := range b.blockEpochClients {
+		close(epochClient.cancelChan)
+		epochClient.wg.Wait()
+
+		close(epochClient.epochChan)
+	}
+	b.txNotifier.TearDown()
+
+	return nil
+}
+
+func (b *BtcdNotifier) startNotifier() error {
 	// Start our concurrent queues before starting the chain connection, to
 	// ensure onBlockConnected and onRedeemingTx callbacks won't be
 	// blocked.
@@ -178,36 +211,6 @@ func (b *BtcdNotifier) Start() error {
 
 	b.wg.Add(1)
 	go b.notificationDispatcher()
-
-	return nil
-}
-
-// Stop shutsdown the BtcdNotifier.
-func (b *BtcdNotifier) Stop() error {
-	// Already shutting down?
-	if atomic.AddInt32(&b.stopped, 1) != 1 {
-		return nil
-	}
-
-	// Shutdown the rpc client, this gracefully disconnects from btcd, and
-	// cleans up all related resources.
-	b.chainConn.Shutdown()
-
-	close(b.quit)
-	b.wg.Wait()
-
-	b.chainUpdates.Stop()
-	b.txUpdates.Stop()
-
-	// Notify all pending clients of our shutdown by closing the related
-	// notification channels.
-	for _, epochClient := range b.blockEpochClients {
-		close(epochClient.cancelChan)
-		epochClient.wg.Wait()
-
-		close(epochClient.epochChan)
-	}
-	b.txNotifier.TearDown()
 
 	return nil
 }

--- a/chainntnfs/interface.go
+++ b/chainntnfs/interface.go
@@ -139,6 +139,9 @@ type ChainNotifier interface {
 	// ready, and able to receive notification registrations from clients.
 	Start() error
 
+	// Started returns true if this instance has been started, and false otherwise.
+	Started() bool
+
 	// Stops the concrete ChainNotifier. Once stopped, the ChainNotifier
 	// should disallow any future requests from potential clients.
 	// Additionally, all pending client notifications will be canceled

--- a/contractcourt/chain_watcher_test.go
+++ b/contractcourt/chain_watcher_test.go
@@ -43,6 +43,10 @@ func (m *mockNotifier) Start() error {
 	return nil
 }
 
+func (m *mockNotifier) Started() bool {
+	return true
+}
+
 func (m *mockNotifier) Stop() error {
 	return nil
 }

--- a/discovery/gossiper_test.go
+++ b/discovery/gossiper_test.go
@@ -453,6 +453,10 @@ func (m *mockNotifier) Start() error {
 	return nil
 }
 
+func (m *mockNotifier) Started() bool {
+	return true
+}
+
 func (m *mockNotifier) Stop() error {
 	return nil
 }

--- a/fundingmanager_test.go
+++ b/fundingmanager_test.go
@@ -131,6 +131,10 @@ func (m *mockNotifier) Start() error {
 	return nil
 }
 
+func (m *mockNotifier) Started() bool {
+	return true
+}
+
 func (m *mockNotifier) Stop() error {
 	return nil
 }

--- a/htlcswitch/mock.go
+++ b/htlcswitch/mock.go
@@ -931,6 +931,10 @@ func (m *mockNotifier) Start() error {
 	return nil
 }
 
+func (m *mockNotifier) Started() bool {
+	return true
+}
+
 func (m *mockNotifier) Stop() error {
 	return nil
 }

--- a/lnrpc/chainrpc/chainnotifier_server.go
+++ b/lnrpc/chainrpc/chainnotifier_server.go
@@ -63,6 +63,11 @@ var (
 	// has been shut down.
 	ErrChainNotifierServerShuttingDown = errors.New("chain notifier RPC " +
 		"subserver shutting down")
+
+	// ErrChainNotifierServerNotActive indicates that the chain notifier hasn't
+	// finished the startup process.
+	ErrChainNotifierServerNotActive = errors.New("chain notifier RPC is" +
+		"still in the process of starting")
 )
 
 // fileExists reports whether the named file or directory exists.
@@ -196,6 +201,10 @@ func (s *Server) RegisterWithRootServer(grpcServer *grpc.Server) error {
 func (s *Server) RegisterConfirmationsNtfn(in *ConfRequest,
 	confStream ChainNotifier_RegisterConfirmationsNtfnServer) error {
 
+	if !s.cfg.ChainNotifier.Started() {
+		return ErrChainNotifierServerNotActive
+	}
+
 	// We'll start by reconstructing the RPC request into what the
 	// underlying ChainNotifier expects.
 	var txid chainhash.Hash
@@ -291,6 +300,10 @@ func (s *Server) RegisterConfirmationsNtfn(in *ConfRequest,
 // NOTE: This is part of the chainrpc.ChainNotifierService interface.
 func (s *Server) RegisterSpendNtfn(in *SpendRequest,
 	spendStream ChainNotifier_RegisterSpendNtfnServer) error {
+
+	if !s.cfg.ChainNotifier.Started() {
+		return ErrChainNotifierServerNotActive
+	}
 
 	// We'll start by reconstructing the RPC request into what the
 	// underlying ChainNotifier expects.
@@ -398,6 +411,10 @@ func (s *Server) RegisterSpendNtfn(in *SpendRequest,
 // NOTE: This is part of the chainrpc.ChainNotifierService interface.
 func (s *Server) RegisterBlockEpochNtfn(in *BlockEpoch,
 	epochStream ChainNotifier_RegisterBlockEpochNtfnServer) error {
+
+	if !s.cfg.ChainNotifier.Started() {
+		return ErrChainNotifierServerNotActive
+	}
 
 	// We'll start by reconstructing the RPC request into what the
 	// underlying ChainNotifier expects.

--- a/mock.go
+++ b/mock.go
@@ -112,6 +112,10 @@ func (m *mockNotfier) Start() error {
 	return nil
 }
 
+func (m *mockNotfier) Started() bool {
+	return true
+}
+
 func (m *mockNotfier) Stop() error {
 	return nil
 }

--- a/sweep/test_utils.go
+++ b/sweep/test_utils.go
@@ -200,6 +200,11 @@ func (m *MockNotifier) Start() error {
 	return nil
 }
 
+// Started checks if started
+func (m *MockNotifier) Started() bool {
+	return true
+}
+
 // Stop the notifier.
 func (m *MockNotifier) Stop() error {
 	return nil


### PR DESCRIPTION
The crash reproduces by calling one of the sub server endpoints after the RPC server is ready and before the ChainNotifier sub system starts.
The code was changed to return an error in that case allowing the caller to retry later.