### PR TITLE
Ability to configure neutrino useragent

### DIFF
--- a/chainregistry.go
+++ b/chainregistry.go
@@ -785,6 +785,7 @@ func initNeutrinoBackend(cfg *Config, chainDir string) (*neutrino.ChainService,
 
 	neutrino.MaxPeers = 8
 	neutrino.BanDuration = time.Hour * 48
+	neutrino.UserAgentName = cfg.NeutrinoMode.UserAgentName
 
 	neutrinoCS, err := neutrino.NewChainService(config)
 	if err != nil {

--- a/chainregistry.go
+++ b/chainregistry.go
@@ -786,6 +786,7 @@ func initNeutrinoBackend(cfg *Config, chainDir string) (*neutrino.ChainService,
 	neutrino.MaxPeers = 8
 	neutrino.BanDuration = time.Hour * 48
 	neutrino.UserAgentName = cfg.NeutrinoMode.UserAgentName
+	neutrino.UserAgentVersion = cfg.NeutrinoMode.UserAgentVersion
 
 	neutrinoCS, err := neutrino.NewChainService(config)
 	if err != nil {

--- a/config.go
+++ b/config.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/btcsuite/btcutil"
 	flags "github.com/jessevdk/go-flags"
+	"github.com/lightninglabs/neutrino"
 	"github.com/lightningnetwork/lnd/autopilot"
 	"github.com/lightningnetwork/lnd/build"
 	"github.com/lightningnetwork/lnd/chanbackup"
@@ -312,6 +313,10 @@ func DefaultConfig() Config {
 			Dir:          defaultLitecoindDir,
 			RPCHost:      defaultRPCHost,
 			EstimateMode: defaultBitcoindEstimateMode,
+		},
+		NeutrinoMode: &lncfg.Neutrino{
+			UserAgentName:    neutrino.UserAgentName,
+			UserAgentVersion: neutrino.UserAgentVersion,
 		},
 		UnsafeDisconnect:   true,
 		MaxPendingChannels: lncfg.DefaultMaxPendingChannels,

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -197,6 +197,7 @@ neutrino:
       --neutrino.maxpeers=                                    Max number of inbound and outbound peers
       --neutrino.banduration=                                 How long to ban misbehaving peers.  Valid time units are {s, m, h}.  Minimum 1 second
       --neutrino.banthreshold=                                Maximum allowed ban score before disconnecting and banning misbehaving peers.
+      --neutrino.useragentname=                               Used to help identify ourselves to other bitcoin peers.
 ```
 
 ## Bitcoind Options

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -198,6 +198,7 @@ neutrino:
       --neutrino.banduration=                                 How long to ban misbehaving peers.  Valid time units are {s, m, h}.  Minimum 1 second
       --neutrino.banthreshold=                                Maximum allowed ban score before disconnecting and banning misbehaving peers.
       --neutrino.useragentname=                               Used to help identify ourselves to other bitcoin peers.
+      --neutrino.useragentversion=                            Used to help identify ourselves to other bitcoin peers.
 ```
 
 ## Bitcoind Options

--- a/lncfg/neutrino.go
+++ b/lncfg/neutrino.go
@@ -12,4 +12,5 @@ type Neutrino struct {
 	BanThreshold       uint32        `long:"banthreshold" description:"Maximum allowed ban score before disconnecting and banning misbehaving peers."`
 	FeeURL             string        `long:"feeurl" description:"Optional URL for fee estimation. If a URL is not specified, static fees will be used for estimation."`
 	AssertFilterHeader string        `long:"assertfilterheader" description:"Optional filter header in height:hash format to assert the state of neutrino's filter header chain on startup. If the assertion does not hold, then the filter header chain will be re-synced from the genesis block."`
+	UserAgentName      string        `long:"useragentname" description:"Used to help identify ourselves to other bitcoin peers"`
 }

--- a/lncfg/neutrino.go
+++ b/lncfg/neutrino.go
@@ -13,4 +13,5 @@ type Neutrino struct {
 	FeeURL             string        `long:"feeurl" description:"Optional URL for fee estimation. If a URL is not specified, static fees will be used for estimation."`
 	AssertFilterHeader string        `long:"assertfilterheader" description:"Optional filter header in height:hash format to assert the state of neutrino's filter header chain on startup. If the assertion does not hold, then the filter header chain will be re-synced from the genesis block."`
 	UserAgentName      string        `long:"useragentname" description:"Used to help identify ourselves to other bitcoin peers"`
+	UserAgentVersion   string        `long:"useragentversion" description:"Used to help identify ourselves to other bitcoin peers"`
 }


### PR DESCRIPTION
This PR adds the ability to alter the neutrino useragent string so that neutrino clients can identify themselves as they please.

It exposes the neutrino `UserAgentVersion` and `UserAgentName` config options which can be set by starting lnd with the `--neutrino.useragentversion=` and `--neutrino.useragentname=` flags.

This enables btcd nodes to better identify connecting clients. For example, it could be used in conjunction with [btcd's `agentblacklist` and `agentwhitelist` settings]( https://github.com/btcsuite/btcd/pull/1418) to ensure that only clients that identify themselves in a specific way are allowed to connect.