### PR TITLE
lncli: print all permission actions

### DIFF
--- a/cmd/lncli/cmd_macaroon.go
+++ b/cmd/lncli/cmd_macaroon.go
@@ -399,8 +399,12 @@ func printMacaroon(ctx *cli.Context) error {
 		content.Caveats = append(content.Caveats, string(caveat.Id))
 	}
 	for _, op := range decodedID.Ops {
-		permission := fmt.Sprintf("%s:%s", op.Entity, op.Actions[0])
-		content.Permissions = append(content.Permissions, permission)
+		for _, action := range op.Actions {
+			permission := fmt.Sprintf("%s:%s", op.Entity, action)
+			content.Permissions = append(
+				content.Permissions, permission,
+			)
+		}
 	}
 
 	printJSON(content)


### PR DESCRIPTION
Due to a misunderstanding about how the entities/actions are encoded
inside the macaroon, only the first action was printed per entity.
Even though we add them as separate pairs in the macaroon service (for
example "offchain:read" and "offchain:write"), they are grouped in the
serialized macaroon ("offchain:read,write").

