### PR TITLE
New config option - disable height hint cache queries

### DIFF
--- a/chainntnfs/bitcoindnotify/bitcoind_test.go
+++ b/chainntnfs/bitcoindnotify/bitcoind_test.go
@@ -40,7 +40,10 @@ func initHintCache(t *testing.T) *chainntnfs.HeightHintCache {
 	if err != nil {
 		t.Fatalf("unable to create db: %v", err)
 	}
-	hintCache, err := chainntnfs.NewHeightHintCache(db)
+	testCfg := chainntnfs.Config{
+		HeightHintCacheQueryDisable: false,
+	}
+	hintCache, err := chainntnfs.NewHeightHintCache(testCfg, db)
 	if err != nil {
 		t.Fatalf("unable to create hint cache: %v", err)
 	}

--- a/chainntnfs/btcdnotify/btcd_test.go
+++ b/chainntnfs/btcdnotify/btcd_test.go
@@ -38,7 +38,10 @@ func initHintCache(t *testing.T) *chainntnfs.HeightHintCache {
 	if err != nil {
 		t.Fatalf("unable to create db: %v", err)
 	}
-	hintCache, err := chainntnfs.NewHeightHintCache(db)
+	testCfg := chainntnfs.Config{
+		HeightHintCacheQueryDisable: false,
+	}
+	hintCache, err := chainntnfs.NewHeightHintCache(testCfg, db)
 	if err != nil {
 		t.Fatalf("unable to create hint cache: %v", err)
 	}

--- a/chainntnfs/height_hint_cache.go
+++ b/chainntnfs/height_hint_cache.go
@@ -35,6 +35,15 @@ var (
 	ErrConfirmHintNotFound = errors.New("confirm hint not found")
 )
 
+// Config contains the HeightHintCache configuration
+type Config struct {
+	// HeightHintCacheQueryDisable prevents reliance on the Height Hint Cache.
+	// This is necessary to recover from an edge case when the height
+	// recorded in the cache is higher than the actual height of a spend,
+	// causing a channel to become "stuck" in a pending close state.
+	HeightHintCacheQueryDisable bool
+}
+
 // SpendHintCache is an interface whose duty is to cache spend hints for
 // outpoints. A spend hint is defined as the earliest height in the chain at
 // which an outpoint could have been spent within.
@@ -74,7 +83,8 @@ type ConfirmHintCache interface {
 // ConfirmHintCache interfaces backed by a channeldb DB instance where the hints
 // will be stored.
 type HeightHintCache struct {
-	db *channeldb.DB
+	cfg Config
+	db  *channeldb.DB
 }
 
 // Compile-time checks to ensure HeightHintCache satisfies the SpendHintCache
@@ -83,8 +93,8 @@ var _ SpendHintCache = (*HeightHintCache)(nil)
 var _ ConfirmHintCache = (*HeightHintCache)(nil)
 
 // NewHeightHintCache returns a new height hint cache backed by a database.
-func NewHeightHintCache(db *channeldb.DB) (*HeightHintCache, error) {
-	cache := &HeightHintCache{db}
+func NewHeightHintCache(cfg Config, db *channeldb.DB) (*HeightHintCache, error) {
+	cache := &HeightHintCache{cfg, db}
 	if err := cache.initBuckets(); err != nil {
 		return nil, err
 	}
@@ -148,6 +158,10 @@ func (c *HeightHintCache) CommitSpendHint(height uint32,
 // cache for the outpoint.
 func (c *HeightHintCache) QuerySpendHint(spendRequest SpendRequest) (uint32, error) {
 	var hint uint32
+	if c.cfg.HeightHintCacheQueryDisable {
+		Log.Debugf("Ignoring spend height hint for %v (height hint cache query disabled)", spendRequest)
+		return 0, nil
+	}
 	err := kvdb.View(c.db, func(tx kvdb.RTx) error {
 		spendHints := tx.ReadBucket(spendHintBucket)
 		if spendHints == nil {
@@ -242,6 +256,10 @@ func (c *HeightHintCache) CommitConfirmHint(height uint32,
 // the cache for the transaction hash.
 func (c *HeightHintCache) QueryConfirmHint(confRequest ConfRequest) (uint32, error) {
 	var hint uint32
+	if c.cfg.HeightHintCacheQueryDisable {
+		Log.Debugf("Ignoring confirmation height hint for %v (height hint cache query disabled)", confRequest)
+		return 0, nil
+	}
 	err := kvdb.View(c.db, func(tx kvdb.RTx) error {
 		confirmHints := tx.ReadBucket(confirmHintBucket)
 		if confirmHints == nil {

--- a/chainntnfs/height_hint_cache_test.go
+++ b/chainntnfs/height_hint_cache_test.go
@@ -21,7 +21,10 @@ func initHintCache(t *testing.T) *HeightHintCache {
 	if err != nil {
 		t.Fatalf("unable to create db: %v", err)
 	}
-	hintCache, err := NewHeightHintCache(db)
+	testCfg := Config{
+		HeightHintCacheQueryDisable: false,
+	}
+	hintCache, err := NewHeightHintCache(testCfg, db)
 	if err != nil {
 		t.Fatalf("unable to create hint cache: %v", err)
 	}

--- a/chainntnfs/interface_test.go
+++ b/chainntnfs/interface_test.go
@@ -1911,7 +1911,10 @@ func TestInterfaces(t *testing.T) {
 		if err != nil {
 			t.Fatalf("unable to create db: %v", err)
 		}
-		hintCache, err := chainntnfs.NewHeightHintCache(db)
+		testCfg := chainntnfs.Config{
+			HeightHintCacheQueryDisable: false,
+		}
+		hintCache, err := chainntnfs.NewHeightHintCache(testCfg, db)
 		if err != nil {
 			t.Fatalf("unable to create height hint cache: %v", err)
 		}

--- a/chainregistry.go
+++ b/chainregistry.go
@@ -219,8 +219,14 @@ func newChainControlFromConfig(cfg *Config, chanDB *channeldb.DB,
 
 	var err error
 
+	heightHintCacheConfig := chainntnfs.Config{
+		HeightHintCacheQueryDisable: cfg.HeightHintCacheQueryDisable,
+	}
+	if cfg.HeightHintCacheQueryDisable {
+		ltndLog.Infof("Height Hint Cache Queries disabled")
+	}
 	// Initialize the height hint cache within the chain directory.
-	hintCache, err := chainntnfs.NewHeightHintCache(chanDB)
+	hintCache, err := chainntnfs.NewHeightHintCache(heightHintCacheConfig, chanDB)
 	if err != nil {
 		return nil, fmt.Errorf("unable to initialize height hint "+
 			"cache: %v", err)

--- a/config.go
+++ b/config.go
@@ -58,6 +58,7 @@ const (
 	defaultChanStatusSampleInterval      = time.Minute
 	defaultChanEnableTimeout             = 19 * time.Minute
 	defaultChanDisableTimeout            = 20 * time.Minute
+	defaultHeightHintCacheQueryDisable   = false
 	defaultMaxLogFiles                   = 3
 	defaultMaxLogFileSize                = 10
 	defaultMinBackoff                    = time.Second
@@ -205,10 +206,10 @@ type Config struct {
 	ChanEnableTimeout             time.Duration `long:"chan-enable-timeout" description:"The duration that a peer connection must be stable before attempting to send a channel update to reenable or cancel a pending disables of the peer's channels on the network."`
 	ChanDisableTimeout            time.Duration `long:"chan-disable-timeout" description:"The duration that must elapse after first detecting that an already active channel is actually inactive and sending channel update disabling it to the network. The pending disable can be canceled if the peer reconnects and becomes stable for chan-enable-timeout before the disable update is sent."`
 	ChanStatusSampleInterval      time.Duration `long:"chan-status-sample-interval" description:"The polling interval between attempts to detect if an active channel has become inactive due to its peer going offline."`
-
-	Alias       string `long:"alias" description:"The node alias. Used as a moniker by peers and intelligence services"`
-	Color       string `long:"color" description:"The color of the node in hex format (i.e. '#3399FF'). Used to customize node appearance in intelligence services"`
-	MinChanSize int64  `long:"minchansize" description:"The smallest channel size (in satoshis) that we should accept. Incoming channels smaller than this will be rejected"`
+	HeightHintCacheQueryDisable   bool          `long:"height-hint-cache-query-disable" description:"Disable queries from the height-hint cache to try to recover channels stuck in the pending close state. Disabling height hint queries may cause longer chain rescans, resulting in a performance hit. Unset this after channels are unstuck so you can get better performance again."`
+	Alias                         string        `long:"alias" description:"The node alias. Used as a moniker by peers and intelligence services"`
+	Color                         string        `long:"color" description:"The color of the node in hex format (i.e. '#3399FF'). Used to customize node appearance in intelligence services"`
+	MinChanSize                   int64         `long:"minchansize" description:"The smallest channel size (in satoshis) that we should accept. Incoming channels smaller than this will be rejected"`
 
 	NumGraphSyncPeers      int           `long:"numgraphsyncpeers" description:"The number of peers that we should receive new graph updates from. This option can be tuned to save bandwidth for light clients or routing nodes."`
 	HistoricalSyncInterval time.Duration `long:"historicalsyncinterval" description:"The polling interval between historical graph sync attempts. Each historical graph sync attempt ensures we reconcile with the remote peer's graph from the genesis block."`
@@ -339,6 +340,7 @@ func DefaultConfig() Config {
 		ChanStatusSampleInterval:      defaultChanStatusSampleInterval,
 		ChanEnableTimeout:             defaultChanEnableTimeout,
 		ChanDisableTimeout:            defaultChanDisableTimeout,
+		HeightHintCacheQueryDisable:   defaultHeightHintCacheQueryDisable,
 		Alias:                         defaultAlias,
 		Color:                         defaultColor,
 		MinChanSize:                   int64(minChanFundingSize),

--- a/lnwallet/interface_test.go
+++ b/lnwallet/interface_test.go
@@ -2964,7 +2964,10 @@ func TestLightningWallet(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unable to create db: %v", err)
 	}
-	hintCache, err := chainntnfs.NewHeightHintCache(db)
+	testCfg := chainntnfs.Config{
+		HeightHintCacheQueryDisable: false,
+	}
+	hintCache, err := chainntnfs.NewHeightHintCache(testCfg, db)
 	if err != nil {
 		t.Fatalf("unable to create height hint cache: %v", err)
 	}


### PR DESCRIPTION
Disable Height Hint Cache Queries is a new configuration option that, as the name implies, disables queries on the height hint cache. This allows lnd node operators to recover from stuck pending channels due to cached incorrect-height hints. The following describes the problem:

**Problem description**
A busy node that goes offline for several days can end up with a lot of closed channels. If the node remains down long enough, when it restarts it will look for channel closure transactions by scanning the chain. Because such rescans of the chain are "expensive" (performance/time), a cache called the "height hint cache" is used. But if this cache has the wrong height in it, the node will never be able to find the channel closure transactions. For example, If the cached height is 630,000, but the actual confirmation happened before (say 625,000), the rescan will miss the confirmation transaction because it won't search far enough in the past. To recover from this edge case, the node operator needs to disable the cache, forcing the node to rescan from the earliest block (ie. from the block right after the funding transaction confirmation I think ?). Stuck channels will get resolved. 

Since my node had ended up in this situation _twice_, I had to manually disable the cache in a very ugly way, by breaking the query function and returning an error. This is the easy and clean way to do it. 

**Solution**

A new configuration option is added ```height-hint-cache-query-disable```. From the lnd help:

```
--height-hint-cache-query-disable                       Disable queries from the height-hint cache to try to recover channels stuck in the
                                                              pending close state. Disabling height hint queries may cause longer chain rescans,
                                                              resulting in a performance hit. Unset this after channels are unstuck so you can
                                                              get better performance again.
```

Set the option on the command line with ``` lnd --height-hint-cache-query-disable``` or in the configuration file
```
height-hint-cache-query-disable=1
```

The "solution" needs to be applied only for as long as the node is rescanning for the stuck channels. Once it clears them, you can unset this option to recover the lost performance

**How it works**

As the option's name implies, this disables the _queries_ of the height hint cache. It does not disable the cache. Importantly, while the node will ignore previously cached heights, it will add new height hints to the cache as it finds spends and confirmations while operating under this option, thereby "sanitizing" the height hints to the correct values. 

**Logging**

On initial startup, the chain registry will log a message at INFO level to notify us that the height hint cache queries have been disabled:

```Height Hint Cache Queries disabled```

As the node starts the chain watcher for the different channels, it logs the fact that it is ignoring height hints:
```
2020-06-24 21:56:46.823 [DBG] CNCT: Starting chain watcher for ChannelPoint(bce21...
2020-06-24 21:56:46.823 [DBG] NTFN: Ignoring spend height hint for outpoint=bce21... (height hint cache query disabled)
2020-06-24 21:56:46.828 [INF] NTFN: Dispatching historical spend rescan for outpoint=bce21... start=632580, end=636197
```

The same is done for confirmations:
```
2020-06-24 21:56:49.102 [DBG] NTFN: Ignoring confirmation height hint for txid=3d68... (height hint cache query disabled)
2020-06-24 21:56:49.102 [INF] NTFN: New confirmation subscription: conf_id=1, txid=3d68..., num_confs=1 height_hint=631068
2020-06-24 21:56:49.102 [DBG] NTFN: Dispatching historical confirmation rescan for txid=3d68...
```

**Result**

All pending channels cleared within an hour!

**Code Changes & Testing**

I've tried to follow the code conventions and formatting (go fmt), I've also tried to keep the code changes to a minimum. If I missed anything or did it wrong, please let me know so I can add fixes. 




 


