### PR TITLE
channeldb: eliminate extra copy in QueryPayments

### DIFF
--- a/channeldb/payments.go
+++ b/channeldb/payments.go
@@ -460,7 +460,7 @@ type PaymentsQuery struct {
 type PaymentsResponse struct {
 	// Payments is the set of payments returned from the database for the
 	// PaymentsQuery.
-	Payments []MPPayment
+	Payments []*MPPayment
 
 	// FirstIndexOffset is the index of the first element in the set of
 	// returned MPPayments. Callers can use this to resume their query
@@ -536,7 +536,7 @@ func (db *DB) QueryPayments(query PaymentsQuery) (PaymentsResponse, error) {
 			continue
 		}
 
-		resp.Payments = append(resp.Payments, *payment)
+		resp.Payments = append(resp.Payments, payment)
 	}
 
 	// Need to swap the payments slice order if reversed order.

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -5191,7 +5191,7 @@ func (r *rpcServer) ListPayments(ctx context.Context,
 	for _, payment := range paymentsQuerySlice.Payments {
 		payment := payment
 
-		rpcPayment, err := r.routerBackend.MarshallPayment(&payment)
+		rpcPayment, err := r.routerBackend.MarshallPayment(payment)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
In this commit, we eliminate an extraneous copy in the `QueryPayments`
method. Before this commit, we would copy each payment from the initial
FetchPayments call into a new slice. However, pointers to payments are
return from `FetchPayments`, so we can just maintain that same reference
rather than copying again when we want to limit our response.