### PR TITLE
contractcourt: track best block height in chain arbitrator

### DIFF
--- a/contractcourt/channel_arbitrator.go
+++ b/contractcourt/channel_arbitrator.go
@@ -416,8 +416,9 @@ func (c *ChannelArbitrator) getStartState(tx kvdb.RTx) (*chanArbStartState,
 
 // Start starts all the goroutines that the ChannelArbitrator needs to operate.
 // If takes a start state, which will be looked up on disk if it is not
-// provided.
-func (c *ChannelArbitrator) Start(state *chanArbStartState) error {
+// provided, and the height of our current best block.
+func (c *ChannelArbitrator) Start(state *chanArbStartState,
+	bestHeight int32) error {
 	if !atomic.CompareAndSwapInt32(&c.started, 0, 1) {
 		return nil
 	}
@@ -440,11 +441,6 @@ func (c *ChannelArbitrator) Start(state *chanArbStartState) error {
 
 	// Set our state from our starting state.
 	c.state = state.currentState
-
-	_, bestHeight, err := c.cfg.ChainIO.GetBestBlock()
-	if err != nil {
-		return err
-	}
 
 	// If the channel has been marked pending close in the database, and we
 	// haven't transitioned the state machine to StateContractClosed (or a

--- a/contractcourt/channel_arbitrator_test.go
+++ b/contractcourt/channel_arbitrator_test.go
@@ -275,7 +275,7 @@ func (c *chanArbTestCtx) Restart(restartClosure func(*chanArbTestCtx)) (*chanArb
 		restartClosure(newCtx)
 	}
 
-	if err := newCtx.chanArb.Start(nil); err != nil {
+	if err := newCtx.chanArb.Start(nil, 0); err != nil {
 		return nil, err
 	}
 
@@ -447,7 +447,7 @@ func TestChannelArbitratorCooperativeClose(t *testing.T) {
 		t.Fatalf("unable to create ChannelArbitrator: %v", err)
 	}
 
-	if err := chanArbCtx.chanArb.Start(nil); err != nil {
+	if err := chanArbCtx.chanArb.Start(nil, 0); err != nil {
 		t.Fatalf("unable to start ChannelArbitrator: %v", err)
 	}
 	defer func() {
@@ -509,7 +509,7 @@ func TestChannelArbitratorRemoteForceClose(t *testing.T) {
 	}
 	chanArb := chanArbCtx.chanArb
 
-	if err := chanArb.Start(nil); err != nil {
+	if err := chanArb.Start(nil, 0); err != nil {
 		t.Fatalf("unable to start ChannelArbitrator: %v", err)
 	}
 	defer chanArb.Stop()
@@ -564,7 +564,7 @@ func TestChannelArbitratorLocalForceClose(t *testing.T) {
 	}
 	chanArb := chanArbCtx.chanArb
 
-	if err := chanArb.Start(nil); err != nil {
+	if err := chanArb.Start(nil, 0); err != nil {
 		t.Fatalf("unable to start ChannelArbitrator: %v", err)
 	}
 	defer chanArb.Stop()
@@ -670,7 +670,7 @@ func TestChannelArbitratorBreachClose(t *testing.T) {
 	}
 	chanArb := chanArbCtx.chanArb
 
-	if err := chanArb.Start(nil); err != nil {
+	if err := chanArb.Start(nil, 0); err != nil {
 		t.Fatalf("unable to start ChannelArbitrator: %v", err)
 	}
 	defer func() {
@@ -715,7 +715,7 @@ func TestChannelArbitratorLocalForceClosePendingHtlc(t *testing.T) {
 	chanArb.cfg.PreimageDB = newMockWitnessBeacon()
 	chanArb.cfg.Registry = &mockRegistry{}
 
-	if err := chanArb.Start(nil); err != nil {
+	if err := chanArb.Start(nil, 0); err != nil {
 		t.Fatalf("unable to start ChannelArbitrator: %v", err)
 	}
 	defer chanArb.Stop()
@@ -987,7 +987,7 @@ func TestChannelArbitratorLocalForceCloseRemoteConfirmed(t *testing.T) {
 	}
 	chanArb := chanArbCtx.chanArb
 
-	if err := chanArb.Start(nil); err != nil {
+	if err := chanArb.Start(nil, 0); err != nil {
 		t.Fatalf("unable to start ChannelArbitrator: %v", err)
 	}
 	defer chanArb.Stop()
@@ -1096,7 +1096,7 @@ func TestChannelArbitratorLocalForceDoubleSpend(t *testing.T) {
 	}
 	chanArb := chanArbCtx.chanArb
 
-	if err := chanArb.Start(nil); err != nil {
+	if err := chanArb.Start(nil, 0); err != nil {
 		t.Fatalf("unable to start ChannelArbitrator: %v", err)
 	}
 	defer chanArb.Stop()
@@ -1204,7 +1204,7 @@ func TestChannelArbitratorPersistence(t *testing.T) {
 	}
 
 	chanArb := chanArbCtx.chanArb
-	if err := chanArb.Start(nil); err != nil {
+	if err := chanArb.Start(nil, 0); err != nil {
 		t.Fatalf("unable to start ChannelArbitrator: %v", err)
 	}
 
@@ -1328,7 +1328,7 @@ func TestChannelArbitratorForceCloseBreachedChannel(t *testing.T) {
 	}
 
 	chanArb := chanArbCtx.chanArb
-	if err := chanArb.Start(nil); err != nil {
+	if err := chanArb.Start(nil, 0); err != nil {
 		t.Fatalf("unable to start ChannelArbitrator: %v", err)
 	}
 
@@ -1490,7 +1490,7 @@ func TestChannelArbitratorCommitFailure(t *testing.T) {
 		}
 
 		chanArb := chanArbCtx.chanArb
-		if err := chanArb.Start(nil); err != nil {
+		if err := chanArb.Start(nil, 0); err != nil {
 			t.Fatalf("unable to start ChannelArbitrator: %v", err)
 		}
 
@@ -1575,7 +1575,7 @@ func TestChannelArbitratorEmptyResolutions(t *testing.T) {
 	chanArb.cfg.ClosingHeight = 100
 	chanArb.cfg.CloseType = channeldb.RemoteForceClose
 
-	if err := chanArb.Start(nil); err != nil {
+	if err := chanArb.Start(nil, 0); err != nil {
 		t.Fatalf("unable to start ChannelArbitrator: %v", err)
 	}
 
@@ -1607,7 +1607,7 @@ func TestChannelArbitratorAlreadyForceClosed(t *testing.T) {
 		t.Fatalf("unable to create ChannelArbitrator: %v", err)
 	}
 	chanArb := chanArbCtx.chanArb
-	if err := chanArb.Start(nil); err != nil {
+	if err := chanArb.Start(nil, 0); err != nil {
 		t.Fatalf("unable to start ChannelArbitrator: %v", err)
 	}
 	defer chanArb.Stop()
@@ -1705,7 +1705,7 @@ func TestChannelArbitratorDanglingCommitForceClose(t *testing.T) {
 				t.Fatalf("unable to create ChannelArbitrator: %v", err)
 			}
 			chanArb := chanArbCtx.chanArb
-			if err := chanArb.Start(nil); err != nil {
+			if err := chanArb.Start(nil, 0); err != nil {
 				t.Fatalf("unable to start ChannelArbitrator: %v", err)
 			}
 			defer chanArb.Stop()
@@ -1896,7 +1896,7 @@ func TestChannelArbitratorPendingExpiredHTLC(t *testing.T) {
 		return false
 	}
 
-	if err := chanArb.Start(nil); err != nil {
+	if err := chanArb.Start(nil, 0); err != nil {
 		t.Fatalf("unable to start ChannelArbitrator: %v", err)
 	}
 	defer func() {
@@ -2053,7 +2053,7 @@ func TestRemoteCloseInitiator(t *testing.T) {
 			}
 			chanArb := chanArbCtx.chanArb
 
-			if err := chanArb.Start(nil); err != nil {
+			if err := chanArb.Start(nil, 0); err != nil {
 				t.Fatalf("unable to start "+
 					"ChannelArbitrator: %v", err)
 			}
@@ -2123,7 +2123,7 @@ func TestChannelArbitratorAnchors(t *testing.T) {
 			{}, {},
 		}
 
-	if err := chanArb.Start(nil); err != nil {
+	if err := chanArb.Start(nil, 0); err != nil {
 		t.Fatalf("unable to start ChannelArbitrator: %v", err)
 	}
 	defer func() {


### PR DESCRIPTION
The `GetBestBlock` call can be very slow when using bitcoind backend - up to 5 minutes as we found out in #4669.

When we start up arbitrator, we get our best block height every time from this API. This can slow us down on startup, and during the funding flow because we do a fresh lookup every time, the latter affecting applications like pool which require timely responses in the funding flow (thx @C-Otto for the slack report).

This PR makes use of the single block subscription added to the chain arbitrator in #4697 to store out latest known block height, and reduce our reliance on this slow API.

