### PR TITLE
watchtower: remove dev tag from unit test files

### DIFF
--- a/watchtower/lookout/justice_descriptor_test.go
+++ b/watchtower/lookout/justice_descriptor_test.go
@@ -1,5 +1,3 @@
-// +build dev
-
 package lookout_test
 
 import (

--- a/watchtower/lookout/lookout_test.go
+++ b/watchtower/lookout/lookout_test.go
@@ -1,5 +1,3 @@
-// +build dev
-
 package lookout_test
 
 import (

--- a/watchtower/lookout/mock.go
+++ b/watchtower/lookout/mock.go
@@ -1,5 +1,3 @@
-// +build dev
-
 package lookout
 
 import (

--- a/watchtower/wtclient/client_test.go
+++ b/watchtower/wtclient/client_test.go
@@ -1,5 +1,3 @@
-// +build dev
-
 package wtclient_test
 
 import (
@@ -24,6 +22,7 @@ import (
 	"github.com/lightningnetwork/lnd/watchtower/wtmock"
 	"github.com/lightningnetwork/lnd/watchtower/wtpolicy"
 	"github.com/lightningnetwork/lnd/watchtower/wtserver"
+	"github.com/stretchr/testify/require"
 )
 
 const (
@@ -1457,7 +1456,8 @@ var clientTests = []clientTest{
 			// Re-add the tower. We prevent the tower from acking
 			// session creation to ensure the inactive sessions are
 			// not used.
-			h.server.Stop()
+			err := h.server.Stop()
+			require.Nil(h.t, err)
 			h.serverCfg.NoAckCreateSession = true
 			h.startServer()
 			h.addTower(h.serverAddr)
@@ -1466,7 +1466,8 @@ var clientTests = []clientTest{
 			// Finally, allow the tower to ack session creation,
 			// allowing the state updates to be sent through the new
 			// session.
-			h.server.Stop()
+			err = h.server.Stop()
+			require.Nil(h.t, err)
 			h.serverCfg.NoAckCreateSession = false
 			h.startServer()
 			h.waitServerUpdates(hints[numUpdates/2:], 5*time.Second)


### PR DESCRIPTION
Several watchtower unit tests were not being executed by make unit since
they require the dev tag to be passed in. All tests still pass.