### PR TITLE
make: add unit-debug target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -192,6 +192,10 @@ unit: btcd
 	@$(call print, "Running unit tests.")
 	$(UNIT)
 
+unit-debug: btcd
+	@$(call print, "Running debug unit tests.")
+	$(UNIT_DEBUG)
+
 unit-cover: $(GOACC_BIN)
 	@$(call print, "Running unit coverage tests.")
 	$(GOACC_BIN) $(COVER_PKG) -- -tags="$(DEV_TAGS) $(LOG_TAGS)"
@@ -316,6 +320,7 @@ clean-mobile:
 	itest-only \
 	itest \
 	unit \
+	unit-debug \
 	unit-cover \
 	unit-race \
 	goveralls \

--- a/make/testing_flags.mk
+++ b/make/testing_flags.mk
@@ -86,11 +86,13 @@ UNIT_TARGETED ?= no
 # targeted case. Otherwise, default to running all tests.
 ifeq ($(UNIT_TARGETED), yes)
 UNIT := $(GOTEST) -tags="$(DEV_TAGS) $(LOG_TAGS)" $(TEST_FLAGS) $(UNITPKG)
+UNIT_DEBUG := $(GOTEST) -v -tags="$(DEV_TAGS) $(LOG_TAGS)" $(TEST_FLAGS) $(UNITPKG)
 UNIT_RACE := $(GOTEST) -tags="$(DEV_TAGS) $(LOG_TAGS) lowscrypt" $(TEST_FLAGS) -race $(UNITPKG)
 endif
 
 ifeq ($(UNIT_TARGETED), no)
 UNIT := $(GOLIST) | $(XARGS) env $(GOTEST) -tags="$(DEV_TAGS) $(LOG_TAGS)" $(TEST_FLAGS)
+UNIT_DEBUG := $(GOLIST) | $(XARGS) env $(GOTEST) -v -tags="$(DEV_TAGS) $(LOG_TAGS)" $(TEST_FLAGS)
 UNIT_RACE := $(UNIT) -race
 endif
 


### PR DESCRIPTION
This PR adds a new `make unit-debug` target which runs the unit tests with `-v`. A while back, the go toolchain changed to not print stdout if `-v` was not set, which nerfed all the work we did in conditionally compiling production logging into our unit tests.

The work around I've been using is to run `make unit`, then copy the actual command being run and add a `-v`, which is very tedious. So instead, we just add a new target that includes this automatically.

Output when running the unit tests with production debug logs on master:
```
❯ make unit pkg=netann log="stdlog debug"
 Installing btcd.
cd /tmp && GO111MODULE=on go get -v github.com/btcsuite/btcd@v0.21.0-beta.0.20201208033208-6bd4c64a54fa
 Running unit tests.
GO111MODULE=on go test  -tags="dev stdlog debug"  -test.timeout=40m github.com/lightningnetwork/lnd/netann
ok      github.com/lightningnetwork/lnd/netann  4.775s
```

Output when running the debug unit tests with production debug logs (this PR):
```
❯ make unit-debug pkg=netann log="stdlog debug"
```
https://paste.ubuntu.com/p/VwNv89z4ky/