### PR TITLE
discovery: allow DNS seeds to be overwritten

### DIFF
--- a/lncfg/chain.go
+++ b/lncfg/chain.go
@@ -26,6 +26,7 @@ type Chain struct {
 	BaseFee             lnwire.MilliSatoshi `long:"basefee" description:"The base fee in millisatoshi we will charge for forwarding payments on our channels"`
 	FeeRate             lnwire.MilliSatoshi `long:"feerate" description:"The fee rate used when forwarding payments on our channels. The total fee charged is basefee + (amount * feerate / 1000000), where amount is the forwarded amount."`
 	TimeLockDelta       uint32              `long:"timelockdelta" description:"The CLTV delta we will subtract from a forwarded HTLC's timelock value"`
+	DNSSeeds            []string            `long:"dnsseed" description:"The seed DNS server(s) to use for initial peer discovery. Must be specified as a '<primary_dns>[,<soa_primary_dns>]' tuple where the SOA address is needed for DNS resolution through Tor but is optional for clearnet users. Multiple tuples can be specified, will overwrite the default seed servers."`
 }
 
 // Validate performs validation on our chain config.

--- a/sample-lnd.conf
+++ b/sample-lnd.conf
@@ -417,6 +417,21 @@ bitcoin.node=btcd
 ; The CLTV delta we will subtract from a forwarded HTLC's timelock value.
 ; bitcoin.timelockdelta=40
 
+; The seed DNS server(s) to use for initial peer discovery. Must be specified as
+; a '<primary_dns>[,<soa_primary_dns>]' tuple where the SOA address is needed
+; for DNS resolution through Tor but is optional for clearnet users. Multiple
+; tuples can be specified, will overwrite the default seed servers.
+; The default seed servers are:
+;  mainnet:
+;    bitcoin.dnsseed=nodes.lightning.directory,soa.nodes.lightning.directory
+;    bitcoin.dnsseed=lseed.bitcoinstats.com
+;  testnet:
+;    bitcoin.dnsseed=test.nodes.lightning.directory,soa.nodes.lightning.directory
+;
+; Example for custom DNS servers:
+; bitcoin.dnsseed=seed1.test.lightning
+; bitcoin.dnsseed=seed2.test.lightning,soa.seed2.test.lightning
+
 ; Used to help identify ourselves to other bitcoin peers (default: neutrino).
 ; neutrino.useragentname=neutrino
 
@@ -588,6 +603,18 @@ litecoin.node=ltcd
 
 ; The CLTV delta we will subtract from a forwarded HTLC's timelock value.
 ; litecoin.timelockdelta=576
+
+; The seed DNS server(s) to use for initial peer discovery. Must be specified as
+; a '<primary_dns>[,<soa_primary_dns>]' tuple where the SOA address is needed
+; for DNS resolution through Tor but is optional for clearnet users. Multiple
+; tuples can be specified, will overwrite the default seed servers.
+; The default seed servers are:
+;  mainnet:
+;    litecoin.dnsseed=ltc.nodes.lightning.directory,soa.nodes.lightning.directory
+;
+; Example for custom DNS servers:
+; litecoin.dnsseed=seed1.test-ltc.lightning
+; litecoin.dnsseed=seed2.test-ltc.lightning,soa.seed2.test-ltc.lightning
 
 [Ltcd]
 


### PR DESCRIPTION
Fixes https://github.com/lightningnetwork/lnd/issues/3817.

Need to manually test on testnet, but should be pretty straightforward.
