### PR TITLE
config: prevent displaying usage twice if --help was requested

### DIFF
--- a/cmd/lnd/main.go
+++ b/cmd/lnd/main.go
@@ -14,8 +14,14 @@ func main() {
 	// function will also set up logging properly.
 	loadedConfig, err := lnd.LoadConfig()
 	if err != nil {
-		_, _ = fmt.Fprintln(os.Stderr, err)
-		os.Exit(1)
+		if e, ok := err.(*flags.Error); !ok || e.Type != flags.ErrHelp {
+			// Print error if not due to help request.
+			_, _ = fmt.Fprintln(os.Stderr, err)
+			os.Exit(1)
+		}
+
+		// Help was requested, exit normally.
+		os.Exit(0)
 	}
 
 	// Hook interceptor for os signals.
@@ -26,14 +32,10 @@ func main() {
 
 	// Call the "real" main in a nested manner so the defers will properly
 	// be executed in the case of a graceful shutdown.
-	err = lnd.Main(
+	if err := lnd.Main(
 		loadedConfig, lnd.ListenerCfg{}, signal.ShutdownChannel(),
-	)
-	if err != nil {
-		if e, ok := err.(*flags.Error); ok && e.Type == flags.ErrHelp {
-		} else {
-			_, _ = fmt.Fprintln(os.Stderr, err)
-		}
+	); err != nil {
+		_, _ = fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
 	}
 }


### PR DESCRIPTION
Recently discovered that we display the help twice when `--help` is requested.
This PR is a trivial fix for that.