### PR TITLE
lnwallet: require fee reserve routing node inc. anchor channels

### DIFF
--- a/chainreg/chainregistry.go
+++ b/chainreg/chainregistry.go
@@ -105,6 +105,12 @@ type Config struct {
 	// DBTimeOut specifies the timeout value to use when opening the wallet
 	// database.
 	DBTimeOut time.Duration
+
+	// IsRoutingNode indicates whether the daemon is currently configured to
+	// forward HTLCs. This is used internally by the wallet to determine
+	// potentially unsafe funding scenarios, e.g. when accepting incoming
+	// anchor channels without reserved UTXOs for on-chain fees.
+	IsRoutingNode bool
 }
 
 const (
@@ -648,6 +654,7 @@ func NewChainControl(cfg *Config) (*ChainControl, error) {
 		ChainIO:            cc.ChainIO,
 		DefaultConstraints: channelConstraints,
 		NetParams:          *cfg.ActiveNetParams.Params,
+		IsRoutingNode:      cfg.IsRoutingNode,
 	}
 	lnWallet, err := lnwallet.NewLightningWallet(walletCfg)
 	if err != nil {

--- a/lnd.go
+++ b/lnd.go
@@ -526,6 +526,7 @@ func Main(cfg *Config, lisCfg ListenerCfg, shutdownChan <-chan struct{}) error {
 		NeutrinoCS:                  neutrinoCS,
 		ActiveNetParams:             cfg.ActiveNetParams,
 		FeeURL:                      cfg.FeeURL,
+		IsRoutingNode:               !cfg.RejectHTLC,
 	}
 
 	activeChainControl, err := chainreg.NewChainControl(chainControlCfg)

--- a/lntest/itest/lnd_test.go
+++ b/lntest/itest/lnd_test.go
@@ -1360,18 +1360,31 @@ func testBasicChannelFunding(net *lntest.NetworkHarness, t *harnessTest) {
 		commitTypeAnchors,
 	}
 
-test:
+	type testCase struct {
+		carolCommitType commitType
+		daveCommitType  commitType
+	}
+
+	var tests []testCase
+
 	// We'll test all possible combinations of the feature bit presence
-	// that both nodes can signal for this new channel type. We'll make a
-	// new Carol+Dave for each test instance as well.
+	// that both nodes can signal for this new channel type.
 	for _, carolCommitType := range allTypes {
 		for _, daveCommitType := range allTypes {
-			success := runBasicFundingFlow(
-				net, t, carolCommitType, daveCommitType,
-			)
-			if !success {
-				break test
-			}
+			tests = append(tests, testCase{
+				carolCommitType: carolCommitType,
+				daveCommitType:  daveCommitType,
+			})
+		}
+	}
+
+test:
+	for _, test := range tests {
+		success := runBasicFundingFlow(
+			net, t, test.carolCommitType, test.daveCommitType,
+		)
+		if !success {
+			break test
 		}
 	}
 }

--- a/lntest/itest/lnd_test.go
+++ b/lntest/itest/lnd_test.go
@@ -1374,32 +1374,24 @@ test:
 			// We do the same for Dave shortly below.
 			carolArgs := carolCommitType.Args()
 			carol, err := net.NewNode("Carol", carolArgs)
-			if err != nil {
-				t.Fatalf("unable to create new node: %v", err)
-			}
+			require.NoError(t.t, err)
 
 			// Each time, we'll send Carol a new set of coins in
 			// order to fund the channel.
 			ctxt, _ := context.WithTimeout(ctxb, defaultTimeout)
 			err = net.SendCoins(ctxt, btcutil.SatoshiPerBitcoin, carol)
-			if err != nil {
-				t.Fatalf("unable to send coins to carol: %v", err)
-			}
+			require.NoError(t.t, err)
 
 			daveArgs := daveCommitType.Args()
 			dave, err := net.NewNode("Dave", daveArgs)
-			if err != nil {
-				t.Fatalf("unable to create new node: %v", err)
-			}
+			require.NoError(t.t, err)
 
 			// Before we start the test, we'll ensure both sides
 			// are connected to the funding flow can properly be
 			// executed.
 			ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
 			err = net.EnsureConnected(ctxt, carol, dave)
-			if err != nil {
-				t.Fatalf("unable to connect peers: %v", err)
-			}
+			require.NoError(t.t, err)
 
 			testName := fmt.Sprintf("carol_commit=%v,dave_commit=%v",
 				carolCommitType, daveCommitType)
@@ -1411,20 +1403,12 @@ test:
 				carolChannel, daveChannel, closeChan, err := basicChannelFundingTest(
 					ht, net, carol, dave, nil,
 				)
-				if err != nil {
-					t.Fatalf("failed funding flow: %v", err)
-				}
+				require.NoError(t, err)
 
 				// Both nodes should report the same commitment
 				// type.
 				chansCommitType := carolChannel.CommitmentType
-				if daveChannel.CommitmentType != chansCommitType {
-					t.Fatalf("commit types don't match, "+
-						"carol got %v, dave got %v",
-						carolChannel.CommitmentType,
-						daveChannel.CommitmentType,
-					)
-				}
+				require.Equal(t, daveChannel.CommitmentType, chansCommitType)
 
 				// Now check that the commitment type reported
 				// by both nodes is what we expect. It will be

--- a/lnwallet/config.go
+++ b/lnwallet/config.go
@@ -56,4 +56,10 @@ type Config struct {
 	// NetParams is the set of parameters that tells the wallet which chain
 	// it will be operating on.
 	NetParams chaincfg.Params
+
+	// IsRoutingNode indicates whether the node is currently configured to
+	// route payments. This is currently used to identify potentially unsafe
+	// funding flows, e.g. when accepting anchor channels with no utxos
+	// reserved for on-chain fees.
+	IsRoutingNode bool
 }

--- a/lnwallet/wallet.go
+++ b/lnwallet/wallet.go
@@ -579,8 +579,16 @@ func (l *LightningWallet) PsbtFundingVerify(pendingChanID [32]byte,
 	// but only if we are contributing funds to the channel. This is done
 	// to still allow incoming channels even though we have no UTXOs
 	// available, as in bootstrapping phases.
+	//
+	// We also increment the counter when _accepting_ an incoming anchor
+	// channel and the node is configured for HTLC forwarding. This ensures
+	// that we attempt to maintain an onchain UTXO for fee bumping in the
+	// event of unilateral closure. Not maintaining a fee bumping UTXO is
+	// dangerous when forwarding payments, since the node may not be able to
+	// sweep a disputed HTLC on the upstream channel with the preimage,
+	// resulting in loss of funds.
 	if pendingReservation.partialState.ChanType.HasAnchors() &&
-		intent.LocalFundingAmt() > 0 {
+		(intent.LocalFundingAmt() > 0 || l.Cfg.IsRoutingNode) {
 		numAnchors++
 	}
 
@@ -792,8 +800,16 @@ func (l *LightningWallet) handleFundingReserveRequest(req *InitFundingReserveMsg
 	// but only if we are contributing funds to the channel. This is done
 	// to still allow incoming channels even though we have no UTXOs
 	// available, as in bootstrapping phases.
+	//
+	// We also increment the counter when _accepting_ an incoming anchor
+	// channel and the node is configured for HTLC forwarding. This ensures
+	// that we attempt to maintain an onchain UTXO for fee bumping in the
+	// event of unilateral closure. Not maintaining a fee bumping UTXO is
+	// dangerous when forwarding payments, since the node may not be able to
+	// sweep a disputed HTLC on the upstream channel with the preimage,
+	// resulting in loss of funds.
 	if req.CommitType == CommitmentTypeAnchorsZeroFeeHtlcTx &&
-		fundingIntent.LocalFundingAmt() > 0 {
+		(fundingIntent.LocalFundingAmt() > 0 || l.Cfg.IsRoutingNode) {
 		numAnchors++
 	}
 


### PR DESCRIPTION
This commit restricts the funding case for incoming anchor channels when
a node has no on-chain fee reserve such that this may only happen when
the node is not configured for forwarding htlcs.

This is an attempt to disallow a potentially dangerous case where a node
has no utxos available to sweep a disputed HTLC on an upstream channel
with the preimage. Failure to do so allows the upstream node to timeout
the HTLC and take their funds back, resulting in loss of funds for the
intermediary.

We permit this to occur when the node *is not* configured for routing
because the situation can't result in a loss of funds scenario. The
worst case is that the HTLC remains on chain, and can be timed out
indefinitely (e.g. by adding some funds to the node at a later point int
time) since there is not upstream deadline to meet.