### PR TITLE
invoices: add String() method to failure resolution outcome

### DIFF
--- a/invoices/resolution_result.go
+++ b/invoices/resolution_result.go
@@ -107,6 +107,11 @@ const (
 	ResultMppInProgress
 )
 
+// String returns a string representation of the result.
+func (f FailResolutionResult) String() string {
+	return f.FailureString()
+}
+
 // FailureString returns a string representation of the result.
 //
 // Note: it is part of the FailureDetail interface.


### PR DESCRIPTION
In this commit, we add a String() method to the failure resolution
outcome. Without this, logs aren't very useful as the integer version of
the outcome is printed rather than the description.

