### PR TITLE
rpc: add missing space to error message

### DIFF
--- a/lnrpc/chainrpc/chainnotifier_server.go
+++ b/lnrpc/chainrpc/chainnotifier_server.go
@@ -67,7 +67,7 @@ var (
 
 	// ErrChainNotifierServerNotActive indicates that the chain notifier hasn't
 	// finished the startup process.
-	ErrChainNotifierServerNotActive = errors.New("chain notifier RPC is" +
+	ErrChainNotifierServerNotActive = errors.New("chain notifier RPC is " +
 		"still in the process of starting")
 )
 


### PR DESCRIPTION
This corrects the output of the chain notifier RPC error. It has been displayed as: "chain notifier RPC **isstill** in the process of starting"