### PR TITLE
Advanced macaroons 2/2: Custom macaroon validator for external subservers

### DIFF
--- a/lnd.go
+++ b/lnd.go
@@ -145,6 +145,12 @@ type RPCSubserverConfig struct {
 	// per URI, they are all required. See rpcserver.go for a list of valid
 	// action and entity values.
 	Permissions map[string][]bakery.Op
+
+	// MacaroonValidator is a custom macaroon validator that should be used
+	// instead of the default lnd validator. If specified, the custom
+	// validator is used for all URIs specified in the above Permissions
+	// map.
+	MacaroonValidator macaroons.MacaroonValidator
 }
 
 // ListenerWithSignal is a net.Listener that has an additional Ready channel that

--- a/lnd.go
+++ b/lnd.go
@@ -393,7 +393,7 @@ func Main(cfg *Config, lisCfg ListenerCfg, shutdownChan <-chan struct{}) error {
 	if !cfg.NoMacaroons {
 		// Create the macaroon authentication/authorization service.
 		macaroonService, err = macaroons.NewService(
-			cfg.networkDir, macaroons.IPLockChecker,
+			cfg.networkDir, "lnd", macaroons.IPLockChecker,
 		)
 		if err != nil {
 			err := fmt.Errorf("unable to set up macaroon "+

--- a/macaroons/service.go
+++ b/macaroons/service.go
@@ -54,7 +54,7 @@ type Service struct {
 // listing the same checker more than once is not harmful. Default checkers,
 // such as those for `allow`, `time-before`, `declared`, and `error` caveats
 // are registered automatically and don't need to be added.
-func NewService(dir string, checks ...Checker) (*Service, error) {
+func NewService(dir, location string, checks ...Checker) (*Service, error) {
 	// Ensure that the path to the directory exists.
 	if _, err := os.Stat(dir); os.IsNotExist(err) {
 		if err := os.MkdirAll(dir, 0700); err != nil {
@@ -77,7 +77,7 @@ func NewService(dir string, checks ...Checker) (*Service, error) {
 	}
 
 	macaroonParams := bakery.BakeryParams{
-		Location:     "lnd",
+		Location:     location,
 		RootKeyStore: rootKeyStore,
 		// No third-party caveat support for now.
 		// TODO(aakselrod): Add third-party caveat support.

--- a/macaroons/service_test.go
+++ b/macaroons/service_test.go
@@ -66,7 +66,9 @@ func TestNewService(t *testing.T) {
 
 	// Second, create the new service instance, unlock it and pass in a
 	// checker that we expect it to add to the bakery.
-	service, err := macaroons.NewService(tempDir, macaroons.IPLockChecker)
+	service, err := macaroons.NewService(
+		tempDir, "lnd", macaroons.IPLockChecker,
+	)
 	if err != nil {
 		t.Fatalf("Error creating new service: %v", err)
 	}
@@ -115,7 +117,9 @@ func TestValidateMacaroon(t *testing.T) {
 	// First, initialize the service and unlock it.
 	tempDir := setupTestRootKeyStorage(t)
 	defer os.RemoveAll(tempDir)
-	service, err := macaroons.NewService(tempDir, macaroons.IPLockChecker)
+	service, err := macaroons.NewService(
+		tempDir, "lnd", macaroons.IPLockChecker,
+	)
 	if err != nil {
 		t.Fatalf("Error creating new service: %v", err)
 	}
@@ -173,7 +177,9 @@ func TestListMacaroonIDs(t *testing.T) {
 
 	// Second, create the new service instance, unlock it and pass in a
 	// checker that we expect it to add to the bakery.
-	service, err := macaroons.NewService(tempDir, macaroons.IPLockChecker)
+	service, err := macaroons.NewService(
+		tempDir, "lnd", macaroons.IPLockChecker,
+	)
 	require.NoError(t, err, "Error creating new service")
 	defer service.Close()
 
@@ -203,7 +209,9 @@ func TestDeleteMacaroonID(t *testing.T) {
 
 	// Second, create the new service instance, unlock it and pass in a
 	// checker that we expect it to add to the bakery.
-	service, err := macaroons.NewService(tempDir, macaroons.IPLockChecker)
+	service, err := macaroons.NewService(
+		tempDir, "lnd", macaroons.IPLockChecker,
+	)
 	require.NoError(t, err, "Error creating new service")
 	defer service.Close()
 

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -213,9 +213,9 @@ func stringInSlice(a string, slice []string) bool {
 	return false
 }
 
-// mainRPCServerPermissions returns a mapping of the main RPC server calls to
+// MainRPCServerPermissions returns a mapping of the main RPC server calls to
 // the permissions they require.
-func mainRPCServerPermissions() map[string][]bakery.Op {
+func MainRPCServerPermissions() map[string][]bakery.Op {
 	return map[string][]bakery.Op{
 		"/lnrpc.Lightning/SendCoins": {{
 			Entity: "onchain",
@@ -640,7 +640,7 @@ func newRPCServer(cfg *Config, s *server, macService *macaroons.Service,
 	// Next, we need to merge the set of sub server macaroon permissions
 	// with the main RPC server permissions so we can unite them under a
 	// single set of interceptors.
-	permissions := mainRPCServerPermissions()
+	permissions := MainRPCServerPermissions()
 	for _, subServerPerm := range subServerPerms {
 		for method, ops := range subServerPerm {
 			// For each new method:ops combo, we also ensure that

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -661,10 +661,12 @@ func newRPCServer(cfg *Config, s *server, macService *macaroons.Service,
 		return nil, err
 	}
 
-	// External subserver possibly need to register their own permissions.
+	// External subserver possibly need to register their own permissions
+	// and macaroon validator.
 	for _, lis := range listeners {
 		extSubserver := lis.ExternalRPCSubserverCfg
 		if extSubserver != nil {
+			macValidator := extSubserver.MacaroonValidator
 			for method, ops := range extSubserver.Permissions {
 				// For each new method:ops combo, we also ensure
 				// that non of the sub-servers try to override
@@ -677,6 +679,23 @@ func newRPCServer(cfg *Config, s *server, macService *macaroons.Service,
 				}
 
 				permissions[method] = ops
+
+				// Give the external subservers the possibility
+				// to also use their own validator to check any
+				// macaroons attached to calls to this method.
+				// This allows them to have their own root key
+				// ID database and permission entities.
+				if macValidator != nil {
+					err := macService.RegisterExternalValidator(
+						method, macValidator,
+					)
+					if err != nil {
+						return nil, fmt.Errorf("could "+
+							"not register "+
+							"external macaroon "+
+							"validator: %v", err)
+					}
+				}
 			}
 		}
 	}


### PR DESCRIPTION
This is part 2 of the series, part 1 can be found here: #4463. Only the last 3 commits are new.

When external subservers register themselves to be served through the
same gRPC interface as the main lnd RPC, their requests are also
intercepted by the main lnd macaroon interceptor.
If the external subservers want to use their own macaroons that are
independent of lnd's, they need a way to overwrite the default validator
of the macaroon interceptor. We add this mechanism with the concept of
external validators.