### PR TITLE
discovery: rate limit incoming channel updates

### DIFF
--- a/channeldb/graph.go
+++ b/channeldb/graph.go
@@ -2862,8 +2862,7 @@ func (c *ChannelEdgePolicy) SetSigBytes(sig []byte) {
 
 // IsDisabled determines whether the edge has the disabled bit set.
 func (c *ChannelEdgePolicy) IsDisabled() bool {
-	return c.ChannelFlags&lnwire.ChanUpdateDisabled ==
-		lnwire.ChanUpdateDisabled
+	return c.ChannelFlags.IsDisabled()
 }
 
 // ComputeFee computes the fee to forward an HTLC of `amt` milli-satoshis over

--- a/lnwire/channel_update.go
+++ b/lnwire/channel_update.go
@@ -47,6 +47,11 @@ const (
 	ChanUpdateDisabled
 )
 
+// IsDisabled determines whether the channel flags has the disabled bit set.
+func (c ChanUpdateChanFlags) IsDisabled() bool {
+	return c&ChanUpdateDisabled == ChanUpdateDisabled
+}
+
 // String returns the bitfield flags as a string.
 func (c ChanUpdateChanFlags) String() string {
 	return fmt.Sprintf("%08b", c)


### PR DESCRIPTION
This change was largely motivated by an increase in high disk usage as a result of channel update spam and serves as an initial step towards https://github.com/lightningnetwork/lnd/issues/4724. With an in memory graph, this would've gone mostly undetected except for the increased bandwidth usage, which this doesn't aim to solve yet. To minimize the effects to disks, we begin to rate limit channel updates in two ways. Keep alive updates, those which only increase their timestamps to signal liveliness, are now limited to one per lnd's rebroadcast interval (current default of 24H). Non keep alive updates are now limited to one per block per direction.