### PR TITLE
build: build and run CI against Go 1.15

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,7 +18,7 @@ env:
   GOPATH: /home/runner/work/go
   DOWNLOAD_CACHE: /home/runner/work/download_cache
   BITCOIN_VERSION: 0.19.1
-  GO_VERSION: 1.14.4
+  GO_VERSION: 1.15.2
 
 jobs:
   ########################

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ git:
   depth: false
 
 go:
-  - "1.14.x"
+  - "1.15.x"
 
 env:
   global:

--- a/Makefile
+++ b/Makefile
@@ -169,7 +169,7 @@ unit: btcd
 
 unit-cover: $(GOACC_BIN)
 	@$(call print, "Running unit coverage tests.")
-	$(GOACC_BIN) $(COVER_PKG) -- -test.tags="$(DEV_TAGS) $(LOG_TAGS)"
+	$(GOACC_BIN) $(COVER_PKG) -- -tags="$(DEV_TAGS) $(LOG_TAGS)"
 
 
 unit-race:


### PR DESCRIPTION
This commit updates our CI to build and run against the newly release Go 1.15 version. I don't think we should merge this quite yet, as in the past we've been burned by attempting to upgrade to the latest Go version _too quickly_. However, once we're confident in this new version, then we can start to use any new language and standard library features that were included as part of Go 1.14. 