### PR TITLE
channeldb+multi: export {Write,Read}Outpoint, new {Write,Read}VarOutPoint

### DIFF
--- a/breacharbiter.go
+++ b/breacharbiter.go
@@ -1246,7 +1246,8 @@ func (rs *retributionStore) Add(ret *retributionInfo) error {
 		}
 
 		var outBuf bytes.Buffer
-		if err := writeOutpoint(&outBuf, &ret.chanPoint); err != nil {
+		err = channeldb.WriteVarOutpoint(&outBuf, &ret.chanPoint)
+		if err != nil {
 			return err
 		}
 
@@ -1271,7 +1272,8 @@ func (rs *retributionStore) Finalize(chanPoint *wire.OutPoint,
 		}
 
 		var chanBuf bytes.Buffer
-		if err := writeOutpoint(&chanBuf, chanPoint); err != nil {
+		err = channeldb.WriteVarOutpoint(&chanBuf, chanPoint)
+		if err != nil {
 			return err
 		}
 
@@ -1298,7 +1300,8 @@ func (rs *retributionStore) GetFinalizedTxn(
 		}
 
 		var chanBuf bytes.Buffer
-		if err := writeOutpoint(&chanBuf, chanPoint); err != nil {
+		err := channeldb.WriteVarOutpoint(&chanBuf, chanPoint)
+		if err != nil {
 			return err
 		}
 
@@ -1332,7 +1335,8 @@ func (rs *retributionStore) IsBreached(chanPoint *wire.OutPoint) (bool, error) {
 		}
 
 		var chanBuf bytes.Buffer
-		if err := writeOutpoint(&chanBuf, chanPoint); err != nil {
+		err := channeldb.WriteVarOutpoint(&chanBuf, chanPoint)
+		if err != nil {
 			return err
 		}
 
@@ -1364,7 +1368,8 @@ func (rs *retributionStore) Remove(chanPoint *wire.OutPoint) error {
 
 		// Serialize the channel point we are intending to remove.
 		var chanBuf bytes.Buffer
-		if err := writeOutpoint(&chanBuf, chanPoint); err != nil {
+		err := channeldb.WriteVarOutpoint(&chanBuf, chanPoint)
+		if err != nil {
 			return err
 		}
 		chanBytes := chanBuf.Bytes()
@@ -1420,7 +1425,8 @@ func (ret *retributionInfo) Encode(w io.Writer) error {
 		return err
 	}
 
-	if err := writeOutpoint(w, &ret.chanPoint); err != nil {
+	err := channeldb.WriteVarOutpoint(w, &ret.chanPoint)
+	if err != nil {
 		return err
 	}
 
@@ -1460,7 +1466,7 @@ func (ret *retributionInfo) Decode(r io.Reader) error {
 	}
 	ret.commitHash = *hash
 
-	if err := readOutpoint(r, &ret.chanPoint); err != nil {
+	if err := channeldb.ReadVarOutpoint(r, &ret.chanPoint); err != nil {
 		return err
 	}
 
@@ -1503,11 +1509,12 @@ func (bo *breachedOutput) Encode(w io.Writer) error {
 		return err
 	}
 
-	if err := writeOutpoint(w, &bo.outpoint); err != nil {
+	err := channeldb.WriteVarOutpoint(w, &bo.outpoint)
+	if err != nil {
 		return err
 	}
 
-	err := input.WriteSignDescriptor(w, &bo.signDesc)
+	err = input.WriteSignDescriptor(w, &bo.signDesc)
 	if err != nil {
 		return err
 	}
@@ -1534,7 +1541,7 @@ func (bo *breachedOutput) Decode(r io.Reader) error {
 	}
 	bo.amt = btcutil.Amount(binary.BigEndian.Uint64(scratch[:8]))
 
-	if err := readOutpoint(r, &bo.outpoint); err != nil {
+	if err := channeldb.ReadVarOutpoint(r, &bo.outpoint); err != nil {
 		return err
 	}
 

--- a/channeldb/channel.go
+++ b/channeldb/channel.go
@@ -794,7 +794,7 @@ func fetchChanBucket(tx kvdb.RTx, nodeKey *btcec.PublicKey,
 	// With the bucket for the node and chain fetched, we can now go down
 	// another level, for this channel itself.
 	var chanPointBuf bytes.Buffer
-	if err := writeOutpoint(&chanPointBuf, outPoint); err != nil {
+	if err := WriteOutpoint(&chanPointBuf, outPoint); err != nil {
 		return nil, err
 	}
 	chanBucket := chainBucket.NestedReadBucket(chanPointBuf.Bytes())
@@ -848,7 +848,7 @@ func (c *OpenChannel) fullSync(tx kvdb.RwTx) error {
 	// With the bucket for the node fetched, we can now go down another
 	// level, creating the bucket for this channel itself.
 	var chanPointBuf bytes.Buffer
-	if err := writeOutpoint(&chanPointBuf, &c.FundingOutpoint); err != nil {
+	if err := WriteOutpoint(&chanPointBuf, &c.FundingOutpoint); err != nil {
 		return err
 	}
 	chanBucket, err := chainBucket.CreateBucket(
@@ -2577,7 +2577,7 @@ func (c *OpenChannel) CloseChannel(summary *ChannelCloseSummary,
 		}
 
 		var chanPointBuf bytes.Buffer
-		err := writeOutpoint(&chanPointBuf, &c.FundingOutpoint)
+		err := WriteOutpoint(&chanPointBuf, &c.FundingOutpoint)
 		if err != nil {
 			return err
 		}

--- a/channeldb/codec.go
+++ b/channeldb/codec.go
@@ -15,9 +15,9 @@ import (
 	"github.com/lightningnetwork/lnd/shachain"
 )
 
-// writeOutpoint writes an outpoint to the passed writer using the minimal
+// WriteOutpoint writes an outpoint to the passed writer using the minimal
 // amount of bytes possible.
-func writeOutpoint(w io.Writer, o *wire.OutPoint) error {
+func WriteOutpoint(w io.Writer, o *wire.OutPoint) error {
 	if _, err := w.Write(o.Hash[:]); err != nil {
 		return err
 	}
@@ -28,9 +28,9 @@ func writeOutpoint(w io.Writer, o *wire.OutPoint) error {
 	return nil
 }
 
-// readOutpoint reads an outpoint from the passed reader that was previously
-// written using the writeOutpoint struct.
-func readOutpoint(r io.Reader, o *wire.OutPoint) error {
+// ReadOutpoint reads an outpoint from the passed reader that was previously
+// written using the *wire.OutPoint struct.
+func ReadOutpoint(r io.Reader, o *wire.OutPoint) error {
 	if _, err := io.ReadFull(r, o.Hash[:]); err != nil {
 		return err
 	}
@@ -131,7 +131,7 @@ func WriteElement(w io.Writer, element interface{}) error {
 		}
 
 	case wire.OutPoint:
-		return writeOutpoint(w, &e)
+		return WriteOutpoint(w, &e)
 
 	case lnwire.ShortChannelID:
 		if err := binary.Write(w, byteOrder, e.ToUint64()); err != nil {
@@ -306,7 +306,7 @@ func ReadElement(r io.Reader, element interface{}) error {
 		}
 
 	case *wire.OutPoint:
-		return readOutpoint(r, e)
+		return ReadOutpoint(r, e)
 
 	case *lnwire.ShortChannelID:
 		var a uint64

--- a/channeldb/db.go
+++ b/channeldb/db.go
@@ -460,7 +460,7 @@ func (db *DB) fetchNodeChannels(chainBucket kvdb.RBucket) ([]*OpenChannel, error
 		chanBucket := chainBucket.NestedReadBucket(chanPoint)
 
 		var outPoint wire.OutPoint
-		err := readOutpoint(bytes.NewReader(chanPoint), &outPoint)
+		err := ReadOutpoint(bytes.NewReader(chanPoint), &outPoint)
 		if err != nil {
 			return err
 		}
@@ -490,7 +490,7 @@ func (d *DB) FetchChannel(chanPoint wire.OutPoint) (*OpenChannel, error) {
 		targetChanPoint bytes.Buffer
 	)
 
-	if err := writeOutpoint(&targetChanPoint, &chanPoint); err != nil {
+	if err := WriteOutpoint(&targetChanPoint, &chanPoint); err != nil {
 		return nil, err
 	}
 
@@ -796,7 +796,7 @@ func (d *DB) FetchClosedChannel(chanID *wire.OutPoint) (*ChannelCloseSummary, er
 
 		var b bytes.Buffer
 		var err error
-		if err = writeOutpoint(&b, chanID); err != nil {
+		if err = WriteOutpoint(&b, chanID); err != nil {
 			return err
 		}
 
@@ -836,7 +836,7 @@ func (d *DB) FetchClosedChannelForID(cid lnwire.ChannelID) (
 		// We scan over all possible candidates for this channel ID.
 		for ; op != nil && bytes.Compare(cid[:30], op[:30]) <= 0; op, c = cursor.Next() {
 			var outPoint wire.OutPoint
-			err := readOutpoint(bytes.NewReader(op), &outPoint)
+			err := ReadOutpoint(bytes.NewReader(op), &outPoint)
 			if err != nil {
 				return err
 			}
@@ -872,7 +872,7 @@ func (d *DB) FetchClosedChannelForID(cid lnwire.ChannelID) (
 func (d *DB) MarkChanFullyClosed(chanPoint *wire.OutPoint) error {
 	return kvdb.Update(d, func(tx kvdb.RwTx) error {
 		var b bytes.Buffer
-		if err := writeOutpoint(&b, chanPoint); err != nil {
+		if err := WriteOutpoint(&b, chanPoint); err != nil {
 			return err
 		}
 
@@ -1230,7 +1230,7 @@ func fetchHistoricalChanBucket(tx kvdb.RTx,
 	// With the bucket for the node and chain fetched, we can now go down
 	// another level, for the channel itself.
 	var chanPointBuf bytes.Buffer
-	if err := writeOutpoint(&chanPointBuf, outPoint); err != nil {
+	if err := WriteOutpoint(&chanPointBuf, outPoint); err != nil {
 		return nil, err
 	}
 	chanBucket := historicalChanBucket.NestedReadBucket(chanPointBuf.Bytes())

--- a/channeldb/graph.go
+++ b/channeldb/graph.go
@@ -673,7 +673,7 @@ func (c *ChannelGraph) addChannelEdge(tx kvdb.RwTx, edge *ChannelEdgeInfo) error
 	// Finally we add it to the channel index which maps channel points
 	// (outpoints) to the shorter channel ID's.
 	var b bytes.Buffer
-	if err := writeOutpoint(&b, &edge.ChannelPoint); err != nil {
+	if err := WriteOutpoint(&b, &edge.ChannelPoint); err != nil {
 		return err
 	}
 	return chanIndex.Put(b.Bytes(), chanKey[:])
@@ -874,7 +874,7 @@ func (c *ChannelGraph) PruneGraph(spentOutputs []*wire.OutPoint,
 			// if NOT if filter
 
 			var opBytes bytes.Buffer
-			if err := writeOutpoint(&opBytes, chanPoint); err != nil {
+			if err := WriteOutpoint(&opBytes, chanPoint); err != nil {
 				return err
 			}
 
@@ -1322,7 +1322,7 @@ func (c *ChannelGraph) ChannelID(chanPoint *wire.OutPoint) (uint64, error) {
 // getChanID returns the assigned channel ID for a given channel point.
 func getChanID(tx kvdb.RTx, chanPoint *wire.OutPoint) (uint64, error) {
 	var b bytes.Buffer
-	if err := writeOutpoint(&b, chanPoint); err != nil {
+	if err := WriteOutpoint(&b, chanPoint); err != nil {
 		return 0, err
 	}
 
@@ -1876,7 +1876,7 @@ func delChannelEdge(edges, edgeIndex, chanIndex, zombieIndex,
 		return err
 	}
 	var b bytes.Buffer
-	if err := writeOutpoint(&b, &edgeInfo.ChannelPoint); err != nil {
+	if err := WriteOutpoint(&b, &edgeInfo.ChannelPoint); err != nil {
 		return err
 	}
 	if err := chanIndex.Delete(b.Bytes()); err != nil {
@@ -2899,7 +2899,7 @@ func (c *ChannelGraph) FetchChannelEdgesByOutpoint(op *wire.OutPoint,
 			return ErrGraphNoEdgesFound
 		}
 		var b bytes.Buffer
-		if err := writeOutpoint(&b, op); err != nil {
+		if err := WriteOutpoint(&b, op); err != nil {
 			return err
 		}
 		chanID := chanIndex.Get(b.Bytes())
@@ -3156,7 +3156,7 @@ func (c *ChannelGraph) ChannelView() ([]EdgePoint, error) {
 			chanPointReader := bytes.NewReader(chanPointBytes)
 
 			var chanPoint wire.OutPoint
-			err := readOutpoint(chanPointReader, &chanPoint)
+			err := ReadOutpoint(chanPointReader, &chanPoint)
 			if err != nil {
 				return err
 			}
@@ -3594,7 +3594,7 @@ func putChanEdgeInfo(edgeIndex kvdb.RwBucket, edgeInfo *ChannelEdgeInfo, chanID 
 		return err
 	}
 
-	if err := writeOutpoint(&b, &edgeInfo.ChannelPoint); err != nil {
+	if err := WriteOutpoint(&b, &edgeInfo.ChannelPoint); err != nil {
 		return err
 	}
 	if err := binary.Write(&b, byteOrder, uint64(edgeInfo.Capacity)); err != nil {
@@ -3678,7 +3678,7 @@ func deserializeChanEdgeInfo(r io.Reader) (ChannelEdgeInfo, error) {
 	}
 
 	edgeInfo.ChannelPoint = wire.OutPoint{}
-	if err := readOutpoint(r, &edgeInfo.ChannelPoint); err != nil {
+	if err := ReadOutpoint(r, &edgeInfo.ChannelPoint); err != nil {
 		return ChannelEdgeInfo{}, err
 	}
 	if err := binary.Read(r, byteOrder, &edgeInfo.Capacity); err != nil {

--- a/channeldb/reports.go
+++ b/channeldb/reports.go
@@ -164,7 +164,7 @@ func putReport(tx kvdb.RwTx, chainHash chainhash.Hash,
 
 	// Finally write our outpoint to be used as the key for this record.
 	var keyBuf bytes.Buffer
-	if err := writeOutpoint(&keyBuf, &report.OutPoint); err != nil {
+	if err := WriteOutpoint(&keyBuf, &report.OutPoint); err != nil {
 		return err
 	}
 
@@ -315,7 +315,7 @@ func fetchReportWriteBucket(tx kvdb.RwTx, chainHash chainhash.Hash,
 	}
 
 	var chanPointBuf bytes.Buffer
-	if err := writeOutpoint(&chanPointBuf, outPoint); err != nil {
+	if err := WriteOutpoint(&chanPointBuf, outPoint); err != nil {
 		return nil, err
 	}
 
@@ -339,7 +339,7 @@ func fetchReportReadBucket(tx kvdb.RTx, chainHash chainhash.Hash,
 	// With the bucket for the node and chain fetched, we can now go down
 	// another level, for the channel itself.
 	var chanPointBuf bytes.Buffer
-	if err := writeOutpoint(&chanPointBuf, outPoint); err != nil {
+	if err := WriteOutpoint(&chanPointBuf, outPoint); err != nil {
 		return nil, err
 	}
 

--- a/channeldb/reports_test.go
+++ b/channeldb/reports_test.go
@@ -139,7 +139,7 @@ func TestFetchChannelWriteBucket(t *testing.T) {
 		error) {
 
 		var chanPointBuf bytes.Buffer
-		err := writeOutpoint(&chanPointBuf, &testChanPoint1)
+		err := WriteOutpoint(&chanPointBuf, &testChanPoint1)
 		require.NoError(t, err)
 
 		return chainHash.CreateBucketIfNotExists(chanPointBuf.Bytes())

--- a/fundingmanager.go
+++ b/fundingmanager.go
@@ -3498,7 +3498,8 @@ func (f *fundingManager) saveChannelOpeningState(chanPoint *wire.OutPoint,
 		}
 
 		var outpointBytes bytes.Buffer
-		if err = writeOutpoint(&outpointBytes, chanPoint); err != nil {
+		err = channeldb.WriteVarOutpoint(&outpointBytes, chanPoint)
+		if err != nil {
 			return err
 		}
 
@@ -3530,7 +3531,8 @@ func (f *fundingManager) getChannelOpeningState(chanPoint *wire.OutPoint) (
 		}
 
 		var outpointBytes bytes.Buffer
-		if err := writeOutpoint(&outpointBytes, chanPoint); err != nil {
+		err := channeldb.WriteVarOutpoint(&outpointBytes, chanPoint)
+		if err != nil {
 			return err
 		}
 
@@ -3559,7 +3561,8 @@ func (f *fundingManager) deleteChannelOpeningState(chanPoint *wire.OutPoint) err
 		}
 
 		var outpointBytes bytes.Buffer
-		if err := writeOutpoint(&outpointBytes, chanPoint); err != nil {
+		err := channeldb.WriteVarOutpoint(&outpointBytes, chanPoint)
+		if err != nil {
 			return err
 		}
 


### PR DESCRIPTION
Removes duplicate `writeOutpoint` and `readOutpoint` function in `utxonursery.go`.