### PR TITLE
routing: fix mission control deadlock

### DIFF
--- a/routing/missioncontrol.go
+++ b/routing/missioncontrol.go
@@ -238,9 +238,6 @@ func NewMissionControl(db kvdb.Backend, self route.Vertex,
 func (m *MissionControl) init() error {
 	log.Debugf("Mission control state reconstruction started")
 
-	m.Lock()
-	defer m.Unlock()
-
 	start := time.Now()
 
 	results, err := m.store.fetchAll()

--- a/routing/missioncontrol.go
+++ b/routing/missioncontrol.go
@@ -371,9 +371,6 @@ func (m *MissionControl) ReportPaymentFail(paymentID uint64, rt *route.Route,
 	failureSourceIdx *int, failure lnwire.FailureMessage) (
 	*channeldb.FailureReason, error) {
 
-	m.Lock()
-	defer m.Unlock()
-
 	timestamp := m.now()
 
 	result := &paymentResult{
@@ -393,9 +390,6 @@ func (m *MissionControl) ReportPaymentFail(paymentID uint64, rt *route.Route,
 // for future probability estimates.
 func (m *MissionControl) ReportPaymentSuccess(paymentID uint64,
 	rt *route.Route) error {
-
-	m.Lock()
-	defer m.Unlock()
 
 	timestamp := m.now()
 
@@ -420,6 +414,9 @@ func (m *MissionControl) processPaymentResult(result *paymentResult) (
 	if err := m.store.AddResult(result); err != nil {
 		return nil, err
 	}
+
+	m.Lock()
+	defer m.Unlock()
 
 	// Apply result to update mission control state.
 	reason := m.applyPaymentResult(result)


### PR DESCRIPTION
Fixes the following potential deadlock situation:
* Pathfinding holds a database lock and tries to obtain a mission control lock via GetProbability
* ReportPaymentSuccess/ReportPaymentFail holds a mission control lock and tries to obtain a database lock to store the payment result.

Fixes https://github.com/lightningnetwork/lnd/issues/5104