### PR TITLE
signrpc: parse both KeyDescriptor fields for SignOutputRaw requests

### DIFF
--- a/lnrpc/signrpc/signer.pb.go
+++ b/lnrpc/signrpc/signer.pb.go
@@ -180,6 +180,10 @@ type SignDescriptor struct {
 	//A descriptor that precisely describes *which* key to use for signing. This
 	//may provide the raw public key directly, or require the Signer to re-derive
 	//the key according to the populated derivation path.
+	//
+	//Note that if the key descriptor was obtained through walletrpc.DeriveKey,
+	//then the key locator MUST always be provided, since the derived keys are not
+	//persisted unlike with DeriveNextKey.
 	KeyDesc *KeyDescriptor `protobuf:"bytes,1,opt,name=key_desc,json=keyDesc,proto3" json:"key_desc,omitempty"`
 	//
 	//A scalar value that will be added to the private key corresponding to the

--- a/lnrpc/signrpc/signer.proto
+++ b/lnrpc/signrpc/signer.proto
@@ -98,6 +98,10 @@ message SignDescriptor {
     A descriptor that precisely describes *which* key to use for signing. This
     may provide the raw public key directly, or require the Signer to re-derive
     the key according to the populated derivation path.
+
+    Note that if the key descriptor was obtained through walletrpc.DeriveKey,
+    then the key locator MUST always be provided, since the derived keys are not
+    persisted unlike with DeriveNextKey.
     */
     KeyDescriptor key_desc = 1;
 

--- a/lnrpc/signrpc/signer.swagger.json
+++ b/lnrpc/signrpc/signer.swagger.json
@@ -303,7 +303,7 @@
       "properties": {
         "key_desc": {
           "$ref": "#/definitions/signrpcKeyDescriptor",
-          "description": "A descriptor that precisely describes *which* key to use for signing. This\nmay provide the raw public key directly, or require the Signer to re-derive\nthe key according to the populated derivation path."
+          "description": "A descriptor that precisely describes *which* key to use for signing. This\nmay provide the raw public key directly, or require the Signer to re-derive\nthe key according to the populated derivation path.\n\nNote that if the key descriptor was obtained through walletrpc.DeriveKey,\nthen the key locator MUST always be provided, since the derived keys are not\npersisted unlike with DeriveNextKey."
         },
         "single_tweak": {
           "type": "string",


### PR DESCRIPTION
This is meant to handle a quirk in which key descriptors obtained through walletrpc.DeriveKey don't result in the derived key being persisted to the wallet's database, unlike with DeriveNextKey. Due to this and some fallback logic in the wallet with regards to empty key locators, if a request only specified the compressed public key, the signature returned would be over a different key, namely the one derived from (family=0, index=0).