### PR TITLE
lnd: Call loader.UnloadWallet on shutdown

### DIFF
--- a/walletunlocker/service.go
+++ b/walletunlocker/service.go
@@ -81,6 +81,10 @@ type WalletUnlockMsg struct {
 	// ChanBackups a set of static channel backups that should be received
 	// after the wallet has been unlocked.
 	ChanBackups ChannelsToRecover
+
+	// UnloadWallet is a function for unloading the wallet, which should
+	// be called on shutdown.
+	UnloadWallet func() error
 }
 
 // UnlockerService implements the WalletUnlocker service used to provide lnd
@@ -346,6 +350,7 @@ func (u *UnlockerService) UnlockWallet(ctx context.Context,
 		Passphrase:     password,
 		RecoveryWindow: recoveryWindow,
 		Wallet:         unlockedWallet,
+		UnloadWallet:   loader.UnloadWallet,
 	}
 
 	// Before we return the unlock payload, we'll check if we can extract


### PR DESCRIPTION
This is required to make restart work for LndMobile builds.
Not calling `UnloadWallet` would make `UnlockWallet` stall forever on the second run as the file is already opened.

This was pretty much a non-issue for the normal UNIX daemon build, as sending `stopDaemon` or `SIGINT` would close down the process and Go's runtime would presumably handle any open files.
But on mobile builds, this is not the case, thus we have to explicitly close it down.  

Right now I'm just grabbing the loader all the way to `Main` and `defer`-ing the call so that it will execute once we get a `shutdownChan` signal, I'm unsure if this is the best approach.
N.B: wallet has to be opened for the main RPC server to function properly.

This is a part of an on-going work to address mobile restarting problems #4492.