### PR TITLE
lntest/timeouts: fix timeout build predicates

### DIFF
--- a/lntest/timeouts.go
+++ b/lntest/timeouts.go
@@ -1,4 +1,4 @@
-// +build !darwin, !kvdb_etcd
+// +build !darwin,!kvdb_etcd
 
 package lntest
 

--- a/lntest/timeouts_darwin.go
+++ b/lntest/timeouts_darwin.go
@@ -1,4 +1,4 @@
-// +build darwin
+// +build darwin,!kvdb_etcd
 
 package lntest
 

--- a/lntest/timeouts_etcd.go
+++ b/lntest/timeouts_etcd.go
@@ -1,4 +1,4 @@
-// +build !darwin,kvdb_etcd
+// +build kvdb_etcd
 
 package lntest
 

--- a/lntest/timeouts_etcd.go
+++ b/lntest/timeouts_etcd.go
@@ -1,4 +1,4 @@
-// +build !darwin, kvdb_etcd
+// +build !darwin,kvdb_etcd
 
 package lntest
 


### PR DESCRIPTION
This PR removes spaces from the timeout build predicates, which causes parsing errors
when compiling/linting darwin targets. We also correct the timeouts to use the etcd
timeouts when running w/ `darwin,kvdb_etcd`, which currently fall back to plain darwin
timeouts.