### PR TITLE
itest: fix pattern for short_chan_id in err whitelist

### DIFF
--- a/lntest/itest/log_error_whitelist.txt
+++ b/lntest/itest/log_error_whitelist.txt
@@ -40,7 +40,7 @@
 <time> [ERR] CRTR: Resuming payment with hash <hex> failed: no_route.
 <time> [ERR] CRTR: Resuming payment with hash <hex> failed: router shutting down.
 <time> [ERR] CRTR: Unable to retrieve channel by id: edge not found
-<time> [ERR] DISC: channel  announcement proof for short_chan_id=<hex> isn't valid: can't verify first bitcoin signature
+<time> [ERR] DISC: channel  announcement proof for short_chan_id=<cid> isn't valid: can't verify first bitcoin signature
 <time> [ERR] DISC: router shutting down
 <time> [ERR] DISC: unable add proof to the channel chanID=<hex>: edge marked as zombie
 <time> [ERR] DISC: unable add proof to the channel chanID=<hex>: edge not found
@@ -54,7 +54,7 @@
 <time> [ERR] FNDG: Unable to advance pending state of ChannelPoint(<chan_point>): error waiting for funding confirmation for ChannelPoint(<chan_point>): epoch client shutting down
 <time> [ERR] FNDG: Unable to advance pending state of ChannelPoint(<chan_point>): error waiting for funding confirmation for ChannelPoint(<chan_point>): funding manager shutting down
 <time> [ERR] FNDG: Unable to advance pending state of ChannelPoint(<chan_point>): error waiting for funding confirmation for ChannelPoint(<chan_point>): waiting for fundingconfirmation failed
-<time> [ERR] FNDG: Unable to advance state(<chan_point>): error sending channel announcement: channel announcement failed: channel  announcement proof for short_chan_id=<hex> isn't valid: can't verify first bitcoin signature
+<time> [ERR] FNDG: Unable to advance state(<chan_point>): error sending channel announcement: channel announcement failed: channel  announcement proof for short_chan_id=<cid> isn't valid: can't verify first bitcoin signature
 <time> [ERR] FNDG: Unable to advance state(<chan_point>): error sending channel announcement: channel announcement failed: funding manager shutting down
 <time> [ERR] FNDG: Unable to advance state(<chan_point>): error sending channel announcement: channel announcement failed: gossiper is shutting down
 <time> [ERR] FNDG: Unable to advance state(<chan_point>): error sending channel announcement: channel announcement failed: router shutting down
@@ -65,7 +65,7 @@
 <time> [ERR] FNDG: Unable to advance state(<chan_point>): failed sending fundingLocked: funding manager shutting down
 <time> [ERR] FNDG: unable to cancel reservation: no active reservations for peer(<hex>)
 <time> [ERR] FNDG: unable to report short chan id: link <hex> not found
-<time> [ERR] FNDG: Unable to send channel proof: channel  announcement proof for short_chan_id=<hex> isn't valid: can't verify first bitcoin signature
+<time> [ERR] FNDG: Unable to send channel proof: channel  announcement proof for short_chan_id=<cid> isn't valid: can't verify first bitcoin signature
 <time> [ERR] FNDG: Unable to send channel proof: gossiper is shutting down
 <time> [ERR] FNDG: Unable to send channel proof: unable add proof to the channel chanID=<hex>: edge marked as zombie
 <time> [ERR] FNDG: Unable to send channel proof: unable add proof to the channel chanID=<hex>: edge not found

--- a/lntest/itest/log_substitutions.txt
+++ b/lntest/itest/log_substitutions.txt
@@ -1,4 +1,5 @@
 s/[0-9a-f]{64}\:[[:digit:]]+/<chan_point>/g
+s/short_chan_id=[[:digit:]]+/short_chan_id=<cid>/g
 s/[0-9a-f]{16,}/<hex>/g
 s/[[:digit:]]+\.[[:digit:]]+\.[[:digit:]]+\.[[:digit:]]+\:[[:digit:]]+/<ip>/g
 s/[[:digit:]]{4}-[[:digit:]]{2}-[[:digit:]]{2} [[:digit:]]{2}:[[:digit:]]{2}:[[:digit:]]{2}\.[[:digit:]]{3}/<time>/g


### PR DESCRIPTION
Fixes a replacement pattern in the error whitelist that caused some errors not to be white listed.