### PR TITLE
Use static key for ChannelPackager

### DIFF
--- a/breacharbiter_test.go
+++ b/breacharbiter_test.go
@@ -2357,6 +2357,7 @@ func createInitChannels(revocationWindow int) (*lnwallet.LightningChannel, *lnwa
 	shortChanID := lnwire.NewShortChanIDFromInt(
 		binary.BigEndian.Uint64(chanIDBytes[:]),
 	)
+	chanID := lnwire.NewChanIDFromOutPoint(prevOut)
 
 	aliceChannelState := &channeldb.OpenChannel{
 		LocalChanCfg:            aliceCfg,
@@ -2373,7 +2374,7 @@ func createInitChannels(revocationWindow int) (*lnwallet.LightningChannel, *lnwa
 		LocalCommitment:         aliceCommit,
 		RemoteCommitment:        aliceCommit,
 		Db:                      dbAlice,
-		Packager:                channeldb.NewChannelPackager(shortChanID),
+		Packager:                channeldb.NewChannelPackager(chanID),
 		FundingTxn:              channels.TestFundingTx,
 	}
 	bobChannelState := &channeldb.OpenChannel{
@@ -2391,7 +2392,7 @@ func createInitChannels(revocationWindow int) (*lnwallet.LightningChannel, *lnwa
 		LocalCommitment:         bobCommit,
 		RemoteCommitment:        bobCommit,
 		Db:                      dbBob,
-		Packager:                channeldb.NewChannelPackager(shortChanID),
+		Packager:                channeldb.NewChannelPackager(chanID),
 	}
 
 	aliceSigner := &mock.SingleSigner{Privkey: aliceKeyPriv}

--- a/channeldb/channel.go
+++ b/channeldb/channel.go
@@ -987,7 +987,8 @@ func (c *OpenChannel) MarkAsOpen(openLoc lnwire.ShortChannelID) error {
 
 	c.IsPending = false
 	c.ShortChannelID = openLoc
-	c.Packager = NewChannelPackager(openLoc)
+	chanID := lnwire.NewChanIDFromOutPoint(&c.FundingOutpoint)
+	c.Packager = NewChannelPackager(chanID)
 
 	return nil
 }
@@ -1420,7 +1421,8 @@ func fetchOpenChannel(chanBucket kvdb.RBucket,
 		return nil, fmt.Errorf("unable to fetch chan revocations: %v", err)
 	}
 
-	channel.Packager = NewChannelPackager(channel.ShortChannelID)
+	chanID := lnwire.NewChanIDFromOutPoint(&channel.FundingOutpoint)
+	channel.Packager = NewChannelPackager(chanID)
 
 	return channel, nil
 }
@@ -3509,7 +3511,8 @@ func fetchChanInfo(chanBucket kvdb.RBucket, channel *OpenChannel) error {
 		return err
 	}
 
-	channel.Packager = NewChannelPackager(channel.ShortChannelID)
+	chanID := lnwire.NewChanIDFromOutPoint(&channel.FundingOutpoint)
+	channel.Packager = NewChannelPackager(chanID)
 
 	// Finally, read the optional shutdown scripts.
 	if err := getOptionalUpfrontShutdownScript(

--- a/channeldb/db.go
+++ b/channeldb/db.go
@@ -195,6 +195,10 @@ var (
 			number:    22,
 			migration: mig.CreateTLB(setIDIndexBucket),
 		},
+		{
+			number:    23,
+			migration: mig.MigrateFwdPackageKeys,
+		},
 	}
 
 	// Big endian is the preferred byte order, due to cursor scans over

--- a/channeldb/forwarding_package_test.go
+++ b/channeldb/forwarding_package_test.go
@@ -195,8 +195,8 @@ func TestPackagerEmptyFwdPkg(t *testing.T) {
 
 	db := makeFwdPkgDB(t, "")
 
-	shortChanID := lnwire.NewShortChanIDFromInt(1)
-	packager := channeldb.NewChannelPackager(shortChanID)
+	var chanID [32]byte
+	packager := channeldb.NewChannelPackager(chanID)
 
 	// To begin, there should be no forwarding packages on disk.
 	fwdPkgs := loadFwdPkgs(t, db, packager)
@@ -205,7 +205,7 @@ func TestPackagerEmptyFwdPkg(t *testing.T) {
 	}
 
 	// Next, create and write a new forwarding package with no htlcs.
-	fwdPkg := channeldb.NewFwdPkg(shortChanID, 0, nil, nil)
+	fwdPkg := channeldb.NewFwdPkg(chanID, 0, nil, nil)
 
 	if err := kvdb.Update(db, func(tx kvdb.RwTx) error {
 		return packager.AddFwdPkg(tx, fwdPkg)
@@ -264,8 +264,8 @@ func TestPackagerOnlyAdds(t *testing.T) {
 
 	db := makeFwdPkgDB(t, "")
 
-	shortChanID := lnwire.NewShortChanIDFromInt(1)
-	packager := channeldb.NewChannelPackager(shortChanID)
+	var chanID [32]byte
+	packager := channeldb.NewChannelPackager(chanID)
 
 	// To begin, there should be no forwarding packages on disk.
 	fwdPkgs := loadFwdPkgs(t, db, packager)
@@ -275,7 +275,7 @@ func TestPackagerOnlyAdds(t *testing.T) {
 
 	// Next, create and write a new forwarding package that only has add
 	// htlcs.
-	fwdPkg := channeldb.NewFwdPkg(shortChanID, 0, adds, nil)
+	fwdPkg := channeldb.NewFwdPkg(chanID, 0, adds, nil)
 
 	nAdds := len(adds)
 
@@ -366,8 +366,8 @@ func TestPackagerOnlySettleFails(t *testing.T) {
 
 	db := makeFwdPkgDB(t, "")
 
-	shortChanID := lnwire.NewShortChanIDFromInt(1)
-	packager := channeldb.NewChannelPackager(shortChanID)
+	var chanID [32]byte
+	packager := channeldb.NewChannelPackager(chanID)
 
 	// To begin, there should be no forwarding packages on disk.
 	fwdPkgs := loadFwdPkgs(t, db, packager)
@@ -377,7 +377,7 @@ func TestPackagerOnlySettleFails(t *testing.T) {
 
 	// Next, create and write a new forwarding package that only has add
 	// htlcs.
-	fwdPkg := channeldb.NewFwdPkg(shortChanID, 0, nil, settleFails)
+	fwdPkg := channeldb.NewFwdPkg(chanID, 0, nil, settleFails)
 
 	nSettleFails := len(settleFails)
 
@@ -423,7 +423,7 @@ func TestPackagerOnlySettleFails(t *testing.T) {
 		assertAckFilterIsFull(t, fwdPkgs[0], true)
 
 		failSettleRef := channeldb.SettleFailRef{
-			Source: shortChanID,
+			Source: chanID,
 			Height: fwdPkg.Height,
 			Index:  uint16(i),
 		}
@@ -470,8 +470,8 @@ func TestPackagerAddsThenSettleFails(t *testing.T) {
 
 	db := makeFwdPkgDB(t, "")
 
-	shortChanID := lnwire.NewShortChanIDFromInt(1)
-	packager := channeldb.NewChannelPackager(shortChanID)
+	var chanID [32]byte
+	packager := channeldb.NewChannelPackager(chanID)
 
 	// To begin, there should be no forwarding packages on disk.
 	fwdPkgs := loadFwdPkgs(t, db, packager)
@@ -481,7 +481,7 @@ func TestPackagerAddsThenSettleFails(t *testing.T) {
 
 	// Next, create and write a new forwarding package that only has add
 	// htlcs.
-	fwdPkg := channeldb.NewFwdPkg(shortChanID, 0, adds, settleFails)
+	fwdPkg := channeldb.NewFwdPkg(chanID, 0, adds, settleFails)
 
 	nAdds := len(adds)
 	nSettleFails := len(settleFails)
@@ -554,7 +554,7 @@ func TestPackagerAddsThenSettleFails(t *testing.T) {
 		assertAckFilterIsFull(t, fwdPkgs[0], true)
 
 		failSettleRef := channeldb.SettleFailRef{
-			Source: shortChanID,
+			Source: chanID,
 			Height: fwdPkg.Height,
 			Index:  uint16(i),
 		}
@@ -603,8 +603,8 @@ func TestPackagerSettleFailsThenAdds(t *testing.T) {
 
 	db := makeFwdPkgDB(t, "")
 
-	shortChanID := lnwire.NewShortChanIDFromInt(1)
-	packager := channeldb.NewChannelPackager(shortChanID)
+	var chanID [32]byte
+	packager := channeldb.NewChannelPackager(chanID)
 
 	// To begin, there should be no forwarding packages on disk.
 	fwdPkgs := loadFwdPkgs(t, db, packager)
@@ -614,7 +614,7 @@ func TestPackagerSettleFailsThenAdds(t *testing.T) {
 
 	// Next, create and write a new forwarding package that has both add
 	// and settle/fail htlcs.
-	fwdPkg := channeldb.NewFwdPkg(shortChanID, 0, adds, settleFails)
+	fwdPkg := channeldb.NewFwdPkg(chanID, 0, adds, settleFails)
 
 	nAdds := len(adds)
 	nSettleFails := len(settleFails)
@@ -664,7 +664,7 @@ func TestPackagerSettleFailsThenAdds(t *testing.T) {
 		assertAckFilterIsFull(t, fwdPkgs[0], false)
 
 		failSettleRef := channeldb.SettleFailRef{
-			Source: shortChanID,
+			Source: chanID,
 			Height: fwdPkg.Height,
 			Index:  uint16(i),
 		}

--- a/channeldb/migration/fwd_package.go
+++ b/channeldb/migration/fwd_package.go
@@ -1,0 +1,152 @@
+package migration
+
+import (
+	"bytes"
+	"encoding/binary"
+	"fmt"
+	"io"
+
+	"github.com/btcsuite/btcwallet/walletdb"
+	"github.com/lightningnetwork/lnd/kvdb"
+)
+
+var (
+	fwdPackagesKey    = []byte("fwd-packages")
+	openChannelBucket = []byte("open-chan-bucket")
+	chanInfoKey       = []byte("chan-info-key")
+	byteOrder         = binary.BigEndian
+)
+
+// MigrateFwdPackageKeys converts existing packages keys from
+// lnwire.ShortChannelID to lnwire.ChannelID.
+func MigrateFwdPackageKeys(tx kvdb.RwTx) error {
+	log.Infof("Migrating forward packages keys...")
+
+	openChanBkt := tx.ReadBucket(openChannelBucket)
+	if openChanBkt == nil {
+		return fmt.Errorf("%v bucket does not exist", string(openChannelBucket))
+	}
+
+	// First we create a mapping between ShortChannelID to ChannelID.
+	shortIDToChanID := make(map[uint64][32]byte)
+
+	// Iterating all nodes inside open channels bucket.
+	err := openChanBkt.ForEach(func(k, v []byte) error {
+		if v != nil {
+			return nil
+		}
+		nodeChanBucket := openChanBkt.NestedReadBucket(k)
+		if nodeChanBucket == nil {
+			return fmt.Errorf("node channels bucket doesn't exist")
+		}
+
+		// Iterating all chains.
+		return nodeChanBucket.ForEach(func(chainHash, v []byte) error {
+			if v != nil {
+				return nil
+			}
+
+			chainBucket := nodeChanBucket.NestedReadBucket(chainHash)
+			if chainBucket == nil {
+				return nil
+			}
+
+			// Iterating all channel points.
+			return chainBucket.ForEach(func(chanPoint, v []byte) error {
+				chanBucket := chainBucket.NestedReadBucket(chanPoint)
+				chanID := channelIDFromSerializedOutpoint(chanPoint)
+
+				infoBytes := chanBucket.Get(chanInfoKey)
+				if infoBytes == nil {
+					return fmt.Errorf("failed go get channel info")
+				}
+
+				// We are interested in the short channel id from the serialized channel info.
+				r := bytes.NewReader(infoBytes)
+
+				// Skip ChanType(1 bytes), ChainHash(32 bytes), FundingOutpoint(36 bytes)
+				_, err := r.Seek(1+32+36, io.SeekStart)
+				if err != nil {
+					return err
+				}
+
+				// read short channel id
+				var shortID uint64
+				if err := binary.Read(r, byteOrder, &shortID); err != nil {
+					return err
+				}
+				log.Infof("Mapping %v, to %x", shortID, chanID)
+				shortIDToChanID[shortID] = chanID
+				return nil
+
+			})
+		})
+	})
+
+	if err != nil {
+		return err
+	}
+
+	// Now that we have the mapping we rename the packager buckets keys to the new format.
+	fwdPkgBkt := tx.ReadWriteBucket(fwdPackagesKey)
+	if fwdPkgBkt == nil {
+		return fmt.Errorf("%v bucket doesn't exist", string(fwdPackagesKey))
+	}
+
+	// First getting a list of keys to rename.
+	var existingShortIDs []uint64
+	err = fwdPkgBkt.ForEach(func(k, v []byte) error {
+		existingShortIDs = append(existingShortIDs, byteOrder.Uint64(k))
+		return nil
+	})
+	if err != nil {
+		return fmt.Errorf("failed to iterate %v bucket", string(fwdPackagesKey))
+	}
+
+	for _, shortID := range existingShortIDs {
+		chanID, ok := shortIDToChanID[shortID]
+		if !ok {
+			// TODO: Should we return error here?
+			log.Infof("Couldn't find channel point for %v", shortID)
+			continue
+		}
+		var oldKey [8]byte
+		byteOrder.PutUint64(oldKey[:], shortID)
+		log.Infof("Migrating bucket from %v to %x", shortID, chanID)
+
+		// Unfortunately the db doesn't support rename so we need to
+		// copy all bucket content.
+		if err := copyBucket(fwdPkgBkt, fwdPkgBkt, oldKey[:], chanID[:]); err != nil {
+			return err
+		}
+
+		// Now we can delete the old bucket.
+		return fwdPkgBkt.DeleteNestedBucket(oldKey[:])
+	}
+
+	return nil
+}
+
+func channelIDFromSerializedOutpoint(chanPoint []byte) [32]byte {
+	var cid [32]byte
+	copy(cid[:], chanPoint[:32])
+	cid[30] ^= chanPoint[33]
+	cid[31] ^= chanPoint[34]
+	return cid
+}
+
+func copyBucket(oldParent, newParent walletdb.ReadWriteBucket, oldkey, newkey []byte) error {
+	oldBuck := oldParent.NestedReadWriteBucket(oldkey)
+	newBuck, err := newParent.CreateBucket(newkey)
+	if err != nil {
+		return err
+	}
+
+	err = oldBuck.ForEach(func(k, v []byte) error {
+		if v == nil {
+			return copyBucket(oldBuck, newBuck, k, k)
+		}
+		return newBuck.Put(k, v)
+	})
+	return err
+}

--- a/htlcswitch/test_utils.go
+++ b/htlcswitch/test_utils.go
@@ -272,6 +272,7 @@ func createTestChannel(alicePrivKey, bobPrivKey []byte,
 		IP:   net.ParseIP("127.0.0.1"),
 		Port: 18556,
 	}
+	packagerSource := lnwire.NewChanIDFromOutPoint(prevOut)
 
 	aliceCommit := channeldb.ChannelCommitment{
 		CommitHeight:  0,
@@ -307,7 +308,7 @@ func createTestChannel(alicePrivKey, bobPrivKey []byte,
 		RemoteCommitment:        aliceCommit,
 		ShortChannelID:          chanID,
 		Db:                      dbAlice,
-		Packager:                channeldb.NewChannelPackager(chanID),
+		Packager:                channeldb.NewChannelPackager(packagerSource),
 		FundingTxn:              channels.TestFundingTx,
 	}
 
@@ -326,7 +327,7 @@ func createTestChannel(alicePrivKey, bobPrivKey []byte,
 		RemoteCommitment:        bobCommit,
 		ShortChannelID:          chanID,
 		Db:                      dbBob,
-		Packager:                channeldb.NewChannelPackager(chanID),
+		Packager:                channeldb.NewChannelPackager(packagerSource),
 	}
 
 	if err := aliceChannelState.SyncPending(bobAddr, broadcastHeight); err != nil {

--- a/lnwallet/channel.go
+++ b/lnwallet/channel.go
@@ -371,7 +371,7 @@ type PaymentDescriptor struct {
 //
 // NOTE: The provided `logUpdates` MUST corresponding exactly to either the Adds
 // or SettleFails in this channel's forwarding package at `height`.
-func PayDescsFromRemoteLogUpdates(chanID lnwire.ShortChannelID, height uint64,
+func PayDescsFromRemoteLogUpdates(chanID lnwire.ChannelID, height uint64,
 	logUpdates []channeldb.LogUpdate) ([]*PaymentDescriptor, error) {
 
 	// Allocate enough space to hold all of the payment descriptors we will
@@ -4661,7 +4661,6 @@ func (lc *LightningChannel) ReceiveRevocation(revMsg *lnwire.RevokeAndAck) (
 	remoteChainTail := lc.remoteCommitChain.tail().height + 1
 	localChainTail := lc.localCommitChain.tail().height
 
-	source := lc.ShortChanID()
 	chanID := lnwire.NewChanIDFromOutPoint(&lc.channelState.FundingOutpoint)
 
 	// Determine the set of htlcs that can be forwarded as a result of
@@ -4732,7 +4731,7 @@ func (lc *LightningChannel) ReceiveRevocation(revMsg *lnwire.RevokeAndAck) (
 			// this forwarded Settle/Fail will be written in the
 			// forwarding package constructed at this remote height.
 			pd.DestRef = &channeldb.SettleFailRef{
-				Source: source,
+				Source: chanID,
 				Height: remoteChainTail,
 				Index:  settleFailIndex,
 			}
@@ -4810,7 +4809,7 @@ func (lc *LightningChannel) ReceiveRevocation(revMsg *lnwire.RevokeAndAck) (
 	// type, construct a forwarding package using the height that the remote
 	// commitment chain will be extended after persisting the revocation.
 	fwdPkg := channeldb.NewFwdPkg(
-		source, remoteChainTail, addUpdates, settleFailUpdates,
+		chanID, remoteChainTail, addUpdates, settleFailUpdates,
 	)
 
 	// At this point, the revocation has been accepted, and we've rotated

--- a/lnwallet/test_utils.go
+++ b/lnwallet/test_utils.go
@@ -307,6 +307,7 @@ func CreateTestChannels(chanType channeldb.ChannelType) (
 	shortChanID := lnwire.NewShortChanIDFromInt(
 		binary.BigEndian.Uint64(chanIDBytes[:]),
 	)
+	chanID := lnwire.NewChanIDFromOutPoint(prevOut)
 
 	aliceChannelState := &channeldb.OpenChannel{
 		LocalChanCfg:            aliceCfg,
@@ -323,7 +324,7 @@ func CreateTestChannels(chanType channeldb.ChannelType) (
 		LocalCommitment:         aliceLocalCommit,
 		RemoteCommitment:        aliceRemoteCommit,
 		Db:                      dbAlice,
-		Packager:                channeldb.NewChannelPackager(shortChanID),
+		Packager:                channeldb.NewChannelPackager(chanID),
 		FundingTxn:              testTx,
 	}
 	bobChannelState := &channeldb.OpenChannel{
@@ -341,7 +342,7 @@ func CreateTestChannels(chanType channeldb.ChannelType) (
 		LocalCommitment:         bobLocalCommit,
 		RemoteCommitment:        bobRemoteCommit,
 		Db:                      dbBob,
-		Packager:                channeldb.NewChannelPackager(shortChanID),
+		Packager:                channeldb.NewChannelPackager(chanID),
 	}
 
 	aliceSigner := &input.MockSigner{Privkeys: aliceKeys}

--- a/lnwallet/transactions_test.go
+++ b/lnwallet/transactions_test.go
@@ -922,6 +922,7 @@ func createTestChannelsForVectors(tc *testContext, chanType channeldb.ChannelTyp
 	shortChanID := lnwire.NewShortChanIDFromInt(
 		binary.BigEndian.Uint64(chanIDBytes[:]),
 	)
+	chanID := lnwire.NewChanIDFromOutPoint(prevOut)
 
 	remoteChannelState := &channeldb.OpenChannel{
 		LocalChanCfg:            remoteCfg,
@@ -938,7 +939,7 @@ func createTestChannelsForVectors(tc *testContext, chanType channeldb.ChannelTyp
 		LocalCommitment:         remoteCommit,
 		RemoteCommitment:        remoteCommit,
 		Db:                      dbRemote,
-		Packager:                channeldb.NewChannelPackager(shortChanID),
+		Packager:                channeldb.NewChannelPackager(chanID),
 		FundingTxn:              tc.fundingTx.MsgTx(),
 	}
 	localChannelState := &channeldb.OpenChannel{
@@ -956,7 +957,7 @@ func createTestChannelsForVectors(tc *testContext, chanType channeldb.ChannelTyp
 		LocalCommitment:         localCommit,
 		RemoteCommitment:        localCommit,
 		Db:                      dbLocal,
-		Packager:                channeldb.NewChannelPackager(shortChanID),
+		Packager:                channeldb.NewChannelPackager(chanID),
 		FundingTxn:              tc.fundingTx.MsgTx(),
 	}
 

--- a/peer/test_utils.go
+++ b/peer/test_utils.go
@@ -214,6 +214,7 @@ func createTestPeer(notifier chainntnfs.ChainNotifier,
 	shortChanID := lnwire.NewShortChanIDFromInt(
 		binary.BigEndian.Uint64(chanIDBytes[:]),
 	)
+	chanID := lnwire.NewChanIDFromOutPoint(prevOut)
 
 	aliceChannelState := &channeldb.OpenChannel{
 		LocalChanCfg:            aliceCfg,
@@ -230,7 +231,7 @@ func createTestPeer(notifier chainntnfs.ChainNotifier,
 		LocalCommitment:         aliceCommit,
 		RemoteCommitment:        aliceCommit,
 		Db:                      dbAlice,
-		Packager:                channeldb.NewChannelPackager(shortChanID),
+		Packager:                channeldb.NewChannelPackager(chanID),
 		FundingTxn:              channels.TestFundingTx,
 	}
 	bobChannelState := &channeldb.OpenChannel{
@@ -247,7 +248,7 @@ func createTestPeer(notifier chainntnfs.ChainNotifier,
 		LocalCommitment:         bobCommit,
 		RemoteCommitment:        bobCommit,
 		Db:                      dbBob,
-		Packager:                channeldb.NewChannelPackager(shortChanID),
+		Packager:                channeldb.NewChannelPackager(chanID),
 	}
 
 	// Set custom values on the channel states.
@@ -386,7 +387,6 @@ func createTestPeer(notifier chainntnfs.ChainNotifier,
 
 	alicePeer := NewBrontide(*cfg)
 
-	chanID := lnwire.NewChanIDFromOutPoint(channelAlice.ChannelPoint())
 	alicePeer.activeChannels[chanID] = channelAlice
 
 	alicePeer.wg.Add(1)


### PR DESCRIPTION
This PR follows the suggestion here https://github.com/lightningnetwork/lnd/pull/4424 to make the ChannelPackager use `lnwire.ChannelD ` as key which doesn't change on confirmation.
A migration is needed to handle existing keys by renaming existing keys (copy buckets) to the new format.