### PR TITLE
healthcheck: bump logging for failed healthchecks to info

### DIFF
--- a/healthcheck/healthcheck.go
+++ b/healthcheck/healthcheck.go
@@ -215,7 +215,7 @@ func (o *Observation) retryCheck(quit chan struct{}, shutdown shutdownFunc) {
 			return
 		}
 
-		log.Debugf("Health check: %v, call: %v failed with: %v, "+
+		log.Infof("Health check: %v, call: %v failed with: %v, "+
 			"backing off for: %v", o, count, err, o.Backoff)
 
 		// If we are still within the number of calls allowed for this


### PR DESCRIPTION
In this commit, we bump up the logging for failed healthchecks from
`debug` to `info`. This should help us get to the bottom of the current
set of reported false positives that are causing `lnd` nodes to
erroneously shutdown.

