### PR TITLE
btcwallet: skip unsupported addresses in ListTransasctionDetails

### DIFF
--- a/lnwallet/btcwallet/btcwallet.go
+++ b/lnwallet/btcwallet/btcwallet.go
@@ -558,7 +558,9 @@ func minedTransactionsToDetails(
 				txOut.PkScript, chainParams,
 			)
 			if err != nil {
-				return nil, err
+				// Skip any unsupported addresses to prevent
+				// other transactions from not being returned.
+				continue
 			}
 
 			destAddresses = append(destAddresses, outAddresses...)
@@ -607,7 +609,9 @@ func unminedTransactionsToDetail(
 		_, outAddresses, _, err :=
 			txscript.ExtractPkScriptAddrs(txOut.PkScript, chainParams)
 		if err != nil {
-			return nil, err
+			// Skip any unsupported addresses to prevent other
+			// transactions from not being returned.
+			continue
 		}
 
 		destAddresses = append(destAddresses, outAddresses...)


### PR DESCRIPTION
A transaction with an unsupported address would prevent the method from returning any other transactions and would instead return an error.

Fixes https://github.com/lightningnetwork/lnd/issues/4568.