### PR TITLE
itest: logging for subtests and refactor WaitForBlockchainSync

### DIFF
--- a/lntest/itest/assertions.go
+++ b/lntest/itest/assertions.go
@@ -1,0 +1,16 @@
+package itest
+
+import (
+	"testing"
+
+	"github.com/lightningnetwork/lnd/lntest"
+	"github.com/stretchr/testify/require"
+)
+
+// AddToNodeLog adds a line to the log file and asserts there's no error.
+func AddToNodeLog(t *testing.T,
+	node *lntest.HarnessNode, logLine string) {
+
+	err := node.AddToLog(logLine)
+	require.NoError(t, err, "unable to add to log")
+}

--- a/lntest/itest/lnd_funding_test.go
+++ b/lntest/itest/lnd_funding_test.go
@@ -137,6 +137,12 @@ test:
 				"carol_commit=%v,dave_commit=%v", cc, dc,
 			)
 
+			logLine := fmt.Sprintf(
+				"---- basic channel funding subtest %s ----\n",
+				testName,
+			)
+			AddToNodeLog(t.t, net.Alice, logLine)
+
 			success := t.t.Run(testName, func(t *testing.T) {
 				testFunding(cc, dc)
 			})

--- a/lntest/itest/lnd_multi-hop_test.go
+++ b/lntest/itest/lnd_multi-hop_test.go
@@ -102,6 +102,13 @@ func testMultiHopHtlcClaims(net *lntest.NetworkHarness, t *harnessTest) {
 			for _, subTest := range subTests {
 				subTest := subTest
 
+				logLine := fmt.Sprintf(
+					"---- multi-hop htlc subtest "+
+						"%s/%s ----\n",
+					testName, subTest.name,
+				)
+				AddToNodeLog(t, net.Alice, logLine)
+
 				success := ht.t.Run(subTest.name, func(t *testing.T) {
 					ht := newHarnessTest(t, net)
 

--- a/lntest/itest/lnd_test.go
+++ b/lntest/itest/lnd_test.go
@@ -3153,6 +3153,11 @@ func testChannelForceClosure(net *lntest.NetworkHarness, t *harnessTest) {
 
 	for _, channelType := range commitTypes {
 		testName := fmt.Sprintf("committype=%v", channelType)
+		logLine := fmt.Sprintf(
+			"---- channel force close subtest %s ----\n",
+			testName,
+		)
+		AddToNodeLog(t.t, net.Alice, logLine)
 
 		channelType := channelType
 		success := t.t.Run(testName, func(t *testing.T) {
@@ -14476,11 +14481,8 @@ func TestLightningNetworkDaemon(t *testing.T) {
 				testCase.name,
 			)
 
-			err = lndHarness.Alice.AddToLog(logLine)
-			require.NoError(t1, err, "unable to add to log")
-
-			err = lndHarness.Bob.AddToLog(logLine)
-			require.NoError(t1, err, "unable to add to log")
+			AddToNodeLog(t, lndHarness.Alice, logLine)
+			AddToNodeLog(t, lndHarness.Bob, logLine)
 
 			// Start every test with the default static fee estimate.
 			lndHarness.SetFeeEstimate(12500)

--- a/lntest/node.go
+++ b/lntest/node.go
@@ -1304,50 +1304,31 @@ func (hn *HarnessNode) WaitForNetworkChannelClose(ctx context.Context,
 	}
 }
 
-// WaitForBlockchainSync will block until the target nodes has fully
-// synchronized with the blockchain. If the passed context object has a set
-// timeout, then the goroutine will continually poll until the timeout has
-// elapsed. In the case that the chain isn't synced before the timeout is up,
-// then this function will return an error.
+// WaitForBlockchainSync waits for the target node to be fully synchronized with
+// the blockchain. If the passed context object has a set timeout, it will
+// continually poll until the timeout has elapsed. In the case that the chain
+// isn't synced before the timeout is up, this function will return an error.
 func (hn *HarnessNode) WaitForBlockchainSync(ctx context.Context) error {
-	errChan := make(chan error, 1)
-	retryDelay := time.Millisecond * 100
+	ticker := time.NewTicker(time.Millisecond * 100)
+	defer ticker.Stop()
 
-	go func() {
-		for {
-			select {
-			case <-ctx.Done():
-			case <-hn.quit:
-				return
-			default:
-			}
-
-			getInfoReq := &lnrpc.GetInfoRequest{}
-			getInfoResp, err := hn.GetInfo(ctx, getInfoReq)
-			if err != nil {
-				errChan <- err
-				return
-			}
-			if getInfoResp.SyncedToChain {
-				errChan <- nil
-				return
-			}
-
-			select {
-			case <-ctx.Done():
-				return
-			case <-time.After(retryDelay):
-			}
+	for {
+		resp, err := hn.GetInfo(ctx, &lnrpc.GetInfoRequest{})
+		if err != nil {
+			return err
 		}
-	}()
+		if resp.SyncedToChain {
+			return nil
+		}
 
-	select {
-	case <-hn.quit:
-		return nil
-	case err := <-errChan:
-		return err
-	case <-ctx.Done():
-		return fmt.Errorf("timeout while waiting for blockchain sync")
+		select {
+		case <-ctx.Done():
+			return fmt.Errorf("timeout while waiting for " +
+				"blockchain sync")
+		case <-hn.quit:
+			return nil
+		case <-ticker.C:
+		}
 	}
 }
 


### PR DESCRIPTION
I was reading the test logs to understand why the tests were flaky, and made a few changes in assisting me to locate tests. 