### PR TITLE
autopilot: fix returned map size in mergeNodeMaps

### DIFF
--- a/autopilot/agent.go
+++ b/autopilot/agent.go
@@ -364,7 +364,7 @@ func mergeNodeMaps(c map[NodeID]LocalChannel,
 		numNodes += len(skip)
 	}
 
-	res := make(map[NodeID]struct{}, len(c)+numNodes)
+	res := make(map[NodeID]struct{}, numNodes)
 	for nodeID := range c {
 		res[nodeID] = struct{}{}
 	}


### PR DESCRIPTION
Looks like we are allocating extra `len(c)` for the size of `res`.