### PR TITLE
lnrpc: correct comment on half life seconds

### DIFF
--- a/lnrpc/routerrpc/router.pb.go
+++ b/lnrpc/routerrpc/router.pb.go
@@ -1190,10 +1190,10 @@ var xxx_messageInfo_SetMissionControlConfigResponse proto.InternalMessageInfo
 type MissionControlConfig struct {
 	//
 	//The amount of time mission control will take to restore a penalized node
-	//or channel back to 50% success probability, expressed as a unix timestamp
-	//in seconds. Setting this value to a higher value will penalize failures for
-	//longer, making mission control less likely to route through nodes and
-	//channels that we have previously recorded failures for.
+	//or channel back to 50% success probability, expressed in seconds. Setting
+	//this value to a higher value will penalize failures for longer, making
+	//mission control less likely to route through nodes and channels that we
+	//have previously recorded failures for.
 	HalfLifeSeconds uint64 `protobuf:"varint,1,opt,name=half_life_seconds,json=halfLifeSeconds,proto3" json:"half_life_seconds,omitempty"`
 	//
 	//The probability of success mission control should assign to hop in a route

--- a/lnrpc/routerrpc/router.proto
+++ b/lnrpc/routerrpc/router.proto
@@ -399,10 +399,10 @@ message SetMissionControlConfigResponse {
 message MissionControlConfig {
     /*
     The amount of time mission control will take to restore a penalized node
-    or channel back to 50% success probability, expressed as a unix timestamp
-    in seconds. Setting this value to a higher value will penalize failures for
-    longer, making mission control less likely to route through nodes and
-    channels that we have previously recorded failures for.
+    or channel back to 50% success probability, expressed in seconds. Setting
+    this value to a higher value will penalize failures for longer, making
+    mission control less likely to route through nodes and channels that we
+    have previously recorded failures for.
     */
     uint64 half_life_seconds = 1;
 

--- a/lnrpc/routerrpc/router.swagger.json
+++ b/lnrpc/routerrpc/router.swagger.json
@@ -1109,7 +1109,7 @@
         "half_life_seconds": {
           "type": "string",
           "format": "uint64",
-          "description": "The amount of time mission control will take to restore a penalized node\nor channel back to 50% success probability, expressed as a unix timestamp\nin seconds. Setting this value to a higher value will penalize failures for\nlonger, making mission control less likely to route through nodes and\nchannels that we have previously recorded failures for."
+          "description": "The amount of time mission control will take to restore a penalized node\nor channel back to 50% success probability, expressed in seconds. Setting\nthis value to a higher value will penalize failures for longer, making\nmission control less likely to route through nodes and channels that we\nhave previously recorded failures for."
         },
         "hop_probability": {
           "type": "number",


### PR DESCRIPTION
Update comment on PenaltyHalfLife, as identified [here](https://github.com/lightningnetwork/lnd/pull/4909#issuecomment-790926865).