### PR TITLE
itest: run sub itests correctly for watchtower tests

### DIFF
--- a/lntest/itest/lnd_test.go
+++ b/lntest/itest/lnd_test.go
@@ -9070,14 +9070,42 @@ func testRevokedCloseRetributionRemoteHodl(net *lntest.NetworkHarness,
 func testRevokedCloseRetributionAltruistWatchtower(net *lntest.NetworkHarness,
 	t *harnessTest) {
 
-	t.t.Run("anchors", func(tt *testing.T) {
-		ht := newHarnessTest(tt, net)
-		testRevokedCloseRetributionAltruistWatchtowerCase(net, ht, true)
-	})
-	t.t.Run("legacy", func(tt *testing.T) {
-		ht := newHarnessTest(tt, net)
-		testRevokedCloseRetributionAltruistWatchtowerCase(net, ht, false)
-	})
+	testCases := []struct {
+		name    string
+		anchors bool
+	}{{
+		name:    "anchors",
+		anchors: true,
+	}, {
+		name:    "legacy",
+		anchors: false,
+	}}
+
+	for _, tc := range testCases {
+		tc := tc
+
+		success := t.t.Run(tc.name, func(tt *testing.T) {
+			ht := newHarnessTest(tt, net)
+			ht.RunTestCase(&testCase{
+				name: tc.name,
+				test: func(net1 *lntest.NetworkHarness, t1 *harnessTest) {
+					testRevokedCloseRetributionAltruistWatchtowerCase(
+						net1, t1, tc.anchors,
+					)
+				},
+			})
+		})
+
+		if !success {
+			// Log failure time to help relate the lnd logs to the
+			// failure.
+			t.Logf("Failure time: %v", time.Now().Format(
+				"2006-01-02 15:04:05.000",
+			))
+
+			break
+		}
+	}
 }
 
 func testRevokedCloseRetributionAltruistWatchtowerCase(


### PR DESCRIPTION
To avoid the "Error outside of test" log and to properly terminate the
test if a sub test fails, we need to correctly invoke them using the
RunTestCase method.

