### PR TITLE
kvdb+etcd+tests: change etcd flattened bucket key derivation to make it compatible with bbolt

### DIFF
--- a/channeldb/db.go
+++ b/channeldb/db.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/binary"
 	"fmt"
+	"io/ioutil"
 	"net"
 	"os"
 
@@ -1259,4 +1260,38 @@ func (db *DB) FetchHistoricalChannel(outPoint *wire.OutPoint) (*OpenChannel, err
 	}
 
 	return channel, nil
+}
+
+// MakeTestDB creates a new instance of the ChannelDB for testing purposes.
+// A callback which cleans up the created temporary directories is also
+// returned and intended to be executed after the test completes.
+func MakeTestDB(modifiers ...OptionModifier) (*DB, func(), error) {
+	// First, create a temporary directory to be used for the duration of
+	// this test.
+	tempDirName, err := ioutil.TempDir("", "channeldb")
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// Next, create channeldb for the first time.
+	backend, backendCleanup, err := kvdb.GetTestBackend(tempDirName, "cdb")
+	if err != nil {
+		backendCleanup()
+		return nil, nil, err
+	}
+
+	cdb, err := CreateWithBackend(backend, modifiers...)
+	if err != nil {
+		backendCleanup()
+		os.RemoveAll(tempDirName)
+		return nil, nil, err
+	}
+
+	cleanUp := func() {
+		cdb.Close()
+		backendCleanup()
+		os.RemoveAll(tempDirName)
+	}
+
+	return cdb, cleanUp, nil
 }

--- a/channeldb/db_test.go
+++ b/channeldb/db_test.go
@@ -115,7 +115,7 @@ func TestFetchClosedChannelForID(t *testing.T) {
 
 	const numChans = 101
 
-	cdb, cleanUp, err := makeTestDB()
+	cdb, cleanUp, err := MakeTestDB()
 	if err != nil {
 		t.Fatalf("unable to make test database: %v", err)
 	}
@@ -186,7 +186,7 @@ func TestFetchClosedChannelForID(t *testing.T) {
 func TestAddrsForNode(t *testing.T) {
 	t.Parallel()
 
-	cdb, cleanUp, err := makeTestDB()
+	cdb, cleanUp, err := MakeTestDB()
 	if err != nil {
 		t.Fatalf("unable to make test database: %v", err)
 	}
@@ -247,7 +247,7 @@ func TestAddrsForNode(t *testing.T) {
 func TestFetchChannel(t *testing.T) {
 	t.Parallel()
 
-	cdb, cleanUp, err := makeTestDB()
+	cdb, cleanUp, err := MakeTestDB()
 	if err != nil {
 		t.Fatalf("unable to make test database: %v", err)
 	}
@@ -351,7 +351,7 @@ func genRandomChannelShell() (*ChannelShell, error) {
 func TestRestoreChannelShells(t *testing.T) {
 	t.Parallel()
 
-	cdb, cleanUp, err := makeTestDB()
+	cdb, cleanUp, err := MakeTestDB()
 	if err != nil {
 		t.Fatalf("unable to make test database: %v", err)
 	}
@@ -445,7 +445,7 @@ func TestRestoreChannelShells(t *testing.T) {
 func TestAbandonChannel(t *testing.T) {
 	t.Parallel()
 
-	cdb, cleanUp, err := makeTestDB()
+	cdb, cleanUp, err := MakeTestDB()
 	if err != nil {
 		t.Fatalf("unable to make test database: %v", err)
 	}
@@ -618,7 +618,7 @@ func TestFetchChannels(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
 
-			cdb, cleanUp, err := makeTestDB()
+			cdb, cleanUp, err := MakeTestDB()
 			if err != nil {
 				t.Fatalf("unable to make test "+
 					"database: %v", err)
@@ -687,7 +687,7 @@ func TestFetchChannels(t *testing.T) {
 
 // TestFetchHistoricalChannel tests lookup of historical channels.
 func TestFetchHistoricalChannel(t *testing.T) {
-	cdb, cleanUp, err := makeTestDB()
+	cdb, cleanUp, err := MakeTestDB()
 	if err != nil {
 		t.Fatalf("unable to make test database: %v", err)
 	}

--- a/channeldb/forwarding_log_test.go
+++ b/channeldb/forwarding_log_test.go
@@ -19,7 +19,7 @@ func TestForwardingLogBasicStorageAndQuery(t *testing.T) {
 	// First, we'll set up a test database, and use that to instantiate the
 	// forwarding event log that we'll be using for the duration of the
 	// test.
-	db, cleanUp, err := makeTestDB()
+	db, cleanUp, err := MakeTestDB()
 	defer cleanUp()
 	if err != nil {
 		t.Fatalf("unable to make test db: %v", err)
@@ -91,7 +91,7 @@ func TestForwardingLogQueryOptions(t *testing.T) {
 	// First, we'll set up a test database, and use that to instantiate the
 	// forwarding event log that we'll be using for the duration of the
 	// test.
-	db, cleanUp, err := makeTestDB()
+	db, cleanUp, err := MakeTestDB()
 	defer cleanUp()
 	if err != nil {
 		t.Fatalf("unable to make test db: %v", err)
@@ -196,7 +196,7 @@ func TestForwardingLogQueryLimit(t *testing.T) {
 	// First, we'll set up a test database, and use that to instantiate the
 	// forwarding event log that we'll be using for the duration of the
 	// test.
-	db, cleanUp, err := makeTestDB()
+	db, cleanUp, err := MakeTestDB()
 	defer cleanUp()
 	if err != nil {
 		t.Fatalf("unable to make test db: %v", err)

--- a/channeldb/graph_test.go
+++ b/channeldb/graph_test.go
@@ -73,7 +73,7 @@ func createTestVertex(db *DB) (*LightningNode, error) {
 func TestNodeInsertionAndDeletion(t *testing.T) {
 	t.Parallel()
 
-	db, cleanUp, err := makeTestDB()
+	db, cleanUp, err := MakeTestDB()
 	defer cleanUp()
 	if err != nil {
 		t.Fatalf("unable to make test database: %v", err)
@@ -139,7 +139,7 @@ func TestNodeInsertionAndDeletion(t *testing.T) {
 func TestPartialNode(t *testing.T) {
 	t.Parallel()
 
-	db, cleanUp, err := makeTestDB()
+	db, cleanUp, err := MakeTestDB()
 	defer cleanUp()
 	if err != nil {
 		t.Fatalf("unable to make test database: %v", err)
@@ -201,7 +201,7 @@ func TestPartialNode(t *testing.T) {
 func TestAliasLookup(t *testing.T) {
 	t.Parallel()
 
-	db, cleanUp, err := makeTestDB()
+	db, cleanUp, err := MakeTestDB()
 	defer cleanUp()
 	if err != nil {
 		t.Fatalf("unable to make test database: %v", err)
@@ -255,7 +255,7 @@ func TestAliasLookup(t *testing.T) {
 func TestSourceNode(t *testing.T) {
 	t.Parallel()
 
-	db, cleanUp, err := makeTestDB()
+	db, cleanUp, err := MakeTestDB()
 	defer cleanUp()
 	if err != nil {
 		t.Fatalf("unable to make test database: %v", err)
@@ -296,7 +296,7 @@ func TestSourceNode(t *testing.T) {
 func TestEdgeInsertionDeletion(t *testing.T) {
 	t.Parallel()
 
-	db, cleanUp, err := makeTestDB()
+	db, cleanUp, err := MakeTestDB()
 	defer cleanUp()
 	if err != nil {
 		t.Fatalf("unable to make test database: %v", err)
@@ -431,7 +431,7 @@ func createEdge(height, txIndex uint32, txPosition uint16, outPointIndex uint32,
 func TestDisconnectBlockAtHeight(t *testing.T) {
 	t.Parallel()
 
-	db, cleanUp, err := makeTestDB()
+	db, cleanUp, err := MakeTestDB()
 	defer cleanUp()
 	if err != nil {
 		t.Fatalf("unable to make test database: %v", err)
@@ -718,7 +718,7 @@ func createChannelEdge(db *DB, node1, node2 *LightningNode) (*ChannelEdgeInfo,
 func TestEdgeInfoUpdates(t *testing.T) {
 	t.Parallel()
 
-	db, cleanUp, err := makeTestDB()
+	db, cleanUp, err := MakeTestDB()
 	defer cleanUp()
 	if err != nil {
 		t.Fatalf("unable to make test database: %v", err)
@@ -848,7 +848,7 @@ func newEdgePolicy(chanID uint64, op wire.OutPoint, db *DB,
 func TestGraphTraversal(t *testing.T) {
 	t.Parallel()
 
-	db, cleanUp, err := makeTestDB()
+	db, cleanUp, err := MakeTestDB()
 	defer cleanUp()
 	if err != nil {
 		t.Fatalf("unable to make test database: %v", err)
@@ -1109,7 +1109,7 @@ func assertChanViewEqualChanPoints(t *testing.T, a []EdgePoint, b []*wire.OutPoi
 func TestGraphPruning(t *testing.T) {
 	t.Parallel()
 
-	db, cleanUp, err := makeTestDB()
+	db, cleanUp, err := MakeTestDB()
 	defer cleanUp()
 	if err != nil {
 		t.Fatalf("unable to make test database: %v", err)
@@ -1317,7 +1317,7 @@ func TestGraphPruning(t *testing.T) {
 func TestHighestChanID(t *testing.T) {
 	t.Parallel()
 
-	db, cleanUp, err := makeTestDB()
+	db, cleanUp, err := MakeTestDB()
 	defer cleanUp()
 	if err != nil {
 		t.Fatalf("unable to make test database: %v", err)
@@ -1394,7 +1394,7 @@ func TestHighestChanID(t *testing.T) {
 func TestChanUpdatesInHorizon(t *testing.T) {
 	t.Parallel()
 
-	db, cleanUp, err := makeTestDB()
+	db, cleanUp, err := MakeTestDB()
 	defer cleanUp()
 	if err != nil {
 		t.Fatalf("unable to make test database: %v", err)
@@ -1570,7 +1570,7 @@ func TestChanUpdatesInHorizon(t *testing.T) {
 func TestNodeUpdatesInHorizon(t *testing.T) {
 	t.Parallel()
 
-	db, cleanUp, err := makeTestDB()
+	db, cleanUp, err := MakeTestDB()
 	defer cleanUp()
 	if err != nil {
 		t.Fatalf("unable to make test database: %v", err)
@@ -1693,7 +1693,7 @@ func TestNodeUpdatesInHorizon(t *testing.T) {
 func TestFilterKnownChanIDs(t *testing.T) {
 	t.Parallel()
 
-	db, cleanUp, err := makeTestDB()
+	db, cleanUp, err := MakeTestDB()
 	defer cleanUp()
 	if err != nil {
 		t.Fatalf("unable to make test database: %v", err)
@@ -1810,7 +1810,7 @@ func TestFilterKnownChanIDs(t *testing.T) {
 func TestFilterChannelRange(t *testing.T) {
 	t.Parallel()
 
-	db, cleanUp, err := makeTestDB()
+	db, cleanUp, err := MakeTestDB()
 	defer cleanUp()
 	if err != nil {
 		t.Fatalf("unable to make test database: %v", err)
@@ -1929,7 +1929,7 @@ func TestFilterChannelRange(t *testing.T) {
 func TestFetchChanInfos(t *testing.T) {
 	t.Parallel()
 
-	db, cleanUp, err := makeTestDB()
+	db, cleanUp, err := MakeTestDB()
 	defer cleanUp()
 	if err != nil {
 		t.Fatalf("unable to make test database: %v", err)
@@ -2057,7 +2057,7 @@ func TestFetchChanInfos(t *testing.T) {
 func TestIncompleteChannelPolicies(t *testing.T) {
 	t.Parallel()
 
-	db, cleanUp, err := makeTestDB()
+	db, cleanUp, err := MakeTestDB()
 	defer cleanUp()
 	if err != nil {
 		t.Fatalf("unable to make test database: %v", err)
@@ -2172,7 +2172,7 @@ func TestIncompleteChannelPolicies(t *testing.T) {
 func TestChannelEdgePruningUpdateIndexDeletion(t *testing.T) {
 	t.Parallel()
 
-	db, cleanUp, err := makeTestDB()
+	db, cleanUp, err := MakeTestDB()
 	defer cleanUp()
 	if err != nil {
 		t.Fatalf("unable to make test database: %v", err)
@@ -2327,7 +2327,7 @@ func TestChannelEdgePruningUpdateIndexDeletion(t *testing.T) {
 func TestPruneGraphNodes(t *testing.T) {
 	t.Parallel()
 
-	db, cleanUp, err := makeTestDB()
+	db, cleanUp, err := MakeTestDB()
 	defer cleanUp()
 	if err != nil {
 		t.Fatalf("unable to make test database: %v", err)
@@ -2411,7 +2411,7 @@ func TestPruneGraphNodes(t *testing.T) {
 func TestAddChannelEdgeShellNodes(t *testing.T) {
 	t.Parallel()
 
-	db, cleanUp, err := makeTestDB()
+	db, cleanUp, err := MakeTestDB()
 	defer cleanUp()
 	if err != nil {
 		t.Fatalf("unable to make test database: %v", err)
@@ -2465,7 +2465,7 @@ func TestAddChannelEdgeShellNodes(t *testing.T) {
 func TestNodePruningUpdateIndexDeletion(t *testing.T) {
 	t.Parallel()
 
-	db, cleanUp, err := makeTestDB()
+	db, cleanUp, err := MakeTestDB()
 	defer cleanUp()
 	if err != nil {
 		t.Fatalf("unable to make test database: %v", err)
@@ -2535,7 +2535,7 @@ func TestNodeIsPublic(t *testing.T) {
 	// We'll need to create a separate database and channel graph for each
 	// participant to replicate real-world scenarios (private edges being in
 	// some graphs but not others, etc.).
-	aliceDB, cleanUp, err := makeTestDB()
+	aliceDB, cleanUp, err := MakeTestDB()
 	defer cleanUp()
 	if err != nil {
 		t.Fatalf("unable to make test database: %v", err)
@@ -2549,7 +2549,7 @@ func TestNodeIsPublic(t *testing.T) {
 		t.Fatalf("unable to set source node: %v", err)
 	}
 
-	bobDB, cleanUp, err := makeTestDB()
+	bobDB, cleanUp, err := MakeTestDB()
 	defer cleanUp()
 	if err != nil {
 		t.Fatalf("unable to make test database: %v", err)
@@ -2563,7 +2563,7 @@ func TestNodeIsPublic(t *testing.T) {
 		t.Fatalf("unable to set source node: %v", err)
 	}
 
-	carolDB, cleanUp, err := makeTestDB()
+	carolDB, cleanUp, err := MakeTestDB()
 	defer cleanUp()
 	if err != nil {
 		t.Fatalf("unable to make test database: %v", err)
@@ -2684,7 +2684,7 @@ func TestNodeIsPublic(t *testing.T) {
 func TestDisabledChannelIDs(t *testing.T) {
 	t.Parallel()
 
-	db, cleanUp, err := makeTestDB()
+	db, cleanUp, err := MakeTestDB()
 	if err != nil {
 		t.Fatalf("unable to make test database: %v", err)
 	}
@@ -2782,7 +2782,7 @@ func TestDisabledChannelIDs(t *testing.T) {
 func TestEdgePolicyMissingMaxHtcl(t *testing.T) {
 	t.Parallel()
 
-	db, cleanUp, err := makeTestDB()
+	db, cleanUp, err := MakeTestDB()
 	defer cleanUp()
 	if err != nil {
 		t.Fatalf("unable to make test database: %v", err)
@@ -2962,7 +2962,7 @@ func TestGraphZombieIndex(t *testing.T) {
 	t.Parallel()
 
 	// We'll start by creating our test graph along with a test edge.
-	db, cleanUp, err := makeTestDB()
+	db, cleanUp, err := MakeTestDB()
 	defer cleanUp()
 	if err != nil {
 		t.Fatalf("unable to create test database: %v", err)
@@ -3151,7 +3151,7 @@ func TestLightningNodeSigVerification(t *testing.T) {
 	}
 
 	// Create a LightningNode from the same private key.
-	db, cleanUp, err := makeTestDB()
+	db, cleanUp, err := MakeTestDB()
 	if err != nil {
 		t.Fatalf("unable to make test database: %v", err)
 	}

--- a/channeldb/invoice_test.go
+++ b/channeldb/invoice_test.go
@@ -136,7 +136,7 @@ func TestInvoiceWorkflow(t *testing.T) {
 }
 
 func testInvoiceWorkflow(t *testing.T, test invWorkflowTest) {
-	db, cleanUp, err := makeTestDB()
+	db, cleanUp, err := MakeTestDB()
 	defer cleanUp()
 	if err != nil {
 		t.Fatalf("unable to make test db: %v", err)
@@ -290,7 +290,7 @@ func testInvoiceWorkflow(t *testing.T, test invWorkflowTest) {
 // TestAddDuplicatePayAddr asserts that the payment addresses of inserted
 // invoices are unique.
 func TestAddDuplicatePayAddr(t *testing.T) {
-	db, cleanUp, err := makeTestDB()
+	db, cleanUp, err := MakeTestDB()
 	defer cleanUp()
 	require.NoError(t, err)
 
@@ -317,7 +317,7 @@ func TestAddDuplicatePayAddr(t *testing.T) {
 // addresses to be inserted if they are blank to support JIT legacy keysend
 // invoices.
 func TestAddDuplicateKeysendPayAddr(t *testing.T) {
-	db, cleanUp, err := makeTestDB()
+	db, cleanUp, err := MakeTestDB()
 	defer cleanUp()
 	require.NoError(t, err)
 
@@ -358,7 +358,7 @@ func TestAddDuplicateKeysendPayAddr(t *testing.T) {
 // TestInvRefEquivocation asserts that retrieving or updating an invoice using
 // an equivocating InvoiceRef results in ErrInvRefEquivocation.
 func TestInvRefEquivocation(t *testing.T) {
-	db, cleanUp, err := makeTestDB()
+	db, cleanUp, err := MakeTestDB()
 	defer cleanUp()
 	require.NoError(t, err)
 
@@ -398,7 +398,7 @@ func TestInvRefEquivocation(t *testing.T) {
 func TestInvoiceCancelSingleHtlc(t *testing.T) {
 	t.Parallel()
 
-	db, cleanUp, err := makeTestDB()
+	db, cleanUp, err := MakeTestDB()
 	defer cleanUp()
 	if err != nil {
 		t.Fatalf("unable to make test db: %v", err)
@@ -472,7 +472,7 @@ func TestInvoiceCancelSingleHtlc(t *testing.T) {
 func TestInvoiceAddTimeSeries(t *testing.T) {
 	t.Parallel()
 
-	db, cleanUp, err := makeTestDB()
+	db, cleanUp, err := MakeTestDB(OptionClock(testClock))
 	defer cleanUp()
 	if err != nil {
 		t.Fatalf("unable to make test db: %v", err)
@@ -627,7 +627,7 @@ func TestInvoiceAddTimeSeries(t *testing.T) {
 func TestFetchAllInvoicesWithPaymentHash(t *testing.T) {
 	t.Parallel()
 
-	db, cleanup, err := makeTestDB()
+	db, cleanup, err := MakeTestDB()
 	defer cleanup()
 	if err != nil {
 		t.Fatalf("unable to make test db: %v", err)
@@ -732,7 +732,7 @@ func TestFetchAllInvoicesWithPaymentHash(t *testing.T) {
 func TestDuplicateSettleInvoice(t *testing.T) {
 	t.Parallel()
 
-	db, cleanUp, err := makeTestDB()
+	db, cleanUp, err := MakeTestDB(OptionClock(testClock))
 	defer cleanUp()
 	if err != nil {
 		t.Fatalf("unable to make test db: %v", err)
@@ -797,7 +797,7 @@ func TestDuplicateSettleInvoice(t *testing.T) {
 func TestQueryInvoices(t *testing.T) {
 	t.Parallel()
 
-	db, cleanUp, err := makeTestDB()
+	db, cleanUp, err := MakeTestDB(OptionClock(testClock))
 	defer cleanUp()
 	if err != nil {
 		t.Fatalf("unable to make test db: %v", err)
@@ -1112,7 +1112,7 @@ func getUpdateInvoice(amt lnwire.MilliSatoshi) InvoiceUpdateCallback {
 func TestCustomRecords(t *testing.T) {
 	t.Parallel()
 
-	db, cleanUp, err := makeTestDB()
+	db, cleanUp, err := MakeTestDB()
 	defer cleanUp()
 	if err != nil {
 		t.Fatalf("unable to make test db: %v", err)

--- a/channeldb/kvdb/etcd/db_test.go
+++ b/channeldb/kvdb/etcd/db_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 
 	"github.com/btcsuite/btcwallet/walletdb"
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestCopy(t *testing.T) {
@@ -18,30 +18,30 @@ func TestCopy(t *testing.T) {
 	defer f.Cleanup()
 
 	db, err := newEtcdBackend(f.BackendConfig())
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	err = db.Update(func(tx walletdb.ReadWriteTx) error {
 		// "apple"
 		apple, err := tx.CreateTopLevelBucket([]byte("apple"))
-		assert.NoError(t, err)
-		assert.NotNil(t, apple)
+		require.NoError(t, err)
+		require.NotNil(t, apple)
 
-		assert.NoError(t, apple.Put([]byte("key"), []byte("val")))
+		require.NoError(t, apple.Put([]byte("key"), []byte("val")))
 		return nil
 	})
 
 	// Expect non-zero copy.
 	var buf bytes.Buffer
 
-	assert.NoError(t, db.Copy(&buf))
-	assert.Greater(t, buf.Len(), 0)
-	assert.Nil(t, err)
+	require.NoError(t, db.Copy(&buf))
+	require.Greater(t, buf.Len(), 0)
+	require.Nil(t, err)
 
 	expected := map[string]string{
 		bkey("apple"):        bval("apple"),
 		vkey("key", "apple"): "val",
 	}
-	assert.Equal(t, expected, f.Dump())
+	require.Equal(t, expected, f.Dump())
 }
 
 func TestAbortContext(t *testing.T) {
@@ -57,19 +57,19 @@ func TestAbortContext(t *testing.T) {
 
 	// Pass abort context and abort right away.
 	db, err := newEtcdBackend(config)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	cancel()
 
 	// Expect that the update will fail.
 	err = db.Update(func(tx walletdb.ReadWriteTx) error {
 		_, err := tx.CreateTopLevelBucket([]byte("bucket"))
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		return nil
 	})
 
-	assert.Error(t, err, "context canceled")
+	require.Error(t, err, "context canceled")
 
 	// No changes in the DB.
-	assert.Equal(t, map[string]string{}, f.Dump())
+	require.Equal(t, map[string]string{}, f.Dump())
 }

--- a/channeldb/kvdb/etcd/driver_test.go
+++ b/channeldb/kvdb/etcd/driver_test.go
@@ -6,25 +6,25 @@ import (
 	"testing"
 
 	"github.com/btcsuite/btcwallet/walletdb"
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestOpenCreateFailure(t *testing.T) {
 	t.Parallel()
 
 	db, err := walletdb.Open(dbType)
-	assert.Error(t, err)
-	assert.Nil(t, db)
+	require.Error(t, err)
+	require.Nil(t, db)
 
 	db, err = walletdb.Open(dbType, "wrong")
-	assert.Error(t, err)
-	assert.Nil(t, db)
+	require.Error(t, err)
+	require.Nil(t, db)
 
 	db, err = walletdb.Create(dbType)
-	assert.Error(t, err)
-	assert.Nil(t, db)
+	require.Error(t, err)
+	require.Nil(t, db)
 
 	db, err = walletdb.Create(dbType, "wrong")
-	assert.Error(t, err)
-	assert.Nil(t, db)
+	require.Error(t, err)
+	require.Nil(t, db)
 }

--- a/channeldb/kvdb/etcd/readwrite_bucket.go
+++ b/channeldb/kvdb/etcd/readwrite_bucket.go
@@ -3,7 +3,6 @@
 package etcd
 
 import (
-	"bytes"
 	"strconv"
 
 	"github.com/btcsuite/btcwallet/walletdb"
@@ -24,11 +23,6 @@ type readWriteBucket struct {
 // newReadWriteBucket creates a new rw bucket with the passed transaction
 // and bucket id.
 func newReadWriteBucket(tx *readWriteTx, key, id []byte) *readWriteBucket {
-	if !bytes.Equal(id, tx.rootBucketID[:]) {
-		// Add the bucket key/value to the lock set.
-		tx.lock(string(key), string(id))
-	}
-
 	return &readWriteBucket{
 		id: id,
 		tx: tx,

--- a/channeldb/kvdb/etcd/readwrite_bucket_test.go
+++ b/channeldb/kvdb/etcd/readwrite_bucket_test.go
@@ -315,7 +315,7 @@ func TestBucketForEachWithError(t *testing.T) {
 		i := 0
 		// Error while iterating value keys.
 		err = apple.ForEach(func(key, val []byte) error {
-			if i == 1 {
+			if i == 2 {
 				return fmt.Errorf("error")
 			}
 
@@ -325,7 +325,8 @@ func TestBucketForEachWithError(t *testing.T) {
 		})
 
 		expected := map[string]string{
-			"key1": "val1",
+			"banana": "",
+			"key1":   "val1",
 		}
 
 		require.Equal(t, expected, got)
@@ -345,9 +346,9 @@ func TestBucketForEachWithError(t *testing.T) {
 		})
 
 		expected = map[string]string{
+			"banana": "",
 			"key1":   "val1",
 			"key2":   "val2",
-			"banana": "",
 		}
 
 		require.Equal(t, expected, got)

--- a/channeldb/kvdb/etcd/readwrite_cursor_test.go
+++ b/channeldb/kvdb/etcd/readwrite_cursor_test.go
@@ -19,7 +19,7 @@ func TestReadCursorEmptyInterval(t *testing.T) {
 	require.NoError(t, err)
 
 	err = db.Update(func(tx walletdb.ReadWriteTx) error {
-		b, err := tx.CreateTopLevelBucket([]byte("alma"))
+		b, err := tx.CreateTopLevelBucket([]byte("apple"))
 		require.NoError(t, err)
 		require.NotNil(t, b)
 
@@ -28,7 +28,7 @@ func TestReadCursorEmptyInterval(t *testing.T) {
 	require.NoError(t, err)
 
 	err = db.View(func(tx walletdb.ReadTx) error {
-		b := tx.ReadBucket([]byte("alma"))
+		b := tx.ReadBucket([]byte("apple"))
 		require.NotNil(t, b)
 
 		cursor := b.ReadCursor()
@@ -70,7 +70,7 @@ func TestReadCursorNonEmptyInterval(t *testing.T) {
 	}
 
 	err = db.Update(func(tx walletdb.ReadWriteTx) error {
-		b, err := tx.CreateTopLevelBucket([]byte("alma"))
+		b, err := tx.CreateTopLevelBucket([]byte("apple"))
 		require.NoError(t, err)
 		require.NotNil(t, b)
 
@@ -83,7 +83,7 @@ func TestReadCursorNonEmptyInterval(t *testing.T) {
 	require.NoError(t, err)
 
 	err = db.View(func(tx walletdb.ReadTx) error {
-		b := tx.ReadBucket([]byte("alma"))
+		b := tx.ReadBucket([]byte("apple"))
 		require.NotNil(t, b)
 
 		// Iterate from the front.

--- a/channeldb/kvdb/etcd/readwrite_tx.go
+++ b/channeldb/kvdb/etcd/readwrite_tx.go
@@ -17,14 +17,6 @@ type readWriteTx struct {
 
 	// active is true if the transaction hasn't been committed yet.
 	active bool
-
-	// dirty is true if we intent to update a value in this transaction.
-	dirty bool
-
-	// lset holds key/value set that we want to lock on. If upon commit the
-	// transaction is dirty and the lset is not empty, we'll bump the mod
-	// version of these key/values.
-	lset map[string]string
 }
 
 // newReadWriteTx creates an rw transaction with the passed STM.
@@ -33,7 +25,6 @@ func newReadWriteTx(stm STM, prefix string) *readWriteTx {
 		stm:          stm,
 		active:       true,
 		rootBucketID: makeBucketID([]byte(prefix)),
-		lset:         make(map[string]string),
 	}
 }
 
@@ -43,48 +34,14 @@ func rootBucket(tx *readWriteTx) *readWriteBucket {
 	return newReadWriteBucket(tx, tx.rootBucketID[:], tx.rootBucketID[:])
 }
 
-// lock adds a key value to the lock set.
-func (tx *readWriteTx) lock(key, val string) {
-	tx.stm.Lock(key)
-	if !tx.dirty {
-		tx.lset[key] = val
-	} else {
-		// Bump the mod version of the key,
-		// leaving the value intact.
-		tx.stm.Put(key, val)
-	}
-}
-
 // put updates the passed key/value.
 func (tx *readWriteTx) put(key, val string) {
 	tx.stm.Put(key, val)
-	tx.setDirty()
 }
 
 // del marks the passed key deleted.
 func (tx *readWriteTx) del(key string) {
 	tx.stm.Del(key)
-	tx.setDirty()
-}
-
-// setDirty marks the transaction dirty and bumps
-// mod version for the existing lock set if it is
-// not empty.
-func (tx *readWriteTx) setDirty() {
-	// Bump the lock set.
-	if !tx.dirty && len(tx.lset) > 0 {
-		for key, val := range tx.lset {
-			// Bump the mod version of the key,
-			// leaving the value intact.
-			tx.stm.Put(key, val)
-		}
-
-		// Clear the lock set.
-		tx.lset = make(map[string]string)
-	}
-
-	// Set dirty.
-	tx.dirty = true
 }
 
 // ReadBucket opens the root bucket for read only access.  If the bucket

--- a/channeldb/kvdb/etcd/readwrite_tx.go
+++ b/channeldb/kvdb/etcd/readwrite_tx.go
@@ -34,16 +34,6 @@ func rootBucket(tx *readWriteTx) *readWriteBucket {
 	return newReadWriteBucket(tx, tx.rootBucketID[:], tx.rootBucketID[:])
 }
 
-// put updates the passed key/value.
-func (tx *readWriteTx) put(key, val string) {
-	tx.stm.Put(key, val)
-}
-
-// del marks the passed key deleted.
-func (tx *readWriteTx) del(key string) {
-	tx.stm.Del(key)
-}
-
 // ReadBucket opens the root bucket for read only access.  If the bucket
 // described by the key does not exist, nil is returned.
 func (tx *readWriteTx) ReadBucket(key []byte) walletdb.ReadBucket {

--- a/channeldb/meta_test.go
+++ b/channeldb/meta_test.go
@@ -15,7 +15,7 @@ import (
 func applyMigration(t *testing.T, beforeMigration, afterMigration func(d *DB),
 	migrationFunc migration, shouldFail bool, dryRun bool) {
 
-	cdb, cleanUp, err := makeTestDB()
+	cdb, cleanUp, err := MakeTestDB()
 	defer cleanUp()
 	if err != nil {
 		t.Fatal(err)
@@ -86,7 +86,7 @@ func applyMigration(t *testing.T, beforeMigration, afterMigration func(d *DB),
 func TestVersionFetchPut(t *testing.T) {
 	t.Parallel()
 
-	db, cleanUp, err := makeTestDB()
+	db, cleanUp, err := MakeTestDB()
 	defer cleanUp()
 	if err != nil {
 		t.Fatal(err)

--- a/channeldb/nodes_test.go
+++ b/channeldb/nodes_test.go
@@ -13,7 +13,7 @@ import (
 func TestLinkNodeEncodeDecode(t *testing.T) {
 	t.Parallel()
 
-	cdb, cleanUp, err := makeTestDB()
+	cdb, cleanUp, err := MakeTestDB()
 	if err != nil {
 		t.Fatalf("unable to make test database: %v", err)
 	}
@@ -110,7 +110,7 @@ func TestLinkNodeEncodeDecode(t *testing.T) {
 func TestDeleteLinkNode(t *testing.T) {
 	t.Parallel()
 
-	cdb, cleanUp, err := makeTestDB()
+	cdb, cleanUp, err := MakeTestDB()
 	if err != nil {
 		t.Fatalf("unable to make test database: %v", err)
 	}

--- a/channeldb/payment_control_test.go
+++ b/channeldb/payment_control_test.go
@@ -56,7 +56,7 @@ func genInfo() (*PaymentCreationInfo, *HTLCAttemptInfo,
 func TestPaymentControlSwitchFail(t *testing.T) {
 	t.Parallel()
 
-	db, cleanup, err := makeTestDB()
+	db, cleanup, err := MakeTestDB()
 	defer cleanup()
 	if err != nil {
 		t.Fatalf("unable to init db: %v", err)
@@ -203,7 +203,7 @@ func TestPaymentControlSwitchFail(t *testing.T) {
 func TestPaymentControlSwitchDoubleSend(t *testing.T) {
 	t.Parallel()
 
-	db, cleanup, err := makeTestDB()
+	db, cleanup, err := MakeTestDB()
 	defer cleanup()
 
 	if err != nil {
@@ -286,7 +286,7 @@ func TestPaymentControlSwitchDoubleSend(t *testing.T) {
 func TestPaymentControlSuccessesWithoutInFlight(t *testing.T) {
 	t.Parallel()
 
-	db, cleanup, err := makeTestDB()
+	db, cleanup, err := MakeTestDB()
 	defer cleanup()
 
 	if err != nil {
@@ -319,7 +319,7 @@ func TestPaymentControlSuccessesWithoutInFlight(t *testing.T) {
 func TestPaymentControlFailsWithoutInFlight(t *testing.T) {
 	t.Parallel()
 
-	db, cleanup, err := makeTestDB()
+	db, cleanup, err := MakeTestDB()
 	defer cleanup()
 
 	if err != nil {
@@ -347,7 +347,7 @@ func TestPaymentControlFailsWithoutInFlight(t *testing.T) {
 func TestPaymentControlDeleteNonInFligt(t *testing.T) {
 	t.Parallel()
 
-	db, cleanup, err := makeTestDB()
+	db, cleanup, err := MakeTestDB()
 	defer cleanup()
 
 	if err != nil {
@@ -530,7 +530,7 @@ func TestPaymentControlMultiShard(t *testing.T) {
 	}
 
 	runSubTest := func(t *testing.T, test testCase) {
-		db, cleanup, err := makeTestDB()
+		db, cleanup, err := MakeTestDB()
 		defer cleanup()
 
 		if err != nil {
@@ -780,7 +780,7 @@ func TestPaymentControlMultiShard(t *testing.T) {
 func TestPaymentControlMPPRecordValidation(t *testing.T) {
 	t.Parallel()
 
-	db, cleanup, err := makeTestDB()
+	db, cleanup, err := MakeTestDB()
 	defer cleanup()
 
 	if err != nil {

--- a/channeldb/payments_test.go
+++ b/channeldb/payments_test.go
@@ -399,7 +399,7 @@ func TestQueryPayments(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			db, cleanup, err := makeTestDB()
+			db, cleanup, err := MakeTestDB()
 			if err != nil {
 				t.Fatalf("unable to init db: %v", err)
 			}
@@ -512,7 +512,7 @@ func TestQueryPayments(t *testing.T) {
 // case where a specific duplicate is not found and the duplicates bucket is not
 // present when we expect it to be.
 func TestFetchPaymentWithSequenceNumber(t *testing.T) {
-	db, cleanup, err := makeTestDB()
+	db, cleanup, err := MakeTestDB()
 	require.NoError(t, err)
 
 	defer cleanup()

--- a/channeldb/reports_test.go
+++ b/channeldb/reports_test.go
@@ -48,7 +48,7 @@ func TestPersistReport(t *testing.T) {
 		test := test
 
 		t.Run(test.name, func(t *testing.T) {
-			db, cleanup, err := makeTestDB()
+			db, cleanup, err := MakeTestDB()
 			require.NoError(t, err)
 			defer cleanup()
 
@@ -85,7 +85,7 @@ func TestPersistReport(t *testing.T) {
 // channel, testing that the appropriate error is returned based on the state
 // of the existing bucket.
 func TestFetchChannelReadBucket(t *testing.T) {
-	db, cleanup, err := makeTestDB()
+	db, cleanup, err := MakeTestDB()
 	require.NoError(t, err)
 	defer cleanup()
 
@@ -197,7 +197,7 @@ func TestFetchChannelWriteBucket(t *testing.T) {
 		test := test
 
 		t.Run(test.name, func(t *testing.T) {
-			db, cleanup, err := makeTestDB()
+			db, cleanup, err := MakeTestDB()
 			require.NoError(t, err)
 			defer cleanup()
 

--- a/channeldb/waitingproof_test.go
+++ b/channeldb/waitingproof_test.go
@@ -14,7 +14,7 @@ import (
 func TestWaitingProofStore(t *testing.T) {
 	t.Parallel()
 
-	db, cleanup, err := makeTestDB()
+	db, cleanup, err := MakeTestDB()
 	if err != nil {
 		t.Fatalf("failed to make test database: %s", err)
 	}

--- a/channeldb/witness_cache_test.go
+++ b/channeldb/witness_cache_test.go
@@ -12,7 +12,7 @@ import (
 func TestWitnessCacheSha256Retrieval(t *testing.T) {
 	t.Parallel()
 
-	cdb, cleanUp, err := makeTestDB()
+	cdb, cleanUp, err := MakeTestDB()
 	if err != nil {
 		t.Fatalf("unable to make test database: %v", err)
 	}
@@ -57,7 +57,7 @@ func TestWitnessCacheSha256Retrieval(t *testing.T) {
 func TestWitnessCacheSha256Deletion(t *testing.T) {
 	t.Parallel()
 
-	cdb, cleanUp, err := makeTestDB()
+	cdb, cleanUp, err := MakeTestDB()
 	if err != nil {
 		t.Fatalf("unable to make test database: %v", err)
 	}
@@ -108,7 +108,7 @@ func TestWitnessCacheSha256Deletion(t *testing.T) {
 func TestWitnessCacheUnknownWitness(t *testing.T) {
 	t.Parallel()
 
-	cdb, cleanUp, err := makeTestDB()
+	cdb, cleanUp, err := MakeTestDB()
 	if err != nil {
 		t.Fatalf("unable to make test database: %v", err)
 	}
@@ -127,7 +127,7 @@ func TestWitnessCacheUnknownWitness(t *testing.T) {
 // TestAddSha256Witnesses tests that insertion using AddSha256Witnesses behaves
 // identically to the insertion via the generalized interface.
 func TestAddSha256Witnesses(t *testing.T) {
-	cdb, cleanUp, err := makeTestDB()
+	cdb, cleanUp, err := MakeTestDB()
 	if err != nil {
 		t.Fatalf("unable to make test database: %v", err)
 	}

--- a/nursery_store_test.go
+++ b/nursery_store_test.go
@@ -3,39 +3,12 @@
 package lnd
 
 import (
-	"io/ioutil"
-	"os"
 	"reflect"
 	"testing"
 
 	"github.com/btcsuite/btcd/wire"
 	"github.com/lightningnetwork/lnd/channeldb"
 )
-
-// makeTestDB creates a new instance of the ChannelDB for testing purposes. A
-// callback which cleans up the created temporary directories is also returned
-// and intended to be executed after the test completes.
-func makeTestDB() (*channeldb.DB, func(), error) {
-	// First, create a temporary directory to be used for the duration of
-	// this test.
-	tempDirName, err := ioutil.TempDir("", "channeldb")
-	if err != nil {
-		return nil, nil, err
-	}
-
-	// Next, create channeldb for the first time.
-	cdb, err := channeldb.Open(tempDirName)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	cleanUp := func() {
-		cdb.Close()
-		os.RemoveAll(tempDirName)
-	}
-
-	return cdb, cleanUp, nil
-}
 
 type incubateTest struct {
 	nOutputs    int
@@ -75,7 +48,7 @@ func initIncubateTests() {
 // TestNurseryStoreInit verifies basic properties of the nursery store before
 // any modifying calls are made.
 func TestNurseryStoreInit(t *testing.T) {
-	cdb, cleanUp, err := makeTestDB()
+	cdb, cleanUp, err := channeldb.MakeTestDB()
 	if err != nil {
 		t.Fatalf("unable to open channel db: %v", err)
 	}
@@ -95,7 +68,7 @@ func TestNurseryStoreInit(t *testing.T) {
 // outputs through the nursery store, verifying the properties of the
 // intermediate states.
 func TestNurseryStoreIncubate(t *testing.T) {
-	cdb, cleanUp, err := makeTestDB()
+	cdb, cleanUp, err := channeldb.MakeTestDB()
 	if err != nil {
 		t.Fatalf("unable to open channel db: %v", err)
 	}
@@ -336,7 +309,7 @@ func TestNurseryStoreIncubate(t *testing.T) {
 // populated entries from the height index as it is purged, and that the last
 // purged height is set appropriately.
 func TestNurseryStoreGraduate(t *testing.T) {
-	cdb, cleanUp, err := makeTestDB()
+	cdb, cleanUp, err := channeldb.MakeTestDB()
 	if err != nil {
 		t.Fatalf("unable to open channel db: %v", err)
 	}

--- a/sweep/store_test.go
+++ b/sweep/store_test.go
@@ -1,8 +1,6 @@
 package sweep
 
 import (
-	"io/ioutil"
-	"os"
 	"testing"
 
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
@@ -10,38 +8,13 @@ import (
 	"github.com/lightningnetwork/lnd/channeldb"
 )
 
-// makeTestDB creates a new instance of the ChannelDB for testing purposes. A
-// callback which cleans up the created temporary directories is also returned
-// and intended to be executed after the test completes.
-func makeTestDB() (*channeldb.DB, func(), error) {
-	// First, create a temporary directory to be used for the duration of
-	// this test.
-	tempDirName, err := ioutil.TempDir("", "channeldb")
-	if err != nil {
-		return nil, nil, err
-	}
-
-	// Next, create channeldb for the first time.
-	cdb, err := channeldb.Open(tempDirName)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	cleanUp := func() {
-		cdb.Close()
-		os.RemoveAll(tempDirName)
-	}
-
-	return cdb, cleanUp, nil
-}
-
 // TestStore asserts that the store persists the presented data to disk and is
 // able to retrieve it again.
 func TestStore(t *testing.T) {
 	t.Run("bolt", func(t *testing.T) {
 
 		// Create new store.
-		cdb, cleanUp, err := makeTestDB()
+		cdb, cleanUp, err := channeldb.MakeTestDB()
 		if err != nil {
 			t.Fatalf("unable to open channel db: %v", err)
 		}

--- a/utxonursery_test.go
+++ b/utxonursery_test.go
@@ -5,7 +5,6 @@ package lnd
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
 	"math"
 	"os"
 	"reflect"
@@ -407,6 +406,7 @@ type nurseryTestContext struct {
 	sweeper     *mockSweeper
 	timeoutChan chan chan time.Time
 	t           *testing.T
+	dbCleanup   func()
 }
 
 func createNurseryTestContext(t *testing.T,
@@ -416,12 +416,7 @@ func createNurseryTestContext(t *testing.T,
 	// alternative, mocking nurseryStore, is not chosen because there is
 	// still considerable logic in the store.
 
-	tempDirName, err := ioutil.TempDir("", "channeldb")
-	if err != nil {
-		t.Fatalf("unable to create temp dir: %v", err)
-	}
-
-	cdb, err := channeldb.Open(tempDirName)
+	cdb, cleanup, err := channeldb.MakeTestDB()
 	if err != nil {
 		t.Fatalf("unable to open channeldb: %v", err)
 	}
@@ -484,6 +479,7 @@ func createNurseryTestContext(t *testing.T,
 		sweeper:     sweeper,
 		timeoutChan: timeoutChan,
 		t:           t,
+		dbCleanup:   cleanup,
 	}
 
 	ctx.receiveTx = func() wire.MsgTx {
@@ -531,6 +527,8 @@ func (ctx *nurseryTestContext) notifyEpoch(height int32) {
 }
 
 func (ctx *nurseryTestContext) finish() {
+	defer ctx.dbCleanup()
+
 	// Add a final restart point in this state
 	ctx.restart()
 


### PR DESCRIPTION
This PR is part of a multi PR effort to speed up our etcd wrapper and make all tests succeed:
Key derivation: https://github.com/lightningnetwork/lnd/pull/4411
Range cache: https://github.com/lightningnetwork/lnd/pull/4433
Integration tests: https://github.com/lightningnetwork/lnd/pull/4402

This PR enables testing some remaining packages that use channeldb on etcd backend. 

Furthermore the PR also changes the flattened bucket key derivation such that the bucket/value prefix becomes a postfix instead. This fixes incompatibility with the bbolt backend, where buckets containing bucket keys were not picked up by our cursor wrappers. The issue was discovered on while investigating failing nursery tests which are also migrated to be able to run on etcd too.