### PR TITLE
build: switch all builds systems and CI/ID to go 1.16, update min go version, add support for compiling M1 binaries

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,7 +24,7 @@ env:
   # /dev.Dockerfile
   # /make/builder.Dockerfile
   # /.github/workflows/release.yml
-  GO_VERSION: 1.15.7
+  GO_VERSION: 1.16.3
 
 jobs:
   ########################

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -16,7 +16,7 @@ env:
   # /dev.Dockerfile
   # /make/builder.Dockerfile
   # /.github/workflows/main.yml
-  GO_VERSION: 1.15.7
+  GO_VERSION: 1.16.3
 
 jobs:
   main:

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ go:
   # /make/builder.Dockerfile
   # /.github/workflows/main.yml
   # /.github/workflows/release.yml
-  - "1.15.7"
+  - 1.16.3
 
 env:
   global:

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@
 # /make/builder.Dockerfile
 # /.github/workflows/main.yml
 # /.github/workflows/release.yml
-FROM golang:1.15.7-alpine as builder
+FROM golang:1.16.3-alpine as builder
 
 # Force Go to use the cgo based DNS resolver. This is required to ensure DNS
 # queries required to connect to linked containers succeed.

--- a/dev.Dockerfile
+++ b/dev.Dockerfile
@@ -4,7 +4,7 @@
 # /make/builder.Dockerfile
 # /.github/workflows/main.yml
 # /.github/workflows/release.yml
-FROM golang:1.15.7-alpine as builder
+FROM golang:1.16.3-alpine as builder
 
 LABEL maintainer="Olaoluwa Osuntokun <laolu@lightning.engineering>"
 

--- a/docker/btcd/Dockerfile
+++ b/docker/btcd/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.15.7-alpine as builder
+FROM golang:1.16.3-alpine as builder
 
 LABEL maintainer="Olaoluwa Osuntokun <laolu@lightning.engineering>"
 

--- a/docker/ltcd/Dockerfile
+++ b/docker/ltcd/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.15.7-alpine as builder
+FROM golang:1.16.3-alpine as builder
 
 LABEL maintainer="Olaoluwa Osuntokun <laolu@lightning.engineering>"
 

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -93,46 +93,46 @@ version if there are database migrations present.
   * **Go:** `lnd` is written in Go. To install, run one of the following commands:
 
 
-    **Note**: The minimum version of Go supported is Go 1.13. We recommend that
+    **Note**: The minimum version of Go supported is Go 1.15. We recommend that
     users use the latest version of Go, which at the time of writing is
-    [`1.15`](https://blog.golang.org/go1.15).
+    [`1.16`](https://blog.golang.org/go1.16).
 
 
     On Linux:
 
     (x86-64)
     ```
-    wget https://dl.google.com/go/go1.13.linux-amd64.tar.gz
-    sha256sum go1.13.linux-amd64.tar.gz | awk -F " " '{ print $1 }'
+    wget https://dl.google.com/go/go1.16.linux-amd64.tar.gz
+    sha256sum go1.16.linux-amd64.tar.gz | awk -F " " '{ print $1 }'
     ```
 
     The final output of the command above should be
-    `68a2297eb099d1a76097905a2ce334e3155004ec08cdea85f24527be3c48e856`. If it
+    `013a489ebb3e24ef3d915abe5b94c3286c070dfe0818d5bca8108f1d6e8440d2`. If it
     isn't, then the target REPO HAS BEEN MODIFIED, and you shouldn't install
     this version of Go. If it matches, then proceed to install Go:
     ```
-    tar -C /usr/local -xzf go1.13.linux-amd64.tar.gz
+    tar -C /usr/local -xzf go1.16.linux-amd64.tar.gz
     export PATH=$PATH:/usr/local/go/bin
     ```
 
     (ARMv6)
     ```
-    wget https://dl.google.com/go/go1.13.linux-armv6l.tar.gz
-    sha256sum go1.13.linux-armv6l.tar.gz | awk -F " " '{ print $1 }'
+    wget https://dl.google.com/go/go1.16.linux-armv6l.tar.gz
+    sha256sum go1.16.linux-armv6l.tar.gz | awk -F " " '{ print $1 }'
     ```
 
     The final output of the command above should be
-    `931906d67cae1222f501e7be26e0ee73ba89420be0c4591925901cb9a4e156f0`. If it
+    `d1d9404b1dbd77afa2bdc70934e10fbfcf7d785c372efc29462bb7d83d0a32fd`. If it
     isn't, then the target REPO HAS BEEN MODIFIED, and you shouldn't install
     this version of Go. If it matches, then proceed to install Go:
     ```
-    tar -C /usr/local -xzf go1.13.linux-armv6l.tar.gz
+    tar -C /usr/local -xzf go1.16.linux-armv6l.tar.gz
     export PATH=$PATH:/usr/local/go/bin
     ```
 
     On Mac OS X:
     ```
-    brew install go@1.13
+    brew install go@1.16
     ```
 
     On FreeBSD:

--- a/go.mod
+++ b/go.mod
@@ -90,3 +90,5 @@ replace github.com/lightningnetwork/lnd/clock => ./clock
 replace git.schwanenlied.me/yawning/bsaes.git => github.com/Yawning/bsaes v0.0.0-20180720073208-c0276d75487e
 
 go 1.13
+
+retract v0.0.2

--- a/lnrpc/Dockerfile
+++ b/lnrpc/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.15.7-buster
+FROM golang:1.16.3-buster
 
 RUN apt-get update && apt-get install -y \
   git \

--- a/make/builder.Dockerfile
+++ b/make/builder.Dockerfile
@@ -4,7 +4,7 @@
 # /dev.Dockerfile
 # /.github/workflows/main.yml
 # /.github/workflows/release.yml
-FROM golang:1.15.7-buster
+FROM golang:1.16.3-buster
 
 MAINTAINER Olaoluwa Osuntokun <laolu@lightning.engineering>
 

--- a/make/release_flags.mk
+++ b/make/release_flags.mk
@@ -12,6 +12,7 @@ DOCKER_RELEASE_HELPER = docker run \
   lnd-release-helper
 
 BUILD_SYSTEM = darwin-amd64 \
+darwin-arm64 \
 dragonfly-amd64 \
 freebsd-386 \
 freebsd-amd64 \


### PR DESCRIPTION
Creating this early so we can feel out if there're any changes in Go 1.16 that affect `lnd` itself. 

I have an M1 laptop now, and I've been using `go1.16beta` up until now. I didn't notice any thing out of the ordinary, other than certain tests being extremely slow to the point they don't pass as they timeout with the default settings. An example of such a test is: `htclswitch/TestChannelLinkCancelFullCommitment`. Our "async payment benchmark" tests pass, but advertise "2 TPS" (to be taken with a grain of salt ofc). My early analysis leads me to beleive there's a concurrency interaction in the switch's mailbox code that ends up soft live locking on the M1. 