### PR TITLE
docker: add an extra listener for localhost

### DIFF
--- a/docker/lnd/start-lnd.sh
+++ b/docker/lnd/start-lnd.sh
@@ -65,5 +65,6 @@ exec lnd \
     "--$BACKEND.rpcuser"="$RPCUSER" \
     "--$BACKEND.rpcpass"="$RPCPASS" \
     "--rpclisten=$HOSTNAME:10009" \
+    "--rpclisten=localhost:10009" \
     --debuglevel="$DEBUG" \
     "$@"


### PR DESCRIPTION
Make sure the lncli command can be used inside of the container without
needing to specify the --rpcserver flag all the time. Issue: #4937

#### Pull Request Checklist

- [ ] If this is your first time contributing, we recommend you read the [Code
  Contribution Guidelines](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md)
- [ ] All changes are Go version 1.12 compliant
- [ ] The code being submitted is commented according to [Code Documentation and Commenting](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#CodeDocumentation)
- [ ] For new code: Code is accompanied by tests which exercise both
  the positive and negative (error paths) conditions (if applicable)
- [ ] For bug fixes: Code is accompanied by new tests which trigger
  the bug being fixed to prevent regressions
- [ ] Any new logging statements use an appropriate subsystem and
  logging level
- [ ] Code has been formatted with `go fmt`
- [ ] Protobuf files (`lnrpc/**/*.proto`) have been formatted with
  `make rpc-format` and compiled with `make rpc`
- [ ] New configuration flags have been added to `sample-lnd.conf`
- [ ] For code and documentation: lines are wrapped at 80 characters
  (the tab character should be counted as 8 characters, not 4, as some IDEs do
  per default)
- [ ] Running `make check` does not fail any tests
- [ ] Running `go vet` does not report any issues
- [ ] Running `make lint` does not report any **new** issues that did not
  already exist
- [ ] All commits build properly and pass tests. Only in exceptional
  cases it can be justifiable to violate this condition. In that case, the
  reason should be stated in the commit message.
- [ ] Commits have a logical structure according to [Ideal Git Commit Structure](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#IdealGitCommitStructure)
