### PR TITLE
lnd: return missing shutdown parameter

### DIFF
--- a/lnd.go
+++ b/lnd.go
@@ -1321,7 +1321,7 @@ func waitForWalletPassword(cfg *Config, restEndpoints []net.Addr,
 					ltndLog.Errorf("Could not unload "+
 						"wallet: %v", err)
 				}
-				return nil, err
+				return nil, shutdown, err
 			}
 		}
 


### PR DESCRIPTION
#4715 needed to be rebased again before merge, this PR adds the missing return param that is currently breaking the build. 
```
 github.com/lightningnetwork/lnd
./lnd.go:1324:5: not enough arguments to return
    have (nil, error)
    want (*WalletUnlockParams, func(), error)
make: *** [build] Error 2
```