### PR TITLE
config: make bbolt freelist settings mutually exclusive

### DIFF
--- a/channeldb/kvdb/config.go
+++ b/channeldb/kvdb/config.go
@@ -12,7 +12,7 @@ const EtcdBackendName = "etcd"
 
 // BoltConfig holds bolt configuration.
 type BoltConfig struct {
-	NoFreeListSync bool `long:"nofreelistsync" description:"If true, prevents the database from syncing its freelist to disk"`
+	SyncFreelist bool `long:"nofreelistsync" description:"Whether the databases used within lnd should sync their freelist to disk. This is disabled by default resulting in improved memory performance during operation, but with an increase in startup time."`
 }
 
 // EtcdConfig holds etcd configuration.

--- a/config.go
+++ b/config.go
@@ -1097,6 +1097,14 @@ func ValidateConfig(cfg Config, usageMessage string) (*Config, error) {
 			"minbackoff")
 	}
 
+	// Newer versions of lnd added a new sub-config for bolt-specific
+	// parameters. However we want to also allow existing users to use the
+	// value on the top-level config. If the outer config value is set,
+	// then we'll use that directly.
+	if cfg.SyncFreelist {
+		cfg.DB.Bolt.SyncFreelist = cfg.SyncFreelist
+	}
+
 	// Validate the subconfigs for workers, caches, and the tower client.
 	err = lncfg.Validate(
 		cfg.Workers,

--- a/lnd.go
+++ b/lnd.go
@@ -255,6 +255,11 @@ func Main(cfg *Config, lisCfg ListenerCfg, shutdownChan <-chan struct{}) error {
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
+	if cfg.DB.Backend == lncfg.BoltBackend {
+		ltndLog.Infof("Opening bbolt database, sync_freelist=%v",
+			cfg.DB.Bolt.SyncFreelist)
+	}
+
 	chanDbBackend, err := cfg.DB.GetBackend(ctx,
 		cfg.localDatabaseDir(), cfg.networkName(),
 	)

--- a/lnd.go
+++ b/lnd.go
@@ -269,7 +269,6 @@ func Main(cfg *Config, lisCfg ListenerCfg, shutdownChan <-chan struct{}) error {
 		chanDbBackend,
 		channeldb.OptionSetRejectCacheSize(cfg.Caches.RejectCacheSize),
 		channeldb.OptionSetChannelCacheSize(cfg.Caches.ChannelCacheSize),
-		channeldb.OptionSetSyncFreelist(cfg.SyncFreelist),
 		channeldb.OptionDryRunMigration(cfg.DryRunMigration),
 	)
 	switch {


### PR DESCRIPTION
In this commit, we make sure that `cfg.SyncFreeList`, and
`cfg.Bolt.NoSyncFreeList` cannot be set together. Atm, only the latter
value is actually read when we go to open `bbolt`. We also make another
change to force the DB config value to reflect the outer config value if
it's set.

Without this commit, those that update to `v0.11` and were running with
`--sync-freelist=1`, would be met with a regression as `lnd` would
reconstruct the free list from scratch on start up. This may have
resulted in long start up times for those with very large free lists.