### PR TITLE
RPC: add --no-rest-tls option

### DIFF
--- a/config.go
+++ b/config.go
@@ -1176,9 +1176,10 @@ func ValidateConfig(cfg Config, usageMessage string) (*Config, error) {
 
 	// For each of the RPC listeners (REST+gRPC), we'll ensure that users
 	// have specified a safe combo for authentication. If not, we'll bail
-	// out with an error.
+	// out with an error. Since we don't allow disabling TLS for gRPC
+	// connections we pass in tlsActive=true.
 	err = lncfg.EnforceSafeAuthentication(
-		cfg.RPCListeners, !cfg.NoMacaroons,
+		cfg.RPCListeners, !cfg.NoMacaroons, true,
 	)
 	if err != nil {
 		return nil, err
@@ -1189,7 +1190,7 @@ func ValidateConfig(cfg Config, usageMessage string) (*Config, error) {
 		cfg.RESTListeners = nil
 	} else {
 		err = lncfg.EnforceSafeAuthentication(
-			cfg.RESTListeners, !cfg.NoMacaroons,
+			cfg.RESTListeners, !cfg.NoMacaroons, !cfg.DisableRestTLS,
 		)
 		if err != nil {
 			return nil, err

--- a/config.go
+++ b/config.go
@@ -210,6 +210,7 @@ type Config struct {
 	ExternalIPs       []net.Addr
 	DisableListen     bool          `long:"nolisten" description:"Disable listening for incoming peer connections"`
 	DisableRest       bool          `long:"norest" description:"Disable REST API"`
+	DisableRestTLS    bool          `long:"no-rest-tls" description:"Disable TLS for REST connections"`
 	NAT               bool          `long:"nat" description:"Toggle NAT traversal support (using either UPnP or NAT-PMP) to automatically advertise your external IP address to the network -- NOTE this does not support devices behind multiple NATs"`
 	MinBackoff        time.Duration `long:"minbackoff" description:"Shortest backoff when reconnecting to persistent peers. Valid time units are {s, m, h}."`
 	MaxBackoff        time.Duration `long:"maxbackoff" description:"Longest backoff when reconnecting to persistent peers. Valid time units are {s, m, h}."`

--- a/lncfg/address.go
+++ b/lncfg/address.go
@@ -48,11 +48,13 @@ func NormalizeAddresses(addrs []string, defaultPort string,
 }
 
 // EnforceSafeAuthentication enforces "safe" authentication taking into account
-// the interfaces that the RPC servers are listening on, and if macaroons are
-// activated or not. To protect users from using dangerous config combinations,
-// we'll prevent disabling authentication if the server is listening on a public
-// interface.
-func EnforceSafeAuthentication(addrs []net.Addr, macaroonsActive bool) error {
+// the interfaces that the RPC servers are listening on, and if macaroons and
+// TLS is activated or not. To protect users from using dangerous config
+// combinations, we'll prevent disabling authentication if the server is
+// listening on a public interface.
+func EnforceSafeAuthentication(addrs []net.Addr, macaroonsActive,
+	tlsActive bool) error {
+
 	// We'll now examine all addresses that this RPC server is listening
 	// on. If it's a localhost address or a private address, we'll skip it,
 	// otherwise, we'll return an error if macaroons are inactive.
@@ -62,10 +64,17 @@ func EnforceSafeAuthentication(addrs []net.Addr, macaroonsActive bool) error {
 		}
 
 		if !macaroonsActive {
-			return fmt.Errorf("Detected RPC server listening on "+
+			return fmt.Errorf("detected RPC server listening on "+
 				"publicly reachable interface %v with "+
 				"authentication disabled! Refusing to start "+
-				"with --no-macaroons specified.", addr)
+				"with --no-macaroons specified", addr)
+		}
+
+		if !tlsActive {
+			return fmt.Errorf("detected RPC server listening on "+
+				"publicly reachable interface %v with "+
+				"encryption disabled! Refusing to start "+
+				"with --notls specified", addr)
 		}
 	}
 

--- a/lnd.go
+++ b/lnd.go
@@ -990,6 +990,12 @@ func getTLSConfig(cfg *Config) ([]grpc.ServerOption, []grpc.DialOption,
 	// Return a function closure that can be used to listen on a given
 	// address with the current TLS config.
 	restListen := func(addr net.Addr) (net.Listener, error) {
+		// For restListen we will call ListenOnAddress if TLS is
+		// disabled.
+		if cfg.DisableRestTLS {
+			return lncfg.ListenOnAddress(addr)
+		}
+
 		return lncfg.TLSListenOnAddress(addr, tlsCfg)
 	}
 

--- a/sample-lnd.conf
+++ b/sample-lnd.conf
@@ -176,6 +176,9 @@
 ; Disable REST API.
 ; norest=true
 
+; Disable TLS for the REST API.
+; no-rest-tls=true
+
 ; Shortest backoff when reconnecting to persistent peers. Valid time units are
 ; {s, m, h}.
 ; minbackoff=1s


### PR DESCRIPTION
Supersedes #2277, disabling TLS for REST ~~and gRPC~~ connections.