### PR TITLE
discovery: prevent endBlock overflow in replyChanRangeQuery

### DIFF
--- a/discovery/syncer.go
+++ b/discovery/syncer.go
@@ -918,7 +918,7 @@ func (g *GossipSyncer) replyChanRangeQuery(query *lnwire.QueryChannelRange) erro
 	// Next, we'll consult the time series to obtain the set of known
 	// channel ID's that match their query.
 	startBlock := query.FirstBlockHeight
-	endBlock := startBlock + query.NumBlocks - 1
+	endBlock := query.LastBlockHeight()
 	channelRange, err := g.cfg.channelSeries.FilterChannelRange(
 		query.ChainHash, startBlock, endBlock,
 	)


### PR DESCRIPTION
One line change to `syncer.replyChanRangeQuery` to ensure endBlock calculation doesn't overflow.  Adds a test that performs multiple queries to ensure the correct start / end block values are supplied to the channel graph filter.

Fixes #4393 
