### PR TITLE
[anchors] zero-fee HTLC secondlevel transactions

### DIFF
--- a/chanbackup/single.go
+++ b/chanbackup/single.go
@@ -36,6 +36,10 @@ const (
 	// implicitly denotes that this channel uses the new anchor commitment
 	// format.
 	AnchorsCommitVersion = 2
+
+	// AnchorsZeroFeeHtlcTxCommitVersion is a version that denotes this
+	// channel is using the zero-fee second-level anchor commitment format.
+	AnchorsZeroFeeHtlcTxCommitVersion = 3
 )
 
 // Single is a static description of an existing channel that can be used for
@@ -163,6 +167,9 @@ func NewSingle(channel *channeldb.OpenChannel,
 	}
 
 	switch {
+	case channel.ChanType.ZeroHtlcTxFee():
+		single.Version = AnchorsZeroFeeHtlcTxCommitVersion
+
 	case channel.ChanType.HasAnchors():
 		single.Version = AnchorsCommitVersion
 
@@ -185,6 +192,7 @@ func (s *Single) Serialize(w io.Writer) error {
 	case DefaultSingleVersion:
 	case TweaklessCommitVersion:
 	case AnchorsCommitVersion:
+	case AnchorsZeroFeeHtlcTxCommitVersion:
 	default:
 		return fmt.Errorf("unable to serialize w/ unknown "+
 			"version: %v", s.Version)
@@ -344,6 +352,7 @@ func (s *Single) Deserialize(r io.Reader) error {
 	case DefaultSingleVersion:
 	case TweaklessCommitVersion:
 	case AnchorsCommitVersion:
+	case AnchorsZeroFeeHtlcTxCommitVersion:
 	default:
 		return fmt.Errorf("unable to de-serialize w/ unknown "+
 			"version: %v", s.Version)

--- a/channeldb/channel.go
+++ b/channeldb/channel.go
@@ -244,6 +244,10 @@ const (
 	// that only the responder can decide to cooperatively close the
 	// channel.
 	FrozenBit ChannelType = 1 << 4
+
+	// ZeroHtlcTxFeeBit indicates that the channel should use zero-fee
+	// second-level HTLC transactions.
+	ZeroHtlcTxFeeBit ChannelType = 1 << 5
 )
 
 // IsSingleFunder returns true if the channel type if one of the known single
@@ -273,6 +277,12 @@ func (c ChannelType) HasFundingTx() bool {
 // commitment.
 func (c ChannelType) HasAnchors() bool {
 	return c&AnchorOutputsBit == AnchorOutputsBit
+}
+
+// ZeroHtlcTxFee returns true if this channel type uses second-level HTLC
+// transactions signed with zero-fee.
+func (c ChannelType) ZeroHtlcTxFee() bool {
+	return c&ZeroHtlcTxFeeBit == ZeroHtlcTxFeeBit
 }
 
 // IsFrozen returns true if the channel is considered to be "frozen". A frozen

--- a/chanrestore.go
+++ b/chanrestore.go
@@ -110,6 +110,11 @@ func (c *chanDBRestorer) openChannelShell(backup chanbackup.Single) (
 		chanType = channeldb.AnchorOutputsBit
 		chanType |= channeldb.SingleFunderTweaklessBit
 
+	case chanbackup.AnchorsZeroFeeHtlcTxCommitVersion:
+		chanType = channeldb.ZeroHtlcTxFeeBit
+		chanType |= channeldb.AnchorOutputsBit
+		chanType |= channeldb.SingleFunderTweaklessBit
+
 	default:
 		return nil, fmt.Errorf("unknown Single version: %v", err)
 	}

--- a/feature/default_sets.go
+++ b/feature/default_sets.go
@@ -43,7 +43,7 @@ var defaultSetDesc = setDesc{
 		SetNodeAnn: {}, // N
 		SetInvoice: {}, // 9
 	},
-	lnwire.AnchorsOptional: {
+	lnwire.AnchorsZeroFeeHtlcTxOptional: {
 		SetInit:    {}, // I
 		SetNodeAnn: {}, // N
 	},

--- a/feature/manager.go
+++ b/feature/manager.go
@@ -83,8 +83,8 @@ func newManager(cfg Config, desc setDesc) (*Manager, error) {
 			raw.Unset(lnwire.StaticRemoteKeyRequired)
 		}
 		if cfg.NoAnchors {
-			raw.Unset(lnwire.AnchorsOptional)
-			raw.Unset(lnwire.AnchorsRequired)
+			raw.Unset(lnwire.AnchorsZeroFeeHtlcTxOptional)
+			raw.Unset(lnwire.AnchorsZeroFeeHtlcTxRequired)
 		}
 		if cfg.NoWumbo {
 			raw.Unset(lnwire.WumboChannelsOptional)

--- a/lncfg/protocol.go
+++ b/lncfg/protocol.go
@@ -17,10 +17,20 @@ type ProtocolOptions struct {
 	// (channels larger than 0.16 BTC) channels, which is the opposite of
 	// mini.
 	WumboChans bool `long:"wumbo-channels" description:"if set, then lnd will create and accept requests for channels larger chan 0.16 BTC"`
+
+	// NoAnchors should be set if we don't want to support opening or accepting
+	// channels having the anchor commitment type.
+	NoAnchors bool `long:"no-anchors" description:"disable support for anchor commitments"`
 }
 
 // Wumbo returns true if lnd should permit the creation and acceptance of wumbo
 // channels.
 func (l *ProtocolOptions) Wumbo() bool {
 	return l.WumboChans
+}
+
+// NoAnchorCommitments returns true if we have disabled support for the anchor
+// commitment type.
+func (l *ProtocolOptions) NoAnchorCommitments() bool {
+	return l.NoAnchors
 }

--- a/lncfg/protocol_experimental_off.go
+++ b/lncfg/protocol_experimental_off.go
@@ -6,9 +6,3 @@ package lncfg
 // features that also require a build-tag to activate.
 type ExperimentalProtocol struct {
 }
-
-// AnchorCommitments returns true if support for the anchor commitment type
-// should be signaled.
-func (l *ExperimentalProtocol) AnchorCommitments() bool {
-	return false
-}

--- a/lncfg/protocol_experimental_on.go
+++ b/lncfg/protocol_experimental_on.go
@@ -5,13 +5,4 @@ package lncfg
 // ExperimentalProtocol is a sub-config that houses any experimental protocol
 // features that also require a build-tag to activate.
 type ExperimentalProtocol struct {
-	// Anchors should be set if we want to support opening or accepting
-	// channels having the anchor commitment type.
-	Anchors bool `long:"anchors" description:"EXPERIMENTAL: enable experimental support for anchor commitments, won't work with watchtowers"`
-}
-
-// AnchorCommitments returns true if support for the anchor commitment type
-// should be signaled.
-func (l *ExperimentalProtocol) AnchorCommitments() bool {
-	return l.Anchors
 }

--- a/lncfg/protocol_rpctest.go
+++ b/lncfg/protocol_rpctest.go
@@ -1,4 +1,4 @@
-// +build !rpctest
+// +build rpctest
 
 package lncfg
 
@@ -20,9 +20,9 @@ type ProtocolOptions struct {
 	// mini.
 	WumboChans bool `long:"wumbo-channels" description:"if set, then lnd will create and accept requests for channels larger chan 0.16 BTC"`
 
-	// NoAnchors should be set if we don't want to support opening or accepting
-	// channels having the anchor commitment type.
-	NoAnchors bool `long:"no-anchors" description:"disable support for anchor commitments"`
+	// Anchors enables anchor commitments.
+	// TODO(halseth): transition itests to anchors instead!
+	Anchors bool `long:"anchors" description:"enable support for anchor commitments"`
 }
 
 // Wumbo returns true if lnd should permit the creation and acceptance of wumbo
@@ -34,5 +34,5 @@ func (l *ProtocolOptions) Wumbo() bool {
 // NoAnchorCommitments returns true if we have disabled support for the anchor
 // commitment type.
 func (l *ProtocolOptions) NoAnchorCommitments() bool {
-	return l.NoAnchors
+	return !l.Anchors
 }

--- a/lnwallet/commitment.go
+++ b/lnwallet/commitment.go
@@ -278,6 +278,12 @@ func CommitWeight(chanType channeldb.ChannelType) int64 {
 func HtlcTimeoutFee(chanType channeldb.ChannelType,
 	feePerKw chainfee.SatPerKWeight) btcutil.Amount {
 
+	// For zero-fee HTLC channels, this will always be zero, regardless of
+	// feerate.
+	if chanType.ZeroHtlcTxFee() {
+		return 0
+	}
+
 	if chanType.HasAnchors() {
 		return feePerKw.FeeForWeight(input.HtlcTimeoutWeightConfirmed)
 	}
@@ -289,6 +295,12 @@ func HtlcTimeoutFee(chanType channeldb.ChannelType,
 // transaction based on the current fee rate.
 func HtlcSuccessFee(chanType channeldb.ChannelType,
 	feePerKw chainfee.SatPerKWeight) btcutil.Amount {
+
+	// For zero-fee HTLC channels, this will always be zero, regardless of
+	// feerate.
+	if chanType.ZeroHtlcTxFee() {
+		return 0
+	}
 
 	if chanType.HasAnchors() {
 		return feePerKw.FeeForWeight(input.HtlcSuccessWeightConfirmed)

--- a/lnwallet/reservation.go
+++ b/lnwallet/reservation.go
@@ -28,10 +28,11 @@ const (
 	// to_remote key is static.
 	CommitmentTypeTweakless
 
-	// CommitmentTypeAnchors is a commitment type that is tweakless, and
-	// has extra anchor ouputs in order to bump the fee of the commitment
-	// transaction.
-	CommitmentTypeAnchors
+	// CommitmentTypeAnchorsZeroFeeHtlcTx is a commitment type that is an
+	// extension of the outdated CommitmentTypeAnchors, which in addition
+	// requires second-level HTLC transactions to be signed using a
+	// zero-fee.
+	CommitmentTypeAnchorsZeroFeeHtlcTx
 )
 
 // String returns the name of the CommitmentType.
@@ -41,8 +42,8 @@ func (c CommitmentType) String() string {
 		return "legacy"
 	case CommitmentTypeTweakless:
 		return "tweakless"
-	case CommitmentTypeAnchors:
-		return "anchors"
+	case CommitmentTypeAnchorsZeroFeeHtlcTx:
+		return "anchors-zero-fee-second-level"
 	default:
 		return "invalid"
 	}
@@ -182,7 +183,7 @@ func NewChannelReservation(capacity, localFundingAmt btcutil.Amount,
 	// Based on the channel type, we determine the initial commit weight
 	// and fee.
 	commitWeight := int64(input.CommitWeight)
-	if commitType == CommitmentTypeAnchors {
+	if commitType == CommitmentTypeAnchorsZeroFeeHtlcTx {
 		commitWeight = input.AnchorCommitWeight
 	}
 	commitFee := commitFeePerKw.FeeForWeight(commitWeight)
@@ -195,7 +196,7 @@ func NewChannelReservation(capacity, localFundingAmt btcutil.Amount,
 	// The total fee paid by the initiator will be the commitment fee in
 	// addition to the two anchor outputs.
 	feeMSat := lnwire.NewMSatFromSatoshis(commitFee)
-	if commitType == CommitmentTypeAnchors {
+	if commitType == CommitmentTypeAnchorsZeroFeeHtlcTx {
 		feeMSat += 2 * lnwire.NewMSatFromSatoshis(anchorSize)
 	}
 
@@ -280,8 +281,7 @@ func NewChannelReservation(capacity, localFundingAmt btcutil.Amount,
 		// Both the tweakless type and the anchor type is tweakless,
 		// hence set the bit.
 		if commitType == CommitmentTypeTweakless ||
-			commitType == CommitmentTypeAnchors {
-
+			commitType == CommitmentTypeAnchorsZeroFeeHtlcTx {
 			chanType |= channeldb.SingleFunderTweaklessBit
 		} else {
 			chanType |= channeldb.SingleFunderBit
@@ -315,9 +315,11 @@ func NewChannelReservation(capacity, localFundingAmt btcutil.Amount,
 		chanType |= channeldb.DualFunderBit
 	}
 
-	// We are adding anchor outputs to our commitment.
-	if commitType == CommitmentTypeAnchors {
+	// We are adding anchor outputs to our commitment. We only support this
+	// in combination with zero-fee second-levels HTLCs.
+	if commitType == CommitmentTypeAnchorsZeroFeeHtlcTx {
 		chanType |= channeldb.AnchorOutputsBit
+		chanType |= channeldb.ZeroHtlcTxFeeBit
 	}
 
 	// If the channel is meant to be frozen, then we'll set the frozen bit

--- a/lnwire/features.go
+++ b/lnwire/features.go
@@ -119,6 +119,16 @@ const (
 	// outputs.
 	AnchorsOptional FeatureBit = 21
 
+	// AnchorsZeroFeeHtlcTxRequired is a required feature bit that signals
+	// that the node requires channels having zero-fee second-level HTLC
+	// transactions, which also imply anchor commitments.
+	AnchorsZeroFeeHtlcTxRequired FeatureBit = 22
+
+	// AnchorsZeroFeeHtlcTxRequired is an optional feature bit that signals
+	// that the node supports channels having zero-fee second-level HTLC
+	// transactions, which also imply anchor commitments.
+	AnchorsZeroFeeHtlcTxOptional FeatureBit = 23
+
 	// maxAllowedSize is a maximum allowed size of feature vector.
 	//
 	// NOTE: Within the protocol, the maximum allowed message size is 65535
@@ -158,6 +168,8 @@ var Features = map[FeatureBit]string{
 	MPPRequired:                   "multi-path-payments",
 	AnchorsRequired:               "anchor-commitments",
 	AnchorsOptional:               "anchor-commitments",
+	AnchorsZeroFeeHtlcTxRequired:  "anchors-zero-fee-htlc-tx",
+	AnchorsZeroFeeHtlcTxOptional:  "anchors-zero-fee-htlc-tx",
 	WumboChannelsRequired:         "wumbo-channels",
 	WumboChannelsOptional:         "wumbo-channels",
 }

--- a/sample-lnd.conf
+++ b/sample-lnd.conf
@@ -938,8 +938,8 @@ litecoin.node=ltcd
 ; BTC
 ; protocol.wumbo-channels=true
 
-; Set to enable experimental support for anchor commitments, won't work with watchtowers yet.
-; protocol.anchors=true
+; Set to disable support for anchor commitments
+; protocol.no-anchors=true
 
 [db]
 ; The selected database backend. The current default backend is "bolt". lnd

--- a/server.go
+++ b/server.go
@@ -404,7 +404,7 @@ func newServer(cfg *Config, listenAddrs []net.Addr,
 	featureMgr, err := feature.NewManager(feature.Config{
 		NoTLVOnion:        cfg.ProtocolOptions.LegacyOnion(),
 		NoStaticRemoteKey: cfg.ProtocolOptions.NoStaticRemoteKey(),
-		NoAnchors:         !cfg.ProtocolOptions.AnchorCommitments(),
+		NoAnchors:         cfg.ProtocolOptions.NoAnchorCommitments(),
 		NoWumbo:           !cfg.ProtocolOptions.Wumbo(),
 	})
 	if err != nil {


### PR DESCRIPTION
This PR enables an extension to the `anchor` commitment type that makes second-level HTLC transactions pay a zero fee, meaning they will have to have fees added as in #4779.

This PR adds this type to the already existing `anchors` type, meaning all new anchor channels being opened will have this enabled (as long as both nodes support it). Existing anchor channels will stay the same.

### TODO
- [ ] Reserve feature bit at spec level

### Builds on
#4779 