### PR TITLE
itest: case insensitive log errors check

### DIFF
--- a/lntest/itest/log_check_errors.sh
+++ b/lntest/itest/log_check_errors.sh
@@ -6,7 +6,7 @@ BASEDIR=$(dirname "$0")
 cat $BASEDIR/*.log | grep "\[ERR\]" | \
 sed -r -f $BASEDIR/log_substitutions.txt | \
 sort | uniq | \
-grep -Fv -f $BASEDIR/log_error_whitelist.txt
+grep -Fvi -f $BASEDIR/log_error_whitelist.txt
 
 # If something shows up (not on whitelist) exit with error code 1.
 test $? -eq 1

--- a/lntest/itest/log_error_whitelist.txt
+++ b/lntest/itest/log_error_whitelist.txt
@@ -140,6 +140,7 @@
 <time> [ERR] RPCS: [/lnrpc.Lightning/SubscribeChannelGraph]: rpc error: code = Internal desc = transport: transport: the stream is done or WriteHeader was already called
 <time> [ERR] RPCS: [/lnrpc.Lightning/SubscribeInvoices]: rpc error: code = Canceled desc = context canceled
 <time> [ERR] RPCS: [/routerrpc.Router/SendPayment]: routerrpc server shutting down
+<time> [ERR] RPCS: [/routerrpc.Router/SendPaymentV2]: routerrpc server shutting down
 <time> [ERR] RPCS: [closechannel] unable to close ChannelPoint(<chan_point>): chain notifier shutting down
 <time> [ERR] RPCS: [connectpeer]: error connecting to peer: already connected to peer: <hex>@<ip>
 <time> [ERR] RPCS: Failed receiving from stream: rpc error: code = Canceled desc = context canceled


### PR DESCRIPTION
The itest [ERR] log check fails because recently some character cases have changed. Didn't rebase the pr before we merged and travis doesn't automatically build every pr against latest master.