### PR TITLE
fundingmanager+channeldb: export and use WriteOutpoint

### DIFF
--- a/channeldb/channel.go
+++ b/channeldb/channel.go
@@ -798,7 +798,7 @@ func fetchChanBucket(tx kvdb.RTx, nodeKey *btcec.PublicKey,
 	// With the bucket for the node and chain fetched, we can now go down
 	// another level, for this channel itself.
 	var chanPointBuf bytes.Buffer
-	if err := writeOutpoint(&chanPointBuf, outPoint); err != nil {
+	if err := WriteOutpoint(&chanPointBuf, outPoint); err != nil {
 		return nil, err
 	}
 	chanBucket := chainBucket.NestedReadBucket(chanPointBuf.Bytes())
@@ -852,7 +852,7 @@ func (c *OpenChannel) fullSync(tx kvdb.RwTx) error {
 	// With the bucket for the node fetched, we can now go down another
 	// level, creating the bucket for this channel itself.
 	var chanPointBuf bytes.Buffer
-	if err := writeOutpoint(&chanPointBuf, &c.FundingOutpoint); err != nil {
+	if err := WriteOutpoint(&chanPointBuf, &c.FundingOutpoint); err != nil {
 		return err
 	}
 	chanBucket, err := chainBucket.CreateBucket(
@@ -2703,7 +2703,7 @@ func (c *OpenChannel) CloseChannel(summary *ChannelCloseSummary,
 		}
 
 		var chanPointBuf bytes.Buffer
-		err := writeOutpoint(&chanPointBuf, &c.FundingOutpoint)
+		err := WriteOutpoint(&chanPointBuf, &c.FundingOutpoint)
 		if err != nil {
 			return err
 		}

--- a/channeldb/codec.go
+++ b/channeldb/codec.go
@@ -15,9 +15,9 @@ import (
 	"github.com/lightningnetwork/lnd/shachain"
 )
 
-// writeOutpoint writes an outpoint to the passed writer using the minimal
+// WriteOutpoint writes an outpoint to the passed writer using the minimal
 // amount of bytes possible.
-func writeOutpoint(w io.Writer, o *wire.OutPoint) error {
+func WriteOutpoint(w io.Writer, o *wire.OutPoint) error {
 	if _, err := w.Write(o.Hash[:]); err != nil {
 		return err
 	}
@@ -28,9 +28,9 @@ func writeOutpoint(w io.Writer, o *wire.OutPoint) error {
 	return nil
 }
 
-// readOutpoint reads an outpoint from the passed reader that was previously
-// written using the writeOutpoint struct.
-func readOutpoint(r io.Reader, o *wire.OutPoint) error {
+// ReadOutpoint reads an outpoint from the passed reader that was previously
+// written using the WriteOutpoint struct.
+func ReadOutpoint(r io.Reader, o *wire.OutPoint) error {
 	if _, err := io.ReadFull(r, o.Hash[:]); err != nil {
 		return err
 	}
@@ -94,7 +94,7 @@ func WriteElement(w io.Writer, element interface{}) error {
 		}
 
 	case wire.OutPoint:
-		return writeOutpoint(w, &e)
+		return WriteOutpoint(w, &e)
 
 	case lnwire.ShortChannelID:
 		if err := binary.Write(w, byteOrder, e.ToUint64()); err != nil {
@@ -269,7 +269,7 @@ func ReadElement(r io.Reader, element interface{}) error {
 		}
 
 	case *wire.OutPoint:
-		return readOutpoint(r, e)
+		return ReadOutpoint(r, e)
 
 	case *lnwire.ShortChannelID:
 		var a uint64

--- a/channeldb/db.go
+++ b/channeldb/db.go
@@ -468,7 +468,7 @@ func (db *DB) fetchNodeChannels(chainBucket kvdb.RBucket) ([]*OpenChannel, error
 		chanBucket := chainBucket.NestedReadBucket(chanPoint)
 
 		var outPoint wire.OutPoint
-		err := readOutpoint(bytes.NewReader(chanPoint), &outPoint)
+		err := ReadOutpoint(bytes.NewReader(chanPoint), &outPoint)
 		if err != nil {
 			return err
 		}
@@ -498,7 +498,7 @@ func (d *DB) FetchChannel(chanPoint wire.OutPoint) (*OpenChannel, error) {
 		targetChanPoint bytes.Buffer
 	)
 
-	if err := writeOutpoint(&targetChanPoint, &chanPoint); err != nil {
+	if err := WriteOutpoint(&targetChanPoint, &chanPoint); err != nil {
 		return nil, err
 	}
 
@@ -804,7 +804,7 @@ func (d *DB) FetchClosedChannel(chanID *wire.OutPoint) (*ChannelCloseSummary, er
 
 		var b bytes.Buffer
 		var err error
-		if err = writeOutpoint(&b, chanID); err != nil {
+		if err = WriteOutpoint(&b, chanID); err != nil {
 			return err
 		}
 
@@ -844,7 +844,7 @@ func (d *DB) FetchClosedChannelForID(cid lnwire.ChannelID) (
 		// We scan over all possible candidates for this channel ID.
 		for ; op != nil && bytes.Compare(cid[:30], op[:30]) <= 0; op, c = cursor.Next() {
 			var outPoint wire.OutPoint
-			err := readOutpoint(bytes.NewReader(op), &outPoint)
+			err := ReadOutpoint(bytes.NewReader(op), &outPoint)
 			if err != nil {
 				return err
 			}
@@ -880,7 +880,7 @@ func (d *DB) FetchClosedChannelForID(cid lnwire.ChannelID) (
 func (d *DB) MarkChanFullyClosed(chanPoint *wire.OutPoint) error {
 	return kvdb.Update(d, func(tx kvdb.RwTx) error {
 		var b bytes.Buffer
-		if err := writeOutpoint(&b, chanPoint); err != nil {
+		if err := WriteOutpoint(&b, chanPoint); err != nil {
 			return err
 		}
 
@@ -1238,7 +1238,7 @@ func fetchHistoricalChanBucket(tx kvdb.RTx,
 	// With the bucket for the node and chain fetched, we can now go down
 	// another level, for the channel itself.
 	var chanPointBuf bytes.Buffer
-	if err := writeOutpoint(&chanPointBuf, outPoint); err != nil {
+	if err := WriteOutpoint(&chanPointBuf, outPoint); err != nil {
 		return nil, err
 	}
 	chanBucket := historicalChanBucket.NestedReadBucket(chanPointBuf.Bytes())

--- a/channeldb/graph.go
+++ b/channeldb/graph.go
@@ -673,7 +673,7 @@ func (c *ChannelGraph) addChannelEdge(tx kvdb.RwTx, edge *ChannelEdgeInfo) error
 	// Finally we add it to the channel index which maps channel points
 	// (outpoints) to the shorter channel ID's.
 	var b bytes.Buffer
-	if err := writeOutpoint(&b, &edge.ChannelPoint); err != nil {
+	if err := WriteOutpoint(&b, &edge.ChannelPoint); err != nil {
 		return err
 	}
 	return chanIndex.Put(b.Bytes(), chanKey[:])
@@ -874,7 +874,7 @@ func (c *ChannelGraph) PruneGraph(spentOutputs []*wire.OutPoint,
 			// if NOT if filter
 
 			var opBytes bytes.Buffer
-			if err := writeOutpoint(&opBytes, chanPoint); err != nil {
+			if err := WriteOutpoint(&opBytes, chanPoint); err != nil {
 				return err
 			}
 
@@ -1322,7 +1322,7 @@ func (c *ChannelGraph) ChannelID(chanPoint *wire.OutPoint) (uint64, error) {
 // getChanID returns the assigned channel ID for a given channel point.
 func getChanID(tx kvdb.RTx, chanPoint *wire.OutPoint) (uint64, error) {
 	var b bytes.Buffer
-	if err := writeOutpoint(&b, chanPoint); err != nil {
+	if err := WriteOutpoint(&b, chanPoint); err != nil {
 		return 0, err
 	}
 
@@ -1876,7 +1876,7 @@ func delChannelEdge(edges, edgeIndex, chanIndex, zombieIndex,
 		return err
 	}
 	var b bytes.Buffer
-	if err := writeOutpoint(&b, &edgeInfo.ChannelPoint); err != nil {
+	if err := WriteOutpoint(&b, &edgeInfo.ChannelPoint); err != nil {
 		return err
 	}
 	if err := chanIndex.Delete(b.Bytes()); err != nil {
@@ -2899,7 +2899,7 @@ func (c *ChannelGraph) FetchChannelEdgesByOutpoint(op *wire.OutPoint,
 			return ErrGraphNoEdgesFound
 		}
 		var b bytes.Buffer
-		if err := writeOutpoint(&b, op); err != nil {
+		if err := WriteOutpoint(&b, op); err != nil {
 			return err
 		}
 		chanID := chanIndex.Get(b.Bytes())
@@ -3156,7 +3156,7 @@ func (c *ChannelGraph) ChannelView() ([]EdgePoint, error) {
 			chanPointReader := bytes.NewReader(chanPointBytes)
 
 			var chanPoint wire.OutPoint
-			err := readOutpoint(chanPointReader, &chanPoint)
+			err := ReadOutpoint(chanPointReader, &chanPoint)
 			if err != nil {
 				return err
 			}
@@ -3594,7 +3594,7 @@ func putChanEdgeInfo(edgeIndex kvdb.RwBucket, edgeInfo *ChannelEdgeInfo, chanID 
 		return err
 	}
 
-	if err := writeOutpoint(&b, &edgeInfo.ChannelPoint); err != nil {
+	if err := WriteOutpoint(&b, &edgeInfo.ChannelPoint); err != nil {
 		return err
 	}
 	if err := binary.Write(&b, byteOrder, uint64(edgeInfo.Capacity)); err != nil {
@@ -3678,7 +3678,7 @@ func deserializeChanEdgeInfo(r io.Reader) (ChannelEdgeInfo, error) {
 	}
 
 	edgeInfo.ChannelPoint = wire.OutPoint{}
-	if err := readOutpoint(r, &edgeInfo.ChannelPoint); err != nil {
+	if err := ReadOutpoint(r, &edgeInfo.ChannelPoint); err != nil {
 		return ChannelEdgeInfo{}, err
 	}
 	if err := binary.Read(r, byteOrder, &edgeInfo.Capacity); err != nil {

--- a/channeldb/migration19/codec.go
+++ b/channeldb/migration19/codec.go
@@ -1,0 +1,56 @@
+package migration19
+
+import (
+	"encoding/binary"
+	"io"
+
+	"github.com/btcsuite/btcd/wire"
+)
+
+var (
+	byteOrder = binary.BigEndian
+)
+
+// legacyWriteOutpoint is the legacy write encoding for outpoints.
+func legacyWriteOutpoint(w io.Writer, o *wire.OutPoint) error {
+	scratch := make([]byte, 4)
+
+	if err := wire.WriteVarBytes(w, 0, o.Hash[:]); err != nil {
+		return err
+	}
+
+	byteOrder.PutUint32(scratch, o.Index)
+	_, err := w.Write(scratch)
+	return err
+}
+
+// legacyReadOutpoint is the legacy read encoding for outpoints.
+func legacyReadOutpoint(r io.Reader, o *wire.OutPoint) error {
+	scratch := make([]byte, 4)
+
+	txid, err := wire.ReadVarBytes(r, 0, 32, "prevout")
+	if err != nil {
+		return err
+	}
+	copy(o.Hash[:], txid)
+
+	if _, err := r.Read(scratch); err != nil {
+		return err
+	}
+	o.Index = byteOrder.Uint32(scratch)
+
+	return nil
+}
+
+// channeldbWriteOutpoint is a copy of the channeldb version of
+// WriteOutpoint.
+func channeldbWriteOutpoint(w io.Writer, o *wire.OutPoint) error {
+	if _, err := w.Write(o.Hash[:]); err != nil {
+		return err
+	}
+	if err := binary.Write(w, byteOrder, o.Index); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/channeldb/migration19/log.go
+++ b/channeldb/migration19/log.go
@@ -1,0 +1,14 @@
+package migration19
+
+import (
+	"github.com/btcsuite/btclog"
+)
+
+// log is a logger that is initialized as disabled. This means the package
+// will not perform any logging by default until a logger is set.
+var log = btclog.Disabled
+
+// UseLogger uses a specified Logger to output package logging info.
+func UseLogger(logger btclog.Logger) {
+	log = logger
+}

--- a/channeldb/migration19/migration.go
+++ b/channeldb/migration19/migration.go
@@ -1,0 +1,141 @@
+package migration19
+
+import (
+	"bytes"
+
+	"github.com/btcsuite/btcd/wire"
+	"github.com/lightningnetwork/lnd/channeldb/kvdb"
+	"github.com/lightningnetwork/lnd/lnwire"
+)
+
+var (
+	// channelOpeningStateBucket stores channelOpeningState for
+	// pending channels.
+	channelOpeningStateBucket = []byte("channelOpeningState")
+)
+
+// channelOpeningState represents different states of a channel on-disk.
+type channelOpeningState uint8
+
+// openingInfo describes the data stored in the channelOpeningState bucket.
+type openingInfo struct {
+	op    wire.OutPoint
+	state channelOpeningState
+	sid   lnwire.ShortChannelID
+}
+
+// MigrateOutpoint migrates the outpoints stored in the funding open process
+// to use a 32-byte encoding rather than a 33-byte encoding. This allows the
+// fundingmanager to use the channeldb versions of the functions instead.
+func MigrateOutpoint(tx kvdb.RwTx) error {
+	log.Infof("Migrating outpoints in channelOpeningState bucket")
+
+	// For every entry in the openingStateBucket, grab the key and value.
+	// This tuple will be stored in a map.
+	infos, err := getChannelOpeningState(tx)
+	if err != nil {
+		return err
+	}
+
+	// Now we delete everything in the channelOpeningState bucket.
+	if err := deleteChannelOpeningState(tx, infos); err != nil {
+		return err
+	}
+
+	// Then put all of the entries back under a new key.
+	if err := putChannelOpeningState(tx, infos); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// putChannelOpeningState puts all of the entries back under a new key.
+func putChannelOpeningState(tx kvdb.RwTx, infos []openingInfo) error {
+	opBucket := tx.ReadWriteBucket(channelOpeningStateBucket)
+	if opBucket == nil {
+		return nil
+	}
+
+	// For every openingInfo, put the associated data into the bucket
+	// under the channeldb outpoint encoding.
+	for _, info := range infos {
+		var opBytes bytes.Buffer
+		if err := channeldbWriteOutpoint(&opBytes, &info.op); err != nil {
+			return err
+		}
+
+		scratch := make([]byte, 10)
+		byteOrder.PutUint16(scratch[:2], uint16(info.state))
+		byteOrder.PutUint64(scratch[2:], info.sid.ToUint64())
+
+		if err := opBucket.Put(opBytes.Bytes(), scratch); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// deleteChannelOpeningState deletes all channelOpeningState from the
+// bucket.
+func deleteChannelOpeningState(tx kvdb.RwTx, infos []openingInfo) error {
+	opBucket := tx.ReadWriteBucket(channelOpeningStateBucket)
+	if opBucket == nil {
+		return nil
+	}
+
+	// For every openingInfo, delete the associated data from the bucket.
+	for _, info := range infos {
+		var opBytes bytes.Buffer
+		if err := legacyWriteOutpoint(&opBytes, &info.op); err != nil {
+			return err
+		}
+
+		if err := opBucket.Delete(opBytes.Bytes()); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// getChannelOpeningState retrieves all the channelOpeningState data from
+// the bucket and returns it in a slice.
+func getChannelOpeningState(tx kvdb.RwTx) ([]openingInfo, error) {
+	var infos []openingInfo
+
+	openingStateBucket := tx.ReadBucket(channelOpeningStateBucket)
+	if openingStateBucket == nil {
+		return infos, nil
+	}
+
+	err := openingStateBucket.ForEach(func(k, v []byte) error {
+		var op wire.OutPoint
+		var state channelOpeningState
+		var shortChanID lnwire.ShortChannelID
+
+		r := bytes.NewReader(k)
+		if err := legacyReadOutpoint(r, &op); err != nil {
+			return err
+		}
+
+		state = channelOpeningState(byteOrder.Uint16(v[:2]))
+		shortChanID = lnwire.NewShortChanIDFromInt(byteOrder.Uint64(v[2:]))
+
+		info := openingInfo{
+			op:    op,
+			state: state,
+			sid:   shortChanID,
+		}
+
+		infos = append(infos, info)
+
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return infos, nil
+}

--- a/channeldb/migration19/migration_test.go
+++ b/channeldb/migration19/migration_test.go
@@ -1,0 +1,39 @@
+package migration19
+
+import (
+	"testing"
+
+	"github.com/lightningnetwork/lnd/channeldb/kvdb"
+	"github.com/lightningnetwork/lnd/channeldb/migtest"
+)
+
+var (
+	hexStr = migtest.Hex
+
+	varintOpString = hexStr("20166f95b104cf2a8d6c158de72ef0b78632f6a9e104ac4233867475714e8c5b1700000000")
+	normalOpString = hexStr("166f95b104cf2a8d6c158de72ef0b78632f6a9e104ac4233867475714e8c5b1700000000")
+	data           = hexStr("00010000000000000000")
+
+	pre = map[string]interface{}{
+		varintOpString: data,
+	}
+
+	post = map[string]interface{}{
+		normalOpString: data,
+	}
+)
+
+// TestMigrateOutpoint asserts that the channelOpeningState bucket
+// is properly migrated.
+func TestMigrateOutpoint(t *testing.T) {
+	before := func(tx kvdb.RwTx) error {
+		return migtest.RestoreDB(tx, channelOpeningStateBucket, pre)
+
+	}
+
+	after := func(tx kvdb.RwTx) error {
+		return migtest.VerifyDB(tx, channelOpeningStateBucket, post)
+	}
+
+	migtest.ApplyMigration(t, before, after, MigrateOutpoint, false)
+}

--- a/channeldb/reports.go
+++ b/channeldb/reports.go
@@ -164,7 +164,7 @@ func putReport(tx kvdb.RwTx, chainHash chainhash.Hash,
 
 	// Finally write our outpoint to be used as the key for this record.
 	var keyBuf bytes.Buffer
-	if err := writeOutpoint(&keyBuf, &report.OutPoint); err != nil {
+	if err := WriteOutpoint(&keyBuf, &report.OutPoint); err != nil {
 		return err
 	}
 
@@ -315,7 +315,7 @@ func fetchReportWriteBucket(tx kvdb.RwTx, chainHash chainhash.Hash,
 	}
 
 	var chanPointBuf bytes.Buffer
-	if err := writeOutpoint(&chanPointBuf, outPoint); err != nil {
+	if err := WriteOutpoint(&chanPointBuf, outPoint); err != nil {
 		return nil, err
 	}
 
@@ -339,7 +339,7 @@ func fetchReportReadBucket(tx kvdb.RTx, chainHash chainhash.Hash,
 	// With the bucket for the node and chain fetched, we can now go down
 	// another level, for the channel itself.
 	var chanPointBuf bytes.Buffer
-	if err := writeOutpoint(&chanPointBuf, outPoint); err != nil {
+	if err := WriteOutpoint(&chanPointBuf, outPoint); err != nil {
 		return nil, err
 	}
 

--- a/channeldb/reports_test.go
+++ b/channeldb/reports_test.go
@@ -139,7 +139,7 @@ func TestFetchChannelWriteBucket(t *testing.T) {
 		error) {
 
 		var chanPointBuf bytes.Buffer
-		err := writeOutpoint(&chanPointBuf, &testChanPoint1)
+		err := WriteOutpoint(&chanPointBuf, &testChanPoint1)
 		require.NoError(t, err)
 
 		return chainHash.CreateBucketIfNotExists(chanPointBuf.Bytes())

--- a/fundingmanager.go
+++ b/fundingmanager.go
@@ -3474,7 +3474,8 @@ func (f *fundingManager) saveChannelOpeningState(chanPoint *wire.OutPoint,
 		}
 
 		var outpointBytes bytes.Buffer
-		if err = writeOutpoint(&outpointBytes, chanPoint); err != nil {
+		err = channeldb.WriteOutpoint(&outpointBytes, chanPoint)
+		if err != nil {
 			return err
 		}
 
@@ -3506,7 +3507,8 @@ func (f *fundingManager) getChannelOpeningState(chanPoint *wire.OutPoint) (
 		}
 
 		var outpointBytes bytes.Buffer
-		if err := writeOutpoint(&outpointBytes, chanPoint); err != nil {
+		err := channeldb.WriteOutpoint(&outpointBytes, chanPoint)
+		if err != nil {
 			return err
 		}
 
@@ -3535,7 +3537,8 @@ func (f *fundingManager) deleteChannelOpeningState(chanPoint *wire.OutPoint) err
 		}
 
 		var outpointBytes bytes.Buffer
-		if err := writeOutpoint(&outpointBytes, chanPoint); err != nil {
+		err := channeldb.WriteOutpoint(&outpointBytes, chanPoint)
+		if err != nil {
 			return err
 		}
 


### PR DESCRIPTION
Gets rid of the utxonursery encoding in favor of the channeldb variant and has a migration to go with it for nodes with pending channels in the fundingmanager. A small change but helps us get closer to refactoring the fundingmanager.

Conflicts with #4642 