### PR TITLE
[trivial] htlcswitch: log with format

### DIFF
--- a/htlcswitch/switch.go
+++ b/htlcswitch/switch.go
@@ -936,7 +936,7 @@ func (s *Switch) parseFailedPayment(deobfuscator ErrorDecrypter,
 			OutgoingFailureOnChainTimeout,
 		)
 
-		log.Info("%v: hash=%v, pid=%d",
+		log.Infof("%v: hash=%v, pid=%d",
 			linkError.FailureDetail.FailureString(),
 			paymentHash, paymentID)
 


### PR DESCRIPTION
Log message would look like

```
2020-12-08 13:43:51.445 [INF] HSWC: %v: hash=%v, pid=%d payment was resolved on-chain, then canceled back c5047d3bc9dcbd5a7754f759e1d56146c540fc5b647ca78535cc479bcd3e7d1e 2
```