### PR TITLE
config+lnrpc: Allow external config parsing and external subservers

### DIFF
--- a/chainregistry.go
+++ b/chainregistry.go
@@ -28,6 +28,7 @@ import (
 	"github.com/lightningnetwork/lnd/htlcswitch"
 	"github.com/lightningnetwork/lnd/input"
 	"github.com/lightningnetwork/lnd/keychain"
+	"github.com/lightningnetwork/lnd/lncfg"
 	"github.com/lightningnetwork/lnd/lnwallet"
 	"github.com/lightningnetwork/lnd/lnwallet/btcwallet"
 	"github.com/lightningnetwork/lnd/lnwallet/chainfee"
@@ -263,7 +264,7 @@ func newChainControlFromConfig(cfg *Config, chanDB *channeldb.DB,
 		)
 
 	case "bitcoind", "litecoind":
-		var bitcoindMode *bitcoindConfig
+		var bitcoindMode *lncfg.Bitcoind
 		switch {
 		case cfg.Bitcoin.Active:
 			bitcoindMode = cfg.BitcoindMode
@@ -388,7 +389,7 @@ func newChainControlFromConfig(cfg *Config, chanDB *channeldb.DB,
 		// connection. If a raw cert was specified in the config, then
 		// we'll set that directly. Otherwise, we attempt to read the
 		// cert from the path specified in the config.
-		var btcdMode *btcdConfig
+		var btcdMode *lncfg.Btcd
 		switch {
 		case cfg.Bitcoin.Active:
 			btcdMode = cfg.BtcdMode

--- a/chainregistry.go
+++ b/chainregistry.go
@@ -160,7 +160,7 @@ type chainControl struct {
 // full-node, another backed by a running bitcoind full-node, and the other
 // backed by a running neutrino light client instance. When running with a
 // neutrino light client instance, `neutrinoCS` must be non-nil.
-func newChainControlFromConfig(cfg *config, chanDB *channeldb.DB,
+func newChainControlFromConfig(cfg *Config, chanDB *channeldb.DB,
 	privateWalletPw, publicWalletPw []byte, birthday time.Time,
 	recoveryWindow uint32, wallet *wallet.Wallet,
 	neutrinoCS *neutrino.ChainService) (*chainControl, error) {

--- a/cmd/lnd/main.go
+++ b/cmd/lnd/main.go
@@ -4,8 +4,9 @@ import (
 	"fmt"
 	"os"
 
-	flags "github.com/jessevdk/go-flags"
+	"github.com/jessevdk/go-flags"
 	"github.com/lightningnetwork/lnd"
+	"github.com/lightningnetwork/lnd/signal"
 )
 
 func main() {
@@ -17,9 +18,15 @@ func main() {
 		os.Exit(1)
 	}
 
+	// Hook interceptor for os signals.
+	signal.Intercept()
+
 	// Call the "real" main in a nested manner so the defers will properly
 	// be executed in the case of a graceful shutdown.
-	if err := lnd.Main(loadedConfig, lnd.ListenerCfg{}); err != nil {
+	err = lnd.Main(
+		loadedConfig, lnd.ListenerCfg{}, signal.ShutdownChannel(),
+	)
+	if err != nil {
 		if e, ok := err.(*flags.Error); ok && e.Type == flags.ErrHelp {
 		} else {
 			_, _ = fmt.Fprintln(os.Stderr, err)

--- a/cmd/lnd/main.go
+++ b/cmd/lnd/main.go
@@ -9,12 +9,20 @@ import (
 )
 
 func main() {
+	// Load the configuration, and parse any command line options. This
+	// function will also set up logging properly.
+	loadedConfig, err := lnd.LoadConfig()
+	if err != nil {
+		_, _ = fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+
 	// Call the "real" main in a nested manner so the defers will properly
 	// be executed in the case of a graceful shutdown.
-	if err := lnd.Main(lnd.ListenerCfg{}); err != nil {
+	if err := lnd.Main(loadedConfig, lnd.ListenerCfg{}); err != nil {
 		if e, ok := err.(*flags.Error); ok && e.Type == flags.ErrHelp {
 		} else {
-			fmt.Fprintln(os.Stderr, err)
+			_, _ = fmt.Fprintln(os.Stderr, err)
 		}
 		os.Exit(1)
 	}

--- a/config.go
+++ b/config.go
@@ -30,7 +30,6 @@ import (
 	"github.com/lightningnetwork/lnd/lncfg"
 	"github.com/lightningnetwork/lnd/lnrpc/routerrpc"
 	"github.com/lightningnetwork/lnd/lnrpc/signrpc"
-	"github.com/lightningnetwork/lnd/lnwire"
 	"github.com/lightningnetwork/lnd/routing"
 	"github.com/lightningnetwork/lnd/tor"
 )
@@ -163,81 +162,6 @@ var (
 	bitcoindEstimateModes       = [2]string{"ECONOMICAL", defaultBitcoindEstimateMode}
 )
 
-type chainConfig struct {
-	Active   bool   `long:"active" description:"If the chain should be active or not."`
-	ChainDir string `long:"chaindir" description:"The directory to store the chain's data within."`
-
-	Node string `long:"node" description:"The blockchain interface to use." choice:"btcd" choice:"bitcoind" choice:"neutrino" choice:"ltcd" choice:"litecoind"`
-
-	MainNet  bool `long:"mainnet" description:"Use the main network"`
-	TestNet3 bool `long:"testnet" description:"Use the test network"`
-	SimNet   bool `long:"simnet" description:"Use the simulation test network"`
-	RegTest  bool `long:"regtest" description:"Use the regression test network"`
-
-	DefaultNumChanConfs int                 `long:"defaultchanconfs" description:"The default number of confirmations a channel must have before it's considered open. If this is not set, we will scale the value according to the channel size."`
-	DefaultRemoteDelay  int                 `long:"defaultremotedelay" description:"The default number of blocks we will require our channel counterparty to wait before accessing its funds in case of unilateral close. If this is not set, we will scale the value according to the channel size."`
-	MinHTLCIn           lnwire.MilliSatoshi `long:"minhtlc" description:"The smallest HTLC we are willing to accept on our channels, in millisatoshi"`
-	MinHTLCOut          lnwire.MilliSatoshi `long:"minhtlcout" description:"The smallest HTLC we are willing to send out on our channels, in millisatoshi"`
-	BaseFee             lnwire.MilliSatoshi `long:"basefee" description:"The base fee in millisatoshi we will charge for forwarding payments on our channels"`
-	FeeRate             lnwire.MilliSatoshi `long:"feerate" description:"The fee rate used when forwarding payments on our channels. The total fee charged is basefee + (amount * feerate / 1000000), where amount is the forwarded amount."`
-	TimeLockDelta       uint32              `long:"timelockdelta" description:"The CLTV delta we will subtract from a forwarded HTLC's timelock value"`
-}
-
-type neutrinoConfig struct {
-	AddPeers           []string      `short:"a" long:"addpeer" description:"Add a peer to connect with at startup"`
-	ConnectPeers       []string      `long:"connect" description:"Connect only to the specified peers at startup"`
-	MaxPeers           int           `long:"maxpeers" description:"Max number of inbound and outbound peers"`
-	BanDuration        time.Duration `long:"banduration" description:"How long to ban misbehaving peers.  Valid time units are {s, m, h}.  Minimum 1 second"`
-	BanThreshold       uint32        `long:"banthreshold" description:"Maximum allowed ban score before disconnecting and banning misbehaving peers."`
-	FeeURL             string        `long:"feeurl" description:"Optional URL for fee estimation. If a URL is not specified, static fees will be used for estimation."`
-	AssertFilterHeader string        `long:"assertfilterheader" description:"Optional filter header in height:hash format to assert the state of neutrino's filter header chain on startup. If the assertion does not hold, then the filter header chain will be re-synced from the genesis block."`
-}
-
-type btcdConfig struct {
-	Dir        string `long:"dir" description:"The base directory that contains the node's data, logs, configuration file, etc."`
-	RPCHost    string `long:"rpchost" description:"The daemon's rpc listening address. If a port is omitted, then the default port for the selected chain parameters will be used."`
-	RPCUser    string `long:"rpcuser" description:"Username for RPC connections"`
-	RPCPass    string `long:"rpcpass" default-mask:"-" description:"Password for RPC connections"`
-	RPCCert    string `long:"rpccert" description:"File containing the daemon's certificate file"`
-	RawRPCCert string `long:"rawrpccert" description:"The raw bytes of the daemon's PEM-encoded certificate chain which will be used to authenticate the RPC connection."`
-}
-
-type bitcoindConfig struct {
-	Dir            string `long:"dir" description:"The base directory that contains the node's data, logs, configuration file, etc."`
-	RPCHost        string `long:"rpchost" description:"The daemon's rpc listening address. If a port is omitted, then the default port for the selected chain parameters will be used."`
-	RPCUser        string `long:"rpcuser" description:"Username for RPC connections"`
-	RPCPass        string `long:"rpcpass" default-mask:"-" description:"Password for RPC connections"`
-	ZMQPubRawBlock string `long:"zmqpubrawblock" description:"The address listening for ZMQ connections to deliver raw block notifications"`
-	ZMQPubRawTx    string `long:"zmqpubrawtx" description:"The address listening for ZMQ connections to deliver raw transaction notifications"`
-	EstimateMode   string `long:"estimatemode" description:"The fee estimate mode. Must be either ECONOMICAL or CONSERVATIVE."`
-}
-
-type autoPilotConfig struct {
-	Active         bool               `long:"active" description:"If the autopilot agent should be active or not."`
-	Heuristic      map[string]float64 `long:"heuristic" description:"Heuristic to activate, and the weight to give it during scoring."`
-	MaxChannels    int                `long:"maxchannels" description:"The maximum number of channels that should be created"`
-	Allocation     float64            `long:"allocation" description:"The percentage of total funds that should be committed to automatic channel establishment"`
-	MinChannelSize int64              `long:"minchansize" description:"The smallest channel that the autopilot agent should create"`
-	MaxChannelSize int64              `long:"maxchansize" description:"The largest channel that the autopilot agent should create"`
-	Private        bool               `long:"private" description:"Whether the channels created by the autopilot agent should be private or not. Private channels won't be announced to the network."`
-	MinConfs       int32              `long:"minconfs" description:"The minimum number of confirmations each of your inputs in funding transactions created by the autopilot agent must have."`
-	ConfTarget     uint32             `long:"conftarget" description:"The confirmation target (in blocks) for channels opened by autopilot."`
-}
-
-type torConfig struct {
-	Active            bool   `long:"active" description:"Allow outbound and inbound connections to be routed through Tor"`
-	SOCKS             string `long:"socks" description:"The host:port that Tor's exposed SOCKS5 proxy is listening on"`
-	DNS               string `long:"dns" description:"The DNS server as host:port that Tor will use for SRV queries - NOTE must have TCP resolution enabled"`
-	StreamIsolation   bool   `long:"streamisolation" description:"Enable Tor stream isolation by randomizing user credentials for each connection."`
-	Control           string `long:"control" description:"The host:port that Tor is listening on for Tor control connections"`
-	TargetIPAddress   string `long:"targetipaddress" description:"IP address that Tor should use as the target of the hidden service"`
-	Password          string `long:"password" description:"The password used to arrive at the HashedControlPassword for the control port. If provided, the HASHEDPASSWORD authentication method will be used instead of the SAFECOOKIE one."`
-	V2                bool   `long:"v2" description:"Automatically set up a v2 onion service to listen for inbound connections"`
-	V3                bool   `long:"v3" description:"Automatically set up a v3 onion service to listen for inbound connections"`
-	PrivateKeyPath    string `long:"privatekeypath" description:"The path to the private key of the onion service being created"`
-	WatchtowerKeyPath string `long:"watchtowerkeypath" description:"The path to the private key of the watchtower onion service being created"`
-}
-
 // Config defines the configuration options for lnd.
 //
 // See LoadConfig for further details regarding the configuration
@@ -294,18 +218,18 @@ type Config struct {
 	MaxPendingChannels int    `long:"maxpendingchannels" description:"The maximum number of incoming pending channels permitted per peer."`
 	BackupFilePath     string `long:"backupfilepath" description:"The target location of the channel backup file"`
 
-	Bitcoin      *chainConfig    `group:"Bitcoin" namespace:"bitcoin"`
-	BtcdMode     *btcdConfig     `group:"btcd" namespace:"btcd"`
-	BitcoindMode *bitcoindConfig `group:"bitcoind" namespace:"bitcoind"`
-	NeutrinoMode *neutrinoConfig `group:"neutrino" namespace:"neutrino"`
+	Bitcoin      *lncfg.Chain    `group:"Bitcoin" namespace:"bitcoin"`
+	BtcdMode     *lncfg.Btcd     `group:"btcd" namespace:"btcd"`
+	BitcoindMode *lncfg.Bitcoind `group:"bitcoind" namespace:"bitcoind"`
+	NeutrinoMode *lncfg.Neutrino `group:"neutrino" namespace:"neutrino"`
 
-	Litecoin      *chainConfig    `group:"Litecoin" namespace:"litecoin"`
-	LtcdMode      *btcdConfig     `group:"ltcd" namespace:"ltcd"`
-	LitecoindMode *bitcoindConfig `group:"litecoind" namespace:"litecoind"`
+	Litecoin      *lncfg.Chain    `group:"Litecoin" namespace:"litecoin"`
+	LtcdMode      *lncfg.Btcd     `group:"ltcd" namespace:"ltcd"`
+	LitecoindMode *lncfg.Bitcoind `group:"litecoind" namespace:"litecoind"`
 
-	Autopilot *autoPilotConfig `group:"Autopilot" namespace:"autopilot"`
+	Autopilot *lncfg.AutoPilot `group:"Autopilot" namespace:"autopilot"`
 
-	Tor *torConfig `group:"Tor" namespace:"tor"`
+	Tor *lncfg.Tor `group:"Tor" namespace:"tor"`
 
 	SubRPCServers *subRPCServerConfigs `group:"subrpc"`
 
@@ -385,7 +309,7 @@ func LoadConfig() (*Config, error) {
 		MaxLogFiles:     defaultMaxLogFiles,
 		MaxLogFileSize:  defaultMaxLogFileSize,
 		AcceptorTimeout: defaultAcceptorTimeout,
-		Bitcoin: &chainConfig{
+		Bitcoin: &lncfg.Chain{
 			MinHTLCIn:     defaultBitcoinMinHTLCInMSat,
 			MinHTLCOut:    defaultBitcoinMinHTLCOutMSat,
 			BaseFee:       DefaultBitcoinBaseFeeMSat,
@@ -393,17 +317,17 @@ func LoadConfig() (*Config, error) {
 			TimeLockDelta: DefaultBitcoinTimeLockDelta,
 			Node:          "btcd",
 		},
-		BtcdMode: &btcdConfig{
+		BtcdMode: &lncfg.Btcd{
 			Dir:     defaultBtcdDir,
 			RPCHost: defaultRPCHost,
 			RPCCert: defaultBtcdRPCCertFile,
 		},
-		BitcoindMode: &bitcoindConfig{
+		BitcoindMode: &lncfg.Bitcoind{
 			Dir:          defaultBitcoindDir,
 			RPCHost:      defaultRPCHost,
 			EstimateMode: defaultBitcoindEstimateMode,
 		},
-		Litecoin: &chainConfig{
+		Litecoin: &lncfg.Chain{
 			MinHTLCIn:     defaultLitecoinMinHTLCInMSat,
 			MinHTLCOut:    defaultLitecoinMinHTLCOutMSat,
 			BaseFee:       defaultLitecoinBaseFeeMSat,
@@ -411,12 +335,12 @@ func LoadConfig() (*Config, error) {
 			TimeLockDelta: defaultLitecoinTimeLockDelta,
 			Node:          "ltcd",
 		},
-		LtcdMode: &btcdConfig{
+		LtcdMode: &lncfg.Btcd{
 			Dir:     defaultLtcdDir,
 			RPCHost: defaultRPCHost,
 			RPCCert: defaultLtcdRPCCertFile,
 		},
-		LitecoindMode: &bitcoindConfig{
+		LitecoindMode: &lncfg.Bitcoind{
 			Dir:          defaultLitecoindDir,
 			RPCHost:      defaultRPCHost,
 			EstimateMode: defaultBitcoindEstimateMode,
@@ -430,7 +354,7 @@ func LoadConfig() (*Config, error) {
 			SignRPC:   &signrpc.Config{},
 			RouterRPC: routerrpc.DefaultConfig(),
 		},
-		Autopilot: &autoPilotConfig{
+		Autopilot: &lncfg.AutoPilot{
 			MaxChannels:    5,
 			Allocation:     0.6,
 			MinChannelSize: int64(minChanFundingSize),
@@ -451,7 +375,7 @@ func LoadConfig() (*Config, error) {
 		MinChanSize:                   int64(minChanFundingSize),
 		NumGraphSyncPeers:             defaultMinPeers,
 		HistoricalSyncInterval:        discovery.DefaultHistoricalSyncInterval,
-		Tor: &torConfig{
+		Tor: &lncfg.Tor{
 			SOCKS:   defaultTorSOCKS,
 			DNS:     defaultTorDNS,
 			Control: defaultTorControl,
@@ -1205,7 +1129,7 @@ func cleanAndExpandPath(path string) string {
 	return filepath.Clean(os.ExpandEnv(path))
 }
 
-func parseRPCParams(cConfig *chainConfig, nodeConfig interface{}, net chainCode,
+func parseRPCParams(cConfig *lncfg.Chain, nodeConfig interface{}, net chainCode,
 	funcName string) error {
 
 	// First, we'll check our node config to make sure the RPC parameters
@@ -1213,7 +1137,7 @@ func parseRPCParams(cConfig *chainConfig, nodeConfig interface{}, net chainCode,
 	// depending on the backend node.
 	var daemonName, confDir, confFile string
 	switch conf := nodeConfig.(type) {
-	case *btcdConfig:
+	case *lncfg.Btcd:
 		// If both RPCUser and RPCPass are set, we assume those
 		// credentials are good to use.
 		if conf.RPCUser != "" && conf.RPCPass != "" {
@@ -1239,7 +1163,7 @@ func parseRPCParams(cConfig *chainConfig, nodeConfig interface{}, net chainCode,
 				"%[1]v.rpcuser, %[1]v.rpcpass", daemonName)
 		}
 
-	case *bitcoindConfig:
+	case *lncfg.Bitcoind:
 		// Ensure that if the ZMQ options are set, that they are not
 		// equal.
 		if conf.ZMQPubRawBlock != "" && conf.ZMQPubRawTx != "" {
@@ -1305,7 +1229,7 @@ func parseRPCParams(cConfig *chainConfig, nodeConfig interface{}, net chainCode,
 	confFile = filepath.Join(confDir, fmt.Sprintf("%v.conf", confFile))
 	switch cConfig.Node {
 	case "btcd", "ltcd":
-		nConf := nodeConfig.(*btcdConfig)
+		nConf := nodeConfig.(*lncfg.Btcd)
 		rpcUser, rpcPass, err := extractBtcdRPCParams(confFile)
 		if err != nil {
 			return fmt.Errorf("unable to extract RPC credentials:"+
@@ -1314,7 +1238,7 @@ func parseRPCParams(cConfig *chainConfig, nodeConfig interface{}, net chainCode,
 		}
 		nConf.RPCUser, nConf.RPCPass = rpcUser, rpcPass
 	case "bitcoind", "litecoind":
-		nConf := nodeConfig.(*bitcoindConfig)
+		nConf := nodeConfig.(*lncfg.Bitcoind)
 		rpcUser, rpcPass, zmqBlockHost, zmqTxHost, err :=
 			extractBitcoindRPCParams(confFile)
 		if err != nil {

--- a/config.go
+++ b/config.go
@@ -238,11 +238,11 @@ type torConfig struct {
 	WatchtowerKeyPath string `long:"watchtowerkeypath" description:"The path to the private key of the watchtower onion service being created"`
 }
 
-// config defines the configuration options for lnd.
+// Config defines the configuration options for lnd.
 //
-// See loadConfig for further details regarding the configuration
+// See LoadConfig for further details regarding the configuration
 // loading+parsing process.
-type config struct {
+type Config struct {
 	ShowVersion bool `short:"V" long:"version" description:"Display version information and exit"`
 
 	LndDir       string `long:"lnddir" description:"The base directory that contains lnd's data, logs, configuration file, etc."`
@@ -365,7 +365,7 @@ type config struct {
 	AllowCircularRoute bool `long:"allow-circular-route" description:"If true, our node will allow htlc forwards that arrive and depart on the same channel."`
 }
 
-// loadConfig initializes and parses the config using a config file and command
+// LoadConfig initializes and parses the config using a config file and command
 // line options.
 //
 // The configuration proceeds as follows:
@@ -373,8 +373,8 @@ type config struct {
 // 	2) Pre-parse the command line to check for an alternative config file
 // 	3) Load configuration file overwriting defaults with any specified options
 // 	4) Parse CLI options and overwrite/add any specified options
-func loadConfig() (*config, error) {
-	defaultCfg := config{
+func LoadConfig() (*Config, error) {
+	defaultCfg := Config{
 		LndDir:          defaultLndDir,
 		ConfigFile:      defaultConfigFile,
 		DataDir:         defaultDataDir,

--- a/config.go
+++ b/config.go
@@ -435,8 +435,8 @@ func LoadConfig() (*Config, error) {
 	// use the default config file path. However, if the user has modified
 	// their lnddir, then we should assume they intend to use the config
 	// file within it.
-	configFileDir := cleanAndExpandPath(preCfg.LndDir)
-	configFilePath := cleanAndExpandPath(preCfg.ConfigFile)
+	configFileDir := CleanAndExpandPath(preCfg.LndDir)
+	configFilePath := CleanAndExpandPath(preCfg.ConfigFile)
 	if configFileDir != DefaultLndDir {
 		if configFilePath == DefaultConfigFile {
 			configFilePath = filepath.Join(
@@ -487,7 +487,7 @@ func LoadConfig() (*Config, error) {
 func ValidateConfig(cfg Config, usageMessage string) (*Config, error) {
 	// If the provided lnd directory is not the default, we'll modify the
 	// path to all of the files and directories that will live within it.
-	lndDir := cleanAndExpandPath(cfg.LndDir)
+	lndDir := CleanAndExpandPath(cfg.LndDir)
 	if lndDir != DefaultLndDir {
 		cfg.DataDir = filepath.Join(lndDir, defaultDataDirname)
 		cfg.TLSCertPath = filepath.Join(lndDir, defaultTLSCertFilename)
@@ -525,20 +525,20 @@ func ValidateConfig(cfg Config, usageMessage string) (*Config, error) {
 	// As soon as we're done parsing configuration options, ensure all paths
 	// to directories and files are cleaned and expanded before attempting
 	// to use them later on.
-	cfg.DataDir = cleanAndExpandPath(cfg.DataDir)
-	cfg.TLSCertPath = cleanAndExpandPath(cfg.TLSCertPath)
-	cfg.TLSKeyPath = cleanAndExpandPath(cfg.TLSKeyPath)
-	cfg.AdminMacPath = cleanAndExpandPath(cfg.AdminMacPath)
-	cfg.ReadMacPath = cleanAndExpandPath(cfg.ReadMacPath)
-	cfg.InvoiceMacPath = cleanAndExpandPath(cfg.InvoiceMacPath)
-	cfg.LogDir = cleanAndExpandPath(cfg.LogDir)
-	cfg.BtcdMode.Dir = cleanAndExpandPath(cfg.BtcdMode.Dir)
-	cfg.LtcdMode.Dir = cleanAndExpandPath(cfg.LtcdMode.Dir)
-	cfg.BitcoindMode.Dir = cleanAndExpandPath(cfg.BitcoindMode.Dir)
-	cfg.LitecoindMode.Dir = cleanAndExpandPath(cfg.LitecoindMode.Dir)
-	cfg.Tor.PrivateKeyPath = cleanAndExpandPath(cfg.Tor.PrivateKeyPath)
-	cfg.Tor.WatchtowerKeyPath = cleanAndExpandPath(cfg.Tor.WatchtowerKeyPath)
-	cfg.Watchtower.TowerDir = cleanAndExpandPath(cfg.Watchtower.TowerDir)
+	cfg.DataDir = CleanAndExpandPath(cfg.DataDir)
+	cfg.TLSCertPath = CleanAndExpandPath(cfg.TLSCertPath)
+	cfg.TLSKeyPath = CleanAndExpandPath(cfg.TLSKeyPath)
+	cfg.AdminMacPath = CleanAndExpandPath(cfg.AdminMacPath)
+	cfg.ReadMacPath = CleanAndExpandPath(cfg.ReadMacPath)
+	cfg.InvoiceMacPath = CleanAndExpandPath(cfg.InvoiceMacPath)
+	cfg.LogDir = CleanAndExpandPath(cfg.LogDir)
+	cfg.BtcdMode.Dir = CleanAndExpandPath(cfg.BtcdMode.Dir)
+	cfg.LtcdMode.Dir = CleanAndExpandPath(cfg.LtcdMode.Dir)
+	cfg.BitcoindMode.Dir = CleanAndExpandPath(cfg.BitcoindMode.Dir)
+	cfg.LitecoindMode.Dir = CleanAndExpandPath(cfg.LitecoindMode.Dir)
+	cfg.Tor.PrivateKeyPath = CleanAndExpandPath(cfg.Tor.PrivateKeyPath)
+	cfg.Tor.WatchtowerKeyPath = CleanAndExpandPath(cfg.Tor.WatchtowerKeyPath)
+	cfg.Watchtower.TowerDir = CleanAndExpandPath(cfg.Watchtower.TowerDir)
 
 	// Ensure that the user didn't attempt to specify negative values for
 	// any of the autopilot params.
@@ -1133,10 +1133,10 @@ func ValidateConfig(cfg Config, usageMessage string) (*Config, error) {
 	return &cfg, err
 }
 
-// cleanAndExpandPath expands environment variables and leading ~ in the
+// CleanAndExpandPath expands environment variables and leading ~ in the
 // passed path, cleans the result, and returns it.
 // This function is taken from https://github.com/btcsuite/btcd
-func cleanAndExpandPath(path string) string {
+func CleanAndExpandPath(path string) string {
 	if path == "" {
 		return ""
 	}

--- a/config.go
+++ b/config.go
@@ -289,16 +289,9 @@ type Config struct {
 	AllowCircularRoute bool `long:"allow-circular-route" description:"If true, our node will allow htlc forwards that arrive and depart on the same channel."`
 }
 
-// LoadConfig initializes and parses the config using a config file and command
-// line options.
-//
-// The configuration proceeds as follows:
-// 	1) Start with a default config with sane settings
-// 	2) Pre-parse the command line to check for an alternative config file
-// 	3) Load configuration file overwriting defaults with any specified options
-// 	4) Parse CLI options and overwrite/add any specified options
-func LoadConfig() (*Config, error) {
-	defaultCfg := Config{
+// DefaultConfig returns all default values for the Config struct.
+func DefaultConfig() Config {
+	return Config{
 		LndDir:          defaultLndDir,
 		ConfigFile:      defaultConfigFile,
 		DataDir:         defaultDataDir,
@@ -397,10 +390,20 @@ func LoadConfig() (*Config, error) {
 		MaxOutgoingCltvExpiry:   htlcswitch.DefaultMaxOutgoingCltvExpiry,
 		MaxChannelFeeAllocation: htlcswitch.DefaultMaxLinkFeeAllocation,
 	}
+}
 
+// LoadConfig initializes and parses the config using a config file and command
+// line options.
+//
+// The configuration proceeds as follows:
+// 	1) Start with a default config with sane settings
+// 	2) Pre-parse the command line to check for an alternative config file
+// 	3) Load configuration file overwriting defaults with any specified options
+// 	4) Parse CLI options and overwrite/add any specified options
+func LoadConfig() (*Config, error) {
 	// Pre-parse the command line options to pick up an alternative config
 	// file.
-	preCfg := defaultCfg
+	preCfg := DefaultConfig()
 	if _, err := flags.Parse(&preCfg); err != nil {
 		return nil, err
 	}

--- a/config.go
+++ b/config.go
@@ -452,6 +452,26 @@ func LoadConfig() (*Config, error) {
 		return nil, err
 	}
 
+	// Make sure everything we just loaded makes sense.
+	cleanCfg, err := ValidateConfig(cfg, usageMessage)
+	if err != nil {
+		return nil, err
+	}
+
+	// Warn about missing config file only after all other configuration is
+	// done.  This prevents the warning on help messages and invalid
+	// options.  Note this should go directly before the return.
+	if configFileError != nil {
+		ltndLog.Warnf("%v", configFileError)
+	}
+
+	return cleanCfg, nil
+}
+
+// ValidateConfig check the given configuration to be sane. This makes sure no
+// illegal values or combination of values are set. All file system paths are
+// normalized. The cleaned up config is returned on success.
+func ValidateConfig(cfg Config, usageMessage string) (*Config, error) {
 	// If the provided lnd directory is not the default, we'll modify the
 	// path to all of the files and directories that will live within it.
 	lndDir := cleanAndExpandPath(cfg.LndDir)
@@ -485,7 +505,7 @@ func LoadConfig() (*Config, error) {
 
 		str := "%s: Failed to create lnd directory: %v"
 		err := fmt.Errorf(str, funcName, err)
-		fmt.Fprintln(os.Stderr, err)
+		_, _ = fmt.Fprintln(os.Stderr, err)
 		return nil, err
 	}
 
@@ -512,37 +532,37 @@ func LoadConfig() (*Config, error) {
 	if cfg.Autopilot.MaxChannels < 0 {
 		str := "%s: autopilot.maxchannels must be non-negative"
 		err := fmt.Errorf(str, funcName)
-		fmt.Fprintln(os.Stderr, err)
+		_, _ = fmt.Fprintln(os.Stderr, err)
 		return nil, err
 	}
 	if cfg.Autopilot.Allocation < 0 {
 		str := "%s: autopilot.allocation must be non-negative"
 		err := fmt.Errorf(str, funcName)
-		fmt.Fprintln(os.Stderr, err)
+		_, _ = fmt.Fprintln(os.Stderr, err)
 		return nil, err
 	}
 	if cfg.Autopilot.MinChannelSize < 0 {
 		str := "%s: autopilot.minchansize must be non-negative"
 		err := fmt.Errorf(str, funcName)
-		fmt.Fprintln(os.Stderr, err)
+		_, _ = fmt.Fprintln(os.Stderr, err)
 		return nil, err
 	}
 	if cfg.Autopilot.MaxChannelSize < 0 {
 		str := "%s: autopilot.maxchansize must be non-negative"
 		err := fmt.Errorf(str, funcName)
-		fmt.Fprintln(os.Stderr, err)
+		_, _ = fmt.Fprintln(os.Stderr, err)
 		return nil, err
 	}
 	if cfg.Autopilot.MinConfs < 0 {
 		str := "%s: autopilot.minconfs must be non-negative"
 		err := fmt.Errorf(str, funcName)
-		fmt.Fprintln(os.Stderr, err)
+		_, _ = fmt.Fprintln(os.Stderr, err)
 		return nil, err
 	}
 	if cfg.Autopilot.ConfTarget < 1 {
 		str := "%s: autopilot.conftarget must be positive"
 		err := fmt.Errorf(str, funcName)
-		fmt.Fprintln(os.Stderr, err)
+		_, _ = fmt.Fprintln(os.Stderr, err)
 		return nil, err
 	}
 
@@ -851,25 +871,25 @@ func LoadConfig() (*Config, error) {
 	if cfg.Autopilot.MaxChannels < 0 {
 		str := "%s: autopilot.maxchannels must be non-negative"
 		err := fmt.Errorf(str, funcName)
-		fmt.Fprintln(os.Stderr, err)
+		_, _ = fmt.Fprintln(os.Stderr, err)
 		return nil, err
 	}
 	if cfg.Autopilot.Allocation < 0 {
 		str := "%s: autopilot.allocation must be non-negative"
 		err := fmt.Errorf(str, funcName)
-		fmt.Fprintln(os.Stderr, err)
+		_, _ = fmt.Fprintln(os.Stderr, err)
 		return nil, err
 	}
 	if cfg.Autopilot.MinChannelSize < 0 {
 		str := "%s: autopilot.minchansize must be non-negative"
 		err := fmt.Errorf(str, funcName)
-		fmt.Fprintln(os.Stderr, err)
+		_, _ = fmt.Fprintln(os.Stderr, err)
 		return nil, err
 	}
 	if cfg.Autopilot.MaxChannelSize < 0 {
 		str := "%s: autopilot.maxchansize must be non-negative"
 		err := fmt.Errorf(str, funcName)
-		fmt.Fprintln(os.Stderr, err)
+		_, _ = fmt.Fprintln(os.Stderr, err)
 		return nil, err
 	}
 
@@ -888,8 +908,8 @@ func LoadConfig() (*Config, error) {
 		if err != nil || profilePort < 1024 || profilePort > 65535 {
 			str := "%s: The profile port must be between 1024 and 65535"
 			err := fmt.Errorf(str, funcName)
-			fmt.Fprintln(os.Stderr, err)
-			fmt.Fprintln(os.Stderr, usageMessage)
+			_, _ = fmt.Fprintln(os.Stderr, err)
+			_, _ = fmt.Fprintln(os.Stderr, usageMessage)
 			return nil, err
 		}
 	}
@@ -950,7 +970,7 @@ func LoadConfig() (*Config, error) {
 	if err != nil {
 		str := "%s: log rotation setup failed: %v"
 		err = fmt.Errorf(str, funcName, err.Error())
-		fmt.Fprintln(os.Stderr, err)
+		_, _ = fmt.Fprintln(os.Stderr, err)
 		return nil, err
 	}
 
@@ -958,8 +978,8 @@ func LoadConfig() (*Config, error) {
 	err = build.ParseAndSetDebugLevels(cfg.DebugLevel, logWriter)
 	if err != nil {
 		err = fmt.Errorf("%s: %v", funcName, err.Error())
-		fmt.Fprintln(os.Stderr, err)
-		fmt.Fprintln(os.Stderr, usageMessage)
+		_, _ = fmt.Fprintln(os.Stderr, err)
+		_, _ = fmt.Fprintln(os.Stderr, usageMessage)
 		return nil, err
 	}
 
@@ -1096,14 +1116,8 @@ func LoadConfig() (*Config, error) {
 		return nil, fmt.Errorf("unable to parse node color: %v", err)
 	}
 
-	// Warn about missing config file only after all other configuration is
-	// done.  This prevents the warning on help messages and invalid
-	// options.  Note this should go directly before the return.
-	if configFileError != nil {
-		ltndLog.Warnf("%v", configFileError)
-	}
-
-	return &cfg, nil
+	// All good, return the sanitized result.
+	return &cfg, err
 }
 
 // cleanAndExpandPath expands environment variables and leading ~ in the

--- a/config.go
+++ b/config.go
@@ -1,6 +1,6 @@
 // Copyright (c) 2013-2017 The btcsuite developers
 // Copyright (c) 2015-2016 The Decred developers
-// Copyright (C) 2015-2017 The Lightning Network Developers
+// Copyright (C) 2015-2020 The Lightning Network Developers
 
 package lnd
 
@@ -1144,9 +1144,9 @@ func CleanAndExpandPath(path string) string {
 	// Expand initial ~ to OS specific home directory.
 	if strings.HasPrefix(path, "~") {
 		var homeDir string
-		user, err := user.Current()
+		u, err := user.Current()
 		if err == nil {
-			homeDir = user.HomeDir
+			homeDir = u.HomeDir
 		} else {
 			homeDir = os.Getenv("HOME")
 		}
@@ -1160,7 +1160,7 @@ func CleanAndExpandPath(path string) string {
 }
 
 func parseRPCParams(cConfig *lncfg.Chain, nodeConfig interface{}, net chainCode,
-	funcName string) error {
+	funcName string) error { // nolint:unparam
 
 	// First, we'll check our node config to make sure the RPC parameters
 	// were set correctly. We'll also determine the path to the conf file
@@ -1294,7 +1294,7 @@ func extractBtcdRPCParams(btcdConfigPath string) (string, string, error) {
 	if err != nil {
 		return "", "", err
 	}
-	defer btcdConfigFile.Close()
+	defer func() { _ = btcdConfigFile.Close() }()
 
 	// With the file open extract the contents of the configuration file so
 	// we can attempt to locate the RPC credentials.
@@ -1335,14 +1335,16 @@ func extractBtcdRPCParams(btcdConfigPath string) (string, string, error) {
 // location of bitcoind's bitcoin.conf on the target system. The routine looks
 // for a cookie first, optionally following the datadir configuration option in
 // the bitcoin.conf. If it doesn't find one, it looks for rpcuser/rpcpassword.
-func extractBitcoindRPCParams(bitcoindConfigPath string) (string, string, string, string, error) {
+func extractBitcoindRPCParams(bitcoindConfigPath string) (string, string, string,
+	string, error) {
+
 	// First, we'll open up the bitcoind configuration file found at the
 	// target destination.
 	bitcoindConfigFile, err := os.Open(bitcoindConfigPath)
 	if err != nil {
 		return "", "", "", "", err
 	}
-	defer bitcoindConfigFile.Close()
+	defer func() { _ = bitcoindConfigFile.Close() }()
 
 	// With the file open extract the contents of the configuration file so
 	// we can attempt to locate the RPC credentials.

--- a/config.go
+++ b/config.go
@@ -35,10 +35,6 @@ import (
 )
 
 const (
-	// DefaultConfigFilename is the default configuration file name lnd
-	// tries to load.
-	DefaultConfigFilename = "lnd.conf"
-
 	defaultDataDirname        = "data"
 	defaultChainSubDirname    = "chain"
 	defaultGraphSubDirname    = "graph"
@@ -55,10 +51,6 @@ const (
 	defaultRESTPort           = 8080
 	defaultPeerPort           = 9735
 	defaultRPCHost            = "localhost"
-
-	// DefaultMaxPendingChannels is the default maximum number of incoming
-	// pending channels permitted per peer.
-	DefaultMaxPendingChannels = 1
 
 	defaultNoSeedBackup                  = false
 	defaultPaymentsExpirationGracePeriod = time.Duration(0)
@@ -77,51 +69,6 @@ const (
 	defaultTorControlPort          = 9051
 	defaultTorV2PrivateKeyFilename = "v2_onion_private_key"
 	defaultTorV3PrivateKeyFilename = "v3_onion_private_key"
-
-	// DefaultIncomingBroadcastDelta defines the number of blocks before the
-	// expiry of an incoming htlc at which we force close the channel. We
-	// only go to chain if we also have the preimage to actually pull in the
-	// htlc. BOLT #2 suggests 7 blocks. We use a few more for extra safety.
-	// Within this window we need to get our sweep or 2nd level success tx
-	// confirmed, because after that the remote party is also able to claim
-	// the htlc using the timeout path.
-	DefaultIncomingBroadcastDelta = 10
-
-	// defaultFinalCltvRejectDelta defines the number of blocks before the
-	// expiry of an incoming exit hop htlc at which we cancel it back
-	// immediately. It is an extra safety measure over the final cltv
-	// requirement as it is defined in the invoice. It ensures that we
-	// cancel back htlcs that, when held on to, may cause us to force close
-	// the channel because we enter the incoming broadcast window. Bolt #11
-	// suggests 9 blocks here. We use a few more for additional safety.
-	//
-	// There is still a small gap that remains between receiving the
-	// RevokeAndAck and canceling back. If a new block arrives within that
-	// window, we may still force close the channel. There is currently no
-	// way to reject an UpdateAddHtlc of which we already know that it will
-	// push us in the broadcast window.
-	defaultFinalCltvRejectDelta = DefaultIncomingBroadcastDelta + 3
-
-	// DefaultOutgoingBroadcastDelta defines the number of blocks before the
-	// expiry of an outgoing htlc at which we force close the channel. We
-	// are not in a hurry to force close, because there is nothing to claim
-	// for us. We do need to time the htlc out, because there may be an
-	// incoming htlc that will time out too (albeit later). Bolt #2 suggests
-	// a value of -1 here, but we allow one block less to prevent potential
-	// confusion around the negative value. It means we force close the
-	// channel at exactly the htlc expiry height.
-	DefaultOutgoingBroadcastDelta = 0
-
-	// defaultOutgoingCltvRejectDelta defines the number of blocks before
-	// the expiry of an outgoing htlc at which we don't want to offer it to
-	// the next peer anymore. If that happens, we cancel back the incoming
-	// htlc. This is to prevent the situation where we have an outstanding
-	// htlc that brings or will soon bring us inside the outgoing broadcast
-	// window and trigger us to force close the channel. Bolt #2 suggests a
-	// value of 0. We pad it a bit, to prevent a slow round trip to the next
-	// peer and a block arriving during that round trip to trigger force
-	// closure.
-	defaultOutgoingCltvRejectDelta = DefaultOutgoingBroadcastDelta + 3
 
 	// minTimeLockDelta is the minimum timelock we require for incoming
 	// HTLCs on our channels.
@@ -146,7 +93,7 @@ var (
 
 	// DefaultConfigFile is the default full path of lnd's configuration
 	// file.
-	DefaultConfigFile = filepath.Join(DefaultLndDir, DefaultConfigFilename)
+	DefaultConfigFile = filepath.Join(DefaultLndDir, lncfg.DefaultConfigFilename)
 
 	defaultDataDir = filepath.Join(DefaultLndDir, defaultDataDirname)
 	defaultLogDir  = filepath.Join(DefaultLndDir, defaultLogDirname)
@@ -352,7 +299,7 @@ func DefaultConfig() Config {
 			EstimateMode: defaultBitcoindEstimateMode,
 		},
 		UnsafeDisconnect:   true,
-		MaxPendingChannels: DefaultMaxPendingChannels,
+		MaxPendingChannels: lncfg.DefaultMaxPendingChannels,
 		NoSeedBackup:       defaultNoSeedBackup,
 		MinBackoff:         defaultMinBackoff,
 		MaxBackoff:         defaultMaxBackoff,
@@ -440,7 +387,7 @@ func LoadConfig() (*Config, error) {
 	if configFileDir != DefaultLndDir {
 		if configFilePath == DefaultConfigFile {
 			configFilePath = filepath.Join(
-				configFileDir, DefaultConfigFilename,
+				configFileDir, lncfg.DefaultConfigFilename,
 			)
 		}
 	}

--- a/config.go
+++ b/config.go
@@ -35,7 +35,10 @@ import (
 )
 
 const (
-	defaultConfigFilename     = "lnd.conf"
+	// DefaultConfigFilename is the default configuration file name lnd
+	// tries to load.
+	DefaultConfigFilename = "lnd.conf"
+
 	defaultDataDirname        = "data"
 	defaultChainSubDirname    = "chain"
 	defaultGraphSubDirname    = "graph"
@@ -133,15 +136,25 @@ const (
 )
 
 var (
-	defaultLndDir     = btcutil.AppDataDir("lnd", false)
-	defaultConfigFile = filepath.Join(defaultLndDir, defaultConfigFilename)
-	defaultDataDir    = filepath.Join(defaultLndDir, defaultDataDirname)
-	defaultLogDir     = filepath.Join(defaultLndDir, defaultLogDirname)
+	// DefaultLndDir is the default directory where lnd tries to find its
+	// configuration file and store its data. This is a directory in the
+	// user's application data, for example:
+	//   C:\Users\<username>\AppData\Local\Lnd on Windows
+	//   ~/.lnd on Linux
+	//   ~/Library/Application Support/Lnd on MacOS
+	DefaultLndDir = btcutil.AppDataDir("lnd", false)
+
+	// DefaultConfigFile is the default full path of lnd's configuration
+	// file.
+	DefaultConfigFile = filepath.Join(DefaultLndDir, DefaultConfigFilename)
+
+	defaultDataDir = filepath.Join(DefaultLndDir, defaultDataDirname)
+	defaultLogDir  = filepath.Join(DefaultLndDir, defaultLogDirname)
 
 	defaultTowerDir = filepath.Join(defaultDataDir, defaultTowerSubDirname)
 
-	defaultTLSCertPath = filepath.Join(defaultLndDir, defaultTLSCertFilename)
-	defaultTLSKeyPath  = filepath.Join(defaultLndDir, defaultTLSKeyFilename)
+	defaultTLSCertPath = filepath.Join(DefaultLndDir, defaultTLSCertFilename)
+	defaultTLSKeyPath  = filepath.Join(DefaultLndDir, defaultTLSKeyFilename)
 
 	defaultBtcdDir         = btcutil.AppDataDir("btcd", false)
 	defaultBtcdRPCCertFile = filepath.Join(defaultBtcdDir, "rpc.cert")
@@ -292,8 +305,8 @@ type Config struct {
 // DefaultConfig returns all default values for the Config struct.
 func DefaultConfig() Config {
 	return Config{
-		LndDir:          defaultLndDir,
-		ConfigFile:      defaultConfigFile,
+		LndDir:          DefaultLndDir,
+		ConfigFile:      DefaultConfigFile,
 		DataDir:         defaultDataDir,
 		DebugLevel:      defaultLogLevel,
 		TLSCertPath:     defaultTLSCertPath,
@@ -424,10 +437,10 @@ func LoadConfig() (*Config, error) {
 	// file within it.
 	configFileDir := cleanAndExpandPath(preCfg.LndDir)
 	configFilePath := cleanAndExpandPath(preCfg.ConfigFile)
-	if configFileDir != defaultLndDir {
-		if configFilePath == defaultConfigFile {
+	if configFileDir != DefaultLndDir {
+		if configFilePath == DefaultConfigFile {
 			configFilePath = filepath.Join(
-				configFileDir, defaultConfigFilename,
+				configFileDir, DefaultConfigFilename,
 			)
 		}
 	}
@@ -475,7 +488,7 @@ func ValidateConfig(cfg Config, usageMessage string) (*Config, error) {
 	// If the provided lnd directory is not the default, we'll modify the
 	// path to all of the files and directories that will live within it.
 	lndDir := cleanAndExpandPath(cfg.LndDir)
-	if lndDir != defaultLndDir {
+	if lndDir != DefaultLndDir {
 		cfg.DataDir = filepath.Join(lndDir, defaultDataDirname)
 		cfg.TLSCertPath = filepath.Join(lndDir, defaultTLSCertFilename)
 		cfg.TLSKeyPath = filepath.Join(lndDir, defaultTLSKeyFilename)

--- a/config.go
+++ b/config.go
@@ -971,12 +971,12 @@ func ValidateConfig(cfg Config, usageMessage string) (*Config, error) {
 	// Special show command to list supported subsystems and exit.
 	if cfg.DebugLevel == "show" {
 		fmt.Println("Supported subsystems",
-			logWriter.SupportedSubsystems())
+			RootLogWriter.SupportedSubsystems())
 		os.Exit(0)
 	}
 
 	// Initialize logging at the default logging level.
-	err = logWriter.InitLogRotator(
+	err = RootLogWriter.InitLogRotator(
 		filepath.Join(cfg.LogDir, defaultLogFilename),
 		cfg.MaxLogFileSize, cfg.MaxLogFiles,
 	)
@@ -988,7 +988,7 @@ func ValidateConfig(cfg Config, usageMessage string) (*Config, error) {
 	}
 
 	// Parse, validate, and set debug log level(s).
-	err = build.ParseAndSetDebugLevels(cfg.DebugLevel, logWriter)
+	err = build.ParseAndSetDebugLevels(cfg.DebugLevel, RootLogWriter)
 	if err != nil {
 		err = fmt.Errorf("%s: %v", funcName, err.Error())
 		_, _ = fmt.Fprintln(os.Stderr, err)

--- a/fundingmanager_test.go
+++ b/fundingmanager_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcd/wire"
 	"github.com/btcsuite/btcutil"
+	"github.com/lightningnetwork/lnd/lncfg"
 
 	"github.com/lightningnetwork/lnd/chainntnfs"
 	"github.com/lightningnetwork/lnd/chanacceptor"
@@ -413,7 +414,7 @@ func createTestFundingManager(t *testing.T, privKey *btcec.PrivateKey,
 		},
 		ZombieSweeperInterval:         1 * time.Hour,
 		ReservationTimeout:            1 * time.Nanosecond,
-		MaxPendingChannels:            DefaultMaxPendingChannels,
+		MaxPendingChannels:            lncfg.DefaultMaxPendingChannels,
 		NotifyOpenChannelEvent:        evt.NotifyOpenChannelEvent,
 		OpenChannelPredicate:          chainedAcceptor,
 		NotifyPendingOpenChannelEvent: evt.NotifyPendingOpenChannelEvent,

--- a/fundingmanager_test.go
+++ b/fundingmanager_test.go
@@ -3084,7 +3084,7 @@ func TestGetUpfrontShutdownScript(t *testing.T) {
 			}
 
 			// Set the command line option in config as needed.
-			cfg = &config{EnableUpfrontShutdown: test.localEnabled}
+			cfg = &Config{EnableUpfrontShutdown: test.localEnabled}
 
 			addr, err := getUpfrontShutdownScript(
 				&mockPeer, test.upfrontScript, test.getScript,

--- a/lncfg/autopilot.go
+++ b/lncfg/autopilot.go
@@ -1,0 +1,14 @@
+package lncfg
+
+// AutoPilot holds the configuration options for the daemon's autopilot.
+type AutoPilot struct {
+	Active         bool               `long:"active" description:"If the autopilot agent should be active or not."`
+	Heuristic      map[string]float64 `long:"heuristic" description:"Heuristic to activate, and the weight to give it during scoring."`
+	MaxChannels    int                `long:"maxchannels" description:"The maximum number of channels that should be created"`
+	Allocation     float64            `long:"allocation" description:"The percentage of total funds that should be committed to automatic channel establishment"`
+	MinChannelSize int64              `long:"minchansize" description:"The smallest channel that the autopilot agent should create"`
+	MaxChannelSize int64              `long:"maxchansize" description:"The largest channel that the autopilot agent should create"`
+	Private        bool               `long:"private" description:"Whether the channels created by the autopilot agent should be private or not. Private channels won't be announced to the network."`
+	MinConfs       int32              `long:"minconfs" description:"The minimum number of confirmations each of your inputs in funding transactions created by the autopilot agent must have."`
+	ConfTarget     uint32             `long:"conftarget" description:"The confirmation target (in blocks) for channels opened by autopilot."`
+}

--- a/lncfg/bitcoind.go
+++ b/lncfg/bitcoind.go
@@ -1,0 +1,13 @@
+package lncfg
+
+// Bitcoind holds the configuration options for the daemon's connection to
+// bitcoind.
+type Bitcoind struct {
+	Dir            string `long:"dir" description:"The base directory that contains the node's data, logs, configuration file, etc."`
+	RPCHost        string `long:"rpchost" description:"The daemon's rpc listening address. If a port is omitted, then the default port for the selected chain parameters will be used."`
+	RPCUser        string `long:"rpcuser" description:"Username for RPC connections"`
+	RPCPass        string `long:"rpcpass" default-mask:"-" description:"Password for RPC connections"`
+	ZMQPubRawBlock string `long:"zmqpubrawblock" description:"The address listening for ZMQ connections to deliver raw block notifications"`
+	ZMQPubRawTx    string `long:"zmqpubrawtx" description:"The address listening for ZMQ connections to deliver raw transaction notifications"`
+	EstimateMode   string `long:"estimatemode" description:"The fee estimate mode. Must be either ECONOMICAL or CONSERVATIVE."`
+}

--- a/lncfg/btcd.go
+++ b/lncfg/btcd.go
@@ -1,0 +1,11 @@
+package lncfg
+
+// Btcd holds the configuration options for the daemon's connection to btcd.
+type Btcd struct {
+	Dir        string `long:"dir" description:"The base directory that contains the node's data, logs, configuration file, etc."`
+	RPCHost    string `long:"rpchost" description:"The daemon's rpc listening address. If a port is omitted, then the default port for the selected chain parameters will be used."`
+	RPCUser    string `long:"rpcuser" description:"Username for RPC connections"`
+	RPCPass    string `long:"rpcpass" default-mask:"-" description:"Password for RPC connections"`
+	RPCCert    string `long:"rpccert" description:"File containing the daemon's certificate file"`
+	RawRPCCert string `long:"rawrpccert" description:"The raw bytes of the daemon's PEM-encoded certificate chain which will be used to authenticate the RPC connection."`
+}

--- a/lncfg/chain.go
+++ b/lncfg/chain.go
@@ -1,0 +1,24 @@
+package lncfg
+
+import "github.com/lightningnetwork/lnd/lnwire"
+
+// Chain holds the configuration options for the daemon's chain settings.
+type Chain struct {
+	Active   bool   `long:"active" description:"If the chain should be active or not."`
+	ChainDir string `long:"chaindir" description:"The directory to store the chain's data within."`
+
+	Node string `long:"node" description:"The blockchain interface to use." choice:"btcd" choice:"bitcoind" choice:"neutrino" choice:"ltcd" choice:"litecoind"`
+
+	MainNet  bool `long:"mainnet" description:"Use the main network"`
+	TestNet3 bool `long:"testnet" description:"Use the test network"`
+	SimNet   bool `long:"simnet" description:"Use the simulation test network"`
+	RegTest  bool `long:"regtest" description:"Use the regression test network"`
+
+	DefaultNumChanConfs int                 `long:"defaultchanconfs" description:"The default number of confirmations a channel must have before it's considered open. If this is not set, we will scale the value according to the channel size."`
+	DefaultRemoteDelay  int                 `long:"defaultremotedelay" description:"The default number of blocks we will require our channel counterparty to wait before accessing its funds in case of unilateral close. If this is not set, we will scale the value according to the channel size."`
+	MinHTLCIn           lnwire.MilliSatoshi `long:"minhtlc" description:"The smallest HTLC we are willing to accept on our channels, in millisatoshi"`
+	MinHTLCOut          lnwire.MilliSatoshi `long:"minhtlcout" description:"The smallest HTLC we are willing to send out on our channels, in millisatoshi"`
+	BaseFee             lnwire.MilliSatoshi `long:"basefee" description:"The base fee in millisatoshi we will charge for forwarding payments on our channels"`
+	FeeRate             lnwire.MilliSatoshi `long:"feerate" description:"The fee rate used when forwarding payments on our channels. The total fee charged is basefee + (amount * feerate / 1000000), where amount is the forwarded amount."`
+	TimeLockDelta       uint32              `long:"timelockdelta" description:"The CLTV delta we will subtract from a forwarded HTLC's timelock value"`
+}

--- a/lncfg/config.go
+++ b/lncfg/config.go
@@ -1,0 +1,89 @@
+package lncfg
+
+import (
+	"os"
+	"os/user"
+	"path/filepath"
+	"strings"
+)
+
+const (
+	// DefaultConfigFilename is the default configuration file name lnd
+	// tries to load.
+	DefaultConfigFilename = "lnd.conf"
+
+	// DefaultMaxPendingChannels is the default maximum number of incoming
+	// pending channels permitted per peer.
+	DefaultMaxPendingChannels = 1
+
+	// DefaultIncomingBroadcastDelta defines the number of blocks before the
+	// expiry of an incoming htlc at which we force close the channel. We
+	// only go to chain if we also have the preimage to actually pull in the
+	// htlc. BOLT #2 suggests 7 blocks. We use a few more for extra safety.
+	// Within this window we need to get our sweep or 2nd level success tx
+	// confirmed, because after that the remote party is also able to claim
+	// the htlc using the timeout path.
+	DefaultIncomingBroadcastDelta = 10
+
+	// DefaultFinalCltvRejectDelta defines the number of blocks before the
+	// expiry of an incoming exit hop htlc at which we cancel it back
+	// immediately. It is an extra safety measure over the final cltv
+	// requirement as it is defined in the invoice. It ensures that we
+	// cancel back htlcs that, when held on to, may cause us to force close
+	// the channel because we enter the incoming broadcast window. Bolt #11
+	// suggests 9 blocks here. We use a few more for additional safety.
+	//
+	// There is still a small gap that remains between receiving the
+	// RevokeAndAck and canceling back. If a new block arrives within that
+	// window, we may still force close the channel. There is currently no
+	// way to reject an UpdateAddHtlc of which we already know that it will
+	// push us in the broadcast window.
+	DefaultFinalCltvRejectDelta = DefaultIncomingBroadcastDelta + 3
+
+	// DefaultOutgoingBroadcastDelta defines the number of blocks before the
+	// expiry of an outgoing htlc at which we force close the channel. We
+	// are not in a hurry to force close, because there is nothing to claim
+	// for us. We do need to time the htlc out, because there may be an
+	// incoming htlc that will time out too (albeit later). Bolt #2 suggests
+	// a value of -1 here, but we allow one block less to prevent potential
+	// confusion around the negative value. It means we force close the
+	// channel at exactly the htlc expiry height.
+	DefaultOutgoingBroadcastDelta = 0
+
+	// DefaultOutgoingCltvRejectDelta defines the number of blocks before
+	// the expiry of an outgoing htlc at which we don't want to offer it to
+	// the next peer anymore. If that happens, we cancel back the incoming
+	// htlc. This is to prevent the situation where we have an outstanding
+	// htlc that brings or will soon bring us inside the outgoing broadcast
+	// window and trigger us to force close the channel. Bolt #2 suggests a
+	// value of 0. We pad it a bit, to prevent a slow round trip to the next
+	// peer and a block arriving during that round trip to trigger force
+	// closure.
+	DefaultOutgoingCltvRejectDelta = DefaultOutgoingBroadcastDelta + 3
+)
+
+// CleanAndExpandPath expands environment variables and leading ~ in the
+// passed path, cleans the result, and returns it.
+// This function is taken from https://github.com/btcsuite/btcd
+func CleanAndExpandPath(path string) string {
+	if path == "" {
+		return ""
+	}
+
+	// Expand initial ~ to OS specific home directory.
+	if strings.HasPrefix(path, "~") {
+		var homeDir string
+		u, err := user.Current()
+		if err == nil {
+			homeDir = u.HomeDir
+		} else {
+			homeDir = os.Getenv("HOME")
+		}
+
+		path = strings.Replace(path, "~", homeDir, 1)
+	}
+
+	// NOTE: The os.ExpandEnv doesn't work with Windows-style %VARIABLE%,
+	// but the variables can still be expanded via POSIX-style $VARIABLE.
+	return filepath.Clean(os.ExpandEnv(path))
+}

--- a/lncfg/neutrino.go
+++ b/lncfg/neutrino.go
@@ -1,0 +1,15 @@
+package lncfg
+
+import "time"
+
+// Neutrino holds the configuration options for the daemon's connection to
+// neutrino.
+type Neutrino struct {
+	AddPeers           []string      `short:"a" long:"addpeer" description:"Add a peer to connect with at startup"`
+	ConnectPeers       []string      `long:"connect" description:"Connect only to the specified peers at startup"`
+	MaxPeers           int           `long:"maxpeers" description:"Max number of inbound and outbound peers"`
+	BanDuration        time.Duration `long:"banduration" description:"How long to ban misbehaving peers.  Valid time units are {s, m, h}.  Minimum 1 second"`
+	BanThreshold       uint32        `long:"banthreshold" description:"Maximum allowed ban score before disconnecting and banning misbehaving peers."`
+	FeeURL             string        `long:"feeurl" description:"Optional URL for fee estimation. If a URL is not specified, static fees will be used for estimation."`
+	AssertFilterHeader string        `long:"assertfilterheader" description:"Optional filter header in height:hash format to assert the state of neutrino's filter header chain on startup. If the assertion does not hold, then the filter header chain will be re-synced from the genesis block."`
+}

--- a/lncfg/tor.go
+++ b/lncfg/tor.go
@@ -1,0 +1,16 @@
+package lncfg
+
+// Tor holds the configuration options for the daemon's connection to tor.
+type Tor struct {
+	Active            bool   `long:"active" description:"Allow outbound and inbound connections to be routed through Tor"`
+	SOCKS             string `long:"socks" description:"The host:port that Tor's exposed SOCKS5 proxy is listening on"`
+	DNS               string `long:"dns" description:"The DNS server as host:port that Tor will use for SRV queries - NOTE must have TCP resolution enabled"`
+	StreamIsolation   bool   `long:"streamisolation" description:"Enable Tor stream isolation by randomizing user credentials for each connection."`
+	Control           string `long:"control" description:"The host:port that Tor is listening on for Tor control connections"`
+	TargetIPAddress   string `long:"targetipaddress" description:"IP address that Tor should use as the target of the hidden service"`
+	Password          string `long:"password" description:"The password used to arrive at the HashedControlPassword for the control port. If provided, the HASHEDPASSWORD authentication method will be used instead of the SAFECOOKIE one."`
+	V2                bool   `long:"v2" description:"Automatically set up a v2 onion service to listen for inbound connections"`
+	V3                bool   `long:"v3" description:"Automatically set up a v3 onion service to listen for inbound connections"`
+	PrivateKeyPath    string `long:"privatekeypath" description:"The path to the private key of the onion service being created"`
+	WatchtowerKeyPath string `long:"watchtowerkeypath" description:"The path to the private key of the watchtower onion service being created"`
+}

--- a/lnd.go
+++ b/lnd.go
@@ -52,7 +52,7 @@ import (
 )
 
 var (
-	cfg              *config
+	cfg              *Config
 	registeredChains = newChainRegistry()
 
 	// networkDir is the path to the directory of the currently active
@@ -156,7 +156,7 @@ func Main(lisCfg ListenerCfg) error {
 
 	// Load the configuration, and parse any command line options. This
 	// function will also set up logging properly.
-	loadedConfig, err := loadConfig()
+	loadedConfig, err := LoadConfig()
 	if err != nil {
 		return err
 	}

--- a/lnd.go
+++ b/lnd.go
@@ -150,17 +150,11 @@ type rpcListeners func() ([]*ListenerWithSignal, func(), error)
 // Main is the true entry point for lnd. This function is required since defers
 // created in the top-level scope of a main method aren't executed if os.Exit()
 // is called.
-func Main(lisCfg ListenerCfg) error {
+func Main(config *Config, lisCfg ListenerCfg) error {
 	// Hook interceptor for os signals.
 	signal.Intercept()
 
-	// Load the configuration, and parse any command line options. This
-	// function will also set up logging properly.
-	loadedConfig, err := LoadConfig()
-	if err != nil {
-		return err
-	}
-	cfg = loadedConfig
+	cfg = config
 	defer func() {
 		ltndLog.Info("Shutdown complete")
 		err := RootLogWriter.Close()

--- a/lnd.go
+++ b/lnd.go
@@ -163,7 +163,7 @@ func Main(lisCfg ListenerCfg) error {
 	cfg = loadedConfig
 	defer func() {
 		ltndLog.Info("Shutdown complete")
-		err := logWriter.Close()
+		err := RootLogWriter.Close()
 		if err != nil {
 			ltndLog.Errorf("Could not close log rotator: %v", err)
 		}

--- a/lntest/itest/lnd_multi-hop_htlc_local_chain_claim_test.go
+++ b/lntest/itest/lnd_multi-hop_htlc_local_chain_claim_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/btcsuite/btcd/wire"
 	"github.com/davecgh/go-spew/spew"
 	"github.com/lightningnetwork/lnd"
+	"github.com/lightningnetwork/lnd/lncfg"
 	"github.com/lightningnetwork/lnd/lnrpc"
 	"github.com/lightningnetwork/lnd/lnrpc/invoicesrpc"
 	"github.com/lightningnetwork/lnd/lntest"
@@ -136,7 +137,7 @@ func testMultiHopHtlcLocalChainClaim(net *lntest.NetworkHarness, t *harnessTest,
 	// We'll now mine enough blocks so Carol decides that she needs to go
 	// on-chain to claim the HTLC as Bob has been inactive.
 	numBlocks := padCLTV(uint32(invoiceReq.CltvExpiry -
-		lnd.DefaultIncomingBroadcastDelta))
+		lncfg.DefaultIncomingBroadcastDelta))
 
 	if _, err := net.Miner.Node.Generate(numBlocks); err != nil {
 		t.Fatalf("unable to generate blocks")

--- a/lntest/itest/lnd_multi-hop_htlc_local_timeout_test.go
+++ b/lntest/itest/lnd_multi-hop_htlc_local_timeout_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/btcsuite/btcutil"
 	"github.com/davecgh/go-spew/spew"
 	"github.com/lightningnetwork/lnd"
+	"github.com/lightningnetwork/lnd/lncfg"
 	"github.com/lightningnetwork/lnd/lnrpc"
 	"github.com/lightningnetwork/lnd/lntest"
 	"github.com/lightningnetwork/lnd/lntest/wait"
@@ -101,7 +102,7 @@ func testMultiHopHtlcLocalTimeout(net *lntest.NetworkHarness, t *harnessTest,
 	// timeout. With the default outgoing broadcast delta of zero, this will
 	// be the same height as the htlc expiry height.
 	numBlocks := padCLTV(
-		uint32(finalCltvDelta - lnd.DefaultOutgoingBroadcastDelta),
+		uint32(finalCltvDelta - lncfg.DefaultOutgoingBroadcastDelta),
 	)
 	if _, err := net.Miner.Node.Generate(numBlocks); err != nil {
 		t.Fatalf("unable to generate blocks: %v", err)

--- a/lntest/itest/lnd_multi-hop_htlc_receiver_chain_claim_test.go
+++ b/lntest/itest/lnd_multi-hop_htlc_receiver_chain_claim_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/btcsuite/btcd/wire"
 	"github.com/davecgh/go-spew/spew"
 	"github.com/lightningnetwork/lnd"
+	"github.com/lightningnetwork/lnd/lncfg"
 	"github.com/lightningnetwork/lnd/lnrpc"
 	"github.com/lightningnetwork/lnd/lnrpc/invoicesrpc"
 	"github.com/lightningnetwork/lnd/lntest"
@@ -118,7 +119,7 @@ func testMultiHopReceiverChainClaim(net *lntest.NetworkHarness, t *harnessTest,
 	// chain in order to sweep her HTLC since the value is high enough.
 	// TODO(roasbeef): modify once go to chain policy changes
 	numBlocks := padCLTV(uint32(
-		invoiceReq.CltvExpiry - lnd.DefaultIncomingBroadcastDelta,
+		invoiceReq.CltvExpiry - lncfg.DefaultIncomingBroadcastDelta,
 	))
 	if _, err := net.Miner.Node.Generate(numBlocks); err != nil {
 		t.Fatalf("unable to generate blocks")

--- a/lntest/itest/lnd_multi-hop_htlc_remote_chain_claim_test.go
+++ b/lntest/itest/lnd_multi-hop_htlc_remote_chain_claim_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/btcsuite/btcd/wire"
 	"github.com/davecgh/go-spew/spew"
 	"github.com/lightningnetwork/lnd"
+	"github.com/lightningnetwork/lnd/lncfg"
 	"github.com/lightningnetwork/lnd/lnrpc"
 	"github.com/lightningnetwork/lnd/lnrpc/invoicesrpc"
 	"github.com/lightningnetwork/lnd/lntest"
@@ -148,7 +149,7 @@ func testMultiHopHtlcRemoteChainClaim(net *lntest.NetworkHarness, t *harnessTest
 	// We'll now mine enough blocks so Carol decides that she needs to go
 	// on-chain to claim the HTLC as Bob has been inactive.
 	numBlocks := padCLTV(uint32(invoiceReq.CltvExpiry-
-		lnd.DefaultIncomingBroadcastDelta) - defaultCSV)
+		lncfg.DefaultIncomingBroadcastDelta) - defaultCSV)
 
 	if _, err := net.Miner.Node.Generate(numBlocks); err != nil {
 		t.Fatalf("unable to generate blocks")

--- a/lntest/itest/lnd_test.go
+++ b/lntest/itest/lnd_test.go
@@ -34,6 +34,7 @@ import (
 	"github.com/lightningnetwork/lnd/chanbackup"
 	"github.com/lightningnetwork/lnd/channeldb"
 	"github.com/lightningnetwork/lnd/input"
+	"github.com/lightningnetwork/lnd/lncfg"
 	"github.com/lightningnetwork/lnd/lnrpc"
 	"github.com/lightningnetwork/lnd/lnrpc/invoicesrpc"
 	"github.com/lightningnetwork/lnd/lnrpc/routerrpc"
@@ -6695,7 +6696,7 @@ func testBasicChannelCreationAndUpdates(net *lntest.NetworkHarness, t *harnessTe
 func testMaxPendingChannels(net *lntest.NetworkHarness, t *harnessTest) {
 	ctxb := context.Background()
 
-	maxPendingChannels := lnd.DefaultMaxPendingChannels + 1
+	maxPendingChannels := lncfg.DefaultMaxPendingChannels + 1
 	amount := lnd.MaxBtcFundingAmount
 
 	// Create a new node (Carol) with greater number of max pending

--- a/log.go
+++ b/log.go
@@ -47,21 +47,23 @@ import (
 //
 // Loggers can not be used before the log rotator has been initialized with a
 // log file.  This must be performed early during application startup by
-// calling logWriter.InitLogRotator.
+// calling RootLogWriter.InitLogRotator.
 var (
-	logWriter = build.NewRotatingLogWriter()
+	// RootLogWriter is the main parent log writer all sub loggers should be
+	// appended to.
+	RootLogWriter = build.NewRotatingLogWriter()
 
 	// Loggers that need to be accessible from the lnd package can be placed
 	// here. Loggers that are only used in sub modules can be added directly
 	// by using the addSubLogger method.
-	ltndLog = build.NewSubLogger("LTND", logWriter.GenSubLogger)
-	peerLog = build.NewSubLogger("PEER", logWriter.GenSubLogger)
-	rpcsLog = build.NewSubLogger("RPCS", logWriter.GenSubLogger)
-	srvrLog = build.NewSubLogger("SRVR", logWriter.GenSubLogger)
-	fndgLog = build.NewSubLogger("FNDG", logWriter.GenSubLogger)
-	utxnLog = build.NewSubLogger("UTXN", logWriter.GenSubLogger)
-	brarLog = build.NewSubLogger("BRAR", logWriter.GenSubLogger)
-	atplLog = build.NewSubLogger("ATPL", logWriter.GenSubLogger)
+	ltndLog = build.NewSubLogger("LTND", RootLogWriter.GenSubLogger)
+	peerLog = build.NewSubLogger("PEER", RootLogWriter.GenSubLogger)
+	rpcsLog = build.NewSubLogger("RPCS", RootLogWriter.GenSubLogger)
+	srvrLog = build.NewSubLogger("SRVR", RootLogWriter.GenSubLogger)
+	fndgLog = build.NewSubLogger("FNDG", RootLogWriter.GenSubLogger)
+	utxnLog = build.NewSubLogger("UTXN", RootLogWriter.GenSubLogger)
+	brarLog = build.NewSubLogger("BRAR", RootLogWriter.GenSubLogger)
+	atplLog = build.NewSubLogger("ATPL", RootLogWriter.GenSubLogger)
 )
 
 // Initialize package-global logger variables.
@@ -112,7 +114,7 @@ func init() {
 func addSubLogger(subsystem string, useLoggers ...func(btclog.Logger)) {
 	// Create and register just a single logger to prevent them from
 	// overwriting each other internally.
-	logger := build.NewSubLogger(subsystem, logWriter.GenSubLogger)
+	logger := build.NewSubLogger(subsystem, RootLogWriter.GenSubLogger)
 	setSubLogger(subsystem, logger, useLoggers...)
 }
 
@@ -121,7 +123,7 @@ func addSubLogger(subsystem string, useLoggers ...func(btclog.Logger)) {
 func setSubLogger(subsystem string, logger btclog.Logger,
 	useLoggers ...func(btclog.Logger)) {
 
-	logWriter.RegisterSubLogger(subsystem, logger)
+	RootLogWriter.RegisterSubLogger(subsystem, logger)
 	for _, useLogger := range useLoggers {
 		useLogger(logger)
 	}

--- a/pilot.go
+++ b/pilot.go
@@ -9,6 +9,7 @@ import (
 	"github.com/btcsuite/btcd/wire"
 	"github.com/btcsuite/btcutil"
 	"github.com/lightningnetwork/lnd/autopilot"
+	"github.com/lightningnetwork/lnd/lncfg"
 	"github.com/lightningnetwork/lnd/lnwire"
 	"github.com/lightningnetwork/lnd/tor"
 )
@@ -17,7 +18,7 @@ import (
 // configuration is sane. Currently it checks that the heuristic configuration
 // makes sense. In case the config is valid, it will return a list of
 // WeightedHeuristics that can be combined for use with the autopilot agent.
-func validateAtplCfg(cfg *autoPilotConfig) ([]*autopilot.WeightedHeuristic,
+func validateAtplCfg(cfg *lncfg.AutoPilot) ([]*autopilot.WeightedHeuristic,
 	error) {
 
 	var (
@@ -138,8 +139,8 @@ var _ autopilot.ChannelController = (*chanController)(nil)
 // Agent instance based on the passed configuration structs. The agent and all
 // interfaces needed to drive it won't be launched before the Manager's
 // StartAgent method is called.
-func initAutoPilot(svr *server, cfg *autoPilotConfig, chainCfg *chainConfig) (
-	*autopilot.ManagerCfg, error) {
+func initAutoPilot(svr *server, cfg *lncfg.AutoPilot,
+	chainCfg *lncfg.Chain) (*autopilot.ManagerCfg, error) {
 
 	atplLog.Infof("Instantiating autopilot with active=%v, "+
 		"max_channels=%d, allocation=%f, min_chan_size=%d, "+

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -5220,7 +5220,7 @@ func (r *rpcServer) DebugLevel(ctx context.Context,
 	if req.Show {
 		return &lnrpc.DebugLevelResponse{
 			SubSystems: strings.Join(
-				logWriter.SupportedSubsystems(), " ",
+				RootLogWriter.SupportedSubsystems(), " ",
 			),
 		}, nil
 	}
@@ -5229,7 +5229,7 @@ func (r *rpcServer) DebugLevel(ctx context.Context,
 
 	// Otherwise, we'll attempt to set the logging level using the
 	// specified level spec.
-	err := build.ParseAndSetDebugLevels(req.LevelSpec, logWriter)
+	err := build.ParseAndSetDebugLevels(req.LevelSpec, RootLogWriter)
 	if err != nil {
 		return nil, err
 	}

--- a/server.go
+++ b/server.go
@@ -399,7 +399,7 @@ func newServer(listenAddrs []net.Addr, chanDB *channeldb.DB,
 	}
 
 	registryConfig := invoices.RegistryConfig{
-		FinalCltvRejectDelta: defaultFinalCltvRejectDelta,
+		FinalCltvRejectDelta: lncfg.DefaultFinalCltvRejectDelta,
 		HtlcHoldDuration:     invoices.DefaultHtlcHoldDuration,
 		Clock:                clock.NewDefaultClock(),
 		AcceptKeySend:        cfg.AcceptKeySend,
@@ -867,8 +867,8 @@ func newServer(listenAddrs []net.Addr, chanDB *channeldb.DB,
 
 	s.chainArb = contractcourt.NewChainArbitrator(contractcourt.ChainArbitratorConfig{
 		ChainHash:              *activeNetParams.GenesisHash,
-		IncomingBroadcastDelta: DefaultIncomingBroadcastDelta,
-		OutgoingBroadcastDelta: DefaultOutgoingBroadcastDelta,
+		IncomingBroadcastDelta: lncfg.DefaultIncomingBroadcastDelta,
+		OutgoingBroadcastDelta: lncfg.DefaultOutgoingBroadcastDelta,
 		NewSweepAddr:           newSweepPkScriptGen(cc.wallet),
 		PublishTx:              cc.wallet.PublishTransaction,
 		DeliverResolutionMsg: func(msgs ...contractcourt.ResolutionMsg) error {
@@ -2782,7 +2782,7 @@ func (s *server) peerConnected(conn net.Conn, connReq *connmgr.ConnReq,
 	p, err := newPeer(
 		conn, connReq, s, peerAddr, inbound, initFeatures,
 		legacyFeatures, cfg.ChanEnableTimeout,
-		defaultOutgoingCltvRejectDelta, errBuffer,
+		lncfg.DefaultOutgoingCltvRejectDelta, errBuffer,
 	)
 	if err != nil {
 		srvrLog.Errorf("unable to create peer %v", err)


### PR DESCRIPTION
To allow `lnd` to be used as a library, we refactor out some of the configuration parsing functions so they can be used externally. Also we allow external subservers to register to lnd's main `grpc.Server` and `proxy.ServeMux` instances.