### PR TITLE
GitHub+Travis: avoid Docker Hub pull limit by logging into docker account

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -53,9 +53,18 @@ jobs:
         with:
           go-version: '${{ env.GO_VERSION }}'
 
+      # To avoid sharing the per-IP pull limit on Docker Hub for unauthenticated
+      # users with other jobs running on the same VM we log in to get our own,
+      # currently 200 pulls per 6 hours limit.
+      - name: Login to DockerHub
+        uses: lightninglabs/gh-actions/login-action@2021.01.25.00
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_API_KEY }}
+
       - name: run check
         run: make rpc-check
-        
+
       - name: build mobile RPC bindings
         run: make mobile-rpc
 
@@ -257,4 +266,4 @@ jobs:
         uses: actions/checkout@v2
 
       - name: ensure dependences at correct version
-        run:   if ! grep -q "${{ matrix.pinned_dep }}" go.mod; then echo dependency ${{ matrix.pinned_dep }} should not be altered ; exit 1 ; fi
+        run: if ! grep -q "${{ matrix.pinned_dep }}" go.mod; then echo dependency ${{ matrix.pinned_dep }} should not be altered ; exit 1 ; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,6 +35,10 @@ jobs:
     - stage: Sanity Check
       name: Lint and compile
       script:
+        # Step 0: Login to Docker Hub to avoid running into the anonymous user
+        # pull limits.
+        - echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
+
         # Step 1: Make sure no diff is produced when compiling with the correct
         # version.
         - make rpc-check


### PR DESCRIPTION
There is a new image pull limit enforced by Docker Hub for anonymous
users. Since we seem to be sharing that pull limit with other jobs
running from the same IP, we want to log in to get our own, exclusive
pull limit of currently 200 pulls per 6 hours.

@Roasbeef: Need new secrets in Travis:
- `DOCKER_USERNAME`: same value as on GitHub
- `DOCKER_PASSWORD` same value as `DOCKER_API_KEY` on GitHub
