### PR TITLE
[mobile] Allow state API on mobile, simplify callback mechanism

### DIFF
--- a/lnd.go
+++ b/lnd.go
@@ -54,31 +54,15 @@ import (
 	"github.com/lightningnetwork/lnd/watchtower/wtdb"
 )
 
-// WalletUnlockerAuthOptions returns a list of DialOptions that can be used to
-// authenticate with the wallet unlocker service.
-//
-// NOTE: This should only be called after the WalletUnlocker listener has
-// signaled it is ready.
-func WalletUnlockerAuthOptions(cfg *Config) ([]grpc.DialOption, error) {
-	creds, err := credentials.NewClientTLSFromFile(cfg.TLSCertPath, "")
-	if err != nil {
-		return nil, fmt.Errorf("unable to read TLS cert: %v", err)
-	}
-
-	// Create a dial options array with the TLS credentials.
-	opts := []grpc.DialOption{
-		grpc.WithTransportCredentials(creds),
-	}
-
-	return opts, nil
-}
-
 // AdminAuthOptions returns a list of DialOptions that can be used to
 // authenticate with the RPC server with admin capabilities.
+// skipMacaroons=true should be set if we don't want to include macaroons with
+// the auth options. This is needed for instance for the WalletUnlocker
+// service, which must be usable also before macaroons are created.
 //
 // NOTE: This should only be called after the RPCListener has signaled it is
 // ready.
-func AdminAuthOptions(cfg *Config) ([]grpc.DialOption, error) {
+func AdminAuthOptions(cfg *Config, skipMacaroons bool) ([]grpc.DialOption, error) {
 	creds, err := credentials.NewClientTLSFromFile(cfg.TLSCertPath, "")
 	if err != nil {
 		return nil, fmt.Errorf("unable to read TLS cert: %v", err)
@@ -90,7 +74,7 @@ func AdminAuthOptions(cfg *Config) ([]grpc.DialOption, error) {
 	}
 
 	// Get the admin macaroon if macaroons are active.
-	if !cfg.NoMacaroons {
+	if !skipMacaroons && !cfg.NoMacaroons {
 		// Load the adming macaroon file.
 		macBytes, err := ioutil.ReadFile(cfg.AdminMacPath)
 		if err != nil {

--- a/lnd.go
+++ b/lnd.go
@@ -153,10 +153,6 @@ type ListenerWithSignal struct {
 // ListenerCfg is a wrapper around custom listeners that can be passed to lnd
 // when calling its main method.
 type ListenerCfg struct {
-	// WalletUnlocker can be set to the listener to use for the wallet
-	// unlocker. If nil a regular network listener will be created.
-	WalletUnlocker *ListenerWithSignal
-
 	// RPCListener can be set to the listener to use for the RPC server. If
 	// nil a regular network listener will be created.
 	RPCListener *ListenerWithSignal

--- a/lnrpc/Dockerfile
+++ b/lnrpc/Dockerfile
@@ -11,7 +11,7 @@ RUN apt-get update && apt-get install -y \
 ARG PROTOC_GEN_VERSION
 ARG GRPC_GATEWAY_VERSION
 
-ENV FALAFEL_VERSION="v0.7.1"
+ENV FALAFEL_VERSION="v0.8.1"
 ENV GOCACHE=/tmp/build/.cache
 ENV GOMODCACHE=/tmp/build/.modcache
 

--- a/mobile/bindings.go
+++ b/mobile/bindings.go
@@ -3,15 +3,21 @@
 package lndmobile
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"strings"
+	"sync/atomic"
 
 	flags "github.com/jessevdk/go-flags"
 	"github.com/lightningnetwork/lnd"
 	"github.com/lightningnetwork/lnd/signal"
 	"google.golang.org/grpc"
 )
+
+// lndStarted will be used atomically to ensure only a singel lnd instance is
+// attempted to be started at once.
+var lndStarted int32
 
 // Start starts lnd in a new goroutine.
 //
@@ -77,9 +83,19 @@ func Start(extraArgs string, rpcReady Callback) {
 		},
 	}
 
+	// We only support a single lnd instance at a time (singleton) for now,
+	// so we make sure to return immediately if it has already been
+	// started.
+	if !atomic.CompareAndSwapInt32(&lndStarted, 0, 1) {
+		err := errors.New("lnd already started")
+		rpcReady.OnError(err)
+		return
+	}
+
 	// Call the "real" main in a nested manner so the defers will properly
 	// be executed in the case of a graceful shutdown.
 	go func() {
+		defer atomic.StoreInt32(&lndStarted, 0)
 		defer close(quit)
 
 		if err := lnd.Main(

--- a/mobile/bindings.go
+++ b/mobile/bindings.go
@@ -105,7 +105,7 @@ func Start(extraArgs string, unlockerReady, rpcReady Callback) {
 
 		// We must set the TLS certificates in order to properly
 		// authenticate with the wallet unlocker service.
-		auth, err := lnd.WalletUnlockerAuthOptions(loadedConfig)
+		auth, err := lnd.AdminAuthOptions(loadedConfig, true)
 		if err != nil {
 			unlockerReady.OnError(err)
 			return
@@ -123,7 +123,7 @@ func Start(extraArgs string, unlockerReady, rpcReady Callback) {
 		// Now that the RPC server is ready, we can get the needed
 		// authentication options, and add them to the global dial
 		// options.
-		auth, err := lnd.AdminAuthOptions(loadedConfig)
+		auth, err := lnd.AdminAuthOptions(loadedConfig, false)
 		if err != nil {
 			rpcReady.OnError(err)
 			return

--- a/mobile/gen_bindings.sh
+++ b/mobile/gen_bindings.sh
@@ -16,7 +16,7 @@ then
         version="v$($falafel -v)"
         if [ $version != $falafelVersion ]
         then
-                echo "falafel version $falafelVersion required"
+                echo "falafel version $falafelVersion required, had $version"
                 exit 1
         fi
         echo "Using plugin $falafel $version"

--- a/mobile/gen_bindings.sh
+++ b/mobile/gen_bindings.sh
@@ -33,13 +33,13 @@ target_pkg="github.com/lightningnetwork/lnd/lnrpc"
 
 # A mapping from grpc service to name of the custom listeners. The grpc server
 # must be configured to listen on these.
-listeners="lightning=lightningLis walletunlocker=walletUnlockerLis"
+listeners="lightning=lightningLis walletunlocker=lightningLis state=lightningLis"
 
 # Set to 1 to create boiler plate grpc client code and listeners. If more than
 # one proto file is being parsed, it should only be done once.
 mem_rpc=1
 
-PROTOS="rpc.proto walletunlocker.proto"
+PROTOS="rpc.proto walletunlocker.proto stateservice.proto"
 
 opts="package_name=$pkg,target_package=$target_pkg,listeners=$listeners,mem_rpc=$mem_rpc"
 


### PR DESCRIPTION
It's been a long standing issue that React Native only supports a single callback, which was a problem with the `unlockerReady` and `rpcReady` callbacks we used in the start method.

This PR builds on top of #5005 to circumvent this by exposing the `StateAPI` also on mobile. This let the client start LND, and immediately start using the new API to determine whether the `walletUnlocker` is ready, and finally when the RPC is.

Depends on
- [x] #4985 
- [x] #5005 
- [x] https://github.com/lightninglabs/falafel/pull/9