### PR TITLE
mobile: Add ServiceStatus for retrieving started up status of lnd

### DIFF
--- a/mobile/bindings.go
+++ b/mobile/bindings.go
@@ -156,3 +156,18 @@ func Start(extraArgs string, rpcReady Callback) {
 		rpcReady.OnResponse([]byte{})
 	}()
 }
+
+type LndStatusCallback interface {
+	OnResponse(lndStarted int32)
+}
+
+// ServiceStatus returns 1 if lnd has started up successfully, allowing the
+// caller to interact with the in-memory gRPC servers. If 0 is returned, the
+// caller should invoke `Start` to initialize lnd.
+//
+// ServiceStatus can also be used to determine when lnd has shut down, since
+// `stopDaemon` returns immediately and does not wait for the gRPC servers to be
+// fully closed.
+func ServiceStatus(callback LndStatusCallback) {
+	callback.OnResponse(atomic.LoadInt32(&lndStarted))
+}


### PR DESCRIPTION
This PR adds a new exported gomobile function `ServiceStatus` that can be used to figure out lnd's runtime state (as in whether it's considered started or not).
This is helpful in certain situations, see my comments below (https://github.com/lightningnetwork/lnd/pull/4595#issuecomment-3927255801).

Cheers