### PR TITLE
docs: Update minimum golang version to 1.14

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,7 +2,7 @@
 
 - [ ] If this is your first time contributing, we recommend you read the [Code
   Contribution Guidelines](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md)
-- [ ] All changes are Go version 1.12 compliant
+- [ ] All changes are Go version 1.14 compliant
 - [ ] The code being submitted is commented according to [Code Documentation and Commenting](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#CodeDocumentation)
 - [ ] For new code: Code is accompanied by tests which exercise both
   the positive and negative (error paths) conditions (if applicable)

--- a/docker/btcd/Dockerfile
+++ b/docker/btcd/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.12-alpine as builder
+FROM golang:1.15.7-alpine as builder
 
 LABEL maintainer="Olaoluwa Osuntokun <laolu@lightning.engineering>"
 

--- a/docs/code_contribution_guidelines.md
+++ b/docs/code_contribution_guidelines.md
@@ -572,7 +572,7 @@ Rejoice as you will now be listed as a [contributor](https://github.com/lightnin
 
 ## Contribution Checklist
 
-- [&nbsp;&nbsp;] All changes are Go version 1.12 compliant
+- [&nbsp;&nbsp;] All changes are Go version 1.14 compliant
 - [&nbsp;&nbsp;] The code being submitted is commented according to
   [Code Documentation and Commenting](#code-documentation-and-commenting)
 - [&nbsp;&nbsp;] For new code: Code is accompanied by tests which exercise both


### PR DESCRIPTION
Hey, so looks like I missed this in #4438. So btcd now requires go 1.14 as per btcsuite/btcd#1621. I've never touched [ltcd](https://github.com/ltcsuite/ltcd), but it is a [btcd](https://github.com/btcsuite/btcd) fork. It looks like their minimum is still go [1.12](https://github.com/ltcsuite/ltcd) so I've left that [dockerfile](https://github.com/lightningnetwork/lnd/blob/master/docker/ltcd/Dockerfile#L1) alone for now. I can update this if needed

There's also the matter of [ticker](https://github.com/lightningnetwork/lnd/blob/567c357c613b910181dd74f54c774f72f268dc3e/ticker/go.mod#L3) and [queue](https://github.com/lightningnetwork/lnd/blob/976c996fda11bb5f88f823b638112dbc7c76ef85/queue/go.mod#L7) which are still at 1.12. I've left these alone for now. Happy to update if needed 


#### Pull Request Checklist

- [x] If this is your first time contributing, we recommend you read the [Code
  Contribution Guidelines](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md)
- [ ] ~All changes are Go version 1.12 compliant~ see pr description
- [x] The code being submitted is commented according to [Code Documentation and Commenting](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#CodeDocumentation)
- [x] For new code: Code is accompanied by tests which exercise both
  the positive and negative (error paths) conditions (if applicable)
- [x] For bug fixes: Code is accompanied by new tests which trigger
  the bug being fixed to prevent regressions
- [x] Any new logging statements use an appropriate subsystem and
  logging level
- [x] Code has been formatted with `go fmt`
- [x] Protobuf files (`lnrpc/**/*.proto`) have been formatted with
  `make rpc-format` and compiled with `make rpc`
- [x] For code and documentation: lines are wrapped at 80 characters
  (the tab character should be counted as 8 characters, not 4, as some IDEs do
  per default)
- [x] Running `make check` does not fail any tests
- [x] Running `go vet` does not report any issues
- [x] Running `make lint` does not report any **new** issues that did not
  already exist
- [ ] All commits build properly and pass tests. Only in exceptional
  cases it can be justifiable to violate this condition. In that case, the
  reason should be stated in the commit message.
- [x] Commits have a logical structure according to [Ideal Git Commit Structure](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#IdealGitCommitStructure)
