### PR TITLE
routerrpc: map errors to grpc status code

### DIFF
--- a/lnrpc/routerrpc/router_server.go
+++ b/lnrpc/routerrpc/router_server.go
@@ -375,6 +375,13 @@ func (s *Server) SendToRouteV2(ctx context.Context,
 		return rpcAttempt, nil
 	}
 
+	// Transform user errors to grpc code.
+	if err == channeldb.ErrPaymentInFlight ||
+		err == channeldb.ErrAlreadyPaid {
+
+		return nil, status.Error(codes.AlreadyExists, err.Error())
+	}
+
 	return nil, err
 }
 


### PR DESCRIPTION
The 'payment already exists' case is common in restart scenarios. With this change it is no longer necessary to string-match on the error message. Implementation is identical to `SendPaymentV2`.