### PR TITLE
build: bump version to v0.12.99-beta

### DIFF
--- a/build/version.go
+++ b/build/version.go
@@ -44,7 +44,7 @@ const (
 	AppMinor uint = 12
 
 	// AppPatch defines the application patch for this binary.
-	AppPatch uint = 0
+	AppPatch uint = 99
 
 	// AppPreRelease MUST only contain characters from semanticAlphabet
 	// per the semantic versioning spec.


### PR DESCRIPTION
In this commit we bump the version to v0.12.99-beta to reflect that the
master branch is a super set of the recently released v0.12.1-beta.

