### PR TITLE
lnrpc: remove double asterix comments

### DIFF
--- a/lnrpc/signrpc/signer.pb.go
+++ b/lnrpc/signrpc/signer.pb.go
@@ -385,7 +385,7 @@ func (m *SignResp) GetRawSigs() [][]byte {
 type InputScript struct {
 	// The serializes witness stack for the specified input.
 	Witness [][]byte `protobuf:"bytes,1,rep,name=witness,proto3" json:"witness,omitempty"`
-	//*
+	//
 	//The optional sig script for the specified witness that will only be set if
 	//the input specified is a nested p2sh witness program.
 	SigScript            []byte   `protobuf:"bytes,2,opt,name=sig_script,json=sigScript,proto3" json:"sig_script,omitempty"`

--- a/lnrpc/signrpc/signer.proto
+++ b/lnrpc/signrpc/signer.proto
@@ -167,7 +167,7 @@ message InputScript {
     // The serializes witness stack for the specified input.
     repeated bytes witness = 1;
 
-    /**
+    /*
     The optional sig script for the specified witness that will only be set if
     the input specified is a nested p2sh witness program.
     */

--- a/lnrpc/signrpc/signer.swagger.json
+++ b/lnrpc/signrpc/signer.swagger.json
@@ -30,7 +30,7 @@
         "sig_script": {
           "type": "string",
           "format": "byte",
-          "description": "*\nThe optional sig script for the specified witness that will only be set if\nthe input specified is a nested p2sh witness program."
+          "description": "The optional sig script for the specified witness that will only be set if\nthe input specified is a nested p2sh witness program."
         }
       }
     },

--- a/lnrpc/walletrpc/walletkit.pb.go
+++ b/lnrpc/walletrpc/walletkit.pb.go
@@ -1156,7 +1156,7 @@ type WalletKitClient interface {
 	//fee preference being provided. For now, the responsibility of ensuring that
 	//the new fee preference is sufficient is delegated to the user.
 	BumpFee(ctx context.Context, in *BumpFeeRequest, opts ...grpc.CallOption) (*BumpFeeResponse, error)
-	//*
+	//
 	//ListSweeps returns a list of the sweep transactions our node has produced.
 	//Note that these sweeps may not be confirmed yet, as we record sweeps on
 	//broadcast, not confirmation.
@@ -1319,7 +1319,7 @@ type WalletKitServer interface {
 	//fee preference being provided. For now, the responsibility of ensuring that
 	//the new fee preference is sufficient is delegated to the user.
 	BumpFee(context.Context, *BumpFeeRequest) (*BumpFeeResponse, error)
-	//*
+	//
 	//ListSweeps returns a list of the sweep transactions our node has produced.
 	//Note that these sweeps may not be confirmed yet, as we record sweeps on
 	//broadcast, not confirmation.

--- a/lnrpc/walletrpc/walletkit.proto
+++ b/lnrpc/walletrpc/walletkit.proto
@@ -91,7 +91,7 @@ service WalletKit {
     */
     rpc BumpFee (BumpFeeRequest) returns (BumpFeeResponse);
 
-    /**
+    /*
     ListSweeps returns a list of the sweep transactions our node has produced.
     Note that these sweeps may not be confirmed yet, as we record sweeps on
     broadcast, not confirmation.


### PR DESCRIPTION
Replace `/**` with `/*` as in #4250, `ListSweeps` subject to strange rebase/merge order so it wasn't in the original PR. `InputScript` previously had a triple asterix so it fooled find and replace. 