### PR TITLE
Itest: proper connect/disconnect miner

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ require (
 	github.com/NebulousLabs/fastrand v0.0.0-20181203155948-6fb6489aac4e // indirect
 	github.com/NebulousLabs/go-upnp v0.0.0-20180202185039-29b680b06c82
 	github.com/Yawning/aez v0.0.0-20180114000226-4dad034d9db2
-	github.com/btcsuite/btcd v0.20.1-beta.0.20200730232343-1db1b6f8217f
+	github.com/btcsuite/btcd v0.20.1-beta.0.20200903105316-61634447e719
 	github.com/btcsuite/btclog v0.0.0-20170628155309-84c8d2346e9f
 	github.com/btcsuite/btcutil v1.0.2
 	github.com/btcsuite/btcutil/psbt v1.0.2

--- a/go.sum
+++ b/go.sum
@@ -29,6 +29,8 @@ github.com/btcsuite/btcd v0.20.1-beta/go.mod h1:wVuoA8VJLEcwgqHBwHmzLRazpKxTv13P
 github.com/btcsuite/btcd v0.20.1-beta.0.20200513120220-b470eee47728/go.mod h1:wVuoA8VJLEcwgqHBwHmzLRazpKxTv13Px/pDuV7OomQ=
 github.com/btcsuite/btcd v0.20.1-beta.0.20200730232343-1db1b6f8217f h1:m/GhMTvDQLbID616c4TYdHyt0MZ9lH5B/nf9Lu3okCY=
 github.com/btcsuite/btcd v0.20.1-beta.0.20200730232343-1db1b6f8217f/go.mod h1:ZSWyehm27aAuS9bvkATT+Xte3hjHZ+MRgMY/8NJ7K94=
+github.com/btcsuite/btcd v0.20.1-beta.0.20200903105316-61634447e719 h1:EVCN2/T2EhbccMSuV3iM6cVcVVYSzmsx4EP3fWgdFGQ=
+github.com/btcsuite/btcd v0.20.1-beta.0.20200903105316-61634447e719/go.mod h1:ZSWyehm27aAuS9bvkATT+Xte3hjHZ+MRgMY/8NJ7K94=
 github.com/btcsuite/btclog v0.0.0-20170628155309-84c8d2346e9f h1:bAs4lUbRJpnnkd9VhRV3jjAVU7DJVjMaK+IsvSeZvFo=
 github.com/btcsuite/btclog v0.0.0-20170628155309-84c8d2346e9f/go.mod h1:TdznJufoqS23FtqVCzL0ZqgP5MqXbb4fg/WgDys70nA=
 github.com/btcsuite/btcutil v0.0.0-20190425235716-9e5f4b9a998d h1:yJzD/yFppdVCf6ApMkVy8cUxV0XrxdP9rVf6D87/Mng=

--- a/lntest/bitcoind.go
+++ b/lntest/bitcoind.go
@@ -174,14 +174,6 @@ func NewBackend(miner string, netParams *chaincfg.Params) (
 			err)
 	}
 
-	// We start by adding the miner to the bitcoind addnode list. We do
-	// this instead of connecting using command line flags, because it will
-	// allow us to disconnect the miner using the AddNode command later.
-	if err := client.AddNode(miner, rpcclient.ANAdd); err != nil {
-		cleanUp()
-		return nil, nil, fmt.Errorf("unable to add node: %v", err)
-	}
-
 	bd := BitcoindBackendConfig{
 		rpcHost:      rpcHost,
 		rpcUser:      rpcUser,

--- a/lntest/itest/lnd_test.go
+++ b/lntest/itest/lnd_test.go
@@ -2477,7 +2477,12 @@ func testOpenChannelAfterReorg(net *lntest.NetworkHarness, t *harnessTest) {
 	if err := tempMiner.SetUp(false, 0); err != nil {
 		t.Fatalf("unable to set up mining node: %v", err)
 	}
-	defer tempMiner.TearDown()
+	defer func() {
+		require.NoError(
+			t.t, tempMiner.TearDown(),
+			"failed to tear down temp miner",
+		)
+	}()
 
 	// We start by connecting the new miner to our original miner,
 	// such that it will sync to our original chain.
@@ -14414,7 +14419,9 @@ func TestLightningNetworkDaemon(t *testing.T) {
 		ht.Fatalf("unable to create mining node: %v", err)
 	}
 	defer func() {
-		miner.TearDown()
+		require.NoError(
+			t, miner.TearDown(), "failed to tear down miner",
+		)
 
 		// After shutting down the miner, we'll make a copy of the log
 		// file before deleting the temporary log dir.

--- a/lntest/itest/lnd_test.go
+++ b/lntest/itest/lnd_test.go
@@ -14445,7 +14445,11 @@ func TestLightningNetworkDaemon(t *testing.T) {
 	if err != nil {
 		ht.Fatalf("unable to start backend: %v", err)
 	}
-	defer cleanUp()
+	defer func() {
+		require.NoError(
+			t, cleanUp(), "failed to clean up chain backend",
+		)
+	}()
 
 	if err := miner.SetUp(true, 50); err != nil {
 		ht.Fatalf("unable to set up mining node: %v", err)

--- a/lntest/itest/lnd_test.go
+++ b/lntest/itest/lnd_test.go
@@ -2467,6 +2467,7 @@ func testOpenChannelAfterReorg(net *lntest.NetworkHarness, t *harnessTest) {
 		"--rejectnonstd",
 		"--txindex",
 		"--nowinservice",
+		"--nobanning",
 	}
 	tempMiner, err := rpctest.New(
 		harnessNetParams, &rpcclient.NotificationHandlers{}, args,
@@ -14407,6 +14408,7 @@ func TestLightningNetworkDaemon(t *testing.T) {
 		"--logdir=" + minerLogDir,
 		"--trickleinterval=100ms",
 		"--nowinservice",
+		"--nobanning",
 	}
 	handlers := &rpcclient.NotificationHandlers{
 		OnTxAccepted: func(hash *chainhash.Hash, amt btcutil.Amount) {
@@ -14457,6 +14459,12 @@ func TestLightningNetworkDaemon(t *testing.T) {
 	if err := miner.Node.NotifyNewTransactions(false); err != nil {
 		ht.Fatalf("unable to request transaction notifications: %v", err)
 	}
+
+	// Connect chainbackend to miner.
+	require.NoError(
+		t, chainBackend.ConnectMiner(),
+		"failed to connect to miner",
+	)
 
 	binary := itestLndBinary
 	if runtime.GOOS == "windows" {

--- a/lntest/neutrino.go
+++ b/lntest/neutrino.go
@@ -44,12 +44,12 @@ func (b NeutrinoBackendConfig) Name() string {
 
 // NewBackend starts and returns a NeutrinoBackendConfig for the node.
 func NewBackend(miner string, _ *chaincfg.Params) (
-	*NeutrinoBackendConfig, func(), error) {
+	*NeutrinoBackendConfig, func() error, error) {
 
 	bd := &NeutrinoBackendConfig{
 		minerAddr: miner,
 	}
 
-	cleanUp := func() {}
+	cleanUp := func() error { return nil }
 	return bd, cleanUp, nil
 }

--- a/lntest/neutrino.go
+++ b/lntest/neutrino.go
@@ -29,7 +29,7 @@ func (b NeutrinoBackendConfig) GenArgs() []string {
 
 // ConnectMiner is called to establish a connection to the test miner.
 func (b NeutrinoBackendConfig) ConnectMiner() error {
-	return fmt.Errorf("unimplemented")
+	return nil
 }
 
 // DisconnectMiner is called to disconnect the miner.


### PR DESCRIPTION
This PR tries to make it easier to catch flakes in itest. It,
- catches error when miner tears down.
- caches error when chain backend cleans up.
- disables chain backend retrying connection to the miner.

The last one is somewhat tricky. Before this fix, the `btcd` chain backend automatically retries connecting to the miner on several occasions,
- during the test setup, when miner was not ready, it tried to connect and failed, then it would retry it in 5s, as shown in the log,
    ```python
    2020-08-29 16:24:04.980 [DBG] CMGR: Retrying connection to 127.0.0.1:11160 (reqid 1) in 5s
    ```
- in the test `testOpenChannelAfterReorg`, we manually disconnected the chain backend and the miner. Still, the chain backend retried in 5s and succeeded.
- and other occasions, which can be found in the logs.

The miner ended with multiple connections with the chain backend, which makes debugging difficult.


And a [recent change in btcd](https://github.com/btcsuite/btcd/commit/24db7d7c0cea3bebf44f9f274db60c778acef94b#diff-34c6b408d72845d076d47126c29948d1R1327) validates the not found message and disconnects the peer when needed.

When this `InvTypeWitnessTx` is receieved by the `chainbackend`, it's considered invalid and the miner will be disconnected. Currently, due to the permanent connection, the chainbackend will retry connection in 5 seconds. This is more clear in the following log, notice that the miner and chainbackend logs are combined and ordered by time,

```go
# miner started processing the transaction.
2020-09-08 09:50:42.155 ["miner"] TXMP: Processing transaction 2d7ae05ad86da2585de25e9ab274dbc673088415e553133d974de7287419c003
2020-09-08 09:50:42.301 ["miner"] TXMP: Accepted transaction 2d7ae05ad86da2585de25e9ab274dbc673088415e553133d974de7287419c003 (pool size: 4)
2020-09-08 09:50:42.368 ["miner"] PEER: Sending inv (tx 2d7ae05ad86da2585de25e9ab274dbc673088415e553133d974de7287419c003) to 127.0.0.1:59724-"chainbackend" (inbound)

# miner was asked to generate 10 more blocks, this would clean the mempool.
2020-09-08 09:50:43.533 ["miner"] TXMP: Accepted transaction d0fc68e689ba5eb76a82b19fc3642605072af24cfe390bce40d9dc781924ff32 (pool size: 20)
2020-09-08 09:50:43.536 ["miner"] RPCS: Received command <generate> from 127.0.0.1:46164-"itest"
2020-09-08 09:50:43.537 ["miner"] MINR: Generating 10 blocks
2020-09-08 09:50:43.538 ["miner"] MINR: Considering 20 transactions for inclusion to new block

# the chainbackend tried to fetch the transaction, since it was not in the mempool, the miner would send
# a notfound message.
2020-09-08 09:50:44.318 ["chainbackend"] PEER: Received inv (tx 2d7ae05ad86da2585de25e9ab274dbc673088415e553133d974de7287419c003) from 127.0.0.1:23460-"miner" (outbound)
2020-09-08 09:50:44.348 ["miner"] MINR: Adding tx 2d7ae05ad86da2585de25e9ab274dbc673088415e553133d974de7287419c003 (priority 6166666666.67, feePerKB %!f(int64=6418918))
2020-09-08 09:50:44.430 ["chainbackend"] PEER: Sending getdata (witness tx 2d7ae05ad86da2585de25e9ab274dbc673088415e553133d974de7287419c003) to 127.0.0.1:23460-"miner" (outbound)
2020-09-08 09:50:45.214 ["miner"] PEER: Received getdata (witness tx 2d7ae05ad86da2585de25e9ab274dbc673088415e553133d974de7287419c003) from 127.0.0.1:59724-"chainbackend" (inbound)
2020-09-08 09:50:45.215 ["miner"] PEER: Unable to fetch tx 2d7ae05ad86da2585de25e9ab274dbc673088415e553133d974de7287419c003 from transaction pool: transaction is not in the pool
2020-09-08 09:50:45.217 ["miner"] PEER: Sending notfound (witness tx 2d7ae05ad86da2585de25e9ab274dbc673088415e553133d974de7287419c003) to 127.0.0.1:59724-"chainbackend" (inbound)
2020-09-08 09:50:45.224 ["chainbackend"] PEER: Received notfound (witness tx 2d7ae05ad86da2585de25e9ab274dbc673088415e553133d974de7287419c003) from 127.0.0.1:23460-"miner" (outbound)
2020-09-08 09:50:45.225 ["chainbackend"] PEER: Invalid inv type '1073741825' in notfound message from 127.0.0.1:23460-"miner" (outbound)
2020-09-08 09:50:45.226 ["chainbackend"] PEER: Disconnecting 127.0.0.1:23460-"miner" (outbound)
2020-09-08 09:50:45.226 ["chainbackend"] SYNC: Lost peer 127.0.0.1:23460-"miner" (outbound)
```

The ending `1073741825` is a type,
```go
InvTypeWitnessTx     InvType = InvTypeTx | InvWitnessFlag
```

The above log happened during test setup, right after [this line](https://github.com/lightningnetwork/lnd/blob/master/lntest/harness.go#L202). After generating the blocks, we would wait for the balance to be synced. It wouldn't happen though, as the miner was disconnected and later the sync would time out.
Detailed logs can be [found here](https://file.io/aLLaks5BS25E).

Current itest won't pass, blocked by this fix in btcd https://github.com/btcsuite/btcd/pull/1625

Related #4553,  #4561 and #4563.