### PR TITLE
trivial: remove unused print

### DIFF
--- a/contractcourt/briefcase.go
+++ b/contractcourt/briefcase.go
@@ -442,7 +442,6 @@ func (b *boltArbitratorLog) CurrentState() (ArbitratorState, error) {
 //
 // NOTE: Part of the ContractResolver interface.
 func (b *boltArbitratorLog) CommitState(s ArbitratorState) error {
-	fmt.Printf("yeee: %T\n", b.db)
 	return kvdb.Batch(b.db, func(tx kvdb.RwTx) error {
 		scopeBucket, err := tx.CreateTopLevelBucket(b.scopeKey[:])
 		if err != nil {


### PR DESCRIPTION
Was looking into the itest logs, found this weird line,
```go
2020-08-28 16:43:19.897 [DBG] CNCT: ChannelArbitrator(255e8b3abfa890f33966bfe61a32b39bb86a766809312fa3c90ec21663499a10:0): checking commit chain actions at height=461, in_htlc_count=0, out_htlc_count=0
yeee: *bdb.db
2020-08-28 16:43:19.894 [ERR] CHFT: Close channel 255e8b3abfa890f33966bfe61a32b39bb86a766809312fa3c90ec21663499a10:0 unknown to store
```