### PR TITLE
multi: add new config option to toggle gossip rate limiting 

### DIFF
--- a/discovery/gossiper_test.go
+++ b/discovery/gossiper_test.go
@@ -3957,6 +3957,7 @@ func TestRateLimitChannelUpdates(t *testing.T) {
 	}
 	defer cleanup()
 	ctx.gossiper.cfg.RebroadcastInterval = time.Hour
+	ctx.gossiper.cfg.GossipUpdateThrottle = true
 
 	// The graph should start empty.
 	require.Empty(t, ctx.router.infos)

--- a/lncfg/protocol_legacy_off.go
+++ b/lncfg/protocol_legacy_off.go
@@ -20,3 +20,8 @@ func (l *LegacyProtocol) LegacyOnion() bool {
 func (l *LegacyProtocol) NoStaticRemoteKey() bool {
 	return false
 }
+
+// NoGossipThrottle returns true if gossip updates shouldn't be throttled.
+func (l *LegacyProtocol) NoGossipThrottle() bool {
+	return false
+}

--- a/lncfg/protocol_legacy_on.go
+++ b/lncfg/protocol_legacy_on.go
@@ -16,6 +16,12 @@ type LegacyProtocol struct {
 	// remote party's output in the commitment. If set to true, then we
 	// won't signal StaticRemoteKeyOptional.
 	CommitmentTweak bool `long:"committweak" description:"force node to not advertise the new commitment format"`
+
+	// NoGossipUpdateThrottle if true, then gossip updates won't be
+	// throttled using the current set of heuristics. This should mainly be
+	// used for integration tests where we want nearly instant propagation
+	// of gossip updates.
+	NoGossipUpdateThrottle bool `long:"no-gossip-throttle" description:"if true, then gossip updates will not be throttled to once per rebroadcast interval for non keep-alive updates"`
 }
 
 // LegacyOnion returns true if the old legacy onion format should be used when
@@ -29,4 +35,9 @@ func (l *LegacyProtocol) LegacyOnion() bool {
 // remote key should be used for new funded channels.
 func (l *LegacyProtocol) NoStaticRemoteKey() bool {
 	return l.CommitmentTweak
+}
+
+// NoGossipThrottle returns true if gossip updates shouldn't be throttled.
+func (l *LegacyProtocol) NoGossipThrottle() bool {
+	return l.NoGossipUpdateThrottle
 }

--- a/lntest/node.go
+++ b/lntest/node.go
@@ -255,6 +255,7 @@ func (cfg NodeConfig) genArgs() []string {
 	args = append(args, fmt.Sprintf("--invoicemacaroonpath=%v", cfg.InvoiceMacPath))
 	args = append(args, fmt.Sprintf("--trickledelay=%v", trickleDelay))
 	args = append(args, fmt.Sprintf("--profile=%d", cfg.ProfilePort))
+	args = append(args, fmt.Sprintf("--protocol.legacy.no-gossip-throttle"))
 
 	if !cfg.HasSeed {
 		args = append(args, "--noseedbackup")

--- a/server.go
+++ b/server.go
@@ -804,6 +804,7 @@ func newServer(cfg *Config, listenAddrs []net.Addr,
 		MinimumBatchSize:        10,
 		SubBatchDelay:           time.Second * 5,
 		IgnoreHistoricalFilters: cfg.IgnoreHistoricalGossipFilters,
+		GossipUpdateThrottle:    !cfg.ProtocolOptions.NoGossipThrottle(),
 	},
 		s.identityECDH.PubKey(),
 	)


### PR DESCRIPTION
In this PR, we add a new legacy protocol config option to allow the itests to enable/disable gossip throttling for each new node (default is no throttling in the itests). We also pull in a commit meant to restore stability to the set of itests by reducing the number of parallel itests execution instances to 1 (effectively disabling the parallelization). 