### PR TITLE
lnrpc/invoicesrpc: extend hop hint selection to account for MPP 

### DIFF
--- a/lnrpc/invoicesrpc/addinvoice.go
+++ b/lnrpc/invoicesrpc/addinvoice.go
@@ -255,14 +255,16 @@ func AddInvoice(ctx context.Context, cfg *AddInvoiceConfig,
 			return nil, nil, fmt.Errorf("could not fetch all channels")
 		}
 
-		// We'll restrict the number of individual route hints
-		// to 20 to avoid creating overly large invoices.
-		const numMaxHophints = 20
-		hopHints := selectHopHints(
-			amtMSat, cfg, openChannels, numMaxHophints,
-		)
+		if len(openChannels) > 0 {
+			// We'll restrict the number of individual route hints
+			// to 20 to avoid creating overly large invoices.
+			const numMaxHophints = 20
+			hopHints := selectHopHints(
+				amtMSat, cfg, openChannels, numMaxHophints,
+			)
 
-		options = append(options, hopHints...)
+			options = append(options, hopHints...)
+		}
 	}
 
 	// Set our desired invoice features and add them to our list of options.


### PR DESCRIPTION
In this commit, we update the hop hint selection to account for the fact
that with MPP, a single payment may consume multiple channels. As is, if
a user only has two 0.5 BTC channels, and tries to make a 1 BTC channel,
then the current logic won't include any hop hints.

In this commit we fix this with a simple algorithm for selecting hop
hints:

   * randomly shuffle all hop hints
   * add hop hints until we exceed our max, or the set of available
      bandwidth for all hop hints sums to 2x the invoice payment size

This ensures that users don't always get the same set of routing hints
when they go to pay, which may prevent proper payments as users may be
trying to use the same set of channels causing HTLCs to fail. We add 2x
here to give some margin of error if the active channels are used for
other purposes.

Right now we just prand (`math/rand`) to shuffle the channels, using a
new seed for each new invoice. In the future, we may want to use
stronger randomness here just to make the set of chosen channels less
predictable.

The first commit is move-only, while the second implements the heuristic
described above. 

Fixes #4514