### PR TITLE
PSBT funding: don't include scriptSig field for nested SegWit inputs

### DIFF
--- a/docs/psbt.md
+++ b/docs/psbt.md
@@ -34,11 +34,7 @@ $ lncli wallet psbt fund --outputs='{"bcrt1qjrdns4f5zwkv29ln86plqzs092yd5fg6nsz8
         "locks": [
                 {
                         "id": "ede19a92ed321a4705f8a1cccc1d4f6182545d4bb4fae08bd5937831b7e38f98",
-                        "outpoint": {
-                                "txid_bytes": "e25063654b46dbad2a04181546a310aa6315f974532ae6eb1db73ae983a5eff8",
-                                "txid_str": "f8efa583e93ab71debe62a5374f91563aa10a3461518042aaddb464b656350e2:1",
-                                "output_index": 1
-                        },
+                        "outpoint": "f8efa583e93ab71debe62a5374f91563aa10a3461518042aaddb464b656350e2:1",
                         "expiration": 1601553408
                 }
         ]
@@ -174,20 +170,12 @@ $ lncli wallet psbt fund --outputs='{"bcrt1qjrdns4f5zwkv29ln86plqzs092yd5fg6nsz8
         "locks": [
                 {
                         "id": "ede19a92ed321a4705f8a1cccc1d4f6182545d4bb4fae08bd5937831b7e38f98",
-                        "outpoint": {
-                                "txid_bytes": "488c765c45dccdb456976708c2b434e904a044c6e806b81e90bc56ff51b49735",
-                                "txid_str": "3597b451ff56bc901eb806e8c644a004e934b4c208679756b4cddc455c768c48:1",
-                                "output_index": 1
-                        },
+                        "outpoint": "3597b451ff56bc901eb806e8c644a004e934b4c208679756b4cddc455c768c48:1",
                         "expiration": 1601560626
                 },
                 {
                         "id": "ede19a92ed321a4705f8a1cccc1d4f6182545d4bb4fae08bd5937831b7e38f98",
-                        "outpoint": {
-                                "txid_bytes": "e25063654b46dbad2a04181546a310aa6315f974532ae6eb1db73ae983a5eff8",
-                                "txid_str": "f8efa583e93ab71debe62a5374f91563aa10a3461518042aaddb464b656350e2:1",
-                                "output_index": 1
-                        },
+                        "outpoint": "f8efa583e93ab71debe62a5374f91563aa10a3461518042aaddb464b656350e2:1",
                         "expiration": 1601560626
                 }
         ]
@@ -475,11 +463,7 @@ $ lncli wallet psbt fund --outputs='{"bcrt1qh33ghvgjj3ef625nl9jxz6nnrz2z9e65vsde
         "locks": [
                 {
                         "id": "ede19a92ed321a4705f8a1cccc1d4f6182545d4bb4fae08bd5937831b7e38f98",
-                        "outpoint": {
-                                "txid_bytes": "488c765c45dccdb456976708c2b434e904a044c6e806b81e90bc56ff51b49735",
-                                "txid_str": "3597b451ff56bc901eb806e8c644a004e934b4c208679756b4cddc455c768c48:1",
-                                "output_index": 1
-                        },
+                        "outpoint": "3597b451ff56bc901eb806e8c644a004e934b4c208679756b4cddc455c768c48:1",
                         "expiration": 1601562037
                 }
         ]

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/btcsuite/btclog v0.0.0-20170628155309-84c8d2346e9f
 	github.com/btcsuite/btcutil v1.0.2
 	github.com/btcsuite/btcutil/psbt v1.0.3-0.20200826194809-5f93e33af2b0
-	github.com/btcsuite/btcwallet v0.11.1-0.20201002003944-e6d01202cb6b
+	github.com/btcsuite/btcwallet v0.11.1-0.20201005184831-a7f551a6301c
 	github.com/btcsuite/btcwallet/wallet/txauthor v1.0.0
 	github.com/btcsuite/btcwallet/wallet/txrules v1.0.0
 	github.com/btcsuite/btcwallet/walletdb v1.3.3

--- a/go.sum
+++ b/go.sum
@@ -37,8 +37,8 @@ github.com/btcsuite/btcutil v1.0.2 h1:9iZ1Terx9fMIOtq1VrwdqfsATL9MC2l8ZrUY6YZ2ut
 github.com/btcsuite/btcutil v1.0.2/go.mod h1:j9HUFwoQRsZL3V4n+qG+CUnEGHOarIxfC3Le2Yhbcts=
 github.com/btcsuite/btcutil/psbt v1.0.3-0.20200826194809-5f93e33af2b0 h1:3Zumkyl6PWyHuVJ04me0xeD9CnPOhNgeGpapFbzy7O4=
 github.com/btcsuite/btcutil/psbt v1.0.3-0.20200826194809-5f93e33af2b0/go.mod h1:LVveMu4VaNSkIRTZu2+ut0HDBRuYjqGocxDMNS1KuGQ=
-github.com/btcsuite/btcwallet v0.11.1-0.20201002003944-e6d01202cb6b h1:gblgCqJNcFulA2eiQLweSbfB8H/0SgviQ0Bkx7ADLwE=
-github.com/btcsuite/btcwallet v0.11.1-0.20201002003944-e6d01202cb6b/go.mod h1:owv9oZqM0HnUW+ByF7VqOgfs2eb0ooiePW/+Tl/i/Nk=
+github.com/btcsuite/btcwallet v0.11.1-0.20201005184831-a7f551a6301c h1:1FMwQTKFp9Pf7ZYW0gTHSeyIKNd1fF+wx1f2RvUHngA=
+github.com/btcsuite/btcwallet v0.11.1-0.20201005184831-a7f551a6301c/go.mod h1:owv9oZqM0HnUW+ByF7VqOgfs2eb0ooiePW/+Tl/i/Nk=
 github.com/btcsuite/btcwallet/wallet/txauthor v1.0.0 h1:KGHMW5sd7yDdDMkCZ/JpP0KltolFsQcB973brBnfj4c=
 github.com/btcsuite/btcwallet/wallet/txauthor v1.0.0/go.mod h1:VufDts7bd/zs3GV13f/lXc/0lXrPnvxD/NvmpG/FEKU=
 github.com/btcsuite/btcwallet/wallet/txrules v1.0.0 h1:2VsfS0sBedcM5KmDzRMT3+b6xobqWveZGvjb+jFez5w=

--- a/lnrpc/walletrpc/walletkit_server.go
+++ b/lnrpc/walletrpc/walletkit_server.go
@@ -1048,7 +1048,7 @@ func (w *WalletKit) FundPsbt(_ context.Context,
 			Id: lock.lockID[:],
 			Outpoint: &lnrpc.OutPoint{
 				TxidBytes:   lock.outpoint.Hash[:],
-				TxidStr:     lock.outpoint.String(),
+				TxidStr:     lock.outpoint.Hash.String(),
 				OutputIndex: lock.outpoint.Index,
 			},
 			Expiration: uint64(lock.expiration.Unix()),


### PR DESCRIPTION
~Depends on https://github.com/btcsuite/btcwallet/pull/722.~

Fixes https://github.com/lightningnetwork/lnd/issues/4670.

This PR fixes an oversight in the way nested SegWit inputs are added to the unsigned TX of a PSBT.
The fix itself is in `btcwallet`.

We also fix a small cosmetic issue in the way the locked UTXOs are returned and displayed in the command line.