### PR TITLE
scripts/verify-install: require 5 of 7 signatures before accepting

### DIFF
--- a/scripts/verify-install.sh
+++ b/scripts/verify-install.sh
@@ -172,6 +172,22 @@ for signature in $SIGNATURES; do
   ((NUM_CHECKS=NUM_CHECKS+1))
 done
 
+# We want at least five signatures (out of seven public keys) that sign the
+# hashes of the binaries we have installed. If we arrive here without exiting,
+# it means no signature manifests were uploaded (yet) with the correct naming
+# pattern.
+MIN_REQUIRED_SIGNATURES=5
+if [[ $NUM_CHECKS -lt $MIN_REQUIRED_SIGNATURES ]]; then
+  echo "ERROR: Not enough valid signatures found!"
+  echo "  Valid signatures found: $NUM_CHECKS"
+  echo "  Valid signatures required: $MIN_REQUIRED_SIGNATURES"
+  echo
+  echo "  Make sure the release $LND_VERSION contains the required "
+  echo "  number of signatures on the manifest, or wait until more "
+  echo "  signatures have been added to the release."
+  exit 1
+fi
+
 # Then make sure that the hash of the installed binaries can be found in the
 # manifest that we now have verified the signatures for.
 if ! grep -q "^$LND_SUM" "$MANIFEST"; then
@@ -194,15 +210,6 @@ fi
 
 echo ""
 echo "Verified lnd and lncli hashes against $MANIFEST"
-
-# We want at least one signature that signs the hashes of the binaries we have
-# installed. If we arrive here without exiting, it means no signature manifests
-# were uploaded (yet) with the correct naming pattern.
-if [[ $NUM_CHECKS -lt 1 ]]; then
-  echo "ERROR: No valid signatures found!"
-  echo "Make sure the release $LND_VERSION contains any signatures for the manifest."
-  exit 1
-fi
 
 echo ""
 echo "SUCCESS! Verified lnd and lncli against $NUM_CHECKS developer signature(s)."

--- a/scripts/verify-install.sh
+++ b/scripts/verify-install.sh
@@ -209,7 +209,4 @@ if ! grep -q "^$LNCLI_SUM" "$MANIFEST"; then
 fi
 
 echo ""
-echo "Verified lnd and lncli hashes against $MANIFEST"
-
-echo ""
-echo "SUCCESS! Verified lnd and lncli against $NUM_CHECKS developer signature(s)."
+echo "SUCCESS! Verified lnd and lncli against $MANIFEST signed by $NUM_CHECKS developers."


### PR DESCRIPTION
This is a precaution is done to protect against rogue/accidental behavior of any one of the seven signers,
due to the fact that only one valid signatures is currently required in order for `scripts/verify_install.sh` to
accept a binary.

There are two cases where this is relevant:
 - When only one signature is required, the first signer is able to upload/replace the manifest by themselves
and cause the initial set of installs to accept a potentially malicious binary. Normally this would be rectified
after one other signer has added their signatures, which sign the _correct_ manifest as it will fail the
verification script due to signature disagreements.
 - When only one signatures is required, another signer may remove the signatures after the initial release
is published on the valid manfiest, and reupload a different/malicious manifest along with their signature.
This reverts back to the first case and is only resolved when another signature of a differing manifest is
uploaded (if it is ever detected).

To remedy, we increase the number of required signatures when verifying a release using
`scripts/verify_install.sh` from 1 signature to 5. We currently have 7 active public keys embedded in
the release script, so this forms a 5 of 7 multisig before the verification script will approve a given binary
against the release manifest. This prevents both of the above cases, the degenerate case when the release
is created, and resetting of the release via deletion.

We don't require 7 of 7 to account for the possibility of key loss/compromise.
