### PR TITLE
multi: use bitcoind uptime api for healthcheck

### DIFF
--- a/server.go
+++ b/server.go
@@ -1292,10 +1292,7 @@ func newServer(cfg *Config, listenAddrs []net.Addr,
 	// will not run it.
 	chainHealthCheck := healthcheck.NewObservation(
 		"chain backend",
-		func() error {
-			_, _, err := cc.ChainIO.GetBestBlock()
-			return err
-		},
+		cc.HealthCheck,
 		cfg.HealthChecks.ChainCheck.Interval,
 		cfg.HealthChecks.ChainCheck.Timeout,
 		cfg.HealthChecks.ChainCheck.Backoff,


### PR DESCRIPTION
Previously we were using `GetBestBlock` for all of our healthchecks. This was running into some issues with `bitcoind`, because the `GetBestBlock` rpc call uses the csmain lock, which is widely used, and would block for extended periods of time (5 minutes sometimes!). `btcd` has more granular locking, so it does not face these issues. 

This PR updates our chain backend health check to use the `uptime` api because it has no locking. Another option would be to use something like `estimatesmartfee` which uses a less common lock in `bitcoind` and does not need us to make an ad-hoc `rpcclient`. Decided against this because `estimatesmartfee` could crunch through mempool data unnecessarily. 

Fixes #4669. 
