### PR TITLE
lncli: start signal interceptor in getContext

### DIFF
--- a/cmd/lncli/cmd_open_channel.go
+++ b/cmd/lncli/cmd_open_channel.go
@@ -436,10 +436,6 @@ func openChannelPsbt(rpcCtx context.Context, ctx *cli.Context,
 		return fmt.Errorf("opening stream to server failed: %v", err)
 	}
 
-	if err := signal.Intercept(); err != nil {
-		return err
-	}
-
 	// We also need to spawn a goroutine that reads from the server. This
 	// will copy the messages to the channel as long as they come in or add
 	// exactly one error to the error stream and then bail out.

--- a/cmd/lncli/commands.go
+++ b/cmd/lncli/commands.go
@@ -41,6 +41,11 @@ const (
 )
 
 func getContext() context.Context {
+	if err := signal.Intercept(); err != nil {
+		_, _ = fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+
 	ctxc, cancel := context.WithCancel(context.Background())
 	go func() {
 		<-signal.ShutdownChannel()


### PR DESCRIPTION
Signal Intercept function needs to be called if the signal shutdown
channel will be listened on. Fixing the bug caught in comment: https://github.com/lightningnetwork/lnd/pull/5097#issuecomment-801415227