### PR TITLE
lnwallet+channeldb: delete owed remote updates when signing

### DIFF
--- a/lnwallet/channel.go
+++ b/lnwallet/channel.go
@@ -2120,6 +2120,8 @@ func (lc *LightningChannel) restorePendingLocalUpdates(
 	// If we did have a dangling commit, then we'll examine which updates
 	// we included in that state and re-insert them into our update log.
 	for _, logUpdate := range pendingRemoteCommitDiff.LogUpdates {
+		logUpdate := logUpdate
+
 		payDesc, err := lc.logUpdateToPayDesc(
 			&logUpdate, lc.remoteUpdateLog, pendingHeight,
 			chainfee.SatPerKWeight(pendingCommit.FeePerKw),


### PR DESCRIPTION
Fixes regression introduced in https://github.com/lightningnetwork/lnd/pull/4431
See commit messages for details.

Fixes https://github.com/lightningnetwork/lnd/issues/5103