### PR TITLE
multi: single hop hint per private channel

### DIFF
--- a/lnrpc/invoicesrpc/addinvoice.go
+++ b/lnrpc/invoicesrpc/addinvoice.go
@@ -563,7 +563,7 @@ func selectHopHints(amtMSat lnwire.MilliSatoshi, cfg *AddInvoiceConfig,
 	numMaxHophints int) []func(*zpay32.Invoice) {
 
 	// We'll add our hop hints in two passes, first we'll add all channels
-	// that are eligible to be hop hints, and also have a local balance
+	// that are eligible to be hop hints, and also have a remote balance
 	// above the payment amount.
 	var totalHintBandwidth lnwire.MilliSatoshi
 	hopHintChans := make(map[wire.OutPoint]struct{})


### PR DESCRIPTION
Fixes #4520 

Previously, if a node had multiple private channels with a peer, it would include hop hints for each of the channels in an invoice. Due to non-strict forwarding it is not necessary to so.

This change only adds one set of maximal policy values as hop hints per private peer.