### PR TITLE
lncli: Fix typos in closechannel help dialog

### DIFF
--- a/cmd/lncli/commands.go
+++ b/cmd/lncli/commands.go
@@ -644,7 +644,7 @@ var closeChannelCommand = cli.Command{
 			Name: "delivery_addr",
 			Usage: "(optional) an address to deliver funds " +
 				"upon cooperative channel closing, may only " +
-				"be used if an upfront shutdown addresss is not" +
+				"be used if an upfront shutdown address is not " +
 				"already set",
 		},
 	},


### PR DESCRIPTION
Fixes 2 typos in the help dialog for `lncli closechannel` (attribute `--delivery_addr`)