### PR TITLE
invoices: garbage collect settled/canceled invoices

### DIFF
--- a/config.go
+++ b/config.go
@@ -244,6 +244,8 @@ type Config struct {
 
 	GcCanceledInvoicesOnStartup bool `long:"gc-canceled-invoices-on-startup" description:"If true, we'll attempt to garbage collect canceled invoices upon start."`
 
+	GcCanceledInvoicesOnTheFly bool `long:"gc-canceled-invoices-on-the-fly" description:"If true, we'll delete newly canceled invoices on the fly."`
+
 	Routing *routing.Conf `group:"routing" namespace:"routing"`
 
 	Workers *lncfg.Workers `group:"workers" namespace:"workers"`

--- a/config.go
+++ b/config.go
@@ -242,6 +242,8 @@ type Config struct {
 
 	KeysendHoldTime time.Duration `long:"keysend-hold-time" description:"If non-zero, keysend payments are accepted but not immediately settled. If the payment isn't settled manually after the specified time, it is canceled automatically. [experimental]"`
 
+	GcCanceledInvoicesOnStartup bool `long:"gc-canceled-invoices-on-startup" description:"If true, we'll attempt to garbage collect canceled invoices upon start."`
+
 	Routing *routing.Conf `group:"routing" namespace:"routing"`
 
 	Workers *lncfg.Workers `group:"workers" namespace:"workers"`

--- a/invoices/invoice_expiry_watcher.go
+++ b/invoices/invoice_expiry_watcher.go
@@ -48,8 +48,8 @@ type InvoiceExpiryWatcher struct {
 	// invoice to expire.
 	expiryQueue queue.PriorityQueue
 
-	// newInvoices channel is used to wake up the main loop when a new invoices
-	// is added.
+	// newInvoices channel is used to wake up the main loop when a new
+	// invoices is added.
 	newInvoices chan []*invoiceExpiry
 
 	wg sync.WaitGroup
@@ -109,7 +109,8 @@ func (ew *InvoiceExpiryWatcher) prepareInvoice(
 	paymentHash lntypes.Hash, invoice *channeldb.Invoice) *invoiceExpiry {
 
 	if invoice.State != channeldb.ContractOpen {
-		log.Debugf("Invoice not added to expiry watcher: %v", paymentHash)
+		log.Debugf("Invoice not added to expiry watcher: %v",
+			paymentHash)
 		return nil
 	}
 
@@ -133,10 +134,13 @@ func (ew *InvoiceExpiryWatcher) AddInvoices(
 	invoicesWithExpiry := make([]*invoiceExpiry, 0, len(invoices))
 	for _, invoiceWithPaymentHash := range invoices {
 		newInvoiceExpiry := ew.prepareInvoice(
-			invoiceWithPaymentHash.PaymentHash, &invoiceWithPaymentHash.Invoice,
+			invoiceWithPaymentHash.PaymentHash,
+			&invoiceWithPaymentHash.Invoice,
 		)
 		if newInvoiceExpiry != nil {
-			invoicesWithExpiry = append(invoicesWithExpiry, newInvoiceExpiry)
+			invoicesWithExpiry = append(
+				invoicesWithExpiry, newInvoiceExpiry,
+			)
 		}
 	}
 
@@ -160,8 +164,8 @@ func (ew *InvoiceExpiryWatcher) AddInvoice(
 
 	newInvoiceExpiry := ew.prepareInvoice(paymentHash, invoice)
 	if newInvoiceExpiry != nil {
-		log.Debugf("Adding invoice '%v' to expiry watcher, expiration: %v",
-			paymentHash, newInvoiceExpiry.Expiry)
+		log.Debugf("Adding invoice '%v' to expiry watcher,"+
+			"expiration: %v", paymentHash, newInvoiceExpiry.Expiry)
 
 		select {
 		case ew.newInvoices <- []*invoiceExpiry{newInvoiceExpiry}:
@@ -202,7 +206,8 @@ func (ew *InvoiceExpiryWatcher) cancelNextExpiredInvoice() {
 		if err != nil && err != channeldb.ErrInvoiceAlreadySettled &&
 			err != channeldb.ErrInvoiceAlreadyCanceled {
 
-			log.Errorf("Unable to cancel invoice: %v", top.PaymentHash)
+			log.Errorf("Unable to cancel invoice: %v",
+				top.PaymentHash)
 		}
 
 		ew.expiryQueue.Pop()
@@ -236,8 +241,8 @@ func (ew *InvoiceExpiryWatcher) mainLoop() {
 				continue
 
 			case invoicesWithExpiry := <-ew.newInvoices:
-				for _, invoiceWithExpiry := range invoicesWithExpiry {
-					ew.expiryQueue.Push(invoiceWithExpiry)
+				for _, invoice := range invoicesWithExpiry {
+					ew.expiryQueue.Push(invoice)
 				}
 
 			case <-ew.quit:

--- a/invoices/invoice_expiry_watcher.go
+++ b/invoices/invoice_expiry_watcher.go
@@ -129,14 +129,11 @@ func (ew *InvoiceExpiryWatcher) prepareInvoice(
 
 // AddInvoices adds multiple invoices to the InvoiceExpiryWatcher.
 func (ew *InvoiceExpiryWatcher) AddInvoices(
-	invoices []channeldb.InvoiceWithPaymentHash) {
+	invoices map[lntypes.Hash]*channeldb.Invoice) {
 
 	invoicesWithExpiry := make([]*invoiceExpiry, 0, len(invoices))
-	for _, invoiceWithPaymentHash := range invoices {
-		newInvoiceExpiry := ew.prepareInvoice(
-			invoiceWithPaymentHash.PaymentHash,
-			&invoiceWithPaymentHash.Invoice,
-		)
+	for paymentHash, invoice := range invoices {
+		newInvoiceExpiry := ew.prepareInvoice(paymentHash, invoice)
 		if newInvoiceExpiry != nil {
 			invoicesWithExpiry = append(
 				invoicesWithExpiry, newInvoiceExpiry,

--- a/invoices/invoice_expiry_watcher_test.go
+++ b/invoices/invoice_expiry_watcher_test.go
@@ -158,24 +158,14 @@ func TestInvoiceExpiryWhenAddingMultipleInvoices(t *testing.T) {
 	t.Parallel()
 
 	test := newInvoiceExpiryWatcherTest(t, testTime, 5, 5)
-	var invoices []channeldb.InvoiceWithPaymentHash
+	invoices := make(map[lntypes.Hash]*channeldb.Invoice)
 
 	for hash, invoice := range test.testData.expiredInvoices {
-		invoices = append(invoices,
-			channeldb.InvoiceWithPaymentHash{
-				Invoice:     *invoice,
-				PaymentHash: hash,
-			},
-		)
+		invoices[hash] = invoice
 	}
 
 	for hash, invoice := range test.testData.pendingInvoices {
-		invoices = append(invoices,
-			channeldb.InvoiceWithPaymentHash{
-				Invoice:     *invoice,
-				PaymentHash: hash,
-			},
-		)
+		invoices[hash] = invoice
 	}
 
 	test.watcher.AddInvoices(invoices)

--- a/invoices/invoice_expiry_watcher_test.go
+++ b/invoices/invoice_expiry_watcher_test.go
@@ -37,7 +37,9 @@ func newInvoiceExpiryWatcherTest(t *testing.T, now time.Time,
 	err := test.watcher.Start(func(paymentHash lntypes.Hash,
 		force bool) error {
 
-		test.canceledInvoices = append(test.canceledInvoices, paymentHash)
+		test.canceledInvoices = append(
+			test.canceledInvoices, paymentHash,
+		)
 		test.wg.Done()
 		return nil
 	})
@@ -70,7 +72,8 @@ func (t *invoiceExpiryWatcherTest) checkExpectations() {
 	// that expired.
 	if len(t.canceledInvoices) != len(t.testData.expiredInvoices) {
 		t.t.Fatalf("expected %v cancellations, got %v",
-			len(t.testData.expiredInvoices), len(t.canceledInvoices))
+			len(t.testData.expiredInvoices),
+			len(t.canceledInvoices))
 	}
 
 	for i := range t.canceledInvoices {

--- a/invoices/invoiceregistry.go
+++ b/invoices/invoiceregistry.go
@@ -57,6 +57,10 @@ type RegistryConfig struct {
 	// send payments.
 	AcceptKeySend bool
 
+	// GcCanceledInvoicesOnStartup if set, we'll attempt to garbage collect
+	// all canceled invoices upon start.
+	GcCanceledInvoicesOnStartup bool
+
 	// KeysendHoldTime indicates for how long we want to accept and hold
 	// spontaneous keysend payments.
 	KeysendHoldTime time.Duration
@@ -171,7 +175,9 @@ func (i *InvoiceRegistry) scanInvoicesOnStart() error {
 
 		if invoice.IsPending() {
 			pending[paymentHash] = invoice
-		} else if invoice.State == channeldb.ContractCanceled {
+		} else if i.cfg.GcCanceledInvoicesOnStartup &&
+			invoice.State == channeldb.ContractCanceled {
+
 			// Consider invoice for removal if it is already
 			// canceled. Invoices that are expired but not yet
 			// canceled, will be queued up for cancellation after

--- a/invoices/invoiceregistry_test.go
+++ b/invoices/invoiceregistry_test.go
@@ -1091,8 +1091,9 @@ func TestOldInvoiceRemovalOnStart(t *testing.T) {
 	require.NoError(t, err)
 
 	cfg := RegistryConfig{
-		FinalCltvRejectDelta: testFinalCltvRejectDelta,
-		Clock:                testClock,
+		FinalCltvRejectDelta:        testFinalCltvRejectDelta,
+		Clock:                       testClock,
+		GcCanceledInvoicesOnStartup: true,
 	}
 
 	expiryWatcher := NewInvoiceExpiryWatcher(cfg.Clock)

--- a/server.go
+++ b/server.go
@@ -396,11 +396,12 @@ func newServer(cfg *Config, listenAddrs []net.Addr, chanDB *channeldb.DB,
 	}
 
 	registryConfig := invoices.RegistryConfig{
-		FinalCltvRejectDelta: lncfg.DefaultFinalCltvRejectDelta,
-		HtlcHoldDuration:     invoices.DefaultHtlcHoldDuration,
-		Clock:                clock.NewDefaultClock(),
-		AcceptKeySend:        cfg.AcceptKeySend,
-		KeysendHoldTime:      cfg.KeysendHoldTime,
+		FinalCltvRejectDelta:        lncfg.DefaultFinalCltvRejectDelta,
+		HtlcHoldDuration:            invoices.DefaultHtlcHoldDuration,
+		Clock:                       clock.NewDefaultClock(),
+		AcceptKeySend:               cfg.AcceptKeySend,
+		GcCanceledInvoicesOnStartup: cfg.GcCanceledInvoicesOnStartup,
+		KeysendHoldTime:             cfg.KeysendHoldTime,
 	}
 
 	s := &server{

--- a/server.go
+++ b/server.go
@@ -401,6 +401,7 @@ func newServer(cfg *Config, listenAddrs []net.Addr, chanDB *channeldb.DB,
 		Clock:                       clock.NewDefaultClock(),
 		AcceptKeySend:               cfg.AcceptKeySend,
 		GcCanceledInvoicesOnStartup: cfg.GcCanceledInvoicesOnStartup,
+		GcCanceledInvoicesOnTheFly:  cfg.GcCanceledInvoicesOnTheFly,
 		KeysendHoldTime:             cfg.KeysendHoldTime,
 	}
 


### PR DESCRIPTION
This PR adds configurable garbage collection to remove canceled invoices when LND starts up and also to delete newly canceled ones on the fly. As users might have many of such invoices where collecting and deleting them may take a long time, garbage collection on startup is off by default.