### PR TITLE
mobile+make: restore mobile compilation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,6 +44,8 @@ jobs:
         - make lint workers=1
         - make btcd
         - make release sys=windows-amd64
+        - make mobile-rpc
+        - go build --tags="mobile" ./mobile
     - stage: Test
       script: make travis-cover
       name: Unit Cover

--- a/Makefile
+++ b/Makefile
@@ -226,7 +226,7 @@ rpc-check: rpc
 
 mobile-rpc: falafel goimports
 	@$(call print, "Creating mobile RPC from protos.")
-	cd ./mobile; ./gen_bindings.sh
+	cd ./mobile; ./gen_bindings.sh $(FALAFEL_COMMIT)
 
 vendor:
 	@$(call print, "Re-creating vendor directory.")

--- a/Makefile
+++ b/Makefile
@@ -224,12 +224,12 @@ vendor:
 ios: vendor mobile-rpc
 	@$(call print, "Building iOS framework ($(IOS_BUILD)).")
 	mkdir -p $(IOS_BUILD_DIR)
-	$(GOMOBILE_BIN) bind -target=ios -tags="ios $(DEV_TAGS) autopilotrpc experimental" $(LDFLAGS) -v -o $(IOS_BUILD) $(MOBILE_PKG)
+	$(GOMOBILE_BIN) bind -target=ios -tags="mobile $(DEV_TAGS) autopilotrpc experimental" $(LDFLAGS) -v -o $(IOS_BUILD) $(MOBILE_PKG)
 
 android: vendor mobile-rpc
 	@$(call print, "Building Android library ($(ANDROID_BUILD)).")
 	mkdir -p $(ANDROID_BUILD_DIR)
-	$(GOMOBILE_BIN) bind -target=android -tags="android $(DEV_TAGS) autopilotrpc experimental" $(LDFLAGS) -v -o $(ANDROID_BUILD) $(MOBILE_PKG)
+	$(GOMOBILE_BIN) bind -target=android -tags="mobile $(DEV_TAGS) autopilotrpc experimental" $(LDFLAGS) -v -o $(ANDROID_BUILD) $(MOBILE_PKG)
 
 mobile: ios android
 

--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,7 @@ GOVERALLS_PKG := github.com/mattn/goveralls
 LINT_PKG := github.com/golangci/golangci-lint/cmd/golangci-lint
 GOACC_PKG := github.com/ory/go-acc
 FALAFEL_PKG := github.com/lightninglabs/falafel
+GOIMPORTS_PKG := golang.org/x/tools/cmd/goimports
 
 GO_BIN := ${GOPATH}/bin
 BTCD_BIN := $(GO_BIN)/btcd
@@ -112,6 +113,10 @@ btcd:
 falafel:
 	@$(call print, "Installing falafel.")
 	$(DEPGET) $(FALAFEL_PKG)@$(FALAFEL_COMMIT)
+
+goimports:
+	@$(call print, "Installing goimports.")
+	$(DEPGET) $(GOIMPORTS_PKG)
 
 # ============
 # INSTALLATION
@@ -219,7 +224,7 @@ rpc-check: rpc
 	for rpc in $$(find lnrpc/ -name "*.proto" | $(XARGS) awk '/    rpc /{print $$2}'); do if ! grep -q $$rpc lnrpc/rest-annotations.yaml; then echo "RPC $$rpc not added to lnrpc/rest-annotations.yaml"; exit 1; fi; done
 	if test -n "$$(git describe --dirty | grep dirty)"; then echo "Protos not properly formatted or not compiled with v3.4.0"; git status; git diff; exit 1; fi
 
-mobile-rpc: falafel
+mobile-rpc: falafel goimports
 	@$(call print, "Creating mobile RPC from protos.")
 	cd ./mobile; ./gen_bindings.sh
 

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,7 @@ BTCD_PKG := github.com/btcsuite/btcd
 GOVERALLS_PKG := github.com/mattn/goveralls
 LINT_PKG := github.com/golangci/golangci-lint/cmd/golangci-lint
 GOACC_PKG := github.com/ory/go-acc
+FALAFEL_PKG := github.com/lightninglabs/falafel
 
 GO_BIN := ${GOPATH}/bin
 BTCD_BIN := $(GO_BIN)/btcd
@@ -32,6 +33,7 @@ BTCD_COMMIT := $(shell cat go.mod | \
 
 LINT_COMMIT := v1.18.0
 GOACC_COMMIT := ddc355013f90fea78d83d3a6c71f1d37ac07ecd5
+FALAFEL_COMMIT := v0.7.1
 
 DEPGET := cd /tmp && GO111MODULE=on go get -v
 GOBUILD := GO111MODULE=on go build -v
@@ -106,6 +108,10 @@ $(GOACC_BIN):
 btcd:
 	@$(call print, "Installing btcd.")
 	$(DEPGET) $(BTCD_PKG)@$(BTCD_COMMIT)
+
+falafel:
+	@$(call print, "Installing falafel.")
+	$(DEPGET) $(FALAFEL_PKG)@$(FALAFEL_COMMIT)
 
 # ============
 # INSTALLATION
@@ -213,7 +219,7 @@ rpc-check: rpc
 	for rpc in $$(find lnrpc/ -name "*.proto" | $(XARGS) awk '/    rpc /{print $$2}'); do if ! grep -q $$rpc lnrpc/rest-annotations.yaml; then echo "RPC $$rpc not added to lnrpc/rest-annotations.yaml"; exit 1; fi; done
 	if test -n "$$(git describe --dirty | grep dirty)"; then echo "Protos not properly formatted or not compiled with v3.4.0"; git status; git diff; exit 1; fi
 
-mobile-rpc:
+mobile-rpc: falafel
 	@$(call print, "Creating mobile RPC from protos.")
 	cd ./mobile; ./gen_bindings.sh
 
@@ -252,6 +258,7 @@ clean:
 	unit \
 	unit-cover \
 	unit-race \
+	falafel \
 	goveralls \
 	travis-race \
 	travis-cover \

--- a/mobile/bindings.go
+++ b/mobile/bindings.go
@@ -1,4 +1,4 @@
-// +build ios android
+// +build mobile
 
 package lndmobile
 

--- a/mobile/bindings.go
+++ b/mobile/bindings.go
@@ -9,6 +9,7 @@ import (
 
 	flags "github.com/jessevdk/go-flags"
 	"github.com/lightningnetwork/lnd"
+	"github.com/lightningnetwork/lnd/signal"
 )
 
 // Start starts lnd in a new goroutine.
@@ -40,9 +41,20 @@ func Start(extraArgs string, unlockerReady, rpcReady Callback) {
 		splitArgs = append(splitArgs, "--"+a)
 	}
 
-	// Add the extra arguments to os.Args, as that will be parsed during
-	// startup.
+	// Add the extra arguments to os.Args, as that will be parsed in
+	// LoadConfig below.
 	os.Args = append(os.Args, splitArgs...)
+
+	// Load the configuration, and parse the extra arguments as command
+	// line options. This function will also set up logging properly.
+	loadedConfig, err := lnd.LoadConfig()
+	if err != nil {
+		_, _ = fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+
+	// Hook interceptor for os signals.
+	signal.Intercept()
 
 	// Set up channels that will be notified when the RPC servers are ready
 	// to accept calls.
@@ -67,7 +79,9 @@ func Start(extraArgs string, unlockerReady, rpcReady Callback) {
 	// Call the "real" main in a nested manner so the defers will properly
 	// be executed in the case of a graceful shutdown.
 	go func() {
-		if err := lnd.Main(cfg); err != nil {
+		if err := lnd.Main(
+			loadedConfig, cfg, signal.ShutdownChannel(),
+		); err != nil {
 			if e, ok := err.(*flags.Error); ok &&
 				e.Type == flags.ErrHelp {
 			} else {
@@ -84,7 +98,7 @@ func Start(extraArgs string, unlockerReady, rpcReady Callback) {
 
 		// We must set the TLS certificates in order to properly
 		// authenticate with the wallet unlocker service.
-		auth, err := lnd.WalletUnlockerAuthOptions()
+		auth, err := lnd.WalletUnlockerAuthOptions(loadedConfig)
 		if err != nil {
 			unlockerReady.OnError(err)
 			return
@@ -102,7 +116,7 @@ func Start(extraArgs string, unlockerReady, rpcReady Callback) {
 		// Now that the RPC server is ready, we can get the needed
 		// authentication options, and add them to the global dial
 		// options.
-		auth, err := lnd.AdminAuthOptions()
+		auth, err := lnd.AdminAuthOptions(loadedConfig)
 		if err != nil {
 			rpcReady.OnError(err)
 			return

--- a/mobile/gen_bindings.sh
+++ b/mobile/gen_bindings.sh
@@ -3,7 +3,7 @@
 mkdir -p build
 
 # Check falafel version.
-falafelVersion="0.7"
+falafelVersion="0.7.1"
 falafel=$(which falafel)
 if [ $falafel ]
 then

--- a/mobile/gen_bindings.sh
+++ b/mobile/gen_bindings.sh
@@ -45,7 +45,7 @@ protoc -I/usr/local/include -I. \
 # If prefix=1 is specified, prefix the generated methods with subserver name.
 # This must be enabled to support subservers with name conflicts.
 use_prefix="0"
-if [[ $prefix = "1" ]]
+if [ "$prefix" = "1" ]
 then
     echo "Prefixing methods with subserver name"
     use_prefix="1"

--- a/mobile/gen_bindings.sh
+++ b/mobile/gen_bindings.sh
@@ -3,11 +3,17 @@
 mkdir -p build
 
 # Check falafel version.
-falafelVersion="0.7.1"
+falafelVersion=$1
+if [ -z $falafelVersion ]
+then
+        echo "falafel version not set"
+        exit 1
+fi
+
 falafel=$(which falafel)
 if [ $falafel ]
 then
-        version=$($falafel -v)
+        version="v$($falafel -v)"
         if [ $version != $falafelVersion ]
         then
                 echo "falafel version $falafelVersion required"


### PR DESCRIPTION
Fixes compilation error originating from moving of the config parsing: #4286 

The config parsing itself could probably be made more mobile aware, but for now we restore the same flow as has been used.

Also adds a Travis build step for making sure the mobile bindings builds with the `mobile` tag set. 

Fixes https://github.com/lightningnetwork/lnd/issues/4382