### PR TITLE
lnwire: fix heap escapes to reduce gc pressure

### DIFF
--- a/buffer/read.go
+++ b/buffer/read.go
@@ -7,7 +7,7 @@ import (
 // ReadSize represents the size of the maximum message that can be read off the
 // wire by brontide. The buffer is used to hold the ciphertext while the
 // brontide state machine decrypts the message.
-const ReadSize = lnwire.MaxMessagePayload + 16
+const ReadSize = lnwire.MaxSliceLength + 16
 
 // Read is a static byte array sized to the maximum-allowed Lightning message
 // size, plus 16 bytes for the MAC.

--- a/buffer/write.go
+++ b/buffer/write.go
@@ -7,7 +7,7 @@ import (
 // WriteSize represents the size of the maximum plaintext message than can be
 // sent using brontide. The buffer does not include extra space for the MAC, as
 // that is applied by the Noise protocol after encrypting the plaintext.
-const WriteSize = lnwire.MaxMessagePayload
+const WriteSize = lnwire.MaxSliceLength
 
 // Write is static byte array occupying to maximum-allowed plaintext-message
 // size.

--- a/chanbackup/single.go
+++ b/chanbackup/single.go
@@ -265,8 +265,15 @@ func (s *Single) Serialize(w io.Writer) error {
 		return err
 	}
 
+	// TODO(yy): remove the type assertion when we finished refactoring db
+	// into using write buffer.
+	buf, ok := w.(*bytes.Buffer)
+	if !ok {
+		return fmt.Errorf("expect io.Writer to be *bytes.Buffer")
+	}
+
 	return lnwire.WriteElements(
-		w,
+		buf,
 		byte(s.Version),
 		uint16(len(singleBytes.Bytes())),
 		singleBytes.Bytes(),

--- a/channeldb/waitingproof.go
+++ b/channeldb/waitingproof.go
@@ -2,6 +2,7 @@ package channeldb
 
 import (
 	"encoding/binary"
+	"fmt"
 	"sync"
 
 	"io"
@@ -232,7 +233,14 @@ func (p *WaitingProof) Encode(w io.Writer) error {
 		return err
 	}
 
-	if err := p.AnnounceSignatures.Encode(w, 0); err != nil {
+	// TODO(yy): remove the type assertion when we finished refactoring db
+	// into using write buffer.
+	buf, ok := w.(*bytes.Buffer)
+	if !ok {
+		return fmt.Errorf("expect io.Writer to be *bytes.Buffer")
+	}
+
+	if err := p.AnnounceSignatures.Encode(buf, 0); err != nil {
 		return err
 	}
 

--- a/docs/release-notes/release-notes-0.14.0.md
+++ b/docs/release-notes/release-notes-0.14.0.md
@@ -119,6 +119,10 @@ you.
 * [Update MC store in blocks](https://github.com/lightningnetwork/lnd/pull/5515)
   to make payment throughput better when using etcd.
 
+* [The `lnwire` package now uses a write buffer pool](https://github.com/lightningnetwork/lnd/pull/4884)
+  when encoding/decoding messages. Such that most of the heap escapes are fixed,
+  resulting in less memory being used when running `lnd`.
+
 ## Bug Fixes
 
 A bug has been fixed that would cause `lnd` to [try to bootstrap using the

--- a/lnwire/accept_channel.go
+++ b/lnwire/accept_channel.go
@@ -1,6 +1,7 @@
 package lnwire
 
 import (
+	"bytes"
 	"fmt"
 	"io"
 
@@ -115,7 +116,7 @@ var _ Message = (*AcceptChannel)(nil)
 // protocol version.
 //
 // This is part of the lnwire.Message interface.
-func (a *AcceptChannel) Encode(w io.Writer, pver uint32) error {
+func (a *AcceptChannel) Encode(w *bytes.Buffer, pver uint32) error {
 	// Since the upfront script is encoded as a TLV record, concatenate it
 	// with the ExtraData, and write them as one.
 	tlvRecords, err := packShutdownScript(

--- a/lnwire/accept_channel.go
+++ b/lnwire/accept_channel.go
@@ -126,23 +126,63 @@ func (a *AcceptChannel) Encode(w *bytes.Buffer, pver uint32) error {
 		return err
 	}
 
-	return WriteElements(w,
-		a.PendingChannelID[:],
-		a.DustLimit,
-		a.MaxValueInFlight,
-		a.ChannelReserve,
-		a.HtlcMinimum,
-		a.MinAcceptDepth,
-		a.CsvDelay,
-		a.MaxAcceptedHTLCs,
-		a.FundingKey,
-		a.RevocationPoint,
-		a.PaymentPoint,
-		a.DelayedPaymentPoint,
-		a.HtlcPoint,
-		a.FirstCommitmentPoint,
-		tlvRecords,
-	)
+	if err := WriteBytes(w, a.PendingChannelID[:]); err != nil {
+		return err
+	}
+
+	if err := WriteSatoshi(w, a.DustLimit); err != nil {
+		return err
+	}
+
+	if err := WriteMilliSatoshi(w, a.MaxValueInFlight); err != nil {
+		return err
+	}
+
+	if err := WriteSatoshi(w, a.ChannelReserve); err != nil {
+		return err
+	}
+
+	if err := WriteMilliSatoshi(w, a.HtlcMinimum); err != nil {
+		return err
+	}
+
+	if err := WriteUint32(w, a.MinAcceptDepth); err != nil {
+		return err
+	}
+
+	if err := WriteUint16(w, a.CsvDelay); err != nil {
+		return err
+	}
+
+	if err := WriteUint16(w, a.MaxAcceptedHTLCs); err != nil {
+		return err
+	}
+
+	if err := WritePublicKey(w, a.FundingKey); err != nil {
+		return err
+	}
+
+	if err := WritePublicKey(w, a.RevocationPoint); err != nil {
+		return err
+	}
+
+	if err := WritePublicKey(w, a.PaymentPoint); err != nil {
+		return err
+	}
+
+	if err := WritePublicKey(w, a.DelayedPaymentPoint); err != nil {
+		return err
+	}
+
+	if err := WritePublicKey(w, a.HtlcPoint); err != nil {
+		return err
+	}
+
+	if err := WritePublicKey(w, a.FirstCommitmentPoint); err != nil {
+		return err
+	}
+
+	return WriteBytes(w, tlvRecords)
 }
 
 // Decode deserializes the serialized AcceptChannel stored in the passed

--- a/lnwire/announcement_signatures.go
+++ b/lnwire/announcement_signatures.go
@@ -1,6 +1,7 @@
 package lnwire
 
 import (
+	"bytes"
 	"io"
 )
 
@@ -64,7 +65,7 @@ func (a *AnnounceSignatures) Decode(r io.Reader, pver uint32) error {
 // observing the protocol version specified.
 //
 // This is part of the lnwire.Message interface.
-func (a *AnnounceSignatures) Encode(w io.Writer, pver uint32) error {
+func (a *AnnounceSignatures) Encode(w *bytes.Buffer, pver uint32) error {
 	return WriteElements(w,
 		a.ChannelID,
 		a.ShortChannelID,

--- a/lnwire/announcement_signatures.go
+++ b/lnwire/announcement_signatures.go
@@ -66,13 +66,23 @@ func (a *AnnounceSignatures) Decode(r io.Reader, pver uint32) error {
 //
 // This is part of the lnwire.Message interface.
 func (a *AnnounceSignatures) Encode(w *bytes.Buffer, pver uint32) error {
-	return WriteElements(w,
-		a.ChannelID,
-		a.ShortChannelID,
-		a.NodeSignature,
-		a.BitcoinSignature,
-		a.ExtraOpaqueData,
-	)
+	if err := WriteChannelID(w, a.ChannelID); err != nil {
+		return err
+	}
+
+	if err := WriteShortChannelID(w, a.ShortChannelID); err != nil {
+		return err
+	}
+
+	if err := WriteSig(w, a.NodeSignature); err != nil {
+		return err
+	}
+
+	if err := WriteSig(w, a.BitcoinSignature); err != nil {
+		return err
+	}
+
+	return WriteBytes(w, a.ExtraOpaqueData)
 }
 
 // MsgType returns the integer uniquely identifying this message type on the

--- a/lnwire/channel_announcement.go
+++ b/lnwire/channel_announcement.go
@@ -87,7 +87,7 @@ func (a *ChannelAnnouncement) Decode(r io.Reader, pver uint32) error {
 // observing the protocol version specified.
 //
 // This is part of the lnwire.Message interface.
-func (a *ChannelAnnouncement) Encode(w io.Writer, pver uint32) error {
+func (a *ChannelAnnouncement) Encode(w *bytes.Buffer, pver uint32) error {
 	return WriteElements(w,
 		a.NodeSig1,
 		a.NodeSig2,

--- a/lnwire/channel_reestablish.go
+++ b/lnwire/channel_reestablish.go
@@ -1,6 +1,7 @@
 package lnwire
 
 import (
+	"bytes"
 	"io"
 
 	"github.com/btcsuite/btcd/btcec"
@@ -75,7 +76,7 @@ var _ Message = (*ChannelReestablish)(nil)
 // observing the protocol version specified.
 //
 // This is part of the lnwire.Message interface.
-func (a *ChannelReestablish) Encode(w io.Writer, pver uint32) error {
+func (a *ChannelReestablish) Encode(w *bytes.Buffer, pver uint32) error {
 	err := WriteElements(w,
 		a.ChanID,
 		a.NextLocalCommitHeight,

--- a/lnwire/channel_reestablish.go
+++ b/lnwire/channel_reestablish.go
@@ -77,12 +77,15 @@ var _ Message = (*ChannelReestablish)(nil)
 //
 // This is part of the lnwire.Message interface.
 func (a *ChannelReestablish) Encode(w *bytes.Buffer, pver uint32) error {
-	err := WriteElements(w,
-		a.ChanID,
-		a.NextLocalCommitHeight,
-		a.RemoteCommitTailHeight,
-	)
-	if err != nil {
+	if err := WriteChannelID(w, a.ChanID); err != nil {
+		return err
+	}
+
+	if err := WriteUint64(w, a.NextLocalCommitHeight); err != nil {
+		return err
+	}
+
+	if err := WriteUint64(w, a.RemoteCommitTailHeight); err != nil {
 		return err
 	}
 
@@ -94,15 +97,18 @@ func (a *ChannelReestablish) Encode(w *bytes.Buffer, pver uint32) error {
 		//
 		// NOTE: This is here primarily for the quickcheck tests, in
 		// practice, we'll always populate this field.
-		return WriteElements(w, a.ExtraData)
+		return WriteBytes(w, a.ExtraData)
 	}
 
 	// Otherwise, we'll write out the remaining elements.
-	return WriteElements(w,
-		a.LastRemoteCommitSecret[:],
-		a.LocalUnrevokedCommitPoint,
-		a.ExtraData,
-	)
+	if err := WriteBytes(w, a.LastRemoteCommitSecret[:]); err != nil {
+		return err
+	}
+
+	if err := WritePublicKey(w, a.LocalUnrevokedCommitPoint); err != nil {
+		return err
+	}
+	return WriteBytes(w, a.ExtraData)
 }
 
 // Decode deserializes a serialized ChannelReestablish stored in the passed

--- a/lnwire/channel_update.go
+++ b/lnwire/channel_update.go
@@ -160,32 +160,57 @@ func (a *ChannelUpdate) Decode(r io.Reader, pver uint32) error {
 //
 // This is part of the lnwire.Message interface.
 func (a *ChannelUpdate) Encode(w *bytes.Buffer, pver uint32) error {
-	err := WriteElements(w,
-		a.Signature,
-		a.ChainHash[:],
-		a.ShortChannelID,
-		a.Timestamp,
-		a.MessageFlags,
-		a.ChannelFlags,
-		a.TimeLockDelta,
-		a.HtlcMinimumMsat,
-		a.BaseFee,
-		a.FeeRate,
-	)
-	if err != nil {
+	if err := WriteSig(w, a.Signature); err != nil {
+		return err
+	}
+
+	if err := WriteBytes(w, a.ChainHash[:]); err != nil {
+		return err
+	}
+
+	if err := WriteShortChannelID(w, a.ShortChannelID); err != nil {
+		return err
+	}
+
+	if err := WriteUint32(w, a.Timestamp); err != nil {
+		return err
+	}
+
+	if err := WriteChanUpdateMsgFlags(w, a.MessageFlags); err != nil {
+		return err
+	}
+
+	if err := WriteChanUpdateChanFlags(w, a.ChannelFlags); err != nil {
+		return err
+	}
+
+	if err := WriteUint16(w, a.TimeLockDelta); err != nil {
+		return err
+	}
+
+	if err := WriteMilliSatoshi(w, a.HtlcMinimumMsat); err != nil {
+		return err
+	}
+
+	if err := WriteUint32(w, a.BaseFee); err != nil {
+		return err
+	}
+
+	if err := WriteUint32(w, a.FeeRate); err != nil {
 		return err
 	}
 
 	// Now append optional fields if they are set. Currently, the only
 	// optional field is max HTLC.
 	if a.MessageFlags.HasMaxHtlc() {
-		if err := WriteElements(w, a.HtlcMaximumMsat); err != nil {
+		err := WriteMilliSatoshi(w, a.HtlcMaximumMsat)
+		if err != nil {
 			return err
 		}
 	}
 
 	// Finally, append any extra opaque data.
-	return a.ExtraOpaqueData.Encode(w)
+	return WriteBytes(w, a.ExtraOpaqueData)
 }
 
 // MsgType returns the integer uniquely identifying this message type on the
@@ -199,36 +224,58 @@ func (a *ChannelUpdate) MsgType() MessageType {
 // DataToSign is used to retrieve part of the announcement message which should
 // be signed.
 func (a *ChannelUpdate) DataToSign() ([]byte, error) {
-
 	// We should not include the signatures itself.
-	var w bytes.Buffer
-	err := WriteElements(&w,
-		a.ChainHash[:],
-		a.ShortChannelID,
-		a.Timestamp,
-		a.MessageFlags,
-		a.ChannelFlags,
-		a.TimeLockDelta,
-		a.HtlcMinimumMsat,
-		a.BaseFee,
-		a.FeeRate,
-	)
-	if err != nil {
+	b := make([]byte, 0, MaxMsgBody)
+	buf := bytes.NewBuffer(b)
+	if err := WriteBytes(buf, a.ChainHash[:]); err != nil {
+		return nil, err
+	}
+
+	if err := WriteShortChannelID(buf, a.ShortChannelID); err != nil {
+		return nil, err
+	}
+
+	if err := WriteUint32(buf, a.Timestamp); err != nil {
+		return nil, err
+	}
+
+	if err := WriteChanUpdateMsgFlags(buf, a.MessageFlags); err != nil {
+		return nil, err
+	}
+
+	if err := WriteChanUpdateChanFlags(buf, a.ChannelFlags); err != nil {
+		return nil, err
+	}
+
+	if err := WriteUint16(buf, a.TimeLockDelta); err != nil {
+		return nil, err
+	}
+
+	if err := WriteMilliSatoshi(buf, a.HtlcMinimumMsat); err != nil {
+		return nil, err
+	}
+
+	if err := WriteUint32(buf, a.BaseFee); err != nil {
+		return nil, err
+	}
+
+	if err := WriteUint32(buf, a.FeeRate); err != nil {
 		return nil, err
 	}
 
 	// Now append optional fields if they are set. Currently, the only
 	// optional field is max HTLC.
 	if a.MessageFlags.HasMaxHtlc() {
-		if err := WriteElements(&w, a.HtlcMaximumMsat); err != nil {
+		err := WriteMilliSatoshi(buf, a.HtlcMaximumMsat)
+		if err != nil {
 			return nil, err
 		}
 	}
 
 	// Finally, append any extra opaque data.
-	if err := a.ExtraOpaqueData.Encode(&w); err != nil {
+	if err := WriteBytes(buf, a.ExtraOpaqueData); err != nil {
 		return nil, err
 	}
 
-	return w.Bytes(), nil
+	return buf.Bytes(), nil
 }

--- a/lnwire/channel_update.go
+++ b/lnwire/channel_update.go
@@ -159,7 +159,7 @@ func (a *ChannelUpdate) Decode(r io.Reader, pver uint32) error {
 // observing the protocol version specified.
 //
 // This is part of the lnwire.Message interface.
-func (a *ChannelUpdate) Encode(w io.Writer, pver uint32) error {
+func (a *ChannelUpdate) Encode(w *bytes.Buffer, pver uint32) error {
 	err := WriteElements(w,
 		a.Signature,
 		a.ChainHash[:],

--- a/lnwire/closing_signed.go
+++ b/lnwire/closing_signed.go
@@ -1,6 +1,7 @@
 package lnwire
 
 import (
+	"bytes"
 	"io"
 
 	"github.com/btcsuite/btcutil"
@@ -63,7 +64,7 @@ func (c *ClosingSigned) Decode(r io.Reader, pver uint32) error {
 // observing the protocol version specified.
 //
 // This is part of the lnwire.Message interface.
-func (c *ClosingSigned) Encode(w io.Writer, pver uint32) error {
+func (c *ClosingSigned) Encode(w *bytes.Buffer, pver uint32) error {
 	return WriteElements(
 		w, c.ChannelID, c.FeeSatoshis, c.Signature, c.ExtraData,
 	)

--- a/lnwire/closing_signed.go
+++ b/lnwire/closing_signed.go
@@ -65,9 +65,19 @@ func (c *ClosingSigned) Decode(r io.Reader, pver uint32) error {
 //
 // This is part of the lnwire.Message interface.
 func (c *ClosingSigned) Encode(w *bytes.Buffer, pver uint32) error {
-	return WriteElements(
-		w, c.ChannelID, c.FeeSatoshis, c.Signature, c.ExtraData,
-	)
+	if err := WriteChannelID(w, c.ChannelID); err != nil {
+		return err
+	}
+
+	if err := WriteSatoshi(w, c.FeeSatoshis); err != nil {
+		return err
+	}
+
+	if err := WriteSig(w, c.Signature); err != nil {
+		return err
+	}
+
+	return WriteBytes(w, c.ExtraData)
 }
 
 // MsgType returns the integer uniquely identifying this message type on the

--- a/lnwire/commit_sig.go
+++ b/lnwire/commit_sig.go
@@ -71,12 +71,19 @@ func (c *CommitSig) Decode(r io.Reader, pver uint32) error {
 //
 // This is part of the lnwire.Message interface.
 func (c *CommitSig) Encode(w *bytes.Buffer, pver uint32) error {
-	return WriteElements(w,
-		c.ChanID,
-		c.CommitSig,
-		c.HtlcSigs,
-		c.ExtraData,
-	)
+	if err := WriteChannelID(w, c.ChanID); err != nil {
+		return err
+	}
+
+	if err := WriteSig(w, c.CommitSig); err != nil {
+		return err
+	}
+
+	if err := WriteSigs(w, c.HtlcSigs); err != nil {
+		return err
+	}
+
+	return WriteBytes(w, c.ExtraData)
 }
 
 // MsgType returns the integer uniquely identifying this message type on the

--- a/lnwire/commit_sig.go
+++ b/lnwire/commit_sig.go
@@ -1,6 +1,7 @@
 package lnwire
 
 import (
+	"bytes"
 	"io"
 )
 
@@ -69,7 +70,7 @@ func (c *CommitSig) Decode(r io.Reader, pver uint32) error {
 // observing the protocol version specified.
 //
 // This is part of the lnwire.Message interface.
-func (c *CommitSig) Encode(w io.Writer, pver uint32) error {
+func (c *CommitSig) Encode(w *bytes.Buffer, pver uint32) error {
 	return WriteElements(w,
 		c.ChanID,
 		c.CommitSig,

--- a/lnwire/error.go
+++ b/lnwire/error.go
@@ -105,10 +105,11 @@ func (c *Error) Decode(r io.Reader, pver uint32) error {
 //
 // This is part of the lnwire.Message interface.
 func (c *Error) Encode(w *bytes.Buffer, pver uint32) error {
-	return WriteElements(w,
-		c.ChanID,
-		c.Data,
-	)
+	if err := WriteBytes(w, c.ChanID[:]); err != nil {
+		return err
+	}
+
+	return WriteErrorData(w, c.Data)
 }
 
 // MsgType returns the integer uniquely identifying an Error message on the

--- a/lnwire/error.go
+++ b/lnwire/error.go
@@ -1,6 +1,7 @@
 package lnwire
 
 import (
+	"bytes"
 	"fmt"
 	"io"
 )
@@ -103,7 +104,7 @@ func (c *Error) Decode(r io.Reader, pver uint32) error {
 // protocol version specified.
 //
 // This is part of the lnwire.Message interface.
-func (c *Error) Encode(w io.Writer, pver uint32) error {
+func (c *Error) Encode(w *bytes.Buffer, pver uint32) error {
 	return WriteElements(w,
 		c.ChanID,
 		c.Data,

--- a/lnwire/extra_bytes.go
+++ b/lnwire/extra_bytes.go
@@ -18,7 +18,7 @@ type ExtraOpaqueData []byte
 // Encode attempts to encode the raw extra bytes into the passed io.Writer.
 func (e *ExtraOpaqueData) Encode(w *bytes.Buffer) error {
 	eBytes := []byte((*e)[:])
-	if err := WriteElements(w, eBytes); err != nil {
+	if err := WriteBytes(w, eBytes); err != nil {
 		return err
 	}
 

--- a/lnwire/extra_bytes.go
+++ b/lnwire/extra_bytes.go
@@ -16,7 +16,7 @@ import (
 type ExtraOpaqueData []byte
 
 // Encode attempts to encode the raw extra bytes into the passed io.Writer.
-func (e *ExtraOpaqueData) Encode(w io.Writer) error {
+func (e *ExtraOpaqueData) Encode(w *bytes.Buffer) error {
 	eBytes := []byte((*e)[:])
 	if err := WriteElements(w, eBytes); err != nil {
 		return err

--- a/lnwire/features.go
+++ b/lnwire/features.go
@@ -91,7 +91,7 @@ const (
 	// attacks on the receiver of a payment.
 	PaymentAddrOptional FeatureBit = 15
 
-	// MPPOptional is a required feature bit that signals that the receiver
+	// MPPRequired is a required feature bit that signals that the receiver
 	// of a payment requires settlement of an invoice with more than one
 	// HTLC.
 	MPPRequired FeatureBit = 16
@@ -124,7 +124,7 @@ const (
 	// transactions, which also imply anchor commitments.
 	AnchorsZeroFeeHtlcTxRequired FeatureBit = 22
 
-	// AnchorsZeroFeeHtlcTxRequired is an optional feature bit that signals
+	// AnchorsZeroFeeHtlcTxOptional is an optional feature bit that signals
 	// that the node supports channels having zero-fee second-level HTLC
 	// transactions, which also imply anchor commitments.
 	AnchorsZeroFeeHtlcTxOptional FeatureBit = 23

--- a/lnwire/funding_created.go
+++ b/lnwire/funding_created.go
@@ -42,10 +42,19 @@ var _ Message = (*FundingCreated)(nil)
 //
 // This is part of the lnwire.Message interface.
 func (f *FundingCreated) Encode(w *bytes.Buffer, pver uint32) error {
-	return WriteElements(
-		w, f.PendingChannelID[:], f.FundingPoint, f.CommitSig,
-		f.ExtraData,
-	)
+	if err := WriteBytes(w, f.PendingChannelID[:]); err != nil {
+		return err
+	}
+
+	if err := WriteOutPoint(w, f.FundingPoint); err != nil {
+		return err
+	}
+
+	if err := WriteSig(w, f.CommitSig); err != nil {
+		return err
+	}
+
+	return WriteBytes(w, f.ExtraData)
 }
 
 // Decode deserializes the serialized FundingCreated stored in the passed

--- a/lnwire/funding_created.go
+++ b/lnwire/funding_created.go
@@ -1,6 +1,7 @@
 package lnwire
 
 import (
+	"bytes"
 	"io"
 
 	"github.com/btcsuite/btcd/wire"
@@ -40,7 +41,7 @@ var _ Message = (*FundingCreated)(nil)
 // protocol version.
 //
 // This is part of the lnwire.Message interface.
-func (f *FundingCreated) Encode(w io.Writer, pver uint32) error {
+func (f *FundingCreated) Encode(w *bytes.Buffer, pver uint32) error {
 	return WriteElements(
 		w, f.PendingChannelID[:], f.FundingPoint, f.CommitSig,
 		f.ExtraData,

--- a/lnwire/funding_locked.go
+++ b/lnwire/funding_locked.go
@@ -60,11 +60,15 @@ func (c *FundingLocked) Decode(r io.Reader, pver uint32) error {
 //
 // This is part of the lnwire.Message interface.
 func (c *FundingLocked) Encode(w *bytes.Buffer, pver uint32) error {
-	return WriteElements(w,
-		c.ChanID,
-		c.NextPerCommitmentPoint,
-		c.ExtraData,
-	)
+	if err := WriteChannelID(w, c.ChanID); err != nil {
+		return err
+	}
+
+	if err := WritePublicKey(w, c.NextPerCommitmentPoint); err != nil {
+		return err
+	}
+
+	return WriteBytes(w, c.ExtraData)
 }
 
 // MsgType returns the uint32 code which uniquely identifies this message as a

--- a/lnwire/funding_locked.go
+++ b/lnwire/funding_locked.go
@@ -1,6 +1,7 @@
 package lnwire
 
 import (
+	"bytes"
 	"io"
 
 	"github.com/btcsuite/btcd/btcec"
@@ -58,7 +59,7 @@ func (c *FundingLocked) Decode(r io.Reader, pver uint32) error {
 // protocol version.
 //
 // This is part of the lnwire.Message interface.
-func (c *FundingLocked) Encode(w io.Writer, pver uint32) error {
+func (c *FundingLocked) Encode(w *bytes.Buffer, pver uint32) error {
 	return WriteElements(w,
 		c.ChanID,
 		c.NextPerCommitmentPoint,

--- a/lnwire/funding_signed.go
+++ b/lnwire/funding_signed.go
@@ -1,6 +1,9 @@
 package lnwire
 
-import "io"
+import (
+	"bytes"
+	"io"
+)
 
 // FundingSigned is sent from Bob (the responder) to Alice (the initiator)
 // after receiving the funding outpoint and her signature for Bob's version of
@@ -29,7 +32,7 @@ var _ Message = (*FundingSigned)(nil)
 // protocol version.
 //
 // This is part of the lnwire.Message interface.
-func (f *FundingSigned) Encode(w io.Writer, pver uint32) error {
+func (f *FundingSigned) Encode(w *bytes.Buffer, pver uint32) error {
 	return WriteElements(w, f.ChanID, f.CommitSig, f.ExtraData)
 }
 

--- a/lnwire/funding_signed.go
+++ b/lnwire/funding_signed.go
@@ -33,7 +33,15 @@ var _ Message = (*FundingSigned)(nil)
 //
 // This is part of the lnwire.Message interface.
 func (f *FundingSigned) Encode(w *bytes.Buffer, pver uint32) error {
-	return WriteElements(w, f.ChanID, f.CommitSig, f.ExtraData)
+	if err := WriteChannelID(w, f.ChanID); err != nil {
+		return err
+	}
+
+	if err := WriteSig(w, f.CommitSig); err != nil {
+		return err
+	}
+
+	return WriteBytes(w, f.ExtraData)
 }
 
 // Decode deserializes the serialized FundingSigned stored in the passed

--- a/lnwire/gossip_timestamp_range.go
+++ b/lnwire/gossip_timestamp_range.go
@@ -1,6 +1,7 @@
 package lnwire
 
 import (
+	"bytes"
 	"io"
 
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
@@ -57,7 +58,7 @@ func (g *GossipTimestampRange) Decode(r io.Reader, pver uint32) error {
 // observing the protocol version specified.
 //
 // This is part of the lnwire.Message interface.
-func (g *GossipTimestampRange) Encode(w io.Writer, pver uint32) error {
+func (g *GossipTimestampRange) Encode(w *bytes.Buffer, pver uint32) error {
 	return WriteElements(w,
 		g.ChainHash[:],
 		g.FirstTimestamp,

--- a/lnwire/gossip_timestamp_range.go
+++ b/lnwire/gossip_timestamp_range.go
@@ -59,12 +59,19 @@ func (g *GossipTimestampRange) Decode(r io.Reader, pver uint32) error {
 //
 // This is part of the lnwire.Message interface.
 func (g *GossipTimestampRange) Encode(w *bytes.Buffer, pver uint32) error {
-	return WriteElements(w,
-		g.ChainHash[:],
-		g.FirstTimestamp,
-		g.TimestampRange,
-		g.ExtraData,
-	)
+	if err := WriteBytes(w, g.ChainHash[:]); err != nil {
+		return err
+	}
+
+	if err := WriteUint32(w, g.FirstTimestamp); err != nil {
+		return err
+	}
+
+	if err := WriteUint32(w, g.TimestampRange); err != nil {
+		return err
+	}
+
+	return WriteBytes(w, g.ExtraData)
 }
 
 // MsgType returns the integer uniquely identifying this message type on the

--- a/lnwire/init_message.go
+++ b/lnwire/init_message.go
@@ -60,11 +60,15 @@ func (msg *Init) Decode(r io.Reader, pver uint32) error {
 //
 // This is part of the lnwire.Message interface.
 func (msg *Init) Encode(w *bytes.Buffer, pver uint32) error {
-	return WriteElements(w,
-		msg.GlobalFeatures,
-		msg.Features,
-		msg.ExtraData,
-	)
+	if err := WriteRawFeatureVector(w, msg.GlobalFeatures); err != nil {
+		return err
+	}
+
+	if err := WriteRawFeatureVector(w, msg.Features); err != nil {
+		return err
+	}
+
+	return WriteBytes(w, msg.ExtraData)
 }
 
 // MsgType returns the integer uniquely identifying this message type on the

--- a/lnwire/init_message.go
+++ b/lnwire/init_message.go
@@ -1,6 +1,9 @@
 package lnwire
 
-import "io"
+import (
+	"bytes"
+	"io"
+)
 
 // Init is the first message reveals the features supported or required by this
 // node. Nodes wait for receipt of the other's features to simplify error
@@ -56,7 +59,7 @@ func (msg *Init) Decode(r io.Reader, pver uint32) error {
 // the protocol version specified.
 //
 // This is part of the lnwire.Message interface.
-func (msg *Init) Encode(w io.Writer, pver uint32) error {
+func (msg *Init) Encode(w *bytes.Buffer, pver uint32) error {
 	return WriteElements(w,
 		msg.GlobalFeatures,
 		msg.Features,

--- a/lnwire/lnwire.go
+++ b/lnwire/lnwire.go
@@ -76,6 +76,9 @@ func (a addressType) AddrLen() uint16 {
 
 // WriteElement is a one-stop shop to write the big endian representation of
 // any element which is to be serialized for the wire protocol.
+//
+// TODO(yy): rm this method once we finish dereferencing it from other
+// packages.
 func WriteElement(w *bytes.Buffer, element interface{}) error {
 	switch e := element.(type) {
 	case NodeAlias:
@@ -433,6 +436,9 @@ func WriteElement(w *bytes.Buffer, element interface{}) error {
 
 // WriteElements is writes each element in the elements slice to the passed
 // buffer using WriteElement.
+//
+// TODO(yy): rm this method once we finish dereferencing it from other
+// packages.
 func WriteElements(buf *bytes.Buffer, elements ...interface{}) error {
 	for _, element := range elements {
 		err := WriteElement(buf, element)
@@ -823,8 +829,11 @@ func ReadElement(r io.Reader, element interface{}) error {
 		length := binary.BigEndian.Uint16(addrLen[:])
 
 		var addrBytes [deliveryAddressMaxSize]byte
+
 		if length > deliveryAddressMaxSize {
-			return fmt.Errorf("cannot read %d bytes into addrBytes", length)
+			return fmt.Errorf(
+				"cannot read %d bytes into addrBytes", length,
+			)
 		}
 		if _, err = io.ReadFull(r, addrBytes[:length]); err != nil {
 			return err

--- a/lnwire/lnwire.go
+++ b/lnwire/lnwire.go
@@ -75,13 +75,8 @@ func (a addressType) AddrLen() uint16 {
 }
 
 // WriteElement is a one-stop shop to write the big endian representation of
-// any element which is to be serialized for the wire protocol. The passed
-// io.Writer should be backed by an appropriately sized byte slice, or be able
-// to dynamically expand to accommodate additional data.
-//
-// TODO(roasbeef): this should eventually draw from a buffer pool for
-// serialization.
-func WriteElement(w io.Writer, element interface{}) error {
+// any element which is to be serialized for the wire protocol.
+func WriteElement(w *bytes.Buffer, element interface{}) error {
 	switch e := element.(type) {
 	case NodeAlias:
 		if _, err := w.Write(e[:]); err != nil {
@@ -437,10 +432,10 @@ func WriteElement(w io.Writer, element interface{}) error {
 }
 
 // WriteElements is writes each element in the elements slice to the passed
-// io.Writer using WriteElement.
-func WriteElements(w io.Writer, elements ...interface{}) error {
+// buffer using WriteElement.
+func WriteElements(buf *bytes.Buffer, elements ...interface{}) error {
 	for _, element := range elements {
-		err := WriteElement(w, element)
+		err := WriteElement(buf, element)
 		if err != nil {
 			return err
 		}

--- a/lnwire/lnwire_test.go
+++ b/lnwire/lnwire_test.go
@@ -232,7 +232,7 @@ func TestMaxOutPointIndex(t *testing.T) {
 	}
 
 	var b bytes.Buffer
-	if err := WriteElement(&b, op); err == nil {
+	if err := WriteOutPoint(&b, op); err == nil {
 		t.Fatalf("write of outPoint should fail, index exceeds 16-bits")
 	}
 }

--- a/lnwire/message.go
+++ b/lnwire/message.go
@@ -12,10 +12,6 @@ import (
 	"io"
 )
 
-// MaxMessagePayload is the maximum bytes a message can be regardless of other
-// individual limits imposed by messages themselves.
-const MaxMessagePayload = 65535 // 65KB
-
 // MessageType is the unique 2 byte big-endian integer that indicates the type
 // of message on the wire. All messages have a very simple header which
 // consists simply of 2-byte message type. We omit a length field, and checksum

--- a/lnwire/message.go
+++ b/lnwire/message.go
@@ -52,6 +52,27 @@ const (
 	MsgGossipTimestampRange                = 265
 )
 
+// ErrorEncodeMessage is used when failed to encode the message payload.
+func ErrorEncodeMessage(err error) error {
+	return fmt.Errorf("failed to encode message to buffer, got %w", err)
+}
+
+// ErrorWriteMessageType is used when failed to write the message type.
+func ErrorWriteMessageType(err error) error {
+	return fmt.Errorf("failed to write message type, got %w", err)
+}
+
+// ErrorPayloadTooLarge is used when the payload size exceeds the
+// MaxMsgBody.
+func ErrorPayloadTooLarge(size int) error {
+	return fmt.Errorf(
+		"message payload is too large - encoded %d bytes, "+
+			"but maximum message payload is %d bytes",
+		size, MaxMsgBody,
+	)
+
+}
+
 // String return the string representation of message type.
 func (t MessageType) String() string {
 	switch t {
@@ -218,44 +239,49 @@ func makeEmptyMessage(msgType MessageType) (Message, error) {
 	return msg, nil
 }
 
-// WriteMessage writes a lightning Message to w including the necessary header
-// information and returns the number of bytes written.
-func WriteMessage(w io.Writer, msg Message, pver uint32) (int, error) {
-	totalBytes := 0
+// WriteMessage writes a lightning Message to a buffer including the necessary
+// header information and returns the number of bytes written. If any error is
+// encountered, the buffer passed will be reset to its original state since we
+// don't want any broken bytes left. In other words, no bytes will be written
+// if there's an error. Either all or none of the message bytes will be written
+// to the buffer.
+//
+// NOTE: this method is not concurrent safe.
+func WriteMessage(buf *bytes.Buffer, msg Message, pver uint32) (int, error) {
+	// Record the size of the bytes already written in buffer.
+	oldByteSize := buf.Len()
 
-	// Encode the message payload itself into a temporary buffer.
-	// TODO(roasbeef): create buffer pool
-	var bw bytes.Buffer
-	if err := msg.Encode(&bw, pver); err != nil {
-		return totalBytes, err
-	}
-	payload := bw.Bytes()
-	lenp := len(payload)
-
-	// Enforce maximum message payload, which means the body cannot be
-	// greater than MaxMsgBody.
-	if lenp > MaxMsgBody {
-		return totalBytes, fmt.Errorf("message payload is too large - "+
-			"encoded %d bytes, but maximum message body is %d bytes",
-			lenp, MaxMsgBody)
+	// cleanBrokenBytes is a helper closure that helps reset the buffer to
+	// its original state. It truncates all the bytes written in current
+	// scope.
+	var cleanBrokenBytes = func(b *bytes.Buffer) int {
+		b.Truncate(oldByteSize)
+		return 0
 	}
 
-	// With the initial sanity checks complete, we'll now write out the
-	// message type itself.
+	// Write the message type.
 	var mType [2]byte
 	binary.BigEndian.PutUint16(mType[:], uint16(msg.MsgType()))
-	n, err := w.Write(mType[:])
-	totalBytes += n
+	msgTypeBytes, err := buf.Write(mType[:])
 	if err != nil {
-		return totalBytes, err
+		return cleanBrokenBytes(buf), ErrorWriteMessageType(err)
 	}
 
-	// With the message type written, we'll now write out the raw payload
-	// itself.
-	n, err = w.Write(payload)
-	totalBytes += n
+	// Use the write buffer to encode our message.
+	if err := msg.Encode(buf, pver); err != nil {
+		return cleanBrokenBytes(buf), ErrorEncodeMessage(err)
+	}
 
-	return totalBytes, err
+	// Enforce maximum overall message payload. The write buffer now has
+	// the size of len(originalBytes) + len(payload) + len(type). We want
+	// to enforce the payload here, so we subtract it by the length of the
+	// type and old bytes.
+	lenp := buf.Len() - oldByteSize - msgTypeBytes
+	if lenp > MaxMsgBody {
+		return cleanBrokenBytes(buf), ErrorPayloadTooLarge(lenp)
+	}
+
+	return buf.Len() - oldByteSize, nil
 }
 
 // ReadMessage reads, validates, and parses the next Lightning message from r

--- a/lnwire/message.go
+++ b/lnwire/message.go
@@ -158,8 +158,8 @@ type Serializable interface {
 	Decode(io.Reader, uint32) error
 
 	// Encode converts object to the bytes stream and write it into the
-	// writer.
-	Encode(io.Writer, uint32) error
+	// write buffer.
+	Encode(*bytes.Buffer, uint32) error
 }
 
 // Message is an interface that defines a lightning wire protocol message. The

--- a/lnwire/message_test.go
+++ b/lnwire/message_test.go
@@ -1,0 +1,867 @@
+package lnwire_test
+
+import (
+	"bytes"
+	"encoding/binary"
+	"image/color"
+	"io"
+	"math"
+	"math/big"
+	"math/rand"
+	"net"
+	"sync"
+	"testing"
+
+	"github.com/btcsuite/btcd/btcec"
+	"github.com/btcsuite/btcutil"
+	"github.com/lightningnetwork/lnd/lnwire"
+	"github.com/lightningnetwork/lnd/tor"
+	"github.com/stretchr/testify/require"
+)
+
+const deliveryAddressMaxSize = 34
+const letterBytes = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
+
+var (
+	testSig = &btcec.Signature{
+		R: new(big.Int),
+		S: new(big.Int),
+	}
+	testNodeSig, _ = lnwire.NewSigFromSignature(testSig)
+
+	testNumExtraBytes = 1000
+	testNumSigs       = 100
+	testNumChanIDs    = 1000
+	buffer            = make([]byte, 0, lnwire.MaxSliceLength)
+
+	bufPool = sync.Pool{
+		New: func() interface{} {
+			return bytes.NewBuffer(buffer)
+		},
+	}
+)
+
+// BenchmarkWriteMessage benchmarks the performance of lnwire.WriteMessage. It
+// generates a test message for each of the lnwire.Message, calls the
+// WriteMessage method and benchmark it.
+func BenchmarkWriteMessage(b *testing.B) {
+	// Create testing messages. We will use a constant seed to make sure
+	// the benchmark uses the same data every time.
+	r := rand.New(rand.NewSource(42))
+
+	msgAll := makeAllMessages(b, r)
+
+	// Iterate all messages and write each once.
+	for _, msg := range msgAll {
+		m := msg
+		// Run each message as a sub benchmark test.
+		b.Run(msg.MsgType().String(), func(b *testing.B) {
+
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				// Fetch a buffer from the pool and reset it.
+				buf := bufPool.Get().(*bytes.Buffer)
+				buf.Reset()
+
+				_, err := lnwire.WriteMessage(buf, m, 0)
+				require.NoError(b, err, "unable to write msg")
+
+				// Put the buffer back when done.
+				bufPool.Put(buf)
+			}
+		})
+	}
+}
+
+// BenchmarkReadMessage benchmarks the performance of lnwire.ReadMessage. It
+// first creates a test message for each of the lnwire.Message, writes it to
+// the buffer, then later reads it from the buffer.
+func BenchmarkReadMessage(b *testing.B) {
+	// Create testing messages. We will use a constant seed to make sure
+	// the benchmark uses the same data every time.
+	r := rand.New(rand.NewSource(42))
+	msgAll := makeAllMessages(b, r)
+
+	// Write all the messages to the buffer.
+	for _, msg := range msgAll {
+		// Fetch a buffer from the pool and reset it.
+		buf := bufPool.Get().(*bytes.Buffer)
+		buf.Reset()
+
+		_, err := lnwire.WriteMessage(buf, msg, 0)
+		require.NoError(b, err, "unable to write msg")
+
+		// Run each message as a sub benchmark test.
+		m := msg
+		b.Run(m.MsgType().String(), func(b *testing.B) {
+			b.ResetTimer()
+
+			for i := 0; i < b.N; i++ {
+				r := bytes.NewBuffer(buf.Bytes())
+
+				// Read the message from the buffer.
+				_, err := lnwire.ReadMessage(r, 0)
+				require.NoError(b, err, "unable to read msg")
+			}
+		})
+
+		// Put the buffer back when done.
+		bufPool.Put(buf)
+	}
+}
+
+// makeAllMessages is used to create testing messages for each lnwire message
+// type.
+//
+// TODO(yy): the following testing messages are created somewhat arbitrary. We
+// should standardlize each of the testing messages so that a better baseline
+// can be used.
+func makeAllMessages(t testing.TB, r *rand.Rand) []lnwire.Message {
+	msgAll := []lnwire.Message{}
+
+	msgAll = append(msgAll, newMsgInit(t, r))
+	msgAll = append(msgAll, newMsgError(t, r))
+	msgAll = append(msgAll, newMsgPing(t, r))
+	msgAll = append(msgAll, newMsgPong(t, r))
+	msgAll = append(msgAll, newMsgOpenChannel(t, r))
+	msgAll = append(msgAll, newMsgAcceptChannel(t, r))
+	msgAll = append(msgAll, newMsgFundingCreated(t, r))
+	msgAll = append(msgAll, newMsgFundingSigned(t, r))
+	msgAll = append(msgAll, newMsgFundingLocked(t, r))
+	msgAll = append(msgAll, newMsgShutdown(t, r))
+	msgAll = append(msgAll, newMsgClosingSigned(t, r))
+	msgAll = append(msgAll, newMsgUpdateAddHTLC(t, r))
+	msgAll = append(msgAll, newMsgUpdateFulfillHTLC(t, r))
+	msgAll = append(msgAll, newMsgUpdateFailHTLC(t, r))
+	msgAll = append(msgAll, newMsgCommitSig(t, r))
+	msgAll = append(msgAll, newMsgRevokeAndAck(t, r))
+	msgAll = append(msgAll, newMsgUpdateFee(t, r))
+	msgAll = append(msgAll, newMsgUpdateFailMalformedHTLC(t, r))
+	msgAll = append(msgAll, newMsgChannelReestablish(t, r))
+	msgAll = append(msgAll, newMsgChannelAnnouncement(t, r))
+	msgAll = append(msgAll, newMsgNodeAnnouncement(t, r))
+	msgAll = append(msgAll, newMsgChannelUpdate(t, r))
+	msgAll = append(msgAll, newMsgAnnounceSignatures(t, r))
+	msgAll = append(msgAll, newMsgQueryShortChanIDs(t, r))
+	msgAll = append(msgAll, newMsgReplyShortChanIDsEnd(t, r))
+	msgAll = append(msgAll, newMsgQueryChannelRange(t, r))
+	msgAll = append(msgAll, newMsgReplyChannelRange(t, r))
+	msgAll = append(msgAll, newMsgGossipTimestampRange(t, r))
+	msgAll = append(msgAll, newMsgQueryShortChanIDsZlib(t, r))
+	msgAll = append(msgAll, newMsgReplyChannelRangeZlib(t, r))
+
+	return msgAll
+}
+
+func newMsgInit(t testing.TB, r io.Reader) *lnwire.Init {
+	t.Helper()
+
+	return &lnwire.Init{
+		GlobalFeatures: rawFeatureVector(),
+		Features:       rawFeatureVector(),
+		ExtraData:      createExtraData(t, r),
+	}
+}
+
+// newMsgOpenChannel creates a testing OpenChannel message.
+func newMsgOpenChannel(t testing.TB, r *rand.Rand) *lnwire.OpenChannel {
+	t.Helper()
+
+	msg := &lnwire.OpenChannel{
+		FundingAmount:        btcutil.Amount(r.Int63()),
+		PushAmount:           lnwire.MilliSatoshi(r.Int63()),
+		DustLimit:            btcutil.Amount(r.Int63()),
+		MaxValueInFlight:     lnwire.MilliSatoshi(r.Int63()),
+		ChannelReserve:       btcutil.Amount(r.Int63()),
+		HtlcMinimum:          lnwire.MilliSatoshi(r.Int63()),
+		FeePerKiloWeight:     uint32(r.Int31()),
+		CsvDelay:             uint16(r.Intn(1 << 16)),
+		MaxAcceptedHTLCs:     uint16(r.Intn(1 << 16)),
+		ChannelFlags:         lnwire.FundingFlag(uint8(r.Intn(1 << 8))),
+		FundingKey:           randPubKey(t),
+		RevocationPoint:      randPubKey(t),
+		PaymentPoint:         randPubKey(t),
+		DelayedPaymentPoint:  randPubKey(t),
+		HtlcPoint:            randPubKey(t),
+		FirstCommitmentPoint: randPubKey(t),
+		ExtraData:            createExtraData(t, r),
+	}
+
+	_, err := r.Read(msg.ChainHash[:])
+	require.NoError(t, err, "unable to read bytes for ChainHash")
+
+	_, err = r.Read(msg.PendingChannelID[:])
+	require.NoError(t, err, "unable to read bytes for PendingChannelID")
+
+	return msg
+}
+
+func newMsgAcceptChannel(t testing.TB, r *rand.Rand) *lnwire.AcceptChannel {
+	t.Helper()
+
+	msg := &lnwire.AcceptChannel{
+		DustLimit:             btcutil.Amount(r.Int63()),
+		MaxValueInFlight:      lnwire.MilliSatoshi(r.Int63()),
+		ChannelReserve:        btcutil.Amount(r.Int63()),
+		MinAcceptDepth:        uint32(r.Int31()),
+		HtlcMinimum:           lnwire.MilliSatoshi(r.Int63()),
+		CsvDelay:              uint16(r.Intn(1 << 16)),
+		MaxAcceptedHTLCs:      uint16(r.Intn(1 << 16)),
+		FundingKey:            randPubKey(t),
+		RevocationPoint:       randPubKey(t),
+		PaymentPoint:          randPubKey(t),
+		DelayedPaymentPoint:   randPubKey(t),
+		HtlcPoint:             randPubKey(t),
+		FirstCommitmentPoint:  randPubKey(t),
+		UpfrontShutdownScript: randDeliveryAddress(t, r),
+		ExtraData:             createExtraData(t, r),
+	}
+	_, err := r.Read(msg.PendingChannelID[:])
+	require.NoError(t, err, "unable to generate pending chan id")
+
+	return msg
+}
+
+func newMsgError(t testing.TB, r io.Reader) *lnwire.Error {
+	t.Helper()
+
+	msg := lnwire.NewError()
+
+	_, err := r.Read(msg.ChanID[:])
+	require.NoError(t, err, "unable to generate chan id")
+
+	msg.Data = createExtraData(t, r)
+
+	return msg
+}
+
+func newMsgPing(t testing.TB, r *rand.Rand) *lnwire.Ping {
+	t.Helper()
+
+	return &lnwire.Ping{
+		NumPongBytes: uint16(r.Intn(1 << 16)),
+		PaddingBytes: createExtraData(t, r),
+	}
+}
+
+func newMsgPong(t testing.TB, r io.Reader) *lnwire.Pong {
+	t.Helper()
+
+	return &lnwire.Pong{
+		PongBytes: createExtraData(t, r),
+	}
+}
+
+func newMsgFundingCreated(t testing.TB, r *rand.Rand) *lnwire.FundingCreated {
+	t.Helper()
+
+	msg := &lnwire.FundingCreated{
+		CommitSig: testNodeSig,
+		ExtraData: createExtraData(t, r),
+	}
+
+	_, err := r.Read(msg.PendingChannelID[:])
+	require.NoError(t, err, "unable to generate pending chan id")
+
+	_, err = r.Read(msg.FundingPoint.Hash[:])
+	require.NoError(t, err, "unable to generate hash")
+
+	msg.FundingPoint.Index = uint32(r.Int31()) % math.MaxUint16
+
+	return msg
+}
+
+func newMsgFundingSigned(t testing.TB, r io.Reader) *lnwire.FundingSigned {
+	t.Helper()
+
+	var c [32]byte
+
+	_, err := r.Read(c[:])
+	require.NoError(t, err, "unable to generate chan id")
+
+	msg := &lnwire.FundingSigned{
+		ChanID:    lnwire.ChannelID(c),
+		CommitSig: testNodeSig,
+		ExtraData: createExtraData(t, r),
+	}
+
+	return msg
+}
+
+func newMsgFundingLocked(t testing.TB, r io.Reader) *lnwire.FundingLocked {
+	t.Helper()
+
+	var c [32]byte
+
+	_, err := r.Read(c[:])
+	require.NoError(t, err, "unable to generate chan id")
+
+	pubKey := randPubKey(t)
+
+	msg := lnwire.NewFundingLocked(lnwire.ChannelID(c), pubKey)
+	msg.ExtraData = createExtraData(t, r)
+
+	return msg
+}
+
+func newMsgShutdown(t testing.TB, r *rand.Rand) *lnwire.Shutdown {
+	t.Helper()
+
+	msg := &lnwire.Shutdown{
+		Address:   randDeliveryAddress(t, r),
+		ExtraData: createExtraData(t, r),
+	}
+
+	_, err := r.Read(msg.ChannelID[:])
+	require.NoError(t, err, "unable to generate channel id")
+
+	return msg
+}
+
+func newMsgClosingSigned(t testing.TB, r *rand.Rand) *lnwire.ClosingSigned {
+	t.Helper()
+
+	msg := &lnwire.ClosingSigned{
+		FeeSatoshis: btcutil.Amount(r.Int63()),
+		Signature:   testNodeSig,
+		ExtraData:   createExtraData(t, r),
+	}
+
+	_, err := r.Read(msg.ChannelID[:])
+	require.NoError(t, err, "unable to generate chan id")
+
+	return msg
+}
+
+func newMsgUpdateAddHTLC(t testing.TB, r *rand.Rand) *lnwire.UpdateAddHTLC {
+	t.Helper()
+
+	msg := &lnwire.UpdateAddHTLC{
+		ID:        r.Uint64(),
+		Amount:    lnwire.MilliSatoshi(r.Int63()),
+		Expiry:    r.Uint32(),
+		ExtraData: createExtraData(t, r),
+	}
+
+	_, err := r.Read(msg.ChanID[:])
+	require.NoError(t, err, "unable to generate chan id")
+
+	_, err = r.Read(msg.PaymentHash[:])
+	require.NoError(t, err, "unable to generate paymenthash")
+
+	_, err = r.Read(msg.OnionBlob[:])
+	require.NoError(t, err, "unable to generate onion blob")
+
+	return msg
+}
+
+func newMsgUpdateFulfillHTLC(t testing.TB,
+	r *rand.Rand) *lnwire.UpdateFulfillHTLC {
+
+	t.Helper()
+
+	msg := &lnwire.UpdateFulfillHTLC{
+		ID:        r.Uint64(),
+		ExtraData: createExtraData(t, r),
+	}
+
+	_, err := r.Read(msg.ChanID[:])
+	require.NoError(t, err, "unable to generate chan id")
+
+	_, err = r.Read(msg.PaymentPreimage[:])
+	require.NoError(t, err, "unable to generate payment preimage")
+
+	return msg
+}
+
+func newMsgUpdateFailHTLC(t testing.TB, r *rand.Rand) *lnwire.UpdateFailHTLC {
+	t.Helper()
+
+	msg := &lnwire.UpdateFailHTLC{
+		ID:        r.Uint64(),
+		ExtraData: createExtraData(t, r),
+	}
+
+	_, err := r.Read(msg.ChanID[:])
+	require.NoError(t, err, "unable to generate chan id")
+
+	return msg
+}
+
+func newMsgCommitSig(t testing.TB, r io.Reader) *lnwire.CommitSig {
+	t.Helper()
+
+	msg := lnwire.NewCommitSig()
+
+	_, err := r.Read(msg.ChanID[:])
+	require.NoError(t, err, "unable to generate chan id")
+
+	msg.CommitSig = testNodeSig
+	msg.ExtraData = createExtraData(t, r)
+
+	msg.HtlcSigs = make([]lnwire.Sig, testNumSigs)
+	for i := 0; i < testNumSigs; i++ {
+		msg.HtlcSigs[i] = testNodeSig
+	}
+
+	return msg
+}
+
+func newMsgRevokeAndAck(t testing.TB, r io.Reader) *lnwire.RevokeAndAck {
+	t.Helper()
+
+	msg := lnwire.NewRevokeAndAck()
+
+	_, err := r.Read(msg.ChanID[:])
+	require.NoError(t, err, "unable to generate chan id")
+
+	_, err = r.Read(msg.Revocation[:])
+	require.NoError(t, err, "unable to generate bytes")
+
+	msg.NextRevocationKey = randPubKey(t)
+	require.NoError(t, err, "unable to generate key")
+
+	msg.ExtraData = createExtraData(t, r)
+
+	return msg
+}
+
+func newMsgUpdateFee(t testing.TB, r *rand.Rand) *lnwire.UpdateFee {
+	t.Helper()
+
+	msg := &lnwire.UpdateFee{
+		FeePerKw:  uint32(r.Int31()),
+		ExtraData: createExtraData(t, r),
+	}
+
+	_, err := r.Read(msg.ChanID[:])
+	require.NoError(t, err, "unable to generate chan id")
+
+	return msg
+}
+
+func newMsgUpdateFailMalformedHTLC(t testing.TB,
+	r *rand.Rand) *lnwire.UpdateFailMalformedHTLC {
+
+	t.Helper()
+
+	msg := &lnwire.UpdateFailMalformedHTLC{
+		ID:          r.Uint64(),
+		FailureCode: lnwire.FailCode(r.Intn(1 << 16)),
+		ExtraData:   createExtraData(t, r),
+	}
+
+	_, err := r.Read(msg.ChanID[:])
+	require.NoError(t, err, "unable to generate chan id")
+
+	_, err = r.Read(msg.ShaOnionBlob[:])
+	require.NoError(t, err, "unable to generate sha256 onion blob")
+
+	return msg
+}
+
+func newMsgChannelReestablish(t testing.TB,
+	r *rand.Rand) *lnwire.ChannelReestablish {
+
+	t.Helper()
+
+	msg := &lnwire.ChannelReestablish{
+		NextLocalCommitHeight:     uint64(r.Int63()),
+		RemoteCommitTailHeight:    uint64(r.Int63()),
+		LocalUnrevokedCommitPoint: randPubKey(t),
+		ExtraData:                 createExtraData(t, r),
+	}
+
+	_, err := r.Read(msg.LastRemoteCommitSecret[:])
+	require.NoError(t, err, "unable to read commit secret")
+
+	return msg
+}
+
+func newMsgChannelAnnouncement(t testing.TB,
+	r *rand.Rand) *lnwire.ChannelAnnouncement {
+
+	t.Helper()
+
+	msg := &lnwire.ChannelAnnouncement{
+		ShortChannelID:  lnwire.NewShortChanIDFromInt(uint64(r.Int63())),
+		Features:        rawFeatureVector(),
+		NodeID1:         randRawKey(t),
+		NodeID2:         randRawKey(t),
+		BitcoinKey1:     randRawKey(t),
+		BitcoinKey2:     randRawKey(t),
+		ExtraOpaqueData: createExtraData(t, r),
+		NodeSig1:        testNodeSig,
+		NodeSig2:        testNodeSig,
+		BitcoinSig1:     testNodeSig,
+		BitcoinSig2:     testNodeSig,
+	}
+
+	_, err := r.Read(msg.ChainHash[:])
+	require.NoError(t, err, "unable to generate chain hash")
+
+	return msg
+}
+
+func newMsgNodeAnnouncement(t testing.TB,
+	r *rand.Rand) *lnwire.NodeAnnouncement {
+
+	t.Helper()
+
+	msg := &lnwire.NodeAnnouncement{
+		Features:  rawFeatureVector(),
+		Timestamp: uint32(r.Int31()),
+		Alias:     randAlias(r),
+		RGBColor: color.RGBA{
+			R: uint8(r.Intn(1 << 8)),
+			G: uint8(r.Intn(1 << 8)),
+			B: uint8(r.Intn(1 << 8)),
+		},
+		NodeID:          randRawKey(t),
+		Addresses:       randAddrs(t, r),
+		ExtraOpaqueData: createExtraData(t, r),
+		Signature:       testNodeSig,
+	}
+
+	return msg
+}
+
+func newMsgChannelUpdate(t testing.TB, r *rand.Rand) *lnwire.ChannelUpdate {
+	t.Helper()
+
+	msgFlags := lnwire.ChanUpdateMsgFlags(r.Int31())
+	maxHtlc := lnwire.MilliSatoshi(r.Int63())
+
+	// We make the max_htlc field zero if it is not flagged
+	// as being part of the ChannelUpdate, to pass
+	// serialization tests, as it will be ignored if the bit
+	// is not set.
+	if msgFlags&lnwire.ChanUpdateOptionMaxHtlc == 0 {
+		maxHtlc = 0
+	}
+
+	msg := &lnwire.ChannelUpdate{
+		ShortChannelID:  lnwire.NewShortChanIDFromInt(r.Uint64()),
+		Timestamp:       uint32(r.Int31()),
+		MessageFlags:    msgFlags,
+		ChannelFlags:    lnwire.ChanUpdateChanFlags(r.Int31()),
+		TimeLockDelta:   uint16(r.Int31()),
+		HtlcMinimumMsat: lnwire.MilliSatoshi(r.Int63()),
+		HtlcMaximumMsat: maxHtlc,
+		BaseFee:         uint32(r.Int31()),
+		FeeRate:         uint32(r.Int31()),
+		ExtraOpaqueData: createExtraData(t, r),
+		Signature:       testNodeSig,
+	}
+
+	_, err := r.Read(msg.ChainHash[:])
+	require.NoError(t, err, "unable to generate chain hash")
+
+	return msg
+}
+
+func newMsgAnnounceSignatures(t testing.TB,
+	r *rand.Rand) *lnwire.AnnounceSignatures {
+
+	t.Helper()
+
+	msg := &lnwire.AnnounceSignatures{
+		ShortChannelID: lnwire.NewShortChanIDFromInt(
+			uint64(r.Int63()),
+		),
+		ExtraOpaqueData:  createExtraData(t, r),
+		NodeSignature:    testNodeSig,
+		BitcoinSignature: testNodeSig,
+	}
+
+	_, err := r.Read(msg.ChannelID[:])
+	require.NoError(t, err, "unable to generate chan id")
+
+	return msg
+}
+
+func newMsgQueryShortChanIDs(t testing.TB,
+	r *rand.Rand) *lnwire.QueryShortChanIDs {
+
+	t.Helper()
+
+	msg := &lnwire.QueryShortChanIDs{
+		EncodingType: lnwire.EncodingSortedPlain,
+		ExtraData:    createExtraData(t, r),
+	}
+
+	_, err := rand.Read(msg.ChainHash[:])
+	require.NoError(t, err, "unable to read chain hash")
+
+	for i := 0; i < testNumChanIDs; i++ {
+		msg.ShortChanIDs = append(msg.ShortChanIDs,
+			lnwire.NewShortChanIDFromInt(uint64(r.Int63())))
+	}
+
+	return msg
+}
+
+func newMsgQueryShortChanIDsZlib(t testing.TB,
+	r *rand.Rand) *lnwire.QueryShortChanIDs {
+
+	t.Helper()
+
+	msg := &lnwire.QueryShortChanIDs{
+		EncodingType: lnwire.EncodingSortedZlib,
+		ExtraData:    createExtraData(t, r),
+	}
+
+	_, err := rand.Read(msg.ChainHash[:])
+	require.NoError(t, err, "unable to read chain hash")
+
+	for i := 0; i < testNumChanIDs; i++ {
+		msg.ShortChanIDs = append(msg.ShortChanIDs,
+			lnwire.NewShortChanIDFromInt(uint64(r.Int63())))
+	}
+
+	return msg
+}
+
+func newMsgReplyShortChanIDsEnd(t testing.TB,
+	r *rand.Rand) *lnwire.ReplyShortChanIDsEnd {
+
+	t.Helper()
+
+	msg := lnwire.NewReplyShortChanIDsEnd()
+
+	_, err := rand.Read(msg.ChainHash[:])
+	require.NoError(t, err, "unable to read chain hash")
+
+	msg.Complete = uint8(r.Int31n(2))
+	msg.ExtraData = createExtraData(t, r)
+
+	return msg
+}
+
+func newMsgQueryChannelRange(t testing.TB,
+	r *rand.Rand) *lnwire.QueryChannelRange {
+
+	t.Helper()
+
+	msg := lnwire.NewQueryChannelRange()
+
+	_, err := rand.Read(msg.ChainHash[:])
+	require.NoError(t, err, "unable to read chain hash")
+
+	msg.FirstBlockHeight = r.Uint32()
+	msg.NumBlocks = r.Uint32()
+	msg.ExtraData = createExtraData(t, r)
+
+	return msg
+}
+
+func newMsgReplyChannelRange(t testing.TB,
+	r *rand.Rand) *lnwire.ReplyChannelRange {
+
+	t.Helper()
+
+	msg := &lnwire.ReplyChannelRange{
+		EncodingType: lnwire.EncodingSortedPlain,
+		ExtraData:    createExtraData(t, r),
+	}
+
+	_, err := rand.Read(msg.ChainHash[:])
+	require.NoError(t, err, "unable to read chain hash")
+
+	msg.Complete = uint8(r.Int31n(2))
+
+	for i := 0; i < testNumChanIDs; i++ {
+		msg.ShortChanIDs = append(msg.ShortChanIDs,
+			lnwire.NewShortChanIDFromInt(uint64(r.Int63())))
+	}
+
+	return msg
+}
+
+func newMsgReplyChannelRangeZlib(t testing.TB,
+	r *rand.Rand) *lnwire.ReplyChannelRange {
+
+	t.Helper()
+
+	msg := &lnwire.ReplyChannelRange{
+		EncodingType: lnwire.EncodingSortedZlib,
+		ExtraData:    createExtraData(t, r),
+	}
+
+	_, err := rand.Read(msg.ChainHash[:])
+	require.NoError(t, err, "unable to read chain hash")
+
+	msg.Complete = uint8(r.Int31n(2))
+
+	for i := 0; i < testNumChanIDs; i++ {
+		msg.ShortChanIDs = append(msg.ShortChanIDs,
+			lnwire.NewShortChanIDFromInt(uint64(r.Int63())))
+	}
+
+	return msg
+}
+
+func newMsgGossipTimestampRange(t testing.TB,
+	r *rand.Rand) *lnwire.GossipTimestampRange {
+
+	t.Helper()
+
+	msg := lnwire.NewGossipTimestampRange()
+	msg.FirstTimestamp = r.Uint32()
+	msg.TimestampRange = r.Uint32()
+	msg.ExtraData = createExtraData(t, r)
+
+	_, err := r.Read(msg.ChainHash[:])
+	require.NoError(t, err, "unable to read chain hash")
+
+	return msg
+}
+
+func randRawKey(t testing.TB) [33]byte {
+	t.Helper()
+
+	var n [33]byte
+
+	priv, err := btcec.NewPrivateKey(btcec.S256())
+	require.NoError(t, err, "failed to create privKey")
+
+	copy(n[:], priv.PubKey().SerializeCompressed())
+
+	return n
+}
+
+func randPubKey(t testing.TB) *btcec.PublicKey {
+	t.Helper()
+
+	priv, err := btcec.NewPrivateKey(btcec.S256())
+	require.NoError(t, err, "failed to create pubkey")
+
+	return priv.PubKey()
+}
+
+func rawFeatureVector() *lnwire.RawFeatureVector {
+	// Get a slice of known feature bits.
+	featureBits := make([]lnwire.FeatureBit, 0, len(lnwire.Features))
+	for fb := range lnwire.Features {
+		featureBits = append(featureBits, fb)
+	}
+
+	featureVec := lnwire.NewRawFeatureVector(featureBits...)
+
+	return featureVec
+}
+
+func randDeliveryAddress(t testing.TB, r *rand.Rand) lnwire.DeliveryAddress {
+	t.Helper()
+
+	// Generate a max sized address.
+	size := r.Intn(deliveryAddressMaxSize) + 1
+	da := lnwire.DeliveryAddress(make([]byte, size))
+
+	_, err := r.Read(da)
+	require.NoError(t, err, "unable to read address")
+	return da
+}
+
+func randTCP4Addr(t testing.TB, r *rand.Rand) *net.TCPAddr {
+	t.Helper()
+
+	var ip [4]byte
+	_, err := r.Read(ip[:])
+	require.NoError(t, err, "unable to read ip")
+
+	var port [2]byte
+	_, err = r.Read(port[:])
+	require.NoError(t, err, "unable to read port")
+
+	addrIP := net.IP(ip[:])
+	addrPort := int(binary.BigEndian.Uint16(port[:]))
+
+	return &net.TCPAddr{IP: addrIP, Port: addrPort}
+}
+
+func randTCP6Addr(t testing.TB, r *rand.Rand) *net.TCPAddr {
+	t.Helper()
+
+	var ip [16]byte
+
+	_, err := r.Read(ip[:])
+	require.NoError(t, err, "unable to read ip")
+
+	var port [2]byte
+	_, err = r.Read(port[:])
+	require.NoError(t, err, "unable to read port")
+
+	addrIP := net.IP(ip[:])
+	addrPort := int(binary.BigEndian.Uint16(port[:]))
+
+	return &net.TCPAddr{IP: addrIP, Port: addrPort}
+}
+
+func randV2OnionAddr(t testing.TB, r *rand.Rand) *tor.OnionAddr {
+	t.Helper()
+
+	var serviceID [tor.V2DecodedLen]byte
+	_, err := r.Read(serviceID[:])
+	require.NoError(t, err, "unable to read serviceID")
+
+	var port [2]byte
+	_, err = r.Read(port[:])
+	require.NoError(t, err, "unable to read port")
+
+	onionService := tor.Base32Encoding.EncodeToString(serviceID[:])
+	onionService += tor.OnionSuffix
+	addrPort := int(binary.BigEndian.Uint16(port[:]))
+
+	return &tor.OnionAddr{OnionService: onionService, Port: addrPort}
+}
+
+func randV3OnionAddr(t testing.TB, r *rand.Rand) *tor.OnionAddr {
+	t.Helper()
+
+	var serviceID [tor.V3DecodedLen]byte
+	_, err := r.Read(serviceID[:])
+	require.NoError(t, err, "unable to read serviceID")
+
+	var port [2]byte
+	_, err = r.Read(port[:])
+	require.NoError(t, err, "unable to read port")
+
+	onionService := tor.Base32Encoding.EncodeToString(serviceID[:])
+	onionService += tor.OnionSuffix
+	addrPort := int(binary.BigEndian.Uint16(port[:]))
+
+	return &tor.OnionAddr{OnionService: onionService, Port: addrPort}
+}
+
+func randAddrs(t testing.TB, r *rand.Rand) []net.Addr {
+	tcp4Addr := randTCP4Addr(t, r)
+	tcp6Addr := randTCP6Addr(t, r)
+	v2OnionAddr := randV2OnionAddr(t, r)
+	v3OnionAddr := randV3OnionAddr(t, r)
+
+	return []net.Addr{tcp4Addr, tcp6Addr, v2OnionAddr, v3OnionAddr}
+}
+
+func randAlias(r *rand.Rand) lnwire.NodeAlias {
+	var a lnwire.NodeAlias
+	for i := range a {
+		a[i] = letterBytes[r.Intn(len(letterBytes))]
+	}
+
+	return a
+}
+
+func createExtraData(t testing.TB, r io.Reader) []byte {
+	t.Helper()
+
+	// Read random bytes.
+	extraData := make([]byte, testNumExtraBytes)
+	_, err := r.Read(extraData)
+	require.NoError(t, err, "unable to generate extra data")
+
+	// Encode the data length.
+	binary.BigEndian.PutUint16(extraData[:2], uint16(len(extraData[2:])))
+
+	return extraData
+}

--- a/lnwire/message_test.go
+++ b/lnwire/message_test.go
@@ -52,7 +52,7 @@ func (m *mockMsg) Decode(r io.Reader, pver uint32) error {
 	return args.Error(0)
 }
 
-func (m *mockMsg) Encode(w io.Writer, pver uint32) error {
+func (m *mockMsg) Encode(w *bytes.Buffer, pver uint32) error {
 	args := m.Called(w, pver)
 	return args.Error(0)
 }

--- a/lnwire/node_announcement.go
+++ b/lnwire/node_announcement.go
@@ -124,7 +124,7 @@ func (a *NodeAnnouncement) Decode(r io.Reader, pver uint32) error {
 // Encode serializes the target NodeAnnouncement into the passed io.Writer
 // observing the protocol version specified.
 //
-func (a *NodeAnnouncement) Encode(w io.Writer, pver uint32) error {
+func (a *NodeAnnouncement) Encode(w *bytes.Buffer, pver uint32) error {
 	return WriteElements(w,
 		a.Signature,
 		a.Features,

--- a/lnwire/onion_error.go
+++ b/lnwire/onion_error.go
@@ -419,7 +419,7 @@ func (f *FailIncorrectDetails) Decode(r io.Reader, pver uint32) error {
 // Encode writes the failure in bytes stream.
 //
 // NOTE: Part of the Serializable interface.
-func (f *FailIncorrectDetails) Encode(w io.Writer, pver uint32) error {
+func (f *FailIncorrectDetails) Encode(w *bytes.Buffer, pver uint32) error {
 	return WriteElements(w, f.amount, f.height)
 }
 
@@ -485,7 +485,7 @@ func (f *FailInvalidOnionVersion) Decode(r io.Reader, pver uint32) error {
 // Encode writes the failure in bytes stream.
 //
 // NOTE: Part of the Serializable interface.
-func (f *FailInvalidOnionVersion) Encode(w io.Writer, pver uint32) error {
+func (f *FailInvalidOnionVersion) Encode(w *bytes.Buffer, pver uint32) error {
 	return WriteElement(w, f.OnionSHA256[:])
 }
 
@@ -519,7 +519,7 @@ func (f *FailInvalidOnionHmac) Decode(r io.Reader, pver uint32) error {
 // Encode writes the failure in bytes stream.
 //
 // NOTE: Part of the Serializable interface.
-func (f *FailInvalidOnionHmac) Encode(w io.Writer, pver uint32) error {
+func (f *FailInvalidOnionHmac) Encode(w *bytes.Buffer, pver uint32) error {
 	return WriteElement(w, f.OnionSHA256[:])
 }
 
@@ -561,7 +561,7 @@ func (f *FailInvalidOnionKey) Decode(r io.Reader, pver uint32) error {
 // Encode writes the failure in bytes stream.
 //
 // NOTE: Part of the Serializable interface.
-func (f *FailInvalidOnionKey) Encode(w io.Writer, pver uint32) error {
+func (f *FailInvalidOnionKey) Encode(w *bytes.Buffer, pver uint32) error {
 	return WriteElement(w, f.OnionSHA256[:])
 }
 
@@ -670,7 +670,9 @@ func (f *FailTemporaryChannelFailure) Decode(r io.Reader, pver uint32) error {
 // Encode writes the failure in bytes stream.
 //
 // NOTE: Part of the Serializable interface.
-func (f *FailTemporaryChannelFailure) Encode(w io.Writer, pver uint32) error {
+func (f *FailTemporaryChannelFailure) Encode(w *bytes.Buffer,
+	pver uint32) error {
+
 	var payload []byte
 	if f.Update != nil {
 		var bw bytes.Buffer
@@ -749,7 +751,7 @@ func (f *FailAmountBelowMinimum) Decode(r io.Reader, pver uint32) error {
 // Encode writes the failure in bytes stream.
 //
 // NOTE: Part of the Serializable interface.
-func (f *FailAmountBelowMinimum) Encode(w io.Writer, pver uint32) error {
+func (f *FailAmountBelowMinimum) Encode(w *bytes.Buffer, pver uint32) error {
 	if err := WriteElement(w, f.HtlcMsat); err != nil {
 		return err
 	}
@@ -817,7 +819,7 @@ func (f *FailFeeInsufficient) Decode(r io.Reader, pver uint32) error {
 // Encode writes the failure in bytes stream.
 //
 // NOTE: Part of the Serializable interface.
-func (f *FailFeeInsufficient) Encode(w io.Writer, pver uint32) error {
+func (f *FailFeeInsufficient) Encode(w *bytes.Buffer, pver uint32) error {
 	if err := WriteElement(w, f.HtlcMsat); err != nil {
 		return err
 	}
@@ -885,7 +887,7 @@ func (f *FailIncorrectCltvExpiry) Decode(r io.Reader, pver uint32) error {
 // Encode writes the failure in bytes stream.
 //
 // NOTE: Part of the Serializable interface.
-func (f *FailIncorrectCltvExpiry) Encode(w io.Writer, pver uint32) error {
+func (f *FailIncorrectCltvExpiry) Encode(w *bytes.Buffer, pver uint32) error {
 	if err := WriteElement(w, f.CltvExpiry); err != nil {
 		return err
 	}
@@ -942,7 +944,7 @@ func (f *FailExpiryTooSoon) Decode(r io.Reader, pver uint32) error {
 // Encode writes the failure in bytes stream.
 //
 // NOTE: Part of the Serializable interface.
-func (f *FailExpiryTooSoon) Encode(w io.Writer, pver uint32) error {
+func (f *FailExpiryTooSoon) Encode(w *bytes.Buffer, pver uint32) error {
 	return writeOnionErrorChanUpdate(w, &f.Update, pver)
 }
 
@@ -1006,7 +1008,7 @@ func (f *FailChannelDisabled) Decode(r io.Reader, pver uint32) error {
 // Encode writes the failure in bytes stream.
 //
 // NOTE: Part of the Serializable interface.
-func (f *FailChannelDisabled) Encode(w io.Writer, pver uint32) error {
+func (f *FailChannelDisabled) Encode(w *bytes.Buffer, pver uint32) error {
 	if err := WriteElement(w, f.Flags); err != nil {
 		return err
 	}
@@ -1056,7 +1058,9 @@ func (f *FailFinalIncorrectCltvExpiry) Decode(r io.Reader, pver uint32) error {
 // Encode writes the failure in bytes stream.
 //
 // NOTE: Part of the Serializable interface.
-func (f *FailFinalIncorrectCltvExpiry) Encode(w io.Writer, pver uint32) error {
+func (f *FailFinalIncorrectCltvExpiry) Encode(w *bytes.Buffer,
+	pver uint32) error {
+
 	return WriteElement(w, f.CltvExpiry)
 }
 
@@ -1102,7 +1106,9 @@ func (f *FailFinalIncorrectHtlcAmount) Decode(r io.Reader, pver uint32) error {
 // Encode writes the failure in bytes stream.
 //
 // NOTE: Part of the Serializable interface.
-func (f *FailFinalIncorrectHtlcAmount) Encode(w io.Writer, pver uint32) error {
+func (f *FailFinalIncorrectHtlcAmount) Encode(w *bytes.Buffer,
+	pver uint32) error {
+
 	return WriteElement(w, f.IncomingHTLCAmount)
 }
 
@@ -1177,7 +1183,7 @@ func (f *InvalidOnionPayload) Decode(r io.Reader, pver uint32) error {
 // Encode writes the failure in bytes stream.
 //
 // NOTE: Part of the Serializable interface.
-func (f *InvalidOnionPayload) Encode(w io.Writer, pver uint32) error {
+func (f *InvalidOnionPayload) Encode(w *bytes.Buffer, pver uint32) error {
 	var buf [8]byte
 	if err := tlv.WriteVarInt(w, f.Type, &buf); err != nil {
 		return err
@@ -1263,7 +1269,7 @@ func DecodeFailureMessage(r io.Reader, pver uint32) (FailureMessage, error) {
 
 // EncodeFailure encodes, including the necessary onion failure header
 // information.
-func EncodeFailure(w io.Writer, failure FailureMessage, pver uint32) error {
+func EncodeFailure(w *bytes.Buffer, failure FailureMessage, pver uint32) error {
 	var failureMessageBuffer bytes.Buffer
 
 	err := EncodeFailureMessage(&failureMessageBuffer, failure, pver)
@@ -1293,7 +1299,9 @@ func EncodeFailure(w io.Writer, failure FailureMessage, pver uint32) error {
 
 // EncodeFailureMessage encodes just the failure message without adding a length
 // and padding the message for the onion protocol.
-func EncodeFailureMessage(w io.Writer, failure FailureMessage, pver uint32) error {
+func EncodeFailureMessage(w *bytes.Buffer,
+	failure FailureMessage, pver uint32) error {
+
 	// First, we'll write out the error code itself into the failure
 	// buffer.
 	var codeBytes [2]byte
@@ -1401,7 +1409,7 @@ func makeEmptyOnionError(code FailCode) (FailureMessage, error) {
 // writeOnionErrorChanUpdate writes out a ChannelUpdate using the onion error
 // format. The format is that we first write out the true serialized length of
 // the channel update, followed by the serialized channel update itself.
-func writeOnionErrorChanUpdate(w io.Writer, chanUpdate *ChannelUpdate,
+func writeOnionErrorChanUpdate(w *bytes.Buffer, chanUpdate *ChannelUpdate,
 	pver uint32) error {
 
 	// First, we encode the channel update in a temporary buffer in order

--- a/lnwire/onion_error_test.go
+++ b/lnwire/onion_error_test.go
@@ -275,6 +275,8 @@ func (f *mockFailIncorrectDetailsNoHeight) Decode(r io.Reader, pver uint32) erro
 	return nil
 }
 
-func (f *mockFailIncorrectDetailsNoHeight) Encode(w io.Writer, pver uint32) error {
+func (f *mockFailIncorrectDetailsNoHeight) Encode(w *bytes.Buffer,
+	pver uint32) error {
+
 	return WriteElement(w, f.amount)
 }

--- a/lnwire/onion_error_test.go
+++ b/lnwire/onion_error_test.go
@@ -278,5 +278,5 @@ func (f *mockFailIncorrectDetailsNoHeight) Decode(r io.Reader, pver uint32) erro
 func (f *mockFailIncorrectDetailsNoHeight) Encode(w *bytes.Buffer,
 	pver uint32) error {
 
-	return WriteElement(w, f.amount)
+	return WriteUint64(w, f.amount)
 }

--- a/lnwire/open_channel.go
+++ b/lnwire/open_channel.go
@@ -1,6 +1,7 @@
 package lnwire
 
 import (
+	"bytes"
 	"io"
 
 	"github.com/btcsuite/btcd/btcec"
@@ -150,7 +151,7 @@ var _ Message = (*OpenChannel)(nil)
 // protocol version.
 //
 // This is part of the lnwire.Message interface.
-func (o *OpenChannel) Encode(w io.Writer, pver uint32) error {
+func (o *OpenChannel) Encode(w *bytes.Buffer, pver uint32) error {
 	// Since the upfront script is encoded as a TLV record, concatenate it
 	// with the ExtraData, and write them as one.
 	tlvRecords, err := packShutdownScript(

--- a/lnwire/open_channel.go
+++ b/lnwire/open_channel.go
@@ -161,27 +161,80 @@ func (o *OpenChannel) Encode(w *bytes.Buffer, pver uint32) error {
 		return err
 	}
 
-	return WriteElements(w,
-		o.ChainHash[:],
-		o.PendingChannelID[:],
-		o.FundingAmount,
-		o.PushAmount,
-		o.DustLimit,
-		o.MaxValueInFlight,
-		o.ChannelReserve,
-		o.HtlcMinimum,
-		o.FeePerKiloWeight,
-		o.CsvDelay,
-		o.MaxAcceptedHTLCs,
-		o.FundingKey,
-		o.RevocationPoint,
-		o.PaymentPoint,
-		o.DelayedPaymentPoint,
-		o.HtlcPoint,
-		o.FirstCommitmentPoint,
-		o.ChannelFlags,
-		tlvRecords,
-	)
+	if err := WriteBytes(w, o.ChainHash[:]); err != nil {
+		return err
+	}
+
+	if err := WriteBytes(w, o.PendingChannelID[:]); err != nil {
+		return err
+	}
+
+	if err := WriteSatoshi(w, o.FundingAmount); err != nil {
+		return err
+	}
+
+	if err := WriteMilliSatoshi(w, o.PushAmount); err != nil {
+		return err
+	}
+
+	if err := WriteSatoshi(w, o.DustLimit); err != nil {
+		return err
+	}
+
+	if err := WriteMilliSatoshi(w, o.MaxValueInFlight); err != nil {
+		return err
+	}
+
+	if err := WriteSatoshi(w, o.ChannelReserve); err != nil {
+		return err
+	}
+
+	if err := WriteMilliSatoshi(w, o.HtlcMinimum); err != nil {
+		return err
+	}
+
+	if err := WriteUint32(w, o.FeePerKiloWeight); err != nil {
+		return err
+	}
+
+	if err := WriteUint16(w, o.CsvDelay); err != nil {
+		return err
+	}
+
+	if err := WriteUint16(w, o.MaxAcceptedHTLCs); err != nil {
+		return err
+	}
+
+	if err := WritePublicKey(w, o.FundingKey); err != nil {
+		return err
+	}
+
+	if err := WritePublicKey(w, o.RevocationPoint); err != nil {
+		return err
+	}
+
+	if err := WritePublicKey(w, o.PaymentPoint); err != nil {
+		return err
+	}
+
+	if err := WritePublicKey(w, o.DelayedPaymentPoint); err != nil {
+		return err
+	}
+
+	if err := WritePublicKey(w, o.HtlcPoint); err != nil {
+		return err
+
+	}
+
+	if err := WritePublicKey(w, o.FirstCommitmentPoint); err != nil {
+		return err
+	}
+
+	if err := WriteFundingFlag(w, o.ChannelFlags); err != nil {
+		return err
+	}
+
+	return WriteBytes(w, tlvRecords)
 }
 
 // Decode deserializes the serialized OpenChannel stored in the passed

--- a/lnwire/ping.go
+++ b/lnwire/ping.go
@@ -1,6 +1,9 @@
 package lnwire
 
-import "io"
+import (
+	"bytes"
+	"io"
+)
 
 // PingPayload is a set of opaque bytes used to pad out a ping message.
 type PingPayload []byte
@@ -44,7 +47,7 @@ func (p *Ping) Decode(r io.Reader, pver uint32) error {
 // protocol version specified.
 //
 // This is part of the lnwire.Message interface.
-func (p *Ping) Encode(w io.Writer, pver uint32) error {
+func (p *Ping) Encode(w *bytes.Buffer, pver uint32) error {
 	return WriteElements(w,
 		p.NumPongBytes,
 		p.PaddingBytes)

--- a/lnwire/ping.go
+++ b/lnwire/ping.go
@@ -48,9 +48,11 @@ func (p *Ping) Decode(r io.Reader, pver uint32) error {
 //
 // This is part of the lnwire.Message interface.
 func (p *Ping) Encode(w *bytes.Buffer, pver uint32) error {
-	return WriteElements(w,
-		p.NumPongBytes,
-		p.PaddingBytes)
+	if err := WriteUint16(w, p.NumPongBytes); err != nil {
+		return err
+	}
+
+	return WritePingPayload(w, p.PaddingBytes)
 }
 
 // MsgType returns the integer uniquely identifying this message type on the

--- a/lnwire/pong.go
+++ b/lnwire/pong.go
@@ -44,9 +44,7 @@ func (p *Pong) Decode(r io.Reader, pver uint32) error {
 //
 // This is part of the lnwire.Message interface.
 func (p *Pong) Encode(w *bytes.Buffer, pver uint32) error {
-	return WriteElements(w,
-		p.PongBytes,
-	)
+	return WritePongPayload(w, p.PongBytes)
 }
 
 // MsgType returns the integer uniquely identifying this message type on the

--- a/lnwire/pong.go
+++ b/lnwire/pong.go
@@ -1,6 +1,9 @@
 package lnwire
 
-import "io"
+import (
+	"bytes"
+	"io"
+)
 
 // PongPayload is a set of opaque bytes sent in response to a ping message.
 type PongPayload []byte
@@ -40,7 +43,7 @@ func (p *Pong) Decode(r io.Reader, pver uint32) error {
 // protocol version specified.
 //
 // This is part of the lnwire.Message interface.
-func (p *Pong) Encode(w io.Writer, pver uint32) error {
+func (p *Pong) Encode(w *bytes.Buffer, pver uint32) error {
 	return WriteElements(w,
 		p.PongBytes,
 	)

--- a/lnwire/query_channel_range.go
+++ b/lnwire/query_channel_range.go
@@ -60,12 +60,19 @@ func (q *QueryChannelRange) Decode(r io.Reader, pver uint32) error {
 //
 // This is part of the lnwire.Message interface.
 func (q *QueryChannelRange) Encode(w *bytes.Buffer, pver uint32) error {
-	return WriteElements(w,
-		q.ChainHash[:],
-		q.FirstBlockHeight,
-		q.NumBlocks,
-		q.ExtraData,
-	)
+	if err := WriteBytes(w, q.ChainHash[:]); err != nil {
+		return err
+	}
+
+	if err := WriteUint32(w, q.FirstBlockHeight); err != nil {
+		return err
+	}
+
+	if err := WriteUint32(w, q.NumBlocks); err != nil {
+		return err
+	}
+
+	return WriteBytes(w, q.ExtraData)
 }
 
 // MsgType returns the integer uniquely identifying this message type on the

--- a/lnwire/query_channel_range.go
+++ b/lnwire/query_channel_range.go
@@ -1,6 +1,7 @@
 package lnwire
 
 import (
+	"bytes"
 	"io"
 	"math"
 
@@ -58,7 +59,7 @@ func (q *QueryChannelRange) Decode(r io.Reader, pver uint32) error {
 // observing the protocol version specified.
 //
 // This is part of the lnwire.Message interface.
-func (q *QueryChannelRange) Encode(w io.Writer, pver uint32) error {
+func (q *QueryChannelRange) Encode(w *bytes.Buffer, pver uint32) error {
 	return WriteElements(w,
 		q.ChainHash[:],
 		q.FirstBlockHeight,

--- a/lnwire/query_short_chan_ids.go
+++ b/lnwire/query_short_chan_ids.go
@@ -291,7 +291,7 @@ func decodeShortChanIDs(r io.Reader) (ShortChanIDEncoding, []ShortChannelID, err
 // observing the protocol version specified.
 //
 // This is part of the lnwire.Message interface.
-func (q *QueryShortChanIDs) Encode(w io.Writer, pver uint32) error {
+func (q *QueryShortChanIDs) Encode(w *bytes.Buffer, pver uint32) error {
 	// First, we'll write out the chain hash.
 	err := WriteElements(w, q.ChainHash[:])
 	if err != nil {
@@ -310,7 +310,7 @@ func (q *QueryShortChanIDs) Encode(w io.Writer, pver uint32) error {
 
 // encodeShortChanIDs encodes the passed short channel ID's into the passed
 // io.Writer, respecting the specified encoding type.
-func encodeShortChanIDs(w io.Writer, encodingType ShortChanIDEncoding,
+func encodeShortChanIDs(w *bytes.Buffer, encodingType ShortChanIDEncoding,
 	shortChanIDs []ShortChannelID, noSort bool) error {
 
 	// For both of the current encoding types, the channel ID's are to be
@@ -360,27 +360,38 @@ func encodeShortChanIDs(w io.Writer, encodingType ShortChanIDEncoding,
 	// TODO(roasbeef): assumes the caller knows the proper chunk size to
 	// pass to avoid bin-packing here
 	case EncodingSortedZlib:
-		// We'll make a new buffer, then wrap that with a zlib writer
-		// so we can write directly to the buffer and encode in a
-		// streaming manner.
-		var buf bytes.Buffer
-		zlibWriter := zlib.NewWriter(&buf)
-
 		// If we don't have anything at all to write, then we'll write
 		// an empty payload so we don't include things like the zlib
 		// header when the remote party is expecting no actual short
 		// channel IDs.
 		var compressedPayload []byte
 		if len(shortChanIDs) > 0 {
+			// We'll make a new write buffer to hold the bytes of
+			// shortChanIDs.
+			var wb bytes.Buffer
+
 			// Next, we'll write out all the channel ID's directly
 			// into the zlib writer, which will do compressing on
 			// the fly.
 			for _, chanID := range shortChanIDs {
-				err := WriteElements(zlibWriter, chanID)
+				err := WriteElements(&wb, chanID)
 				if err != nil {
-					return fmt.Errorf("unable to write short chan "+
-						"ID: %v", err)
+					return fmt.Errorf(
+						"unable to write short chan "+
+							"ID: %v", err,
+					)
 				}
+			}
+
+			// With shortChanIDs written into wb, we'll create a
+			// zlib writer and write all the compressed bytes.
+			var zlibBuffer bytes.Buffer
+			zlibWriter := zlib.NewWriter(&zlibBuffer)
+
+			if _, err := zlibWriter.Write(wb.Bytes()); err != nil {
+				return fmt.Errorf(
+					"unable to write compressed short chan"+
+						"ID: %w", err)
 			}
 
 			// Now that we've written all the elements, we'll
@@ -391,7 +402,7 @@ func encodeShortChanIDs(w io.Writer, encodingType ShortChanIDEncoding,
 					"compression: %v", err)
 			}
 
-			compressedPayload = buf.Bytes()
+			compressedPayload = zlibBuffer.Bytes()
 		}
 
 		// Now that we have all the items compressed, we can compute

--- a/lnwire/reply_channel_range.go
+++ b/lnwire/reply_channel_range.go
@@ -87,22 +87,28 @@ func (c *ReplyChannelRange) Decode(r io.Reader, pver uint32) error {
 //
 // This is part of the lnwire.Message interface.
 func (c *ReplyChannelRange) Encode(w *bytes.Buffer, pver uint32) error {
-	err := WriteElements(w,
-		c.ChainHash[:],
-		c.FirstBlockHeight,
-		c.NumBlocks,
-		c.Complete,
-	)
+	if err := WriteBytes(w, c.ChainHash[:]); err != nil {
+		return err
+	}
+
+	if err := WriteUint32(w, c.FirstBlockHeight); err != nil {
+		return err
+	}
+
+	if err := WriteUint32(w, c.NumBlocks); err != nil {
+		return err
+	}
+
+	if err := WriteUint8(w, c.Complete); err != nil {
+		return err
+	}
+
+	err := encodeShortChanIDs(w, c.EncodingType, c.ShortChanIDs, c.noSort)
 	if err != nil {
 		return err
 	}
 
-	err = encodeShortChanIDs(w, c.EncodingType, c.ShortChanIDs, c.noSort)
-	if err != nil {
-		return err
-	}
-
-	return c.ExtraData.Encode(w)
+	return WriteBytes(w, c.ExtraData)
 }
 
 // MsgType returns the integer uniquely identifying this message type on the

--- a/lnwire/reply_channel_range.go
+++ b/lnwire/reply_channel_range.go
@@ -1,6 +1,7 @@
 package lnwire
 
 import (
+	"bytes"
 	"io"
 	"math"
 
@@ -85,7 +86,7 @@ func (c *ReplyChannelRange) Decode(r io.Reader, pver uint32) error {
 // observing the protocol version specified.
 //
 // This is part of the lnwire.Message interface.
-func (c *ReplyChannelRange) Encode(w io.Writer, pver uint32) error {
+func (c *ReplyChannelRange) Encode(w *bytes.Buffer, pver uint32) error {
 	err := WriteElements(w,
 		c.ChainHash[:],
 		c.FirstBlockHeight,

--- a/lnwire/reply_short_chan_ids_end.go
+++ b/lnwire/reply_short_chan_ids_end.go
@@ -1,6 +1,7 @@
 package lnwire
 
 import (
+	"bytes"
 	"io"
 
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
@@ -54,7 +55,7 @@ func (c *ReplyShortChanIDsEnd) Decode(r io.Reader, pver uint32) error {
 // observing the protocol version specified.
 //
 // This is part of the lnwire.Message interface.
-func (c *ReplyShortChanIDsEnd) Encode(w io.Writer, pver uint32) error {
+func (c *ReplyShortChanIDsEnd) Encode(w *bytes.Buffer, pver uint32) error {
 	return WriteElements(w,
 		c.ChainHash[:],
 		c.Complete,

--- a/lnwire/reply_short_chan_ids_end.go
+++ b/lnwire/reply_short_chan_ids_end.go
@@ -56,11 +56,15 @@ func (c *ReplyShortChanIDsEnd) Decode(r io.Reader, pver uint32) error {
 //
 // This is part of the lnwire.Message interface.
 func (c *ReplyShortChanIDsEnd) Encode(w *bytes.Buffer, pver uint32) error {
-	return WriteElements(w,
-		c.ChainHash[:],
-		c.Complete,
-		c.ExtraData,
-	)
+	if err := WriteBytes(w, c.ChainHash[:]); err != nil {
+		return err
+	}
+
+	if err := WriteUint8(w, c.Complete); err != nil {
+		return err
+	}
+
+	return WriteBytes(w, c.ExtraData)
 }
 
 // MsgType returns the integer uniquely identifying this message type on the

--- a/lnwire/revoke_and_ack.go
+++ b/lnwire/revoke_and_ack.go
@@ -1,6 +1,7 @@
 package lnwire
 
 import (
+	"bytes"
 	"io"
 
 	"github.com/btcsuite/btcd/btcec"
@@ -65,7 +66,7 @@ func (c *RevokeAndAck) Decode(r io.Reader, pver uint32) error {
 // observing the protocol version specified.
 //
 // This is part of the lnwire.Message interface.
-func (c *RevokeAndAck) Encode(w io.Writer, pver uint32) error {
+func (c *RevokeAndAck) Encode(w *bytes.Buffer, pver uint32) error {
 	return WriteElements(w,
 		c.ChanID,
 		c.Revocation[:],

--- a/lnwire/revoke_and_ack.go
+++ b/lnwire/revoke_and_ack.go
@@ -67,12 +67,19 @@ func (c *RevokeAndAck) Decode(r io.Reader, pver uint32) error {
 //
 // This is part of the lnwire.Message interface.
 func (c *RevokeAndAck) Encode(w *bytes.Buffer, pver uint32) error {
-	return WriteElements(w,
-		c.ChanID,
-		c.Revocation[:],
-		c.NextRevocationKey,
-		c.ExtraData,
-	)
+	if err := WriteChannelID(w, c.ChanID); err != nil {
+		return err
+	}
+
+	if err := WriteBytes(w, c.Revocation[:]); err != nil {
+		return err
+	}
+
+	if err := WritePublicKey(w, c.NextRevocationKey); err != nil {
+		return err
+	}
+
+	return WriteBytes(w, c.ExtraData)
 }
 
 // MsgType returns the integer uniquely identifying this message type on the

--- a/lnwire/shutdown.go
+++ b/lnwire/shutdown.go
@@ -1,6 +1,7 @@
 package lnwire
 
 import (
+	"bytes"
 	"io"
 )
 
@@ -46,7 +47,7 @@ func (s *Shutdown) Decode(r io.Reader, pver uint32) error {
 // the protocol version specified.
 //
 // This is part of the lnwire.Message interface.
-func (s *Shutdown) Encode(w io.Writer, pver uint32) error {
+func (s *Shutdown) Encode(w *bytes.Buffer, pver uint32) error {
 	return WriteElements(w, s.ChannelID, s.Address, s.ExtraData)
 }
 

--- a/lnwire/shutdown.go
+++ b/lnwire/shutdown.go
@@ -48,7 +48,15 @@ func (s *Shutdown) Decode(r io.Reader, pver uint32) error {
 //
 // This is part of the lnwire.Message interface.
 func (s *Shutdown) Encode(w *bytes.Buffer, pver uint32) error {
-	return WriteElements(w, s.ChannelID, s.Address, s.ExtraData)
+	if err := WriteChannelID(w, s.ChannelID); err != nil {
+		return err
+	}
+
+	if err := WriteDeliveryAddress(w, s.Address); err != nil {
+		return err
+	}
+
+	return WriteBytes(w, s.ExtraData)
 }
 
 // MsgType returns the integer uniquely identifying this message type on the

--- a/lnwire/update_add_htlc.go
+++ b/lnwire/update_add_htlc.go
@@ -85,20 +85,36 @@ func (c *UpdateAddHTLC) Decode(r io.Reader, pver uint32) error {
 	)
 }
 
-// Encode serializes the target UpdateAddHTLC into the passed io.Writer observing
-// the protocol version specified.
+// Encode serializes the target UpdateAddHTLC into the passed io.Writer
+// observing the protocol version specified.
 //
 // This is part of the lnwire.Message interface.
 func (c *UpdateAddHTLC) Encode(w *bytes.Buffer, pver uint32) error {
-	return WriteElements(w,
-		c.ChanID,
-		c.ID,
-		c.Amount,
-		c.PaymentHash[:],
-		c.Expiry,
-		c.OnionBlob[:],
-		c.ExtraData,
-	)
+	if err := WriteChannelID(w, c.ChanID); err != nil {
+		return err
+	}
+
+	if err := WriteUint64(w, c.ID); err != nil {
+		return err
+	}
+
+	if err := WriteMilliSatoshi(w, c.Amount); err != nil {
+		return err
+	}
+
+	if err := WriteBytes(w, c.PaymentHash[:]); err != nil {
+		return err
+	}
+
+	if err := WriteUint32(w, c.Expiry); err != nil {
+		return err
+	}
+
+	if err := WriteBytes(w, c.OnionBlob[:]); err != nil {
+		return err
+	}
+
+	return WriteBytes(w, c.ExtraData)
 }
 
 // MsgType returns the integer uniquely identifying this message type on the

--- a/lnwire/update_add_htlc.go
+++ b/lnwire/update_add_htlc.go
@@ -1,6 +1,7 @@
 package lnwire
 
 import (
+	"bytes"
 	"io"
 )
 
@@ -88,7 +89,7 @@ func (c *UpdateAddHTLC) Decode(r io.Reader, pver uint32) error {
 // the protocol version specified.
 //
 // This is part of the lnwire.Message interface.
-func (c *UpdateAddHTLC) Encode(w io.Writer, pver uint32) error {
+func (c *UpdateAddHTLC) Encode(w *bytes.Buffer, pver uint32) error {
 	return WriteElements(w,
 		c.ChanID,
 		c.ID,

--- a/lnwire/update_fail_htlc.go
+++ b/lnwire/update_fail_htlc.go
@@ -56,12 +56,19 @@ func (c *UpdateFailHTLC) Decode(r io.Reader, pver uint32) error {
 //
 // This is part of the lnwire.Message interface.
 func (c *UpdateFailHTLC) Encode(w *bytes.Buffer, pver uint32) error {
-	return WriteElements(w,
-		c.ChanID,
-		c.ID,
-		c.Reason,
-		c.ExtraData,
-	)
+	if err := WriteChannelID(w, c.ChanID); err != nil {
+		return err
+	}
+
+	if err := WriteUint64(w, c.ID); err != nil {
+		return err
+	}
+
+	if err := WriteOpaqueReason(w, c.Reason); err != nil {
+		return err
+	}
+
+	return WriteBytes(w, c.ExtraData)
 }
 
 // MsgType returns the integer uniquely identifying this message type on the

--- a/lnwire/update_fail_htlc.go
+++ b/lnwire/update_fail_htlc.go
@@ -1,6 +1,7 @@
 package lnwire
 
 import (
+	"bytes"
 	"io"
 )
 
@@ -54,7 +55,7 @@ func (c *UpdateFailHTLC) Decode(r io.Reader, pver uint32) error {
 // the protocol version specified.
 //
 // This is part of the lnwire.Message interface.
-func (c *UpdateFailHTLC) Encode(w io.Writer, pver uint32) error {
+func (c *UpdateFailHTLC) Encode(w *bytes.Buffer, pver uint32) error {
 	return WriteElements(w,
 		c.ChanID,
 		c.ID,

--- a/lnwire/update_fail_malformed_htlc.go
+++ b/lnwire/update_fail_malformed_htlc.go
@@ -54,14 +54,26 @@ func (c *UpdateFailMalformedHTLC) Decode(r io.Reader, pver uint32) error {
 // io.Writer observing the protocol version specified.
 //
 // This is part of the lnwire.Message interface.
-func (c *UpdateFailMalformedHTLC) Encode(w *bytes.Buffer, pver uint32) error {
-	return WriteElements(w,
-		c.ChanID,
-		c.ID,
-		c.ShaOnionBlob[:],
-		c.FailureCode,
-		c.ExtraData,
-	)
+func (c *UpdateFailMalformedHTLC) Encode(w *bytes.Buffer,
+	pver uint32) error {
+
+	if err := WriteChannelID(w, c.ChanID); err != nil {
+		return err
+	}
+
+	if err := WriteUint64(w, c.ID); err != nil {
+		return err
+	}
+
+	if err := WriteBytes(w, c.ShaOnionBlob[:]); err != nil {
+		return err
+	}
+
+	if err := WriteFailCode(w, c.FailureCode); err != nil {
+		return err
+	}
+
+	return WriteBytes(w, c.ExtraData)
 }
 
 // MsgType returns the integer uniquely identifying this message type on the

--- a/lnwire/update_fail_malformed_htlc.go
+++ b/lnwire/update_fail_malformed_htlc.go
@@ -1,6 +1,7 @@
 package lnwire
 
 import (
+	"bytes"
 	"crypto/sha256"
 	"io"
 )
@@ -53,7 +54,7 @@ func (c *UpdateFailMalformedHTLC) Decode(r io.Reader, pver uint32) error {
 // io.Writer observing the protocol version specified.
 //
 // This is part of the lnwire.Message interface.
-func (c *UpdateFailMalformedHTLC) Encode(w io.Writer, pver uint32) error {
+func (c *UpdateFailMalformedHTLC) Encode(w *bytes.Buffer, pver uint32) error {
 	return WriteElements(w,
 		c.ChanID,
 		c.ID,

--- a/lnwire/update_fee.go
+++ b/lnwire/update_fee.go
@@ -53,11 +53,15 @@ func (c *UpdateFee) Decode(r io.Reader, pver uint32) error {
 //
 // This is part of the lnwire.Message interface.
 func (c *UpdateFee) Encode(w *bytes.Buffer, pver uint32) error {
-	return WriteElements(w,
-		c.ChanID,
-		c.FeePerKw,
-		c.ExtraData,
-	)
+	if err := WriteChannelID(w, c.ChanID); err != nil {
+		return err
+	}
+
+	if err := WriteUint32(w, c.FeePerKw); err != nil {
+		return err
+	}
+
+	return WriteBytes(w, c.ExtraData)
 }
 
 // MsgType returns the integer uniquely identifying this message type on the

--- a/lnwire/update_fee.go
+++ b/lnwire/update_fee.go
@@ -1,6 +1,7 @@
 package lnwire
 
 import (
+	"bytes"
 	"io"
 )
 
@@ -51,7 +52,7 @@ func (c *UpdateFee) Decode(r io.Reader, pver uint32) error {
 // observing the protocol version specified.
 //
 // This is part of the lnwire.Message interface.
-func (c *UpdateFee) Encode(w io.Writer, pver uint32) error {
+func (c *UpdateFee) Encode(w *bytes.Buffer, pver uint32) error {
 	return WriteElements(w,
 		c.ChanID,
 		c.FeePerKw,

--- a/lnwire/update_fulfill_htlc.go
+++ b/lnwire/update_fulfill_htlc.go
@@ -62,12 +62,19 @@ func (c *UpdateFulfillHTLC) Decode(r io.Reader, pver uint32) error {
 //
 // This is part of the lnwire.Message interface.
 func (c *UpdateFulfillHTLC) Encode(w *bytes.Buffer, pver uint32) error {
-	return WriteElements(w,
-		c.ChanID,
-		c.ID,
-		c.PaymentPreimage[:],
-		c.ExtraData,
-	)
+	if err := WriteChannelID(w, c.ChanID); err != nil {
+		return err
+	}
+
+	if err := WriteUint64(w, c.ID); err != nil {
+		return err
+	}
+
+	if err := WriteBytes(w, c.PaymentPreimage[:]); err != nil {
+		return err
+	}
+
+	return WriteBytes(w, c.ExtraData)
 }
 
 // MsgType returns the integer uniquely identifying this message type on the

--- a/lnwire/update_fulfill_htlc.go
+++ b/lnwire/update_fulfill_htlc.go
@@ -1,6 +1,7 @@
 package lnwire
 
 import (
+	"bytes"
 	"io"
 )
 
@@ -60,7 +61,7 @@ func (c *UpdateFulfillHTLC) Decode(r io.Reader, pver uint32) error {
 // observing the protocol version specified.
 //
 // This is part of the lnwire.Message interface.
-func (c *UpdateFulfillHTLC) Encode(w io.Writer, pver uint32) error {
+func (c *UpdateFulfillHTLC) Encode(w *bytes.Buffer, pver uint32) error {
 	return WriteElements(w,
 		c.ChanID,
 		c.ID,

--- a/lnwire/writer.go
+++ b/lnwire/writer.go
@@ -1,0 +1,431 @@
+package lnwire
+
+import (
+	"bytes"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"image/color"
+	"math"
+	"net"
+
+	"github.com/btcsuite/btcd/btcec"
+	"github.com/btcsuite/btcd/wire"
+	"github.com/btcsuite/btcutil"
+	"github.com/lightningnetwork/lnd/tor"
+)
+
+var (
+	// ErrNilFeatureVector is returned when the supplied feature is nil.
+	ErrNilFeatureVector = errors.New("cannot write nil feature vector")
+
+	// ErrPkScriptTooLong is returned when the length of the provided
+	// script exceeds 34.
+	ErrPkScriptTooLong = errors.New("'PkScript' too long")
+
+	// ErrNilTCPAddress is returned when the supplied address is nil.
+	ErrNilTCPAddress = errors.New("cannot write nil TCPAddr")
+
+	// ErrNilOnionAddress is returned when the supplied address is nil.
+	ErrNilOnionAddress = errors.New("cannot write nil onion address")
+
+	// ErrNilNetAddress is returned when a nil value is used in []net.Addr.
+	ErrNilNetAddress = errors.New("cannot write nil address")
+
+	// ErrNilPublicKey is returned when a nil pubkey is used.
+	ErrNilPublicKey = errors.New("cannot write nil pubkey")
+
+	// ErrUnknownServiceLength is returned when the onion service length is
+	// unknown.
+	ErrUnknownServiceLength = errors.New("unknown onion service length")
+)
+
+// ErrOutpointIndexTooBig is used when the outpoint index exceeds the max value
+// of uint16.
+func ErrOutpointIndexTooBig(index uint32) error {
+	return fmt.Errorf(
+		"index for outpoint (%v) is greater than "+
+			"max index of %v", index, math.MaxUint16,
+	)
+}
+
+// WriteBytes appends the given bytes to the provided buffer.
+//
+// Note: We intentionally skip the interfacer linter check here because we want
+// to have concrete type (bytes.Buffer) rather than interface type (io.Write)
+// due to performance concern.
+func WriteBytes(buf *bytes.Buffer, b []byte) error { // nolint: interfacer
+	_, err := buf.Write(b)
+	return err
+}
+
+// WriteUint8 appends the uint8 to the provided buffer.
+//
+// Note: We intentionally skip the interfacer linter check here because we want
+// to have concrete type (bytes.Buffer) rather than interface type (io.Write)
+// due to performance concern.
+func WriteUint8(buf *bytes.Buffer, n uint8) error { // nolint: interfacer
+	_, err := buf.Write([]byte{n})
+	return err
+}
+
+// WriteUint16 appends the uint16 to the provided buffer. It encodes the
+// integer using big endian byte order.
+//
+// Note: We intentionally skip the interfacer linter check here because we want
+// to have concrete type (bytes.Buffer) rather than interface type (io.Write)
+// due to performance concern.
+func WriteUint16(buf *bytes.Buffer, n uint16) error { // nolint: interfacer
+	var b [2]byte
+	binary.BigEndian.PutUint16(b[:], n)
+	_, err := buf.Write(b[:])
+	return err
+}
+
+// WriteUint32 appends the uint32 to the provided buffer. It encodes the
+// integer using big endian byte order.
+func WriteUint32(buf *bytes.Buffer, n uint32) error {
+	var b [4]byte
+	binary.BigEndian.PutUint32(b[:], n)
+	_, err := buf.Write(b[:])
+	return err
+}
+
+// WriteUint64 appends the uint64 to the provided buffer. It encodes the
+// integer using big endian byte order.
+//
+// Note: We intentionally skip the interfacer linter check here because we want
+// to have concrete type (bytes.Buffer) rather than interface type (io.Write)
+// due to performance concern.
+func WriteUint64(buf *bytes.Buffer, n uint64) error { // nolint: interfacer
+	var b [8]byte
+	binary.BigEndian.PutUint64(b[:], n)
+	_, err := buf.Write(b[:])
+	return err
+}
+
+// WriteSatoshi appends the Satoshi value to the provided buffer.
+func WriteSatoshi(buf *bytes.Buffer, amount btcutil.Amount) error {
+	return WriteUint64(buf, uint64(amount))
+}
+
+// WriteMilliSatoshi appends the MilliSatoshi value to the provided buffer.
+func WriteMilliSatoshi(buf *bytes.Buffer, amount MilliSatoshi) error {
+	return WriteUint64(buf, uint64(amount))
+}
+
+// WritePublicKey appends the compressed public key to the provided buffer.
+func WritePublicKey(buf *bytes.Buffer, pub *btcec.PublicKey) error {
+	if pub == nil {
+		return ErrNilPublicKey
+	}
+
+	serializedPubkey := pub.SerializeCompressed()
+	return WriteBytes(buf, serializedPubkey)
+
+}
+
+// WriteChannelID appends the ChannelID to the provided buffer.
+func WriteChannelID(buf *bytes.Buffer, channelID ChannelID) error {
+	return WriteBytes(buf, channelID[:])
+}
+
+// WriteNodeAlias appends the alias to the provided buffer.
+func WriteNodeAlias(buf *bytes.Buffer, alias NodeAlias) error {
+	return WriteBytes(buf, alias[:])
+}
+
+// WriteShortChannelID appends the ShortChannelID to the provided buffer. It
+// encodes the BlockHeight and TxIndex each using 3 bytes with big endian byte
+// order, and encodes txPosition using 2 bytes with big endian byte order.
+func WriteShortChannelID(buf *bytes.Buffer, shortChanID ShortChannelID) error {
+	// Check that field fit in 3 bytes and write the blockHeight
+	if shortChanID.BlockHeight > ((1 << 24) - 1) {
+		return errors.New("block height should fit in 3 bytes")
+	}
+
+	var blockHeight [4]byte
+	binary.BigEndian.PutUint32(blockHeight[:], shortChanID.BlockHeight)
+
+	if _, err := buf.Write(blockHeight[1:]); err != nil {
+		return err
+	}
+
+	// Check that field fit in 3 bytes and write the txIndex
+	if shortChanID.TxIndex > ((1 << 24) - 1) {
+		return errors.New("tx index should fit in 3 bytes")
+	}
+
+	var txIndex [4]byte
+	binary.BigEndian.PutUint32(txIndex[:], shortChanID.TxIndex)
+	if _, err := buf.Write(txIndex[1:]); err != nil {
+		return err
+	}
+
+	// Write the TxPosition
+	return WriteUint16(buf, shortChanID.TxPosition)
+}
+
+// WriteSig appends the signature to the provided buffer.
+func WriteSig(buf *bytes.Buffer, sig Sig) error {
+	return WriteBytes(buf, sig[:])
+}
+
+// WriteSigs appends the slice of signatures to the provided buffer with its
+// length.
+func WriteSigs(buf *bytes.Buffer, sigs []Sig) error {
+	// Write the length of the sigs.
+	if err := WriteUint16(buf, uint16(len(sigs))); err != nil {
+		return err
+	}
+
+	for _, sig := range sigs {
+		if err := WriteSig(buf, sig); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// WriteFailCode appends the FailCode to the provided buffer.
+func WriteFailCode(buf *bytes.Buffer, e FailCode) error {
+	return WriteUint16(buf, uint16(e))
+}
+
+// WriteRawFeatureVector encodes the feature using the feature's Encode method
+// and appends the data to the provided buffer. An error will return if the
+// passed feature is nil.
+//
+// Note: We intentionally skip the interfacer linter check here because we want
+// to have concrete type (bytes.Buffer) rather than interface type (io.Write)
+// due to performance concern.
+func WriteRawFeatureVector(buf *bytes.Buffer, // nolint: interfacer
+	feature *RawFeatureVector) error {
+
+	if feature == nil {
+		return ErrNilFeatureVector
+	}
+
+	return feature.Encode(buf)
+}
+
+// WriteColorRGBA appends the RGBA color using three bytes.
+func WriteColorRGBA(buf *bytes.Buffer, e color.RGBA) error {
+	// Write R
+	if err := WriteUint8(buf, e.R); err != nil {
+		return err
+	}
+
+	// Write G
+	if err := WriteUint8(buf, e.G); err != nil {
+		return err
+	}
+
+	// Write B
+	return WriteUint8(buf, e.B)
+}
+
+// WriteShortChanIDEncoding appends the ShortChanIDEncoding to the provided
+// buffer.
+func WriteShortChanIDEncoding(buf *bytes.Buffer, e ShortChanIDEncoding) error {
+	return WriteUint8(buf, uint8(e))
+}
+
+// WriteFundingFlag appends the FundingFlag to the provided buffer.
+func WriteFundingFlag(buf *bytes.Buffer, flag FundingFlag) error {
+	return WriteUint8(buf, uint8(flag))
+}
+
+// WriteChanUpdateMsgFlags appends the update flag to the provided buffer.
+func WriteChanUpdateMsgFlags(buf *bytes.Buffer, f ChanUpdateMsgFlags) error {
+	return WriteUint8(buf, uint8(f))
+}
+
+// WriteChanUpdateChanFlags appends the update flag to the provided buffer.
+func WriteChanUpdateChanFlags(buf *bytes.Buffer, f ChanUpdateChanFlags) error {
+	return WriteUint8(buf, uint8(f))
+}
+
+// WriteDeliveryAddress appends the address to the provided buffer.
+func WriteDeliveryAddress(buf *bytes.Buffer, addr DeliveryAddress) error {
+	return writeDataWithLength(buf, addr)
+}
+
+// WritePingPayload appends the payload to the provided buffer.
+func WritePingPayload(buf *bytes.Buffer, payload PingPayload) error {
+	return writeDataWithLength(buf, payload)
+}
+
+// WritePongPayload appends the payload to the provided buffer.
+func WritePongPayload(buf *bytes.Buffer, payload PongPayload) error {
+	return writeDataWithLength(buf, payload)
+}
+
+// WriteErrorData appends the data to the provided buffer.
+func WriteErrorData(buf *bytes.Buffer, data ErrorData) error {
+	return writeDataWithLength(buf, data)
+}
+
+// WriteOpaqueReason appends the reason to the provided buffer.
+func WriteOpaqueReason(buf *bytes.Buffer, reason OpaqueReason) error {
+	return writeDataWithLength(buf, reason)
+}
+
+// WriteBool appends the boolean to the provided buffer.
+func WriteBool(buf *bytes.Buffer, b bool) error {
+	if b {
+		return WriteBytes(buf, []byte{1})
+	}
+	return WriteBytes(buf, []byte{0})
+}
+
+// WritePkScript appends the script to the provided buffer. Returns an error if
+// the provided script exceeds 34 bytes.
+//
+// Note: We intentionally skip the interfacer linter check here because we want
+// to have concrete type (bytes.Buffer) rather than interface type (io.Write)
+// due to performance concern.
+func WritePkScript(buf *bytes.Buffer, s PkScript) error { // nolint: interfacer
+	// The largest script we'll accept is a p2wsh which is exactly
+	// 34 bytes long.
+	scriptLength := len(s)
+	if scriptLength > 34 {
+		return ErrPkScriptTooLong
+	}
+
+	return wire.WriteVarBytes(buf, 0, s)
+}
+
+// WriteOutPoint appends the outpoint to the provided buffer.
+func WriteOutPoint(buf *bytes.Buffer, p wire.OutPoint) error {
+	// Before we write anything to the buffer, check the Index is sane.
+	if p.Index > math.MaxUint16 {
+		return ErrOutpointIndexTooBig(p.Index)
+	}
+
+	var h [32]byte
+	copy(h[:], p.Hash[:])
+	if _, err := buf.Write(h[:]); err != nil {
+		return err
+	}
+
+	// Write the index using two bytes.
+	return WriteUint16(buf, uint16(p.Index))
+}
+
+// WriteTCPAddr appends the TCP address to the provided buffer, either a IPv4
+// or a IPv6.
+func WriteTCPAddr(buf *bytes.Buffer, addr *net.TCPAddr) error {
+	if addr == nil {
+		return ErrNilTCPAddress
+	}
+
+	// Make a slice of bytes to hold the data of descriptor and ip. At
+	// most, we need 17 bytes - 1 byte for the descriptor, 16 bytes for
+	// IPv6.
+	data := make([]byte, 0, 17)
+
+	if addr.IP.To4() != nil {
+		data = append(data, uint8(tcp4Addr))
+		data = append(data, addr.IP.To4()...)
+	} else {
+		data = append(data, uint8(tcp6Addr))
+		data = append(data, addr.IP.To16()...)
+	}
+
+	if _, err := buf.Write(data); err != nil {
+		return err
+	}
+
+	return WriteUint16(buf, uint16(addr.Port))
+}
+
+// WriteOnionAddr appends the onion address to the provided buffer.
+func WriteOnionAddr(buf *bytes.Buffer, addr *tor.OnionAddr) error {
+	if addr == nil {
+		return ErrNilOnionAddress
+	}
+
+	var (
+		suffixIndex int
+		descriptor  []byte
+	)
+
+	// Decide the suffixIndex and descriptor.
+	switch len(addr.OnionService) {
+	case tor.V2Len:
+		descriptor = []byte{byte(v2OnionAddr)}
+		suffixIndex = tor.V2Len - tor.OnionSuffixLen
+
+	case tor.V3Len:
+		descriptor = []byte{byte(v3OnionAddr)}
+		suffixIndex = tor.V3Len - tor.OnionSuffixLen
+
+	default:
+		return ErrUnknownServiceLength
+	}
+
+	// Decode the address.
+	host, err := tor.Base32Encoding.DecodeString(
+		addr.OnionService[:suffixIndex],
+	)
+	if err != nil {
+		return err
+	}
+
+	// Perform the actual write when the above checks passed.
+	if _, err := buf.Write(descriptor); err != nil {
+		return err
+	}
+	if _, err := buf.Write(host); err != nil {
+		return err
+	}
+
+	return WriteUint16(buf, uint16(addr.Port))
+}
+
+// WriteNetAddrs appends a slice of addresses to the provided buffer with the
+// length info.
+func WriteNetAddrs(buf *bytes.Buffer, addresses []net.Addr) error {
+	// First, we'll encode all the addresses into an intermediate
+	// buffer. We need to do this in order to compute the total
+	// length of the addresses.
+	buffer := make([]byte, 0, MaxMsgBody)
+	addrBuf := bytes.NewBuffer(buffer)
+
+	for _, address := range addresses {
+		switch a := address.(type) {
+		case *net.TCPAddr:
+			if err := WriteTCPAddr(addrBuf, a); err != nil {
+				return err
+			}
+		case *tor.OnionAddr:
+			if err := WriteOnionAddr(addrBuf, a); err != nil {
+				return err
+			}
+		default:
+			return ErrNilNetAddress
+		}
+	}
+
+	// With the addresses fully encoded, we can now write out data.
+	return writeDataWithLength(buf, addrBuf.Bytes())
+}
+
+// writeDataWithLength writes the data and its length to the buffer.
+//
+// Note: We intentionally skip the interfacer linter check here because we want
+// to have concrete type (bytes.Buffer) rather than interface type (io.Write)
+// due to performance concern.
+func writeDataWithLength(buf *bytes.Buffer, // nolint: interfacer
+	data []byte) error {
+
+	var l [2]byte
+	binary.BigEndian.PutUint16(l[:], uint16(len(data)))
+	if _, err := buf.Write(l[:]); err != nil {
+		return err
+	}
+
+	_, err := buf.Write(data)
+	return err
+}

--- a/lnwire/writer_test.go
+++ b/lnwire/writer_test.go
@@ -1,0 +1,618 @@
+package lnwire
+
+import (
+	"bytes"
+	"encoding/base32"
+	"image/color"
+	"math"
+	"net"
+	"testing"
+
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"github.com/btcsuite/btcd/wire"
+	"github.com/btcsuite/btcutil"
+	"github.com/lightningnetwork/lnd/tor"
+	"github.com/stretchr/testify/require"
+)
+
+func TestWriteBytes(t *testing.T) {
+	buf := new(bytes.Buffer)
+	data := []byte{1, 2, 3}
+
+	err := WriteBytes(buf, data)
+
+	require.NoError(t, err)
+	require.Equal(t, data, buf.Bytes())
+}
+
+func TestWriteUint8(t *testing.T) {
+	buf := new(bytes.Buffer)
+	data := uint8(1)
+	expectedBytes := []byte{1}
+
+	err := WriteUint8(buf, data)
+
+	require.NoError(t, err)
+	require.Equal(t, expectedBytes, buf.Bytes())
+}
+
+func TestWriteUint16(t *testing.T) {
+	buf := new(bytes.Buffer)
+	data := uint16(1)
+	expectedBytes := []byte{0, 1}
+
+	err := WriteUint16(buf, data)
+
+	require.NoError(t, err)
+	require.Equal(t, expectedBytes, buf.Bytes())
+}
+
+func TestWriteUint32(t *testing.T) {
+	buf := new(bytes.Buffer)
+	data := uint32(1)
+	expectedBytes := []byte{0, 0, 0, 1}
+
+	err := WriteUint32(buf, data)
+
+	require.NoError(t, err)
+	require.Equal(t, expectedBytes, buf.Bytes())
+}
+
+func TestWriteUint64(t *testing.T) {
+	buf := new(bytes.Buffer)
+	data := uint64(1)
+	expectedBytes := []byte{0, 0, 0, 0, 0, 0, 0, 1}
+
+	err := WriteUint64(buf, data)
+
+	require.NoError(t, err)
+	require.Equal(t, expectedBytes, buf.Bytes())
+}
+
+func TestWriteSatoshi(t *testing.T) {
+	buf := new(bytes.Buffer)
+	data := btcutil.Amount(1)
+	expectedBytes := []byte{0, 0, 0, 0, 0, 0, 0, 1}
+
+	err := WriteSatoshi(buf, data)
+
+	require.NoError(t, err)
+	require.Equal(t, expectedBytes, buf.Bytes())
+}
+
+func TestWriteMilliSatoshi(t *testing.T) {
+	buf := new(bytes.Buffer)
+	data := MilliSatoshi(1)
+	expectedBytes := []byte{0, 0, 0, 0, 0, 0, 0, 1}
+
+	err := WriteMilliSatoshi(buf, data)
+
+	require.NoError(t, err)
+	require.Equal(t, expectedBytes, buf.Bytes())
+}
+
+func TestWritePublicKey(t *testing.T) {
+	buf := new(bytes.Buffer)
+
+	// Check that when nil pubkey is used, an error will return.
+	err := WritePublicKey(buf, nil)
+	require.Equal(t, ErrNilPublicKey, err)
+
+	pub, err := randPubKey()
+	require.NoError(t, err)
+	expectedBytes := pub.SerializeCompressed()
+
+	err = WritePublicKey(buf, pub)
+
+	require.NoError(t, err)
+	require.Equal(t, expectedBytes, buf.Bytes())
+}
+
+func TestWriteChannelID(t *testing.T) {
+	buf := new(bytes.Buffer)
+	data := ChannelID{1}
+	expectedBytes := [32]byte{1}
+
+	err := WriteChannelID(buf, data)
+
+	require.NoError(t, err)
+	require.Equal(t, expectedBytes[:], buf.Bytes())
+}
+
+func TestWriteNodeAlias(t *testing.T) {
+	buf := new(bytes.Buffer)
+	data := NodeAlias{1}
+	expectedBytes := [32]byte{1}
+
+	err := WriteNodeAlias(buf, data)
+
+	require.NoError(t, err)
+	require.Equal(t, expectedBytes[:], buf.Bytes())
+}
+
+func TestWriteShortChannelID(t *testing.T) {
+	buf := new(bytes.Buffer)
+	data := ShortChannelID{BlockHeight: 1, TxIndex: 2, TxPosition: 3}
+	expectedBytes := []byte{
+		0, 0, 1, // First three bytes encodes BlockHeight.
+		0, 0, 2, // Second three bytes encodes TxIndex.
+		0, 3, // Final two bytes encodes TxPosition.
+	}
+
+	err := WriteShortChannelID(buf, data)
+
+	require.NoError(t, err)
+	require.Equal(t, expectedBytes, buf.Bytes())
+}
+
+func TestWriteSig(t *testing.T) {
+	buf := new(bytes.Buffer)
+	data := Sig{1, 2, 3}
+	expectedBytes := [64]byte{1, 2, 3}
+
+	err := WriteSig(buf, data)
+
+	require.NoError(t, err)
+	require.Equal(t, expectedBytes[:], buf.Bytes())
+}
+
+func TestWriteSigs(t *testing.T) {
+	buf := new(bytes.Buffer)
+	sig1, sig2, sig3 := Sig{1}, Sig{2}, Sig{3}
+	data := []Sig{sig1, sig2, sig3}
+
+	// First two bytes encode the length of the slice.
+	expectedBytes := []byte{0, 3}
+	expectedBytes = append(expectedBytes, sig1[:]...)
+	expectedBytes = append(expectedBytes, sig2[:]...)
+	expectedBytes = append(expectedBytes, sig3[:]...)
+
+	err := WriteSigs(buf, data)
+
+	require.NoError(t, err)
+	require.Equal(t, expectedBytes, buf.Bytes())
+}
+
+func TestWriteFailCode(t *testing.T) {
+	buf := new(bytes.Buffer)
+	data := FailCode(1)
+	expectedBytes := []byte{0, 1}
+
+	err := WriteFailCode(buf, data)
+
+	require.NoError(t, err)
+	require.Equal(t, expectedBytes, buf.Bytes())
+}
+
+// TODO(yy): expand the test to cover more encoding scenarios.
+func TestWriteRawFeatureVector(t *testing.T) {
+	buf := new(bytes.Buffer)
+
+	// Check that when nil feature is used, an error will return.
+	err := WriteRawFeatureVector(buf, nil)
+	require.Equal(t, ErrNilFeatureVector, err)
+
+	// Create a raw feature vector.
+	feature := &RawFeatureVector{features: map[FeatureBit]bool{
+		InitialRoutingSync: true, // FeatureBit 3.
+	}}
+	expectedBytes := []byte{
+		0, 1, // First two bytes encode the length.
+		8, // Last byte encodes the feature bit (1 << 3).
+	}
+
+	err = WriteRawFeatureVector(buf, feature)
+	require.NoError(t, err)
+	require.Equal(t, expectedBytes, buf.Bytes())
+}
+
+func TestWriteColorRGBA(t *testing.T) {
+	buf := new(bytes.Buffer)
+	data := color.RGBA{R: 1, G: 2, B: 3}
+	expectedBytes := []byte{1, 2, 3}
+
+	err := WriteColorRGBA(buf, data)
+
+	require.NoError(t, err)
+	require.Equal(t, expectedBytes, buf.Bytes())
+}
+
+func TestWriteShortChanIDEncoding(t *testing.T) {
+	buf := new(bytes.Buffer)
+	data := ShortChanIDEncoding(1)
+	expectedBytes := []byte{1}
+
+	err := WriteShortChanIDEncoding(buf, data)
+
+	require.NoError(t, err)
+	require.Equal(t, expectedBytes, buf.Bytes())
+}
+
+func TestWriteFundingFlag(t *testing.T) {
+	buf := new(bytes.Buffer)
+	data := FundingFlag(1)
+	expectedBytes := []byte{1}
+
+	err := WriteFundingFlag(buf, data)
+
+	require.NoError(t, err)
+	require.Equal(t, expectedBytes, buf.Bytes())
+}
+
+func TestWriteChanUpdateMsgFlags(t *testing.T) {
+	buf := new(bytes.Buffer)
+	data := ChanUpdateMsgFlags(1)
+	expectedBytes := []byte{1}
+
+	err := WriteChanUpdateMsgFlags(buf, data)
+
+	require.NoError(t, err)
+	require.Equal(t, expectedBytes, buf.Bytes())
+}
+
+func TestWriteChanUpdateChanFlags(t *testing.T) {
+	buf := new(bytes.Buffer)
+	data := ChanUpdateChanFlags(1)
+	expectedBytes := []byte{1}
+
+	err := WriteChanUpdateChanFlags(buf, data)
+
+	require.NoError(t, err)
+	require.Equal(t, expectedBytes, buf.Bytes())
+}
+
+func TestWriteDeliveryAddress(t *testing.T) {
+	buf := new(bytes.Buffer)
+	data := DeliveryAddress{1, 1, 1}
+	expectedBytes := []byte{
+		0, 3, // First two bytes encode the length.
+		1, 1, 1, // The actual data.
+	}
+
+	err := WriteDeliveryAddress(buf, data)
+
+	require.NoError(t, err)
+	require.Equal(t, expectedBytes, buf.Bytes())
+}
+
+func TestWritePingPayload(t *testing.T) {
+	buf := new(bytes.Buffer)
+	data := PingPayload{1, 1, 1}
+	expectedBytes := []byte{
+		0, 3, // First two bytes encode the length.
+		1, 1, 1, // The actual data.
+	}
+
+	err := WritePingPayload(buf, data)
+
+	require.NoError(t, err)
+	require.Equal(t, expectedBytes, buf.Bytes())
+}
+
+func TestWritePongPayload(t *testing.T) {
+	buf := new(bytes.Buffer)
+	data := PongPayload{1, 1, 1}
+	expectedBytes := []byte{
+		0, 3, // First two bytes encode the length.
+		1, 1, 1, // The actual data.
+	}
+
+	err := WritePongPayload(buf, data)
+
+	require.NoError(t, err)
+	require.Equal(t, expectedBytes, buf.Bytes())
+}
+
+func TestWriteErrorData(t *testing.T) {
+	buf := new(bytes.Buffer)
+	data := ErrorData{1, 1, 1}
+	expectedBytes := []byte{
+		0, 3, // First two bytes encode the length.
+		1, 1, 1, // The actual data.
+	}
+
+	err := WriteErrorData(buf, data)
+
+	require.NoError(t, err)
+	require.Equal(t, expectedBytes, buf.Bytes())
+}
+
+func TestWriteOpaqueReason(t *testing.T) {
+	buf := new(bytes.Buffer)
+	data := OpaqueReason{1, 1, 1}
+	expectedBytes := []byte{
+		0, 3, // First two bytes encode the length.
+		1, 1, 1, // The actual data.
+	}
+
+	err := WriteOpaqueReason(buf, data)
+
+	require.NoError(t, err)
+	require.Equal(t, expectedBytes, buf.Bytes())
+}
+
+func TestWriteBool(t *testing.T) {
+	buf := new(bytes.Buffer)
+
+	// Test write true.
+	data := true
+	expectedBytes := []byte{1}
+
+	err := WriteBool(buf, data)
+
+	require.NoError(t, err)
+	require.Equal(t, expectedBytes, buf.Bytes())
+
+	// Test write false.
+	data = false
+	expectedBytes = append(expectedBytes, 0)
+
+	err = WriteBool(buf, data)
+
+	require.NoError(t, err)
+	require.Equal(t, expectedBytes, buf.Bytes())
+}
+
+func TestWritePkScript(t *testing.T) {
+	buf := new(bytes.Buffer)
+
+	// Write a very long script to check the error is returned as expected.
+	script := PkScript{}
+	zeros := [35]byte{}
+	script = append(script, zeros[:]...)
+	err := WritePkScript(buf, script)
+	require.Equal(t, ErrPkScriptTooLong, err)
+
+	data := PkScript{1, 1, 1}
+	expectedBytes := []byte{
+		3,       // First byte encodes the length.
+		1, 1, 1, // The actual data.
+	}
+
+	err = WritePkScript(buf, data)
+
+	require.NoError(t, err)
+	require.Equal(t, expectedBytes, buf.Bytes())
+}
+
+func TestWriteOutPoint(t *testing.T) {
+	buf := new(bytes.Buffer)
+
+	// Create an outpoint with very large index to check the error is
+	// returned as expected.
+	outpointWrong := wire.OutPoint{Index: math.MaxUint16 + 1}
+	err := WriteOutPoint(buf, outpointWrong)
+	require.Equal(t, ErrOutpointIndexTooBig(outpointWrong.Index), err)
+
+	// Now check the normal write succeeds.
+	hash := chainhash.Hash{1}
+	data := wire.OutPoint{Index: 2, Hash: hash}
+	expectedBytes := []byte{}
+	expectedBytes = append(expectedBytes, hash[:]...)
+	expectedBytes = append(expectedBytes, []byte{0, 2}...)
+
+	err = WriteOutPoint(buf, data)
+
+	require.NoError(t, err)
+	require.Equal(t, expectedBytes, buf.Bytes())
+}
+
+func TestWriteTCPAddr(t *testing.T) {
+	buf := new(bytes.Buffer)
+
+	testCases := []struct {
+		name string
+		addr *net.TCPAddr
+
+		expectedErr   error
+		expectedBytes []byte
+	}{
+		{
+			// Check that the error is returned when nil address is
+			// used.
+			name:          "nil address err",
+			addr:          nil,
+			expectedErr:   ErrNilTCPAddress,
+			expectedBytes: nil,
+		},
+		{
+			// Check write IPv4.
+			name: "write ipv4",
+			addr: &net.TCPAddr{
+				IP:   net.IP{127, 0, 0, 1},
+				Port: 8080,
+			},
+			expectedErr: nil,
+			expectedBytes: []byte{
+				0x1,                 // The addressType.
+				0x7f, 0x0, 0x0, 0x1, // The IP.
+				0x1f, 0x90, // The port (31 * 256 + 144).
+			},
+		},
+		{
+			// Check write IPv6.
+			name: "write ipv6",
+			addr: &net.TCPAddr{
+				IP: net.IP{
+					1, 1, 1, 1, 1, 1, 1, 1,
+					1, 1, 1, 1, 1, 1, 1, 1,
+				},
+				Port: 8080,
+			},
+			expectedErr: nil,
+			expectedBytes: []byte{
+				0x2, // The addressType.
+				// The IP.
+				0x1, 0x1, 0x1, 0x1, 0x1, 0x1, 0x1, 0x1,
+				0x1, 0x1, 0x1, 0x1, 0x1, 0x1, 0x1, 0x1,
+				0x1f, 0x90, // The port (31 * 256 + 144).
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			oldLen := buf.Len()
+
+			err := WriteTCPAddr(buf, tc.addr)
+			require.Equal(t, tc.expectedErr, err)
+
+			bytesWritten := buf.Bytes()[oldLen:buf.Len()]
+			require.Equal(t, tc.expectedBytes, bytesWritten)
+		})
+	}
+}
+
+func TestWriteOnionAddr(t *testing.T) {
+	buf := new(bytes.Buffer)
+
+	testCases := []struct {
+		name string
+		addr *tor.OnionAddr
+
+		expectedErr   error
+		expectedBytes []byte
+	}{
+		{
+			// Check that the error is returned when nil address is
+			// used.
+			name:          "nil address err",
+			addr:          nil,
+			expectedErr:   ErrNilOnionAddress,
+			expectedBytes: nil,
+		},
+		{
+			// Check the error is returned when an invalid onion
+			// address is used.
+			name:          "wrong onion service length",
+			addr:          &tor.OnionAddr{OnionService: "wrong"},
+			expectedErr:   ErrUnknownServiceLength,
+			expectedBytes: nil,
+		},
+		{
+			// Check when the address has invalid base32 encoding,
+			// the error is returned.
+			name: "invalid base32 encoding",
+			addr: &tor.OnionAddr{
+				OnionService: "1234567890123456.onion",
+			},
+			expectedErr:   base32.CorruptInputError(0),
+			expectedBytes: nil,
+		},
+		{
+			// Check write onion v2.
+			name: "onion address v2",
+			addr: &tor.OnionAddr{
+				OnionService: "abcdefghijklmnop.onion",
+				Port:         9065,
+			},
+			expectedErr: nil,
+			expectedBytes: []byte{
+				0x3,                         // The descriptor.
+				0x0, 0x44, 0x32, 0x14, 0xc7, // The host.
+				0x42, 0x54, 0xb6, 0x35, 0xcf,
+				0x23, 0x69, // The port.
+			},
+		},
+		{
+			// Check write onion v3.
+			name: "onion address v3",
+			addr: &tor.OnionAddr{
+				OnionService: "abcdefghij" +
+					"abcdefghijabcdefghij" +
+					"abcdefghijabcdefghij" +
+					"234567.onion",
+				Port: 9065,
+			},
+			expectedErr: nil,
+			expectedBytes: []byte{
+				0x4, // The descriptor.
+				0x0, 0x44, 0x32, 0x14, 0xc7, 0x42, 0x40,
+				0x11, 0xc, 0x85, 0x31, 0xd0, 0x90, 0x4,
+				0x43, 0x21, 0x4c, 0x74, 0x24, 0x1, 0x10,
+				0xc8, 0x53, 0x1d, 0x9, 0x0, 0x44, 0x32,
+				0x14, 0xc7, 0x42, 0x75, 0xbe, 0x77, 0xdf,
+				0x23, 0x69, // The port.
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			oldLen := buf.Len()
+
+			err := WriteOnionAddr(buf, tc.addr)
+			require.Equal(t, tc.expectedErr, err)
+
+			bytesWritten := buf.Bytes()[oldLen:buf.Len()]
+			require.Equal(t, tc.expectedBytes, bytesWritten)
+		})
+	}
+}
+
+func TestWriteNetAddrs(t *testing.T) {
+	buf := new(bytes.Buffer)
+	tcpAddr := &net.TCPAddr{
+		IP:   net.IP{127, 0, 0, 1},
+		Port: 8080,
+	}
+	onionAddr := &tor.OnionAddr{
+		OnionService: "abcdefghijklmnop.onion",
+		Port:         9065,
+	}
+
+	testCases := []struct {
+		name string
+		addr []net.Addr
+
+		expectedErr   error
+		expectedBytes []byte
+	}{
+		{
+			// Check that the error is returned when nil address is
+			// used.
+			name:          "nil address err",
+			addr:          []net.Addr{nil, tcpAddr, onionAddr},
+			expectedErr:   ErrNilNetAddress,
+			expectedBytes: nil,
+		},
+		{
+			// Check empty address slice.
+			name:        "empty address slice",
+			addr:        []net.Addr{},
+			expectedErr: nil,
+			// Use two bytes to encode the address size.
+			expectedBytes: []byte{0, 0},
+		},
+		{
+			// Check a successful writes of a slice of addresses.
+			name:        "two addresses",
+			addr:        []net.Addr{tcpAddr, onionAddr},
+			expectedErr: nil,
+			expectedBytes: []byte{
+				// 7 bytes for TCP and 13 bytes for onion.
+				0x0, 0x14,
+				// TCP address.
+				0x1, 0x7f, 0x0, 0x0, 0x1, 0x1f, 0x90,
+				// Onion address.
+				0x3, 0x0, 0x44, 0x32, 0x14, 0xc7, 0x42,
+				0x54, 0xb6, 0x35, 0xcf, 0x23, 0x69,
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			oldLen := buf.Len()
+
+			err := WriteNetAddrs(buf, tc.addr)
+			require.Equal(t, tc.expectedErr, err)
+
+			bytesWritten := buf.Bytes()[oldLen:buf.Len()]
+			require.Equal(t, tc.expectedBytes, bytesWritten)
+		})
+	}
+}

--- a/watchtower/wtwire/message.go
+++ b/watchtower/wtwire/message.go
@@ -5,8 +5,6 @@ import (
 	"encoding/binary"
 	"fmt"
 	"io"
-
-	"github.com/lightningnetwork/lnd/lnwire"
 )
 
 // MaxMessagePayload is the maximum bytes a message can be regardless of other
@@ -75,7 +73,14 @@ func (m MessageType) String() string {
 
 // Serializable is an interface which defines a lightning wire serializable
 // object.
-type Serializable = lnwire.Serializable
+type Serializable interface {
+	// Decode reads the bytes stream and converts it to the object.
+	Decode(io.Reader, uint32) error
+
+	// Encode converts object to the bytes stream and write it into the
+	// write buffer.
+	Encode(io.Writer, uint32) error
+}
 
 // Message is an interface that defines a lightning wire protocol message. The
 // interface is general in order to allow implementing types full control over


### PR DESCRIPTION
This PR is meant to fix #3004.

The overall optimization is done in three steps,
- change `WriteMessage` to use write buffer.
- change `Encode` and `WriteElement` to use write buffer.
- replace interface types with concrete types inside `Encode`.

The result,
```bash
name                                    old time/op    new time/op    delta
WriteMessage/Init-4                       3.62µs ±25%    2.29µs ±11%   -36.70%  (p=0.000 n=10+10)
WriteMessage/Error-4                      1.03µs ±10%    0.37µs ± 9%   -63.94%  (p=0.000 n=10+10)
WriteMessage/Ping-4                        977ns ±17%     352ns ± 7%   -63.98%  (p=0.000 n=10+10)
WriteMessage/Pong-4                        834ns ± 1%     336ns ± 3%   -59.72%  (p=0.000 n=8+10)
WriteMessage/MsgOpenChannel-4             3.54µs ± 0%    1.65µs ± 3%   -53.30%  (p=0.000 n=7+10)
WriteMessage/MsgAcceptChannel-4           3.03µs ± 4%    1.65µs ± 2%   -45.48%  (p=0.000 n=10+9)
WriteMessage/MsgFundingCreated-4          1.34µs ± 0%    0.36µs ± 1%   -73.36%  (p=0.000 n=6+10)
WriteMessage/MsgFundingSigned-4           1.26µs ± 3%    0.34µs ± 1%   -73.00%  (p=0.000 n=9+10)
WriteMessage/FundingLocked-4              1.21µs ± 1%    0.45µs ± 1%   -62.51%  (p=0.000 n=8+9)
WriteMessage/Shutdown-4                   1.01µs ± 1%    0.34µs ± 3%   -66.18%  (p=0.000 n=9+10)
WriteMessage/ClosingSigned-4              1.17µs ± 2%    0.37µs ± 3%   -68.86%  (p=0.000 n=10+10)
WriteMessage/UpdateAddHTLC-4              2.21µs ± 1%    0.38µs ± 1%   -82.71%  (p=0.000 n=8+8)
WriteMessage/UpdateFulfillHTLC-4          1.14µs ± 2%    0.33µs ± 0%   -70.66%  (p=0.000 n=9+9)
WriteMessage/UpdateFailHTLC-4             1.01µs ± 1%    0.35µs ± 2%   -65.60%  (p=0.000 n=10+10)
WriteMessage/CommitSig-4                  11.8µs ± 2%     1.4µs ± 1%   -88.00%  (p=0.000 n=9+9)
WriteMessage/RevokeAndAck-4               1.26µs ± 1%    0.47µs ± 2%   -63.02%  (p=0.000 n=9+9)
WriteMessage/UpdateFee-4                   960ns ± 1%     329ns ± 1%   -65.69%  (p=0.000 n=8+10)
WriteMessage/UpdateFailMalformedHTLC-4    1.19µs ± 1%    0.35µs ± 2%   -70.95%  (p=0.000 n=9+10)
WriteMessage/ChannelReestablish-4         1.34µs ± 1%    0.48µs ± 1%   -63.74%  (p=0.000 n=8+9)
WriteMessage/ChannelAnnouncement-4        3.01µs ± 1%    1.23µs ± 2%   -59.27%  (p=0.000 n=10+9)
WriteMessage/NodeAnnouncement-4           3.33µs ± 3%    2.99µs ± 1%   -10.37%  (p=0.000 n=9+9)
WriteMessage/ChannelUpdate-4              1.42µs ± 1%    0.43µs ± 9%   -69.71%  (p=0.000 n=9+9)
WriteMessage/AnnounceSignatures-4         1.45µs ± 7%    0.40µs ±12%   -72.19%  (p=0.000 n=9+10)
WriteMessage/QueryShortChanIDs-4           161µs ± 7%      75µs ± 2%   -53.30%  (p=0.000 n=9+10)
WriteMessage/ReplyShortChanIDsEnd-4        917ns ± 1%     326ns ± 1%   -64.41%  (p=0.000 n=9+9)
WriteMessage/QueryChannelRange-4           975ns ± 1%     337ns ± 1%   -65.49%  (p=0.000 n=8+9)
WriteMessage/ReplyChannelRange-4           145µs ± 1%      74µs ± 1%   -48.87%  (p=0.000 n=9+10)
WriteMessage/GossipTimestampRange-4       1.01µs ±10%    0.34µs ± 1%   -66.38%  (p=0.000 n=10+9)
WriteMessage/QueryShortChanIDs#01-4        712µs ±23%     408µs ± 3%   -42.65%  (p=0.000 n=10+10)
WriteMessage/ReplyChannelRange#01-4        681µs ± 3%     406µs ± 2%   -40.40%  (p=0.000 n=9+9)

name                                    old alloc/op   new alloc/op   delta
WriteMessage/Init-4                       1.33kB ± 0%    0.02kB ± 0%   -98.80%  (p=0.000 n=10+10)
WriteMessage/Error-4                      1.36kB ± 0%    0.00kB       -100.00%  (p=0.000 n=10+10)
WriteMessage/Ping-4                       1.30kB ± 0%    0.00kB       -100.00%  (p=0.000 n=10+10)
WriteMessage/Pong-4                       1.29kB ± 0%    0.00kB       -100.00%  (p=0.000 n=10+10)
WriteMessage/MsgOpenChannel-4             5.84kB ± 0%    1.75kB ± 0%   -70.00%  (p=0.000 n=10+10)
WriteMessage/MsgAcceptChannel-4           4.57kB ± 0%    1.75kB ± 0%   -61.65%  (p=0.000 n=9+10)
WriteMessage/MsgFundingCreated-4          1.82kB ± 0%    0.00kB       -100.00%  (p=0.000 n=10+10)
WriteMessage/MsgFundingSigned-4           1.95kB ± 0%    0.00kB       -100.00%  (p=0.000 n=10+10)
WriteMessage/FundingLocked-4              1.94kB ± 0%    0.08kB ± 0%   -95.87%  (p=0.000 n=10+10)
WriteMessage/Shutdown-4                   1.40kB ± 0%    0.00kB       -100.00%  (p=0.000 n=10+10)
WriteMessage/ClosingSigned-4              1.98kB ± 0%    0.00kB       -100.00%  (p=0.000 n=10+10)
WriteMessage/UpdateAddHTLC-4              7.14kB ± 0%    0.00kB       -100.00%  (p=0.000 n=10+10)
WriteMessage/UpdateFulfillHTLC-4          1.84kB ± 0%    0.00kB       -100.00%  (p=0.000 n=10+10)
WriteMessage/UpdateFailHTLC-4             1.40kB ± 0%    0.00kB       -100.00%  (p=0.000 n=10+10)
WriteMessage/CommitSig-4                  29.2kB ± 0%     0.0kB       -100.00%  (p=0.000 n=10+10)
WriteMessage/RevokeAndAck-4               1.96kB ± 0%    0.08kB ± 0%   -95.92%  (p=0.000 n=10+10)
WriteMessage/UpdateFee-4                  1.39kB ± 0%    0.00kB       -100.00%  (p=0.000 n=10+10)
WriteMessage/UpdateFailMalformedHTLC-4    1.85kB ± 0%    0.00kB       -100.00%  (p=0.000 n=10+10)
WriteMessage/ChannelReestablish-4         1.98kB ± 0%    0.08kB ± 0%   -95.97%  (p=0.000 n=10+10)
WriteMessage/ChannelAnnouncement-4        3.80kB ± 0%    0.01kB ± 0%   -99.79%  (p=0.000 n=10+10)
WriteMessage/NodeAnnouncement-4           3.16kB ± 0%    0.09kB ± 0%   -97.22%  (p=0.000 n=10+10)
WriteMessage/ChannelUpdate-4              1.95kB ± 0%    0.00kB       -100.00%  (p=0.000 n=10+10)
WriteMessage/AnnounceSignatures-4         2.11kB ± 0%    0.00kB       -100.00%  (p=0.000 n=10+10)
WriteMessage/QueryShortChanIDs-4          64.2kB ± 0%     0.1kB ± 1%   -99.86%  (p=0.000 n=10+10)
WriteMessage/ReplyShortChanIDsEnd-4       1.34kB ± 0%    0.00kB       -100.00%  (p=0.000 n=10+10)
WriteMessage/QueryChannelRange-4          1.36kB ± 0%    0.00kB       -100.00%  (p=0.000 n=10+10)
WriteMessage/ReplyChannelRange-4          64.2kB ± 0%     0.1kB ± 0%   -99.86%  (p=0.000 n=10+8)
WriteMessage/GossipTimestampRange-4       1.36kB ± 0%    0.00kB       -100.00%  (p=0.000 n=10+10)
WriteMessage/QueryShortChanIDs#01-4        876kB ± 0%     841kB ± 0%    -3.95%  (p=0.000 n=7+10)
WriteMessage/ReplyChannelRange#01-4        876kB ± 0%     841kB ± 0%    -3.95%  (p=0.000 n=9+10)

name                                    old allocs/op  new allocs/op  delta
WriteMessage/Init-4                         10.0 ± 0%       4.0 ± 0%   -60.00%  (p=0.000 n=10+10)
WriteMessage/Error-4                        8.00 ± 0%      0.00       -100.00%  (p=0.000 n=10+10)
WriteMessage/Ping-4                         8.00 ± 0%      0.00       -100.00%  (p=0.000 n=10+10)
WriteMessage/Pong-4                         6.00 ± 0%      0.00       -100.00%  (p=0.000 n=10+10)
WriteMessage/MsgOpenChannel-4               55.0 ± 0%      19.0 ± 0%   -65.45%  (p=0.000 n=10+10)
WriteMessage/MsgAcceptChannel-4             48.0 ± 0%      19.0 ± 0%   -60.42%  (p=0.000 n=10+10)
WriteMessage/MsgFundingCreated-4            13.0 ± 0%       0.0       -100.00%  (p=0.000 n=10+10)
WriteMessage/MsgFundingSigned-4             11.0 ± 0%       0.0       -100.00%  (p=0.000 n=10+10)
WriteMessage/FundingLocked-4                12.0 ± 0%       2.0 ± 0%   -83.33%  (p=0.000 n=10+10)
WriteMessage/Shutdown-4                     10.0 ± 0%       0.0       -100.00%  (p=0.000 n=10+10)
WriteMessage/ClosingSigned-4                13.0 ± 0%       0.0       -100.00%  (p=0.000 n=10+10)
WriteMessage/UpdateAddHTLC-4                18.0 ± 0%       0.0       -100.00%  (p=0.000 n=10+10)
WriteMessage/UpdateFulfillHTLC-4            12.0 ± 0%       0.0       -100.00%  (p=0.000 n=10+10)
WriteMessage/UpdateFailHTLC-4               11.0 ± 0%       0.0       -100.00%  (p=0.000 n=10+10)
WriteMessage/CommitSig-4                     217 ± 0%         0       -100.00%  (p=0.000 n=10+10)
WriteMessage/RevokeAndAck-4                 13.0 ± 0%       2.0 ± 0%   -84.62%  (p=0.000 n=10+10)
WriteMessage/UpdateFee-4                    10.0 ± 0%       0.0       -100.00%  (p=0.000 n=10+10)
WriteMessage/UpdateFailMalformedHTLC-4      15.0 ± 0%       0.0       -100.00%  (p=0.000 n=10+10)
WriteMessage/ChannelReestablish-4           17.0 ± 0%       2.0 ± 0%   -88.24%  (p=0.000 n=10+10)
WriteMessage/ChannelAnnouncement-4          31.0 ± 0%       2.0 ± 0%   -93.55%  (p=0.000 n=10+10)
WriteMessage/NodeAnnouncement-4             39.0 ± 0%       4.0 ± 0%   -89.74%  (p=0.000 n=10+10)
WriteMessage/ChannelUpdate-4                27.0 ± 0%       0.0       -100.00%  (p=0.000 n=10+10)
WriteMessage/AnnounceSignatures-4           17.0 ± 0%       0.0       -100.00%  (p=0.000 n=10+10)
WriteMessage/QueryShortChanIDs-4           4.02k ± 0%     0.00k ± 0%   -99.93%  (p=0.000 n=10+10)
WriteMessage/ReplyShortChanIDsEnd-4         8.00 ± 0%      0.00       -100.00%  (p=0.000 n=10+10)
WriteMessage/QueryChannelRange-4            11.0 ± 0%       0.0       -100.00%  (p=0.000 n=10+10)
WriteMessage/ReplyChannelRange-4           4.02k ± 0%     0.00k ± 0%   -99.93%  (p=0.000 n=10+10)
WriteMessage/GossipTimestampRange-4         11.0 ± 0%       0.0       -100.00%  (p=0.000 n=10+10)
WriteMessage/QueryShortChanIDs#01-4        4.04k ± 0%     0.03k ± 0%   -99.18%  (p=0.000 n=10+10)
WriteMessage/ReplyChannelRange#01-4        4.04k ± 0%     0.03k ± 0%   -99.18%  (p=0.000 n=10+10)
```

Top heap allocs,
```bash
(pprof) top
Showing nodes accounting for 79.53GB, 98.26% of 80.94GB total
Dropped 61 nodes (cum <= 0.40GB)
Showing top 10 nodes out of 39
      flat  flat%   sum%        cum   cum%
   37.77GB 46.66% 46.66%    45.84GB 56.64%  compress/flate.NewWriter
   15.61GB 19.28% 65.94%    17.82GB 22.02%  github.com/lightningnetwork/lnd/lnwire.packShutdownScript
    8.87GB 10.96% 76.91%    14.73GB 18.20%  github.com/btcsuite/btcd/btcec.(*PublicKey).SerializeCompressed
    7.84GB  9.69% 86.60%     7.84GB  9.69%  compress/flate.(*compressor).initDeflate (inline)
    5.86GB  7.24% 93.83%     5.86GB  7.24%  math/big.(*Int).Bytes (inline)
    1.57GB  1.94% 95.78%     1.57GB  1.94%  bytes.makeSlice
    0.88GB  1.08% 96.86%     2.45GB  3.03%  bytes.(*Buffer).grow
    0.66GB  0.81% 97.67%     1.98GB  2.45%  github.com/lightningnetwork/lnd/lnwire.(*ExtraOpaqueData).PackRecords
    0.46GB  0.57% 98.24%     0.46GB  0.57%  github.com/lightningnetwork/lnd/tlv.NewStream
    0.02GB 0.021% 98.26%    47.87GB 59.14%  github.com/lightningnetwork/lnd/lnwire.encodeShortChanIDs
```

### Build the benchmark
This first step is to build the benchmark for our optimization. Run the following commands to build the profiles. Notice that we need to run the bench test multiple times (I've chosen 10) to gather meaningful statistics for `benchstat` to analyze.

```bash
cd lnwire

gco 0c409c59

go test -run=^$ -bench=Write -count=10 -benchmem -memprofile=write-mem-base.prof -cpuprofile=write-cpu-base.prof -o lnwire-base.test | tee write-bench-base.prof
```

Now we can check the heap allocs using,

```bash
go tool pprof --sample_index=alloc_space lnwire-base.test write-mem-base.prof
```

And checking the heap escapes using `go build -gcflags "-m -m"`.


### First optimiztion - Using write buffer in `WriteMessage`

Run the following commands to gather stats.
```bash
gco e2a51cf2

go test -run=^$ -bench=Write -count=10 -benchmem -memprofile=write-mem-1.prof -cpuprofile=write-cpu-1.prof -o lnwire-1.test | tee write-bench-1.prof
```

See the improvement,

```bash
benchstat write-bench-base.prof write-bench-1.prof
```

```bash
name                                    old time/op    new time/op    delta
WriteMessage/Init-4                       3.62µs ±25%    2.36µs ± 5%  -34.81%  (p=0.000 n=10+8)
WriteMessage/Error-4                      1.03µs ±10%    0.53µs ±16%  -48.73%  (p=0.000 n=10+9)
WriteMessage/Ping-4                        977ns ±17%     709ns ±46%  -27.37%  (p=0.001 n=10+10)
WriteMessage/Pong-4                        834ns ± 1%     483ns ± 5%  -42.13%  (p=0.000 n=8+8)
WriteMessage/MsgOpenChannel-4             3.54µs ± 0%    3.05µs ±16%  -13.78%  (p=0.000 n=7+8)
WriteMessage/MsgAcceptChannel-4           3.03µs ± 4%    2.41µs ±13%  -20.72%  (p=0.000 n=10+10)
WriteMessage/MsgFundingCreated-4          1.34µs ± 0%    0.74µs ±12%  -44.88%  (p=0.000 n=6+9)
WriteMessage/MsgFundingSigned-4           1.26µs ± 3%    0.72µs ±24%  -42.60%  (p=0.000 n=9+10)
WriteMessage/FundingLocked-4              1.21µs ± 1%    0.82µs ±19%  -32.25%  (p=0.000 n=8+9)
WriteMessage/Shutdown-4                   1.01µs ± 1%    0.62µs ±10%  -38.19%  (p=0.000 n=9+10)
WriteMessage/ClosingSigned-4              1.17µs ± 2%    0.69µs ± 7%  -41.31%  (p=0.000 n=10+10)
WriteMessage/UpdateAddHTLC-4              2.21µs ± 1%    0.75µs ± 1%  -66.32%  (p=0.000 n=8+8)
WriteMessage/UpdateFulfillHTLC-4          1.14µs ± 2%    0.63µs ± 5%  -44.89%  (p=0.000 n=9+10)
WriteMessage/UpdateFailHTLC-4             1.01µs ± 1%    0.64µs ± 9%  -36.30%  (p=0.000 n=10+10)
WriteMessage/CommitSig-4                  11.8µs ± 2%     8.9µs ± 9%  -24.86%  (p=0.000 n=9+10)
WriteMessage/RevokeAndAck-4               1.26µs ± 1%    0.80µs ± 9%  -36.21%  (p=0.000 n=9+10)
WriteMessage/UpdateFee-4                   960ns ± 1%     626ns ±17%  -34.80%  (p=0.000 n=8+10)
WriteMessage/UpdateFailMalformedHTLC-4    1.19µs ± 1%    0.73µs ± 7%  -38.80%  (p=0.000 n=9+8)
WriteMessage/ChannelReestablish-4         1.34µs ± 1%    0.92µs ± 8%  -31.42%  (p=0.000 n=8+8)
WriteMessage/ChannelAnnouncement-4        3.01µs ± 1%    2.28µs ± 7%  -24.15%  (p=0.000 n=10+10)
WriteMessage/NodeAnnouncement-4           3.33µs ± 3%    2.53µs ± 0%  -24.01%  (p=0.000 n=9+8)
WriteMessage/ChannelUpdate-4              1.42µs ± 1%    0.95µs ± 6%  -32.92%  (p=0.000 n=9+10)
WriteMessage/AnnounceSignatures-4         1.45µs ± 7%    0.93µs ±11%  -35.66%  (p=0.000 n=9+8)
WriteMessage/QueryShortChanIDs-4           161µs ± 7%     155µs ±12%     ~     (p=0.400 n=9+10)
WriteMessage/ReplyShortChanIDsEnd-4        917ns ± 1%     630ns ±21%  -31.24%  (p=0.000 n=9+10)
WriteMessage/QueryChannelRange-4           975ns ± 1%     655ns ±11%  -32.82%  (p=0.000 n=8+9)
WriteMessage/ReplyChannelRange-4           145µs ± 1%     146µs ± 9%     ~     (p=1.000 n=9+9)
WriteMessage/GossipTimestampRange-4       1.01µs ±10%    0.58µs ± 4%  -42.41%  (p=0.000 n=10+8)
WriteMessage/QueryShortChanIDs#01-4        712µs ±23%     762µs ± 4%     ~     (p=0.122 n=10+8)
WriteMessage/ReplyChannelRange#01-4        681µs ± 3%     600µs ±10%  -11.81%  (p=0.000 n=9+10)

name                                    old alloc/op   new alloc/op   delta
WriteMessage/Init-4                       1.33kB ± 0%    0.06kB ± 0%  -95.18%  (p=0.000 n=10+10)
WriteMessage/Error-4                      1.36kB ± 0%    0.09kB ± 0%  -93.36%  (p=0.000 n=10+10)
WriteMessage/Ping-4                       1.30kB ± 0%    0.03kB ± 0%  -97.69%  (p=0.000 n=10+10)
WriteMessage/Pong-4                       1.29kB ± 0%    0.03kB ± 0%  -97.99%  (p=0.000 n=10+10)
WriteMessage/MsgOpenChannel-4             5.84kB ± 0%    2.26kB ± 0%  -61.37%  (p=0.000 n=10+10)
WriteMessage/MsgAcceptChannel-4           4.57kB ± 0%    2.19kB ± 0%  -52.01%  (p=0.000 n=9+10)
WriteMessage/MsgFundingCreated-4          1.82kB ± 0%    0.28kB ± 0%  -84.51%  (p=0.000 n=10+10)
WriteMessage/MsgFundingSigned-4           1.95kB ± 0%    0.24kB ± 0%  -87.72%  (p=0.000 n=10+10)
WriteMessage/FundingLocked-4              1.94kB ± 0%    0.24kB ± 0%  -87.62%  (p=0.000 n=10+10)
WriteMessage/Shutdown-4                   1.40kB ± 0%    0.14kB ± 0%  -90.17%  (p=0.000 n=10+10)
WriteMessage/ClosingSigned-4              1.98kB ± 0%    0.26kB ± 0%  -87.04%  (p=0.000 n=10+10)
WriteMessage/UpdateAddHTLC-4              7.14kB ± 0%    0.21kB ± 0%  -97.09%  (p=0.000 n=10+10)
WriteMessage/UpdateFulfillHTLC-4          1.84kB ± 0%    0.15kB ± 0%  -91.74%  (p=0.000 n=10+10)
WriteMessage/UpdateFailHTLC-4             1.40kB ± 0%    0.14kB ± 0%  -90.29%  (p=0.000 n=10+10)
WriteMessage/CommitSig-4                  29.2kB ± 0%    13.1kB ± 0%  -55.22%  (p=0.000 n=10+10)
WriteMessage/RevokeAndAck-4               1.96kB ± 0%    0.26kB ± 0%  -86.54%  (p=0.000 n=10+10)
WriteMessage/UpdateFee-4                  1.39kB ± 0%    0.12kB ± 0%  -91.35%  (p=0.000 n=10+10)
WriteMessage/UpdateFailMalformedHTLC-4    1.85kB ± 0%    0.17kB ± 0%  -90.91%  (p=0.000 n=10+10)
WriteMessage/ChannelReestablish-4         1.98kB ± 0%    0.30kB ± 0%  -85.08%  (p=0.000 n=10+10)
WriteMessage/ChannelAnnouncement-4        3.80kB ± 0%    1.00kB ± 0%  -73.68%  (p=0.000 n=10+10)
WriteMessage/NodeAnnouncement-4           3.16kB ± 0%    0.79kB ± 0%  -75.06%  (p=0.000 n=10+10)
WriteMessage/ChannelUpdate-4              1.95kB ± 0%    0.27kB ± 0%  -86.07%  (p=0.000 n=10+10)
WriteMessage/AnnounceSignatures-4         2.11kB ± 0%    0.39kB ± 0%  -81.29%  (p=0.000 n=10+10)
WriteMessage/QueryShortChanIDs-4          64.2kB ± 0%    26.8kB ± 0%  -58.21%  (p=0.000 n=10+10)
WriteMessage/ReplyShortChanIDsEnd-4       1.34kB ± 0%    0.07kB ± 0%  -94.55%  (p=0.000 n=10+10)
WriteMessage/QueryChannelRange-4          1.36kB ± 0%    0.09kB ± 0%  -93.51%  (p=0.000 n=10+10)
WriteMessage/ReplyChannelRange-4          64.2kB ± 0%    26.8kB ± 0%  -58.20%  (p=0.000 n=10+10)
WriteMessage/GossipTimestampRange-4       1.36kB ± 0%    0.09kB ± 0%  -93.51%  (p=0.000 n=10+10)
WriteMessage/QueryShortChanIDs#01-4        876kB ± 0%     849kB ± 0%   -3.05%  (p=0.000 n=7+10)
WriteMessage/ReplyChannelRange#01-4        876kB ± 0%     849kB ± 0%   -3.05%  (p=0.000 n=9+10)

name                                    old allocs/op  new allocs/op  delta
WriteMessage/Init-4                         10.0 ± 0%       6.0 ± 0%  -40.00%  (p=0.000 n=10+10)
WriteMessage/Error-4                        8.00 ± 0%      4.00 ± 0%  -50.00%  (p=0.000 n=10+10)
WriteMessage/Ping-4                         8.00 ± 0%      4.00 ± 0%  -50.00%  (p=0.000 n=10+10)
WriteMessage/Pong-4                         6.00 ± 0%      2.00 ± 0%  -66.67%  (p=0.000 n=10+10)
WriteMessage/MsgOpenChannel-4               55.0 ± 0%      48.0 ± 0%  -12.73%  (p=0.000 n=10+10)
WriteMessage/MsgAcceptChannel-4             48.0 ± 0%      42.0 ± 0%  -12.50%  (p=0.000 n=10+10)
WriteMessage/MsgFundingCreated-4            13.0 ± 0%       8.0 ± 0%  -38.46%  (p=0.000 n=10+10)
WriteMessage/MsgFundingSigned-4             11.0 ± 0%       6.0 ± 0%  -45.45%  (p=0.000 n=10+10)
WriteMessage/FundingLocked-4                12.0 ± 0%       7.0 ± 0%  -41.67%  (p=0.000 n=10+10)
WriteMessage/Shutdown-4                     10.0 ± 0%       6.0 ± 0%  -40.00%  (p=0.000 n=10+10)
WriteMessage/ClosingSigned-4                13.0 ± 0%       8.0 ± 0%  -38.46%  (p=0.000 n=10+10)
WriteMessage/UpdateAddHTLC-4                18.0 ± 0%      12.0 ± 0%  -33.33%  (p=0.000 n=10+10)
WriteMessage/UpdateFulfillHTLC-4            12.0 ± 0%       7.0 ± 0%  -41.67%  (p=0.000 n=10+10)
WriteMessage/UpdateFailHTLC-4               11.0 ± 0%       7.0 ± 0%  -36.36%  (p=0.000 n=10+10)
WriteMessage/CommitSig-4                     217 ± 0%       208 ± 0%   -4.15%  (p=0.000 n=10+10)
WriteMessage/RevokeAndAck-4                 13.0 ± 0%       8.0 ± 0%  -38.46%  (p=0.000 n=10+10)
WriteMessage/UpdateFee-4                    10.0 ± 0%       6.0 ± 0%  -40.00%  (p=0.000 n=10+10)
WriteMessage/UpdateFailMalformedHTLC-4      15.0 ± 0%      10.0 ± 0%  -33.33%  (p=0.000 n=10+10)
WriteMessage/ChannelReestablish-4           17.0 ± 0%      12.0 ± 0%  -29.41%  (p=0.000 n=10+10)
WriteMessage/ChannelAnnouncement-4          31.0 ± 0%      25.0 ± 0%  -19.35%  (p=0.000 n=10+10)
WriteMessage/NodeAnnouncement-4             39.0 ± 0%      33.0 ± 0%  -15.38%  (p=0.000 n=10+10)
WriteMessage/ChannelUpdate-4                27.0 ± 0%      22.0 ± 0%  -18.52%  (p=0.000 n=10+10)
WriteMessage/AnnounceSignatures-4           17.0 ± 0%      12.0 ± 0%  -29.41%  (p=0.000 n=10+10)
WriteMessage/QueryShortChanIDs-4           4.02k ± 0%     4.01k ± 0%   -0.27%  (p=0.000 n=10+10)
WriteMessage/ReplyShortChanIDsEnd-4         8.00 ± 0%      4.00 ± 0%  -50.00%  (p=0.000 n=10+10)
WriteMessage/QueryChannelRange-4            11.0 ± 0%       7.0 ± 0%  -36.36%  (p=0.000 n=10+10)
WriteMessage/ReplyChannelRange-4           4.02k ± 0%     4.01k ± 0%   -0.27%  (p=0.000 n=10+10)
WriteMessage/GossipTimestampRange-4         11.0 ± 0%       7.0 ± 0%  -36.36%  (p=0.000 n=10+10)
WriteMessage/QueryShortChanIDs#01-4        4.04k ± 0%     4.03k ± 0%   -0.12%  (p=0.000 n=10+10)
WriteMessage/ReplyChannelRange#01-4        4.04k ± 0%     4.03k ± 0%   -0.12%  (p=0.000 n=10+10)
```


### Second optimiztion - Using write buffer in `Encode`

Run the following commands to gather stats.
```bash
gco 7c0e6d4b

go test -run=^$ -bench=Write -count=10 -benchmem -memprofile=write-mem-2.prof -cpuprofile=write-cpu-2.prof -o lnwire-2.test | tee write-bench-2.prof
```

See incremental gain,
```bash
benchstat write-bench-1.prof write-bench-2.prof
```
```bash
name                                    old time/op    new time/op    delta
WriteMessage/Init-4                       2.36µs ± 5%    2.65µs ±31%     ~     (p=0.068 n=8+10)
WriteMessage/Error-4                       526ns ±16%     564ns ±11%   +7.21%  (p=0.043 n=9+10)
WriteMessage/Ping-4                        709ns ±46%     479ns ± 9%  -32.45%  (p=0.000 n=10+10)
WriteMessage/Pong-4                        483ns ± 5%     535ns ±25%     ~     (p=0.074 n=8+9)
WriteMessage/MsgOpenChannel-4             3.05µs ±16%    2.31µs ±26%  -24.41%  (p=0.000 n=8+9)
WriteMessage/MsgAcceptChannel-4           2.41µs ±13%    1.96µs ± 1%  -18.43%  (p=0.000 n=10+9)
WriteMessage/MsgFundingCreated-4           737ns ±12%     843ns ±33%     ~     (p=1.000 n=9+10)
WriteMessage/MsgFundingSigned-4            722ns ±24%     615ns ±11%  -14.75%  (p=0.002 n=10+8)
WriteMessage/FundingLocked-4               817ns ±19%     682ns ±15%  -16.52%  (p=0.000 n=9+10)
WriteMessage/Shutdown-4                    622ns ±10%     548ns ±10%  -12.01%  (p=0.000 n=10+10)
WriteMessage/ClosingSigned-4               689ns ± 7%     624ns ±16%   -9.41%  (p=0.015 n=10+10)
WriteMessage/UpdateAddHTLC-4               746ns ± 1%     708ns ± 8%   -5.09%  (p=0.006 n=8+9)
WriteMessage/UpdateFulfillHTLC-4           629ns ± 5%     591ns ± 3%   -6.04%  (p=0.000 n=10+10)
WriteMessage/UpdateFailHTLC-4              641ns ± 9%     562ns ± 7%  -12.32%  (p=0.000 n=10+10)
WriteMessage/CommitSig-4                  8.89µs ± 9%    5.02µs ± 2%  -43.51%  (p=0.000 n=10+9)
WriteMessage/RevokeAndAck-4                802ns ± 9%     710ns ± 9%  -11.47%  (p=0.000 n=10+10)
WriteMessage/UpdateFee-4                   626ns ±17%     528ns ± 5%  -15.66%  (p=0.000 n=10+10)
WriteMessage/UpdateFailMalformedHTLC-4     728ns ± 7%     621ns ± 2%  -14.76%  (p=0.000 n=8+8)
WriteMessage/ChannelReestablish-4          917ns ± 8%     736ns ± 9%  -19.73%  (p=0.000 n=8+10)
WriteMessage/ChannelAnnouncement-4        2.28µs ± 7%    1.77µs ± 1%  -22.47%  (p=0.000 n=10+9)
WriteMessage/NodeAnnouncement-4           2.53µs ± 0%    2.35µs ± 9%   -7.01%  (p=0.033 n=8+10)
WriteMessage/ChannelUpdate-4               950ns ± 6%     738ns ± 1%  -22.32%  (p=0.000 n=10+9)
WriteMessage/AnnounceSignatures-4          930ns ±11%     659ns ±14%  -29.15%  (p=0.000 n=8+10)
WriteMessage/QueryShortChanIDs-4           155µs ±12%     105µs ±13%  -32.56%  (p=0.000 n=10+10)
WriteMessage/ReplyShortChanIDsEnd-4        630ns ±21%     702ns ±47%     ~     (p=0.529 n=10+10)
WriteMessage/QueryChannelRange-4           655ns ±11%     845ns ±40%     ~     (p=0.133 n=9+10)
WriteMessage/ReplyChannelRange-4           146µs ± 9%     135µs ±40%     ~     (p=0.243 n=9+10)
WriteMessage/GossipTimestampRange-4        584ns ± 4%     553ns ± 6%   -5.22%  (p=0.001 n=8+10)
WriteMessage/QueryShortChanIDs#01-4        762µs ± 4%     466µs ± 3%  -38.92%  (p=0.000 n=8+8)
WriteMessage/ReplyChannelRange#01-4        600µs ±10%     632µs ±26%     ~     (p=0.720 n=10+9)

name                                    old alloc/op   new alloc/op   delta
WriteMessage/Init-4                        64.0B ± 0%     64.0B ± 0%     ~     (all equal)
WriteMessage/Error-4                       90.0B ± 0%     56.0B ± 0%  -37.78%  (p=0.000 n=10+10)
WriteMessage/Ping-4                        30.0B ± 0%     26.0B ± 0%  -13.33%  (p=0.000 n=10+10)
WriteMessage/Pong-4                        26.0B ± 0%     24.0B ± 0%   -7.69%  (p=0.000 n=10+10)
WriteMessage/MsgOpenChannel-4             2.26kB ± 0%    1.90kB ± 0%  -15.60%  (p=0.000 n=10+10)
WriteMessage/MsgAcceptChannel-4           2.19kB ± 0%    1.86kB ± 0%  -14.96%  (p=0.000 n=10+10)
WriteMessage/MsgFundingCreated-4            282B ± 0%      184B ± 0%  -34.75%  (p=0.000 n=10+10)
WriteMessage/MsgFundingSigned-4             240B ± 0%      144B ± 0%  -40.00%  (p=0.000 n=10+10)
WriteMessage/FundingLocked-4                240B ± 0%      160B ± 0%  -33.33%  (p=0.000 n=10+10)
WriteMessage/Shutdown-4                     138B ± 0%      104B ± 0%  -24.64%  (p=0.000 n=10+10)
WriteMessage/ClosingSigned-4                256B ± 0%      152B ± 0%  -40.62%  (p=0.000 n=10+10)
WriteMessage/UpdateAddHTLC-4                208B ± 0%      152B ± 0%  -26.92%  (p=0.000 n=10+10)
WriteMessage/UpdateFulfillHTLC-4            152B ± 0%      112B ± 0%  -26.32%  (p=0.000 n=10+10)
WriteMessage/UpdateFailHTLC-4               136B ± 0%       88B ± 0%  -35.29%  (p=0.000 n=10+10)
WriteMessage/CommitSig-4                  13.1kB ± 0%     6.6kB ± 0%  -49.74%  (p=0.000 n=10+10)
WriteMessage/RevokeAndAck-4                 264B ± 0%      184B ± 0%  -30.30%  (p=0.000 n=10+10)
WriteMessage/UpdateFee-4                    120B ± 0%       84B ± 0%  -30.00%  (p=0.000 n=10+10)
WriteMessage/UpdateFailMalformedHTLC-4      168B ± 0%      120B ± 0%  -28.57%  (p=0.000 n=10+10)
WriteMessage/ChannelReestablish-4           296B ± 0%      200B ± 0%  -32.43%  (p=0.000 n=10+10)
WriteMessage/ChannelAnnouncement-4        1.00kB ± 0%    0.54kB ± 0%  -45.90%  (p=0.000 n=10+10)
WriteMessage/NodeAnnouncement-4             788B ± 0%      600B ± 0%  -23.86%  (p=0.000 n=10+10)
WriteMessage/ChannelUpdate-4                272B ± 0%      160B ± 0%  -41.18%  (p=0.000 n=10+10)
WriteMessage/AnnounceSignatures-4           394B ± 0%      224B ± 0%  -43.15%  (p=0.000 n=10+10)
WriteMessage/QueryShortChanIDs-4          26.8kB ± 0%    16.1kB ± 0%  -39.81%  (p=0.000 n=10+10)
WriteMessage/ReplyShortChanIDsEnd-4        73.0B ± 0%     72.0B ± 0%   -1.37%  (p=0.000 n=10+10)
WriteMessage/QueryChannelRange-4           88.0B ± 0%     80.0B ± 0%   -9.09%  (p=0.000 n=10+10)
WriteMessage/ReplyChannelRange-4          26.8kB ± 0%    16.1kB ± 0%  -39.83%  (p=0.000 n=10+9)
WriteMessage/GossipTimestampRange-4        88.0B ± 0%     80.0B ± 0%   -9.09%  (p=0.000 n=10+10)
WriteMessage/QueryShortChanIDs#01-4        849kB ± 0%     857kB ± 0%   +0.97%  (p=0.000 n=10+10)
WriteMessage/ReplyChannelRange#01-4        849kB ± 0%     857kB ± 0%   +0.97%  (p=0.000 n=10+10)

name                                    old allocs/op  new allocs/op  delta
WriteMessage/Init-4                         6.00 ± 0%      6.00 ± 0%     ~     (all equal)
WriteMessage/Error-4                        4.00 ± 0%      2.00 ± 0%  -50.00%  (p=0.000 n=10+10)
WriteMessage/Ping-4                         4.00 ± 0%      2.00 ± 0%  -50.00%  (p=0.000 n=10+10)
WriteMessage/Pong-4                         2.00 ± 0%      1.00 ± 0%  -50.00%  (p=0.000 n=10+10)
WriteMessage/MsgOpenChannel-4               48.0 ± 0%      32.0 ± 0%  -33.33%  (p=0.000 n=10+10)
WriteMessage/MsgAcceptChannel-4             42.0 ± 0%      29.0 ± 0%  -30.95%  (p=0.000 n=10+10)
WriteMessage/MsgFundingCreated-4            8.00 ± 0%      5.00 ± 0%  -37.50%  (p=0.000 n=10+10)
WriteMessage/MsgFundingSigned-4             6.00 ± 0%      4.00 ± 0%  -33.33%  (p=0.000 n=10+10)
WriteMessage/FundingLocked-4                7.00 ± 0%      5.00 ± 0%  -28.57%  (p=0.000 n=10+10)
WriteMessage/Shutdown-4                     6.00 ± 0%      4.00 ± 0%  -33.33%  (p=0.000 n=10+10)
WriteMessage/ClosingSigned-4                8.00 ± 0%      5.00 ± 0%  -37.50%  (p=0.000 n=10+10)
WriteMessage/UpdateAddHTLC-4                12.0 ± 0%       8.0 ± 0%  -33.33%  (p=0.000 n=10+10)
WriteMessage/UpdateFulfillHTLC-4            7.00 ± 0%      5.00 ± 0%  -28.57%  (p=0.000 n=10+10)
WriteMessage/UpdateFailHTLC-4               7.00 ± 0%      4.00 ± 0%  -42.86%  (p=0.000 n=10+10)
WriteMessage/CommitSig-4                     208 ± 0%       105 ± 0%  -49.52%  (p=0.000 n=10+10)
WriteMessage/RevokeAndAck-4                 8.00 ± 0%      6.00 ± 0%  -25.00%  (p=0.000 n=10+10)
WriteMessage/UpdateFee-4                    6.00 ± 0%      4.00 ± 0%  -33.33%  (p=0.000 n=10+10)
WriteMessage/UpdateFailMalformedHTLC-4      10.0 ± 0%       7.0 ± 0%  -30.00%  (p=0.000 n=10+10)
WriteMessage/ChannelReestablish-4           12.0 ± 0%       8.0 ± 0%  -33.33%  (p=0.000 n=10+10)
WriteMessage/ChannelAnnouncement-4          25.0 ± 0%      14.0 ± 0%  -44.00%  (p=0.000 n=10+10)
WriteMessage/NodeAnnouncement-4             33.0 ± 0%      15.0 ± 0%  -54.55%  (p=0.000 n=10+10)
WriteMessage/ChannelUpdate-4                22.0 ± 0%      10.0 ± 0%  -54.55%  (p=0.000 n=10+10)
WriteMessage/AnnounceSignatures-4           12.0 ± 0%       6.0 ± 0%  -50.00%  (p=0.000 n=10+10)
WriteMessage/QueryShortChanIDs-4           4.01k ± 0%     1.01k ± 0%  -74.90%  (p=0.000 n=10+10)
WriteMessage/ReplyShortChanIDsEnd-4         4.00 ± 0%      3.00 ± 0%  -25.00%  (p=0.000 n=10+10)
WriteMessage/QueryChannelRange-4            7.00 ± 0%      5.00 ± 0%  -28.57%  (p=0.000 n=10+10)
WriteMessage/ReplyChannelRange-4           4.01k ± 0%     1.01k ± 0%  -74.92%  (p=0.000 n=10+10)
WriteMessage/GossipTimestampRange-4         7.00 ± 0%      5.00 ± 0%  -28.57%  (p=0.000 n=10+10)
WriteMessage/QueryShortChanIDs#01-4        4.03k ± 0%     1.04k ± 0%  -74.27%  (p=0.000 n=10+10)
WriteMessage/ReplyChannelRange#01-4        4.03k ± 0%     1.04k ± 0%  -74.29%  (p=0.000 n=10+10)
```

You can also view overall gain using,
```bash
benchstat write-bench-base.prof write-bench-2.prof
```


### Third optimiztion - Using concrete types in `Encode`

Run the following commands to gather stats.

```bash
gco c4ad0e33

go test -run=^$ -bench=Write -count=10 -benchmem -memprofile=write-mem-final.prof -cpuprofile=write-cpu-final.prof -o lnwire-final.test | tee write-bench-final.prof
```

```bash
go tool pprof --sample_index=alloc_space lnwire-final.test write-mem-final.prof
```

Check the incremental gain using,
```bash
benchstat write-bench-2.prof write-bench-final.prof
```

```bash
name                                    old time/op    new time/op    delta
WriteMessage/Init-4                       2.65µs ±31%    2.29µs ±11%   -13.57%  (p=0.007 n=10+10)
WriteMessage/Error-4                       564ns ±11%     370ns ± 9%   -34.39%  (p=0.000 n=10+10)
WriteMessage/Ping-4                        479ns ± 9%     352ns ± 7%   -26.57%  (p=0.000 n=10+10)
WriteMessage/Pong-4                        535ns ±25%     336ns ± 3%   -37.17%  (p=0.000 n=9+10)
WriteMessage/MsgOpenChannel-4             2.31µs ±26%    1.65µs ± 3%   -28.36%  (p=0.000 n=9+10)
WriteMessage/MsgAcceptChannel-4           1.96µs ± 1%    1.65µs ± 2%   -15.68%  (p=0.000 n=9+9)
WriteMessage/MsgFundingCreated-4           843ns ±33%     356ns ± 1%   -57.73%  (p=0.000 n=10+10)
WriteMessage/MsgFundingSigned-4            615ns ±11%     339ns ± 1%   -44.82%  (p=0.000 n=8+10)
WriteMessage/FundingLocked-4               682ns ±15%     452ns ± 1%   -33.72%  (p=0.000 n=10+9)
WriteMessage/Shutdown-4                    548ns ±10%     341ns ± 3%   -37.80%  (p=0.000 n=10+10)
WriteMessage/ClosingSigned-4               624ns ±16%     366ns ± 3%   -41.42%  (p=0.000 n=10+10)
WriteMessage/UpdateAddHTLC-4               708ns ± 8%     383ns ± 1%   -45.90%  (p=0.000 n=9+8)
WriteMessage/UpdateFulfillHTLC-4           591ns ± 3%     335ns ± 0%   -43.34%  (p=0.000 n=10+9)
WriteMessage/UpdateFailHTLC-4              562ns ± 7%     346ns ± 2%   -38.41%  (p=0.000 n=10+10)
WriteMessage/CommitSig-4                  5.02µs ± 2%    1.42µs ± 1%   -71.74%  (p=0.000 n=9+9)
WriteMessage/RevokeAndAck-4                710ns ± 9%     465ns ± 2%   -34.52%  (p=0.000 n=10+9)
WriteMessage/UpdateFee-4                   528ns ± 5%     329ns ± 1%   -37.60%  (p=0.000 n=10+10)
WriteMessage/UpdateFailMalformedHTLC-4     621ns ± 2%     346ns ± 2%   -44.32%  (p=0.000 n=8+10)
WriteMessage/ChannelReestablish-4          736ns ± 9%     485ns ± 1%   -34.13%  (p=0.000 n=10+9)
WriteMessage/ChannelAnnouncement-4        1.77µs ± 1%    1.23µs ± 2%   -30.74%  (p=0.000 n=9+9)
WriteMessage/NodeAnnouncement-4           2.35µs ± 9%    2.99µs ± 1%   +26.83%  (p=0.000 n=10+9)
WriteMessage/ChannelUpdate-4               738ns ± 1%     429ns ± 9%   -41.87%  (p=0.000 n=9+9)
WriteMessage/AnnounceSignatures-4          659ns ±14%     402ns ±12%   -38.98%  (p=0.000 n=10+10)
WriteMessage/QueryShortChanIDs-4           105µs ±13%      75µs ± 2%   -28.28%  (p=0.000 n=10+10)
WriteMessage/ReplyShortChanIDsEnd-4        702ns ±47%     326ns ± 1%   -53.51%  (p=0.000 n=10+9)
WriteMessage/QueryChannelRange-4           845ns ±40%     337ns ± 1%   -60.18%  (p=0.000 n=10+9)
WriteMessage/ReplyChannelRange-4           135µs ±40%      74µs ± 1%   -44.88%  (p=0.000 n=10+10)
WriteMessage/GossipTimestampRange-4        553ns ± 6%     341ns ± 1%   -38.41%  (p=0.000 n=10+9)
WriteMessage/QueryShortChanIDs#01-4        466µs ± 3%     408µs ± 3%   -12.34%  (p=0.000 n=8+10)
WriteMessage/ReplyChannelRange#01-4        632µs ±26%     406µs ± 2%   -35.81%  (p=0.000 n=9+9)

name                                    old alloc/op   new alloc/op   delta
WriteMessage/Init-4                        64.0B ± 0%     16.0B ± 0%   -75.00%  (p=0.000 n=10+10)
WriteMessage/Error-4                       56.0B ± 0%      0.0B       -100.00%  (p=0.000 n=10+10)
WriteMessage/Ping-4                        26.0B ± 0%      0.0B       -100.00%  (p=0.000 n=10+10)
WriteMessage/Pong-4                        24.0B ± 0%      0.0B       -100.00%  (p=0.000 n=10+10)
WriteMessage/MsgOpenChannel-4             1.90kB ± 0%    1.75kB ± 0%    -7.98%  (p=0.000 n=10+10)
WriteMessage/MsgAcceptChannel-4           1.86kB ± 0%    1.75kB ± 0%    -6.01%  (p=0.000 n=10+10)
WriteMessage/MsgFundingCreated-4            184B ± 0%        0B       -100.00%  (p=0.000 n=10+10)
WriteMessage/MsgFundingSigned-4             144B ± 0%        0B       -100.00%  (p=0.000 n=10+10)
WriteMessage/FundingLocked-4                160B ± 0%       80B ± 0%   -50.00%  (p=0.000 n=10+10)
WriteMessage/Shutdown-4                     104B ± 0%        0B       -100.00%  (p=0.000 n=10+10)
WriteMessage/ClosingSigned-4                152B ± 0%        0B       -100.00%  (p=0.000 n=10+10)
WriteMessage/UpdateAddHTLC-4                152B ± 0%        0B       -100.00%  (p=0.000 n=10+10)
WriteMessage/UpdateFulfillHTLC-4            112B ± 0%        0B       -100.00%  (p=0.000 n=10+10)
WriteMessage/UpdateFailHTLC-4              88.0B ± 0%      0.0B       -100.00%  (p=0.000 n=10+10)
WriteMessage/CommitSig-4                  6.57kB ± 0%    0.00kB       -100.00%  (p=0.000 n=10+10)
WriteMessage/RevokeAndAck-4                 184B ± 0%       80B ± 0%   -56.52%  (p=0.000 n=10+10)
WriteMessage/UpdateFee-4                   84.0B ± 0%      0.0B       -100.00%  (p=0.000 n=10+10)
WriteMessage/UpdateFailMalformedHTLC-4      120B ± 0%        0B       -100.00%  (p=0.000 n=10+10)
WriteMessage/ChannelReestablish-4           200B ± 0%       80B ± 0%   -60.00%  (p=0.000 n=10+10)
WriteMessage/ChannelAnnouncement-4          541B ± 0%        8B ± 0%   -98.52%  (p=0.000 n=10+10)
WriteMessage/NodeAnnouncement-4             600B ± 0%       88B ± 0%   -85.33%  (p=0.000 n=10+10)
WriteMessage/ChannelUpdate-4                160B ± 0%        0B       -100.00%  (p=0.000 n=10+10)
WriteMessage/AnnounceSignatures-4           224B ± 0%        0B       -100.00%  (p=0.000 n=10+10)
WriteMessage/QueryShortChanIDs-4          16.1kB ± 0%     0.1kB ± 1%   -99.45%  (p=0.000 n=10+10)
WriteMessage/ReplyShortChanIDsEnd-4        72.0B ± 0%      0.0B       -100.00%  (p=0.000 n=10+10)
WriteMessage/QueryChannelRange-4           80.0B ± 0%      0.0B       -100.00%  (p=0.000 n=10+10)
WriteMessage/ReplyChannelRange-4          16.1kB ± 0%     0.1kB ± 0%   -99.45%  (p=0.000 n=9+8)
WriteMessage/GossipTimestampRange-4        80.0B ± 0%      0.0B       -100.00%  (p=0.000 n=10+10)
WriteMessage/QueryShortChanIDs#01-4        857kB ± 0%     841kB ± 0%    -1.88%  (p=0.000 n=10+10)
WriteMessage/ReplyChannelRange#01-4        857kB ± 0%     841kB ± 0%    -1.88%  (p=0.000 n=10+10)

name                                    old allocs/op  new allocs/op  delta
WriteMessage/Init-4                         6.00 ± 0%      4.00 ± 0%   -33.33%  (p=0.000 n=10+10)
WriteMessage/Error-4                        2.00 ± 0%      0.00       -100.00%  (p=0.000 n=10+10)
WriteMessage/Ping-4                         2.00 ± 0%      0.00       -100.00%  (p=0.000 n=10+10)
WriteMessage/Pong-4                         1.00 ± 0%      0.00       -100.00%  (p=0.000 n=10+10)
WriteMessage/MsgOpenChannel-4               32.0 ± 0%      19.0 ± 0%   -40.62%  (p=0.000 n=10+10)
WriteMessage/MsgAcceptChannel-4             29.0 ± 0%      19.0 ± 0%   -34.48%  (p=0.000 n=10+10)
WriteMessage/MsgFundingCreated-4            5.00 ± 0%      0.00       -100.00%  (p=0.000 n=10+10)
WriteMessage/MsgFundingSigned-4             4.00 ± 0%      0.00       -100.00%  (p=0.000 n=10+10)
WriteMessage/FundingLocked-4                5.00 ± 0%      2.00 ± 0%   -60.00%  (p=0.000 n=10+10)
WriteMessage/Shutdown-4                     4.00 ± 0%      0.00       -100.00%  (p=0.000 n=10+10)
WriteMessage/ClosingSigned-4                5.00 ± 0%      0.00       -100.00%  (p=0.000 n=10+10)
WriteMessage/UpdateAddHTLC-4                8.00 ± 0%      0.00       -100.00%  (p=0.000 n=10+10)
WriteMessage/UpdateFulfillHTLC-4            5.00 ± 0%      0.00       -100.00%  (p=0.000 n=10+10)
WriteMessage/UpdateFailHTLC-4               4.00 ± 0%      0.00       -100.00%  (p=0.000 n=10+10)
WriteMessage/CommitSig-4                     105 ± 0%         0       -100.00%  (p=0.000 n=10+10)
WriteMessage/RevokeAndAck-4                 6.00 ± 0%      2.00 ± 0%   -66.67%  (p=0.000 n=10+10)
WriteMessage/UpdateFee-4                    4.00 ± 0%      0.00       -100.00%  (p=0.000 n=10+10)
WriteMessage/UpdateFailMalformedHTLC-4      7.00 ± 0%      0.00       -100.00%  (p=0.000 n=10+10)
WriteMessage/ChannelReestablish-4           8.00 ± 0%      2.00 ± 0%   -75.00%  (p=0.000 n=10+10)
WriteMessage/ChannelAnnouncement-4          14.0 ± 0%       2.0 ± 0%   -85.71%  (p=0.000 n=10+10)
WriteMessage/NodeAnnouncement-4             15.0 ± 0%       4.0 ± 0%   -73.33%  (p=0.000 n=10+10)
WriteMessage/ChannelUpdate-4                10.0 ± 0%       0.0       -100.00%  (p=0.000 n=10+10)
WriteMessage/AnnounceSignatures-4           6.00 ± 0%      0.00       -100.00%  (p=0.000 n=10+10)
WriteMessage/QueryShortChanIDs-4           1.01k ± 0%     0.00k ± 0%   -99.70%  (p=0.000 n=10+10)
WriteMessage/ReplyShortChanIDsEnd-4         3.00 ± 0%      0.00       -100.00%  (p=0.000 n=10+10)
WriteMessage/QueryChannelRange-4            5.00 ± 0%      0.00       -100.00%  (p=0.000 n=10+10)
WriteMessage/ReplyChannelRange-4           1.01k ± 0%     0.00k ± 0%   -99.70%  (p=0.000 n=10+10)
WriteMessage/GossipTimestampRange-4         5.00 ± 0%      0.00       -100.00%  (p=0.000 n=10+10)
WriteMessage/QueryShortChanIDs#01-4        1.04k ± 0%     0.03k ± 0%   -96.82%  (p=0.000 n=10+10)
WriteMessage/ReplyChannelRange#01-4        1.04k ± 0%     0.03k ± 0%   -96.82%  (p=0.000 n=10+10)
```

Check the overall gain using `benchstat write-bench-base.prof write-bench-final.prof`.

Most of the messages now use zero heap allocations, except when,
- calling `serializedPubkey := e.SerializeCompressed()`, as in `MsgOpenChannel`,`MsgAcceptChannel`,`FundingLocked`,`RevokeAndAck` and `ChannelReestablish`.
- using `zlib`, found in `QueryShortChanIDs` and `ReplyChannelRange`.

# Next Step

Optimization can be an endless task. This PR focuses on optimizing the write methods used in `lnwire`. The following steps would be,

- remove `WriteElement` method and its related usage in other packages.
- optimize the Write methods in `channeldb` to make use of the buffer.
- optimize the Read methods in `lnwire`.
- optimize the Read methods in `channeldb`.