### PR TITLE
channeldb: remove graph insertion of restored channels

### DIFF
--- a/channeldb/db_test.go
+++ b/channeldb/db_test.go
@@ -365,19 +365,6 @@ func TestRestoreChannelShells(t *testing.T) {
 		t.Fatalf("unable to gen channel shell: %v", err)
 	}
 
-	graph := cdb.ChannelGraph()
-
-	// Before we can restore the channel, we'll need to make a source node
-	// in the graph as the channel edge we create will need to have a
-	// origin.
-	testNode, err := createTestVertex(cdb)
-	if err != nil {
-		t.Fatalf("unable to create test node: %v", err)
-	}
-	if err := graph.SetSourceNode(testNode); err != nil {
-		t.Fatalf("unable to set source node: %v", err)
-	}
-
 	// With the channel shell constructed, we'll now insert it into the
 	// database with the restoration method.
 	if err := cdb.RestoreChannelShells(channelShell); err != nil {
@@ -448,25 +435,6 @@ func TestRestoreChannelShells(t *testing.T) {
 	if reflect.DeepEqual(linkNode.Addresses, channelShell.NodeAddrs) {
 		t.Fatalf("addr mismach: expected %v, got %v",
 			linkNode.Addresses, channelShell.NodeAddrs)
-	}
-
-	// Finally, we'll ensure that the edge for the channel was properly
-	// inserted.
-	chanInfos, err := graph.FetchChanInfos(
-		[]uint64{channelShell.Chan.ShortChannelID.ToUint64()},
-	)
-	if err != nil {
-		t.Fatalf("unable to find edges: %v", err)
-	}
-
-	if len(chanInfos) != 1 {
-		t.Fatalf("wrong amount of chan infos: expected %v got %v",
-			len(chanInfos), 1)
-	}
-
-	// We should only find a single edge.
-	if chanInfos[0].Policy1 != nil && chanInfos[0].Policy2 != nil {
-		t.Fatalf("only a single edge should be inserted: %v", err)
 	}
 }
 

--- a/lntest/itest/log_error_whitelist.txt
+++ b/lntest/itest/log_error_whitelist.txt
@@ -70,6 +70,7 @@
 <time> [ERR] FNDG: Unable to send node announcement: gossiper is shutting down
 <time> [ERR] FNDG: Unable to send node announcement: router shutting down
 <time> [ERR] HSWC: AmountBelowMinimum(amt=<amt>, update=(lnwire.ChannelUpdate) {
+<time> [ERR] HSWC: ChannelLink(<chan>): failing link: ChannelPoint(<chan_point>): received error from peer: chan_id=<hex>, err=sync error with error: remote error
 <time> [ERR] HSWC: ChannelLink(<chan>): failing link: ChannelPoint(<chan_point>): received error from peer: chan_id=<hex>, err=invalid update with error: remote error
 <time> [ERR] HSWC: ChannelLink(<chan>): failing link: unable to handle upstream settle HTLC: Invalid payment preimage <hex> for hash <hex> with error: invalid update
 <time> [ERR] HSWC: ChannelLink(<chan>): failing link: unable to synchronize channel states: ChannelPoint(<chan_point>) with CommitPoint(<hex>) had possible local commitment state data loss with error: unable to resume channel, recovery required


### PR DESCRIPTION
This was initially done as there were a few assertions throughout the codebase requiring a channel's policy to be known. Now that these have been addressed, we no longer need to store restored channels in the graph, as their policies where incomplete anyway.