### PR TITLE
config: increase chain backend healthcheck timeout and backoff

### DIFF
--- a/config.go
+++ b/config.go
@@ -95,8 +95,8 @@ const (
 	defaultHostSampleInterval = time.Minute * 5
 
 	defaultChainInterval = time.Minute
-	defaultChainTimeout  = time.Second * 10
-	defaultChainBackoff  = time.Second * 30
+	defaultChainTimeout  = time.Second * 30
+	defaultChainBackoff  = time.Minute * 2
 	defaultChainAttempts = 3
 
 	// Set defaults for a health check which ensures that we have space

--- a/sample-lnd.conf
+++ b/sample-lnd.conf
@@ -337,6 +337,11 @@
 ; automatically. [experimental]
 ; keysend-hold-time=true
 
+; If set, lnd will use anchor channels by default if the remote channel party
+; supports them. Note that lnd will require 1 UTXO to be reserved for this
+; channel type if it is enabled.
+; protocol.anchors=true
+
 ; If true, we'll attempt to garbage collect canceled invoices upon start.
 ; gc-canceled-invoices-on-startup=true
 


### PR DESCRIPTION
Some nodes still having issues with health check, #4913, despite upgrade to uptime call. This PR bumps out defaults to be more tolerant of slower bitcoinds.