### PR TITLE
[trivial] htlcswitch: use kvdb.View for loading fwdpkgs

### DIFF
--- a/channeldb/forwarding_package.go
+++ b/channeldb/forwarding_package.go
@@ -326,7 +326,7 @@ type SettleFailAcker interface {
 type GlobalFwdPkgReader interface {
 	// LoadChannelFwdPkgs loads all known forwarding packages for the given
 	// channel.
-	LoadChannelFwdPkgs(tx kvdb.RwTx,
+	LoadChannelFwdPkgs(tx kvdb.RTx,
 		source lnwire.ShortChannelID) ([]*FwdPkg, error)
 }
 
@@ -364,7 +364,7 @@ func (*SwitchPackager) AckSettleFails(tx kvdb.RwTx,
 }
 
 // LoadChannelFwdPkgs loads all forwarding packages for a particular channel.
-func (*SwitchPackager) LoadChannelFwdPkgs(tx kvdb.RwTx,
+func (*SwitchPackager) LoadChannelFwdPkgs(tx kvdb.RTx,
 	source lnwire.ShortChannelID) ([]*FwdPkg, error) {
 
 	return loadChannelFwdPkgs(tx, source)

--- a/htlcswitch/switch.go
+++ b/htlcswitch/switch.go
@@ -1811,7 +1811,7 @@ func (s *Switch) reforwardResponses() error {
 func (s *Switch) loadChannelFwdPkgs(source lnwire.ShortChannelID) ([]*channeldb.FwdPkg, error) {
 
 	var fwdPkgs []*channeldb.FwdPkg
-	if err := kvdb.Update(s.cfg.DB, func(tx kvdb.RwTx) error {
+	if err := kvdb.View(s.cfg.DB, func(tx kvdb.RTx) error {
 		var err error
 		fwdPkgs, err = s.cfg.SwitchPackager.LoadChannelFwdPkgs(
 			tx, source,


### PR DESCRIPTION
Not necessary to open a write tx.
