### PR TITLE
btcwallet: return chain best timestamp while backend is syncing

### DIFF
--- a/lnwallet/btcwallet/btcwallet.go
+++ b/lnwallet/btcwallet/btcwallet.go
@@ -875,9 +875,19 @@ func (b *BtcWallet) IsSynced() (bool, int64, error) {
 		return false, 0, err
 	}
 
+	// Make sure the backing chain has been considered synced first.
+	if !b.wallet.ChainSynced() {
+		bestHeader, err := b.cfg.ChainSource.GetBlockHeader(bestHash)
+		if err != nil {
+			return false, 0, err
+		}
+		bestTimestamp = bestHeader.Timestamp.Unix()
+		return false, bestTimestamp, nil
+	}
+
 	// If the wallet hasn't yet fully synced to the node's best chain tip,
 	// then we're not yet fully synced.
-	if syncState.Height < bestHeight || !b.wallet.ChainSynced() {
+	if syncState.Height < bestHeight {
 		return false, bestTimestamp, nil
 	}
 


### PR DESCRIPTION
A while back, changes were made to the wallet such that it waits for the backend to be synced before beginning to store the latest 10,000 blocks of the chain. This inherently broke sync progress implementations based on the best_header_timestamp result from the GetInfo RPC for neutrino-based nodes as the wallet is no longer tracking all blocks in the chain. To work around this, we now make sure to return the backend's best header timestamp instead of the wallet's, allowing said sync progress implementations to work again.

One potential drawback of the approach taken in this PR is that the best header timestamp can decrease (causing the sync progress to momentarily decrease) if it's called twice in succession, the first being right as the chain backend is synced and the second being right before the wallet begins storing the latest 10,000 block hashes of the chain. To address this, we could expose two `best_header_timestamp` fields, one for the wallet and one for the backend node (btcd, bitcoind, neutrino). Thoughts @mandelmonkey?

Fixes https://github.com/lightningnetwork/lnd/issues/4676.