### PR TITLE
netann: ignore unknown channel update on startup

### DIFF
--- a/netann/chan_status_manager.go
+++ b/netann/chan_status_manager.go
@@ -182,6 +182,16 @@ func (m *ChanStatusManager) start() error {
 				"in the process of closing.", c.FundingOutpoint)
 			continue
 
+		// If we are in the process of opening a channel, the funding
+		// manager might not have added the ChannelUpdate to the graph
+		// yet. We'll ignore the channel for now.
+		case err == ErrUnableToExtractChanUpdate:
+			log.Warnf("Unable to find channel policies for %v, "+
+				"skipping. This is typical if the channel is "+
+				"in the process of being opened.",
+				c.FundingOutpoint)
+			continue
+
 		case err != nil:
 			return err
 		}

--- a/netann/channel_update.go
+++ b/netann/channel_update.go
@@ -11,6 +11,10 @@ import (
 	"github.com/lightningnetwork/lnd/lnwire"
 )
 
+// ErrUnableToExtractChanUpdate is returned when a channel update cannot be
+// found for one of our active channels.
+var ErrUnableToExtractChanUpdate = fmt.Errorf("unable to extract ChannelUpdate")
+
 // ChannelUpdateModifier is a closure that makes in-place modifications to an
 // lnwire.ChannelUpdate.
 type ChannelUpdateModifier func(*lnwire.ChannelUpdate)
@@ -107,8 +111,7 @@ func ExtractChannelUpdate(ownerPubKey []byte,
 		}
 	}
 
-	return nil, fmt.Errorf("unable to extract ChannelUpdate for channel %v",
-		info.ChannelPoint)
+	return nil, ErrUnableToExtractChanUpdate
 }
 
 // UnsignedChannelUpdateFromEdge reconstructs an unsigned ChannelUpdate from the


### PR DESCRIPTION
Since the funding manager might be in process of adding the edge to the
graph, we ignore the error.

Fixes #4798 