### PR TITLE
GitHub: fail early if compilation or linter jobs fail

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -61,6 +61,11 @@ jobs:
 
       - name: run check
         run: make rpc-check
+        
+      # Cancel the whole workflow if the RPC check fails.
+      - name: cancelling
+        uses: andymckay/cancel-action@0.2
+        if: failure()
 
   ########################
   # compile unit tests
@@ -90,6 +95,11 @@ jobs:
 
       - name: compile
         run: make unit pkg=... case=_NONE_
+        
+      # Cancel the whole workflow if compilation fails.
+      - name: cancelling
+        uses: andymckay/cancel-action@0.2
+        if: failure()
 
   ########################
   # lint code
@@ -119,6 +129,11 @@ jobs:
 
       - name: lint
         run: make lint
+
+      # Cancel the whole workflow if linting fails.
+      - name: cancelling
+        uses: andymckay/cancel-action@0.2
+        if: failure()
 
   ########################
   # cross compilation
@@ -154,6 +169,11 @@ jobs:
 
       - name: build release for architecture
         run: make release sys=${{ matrix.build_sys }}
+        
+      # Cancel the whole workflow if compilation fails.
+      - name: cancelling
+        uses: andymckay/cancel-action@0.2
+        if: failure()
 
   ########################
   # run unit tests

--- a/breacharbiter.go
+++ b/breacharbiter.go
@@ -1,6 +1,7 @@
 package lnd
 
 import (
+	"github.com/btcsuite/btcd/blockchain"
 	"bytes"
 	"encoding/binary"
 	"errors"
@@ -8,7 +9,6 @@ import (
 	"io"
 	"sync"
 
-	"github.com/btcsuite/btcd/blockchain"
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcd/txscript"
 	"github.com/btcsuite/btcd/wire"


### PR DESCRIPTION
To avoid spending a lot of compute minutes on the unit and integration tests, we want to fail the whole workflow if one of the shorter jobs like cross compilation or linting fails.