### PR TITLE
docs: fix sync-freelist documentation

### DIFF
--- a/sample-lnd.conf
+++ b/sample-lnd.conf
@@ -70,7 +70,7 @@
 ; the line below.
 ; no-macaroons=true
 
-; Enable free list syncing for the default bbolt database. This will increase
+; Enable free list syncing for the default bbolt database. This will decrease
 ; start up time, but can result in performance degradation for very large
 ; databases, and also result in higher memory usage. If "free list corruption"
 ; is detected, then this flag may resolve things.


### PR DESCRIPTION
The godocs [page](https://godoc.org/github.com/lightningnetwork/lnd#Config) for lnd mentions that a disabled `sync-freelist` translates to an increased startup time. This would mean it'd decrease the startup time when enabled, and is wrongly stated to do the opposite here.