### PR TITLE
itest: fix off-by-one mining while waiting for CSV-encumbered outputs

### DIFF
--- a/lntest/itest/lnd_multi-hop_local_force_close_on_chain_htlc_timeout_test.go
+++ b/lntest/itest/lnd_multi-hop_local_force_close_on_chain_htlc_timeout_test.go
@@ -100,7 +100,11 @@ func testMultiHopLocalForceCloseOnChainHtlcTimeout(net *lntest.NetworkHarness,
 		require.NoError(t.t, err)
 	}
 
-	_, err = net.Miner.Node.Generate(defaultCSV)
+	// The sweep is broadcast on the block immediately before the CSV
+	// expires and the commitment was already mined inside
+	// closeChannelAndAssertType(), so mine one block less than defaultCSV
+	// in order to perform mempool assertions.
+	_, err = net.Miner.Node.Generate(defaultCSV - 1)
 	require.NoError(t.t, err)
 
 	_, err = waitForTxInMempool(net.Miner.Node, minerMempoolTimeout)
@@ -108,7 +112,7 @@ func testMultiHopLocalForceCloseOnChainHtlcTimeout(net *lntest.NetworkHarness,
 
 	// We'll now mine enough blocks for the HTLC to expire. After this, Bob
 	// should hand off the now expired HTLC output to the utxo nursery.
-	numBlocks := padCLTV(uint32(finalCltvDelta - defaultCSV - 1))
+	numBlocks := padCLTV(uint32(finalCltvDelta - defaultCSV))
 	_, err = net.Miner.Node.Generate(numBlocks)
 	require.NoError(t.t, err)
 

--- a/lntest/itest/lnd_test.go
+++ b/lntest/itest/lnd_test.go
@@ -409,7 +409,10 @@ func cleanupForceClose(t *harnessTest, net *lntest.NetworkHarness,
 
 	// Mine enough blocks for the node to sweep its funds from the force
 	// closed channel.
-	_, err = net.Miner.Node.Generate(defaultCSV)
+	//
+	// The commit sweep resolver is able to broadcast the sweep tx up to
+	// one block before the CSV elapses, so wait until defaulCSV-1.
+	_, err = net.Miner.Node.Generate(defaultCSV - 1)
 	if err != nil {
 		t.Fatalf("unable to generate blocks: %v", err)
 	}
@@ -7726,7 +7729,7 @@ func testFailingChannel(net *lntest.NetworkHarness, t *harnessTest) {
 
 	// Mine enough blocks for Alice to sweep her funds from the force
 	// closed channel.
-	_, err = net.Miner.Node.Generate(defaultCSV)
+	_, err = net.Miner.Node.Generate(defaultCSV - 1)
 	if err != nil {
 		t.Fatalf("unable to generate blocks: %v", err)
 	}
@@ -9505,7 +9508,11 @@ func assertDLPExecuted(net *lntest.NetworkHarness, t *harnessTest,
 	}
 
 	// After the Carol's output matures, she should also reclaim her funds.
-	mineBlocks(t, net, defaultCSV-1, 0)
+	//
+	// The commit sweep resolver publishes the sweep tx at defaultCSV-1 and
+	// we already mined one block after the commitmment was published, so
+	// take that into account.
+	mineBlocks(t, net, defaultCSV-1-1, 0)
 	carolSweep, err := waitForTxInMempool(
 		net.Miner.Node, minerMempoolTimeout,
 	)
@@ -9796,7 +9803,7 @@ func testDataLossProtection(net *lntest.NetworkHarness, t *harnessTest) {
 	}
 
 	// Mine enough blocks for Carol to sweep her funds.
-	mineBlocks(t, net, defaultCSV, 0)
+	mineBlocks(t, net, defaultCSV-1, 0)
 
 	carolSweep, err := waitForTxInMempool(net.Miner.Node, minerMempoolTimeout)
 	if err != nil {


### PR DESCRIPTION
Many instances where the itests mine `defaultCSV` blocks (to wait for a sweep of a CSV-encumbered output) have an off-by-one error. This causes flaky tests when the CI slows downs during mining.

This fixes those tests by introducing a debug function to slowly mine blocks (thus causing the buggy tests to show themselves) then adjusting the number of mined blocks as needed.