### PR TITLE
itest: fwd interceptor fixes

### DIFF
--- a/lntest/itest/lnd_forward_interceptor_test.go
+++ b/lntest/itest/lnd_forward_interceptor_test.go
@@ -227,11 +227,15 @@ func newInterceptorTestContext(t *harnessTest,
 	ctxb := context.Background()
 
 	// Create a three-node context consisting of Alice, Bob and Carol
+	alice, err := net.NewNode("alice", nil)
+	require.NoError(t.t, err, "unable to create alice")
+	bob, err := net.NewNode("bob", nil)
+	require.NoError(t.t, err, "unable to create bob")
 	carol, err := net.NewNode("carol", nil)
 	require.NoError(t.t, err, "unable to create carol")
 
 	// Connect nodes
-	nodes := []*lntest.HarnessNode{net.Alice, net.Bob, carol}
+	nodes := []*lntest.HarnessNode{alice, bob, carol}
 	for i := 0; i < len(nodes); i++ {
 		for j := i + 1; j < len(nodes); j++ {
 			ctxt, _ := context.WithTimeout(ctxb, defaultTimeout)
@@ -243,8 +247,8 @@ func newInterceptorTestContext(t *harnessTest,
 	ctx := interceptorTestContext{
 		t:     t,
 		net:   net,
-		alice: net.Alice,
-		bob:   net.Bob,
+		alice: alice,
+		bob:   bob,
 		carol: carol,
 		nodes: nodes,
 	}
@@ -328,6 +332,8 @@ func (c *interceptorTestContext) closeChannels() {
 }
 
 func (c *interceptorTestContext) shutdownNodes() {
+	shutdownAndAssert(c.net, c.t, c.alice)
+	shutdownAndAssert(c.net, c.t, c.bob)
 	shutdownAndAssert(c.net, c.t, c.carol)
 }
 


### PR DESCRIPTION
While investigating the source of:
```
    lnd_forward_interceptor_test.go:117: failed to send payment rpc error: code = Unknown desc = cannot attach payment addr
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0xeb4f01]
goroutine 2911 [running]:
github.com/lightningnetwork/lnd/lntest/itest.testForwardInterceptor.func2(0xc00036a130, 0xc00079aa40, 0x4, 0x4, 0xc0000d6cb0, 0xc0006c8540)
	/home/travis/gopath/src/github.com/lightningnetwork/lnd/lntest/itest/lnd_forward_interceptor_test.go:123 +0x221
created by github.com/lightningnetwork/lnd/lntest/itest.testForwardInterceptor
	/home/travis/gopath/src/github.com/lightningnetwork/lnd/lntest/itest/lnd_forward_interceptor_test.go:105 +0x38a
```
I noticed that the test harness shuts down entirely as a result of the failure. This PR makes some improvements to
the harness so that we can better diagnose the root cause.

Summary
 * Fixes itest panic where use of `Errorf` only logs the error, rather than failing the
  test, which results in a nil pointer deference that kills the itest suite
 * Replaces use of `Fatalf` with `require`
 * Initializes fresh Alice and Bob nodes rather than depending on `net.Alice` and `net.Bob`
 * Properly defers shutdown of individual nodes in main test method to prevent
   cases where the nodes linger after the test shutsdown