### PR TITLE
htlcswitch: remove fastsha256 in test

### DIFF
--- a/htlcswitch/switch_test.go
+++ b/htlcswitch/switch_test.go
@@ -11,7 +11,6 @@ import (
 	"time"
 
 	"github.com/btcsuite/btcutil"
-	"github.com/btcsuite/fastsha256"
 	"github.com/davecgh/go-spew/spew"
 	"github.com/lightningnetwork/lnd/channeldb"
 	"github.com/lightningnetwork/lnd/htlcswitch/hop"
@@ -3224,7 +3223,7 @@ func TestSwitchHoldForward(t *testing.T) {
 	// Create request which should be forwarded from Alice channel link to
 	// bob channel link.
 	preimage := [sha256.Size]byte{1}
-	rhash := fastsha256.Sum256(preimage[:])
+	rhash := sha256.Sum256(preimage[:])
 	ogPacket := &htlcPacket{
 		incomingChanID: aliceChannelLink.ShortChanID(),
 		incomingHTLCID: 0,


### PR DESCRIPTION
Previously fixed by this commit,
[channeldb+htlcswitch: don't use fastsha256 in tests](https://github.com/lightningnetwork/lnd/commit/a17ddc5dd1849ae9f6b01fb59cd5659167bd9848#diff-9ca6c00aa4cbaaa08aaa8bd697703398)


And broken by this commit,
[htlcswitch: introducing interceptable switch.](https://github.com/lightningnetwork/lnd/commit/0f50d8b2eddf95531ecb376e358514dd50b07bac#diff-9ca6c00aa4cbaaa08aaa8bd697703398R14)

This PR removes fastsha256.