### PR TITLE
mobile: gracefully exit if lnd fails to start

### DIFF
--- a/mobile/bindings.go
+++ b/mobile/bindings.go
@@ -50,13 +50,15 @@ func Start(extraArgs string, unlockerReady, rpcReady Callback) {
 	loadedConfig, err := lnd.LoadConfig()
 	if err != nil {
 		_, _ = fmt.Fprintln(os.Stderr, err)
-		os.Exit(1)
+		rpcReady.OnError(err)
+		return
 	}
 
 	// Hook interceptor for os signals.
 	if err := signal.Intercept(); err != nil {
 		_, _ = fmt.Fprintln(os.Stderr, err)
-		os.Exit(1)
+		rpcReady.OnError(err)
+		return
 	}
 
 	// Set up channels that will be notified when the RPC servers are ready
@@ -90,7 +92,8 @@ func Start(extraArgs string, unlockerReady, rpcReady Callback) {
 			} else {
 				fmt.Fprintln(os.Stderr, err)
 			}
-			os.Exit(1)
+			rpcReady.OnError(err)
+			return
 		}
 	}()
 


### PR DESCRIPTION
Instead of killing the app, report an error back to the application.

NOTE: this PR depends on https://github.com/lightningnetwork/lnd/pull/5010 as there we remove the `unlockerReady` callback.

Fixes https://github.com/lightningnetwork/lnd/issues/5077