### PR TITLE
channeldb: use consistent receiver

### DIFF
--- a/channeldb/forwarding_log.go
+++ b/channeldb/forwarding_log.go
@@ -41,9 +41,9 @@ const (
 
 // ForwardingLog returns an instance of the ForwardingLog object backed by the
 // target database instance.
-func (d *DB) ForwardingLog() *ForwardingLog {
+func (db *DB) ForwardingLog() *ForwardingLog {
 	return &ForwardingLog{
-		db: d,
+		db: db,
 	}
 }
 

--- a/channeldb/meta.go
+++ b/channeldb/meta.go
@@ -22,10 +22,10 @@ type Meta struct {
 
 // FetchMeta fetches the meta data from boltdb and returns filled meta
 // structure.
-func (d *DB) FetchMeta(tx kvdb.RTx) (*Meta, error) {
+func (db *DB) FetchMeta(tx kvdb.RTx) (*Meta, error) {
 	var meta *Meta
 
-	err := kvdb.View(d, func(tx kvdb.RTx) error {
+	err := kvdb.View(db, func(tx kvdb.RTx) error {
 		return fetchMeta(meta, tx)
 	}, func() {
 		meta = &Meta{}
@@ -57,8 +57,8 @@ func fetchMeta(meta *Meta, tx kvdb.RTx) error {
 }
 
 // PutMeta writes the passed instance of the database met-data struct to disk.
-func (d *DB) PutMeta(meta *Meta) error {
-	return kvdb.Update(d, func(tx kvdb.RwTx) error {
+func (db *DB) PutMeta(meta *Meta) error {
+	return kvdb.Update(db, func(tx kvdb.RwTx) error {
 		return putMeta(meta, tx)
 	}, func() {})
 }

--- a/channeldb/peers.go
+++ b/channeldb/peers.go
@@ -49,8 +49,8 @@ type FlapCount struct {
 // WriteFlapCounts writes the flap count for a set of peers to disk, creating a
 // bucket for the peer's pubkey if necessary. Note that this function overwrites
 // the current value.
-func (d *DB) WriteFlapCounts(flapCounts map[route.Vertex]*FlapCount) error {
-	return kvdb.Update(d, func(tx kvdb.RwTx) error {
+func (db *DB) WriteFlapCounts(flapCounts map[route.Vertex]*FlapCount) error {
+	return kvdb.Update(db, func(tx kvdb.RwTx) error {
 		// Run through our set of flap counts and record them for
 		// each peer, creating a bucket for the peer pubkey if required.
 		for peer, flapCount := range flapCounts {
@@ -85,10 +85,10 @@ func (d *DB) WriteFlapCounts(flapCounts map[route.Vertex]*FlapCount) error {
 
 // ReadFlapCount attempts to read the flap count for a peer, failing if the
 // peer is not found or we do not have flap count stored.
-func (d *DB) ReadFlapCount(pubkey route.Vertex) (*FlapCount, error) {
+func (db *DB) ReadFlapCount(pubkey route.Vertex) (*FlapCount, error) {
 	var flapCount FlapCount
 
-	if err := kvdb.View(d, func(tx kvdb.RTx) error {
+	if err := kvdb.View(db, func(tx kvdb.RTx) error {
 		peers := tx.ReadBucket(peersBucket)
 
 		peerBucket := peers.NestedReadBucket(pubkey[:])

--- a/channeldb/reports.go
+++ b/channeldb/reports.go
@@ -121,7 +121,7 @@ type ResolverReport struct {
 
 // PutResolverReport creates and commits a transaction that is used to write a
 // resolver report to disk.
-func (d *DB) PutResolverReport(tx kvdb.RwTx, chainHash chainhash.Hash,
+func (db *DB) PutResolverReport(tx kvdb.RwTx, chainHash chainhash.Hash,
 	channelOutpoint *wire.OutPoint, report *ResolverReport) error {
 
 	putReportFunc := func(tx kvdb.RwTx) error {
@@ -130,7 +130,7 @@ func (d *DB) PutResolverReport(tx kvdb.RwTx, chainHash chainhash.Hash,
 
 	// If the transaction is nil, we'll create a new one.
 	if tx == nil {
-		return kvdb.Update(d, putReportFunc, func() {})
+		return kvdb.Update(db, putReportFunc, func() {})
 	}
 
 	// Otherwise, we can write the report to disk using the existing
@@ -209,12 +209,12 @@ func serializeReport(w io.Writer, report *ResolverReport) error {
 }
 
 // FetchChannelReports fetches the set of reports for a channel.
-func (d DB) FetchChannelReports(chainHash chainhash.Hash,
+func (db DB) FetchChannelReports(chainHash chainhash.Hash,
 	outPoint *wire.OutPoint) ([]*ResolverReport, error) {
 
 	var reports []*ResolverReport
 
-	if err := kvdb.View(d, func(tx kvdb.RTx) error {
+	if err := kvdb.View(db, func(tx kvdb.RTx) error {
 		chanBucket, err := fetchReportReadBucket(
 			tx, chainHash, outPoint,
 		)

--- a/channeldb/witness_cache.go
+++ b/channeldb/witness_cache.go
@@ -64,9 +64,9 @@ type WitnessCache struct {
 }
 
 // NewWitnessCache returns a new instance of the witness cache.
-func (d *DB) NewWitnessCache() *WitnessCache {
+func (db *DB) NewWitnessCache() *WitnessCache {
 	return &WitnessCache{
-		db: d,
+		db: db,
 	}
 }
 


### PR DESCRIPTION
`channeldb` methods currently use inconsistent receivers (`d` more than `db` see: xplorfin/lnd#17)) Since they're both used all over the place, I just made the receivers consistent as db.

Super minor - I just noticed this while looking at itest

#### Pull Request Checklist

- [x] If this is your first time contributing, we recommend you read the [Code
  Contribution Guidelines](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md)
- [x] All changes are Go version 1.12 compliant
- [x] The code being submitted is commented according to [Code Documentation and Commenting](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#CodeDocumentation)
- [x] For new code: Code is accompanied by tests which exercise both
  the positive and negative (error paths) conditions (if applicable)
- [x] For bug fixes: Code is accompanied by new tests which trigger
  the bug being fixed to prevent regressions
- [x] Any new logging statements use an appropriate subsystem and
  logging level
- [x] Code has been formatted with `go fmt`
- [x] Protobuf files (`lnrpc/**/*.proto`) have been formatted with
  `make rpc-format` and compiled with `make rpc`
- [x] New configuration flags have been added to `sample-lnd.conf`
- [x] For code and documentation: lines are wrapped at 80 characters
  (the tab character should be counted as 8 characters, not 4, as some IDEs do
  per default)
- [x] Running `make check` does not fail any tests
- [x] Running `go vet` does not report any issues
- [x] Running `make lint` does not report any **new** issues that did not
  already exist
- [x] All commits build properly and pass tests. Only in exceptional
  cases it can be justifiable to violate this condition. In that case, the
  reason should be stated in the commit message.
- [x] Commits have a logical structure according to [Ideal Git Commit Structure](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#IdealGitCommitStructure)
