### PR TITLE
fuzz/tlv: harnesses to test equality, encoding+decoding

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ BTCD_COMMIT := $(shell cat go.mod | \
 
 LINT_COMMIT := v1.18.0
 GOACC_COMMIT := ddc355013f90fea78d83d3a6c71f1d37ac07ecd5
-GOFUZZ_COMMIT := 21309f307f61
+GOFUZZ_COMMIT := 6a8e9d1f2415cf672ddbe864c2d4092287b33a21
 
 DEPGET := cd /tmp && GO111MODULE=on go get -v
 GOBUILD := GO111MODULE=on go build -v

--- a/fuzz/tlv/bytes32.go
+++ b/fuzz/tlv/bytes32.go
@@ -1,0 +1,49 @@
+// +build gofuzz
+
+package tlvfuzz
+
+import (
+	"bytes"
+
+	"github.com/lightningnetwork/lnd/tlv"
+)
+
+// Fuzz_bytes32 is used by go-fuzz.
+func Fuzz_bytes32(data []byte) int {
+	if len(data) > 32 {
+		return 1
+	}
+
+	r := bytes.NewReader(data)
+
+	var (
+		val  [32]byte
+		val2 [32]byte
+		buf  [8]byte
+		b    bytes.Buffer
+	)
+
+	if err := tlv.DBytes32(r, &val, &buf, 32); err != nil {
+		return 1
+	}
+
+	if err := tlv.EBytes32(&b, &val, &buf); err != nil {
+		return 1
+	}
+
+	if !bytes.Equal(b.Bytes(), data) {
+		panic("bytes not equal")
+	}
+
+	r2 := bytes.NewReader(b.Bytes())
+
+	if err := tlv.DBytes32(r2, &val2, &buf, 32); err != nil {
+		return 1
+	}
+
+	if !bytes.Equal(val[:], val2[:]) {
+		panic("values not equal")
+	}
+
+	return 1
+}

--- a/fuzz/tlv/bytes33.go
+++ b/fuzz/tlv/bytes33.go
@@ -1,0 +1,49 @@
+// +build gofuzz
+
+package tlvfuzz
+
+import (
+	"bytes"
+
+	"github.com/lightningnetwork/lnd/tlv"
+)
+
+// Fuzz_bytes33 is used by go-fuzz.
+func Fuzz_bytes33(data []byte) int {
+	if len(data) > 33 {
+		return 1
+	}
+
+	r := bytes.NewReader(data)
+
+	var (
+		val  [33]byte
+		val2 [33]byte
+		buf  [8]byte
+		b    bytes.Buffer
+	)
+
+	if err := tlv.DBytes33(r, &val, &buf, 33); err != nil {
+		return 1
+	}
+
+	if err := tlv.EBytes33(&b, &val, &buf); err != nil {
+		return 1
+	}
+
+	if !bytes.Equal(b.Bytes(), data) {
+		panic("bytes not equal")
+	}
+
+	r2 := bytes.NewReader(b.Bytes())
+
+	if err := tlv.DBytes33(r2, &val2, &buf, 33); err != nil {
+		return 1
+	}
+
+	if !bytes.Equal(val[:], val2[:]) {
+		panic("values not equal")
+	}
+
+	return 1
+}

--- a/fuzz/tlv/bytes64.go
+++ b/fuzz/tlv/bytes64.go
@@ -1,0 +1,49 @@
+// +build gofuzz
+
+package tlvfuzz
+
+import (
+	"bytes"
+
+	"github.com/lightningnetwork/lnd/tlv"
+)
+
+// Fuzz_bytes64 is used by go-fuzz.
+func Fuzz_bytes64(data []byte) int {
+	if len(data) > 64 {
+		return 1
+	}
+
+	r := bytes.NewReader(data)
+
+	var (
+		val  [64]byte
+		val2 [64]byte
+		buf  [8]byte
+		b    bytes.Buffer
+	)
+
+	if err := tlv.DBytes64(r, &val, &buf, 64); err != nil {
+		return 1
+	}
+
+	if err := tlv.EBytes64(&b, &val, &buf); err != nil {
+		return 1
+	}
+
+	if !bytes.Equal(b.Bytes(), data) {
+		panic("bytes not equal")
+	}
+
+	r2 := bytes.NewReader(b.Bytes())
+
+	if err := tlv.DBytes64(r2, &val2, &buf, 64); err != nil {
+		return 1
+	}
+
+	if !bytes.Equal(val[:], val2[:]) {
+		panic("values not equal")
+	}
+
+	return 1
+}

--- a/fuzz/tlv/pubkey.go
+++ b/fuzz/tlv/pubkey.go
@@ -1,0 +1,50 @@
+// +build gofuzz
+
+package tlvfuzz
+
+import (
+	"bytes"
+
+	"github.com/btcsuite/btcd/btcec"
+	"github.com/lightningnetwork/lnd/tlv"
+)
+
+// Fuzz_pubkey is used by go-fuzz.
+func Fuzz_pubkey(data []byte) int {
+	if len(data) > 33 {
+		return 1
+	}
+
+	r := bytes.NewReader(data)
+
+	var (
+		val  *btcec.PublicKey
+		val2 *btcec.PublicKey
+		buf  [8]byte
+		b    bytes.Buffer
+	)
+
+	if err := tlv.DPubKey(r, &val, &buf, 33); err != nil {
+		return 1
+	}
+
+	if err := tlv.EPubKey(&b, &val, &buf); err != nil {
+		return 1
+	}
+
+	if !bytes.Equal(b.Bytes(), data) {
+		panic("bytes not equal")
+	}
+
+	r2 := bytes.NewReader(b.Bytes())
+
+	if err := tlv.DPubKey(r2, &val2, &buf, 33); err != nil {
+		return 1
+	}
+
+	if !val.IsEqual(val2) {
+		panic("values not equal")
+	}
+
+	return 1
+}

--- a/fuzz/tlv/stream.go
+++ b/fuzz/tlv/stream.go
@@ -1,0 +1,50 @@
+// +build gofuzz
+
+package tlvfuzz
+
+import (
+	"bytes"
+	"github.com/btcsuite/btcd/btcec"
+	"github.com/lightningnetwork/lnd/tlv"
+)
+
+// Fuzz_stream is used by go-fuzz.
+func Fuzz_stream(data []byte) int {
+	var (
+		val  uint8
+		val2 uint16
+		val3 uint32
+		val4 uint64
+		val5 [32]byte
+		val6 [33]byte
+		val7 *btcec.PublicKey
+		val8 [64]byte
+		val9 []byte
+
+		b bytes.Buffer
+	)
+
+	stream := tlv.MustNewStream(
+		tlv.MakePrimitiveRecord(1, &val),
+		tlv.MakePrimitiveRecord(2, &val2),
+		tlv.MakePrimitiveRecord(3, &val3),
+		tlv.MakePrimitiveRecord(4, &val4),
+		tlv.MakePrimitiveRecord(5, &val5),
+		tlv.MakePrimitiveRecord(6, &val6),
+		tlv.MakePrimitiveRecord(7, &val7),
+		tlv.MakePrimitiveRecord(8, &val8),
+		tlv.MakePrimitiveRecord(9, &val9),
+	)
+
+	r := bytes.NewReader(data)
+
+	if err := stream.Decode(r); err != nil {
+		return 1
+	}
+
+	if err := stream.Encode(&b); err != nil {
+		return 1
+	}
+
+	return 1
+}

--- a/fuzz/tlv/uint16.go
+++ b/fuzz/tlv/uint16.go
@@ -1,0 +1,49 @@
+// +build gofuzz
+
+package tlvfuzz
+
+import (
+	"bytes"
+
+	"github.com/lightningnetwork/lnd/tlv"
+)
+
+// Fuzz_uint16 is used by go-fuzz.
+func Fuzz_uint16(data []byte) int {
+	if len(data) > 2 {
+		return 1
+	}
+
+	r := bytes.NewReader(data)
+
+	var (
+		val  uint16
+		val2 uint16
+		buf  [8]byte
+		b    bytes.Buffer
+	)
+
+	if err := tlv.DUint16(r, &val, &buf, 2); err != nil {
+		return 1
+	}
+
+	if err := tlv.EUint16(&b, &val, &buf); err != nil {
+		return 1
+	}
+
+	if !bytes.Equal(b.Bytes(), data) {
+		panic("bytes not equal")
+	}
+
+	r2 := bytes.NewReader(b.Bytes())
+
+	if err := tlv.DUint16(r2, &val2, &buf, 2); err != nil {
+		return 1
+	}
+
+	if val != val2 {
+		panic("values not equal")
+	}
+
+	return 1
+}

--- a/fuzz/tlv/uint32.go
+++ b/fuzz/tlv/uint32.go
@@ -1,0 +1,49 @@
+// +build gofuzz
+
+package tlvfuzz
+
+import (
+	"bytes"
+
+	"github.com/lightningnetwork/lnd/tlv"
+)
+
+// Fuzz_uint32 is used by go-fuzz.
+func Fuzz_uint32(data []byte) int {
+	if len(data) > 4 {
+		return 1
+	}
+
+	r := bytes.NewReader(data)
+
+	var (
+		val  uint32
+		val2 uint32
+		buf  [8]byte
+		b    bytes.Buffer
+	)
+
+	if err := tlv.DUint32(r, &val, &buf, 4); err != nil {
+		return 1
+	}
+
+	if err := tlv.EUint32(&b, &val, &buf); err != nil {
+		return 1
+	}
+
+	if !bytes.Equal(b.Bytes(), data) {
+		panic("bytes not equal")
+	}
+
+	r2 := bytes.NewReader(b.Bytes())
+
+	if err := tlv.DUint32(r2, &val2, &buf, 4); err != nil {
+		return 1
+	}
+
+	if val != val2 {
+		panic("values not equal")
+	}
+
+	return 1
+}

--- a/fuzz/tlv/uint64.go
+++ b/fuzz/tlv/uint64.go
@@ -1,0 +1,49 @@
+// +build gofuzz
+
+package tlvfuzz
+
+import (
+	"bytes"
+
+	"github.com/lightningnetwork/lnd/tlv"
+)
+
+// Fuzz_uint64 is used by go-fuzz.
+func Fuzz_uint64(data []byte) int {
+	if len(data) > 8 {
+		return 1
+	}
+
+	r := bytes.NewReader(data)
+
+	var (
+		val  uint64
+		val2 uint64
+		buf  [8]byte
+		b    bytes.Buffer
+	)
+
+	if err := tlv.DUint64(r, &val, &buf, 8); err != nil {
+		return 1
+	}
+
+	if err := tlv.EUint64(&b, &val, &buf); err != nil {
+		return 1
+	}
+
+	if !bytes.Equal(b.Bytes(), data) {
+		panic("bytes not equal")
+	}
+
+	r2 := bytes.NewReader(b.Bytes())
+
+	if err := tlv.DUint64(r2, &val2, &buf, 8); err != nil {
+		return 1
+	}
+
+	if val != val2 {
+		panic("values not equal")
+	}
+
+	return 1
+}

--- a/fuzz/tlv/uint8.go
+++ b/fuzz/tlv/uint8.go
@@ -1,0 +1,49 @@
+// +build gofuzz
+
+package tlvfuzz
+
+import (
+	"bytes"
+
+	"github.com/lightningnetwork/lnd/tlv"
+)
+
+// Fuzz_uint8 is used by go-fuzz.
+func Fuzz_uint8(data []byte) int {
+	if len(data) > 1 {
+		return 1
+	}
+
+	r := bytes.NewReader(data)
+
+	var (
+		val  uint8
+		val2 uint8
+		buf  [8]byte
+		b    bytes.Buffer
+	)
+
+	if err := tlv.DUint8(r, &val, &buf, 1); err != nil {
+		return 1
+	}
+
+	if err := tlv.EUint8(&b, &val, &buf); err != nil {
+		return 1
+	}
+
+	if !bytes.Equal(b.Bytes(), data) {
+		panic("bytes not equal")
+	}
+
+	r2 := bytes.NewReader(b.Bytes())
+
+	if err := tlv.DUint8(r2, &val2, &buf, 1); err != nil {
+		return 1
+	}
+
+	if val != val2 {
+		panic("values not equal")
+	}
+
+	return 1
+}

--- a/fuzz/tlv/varbytes.go
+++ b/fuzz/tlv/varbytes.go
@@ -1,0 +1,48 @@
+// +build gofuzz
+
+package tlvfuzz
+
+import (
+	"bytes"
+
+	"github.com/lightningnetwork/lnd/tlv"
+)
+
+// Fuzz_varbytes is used by go-fuzz.
+func Fuzz_varbytes(data []byte) int {
+	l := len(data)
+
+	r := bytes.NewReader(data)
+
+	var (
+		val  []byte
+		val2 []byte
+		buf  [8]byte
+		b    bytes.Buffer
+	)
+
+	if err := tlv.DVarBytes(r, &val, &buf, uint64(l)); err != nil {
+		return 1
+	}
+
+	if err := tlv.EVarBytes(&b, &val, &buf); err != nil {
+		return 1
+	}
+
+	if !bytes.Equal(b.Bytes(), data) {
+		panic("bytes not equal")
+	}
+
+	r2 := bytes.NewReader(b.Bytes())
+	l2 := len(b.Bytes())
+
+	if err := tlv.DVarBytes(r2, &val2, &buf, uint64(l2)); err != nil {
+		return 1
+	}
+
+	if !bytes.Equal(val, val2) {
+		panic("values not equal")
+	}
+
+	return 1
+}

--- a/fuzz/tlv/varint.go
+++ b/fuzz/tlv/varint.go
@@ -1,0 +1,47 @@
+// +build gofuzz
+
+package tlvfuzz
+
+import (
+	"bytes"
+
+	"github.com/lightningnetwork/lnd/tlv"
+)
+
+// Fuzz_varint is used by go-fuzz.
+func Fuzz_varint(data []byte) int {
+	r := bytes.NewReader(data)
+
+	var (
+		val  uint64
+		val2 uint64
+		err  error
+		buf  [8]byte
+		b    bytes.Buffer
+	)
+
+	val, err = tlv.ReadVarInt(r, &buf)
+	if err != nil {
+		return 1
+	}
+
+	if err := tlv.WriteVarInt(&b, val, &buf); err != nil {
+		return 1
+	}
+
+	// A byte comparison isn't performed here since ReadVarInt doesn't read
+	// all of the bytes from data and so b.Bytes() won't be equal to data.
+
+	r2 := bytes.NewReader(b.Bytes())
+
+	val2, err = tlv.ReadVarInt(r2, &buf)
+	if err != nil {
+		return 1
+	}
+
+	if val != val2 {
+		panic("values not equal")
+	}
+
+	return 1
+}

--- a/make/fuzz_flags.mk
+++ b/make/fuzz_flags.mk
@@ -1,4 +1,4 @@
-FUZZPKG = brontide lnwire wtwire zpay32
+FUZZPKG = brontide lnwire tlv wtwire zpay32
 FUZZ_TEST_RUN_TIME = 30
 FUZZ_TEST_TIMEOUT = 20
 FUZZ_NUM_PROCESSES = 4

--- a/tlv/primitive.go
+++ b/tlv/primitive.go
@@ -258,7 +258,7 @@ func DBytes64(r io.Reader, val interface{}, _ *[8]byte, l uint64) error {
 // EPubKey is an Encoder for *btcec.PublicKey values. An error is returned if
 // val is not a **btcec.PublicKey.
 func EPubKey(w io.Writer, val interface{}, _ *[8]byte) error {
-	if pk, ok := val.(**btcec.PublicKey); ok {
+	if pk, ok := val.(**btcec.PublicKey); ok && *pk != nil {
 		_, err := w.Write((*pk).SerializeCompressed())
 		return err
 	}


### PR DESCRIPTION
Uncovered one OOM a while ago. They were up on my local github though.

Testing:
```
make fuzz-build pkg=tlv
make fuzz-run pkg=tlv
```

Commits:
- fix a false positive with the way the fuzzer would handle pubkeys.
- add fuzz tests that test decoding + encoding, assert equality, don't panic / oom
- modify Makefile and make/fuzz_flags.mk