### PR TITLE
add jq tool to Docker image so we can parse lncli output

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,9 +26,10 @@ FROM alpine as final
 # Define a root volume for data persistence.
 VOLUME /root/.lnd
 
-# Add bash and ca-certs, for quality of life and SSL-related reasons.
+# Add bash, jq and ca-certs, for quality of life and SSL-related reasons.
 RUN apk --no-cache add \
     bash \
+    jq \
     ca-certificates
 
 # Copy the binaries from the builder image.


### PR DESCRIPTION
This is just a one line change to the Dockerfile to add the ``jq`` tool to our Docker image.
Using ``jq`` we can parse lncli output and extract individual fields.