### PR TITLE
scripts: don't fail signature verification on missing public key

### DIFF
--- a/scripts/verify-install.sh
+++ b/scripts/verify-install.sh
@@ -107,13 +107,16 @@ NUM_CHECKS=0
 for signature in $SIGNATURES; do
   # First make sure the downloaded signature file is valid.
   echo "Verifying $signature"
-  if ! gpg --verify "$signature" 2>&1 | grep -q "Good signature"; then
+  if gpg --verify "$signature" 2>&1 | grep -q "Good signature"; then
+    echo "Signature for $signature checks out: "
+    gpg --verify "$signature" 2>&1 | grep "using"
+  elif gpg --verify "$signature" 2>&1 | grep -q "No public key"; then
+    echo "Unable to verify signature $signature, no key available, skipping"
+    continue
+  else
     echo "ERROR: Did not get valid signature for $signature!"
     exit 1
   fi
-
-  echo "Signature for $signature checks out: "
-  gpg --verify "$signature" 2>&1 | grep "using"
 
   echo ""
 


### PR DESCRIPTION
When verifying the release signatures, we don't want to fail if a
signer's signature is not available in the gpg key ring. Instead we just
don't want to count the signature for now and still succeed if there's
at least one other good sig with a known key.

