### PR TITLE
build+lncfg: support pruned bitcoind backends

### DIFF
--- a/chainntnfs/test_utils.go
+++ b/chainntnfs/test_utils.go
@@ -233,10 +233,19 @@ func NewBitcoindBackend(t *testing.T, minerAddr string,
 	time.Sleep(time.Second)
 
 	host := fmt.Sprintf("127.0.0.1:%d", rpcPort)
-	conn, err := chain.NewBitcoindConn(
-		NetParams, host, "weks", "weks", zmqBlockHost, zmqTxHost,
-		100*time.Millisecond,
-	)
+	conn, err := chain.NewBitcoindConn(&chain.BitcoindConfig{
+		ChainParams:     NetParams,
+		Host:            host,
+		User:            "weks",
+		Pass:            "weks",
+		ZMQBlockHost:    zmqBlockHost,
+		ZMQTxHost:       zmqTxHost,
+		ZMQReadDeadline: 5 * time.Second,
+		// Fields only required for pruned nodes, not needed for these
+		// tests.
+		Dialer:             nil,
+		PrunedModeMaxPeers: 0,
+	})
 	if err != nil {
 		bitcoind.Process.Kill()
 		bitcoind.Wait()

--- a/chainreg/chainregistry.go
+++ b/chainreg/chainregistry.go
@@ -397,6 +397,7 @@ func NewChainControl(cfg *Config) (*ChainControl, error) {
 			ZMQTxHost:          bitcoindMode.ZMQPubRawTx,
 			ZMQReadDeadline:    5 * time.Second,
 			Dialer:             cfg.Dialer,
+			PrunedModeMaxPeers: bitcoindMode.PrunedNodeMaxPeers,
 		})
 		if err != nil {
 			return nil, err

--- a/config.go
+++ b/config.go
@@ -183,6 +183,8 @@ var (
 	defaultBitcoindEstimateMode = "CONSERVATIVE"
 	bitcoindEstimateModes       = [2]string{"ECONOMICAL", defaultBitcoindEstimateMode}
 
+	defaultPrunedNodeMaxPeers = 4
+
 	defaultSphinxDbName = "sphinxreplay.db"
 )
 
@@ -392,9 +394,10 @@ func DefaultConfig() Config {
 			RPCCert: defaultBtcdRPCCertFile,
 		},
 		BitcoindMode: &lncfg.Bitcoind{
-			Dir:          defaultBitcoindDir,
-			RPCHost:      defaultRPCHost,
-			EstimateMode: defaultBitcoindEstimateMode,
+			Dir:                defaultBitcoindDir,
+			RPCHost:            defaultRPCHost,
+			EstimateMode:       defaultBitcoindEstimateMode,
+			PrunedNodeMaxPeers: defaultPrunedNodeMaxPeers,
 		},
 		Litecoin: &lncfg.Chain{
 			MinHTLCIn:     chainreg.DefaultLitecoinMinHTLCInMSat,
@@ -411,9 +414,10 @@ func DefaultConfig() Config {
 			RPCCert: defaultLtcdRPCCertFile,
 		},
 		LitecoindMode: &lncfg.Bitcoind{
-			Dir:          defaultLitecoindDir,
-			RPCHost:      defaultRPCHost,
-			EstimateMode: defaultBitcoindEstimateMode,
+			Dir:                defaultLitecoindDir,
+			RPCHost:            defaultRPCHost,
+			EstimateMode:       defaultBitcoindEstimateMode,
+			PrunedNodeMaxPeers: defaultPrunedNodeMaxPeers,
 		},
 		NeutrinoMode: &lncfg.Neutrino{
 			UserAgentName:    neutrino.UserAgentName,

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/btcsuite/btclog v0.0.0-20170628155309-84c8d2346e9f
 	github.com/btcsuite/btcutil v1.0.3-0.20201208143702-a53e38424cce
 	github.com/btcsuite/btcutil/psbt v1.0.3-0.20201208143702-a53e38424cce
-	github.com/btcsuite/btcwallet v0.11.1-0.20210329233242-e0607006dce6
+	github.com/btcsuite/btcwallet v0.11.1-0.20210405201449-683061f79797
 	github.com/btcsuite/btcwallet/wallet/txauthor v1.0.1-0.20210329233242-e0607006dce6
 	github.com/btcsuite/btcwallet/wallet/txrules v1.0.0
 	github.com/btcsuite/btcwallet/wallet/txsizes v1.0.1-0.20210329233242-e0607006dce6 // indirect

--- a/go.sum
+++ b/go.sum
@@ -25,8 +25,8 @@ github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+Ce
 github.com/btcsuite/btcd v0.0.0-20190629003639-c26ffa870fd8/go.mod h1:3J08xEfcugPacsc34/LKRU2yO7YmuT8yt28J8k2+rrI=
 github.com/btcsuite/btcd v0.0.0-20190824003749-130ea5bddde3/go.mod h1:3J08xEfcugPacsc34/LKRU2yO7YmuT8yt28J8k2+rrI=
 github.com/btcsuite/btcd v0.20.1-beta/go.mod h1:wVuoA8VJLEcwgqHBwHmzLRazpKxTv13Px/pDuV7OomQ=
-github.com/btcsuite/btcd v0.20.1-beta.0.20200513120220-b470eee47728/go.mod h1:wVuoA8VJLEcwgqHBwHmzLRazpKxTv13Px/pDuV7OomQ=
 github.com/btcsuite/btcd v0.21.0-beta.0.20201208033208-6bd4c64a54fa/go.mod h1:Sv4JPQ3/M+teHz9Bo5jBpkNcP0x6r7rdihlNL/7tTAs=
+github.com/btcsuite/btcd v0.21.0-beta.0.20210316172410-f86ae60936d7/go.mod h1:Sv4JPQ3/M+teHz9Bo5jBpkNcP0x6r7rdihlNL/7tTAs=
 github.com/btcsuite/btcd v0.21.0-beta.0.20210401013323-36a96f6a0025 h1:aoVqvZk4mLyF3WZbqEVPq+vXnwL2wekZg4P4mjYJNLs=
 github.com/btcsuite/btcd v0.21.0-beta.0.20210401013323-36a96f6a0025/go.mod h1:9n5ntfhhHQBIhUvlhDvD3Qg6fRUj4jkN0VB8L8svzOA=
 github.com/btcsuite/btclog v0.0.0-20170628155309-84c8d2346e9f h1:bAs4lUbRJpnnkd9VhRV3jjAVU7DJVjMaK+IsvSeZvFo=
@@ -37,8 +37,8 @@ github.com/btcsuite/btcutil v1.0.3-0.20201208143702-a53e38424cce h1:YtWJF7RHm2pY
 github.com/btcsuite/btcutil v1.0.3-0.20201208143702-a53e38424cce/go.mod h1:0DVlHczLPewLcPGEIeUEzfOJhqGPQ0mJJRDBtD307+o=
 github.com/btcsuite/btcutil/psbt v1.0.3-0.20201208143702-a53e38424cce h1:3PRwz+js0AMMV1fHRrCdQ55akoomx4Q3ulozHC3BDDY=
 github.com/btcsuite/btcutil/psbt v1.0.3-0.20201208143702-a53e38424cce/go.mod h1:LVveMu4VaNSkIRTZu2+ut0HDBRuYjqGocxDMNS1KuGQ=
-github.com/btcsuite/btcwallet v0.11.1-0.20210329233242-e0607006dce6 h1:5Y6ui667YQrFCxPYV4Pmf9jpEsIkcJxMKsXJzNsMU9o=
-github.com/btcsuite/btcwallet v0.11.1-0.20210329233242-e0607006dce6/go.mod h1:JBUz2SCnYLn2Dw9bcnqZYvKchnKVvWSLv8OUzihHTcc=
+github.com/btcsuite/btcwallet v0.11.1-0.20210405201449-683061f79797 h1:FqPzyVNKoqE+qV57Cn8zpTfUy/G698M9b6dNprGj0cY=
+github.com/btcsuite/btcwallet v0.11.1-0.20210405201449-683061f79797/go.mod h1:CevOfPKvF6kHr+JXhWD3TtqLbsJrD1CzrtDqZ+5G6ss=
 github.com/btcsuite/btcwallet/wallet/txauthor v1.0.0/go.mod h1:VufDts7bd/zs3GV13f/lXc/0lXrPnvxD/NvmpG/FEKU=
 github.com/btcsuite/btcwallet/wallet/txauthor v1.0.1-0.20210329233242-e0607006dce6 h1:mO7NxcfgLe75paLDHx+LWNG5BskiDQigHnSVT2KvNZA=
 github.com/btcsuite/btcwallet/wallet/txauthor v1.0.1-0.20210329233242-e0607006dce6/go.mod h1:VufDts7bd/zs3GV13f/lXc/0lXrPnvxD/NvmpG/FEKU=

--- a/lncfg/bitcoind.go
+++ b/lncfg/bitcoind.go
@@ -3,11 +3,12 @@ package lncfg
 // Bitcoind holds the configuration options for the daemon's connection to
 // bitcoind.
 type Bitcoind struct {
-	Dir            string `long:"dir" description:"The base directory that contains the node's data, logs, configuration file, etc."`
-	RPCHost        string `long:"rpchost" description:"The daemon's rpc listening address. If a port is omitted, then the default port for the selected chain parameters will be used."`
-	RPCUser        string `long:"rpcuser" description:"Username for RPC connections"`
-	RPCPass        string `long:"rpcpass" default-mask:"-" description:"Password for RPC connections"`
-	ZMQPubRawBlock string `long:"zmqpubrawblock" description:"The address listening for ZMQ connections to deliver raw block notifications"`
-	ZMQPubRawTx    string `long:"zmqpubrawtx" description:"The address listening for ZMQ connections to deliver raw transaction notifications"`
-	EstimateMode   string `long:"estimatemode" description:"The fee estimate mode. Must be either ECONOMICAL or CONSERVATIVE."`
+	Dir                string `long:"dir" description:"The base directory that contains the node's data, logs, configuration file, etc."`
+	RPCHost            string `long:"rpchost" description:"The daemon's rpc listening address. If a port is omitted, then the default port for the selected chain parameters will be used."`
+	RPCUser            string `long:"rpcuser" description:"Username for RPC connections"`
+	RPCPass            string `long:"rpcpass" default-mask:"-" description:"Password for RPC connections"`
+	ZMQPubRawBlock     string `long:"zmqpubrawblock" description:"The address listening for ZMQ connections to deliver raw block notifications"`
+	ZMQPubRawTx        string `long:"zmqpubrawtx" description:"The address listening for ZMQ connections to deliver raw transaction notifications"`
+	EstimateMode       string `long:"estimatemode" description:"The fee estimate mode. Must be either ECONOMICAL or CONSERVATIVE."`
+	PrunedNodeMaxPeers int    `long:"pruned-node-max-peers" description:"The maximum number of peers lnd will choose from the backend node to retrieve pruned blocks from. This only applies to pruned nodes."`
 }

--- a/lnd.go
+++ b/lnd.go
@@ -543,6 +543,9 @@ func Main(cfg *Config, lisCfg ListenerCfg, interceptor signal.Interceptor) error
 		NeutrinoCS:                  neutrinoCS,
 		ActiveNetParams:             cfg.ActiveNetParams,
 		FeeURL:                      cfg.FeeURL,
+		Dialer: func(addr string) (net.Conn, error) {
+			return cfg.net.Dial("tcp", addr, cfg.ConnectionTimeout)
+		},
 	}
 
 	activeChainControl, err := chainreg.NewChainControl(chainControlCfg)

--- a/lnwallet/test/test_interface.go
+++ b/lnwallet/test/test_interface.go
@@ -3323,11 +3323,19 @@ func runTests(t *testing.T, walletDriver *lnwallet.WalletDriver,
 			host := fmt.Sprintf("127.0.0.1:%d", rpcPort)
 			var chainConn *chain.BitcoindConn
 			err = wait.NoError(func() error {
-				chainConn, err = chain.NewBitcoindConn(
-					netParams, host, "weks", "weks",
-					zmqBlockHost, zmqTxHost,
-					100*time.Millisecond,
-				)
+				chainConn, err = chain.NewBitcoindConn(&chain.BitcoindConfig{
+					ChainParams:     netParams,
+					Host:            host,
+					User:            "weks",
+					Pass:            "weks",
+					ZMQBlockHost:    zmqBlockHost,
+					ZMQTxHost:       zmqTxHost,
+					ZMQReadDeadline: 5 * time.Second,
+					// Fields only required for pruned nodes, not
+					// needed for these tests.
+					Dialer:             nil,
+					PrunedModeMaxPeers: 0,
+				})
 				if err != nil {
 					return err
 				}

--- a/routing/chainview/interface_test.go
+++ b/routing/chainview/interface_test.go
@@ -816,11 +816,19 @@ var interfaceImpls = []struct {
 			time.Sleep(time.Second)
 
 			host := fmt.Sprintf("127.0.0.1:%d", rpcPort)
-			chainConn, err := chain.NewBitcoindConn(
-				&chaincfg.RegressionNetParams, host, "weks",
-				"weks", zmqBlockHost, zmqTxHost,
-				100*time.Millisecond,
-			)
+			chainConn, err := chain.NewBitcoindConn(&chain.BitcoindConfig{
+				ChainParams:     &chaincfg.RegressionNetParams,
+				Host:            host,
+				User:            "weks",
+				Pass:            "weks",
+				ZMQBlockHost:    zmqBlockHost,
+				ZMQTxHost:       zmqTxHost,
+				ZMQReadDeadline: 5 * time.Second,
+				// Fields only required for pruned nodes, not
+				// needed for these tests.
+				Dialer:             nil,
+				PrunedModeMaxPeers: 0,
+			})
 			if err != nil {
 				return cleanUp2, nil, fmt.Errorf("unable to "+
 					"establish connection to bitcoind: %v",

--- a/sample-lnd.conf
+++ b/sample-lnd.conf
@@ -536,6 +536,10 @@ bitcoin.node=btcd
 ; If unset, the default value is "CONSERVATIVE".
 ; bitcoind.estimatemode=CONSERVATIVE
 
+; The maximum number of peers lnd will choose from the backend node to retrieve
+; pruned blocks from. This only applies to pruned nodes.
+; bitcoind.pruned-node-max-peers=4
+
 [neutrino]
 
 ; Connect only to the specified peers at startup. This creates a persistent
@@ -705,6 +709,10 @@ litecoin.node=ltcd
 ; Fee estimate mode for litecoind. It must be either "ECONOMICAL" or "CONSERVATIVE".
 ; If unset, the default value is "CONSERVATIVE".
 ; litecoind.estimatemode=CONSERVATIVE
+
+; The maximum number of peers lnd will choose from the backend node to retrieve
+; pruned blocks from. This only applies to pruned nodes.
+; litecoind.pruned-node-max-peers=4
 
 [autopilot]
 


### PR DESCRIPTION
To minimally support lnd deployments connected to pruned nodes, we've extended our bitcoind RPC client with the ability to request blocks that the server has already pruned. This is done by connecting to the server's full node peers and querying them directly. The number of peers we connect to can be set through the new `pruned-node-max-peers` config option; it is configured with a default of 4 at the moment. Ideally, this is a capability supported by the server, though this is not yet possible with bitcoind.

Block caching is not done yet, but will be expected to roll out along with this feature as a separate PR to minimize bandwidth consumption.

Note that a lot of the diff is unrelated due to a name change within the updated btcd dependency that caused changes across several files in the codebase.

Depends on https://github.com/btcsuite/btcwallet/pull/737.
Fixes https://github.com/lightningnetwork/lnd/issues/2997.