### PR TITLE
Sweeper: support Inputs with required locktimes and txOuts

### DIFF
--- a/breacharbiter.go
+++ b/breacharbiter.go
@@ -866,6 +866,13 @@ func (bo *breachedOutput) OutPoint() *wire.OutPoint {
 	return &bo.outpoint
 }
 
+// RequiredTxOut returns a non-nil TxOut if input commits to a certain
+// transaction output. This is used in the SINGLE|ANYONECANPAY case to make
+// sure any presigned input is still valid by including the output.
+func (bo *breachedOutput) RequiredTxOut() *wire.TxOut {
+	return nil
+}
+
 // RequiredLockTime returns whether this input commits to a tx locktime that
 // must be used in the transaction including it.
 func (bo *breachedOutput) RequiredLockTime() (uint32, bool) {

--- a/breacharbiter.go
+++ b/breacharbiter.go
@@ -866,6 +866,12 @@ func (bo *breachedOutput) OutPoint() *wire.OutPoint {
 	return &bo.outpoint
 }
 
+// RequiredLockTime returns whether this input commits to a tx locktime that
+// must be used in the transaction including it.
+func (bo *breachedOutput) RequiredLockTime() (uint32, bool) {
+	return 0, false
+}
+
 // WitnessType returns the type of witness that must be generated to spend the
 // breached output.
 func (bo *breachedOutput) WitnessType() input.WitnessType {

--- a/input/input.go
+++ b/input/input.go
@@ -15,6 +15,12 @@ type Input interface {
 	// construct the corresponding transaction input.
 	OutPoint() *wire.OutPoint
 
+	// RequiredTxOut returns a non-nil TxOut if input commits to a certain
+	// transaction output. This is used in the SINGLE|ANYONECANPAY case to
+	// make sure any presigned input is still valid by including the
+	// output.
+	RequiredTxOut() *wire.TxOut
+
 	// RequiredLockTime returns whether this input commits to a tx locktime
 	// that must be used in the transaction including it.
 	RequiredLockTime() (uint32, bool)
@@ -77,6 +83,11 @@ type inputKit struct {
 // a transaction input.
 func (i *inputKit) OutPoint() *wire.OutPoint {
 	return &i.outpoint
+}
+
+// RequiredTxOut returns a nil for the base input type.
+func (i *inputKit) RequiredTxOut() *wire.TxOut {
+	return nil
 }
 
 // RequiredLockTime returns whether this input commits to a tx locktime that

--- a/input/input.go
+++ b/input/input.go
@@ -15,6 +15,10 @@ type Input interface {
 	// construct the corresponding transaction input.
 	OutPoint() *wire.OutPoint
 
+	// RequiredLockTime returns whether this input commits to a tx locktime
+	// that must be used in the transaction including it.
+	RequiredLockTime() (uint32, bool)
+
 	// WitnessType returns an enum specifying the type of witness that must
 	// be generated in order to spend this output.
 	WitnessType() WitnessType
@@ -73,6 +77,13 @@ type inputKit struct {
 // a transaction input.
 func (i *inputKit) OutPoint() *wire.OutPoint {
 	return &i.outpoint
+}
+
+// RequiredLockTime returns whether this input commits to a tx locktime that
+// must be used in the transaction including it. This will be false for the
+// base input type since we can re-sign for any lock time.
+func (i *inputKit) RequiredLockTime() (uint32, bool) {
+	return 0, false
 }
 
 // WitnessType returns the type of witness that must be generated to spend the

--- a/input/size.go
+++ b/input/size.go
@@ -533,6 +533,14 @@ func (twe *TxWeightEstimator) AddNestedP2WSHInput(witnessSize int) *TxWeightEsti
 	return twe
 }
 
+// AddTxOutput adds a known TxOut to the weight estimator.
+func (twe *TxWeightEstimator) AddTxOutput(txOut *wire.TxOut) *TxWeightEstimator {
+	twe.outputSize += txOut.SerializeSize()
+	twe.outputCount++
+
+	return twe
+}
+
 // AddP2PKHOutput updates the weight estimate to account for an additional P2PKH
 // output.
 func (twe *TxWeightEstimator) AddP2PKHOutput() *TxWeightEstimator {

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -1254,7 +1254,8 @@ func (r *rpcServer) SendCoins(ctx context.Context,
 		// single transaction. This will be generated in a concurrent
 		// safe manner, so no need to worry about locking.
 		sweepTxPkg, err := sweep.CraftSweepAllTx(
-			feePerKw, uint32(bestHeight), targetAddr, wallet,
+			feePerKw, lnwallet.DefaultDustLimit(),
+			uint32(bestHeight), targetAddr, wallet,
 			wallet.WalletController, wallet.WalletController,
 			r.server.cc.FeeEstimator, r.server.cc.Signer,
 		)

--- a/sweep/backend_mock_test.go
+++ b/sweep/backend_mock_test.go
@@ -27,6 +27,7 @@ type mockBackend struct {
 	publishChan chan wire.MsgTx
 
 	walletUtxos []*lnwallet.Utxo
+	utxoCnt     int
 }
 
 func newMockBackend(t *testing.T, notifier *MockNotifier) *mockBackend {
@@ -88,6 +89,16 @@ func (b *mockBackend) PublishTransaction(tx *wire.MsgTx, _ string) error {
 
 func (b *mockBackend) ListUnspentWitness(minconfirms, maxconfirms int32) (
 	[]*lnwallet.Utxo, error) {
+	b.lock.Lock()
+	defer b.lock.Unlock()
+
+	// Each time we list output, we increment the utxo counter, to
+	// ensure we don't return the same outpoint every time.
+	b.utxoCnt++
+
+	for i := range b.walletUtxos {
+		b.walletUtxos[i].OutPoint.Hash[0] = byte(b.utxoCnt)
+	}
 
 	return b.walletUtxos, nil
 }

--- a/sweep/sweeper.go
+++ b/sweep/sweeper.go
@@ -1165,7 +1165,7 @@ func (s *UtxoSweeper) sweep(inputs inputSet, feeRate chainfee.SatPerKWeight,
 	// Create sweep tx.
 	tx, err := createSweepTx(
 		inputs, s.currentOutputScript, uint32(currentHeight), feeRate,
-		s.cfg.Signer,
+		dustLimit(s.relayFeeRate), s.cfg.Signer,
 	)
 	if err != nil {
 		return fmt.Errorf("create sweep tx: %v", err)
@@ -1455,7 +1455,8 @@ func (s *UtxoSweeper) CreateSweepTx(inputs []input.Input, feePref FeePreference,
 	}
 
 	return createSweepTx(
-		inputs, pkScript, currentBlockHeight, feePerKw, s.cfg.Signer,
+		inputs, pkScript, currentBlockHeight, feePerKw,
+		dustLimit(s.relayFeeRate), s.cfg.Signer,
 	)
 }
 

--- a/sweep/sweeper_test.go
+++ b/sweep/sweeper_test.go
@@ -64,7 +64,7 @@ var (
 func createTestInput(value int64, witnessType input.WitnessType) input.BaseInput {
 	hash := chainhash.Hash{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
 		0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-		byte(testInputCount)}
+		byte(testInputCount + 1)}
 
 	input := input.MakeBaseInput(
 		&wire.OutPoint{
@@ -106,7 +106,7 @@ func createSweeperTestContext(t *testing.T) *sweeperTestContext {
 	backend := newMockBackend(t, notifier)
 	backend.walletUtxos = []*lnwallet.Utxo{
 		{
-			Value:       btcutil.Amount(10000),
+			Value:       btcutil.Amount(1_000_000),
 			AddressType: lnwallet.WitnessPubKey,
 		},
 	}
@@ -493,8 +493,9 @@ func TestWalletUtxo(t *testing.T) {
 			"inputs instead", len(sweepTx.TxIn))
 	}
 
-	// Calculate expected output value based on wallet utxo of 10000 sats.
-	expectedOutputValue := int64(294 + 10000 - 180)
+	// Calculate expected output value based on wallet utxo of 1_000_000
+	// sats.
+	expectedOutputValue := int64(294 + 1_000_000 - 180)
 	if sweepTx.TxOut[0].Value != expectedOutputValue {
 		t.Fatalf("Expected output value of %v, but got %v",
 			expectedOutputValue, sweepTx.TxOut[0].Value)
@@ -1369,8 +1370,8 @@ func TestCpfp(t *testing.T) {
 	// package, making a total of 1059. At 5000 sat/kw, the required fee for
 	// the package is 5295 sats. The parent already paid 900 sats, so there
 	// is 4395 sat remaining to be paid. The expected output value is
-	// therefore: 10000 + 330 - 4395 = 5935.
-	require.Equal(t, int64(5935), tx.TxOut[0].Value)
+	// therefore: 1_000_000 + 330 - 4395 = 995 935.
+	require.Equal(t, int64(995_935), tx.TxOut[0].Value)
 
 	// Mine the tx and assert that the result is passed back.
 	ctx.backend.mine()

--- a/sweep/tx_input_set.go
+++ b/sweep/tx_input_set.go
@@ -31,15 +31,22 @@ const (
 )
 
 type txInputSetState struct {
-	// weightEstimate is the (worst case) tx weight with the current set of
-	// inputs.
-	weightEstimate *weightEstimator
+	// feeRate is the fee rate to use for the sweep transaction.
+	feeRate chainfee.SatPerKWeight
 
 	// inputTotal is the total value of all inputs.
 	inputTotal btcutil.Amount
 
-	// outputValue is the value of the tx output.
-	outputValue btcutil.Amount
+	// requiredOutput is the sum of the outputs committed to by the inputs.
+	requiredOutput btcutil.Amount
+
+	// changeOutput is the value of the change output. This will be what is
+	// left over after subtracting the requiredOutput and the tx fee from
+	// the inputTotal.
+	//
+	// NOTE: This might be below the dust limit, or even negative since it
+	// is the change remaining in csse we pay the fee for a change output.
+	changeOutput btcutil.Amount
 
 	// inputs is the set of tx inputs.
 	inputs []input.Input
@@ -52,11 +59,42 @@ type txInputSetState struct {
 	force bool
 }
 
+// weightEstimate is the (worst case) tx weight with the current set of
+// inputs. It takes a parameter whether to add a change output or not.
+func (t *txInputSetState) weightEstimate(change bool) *weightEstimator {
+	weightEstimate := newWeightEstimator(t.feeRate)
+	for _, i := range t.inputs {
+		// Can ignore error, because it has already been checked when
+		// calculating the yields.
+		_ = weightEstimate.add(i)
+
+		r := i.RequiredTxOut()
+		if r != nil {
+			weightEstimate.addOutput(r)
+		}
+	}
+
+	// Add a change output to the weight estimate if requested.
+	if change {
+		weightEstimate.addP2WKHOutput()
+	}
+
+	return weightEstimate
+}
+
+// totalOutput is the total amount left for us after paying fees.
+//
+// NOTE: This might be dust.
+func (t *txInputSetState) totalOutput() btcutil.Amount {
+	return t.requiredOutput + t.changeOutput
+}
+
 func (t *txInputSetState) clone() txInputSetState {
 	s := txInputSetState{
-		weightEstimate:   t.weightEstimate.clone(),
+		feeRate:          t.feeRate,
 		inputTotal:       t.inputTotal,
-		outputValue:      t.outputValue,
+		changeOutput:     t.changeOutput,
+		requiredOutput:   t.requiredOutput,
 		walletInputTotal: t.walletInputTotal,
 		force:            t.force,
 		inputs:           make([]input.Input, len(t.inputs)),
@@ -97,7 +135,7 @@ func newTxInputSet(wallet Wallet, feePerKW,
 	dustLimit := dustLimit(relayFee)
 
 	state := txInputSetState{
-		weightEstimate: newWeightEstimator(feePerKW),
+		feeRate: feePerKW,
 	}
 
 	b := txInputSet{
@@ -107,16 +145,36 @@ func newTxInputSet(wallet Wallet, feePerKW,
 		txInputSetState: state,
 	}
 
-	// Add the sweep tx output to the weight estimate.
-	b.weightEstimate.addP2WKHOutput()
-
 	return &b
 }
 
-// dustLimitReached returns true if we've accumulated enough inputs to meet the
-// dust limit.
-func (t *txInputSet) dustLimitReached() bool {
-	return t.outputValue >= t.dustLimit
+// enoughInput returns true if we've accumulated enough inputs to pay the fees
+// and have at least one output that meets the dust limit.
+func (t *txInputSet) enoughInput() bool {
+	// If we have a change output above dust, then we certainly have enough
+	// inputs to the transaction.
+	if t.changeOutput >= t.dustLimit {
+		return true
+	}
+
+	// We did not have enough input for a change output. Check if we have
+	// enough input to pay the fees for a transaction with no change
+	// output.
+	fee := t.weightEstimate(false).fee()
+	if t.inputTotal < t.requiredOutput+fee {
+		return false
+	}
+
+	// We could pay the fees, but we still need at least one output to be
+	// above the dust limit for the tx to be valid (we assume that these
+	// required outputs only get added if they are above dust)
+	for _, inp := range t.inputs {
+		if inp.RequiredTxOut() != nil {
+			return true
+		}
+	}
+
+	return false
 }
 
 // add adds a new input to the set. It returns a bool indicating whether the
@@ -131,28 +189,35 @@ func (t *txInputSet) addToState(inp input.Input, constraints addConstraints) *tx
 		return nil
 	}
 
+	// If the input comes with a required tx out that is below dust, we
+	// won't add it.
+	reqOut := inp.RequiredTxOut()
+	if reqOut != nil && btcutil.Amount(reqOut.Value) < t.dustLimit {
+		return nil
+	}
+
 	// Clone the current set state.
 	s := t.clone()
 
 	// Add the new input.
 	s.inputs = append(s.inputs, inp)
 
-	// Can ignore error, because it has already been checked when
-	// calculating the yields.
-	_ = s.weightEstimate.add(inp)
-
 	// Add the value of the new input.
 	value := btcutil.Amount(inp.SignDesc().Output.Value)
 	s.inputTotal += value
 
 	// Recalculate the tx fee.
-	fee := s.weightEstimate.fee()
+	fee := s.weightEstimate(true).fee()
 
 	// Calculate the new output value.
-	s.outputValue = s.inputTotal - fee
+	if reqOut != nil {
+		s.requiredOutput += btcutil.Amount(reqOut.Value)
+	}
+	s.changeOutput = s.inputTotal - s.requiredOutput - fee
 
-	// Calculate the yield of this input from the change in tx output value.
-	inputYield := s.outputValue - t.outputValue
+	// Calculate the yield of this input from the change in total tx output
+	// value.
+	inputYield := s.totalOutput() - t.totalOutput()
 
 	switch constraints {
 
@@ -192,11 +257,11 @@ func (t *txInputSet) addToState(inp input.Input, constraints addConstraints) *tx
 		// value of the wallet input and what we get out of this
 		// transaction. To prevent attaching and locking a big utxo for
 		// very little benefit.
-		if !s.force && s.walletInputTotal >= s.outputValue {
+		if !s.force && s.walletInputTotal >= s.totalOutput() {
 			log.Debugf("Rejecting wallet input of %v, because it "+
 				"would make a negative yielding transaction "+
 				"(%v)",
-				value, s.outputValue-s.walletInputTotal)
+				value, s.totalOutput()-s.walletInputTotal)
 
 			return nil
 		}
@@ -250,8 +315,9 @@ func (t *txInputSet) addPositiveYieldInputs(sweepableInputs []txInput) {
 // tryAddWalletInputsIfNeeded retrieves utxos from the wallet and tries adding as
 // many as required to bring the tx output value above the given minimum.
 func (t *txInputSet) tryAddWalletInputsIfNeeded() error {
-	// If we've already reached the dust limit, no action is needed.
-	if t.dustLimitReached() {
+	// If we've already have enough to pay the transaction fees and have at
+	// least one output materialize, no action is needed.
+	if t.enoughInput() {
 		return nil
 	}
 
@@ -275,7 +341,7 @@ func (t *txInputSet) tryAddWalletInputsIfNeeded() error {
 		}
 
 		// Return if we've reached the minimum output amount.
-		if t.dustLimitReached() {
+		if t.enoughInput() {
 			return nil
 		}
 	}

--- a/sweep/tx_input_set.go
+++ b/sweep/tx_input_set.go
@@ -83,14 +83,18 @@ type txInputSet struct {
 	wallet Wallet
 }
 
+func dustLimit(relayFee chainfee.SatPerKWeight) btcutil.Amount {
+	return txrules.GetDustThreshold(
+		input.P2WPKHSize,
+		btcutil.Amount(relayFee.FeePerKVByte()),
+	)
+}
+
 // newTxInputSet constructs a new, empty input set.
 func newTxInputSet(wallet Wallet, feePerKW,
 	relayFee chainfee.SatPerKWeight, maxInputs int) *txInputSet {
 
-	dustLimit := txrules.GetDustThreshold(
-		input.P2WPKHSize,
-		btcutil.Amount(relayFee.FeePerKVByte()),
-	)
+	dustLimit := dustLimit(relayFee)
 
 	state := txInputSetState{
 		weightEstimate: newWeightEstimator(feePerKW),

--- a/sweep/tx_input_set_test.go
+++ b/sweep/tx_input_set_test.go
@@ -3,9 +3,11 @@ package sweep
 import (
 	"testing"
 
+	"github.com/btcsuite/btcd/wire"
 	"github.com/btcsuite/btcutil"
 	"github.com/lightningnetwork/lnd/input"
 	"github.com/lightningnetwork/lnd/lnwallet"
+	"github.com/stretchr/testify/require"
 )
 
 // TestTxInputSet tests adding various sized inputs to the set.
@@ -34,12 +36,15 @@ func TestTxInputSet(t *testing.T) {
 		t.Fatal("expected add of positively yielding input to succeed")
 	}
 
+	fee := set.weightEstimate(true).fee()
+	require.Equal(t, btcutil.Amount(439), fee)
+
 	// The tx output should now be 700-439 = 261 sats. The dust limit isn't
 	// reached yet.
-	if set.outputValue != 261 {
+	if set.totalOutput() != 261 {
 		t.Fatal("unexpected output value")
 	}
-	if set.dustLimitReached() {
+	if set.enoughInput() {
 		t.Fatal("expected dust limit not yet to be reached")
 	}
 
@@ -48,10 +53,10 @@ func TestTxInputSet(t *testing.T) {
 	if !set.add(createP2WKHInput(1000), constraintsRegular) {
 		t.Fatal("expected add of positively yielding input to succeed")
 	}
-	if set.outputValue != 988 {
+	if set.totalOutput() != 988 {
 		t.Fatal("unexpected output value")
 	}
-	if !set.dustLimitReached() {
+	if !set.enoughInput() {
 		t.Fatal("expected dust limit to be reached")
 	}
 }
@@ -73,7 +78,7 @@ func TestTxInputSetFromWallet(t *testing.T) {
 	if !set.add(createP2WKHInput(700), constraintsRegular) {
 		t.Fatal("expected add of positively yielding input to succeed")
 	}
-	if set.dustLimitReached() {
+	if set.enoughInput() {
 		t.Fatal("expected dust limit not yet to be reached")
 	}
 
@@ -92,7 +97,7 @@ func TestTxInputSetFromWallet(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if !set.dustLimitReached() {
+	if !set.enoughInput() {
 		t.Fatal("expected dust limit to be reached")
 	}
 }
@@ -116,4 +121,130 @@ func (m *mockWallet) ListUnspentWitness(minconfirms, maxconfirms int32) (
 			Value:       10000,
 		},
 	}, nil
+}
+
+type reqInput struct {
+	input.Input
+
+	txOut *wire.TxOut
+}
+
+func (r *reqInput) RequiredTxOut() *wire.TxOut {
+	return r.txOut
+}
+
+// TestTxInputSetRequiredOutput tests that the tx input set behaves as expected
+// when we add inputs that have required tx outs.
+func TestTxInputSetRequiredOutput(t *testing.T) {
+	const (
+		feeRate   = 1000
+		relayFee  = 300
+		maxInputs = 10
+	)
+	set := newTxInputSet(nil, feeRate, relayFee, maxInputs)
+	if set.dustLimit != 537 {
+		t.Fatalf("incorrect dust limit")
+	}
+
+	// Attempt to add an input with a required txout below the dust limit.
+	// This should fail since we cannot trim such outputs.
+	inp := &reqInput{
+		Input: createP2WKHInput(500),
+		txOut: &wire.TxOut{
+			Value:    500,
+			PkScript: make([]byte, 33),
+		},
+	}
+	require.False(t, set.add(inp, constraintsRegular),
+		"expected adding dust required tx out to fail")
+
+	// Create a 1000 sat input that also has a required TxOut of 1000 sat.
+	// The fee to sweep this input to a P2WKH output is 439 sats.
+	inp = &reqInput{
+		Input: createP2WKHInput(1000),
+		txOut: &wire.TxOut{
+			Value:    1000,
+			PkScript: make([]byte, 22),
+		},
+	}
+	require.True(t, set.add(inp, constraintsRegular), "failed adding input")
+
+	// The fee needed to pay for this input and output should be 439 sats.
+	fee := set.weightEstimate(false).fee()
+	require.Equal(t, btcutil.Amount(439), fee)
+
+	// Since the tx set currently pays no fees, we expect the current
+	// change to actually be negative, since this is what it would cost us
+	// in fees to add a change output.
+	feeWithChange := set.weightEstimate(true).fee()
+	if set.changeOutput != -feeWithChange {
+		t.Fatalf("expected negative change of %v, had %v",
+			-feeWithChange, set.changeOutput)
+	}
+
+	// This should also be reflected by not having enough input.
+	require.False(t, set.enoughInput())
+
+	// Get a weight estimate without change output, and add an additional
+	// input to it.
+	dummyInput := createP2WKHInput(1000)
+	weight := set.weightEstimate(false)
+	require.NoError(t, weight.add(dummyInput))
+
+	// Now we add a an input that is large enough to pay the fee for the
+	// transaction without a change output, but not large enough to afford
+	// adding a change output.
+	extraInput1 := weight.fee() + 100
+	require.True(t, set.add(createP2WKHInput(extraInput1), constraintsRegular),
+		"expected add of positively yielding input to succeed")
+
+	// The change should be negative, since we would have to add a change
+	// output, which we cannot yet afford.
+	if set.changeOutput >= 0 {
+		t.Fatal("expected change to be negaitve")
+	}
+
+	// Even though we cannot afford a change output, the tx set is valid,
+	// since we can pay the fees without the change output.
+	require.True(t, set.enoughInput())
+
+	// Get another weight estimate, this time with a change output, and
+	// figure out how much we must add to afford a change output.
+	weight = set.weightEstimate(true)
+	require.NoError(t, weight.add(dummyInput))
+
+	// We add what is left to reach this value.
+	extraInput2 := weight.fee() - extraInput1 + 100
+
+	// Add this input, which should result in the change now being 100 sats.
+	require.True(t, set.add(createP2WKHInput(extraInput2), constraintsRegular))
+
+	// The change should be 100, since this is what is left after paying
+	// fees in case of a change output.
+	change := set.changeOutput
+	if change != 100 {
+		t.Fatalf("expected change be 100, was %v", change)
+	}
+
+	// Even though the change output is dust, we have enough for fees, and
+	// we have an output, so it should be considered enough to craft a
+	// valid sweep transaction.
+	require.True(t, set.enoughInput())
+
+	// Finally we add an input that should push the change output above the
+	// dust limit.
+	weight = set.weightEstimate(true)
+	require.NoError(t, weight.add(dummyInput))
+
+	// We expect the change to everything that is left after paying the tx
+	// fee.
+	extraInput3 := weight.fee() - extraInput1 - extraInput2 + 1000
+	require.True(t, set.add(createP2WKHInput(extraInput3), constraintsRegular))
+
+	change = set.changeOutput
+	if change != 1000 {
+		t.Fatalf("expected change to be %v, had %v", 1000, change)
+
+	}
+	require.True(t, set.enoughInput())
 }

--- a/sweep/txgenerator.go
+++ b/sweep/txgenerator.go
@@ -110,17 +110,19 @@ func generateInputPartitionings(sweepableInputs []txInput,
 		// the dust limit, stop sweeping. Because of the sorting,
 		// continuing with the remaining inputs will only lead to sets
 		// with an even lower output value.
-		if !txInputs.dustLimitReached() {
-			log.Debugf("Set value %v below dust limit of %v",
-				txInputs.outputValue, txInputs.dustLimit)
+		if !txInputs.enoughInput() {
+			log.Debugf("Set value %v (r=%v, c=%v) below dust "+
+				"limit of %v", txInputs.totalOutput(),
+				txInputs.requiredOutput, txInputs.changeOutput,
+				txInputs.dustLimit)
 			return sets, nil
 		}
 
 		log.Infof("Candidate sweep set of size=%v (+%v wallet inputs), "+
 			"has yield=%v, weight=%v",
 			inputCount, len(txInputs.inputs)-inputCount,
-			txInputs.outputValue-txInputs.walletInputTotal,
-			txInputs.weightEstimate.weight())
+			txInputs.totalOutput()-txInputs.walletInputTotal,
+			txInputs.weightEstimate(true).weight())
 
 		sets = append(sets, txInputs.inputs)
 		sweepableInputs = sweepableInputs[inputCount:]

--- a/sweep/walletsweep.go
+++ b/sweep/walletsweep.go
@@ -153,10 +153,10 @@ type WalletSweepPackage struct {
 // by the delivery address. The sweep transaction will be crafted with the
 // target fee rate, and will use the utxoSource and outpointLocker as sources
 // for wallet funds.
-func CraftSweepAllTx(feeRate chainfee.SatPerKWeight, blockHeight uint32,
-	deliveryAddr btcutil.Address, coinSelectLocker CoinSelectionLocker,
-	utxoSource UtxoSource, outpointLocker OutpointLocker,
-	feeEstimator chainfee.Estimator,
+func CraftSweepAllTx(feeRate chainfee.SatPerKWeight, dustLimit btcutil.Amount,
+	blockHeight uint32, deliveryAddr btcutil.Address,
+	coinSelectLocker CoinSelectionLocker, utxoSource UtxoSource,
+	outpointLocker OutpointLocker, feeEstimator chainfee.Estimator,
 	signer input.Signer) (*WalletSweepPackage, error) {
 
 	// TODO(roasbeef): turn off ATPL as well when available?
@@ -273,7 +273,8 @@ func CraftSweepAllTx(feeRate chainfee.SatPerKWeight, blockHeight uint32,
 	// Finally, we'll ask the sweeper to craft a sweep transaction which
 	// respects our fee preference and targets all the UTXOs of the wallet.
 	sweepTx, err := createSweepTx(
-		inputsToSweep, deliveryPkScript, blockHeight, feeRate, signer,
+		inputsToSweep, deliveryPkScript, blockHeight, feeRate,
+		dustLimit, signer,
 	)
 	if err != nil {
 		unlockOutputs()

--- a/sweep/walletsweep_test.go
+++ b/sweep/walletsweep_test.go
@@ -288,7 +288,7 @@ func TestCraftSweepAllTxCoinSelectFail(t *testing.T) {
 	utxoLocker := newMockOutpointLocker()
 
 	_, err := CraftSweepAllTx(
-		0, 100, nil, coinSelectLocker, utxoSource, utxoLocker, nil, nil,
+		0, 100, 10, nil, coinSelectLocker, utxoSource, utxoLocker, nil, nil,
 	)
 
 	// Since we instructed the coin select locker to fail above, we should
@@ -313,7 +313,7 @@ func TestCraftSweepAllTxUnknownWitnessType(t *testing.T) {
 	utxoLocker := newMockOutpointLocker()
 
 	_, err := CraftSweepAllTx(
-		0, 100, nil, coinSelectLocker, utxoSource, utxoLocker, nil, nil,
+		0, 100, 10, nil, coinSelectLocker, utxoSource, utxoLocker, nil, nil,
 	)
 
 	// Since passed in a p2wsh output, which is unknown, we should fail to
@@ -347,7 +347,7 @@ func TestCraftSweepAllTx(t *testing.T) {
 	utxoLocker := newMockOutpointLocker()
 
 	sweepPkg, err := CraftSweepAllTx(
-		0, 100, deliveryAddr, coinSelectLocker, utxoSource, utxoLocker,
+		0, 100, 10, deliveryAddr, coinSelectLocker, utxoSource, utxoLocker,
 		feeEstimator, signer,
 	)
 	if err != nil {

--- a/sweep/weight_estimator.go
+++ b/sweep/weight_estimator.go
@@ -2,6 +2,7 @@ package sweep
 
 import (
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"github.com/btcsuite/btcd/wire"
 	"github.com/btcsuite/btcutil"
 	"github.com/lightningnetwork/lnd/input"
 	"github.com/lightningnetwork/lnd/lnwallet/chainfee"
@@ -90,6 +91,12 @@ func (w *weightEstimator) tryAddParent(inp input.Input) {
 // native P2WKH output.
 func (w *weightEstimator) addP2WKHOutput() {
 	w.estimator.AddP2WKHOutput()
+}
+
+// addOutput updates the weight estimate to account for the known
+// output given.
+func (w *weightEstimator) addOutput(txOut *wire.TxOut) {
+	w.estimator.AddTxOutput(txOut)
 }
 
 // weight gets the estimated weight of the transaction.

--- a/sweep/weight_estimator.go
+++ b/sweep/weight_estimator.go
@@ -26,22 +26,6 @@ func newWeightEstimator(feeRate chainfee.SatPerKWeight) *weightEstimator {
 	}
 }
 
-// clone returns a copy of this weight estimator.
-func (w *weightEstimator) clone() *weightEstimator {
-	parents := make(map[chainhash.Hash]struct{}, len(w.parents))
-	for hash := range w.parents {
-		parents[hash] = struct{}{}
-	}
-
-	return &weightEstimator{
-		estimator:     w.estimator,
-		feeRate:       w.feeRate,
-		parents:       parents,
-		parentsFee:    w.parentsFee,
-		parentsWeight: w.parentsWeight,
-	}
-}
-
 // add adds the weight of the given input to the weight estimate.
 func (w *weightEstimator) add(inp input.Input) error {
 	// If there is a parent tx, add the parent's fee and weight.


### PR DESCRIPTION
This PR adds support for inputs that put extra restrictions on the sweep tx, namely a locktime and accompanied output.

Two methods are added to the `Input` interface that for most normal inputs will do nothing:
```go
	// RequiredTxOut returns a non-nil TxOut if input commits to a certain
	// transaction output. This is used in the SINGLE|ANYONECANPAY case to
	// make sure any presigned input is still valid by including the
	// output.
	RequiredTxOut() *wire.TxOut

	// RequiredLockTime returns whether this input commits to a tx locktime
	// that must be used in the transaction including it.
	RequiredLockTime() (uint32, bool)
```

For certain inputs though, this is needed. Most notably we plan to use this for sweeping and aggregation of second level HTLC transactions for anchor channels. Since these transactions are pre-signed by the channel counterparty using sighash `SINGLE|ANYONECANPAY`, they can be altered at will _as long as the locktime and input-ouput pair stays intact_.

By allowing the sweeper to add such input-output pairs to the sweep transaction, we get BYOF (bring-your-own-fees) and HTLC aggregation for free.