### PR TITLE
invoices: add explicit hodl invoice flag

### DIFF
--- a/contractcourt/channel_arbitrator.go
+++ b/contractcourt/channel_arbitrator.go
@@ -1457,8 +1457,7 @@ func (c *ChannelArbitrator) isPreimageAvailable(hash lntypes.Hash) (bool,
 		return false, err
 	}
 
-	preimageAvailable = invoice.Terms.PaymentPreimage !=
-		channeldb.UnknownPreimage
+	preimageAvailable = invoice.Terms.PaymentPreimage != nil
 
 	return preimageAvailable, nil
 }

--- a/htlcswitch/link_test.go
+++ b/htlcswitch/link_test.go
@@ -437,7 +437,9 @@ func TestChannelLinkCancelFullCommitment(t *testing.T) {
 
 	var wg sync.WaitGroup
 	for i := 0; i < count; i++ {
-		preimages[i] = lntypes.Preimage{byte(i >> 8), byte(i)}
+		// Deterministically generate preimages. Avoid the all-zeroes
+		// preimage because that will be rejected by the database.
+		preimages[i] = lntypes.Preimage{byte(i >> 8), byte(i), 1}
 
 		wg.Add(1)
 		go func(i int) {
@@ -2015,13 +2017,13 @@ func TestChannelLinkBandwidthConsistency(t *testing.T) {
 	// If we now send in a valid HTLC settle for the prior HTLC we added,
 	// then the bandwidth should remain unchanged as the remote party will
 	// gain additional channel balance.
-	err = bobChannel.SettleHTLC(invoice.Terms.PaymentPreimage, bobIndex, nil, nil, nil)
+	err = bobChannel.SettleHTLC(*invoice.Terms.PaymentPreimage, bobIndex, nil, nil, nil)
 	if err != nil {
 		t.Fatalf("unable to settle htlc: %v", err)
 	}
 	htlcSettle := &lnwire.UpdateFulfillHTLC{
 		ID:              0,
-		PaymentPreimage: invoice.Terms.PaymentPreimage,
+		PaymentPreimage: *invoice.Terms.PaymentPreimage,
 	}
 	aliceLink.HandleChannelUpdate(htlcSettle)
 	time.Sleep(time.Millisecond * 500)
@@ -2193,7 +2195,7 @@ func TestChannelLinkBandwidthConsistency(t *testing.T) {
 		outgoingHTLCID: addPkt.outgoingHTLCID,
 		htlc: &lnwire.UpdateFulfillHTLC{
 			ID:              0,
-			PaymentPreimage: invoice.Terms.PaymentPreimage,
+			PaymentPreimage: *invoice.Terms.PaymentPreimage,
 		},
 		obfuscator: NewMockObfuscator(),
 	}
@@ -3153,13 +3155,13 @@ func TestChannelLinkBandwidthChanReserve(t *testing.T) {
 	// If we now send in a valid HTLC settle for the prior HTLC we added,
 	// then the bandwidth should remain unchanged as the remote party will
 	// gain additional channel balance.
-	err = bobChannel.SettleHTLC(invoice.Terms.PaymentPreimage, bobIndex, nil, nil, nil)
+	err = bobChannel.SettleHTLC(*invoice.Terms.PaymentPreimage, bobIndex, nil, nil, nil)
 	if err != nil {
 		t.Fatalf("unable to settle htlc: %v", err)
 	}
 	htlcSettle := &lnwire.UpdateFulfillHTLC{
 		ID:              bobIndex,
-		PaymentPreimage: invoice.Terms.PaymentPreimage,
+		PaymentPreimage: *invoice.Terms.PaymentPreimage,
 	}
 	aliceLink.HandleChannelUpdate(htlcSettle)
 	time.Sleep(time.Millisecond * 500)
@@ -4730,7 +4732,7 @@ func testChannelLinkBatchPreimageWrite(t *testing.T, disconnect bool) {
 	for i, invoice := range invoices {
 		ctx.sendSettleBobToAlice(
 			uint64(i),
-			invoice.Terms.PaymentPreimage,
+			*invoice.Terms.PaymentPreimage,
 		)
 	}
 
@@ -5772,7 +5774,8 @@ func TestChannelLinkHoldInvoiceRestart(t *testing.T) {
 
 	// Convert into a hodl invoice and save the preimage for later.
 	preimage := invoice.Terms.PaymentPreimage
-	invoice.Terms.PaymentPreimage = channeldb.UnknownPreimage
+	invoice.Terms.PaymentPreimage = nil
+	invoice.HodlInvoice = true
 
 	// We must add the invoice to the registry, such that Alice
 	// expects this payment.
@@ -5814,7 +5817,10 @@ func TestChannelLinkHoldInvoiceRestart(t *testing.T) {
 	<-registry.settleChan
 
 	// Settle the invoice with the preimage.
-	registry.SettleHodlInvoice(preimage)
+	err = registry.SettleHodlInvoice(*preimage)
+	if err != nil {
+		t.Fatalf("settle hodl invoice: %v", err)
+	}
 
 	// Expect alice to send a settle and commitsig message to bob.
 	ctx.receiveSettleAliceToBob()
@@ -5957,10 +5963,12 @@ func TestChannelLinkRevocationWindowHodl(t *testing.T) {
 
 	// Convert into hodl invoices and save the preimages for later.
 	preimage1 := invoice1.Terms.PaymentPreimage
-	invoice1.Terms.PaymentPreimage = channeldb.UnknownPreimage
+	invoice1.Terms.PaymentPreimage = nil
+	invoice1.HodlInvoice = true
 
 	preimage2 := invoice2.Terms.PaymentPreimage
-	invoice2.Terms.PaymentPreimage = channeldb.UnknownPreimage
+	invoice2.Terms.PaymentPreimage = nil
+	invoice2.HodlInvoice = true
 
 	// We must add the invoices to the registry, such that Alice
 	// expects the payments.
@@ -6009,7 +6017,10 @@ func TestChannelLinkRevocationWindowHodl(t *testing.T) {
 	}
 
 	// Settle invoice 1 with the preimage.
-	registry.SettleHodlInvoice(preimage1)
+	err = registry.SettleHodlInvoice(*preimage1)
+	if err != nil {
+		t.Fatalf("settle hodl invoice: %v", err)
+	}
 
 	// Expect alice to send a settle and commitsig message to bob. Bob does
 	// not yet send the revocation.
@@ -6017,7 +6028,10 @@ func TestChannelLinkRevocationWindowHodl(t *testing.T) {
 	ctx.receiveCommitSigAliceToBob(1)
 
 	// Settle invoice 2 with the preimage.
-	registry.SettleHodlInvoice(preimage2)
+	err = registry.SettleHodlInvoice(*preimage2)
+	if err != nil {
+		t.Fatalf("settle hodl invoice: %v", err)
+	}
 
 	// Expect alice to send a settle for htlc 2.
 	ctx.receiveSettleAliceToBob()

--- a/invoices/invoiceregistry.go
+++ b/invoices/invoiceregistry.go
@@ -652,12 +652,6 @@ func (i *InvoiceRegistry) processKeySend(ctx invoiceUpdateCtx) error {
 		return errors.New("invalid keysend preimage")
 	}
 
-	// Don't accept zero preimages as those have a special meaning in our
-	// database for hodl invoices.
-	if preimage == channeldb.UnknownPreimage {
-		return errors.New("invalid keysend preimage")
-	}
-
 	// Only allow keysend for non-mpp payments.
 	if ctx.mpp != nil {
 		return errors.New("no mpp keysend supported")
@@ -688,7 +682,7 @@ func (i *InvoiceRegistry) processKeySend(ctx invoiceUpdateCtx) error {
 		Terms: channeldb.ContractTerm{
 			FinalCltvDelta:  finalCltvDelta,
 			Value:           amt,
-			PaymentPreimage: preimage,
+			PaymentPreimage: &preimage,
 			Features:        features,
 		},
 	}
@@ -948,7 +942,7 @@ func (i *InvoiceRegistry) SettleHodlInvoice(preimage lntypes.Preimage) error {
 		return &channeldb.InvoiceUpdateDesc{
 			State: &channeldb.InvoiceStateUpdateDesc{
 				NewState: channeldb.ContractSettled,
-				Preimage: preimage,
+				Preimage: &preimage,
 			},
 		}, nil
 	}

--- a/invoices/test_utils_test.go
+++ b/invoices/test_utils_test.go
@@ -92,7 +92,7 @@ var (
 	testInvoiceAmt = lnwire.MilliSatoshi(100000)
 	testInvoice    = &channeldb.Invoice{
 		Terms: channeldb.ContractTerm{
-			PaymentPreimage: testInvoicePreimage,
+			PaymentPreimage: &testInvoicePreimage,
 			Value:           testInvoiceAmt,
 			Expiry:          time.Hour,
 			Features:        testFeatures,
@@ -102,12 +102,12 @@ var (
 
 	testHodlInvoice = &channeldb.Invoice{
 		Terms: channeldb.ContractTerm{
-			PaymentPreimage: channeldb.UnknownPreimage,
-			Value:           testInvoiceAmt,
-			Expiry:          time.Hour,
-			Features:        testFeatures,
+			Value:    testInvoiceAmt,
+			Expiry:   time.Hour,
+			Features: testFeatures,
 		},
 		CreationDate: testInvoiceCreationDate,
+		HodlInvoice:  true,
 	}
 )
 
@@ -225,7 +225,7 @@ func newTestInvoice(t *testing.T, preimage lntypes.Preimage,
 
 	return &channeldb.Invoice{
 		Terms: channeldb.ContractTerm{
-			PaymentPreimage: preimage,
+			PaymentPreimage: &preimage,
 			PaymentAddr:     payAddr,
 			Value:           testInvoiceAmount,
 			Expiry:          expiry,

--- a/invoices/update.go
+++ b/invoices/update.go
@@ -81,7 +81,7 @@ func updateInvoice(ctx *invoiceUpdateCtx, inv *channeldb.Invoice) (
 
 		case channeldb.HtlcStateSettled:
 			return nil, ctx.settleRes(
-				inv.Terms.PaymentPreimage,
+				*inv.Terms.PaymentPreimage,
 				ResultReplayToSettled,
 			), nil
 
@@ -187,8 +187,7 @@ func updateMpp(ctx *invoiceUpdateCtx,
 
 	// Check to see if we can settle or this is an hold invoice and
 	// we need to wait for the preimage.
-	holdInvoice := inv.Terms.PaymentPreimage == channeldb.UnknownPreimage
-	if holdInvoice {
+	if inv.HodlInvoice {
 		update.State = &channeldb.InvoiceStateUpdateDesc{
 			NewState: channeldb.ContractAccepted,
 		}
@@ -201,7 +200,7 @@ func updateMpp(ctx *invoiceUpdateCtx,
 	}
 
 	return &update, ctx.settleRes(
-		inv.Terms.PaymentPreimage, ResultSettled,
+		*inv.Terms.PaymentPreimage, ResultSettled,
 	), nil
 }
 
@@ -269,14 +268,13 @@ func updateLegacy(ctx *invoiceUpdateCtx,
 
 	case channeldb.ContractSettled:
 		return &update, ctx.settleRes(
-			inv.Terms.PaymentPreimage, ResultDuplicateToSettled,
+			*inv.Terms.PaymentPreimage, ResultDuplicateToSettled,
 		), nil
 	}
 
 	// Check to see if we can settle or this is an hold invoice and we need
 	// to wait for the preimage.
-	holdInvoice := inv.Terms.PaymentPreimage == channeldb.UnknownPreimage
-	if holdInvoice {
+	if inv.HodlInvoice {
 		update.State = &channeldb.InvoiceStateUpdateDesc{
 			NewState: channeldb.ContractAccepted,
 		}
@@ -290,6 +288,6 @@ func updateLegacy(ctx *invoiceUpdateCtx,
 	}
 
 	return &update, ctx.settleRes(
-		inv.Terms.PaymentPreimage, ResultSettled,
+		*inv.Terms.PaymentPreimage, ResultSettled,
 	), nil
 }

--- a/lnrpc/invoicesrpc/invoices_server.go
+++ b/lnrpc/invoicesrpc/invoices_server.go
@@ -274,6 +274,8 @@ func (s *Server) AddHoldInvoice(ctx context.Context,
 		FallbackAddr:    invoice.FallbackAddr,
 		CltvExpiry:      invoice.CltvExpiry,
 		Private:         invoice.Private,
+		HodlInvoice:     true,
+		Preimage:        nil,
 	}
 
 	_, dbInvoice, err := AddInvoice(ctx, addInvoiceCfg, addInvoiceData)

--- a/lnrpc/invoicesrpc/utils.go
+++ b/lnrpc/invoicesrpc/utils.go
@@ -22,7 +22,7 @@ func decodePayReq(invoice *channeldb.Invoice,
 	paymentRequest := string(invoice.PaymentRequest)
 	if paymentRequest == "" {
 		preimage := invoice.Terms.PaymentPreimage
-		if preimage == channeldb.UnknownPreimage {
+		if preimage == nil {
 			return nil, errors.New("cannot reconstruct pay req")
 		}
 		hash := [32]byte(preimage.Hash())
@@ -149,7 +149,7 @@ func CreateRPCInvoice(invoice *channeldb.Invoice,
 		IsKeysend:       len(invoice.PaymentRequest) == 0,
 	}
 
-	if preimage != channeldb.UnknownPreimage {
+	if preimage != nil {
 		rpcInvoice.RPreimage = preimage[:]
 	}
 


### PR DESCRIPTION
Previously it wasn't possible to store a preimage in the invoice database and signal that a payment should not be settled right away. The only way to hold a payment was to insert the magic `UnknownPreimage` value in the invoice database. This commit introduces a distinct flag to
signal that an invoice is a hold invoice and thereby allows the preimage to be present in the database already.

Preparation for (key send) hodl invoices for which we already know the preimage.

This PR is a spin-off of #4167 