### PR TITLE
lnd: Adds addpeer flag

### DIFF
--- a/config.go
+++ b/config.go
@@ -293,6 +293,7 @@ type Config struct {
 	WSPingInterval    time.Duration `long:"ws-ping-interval" description:"The ping interval for REST based WebSocket connections, set to 0 to disable sending ping messages from the server side"`
 	WSPongWait        time.Duration `long:"ws-pong-wait" description:"The time we wait for a pong response message on REST based WebSocket connections before the connection is closed as inactive"`
 	NAT               bool          `long:"nat" description:"Toggle NAT traversal support (using either UPnP or NAT-PMP) to automatically advertise your external IP address to the network -- NOTE this does not support devices behind multiple NATs"`
+	AddPeers          []string      `long:"addpeer" description:"Specify peers to connect to first"`
 	MinBackoff        time.Duration `long:"minbackoff" description:"Shortest backoff when reconnecting to persistent peers. Valid time units are {s, m, h}."`
 	MaxBackoff        time.Duration `long:"maxbackoff" description:"Longest backoff when reconnecting to persistent peers. Valid time units are {s, m, h}."`
 	ConnectionTimeout time.Duration `long:"connectiontimeout" description:"The timeout value for network connections. Valid time units are {ms, s, m, h}."`

--- a/docs/release-notes/release-notes-0.15.0.md
+++ b/docs/release-notes/release-notes-0.15.0.md
@@ -181,6 +181,7 @@ then watch it on chain. Taproot script spends are also supported through the
 * [Fix a flaky unit test in the `chainview`
   package](https://github.com/lightningnetwork/lnd/pull/6354).
 
+* [Adds a new config option for adding a specific peer at startup](https://github.com/lightningnetwork/lnd/pull/5157).
 
 * [Add a new method in `tlv` to encode an uint64/uint32 field using `BigSize`
   format.](https://github.com/lightningnetwork/lnd/pull/6421)
@@ -276,6 +277,7 @@ gRPC performance metrics (latency to process `GetInfo`, etc)](https://github.com
 # Contributors (Alphabetical Order)
 
 * 3nprob
+* Alyssa Hertig
 * Andras Banki-Horvath
 * Andreas Schjønhaug
 * asvdf

--- a/lntest/itest/lnd_test_list_on_test.go
+++ b/lntest/itest/lnd_test_list_on_test.go
@@ -395,4 +395,8 @@ var allTestCases = []*testCase{
 		name: "taproot",
 		test: testTaproot,
 	},
+	{
+		name: "addpeer config",
+		test: testAddPeerConfig,
+	},
 }

--- a/sample-lnd.conf
+++ b/sample-lnd.conf
@@ -183,6 +183,9 @@
 ; Disable TLS for the REST API.
 ; no-rest-tls=true
 
+; Specify peer(s) to connect to first.
+; addpeer=
+
 ; The ping interval for REST based WebSocket connections, set to 0 to disable
 ; sending ping messages from the server side. Valid time units are {s, m, h}.
 ; ws-ping-interval=30s


### PR DESCRIPTION
Adds a new parameter to LND that makes a peer connection to a node on start up, similar to `--neutrino.addpeer`. The parameter takes an input of a node's connection string (`<pubkey>@<ip or onion>:<port>`) & when LND starts up it attempts make a peering connection to the node before any other connections. 