### PR TITLE
docker: fix chain for lnd_ltc

### DIFF
--- a/docker/docker-compose.ltc.yml
+++ b/docker/docker-compose.ltc.yml
@@ -29,7 +29,7 @@ services:
         - RPCUSER
         - RPCPASS
         - NETWORK
-        - CHAIN
+        - CHAIN=litecoin
         - DEBUG
       volumes:
         - shared:/rpc

--- a/docker/lnd/start-lnd.sh
+++ b/docker/lnd/start-lnd.sh
@@ -59,7 +59,7 @@ exec lnd \
     --noseedbackup \
     "--$CHAIN.active" \
     "--$CHAIN.$NETWORK" \
-    "--$CHAIN.node"="btcd" \
+    "--$CHAIN.node"="$BACKEND" \
     "--$BACKEND.rpccert"="/rpc/rpc.cert" \
     "--$BACKEND.rpchost"="blockchain" \
     "--$BACKEND.rpcuser"="$RPCUSER" \


### PR DESCRIPTION
A mistake in the entrypoint for the LND container and in the configuration for the Litecoin LND container prevents from actually spinning up a Litecoin LND node using the provided `docker-compose.yml` file.

This PR fixes the entrypoint and adds the Litecoin chain parameter to the docker-compose configartion file.