### PR TITLE
watchtower/wtclient: add prefix logging

### DIFF
--- a/watchtower/wtclient/client.go
+++ b/watchtower/wtclient/client.go
@@ -1007,6 +1007,7 @@ func (c *TowerClient) newSessionQueue(s *wtdb.ClientSession) *sessionQueue {
 		DB:            c.cfg.DB,
 		MinBackoff:    c.cfg.MinBackoff,
 		MaxBackoff:    c.cfg.MaxBackoff,
+		Log:           c.log,
 	})
 }
 

--- a/watchtower/wtclient/client.go
+++ b/watchtower/wtclient/client.go
@@ -339,6 +339,7 @@ func New(config *Config) (*TowerClient, error) {
 		Candidates:    c.candidateTowers,
 		MinBackoff:    cfg.MinBackoff,
 		MaxBackoff:    cfg.MaxBackoff,
+		Log:           plog,
 	})
 
 	// Reconstruct the highest commit height processed for each channel

--- a/watchtower/wtclient/client.go
+++ b/watchtower/wtclient/client.go
@@ -469,7 +469,7 @@ func (c *TowerClient) Start() error {
 		c.wg.Add(1)
 		go c.backupDispatcher()
 
-		log.Infof("Watchtower client started successfully")
+		c.log.Infof("Watchtower client started successfully")
 	})
 	return err
 }

--- a/watchtower/wtclient/client.go
+++ b/watchtower/wtclient/client.go
@@ -317,7 +317,7 @@ func New(config *Config) (*TowerClient, error) {
 	c := &TowerClient{
 		cfg:               cfg,
 		log:               plog,
-		pipeline:          newTaskPipeline(),
+		pipeline:          newTaskPipeline(plog),
 		candidateTowers:   newTowerListIterator(candidateTowers...),
 		candidateSessions: candidateSessions,
 		activeSessions:    make(sessionQueueSet),


### PR DESCRIPTION
Follow up from #4782, adds the `(legacy)` or `(anchor)` prefix to logs output by the individual sub-clients