### PR TITLE
docs: fix "tor.active" item in sample-lnd.conf

### DIFF
--- a/sample-lnd.conf
+++ b/sample-lnd.conf
@@ -474,7 +474,7 @@ litecoin.node=ltcd
 
 [tor]
 ; Allow outbound and inbound connections to be routed through Tor
-; tor.active                                            
+; tor.active=true                                            
 
 ; The port that Tor's exposed SOCKS5 proxy is listening on. Using Tor allows
 ; outbound-only connections (listening will be disabled) -- NOTE port must be


### PR DESCRIPTION
When starting up with lnd.conf that contains the sample line
"tor.active", lnd crashes and prints the error:

malformed key=value (tor.active)

Using "tor.active=true" instead works as expected.