### PR TITLE
watchtower: prevent removal of last tower addr

### DIFF
--- a/watchtower/wtclient/client.go
+++ b/watchtower/wtclient/client.go
@@ -1124,7 +1124,10 @@ func (c *TowerClient) handleStaleTower(msg *staleTowerMsg) error {
 	if err := c.cfg.DB.RemoveTower(msg.pubKey, msg.addr); err != nil {
 		return err
 	}
-	c.candidateTowers.RemoveCandidate(tower.ID, msg.addr)
+	err = c.candidateTowers.RemoveCandidate(tower.ID, msg.addr)
+	if err != nil {
+		return err
+	}
 
 	// If an address was provided, then we're only meant to remove the
 	// address from the tower, so there's nothing left for us to do.

--- a/watchtower/wtdb/client_db.go
+++ b/watchtower/wtdb/client_db.go
@@ -108,6 +108,10 @@ var (
 	// created because session key index differs from the reserved key
 	// index.
 	ErrIncorrectKeyIndex = errors.New("incorrect key index")
+
+	// ErrLastTowerAddr is an error returned when the last address of a
+	// watchtower is attempted to be removed.
+	ErrLastTowerAddr = errors.New("cannot remove last tower address")
 )
 
 // ClientDB is single database providing a persistent storage engine for the
@@ -333,7 +337,13 @@ func (c *ClientDB) RemoveTower(pubKey *btcec.PublicKey, addr net.Addr) error {
 			if err != nil {
 				return err
 			}
+
+			// Towers should always have at least one address saved.
 			tower.RemoveAddress(addr)
+			if len(tower.Addresses) == 0 {
+				return ErrLastTowerAddr
+			}
+
 			return putTower(towers, tower)
 		}
 

--- a/watchtower/wtdb/client_db_test.go
+++ b/watchtower/wtdb/client_db_test.go
@@ -445,7 +445,7 @@ func testRemoveTower(h *clientDBHarness) {
 
 	// We'll then remove the first address. We should now see that the tower
 	// has no addresses left.
-	h.removeTower(pk, addr1, false, nil)
+	h.removeTower(pk, addr1, false, wtdb.ErrLastTowerAddr)
 
 	// Removing the tower as a whole from the database should succeed since
 	// there aren't any active sessions for it.

--- a/watchtower/wtmock/client_db.go
+++ b/watchtower/wtmock/client_db.go
@@ -101,6 +101,9 @@ func (m *ClientDB) RemoveTower(pubKey *btcec.PublicKey, addr net.Addr) error {
 
 	if addr != nil {
 		tower.RemoveAddress(addr)
+		if len(tower.Addresses) == 0 {
+			return wtdb.ErrLastTowerAddr
+		}
 		m.towers[tower.ID] = tower
 		return nil
 	}


### PR DESCRIPTION
This addresses a potential panic when a tower has one of its candidate sessions chosen, but its only reachable address was removed by a user-initiated RPC before the fact.

Fixes #4739.