### PR TITLE
build: update to walletdb/bdb version w/ mmap pre-sizing

### DIFF
--- a/chainntnfs/interface_test.go
+++ b/chainntnfs/interface_test.go
@@ -17,7 +17,6 @@ import (
 	"github.com/btcsuite/btcd/wire"
 	"github.com/btcsuite/btcutil"
 	"github.com/btcsuite/btcwallet/chain"
-	_ "github.com/btcsuite/btcwallet/walletdb/bdb" // Required to auto-register the boltdb walletdb implementation.
 	"github.com/lightninglabs/neutrino"
 	"github.com/lightningnetwork/lnd/chainntnfs"
 	"github.com/lightningnetwork/lnd/chainntnfs/bitcoindnotify"

--- a/chainntnfs/test_utils.go
+++ b/chainntnfs/test_utils.go
@@ -24,6 +24,7 @@ import (
 	"github.com/btcsuite/btcwallet/chain"
 	"github.com/btcsuite/btcwallet/walletdb"
 	"github.com/lightninglabs/neutrino"
+	"go.etcd.io/bbolt"
 )
 
 var (
@@ -268,7 +269,11 @@ func NewNeutrinoBackend(t *testing.T, minerAddr string) (*neutrino.ChainService,
 	}
 
 	dbName := filepath.Join(spvDir, "neutrino.db")
-	spvDatabase, err := walletdb.Create("bdb", dbName, true)
+	spvDatabase, err := walletdb.Create(
+		"bdb", dbName, &bbolt.Options{
+			NoFreelistSync: true,
+		},
+	)
 	if err != nil {
 		os.RemoveAll(spvDir)
 		t.Fatalf("unable to create walletdb: %v", err)

--- a/chainregistry.go
+++ b/chainregistry.go
@@ -33,6 +33,7 @@ import (
 	"github.com/lightningnetwork/lnd/lnwallet/chainfee"
 	"github.com/lightningnetwork/lnd/lnwire"
 	"github.com/lightningnetwork/lnd/routing/chainview"
+	"go.etcd.io/bbolt"
 )
 
 const (
@@ -733,7 +734,11 @@ func initNeutrinoBackend(chainDir string) (*neutrino.ChainService, func(), error
 	}
 
 	dbName := filepath.Join(dbPath, "neutrino.db")
-	db, err := walletdb.Create("bdb", dbName, !cfg.SyncFreelist)
+	db, err := walletdb.Create(
+		"bdb", dbName, &bbolt.Options{
+			NoFreelistSync: !cfg.SyncFreelist,
+		},
+	)
 	if err != nil {
 		return nil, nil, fmt.Errorf("unable to create neutrino "+
 			"database: %v", err)

--- a/channeldb/db.go
+++ b/channeldb/db.go
@@ -18,6 +18,7 @@ import (
 	"github.com/lightningnetwork/lnd/channeldb/migration_01_to_11"
 	"github.com/lightningnetwork/lnd/clock"
 	"github.com/lightningnetwork/lnd/lnwire"
+	"go.etcd.io/bbolt"
 )
 
 const (
@@ -165,7 +166,10 @@ func Open(dbPath string, modifiers ...OptionModifier) (*DB, error) {
 
 	// Specify bbolt freelist options to reduce heap pressure in case the
 	// freelist grows to be very large.
-	bdb, err := kvdb.Open(kvdb.BoltBackendName, path, opts.NoFreelistSync)
+	bboltOpts := &bbolt.Options{
+		NoFreelistSync: opts.NoFreelistSync,
+	}
+	bdb, err := kvdb.Open(kvdb.BoltBackendName, path, bboltOpts)
 	if err != nil {
 		return nil, err
 	}
@@ -251,7 +255,10 @@ func createChannelDB(dbPath string) error {
 	}
 
 	path := filepath.Join(dbPath, dbName)
-	bdb, err := kvdb.Create(kvdb.BoltBackendName, path, true)
+	bboltOpts := &bbolt.Options{
+		NoFreelistSync: true,
+	}
+	bdb, err := kvdb.Create(kvdb.BoltBackendName, path, bboltOpts)
 	if err != nil {
 		return err
 	}

--- a/channeldb/forwarding_package_test.go
+++ b/channeldb/forwarding_package_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/lightningnetwork/lnd/channeldb"
 	"github.com/lightningnetwork/lnd/channeldb/kvdb"
 	"github.com/lightningnetwork/lnd/lnwire"
+	"go.etcd.io/bbolt"
 )
 
 // TestPkgFilterBruteForce tests the behavior of a pkg filter up to size 1000,
@@ -806,7 +807,10 @@ func makeFwdPkgDB(t *testing.T, path string) kvdb.Backend { // nolint:unparam
 		path = filepath.Join(path, "fwdpkg.db")
 	}
 
-	bdb, err := kvdb.Create(kvdb.BoltBackendName, path, true)
+	bboltOpts := &bbolt.Options{
+		NoFreelistSync: true,
+	}
+	bdb, err := kvdb.Create(kvdb.BoltBackendName, path, bboltOpts)
 	if err != nil {
 		t.Fatalf("unable to open boltdb: %v", err)
 	}

--- a/channeldb/migration13/migration.go
+++ b/channeldb/migration13/migration.go
@@ -136,12 +136,10 @@ func MigrateMPP(tx kvdb.RwTx) error {
 		// Save attempt id for later use.
 		copy(attemptID[:], attemptInfo[:8])
 
-		// Discard attempt id. It will become a bucket key in the new
-		// structure.
-		attemptInfo = attemptInfo[8:]
-
-		// Append unknown (zero) attempt time.
-		attemptInfo = append(attemptInfo, zero[:]...)
+		// Copy over the attempt info into a new slice, the last 8
+		// bytes will be zero to mark a zero attempt time.
+		newAttemptInfo := make([]byte, len(attemptInfo))
+		copy(newAttemptInfo, attemptInfo[8:])
 
 		// Create bucket that contains all htlcs.
 		htlcsBucket, err := bucket.CreateBucket(paymentHtlcsBucket)
@@ -156,7 +154,7 @@ func MigrateMPP(tx kvdb.RwTx) error {
 		}
 
 		// Save migrated attempt info.
-		err = htlcBucket.Put(htlcAttemptInfoKey, attemptInfo)
+		err = htlcBucket.Put(htlcAttemptInfoKey, newAttemptInfo)
 		if err != nil {
 			return err
 		}

--- a/channeldb/migration_01_to_11/db.go
+++ b/channeldb/migration_01_to_11/db.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/lightningnetwork/lnd/channeldb/kvdb"
+	"go.etcd.io/bbolt"
 )
 
 const (
@@ -55,7 +56,10 @@ func Open(dbPath string, modifiers ...OptionModifier) (*DB, error) {
 
 	// Specify bbolt freelist options to reduce heap pressure in case the
 	// freelist grows to be very large.
-	bdb, err := kvdb.Open(kvdb.BoltBackendName, path, opts.NoFreelistSync)
+	bboltOpts := &bbolt.Options{
+		NoFreelistSync: opts.NoFreelistSync,
+	}
+	bdb, err := kvdb.Open(kvdb.BoltBackendName, path, bboltOpts)
 	if err != nil {
 		return nil, err
 	}
@@ -84,7 +88,10 @@ func createChannelDB(dbPath string) error {
 	}
 
 	path := filepath.Join(dbPath, dbName)
-	bdb, err := kvdb.Create(kvdb.BoltBackendName, path, false)
+	bboltOpts := &bbolt.Options{
+		NoFreelistSync: false,
+	}
+	bdb, err := kvdb.Create(kvdb.BoltBackendName, path, bboltOpts)
 	if err != nil {
 		return err
 	}

--- a/channeldb/migtest/migtest.go
+++ b/channeldb/migtest/migtest.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/lightningnetwork/lnd/channeldb/kvdb"
+	"go.etcd.io/bbolt"
 )
 
 // MakeDB creates a new instance of the ChannelDB for testing purposes. A
@@ -20,7 +21,10 @@ func MakeDB() (kvdb.Backend, func(), error) {
 	}
 
 	dbPath := file.Name()
-	db, err := kvdb.Open(kvdb.BoltBackendName, dbPath, true)
+	bboltOpts := &bbolt.Options{
+		NoFreelistSync: true,
+	}
+	db, err := kvdb.Open(kvdb.BoltBackendName, dbPath, bboltOpts)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/contractcourt/briefcase_test.go
+++ b/contractcourt/briefcase_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/lightningnetwork/lnd/channeldb/kvdb"
 	"github.com/lightningnetwork/lnd/input"
 	"github.com/lightningnetwork/lnd/lnwallet"
+	"go.etcd.io/bbolt"
 )
 
 var (
@@ -112,7 +113,12 @@ func makeTestDB() (kvdb.Backend, func(), error) {
 		return nil, nil, err
 	}
 
-	db, err := kvdb.Create(kvdb.BoltBackendName, tempDirName+"/test.db", true)
+	bboltOpts := &bbolt.Options{
+		NoFreelistSync: true,
+	}
+	db, err := kvdb.Create(
+		kvdb.BoltBackendName, tempDirName+"/test.db", bboltOpts,
+	)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/contractcourt/channel_arbitrator_test.go
+++ b/contractcourt/channel_arbitrator_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/lightningnetwork/lnd/input"
 	"github.com/lightningnetwork/lnd/lnwallet"
 	"github.com/lightningnetwork/lnd/lnwire"
+	"go.etcd.io/bbolt"
 )
 
 const (
@@ -394,7 +395,10 @@ func createTestChannelArbitrator(t *testing.T, log ArbitratorLog,
 			return nil, err
 		}
 		dbPath := filepath.Join(dbDir, "testdb")
-		db, err := kvdb.Create(kvdb.BoltBackendName, dbPath, true)
+		bboltOpts := &bbolt.Options{
+			NoFreelistSync: true,
+		}
+		db, err := kvdb.Create(kvdb.BoltBackendName, dbPath, bboltOpts)
 		if err != nil {
 			return nil, err
 		}

--- a/go.mod
+++ b/go.mod
@@ -48,6 +48,7 @@ require (
 	github.com/rogpeppe/fastuuid v1.2.0 // indirect
 	github.com/tv42/zbase32 v0.0.0-20160707012821-501572607d02
 	github.com/urfave/cli v1.18.0
+	go.etcd.io/bbolt v1.3.3
 	golang.org/x/crypto v0.0.0-20200115085410-6d4e4cb37c7d
 	golang.org/x/net v0.0.0-20190206173232-65e2d4e15006
 	golang.org/x/sys v0.0.0-20200116001909-b77594299b42 // indirect

--- a/go.mod
+++ b/go.mod
@@ -73,3 +73,7 @@ replace git.schwanenlied.me/yawning/bsaes.git => github.com/Yawning/bsaes v0.0.0
 replace golang.org/x/crypto => golang.org/x/crypto v0.0.0-20190211182817-74369b46fc67
 
 go 1.12
+
+replace github.com/btcsuite/btcwallet/walletdb v1.3.1 => github.com/roasbeef/btcwallet/walletdb v1.1.1-0.20200504232237-d0cfd3720fbc
+
+replace github.com/btcsuite/btcwallet v0.11.1-0.20200403222202-ada7ca077ebb => github.com/roasbeef/btcwallet v0.11.1-0.20200504232237-d0cfd3720fbc

--- a/go.sum
+++ b/go.sum
@@ -32,8 +32,6 @@ github.com/btcsuite/btcutil v1.0.2 h1:9iZ1Terx9fMIOtq1VrwdqfsATL9MC2l8ZrUY6YZ2ut
 github.com/btcsuite/btcutil v1.0.2/go.mod h1:j9HUFwoQRsZL3V4n+qG+CUnEGHOarIxfC3Le2Yhbcts=
 github.com/btcsuite/btcutil/psbt v1.0.2 h1:gCVY3KxdoEVU7Q6TjusPO+GANIwVgr9yTLqM+a6CZr8=
 github.com/btcsuite/btcutil/psbt v1.0.2/go.mod h1:LVveMu4VaNSkIRTZu2+ut0HDBRuYjqGocxDMNS1KuGQ=
-github.com/btcsuite/btcwallet v0.11.1-0.20200403222202-ada7ca077ebb h1:kkq2SSCy+OrC7GVZLIqutoHVR2yW4SJQdX70jtmuLDI=
-github.com/btcsuite/btcwallet v0.11.1-0.20200403222202-ada7ca077ebb/go.mod h1:9fJNm1aXi4q9P5Nk23mmqppCy1Le3f2/JMWj9UXKkCc=
 github.com/btcsuite/btcwallet/wallet/txauthor v1.0.0 h1:KGHMW5sd7yDdDMkCZ/JpP0KltolFsQcB973brBnfj4c=
 github.com/btcsuite/btcwallet/wallet/txauthor v1.0.0/go.mod h1:VufDts7bd/zs3GV13f/lXc/0lXrPnvxD/NvmpG/FEKU=
 github.com/btcsuite/btcwallet/wallet/txrules v1.0.0 h1:2VsfS0sBedcM5KmDzRMT3+b6xobqWveZGvjb+jFez5w=
@@ -43,8 +41,6 @@ github.com/btcsuite/btcwallet/wallet/txsizes v1.0.0/go.mod h1:pauEU8UuMFiThe5PB3
 github.com/btcsuite/btcwallet/walletdb v1.0.0/go.mod h1:bZTy9RyYZh9fLnSua+/CD48TJtYJSHjjYcSaszuxCCk=
 github.com/btcsuite/btcwallet/walletdb v1.2.0 h1:E0+M4jHOToAvGWZ27ew5AaDAHDi6fUiXkjUJUnoEOD0=
 github.com/btcsuite/btcwallet/walletdb v1.2.0/go.mod h1:9cwc1Yyg4uvd4ZdfdoMnALji+V9gfWSMfxEdLdR5Vwc=
-github.com/btcsuite/btcwallet/walletdb v1.3.1 h1:lW1Ac3F1jJY4K11P+YQtRNcP5jFk27ASfrV7C6mvRU0=
-github.com/btcsuite/btcwallet/walletdb v1.3.1/go.mod h1:9cwc1Yyg4uvd4ZdfdoMnALji+V9gfWSMfxEdLdR5Vwc=
 github.com/btcsuite/btcwallet/wtxmgr v1.0.0 h1:aIHgViEmZmZfe0tQQqF1xyd2qBqFWxX5vZXkkbjtbeA=
 github.com/btcsuite/btcwallet/wtxmgr v1.0.0/go.mod h1:vc4gBprll6BP0UJ+AIGDaySoc7MdAmZf8kelfNb8CFY=
 github.com/btcsuite/fastsha256 v0.0.0-20160815193821-637e65642941 h1:kij1x2aL7VE6gtx8KMIt8PGPgI5GV9LgtHFG5KaEMPY=
@@ -191,6 +187,10 @@ github.com/prometheus/procfs v0.0.0-20181005140218-185b4288413d/go.mod h1:c3At6R
 github.com/prometheus/procfs v0.0.0-20190507164030-5867b95ac084 h1:sofwID9zm4tzrgykg80hfFph1mryUeLRsUfoocVVmRY=
 github.com/prometheus/procfs v0.0.0-20190507164030-5867b95ac084/go.mod h1:TjEm7ze935MbeOT/UhFTIMYKhuLP4wbCsTZCD3I8kEA=
 github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
+github.com/roasbeef/btcwallet v0.11.1-0.20200504232237-d0cfd3720fbc h1:W3U+BYYfg4/xGpsFOYXtuA2G6lKOoeCdYzdbUM9a41M=
+github.com/roasbeef/btcwallet v0.11.1-0.20200504232237-d0cfd3720fbc/go.mod h1:cPwCPN+sOeaFebJTeVLQ4Bfwh8dyYX3wqyWdYtyL6sM=
+github.com/roasbeef/btcwallet/walletdb v1.1.1-0.20200504232237-d0cfd3720fbc h1:3miUtIw38iJ1kh/BV210RnSVpezbbmKnzHTF3lj7beM=
+github.com/roasbeef/btcwallet/walletdb v1.1.1-0.20200504232237-d0cfd3720fbc/go.mod h1:HVMjSxQitIbiaKk9A3eExYS7VQggeS/74J6c9K9Cj/Q=
 github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=
 github.com/rogpeppe/fastuuid v1.2.0 h1:Ppwyp6VYCF1nvBTXL3trRso7mXMlRrw9ooo375wvi2s=
 github.com/rogpeppe/fastuuid v1.2.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6LYCDYWNEvQ=

--- a/htlcswitch/decayedlog.go
+++ b/htlcswitch/decayedlog.go
@@ -11,6 +11,7 @@ import (
 	sphinx "github.com/lightningnetwork/lightning-onion"
 	"github.com/lightningnetwork/lnd/chainntnfs"
 	"github.com/lightningnetwork/lnd/channeldb/kvdb"
+	"go.etcd.io/bbolt"
 )
 
 const (
@@ -89,8 +90,11 @@ func (d *DecayedLog) Start() error {
 
 	// Open the boltdb for use.
 	var err error
+	bboltOpts := &bbolt.Options{
+		NoFreelistSync: true,
+	}
 	d.db, err = kvdb.Create(
-		kvdb.BoltBackendName, d.dbPath, true,
+		kvdb.BoltBackendName, d.dbPath, bboltOpts,
 	)
 	if err != nil {
 		return fmt.Errorf("could not open boltdb: %v", err)

--- a/keychain/interface_test.go
+++ b/keychain/interface_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/btcsuite/btcwallet/wallet"
 	"github.com/btcsuite/btcwallet/walletdb"
 	"github.com/davecgh/go-spew/spew"
+	"github.com/lightningnetwork/lnd/channeldb/kvdb"
 
 	_ "github.com/btcsuite/btcwallet/walletdb/bdb" // Required in order to create the default database.
 )
@@ -86,7 +87,7 @@ func createTestBtcWallet(coinType uint32) (func(), *wallet.Wallet, error) {
 	// the keys required for signing various contracts.
 	_, err = baseWallet.Manager.FetchScopedKeyManager(chainKeyScope)
 	if err != nil {
-		err := walletdb.Update(baseWallet.Database(), func(tx walletdb.ReadWriteTx) error {
+		err := kvdb.Update(baseWallet.Database(), func(tx walletdb.ReadWriteTx) error {
 			addrmgrNs := tx.ReadWriteBucket(waddrmgrNamespaceKey)
 
 			_, err := baseWallet.Manager.NewScopedKeyManager(

--- a/lnwallet/interface_test.go
+++ b/lnwallet/interface_test.go
@@ -44,6 +44,7 @@ import (
 	"github.com/lightningnetwork/lnd/lnwallet/chainfee"
 	"github.com/lightningnetwork/lnd/lnwallet/chanfunding"
 	"github.com/lightningnetwork/lnd/lnwire"
+	"go.etcd.io/bbolt"
 )
 
 var (
@@ -2978,7 +2979,10 @@ func runTests(t *testing.T, walletDriver *lnwallet.WalletDriver,
 			// Start Alice - open a database, start a neutrino
 			// instance, and initialize a btcwallet driver for it.
 			aliceDB, err := walletdb.Create(
-				"bdb", tempTestDirAlice+"/neutrino.db", true,
+				"bdb", tempTestDirAlice+"/neutrino.db",
+				&bbolt.Options{
+					NoFreelistSync: true,
+				},
 			)
 			if err != nil {
 				t.Fatalf("unable to create DB: %v", err)
@@ -3006,7 +3010,10 @@ func runTests(t *testing.T, walletDriver *lnwallet.WalletDriver,
 			// Start Bob - open a database, start a neutrino
 			// instance, and initialize a btcwallet driver for it.
 			bobDB, err := walletdb.Create(
-				"bdb", tempTestDirBob+"/neutrino.db", true,
+				"bdb", tempTestDirBob+"/neutrino.db",
+				&bbolt.Options{
+					NoFreelistSync: true,
+				},
 			)
 			if err != nil {
 				t.Fatalf("unable to create DB: %v", err)

--- a/macaroons/service.go
+++ b/macaroons/service.go
@@ -8,6 +8,7 @@ import (
 	"path"
 
 	"github.com/lightningnetwork/lnd/channeldb/kvdb"
+	"go.etcd.io/bbolt"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/metadata"
 
@@ -48,8 +49,11 @@ func NewService(dir string, checks ...Checker) (*Service, error) {
 
 	// Open the database that we'll use to store the primary macaroon key,
 	// and all generated macaroons+caveats.
+	bboltOpts := &bbolt.Options{
+		NoFreelistSync: true,
+	}
 	macaroonDB, err := kvdb.Create(
-		kvdb.BoltBackendName, path.Join(dir, DBFilename), true,
+		kvdb.BoltBackendName, path.Join(dir, DBFilename), bboltOpts,
 	)
 	if err != nil {
 		return nil, err

--- a/macaroons/service_test.go
+++ b/macaroons/service_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/lightningnetwork/lnd/channeldb/kvdb"
 	"github.com/lightningnetwork/lnd/macaroons"
+	"go.etcd.io/bbolt"
 	"google.golang.org/grpc/metadata"
 	"gopkg.in/macaroon-bakery.v2/bakery"
 	"gopkg.in/macaroon-bakery.v2/bakery/checkers"
@@ -33,8 +34,12 @@ func setupTestRootKeyStorage(t *testing.T) string {
 	if err != nil {
 		t.Fatalf("Error creating temp dir: %v", err)
 	}
+	bboltOpts := &bbolt.Options{
+		NoFreelistSync: true,
+	}
 	db, err := kvdb.Create(
-		kvdb.BoltBackendName, path.Join(tempDir, "macaroons.db"), true,
+		kvdb.BoltBackendName, path.Join(tempDir, "macaroons.db"),
+		bboltOpts,
 	)
 	if err != nil {
 		t.Fatalf("Error opening store DB: %v", err)

--- a/macaroons/store_test.go
+++ b/macaroons/store_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/lightningnetwork/lnd/channeldb/kvdb"
 	"github.com/lightningnetwork/lnd/macaroons"
+	"go.etcd.io/bbolt"
 
 	"github.com/btcsuite/btcwallet/snacl"
 )
@@ -21,8 +22,11 @@ func TestStore(t *testing.T) {
 	}
 	defer os.RemoveAll(tempDir)
 
+	bboltOpts := &bbolt.Options{
+		NoFreelistSync: true,
+	}
 	db, err := kvdb.Create(
-		kvdb.BoltBackendName, path.Join(tempDir, "weks.db"), true,
+		kvdb.BoltBackendName, path.Join(tempDir, "weks.db"), bboltOpts,
 	)
 	if err != nil {
 		t.Fatalf("Error opening store DB: %v", err)
@@ -78,7 +82,7 @@ func TestStore(t *testing.T) {
 	// a double-close, but that's not such a big deal since the tests will
 	// fail anyway in that case.
 	db, err = kvdb.Create(
-		kvdb.BoltBackendName, path.Join(tempDir, "weks.db"), true,
+		kvdb.BoltBackendName, path.Join(tempDir, "weks.db"), bboltOpts,
 	)
 	if err != nil {
 		t.Fatalf("Error opening store DB: %v", err)

--- a/routing/chainview/interface_test.go
+++ b/routing/chainview/interface_test.go
@@ -23,7 +23,7 @@ import (
 	"github.com/btcsuite/btcutil"
 	"github.com/btcsuite/btcwallet/chain"
 	"github.com/btcsuite/btcwallet/walletdb"
-	_ "github.com/btcsuite/btcwallet/walletdb/bdb" // Required to register the boltdb walletdb implementation.
+	"go.etcd.io/bbolt"
 
 	"github.com/lightninglabs/neutrino"
 	"github.com/lightningnetwork/lnd/channeldb"
@@ -846,7 +846,11 @@ var interfaceImpls = []struct {
 			}
 
 			dbName := filepath.Join(spvDir, "neutrino.db")
-			spvDatabase, err := walletdb.Create("bdb", dbName, true)
+			spvDatabase, err := walletdb.Create(
+				"bdb", dbName, &bbolt.Options{
+					NoFreelistSync: true,
+				},
+			)
 			if err != nil {
 				return nil, nil, err
 			}

--- a/routing/integrated_routing_context_test.go
+++ b/routing/integrated_routing_context_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/lightningnetwork/lnd/channeldb/kvdb"
 	"github.com/lightningnetwork/lnd/lnwire"
 	"github.com/lightningnetwork/lnd/routing/route"
+	"go.etcd.io/bbolt"
 )
 
 const (
@@ -105,7 +106,10 @@ func (c *integratedRoutingContext) testPayment(maxParts uint32) ([]htlcAttempt,
 	dbPath := file.Name()
 	defer os.Remove(dbPath)
 
-	db, err := kvdb.Open(kvdb.BoltBackendName, dbPath, true)
+	bboltOpts := &bbolt.Options{
+		NoFreelistSync: true,
+	}
+	db, err := kvdb.Open(kvdb.BoltBackendName, dbPath, bboltOpts)
 	if err != nil {
 		c.t.Fatal(err)
 	}

--- a/routing/missioncontrol_store_test.go
+++ b/routing/missioncontrol_store_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/davecgh/go-spew/spew"
 	"github.com/lightningnetwork/lnd/channeldb/kvdb"
 	"github.com/lightningnetwork/lnd/lnwire"
+	"go.etcd.io/bbolt"
 
 	"github.com/lightningnetwork/lnd/routing/route"
 )
@@ -31,7 +32,10 @@ func TestMissionControlStore(t *testing.T) {
 
 	dbPath := file.Name()
 
-	db, err := kvdb.Create(kvdb.BoltBackendName, dbPath, true)
+	bboltOpts := &bbolt.Options{
+		NoFreelistSync: true,
+	}
+	db, err := kvdb.Create(kvdb.BoltBackendName, dbPath, bboltOpts)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/routing/missioncontrol_test.go
+++ b/routing/missioncontrol_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/lightningnetwork/lnd/channeldb/kvdb"
 	"github.com/lightningnetwork/lnd/lnwire"
 	"github.com/lightningnetwork/lnd/routing/route"
+	"go.etcd.io/bbolt"
 )
 
 var (
@@ -63,7 +64,10 @@ func createMcTestContext(t *testing.T) *mcTestContext {
 
 	ctx.dbPath = file.Name()
 
-	ctx.db, err = kvdb.Open(kvdb.BoltBackendName, ctx.dbPath, true)
+	bboltOpts := &bbolt.Options{
+		NoFreelistSync: true,
+	}
+	ctx.db, err = kvdb.Open(kvdb.BoltBackendName, ctx.dbPath, bboltOpts)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/watchtower/wtdb/db_common.go
+++ b/watchtower/wtdb/db_common.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 
 	"github.com/lightningnetwork/lnd/channeldb/kvdb"
+	"go.etcd.io/bbolt"
 )
 
 const (
@@ -65,7 +66,10 @@ func createDBIfNotExist(dbPath, name string) (kvdb.Backend, bool, error) {
 
 	// Specify bbolt freelist options to reduce heap pressure in case the
 	// freelist grows to be very large.
-	bdb, err := kvdb.Create(kvdb.BoltBackendName, path, true)
+	bboltOpts := &bbolt.Options{
+		NoFreelistSync: true,
+	}
+	bdb, err := kvdb.Create(kvdb.BoltBackendName, path, bboltOpts)
 	if err != nil {
 		return nil, false, err
 	}


### PR DESCRIPTION
In this commit, we update to the `walletdb/bdb` version that now has
mmap-pre-sizing. By sizing the memory map ahead of time, we aim to avoid
the mass copies in the DB each time we need to expand the size of the
DB. The new version will set the mmap size to 2x the db size, which
allows the DB to double before we need to remap everything.