### PR TITLE
lnd+lnwallet: make capacity check stricter by adding fee

### DIFF
--- a/breacharbiter_test.go
+++ b/breacharbiter_test.go
@@ -1843,22 +1843,24 @@ func createInitChannels(revocationWindow int) (*lnwallet.LightningChannel, *lnwa
 		return nil, nil, nil, err
 	}
 
+	commitFee := feePerKw.FeeForWeight(input.CommitWeight)
+
 	// TODO(roasbeef): need to factor in commit fee?
 	aliceCommit := channeldb.ChannelCommitment{
 		CommitHeight:  0,
-		LocalBalance:  lnwire.NewMSatFromSatoshis(channelBal),
+		LocalBalance:  lnwire.NewMSatFromSatoshis(channelBal - commitFee),
 		RemoteBalance: lnwire.NewMSatFromSatoshis(channelBal),
 		FeePerKw:      btcutil.Amount(feePerKw),
-		CommitFee:     8688,
+		CommitFee:     commitFee,
 		CommitTx:      aliceCommitTx,
 		CommitSig:     bytes.Repeat([]byte{1}, 71),
 	}
 	bobCommit := channeldb.ChannelCommitment{
 		CommitHeight:  0,
 		LocalBalance:  lnwire.NewMSatFromSatoshis(channelBal),
-		RemoteBalance: lnwire.NewMSatFromSatoshis(channelBal),
+		RemoteBalance: lnwire.NewMSatFromSatoshis(channelBal - commitFee),
 		FeePerKw:      btcutil.Amount(feePerKw),
-		CommitFee:     8688,
+		CommitFee:     commitFee,
 		CommitTx:      bobCommitTx,
 		CommitSig:     bytes.Repeat([]byte{1}, 71),
 	}

--- a/lnwallet/commitment.go
+++ b/lnwallet/commitment.go
@@ -589,11 +589,11 @@ func (cb *CommitmentBuilder) createUnsignedCommitmentTx(ourBalance,
 	for _, txOut := range commitTx.TxOut {
 		totalOut += btcutil.Amount(txOut.Value)
 	}
-	if totalOut > cb.chanState.Capacity {
+	if totalOut+commitFee > cb.chanState.Capacity {
 		return nil, fmt.Errorf("height=%v, for ChannelPoint(%v) "+
 			"attempts to consume %v while channel capacity is %v",
 			height, cb.chanState.FundingOutpoint,
-			totalOut, cb.chanState.Capacity)
+			totalOut+commitFee, cb.chanState.Capacity)
 	}
 
 	return &unsignedCommitmentTx{


### PR DESCRIPTION
Noticed we could make the capacity check stricter in `lnwallet/commitment.go` by adding the `commitFee`. After doing this, noticed that the breacharbiter tests were failing.

