### PR TITLE
multi: store KeyLocator in OpenChannel, use ECDH instead of DerivePrivKey

### DIFF
--- a/chanbackup/single.go
+++ b/chanbackup/single.go
@@ -124,19 +124,34 @@ type Single struct {
 func NewSingle(channel *channeldb.OpenChannel,
 	nodeAddrs []net.Addr) Single {
 
-	// TODO(roasbeef): update after we start to store the KeyLoc for
-	// shachain root
+	var shaChainRootDesc keychain.KeyDescriptor
 
-	// We'll need to obtain the shachain root which is derived directly
-	// from a private key in our keychain.
-	var b bytes.Buffer
-	channel.RevocationProducer.Encode(&b) // Can't return an error.
+	// If the channel has a populated RevocationKeyLocator, then we can
+	// just store that instead of the public key.
+	if channel.RevocationKeyLocator.Family == keychain.KeyFamilyRevocationRoot {
+		shaChainRootDesc = keychain.KeyDescriptor{
+			KeyLocator: channel.RevocationKeyLocator,
+		}
+	} else {
+		// If the RevocationKeyLocator is not populated, then we'll need
+		// to obtain a public point for the shachain root and store that.
+		// This is the legacy scheme.
+		var b bytes.Buffer
+		_ = channel.RevocationProducer.Encode(&b) // Can't return an error.
 
-	// Once we have the root, we'll make a public key from it, such that
-	// the backups plaintext don't carry any private information. When we
-	// go to recover, we'll present this in order to derive the private
-	// key.
-	_, shaChainPoint := btcec.PrivKeyFromBytes(btcec.S256(), b.Bytes())
+		// Once we have the root, we'll make a public key from it, such that
+		// the backups plaintext don't carry any private information. When
+		// we go to recover, we'll present this in order to derive the
+		// private key.
+		_, shaChainPoint := btcec.PrivKeyFromBytes(btcec.S256(), b.Bytes())
+
+		shaChainRootDesc = keychain.KeyDescriptor{
+			PubKey: shaChainPoint,
+			KeyLocator: keychain.KeyLocator{
+				Family: keychain.KeyFamilyRevocationRoot,
+			},
+		}
+	}
 
 	// If a channel is unconfirmed, the block height of the ShortChannelID
 	// is zero. This will lead to problems when trying to restore that
@@ -149,21 +164,16 @@ func NewSingle(channel *channeldb.OpenChannel,
 	}
 
 	single := Single{
-		IsInitiator:     channel.IsInitiator,
-		ChainHash:       channel.ChainHash,
-		FundingOutpoint: channel.FundingOutpoint,
-		ShortChannelID:  chanID,
-		RemoteNodePub:   channel.IdentityPub,
-		Addresses:       nodeAddrs,
-		Capacity:        channel.Capacity,
-		LocalChanCfg:    channel.LocalChanCfg,
-		RemoteChanCfg:   channel.RemoteChanCfg,
-		ShaChainRootDesc: keychain.KeyDescriptor{
-			PubKey: shaChainPoint,
-			KeyLocator: keychain.KeyLocator{
-				Family: keychain.KeyFamilyRevocationRoot,
-			},
-		},
+		IsInitiator:      channel.IsInitiator,
+		ChainHash:        channel.ChainHash,
+		FundingOutpoint:  channel.FundingOutpoint,
+		ShortChannelID:   chanID,
+		RemoteNodePub:    channel.IdentityPub,
+		Addresses:        nodeAddrs,
+		Capacity:         channel.Capacity,
+		LocalChanCfg:     channel.LocalChanCfg,
+		RemoteChanCfg:    channel.RemoteChanCfg,
+		ShaChainRootDesc: shaChainRootDesc,
 	}
 
 	switch {

--- a/channeldb/channel_test.go
+++ b/channeldb/channel_test.go
@@ -8,6 +8,8 @@ import (
 	"runtime"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/btcsuite/btcd/btcec"
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcd/wire"
@@ -50,6 +52,9 @@ var (
 		IP:   net.ParseIP("127.0.0.1"),
 		Port: 18555,
 	}
+
+	// keyLocIndex is the KeyLocator Index we use for TestKeyLocatorEncoding.
+	keyLocIndex = uint32(2049)
 )
 
 // testChannelParams is a struct which details the specifics of how a channel
@@ -1586,4 +1591,34 @@ func TestHasChanStatus(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestKeyLocatorEncoding tests that we are able to serialize a given
+// keychain.KeyLocator. After successfully encoding, we check that the decode
+// output arrives at the same initial KeyLocator.
+func TestKeyLocatorEncoding(t *testing.T) {
+	keyLoc := keychain.KeyLocator{
+		Family: keychain.KeyFamilyRevocationRoot,
+		Index:  keyLocIndex,
+	}
+
+	// First, we'll encode the KeyLocator into a buffer.
+	var (
+		b   bytes.Buffer
+		buf [8]byte
+	)
+
+	err := EKeyLocator(&b, &keyLoc, &buf)
+	require.NoError(t, err, "unable to encode key locator")
+
+	// Next, we'll attempt to decode the bytes into a new KeyLocator.
+	r := bytes.NewReader(b.Bytes())
+	var decodedKeyLoc keychain.KeyLocator
+
+	err = DKeyLocator(r, &decodedKeyLoc, &buf, 8)
+	require.NoError(t, err, "unable to decode key locator")
+
+	// Finally, we'll compare that the original KeyLocator and the decoded
+	// version are equal.
+	require.Equal(t, keyLoc, decodedKeyLoc)
 }

--- a/lnwallet/reservation.go
+++ b/lnwallet/reservation.go
@@ -10,6 +10,7 @@ import (
 	"github.com/btcsuite/btcutil"
 	"github.com/lightningnetwork/lnd/channeldb"
 	"github.com/lightningnetwork/lnd/input"
+	"github.com/lightningnetwork/lnd/keychain"
 	"github.com/lightningnetwork/lnd/lnwallet/chainfee"
 	"github.com/lightningnetwork/lnd/lnwallet/chanfunding"
 	"github.com/lightningnetwork/lnd/lnwire"
@@ -161,6 +162,10 @@ type ChannelReservation struct {
 	chanFunder chanfunding.Assembler
 
 	fundingIntent chanfunding.Intent
+
+	// nextRevocationKeyLoc stores the key locator information for this
+	// channel.
+	nextRevocationKeyLoc keychain.KeyLocator
 }
 
 // NewChannelReservation creates a new channel reservation. This function is

--- a/lnwallet/revocation_producer.go
+++ b/lnwallet/revocation_producer.go
@@ -1,0 +1,51 @@
+// +build !rpctest
+
+package lnwallet
+
+import (
+	"github.com/lightningnetwork/lnd/keychain"
+	"github.com/lightningnetwork/lnd/shachain"
+)
+
+// nextRevocationProducer creates a new revocation producer, deriving the
+// revocation root by applying ECDH to a new key from our revocation root family
+// and the multisig key we use for the channel.
+func (l *LightningWallet) nextRevocationProducer(res *ChannelReservation,
+	keyRing keychain.KeyRing) (shachain.Producer, error) {
+
+	// Derive the next key in the revocation root family.
+	nextRevocationKeyDesc, err := keyRing.DeriveNextKey(
+		keychain.KeyFamilyRevocationRoot,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	// If the DeriveNextKey call returns the first key with Index 0, we need
+	// to re-derive the key as the keychain/btcwallet.go DerivePrivKey call
+	// special-cases Index 0.
+	if nextRevocationKeyDesc.Index == 0 {
+		nextRevocationKeyDesc, err = keyRing.DeriveNextKey(
+			keychain.KeyFamilyRevocationRoot,
+		)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	res.nextRevocationKeyLoc = nextRevocationKeyDesc.KeyLocator
+
+	// Perform an ECDH operation between the private key described in
+	// nextRevocationKeyDesc and our public multisig key. The result will be
+	// used to seed the revocation producer.
+	revRoot, err := l.ECDH(
+		nextRevocationKeyDesc, res.ourContribution.MultiSigKey.PubKey,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	// Once we have the root, we can then generate our shachain producer
+	// and from that generate the per-commitment point.
+	return shachain.NewRevocationProducer(revRoot), nil
+}

--- a/lnwallet/revocation_producer_itest.go
+++ b/lnwallet/revocation_producer_itest.go
@@ -1,0 +1,77 @@
+// +build rpctest
+
+package lnwallet
+
+import (
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"github.com/lightningnetwork/lnd/keychain"
+	"github.com/lightningnetwork/lnd/shachain"
+)
+
+// nextRevocationProducer creates a new revocation producer, deriving the
+// revocation root by applying ECDH to a new key from our revocation root family
+// and the multisig key we use for the channel.
+func (l *LightningWallet) nextRevocationProducer(res *ChannelReservation,
+	keyRing keychain.KeyRing) (shachain.Producer, error) {
+
+	// Derive the next key in the revocation root family.
+	nextRevocationKeyDesc, err := keyRing.DeriveNextKey(
+		keychain.KeyFamilyRevocationRoot,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	// Within our itests, we want to make sure we can still restore channel
+	// backups created with the old revocation root derivation method. To
+	// create a channel in the legacy format during the test, we signal this
+	// by setting an explicit pending channel ID. The ID is the hex
+	// representation of the string "legacy-revocation".
+	itestLegacyFormatChanID := [32]byte{
+		0x6c, 0x65, 0x67, 0x61, 0x63, 0x79, 0x2d, 0x72, 0x65, 0x76,
+		0x6f, 0x63, 0x61, 0x74, 0x69, 0x6f, 0x6e,
+	}
+	if res.pendingChanID == itestLegacyFormatChanID {
+		revocationRoot, err := l.DerivePrivKey(nextRevocationKeyDesc)
+		if err != nil {
+			return nil, err
+		}
+
+		// Once we have the root, we can then generate our shachain
+		// producer and from that generate the per-commitment point.
+		revRoot, err := chainhash.NewHash(revocationRoot.Serialize())
+		if err != nil {
+			return nil, err
+		}
+
+		return shachain.NewRevocationProducer(*revRoot), nil
+	}
+
+	// If the DeriveNextKey call returns the first key with Index 0, we need
+	// to re-derive the key as the keychain/btcwallet.go DerivePrivKey call
+	// special-cases Index 0.
+	if nextRevocationKeyDesc.Index == 0 {
+		nextRevocationKeyDesc, err = keyRing.DeriveNextKey(
+			keychain.KeyFamilyRevocationRoot,
+		)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	res.nextRevocationKeyLoc = nextRevocationKeyDesc.KeyLocator
+
+	// Perform an ECDH operation between the private key described in
+	// nextRevocationKeyDesc and our public multisig key. The result will be
+	// used to seed the revocation producer.
+	revRoot, err := l.ECDH(
+		nextRevocationKeyDesc, res.ourContribution.MultiSigKey.PubKey,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	// Once we have the root, we can then generate our shachain producer
+	// and from that generate the per-commitment point.
+	return shachain.NewRevocationProducer(revRoot), nil
+}


### PR DESCRIPTION
Closes #2659
Related #3929 

By adding the `RevocationKeyLocator` in the same PR, we get away with not adding a version to SCB as we know that if an `OpenChannel` has a populated `RevocationKeyLocator`, they are using `ECDH` derivation for the sha chain root key.

The question then is if this is better, or more confusing down the line and a version would come with the least amount of headaches.