### PR TITLE
config+log: remove global RootLogWriter variable

### DIFF
--- a/config.go
+++ b/config.go
@@ -250,6 +250,10 @@ type Config struct {
 
 	DB *lncfg.DB `group:"db" namespace:"db"`
 
+	// LogWriter is the root logger that all of the daemon's subloggers are
+	// hooked up to.
+	LogWriter *build.RotatingLogWriter
+
 	// registeredChains keeps track of all chains that have been registered
 	// with the daemon.
 	registeredChains *chainRegistry
@@ -360,6 +364,7 @@ func DefaultConfig() Config {
 		},
 		MaxOutgoingCltvExpiry:   htlcswitch.DefaultMaxOutgoingCltvExpiry,
 		MaxChannelFeeAllocation: htlcswitch.DefaultMaxLinkFeeAllocation,
+		LogWriter:               build.NewRotatingLogWriter(),
 		DB:                      lncfg.DefaultDB(),
 		registeredChains:        newChainRegistry(),
 	}
@@ -928,15 +933,21 @@ func ValidateConfig(cfg Config, usageMessage string) (*Config, error) {
 		cfg.registeredChains.PrimaryChain().String(),
 		normalizeNetwork(activeNetParams.Name))
 
+	// A log writer must be passed in, otherwise we can't function and would
+	// run into a panic later on.
+	if cfg.LogWriter == nil {
+		return nil, fmt.Errorf("log writer missing in config")
+	}
+
 	// Special show command to list supported subsystems and exit.
 	if cfg.DebugLevel == "show" {
 		fmt.Println("Supported subsystems",
-			RootLogWriter.SupportedSubsystems())
+			cfg.LogWriter.SupportedSubsystems())
 		os.Exit(0)
 	}
 
 	// Initialize logging at the default logging level.
-	err = RootLogWriter.InitLogRotator(
+	err = cfg.LogWriter.InitLogRotator(
 		filepath.Join(cfg.LogDir, defaultLogFilename),
 		cfg.MaxLogFileSize, cfg.MaxLogFiles,
 	)
@@ -948,7 +959,7 @@ func ValidateConfig(cfg Config, usageMessage string) (*Config, error) {
 	}
 
 	// Parse, validate, and set debug log level(s).
-	err = build.ParseAndSetDebugLevels(cfg.DebugLevel, RootLogWriter)
+	err = build.ParseAndSetDebugLevels(cfg.DebugLevel, cfg.LogWriter)
 	if err != nil {
 		err = fmt.Errorf("%s: %v", funcName, err.Error())
 		_, _ = fmt.Fprintln(os.Stderr, err)

--- a/config.go
+++ b/config.go
@@ -947,6 +947,7 @@ func ValidateConfig(cfg Config, usageMessage string) (*Config, error) {
 	}
 
 	// Initialize logging at the default logging level.
+	SetupLoggers(cfg.LogWriter)
 	err = cfg.LogWriter.InitLogRotator(
 		filepath.Join(cfg.LogDir, defaultLogFilename),
 		cfg.MaxLogFileSize, cfg.MaxLogFiles,

--- a/lnd.go
+++ b/lnd.go
@@ -190,7 +190,7 @@ type rpcListeners func() ([]*ListenerWithSignal, func(), error)
 func Main(cfg *Config, lisCfg ListenerCfg, shutdownChan <-chan struct{}) error {
 	defer func() {
 		ltndLog.Info("Shutdown complete")
-		err := RootLogWriter.Close()
+		err := cfg.LogWriter.Close()
 		if err != nil {
 			ltndLog.Errorf("Could not close log rotator: %v", err)
 		}

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -5295,7 +5295,7 @@ func (r *rpcServer) DebugLevel(ctx context.Context,
 	if req.Show {
 		return &lnrpc.DebugLevelResponse{
 			SubSystems: strings.Join(
-				RootLogWriter.SupportedSubsystems(), " ",
+				r.cfg.LogWriter.SupportedSubsystems(), " ",
 			),
 		}, nil
 	}
@@ -5304,7 +5304,7 @@ func (r *rpcServer) DebugLevel(ctx context.Context,
 
 	// Otherwise, we'll attempt to set the logging level using the
 	// specified level spec.
-	err := build.ParseAndSetDebugLevels(req.LevelSpec, RootLogWriter)
+	err := build.ParseAndSetDebugLevels(req.LevelSpec, r.cfg.LogWriter)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
To get rid of another global (and exported) variable, we refactor the `config.go`, `lnd.go` and `log.go` to make it possible to pass in a log writer through the main `Config` struct.