### PR TITLE
lnwire: remove MaxPayloadLength from lnwire.Message interface

### DIFF
--- a/lnwire/accept_channel.go
+++ b/lnwire/accept_channel.go
@@ -254,11 +254,3 @@ func parseShutdownScript(tlvRecords ExtraOpaqueData) (DeliveryAddress,
 func (a *AcceptChannel) MsgType() MessageType {
 	return MsgAcceptChannel
 }
-
-// MaxPayloadLength returns the maximum allowed payload length for a
-// AcceptChannel message.
-//
-// This is part of the lnwire.Message interface.
-func (a *AcceptChannel) MaxPayloadLength(uint32) uint32 {
-	return MaxMsgBody
-}

--- a/lnwire/announcement_signatures.go
+++ b/lnwire/announcement_signatures.go
@@ -81,11 +81,3 @@ func (a *AnnounceSignatures) Encode(w io.Writer, pver uint32) error {
 func (a *AnnounceSignatures) MsgType() MessageType {
 	return MsgAnnounceSignatures
 }
-
-// MaxPayloadLength returns the maximum allowed payload size for this message
-// observing the specified protocol version.
-//
-// This is part of the lnwire.Message interface.
-func (a *AnnounceSignatures) MaxPayloadLength(pver uint32) uint32 {
-	return MaxMsgBody
-}

--- a/lnwire/channel_announcement.go
+++ b/lnwire/channel_announcement.go
@@ -112,14 +112,6 @@ func (a *ChannelAnnouncement) MsgType() MessageType {
 	return MsgChannelAnnouncement
 }
 
-// MaxPayloadLength returns the maximum allowed payload size for this message
-// observing the specified protocol version.
-//
-// This is part of the lnwire.Message interface.
-func (a *ChannelAnnouncement) MaxPayloadLength(pver uint32) uint32 {
-	return MaxMsgBody
-}
-
 // DataToSign is used to retrieve part of the announcement message which should
 // be signed.
 func (a *ChannelAnnouncement) DataToSign() ([]byte, error) {

--- a/lnwire/channel_reestablish.go
+++ b/lnwire/channel_reestablish.go
@@ -159,11 +159,3 @@ func (a *ChannelReestablish) Decode(r io.Reader, pver uint32) error {
 func (a *ChannelReestablish) MsgType() MessageType {
 	return MsgChannelReestablish
 }
-
-// MaxPayloadLength returns the maximum allowed payload size for this message
-// observing the specified protocol version.
-//
-// This is part of the lnwire.Message interface.
-func (a *ChannelReestablish) MaxPayloadLength(pver uint32) uint32 {
-	return MaxMsgBody
-}

--- a/lnwire/channel_update.go
+++ b/lnwire/channel_update.go
@@ -196,14 +196,6 @@ func (a *ChannelUpdate) MsgType() MessageType {
 	return MsgChannelUpdate
 }
 
-// MaxPayloadLength returns the maximum allowed payload size for this message
-// observing the specified protocol version.
-//
-// This is part of the lnwire.Message interface.
-func (a *ChannelUpdate) MaxPayloadLength(pver uint32) uint32 {
-	return MaxMsgBody
-}
-
 // DataToSign is used to retrieve part of the announcement message which should
 // be signed.
 func (a *ChannelUpdate) DataToSign() ([]byte, error) {

--- a/lnwire/closing_signed.go
+++ b/lnwire/closing_signed.go
@@ -76,11 +76,3 @@ func (c *ClosingSigned) Encode(w io.Writer, pver uint32) error {
 func (c *ClosingSigned) MsgType() MessageType {
 	return MsgClosingSigned
 }
-
-// MaxPayloadLength returns the maximum allowed payload size for a
-// ClosingSigned complete message observing the specified protocol version.
-//
-// This is part of the lnwire.Message interface.
-func (c *ClosingSigned) MaxPayloadLength(uint32) uint32 {
-	return MaxMsgBody
-}

--- a/lnwire/commit_sig.go
+++ b/lnwire/commit_sig.go
@@ -86,14 +86,6 @@ func (c *CommitSig) MsgType() MessageType {
 	return MsgCommitSig
 }
 
-// MaxPayloadLength returns the maximum allowed payload size for a
-// CommitSig complete message observing the specified protocol version.
-//
-// This is part of the lnwire.Message interface.
-func (c *CommitSig) MaxPayloadLength(uint32) uint32 {
-	return MaxMsgBody
-}
-
 // TargetChanID returns the channel id of the link for which this message is
 // intended.
 //

--- a/lnwire/error.go
+++ b/lnwire/error.go
@@ -118,14 +118,6 @@ func (c *Error) MsgType() MessageType {
 	return MsgError
 }
 
-// MaxPayloadLength returns the maximum allowed payload size for an Error
-// complete message observing the specified protocol version.
-//
-// This is part of the lnwire.Message interface.
-func (c *Error) MaxPayloadLength(uint32) uint32 {
-	return MaxMsgBody
-}
-
 // isASCII is a helper method that checks whether all bytes in `data` would be
 // printable ASCII characters if interpreted as a string.
 func isASCII(data []byte) bool {

--- a/lnwire/funding_created.go
+++ b/lnwire/funding_created.go
@@ -66,11 +66,3 @@ func (f *FundingCreated) Decode(r io.Reader, pver uint32) error {
 func (f *FundingCreated) MsgType() MessageType {
 	return MsgFundingCreated
 }
-
-// MaxPayloadLength returns the maximum allowed payload length for a
-// FundingCreated message.
-//
-// This is part of the lnwire.Message interface.
-func (f *FundingCreated) MaxPayloadLength(uint32) uint32 {
-	return MaxMsgBody
-}

--- a/lnwire/funding_locked.go
+++ b/lnwire/funding_locked.go
@@ -73,12 +73,3 @@ func (c *FundingLocked) Encode(w io.Writer, pver uint32) error {
 func (c *FundingLocked) MsgType() MessageType {
 	return MsgFundingLocked
 }
-
-// MaxPayloadLength returns the maximum allowed payload length for a
-// FundingLocked message. This is calculated by summing the max length of all
-// the fields within a FundingLocked message.
-//
-// This is part of the lnwire.Message interface.
-func (c *FundingLocked) MaxPayloadLength(uint32) uint32 {
-	return MaxMsgBody
-}

--- a/lnwire/funding_signed.go
+++ b/lnwire/funding_signed.go
@@ -49,11 +49,3 @@ func (f *FundingSigned) Decode(r io.Reader, pver uint32) error {
 func (f *FundingSigned) MsgType() MessageType {
 	return MsgFundingSigned
 }
-
-// MaxPayloadLength returns the maximum allowed payload length for a
-// FundingSigned message.
-//
-// This is part of the lnwire.Message interface.
-func (f *FundingSigned) MaxPayloadLength(uint32) uint32 {
-	return MaxMsgBody
-}

--- a/lnwire/gossip_timestamp_range.go
+++ b/lnwire/gossip_timestamp_range.go
@@ -73,12 +73,3 @@ func (g *GossipTimestampRange) Encode(w io.Writer, pver uint32) error {
 func (g *GossipTimestampRange) MsgType() MessageType {
 	return MsgGossipTimestampRange
 }
-
-// MaxPayloadLength returns the maximum allowed payload size for a
-// GossipTimestampRange complete message observing the specified protocol
-// version.
-//
-// This is part of the lnwire.Message interface.
-func (g *GossipTimestampRange) MaxPayloadLength(uint32) uint32 {
-	return MaxMsgBody
-}

--- a/lnwire/init_message.go
+++ b/lnwire/init_message.go
@@ -71,11 +71,3 @@ func (msg *Init) Encode(w io.Writer, pver uint32) error {
 func (msg *Init) MsgType() MessageType {
 	return MsgInit
 }
-
-// MaxPayloadLength returns the maximum allowed payload size for an Init
-// complete message observing the specified protocol version.
-//
-// This is part of the lnwire.Message interface.
-func (msg *Init) MaxPayloadLength(uint32) uint32 {
-	return MaxMsgBody
-}

--- a/lnwire/lnwire_test.go
+++ b/lnwire/lnwire_test.go
@@ -250,9 +250,6 @@ func TestEmptyMessageUnknownType(t *testing.T) {
 // TestLightningWireProtocol uses the testing/quick package to create a series
 // of fuzz tests to attempt to break a primary scenario which is implemented as
 // property based testing scenario.
-//
-// Debug help: when the message payload can reach a size larger than the return
-// value of MaxPayloadLength, the test can panic without a helpful message.
 func TestLightningWireProtocol(t *testing.T) {
 	t.Parallel()
 
@@ -274,9 +271,9 @@ func TestLightningWireProtocol(t *testing.T) {
 		// the 2 bytes for the message type) is _below_ the specified
 		// max payload size for this message.
 		payloadLen := uint32(b.Len()) - 2
-		if payloadLen > msg.MaxPayloadLength(0) {
+		if payloadLen > MaxMsgBody {
 			t.Fatalf("msg payload constraint violated: %v > %v",
-				payloadLen, msg.MaxPayloadLength(0))
+				payloadLen, MaxMsgBody)
 			return false
 		}
 

--- a/lnwire/message.go
+++ b/lnwire/message.go
@@ -151,7 +151,6 @@ type Serializable interface {
 type Message interface {
 	Serializable
 	MsgType() MessageType
-	MaxPayloadLength(uint32) uint32
 }
 
 // makeEmptyMessage creates a new empty message of the proper concrete type
@@ -237,19 +236,12 @@ func WriteMessage(w io.Writer, msg Message, pver uint32) (int, error) {
 	payload := bw.Bytes()
 	lenp := len(payload)
 
-	// Enforce maximum overall message payload.
-	if lenp > MaxMessagePayload {
+	// Enforce maximum message payload, which means the body cannot be
+	// greater than MaxMsgBody.
+	if lenp > MaxMsgBody {
 		return totalBytes, fmt.Errorf("message payload is too large - "+
-			"encoded %d bytes, but maximum message payload is %d bytes",
-			lenp, MaxMessagePayload)
-	}
-
-	// Enforce maximum message payload on the message type.
-	mpl := msg.MaxPayloadLength(pver)
-	if uint32(lenp) > mpl {
-		return totalBytes, fmt.Errorf("message payload is too large - "+
-			"encoded %d bytes, but maximum message payload of "+
-			"type %v is %d bytes", lenp, msg.MsgType(), mpl)
+			"encoded %d bytes, but maximum message body is %d bytes",
+			lenp, MaxMsgBody)
 	}
 
 	// With the initial sanity checks complete, we'll now write out the

--- a/lnwire/node_announcement.go
+++ b/lnwire/node_announcement.go
@@ -145,14 +145,6 @@ func (a *NodeAnnouncement) MsgType() MessageType {
 	return MsgNodeAnnouncement
 }
 
-// MaxPayloadLength returns the maximum allowed payload size for this message
-// observing the specified protocol version.
-//
-// This is part of the lnwire.Message interface.
-func (a *NodeAnnouncement) MaxPayloadLength(pver uint32) uint32 {
-	return MaxMsgBody
-}
-
 // DataToSign returns the part of the message that should be signed.
 func (a *NodeAnnouncement) DataToSign() ([]byte, error) {
 

--- a/lnwire/open_channel.go
+++ b/lnwire/open_channel.go
@@ -239,11 +239,3 @@ func (o *OpenChannel) Decode(r io.Reader, pver uint32) error {
 func (o *OpenChannel) MsgType() MessageType {
 	return MsgOpenChannel
 }
-
-// MaxPayloadLength returns the maximum allowed payload length for a
-// OpenChannel message.
-//
-// This is part of the lnwire.Message interface.
-func (o *OpenChannel) MaxPayloadLength(uint32) uint32 {
-	return MaxMsgBody
-}

--- a/lnwire/ping.go
+++ b/lnwire/ping.go
@@ -57,11 +57,3 @@ func (p *Ping) Encode(w io.Writer, pver uint32) error {
 func (p *Ping) MsgType() MessageType {
 	return MsgPing
 }
-
-// MaxPayloadLength returns the maximum allowed payload size for a Ping
-// complete message observing the specified protocol version.
-//
-// This is part of the lnwire.Message interface.
-func (p Ping) MaxPayloadLength(uint32) uint32 {
-	return 65532
-}

--- a/lnwire/pong.go
+++ b/lnwire/pong.go
@@ -53,11 +53,3 @@ func (p *Pong) Encode(w io.Writer, pver uint32) error {
 func (p *Pong) MsgType() MessageType {
 	return MsgPong
 }
-
-// MaxPayloadLength returns the maximum allowed payload size for a Pong
-// complete message observing the specified protocol version.
-//
-// This is part of the lnwire.Message interface.
-func (p *Pong) MaxPayloadLength(uint32) uint32 {
-	return 65532
-}

--- a/lnwire/query_channel_range.go
+++ b/lnwire/query_channel_range.go
@@ -75,14 +75,6 @@ func (q *QueryChannelRange) MsgType() MessageType {
 	return MsgQueryChannelRange
 }
 
-// MaxPayloadLength returns the maximum allowed payload size for a
-// QueryChannelRange complete message observing the specified protocol version.
-//
-// This is part of the lnwire.Message interface.
-func (q *QueryChannelRange) MaxPayloadLength(uint32) uint32 {
-	return MaxMsgBody
-}
-
 // LastBlockHeight returns the last block height covered by the range of a
 // QueryChannelRange message.
 func (q *QueryChannelRange) LastBlockHeight() uint32 {

--- a/lnwire/query_short_chan_ids.go
+++ b/lnwire/query_short_chan_ids.go
@@ -432,11 +432,3 @@ func encodeShortChanIDs(w io.Writer, encodingType ShortChanIDEncoding,
 func (q *QueryShortChanIDs) MsgType() MessageType {
 	return MsgQueryShortChanIDs
 }
-
-// MaxPayloadLength returns the maximum allowed payload size for a
-// QueryShortChanIDs complete message observing the specified protocol version.
-//
-// This is part of the lnwire.Message interface.
-func (q *QueryShortChanIDs) MaxPayloadLength(uint32) uint32 {
-	return MaxMsgBody
-}

--- a/lnwire/reply_channel_range.go
+++ b/lnwire/reply_channel_range.go
@@ -112,14 +112,6 @@ func (c *ReplyChannelRange) MsgType() MessageType {
 	return MsgReplyChannelRange
 }
 
-// MaxPayloadLength returns the maximum allowed payload size for a
-// ReplyChannelRange complete message observing the specified protocol version.
-//
-// This is part of the lnwire.Message interface.
-func (c *ReplyChannelRange) MaxPayloadLength(uint32) uint32 {
-	return MaxMsgBody
-}
-
 // LastBlockHeight returns the last block height covered by the range of a
 // QueryChannelRange message.
 func (c *ReplyChannelRange) LastBlockHeight() uint32 {

--- a/lnwire/reply_short_chan_ids_end.go
+++ b/lnwire/reply_short_chan_ids_end.go
@@ -69,12 +69,3 @@ func (c *ReplyShortChanIDsEnd) Encode(w io.Writer, pver uint32) error {
 func (c *ReplyShortChanIDsEnd) MsgType() MessageType {
 	return MsgReplyShortChanIDsEnd
 }
-
-// MaxPayloadLength returns the maximum allowed payload size for a
-// ReplyShortChanIDsEnd complete message observing the specified protocol
-// version.
-//
-// This is part of the lnwire.Message interface.
-func (c *ReplyShortChanIDsEnd) MaxPayloadLength(uint32) uint32 {
-	return MaxMsgBody
-}

--- a/lnwire/revoke_and_ack.go
+++ b/lnwire/revoke_and_ack.go
@@ -82,14 +82,6 @@ func (c *RevokeAndAck) MsgType() MessageType {
 	return MsgRevokeAndAck
 }
 
-// MaxPayloadLength returns the maximum allowed payload size for a RevokeAndAck
-// complete message observing the specified protocol version.
-//
-// This is part of the lnwire.Message interface.
-func (c *RevokeAndAck) MaxPayloadLength(uint32) uint32 {
-	return MaxMsgBody
-}
-
 // TargetChanID returns the channel id of the link for which this message is
 // intended.
 //

--- a/lnwire/shutdown.go
+++ b/lnwire/shutdown.go
@@ -57,11 +57,3 @@ func (s *Shutdown) Encode(w io.Writer, pver uint32) error {
 func (s *Shutdown) MsgType() MessageType {
 	return MsgShutdown
 }
-
-// MaxPayloadLength returns the maximum allowed payload size for this message
-// observing the specified protocol version.
-//
-// This is part of the lnwire.Message interface.
-func (s *Shutdown) MaxPayloadLength(pver uint32) uint32 {
-	return MaxMsgBody
-}

--- a/lnwire/update_add_htlc.go
+++ b/lnwire/update_add_htlc.go
@@ -108,14 +108,6 @@ func (c *UpdateAddHTLC) MsgType() MessageType {
 	return MsgUpdateAddHTLC
 }
 
-// MaxPayloadLength returns the maximum allowed payload size for an UpdateAddHTLC
-// complete message observing the specified protocol version.
-//
-// This is part of the lnwire.Message interface.
-func (c *UpdateAddHTLC) MaxPayloadLength(uint32) uint32 {
-	return MaxMsgBody
-}
-
 // TargetChanID returns the channel id of the link for which this message is
 // intended.
 //

--- a/lnwire/update_fail_htlc.go
+++ b/lnwire/update_fail_htlc.go
@@ -71,14 +71,6 @@ func (c *UpdateFailHTLC) MsgType() MessageType {
 	return MsgUpdateFailHTLC
 }
 
-// MaxPayloadLength returns the maximum allowed payload size for an UpdateFailHTLC
-// complete message observing the specified protocol version.
-//
-// This is part of the lnwire.Message interface.
-func (c *UpdateFailHTLC) MaxPayloadLength(uint32) uint32 {
-	return MaxMsgBody
-}
-
 // TargetChanID returns the channel id of the link for which this message is
 // intended.
 //

--- a/lnwire/update_fail_malformed_htlc.go
+++ b/lnwire/update_fail_malformed_htlc.go
@@ -71,15 +71,6 @@ func (c *UpdateFailMalformedHTLC) MsgType() MessageType {
 	return MsgUpdateFailMalformedHTLC
 }
 
-// MaxPayloadLength returns the maximum allowed payload size for a
-// UpdateFailMalformedHTLC complete message observing the specified protocol
-// version.
-//
-// This is part of the lnwire.Message interface.
-func (c *UpdateFailMalformedHTLC) MaxPayloadLength(uint32) uint32 {
-	return MaxMsgBody
-}
-
 // TargetChanID returns the channel id of the link for which this message is
 // intended.
 //

--- a/lnwire/update_fee.go
+++ b/lnwire/update_fee.go
@@ -67,14 +67,6 @@ func (c *UpdateFee) MsgType() MessageType {
 	return MsgUpdateFee
 }
 
-// MaxPayloadLength returns the maximum allowed payload size for an UpdateFee
-// complete message observing the specified protocol version.
-//
-// This is part of the lnwire.Message interface.
-func (c *UpdateFee) MaxPayloadLength(uint32) uint32 {
-	return MaxMsgBody
-}
-
 // TargetChanID returns the channel id of the link for which this message is
 // intended.
 //

--- a/lnwire/update_fulfill_htlc.go
+++ b/lnwire/update_fulfill_htlc.go
@@ -77,14 +77,6 @@ func (c *UpdateFulfillHTLC) MsgType() MessageType {
 	return MsgUpdateFulfillHTLC
 }
 
-// MaxPayloadLength returns the maximum allowed payload size for an UpdateFulfillHTLC
-// complete message observing the specified protocol version.
-//
-// This is part of the lnwire.Message interface.
-func (c *UpdateFulfillHTLC) MaxPayloadLength(uint32) uint32 {
-	return MaxMsgBody
-}
-
 // TargetChanID returns the channel id of the link for which this message is
 // intended.
 //


### PR DESCRIPTION
Removes the `MaxPayloadLength` function from the `lnwire.Message` interface since each message can now be up to 65535 bytes including the 2-byte type.  This PR also fixes the `ping` and `pong` payloads which were previously coded as 65532, instead of 65533.