### PR TITLE
lnd+kvdb+etcd: remove retry goroutine from the STM and integrate abort context

### DIFF
--- a/channeldb/kvdb/etcd/embed.go
+++ b/channeldb/kvdb/etcd/embed.go
@@ -3,6 +3,7 @@
 package etcd
 
 import (
+	"context"
 	"fmt"
 	"net"
 	"net/url"
@@ -63,6 +64,7 @@ func NewEmbeddedEtcdInstance(path string) (*BackendConfig, func(), error) {
 	}
 
 	connConfig := &BackendConfig{
+		Ctx:                context.Background(),
 		Host:               "http://" + peerURL,
 		User:               "user",
 		Pass:               "pass",

--- a/channeldb/kvdb/kvdb_etcd.go
+++ b/channeldb/kvdb/kvdb_etcd.go
@@ -3,6 +3,8 @@
 package kvdb
 
 import (
+	"context"
+
 	"github.com/lightningnetwork/lnd/channeldb/kvdb/etcd"
 )
 
@@ -12,10 +14,13 @@ const TestBackend = EtcdBackendName
 
 // GetEtcdBackend returns an etcd backend configured according to the
 // passed etcdConfig.
-func GetEtcdBackend(prefix string, etcdConfig *EtcdConfig) (Backend, error) {
+func GetEtcdBackend(ctx context.Context, prefix string,
+	etcdConfig *EtcdConfig) (Backend, error) {
+
 	// Config translation is needed here in order to keep the
 	// etcd package fully independent from the rest of the source tree.
 	backendConfig := etcd.BackendConfig{
+		Ctx:                ctx,
 		Host:               etcdConfig.Host,
 		User:               etcdConfig.User,
 		Pass:               etcdConfig.Pass,

--- a/channeldb/kvdb/kvdb_no_etcd.go
+++ b/channeldb/kvdb/kvdb_no_etcd.go
@@ -3,6 +3,7 @@
 package kvdb
 
 import (
+	"context"
 	"fmt"
 )
 
@@ -13,7 +14,9 @@ const TestBackend = BoltBackendName
 var errEtcdNotAvailable = fmt.Errorf("etcd backend not available")
 
 // GetEtcdBackend is a stub returning nil and errEtcdNotAvailable error.
-func GetEtcdBackend(prefix string, etcdConfig *EtcdConfig) (Backend, error) {
+func GetEtcdBackend(ctx context.Context, prefix string,
+	etcdConfig *EtcdConfig) (Backend, error) {
+
 	return nil, errEtcdNotAvailable
 }
 

--- a/lncfg/db.go
+++ b/lncfg/db.go
@@ -1,6 +1,7 @@
 package lncfg
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/lightningnetwork/lnd/channeldb/kvdb"
@@ -50,12 +51,12 @@ func (db *DB) Validate() error {
 }
 
 // GetBackend returns a kvdb.Backend as set in the DB config.
-func (db *DB) GetBackend(dbPath string, networkName string) (
-	kvdb.Backend, error) {
+func (db *DB) GetBackend(ctx context.Context, dbPath string,
+	networkName string) (kvdb.Backend, error) {
 
 	if db.Backend == etcdBackend {
 		// Prefix will separate key/values in the db.
-		return kvdb.GetEtcdBackend(networkName, db.Etcd)
+		return kvdb.GetEtcdBackend(ctx, networkName, db.Etcd)
 	}
 
 	return kvdb.GetBoltBackend(dbPath, dbName, db.Bolt.NoFreeListSync)

--- a/lnd.go
+++ b/lnd.go
@@ -251,7 +251,11 @@ func Main(cfg *Config, lisCfg ListenerCfg, shutdownChan <-chan struct{}) error {
 		"minutes...")
 
 	startOpenTime := time.Now()
-	chanDbBackend, err := cfg.DB.GetBackend(
+	ctx := context.Background()
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	chanDbBackend, err := cfg.DB.GetBackend(ctx,
 		cfg.localDatabaseDir(), cfg.networkName(),
 	)
 	if err != nil {
@@ -283,10 +287,6 @@ func Main(cfg *Config, lisCfg ListenerCfg, shutdownChan <-chan struct{}) error {
 	ltndLog.Infof("Database now open (time_to_open=%v)!", openTime)
 
 	// Only process macaroons if --no-macaroons isn't set.
-	ctx := context.Background()
-	ctx, cancel := context.WithCancel(ctx)
-	defer cancel()
-
 	tlsCfg, restCreds, restProxyDest, err := getTLSConfig(cfg)
 	if err != nil {
 		err := fmt.Errorf("unable to load TLS credentials: %v", err)


### PR DESCRIPTION
This PR removes the retry goroutine from the STM as the retry loop
is only running when the STM transaction is encapsulated in Update/View
whereas for self-standing transactions we use a different approach.
By removing the goroutine we won't catch panics thrown that are supposed
to be catched outside of the STM.

Furthermore the PR also integrates the LND abort context to the STM  to fix
blocking upon exit when multiple transactions keep conflicting with each other.