### PR TITLE
mod: update cert to v1.0.3

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -48,7 +48,7 @@ require (
 	github.com/lightninglabs/neutrino v0.11.1-0.20200316235139-bffc52e8f200
 	github.com/lightninglabs/protobuf-hex-display v1.3.3-0.20191212020323-b444784ce75d
 	github.com/lightningnetwork/lightning-onion v1.0.2-0.20200501022730-3c8c8d0b89ea
-	github.com/lightningnetwork/lnd/cert v1.0.2
+	github.com/lightningnetwork/lnd/cert v1.0.3
 	github.com/lightningnetwork/lnd/clock v1.0.1
 	github.com/lightningnetwork/lnd/queue v1.0.4
 	github.com/lightningnetwork/lnd/ticker v1.0.0


### PR DESCRIPTION
The PR #4421 updated the cert package. To make lnd usable as dependency
in other projects after the PR was merged, we need to tag and update the
cert package.

