### PR TITLE
itest: clean harness state before each icase and better naming for icase logs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,8 +32,7 @@ _testmain.go
 /lncli-itest
 
 # Integration test log files
-lntest/itest/output*.log
-lntest/itest/pprof*.log
+lntest/itest/*.log
 lntest/itest/.backendlogs
 lntest/itest/.minerlogs
 lntest/itest/lnd-itest

--- a/lntest/itest/lnd_macaroons_test.go
+++ b/lntest/itest/lnd_macaroons_test.go
@@ -22,7 +22,7 @@ import (
 // enabled on the gRPC interface, no requests with missing or invalid
 // macaroons are allowed. Further, the specific access rights (read/write,
 // entity based) and first-party caveats are tested as well.
-func testMacaroonAuthentication(net *lntest.NetworkHarness, t *harnessTest) {
+func testMacaroonAuthentication(net *lntest.NetworkHarness, ht *harnessTest) {
 	var (
 		infoReq    = &lnrpc.GetInfoRequest{}
 		newAddrReq = &lnrpc.NewAddressRequest{
@@ -200,15 +200,13 @@ func testMacaroonAuthentication(net *lntest.NetworkHarness, t *harnessTest) {
 
 	for _, tc := range testCases {
 		tc := tc
-		t.t.Run(tc.name, func(t *testing.T) {
-			t.Parallel()
-
+		ht.t.Run(tc.name, func(tt *testing.T) {
 			ctxt, cancel := context.WithTimeout(
 				context.Background(), defaultTimeout,
 			)
 			defer cancel()
 
-			tc.run(ctxt, t)
+			tc.run(ctxt, tt)
 		})
 	}
 }
@@ -377,9 +375,7 @@ func testBakeMacaroon(net *lntest.NetworkHarness, t *harnessTest) {
 
 	for _, tc := range testCases {
 		tc := tc
-		t.t.Run(tc.name, func(t *testing.T) {
-			t.Parallel()
-
+		t.t.Run(tc.name, func(tt *testing.T) {
 			ctxt, cancel := context.WithTimeout(
 				context.Background(), defaultTimeout,
 			)
@@ -388,11 +384,11 @@ func testBakeMacaroon(net *lntest.NetworkHarness, t *harnessTest) {
 			adminMac, err := testNode.ReadMacaroon(
 				testNode.AdminMacPath(), defaultTimeout,
 			)
-			require.NoError(t, err)
-			cleanup, client := macaroonClient(t, testNode, adminMac)
+			require.NoError(tt, err)
+			cleanup, client := macaroonClient(tt, testNode, adminMac)
 			defer cleanup()
 
-			tc.run(ctxt, t, client)
+			tc.run(ctxt, tt, client)
 		})
 	}
 }

--- a/lntest/itest/lnd_test.go
+++ b/lntest/itest/lnd_test.go
@@ -14278,16 +14278,13 @@ func TestLightningNetworkDaemon(t *testing.T) {
 		err := lndHarness.EnsureConnected(
 			context.Background(), lndHarness.Alice, lndHarness.Bob,
 		)
-		if err != nil {
-			t.Fatalf("unable to connect alice to bob: %v", err)
-		}
+		require.NoError(t, err, "unable to connect alice to bob")
 
-		if err := lndHarness.Alice.AddToLog(logLine); err != nil {
-			t.Fatalf("unable to add to log: %v", err)
-		}
-		if err := lndHarness.Bob.AddToLog(logLine); err != nil {
-			t.Fatalf("unable to add to log: %v", err)
-		}
+		err = lndHarness.Alice.AddToLog(logLine)
+		require.NoError(t, err, "unable to add to Alice's log")
+
+		err = lndHarness.Bob.AddToLog(logLine)
+		require.NoError(t, err, "unable to add to Bob's log")
 
 		// Start every test with the default static fee estimate.
 		lndHarness.SetFeeEstimate(12500)

--- a/lntest/itest/log_error_whitelist.txt
+++ b/lntest/itest/log_error_whitelist.txt
@@ -49,6 +49,7 @@
 <time> [ERR] DISC: Unable to reply to peer query: set tcp <ip>: use of closed network connection
 <time> [ERR] DISC: Unable to reply to peer query: write tcp <ip>-><ip>: use of closed network connection
 <time> [ERR] DISC: Unable to reply to peer query: write tcp <ip>-><ip>: write: broken pipe
+<time> [ERR] DISC: Unable to reply to peer query: write tcp <ip>-><ip>: write: connection reset by peer
 <time> [ERR] FNDG: received funding error from <hex>: chan_id=<hex>, err=channel too large
 <time> [ERR] FNDG: received funding error from <hex>: chan_id=<hex>, err=chan size of 0.16777216 BTC exceeds maximum chan size of 0.16777215 BTC
 <time> [ERR] FNDG: received funding error from <hex>: chan_id=<hex>, err=chan size of 10.00000001 BTC exceeds maximum chan size of 0.16777215 BTC

--- a/lntest/node.go
+++ b/lntest/node.go
@@ -153,7 +153,12 @@ type BackendConfig interface {
 }
 
 type NodeConfig struct {
-	Name       string
+	Name string
+
+	// LogFilenamePrefix is is used to prefix node log files. Can be used
+	// to store the current test case for simpler postmortem debugging.
+	LogFilenamePrefix string
+
 	BackendCfg BackendConfig
 	NetParams  *chaincfg.Params
 	BaseDir    string
@@ -493,17 +498,21 @@ func (hn *HarnessNode) start(lndBinary string, lndError chan<- error) error {
 	// log files.
 	if *logOutput {
 		dir := GetLogDir()
-		fileName := fmt.Sprintf("%s/output-%d-%s-%s.log", dir, hn.NodeID,
-			hn.Cfg.Name, hex.EncodeToString(hn.PubKey[:logPubKeyBytes]))
+		fileName := fmt.Sprintf("%s/%d-%s-%s-%s.log", dir, hn.NodeID,
+			hn.Cfg.LogFilenamePrefix, hn.Cfg.Name,
+			hex.EncodeToString(hn.PubKey[:logPubKeyBytes]))
 
-		// If the node's PubKey is not yet initialized, create a temporary
-		// file name. Later, after the PubKey has been initialized, the
-		// file can be moved to its final name with the PubKey included.
+		// If the node's PubKey is not yet initialized, create a
+		// temporary file name. Later, after the PubKey has been
+		// initialized, the file can be moved to its final name with
+		// the PubKey included.
 		if bytes.Equal(hn.PubKey[:4], []byte{0, 0, 0, 0}) {
-			fileName = fmt.Sprintf("%s/output-%d-%s-tmp__.log",
-				dir, hn.NodeID, hn.Cfg.Name)
+			fileName = fmt.Sprintf("%s/%d-%s-%s-tmp__.log", dir,
+				hn.NodeID, hn.Cfg.LogFilenamePrefix,
+				hn.Cfg.Name)
 
-			// Once the node has done its work, the log file can be renamed.
+			// Once the node has done its work, the log file can be
+			// renamed.
 			finalizeLogfile = func() {
 				if hn.logFile != nil {
 					hn.logFile.Close()
@@ -511,8 +520,10 @@ func (hn *HarnessNode) start(lndBinary string, lndError chan<- error) error {
 					pubKeyHex := hex.EncodeToString(
 						hn.PubKey[:logPubKeyBytes],
 					)
-					newFileName := fmt.Sprintf("%s/output"+
-						"-%d-%s-%s.log", dir, hn.NodeID,
+					newFileName := fmt.Sprintf("%s/"+
+						"%d-%s-%s-%s.log",
+						dir, hn.NodeID,
+						hn.Cfg.LogFilenamePrefix,
 						hn.Cfg.Name, pubKeyHex)
 					err := os.Rename(fileName, newFileName)
 					if err != nil {


### PR DESCRIPTION
This PR changes the itest harness to make it possible to restart the harness nodes (Alice & Bob) before each icase while also changing the way we name icase node logs, to make it easier to see which logs belong to which icase.