### PR TITLE
rpcserver: revert target conf to previous behavior

### DIFF
--- a/lntest/harness.go
+++ b/lntest/harness.go
@@ -845,6 +845,10 @@ type OpenChannelParams struct {
 	// FundingShim is an optional funding shim that the caller can specify
 	// in order to modify the channel funding workflow.
 	FundingShim *lnrpc.FundingShim
+
+	// SatPerVByte is the amount of satoshis to spend in chain fees per virtual
+	// byte of the transaction.
+	SatPerVByte btcutil.Amount
 }
 
 // OpenChannel attempts to open a channel between srcNode and destNode with the
@@ -882,6 +886,7 @@ func (n *NetworkHarness) OpenChannel(ctx context.Context,
 		MinHtlcMsat:        int64(p.MinHtlc),
 		RemoteMaxHtlcs:     uint32(p.RemoteMaxHtlcs),
 		FundingShim:        p.FundingShim,
+		SatPerByte:         int64(p.SatPerVByte),
 	}
 
 	respStream, err := srcNode.OpenChannel(ctx, openReq)

--- a/lntest/itest/lnd_test.go
+++ b/lntest/itest/lnd_test.go
@@ -1253,6 +1253,7 @@ func basicChannelFundingTest(t *harnessTest, net *lntest.NetworkHarness,
 
 	chanAmt := funding.MaxBtcFundingAmount
 	pushAmt := btcutil.Amount(100000)
+	satPerVbyte := btcutil.Amount(1)
 
 	// Record nodes' channel balance before testing.
 	aliceChannelBalance := getChannelBalance(t, alice)
@@ -1293,6 +1294,7 @@ func basicChannelFundingTest(t *harnessTest, net *lntest.NetworkHarness,
 			Amt:         chanAmt,
 			PushAmt:     pushAmt,
 			FundingShim: fundingShim,
+			SatPerVByte: satPerVbyte,
 		},
 	)
 

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -2168,13 +2168,6 @@ func (r *rpcServer) CloseChannel(in *lnrpc.CloseChannelRequest,
 				"is offline (try force closing it instead): %v", err)
 		}
 
-		// If conf-target is not set then use the conf-target used for
-		// co-op closes that are initiated by the remote peer.
-		targetConf := uint32(in.TargetConf)
-		if targetConf == 0 {
-			targetConf = r.cfg.CoopCloseTargetConfs
-		}
-
 		// Based on the passed fee related parameters, we'll determine
 		// an appropriate fee rate for the cooperative closure
 		// transaction.
@@ -2183,7 +2176,7 @@ func (r *rpcServer) CloseChannel(in *lnrpc.CloseChannelRequest,
 		).FeePerKWeight()
 		feeRate, err := sweep.DetermineFeePerKw(
 			r.server.cc.FeeEstimator, sweep.FeePreference{
-				ConfTarget: targetConf,
+				ConfTarget: uint32(in.TargetConf),
 				FeeRate:    satPerKw,
 			},
 		)


### PR DESCRIPTION
[Previously](https://github.com/lightningnetwork/lnd/pull/5064/files#diff-674c79ba02b6e9c45a994388392689814f3538800351b2fd43fb3ade21e1effbR2323) the rpcserver would not use the remote conf target as its local conf target and this behavior is desirable.

This also re-allows setting a fee rate when cooperatively closing a channel