### PR TITLE
lnd: require blocks to be synced in regtest/simnet

### DIFF
--- a/lnd.go
+++ b/lnd.go
@@ -744,55 +744,51 @@ func Main(cfg *Config, lisCfg ListenerCfg, shutdownChan <-chan struct{}) error {
 	}
 	defer rpcServer.Stop()
 
-	// If we're not in regtest or simnet mode, We'll wait until we're fully
-	// synced to continue the start up of the remainder of the daemon. This
-	// ensures that we don't accept any possibly invalid state transitions, or
-	// accept channels with spent funds.
-	if !(cfg.Bitcoin.RegTest || cfg.Bitcoin.SimNet ||
-		cfg.Litecoin.RegTest || cfg.Litecoin.SimNet) {
-
-		_, bestHeight, err := activeChainControl.ChainIO.GetBestBlock()
-		if err != nil {
-			err := fmt.Errorf("unable to determine chain tip: %v",
-				err)
-			ltndLog.Error(err)
-			return err
-		}
-
-		ltndLog.Infof("Waiting for chain backend to finish sync, "+
-			"start_height=%v", bestHeight)
-
-		for {
-			if !signal.Alive() {
-				return nil
-			}
-
-			synced, _, err := activeChainControl.Wallet.IsSynced()
-			if err != nil {
-				err := fmt.Errorf("unable to determine if "+
-					"wallet is synced: %v", err)
-				ltndLog.Error(err)
-				return err
-			}
-
-			if synced {
-				break
-			}
-
-			time.Sleep(time.Second * 1)
-		}
-
-		_, bestHeight, err = activeChainControl.ChainIO.GetBestBlock()
-		if err != nil {
-			err := fmt.Errorf("unable to determine chain tip: %v",
-				err)
-			ltndLog.Error(err)
-			return err
-		}
-
-		ltndLog.Infof("Chain backend is fully synced (end_height=%v)!",
-			bestHeight)
+	// We'll wait until we're fully synced to continue the start up of the
+	// remainder of the daemon. This ensures that we don't accept any
+	// possibly invalid state transitions, or accept channels with spent
+	// funds.
+	_, bestHeight, err := activeChainControl.chainIO.GetBestBlock()
+	if err != nil {
+		err := fmt.Errorf("unable to determine chain tip: %v",
+			err)
+		ltndLog.Error(err)
+		return err
 	}
+
+	ltndLog.Infof("Waiting for chain backend to finish sync, "+
+		"start_height=%v", bestHeight)
+
+	for {
+		if !signal.Alive() {
+			return nil
+		}
+
+		synced, _, err := activeChainControl.wallet.IsSynced()
+		if err != nil {
+			err := fmt.Errorf("unable to determine if "+
+				"wallet is synced: %v", err)
+			ltndLog.Error(err)
+			return err
+		}
+
+		if synced {
+			break
+		}
+
+		time.Sleep(time.Second * 1)
+	}
+
+	_, bestHeight, err = activeChainControl.chainIO.GetBestBlock()
+	if err != nil {
+		err := fmt.Errorf("unable to determine chain tip: %v",
+			err)
+		ltndLog.Error(err)
+		return err
+	}
+
+	ltndLog.Infof("Chain backend is fully synced (end_height=%v)!",
+		bestHeight)
 
 	// With all the relevant chains initialized, we can finally start the
 	// server itself.


### PR DESCRIPTION
From the logs, I saw that when a new node was created, the lnd server started all services without waiting for the block sync. Sometimes the node could catch up later, other times, it didn't and the test case would time out while the syncing was still going on. I believe it's causing some of the test flake.