### PR TITLE
routing: check payment.DestFeatures against nil

### DIFF
--- a/routing/payment_session.go
+++ b/routing/payment_session.go
@@ -290,6 +290,12 @@ func (p *paymentSession) RequestRoute(maxAmt, feeLimit lnwire.MilliSatoshi,
 				return nil, errNoPathFound
 			}
 
+			if p.payment.DestFeatures == nil {
+				p.log.Debug("Not splitting because " +
+					"destination DestFeatures is nil")
+				return nil, errNoPathFound
+			}
+
 			if !p.payment.DestFeatures.HasFeature(lnwire.MPPOptional) {
 				p.log.Debug("not splitting because " +
 					"destination doesn't declare MPP")


### PR DESCRIPTION
When no nodes are available, `lnd` will give a segfault. 
```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x1805e47]

goroutine 356 [running]:
github.com/lightningnetwork/lnd/lnwire.(*FeatureVector).HasFeature(...)
    .../lnd/lnwire/features.go:409
github.com/lightningnetwork/lnd/routing.(*paymentSession).RequestRoute(0xc0003349a0, 0x1388, 0x1388, 0x19f00000000, 0x2, 0x0, 0xffffffffffffffff)
    .../lnd/routing/payment_session.go:300 +0x7c7
github.com/lightningnetwork/lnd/routing.(*paymentLifecycle).resumePayment(0xc000459e68, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0)
    .../lnd/routing/payment_lifecycle.go:208 +0x8dd
github.com/lightningnetwork/lnd/routing.(*ChannelRouter).sendPayment(0xc0001b68c0, 0x1388, 0x1388, 0x5900ba209997086b, 0xcd3c6734c8c71d74, 0x533f74b21cc95c8e, 0x744dfb7102640382, 0xdf8475800, 0x22b4c40, 0xc0003349a0, ...)
    .../lnd/routing/router.go:1994 +0x14c
github.com/lightningnetwork/lnd/routing.(*ChannelRouter).SendPaymentAsync.func1(0xc0001b68c0, 0xc000494fc0, 0x22b4c40, 0xc0003349a0)
    .../lnd/routing/router.go:1762 +0x196
created by github.com/lightningnetwork/lnd/routing.(*ChannelRouter).SendPaymentAsync
    .../lnd/routing/router.go:1756 +0xd3
```