### PR TITLE
release: fix golang version issue in docker-release and shasum issue in verification script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -157,13 +157,15 @@ release: clean-mobile
 	$(VERSION_CHECK)
 	./scripts/release.sh build-release "$(VERSION_TAG)" "$(BUILD_SYSTEM)" "$(RELEASE_TAGS)" "$(RELEASE_LDFLAGS)"
 
-docker-release: clean-mobile
+docker-release:
 	@$(call print, "Building release helper docker image.")
 	if [ "$(tag)" = "" ]; then echo "Must specify tag=<commit_or_tag>!"; exit 1; fi
 
 	docker build -t lnd-release-helper -f make/builder.Dockerfile make/
-	$(DOCKER_RELEASE_HELPER) scripts/release.sh check-tag "$(VERSION_TAG)"
-	$(DOCKER_RELEASE_HELPER) scripts/release.sh build-release "$(VERSION_TAG)" "$(BUILD_SYSTEM)" "$(RELEASE_TAGS)" "$(RELEASE_LDFLAGS)"
+
+	# Run the actual compilation inside the docker image. We pass in all flags
+	# that we might want to overwrite in manual tests.
+	$(DOCKER_RELEASE_HELPER) make release tag="$(tag)" sys="$(sys)" COMMIT="$(COMMIT)" COMMIT_HASH="$(COMMIT_HASH)"
 
 scratch: build
 

--- a/scripts/verify-install.sh
+++ b/scripts/verify-install.sh
@@ -64,8 +64,19 @@ check_command gpg
 
 LND_VERSION=$($LND_BIN --version | cut -d'=' -f2)
 LNCLI_VERSION=$($LNCLI_BIN --version | cut -d'=' -f2)
-LND_SUM=$(shasum -a 256 $LND_BIN | cut -d' ' -f1)
-LNCLI_SUM=$(shasum -a 256 $LNCLI_BIN | cut -d' ' -f1)
+
+# Make this script compatible with both linux and *nix.
+SHA_CMD="sha256sum"
+if ! command -v "$SHA_CMD"; then
+  if command -v "shasum"; then
+    SHA_CMD="shasum -a 256"
+  else
+    echo "ERROR: no SHA256 sum binary installed!"
+    exit 1
+  fi
+fi
+LND_SUM=$($SHA_CMD $LND_BIN | cut -d' ' -f1)
+LNCLI_SUM=$($SHA_CMD $LNCLI_BIN | cut -d' ' -f1)
 
 echo "Detected lnd $LND_BIN version $LND_VERSION with SHA256 sum $LND_SUM"
 echo "Detected lncli $LNCLI_BIN version $LNCLI_VERSION with SHA256 sum $LNCLI_SUM"


### PR DESCRIPTION
To fix an issue where the golang version would be picked up from the
host system if the docker-release command was used, we switch over to
using make inside of the container as well instead of feeding the
parameters into the release script manually.
We only pass in the flags that we might actually want to overwrite.

Additionally, the shasum command isn't available in Alpine linux while the sha256sum
command isn't available on MacOS. We add a simple switch that tries to
detect which one is available.