### PR TITLE
routerrpc,routing: limit max parts if the invoice doesn't declare MPP support

### DIFF
--- a/lnrpc/routerrpc/router_backend.go
+++ b/lnrpc/routerrpc/router_backend.go
@@ -648,6 +648,10 @@ func (r *RouterBackend) extractIntentFromSendRequest(
 			payIntent.Amount = *payReq.MilliSat
 		}
 
+		if !payReq.Features.HasFeature(lnwire.MPPOptional) {
+			payIntent.MaxParts = 1
+		}
+
 		copy(payIntent.PaymentHash[:], payReq.PaymentHash[:])
 		destKey := payReq.Destination.SerializeCompressed()
 		copy(payIntent.Target[:], destKey)

--- a/routing/payment_session.go
+++ b/routing/payment_session.go
@@ -278,6 +278,12 @@ func (p *paymentSession) RequestRoute(maxAmt, feeLimit lnwire.MilliSatoshi,
 				return nil, errNoPathFound
 			}
 
+			if !p.payment.DestFeatures.HasFeature(lnwire.MPPOptional) {
+				p.log.Debug("not splitting because destination doesn't declare MPP")
+
+				return nil, errNoPathFound
+			}
+
 			// No splitting if this is the last shard.
 			isLastShard := activeShards+1 >= p.payment.MaxParts
 			if isLastShard {


### PR DESCRIPTION
LND was allowing MPP payments to destinations that do not support them. We noticed this when an open amount invoice with MPP disabled received a multi part payment (which of course triggered a bug in our implementation 🤷 too).

I'm not sure how to go around adding tests for this given that both affected structs have little tests.

#### Pull Request Checklist

- [x] All changes are Go version 1.12 compliant
- [x] The code being submitted is commented according to [Code Documentation and Commenting](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#CodeDocumentation)
- [ ] For bug fixes: Code is accompanied by new tests which trigger
  the bug being fixed to prevent regressions
- [x] Any new logging statements use an appropriate subsystem and
  logging level
- [x] Code has been formatted with `go fmt`
- [x] Running `make check` does not fail any tests
- [x] Running `go vet` does not report any issues
- [ ] Running `make lint` does not report any **new** issues that did not
  already exist
- [x] All commits build properly and pass tests. Only in exceptional
  cases it can be justifiable to violate this condition. In that case, the
  reason should be stated in the commit message.
- [x] Commits have a logical structure according to [Ideal Git Commit Structure](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#IdealGitCommitStructure)
