### PR TITLE
lnwire: correct payload length checks in WriteMessage

### DIFF
--- a/lnwire/commit_sig.go
+++ b/lnwire/commit_sig.go
@@ -83,7 +83,7 @@ func (c *CommitSig) MsgType() MessageType {
 // This is part of the lnwire.Message interface.
 func (c *CommitSig) MaxPayloadLength(uint32) uint32 {
 	// 32 + 64 + 2 + max_allowed_htlcs
-	return MaxMessagePayload
+	return 65533
 }
 
 // TargetChanID returns the channel id of the link for which this message is

--- a/lnwire/error.go
+++ b/lnwire/error.go
@@ -123,8 +123,8 @@ func (c *Error) MsgType() MessageType {
 //
 // This is part of the lnwire.Message interface.
 func (c *Error) MaxPayloadLength(uint32) uint32 {
-	// 32 + 2 + 65501
-	return MaxMessagePayload
+	// 32 + 65501
+	return 65533
 }
 
 // isASCII is a helper method that checks whether all bytes in `data` would be

--- a/lnwire/init_message.go
+++ b/lnwire/init_message.go
@@ -69,5 +69,5 @@ func (msg *Init) MsgType() MessageType {
 //
 // This is part of the lnwire.Message interface.
 func (msg *Init) MaxPayloadLength(uint32) uint32 {
-	return 2 + 2 + maxAllowedSize + 2 + maxAllowedSize
+	return 2 + maxAllowedSize + 2 + maxAllowedSize
 }

--- a/lnwire/message.go
+++ b/lnwire/message.go
@@ -237,11 +237,11 @@ func WriteMessage(w io.Writer, msg Message, pver uint32) (int, error) {
 	payload := bw.Bytes()
 	lenp := len(payload)
 
-	// Enforce maximum overall message payload.
-	if lenp > MaxMessagePayload {
+	// Enforce maximum overall message payload without the message type.
+	if lenp > MaxMessagePayload-2 {
 		return totalBytes, fmt.Errorf("message payload is too large - "+
 			"encoded %d bytes, but maximum message payload is %d bytes",
-			lenp, MaxMessagePayload)
+			lenp, MaxMessagePayload-2)
 	}
 
 	// Enforce maximum message payload on the message type.

--- a/lnwire/ping.go
+++ b/lnwire/ping.go
@@ -63,5 +63,5 @@ func (p *Ping) MsgType() MessageType {
 //
 // This is part of the lnwire.Message interface.
 func (p Ping) MaxPayloadLength(uint32) uint32 {
-	return 65532
+	return 65533
 }

--- a/lnwire/pong.go
+++ b/lnwire/pong.go
@@ -59,5 +59,5 @@ func (p *Pong) MsgType() MessageType {
 //
 // This is part of the lnwire.Message interface.
 func (p *Pong) MaxPayloadLength(uint32) uint32 {
-	return 65532
+	return 65533
 }

--- a/lnwire/query_short_chan_ids.go
+++ b/lnwire/query_short_chan_ids.go
@@ -425,5 +425,5 @@ func (q *QueryShortChanIDs) MsgType() MessageType {
 //
 // This is part of the lnwire.Message interface.
 func (q *QueryShortChanIDs) MaxPayloadLength(uint32) uint32 {
-	return MaxMessagePayload
+	return 65533
 }

--- a/lnwire/reply_channel_range.go
+++ b/lnwire/reply_channel_range.go
@@ -86,5 +86,5 @@ func (c *ReplyChannelRange) MsgType() MessageType {
 //
 // This is part of the lnwire.Message interface.
 func (c *ReplyChannelRange) MaxPayloadLength(uint32) uint32 {
-	return MaxMessagePayload
+	return 65533
 }


### PR DESCRIPTION
This commit also modifies the `MaxPayloadLength` functions of several messages that were previously incorrect. The `MaxPayloadLength` of a message should not contain the 2-byte message type.
