### PR TITLE
itest: Fix flakes when payments cause chan closure 

### DIFF
--- a/lntest/itest/lnd_test.go
+++ b/lntest/itest/lnd_test.go
@@ -578,6 +578,15 @@ func completePaymentRequests(ctx context.Context, client lnrpc.LightningClient,
 			return false
 		}
 
+		// If the number of open channels is now lower than before
+		// attempting the payments, it means one of the payments
+		// triggered a force closure (for example, due to an incorrect
+		// preimage). Return early since it's clear the payment was
+		// attempted.
+		if len(newListResp.Channels) < len(listResp.Channels) {
+			return true
+		}
+
 		for _, c1 := range listResp.Channels {
 			for _, c2 := range newListResp.Channels {
 				if c1.ChannelPoint != c2.ChannelPoint {


### PR DESCRIPTION
This fixes itest flakes that happen when a payment is attempted that
ends up causing a channel closure.

completePaymentRequests() attempts to monitor the open channels after a
payment is attempted in order to identify that payment was actually
dispatched to a remote node before returning.

However, when the payment actually causes a channel closure (for
example, because the receiver sent an incorrect preimage) this logic
fails in that the channel will no longer the found in the list of open
channels. This could cause a flake when there was enough time for the
channel to close before performing the check.

One example of such a flaky test is failing_link.

This fixes the issue by also checking whether the total number of
channels was reduced, which indicates (assuming itest operations are
being executed serially) that one of the attempted payments affected at
least one channel.

The intermediate commits are there to demonstrate the issue and will be removed before the final merge.