### PR TITLE
build: bump version of master branch to v0.11.99-beta

### DIFF
--- a/build/version.go
+++ b/build/version.go
@@ -44,7 +44,7 @@ const (
 	AppMinor uint = 11
 
 	// AppPatch defines the application patch for this binary.
-	AppPatch uint = 0
+	AppPatch uint = 99
 
 	// AppPreRelease MUST only contain characters from semanticAlphabet
 	// per the semantic versioning spec.


### PR DESCRIPTION
As a preparation for external projects that require some features of the `master` branch to be in the not-yet-released version `v0.11.1-beta`, we tag the master branch with version `v0.11.99-beta` so the version check can be added in those projects.