### PR TITLE
cmd/lncli: remove usage of Millisecond() for Go 1.12

### DIFF
--- a/cmd/lncli/cmd_pay.go
+++ b/cmd/lncli/cmd_pay.go
@@ -605,8 +605,8 @@ func formatPayment(payment *lnrpc.Payment, aliases *aliasCache) string {
 				return "-"
 			}
 			resolveTime := time.Unix(0, timeNs)
-			resolveTimeMs := resolveTime.Sub(createTime).
-				Milliseconds()
+			resolveTimeDiff := resolveTime.Sub(createTime)
+			resolveTimeMs := resolveTimeDiff / time.Millisecond
 			return fmt.Sprintf(
 				"%.3f", float64(resolveTimeMs)/1000.0,
 			)


### PR DESCRIPTION
The new table format for the pay command started to use the
`Millisecond()` method on `time.Duration`. However, this method was only
added in Go 1.13, so this breaks the build for Go 1.12. We replace this
by manual division. `time.Duration` "natively" is in nanoseconds, so we
covert to milli seconds by dividing my `time.Millisecond`, which is
1,000,000.