### PR TITLE
contractcourt: cancel invoices that timeout on chain

### DIFF
--- a/contractcourt/chain_arbitrator.go
+++ b/contractcourt/chain_arbitrator.go
@@ -339,6 +339,7 @@ func newActiveChannelArbitrator(channel *channeldb.OpenChannel,
 		IsPendingClose:        false,
 		ChainArbitratorConfig: c.cfg,
 		ChainEvents:           chanEvents,
+		CancelInvoice:         c.cfg.Registry.CancelInvoice,
 		PutResolverReport: func(tx kvdb.RwTx,
 			report *channeldb.ResolverReport) error {
 
@@ -544,6 +545,7 @@ func (c *ChainArbitrator) Start() error {
 			IsPendingClose:        true,
 			ClosingHeight:         closeChanInfo.CloseHeight,
 			CloseType:             closeChanInfo.CloseType,
+			CancelInvoice:         c.cfg.Registry.CancelInvoice,
 			PutResolverReport: func(tx kvdb.RwTx,
 				report *channeldb.ResolverReport) error {
 

--- a/contractcourt/chain_arbitrator_test.go
+++ b/contractcourt/chain_arbitrator_test.go
@@ -88,6 +88,7 @@ func TestChainArbitratorRepublishCloses(t *testing.T) {
 			EpochChan: make(chan *chainntnfs.BlockEpoch),
 			ConfChan:  make(chan *chainntnfs.TxConfirmation),
 		},
+		Registry: &mockRegistry{},
 		PublishTx: func(tx *wire.MsgTx, _ string) error {
 			published[tx.TxHash()]++
 			return nil
@@ -178,7 +179,8 @@ func TestResolveContract(t *testing.T) {
 	// chain arbitrator that should pick up these new channels and launch
 	// resolver for them.
 	chainArbCfg := ChainArbitratorConfig{
-		ChainIO: &mock.ChainIO{},
+		Registry: &mockRegistry{},
+		ChainIO:  &mock.ChainIO{},
 		Notifier: &mock.ChainNotifier{
 			SpendChan: make(chan *chainntnfs.SpendDetail),
 			EpochChan: make(chan *chainntnfs.BlockEpoch),

--- a/contractcourt/channel_arbitrator.go
+++ b/contractcourt/channel_arbitrator.go
@@ -149,6 +149,10 @@ type ChannelArbitratorConfig struct {
 	// TODO(roasbeef): need RPC's to combine for pendingchannels RPC
 	MarkChannelResolved func() error
 
+	// CancelInvoice can be used to update the invoice registry to cancel
+	// invoices which are not settled.
+	CancelInvoice func(lntypes.Hash) error
+
 	// PutResolverReport records a resolver report for the channel. If the
 	// transaction provided is nil, the function should write the report
 	// in a new transaction.

--- a/contractcourt/interfaces.go
+++ b/contractcourt/interfaces.go
@@ -20,6 +20,9 @@ type Registry interface {
 	// byte payment hash.
 	LookupInvoice(lntypes.Hash) (channeldb.Invoice, error)
 
+	// CancelInvoice attempts to cancel an invoice with the hash provided.
+	CancelInvoice(lntypes.Hash) error
+
 	// NotifyExitHopHtlc attempts to mark an invoice as settled. If the
 	// invoice is a debug invoice, then this method is a noop as debug
 	// invoices are never fully settled. The return value describes how the

--- a/contractcourt/mock_registry_test.go
+++ b/contractcourt/mock_registry_test.go
@@ -1,10 +1,13 @@
 package contractcourt
 
 import (
+	"testing"
+
 	"github.com/lightningnetwork/lnd/channeldb"
 	"github.com/lightningnetwork/lnd/invoices"
 	"github.com/lightningnetwork/lnd/lntypes"
 	"github.com/lightningnetwork/lnd/lnwire"
+	"github.com/stretchr/testify/require"
 )
 
 type notifyExitHopData struct {
@@ -19,6 +22,9 @@ type mockRegistry struct {
 	notifyChan       chan notifyExitHopData
 	notifyErr        error
 	notifyResolution invoices.HtlcResolution
+
+	cancelChan chan lntypes.Hash
+	cancelErr  error
 }
 
 func (r *mockRegistry) NotifyExitHopHtlc(payHash lntypes.Hash,
@@ -43,4 +49,22 @@ func (r *mockRegistry) LookupInvoice(lntypes.Hash) (channeldb.Invoice,
 	error) {
 
 	return channeldb.Invoice{}, channeldb.ErrInvoiceNotFound
+}
+
+// Cancel invoice mocks canceling an invoice with the registry, sending the
+// hash into our cancel channel and returning the error that we configured the
+// mock with.
+func (r *mockRegistry) CancelInvoice(hash lntypes.Hash) error {
+	r.cancelChan <- hash
+
+	return r.cancelErr
+}
+
+// assertCancelInvoice asserts that we have canceled an invoice with the hash
+// provided with our mock registry.
+func (r *mockRegistry) assertCancelInvoice(t *testing.T,
+	expected lntypes.Hash) {
+
+	t.Helper()
+	require.Equal(t, expected, <-r.cancelChan)
 }

--- a/lntest/itest/lnd_multi-hop_remote_force_close_on_chain_htlc_timeout_test.go
+++ b/lntest/itest/lnd_multi-hop_remote_force_close_on_chain_htlc_timeout_test.go
@@ -5,9 +5,11 @@ import (
 	"fmt"
 
 	"github.com/btcsuite/btcutil"
+	"github.com/lightningnetwork/lnd/lnrpc/invoicesrpc"
 	"github.com/lightningnetwork/lnd/lnrpc/routerrpc"
 	"github.com/lightningnetwork/lnd/lntest"
 	"github.com/lightningnetwork/lnd/lntest/wait"
+	"github.com/lightningnetwork/lnd/lntypes"
 	"github.com/stretchr/testify/require"
 )
 
@@ -43,14 +45,21 @@ func testMultiHopRemoteForceCloseOnChainHtlcTimeout(net *lntest.NetworkHarness,
 	defer cancel()
 
 	// We'll now send a single HTLC across our multi-hop network.
-	carolPubKey := carol.PubKey[:]
-	payHash := makeFakePayHash(t)
-	_, err := alice.RouterClient.SendPaymentV2(
+	preimage := lntypes.Preimage{1, 2, 3}
+	payHash := preimage.Hash()
+	invoiceReq := &invoicesrpc.AddHoldInvoiceRequest{
+		Value:      int64(htlcAmt),
+		CltvExpiry: 40,
+		Hash:       payHash[:],
+	}
+
+	ctxt, _ := context.WithTimeout(ctxb, defaultTimeout)
+	carolInvoice, err := carol.AddHoldInvoice(ctxt, invoiceReq)
+	require.NoError(t.t, err)
+
+	_, err = alice.RouterClient.SendPaymentV2(
 		ctx, &routerrpc.SendPaymentRequest{
-			Dest:           carolPubKey,
-			Amt:            int64(htlcAmt),
-			PaymentHash:    payHash,
-			FinalCltvDelta: finalCltvDelta,
+			PaymentRequest: carolInvoice.PaymentRequest,
 			TimeoutSeconds: 60,
 			FeeLimitMsat:   noFeeLimitMsat,
 		},
@@ -61,7 +70,7 @@ func testMultiHopRemoteForceCloseOnChainHtlcTimeout(net *lntest.NetworkHarness,
 	// show that the HTLC has been locked in.
 	nodes := []*lntest.HarnessNode{alice, bob, carol}
 	err = wait.NoError(func() error {
-		return assertActiveHtlcs(nodes, payHash)
+		return assertActiveHtlcs(nodes, payHash[:])
 	}, defaultTimeout)
 	require.NoError(t.t, err)
 
@@ -73,7 +82,7 @@ func testMultiHopRemoteForceCloseOnChainHtlcTimeout(net *lntest.NetworkHarness,
 	// transaction. This will let us exercise that Bob is able to sweep the
 	// expired HTLC on Carol's version of the commitment transaction. If
 	// Carol has an anchor, it will be swept too.
-	ctxt, _ := context.WithTimeout(ctxb, channelCloseTimeout)
+	ctxt, _ = context.WithTimeout(ctxb, channelCloseTimeout)
 	closeChannelAndAssertType(
 		ctxt, t, net, carol, bobChanPoint, c == commitTypeAnchors,
 		true,
@@ -81,7 +90,7 @@ func testMultiHopRemoteForceCloseOnChainHtlcTimeout(net *lntest.NetworkHarness,
 
 	// At this point, Bob should have a pending force close channel as
 	// Carol has gone directly to chain.
-	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
+	ctxt, _ = context.WithTimeout(ctxb, channelCloseTimeout)
 	err = waitForNumChannelPendingForceClose(ctxt, bob, 1, nil)
 	require.NoError(t.t, err)
 
@@ -171,7 +180,7 @@ func testMultiHopRemoteForceCloseOnChainHtlcTimeout(net *lntest.NetworkHarness,
 	// We'll close out the test by closing the channel from Alice to Bob,
 	// and then shutting down the new node we created as its no longer
 	// needed. Coop close, no anchors.
-	ctxt, _ = context.WithTimeout(ctxb, channelCloseTimeout)
+	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
 	closeChannelAndAssertType(
 		ctxt, t, net, alice, aliceChanPoint, false, false,
 	)

--- a/lntest/itest/lnd_multi-hop_remote_force_close_on_chain_htlc_timeout_test.go
+++ b/lntest/itest/lnd_multi-hop_remote_force_close_on_chain_htlc_timeout_test.go
@@ -183,7 +183,7 @@ func testMultiHopRemoteForceCloseOnChainHtlcTimeout(net *lntest.NetworkHarness,
 	_, err = carol.SettleInvoice(ctxb, &invoicesrpc.SettleInvoiceMsg{
 		Preimage: preimage[:],
 	})
-	require.NoError(t.t, err, "expected erroneous invoice settle")
+	require.Error(t.t, err, "expected settle to fail")
 
 	// Assert that the htlcs for our invoice are erroneously still in the
 	// accepted state and our invoice is settled.
@@ -192,10 +192,10 @@ func testMultiHopRemoteForceCloseOnChainHtlcTimeout(net *lntest.NetworkHarness,
 	})
 	require.NoError(t.t, err)
 
-	require.True(t.t, inv.Settled, "expected erroneously settled invoice")
+	require.False(t.t, inv.Settled, "unexpected settle state")
 	for _, htlc := range inv.Htlcs {
-		require.Equal(t.t, lnrpc.InvoiceHTLCState_SETTLED, htlc.State,
-			"expected htlcs to be erroneously settled")
+		require.Equal(t.t, lnrpc.InvoiceHTLCState_CANCELED, htlc.State,
+			"expected canceled htlcs")
 	}
 
 	// We'll close out the test by closing the channel from Alice to Bob,


### PR DESCRIPTION
This PR adds logic to contractcourt to cancel invoices when their htlcs timeout on chain. Previously, we would simply resolve the htlc without checking whether it was for one of our invoices, so we would not update invoices state accordingly. It only takes this action for invoices (not forwards), so that there are no unexpected interactions between forwards/invoices with the same hash.

This change fixes #4987 by cancelling the invoice (and its htlcs) once we reach our timeout on chain, and #4587 because the cancelled invoice can't be settled after timeout.

Our existing itest is modified to assert that this bug occurs, then updated with the fix. Since travis doesn't run on each commit, I've opened PRs on my own fork to demonstrate that the incremental changes to the itest pass: 
- Refactoring in [a78acd6](https://github.com/carlaKC/lnd/pull/9) 
- Reproduce in [3b374da ](https://github.com/carlaKC/lnd/pull/8)
(have been running into docker rate limiting issues with these, will address)