### PR TITLE
lntest: update error log whitelist

### DIFF
--- a/lntest/itest/log_error_whitelist.txt
+++ b/lntest/itest/log_error_whitelist.txt
@@ -254,3 +254,4 @@
 <time> [ERR] RPCS: [/lnrpc.Lightning/OpenChannel]: reserved wallet balance invalidated
 <time> [ERR] RPCS: [/lnrpc.Lightning/SendCoins]: reserved wallet balance invalidated
 <time> [ERR] RPCS: unable to open channel to NodeKey(<hex>): reserved wallet balance invalidated
+<time> [ERR] NANN: Unable to retrieve chan status for Channel(<chan_point>): unable to extract ChannelUpdate

--- a/lntest/itest/log_error_whitelist.txt
+++ b/lntest/itest/log_error_whitelist.txt
@@ -255,3 +255,4 @@
 <time> [ERR] RPCS: [/lnrpc.Lightning/SendCoins]: reserved wallet balance invalidated
 <time> [ERR] RPCS: unable to open channel to NodeKey(<hex>): reserved wallet balance invalidated
 <time> [ERR] NANN: Unable to retrieve chan status for Channel(<chan_point>): unable to extract ChannelUpdate
+<time> [ERR] NTFN: Unable to rewind chain from height 1 to height -1: unable to find blockhash for disconnected height=<height>: -8: Block height out of range


### PR DESCRIPTION
Fixes two itests flakes by adding now-common logs to the whitelist.