### PR TITLE
[autopilot] change default heuristic to top_centrality

### DIFF
--- a/config.go
+++ b/config.go
@@ -395,7 +395,7 @@ func DefaultConfig() Config {
 			MinConfs:       1,
 			ConfTarget:     autopilot.DefaultConfTarget,
 			Heuristic: map[string]float64{
-				"preferential": 1.0,
+				"top_centrality": 1.0,
 			},
 		},
 		PaymentsExpirationGracePeriod: defaultPaymentsExpirationGracePeriod,

--- a/sample-lnd.conf
+++ b/sample-lnd.conf
@@ -477,8 +477,8 @@ litecoin.node=ltcd
 ; autopilot.allocation=0.6
 
 ; Heuristic to activate, and the weight to give it during scoring. (default:
-; {preferential:1})
-; autopilot.heuristic={topk_centrality:1}
+; preferential:1)
+; autopilot.heuristic=top_centrality:1
 
 ; The smallest channel that the autopilot agent should create (default: 20000)
 ; autopilot.minchansize=20000

--- a/sample-lnd.conf
+++ b/sample-lnd.conf
@@ -477,8 +477,8 @@ litecoin.node=ltcd
 ; autopilot.allocation=0.6
 
 ; Heuristic to activate, and the weight to give it during scoring. (default:
-; preferential:1)
-; autopilot.heuristic=top_centrality:1
+; top_centrality:1)
+; autopilot.heuristic=preferential:1
 
 ; The smallest channel that the autopilot agent should create (default: 20000)
 ; autopilot.minchansize=20000


### PR DESCRIPTION
Correct me if I'm wrong, but this seems incorrect, and local testing confirms.

Input:
> autopilot.heuristic={topk_centrality:1}

Result:
> strconv.ParseFloat: parsing "1}": invalid syntax

Input:
> autopilot.heuristic=topk_centrality:1

Result:
> heuristic topk_centrality not available. Available heuristics are: [ 'preferential'  'externalscore'  'top_centrality' ]

It's causing confusion, e.g. here: https://www.reddit.com/r/lightningnetwork/comments/j29ai3/how_to_enable_the_new_autopilot_heuristic_in_v0110/