### PR TITLE
[WIP] htlcswitch+lnwallet: avoid incrementally persisting open circuit

### DIFF
--- a/lnwallet/channel.go
+++ b/lnwallet/channel.go
@@ -3490,6 +3490,16 @@ func (lc *LightningChannel) validateCommitmentSanity(theirLogCounter,
 	return nil
 }
 
+// CanSignNextCommitment returns true if the channel is in a state where we can
+// sign a new commitment, i.e. we have the remote party's next revocation point
+// and we don't have any unacked commitments that we've signed for.
+func (lc *LightningChannel) CanSignNextCommitment() bool {
+	lc.Lock()
+	defer lc.Unlock()
+
+	return lc.canSignNextCommitment()
+}
+
 // canSignNextCommitment returns true if the channel is in a state where we can
 // sign a new commitment, i.e. we have the remote party's next revocation point
 // and we don't have any unacked commitments that we've signed for.


### PR DESCRIPTION
This PR exposes a CanSignNextCommitment method on LightningChannel
to determine if the channel is even capable of signing another commitment
state. This avoids incrementally persisting the open circuits to disk while
the channel cannot be updated, and waits to batch them all in a single write.

Wanted to run on travis to get some performance numbers.