### PR TITLE
htlcswitch: use a spec-compliant fail for intercepted HTLCs

### DIFF
--- a/htlcswitch/interceptable_switch.go
+++ b/htlcswitch/interceptable_switch.go
@@ -139,7 +139,7 @@ func (f *interceptedForward) Resume() error {
 
 // Fail forward a failed packet to the switch.
 func (f *interceptedForward) Fail() error {
-	reason, err := f.packet.obfuscator.EncryptFirstHop(lnwire.NewTemporaryChannelFailure(nil))
+	reason, err := f.packet.obfuscator.EncryptFirstHop(&lnwire.FailUnknownNextPeer{})
 	if err != nil {
 		return fmt.Errorf("failed to encrypt failure reason %v", err)
 	}


### PR DESCRIPTION
The old message is not spec compliant: [all Update reasons must include the
channel details](https://github.com/lightningnetwork/lightning-rfc/blob/master/04-onion-routing.md#failure-messages). On the other hand, using a Fail reason is also a
bit harsh since they are considered permanent. That is, a node could
refuse payment attempts to that channel for all time and be spec
compliant while doing so.

TBH I'm not sure if this change is a good default. I chose this error mostly cause it penalizes the channel instead of the routing node. The main motivation for this is that Acinq-based nodes don't react kindly to the current state of affairs. 