### PR TITLE
itest: increase recovery payment amount so htlc isn't dust

### DIFF
--- a/lntest/itest/lnd_channel_backup_test.go
+++ b/lntest/itest/lnd_channel_backup_test.go
@@ -895,7 +895,7 @@ func testChanRestoreScenario(t *harnessTest, net *lntest.NetworkHarness,
 	if testCase.channelsUpdated {
 		invoice := &lnrpc.Invoice{
 			Memo:  "testing",
-			Value: 10000,
+			Value: 100000,
 		}
 		invoiceResp, err := to.AddInvoice(ctxt, invoice)
 		if err != nil {


### PR DESCRIPTION
This PR fixes a bug in the current itest harness, resulting in this error on neutrino:
```
test_harness.go:91: Error outside of test: *errors.errorString unable to find Carol's force close tx in mempool: wanted 2, found 1 txs in mempool: [306027425abd0b846c54599169b911127cbc247b03b5ab4feb7fb2655f4f032e]
        /home/travis/gopath/src/github.com/lightningnetwork/lnd/lntest/itest/lnd_test.go:9574 (0xe98f5e)
        	assertDLPExecuted: t.Fatalf("unable to find Carol's force close tx in mempool: %v",
        /home/travis/gopath/src/github.com/lightningnetwork/lnd/lntest/itest/lnd_channel_backup_test.go:1065 (0xe45ab1)
        	testChanRestoreScenario: assertDLPExecuted(
        /home/travis/gopath/src/github.com/lightningnetwork/lnd/lntest/itest/lnd_channel_backup_test.go:374 (0xebb9db)
        	testChannelBackupRestore.func9: testChanRestoreScenario(h, net, &testCase, password)
        /home/travis/.gimme/versions/go1.15.6.linux.amd64/src/testing/testing.go:1123 (0x51c2ef)
        	tRunner: fn(t)
        /home/travis/.gimme/versions/go1.15.6.linux.amd64/src/runtime/asm_amd64.s:1374 (0x46f821)
        	goexit: BYTE	$0x90	// NOP
```

The logs indicate that we are trying to create a sweep transaction that doesn't meet the dust threshold:
```
2020-12-08 22:25:27.628 [DBG] SWPR: Set value -0.0003248 BTC (r=0 BTC, c=-0.0003248 BTC) below dust limit of 0.00000537 BTC
```
which explains why only one of the two transactions isn't published.

It looks like this might have stemmed from a related itest flake fix [in this commit](https://github.com/lightningnetwork/lnd/commit/ea4bb5dc5ce1a028811617ecd74197f296890c32), and the fee may now be too high for the payment size. To remedy we increase the payment size so that the sweep won't create a dust output.