### PR TITLE
htlcswitch: init mockFeeEstimator in other LinkChannelConfigs

### DIFF
--- a/htlcswitch/link_test.go
+++ b/htlcswitch/link_test.go
@@ -1967,6 +1967,7 @@ func newSingleLinkTestHarness(chanAmt, chanReserve btcutil.Amount) (
 			return nil
 		},
 		Registry:            invoiceRegistry,
+		FeeEstimator:        newMockFeeEstimator(),
 		ChainEvents:         &contractcourt.ChainEventSubscription{},
 		BatchTicker:         bticker,
 		FwdPkgGCTicker:      ticker.NewForce(15 * time.Second),
@@ -4469,6 +4470,7 @@ func (h *persistentLinkHarness) restartLink(
 			return nil
 		},
 		Registry:            h.coreLink.cfg.Registry,
+		FeeEstimator:        newMockFeeEstimator(),
 		ChainEvents:         &contractcourt.ChainEventSubscription{},
 		BatchTicker:         bticker,
 		FwdPkgGCTicker:      ticker.New(5 * time.Second),

--- a/htlcswitch/mock.go
+++ b/htlcswitch/mock.go
@@ -74,6 +74,13 @@ type mockFeeEstimator struct {
 	quit chan struct{}
 }
 
+func newMockFeeEstimator() *mockFeeEstimator {
+	return &mockFeeEstimator{
+		byteFeeIn: make(chan chainfee.SatPerKWeight),
+		quit:      make(chan struct{}),
+	}
+}
+
 func (m *mockFeeEstimator) EstimateFeePerKW(
 	numBlocks uint32) (chainfee.SatPerKWeight, error) {
 

--- a/htlcswitch/test_utils.go
+++ b/htlcswitch/test_utils.go
@@ -1098,13 +1098,8 @@ func newHopNetwork() *hopNetwork {
 	}
 	obfuscator := NewMockObfuscator()
 
-	feeEstimator := &mockFeeEstimator{
-		byteFeeIn: make(chan chainfee.SatPerKWeight),
-		quit:      make(chan struct{}),
-	}
-
 	return &hopNetwork{
-		feeEstimator: feeEstimator,
+		feeEstimator: newMockFeeEstimator(),
 		globalPolicy: globalPolicy,
 		obfuscator:   obfuscator,
 		defaultDelta: defaultDelta,


### PR DESCRIPTION
If the tests don't execute quick enough, the link will try to sample the
network fee and cause a panic. This happens semi-regularly on travis.