### PR TITLE
etcd: add support for namespaces

### DIFF
--- a/channeldb/kvdb/config.go
+++ b/channeldb/kvdb/config.go
@@ -44,6 +44,8 @@ type EtcdConfig struct {
 
 	Pass string `long:"pass" description:"Password for the database user."`
 
+	Namespace string `long:"namespace" description:"The etcd namespace to use."`
+
 	CertFile string `long:"cert_file" description:"Path to the TLS certificate for etcd RPC."`
 
 	KeyFile string `long:"key_file" description:"Path to the TLS private key for etcd RPC."`

--- a/channeldb/kvdb/etcd/embed.go
+++ b/channeldb/kvdb/etcd/embed.go
@@ -21,6 +21,12 @@ const (
 	// embedded etcd servers. Ports are monotonically increasing starting
 	// from this number and are determined by the results of getFreePort().
 	defaultEtcdPort = 2379
+
+	// defaultNamespace is the namespace we'll use in our embedded etcd
+	// instance. Since it is only used for testing, we'll use the namespace
+	// name "test/" for this. Note that the namespace can be any string,
+	// the trailing / is not required.
+	defaultNamespace = "test/"
 )
 
 var (
@@ -90,6 +96,7 @@ func NewEmbeddedEtcdInstance(path string) (*BackendConfig, func(), error) {
 		User:               "user",
 		Pass:               "pass",
 		InsecureSkipVerify: true,
+		Namespace:          defaultNamespace,
 	}
 
 	return connConfig, func() {

--- a/channeldb/kvdb/kvdb_etcd.go
+++ b/channeldb/kvdb/kvdb_etcd.go
@@ -28,6 +28,7 @@ func GetEtcdBackend(ctx context.Context, prefix string,
 		KeyFile:            etcdConfig.KeyFile,
 		InsecureSkipVerify: etcdConfig.InsecureSkipVerify,
 		Prefix:             prefix,
+		Namespace:          etcdConfig.Namespace,
 		CollectCommitStats: etcdConfig.CollectStats,
 	}
 

--- a/sample-lnd.conf
+++ b/sample-lnd.conf
@@ -965,6 +965,9 @@ litecoin.node=ltcd
 ; Password for the database user.
 ; db.etcd.pass=longandsekrit
 
+; Etcd namespace to use.
+; db.etcd.namespace=lnd
+
 ; Path to the TLS certificate for etcd RPC.
 ; db.etcd.cert_file=/key/path
 


### PR DESCRIPTION
This PR adds support for etcd namespaces. This is useful when
using a shared etcd database where separate users have access to
separate namespaces.
