### PR TITLE
zpay32: set maximum invoice length to fit into a single QR code

### DIFF
--- a/zpay32/invoice.go
+++ b/zpay32/invoice.go
@@ -81,7 +81,7 @@ const (
 	// maxInvoiceLength is the maximum total length an invoice can have.
 	// This is chosen to be the maximum number of bytes that can fit into a
 	// single QR code: https://en.wikipedia.org/wiki/QR_code#Storage
-	maxInvoiceLength = 7089
+	maxInvoiceLength = 4296
 
 	// DefaultInvoiceExpiry is the default expiry duration from the creation
 	// timestamp if expiry is set to zero.


### PR DESCRIPTION
This commit sets the maximum total length of an invoice to 4296 bytes.

fixes #4415