### PR TITLE
Use `routing.assumechanvalid=true` by default in Neutrino mode

### DIFF
--- a/lncfg/neutrino.go
+++ b/lncfg/neutrino.go
@@ -14,4 +14,5 @@ type Neutrino struct {
 	AssertFilterHeader string        `long:"assertfilterheader" description:"Optional filter header in height:hash format to assert the state of neutrino's filter header chain on startup. If the assertion does not hold, then the filter header chain will be re-synced from the genesis block."`
 	UserAgentName      string        `long:"useragentname" description:"Used to help identify ourselves to other bitcoin peers"`
 	UserAgentVersion   string        `long:"useragentversion" description:"Used to help identify ourselves to other bitcoin peers"`
+	ValidateChannels   bool          `long:"validatechannels" description:"Validate every channel in the graph during sync by downloading the containing block. This is the inverse of routing.assumechanvalid, meaning that for Neutrino the validation is turned off by default for massively increased graph sync performance. This speedup comes at the risk of using an unvalidated view of the network for routing. Overwrites the value of routing.assumechanvalid if Neutrino is used. (default: false)"`
 }

--- a/lncfg/routing.go
+++ b/lncfg/routing.go
@@ -2,5 +2,5 @@ package lncfg
 
 // Routing holds the configuration options for routing.
 type Routing struct {
-	AssumeChannelValid bool `long:"assumechanvalid" description:"Skip checking channel spentness during graph validation. This speedup comes at the risk of using an unvalidated view of the network for routing. (default: false)"`
+	AssumeChannelValid bool `long:"assumechanvalid" description:"DEPRECATED: This is now turned on by default for Neutrino (use neutrino.validatechannels=true to turn off) and shouldn't be used for any other backend! (default: false)"`
 }

--- a/lnd.go
+++ b/lnd.go
@@ -1569,6 +1569,17 @@ func initializeDatabases(ctx context.Context,
 func initNeutrinoBackend(cfg *Config, chainDir string) (*neutrino.ChainService,
 	func(), error) {
 
+	// Both channel validation flags are false by default but their meaning
+	// is the inverse of each other. Therefore both cannot be true. For
+	// every other case, the neutrino.validatechannels overwrites the
+	// routing.assumechanvalid value.
+	if cfg.NeutrinoMode.ValidateChannels && cfg.Routing.AssumeChannelValid {
+		return nil, nil, fmt.Errorf("can't set both " +
+			"neutrino.validatechannels and routing." +
+			"assumechanvalid to true at the same time")
+	}
+	cfg.Routing.AssumeChannelValid = !cfg.NeutrinoMode.ValidateChannels
+
 	// First we'll open the database file for neutrino, creating the
 	// database if needed. We append the normalized network name here to
 	// match the behavior of btcwallet.

--- a/sample-lnd.conf
+++ b/sample-lnd.conf
@@ -468,13 +468,9 @@ bitcoin.node=btcd
 ; Neutrino is used. (default: false)
 ; neutrino.validatechannels=false
 
-; Skip checking channel spentness and existence during graph validation for
-; neutrino. Enabling this option means that neutrino nodes will not need to
-; perform long rescans which block initial usage of the daemon, but comes at
-; the cost of not validating channels in your routing graph. Skipping this
-; validation means that your node may have an incorrect view of the network
-; if it receives updates for closed or non-existent channels. This could affect
-; routing, but funds are safu.
+; DEPRECATED: This is now turned on by default for Neutrino (use 
+; neutrino.validatechannels=true to turn off) and shouldn't be used for any
+; other backend!
 ; --routing.assumechanvalid=true
 
 [Btcd]

--- a/sample-lnd.conf
+++ b/sample-lnd.conf
@@ -460,6 +460,14 @@ bitcoin.node=btcd
 ; Used to help identify ourselves to other bitcoin peers (default: 0.11.0-beta).
 ; neutrino.useragentversion=0.11.0-beta
 
+; Validate every channel in the graph during sync by downloading the containing
+; block. This is the inverse of routing.assumechanvalid, meaning that for
+; Neutrino the validation is turned off by default for massively increased graph
+; sync performance. This speedup comes at the risk of using an unvalidated view
+; of the network for routing. Overwrites the value of routing.assumechanvalid if
+; Neutrino is used. (default: false)
+; neutrino.validatechannels=false
+
 ; Skip checking channel spentness and existence during graph validation for
 ; neutrino. Enabling this option means that neutrino nodes will not need to
 ; perform long rescans which block initial usage of the daemon, but comes at


### PR DESCRIPTION
Fixes https://github.com/lightningnetwork/lnd/issues/5149.

Downloading every block that contains a channel point takes a very long
time when syncing the graph on mainnet with Neutrino. Therefore it makes
sense to use routing.assumechanvalid=true since by using Neutrino a user
already accepts the different trust model.
Apparently the existence or meaning of the routing.assumechanvalid flag
is unknown to a lot of users and is overlooked.
This PR basically sets the default to routing.assumechanvalid=true
for Neutrino. Because the CLI library doesn't support setting a bool
value to false by the user if the default is true, we need to add an
additional flag that is the inverse of the routing one, just for the
case where a Neutrino user explicitly wants to turn on channel
validation.

I'm not sure if we really want to make this decision for the user. If we don't want to use this default, then another option would be to add an alias of `routing.assumechanvalid` as `neutrino.assumechanvalid` to make it more visible for users looking at the Neutrino options.