### PR TITLE
mod: update to queue/v1.0.4

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -39,7 +39,7 @@ require (
 	github.com/lightninglabs/protobuf-hex-display v1.3.3-0.20191212020323-b444784ce75d
 	github.com/lightningnetwork/lightning-onion v1.0.1
 	github.com/lightningnetwork/lnd/cert v1.0.2
-	github.com/lightningnetwork/lnd/queue v1.0.3
+	github.com/lightningnetwork/lnd/queue v1.0.4
 	github.com/lightningnetwork/lnd/ticker v1.0.0
 	github.com/ltcsuite/ltcd v0.0.0-20190101042124-f37f8bf35796
 	github.com/mattn/go-runewidth v0.0.9 // indirect


### PR DESCRIPTION
No new tag was pushed after changes to the `queue` package in #3972 and #4192. This leads to external dependencies picking up the old version.