### PR TITLE
ensure 64bit alignment of atomically accessed field in ChannelAcceptor

### DIFF
--- a/chanacceptor/chainedacceptor.go
+++ b/chanacceptor/chainedacceptor.go
@@ -7,12 +7,12 @@ import (
 
 // ChainedAcceptor represents a conjunction of ChannelAcceptor results.
 type ChainedAcceptor struct {
+	acceptorID uint64 // To be used atomically.
+
 	// acceptors is a map of ChannelAcceptors that will be evaluated when
 	// the ChainedAcceptor's Accept method is called.
 	acceptors    map[uint64]ChannelAcceptor
 	acceptorsMtx sync.RWMutex
-
-	acceptorID uint64 // To be used atomically.
 }
 
 // NewChainedAcceptor initializes a ChainedAcceptor.


### PR DESCRIPTION
- help lnd avoid a bug in the `sync/atomic` package which requires 64-bit alignment of atomically accessed fields

Addresses: https://github.com/lightningnetwork/lnd/issues/4886

#### Pull Request Checklist

- [ ] If this is your first time contributing, we recommend you read the [Code
  Contribution Guidelines](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md)
- [ ] All changes are Go version 1.12 compliant
- [ ] The code being submitted is commented according to [Code Documentation and Commenting](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#CodeDocumentation)
- [ ] For new code: Code is accompanied by tests which exercise both
  the positive and negative (error paths) conditions (if applicable)
- [ ] For bug fixes: Code is accompanied by new tests which trigger
  the bug being fixed to prevent regressions
- [ ] Any new logging statements use an appropriate subsystem and
  logging level
- [x] Code has been formatted with `go fmt`
- [ ] Protobuf files (`lnrpc/**/*.proto`) have been formatted with
  `make rpc-format` and compiled with `make rpc`
- [ ] New configuration flags have been added to `sample-lnd.conf`
- [ ] For code and documentation: lines are wrapped at 80 characters
  (the tab character should be counted as 8 characters, not 4, as some IDEs do
  per default)
- [x] Running `make check` does not fail any tests
- [x] Running `go vet` does not report any issues
- [x] Running `make lint` does not report any **new** issues that did not
  already exist
- [x] All commits build properly and pass tests. Only in exceptional
  cases it can be justifiable to violate this condition. In that case, the
  reason should be stated in the commit message.
- [x] Commits have a logical structure according to [Ideal Git Commit Structure](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#IdealGitCommitStructure)
