### PR TITLE
invoices: add debug logs to startup invoice GC

### DIFF
--- a/invoices/invoiceregistry.go
+++ b/invoices/invoiceregistry.go
@@ -213,8 +213,16 @@ func (i *InvoiceRegistry) scanInvoicesOnStart() error {
 		len(pending))
 	i.expiryWatcher.AddInvoices(pending...)
 
-	if err := i.cdb.DeleteInvoice(removable); err != nil {
-		log.Warnf("Deleting old invoices failed: %v", err)
+	if len(removable) > 0 {
+		log.Debugf("Attempting to delete %v canceled invoices",
+			len(removable))
+
+		if err := i.cdb.DeleteInvoice(removable); err != nil {
+			log.Warnf("Deleting old invoices failed: %v", err)
+		} else {
+			log.Debugf("Removed %v canceled invoices",
+				len(removable))
+		}
 	}
 
 	return nil


### PR DESCRIPTION
This PR adds debug logs to startup invoice garbage collect (`--gc-canceled-invoices-on-startup`).