### PR TITLE
discovery: no graph sync

### DIFF
--- a/lntest/itest/lnd_test.go
+++ b/lntest/itest/lnd_test.go
@@ -10398,7 +10398,7 @@ func testGraphTopologyNtfns(net *lntest.NetworkHarness, t *harnessTest, pinned b
 	var aliceArgs []string
 	if pinned {
 		aliceArgs = []string{
-			"--numgraphsyncpeers=1",
+			"--numgraphsyncpeers=0",
 			fmt.Sprintf("--gossip.pinned-syncers=%s", bobPubkey),
 		}
 	}


### PR DESCRIPTION
Depends on #4934, only the last commit is new.

Changes behavior when `numgraphsyncpeers=0` to forgo syncing entirely.