### PR TITLE
fuzz/zpay32: add Decode/Encode fuzz tests.

### DIFF
--- a/fuzz/zpay32/decode.go
+++ b/fuzz/zpay32/decode.go
@@ -1,0 +1,22 @@
+// +build gofuzz
+
+package zpay32fuzz
+
+import (
+	"github.com/btcsuite/btcd/chaincfg"
+	"github.com/lightningnetwork/lnd/zpay32"
+)
+
+// Fuzz_decode is used by go-fuzz.
+func Fuzz_decode(data []byte) int {
+	inv, err := zpay32.Decode(string(data), &chaincfg.TestNet3Params)
+	if err != nil {
+		return 1
+	}
+
+	// Call these functions as a sanity check to make sure the invoice
+	// is well-formed.
+	_ = inv.MinFinalCLTVExpiry()
+	_ = inv.Expiry()
+	return 1
+}

--- a/fuzz/zpay32/encode.go
+++ b/fuzz/zpay32/encode.go
@@ -1,0 +1,49 @@
+// +build gofuzz
+
+package zpay32fuzz
+
+import (
+	"encoding/hex"
+	"fmt"
+
+	"github.com/btcsuite/btcd/btcec"
+	"github.com/btcsuite/btcd/chaincfg"
+	"github.com/lightningnetwork/lnd/zpay32"
+)
+
+// Fuzz_encode is used by go-fuzz.
+func Fuzz_encode(data []byte) int {
+	inv, err := zpay32.Decode(string(data), &chaincfg.TestNet3Params)
+	if err != nil {
+		return 1
+	}
+
+	// Call these functions as a sanity check to make sure the invoice
+	// is well-formed.
+	_ = inv.MinFinalCLTVExpiry()
+	_ = inv.Expiry()
+
+	// Initialize the static key we will be using for this fuzz test.
+	testPrivKeyBytes, _ := hex.DecodeString("e126f68f7eafcc8b74f54d269fe206be715000f94dac067d1c04a8ca3b2db734")
+	testPrivKey, _ := btcec.PrivKeyFromBytes(btcec.S256(), testPrivKeyBytes)
+
+	// Then, initialize the testMessageSigner so we can encode out
+	// invoices with this private key.
+	testMessageSigner := zpay32.MessageSigner{
+		SignCompact: func(hash []byte) ([]byte, error) {
+			sig, err := btcec.SignCompact(btcec.S256(),
+				testPrivKey, hash, true)
+			if err != nil {
+				return nil, fmt.Errorf("can't sign the "+
+					"message: %v", err)
+			}
+			return sig, nil
+		},
+	}
+	_, err = inv.Encode(testMessageSigner)
+	if err != nil {
+		return 1
+	}
+
+	return 1
+}


### PR DESCRIPTION
These can be expanded on in the future. Haven't turned up anything which is good. Encoding is currently done with a static key for test determinism. Can be expanded in the future for another test with random key.
