### PR TITLE
multi: the great tlv wire migration

### DIFF
--- a/chanbackup/multi.go
+++ b/chanbackup/multi.go
@@ -63,7 +63,9 @@ func (m Multi) PackToWriter(w io.Writer, keyRing keychain.KeyRing) error {
 	var multiBackupBuffer bytes.Buffer
 
 	// First, we'll write out the version of this multi channel baackup.
-	err := lnwire.WriteElements(&multiBackupBuffer, byte(m.Version))
+	err := lnwire.WriteElements(
+		&multiBackupBuffer, lnwire.ProtocolVersionTLV, byte(m.Version),
+	)
 	if err != nil {
 		return err
 	}
@@ -111,7 +113,9 @@ func (m *Multi) UnpackFromReader(r io.Reader, keyRing keychain.KeyRing) error {
 	// First, we'll need to read the version of this multi-back up so we
 	// can know how to unpack each of the individual SCB's.
 	var multiVersion byte
-	err = lnwire.ReadElements(backupReader, &multiVersion)
+	err = lnwire.ReadElements(
+		backupReader, lnwire.ProtocolVersionTLV, &multiVersion,
+	)
 	if err != nil {
 		return err
 	}
@@ -127,7 +131,9 @@ func (m *Multi) UnpackFromReader(r io.Reader, keyRing keychain.KeyRing) error {
 		// backup is the same size, so we can continue until we've
 		// parsed out everything.
 		var numBackups uint32
-		err = lnwire.ReadElements(backupReader, &numBackups)
+		err = lnwire.ReadElements(
+			backupReader, lnwire.ProtocolVersionTLV, &numBackups,
+		)
 		if err != nil {
 			return err
 		}

--- a/channeldb/channel.go
+++ b/channeldb/channel.go
@@ -1866,12 +1866,12 @@ func deserializeLogUpdates(r io.Reader) ([]LogUpdate, error) {
 	return logUpdates, nil
 }
 
-func serializeCommitDiff(w io.Writer, diff *CommitDiff) error {
+func serializeCommitDiff(w io.Writer, diff *CommitDiff) error { // nolint: dupl
 	if err := serializeChanCommit(w, &diff.Commitment); err != nil {
 		return err
 	}
 
-	if err := diff.CommitSig.Encode(w, 0); err != nil {
+	if err := WriteElements(w, diff.CommitSig); err != nil {
 		return err
 	}
 
@@ -1917,10 +1917,16 @@ func deserializeCommitDiff(r io.Reader) (*CommitDiff, error) {
 		return nil, err
 	}
 
-	d.CommitSig = &lnwire.CommitSig{}
-	if err := d.CommitSig.Decode(r, 0); err != nil {
+	var msg lnwire.Message
+	if err := ReadElements(r, &msg); err != nil {
 		return nil, err
 	}
+	commitSig, ok := msg.(*lnwire.CommitSig)
+	if !ok {
+		return nil, fmt.Errorf("expected lnwire.CommitSig, instead "+
+			"read: %T", msg)
+	}
+	d.CommitSig = commitSig
 
 	d.LogUpdates, err = deserializeLogUpdates(r)
 	if err != nil {

--- a/channeldb/channel_test.go
+++ b/channeldb/channel_test.go
@@ -639,7 +639,8 @@ func TestChannelStateTransition(t *testing.T) {
 		{
 			LogIndex: 2,
 			UpdateMsg: &lnwire.UpdateAddHTLC{
-				ChanID: lnwire.ChannelID{1, 2, 3},
+				ChanID:    lnwire.ChannelID{1, 2, 3},
+				ExtraData: make([]byte, 0),
 			},
 		},
 	}
@@ -660,7 +661,9 @@ func TestChannelStateTransition(t *testing.T) {
 	if !reflect.DeepEqual(
 		dbUnsignedAckedUpdates[0], unsignedAckedUpdates[0],
 	) {
-		t.Fatalf("unexpected update")
+		t.Fatalf("unexpected update: expected %v, got %v",
+			spew.Sdump(unsignedAckedUpdates[0]),
+			spew.Sdump(dbUnsignedAckedUpdates))
 	}
 
 	// The balances, new update, the HTLCs and the changes to the fake
@@ -702,22 +705,25 @@ func TestChannelStateTransition(t *testing.T) {
 				wireSig,
 				wireSig,
 			},
+			ExtraData: make([]byte, 0),
 		},
 		LogUpdates: []LogUpdate{
 			{
 				LogIndex: 1,
 				UpdateMsg: &lnwire.UpdateAddHTLC{
-					ID:     1,
-					Amount: lnwire.NewMSatFromSatoshis(100),
-					Expiry: 25,
+					ID:        1,
+					Amount:    lnwire.NewMSatFromSatoshis(100),
+					Expiry:    25,
+					ExtraData: make([]byte, 0),
 				},
 			},
 			{
 				LogIndex: 2,
 				UpdateMsg: &lnwire.UpdateAddHTLC{
-					ID:     2,
-					Amount: lnwire.NewMSatFromSatoshis(200),
-					Expiry: 50,
+					ID:        2,
+					Amount:    lnwire.NewMSatFromSatoshis(200),
+					Expiry:    50,
+					ExtraData: make([]byte, 0),
 				},
 			},
 		},

--- a/channeldb/codec.go
+++ b/channeldb/codec.go
@@ -1,6 +1,7 @@
 package channeldb
 
 import (
+	"bytes"
 	"encoding/binary"
 	"fmt"
 	"io"
@@ -178,7 +179,17 @@ func WriteElement(w io.Writer, element interface{}) error {
 		}
 
 	case lnwire.Message:
-		if _, err := lnwire.WriteMessage(w, e, 0); err != nil {
+		var msgBuf bytes.Buffer
+		if _, err := lnwire.WriteMessage(&msgBuf, e, 0); err != nil {
+			return err
+		}
+
+		msgLen := uint16(len(msgBuf.Bytes()))
+		if err := WriteElements(w, msgLen); err != nil {
+			return err
+		}
+
+		if _, err := w.Write(msgBuf.Bytes()); err != nil {
 			return err
 		}
 
@@ -394,7 +405,13 @@ func ReadElement(r io.Reader, element interface{}) error {
 		*e = bytes
 
 	case *lnwire.Message:
-		msg, err := lnwire.ReadMessage(r, 0)
+		var msgLen uint16
+		if err := ReadElement(r, &msgLen); err != nil {
+			return err
+		}
+
+		msgReader := io.LimitReader(r, int64(msgLen))
+		msg, err := lnwire.ReadMessage(msgReader, 0)
 		if err != nil {
 			return err
 		}

--- a/channeldb/db.go
+++ b/channeldb/db.go
@@ -17,6 +17,7 @@ import (
 	"github.com/lightningnetwork/lnd/channeldb/migration12"
 	"github.com/lightningnetwork/lnd/channeldb/migration13"
 	"github.com/lightningnetwork/lnd/channeldb/migration16"
+	"github.com/lightningnetwork/lnd/channeldb/migration19"
 	"github.com/lightningnetwork/lnd/channeldb/migration_01_to_11"
 	"github.com/lightningnetwork/lnd/clock"
 	"github.com/lightningnetwork/lnd/lnwire"

--- a/channeldb/db.go
+++ b/channeldb/db.go
@@ -170,6 +170,12 @@ var (
 			number:    18,
 			migration: mig.CreateTLB(peersBucket),
 		},
+		{
+			// Migrate to length prefixed wire messages everywhere
+			// in the database.
+			number:    19,
+			migration: migration19.MigrateDatabaseWireMessages,
+		},
 	}
 
 	// Big endian is the preferred byte order, due to cursor scans over

--- a/channeldb/migration19/enclosed_codec.go
+++ b/channeldb/migration19/enclosed_codec.go
@@ -171,7 +171,8 @@ func WriteElement(w io.Writer, element interface{}) error {
 		}
 
 	case lnwire.Message:
-		if _, err := lnwire.WriteMessage(w, e, 0); err != nil {
+		_, err := lnwire.WriteMessage(w, e, lnwire.ProtocolVersionLegacy)
+		if err != nil {
 			return err
 		}
 
@@ -303,7 +304,7 @@ func ReadElement(r io.Reader, element interface{}) error {
 		*e = bytes
 
 	case *lnwire.Message:
-		msg, err := lnwire.ReadMessage(r, 0)
+		msg, err := lnwire.ReadMessage(r, lnwire.ProtocolVersionLegacy)
 		if err != nil {
 			return err
 		}

--- a/channeldb/migration19/enclosed_codec.go
+++ b/channeldb/migration19/enclosed_codec.go
@@ -1,0 +1,358 @@
+package migration19
+
+import (
+	"encoding/binary"
+	"fmt"
+	"io"
+
+	"github.com/btcsuite/btcd/btcec"
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"github.com/btcsuite/btcd/wire"
+	"github.com/btcsuite/btcutil"
+	"github.com/lightningnetwork/lnd/keychain"
+	"github.com/lightningnetwork/lnd/lnwire"
+)
+
+var (
+	// Big endian is the preferred byte order, due to cursor scans over
+	// integer keys iterating in order.
+	byteOrder = binary.BigEndian
+)
+
+// writeOutpoint writes an outpoint to the passed writer using the minimal
+// amount of bytes possible.
+func writeOutpoint(w io.Writer, o *wire.OutPoint) error {
+	if _, err := w.Write(o.Hash[:]); err != nil {
+		return err
+	}
+	if err := binary.Write(w, byteOrder, o.Index); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// readOutpoint reads an outpoint from the passed reader that was previously
+// written using the writeOutpoint struct.
+func readOutpoint(r io.Reader, o *wire.OutPoint) error {
+	if _, err := io.ReadFull(r, o.Hash[:]); err != nil {
+		return err
+	}
+	if err := binary.Read(r, byteOrder, &o.Index); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// UnknownElementType is an error returned when the codec is unable to encode or
+// decode a particular type.
+type UnknownElementType struct {
+	method  string
+	element interface{}
+}
+
+// NewUnknownElementType creates a new UnknownElementType error from the passed
+// method name and element.
+func NewUnknownElementType(method string, el interface{}) UnknownElementType {
+	return UnknownElementType{method: method, element: el}
+}
+
+// Error returns the name of the method that encountered the error, as well as
+// the type that was unsupported.
+func (e UnknownElementType) Error() string {
+	return fmt.Sprintf("Unknown type in %s: %T", e.method, e.element)
+}
+
+// WriteElement is a one-stop shop to write the big endian representation of
+// any element which is to be serialized for storage on disk. The passed
+// io.Writer should be backed by an appropriately sized byte slice, or be able
+// to dynamically expand to accommodate additional data.
+func WriteElement(w io.Writer, element interface{}) error {
+	switch e := element.(type) {
+	case keychain.KeyDescriptor:
+		if err := binary.Write(w, byteOrder, e.Family); err != nil {
+			return err
+		}
+		if err := binary.Write(w, byteOrder, e.Index); err != nil {
+			return err
+		}
+
+		if e.PubKey != nil {
+			if err := binary.Write(w, byteOrder, true); err != nil {
+				return fmt.Errorf("error writing serialized element: %s", err)
+			}
+
+			return WriteElement(w, e.PubKey)
+		}
+
+		return binary.Write(w, byteOrder, false)
+
+	case chainhash.Hash:
+		if _, err := w.Write(e[:]); err != nil {
+			return err
+		}
+
+	case ClosureType:
+		if err := binary.Write(w, byteOrder, e); err != nil {
+			return err
+		}
+
+	case wire.OutPoint:
+		return writeOutpoint(w, &e)
+
+	case lnwire.ShortChannelID:
+		if err := binary.Write(w, byteOrder, e.ToUint64()); err != nil {
+			return err
+		}
+
+	case lnwire.ChannelID:
+		if _, err := w.Write(e[:]); err != nil {
+			return err
+		}
+
+	case int64, uint64:
+		if err := binary.Write(w, byteOrder, e); err != nil {
+			return err
+		}
+
+	case uint32:
+		if err := binary.Write(w, byteOrder, e); err != nil {
+			return err
+		}
+
+	case int32:
+		if err := binary.Write(w, byteOrder, e); err != nil {
+			return err
+		}
+
+	case uint16:
+		if err := binary.Write(w, byteOrder, e); err != nil {
+			return err
+		}
+
+	case uint8:
+		if err := binary.Write(w, byteOrder, e); err != nil {
+			return err
+		}
+
+	case bool:
+		if err := binary.Write(w, byteOrder, e); err != nil {
+			return err
+		}
+
+	case btcutil.Amount:
+		if err := binary.Write(w, byteOrder, uint64(e)); err != nil {
+			return err
+		}
+
+	case lnwire.MilliSatoshi:
+		if err := binary.Write(w, byteOrder, uint64(e)); err != nil {
+			return err
+		}
+
+	case *btcec.PublicKey:
+		b := e.SerializeCompressed()
+		if _, err := w.Write(b); err != nil {
+			return err
+		}
+
+	case *wire.MsgTx:
+		return e.Serialize(w)
+
+	case [32]byte:
+		if _, err := w.Write(e[:]); err != nil {
+			return err
+		}
+
+	case []byte:
+		if err := wire.WriteVarBytes(w, 0, e); err != nil {
+			return err
+		}
+
+	case lnwire.Message:
+		if _, err := lnwire.WriteMessage(w, e, 0); err != nil {
+			return err
+		}
+
+	case lnwire.FundingFlag:
+		if err := binary.Write(w, byteOrder, e); err != nil {
+			return err
+		}
+
+	default:
+		return UnknownElementType{"WriteElement", e}
+	}
+
+	return nil
+}
+
+// WriteElements is writes each element in the elements slice to the passed
+// io.Writer using WriteElement.
+func WriteElements(w io.Writer, elements ...interface{}) error {
+	for _, element := range elements {
+		err := WriteElement(w, element)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// ReadElement is a one-stop utility function to deserialize any datastructure
+// encoded using the serialization format of the database.
+func ReadElement(r io.Reader, element interface{}) error {
+	switch e := element.(type) {
+	case *chainhash.Hash:
+		if _, err := io.ReadFull(r, e[:]); err != nil {
+			return err
+		}
+
+	case *wire.OutPoint:
+		return readOutpoint(r, e)
+
+	case *lnwire.ShortChannelID:
+		var a uint64
+		if err := binary.Read(r, byteOrder, &a); err != nil {
+			return err
+		}
+		*e = lnwire.NewShortChanIDFromInt(a)
+
+	case *lnwire.ChannelID:
+		if _, err := io.ReadFull(r, e[:]); err != nil {
+			return err
+		}
+
+	case *int64, *uint64:
+		if err := binary.Read(r, byteOrder, e); err != nil {
+			return err
+		}
+
+	case *uint32:
+		if err := binary.Read(r, byteOrder, e); err != nil {
+			return err
+		}
+
+	case *int32:
+		if err := binary.Read(r, byteOrder, e); err != nil {
+			return err
+		}
+
+	case *uint16:
+		if err := binary.Read(r, byteOrder, e); err != nil {
+			return err
+		}
+
+	case *uint8:
+		if err := binary.Read(r, byteOrder, e); err != nil {
+			return err
+		}
+
+	case *bool:
+		if err := binary.Read(r, byteOrder, e); err != nil {
+			return err
+		}
+
+	case *btcutil.Amount:
+		var a uint64
+		if err := binary.Read(r, byteOrder, &a); err != nil {
+			return err
+		}
+
+		*e = btcutil.Amount(a)
+
+	case *lnwire.MilliSatoshi:
+		var a uint64
+		if err := binary.Read(r, byteOrder, &a); err != nil {
+			return err
+		}
+
+		*e = lnwire.MilliSatoshi(a)
+
+	case **btcec.PublicKey:
+		var b [btcec.PubKeyBytesLenCompressed]byte
+		if _, err := io.ReadFull(r, b[:]); err != nil {
+			return err
+		}
+
+		pubKey, err := btcec.ParsePubKey(b[:], btcec.S256())
+		if err != nil {
+			return err
+		}
+		*e = pubKey
+
+	case **wire.MsgTx:
+		tx := wire.NewMsgTx(2)
+		if err := tx.Deserialize(r); err != nil {
+			return err
+		}
+
+		*e = tx
+
+	case *[32]byte:
+		if _, err := io.ReadFull(r, e[:]); err != nil {
+			return err
+		}
+
+	case *[]byte:
+		bytes, err := wire.ReadVarBytes(r, 0, 66000, "[]byte")
+		if err != nil {
+			return err
+		}
+
+		*e = bytes
+
+	case *lnwire.Message:
+		msg, err := lnwire.ReadMessage(r, 0)
+		if err != nil {
+			return err
+		}
+
+		*e = msg
+
+	case *lnwire.FundingFlag:
+		if err := binary.Read(r, byteOrder, e); err != nil {
+			return err
+		}
+
+	case *ClosureType:
+		if err := binary.Read(r, byteOrder, e); err != nil {
+			return err
+		}
+
+	case *keychain.KeyDescriptor:
+		if err := binary.Read(r, byteOrder, &e.Family); err != nil {
+			return err
+		}
+		if err := binary.Read(r, byteOrder, &e.Index); err != nil {
+			return err
+		}
+
+		var hasPubKey bool
+		if err := binary.Read(r, byteOrder, &hasPubKey); err != nil {
+			return err
+		}
+
+		if hasPubKey {
+			return ReadElement(r, &e.PubKey)
+		}
+
+	default:
+		return UnknownElementType{"ReadElement", e}
+	}
+
+	return nil
+}
+
+// ReadElements deserializes a variable number of elements into the passed
+// io.Reader, with each element being deserialized according to the ReadElement
+// function.
+func ReadElements(r io.Reader, elements ...interface{}) error {
+	for _, element := range elements {
+		err := ReadElement(r, element)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/channeldb/migration19/enclosed_types.go
+++ b/channeldb/migration19/enclosed_types.go
@@ -1,0 +1,541 @@
+package migration19
+
+import (
+	"encoding/binary"
+	"fmt"
+	"io"
+
+	"github.com/btcsuite/btcd/btcec"
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"github.com/btcsuite/btcd/wire"
+	"github.com/btcsuite/btcutil"
+	"github.com/lightningnetwork/lnd/keychain"
+	"github.com/lightningnetwork/lnd/lnwire"
+)
+
+var (
+	// ErrInvalidCircuitKeyLen signals that a circuit key could not be
+	// decoded because the byte slice is of an invalid length.
+	ErrInvalidCircuitKeyLen = fmt.Errorf(
+		"length of serialized circuit key must be 16 bytes")
+)
+
+// CircuitKey is used by a channel to uniquely identify the HTLCs it receives
+// from the switch, and is used to purge our in-memory state of HTLCs that have
+// already been processed by a link. Two list of CircuitKeys are included in
+// each CommitDiff to allow a link to determine which in-memory htlcs directed
+// the opening and closing of circuits in the switch's circuit map.
+type CircuitKey struct {
+	// ChanID is the short chanid indicating the HTLC's origin.
+	//
+	// NOTE: It is fine for this value to be blank, as this indicates a
+	// locally-sourced payment.
+	ChanID lnwire.ShortChannelID
+
+	// HtlcID is the unique htlc index predominately assigned by links,
+	// though can also be assigned by switch in the case of locally-sourced
+	// payments.
+	HtlcID uint64
+}
+
+// SetBytes deserializes the given bytes into this CircuitKey.
+func (k *CircuitKey) SetBytes(bs []byte) error {
+	if len(bs) != 16 {
+		return ErrInvalidCircuitKeyLen
+	}
+
+	k.ChanID = lnwire.NewShortChanIDFromInt(
+		binary.BigEndian.Uint64(bs[:8]))
+	k.HtlcID = binary.BigEndian.Uint64(bs[8:])
+
+	return nil
+}
+
+// Bytes returns the serialized bytes for this circuit key.
+func (k CircuitKey) Bytes() []byte {
+	var bs = make([]byte, 16)
+	binary.BigEndian.PutUint64(bs[:8], k.ChanID.ToUint64())
+	binary.BigEndian.PutUint64(bs[8:], k.HtlcID)
+	return bs
+}
+
+// Encode writes a CircuitKey to the provided io.Writer.
+func (k *CircuitKey) Encode(w io.Writer) error {
+	var scratch [16]byte
+	binary.BigEndian.PutUint64(scratch[:8], k.ChanID.ToUint64())
+	binary.BigEndian.PutUint64(scratch[8:], k.HtlcID)
+
+	_, err := w.Write(scratch[:])
+	return err
+}
+
+// Decode reads a CircuitKey from the provided io.Reader.
+func (k *CircuitKey) Decode(r io.Reader) error {
+	var scratch [16]byte
+
+	if _, err := io.ReadFull(r, scratch[:]); err != nil {
+		return err
+	}
+	k.ChanID = lnwire.NewShortChanIDFromInt(
+		binary.BigEndian.Uint64(scratch[:8]))
+	k.HtlcID = binary.BigEndian.Uint64(scratch[8:])
+
+	return nil
+}
+
+// String returns a string representation of the CircuitKey.
+func (k CircuitKey) String() string {
+	return fmt.Sprintf("(Chan ID=%s, HTLC ID=%d)", k.ChanID, k.HtlcID)
+}
+
+// HTLC is the on-disk representation of a hash time-locked contract. HTLCs are
+// contained within ChannelDeltas which encode the current state of the
+// commitment between state updates.
+//
+// TODO(roasbeef): save space by using smaller ints at tail end?
+type HTLC struct {
+	// Signature is the signature for the second level covenant transaction
+	// for this HTLC. The second level transaction is a timeout tx in the
+	// case that this is an outgoing HTLC, and a success tx in the case
+	// that this is an incoming HTLC.
+	//
+	// TODO(roasbeef): make [64]byte instead?
+	Signature []byte
+
+	// RHash is the payment hash of the HTLC.
+	RHash [32]byte
+
+	// Amt is the amount of milli-satoshis this HTLC escrows.
+	Amt lnwire.MilliSatoshi
+
+	// RefundTimeout is the absolute timeout on the HTLC that the sender
+	// must wait before reclaiming the funds in limbo.
+	RefundTimeout uint32
+
+	// OutputIndex is the output index for this particular HTLC output
+	// within the commitment transaction.
+	OutputIndex int32
+
+	// Incoming denotes whether we're the receiver or the sender of this
+	// HTLC.
+	Incoming bool
+
+	// OnionBlob is an opaque blob which is used to complete multi-hop
+	// routing.
+	OnionBlob []byte
+
+	// HtlcIndex is the HTLC counter index of this active, outstanding
+	// HTLC. This differs from the LogIndex, as the HtlcIndex is only
+	// incremented for each offered HTLC, while they LogIndex is
+	// incremented for each update (includes settle+fail).
+	HtlcIndex uint64
+
+	// LogIndex is the cumulative log index of this HTLC. This differs
+	// from the HtlcIndex as this will be incremented for each new log
+	// update added.
+	LogIndex uint64
+}
+
+// ChannelCommitment is a snapshot of the commitment state at a particular
+// point in the commitment chain. With each state transition, a snapshot of the
+// current state along with all non-settled HTLCs are recorded. These snapshots
+// detail the state of the _remote_ party's commitment at a particular state
+// number.  For ourselves (the local node) we ONLY store our most recent
+// (unrevoked) state for safety purposes.
+type ChannelCommitment struct {
+	// CommitHeight is the update number that this ChannelDelta represents
+	// the total number of commitment updates to this point. This can be
+	// viewed as sort of a "commitment height" as this number is
+	// monotonically increasing.
+	CommitHeight uint64
+
+	// LocalLogIndex is the cumulative log index index of the local node at
+	// this point in the commitment chain. This value will be incremented
+	// for each _update_ added to the local update log.
+	LocalLogIndex uint64
+
+	// LocalHtlcIndex is the current local running HTLC index. This value
+	// will be incremented for each outgoing HTLC the local node offers.
+	LocalHtlcIndex uint64
+
+	// RemoteLogIndex is the cumulative log index index of the remote node
+	// at this point in the commitment chain. This value will be
+	// incremented for each _update_ added to the remote update log.
+	RemoteLogIndex uint64
+
+	// RemoteHtlcIndex is the current remote running HTLC index. This value
+	// will be incremented for each outgoing HTLC the remote node offers.
+	RemoteHtlcIndex uint64
+
+	// LocalBalance is the current available settled balance within the
+	// channel directly spendable by us.
+	//
+	// NOTE: This is the balance *after* subtracting any commitment fee,
+	// AND anchor output values.
+	LocalBalance lnwire.MilliSatoshi
+
+	// RemoteBalance is the current available settled balance within the
+	// channel directly spendable by the remote node.
+	//
+	// NOTE: This is the balance *after* subtracting any commitment fee,
+	// AND anchor output values.
+	RemoteBalance lnwire.MilliSatoshi
+
+	// CommitFee is the amount calculated to be paid in fees for the
+	// current set of commitment transactions. The fee amount is persisted
+	// with the channel in order to allow the fee amount to be removed and
+	// recalculated with each channel state update, including updates that
+	// happen after a system restart.
+	CommitFee btcutil.Amount
+
+	// FeePerKw is the min satoshis/kilo-weight that should be paid within
+	// the commitment transaction for the entire duration of the channel's
+	// lifetime. This field may be updated during normal operation of the
+	// channel as on-chain conditions change.
+	//
+	// TODO(halseth): make this SatPerKWeight. Cannot be done atm because
+	// this will cause the import cycle lnwallet<->channeldb. Fee
+	// estimation stuff should be in its own package.
+	FeePerKw btcutil.Amount
+
+	// CommitTx is the latest version of the commitment state, broadcast
+	// able by us.
+	CommitTx *wire.MsgTx
+
+	// CommitSig is one half of the signature required to fully complete
+	// the script for the commitment transaction above. This is the
+	// signature signed by the remote party for our version of the
+	// commitment transactions.
+	CommitSig []byte
+
+	// Htlcs is the set of HTLC's that are pending at this particular
+	// commitment height.
+	Htlcs []HTLC
+
+	// TODO(roasbeef): pending commit pointer?
+	//  * lets just walk through
+}
+
+// LogUpdate represents a pending update to the remote commitment chain. The
+// log update may be an add, fail, or settle entry. We maintain this data in
+// order to be able to properly retransmit our proposed
+// state if necessary.
+type LogUpdate struct {
+	// LogIndex is the log index of this proposed commitment update entry.
+	LogIndex uint64
+
+	// UpdateMsg is the update message that was included within the our
+	// local update log. The LogIndex value denotes the log index of this
+	// update which will be used when restoring our local update log if
+	// we're left with a dangling update on restart.
+	UpdateMsg lnwire.Message
+}
+
+// Encode writes a log update to the provided io.Writer.
+func (l *LogUpdate) Encode(w io.Writer) error {
+	return WriteElements(w, l.LogIndex, l.UpdateMsg)
+}
+
+// Decode reads a log update from the provided io.Reader.
+func (l *LogUpdate) Decode(r io.Reader) error {
+	return ReadElements(r, &l.LogIndex, &l.UpdateMsg)
+}
+
+// AddRef is used to identify a particular Add in a FwdPkg. The short channel ID
+// is assumed to be that of the packager.
+type AddRef struct {
+	// Height is the remote commitment height that locked in the Add.
+	Height uint64
+
+	// Index is the index of the Add within the fwd pkg's Adds.
+	//
+	// NOTE: This index is static over the lifetime of a forwarding package.
+	Index uint16
+}
+
+// Encode serializes the AddRef to the given io.Writer.
+func (a *AddRef) Encode(w io.Writer) error {
+	if err := binary.Write(w, binary.BigEndian, a.Height); err != nil {
+		return err
+	}
+
+	return binary.Write(w, binary.BigEndian, a.Index)
+}
+
+// Decode deserializes the AddRef from the given io.Reader.
+func (a *AddRef) Decode(r io.Reader) error {
+	if err := binary.Read(r, binary.BigEndian, &a.Height); err != nil {
+		return err
+	}
+
+	return binary.Read(r, binary.BigEndian, &a.Index)
+}
+
+// SettleFailRef is used to locate a Settle/Fail in another channel's FwdPkg. A
+// channel does not remove its own Settle/Fail htlcs, so the source is provided
+// to locate a db bucket belonging to another channel.
+type SettleFailRef struct {
+	// Source identifies the outgoing link that locked in the settle or
+	// fail. This is then used by the *incoming* link to find the settle
+	// fail in another link's forwarding packages.
+	Source lnwire.ShortChannelID
+
+	// Height is the remote commitment height that locked in this
+	// Settle/Fail.
+	Height uint64
+
+	// Index is the index of the Add with the fwd pkg's SettleFails.
+	//
+	// NOTE: This index is static over the lifetime of a forwarding package.
+	Index uint16
+}
+
+// CommitDiff represents the delta needed to apply the state transition between
+// two subsequent commitment states. Given state N and state N+1, one is able
+// to apply the set of messages contained within the CommitDiff to N to arrive
+// at state N+1. Each time a new commitment is extended, we'll write a new
+// commitment (along with the full commitment state) to disk so we can
+// re-transmit the state in the case of a connection loss or message drop.
+type CommitDiff struct {
+	// ChannelCommitment is the full commitment state that one would arrive
+	// at by applying the set of messages contained in the UpdateDiff to
+	// the prior accepted commitment.
+	Commitment ChannelCommitment
+
+	// LogUpdates is the set of messages sent prior to the commitment state
+	// transition in question. Upon reconnection, if we detect that they
+	// don't have the commitment, then we re-send this along with the
+	// proper signature.
+	LogUpdates []LogUpdate
+
+	// CommitSig is the exact CommitSig message that should be sent after
+	// the set of LogUpdates above has been retransmitted. The signatures
+	// within this message should properly cover the new commitment state
+	// and also the HTLC's within the new commitment state.
+	CommitSig *lnwire.CommitSig
+
+	// OpenedCircuitKeys is a set of unique identifiers for any downstream
+	// Add packets included in this commitment txn. After a restart, this
+	// set of htlcs is acked from the link's incoming mailbox to ensure
+	// there isn't an attempt to re-add them to this commitment txn.
+	OpenedCircuitKeys []CircuitKey
+
+	// ClosedCircuitKeys records the unique identifiers for any settle/fail
+	// packets that were resolved by this commitment txn. After a restart,
+	// this is used to ensure those circuits are removed from the circuit
+	// map, and the downstream packets in the link's mailbox are removed.
+	ClosedCircuitKeys []CircuitKey
+
+	// AddAcks specifies the locations (commit height, pkg index) of any
+	// Adds that were failed/settled in this commit diff. This will ack
+	// entries in *this* channel's forwarding packages.
+	//
+	// NOTE: This value is not serialized, it is used to atomically mark the
+	// resolution of adds, such that they will not be reprocessed after a
+	// restart.
+	AddAcks []AddRef
+
+	// SettleFailAcks specifies the locations (chan id, commit height, pkg
+	// index) of any Settles or Fails that were locked into this commit
+	// diff, and originate from *another* channel, i.e. the outgoing link.
+	//
+	// NOTE: This value is not serialized, it is used to atomically acks
+	// settles and fails from the forwarding packages of other channels,
+	// such that they will not be reforwarded internally after a restart.
+	SettleFailAcks []SettleFailRef
+}
+
+// networkResult is the raw result received from the network after a payment
+// attempt has been made. Since the switch doesn't always have the necessary
+// data to decode the raw message, we store it together with some meta data,
+// and decode it when the router query for the final result.
+type networkResult struct {
+	// msg is the received result. This should be of type UpdateFulfillHTLC
+	// or UpdateFailHTLC.
+	msg lnwire.Message
+
+	// unencrypted indicates whether the failure encoded in the message is
+	// unencrypted, and hence doesn't need to be decrypted.
+	unencrypted bool
+
+	// isResolution indicates whether this is a resolution message, in
+	// which the failure reason might not be included.
+	isResolution bool
+}
+
+// ClosureType is an enum like structure that details exactly _how_ a channel
+// was closed. Three closure types are currently possible: none, cooperative,
+// local force close, remote force close, and (remote) breach.
+type ClosureType uint8
+
+// ChannelConstraints represents a set of constraints meant to allow a node to
+// limit their exposure, enact flow control and ensure that all HTLCs are
+// economically relevant. This struct will be mirrored for both sides of the
+// channel, as each side will enforce various constraints that MUST be adhered
+// to for the life time of the channel. The parameters for each of these
+// constraints are static for the duration of the channel, meaning the channel
+// must be torn down for them to change.
+type ChannelConstraints struct {
+	// DustLimit is the threshold (in satoshis) below which any outputs
+	// should be trimmed. When an output is trimmed, it isn't materialized
+	// as an actual output, but is instead burned to miner's fees.
+	DustLimit btcutil.Amount
+
+	// ChanReserve is an absolute reservation on the channel for the
+	// owner of this set of constraints. This means that the current
+	// settled balance for this node CANNOT dip below the reservation
+	// amount. This acts as a defense against costless attacks when
+	// either side no longer has any skin in the game.
+	ChanReserve btcutil.Amount
+
+	// MaxPendingAmount is the maximum pending HTLC value that the
+	// owner of these constraints can offer the remote node at a
+	// particular time.
+	MaxPendingAmount lnwire.MilliSatoshi
+
+	// MinHTLC is the minimum HTLC value that the owner of these
+	// constraints can offer the remote node. If any HTLCs below this
+	// amount are offered, then the HTLC will be rejected. This, in
+	// tandem with the dust limit allows a node to regulate the
+	// smallest HTLC that it deems economically relevant.
+	MinHTLC lnwire.MilliSatoshi
+
+	// MaxAcceptedHtlcs is the maximum number of HTLCs that the owner of
+	// this set of constraints can offer the remote node. This allows each
+	// node to limit their over all exposure to HTLCs that may need to be
+	// acted upon in the case of a unilateral channel closure or a contract
+	// breach.
+	MaxAcceptedHtlcs uint16
+
+	// CsvDelay is the relative time lock delay expressed in blocks. Any
+	// settled outputs that pay to the owner of this channel configuration
+	// MUST ensure that the delay branch uses this value as the relative
+	// time lock. Similarly, any HTLC's offered by this node should use
+	// this value as well.
+	CsvDelay uint16
+}
+
+// ChannelConfig is a struct that houses the various configuration opens for
+// channels. Each side maintains an instance of this configuration file as it
+// governs: how the funding and commitment transaction to be created, the
+// nature of HTLC's allotted, the keys to be used for delivery, and relative
+// time lock parameters.
+type ChannelConfig struct {
+	// ChannelConstraints is the set of constraints that must be upheld for
+	// the duration of the channel for the owner of this channel
+	// configuration. Constraints govern a number of flow control related
+	// parameters, also including the smallest HTLC that will be accepted
+	// by a participant.
+	ChannelConstraints
+
+	// MultiSigKey is the key to be used within the 2-of-2 output script
+	// for the owner of this channel config.
+	MultiSigKey keychain.KeyDescriptor
+
+	// RevocationBasePoint is the base public key to be used when deriving
+	// revocation keys for the remote node's commitment transaction. This
+	// will be combined along with a per commitment secret to derive a
+	// unique revocation key for each state.
+	RevocationBasePoint keychain.KeyDescriptor
+
+	// PaymentBasePoint is the base public key to be used when deriving
+	// the key used within the non-delayed pay-to-self output on the
+	// commitment transaction for a node. This will be combined with a
+	// tweak derived from the per-commitment point to ensure unique keys
+	// for each commitment transaction.
+	PaymentBasePoint keychain.KeyDescriptor
+
+	// DelayBasePoint is the base public key to be used when deriving the
+	// key used within the delayed pay-to-self output on the commitment
+	// transaction for a node. This will be combined with a tweak derived
+	// from the per-commitment point to ensure unique keys for each
+	// commitment transaction.
+	DelayBasePoint keychain.KeyDescriptor
+
+	// HtlcBasePoint is the base public key to be used when deriving the
+	// local HTLC key. The derived key (combined with the tweak derived
+	// from the per-commitment point) is used within the "to self" clause
+	// within any HTLC output scripts.
+	HtlcBasePoint keychain.KeyDescriptor
+}
+
+// ChannelCloseSummary contains the final state of a channel at the point it
+// was closed. Once a channel is closed, all the information pertaining to that
+// channel within the openChannelBucket is deleted, and a compact summary is
+// put in place instead.
+type ChannelCloseSummary struct {
+	// ChanPoint is the outpoint for this channel's funding transaction,
+	// and is used as a unique identifier for the channel.
+	ChanPoint wire.OutPoint
+
+	// ShortChanID encodes the exact location in the chain in which the
+	// channel was initially confirmed. This includes: the block height,
+	// transaction index, and the output within the target transaction.
+	ShortChanID lnwire.ShortChannelID
+
+	// ChainHash is the hash of the genesis block that this channel resides
+	// within.
+	ChainHash chainhash.Hash
+
+	// ClosingTXID is the txid of the transaction which ultimately closed
+	// this channel.
+	ClosingTXID chainhash.Hash
+
+	// RemotePub is the public key of the remote peer that we formerly had
+	// a channel with.
+	RemotePub *btcec.PublicKey
+
+	// Capacity was the total capacity of the channel.
+	Capacity btcutil.Amount
+
+	// CloseHeight is the height at which the funding transaction was
+	// spent.
+	CloseHeight uint32
+
+	// SettledBalance is our total balance settled balance at the time of
+	// channel closure. This _does not_ include the sum of any outputs that
+	// have been time-locked as a result of the unilateral channel closure.
+	SettledBalance btcutil.Amount
+
+	// TimeLockedBalance is the sum of all the time-locked outputs at the
+	// time of channel closure. If we triggered the force closure of this
+	// channel, then this value will be non-zero if our settled output is
+	// above the dust limit. If we were on the receiving side of a channel
+	// force closure, then this value will be non-zero if we had any
+	// outstanding outgoing HTLC's at the time of channel closure.
+	TimeLockedBalance btcutil.Amount
+
+	// CloseType details exactly _how_ the channel was closed. Five closure
+	// types are possible: cooperative, local force, remote force, breach
+	// and funding canceled.
+	CloseType ClosureType
+
+	// IsPending indicates whether this channel is in the 'pending close'
+	// state, which means the channel closing transaction has been
+	// confirmed, but not yet been fully resolved. In the case of a channel
+	// that has been cooperatively closed, it will go straight into the
+	// fully resolved state as soon as the closing transaction has been
+	// confirmed. However, for channels that have been force closed, they'll
+	// stay marked as "pending" until _all_ the pending funds have been
+	// swept.
+	IsPending bool
+
+	// RemoteCurrentRevocation is the current revocation for their
+	// commitment transaction. However, since this is the derived public key,
+	// we don't yet have the private key so we aren't yet able to verify
+	// that it's actually in the hash chain.
+	RemoteCurrentRevocation *btcec.PublicKey
+
+	// RemoteNextRevocation is the revocation key to be used for the *next*
+	// commitment transaction we create for the local node. Within the
+	// specification, this value is referred to as the
+	// per-commitment-point.
+	RemoteNextRevocation *btcec.PublicKey
+
+	// LocalChanCfg is the channel configuration for the local node.
+	LocalChanConfig ChannelConfig
+
+	// LastChanSyncMsg is the ChannelReestablish message for this channel
+	// for the state at the point where it was closed.
+	LastChanSyncMsg *lnwire.ChannelReestablish
+}

--- a/channeldb/migration19/legacy_decoding.go
+++ b/channeldb/migration19/legacy_decoding.go
@@ -222,7 +222,7 @@ func deserializeNetworkResultLegacy(r io.Reader) (*networkResult, error) {
 
 	n := &networkResult{}
 
-	n.msg, err = lnwire.ReadMessage(r, 0)
+	n.msg, err = lnwire.ReadMessage(r, lnwire.ProtocolVersionLegacy)
 	if err != nil {
 		return nil, err
 	}
@@ -237,7 +237,8 @@ func deserializeNetworkResultLegacy(r io.Reader) (*networkResult, error) {
 }
 
 func serializeNetworkResultLegacy(w io.Writer, n *networkResult) error {
-	if _, err := lnwire.WriteMessage(w, n.msg, 0); err != nil {
+	_, err := lnwire.WriteMessage(w, n.msg, lnwire.ProtocolVersionLegacy)
+	if err != nil {
 		return err
 	}
 
@@ -320,7 +321,7 @@ func deserializeCloseChannelSummaryLegacy(r io.Reader) (*ChannelCloseSummary, er
 	if hasChanSyncMsg {
 		// We must pass in reference to a lnwire.Message for the codec
 		// to support it.
-		msg, err := lnwire.ReadMessage(r, 0)
+		msg, err := lnwire.ReadMessage(r, lnwire.ProtocolVersionLegacy)
 		if err != nil {
 			return nil, err
 		}
@@ -396,7 +397,9 @@ func serializeChannelCloseSummaryLegacy(w io.Writer, cs *ChannelCloseSummary) er
 
 	// Write the channel sync message, if present.
 	if cs.LastChanSyncMsg != nil {
-		_, err = lnwire.WriteMessage(w, cs.LastChanSyncMsg, 0)
+		_, err = lnwire.WriteMessage(
+			w, cs.LastChanSyncMsg, lnwire.ProtocolVersionLegacy,
+		)
 		if err != nil {
 			return err
 		}

--- a/channeldb/migration19/legacy_decoding.go
+++ b/channeldb/migration19/legacy_decoding.go
@@ -1,0 +1,406 @@
+package migration19
+
+import (
+	"encoding/binary"
+	"errors"
+	"io"
+
+	"github.com/lightningnetwork/lnd/lnwire"
+)
+
+func deserializeHtlcsLegacy(r io.Reader) ([]HTLC, error) {
+	var numHtlcs uint16
+	if err := ReadElement(r, &numHtlcs); err != nil {
+		return nil, err
+	}
+
+	var htlcs []HTLC
+	if numHtlcs == 0 {
+		return htlcs, nil
+	}
+
+	htlcs = make([]HTLC, numHtlcs)
+	for i := uint16(0); i < numHtlcs; i++ {
+		if err := ReadElements(r,
+			&htlcs[i].Signature, &htlcs[i].RHash, &htlcs[i].Amt,
+			&htlcs[i].RefundTimeout, &htlcs[i].OutputIndex,
+			&htlcs[i].Incoming, &htlcs[i].OnionBlob,
+			&htlcs[i].HtlcIndex, &htlcs[i].LogIndex,
+		); err != nil {
+			return htlcs, err
+		}
+	}
+
+	return htlcs, nil
+}
+
+func deserializeLogUpdatesLegacy(r io.Reader) ([]LogUpdate, error) {
+	var numUpdates uint16
+	if err := binary.Read(r, byteOrder, &numUpdates); err != nil {
+		return nil, err
+	}
+
+	logUpdates := make([]LogUpdate, numUpdates)
+	for i := 0; i < int(numUpdates); i++ {
+		err := ReadElements(r,
+			&logUpdates[i].LogIndex, &logUpdates[i].UpdateMsg,
+		)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return logUpdates, nil
+}
+
+func deserializeChanCommitLegacy(r io.Reader) (ChannelCommitment, error) {
+	var c ChannelCommitment
+
+	err := ReadElements(r,
+		&c.CommitHeight, &c.LocalLogIndex, &c.LocalHtlcIndex, &c.RemoteLogIndex,
+		&c.RemoteHtlcIndex, &c.LocalBalance, &c.RemoteBalance,
+		&c.CommitFee, &c.FeePerKw, &c.CommitTx, &c.CommitSig,
+	)
+	if err != nil {
+		return c, err
+	}
+
+	c.Htlcs, err = deserializeHtlcsLegacy(r)
+	if err != nil {
+		return c, err
+	}
+
+	return c, nil
+}
+
+func deserializeCommitDiffLegacy(r io.Reader) (*CommitDiff, error) {
+	var (
+		d   CommitDiff
+		err error
+	)
+
+	d.Commitment, err = deserializeChanCommitLegacy(r)
+	if err != nil {
+		return nil, err
+	}
+
+	d.CommitSig = &lnwire.CommitSig{}
+	if err := d.CommitSig.Decode(r, 0); err != nil {
+		return nil, err
+	}
+
+	d.LogUpdates, err = deserializeLogUpdatesLegacy(r)
+	if err != nil {
+		return nil, err
+	}
+
+	var numOpenRefs uint16
+	if err := binary.Read(r, byteOrder, &numOpenRefs); err != nil {
+		return nil, err
+	}
+
+	d.OpenedCircuitKeys = make([]CircuitKey, numOpenRefs)
+	for i := 0; i < int(numOpenRefs); i++ {
+		err := ReadElements(r,
+			&d.OpenedCircuitKeys[i].ChanID,
+			&d.OpenedCircuitKeys[i].HtlcID)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	var numClosedRefs uint16
+	if err := binary.Read(r, byteOrder, &numClosedRefs); err != nil {
+		return nil, err
+	}
+
+	d.ClosedCircuitKeys = make([]CircuitKey, numClosedRefs)
+	for i := 0; i < int(numClosedRefs); i++ {
+		err := ReadElements(r,
+			&d.ClosedCircuitKeys[i].ChanID,
+			&d.ClosedCircuitKeys[i].HtlcID)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return &d, nil
+}
+
+func serializeHtlcsLegacy(b io.Writer, htlcs ...HTLC) error {
+	numHtlcs := uint16(len(htlcs))
+	if err := WriteElement(b, numHtlcs); err != nil {
+		return err
+	}
+
+	for _, htlc := range htlcs {
+		if err := WriteElements(b,
+			htlc.Signature, htlc.RHash, htlc.Amt, htlc.RefundTimeout,
+			htlc.OutputIndex, htlc.Incoming, htlc.OnionBlob,
+			htlc.HtlcIndex, htlc.LogIndex,
+		); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func serializeChanCommitLegacy(w io.Writer, c *ChannelCommitment) error {
+	if err := WriteElements(w,
+		c.CommitHeight, c.LocalLogIndex, c.LocalHtlcIndex,
+		c.RemoteLogIndex, c.RemoteHtlcIndex, c.LocalBalance,
+		c.RemoteBalance, c.CommitFee, c.FeePerKw, c.CommitTx,
+		c.CommitSig,
+	); err != nil {
+		return err
+	}
+
+	return serializeHtlcsLegacy(w, c.Htlcs...)
+}
+
+func serializeLogUpdatesLegacy(w io.Writer, logUpdates []LogUpdate) error {
+	numUpdates := uint16(len(logUpdates))
+	if err := binary.Write(w, byteOrder, numUpdates); err != nil {
+		return err
+	}
+
+	for _, diff := range logUpdates {
+		err := WriteElements(w, diff.LogIndex, diff.UpdateMsg)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func serializeCommitDiffLegacy(w io.Writer, diff *CommitDiff) error {
+	if err := serializeChanCommitLegacy(w, &diff.Commitment); err != nil {
+		return err
+	}
+
+	if err := diff.CommitSig.Encode(w, 0); err != nil {
+		return err
+	}
+
+	if err := serializeLogUpdatesLegacy(w, diff.LogUpdates); err != nil {
+		return err
+	}
+
+	numOpenRefs := uint16(len(diff.OpenedCircuitKeys))
+	if err := binary.Write(w, byteOrder, numOpenRefs); err != nil {
+		return err
+	}
+
+	for _, openRef := range diff.OpenedCircuitKeys {
+		err := WriteElements(w, openRef.ChanID, openRef.HtlcID)
+		if err != nil {
+			return err
+		}
+	}
+
+	numClosedRefs := uint16(len(diff.ClosedCircuitKeys))
+	if err := binary.Write(w, byteOrder, numClosedRefs); err != nil {
+		return err
+	}
+
+	for _, closedRef := range diff.ClosedCircuitKeys {
+		err := WriteElements(w, closedRef.ChanID, closedRef.HtlcID)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func deserializeNetworkResultLegacy(r io.Reader) (*networkResult, error) {
+	var (
+		err error
+	)
+
+	n := &networkResult{}
+
+	n.msg, err = lnwire.ReadMessage(r, 0)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := ReadElements(r,
+		&n.unencrypted, &n.isResolution,
+	); err != nil {
+		return nil, err
+	}
+
+	return n, nil
+}
+
+func serializeNetworkResultLegacy(w io.Writer, n *networkResult) error {
+	if _, err := lnwire.WriteMessage(w, n.msg, 0); err != nil {
+		return err
+	}
+
+	return WriteElements(w, n.unencrypted, n.isResolution)
+}
+
+func readChanConfigLegacy(b io.Reader, c *ChannelConfig) error { // nolint: dupl
+	return ReadElements(b,
+		&c.DustLimit, &c.MaxPendingAmount, &c.ChanReserve,
+		&c.MinHTLC, &c.MaxAcceptedHtlcs, &c.CsvDelay,
+		&c.MultiSigKey, &c.RevocationBasePoint,
+		&c.PaymentBasePoint, &c.DelayBasePoint,
+		&c.HtlcBasePoint,
+	)
+}
+
+func deserializeCloseChannelSummaryLegacy(r io.Reader) (*ChannelCloseSummary, error) { // nolint: dupl
+
+	c := &ChannelCloseSummary{}
+
+	err := ReadElements(r,
+		&c.ChanPoint, &c.ShortChanID, &c.ChainHash, &c.ClosingTXID,
+		&c.CloseHeight, &c.RemotePub, &c.Capacity, &c.SettledBalance,
+		&c.TimeLockedBalance, &c.CloseType, &c.IsPending,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	// We'll now check to see if the channel close summary was encoded with
+	// any of the additional optional fields.
+	var hasNewFields bool
+	err = ReadElements(r, &hasNewFields)
+	if err != nil {
+		return nil, err
+	}
+
+	// If fields are not present, we can return.
+	if !hasNewFields {
+		return c, nil
+	}
+
+	// Otherwise read the new fields.
+	if err := ReadElements(r, &c.RemoteCurrentRevocation); err != nil {
+		return nil, err
+	}
+
+	if err := readChanConfigLegacy(r, &c.LocalChanConfig); err != nil {
+		return nil, err
+	}
+
+	// Finally, we'll attempt to read the next unrevoked commitment point
+	// for the remote party. If we closed the channel before receiving a
+	// funding locked message then this might not be present. A boolean
+	// indicating whether the field is present will come first.
+	var hasRemoteNextRevocation bool
+	err = ReadElements(r, &hasRemoteNextRevocation)
+	if err != nil {
+		return nil, err
+	}
+
+	// If this field was written, read it.
+	if hasRemoteNextRevocation {
+		err = ReadElements(r, &c.RemoteNextRevocation)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	// Check if we have a channel sync message to read.
+	var hasChanSyncMsg bool
+	err = ReadElements(r, &hasChanSyncMsg)
+	if err == io.EOF {
+		return c, nil
+	} else if err != nil {
+		return nil, err
+	}
+
+	// If a chan sync message is present, read it.
+	if hasChanSyncMsg {
+		// We must pass in reference to a lnwire.Message for the codec
+		// to support it.
+		msg, err := lnwire.ReadMessage(r, 0)
+		if err != nil {
+			return nil, err
+		}
+
+		chanSync, ok := msg.(*lnwire.ChannelReestablish)
+		if !ok {
+			return nil, errors.New("unable cast db Message to " +
+				"ChannelReestablish")
+		}
+		c.LastChanSyncMsg = chanSync
+	}
+
+	return c, nil
+}
+
+func writeChanConfigLegacy(b io.Writer, c *ChannelConfig) error { // nolint: dupl
+	return WriteElements(b,
+		c.DustLimit, c.MaxPendingAmount, c.ChanReserve, c.MinHTLC,
+		c.MaxAcceptedHtlcs, c.CsvDelay, c.MultiSigKey,
+		c.RevocationBasePoint, c.PaymentBasePoint, c.DelayBasePoint,
+		c.HtlcBasePoint,
+	)
+}
+
+func serializeChannelCloseSummaryLegacy(w io.Writer, cs *ChannelCloseSummary) error {
+	err := WriteElements(w,
+		cs.ChanPoint, cs.ShortChanID, cs.ChainHash, cs.ClosingTXID,
+		cs.CloseHeight, cs.RemotePub, cs.Capacity, cs.SettledBalance,
+		cs.TimeLockedBalance, cs.CloseType, cs.IsPending,
+	)
+	if err != nil {
+		return err
+	}
+
+	// If this is a close channel summary created before the addition of
+	// the new fields, then we can exit here.
+	if cs.RemoteCurrentRevocation == nil {
+		return WriteElements(w, false)
+	}
+
+	// If fields are present, write boolean to indicate this, and continue.
+	if err := WriteElements(w, true); err != nil {
+		return err
+	}
+
+	if err := WriteElements(w, cs.RemoteCurrentRevocation); err != nil {
+		return err
+	}
+
+	if err := writeChanConfigLegacy(w, &cs.LocalChanConfig); err != nil {
+		return err
+	}
+
+	// The RemoteNextRevocation field is optional, as it's possible for a
+	// channel to be closed before we learn of the next unrevoked
+	// revocation point for the remote party. Write a boolen indicating
+	// whether this field is present or not.
+	if err := WriteElements(w, cs.RemoteNextRevocation != nil); err != nil {
+		return err
+	}
+
+	// Write the field, if present.
+	if cs.RemoteNextRevocation != nil {
+		if err = WriteElements(w, cs.RemoteNextRevocation); err != nil {
+			return err
+		}
+	}
+
+	// Write whether the channel sync message is present.
+	if err := WriteElements(w, cs.LastChanSyncMsg != nil); err != nil {
+		return err
+	}
+
+	// Write the channel sync message, if present.
+	if cs.LastChanSyncMsg != nil {
+		_, err = lnwire.WriteMessage(w, cs.LastChanSyncMsg, 0)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/channeldb/migration19/log.go
+++ b/channeldb/migration19/log.go
@@ -1,0 +1,14 @@
+package migration19
+
+import (
+	"github.com/btcsuite/btclog"
+)
+
+// log is a logger that is initialized as disabled.  This means the package will
+// not perform any logging by default until a logger is set.
+var log = btclog.Disabled
+
+// UseLogger uses a specified Logger to output package logging info.
+func UseLogger(logger btclog.Logger) {
+	log = logger
+}

--- a/channeldb/migration19/migration.go
+++ b/channeldb/migration19/migration.go
@@ -1,0 +1,242 @@
+package migration19
+
+import (
+	"bytes"
+	"fmt"
+
+	"github.com/lightningnetwork/lnd/channeldb/kvdb"
+)
+
+// MigrateDatabaseWireMessages performs a migration in all areas that we
+// currently store wire messages without length prefixes. This includes the
+// CommitDiff struct, ChannelCloseSummary, LogUpdates, and also the
+// networkResult struct as well.
+func MigrateDatabaseWireMessages(tx kvdb.RwTx) error {
+	openChanBucket := tx.ReadWriteBucket(openChannelBucket)
+	if openChanBucket == nil {
+		return nil
+	}
+
+	// The migration will proceed in three phases: we'll need to update any
+	// pending commit diffs, then any unsigned acked updates for all open
+	// channels, then finally we'll need to update all the current
+	// stored network results for payments in the switch.
+	//
+	// In this phase, we'll migrate the open channel data.
+	type channelPath struct {
+		nodePub   []byte
+		chainHash []byte
+		chanPoint []byte
+	}
+	var channelPaths []channelPath
+	err := openChanBucket.ForEach(func(nodePub, v []byte) error {
+		// Ensure that this is a key the same size as a pubkey, and
+		// also that it leads directly to a bucket.
+		if len(nodePub) != 33 || v != nil {
+			return nil
+		}
+
+		nodeChanBucket := openChanBucket.NestedReadBucket(nodePub)
+		if nodeChanBucket == nil {
+			return fmt.Errorf("no bucket for node %x", nodePub)
+		}
+
+		// The next layer down is all the chains that this node
+		// has channels on with us.
+		return nodeChanBucket.ForEach(func(chainHash, v []byte) error {
+			// If there's a value, it's not a bucket so
+			// ignore it.
+			if v != nil {
+				return nil
+			}
+
+			chainBucket := nodeChanBucket.NestedReadBucket(
+				chainHash,
+			)
+			if chainBucket == nil {
+				return fmt.Errorf("unable to read "+
+					"bucket for chain=%x", chainHash)
+			}
+
+			return chainBucket.ForEach(func(chanPoint, v []byte) error {
+				// If there's a value, it's not a bucket so
+				// ignore it.
+				if v != nil {
+					return nil
+				}
+
+				channelPaths = append(channelPaths, channelPath{
+					nodePub:   nodePub,
+					chainHash: chainHash,
+					chanPoint: chanPoint,
+				})
+
+				return nil
+			})
+		})
+	})
+	if err != nil {
+		return err
+	}
+
+	// Now that we have all the paths of the channel we need to migrate,
+	// we'll update all the state in a distinct step to avoid weird
+	// behavior from  modifying buckets in a ForEach statement.
+	for _, channelPath := range channelPaths {
+		// First, we'll extract it from the node's chain bucket.
+		nodeChanBucket := openChanBucket.NestedReadWriteBucket(
+			channelPath.nodePub,
+		)
+		chainBucket := nodeChanBucket.NestedReadWriteBucket(
+			channelPath.chainHash,
+		)
+		chanBucket := chainBucket.NestedReadWriteBucket(
+			channelPath.chanPoint,
+		)
+
+		// At this point, we have the channel bucket now, so we'll
+		// check to see if this channel has a pending commitment or
+		// not.
+		commitDiffBytes := chanBucket.Get(commitDiffKey)
+		if commitDiffBytes != nil {
+			// Now that we have the commit diff in the _old_
+			// encoding, we'll write it back to disk using the new
+			// encoding which has a length prefix in front of the
+			// CommitSig.
+			commitDiff, err := deserializeCommitDiffLegacy(
+				bytes.NewReader(commitDiffBytes),
+			)
+			if err != nil {
+				return err
+			}
+
+			var b bytes.Buffer
+			err = serializeCommitDiff(&b, commitDiff)
+			if err != nil {
+				return err
+			}
+
+			err = chanBucket.Put(commitDiffKey, b.Bytes())
+			if err != nil {
+				return err
+			}
+		}
+
+		// With the commit diff migrated, we'll now check to see if
+		// there're any un-acked updates we need to migrate as well.
+		updateBytes := chanBucket.Get(unsignedAckedUpdatesKey)
+		if updateBytes == nil {
+			return nil
+		}
+
+		// We have un-acked updates we need to migrate so we'll decode
+		// then re-encode them here using the new format.
+		legacyUnackedUpdates, err := deserializeLogUpdatesLegacy(
+			bytes.NewReader(updateBytes),
+		)
+		if err != nil {
+			return err
+		}
+
+		var ub bytes.Buffer
+		err = serializeLogUpdates(&ub, legacyUnackedUpdates)
+		if err != nil {
+			return err
+		}
+
+		err = chanBucket.Put(unsignedAckedUpdatesKey, ub.Bytes())
+		if err != nil {
+			return err
+		}
+	}
+
+	// Next, we'll update all the present close channel summaries as well.
+	type closedChan struct {
+		chanKey      []byte
+		summaryBytes []byte
+	}
+	var closedChans []closedChan
+
+	closedChanBucket := tx.ReadWriteBucket(closedChannelBucket)
+	if closedChannelBucket == nil {
+		return fmt.Errorf("no closed channels found")
+	}
+	err = closedChanBucket.ForEach(func(k, v []byte) error {
+		closedChans = append(closedChans, closedChan{
+			chanKey:      k,
+			summaryBytes: v,
+		})
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+
+	for _, closedChan := range closedChans {
+		oldSummary, err := deserializeCloseChannelSummaryLegacy(
+			bytes.NewReader(closedChan.summaryBytes),
+		)
+		if err != nil {
+			return err
+		}
+
+		var newSummaryBytes bytes.Buffer
+		err = serializeChannelCloseSummary(
+			&newSummaryBytes, oldSummary,
+		)
+		if err != nil {
+			return err
+		}
+
+		err = closedChanBucket.Put(
+			closedChan.chanKey, newSummaryBytes.Bytes(),
+		)
+		if err != nil {
+			return err
+		}
+	}
+
+	// Finally, we'll update the pending network results as well.
+	networkResults := tx.ReadWriteBucket(networkResultStoreBucketKey)
+	if networkResults == nil {
+		return nil
+	}
+
+	// Similar to the prior migrations, we'll do this one in two phases:
+	// we'll first grab all the keys we need to migrate in one loop, then
+	// update them all in another loop.
+	var netResultsToMigrate [][2][]byte
+	err = networkResults.ForEach(func(k, v []byte) error {
+		netResultsToMigrate = append(netResultsToMigrate, [2][]byte{
+			k, v,
+		})
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+
+	for _, netResult := range netResultsToMigrate {
+		resKey := netResult[0]
+		resBytes := netResult[1]
+		oldResult, err := deserializeNetworkResultLegacy(
+			bytes.NewReader(resBytes),
+		)
+		if err != nil {
+			return err
+		}
+
+		var newResultBuf bytes.Buffer
+		err = serializeNetworkResult(&newResultBuf, oldResult)
+		if err != nil {
+			return err
+		}
+
+		err = networkResults.Put(resKey, newResultBuf.Bytes())
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/channeldb/migration19/migration_test.go
+++ b/channeldb/migration19/migration_test.go
@@ -1,0 +1,358 @@
+package migration19
+
+import (
+	"bytes"
+	"fmt"
+	"math/big"
+	"reflect"
+	"testing"
+
+	"github.com/btcsuite/btcd/btcec"
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"github.com/btcsuite/btcd/wire"
+	"github.com/davecgh/go-spew/spew"
+	"github.com/lightningnetwork/lnd/channeldb/kvdb"
+	"github.com/lightningnetwork/lnd/channeldb/migtest"
+	"github.com/lightningnetwork/lnd/lnwire"
+)
+
+var (
+	key = [chainhash.HashSize]byte{
+		0x81, 0xb6, 0x37, 0xd8, 0xfc, 0xd2, 0xc6, 0xda,
+		0x68, 0x59, 0xe6, 0x96, 0x31, 0x13, 0xa1, 0x17,
+		0xd, 0xe7, 0x93, 0xe4, 0xb7, 0x25, 0xb8, 0x4d,
+		0x1e, 0xb, 0x4c, 0xf9, 0x9e, 0xc5, 0x8c, 0xe9,
+	}
+
+	_, pubKey = btcec.PrivKeyFromBytes(btcec.S256(), key[:])
+
+	wireSig, _ = lnwire.NewSigFromSignature(testSig)
+
+	testSig = &btcec.Signature{
+		R: new(big.Int),
+		S: new(big.Int),
+	}
+	_, _ = testSig.R.SetString("63724406601629180062774974542967536251589935445068131219452686511677818569431", 10)
+	_, _ = testSig.S.SetString("18801056069249825825291287104931333862866033135609736119018462340006816851118", 10)
+
+	testTx = &wire.MsgTx{
+		Version: 1,
+		TxIn: []*wire.TxIn{
+			{
+				PreviousOutPoint: wire.OutPoint{
+					Hash:  chainhash.Hash{},
+					Index: 0xffffffff,
+				},
+				SignatureScript: []byte{0x04, 0x31, 0xdc, 0x00, 0x1b, 0x01, 0x62},
+				Sequence:        0xffffffff,
+			},
+		},
+		TxOut: []*wire.TxOut{
+			{
+				Value: 5000000000,
+				PkScript: []byte{
+					0x41, // OP_DATA_65
+					0x04, 0xd6, 0x4b, 0xdf, 0xd0, 0x9e, 0xb1, 0xc5,
+					0xfe, 0x29, 0x5a, 0xbd, 0xeb, 0x1d, 0xca, 0x42,
+					0x81, 0xbe, 0x98, 0x8e, 0x2d, 0xa0, 0xb6, 0xc1,
+					0xc6, 0xa5, 0x9d, 0xc2, 0x26, 0xc2, 0x86, 0x24,
+					0xe1, 0x81, 0x75, 0xe8, 0x51, 0xc9, 0x6b, 0x97,
+					0x3d, 0x81, 0xb0, 0x1c, 0xc3, 0x1f, 0x04, 0x78,
+					0x34, 0xbc, 0x06, 0xd6, 0xd6, 0xed, 0xf6, 0x20,
+					0xd1, 0x84, 0x24, 0x1a, 0x6a, 0xed, 0x8b, 0x63,
+					0xa6, // 65-byte signature
+					0xac, // OP_CHECKSIG
+				},
+			},
+		},
+		LockTime: 5,
+	}
+
+	testCommitDiff = &CommitDiff{
+		Commitment: ChannelCommitment{
+			CommitTx:  testTx,
+			CommitSig: make([]byte, 0),
+		},
+		CommitSig: &lnwire.CommitSig{
+			ChanID:    lnwire.ChannelID(key),
+			CommitSig: wireSig,
+			HtlcSigs: []lnwire.Sig{
+				wireSig,
+				wireSig,
+			},
+		},
+		LogUpdates: []LogUpdate{
+			{
+				LogIndex: 1,
+				UpdateMsg: &lnwire.UpdateAddHTLC{
+					ID:     1,
+					Amount: lnwire.NewMSatFromSatoshis(100),
+					Expiry: 25,
+				},
+			},
+			{
+				LogIndex: 2,
+				UpdateMsg: &lnwire.UpdateAddHTLC{
+					ID:     2,
+					Amount: lnwire.NewMSatFromSatoshis(200),
+					Expiry: 50,
+				},
+			},
+		},
+		OpenedCircuitKeys: []CircuitKey{},
+		ClosedCircuitKeys: []CircuitKey{},
+	}
+
+	testNetworkResult = &networkResult{
+		msg:          testCommitDiff.CommitSig,
+		unencrypted:  true,
+		isResolution: true,
+	}
+
+	testChanCloseSummary = &ChannelCloseSummary{
+		RemotePub:               pubKey,
+		Capacity:                9,
+		RemoteCurrentRevocation: pubKey,
+		RemoteNextRevocation:    pubKey,
+		LastChanSyncMsg: &lnwire.ChannelReestablish{
+			LocalUnrevokedCommitPoint: pubKey,
+		},
+	}
+
+	netResultKey = []byte{3}
+)
+
+// TestMigrateDatabaseWireMessages tests that we're able to properly migrate
+// all the wire messages in the database which are written without a length
+// prefix in front of them. At the time this test was written we need to
+// migrate three areas: open channel commit diffs, open channel unacked updates,
+// and network results in the switch.
+func TestMigrateDatabaseWireMessages(t *testing.T) {
+
+	var pub [33]byte
+	copy(pub[:], key[:])
+
+	migtest.ApplyMigration(
+		t,
+		func(tx kvdb.RwTx) error {
+			t.Helper()
+
+			// First, we'll insert a new fake channel (well just
+			// the commitment diff) at the expected location
+			// on-disk.
+			openChanBucket, err := tx.CreateTopLevelBucket(
+				openChannelBucket,
+			)
+			if err != nil {
+				return err
+			}
+			nodeBucket, err := openChanBucket.CreateBucket(pub[:])
+			if err != nil {
+				return err
+			}
+			chainBucket, err := nodeBucket.CreateBucket(key[:])
+			if err != nil {
+				return err
+			}
+			chanBucket, err := chainBucket.CreateBucket(key[:])
+			if err != nil {
+				return err
+			}
+
+			var b bytes.Buffer
+			err = serializeCommitDiffLegacy(&b, testCommitDiff)
+			if err != nil {
+				return err
+			}
+
+			err = chanBucket.Put(commitDiffKey, b.Bytes())
+			if err != nil {
+				return err
+			}
+
+			var logUpdateBuf bytes.Buffer
+			err = serializeLogUpdatesLegacy(
+				&logUpdateBuf, testCommitDiff.LogUpdates,
+			)
+			if err != nil {
+				return err
+			}
+
+			// We'll re-use the same log updates to insert as a set
+			// of un-acked pending log updateas we well.
+			err = chanBucket.Put(
+				unsignedAckedUpdatesKey, logUpdateBuf.Bytes(),
+			)
+			if err != nil {
+				return err
+			}
+
+			// Next, we'll insert a sample closed channel summary
+			// for the 2nd part of our migration.
+			closedChanBucket, err := tx.CreateTopLevelBucket(
+				closedChannelBucket,
+			)
+			if err != nil {
+				return err
+			}
+
+			var summaryBuf bytes.Buffer
+			err = serializeChannelCloseSummaryLegacy(
+				&summaryBuf, testChanCloseSummary,
+			)
+			if err != nil {
+				return err
+			}
+
+			err = closedChanBucket.Put(key[:], summaryBuf.Bytes())
+			if err != nil {
+				return err
+			}
+
+			// Finally, we need to insert a sample network result
+			// as well for the final component of our migration.
+			var netResBuf bytes.Buffer
+			err = serializeNetworkResultLegacy(
+				&netResBuf, testNetworkResult,
+			)
+			if err != nil {
+				return err
+			}
+
+			networkResults, err := tx.CreateTopLevelBucket(
+				networkResultStoreBucketKey,
+			)
+			if err != nil {
+				return err
+			}
+
+			return networkResults.Put(
+				netResultKey, netResBuf.Bytes(),
+			)
+		},
+		func(tx kvdb.RwTx) error {
+			t.Helper()
+
+			// We'll now read the commit diff from disk using the
+			// _new_ decoding method. This should match the commit
+			// diff we inserted in the pre-migration step.
+			openChanBucket := tx.ReadWriteBucket(openChannelBucket)
+			nodeBucket := openChanBucket.NestedReadWriteBucket(
+				pub[:],
+			)
+			chainBucket := nodeBucket.NestedReadWriteBucket(key[:])
+			chanBucket := chainBucket.NestedReadWriteBucket(key[:])
+
+			commitDiffBytes := chanBucket.Get(commitDiffKey)
+			if commitDiffBytes == nil {
+				return fmt.Errorf("no commit diff found")
+			}
+
+			newCommitDiff, err := deserializeCommitDiff(
+				bytes.NewReader(commitDiffBytes),
+			)
+			if err != nil {
+				return fmt.Errorf("unable to decode commit "+
+					"diff: %v", err)
+			}
+
+			if !reflect.DeepEqual(newCommitDiff, testCommitDiff) {
+				return fmt.Errorf("diff mismatch: expected "+
+					"%v, got %v", spew.Sdump(testCommitDiff),
+					spew.Sdump(newCommitDiff))
+			}
+
+			// Next, we'll ensure that the un-acked updates match
+			// up as well.
+			updateBytes := chanBucket.Get(unsignedAckedUpdatesKey)
+			if updateBytes == nil {
+				return fmt.Errorf("no update bytes found")
+			}
+
+			newUpdates, err := deserializeLogUpdates(
+				bytes.NewReader(updateBytes),
+			)
+			if err != nil {
+				return err
+			}
+
+			if !reflect.DeepEqual(
+				newUpdates, testCommitDiff.LogUpdates,
+			) {
+				return fmt.Errorf("updates mismatch: expected "+
+					"%v, got %v",
+					spew.Sdump(testCommitDiff.LogUpdates),
+					spew.Sdump(newUpdates))
+			}
+
+			// Next, we'll ensure that the inserted close channel
+			// summary bytes also mach up with what we inserted in
+			// the prior step.
+			closedChanBucket := tx.ReadWriteBucket(
+				closedChannelBucket,
+			)
+			if closedChannelBucket == nil {
+				return fmt.Errorf("no closed channels found")
+			}
+
+			chanSummaryBytes := closedChanBucket.Get(key[:])
+			newChanCloseSummary, err := deserializeCloseChannelSummary(
+				bytes.NewReader(chanSummaryBytes),
+			)
+			if err != nil {
+				return err
+			}
+
+			testChanCloseSummary.RemotePub.Curve = nil
+			testChanCloseSummary.RemoteCurrentRevocation.Curve = nil
+			testChanCloseSummary.RemoteNextRevocation.Curve = nil
+			testChanCloseSummary.LastChanSyncMsg.LocalUnrevokedCommitPoint.Curve = nil
+
+			newChanCloseSummary.RemotePub.Curve = nil
+			newChanCloseSummary.RemoteCurrentRevocation.Curve = nil
+			newChanCloseSummary.RemoteNextRevocation.Curve = nil
+			newChanCloseSummary.LastChanSyncMsg.LocalUnrevokedCommitPoint.Curve = nil
+
+			if !reflect.DeepEqual(
+				newChanCloseSummary, testChanCloseSummary,
+			) {
+				return fmt.Errorf("summary mismatch: expected "+
+					"%v, got %v",
+					spew.Sdump(testChanCloseSummary),
+					spew.Sdump(newChanCloseSummary))
+			}
+
+			// Finally, we'll check the network results to ensure
+			// that was migrated properly as well.
+			networkResults := tx.ReadBucket(
+				networkResultStoreBucketKey,
+			)
+			if networkResults == nil {
+				return fmt.Errorf("no net results found")
+			}
+
+			netResBytes := networkResults.Get(netResultKey)
+			if netResBytes == nil {
+				return fmt.Errorf("no network res found")
+			}
+
+			newNetRes, err := deserializeNetworkResult(
+				bytes.NewReader(netResBytes),
+			)
+			if err != nil {
+				return err
+			}
+
+			if !reflect.DeepEqual(newNetRes, testNetworkResult) {
+				return fmt.Errorf("res mismatch: expected "+
+					"%v, got %v",
+					spew.Sdump(testNetworkResult),
+					spew.Sdump(newNetRes))
+			}
+
+			return nil
+		},
+		MigrateDatabaseWireMessages,
+		false,
+	)
+}

--- a/channeldb/migration19/new_encoding.go
+++ b/channeldb/migration19/new_encoding.go
@@ -1,0 +1,431 @@
+package migration19
+
+import (
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"io"
+
+	"github.com/lightningnetwork/lnd/lnwire"
+)
+
+var (
+	// openChanBucket stores all the currently open channels. This bucket
+	// has a second, nested bucket which is keyed by a node's ID. Within
+	// that node ID bucket, all attributes required to track, update, and
+	// close a channel are stored.
+	//
+	// openChan -> nodeID -> chanPoint
+	//
+	// TODO(roasbeef): flesh out comment
+	openChannelBucket = []byte("open-chan-bucket")
+
+	// commitDiffKey stores the current pending commitment state we've
+	// extended to the remote party (if any). Each time we propose a new
+	// state, we store the information necessary to reconstruct this state
+	// from the prior commitment. This allows us to resync the remote party
+	// to their expected state in the case of message loss.
+	//
+	// TODO(roasbeef): rename to commit chain?
+	commitDiffKey = []byte("commit-diff-key")
+
+	// unsignedAckedUpdatesKey is an entry in the channel bucket that
+	// contains the remote updates that we have acked, but not yet signed
+	// for in one of our remote commits.
+	unsignedAckedUpdatesKey = []byte("unsigned-acked-updates-key")
+
+	// networkResultStoreBucketKey is used for the root level bucket that
+	// stores the network result for each payment ID.
+	networkResultStoreBucketKey = []byte("network-result-store-bucket")
+
+	// closedChannelBucket stores summarization information concerning
+	// previously open, but now closed channels.
+	closedChannelBucket = []byte("closed-chan-bucket")
+)
+
+func serializeChanCommit(w io.Writer, c *ChannelCommitment) error { // nolint: dupl
+	if err := WriteElements(w,
+		c.CommitHeight, c.LocalLogIndex, c.LocalHtlcIndex,
+		c.RemoteLogIndex, c.RemoteHtlcIndex, c.LocalBalance,
+		c.RemoteBalance, c.CommitFee, c.FeePerKw, c.CommitTx,
+		c.CommitSig,
+	); err != nil {
+		return err
+	}
+
+	return serializeHtlcs(w, c.Htlcs...)
+}
+
+func serializeLogUpdates(w io.Writer, logUpdates []LogUpdate) error { // nolint: dupl
+	numUpdates := uint16(len(logUpdates))
+	if err := binary.Write(w, byteOrder, numUpdates); err != nil {
+		return err
+	}
+
+	for _, diff := range logUpdates {
+		err := WriteElements(w, diff.LogIndex, diff.UpdateMsg)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func serializeHtlcs(b io.Writer, htlcs ...HTLC) error { // nolint: dupl
+	numHtlcs := uint16(len(htlcs))
+	if err := WriteElement(b, numHtlcs); err != nil {
+		return err
+	}
+
+	for _, htlc := range htlcs {
+		if err := WriteElements(b,
+			htlc.Signature, htlc.RHash, htlc.Amt, htlc.RefundTimeout,
+			htlc.OutputIndex, htlc.Incoming, htlc.OnionBlob,
+			htlc.HtlcIndex, htlc.LogIndex,
+		); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func serializeCommitDiff(w io.Writer, diff *CommitDiff) error { // nolint: dupl
+	if err := serializeChanCommit(w, &diff.Commitment); err != nil {
+		return err
+	}
+
+	if err := WriteElements(w, diff.CommitSig); err != nil {
+		return err
+	}
+
+	if err := serializeLogUpdates(w, diff.LogUpdates); err != nil {
+		return err
+	}
+
+	numOpenRefs := uint16(len(diff.OpenedCircuitKeys))
+	if err := binary.Write(w, byteOrder, numOpenRefs); err != nil {
+		return err
+	}
+
+	for _, openRef := range diff.OpenedCircuitKeys {
+		err := WriteElements(w, openRef.ChanID, openRef.HtlcID)
+		if err != nil {
+			return err
+		}
+	}
+
+	numClosedRefs := uint16(len(diff.ClosedCircuitKeys))
+	if err := binary.Write(w, byteOrder, numClosedRefs); err != nil {
+		return err
+	}
+
+	for _, closedRef := range diff.ClosedCircuitKeys {
+		err := WriteElements(w, closedRef.ChanID, closedRef.HtlcID)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func deserializeHtlcs(r io.Reader) ([]HTLC, error) { // nolint: dupl
+	var numHtlcs uint16
+	if err := ReadElement(r, &numHtlcs); err != nil {
+		return nil, err
+	}
+
+	var htlcs []HTLC
+	if numHtlcs == 0 {
+		return htlcs, nil
+	}
+
+	htlcs = make([]HTLC, numHtlcs)
+	for i := uint16(0); i < numHtlcs; i++ {
+		if err := ReadElements(r,
+			&htlcs[i].Signature, &htlcs[i].RHash, &htlcs[i].Amt,
+			&htlcs[i].RefundTimeout, &htlcs[i].OutputIndex,
+			&htlcs[i].Incoming, &htlcs[i].OnionBlob,
+			&htlcs[i].HtlcIndex, &htlcs[i].LogIndex,
+		); err != nil {
+			return htlcs, err
+		}
+	}
+
+	return htlcs, nil
+}
+
+func deserializeChanCommit(r io.Reader) (ChannelCommitment, error) { // nolint: dupl
+	var c ChannelCommitment
+
+	err := ReadElements(r,
+		&c.CommitHeight, &c.LocalLogIndex, &c.LocalHtlcIndex, &c.RemoteLogIndex,
+		&c.RemoteHtlcIndex, &c.LocalBalance, &c.RemoteBalance,
+		&c.CommitFee, &c.FeePerKw, &c.CommitTx, &c.CommitSig,
+	)
+	if err != nil {
+		return c, err
+	}
+
+	c.Htlcs, err = deserializeHtlcs(r)
+	if err != nil {
+		return c, err
+	}
+
+	return c, nil
+}
+
+func deserializeLogUpdates(r io.Reader) ([]LogUpdate, error) { // nolint: dupl
+	var numUpdates uint16
+	if err := binary.Read(r, byteOrder, &numUpdates); err != nil {
+		return nil, err
+	}
+
+	logUpdates := make([]LogUpdate, numUpdates)
+	for i := 0; i < int(numUpdates); i++ {
+		err := ReadElements(r,
+			&logUpdates[i].LogIndex, &logUpdates[i].UpdateMsg,
+		)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return logUpdates, nil
+}
+
+func deserializeCommitDiff(r io.Reader) (*CommitDiff, error) { // nolint: dupl
+	var (
+		d   CommitDiff
+		err error
+	)
+
+	d.Commitment, err = deserializeChanCommit(r)
+	if err != nil {
+		return nil, err
+	}
+
+	var msg lnwire.Message
+	if err := ReadElements(r, &msg); err != nil {
+		return nil, err
+	}
+	commitSig, ok := msg.(*lnwire.CommitSig)
+	if !ok {
+		return nil, fmt.Errorf("expected lnwire.CommitSig, instead "+
+			"read: %T", msg)
+	}
+	d.CommitSig = commitSig
+
+	d.LogUpdates, err = deserializeLogUpdates(r)
+	if err != nil {
+		return nil, err
+	}
+
+	var numOpenRefs uint16
+	if err := binary.Read(r, byteOrder, &numOpenRefs); err != nil {
+		return nil, err
+	}
+
+	d.OpenedCircuitKeys = make([]CircuitKey, numOpenRefs)
+	for i := 0; i < int(numOpenRefs); i++ {
+		err := ReadElements(r,
+			&d.OpenedCircuitKeys[i].ChanID,
+			&d.OpenedCircuitKeys[i].HtlcID)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	var numClosedRefs uint16
+	if err := binary.Read(r, byteOrder, &numClosedRefs); err != nil {
+		return nil, err
+	}
+
+	d.ClosedCircuitKeys = make([]CircuitKey, numClosedRefs)
+	for i := 0; i < int(numClosedRefs); i++ {
+		err := ReadElements(r,
+			&d.ClosedCircuitKeys[i].ChanID,
+			&d.ClosedCircuitKeys[i].HtlcID)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return &d, nil
+}
+
+func serializeNetworkResult(w io.Writer, n *networkResult) error { // nolint: dupl
+	return WriteElements(w, n.msg, n.unencrypted, n.isResolution)
+}
+
+func deserializeNetworkResult(r io.Reader) (*networkResult, error) { // nolint: dupl
+	n := &networkResult{}
+
+	if err := ReadElements(r,
+		&n.msg, &n.unencrypted, &n.isResolution,
+	); err != nil {
+		return nil, err
+	}
+
+	return n, nil
+}
+
+func writeChanConfig(b io.Writer, c *ChannelConfig) error { // nolint: dupl
+	return WriteElements(b,
+		c.DustLimit, c.MaxPendingAmount, c.ChanReserve, c.MinHTLC,
+		c.MaxAcceptedHtlcs, c.CsvDelay, c.MultiSigKey,
+		c.RevocationBasePoint, c.PaymentBasePoint, c.DelayBasePoint,
+		c.HtlcBasePoint,
+	)
+}
+
+func serializeChannelCloseSummary(w io.Writer, cs *ChannelCloseSummary) error { // nolint: dupl
+	err := WriteElements(w,
+		cs.ChanPoint, cs.ShortChanID, cs.ChainHash, cs.ClosingTXID,
+		cs.CloseHeight, cs.RemotePub, cs.Capacity, cs.SettledBalance,
+		cs.TimeLockedBalance, cs.CloseType, cs.IsPending,
+	)
+	if err != nil {
+		return err
+	}
+
+	// If this is a close channel summary created before the addition of
+	// the new fields, then we can exit here.
+	if cs.RemoteCurrentRevocation == nil {
+		return WriteElements(w, false)
+	}
+
+	// If fields are present, write boolean to indicate this, and continue.
+	if err := WriteElements(w, true); err != nil {
+		return err
+	}
+
+	if err := WriteElements(w, cs.RemoteCurrentRevocation); err != nil {
+		return err
+	}
+
+	if err := writeChanConfig(w, &cs.LocalChanConfig); err != nil {
+		return err
+	}
+
+	// The RemoteNextRevocation field is optional, as it's possible for a
+	// channel to be closed before we learn of the next unrevoked
+	// revocation point for the remote party. Write a boolen indicating
+	// whether this field is present or not.
+	if err := WriteElements(w, cs.RemoteNextRevocation != nil); err != nil {
+		return err
+	}
+
+	// Write the field, if present.
+	if cs.RemoteNextRevocation != nil {
+		if err = WriteElements(w, cs.RemoteNextRevocation); err != nil {
+			return err
+		}
+	}
+
+	// Write whether the channel sync message is present.
+	if err := WriteElements(w, cs.LastChanSyncMsg != nil); err != nil {
+		return err
+	}
+
+	// Write the channel sync message, if present.
+	if cs.LastChanSyncMsg != nil {
+		if err := WriteElements(w, cs.LastChanSyncMsg); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func readChanConfig(b io.Reader, c *ChannelConfig) error {
+	return ReadElements(b,
+		&c.DustLimit, &c.MaxPendingAmount, &c.ChanReserve,
+		&c.MinHTLC, &c.MaxAcceptedHtlcs, &c.CsvDelay,
+		&c.MultiSigKey, &c.RevocationBasePoint,
+		&c.PaymentBasePoint, &c.DelayBasePoint,
+		&c.HtlcBasePoint,
+	)
+}
+
+func deserializeCloseChannelSummary(r io.Reader) (*ChannelCloseSummary, error) { // nolint: dupl
+	c := &ChannelCloseSummary{}
+
+	err := ReadElements(r,
+		&c.ChanPoint, &c.ShortChanID, &c.ChainHash, &c.ClosingTXID,
+		&c.CloseHeight, &c.RemotePub, &c.Capacity, &c.SettledBalance,
+		&c.TimeLockedBalance, &c.CloseType, &c.IsPending,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	// We'll now check to see if the channel close summary was encoded with
+	// any of the additional optional fields.
+	var hasNewFields bool
+	err = ReadElements(r, &hasNewFields)
+	if err != nil {
+		return nil, err
+	}
+
+	// If fields are not present, we can return.
+	if !hasNewFields {
+		return c, nil
+	}
+
+	// Otherwise read the new fields.
+	if err := ReadElements(r, &c.RemoteCurrentRevocation); err != nil {
+		return nil, err
+	}
+
+	if err := readChanConfig(r, &c.LocalChanConfig); err != nil {
+		return nil, err
+	}
+
+	// Finally, we'll attempt to read the next unrevoked commitment point
+	// for the remote party. If we closed the channel before receiving a
+	// funding locked message then this might not be present. A boolean
+	// indicating whether the field is present will come first.
+	var hasRemoteNextRevocation bool
+	err = ReadElements(r, &hasRemoteNextRevocation)
+	if err != nil {
+		return nil, err
+	}
+
+	// If this field was written, read it.
+	if hasRemoteNextRevocation {
+		err = ReadElements(r, &c.RemoteNextRevocation)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	// Check if we have a channel sync message to read.
+	var hasChanSyncMsg bool
+	err = ReadElements(r, &hasChanSyncMsg)
+	if err == io.EOF {
+		return c, nil
+	} else if err != nil {
+		return nil, err
+	}
+
+	// If a chan sync message is present, read it.
+	if hasChanSyncMsg {
+		// We must pass in reference to a lnwire.Message for the codec
+		// to support it.
+		var msg lnwire.Message
+		if err := ReadElements(r, &msg); err != nil {
+			return nil, err
+		}
+
+		chanSync, ok := msg.(*lnwire.ChannelReestablish)
+		if !ok {
+			return nil, errors.New("unable cast db Message to " +
+				"ChannelReestablish")
+		}
+		c.LastChanSyncMsg = chanSync
+	}
+
+	return c, nil
+}

--- a/channeldb/migration_01_to_11/codec.go
+++ b/channeldb/migration_01_to_11/codec.go
@@ -172,7 +172,8 @@ func WriteElement(w io.Writer, element interface{}) error {
 		}
 
 	case lnwire.Message:
-		if _, err := lnwire.WriteMessage(w, e, 0); err != nil {
+		_, err := lnwire.WriteMessage(w, e, lnwire.ProtocolVersionLegacy)
+		if err != nil {
 			return err
 		}
 
@@ -383,7 +384,7 @@ func ReadElement(r io.Reader, element interface{}) error {
 		*e = bytes
 
 	case *lnwire.Message:
-		msg, err := lnwire.ReadMessage(r, 0)
+		msg, err := lnwire.ReadMessage(r, lnwire.ProtocolVersionLegacy)
 		if err != nil {
 			return err
 		}

--- a/channeldb/migration_01_to_11/migrations.go
+++ b/channeldb/migration_01_to_11/migrations.go
@@ -724,7 +724,8 @@ func MigrateGossipMessageStoreKeys(tx kvdb.RwTx) error {
 
 		// Serialize the message with its wire encoding.
 		var b bytes.Buffer
-		if _, err := lnwire.WriteMessage(&b, msg, 0); err != nil {
+		_, err := lnwire.WriteMessage(&b, msg, lnwire.ProtocolVersionTLV)
+		if err != nil {
 			return err
 		}
 

--- a/channeldb/migration_01_to_11/migrations_test.go
+++ b/channeldb/migration_01_to_11/migrations_test.go
@@ -464,7 +464,10 @@ func TestMigrateGossipMessageStoreKeys(t *testing.T) {
 	// Construct the message which we'll use to test the migration, along
 	// with its old and new key formats.
 	shortChanID := lnwire.ShortChannelID{BlockHeight: 10}
-	msg := &lnwire.AnnounceSignatures{ShortChannelID: shortChanID}
+	msg := &lnwire.AnnounceSignatures{
+		ShortChannelID:  shortChanID,
+		ExtraOpaqueData: make([]byte, 0),
+	}
 
 	var oldMsgKey [33 + 8]byte
 	copy(oldMsgKey[:33], pubKey.SerializeCompressed())

--- a/channeldb/migration_01_to_11/migrations_test.go
+++ b/channeldb/migration_01_to_11/migrations_test.go
@@ -529,7 +529,9 @@ func TestMigrateGossipMessageStoreKeys(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		gotMsg, err := lnwire.ReadMessage(bytes.NewReader(rawMsg), 0)
+		gotMsg, err := lnwire.ReadMessage(
+			bytes.NewReader(rawMsg), lnwire.ProtocolVersionLegacy,
+		)
 		if err != nil {
 			t.Fatalf("unable to deserialize raw message: %v", err)
 		}

--- a/channeldb/migtest/migtest.go
+++ b/channeldb/migtest/migtest.go
@@ -39,6 +39,8 @@ func ApplyMigration(t *testing.T,
 	beforeMigration, afterMigration, migrationFunc func(tx kvdb.RwTx) error,
 	shouldFail bool) {
 
+	t.Helper()
+
 	cdb, cleanUp, err := MakeDB()
 	defer cleanUp()
 	if err != nil {
@@ -53,6 +55,8 @@ func ApplyMigration(t *testing.T,
 	}
 
 	defer func() {
+		t.Helper()
+
 		if r := recover(); r != nil {
 			err = newError(r)
 		}

--- a/channeldb/waitingproof.go
+++ b/channeldb/waitingproof.go
@@ -227,7 +227,8 @@ func (p *WaitingProof) Encode(w io.Writer) error {
 		return err
 	}
 
-	if err := p.AnnounceSignatures.Encode(w, 0); err != nil {
+	err := p.AnnounceSignatures.Encode(w, lnwire.ProtocolVersionTLV)
+	if err != nil {
 		return err
 	}
 
@@ -242,7 +243,7 @@ func (p *WaitingProof) Decode(r io.Reader) error {
 	}
 
 	msg := &lnwire.AnnounceSignatures{}
-	if err := msg.Decode(r, 0); err != nil {
+	if err := msg.Decode(r, lnwire.ProtocolVersionTLV); err != nil {
 		return err
 	}
 

--- a/channeldb/waitingproof_test.go
+++ b/channeldb/waitingproof_test.go
@@ -5,6 +5,7 @@ import (
 
 	"reflect"
 
+	"github.com/davecgh/go-spew/spew"
 	"github.com/go-errors/errors"
 	"github.com/lightningnetwork/lnd/lnwire"
 )
@@ -23,6 +24,7 @@ func TestWaitingProofStore(t *testing.T) {
 	proof1 := NewWaitingProof(true, &lnwire.AnnounceSignatures{
 		NodeSignature:    wireSig,
 		BitcoinSignature: wireSig,
+		ExtraOpaqueData:  make([]byte, 0),
 	})
 
 	store, err := NewWaitingProofStore(db)
@@ -40,7 +42,8 @@ func TestWaitingProofStore(t *testing.T) {
 		t.Fatalf("unable retrieve proof from storage: %v", err)
 	}
 	if !reflect.DeepEqual(proof1, proof2) {
-		t.Fatal("wrong proof retrieved")
+		t.Fatalf("wrong proof retrieved: expected %v, got %v",
+			spew.Sdump(proof1), spew.Sdump(proof2))
 	}
 
 	if _, err := store.Get(proof1.OppositeKey()); err != ErrWaitingProofNotFound {

--- a/discovery/message_store.go
+++ b/discovery/message_store.go
@@ -120,7 +120,8 @@ func (s *MessageStore) AddMessage(msg lnwire.Message, peerPubKey [33]byte) error
 
 	// Serialize the message with its wire encoding.
 	var b bytes.Buffer
-	if _, err := lnwire.WriteMessage(&b, msg, 0); err != nil {
+	_, err = lnwire.WriteMessage(&b, msg, lnwire.ProtocolVersionTLV)
+	if err != nil {
 		return err
 	}
 
@@ -163,7 +164,9 @@ func (s *MessageStore) DeleteMessage(msg lnwire.Message,
 				return nil
 			}
 
-			dbMsg, err := lnwire.ReadMessage(bytes.NewReader(v), 0)
+			dbMsg, err := lnwire.ReadMessage(
+				bytes.NewReader(v), lnwire.ProtocolVersionTLV,
+			)
 			if err != nil {
 				return err
 			}
@@ -182,7 +185,9 @@ func (s *MessageStore) DeleteMessage(msg lnwire.Message,
 // readMessage reads a message from its serialized form and ensures its
 // supported by the current version of the message store.
 func readMessage(msgBytes []byte) (lnwire.Message, error) {
-	msg, err := lnwire.ReadMessage(bytes.NewReader(msgBytes), 0)
+	msg, err := lnwire.ReadMessage(
+		bytes.NewReader(msgBytes), lnwire.ProtocolVersionTLV,
+	)
 	if err != nil {
 		return nil, err
 	}

--- a/discovery/message_store_test.go
+++ b/discovery/message_store_test.go
@@ -64,13 +64,15 @@ func randCompressedPubKey(t *testing.T) [33]byte {
 
 func randAnnounceSignatures() *lnwire.AnnounceSignatures {
 	return &lnwire.AnnounceSignatures{
-		ShortChannelID: lnwire.NewShortChanIDFromInt(rand.Uint64()),
+		ShortChannelID:  lnwire.NewShortChanIDFromInt(rand.Uint64()),
+		ExtraOpaqueData: make([]byte, 0),
 	}
 }
 
 func randChannelUpdate() *lnwire.ChannelUpdate {
 	return &lnwire.ChannelUpdate{
-		ShortChannelID: lnwire.NewShortChanIDFromInt(rand.Uint64()),
+		ShortChannelID:  lnwire.NewShortChanIDFromInt(rand.Uint64()),
+		ExtraOpaqueData: make([]byte, 0),
 	}
 }
 

--- a/discovery/sync_manager_test.go
+++ b/discovery/sync_manager_test.go
@@ -536,8 +536,9 @@ func assertTransitionToChansSynced(t *testing.T, s *GossipSyncer, peer *mockPeer
 	assertMsgSent(t, peer, query)
 
 	s.ProcessQueryMsg(&lnwire.ReplyChannelRange{
-		QueryChannelRange: *query,
-		Complete:          1,
+		FirstBlockHeight: 0,
+		NumBlocks:        math.MaxUint32,
+		Complete:         1,
 	}, nil)
 
 	chanSeries := s.cfg.channelSeries.(*mockChannelGraphTimeSeries)

--- a/fundingmanager.go
+++ b/fundingmanager.go
@@ -1437,7 +1437,9 @@ func (f *fundingManager) handleFundingOpen(peer lnpeer.Peer,
 				PubKey: copyPubKey(msg.HtlcPoint),
 			},
 		},
-		UpfrontShutdown: msg.UpfrontShutdownScript,
+		UpfrontShutdown: lnwire.DeliveryAddress(
+			msg.UpfrontShutdownScript,
+		),
 	}
 	err = reservation.ProcessSingleContribution(remoteContribution)
 	if err != nil {
@@ -1455,21 +1457,23 @@ func (f *fundingManager) handleFundingOpen(peer lnpeer.Peer,
 	// contribution in the next message of the workflow.
 	ourContribution := reservation.OurContribution()
 	fundingAccept := lnwire.AcceptChannel{
-		PendingChannelID:      msg.PendingChannelID,
-		DustLimit:             ourContribution.DustLimit,
-		MaxValueInFlight:      remoteMaxValue,
-		ChannelReserve:        chanReserve,
-		MinAcceptDepth:        uint32(numConfsReq),
-		HtlcMinimum:           minHtlc,
-		CsvDelay:              remoteCsvDelay,
-		MaxAcceptedHTLCs:      maxHtlcs,
-		FundingKey:            ourContribution.MultiSigKey.PubKey,
-		RevocationPoint:       ourContribution.RevocationBasePoint.PubKey,
-		PaymentPoint:          ourContribution.PaymentBasePoint.PubKey,
-		DelayedPaymentPoint:   ourContribution.DelayBasePoint.PubKey,
-		HtlcPoint:             ourContribution.HtlcBasePoint.PubKey,
-		FirstCommitmentPoint:  ourContribution.FirstCommitmentPoint,
-		UpfrontShutdownScript: ourContribution.UpfrontShutdown,
+		PendingChannelID:     msg.PendingChannelID,
+		DustLimit:            ourContribution.DustLimit,
+		MaxValueInFlight:     remoteMaxValue,
+		ChannelReserve:       chanReserve,
+		MinAcceptDepth:       uint32(numConfsReq),
+		HtlcMinimum:          minHtlc,
+		CsvDelay:             remoteCsvDelay,
+		MaxAcceptedHTLCs:     maxHtlcs,
+		FundingKey:           ourContribution.MultiSigKey.PubKey,
+		RevocationPoint:      ourContribution.RevocationBasePoint.PubKey,
+		PaymentPoint:         ourContribution.PaymentBasePoint.PubKey,
+		DelayedPaymentPoint:  ourContribution.DelayBasePoint.PubKey,
+		HtlcPoint:            ourContribution.HtlcBasePoint.PubKey,
+		FirstCommitmentPoint: ourContribution.FirstCommitmentPoint,
+		UpfrontShutdownScript: lnwire.TypedDeliveryAddress(
+			ourContribution.UpfrontShutdown,
+		),
 	}
 
 	if err := peer.SendMessage(true, &fundingAccept); err != nil {
@@ -1568,7 +1572,9 @@ func (f *fundingManager) handleFundingAccept(peer lnpeer.Peer,
 				PubKey: copyPubKey(msg.HtlcPoint),
 			},
 		},
-		UpfrontShutdown: msg.UpfrontShutdownScript,
+		UpfrontShutdown: lnwire.DeliveryAddress(
+			msg.UpfrontShutdownScript,
+		),
 	}
 	err = resCtx.reservation.ProcessContribution(remoteContribution)
 
@@ -3255,7 +3261,7 @@ func (f *fundingManager) handleInitFundingMsg(msg *initFundingMsg) {
 		DelayedPaymentPoint:   ourContribution.DelayBasePoint.PubKey,
 		FirstCommitmentPoint:  ourContribution.FirstCommitmentPoint,
 		ChannelFlags:          channelFlags,
-		UpfrontShutdownScript: shutdown,
+		UpfrontShutdownScript: lnwire.TypedDeliveryAddress(shutdown),
 	}
 	if err := msg.peer.SendMessage(true, &fundingOpen); err != nil {
 		e := fmt.Errorf("unable to send funding request message: %v",

--- a/htlcswitch/payment_result.go
+++ b/htlcswitch/payment_result.go
@@ -61,28 +61,15 @@ type networkResult struct {
 
 // serializeNetworkResult serializes the networkResult.
 func serializeNetworkResult(w io.Writer, n *networkResult) error {
-	if _, err := lnwire.WriteMessage(w, n.msg, 0); err != nil {
-		return err
-	}
-
-	return channeldb.WriteElements(w, n.unencrypted, n.isResolution)
+	return channeldb.WriteElements(w, n.msg, n.unencrypted, n.isResolution)
 }
 
 // deserializeNetworkResult deserializes the networkResult.
 func deserializeNetworkResult(r io.Reader) (*networkResult, error) {
-	var (
-		err error
-	)
-
 	n := &networkResult{}
 
-	n.msg, err = lnwire.ReadMessage(r, 0)
-	if err != nil {
-		return nil, err
-	}
-
 	if err := channeldb.ReadElements(r,
-		&n.unencrypted, &n.isResolution,
+		&n.msg, &n.unencrypted, &n.isResolution,
 	); err != nil {
 		return nil, err
 	}

--- a/htlcswitch/payment_result_test.go
+++ b/htlcswitch/payment_result_test.go
@@ -39,18 +39,21 @@ func TestNetworkResultSerialization(t *testing.T) {
 		ChanID:          chanID,
 		ID:              2,
 		PaymentPreimage: preimage,
+		ExtraData:       make([]byte, 0),
 	}
 
 	fail := &lnwire.UpdateFailHTLC{
-		ChanID: chanID,
-		ID:     1,
-		Reason: []byte{},
+		ChanID:    chanID,
+		ID:        1,
+		Reason:    []byte{},
+		ExtraData: make([]byte, 0),
 	}
 
 	fail2 := &lnwire.UpdateFailHTLC{
-		ChanID: chanID,
-		ID:     1,
-		Reason: reason[:],
+		ChanID:    chanID,
+		ID:        1,
+		Reason:    reason[:],
+		ExtraData: make([]byte, 0),
 	}
 
 	testCases := []*networkResult{

--- a/lnwallet/channel_test.go
+++ b/lnwallet/channel_test.go
@@ -3176,6 +3176,7 @@ func TestChanSyncOweCommitment(t *testing.T) {
 			Amount:      htlcAmt,
 			Expiry:      uint32(10),
 			OnionBlob:   fakeOnionBlob,
+			ExtraData:   make([]byte, 0),
 		}
 
 		htlcIndex, err := bobChannel.AddHTLC(h, nil)
@@ -3220,6 +3221,7 @@ func TestChanSyncOweCommitment(t *testing.T) {
 		Amount:      htlcAmt,
 		Expiry:      uint32(10),
 		OnionBlob:   fakeOnionBlob,
+		ExtraData:   make([]byte, 0),
 	}
 	aliceHtlcIndex, err := aliceChannel.AddHTLC(aliceHtlc, nil)
 	if err != nil {

--- a/lnwire/accept_channel.go
+++ b/lnwire/accept_channel.go
@@ -110,6 +110,7 @@ var _ Message = (*AcceptChannel)(nil)
 // This is part of the lnwire.Message interface.
 func (a *AcceptChannel) Encode(w io.Writer, pver uint32) error {
 	return WriteElements(w,
+		pver,
 		a.PendingChannelID[:],
 		a.DustLimit,
 		a.MaxValueInFlight,
@@ -137,6 +138,7 @@ func (a *AcceptChannel) Encode(w io.Writer, pver uint32) error {
 func (a *AcceptChannel) Decode(r io.Reader, pver uint32) error {
 	// Read all the mandatory fields in the accept message.
 	return ReadElements(r,
+		pver,
 		a.PendingChannelID[:],
 		&a.DustLimit,
 		&a.MaxValueInFlight,

--- a/lnwire/accept_channel_test.go
+++ b/lnwire/accept_channel_test.go
@@ -12,7 +12,7 @@ import (
 func TestDecodeAcceptChannel(t *testing.T) {
 	tests := []struct {
 		name           string
-		shutdownScript DeliveryAddress
+		shutdownScript TypedDeliveryAddress
 	}{
 		{
 			name:           "no upfront shutdown script",

--- a/lnwire/announcement_signatures.go
+++ b/lnwire/announcement_signatures.go
@@ -52,6 +52,7 @@ var _ Message = (*AnnounceSignatures)(nil)
 // This is part of the lnwire.Message interface.
 func (a *AnnounceSignatures) Decode(r io.Reader, pver uint32) error {
 	return ReadElements(r,
+		pver,
 		&a.ChannelID,
 		&a.ShortChannelID,
 		&a.NodeSignature,
@@ -66,6 +67,7 @@ func (a *AnnounceSignatures) Decode(r io.Reader, pver uint32) error {
 // This is part of the lnwire.Message interface.
 func (a *AnnounceSignatures) Encode(w io.Writer, pver uint32) error {
 	return WriteElements(w,
+		pver,
 		a.ChannelID,
 		a.ShortChannelID,
 		a.NodeSignature,

--- a/lnwire/announcement_signatures.go
+++ b/lnwire/announcement_signatures.go
@@ -2,7 +2,6 @@ package lnwire
 
 import (
 	"io"
-	"io/ioutil"
 )
 
 // AnnounceSignatures this is a direct message between two endpoints of a
@@ -40,7 +39,7 @@ type AnnounceSignatures struct {
 	// properly validate the set of signatures that cover these new fields,
 	// and ensure we're able to make upgrades to the network in a forwards
 	// compatible manner.
-	ExtraOpaqueData []byte
+	ExtraOpaqueData ExtraOpaqueData
 }
 
 // A compile time check to ensure AnnounceSignatures implements the
@@ -52,29 +51,13 @@ var _ Message = (*AnnounceSignatures)(nil)
 //
 // This is part of the lnwire.Message interface.
 func (a *AnnounceSignatures) Decode(r io.Reader, pver uint32) error {
-	err := ReadElements(r,
+	return ReadElements(r,
 		&a.ChannelID,
 		&a.ShortChannelID,
 		&a.NodeSignature,
 		&a.BitcoinSignature,
+		&a.ExtraOpaqueData,
 	)
-	if err != nil {
-		return err
-	}
-
-	// Now that we've read out all the fields that we explicitly know of,
-	// we'll collect the remainder into the ExtraOpaqueData field. If there
-	// aren't any bytes, then we'll snip off the slice to avoid carrying
-	// around excess capacity.
-	a.ExtraOpaqueData, err = ioutil.ReadAll(r)
-	if err != nil {
-		return err
-	}
-	if len(a.ExtraOpaqueData) == 0 {
-		a.ExtraOpaqueData = nil
-	}
-
-	return nil
 }
 
 // Encode serializes the target AnnounceSignatures into the passed io.Writer
@@ -104,5 +87,5 @@ func (a *AnnounceSignatures) MsgType() MessageType {
 //
 // This is part of the lnwire.Message interface.
 func (a *AnnounceSignatures) MaxPayloadLength(pver uint32) uint32 {
-	return 65533
+	return MaxMsgBody
 }

--- a/lnwire/channel_announcement.go
+++ b/lnwire/channel_announcement.go
@@ -68,6 +68,7 @@ var _ Message = (*ChannelAnnouncement)(nil)
 // This is part of the lnwire.Message interface.
 func (a *ChannelAnnouncement) Decode(r io.Reader, pver uint32) error {
 	return ReadElements(r,
+		pver,
 		&a.NodeSig1,
 		&a.NodeSig2,
 		&a.BitcoinSig1,
@@ -89,6 +90,7 @@ func (a *ChannelAnnouncement) Decode(r io.Reader, pver uint32) error {
 // This is part of the lnwire.Message interface.
 func (a *ChannelAnnouncement) Encode(w io.Writer, pver uint32) error {
 	return WriteElements(w,
+		pver,
 		a.NodeSig1,
 		a.NodeSig2,
 		a.BitcoinSig1,
@@ -126,6 +128,10 @@ func (a *ChannelAnnouncement) DataToSign() ([]byte, error) {
 	// We should not include the signatures itself.
 	var w bytes.Buffer
 	err := WriteElements(&w,
+		// We always use the modern protocol version here as we always
+		// need to include any optional data in the signature digest
+		// for forwards compatibility.
+		ProtocolVersionTLV,
 		a.Features,
 		a.ChainHash[:],
 		a.ShortChannelID,

--- a/lnwire/channel_reestablish.go
+++ b/lnwire/channel_reestablish.go
@@ -60,6 +60,11 @@ type ChannelReestablish struct {
 	// LocalUnrevokedCommitPoint is the commitment point used in the
 	// current un-revoked commitment transaction of the sending party.
 	LocalUnrevokedCommitPoint *btcec.PublicKey
+
+	// ExtraData is the set of data that was appended to this message to
+	// fill out the full maximum transport message size. These fields can
+	// be used to specify optional data such as custom TLV fields.
+	ExtraData ExtraOpaqueData
 }
 
 // A compile time check to ensure ChannelReestablish implements the
@@ -83,12 +88,20 @@ func (a *ChannelReestablish) Encode(w io.Writer, pver uint32) error {
 	// If the commit point wasn't sent, then we won't write out any of the
 	// remaining fields as they're optional.
 	if a.LocalUnrevokedCommitPoint == nil {
-		return nil
+		// However, we'll still write out the extra data if it's
+		// present.
+		//
+		// NOTE: This is here primarily for the quickcheck tests, in
+		// practice, we'll always populate this field.
+		return WriteElements(w, a.ExtraData)
 	}
 
 	// Otherwise, we'll write out the remaining elements.
-	return WriteElements(w, a.LastRemoteCommitSecret[:],
-		a.LocalUnrevokedCommitPoint)
+	return WriteElements(w,
+		a.LastRemoteCommitSecret[:],
+		a.LocalUnrevokedCommitPoint,
+		a.ExtraData,
+	)
 }
 
 // Decode deserializes a serialized ChannelReestablish stored in the passed
@@ -118,6 +131,9 @@ func (a *ChannelReestablish) Decode(r io.Reader, pver uint32) error {
 	var buf [32]byte
 	_, err = io.ReadFull(r, buf[:32])
 	if err == io.EOF {
+		// If there aren't any more bytes, then we'll emplace an empty
+		// extra data to make our quickcheck tests happy.
+		a.ExtraData = make([]byte, 0)
 		return nil
 	} else if err != nil {
 		return err
@@ -127,9 +143,13 @@ func (a *ChannelReestablish) Decode(r io.Reader, pver uint32) error {
 	copy(a.LastRemoteCommitSecret[:], buf[:])
 
 	// We'll conclude by parsing out the commitment point. We don't check
-	// the error in this case, as it hey included the commit secret, then
+	// the error in this case, as it they included the commit secret, then
 	// they MUST also include the commit point.
-	return ReadElement(r, &a.LocalUnrevokedCommitPoint)
+	if err = ReadElement(r, &a.LocalUnrevokedCommitPoint); err != nil {
+		return err
+	}
+
+	return a.ExtraData.Decode(r)
 }
 
 // MsgType returns the integer uniquely identifying this message type on the
@@ -145,22 +165,5 @@ func (a *ChannelReestablish) MsgType() MessageType {
 //
 // This is part of the lnwire.Message interface.
 func (a *ChannelReestablish) MaxPayloadLength(pver uint32) uint32 {
-	var length uint32
-
-	// ChanID - 32 bytes
-	length += 32
-
-	// NextLocalCommitHeight - 8 bytes
-	length += 8
-
-	// RemoteCommitTailHeight - 8 bytes
-	length += 8
-
-	// LastRemoteCommitSecret - 32 bytes
-	length += 32
-
-	// LocalUnrevokedCommitPoint - 33 bytes
-	length += 33
-
-	return length
+	return MaxMsgBody
 }

--- a/lnwire/channel_reestablish.go
+++ b/lnwire/channel_reestablish.go
@@ -77,6 +77,7 @@ var _ Message = (*ChannelReestablish)(nil)
 // This is part of the lnwire.Message interface.
 func (a *ChannelReestablish) Encode(w io.Writer, pver uint32) error {
 	err := WriteElements(w,
+		pver,
 		a.ChanID,
 		a.NextLocalCommitHeight,
 		a.RemoteCommitTailHeight,
@@ -93,11 +94,12 @@ func (a *ChannelReestablish) Encode(w io.Writer, pver uint32) error {
 		//
 		// NOTE: This is here primarily for the quickcheck tests, in
 		// practice, we'll always populate this field.
-		return WriteElements(w, a.ExtraData)
+		return WriteElements(w, pver, a.ExtraData)
 	}
 
 	// Otherwise, we'll write out the remaining elements.
 	return WriteElements(w,
+		pver,
 		a.LastRemoteCommitSecret[:],
 		a.LocalUnrevokedCommitPoint,
 		a.ExtraData,
@@ -110,6 +112,7 @@ func (a *ChannelReestablish) Encode(w io.Writer, pver uint32) error {
 // This is part of the lnwire.Message interface.
 func (a *ChannelReestablish) Decode(r io.Reader, pver uint32) error {
 	err := ReadElements(r,
+		pver,
 		&a.ChanID,
 		&a.NextLocalCommitHeight,
 		&a.RemoteCommitTailHeight,
@@ -145,11 +148,11 @@ func (a *ChannelReestablish) Decode(r io.Reader, pver uint32) error {
 	// We'll conclude by parsing out the commitment point. We don't check
 	// the error in this case, as it they included the commit secret, then
 	// they MUST also include the commit point.
-	if err = ReadElement(r, &a.LocalUnrevokedCommitPoint); err != nil {
+	if err = ReadElement(r, pver, &a.LocalUnrevokedCommitPoint); err != nil {
 		return err
 	}
 
-	return a.ExtraData.Decode(r)
+	return a.ExtraData.Decode(r, pver)
 }
 
 // MsgType returns the integer uniquely identifying this message type on the

--- a/lnwire/channel_update.go
+++ b/lnwire/channel_update.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"io/ioutil"
 
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 )
@@ -110,13 +109,10 @@ type ChannelUpdate struct {
 	// HtlcMaximumMsat is the maximum HTLC value which will be accepted.
 	HtlcMaximumMsat MilliSatoshi
 
-	// ExtraOpaqueData is the set of data that was appended to this
-	// message, some of which we may not actually know how to iterate or
-	// parse. By holding onto this data, we ensure that we're able to
-	// properly validate the set of signatures that cover these new fields,
-	// and ensure we're able to make upgrades to the network in a forwards
-	// compatible manner.
-	ExtraOpaqueData []byte
+	// ExtraData is the set of data that was appended to this message to
+	// fill out the full maximum transport message size. These fields can
+	// be used to specify optional data such as custom TLV fields.
+	ExtraOpaqueData ExtraOpaqueData
 }
 
 // A compile time check to ensure ChannelUpdate implements the lnwire.Message
@@ -151,19 +147,7 @@ func (a *ChannelUpdate) Decode(r io.Reader, pver uint32) error {
 		}
 	}
 
-	// Now that we've read out all the fields that we explicitly know of,
-	// we'll collect the remainder into the ExtraOpaqueData field. If there
-	// aren't any bytes, then we'll snip off the slice to avoid carrying
-	// around excess capacity.
-	a.ExtraOpaqueData, err = ioutil.ReadAll(r)
-	if err != nil {
-		return err
-	}
-	if len(a.ExtraOpaqueData) == 0 {
-		a.ExtraOpaqueData = nil
-	}
-
-	return nil
+	return a.ExtraOpaqueData.Decode(r)
 }
 
 // Encode serializes the target ChannelUpdate into the passed io.Writer
@@ -196,7 +180,7 @@ func (a *ChannelUpdate) Encode(w io.Writer, pver uint32) error {
 	}
 
 	// Finally, append any extra opaque data.
-	return WriteElements(w, a.ExtraOpaqueData)
+	return a.ExtraOpaqueData.Encode(w)
 }
 
 // MsgType returns the integer uniquely identifying this message type on the
@@ -212,7 +196,7 @@ func (a *ChannelUpdate) MsgType() MessageType {
 //
 // This is part of the lnwire.Message interface.
 func (a *ChannelUpdate) MaxPayloadLength(pver uint32) uint32 {
-	return 65533
+	return MaxMsgBody
 }
 
 // DataToSign is used to retrieve part of the announcement message which should
@@ -245,7 +229,7 @@ func (a *ChannelUpdate) DataToSign() ([]byte, error) {
 	}
 
 	// Finally, append any extra opaque data.
-	if err := WriteElements(&w, a.ExtraOpaqueData); err != nil {
+	if err := a.ExtraOpaqueData.Encode(&w); err != nil {
 		return nil, err
 	}
 

--- a/lnwire/channel_update.go
+++ b/lnwire/channel_update.go
@@ -125,6 +125,7 @@ var _ Message = (*ChannelUpdate)(nil)
 // This is part of the lnwire.Message interface.
 func (a *ChannelUpdate) Decode(r io.Reader, pver uint32) error {
 	err := ReadElements(r,
+		pver,
 		&a.Signature,
 		a.ChainHash[:],
 		&a.ShortChannelID,
@@ -142,12 +143,12 @@ func (a *ChannelUpdate) Decode(r io.Reader, pver uint32) error {
 
 	// Now check whether the max HTLC field is present and read it if so.
 	if a.MessageFlags.HasMaxHtlc() {
-		if err := ReadElements(r, &a.HtlcMaximumMsat); err != nil {
+		if err := ReadElements(r, pver, &a.HtlcMaximumMsat); err != nil {
 			return err
 		}
 	}
 
-	return a.ExtraOpaqueData.Decode(r)
+	return a.ExtraOpaqueData.Decode(r, pver)
 }
 
 // Encode serializes the target ChannelUpdate into the passed io.Writer
@@ -156,6 +157,7 @@ func (a *ChannelUpdate) Decode(r io.Reader, pver uint32) error {
 // This is part of the lnwire.Message interface.
 func (a *ChannelUpdate) Encode(w io.Writer, pver uint32) error {
 	err := WriteElements(w,
+		pver,
 		a.Signature,
 		a.ChainHash[:],
 		a.ShortChannelID,
@@ -174,13 +176,13 @@ func (a *ChannelUpdate) Encode(w io.Writer, pver uint32) error {
 	// Now append optional fields if they are set. Currently, the only
 	// optional field is max HTLC.
 	if a.MessageFlags.HasMaxHtlc() {
-		if err := WriteElements(w, a.HtlcMaximumMsat); err != nil {
+		if err := WriteElements(w, pver, a.HtlcMaximumMsat); err != nil {
 			return err
 		}
 	}
 
 	// Finally, append any extra opaque data.
-	return a.ExtraOpaqueData.Encode(w)
+	return a.ExtraOpaqueData.Encode(w, pver)
 }
 
 // MsgType returns the integer uniquely identifying this message type on the
@@ -202,10 +204,10 @@ func (a *ChannelUpdate) MaxPayloadLength(pver uint32) uint32 {
 // DataToSign is used to retrieve part of the announcement message which should
 // be signed.
 func (a *ChannelUpdate) DataToSign() ([]byte, error) {
-
 	// We should not include the signatures itself.
 	var w bytes.Buffer
 	err := WriteElements(&w,
+		ProtocolVersionTLV,
 		a.ChainHash[:],
 		a.ShortChannelID,
 		a.Timestamp,
@@ -223,13 +225,18 @@ func (a *ChannelUpdate) DataToSign() ([]byte, error) {
 	// Now append optional fields if they are set. Currently, the only
 	// optional field is max HTLC.
 	if a.MessageFlags.HasMaxHtlc() {
-		if err := WriteElements(&w, a.HtlcMaximumMsat); err != nil {
+		err := WriteElements(
+			&w, ProtocolVersionTLV, a.HtlcMaximumMsat,
+		)
+		if err != nil {
 			return nil, err
 		}
 	}
 
-	// Finally, append any extra opaque data.
-	if err := a.ExtraOpaqueData.Encode(&w); err != nil {
+	// Finally, append any extra opaque data. We always pass in the modern
+	// protocol version here as we always need to include any extra bytes
+	// in the signature digest.
+	if err := a.ExtraOpaqueData.Encode(&w, ProtocolVersionTLV); err != nil {
 		return nil, err
 	}
 

--- a/lnwire/closing_signed.go
+++ b/lnwire/closing_signed.go
@@ -27,6 +27,11 @@ type ClosingSigned struct {
 
 	// Signature is for the proposed channel close transaction.
 	Signature Sig
+
+	// ExtraData is the set of data that was appended to this message to
+	// fill out the full maximum transport message size. These fields can
+	// be used to specify optional data such as custom TLV fields.
+	ExtraData ExtraOpaqueData
 }
 
 // NewClosingSigned creates a new empty ClosingSigned message.
@@ -49,7 +54,9 @@ var _ Message = (*ClosingSigned)(nil)
 //
 // This is part of the lnwire.Message interface.
 func (c *ClosingSigned) Decode(r io.Reader, pver uint32) error {
-	return ReadElements(r, &c.ChannelID, &c.FeeSatoshis, &c.Signature)
+	return ReadElements(
+		r, &c.ChannelID, &c.FeeSatoshis, &c.Signature, &c.ExtraData,
+	)
 }
 
 // Encode serializes the target ClosingSigned into the passed io.Writer
@@ -57,7 +64,9 @@ func (c *ClosingSigned) Decode(r io.Reader, pver uint32) error {
 //
 // This is part of the lnwire.Message interface.
 func (c *ClosingSigned) Encode(w io.Writer, pver uint32) error {
-	return WriteElements(w, c.ChannelID, c.FeeSatoshis, c.Signature)
+	return WriteElements(
+		w, c.ChannelID, c.FeeSatoshis, c.Signature, c.ExtraData,
+	)
 }
 
 // MsgType returns the integer uniquely identifying this message type on the
@@ -73,16 +82,5 @@ func (c *ClosingSigned) MsgType() MessageType {
 //
 // This is part of the lnwire.Message interface.
 func (c *ClosingSigned) MaxPayloadLength(uint32) uint32 {
-	var length uint32
-
-	// ChannelID - 32 bytes
-	length += 32
-
-	// FeeSatoshis - 8 bytes
-	length += 8
-
-	// Signature - 64 bytes
-	length += 64
-
-	return length
+	return MaxMsgBody
 }

--- a/lnwire/closing_signed.go
+++ b/lnwire/closing_signed.go
@@ -55,7 +55,8 @@ var _ Message = (*ClosingSigned)(nil)
 // This is part of the lnwire.Message interface.
 func (c *ClosingSigned) Decode(r io.Reader, pver uint32) error {
 	return ReadElements(
-		r, &c.ChannelID, &c.FeeSatoshis, &c.Signature, &c.ExtraData,
+		r, pver, &c.ChannelID, &c.FeeSatoshis, &c.Signature,
+		&c.ExtraData,
 	)
 }
 
@@ -65,7 +66,7 @@ func (c *ClosingSigned) Decode(r io.Reader, pver uint32) error {
 // This is part of the lnwire.Message interface.
 func (c *ClosingSigned) Encode(w io.Writer, pver uint32) error {
 	return WriteElements(
-		w, c.ChannelID, c.FeeSatoshis, c.Signature, c.ExtraData,
+		w, pver, c.ChannelID, c.FeeSatoshis, c.Signature, c.ExtraData,
 	)
 }
 

--- a/lnwire/commit_sig.go
+++ b/lnwire/commit_sig.go
@@ -34,11 +34,18 @@ type CommitSig struct {
 	// should be signed, for each incoming HTLC the HTLC timeout
 	// transaction should be signed.
 	HtlcSigs []Sig
+
+	// ExtraData is the set of data that was appended to this message to
+	// fill out the full maximum transport message size. These fields can
+	// be used to specify optional data such as custom TLV fields.
+	ExtraData ExtraOpaqueData
 }
 
 // NewCommitSig creates a new empty CommitSig message.
 func NewCommitSig() *CommitSig {
-	return &CommitSig{}
+	return &CommitSig{
+		ExtraData: make([]byte, 0),
+	}
 }
 
 // A compile time check to ensure CommitSig implements the lnwire.Message
@@ -54,6 +61,7 @@ func (c *CommitSig) Decode(r io.Reader, pver uint32) error {
 		&c.ChanID,
 		&c.CommitSig,
 		&c.HtlcSigs,
+		&c.ExtraData,
 	)
 }
 
@@ -66,6 +74,7 @@ func (c *CommitSig) Encode(w io.Writer, pver uint32) error {
 		c.ChanID,
 		c.CommitSig,
 		c.HtlcSigs,
+		c.ExtraData,
 	)
 }
 
@@ -82,8 +91,7 @@ func (c *CommitSig) MsgType() MessageType {
 //
 // This is part of the lnwire.Message interface.
 func (c *CommitSig) MaxPayloadLength(uint32) uint32 {
-	// 32 + 64 + 2 + max_allowed_htlcs
-	return MaxMessagePayload
+	return MaxMsgBody
 }
 
 // TargetChanID returns the channel id of the link for which this message is

--- a/lnwire/commit_sig.go
+++ b/lnwire/commit_sig.go
@@ -58,6 +58,7 @@ var _ Message = (*CommitSig)(nil)
 // This is part of the lnwire.Message interface.
 func (c *CommitSig) Decode(r io.Reader, pver uint32) error {
 	return ReadElements(r,
+		pver,
 		&c.ChanID,
 		&c.CommitSig,
 		&c.HtlcSigs,
@@ -71,6 +72,7 @@ func (c *CommitSig) Decode(r io.Reader, pver uint32) error {
 // This is part of the lnwire.Message interface.
 func (c *CommitSig) Encode(w io.Writer, pver uint32) error {
 	return WriteElements(w,
+		pver,
 		c.ChanID,
 		c.CommitSig,
 		c.HtlcSigs,

--- a/lnwire/error.go
+++ b/lnwire/error.go
@@ -123,8 +123,7 @@ func (c *Error) MsgType() MessageType {
 //
 // This is part of the lnwire.Message interface.
 func (c *Error) MaxPayloadLength(uint32) uint32 {
-	// 32 + 2 + 65501
-	return 65535
+	return MaxMsgBody
 }
 
 // isASCII is a helper method that checks whether all bytes in `data` would be

--- a/lnwire/error.go
+++ b/lnwire/error.go
@@ -94,6 +94,7 @@ func (c *Error) Error() string {
 // This is part of the lnwire.Message interface.
 func (c *Error) Decode(r io.Reader, pver uint32) error {
 	return ReadElements(r,
+		pver,
 		&c.ChanID,
 		&c.Data,
 	)
@@ -105,6 +106,7 @@ func (c *Error) Decode(r io.Reader, pver uint32) error {
 // This is part of the lnwire.Message interface.
 func (c *Error) Encode(w io.Writer, pver uint32) error {
 	return WriteElements(w,
+		pver,
 		c.ChanID,
 		c.Data,
 	)

--- a/lnwire/extra_bytes.go
+++ b/lnwire/extra_bytes.go
@@ -1,0 +1,84 @@
+package lnwire
+
+import (
+	"bytes"
+	"io"
+	"io/ioutil"
+
+	"github.com/lightningnetwork/lnd/tlv"
+)
+
+// ExtraOpaqueData is the set of data that was appended to this message, some
+// of which we may not actually know how to iterate or parse. By holding onto
+// this data, we ensure that we're able to properly validate the set of
+// signatures that cover these new fields, and ensure we're able to make
+// upgrades to the network in a forwards compatible manner.
+type ExtraOpaqueData []byte
+
+// Encode attempts to encode the raw extra bytes into the passed io.Writer.
+func (e *ExtraOpaqueData) Encode(w io.Writer) error {
+	eBytes := []byte((*e)[:])
+	if err := WriteElements(w, eBytes); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// Decode attempts to unpack the raw bytes encoded in the passed io.Reader as a
+// set of extra opaque data.
+func (e *ExtraOpaqueData) Decode(r io.Reader) error {
+	// First, we'll attempt to read a set of bytes contained within the
+	// passed io.Reader (if any exist).
+	rawBytes, err := ioutil.ReadAll(r)
+	if err != nil {
+		return err
+	}
+
+	// If we _do_ have some bytes, then we'll swap out our backing pointer.
+	// This ensures that any struct that embeds this type will properly
+	// store the bytes once this method exits.
+	if len(rawBytes) > 0 {
+		*e = ExtraOpaqueData(rawBytes)
+	} else {
+		*e = make([]byte, 0)
+	}
+
+	return nil
+}
+
+// PackRecords attempts to encode the set of tlv records into the target
+// ExtraOpaqueData instance. The records will be encoded as a raw TLV stream
+// and stored within the backing slice pointer.
+func (e *ExtraOpaqueData) PackRecords(records []tlv.Record) error {
+	tlvStream, err := tlv.NewStream(records...)
+	if err != nil {
+		return err
+	}
+
+	var extraBytesWriter bytes.Buffer
+	if err := tlvStream.Encode(&extraBytesWriter); err != nil {
+		return err
+	}
+
+	*e = ExtraOpaqueData(extraBytesWriter.Bytes())
+
+	return nil
+}
+
+// ExtractRecords attempts to decode any types in the internal raw bytes as if
+// it were a tlv stream. The set of raw parsed types is returned, and any
+// passed records (if found in the stream) will be parsed into the proper
+// tlv.Record.
+func (e *ExtraOpaqueData) ExtractRecords(records ...tlv.Record) (
+	tlv.TypeMap, error) {
+
+	extraBytesReader := bytes.NewReader(*e)
+
+	tlvStream, err := tlv.NewStream(records...)
+	if err != nil {
+		return nil, err
+	}
+
+	return tlvStream.DecodeWithParsedTypes(extraBytesReader)
+}

--- a/lnwire/extra_bytes_test.go
+++ b/lnwire/extra_bytes_test.go
@@ -1,0 +1,147 @@
+package lnwire
+
+import (
+	"bytes"
+	"math/rand"
+	"reflect"
+	"testing"
+	"testing/quick"
+
+	"github.com/lightningnetwork/lnd/tlv"
+)
+
+// TestExtraOpaqueDataEncodeDecode tests that we're able to encode/decode
+// arbitrary payloads.
+func TestExtraOpaqueDataEncodeDecode(t *testing.T) {
+	t.Parallel()
+
+	type testCase struct {
+		// emptyBytes indicates if we should try to encode empty bytes
+		// or not.
+		emptyBytes bool
+
+		// inputBytes if emptyBytes is false, then we'll read in this
+		// set of bytes instead.
+		inputBytes []byte
+	}
+
+	// We should be able to read in an arbitrary set of bytes as an
+	// ExtraOpaqueData, then encode those new bytes into a new instance.
+	// The final two instances should be identical.
+	scenario := func(test testCase) bool {
+		var (
+			extraData ExtraOpaqueData
+			b         bytes.Buffer
+		)
+
+		copy(extraData[:], test.inputBytes)
+
+		if err := extraData.Encode(&b); err != nil {
+			t.Fatalf("unable to encode extra data: %v", err)
+			return false
+		}
+
+		var newBytes ExtraOpaqueData
+		if err := newBytes.Decode(&b); err != nil {
+			t.Fatalf("unable to decode extra bytes: %v", err)
+			return false
+		}
+
+		if !bytes.Equal(extraData[:], newBytes[:]) {
+			t.Fatalf("expected %x, got %x", extraData,
+				newBytes)
+			return false
+		}
+
+		return true
+	}
+
+	// We'll make a function to generate random test data. Half of the
+	// time, we'll actually feed in blank bytes.
+	quickCfg := &quick.Config{
+		Values: func(v []reflect.Value, r *rand.Rand) {
+
+			var newTestCase testCase
+			if r.Int31()%2 == 0 {
+				newTestCase.emptyBytes = true
+			}
+
+			if !newTestCase.emptyBytes {
+				numBytes := r.Int31n(1000)
+				newTestCase.inputBytes = make([]byte, numBytes)
+
+				_, err := r.Read(newTestCase.inputBytes)
+				if err != nil {
+					t.Fatalf("unable to gen random bytes: %v", err)
+					return
+				}
+			}
+
+			v[0] = reflect.ValueOf(newTestCase)
+		},
+	}
+
+	if err := quick.Check(scenario, quickCfg); err != nil {
+		t.Fatalf("encode+decode test failed: %v", err)
+	}
+}
+
+// TestExtraOpaqueDataPackUnpackRecords tests that we're able to pack a set of
+// tlv.Records into a stream, and unpack them on the other side to obtain the
+// same set of records.
+func TestExtraOpaqueDataPackUnpackRecords(t *testing.T) {
+	t.Parallel()
+
+	var (
+		type1 tlv.Type = 1
+		type2 tlv.Type = 2
+
+		channelType1 uint8 = 2
+		channelType2 uint8
+
+		hop1 uint32 = 99
+		hop2 uint32
+	)
+	testRecords := []tlv.Record{
+		tlv.MakePrimitiveRecord(type1, &channelType1),
+		tlv.MakePrimitiveRecord(type2, &hop1),
+	}
+
+	// Now that we have our set of sample records and types, we'll encode
+	// them into the passed ExtraOpaqueData instance.
+	var extraBytes ExtraOpaqueData
+	if err := extraBytes.PackRecords(testRecords); err != nil {
+		t.Fatalf("unable to pack records: %v", err)
+	}
+
+	// We'll now simulate decoding these types _back_ into records on the
+	// other side.
+	newRecords := []tlv.Record{
+		tlv.MakePrimitiveRecord(type1, &channelType2),
+		tlv.MakePrimitiveRecord(type2, &hop2),
+	}
+	typeMap, err := extraBytes.ExtractRecords(newRecords...)
+	if err != nil {
+		t.Fatalf("unable to extract record: %v", err)
+	}
+
+	// We should find that the new backing values have been populated with
+	// the proper value.
+	switch {
+	case channelType1 != channelType2:
+		t.Fatalf("wrong record for channel type: expected %v, got %v",
+			channelType1, channelType2)
+
+	case hop1 != hop2:
+		t.Fatalf("wrong record for hop: expected %v, got %v", hop1,
+			hop2)
+	}
+
+	// Both types we created above should be found in the type map.
+	if _, ok := typeMap[type1]; !ok {
+		t.Fatalf("type1 not found in typeMap")
+	}
+	if _, ok := typeMap[type2]; !ok {
+		t.Fatalf("type2 not found in typeMap")
+	}
+}

--- a/lnwire/funding_created.go
+++ b/lnwire/funding_created.go
@@ -24,6 +24,11 @@ type FundingCreated struct {
 	// CommitSig is Alice's signature from Bob's version of the commitment
 	// transaction.
 	CommitSig Sig
+
+	// ExtraData is the set of data that was appended to this message to
+	// fill out the full maximum transport message size. These fields can
+	// be used to specify optional data such as custom TLV fields.
+	ExtraData ExtraOpaqueData
 }
 
 // A compile time check to ensure FundingCreated implements the lnwire.Message
@@ -36,7 +41,10 @@ var _ Message = (*FundingCreated)(nil)
 //
 // This is part of the lnwire.Message interface.
 func (f *FundingCreated) Encode(w io.Writer, pver uint32) error {
-	return WriteElements(w, f.PendingChannelID[:], f.FundingPoint, f.CommitSig)
+	return WriteElements(
+		w, f.PendingChannelID[:], f.FundingPoint, f.CommitSig,
+		f.ExtraData,
+	)
 }
 
 // Decode deserializes the serialized FundingCreated stored in the passed
@@ -45,7 +53,10 @@ func (f *FundingCreated) Encode(w io.Writer, pver uint32) error {
 //
 // This is part of the lnwire.Message interface.
 func (f *FundingCreated) Decode(r io.Reader, pver uint32) error {
-	return ReadElements(r, f.PendingChannelID[:], &f.FundingPoint, &f.CommitSig)
+	return ReadElements(
+		r, f.PendingChannelID[:], &f.FundingPoint, &f.CommitSig,
+		&f.ExtraData,
+	)
 }
 
 // MsgType returns the uint32 code which uniquely identifies this message as a
@@ -61,6 +72,5 @@ func (f *FundingCreated) MsgType() MessageType {
 //
 // This is part of the lnwire.Message interface.
 func (f *FundingCreated) MaxPayloadLength(uint32) uint32 {
-	// 32 + 32 + 2 + 64
-	return 130
+	return MaxMsgBody
 }

--- a/lnwire/funding_created.go
+++ b/lnwire/funding_created.go
@@ -42,7 +42,7 @@ var _ Message = (*FundingCreated)(nil)
 // This is part of the lnwire.Message interface.
 func (f *FundingCreated) Encode(w io.Writer, pver uint32) error {
 	return WriteElements(
-		w, f.PendingChannelID[:], f.FundingPoint, f.CommitSig,
+		w, pver, f.PendingChannelID[:], f.FundingPoint, f.CommitSig,
 		f.ExtraData,
 	)
 }
@@ -54,7 +54,7 @@ func (f *FundingCreated) Encode(w io.Writer, pver uint32) error {
 // This is part of the lnwire.Message interface.
 func (f *FundingCreated) Decode(r io.Reader, pver uint32) error {
 	return ReadElements(
-		r, f.PendingChannelID[:], &f.FundingPoint, &f.CommitSig,
+		r, pver, f.PendingChannelID[:], &f.FundingPoint, &f.CommitSig,
 		&f.ExtraData,
 	)
 }

--- a/lnwire/funding_locked.go
+++ b/lnwire/funding_locked.go
@@ -19,6 +19,11 @@ type FundingLocked struct {
 	// NextPerCommitmentPoint is the secret that can be used to revoke the
 	// next commitment transaction for the channel.
 	NextPerCommitmentPoint *btcec.PublicKey
+
+	// ExtraData is the set of data that was appended to this message to
+	// fill out the full maximum transport message size. These fields can
+	// be used to specify optional data such as custom TLV fields.
+	ExtraData ExtraOpaqueData
 }
 
 // NewFundingLocked creates a new FundingLocked message, populating it with the
@@ -27,6 +32,7 @@ func NewFundingLocked(cid ChannelID, npcp *btcec.PublicKey) *FundingLocked {
 	return &FundingLocked{
 		ChanID:                 cid,
 		NextPerCommitmentPoint: npcp,
+		ExtraData:              make([]byte, 0),
 	}
 }
 
@@ -42,7 +48,9 @@ var _ Message = (*FundingLocked)(nil)
 func (c *FundingLocked) Decode(r io.Reader, pver uint32) error {
 	return ReadElements(r,
 		&c.ChanID,
-		&c.NextPerCommitmentPoint)
+		&c.NextPerCommitmentPoint,
+		&c.ExtraData,
+	)
 }
 
 // Encode serializes the target FundingLocked message into the passed io.Writer
@@ -53,7 +61,9 @@ func (c *FundingLocked) Decode(r io.Reader, pver uint32) error {
 func (c *FundingLocked) Encode(w io.Writer, pver uint32) error {
 	return WriteElements(w,
 		c.ChanID,
-		c.NextPerCommitmentPoint)
+		c.NextPerCommitmentPoint,
+		c.ExtraData,
+	)
 }
 
 // MsgType returns the uint32 code which uniquely identifies this message as a
@@ -70,14 +80,5 @@ func (c *FundingLocked) MsgType() MessageType {
 //
 // This is part of the lnwire.Message interface.
 func (c *FundingLocked) MaxPayloadLength(uint32) uint32 {
-	var length uint32
-
-	// ChanID - 32 bytes
-	length += 32
-
-	// NextPerCommitmentPoint - 33 bytes
-	length += 33
-
-	// 65 bytes
-	return length
+	return MaxMsgBody
 }

--- a/lnwire/funding_locked.go
+++ b/lnwire/funding_locked.go
@@ -47,6 +47,7 @@ var _ Message = (*FundingLocked)(nil)
 // This is part of the lnwire.Message interface.
 func (c *FundingLocked) Decode(r io.Reader, pver uint32) error {
 	return ReadElements(r,
+		pver,
 		&c.ChanID,
 		&c.NextPerCommitmentPoint,
 		&c.ExtraData,
@@ -60,6 +61,7 @@ func (c *FundingLocked) Decode(r io.Reader, pver uint32) error {
 // This is part of the lnwire.Message interface.
 func (c *FundingLocked) Encode(w io.Writer, pver uint32) error {
 	return WriteElements(w,
+		pver,
 		c.ChanID,
 		c.NextPerCommitmentPoint,
 		c.ExtraData,

--- a/lnwire/funding_signed.go
+++ b/lnwire/funding_signed.go
@@ -13,6 +13,11 @@ type FundingSigned struct {
 	// CommitSig is Bob's signature for Alice's version of the commitment
 	// transaction.
 	CommitSig Sig
+
+	// ExtraData is the set of data that was appended to this message to
+	// fill out the full maximum transport message size. These fields can
+	// be used to specify optional data such as custom TLV fields.
+	ExtraData ExtraOpaqueData
 }
 
 // A compile time check to ensure FundingSigned implements the lnwire.Message
@@ -25,7 +30,7 @@ var _ Message = (*FundingSigned)(nil)
 //
 // This is part of the lnwire.Message interface.
 func (f *FundingSigned) Encode(w io.Writer, pver uint32) error {
-	return WriteElements(w, f.ChanID, f.CommitSig)
+	return WriteElements(w, f.ChanID, f.CommitSig, f.ExtraData)
 }
 
 // Decode deserializes the serialized FundingSigned stored in the passed
@@ -34,7 +39,7 @@ func (f *FundingSigned) Encode(w io.Writer, pver uint32) error {
 //
 // This is part of the lnwire.Message interface.
 func (f *FundingSigned) Decode(r io.Reader, pver uint32) error {
-	return ReadElements(r, &f.ChanID, &f.CommitSig)
+	return ReadElements(r, &f.ChanID, &f.CommitSig, &f.ExtraData)
 }
 
 // MsgType returns the uint32 code which uniquely identifies this message as a
@@ -50,6 +55,5 @@ func (f *FundingSigned) MsgType() MessageType {
 //
 // This is part of the lnwire.Message interface.
 func (f *FundingSigned) MaxPayloadLength(uint32) uint32 {
-	// 32 + 64
-	return 96
+	return MaxMsgBody
 }

--- a/lnwire/funding_signed.go
+++ b/lnwire/funding_signed.go
@@ -30,7 +30,7 @@ var _ Message = (*FundingSigned)(nil)
 //
 // This is part of the lnwire.Message interface.
 func (f *FundingSigned) Encode(w io.Writer, pver uint32) error {
-	return WriteElements(w, f.ChanID, f.CommitSig, f.ExtraData)
+	return WriteElements(w, pver, f.ChanID, f.CommitSig, f.ExtraData)
 }
 
 // Decode deserializes the serialized FundingSigned stored in the passed
@@ -39,7 +39,7 @@ func (f *FundingSigned) Encode(w io.Writer, pver uint32) error {
 //
 // This is part of the lnwire.Message interface.
 func (f *FundingSigned) Decode(r io.Reader, pver uint32) error {
-	return ReadElements(r, &f.ChanID, &f.CommitSig, &f.ExtraData)
+	return ReadElements(r, pver, &f.ChanID, &f.CommitSig, &f.ExtraData)
 }
 
 // MsgType returns the uint32 code which uniquely identifies this message as a

--- a/lnwire/gossip_timestamp_range.go
+++ b/lnwire/gossip_timestamp_range.go
@@ -24,6 +24,11 @@ type GossipTimestampRange struct {
 	// NOT send any announcements that have a timestamp greater than
 	// FirstTimestamp + TimestampRange.
 	TimestampRange uint32
+
+	// ExtraData is the set of data that was appended to this message to
+	// fill out the full maximum transport message size. These fields can
+	// be used to specify optional data such as custom TLV fields.
+	ExtraData ExtraOpaqueData
 }
 
 // NewGossipTimestampRange creates a new empty GossipTimestampRange message.
@@ -44,6 +49,7 @@ func (g *GossipTimestampRange) Decode(r io.Reader, pver uint32) error {
 		g.ChainHash[:],
 		&g.FirstTimestamp,
 		&g.TimestampRange,
+		&g.ExtraData,
 	)
 }
 
@@ -56,6 +62,7 @@ func (g *GossipTimestampRange) Encode(w io.Writer, pver uint32) error {
 		g.ChainHash[:],
 		g.FirstTimestamp,
 		g.TimestampRange,
+		g.ExtraData,
 	)
 }
 
@@ -73,8 +80,5 @@ func (g *GossipTimestampRange) MsgType() MessageType {
 //
 // This is part of the lnwire.Message interface.
 func (g *GossipTimestampRange) MaxPayloadLength(uint32) uint32 {
-	// 32 + 4 + 4
-	//
-	// TODO(roasbeef): update to 8 byte timestmaps?
-	return 40
+	return MaxMsgBody
 }

--- a/lnwire/gossip_timestamp_range.go
+++ b/lnwire/gossip_timestamp_range.go
@@ -46,6 +46,7 @@ var _ Message = (*GossipTimestampRange)(nil)
 // This is part of the lnwire.Message interface.
 func (g *GossipTimestampRange) Decode(r io.Reader, pver uint32) error {
 	return ReadElements(r,
+		pver,
 		g.ChainHash[:],
 		&g.FirstTimestamp,
 		&g.TimestampRange,
@@ -59,6 +60,7 @@ func (g *GossipTimestampRange) Decode(r io.Reader, pver uint32) error {
 // This is part of the lnwire.Message interface.
 func (g *GossipTimestampRange) Encode(w io.Writer, pver uint32) error {
 	return WriteElements(w,
+		pver,
 		g.ChainHash[:],
 		g.FirstTimestamp,
 		g.TimestampRange,

--- a/lnwire/init_message.go
+++ b/lnwire/init_message.go
@@ -20,6 +20,11 @@ type Init struct {
 	// message, any GlobalFeatures should be merged into the unified
 	// Features field.
 	Features *RawFeatureVector
+
+	// ExtraData is the set of data that was appended to this message to
+	// fill out the full maximum transport message size. These fields can
+	// be used to specify optional data such as custom TLV fields.
+	ExtraData ExtraOpaqueData
 }
 
 // NewInitMessage creates new instance of init message object.
@@ -27,6 +32,7 @@ func NewInitMessage(gf *RawFeatureVector, f *RawFeatureVector) *Init {
 	return &Init{
 		GlobalFeatures: gf,
 		Features:       f,
+		ExtraData:      make([]byte, 0),
 	}
 }
 
@@ -42,6 +48,7 @@ func (msg *Init) Decode(r io.Reader, pver uint32) error {
 	return ReadElements(r,
 		&msg.GlobalFeatures,
 		&msg.Features,
+		&msg.ExtraData,
 	)
 }
 
@@ -53,6 +60,7 @@ func (msg *Init) Encode(w io.Writer, pver uint32) error {
 	return WriteElements(w,
 		msg.GlobalFeatures,
 		msg.Features,
+		msg.ExtraData,
 	)
 }
 
@@ -69,5 +77,5 @@ func (msg *Init) MsgType() MessageType {
 //
 // This is part of the lnwire.Message interface.
 func (msg *Init) MaxPayloadLength(uint32) uint32 {
-	return 2 + 2 + maxAllowedSize + 2 + maxAllowedSize
+	return MaxMsgBody
 }

--- a/lnwire/init_message.go
+++ b/lnwire/init_message.go
@@ -46,6 +46,7 @@ var _ Message = (*Init)(nil)
 // This is part of the lnwire.Message interface.
 func (msg *Init) Decode(r io.Reader, pver uint32) error {
 	return ReadElements(r,
+		pver,
 		&msg.GlobalFeatures,
 		&msg.Features,
 		&msg.ExtraData,
@@ -58,6 +59,7 @@ func (msg *Init) Decode(r io.Reader, pver uint32) error {
 // This is part of the lnwire.Message interface.
 func (msg *Init) Encode(w io.Writer, pver uint32) error {
 	return WriteElements(w,
+		pver,
 		msg.GlobalFeatures,
 		msg.Features,
 		msg.ExtraData,

--- a/lnwire/lnwire.go
+++ b/lnwire/lnwire.go
@@ -18,9 +18,16 @@ import (
 	"github.com/lightningnetwork/lnd/tor"
 )
 
-// MaxSliceLength is the maximum allowed length for any opaque byte slices in
-// the wire protocol.
-const MaxSliceLength = 65535
+const (
+	// MaxSliceLength is the maximum allowed length for any opaque byte
+	// slices in the wire protocol.
+	MaxSliceLength = 65535
+
+	// MaxMsgBody is the largest payload any message is allowed to provide.
+	// This is two less than the MaxSliceLength as each message has a 2
+	// byte type that precedes the message body.
+	MaxMsgBody = 65533
+)
 
 // PkScript is simple type definition which represents a raw serialized public
 // key script.
@@ -418,6 +425,10 @@ func WriteElement(w io.Writer, element interface{}) error {
 		if _, err := w.Write(b[:]); err != nil {
 			return err
 		}
+
+	case ExtraOpaqueData:
+		return e.Encode(w)
+
 	default:
 		return fmt.Errorf("unknown type in WriteElement: %T", e)
 	}
@@ -824,6 +835,10 @@ func ReadElement(r io.Reader, element interface{}) error {
 			return err
 		}
 		*e = addrBytes[:length]
+
+	case *ExtraOpaqueData:
+		return e.Decode(r)
+
 	default:
 		return fmt.Errorf("unknown type in ReadElement: %T", e)
 	}

--- a/lnwire/lnwire.go
+++ b/lnwire/lnwire.go
@@ -429,6 +429,9 @@ func WriteElement(w io.Writer, element interface{}) error {
 	case ExtraOpaqueData:
 		return e.Encode(w)
 
+	case TypedDeliveryAddress:
+		return e.Encode(w)
+
 	default:
 		return fmt.Errorf("unknown type in WriteElement: %T", e)
 	}
@@ -837,6 +840,9 @@ func ReadElement(r io.Reader, element interface{}) error {
 		*e = addrBytes[:length]
 
 	case *ExtraOpaqueData:
+		return e.Decode(r)
+
+	case *TypedDeliveryAddress:
 		return e.Decode(r)
 
 	default:

--- a/lnwire/lnwire_test.go
+++ b/lnwire/lnwire_test.go
@@ -810,10 +810,8 @@ func TestLightningWireProtocol(t *testing.T) {
 		},
 		MsgReplyChannelRange: func(v []reflect.Value, r *rand.Rand) {
 			req := ReplyChannelRange{
-				QueryChannelRange: QueryChannelRange{
-					FirstBlockHeight: uint32(r.Int31()),
-					NumBlocks:        uint32(r.Int31()),
-				},
+				FirstBlockHeight: uint32(r.Int31()),
+				NumBlocks:        uint32(r.Int31()),
 			}
 
 			if _, err := rand.Read(req.ChainHash[:]); err != nil {

--- a/lnwire/lnwire_test.go
+++ b/lnwire/lnwire_test.go
@@ -67,10 +67,10 @@ func randRawKey() ([33]byte, error) {
 	return n, nil
 }
 
-func randDeliveryAddress(r *rand.Rand) (DeliveryAddress, error) {
+func randDeliveryAddress(r *rand.Rand) (TypedDeliveryAddress, error) {
 	// Generate size minimum one. Empty scripts should be tested specifically.
 	size := r.Intn(deliveryAddressMaxSize) + 1
-	da := DeliveryAddress(make([]byte, size))
+	da := TypedDeliveryAddress(make([]byte, size))
 
 	_, err := r.Read(da)
 	return da, err

--- a/lnwire/lnwire_test.go
+++ b/lnwire/lnwire_test.go
@@ -232,7 +232,7 @@ func TestMaxOutPointIndex(t *testing.T) {
 	}
 
 	var b bytes.Buffer
-	if err := WriteElement(&b, op); err == nil {
+	if err := WriteElement(&b, ProtocolVersionTLV, op); err == nil {
 		t.Fatalf("write of outPoint should fail, index exceeds 16-bits")
 	}
 }
@@ -265,7 +265,8 @@ func TestLightningWireProtocol(t *testing.T) {
 		// Give a new message, we'll serialize the message into a new
 		// bytes buffer.
 		var b bytes.Buffer
-		if _, err := WriteMessage(&b, msg, 0); err != nil {
+		_, err := WriteMessage(&b, msg, ProtocolVersionTLV)
+		if err != nil {
 			t.Fatalf("unable to write msg: %v", err)
 			return false
 		}
@@ -282,7 +283,7 @@ func TestLightningWireProtocol(t *testing.T) {
 
 		// Finally, we'll deserialize the message from the written
 		// buffer, and finally assert that the messages are equal.
-		newMsg, err := ReadMessage(&b, 0)
+		newMsg, err := ReadMessage(&b, ProtocolVersionTLV)
 		if err != nil {
 			t.Fatalf("unable to read msg: %v", err)
 			return false

--- a/lnwire/lnwire_test.go
+++ b/lnwire/lnwire_test.go
@@ -321,6 +321,7 @@ func TestLightningWireProtocol(t *testing.T) {
 				CsvDelay:         uint16(r.Int31()),
 				MaxAcceptedHTLCs: uint16(r.Int31()),
 				ChannelFlags:     FundingFlag(uint8(r.Int31())),
+				ExtraData:        make([]byte, 0),
 			}
 
 			if _, err := r.Read(req.ChainHash[:]); err != nil {
@@ -387,6 +388,7 @@ func TestLightningWireProtocol(t *testing.T) {
 				HtlcMinimum:      MilliSatoshi(r.Int31()),
 				CsvDelay:         uint16(r.Int31()),
 				MaxAcceptedHTLCs: uint16(r.Int31()),
+				ExtraData:        make([]byte, 0),
 			}
 
 			if _, err := r.Read(req.PendingChannelID[:]); err != nil {
@@ -440,7 +442,9 @@ func TestLightningWireProtocol(t *testing.T) {
 			v[0] = reflect.ValueOf(req)
 		},
 		MsgFundingCreated: func(v []reflect.Value, r *rand.Rand) {
-			req := FundingCreated{}
+			req := FundingCreated{
+				ExtraData: make([]byte, 0),
+			}
 
 			if _, err := r.Read(req.PendingChannelID[:]); err != nil {
 				t.Fatalf("unable to generate pending chan id: %v", err)
@@ -471,7 +475,8 @@ func TestLightningWireProtocol(t *testing.T) {
 			}
 
 			req := FundingSigned{
-				ChanID: ChannelID(c),
+				ChanID:    ChannelID(c),
+				ExtraData: make([]byte, 0),
 			}
 			req.CommitSig, err = NewSigFromSignature(testSig)
 			if err != nil {
@@ -502,6 +507,7 @@ func TestLightningWireProtocol(t *testing.T) {
 		MsgClosingSigned: func(v []reflect.Value, r *rand.Rand) {
 			req := ClosingSigned{
 				FeeSatoshis: btcutil.Amount(r.Int63()),
+				ExtraData:   make([]byte, 0),
 			}
 			var err error
 			req.Signature, err = NewSigFromSignature(testSig)
@@ -570,8 +576,9 @@ func TestLightningWireProtocol(t *testing.T) {
 		MsgChannelAnnouncement: func(v []reflect.Value, r *rand.Rand) {
 			var err error
 			req := ChannelAnnouncement{
-				ShortChannelID: NewShortChanIDFromInt(uint64(r.Int63())),
-				Features:       randRawFeatureVector(r),
+				ShortChannelID:  NewShortChanIDFromInt(uint64(r.Int63())),
+				Features:        randRawFeatureVector(r),
+				ExtraOpaqueData: make([]byte, 0),
 			}
 			req.NodeSig1, err = NewSigFromSignature(testSig)
 			if err != nil {
@@ -643,6 +650,7 @@ func TestLightningWireProtocol(t *testing.T) {
 					G: uint8(r.Int31()),
 					B: uint8(r.Int31()),
 				},
+				ExtraOpaqueData: make([]byte, 0),
 			}
 			req.Signature, err = NewSigFromSignature(testSig)
 			if err != nil {
@@ -698,6 +706,7 @@ func TestLightningWireProtocol(t *testing.T) {
 				HtlcMaximumMsat: maxHtlc,
 				BaseFee:         uint32(r.Int31()),
 				FeeRate:         uint32(r.Int31()),
+				ExtraOpaqueData: make([]byte, 0),
 			}
 			req.Signature, err = NewSigFromSignature(testSig)
 			if err != nil {
@@ -726,7 +735,8 @@ func TestLightningWireProtocol(t *testing.T) {
 		MsgAnnounceSignatures: func(v []reflect.Value, r *rand.Rand) {
 			var err error
 			req := AnnounceSignatures{
-				ShortChannelID: NewShortChanIDFromInt(uint64(r.Int63())),
+				ShortChannelID:  NewShortChanIDFromInt(uint64(r.Int63())),
+				ExtraOpaqueData: make([]byte, 0),
 			}
 
 			req.NodeSignature, err = NewSigFromSignature(testSig)
@@ -763,6 +773,7 @@ func TestLightningWireProtocol(t *testing.T) {
 			req := ChannelReestablish{
 				NextLocalCommitHeight:  uint64(r.Int63()),
 				RemoteCommitTailHeight: uint64(r.Int63()),
+				ExtraData:              make([]byte, 0),
 			}
 
 			// With a 50/50 probability, we'll include the
@@ -785,7 +796,9 @@ func TestLightningWireProtocol(t *testing.T) {
 			v[0] = reflect.ValueOf(req)
 		},
 		MsgQueryShortChanIDs: func(v []reflect.Value, r *rand.Rand) {
-			req := QueryShortChanIDs{}
+			req := QueryShortChanIDs{
+				ExtraData: make([]byte, 0),
+			}
 
 			// With a 50/50 change, we'll either use zlib encoding,
 			// or regular encoding.
@@ -812,6 +825,7 @@ func TestLightningWireProtocol(t *testing.T) {
 			req := ReplyChannelRange{
 				FirstBlockHeight: uint32(r.Int31()),
 				NumBlocks:        uint32(r.Int31()),
+				ExtraData:        make([]byte, 0),
 			}
 
 			if _, err := rand.Read(req.ChainHash[:]); err != nil {

--- a/lnwire/message.go
+++ b/lnwire/message.go
@@ -56,6 +56,20 @@ const (
 	MsgGossipTimestampRange                = 265
 )
 
+const (
+	// ProtocolVersionLegacy is the legacy protocol version. When reading
+	// or writing messages using this protocol version, any optional fields
+	// appended to the end of the message will be ignored.
+	ProtocolVersionLegacy uint32 = 0
+
+	// ProtocolVersionTLV is the current modern protocol version. When
+	// reading/writing messages with this version, decoding will continue
+	// until the entire payload has been ready. When writing with this
+	// version, any optional fields appended to the end of the main message
+	// will also be written out.
+	ProtocolVersionTLV uint32 = 1
+)
+
 // String return the string representation of message type.
 func (t MessageType) String() string {
 	switch t {

--- a/lnwire/node_announcement.go
+++ b/lnwire/node_announcement.go
@@ -110,6 +110,7 @@ var _ Message = (*NodeAnnouncement)(nil)
 // This is part of the lnwire.Message interface.
 func (a *NodeAnnouncement) Decode(r io.Reader, pver uint32) error {
 	return ReadElements(r,
+		pver,
 		&a.Signature,
 		&a.Features,
 		&a.Timestamp,
@@ -126,6 +127,7 @@ func (a *NodeAnnouncement) Decode(r io.Reader, pver uint32) error {
 //
 func (a *NodeAnnouncement) Encode(w io.Writer, pver uint32) error {
 	return WriteElements(w,
+		pver,
 		a.Signature,
 		a.Features,
 		a.Timestamp,
@@ -159,6 +161,9 @@ func (a *NodeAnnouncement) DataToSign() ([]byte, error) {
 	// We should not include the signatures itself.
 	var w bytes.Buffer
 	err := WriteElements(&w,
+		// We always use the modern protocol version as we need to
+		// include all data for forawrds compatability.
+		ProtocolVersionTLV,
 		a.Features,
 		a.Timestamp,
 		a.NodeID,

--- a/lnwire/onion_error.go
+++ b/lnwire/onion_error.go
@@ -389,7 +389,7 @@ func (f *FailIncorrectDetails) Error() string {
 //
 // NOTE: Part of the Serializable interface.
 func (f *FailIncorrectDetails) Decode(r io.Reader, pver uint32) error {
-	err := ReadElement(r, &f.amount)
+	err := ReadElement(r, pver, &f.amount)
 	switch {
 	// This is an optional tack on that was added later in the protocol. As
 	// a result, older nodes may not include this value. We'll account for
@@ -404,7 +404,7 @@ func (f *FailIncorrectDetails) Decode(r io.Reader, pver uint32) error {
 
 	// At a later stage, the height field was also tacked on. We need to
 	// check for io.EOF here as well.
-	err = ReadElement(r, &f.height)
+	err = ReadElement(r, pver, &f.height)
 	switch {
 	case err == io.EOF:
 		return nil
@@ -420,7 +420,7 @@ func (f *FailIncorrectDetails) Decode(r io.Reader, pver uint32) error {
 //
 // NOTE: Part of the Serializable interface.
 func (f *FailIncorrectDetails) Encode(w io.Writer, pver uint32) error {
-	return WriteElements(w, f.amount, f.height)
+	return WriteElements(w, pver, f.amount, f.height)
 }
 
 // FailFinalExpiryTooSoon is returned if the cltv_expiry is too low, the final
@@ -479,14 +479,14 @@ func (f *FailInvalidOnionVersion) Code() FailCode {
 //
 // NOTE: Part of the Serializable interface.
 func (f *FailInvalidOnionVersion) Decode(r io.Reader, pver uint32) error {
-	return ReadElement(r, f.OnionSHA256[:])
+	return ReadElement(r, pver, f.OnionSHA256[:])
 }
 
 // Encode writes the failure in bytes stream.
 //
 // NOTE: Part of the Serializable interface.
 func (f *FailInvalidOnionVersion) Encode(w io.Writer, pver uint32) error {
-	return WriteElement(w, f.OnionSHA256[:])
+	return WriteElement(w, pver, f.OnionSHA256[:])
 }
 
 // FailInvalidOnionHmac is return if the onion HMAC is incorrect.
@@ -513,14 +513,14 @@ func (f *FailInvalidOnionHmac) Code() FailCode {
 //
 // NOTE: Part of the Serializable interface.
 func (f *FailInvalidOnionHmac) Decode(r io.Reader, pver uint32) error {
-	return ReadElement(r, f.OnionSHA256[:])
+	return ReadElement(r, pver, f.OnionSHA256[:])
 }
 
 // Encode writes the failure in bytes stream.
 //
 // NOTE: Part of the Serializable interface.
 func (f *FailInvalidOnionHmac) Encode(w io.Writer, pver uint32) error {
-	return WriteElement(w, f.OnionSHA256[:])
+	return WriteElement(w, pver, f.OnionSHA256[:])
 }
 
 // Returns a human readable string describing the target FailureMessage.
@@ -555,14 +555,14 @@ func (f *FailInvalidOnionKey) Code() FailCode {
 //
 // NOTE: Part of the Serializable interface.
 func (f *FailInvalidOnionKey) Decode(r io.Reader, pver uint32) error {
-	return ReadElement(r, f.OnionSHA256[:])
+	return ReadElement(r, pver, f.OnionSHA256[:])
 }
 
 // Encode writes the failure in bytes stream.
 //
 // NOTE: Part of the Serializable interface.
 func (f *FailInvalidOnionKey) Encode(w io.Writer, pver uint32) error {
-	return WriteElement(w, f.OnionSHA256[:])
+	return WriteElement(w, pver, f.OnionSHA256[:])
 }
 
 // Returns a human readable string describing the target FailureMessage.
@@ -652,7 +652,7 @@ func (f *FailTemporaryChannelFailure) Error() string {
 // NOTE: Part of the Serializable interface.
 func (f *FailTemporaryChannelFailure) Decode(r io.Reader, pver uint32) error {
 	var length uint16
-	err := ReadElement(r, &length)
+	err := ReadElement(r, pver, &length)
 	if err != nil {
 		return err
 	}
@@ -680,7 +680,7 @@ func (f *FailTemporaryChannelFailure) Encode(w io.Writer, pver uint32) error {
 		payload = bw.Bytes()
 	}
 
-	if err := WriteElement(w, uint16(len(payload))); err != nil {
+	if err := WriteElement(w, pver, uint16(len(payload))); err != nil {
 		return err
 	}
 
@@ -731,12 +731,12 @@ func (f *FailAmountBelowMinimum) Error() string {
 //
 // NOTE: Part of the Serializable interface.
 func (f *FailAmountBelowMinimum) Decode(r io.Reader, pver uint32) error {
-	if err := ReadElement(r, &f.HtlcMsat); err != nil {
+	if err := ReadElement(r, pver, &f.HtlcMsat); err != nil {
 		return err
 	}
 
 	var length uint16
-	if err := ReadElement(r, &length); err != nil {
+	if err := ReadElement(r, pver, &length); err != nil {
 		return err
 	}
 
@@ -750,7 +750,7 @@ func (f *FailAmountBelowMinimum) Decode(r io.Reader, pver uint32) error {
 //
 // NOTE: Part of the Serializable interface.
 func (f *FailAmountBelowMinimum) Encode(w io.Writer, pver uint32) error {
-	if err := WriteElement(w, f.HtlcMsat); err != nil {
+	if err := WriteElement(w, pver, f.HtlcMsat); err != nil {
 		return err
 	}
 
@@ -799,12 +799,12 @@ func (f *FailFeeInsufficient) Error() string {
 //
 // NOTE: Part of the Serializable interface.
 func (f *FailFeeInsufficient) Decode(r io.Reader, pver uint32) error {
-	if err := ReadElement(r, &f.HtlcMsat); err != nil {
+	if err := ReadElement(r, pver, &f.HtlcMsat); err != nil {
 		return err
 	}
 
 	var length uint16
-	if err := ReadElement(r, &length); err != nil {
+	if err := ReadElement(r, pver, &length); err != nil {
 		return err
 	}
 
@@ -818,7 +818,7 @@ func (f *FailFeeInsufficient) Decode(r io.Reader, pver uint32) error {
 //
 // NOTE: Part of the Serializable interface.
 func (f *FailFeeInsufficient) Encode(w io.Writer, pver uint32) error {
-	if err := WriteElement(w, f.HtlcMsat); err != nil {
+	if err := WriteElement(w, pver, f.HtlcMsat); err != nil {
 		return err
 	}
 
@@ -867,12 +867,12 @@ func (f *FailIncorrectCltvExpiry) Error() string {
 //
 // NOTE: Part of the Serializable interface.
 func (f *FailIncorrectCltvExpiry) Decode(r io.Reader, pver uint32) error {
-	if err := ReadElement(r, &f.CltvExpiry); err != nil {
+	if err := ReadElement(r, pver, &f.CltvExpiry); err != nil {
 		return err
 	}
 
 	var length uint16
-	if err := ReadElement(r, &length); err != nil {
+	if err := ReadElement(r, pver, &length); err != nil {
 		return err
 	}
 
@@ -886,7 +886,7 @@ func (f *FailIncorrectCltvExpiry) Decode(r io.Reader, pver uint32) error {
 //
 // NOTE: Part of the Serializable interface.
 func (f *FailIncorrectCltvExpiry) Encode(w io.Writer, pver uint32) error {
-	if err := WriteElement(w, f.CltvExpiry); err != nil {
+	if err := WriteElement(w, pver, f.CltvExpiry); err != nil {
 		return err
 	}
 
@@ -929,7 +929,7 @@ func (f *FailExpiryTooSoon) Error() string {
 // NOTE: Part of the Serializable interface.
 func (f *FailExpiryTooSoon) Decode(r io.Reader, pver uint32) error {
 	var length uint16
-	if err := ReadElement(r, &length); err != nil {
+	if err := ReadElement(r, pver, &length); err != nil {
 		return err
 	}
 
@@ -988,12 +988,12 @@ func (f *FailChannelDisabled) Error() string {
 //
 // NOTE: Part of the Serializable interface.
 func (f *FailChannelDisabled) Decode(r io.Reader, pver uint32) error {
-	if err := ReadElement(r, &f.Flags); err != nil {
+	if err := ReadElement(r, pver, &f.Flags); err != nil {
 		return err
 	}
 
 	var length uint16
-	if err := ReadElement(r, &length); err != nil {
+	if err := ReadElement(r, pver, &length); err != nil {
 		return err
 	}
 
@@ -1007,7 +1007,7 @@ func (f *FailChannelDisabled) Decode(r io.Reader, pver uint32) error {
 //
 // NOTE: Part of the Serializable interface.
 func (f *FailChannelDisabled) Encode(w io.Writer, pver uint32) error {
-	if err := WriteElement(w, f.Flags); err != nil {
+	if err := WriteElement(w, pver, f.Flags); err != nil {
 		return err
 	}
 
@@ -1050,14 +1050,14 @@ func (f *FailFinalIncorrectCltvExpiry) Code() FailCode {
 //
 // NOTE: Part of the Serializable interface.
 func (f *FailFinalIncorrectCltvExpiry) Decode(r io.Reader, pver uint32) error {
-	return ReadElement(r, &f.CltvExpiry)
+	return ReadElement(r, pver, &f.CltvExpiry)
 }
 
 // Encode writes the failure in bytes stream.
 //
 // NOTE: Part of the Serializable interface.
 func (f *FailFinalIncorrectCltvExpiry) Encode(w io.Writer, pver uint32) error {
-	return WriteElement(w, f.CltvExpiry)
+	return WriteElement(w, pver, f.CltvExpiry)
 }
 
 // FailFinalIncorrectHtlcAmount is returned if the amt_to_forward is higher
@@ -1096,14 +1096,14 @@ func (f *FailFinalIncorrectHtlcAmount) Code() FailCode {
 //
 // NOTE: Part of the Serializable interface.
 func (f *FailFinalIncorrectHtlcAmount) Decode(r io.Reader, pver uint32) error {
-	return ReadElement(r, &f.IncomingHTLCAmount)
+	return ReadElement(r, pver, &f.IncomingHTLCAmount)
 }
 
 // Encode writes the failure in bytes stream.
 //
 // NOTE: Part of the Serializable interface.
 func (f *FailFinalIncorrectHtlcAmount) Encode(w io.Writer, pver uint32) error {
-	return WriteElement(w, f.IncomingHTLCAmount)
+	return WriteElement(w, pver, f.IncomingHTLCAmount)
 }
 
 // FailExpiryTooFar is returned if the CLTV expiry in the HTLC is too far in the
@@ -1171,7 +1171,7 @@ func (f *InvalidOnionPayload) Decode(r io.Reader, pver uint32) error {
 	}
 	f.Type = typ
 
-	return ReadElements(r, &f.Offset)
+	return ReadElements(r, pver, &f.Offset)
 }
 
 // Encode writes the failure in bytes stream.
@@ -1183,7 +1183,7 @@ func (f *InvalidOnionPayload) Encode(w io.Writer, pver uint32) error {
 		return err
 	}
 
-	return WriteElements(w, f.Offset)
+	return WriteElements(w, pver, f.Offset)
 }
 
 // FailMPPTimeout is returned if the complete amount for a multi part payment
@@ -1212,7 +1212,7 @@ func DecodeFailure(r io.Reader, pver uint32) (FailureMessage, error) {
 	// First, we'll parse out the encapsulated failure message itself. This
 	// is a 2 byte length followed by the payload itself.
 	var failureLength uint16
-	if err := ReadElement(r, &failureLength); err != nil {
+	if err := ReadElement(r, pver, &failureLength); err != nil {
 		return nil, fmt.Errorf("unable to read error len: %v", err)
 	}
 	if failureLength > FailureMessageLength {
@@ -1284,6 +1284,7 @@ func EncodeFailure(w io.Writer, failure FailureMessage, pver uint32) error {
 	pad := make([]byte, FailureMessageLength-len(failureMessage))
 
 	return WriteElements(w,
+		pver,
 		uint16(len(failureMessage)),
 		failureMessage,
 		uint16(len(pad)),
@@ -1414,7 +1415,7 @@ func writeOnionErrorChanUpdate(w io.Writer, chanUpdate *ChannelUpdate,
 	// Now that we know the size, we can write the length out in the main
 	// writer.
 	updateLen := b.Len()
-	if err := WriteElement(w, uint16(updateLen)); err != nil {
+	if err := WriteElement(w, pver, uint16(updateLen)); err != nil {
 		return err
 	}
 

--- a/lnwire/onion_error_test.go
+++ b/lnwire/onion_error_test.go
@@ -20,11 +20,12 @@ var (
 	testOffset        = uint16(24)
 	sig, _            = NewSigFromSignature(testSig)
 	testChannelUpdate = ChannelUpdate{
-		Signature:      sig,
-		ShortChannelID: NewShortChanIDFromInt(1),
-		Timestamp:      1,
-		MessageFlags:   0,
-		ChannelFlags:   1,
+		Signature:       sig,
+		ShortChannelID:  NewShortChanIDFromInt(1),
+		Timestamp:       1,
+		MessageFlags:    0,
+		ChannelFlags:    1,
+		ExtraOpaqueData: make([]byte, 0),
 	}
 )
 

--- a/lnwire/onion_error_test.go
+++ b/lnwire/onion_error_test.go
@@ -63,12 +63,13 @@ func TestEncodeDecodeCode(t *testing.T) {
 	for _, failure1 := range onionFailures {
 		var b bytes.Buffer
 
-		if err := EncodeFailure(&b, failure1, 0); err != nil {
+		err := EncodeFailure(&b, failure1, ProtocolVersionTLV)
+		if err != nil {
 			t.Fatalf("unable to encode failure code(%v): %v",
 				failure1.Code(), err)
 		}
 
-		failure2, err := DecodeFailure(&b, 0)
+		failure2, err := DecodeFailure(&b, ProtocolVersionTLV)
 		if err != nil {
 			t.Fatalf("unable to decode failure code(%v): %v",
 				failure1.Code(), err)
@@ -90,7 +91,7 @@ func TestChannelUpdateCompatabilityParsing(t *testing.T) {
 	// We'll start by taking out test channel update, and encoding it into
 	// a set of raw bytes.
 	var b bytes.Buffer
-	if err := testChannelUpdate.Encode(&b, 0); err != nil {
+	if err := testChannelUpdate.Encode(&b, ProtocolVersionTLV); err != nil {
 		t.Fatalf("unable to encode chan update: %v", err)
 	}
 
@@ -99,7 +100,7 @@ func TestChannelUpdateCompatabilityParsing(t *testing.T) {
 	// encoded channel update message.
 	var newChanUpdate ChannelUpdate
 	err := parseChannelUpdateCompatabilityMode(
-		bufio.NewReader(&b), &newChanUpdate, 0,
+		bufio.NewReader(&b), &newChanUpdate, ProtocolVersionTLV,
 	)
 	if err != nil {
 		t.Fatalf("unable to parse channel update: %v", err)
@@ -120,7 +121,7 @@ func TestChannelUpdateCompatabilityParsing(t *testing.T) {
 	var tByte [2]byte
 	binary.BigEndian.PutUint16(tByte[:], MsgChannelUpdate)
 	b.Write(tByte[:])
-	if err := testChannelUpdate.Encode(&b, 0); err != nil {
+	if err := testChannelUpdate.Encode(&b, ProtocolVersionTLV); err != nil {
 		t.Fatalf("unable to encode chan update: %v", err)
 	}
 
@@ -128,7 +129,7 @@ func TestChannelUpdateCompatabilityParsing(t *testing.T) {
 	// message even with the extra two bytes.
 	var newChanUpdate2 ChannelUpdate
 	err = parseChannelUpdateCompatabilityMode(
-		bufio.NewReader(&b), &newChanUpdate2, 0,
+		bufio.NewReader(&b), &newChanUpdate2, ProtocolVersionTLV,
 	)
 	if err != nil {
 		t.Fatalf("unable to parse channel update: %v", err)
@@ -165,7 +166,7 @@ func TestWriteOnionErrorChanUpdate(t *testing.T) {
 	// Finally, read the length encoded and ensure that it matches the raw
 	// length.
 	var encodedLen uint16
-	if err := ReadElement(&errorBuf, &encodedLen); err != nil {
+	if err := ReadElement(&errorBuf, ProtocolVersionTLV, &encodedLen); err != nil {
 		t.Fatalf("unable to read len: %v", err)
 	}
 	if uint16(trueUpdateLength) != encodedLen {
@@ -276,5 +277,5 @@ func (f *mockFailIncorrectDetailsNoHeight) Decode(r io.Reader, pver uint32) erro
 }
 
 func (f *mockFailIncorrectDetailsNoHeight) Encode(w io.Writer, pver uint32) error {
-	return WriteElement(w, f.amount)
+	return WriteElement(w, ProtocolVersionTLV, f.amount)
 }

--- a/lnwire/open_channel.go
+++ b/lnwire/open_channel.go
@@ -146,6 +146,7 @@ var _ Message = (*OpenChannel)(nil)
 // This is part of the lnwire.Message interface.
 func (o *OpenChannel) Encode(w io.Writer, pver uint32) error {
 	return WriteElements(w,
+		pver,
 		o.ChainHash[:],
 		o.PendingChannelID[:],
 		o.FundingAmount,
@@ -176,6 +177,7 @@ func (o *OpenChannel) Encode(w io.Writer, pver uint32) error {
 // This is part of the lnwire.Message interface.
 func (o *OpenChannel) Decode(r io.Reader, pver uint32) error {
 	return ReadElements(r,
+		pver,
 		o.ChainHash[:],
 		o.PendingChannelID[:],
 		&o.FundingAmount,

--- a/lnwire/open_channel.go
+++ b/lnwire/open_channel.go
@@ -127,7 +127,7 @@ type OpenChannel struct {
 	// be paid when mutually closing the channel. This field is optional, and
 	// and has a length prefix, so a zero will be written if it is not set
 	// and its length followed by the script will be written if it is set.
-	UpfrontShutdownScript DeliveryAddress
+	UpfrontShutdownScript TypedDeliveryAddress
 
 	// ExtraData is the set of data that was appended to this message to
 	// fill out the full maximum transport message size. These fields can
@@ -175,7 +175,7 @@ func (o *OpenChannel) Encode(w io.Writer, pver uint32) error {
 //
 // This is part of the lnwire.Message interface.
 func (o *OpenChannel) Decode(r io.Reader, pver uint32) error {
-	if err := ReadElements(r,
+	return ReadElements(r,
 		o.ChainHash[:],
 		o.PendingChannelID[:],
 		&o.FundingAmount,
@@ -194,18 +194,9 @@ func (o *OpenChannel) Decode(r io.Reader, pver uint32) error {
 		&o.HtlcPoint,
 		&o.FirstCommitmentPoint,
 		&o.ChannelFlags,
-	); err != nil {
-		return err
-	}
-
-	// Check for the optional upfront shutdown script field. If it is not there,
-	// silence the EOF error.
-	err := ReadElement(r, &o.UpfrontShutdownScript)
-	if err != nil && err != io.EOF {
-		return err
-	}
-
-	return ReadElement(r, &o.ExtraData)
+		&o.UpfrontShutdownScript,
+		&o.ExtraData,
+	)
 }
 
 // MsgType returns the MessageType code which uniquely identifies this message

--- a/lnwire/ping.go
+++ b/lnwire/ping.go
@@ -36,6 +36,7 @@ var _ Message = (*Ping)(nil)
 // This is part of the lnwire.Message interface.
 func (p *Ping) Decode(r io.Reader, pver uint32) error {
 	return ReadElements(r,
+		pver,
 		&p.NumPongBytes,
 		&p.PaddingBytes)
 }
@@ -46,6 +47,7 @@ func (p *Ping) Decode(r io.Reader, pver uint32) error {
 // This is part of the lnwire.Message interface.
 func (p *Ping) Encode(w io.Writer, pver uint32) error {
 	return WriteElements(w,
+		pver,
 		p.NumPongBytes,
 		p.PaddingBytes)
 }

--- a/lnwire/pong.go
+++ b/lnwire/pong.go
@@ -32,7 +32,7 @@ var _ Message = (*Pong)(nil)
 // This is part of the lnwire.Message interface.
 func (p *Pong) Decode(r io.Reader, pver uint32) error {
 	return ReadElements(r,
-		&p.PongBytes,
+		pver, &p.PongBytes,
 	)
 }
 
@@ -42,7 +42,7 @@ func (p *Pong) Decode(r io.Reader, pver uint32) error {
 // This is part of the lnwire.Message interface.
 func (p *Pong) Encode(w io.Writer, pver uint32) error {
 	return WriteElements(w,
-		p.PongBytes,
+		pver, p.PongBytes,
 	)
 }
 

--- a/lnwire/query_channel_range.go
+++ b/lnwire/query_channel_range.go
@@ -25,6 +25,11 @@ type QueryChannelRange struct {
 	// NumBlocks is the number of blocks beyond the first block that short
 	// channel ID's should be sent for.
 	NumBlocks uint32
+
+	// ExtraData is the set of data that was appended to this message to
+	// fill out the full maximum transport message size. These fields can
+	// be used to specify optional data such as custom TLV fields.
+	ExtraData ExtraOpaqueData
 }
 
 // NewQueryChannelRange creates a new empty QueryChannelRange message.
@@ -45,6 +50,7 @@ func (q *QueryChannelRange) Decode(r io.Reader, pver uint32) error {
 		q.ChainHash[:],
 		&q.FirstBlockHeight,
 		&q.NumBlocks,
+		&q.ExtraData,
 	)
 }
 
@@ -57,6 +63,7 @@ func (q *QueryChannelRange) Encode(w io.Writer, pver uint32) error {
 		q.ChainHash[:],
 		q.FirstBlockHeight,
 		q.NumBlocks,
+		q.ExtraData,
 	)
 }
 
@@ -73,8 +80,7 @@ func (q *QueryChannelRange) MsgType() MessageType {
 //
 // This is part of the lnwire.Message interface.
 func (q *QueryChannelRange) MaxPayloadLength(uint32) uint32 {
-	// 32 + 4 + 4
-	return 40
+	return MaxMsgBody
 }
 
 // LastBlockHeight returns the last block height covered by the range of a

--- a/lnwire/query_channel_range.go
+++ b/lnwire/query_channel_range.go
@@ -47,6 +47,7 @@ var _ Message = (*QueryChannelRange)(nil)
 // This is part of the lnwire.Message interface.
 func (q *QueryChannelRange) Decode(r io.Reader, pver uint32) error {
 	return ReadElements(r,
+		pver,
 		q.ChainHash[:],
 		&q.FirstBlockHeight,
 		&q.NumBlocks,
@@ -60,6 +61,7 @@ func (q *QueryChannelRange) Decode(r io.Reader, pver uint32) error {
 // This is part of the lnwire.Message interface.
 func (q *QueryChannelRange) Encode(w io.Writer, pver uint32) error {
 	return WriteElements(w,
+		pver,
 		q.ChainHash[:],
 		q.FirstBlockHeight,
 		q.NumBlocks,

--- a/lnwire/reply_channel_range.go
+++ b/lnwire/reply_channel_range.go
@@ -64,6 +64,7 @@ var _ Message = (*ReplyChannelRange)(nil)
 // This is part of the lnwire.Message interface.
 func (c *ReplyChannelRange) Decode(r io.Reader, pver uint32) error {
 	err := ReadElements(r,
+		pver,
 		c.ChainHash[:],
 		&c.FirstBlockHeight,
 		&c.NumBlocks,
@@ -73,12 +74,12 @@ func (c *ReplyChannelRange) Decode(r io.Reader, pver uint32) error {
 		return err
 	}
 
-	c.EncodingType, c.ShortChanIDs, err = decodeShortChanIDs(r)
+	c.EncodingType, c.ShortChanIDs, err = decodeShortChanIDs(r, pver)
 	if err != nil {
 		return err
 	}
 
-	return c.ExtraData.Decode(r)
+	return c.ExtraData.Decode(r, pver)
 }
 
 // Encode serializes the target ReplyChannelRange into the passed io.Writer
@@ -87,6 +88,7 @@ func (c *ReplyChannelRange) Decode(r io.Reader, pver uint32) error {
 // This is part of the lnwire.Message interface.
 func (c *ReplyChannelRange) Encode(w io.Writer, pver uint32) error {
 	err := WriteElements(w,
+		pver,
 		c.ChainHash[:],
 		c.FirstBlockHeight,
 		c.NumBlocks,
@@ -96,12 +98,14 @@ func (c *ReplyChannelRange) Encode(w io.Writer, pver uint32) error {
 		return err
 	}
 
-	err = encodeShortChanIDs(w, c.EncodingType, c.ShortChanIDs, c.noSort)
+	err = encodeShortChanIDs(
+		w, c.EncodingType, c.ShortChanIDs, c.noSort, pver,
+	)
 	if err != nil {
 		return err
 	}
 
-	return c.ExtraData.Encode(w)
+	return c.ExtraData.Encode(w, pver)
 }
 
 // MsgType returns the integer uniquely identifying this message type on the

--- a/lnwire/reply_channel_range.go
+++ b/lnwire/reply_channel_range.go
@@ -1,14 +1,29 @@
 package lnwire
 
-import "io"
+import (
+	"io"
+	"math"
+
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
+)
 
 // ReplyChannelRange is the response to the QueryChannelRange message. It
 // includes the original query, and the next streaming chunk of encoded short
 // channel ID's as the response. We'll also include a byte that indicates if
 // this is the last query in the message.
 type ReplyChannelRange struct {
-	// QueryChannelRange is the corresponding query to this response.
-	QueryChannelRange
+	// ChainHash denotes the target chain that we're trying to synchronize
+	// channel graph state for.
+	ChainHash chainhash.Hash
+
+	// FirstBlockHeight is the first block in the query range. The
+	// responder should send all new short channel IDs from this block
+	// until this block plus the specified number of blocks.
+	FirstBlockHeight uint32
+
+	// NumBlocks is the number of blocks beyond the first block that short
+	// channel ID's should be sent for.
+	NumBlocks uint32
 
 	// Complete denotes if this is the conclusion of the set of streaming
 	// responses to the original query.
@@ -43,16 +58,20 @@ var _ Message = (*ReplyChannelRange)(nil)
 //
 // This is part of the lnwire.Message interface.
 func (c *ReplyChannelRange) Decode(r io.Reader, pver uint32) error {
-	err := c.QueryChannelRange.Decode(r, pver)
+	err := ReadElements(r,
+		c.ChainHash[:],
+		&c.FirstBlockHeight,
+		&c.NumBlocks,
+		&c.Complete,
+	)
 	if err != nil {
 		return err
 	}
 
-	if err := ReadElements(r, &c.Complete); err != nil {
+	c.EncodingType, c.ShortChanIDs, err = decodeShortChanIDs(r)
+	if err != nil {
 		return err
 	}
-
-	c.EncodingType, c.ShortChanIDs, err = decodeShortChanIDs(r)
 
 	return err
 }
@@ -62,15 +81,21 @@ func (c *ReplyChannelRange) Decode(r io.Reader, pver uint32) error {
 //
 // This is part of the lnwire.Message interface.
 func (c *ReplyChannelRange) Encode(w io.Writer, pver uint32) error {
-	if err := c.QueryChannelRange.Encode(w, pver); err != nil {
+	err := WriteElements(w,
+		c.ChainHash[:],
+		c.FirstBlockHeight,
+		c.NumBlocks,
+		c.Complete,
+	)
+	if err != nil {
 		return err
 	}
 
-	if err := WriteElements(w, c.Complete); err != nil {
+	err = encodeShortChanIDs(w, c.EncodingType, c.ShortChanIDs, c.noSort)
+	if err != nil {
 		return err
 	}
 
-	return encodeShortChanIDs(w, c.EncodingType, c.ShortChanIDs, c.noSort)
 }
 
 // MsgType returns the integer uniquely identifying this message type on the
@@ -87,4 +112,14 @@ func (c *ReplyChannelRange) MsgType() MessageType {
 // This is part of the lnwire.Message interface.
 func (c *ReplyChannelRange) MaxPayloadLength(uint32) uint32 {
 	return MaxMessagePayload
+
+// LastBlockHeight returns the last block height covered by the range of a
+// QueryChannelRange message.
+func (c *ReplyChannelRange) LastBlockHeight() uint32 {
+	// Handle overflows by casting to uint64.
+	lastBlockHeight := uint64(c.FirstBlockHeight) + uint64(c.NumBlocks) - 1
+	if lastBlockHeight > math.MaxUint32 {
+		return math.MaxUint32
+	}
+	return uint32(lastBlockHeight)
 }

--- a/lnwire/reply_channel_range.go
+++ b/lnwire/reply_channel_range.go
@@ -37,6 +37,11 @@ type ReplyChannelRange struct {
 	// ShortChanIDs is a slice of decoded short channel ID's.
 	ShortChanIDs []ShortChannelID
 
+	// ExtraData is the set of data that was appended to this message to
+	// fill out the full maximum transport message size. These fields can
+	// be used to specify optional data such as custom TLV fields.
+	ExtraData ExtraOpaqueData
+
 	// noSort indicates whether or not to sort the short channel ids before
 	// writing them out.
 	//
@@ -73,7 +78,7 @@ func (c *ReplyChannelRange) Decode(r io.Reader, pver uint32) error {
 		return err
 	}
 
-	return err
+	return c.ExtraData.Decode(r)
 }
 
 // Encode serializes the target ReplyChannelRange into the passed io.Writer
@@ -96,6 +101,7 @@ func (c *ReplyChannelRange) Encode(w io.Writer, pver uint32) error {
 		return err
 	}
 
+	return c.ExtraData.Encode(w)
 }
 
 // MsgType returns the integer uniquely identifying this message type on the
@@ -111,7 +117,8 @@ func (c *ReplyChannelRange) MsgType() MessageType {
 //
 // This is part of the lnwire.Message interface.
 func (c *ReplyChannelRange) MaxPayloadLength(uint32) uint32 {
-	return MaxMessagePayload
+	return MaxMsgBody
+}
 
 // LastBlockHeight returns the last block height covered by the range of a
 // QueryChannelRange message.

--- a/lnwire/reply_channel_range_test.go
+++ b/lnwire/reply_channel_range_test.go
@@ -72,6 +72,7 @@ func TestReplyChannelRangeEmpty(t *testing.T) {
 				Complete:         1,
 				EncodingType:     test.encType,
 				ShortChanIDs:     nil,
+				ExtraData:        make([]byte, 0),
 			}
 
 			// First decode the hex string in the test case into a

--- a/lnwire/reply_channel_range_test.go
+++ b/lnwire/reply_channel_range_test.go
@@ -30,7 +30,7 @@ func TestReplyChannelRangeUnsorted(t *testing.T) {
 			var req2 ReplyChannelRange
 			err = req2.Decode(bytes.NewReader(b.Bytes()), 0)
 			if _, ok := err.(ErrUnsortedSIDs); !ok {
-				t.Fatalf("expected ErrUnsortedSIDs, got: %T",
+				t.Fatalf("expected ErrUnsortedSIDs, got: %v",
 					err)
 			}
 		})
@@ -67,13 +67,11 @@ func TestReplyChannelRangeEmpty(t *testing.T) {
 		test := test
 		t.Run(test.name, func(t *testing.T) {
 			req := ReplyChannelRange{
-				QueryChannelRange: QueryChannelRange{
-					FirstBlockHeight: 1,
-					NumBlocks:        2,
-				},
-				Complete:     1,
-				EncodingType: test.encType,
-				ShortChanIDs: nil,
+				FirstBlockHeight: 1,
+				NumBlocks:        2,
+				Complete:         1,
+				EncodingType:     test.encType,
+				ShortChanIDs:     nil,
 			}
 
 			// First decode the hex string in the test case into a

--- a/lnwire/reply_channel_range_test.go
+++ b/lnwire/reply_channel_range_test.go
@@ -80,7 +80,9 @@ func TestReplyChannelRangeEmpty(t *testing.T) {
 			// identical to the one created above.
 			var req2 ReplyChannelRange
 			b, _ := hex.DecodeString(test.encodedHex)
-			err := req2.Decode(bytes.NewReader(b), 0)
+			err := req2.Decode(
+				bytes.NewReader(b), ProtocolVersionTLV,
+			)
 			if err != nil {
 				t.Fatalf("unable to decode req: %v", err)
 			}
@@ -93,7 +95,7 @@ func TestReplyChannelRangeEmpty(t *testing.T) {
 			// request created above, and assert that it matches
 			// the raw byte encoding.
 			var b2 bytes.Buffer
-			err = req.Encode(&b2, 0)
+			err = req.Encode(&b2, ProtocolVersionTLV)
 			if err != nil {
 				t.Fatalf("unable to encode req: %v", err)
 			}

--- a/lnwire/reply_short_chan_ids_end.go
+++ b/lnwire/reply_short_chan_ids_end.go
@@ -22,6 +22,11 @@ type ReplyShortChanIDsEnd struct {
 	// set of short chan ID's in the corresponding QueryShortChanIDs
 	// message.
 	Complete uint8
+
+	// ExtraData is the set of data that was appended to this message to
+	// fill out the full maximum transport message size. These fields can
+	// be used to specify optional data such as custom TLV fields.
+	ExtraData ExtraOpaqueData
 }
 
 // NewReplyShortChanIDsEnd creates a new empty ReplyShortChanIDsEnd message.
@@ -41,6 +46,7 @@ func (c *ReplyShortChanIDsEnd) Decode(r io.Reader, pver uint32) error {
 	return ReadElements(r,
 		c.ChainHash[:],
 		&c.Complete,
+		&c.ExtraData,
 	)
 }
 
@@ -52,6 +58,7 @@ func (c *ReplyShortChanIDsEnd) Encode(w io.Writer, pver uint32) error {
 	return WriteElements(w,
 		c.ChainHash[:],
 		c.Complete,
+		c.ExtraData,
 	)
 }
 
@@ -69,6 +76,5 @@ func (c *ReplyShortChanIDsEnd) MsgType() MessageType {
 //
 // This is part of the lnwire.Message interface.
 func (c *ReplyShortChanIDsEnd) MaxPayloadLength(uint32) uint32 {
-	// 32 (chain hash) + 1 (complete)
-	return 33
+	return MaxMsgBody
 }

--- a/lnwire/reply_short_chan_ids_end.go
+++ b/lnwire/reply_short_chan_ids_end.go
@@ -44,6 +44,7 @@ var _ Message = (*ReplyShortChanIDsEnd)(nil)
 // This is part of the lnwire.Message interface.
 func (c *ReplyShortChanIDsEnd) Decode(r io.Reader, pver uint32) error {
 	return ReadElements(r,
+		pver,
 		c.ChainHash[:],
 		&c.Complete,
 		&c.ExtraData,
@@ -56,6 +57,7 @@ func (c *ReplyShortChanIDsEnd) Decode(r io.Reader, pver uint32) error {
 // This is part of the lnwire.Message interface.
 func (c *ReplyShortChanIDsEnd) Encode(w io.Writer, pver uint32) error {
 	return WriteElements(w,
+		pver,
 		c.ChainHash[:],
 		c.Complete,
 		c.ExtraData,

--- a/lnwire/revoke_and_ack.go
+++ b/lnwire/revoke_and_ack.go
@@ -30,11 +30,18 @@ type RevokeAndAck struct {
 	// create the proper revocation key used within the commitment
 	// transaction.
 	NextRevocationKey *btcec.PublicKey
+
+	// ExtraData is the set of data that was appended to this message to
+	// fill out the full maximum transport message size. These fields can
+	// be used to specify optional data such as custom TLV fields.
+	ExtraData ExtraOpaqueData
 }
 
 // NewRevokeAndAck creates a new RevokeAndAck message.
 func NewRevokeAndAck() *RevokeAndAck {
-	return &RevokeAndAck{}
+	return &RevokeAndAck{
+		ExtraData: make([]byte, 0),
+	}
 }
 
 // A compile time check to ensure RevokeAndAck implements the lnwire.Message
@@ -50,6 +57,7 @@ func (c *RevokeAndAck) Decode(r io.Reader, pver uint32) error {
 		&c.ChanID,
 		c.Revocation[:],
 		&c.NextRevocationKey,
+		&c.ExtraData,
 	)
 }
 
@@ -62,6 +70,7 @@ func (c *RevokeAndAck) Encode(w io.Writer, pver uint32) error {
 		c.ChanID,
 		c.Revocation[:],
 		c.NextRevocationKey,
+		c.ExtraData,
 	)
 }
 
@@ -78,8 +87,7 @@ func (c *RevokeAndAck) MsgType() MessageType {
 //
 // This is part of the lnwire.Message interface.
 func (c *RevokeAndAck) MaxPayloadLength(uint32) uint32 {
-	// 32 + 32 + 33
-	return 97
+	return MaxMsgBody
 }
 
 // TargetChanID returns the channel id of the link for which this message is

--- a/lnwire/revoke_and_ack.go
+++ b/lnwire/revoke_and_ack.go
@@ -54,6 +54,7 @@ var _ Message = (*RevokeAndAck)(nil)
 // This is part of the lnwire.Message interface.
 func (c *RevokeAndAck) Decode(r io.Reader, pver uint32) error {
 	return ReadElements(r,
+		pver,
 		&c.ChanID,
 		c.Revocation[:],
 		&c.NextRevocationKey,
@@ -67,6 +68,7 @@ func (c *RevokeAndAck) Decode(r io.Reader, pver uint32) error {
 // This is part of the lnwire.Message interface.
 func (c *RevokeAndAck) Encode(w io.Writer, pver uint32) error {
 	return WriteElements(w,
+		pver,
 		c.ChanID,
 		c.Revocation[:],
 		c.NextRevocationKey,

--- a/lnwire/shutdown.go
+++ b/lnwire/shutdown.go
@@ -15,6 +15,11 @@ type Shutdown struct {
 
 	// Address is the script to which the channel funds will be paid.
 	Address DeliveryAddress
+
+	// ExtraData is the set of data that was appended to this message to
+	// fill out the full maximum transport message size. These fields can
+	// be used to specify optional data such as custom TLV fields.
+	ExtraData ExtraOpaqueData
 }
 
 // DeliveryAddress is used to communicate the address to which funds from a
@@ -48,7 +53,7 @@ var _ Message = (*Shutdown)(nil)
 //
 // This is part of the lnwire.Message interface.
 func (s *Shutdown) Decode(r io.Reader, pver uint32) error {
-	return ReadElements(r, &s.ChannelID, &s.Address)
+	return ReadElements(r, &s.ChannelID, &s.Address, &s.ExtraData)
 }
 
 // Encode serializes the target Shutdown into the passed io.Writer observing
@@ -56,7 +61,7 @@ func (s *Shutdown) Decode(r io.Reader, pver uint32) error {
 //
 // This is part of the lnwire.Message interface.
 func (s *Shutdown) Encode(w io.Writer, pver uint32) error {
-	return WriteElements(w, s.ChannelID, s.Address)
+	return WriteElements(w, s.ChannelID, s.Address, s.ExtraData)
 }
 
 // MsgType returns the integer uniquely identifying this message type on the
@@ -72,16 +77,5 @@ func (s *Shutdown) MsgType() MessageType {
 //
 // This is part of the lnwire.Message interface.
 func (s *Shutdown) MaxPayloadLength(pver uint32) uint32 {
-	var length uint32
-
-	// ChannelID - 32bytes
-	length += 32
-
-	// Len - 2 bytes
-	length += 2
-
-	// ScriptPubKey - maximum delivery address size.
-	length += deliveryAddressMaxSize
-
-	return length
+	return MaxMsgBody
 }

--- a/lnwire/shutdown.go
+++ b/lnwire/shutdown.go
@@ -53,7 +53,7 @@ var _ Message = (*Shutdown)(nil)
 //
 // This is part of the lnwire.Message interface.
 func (s *Shutdown) Decode(r io.Reader, pver uint32) error {
-	return ReadElements(r, &s.ChannelID, &s.Address, &s.ExtraData)
+	return ReadElements(r, pver, &s.ChannelID, &s.Address, &s.ExtraData)
 }
 
 // Encode serializes the target Shutdown into the passed io.Writer observing
@@ -61,7 +61,7 @@ func (s *Shutdown) Decode(r io.Reader, pver uint32) error {
 //
 // This is part of the lnwire.Message interface.
 func (s *Shutdown) Encode(w io.Writer, pver uint32) error {
-	return WriteElements(w, s.ChannelID, s.Address, s.ExtraData)
+	return WriteElements(w, pver, s.ChannelID, s.Address, s.ExtraData)
 }
 
 // MsgType returns the integer uniquely identifying this message type on the

--- a/lnwire/typed_delivery_addr.go
+++ b/lnwire/typed_delivery_addr.go
@@ -1,0 +1,65 @@
+package lnwire
+
+import (
+	"io"
+
+	"github.com/lightningnetwork/lnd/tlv"
+)
+
+const (
+	// DeliveryAddrType is the TLV record type for delivery addreses within
+	// the name space of the OpenChannel and AcceptChannel messages.
+	DeliveryAddrType = 0
+)
+
+// TypedDeliveryAddress is similar to the DeliveryAddrType type, but it's
+// encoded using a mini TLV stream. This tyupe was intorudced in order to allow
+// the OpenChannel/AcceptChannel messages to properly be extended with TLV types.
+type TypedDeliveryAddress []byte
+
+// Encode encodes the target TypedDeliveryAddress into the target io.Writer
+// using a TLV stream.
+func (t *TypedDeliveryAddress) Encode(w io.Writer) error {
+	addrBytes := []byte((*t)[:])
+
+	records := []tlv.Record{
+		tlv.MakeDynamicRecord(
+			DeliveryAddrType, &addrBytes,
+			func() uint64 {
+				return uint64(len(addrBytes))
+			},
+			tlv.EVarBytes, tlv.DVarBytes,
+		),
+	}
+	tlvStream, err := tlv.NewStream(records...)
+	if err != nil {
+		return err
+	}
+
+	return tlvStream.Encode(w)
+}
+
+// Decode decodes a set of bytes from the targer io.Reader into the target
+// TypedDeliveryAddress.
+func (t *TypedDeliveryAddress) Decode(r io.Reader) error {
+	addrBytes := []byte((*t)[:])
+
+	records := []tlv.Record{
+		tlv.MakeDynamicRecord(
+			DeliveryAddrType, &addrBytes, nil,
+			tlv.EVarBytes, tlv.DVarBytes,
+		),
+	}
+
+	tlvStream, err := tlv.NewStream(records...)
+	if err != nil {
+		return err
+	}
+	if err := tlvStream.Decode(r); err != nil {
+		return err
+	}
+
+	*t = addrBytes
+
+	return nil
+}

--- a/lnwire/typed_delivery_addr_test.go
+++ b/lnwire/typed_delivery_addr_test.go
@@ -1,0 +1,31 @@
+package lnwire
+
+import (
+	"bytes"
+	"testing"
+)
+
+// TestTypedDeliveryAddressEncodeDecode tests that we're able to properly
+// encode and decode typed delivery addresses.
+func TestTypedDeliveryAddressEncodeDecode(t *testing.T) {
+	t.Parallel()
+
+	addr := TypedDeliveryAddress(
+		bytes.Repeat([]byte("a"), deliveryAddressMaxSize),
+	)
+
+	var b bytes.Buffer
+	if err := addr.Encode(&b); err != nil {
+		t.Fatalf("unable to encode addr: %v", err)
+	}
+
+	var addr2 TypedDeliveryAddress
+	if err := addr2.Decode(&b); err != nil {
+		t.Fatalf("unable to decode addr: %v", err)
+	}
+
+	if !bytes.Equal(addr, addr2) {
+		t.Fatalf("addr mismatch: expected %x, got %x", addr[:],
+			addr2[:])
+	}
+}

--- a/lnwire/update_add_htlc.go
+++ b/lnwire/update_add_htlc.go
@@ -52,6 +52,11 @@ type UpdateAddHTLC struct {
 	// should strip off a layer of encryption, exposing the next hop to be
 	// used in the subsequent UpdateAddHTLC message.
 	OnionBlob [OnionPacketSize]byte
+
+	// ExtraData is the set of data that was appended to this message to
+	// fill out the full maximum transport message size. These fields can
+	// be used to specify optional data such as custom TLV fields.
+	ExtraData ExtraOpaqueData
 }
 
 // NewUpdateAddHTLC returns a new empty UpdateAddHTLC message.
@@ -75,6 +80,7 @@ func (c *UpdateAddHTLC) Decode(r io.Reader, pver uint32) error {
 		c.PaymentHash[:],
 		&c.Expiry,
 		c.OnionBlob[:],
+		&c.ExtraData,
 	)
 }
 
@@ -90,6 +96,7 @@ func (c *UpdateAddHTLC) Encode(w io.Writer, pver uint32) error {
 		c.PaymentHash[:],
 		c.Expiry,
 		c.OnionBlob[:],
+		c.ExtraData,
 	)
 }
 
@@ -106,8 +113,7 @@ func (c *UpdateAddHTLC) MsgType() MessageType {
 //
 // This is part of the lnwire.Message interface.
 func (c *UpdateAddHTLC) MaxPayloadLength(uint32) uint32 {
-	// 1450
-	return 32 + 8 + 4 + 8 + 32 + 1366
+	return MaxMsgBody
 }
 
 // TargetChanID returns the channel id of the link for which this message is

--- a/lnwire/update_add_htlc.go
+++ b/lnwire/update_add_htlc.go
@@ -74,6 +74,7 @@ var _ Message = (*UpdateAddHTLC)(nil)
 // This is part of the lnwire.Message interface.
 func (c *UpdateAddHTLC) Decode(r io.Reader, pver uint32) error {
 	return ReadElements(r,
+		pver,
 		&c.ChanID,
 		&c.ID,
 		&c.Amount,
@@ -90,6 +91,7 @@ func (c *UpdateAddHTLC) Decode(r io.Reader, pver uint32) error {
 // This is part of the lnwire.Message interface.
 func (c *UpdateAddHTLC) Encode(w io.Writer, pver uint32) error {
 	return WriteElements(w,
+		pver,
 		c.ChanID,
 		c.ID,
 		c.Amount,

--- a/lnwire/update_fail_htlc.go
+++ b/lnwire/update_fail_htlc.go
@@ -26,6 +26,11 @@ type UpdateFailHTLC struct {
 	// failed. This blob is only fully decryptable by the initiator of the
 	// HTLC message.
 	Reason OpaqueReason
+
+	// ExtraData is the set of data that was appended to this message to
+	// fill out the full maximum transport message size. These fields can
+	// be used to specify optional data such as custom TLV fields.
+	ExtraData ExtraOpaqueData
 }
 
 // A compile time check to ensure UpdateFailHTLC implements the lnwire.Message
@@ -41,6 +46,7 @@ func (c *UpdateFailHTLC) Decode(r io.Reader, pver uint32) error {
 		&c.ChanID,
 		&c.ID,
 		&c.Reason,
+		&c.ExtraData,
 	)
 }
 
@@ -53,6 +59,7 @@ func (c *UpdateFailHTLC) Encode(w io.Writer, pver uint32) error {
 		c.ChanID,
 		c.ID,
 		c.Reason,
+		c.ExtraData,
 	)
 }
 
@@ -69,21 +76,7 @@ func (c *UpdateFailHTLC) MsgType() MessageType {
 //
 // This is part of the lnwire.Message interface.
 func (c *UpdateFailHTLC) MaxPayloadLength(uint32) uint32 {
-	var length uint32
-
-	// Length of the ChanID
-	length += 32
-
-	// Length of the ID
-	length += 8
-
-	// Length of the length opaque reason
-	length += 2
-
-	// Length of the Reason
-	length += 292
-
-	return length
+	return MaxMsgBody
 }
 
 // TargetChanID returns the channel id of the link for which this message is

--- a/lnwire/update_fail_htlc.go
+++ b/lnwire/update_fail_htlc.go
@@ -43,6 +43,7 @@ var _ Message = (*UpdateFailHTLC)(nil)
 // This is part of the lnwire.Message interface.
 func (c *UpdateFailHTLC) Decode(r io.Reader, pver uint32) error {
 	return ReadElements(r,
+		pver,
 		&c.ChanID,
 		&c.ID,
 		&c.Reason,
@@ -56,6 +57,7 @@ func (c *UpdateFailHTLC) Decode(r io.Reader, pver uint32) error {
 // This is part of the lnwire.Message interface.
 func (c *UpdateFailHTLC) Encode(w io.Writer, pver uint32) error {
 	return WriteElements(w,
+		pver,
 		c.ChanID,
 		c.ID,
 		c.Reason,

--- a/lnwire/update_fail_malformed_htlc.go
+++ b/lnwire/update_fail_malformed_htlc.go
@@ -24,6 +24,11 @@ type UpdateFailMalformedHTLC struct {
 
 	// FailureCode the exact reason why onion blob haven't been parsed.
 	FailureCode FailCode
+
+	// ExtraData is the set of data that was appended to this message to
+	// fill out the full maximum transport message size. These fields can
+	// be used to specify optional data such as custom TLV fields.
+	ExtraData ExtraOpaqueData
 }
 
 // A compile time check to ensure UpdateFailMalformedHTLC implements the
@@ -40,6 +45,7 @@ func (c *UpdateFailMalformedHTLC) Decode(r io.Reader, pver uint32) error {
 		&c.ID,
 		c.ShaOnionBlob[:],
 		&c.FailureCode,
+		&c.ExtraData,
 	)
 }
 
@@ -53,6 +59,7 @@ func (c *UpdateFailMalformedHTLC) Encode(w io.Writer, pver uint32) error {
 		c.ID,
 		c.ShaOnionBlob[:],
 		c.FailureCode,
+		c.ExtraData,
 	)
 }
 
@@ -70,8 +77,7 @@ func (c *UpdateFailMalformedHTLC) MsgType() MessageType {
 //
 // This is part of the lnwire.Message interface.
 func (c *UpdateFailMalformedHTLC) MaxPayloadLength(uint32) uint32 {
-	// 32 +  8 + 32 + 2
-	return 74
+	return MaxMsgBody
 }
 
 // TargetChanID returns the channel id of the link for which this message is

--- a/lnwire/update_fail_malformed_htlc.go
+++ b/lnwire/update_fail_malformed_htlc.go
@@ -41,6 +41,7 @@ var _ Message = (*UpdateFailMalformedHTLC)(nil)
 // This is part of the lnwire.Message interface.
 func (c *UpdateFailMalformedHTLC) Decode(r io.Reader, pver uint32) error {
 	return ReadElements(r,
+		pver,
 		&c.ChanID,
 		&c.ID,
 		c.ShaOnionBlob[:],
@@ -55,6 +56,7 @@ func (c *UpdateFailMalformedHTLC) Decode(r io.Reader, pver uint32) error {
 // This is part of the lnwire.Message interface.
 func (c *UpdateFailMalformedHTLC) Encode(w io.Writer, pver uint32) error {
 	return WriteElements(w,
+		pver,
 		c.ChanID,
 		c.ID,
 		c.ShaOnionBlob[:],

--- a/lnwire/update_fee.go
+++ b/lnwire/update_fee.go
@@ -16,6 +16,11 @@ type UpdateFee struct {
 	// TODO(halseth): make SatPerKWeight when fee estimation is moved to
 	// own package. Currently this will cause an import cycle.
 	FeePerKw uint32
+
+	// ExtraData is the set of data that was appended to this message to
+	// fill out the full maximum transport message size. These fields can
+	// be used to specify optional data such as custom TLV fields.
+	ExtraData ExtraOpaqueData
 }
 
 // NewUpdateFee creates a new UpdateFee message.
@@ -38,6 +43,7 @@ func (c *UpdateFee) Decode(r io.Reader, pver uint32) error {
 	return ReadElements(r,
 		&c.ChanID,
 		&c.FeePerKw,
+		&c.ExtraData,
 	)
 }
 
@@ -49,6 +55,7 @@ func (c *UpdateFee) Encode(w io.Writer, pver uint32) error {
 	return WriteElements(w,
 		c.ChanID,
 		c.FeePerKw,
+		c.ExtraData,
 	)
 }
 
@@ -65,8 +72,7 @@ func (c *UpdateFee) MsgType() MessageType {
 //
 // This is part of the lnwire.Message interface.
 func (c *UpdateFee) MaxPayloadLength(uint32) uint32 {
-	// 32 + 4
-	return 36
+	return MaxMsgBody
 }
 
 // TargetChanID returns the channel id of the link for which this message is

--- a/lnwire/update_fee.go
+++ b/lnwire/update_fee.go
@@ -41,6 +41,7 @@ var _ Message = (*UpdateFee)(nil)
 // This is part of the lnwire.Message interface.
 func (c *UpdateFee) Decode(r io.Reader, pver uint32) error {
 	return ReadElements(r,
+		pver,
 		&c.ChanID,
 		&c.FeePerKw,
 		&c.ExtraData,
@@ -53,6 +54,7 @@ func (c *UpdateFee) Decode(r io.Reader, pver uint32) error {
 // This is part of the lnwire.Message interface.
 func (c *UpdateFee) Encode(w io.Writer, pver uint32) error {
 	return WriteElements(w,
+		pver,
 		c.ChanID,
 		c.FeePerKw,
 		c.ExtraData,

--- a/lnwire/update_fulfill_htlc.go
+++ b/lnwire/update_fulfill_htlc.go
@@ -21,6 +21,11 @@ type UpdateFulfillHTLC struct {
 	// PaymentPreimage is the R-value preimage required to fully settle an
 	// HTLC.
 	PaymentPreimage [32]byte
+
+	// ExtraData is the set of data that was appended to this message to
+	// fill out the full maximum transport message size. These fields can
+	// be used to specify optional data such as custom TLV fields.
+	ExtraData ExtraOpaqueData
 }
 
 // NewUpdateFulfillHTLC returns a new empty UpdateFulfillHTLC.
@@ -47,6 +52,7 @@ func (c *UpdateFulfillHTLC) Decode(r io.Reader, pver uint32) error {
 		&c.ChanID,
 		&c.ID,
 		c.PaymentPreimage[:],
+		&c.ExtraData,
 	)
 }
 
@@ -59,6 +65,7 @@ func (c *UpdateFulfillHTLC) Encode(w io.Writer, pver uint32) error {
 		c.ChanID,
 		c.ID,
 		c.PaymentPreimage[:],
+		c.ExtraData,
 	)
 }
 
@@ -75,8 +82,7 @@ func (c *UpdateFulfillHTLC) MsgType() MessageType {
 //
 // This is part of the lnwire.Message interface.
 func (c *UpdateFulfillHTLC) MaxPayloadLength(uint32) uint32 {
-	// 32 + 8 + 32
-	return 72
+	return MaxMsgBody
 }
 
 // TargetChanID returns the channel id of the link for which this message is

--- a/lnwire/update_fulfill_htlc.go
+++ b/lnwire/update_fulfill_htlc.go
@@ -49,6 +49,7 @@ var _ Message = (*UpdateFulfillHTLC)(nil)
 // This is part of the lnwire.Message interface.
 func (c *UpdateFulfillHTLC) Decode(r io.Reader, pver uint32) error {
 	return ReadElements(r,
+		pver,
 		&c.ChanID,
 		&c.ID,
 		c.PaymentPreimage[:],
@@ -62,6 +63,7 @@ func (c *UpdateFulfillHTLC) Decode(r io.Reader, pver uint32) error {
 // This is part of the lnwire.Message interface.
 func (c *UpdateFulfillHTLC) Encode(w io.Writer, pver uint32) error {
 	return WriteElements(w,
+		pver,
 		c.ChanID,
 		c.ID,
 		c.PaymentPreimage[:],

--- a/peer/brontide.go
+++ b/peer/brontide.go
@@ -919,7 +919,7 @@ func (p *Brontide) readNextMessage() (lnwire.Message, error) {
 	// Next, create a new io.Reader implementation from the raw message,
 	// and use this to decode the message directly from.
 	msgReader := bytes.NewReader(rawMsg)
-	nextMsg, err := lnwire.ReadMessage(msgReader, 0)
+	nextMsg, err := lnwire.ReadMessage(msgReader, lnwire.ProtocolVersionTLV)
 	if err != nil {
 		return nil, err
 	}

--- a/routing/ann_validation.go
+++ b/routing/ann_validation.go
@@ -110,7 +110,10 @@ func ValidateNodeAnn(a *lnwire.NodeAnnouncement) error {
 	dataHash := chainhash.DoubleHashB(data)
 	if !nodeSig.Verify(dataHash, nodeKey) {
 		var msgBuf bytes.Buffer
-		if _, err := lnwire.WriteMessage(&msgBuf, a, 0); err != nil {
+		_, err := lnwire.WriteMessage(
+			&msgBuf, a, lnwire.ProtocolVersionTLV,
+		)
+		if err != nil {
 			return err
 		}
 


### PR DESCRIPTION
This PR is a combination of #4099 and #3966 as they're interdependent and can't be merged in isolation yet leave master in a clean slate. The only _new_ commit here is the last one that ensures the prior added migration uses the new protocol version to gate the "proper" behavior w.r.t always reading/writing the extra bytes for each migration. 

Putting this up now so it can start building, there're a few relevant comments from the prior PRs that I'll address as fix up commits here. I know it _looks_ large, but the bulk of the commits are mostly small changes in the `lnwire` package. If requested, I can squash in those 30 or so commits into a single one if it actually makes things easier to review. 

## First PR Description 

In this Pr, we create a new ExtraOpaqueData based on the field with the same name that's present in all the announcement related messages. In later commits, we'll embed this new type in each message, so we'll have a generic way to add/parse TLV extensions from messages.

We then convert all the current known messages to include this new field, and parse it accordignly. The new ExtraOpaqueData also comes with some propsective helper methods for TLV encoding/decoding. I envision these will be used either within the top-level Encode/Decode methods, or by callers to populate new (optional) pointer fields that get added in the wire messages similar to the structs in htlcswitch/hop.

## Second PR Description 

In this commit, we modify the way we write the CommitSIg in certain locations to match the way it's encoded on the wire. With this change, we'll now properly add a length prefix in front of the message, meaning we'll be able to read the extra data included (if present), and still be able to serialize content after this message.

We add a simple migration to migrate all the current pending commitments, along with a test. We opt to do the simple enclose-copy method for the migration, which results in a larger diff, but IMO an easier to understand migration test.