### PR TITLE
lnwire: fix decoding for initial zero sid

### DIFF
--- a/lnwire/query_short_chan_ids.go
+++ b/lnwire/query_short_chan_ids.go
@@ -184,8 +184,13 @@ func decodeShortChanIDs(r io.Reader) (ShortChanIDEncoding, []ShortChannelID, err
 					"short chan ID: %v", err)
 			}
 
+			// We'll ensure that this short chan ID is greater than
+			// the last one. This is a requirement within the
+			// encoding, and if violated can aide us in detecting
+			// malicious payloads. This can only be true starting
+			// at the second chanID.
 			cid := shortChanIDs[i]
-			if cid.ToUint64() <= lastChanID.ToUint64() {
+			if i > 0 && cid.ToUint64() <= lastChanID.ToUint64() {
 				return 0, nil, ErrUnsortedSIDs{lastChanID, cid}
 			}
 			lastChanID = cid
@@ -224,6 +229,7 @@ func decodeShortChanIDs(r io.Reader) (ShortChanIDEncoding, []ShortChannelID, err
 		var (
 			shortChanIDs []ShortChannelID
 			lastChanID   ShortChannelID
+			i            int
 		)
 		for {
 			// We'll now attempt to read the next short channel ID
@@ -255,12 +261,14 @@ func decodeShortChanIDs(r io.Reader) (ShortChanIDEncoding, []ShortChannelID, err
 			// Finally, we'll ensure that this short chan ID is
 			// greater than the last one. This is a requirement
 			// within the encoding, and if violated can aide us in
-			// detecting malicious payloads.
-			if cid.ToUint64() <= lastChanID.ToUint64() {
+			// detecting malicious payloads. This can only be true
+			// starting at the second chanID.
+			if i > 0 && cid.ToUint64() <= lastChanID.ToUint64() {
 				return 0, nil, ErrUnsortedSIDs{lastChanID, cid}
 			}
 
 			lastChanID = cid
+			i++
 		}
 
 	default:


### PR DESCRIPTION
This fixes a decoding error when the list of short channel ids within a
QueryShortChanIDs message started with a zero sid.

BOLT-0007 specifies that lists of short channel ids should be sorted in
ascending order. Previously, this was checked within lnwire by comparing
two consecutive sids in the list, starting at the empty (zero) sid.

This meant that a list that started with a zero sid couldn't be decoded
since the first element would _not_ be greater than the last one
(namely: also zero).

Given that one can only check for ordering starting at the second
element, we add a check to ensure the proper behavior.

A unit test is also added to ensure no future regressions on this
behavior.

Extracted from #4346 