### PR TITLE
Add basic bitcoin signet support

### DIFF
--- a/chainreg/chainparams.go
+++ b/chainreg/chainparams.go
@@ -50,6 +50,13 @@ var BitcoinSimNetParams = BitcoinNetParams{
 	CoinType: keychain.CoinTypeTestnet,
 }
 
+// BitcoinSigNetParams contains parameters specific to the signet test network.
+var BitcoinSigNetParams = BitcoinNetParams{
+	Params:   &bitcoinCfg.SigNetParams,
+	RPCPort:  "38332",
+	CoinType: keychain.CoinTypeTestnet,
+}
+
 // LitecoinSimNetParams contains parameters specific to the simulation test
 // network.
 var LitecoinSimNetParams = LitecoinNetParams{

--- a/chainreg/chainregistry.go
+++ b/chainreg/chainregistry.go
@@ -377,10 +377,13 @@ func NewChainControl(cfg *Config, blockCache *blockcache.BlockCache) (
 				(cfg.Litecoin.Active && cfg.Litecoin.RegTest) {
 				conn, err := net.Dial("tcp", bitcoindHost)
 				if err != nil || conn == nil {
-					if cfg.Bitcoin.Active && cfg.Bitcoin.RegTest {
+					switch {
+					case cfg.Bitcoin.Active && cfg.Bitcoin.RegTest:
 						rpcPort = 18443
-					} else if cfg.Litecoin.Active && cfg.Litecoin.RegTest {
+					case cfg.Litecoin.Active && cfg.Litecoin.RegTest:
 						rpcPort = 19443
+					case cfg.Bitcoin.Active && cfg.Bitcoin.SigNet:
+						rpcPort = 38332
 					}
 					bitcoindHost = fmt.Sprintf("%v:%d",
 						bitcoindMode.RPCHost,
@@ -743,6 +746,14 @@ var (
 		0x01, 0xea, 0x33, 0x09, 0x00, 0x00, 0x00, 0x00,
 	})
 
+	// BitcoinSignetGenesis is the genesis hash of Bitcoin's signet chain.
+	BitcoinSignetGenesis = chainhash.Hash([chainhash.HashSize]byte{
+		0xf6, 0x1e, 0xee, 0x3b, 0x63, 0xa3, 0x80, 0xa4,
+		0x77, 0xa0, 0x63, 0xaf, 0x32, 0xb2, 0xbb, 0xc9,
+		0x7c, 0x9f, 0xf9, 0xf0, 0x1f, 0x2c, 0x42, 0x25,
+		0xe9, 0x73, 0x98, 0x81, 0x08, 0x00, 0x00, 0x00,
+	})
+
 	// BitcoinMainnetGenesis is the genesis hash of Bitcoin's main chain.
 	BitcoinMainnetGenesis = chainhash.Hash([chainhash.HashSize]byte{
 		0x6f, 0xe2, 0x8c, 0x0a, 0xb6, 0xf1, 0xb3, 0x72,
@@ -805,6 +816,12 @@ var (
 			{
 				"test.nodes.lightning.directory",
 				"soa.nodes.lightning.directory",
+			},
+		},
+
+		BitcoinSignetGenesis: {
+			{
+				"ln.signet.secp.tech",
 			},
 		},
 

--- a/cmd/lncli/main.go
+++ b/cmd/lncli/main.go
@@ -200,7 +200,7 @@ func extractPathArgs(ctx *cli.Context) (string, string, error) {
 
 	network := strings.ToLower(ctx.GlobalString("network"))
 	switch network {
-	case "mainnet", "testnet", "regtest", "simnet":
+	case "mainnet", "testnet", "regtest", "simnet", "signet":
 	default:
 		return "", "", fmt.Errorf("unknown network: %v", network)
 	}

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ require (
 	github.com/NebulousLabs/fastrand v0.0.0-20181203155948-6fb6489aac4e // indirect
 	github.com/NebulousLabs/go-upnp v0.0.0-20180202185039-29b680b06c82
 	github.com/Yawning/aez v0.0.0-20180114000226-4dad034d9db2
-	github.com/btcsuite/btcd v0.21.0-beta.0.20210429225535-ce697fe7e82b
+	github.com/btcsuite/btcd v0.21.0-beta.0.20210513141527-ee5896bad5be
 	github.com/btcsuite/btclog v0.0.0-20170628155309-84c8d2346e9f
 	github.com/btcsuite/btcutil v1.0.3-0.20201208143702-a53e38424cce
 	github.com/btcsuite/btcutil/psbt v1.0.3-0.20201208143702-a53e38424cce

--- a/go.sum
+++ b/go.sum
@@ -27,8 +27,8 @@ github.com/btcsuite/btcd v0.0.0-20190824003749-130ea5bddde3/go.mod h1:3J08xEfcug
 github.com/btcsuite/btcd v0.20.1-beta/go.mod h1:wVuoA8VJLEcwgqHBwHmzLRazpKxTv13Px/pDuV7OomQ=
 github.com/btcsuite/btcd v0.21.0-beta.0.20201208033208-6bd4c64a54fa/go.mod h1:Sv4JPQ3/M+teHz9Bo5jBpkNcP0x6r7rdihlNL/7tTAs=
 github.com/btcsuite/btcd v0.21.0-beta.0.20210426180113-7eba688b65e5/go.mod h1:9n5ntfhhHQBIhUvlhDvD3Qg6fRUj4jkN0VB8L8svzOA=
-github.com/btcsuite/btcd v0.21.0-beta.0.20210429225535-ce697fe7e82b h1:+BMyRYlNCozjv6zGhnyHExB6JquAIYZRwsc5bxPEXrI=
-github.com/btcsuite/btcd v0.21.0-beta.0.20210429225535-ce697fe7e82b/go.mod h1:9n5ntfhhHQBIhUvlhDvD3Qg6fRUj4jkN0VB8L8svzOA=
+github.com/btcsuite/btcd v0.21.0-beta.0.20210513141527-ee5896bad5be h1:vDD/JWWS2v4GJUG/RZE/50wT6Saerbujijd7mFqgsKI=
+github.com/btcsuite/btcd v0.21.0-beta.0.20210513141527-ee5896bad5be/go.mod h1:9n5ntfhhHQBIhUvlhDvD3Qg6fRUj4jkN0VB8L8svzOA=
 github.com/btcsuite/btclog v0.0.0-20170628155309-84c8d2346e9f h1:bAs4lUbRJpnnkd9VhRV3jjAVU7DJVjMaK+IsvSeZvFo=
 github.com/btcsuite/btclog v0.0.0-20170628155309-84c8d2346e9f/go.mod h1:TdznJufoqS23FtqVCzL0ZqgP5MqXbb4fg/WgDys70nA=
 github.com/btcsuite/btcutil v0.0.0-20190425235716-9e5f4b9a998d/go.mod h1:+5NJ2+qvTyV9exUAL/rxXi3DcLg2Ts+ymUAY5y4NvMg=

--- a/lncfg/chain.go
+++ b/lncfg/chain.go
@@ -13,10 +13,13 @@ type Chain struct {
 
 	Node string `long:"node" description:"The blockchain interface to use." choice:"btcd" choice:"bitcoind" choice:"neutrino" choice:"ltcd" choice:"litecoind"`
 
-	MainNet  bool `long:"mainnet" description:"Use the main network"`
-	TestNet3 bool `long:"testnet" description:"Use the test network"`
-	SimNet   bool `long:"simnet" description:"Use the simulation test network"`
-	RegTest  bool `long:"regtest" description:"Use the regression test network"`
+	MainNet         bool     `long:"mainnet" description:"Use the main network"`
+	TestNet3        bool     `long:"testnet" description:"Use the test network"`
+	SimNet          bool     `long:"simnet" description:"Use the simulation test network"`
+	RegTest         bool     `long:"regtest" description:"Use the regression test network"`
+	SigNet          bool     `long:"signet" description:"Use the signet test network"`
+	SigNetChallenge string   `long:"signetchallenge" description:"Connect to a custom signet network defined by this challenge instead of using the global default signet test network -- Can be specified multiple times"`
+	SigNetSeedNode  []string `long:"signetseednode" description:"Specify a seed node for the signet network instead of using the global default signet network seed nodes"`
 
 	DefaultNumChanConfs int                 `long:"defaultchanconfs" description:"The default number of confirmations a channel must have before it's considered open. If this is not set, we will scale the value according to the channel size."`
 	DefaultRemoteDelay  int                 `long:"defaultremotedelay" description:"The default number of blocks we will require our channel counterparty to wait before accessing its funds in case of unilateral close. If this is not set, we will scale the value according to the channel size."`

--- a/lnd.go
+++ b/lnd.go
@@ -199,6 +199,9 @@ func Main(cfg *Config, lisCfg ListenerCfg, interceptor signal.Interceptor) error
 
 	case cfg.Bitcoin.RegTest || cfg.Litecoin.RegTest:
 		network = "regtest"
+
+	case cfg.Bitcoin.SigNet:
+		network = "signet"
 	}
 
 	ltndLog.Infof("Active chain: %v (network=%v)",

--- a/sample-lnd.conf
+++ b/sample-lnd.conf
@@ -436,6 +436,17 @@ bitcoin.simnet=true
 ; Use Bitcoin's regression test network
 ; bitcoin.regtest=false
 
+; Use Bitcoin's signet test network
+; bitcoin.signet=false
+
+; Connect to a custom signet network defined by this challenge instead of using
+; the global default signet test network -- Can be specified multiple times
+; bitcoin.signetchallenge=
+
+; Specify a seed node for the signet network instead of using the global default
+; signet network seed nodes
+; bitcoin.signetseednode=123.45.67.89
+
 ; Use the btcd back-end
 bitcoin.node=btcd
 
@@ -646,6 +657,10 @@ bitcoin.node=btcd
 
 ; Use Litecoin's regression test network
 ; litecoin.regtest=false
+
+; Litecoin does not support the signet test network. The options
+; litecoin.signet, litecoin.signetchallenge and litecoin.signetseednode are
+; only defined because the data structure is shared with bitcoind.
 
 ; Use the ltcd back-end.
 litecoin.node=ltcd

--- a/server.go
+++ b/server.go
@@ -1760,6 +1760,12 @@ func (s *server) Start() error {
 				chainreg.BitcoinTestnetGenesis,
 			)
 		}
+		if s.cfg.Bitcoin.Active && s.cfg.Bitcoin.SigNet {
+			setSeedList(
+				s.cfg.Bitcoin.DNSSeeds,
+				chainreg.BitcoinSignetGenesis,
+			)
+		}
 		if s.cfg.Litecoin.Active && s.cfg.Litecoin.MainNet {
 			setSeedList(
 				s.cfg.Litecoin.DNSSeeds,


### PR DESCRIPTION
Fixes https://github.com/lightningnetwork/lnd/issues/5018.

Depends on https://github.com/btcsuite/btcd/pull/1692.
Depends on https://github.com/btcsuite/btcwallet/pull/735.

Updates to the latest `btcd` version (which is why the diff is that large) and adds basic signet support.
