### PR TITLE
[anchors] Reserve wallet balance for anchor fee bumping

### DIFF
--- a/lntest/itest/lnd_test_list_on_test.go
+++ b/lntest/itest/lnd_test_list_on_test.go
@@ -231,6 +231,10 @@ var allTestCases = []*testCase{
 		test: testCPFP,
 	},
 	{
+		name: "anchors reserved value",
+		test: testAnchorReservedValue,
+	},
+	{
 		name: "macaroon authentication",
 		test: testMacaroonAuthentication,
 	},

--- a/lntest/itest/log_error_whitelist.txt
+++ b/lntest/itest/log_error_whitelist.txt
@@ -251,3 +251,6 @@
 <time> [ERR] UTXN: Failed to sweep first-stage HTLC (CLTV-delayed) output <chan_point>
 <time> [ERR] UTXN: Notification chan closed, can't advance output <chan_point>
 <time> [ERR] DISC: Unable to rebroadcast stale announcements: unable to retrieve outgoing channels: channel from self node has no policy
+<time> [ERR] RPCS: [/lnrpc.Lightning/OpenChannel]: reserved wallet balance invalidated
+<time> [ERR] RPCS: [/lnrpc.Lightning/SendCoins]: reserved wallet balance invalidated
+<time> [ERR] RPCS: unable to open channel to NodeKey(<hex>): reserved wallet balance invalidated

--- a/lnwallet/chanfunding/assembler.go
+++ b/lnwallet/chanfunding/assembler.go
@@ -103,6 +103,16 @@ type Intent interface {
 	// change.
 	LocalFundingAmt() btcutil.Amount
 
+	// Inputs returns all inputs to the final funding transaction that we
+	// know about. Note that there might be more, but we are not (yet)
+	// aware of.
+	Inputs() []wire.OutPoint
+
+	// Outputs returns all outputs of the final funding transaction that we
+	// know about. Note that there might be more, but we are not (yet)
+	// aware of.
+	Outputs() []*wire.TxOut
+
 	// Cancel allows the caller to cancel a funding Intent at any time.
 	// This will return any resources such as coins back to the eligible
 	// pool to be used in order channel fundings.

--- a/lnwallet/chanfunding/canned_assembler.go
+++ b/lnwallet/chanfunding/canned_assembler.go
@@ -98,6 +98,30 @@ func (s *ShimIntent) ThawHeight() uint32 {
 	return s.thawHeight
 }
 
+// Inputs returns all inputs to the final funding transaction that we
+// know about. For the ShimIntent this will always be none, since it is funded
+// externally.
+func (s *ShimIntent) Inputs() []wire.OutPoint {
+	return nil
+}
+
+// Outputs returns all outputs of the final funding transaction that we
+// know about. Since this is an externally funded channel, the channel output
+// is the only known one.
+func (s *ShimIntent) Outputs() []*wire.TxOut {
+	_, txOut, err := s.FundingOutput()
+	if err != nil {
+		log.Warnf("Unable to find funding output for shim intent: %v",
+			err)
+
+		// Failed finding funding output, return empty list of known
+		// outputs.
+		return nil
+	}
+
+	return []*wire.TxOut{txOut}
+}
+
 // FundingKeys couples our multi-sig key along with the remote party's key.
 type FundingKeys struct {
 	// LocalKey is our multi-sig key.

--- a/lnwallet/chanfunding/wallet_assembler.go
+++ b/lnwallet/chanfunding/wallet_assembler.go
@@ -152,6 +152,28 @@ func (f *FullIntent) CompileFundingTx(extraInputs []*wire.TxIn,
 	return fundingTx, nil
 }
 
+// Inputs returns all inputs to the final funding transaction that we
+// know about. Since this funding transaction is created all from our wallet,
+// it will be all inputs.
+func (f *FullIntent) Inputs() []wire.OutPoint {
+	var ins []wire.OutPoint
+	for _, coin := range f.InputCoins {
+		ins = append(ins, coin.OutPoint)
+	}
+
+	return ins
+}
+
+// Outputs returns all outputs of the final funding transaction that we
+// know about. This will be the funding output and the change outputs going
+// back to our wallet.
+func (f *FullIntent) Outputs() []*wire.TxOut {
+	outs := f.ShimIntent.Outputs()
+	outs = append(outs, f.ChangeOutputs...)
+
+	return outs
+}
+
 // Cancel allows the caller to cancel a funding Intent at any time.  This will
 // return any resources such as coins back to the eligible pool to be used in
 // order channel fundings.

--- a/lnwallet/wallet.go
+++ b/lnwallet/wallet.go
@@ -986,6 +986,27 @@ func (l *LightningWallet) CheckReservedValue(in []wire.OutPoint,
 	return reserved, nil
 }
 
+// CheckReservedValueTx calls CheckReservedValue with the inputs and outputs
+// from the given tx, with the number of anchor channels currently open in the
+// database.
+//
+// NOTE: This method should only be run with the CoinSelectLock held.
+func (l *LightningWallet) CheckReservedValueTx(tx *wire.MsgTx) (btcutil.Amount,
+	error) {
+
+	numAnchors, err := l.currentNumAnchorChans()
+	if err != nil {
+		return 0, err
+	}
+
+	var inputs []wire.OutPoint
+	for _, txIn := range tx.TxIn {
+		inputs = append(inputs, txIn.PreviousOutPoint)
+	}
+
+	return l.CheckReservedValue(inputs, tx.TxOut, numAnchors)
+}
+
 // initOurContribution initializes the given ChannelReservation with our coins
 // and change reserved for the channel, and derives the keys to use for this
 // channel.

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -1256,7 +1256,7 @@ func (r *rpcServer) SendCoins(ctx context.Context,
 		// safe manner, so no need to worry about locking.
 		sweepTxPkg, err := sweep.CraftSweepAllTx(
 			feePerKw, lnwallet.DefaultDustLimit(),
-			uint32(bestHeight), targetAddr, wallet,
+			uint32(bestHeight), nil, targetAddr, wallet,
 			wallet.WalletController, wallet.WalletController,
 			r.server.cc.FeeEstimator, r.server.cc.Signer,
 		)

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -1056,7 +1056,25 @@ func (r *rpcServer) sendCoinsOnChain(paymentMap map[string]int64,
 		return nil, err
 	}
 
-	tx, err := r.server.cc.Wallet.SendOutputs(outputs, feeRate, minconf, label)
+	// We first do a dry run, to sanity check we won't spend our wallet
+	// balance below the reserved amount.
+	authoredTx, err := r.server.cc.Wallet.CreateSimpleTx(
+		outputs, feeRate, true,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	_, err = r.server.cc.Wallet.CheckReservedValueTx(authoredTx.Tx)
+	if err != nil {
+		return nil, err
+	}
+
+	// If that checks out, we're failry confident that creating sending to
+	// these outputs will keep the wallet balance above the reserve.
+	tx, err := r.server.cc.Wallet.SendOutputs(
+		outputs, feeRate, minconf, label,
+	)
 	if err != nil {
 		return nil, err
 	}
@@ -1253,7 +1271,9 @@ func (r *rpcServer) SendCoins(ctx context.Context,
 		// With the sweeper instance created, we can now generate a
 		// transaction that will sweep ALL outputs from the wallet in a
 		// single transaction. This will be generated in a concurrent
-		// safe manner, so no need to worry about locking.
+		// safe manner, so no need to worry about locking. The tx will
+		// pay to the change address created above if we needed to
+		// reserve any value, the rest will go to targetAddr.
 		sweepTxPkg, err := sweep.CraftSweepAllTx(
 			feePerKw, lnwallet.DefaultDustLimit(),
 			uint32(bestHeight), nil, targetAddr, wallet,
@@ -1261,6 +1281,75 @@ func (r *rpcServer) SendCoins(ctx context.Context,
 			r.server.cc.FeeEstimator, r.server.cc.Signer,
 		)
 		if err != nil {
+			return nil, err
+		}
+
+		// Before we publish the transaction we make sure it won't
+		// violate our reserved wallet value.
+		var reservedVal btcutil.Amount
+		err = wallet.WithCoinSelectLock(func() error {
+			var err error
+			reservedVal, err = wallet.CheckReservedValueTx(
+				sweepTxPkg.SweepTx,
+			)
+			return err
+		})
+
+		// If sending everything to this address would invalidate our
+		// reserved wallet balance, we create a new sweep tx, where
+		// we'll send the reserved value back to our wallet.
+		if err == lnwallet.ErrReservedValueInvalidated {
+			sweepTxPkg.CancelSweepAttempt()
+
+			rpcsLog.Debugf("Reserved value %v not satisfied after "+
+				"send_all, trying with change output",
+				reservedVal)
+
+			// We'll request a change address from the wallet,
+			// where we'll send this reserved value back to. This
+			// ensures this is an address the wallet knows about,
+			// allowing us to pass the reserved value check.
+			changeAddr, err := r.server.cc.Wallet.NewAddress(
+				lnwallet.WitnessPubKey, true,
+			)
+			if err != nil {
+				return nil, err
+			}
+
+			// Send the reserved value to this change address, the
+			// remaining funds will go to the targetAddr.
+			outputs := []sweep.DeliveryAddr{
+				{
+					Addr: changeAddr,
+					Amt:  reservedVal,
+				},
+			}
+
+			sweepTxPkg, err = sweep.CraftSweepAllTx(
+				feePerKw, lnwallet.DefaultDustLimit(),
+				uint32(bestHeight), outputs, targetAddr, wallet,
+				wallet.WalletController, wallet.WalletController,
+				r.server.cc.FeeEstimator, r.server.cc.Signer,
+			)
+			if err != nil {
+				return nil, err
+			}
+
+			// Sanity check the new tx by re-doing the check.
+			err = wallet.WithCoinSelectLock(func() error {
+				_, err := wallet.CheckReservedValueTx(
+					sweepTxPkg.SweepTx,
+				)
+				return err
+			})
+			if err != nil {
+				sweepTxPkg.CancelSweepAttempt()
+
+				return nil, err
+			}
+		} else if err != nil {
+			sweepTxPkg.CancelSweepAttempt()
+
 			return nil, err
 		}
 

--- a/sweep/sweeper.go
+++ b/sweep/sweeper.go
@@ -1192,8 +1192,8 @@ func (s *UtxoSweeper) sweep(inputs inputSet, feeRate chainfee.SatPerKWeight,
 
 	// Create sweep tx.
 	tx, err := createSweepTx(
-		inputs, s.currentOutputScript, uint32(currentHeight), feeRate,
-		dustLimit(s.relayFeeRate), s.cfg.Signer,
+		inputs, nil, s.currentOutputScript, uint32(currentHeight),
+		feeRate, dustLimit(s.relayFeeRate), s.cfg.Signer,
 	)
 	if err != nil {
 		return fmt.Errorf("create sweep tx: %v", err)
@@ -1487,7 +1487,7 @@ func (s *UtxoSweeper) CreateSweepTx(inputs []input.Input, feePref FeePreference,
 	}
 
 	return createSweepTx(
-		inputs, pkScript, currentBlockHeight, feePerKw,
+		inputs, nil, pkScript, currentBlockHeight, feePerKw,
 		dustLimit(s.relayFeeRate), s.cfg.Signer,
 	)
 }

--- a/sweep/sweeper_test.go
+++ b/sweep/sweeper_test.go
@@ -354,7 +354,7 @@ func assertTxFeeRate(t *testing.T, tx *wire.MsgTx,
 	outputAmt := tx.TxOut[0].Value
 
 	fee := btcutil.Amount(inputAmt - outputAmt)
-	_, estimator := getWeightEstimate(inputs, 0)
+	_, estimator := getWeightEstimate(inputs, nil, 0)
 	txWeight := estimator.weight()
 
 	expectedFee := expectedFeeRate.FeeForWeight(int64(txWeight))

--- a/sweep/txgenerator_test.go
+++ b/sweep/txgenerator_test.go
@@ -39,7 +39,7 @@ func TestWeightEstimate(t *testing.T) {
 		))
 	}
 
-	_, estimator := getWeightEstimate(inputs, 0)
+	_, estimator := getWeightEstimate(inputs, nil, 0)
 	weight := int64(estimator.weight())
 	if weight != expectedWeight {
 		t.Fatalf("unexpected weight. expected %d but got %d.",

--- a/sweep/walletsweep_test.go
+++ b/sweep/walletsweep_test.go
@@ -288,7 +288,8 @@ func TestCraftSweepAllTxCoinSelectFail(t *testing.T) {
 	utxoLocker := newMockOutpointLocker()
 
 	_, err := CraftSweepAllTx(
-		0, 100, 10, nil, coinSelectLocker, utxoSource, utxoLocker, nil, nil,
+		0, 100, 10, nil, nil, coinSelectLocker, utxoSource,
+		utxoLocker, nil, nil,
 	)
 
 	// Since we instructed the coin select locker to fail above, we should
@@ -313,7 +314,8 @@ func TestCraftSweepAllTxUnknownWitnessType(t *testing.T) {
 	utxoLocker := newMockOutpointLocker()
 
 	_, err := CraftSweepAllTx(
-		0, 100, 10, nil, coinSelectLocker, utxoSource, utxoLocker, nil, nil,
+		0, 100, 10, nil, nil, coinSelectLocker, utxoSource,
+		utxoLocker, nil, nil,
 	)
 
 	// Since passed in a p2wsh output, which is unknown, we should fail to
@@ -347,8 +349,8 @@ func TestCraftSweepAllTx(t *testing.T) {
 	utxoLocker := newMockOutpointLocker()
 
 	sweepPkg, err := CraftSweepAllTx(
-		0, 100, 10, deliveryAddr, coinSelectLocker, utxoSource, utxoLocker,
-		feeEstimator, signer,
+		0, 100, 10, nil, deliveryAddr, coinSelectLocker, utxoSource,
+		utxoLocker, feeEstimator, signer,
 	)
 	if err != nil {
 		t.Fatalf("unable to make sweep tx: %v", err)


### PR DESCRIPTION
The recently introduced anchor commitment format has several advantages, most notably that one can decide on channel closure how much fees to apply to the commitment transaction. However, in order to do this fee bumping, one need to have a UTXO available. This PR attempts to make sure such a UTXO is kept around, by disallowing transactions that would spend what we have left in the wallet.

This PR starts by checking the final wallet balance in cases of `channel open` and `send all`. More cases could be added later, in particular the regular `send coins` call is not performing this check, since the tx is crafted and published directly by the wallet.