### PR TITLE
build: bump version to lnd v0.10.99-beta

### DIFF
--- a/build/version.go
+++ b/build/version.go
@@ -44,7 +44,7 @@ const (
 	AppMinor uint = 10
 
 	// AppPatch defines the application patch for this binary.
-	AppPatch uint = 0
+	AppPatch uint = 99
 
 	// AppPreRelease MUST only contain characters from semanticAlphabet
 	// per the semantic versioning spec.


### PR DESCRIPTION
In this commit, we bump the version to a `.99` minor version to reflect
the fact that master is ahead of _both_ `v0.10.0-beta`, and the upcoming
`v0.10.1-beta` release. 
