### PR TITLE
channeldb/kvdb/bolt: automatically compact database on startup

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -129,12 +129,6 @@ jobs:
   cross-compile:
     name: cross compilation
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        build_sys:
-          - windows-amd64
-          - freebsd-amd64
-          - solaris-amd64
     steps:
       - name: git checkout
         uses: actions/checkout@v2
@@ -155,8 +149,8 @@ jobs:
         with:
           go-version: '~${{ env.GO_VERSION }}'
 
-      - name: build release for architecture
-        run: make release sys=${{ matrix.build_sys }}
+      - name: build release for all architectures
+        run: make release
 
   ########################
   # mobile compilation

--- a/channeldb/db.go
+++ b/channeldb/db.go
@@ -238,7 +238,13 @@ func Open(dbPath string, modifiers ...OptionModifier) (*DB, error) {
 		modifier(&opts)
 	}
 
-	backend, err := kvdb.GetBoltBackend(dbPath, dbName, opts.NoFreelistSync)
+	backend, err := kvdb.GetBoltBackend(&kvdb.BoltBackendConfig{
+		DBPath:            dbPath,
+		DBFileName:        dbName,
+		NoFreelistSync:    opts.NoFreelistSync,
+		AutoCompact:       opts.AutoCompact,
+		AutoCompactMinAge: opts.AutoCompactMinAge,
+	})
 	if err != nil {
 		return nil, err
 	}

--- a/channeldb/kvdb/backend.go
+++ b/channeldb/kvdb/backend.go
@@ -9,6 +9,13 @@ import (
 	_ "github.com/btcsuite/btcwallet/walletdb/bdb" // Import to register backend.
 )
 
+const (
+	// DefaultTempDBFileName is the default name of the temporary bolt DB
+	// file that we'll use to atomically compact the primary DB file on
+	// startup.
+	DefaultTempDBFileName = "temp-dont-use.db"
+)
+
 // fileExists returns true if the file exists, and false otherwise.
 func fileExists(path string) bool {
 	if _, err := os.Stat(path); err != nil {
@@ -48,15 +55,12 @@ type BoltBackendConfig struct {
 	AutoCompactMinAge time.Duration
 }
 
-// GetBoltBackend opens (or creates if doesn't exits) a bbolt
-// backed database and returns a kvdb.Backend wrapping it.
+// GetBoltBackend opens (or creates if doesn't exits) a bbolt backed database
+// and returns a kvdb.Backend wrapping it.
 func GetBoltBackend(cfg *BoltBackendConfig) (Backend, error) {
 	dbFilePath := filepath.Join(cfg.DBPath, cfg.DBFileName)
-	var (
-		db  Backend
-		err error
-	)
 
+	// Is this a new database?
 	if !fileExists(dbFilePath) {
 		if !fileExists(cfg.DBPath) {
 			if err := os.MkdirAll(cfg.DBPath, 0700); err != nil {
@@ -64,16 +68,86 @@ func GetBoltBackend(cfg *BoltBackendConfig) (Backend, error) {
 			}
 		}
 
-		db, err = Create(BoltBackendName, dbFilePath, cfg.NoFreelistSync)
-	} else {
-		db, err = Open(BoltBackendName, dbFilePath, cfg.NoFreelistSync)
+		return Create(BoltBackendName, dbFilePath, cfg.NoFreelistSync)
 	}
 
+	// This is an existing database. We might want to compact it on startup
+	// to free up some space.
+	if cfg.AutoCompact {
+		if err := compactAndSwap(cfg); err != nil {
+			return nil, err
+		}
+	}
+
+	return Open(BoltBackendName, dbFilePath, cfg.NoFreelistSync)
+}
+
+// compactAndSwap will attempt to write a new temporary DB file to disk with
+// the compacted database content, then atomically swap (via rename) the old
+// file for the new file by updating the name of the new file to the old.
+func compactAndSwap(cfg *BoltBackendConfig) error {
+	sourceName := cfg.DBFileName
+
+	// If the main DB file isn't set, then we can't proceed.
+	if sourceName == "" {
+		return fmt.Errorf("cannot compact DB with empty name")
+	}
+	sourceFilePath := filepath.Join(cfg.DBPath, sourceName)
+	tempDestFilePath := filepath.Join(cfg.DBPath, DefaultTempDBFileName)
+
+	log.Infof("Compacting database file at %v", sourceFilePath)
+
+	// If the old temporary DB file still exists, then we'll delete it
+	// before proceeding.
+	if _, err := os.Stat(tempDestFilePath); err == nil {
+		log.Infof("Found old temp DB @ %v, removing before swap",
+			tempDestFilePath)
+
+		err = os.Remove(tempDestFilePath)
+		if err != nil {
+			return fmt.Errorf("unable to remove old temp DB file: "+
+				"%v", err)
+		}
+	}
+
+	// Now that we know the staging area is clear, we'll create the new
+	// temporary DB file and close it before we write the new DB to it.
+	tempFile, err := os.Create(tempDestFilePath)
 	if err != nil {
-		return nil, err
+		return fmt.Errorf("unable to create temp DB file: %v", err)
+	}
+	if err := tempFile.Close(); err != nil {
+		return fmt.Errorf("unable to close file: %v", err)
 	}
 
-	return db, nil
+	// With the file created, we'll start the compaction and remove the
+	// temporary file all together once this method exits.
+	defer func() {
+		// This will only succeed if the rename below fails. If the
+		// compaction is successful, the file won't exist on exit
+		// anymore so no need to log an error here.
+		_ = os.Remove(tempDestFilePath)
+	}()
+	c := &compacter{
+		srcPath: sourceFilePath,
+		dstPath: tempDestFilePath,
+	}
+	initialSize, newSize, err := c.execute()
+	if err != nil {
+		return fmt.Errorf("error during compact: %v", err)
+	}
+
+	log.Infof("DB compaction of %v successful, %d -> %d bytes (gain=%.2fx)",
+		sourceFilePath, initialSize, newSize,
+		float64(initialSize)/float64(newSize))
+
+	log.Infof("Swapping old DB file from %v to %v", tempDestFilePath,
+		sourceFilePath)
+
+	// Finally, we'll attempt to atomically rename the temporary file to
+	// the main back up file. If this succeeds, then we'll only have a
+	// single file on disk once this method exits.
+	return os.Rename(tempDestFilePath, sourceFilePath)
 }
 
 // GetTestBackend opens (or creates if doesn't exist) a bbolt or etcd

--- a/channeldb/kvdb/backend.go
+++ b/channeldb/kvdb/backend.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"time"
 
 	_ "github.com/btcsuite/btcwallet/walletdb/bdb" // Import to register backend.
 )
@@ -19,25 +20,53 @@ func fileExists(path string) bool {
 	return true
 }
 
+// BoltBackendConfig is a struct that holds settings specific to the bolt
+// database backend.
+type BoltBackendConfig struct {
+	// DBPath is the directory path in which the database file should be
+	// stored.
+	DBPath string
+
+	// DBFileName is the name of the database file.
+	DBFileName string
+
+	// NoFreelistSync, if true, prevents the database from syncing its
+	// freelist to disk, resulting in improved performance at the expense of
+	// increased startup time.
+	NoFreelistSync bool
+
+	// AutoCompact specifies if a Bolt based database backend should be
+	// automatically compacted on startup (if the minimum age of the
+	// database file is reached). This will require additional disk space
+	// for the compacted copy of the database but will result in an overall
+	// lower database size after the compaction.
+	AutoCompact bool
+
+	// AutoCompactMinAge specifies the minimum time that must have passed
+	// since a bolt database file was last compacted for the compaction to
+	// be considered again.
+	AutoCompactMinAge time.Duration
+}
+
 // GetBoltBackend opens (or creates if doesn't exits) a bbolt
 // backed database and returns a kvdb.Backend wrapping it.
-func GetBoltBackend(path, name string, noFreeListSync bool) (Backend, error) {
-	dbFilePath := filepath.Join(path, name)
+func GetBoltBackend(cfg *BoltBackendConfig) (Backend, error) {
+	dbFilePath := filepath.Join(cfg.DBPath, cfg.DBFileName)
 	var (
 		db  Backend
 		err error
 	)
 
 	if !fileExists(dbFilePath) {
-		if !fileExists(path) {
-			if err := os.MkdirAll(path, 0700); err != nil {
+		if !fileExists(cfg.DBPath) {
+			if err := os.MkdirAll(cfg.DBPath, 0700); err != nil {
 				return nil, err
 			}
 		}
 
-		db, err = Create(BoltBackendName, dbFilePath, noFreeListSync)
+		db, err = Create(BoltBackendName, dbFilePath, cfg.NoFreelistSync)
 	} else {
-		db, err = Open(BoltBackendName, dbFilePath, noFreeListSync)
+		db, err = Open(BoltBackendName, dbFilePath, cfg.NoFreelistSync)
 	}
 
 	if err != nil {
@@ -57,7 +86,11 @@ func GetTestBackend(path, name string) (Backend, func(), error) {
 	empty := func() {}
 
 	if TestBackend == BoltBackendName {
-		db, err := GetBoltBackend(path, name, true)
+		db, err := GetBoltBackend(&BoltBackendConfig{
+			DBPath:         path,
+			DBFileName:     name,
+			NoFreelistSync: true,
+		})
 		if err != nil {
 			return nil, nil, err
 		}

--- a/channeldb/kvdb/bolt_compact.go
+++ b/channeldb/kvdb/bolt_compact.go
@@ -1,0 +1,246 @@
+// The code in this file is an adapted version of the bbolt compact command
+// implemented in this file:
+// https://github.com/etcd-io/bbolt/blob/master/cmd/bbolt/main.go
+
+package kvdb
+
+import (
+	"fmt"
+	"os"
+	"path"
+
+	"github.com/lightningnetwork/lnd/healthcheck"
+	"go.etcd.io/bbolt"
+)
+
+const (
+	// defaultResultFileSizeMultiplier is the default multiplier we apply to
+	// the current database size to calculate how big it could possibly get
+	// after compacting, in case the database is already at its optimal size
+	// and compaction causes it to grow. This should normally not be the
+	// case but we really want to avoid not having enough disk space for the
+	// compaction, so we apply a safety margin of 10%.
+	defaultResultFileSizeMultiplier = float64(1.1)
+
+	// defaultTxMaxSize is the default maximum number of operations that
+	// are allowed to be executed in a single transaction.
+	defaultTxMaxSize = 65536
+
+	// bucketFillSize is the fill size setting that is used for each new
+	// bucket that is created in the compacted database. This setting is not
+	// persisted and is therefore only effective for the compaction itself.
+	// Because during the compaction we only append data a fill percent of
+	// 100% is optimal for performance.
+	bucketFillSize = 1.0
+)
+
+type compacter struct {
+	srcPath   string
+	dstPath   string
+	txMaxSize int64
+}
+
+// execute opens the source and destination databases and then compacts the
+// source into destination and returns the size of both files as a result.
+func (cmd *compacter) execute() (int64, int64, error) {
+	if cmd.txMaxSize == 0 {
+		cmd.txMaxSize = defaultTxMaxSize
+	}
+
+	// Ensure source file exists.
+	fi, err := os.Stat(cmd.srcPath)
+	if err != nil {
+		return 0, 0, fmt.Errorf("error determining source database "+
+			"size: %v", err)
+	}
+	initialSize := fi.Size()
+	marginSize := float64(initialSize) * defaultResultFileSizeMultiplier
+
+	// Before opening any of the databases, let's first make sure we have
+	// enough free space on the destination file system to create a full
+	// copy of the source DB (worst-case scenario if the compaction doesn't
+	// actually shrink the file size).
+	destFolder := path.Dir(cmd.dstPath)
+	freeSpace, err := healthcheck.AvailableDiskSpace(destFolder)
+	if err != nil {
+		return 0, 0, fmt.Errorf("error determining free disk space on "+
+			"%s: %v", destFolder, err)
+	}
+	log.Debugf("Free disk space on compaction destination file system: "+
+		"%d bytes", freeSpace)
+	if freeSpace < uint64(marginSize) {
+		return 0, 0, fmt.Errorf("could not start compaction, "+
+			"destination folder %s only has %d bytes of free disk "+
+			"space available while we need at least %d for worst-"+
+			"case compaction", destFolder, freeSpace, initialSize)
+	}
+
+	// Open source database. We open it in read only mode to avoid (and fix)
+	// possible freelist sync problems.
+	src, err := bbolt.Open(cmd.srcPath, 0444, &bbolt.Options{
+		ReadOnly: true,
+	})
+	if err != nil {
+		return 0, 0, fmt.Errorf("error opening source database: %v",
+			err)
+	}
+	defer func() {
+		if err := src.Close(); err != nil {
+			log.Errorf("Compact error: closing source DB: %v", err)
+		}
+	}()
+
+	// Open destination database.
+	dst, err := bbolt.Open(cmd.dstPath, fi.Mode(), nil)
+	if err != nil {
+		return 0, 0, fmt.Errorf("error opening destination database: "+
+			"%v", err)
+	}
+	defer func() {
+		if err := dst.Close(); err != nil {
+			log.Errorf("Compact error: closing dest DB: %v", err)
+		}
+	}()
+
+	// Run compaction.
+	if err := cmd.compact(dst, src); err != nil {
+		return 0, 0, fmt.Errorf("error running compaction: %v", err)
+	}
+
+	// Report stats on new size.
+	fi, err = os.Stat(cmd.dstPath)
+	if err != nil {
+		return 0, 0, fmt.Errorf("error determining destination "+
+			"database size: %v", err)
+	} else if fi.Size() == 0 {
+		return 0, 0, fmt.Errorf("zero db size")
+	}
+
+	return initialSize, fi.Size(), nil
+}
+
+// compact tries to create a compacted copy of the source database in a new
+// destination database.
+func (cmd *compacter) compact(dst, src *bbolt.DB) error {
+	// Commit regularly, or we'll run out of memory for large datasets if
+	// using one transaction.
+	var size int64
+	tx, err := dst.Begin(true)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		_ = tx.Rollback()
+	}()
+
+	if err := cmd.walk(src, func(keys [][]byte, k, v []byte, seq uint64) error {
+		// On each key/value, check if we have exceeded tx size.
+		sz := int64(len(k) + len(v))
+		if size+sz > cmd.txMaxSize && cmd.txMaxSize != 0 {
+			// Commit previous transaction.
+			if err := tx.Commit(); err != nil {
+				return err
+			}
+
+			// Start new transaction.
+			tx, err = dst.Begin(true)
+			if err != nil {
+				return err
+			}
+			size = 0
+		}
+		size += sz
+
+		// Create bucket on the root transaction if this is the first
+		// level.
+		nk := len(keys)
+		if nk == 0 {
+			bkt, err := tx.CreateBucket(k)
+			if err != nil {
+				return err
+			}
+			if err := bkt.SetSequence(seq); err != nil {
+				return err
+			}
+			return nil
+		}
+
+		// Create buckets on subsequent levels, if necessary.
+		b := tx.Bucket(keys[0])
+		if nk > 1 {
+			for _, k := range keys[1:] {
+				b = b.Bucket(k)
+			}
+		}
+
+		// Fill the entire page for best compaction.
+		b.FillPercent = bucketFillSize
+
+		// If there is no value then this is a bucket call.
+		if v == nil {
+			bkt, err := b.CreateBucket(k)
+			if err != nil {
+				return err
+			}
+			if err := bkt.SetSequence(seq); err != nil {
+				return err
+			}
+			return nil
+		}
+
+		// Otherwise treat it as a key/value pair.
+		return b.Put(k, v)
+	}); err != nil {
+		return err
+	}
+
+	return tx.Commit()
+}
+
+// walkFunc is the type of the function called for keys (buckets and "normal"
+// values) discovered by Walk. keys is the list of keys to descend to the bucket
+// owning the discovered key/value pair k/v.
+type walkFunc func(keys [][]byte, k, v []byte, seq uint64) error
+
+// walk walks recursively the bolt database db, calling walkFn for each key it
+// finds.
+func (cmd *compacter) walk(db *bbolt.DB, walkFn walkFunc) error {
+	return db.View(func(tx *bbolt.Tx) error {
+		return tx.ForEach(func(name []byte, b *bbolt.Bucket) error {
+			// This will log the top level buckets only to give the
+			// user some sense of progress.
+			log.Debugf("Compacting top level bucket %s", name)
+
+			return cmd.walkBucket(
+				b, nil, name, nil, b.Sequence(), walkFn,
+			)
+		})
+	})
+}
+
+// walkBucket recursively walks through a bucket.
+func (cmd *compacter) walkBucket(b *bbolt.Bucket, keyPath [][]byte, k, v []byte,
+	seq uint64, fn walkFunc) error {
+
+	// Execute callback.
+	if err := fn(keyPath, k, v, seq); err != nil {
+		return err
+	}
+
+	// If this is not a bucket then stop.
+	if v != nil {
+		return nil
+	}
+
+	// Iterate over each child key/value.
+	keyPath = append(keyPath, k)
+	return b.ForEach(func(k, v []byte) error {
+		if v == nil {
+			bkt := b.Bucket(k)
+			return cmd.walkBucket(
+				bkt, keyPath, k, nil, bkt.Sequence(), fn,
+			)
+		}
+		return cmd.walkBucket(b, keyPath, k, v, b.Sequence(), fn)
+	})
+}

--- a/channeldb/kvdb/config.go
+++ b/channeldb/kvdb/config.go
@@ -1,18 +1,31 @@
 package kvdb
 
-// BoltBackendName is the name of the backend that should be passed into
-// kvdb.Create to initialize a new instance of kvdb.Backend backed by a live
-// instance of bbolt.
-const BoltBackendName = "bdb"
+import "time"
 
-// EtcdBackendName is the name of the backend that should be passed into
-// kvdb.Create to initialize a new instance of kvdb.Backend backed by a live
-// instance of etcd.
-const EtcdBackendName = "etcd"
+const (
+	// BoltBackendName is the name of the backend that should be passed into
+	// kvdb.Create to initialize a new instance of kvdb.Backend backed by a
+	// live instance of bbolt.
+	BoltBackendName = "bdb"
+
+	// EtcdBackendName is the name of the backend that should be passed into
+	// kvdb.Create to initialize a new instance of kvdb.Backend backed by a
+	// live instance of etcd.
+	EtcdBackendName = "etcd"
+
+	// DefaultBoltAutoCompactMinAge is the default minimum time that must
+	// have passed since a bolt database file was last compacted for the
+	// compaction to be considered again.
+	DefaultBoltAutoCompactMinAge = time.Hour * 24 * 7
+)
 
 // BoltConfig holds bolt configuration.
 type BoltConfig struct {
 	SyncFreelist bool `long:"nofreelistsync" description:"Whether the databases used within lnd should sync their freelist to disk. This is disabled by default resulting in improved memory performance during operation, but with an increase in startup time."`
+
+	AutoCompact bool `long:"auto-compact" description:"Whether the databases used within lnd should automatically be compacted on every startup (and if the database has the configured minimum age). This is disabled by default because it requires additional disk space to be available during the compaction that is freed afterwards. In general compaction leads to smaller database files."`
+
+	AutoCompactMinAge time.Duration `long:"auto-compact-min-age" description:"How long ago the last compaction of a database file must be for it to be considered for auto compaction again. Can be set to 0 to compact on every startup."`
 }
 
 // EtcdConfig holds etcd configuration.

--- a/channeldb/kvdb/log.go
+++ b/channeldb/kvdb/log.go
@@ -1,0 +1,12 @@
+package kvdb
+
+import "github.com/btcsuite/btclog"
+
+// log is a logger that is initialized as disabled.  This means the package will
+// not perform any logging by default until a logger is set.
+var log = btclog.Disabled
+
+// UseLogger uses a specified Logger to output package logging info.
+func UseLogger(logger btclog.Logger) {
+	log = logger
+}

--- a/channeldb/log.go
+++ b/channeldb/log.go
@@ -3,6 +3,7 @@ package channeldb
 import (
 	"github.com/btcsuite/btclog"
 	"github.com/lightningnetwork/lnd/build"
+	"github.com/lightningnetwork/lnd/channeldb/kvdb"
 	mig "github.com/lightningnetwork/lnd/channeldb/migration"
 	"github.com/lightningnetwork/lnd/channeldb/migration12"
 	"github.com/lightningnetwork/lnd/channeldb/migration13"
@@ -35,4 +36,5 @@ func UseLogger(logger btclog.Logger) {
 	migration12.UseLogger(logger)
 	migration13.UseLogger(logger)
 	migration16.UseLogger(logger)
+	kvdb.UseLogger(logger)
 }

--- a/go.mod
+++ b/go.mod
@@ -63,6 +63,7 @@ require (
 	github.com/tv42/zbase32 v0.0.0-20160707012821-501572607d02
 	github.com/urfave/cli v1.18.0
 	github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2 // indirect
+	go.etcd.io/bbolt v1.3.5-0.20200615073812-232d8fc87f50
 	go.uber.org/zap v1.14.1 // indirect
 	golang.org/x/crypto v0.0.0-20200709230013-948cd5f35899
 	golang.org/x/net v0.0.0-20191002035440-2ec189313ef0

--- a/healthcheck/diskcheck.go
+++ b/healthcheck/diskcheck.go
@@ -4,8 +4,9 @@ package healthcheck
 
 import "syscall"
 
-// AvailableDiskSpace returns ratio of available disk space to total capacity.
-func AvailableDiskSpace(path string) (float64, error) {
+// AvailableDiskSpaceRatio returns ratio of available disk space to total
+// capacity.
+func AvailableDiskSpaceRatio(path string) (float64, error) {
 	s := syscall.Statfs_t{}
 	err := syscall.Statfs(path, &s)
 	if err != nil {
@@ -15,4 +16,18 @@ func AvailableDiskSpace(path string) (float64, error) {
 	// Calculate our free blocks/total blocks to get our total ratio of
 	// free blocks.
 	return float64(s.Bfree) / float64(s.Blocks), nil
+}
+
+// AvailableDiskSpace returns the available disk space in bytes of the given
+// file system.
+func AvailableDiskSpace(path string) (uint64, error) {
+	s := syscall.Statfs_t{}
+	err := syscall.Statfs(path, &s)
+	if err != nil {
+		return 0, err
+	}
+
+	// Some OSes have s.Bavail defined as int64, others as uint64, so we
+	// need the explicit type conversion here.
+	return uint64(s.Bavail) * uint64(s.Bsize), nil // nolint:unconvert
 }

--- a/healthcheck/diskcheck_netbsd.go
+++ b/healthcheck/diskcheck_netbsd.go
@@ -2,9 +2,9 @@ package healthcheck
 
 import "golang.org/x/sys/unix"
 
-// AvailableDiskSpace returns ratio of available disk space to total capacity
-// for solaris.
-func AvailableDiskSpace(path string) (float64, error) {
+// AvailableDiskSpaceRatio returns ratio of available disk space to total
+// capacity for netbsd.
+func AvailableDiskSpaceRatio(path string) (float64, error) {
 	s := unix.Statvfs_t{}
 	err := unix.Statvfs(path, &s)
 	if err != nil {
@@ -14,4 +14,16 @@ func AvailableDiskSpace(path string) (float64, error) {
 	// Calculate our free blocks/total blocks to get our total ratio of
 	// free blocks.
 	return float64(s.Bfree) / float64(s.Blocks), nil
+}
+
+// AvailableDiskSpace returns the available disk space in bytes of the given
+// file system for netbsd.
+func AvailableDiskSpace(path string) (uint64, error) {
+	s := unix.Statvfs_t{}
+	err := unix.Statvfs(path, &s)
+	if err != nil {
+		return 0, err
+	}
+
+	return s.Bavail * uint64(s.Bsize), nil
 }

--- a/healthcheck/diskcheck_openbsd.go
+++ b/healthcheck/diskcheck_openbsd.go
@@ -2,9 +2,9 @@ package healthcheck
 
 import "golang.org/x/sys/unix"
 
-// AvailableDiskSpace returns ratio of available disk space to total capacity
-// for solaris.
-func AvailableDiskSpace(path string) (float64, error) {
+// AvailableDiskSpaceRatio returns ratio of available disk space to total
+// capacity for openbsd.
+func AvailableDiskSpaceRatio(path string) (float64, error) {
 	s := unix.Statfs_t{}
 	err := unix.Statfs(path, &s)
 	if err != nil {
@@ -14,4 +14,16 @@ func AvailableDiskSpace(path string) (float64, error) {
 	// Calculate our free blocks/total blocks to get our total ratio of
 	// free blocks.
 	return float64(s.F_bfree) / float64(s.F_blocks), nil
+}
+
+// AvailableDiskSpace returns the available disk space in bytes of the given
+// file system for openbsd.
+func AvailableDiskSpace(path string) (uint64, error) {
+	s := unix.Statfs_t{}
+	err := unix.Statfs(path, &s)
+	if err != nil {
+		return 0, err
+	}
+
+	return uint64(s.F_bavail) * uint64(s.F_bsize), nil
 }

--- a/healthcheck/diskcheck_solaris.go
+++ b/healthcheck/diskcheck_solaris.go
@@ -2,9 +2,9 @@ package healthcheck
 
 import "golang.org/x/sys/unix"
 
-// AvailableDiskSpace returns ratio of available disk space to total capacity
-// for solaris.
-func AvailableDiskSpace(path string) (float64, error) {
+// AvailableDiskSpaceRatio returns ratio of available disk space to total
+// capacity for solaris.
+func AvailableDiskSpaceRatio(path string) (float64, error) {
 	s := unix.Statvfs_t{}
 	err := unix.Statvfs(path, &s)
 	if err != nil {
@@ -14,4 +14,16 @@ func AvailableDiskSpace(path string) (float64, error) {
 	// Calculate our free blocks/total blocks to get our total ratio of
 	// free blocks.
 	return float64(s.Bfree) / float64(s.Blocks), nil
+}
+
+// AvailableDiskSpace returns the available disk space in bytes of the given
+// file system for solaris.
+func AvailableDiskSpace(path string) (uint64, error) {
+	s := unix.Statvfs_t{}
+	err := unix.Statvfs(path, &s)
+	if err != nil {
+		return 0, err
+	}
+
+	return s.Bavail * uint64(s.Bsize), nil
 }

--- a/healthcheck/diskcheck_windows.go
+++ b/healthcheck/diskcheck_windows.go
@@ -2,16 +2,30 @@ package healthcheck
 
 import "golang.org/x/sys/windows"
 
-// AvailableDiskSpace returns ratio of available disk space to total capacity
-// for windows.
-func AvailableDiskSpace(path string) (float64, error) {
+// AvailableDiskSpaceRatio returns ratio of available disk space to total
+// capacity for windows.
+func AvailableDiskSpaceRatio(path string) (float64, error) {
 	var free, total, avail uint64
 
 	pathPtr, err := windows.UTF16PtrFromString(path)
 	if err != nil {
-		panic(err)
+		return 0, err
 	}
 	err = windows.GetDiskFreeSpaceEx(pathPtr, &free, &total, &avail)
 
 	return float64(avail) / float64(total), nil
+}
+
+// AvailableDiskSpace returns the available disk space in bytes of the given
+// file system for windows.
+func AvailableDiskSpace(path string) (uint64, error) {
+	var free, total, avail uint64
+
+	pathPtr, err := windows.UTF16PtrFromString(path)
+	if err != nil {
+		return 0, err
+	}
+	err = windows.GetDiskFreeSpaceEx(pathPtr, &free, &total, &avail)
+
+	return avail, nil
 }

--- a/lncfg/db.go
+++ b/lncfg/db.go
@@ -83,9 +83,13 @@ func (db *DB) GetBackends(ctx context.Context, dbPath string,
 		}
 	}
 
-	localDB, err = kvdb.GetBoltBackend(
-		dbPath, dbName, !db.Bolt.SyncFreelist,
-	)
+	localDB, err = kvdb.GetBoltBackend(&kvdb.BoltBackendConfig{
+		DBPath:            dbPath,
+		DBFileName:        dbName,
+		NoFreelistSync:    !db.Bolt.SyncFreelist,
+		AutoCompact:       db.Bolt.AutoCompact,
+		AutoCompactMinAge: db.Bolt.AutoCompactMinAge,
+	})
 	if err != nil {
 		return nil, err
 	}

--- a/lncfg/db.go
+++ b/lncfg/db.go
@@ -26,7 +26,9 @@ type DB struct {
 func DefaultDB() *DB {
 	return &DB{
 		Backend: BoltBackend,
-		Bolt:    &kvdb.BoltConfig{},
+		Bolt: &kvdb.BoltConfig{
+			AutoCompactMinAge: kvdb.DefaultBoltAutoCompactMinAge,
+		},
 	}
 }
 

--- a/lnd.go
+++ b/lnd.go
@@ -1353,8 +1353,9 @@ func initializeDatabases(ctx context.Context,
 		"minutes...")
 
 	if cfg.DB.Backend == lncfg.BoltBackend {
-		ltndLog.Infof("Opening bbolt database, sync_freelist=%v",
-			cfg.DB.Bolt.SyncFreelist)
+		ltndLog.Infof("Opening bbolt database, sync_freelist=%v, "+
+			"auto_compact=%v", cfg.DB.Bolt.SyncFreelist,
+			cfg.DB.Bolt.AutoCompact)
 	}
 
 	startOpenTime := time.Now()

--- a/make/release_flags.mk
+++ b/make/release_flags.mk
@@ -1,8 +1,7 @@
 VERSION_TAG = $(shell date +%Y%m%d)-01
 VERSION_CHECK = @$(call print, "Building master with date version tag")
 
-BUILD_SYSTEM = darwin-386 \
-darwin-amd64 \
+BUILD_SYSTEM = darwin-amd64 \
 dragonfly-amd64 \
 freebsd-386 \
 freebsd-amd64 \

--- a/sample-lnd.conf
+++ b/sample-lnd.conf
@@ -928,3 +928,15 @@ litecoin.node=ltcd
 [bolt]
 ; If true, prevents the database from syncing its freelist to disk. 
 ; db.bolt.nofreelistsync=1
+
+; Whether the databases used within lnd should automatically be compacted on
+; every startup (and if the database has the configured minimum age). This is
+; disabled by default because it requires additional disk space to be available
+; during the compaction that is freed afterwards. In general compaction leads to
+; smaller database files.
+; db.bolt.auto-compact=true
+
+; How long ago the last compaction of a database file must be for it to be
+; considered for auto compaction again. Can be set to 0 to compact on every
+; startup. (default: 168h)
+; db.bolt.auto-compact-min-age=0

--- a/server.go
+++ b/server.go
@@ -1302,7 +1302,9 @@ func newServer(cfg *Config, listenAddrs []net.Addr,
 	diskCheck := healthcheck.NewObservation(
 		"disk space",
 		func() error {
-			free, err := healthcheck.AvailableDiskSpace(cfg.LndDir)
+			free, err := healthcheck.AvailableDiskSpaceRatio(
+				cfg.LndDir,
+			)
 			if err != nil {
 				return err
 			}

--- a/server.go
+++ b/server.go
@@ -10,7 +10,6 @@ import (
 	"math/big"
 	prand "math/rand"
 	"net"
-	"path/filepath"
 	"regexp"
 	"strconv"
 	"sync"
@@ -371,10 +370,10 @@ func newServer(cfg *Config, listenAddrs []net.Addr,
 	// Initialize the sphinx router, placing it's persistent replay log in
 	// the same directory as the channel graph database. We don't need to
 	// replicate this data, so we'll store it locally.
-	sharedSecretPath := filepath.Join(
-		cfg.localDatabaseDir(), defaultSphinxDbName,
+	replayLog := htlcswitch.NewDecayedLog(
+		cfg.localDatabaseDir(), defaultSphinxDbName, cfg.DB.Bolt,
+		cc.ChainNotifier,
 	)
-	replayLog := htlcswitch.NewDecayedLog(sharedSecretPath, cc.ChainNotifier)
 	sphinxRouter := sphinx.NewRouter(
 		nodeKeyECDH, cfg.ActiveNetParams.Params, replayLog,
 	)


### PR DESCRIPTION
Fixes https://github.com/lightningnetwork/lnd/issues/4131.

Can be turned on with `--db.bolt.auto-compact` in the command line or `db.bolt.auto-compact=true` in the configuration file.

This PR also includes two changes that aren't directly related to compaction:
 - Compile for every architecture on Travis to make sure all architecture dependent compilation succeeds.
 - Remove `darwin-386` from the list of target architectures as it isn't supported by `go 1.15.x` anymore.