### PR TITLE
channeldb: index payments by payment addr, use payment hash as fallback

### DIFF
--- a/channeldb/db.go
+++ b/channeldb/db.go
@@ -242,48 +242,31 @@ func (d *DB) Path() string {
 	return d.dbPath
 }
 
+var topLevelBuckets = [][]byte{
+	openChannelBucket,
+	closedChannelBucket,
+	forwardingLogBucket,
+	fwdPackagesKey,
+	invoiceBucket,
+	nodeInfoBucket,
+	nodeBucket,
+	edgeBucket,
+	edgeIndexBucket,
+	graphMetaBucket,
+	metaBucket,
+}
+
 // Wipe completely deletes all saved state within all used buckets within the
 // database. The deletion is done in a single transaction, therefore this
 // operation is fully atomic.
 func (d *DB) Wipe() error {
 	return kvdb.Update(d, func(tx kvdb.RwTx) error {
-		err := tx.DeleteTopLevelBucket(openChannelBucket)
-		if err != nil && err != kvdb.ErrBucketNotFound {
-			return err
+		for _, tlb := range topLevelBuckets {
+			err := tx.DeleteTopLevelBucket(tlb)
+			if err != nil && err != kvdb.ErrBucketNotFound {
+				return err
+			}
 		}
-
-		err = tx.DeleteTopLevelBucket(closedChannelBucket)
-		if err != nil && err != kvdb.ErrBucketNotFound {
-			return err
-		}
-
-		err = tx.DeleteTopLevelBucket(invoiceBucket)
-		if err != nil && err != kvdb.ErrBucketNotFound {
-			return err
-		}
-
-		err = tx.DeleteTopLevelBucket(nodeInfoBucket)
-		if err != nil && err != kvdb.ErrBucketNotFound {
-			return err
-		}
-
-		err = tx.DeleteTopLevelBucket(nodeBucket)
-		if err != nil && err != kvdb.ErrBucketNotFound {
-			return err
-		}
-		err = tx.DeleteTopLevelBucket(edgeBucket)
-		if err != nil && err != kvdb.ErrBucketNotFound {
-			return err
-		}
-		err = tx.DeleteTopLevelBucket(edgeIndexBucket)
-		if err != nil && err != kvdb.ErrBucketNotFound {
-			return err
-		}
-		err = tx.DeleteTopLevelBucket(graphMetaBucket)
-		if err != nil && err != kvdb.ErrBucketNotFound {
-			return err
-		}
-
 		return nil
 	})
 }
@@ -301,33 +284,13 @@ func initChannelDB(db kvdb.Backend) error {
 			return nil
 		}
 
-		if _, err := tx.CreateTopLevelBucket(openChannelBucket); err != nil {
-			return err
-		}
-		if _, err := tx.CreateTopLevelBucket(closedChannelBucket); err != nil {
-			return err
-		}
-
-		if _, err := tx.CreateTopLevelBucket(forwardingLogBucket); err != nil {
-			return err
+		for _, tlb := range topLevelBuckets {
+			if _, err := tx.CreateTopLevelBucket(tlb); err != nil {
+				return err
+			}
 		}
 
-		if _, err := tx.CreateTopLevelBucket(fwdPackagesKey); err != nil {
-			return err
-		}
-
-		if _, err := tx.CreateTopLevelBucket(invoiceBucket); err != nil {
-			return err
-		}
-
-		if _, err := tx.CreateTopLevelBucket(nodeInfoBucket); err != nil {
-			return err
-		}
-
-		nodes, err := tx.CreateTopLevelBucket(nodeBucket)
-		if err != nil {
-			return err
-		}
+		nodes := tx.ReadWriteBucket(nodeBucket)
 		_, err = nodes.CreateBucket(aliasIndexBucket)
 		if err != nil {
 			return err
@@ -337,10 +300,7 @@ func initChannelDB(db kvdb.Backend) error {
 			return err
 		}
 
-		edges, err := tx.CreateTopLevelBucket(edgeBucket)
-		if err != nil {
-			return err
-		}
+		edges := tx.ReadWriteBucket(edgeBucket)
 		if _, err := edges.CreateBucket(edgeIndexBucket); err != nil {
 			return err
 		}
@@ -354,16 +314,9 @@ func initChannelDB(db kvdb.Backend) error {
 			return err
 		}
 
-		graphMeta, err := tx.CreateTopLevelBucket(graphMetaBucket)
-		if err != nil {
-			return err
-		}
+		graphMeta := tx.ReadWriteBucket(graphMetaBucket)
 		_, err = graphMeta.CreateBucket(pruneLogBucket)
 		if err != nil {
-			return err
-		}
-
-		if _, err := tx.CreateTopLevelBucket(metaBucket); err != nil {
 			return err
 		}
 

--- a/channeldb/db.go
+++ b/channeldb/db.go
@@ -13,6 +13,7 @@ import (
 	"github.com/btcsuite/btcwallet/walletdb"
 	"github.com/go-errors/errors"
 	"github.com/lightningnetwork/lnd/channeldb/kvdb"
+	mig "github.com/lightningnetwork/lnd/channeldb/migration"
 	"github.com/lightningnetwork/lnd/channeldb/migration12"
 	"github.com/lightningnetwork/lnd/channeldb/migration13"
 	"github.com/lightningnetwork/lnd/channeldb/migration_01_to_11"
@@ -136,6 +137,13 @@ var (
 			number:    13,
 			migration: migration13.MigrateMPP,
 		},
+		{
+			// Initialize payment address index and begin using it
+			// as the default index, falling back to payment hash
+			// index.
+			number:    14,
+			migration: mig.CreateTLB(payAddrIndexBucket),
+		},
 	}
 
 	// Big endian is the preferred byte order, due to cursor scans over
@@ -248,6 +256,7 @@ var topLevelBuckets = [][]byte{
 	forwardingLogBucket,
 	fwdPackagesKey,
 	invoiceBucket,
+	payAddrIndexBucket,
 	nodeInfoBucket,
 	nodeBucket,
 	edgeBucket,

--- a/channeldb/error.go
+++ b/channeldb/error.go
@@ -43,6 +43,14 @@ var (
 	// payment hash already exists.
 	ErrDuplicateInvoice = fmt.Errorf("invoice with payment hash already exists")
 
+	// ErrDuplicatePayAddr is returned when an invoice with the target
+	// payment addr already exists.
+	ErrDuplicatePayAddr = fmt.Errorf("invoice with payemnt addr already exists")
+
+	// ErrInvRefEquivocation is returned when an InvoiceRef targets
+	// multiple, distinct invoices.
+	ErrInvRefEquivocation = errors.New("inv ref matches multiple invoices")
+
 	// ErrNoPaymentsCreated is returned when bucket of payments hasn't been
 	// created.
 	ErrNoPaymentsCreated = fmt.Errorf("there are no existing payments")

--- a/channeldb/log.go
+++ b/channeldb/log.go
@@ -3,6 +3,7 @@ package channeldb
 import (
 	"github.com/btcsuite/btclog"
 	"github.com/lightningnetwork/lnd/build"
+	mig "github.com/lightningnetwork/lnd/channeldb/migration"
 	"github.com/lightningnetwork/lnd/channeldb/migration12"
 	"github.com/lightningnetwork/lnd/channeldb/migration13"
 	"github.com/lightningnetwork/lnd/channeldb/migration_01_to_11"
@@ -28,6 +29,7 @@ func DisableLog() {
 // using btclog.
 func UseLogger(logger btclog.Logger) {
 	log = logger
+	mig.UseLogger(logger)
 	migration_01_to_11.UseLogger(logger)
 	migration12.UseLogger(logger)
 	migration13.UseLogger(logger)

--- a/channeldb/migration/create_tlb.go
+++ b/channeldb/migration/create_tlb.go
@@ -1,0 +1,27 @@
+package migration
+
+import (
+	"fmt"
+
+	"github.com/lightningnetwork/lnd/channeldb/kvdb"
+)
+
+// CreateTLB creates a new top-level bucket with the passed bucket identifier.
+func CreateTLB(bucket []byte) func(kvdb.RwTx) error {
+	return func(tx kvdb.RwTx) error {
+		log.Infof("Creating top-level bucket: \"%s\" ...", bucket)
+
+		if tx.ReadBucket(bucket) != nil {
+			return fmt.Errorf("top-level bucket \"%s\" "+
+				"already exists", bucket)
+		}
+
+		_, err := tx.CreateTopLevelBucket(bucket)
+		if err != nil {
+			return err
+		}
+
+		log.Infof("Created top-level bucket: \"%s\"", bucket)
+		return nil
+	}
+}

--- a/channeldb/migration/create_tlb_test.go
+++ b/channeldb/migration/create_tlb_test.go
@@ -1,0 +1,57 @@
+package migration_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/lightningnetwork/lnd/channeldb/kvdb"
+	"github.com/lightningnetwork/lnd/channeldb/migration"
+	"github.com/lightningnetwork/lnd/channeldb/migtest"
+)
+
+// TestCreateTLB asserts that a CreateTLB properly initializes a new top-level
+// bucket, and that it succeeds even if the bucket already exists. It would
+// probably be better if the latter failed, but the kvdb abstraction doesn't
+// support this.
+func TestCreateTLB(t *testing.T) {
+	newBucket := []byte("hello")
+
+	tests := []struct {
+		name            string
+		beforeMigration func(kvdb.RwTx) error
+		shouldFail      bool
+	}{
+		{
+			name: "already exists",
+			beforeMigration: func(tx kvdb.RwTx) error {
+				_, err := tx.CreateTopLevelBucket(newBucket)
+				return err
+			},
+			shouldFail: true,
+		},
+		{
+			name:            "does not exist",
+			beforeMigration: func(_ kvdb.RwTx) error { return nil },
+			shouldFail:      false,
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			migtest.ApplyMigration(
+				t,
+				test.beforeMigration,
+				func(tx kvdb.RwTx) error {
+					if tx.ReadBucket(newBucket) != nil {
+						return nil
+					}
+					return fmt.Errorf("bucket \"%s\" not "+
+						"created", newBucket)
+				},
+				migration.CreateTLB(newBucket),
+				test.shouldFail,
+			)
+		})
+	}
+}

--- a/channeldb/migration/log.go
+++ b/channeldb/migration/log.go
@@ -1,0 +1,12 @@
+package migration
+
+import "github.com/btcsuite/btclog"
+
+// log is a logger that is initialized as disabled.  This means the package will
+// not perform any logging by default until a logger is set.
+var log = btclog.Disabled
+
+// UseLogger uses a specified Logger to output package logging info.
+func UseLogger(logger btclog.Logger) {
+	log = logger
+}

--- a/channeldb/migtest/migtest.go
+++ b/channeldb/migtest/migtest.go
@@ -74,7 +74,7 @@ func ApplyMigration(t *testing.T,
 	// Apply migration.
 	err = kvdb.Update(cdb, migrationFunc)
 	if err != nil {
-		t.Fatal(err)
+		t.Logf("migration error: %v", err)
 	}
 }
 

--- a/htlcswitch/test_utils.go
+++ b/htlcswitch/test_utils.go
@@ -2,7 +2,7 @@ package htlcswitch
 
 import (
 	"bytes"
-	"crypto/rand"
+	crand "crypto/rand"
 	"crypto/sha256"
 	"encoding/binary"
 	"fmt"
@@ -137,7 +137,7 @@ func generateRandomBytes(n int) ([]byte, error) {
 	// TODO(roasbeef): should use counter in tests (atomic) rather than
 	// this
 
-	_, err := rand.Read(b[:])
+	_, err := crand.Read(b)
 	// Note that Err == nil only if we read len(b) bytes.
 	if err != nil {
 		return nil, err
@@ -547,7 +547,7 @@ func getChanID(msg lnwire.Message) (lnwire.ChannelID, error) {
 // invoice which should be added by destination peer.
 func generatePaymentWithPreimage(invoiceAmt, htlcAmt lnwire.MilliSatoshi,
 	timelock uint32, blob [lnwire.OnionPacketSize]byte,
-	preimage, rhash [32]byte) (*channeldb.Invoice, *lnwire.UpdateAddHTLC,
+	preimage, rhash, payAddr [32]byte) (*channeldb.Invoice, *lnwire.UpdateAddHTLC,
 	uint64, error) {
 
 	// Create the db invoice. Normally the payment requests needs to be set,
@@ -562,6 +562,7 @@ func generatePaymentWithPreimage(invoiceAmt, htlcAmt lnwire.MilliSatoshi,
 			FinalCltvDelta:  testInvoiceCltvExpiry,
 			Value:           invoiceAmt,
 			PaymentPreimage: preimage,
+			PaymentAddr:     payAddr,
 			Features: lnwire.NewFeatureVector(
 				nil, lnwire.Features,
 			),
@@ -598,8 +599,16 @@ func generatePayment(invoiceAmt, htlcAmt lnwire.MilliSatoshi, timelock uint32,
 	copy(preimage[:], r)
 
 	rhash := sha256.Sum256(preimage[:])
+
+	var payAddr [sha256.Size]byte
+	r, err = generateRandomBytes(sha256.Size)
+	if err != nil {
+		return nil, nil, 0, err
+	}
+	copy(payAddr[:], r)
+
 	return generatePaymentWithPreimage(
-		invoiceAmt, htlcAmt, timelock, blob, preimage, rhash,
+		invoiceAmt, htlcAmt, timelock, blob, preimage, rhash, payAddr,
 	)
 }
 
@@ -1328,10 +1337,15 @@ func (n *twoHopNetwork) makeHoldPayment(sendingPeer, receivingPeer lnpeer.Peer,
 
 	rhash := preimage.Hash()
 
+	var payAddr [32]byte
+	if _, err := crand.Read(payAddr[:]); err != nil {
+		panic(err)
+	}
+
 	// Generate payment: invoice and htlc.
 	invoice, htlc, pid, err := generatePaymentWithPreimage(
 		invoiceAmt, htlcAmt, timelock, blob,
-		channeldb.UnknownPreimage, rhash,
+		channeldb.UnknownPreimage, rhash, payAddr,
 	)
 	if err != nil {
 		paymentErr <- err

--- a/invoices/invoiceregistry.go
+++ b/invoices/invoiceregistry.go
@@ -61,8 +61,8 @@ type RegistryConfig struct {
 // htlcReleaseEvent describes an htlc auto-release event. It is used to release
 // mpp htlcs for which the complete set didn't arrive in time.
 type htlcReleaseEvent struct {
-	// hash is the payment hash of the htlc to release.
-	hash lntypes.Hash
+	// invoiceRef identifiers the invoice this htlc belongs to.
+	invoiceRef channeldb.InvoiceRef
 
 	// key is the circuit key of the htlc to release.
 	key channeldb.CircuitKey
@@ -289,7 +289,8 @@ func (i *InvoiceRegistry) invoiceEventLoop() {
 			// the subscriber.
 			case *SingleInvoiceSubscription:
 				log.Infof("New single invoice subscription "+
-					"client: id=%v, hash=%v", e.id, e.hash)
+					"client: id=%v, ref=%v", e.id,
+					e.invoiceRef)
 
 				i.singleNotificationClients[e.id] = e
 			}
@@ -297,8 +298,8 @@ func (i *InvoiceRegistry) invoiceEventLoop() {
 		// A new htlc came in for auto-release.
 		case event := <-i.htlcAutoReleaseChan:
 			log.Debugf("Scheduling auto-release for htlc: "+
-				"hash=%v, key=%v at %v",
-				event.hash, event.key, event.releaseTime)
+				"ref=%v, key=%v at %v",
+				event.invoiceRef, event.key, event.releaseTime)
 
 			// We use an independent timer for every htlc rather
 			// than a set timer that is reset with every htlc coming
@@ -311,7 +312,7 @@ func (i *InvoiceRegistry) invoiceEventLoop() {
 		case <-nextReleaseTick:
 			event := autoReleaseHeap.Pop().(*htlcReleaseEvent)
 			err := i.cancelSingleHtlc(
-				event.hash, event.key, ResultMppTimeout,
+				event.invoiceRef, event.key, ResultMppTimeout,
 			)
 			if err != nil {
 				log.Errorf("HTLC timer: %v", err)
@@ -328,7 +329,7 @@ func (i *InvoiceRegistry) invoiceEventLoop() {
 func (i *InvoiceRegistry) dispatchToSingleClients(event *invoiceEvent) {
 	// Dispatch to single invoice subscribers.
 	for _, client := range i.singleNotificationClients {
-		if client.hash != event.hash {
+		if client.invoiceRef.PayHash() != event.hash {
 			continue
 		}
 
@@ -465,7 +466,7 @@ func (i *InvoiceRegistry) deliverBacklogEvents(client *InvoiceSubscription) erro
 func (i *InvoiceRegistry) deliverSingleBacklogEvents(
 	client *SingleInvoiceSubscription) error {
 
-	invoice, err := i.cdb.LookupInvoice(client.hash)
+	invoice, err := i.cdb.LookupInvoice(client.invoiceRef)
 
 	// It is possible that the invoice does not exist yet, but the client is
 	// already watching it in anticipation.
@@ -479,7 +480,7 @@ func (i *InvoiceRegistry) deliverSingleBacklogEvents(
 	}
 
 	err = client.notify(&invoiceEvent{
-		hash:    client.hash,
+		hash:    client.invoiceRef.PayHash(),
 		invoice: &invoice,
 	})
 	if err != nil {
@@ -502,8 +503,8 @@ func (i *InvoiceRegistry) AddInvoice(invoice *channeldb.Invoice,
 
 	i.Lock()
 
-	log.Debugf("Invoice(%v): added with terms %v", paymentHash,
-		invoice.Terms)
+	ref := channeldb.InvoiceRefByHash(paymentHash)
+	log.Debugf("Invoice%v: added with terms %v", ref, invoice.Terms)
 
 	addIndex, err := i.cdb.AddInvoice(invoice, paymentHash)
 	if err != nil {
@@ -533,17 +534,18 @@ func (i *InvoiceRegistry) LookupInvoice(rHash lntypes.Hash) (channeldb.Invoice,
 
 	// We'll check the database to see if there's an existing matching
 	// invoice.
-	return i.cdb.LookupInvoice(rHash)
+	ref := channeldb.InvoiceRefByHash(rHash)
+	return i.cdb.LookupInvoice(ref)
 }
 
 // startHtlcTimer starts a new timer via the invoice registry main loop that
 // cancels a single htlc on an invoice when the htlc hold duration has passed.
-func (i *InvoiceRegistry) startHtlcTimer(hash lntypes.Hash,
+func (i *InvoiceRegistry) startHtlcTimer(invoiceRef channeldb.InvoiceRef,
 	key channeldb.CircuitKey, acceptTime time.Time) error {
 
 	releaseTime := acceptTime.Add(i.cfg.HtlcHoldDuration)
 	event := &htlcReleaseEvent{
-		hash:        hash,
+		invoiceRef:  invoiceRef,
 		key:         key,
 		releaseTime: releaseTime,
 	}
@@ -560,7 +562,7 @@ func (i *InvoiceRegistry) startHtlcTimer(hash lntypes.Hash,
 // cancelSingleHtlc cancels a single accepted htlc on an invoice. It takes
 // a resolution result which will be used to notify subscribed links and
 // resolvers of the details of the htlc cancellation.
-func (i *InvoiceRegistry) cancelSingleHtlc(hash lntypes.Hash,
+func (i *InvoiceRegistry) cancelSingleHtlc(invoiceRef channeldb.InvoiceRef,
 	key channeldb.CircuitKey, result FailResolutionResult) error {
 
 	i.Lock()
@@ -572,7 +574,7 @@ func (i *InvoiceRegistry) cancelSingleHtlc(hash lntypes.Hash,
 		// Only allow individual htlc cancelation on open invoices.
 		if invoice.State != channeldb.ContractOpen {
 			log.Debugf("cancelSingleHtlc: invoice %v no longer "+
-				"open", hash)
+				"open", invoiceRef)
 
 			return nil, nil
 		}
@@ -587,13 +589,13 @@ func (i *InvoiceRegistry) cancelSingleHtlc(hash lntypes.Hash,
 		// resolved.
 		if htlc.State != channeldb.HtlcStateAccepted {
 			log.Debugf("cancelSingleHtlc: htlc %v on invoice %v "+
-				"is already resolved", key, hash)
+				"is already resolved", key, invoiceRef)
 
 			return nil, nil
 		}
 
 		log.Debugf("cancelSingleHtlc: cancelling htlc %v on invoice %v",
-			key, hash)
+			key, invoiceRef)
 
 		// Return an update descriptor that cancels htlc and keeps
 		// invoice open.
@@ -610,7 +612,7 @@ func (i *InvoiceRegistry) cancelSingleHtlc(hash lntypes.Hash,
 	// Intercept the update descriptor to set the local updated variable. If
 	// no invoice update is performed, we can return early.
 	var updated bool
-	invoice, err := i.cdb.UpdateInvoice(hash,
+	invoice, err := i.cdb.UpdateInvoice(invoiceRef,
 		func(invoice *channeldb.Invoice) (
 			*channeldb.InvoiceUpdateDesc, error) {
 
@@ -774,7 +776,9 @@ func (i *InvoiceRegistry) NotifyExitHopHtlc(rHash lntypes.Hash,
 	// main event loop.
 	case *htlcAcceptResolution:
 		if r.autoRelease {
-			err := i.startHtlcTimer(rHash, circuitKey, r.acceptTime)
+			err := i.startHtlcTimer(
+				ctx.invoiceRef(), circuitKey, r.acceptTime,
+			)
 			if err != nil {
 				return nil, err
 			}
@@ -808,7 +812,7 @@ func (i *InvoiceRegistry) notifyExitHopHtlcLocked(
 		updateSubscribers bool
 	)
 	invoice, err := i.cdb.UpdateInvoice(
-		ctx.hash,
+		ctx.invoiceRef(),
 		func(inv *channeldb.Invoice) (
 			*channeldb.InvoiceUpdateDesc, error) {
 
@@ -962,7 +966,8 @@ func (i *InvoiceRegistry) SettleHodlInvoice(preimage lntypes.Preimage) error {
 	}
 
 	hash := preimage.Hash()
-	invoice, err := i.cdb.UpdateInvoice(hash, updateInvoice)
+	invoiceRef := channeldb.InvoiceRefByHash(hash)
+	invoice, err := i.cdb.UpdateInvoice(invoiceRef, updateInvoice)
 	if err != nil {
 		log.Errorf("SettleHodlInvoice with preimage %v: %v",
 			preimage, err)
@@ -970,7 +975,7 @@ func (i *InvoiceRegistry) SettleHodlInvoice(preimage lntypes.Preimage) error {
 		return err
 	}
 
-	log.Debugf("Invoice(%v): settled with preimage %v", hash,
+	log.Debugf("Invoice%v: settled with preimage %v", invoiceRef,
 		invoice.Terms.PaymentPreimage)
 
 	// In the callback, we marked the invoice as settled. UpdateInvoice will
@@ -1011,7 +1016,8 @@ func (i *InvoiceRegistry) cancelInvoiceImpl(payHash lntypes.Hash,
 	i.Lock()
 	defer i.Unlock()
 
-	log.Debugf("Invoice(%v): canceling invoice", payHash)
+	ref := channeldb.InvoiceRefByHash(payHash)
+	log.Debugf("Invoice%v: canceling invoice", ref)
 
 	updateInvoice := func(invoice *channeldb.Invoice) (
 		*channeldb.InvoiceUpdateDesc, error) {
@@ -1032,12 +1038,13 @@ func (i *InvoiceRegistry) cancelInvoiceImpl(payHash lntypes.Hash,
 		}, nil
 	}
 
-	invoice, err := i.cdb.UpdateInvoice(payHash, updateInvoice)
+	invoiceRef := channeldb.InvoiceRefByHash(payHash)
+	invoice, err := i.cdb.UpdateInvoice(invoiceRef, updateInvoice)
 
 	// Implement idempotency by returning success if the invoice was already
 	// canceled.
 	if err == channeldb.ErrInvoiceAlreadyCanceled {
-		log.Debugf("Invoice(%v): already canceled", payHash)
+		log.Debugf("Invoice%v: already canceled", ref)
 		return nil
 	}
 	if err != nil {
@@ -1046,12 +1053,12 @@ func (i *InvoiceRegistry) cancelInvoiceImpl(payHash lntypes.Hash,
 
 	// Return without cancellation if the invoice state is ContractAccepted.
 	if invoice.State == channeldb.ContractAccepted {
-		log.Debugf("Invoice(%v): remains accepted as cancel wasn't"+
-			"explicitly requested.", payHash)
+		log.Debugf("Invoice%v: remains accepted as cancel wasn't"+
+			"explicitly requested.", ref)
 		return nil
 	}
 
-	log.Debugf("Invoice(%v): canceled", payHash)
+	log.Debugf("Invoice%v: canceled", ref)
 
 	// In the callback, some htlcs may have been moved to the canceled
 	// state. We now go through all of these and notify links and resolvers
@@ -1140,7 +1147,7 @@ type InvoiceSubscription struct {
 type SingleInvoiceSubscription struct {
 	invoiceSubscriptionKit
 
-	hash lntypes.Hash
+	invoiceRef channeldb.InvoiceRef
 
 	// Updates is a channel that we'll use to send all invoice events for
 	// the invoice that is subscribed to.
@@ -1269,7 +1276,7 @@ func (i *InvoiceRegistry) SubscribeSingleInvoice(
 			ntfnQueue:  queue.NewConcurrentQueue(20),
 			cancelChan: make(chan struct{}),
 		},
-		hash: hash,
+		invoiceRef: channeldb.InvoiceRefByHash(hash),
 	}
 	client.ntfnQueue.Start()
 

--- a/invoices/invoiceregistry_test.go
+++ b/invoices/invoiceregistry_test.go
@@ -26,7 +26,7 @@ func TestSettleInvoice(t *testing.T) {
 	}
 	defer subscription.Cancel()
 
-	if subscription.hash != testInvoicePaymentHash {
+	if subscription.invoiceRef.PayHash() != testInvoicePaymentHash {
 		t.Fatalf("expected subscription for provided hash")
 	}
 
@@ -237,7 +237,7 @@ func TestCancelInvoice(t *testing.T) {
 	}
 	defer subscription.Cancel()
 
-	if subscription.hash != testInvoicePaymentHash {
+	if subscription.invoiceRef.PayHash() != testInvoicePaymentHash {
 		t.Fatalf("expected subscription for provided hash")
 	}
 
@@ -362,7 +362,7 @@ func TestSettleHoldInvoice(t *testing.T) {
 	}
 	defer subscription.Cancel()
 
-	if subscription.hash != testInvoicePaymentHash {
+	if subscription.invoiceRef.PayHash() != testInvoicePaymentHash {
 		t.Fatalf("expected subscription for provided hash")
 	}
 

--- a/invoices/update.go
+++ b/invoices/update.go
@@ -22,10 +22,16 @@ type invoiceUpdateCtx struct {
 	mpp                  *record.MPP
 }
 
+// invoiceRef returns an identifier that can be used to lookup or update the
+// invoice this HTLC is targeting.
+func (i *invoiceUpdateCtx) invoiceRef() channeldb.InvoiceRef {
+	return channeldb.InvoiceRefByHash(i.hash)
+}
+
 // log logs a message specific to this update context.
 func (i *invoiceUpdateCtx) log(s string) {
-	log.Debugf("Invoice(%x): %v, amt=%v, expiry=%v, circuit=%v, mpp=%v",
-		i.hash[:], s, i.amtPaid, i.expiry, i.circuitKey, i.mpp)
+	log.Debugf("Invoice%v: %v, amt=%v, expiry=%v, circuit=%v, mpp=%v",
+		i.invoiceRef, s, i.amtPaid, i.expiry, i.circuitKey, i.mpp)
 }
 
 // failRes is a helper function which creates a failure resolution with

--- a/invoices/update.go
+++ b/invoices/update.go
@@ -25,6 +25,10 @@ type invoiceUpdateCtx struct {
 // invoiceRef returns an identifier that can be used to lookup or update the
 // invoice this HTLC is targeting.
 func (i *invoiceUpdateCtx) invoiceRef() channeldb.InvoiceRef {
+	if i.mpp != nil {
+		payAddr := i.mpp.PaymentAddr()
+		return channeldb.InvoiceRefByHashAndAddr(i.hash, payAddr)
+	}
 	return channeldb.InvoiceRefByHash(i.hash)
 }
 

--- a/lntest/itest/log_error_whitelist.txt
+++ b/lntest/itest/log_error_whitelist.txt
@@ -181,3 +181,6 @@
 <time> [ERR] UTXN: Notification chan closed, can't advance output <chan_point>
 <time> [ERR] RPCS: [/walletrpc.WalletKit/LabelTransaction]: cannot label transaction with empty label
 <time> [ERR] RPCS: [/walletrpc.WalletKit/LabelTransaction]: transaction already labelled
+<time> [ERR] NTFN: unable to get hash from block with height 790
+<time> [ERR] CRTR: Payment with hash <hex> failed: timeout
+<time> [ERR] RPCS: [/routerrpc.Route<time> [INF] LTND: Listening on the p2p interface is disabled!

--- a/lntest/timeouts.go
+++ b/lntest/timeouts.go
@@ -7,7 +7,7 @@ import "time"
 const (
 	// MinerMempoolTimeout is the max time we will wait for a transaction
 	// to propagate to the mining node's mempool.
-	MinerMempoolTimeout = time.Second * 30
+	MinerMempoolTimeout = time.Minute
 
 	// ChannelOpenTimeout is the max time we will wait before a channel to
 	// be considered opened.

--- a/lntest/timeouts_darwin.go
+++ b/lntest/timeouts_darwin.go
@@ -7,7 +7,7 @@ import "time"
 const (
 	// MinerMempoolTimeout is the max time we will wait for a transaction
 	// to propagate to the mining node's mempool.
-	MinerMempoolTimeout = time.Second * 30
+	MinerMempoolTimeout = time.Minute
 
 	// ChannelOpenTimeout is the max time we will wait before a channel to
 	// be considered opened.


### PR DESCRIPTION
This PR adds a new persistent index on invoices to allow efficient
lookups and updates by payment address. This is stepping stone
to enable AMP payments where the payment hash will not be
associated with the target invoice.

Since 0.9, all new invoices include a random payment address,
however older invoices do not have this value. New invoices will
be added to the payment address index on a rolling basis, but 
the payment hash index will continue to serve as a fallback in case
the target invoice was created prior to this commit. As such,
no migration is needed for invoices created prior to this commit, 
but we include one to bump the db version number and initialize
the top-level index bucket.

This also unblocks #4167, since it allows us to insert a random
payment address for experimental keysend payments. In the future,
where keysend is rolled into the final AMP proposal, this ensures that 
all keysend (experimental or otherwise) have a payment address
associated with the invoice. This is desired since we will be using
payment addresses entirely to identify and update AMP payments, so
we ensure the code paths between AMP and legacy keysend are
identical.

Further off, once payment addresses are required, we can stop inserting
invoices into the payment hash index entirely. Currently however, we rely
on invoices being indexed to support other operations, e.g. hodl settle/cancel
or legacy senders that don't understand MPP.