### PR TITLE
gen_protos_docker: make image build non-quiet

### DIFF
--- a/lnrpc/gen_protos_docker.sh
+++ b/lnrpc/gen_protos_docker.sh
@@ -9,7 +9,7 @@ PROTOC_GEN_VERSION=$(go list -f '{{.Version}}' -m github.com/golang/protobuf)
 GRPC_GATEWAY_VERSION=$(go list -f '{{.Version}}' -m github.com/grpc-ecosystem/grpc-gateway)
 
 echo "Building protobuf compiler docker image..."
-docker build -q -t lnd-protobuf-builder \
+docker build -t lnd-protobuf-builder \
   --build-arg PROTOC_GEN_VERSION="$PROTOC_GEN_VERSION" \
   --build-arg GRPC_GATEWAY_VERSION="$GRPC_GATEWAY_VERSION" \
   .


### PR DESCRIPTION
This allows users to see progress whenever the docker image is
[re]built, and (esp on non-linux hosts) track the size of the build
context being uploaded. Currently no output is displayed, so it's hard
to attribute the source of latency, e.g. network latency, building
layers, a large work directory, etc.