### PR TITLE
lncli: remove new line from password confirmation

### DIFF
--- a/cmd/lncli/commands.go
+++ b/cmd/lncli/commands.go
@@ -1481,7 +1481,7 @@ func capturePassword(instruction string, optional bool,
 			continue
 		}
 
-		fmt.Println("Confirm password:")
+		fmt.Printf("Confirm password: ")
 		passwordConfirmed, err := terminal.ReadPassword(
 			int(syscall.Stdin),
 		)


### PR DESCRIPTION
The password instruction in the same function and many other related outputs use Printf except of Println.
