### PR TITLE
docs: Add clang-format instructions for mac

### DIFF
--- a/lnrpc/README.md
+++ b/lnrpc/README.md
@@ -204,7 +204,7 @@ or `make rpc` to generate new protobuf definitions.
 ## Format .proto files
 
 We use `clang-format` to make sure the `.proto` files are formatted correctly.
-You can install the formatter on Ubuntu by running `apt install clang-format`.
+You can install the formatter on Ubuntu by running `apt install clang-format` or on Mac by running `brew install clang-format`.
 
 Consult [this page](http://releases.llvm.org/download.html) to find binaries
 for other operating systems or distributions.


### PR DESCRIPTION
As per this [stack overflow answer](https://stackoverflow.com/questions/21151731/where-are-clang-format-and-clang-format-py-in-mac-os-x-with-xcode-command-line-t) mac doesn't ship with clang-format.

I've added instructions for installing

#### Pull Request Checklist

- [x] If this is your first time contributing, we recommend you read the [Code
  Contribution Guidelines](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md)
- [x] All changes are Go version 1.12 compliant
- [x] The code being submitted is commented according to [Code Documentation and Commenting](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#CodeDocumentation)
- [x] For new code: Code is accompanied by tests which exercise both
  the positive and negative (error paths) conditions (if applicable)
- [x] For bug fixes: Code is accompanied by new tests which trigger
  the bug being fixed to prevent regressions
- [x] Any new logging statements use an appropriate subsystem and
  logging level
- [x] Code has been formatted with `go fmt`
- [x] Protobuf files (`lnrpc/**/*.proto`) have been formatted with
  `make rpc-format` and compiled with `make rpc`
- [x] For code and documentation: lines are wrapped at 80 characters
  (the tab character should be counted as 8 characters, not 4, as some IDEs do
  per default)
- [x] Running `make check` does not fail any tests
- [x] Running `go vet` does not report any issues
- [x] Running `make lint` does not report any **new** issues that did not
  already exist
- [x] All commits build properly and pass tests. Only in exceptional
  cases it can be justifiable to violate this condition. In that case, the
  reason should be stated in the commit message.
- [x] Commits have a logical structure according to [Ideal Git Commit Structure](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#IdealGitCommitStructure)
