### PR TITLE
watchtower: conditionally reconstruct justice txns for anchor channels

### DIFF
--- a/watchtower/blob/justice_kit.go
+++ b/watchtower/blob/justice_kit.go
@@ -100,6 +100,15 @@ type PubKey [33]byte
 // and for a watchtower to later decrypt if action must be taken. The encoding
 // format is versioned to allow future extensions.
 type JusticeKit struct {
+	// BlobType encodes a bitfield that inform the tower of various features
+	// requested by the client when resolving a breach. Examples include
+	// whether the justice transaction contains a reward for the tower, or
+	// whether the channel is a legacy or anchor channel.
+	//
+	// NOTE: This value is not serialized in the encrypted payload. It is
+	// stored separately and added to the JusticeKit after decryption.
+	BlobType Type
+
 	// SweepAddress is the witness program of the output where the client's
 	// fund will be deposited. This value is included in the blobs, as
 	// opposed to the session info, such that the sweep addresses can't be
@@ -187,17 +196,33 @@ func (b *JusticeKit) HasCommitToRemoteOutput() bool {
 }
 
 // CommitToRemoteWitnessScript returns the witness script for the commitment
-// to-remote p2wkh output, which is the pubkey itself.
+// to-remote output given the blob type. The script returned will either be for
+// a p2wpkh to-remote output or an p2wsh anchor to-remote output which includes
+// a CSV delay.
 func (b *JusticeKit) CommitToRemoteWitnessScript() ([]byte, error) {
 	if !btcec.IsCompressedPubKey(b.CommitToRemotePubKey[:]) {
 		return nil, ErrNoCommitToRemoteOutput
+	}
+
+	// If this is a blob for an anchor channel, we'll return the p2wsh
+	// output containing a CSV delay of 1.
+	if b.BlobType.IsAnchorChannel() {
+		pk, err := btcec.ParsePubKey(
+			b.CommitToRemotePubKey[:], btcec.S256(),
+		)
+		if err != nil {
+			return nil, err
+		}
+
+		return input.CommitScriptToRemoteConfirmed(pk)
 	}
 
 	return b.CommitToRemotePubKey[:], nil
 }
 
 // CommitToRemoteWitnessStack returns a witness stack spending the commitment
-// to-remote output, which is a regular p2wkh.
+// to-remote output, which consists of a single signature satisfying either the
+// legacy or anchor witness scripts.
 //   <to-remote-sig>
 func (b *JusticeKit) CommitToRemoteWitnessStack() ([][]byte, error) {
 	toRemoteSig, err := b.CommitToRemoteSig.ToSignature()
@@ -218,11 +243,11 @@ func (b *JusticeKit) CommitToRemoteWitnessStack() ([][]byte, error) {
 //
 // NOTE: It is the caller's responsibility to ensure that this method is only
 // called once for a given (nonce, key) pair.
-func (b *JusticeKit) Encrypt(key BreachKey, blobType Type) ([]byte, error) {
+func (b *JusticeKit) Encrypt(key BreachKey) ([]byte, error) {
 	// Encode the plaintext using the provided version, to obtain the
 	// plaintext bytes.
 	var ptxtBuf bytes.Buffer
-	err := b.encode(&ptxtBuf, blobType)
+	err := b.encode(&ptxtBuf, b.BlobType)
 	if err != nil {
 		return nil, err
 	}
@@ -236,7 +261,7 @@ func (b *JusticeKit) Encrypt(key BreachKey, blobType Type) ([]byte, error) {
 	// Allocate the ciphertext, which will contain the nonce, encrypted
 	// plaintext and MAC.
 	plaintext := ptxtBuf.Bytes()
-	ciphertext := make([]byte, Size(blobType))
+	ciphertext := make([]byte, Size(b.BlobType))
 
 	// Generate a random  24-byte nonce in the ciphertext's prefix.
 	nonce := ciphertext[:NonceSize]
@@ -284,7 +309,9 @@ func Decrypt(key BreachKey, ciphertext []byte,
 
 	// If decryption succeeded, we will then decode the plaintext bytes
 	// using the specified blob version.
-	boj := &JusticeKit{}
+	boj := &JusticeKit{
+		BlobType: blobType,
+	}
 	err = boj.decode(bytes.NewReader(plaintext), blobType)
 	if err != nil {
 		return nil, err

--- a/watchtower/blob/justice_kit_test.go
+++ b/watchtower/blob/justice_kit_test.go
@@ -150,6 +150,7 @@ func TestBlobJusticeKitEncryptDecrypt(t *testing.T) {
 
 func testBlobJusticeKitEncryptDecrypt(t *testing.T, test descriptorTest) {
 	boj := &blob.JusticeKit{
+		BlobType:             test.encVersion,
 		SweepAddress:         test.sweepAddr,
 		RevocationPubKey:     test.revPubKey,
 		LocalDelayPubKey:     test.delayPubKey,
@@ -170,7 +171,7 @@ func testBlobJusticeKitEncryptDecrypt(t *testing.T, test descriptorTest) {
 
 	// Encrypt the blob plaintext using the generated key and
 	// target version for this test.
-	ctxt, err := boj.Encrypt(key, test.encVersion)
+	ctxt, err := boj.Encrypt(key)
 	if err != test.encErr {
 		t.Fatalf("unable to encrypt blob: %v", err)
 	} else if test.encErr != nil {

--- a/watchtower/blob/type.go
+++ b/watchtower/blob/type.go
@@ -19,6 +19,11 @@ const (
 	// FlagCommitOutputs signals that the blob contains the information
 	// required to sweep commitment outputs.
 	FlagCommitOutputs Flag = 1 << 1
+
+	// FlagAnchorChannel signals that this blob is meant to spend an anchor
+	// channel, and therefore must expect a P2WSH-style to-remote output if
+	// one exists.
+	FlagAnchorChannel Flag = 1 << 2
 )
 
 // Type returns a Type consisting solely of this flag enabled.
@@ -33,6 +38,8 @@ func (f Flag) String() string {
 		return "FlagReward"
 	case FlagCommitOutputs:
 		return "FlagCommitOutputs"
+	case FlagAnchorChannel:
+		return "FlagAnchorChannel"
 	default:
 		return "FlagUnknown"
 	}
@@ -49,6 +56,11 @@ const (
 	// TypeAltruistCommit sweeps only commitment outputs to a sweep address
 	// controlled by the user, and does not give the tower a reward.
 	TypeAltruistCommit = Type(FlagCommitOutputs)
+
+	// TypeAltruistAnchorCommit sweeps only commitment outputs from an
+	// anchor commitment to a sweep address controlled by the user, and does
+	// not give the tower a reward.
+	TypeAltruistAnchorCommit = Type(FlagCommitOutputs | FlagAnchorChannel)
 
 	// TypeRewardCommit sweeps only commitment outputs to a sweep address
 	// controlled by the user, and pays a negotiated reward to the tower.
@@ -70,10 +82,16 @@ func TypeFromFlags(flags ...Flag) Type {
 	return typ
 }
 
+// IsAnchorChannel returns true if the blob type is for an anchor channel.
+func (t Type) IsAnchorChannel() bool {
+	return t.Has(FlagAnchorChannel)
+}
+
 // knownFlags maps the supported flags to their name.
 var knownFlags = map[Flag]struct{}{
 	FlagReward:        {},
 	FlagCommitOutputs: {},
+	FlagAnchorChannel: {},
 }
 
 // String returns a human readable description of a Type.

--- a/watchtower/blob/type.go
+++ b/watchtower/blob/type.go
@@ -14,11 +14,11 @@ const (
 	// include the reward script negotiated during session creation. Without
 	// the flag, there is only one output sweeping clients funds back to
 	// them solely.
-	FlagReward Flag = 1 << iota
+	FlagReward Flag = 1
 
 	// FlagCommitOutputs signals that the blob contains the information
 	// required to sweep commitment outputs.
-	FlagCommitOutputs
+	FlagCommitOutputs Flag = 1 << 1
 )
 
 // Type returns a Type consisting solely of this flag enabled.

--- a/watchtower/blob/type_test.go
+++ b/watchtower/blob/type_test.go
@@ -18,17 +18,17 @@ var typeStringTests = []typeStringTest{
 	{
 		name:   "commit no-reward",
 		typ:    blob.TypeAltruistCommit,
-		expStr: "[FlagCommitOutputs|No-FlagReward]",
+		expStr: "[No-FlagAnchorChannel|FlagCommitOutputs|No-FlagReward]",
 	},
 	{
 		name:   "commit reward",
 		typ:    blob.TypeRewardCommit,
-		expStr: "[FlagCommitOutputs|FlagReward]",
+		expStr: "[No-FlagAnchorChannel|FlagCommitOutputs|FlagReward]",
 	},
 	{
 		name:   "unknown flag",
 		typ:    unknownFlag.Type(),
-		expStr: "0000000000010000[No-FlagCommitOutputs|No-FlagReward]",
+		expStr: "0000000000010000[No-FlagAnchorChannel|No-FlagCommitOutputs|No-FlagReward]",
 	},
 }
 

--- a/watchtower/lookout/justice_descriptor.go
+++ b/watchtower/lookout/justice_descriptor.go
@@ -284,8 +284,13 @@ func (p *JusticeDescriptor) CreateJusticeTxn() (*wire.MsgTx, error) {
 	// An older ToLocalPenaltyWitnessSize constant used to underestimate the
 	// size by one byte. The diferrence in weight can cause different output
 	// values on the sweep transaction, so we mimic the original bug to
-	// avoid invalidating signatures by older clients.
-	weightEstimate.AddWitnessInput(input.ToLocalPenaltyWitnessSize - 1)
+	// avoid invalidating signatures by older clients. For anchor channels
+	// we correct this and use the correct witness size.
+	if p.JusticeKit.BlobType.IsAnchorChannel() {
+		weightEstimate.AddWitnessInput(input.ToLocalPenaltyWitnessSize)
+	} else {
+		weightEstimate.AddWitnessInput(input.ToLocalPenaltyWitnessSize - 1)
+	}
 
 	sweepInputs = append(sweepInputs, toLocalInput)
 

--- a/watchtower/lookout/justice_descriptor_test.go
+++ b/watchtower/lookout/justice_descriptor_test.go
@@ -192,8 +192,13 @@ func testJusticeDescriptor(t *testing.T, blobType blob.Type) {
 	// An older ToLocalPenaltyWitnessSize constant used to underestimate the
 	// size by one byte. The diferrence in weight can cause different output
 	// values on the sweep transaction, so we mimic the original bug and
-	// create signatures using the original weight estimate.
-	weightEstimate.AddWitnessInput(input.ToLocalPenaltyWitnessSize - 1)
+	// create signatures using the original weight estimate. For anchor
+	// channels we fix this and use the correct witness size.
+	if isAnchorChannel {
+		weightEstimate.AddWitnessInput(input.ToLocalPenaltyWitnessSize)
+	} else {
+		weightEstimate.AddWitnessInput(input.ToLocalPenaltyWitnessSize - 1)
+	}
 
 	if isAnchorChannel {
 		weightEstimate.AddWitnessInput(input.ToRemoteConfirmedWitnessSize)

--- a/watchtower/lookout/justice_descriptor_test.go
+++ b/watchtower/lookout/justice_descriptor_test.go
@@ -1,7 +1,6 @@
 package lookout_test
 
 import (
-	"reflect"
 	"testing"
 	"time"
 
@@ -11,7 +10,6 @@ import (
 	"github.com/btcsuite/btcd/wire"
 	"github.com/btcsuite/btcutil"
 	"github.com/btcsuite/btcutil/txsort"
-	"github.com/davecgh/go-spew/spew"
 	"github.com/lightningnetwork/lnd/input"
 	"github.com/lightningnetwork/lnd/keychain"
 	"github.com/lightningnetwork/lnd/lnwire"
@@ -20,6 +18,7 @@ import (
 	"github.com/lightningnetwork/lnd/watchtower/wtdb"
 	"github.com/lightningnetwork/lnd/watchtower/wtmock"
 	"github.com/lightningnetwork/lnd/watchtower/wtpolicy"
+	"github.com/stretchr/testify/require"
 )
 
 const csvDelay uint32 = 144
@@ -106,21 +105,15 @@ func testJusticeDescriptor(t *testing.T, blobType blob.Type) {
 	toLocalScript, err := input.CommitScriptToSelf(
 		csvDelay, toLocalPK, revPK,
 	)
-	if err != nil {
-		t.Fatalf("unable to create to-local script: %v", err)
-	}
+	require.Nil(t, err)
 
 	// Compute the to-local witness script hash.
 	toLocalScriptHash, err := input.WitnessScriptHash(toLocalScript)
-	if err != nil {
-		t.Fatalf("unable to create to-local witness script hash: %v", err)
-	}
+	require.Nil(t, err)
 
 	// Compute the to-remote witness script hash.
 	toRemoteScriptHash, err := input.CommitScriptUnencumbered(toRemotePK)
-	if err != nil {
-		t.Fatalf("unable to create to-remote script: %v", err)
-	}
+	require.Nil(t, err)
 
 	// Construct the breaching commitment txn, containing the to-local and
 	// to-remote outputs. We don't need any inputs for this test.
@@ -207,9 +200,7 @@ func testJusticeDescriptor(t *testing.T, blobType blob.Type) {
 		totalAmount, int64(txWeight), justiceKit.SweepAddress,
 		sessionInfo.RewardAddress,
 	)
-	if err != nil {
-		t.Fatalf("unable to compute justice txouts: %v", err)
-	}
+	require.Nil(t, err)
 
 	// Attach the txouts and BIP69 sort the resulting transaction.
 	justiceTxn.TxOut = outputs
@@ -244,15 +235,12 @@ func testJusticeDescriptor(t *testing.T, blobType blob.Type) {
 
 	// Verify that our test justice transaction is sane.
 	btx := btcutil.NewTx(justiceTxn)
-	if err := blockchain.CheckTransactionSanity(btx); err != nil {
-		t.Fatalf("justice txn is not sane: %v", err)
-	}
+	err = blockchain.CheckTransactionSanity(btx)
+	require.Nil(t, err)
 
 	// Compute a DER-encoded signature for the to-local input.
 	toLocalSigRaw, err := signer.SignOutputRaw(justiceTxn, toLocalSignDesc)
-	if err != nil {
-		t.Fatalf("unable to sign to-local input: %v", err)
-	}
+	require.Nil(t, err)
 
 	// Compute the witness for the to-remote input. The first element is a
 	// DER-encoded signature under the to-remote pubkey. The sighash flag is
@@ -260,22 +248,16 @@ func testJusticeDescriptor(t *testing.T, blobType blob.Type) {
 	toRemoteWitness, err := input.CommitSpendNoDelay(
 		signer, toRemoteSignDesc, justiceTxn, false,
 	)
-	if err != nil {
-		t.Fatalf("unable to sign to-remote input: %v", err)
-	}
+	require.Nil(t, err)
 	toRemoteSigRaw := toRemoteWitness[0][:len(toRemoteWitness[0])-1]
 
 	// Convert the DER to-local sig into a fixed-size signature.
 	toLocalSig, err := lnwire.NewSigFromSignature(toLocalSigRaw)
-	if err != nil {
-		t.Fatalf("unable to parse to-local signature: %v", err)
-	}
+	require.Nil(t, err)
 
 	// Convert the DER to-remote sig into a fixed-size signature.
 	toRemoteSig, err := lnwire.NewSigFromRawSignature(toRemoteSigRaw)
-	if err != nil {
-		t.Fatalf("unable to parse to-remote signature: %v", err)
-	}
+	require.Nil(t, err)
 
 	// Complete our justice kit by copying the signatures into the payload.
 	copy(justiceKit.CommitToLocalSig[:], toLocalSig[:])
@@ -300,9 +282,7 @@ func testJusticeDescriptor(t *testing.T, blobType blob.Type) {
 	// Exact retribution on the offender. If no error is returned, we expect
 	// the justice transaction to be published via the channel.
 	err = punisher.Punish(justiceDesc, nil)
-	if err != nil {
-		t.Fatalf("unable to punish breach: %v", err)
-	}
+	require.Nil(t, err)
 
 	// Retrieve the published justice transaction.
 	var wtJusticeTxn *wire.MsgTx
@@ -326,9 +306,5 @@ func testJusticeDescriptor(t *testing.T, blobType blob.Type) {
 	justiceTxn.TxIn[1].Witness[1] = toRemotePK.SerializeCompressed()
 
 	// Assert that the watchtower derives the same justice txn.
-	if !reflect.DeepEqual(justiceTxn, wtJusticeTxn) {
-		t.Fatalf("expected justice txn: %v\ngot %v",
-			spew.Sdump(justiceTxn),
-			spew.Sdump(wtJusticeTxn))
-	}
+	require.Equal(t, justiceTxn, wtJusticeTxn)
 }

--- a/watchtower/lookout/lookout_test.go
+++ b/watchtower/lookout/lookout_test.go
@@ -137,7 +137,9 @@ func TestLookoutBreachMatching(t *testing.T) {
 	}
 
 	// Construct a justice kit for each possible breach transaction.
+	blobType := blob.FlagCommitOutputs.Type()
 	blob1 := &blob.JusticeKit{
+		BlobType:         blobType,
 		SweepAddress:     makeAddrSlice(22),
 		RevocationPubKey: makePubKey(1),
 		LocalDelayPubKey: makePubKey(1),
@@ -145,6 +147,7 @@ func TestLookoutBreachMatching(t *testing.T) {
 		CommitToLocalSig: makeArray64(1),
 	}
 	blob2 := &blob.JusticeKit{
+		BlobType:         blobType,
 		SweepAddress:     makeAddrSlice(22),
 		RevocationPubKey: makePubKey(2),
 		LocalDelayPubKey: makePubKey(2),
@@ -156,13 +159,13 @@ func TestLookoutBreachMatching(t *testing.T) {
 	key2 := blob.NewBreachKeyFromHash(&hash2)
 
 	// Encrypt the first justice kit under breach key one.
-	encBlob1, err := blob1.Encrypt(key1, blob.FlagCommitOutputs.Type())
+	encBlob1, err := blob1.Encrypt(key1)
 	if err != nil {
 		t.Fatalf("unable to encrypt sweep detail 1: %v", err)
 	}
 
 	// Encrypt the second justice kit under breach key two.
-	encBlob2, err := blob2.Encrypt(key2, blob.FlagCommitOutputs.Type())
+	encBlob2, err := blob2.Encrypt(key2)
 	if err != nil {
 		t.Fatalf("unable to encrypt sweep detail 2: %v", err)
 	}

--- a/watchtower/wtclient/backup_task.go
+++ b/watchtower/wtclient/backup_task.go
@@ -194,6 +194,7 @@ func (t *backupTask) craftSessionPayload(
 	// to-local script, and the remote CSV delay.
 	keyRing := t.breachInfo.KeyRing
 	justiceKit := &blob.JusticeKit{
+		BlobType:         t.blobType,
 		SweepAddress:     t.sweepPkScript,
 		RevocationPubKey: toBlobPubKey(keyRing.RevocationKey),
 		LocalDelayPubKey: toBlobPubKey(keyRing.ToLocalKey),
@@ -299,7 +300,7 @@ func (t *backupTask) craftSessionPayload(
 	// Then, we'll encrypt the computed justice kit using the full breach
 	// transaction id, which will allow the tower to recover the contents
 	// after the transaction is seen in the chain or mempool.
-	encBlob, err := justiceKit.Encrypt(key, t.blobType)
+	encBlob, err := justiceKit.Encrypt(key)
 	if err != nil {
 		return hint, nil, err
 	}


### PR DESCRIPTION
This PR is the first in a series that will enable watchtower support for anchor channels in 0.12.
We start by adding a new `blob.FlagAnchorChannel` indicating whether an encrypted blob is
supposed to spend an anchor channel. Upon successful decryption, this bit is used to signal
that the tower needs to craft the justice txn such that properly spends a `to_remote_confirmed`
p2wsh input rather than the legacy `to_remote` p2wkh input.

The good news is that these changes require no modification of the encrypted payload format.
The anchor payloads are equal size and contain exactly the same witness info as the legacy
payloads, only requiring light modifications to the reconstruction logic.
