### PR TITLE
routerrpc: pass in probability source

### DIFF
--- a/lnrpc/routerrpc/router_server.go
+++ b/lnrpc/routerrpc/router_server.go
@@ -320,11 +320,13 @@ func (s *Server) EstimateRouteFee(ctx context.Context,
 	// that target amount, we'll only request a single route. Set a
 	// restriction for the default CLTV limit, otherwise we can find a route
 	// that exceeds it and is useless to us.
+	mc := s.cfg.RouterBackend.MissionControl
 	route, err := s.cfg.Router.FindRoute(
 		s.cfg.RouterBackend.SelfNode, destNode, amtMsat,
 		&routing.RestrictParams{
-			FeeLimit:  feeLimit,
-			CltvLimit: s.cfg.RouterBackend.MaxTotalTimelock,
+			FeeLimit:          feeLimit,
+			CltvLimit:         s.cfg.RouterBackend.MaxTotalTimelock,
+			ProbabilitySource: mc.GetProbability,
 		}, nil, nil, s.cfg.RouterBackend.DefaultFinalCltvDelta,
 	)
 	if err != nil {


### PR DESCRIPTION
Fixes  #4594.

When using `routerrpc.EstimateRouteFee`, the routing algorithm is invoked without setting a probability source which results in a crash in the router.