### PR TITLE
htlcswitch/link: revert borking channels on received Errors

### DIFF
--- a/htlcswitch/link.go
+++ b/htlcswitch/link.go
@@ -1902,8 +1902,15 @@ func (l *channelLink) handleUpstreamMsg(msg lnwire.Message) {
 		// characters are printable ASCII.
 		l.fail(
 			LinkFailureError{
-				code:             ErrRemoteError,
-				PermanentFailure: true,
+				code: ErrRemoteError,
+
+				// TODO(halseth): we currently don't fail the
+				// channel permanently, as there are some sync
+				// issues with other implementations that will
+				// lead to them sending an error message, but
+				// we can recover from on next connection. See
+				// https://github.com/ElementsProject/lightning/issues/4212
+				PermanentFailure: false,
 			},
 			"ChannelPoint(%v): received error from peer: %v",
 			l.channel.ChannelPoint(), msg.Error(),

--- a/htlcswitch/link_test.go
+++ b/htlcswitch/link_test.go
@@ -5273,7 +5273,9 @@ func TestChannelLinkFail(t *testing.T) {
 				c.HandleChannelUpdate(err)
 			},
 			false,
-			true,
+			// TODO(halseth) For compatibility with CL we currently
+			// don't treat Errors as permanent errors.
+			false,
 		},
 	}
 


### PR DESCRIPTION
Since it turned out borking channels on every received error could cause
us to bork channels in case of a sync error with C-lightning, we revert
this for now.

See #2018 and https://github.com/ElementsProject/lightning/issues/4212

Fixes https://github.com/lightningnetwork/lnd/issues/4776