### PR TITLE
Skip funding confirmation

### DIFF
--- a/channeldb/channel_test.go
+++ b/channeldb/channel_test.go
@@ -194,7 +194,7 @@ func createTestChannel(t *testing.T, cdb *DB,
 	}
 
 	// Mark the channel as open with the short channel id provided.
-	err = params.channel.MarkAsOpen(params.channel.ShortChannelID)
+	err = params.channel.MarkAsOpen(params.channel.ShortChannelID, true)
 	if err != nil {
 		t.Fatalf("unable to mark channel open: %v", err)
 	}
@@ -890,7 +890,7 @@ func TestFetchPendingChannels(t *testing.T) {
 		TxIndex:     10,
 		TxPosition:  15,
 	}
-	err = pendingChannels[0].MarkAsOpen(chanOpenLoc)
+	err = pendingChannels[0].MarkAsOpen(chanOpenLoc, true)
 	if err != nil {
 		t.Fatalf("unable to mark channel as open: %v", err)
 	}
@@ -1048,7 +1048,7 @@ func TestFetchWaitingCloseChannels(t *testing.T) {
 		TxIndex:     10,
 		TxPosition:  15,
 	}
-	if err := channels[0].MarkAsOpen(channelConf); err != nil {
+	if err := channels[0].MarkAsOpen(channelConf, true); err != nil {
 		t.Fatalf("unable to mark channel as open: %v", err)
 	}
 
@@ -1177,7 +1177,7 @@ func TestRefreshShortChanID(t *testing.T) {
 		TxPosition:  15,
 	}
 
-	err = state.MarkAsOpen(chanOpenLoc)
+	err = state.MarkAsOpen(chanOpenLoc, true)
 	if err != nil {
 		t.Fatalf("unable to mark channel open: %v", err)
 	}

--- a/config.go
+++ b/config.go
@@ -940,6 +940,13 @@ func ValidateConfig(cfg Config, usageMessage string,
 			return nil, err
 		}
 
+		if cfg.Litecoin.SkipChannelConfirmation && cfg.Litecoin.DefaultNumChanConfs != 1 {
+			str := "%s: defaultchanconfs needs to be 1 if skip-channel-confirmation is enabled"
+			err := fmt.Errorf(str, funcName)
+			_, _ = fmt.Fprintln(os.Stderr, err)
+			return nil, err
+		}
+
 		// Multiple networks can't be selected simultaneously.  Count
 		// number of network flags passed; assign active network params
 		// while we're at it.
@@ -1026,6 +1033,13 @@ func ValidateConfig(cfg Config, usageMessage string,
 		MaxFundingAmount = funding.MaxLtcFundingAmount
 
 	case cfg.Bitcoin.Active:
+		if cfg.Bitcoin.SkipChannelConfirmation && cfg.Bitcoin.DefaultNumChanConfs != 1 {
+			str := "%s: defaultchanconfs needs to be 1 if skip-channel-confirmation is enabled"
+			err := fmt.Errorf(str, funcName)
+			_, _ = fmt.Fprintln(os.Stderr, err)
+			return nil, err
+		}
+
 		// Multiple networks can't be selected simultaneously.  Count
 		// number of network flags passed; assign active network params
 		// while we're at it.

--- a/discovery/gossiper.go
+++ b/discovery/gossiper.go
@@ -1624,7 +1624,7 @@ func (d *AuthenticatedGossiper) processNetworkAnnouncement(
 		// If the advertised inclusionary block is beyond our knowledge
 		// of the chain tip, then we'll ignore for it now.
 		d.Lock()
-		if nMsg.isRemote && isPremature(msg.ShortChannelID, 0) {
+		if nMsg.isRemote && !msg.ShortChannelID.IsFake() && isPremature(msg.ShortChannelID, 0) {
 			log.Infof("Announcement for chan_id=(%v), is "+
 				"premature: advertises height %v, only "+
 				"height %v is known",
@@ -1849,7 +1849,7 @@ func (d *AuthenticatedGossiper) processNetworkAnnouncement(
 		// of the chain tip, then we'll put the announcement in limbo
 		// to be fully verified once we advance forward in the chain.
 		d.Lock()
-		if nMsg.isRemote && isPremature(msg.ShortChannelID, 0) {
+		if nMsg.isRemote && !msg.ShortChannelID.IsFake() && isPremature(msg.ShortChannelID, 0) {
 			log.Infof("Update announcement for "+
 				"short_chan_id(%v), is premature: advertises "+
 				"height %v, only height %v is known",

--- a/feature/default_sets.go
+++ b/feature/default_sets.go
@@ -64,4 +64,8 @@ var defaultSetDesc = setDesc{
 		SetInit:    {}, // I
 		SetNodeAnn: {}, // N
 	},
+	lnwire.SkipFundingConfirmationOptional: {
+		SetInit:    {}, // I
+		SetNodeAnn: {}, // N
+	},
 }

--- a/feature/manager.go
+++ b/feature/manager.go
@@ -23,6 +23,11 @@ type Config struct {
 
 	// NoWumbo unsets any bits signalling support for wumbo channels.
 	NoWumbo bool
+
+	// NoZeroConfChannels signals that this peer doesn't accept zero conf
+	// and will fail accept_channel response that contains minimum_depth
+	// as zero.
+	NoZeroConfChannels bool
 }
 
 // Manager is responsible for generating feature vectors for different requested
@@ -91,6 +96,10 @@ func newManager(cfg Config, desc setDesc) (*Manager, error) {
 		if cfg.NoWumbo {
 			raw.Unset(lnwire.WumboChannelsOptional)
 			raw.Unset(lnwire.WumboChannelsRequired)
+		}
+		if cfg.NoZeroConfChannels {
+			raw.Unset(lnwire.SkipFundingConfirmationOptional)
+			raw.Unset(lnwire.SkipFundingConfirmationRequired)
 		}
 
 		// Ensure that all of our feature sets properly set any

--- a/funding/fake_ids_manager.go
+++ b/funding/fake_ids_manager.go
@@ -1,0 +1,121 @@
+package funding
+
+import (
+	"github.com/lightningnetwork/lnd/channeldb"
+	"github.com/lightningnetwork/lnd/kvdb"
+	"github.com/lightningnetwork/lnd/lnwire"
+)
+
+// FakeIDsManager is an interface for managing fake ids.
+// The implementation keeps a set of fake ids that are currently in use and
+// provide interface for using/releasing such ids.
+type FakeIDsManager interface {
+	// Use marked the given short channel id as used.
+	Use(lnwire.ShortChannelID) error
+
+	// Release released the given short channel id, prune it from the graph and
+	// removes it from the underline storage.
+	Release(lnwire.ShortChannelID) error
+}
+
+// persistentFakeIDsManager is an implementation of FakeIDsManager that uses
+// a persistent storage for keeping the set of used ids.
+type persistentFakeIDsManager struct {
+	db *channeldb.DB
+}
+
+// newPersistentFakeIDsManager creates a new PersistentFakeIDsManager instance.
+// In addition this method also loads all fake channel ids from the channels
+// db and prunes all those ids that were marked as used and do not exist
+// any more.
+func newPersistentFakeIDsManager(db *channeldb.DB) (*persistentFakeIDsManager, error) {
+
+	channels, err := db.FetchAllChannels()
+	if err != nil {
+		return nil, err
+	}
+
+	graph := db.ChannelGraph()
+
+	// We would like to prune from the fake ids bucket all those that are not
+	// in use anymore. We start by create a mapping between ids to channels.
+	fakeIDsToChannels := make(map[uint64]*channeldb.OpenChannel, len(channels))
+	for _, c := range channels {
+		shortID := c.ShortChannelID
+		if shortID.IsFake() {
+			fakeIDsToChannels[shortID.ToUint64()] = c
+		}
+	}
+
+	// We mark each fake id in our bucket that is not associated with
+	// a pending or opened channel for prune.
+	var idsToPrune [][]byte
+	err = kvdb.Update(db, func(tx kvdb.RwTx) error {
+		fakeIDsBucket, err := tx.CreateTopLevelBucket(fakeIDsBucket)
+		if err != nil {
+			return err
+		}
+		return fakeIDsBucket.ForEach(func(k, v []byte) error {
+			shortID := byteOrder.Uint64(k)
+			_, exists := fakeIDsToChannels[shortID]
+			if !exists {
+				log.Infof("prunning fake id from graph %v", shortID)
+				idsToPrune = append(idsToPrune, k)
+			}
+			return nil
+		})
+	}, func() {})
+	if err != nil {
+		return nil, err
+	}
+
+	// We prune first from the graph.
+	for _, id := range idsToPrune {
+		shortID := byteOrder.Uint64(id)
+		if err = graph.DeleteChannelEdges(false, shortID); err != nil {
+			log.Debugf("failed to delete fake edge, probably "+
+				"already deleted %v: %v", shortID, err)
+		}
+	}
+
+	// Now we can safely remove from the fake id store.
+	err = kvdb.Update(db, func(tx kvdb.RwTx) error {
+		fakeIDsBucket := tx.ReadWriteBucket(fakeIDsBucket)
+		for _, id := range idsToPrune {
+			if err := fakeIDsBucket.Delete(id); err != nil {
+				return err
+			}
+		}
+		return nil
+	}, func() {})
+	if err != nil {
+		return nil, err
+	}
+
+	return &persistentFakeIDsManager{db: db}, nil
+}
+
+func (f *persistentFakeIDsManager) Use(
+	fakeID lnwire.ShortChannelID) error {
+
+	err := kvdb.Update(f.db, func(tx kvdb.RwTx) error {
+		fakeIDsBucket := tx.ReadWriteBucket(fakeIDsBucket)
+		var id = make([]byte, 8)
+		byteOrder.PutUint64(id[:8], fakeID.ToUint64())
+		return fakeIDsBucket.Put(id, []byte{})
+	}, func() {})
+	return err
+}
+
+func (f *persistentFakeIDsManager) Release(
+	fakeID lnwire.ShortChannelID) error {
+
+	log.Infof("releasing fake short channel id %v", fakeID)
+	err := kvdb.Update(f.db, func(tx kvdb.RwTx) error {
+		fakeIDsBucket := tx.ReadWriteBucket(fakeIDsBucket)
+		var id = make([]byte, 8)
+		byteOrder.PutUint64(id[:8], fakeID.ToUint64())
+		return fakeIDsBucket.Delete(id)
+	}, func() {})
+	return err
+}

--- a/funding/manager_test.go
+++ b/funding/manager_test.go
@@ -399,7 +399,7 @@ func createTestFundingManager(t *testing.T, privKey *btcec.PrivateKey,
 		},
 		DefaultMinHtlcIn: 5,
 		NumRequiredConfs: func(chanAmt btcutil.Amount,
-			pushAmt lnwire.MilliSatoshi) uint16 {
+			pushAmt lnwire.MilliSatoshi, allowZeroConfs bool) uint16 {
 			return 3
 		},
 		RequiredRemoteDelay: func(amt btcutil.Amount) uint16 {

--- a/htlcswitch/switch.go
+++ b/htlcswitch/switch.go
@@ -2132,10 +2132,10 @@ func (s *Switch) UpdateShortChanID(chanID lnwire.ChannelID) error {
 	s.indexMtx.Lock()
 	defer s.indexMtx.Unlock()
 
-	// Locate the target link in the pending link index. If no such link
-	// exists, then we will ignore the request.
-	link, ok := s.pendingLinkIndex[chanID]
-	if !ok {
+	// Locate the target link to update. If no such link exists, then we will
+	// ignore the request.
+	link, err := s.getLink(chanID)
+	if err != nil {
 		return fmt.Errorf("link %v not found", chanID)
 	}
 

--- a/lncfg/chain.go
+++ b/lncfg/chain.go
@@ -21,15 +21,16 @@ type Chain struct {
 	SigNetChallenge string   `long:"signetchallenge" description:"Connect to a custom signet network defined by this challenge instead of using the global default signet test network -- Can be specified multiple times"`
 	SigNetSeedNode  []string `long:"signetseednode" description:"Specify a seed node for the signet network instead of using the global default signet network seed nodes"`
 
-	DefaultNumChanConfs int                 `long:"defaultchanconfs" description:"The default number of confirmations a channel must have before it's considered open. If this is not set, we will scale the value according to the channel size."`
-	DefaultRemoteDelay  int                 `long:"defaultremotedelay" description:"The default number of blocks we will require our channel counterparty to wait before accessing its funds in case of unilateral close. If this is not set, we will scale the value according to the channel size."`
-	MaxLocalDelay       uint16              `long:"maxlocaldelay" description:"The maximum blocks we will allow our funds to be timelocked before accessing its funds in case of unilateral close. If a peer proposes a value greater than this, we will reject the channel."`
-	MinHTLCIn           lnwire.MilliSatoshi `long:"minhtlc" description:"The smallest HTLC we are willing to accept on our channels, in millisatoshi"`
-	MinHTLCOut          lnwire.MilliSatoshi `long:"minhtlcout" description:"The smallest HTLC we are willing to send out on our channels, in millisatoshi"`
-	BaseFee             lnwire.MilliSatoshi `long:"basefee" description:"The base fee in millisatoshi we will charge for forwarding payments on our channels"`
-	FeeRate             lnwire.MilliSatoshi `long:"feerate" description:"The fee rate used when forwarding payments on our channels. The total fee charged is basefee + (amount * feerate / 1000000), where amount is the forwarded amount."`
-	TimeLockDelta       uint32              `long:"timelockdelta" description:"The CLTV delta we will subtract from a forwarded HTLC's timelock value"`
-	DNSSeeds            []string            `long:"dnsseed" description:"The seed DNS server(s) to use for initial peer discovery. Must be specified as a '<primary_dns>[,<soa_primary_dns>]' tuple where the SOA address is needed for DNS resolution through Tor but is optional for clearnet users. Multiple tuples can be specified, will overwrite the default seed servers."`
+	DefaultNumChanConfs     int                 `long:"defaultchanconfs" description:"The default number of confirmations a channel must have before it's considered open. If this is not set, we will scale the value according to the channel size."`
+	DefaultRemoteDelay      int                 `long:"defaultremotedelay" description:"The default number of blocks we will require our channel counterparty to wait before accessing its funds in case of unilateral close. If this is not set, we will scale the value according to the channel size."`
+	MaxLocalDelay           uint16              `long:"maxlocaldelay" description:"The maximum blocks we will allow our funds to be timelocked before accessing its funds in case of unilateral close. If a peer proposes a value greater than this, we will reject the channel."`
+	MinHTLCIn               lnwire.MilliSatoshi `long:"minhtlc" description:"The smallest HTLC we are willing to accept on our channels, in millisatoshi"`
+	MinHTLCOut              lnwire.MilliSatoshi `long:"minhtlcout" description:"The smallest HTLC we are willing to send out on our channels, in millisatoshi"`
+	BaseFee                 lnwire.MilliSatoshi `long:"basefee" description:"The base fee in millisatoshi we will charge for forwarding payments on our channels"`
+	FeeRate                 lnwire.MilliSatoshi `long:"feerate" description:"The fee rate used when forwarding payments on our channels. The total fee charged is basefee + (amount * feerate / 1000000), where amount is the forwarded amount."`
+	TimeLockDelta           uint32              `long:"timelockdelta" description:"The CLTV delta we will subtract from a forwarded HTLC's timelock value"`
+	DNSSeeds                []string            `long:"dnsseed" description:"The seed DNS server(s) to use for initial peer discovery. Must be specified as a '<primary_dns>[,<soa_primary_dns>]' tuple where the SOA address is needed for DNS resolution through Tor but is optional for clearnet users. Multiple tuples can be specified, will overwrite the default seed servers."`
+	SkipChannelConfirmation bool                `long:"skip-channel-confirmation" description:"Whether or not to wait for a channel to confirm on-chain before making it operational"`
 }
 
 // Validate performs validation on our chain config.

--- a/lncfg/protocol.go
+++ b/lncfg/protocol.go
@@ -23,6 +23,11 @@ type ProtocolOptions struct {
 	// NoAnchors should be set if we don't want to support opening or accepting
 	// channels having the anchor commitment type.
 	NoAnchors bool `long:"no-anchors" description:"disable support for anchor commitments"`
+
+	// ZeroConfChans should be set if we want to enable support for zero conf
+	// channels (channels that become operational before funding transaction
+	// was confirmed).
+	ZeroConfChans bool `long:"zero-conf-channels" description:"if set, then lnd will accept zero as minimum_depth in accept_channel message"`
 }
 
 // Wumbo returns true if lnd should permit the creation and acceptance of wumbo
@@ -35,4 +40,10 @@ func (l *ProtocolOptions) Wumbo() bool {
 // commitment type.
 func (l *ProtocolOptions) NoAnchorCommitments() bool {
 	return l.NoAnchors
+}
+
+// ZeroConf returns true if lnd accepts zero confs channels.
+// channels.
+func (l *ProtocolOptions) ZeroConf() bool {
+	return l.ZeroConfChans
 }

--- a/lncfg/protocol_rpctest.go
+++ b/lncfg/protocol_rpctest.go
@@ -23,6 +23,11 @@ type ProtocolOptions struct {
 	// Anchors enables anchor commitments.
 	// TODO(halseth): transition itests to anchors instead!
 	Anchors bool `long:"anchors" description:"enable support for anchor commitments"`
+
+	// ZeroConfChans should be set if we want to enable support for zero conf
+	// channels (channels that become operational before funding transaction
+	// was confirmed).
+	ZeroConfChans bool `long:"zero-conf-channels" description:"if set, then lnd will accept zero as minimum_depth in accept_channel message"`
 }
 
 // Wumbo returns true if lnd should permit the creation and acceptance of wumbo
@@ -35,4 +40,10 @@ func (l *ProtocolOptions) Wumbo() bool {
 // commitment type.
 func (l *ProtocolOptions) NoAnchorCommitments() bool {
 	return !l.Anchors
+}
+
+// ZeroConf returns true if lnd accepts zero confs channels.
+// channels.
+func (l *ProtocolOptions) ZeroConf() bool {
+	return l.ZeroConfChans
 }

--- a/lnwallet/reservation.go
+++ b/lnwallet/reservation.go
@@ -382,6 +382,9 @@ func (r *ChannelReservation) SetNumConfsRequired(numConfs uint16) {
 	defer r.Unlock()
 
 	r.partialState.NumConfsRequired = numConfs
+	if numConfs == 0 {
+		r.partialState.ChanType |= channeldb.ZeroConfBit
+	}
 }
 
 // CommitConstraints takes the constraints that the remote party specifies for

--- a/lnwallet/wallet.go
+++ b/lnwallet/wallet.go
@@ -143,6 +143,10 @@ type InitFundingReserveMsg struct {
 	// output selected to fund the channel should satisfy.
 	MinConfs int32
 
+	// AllowSkipFundingConfirmation indicates that the initiator won't reject
+	// the responder request to skip channel confirmation (min_depth=0).
+	AllowSkipFundingConfirmation bool
+
 	// CommitType indicates what type of commitment type the channel should
 	// be using, like tweakless or anchors.
 	CommitType CommitmentType

--- a/lnwire/features.go
+++ b/lnwire/features.go
@@ -138,6 +138,15 @@ const (
 	// of a payment supports accepts spontaneous payments, i.e.
 	// sender-generated preimages according to BOLT XX.
 	AMPOptional FeatureBit = 31
+	// SkipFundingConfirmationRequired is a required feature bit that signals that the node
+	// supports initiated channels to be made operational before funding transaction is
+	// confirmed on chain
+	SkipFundingConfirmationRequired FeatureBit = 1338
+
+	// SkipFundingConfirmationOptional is a required feature bit that signals that the node
+	// supports initiated channels to be made operational before funding transaction is
+	// confirmed on chain
+	SkipFundingConfirmationOptional FeatureBit = 1339
 
 	// ExplicitChannelTypeRequired is a required bit that denotes that a
 	// connection established with this node is to use explicit channel
@@ -181,31 +190,33 @@ func (b FeatureBit) IsRequired() bool {
 // feature bits must be assigned a name in this mapping, and feature bit pairs
 // must be assigned together for correct behavior.
 var Features = map[FeatureBit]string{
-	DataLossProtectRequired:       "data-loss-protect",
-	DataLossProtectOptional:       "data-loss-protect",
-	InitialRoutingSync:            "initial-routing-sync",
-	UpfrontShutdownScriptRequired: "upfront-shutdown-script",
-	UpfrontShutdownScriptOptional: "upfront-shutdown-script",
-	GossipQueriesRequired:         "gossip-queries",
-	GossipQueriesOptional:         "gossip-queries",
-	TLVOnionPayloadRequired:       "tlv-onion",
-	TLVOnionPayloadOptional:       "tlv-onion",
-	StaticRemoteKeyOptional:       "static-remote-key",
-	StaticRemoteKeyRequired:       "static-remote-key",
-	PaymentAddrOptional:           "payment-addr",
-	PaymentAddrRequired:           "payment-addr",
-	MPPOptional:                   "multi-path-payments",
-	MPPRequired:                   "multi-path-payments",
-	AnchorsRequired:               "anchor-commitments",
-	AnchorsOptional:               "anchor-commitments",
-	AnchorsZeroFeeHtlcTxRequired:  "anchors-zero-fee-htlc-tx",
-	AnchorsZeroFeeHtlcTxOptional:  "anchors-zero-fee-htlc-tx",
-	WumboChannelsRequired:         "wumbo-channels",
-	WumboChannelsOptional:         "wumbo-channels",
-	AMPRequired:                   "amp",
-	AMPOptional:                   "amp",
-	ExplicitChannelTypeOptional:   "explicit-commitment-type",
-	ExplicitChannelTypeRequired:   "explicit-commitment-type",
+	DataLossProtectRequired:         "data-loss-protect",
+	DataLossProtectOptional:         "data-loss-protect",
+	InitialRoutingSync:              "initial-routing-sync",
+	UpfrontShutdownScriptRequired:   "upfront-shutdown-script",
+	UpfrontShutdownScriptOptional:   "upfront-shutdown-script",
+	GossipQueriesRequired:           "gossip-queries",
+	GossipQueriesOptional:           "gossip-queries",
+	TLVOnionPayloadRequired:         "tlv-onion",
+	TLVOnionPayloadOptional:         "tlv-onion",
+	StaticRemoteKeyOptional:         "static-remote-key",
+	StaticRemoteKeyRequired:         "static-remote-key",
+	PaymentAddrOptional:             "payment-addr",
+	PaymentAddrRequired:             "payment-addr",
+	MPPOptional:                     "multi-path-payments",
+	MPPRequired:                     "multi-path-payments",
+	AnchorsRequired:                 "anchor-commitments",
+	AnchorsOptional:                 "anchor-commitments",
+	AnchorsZeroFeeHtlcTxRequired:    "anchors-zero-fee-htlc-tx",
+	AnchorsZeroFeeHtlcTxOptional:    "anchors-zero-fee-htlc-tx",
+	WumboChannelsRequired:           "wumbo-channels",
+	WumboChannelsOptional:           "wumbo-channels",
+	AMPRequired:                     "amp",
+	AMPOptional:                     "amp",
+	ExplicitChannelTypeOptional:     "explicit-commitment-type",
+	ExplicitChannelTypeRequired:     "explicit-commitment-type",
+	SkipFundingConfirmationOptional: "skip-funding-confirmation",
+	SkipFundingConfirmationRequired: "skip-funding-confirmation",
 }
 
 // RawFeatureVector represents a set of feature bits as defined in BOLT-09.  A

--- a/lnwire/short_channel_id.go
+++ b/lnwire/short_channel_id.go
@@ -34,6 +34,20 @@ func NewShortChanIDFromInt(chanID uint64) ShortChannelID {
 	}
 }
 
+// NewFakeShortChanIDFromPendingID generates a new short channel that its block
+// height is between 2^17 = 131072 and 2^17 + 2^18 - 1 = 393215
+func NewFakeShortChanIDFromPendingID(pendingID uint64) ShortChannelID {
+	c := NewShortChanIDFromInt(pendingID)
+	c.BlockHeight = (c.BlockHeight >> 6) + (1 << 17)
+	return c
+}
+
+// IsFake test if this is a fake channel id. It does it by making sure the
+// block height is between 2^17 = 131072 and 2^17 + 2^18 - 1 = 393215
+func (c ShortChannelID) IsFake() bool {
+	return c.BlockHeight >= (1<<17) && c.BlockHeight < (3<<17)
+}
+
 // ToUint64 converts the ShortChannelID into a compact format encoded within a
 // uint64 (8 bytes).
 func (c ShortChannelID) ToUint64() uint64 {

--- a/sample-lnd.conf
+++ b/sample-lnd.conf
@@ -515,6 +515,8 @@ bitcoin.node=btcd
 ; bitcoin.dnsseed=seed1.test.lightning
 ; bitcoin.dnsseed=seed2.test.lightning,soa.seed2.test.lightning
 
+; Whether or not to wait for a channel to confirm on-chain before making it operational.
+; bitcoin.skip-channel-confirmation=false
 
 [Btcd]
 
@@ -716,6 +718,8 @@ litecoin.node=ltcd
 ; litecoin.dnsseed=seed1.test-ltc.lightning
 ; litecoin.dnsseed=seed2.test-ltc.lightning,soa.seed2.test-ltc.lightning
 
+; Whether or not to wait for a channel to confirm on-chain before making it operational.
+; litecoin.skip-channel-confirmation=false
 
 [Ltcd]
 
@@ -1080,6 +1084,8 @@ litecoin.node=ltcd
 ; (Deprecates the previous "protocol.anchors" setting.)
 ; protocol.no-anchors=true
 
+; if set, then lnd will accept zero as minimum_depth in accept_channel message
+; protocol.zero-conf-channels
 
 [db]
 

--- a/server.go
+++ b/server.go
@@ -409,10 +409,11 @@ func newServer(cfg *Config, listenAddrs []net.Addr,
 	)
 
 	featureMgr, err := feature.NewManager(feature.Config{
-		NoTLVOnion:        cfg.ProtocolOptions.LegacyOnion(),
-		NoStaticRemoteKey: cfg.ProtocolOptions.NoStaticRemoteKey(),
-		NoAnchors:         cfg.ProtocolOptions.NoAnchorCommitments(),
-		NoWumbo:           !cfg.ProtocolOptions.Wumbo(),
+		NoTLVOnion:         cfg.ProtocolOptions.LegacyOnion(),
+		NoStaticRemoteKey:  cfg.ProtocolOptions.NoStaticRemoteKey(),
+		NoAnchors:          cfg.ProtocolOptions.NoAnchorCommitments(),
+		NoWumbo:            !cfg.ProtocolOptions.Wumbo(),
+		NoZeroConfChannels: !cfg.ProtocolOptions.ZeroConf(),
 	})
 	if err != nil {
 		return nil, err
@@ -1084,7 +1085,7 @@ func newServer(cfg *Config, listenAddrs []net.Addr,
 		DefaultRoutingPolicy: cc.RoutingPolicy,
 		DefaultMinHtlcIn:     cc.MinHtlcIn,
 		NumRequiredConfs: func(chanAmt btcutil.Amount,
-			pushAmt lnwire.MilliSatoshi) uint16 {
+			pushAmt lnwire.MilliSatoshi, allowZeroConfs bool) uint16 {
 			// For large channels we increase the number
 			// of confirmations we require for the
 			// channel to be considered open. As it is
@@ -1100,7 +1101,7 @@ func newServer(cfg *Config, listenAddrs []net.Addr,
 			// In case the user has explicitly specified
 			// a default value for the number of
 			// confirmations, we use it.
-			if chainCfg.SkipChannelConfirmation {
+			if chainCfg.SkipChannelConfirmation && allowZeroConfs {
 				return 0
 			}
 			defaultConf := uint16(chainCfg.DefaultNumChanConfs)

--- a/server.go
+++ b/server.go
@@ -1100,6 +1100,9 @@ func newServer(cfg *Config, listenAddrs []net.Addr,
 			// In case the user has explicitly specified
 			// a default value for the number of
 			// confirmations, we use it.
+			if chainCfg.SkipChannelConfirmation {
+				return 0
+			}
 			defaultConf := uint16(chainCfg.DefaultNumChanConfs)
 			if defaultConf != 0 {
 				return defaultConf


### PR DESCRIPTION
This PR introduces the ability to skip a channel funding transaction confirmation, making the channel fully operational before its on-chain confirmation (aka a zero-conf channel).
Till confirmation, this channel requires trust between its two parties and in the case of a remote initiator, it puts the received funds of the local party at risk.
Nevertheless, there are cases where it makes sense to support this behavior. For example, in cases both parties decide to trust each other. Or, in cases where trust between the parties already exists (buying a pre-loaded channel from a service like Bitrefill).

We at Breez want this capability to support the following:

**Immediate on-boarding:**
Currently, new users need to wait for channel confirmation before being able to receive. This PR, together with https://github.com/lightningnetwork/lnd/pull/4018, enables us to provide a far better user experience as follows:
Let's say Alice wants to pay a new Breez user, Bob.

1. Bob is connected to the Breez node and issues an invoice with a routing hint that points to a fake channel between Bob and the Breez node.
2. When Alice pays Bob's invoice, the Breez node intercepts the HTLC and holds it.
3. Then, the Breez node does the following:
    - Opens a channel to Bob.
    - Uses the fake short channel id in the routing hints to skip funding confirmation.
    - Waits for the channel to become active.
    - Pays Bob the original Alices' tx (potentially, minus a service fee https://github.com/lightningnetwork/lnd/pull/4423)
    - Settles backword.
 4. When Bob has a new pending channel it is his choice whether to call SkipFundingConfirmation or use the default behavior that requires confirmation.
In case Bob decided to skip confirmation all received payments are held, giving him control whether to settle additional payments and add to existing trust between the parties.

**Behavior:**
In order to skip confirmation, the funding locked message should be sent and received on both sides.
Both parties need to agree on a “fake” short channel id and because the protocol doesn't define any kind of message that supports it,  a simplified approach was taken where both parties use the "temporary_channel_id" 58 first bits to create a "fake" short channel id. This leaves 18 bits for the block height which ensures it will be less than 2^18 = 262144.


This PR is a work in progress on which I would like to get early feedback regarding the overall approach.
