### PR TITLE
[gRPC] WalletUnlocker and RPCServer unification

### DIFF
--- a/lnd.go
+++ b/lnd.go
@@ -45,6 +45,7 @@ import (
 	"github.com/lightningnetwork/lnd/lnwallet"
 	"github.com/lightningnetwork/lnd/lnwallet/btcwallet"
 	"github.com/lightningnetwork/lnd/macaroons"
+	"github.com/lightningnetwork/lnd/rpcperms"
 	"github.com/lightningnetwork/lnd/signal"
 	"github.com/lightningnetwork/lnd/tor"
 	"github.com/lightningnetwork/lnd/walletunlocker"
@@ -375,6 +376,15 @@ func Main(cfg *Config, lisCfg ListenerCfg, shutdownChan <-chan struct{}) error {
 		return getListeners()
 	}
 
+	// Create a new RPC interceptor chain that we'll add to the GRPC
+	// server. This will be used to log the API calls invoked on the GRPC
+	// server.
+	interceptorChain := rpcperms.NewInterceptorChain(
+		rpcsLog, cfg.NoMacaroons,
+	)
+	rpcServerOpts := interceptorChain.CreateServerOpts()
+	serverOpts = append(serverOpts, rpcServerOpts...)
+
 	// We wait until the user provides a password over RPC. In case lnd is
 	// started with the --noseedbackup flag, we use the default password
 	// for wallet encryption.
@@ -492,6 +502,11 @@ func Main(cfg *Config, lisCfg ListenerCfg, shutdownChan <-chan struct{}) error {
 				ltndLog.Warnf(msg, "invoice", cfg.InvoiceMacPath)
 			}
 		}
+
+		// We add the macaroon service to our RPC interceptor. This
+		// will start checking macaroons against permissions on every
+		// RPC invocation.
+		interceptorChain.AddMacaroonService(macaroonService)
 	}
 
 	// Now we're definitely done with the unlocker, shut it down so we can
@@ -737,6 +752,7 @@ func Main(cfg *Config, lisCfg ListenerCfg, shutdownChan <-chan struct{}) error {
 		cfg, server, macaroonService, cfg.SubRPCServers, serverOpts,
 		restDialOpts, restProxyDest, atplManager, server.invoices,
 		tower, restListen, rpcListeners, chainedAcceptor,
+		interceptorChain,
 	)
 	if err != nil {
 		err := fmt.Errorf("unable to create RPC server: %v", err)

--- a/lnd.go
+++ b/lnd.go
@@ -163,14 +163,6 @@ type ListenerWithSignal struct {
 
 	// Ready will be closed by the server listening on Listener.
 	Ready chan struct{}
-
-	// ExternalRPCSubserverCfg is optional and specifies the registration
-	// callback and permissions to register external gRPC subservers.
-	ExternalRPCSubserverCfg *RPCSubserverConfig
-
-	// ExternalRestRegistrar is optional and specifies the registration
-	// callback to register external REST subservers.
-	ExternalRestRegistrar RestRegistrar
 }
 
 // ListenerCfg is a wrapper around custom listeners that can be passed to lnd
@@ -183,6 +175,14 @@ type ListenerCfg struct {
 	// RPCListener can be set to the listener to use for the RPC server. If
 	// nil a regular network listener will be created.
 	RPCListener *ListenerWithSignal
+
+	// ExternalRPCSubserverCfg is optional and specifies the registration
+	// callback and permissions to register external gRPC subservers.
+	ExternalRPCSubserverCfg *RPCSubserverConfig
+
+	// ExternalRestRegistrar is optional and specifies the registration
+	// callback to register external REST subservers.
+	ExternalRestRegistrar RestRegistrar
 }
 
 // rpcListeners is a function type used for closures that fetches a set of RPC
@@ -752,7 +752,8 @@ func Main(cfg *Config, lisCfg ListenerCfg, shutdownChan <-chan struct{}) error {
 		cfg, server, macaroonService, cfg.SubRPCServers, serverOpts,
 		restDialOpts, restProxyDest, atplManager, server.invoices,
 		tower, restListen, rpcListeners, chainedAcceptor,
-		interceptorChain,
+		interceptorChain, lisCfg.ExternalRPCSubserverCfg,
+		lisCfg.ExternalRestRegistrar,
 	)
 	if err != nil {
 		err := fmt.Errorf("unable to create RPC server: %v", err)

--- a/lnrpc/autopilotrpc/driver.go
+++ b/lnrpc/autopilotrpc/driver.go
@@ -13,7 +13,7 @@ import (
 // that is meant for us in the config dispatcher, then we'll exit with an
 // error.
 func createNewSubServer(configRegistry lnrpc.SubServerConfigDispatcher) (
-	lnrpc.SubServer, lnrpc.MacaroonPerms, error) {
+	*Server, lnrpc.MacaroonPerms, error) {
 
 	// We'll attempt to look up the config that we expect, according to our
 	// subServerName name. If we can't find this, then we'll exit with an
@@ -48,9 +48,8 @@ func createNewSubServer(configRegistry lnrpc.SubServerConfigDispatcher) (
 func init() {
 	subServer := &lnrpc.SubServerDriver{
 		SubServerName: subServerName,
-		New: func(c lnrpc.SubServerConfigDispatcher) (lnrpc.SubServer,
-			lnrpc.MacaroonPerms, error) {
-			return createNewSubServer(c)
+		NewGrpcHandler: func() lnrpc.GrpcHandler {
+			return &ServerShell{}
 		},
 	}
 

--- a/lnrpc/chainrpc/chainnotifier_server.go
+++ b/lnrpc/chainrpc/chainnotifier_server.go
@@ -72,6 +72,13 @@ var (
 		"still in the process of starting")
 )
 
+// ServerShell is a shell struct holding a reference to the actual sub-server.
+// It is used to register the gRPC sub-server with the root server before we
+// have the necessary dependencies to populate the actual sub-server.
+type ServerShell struct {
+	ChainNotifierServer
+}
+
 // Server is a sub-server of the main RPC server: the chain notifier RPC. This
 // RPC sub-server allows external callers to access the full chain notifier
 // capabilities of lnd. This allows callers to create custom protocols, external
@@ -172,11 +179,11 @@ func (s *Server) Name() string {
 // sub-server to register itself with the main gRPC root server. Until this is
 // called, each sub-server won't be able to have requests routed towards it.
 //
-// NOTE: This is part of the lnrpc.SubServer interface.
-func (s *Server) RegisterWithRootServer(grpcServer *grpc.Server) error {
+// NOTE: This is part of the lnrpc.GrpcHandler interface.
+func (r *ServerShell) RegisterWithRootServer(grpcServer *grpc.Server) error {
 	// We make sure that we register it with the main gRPC server to ensure
 	// all our methods are routed properly.
-	RegisterChainNotifierServer(grpcServer, s)
+	RegisterChainNotifierServer(grpcServer, r)
 
 	log.Debug("ChainNotifier RPC server successfully register with root " +
 		"gRPC server")
@@ -188,8 +195,8 @@ func (s *Server) RegisterWithRootServer(grpcServer *grpc.Server) error {
 // RPC server to register itself with the main REST mux server. Until this is
 // called, each sub-server won't be able to have requests routed towards it.
 //
-// NOTE: This is part of the lnrpc.SubServer interface.
-func (s *Server) RegisterWithRestServer(ctx context.Context,
+// NOTE: This is part of the lnrpc.GrpcHandler interface.
+func (r *ServerShell) RegisterWithRestServer(ctx context.Context,
 	mux *runtime.ServeMux, dest string, opts []grpc.DialOption) error {
 
 	// We make sure that we register it with the main REST server to ensure
@@ -204,6 +211,25 @@ func (s *Server) RegisterWithRestServer(ctx context.Context,
 	log.Debugf("ChainNotifier REST server successfully registered with " +
 		"root REST server")
 	return nil
+}
+
+// CreateSubServer populates the subserver's dependencies using the passed
+// SubServerConfigDispatcher. This method should fully initialize the
+// sub-server instance, making it ready for action. It returns the macaroon
+// permissions that the sub-server wishes to pass on to the root server for all
+// methods routed towards it.
+//
+// NOTE: This is part of the lnrpc.GrpcHandler interface.
+func (r *ServerShell) CreateSubServer(configRegistry lnrpc.SubServerConfigDispatcher) (
+	lnrpc.SubServer, lnrpc.MacaroonPerms, error) {
+
+	subServer, macPermissions, err := createNewSubServer(configRegistry)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	r.ChainNotifierServer = subServer
+	return subServer, macPermissions, nil
 }
 
 // RegisterConfirmationsNtfn is a synchronous response-streaming RPC that

--- a/lnrpc/chainrpc/driver.go
+++ b/lnrpc/chainrpc/driver.go
@@ -13,7 +13,7 @@ import (
 // the config that is meant for us in the config dispatcher, then we'll exit
 // with an error.
 func createNewSubServer(configRegistry lnrpc.SubServerConfigDispatcher) (
-	lnrpc.SubServer, lnrpc.MacaroonPerms, error) {
+	*Server, lnrpc.MacaroonPerms, error) {
 
 	// We'll attempt to look up the config that we expect, according to our
 	// subServerName name. If we can't find this, then we'll exit with an
@@ -55,10 +55,8 @@ func createNewSubServer(configRegistry lnrpc.SubServerConfigDispatcher) (
 func init() {
 	subServer := &lnrpc.SubServerDriver{
 		SubServerName: subServerName,
-		New: func(c lnrpc.SubServerConfigDispatcher) (
-			lnrpc.SubServer, lnrpc.MacaroonPerms, error) {
-
-			return createNewSubServer(c)
+		NewGrpcHandler: func() lnrpc.GrpcHandler {
+			return &ServerShell{}
 		},
 	}
 

--- a/lnrpc/invoicesrpc/driver.go
+++ b/lnrpc/invoicesrpc/driver.go
@@ -13,7 +13,7 @@ import (
 // that is meant for us in the config dispatcher, then we'll exit with an
 // error.
 func createNewSubServer(configRegistry lnrpc.SubServerConfigDispatcher) (
-	lnrpc.SubServer, lnrpc.MacaroonPerms, error) {
+	*Server, lnrpc.MacaroonPerms, error) {
 
 	// We'll attempt to look up the config that we expect, according to our
 	// subServerName name. If we can't find this, then we'll exit with an
@@ -40,9 +40,8 @@ func createNewSubServer(configRegistry lnrpc.SubServerConfigDispatcher) (
 func init() {
 	subServer := &lnrpc.SubServerDriver{
 		SubServerName: subServerName,
-		New: func(c lnrpc.SubServerConfigDispatcher) (lnrpc.SubServer,
-			lnrpc.MacaroonPerms, error) {
-			return createNewSubServer(c)
+		NewGrpcHandler: func() lnrpc.GrpcHandler {
+			return &ServerShell{}
 		},
 	}
 

--- a/lnrpc/invoicesrpc/invoices_server.go
+++ b/lnrpc/invoicesrpc/invoices_server.go
@@ -66,6 +66,13 @@ var (
 	DefaultInvoicesMacFilename = "invoices.macaroon"
 )
 
+// ServerShell is a shell struct holding a reference to the actual sub-server.
+// It is used to register the gRPC sub-server with the root server before we
+// have the necessary dependencies to populate the actual sub-server.
+type ServerShell struct {
+	InvoicesServer
+}
+
 // Server is a sub-server of the main RPC server: the invoices RPC. This sub
 // RPC server allows external callers to access the status of the invoices
 // currently active within lnd, as well as configuring it at runtime.
@@ -157,11 +164,11 @@ func (s *Server) Name() string {
 // RPC server to register itself with the main gRPC root server. Until this is
 // called, each sub-server won't be able to have requests routed towards it.
 //
-// NOTE: This is part of the lnrpc.SubServer interface.
-func (s *Server) RegisterWithRootServer(grpcServer *grpc.Server) error {
+// NOTE: This is part of the lnrpc.GrpcHandler interface.
+func (r *ServerShell) RegisterWithRootServer(grpcServer *grpc.Server) error {
 	// We make sure that we register it with the main gRPC server to ensure
 	// all our methods are routed properly.
-	RegisterInvoicesServer(grpcServer, s)
+	RegisterInvoicesServer(grpcServer, r)
 
 	log.Debugf("Invoices RPC server successfully registered with root " +
 		"gRPC server")
@@ -173,8 +180,8 @@ func (s *Server) RegisterWithRootServer(grpcServer *grpc.Server) error {
 // RPC server to register itself with the main REST mux server. Until this is
 // called, each sub-server won't be able to have requests routed towards it.
 //
-// NOTE: This is part of the lnrpc.SubServer interface.
-func (s *Server) RegisterWithRestServer(ctx context.Context,
+// NOTE: This is part of the lnrpc.GrpcHandler interface.
+func (r *ServerShell) RegisterWithRestServer(ctx context.Context,
 	mux *runtime.ServeMux, dest string, opts []grpc.DialOption) error {
 
 	// We make sure that we register it with the main REST server to ensure
@@ -189,6 +196,25 @@ func (s *Server) RegisterWithRestServer(ctx context.Context,
 	log.Debugf("Invoices REST server successfully registered with " +
 		"root REST server")
 	return nil
+}
+
+// CreateSubServer populates the subserver's dependencies using the passed
+// SubServerConfigDispatcher. This method should fully initialize the
+// sub-server instance, making it ready for action. It returns the macaroon
+// permissions that the sub-server wishes to pass on to the root server for all
+// methods routed towards it.
+//
+// NOTE: This is part of the lnrpc.GrpcHandler interface.
+func (r *ServerShell) CreateSubServer(configRegistry lnrpc.SubServerConfigDispatcher) (
+	lnrpc.SubServer, lnrpc.MacaroonPerms, error) {
+
+	subServer, macPermissions, err := createNewSubServer(configRegistry)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	r.InvoicesServer = subServer
+	return subServer, macPermissions, nil
 }
 
 // SubscribeSingleInvoice returns a uni-directional stream (server -> client)

--- a/lnrpc/routerrpc/driver.go
+++ b/lnrpc/routerrpc/driver.go
@@ -11,7 +11,7 @@ import (
 // config that is meant for us in the config dispatcher, then we'll exit with
 // an error.
 func createNewSubServer(configRegistry lnrpc.SubServerConfigDispatcher) (
-	lnrpc.SubServer, lnrpc.MacaroonPerms, error) {
+	*Server, lnrpc.MacaroonPerms, error) {
 
 	// We'll attempt to look up the config that we expect, according to our
 	// subServerName name. If we can't find this, then we'll exit with an
@@ -46,8 +46,8 @@ func createNewSubServer(configRegistry lnrpc.SubServerConfigDispatcher) (
 func init() {
 	subServer := &lnrpc.SubServerDriver{
 		SubServerName: subServerName,
-		New: func(c lnrpc.SubServerConfigDispatcher) (lnrpc.SubServer, lnrpc.MacaroonPerms, error) {
-			return createNewSubServer(c)
+		NewGrpcHandler: func() lnrpc.GrpcHandler {
+			return &ServerShell{}
 		},
 	}
 

--- a/lnrpc/signrpc/driver.go
+++ b/lnrpc/signrpc/driver.go
@@ -13,7 +13,7 @@ import (
 // config that is meant for us in the config dispatcher, then we'll exit with
 // an error.
 func createNewSubServer(configRegistry lnrpc.SubServerConfigDispatcher) (
-	lnrpc.SubServer, lnrpc.MacaroonPerms, error) {
+	*Server, lnrpc.MacaroonPerms, error) {
 
 	// We'll attempt to look up the config that we expect, according to our
 	// subServerName name. If we can't find this, then we'll exit with an
@@ -55,10 +55,8 @@ func createNewSubServer(configRegistry lnrpc.SubServerConfigDispatcher) (
 func init() {
 	subServer := &lnrpc.SubServerDriver{
 		SubServerName: subServerName,
-		New: func(c lnrpc.SubServerConfigDispatcher) (
-			lnrpc.SubServer, lnrpc.MacaroonPerms, error) {
-
-			return createNewSubServer(c)
+		NewGrpcHandler: func() lnrpc.GrpcHandler {
+			return &ServerShell{}
 		},
 	}
 

--- a/lnrpc/signrpc/signer_server.go
+++ b/lnrpc/signrpc/signer_server.go
@@ -76,6 +76,13 @@ var (
 	DefaultSignerMacFilename = "signer.macaroon"
 )
 
+// ServerShell is a shell struct holding a reference to the actual sub-server.
+// It is used to register the gRPC sub-server with the root server before we
+// have the necessary dependencies to populate the actual sub-server.
+type ServerShell struct {
+	SignerServer
+}
+
 // Server is a sub-server of the main RPC server: the signer RPC. This sub RPC
 // server allows external callers to access the full signing capabilities of
 // lnd. This allows callers to create custom protocols, external to lnd, even
@@ -167,11 +174,11 @@ func (s *Server) Name() string {
 // is called, each sub-server won't be able to have
 // requests routed towards it.
 //
-// NOTE: This is part of the lnrpc.SubServer interface.
-func (s *Server) RegisterWithRootServer(grpcServer *grpc.Server) error {
+// NOTE: This is part of the lnrpc.GrpcHandler interface.
+func (r *ServerShell) RegisterWithRootServer(grpcServer *grpc.Server) error {
 	// We make sure that we register it with the main gRPC server to ensure
 	// all our methods are routed properly.
-	RegisterSignerServer(grpcServer, s)
+	RegisterSignerServer(grpcServer, r)
 
 	log.Debugf("Signer RPC server successfully register with root gRPC " +
 		"server")
@@ -183,8 +190,8 @@ func (s *Server) RegisterWithRootServer(grpcServer *grpc.Server) error {
 // RPC server to register itself with the main REST mux server. Until this is
 // called, each sub-server won't be able to have requests routed towards it.
 //
-// NOTE: This is part of the lnrpc.SubServer interface.
-func (s *Server) RegisterWithRestServer(ctx context.Context,
+// NOTE: This is part of the lnrpc.GrpcHandler interface.
+func (r *ServerShell) RegisterWithRestServer(ctx context.Context,
 	mux *runtime.ServeMux, dest string, opts []grpc.DialOption) error {
 
 	// We make sure that we register it with the main REST server to ensure
@@ -199,6 +206,25 @@ func (s *Server) RegisterWithRestServer(ctx context.Context,
 	log.Debugf("Signer REST server successfully registered with " +
 		"root REST server")
 	return nil
+}
+
+// CreateSubServer populates the subserver's dependencies using the passed
+// SubServerConfigDispatcher. This method should fully initialize the
+// sub-server instance, making it ready for action. It returns the macaroon
+// permissions that the sub-server wishes to pass on to the root server for all
+// methods routed towards it.
+//
+// NOTE: This is part of the lnrpc.GrpcHandler interface.
+func (r *ServerShell) CreateSubServer(configRegistry lnrpc.SubServerConfigDispatcher) (
+	lnrpc.SubServer, lnrpc.MacaroonPerms, error) {
+
+	subServer, macPermissions, err := createNewSubServer(configRegistry)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	r.SignerServer = subServer
+	return subServer, macPermissions, nil
 }
 
 // SignOutputRaw generates a signature for the passed transaction according to

--- a/lnrpc/verrpc/driver.go
+++ b/lnrpc/verrpc/driver.go
@@ -9,10 +9,8 @@ import (
 func init() {
 	subServer := &lnrpc.SubServerDriver{
 		SubServerName: subServerName,
-		New: func(c lnrpc.SubServerConfigDispatcher) (lnrpc.SubServer,
-			lnrpc.MacaroonPerms, error) {
-
-			return &Server{}, macPermissions, nil
+		NewGrpcHandler: func() lnrpc.GrpcHandler {
+			return &ServerShell{}
 		},
 	}
 

--- a/lnrpc/verrpc/server.go
+++ b/lnrpc/verrpc/server.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/grpc-ecosystem/grpc-gateway/runtime"
 	"github.com/lightningnetwork/lnd/build"
+	"github.com/lightningnetwork/lnd/lnrpc"
 	"google.golang.org/grpc"
 	"gopkg.in/macaroon-bakery.v2/bakery"
 )
@@ -16,6 +17,13 @@ var macPermissions = map[string][]bakery.Op{
 		Entity: "info",
 		Action: "read",
 	}},
+}
+
+// ServerShell is a shell struct holding a reference to the actual sub-server.
+// It is used to register the gRPC sub-server with the root server before we
+// have the necessary dependencies to populate the actual sub-server.
+type ServerShell struct {
+	VersionerServer
 }
 
 // Server is an rpc server that supports querying for information about the
@@ -48,9 +56,9 @@ func (s *Server) Name() string {
 // sub RPC server to register itself with the main gRPC root server. Until this
 // is called, each sub-server won't be able to have requests routed towards it.
 //
-// NOTE: This is part of the lnrpc.SubServer interface.
-func (s *Server) RegisterWithRootServer(grpcServer *grpc.Server) error {
-	RegisterVersionerServer(grpcServer, s)
+// NOTE: This is part of the lnrpc.GrpcHandler interface.
+func (r *ServerShell) RegisterWithRootServer(grpcServer *grpc.Server) error {
+	RegisterVersionerServer(grpcServer, r)
 
 	log.Debugf("Versioner RPC server successfully registered with root " +
 		"gRPC server")
@@ -62,8 +70,8 @@ func (s *Server) RegisterWithRootServer(grpcServer *grpc.Server) error {
 // RPC server to register itself with the main REST mux server. Until this is
 // called, each sub-server won't be able to have requests routed towards it.
 //
-// NOTE: This is part of the lnrpc.SubServer interface.
-func (s *Server) RegisterWithRestServer(ctx context.Context,
+// NOTE: This is part of the lnrpc.GrpcHandler interface.
+func (r *ServerShell) RegisterWithRestServer(ctx context.Context,
 	mux *runtime.ServeMux, dest string, opts []grpc.DialOption) error {
 
 	// We make sure that we register it with the main REST server to ensure
@@ -78,6 +86,21 @@ func (s *Server) RegisterWithRestServer(ctx context.Context,
 	log.Debugf("Versioner REST server successfully registered with " +
 		"root REST server")
 	return nil
+}
+
+// CreateSubServer populates the subserver's dependencies using the passed
+// SubServerConfigDispatcher. This method should fully initialize the
+// sub-server instance, making it ready for action. It returns the macaroon
+// permissions that the sub-server wishes to pass on to the root server for all
+// methods routed towards it.
+//
+// NOTE: This is part of the lnrpc.GrpcHandler interface.
+func (r *ServerShell) CreateSubServer(_ lnrpc.SubServerConfigDispatcher) (
+	lnrpc.SubServer, lnrpc.MacaroonPerms, error) {
+
+	subServer := &Server{}
+	r.VersionerServer = subServer
+	return subServer, macPermissions, nil
 }
 
 // GetVersion returns information about the compiled binary.

--- a/lnrpc/walletrpc/driver.go
+++ b/lnrpc/walletrpc/driver.go
@@ -12,7 +12,9 @@ import (
 // sub server given the main config dispatcher method. If we're unable to find
 // the config that is meant for us in the config dispatcher, then we'll exit
 // with an error.
-func createNewSubServer(configRegistry lnrpc.SubServerConfigDispatcher) (lnrpc.SubServer, lnrpc.MacaroonPerms, error) {
+func createNewSubServer(configRegistry lnrpc.SubServerConfigDispatcher) (
+	*WalletKit, lnrpc.MacaroonPerms, error) {
+
 	// We'll attempt to look up the config that we expect, according to our
 	// subServerName name. If we can't find this, then we'll exit with an
 	// error, as we're unable to properly initialize ourselves without this
@@ -67,8 +69,8 @@ func createNewSubServer(configRegistry lnrpc.SubServerConfigDispatcher) (lnrpc.S
 func init() {
 	subServer := &lnrpc.SubServerDriver{
 		SubServerName: subServerName,
-		New: func(c lnrpc.SubServerConfigDispatcher) (lnrpc.SubServer, lnrpc.MacaroonPerms, error) {
-			return createNewSubServer(c)
+		NewGrpcHandler: func() lnrpc.GrpcHandler {
+			return &ServerShell{}
 		},
 	}
 

--- a/lnrpc/walletrpc/walletkit_server.go
+++ b/lnrpc/walletrpc/walletkit_server.go
@@ -148,6 +148,13 @@ var (
 // an empty label.
 var ErrZeroLabel = errors.New("cannot label transaction with empty label")
 
+// ServerShell is a shell struct holding a reference to the actual sub-server.
+// It is used to register the gRPC sub-server with the root server before we
+// have the necessary dependencies to populate the actual sub-server.
+type ServerShell struct {
+	WalletKitServer
+}
+
 // WalletKit is a sub-RPC server that exposes a tool kit which allows clients
 // to execute common wallet operations. This includes requesting new addresses,
 // keys (for contracts!), and publishing transactions.
@@ -233,11 +240,11 @@ func (w *WalletKit) Name() string {
 // sub RPC server to register itself with the main gRPC root server. Until this
 // is called, each sub-server won't be able to have requests routed towards it.
 //
-// NOTE: This is part of the lnrpc.SubServer interface.
-func (w *WalletKit) RegisterWithRootServer(grpcServer *grpc.Server) error {
+// NOTE: This is part of the lnrpc.GrpcHandler interface.
+func (r *ServerShell) RegisterWithRootServer(grpcServer *grpc.Server) error {
 	// We make sure that we register it with the main gRPC server to ensure
 	// all our methods are routed properly.
-	RegisterWalletKitServer(grpcServer, w)
+	RegisterWalletKitServer(grpcServer, r)
 
 	log.Debugf("WalletKit RPC server successfully registered with " +
 		"root gRPC server")
@@ -249,8 +256,8 @@ func (w *WalletKit) RegisterWithRootServer(grpcServer *grpc.Server) error {
 // RPC server to register itself with the main REST mux server. Until this is
 // called, each sub-server won't be able to have requests routed towards it.
 //
-// NOTE: This is part of the lnrpc.SubServer interface.
-func (w *WalletKit) RegisterWithRestServer(ctx context.Context,
+// NOTE: This is part of the lnrpc.GrpcHandler interface.
+func (r *ServerShell) RegisterWithRestServer(ctx context.Context,
 	mux *runtime.ServeMux, dest string, opts []grpc.DialOption) error {
 
 	// We make sure that we register it with the main REST server to ensure
@@ -265,6 +272,25 @@ func (w *WalletKit) RegisterWithRestServer(ctx context.Context,
 	log.Debugf("WalletKit REST server successfully registered with " +
 		"root REST server")
 	return nil
+}
+
+// CreateSubServer populates the subserver's dependencies using the passed
+// SubServerConfigDispatcher. This method should fully initialize the
+// sub-server instance, making it ready for action. It returns the macaroon
+// permissions that the sub-server wishes to pass on to the root server for all
+// methods routed towards it.
+//
+// NOTE: This is part of the lnrpc.GrpcHandler interface.
+func (r *ServerShell) CreateSubServer(configRegistry lnrpc.SubServerConfigDispatcher) (
+	lnrpc.SubServer, lnrpc.MacaroonPerms, error) {
+
+	subServer, macPermissions, err := createNewSubServer(configRegistry)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	r.WalletKitServer = subServer
+	return subServer, macPermissions, nil
 }
 
 // ListUnspent returns useful information about each unspent output owned by the

--- a/lnrpc/watchtowerrpc/driver.go
+++ b/lnrpc/watchtowerrpc/driver.go
@@ -13,7 +13,7 @@ import (
 // that is meant for us in the config dispatcher, then we'll exit with an
 // error.
 func createNewSubServer(configRegistry lnrpc.SubServerConfigDispatcher) (
-	lnrpc.SubServer, lnrpc.MacaroonPerms, error) {
+	*Handler, lnrpc.MacaroonPerms, error) {
 
 	// We'll attempt to look up the config that we expect, according to our
 	// subServerName name. If we can't find this, then we'll exit with an
@@ -40,9 +40,8 @@ func createNewSubServer(configRegistry lnrpc.SubServerConfigDispatcher) (
 func init() {
 	subServer := &lnrpc.SubServerDriver{
 		SubServerName: subServerName,
-		New: func(c lnrpc.SubServerConfigDispatcher) (lnrpc.SubServer,
-			lnrpc.MacaroonPerms, error) {
-			return createNewSubServer(c)
+		NewGrpcHandler: func() lnrpc.GrpcHandler {
+			return &ServerShell{}
 		},
 	}
 

--- a/lnrpc/wtclientrpc/driver.go
+++ b/lnrpc/wtclientrpc/driver.go
@@ -12,7 +12,7 @@ import (
 // that is meant for us in the config dispatcher, then we'll exit with an
 // error.
 func createNewSubServer(configRegistry lnrpc.SubServerConfigDispatcher) (
-	lnrpc.SubServer, lnrpc.MacaroonPerms, error) {
+	*WatchtowerClient, lnrpc.MacaroonPerms, error) {
 
 	// We'll attempt to look up the config that we expect, according to our
 	// subServerName name. If we can't find this, then we'll exit with an
@@ -46,9 +46,8 @@ func createNewSubServer(configRegistry lnrpc.SubServerConfigDispatcher) (
 func init() {
 	subServer := &lnrpc.SubServerDriver{
 		SubServerName: subServerName,
-		New: func(c lnrpc.SubServerConfigDispatcher) (lnrpc.SubServer,
-			lnrpc.MacaroonPerms, error) {
-			return createNewSubServer(c)
+		NewGrpcHandler: func() lnrpc.GrpcHandler {
+			return &ServerShell{}
 		},
 	}
 

--- a/lnrpc/wtclientrpc/wtclient.go
+++ b/lnrpc/wtclientrpc/wtclient.go
@@ -64,6 +64,13 @@ var (
 	ErrWtclientNotActive = errors.New("watchtower client not active")
 )
 
+// ServerShell is a shell struct holding a reference to the actual sub-server.
+// It is used to register the gRPC sub-server with the root server before we
+// have the necessary dependencies to populate the actual sub-server.
+type ServerShell struct {
+	WatchtowerClientServer
+}
+
 // WatchtowerClient is the RPC server we'll use to interact with the backing
 // active watchtower client.
 //
@@ -112,14 +119,11 @@ func (c *WatchtowerClient) Name() string {
 // RPC server to register itself with the main gRPC root server. Until this is
 // called, each sub-server won't be able to have requests routed towards it.
 //
-// NOTE: This is part of the lnrpc.SubServer interface.
-func (c *WatchtowerClient) RegisterWithRootServer(grpcServer *grpc.Server) error {
+// NOTE: This is part of the lnrpc.GrpcHandler interface.
+func (r *ServerShell) RegisterWithRootServer(grpcServer *grpc.Server) error {
 	// We make sure that we register it with the main gRPC server to ensure
 	// all our methods are routed properly.
-	RegisterWatchtowerClientServer(grpcServer, c)
-
-	c.cfg.Log.Debugf("WatchtowerClient RPC server successfully registered " +
-		"with  root gRPC server")
+	RegisterWatchtowerClientServer(grpcServer, r)
 
 	return nil
 }
@@ -128,8 +132,8 @@ func (c *WatchtowerClient) RegisterWithRootServer(grpcServer *grpc.Server) error
 // RPC server to register itself with the main REST mux server. Until this is
 // called, each sub-server won't be able to have requests routed towards it.
 //
-// NOTE: This is part of the lnrpc.SubServer interface.
-func (c *WatchtowerClient) RegisterWithRestServer(ctx context.Context,
+// NOTE: This is part of the lnrpc.GrpcHandler interface.
+func (r *ServerShell) RegisterWithRestServer(ctx context.Context,
 	mux *runtime.ServeMux, dest string, opts []grpc.DialOption) error {
 
 	// We make sure that we register it with the main REST server to ensure
@@ -140,6 +144,25 @@ func (c *WatchtowerClient) RegisterWithRestServer(ctx context.Context,
 	}
 
 	return nil
+}
+
+// CreateSubServer populates the subserver's dependencies using the passed
+// SubServerConfigDispatcher. This method should fully initialize the
+// sub-server instance, making it ready for action. It returns the macaroon
+// permissions that the sub-server wishes to pass on to the root server for all
+// methods routed towards it.
+//
+// NOTE: This is part of the lnrpc.GrpcHandler interface.
+func (r *ServerShell) CreateSubServer(configRegistry lnrpc.SubServerConfigDispatcher) (
+	lnrpc.SubServer, lnrpc.MacaroonPerms, error) {
+
+	subServer, macPermissions, err := createNewSubServer(configRegistry)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	r.WatchtowerClientServer = subServer
+	return subServer, macPermissions, nil
 }
 
 // isActive returns nil if the watchtower client is initialized so that we can

--- a/lntest/harness.go
+++ b/lntest/harness.go
@@ -300,8 +300,12 @@ func (n *NetworkHarness) NewNodeWithSeed(name string, extraArgs []string,
 
 	ctxt, cancel := context.WithTimeout(ctxb, DefaultTimeout)
 	defer cancel()
-	genSeedResp, err := node.GenSeed(ctxt, genSeedReq)
-	if err != nil {
+
+	var genSeedResp *lnrpc.GenSeedResponse
+	if err := wait.NoError(func() error {
+		genSeedResp, err = node.GenSeed(ctxt, genSeedReq)
+		return err
+	}, DefaultTimeout); err != nil {
 		return nil, nil, nil, err
 	}
 

--- a/lntest/itest/log_error_whitelist.txt
+++ b/lntest/itest/log_error_whitelist.txt
@@ -232,6 +232,15 @@
 <time> [ERR] RPCS: [/signrpc.Signer/DeriveSharedKey]: use either key_desc or key_loc
 <time> [ERR] RPCS: [/signrpc.Signer/DeriveSharedKey]: use either raw_key_bytes or key_index
 <time> [ERR] RPCS: [/signrpc.Signer/DeriveSharedKey]: when setting key_desc the field key_desc.key_loc must also be set
+<time> [ERR] RPCS: [/lnrpc.Lightning/BakeMacaroon]: permission denied
+<time> [ERR] RPCS: [/lnrpc.Lightning/GetInfo]: cannot retrieve macaroon: cannot get macaroon: root key with id  doesn't exist
+<time> [ERR] RPCS: [/lnrpc.Lightning/GetInfo]: caveat "ipaddr 1.1.1.1" not satisfied: macaroon locked to different IP address
+<time> [ERR] RPCS: [/lnrpc.Lightning/GetInfo]: caveat "time-before <time>" not satisfied: macaroon has expired
+<time> [ERR] RPCS: [/lnrpc.Lightning/GetInfo]: expected 1 macaroon, got 0
+<time> [ERR] RPCS: [/lnrpc.Lightning/GetInfo]: permission denied
+<time> [ERR] RPCS: [/lnrpc.Lightning/GetInfo]: the RPC server is in the process of starting up, but not yet ready to accept calls
+<time> [ERR] RPCS: [/lnrpc.Lightning/ListMacaroonIDs]: cannot retrieve macaroon: cannot get macaroon: root key with id 1 doesn't exist
+<time> [ERR] RPCS: [/lnrpc.Lightning/NewAddress]: permission denied
 <time> [ERR] RPCS: unable to open channel to NodeKey(<hex>): received funding error from <hex>: chan_id=<hex>, err=channel too large
 <time> [ERR] RPCS: unable to open channel to NodeKey(<hex>): received funding error from <hex>: chan_id=<hex>, err=chan size of 0.16777216 BTC exceeds maximum chan size of 0.16777215 BTC
 <time> [ERR] RPCS: unable to open channel to NodeKey(<hex>): received funding error from <hex>: chan_id=<hex>, err=chan size of 10.00000001 BTC exceeds maximum chan size of 0.16777215 BTC

--- a/lntest/itest/log_substitutions.txt
+++ b/lntest/itest/log_substitutions.txt
@@ -3,6 +3,7 @@ s/short_chan_id=[[:digit:]]+/short_chan_id=<cid>/g
 s/[0-9a-f]{16,}/<hex>/g
 s/[[:digit:]]+\.[[:digit:]]+\.[[:digit:]]+\.[[:digit:]]+\:[[:digit:]]+/<ip>/g
 s/[[:digit:]]{4}-[[:digit:]]{2}-[[:digit:]]{2} [[:digit:]]{2}:[[:digit:]]{2}:[[:digit:]]{2}\.[[:digit:]]{3}/<time>/g
+s/[[:digit:]]{4}-[[:digit:]]{2}-[[:digit:]]{2}T[[:digit:]]{2}:[[:digit:]]{2}:[[:digit:]]{2}\.[[:digit:]]{1,18}Z/<time>/g
 s/[[:digit:]]+\:[[:digit:]]+\:[[:digit:]]+/<chan>/g
 s/[[:digit:]]+ mSAT/<amt>/g
 s/HTLC ID = [[:digit:]]+/HTLC ID = <id>/g

--- a/log.go
+++ b/log.go
@@ -1,8 +1,6 @@
 package lnd
 
 import (
-	"context"
-
 	"github.com/btcsuite/btcd/connmgr"
 	"github.com/btcsuite/btclog"
 	"github.com/lightninglabs/neutrino"
@@ -42,7 +40,6 @@ import (
 	"github.com/lightningnetwork/lnd/sweep"
 	"github.com/lightningnetwork/lnd/watchtower"
 	"github.com/lightningnetwork/lnd/watchtower/wtclient"
-	"google.golang.org/grpc"
 )
 
 // replaceableLogger is a thin wrapper around a logger that is used so the
@@ -174,37 +171,4 @@ func (c logClosure) String() string {
 // logging system.
 func newLogClosure(c func() string) logClosure {
 	return logClosure(c)
-}
-
-// errorLogUnaryServerInterceptor is a simple UnaryServerInterceptor that will
-// automatically log any errors that occur when serving a client's unary
-// request.
-func errorLogUnaryServerInterceptor(logger btclog.Logger) grpc.UnaryServerInterceptor {
-	return func(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo,
-		handler grpc.UnaryHandler) (interface{}, error) {
-
-		resp, err := handler(ctx, req)
-		if err != nil {
-			// TODO(roasbeef): also log request details?
-			logger.Errorf("[%v]: %v", info.FullMethod, err)
-		}
-
-		return resp, err
-	}
-}
-
-// errorLogStreamServerInterceptor is a simple StreamServerInterceptor that
-// will log any errors that occur while processing a client or server streaming
-// RPC.
-func errorLogStreamServerInterceptor(logger btclog.Logger) grpc.StreamServerInterceptor {
-	return func(srv interface{}, ss grpc.ServerStream,
-		info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
-
-		err := handler(srv, ss)
-		if err != nil {
-			logger.Errorf("[%v]: %v", info.FullMethod, err)
-		}
-
-		return err
-	}
 }

--- a/rpcperms/interceptor.go
+++ b/rpcperms/interceptor.go
@@ -1,0 +1,259 @@
+package rpcperms
+
+import (
+	"context"
+	"fmt"
+	"sync"
+
+	"github.com/btcsuite/btclog"
+	grpc_middleware "github.com/grpc-ecosystem/go-grpc-middleware"
+	"github.com/lightningnetwork/lnd/macaroons"
+	"github.com/lightningnetwork/lnd/monitoring"
+	"google.golang.org/grpc"
+	"gopkg.in/macaroon-bakery.v2/bakery"
+)
+
+// InterceptorChain is a struct that can be added to the running GRPC server,
+// intercepting API calls. This is useful for logging, enforcing permissions
+// etc.
+type InterceptorChain struct {
+	// noMacaroons should be set true if we don't want to check macaroons.
+	noMacaroons bool
+
+	// svc is the macaroon service used to enforce permissions in case
+	// macaroons are used.
+	svc *macaroons.Service
+
+	// permissionMap is the permissions to enforce if macaroons are used.
+	permissionMap map[string][]bakery.Op
+
+	// rpcsLog is the logger used to log calles to the RPCs intercepted.
+	rpcsLog btclog.Logger
+
+	sync.RWMutex
+}
+
+// NewInterceptorChain creates a new InterceptorChain.
+func NewInterceptorChain(log btclog.Logger, noMacaroons bool) *InterceptorChain {
+	return &InterceptorChain{
+		noMacaroons:   noMacaroons,
+		permissionMap: make(map[string][]bakery.Op),
+		rpcsLog:       log,
+	}
+}
+
+// AddMacaroonService adds a macaroon service to the interceptor. After this is
+// done every RPC call made will have to pass a valid macaroon to be accepted.
+func (r *InterceptorChain) AddMacaroonService(svc *macaroons.Service) {
+	r.Lock()
+	defer r.Unlock()
+
+	r.svc = svc
+}
+
+// AddPermission adds a new macaroon rule for the given method.
+func (r *InterceptorChain) AddPermission(method string, ops []bakery.Op) error {
+	r.Lock()
+	defer r.Unlock()
+
+	if _, ok := r.permissionMap[method]; ok {
+		return fmt.Errorf("detected duplicate macaroon constraints "+
+			"for path: %v", method)
+	}
+
+	r.permissionMap[method] = ops
+	return nil
+}
+
+// Permissions returns the current set of macaroon permissions.
+func (r *InterceptorChain) Permissions() map[string][]bakery.Op {
+	r.RLock()
+	defer r.RUnlock()
+
+	// Make a copy under the read lock to avoid races.
+	c := make(map[string][]bakery.Op)
+	for k, v := range r.permissionMap {
+		s := make([]bakery.Op, len(v))
+		copy(s, v)
+		c[k] = s
+	}
+
+	return c
+}
+
+// CreateServerOpts creates the GRPC server options that can be added to a GRPC
+// server in order to add this InterceptorChain.
+func (r *InterceptorChain) CreateServerOpts() []grpc.ServerOption {
+	macUnaryInterceptors := []grpc.UnaryServerInterceptor{}
+	macStrmInterceptors := []grpc.StreamServerInterceptor{}
+
+	// We'll add the macaroon interceptors. If macaroons aren't disabled,
+	// then these interceptors will enforce macaroon authentication.
+	unaryInterceptor := r.macaroonUnaryServerInterceptor()
+	macUnaryInterceptors = append(macUnaryInterceptors, unaryInterceptor)
+
+	strmInterceptor := r.macaroonStreamServerInterceptor()
+	macStrmInterceptors = append(macStrmInterceptors, strmInterceptor)
+
+	// Get interceptors for Prometheus to gather gRPC performance metrics.
+	// If monitoring is disabled, GetPromInterceptors() will return empty
+	// slices.
+	promUnaryInterceptors, promStrmInterceptors :=
+		monitoring.GetPromInterceptors()
+
+	// Concatenate the slices of unary and stream interceptors respectively.
+	unaryInterceptors := append(macUnaryInterceptors, promUnaryInterceptors...)
+	strmInterceptors := append(macStrmInterceptors, promStrmInterceptors...)
+
+	// We'll also add our logging interceptors as well, so we can
+	// automatically log all errors that happen during RPC calls.
+	unaryInterceptors = append(
+		unaryInterceptors, errorLogUnaryServerInterceptor(r.rpcsLog),
+	)
+	strmInterceptors = append(
+		strmInterceptors, errorLogStreamServerInterceptor(r.rpcsLog),
+	)
+
+	// Create server options from the interceptors we just set up.
+	chainedUnary := grpc_middleware.WithUnaryServerChain(
+		unaryInterceptors...,
+	)
+	chainedStream := grpc_middleware.WithStreamServerChain(
+		strmInterceptors...,
+	)
+	serverOpts := []grpc.ServerOption{chainedUnary, chainedStream}
+
+	return serverOpts
+}
+
+// errorLogUnaryServerInterceptor is a simple UnaryServerInterceptor that will
+// automatically log any errors that occur when serving a client's unary
+// request.
+func errorLogUnaryServerInterceptor(logger btclog.Logger) grpc.UnaryServerInterceptor {
+	return func(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo,
+		handler grpc.UnaryHandler) (interface{}, error) {
+
+		resp, err := handler(ctx, req)
+		if err != nil {
+			// TODO(roasbeef): also log request details?
+			logger.Errorf("[%v]: %v", info.FullMethod, err)
+		}
+
+		return resp, err
+	}
+}
+
+// errorLogStreamServerInterceptor is a simple StreamServerInterceptor that
+// will log any errors that occur while processing a client or server streaming
+// RPC.
+func errorLogStreamServerInterceptor(logger btclog.Logger) grpc.StreamServerInterceptor {
+	return func(srv interface{}, ss grpc.ServerStream,
+		info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
+
+		err := handler(srv, ss)
+		if err != nil {
+			logger.Errorf("[%v]: %v", info.FullMethod, err)
+		}
+
+		return err
+	}
+}
+
+// macaroonUnaryServerInterceptor is a GRPC interceptor that checks whether the
+// request is authorized by the included macaroons.
+func (r *InterceptorChain) macaroonUnaryServerInterceptor() grpc.UnaryServerInterceptor {
+	return func(ctx context.Context, req interface{},
+		info *grpc.UnaryServerInfo,
+		handler grpc.UnaryHandler) (interface{}, error) {
+
+		// If noMacaroons are set, we'll always allow the call.
+		if r.noMacaroons {
+			return handler(ctx, req)
+		}
+
+		r.RLock()
+		svc := r.svc
+		r.RUnlock()
+
+		// If the macaroon service is not yet active, allow the call.
+		// THis means that the wallet has not yet been unlocked, and we
+		// allow calls to the WalletUnlockerService.
+		if svc == nil {
+			return handler(ctx, req)
+		}
+
+		r.RLock()
+		uriPermissions, ok := r.permissionMap[info.FullMethod]
+		r.RUnlock()
+		if !ok {
+			return nil, fmt.Errorf("%s: unknown permissions "+
+				"required for method", info.FullMethod)
+		}
+
+		// Find out if there is an external validator registered for
+		// this method. Fall back to the internal one if there isn't.
+		validator, ok := svc.ExternalValidators[info.FullMethod]
+		if !ok {
+			validator = svc
+		}
+
+		// Now that we know what validator to use, let it do its work.
+		err := validator.ValidateMacaroon(
+			ctx, uriPermissions, info.FullMethod,
+		)
+		if err != nil {
+			return nil, err
+		}
+
+		return handler(ctx, req)
+	}
+}
+
+// macaroonStreamServerInterceptor is a GRPC interceptor that checks whether
+// the request is authorized by the included macaroons.
+func (r *InterceptorChain) macaroonStreamServerInterceptor() grpc.StreamServerInterceptor {
+	return func(srv interface{}, ss grpc.ServerStream,
+		info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
+
+		// If noMacaroons are set, we'll always allow the call.
+		if r.noMacaroons {
+			return handler(srv, ss)
+		}
+
+		r.RLock()
+		svc := r.svc
+		r.RUnlock()
+
+		// If the macaroon service is not yet active, allow the call.
+		// THis means that the wallet has not yet been unlocked, and we
+		// allow calls to the WalletUnlockerService.
+		if svc == nil {
+			return handler(srv, ss)
+		}
+
+		r.RLock()
+		uriPermissions, ok := r.permissionMap[info.FullMethod]
+		r.RUnlock()
+		if !ok {
+			return fmt.Errorf("%s: unknown permissions required "+
+				"for method", info.FullMethod)
+		}
+
+		// Find out if there is an external validator registered for
+		// this method. Fall back to the internal one if there isn't.
+		validator, ok := svc.ExternalValidators[info.FullMethod]
+		if !ok {
+			validator = svc
+		}
+
+		// Now that we know what validator to use, let it do its work.
+		err := validator.ValidateMacaroon(
+			ss.Context(), uriPermissions, info.FullMethod,
+		)
+		if err != nil {
+			return err
+		}
+
+		return handler(srv, ss)
+	}
+}

--- a/rpcperms/interceptor.go
+++ b/rpcperms/interceptor.go
@@ -193,10 +193,10 @@ func (r *InterceptorChain) CreateServerOpts() []grpc.ServerOption {
 	// We'll add the macaroon interceptors. If macaroons aren't disabled,
 	// then these interceptors will enforce macaroon authentication.
 	unaryInterceptors = append(
-		unaryInterceptors, r.macaroonUnaryServerInterceptor(),
+		unaryInterceptors, r.MacaroonUnaryServerInterceptor(),
 	)
 	strmInterceptors = append(
-		strmInterceptors, r.macaroonStreamServerInterceptor(),
+		strmInterceptors, r.MacaroonStreamServerInterceptor(),
 	)
 
 	// Get interceptors for Prometheus to gather gRPC performance metrics.
@@ -300,9 +300,9 @@ func (r *InterceptorChain) checkMacaroon(ctx context.Context,
 	return validator.ValidateMacaroon(ctx, uriPermissions, fullMethod)
 }
 
-// macaroonUnaryServerInterceptor is a GRPC interceptor that checks whether the
+// MacaroonUnaryServerInterceptor is a GRPC interceptor that checks whether the
 // request is authorized by the included macaroons.
-func (r *InterceptorChain) macaroonUnaryServerInterceptor() grpc.UnaryServerInterceptor {
+func (r *InterceptorChain) MacaroonUnaryServerInterceptor() grpc.UnaryServerInterceptor {
 	return func(ctx context.Context, req interface{},
 		info *grpc.UnaryServerInfo,
 		handler grpc.UnaryHandler) (interface{}, error) {
@@ -316,9 +316,9 @@ func (r *InterceptorChain) macaroonUnaryServerInterceptor() grpc.UnaryServerInte
 	}
 }
 
-// macaroonStreamServerInterceptor is a GRPC interceptor that checks whether
+// MacaroonStreamServerInterceptor is a GRPC interceptor that checks whether
 // the request is authorized by the included macaroons.
-func (r *InterceptorChain) macaroonStreamServerInterceptor() grpc.StreamServerInterceptor {
+func (r *InterceptorChain) MacaroonStreamServerInterceptor() grpc.StreamServerInterceptor {
 	return func(srv interface{}, ss grpc.ServerStream,
 		info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
 

--- a/walletunlocker/service.go
+++ b/walletunlocker/service.go
@@ -160,6 +160,17 @@ func New(chainDir string, params *chaincfg.Params, noFreelistSync bool,
 	}
 }
 
+// WalletExists returns whether a wallet exists on the file path the
+// UnlockerService is using.
+func (u *UnlockerService) WalletExists() (bool, error) {
+	netDir := btcwallet.NetworkDir(u.chainDir, u.netParams)
+	loader := wallet.NewLoader(
+		u.netParams, netDir, u.noFreelistSync, u.dbTimeout, 0,
+	)
+
+	return loader.WalletExists()
+}
+
 // GenSeed is the first method that should be used to instantiate a new lnd
 // instance. This method allows a caller to generate a new aezeed cipher seed
 // given an optional passphrase. If provided, the passphrase will be necessary


### PR DESCRIPTION
This PR unifies the gRPC server used for the `WalletUnlockerService` and `LightningService`, making both services available at all times. This addresses a long-standing issue of the gRPC server being torn down and restarted after unlocking the wallet.

### Overview
The reason for the original design of tearing down the gRPC server after unlocking the wallet, was that the RPC server (`LightningService`) was dependent on the wallet being unlocked in order to being created. We mitigate this by now creating the RPC server before the wallet is unlocked, in a "non-functioning" state just in order to register its interface with the gRPC server. After the wallet is finally unlocked, we can populate the dependencies of the root RPC server and its subservers, enabling the full `LightningService` to be operational.

### RPC state interception
Since the RPC server shouldn't be used before it has been fully initialized, we gate the calls to the services through a new gRPC interceptor found in the `rpcperms` package. This `RPCInterceptor` keeps track of the current state of the wallet and RPC server, and allows or rejects calls to the various services based on this. We also move macaroon authentication here.

The RPC state tracked by the `RPCInterceptor` also paves the way for a coming new RPC endpoint for exposing the unlocking state of the wallet. 

Fixes #3982 
Fixes https://github.com/lightningnetwork/lnd/issues/4340
Fixes https://github.com/lightningnetwork/lnd/issues/3631