### PR TITLE
GitHub workflow: Check all command line flags are described in sample-lnd.conf

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -13,6 +13,7 @@
 - [ ] Code has been formatted with `go fmt`
 - [ ] Protobuf files (`lnrpc/**/*.proto`) have been formatted with
   `make rpc-format` and compiled with `make rpc`
+- [ ] New configuration flags have been added to `sample-lnd.conf`
 - [ ] For code and documentation: lines are wrapped at 80 characters
   (the tab character should be counted as 8 characters, not 4, as some IDEs do
   per default)

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -203,6 +203,44 @@ jobs:
         run: go build --tags="mobile" ./mobile
 
   ########################
+  # sample configuration check
+  ########################
+  sample-conf-check:
+    name: sample configuration check
+    runs-on: ubuntu-latest
+    steps:
+      - name: git checkout
+        uses: actions/checkout@v2
+
+      - name: go cache
+        uses: actions/cache@v1
+        with:
+          path: /home/runner/work/go
+          key: lnd-${{ runner.os }}-go-${{ env.GO_VERSION }}-${{ github.job }}-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            lnd-${{ runner.os }}-go-${{ env.GO_VERSION }}-${{ github.job }}-${{ hashFiles('**/go.sum') }}
+            lnd-${{ runner.os }}-go-${{ env.GO_VERSION }}-${{ github.job }}-
+            lnd-${{ runner.os }}-go-${{ env.GO_VERSION }}-
+            lnd-${{ runner.os }}-go-
+
+      - name: setup go ${{ env.GO_VERSION }}
+        uses: actions/setup-go@v2
+        with:
+          go-version: '~${{ env.GO_VERSION }}'
+
+      - name: download cache
+        uses: actions/cache@v1
+        with:
+          path: /home/runner/work/download_cache
+          key: lnd-${{ runner.os }}-download-${{ hashFiles('**/install_travis_proto.sh') }}
+          restore-keys: |
+            lnd-${{ runner.os }}-download-${{ hashFiles('**/install_travis_proto.sh') }}
+            lnd-${{ runner.os }}-download-
+
+      - name: check all command line flags exist in sample-lnd.conf file
+        run: make sample-conf-check
+
+  ########################
   # run unit tests
   ########################
   unit-test:

--- a/Makefile
+++ b/Makefile
@@ -254,6 +254,10 @@ rpc-check: rpc
 	for rpc in $$(find lnrpc/ -name "*.proto" | $(XARGS) awk '/    rpc /{print $$2}'); do if ! grep -q $$rpc lnrpc/rest-annotations.yaml; then echo "RPC $$rpc not added to lnrpc/rest-annotations.yaml"; exit 1; fi; done
 	if test -n "$$(git describe --dirty | grep dirty)"; then echo "Protos not properly formatted or not compiled with v3.4.0"; git status; git diff; exit 1; fi
 
+sample-conf-check:
+	@$(call print, "Making sure every flag has an example in the sample-lnd.conf file")
+	for flag in $$(GO_FLAGS_COMPLETION=1 go run -tags="$(RELEASE_TAGS)" $(PKG)/cmd/lnd -- | grep -v help | cut -c3-); do if ! grep -q $$flag sample-lnd.conf; then echo "Command line flag --$$flag not added to sample-lnd.conf"; exit 1; fi; done
+
 mobile-rpc: falafel goimports
 	@$(call print, "Creating mobile RPC from protos.")
 	cd ./mobile; ./gen_bindings.sh $(FALAFEL_COMMIT)

--- a/sample-lnd.conf
+++ b/sample-lnd.conf
@@ -110,7 +110,7 @@
 ; A period to wait before for closing channels with outgoing htlcs that have 
 ; timed out and are a result of this nodes instead payment. In addition to our 
 ; current block based deadline, is specified this grace period will also be taken
-; into account.  
+; into account.
 ; payments-expiration-grace-period=30
 
 
@@ -254,7 +254,7 @@
 ; stable for chan-enable-timeout before the disable update is sent.
 ; (default: 20m0s)
 ; chan-disable-timeout=22m
-                                                              
+
 ; The polling interval between attempts to detect if an active channel has become
 ; inactive due to its peer going offline. (default: 1m0s)
 ; chan-status-sample-interval=2m
@@ -309,7 +309,7 @@
 ; partial protection of a channel peer disconnecting from us if cooperative
 ; close is attempted with a different script.
 ; enable-upfront-shutdown=true
- 
+
 ; If true, spontaneous payments through keysend will be accepted. [experimental]
 ; accept-keysend=true
 
@@ -661,7 +661,7 @@ litecoin.node=ltcd
 
 [tor]
 ; Allow outbound and inbound connections to be routed through Tor
-; tor.active=true                                            
+; tor.active=true
 
 ; The port that Tor's exposed SOCKS5 proxy is listening on. Using Tor allows
 ; outbound-only connections (listening will be disabled) -- NOTE port must be
@@ -681,27 +681,27 @@ litecoin.node=ltcd
 
 ; The host:port that Tor is listening on for Tor control connections (default:
 ; localhost:9051)
-; tor.control=localhost:9091                                      
+; tor.control=localhost:9091
 
 ; IP address that Tor should use as the target of the hidden service
-; tor.targetipaddress=                                  
- 
+; tor.targetipaddress=
+
 ; The password used to arrive at the HashedControlPassword for the control port.
 ; If provided, the HASHEDPASSWORD authentication method will be used instead of
 ; the SAFECOOKIE one.
-; tor.password=plsdonthackme                                         
- 
+; tor.password=plsdonthackme
+
 ; Automatically set up a v2 onion service to listen for inbound connections
 ; tor.v2=true
- 
+
 ; Automatically set up a v3 onion service to listen for inbound connections
 ; tor.v3=true
- 
+
 ; The path to the private key of the onion service being created
-; tor.privatekeypath=/path/to/torkey                                   
- 
+; tor.privatekeypath=/path/to/torkey
+
 ;The path to the private key of the watchtower onion service being created
-; tor.watchtowerkeypath=/other/path/                                
+; tor.watchtowerkeypath=/other/path/
 
 [watchtower]
 ; Enable integrated watchtower listening on :9911 by default.
@@ -807,22 +807,22 @@ litecoin.node=ltcd
 [routerrpc]
 ; Minimum required route success probability to attempt the payment (default:
 ; 0.01)
-; routerrpc.minrtprob=1             
+; routerrpc.minrtprob=1
 
 ; Assumed success probability of a hop in a route when no other information is
 ; available. (default: 0.6)
-; routerrpc.apriorihopprob=0.2                             
+; routerrpc.apriorihopprob=0.2
 
 ; Weight of the a priori probability in success probability estimation. Valid
 ; values are in [0, 1]. (default: 0.5)
-; routerrpc.aprioriweight=0.3                              
+; routerrpc.aprioriweight=0.3
 
 ; Defines the duration after which a penalized node or channel is back at 50%
 ; probability (default: 1h0m0s)
-; routerrpc.penaltyhalflife=2h                            
+; routerrpc.penaltyhalflife=2h
 
 ; The (virtual) fixed cost in sats of a failed payment attempt (default: 100)
-; routerrpc.attemptcost=90     
+; routerrpc.attemptcost=90
 
 ; The (virtual) proportional cost in ppm of the total amount of a failed payment
 ; attempt (default: 1000)
@@ -830,7 +830,7 @@ litecoin.node=ltcd
 
 ; The maximum number of payment results that are held on disk by mission control
 ; (default: 1000)
-; routerrpc.maxmchistory=900                              
+; routerrpc.maxmchistory=900
 
 ; Path to the router macaroon
 ; routerrpc.routermacaroonpath=~/.lnd/data/chain/bitcoin/simnet/router.macaroon
@@ -838,22 +838,22 @@ litecoin.node=ltcd
 [workers]
 ; Maximum number of concurrent read pool workers. This number should be
 ; proportional to the number of peers. (default: 100)
-; workers.read=200                                         
+; workers.read=200
 
 ; Maximum number of concurrent write pool workers. This number should be
 ; proportional to the number of CPUs on the host.  (default: 8)
-; workers.write=8                                       
+; workers.write=8
 
 ; Maximum number of concurrent sig pool workers. This number should be
 ; proportional to the number of CPUs on the host. (default: 8)
-; workers.sig=4                                          
+; workers.sig=4
 
 [caches]
 
 ; Maximum number of entries contained in the reject cache, which is used to speed
 ; up filtering of new channel announcements and channel updates from peers. Each
 ; entry requires 25 bytes. (default: 50000)
-; caches.reject-cache-size=900000                            
+; caches.reject-cache-size=900000
 
 ; Maximum number of entries contained in the channel cache, which is used to
 ; reduce memory allocations from gossip queries from peers. Each entry requires
@@ -871,7 +871,7 @@ litecoin.node=ltcd
 [db]
 ; The selected database backend. The current default backend is "bolt". lnd
 ; also has experimental support for etcd, a replicated backend.
-; db.backend=bolt                                           
+; db.backend=bolt
 
 [etcd]
 ; Etcd database host.
@@ -879,21 +879,21 @@ litecoin.node=ltcd
 
 ; Etcd database user.
 ; db.etcd.user=userscopedforlnd
- 
+
 ; Password for the database user.
 ; db.etcd.pass=longandsekrit
 
 ; Path to the TLS certificate for etcd RPC.
 ; db.etcd.cert_file=/key/path
- 
+
 ; Path to the TLS private key for etcd RPC.
 ; db.etcd.key_file=/a/path
- 
+
 ; Whether we intend to skip TLS verification
-; db.etcd.insecure_skip_verify=true                         
- 
+; db.etcd.insecure_skip_verify=true
+
 ; Whether to collect etcd commit stats.
-; db.etcd.collect_stats=true                                 
+; db.etcd.collect_stats=true
 
 [bolt]
 ; If true, prevents the database from syncing its freelist to disk. 

--- a/sample-lnd.conf
+++ b/sample-lnd.conf
@@ -1,5 +1,12 @@
 ; Example configuration for lnd.
 ;
+; The default location for this file is in ~/.lnd/lnd.conf on POSIX OSes,
+; $LOCALAPPDATA/Lnd/lnd.conf on Windows,
+; ~/Library/Application Support/Lnd/lnd.conf on Mac OS and $home/lnd/lnd.conf on
+; Plan9.
+; The default location of this file can be overwritten by specifying the
+; --configfile= flag when starting lnd.
+;
 ; Boolean values can be specified as true/false or 1/0.
 
 [Application Options]
@@ -44,6 +51,10 @@
 ; expiring, or if any parameters related to extra IPs or domains in the cert 
 ; change.
 ; tlsautorefresh=true
+
+; Do not include the interface IPs or the system hostname in TLS certificate,
+; use first --tlsextradomain as Common Name instead, if set.
+; tlsdisableautofill=true
 
 ; A list of domains for lnd to periodically resolve, and advertise the resolved
 ; IPs for the backing node. This is useful for users that only have a dynamic IP,
@@ -159,6 +170,20 @@
 ; support devices behind multiple NATs.
 ; nat=true
 
+; Disable listening for incoming peer connections.
+; nolisten=true
+
+; Disable REST API.
+; norest=true
+
+; Shortest backoff when reconnecting to persistent peers. Valid time units are
+; {s, m, h}.
+; minbackoff=1s
+
+; Longest backoff when reconnecting to persistent peers. Valid time units are
+; {s, m, h}.
+; maxbackoff=1h
+
 ; The timeout value for network connections in seconds, default to 120 seconds.
 ; Valid uints are {ms, s, m, h}.
 ; connectiontimeout=120s
@@ -177,13 +202,29 @@
 ; 65536. The profile can be access at: http://localhost:<PORT>/debug/pprof/.
 ; profile=
 
+; DEPRECATED: Allows the rpcserver to intentionally disconnect from peers with
+; open channels. THIS FLAG WILL BE REMOVED IN 0.10.0.
+; unsafe-disconnect=false
+
+; Causes a link to replay the adds on its commitment txn after starting up, this
+; enables testing of the sphinx replay logic.
+; unsafe-replay=true
+
 ; The maximum number of incoming pending channels permitted per peer.
 ; maxpendingchannels=1
+
+; The target location of the channel backup file.
+; backupfilepath=~/.lnd/data/chain/bitcoin/simnet/channel.backup
 
 ; If true, then automatic network bootstrapping will not be attempted. This
 ; means that your node won't attempt to automatically seek out peers on the
 ; network.
 ; nobootstrap=true
+
+; If true, NO SEED WILL BE EXPOSED -- EVER, AND THE WALLET WILL BE ENCRYPTED
+; USING THE DEFAULT PASSPHRASE. THIS FLAG IS ONLY FOR TESTING AND SHOULD NEVER
+; BE USED ON MAINNET.
+; noseedbackup=true
 
 ; The smallest channel size (in satoshis) that we should accept. Incoming
 ; channels smaller than this will be rejected, default value 20000.
@@ -196,6 +237,11 @@
 ; Set this config option explicitly to restrict your maximum channel size
 ; to better align with your risk tolerance
 ; maxchansize=
+
+; The default max_htlc applied when opening or accepting channels. This value
+; limits the number of concurrent HTLCs that the remote party can add to the
+; commitment. The maximum possible value is 483.
+; default-remote-max-htlcs=483
 
 ; The duration that a peer connection must be stable before attempting to send a
 ; channel update to reenable or cancel a pending disables of the peer's channels
@@ -272,6 +318,12 @@
 ; automatically. [experimental]
 ; keysend-hold-time=true
 
+; If true, we'll attempt to garbage collect canceled invoices upon start.
+; gc-canceled-invoices-on-startup=true
+
+; If true, we'll delete newly canceled invoices on the fly.
+; gc-canceled-invoices-on-the-fly=true
+
 ; If true, our node will allow htlc forwards that arrive and depart on the same
 ; channel.
 ; allow-circular-route=true
@@ -298,6 +350,12 @@
 ; active.
 bitcoin.active=true
 
+; The directory to store the chain's data within.
+; bitcoin.chaindir=~/.lnd/data/chain/bitcoin
+
+; Use Bitcoin's main network.
+; bitcoin.mainnet=true
+
 ; Use Bitcoin's test network.
 ; bitcoin.testnet=true
 ;
@@ -321,8 +379,40 @@ bitcoin.node=btcd
 ; confirmations before we consider the channel active.
 ; bitcoin.defaultchanconfs=3
 
+; The default number of blocks we will require our channel counterparty to wait
+; before accessing its funds in case of unilateral close. If this is not set, we
+; will scale the value according to the channel size.
+; bitcoin.defaultremotedelay=144
+
+; The smallest HTLC we are willing to accept on our channels, in millisatoshi.
+; bitcoin.minhtlc=1
+
+; The smallest HTLC we are willing to send out on our channels, in millisatoshi.
+; bitcoin.minhtlcout=1000
+
+; The base fee in millisatoshi we will charge for forwarding payments on our
+; channels.
+; bitcoin.basefee=1000
+
+; The fee rate used when forwarding payments on our channels. The total fee
+; charged is basefee + (amount * feerate / 1000000), where amount is the
+; forwarded amount.
+; bitcoin.feerate=1
+
+; The CLTV delta we will subtract from a forwarded HTLC's timelock value.
+; bitcoin.timelockdelta=40
+
+; Used to help identify ourselves to other bitcoin peers (default: neutrino).
+; neutrino.useragentname=neutrino
+
+; Used to help identify ourselves to other bitcoin peers (default: 0.11.0-beta).
+; neutrino.useragentversion=0.11.0-beta
 
 [Btcd]
+
+; The base directory that contains the node's data, logs, configuration file,
+; etc.
+; btcd.dir=~/.btcd
 
 ; The host that your local btcd daemon is listening on. By default, this
 ; setting is assumed to be localhost with the default port for the current
@@ -350,6 +440,10 @@ bitcoin.node=btcd
 
 
 [Bitcoind]
+
+; The base directory that contains the node's data, logs, configuration file,
+; etc.
+; bitcoind.dir=~/.bitcoin
 
 ; The host that your local bitcoind daemon is listening on. By default, this
 ; setting is assumed to be localhost with the default port for the current
@@ -383,12 +477,32 @@ bitcoin.node=btcd
 ; neutrino compliant full nodes on the test network yet.
 ; neutrino.connect=
 
+; Max number of inbound and outbound peers.
+; 
+; NOTE: This value is currently unused.
+; neutrino.maxpeers=
+
 ; Add a peer to connect with at startup.
 ; neutrino.addpeer=
+
+; How long to ban misbehaving peers. Valid time units are {s, m, h}. Minimum 1
+; second.
+; 
+; NOTE: This value is currently unused.
+; neutrino.banduration=
+
+; Maximum allowed ban score before disconnecting and banning misbehaving peers.
+; 
+; NOTE: This value is currently unused.
+; neutrino.banthreshold=
 
 ; Set a URL source for fee estimates.
 ; neutrino.feeurl=
 
+; Optional filter header in height:hash format to assert the state of neutrino's
+; filter header chain on startup. If the assertion does not hold, then the
+; filter header chain will be re-synced from the genesis block.
+; neutrino.assertfilterheader=
 
 [Litecoin]
 
@@ -396,17 +510,60 @@ bitcoin.node=btcd
 ; active.
 ; litecoin.active=true
 
+; The directory to store the chain's data within.
+; litecoin.chaindir=~/.lnd/data/chain/litecoin
+
+; Use Litecoin's main network.
+; litecoin.mainnet=true
+
 ; Use Litecoin's test network.
 ; litecoin.testnet=true
+;
+; Use Litecoin's simulation test network
+; litecoin.simnet=true
 
-; Use the ltcd back-end
+; Use Litecoin's regression test network
+; litecoin.regtest=false
+
+; Use the ltcd back-end.
 litecoin.node=ltcd
 
-; Use the litecoind back-end
+; Use the litecoind back-end.
 ; litecoin.node=litecoind
 
+; The default number of confirmations a channel must have before it's considered
+; open. We'll require any incoming channel requests to wait this many
+; confirmations before we consider the channel active.
+; litecoin.defaultchanconfs=3
+
+; The default number of blocks we will require our channel counterparty to wait
+; before accessing its funds in case of unilateral close. If this is not set, we
+; will scale the value according to the channel size.
+; litecoin.defaultremotedelay=144
+
+; The smallest HTLC we are willing to accept on our channels, in millisatoshi.
+; litecoin.minhtlc=1
+
+; The smallest HTLC we are willing to send out on our channels, in millisatoshi.
+; litecoin.minhtlcout=1000
+
+; The base fee in millisatoshi we will charge for forwarding payments on our
+; channels.
+; litecoin.basefee=1000
+
+; The fee rate used when forwarding payments on our channels. The total fee
+; charged is basefee + (amount * feerate / 1000000), where amount is the
+; forwarded amount.
+; litecoin.feerate=1
+
+; The CLTV delta we will subtract from a forwarded HTLC's timelock value.
+; litecoin.timelockdelta=576
 
 [Ltcd]
+
+; The base directory that contains the node's data, logs, configuration file,
+; etc.
+; ltcd.dir=~/.ltcd
 
 ; The host that your local ltcd daemon is listening on. By default, this
 ; setting is assumed to be localhost with the default port for the current
@@ -434,6 +591,10 @@ litecoin.node=ltcd
 
 
 [Litecoind]
+
+; The base directory that contains the node's data, logs, configuration file,
+; etc.
+; litecoind.dir=~/.litecoin
 
 ; The host that your local litecoind daemon is listening on. By default, this
 ; setting is assumed to be localhost with the default port for the current
@@ -587,6 +748,11 @@ litecoin.node=ltcd
 ; specified in sat/byte, the default is 10 sat/byte.
 ; wtclient.sweep-fee-rate=10
 
+; (Deprecated) Specifies the URIs of private watchtowers to use in backing up
+; revoked states. URIs must be of the form <pubkey>@<addr>. Only 1 URI is
+; supported at this time, if none are provided the tower will not be enabled.
+; wtclient.private-tower-uris=
+
 [healthcheck]
 ; The number of times we should attempt to query our chain backend before
 ; gracefully shutting down. Set this value to 0 to disable this health check.
@@ -623,6 +789,21 @@ litecoin.node=ltcd
 ; value must be >= 1m.
 ; healthcheck.diskspace.interval=6h
 
+[signrpc]
+
+; Path to the signer macaroon.
+; signrpc.signermacaroonpath=~/.lnd/data/chain/bitcoin/simnet/signer.macaroon
+
+[walletrpc]
+
+; Path to the wallet kit macaroon.
+; walletrpc.walletkitmacaroonpath=~/.lnd/data/chain/bitcoin/simnet/walletkit.macaroon
+
+[chainrpc]
+
+; Path to the chain notifier macaroon.
+; chainrpc.notifiermacaroonpath=~/.lnd/data/chain/bitcoin/simnet/chainnotifier.macaroon
+
 [routerrpc]
 ; Minimum required route success probability to attempt the payment (default:
 ; 0.01)
@@ -652,7 +833,7 @@ litecoin.node=ltcd
 ; routerrpc.maxmchistory=900                              
 
 ; Path to the router macaroon
-; routerrpc.routermacaroonpath=                         
+; routerrpc.routermacaroonpath=~/.lnd/data/chain/bitcoin/simnet/router.macaroon
 
 [workers]
 ; Maximum number of concurrent read pool workers. This number should be


### PR DESCRIPTION
This PR adds a check to the GitHub workflow that checks that all command line flags of `lnd` that are available using the default build tags are described in the `sample-lnd.conf` file.

All currently missing flags are also added to that file with a separate commit.