### PR TITLE
make: use low-scrypt + parallelization to speed up  unit-race

### DIFF
--- a/chainntnfs/test/bitcoind/bitcoind_test.go
+++ b/chainntnfs/test/bitcoind/bitcoind_test.go
@@ -1,0 +1,15 @@
+// +build dev
+
+package bitcoind_test
+
+import (
+	"testing"
+
+	chainntnfstest "github.com/lightningnetwork/lnd/chainntnfs/test"
+)
+
+// TestInterfaces executes the generic notifier test suite against a bitcoind
+// powered chain notifier.
+func TestInterfaces(t *testing.T) {
+	chainntnfstest.TestInterfaces(t, "bitcoind")
+}

--- a/chainntnfs/test/btcd/btcd_test.go
+++ b/chainntnfs/test/btcd/btcd_test.go
@@ -1,0 +1,15 @@
+// +build dev
+
+package btcd_test
+
+import (
+	"testing"
+
+	chainntnfstest "github.com/lightningnetwork/lnd/chainntnfs/test"
+)
+
+// TestInterfaces executes the generic notifier test suite against a btcd
+// powered chain notifier.
+func TestInterfaces(t *testing.T) {
+	chainntnfstest.TestInterfaces(t, "btcd")
+}

--- a/chainntnfs/test/neutrino/neutrino_test.go
+++ b/chainntnfs/test/neutrino/neutrino_test.go
@@ -1,0 +1,15 @@
+// +build dev
+
+package neutrino_test
+
+import (
+	"testing"
+
+	chainntnfstest "github.com/lightningnetwork/lnd/chainntnfs/test"
+)
+
+// TestInterfaces executes the generic notifier test suite against a neutrino
+// powered chain notifier.
+func TestInterfaces(t *testing.T) {
+	chainntnfstest.TestInterfaces(t, "neutrino")
+}

--- a/chainntnfs/test/test_interface.go
+++ b/chainntnfs/test/test_interface.go
@@ -1,6 +1,6 @@
 // +build dev
 
-package chainntnfs_test
+package chainntnfstest
 
 import (
 	"bytes"
@@ -1893,7 +1893,7 @@ var blockCatchupTests = []blockCatchupTestCase{
 // import should trigger an init() method within the package which registers
 // the interface. Second, an additional case in the switch within the main loop
 // below needs to be added which properly initializes the interface.
-func TestInterfaces(t *testing.T) {
+func TestInterfaces(t *testing.T, targetBackEnd string) {
 	// Initialize the harness around a btcd node which will serve as our
 	// dedicated miner to generate blocks, cause re-orgs, etc. We'll set up
 	// this node with a chain length of 125, so we have plenty of BTC to
@@ -1908,6 +1908,11 @@ func TestInterfaces(t *testing.T) {
 		2*len(txNtfnTests)+len(blockNtfnTests)+len(blockCatchupTests))
 
 	for _, notifierDriver := range chainntnfs.RegisteredNotifiers() {
+		notifierType := notifierDriver.NotifierType
+		if notifierType != targetBackEnd {
+			continue
+		}
+
 		// Initialize a height hint cache for each notifier.
 		tempDir, err := ioutil.TempDir("", "channeldb")
 		if err != nil {
@@ -1926,9 +1931,8 @@ func TestInterfaces(t *testing.T) {
 		}
 
 		var (
-			cleanUp      func()
-			newNotifier  func() (chainntnfs.TestChainNotifier, error)
-			notifierType = notifierDriver.NotifierType
+			cleanUp     func()
+			newNotifier func() (chainntnfs.TestChainNotifier, error)
 		)
 
 		switch notifierType {

--- a/lnwallet/btcwallet/btcwallet_rpctest.go
+++ b/lnwallet/btcwallet/btcwallet_rpctest.go
@@ -1,4 +1,4 @@
-// +build rpctest
+// +build rpctest lowscrypt
 
 package btcwallet
 

--- a/lnwallet/test/bitcoind/bitcoind_test.go
+++ b/lnwallet/test/bitcoind/bitcoind_test.go
@@ -1,0 +1,13 @@
+package bitcoind_test
+
+import (
+	"testing"
+
+	lnwallettest "github.com/lightningnetwork/lnd/lnwallet/test"
+)
+
+// TestLightningWallet tests LightningWallet powered by bitcoind against our
+// suite of interface tests.
+func TestLightningWallet(t *testing.T) {
+	lnwallettest.TestLightningWallet(t, "bitcoind")
+}

--- a/lnwallet/test/btcd/btcd_test.go
+++ b/lnwallet/test/btcd/btcd_test.go
@@ -1,0 +1,13 @@
+package btcd_test
+
+import (
+	"testing"
+
+	lnwallettest "github.com/lightningnetwork/lnd/lnwallet/test"
+)
+
+// TestLightningWallet tests LightningWallet powered by btcd against our suite
+// of interface tests.
+func TestLightningWallet(t *testing.T) {
+	lnwallettest.TestLightningWallet(t, "btcd")
+}

--- a/lnwallet/test/interface_test.go
+++ b/lnwallet/test/interface_test.go
@@ -1,4 +1,4 @@
-package lnwallet_test
+package lnwallettest_test
 
 import (
 	"bytes"

--- a/lnwallet/test/neutrino/neutrino_test.go
+++ b/lnwallet/test/neutrino/neutrino_test.go
@@ -1,0 +1,13 @@
+package neutrino_test
+
+import (
+	"testing"
+
+	lnwallettest "github.com/lightningnetwork/lnd/lnwallet/test"
+)
+
+// TestLightningWallet tests LightningWallet powered by neutrino against our
+// suite of interface tests.
+func TestLightningWallet(t *testing.T) {
+	lnwallettest.TestLightningWallet(t, "neutrino")
+}

--- a/lnwallet/test/test_interface.go
+++ b/lnwallet/test/test_interface.go
@@ -1,4 +1,4 @@
-package lnwallettest_test
+package lnwallettest
 
 import (
 	"bytes"
@@ -3086,7 +3086,7 @@ func testSingleFunderExternalFundingTx(miner *rpctest.Harness,
 // below needs to be added which properly initializes the interface.
 //
 // TODO(roasbeef): purge bobNode in favor of dual lnwallet's
-func TestLightningWallet(t *testing.T) {
+func TestLightningWallet(t *testing.T, targetBackEnd string) {
 	t.Parallel()
 
 	// Initialize the harness around a btcd node which will serve as our
@@ -3140,6 +3140,10 @@ func TestLightningWallet(t *testing.T) {
 
 	for _, walletDriver := range lnwallet.RegisteredWallets() {
 		for _, backEnd := range walletDriver.BackEnds() {
+			if backEnd != targetBackEnd {
+				continue
+			}
+
 			if !runTests(t, walletDriver, backEnd, miningNode,
 				rpcConfig, chainNotifier) {
 				return

--- a/make/testing_flags.mk
+++ b/make/testing_flags.mk
@@ -4,7 +4,7 @@ LOG_TAGS =
 TEST_FLAGS =
 ITEST_FLAGS = 
 EXEC_SUFFIX =
-COVER_PKG = $$(go list -deps ./... | grep '$(PKG)' | grep -v lnrpc)
+COVER_PKG = $$(go list -deps -tags="$(DEV_TAGS)" ./... | grep '$(PKG)' | grep -v lnrpc)
 NUM_ITEST_TRANCHES = 4
 ITEST_PARALLELISM = $(NUM_ITEST_TRANCHES)
 

--- a/make/testing_flags.mk
+++ b/make/testing_flags.mk
@@ -86,7 +86,7 @@ UNIT_TARGETED ?= no
 # targeted case. Otherwise, default to running all tests.
 ifeq ($(UNIT_TARGETED), yes)
 UNIT := $(GOTEST) -tags="$(DEV_TAGS) $(LOG_TAGS)" $(TEST_FLAGS) $(UNITPKG)
-UNIT_RACE := $(GOTEST) -tags="$(DEV_TAGS) $(LOG_TAGS)" $(TEST_FLAGS) -race $(UNITPKG)
+UNIT_RACE := $(GOTEST) -tags="$(DEV_TAGS) $(LOG_TAGS) lowscrypt" $(TEST_FLAGS) -race $(UNITPKG)
 endif
 
 ifeq ($(UNIT_TARGETED), no)


### PR DESCRIPTION
This predominately affects the lnwallet unit tests which are the bulk of
the execution time.

We also move around the way the interface tests are invoked, such that
they are called from distinct subpackages for each backend. This gives 
us free parallelism from the standard go test harness.

Together this shaves about 2 minutes (10%) of the `unit-race` execution
time.