### PR TITLE
GitHub: build release binaries and upload to release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,154 @@
+name: Release build
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+defaults:
+  run:
+    shell: bash
+
+env:
+  DOCKER_REPO: lightninglabs
+  DOCKER_IMAGE: lnd
+  GO_VERSION: 1.15.5
+
+jobs:
+  main:
+    name: Release build
+    runs-on: ubuntu-latest
+    steps:
+      - name: git checkout
+        uses: actions/checkout@v2
+
+      - name: go cache
+        uses: actions/cache@v1
+        with:
+          path: /home/runner/work/go
+          key: lnd-${{ runner.os }}-go-${{ env.GO_VERSION }}-${{ github.job }}-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            lnd-${{ runner.os }}-go-${{ env.GO_VERSION }}-${{ github.job }}-${{ hashFiles('**/go.sum') }}
+            lnd-${{ runner.os }}-go-${{ env.GO_VERSION }}-${{ github.job }}-
+            lnd-${{ runner.os }}-go-${{ env.GO_VERSION }}-
+            lnd-${{ runner.os }}-go-
+
+      - name: setup go ${{ env.GO_VERSION }}
+        uses: actions/setup-go@v2
+        with:
+          go-version: '~${{ env.GO_VERSION }}'
+
+      - name: Set env
+        run: echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
+
+      - name: build release for all architectures
+        run: make release tag=${{ env.RELEASE_VERSION }}
+
+      - name: Create Release
+        uses: softprops/action-gh-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ env.RELEASE_VERSION }}
+          name: lnd ${{ env.RELEASE_VERSION }}
+          draft: true
+          prerelease: false
+          files: lnd-${{ env.RELEASE_VERSION }}/*
+          body: |
+            # Database Migrations
+            TODO
+
+            # Verifying the Release
+
+            In order to verify the release, you'll need to have `gpg` or `gpg2` installed on your system. Once you've obtained a copy (and hopefully verified that as well), you'll first need to import the keys that have signed this release if you haven't done so already: 
+
+            ```
+            curl https://keybase.io/bitconner/pgp_keys.asc | gpg --import
+            ```
+
+            Once you have the required PGP keys, you can verify the release (assuming `manifest-${{ env.RELEASE_VERSION }}.txt` and `manifest-${{ env.RELEASE_VERSION }}.txt.sig` are in the current directory) with:
+
+            ```
+            gpg --verify manifest-${{ env.RELEASE_VERSION }}.txt.sig
+            ```
+
+            You should see the following if the verification was successful:
+
+            ```
+            gpg: assuming signed data in 'manifest-${{ env.RELEASE_VERSION }}.txt'
+            gpg: Signature made Thu Oct  1 16:38:32 2020 PDT
+            gpg:                using RSA key 9C8D61868A7C492003B2744EE7D737B67FA592C7
+            gpg: Good signature from "Conner Fromknecht <conner@lightning.engineering>" [ultimate]
+            ```
+
+            That will verify the signature of the manifest file, which ensures integrity and authenticity of the archive you've downloaded locally containing the binaries. Next, depending on your operating system, you should then re-compute the `sha256` hash of the archive with `shasum -a 256 <filename>`, compare it with the corresponding one in the manifest file, and ensure they match *exactly*.
+
+
+            For this release roasbeef's signature is the secondary signature which can be verified with the following command: 
+            ```
+            gpg --verify roasbeef-manifest-${{ env.RELEASE_VERSION }}.txt.sig manifest-${{ env.RELEASE_VERSION }}.txt
+            gpg: Signature made Wed Sep 30 17:35:20 2020 PDT
+            gpg:                using RSA key 4AB7F8DA6FAEBB3B70B1F903BC13F65E2DC84465
+            gpg: Good signature from "Olaoluwa Osuntokun <laolu32@gmail.com>" [ultimate]
+            ```
+
+            ## Verifying the Release Timestamp 
+
+            From this new version onwards, in addition time-stamping the _git tag_ with [OpenTimeStamps](https://opentimestamps.org/), we'll also now timestamp the manifest file along with its signature. Two new files are now included along with the rest of our release artifacts: ` manifest-${{ env.RELEASE_VERSION }}.txt.sig.ots` and `manifest-${{ env.RELEASE_VERSION }}.txt.ots`.
+
+            Assuming you have the opentimestamps client installed locally, the timestamps can be verified with the following commands: 
+            ```
+            ots verify manifest-${{ env.RELEASE_VERSION }}.txt.ots
+            ots verify manifest-${{ env.RELEASE_VERSION }}.txt.sig.ots -f roasbeef-manifest-${{ env.RELEASE_VERSION }}.txt.sig
+            ```
+
+            Alternatively, [the open timestamps website](https://opentimestamps.org/) can be used to verify timestamps if one doesn't have a `bitcoind` instance accessible locally. 
+
+            These timestamps should give users confidence in the integrity of this release even after the key that signed the release expires. 
+
+            ## Verifying the Release Binaries
+
+            Our release binaries are fully reproducible. Third parties are able to verify that the release binaries were produced properly without having to trust the release manager(s). See our [reproducible builds guide](https://github.com/lightningnetwork/lnd/tree/master/build/release) for how this can be achieved.
+            The release binaries are compiled with `go${{ env.GO_VERSION }}`, which is required by verifiers to arrive at the same ones.
+            They include the following build tags: `autopilotrpc`, `signrpc`, `walletrpc`, `chainrpc`, `invoicesrpc`, `routerrpc`, and `watchtowerrpc`. Note that these are already included in the release script, so they do not need to be provided.
+
+            The `make release` command can be used to ensure one rebuilds with all the same flags used for the release. If one wishes to build for only a single platform, then `make release sys=<OS-ARCH> tag=<tag>` can be used. 
+
+            Finally, you can also verify the _tag_ itself with the following command:
+
+            ```
+            $ git verify-tag ${{ env.RELEASE_VERSION }}
+            gpg: Signature made Tue Sep 15 18:55:00 2020 PDT
+            gpg:                using RSA key 4AB7F8DA6FAEBB3B70B1F903BC13F65E2DC84465
+            gpg: Good signature from "Olaoluwa Osuntokun <laolu32@gmail.com>" [ultimate]
+            ```
+
+            # Building the Contained Release 
+
+            Users are able to rebuild the target release themselves without having to fetch any of the dependencies. In order to do so, assuming
+            that `vendor.tar.gz` and `lnd-source-${{ env.RELEASE_VERSION }}.tar.gz` are in the current directory, follow these steps:
+
+            ```
+            tar -xvzf vendor.tar.gz
+            tar -xvzf lnd-source-${{ env.RELEASE_VERSION }}.tar.gz
+            GO111MODULE=on go install -v -mod=vendor -ldflags "-X github.com/lightningnetwork/lnd/build.Commit=${{ env.RELEASE_VERSION }}" ./cmd/lnd
+            GO111MODULE=on go install -v -mod=vendor -ldflags "-X github.com/lightningnetwork/lnd/build.Commit=${{ env.RELEASE_VERSION }}" ./cmd/lncli
+            ```
+
+            The `-mod=vendor` flag tells the `go build` command that it doesn't need to fetch the dependencies, and instead, they're all enclosed in the local vendor directory. 
+
+            Additionally, it's now possible to use the [enclosed `release.sh` script to bundle a release for a _specific_ system like so](https://github.com/lightningnetwork/lnd/pull/2191): 
+
+            ```
+            make release sys="linux-arm64 darwin-amd64"
+            ```
+
+            ⚡️⚡️⚡️ OK, now to the rest of the release notes! ⚡️⚡️⚡️
+
+            # Release Notes
+
+            TODO
+
+            # Contributors (Alphabetical Order)
+
+            TODO

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -42,7 +42,7 @@ jobs:
         run: echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
 
       - name: build release for all architectures
-        run: make release tag=${{ env.RELEASE_VERSION }}
+        run: SKIP_VERSION_CHECK=1 make release tag=${{ env.RELEASE_VERSION }}
 
       - name: Create Release
         uses: softprops/action-gh-release@v1

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -29,6 +29,13 @@ function red() {
 function check_tag_correct() {
   local tag=$1
 
+  # For automated builds we can skip this check as they will only be triggered
+  # on tags.
+  if [[ "$SKIP_VERSION_CHECK" -eq "1" ]]; then
+    green "skipping version check, assuming automated build"
+    exit 0
+  fi
+
   # If a tag is specified, ensure that that tag is present and checked out.
   if [[ $tag != $(git describe) ]]; then
     red "tag $tag not checked out"


### PR DESCRIPTION
This commit adds another GitHub workflow that is activated for each
pushed tag. The release binaries are compiled from that tag for all
supported architectures. A new release in the GitHub repository is then
created for the tag and the finished binary packages are uploaded to
that release.

Example build can be seen here: https://github.com/guggero/lnd/runs/1423819682?check_suite_focus=true
Result can be seen here: https://github.com/guggero/lnd/releases/tag/v0.0.0-beta.test3 (taken out of draft mode manually for it to be visible to anyone).

Before the manual edit, it looked like this (confirming draft mode):
![gh-actions-release-draft](https://user-images.githubusercontent.com/1008879/99660983-73ed6a00-2a63-11eb-910a-cedc66e78cde.png)

