### PR TITLE
channeldb+invoices: minor invoice subscription fixes

### DIFF
--- a/channeldb/invoice_test.go
+++ b/channeldb/invoice_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/lightningnetwork/lnd/lntypes"
 	"github.com/lightningnetwork/lnd/lnwire"
 	"github.com/lightningnetwork/lnd/record"
+	"github.com/stretchr/testify/assert"
 )
 
 var (
@@ -305,6 +306,9 @@ func TestInvoiceAddTimeSeries(t *testing.T) {
 		t.Fatalf("unable to make test db: %v", err)
 	}
 
+	_, err = db.InvoicesAddedSince(0)
+	assert.Nil(t, err)
+
 	// We'll start off by creating 20 random invoices, and inserting them
 	// into the database.
 	const numInvoices = 20
@@ -371,6 +375,9 @@ func TestInvoiceAddTimeSeries(t *testing.T) {
 				spew.Sdump(query.resp), spew.Sdump(resp))
 		}
 	}
+
+	_, err = db.InvoicesSettledSince(0)
+	assert.Nil(t, err)
 
 	var settledInvoices []Invoice
 	var settleIndex uint64 = 1

--- a/channeldb/invoices.go
+++ b/channeldb/invoices.go
@@ -488,12 +488,12 @@ func (d *DB) InvoicesAddedSince(sinceAddIndex uint64) ([]Invoice, error) {
 	err := kvdb.View(d, func(tx kvdb.ReadTx) error {
 		invoices := tx.ReadBucket(invoiceBucket)
 		if invoices == nil {
-			return ErrNoInvoicesCreated
+			return nil
 		}
 
 		addIndex := invoices.NestedReadBucket(addIndexBucket)
 		if addIndex == nil {
-			return ErrNoInvoicesCreated
+			return nil
 		}
 
 		// We'll now run through each entry in the add index starting
@@ -520,12 +520,7 @@ func (d *DB) InvoicesAddedSince(sinceAddIndex uint64) ([]Invoice, error) {
 
 		return nil
 	})
-	switch {
-	// If no invoices have been created, then we'll return the empty set of
-	// invoices.
-	case err == ErrNoInvoicesCreated:
-
-	case err != nil:
+	if err != nil {
 		return nil, err
 	}
 
@@ -886,12 +881,12 @@ func (d *DB) InvoicesSettledSince(sinceSettleIndex uint64) ([]Invoice, error) {
 	err := kvdb.View(d, func(tx kvdb.ReadTx) error {
 		invoices := tx.ReadBucket(invoiceBucket)
 		if invoices == nil {
-			return ErrNoInvoicesCreated
+			return nil
 		}
 
 		settleIndex := invoices.NestedReadBucket(settleIndexBucket)
 		if settleIndex == nil {
-			return ErrNoInvoicesCreated
+			return nil
 		}
 
 		// We'll now run through each entry in the add index starting

--- a/invoices/invoiceregistry.go
+++ b/invoices/invoiceregistry.go
@@ -1182,7 +1182,9 @@ func (i *invoiceSubscriptionKit) notify(event *invoiceEvent) error {
 // added. The invoiceIndex parameter is a streaming "checkpoint". We'll start
 // by first sending out all new events with an invoice index _greater_ than
 // this value. Afterwards, we'll send out real-time notifications.
-func (i *InvoiceRegistry) SubscribeNotifications(addIndex, settleIndex uint64) *InvoiceSubscription {
+func (i *InvoiceRegistry) SubscribeNotifications(
+	addIndex, settleIndex uint64) (*InvoiceSubscription, error) {
+
 	client := &InvoiceSubscription{
 		NewInvoices:     make(chan *channeldb.Invoice),
 		SettledInvoices: make(chan *channeldb.Invoice),
@@ -1254,9 +1256,10 @@ func (i *InvoiceRegistry) SubscribeNotifications(addIndex, settleIndex uint64) *
 	select {
 	case i.newSubscriptions <- client:
 	case <-i.quit:
+		return nil, ErrShuttingDown
 	}
 
-	return client
+	return client, nil
 }
 
 // SubscribeSingleInvoice returns an SingleInvoiceSubscription which allows the

--- a/invoices/invoiceregistry_test.go
+++ b/invoices/invoiceregistry_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/lightningnetwork/lnd/lntypes"
 	"github.com/lightningnetwork/lnd/lnwire"
 	"github.com/lightningnetwork/lnd/record"
+	"github.com/stretchr/testify/assert"
 )
 
 // TestSettleInvoice tests settling of an invoice and related notifications.
@@ -16,7 +17,8 @@ func TestSettleInvoice(t *testing.T) {
 	ctx := newTestContext(t)
 	defer ctx.cleanup()
 
-	allSubscriptions := ctx.registry.SubscribeNotifications(0, 0)
+	allSubscriptions, err := ctx.registry.SubscribeNotifications(0, 0)
+	assert.Nil(t, err)
 	defer allSubscriptions.Cancel()
 
 	// Subscribe to the not yet existing invoice.
@@ -221,11 +223,12 @@ func TestCancelInvoice(t *testing.T) {
 	ctx := newTestContext(t)
 	defer ctx.cleanup()
 
-	allSubscriptions := ctx.registry.SubscribeNotifications(0, 0)
+	allSubscriptions, err := ctx.registry.SubscribeNotifications(0, 0)
+	assert.Nil(t, err)
 	defer allSubscriptions.Cancel()
 
 	// Try to cancel the not yet existing invoice. This should fail.
-	err := ctx.registry.CancelInvoice(testInvoicePaymentHash)
+	err = ctx.registry.CancelInvoice(testInvoicePaymentHash)
 	if err != channeldb.ErrInvoiceNotFound {
 		t.Fatalf("expected ErrInvoiceNotFound, but got %v", err)
 	}
@@ -352,7 +355,8 @@ func TestSettleHoldInvoice(t *testing.T) {
 	}
 	defer registry.Stop()
 
-	allSubscriptions := registry.SubscribeNotifications(0, 0)
+	allSubscriptions, err := registry.SubscribeNotifications(0, 0)
+	assert.Nil(t, err)
 	defer allSubscriptions.Cancel()
 
 	// Subscribe to the not yet existing invoice.
@@ -651,7 +655,8 @@ func testKeySend(t *testing.T, keySendEnabled bool) {
 
 	ctx.registry.cfg.AcceptKeySend = keySendEnabled
 
-	allSubscriptions := ctx.registry.SubscribeNotifications(0, 0)
+	allSubscriptions, err := ctx.registry.SubscribeNotifications(0, 0)
+	assert.Nil(t, err)
 	defer allSubscriptions.Cancel()
 
 	hodlChan := make(chan interface{}, 1)

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -4535,9 +4535,12 @@ func (r *rpcServer) ListInvoices(ctx context.Context,
 func (r *rpcServer) SubscribeInvoices(req *lnrpc.InvoiceSubscription,
 	updateStream lnrpc.Lightning_SubscribeInvoicesServer) error {
 
-	invoiceClient := r.server.invoices.SubscribeNotifications(
+	invoiceClient, err := r.server.invoices.SubscribeNotifications(
 		req.AddIndex, req.SettleIndex,
 	)
+	if err != nil {
+		return err
+	}
 	defer invoiceClient.Cancel()
 
 	for {


### PR DESCRIPTION
This PR addresses three bugs in our current invoice subscriptions:
 - No backlog can be delivered until an invoice is settled.
 - `SubscribeNotifications` can return before registration and backlog delivery have finished, which can lead to duplicate notifications, even in a single process.
 - The database operations for retrieving backlogs are not synchronized in the same manner as the `AddInvoice`, `CancelInvoice` etc, leading to inconsistent reads on the database state and in some cases can lead to duplicate notifications when the registry is processing concurrent operations.

