### PR TITLE
itest: fix node names out of bounds

### DIFF
--- a/lntest/itest/lnd_test.go
+++ b/lntest/itest/lnd_test.go
@@ -6726,7 +6726,10 @@ func testInvoiceRoutingHints(net *lntest.NetworkHarness, t *harnessTest) {
 	)
 
 	// Make sure all the channels have been opened.
-	nodeNames := []string{"bob", "carol", "dave", "eve"}
+	chanNames := []string{
+		"alice-bob", "alice-carol", "bob-carol", "alice-dave",
+		"alice-eve",
+	}
 	aliceChans := []*lnrpc.ChannelPoint{
 		chanPointBob, chanPointCarol, chanPointBobCarol, chanPointDave,
 		chanPointEve,
@@ -6735,8 +6738,8 @@ func testInvoiceRoutingHints(net *lntest.NetworkHarness, t *harnessTest) {
 		ctxt, _ := context.WithTimeout(ctxb, defaultTimeout)
 		err = net.Alice.WaitForNetworkChannelOpen(ctxt, chanPoint)
 		if err != nil {
-			t.Fatalf("timed out waiting for channel open between "+
-				"alice and %s: %v", nodeNames[i], err)
+			t.Fatalf("timed out waiting for channel open %s: %v",
+				chanNames[i], err)
 		}
 	}
 


### PR DESCRIPTION
If the last channel fail, eh indexing into nodeNames would panic. We
instead name the channels, such that the slices will be of the same
length.
