### PR TITLE
Fix Onion v2 support for Neutrino backends

### DIFF
--- a/tor/tor_test.go
+++ b/tor/tor_test.go
@@ -1,0 +1,36 @@
+package tor
+
+import (
+	"fmt"
+	"net"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	testOnion  = "ld47qlr6h2b7hrrf.onion"
+	testFakeIP = "fd87:d87e:eb43:58f9:f82e:3e3e:83f3:c625"
+)
+
+// TestOnionHostToFakeIP tests that an onion host address can be converted into
+// a fake tcp6 address successfully.
+func TestOnionHostToFakeIP(t *testing.T) {
+	ip, err := OnionHostToFakeIP(testOnion)
+	require.NoError(t, err)
+	require.Equal(t, testFakeIP, ip.String())
+}
+
+// TestFakeIPToOnionHost tests that a fake tcp6 address can be converted back
+// into its original .onion host address successfully.
+func TestFakeIPToOnionHost(t *testing.T) {
+	tcpAddr, err := net.ResolveTCPAddr(
+		"tcp6", fmt.Sprintf("[%s]:8333", testFakeIP),
+	)
+	require.NoError(t, err)
+	require.True(t, IsOnionFakeIP(tcpAddr))
+
+	onionHost, err := FakeIPToOnionHost(tcpAddr)
+	require.NoError(t, err)
+	require.Equal(t, fmt.Sprintf("%s:8333", testOnion), onionHost.String())
+}


### PR DESCRIPTION
Fixes https://github.com/lightningnetwork/lnd/issues/4803.

With https://github.com/lightningnetwork/lnd/pull/737 we intended to add Tor support for Neutrino backends.
Either something changed since that PR or we never fully tested this. Before this fix it was not possible to use an Onion v2 address for the `--neutrino.connect` flag.

With this PR we make it possible to use an Onion v2 hidden service
address as the Neutrino backend.
This failed before because an .onion address cannot be looked up and
converted into an IP address through the normal DNS resolving process,
even when using a Tor socks proxy.
Instead, we turn any v2 .onion address into a fake IPv6 representation
before giving it to Neutrino's address manager and turn it back into an
Onion host address when actually dialing.

To enable Onion v3 support, we need to rewrite the `github.com/btcsuite/btcd/addrmgr` library to be able to use `net.Addr` instead of only `net.IP`. Or we need to rewrite Neutrino to use its own address manager.