### PR TITLE
routing: don't treat bad features as an unexpected error

### DIFF
--- a/routing/pathfind.go
+++ b/routing/pathfind.go
@@ -420,13 +420,15 @@ func findPath(g *graphParams, r *RestrictParams, cfg *PathFindingConfig,
 	// required features.
 	err := feature.ValidateRequired(features)
 	if err != nil {
-		return nil, err
+		log.Warnf("Pathfinding destination node features: %v", err)
+		return nil, errUnknownRequiredFeature
 	}
 
 	// Ensure that all transitive dependencies are set.
 	err = feature.ValidateDeps(features)
 	if err != nil {
-		return nil, err
+		log.Warnf("Pathfinding destination node features: %v", err)
+		return nil, errMissingDependentFeature
 	}
 
 	// Now that we know the feature vector is well formed, we'll proceed in

--- a/routing/pathfind_test.go
+++ b/routing/pathfind_test.go
@@ -23,7 +23,6 @@ import (
 	"github.com/btcsuite/btcd/wire"
 	"github.com/btcsuite/btcutil"
 	"github.com/lightningnetwork/lnd/channeldb"
-	"github.com/lightningnetwork/lnd/feature"
 	"github.com/lightningnetwork/lnd/lnwire"
 	"github.com/lightningnetwork/lnd/record"
 	"github.com/lightningnetwork/lnd/routing/route"
@@ -1590,9 +1589,7 @@ func TestMissingFeatureDep(t *testing.T) {
 	joost := ctx.keyFromAlias("joost")
 
 	_, err := ctx.findPath(conner, 100)
-	if err != feature.NewErrMissingFeatureDep(
-		lnwire.TLVOnionPayloadOptional,
-	) {
+	if err != errMissingDependentFeature {
 		t.Fatalf("path shouldn't have been found: %v", err)
 	}
 
@@ -1667,9 +1664,8 @@ func TestUnknownRequiredFeatures(t *testing.T) {
 	// Conner's node in the graph has an unknown required feature (100).
 	// Pathfinding should fail since we check the destination's features for
 	// unknown required features before beginning pathfinding.
-	expErr := feature.NewErrUnknownRequired([]lnwire.FeatureBit{100})
 	_, err := ctx.findPath(conner, 100)
-	if !reflect.DeepEqual(err, expErr) {
+	if !reflect.DeepEqual(err, errUnknownRequiredFeature) {
 		t.Fatalf("path shouldn't have been found: %v", err)
 	}
 

--- a/routing/payment_session.go
+++ b/routing/payment_session.go
@@ -37,6 +37,14 @@ const (
 	// errEmptyPaySession is returned when the empty payment session is
 	// queried for a route.
 	errEmptyPaySession
+
+	// errUnknownRequiredFeature is returned when the destination node
+	// requires an unknown feature.
+	errUnknownRequiredFeature
+
+	// errMissingDependentFeature is returned when the destination node
+	// misses a feature that a feature that we require depends on.
+	errMissingDependentFeature
 )
 
 var (
@@ -64,6 +72,12 @@ func (e noRouteError) Error() string {
 	case errInsufficientBalance:
 		return "insufficient local balance"
 
+	case errUnknownRequiredFeature:
+		return "unknown required feature"
+
+	case errMissingDependentFeature:
+		return "missing dependent feature"
+
 	default:
 		return "unknown no-route error"
 	}
@@ -76,7 +90,9 @@ func (e noRouteError) FailureReason() channeldb.FailureReason {
 		errNoTlvPayload,
 		errNoPaymentAddr,
 		errNoPathFound,
-		errEmptyPaySession:
+		errEmptyPaySession,
+		errUnknownRequiredFeature,
+		errMissingDependentFeature:
 
 		return channeldb.FailureReasonNoRoute
 


### PR DESCRIPTION
Previous behavior led to the payment loop being abandoned immediately, resulting in a payment stuck in state in_flight.

Fixes #4319 