### PR TITLE
invoices+rpc: add missing channel graph to the AddInvoiceConfig

### DIFF
--- a/lnrpc/invoicesrpc/config_active.go
+++ b/lnrpc/invoicesrpc/config_active.go
@@ -44,9 +44,13 @@ type Config struct {
 	// specified.
 	DefaultCLTVExpiry uint32
 
-	// ChanDB is a global boltdb instance which is needed to access the
+	// LocalChanDB is a global boltdb instance which is needed to access the
 	// channel graph.
-	ChanDB *channeldb.DB
+	LocalChanDB *channeldb.DB
+
+	// RemoteChanDB is a replicatd db instance which is the same as the
+	// localdb when running without remote db.
+	RemoteChanDB *channeldb.DB
 
 	// GenInvoiceFeatures returns a feature containing feature bits that
 	// should be advertised on freshly generated invoices.

--- a/lnrpc/invoicesrpc/invoices_server.go
+++ b/lnrpc/invoicesrpc/invoices_server.go
@@ -278,7 +278,8 @@ func (s *Server) AddHoldInvoice(ctx context.Context,
 		ChainParams:        s.cfg.ChainParams,
 		NodeSigner:         s.cfg.NodeSigner,
 		DefaultCLTVExpiry:  s.cfg.DefaultCLTVExpiry,
-		ChanDB:             s.cfg.ChanDB,
+		ChanDB:             s.cfg.RemoteChanDB,
+		Graph:              s.cfg.LocalChanDB.ChannelGraph(),
 		GenInvoiceFeatures: s.cfg.GenInvoiceFeatures,
 	}
 

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -621,9 +621,9 @@ func newRPCServer(cfg *Config, s *server, macService *macaroons.Service,
 	err = subServerCgs.PopulateDependencies(
 		cfg, s.cc, cfg.networkDir, macService, atpl, invoiceRegistry,
 		s.htlcSwitch, cfg.ActiveNetParams.Params, s.chanRouter,
-		routerBackend, s.nodeSigner, s.remoteChanDB, s.sweeper, tower,
-		s.towerClient, s.anchorTowerClient, cfg.net.ResolveTCPAddr,
-		genInvoiceFeatures, rpcsLog,
+		routerBackend, s.nodeSigner, s.localChanDB, s.remoteChanDB,
+		s.sweeper, tower, s.towerClient, s.anchorTowerClient,
+		cfg.net.ResolveTCPAddr, genInvoiceFeatures, rpcsLog,
 	)
 	if err != nil {
 		return nil, err

--- a/subrpcserver_config.go
+++ b/subrpcserver_config.go
@@ -92,7 +92,8 @@ func (s *subRPCServerConfigs) PopulateDependencies(cfg *Config,
 	chanRouter *routing.ChannelRouter,
 	routerBackend *routerrpc.RouterBackend,
 	nodeSigner *netann.NodeSigner,
-	chanDB *channeldb.DB,
+	localChanDB *channeldb.DB,
+	remoteChanDB *channeldb.DB,
 	sweeper *sweep.UtxoSweeper,
 	tower *watchtower.Standalone,
 	towerClient wtclient.Client,
@@ -220,8 +221,11 @@ func (s *subRPCServerConfigs) PopulateDependencies(cfg *Config,
 			subCfgValue.FieldByName("DefaultCLTVExpiry").Set(
 				reflect.ValueOf(defaultDelta),
 			)
-			subCfgValue.FieldByName("ChanDB").Set(
-				reflect.ValueOf(chanDB),
+			subCfgValue.FieldByName("LocalChanDB").Set(
+				reflect.ValueOf(localChanDB),
+			)
+			subCfgValue.FieldByName("RemoteChanDB").Set(
+				reflect.ValueOf(remoteChanDB),
 			)
 			subCfgValue.FieldByName("GenInvoiceFeatures").Set(
 				reflect.ValueOf(genInvoiceFeatures),


### PR DESCRIPTION
`AddHodlInvoice` as copying `AddInvoiceConfig`, leaving out the `Graph` member which later on resulted in a `nil` pointer reference.