### PR TITLE
fuzz: change return values to 1 rather than 0 or -1

### DIFF
--- a/fuzz/brontide/random_actone.go
+++ b/fuzz/brontide/random_actone.go
@@ -11,7 +11,7 @@ import (
 func Fuzz_random_actone(data []byte) int {
 	// Check if data is large enough.
 	if len(data) < brontide.ActOneSize {
-		return -1
+		return 1
 	}
 
 	// This will return brontide machines with random keys.

--- a/fuzz/brontide/random_actthree.go
+++ b/fuzz/brontide/random_actthree.go
@@ -11,7 +11,7 @@ import (
 func Fuzz_random_actthree(data []byte) int {
 	// Check if data is large enough.
 	if len(data) < brontide.ActThreeSize {
-		return -1
+		return 1
 	}
 
 	// This will return brontide machines with random keys.

--- a/fuzz/brontide/random_acttwo.go
+++ b/fuzz/brontide/random_acttwo.go
@@ -11,7 +11,7 @@ import (
 func Fuzz_random_acttwo(data []byte) int {
 	// Check if data is large enough.
 	if len(data) < brontide.ActTwoSize {
-		return -1
+		return 1
 	}
 
 	// This will return brontide machines with random keys.

--- a/fuzz/brontide/random_init_enc_dec.go
+++ b/fuzz/brontide/random_init_enc_dec.go
@@ -12,7 +12,7 @@ import (
 func Fuzz_random_init_enc_dec(data []byte) int {
 	// Ensure that length of message is not greater than max allowed size.
 	if len(data) > math.MaxUint16 {
-		return 0
+		return 1
 	}
 
 	// This will return brontide machines with random keys.

--- a/fuzz/brontide/random_init_encrypt.go
+++ b/fuzz/brontide/random_init_encrypt.go
@@ -12,7 +12,7 @@ import (
 func Fuzz_random_init_encrypt(data []byte) int {
 	// Ensure that length of message is not greater than max allowed size.
 	if len(data) > math.MaxUint16 {
-		return 0
+		return 1
 	}
 
 	// This will return brontide machines with random keys.

--- a/fuzz/brontide/random_resp_enc_dec.go
+++ b/fuzz/brontide/random_resp_enc_dec.go
@@ -12,7 +12,7 @@ import (
 func Fuzz_random_resp_enc_dec(data []byte) int {
 	// Ensure that length of message is not greater than max allowed size.
 	if len(data) > math.MaxUint16 {
-		return 0
+		return 1
 	}
 
 	// This will return brontide machines with random keys.

--- a/fuzz/brontide/random_resp_encrypt.go
+++ b/fuzz/brontide/random_resp_encrypt.go
@@ -12,7 +12,7 @@ import (
 func Fuzz_random_resp_encrypt(data []byte) int {
 	// Ensure that length of message is not greater than max allowed size.
 	if len(data) > math.MaxUint16 {
-		return 0
+		return 1
 	}
 
 	// This will return brontide machines with random keys.

--- a/fuzz/brontide/static_actone.go
+++ b/fuzz/brontide/static_actone.go
@@ -11,7 +11,7 @@ import (
 func Fuzz_static_actone(data []byte) int {
 	// Check if data is large enough.
 	if len(data) < brontide.ActOneSize {
-		return -1
+		return 1
 	}
 
 	// This will return brontide machines with static keys.

--- a/fuzz/brontide/static_actthree.go
+++ b/fuzz/brontide/static_actthree.go
@@ -11,7 +11,7 @@ import (
 func Fuzz_static_actthree(data []byte) int {
 	// Check if data is large enough.
 	if len(data) < brontide.ActThreeSize {
-		return -1
+		return 1
 	}
 
 	// This will return brontide machines with static keys.

--- a/fuzz/brontide/static_acttwo.go
+++ b/fuzz/brontide/static_acttwo.go
@@ -11,7 +11,7 @@ import (
 func Fuzz_static_acttwo(data []byte) int {
 	// Check if data is large enough.
 	if len(data) < brontide.ActTwoSize {
-		return -1
+		return 1
 	}
 
 	// This will return brontide machines with static keys.

--- a/fuzz/brontide/static_init_enc_dec.go
+++ b/fuzz/brontide/static_init_enc_dec.go
@@ -13,7 +13,7 @@ import (
 func Fuzz_static_init_enc_dec(data []byte) int {
 	// Ensure that length of message is not greater than max allowed size.
 	if len(data) > math.MaxUint16 {
-		return 0
+		return 1
 	}
 
 	// This will return brontide machines with static keys.

--- a/fuzz/brontide/static_init_encrypt.go
+++ b/fuzz/brontide/static_init_encrypt.go
@@ -12,7 +12,7 @@ import (
 func Fuzz_static_init_encrypt(data []byte) int {
 	// Ensure that length of message is not greater than max allowed size.
 	if len(data) > math.MaxUint16 {
-		return 0
+		return 1
 	}
 
 	// This will return brontide machines with static keys.

--- a/fuzz/brontide/static_resp_enc_dec.go
+++ b/fuzz/brontide/static_resp_enc_dec.go
@@ -12,7 +12,7 @@ import (
 func Fuzz_static_resp_enc_dec(data []byte) int {
 	// Ensure that length of message is not greater than max allowed size.
 	if len(data) > math.MaxUint16 {
-		return 0
+		return 1
 	}
 
 	// This will return brontide machines with static keys.

--- a/fuzz/brontide/static_resp_encrypt.go
+++ b/fuzz/brontide/static_resp_encrypt.go
@@ -12,7 +12,7 @@ import (
 func Fuzz_static_resp_encrypt(data []byte) int {
 	// Ensure that length of message is not greater than max allowed size.
 	if len(data) > math.MaxUint16 {
-		return 0
+		return 1
 	}
 
 	// This will return brontide machines with static keys.

--- a/fuzz/lnwire/accept_channel.go
+++ b/fuzz/lnwire/accept_channel.go
@@ -32,7 +32,7 @@ func Fuzz_accept_channel(data []byte) int {
 	payloadLen := uint32(len(data)) - 2
 	if payloadLen > emptyMsg.MaxPayloadLength(0) {
 		// Ignore this input - max payload constraint violated.
-		return -1
+		return 1
 	}
 
 	msg, err := lnwire.ReadMessage(r, 0)
@@ -40,7 +40,7 @@ func Fuzz_accept_channel(data []byte) int {
 		// go-fuzz generated []byte that cannot be represented as a
 		// wire message but we will return 0 so go-fuzz can modify the
 		// input.
-		return 0
+		return 1
 	}
 
 	// We will serialize the message into a new bytes buffer.

--- a/fuzz/lnwire/fuzz_utils.go
+++ b/fuzz/lnwire/fuzz_utils.go
@@ -35,7 +35,7 @@ func harness(data []byte, emptyMsg lnwire.Message) int {
 	payloadLen := uint32(len(data)) - 2
 	if payloadLen > emptyMsg.MaxPayloadLength(0) {
 		// Ignore this input - max payload constraint violated.
-		return -1
+		return 1
 	}
 
 	msg, err := lnwire.ReadMessage(r, 0)
@@ -43,7 +43,7 @@ func harness(data []byte, emptyMsg lnwire.Message) int {
 		// go-fuzz generated []byte that cannot be represented as a
 		// wire message but we will return 0 so go-fuzz can modify the
 		// input.
-		return 0
+		return 1
 	}
 
 	// We will serialize the message into a new bytes buffer.

--- a/fuzz/lnwire/node_announcement.go
+++ b/fuzz/lnwire/node_announcement.go
@@ -32,7 +32,7 @@ func Fuzz_node_announcement(data []byte) int {
 	payloadLen := uint32(len(data)) - 2
 	if payloadLen > emptyMsg.MaxPayloadLength(0) {
 		// Ignore this input - max payload constraint violated.
-		return -1
+		return 1
 	}
 
 	msg, err := lnwire.ReadMessage(r, 0)
@@ -40,7 +40,7 @@ func Fuzz_node_announcement(data []byte) int {
 		// go-fuzz generated []byte that cannot be represented as a
 		// wire message but we will return 0 so go-fuzz can modify the
 		// input.
-		return 0
+		return 1
 	}
 
 	// We will serialize the message into a new bytes buffer.

--- a/fuzz/lnwire/open_channel.go
+++ b/fuzz/lnwire/open_channel.go
@@ -32,7 +32,7 @@ func Fuzz_open_channel(data []byte) int {
 	payloadLen := uint32(len(data)) - 2
 	if payloadLen > emptyMsg.MaxPayloadLength(0) {
 		// Ignore this input - max payload constraint violated.
-		return -1
+		return 1
 	}
 
 	msg, err := lnwire.ReadMessage(r, 0)
@@ -40,7 +40,7 @@ func Fuzz_open_channel(data []byte) int {
 		// go-fuzz generated []byte that cannot be represented as a
 		// wire message but we will return 0 so go-fuzz can modify the
 		// input.
-		return 0
+		return 1
 	}
 
 	// We will serialize the message into a new bytes buffer.

--- a/fuzz/wtwire/fuzz_utils.go
+++ b/fuzz/wtwire/fuzz_utils.go
@@ -36,7 +36,7 @@ func harness(data []byte, emptyMsg wtwire.Message) int {
 	payloadLen := uint32(len(data)) - 2
 	if payloadLen > emptyMsg.MaxPayloadLength(0) {
 		// Ignore this input - max payload constraint violated.
-		return -1
+		return 1
 	}
 
 	msg, err := wtwire.ReadMessage(r, 0)
@@ -44,7 +44,7 @@ func harness(data []byte, emptyMsg wtwire.Message) int {
 		// go-fuzz generated []byte that cannot be represented as a
 		// wire message but we will return 0 so go-fuzz can modify the
 		// input.
-		return 0
+		return 1
 	}
 
 	// We will serialize the message into a new bytes buffer.


### PR DESCRIPTION
This allows gofuzz to store the mutating input as coverage if it reaches any new coverage, even if it didn't make it to the end of the test.