### PR TITLE
routing: add new TestPaymentAddrOnlyNoSplit test case 

### DIFF
--- a/routing/integrated_routing_context_test.go
+++ b/routing/integrated_routing_context_test.go
@@ -88,8 +88,16 @@ func (h htlcAttempt) String() string {
 
 // testPayment launches a test payment and asserts that it is completed after
 // the expected number of attempts.
-func (c *integratedRoutingContext) testPayment(maxParts uint32) ([]htlcAttempt,
-	error) {
+func (c *integratedRoutingContext) testPayment(maxParts uint32,
+	destFeatureBits ...lnwire.FeatureBit) ([]htlcAttempt, error) {
+
+	// We start out with the base set of MPP feature bits. If the caller
+	// overrides this set of bits, then we'll use their feature bits
+	// entirely.
+	baseFeatureBits := mppFeatures
+	if len(destFeatureBits) != 0 {
+		baseFeatureBits = lnwire.NewRawFeatureVector(destFeatureBits...)
+	}
 
 	var (
 		nextPid  uint64
@@ -136,7 +144,7 @@ func (c *integratedRoutingContext) testPayment(maxParts uint32) ([]htlcAttempt,
 		FeeLimit:       lnwire.MaxMilliSatoshi,
 		Target:         c.target.pubkey,
 		PaymentAddr:    &paymentAddr,
-		DestFeatures:   lnwire.NewFeatureVector(mppFeatures, nil),
+		DestFeatures:   lnwire.NewFeatureVector(baseFeatureBits, nil),
 		Amount:         c.amt,
 		CltvLimit:      math.MaxUint32,
 		MaxParts:       maxParts,


### PR DESCRIPTION
This test case ensures that we won't try to split payment if the dest
has the payment addr bit, but NOT the mpp optional/require bit.