### PR TITLE
feature: flip static remote key from optional to required

### DIFF
--- a/feature/default_sets.go
+++ b/feature/default_sets.go
@@ -24,7 +24,7 @@ var defaultSetDesc = setDesc{
 		SetInvoice:      {}, // 9
 		SetLegacyGlobal: {},
 	},
-	lnwire.StaticRemoteKeyOptional: {
+	lnwire.StaticRemoteKeyRequired: {
 		SetInit:         {}, // I
 		SetNodeAnn:      {}, // N
 		SetLegacyGlobal: {},


### PR DESCRIPTION
It's been sometime since we introduced this new safety enhancing feature
bit. At this point, we're now moving to require it as it makes our SCB
recovery system more robust, and it's also an implicit feature bit for
for anchor commitments as they're defined now.

