### PR TITLE
healtcheck: add extra build tags+files for netbsd and openbsd

### DIFF
--- a/healthcheck/diskcheck_netbsd.go
+++ b/healthcheck/diskcheck_netbsd.go
@@ -1,13 +1,12 @@
-// +build !windows,!solaris,!netbsd,!openbsd
-
 package healthcheck
 
-import "syscall"
+import "golang.org/x/sys/unix"
 
-// AvailableDiskSpace returns ratio of available disk space to total capacity.
+// AvailableDiskSpace returns ratio of available disk space to total capacity
+// for solaris.
 func AvailableDiskSpace(path string) (float64, error) {
-	s := syscall.Statfs_t{}
-	err := syscall.Statfs(path, &s)
+	s := unix.Statvfs_t{}
+	err := unix.Statvfs(path, &s)
 	if err != nil {
 		return 0, err
 	}

--- a/healthcheck/diskcheck_openbsd.go
+++ b/healthcheck/diskcheck_openbsd.go
@@ -1,0 +1,17 @@
+package healthcheck
+
+import "golang.org/x/sys/unix"
+
+// AvailableDiskSpace returns ratio of available disk space to total capacity
+// for solaris.
+func AvailableDiskSpace(path string) (float64, error) {
+	s := unix.Statfs_t{}
+	err := unix.Statfs(path, &s)
+	if err != nil {
+		return 0, err
+	}
+
+	// Calculate our free blocks/total blocks to get our total ratio of
+	// free blocks.
+	return float64(s.F_bfree) / float64(s.F_blocks), nil
+}


### PR DESCRIPTION
Without these changes, the disk check portions won't compile on these
platforms.

