### PR TITLE
multi: add labels to lnd native transactions

### DIFF
--- a/breacharbiter.go
+++ b/breacharbiter.go
@@ -20,6 +20,7 @@ import (
 	"github.com/lightningnetwork/lnd/channeldb/kvdb"
 	"github.com/lightningnetwork/lnd/htlcswitch"
 	"github.com/lightningnetwork/lnd/input"
+	"github.com/lightningnetwork/lnd/labels"
 	"github.com/lightningnetwork/lnd/lnwallet"
 	"github.com/lightningnetwork/lnd/lnwallet/chainfee"
 )
@@ -566,7 +567,8 @@ justiceTxBroadcast:
 
 	// We'll now attempt to broadcast the transaction which finalized the
 	// channel's retribution against the cheating counter party.
-	err = b.cfg.PublishTransaction(finalTx, "")
+	label := labels.MakeLabel(labels.LabelTypeJusticeTransaction, nil)
+	err = b.cfg.PublishTransaction(finalTx, label)
 	if err != nil {
 		brarLog.Errorf("Unable to broadcast justice tx: %v", err)
 

--- a/contractcourt/chain_arbitrator.go
+++ b/contractcourt/chain_arbitrator.go
@@ -15,6 +15,7 @@ import (
 	"github.com/lightningnetwork/lnd/channeldb/kvdb"
 	"github.com/lightningnetwork/lnd/clock"
 	"github.com/lightningnetwork/lnd/input"
+	"github.com/lightningnetwork/lnd/labels"
 	"github.com/lightningnetwork/lnd/lnwallet"
 	"github.com/lightningnetwork/lnd/lnwallet/chainfee"
 	"github.com/lightningnetwork/lnd/lnwire"
@@ -715,7 +716,10 @@ func (c *ChainArbitrator) rebroadcast(channel *channeldb.OpenChannel,
 	log.Infof("Re-publishing %s close tx(%v) for channel %v",
 		kind, closeTx.TxHash(), chanPoint)
 
-	err = c.cfg.PublishTx(closeTx, "")
+	label := labels.MakeLabel(
+		labels.LabelTypeChannelClose, &channel.ShortChannelID,
+	)
+	err = c.cfg.PublishTx(closeTx, label)
 	if err != nil && err != lnwallet.ErrDoubleSpend {
 		log.Warnf("Unable to broadcast %s close tx(%v): %v",
 			kind, closeTx.TxHash(), err)

--- a/contractcourt/channel_arbitrator.go
+++ b/contractcourt/channel_arbitrator.go
@@ -16,6 +16,7 @@ import (
 	"github.com/lightningnetwork/lnd/channeldb"
 	"github.com/lightningnetwork/lnd/channeldb/kvdb"
 	"github.com/lightningnetwork/lnd/input"
+	"github.com/lightningnetwork/lnd/labels"
 	"github.com/lightningnetwork/lnd/lntypes"
 	"github.com/lightningnetwork/lnd/lnwallet"
 	"github.com/lightningnetwork/lnd/lnwire"
@@ -874,7 +875,11 @@ func (c *ChannelArbitrator) stateStep(
 
 		// At this point, we'll now broadcast the commitment
 		// transaction itself.
-		if err := c.cfg.PublishTx(closeTx, ""); err != nil {
+		label := labels.MakeLabel(
+			labels.LabelTypeChannelClose, &c.cfg.ShortChanID,
+		)
+
+		if err := c.cfg.PublishTx(closeTx, label); err != nil {
 			log.Errorf("ChannelArbitrator(%v): unable to broadcast "+
 				"close tx: %v", c.cfg.ChanPoint, err)
 			if err != lnwallet.ErrDoubleSpend {

--- a/contractcourt/htlc_success_resolver.go
+++ b/contractcourt/htlc_success_resolver.go
@@ -10,6 +10,7 @@ import (
 	"github.com/davecgh/go-spew/spew"
 	"github.com/lightningnetwork/lnd/channeldb"
 	"github.com/lightningnetwork/lnd/input"
+	"github.com/lightningnetwork/lnd/labels"
 	"github.com/lightningnetwork/lnd/lnwallet"
 	"github.com/lightningnetwork/lnd/sweep"
 )
@@ -157,7 +158,10 @@ func (h *htlcSuccessResolver) Resolve() (ContractResolver, error) {
 		// Regardless of whether an existing transaction was found or newly
 		// constructed, we'll broadcast the sweep transaction to the
 		// network.
-		err := h.PublishTx(h.sweepTx, "")
+		label := labels.MakeLabel(
+			labels.LabelTypeChannelClose, &h.ShortChanID,
+		)
+		err := h.PublishTx(h.sweepTx, label)
 		if err != nil {
 			log.Infof("%T(%x): unable to publish tx: %v",
 				h, h.htlc.RHash[:], err)
@@ -206,7 +210,10 @@ func (h *htlcSuccessResolver) Resolve() (ContractResolver, error) {
 	// the claiming process.
 	//
 	// TODO(roasbeef): after changing sighashes send to tx bundler
-	err := h.PublishTx(h.htlcResolution.SignedSuccessTx, "")
+	label := labels.MakeLabel(
+		labels.LabelTypeChannelClose, &h.ShortChanID,
+	)
+	err := h.PublishTx(h.htlcResolution.SignedSuccessTx, label)
 	if err != nil {
 		return nil, err
 	}

--- a/fundingmanager_test.go
+++ b/fundingmanager_test.go
@@ -421,6 +421,9 @@ func createTestFundingManager(t *testing.T, privKey *btcec.PrivateKey,
 			publTxChan <- txn
 			return nil
 		},
+		UpdateLabel: func(chainhash.Hash, string) error {
+			return nil
+		},
 		ZombieSweeperInterval:         1 * time.Hour,
 		ReservationTimeout:            1 * time.Nanosecond,
 		MaxPendingChannels:            lncfg.DefaultMaxPendingChannels,
@@ -522,6 +525,9 @@ func recreateAliceFundingManager(t *testing.T, alice *testNode) {
 		RequiredRemoteMaxValue: oldCfg.RequiredRemoteMaxValue,
 		PublishTransaction: func(txn *wire.MsgTx, _ string) error {
 			publishChan <- txn
+			return nil
+		},
+		UpdateLabel: func(chainhash.Hash, string) error {
 			return nil
 		},
 		ZombieSweeperInterval: oldCfg.ZombieSweeperInterval,

--- a/labels/labels.go
+++ b/labels/labels.go
@@ -1,12 +1,24 @@
 // Package labels contains labels used to label transactions broadcast by lnd.
 // These labels are used across packages, so they are declared in a separate
 // package to avoid dependency issues.
+//
+// Labels for transactions broadcast by lnd have two set fields followed by an
+// optional set labelled data values, all separated by colons.
+// - Label version: an integer that indicates the version lnd used
+// - Label type: the type of transaction we are labelling
+// - {field name}-{value}: a named field followed by its value, these items are
+//   optional, and there may be more than field present.
+//
+// For version 0 we have the following optional data fields defined:
+// - shortchanid: the short channel ID that a transaction is associated with,
+//   with its value set to the uint64 short channel id.
 package labels
 
 import (
 	"fmt"
 
 	"github.com/btcsuite/btcwallet/wtxmgr"
+	"github.com/lightningnetwork/lnd/lnwire"
 )
 
 // External labels a transaction as user initiated via the api. This
@@ -30,4 +42,51 @@ func ValidateAPI(label string) (string, error) {
 	}
 
 	return label, nil
+}
+
+// LabelVersion versions our labels so they can be easily update to contain
+// new data while still easily string matched.
+type LabelVersion uint8
+
+// LabelVersionZero is the label version for labels that contain label type and
+// channel ID (where available).
+const LabelVersionZero LabelVersion = iota
+
+// LabelType indicates the type of label we are creating. It is a string rather
+// than an int for easy string matching and human-readability.
+type LabelType string
+
+const (
+	// LabelTypeChannelOpen is used to label channel opens.
+	LabelTypeChannelOpen LabelType = "openchannel"
+
+	// LabelTypeChannelClose is used to label channel closes.
+	LabelTypeChannelClose LabelType = "closechannel"
+
+	// LabelTypeJusticeTransaction is used to label justice transactions.
+	LabelTypeJusticeTransaction LabelType = "justicetx"
+
+	// LabelTypeSweepTransaction is used to label sweeps.
+	LabelTypeSweepTransaction LabelType = "sweep"
+)
+
+// LabelField is used to tag a value within a label.
+type LabelField string
+
+const (
+	// ShortChanID is used to tag short channel id values in our labels.
+	ShortChanID LabelField = "shortchanid"
+)
+
+// MakeLabel creates a label with the provided type and short channel id. If
+// our short channel ID is not known, we simply return version:label_type. If
+// we do have a short channel ID set, the label will also contain its value:
+// shortchanid-{int64 chan ID}.
+func MakeLabel(labelType LabelType, channelID *lnwire.ShortChannelID) string {
+	if channelID == nil {
+		return fmt.Sprintf("%v:%v", LabelVersionZero, labelType)
+	}
+
+	return fmt.Sprintf("%v:%v:%v-%v", LabelVersionZero, labelType,
+		ShortChanID, channelID.ToUint64())
 }

--- a/lnwallet/chancloser/chancloser.go
+++ b/lnwallet/chancloser/chancloser.go
@@ -8,6 +8,7 @@ import (
 	"github.com/btcsuite/btcutil"
 	"github.com/davecgh/go-spew/spew"
 	"github.com/lightningnetwork/lnd/htlcswitch"
+	"github.com/lightningnetwork/lnd/labels"
 	"github.com/lightningnetwork/lnd/lnwallet"
 	"github.com/lightningnetwork/lnd/lnwallet/chainfee"
 	"github.com/lightningnetwork/lnd/lnwire"
@@ -551,7 +552,14 @@ func (c *ChanCloser) ProcessCloseMsg(msg lnwire.Message) ([]lnwire.Message,
 				return spew.Sdump(closeTx)
 			}),
 		)
-		if err := c.cfg.BroadcastTx(closeTx, ""); err != nil {
+
+		// Create a close channel label.
+		chanID := c.cfg.Channel.ShortChanID()
+		closeLabel := labels.MakeLabel(
+			labels.LabelTypeChannelClose, &chanID,
+		)
+
+		if err := c.cfg.BroadcastTx(closeTx, closeLabel); err != nil {
 			return nil, false, err
 		}
 

--- a/server.go
+++ b/server.go
@@ -971,8 +971,11 @@ func newServer(cfg *Config, listenAddrs []net.Addr, chanDB *channeldb.DB,
 		IDKey:              nodeKeyECDH.PubKey(),
 		Wallet:             cc.wallet,
 		PublishTransaction: cc.wallet.PublishTransaction,
-		Notifier:           cc.chainNotifier,
-		FeeEstimator:       cc.feeEstimator,
+		UpdateLabel: func(hash chainhash.Hash, label string) error {
+			return cc.wallet.LabelTransaction(hash, label, true)
+		},
+		Notifier:     cc.chainNotifier,
+		FeeEstimator: cc.feeEstimator,
 		SignMessage: func(pubKey *btcec.PublicKey,
 			msg []byte) (input.Signature, error) {
 

--- a/utxonursery.go
+++ b/utxonursery.go
@@ -11,10 +11,10 @@ import (
 	"github.com/btcsuite/btcd/wire"
 	"github.com/btcsuite/btcutil"
 	"github.com/davecgh/go-spew/spew"
-
 	"github.com/lightningnetwork/lnd/chainntnfs"
 	"github.com/lightningnetwork/lnd/channeldb"
 	"github.com/lightningnetwork/lnd/input"
+	"github.com/lightningnetwork/lnd/labels"
 	"github.com/lightningnetwork/lnd/lnwallet"
 	"github.com/lightningnetwork/lnd/sweep"
 )
@@ -867,7 +867,8 @@ func (u *utxoNursery) sweepCribOutput(classHeight uint32, baby *babyOutput) erro
 
 	// We'll now broadcast the HTLC transaction, then wait for it to be
 	// confirmed before transitioning it to kindergarten.
-	err := u.cfg.PublishTransaction(baby.timeoutTx, "")
+	label := labels.MakeLabel(labels.LabelTypeSweepTransaction, nil)
+	err := u.cfg.PublishTransaction(baby.timeoutTx, label)
 	if err != nil && err != lnwallet.ErrDoubleSpend {
 		utxnLog.Errorf("Unable to broadcast baby tx: "+
 			"%v, %v", err, spew.Sdump(baby.timeoutTx))

--- a/watchtower/lookout/punisher.go
+++ b/watchtower/lookout/punisher.go
@@ -2,6 +2,7 @@ package lookout
 
 import (
 	"github.com/btcsuite/btcd/wire"
+	"github.com/lightningnetwork/lnd/labels"
 )
 
 // PunisherConfig houses the resources required by the Punisher.
@@ -42,7 +43,8 @@ func (p *BreachPunisher) Punish(desc *JusticeDescriptor, quit <-chan struct{}) e
 	log.Infof("Publishing justice transaction for client=%s with txid=%s",
 		desc.SessionInfo.ID, justiceTxn.TxHash())
 
-	err = p.cfg.PublishTx(justiceTxn, "")
+	label := labels.MakeLabel(labels.LabelTypeJusticeTransaction, nil)
+	err = p.cfg.PublishTx(justiceTxn, label)
 	if err != nil {
 		log.Errorf("Unable to publish justice txn for client=%s"+
 			"with breach-txid=%s: %v",


### PR DESCRIPTION
Follow up labelling of external transactions with labels for the transaction types we create within lnd. Since these labels will live a life of string matching, a version number and rigid format is added so that string matching is less painful. We start out with channel ID, where available, and a transaction "type". External labels, added in a previous PR, are not updated to this new versioned label because they are not lnd-initiated transactions. Label matching can check this case, then check for a version number.
