### PR TITLE
v0.12.1-beta.rc5

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -94,12 +94,13 @@ jobs:
         run: |
           git remote add upstream https://github.com/lightningnetwork/lnd
           git fetch upstream
+          git fetch --tags
           export GIT_COMMITTER_EMAIL="lnd-ci@example.com"
           export GIT_COMMITTER_NAME="LND CI"
-          git rebase upstream/master
+          git rebase v0.12.0-beta
 
       - name: check commits
-        run: scripts/check-each-commit.sh upstream/master
+        run: scripts/check-each-commit.sh v0.12.0-beta
 
   ########################
   # lint code

--- a/Makefile
+++ b/Makefile
@@ -157,13 +157,15 @@ release: clean-mobile
 	$(VERSION_CHECK)
 	./scripts/release.sh build-release "$(VERSION_TAG)" "$(BUILD_SYSTEM)" "$(RELEASE_TAGS)" "$(RELEASE_LDFLAGS)"
 
-docker-release: clean-mobile
+docker-release:
 	@$(call print, "Building release helper docker image.")
 	if [ "$(tag)" = "" ]; then echo "Must specify tag=<commit_or_tag>!"; exit 1; fi
 
 	docker build -t lnd-release-helper -f make/builder.Dockerfile make/
-	$(DOCKER_RELEASE_HELPER) scripts/release.sh check-tag "$(VERSION_TAG)"
-	$(DOCKER_RELEASE_HELPER) scripts/release.sh build-release "$(VERSION_TAG)" "$(BUILD_SYSTEM)" "$(RELEASE_TAGS)" "$(RELEASE_LDFLAGS)"
+
+	# Run the actual compilation inside the docker image. We pass in all flags
+	# that we might want to overwrite in manual tests.
+	$(DOCKER_RELEASE_HELPER) make release tag="$(tag)" sys="$(sys)" COMMIT="$(COMMIT)" COMMIT_HASH="$(COMMIT_HASH)"
 
 scratch: build
 

--- a/build/version.go
+++ b/build/version.go
@@ -48,7 +48,7 @@ const (
 
 	// AppPreRelease MUST only contain characters from semanticAlphabet
 	// per the semantic versioning spec.
-	AppPreRelease = "beta.rc4"
+	AppPreRelease = "beta.rc5"
 )
 
 func init() {

--- a/cmd/lncli/cmd_pay.go
+++ b/cmd/lncli/cmd_pay.go
@@ -64,7 +64,7 @@ var (
 		Name: "max_parts",
 		Usage: "the maximum number of partial payments that may be " +
 			"used",
-		Value: routerrpc.DefaultMaxParts,
+		Value: 1,
 	}
 
 	jsonFlag = cli.BoolFlag{

--- a/lnrpc/routerrpc/router_backend.go
+++ b/lnrpc/routerrpc/router_backend.go
@@ -24,15 +24,6 @@ import (
 	"github.com/lightningnetwork/lnd/zpay32"
 )
 
-const (
-	// DefaultMaxParts is the default number of splits we'll possibly use
-	// for MPP when the user is attempting to send a payment.
-	//
-	// TODO(roasbeef): make this value dynamic based on expected number of
-	// attempts for given amount
-	DefaultMaxParts = 16
-)
-
 // RouterBackend contains the backend implementation of the router rpc sub
 // server calls.
 type RouterBackend struct {
@@ -556,12 +547,11 @@ func (r *RouterBackend) extractIntentFromSendRequest(
 	}
 	payIntent.CltvLimit = cltvLimit
 
-	// Attempt to parse the max parts value set by the user, if this value
-	// isn't set, then we'll use the current default value for this
-	// setting.
+	// Take max htlcs from the request. Map zero to one for backwards
+	// compatibility.
 	maxParts := rpcPayReq.MaxParts
 	if maxParts == 0 {
-		maxParts = DefaultMaxParts
+		maxParts = 1
 	}
 	payIntent.MaxParts = maxParts
 

--- a/lntest/itest/lnd_multi-hop-error-propagation_test.go
+++ b/lntest/itest/lnd_multi-hop-error-propagation_test.go
@@ -204,7 +204,6 @@ out:
 		FinalCltvDelta: int32(carolPayReq.CltvExpiry),
 		TimeoutSeconds: 60,
 		FeeLimitMsat:   noFeeLimitMsat,
-		MaxParts:       1,
 	}
 	sendAndAssertFailure(
 		t, net.Alice,
@@ -241,7 +240,6 @@ out:
 		FinalCltvDelta: int32(carolPayReq.CltvExpiry),
 		TimeoutSeconds: 60,
 		FeeLimitMsat:   noFeeLimitMsat,
-		MaxParts:       1,
 	}
 	sendAndAssertFailure(
 		t, net.Alice,
@@ -302,7 +300,6 @@ out:
 				PaymentRequest: carolInvoice2.PaymentRequest,
 				TimeoutSeconds: 60,
 				FeeLimitMsat:   noFeeLimitMsat,
-				MaxParts:       1,
 			},
 		)
 
@@ -335,7 +332,6 @@ out:
 		PaymentRequest: carolInvoice3.PaymentRequest,
 		TimeoutSeconds: 60,
 		FeeLimitMsat:   noFeeLimitMsat,
-		MaxParts:       1,
 	}
 	sendAndAssertFailure(
 		t, net.Alice,
@@ -385,7 +381,6 @@ out:
 			PaymentRequest: carolInvoice.PaymentRequest,
 			TimeoutSeconds: 60,
 			FeeLimitMsat:   noFeeLimitMsat,
-			MaxParts:       1,
 		},
 		lnrpc.PaymentFailureReason_FAILURE_REASON_NO_ROUTE,
 	)

--- a/scripts/verify-install.sh
+++ b/scripts/verify-install.sh
@@ -64,8 +64,19 @@ check_command gpg
 
 LND_VERSION=$($LND_BIN --version | cut -d'=' -f2)
 LNCLI_VERSION=$($LNCLI_BIN --version | cut -d'=' -f2)
-LND_SUM=$(shasum -a 256 $LND_BIN | cut -d' ' -f1)
-LNCLI_SUM=$(shasum -a 256 $LNCLI_BIN | cut -d' ' -f1)
+
+# Make this script compatible with both linux and *nix.
+SHA_CMD="sha256sum"
+if ! command -v "$SHA_CMD"; then
+  if command -v "shasum"; then
+    SHA_CMD="shasum -a 256"
+  else
+    echo "ERROR: no SHA256 sum binary installed!"
+    exit 1
+  fi
+fi
+LND_SUM=$($SHA_CMD $LND_BIN | cut -d' ' -f1)
+LNCLI_SUM=$($SHA_CMD $LNCLI_BIN | cut -d' ' -f1)
 
 echo "Detected lnd $LND_BIN version $LND_VERSION with SHA256 sum $LND_SUM"
 echo "Detected lncli $LNCLI_BIN version $LNCLI_VERSION with SHA256 sum $LNCLI_SUM"


### PR DESCRIPTION
PRs included since v0.12.1-beta.rc4:
 - #5037 

I've also included a commit to modify the base branch from `upstream/master` to `v0.12.0-beta`, to fix the issue noted in https://github.com/lightningnetwork/lnd/pull/5027#issuecomment-780154676.

The default `MaxParts` via RPC has been reverted from 16 back to 1, since this was reported to introduce a breaking change wrt to the failure message returned in v0.12.0-beta.