### PR TITLE
htlcswitch: non-strict forwarding via lowest capacity channel

### DIFF
--- a/htlcswitch/interfaces.go
+++ b/htlcswitch/interfaces.go
@@ -2,6 +2,7 @@ package htlcswitch
 
 import (
 	"github.com/btcsuite/btcd/wire"
+	"github.com/btcsuite/btcutil"
 	"github.com/lightningnetwork/lnd/channeldb"
 	"github.com/lightningnetwork/lnd/invoices"
 	"github.com/lightningnetwork/lnd/lnpeer"
@@ -129,6 +130,9 @@ type ChannelLink interface {
 	// takes into account any forwarded but un-cleared HTLC's, and any
 	// HTLC's which have been set to the over flow queue.
 	Bandwidth() lnwire.MilliSatoshi
+
+	// Capacity returns the channel capacity in sats.
+	Capacity() btcutil.Amount
 
 	// Stats return the statistics of channel link. Number of updates,
 	// total sent/received milli-satoshis.

--- a/htlcswitch/link.go
+++ b/htlcswitch/link.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/btcsuite/btcd/wire"
 	"github.com/btcsuite/btclog"
+	"github.com/btcsuite/btcutil"
 	"github.com/davecgh/go-spew/spew"
 	"github.com/go-errors/errors"
 	"github.com/lightningnetwork/lnd/build"
@@ -2139,6 +2140,11 @@ func (l *channelLink) Bandwidth() lnwire.MilliSatoshi {
 	// the channel reserve into account so HTLCs up to this value won't
 	// violate it.
 	return l.channel.AvailableBalance()
+}
+
+// Capacity returns the channel capacity in sats.
+func (l *channelLink) Capacity() btcutil.Amount {
+	return l.channel.Capacity
 }
 
 // AttachMailBox updates the current mailbox used by this link, and hooks up

--- a/htlcswitch/mock.go
+++ b/htlcswitch/mock.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/btcsuite/btcd/btcec"
 	"github.com/btcsuite/btcd/wire"
+	"github.com/btcsuite/btcutil"
 	"github.com/go-errors/errors"
 	sphinx "github.com/lightningnetwork/lightning-onion"
 	"github.com/lightningnetwork/lnd/chainntnfs"
@@ -651,6 +652,8 @@ type mockChannelLink struct {
 	checkHtlcTransitResult *LinkError
 
 	checkHtlcForwardResult *LinkError
+
+	capacity btcutil.Amount
 }
 
 // completeCircuit is a helper method for adding the finalized payment circuit
@@ -690,12 +693,15 @@ func newMockChannelLink(htlcSwitch *Switch, chanID lnwire.ChannelID,
 	shortChanID lnwire.ShortChannelID, peer lnpeer.Peer, eligible bool,
 ) *mockChannelLink {
 
+	const testCapacity = 99999999
+
 	return &mockChannelLink{
 		htlcSwitch:  htlcSwitch,
 		chanID:      chanID,
 		shortChanID: shortChanID,
 		peer:        peer,
 		eligible:    eligible,
+		capacity:    testCapacity,
 	}
 }
 
@@ -745,6 +751,7 @@ func (f *mockChannelLink) Start() error {
 func (f *mockChannelLink) ChanID() lnwire.ChannelID                     { return f.chanID }
 func (f *mockChannelLink) ShortChanID() lnwire.ShortChannelID           { return f.shortChanID }
 func (f *mockChannelLink) Bandwidth() lnwire.MilliSatoshi               { return 99999999 }
+func (f *mockChannelLink) Capacity() btcutil.Amount                     { return f.capacity }
 func (f *mockChannelLink) Peer() lnpeer.Peer                            { return f.peer }
 func (f *mockChannelLink) ChannelPoint() *wire.OutPoint                 { return &wire.OutPoint{} }
 func (f *mockChannelLink) Stop()                                        {}


### PR DESCRIPTION
This is a security measure that increases the cost of channel jamming when two nodes have multiple channels open between them with non-equal channel capacities.

By always selecting the lowest capacity channel, an attacker will need to send more htlcs to start tapping into the htlc slots of the bigger (wumbo) channel(s).