### PR TITLE
lncli: Add support for trusted TLS certificates

### DIFF
--- a/cmd/lncli/main.go
+++ b/cmd/lncli/main.go
@@ -366,3 +366,13 @@ func readPassword(text string) ([]byte, error) {
 	fmt.Println()
 	return pw, err
 }
+
+// fileExists reports whether the named file or directory exists.
+func fileExists(name string) bool {
+	if _, err := os.Stat(name); err != nil {
+		if os.IsNotExist(err) {
+			return false
+		}
+	}
+	return true
+}


### PR DESCRIPTION
This PR adds in functionality to lncli to use the system's certificate pool in addition to the tlscertpath. If the file in tlscertpath doesn't exist we assume the node has a certificate from a trusted Certificate Authority. With this functionality users don't have to provide a TLS certificate if their node's certificate is trusted by their system

This was pulled from https://github.com/lightningnetwork/lnd/pull/2428, but only the `lncli` capabilities to use the system's cert pool. As trusted certificates become more widely used this support will be important to include.

If the file doesn't exist at `--tlscertpath` and the node's certificate isn't trusted by their system they will receive a `x509: certificate signed by unknown authority` error.