### PR TITLE
chainwatcher: properly derive to_local script for "future" local force closes

### DIFF
--- a/channeldb/channel.go
+++ b/channeldb/channel.go
@@ -163,9 +163,9 @@ var (
 	// channel.
 	ErrChanBorked = fmt.Errorf("cannot mutate borked channel")
 
-	// errLogEntryNotFound is returned when we cannot find a log entry at
+	// ErrLogEntryNotFound is returned when we cannot find a log entry at
 	// the height requested in the revocation log.
-	errLogEntryNotFound = fmt.Errorf("log entry not found")
+	ErrLogEntryNotFound = fmt.Errorf("log entry not found")
 
 	// errHeightNotFound is returned when a query for channel balances at
 	// a height that we have not reached yet is made.
@@ -3469,7 +3469,7 @@ func fetchChannelLogEntry(log kvdb.RBucket,
 	logEntrykey := makeLogKey(updateNum)
 	commitBytes := log.Get(logEntrykey[:])
 	if commitBytes == nil {
-		return ChannelCommitment{}, errLogEntryNotFound
+		return ChannelCommitment{}, ErrLogEntryNotFound
 	}
 
 	commitReader := bytes.NewReader(commitBytes)

--- a/channeldb/channel_test.go
+++ b/channeldb/channel_test.go
@@ -1485,7 +1485,7 @@ func TestBalanceAtHeight(t *testing.T) {
 			targetHeight:          unknownHeight,
 			expectedLocalBalance:  0,
 			expectedRemoteBalance: 0,
-			expectedError:         errLogEntryNotFound,
+			expectedError:         ErrLogEntryNotFound,
 		},
 		{
 			name:                  "height not reached",

--- a/contractcourt/utils_test.go
+++ b/contractcourt/utils_test.go
@@ -1,10 +1,16 @@
 package contractcourt
 
 import (
+	"fmt"
+	"io"
+	"io/ioutil"
 	"os"
+	"path/filepath"
 	"runtime/pprof"
 	"testing"
 	"time"
+
+	"github.com/lightningnetwork/lnd/channeldb"
 )
 
 // timeout implements a test level timeout.
@@ -23,4 +29,70 @@ func timeout(t *testing.T) func() {
 	return func() {
 		close(done)
 	}
+}
+
+func copyFile(dest, src string) error {
+	s, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer s.Close()
+
+	d, err := os.Create(dest)
+	if err != nil {
+		return err
+	}
+
+	if _, err := io.Copy(d, s); err != nil {
+		d.Close()
+		return err
+	}
+
+	return d.Close()
+}
+
+// copyChannelState copies the OpenChannel state by copying the database and
+// creating a new struct from it. The copied state and a cleanup function are
+// returned.
+func copyChannelState(state *channeldb.OpenChannel) (
+	*channeldb.OpenChannel, func(), error) {
+
+	// Make a copy of the DB.
+	dbFile := filepath.Join(state.Db.Path(), "channel.db")
+	tempDbPath, err := ioutil.TempDir("", "past-state")
+	if err != nil {
+		return nil, nil, err
+	}
+
+	cleanup := func() {
+		os.RemoveAll(tempDbPath)
+	}
+
+	tempDbFile := filepath.Join(tempDbPath, "channel.db")
+	err = copyFile(tempDbFile, dbFile)
+	if err != nil {
+		cleanup()
+		return nil, nil, err
+	}
+
+	newDb, err := channeldb.Open(tempDbPath)
+	if err != nil {
+		cleanup()
+		return nil, nil, err
+	}
+
+	chans, err := newDb.FetchAllChannels()
+	if err != nil {
+		cleanup()
+		return nil, nil, err
+	}
+
+	// We only support DBs with a single channel, for now.
+	if len(chans) != 1 {
+		cleanup()
+		return nil, nil, fmt.Errorf("found %d chans in the db",
+			len(chans))
+	}
+
+	return chans[0], cleanup, nil
 }

--- a/lnwallet/test_utils.go
+++ b/lnwallet/test_utils.go
@@ -262,7 +262,7 @@ func CreateTestChannels(chanType channeldb.ChannelType) (
 	)
 	bobBalance := lnwire.NewMSatFromSatoshis(channelBal)
 
-	aliceCommit := channeldb.ChannelCommitment{
+	aliceLocalCommit := channeldb.ChannelCommitment{
 		CommitHeight:  0,
 		LocalBalance:  aliceBalance,
 		RemoteBalance: bobBalance,
@@ -271,13 +271,31 @@ func CreateTestChannels(chanType channeldb.ChannelType) (
 		CommitTx:      aliceCommitTx,
 		CommitSig:     testSigBytes,
 	}
-	bobCommit := channeldb.ChannelCommitment{
+	aliceRemoteCommit := channeldb.ChannelCommitment{
+		CommitHeight:  0,
+		LocalBalance:  aliceBalance,
+		RemoteBalance: bobBalance,
+		CommitFee:     commitFee,
+		FeePerKw:      btcutil.Amount(feePerKw),
+		CommitTx:      bobCommitTx,
+		CommitSig:     testSigBytes,
+	}
+	bobLocalCommit := channeldb.ChannelCommitment{
 		CommitHeight:  0,
 		LocalBalance:  bobBalance,
 		RemoteBalance: aliceBalance,
 		CommitFee:     commitFee,
 		FeePerKw:      btcutil.Amount(feePerKw),
 		CommitTx:      bobCommitTx,
+		CommitSig:     testSigBytes,
+	}
+	bobRemoteCommit := channeldb.ChannelCommitment{
+		CommitHeight:  0,
+		LocalBalance:  bobBalance,
+		RemoteBalance: aliceBalance,
+		CommitFee:     commitFee,
+		FeePerKw:      btcutil.Amount(feePerKw),
+		CommitTx:      aliceCommitTx,
 		CommitSig:     testSigBytes,
 	}
 
@@ -302,8 +320,8 @@ func CreateTestChannels(chanType channeldb.ChannelType) (
 		RemoteCurrentRevocation: bobCommitPoint,
 		RevocationProducer:      alicePreimageProducer,
 		RevocationStore:         shachain.NewRevocationStore(),
-		LocalCommitment:         aliceCommit,
-		RemoteCommitment:        aliceCommit,
+		LocalCommitment:         aliceLocalCommit,
+		RemoteCommitment:        aliceRemoteCommit,
 		Db:                      dbAlice,
 		Packager:                channeldb.NewChannelPackager(shortChanID),
 		FundingTxn:              testTx,
@@ -320,8 +338,8 @@ func CreateTestChannels(chanType channeldb.ChannelType) (
 		RemoteCurrentRevocation: aliceCommitPoint,
 		RevocationProducer:      bobPreimageProducer,
 		RevocationStore:         shachain.NewRevocationStore(),
-		LocalCommitment:         bobCommit,
-		RemoteCommitment:        bobCommit,
+		LocalCommitment:         bobLocalCommit,
+		RemoteCommitment:        bobRemoteCommit,
 		Db:                      dbBob,
 		Packager:                channeldb.NewChannelPackager(shortChanID),
 	}


### PR DESCRIPTION
This PR fixes a bug within the chain watcher, in case we lost state or attempted recovery **after** we had force closed. In this scenario we would use the wrong state number when deriving our local script, which caused us to ignore the `to_local` output and fail sweeping the funds.

Since we cannot tell from the state number directly if it's a local or remote force close, we move to first handle all known states before we use the state number to derive the scripts for our "future" state.

The scenario in question is added to the tests cases.