### PR TITLE
GitHub: use vendored actions for steps with sensitive info

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -18,13 +18,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
+        uses: lightninglabs/gh-actions/setup-qemu-action@2021.01.25.00
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: lightninglabs/gh-actions/setup-buildx-action@2021.01.25.00
 
       - name: Login to DockerHub
-        uses: docker/login-action@v1
+        uses: lightninglabs/gh-actions/login-action@2021.01.25.00
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_API_KEY }}
@@ -34,7 +34,7 @@ jobs:
 
       - name: Build and push
         id: docker_build
-        uses: docker/build-push-action@v2
+        uses: lightninglabs/gh-actions/build-push-action@2021.01.25.00
         with:
           push: true
           platforms: linux/amd64,linux/arm64

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -51,7 +51,7 @@ jobs:
         run: SKIP_VERSION_CHECK=1 make release tag=${{ env.RELEASE_VERSION }}
 
       - name: Create Release
-        uses: softprops/action-gh-release@v1
+        uses: lightninglabs/gh-actions/action-gh-release@2021.01.25.00
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:


### PR DESCRIPTION
To avoid leaking any sensitive information like Docker Hub credentials
because of compromised actions repositories, we use our own, vendored
actions for all steps that potentially touch sensitive information.
