### PR TITLE
funding: wait for received FundingLocked before sending ChannelUpdate

### DIFF
--- a/funding/manager_test.go
+++ b/funding/manager_test.go
@@ -964,12 +964,12 @@ func assertFundingLockedSent(t *testing.T, alice, bob *testNode,
 	assertDatabaseState(t, bob, fundingOutPoint, fundingLockedSent)
 }
 
-func assertAddedToRouterGraph(t *testing.T, alice, bob *testNode,
+func assertChanUpdateSent(t *testing.T, alice, bob *testNode,
 	fundingOutPoint *wire.OutPoint) {
 	t.Helper()
 
-	assertDatabaseState(t, alice, fundingOutPoint, addedToRouterGraph)
-	assertDatabaseState(t, bob, fundingOutPoint, addedToRouterGraph)
+	assertDatabaseState(t, alice, fundingOutPoint, chanUpdateSent)
+	assertDatabaseState(t, bob, fundingOutPoint, chanUpdateSent)
 }
 
 // assertChannelAnnouncements checks that alice and bob both sends the expected
@@ -1244,7 +1244,7 @@ func TestFundingManagerNormalWorkflow(t *testing.T) {
 	assertChannelAnnouncements(t, alice, bob, capacity, nil, nil)
 
 	// Check that the state machine is updated accordingly
-	assertAddedToRouterGraph(t, alice, bob, fundingOutPoint)
+	assertChanUpdateSent(t, alice, bob, fundingOutPoint)
 
 	// The funding transaction is now confirmed, wait for the
 	// OpenStatusUpdate_ChanOpen update
@@ -1549,7 +1549,7 @@ func TestFundingManagerRestartBehavior(t *testing.T) {
 	assertChannelAnnouncements(t, alice, bob, capacity, nil, nil)
 
 	// Check that the state machine is updated accordingly
-	assertAddedToRouterGraph(t, alice, bob, fundingOutPoint)
+	assertChanUpdateSent(t, alice, bob, fundingOutPoint)
 
 	// Next, we check that Alice sends the announcement signatures
 	// on restart after six confirmations. Bob should as expected send
@@ -1687,7 +1687,7 @@ func TestFundingManagerOfflinePeer(t *testing.T) {
 	assertChannelAnnouncements(t, alice, bob, capacity, nil, nil)
 
 	// Check that the state machine is updated accordingly
-	assertAddedToRouterGraph(t, alice, bob, fundingOutPoint)
+	assertChanUpdateSent(t, alice, bob, fundingOutPoint)
 
 	// The funding transaction is now confirmed, wait for the
 	// OpenStatusUpdate_ChanOpen update
@@ -2098,7 +2098,7 @@ func TestFundingManagerReceiveFundingLockedTwice(t *testing.T) {
 	assertChannelAnnouncements(t, alice, bob, capacity, nil, nil)
 
 	// Check that the state machine is updated accordingly
-	assertAddedToRouterGraph(t, alice, bob, fundingOutPoint)
+	assertChanUpdateSent(t, alice, bob, fundingOutPoint)
 
 	// The funding transaction is now confirmed, wait for the
 	// OpenStatusUpdate_ChanOpen update
@@ -2201,7 +2201,7 @@ func TestFundingManagerRestartAfterChanAnn(t *testing.T) {
 	assertChannelAnnouncements(t, alice, bob, capacity, nil, nil)
 
 	// Check that the state machine is updated accordingly
-	assertAddedToRouterGraph(t, alice, bob, fundingOutPoint)
+	assertChanUpdateSent(t, alice, bob, fundingOutPoint)
 
 	// The funding transaction is now confirmed, wait for the
 	// OpenStatusUpdate_ChanOpen update
@@ -2302,7 +2302,7 @@ func TestFundingManagerRestartAfterReceivingFundingLocked(t *testing.T) {
 	assertChannelAnnouncements(t, alice, bob, capacity, nil, nil)
 
 	// Check that the state machine is updated accordingly
-	assertAddedToRouterGraph(t, alice, bob, fundingOutPoint)
+	assertChanUpdateSent(t, alice, bob, fundingOutPoint)
 
 	// Notify that six confirmations has been reached on funding transaction.
 	alice.mockNotifier.sixConfChannel <- &chainntnfs.TxConfirmation{
@@ -2485,9 +2485,9 @@ func TestFundingManagerPrivateRestart(t *testing.T) {
 	// announcements.
 	assertChannelAnnouncements(t, alice, bob, capacity, nil, nil)
 
-	// Note: We don't check for the addedToRouterGraph state because in
+	// Note: We don't check for the chanUpdateSent state because in
 	// the private channel mode, the state is quickly changed from
-	// addedToRouterGraph to deleted from the database since the public
+	// chanUpdateSent to deleted from the database since the public
 	// announcement phase is skipped.
 
 	// The funding transaction is now confirmed, wait for the


### PR DESCRIPTION
BOLT#7 states that

```
MUST NOT send a created channel_update before funding_locked has been received.
```

We were violating this by not waiting for the message to have been
received from the peer before sending our channel update.

The consequence of not waiting for FundingLocked to be received was that
there was no gurarantee the peer was ready to receive our ChannelUpdate,
which could lead to it being ignored. This was manifested as flakes
during itests.

Now we instead synchronize the state machine with the funding locked
handler, ensureing we don't continue before the message has been
received. To make this work we have to separate adding the
ChannelAnnouncment to the graph from the ChannelUpdate, which requires
us to introduce two new states to the state machine.