### PR TITLE
Travis+GitHub: update bitcoind to 0.20.1, extract bitcoind binary from docker image to speed up download

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,7 +17,7 @@ env:
   GOCACHE: /home/runner/work/go/pkg/build
   GOPATH: /home/runner/work/go
   DOWNLOAD_CACHE: /home/runner/work/download_cache
-  BITCOIN_VERSION: 0.19.1
+  BITCOIN_VERSION: 0.20.1
   GO_VERSION: 1.15.2
 
 jobs:
@@ -235,14 +235,6 @@ jobs:
         uses: actions/setup-go@v2
         with:
           go-version: '~${{ env.GO_VERSION }}'
-
-      - name: bitcoin cache
-        uses: actions/cache@v1
-        with:
-          path: /home/runner/bitcoin/bitcoin-${{ env.BITCOIN_VERSION }}/bin
-          key: lnd-${{ runner.os }}-bitcoin-${{ env.BITCOIN_VERSION }}
-          restore-keys: |
-            lnd-${{ runner.os }}-bitcoin-${{ env.BITCOIN_VERSION }}
 
       - name: install bitcoind
         run: ./scripts/install_bitcoind.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: go
 cache:
   directories:
-    - ~/bitcoin/bitcoin-0.19.1/bin
     - $DOWNLOAD_CACHE
     - $GOCACHE
     - $GOPATH/pkg/mod
@@ -23,6 +22,7 @@ env:
   global:
     - GOCACHE=$HOME/.go-build
     - DOWNLOAD_CACHE=$HOME/download_cache
+    - BITCOIN_VERSION=0.20.1
 
 sudo: required
 

--- a/scripts/install_bitcoind.sh
+++ b/scripts/install_bitcoind.sh
@@ -2,17 +2,9 @@
 
 set -ev
 
-export BITCOIND_VERSION=0.20.0
+BITCOIND_VERSION=${BITCOIN_VERSION:-0.20.1}
 
-if sudo cp ~/bitcoin/bitcoin-$BITCOIND_VERSION/bin/bitcoind /usr/local/bin/bitcoind
-then
-        echo "found cached bitcoind"
-else
-        mkdir -p ~/bitcoin && \
-        pushd ~/bitcoin && \
-        wget https://bitcoin.org/bin/bitcoin-core-$BITCOIND_VERSION/bitcoin-$BITCOIND_VERSION-x86_64-linux-gnu.tar.gz && \
-        tar xvfz bitcoin-$BITCOIND_VERSION-x86_64-linux-gnu.tar.gz && \
-        sudo cp ./bitcoin-$BITCOIND_VERSION/bin/bitcoind /usr/local/bin/bitcoind && \
-        popd
-fi
-
+docker pull ruimarinho/bitcoin-core:$BITCOIND_VERSION
+CONTAINER_ID=$(docker create ruimarinho/bitcoin-core:$BITCOIND_VERSION)
+sudo docker cp $CONTAINER_ID:/opt/bitcoin-$BITCOIND_VERSION/bin/bitcoind /usr/local/bin/bitcoind
+docker rm $CONTAINER_ID


### PR DESCRIPTION
Because the bitcoind mirror is extremely slow, we spend at least 2 to 3
minutes of each bitcoind related test on just downloading the binary. We
can achieve the same result by just pulling the docker image and
extracting the binary from that.

Speedup (observed):
 - GitHub: `0:13 min` now vs. `2:37 min` before
 - Travis: `0:18 min` now vs. `2:25 min` before