### PR TITLE
chanfunding: Add/improve tests for CoinSelectSubtractFees

### DIFF
--- a/lnwallet/chanfunding/coin_select.go
+++ b/lnwallet/chanfunding/coin_select.go
@@ -208,7 +208,7 @@ func CoinSelectSubtractFees(feeRate chainfee.SatPerKWeight, amt,
 	// TODO(halseth): smarter fee limit. Make configurable or dynamic wrt
 	// total funding size?
 	if fee > totalOut/5 {
-		return nil, 0, 0, fmt.Errorf("fee %v on total output"+
+		return nil, 0, 0, fmt.Errorf("fee %v on total output "+
 			"value %v", fee, totalOut)
 	}
 

--- a/lnwallet/chanfunding/coin_select_test.go
+++ b/lnwallet/chanfunding/coin_select_test.go
@@ -250,7 +250,7 @@ func TestCoinSelectSubtractFees(t *testing.T) {
 				{
 					TxOut: wire.TxOut{
 						PkScript: p2wkhScript,
-						Value:    int64(fundingFee(feeRate, 1, false) + dust),
+						Value:    int64(fundingFee(feeRate, 1, false) + dustLimit),
 					},
 				},
 			},

--- a/lnwallet/chanfunding/coin_select_test.go
+++ b/lnwallet/chanfunding/coin_select_test.go
@@ -245,6 +245,27 @@ func TestCoinSelectSubtractFees(t *testing.T) {
 			expectedChange:     0,
 		},
 		{
+			// We have 1.0 BTC available and spend half of it. This
+			// should lead to a funding TX with a change output.
+			name: "spend with change",
+			coins: []Coin{
+				{
+					TxOut: wire.TxOut{
+						PkScript: p2wkhScript,
+						Value:    1 * btcutil.SatoshiPerBitcoin,
+					},
+				},
+			},
+			spendValue: 0.5 * btcutil.SatoshiPerBitcoin,
+
+			// The one and only input will be selected.
+			expectedInput: []btcutil.Amount{
+				1 * btcutil.SatoshiPerBitcoin,
+			},
+			expectedFundingAmt: 0.5*btcutil.SatoshiPerBitcoin - fundingFee(feeRate, 1, true),
+			expectedChange:     0.5 * btcutil.SatoshiPerBitcoin,
+		},
+		{
 			// The total funds available is below the dust limit
 			// after paying fees.
 			name: "dust output",


### PR DESCRIPTION
It seems that the dust-output and high-fee test cases for `CoinSelectSubtractFees` were not independently testing the code as the one triggered the other and vice versa due to testing with low fee values that gave rise to dust outputs (see also comments for the commits).

Also a new test case `"spend with change"` was added to check that a non-zero change output can be created.

#### Pull Request Checklist

- [x] If this is your first time contributing, we recommend you read the [Code
  Contribution Guidelines](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md)
- [x] All changes are Go version 1.12 compliant
- [x] The code being submitted is commented according to [Code Documentation and Commenting](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#CodeDocumentation)
- [x] For new code: Code is accompanied by tests which exercise both
  the positive and negative (error paths) conditions (if applicable)
- [x] For bug fixes: Code is accompanied by new tests which trigger
  the bug being fixed to prevent regressions
- [x] Any new logging statements use an appropriate subsystem and
  logging level
- [x] Code has been formatted with `go fmt`
- [x] Protobuf files (`lnrpc/**/*.proto`) have been formatted with
  `make rpc-format` and compiled with `make rpc`
- [x] For code and documentation: lines are wrapped at 80 characters
  (the tab character should be counted as 8 characters, not 4, as some IDEs do
  per default)
- [x] Running `make check` does not fail any tests
- [x] Running `go vet` does not report any issues
- [x] Running `make lint` does not report any **new** issues that did not
  already exist
- [x] All commits build properly and pass tests. Only in exceptional
  cases it can be justifiable to violate this condition. In that case, the
  reason should be stated in the commit message.
- [x] Commits have a logical structure according to [Ideal Git Commit Structure](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#IdealGitCommitStructure)
