### PR TITLE
lnd: remove instances of ReportShortChanID as it's unused

### DIFF
--- a/fundingmanager.go
+++ b/fundingmanager.go
@@ -306,11 +306,6 @@ type fundingConfig struct {
 	// node we're establishing a channel with for reconnection purposes.
 	WatchNewChannel func(*channeldb.OpenChannel, *btcec.PublicKey) error
 
-	// ReportShortChanID allows the funding manager to report the newly
-	// discovered short channel ID of a formerly pending channel to outside
-	// sub-systems.
-	ReportShortChanID func(wire.OutPoint) error
-
 	// ZombieSweeperInterval is the periodic time interval in which the
 	// zombie sweeper is run.
 	ZombieSweeperInterval time.Duration
@@ -2335,14 +2330,6 @@ func (f *fundingManager) handleFundingConfirmation(
 	// Inform the ChannelNotifier that the channel has transitioned from
 	// pending open to open.
 	f.cfg.NotifyOpenChannelEvent(completeChan.FundingOutpoint)
-
-	// As there might already be an active link in the switch with an
-	// outdated short chan ID, we'll instruct the switch to load the updated
-	// short chan id from disk.
-	err = f.cfg.ReportShortChanID(fundingPoint)
-	if err != nil {
-		fndgLog.Errorf("unable to report short chan id: %v", err)
-	}
 
 	// If we opened the channel, and lnd's wallet published our funding tx
 	// (which is not the case for some channels) then we update our

--- a/fundingmanager_test.go
+++ b/fundingmanager_test.go
@@ -420,9 +420,6 @@ func createTestFundingManager(t *testing.T, privKey *btcec.PrivateKey,
 		WatchNewChannel: func(*channeldb.OpenChannel, *btcec.PublicKey) error {
 			return nil
 		},
-		ReportShortChanID: func(wire.OutPoint) error {
-			return nil
-		},
 		PublishTransaction: func(txn *wire.MsgTx, _ string) error {
 			publTxChan <- txn
 			return nil

--- a/server.go
+++ b/server.go
@@ -1133,10 +1133,6 @@ func newServer(cfg *Config, listenAddrs []net.Addr,
 			// the chain arb so it can react to on-chain events.
 			return s.chainArb.WatchNewChannel(channel)
 		},
-		ReportShortChanID: func(chanPoint wire.OutPoint) error {
-			cid := lnwire.NewChanIDFromOutPoint(&chanPoint)
-			return s.htlcSwitch.UpdateShortChanID(cid)
-		},
 		RequiredRemoteChanReserve: func(chanAmt,
 			dustLimit btcutil.Amount) btcutil.Amount {
 


### PR DESCRIPTION
No longer used since the channel isn't loaded into the link until after confirmation