### PR TITLE
[tests] reverse macaroon time caveat check, fix go 1.15 vet check.

### DIFF
--- a/brontide/noise_test.go
+++ b/brontide/noise_test.go
@@ -110,7 +110,7 @@ func TestConnectionCorrectness(t *testing.T) {
 
 	// Test out some message full-message reads.
 	for i := 0; i < 10; i++ {
-		msg := []byte("hello" + string(i))
+		msg := []byte(fmt.Sprintf("hello%d", i))
 
 		if _, err := localConn.Write(msg); err != nil {
 			t.Fatalf("remote conn failed to write: %v", err)

--- a/macaroons/constraints_test.go
+++ b/macaroons/constraints_test.go
@@ -1,6 +1,7 @@
 package macaroons_test
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 	"time"
@@ -14,7 +15,7 @@ var (
 	testID                      = []byte("dummyId")
 	testLocation                = "lnd"
 	testVersion                 = macaroon.LatestVersion
-	expectedTimeCaveatSubstring = "time-before " + string(time.Now().Year())
+	expectedTimeCaveatSubstring = fmt.Sprintf("time-before %d", time.Now().Year())
 )
 
 func createDummyMacaroon(t *testing.T) *macaroon.Macaroon {
@@ -67,8 +68,8 @@ func TestTimeoutConstraint(t *testing.T) {
 	}
 
 	// Finally, check that the created caveat has an
-	// acceptable value
-	if strings.HasPrefix(string(testMacaroon.Caveats()[0].Id),
+	// acceptable value.
+	if !strings.HasPrefix(string(testMacaroon.Caveats()[0].Id),
 		expectedTimeCaveatSubstring) {
 		t.Fatalf("Added caveat '%s' does not meet the expectations!",
 			testMacaroon.Caveats()[0].Id)
@@ -90,7 +91,7 @@ func TestIpLockConstraint(t *testing.T) {
 	}
 
 	// Finally, check that the created caveat has an
-	// acceptable value
+	// acceptable value.
 	if string(testMacaroon.Caveats()[0].Id) != "ipaddr 127.0.0.1" {
 		t.Fatalf("Added caveat '%s' does not meet the expectations!",
 			testMacaroon.Caveats()[0].Id)

--- a/macaroons/constraints_test.go
+++ b/macaroons/constraints_test.go
@@ -19,8 +19,9 @@ var (
 )
 
 func createDummyMacaroon(t *testing.T) *macaroon.Macaroon {
-	dummyMacaroon, err := macaroon.New(testRootKey, testID,
-		testLocation, testVersion)
+	dummyMacaroon, err := macaroon.New(
+		testRootKey, testID, testLocation, testVersion,
+	)
 	if err != nil {
 		t.Fatalf("Error creating initial macaroon: %v", err)
 	}
@@ -36,8 +37,9 @@ func TestAddConstraints(t *testing.T) {
 
 	// Now add a constraint and make sure we have a cloned macaroon
 	// with the constraint applied instead of a mutated initial one.
-	newMac, err := macaroons.AddConstraints(initialMac,
-		macaroons.TimeoutConstraint(1))
+	newMac, err := macaroons.AddConstraints(
+		initialMac, macaroons.TimeoutConstraint(1),
+	)
 	if err != nil {
 		t.Fatalf("Error adding constraint: %v", err)
 	}
@@ -69,8 +71,10 @@ func TestTimeoutConstraint(t *testing.T) {
 
 	// Finally, check that the created caveat has an
 	// acceptable value.
-	if !strings.HasPrefix(string(testMacaroon.Caveats()[0].Id),
-		expectedTimeCaveatSubstring) {
+	if !strings.HasPrefix(
+		string(testMacaroon.Caveats()[0].Id),
+		expectedTimeCaveatSubstring,
+	) {
 		t.Fatalf("Added caveat '%s' does not meet the expectations!",
 			testMacaroon.Caveats()[0].Id)
 	}


### PR DESCRIPTION
This commit fixes a go 1.15 vet check.

In doing so it uncovers that the time caveat check is actually reversed.
Since we should check that the caveat is added, we should only fail the
check when the caveat prefix is not equal.
