### PR TITLE
chainregistry: increase zmq connection timeout with bitcoind backend

### DIFF
--- a/chainregistry.go
+++ b/chainregistry.go
@@ -314,7 +314,7 @@ func newChainControlFromConfig(cfg *config, chanDB *channeldb.DB,
 			activeNetParams.Params, bitcoindHost,
 			bitcoindMode.RPCUser, bitcoindMode.RPCPass,
 			bitcoindMode.ZMQPubRawBlock, bitcoindMode.ZMQPubRawTx,
-			100*time.Millisecond,
+			5*time.Second,
 		)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
There seems to be a misinterpretation of a variable between the btcwallet and gozmq libraries. When establish a ZMQ connection, it expects a timeout, which is used to set read deadlines and determine how long we should wait before attempting a reconnection. Within btcwallet and lnd however, this is is interpreted as a polling duration, explaining the current value of 100ms. Under load, especially on less-capable hardware, this leads to high resource usage as we get into a constant reconnection loop. To remedy this, we use a timeout of 5s instead, which is a much more reasonable value for read timeouts, and is also what's used for LN peers.