### PR TITLE
routing: proportional attempt cost

### DIFF
--- a/lnrpc/routerrpc/config.go
+++ b/lnrpc/routerrpc/config.go
@@ -46,9 +46,8 @@ func DefaultConfig() *Config {
 		AprioriWeight:         routing.DefaultAprioriWeight,
 		MinRouteProbability:   routing.DefaultMinRouteProbability,
 		PenaltyHalfLife:       routing.DefaultPenaltyHalfLife,
-		AttemptCost: routing.DefaultPaymentAttemptPenalty.
-			ToSatoshis(),
-		MaxMcHistory: routing.DefaultMaxMcHistory,
+		AttemptCost:           routing.DefaultAttemptCost.ToSatoshis(),
+		MaxMcHistory:          routing.DefaultMaxMcHistory,
 	}
 
 	return &Config{

--- a/lnrpc/routerrpc/config.go
+++ b/lnrpc/routerrpc/config.go
@@ -47,6 +47,7 @@ func DefaultConfig() *Config {
 		MinRouteProbability:   routing.DefaultMinRouteProbability,
 		PenaltyHalfLife:       routing.DefaultPenaltyHalfLife,
 		AttemptCost:           routing.DefaultAttemptCost.ToSatoshis(),
+		AttemptCostPPM:        routing.DefaultAttemptCostPPM,
 		MaxMcHistory:          routing.DefaultMaxMcHistory,
 	}
 
@@ -62,6 +63,7 @@ func GetRoutingConfig(cfg *Config) *RoutingConfig {
 		AprioriWeight:         cfg.AprioriWeight,
 		MinRouteProbability:   cfg.MinRouteProbability,
 		AttemptCost:           cfg.AttemptCost,
+		AttemptCostPPM:        cfg.AttemptCostPPM,
 		PenaltyHalfLife:       cfg.PenaltyHalfLife,
 		MaxMcHistory:          cfg.MaxMcHistory,
 	}

--- a/lnrpc/routerrpc/routing_config.go
+++ b/lnrpc/routerrpc/routing_config.go
@@ -32,7 +32,13 @@ type RoutingConfig struct {
 	// AttemptCost is the fixed virtual cost in path finding of a failed
 	// payment attempt. It is used to trade off potentially better routes
 	// against their probability of succeeding.
-	AttemptCost btcutil.Amount `long:"attemptcost" description:"The (virtual) cost in sats of a failed payment attempt"`
+	AttemptCost btcutil.Amount `long:"attemptcost" description:"The fixed (virtual) cost in sats of a failed payment attempt"`
+
+	// AttemptCostPPM is the proportional virtual cost in path finding of a
+	// failed payment attempt. It is used to trade off potentially better
+	// routes against their probability of succeeding. This parameter is
+	// expressed in parts per million of the total payment amount.
+	AttemptCostPPM int64 `long:"attemptcostppm" description:"The proportional (virtual) cost in sats of a failed payment attempt expressed in parts per million of the total payment amount"`
 
 	// MaxMcHistory defines the maximum number of payment results that
 	// are held on disk by mission control.

--- a/lnrpc/routerrpc/routing_config.go
+++ b/lnrpc/routerrpc/routing_config.go
@@ -29,9 +29,9 @@ type RoutingConfig struct {
 	// channel is back at 50% probability.
 	PenaltyHalfLife time.Duration `long:"penaltyhalflife" description:"Defines the duration after which a penalized node or channel is back at 50% probability"`
 
-	// AttemptCost is the virtual cost in path finding weight units of
-	// executing a payment attempt that fails. It is used to trade off
-	// potentially better routes against their probability of succeeding.
+	// AttemptCost is the fixed virtual cost in path finding of a failed
+	// payment attempt. It is used to trade off potentially better routes
+	// against their probability of succeeding.
 	AttemptCost btcutil.Amount `long:"attemptcost" description:"The (virtual) cost in sats of a failed payment attempt"`
 
 	// MaxMcHistory defines the maximum number of payment results that

--- a/routing/integrated_routing_context_test.go
+++ b/routing/integrated_routing_context_test.go
@@ -65,8 +65,8 @@ func newIntegratedRoutingContext(t *testing.T) *integratedRoutingContext {
 		},
 
 		pathFindingCfg: PathFindingConfig{
-			PaymentAttemptPenalty: 1000,
-			MinProbability:        0.01,
+			AttemptCost:    1000,
+			MinProbability: 0.01,
 		},
 
 		source: source,

--- a/routing/pathfind.go
+++ b/routing/pathfind.go
@@ -45,11 +45,10 @@ type pathFinder = func(g *graphParams, r *RestrictParams,
 	[]*channeldb.ChannelEdgePolicy, error)
 
 var (
-	// DefaultPaymentAttemptPenalty is the virtual cost in path finding weight
-	// units of executing a payment attempt that fails. It is used to trade
-	// off potentially better routes against their probability of
-	// succeeding.
-	DefaultPaymentAttemptPenalty = lnwire.NewMSatFromSatoshis(100)
+	// DefaultAttemptCost is the default virtual cost in path finding of a
+	// failed payment attempt. It is used to trade off potentially better
+	// routes against their probability of succeeding.
+	DefaultAttemptCost = lnwire.NewMSatFromSatoshis(100)
 
 	// DefaultMinRouteProbability is the default minimum probability for routes
 	// returned from findPath.
@@ -315,11 +314,10 @@ type RestrictParams struct {
 // PathFindingConfig defines global parameters that control the trade-off in
 // path finding between fees and probabiity.
 type PathFindingConfig struct {
-	// PaymentAttemptPenalty is the virtual cost in path finding weight
-	// units of executing a payment attempt that fails. It is used to trade
-	// off potentially better routes against their probability of
-	// succeeding.
-	PaymentAttemptPenalty lnwire.MilliSatoshi
+	// AttemptCost is the virtual cost in path finding of a failed
+	// payment attempt. It is used to trade off potentially better routes
+	// against their probability of succeeding.
+	AttemptCost lnwire.MilliSatoshi
 
 	// MinProbability defines the minimum success probability of the
 	// returned route.
@@ -644,7 +642,7 @@ func findPath(g *graphParams, r *RestrictParams, cfg *PathFindingConfig,
 		// probability.
 		tempDist := getProbabilityBasedDist(
 			tempWeight, probability,
-			int64(cfg.PaymentAttemptPenalty),
+			int64(cfg.AttemptCost),
 		)
 
 		// If there is already a best route stored, compare this

--- a/routing/pathfind_test.go
+++ b/routing/pathfind_test.go
@@ -2467,9 +2467,9 @@ func TestProbabilityRouting(t *testing.T) {
 		// to the same total route probability. In both cases the three
 		// hop route should be the best route. The three hop route has a
 		// probability of 0.5 * 0.8 = 0.4. The fee is 5 (chan 10) + 8
-		// (chan 11) = 13. Path finding distance should work out to: 13
-		// + 10 (attempt penalty) / 0.4 = 38. The two hop route is 25 +
-		// 10 / 0.7 = 39.
+		// (chan 11) = 13. The attempt cost is 9 + 1% * 100 = 10. Path
+		// finding distance should work out to: 13 + 10 (attempt
+		// penalty) / 0.4 = 38. The two hop route is 25 + 10 / 0.7 = 39.
 		{
 			name: "three hop 1",
 			p10:  0.8, p11: 0.5, p20: 0.7,
@@ -2483,6 +2483,21 @@ func TestProbabilityRouting(t *testing.T) {
 			minProbability: 0.1,
 			expectedChan:   10,
 			amount:         100,
+		},
+
+		// If a larger amount is sent, the effect of the proportional
+		// attempt cost becomes more noticeable. This amount in this
+		// test brings the attempt cost to 9 + 1% * 300 = 12 sat. The
+		// three hop path finding distance should work out to: 13 + 12
+		// (attempt penalty) / 0.4 = 43. The two hop route is 25 + 12 /
+		// 0.7 = 42. For this higher amount, the two hop route is
+		// expected to be selected.
+		{
+			name: "two hop high amount",
+			p10:  0.8, p11: 0.5, p20: 0.7,
+			minProbability: 0.1,
+			expectedChan:   20,
+			amount:         300,
 		},
 
 		// If the probability of the two hop route is increased, its
@@ -2589,7 +2604,8 @@ func testProbabilityRouting(t *testing.T, paymentAmt btcutil.Amount,
 	}
 
 	ctx.pathFindingConfig = PathFindingConfig{
-		AttemptCost:    lnwire.NewMSatFromSatoshis(10),
+		AttemptCost:    lnwire.NewMSatFromSatoshis(9),
+		AttemptCostPPM: 10000,
 		MinProbability: minProbability,
 	}
 

--- a/routing/pathfind_test.go
+++ b/routing/pathfind_test.go
@@ -2582,8 +2582,8 @@ func testProbabilityRouting(t *testing.T, p10, p11, p20, minProbability float64,
 	}
 
 	ctx.pathFindingConfig = PathFindingConfig{
-		PaymentAttemptPenalty: lnwire.NewMSatFromSatoshis(10),
-		MinProbability:        minProbability,
+		AttemptCost:    lnwire.NewMSatFromSatoshis(10),
+		MinProbability: minProbability,
 	}
 
 	path, err := ctx.findPath(target, paymentAmt)
@@ -2656,7 +2656,7 @@ func TestEqualCostRouteSelection(t *testing.T) {
 	}
 
 	ctx.pathFindingConfig = PathFindingConfig{
-		PaymentAttemptPenalty: lnwire.NewMSatFromSatoshis(1),
+		AttemptCost: lnwire.NewMSatFromSatoshis(1),
 	}
 
 	path, err := ctx.findPath(target, paymentAmt)

--- a/routing/router_test.go
+++ b/routing/router_test.go
@@ -79,8 +79,8 @@ func createTestCtxFromGraphInstance(startingHeight uint32, graphInstance *testGr
 	chainView := newMockChainView(chain)
 
 	pathFindingConfig := PathFindingConfig{
-		MinProbability:        0.01,
-		PaymentAttemptPenalty: 100,
+		MinProbability: 0.01,
+		AttemptCost:    100,
 	}
 
 	mcConfig := &MissionControlConfig{

--- a/sample-lnd.conf
+++ b/sample-lnd.conf
@@ -619,8 +619,12 @@ litecoin.node=ltcd
 ; probability (default: 1h0m0s)
 ; routerrpc.penaltyhalflife=2h                            
 
-; The (virtual) cost in sats of a failed payment attempt (default: 100)
-; routerrpc.attemptcost=90                                
+; The (virtual) fixed cost in sats of a failed payment attempt (default: 100)
+; routerrpc.attemptcost=90     
+
+; The (virtual) proportional cost in ppm of the total amount of a failed payment
+; attempt (default: 1000)
+; routerrpc.attemptcostppm=900
 
 ; The maximum number of payment results that are held on disk by mission control
 ; (default: 1000)

--- a/server.go
+++ b/server.go
@@ -724,14 +724,16 @@ func newServer(cfg *Config, listenAddrs []net.Addr,
 	}
 
 	srvrLog.Debugf("Instantiating payment session source with config: "+
-		"AttemptCost=%v, MinRouteProbability=%v",
+		"AttemptCost=%v + %v%%, MinRouteProbability=%v",
 		int64(routingConfig.AttemptCost),
+		float64(routingConfig.AttemptCostPPM)/10000,
 		routingConfig.MinRouteProbability)
 
 	pathFindingConfig := routing.PathFindingConfig{
 		AttemptCost: lnwire.NewMSatFromSatoshis(
 			routingConfig.AttemptCost,
 		),
+		AttemptCostPPM: routingConfig.AttemptCostPPM,
 		MinProbability: routingConfig.MinRouteProbability,
 	}
 

--- a/server.go
+++ b/server.go
@@ -724,12 +724,12 @@ func newServer(cfg *Config, listenAddrs []net.Addr,
 	}
 
 	srvrLog.Debugf("Instantiating payment session source with config: "+
-		"PaymentAttemptPenalty=%v, MinRouteProbability=%v",
+		"AttemptCost=%v, MinRouteProbability=%v",
 		int64(routingConfig.AttemptCost),
 		routingConfig.MinRouteProbability)
 
 	pathFindingConfig := routing.PathFindingConfig{
-		PaymentAttemptPenalty: lnwire.NewMSatFromSatoshis(
+		AttemptCost: lnwire.NewMSatFromSatoshis(
 			routingConfig.AttemptCost,
 		),
 		MinProbability: routingConfig.MinRouteProbability,


### PR DESCRIPTION
In https://github.com/lightningnetwork/lnd/pull/2802 probability based routing was introduced. One of the control parameters introduced is the payment attempt cost.

The payment attempt cost is a virtual cost that is assigned to a failed payment attempt. This parameter influences the trade off between cheap and reliable routes. Specifically it adds an extra term to the pathfinding cost function of `attempt_cost / probability`.

Probability estimation is based on past failures and successes. The impact of failures on probability estimates diminishes relatively quickly (default "half life time" is one hour), but success experiences keep having a constant effect on probability until a failure happens.

For a presentation about mission control, see https://twitter.com/joostjgr/status/1186177262238031872.

For nodes that aren't continuously sending payments and use default mission control parameters, it is likely that failures don't have much impact on mission control performance beyond the currently active payment. For those nodes, recorded information about previously successful routes is the main driver for pathfinding.

The probability estimate is 60% (by default) for unknown hops (or hops with older failures recorded) and 95% for previously successful hops.

Suppose:
* There is a route S through a success hop with routing fee 0.1%
* There is a route U though an unknown hop with routing fee 0.01%
* We are sending 4M sats

What should the attempt cost `c` be set to for pathfinding to choose route S?
`4M * 0.1% + c / 0.95 = 4M * 0.01% + c / 0.6`
Solving for `c` results in an attempt cost = 5863 sats.

So we need to set a pretty high attempt cost to not get distracted by unknown routes. In the reality of the Lightning Network, these unknown routes do often fail and cause a lengthy payment process. Good liquidity isn't the cheapest liquidity generally.

The current default attempt cost is set at 100 sat. For the scenario described above with a relatively large gap in fees and a mid-size payment amount, the default setting would effectively disable probability based routing and lead to a lot of exploration even though successful routes may be known.

One thing that becomes clear is that an absolute attempt cost is unlikely to work for every payment amount. This PR therefore introduces an additional control parameter that allows setting a proportional attempt cost as well. The goal of this is to improve the default pathfinding performance in particular for large payment amounts.