### PR TITLE
multi: add relative thaw height interpretation

### DIFF
--- a/lnrpc/rpc.pb.go
+++ b/lnrpc/rpc.pb.go
@@ -2891,7 +2891,9 @@ type Channel struct {
 	//frozen channel doest not allow a cooperative channel close by the
 	//initiator. The thaw_height is the height that this restriction stops
 	//applying to the channel. This field is optional, not setting it or using a
-	//value of zero will mean the channel has no additional restrictions.
+	//value of zero will mean the channel has no additional restrictions. The
+	//height can be interpreted in two ways: as a relative height if the value is
+	//less than 500,000, or as an absolute height otherwise.
 	ThawHeight uint32 `protobuf:"varint,28,opt,name=thaw_height,json=thawHeight,proto3" json:"thaw_height,omitempty"`
 	// List constraints for the local node.
 	LocalConstraints *ChannelConstraints `protobuf:"bytes,29,opt,name=local_constraints,json=localConstraints,proto3" json:"local_constraints,omitempty"`
@@ -5051,10 +5053,11 @@ type ChanPointShim struct {
 	//channel ID.
 	PendingChanId []byte `protobuf:"bytes,5,opt,name=pending_chan_id,json=pendingChanId,proto3" json:"pending_chan_id,omitempty"`
 	//
-	//This uint32 indicates if this channel is to be considered 'frozen'. A
-	//frozen channel does not allow a cooperative channel close by the
-	//initiator. The thaw_height is the height that this restriction stops
-	//applying to the channel.
+	//This uint32 indicates if this channel is to be considered 'frozen'. A frozen
+	//channel does not allow a cooperative channel close by the initiator. The
+	//thaw_height is the height that this restriction stops applying to the
+	//channel. The height can be interpreted in two ways: as a relative height if
+	//the value is less than 500,000, or as an absolute height otherwise.
 	ThawHeight           uint32   `protobuf:"varint,6,opt,name=thaw_height,json=thawHeight,proto3" json:"thaw_height,omitempty"`
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
 	XXX_unrecognized     []byte   `json:"-"`

--- a/lnrpc/rpc.proto
+++ b/lnrpc/rpc.proto
@@ -1157,7 +1157,9 @@ message Channel {
     frozen channel doest not allow a cooperative channel close by the
     initiator. The thaw_height is the height that this restriction stops
     applying to the channel. This field is optional, not setting it or using a
-    value of zero will mean the channel has no additional restrictions.
+    value of zero will mean the channel has no additional restrictions. The
+    height can be interpreted in two ways: as a relative height if the value is
+    less than 500,000, or as an absolute height otherwise.
     */
     uint32 thaw_height = 28;
 
@@ -1665,10 +1667,11 @@ message ChanPointShim {
     bytes pending_chan_id = 5;
 
     /*
-    This uint32 indicates if this channel is to be considered 'frozen'. A
-    frozen channel does not allow a cooperative channel close by the
-    initiator. The thaw_height is the height that this restriction stops
-    applying to the channel.
+    This uint32 indicates if this channel is to be considered 'frozen'. A frozen
+    channel does not allow a cooperative channel close by the initiator. The
+    thaw_height is the height that this restriction stops applying to the
+    channel. The height can be interpreted in two ways: as a relative height if
+    the value is less than 500,000, or as an absolute height otherwise.
     */
     uint32 thaw_height = 6;
 }

--- a/lnrpc/rpc.swagger.json
+++ b/lnrpc/rpc.swagger.json
@@ -2466,7 +2466,7 @@
         "thaw_height": {
           "type": "integer",
           "format": "int64",
-          "description": "This uint32 indicates if this channel is to be considered 'frozen'. A\nfrozen channel does not allow a cooperative channel close by the\ninitiator. The thaw_height is the height that this restriction stops\napplying to the channel."
+          "description": "This uint32 indicates if this channel is to be considered 'frozen'. A frozen\nchannel does not allow a cooperative channel close by the initiator. The\nthaw_height is the height that this restriction stops applying to the\nchannel. The height can be interpreted in two ways: as a relative height if\nthe value is less than 500,000, or as an absolute height otherwise."
         }
       }
     },
@@ -2608,7 +2608,7 @@
         "thaw_height": {
           "type": "integer",
           "format": "int64",
-          "description": "This uint32 indicates if this channel is to be considered 'frozen'. A\nfrozen channel doest not allow a cooperative channel close by the\ninitiator. The thaw_height is the height that this restriction stops\napplying to the channel. This field is optional, not setting it or using a\nvalue of zero will mean the channel has no additional restrictions."
+          "description": "This uint32 indicates if this channel is to be considered 'frozen'. A\nfrozen channel doest not allow a cooperative channel close by the\ninitiator. The thaw_height is the height that this restriction stops\napplying to the channel. This field is optional, not setting it or using a\nvalue of zero will mean the channel has no additional restrictions. The\nheight can be interpreted in two ways: as a relative height if the value is\nless than 500,000, or as an absolute height otherwise."
         },
         "local_constraints": {
           "$ref": "#/definitions/lnrpcChannelConstraints",

--- a/lntest/itest/lnd_test.go
+++ b/lntest/itest/lnd_test.go
@@ -14501,11 +14501,6 @@ func testExternalFundingChanPoint(net *lntest.NetworkHarness, t *harnessTest) {
 		t.Fatalf("unable to gen pending chan ID: %v", err)
 	}
 
-	_, currentHeight, err := net.Miner.Node.GetBestBlock()
-	if err != nil {
-		t.Fatalf("unable to get current blockheight %v", err)
-	}
-
 	// Now that we have the pending channel ID, Dave (our responder) will
 	// register the intent to receive a new channel funding workflow using
 	// the pending channel ID.
@@ -14514,7 +14509,7 @@ func testExternalFundingChanPoint(net *lntest.NetworkHarness, t *harnessTest) {
 			FundingTxidBytes: txid[:],
 		},
 	}
-	thawHeight := uint32(currentHeight + 10)
+	thawHeight := uint32(10)
 	chanPointShim := &lnrpc.ChanPointShim{
 		Amt:       int64(chanSize),
 		ChanPoint: chanPoint,


### PR DESCRIPTION
This is useful when we wish to have a channel frozen for a specific amount of blocks after its confirmation. This could also be done with an absolute thaw height, but it does not suit cases where a strict block delta needs to be enforced, as it's not possible to know for certain when a channel will be included in the chain. To work around this, we add a relative interpretation of the field, where if its value is below 500,000, then it's interpreted as a relative height. This approach allows us to prevent further database modifications to account for a relative thaw height.