### PR TITLE
trivial: fix make rpc-format

### DIFF
--- a/lnrpc/rpc.proto
+++ b/lnrpc/rpc.proto
@@ -1253,7 +1253,7 @@ message ChannelCloseSummary {
     repeated Resolution resolutions = 13;
 }
 
-enum ResolutionType{
+enum ResolutionType {
     TYPE_UNKNOWN = 0;
 
     // We resolved an anchor output.


### PR DESCRIPTION
missing `make rpc-format`