### PR TITLE
lnd: removing activeNetParams global, passed around instead via configs

### DIFF
--- a/chainparams.go
+++ b/chainparams.go
@@ -10,10 +10,6 @@ import (
 	litecoinWire "github.com/ltcsuite/ltcd/wire"
 )
 
-// activeNetParams is a pointer to the parameters specific to the currently
-// active bitcoin network.
-var activeNetParams = bitcoinTestNetParams
-
 // bitcoinNetParams couples the p2p parameters of a network with the
 // corresponding RPC port of a daemon running on the particular network.
 type bitcoinNetParams struct {

--- a/fundingmanager_test.go
+++ b/fundingmanager_test.go
@@ -99,6 +99,8 @@ var (
 	}
 	_, _ = testSig.R.SetString("63724406601629180062774974542967536251589935445068131219452686511677818569431", 10)
 	_, _ = testSig.S.SetString("18801056069249825825291287104931333862866033135609736119018462340006816851118", 10)
+
+	fundingNetParams = bitcoinTestNetParams
 )
 
 type mockNotifier struct {
@@ -282,7 +284,7 @@ func createTestFundingManager(t *testing.T, privKey *btcec.PrivateKey,
 	addr *lnwire.NetAddress, tempTestDir string,
 	options ...cfgOption) (*testNode, error) {
 
-	netParams := activeNetParams.Params
+	netParams := fundingNetParams.Params
 	estimator := chainfee.NewStaticEstimator(62500, 0)
 
 	chainNotifier := &mockNotifier{
@@ -643,7 +645,7 @@ func fundChannel(t *testing.T, alice, bob *testNode, localFundingAmt,
 	errChan := make(chan error, 1)
 	initReq := &openChanReq{
 		targetPubkey:    bob.privKey.PubKey(),
-		chainHash:       *activeNetParams.GenesisHash,
+		chainHash:       *fundingNetParams.GenesisHash,
 		subtractFees:    subtractFees,
 		localFundingAmt: localFundingAmt,
 		pushAmt:         lnwire.NewMSatFromSatoshis(pushAmt),
@@ -1567,7 +1569,7 @@ func TestFundingManagerPeerTimeoutAfterInitFunding(t *testing.T) {
 	errChan := make(chan error, 1)
 	initReq := &openChanReq{
 		targetPubkey:    bob.privKey.PubKey(),
-		chainHash:       *activeNetParams.GenesisHash,
+		chainHash:       *fundingNetParams.GenesisHash,
 		localFundingAmt: 500000,
 		pushAmt:         lnwire.NewMSatFromSatoshis(0),
 		private:         false,
@@ -1629,7 +1631,7 @@ func TestFundingManagerPeerTimeoutAfterFundingOpen(t *testing.T) {
 	errChan := make(chan error, 1)
 	initReq := &openChanReq{
 		targetPubkey:    bob.privKey.PubKey(),
-		chainHash:       *activeNetParams.GenesisHash,
+		chainHash:       *fundingNetParams.GenesisHash,
 		localFundingAmt: 500000,
 		pushAmt:         lnwire.NewMSatFromSatoshis(0),
 		private:         false,
@@ -1700,7 +1702,7 @@ func TestFundingManagerPeerTimeoutAfterFundingAccept(t *testing.T) {
 	errChan := make(chan error, 1)
 	initReq := &openChanReq{
 		targetPubkey:    bob.privKey.PubKey(),
-		chainHash:       *activeNetParams.GenesisHash,
+		chainHash:       *fundingNetParams.GenesisHash,
 		localFundingAmt: 500000,
 		pushAmt:         lnwire.NewMSatFromSatoshis(0),
 		private:         false,
@@ -2424,7 +2426,7 @@ func TestFundingManagerCustomChannelParameters(t *testing.T) {
 	errChan := make(chan error, 1)
 	initReq := &openChanReq{
 		targetPubkey:     bob.privKey.PubKey(),
-		chainHash:        *activeNetParams.GenesisHash,
+		chainHash:        *fundingNetParams.GenesisHash,
 		localFundingAmt:  localAmt,
 		pushAmt:          lnwire.NewMSatFromSatoshis(pushAmt),
 		private:          false,
@@ -2709,7 +2711,7 @@ func TestFundingManagerMaxPendingChannels(t *testing.T) {
 		errChan := make(chan error, 1)
 		initReq := &openChanReq{
 			targetPubkey:    bob.privKey.PubKey(),
-			chainHash:       *activeNetParams.GenesisHash,
+			chainHash:       *fundingNetParams.GenesisHash,
 			localFundingAmt: 5000000,
 			pushAmt:         lnwire.NewMSatFromSatoshis(0),
 			private:         false,
@@ -2879,7 +2881,7 @@ func TestFundingManagerRejectPush(t *testing.T) {
 	errChan := make(chan error, 1)
 	initReq := &openChanReq{
 		targetPubkey:    bob.privKey.PubKey(),
-		chainHash:       *activeNetParams.GenesisHash,
+		chainHash:       *fundingNetParams.GenesisHash,
 		localFundingAmt: 500000,
 		pushAmt:         lnwire.NewMSatFromSatoshis(10),
 		private:         true,
@@ -2936,7 +2938,7 @@ func TestFundingManagerMaxConfs(t *testing.T) {
 	errChan := make(chan error, 1)
 	initReq := &openChanReq{
 		targetPubkey:    bob.privKey.PubKey(),
-		chainHash:       *activeNetParams.GenesisHash,
+		chainHash:       *fundingNetParams.GenesisHash,
 		localFundingAmt: 500000,
 		pushAmt:         lnwire.NewMSatFromSatoshis(10),
 		private:         false,
@@ -3218,7 +3220,7 @@ func TestWumboChannelConfig(t *testing.T) {
 	errChan := make(chan error, 1)
 	initReq := &openChanReq{
 		targetPubkey:    bob.privKey.PubKey(),
-		chainHash:       *activeNetParams.GenesisHash,
+		chainHash:       *fundingNetParams.GenesisHash,
 		localFundingAmt: MaxFundingAmount,
 		pushAmt:         lnwire.NewMSatFromSatoshis(0),
 		private:         false,

--- a/lnd.go
+++ b/lnd.go
@@ -514,7 +514,7 @@ func Main(cfg *Config, lisCfg ListenerCfg, shutdownChan <-chan struct{}) error {
 		towerDBDir := filepath.Join(
 			cfg.Watchtower.TowerDir,
 			cfg.registeredChains.PrimaryChain().String(),
-			normalizeNetwork(activeNetParams.Name),
+			normalizeNetwork(cfg.ActiveNetParams.Name),
 		)
 
 		towerDB, err := wtdb.OpenTowerDB(towerDBDir)
@@ -552,7 +552,7 @@ func Main(cfg *Config, lisCfg ListenerCfg, shutdownChan <-chan struct{}) error {
 				towerKeyDesc, activeChainControl.keyRing,
 			),
 			PublishTx: activeChainControl.wallet.PublishTransaction,
-			ChainHash: *activeNetParams.GenesisHash,
+			ChainHash: *cfg.ActiveNetParams.GenesisHash,
 		}
 
 		// If there is a tor controller (user wants auto hidden services), then
@@ -604,7 +604,7 @@ func Main(cfg *Config, lisCfg ListenerCfg, shutdownChan <-chan struct{}) error {
 	// Set up an autopilot manager from the current config. This will be
 	// used to manage the underlying autopilot agent, starting and stopping
 	// it at will.
-	atplCfg, err := initAutoPilot(server, cfg.Autopilot, mainChain)
+	atplCfg, err := initAutoPilot(server, cfg.Autopilot, mainChain, cfg.ActiveNetParams)
 	if err != nil {
 		err := fmt.Errorf("unable to initialize autopilot: %v", err)
 		ltndLog.Error(err)
@@ -974,7 +974,7 @@ func waitForWalletPassword(cfg *Config, restEndpoints []net.Addr,
 		cfg.AdminMacPath, cfg.ReadMacPath, cfg.InvoiceMacPath,
 	}
 	pwService := walletunlocker.New(
-		chainConfig.ChainDir, activeNetParams.Params, !cfg.SyncFreelist,
+		chainConfig.ChainDir, cfg.ActiveNetParams.Params, !cfg.SyncFreelist,
 		macaroonFiles,
 	)
 	lnrpc.RegisterWalletUnlockerServer(grpcServer, pwService)
@@ -1069,10 +1069,10 @@ func waitForWalletPassword(cfg *Config, restEndpoints []net.Addr,
 		}
 
 		netDir := btcwallet.NetworkDir(
-			chainConfig.ChainDir, activeNetParams.Params,
+			chainConfig.ChainDir, cfg.ActiveNetParams.Params,
 		)
 		loader := wallet.NewLoader(
-			activeNetParams.Params, netDir, !cfg.SyncFreelist,
+			cfg.ActiveNetParams.Params, netDir, !cfg.SyncFreelist,
 			recoveryWindow,
 		)
 

--- a/mock.go
+++ b/mock.go
@@ -219,7 +219,7 @@ type mockChainIO struct {
 var _ lnwallet.BlockChainIO = (*mockChainIO)(nil)
 
 func (m *mockChainIO) GetBestBlock() (*chainhash.Hash, int32, error) {
-	return activeNetParams.GenesisHash, m.bestHeight, nil
+	return chaincfg.TestNet3Params.GenesisHash, m.bestHeight, nil
 }
 
 func (*mockChainIO) GetUtxo(op *wire.OutPoint, _ []byte,

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -556,7 +556,7 @@ func newRPCServer(cfg *Config, s *server, macService *macaroons.Service,
 		},
 		FindRoute:              s.chanRouter.FindRoute,
 		MissionControl:         s.missionControl,
-		ActiveNetParams:        activeNetParams.Params,
+		ActiveNetParams:        cfg.ActiveNetParams.Params,
 		Tower:                  s.controlTower,
 		MaxTotalTimelock:       cfg.MaxOutgoingCltvExpiry,
 		DefaultFinalCltvDelta:  uint16(cfg.Bitcoin.TimeLockDelta),
@@ -580,7 +580,7 @@ func newRPCServer(cfg *Config, s *server, macService *macaroons.Service,
 	// TODO(roasbeef): extend sub-sever config to have both (local vs remote) DB
 	err = subServerCgs.PopulateDependencies(
 		cfg, s.cc, cfg.networkDir, macService, atpl, invoiceRegistry,
-		s.htlcSwitch, activeNetParams.Params, s.chanRouter,
+		s.htlcSwitch, cfg.ActiveNetParams.Params, s.chanRouter,
 		routerBackend, s.nodeSigner, s.remoteChanDB, s.sweeper, tower,
 		s.towerClient, cfg.net.ResolveTCPAddr, genInvoiceFeatures,
 		rpcsLog,
@@ -918,10 +918,12 @@ func (r *rpcServer) Stop() error {
 // the outputs themselves. The passed map pairs up an address, to a desired
 // output value amount. Each address is converted to its corresponding pkScript
 // to be used within the constructed output(s).
-func addrPairsToOutputs(addrPairs map[string]int64) ([]*wire.TxOut, error) {
+func addrPairsToOutputs(addrPairs map[string]int64,
+	params *chaincfg.Params) ([]*wire.TxOut, error) {
+
 	outputs := make([]*wire.TxOut, 0, len(addrPairs))
 	for addr, amt := range addrPairs {
-		addr, err := btcutil.DecodeAddress(addr, activeNetParams.Params)
+		addr, err := btcutil.DecodeAddress(addr, params)
 		if err != nil {
 			return nil, err
 		}
@@ -989,7 +991,7 @@ func allowCORS(handler http.Handler, origins []string) http.Handler {
 func (r *rpcServer) sendCoinsOnChain(paymentMap map[string]int64,
 	feeRate chainfee.SatPerKWeight, label string) (*chainhash.Hash, error) {
 
-	outputs, err := addrPairsToOutputs(paymentMap)
+	outputs, err := addrPairsToOutputs(paymentMap, r.cfg.ActiveNetParams.Params)
 	if err != nil {
 		return nil, err
 	}
@@ -1036,7 +1038,7 @@ func (r *rpcServer) ListUnspent(ctx context.Context,
 		return nil, err
 	}
 
-	rpcUtxos, err := lnrpc.MarshalUtxos(utxos, activeNetParams.Params)
+	rpcUtxos, err := lnrpc.MarshalUtxos(utxos, r.cfg.ActiveNetParams.Params)
 	if err != nil {
 		return nil, err
 	}
@@ -1060,7 +1062,7 @@ func (r *rpcServer) EstimateFee(ctx context.Context,
 	in *lnrpc.EstimateFeeRequest) (*lnrpc.EstimateFeeResponse, error) {
 
 	// Create the list of outputs we are spending to.
-	outputs, err := addrPairsToOutputs(in.AddrToAmount)
+	outputs, err := addrPairsToOutputs(in.AddrToAmount, r.cfg.ActiveNetParams.Params)
 	if err != nil {
 		return nil, err
 	}
@@ -1131,16 +1133,18 @@ func (r *rpcServer) SendCoins(ctx context.Context,
 
 	// Decode the address receiving the coins, we need to check whether the
 	// address is valid for this network.
-	targetAddr, err := btcutil.DecodeAddress(in.Addr, activeNetParams.Params)
+	targetAddr, err := btcutil.DecodeAddress(
+		in.Addr, r.cfg.ActiveNetParams.Params,
+	)
 	if err != nil {
 		return nil, err
 	}
 
 	// Make the check on the decoded address according to the active network.
-	if !targetAddr.IsForNet(activeNetParams.Params) {
+	if !targetAddr.IsForNet(r.cfg.ActiveNetParams.Params) {
 		return nil, fmt.Errorf("address: %v is not valid for this "+
 			"network: %v", targetAddr.String(),
-			activeNetParams.Params.Name)
+			r.cfg.ActiveNetParams.Params.Name)
 	}
 
 	// If the destination address parses to a valid pubkey, we assume the user
@@ -1449,7 +1453,7 @@ func (r *rpcServer) ConnectPeer(ctx context.Context,
 	peerAddr := &lnwire.NetAddress{
 		IdentityKey: pubKey,
 		Address:     addr,
-		ChainNet:    activeNetParams.Net,
+		ChainNet:    r.cfg.ActiveNetParams.Net,
 	}
 
 	rpcsLog.Debugf("[connectpeer] requested connection to %x@%s",
@@ -1812,7 +1816,9 @@ func (r *rpcServer) parseOpenChannelReq(in *lnrpc.OpenChannelRequest,
 	rpcsLog.Debugf("[openchannel]: using fee of %v sat/kw for funding tx",
 		int64(feeRate))
 
-	script, err := parseUpfrontShutdownAddress(in.CloseAddress)
+	script, err := parseUpfrontShutdownAddress(
+		in.CloseAddress, r.cfg.ActiveNetParams.Params,
+	)
 	if err != nil {
 		return nil, fmt.Errorf("error parsing upfront shutdown: %v",
 			err)
@@ -1823,7 +1829,7 @@ func (r *rpcServer) parseOpenChannelReq(in *lnrpc.OpenChannelRequest,
 	// be used to consume updates of the state of the pending channel.
 	return &openChanReq{
 		targetPubkey:     nodePubKey,
-		chainHash:        *activeNetParams.GenesisHash,
+		chainHash:        *r.cfg.ActiveNetParams.GenesisHash,
 		localFundingAmt:  localFundingAmt,
 		pushAmt:          lnwire.NewMSatFromSatoshis(remoteInitialBalance),
 		minHtlcIn:        minHtlcIn,
@@ -1986,13 +1992,15 @@ func (r *rpcServer) OpenChannelSync(ctx context.Context,
 // parseUpfrontShutdownScript attempts to parse an upfront shutdown address.
 // If the address is empty, it returns nil. If it successfully decoded the
 // address, it returns a script that pays out to the address.
-func parseUpfrontShutdownAddress(address string) (lnwire.DeliveryAddress, error) {
+func parseUpfrontShutdownAddress(address string,
+	params *chaincfg.Params) (lnwire.DeliveryAddress, error) {
+
 	if len(address) == 0 {
 		return nil, nil
 	}
 
 	addr, err := btcutil.DecodeAddress(
-		address, activeNetParams.Params,
+		address, params,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("invalid address: %v", err)
@@ -2196,7 +2204,7 @@ func (r *rpcServer) CloseChannel(in *lnrpc.CloseChannelRequest,
 		if len(in.DeliveryAddress) > 0 {
 			// Decode the address provided.
 			addr, err := btcutil.DecodeAddress(
-				in.DeliveryAddress, activeNetParams.Params,
+				in.DeliveryAddress, r.cfg.ActiveNetParams.Params,
 			)
 			if err != nil {
 				return fmt.Errorf("invalid delivery address: %v", err)
@@ -2437,7 +2445,7 @@ func (r *rpcServer) GetInfo(ctx context.Context,
 			"with current best block in the main chain: %v", err)
 	}
 
-	network := normalizeNetwork(activeNetParams.Name)
+	network := normalizeNetwork(r.cfg.ActiveNetParams.Name)
 	activeChains := make([]*lnrpc.Chain, r.cfg.registeredChains.NumActiveChains())
 	for i, chain := range r.cfg.registeredChains.ActiveChains() {
 		activeChains[i] = &lnrpc.Chain{
@@ -2488,7 +2496,7 @@ func (r *rpcServer) GetInfo(ctx context.Context,
 		BlockHeight:         uint32(bestHeight),
 		BlockHash:           bestHash.String(),
 		SyncedToChain:       isSynced,
-		Testnet:             isTestnet(&activeNetParams),
+		Testnet:             isTestnet(&r.cfg.ActiveNetParams),
 		Chains:              activeChains,
 		Uris:                uris,
 		Alias:               nodeAnn.Alias.String(),
@@ -3432,7 +3440,7 @@ func createRPCOpenChannel(r *rpcServer, graph *channeldb.ChannelGraph,
 
 	if len(dbChannel.LocalShutdownScript) > 0 {
 		_, addresses, _, err := txscript.ExtractPkScriptAddrs(
-			dbChannel.LocalShutdownScript, activeNetParams.Params,
+			dbChannel.LocalShutdownScript, r.cfg.ActiveNetParams.Params,
 		)
 		if err != nil {
 			return nil, err
@@ -3552,8 +3560,7 @@ func (r *rpcServer) createRPCClosedChannel(
 	}
 
 	reports, err := r.server.remoteChanDB.FetchChannelReports(
-
-		*activeNetParams.GenesisHash, &dbChannel.ChanPoint,
+		*r.cfg.ActiveNetParams.GenesisHash, &dbChannel.ChanPoint,
 	)
 	switch err {
 	// If the channel does not have its resolver outcomes stored,
@@ -4009,7 +4016,7 @@ func (r *rpcServer) extractPaymentIntent(rpcPayReq *rpcPaymentRequest) (rpcPayme
 	// attempt to decode it, populating the payment accordingly.
 	if rpcPayReq.PaymentRequest != "" {
 		payReq, err := zpay32.Decode(
-			rpcPayReq.PaymentRequest, activeNetParams.Params,
+			rpcPayReq.PaymentRequest, r.cfg.ActiveNetParams.Params,
 		)
 		if err != nil {
 			return payIntent, err
@@ -4526,7 +4533,7 @@ func (r *rpcServer) AddInvoice(ctx context.Context,
 	addInvoiceCfg := &invoicesrpc.AddInvoiceConfig{
 		AddInvoice:        r.server.invoices.AddInvoice,
 		IsChannelActive:   r.server.htlcSwitch.HasActiveLink,
-		ChainParams:       activeNetParams.Params,
+		ChainParams:       r.cfg.ActiveNetParams.Params,
 		NodeSigner:        r.server.nodeSigner,
 		DefaultCLTVExpiry: defaultDelta,
 		ChanDB:            r.server.remoteChanDB,
@@ -4615,7 +4622,7 @@ func (r *rpcServer) LookupInvoice(ctx context.Context,
 		}))
 
 	rpcInvoice, err := invoicesrpc.CreateRPCInvoice(
-		&invoice, activeNetParams.Params,
+		&invoice, r.cfg.ActiveNetParams.Params,
 	)
 	if err != nil {
 		return nil, err
@@ -4656,8 +4663,9 @@ func (r *rpcServer) ListInvoices(ctx context.Context,
 		LastIndexOffset:  invoiceSlice.LastIndexOffset,
 	}
 	for i, invoice := range invoiceSlice.Invoices {
+		invoice := invoice
 		resp.Invoices[i], err = invoicesrpc.CreateRPCInvoice(
-			&invoice, activeNetParams.Params,
+			&invoice, r.cfg.ActiveNetParams.Params,
 		)
 		if err != nil {
 			return nil, err
@@ -4684,7 +4692,7 @@ func (r *rpcServer) SubscribeInvoices(req *lnrpc.InvoiceSubscription,
 		select {
 		case newInvoice := <-invoiceClient.NewInvoices:
 			rpcInvoice, err := invoicesrpc.CreateRPCInvoice(
-				newInvoice, activeNetParams.Params,
+				newInvoice, r.cfg.ActiveNetParams.Params,
 			)
 			if err != nil {
 				return err
@@ -4696,7 +4704,7 @@ func (r *rpcServer) SubscribeInvoices(req *lnrpc.InvoiceSubscription,
 
 		case settledInvoice := <-invoiceClient.SettledInvoices:
 			rpcInvoice, err := invoicesrpc.CreateRPCInvoice(
-				settledInvoice, activeNetParams.Params,
+				settledInvoice, r.cfg.ActiveNetParams.Params,
 			)
 			if err != nil {
 				return err
@@ -5463,7 +5471,7 @@ func (r *rpcServer) DecodePayReq(ctx context.Context,
 	// Fist we'll attempt to decode the payment request string, if the
 	// request is invalid or the checksum doesn't match, then we'll exit
 	// here with an error.
-	payReq, err := zpay32.Decode(req.PayReq, activeNetParams.Params)
+	payReq, err := zpay32.Decode(req.PayReq, r.cfg.ActiveNetParams.Params)
 	if err != nil {
 		return nil, err
 	}

--- a/server.go
+++ b/server.go
@@ -370,7 +370,7 @@ func newServer(cfg *Config, listenAddrs []net.Addr,
 	)
 	replayLog := htlcswitch.NewDecayedLog(sharedSecretPath, cc.chainNotifier)
 	sphinxRouter := sphinx.NewRouter(
-		nodeKeyECDH, activeNetParams.Params, replayLog,
+		nodeKeyECDH, cfg.ActiveNetParams.Params, replayLog,
 	)
 
 	writeBufferPool := pool.NewWriteBuffer(
@@ -773,7 +773,7 @@ func newServer(cfg *Config, listenAddrs []net.Addr,
 	s.authGossiper = discovery.New(discovery.Config{
 		Router:            s.chanRouter,
 		Notifier:          s.cc.chainNotifier,
-		ChainHash:         *activeNetParams.GenesisHash,
+		ChainHash:         *s.cfg.ActiveNetParams.GenesisHash,
 		Broadcast:         s.BroadcastMessage,
 		ChanSeries:        chanSeries,
 		NotifyWhenOnline:  s.NotifyWhenOnline,
@@ -805,9 +805,7 @@ func newServer(cfg *Config, listenAddrs []net.Addr,
 		FetchChannel:              s.remoteChanDB.FetchChannel,
 	}
 
-	utxnStore, err := newNurseryStore(
-		activeNetParams.GenesisHash, remoteChanDB,
-	)
+	utxnStore, err := newNurseryStore(s.cfg.ActiveNetParams.GenesisHash, remoteChanDB)
 	if err != nil {
 		srvrLog.Errorf("unable to create nursery store: %v", err)
 		return nil, err
@@ -817,7 +815,7 @@ func newServer(cfg *Config, listenAddrs []net.Addr,
 		sweep.DefaultBatchWindowDuration)
 
 	sweeperStore, err := sweep.NewSweeperStore(
-		remoteChanDB, activeNetParams.GenesisHash,
+		remoteChanDB, s.cfg.ActiveNetParams.GenesisHash,
 	)
 	if err != nil {
 		srvrLog.Errorf("unable to create sweeper store: %v", err)
@@ -869,7 +867,7 @@ func newServer(cfg *Config, listenAddrs []net.Addr,
 	contractBreaches := make(chan *ContractBreachEvent, 1)
 
 	s.chainArb = contractcourt.NewChainArbitrator(contractcourt.ChainArbitratorConfig{
-		ChainHash:              *activeNetParams.GenesisHash,
+		ChainHash:              *s.cfg.ActiveNetParams.GenesisHash,
 		IncomingBroadcastDelta: lncfg.DefaultIncomingBroadcastDelta,
 		OutgoingBroadcastDelta: lncfg.DefaultOutgoingBroadcastDelta,
 		NewSweepAddr:           newSweepPkScriptGen(cc.wallet),
@@ -1221,7 +1219,7 @@ func newServer(cfg *Config, listenAddrs []net.Addr,
 			AuthDial:       wtclient.AuthDial,
 			DB:             towerClientDB,
 			Policy:         policy,
-			ChainHash:      *activeNetParams.GenesisHash,
+			ChainHash:      *s.cfg.ActiveNetParams.GenesisHash,
 			MinBackoff:     10 * time.Second,
 			MaxBackoff:     5 * time.Minute,
 			ForceQuitDelay: wtclient.DefaultForceQuitDelay,
@@ -1751,7 +1749,7 @@ func initNetworkBootstrappers(s *server) ([]discovery.NetworkPeerBootstrapper, e
 	// If this isn't simnet mode, then one of our additional bootstrapping
 	// sources will be the set of running DNS seeds.
 	if !s.cfg.Bitcoin.SimNet || !s.cfg.Litecoin.SimNet {
-		dnsSeeds, ok := chainDNSSeeds[*activeNetParams.GenesisHash]
+		dnsSeeds, ok := chainDNSSeeds[*s.cfg.ActiveNetParams.GenesisHash]
 
 		// If we have a set of DNS seeds for this chain, then we'll add
 		// it as an additional bootstrapping source.
@@ -2812,7 +2810,7 @@ func (s *server) peerConnected(conn net.Conn, connReq *connmgr.ConnReq,
 	peerAddr := &lnwire.NetAddress{
 		IdentityKey: pubKey,
 		Address:     addr,
-		ChainNet:    activeNetParams.Net,
+		ChainNet:    s.cfg.ActiveNetParams.Net,
 	}
 
 	// With the brontide connection established, we'll now craft the feature


### PR DESCRIPTION
This commit removes the `activeNetParams` global in `chainparams.go`. This is necessary to isolate code from the lnd package so we can import it for use in tests, other projects, etc.