### PR TITLE
GitHub+Travis+docker: update golang patch version to 1.15.6 everywhere

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,6 +18,12 @@ env:
   GOPATH: /home/runner/work/go
   DOWNLOAD_CACHE: /home/runner/work/download_cache
   BITCOIN_VERSION: 0.20.1
+
+  # If you change this value, please change it in the following files as well:
+  # /.travis.yml
+  # /Dockerfile
+  # /dev.Dockerfile
+  # /.github/workflows/release.yml
   GO_VERSION: 1.15.6
 
 jobs:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -12,7 +12,13 @@ defaults:
 env:
   DOCKER_REPO: lightninglabs
   DOCKER_IMAGE: lnd
-  GO_VERSION: 1.15.5
+  
+  # If you change this value, please change it in the following files as well:
+  # /.travis.yml
+  # /Dockerfile
+  # /dev.Dockerfile
+  # /.github/workflows/main.yml
+  GO_VERSION: 1.15.6
 
 jobs:
   main:

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,12 @@ git:
   depth: false
 
 go:
-  - "1.15.x"
+  # If you change this value, please change it in the following files as well:
+  # /Dockerfile
+  # /dev.Dockerfile
+  # /.github/workflows/main.yml
+  # /.github/workflows/release.yml
+  - "1.15.6"
 
 env:
   global:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.14.5-alpine as builder
+FROM golang:1.15.6-alpine as builder
 
 # Force Go to use the cgo based DNS resolver. This is required to ensure DNS
 # queries required to connect to linked containers succeed.

--- a/dev.Dockerfile
+++ b/dev.Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.13-alpine as builder
+FROM golang:1.15.6-alpine as builder
 
 LABEL maintainer="Olaoluwa Osuntokun <laolu@lightning.engineering>"
 


### PR DESCRIPTION
Addendum to https://github.com/lightningnetwork/lnd/pull/4858: We need to update the golang patch version in the Docker files and release scripts as well to make sure all our upcoming RC deliverables will be built with the latest version.