### PR TITLE
Cosmetic: Add newline to end of log statement

### DIFF
--- a/lnd.go
+++ b/lnd.go
@@ -197,7 +197,7 @@ type rpcListeners func() ([]*ListenerWithSignal, func(), error)
 // is received on the shutdownChan at which point everything is shut down again.
 func Main(cfg *Config, lisCfg ListenerCfg, shutdownChan <-chan struct{}) error {
 	defer func() {
-		ltndLog.Info("Shutdown complete")
+		ltndLog.Info("Shutdown complete\n")
 		err := cfg.LogWriter.Close()
 		if err != nil {
 			ltndLog.Errorf("Could not close log rotator: %v", err)


### PR DESCRIPTION
Adds a newline to the end of a log statement.

[reference issue](https://github.com/lightningnetwork/lnd/issues/3801)