### PR TITLE
Travis: run itests in parallel, get ~60% speedup overall

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,8 @@ lntest/itest/output*.log
 lntest/itest/pprof*.log
 lntest/itest/.backendlogs
 lntest/itest/.minerlogs
+lntest/itest/lnd-itest
+lntest/itest/.logs-*
 
 cmd/cmd
 *.key

--- a/.travis.yml
+++ b/.travis.yml
@@ -50,32 +50,30 @@ jobs:
     - stage: Integration Test
       name: Btcd Integration
       script:
-        - make itest
+        - make itest-parallel
 
     - name: Bitcoind Integration (txindex enabled)
       script:
         - bash ./scripts/install_bitcoind.sh
-        - make itest backend=bitcoind
+        - make itest-parallel backend=bitcoind
 
     - name: Bitcoind Integration (txindex disabled)
       script:
         - bash ./scripts/install_bitcoind.sh
-        - make itest backend="bitcoind notxindex"
+        - make itest-parallel backend="bitcoind notxindex"
 
     - name: Neutrino Integration
       script:
-        - make itest backend=neutrino
+        - make itest-parallel backend=neutrino
 
     - name: Btcd Integration ARM
       script:
-        - GOARM=7 GOARCH=arm GOOS=linux CGO_ENABLED=0 make btcd build-itest
-        - file lnd-itest
-        - GOARM=7 GOARCH=arm GOOS=linux CGO_ENABLED=0 make itest-only
+        - GOARM=7 GOARCH=arm GOOS=linux make itest-parallel
       arch: arm64
 
     - name: Btcd Integration Windows
       script:
-        - make itest-windows
+        - make itest-parallel-windows
       os: windows
       before_install:
         - choco upgrade --no-progress -y make netcat curl findutils
@@ -85,7 +83,8 @@ jobs:
           case $TRAVIS_OS_NAME in
             windows)
               echo "Uploading to termbin.com..."
-              for f in ./lntest/itest/*.log; do cat $f | nc termbin.com 9999 | xargs -r0 printf "$f"' uploaded to %s'; done
+              LOG_FILES=$(find ./lntest/itest -name '*.log')
+              for f in $LOG_FILES; do echo -n $f; cat $f | nc termbin.com 9999 | xargs -r0 printf ' uploaded to %s'; done
               ;;
           esac
 
@@ -97,8 +96,8 @@ after_failure:
         ;;
 
       *)
-        LOG_FILES=./lntest/itest/*.log
-        echo "Uploading to termbin.com..." && find $LOG_FILES | xargs -I{} sh -c "cat {} | nc termbin.com 9999 | xargs -r0 printf '{} uploaded to %s'"
+        LOG_FILES=$(find ./lntest/itest -name '*.log')
+        echo "Uploading to termbin.com..." && for f in $LOG_FILES; do echo -n $f; cat $f | nc termbin.com 9999 | xargs -r0 printf ' uploaded to %s'; done
         echo "Uploading to file.io..." && tar -zcvO $LOG_FILES | curl -s -F 'file=@-;filename=logs.tar.gz' https://file.io | xargs -r0 printf 'logs.tar.gz uploaded to %s\n'
         ;;
     esac

--- a/Makefile
+++ b/Makefile
@@ -175,6 +175,27 @@ itest-only:
 
 itest: btcd build-itest itest-only
 
+itest-parallel: btcd
+	@$(call print, "Building lnd binary")
+	CGO_ENABLED=0 $(GOBUILD) -tags="$(ITEST_TAGS)" -o lntest/itest/lnd-itest $(ITEST_LDFLAGS) $(PKG)/cmd/lnd
+
+	@$(call print, "Building itest binary for $(backend) backend")
+	CGO_ENABLED=0 $(GOTEST) -v ./lntest/itest -tags="$(DEV_TAGS) $(RPC_TAGS) rpctest $(backend)" -logoutput -goroutinedump -c -o lntest/itest/itest.test
+
+	@$(call print, "Running tests")
+	rm -rf lntest/itest/*.log lntest/itest/.logs-*
+	echo -n "$$(seq 0 $$(expr $(NUM_ITEST_TRANCHES) - 1))" | xargs -P $(NUM_ITEST_TRANCHES) -n 1 -I {} scripts/itest_part.sh {} $(NUM_ITEST_TRANCHES) $(TEST_FLAGS)
+
+itest-parallel-windows: btcd
+	@$(call print, "Building lnd binary")
+	CGO_ENABLED=0 $(GOBUILD) -tags="$(ITEST_TAGS)" -o lntest/itest/lnd-itest.exe $(ITEST_LDFLAGS) $(PKG)/cmd/lnd
+
+	@$(call print, "Building itest binary for $(backend) backend")
+	CGO_ENABLED=0 $(GOTEST) -v ./lntest/itest -tags="$(DEV_TAGS) $(RPC_TAGS) rpctest $(backend)" -logoutput -goroutinedump -c -o lntest/itest/itest.test.exe
+
+	@$(call print, "Running tests")
+	EXEC_SUFFIX=".exe" echo -n "$$(seq 0 $$(expr $(NUM_ITEST_TRANCHES) - 1))" | xargs -P $(NUM_ITEST_TRANCHES) -n 1 -I {} scripts/itest_part.sh {} $(NUM_ITEST_TRANCHES) $(TEST_FLAGS)
+
 itest-windows: btcd build-itest-windows itest-only
 
 unit: btcd

--- a/lntest/bitcoind_common.go
+++ b/lntest/bitcoind_common.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"io/ioutil"
-	"math/rand"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -93,10 +92,10 @@ func newBackend(miner string, netParams *chaincfg.Params, extraArgs []string) (
 			fmt.Errorf("unable to create temp directory: %v", err)
 	}
 
-	zmqBlockPath := "ipc:///" + tempBitcoindDir + "/blocks.socket"
-	zmqTxPath := "ipc:///" + tempBitcoindDir + "/txs.socket"
-	rpcPort := rand.Int()%(65536-1024) + 1024
-	p2pPort := rand.Int()%(65536-1024) + 1024
+	zmqBlockAddr := fmt.Sprintf("tcp://127.0.0.1:%d", nextAvailablePort())
+	zmqTxAddr := fmt.Sprintf("tcp://127.0.0.1:%d", nextAvailablePort())
+	rpcPort := nextAvailablePort()
+	p2pPort := nextAvailablePort()
 
 	cmdArgs := []string{
 		"-datadir=" + tempBitcoindDir,
@@ -106,8 +105,8 @@ func newBackend(miner string, netParams *chaincfg.Params, extraArgs []string) (
 			"220110063096c221be9933c82d38e1",
 		fmt.Sprintf("-rpcport=%d", rpcPort),
 		fmt.Sprintf("-port=%d", p2pPort),
-		"-zmqpubrawblock=" + zmqBlockPath,
-		"-zmqpubrawtx=" + zmqTxPath,
+		"-zmqpubrawblock=" + zmqBlockAddr,
+		"-zmqpubrawtx=" + zmqTxAddr,
 		"-debuglogfile=" + logFile,
 	}
 	cmdArgs = append(cmdArgs, extraArgs...)
@@ -178,8 +177,8 @@ func newBackend(miner string, netParams *chaincfg.Params, extraArgs []string) (
 		rpcHost:      rpcHost,
 		rpcUser:      rpcUser,
 		rpcPass:      rpcPass,
-		zmqBlockPath: zmqBlockPath,
-		zmqTxPath:    zmqTxPath,
+		zmqBlockPath: zmqBlockAddr,
+		zmqTxPath:    zmqTxAddr,
 		p2pPort:      p2pPort,
 		rpcClient:    client,
 		minerAddr:    miner,

--- a/lntest/fee_service.go
+++ b/lntest/fee_service.go
@@ -16,9 +16,6 @@ const (
 	// is returned. Requests for higher confirmation targets will fall back
 	// to this.
 	feeServiceTarget = 2
-
-	// feeServicePort is the tcp port on which the service runs.
-	feeServicePort = 16534
 )
 
 // feeService runs a web service that provides fee estimation information.
@@ -40,16 +37,15 @@ type feeEstimates struct {
 
 // startFeeService spins up a go-routine to serve fee estimates.
 func startFeeService() *feeService {
+	port := nextAvailablePort()
 	f := feeService{
-		url: fmt.Sprintf(
-			"http://localhost:%v/fee-estimates.json", feeServicePort,
-		),
+		url: fmt.Sprintf("http://localhost:%v/fee-estimates.json", port),
 	}
 
 	// Initialize default fee estimate.
 	f.Fees = map[uint32]uint32{feeServiceTarget: 50000}
 
-	listenAddr := fmt.Sprintf(":%v", feeServicePort)
+	listenAddr := fmt.Sprintf(":%v", port)
 	f.srv = &http.Server{
 		Addr: listenAddr,
 	}

--- a/lntest/itest/lnd_channel_backup_test.go
+++ b/lntest/itest/lnd_channel_backup_test.go
@@ -1012,6 +1012,10 @@ func testChanRestoreScenario(t *harnessTest, net *lntest.NetworkHarness,
 	require.Contains(t.t, err.Error(), "cannot close channel with state: ")
 	require.Contains(t.t, err.Error(), "ChanStatusRestored")
 
+	// Increase the fee estimate so that the following force close tx will
+	// be cpfp'ed in case of anchor commitments.
+	net.SetFeeEstimate(30000)
+
 	// Now that we have ensured that the channels restored by the backup are
 	// in the correct state even without the remote peer telling us so,
 	// let's start up Carol again.

--- a/lntest/itest/lnd_multi-hop_htlc_remote_chain_claim_test.go
+++ b/lntest/itest/lnd_multi-hop_htlc_remote_chain_claim_test.go
@@ -101,15 +101,17 @@ func testMultiHopHtlcRemoteChainClaim(net *lntest.NetworkHarness, t *harnessTest
 	// bob will attempt to redeem his anchor commitment (if the channel
 	// type is of that type).
 	if c == commitTypeAnchors {
-		_, err = waitForNTxsInMempool(net.Miner.Node, 1, minerMempoolTimeout)
+		_, err = waitForNTxsInMempool(
+			net.Miner.Node, 1, minerMempoolTimeout,
+		)
 		if err != nil {
-			t.Fatalf("unable to find bob's anchor commit sweep: %v", err)
-
+			t.Fatalf("unable to find bob's anchor commit sweep: %v",
+				err)
 		}
 	}
 
 	// Mine enough blocks for Alice to sweep her funds from the force
-	// closed channel. closeCHannelAndAssertType() already mined a block
+	// closed channel. closeChannelAndAssertType() already mined a block
 	// containing the commitment tx and the commit sweep tx will be
 	// broadcast immediately before it can be included in a block, so mine
 	// one less than defaultCSV in order to perform mempool assertions.

--- a/lntest/itest/lnd_test.go
+++ b/lntest/itest/lnd_test.go
@@ -2435,7 +2435,7 @@ func testOpenChannelAfterReorg(net *lntest.NetworkHarness, t *harnessTest) {
 	)
 
 	// Set up a new miner that we can use to cause a reorg.
-	tempLogDir := "./.tempminerlogs"
+	tempLogDir := fmt.Sprintf("%s/.tempminerlogs", lntest.GetLogDir())
 	logFilename := "output-open_channel_reorg-temp_miner.log"
 	tempMiner, tempMinerCleanUp, err := lntest.NewMiner(
 		tempLogDir, logFilename,
@@ -14158,6 +14158,8 @@ func TestLightningNetworkDaemon(t *testing.T) {
 	}
 
 	// Parse testing flags that influence our test execution.
+	logDir := lntest.GetLogDir()
+	require.NoError(t, os.MkdirAll(logDir, 0700))
 	testCases, trancheIndex, trancheOffset := getTestCaseSplitTranche()
 	lntest.ApplyPortOffset(uint32(trancheIndex) * 1000)
 
@@ -14176,7 +14178,7 @@ func TestLightningNetworkDaemon(t *testing.T) {
 	// guarantees of getting included in to blocks.
 	//
 	// We will also connect it to our chain backend.
-	minerLogDir := "./.minerlogs"
+	minerLogDir := fmt.Sprintf("%s/.minerlogs", logDir)
 	miner, minerCleanUp, err := lntest.NewMiner(
 		minerLogDir, "output_btcd_miner.log",
 		harnessNetParams, &rpcclient.NotificationHandlers{},

--- a/lntest/itest/lnd_test.go
+++ b/lntest/itest/lnd_test.go
@@ -6,6 +6,7 @@ import (
 	"crypto/rand"
 	"crypto/sha256"
 	"encoding/hex"
+	"flag"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -52,6 +53,60 @@ import (
 	"github.com/lightningnetwork/lnd/routing"
 	"github.com/stretchr/testify/require"
 )
+
+const (
+	// defaultSplitTranches is the default number of tranches we split the
+	// test cases into.
+	defaultSplitTranches uint = 1
+
+	// defaultRunTranche is the default index of the test cases tranche that
+	// we run.
+	defaultRunTranche uint = 0
+)
+
+var (
+	// testCasesSplitParts is the number of tranches the test cases should
+	// be split into. By default this is set to 1, so no splitting happens.
+	// If this value is increased, then the -runtranche flag must be
+	// specified as well to indicate which part should be run in the current
+	// invocation.
+	testCasesSplitTranches = flag.Uint(
+		"splittranches", defaultSplitTranches, "split the test cases "+
+			"in this many tranches and run the tranche at "+
+			"0-based index specified by the -runtranche flag",
+	)
+
+	// testCasesRunTranche is the 0-based index of the split test cases
+	// tranche to run in the current invocation.
+	testCasesRunTranche = flag.Uint(
+		"runtranche", defaultRunTranche, "run the tranche of the "+
+			"split test cases with the given (0-based) index",
+	)
+)
+
+// getTestCaseSplitTranche returns the sub slice of the test cases that should
+// be run as the current split tranche as well as the index and slice offset of
+// the tranche.
+func getTestCaseSplitTranche() ([]*testCase, uint, uint) {
+	numTranches := defaultSplitTranches
+	if testCasesSplitTranches != nil {
+		numTranches = *testCasesSplitTranches
+	}
+	runTranche := defaultRunTranche
+	if testCasesRunTranche != nil {
+		runTranche = *testCasesRunTranche
+	}
+
+	numCases := uint(len(allTestCases))
+	testsPerTranche := numCases / numTranches
+	trancheOffset := runTranche * testsPerTranche
+	trancheEnd := trancheOffset + testsPerTranche
+	if trancheEnd > numCases || runTranche == numTranches-1 {
+		trancheEnd = numCases
+	}
+
+	return allTestCases[trancheOffset:trancheEnd], runTranche, trancheOffset
+}
 
 func rpcPointToWirePoint(t *harnessTest, chanPoint *lnrpc.ChannelPoint) wire.OutPoint {
 	txid, err := lnd.GetChanPointFundingTxid(chanPoint)
@@ -14098,9 +14153,13 @@ func getPaymentResult(stream routerrpc.Router_SendPaymentV2Client) (
 // programmatically driven network of lnd nodes.
 func TestLightningNetworkDaemon(t *testing.T) {
 	// If no tests are registered, then we can exit early.
-	if len(testsCases) == 0 {
+	if len(allTestCases) == 0 {
 		t.Skip("integration tests not selected with flag 'rpctest'")
 	}
+
+	// Parse testing flags that influence our test execution.
+	testCases, trancheIndex, trancheOffset := getTestCaseSplitTranche()
+	lntest.ApplyPortOffset(uint32(trancheIndex) * 1000)
 
 	ht := newHarnessTest(t, nil)
 
@@ -14149,8 +14208,7 @@ func TestLightningNetworkDaemon(t *testing.T) {
 
 	// Connect chainbackend to miner.
 	require.NoError(
-		t, chainBackend.ConnectMiner(),
-		"failed to connect to miner",
+		t, chainBackend.ConnectMiner(), "failed to connect to miner",
 	)
 
 	binary := itestLndBinary
@@ -14187,7 +14245,8 @@ func TestLightningNetworkDaemon(t *testing.T) {
 				if !more {
 					return
 				}
-				ht.Logf("lnd finished with error (stderr):\n%v", err)
+				ht.Logf("lnd finished with error (stderr):\n%v",
+					err)
 			}
 		}
 	}()
@@ -14210,8 +14269,9 @@ func TestLightningNetworkDaemon(t *testing.T) {
 		ht.Fatalf("unable to set up test lightning network: %v", err)
 	}
 
-	t.Logf("Running %v integration tests", len(testsCases))
-	for _, testCase := range testsCases {
+	// Run the subset of the test cases selected in this tranche.
+	for idx, testCase := range testCases {
+		testCase := testCase
 		logLine := fmt.Sprintf("STARTING ============ %v ============\n",
 			testCase.name)
 
@@ -14232,7 +14292,10 @@ func TestLightningNetworkDaemon(t *testing.T) {
 		// Start every test with the default static fee estimate.
 		lndHarness.SetFeeEstimate(12500)
 
-		success := t.Run(testCase.name, func(t1 *testing.T) {
+		name := fmt.Sprintf("%02d-of-%d/%s/%s",
+			trancheOffset+uint(idx)+1, len(allTestCases),
+			chainBackend.Name(), testCase.name)
+		success := t.Run(name, func(t1 *testing.T) {
 			ht := newHarnessTest(t1, lndHarness)
 			ht.RunTestCase(testCase)
 		})
@@ -14242,8 +14305,9 @@ func TestLightningNetworkDaemon(t *testing.T) {
 		if !success {
 			// Log failure time to help relate the lnd logs to the
 			// failure.
-			t.Logf("Failure time: %v",
-				time.Now().Format("2006-01-02 15:04:05.000"))
+			t.Logf("Failure time: %v", time.Now().Format(
+				"2006-01-02 15:04:05.000",
+			))
 			break
 		}
 	}

--- a/lntest/itest/lnd_test.go
+++ b/lntest/itest/lnd_test.go
@@ -14,7 +14,6 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
-	"runtime"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -14213,23 +14212,9 @@ func TestLightningNetworkDaemon(t *testing.T) {
 		t, chainBackend.ConnectMiner(), "failed to connect to miner",
 	)
 
-	binary := itestLndBinary
-	if runtime.GOOS == "windows" {
-		// Windows (even in a bash like environment like git bash as on
-		// Travis) doesn't seem to like relative paths to exe files...
-		currentDir, err := os.Getwd()
-		if err != nil {
-			ht.Fatalf("unable to get working directory: %v", err)
-		}
-		targetPath := filepath.Join(currentDir, "../../lnd-itest.exe")
-		binary, err = filepath.Abs(targetPath)
-		if err != nil {
-			ht.Fatalf("unable to get absolute path: %v", err)
-		}
-	}
-
 	// Now we can set up our test harness (LND instance), with the chain
 	// backend we just created.
+	binary := ht.getLndBinary()
 	lndHarness, err = lntest.NewNetworkHarness(miner, chainBackend, binary)
 	if err != nil {
 		ht.Fatalf("unable to create lightning network harness: %v", err)

--- a/lntest/itest/lnd_test_list_off_test.go
+++ b/lntest/itest/lnd_test_list_off_test.go
@@ -2,4 +2,4 @@
 
 package itest
 
-var testsCases = []*testCase{}
+var allTestCases = []*testCase{}

--- a/lntest/itest/lnd_test_list_on_test.go
+++ b/lntest/itest/lnd_test_list_on_test.go
@@ -4,6 +4,10 @@ package itest
 
 var allTestCases = []*testCase{
 	{
+		name: "test multi-hop htlc",
+		test: testMultiHopHtlcClaims,
+	},
+	{
 		name: "sweep coins",
 		test: testSweepAllCoins,
 	},
@@ -143,10 +147,6 @@ var allTestCases = []*testCase{
 	{
 		name: "async bidirectional payments",
 		test: testBidirectionalAsyncPayments,
-	},
-	{
-		name: "test multi-hop htlc",
-		test: testMultiHopHtlcClaims,
 	},
 	{
 		name: "switch circuit persistence",

--- a/lntest/itest/lnd_test_list_on_test.go
+++ b/lntest/itest/lnd_test_list_on_test.go
@@ -2,7 +2,7 @@
 
 package itest
 
-var testsCases = []*testCase{
+var allTestCases = []*testCase{
 	{
 		name: "sweep coins",
 		test: testSweepAllCoins,

--- a/lntest/node.go
+++ b/lntest/node.go
@@ -70,6 +70,10 @@ var (
 	logOutput = flag.Bool("logoutput", false,
 		"log output from node n to file output-n.log")
 
+	// logSubDir is the default directory where the logs are written to if
+	// logOutput is true.
+	logSubDir = flag.String("logdir", ".", "default dir to write logs to")
+
 	// goroutineDump is a flag that can be set to dump the active
 	// goroutines of test nodes on failure.
 	goroutineDump = flag.Bool("goroutinedump", false,
@@ -108,6 +112,15 @@ func nextAvailablePort() int {
 // possible to run the tests in parallel without colliding on the same ports.
 func ApplyPortOffset(offset uint32) {
 	_ = atomic.AddUint32(&lastPort, offset)
+}
+
+// GetLogDir returns the passed --logdir flag or the default value if it wasn't
+// set.
+func GetLogDir() string {
+	if logSubDir != nil && *logSubDir != "" {
+		return *logSubDir
+	}
+	return "."
 }
 
 // generateListeningPorts returns four ints representing ports to listen on
@@ -392,11 +405,9 @@ func NewMiner(logDir, logFilename string, netParams *chaincfg.Params,
 
 		// After shutting down the miner, we'll make a copy of the log
 		// file before deleting the temporary log dir.
-		logFile := fmt.Sprintf(
-			"%s/%s/btcd.log", logDir, netParams.Name,
-		)
-		copyPath := fmt.Sprintf("./%s", logFilename)
-		err := CopyFile(copyPath, logFile)
+		logFile := fmt.Sprintf("%s/%s/btcd.log", logDir, netParams.Name)
+		copyPath := fmt.Sprintf("%s/../%s", logDir, logFilename)
+		err := CopyFile(filepath.Clean(copyPath), logFile)
 		if err != nil {
 			return fmt.Errorf("unable to copy file: %v", err)
 		}
@@ -481,24 +492,28 @@ func (hn *HarnessNode) start(lndBinary string, lndError chan<- error) error {
 	// If the logoutput flag is passed, redirect output from the nodes to
 	// log files.
 	if *logOutput {
-		fileName := fmt.Sprintf("output-%d-%s-%s.log", hn.NodeID,
+		dir := GetLogDir()
+		fileName := fmt.Sprintf("%s/output-%d-%s-%s.log", dir, hn.NodeID,
 			hn.Cfg.Name, hex.EncodeToString(hn.PubKey[:logPubKeyBytes]))
 
 		// If the node's PubKey is not yet initialized, create a temporary
 		// file name. Later, after the PubKey has been initialized, the
 		// file can be moved to its final name with the PubKey included.
 		if bytes.Equal(hn.PubKey[:4], []byte{0, 0, 0, 0}) {
-			fileName = fmt.Sprintf("output-%d-%s-tmp__.log", hn.NodeID,
-				hn.Cfg.Name)
+			fileName = fmt.Sprintf("%s/output-%d-%s-tmp__.log",
+				dir, hn.NodeID, hn.Cfg.Name)
 
 			// Once the node has done its work, the log file can be renamed.
 			finalizeLogfile = func() {
 				if hn.logFile != nil {
 					hn.logFile.Close()
 
-					newFileName := fmt.Sprintf("output-%d-%s-%s.log",
-						hn.NodeID, hn.Cfg.Name,
-						hex.EncodeToString(hn.PubKey[:logPubKeyBytes]))
+					pubKeyHex := hex.EncodeToString(
+						hn.PubKey[:logPubKeyBytes],
+					)
+					newFileName := fmt.Sprintf("%s/output"+
+						"-%d-%s-%s.log", dir, hn.NodeID,
+						hn.Cfg.Name, pubKeyHex)
 					err := os.Rename(fileName, newFileName)
 					if err != nil {
 						fmt.Printf("could not rename "+

--- a/lntest/node.go
+++ b/lntest/node.go
@@ -43,7 +43,7 @@ const (
 	// defaultNodePort is the start of the range for listening ports of
 	// harness nodes. Ports are monotonically increasing starting from this
 	// number and are determined by the results of nextAvailablePort().
-	defaultNodePort = 19555
+	defaultNodePort = 5555
 
 	// logPubKeyBytes is the number of bytes of the node's PubKey that will
 	// be appended to the log file name. The whole PubKey is too long and
@@ -102,6 +102,12 @@ func nextAvailablePort() int {
 
 	// No ports available? Must be a mistake.
 	panic("no ports available for listening")
+}
+
+// ApplyPortOffset adds the given offset to the lastPort variable, making it
+// possible to run the tests in parallel without colliding on the same ports.
+func ApplyPortOffset(offset uint32) {
+	_ = atomic.AddUint32(&lastPort, offset)
 }
 
 // generateListeningPorts returns four ints representing ports to listen on

--- a/make/testing_flags.mk
+++ b/make/testing_flags.mk
@@ -3,10 +3,16 @@ RPC_TAGS = autopilotrpc chainrpc invoicesrpc routerrpc signrpc verrpc walletrpc 
 LOG_TAGS =
 TEST_FLAGS =
 COVER_PKG = $$(go list -deps ./... | grep '$(PKG)' | grep -v lnrpc)
+NUM_ITEST_TRANCHES = 6
 
 # If rpc option is set also add all extra RPC tags to DEV_TAGS
 ifneq ($(with-rpc),)
 DEV_TAGS += $(RPC_TAGS)
+endif
+
+# Scale the number of parallel running itest tranches.
+ifneq ($(tranches),)
+NUM_ITEST_TRANCHES = $(tranches)
 endif
 
 # If specific package is being unit tested, construct the full name of the
@@ -25,7 +31,7 @@ endif
 
 # Define the integration test.run filter if the icase argument was provided.
 ifneq ($(icase),)
-TEST_FLAGS += -test.run=TestLightningNetworkDaemon/$(icase)
+TEST_FLAGS += -test.run="TestLightningNetworkDaemon/.*-of-.*/.*/$(icase)"
 endif
 
 ifneq ($(tags),)

--- a/scripts/itest_part.sh
+++ b/scripts/itest_part.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+# Let's work with absolute paths only, we run in the itest directory itself.
+WORKDIR=$(pwd)/lntest/itest
+
+TRANCHE=$1
+NUM_TRANCHES=$2
+
+# Shift the passed parameters by two, giving us all remaining testing flags in
+# the $@ special variable.
+shift
+shift
+
+# Windows insists on having the .exe suffix for an executable, we need to add
+# that here if necessary.
+EXEC="$WORKDIR"/itest.test"$EXEC_SUFFIX"
+LND_EXEC="$WORKDIR"/lnd-itest"$EXEC_SUFFIX"
+echo $EXEC -test.v "$@" -logoutput -goroutinedump -logdir=.logs-tranche$TRANCHE -lndexec=$LND_EXEC -splittranches=$NUM_TRANCHES -runtranche=$TRANCHE
+
+# Exit code 255 causes the parallel jobs to abort, so if one part fails the
+# other is aborted too.
+cd "$WORKDIR" || exit 255
+$EXEC -test.v "$@" -logoutput -goroutinedump -logdir=.logs-tranche$TRANCHE -lndexec=$LND_EXEC -splittranches=$NUM_TRANCHES -runtranche=$TRANCHE || exit 255


### PR DESCRIPTION
Depends on https://github.com/lightningnetwork/lnd/pull/4268, only the last 8 commits are new.

This PR splits all integration tests in 4 distinct groups and runs them in parallel. This creates a bit of overhead by creating the test harness (mining btc node, chain backend btc node and two lnd nodes) four times.
But that easily offset by running the tests in parallel and saturating the CPU much better.

### Before
(master at 9c9ce15ca679b15b73d00c6e912ea93d1458b5eb)
![itest_master_before_speedup](https://user-images.githubusercontent.com/1008879/97591334-cc4ec000-19ff-11eb-8de9-a6dd621a6914.png)

### After
(this PR at 15420639767e0bffe01d8fa22cc73c5de13390da)
![itest_4655_after_speedup](https://user-images.githubusercontent.com/1008879/97591353-d1ac0a80-19ff-11eb-92bd-a19cc5e761f4.png)

### Speedup
 - Btcd: 62%
 - Bitcoind with txindex: 58%
 - Bitcoind without txindex: 59%
 - Neutrino: 64%
 - Btcd ARM: 70%
 - Btcd Windows: 55%

### Flakes

There still are some flakes in the itests. But I feel that they are on an acceptable level with all the recent fixes. Still, the following list gives an indication of the still open flakes and the ones that were fixed by this PR or #4721.

#### `TestLightningNetworkDaemon/group4-9of18/bitcoind/immediate_payment_after_channel_opened`
```
*errors.errorString payment failed: FAILED
.../github.com/lightningnetwork/lnd/lntest/itest/lnd_test.go:13995 (0xea45da)
     sendAndAssertSuccess: t.Fatalf("payment failed: %v", result.Status)
.../github.com/lightningnetwork/lnd/lntest/itest/lnd_test.go:1584 (0xe57f85)
     testPaymentFollowingChannelOpen: sendAndAssertSuccess(t, net.Alice, &routerrpc.SendPaymentRequest{
```
- Fixed 1714394a :heavy_check_mark: 

#### `TestLightningNetworkDaemon/group3-17of18/btcd/async_bidirectional_payments`
```
test_harness.go:88: Failed: (async bidirectional payments): exited with error: 
*errors.errorString unable to close channel: error while waiting for broadcast tx: tx not seen before context timeout
.../github.com/lightningnetwork/lnd/lntest/itest/lnd_test.go:176 (0xe19947)
```
- Found problem, connection issue between miner and backend btcd node :hourglass: 

#### `TestLightningNetworkDaemon/group3-18of18/neutrino/test_multi-hop_htlc/committype=legacy/receiver_chain_claim`
```
test_harness.go:91: Error outside of test: *errors.errorString unable to find Carol's force close tx in mempool: wanted 2, found 1 txs in mempool: [62dea1ffd7a9408616d809e171d18de03c9f55351297e8cf750a83fd63168596]
.../github.com/lightningnetwork/lnd/lntest/itest/lnd_test.go:9411 (0xe8251e)
     assertDLPExecuted: t.Fatalf("unable to find Carol's force close tx in mempool: %v",
```
 - Fixed 0f2827aa :heavy_check_mark: 

#### `TestLightningNetworkDaemon/group2-8of15/bitcoind/abandonchannel`
```
test_harness.go:88: Failed: (abandonchannel): exited with error: 
*errors.errorString channel shouldn't be found in the channel graph!
.../github.com/lightningnetwork/lnd/lntest/itest/lnd_test.go:13106 (0xe9dfe5)
     testAbandonChannel: t.Fatalf("channel shouldn't be found in the channel " +
.../github.com/lightningnetwork/lnd/lntest/itest/test_harness.go:112 (0xe300ee)
     (*harnessTest).RunTestCase: testCase.test(h.lndHarness, h)
.../github.com/lightningnetwork/lnd/lntest/itest/lnd_test.go:14208 (0xec7448)
     TestLightningNetworkDaemon.func4: ht.RunTestCase(testCase)
/home/travis/.gimme/versions/go1.15.3.linux.amd64/src/testing/testing.go:1123 (0x51cd0f)
     tRunner: fn(t)
/home/travis/.gimme/versions/go1.15.3.linux.amd64/src/runtime/asm_amd64.s:1374 (0x46f721)
     goexit: BYTE	$0x90	// NOP
```

#### `TestLightningNetworkDaemon/group2-5of15/neutrino/revoked_uncooperative_close_retribution`
```
test_harness.go:88: Failed: (revoked uncooperative close retribution): exited with error: 
*errors.errorString error while waiting for channel close: rpc error: code = DeadlineExceeded desc = context deadline exceeded
.../github.com/lightningnetwork/lnd/lntest/itest/lnd_test.go:8221 (0xe7b89e)
     testRevokedCloseRetribution: t.Fatalf("error while waiting for channel close: %v", err)
.../github.com/lightningnetwork/lnd/lntest/itest/test_harness.go:112 (0xe2d32e)
     (*harnessTest).RunTestCase: testCase.test(h.lndHarness, h)
.../github.com/lightningnetwork/lnd/lntest/itest/lnd_test.go:14208 (0xec4628)
     TestLightningNetworkDaemon.func4: ht.RunTestCase(testCase)
/home/travis/.gimme/versions/go1.15.3.linux.amd64/src/testing/testing.go:1123 (0x51bd6f)
     tRunner: fn(t)
/home/travis/.gimme/versions/go1.15.3.linux.amd64/src/runtime/asm_amd64.s:1374 (0x46f721)
     goexit: BYTE	$0x90	// NOP
```