### PR TITLE
lnd+lncfg: onlynet config to restrict outbound connections

### DIFF
--- a/lncfg/onlynet.go
+++ b/lncfg/onlynet.go
@@ -1,0 +1,9 @@
+package lncfg
+
+// Onlynet holds the configuration options for the daemon's network
+// connection restrictions.
+type Onlynet struct {
+	Active bool `long:"active" description:"Activate onlynet restrictions"`
+	Clear  bool `long:"clear" description:"Only allow outbound connections to clearnet addresses"`
+	Onion  bool `long:"onion" description:"Only allow outbound connections to onion addresses"`
+}

--- a/lnd.go
+++ b/lnd.go
@@ -560,6 +560,18 @@ func Main(cfg *Config, lisCfg ListenerCfg, shutdownChan <-chan struct{}) error {
 			"is proxying over Tor as well", cfg.Tor.StreamIsolation)
 	}
 
+	if cfg.Onlynet.Active {
+		var network string
+
+		if cfg.Onlynet.Clear {
+			network = "clearnet"
+		} else if cfg.Onlynet.Onion {
+			network = "onionnet"
+		}
+
+		srvrLog.Infof("Onlynet enabled - only connecting to %v addresses", network)
+	}
+
 	// If the watchtower client should be active, open the client database.
 	// This is done here so that Close always executes when lndMain returns.
 	var towerClientDB *wtdb.ClientDB

--- a/sample-lnd.conf
+++ b/sample-lnd.conf
@@ -732,6 +732,17 @@ litecoin.node=ltcd
 ; 3)
 ; autopilot.conftarget=2
 
+[onlynet]
+; Active onlynet restrictions. This means that all outbound p2p connections that
+; lnd makes will only be to the specified network.
+; onlynet.active = true
+
+; Whether the onlynet network is clearnet.
+; onlynet.clear = true
+
+; Whether the onlynet network is the Tor network.
+; onlynet.onion = true
+
 [tor]
 ; Allow outbound and inbound connections to be routed through Tor
 ; tor.active=true


### PR DESCRIPTION
Introduces `--onlynet` configuration option that restricts outbound connections to either clearnet addresses (ipv4/v6) or onion addresses (tor v2/v3 hidden services).  This affects peer bootstapping such that we won't automatically connect out to restricted networks.  If a node restarts and sets restrictions, they may not be able to connect out to channel peers.

Usage:
```
Onlynet:
      --onlynet.active                                        Activate onlynet restrictions
      --onlynet.clear                                         Only allow outbound connections to clearnet addresses
      --onlynet.onion                                         Only allow outbound connections to onion addresses
```

Questions:
- Should we warn in `establishPersistentConnections` if we are unable to connect to a channel peer due to `--onlynet`?
- Should DNS queries be changed during bootstrapping to only request certain types of addresses?
- How does the code mesh with https://github.com/lightningnetwork/lnd/issues/5042 (which is the opposite of `--onlynet`)?

Fixes https://github.com/lightningnetwork/lnd/issues/2387