### PR TITLE
github: remove continue-on-error

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -257,7 +257,6 @@ jobs:
 
       - name: ${{ matrix.backend }} integration
         run: make itest backend=${{ matrix.backend }}
-        continue-on-error: true
 
       - name: package logfiles
         run: tar -zcvf itest-logs-${{ matrix.backend }}.tar.gz lntest/itest/*.log


### PR DESCRIPTION
The continue-on-error was added to make sure the log files of the
failed itests would always be uploaded. But this has the side effect
of marking the whole job successful, even if the itest job itself
failed. The failure condition in the log file steps already solve
that, so the continue-on-error is not needed anymore.
