### PR TITLE
docker+make: use shared base docker image for all Docker images

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,7 +21,6 @@ env:
   # If you change this value, please change it in the following files as well:
   # /docker/lnd-go-base/Dockerfile
   # /.travis.yml
-  # /make/builder.Dockerfile
   # /.github/workflows/release.yml
   GO_VERSION: 1.15.7
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,7 +21,6 @@ env:
   # If you change this value, please change it in the following files as well:
   # /docker/lnd-go-base/Dockerfile
   # /.travis.yml
-  # /dev.Dockerfile
   # /make/builder.Dockerfile
   # /.github/workflows/release.yml
   GO_VERSION: 1.15.7

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,6 +19,7 @@ env:
   BITCOIN_VERSION: 0.20.1
 
   # If you change this value, please change it in the following files as well:
+  # /docker/lnd-go-base/Dockerfile
   # /.travis.yml
   # /Dockerfile
   # /dev.Dockerfile

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,7 +21,6 @@ env:
   # If you change this value, please change it in the following files as well:
   # /docker/lnd-go-base/Dockerfile
   # /.travis.yml
-  # /Dockerfile
   # /dev.Dockerfile
   # /make/builder.Dockerfile
   # /.github/workflows/release.yml

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -11,6 +11,7 @@ defaults:
 
 env:
   # If you change this value, please change it in the following files as well:
+  # /docker/lnd-go-base/Dockerfile
   # /.travis.yml
   # /Dockerfile
   # /dev.Dockerfile

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -13,7 +13,6 @@ env:
   # If you change this value, please change it in the following files as well:
   # /docker/lnd-go-base/Dockerfile
   # /.travis.yml
-  # /make/builder.Dockerfile
   # /.github/workflows/main.yml
   GO_VERSION: 1.15.7
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -13,7 +13,6 @@ env:
   # If you change this value, please change it in the following files as well:
   # /docker/lnd-go-base/Dockerfile
   # /.travis.yml
-  # /Dockerfile
   # /dev.Dockerfile
   # /make/builder.Dockerfile
   # /.github/workflows/main.yml

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -13,7 +13,6 @@ env:
   # If you change this value, please change it in the following files as well:
   # /docker/lnd-go-base/Dockerfile
   # /.travis.yml
-  # /dev.Dockerfile
   # /make/builder.Dockerfile
   # /.github/workflows/main.yml
   GO_VERSION: 1.15.7

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,7 @@ go:
   # /Dockerfile
   # /dev.Dockerfile
   # /make/builder.Dockerfile
+  # /docker/lnd-go-base/Dockerfile
   # /.github/workflows/main.yml
   # /.github/workflows/release.yml
   - "1.15.7"

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,6 @@ git:
 
 go:
   # If you change this value, please change it in the following files as well:
-  # /dev.Dockerfile
   # /make/builder.Dockerfile
   # /docker/lnd-go-base/Dockerfile
   # /.github/workflows/main.yml

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,6 @@ git:
 
 go:
   # If you change this value, please change it in the following files as well:
-  # /make/builder.Dockerfile
   # /docker/lnd-go-base/Dockerfile
   # /.github/workflows/main.yml
   # /.github/workflows/release.yml

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,6 @@ git:
 
 go:
   # If you change this value, please change it in the following files as well:
-  # /Dockerfile
   # /dev.Dockerfile
   # /make/builder.Dockerfile
   # /docker/lnd-go-base/Dockerfile

--- a/Makefile
+++ b/Makefile
@@ -180,6 +180,9 @@ docker-lnd-dev: docker-go-base
 docker-release-helper: docker-go-base
 	docker build -t lnd-release-helper -f make/builder.Dockerfile make/
 
+docker-btcd: docker-go-base
+	docker build -t lnd-btcd ./docker/btcd
+
 # =======
 # TESTING
 # =======

--- a/Makefile
+++ b/Makefile
@@ -155,11 +155,10 @@ release:
 	$(VERSION_CHECK)
 	./scripts/release.sh build-release "$(VERSION_TAG)" "$(BUILD_SYSTEM)" "$(RELEASE_TAGS)" "$(RELEASE_LDFLAGS)"
 
-docker-release:
+docker-release: docker-release-helper
 	@$(call print, "Building release helper docker image.")
 	if [ "$(tag)" = "" ]; then echo "Must specify tag=<commit_or_tag>!"; exit 1; fi
 
-	docker build -t lnd-release-helper -f make/builder.Dockerfile make/
 	$(DOCKER_RELEASE_HELPER) scripts/release.sh check-tag "$(VERSION_TAG)"
 	$(DOCKER_RELEASE_HELPER) scripts/release.sh build-release "$(VERSION_TAG)" "$(BUILD_SYSTEM)" "$(RELEASE_TAGS)" "$(RELEASE_LDFLAGS)"
 
@@ -177,6 +176,9 @@ docker-lnd: docker-go-base
 
 docker-lnd-dev: docker-go-base
 	docker build $(DOCKER_LND_DEV_TAG) -f dev.Dockerfile .
+
+docker-release-helper: docker-go-base
+	docker build -t lnd-release-helper -f make/builder.Dockerfile make/
 
 # =======
 # TESTING

--- a/Makefile
+++ b/Makefile
@@ -165,7 +165,12 @@ docker-release:
 
 scratch: build
 
+# ======
+# DOCKER
+# ======
 
+docker-go-base:
+	docker build -t lnd-go-base ./docker/lnd-go-base
 # =======
 # TESTING
 # =======

--- a/Makefile
+++ b/Makefile
@@ -276,7 +276,7 @@ list:
 		grep -v Makefile | \
 		sort
 
-rpc:
+rpc: docker-go-base
 	@$(call print, "Compiling protos.")
 	cd ./lnrpc; ./gen_protos_docker.sh
 

--- a/Makefile
+++ b/Makefile
@@ -171,6 +171,10 @@ scratch: build
 
 docker-go-base:
 	docker build -t lnd-go-base ./docker/lnd-go-base
+
+docker-lnd: docker-go-base
+	docker build $(DOCKER_LND_TAG) $(DOCKER_CHECKOUT) ./docker/lnd
+
 # =======
 # TESTING
 # =======

--- a/Makefile
+++ b/Makefile
@@ -183,6 +183,9 @@ docker-release-helper: docker-go-base
 docker-btcd: docker-go-base
 	docker build -t lnd-btcd ./docker/btcd
 
+docker-ltcd: docker-go-base
+	docker build -t lnd-ltcd ./docker/ltcd
+
 # =======
 # TESTING
 # =======

--- a/Makefile
+++ b/Makefile
@@ -175,6 +175,9 @@ docker-go-base:
 docker-lnd: docker-go-base
 	docker build $(DOCKER_LND_TAG) $(DOCKER_CHECKOUT) ./docker/lnd
 
+docker-lnd-dev: docker-go-base
+	docker build $(DOCKER_LND_DEV_TAG) -f dev.Dockerfile .
+
 # =======
 # TESTING
 # =======

--- a/dev.Dockerfile
+++ b/dev.Dockerfile
@@ -1,16 +1,6 @@
-# If you change this value, please change it in the following files as well:
-# /.travis.yml
-# /Dockerfile
-# /make/builder.Dockerfile
-# /.github/workflows/main.yml
-# /.github/workflows/release.yml
-FROM golang:1.15.7-alpine as builder
+FROM lnd-go-base:latest as builder
 
 LABEL maintainer="Olaoluwa Osuntokun <laolu@lightning.engineering>"
-
-# Force Go to use the cgo based DNS resolver. This is required to ensure DNS
-# queries required to connect to linked containers succeed.
-ENV GODEBUG netdns=cgo
 
 # Install dependencies and install/build lnd.
 RUN apk add --no-cache --update alpine-sdk \

--- a/docker/btcd/Dockerfile
+++ b/docker/btcd/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.15.7-alpine as builder
+FROM lnd-go-base:latest as builder
 
 LABEL maintainer="Olaoluwa Osuntokun <laolu@lightning.engineering>"
 

--- a/docker/lnd-go-base/Dockerfile
+++ b/docker/lnd-go-base/Dockerfile
@@ -1,0 +1,17 @@
+# If you change this value, please change it in the following files as well:
+# /.travis.yml
+# /.github/workflows/main.yml
+# /.github/workflows/release.yml
+FROM golang:1.15.7-alpine
+
+MAINTAINER Olaoluwa Osuntokun <laolu@lightning.engineering>
+
+# Golang build related environment variables that are static and used for all
+# architectures/OSes.
+
+# Force Go to use the cgo based DNS resolver. This is required to ensure DNS
+# queries required to connect to linked containers succeed.
+ENV GODEBUG netdns=cgo
+
+ENV GO111MODULE=auto
+ENV CGO_ENABLED=0

--- a/docker/lnd/Dockerfile
+++ b/docker/lnd/Dockerfile
@@ -1,14 +1,6 @@
-# If you change this value, please change it in the following files as well:
-# /.travis.yml
-# /dev.Dockerfile
-# /make/builder.Dockerfile
-# /.github/workflows/main.yml
-# /.github/workflows/release.yml
-FROM golang:1.15.7-alpine as builder
+FROM lnd-go-base:latest as builder
 
-# Force Go to use the cgo based DNS resolver. This is required to ensure DNS
-# queries required to connect to linked containers succeed.
-ENV GODEBUG netdns=cgo
+LABEL maintainer="Olaoluwa Osuntokun <laolu@lightning.engineering>"
 
 # Pass a tag, branch or a commit using build-arg.  This allows a docker
 # image to be built from a specified Git state.  The default image

--- a/docker/ltcd/Dockerfile
+++ b/docker/ltcd/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.15.7-alpine as builder
+FROM lnd-go-base:latest as builder
 
 LABEL maintainer="Olaoluwa Osuntokun <laolu@lightning.engineering>"
 

--- a/docs/DOCKER.md
+++ b/docs/DOCKER.md
@@ -29,7 +29,7 @@ Docker container, adding the appropriate command-line options as parameters.
 You first need to build the `lnd` docker image:
 
 ```shell
-⛰  docker build --tag=myrepository/lnd --build-arg checkout=v0.11.1-beta .
+⛰  make docker-lnd checkout=v0.11.1-beta tag=myrpository/lnd-dev
 ```
 
 It is recommended that you checkout the latest released tag.
@@ -114,19 +114,19 @@ To test the Docker production image locally, run the following from
 the project root:
 
 ```shell
-⛰  docker build . -t myrepository/lnd:master
+⛰  make docker-lnd tag=myrepository/lnd:master
 ```
 
 To choose a specific branch or tag instead, use the "checkout" build-arg.  For example, to build the latest commits in master:
 
 ```shell
-⛰  docker build . --build-arg checkout=v0.8.0-beta -t myrepository/lnd:v0.8.0-beta
+⛰  make docker-lnd checkout=v0.8.0-beta tag=myrepository/lnd:master
 ```
 
 To build the image using the most current tag:
 
 ```shell
-⛰  docker build . --build-arg checkout=$(git describe --tags `git rev-list --tags --max-count=1`) -t myrepository/lnd:latest-tag
+⛰  make docker-lnd checkout=$(git describe --tags `git rev-list --tags --max-count=1`) tag=myrepository/lnd:latest-tag
 ```
 
 Once the image has been built and tagged locally, start the container:

--- a/docs/DOCKER.md
+++ b/docs/DOCKER.md
@@ -13,7 +13,7 @@ To build a standalone development image from the local source directory, use the
 following command:
 
 ```shell
-⛰  docker build --tag=myrepository/lnd-dev -f dev.Dockerfile .
+⛰  make docker-lnd-dev tag=myrpository/lnd-dev
 ```
 
 There is also a `docker-compose` setup available for development or testing that

--- a/lnrpc/Dockerfile
+++ b/lnrpc/Dockerfile
@@ -1,9 +1,10 @@
-FROM golang:1.15.7-buster
+FROM lnd-go-base:latest
 
-RUN apt-get update && apt-get install -y \
+RUN apk add --no-cache --update alpine-sdk \
   git \
-  protobuf-compiler='3.6.1*' \
-  clang-format='1:7.0*'
+  bash \
+  protoc=3.13.0-r2 \
+  clang=10.0.1-r0
 
 # We don't want any default values for these variables to make sure they're
 # explicitly provided by parsing the go.mod file. Otherwise we might forget to

--- a/lnrpc/gen_protos.sh
+++ b/lnrpc/gen_protos.sh
@@ -15,18 +15,18 @@ function generate() {
     echo "Generating protos from ${file}, into ${DIRECTORY}"
   
     # Generate the protos.
-    protoc -I/usr/local/include -I. \
+    protoc \
       --go_out=plugins=grpc,paths=source_relative:. \
       "${file}"
   
     # Generate the REST reverse proxy.
-    protoc -I/usr/local/include -I. \
+    protoc \
       --grpc-gateway_out=logtostderr=true,paths=source_relative,grpc_api_configuration=rest-annotations.yaml:. \
       "${file}"
   
   
     # Finally, generate the swagger file which describes the REST API in detail.
-    protoc -I/usr/local/include -I. \
+    protoc \
       --swagger_out=logtostderr=true,grpc_api_configuration=rest-annotations.yaml:. \
       "${file}"
   done

--- a/make/builder.Dockerfile
+++ b/make/builder.Dockerfile
@@ -1,18 +1,6 @@
-# If you change this value, please change it in the following files as well:
-# /.travis.yml
-# /Dockerfile
-# /dev.Dockerfile
-# /.github/workflows/main.yml
-# /.github/workflows/release.yml
-FROM golang:1.15.7-buster
+FROM lnd-go-base:latest
 
 MAINTAINER Olaoluwa Osuntokun <laolu@lightning.engineering>
-
-# Golang build related environment variables that are static and used for all
-# architectures/OSes.
-ENV GODEBUG netdns=cgo
-ENV GO111MODULE=auto
-ENV CGO_ENABLED=0
 
 # Set up cache directories. Those will be mounted from the host system to speed
 # up builds. If go isn't installed on the host system, those will fall back to
@@ -20,7 +8,7 @@ ENV CGO_ENABLED=0
 ENV GOCACHE=/tmp/build/.cache
 ENV GOMODCACHE=/tmp/build/.modcache
 
-RUN apt-get update && apt-get install -y \
+RUN apk add --no-cache --update alpine-sdk \
     git \
     make \
     tar \

--- a/make/testing_flags.mk
+++ b/make/testing_flags.mk
@@ -109,8 +109,10 @@ endif
 # Allows users to tag their docker builds, defaults to :latest if blank.
 ifneq ($(tag),)
 DOCKER_LND_TAG := -t $(tag)
+DOCKER_LND_DEV_TAG := -t $(tag)
 else
 DOCKER_LND_TAG := -t lnd
+DOCKER_LND_DEV_TAG := -t lnd-dev
 endif
 
 # Construct the integration test command with the added build flags.

--- a/make/testing_flags.mk
+++ b/make/testing_flags.mk
@@ -100,5 +100,18 @@ ifeq ($(backend),)
 backend = btcd
 endif
 
+# Allows users to checkout a particular commit/tag when building the lnd docker
+# image. Blank defaults to master.
+ifneq ($(checkout),)
+DOCKER_CHECKOUT := --build-arg checkout=$(checkout)
+endif
+
+# Allows users to tag their docker builds, defaults to :latest if blank.
+ifneq ($(tag),)
+DOCKER_LND_TAG := -t $(tag)
+else
+DOCKER_LND_TAG := -t lnd
+endif
+
 # Construct the integration test command with the added build flags.
 ITEST_TAGS := $(DEV_TAGS) $(RPC_TAGS) rpctest $(backend)


### PR DESCRIPTION
This PR creates a base `lnd-go-base` image (currently go1.15.7) from which all other Dockerfiles are built from.

Currently there are 6 separate Docker images:
 - `Dockerfile`
 - `dev.Dockerfile`
 - `make/builder.Dockerfile`
 - `docker/btcd/Dockerfile`
 - `docker/ltcd/Dockerfile`
 - `lnrpc/Dockerfile`

Historically, keeping all of their base images in sync and updated to the same version of go has been problematic.
By unifying each's base image to build from `lnd-go-base`, we ensure that all images used in the development/testing/release cycle use an identical version, since there is only one variable to change in the entire codebase.

However, this architecture relies on keeping `lnd-go-base` update to date before building any of the Dockerfiles listed above, otherwise one may be building from an out-of-date `lnd-go-base:latest`. To ensure `lnd-go-base` is in sync with the current commit before building the final image, we introduce a host of additional make targets:
 - `make docker-go-base`
 - `make docker-lnd`
 - `make docker-lnd-dev`
 - `make docker-release-helper`
 - `make docker-btcd`
 - `make docker-ltcd`

Apart from the first, all of these specify `docker-go-base` as a dependency and force it to be built (or not if cached) before building the final image. In addition, `make rpc` adds `docker-go-base` as a dependency, since it invokes a docker build from within its shell script.

The `make docker-lnd` includes make arguments that allow for checking out a particular commit/hash as well as tagging the final image, which provides similar ergonomics to invoking docker directly, e.g.
```
make docker-lnd checkout=v0.8.0-beta tag=myrepository/lnd:master
```