### PR TITLE
cnct+sweep: cpfp-aware anchor sweeping

### DIFF
--- a/breacharbiter.go
+++ b/breacharbiter.go
@@ -914,6 +914,11 @@ func (bo *breachedOutput) HeightHint() uint32 {
 	return bo.confHeight
 }
 
+// UnconfParent returns information about a possibly unconfirmed parent tx.
+func (bo *breachedOutput) UnconfParent() *input.TxInfo {
+	return nil
+}
+
 // Add compile-time constraint ensuring breachedOutput implements the Input
 // interface.
 var _ input.Input = (*breachedOutput)(nil)

--- a/contractcourt/anchor_resolver.go
+++ b/contractcourt/anchor_resolver.go
@@ -99,6 +99,7 @@ func (c *anchorResolver) Resolve() (ContractResolver, error) {
 		input.CommitmentAnchor,
 		&c.anchorSignDescriptor,
 		c.broadcastHeight,
+		nil,
 	)
 
 	resultChan, err := c.Sweeper.SweepInput(

--- a/contractcourt/anchor_resolver.go
+++ b/contractcourt/anchor_resolver.go
@@ -89,6 +89,9 @@ func (c *anchorResolver) Resolve() (ContractResolver, error) {
 	// An exclusive group is not necessary anymore, because we know that
 	// this is the only anchor that can be swept.
 	//
+	// We also clear the parent tx information for cpfp, because the
+	// commitment tx is confirmed.
+	//
 	// After a restart or when the remote force closes, the sweeper is not
 	// yet aware of the anchor. In that case, it will be added as new input
 	// to the sweeper.

--- a/contractcourt/channel_arbitrator.go
+++ b/contractcourt/channel_arbitrator.go
@@ -1073,6 +1073,7 @@ func (c *ChannelArbitrator) sweepAnchors(anchors []*lnwallet.AnchorResolution,
 			input.CommitmentAnchor,
 			&anchor.AnchorSignDescriptor,
 			heightHint,
+			nil,
 		)
 
 		// Sweep anchor output with the minimum fee rate. This usually

--- a/contractcourt/channel_arbitrator.go
+++ b/contractcourt/channel_arbitrator.go
@@ -30,6 +30,12 @@ var (
 		"process of being force closed")
 )
 
+const (
+	// anchorSweepConfTarget is the conf target used when sweeping
+	// commitment anchors.
+	anchorSweepConfTarget = 6
+)
+
 // WitnessSubscription represents an intent to be notified once new witnesses
 // are discovered by various active contract resolvers. A contract resolver may
 // use this to be notified of when it can satisfy an incoming contract after we
@@ -1060,9 +1066,6 @@ func (c *ChannelArbitrator) sweepAnchors(anchors []*lnwallet.AnchorResolution,
 	// anchors from being batched together.
 	exclusiveGroup := c.cfg.ShortChanID.ToUint64()
 
-	// Retrieve the current minimum fee rate from the sweeper.
-	minFeeRate := c.cfg.Sweeper.RelayFeePerKW()
-
 	for _, anchor := range anchors {
 		log.Debugf("ChannelArbitrator(%v): pre-confirmation sweep of "+
 			"anchor of tx %v", c.cfg.ChanPoint, anchor.CommitAnchor)
@@ -1073,19 +1076,25 @@ func (c *ChannelArbitrator) sweepAnchors(anchors []*lnwallet.AnchorResolution,
 			input.CommitmentAnchor,
 			&anchor.AnchorSignDescriptor,
 			heightHint,
-			nil,
+			&input.TxInfo{
+				Fee:    anchor.CommitFee,
+				Weight: anchor.CommitWeight,
+			},
 		)
 
-		// Sweep anchor output with the minimum fee rate. This usually
-		// (up to a min relay fee of 3 sat/b) means that the anchor
-		// sweep will be economical. Also signal that this is a force
-		// sweep. If the user decides to bump the fee on the anchor
-		// sweep, it will be swept even if it isn't economical.
+		// Sweep anchor output with a confirmation target fee
+		// preference. Because this is a cpfp-operation, the anchor will
+		// only be attempted to sweep when the current fee estimate for
+		// the confirmation target exceeds the commit fee rate.
+		//
+		// Also signal that this is a force sweep, so that the anchor
+		// will be swept even if it isn't economical purely based on the
+		// anchor value.
 		_, err := c.cfg.Sweeper.SweepInput(
 			&anchorInput,
 			sweep.Params{
 				Fee: sweep.FeePreference{
-					FeeRate: minFeeRate,
+					ConfTarget: anchorSweepConfTarget,
 				},
 				Force:          true,
 				ExclusiveGroup: &exclusiveGroup,

--- a/lntest/itest/lnd_channel_backup_test.go
+++ b/lntest/itest/lnd_channel_backup_test.go
@@ -368,6 +368,10 @@ func testChannelBackupRestore(net *lntest.NetworkHarness, t *harnessTest) {
 	for _, testCase := range testCases {
 		success := t.t.Run(testCase.name, func(t *testing.T) {
 			h := newHarnessTest(t, net)
+
+			// Start each test with the default static fee estimate.
+			net.SetFeeEstimate(12500)
+
 			testChanRestoreScenario(h, net, &testCase, password)
 		})
 		if !success {

--- a/lntest/itest/lnd_multi-hop_htlc_local_chain_claim_test.go
+++ b/lntest/itest/lnd_multi-hop_htlc_local_chain_claim_test.go
@@ -96,6 +96,10 @@ func testMultiHopHtlcLocalChainClaim(net *lntest.NetworkHarness, t *harnessTest,
 	// hop logic.
 	waitForInvoiceAccepted(t, carol, payHash)
 
+	// Increase the fee estimate so that the following force close tx will
+	// be cpfp'ed.
+	net.SetFeeEstimate(30000)
+
 	// At this point, Bob decides that he wants to exit the channel
 	// immediately, so he force closes his commitment transaction.
 	ctxt, _ = context.WithTimeout(ctxb, channelCloseTimeout)

--- a/lntest/itest/lnd_multi-hop_htlc_local_timeout_test.go
+++ b/lntest/itest/lnd_multi-hop_htlc_local_timeout_test.go
@@ -105,6 +105,10 @@ func testMultiHopHtlcLocalTimeout(net *lntest.NetworkHarness, t *harnessTest,
 		t.Fatalf("htlc mismatch: %v", predErr)
 	}
 
+	// Increase the fee estimate so that the following force close tx will
+	// be cpfp'ed.
+	net.SetFeeEstimate(30000)
+
 	// We'll now mine enough blocks to trigger Bob's broadcast of his
 	// commitment transaction due to the fact that the HTLC is about to
 	// timeout. With the default outgoing broadcast delta of zero, this will

--- a/lntest/itest/lnd_multi-hop_htlc_receiver_chain_claim_test.go
+++ b/lntest/itest/lnd_multi-hop_htlc_receiver_chain_claim_test.go
@@ -117,6 +117,10 @@ func testMultiHopReceiverChainClaim(net *lntest.NetworkHarness, t *harnessTest,
 		t.Fatalf("settle invoice: %v", err)
 	}
 
+	// Increase the fee estimate so that the following force close tx will
+	// be cpfp'ed.
+	net.SetFeeEstimate(30000)
+
 	// Now we'll mine enough blocks to prompt carol to actually go to the
 	// chain in order to sweep her HTLC since the value is high enough.
 	// TODO(roasbeef): modify once go to chain policy changes

--- a/lntest/itest/lnd_multi-hop_htlc_remote_chain_claim_test.go
+++ b/lntest/itest/lnd_multi-hop_htlc_remote_chain_claim_test.go
@@ -96,6 +96,10 @@ func testMultiHopHtlcRemoteChainClaim(net *lntest.NetworkHarness, t *harnessTest
 	// hop logic.
 	waitForInvoiceAccepted(t, carol, payHash)
 
+	// Increase the fee estimate so that the following force close tx will
+	// be cpfp'ed.
+	net.SetFeeEstimate(30000)
+
 	// Next, Alice decides that she wants to exit the channel, so she'll
 	// immediately force close the channel by broadcast her commitment
 	// transaction.

--- a/lntest/itest/lnd_multi-hop_local_force_close_on_chain_htlc_timeout_test.go
+++ b/lntest/itest/lnd_multi-hop_local_force_close_on_chain_htlc_timeout_test.go
@@ -79,6 +79,10 @@ func testMultiHopLocalForceCloseOnChainHtlcTimeout(net *lntest.NetworkHarness,
 		t.Fatalf("htlc mismatch: %v", err)
 	}
 
+	// Increase the fee estimate so that the following force close tx will
+	// be cpfp'ed.
+	net.SetFeeEstimate(30000)
+
 	// Now that all parties have the HTLC locked in, we'll immediately
 	// force close the Bob -> Carol channel. This should trigger contract
 	// resolution mode for both of them.

--- a/lntest/itest/lnd_multi-hop_remote_force_close_on_chain_htlc_timeout_test.go
+++ b/lntest/itest/lnd_multi-hop_remote_force_close_on_chain_htlc_timeout_test.go
@@ -80,6 +80,10 @@ func testMultiHopRemoteForceCloseOnChainHtlcTimeout(net *lntest.NetworkHarness,
 		t.Fatalf("htlc mismatch: %v", predErr)
 	}
 
+	// Increase the fee estimate so that the following force close tx will
+	// be cpfp'ed.
+	net.SetFeeEstimate(30000)
+
 	// At this point, we'll now instruct Carol to force close the
 	// transaction. This will let us exercise that Bob is able to sweep the
 	// expired HTLC on Carol's version of the commitment transaction. If

--- a/lntest/itest/lnd_multi-hop_test.go
+++ b/lntest/itest/lnd_multi-hop_test.go
@@ -101,6 +101,10 @@ func testMultiHopHtlcClaims(net *lntest.NetworkHarness, t *harnessTest) {
 				success := ht.t.Run(subTest.name, func(t *testing.T) {
 					ht := newHarnessTest(t, net)
 
+					// Start each test with the default
+					// static fee estimate.
+					net.SetFeeEstimate(12500)
+
 					subTest.test(net, ht, alice, bob, commitType)
 				})
 				if !success {

--- a/sweep/sweeper_test.go
+++ b/sweep/sweeper_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/lightningnetwork/lnd/lntest/mock"
 	"github.com/lightningnetwork/lnd/lnwallet"
 	"github.com/lightningnetwork/lnd/lnwallet/chainfee"
+	"github.com/stretchr/testify/require"
 )
 
 var (
@@ -77,6 +78,7 @@ func createTestInput(value int64, witnessType input.WitnessType) input.BaseInput
 			},
 		},
 		0,
+		nil,
 	)
 
 	testInputCount++
@@ -173,6 +175,18 @@ func (ctx *sweeperTestContext) tick() {
 	case <-time.After(defaultTestTimeout):
 		debug.PrintStack()
 		ctx.t.Fatal("tick timeout - no new timer created")
+	}
+}
+
+// assertNoTick asserts that the sweeper does not wait for a tick.
+func (ctx *sweeperTestContext) assertNoTick() {
+	ctx.t.Helper()
+
+	select {
+	case <-ctx.timeoutChan:
+		ctx.t.Fatal("unexpected tick")
+
+	case <-time.After(processingDelay):
 	}
 }
 
@@ -337,9 +351,10 @@ func assertTxFeeRate(t *testing.T, tx *wire.MsgTx,
 	outputAmt := tx.TxOut[0].Value
 
 	fee := btcutil.Amount(inputAmt - outputAmt)
-	_, txWeight := getWeightEstimate(inputs)
+	_, estimator := getWeightEstimate(inputs, 0)
+	txWeight := estimator.weight()
 
-	expectedFee := expectedFeeRate.FeeForWeight(txWeight)
+	expectedFee := expectedFeeRate.FeeForWeight(int64(txWeight))
 	if fee != expectedFee {
 		t.Fatalf("expected fee rate %v results in %v fee, got %v fee",
 			expectedFeeRate, expectedFee, fee)
@@ -1292,4 +1307,72 @@ func TestExclusiveGroup(t *testing.T) {
 	if result2.Err != ErrExclusiveGroupSpend {
 		t.Fatal("expected third input to be canceled")
 	}
+}
+
+// TestCpfp tests that the sweeper spends cpfp inputs at a fee rate that exceeds
+// the parent tx fee rate.
+func TestCpfp(t *testing.T) {
+	ctx := createSweeperTestContext(t)
+
+	ctx.estimator.updateFees(1000, chainfee.FeePerKwFloor)
+
+	// Offer an input with an unconfirmed parent tx to the sweeper. The
+	// parent tx pays 3000 sat/kw.
+	hash := chainhash.Hash{1}
+	input := input.MakeBaseInput(
+		&wire.OutPoint{Hash: hash},
+		input.CommitmentTimeLock,
+		&input.SignDescriptor{
+			Output: &wire.TxOut{
+				Value: 330,
+			},
+			KeyDesc: keychain.KeyDescriptor{
+				PubKey: testPubKey,
+			},
+		},
+		0,
+		&input.TxInfo{
+			Weight: 300,
+			Fee:    900,
+		},
+	)
+
+	feePref := FeePreference{ConfTarget: 6}
+	result, err := ctx.sweeper.SweepInput(
+		&input, Params{Fee: feePref, Force: true},
+	)
+	require.NoError(t, err)
+
+	// Because we sweep at 1000 sat/kw, the parent cannot be paid for. We
+	// expect the sweeper to remain idle.
+	ctx.assertNoTick()
+
+	// Increase the fee estimate to above the parent tx fee rate.
+	ctx.estimator.updateFees(5000, chainfee.FeePerKwFloor)
+
+	// Signal a new block. This is a trigger for the sweeper to refresh fee
+	// estimates.
+	ctx.notifier.NotifyEpoch(1000)
+
+	// Now we do expect a sweep transaction to be published with our input
+	// and an attached wallet utxo.
+	ctx.tick()
+	tx := ctx.receiveTx()
+	require.Len(t, tx.TxIn, 2)
+	require.Len(t, tx.TxOut, 1)
+
+	// As inputs we have 10000 sats from the wallet and 330 sats from the
+	// cpfp input. The sweep tx is weight expected to be 759 units. There is
+	// an additional 300 weight units from the parent to include in the
+	// package, making a total of 1059. At 5000 sat/kw, the required fee for
+	// the package is 5295 sats. The parent already paid 900 sats, so there
+	// is 4395 sat remaining to be paid. The expected output value is
+	// therefore: 10000 + 330 - 4395 = 5935.
+	require.Equal(t, int64(5935), tx.TxOut[0].Value)
+
+	// Mine the tx and assert that the result is passed back.
+	ctx.backend.mine()
+	ctx.expectResult(result, nil)
+
+	ctx.finish(1)
 }

--- a/sweep/test_utils.go
+++ b/sweep/test_utils.go
@@ -13,6 +13,7 @@ import (
 
 var (
 	defaultTestTimeout = 5 * time.Second
+	processingDelay    = 1 * time.Second
 	mockChainHash, _   = chainhash.NewHashFromStr("00aabbccddeeff")
 	mockChainHeight    = int32(100)
 )

--- a/sweep/tx_input_set.go
+++ b/sweep/tx_input_set.go
@@ -71,9 +71,6 @@ func (t *txInputSetState) clone() txInputSetState {
 type txInputSet struct {
 	txInputSetState
 
-	// feePerKW is the fee rate used to calculate the tx fee.
-	feePerKW chainfee.SatPerKWeight
-
 	// dustLimit is the minimum output value of the tx.
 	dustLimit btcutil.Amount
 
@@ -96,11 +93,10 @@ func newTxInputSet(wallet Wallet, feePerKW,
 	)
 
 	state := txInputSetState{
-		weightEstimate: newWeightEstimator(),
+		weightEstimate: newWeightEstimator(feePerKW),
 	}
 
 	b := txInputSet{
-		feePerKW:        feePerKW,
 		dustLimit:       dustLimit,
 		maxInputs:       maxInputs,
 		wallet:          wallet,
@@ -146,8 +142,7 @@ func (t *txInputSet) addToState(inp input.Input, constraints addConstraints) *tx
 	s.inputTotal += value
 
 	// Recalculate the tx fee.
-	weight := s.weightEstimate.weight()
-	fee := t.feePerKW.FeeForWeight(int64(weight))
+	fee := s.weightEstimate.fee()
 
 	// Calculate the new output value.
 	s.outputValue = s.inputTotal - fee

--- a/sweep/tx_input_set.go
+++ b/sweep/tx_input_set.go
@@ -33,7 +33,7 @@ const (
 type txInputSetState struct {
 	// weightEstimate is the (worst case) tx weight with the current set of
 	// inputs.
-	weightEstimate input.TxWeightEstimator
+	weightEstimate *weightEstimator
 
 	// inputTotal is the total value of all inputs.
 	inputTotal btcutil.Amount
@@ -54,7 +54,7 @@ type txInputSetState struct {
 
 func (t *txInputSetState) clone() txInputSetState {
 	s := txInputSetState{
-		weightEstimate:   t.weightEstimate,
+		weightEstimate:   t.weightEstimate.clone(),
 		inputTotal:       t.inputTotal,
 		outputValue:      t.outputValue,
 		walletInputTotal: t.walletInputTotal,
@@ -95,15 +95,20 @@ func newTxInputSet(wallet Wallet, feePerKW,
 		btcutil.Amount(relayFee.FeePerKVByte()),
 	)
 
+	state := txInputSetState{
+		weightEstimate: newWeightEstimator(),
+	}
+
 	b := txInputSet{
-		feePerKW:  feePerKW,
-		dustLimit: dustLimit,
-		maxInputs: maxInputs,
-		wallet:    wallet,
+		feePerKW:        feePerKW,
+		dustLimit:       dustLimit,
+		maxInputs:       maxInputs,
+		wallet:          wallet,
+		txInputSetState: state,
 	}
 
 	// Add the sweep tx output to the weight estimate.
-	b.weightEstimate.AddP2WKHOutput()
+	b.weightEstimate.addP2WKHOutput()
 
 	return &b
 }
@@ -126,29 +131,22 @@ func (t *txInputSet) addToState(inp input.Input, constraints addConstraints) *tx
 		return nil
 	}
 
-	// Can ignore error, because it has already been checked when
-	// calculating the yields.
-	size, isNestedP2SH, _ := inp.WitnessType().SizeUpperBound()
-
 	// Clone the current set state.
 	s := t.clone()
 
 	// Add the new input.
 	s.inputs = append(s.inputs, inp)
 
-	// Add weight of the new input.
-	if isNestedP2SH {
-		s.weightEstimate.AddNestedP2WSHInput(size)
-	} else {
-		s.weightEstimate.AddWitnessInput(size)
-	}
+	// Can ignore error, because it has already been checked when
+	// calculating the yields.
+	_ = s.weightEstimate.add(inp)
 
 	// Add the value of the new input.
 	value := btcutil.Amount(inp.SignDesc().Output.Value)
 	s.inputTotal += value
 
 	// Recalculate the tx fee.
-	weight := s.weightEstimate.Weight()
+	weight := s.weightEstimate.weight()
 	fee := t.feePerKW.FeeForWeight(int64(weight))
 
 	// Calculate the new output value.

--- a/sweep/txgenerator_test.go
+++ b/sweep/txgenerator_test.go
@@ -39,7 +39,8 @@ func TestWeightEstimate(t *testing.T) {
 		))
 	}
 
-	_, weight := getWeightEstimate(inputs)
+	_, estimator := getWeightEstimate(inputs, 0)
+	weight := int64(estimator.weight())
 	if weight != expectedWeight {
 		t.Fatalf("unexpected weight. expected %d but got %d.",
 			expectedWeight, weight)

--- a/sweep/walletsweep.go
+++ b/sweep/walletsweep.go
@@ -255,7 +255,9 @@ func CraftSweepAllTx(feeRate chainfee.SatPerKWeight, blockHeight uint32,
 		// Now that we've constructed the items required, we'll make an
 		// input which can be passed to the sweeper for ultimate
 		// sweeping.
-		input := input.MakeBaseInput(&output.OutPoint, witnessType, signDesc, 0)
+		input := input.MakeBaseInput(
+			&output.OutPoint, witnessType, signDesc, 0, nil,
+		)
 		inputsToSweep = append(inputsToSweep, &input)
 	}
 

--- a/sweep/weight_estimator.go
+++ b/sweep/weight_estimator.go
@@ -1,31 +1,89 @@
 package sweep
 
 import (
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"github.com/btcsuite/btcutil"
 	"github.com/lightningnetwork/lnd/input"
+	"github.com/lightningnetwork/lnd/lnwallet/chainfee"
 )
 
-// weightEstimator wraps a standard weight estimator instance.
+// weightEstimator wraps a standard weight estimator instance and adds to that
+// support for child-pays-for-parent.
 type weightEstimator struct {
-	estimator input.TxWeightEstimator
+	estimator     input.TxWeightEstimator
+	feeRate       chainfee.SatPerKWeight
+	parents       map[chainhash.Hash]struct{}
+	parentsFee    btcutil.Amount
+	parentsWeight int64
 }
 
 // newWeightEstimator instantiates a new sweeper weight estimator.
-func newWeightEstimator() *weightEstimator {
-	return &weightEstimator{}
+func newWeightEstimator(feeRate chainfee.SatPerKWeight) *weightEstimator {
+	return &weightEstimator{
+		feeRate: feeRate,
+		parents: make(map[chainhash.Hash]struct{}),
+	}
 }
 
 // clone returns a copy of this weight estimator.
 func (w *weightEstimator) clone() *weightEstimator {
+	parents := make(map[chainhash.Hash]struct{}, len(w.parents))
+	for hash := range w.parents {
+		parents[hash] = struct{}{}
+	}
+
 	return &weightEstimator{
-		estimator: w.estimator,
+		estimator:     w.estimator,
+		feeRate:       w.feeRate,
+		parents:       parents,
+		parentsFee:    w.parentsFee,
+		parentsWeight: w.parentsWeight,
 	}
 }
 
 // add adds the weight of the given input to the weight estimate.
 func (w *weightEstimator) add(inp input.Input) error {
+	// If there is a parent tx, add the parent's fee and weight.
+	w.tryAddParent(inp)
+
 	wt := inp.WitnessType()
 
 	return wt.AddWeightEstimation(&w.estimator)
+}
+
+// tryAddParent examines the input and updates parent tx totals if required for
+// cpfp.
+func (w *weightEstimator) tryAddParent(inp input.Input) {
+	// Get unconfirmed parent info from the input.
+	unconfParent := inp.UnconfParent()
+
+	// If there is no parent, there is nothing to add.
+	if unconfParent == nil {
+		return
+	}
+
+	// If we've already accounted for the parent tx, don't do it
+	// again. This can happens when two outputs of the parent tx are
+	// included in the same sweep tx.
+	parentHash := inp.OutPoint().Hash
+	if _, ok := w.parents[parentHash]; ok {
+		return
+	}
+
+	// Calculate parent fee rate.
+	parentFeeRate := chainfee.SatPerKWeight(unconfParent.Fee) * 1000 /
+		chainfee.SatPerKWeight(unconfParent.Weight)
+
+	// Ignore parents that pay at least the fee rate of this transaction.
+	// Parent pays for child is not happening.
+	if parentFeeRate >= w.feeRate {
+		return
+	}
+
+	// Include parent.
+	w.parents[parentHash] = struct{}{}
+	w.parentsFee += unconfParent.Fee
+	w.parentsWeight += unconfParent.Weight
 }
 
 // addP2WKHOutput updates the weight estimate to account for an additional
@@ -37,4 +95,26 @@ func (w *weightEstimator) addP2WKHOutput() {
 // weight gets the estimated weight of the transaction.
 func (w *weightEstimator) weight() int {
 	return w.estimator.Weight()
+}
+
+// fee returns the tx fee to use for the aggregated inputs and outputs, taking
+// into account unconfirmed parent transactions (cpfp).
+func (w *weightEstimator) fee() btcutil.Amount {
+	// Calculate fee and weight for just this tx.
+	childWeight := int64(w.estimator.Weight())
+
+	// Add combined weight of unconfirmed parent txes.
+	totalWeight := childWeight + w.parentsWeight
+
+	// Subtract fee already paid by parents.
+	fee := w.feeRate.FeeForWeight(totalWeight) - w.parentsFee
+
+	// Clamp the fee to what would be required if no parent txes were paid
+	// for. This is to make sure no rounding errors can get us into trouble.
+	childFee := w.feeRate.FeeForWeight(childWeight)
+	if childFee > fee {
+		fee = childFee
+	}
+
+	return fee
 }

--- a/sweep/weight_estimator.go
+++ b/sweep/weight_estimator.go
@@ -1,0 +1,40 @@
+package sweep
+
+import (
+	"github.com/lightningnetwork/lnd/input"
+)
+
+// weightEstimator wraps a standard weight estimator instance.
+type weightEstimator struct {
+	estimator input.TxWeightEstimator
+}
+
+// newWeightEstimator instantiates a new sweeper weight estimator.
+func newWeightEstimator() *weightEstimator {
+	return &weightEstimator{}
+}
+
+// clone returns a copy of this weight estimator.
+func (w *weightEstimator) clone() *weightEstimator {
+	return &weightEstimator{
+		estimator: w.estimator,
+	}
+}
+
+// add adds the weight of the given input to the weight estimate.
+func (w *weightEstimator) add(inp input.Input) error {
+	wt := inp.WitnessType()
+
+	return wt.AddWeightEstimation(&w.estimator)
+}
+
+// addP2WKHOutput updates the weight estimate to account for an additional
+// native P2WKH output.
+func (w *weightEstimator) addP2WKHOutput() {
+	w.estimator.AddP2WKHOutput()
+}
+
+// weight gets the estimated weight of the transaction.
+func (w *weightEstimator) weight() int {
+	return w.estimator.Weight()
+}

--- a/sweep/weight_estimator_test.go
+++ b/sweep/weight_estimator_test.go
@@ -1,0 +1,79 @@
+package sweep
+
+import (
+	"testing"
+
+	"github.com/btcsuite/btcd/wire"
+	"github.com/lightningnetwork/lnd/input"
+	"github.com/lightningnetwork/lnd/lnwallet/chainfee"
+	"github.com/stretchr/testify/require"
+)
+
+// TestWeightEstimator tests weight estimation for inputs with and without
+// unconfirmed parents.
+func TestWeightEstimator(t *testing.T) {
+	testFeeRate := chainfee.SatPerKWeight(20000)
+
+	w := newWeightEstimator(testFeeRate)
+
+	// Add an input without unconfirmed parent tx.
+	input1 := input.MakeBaseInput(
+		&wire.OutPoint{}, input.CommitmentAnchor,
+		&input.SignDescriptor{}, 0, nil,
+	)
+
+	require.NoError(t, w.add(&input1))
+
+	// The expectations is that this input is added.
+	const expectedWeight1 = 322
+	require.Equal(t, expectedWeight1, w.weight())
+	require.Equal(t, testFeeRate.FeeForWeight(expectedWeight1), w.fee())
+
+	// Define a parent transaction that pays a fee of 30000 sat/kw.
+	parentTxHighFee := &input.TxInfo{
+		Weight: 100,
+		Fee:    3000,
+	}
+
+	// Add an output of the parent tx above.
+	input2 := input.MakeBaseInput(
+		&wire.OutPoint{}, input.CommitmentAnchor,
+		&input.SignDescriptor{}, 0,
+		parentTxHighFee,
+	)
+
+	require.NoError(t, w.add(&input2))
+
+	// Pay for parent isn't possible because the parent pays a higher fee
+	// rate than the child. We expect no additional fee on the child.
+	const expectedWeight2 = expectedWeight1 + 280
+	require.Equal(t, expectedWeight2, w.weight())
+	require.Equal(t, testFeeRate.FeeForWeight(expectedWeight2), w.fee())
+
+	// Define a parent transaction that pays a fee of 10000 sat/kw.
+	parentTxLowFee := &input.TxInfo{
+		Weight: 100,
+		Fee:    1000,
+	}
+
+	// Add an output of the low-fee parent tx above.
+	input3 := input.MakeBaseInput(
+		&wire.OutPoint{}, input.CommitmentAnchor,
+		&input.SignDescriptor{}, 0,
+		parentTxLowFee,
+	)
+	require.NoError(t, w.add(&input3))
+
+	// Expect the weight to increase because of the third input.
+	const expectedWeight3 = expectedWeight2 + 280
+	require.Equal(t, expectedWeight3, w.weight())
+
+	// Expect the fee to cover the child and the parent transaction at 20
+	// sat/kw after subtraction of the fee that was already paid by the
+	// parent.
+	expectedFee := testFeeRate.FeeForWeight(
+		expectedWeight3+parentTxLowFee.Weight,
+	) - parentTxLowFee.Fee
+
+	require.Equal(t, expectedFee, w.fee())
+}


### PR DESCRIPTION
This PR modifies the sweeper to take into account potential unconfirmed parent transactions. This enables tracking of the current fee estimate for anchors of not yet confirmed commitment transactions. Previously an anchor-commitment that wouldn't confirm needed to be bumped manually.

`2020-09-08 11:20:19.860 [INF] SWPR: Creating sweep transaction 1b76f06cd667c4d611ce9bd397634e97ac5539e960507c5ad0202965dcae481d for 2 inputs (7d1d2012a7ba95cd8140c47f4688ae0114ae9a88ebfadda107408fd937cfa92b:0 (CommitmentAnchor), ab682225912097d789c33b06b14d1d730869a3869e9b558537085ab2dcef2250:1 (WitnessKeyHash)) using 20000 sat/kw, tx_weight=719, tx_fee=0.0002546 BTC, parents_count=1, parents_fee=0.0001124 BTC, parents_weight=1116`
