### PR TITLE
[anchor commitment] Make the anchor commitment type spec compliant

### DIFF
--- a/channeldb/channel.go
+++ b/channeldb/channel.go
@@ -206,8 +206,7 @@ const (
 
 	// AnchorOutputsBit indicates that the channel makes use of anchor
 	// outputs to bump the commitment transaction's effective feerate. This
-	// channel type also uses a delayed to_remote output script. If bit is
-	// set, we'll find the size of the anchor outputs in the database.
+	// channel type also uses a delayed to_remote output script.
 	AnchorOutputsBit ChannelType = 1 << 3
 
 	// FrozenBit indicates that the channel is a frozen channel, meaning

--- a/lnwallet/channel.go
+++ b/lnwallet/channel.go
@@ -6182,10 +6182,13 @@ func (lc *LightningChannel) CreateCloseProposal(proposedFee btcutil.Amount,
 	// Get the final balances after subtracting the proposed fee, taking
 	// care not to persist the adjusted balance, as the feeRate may change
 	// during the channel closing process.
-	ourBalance, theirBalance := CoopCloseBalance(
+	ourBalance, theirBalance, err := CoopCloseBalance(
 		lc.channelState.ChanType, lc.channelState.IsInitiator,
 		proposedFee, lc.channelState.LocalCommitment,
 	)
+	if err != nil {
+		return nil, nil, 0, err
+	}
 
 	closeTx := CreateCooperativeCloseTx(
 		fundingTxIn(lc.channelState), lc.channelState.LocalChanCfg.DustLimit,
@@ -6241,10 +6244,13 @@ func (lc *LightningChannel) CompleteCooperativeClose(
 	}
 
 	// Get the final balances after subtracting the proposed fee.
-	ourBalance, theirBalance := CoopCloseBalance(
+	ourBalance, theirBalance, err := CoopCloseBalance(
 		lc.channelState.ChanType, lc.channelState.IsInitiator,
 		proposedFee, lc.channelState.LocalCommitment,
 	)
+	if err != nil {
+		return nil, 0, err
+	}
 
 	// Create the transaction used to return the current settled balance
 	// on this active channel back to both parties. In this current model,

--- a/lnwire/features.go
+++ b/lnwire/features.go
@@ -112,12 +112,12 @@ const (
 	// AnchorsRequired is a required feature bit that signals that the node
 	// requires channels to be made using commitments having anchor
 	// outputs.
-	AnchorsRequired FeatureBit = 1336
+	AnchorsRequired FeatureBit = 20
 
 	// AnchorsRequired is an optional feature bit that signals that the
 	// node supports channels to be made using commitments having anchor
 	// outputs.
-	AnchorsOptional FeatureBit = 1337
+	AnchorsOptional FeatureBit = 21
 
 	// maxAllowedSize is a maximum allowed size of feature vector.
 	//

--- a/peer/brontide.go
+++ b/peer/brontide.go
@@ -2785,11 +2785,11 @@ func (p *Brontide) handleCloseMsg(msg *closeMsg) {
 func (p *Brontide) HandleLocalCloseChanReqs(req *htlcswitch.ChanClose) {
 	select {
 	case p.localCloseChanReqs <- req:
-		peerLog.Infof("Local close channel request delivered to peer: %v",
-			p.PubKey())
+		peerLog.Infof("Local close channel request delivered to "+
+			"peer: %x", p.PubKey())
 	case <-p.quit:
-		peerLog.Infof("Unable to deliver local close channel request to peer "+
-			"%x", p.PubKey())
+		peerLog.Infof("Unable to deliver local close channel request "+
+			"to peer %x", p.PubKey())
 	}
 }
 


### PR DESCRIPTION
This PR makes the necessary changes to the anchor commitment type to make it compliant with the final spec version as defined in https://github.com/lightningnetwork/lightning-rfc/pull/688

There are two changes needed:
1. We set the feature bit to `20/21`. This means that we now require this bit to be advertised to signal anchor support. The old bit will be ignored by new nodes.
2. The anchor amounts are given back to the initiator in a coop close scenario. This means that existing nodes having anchor channels will disagree on the final coop close fee _if only one of the channel parties update_. However if both update closing proceeds as normal. In the worst case force closing works as before.
3. Anchors are no longer experimental.

NOTE: Watchtowers are still not supported for anchor commitment types, and anchor support is not advertised by default but must be enabled through the `--protocol.anchors` option.