### PR TITLE
discovery: adhere to proper channel chunk splitting for ReplyChannelRange

### DIFF
--- a/discovery/chan_series.go
+++ b/discovery/chan_series.go
@@ -39,10 +39,11 @@ type ChannelGraphTimeSeries interface {
 		superSet []lnwire.ShortChannelID) ([]lnwire.ShortChannelID, error)
 
 	// FilterChannelRange returns the set of channels that we created
-	// between the start height and the end height. We'll use this to to a
-	// remote peer's QueryChannelRange message.
+	// between the start height and the end height. The channel IDs are
+	// grouped by their common block height. We'll use this to to a remote
+	// peer's QueryChannelRange message.
 	FilterChannelRange(chain chainhash.Hash,
-		startHeight, endHeight uint32) ([]lnwire.ShortChannelID, error)
+		startHeight, endHeight uint32) ([]channeldb.BlockChannelRange, error)
 
 	// FetchChanAnns returns a full set of channel announcements as well as
 	// their updates that match the set of specified short channel ID's.
@@ -203,26 +204,15 @@ func (c *ChanSeries) FilterKnownChanIDs(chain chainhash.Hash,
 }
 
 // FilterChannelRange returns the set of channels that we created between the
-// start height and the end height. We'll use this respond to a remote peer's
-// QueryChannelRange message.
+// start height and the end height. The channel IDs are grouped by their common
+// block height. We'll use this respond to a remote peer's QueryChannelRange
+// message.
 //
 // NOTE: This is part of the ChannelGraphTimeSeries interface.
 func (c *ChanSeries) FilterChannelRange(chain chainhash.Hash,
-	startHeight, endHeight uint32) ([]lnwire.ShortChannelID, error) {
+	startHeight, endHeight uint32) ([]channeldb.BlockChannelRange, error) {
 
-	chansInRange, err := c.graph.FilterChannelRange(startHeight, endHeight)
-	if err != nil {
-		return nil, err
-	}
-
-	chanResp := make([]lnwire.ShortChannelID, 0, len(chansInRange))
-	for _, chanID := range chansInRange {
-		chanResp = append(
-			chanResp, lnwire.NewShortChanIDFromInt(chanID),
-		)
-	}
-
-	return chanResp, nil
+	return c.graph.FilterChannelRange(startHeight, endHeight)
 }
 
 // FetchChanAnns returns a full set of channel announcements as well as their

--- a/discovery/gossiper.go
+++ b/discovery/gossiper.go
@@ -265,16 +265,6 @@ type AuthenticatedGossiper struct {
 	// every new block height.
 	blockEpochs *chainntnfs.BlockEpochEvent
 
-	// prematureAnnouncements maps a block height to a set of network
-	// messages which are "premature" from our PoV. A message is premature
-	// if it claims to be anchored in a block which is beyond the current
-	// main chain tip as we know it. Premature network messages will be
-	// processed once the chain tip as we know it extends to/past the
-	// premature height.
-	//
-	// TODO(roasbeef): limit premature networkMsgs to N
-	prematureAnnouncements map[uint32][]*networkMsg
-
 	// prematureChannelUpdates is a map of ChannelUpdates we have received
 	// that wasn't associated with any channel we know about.  We store
 	// them temporarily, such that we can reprocess them when a
@@ -338,7 +328,6 @@ func New(cfg Config, selfKey *btcec.PublicKey) *AuthenticatedGossiper {
 		networkMsgs:             make(chan *networkMsg),
 		quit:                    make(chan struct{}),
 		chanPolicyUpdates:       make(chan *chanPolicyUpdateRequest),
-		prematureAnnouncements:  make(map[uint32][]*networkMsg),
 		prematureChannelUpdates: make(map[uint64][]*networkMsg),
 		channelMtx:              multimutex.NewMutex(),
 		recentRejects:           make(map[uint64]struct{}),
@@ -1047,32 +1036,10 @@ func (d *AuthenticatedGossiper) networkHandler() {
 			d.Lock()
 			blockHeight := uint32(newBlock.Height)
 			d.bestHeight = blockHeight
+			d.Unlock()
 
 			log.Debugf("New block: height=%d, hash=%s", blockHeight,
 				newBlock.Hash)
-
-			// Next we check if we have any premature announcements
-			// for this height, if so, then we process them once
-			// more as normal announcements.
-			premature := d.prematureAnnouncements[blockHeight]
-			if len(premature) == 0 {
-				d.Unlock()
-				continue
-			}
-			delete(d.prematureAnnouncements, blockHeight)
-			d.Unlock()
-
-			log.Infof("Re-processing %v premature announcements "+
-				"for height %v", len(premature), blockHeight)
-
-			for _, ann := range premature {
-				emittedAnnouncements := d.processNetworkAnnouncement(ann)
-				if emittedAnnouncements != nil {
-					announcements.AddMsgs(
-						emittedAnnouncements...,
-					)
-				}
-			}
 
 		// The trickle timer has ticked, which indicates we should
 		// flush to the network the pending batch of new announcements
@@ -1503,7 +1470,6 @@ func (d *AuthenticatedGossiper) addNode(msg *lnwire.NodeAnnouncement) error {
 func (d *AuthenticatedGossiper) processNetworkAnnouncement(
 	nMsg *networkMsg) []networkMsg {
 
-	// isPremature *MUST* be called with the gossiper's lock held.
 	isPremature := func(chanID lnwire.ShortChannelID, delta uint32) bool {
 		// TODO(roasbeef) make height delta 6
 		//  * or configurable
@@ -1595,18 +1561,12 @@ func (d *AuthenticatedGossiper) processNetworkAnnouncement(
 		// to be fully verified once we advance forward in the chain.
 		d.Lock()
 		if nMsg.isRemote && isPremature(msg.ShortChannelID, 0) {
-			blockHeight := msg.ShortChannelID.BlockHeight
 			log.Infof("Announcement for chan_id=(%v), is "+
 				"premature: advertises height %v, only "+
 				"height %v is known",
 				msg.ShortChannelID.ToUint64(),
 				msg.ShortChannelID.BlockHeight,
 				d.bestHeight)
-
-			d.prematureAnnouncements[blockHeight] = append(
-				d.prematureAnnouncements[blockHeight],
-				nMsg,
-			)
 			d.Unlock()
 			return nil
 		}
@@ -1826,11 +1786,6 @@ func (d *AuthenticatedGossiper) processNetworkAnnouncement(
 				"height %v, only height %v is known",
 				shortChanID, blockHeight,
 				d.bestHeight)
-
-			d.prematureAnnouncements[blockHeight] = append(
-				d.prematureAnnouncements[blockHeight],
-				nMsg,
-			)
 			d.Unlock()
 			return nil
 		}
@@ -2126,10 +2081,6 @@ func (d *AuthenticatedGossiper) processNetworkAnnouncement(
 		// to other clients if this constraint was changed.
 		d.Lock()
 		if isPremature(msg.ShortChannelID, d.cfg.ProofMatureDelta) {
-			d.prematureAnnouncements[needBlockHeight] = append(
-				d.prematureAnnouncements[needBlockHeight],
-				nMsg,
-			)
 			log.Infof("Premature proof announcement, "+
 				"current block height lower than needed: %v <"+
 				" %v, add announcement to reprocessing batch",

--- a/discovery/gossiper_test.go
+++ b/discovery/gossiper_test.go
@@ -918,8 +918,7 @@ func TestPrematureAnnouncement(t *testing.T) {
 
 	// Pretending that we receive the valid channel update announcement from
 	// remote side, but block height of this announcement is greater than
-	// highest know to us, for that reason it should be added to the
-	// repeat/premature batch.
+	// highest known to us, so it should be rejected.
 	ua, err := createUpdateAnnouncement(1, 0, nodeKeyPriv1, timestamp)
 	if err != nil {
 		t.Fatalf("can't create update announcement: %v", err)
@@ -933,31 +932,6 @@ func TestPrematureAnnouncement(t *testing.T) {
 
 	if len(ctx.router.edges) != 0 {
 		t.Fatal("edge update was added to router")
-	}
-
-	// Generate new block and waiting the previously added announcements
-	// to be proceeded.
-	newBlock := &wire.MsgBlock{}
-	ctx.notifier.notifyBlock(newBlock.Header.BlockHash(), 1)
-
-	select {
-	case <-ctx.broadcastedMessage:
-	case <-time.After(2 * trickleDelay):
-		t.Fatal("announcement wasn't broadcasted")
-	}
-
-	if len(ctx.router.infos) != 1 {
-		t.Fatalf("edge wasn't added to router: %v", err)
-	}
-
-	select {
-	case <-ctx.broadcastedMessage:
-	case <-time.After(2 * trickleDelay):
-		t.Fatal("announcement wasn't broadcasted")
-	}
-
-	if len(ctx.router.edges) != 1 {
-		t.Fatalf("edge update wasn't added to router: %v", err)
 	}
 }
 

--- a/discovery/sync_manager.go
+++ b/discovery/sync_manager.go
@@ -426,6 +426,7 @@ func (m *SyncManager) createGossipSyncer(peer lnpeer.Peer) *GossipSyncer {
 		maxUndelayedQueryReplies:  DefaultMaxUndelayedQueryReplies,
 		delayedQueryReplyInterval: DefaultDelayedQueryReplyInterval,
 		bestHeight:                m.cfg.BestHeight,
+		maxQueryChanRangeReplies:  maxQueryChanRangeReplies,
 	})
 
 	// Gossip syncers are initialized by default in a PassiveSync type

--- a/discovery/sync_manager.go
+++ b/discovery/sync_manager.go
@@ -89,6 +89,9 @@ type SyncManagerCfg struct {
 	// This prevents ranges with old start times from causing us to dump the
 	// graph on connect.
 	IgnoreHistoricalFilters bool
+
+	// BestHeight returns the latest height known of the chain.
+	BestHeight func() uint32
 }
 
 // SyncManager is a subsystem of the gossiper that manages the gossip syncers
@@ -419,7 +422,10 @@ func (m *SyncManager) createGossipSyncer(peer lnpeer.Peer) *GossipSyncer {
 		sendToPeerSync: func(msgs ...lnwire.Message) error {
 			return peer.SendMessageLazy(true, msgs...)
 		},
-		ignoreHistoricalFilters: m.cfg.IgnoreHistoricalFilters,
+		ignoreHistoricalFilters:   m.cfg.IgnoreHistoricalFilters,
+		maxUndelayedQueryReplies:  DefaultMaxUndelayedQueryReplies,
+		delayedQueryReplyInterval: DefaultDelayedQueryReplyInterval,
+		bestHeight:                m.cfg.BestHeight,
 	})
 
 	// Gossip syncers are initialized by default in a PassiveSync type

--- a/discovery/sync_manager_test.go
+++ b/discovery/sync_manager_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/lightningnetwork/lnd/lntest/wait"
 	"github.com/lightningnetwork/lnd/lnwire"
 	"github.com/lightningnetwork/lnd/ticker"
+	"github.com/stretchr/testify/require"
 )
 
 // randPeer creates a random peer.
@@ -537,10 +538,14 @@ func assertTransitionToChansSynced(t *testing.T, s *GossipSyncer, peer *mockPeer
 	}
 	assertMsgSent(t, peer, query)
 
-	s.ProcessQueryMsg(&lnwire.ReplyChannelRange{
+	require.Eventually(t, func() bool {
+		return s.syncState() == waitingQueryRangeReply
+	}, time.Second, 500*time.Millisecond)
+
+	require.NoError(t, s.ProcessQueryMsg(&lnwire.ReplyChannelRange{
 		QueryChannelRange: *query,
 		Complete:          1,
-	}, nil)
+	}, nil))
 
 	chanSeries := s.cfg.channelSeries.(*mockChannelGraphTimeSeries)
 

--- a/discovery/sync_manager_test.go
+++ b/discovery/sync_manager_test.go
@@ -2,7 +2,6 @@ package discovery
 
 import (
 	"fmt"
-	"math"
 	"reflect"
 	"sync/atomic"
 	"testing"
@@ -34,6 +33,9 @@ func newTestSyncManager(numActiveSyncers int) *SyncManager {
 		RotateTicker:         ticker.NewForce(DefaultSyncerRotationInterval),
 		HistoricalSyncTicker: ticker.NewForce(DefaultHistoricalSyncInterval),
 		NumActiveSyncers:     numActiveSyncers,
+		BestHeight: func() uint32 {
+			return latestKnownHeight
+		},
 	})
 }
 
@@ -202,7 +204,7 @@ func TestSyncManagerInitialHistoricalSync(t *testing.T) {
 	syncMgr.InitSyncState(peer)
 	assertMsgSent(t, peer, &lnwire.QueryChannelRange{
 		FirstBlockHeight: 0,
-		NumBlocks:        math.MaxUint32,
+		NumBlocks:        latestKnownHeight,
 	})
 
 	// The graph should not be considered as synced since the initial
@@ -290,7 +292,7 @@ func TestSyncManagerForceHistoricalSync(t *testing.T) {
 	syncMgr.InitSyncState(peer)
 	assertMsgSent(t, peer, &lnwire.QueryChannelRange{
 		FirstBlockHeight: 0,
-		NumBlocks:        math.MaxUint32,
+		NumBlocks:        latestKnownHeight,
 	})
 
 	// If an additional peer connects, then a historical sync should not be
@@ -305,7 +307,7 @@ func TestSyncManagerForceHistoricalSync(t *testing.T) {
 	syncMgr.cfg.HistoricalSyncTicker.(*ticker.Force).Force <- time.Time{}
 	assertMsgSent(t, extraPeer, &lnwire.QueryChannelRange{
 		FirstBlockHeight: 0,
-		NumBlocks:        math.MaxUint32,
+		NumBlocks:        latestKnownHeight,
 	})
 }
 
@@ -326,7 +328,7 @@ func TestSyncManagerGraphSyncedAfterHistoricalSyncReplacement(t *testing.T) {
 	syncMgr.InitSyncState(peer)
 	assertMsgSent(t, peer, &lnwire.QueryChannelRange{
 		FirstBlockHeight: 0,
-		NumBlocks:        math.MaxUint32,
+		NumBlocks:        latestKnownHeight,
 	})
 
 	// The graph should not be considered as synced since the initial
@@ -531,7 +533,7 @@ func assertTransitionToChansSynced(t *testing.T, s *GossipSyncer, peer *mockPeer
 
 	query := &lnwire.QueryChannelRange{
 		FirstBlockHeight: 0,
-		NumBlocks:        math.MaxUint32,
+		NumBlocks:        latestKnownHeight,
 	}
 	assertMsgSent(t, peer, query)
 

--- a/discovery/syncer_test.go
+++ b/discovery/syncer_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"math"
 	"reflect"
+	"sort"
 	"sync"
 	"testing"
 	"time"
@@ -12,7 +13,9 @@ import (
 	"github.com/btcsuite/btcd/chaincfg"
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/davecgh/go-spew/spew"
+	"github.com/lightningnetwork/lnd/channeldb"
 	"github.com/lightningnetwork/lnd/lnwire"
+	"github.com/stretchr/testify/require"
 )
 
 const (
@@ -95,11 +98,36 @@ func (m *mockChannelGraphTimeSeries) FilterKnownChanIDs(chain chainhash.Hash,
 	return <-m.filterResp, nil
 }
 func (m *mockChannelGraphTimeSeries) FilterChannelRange(chain chainhash.Hash,
-	startHeight, endHeight uint32) ([]lnwire.ShortChannelID, error) {
+	startHeight, endHeight uint32) ([]channeldb.BlockChannelRange, error) {
 
 	m.filterRangeReqs <- filterRangeReq{startHeight, endHeight}
+	reply := <-m.filterRangeResp
 
-	return <-m.filterRangeResp, nil
+	channelsPerBlock := make(map[uint32][]lnwire.ShortChannelID)
+	for _, cid := range reply {
+		channelsPerBlock[cid.BlockHeight] = append(
+			channelsPerBlock[cid.BlockHeight], cid,
+		)
+	}
+
+	// Return the channel ranges in ascending block height order.
+	blocks := make([]uint32, 0, len(channelsPerBlock))
+	for block := range channelsPerBlock {
+		blocks = append(blocks, block)
+	}
+	sort.Slice(blocks, func(i, j int) bool {
+		return blocks[i] < blocks[j]
+	})
+
+	channelRanges := make([]channeldb.BlockChannelRange, 0, len(channelsPerBlock))
+	for _, block := range blocks {
+		channelRanges = append(channelRanges, channeldb.BlockChannelRange{
+			Height:   block,
+			Channels: channelsPerBlock[block],
+		})
+	}
+
+	return channelRanges, nil
 }
 func (m *mockChannelGraphTimeSeries) FetchChanAnns(chain chainhash.Hash,
 	shortChanIDs []lnwire.ShortChannelID) ([]lnwire.Message, error) {
@@ -161,6 +189,7 @@ func newTestSyncer(hID lnwire.ShortChannelID,
 		bestHeight: func() uint32 {
 			return latestKnownHeight
 		},
+		maxQueryChanRangeReplies: maxQueryChanRangeReplies,
 	}
 	syncer := newGossipSyncer(cfg)
 
@@ -828,6 +857,7 @@ func TestGossipSyncerReplyChanRangeQuery(t *testing.T) {
 	// reply. We should get three sets of messages as two of them should be
 	// full, while the other is the final fragment.
 	const numExpectedChunks = 3
+	var prevResp *lnwire.ReplyChannelRange
 	respMsgs := make([]lnwire.ShortChannelID, 0, 5)
 	for i := 0; i < numExpectedChunks; i++ {
 		select {
@@ -855,14 +885,14 @@ func TestGossipSyncerReplyChanRangeQuery(t *testing.T) {
 			// channels.
 			case i == 0:
 				expectedFirstBlockHeight = startingBlockHeight
-				expectedNumBlocks = chunkSize + 1
+				expectedNumBlocks = 4
 
 			// The last reply should range starting from the next
 			// block of our previous reply up until the ending
 			// height of the query. It should also have the Complete
 			// bit set.
 			case i == numExpectedChunks-1:
-				expectedFirstBlockHeight = respMsgs[len(respMsgs)-1].BlockHeight
+				expectedFirstBlockHeight = prevResp.LastBlockHeight() + 1
 				expectedNumBlocks = endingBlockHeight - expectedFirstBlockHeight + 1
 				expectedComplete = 1
 
@@ -870,8 +900,8 @@ func TestGossipSyncerReplyChanRangeQuery(t *testing.T) {
 			// the next block of our previous reply up until it
 			// reaches its maximum capacity of channels.
 			default:
-				expectedFirstBlockHeight = respMsgs[len(respMsgs)-1].BlockHeight
-				expectedNumBlocks = 5
+				expectedFirstBlockHeight = prevResp.LastBlockHeight() + 1
+				expectedNumBlocks = 4
 			}
 
 			switch {
@@ -889,9 +919,10 @@ func TestGossipSyncerReplyChanRangeQuery(t *testing.T) {
 			case rangeResp.Complete != expectedComplete:
 				t.Fatalf("Complete in resp #%d incorrect: "+
 					"expected %v, got %v", i+1,
-					expectedNumBlocks, rangeResp.Complete)
+					expectedComplete, rangeResp.Complete)
 			}
 
+			prevResp = rangeResp
 			respMsgs = append(respMsgs, rangeResp.ShortChanIDs...)
 		}
 	}
@@ -1498,10 +1529,12 @@ func TestGossipSyncerDelayDOS(t *testing.T) {
 	// inherently disjoint.
 	var syncer2Chans []lnwire.ShortChannelID
 	for i := 0; i < numTotalChans; i++ {
-		syncer2Chans = append(syncer2Chans, lnwire.ShortChannelID{
-			BlockHeight: highestID.BlockHeight - 1,
-			TxIndex:     uint32(i),
-		})
+		syncer2Chans = append([]lnwire.ShortChannelID{
+			{
+				BlockHeight: highestID.BlockHeight - uint32(i) - 1,
+				TxIndex:     uint32(i),
+			},
+		}, syncer2Chans...)
 	}
 
 	// We'll kick off the test by asserting syncer1 sends over the
@@ -2304,4 +2337,81 @@ func TestGossipSyncerSyncedSignal(t *testing.T) {
 	case <-time.After(time.Second):
 		t.Fatal("expected to receive chansSynced signal")
 	}
+}
+
+// TestGossipSyncerMaxChannelRangeReplies ensures that a gossip syncer
+// transitions its state after receiving the maximum possible number of replies
+// for a single QueryChannelRange message, and that any further replies after
+// said limit are not processed.
+func TestGossipSyncerMaxChannelRangeReplies(t *testing.T) {
+	t.Parallel()
+
+	msgChan, syncer, chanSeries := newTestSyncer(
+		lnwire.ShortChannelID{BlockHeight: latestKnownHeight},
+		defaultEncoding, defaultChunkSize,
+	)
+
+	// We'll tune the maxQueryChanRangeReplies to a more sensible value for
+	// the sake of testing.
+	syncer.cfg.maxQueryChanRangeReplies = 100
+
+	syncer.Start()
+	defer syncer.Stop()
+
+	// Upon initialization, the syncer should submit a QueryChannelRange
+	// request.
+	var query *lnwire.QueryChannelRange
+	select {
+	case msgs := <-msgChan:
+		require.Len(t, msgs, 1)
+		require.IsType(t, &lnwire.QueryChannelRange{}, msgs[0])
+		query = msgs[0].(*lnwire.QueryChannelRange)
+
+	case <-time.After(time.Second):
+		t.Fatal("expected query channel range request msg")
+	}
+
+	// We'll send the maximum number of replies allowed to a
+	// QueryChannelRange request with each reply consuming only one block in
+	// order to transition the syncer's state.
+	for i := uint32(0); i < syncer.cfg.maxQueryChanRangeReplies; i++ {
+		reply := &lnwire.ReplyChannelRange{
+			QueryChannelRange: *query,
+			ShortChanIDs: []lnwire.ShortChannelID{
+				{
+					BlockHeight: query.FirstBlockHeight + i,
+				},
+			},
+		}
+		reply.FirstBlockHeight = query.FirstBlockHeight + i
+		reply.NumBlocks = 1
+		require.NoError(t, syncer.ProcessQueryMsg(reply, nil))
+	}
+
+	// We should receive a filter request for the syncer's local channels
+	// after processing all of the replies. We'll send back a nil response
+	// indicating that no new channels need to be synced, so it should
+	// transition to its final chansSynced state.
+	select {
+	case <-chanSeries.filterReq:
+	case <-time.After(time.Second):
+		t.Fatal("expected local filter request of known channels")
+	}
+	select {
+	case chanSeries.filterResp <- nil:
+	case <-time.After(time.Second):
+		t.Fatal("timed out sending filter response")
+	}
+	assertSyncerStatus(t, syncer, chansSynced, ActiveSync)
+
+	// Finally, attempting to process another reply for the same query
+	// should result in an error.
+	require.Error(t, syncer.ProcessQueryMsg(&lnwire.ReplyChannelRange{
+		QueryChannelRange: *query,
+		ShortChanIDs: []lnwire.ShortChannelID{
+			{
+				BlockHeight: query.LastBlockHeight() + 1,
+			},
+		},
+	}, nil))
 }

--- a/discovery/syncer_test.go
+++ b/discovery/syncer_test.go
@@ -158,6 +158,9 @@ func newTestSyncer(hID lnwire.ShortChannelID,
 			return nil
 		},
 		delayedQueryReplyInterval: 2 * time.Second,
+		bestHeight: func() uint32 {
+			return latestKnownHeight
+		},
 	}
 	syncer := newGossipSyncer(cfg)
 
@@ -1134,9 +1137,9 @@ func TestGossipSyncerGenChanRangeQuery(t *testing.T) {
 			rangeQuery.FirstBlockHeight,
 			startingHeight-chanRangeQueryBuffer)
 	}
-	if rangeQuery.NumBlocks != math.MaxUint32-firstHeight {
+	if rangeQuery.NumBlocks != latestKnownHeight-firstHeight {
 		t.Fatalf("wrong num blocks: expected %v, got %v",
-			math.MaxUint32-firstHeight, rangeQuery.NumBlocks)
+			latestKnownHeight-firstHeight, rangeQuery.NumBlocks)
 	}
 
 	// Generating a historical range query should result in a start height
@@ -1149,9 +1152,9 @@ func TestGossipSyncerGenChanRangeQuery(t *testing.T) {
 		t.Fatalf("incorrect chan range query: expected %v, %v", 0,
 			rangeQuery.FirstBlockHeight)
 	}
-	if rangeQuery.NumBlocks != math.MaxUint32 {
+	if rangeQuery.NumBlocks != latestKnownHeight {
 		t.Fatalf("wrong num blocks: expected %v, got %v",
-			math.MaxUint32, rangeQuery.NumBlocks)
+			latestKnownHeight, rangeQuery.NumBlocks)
 	}
 }
 
@@ -2234,7 +2237,7 @@ func TestGossipSyncerHistoricalSync(t *testing.T) {
 	// sent to the remote peer with a FirstBlockHeight of 0.
 	expectedMsg := &lnwire.QueryChannelRange{
 		FirstBlockHeight: 0,
-		NumBlocks:        math.MaxUint32,
+		NumBlocks:        latestKnownHeight,
 	}
 
 	select {


### PR DESCRIPTION
As required by the spec, all channels for a block must fit within a single reply. `lnd` previously could not enforce this as it would allow an overlap of blocks across multiple replies. This became an even bigger issue as other implementations could send us a error due to the overlap and cause connect/disconnect cycles.