### PR TITLE
mobile: re-initialize listeners via RecreateListeners

### DIFF
--- a/lnrpc/Dockerfile
+++ b/lnrpc/Dockerfile
@@ -11,7 +11,7 @@ RUN apt-get update && apt-get install -y \
 ARG PROTOC_GEN_VERSION
 ARG GRPC_GATEWAY_VERSION
 
-ENV FALAFEL_VERSION="v0.8.1"
+ENV FALAFEL_VERSION="v0.9.0"
 ENV GOCACHE=/tmp/build/.cache
 ENV GOMODCACHE=/tmp/build/.modcache
 

--- a/mobile/bindings.go
+++ b/mobile/bindings.go
@@ -31,6 +31,11 @@ var lndStarted int32
 // current app directory in order to ensure lnd has the permissions needed to
 // write to it.
 func Start(extraArgs string, rpcReady Callback) {
+	// (Re-)initialize the in-mem gRPC listeners we're going to give to lnd.
+	// This is required each time lnd is started, because when lnd shuts
+	// down, the in-mem listeners are closed.
+	RecreateListeners()
+
 	// Split the argument string on "--" to get separated command line
 	// arguments.
 	var splitArgs []string


### PR DESCRIPTION
This PR updates the mobile package to work with falafel changes purposed in this PR: https://github.com/lightninglabs/falafel/pull/8.

It is also is a part of an on-going work to address mobile restarting problems #4492.

N.B: the falafel changes has to be merged before this PR can be merged.

Fixes https://github.com/lightningnetwork/lnd/issues/4492