### PR TITLE
contractcourt: add ChannelStatus in MarkChannelClosed

### DIFF
--- a/contractcourt/channel_arbitrator.go
+++ b/contractcourt/channel_arbitrator.go
@@ -2153,6 +2153,7 @@ func (c *ChannelArbitrator) channelAttendant(bestHeight int32) {
 
 			err := c.cfg.MarkChannelClosed(
 				closeInfo.ChannelCloseSummary,
+				channeldb.ChanStatusCoopBroadcasted,
 			)
 			if err != nil {
 				log.Errorf("Unable to mark channel closed: "+
@@ -2223,6 +2224,7 @@ func (c *ChannelArbitrator) channelAttendant(bestHeight int32) {
 			// close status of the channel.
 			err = c.cfg.MarkChannelClosed(
 				closeInfo.ChannelCloseSummary,
+				channeldb.ChanStatusLocalCloseInitiator,
 			)
 			if err != nil {
 				log.Errorf("Unable to mark "+


### PR DESCRIPTION
looks like there are two places missing `ChannelStatus` when calling `MarkChannelClosed`, while [this call](https://github.com/lightningnetwork/lnd/blob/master/contractcourt/channel_arbitrator.go#L2292) did use one.