### PR TITLE
build: add all subservers to dev build with an optional with-rpc build param

### DIFF
--- a/make/testing_flags.mk
+++ b/make/testing_flags.mk
@@ -1,7 +1,13 @@
 DEV_TAGS = dev
+RPC_TAGS = autopilotrpc chainrpc invoicesrpc routerrpc signrpc verrpc walletrpc watchtowerrpc wtclientrpc
 LOG_TAGS =
 TEST_FLAGS =
 COVER_PKG = $$(go list -deps ./... | grep '$(PKG)' | grep -v lnrpc)
+
+# If rpc option is set also add all extra RPC tags to DEV_TAGS
+ifneq ($(with-rpc),)
+DEV_TAGS += $(RPC_TAGS)
+endif
 
 # If specific package is being unit tested, construct the full name of the
 # subpackage.
@@ -61,6 +67,6 @@ backend = btcd
 endif
 
 # Construct the integration test command with the added build flags.
-ITEST_TAGS := $(DEV_TAGS) rpctest chainrpc walletrpc signrpc invoicesrpc autopilotrpc watchtowerrpc $(backend)
+ITEST_TAGS := $(DEV_TAGS) $(RPC_TAGS) rpctest $(backend)
 
 ITEST := rm lntest/itest/*.log; date; $(GOTEST) -v ./lntest/itest -tags="$(ITEST_TAGS)" $(TEST_FLAGS) -logoutput -goroutinedump


### PR DESCRIPTION
This PR enables having a dev build with all subservers with an optional `with-rpc=1` build param.