### PR TITLE
kvdb: add timeout options for bbolt

### DIFF
--- a/chainntnfs/test_utils.go
+++ b/chainntnfs/test_utils.go
@@ -24,6 +24,7 @@ import (
 	"github.com/btcsuite/btcwallet/chain"
 	"github.com/btcsuite/btcwallet/walletdb"
 	"github.com/lightninglabs/neutrino"
+	"github.com/lightningnetwork/lnd/channeldb/kvdb"
 )
 
 var (
@@ -268,7 +269,9 @@ func NewNeutrinoBackend(t *testing.T, minerAddr string) (*neutrino.ChainService,
 	}
 
 	dbName := filepath.Join(spvDir, "neutrino.db")
-	spvDatabase, err := walletdb.Create("bdb", dbName, true)
+	spvDatabase, err := walletdb.Create(
+		"bdb", dbName, true, kvdb.DefaultDBTimeout,
+	)
 	if err != nil {
 		os.RemoveAll(spvDir)
 		t.Fatalf("unable to create walletdb: %v", err)

--- a/chainreg/chainregistry.go
+++ b/chainreg/chainregistry.go
@@ -101,6 +101,10 @@ type Config struct {
 	// FeeURL defines the URL for fee estimation we will use. This field is
 	// optional.
 	FeeURL string
+
+	// DBTimeOut specifies the timeout value to use when opening the wallet
+	// database.
+	DBTimeOut time.Duration
 }
 
 const (
@@ -273,6 +277,7 @@ func NewChainControl(cfg *Config) (*ChainControl, error) {
 		NetParams:      cfg.ActiveNetParams.Params,
 		CoinType:       cfg.ActiveNetParams.CoinType,
 		Wallet:         cfg.Wallet,
+		DBTimeOut:      cfg.DBTimeOut,
 	}
 
 	var err error

--- a/channeldb/db.go
+++ b/channeldb/db.go
@@ -244,6 +244,7 @@ func Open(dbPath string, modifiers ...OptionModifier) (*DB, error) {
 		NoFreelistSync:    opts.NoFreelistSync,
 		AutoCompact:       opts.AutoCompact,
 		AutoCompactMinAge: opts.AutoCompactMinAge,
+		DBTimeout:         opts.DBTimeout,
 	})
 	if err != nil {
 		return nil, err

--- a/channeldb/forwarding_package_test.go
+++ b/channeldb/forwarding_package_test.go
@@ -808,7 +808,9 @@ func makeFwdPkgDB(t *testing.T, path string) kvdb.Backend { // nolint:unparam
 		path = filepath.Join(path, "fwdpkg.db")
 	}
 
-	bdb, err := kvdb.Create(kvdb.BoltBackendName, path, true)
+	bdb, err := kvdb.Create(
+		kvdb.BoltBackendName, path, true, kvdb.DefaultDBTimeout,
+	)
 	if err != nil {
 		t.Fatalf("unable to open boltdb: %v", err)
 	}

--- a/channeldb/kvdb/bolt_compact.go
+++ b/channeldb/kvdb/bolt_compact.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"os"
 	"path"
+	"time"
 
 	"github.com/lightningnetwork/lnd/healthcheck"
 	"go.etcd.io/bbolt"
@@ -38,6 +39,9 @@ type compacter struct {
 	srcPath   string
 	dstPath   string
 	txMaxSize int64
+
+	// dbTimeout specifies the timeout value used when opening the db.
+	dbTimeout time.Duration
 }
 
 // execute opens the source and destination databases and then compacts the
@@ -79,6 +83,7 @@ func (cmd *compacter) execute() (int64, int64, error) {
 	// possible freelist sync problems.
 	src, err := bbolt.Open(cmd.srcPath, 0444, &bbolt.Options{
 		ReadOnly: true,
+		Timeout:  cmd.dbTimeout,
 	})
 	if err != nil {
 		return 0, 0, fmt.Errorf("error opening source database: %v",
@@ -91,7 +96,9 @@ func (cmd *compacter) execute() (int64, int64, error) {
 	}()
 
 	// Open destination database.
-	dst, err := bbolt.Open(cmd.dstPath, fi.Mode(), nil)
+	dst, err := bbolt.Open(cmd.dstPath, fi.Mode(), &bbolt.Options{
+		Timeout: cmd.dbTimeout,
+	})
 	if err != nil {
 		return 0, 0, fmt.Errorf("error opening destination database: "+
 			"%v", err)

--- a/channeldb/kvdb/config.go
+++ b/channeldb/kvdb/config.go
@@ -17,6 +17,10 @@ const (
 	// have passed since a bolt database file was last compacted for the
 	// compaction to be considered again.
 	DefaultBoltAutoCompactMinAge = time.Hour * 24 * 7
+
+	// DefaultDBTimeout specifies the default timeout value when opening
+	// the bbolt database.
+	DefaultDBTimeout = time.Second * 60
 )
 
 // BoltConfig holds bolt configuration.
@@ -26,6 +30,8 @@ type BoltConfig struct {
 	AutoCompact bool `long:"auto-compact" description:"Whether the databases used within lnd should automatically be compacted on every startup (and if the database has the configured minimum age). This is disabled by default because it requires additional disk space to be available during the compaction that is freed afterwards. In general compaction leads to smaller database files."`
 
 	AutoCompactMinAge time.Duration `long:"auto-compact-min-age" description:"How long ago the last compaction of a database file must be for it to be considered for auto compaction again. Can be set to 0 to compact on every startup."`
+
+	DBTimeout time.Duration `long:"dbtimeout" description:"Specify the timeout value used when opening the database."`
 }
 
 // EtcdConfig holds etcd configuration.

--- a/channeldb/migration_01_to_11/db.go
+++ b/channeldb/migration_01_to_11/db.go
@@ -55,7 +55,10 @@ func Open(dbPath string, modifiers ...OptionModifier) (*DB, error) {
 
 	// Specify bbolt freelist options to reduce heap pressure in case the
 	// freelist grows to be very large.
-	bdb, err := kvdb.Open(kvdb.BoltBackendName, path, opts.NoFreelistSync)
+	bdb, err := kvdb.Open(
+		kvdb.BoltBackendName, path,
+		opts.NoFreelistSync, opts.DBTimeout,
+	)
 	if err != nil {
 		return nil, err
 	}
@@ -84,7 +87,9 @@ func createChannelDB(dbPath string) error {
 	}
 
 	path := filepath.Join(dbPath, dbName)
-	bdb, err := kvdb.Create(kvdb.BoltBackendName, path, false)
+	bdb, err := kvdb.Create(
+		kvdb.BoltBackendName, path, false, kvdb.DefaultDBTimeout,
+	)
 	if err != nil {
 		return err
 	}

--- a/channeldb/migration_01_to_11/options.go
+++ b/channeldb/migration_01_to_11/options.go
@@ -1,5 +1,7 @@
 package migration_01_to_11
 
+import "time"
+
 const (
 	// DefaultRejectCacheSize is the default number of rejectCacheEntries to
 	// cache for use in the rejection cache of incoming gossip traffic. This
@@ -10,6 +12,10 @@ const (
 	// in order to reply to gossip queries. This produces a cache size of
 	// around 40MB.
 	DefaultChannelCacheSize = 20000
+
+	// DefaultDBTimeout specifies the default timeout value when opening
+	// the bbolt database.
+	DefaultDBTimeout = time.Second * 60
 )
 
 // Options holds parameters for tuning and customizing a channeldb.DB.
@@ -26,6 +32,10 @@ type Options struct {
 	// freelist to disk, resulting in improved performance at the expense of
 	// increased startup time.
 	NoFreelistSync bool
+
+	// DBTimeout specifies the timeout value to use when opening the wallet
+	// database.
+	DBTimeout time.Duration
 }
 
 // DefaultOptions returns an Options populated with default values.
@@ -34,6 +44,7 @@ func DefaultOptions() Options {
 		RejectCacheSize:  DefaultRejectCacheSize,
 		ChannelCacheSize: DefaultChannelCacheSize,
 		NoFreelistSync:   true,
+		DBTimeout:        DefaultDBTimeout,
 	}
 }
 

--- a/channeldb/migtest/migtest.go
+++ b/channeldb/migtest/migtest.go
@@ -20,7 +20,9 @@ func MakeDB() (kvdb.Backend, func(), error) {
 	}
 
 	dbPath := file.Name()
-	db, err := kvdb.Open(kvdb.BoltBackendName, dbPath, true)
+	db, err := kvdb.Open(
+		kvdb.BoltBackendName, dbPath, true, kvdb.DefaultDBTimeout,
+	)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/channeldb/options.go
+++ b/channeldb/options.go
@@ -46,6 +46,7 @@ func DefaultOptions() Options {
 			NoFreelistSync:    true,
 			AutoCompact:       false,
 			AutoCompactMinAge: kvdb.DefaultBoltAutoCompactMinAge,
+			DBTimeout:         kvdb.DefaultDBTimeout,
 		},
 		RejectCacheSize:  DefaultRejectCacheSize,
 		ChannelCacheSize: DefaultChannelCacheSize,

--- a/channeldb/options_test.go
+++ b/channeldb/options_test.go
@@ -1,0 +1,28 @@
+package channeldb_test
+
+import (
+	"testing"
+
+	"github.com/lightningnetwork/lnd/channeldb"
+	"github.com/lightningnetwork/lnd/channeldb/kvdb"
+	"github.com/stretchr/testify/require"
+)
+
+// TestDefaultOptions tests the default options are created as intended.
+func TestDefaultOptions(t *testing.T) {
+
+	opts := channeldb.DefaultOptions()
+
+	require.True(t, opts.NoFreelistSync)
+	require.False(t, opts.AutoCompact)
+	require.Equal(
+		t, kvdb.DefaultBoltAutoCompactMinAge, opts.AutoCompactMinAge,
+	)
+	require.Equal(t, kvdb.DefaultDBTimeout, opts.DBTimeout)
+	require.Equal(
+		t, channeldb.DefaultRejectCacheSize, opts.RejectCacheSize,
+	)
+	require.Equal(
+		t, channeldb.DefaultChannelCacheSize, opts.ChannelCacheSize,
+	)
+}

--- a/contractcourt/briefcase_test.go
+++ b/contractcourt/briefcase_test.go
@@ -112,7 +112,10 @@ func makeTestDB() (kvdb.Backend, func(), error) {
 		return nil, nil, err
 	}
 
-	db, err := kvdb.Create(kvdb.BoltBackendName, tempDirName+"/test.db", true)
+	db, err := kvdb.Create(
+		kvdb.BoltBackendName, tempDirName+"/test.db", true,
+		kvdb.DefaultDBTimeout,
+	)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/contractcourt/channel_arbitrator_test.go
+++ b/contractcourt/channel_arbitrator_test.go
@@ -392,7 +392,10 @@ func createTestChannelArbitrator(t *testing.T, log ArbitratorLog,
 			return nil, err
 		}
 		dbPath := filepath.Join(dbDir, "testdb")
-		db, err := kvdb.Create(kvdb.BoltBackendName, dbPath, true)
+		db, err := kvdb.Create(
+			kvdb.BoltBackendName, dbPath, true,
+			kvdb.DefaultDBTimeout,
+		)
 		if err != nil {
 			return nil, err
 		}

--- a/go.mod
+++ b/go.mod
@@ -9,10 +9,10 @@ require (
 	github.com/btcsuite/btclog v0.0.0-20170628155309-84c8d2346e9f
 	github.com/btcsuite/btcutil v1.0.2
 	github.com/btcsuite/btcutil/psbt v1.0.3-0.20200826194809-5f93e33af2b0
-	github.com/btcsuite/btcwallet v0.11.1-0.20201104022105-a6f3888450e4
+	github.com/btcsuite/btcwallet v0.11.1-0.20201119022810-664f77ded195
 	github.com/btcsuite/btcwallet/wallet/txauthor v1.0.0
 	github.com/btcsuite/btcwallet/wallet/txrules v1.0.0
-	github.com/btcsuite/btcwallet/walletdb v1.3.3
+	github.com/btcsuite/btcwallet/walletdb v1.3.4-0.20201106155705-08308c81eda0
 	github.com/btcsuite/btcwallet/wtxmgr v1.2.0
 	github.com/coreos/etcd v3.3.22+incompatible
 	github.com/coreos/go-semver v0.3.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -39,6 +39,8 @@ github.com/btcsuite/btcutil/psbt v1.0.3-0.20200826194809-5f93e33af2b0 h1:3Zumkyl
 github.com/btcsuite/btcutil/psbt v1.0.3-0.20200826194809-5f93e33af2b0/go.mod h1:LVveMu4VaNSkIRTZu2+ut0HDBRuYjqGocxDMNS1KuGQ=
 github.com/btcsuite/btcwallet v0.11.1-0.20201104022105-a6f3888450e4 h1:iipg6ldTL0y69KLicrd0gLhY/yErB0rG4a84uQbu7ao=
 github.com/btcsuite/btcwallet v0.11.1-0.20201104022105-a6f3888450e4/go.mod h1:owv9oZqM0HnUW+ByF7VqOgfs2eb0ooiePW/+Tl/i/Nk=
+github.com/btcsuite/btcwallet v0.11.1-0.20201119022810-664f77ded195 h1:QjMLhLVZlpMjgWH5FK0dvwcXAhO2/80g4opgUDa9mAQ=
+github.com/btcsuite/btcwallet v0.11.1-0.20201119022810-664f77ded195/go.mod h1:owv9oZqM0HnUW+ByF7VqOgfs2eb0ooiePW/+Tl/i/Nk=
 github.com/btcsuite/btcwallet/wallet/txauthor v1.0.0 h1:KGHMW5sd7yDdDMkCZ/JpP0KltolFsQcB973brBnfj4c=
 github.com/btcsuite/btcwallet/wallet/txauthor v1.0.0/go.mod h1:VufDts7bd/zs3GV13f/lXc/0lXrPnvxD/NvmpG/FEKU=
 github.com/btcsuite/btcwallet/wallet/txrules v1.0.0 h1:2VsfS0sBedcM5KmDzRMT3+b6xobqWveZGvjb+jFez5w=
@@ -51,6 +53,8 @@ github.com/btcsuite/btcwallet/walletdb v1.3.2 h1:nFnMBVgkqoVOx08Z756oDwNc9sdVgYR
 github.com/btcsuite/btcwallet/walletdb v1.3.2/go.mod h1:GZCMPNpUu5KE3ASoVd+k06p/1OW8OwNGCCaNWRto2cQ=
 github.com/btcsuite/btcwallet/walletdb v1.3.3 h1:u6e7vRIKBF++cJy+hOHaMGg+88ZTwvpaY27AFvtB668=
 github.com/btcsuite/btcwallet/walletdb v1.3.3/go.mod h1:oJDxAEUHVtnmIIBaa22wSBPTVcs6hUp5NKWmI8xDwwU=
+github.com/btcsuite/btcwallet/walletdb v1.3.4-0.20201106155705-08308c81eda0 h1:1ErPv22GAP5CKfQ1cSv5ROu+mSlDvzUOHpOuSnjVU9g=
+github.com/btcsuite/btcwallet/walletdb v1.3.4-0.20201106155705-08308c81eda0/go.mod h1:oJDxAEUHVtnmIIBaa22wSBPTVcs6hUp5NKWmI8xDwwU=
 github.com/btcsuite/btcwallet/wtxmgr v1.0.0/go.mod h1:vc4gBprll6BP0UJ+AIGDaySoc7MdAmZf8kelfNb8CFY=
 github.com/btcsuite/btcwallet/wtxmgr v1.2.0 h1:ZUYPsSv8GjF9KK7lboB2OVHF0uYEcHxgrCfFWqPd9NA=
 github.com/btcsuite/btcwallet/wtxmgr v1.2.0/go.mod h1:h8hkcKUE3X7lMPzTUoGnNiw5g7VhGrKEW3KpR2r0VnY=

--- a/htlcswitch/decayedlog.go
+++ b/htlcswitch/decayedlog.go
@@ -73,6 +73,7 @@ func NewDecayedLog(dbPath, dbFileName string, boltCfg *kvdb.BoltConfig,
 		NoFreelistSync:    true,
 		AutoCompact:       boltCfg.AutoCompact,
 		AutoCompactMinAge: boltCfg.AutoCompactMinAge,
+		DBTimeout:         boltCfg.DBTimeout,
 	}
 
 	// Use default path for log database

--- a/keychain/interface_test.go
+++ b/keychain/interface_test.go
@@ -42,6 +42,9 @@ var (
 		0x4f, 0x2f, 0x6f, 0x25, 0x98, 0xa3, 0xef, 0xb9,
 		0x69, 0x49, 0x18, 0x83, 0x31, 0x98, 0x47, 0x53,
 	}
+
+	// testDBTimeout is the wallet db timeout value used in this test.
+	testDBTimeout = time.Second * 10
 )
 
 func createTestBtcWallet(coinType uint32) (func(), *wallet.Wallet, error) {
@@ -62,7 +65,9 @@ func createTestBtcWallet(coinType uint32) (func(), *wallet.Wallet, error) {
 	if err != nil {
 		return nil, nil, err
 	}
-	loader := wallet.NewLoader(&chaincfg.SimNetParams, tempDir, true, 0)
+	loader := wallet.NewLoader(
+		&chaincfg.SimNetParams, tempDir, true, testDBTimeout, 0,
+	)
 
 	pass := []byte("test")
 

--- a/lncfg/db.go
+++ b/lncfg/db.go
@@ -28,6 +28,7 @@ func DefaultDB() *DB {
 		Backend: BoltBackend,
 		Bolt: &kvdb.BoltConfig{
 			AutoCompactMinAge: kvdb.DefaultBoltAutoCompactMinAge,
+			DBTimeout:         kvdb.DefaultDBTimeout,
 		},
 	}
 }
@@ -90,6 +91,7 @@ func (db *DB) GetBackends(ctx context.Context, dbPath string,
 	localDB, err = kvdb.GetBoltBackend(&kvdb.BoltBackendConfig{
 		DBPath:            dbPath,
 		DBFileName:        dbName,
+		DBTimeout:         db.Bolt.DBTimeout,
 		NoFreelistSync:    !db.Bolt.SyncFreelist,
 		AutoCompact:       db.Bolt.AutoCompact,
 		AutoCompactMinAge: db.Bolt.AutoCompactMinAge,

--- a/lncfg/db_test.go
+++ b/lncfg/db_test.go
@@ -1,0 +1,24 @@
+package lncfg_test
+
+import (
+	"testing"
+
+	"github.com/lightningnetwork/lnd/channeldb/kvdb"
+	"github.com/lightningnetwork/lnd/lncfg"
+	"github.com/stretchr/testify/require"
+)
+
+// TestDBDefaultConfig tests that the default DB config is created as expected.
+func TestDBDefaultConfig(t *testing.T) {
+	defaultConfig := lncfg.DefaultDB()
+
+	require.Equal(t, lncfg.BoltBackend, defaultConfig.Backend)
+	require.Equal(
+		t, kvdb.DefaultBoltAutoCompactMinAge,
+		defaultConfig.Bolt.AutoCompactMinAge,
+	)
+	require.Equal(t, kvdb.DefaultDBTimeout, defaultConfig.Bolt.DBTimeout)
+	// Implicitly, the following fields are default to false.
+	require.False(t, defaultConfig.Bolt.AutoCompact)
+	require.False(t, defaultConfig.Bolt.SyncFreelist)
+}

--- a/lnd.go
+++ b/lnd.go
@@ -412,7 +412,7 @@ func Main(cfg *Config, lisCfg ListenerCfg, shutdownChan <-chan struct{}) error {
 		// Create the macaroon authentication/authorization service.
 		macaroonService, err = macaroons.NewService(
 			cfg.networkDir, "lnd", walletInitParams.StatelessInit,
-			macaroons.IPLockChecker,
+			cfg.DB.Bolt.DBTimeout, macaroons.IPLockChecker,
 		)
 		if err != nil {
 			err := fmt.Errorf("unable to set up macaroon "+
@@ -522,6 +522,7 @@ func Main(cfg *Config, lisCfg ListenerCfg, shutdownChan <-chan struct{}) error {
 		Birthday:                    walletInitParams.Birthday,
 		RecoveryWindow:              walletInitParams.RecoveryWindow,
 		Wallet:                      walletInitParams.Wallet,
+		DBTimeOut:                   cfg.DB.Bolt.DBTimeout,
 		NeutrinoCS:                  neutrinoCS,
 		ActiveNetParams:             cfg.ActiveNetParams,
 		FeeURL:                      cfg.FeeURL,
@@ -564,7 +565,9 @@ func Main(cfg *Config, lisCfg ListenerCfg, shutdownChan <-chan struct{}) error {
 	var towerClientDB *wtdb.ClientDB
 	if cfg.WtClient.Active {
 		var err error
-		towerClientDB, err = wtdb.OpenClientDB(cfg.localDatabaseDir())
+		towerClientDB, err = wtdb.OpenClientDB(
+			cfg.localDatabaseDir(), cfg.DB.Bolt.DBTimeout,
+		)
 		if err != nil {
 			err := fmt.Errorf("unable to open watchtower client "+
 				"database: %v", err)
@@ -605,7 +608,9 @@ func Main(cfg *Config, lisCfg ListenerCfg, shutdownChan <-chan struct{}) error {
 			lncfg.NormalizeNetwork(cfg.ActiveNetParams.Name),
 		)
 
-		towerDB, err := wtdb.OpenTowerDB(towerDBDir)
+		towerDB, err := wtdb.OpenTowerDB(
+			towerDBDir, cfg.DB.Bolt.DBTimeout,
+		)
 		if err != nil {
 			err := fmt.Errorf("unable to open watchtower "+
 				"database: %v", err)
@@ -1140,7 +1145,7 @@ func waitForWalletPassword(cfg *Config, restEndpoints []net.Addr,
 	}
 	pwService := walletunlocker.New(
 		chainConfig.ChainDir, cfg.ActiveNetParams.Params,
-		!cfg.SyncFreelist, macaroonFiles,
+		!cfg.SyncFreelist, macaroonFiles, cfg.DB.Bolt.DBTimeout,
 	)
 
 	// Set up a new PasswordService, which will listen for passwords
@@ -1264,7 +1269,7 @@ func waitForWalletPassword(cfg *Config, restEndpoints []net.Addr,
 		)
 		loader := wallet.NewLoader(
 			cfg.ActiveNetParams.Params, netDir, !cfg.SyncFreelist,
-			recoveryWindow,
+			cfg.DB.Bolt.DBTimeout, recoveryWindow,
 		)
 
 		// With the seed, we can now use the wallet loader to create
@@ -1481,7 +1486,9 @@ func initNeutrinoBackend(cfg *Config, chainDir string) (*neutrino.ChainService,
 	}
 
 	dbName := filepath.Join(dbPath, "neutrino.db")
-	db, err := walletdb.Create("bdb", dbName, !cfg.SyncFreelist)
+	db, err := walletdb.Create(
+		"bdb", dbName, !cfg.SyncFreelist, cfg.DB.Bolt.DBTimeout,
+	)
 	if err != nil {
 		return nil, nil, fmt.Errorf("unable to create neutrino "+
 			"database: %v", err)

--- a/lnwallet/btcwallet/btcwallet.go
+++ b/lnwallet/btcwallet/btcwallet.go
@@ -98,7 +98,7 @@ func New(cfg Config) (*BtcWallet, error) {
 		}
 		loader := base.NewLoader(
 			cfg.NetParams, netDir, cfg.NoFreelistSync,
-			cfg.RecoveryWindow,
+			cfg.DBTimeOut, cfg.RecoveryWindow,
 		)
 		walletExists, err := loader.WalletExists()
 		if err != nil {

--- a/lnwallet/btcwallet/config.go
+++ b/lnwallet/btcwallet/config.go
@@ -80,6 +80,10 @@ type Config struct {
 	// freelist to disk, resulting in improved performance at the expense of
 	// increased startup time.
 	NoFreelistSync bool
+
+	// DBTimeOut specifies the timeout value to use when opening the wallet
+	// database.
+	DBTimeOut time.Duration
 }
 
 // NetworkDir returns the directory name of a network directory to hold wallet

--- a/lnwallet/interface_test.go
+++ b/lnwallet/interface_test.go
@@ -3210,6 +3210,7 @@ func runTests(t *testing.T, walletDriver *lnwallet.WalletDriver,
 			// instance, and initialize a btcwallet driver for it.
 			aliceDB, err := walletdb.Create(
 				"bdb", tempTestDirAlice+"/neutrino.db", true,
+				kvdb.DefaultDBTimeout,
 			)
 			if err != nil {
 				t.Fatalf("unable to create DB: %v", err)
@@ -3238,6 +3239,7 @@ func runTests(t *testing.T, walletDriver *lnwallet.WalletDriver,
 			// instance, and initialize a btcwallet driver for it.
 			bobDB, err := walletdb.Create(
 				"bdb", tempTestDirBob+"/neutrino.db", true,
+				kvdb.DefaultDBTimeout,
 			)
 			if err != nil {
 				t.Fatalf("unable to create DB: %v", err)

--- a/macaroons/service.go
+++ b/macaroons/service.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"path"
+	"time"
 
 	"github.com/lightningnetwork/lnd/channeldb/kvdb"
 	"google.golang.org/grpc"
@@ -76,7 +77,7 @@ type Service struct {
 // such as those for `allow`, `time-before`, `declared`, and `error` caveats
 // are registered automatically and don't need to be added.
 func NewService(dir, location string, statelessInit bool,
-	checks ...Checker) (*Service, error) {
+	dbTimeout time.Duration, checks ...Checker) (*Service, error) {
 
 	// Ensure that the path to the directory exists.
 	if _, err := os.Stat(dir); os.IsNotExist(err) {
@@ -89,6 +90,7 @@ func NewService(dir, location string, statelessInit bool,
 	// and all generated macaroons+caveats.
 	macaroonDB, err := kvdb.Create(
 		kvdb.BoltBackendName, path.Join(dir, DBFilename), true,
+		dbTimeout,
 	)
 	if err != nil {
 		return nil, err

--- a/macaroons/service_test.go
+++ b/macaroons/service_test.go
@@ -40,6 +40,7 @@ func setupTestRootKeyStorage(t *testing.T) string {
 	}
 	db, err := kvdb.Create(
 		kvdb.BoltBackendName, path.Join(tempDir, "macaroons.db"), true,
+		kvdb.DefaultDBTimeout,
 	)
 	if err != nil {
 		t.Fatalf("Error opening store DB: %v", err)
@@ -67,7 +68,8 @@ func TestNewService(t *testing.T) {
 	// Second, create the new service instance, unlock it and pass in a
 	// checker that we expect it to add to the bakery.
 	service, err := macaroons.NewService(
-		tempDir, "lnd", false, macaroons.IPLockChecker,
+		tempDir, "lnd", false, kvdb.DefaultDBTimeout,
+		macaroons.IPLockChecker,
 	)
 	if err != nil {
 		t.Fatalf("Error creating new service: %v", err)
@@ -118,7 +120,8 @@ func TestValidateMacaroon(t *testing.T) {
 	tempDir := setupTestRootKeyStorage(t)
 	defer os.RemoveAll(tempDir)
 	service, err := macaroons.NewService(
-		tempDir, "lnd", false, macaroons.IPLockChecker,
+		tempDir, "lnd", false, kvdb.DefaultDBTimeout,
+		macaroons.IPLockChecker,
 	)
 	if err != nil {
 		t.Fatalf("Error creating new service: %v", err)
@@ -178,7 +181,8 @@ func TestListMacaroonIDs(t *testing.T) {
 	// Second, create the new service instance, unlock it and pass in a
 	// checker that we expect it to add to the bakery.
 	service, err := macaroons.NewService(
-		tempDir, "lnd", false, macaroons.IPLockChecker,
+		tempDir, "lnd", false, kvdb.DefaultDBTimeout,
+		macaroons.IPLockChecker,
 	)
 	require.NoError(t, err, "Error creating new service")
 	defer service.Close()
@@ -210,7 +214,8 @@ func TestDeleteMacaroonID(t *testing.T) {
 	// Second, create the new service instance, unlock it and pass in a
 	// checker that we expect it to add to the bakery.
 	service, err := macaroons.NewService(
-		tempDir, "lnd", false, macaroons.IPLockChecker,
+		tempDir, "lnd", false, kvdb.DefaultDBTimeout,
+		macaroons.IPLockChecker,
 	)
 	require.NoError(t, err, "Error creating new service")
 	defer service.Close()

--- a/macaroons/store_test.go
+++ b/macaroons/store_test.go
@@ -42,6 +42,7 @@ func openTestStore(t *testing.T, tempDir string) (func(),
 
 	db, err := kvdb.Create(
 		kvdb.BoltBackendName, path.Join(tempDir, "weks.db"), true,
+		kvdb.DefaultDBTimeout,
 	)
 	require.NoError(t, err)
 

--- a/routing/chainview/interface_test.go
+++ b/routing/chainview/interface_test.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/lightninglabs/neutrino"
 	"github.com/lightningnetwork/lnd/channeldb"
+	"github.com/lightningnetwork/lnd/channeldb/kvdb"
 )
 
 var (
@@ -846,7 +847,9 @@ var interfaceImpls = []struct {
 			}
 
 			dbName := filepath.Join(spvDir, "neutrino.db")
-			spvDatabase, err := walletdb.Create("bdb", dbName, true)
+			spvDatabase, err := walletdb.Create(
+				"bdb", dbName, true, kvdb.DefaultDBTimeout,
+			)
 			if err != nil {
 				return nil, nil, err
 			}

--- a/routing/integrated_routing_context_test.go
+++ b/routing/integrated_routing_context_test.go
@@ -105,7 +105,9 @@ func (c *integratedRoutingContext) testPayment(maxParts uint32) ([]htlcAttempt,
 	dbPath := file.Name()
 	defer os.Remove(dbPath)
 
-	db, err := kvdb.Open(kvdb.BoltBackendName, dbPath, true)
+	db, err := kvdb.Open(
+		kvdb.BoltBackendName, dbPath, true, kvdb.DefaultDBTimeout,
+	)
 	if err != nil {
 		c.t.Fatal(err)
 	}

--- a/routing/missioncontrol_store_test.go
+++ b/routing/missioncontrol_store_test.go
@@ -31,7 +31,9 @@ func TestMissionControlStore(t *testing.T) {
 
 	dbPath := file.Name()
 
-	db, err := kvdb.Create(kvdb.BoltBackendName, dbPath, true)
+	db, err := kvdb.Create(
+		kvdb.BoltBackendName, dbPath, true, kvdb.DefaultDBTimeout,
+	)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/routing/missioncontrol_test.go
+++ b/routing/missioncontrol_test.go
@@ -63,7 +63,9 @@ func createMcTestContext(t *testing.T) *mcTestContext {
 
 	ctx.dbPath = file.Name()
 
-	ctx.db, err = kvdb.Open(kvdb.BoltBackendName, ctx.dbPath, true)
+	ctx.db, err = kvdb.Open(
+		kvdb.BoltBackendName, ctx.dbPath, true, kvdb.DefaultDBTimeout,
+	)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/sample-lnd.conf
+++ b/sample-lnd.conf
@@ -971,3 +971,6 @@ litecoin.node=ltcd
 ; considered for auto compaction again. Can be set to 0 to compact on every
 ; startup. (default: 168h)
 ; db.bolt.auto-compact-min-age=0
+
+; Specify the timeout to be used when opening the database.
+; db.bolt.dbtimeout=60s

--- a/walletunlocker/service_test.go
+++ b/walletunlocker/service_test.go
@@ -69,7 +69,9 @@ func createTestWalletWithPw(t *testing.T, pubPw, privPw []byte, dir string,
 
 	// Create a new test wallet that uses fast scrypt as KDF.
 	netDir := btcwallet.NetworkDir(dir, netParams)
-	loader := wallet.NewLoader(netParams, netDir, true, 0)
+	loader := wallet.NewLoader(
+		netParams, netDir, true, kvdb.DefaultDBTimeout, 0,
+	)
 	_, err := loader.CreateNewWallet(
 		pubPw, privPw, testSeed, time.Time{},
 	)
@@ -105,7 +107,7 @@ func openOrCreateTestMacStore(tempDir string, pw *[]byte,
 	}
 	db, err := kvdb.Create(
 		kvdb.BoltBackendName, path.Join(netDir, macaroons.DBFilename),
-		true,
+		true, kvdb.DefaultDBTimeout,
 	)
 	if err != nil {
 		return nil, err
@@ -144,7 +146,9 @@ func TestGenSeed(t *testing.T) {
 		_ = os.RemoveAll(testDir)
 	}()
 
-	service := walletunlocker.New(testDir, testNetParams, true, nil)
+	service := walletunlocker.New(
+		testDir, testNetParams, true, nil, kvdb.DefaultDBTimeout,
+	)
 
 	// Now that the service has been created, we'll ask it to generate a
 	// new seed for us given a test passphrase.
@@ -179,7 +183,9 @@ func TestGenSeedGenerateEntropy(t *testing.T) {
 	defer func() {
 		_ = os.RemoveAll(testDir)
 	}()
-	service := walletunlocker.New(testDir, testNetParams, true, nil)
+	service := walletunlocker.New(
+		testDir, testNetParams, true, nil, kvdb.DefaultDBTimeout,
+	)
 
 	// Now that the service has been created, we'll ask it to generate a
 	// new seed for us given a test passphrase. Note that we don't actually
@@ -213,7 +219,9 @@ func TestGenSeedInvalidEntropy(t *testing.T) {
 	defer func() {
 		_ = os.RemoveAll(testDir)
 	}()
-	service := walletunlocker.New(testDir, testNetParams, true, nil)
+	service := walletunlocker.New(
+		testDir, testNetParams, true, nil, kvdb.DefaultDBTimeout,
+	)
 
 	// Now that the service has been created, we'll ask it to generate a
 	// new seed for us given a test passphrase. However, we'll be using an
@@ -244,7 +252,9 @@ func TestInitWallet(t *testing.T) {
 	}()
 
 	// Create new UnlockerService.
-	service := walletunlocker.New(testDir, testNetParams, true, nil)
+	service := walletunlocker.New(
+		testDir, testNetParams, true, nil, kvdb.DefaultDBTimeout,
+	)
 
 	// Once we have the unlocker service created, we'll now instantiate a
 	// new cipher seed and its mnemonic.
@@ -330,7 +340,9 @@ func TestCreateWalletInvalidEntropy(t *testing.T) {
 	}()
 
 	// Create new UnlockerService.
-	service := walletunlocker.New(testDir, testNetParams, true, nil)
+	service := walletunlocker.New(
+		testDir, testNetParams, true, nil, kvdb.DefaultDBTimeout,
+	)
 
 	// We'll attempt to init the wallet with an invalid cipher seed and
 	// passphrase.
@@ -359,7 +371,9 @@ func TestUnlockWallet(t *testing.T) {
 	}()
 
 	// Create new UnlockerService.
-	service := walletunlocker.New(testDir, testNetParams, true, nil)
+	service := walletunlocker.New(
+		testDir, testNetParams, true, nil, kvdb.DefaultDBTimeout,
+	)
 
 	ctx := context.Background()
 	req := &lnrpc.UnlockWalletRequest{
@@ -448,7 +462,9 @@ func TestChangeWalletPasswordNewRootkey(t *testing.T) {
 	}
 
 	// Create a new UnlockerService with our temp files.
-	service := walletunlocker.New(testDir, testNetParams, true, tempFiles)
+	service := walletunlocker.New(
+		testDir, testNetParams, true, tempFiles, kvdb.DefaultDBTimeout,
+	)
 
 	ctx := context.Background()
 	newPassword := []byte("hunter2???")
@@ -558,7 +574,7 @@ func TestChangeWalletPasswordStateless(t *testing.T) {
 	// Create a new UnlockerService with our temp files.
 	service := walletunlocker.New(testDir, testNetParams, true, []string{
 		tempMacFile, nonExistingFile,
-	})
+	}, kvdb.DefaultDBTimeout)
 
 	// Create a wallet we can try to unlock. We use the default password
 	// so we can check that the unlocker service defaults to this when

--- a/watchtower/wtdb/client_db.go
+++ b/watchtower/wtdb/client_db.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"math"
 	"net"
+	"time"
 
 	"github.com/btcsuite/btcd/btcec"
 	"github.com/lightningnetwork/lnd/channeldb/kvdb"
@@ -128,8 +129,10 @@ type ClientDB struct {
 // migrations will be applied before returning. Any attempt to open a database
 // with a version number higher that the latest version will fail to prevent
 // accidental reversion.
-func OpenClientDB(dbPath string) (*ClientDB, error) {
-	bdb, firstInit, err := createDBIfNotExist(dbPath, clientDBName)
+func OpenClientDB(dbPath string, dbTimeout time.Duration) (*ClientDB, error) {
+	bdb, firstInit, err := createDBIfNotExist(
+		dbPath, clientDBName, dbTimeout,
+	)
 	if err != nil {
 		return nil, err
 	}

--- a/watchtower/wtdb/client_db_test.go
+++ b/watchtower/wtdb/client_db_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	"github.com/btcsuite/btcd/btcec"
+	"github.com/lightningnetwork/lnd/channeldb/kvdb"
 	"github.com/lightningnetwork/lnd/lnwire"
 	"github.com/lightningnetwork/lnd/watchtower/blob"
 	"github.com/lightningnetwork/lnd/watchtower/wtclient"
@@ -760,7 +761,9 @@ func TestClientDB(t *testing.T) {
 						err)
 				}
 
-				db, err := wtdb.OpenClientDB(path)
+				db, err := wtdb.OpenClientDB(
+					path, kvdb.DefaultDBTimeout,
+				)
 				if err != nil {
 					os.RemoveAll(path)
 					t.Fatalf("unable to open db: %v", err)
@@ -783,14 +786,18 @@ func TestClientDB(t *testing.T) {
 						err)
 				}
 
-				db, err := wtdb.OpenClientDB(path)
+				db, err := wtdb.OpenClientDB(
+					path, kvdb.DefaultDBTimeout,
+				)
 				if err != nil {
 					os.RemoveAll(path)
 					t.Fatalf("unable to open db: %v", err)
 				}
 				db.Close()
 
-				db, err = wtdb.OpenClientDB(path)
+				db, err = wtdb.OpenClientDB(
+					path, kvdb.DefaultDBTimeout,
+				)
 				if err != nil {
 					os.RemoveAll(path)
 					t.Fatalf("unable to reopen db: %v", err)

--- a/watchtower/wtdb/db_common.go
+++ b/watchtower/wtdb/db_common.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"time"
 
 	"github.com/lightningnetwork/lnd/channeldb/kvdb"
 )
@@ -49,7 +50,9 @@ func fileExists(path string) bool {
 // one doesn't exist. The boolean returned indicates if the database did not
 // exist before, or if it has been created but no version metadata exists within
 // it.
-func createDBIfNotExist(dbPath, name string) (kvdb.Backend, bool, error) {
+func createDBIfNotExist(dbPath, name string,
+	dbTimeout time.Duration) (kvdb.Backend, bool, error) {
+
 	path := filepath.Join(dbPath, name)
 
 	// If the database file doesn't exist, this indicates we much initialize
@@ -65,7 +68,9 @@ func createDBIfNotExist(dbPath, name string) (kvdb.Backend, bool, error) {
 
 	// Specify bbolt freelist options to reduce heap pressure in case the
 	// freelist grows to be very large.
-	bdb, err := kvdb.Create(kvdb.BoltBackendName, path, true)
+	bdb, err := kvdb.Create(
+		kvdb.BoltBackendName, path, true, dbTimeout,
+	)
 	if err != nil {
 		return nil, false, err
 	}

--- a/watchtower/wtdb/tower_db.go
+++ b/watchtower/wtdb/tower_db.go
@@ -3,6 +3,7 @@ package wtdb
 import (
 	"bytes"
 	"errors"
+	"time"
 
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/lightningnetwork/lnd/chainntnfs"
@@ -66,8 +67,10 @@ type TowerDB struct {
 // migrations will be applied before returning. Any attempt to open a database
 // with a version number higher that the latest version will fail to prevent
 // accidental reversion.
-func OpenTowerDB(dbPath string) (*TowerDB, error) {
-	bdb, firstInit, err := createDBIfNotExist(dbPath, towerDBName)
+func OpenTowerDB(dbPath string, dbTimeout time.Duration) (*TowerDB, error) {
+	bdb, firstInit, err := createDBIfNotExist(
+		dbPath, towerDBName, dbTimeout,
+	)
 	if err != nil {
 		return nil, err
 	}

--- a/watchtower/wtdb/tower_db_test.go
+++ b/watchtower/wtdb/tower_db_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/lightningnetwork/lnd/chainntnfs"
+	"github.com/lightningnetwork/lnd/channeldb/kvdb"
 	"github.com/lightningnetwork/lnd/watchtower"
 	"github.com/lightningnetwork/lnd/watchtower/blob"
 	"github.com/lightningnetwork/lnd/watchtower/wtdb"
@@ -642,7 +643,9 @@ func TestTowerDB(t *testing.T) {
 						err)
 				}
 
-				db, err := wtdb.OpenTowerDB(path)
+				db, err := wtdb.OpenTowerDB(
+					path, kvdb.DefaultDBTimeout,
+				)
 				if err != nil {
 					os.RemoveAll(path)
 					t.Fatalf("unable to open db: %v", err)
@@ -665,7 +668,9 @@ func TestTowerDB(t *testing.T) {
 						err)
 				}
 
-				db, err := wtdb.OpenTowerDB(path)
+				db, err := wtdb.OpenTowerDB(
+					path, kvdb.DefaultDBTimeout,
+				)
 				if err != nil {
 					os.RemoveAll(path)
 					t.Fatalf("unable to open db: %v", err)
@@ -675,7 +680,9 @@ func TestTowerDB(t *testing.T) {
 				// Open the db again, ensuring we test a
 				// different path during open and that all
 				// buckets remain initialized.
-				db, err = wtdb.OpenTowerDB(path)
+				db, err = wtdb.OpenTowerDB(
+					path, kvdb.DefaultDBTimeout,
+				)
 				if err != nil {
 					os.RemoveAll(path)
 					t.Fatalf("unable to open db: %v", err)


### PR DESCRIPTION
Since the addition of the timeout option for `kvdb` happens at a very low-level, this simple change has brought modifications to lots of files. It can be summarized as the following, hopefully bringing some ease during code review.

- The function calls to `wallet.NewLoader` and `wallet.Create` are updated with the `DBTimeout` param. This update has modified various packages.
- The function calls to `kvdb.Create` and `kvdb.Open` are updated with the timeout param. This update has modified various packages.
- The three services, `macaroons`, `walletunlocker` and `watcher` all have their own database, and they are updated to share the same timeout value configured in `db.bolt.dbtimeout`.

This PR fixes #4485.

Fixes #4149. 
