### PR TITLE
lncli: cancel RPC context on OS interrupts

### DIFF
--- a/cmd/lncli/autopilotrpc_active.go
+++ b/cmd/lncli/autopilotrpc_active.go
@@ -3,8 +3,6 @@
 package main
 
 import (
-	"context"
-
 	"github.com/lightningnetwork/lnd/lnrpc/autopilotrpc"
 	"github.com/urfave/cli"
 )
@@ -27,13 +25,13 @@ var getStatusCommand = cli.Command{
 }
 
 func getStatus(ctx *cli.Context) error {
-	ctxb := context.Background()
+	ctxc := getContext()
 	client, cleanUp := getAutopilotClient(ctx)
 	defer cleanUp()
 
 	req := &autopilotrpc.StatusRequest{}
 
-	resp, err := client.Status(ctxb, req)
+	resp, err := client.Status(ctxc, req)
 	if err != nil {
 		return err
 	}
@@ -57,7 +55,7 @@ var disableCommand = cli.Command{
 }
 
 func enable(ctx *cli.Context) error {
-	ctxb := context.Background()
+	ctxc := getContext()
 	client, cleanUp := getAutopilotClient(ctx)
 	defer cleanUp()
 
@@ -66,7 +64,7 @@ func enable(ctx *cli.Context) error {
 		Enable: true,
 	}
 
-	resp, err := client.ModifyStatus(ctxb, req)
+	resp, err := client.ModifyStatus(ctxc, req)
 	if err != nil {
 		return err
 	}
@@ -76,7 +74,7 @@ func enable(ctx *cli.Context) error {
 }
 
 func disable(ctx *cli.Context) error {
-	ctxb := context.Background()
+	ctxc := getContext()
 	client, cleanUp := getAutopilotClient(ctx)
 	defer cleanUp()
 
@@ -85,7 +83,7 @@ func disable(ctx *cli.Context) error {
 		Enable: false,
 	}
 
-	resp, err := client.ModifyStatus(ctxb, req)
+	resp, err := client.ModifyStatus(ctxc, req)
 	if err != nil {
 		return err
 	}
@@ -110,7 +108,7 @@ var queryScoresCommand = cli.Command{
 }
 
 func queryScores(ctx *cli.Context) error {
-	ctxb := context.Background()
+	ctxc := getContext()
 	client, cleanUp := getAutopilotClient(ctx)
 	defer cleanUp()
 
@@ -134,7 +132,7 @@ loop:
 		IgnoreLocalState: ctx.Bool("ignorelocalstate"),
 	}
 
-	resp, err := client.QueryScores(ctxb, req)
+	resp, err := client.QueryScores(ctxc, req)
 	if err != nil {
 		return err
 	}

--- a/cmd/lncli/cmd_build_route.go
+++ b/cmd/lncli/cmd_build_route.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"context"
 	"errors"
 	"fmt"
 	"strings"
@@ -43,6 +42,7 @@ var buildRouteCommand = cli.Command{
 }
 
 func buildRoute(ctx *cli.Context) error {
+	ctxc := getContext()
 	conn := getClientConn(ctx, false)
 	defer conn.Close()
 
@@ -80,8 +80,7 @@ func buildRoute(ctx *cli.Context) error {
 		OutgoingChanId: ctx.Uint64("outgoing_chan_id"),
 	}
 
-	rpcCtx := context.Background()
-	route, err := client.BuildRoute(rpcCtx, req)
+	route, err := client.BuildRoute(ctxc, req)
 	if err != nil {
 		return err
 	}

--- a/cmd/lncli/cmd_invoice.go
+++ b/cmd/lncli/cmd_invoice.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"context"
 	"encoding/hex"
 	"fmt"
 	"strconv"
@@ -74,7 +73,7 @@ func addInvoice(ctx *cli.Context) error {
 		amt      int64
 		err      error
 	)
-
+	ctxc := getContext()
 	client, cleanUp := getClient(ctx)
 	defer cleanUp()
 
@@ -117,7 +116,7 @@ func addInvoice(ctx *cli.Context) error {
 		Private:         ctx.Bool("private"),
 	}
 
-	resp, err := client.AddInvoice(context.Background(), invoice)
+	resp, err := client.AddInvoice(ctxc, invoice)
 	if err != nil {
 		return err
 	}
@@ -143,6 +142,7 @@ var lookupInvoiceCommand = cli.Command{
 }
 
 func lookupInvoice(ctx *cli.Context) error {
+	ctxc := getContext()
 	client, cleanUp := getClient(ctx)
 	defer cleanUp()
 
@@ -168,7 +168,7 @@ func lookupInvoice(ctx *cli.Context) error {
 		RHash: rHash,
 	}
 
-	invoice, err := client.LookupInvoice(context.Background(), req)
+	invoice, err := client.LookupInvoice(ctxc, req)
 	if err != nil {
 		return err
 	}
@@ -225,6 +225,7 @@ var listInvoicesCommand = cli.Command{
 }
 
 func listInvoices(ctx *cli.Context) error {
+	ctxc := getContext()
 	client, cleanUp := getClient(ctx)
 	defer cleanUp()
 
@@ -235,7 +236,7 @@ func listInvoices(ctx *cli.Context) error {
 		Reversed:       !ctx.Bool("paginate-forwards"),
 	}
 
-	invoices, err := client.ListInvoices(context.Background(), req)
+	invoices, err := client.ListInvoices(ctxc, req)
 	if err != nil {
 		return err
 	}
@@ -261,7 +262,7 @@ var decodePayReqCommand = cli.Command{
 }
 
 func decodePayReq(ctx *cli.Context) error {
-	ctxb := context.Background()
+	ctxc := getContext()
 	client, cleanUp := getClient(ctx)
 	defer cleanUp()
 
@@ -276,7 +277,7 @@ func decodePayReq(ctx *cli.Context) error {
 		return fmt.Errorf("pay_req argument missing")
 	}
 
-	resp, err := client.DecodePayReq(ctxb, &lnrpc.PayReqString{
+	resp, err := client.DecodePayReq(ctxc, &lnrpc.PayReqString{
 		PayReq: payreq,
 	})
 	if err != nil {

--- a/cmd/lncli/cmd_macaroon.go
+++ b/cmd/lncli/cmd_macaroon.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"bytes"
-	"context"
 	"encoding/hex"
 	"fmt"
 	"io/ioutil"
@@ -75,6 +74,7 @@ var bakeMacaroonCommand = cli.Command{
 }
 
 func bakeMacaroon(ctx *cli.Context) error {
+	ctxc := getContext()
 	client, cleanUp := getClient(ctx)
 	defer cleanUp()
 
@@ -151,7 +151,7 @@ func bakeMacaroon(ctx *cli.Context) error {
 		Permissions: parsedPermissions,
 		RootKeyId:   rootKeyID,
 	}
-	resp, err := client.BakeMacaroon(context.Background(), req)
+	resp, err := client.BakeMacaroon(ctxc, req)
 	if err != nil {
 		return err
 	}
@@ -217,11 +217,12 @@ var listMacaroonIDsCommand = cli.Command{
 }
 
 func listMacaroonIDs(ctx *cli.Context) error {
+	ctxc := getContext()
 	client, cleanUp := getClient(ctx)
 	defer cleanUp()
 
 	req := &lnrpc.ListMacaroonIDsRequest{}
-	resp, err := client.ListMacaroonIDs(context.Background(), req)
+	resp, err := client.ListMacaroonIDs(ctxc, req)
 	if err != nil {
 		return err
 	}
@@ -250,6 +251,7 @@ var deleteMacaroonIDCommand = cli.Command{
 }
 
 func deleteMacaroonID(ctx *cli.Context) error {
+	ctxc := getContext()
 	client, cleanUp := getClient(ctx)
 	defer cleanUp()
 
@@ -277,7 +279,7 @@ func deleteMacaroonID(ctx *cli.Context) error {
 	req := &lnrpc.DeleteMacaroonIDRequest{
 		RootKeyId: rootKeyID,
 	}
-	resp, err := client.DeleteMacaroonID(context.Background(), req)
+	resp, err := client.DeleteMacaroonID(ctxc, req)
 	if err != nil {
 		return err
 	}
@@ -295,11 +297,12 @@ var listPermissionsCommand = cli.Command{
 }
 
 func listPermissions(ctx *cli.Context) error {
+	ctxc := getContext()
 	client, cleanUp := getClient(ctx)
 	defer cleanUp()
 
 	request := &lnrpc.ListPermissionsRequest{}
-	response, err := client.ListPermissions(context.Background(), request)
+	response, err := client.ListPermissions(ctxc, request)
 	if err != nil {
 		return err
 	}

--- a/cmd/lncli/cmd_mc_cfg_get.go
+++ b/cmd/lncli/cmd_mc_cfg_get.go
@@ -1,8 +1,6 @@
 package main
 
 import (
-	"context"
-
 	"github.com/lightningnetwork/lnd/lnrpc/routerrpc"
 	"github.com/urfave/cli"
 )
@@ -17,14 +15,14 @@ var getCfgCommand = cli.Command{
 }
 
 func getCfg(ctx *cli.Context) error {
+	ctxc := getContext()
 	conn := getClientConn(ctx, false)
 	defer conn.Close()
 
 	client := routerrpc.NewRouterClient(conn)
 
-	ctxb := context.Background()
 	resp, err := client.GetMissionControlConfig(
-		ctxb, &routerrpc.GetMissionControlConfigRequest{},
+		ctxc, &routerrpc.GetMissionControlConfigRequest{},
 	)
 	if err != nil {
 		return err

--- a/cmd/lncli/cmd_mc_cfg_set.go
+++ b/cmd/lncli/cmd_mc_cfg_set.go
@@ -1,8 +1,6 @@
 package main
 
 import (
-	"context"
-
 	"github.com/lightningnetwork/lnd/lnrpc/routerrpc"
 	"github.com/urfave/cli"
 )
@@ -45,14 +43,14 @@ var setCfgCommand = cli.Command{
 }
 
 func setCfg(ctx *cli.Context) error {
+	ctxc := getContext()
 	conn := getClientConn(ctx, false)
 	defer conn.Close()
 
 	client := routerrpc.NewRouterClient(conn)
 
-	ctxb := context.Background()
 	resp, err := client.GetMissionControlConfig(
-		ctxb, &routerrpc.GetMissionControlConfigRequest{},
+		ctxc, &routerrpc.GetMissionControlConfigRequest{},
 	)
 	if err != nil {
 		return err
@@ -94,7 +92,7 @@ func setCfg(ctx *cli.Context) error {
 	}
 
 	_, err = client.SetMissionControlConfig(
-		ctxb, &routerrpc.SetMissionControlConfigRequest{
+		ctxc, &routerrpc.SetMissionControlConfigRequest{
 			Config: resp.Config,
 		},
 	)

--- a/cmd/lncli/cmd_open_channel.go
+++ b/cmd/lncli/cmd_open_channel.go
@@ -202,7 +202,7 @@ var openChannelCommand = cli.Command{
 
 func openChannel(ctx *cli.Context) error {
 	// TODO(roasbeef): add deadline to context
-	ctxb := context.Background()
+	ctxc := getContext()
 	client, cleanUp := getClient(ctx)
 	defer cleanUp()
 
@@ -263,7 +263,7 @@ func openChannel(ctx *cli.Context) error {
 
 		// Check if connecting to the node was successful.
 		// We discard the peer id returned as it is not needed.
-		_, err := client.ConnectPeer(ctxb, req)
+		_, err := client.ConnectPeer(ctxc, req)
 		if err != nil &&
 			!strings.Contains(err.Error(), "already connected") {
 			return err
@@ -297,14 +297,14 @@ func openChannel(ctx *cli.Context) error {
 	// PSBT funding is a more involved, interactive process that is too
 	// large to also fit into this already long function.
 	if ctx.Bool("psbt") {
-		return openChannelPsbt(ctx, client, req)
+		return openChannelPsbt(ctxc, ctx, client, req)
 	}
 	if !ctx.Bool("psbt") && ctx.Bool("no_publish") {
 		return fmt.Errorf("the --no_publish flag can only be used in " +
 			"combination with the --psbt flag")
 	}
 
-	stream, err := client.OpenChannel(ctxb, req)
+	stream, err := client.OpenChannel(ctxc, req)
 	if err != nil {
 		return err
 	}
@@ -348,7 +348,8 @@ func openChannel(ctx *cli.Context) error {
 //     |  |-------channel pending------->|  |
 //     |  |-------channel open------------->|
 //     |                                    |
-func openChannelPsbt(ctx *cli.Context, client lnrpc.LightningClient,
+func openChannelPsbt(rpcCtx context.Context, ctx *cli.Context,
+	client lnrpc.LightningClient,
 	req *lnrpc.OpenChannelRequest) error {
 
 	var (
@@ -358,7 +359,7 @@ func openChannelPsbt(ctx *cli.Context, client lnrpc.LightningClient,
 		quit          = make(chan struct{})
 		srvMsg        = make(chan *lnrpc.OpenStatusUpdate, 1)
 		srvErr        = make(chan error, 1)
-		ctxc, cancel  = context.WithCancel(context.Background())
+		ctxc, cancel  = context.WithCancel(rpcCtx)
 	)
 	defer cancel()
 

--- a/cmd/lncli/cmd_query_mission_control.go
+++ b/cmd/lncli/cmd_query_mission_control.go
@@ -1,8 +1,6 @@
 package main
 
 import (
-	"context"
-
 	"github.com/lightningnetwork/lnd/lnrpc/routerrpc"
 
 	"github.com/urfave/cli"
@@ -16,14 +14,14 @@ var queryMissionControlCommand = cli.Command{
 }
 
 func queryMissionControl(ctx *cli.Context) error {
+	ctxc := getContext()
 	conn := getClientConn(ctx, false)
 	defer conn.Close()
 
 	client := routerrpc.NewRouterClient(conn)
 
 	req := &routerrpc.QueryMissionControlRequest{}
-	rpcCtx := context.Background()
-	snapshot, err := client.QueryMissionControl(rpcCtx, req)
+	snapshot, err := client.QueryMissionControl(ctxc, req)
 	if err != nil {
 		return err
 	}

--- a/cmd/lncli/cmd_query_probability.go
+++ b/cmd/lncli/cmd_query_probability.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"context"
 	"fmt"
 	"strconv"
 
@@ -21,6 +20,7 @@ var queryProbCommand = cli.Command{
 }
 
 func queryProb(ctx *cli.Context) error {
+	ctxc := getContext()
 	args := ctx.Args()
 
 	if len(args) != 3 {
@@ -56,8 +56,8 @@ func queryProb(ctx *cli.Context) error {
 		ToNode:   toNode[:],
 		AmtMsat:  int64(amtMsat),
 	}
-	rpcCtx := context.Background()
-	response, err := client.QueryProbability(rpcCtx, req)
+
+	response, err := client.QueryProbability(ctxc, req)
 	if err != nil {
 		return err
 	}

--- a/cmd/lncli/cmd_reset_mission_control.go
+++ b/cmd/lncli/cmd_reset_mission_control.go
@@ -1,8 +1,6 @@
 package main
 
 import (
-	"context"
-
 	"github.com/lightningnetwork/lnd/lnrpc/routerrpc"
 
 	"github.com/urfave/cli"
@@ -16,13 +14,13 @@ var resetMissionControlCommand = cli.Command{
 }
 
 func resetMissionControl(ctx *cli.Context) error {
+	ctxc := getContext()
 	conn := getClientConn(ctx, false)
 	defer conn.Close()
 
 	client := routerrpc.NewRouterClient(conn)
 
 	req := &routerrpc.ResetMissionControlRequest{}
-	rpcCtx := context.Background()
-	_, err := client.ResetMissionControl(rpcCtx, req)
+	_, err := client.ResetMissionControl(ctxc, req)
 	return err
 }

--- a/cmd/lncli/cmd_update_chan_status.go
+++ b/cmd/lncli/cmd_update_chan_status.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"context"
 	"errors"
 
 	"github.com/lightningnetwork/lnd/lnrpc/routerrpc"
@@ -51,6 +50,7 @@ var updateChanStatusCommand = cli.Command{
 }
 
 func updateChanStatus(ctx *cli.Context) error {
+	ctxc := getContext()
 	conn := getClientConn(ctx, false)
 	defer conn.Close()
 
@@ -82,8 +82,7 @@ func updateChanStatus(ctx *cli.Context) error {
 	}
 
 	client := routerrpc.NewRouterClient(conn)
-	ctxb := context.Background()
-	resp, err := client.UpdateChanStatus(ctxb, req)
+	resp, err := client.UpdateChanStatus(ctxc, req)
 	if err != nil {
 		return err
 	}

--- a/cmd/lncli/cmd_version.go
+++ b/cmd/lncli/cmd_version.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"context"
 	"fmt"
 
 	"github.com/lightningnetwork/lnd/build"
@@ -21,6 +20,7 @@ var versionCommand = cli.Command{
 }
 
 func version(ctx *cli.Context) error {
+	ctxc := getContext()
 	conn := getClientConn(ctx, false)
 	defer conn.Close()
 
@@ -40,8 +40,7 @@ func version(ctx *cli.Context) error {
 
 	client := verrpc.NewVersionerClient(conn)
 
-	ctxb := context.Background()
-	lndVersion, err := client.GetVersion(ctxb, &verrpc.VersionRequest{})
+	lndVersion, err := client.GetVersion(ctxc, &verrpc.VersionRequest{})
 	if err != nil {
 		printRespJSON(versions)
 		return fmt.Errorf("unable fetch version from lnd: %v", err)

--- a/cmd/lncli/cmd_walletunlocker.go
+++ b/cmd/lncli/cmd_walletunlocker.go
@@ -3,7 +3,6 @@ package main
 import (
 	"bufio"
 	"bytes"
-	"context"
 	"encoding/hex"
 	"fmt"
 	"io/ioutil"
@@ -115,7 +114,7 @@ func monowidthColumns(words []string, ncols int) []string {
 }
 
 func create(ctx *cli.Context) error {
-	ctxb := context.Background()
+	ctxc := getContext()
 	client, cleanUp := getWalletUnlockerClient(ctx)
 	defer cleanUp()
 
@@ -343,7 +342,7 @@ mnemonicCheck:
 		genSeedReq := &lnrpc.GenSeedRequest{
 			AezeedPassphrase: aezeedPass,
 		}
-		seedResp, err := client.GenSeed(ctxb, genSeedReq)
+		seedResp, err := client.GenSeed(ctxc, genSeedReq)
 		if err != nil {
 			return fmt.Errorf("unable to generate seed: %v", err)
 		}
@@ -384,7 +383,7 @@ mnemonicCheck:
 		ChannelBackups:     chanBackups,
 		StatelessInit:      statelessInit,
 	}
-	response, err := client.InitWallet(ctxb, req)
+	response, err := client.InitWallet(ctxc, req)
 	if err != nil {
 		return err
 	}
@@ -481,7 +480,7 @@ var unlockCommand = cli.Command{
 }
 
 func unlock(ctx *cli.Context) error {
-	ctxb := context.Background()
+	ctxc := getContext()
 	client, cleanUp := getWalletUnlockerClient(ctx)
 	defer cleanUp()
 
@@ -533,7 +532,7 @@ func unlock(ctx *cli.Context) error {
 		RecoveryWindow: recoveryWindow,
 		StatelessInit:  ctx.Bool(statelessInitFlag.Name),
 	}
-	_, err = client.UnlockWallet(ctxb, req)
+	_, err = client.UnlockWallet(ctxc, req)
 	if err != nil {
 		return err
 	}
@@ -591,7 +590,7 @@ var changePasswordCommand = cli.Command{
 }
 
 func changePassword(ctx *cli.Context) error {
-	ctxb := context.Background()
+	ctxc := getContext()
 	client, cleanUp := getWalletUnlockerClient(ctx)
 	defer cleanUp()
 
@@ -630,7 +629,7 @@ func changePassword(ctx *cli.Context) error {
 		NewMacaroonRootKey: ctx.Bool("new_mac_root_key"),
 	}
 
-	response, err := client.ChangePassword(ctxb, req)
+	response, err := client.ChangePassword(ctxc, req)
 	if err != nil {
 		return err
 	}

--- a/cmd/lncli/invoicesrpc_active.go
+++ b/cmd/lncli/invoicesrpc_active.go
@@ -3,7 +3,6 @@
 package main
 
 import (
-	"context"
 	"encoding/hex"
 	"fmt"
 
@@ -56,6 +55,7 @@ func settleInvoice(ctx *cli.Context) error {
 		err      error
 	)
 
+	ctxc := getContext()
 	client, cleanUp := getInvoicesClient(ctx)
 	defer cleanUp()
 
@@ -76,7 +76,7 @@ func settleInvoice(ctx *cli.Context) error {
 		Preimage: preimage,
 	}
 
-	resp, err := client.SettleInvoice(context.Background(), invoice)
+	resp, err := client.SettleInvoice(ctxc, invoice)
 	if err != nil {
 		return err
 	}
@@ -109,6 +109,7 @@ func cancelInvoice(ctx *cli.Context) error {
 		err         error
 	)
 
+	ctxc := getContext()
 	client, cleanUp := getInvoicesClient(ctx)
 	defer cleanUp()
 
@@ -129,7 +130,7 @@ func cancelInvoice(ctx *cli.Context) error {
 		PaymentHash: paymentHash,
 	}
 
-	resp, err := client.CancelInvoice(context.Background(), invoice)
+	resp, err := client.CancelInvoice(ctxc, invoice)
 	if err != nil {
 		return err
 	}
@@ -199,6 +200,7 @@ func addHoldInvoice(ctx *cli.Context) error {
 		err      error
 	)
 
+	ctxc := getContext()
 	client, cleanUp := getInvoicesClient(ctx)
 	defer cleanUp()
 
@@ -245,7 +247,7 @@ func addHoldInvoice(ctx *cli.Context) error {
 		Private:         ctx.Bool("private"),
 	}
 
-	resp, err := client.AddHoldInvoice(context.Background(), invoice)
+	resp, err := client.AddHoldInvoice(ctxc, invoice)
 	if err != nil {
 		return err
 	}

--- a/cmd/lncli/walletrpc_active.go
+++ b/cmd/lncli/walletrpc_active.go
@@ -3,7 +3,6 @@
 package main
 
 import (
-	"context"
 	"encoding/base64"
 	"encoding/hex"
 	"encoding/json"
@@ -75,12 +74,12 @@ var pendingSweepsCommand = cli.Command{
 }
 
 func pendingSweeps(ctx *cli.Context) error {
-	ctxb := context.Background()
+	ctxc := getContext()
 	client, cleanUp := getWalletClient(ctx)
 	defer cleanUp()
 
 	req := &walletrpc.PendingSweepsRequest{}
-	resp, err := client.PendingSweeps(ctxb, req)
+	resp, err := client.PendingSweeps(ctxc, req)
 	if err != nil {
 		return err
 	}
@@ -165,6 +164,8 @@ var bumpFeeCommand = cli.Command{
 }
 
 func bumpFee(ctx *cli.Context) error {
+	ctxc := getContext()
+
 	// Display the command's help message if we do not have the expected
 	// number of arguments/flags.
 	if ctx.NArg() != 1 {
@@ -180,7 +181,7 @@ func bumpFee(ctx *cli.Context) error {
 	client, cleanUp := getWalletClient(ctx)
 	defer cleanUp()
 
-	resp, err := client.BumpFee(context.Background(), &walletrpc.BumpFeeRequest{
+	resp, err := client.BumpFee(ctxc, &walletrpc.BumpFeeRequest{
 		Outpoint:   protoOutPoint,
 		TargetConf: uint32(ctx.Uint64("conf_target")),
 		SatPerByte: uint32(ctx.Uint64("sat_per_byte")),
@@ -222,6 +223,8 @@ var bumpCloseFeeCommand = cli.Command{
 }
 
 func bumpCloseFee(ctx *cli.Context) error {
+	ctxc := getContext()
+
 	// Display the command's help message if we do not have the expected
 	// number of arguments/flags.
 	if ctx.NArg() != 1 {
@@ -249,9 +252,8 @@ func bumpCloseFee(ctx *cli.Context) error {
 	walletClient, cleanUp := getWalletClient(ctx)
 	defer cleanUp()
 
-	ctxb := context.Background()
 	sweeps, err := walletClient.PendingSweeps(
-		ctxb, &walletrpc.PendingSweepsRequest{},
+		ctxc, &walletrpc.PendingSweepsRequest{},
 	)
 	if err != nil {
 		return err
@@ -286,7 +288,7 @@ func bumpCloseFee(ctx *cli.Context) error {
 		fmt.Printf("Bumping fee of %v:%v\n",
 			sweepTxID, sweep.Outpoint.OutputIndex)
 
-		_, err = walletClient.BumpFee(ctxb, &walletrpc.BumpFeeRequest{
+		_, err = walletClient.BumpFee(ctxc, &walletrpc.BumpFeeRequest{
 			Outpoint:   sweep.Outpoint,
 			TargetConf: uint32(ctx.Uint64("conf_target")),
 			SatPerByte: uint32(ctx.Uint64("sat_per_byte")),
@@ -304,10 +306,10 @@ func getWaitingCloseCommitments(client lnrpc.LightningClient,
 	channelPoint string) (*lnrpc.PendingChannelsResponse_Commitments,
 	error) {
 
-	ctxb := context.Background()
+	ctxc := getContext()
 
 	req := &lnrpc.PendingChannelsRequest{}
-	resp, err := client.PendingChannels(ctxb, req)
+	resp, err := client.PendingChannels(ctxc, req)
 	if err != nil {
 		return nil, err
 	}
@@ -343,11 +345,12 @@ var listSweepsCommand = cli.Command{
 }
 
 func listSweeps(ctx *cli.Context) error {
+	ctxc := getContext()
 	client, cleanUp := getWalletClient(ctx)
 	defer cleanUp()
 
 	resp, err := client.ListSweeps(
-		context.Background(), &walletrpc.ListSweepsRequest{
+		ctxc, &walletrpc.ListSweepsRequest{
 			Verbose: ctx.IsSet("verbose"),
 		},
 	)
@@ -380,6 +383,8 @@ var labelTxCommand = cli.Command{
 }
 
 func labelTransaction(ctx *cli.Context) error {
+	ctxc := getContext()
+
 	// Display the command's help message if we do not have the expected
 	// number of arguments/flags.
 	if ctx.NArg() != 2 {
@@ -398,9 +403,8 @@ func labelTransaction(ctx *cli.Context) error {
 	walletClient, cleanUp := getWalletClient(ctx)
 	defer cleanUp()
 
-	ctxb := context.Background()
 	_, err = walletClient.LabelTransaction(
-		ctxb, &walletrpc.LabelTransactionRequest{
+		ctxc, &walletrpc.LabelTransactionRequest{
 			Txid:      hash[:],
 			Label:     label,
 			Overwrite: ctx.Bool("overwrite"),
@@ -494,6 +498,8 @@ var fundPsbtCommand = cli.Command{
 }
 
 func fundPsbt(ctx *cli.Context) error {
+	ctxc := getContext()
+
 	// Display the command's help message if there aren't any flags
 	// specified.
 	if ctx.NumFlags() == 0 {
@@ -594,7 +600,7 @@ func fundPsbt(ctx *cli.Context) error {
 	walletClient, cleanUp := getWalletClient(ctx)
 	defer cleanUp()
 
-	response, err := walletClient.FundPsbt(context.Background(), req)
+	response, err := walletClient.FundPsbt(ctxc, req)
 	if err != nil {
 		return err
 	}
@@ -652,6 +658,8 @@ var finalizePsbtCommand = cli.Command{
 }
 
 func finalizePsbt(ctx *cli.Context) error {
+	ctxc := getContext()
+
 	// Display the command's help message if we do not have the expected
 	// number of arguments/flags.
 	if ctx.NArg() != 1 && ctx.NumFlags() != 1 {
@@ -682,7 +690,7 @@ func finalizePsbt(ctx *cli.Context) error {
 	walletClient, cleanUp := getWalletClient(ctx)
 	defer cleanUp()
 
-	response, err := walletClient.FinalizePsbt(context.Background(), req)
+	response, err := walletClient.FinalizePsbt(ctxc, req)
 	if err != nil {
 		return err
 	}
@@ -717,6 +725,8 @@ var releaseOutputCommand = cli.Command{
 }
 
 func releaseOutput(ctx *cli.Context) error {
+	ctxc := getContext()
+
 	// Display the command's help message if we do not have the expected
 	// number of arguments/flags.
 	if ctx.NArg() != 1 && ctx.NumFlags() != 1 {
@@ -748,7 +758,7 @@ func releaseOutput(ctx *cli.Context) error {
 	walletClient, cleanUp := getWalletClient(ctx)
 	defer cleanUp()
 
-	response, err := walletClient.ReleaseOutput(context.Background(), req)
+	response, err := walletClient.ReleaseOutput(ctxc, req)
 	if err != nil {
 		return err
 	}

--- a/cmd/lncli/watchtower_active.go
+++ b/cmd/lncli/watchtower_active.go
@@ -3,8 +3,6 @@
 package main
 
 import (
-	"context"
-
 	"github.com/lightningnetwork/lnd/lnrpc/watchtowerrpc"
 	"github.com/urfave/cli"
 )
@@ -37,6 +35,7 @@ var towerInfoCommand = cli.Command{
 }
 
 func towerInfo(ctx *cli.Context) error {
+	ctxc := getContext()
 	if ctx.NArg() != 0 || ctx.NumFlags() > 0 {
 		return cli.ShowCommandHelp(ctx, "info")
 	}
@@ -45,7 +44,7 @@ func towerInfo(ctx *cli.Context) error {
 	defer cleanup()
 
 	req := &watchtowerrpc.GetInfoRequest{}
-	resp, err := client.GetInfo(context.Background(), req)
+	resp, err := client.GetInfo(ctxc, req)
 	if err != nil {
 		return err
 	}

--- a/cmd/lncli/wtclient.go
+++ b/cmd/lncli/wtclient.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"context"
 	"encoding/hex"
 	"errors"
 	"fmt"
@@ -51,6 +50,8 @@ var addTowerCommand = cli.Command{
 }
 
 func addTower(ctx *cli.Context) error {
+	ctxc := getContext()
+
 	// Display the command's help message if the number of arguments/flags
 	// is not what we expect.
 	if ctx.NArg() != 1 || ctx.NumFlags() > 0 {
@@ -74,7 +75,7 @@ func addTower(ctx *cli.Context) error {
 		Pubkey:  pubKey,
 		Address: address,
 	}
-	resp, err := client.AddTower(context.Background(), req)
+	resp, err := client.AddTower(ctxc, req)
 	if err != nil {
 		return err
 	}
@@ -96,6 +97,8 @@ var removeTowerCommand = cli.Command{
 }
 
 func removeTower(ctx *cli.Context) error {
+	ctxc := getContext()
+
 	// Display the command's help message if the number of arguments/flags
 	// is not what we expect.
 	if ctx.NArg() != 1 || ctx.NumFlags() > 0 {
@@ -130,7 +133,7 @@ func removeTower(ctx *cli.Context) error {
 		Pubkey:  pubKey,
 		Address: address,
 	}
-	resp, err := client.RemoveTower(context.Background(), req)
+	resp, err := client.RemoveTower(ctxc, req)
 	if err != nil {
 		return err
 	}
@@ -153,6 +156,8 @@ var listTowersCommand = cli.Command{
 }
 
 func listTowers(ctx *cli.Context) error {
+	ctxc := getContext()
+
 	// Display the command's help message if the number of arguments/flags
 	// is not what we expect.
 	if ctx.NArg() > 0 || ctx.NumFlags() > 1 {
@@ -165,7 +170,7 @@ func listTowers(ctx *cli.Context) error {
 	req := &wtclientrpc.ListTowersRequest{
 		IncludeSessions: ctx.Bool("include_sessions"),
 	}
-	resp, err := client.ListTowers(context.Background(), req)
+	resp, err := client.ListTowers(ctxc, req)
 	if err != nil {
 		return err
 	}
@@ -190,6 +195,8 @@ var getTowerCommand = cli.Command{
 }
 
 func getTower(ctx *cli.Context) error {
+	ctxc := getContext()
+
 	// Display the command's help message if the number of arguments/flags
 	// is not what we expect.
 	if ctx.NArg() != 1 || ctx.NumFlags() > 1 {
@@ -211,7 +218,7 @@ func getTower(ctx *cli.Context) error {
 		Pubkey:          pubKey,
 		IncludeSessions: ctx.Bool("include_sessions"),
 	}
-	resp, err := client.GetTowerInfo(context.Background(), req)
+	resp, err := client.GetTowerInfo(ctxc, req)
 	if err != nil {
 		return err
 	}
@@ -227,6 +234,8 @@ var statsCommand = cli.Command{
 }
 
 func stats(ctx *cli.Context) error {
+	ctxc := getContext()
+
 	// Display the command's help message if the number of arguments/flags
 	// is not what we expect.
 	if ctx.NArg() > 0 || ctx.NumFlags() > 0 {
@@ -237,7 +246,7 @@ func stats(ctx *cli.Context) error {
 	defer cleanUp()
 
 	req := &wtclientrpc.StatsRequest{}
-	resp, err := client.Stats(context.Background(), req)
+	resp, err := client.Stats(ctxc, req)
 	if err != nil {
 		return err
 	}
@@ -264,6 +273,8 @@ var policyCommand = cli.Command{
 }
 
 func policy(ctx *cli.Context) error {
+	ctxc := getContext()
+
 	// Display the command's help message if the number of arguments/flags
 	// is not what we expect.
 	if ctx.NArg() > 0 || ctx.NumFlags() > 1 {
@@ -288,7 +299,7 @@ func policy(ctx *cli.Context) error {
 	req := &wtclientrpc.PolicyRequest{
 		PolicyType: policyType,
 	}
-	resp, err := client.Policy(context.Background(), req)
+	resp, err := client.Policy(ctxc, req)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Fixes #2133

This PR makes the lncli gPRC contexts cancelable. An os signal interrupt handler is added which cancels the context is an os signal is received. A follow up PR can address #2134 which will make the server context aware. This is a rebase and continuation of the #2147.

One thing here is that it can perhaps be easy to forget to use this new cancellable context in future when new lncli commands are added. So perhaps a github workflow that checks the lncli dir and to make sure that `context.Background` is only called once (shout out to @carlaKC for this idea).  