### PR TITLE
GitHub: specify docker image platforms to enable ARM image builds

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -37,6 +37,7 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           push: true
+          platforms: linux/amd64,linux/arm64
           tags: "${{ env.DOCKER_REPO }}/${{ env.DOCKER_IMAGE }}:${{ env.RELEASE_VERSION }}"
           build-args: checkout=${{ env.RELEASE_VERSION }}
 


### PR DESCRIPTION
To enable building docker images for ARM64 platforms as well,
we just need to specify the desired target platforms and the Docker
Buildx service will do the job for us (provided the base images support
the given platforms, which is the case for golang).

The result of a test run on my private fork can be inspected here:
 - Build: https://github.com/guggero/lnd/runs/1524288829?check_suite_focus=true
 - Resulting image: https://hub.docker.com/layers/guggero/lnd/v0.0.0-docker-arm1/images/sha256-df8c7ddc94d3a08313f6e9506da852e060c4a31a1f0913eabf9351c35236fd25?context=explore (don't use for mainnet obviously!)

Big shoutout to @openoms who ran a quick sanity check of the above image on a 32bit Raspberry Pi to confirm the output binary format is indeed ARM compatible.

Full functional tests should still be performed during the `v0.12.0` RC phase though!