### PR TITLE
signal: do not trap SIGABRT

### DIFF
--- a/signal/signal.go
+++ b/signal/signal.go
@@ -42,7 +42,6 @@ func Intercept() error {
 	signalsToCatch := []os.Signal{
 		os.Interrupt,
 		os.Kill,
-		syscall.SIGABRT,
 		syscall.SIGTERM,
 		syscall.SIGQUIT,
 	}


### PR DESCRIPTION
SIGABRT is used by the Go runtime to forcefully terminate all
goroutines, even if they are in a deadlocked state.

It is useful in development (to get a glimpse of any potential race or
hang conditions) and in production to forcefully terminate execution
when a standard SIGQUIT won't do.

This modifies the signal package to _not_ trap SIGABRT and let it be
handled in the standard way by the runtime.

