### PR TITLE
itests: option to run our integration tests on etcd + boltdb (remote/local)

### DIFF
--- a/channeldb/kvdb/config.go
+++ b/channeldb/kvdb/config.go
@@ -30,6 +30,8 @@ type BoltConfig struct {
 
 // EtcdConfig holds etcd configuration.
 type EtcdConfig struct {
+	Embedded bool `long:"embedded" description:"Use embedded etcd instance instead of the external one."`
+
 	Host string `long:"host" description:"Etcd database host."`
 
 	User string `long:"user" description:"Etcd database user."`

--- a/lncfg/db.go
+++ b/lncfg/db.go
@@ -38,7 +38,7 @@ func (db *DB) Validate() error {
 	case BoltBackend:
 
 	case EtcdBackend:
-		if db.Etcd.Host == "" {
+		if !db.Etcd.Embedded && db.Etcd.Host == "" {
 			return fmt.Errorf("etcd host must be set")
 		}
 
@@ -76,8 +76,12 @@ func (db *DB) GetBackends(ctx context.Context, dbPath string,
 	)
 
 	if db.Backend == EtcdBackend {
-		// Prefix will separate key/values in the db.
-		remoteDB, err = kvdb.GetEtcdBackend(ctx, networkName, db.Etcd)
+		if db.Etcd.Embedded {
+			remoteDB, _, err = kvdb.GetEtcdTestBackend(dbPath, dbName)
+		} else {
+			// Prefix will separate key/values in the db.
+			remoteDB, err = kvdb.GetEtcdBackend(ctx, networkName, db.Etcd)
+		}
 		if err != nil {
 			return nil, err
 		}

--- a/lntest/harness.go
+++ b/lntest/harness.go
@@ -60,6 +60,10 @@ type NetworkHarness struct {
 	Alice *HarnessNode
 	Bob   *HarnessNode
 
+	// useEtcd is set to true if new nodes are to be created with an
+	// embedded etcd backend instead of just bbolt.
+	useEtcd bool
+
 	// Channel for transmitting stderr output from failed lightning node
 	// to main process.
 	lndErrorChan chan error
@@ -77,8 +81,8 @@ type NetworkHarness struct {
 // TODO(roasbeef): add option to use golang's build library to a binary of the
 // current repo. This will save developers from having to manually `go install`
 // within the repo each time before changes
-func NewNetworkHarness(r *rpctest.Harness, b BackendConfig, lndBinary string) (
-	*NetworkHarness, error) {
+func NewNetworkHarness(r *rpctest.Harness, b BackendConfig, lndBinary string,
+	useEtcd bool) (*NetworkHarness, error) {
 
 	feeService := startFeeService()
 
@@ -92,6 +96,7 @@ func NewNetworkHarness(r *rpctest.Harness, b BackendConfig, lndBinary string) (
 		feeService:   feeService,
 		quit:         make(chan struct{}),
 		lndBinary:    lndBinary,
+		useEtcd:      useEtcd,
 	}
 	return &n, nil
 }
@@ -376,6 +381,7 @@ func (n *NetworkHarness) newNode(name string, extraArgs []string, hasSeed bool,
 		NetParams:         n.netParams,
 		ExtraArgs:         extraArgs,
 		FeeURL:            n.feeService.url,
+		Etcd:              n.useEtcd,
 	})
 	if err != nil {
 		return nil, err

--- a/lntest/itest/lnd_test.go
+++ b/lntest/itest/lnd_test.go
@@ -81,6 +81,9 @@ var (
 		"runtranche", defaultRunTranche, "run the tranche of the "+
 			"split test cases with the given (0-based) index",
 	)
+
+	// useEtcd test LND nodes use (embedded) etcd as remote db.
+	useEtcd = flag.Bool("etcd", false, "Use etcd backend for lnd.")
 )
 
 // getTestCaseSplitTranche returns the sub slice of the test cases that should
@@ -14250,7 +14253,9 @@ func TestLightningNetworkDaemon(t *testing.T) {
 	// Now we can set up our test harness (LND instance), with the chain
 	// backend we just created.
 	binary := ht.getLndBinary()
-	lndHarness, err = lntest.NewNetworkHarness(miner, chainBackend, binary)
+	lndHarness, err = lntest.NewNetworkHarness(
+		miner, chainBackend, binary, *useEtcd,
+	)
 	if err != nil {
 		ht.Fatalf("unable to create lightning network harness: %v", err)
 	}

--- a/lntest/itest/lnd_test.go
+++ b/lntest/itest/lnd_test.go
@@ -11604,10 +11604,7 @@ func testSwitchOfflineDelivery(net *lntest.NetworkHarness, t *harnessTest) {
 	var predErr error
 	err = wait.Predicate(func() bool {
 		predErr = assertNumActiveHtlcs(nodes, numPayments)
-		if predErr != nil {
-			return false
-		}
-		return true
+		return predErr == nil
 	}, time.Second*15)
 	if err != nil {
 		t.Fatalf("htlc mismatch: %v", predErr)

--- a/lntest/itest/lnd_test.go
+++ b/lntest/itest/lnd_test.go
@@ -12,7 +12,6 @@ import (
 	"io/ioutil"
 	"math"
 	"os"
-	"path/filepath"
 	"reflect"
 	"strings"
 	"sync"
@@ -8241,13 +8240,12 @@ func testRevokedCloseRetribution(net *lntest.NetworkHarness, t *harnessTest) {
 	if err != nil {
 		t.Fatalf("unable to create temp db folder: %v", err)
 	}
-	bobTempDbFile := filepath.Join(bobTempDbPath, "channel.db")
 	defer os.Remove(bobTempDbPath)
 
 	// With the temporary file created, copy Bob's current state into the
 	// temporary file we created above. Later after more updates, we'll
 	// restore this state.
-	if err := lntest.CopyFile(bobTempDbFile, net.Bob.DBPath()); err != nil {
+	if err := lntest.CopyAll(bobTempDbPath, net.Bob.DBDir()); err != nil {
 		t.Fatalf("unable to copy database files: %v", err)
 	}
 
@@ -8273,7 +8271,7 @@ func testRevokedCloseRetribution(net *lntest.NetworkHarness, t *harnessTest) {
 	// state. With this, we essentially force Bob to travel back in time
 	// within the channel's history.
 	if err = net.RestartNode(net.Bob, func() error {
-		return os.Rename(bobTempDbFile, net.Bob.DBPath())
+		return lntest.CopyAll(net.Bob.DBDir(), bobTempDbPath)
 	}); err != nil {
 		t.Fatalf("unable to restart node: %v", err)
 	}
@@ -8496,13 +8494,12 @@ func testRevokedCloseRetributionZeroValueRemoteOutput(net *lntest.NetworkHarness
 	if err != nil {
 		t.Fatalf("unable to create temp db folder: %v", err)
 	}
-	carolTempDbFile := filepath.Join(carolTempDbPath, "channel.db")
 	defer os.Remove(carolTempDbPath)
 
 	// With the temporary file created, copy Carol's current state into the
 	// temporary file we created above. Later after more updates, we'll
 	// restore this state.
-	if err := lntest.CopyFile(carolTempDbFile, carol.DBPath()); err != nil {
+	if err := lntest.CopyAll(carolTempDbPath, carol.DBDir()); err != nil {
 		t.Fatalf("unable to copy database files: %v", err)
 	}
 
@@ -8527,7 +8524,7 @@ func testRevokedCloseRetributionZeroValueRemoteOutput(net *lntest.NetworkHarness
 	// state. With this, we essentially force Carol to travel back in time
 	// within the channel's history.
 	if err = net.RestartNode(carol, func() error {
-		return os.Rename(carolTempDbFile, carol.DBPath())
+		return lntest.CopyAll(carol.DBDir(), carolTempDbPath)
 	}); err != nil {
 		t.Fatalf("unable to restart node: %v", err)
 	}
@@ -8820,13 +8817,12 @@ func testRevokedCloseRetributionRemoteHodl(net *lntest.NetworkHarness,
 	if err != nil {
 		t.Fatalf("unable to create temp db folder: %v", err)
 	}
-	carolTempDbFile := filepath.Join(carolTempDbPath, "channel.db")
 	defer os.Remove(carolTempDbPath)
 
 	// With the temporary file created, copy Carol's current state into the
 	// temporary file we created above. Later after more updates, we'll
 	// restore this state.
-	if err := lntest.CopyFile(carolTempDbFile, carol.DBPath()); err != nil {
+	if err := lntest.CopyAll(carolTempDbPath, carol.DBDir()); err != nil {
 		t.Fatalf("unable to copy database files: %v", err)
 	}
 
@@ -8860,7 +8856,7 @@ func testRevokedCloseRetributionRemoteHodl(net *lntest.NetworkHarness,
 	// state. With this, we essentially force Carol to travel back in time
 	// within the channel's history.
 	if err = net.RestartNode(carol, func() error {
-		return os.Rename(carolTempDbFile, carol.DBPath())
+		return lntest.CopyAll(carol.DBDir(), carolTempDbPath)
 	}); err != nil {
 		t.Fatalf("unable to restart node: %v", err)
 	}
@@ -9222,13 +9218,12 @@ func testRevokedCloseRetributionAltruistWatchtower(net *lntest.NetworkHarness,
 	if err != nil {
 		t.Fatalf("unable to create temp db folder: %v", err)
 	}
-	carolTempDbFile := filepath.Join(carolTempDbPath, "channel.db")
 	defer os.Remove(carolTempDbPath)
 
 	// With the temporary file created, copy Carol's current state into the
 	// temporary file we created above. Later after more updates, we'll
 	// restore this state.
-	if err := lntest.CopyFile(carolTempDbFile, carol.DBPath()); err != nil {
+	if err := lntest.CopyAll(carolTempDbPath, carol.DBDir()); err != nil {
 		t.Fatalf("unable to copy database files: %v", err)
 	}
 
@@ -9285,7 +9280,7 @@ func testRevokedCloseRetributionAltruistWatchtower(net *lntest.NetworkHarness,
 	// state. With this, we essentially force Carol to travel back in time
 	// within the channel's history.
 	if err = net.RestartNode(carol, func() error {
-		return os.Rename(carolTempDbFile, carol.DBPath())
+		return lntest.CopyAll(carol.DBDir(), carolTempDbPath)
 	}); err != nil {
 		t.Fatalf("unable to restart node: %v", err)
 	}
@@ -9769,13 +9764,12 @@ func testDataLossProtection(net *lntest.NetworkHarness, t *harnessTest) {
 		if err != nil {
 			t.Fatalf("unable to create temp db folder: %v", err)
 		}
-		tempDbFile := filepath.Join(tempDbPath, "channel.db")
 		defer os.Remove(tempDbPath)
 
 		// With the temporary file created, copy the current state into
 		// the temporary file we created above. Later after more
 		// updates, we'll restore this state.
-		if err := lntest.CopyFile(tempDbFile, node.DBPath()); err != nil {
+		if err := lntest.CopyAll(tempDbPath, node.DBDir()); err != nil {
 			t.Fatalf("unable to copy database files: %v", err)
 		}
 
@@ -9802,7 +9796,7 @@ func testDataLossProtection(net *lntest.NetworkHarness, t *harnessTest) {
 		// force the node to travel back in time within the channel's
 		// history.
 		if err = net.RestartNode(node, func() error {
-			return os.Rename(tempDbFile, node.DBPath())
+			return lntest.CopyAll(node.DBDir(), tempDbPath)
 		}); err != nil {
 			t.Fatalf("unable to restart node: %v", err)
 		}

--- a/lntest/node.go
+++ b/lntest/node.go
@@ -199,9 +199,13 @@ func (cfg NodeConfig) RESTAddr() string {
 	return net.JoinHostPort("127.0.0.1", strconv.Itoa(cfg.RESTPort))
 }
 
+// DBDir returns the holding directory path of the graph database.
+func (cfg NodeConfig) DBDir() string {
+	return filepath.Join(cfg.DataDir, "graph", cfg.NetParams.Name)
+}
+
 func (cfg NodeConfig) DBPath() string {
-	return filepath.Join(cfg.DataDir, "graph",
-		fmt.Sprintf("%v/channel.db", cfg.NetParams.Name))
+	return filepath.Join(cfg.DBDir(), "channel.db")
 }
 
 func (cfg NodeConfig) ChanBackupPath() string {
@@ -438,6 +442,11 @@ func NewMiner(logDir, logFilename string, netParams *chaincfg.Params,
 // DBPath returns the filepath to the channeldb database file for this node.
 func (hn *HarnessNode) DBPath() string {
 	return hn.Cfg.DBPath()
+}
+
+// DBDir returns the path for the directory holding channeldb file(s).
+func (hn *HarnessNode) DBDir() string {
+	return hn.Cfg.DBDir()
 }
 
 // Name returns the name of this node set during initialization.

--- a/lntest/node.go
+++ b/lntest/node.go
@@ -183,6 +183,8 @@ type NodeConfig struct {
 	AcceptKeySend bool
 
 	FeeURL string
+
+	Etcd bool
 }
 
 func (cfg NodeConfig) P2PAddr() string {
@@ -259,6 +261,11 @@ func (cfg NodeConfig) genArgs() []string {
 
 	if cfg.AcceptKeySend {
 		args = append(args, "--accept-keysend")
+	}
+
+	if cfg.Etcd {
+		args = append(args, "--db.backend=etcd")
+		args = append(args, "--db.etcd.embedded")
 	}
 
 	if cfg.FeeURL != "" {

--- a/lntest/timeouts_etcd.go
+++ b/lntest/timeouts_etcd.go
@@ -1,4 +1,4 @@
-// +build !darwin, !kvdb_etcd
+// +build !darwin, kvdb_etcd
 
 package lntest
 
@@ -15,7 +15,7 @@ const (
 
 	// ChannelCloseTimeout is the max time we will wait before a channel is
 	// considered closed.
-	ChannelCloseTimeout = time.Second * 30
+	ChannelCloseTimeout = time.Second * 120
 
 	// DefaultTimeout is a timeout that will be used for various wait
 	// scenarios where no custom timeout value is defined.

--- a/make/testing_flags.mk
+++ b/make/testing_flags.mk
@@ -2,6 +2,7 @@ DEV_TAGS = dev
 RPC_TAGS = autopilotrpc chainrpc invoicesrpc routerrpc signrpc verrpc walletrpc watchtowerrpc wtclientrpc
 LOG_TAGS =
 TEST_FLAGS =
+ITEST_FLAGS = 
 COVER_PKG = $$(go list -deps ./... | grep '$(PKG)' | grep -v lnrpc)
 NUM_ITEST_TRANCHES = 6
 ITEST_PARALLELISM = $(NUM_ITEST_TRANCHES)
@@ -39,6 +40,12 @@ endif
 # Define the integration test.run filter if the icase argument was provided.
 ifneq ($(icase),)
 TEST_FLAGS += -test.run="TestLightningNetworkDaemon/.*-of-.*/.*/$(icase)"
+endif
+
+# Run itests with etcd backend.
+ifeq ($(etcd),1)
+ITEST_FLAGS += -etcd
+DEV_TAGS += kvdb_etcd
 endif
 
 ifneq ($(tags),)
@@ -89,4 +96,4 @@ endif
 # Construct the integration test command with the added build flags.
 ITEST_TAGS := $(DEV_TAGS) $(RPC_TAGS) rpctest $(backend)
 
-ITEST := rm lntest/itest/*.log; date; $(GOTEST) -v ./lntest/itest -tags="$(ITEST_TAGS)" $(TEST_FLAGS) -logoutput -goroutinedump
+ITEST := rm -f lntest/itest/*.log; date; $(GOTEST) -v ./lntest/itest -tags="$(ITEST_TAGS)" $(TEST_FLAGS) $(ITEST_FLAGS) -logoutput -goroutinedump

--- a/sample-lnd.conf
+++ b/sample-lnd.conf
@@ -952,6 +952,10 @@ litecoin.node=ltcd
 ; Whether to collect etcd commit stats.
 ; db.etcd.collect_stats=true
 
+; If set LND will use an embedded etcd instance instead of the external one.
+; Useful for testing.
+; db.etcd.embedded=false
+
 [bolt]
 ; If true, prevents the database from syncing its freelist to disk. 
 ; db.bolt.nofreelistsync=1


### PR DESCRIPTION
This PR adds `etcd` flag to the `itest` binary which controls whether new nodes created during tests should run on embedded etcd too. The flag is also added to the our makefile, such that running `make itest etcd=1` will run the integration tests with the `kvdb_etcd` build tag and also run integration tests with embedded etcd.

This PR is part of a multi PR effort to LND stable on etcd+bbolt:
~Key derivation: https://github.com/lightningnetwork/lnd/pull/4411~
~Reducing commit conflicts by lightweight tx queueing: https://github.com/lightningnetwork/lnd/pull/4457~


Rebased on: 
- ~External state reset: https://github.com/lightningnetwork/lnd/pull/4705~ merged
- ~Node restart before each icase: https://github.com/lightningnetwork/lnd/pull/4737~ merged
- ~@matheusd's flake fixes: https://github.com/lightningnetwork/lnd/pull/4268~ merged
- ~@guggero's flake fix from: https://github.com/lightningnetwork/lnd/pull/4655~ merged