### PR TITLE
docs: remove duplicate "tor.streamisolation" option from sample-lnd.conf

### DIFF
--- a/sample-lnd.conf
+++ b/sample-lnd.conf
@@ -517,11 +517,6 @@ litecoin.node=ltcd
 ; in with lnd's traffic.
 ; tor.streamisolation=true
 
-
-; Enable Tor stream isolation by randomizing user credentials for each
-; connection.
-; tor.streamisolation=true
-
 ; The host:port that Tor is listening on for Tor control connections (default:
 ; localhost:9051)
 ; tor.control=localhost:9091                                      


### PR DESCRIPTION
This PR removes the duplicate `tor.streamisolation` option from `sample-lnd.conf` example config file. It looks like the option was accidentally added by 2284d8c.