### PR TITLE
Implement btcwallet's "dropwtxmgr" command as --reset-wallet-transactions flag

### DIFF
--- a/config.go
+++ b/config.go
@@ -244,6 +244,8 @@ type Config struct {
 
 	NoSeedBackup bool `long:"noseedbackup" description:"If true, NO SEED WILL BE EXPOSED -- EVER, AND THE WALLET WILL BE ENCRYPTED USING THE DEFAULT PASSPHRASE. THIS FLAG IS ONLY FOR TESTING AND SHOULD NEVER BE USED ON MAINNET."`
 
+	ResetWalletTransactions bool `long:"reset-wallet-transactions" description:"Removes all transaction history from the on-chain wallet on startup, forcing a full chain rescan starting at the wallet's birthday. Implements the same functionality as btcwallet's dropwtxmgr command. Should be set to false after successful execution to avoid rescanning on every restart of lnd."`
+
 	PaymentsExpirationGracePeriod time.Duration `long:"payments-expiration-grace-period" description:"A period to wait before force closing channels with outgoing htlcs that have timed-out and are a result of this node initiated payments."`
 	TrickleDelay                  int           `long:"trickledelay" description:"Time in milliseconds between each release of announcements to the network"`
 	ChanEnableTimeout             time.Duration `long:"chan-enable-timeout" description:"The duration that a peer connection must be stable before attempting to send a channel update to reenable or cancel a pending disables of the peer's channels on the network."`

--- a/docs/recovery.md
+++ b/docs/recovery.md
@@ -190,29 +190,24 @@ rescan.
 The recovery methods described above assume a clean slate for a node, so
 there's no existing UTXO or key data in the node's database. However, there're
 times when an _existing_ node may want to _manually_ rescan the chain. We have
-a tool for that! The tool is called
-[`dropwtxmgr`](https://github.com/btcsuite/btcwallet/tree/master/cmd/dropwtxmgr).
-It can be installed with the following command:
+a command line flag for that! Just start `lnd` and add the following flag:
 ```
-⛰  go get -v -u github.com/btcsuite/btcwallet/cmd/dropwtxmgr
+⛰  lnd --reset-wallet-transactions
 ```
 
-The `dropwtxmgr` tool will _reset_ the best synced height of the wallet back to
-its birthday, or genesis if the birthday isn't known (for some older wallets).
-In order to run the tool, you must first **shutdown `lnd`**. Once `lnd` is
-shutdown, the rescan can be initiated with the following commands:
-```
-⛰  cp $HOME/.lnd/data/chain/bitcoin/mainnet/wallet.db $HOME/wallet.db # Copy the existing databse just in case!
-⛰  dropwtxmgr --db=$HOME/.lnd/data/chain/bitcoin/mainnet/wallet.db
-```
+The `--reset-wallet-transactions` flag will _reset_ the best synced height of
+the wallet back to its birthday, or genesis if the birthday isn't known (for
+some older wallets).
 
-Once the above command returns (if it hangs for a while, then `lnd` may not
-actually be shutdown, so double check!), `lnd` can be restarted. After it's
-restarted, then the wallet should being rescanning. An entry resembling the
-following will show up in the logs once it's complete:
+Just run `lnd` with the flag, unlock it, then the wallet should begin
+rescanning. An entry resembling the following will show up in the logs once it's
+complete:
 ```
 [INF] LNWL: Finished rescan for 800 addresses (synced to block 3032830c812a4a6ea305d8ead13b52e9e69d6400ff3c997970b6f76fbc770920, height 748)
 ```
+
+**Remember to remove the flag once the rescan was completed successfully to
+avoid rescanning again for every restart of lnd**.
 
 ## Off-Chain Recovery
 

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/btcsuite/btclog v0.0.0-20170628155309-84c8d2346e9f
 	github.com/btcsuite/btcutil v1.0.2
 	github.com/btcsuite/btcutil/psbt v1.0.3-0.20200826194809-5f93e33af2b0
-	github.com/btcsuite/btcwallet v0.11.1-0.20201005184831-a7f551a6301c
+	github.com/btcsuite/btcwallet v0.11.1-0.20201104022105-a6f3888450e4
 	github.com/btcsuite/btcwallet/wallet/txauthor v1.0.0
 	github.com/btcsuite/btcwallet/wallet/txrules v1.0.0
 	github.com/btcsuite/btcwallet/walletdb v1.3.3
@@ -21,7 +21,6 @@ require (
 	github.com/davecgh/go-spew v1.1.1
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible // indirect
 	github.com/dustin/go-humanize v1.0.0 // indirect
-	github.com/dvyukov/go-fuzz v0.0.0-20200916044129-21309f307f61 // indirect
 	github.com/go-errors/errors v1.0.1
 	github.com/go-openapi/strfmt v0.19.5 // indirect
 	github.com/golang/groupcache v0.0.0-20200121045136-8c9f03a8e57e // indirect

--- a/go.sum
+++ b/go.sum
@@ -37,8 +37,8 @@ github.com/btcsuite/btcutil v1.0.2 h1:9iZ1Terx9fMIOtq1VrwdqfsATL9MC2l8ZrUY6YZ2ut
 github.com/btcsuite/btcutil v1.0.2/go.mod h1:j9HUFwoQRsZL3V4n+qG+CUnEGHOarIxfC3Le2Yhbcts=
 github.com/btcsuite/btcutil/psbt v1.0.3-0.20200826194809-5f93e33af2b0 h1:3Zumkyl6PWyHuVJ04me0xeD9CnPOhNgeGpapFbzy7O4=
 github.com/btcsuite/btcutil/psbt v1.0.3-0.20200826194809-5f93e33af2b0/go.mod h1:LVveMu4VaNSkIRTZu2+ut0HDBRuYjqGocxDMNS1KuGQ=
-github.com/btcsuite/btcwallet v0.11.1-0.20201005184831-a7f551a6301c h1:1FMwQTKFp9Pf7ZYW0gTHSeyIKNd1fF+wx1f2RvUHngA=
-github.com/btcsuite/btcwallet v0.11.1-0.20201005184831-a7f551a6301c/go.mod h1:owv9oZqM0HnUW+ByF7VqOgfs2eb0ooiePW/+Tl/i/Nk=
+github.com/btcsuite/btcwallet v0.11.1-0.20201104022105-a6f3888450e4 h1:iipg6ldTL0y69KLicrd0gLhY/yErB0rG4a84uQbu7ao=
+github.com/btcsuite/btcwallet v0.11.1-0.20201104022105-a6f3888450e4/go.mod h1:owv9oZqM0HnUW+ByF7VqOgfs2eb0ooiePW/+Tl/i/Nk=
 github.com/btcsuite/btcwallet/wallet/txauthor v1.0.0 h1:KGHMW5sd7yDdDMkCZ/JpP0KltolFsQcB973brBnfj4c=
 github.com/btcsuite/btcwallet/wallet/txauthor v1.0.0/go.mod h1:VufDts7bd/zs3GV13f/lXc/0lXrPnvxD/NvmpG/FEKU=
 github.com/btcsuite/btcwallet/wallet/txrules v1.0.0 h1:2VsfS0sBedcM5KmDzRMT3+b6xobqWveZGvjb+jFez5w=
@@ -91,8 +91,6 @@ github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZm
 github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954/go.mod h1:vAd38F8PWV+bWy6jNmig1y/TA+kYO4g3RSRF0IAv0no=
 github.com/dustin/go-humanize v1.0.0 h1:VSnTsYCnlFHaM2/igO1h6X3HA71jcobQuxemgkq4zYo=
 github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
-github.com/dvyukov/go-fuzz v0.0.0-20200916044129-21309f307f61 h1:u7QPBOrJA2lSn2FBupeLsx8pLb7SpCfc6DCutrAo+v8=
-github.com/dvyukov/go-fuzz v0.0.0-20200916044129-21309f307f61/go.mod h1:11Gm+ccJnvAhCNLlf5+cS9KjtbaD5I5zaZpFMsTHWTw=
 github.com/frankban/quicktest v1.2.2 h1:xfmOhhoH5fGPgbEAlhLpJH9p0z/0Qizio9osmvn9IUY=
 github.com/frankban/quicktest v1.2.2/go.mod h1:Qh/WofXFeiAFII1aEBu529AtJo6Zg2VHscnEsbBnJ20=
 github.com/fsnotify/fsnotify v1.4.7 h1:IXs+QLmnXW2CcXuY+8Mzv/fWEsPGWxqefPtCP5CnV9I=

--- a/sample-lnd.conf
+++ b/sample-lnd.conf
@@ -226,6 +226,12 @@
 ; BE USED ON MAINNET.
 ; noseedbackup=true
 
+; Removes all transaction history from the on-chain wallet on startup, forcing a
+; full chain rescan starting at the wallet's birthday. Implements the same
+; functionality as btcwallet's dropwtxmgr command. Should be set to false after
+; successful execution to avoid rescanning on every restart of lnd.
+; reset-wallet-transactions=true
+
 ; The smallest channel size (in satoshis) that we should accept. Incoming
 ; channels smaller than this will be rejected, default value 20000.
 ; minchansize=


### PR DESCRIPTION
Depends on https://github.com/btcsuite/btcwallet/pull/723.

This PR adds the functionality of `btcwallet`'s `dropwtxmgr` command to `lnd`. Users can trigger the functionality by specifying the command line flag `--reset-wallet-transactions` or setting the value `reset-wallet-transactions=true` in the configuration file.

The new flag removes all transaction history from the internal on-chain wallet, resulting in a full chain-rescan starting at the wallet's birthday.