### PR TITLE
multi: allow setting target confs for co-op close

### DIFF
--- a/cmd/lncli/commands.go
+++ b/cmd/lncli/commands.go
@@ -669,7 +669,9 @@ var closeChannelCommand = cli.Command{
 			Name: "conf_target",
 			Usage: "(optional) the number of blocks that the " +
 				"transaction *should* confirm in, will be " +
-				"used for fee estimation",
+				"used for fee estimation. If not set, " +
+				"then the conf-target value set in the main " +
+				"lnd config will be used.",
 		},
 		cli.Int64Flag{
 			Name: "sat_per_byte",

--- a/config.go
+++ b/config.go
@@ -89,6 +89,13 @@ const (
 	defaultAlias = ""
 	defaultColor = "#3399FF"
 
+	// defaultCoopCloseTargetConfs is the default confirmation target
+	// that will be used to estimate a fee rate to use during a
+	// cooperative channel closure initiated by a remote peer. By default
+	// we'll set this to a lax value since we weren't the ones that
+	// initiated the channel closure.
+	defaultCoopCloseTargetConfs = 6
+
 	// defaultHostSampleInterval is the default amount of time that the
 	// HostAnnouncer will wait between DNS resolutions to check if the
 	// backing IP of a host has changed.
@@ -273,6 +280,7 @@ type Config struct {
 	Color                         string        `long:"color" description:"The color of the node in hex format (i.e. '#3399FF'). Used to customize node appearance in intelligence services"`
 	MinChanSize                   int64         `long:"minchansize" description:"The smallest channel size (in satoshis) that we should accept. Incoming channels smaller than this will be rejected"`
 	MaxChanSize                   int64         `long:"maxchansize" description:"The largest channel size (in satoshis) that we should accept. Incoming channels larger than this will be rejected"`
+	CoopCloseTargetConfs          uint32        `long:"coop-close-target-confs" description:"The target number of blocks that a cooperative channel close transaction should confirm in. This is used to estimate the fee to use as the lower bound during fee negotiation for the channel closure."`
 
 	DefaultRemoteMaxHtlcs uint16 `long:"default-remote-max-htlcs" description:"The default max_htlc applied when opening or accepting channels. This value limits the number of concurrent HTLCs that the remote party can add to the commitment. The maximum possible value is 483."`
 
@@ -434,6 +442,7 @@ func DefaultConfig() Config {
 		Color:                         defaultColor,
 		MinChanSize:                   int64(funding.MinChanFundingSize),
 		MaxChanSize:                   int64(0),
+		CoopCloseTargetConfs:          defaultCoopCloseTargetConfs,
 		DefaultRemoteMaxHtlcs:         defaultRemoteMaxHtlcs,
 		NumGraphSyncPeers:             defaultMinPeers,
 		HistoricalSyncInterval:        discovery.DefaultHistoricalSyncInterval,

--- a/peer/brontide.go
+++ b/peer/brontide.go
@@ -298,6 +298,11 @@ type Config struct {
 	// initiator for anchor channel commitments.
 	MaxAnchorsCommitFeeRate chainfee.SatPerKWeight
 
+	// CoopCloseTargetConfs is the confirmation target that will be used
+	// to estimate the fee rate to use during a cooperative channel
+	// closure initiated by the remote peer.
+	CoopCloseTargetConfs uint32
+
 	// ServerPubKey is the serialized, compressed public key of our lnd node.
 	// It is used to determine which policy (channel edge) to pass to the
 	// ChannelLink.
@@ -2340,9 +2345,10 @@ func (p *Brontide) fetchActiveChanCloser(chanID lnwire.ChannelID) (
 		}
 
 		// In order to begin fee negotiations, we'll first compute our
-		// target ideal fee-per-kw. We'll set this to a lax value, as
-		// we weren't the ones that initiated the channel closure.
-		feePerKw, err := p.cfg.FeeEstimator.EstimateFeePerKW(6)
+		// target ideal fee-per-kw.
+		feePerKw, err := p.cfg.FeeEstimator.EstimateFeePerKW(
+			p.cfg.CoopCloseTargetConfs,
+		)
 		if err != nil {
 			peerLog.Errorf("unable to query fee estimator: %v", err)
 

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -2317,6 +2317,13 @@ func (r *rpcServer) CloseChannel(in *lnrpc.CloseChannelRequest,
 				"is offline (try force closing it instead): %v", err)
 		}
 
+		// If conf-target is not set then use the conf-target used for
+		// co-op closes that are initiated by the remote peer.
+		targetConf := uint32(in.TargetConf)
+		if targetConf == 0 {
+			targetConf = r.cfg.CoopCloseTargetConfs
+		}
+
 		// Based on the passed fee related parameters, we'll determine
 		// an appropriate fee rate for the cooperative closure
 		// transaction.
@@ -2325,7 +2332,7 @@ func (r *rpcServer) CloseChannel(in *lnrpc.CloseChannelRequest,
 		).FeePerKWeight()
 		feeRate, err := sweep.DetermineFeePerKw(
 			r.server.cc.FeeEstimator, sweep.FeePreference{
-				ConfTarget: uint32(in.TargetConf),
+				ConfTarget: targetConf,
 				FeeRate:    satPerKw,
 			},
 		)

--- a/sample-lnd.conf
+++ b/sample-lnd.conf
@@ -254,7 +254,9 @@
 
 ; The target number of blocks in which a cooperative close initiated by a remote
 ; peer should be confirmed. This target is used to estimate the starting fee
-; rate that will be used during fee negotiation with the peer.
+; rate that will be used during fee negotiation with the peer. This target is
+; is also used for cooperative closes initiated locally if the --conf_target
+; for the channel closure is not set.
 ; coop-close-target-confs=10
 
 ; The default max_htlc applied when opening or accepting channels. This value

--- a/sample-lnd.conf
+++ b/sample-lnd.conf
@@ -252,6 +252,11 @@
 ; to better align with your risk tolerance
 ; maxchansize=
 
+; The target number of blocks in which a cooperative close initiated by a remote
+; peer should be confirmed. This target is used to estimate the starting fee
+; rate that will be used during fee negotiation with the peer.
+; coop-close-target-confs=10
+
 ; The default max_htlc applied when opening or accepting channels. This value
 ; limits the number of concurrent HTLCs that the remote party can add to the
 ; commitment. The maximum possible value is 483.

--- a/server.go
+++ b/server.go
@@ -3129,6 +3129,7 @@ func (s *server) peerConnected(conn net.Conn, connReq *connmgr.ConnReq,
 		UnsafeReplay:            s.cfg.UnsafeReplay,
 		MaxOutgoingCltvExpiry:   s.cfg.MaxOutgoingCltvExpiry,
 		MaxChannelFeeAllocation: s.cfg.MaxChannelFeeAllocation,
+		CoopCloseTargetConfs:    s.cfg.CoopCloseTargetConfs,
 		MaxAnchorsCommitFeeRate: chainfee.SatPerKVByte(
 			s.cfg.MaxCommitFeeRateAnchors * 1000).FeePerKWeight(),
 		Quit: s.quit,


### PR DESCRIPTION
Fixes #4732 

This PR adds a flag that allows a user to override the default conf target used to estimate the fee that lnd uses when attempting a co-op close.

Currently the value can be set if the channel closure is initiated locally but no option exists for channel closures that are initiated remotely and a hard coded conf target of 6 is used. So this PR just adds a flag so that the user can set this value.

- Commit 1: Adds a new `--coop-close-conf-target` flag used to override the default value used for fee estimation during the channel closure initiated by a _remote_ peer.
- Commit 2: Uses the new `CoopCloseTargetConfs` config value as the default to use for the target conf value to be used for a channel closure initiated _locally_ if the `conf_target` flag has not been set.