### PR TITLE
docs: fix tab size (8 spaces) in contribution guidelines

### DIFF
--- a/docs/code_contribution_guidelines.md
+++ b/docs/code_contribution_guidelines.md
@@ -485,7 +485,7 @@ set of linting scripts run by `make lint`. These include `gofmt`. In addition
 to `gofmt` we've opted to enforce the following style guidelines.
 
    * ALL columns (on a best effort basis) should be wrapped to 80 line columns.
-     Editors should be set to treat a tab as 4 spaces.
+     Editors should be set to treat a tab as 8 spaces.
    * When wrapping a line that contains a function call as the unwrapped line
      exceeds the column limit, the close paren should be placed on its own
      line. Additionally, all arguments should begin in a new line after the


### PR DESCRIPTION
Reading the code contribution guidelines, I noticed that there are contradictory informations about how a tab character should be treated: 
https://github.com/lightningnetwork/lnd/blob/20a776d70398299241ac6b76e11a3b4fe8495b68/docs/code_contribution_guidelines.md#L488
vs.
https://github.com/lightningnetwork/lnd/blob/20a776d70398299241ac6b76e11a3b4fe8495b68/docs/code_contribution_guidelines.md#L626
Looking at the commit history and PR https://github.com/lightningnetwork/lnd/pull/1196 it seems that 8 seems to be the agreed tab size. 