### PR TITLE
make: pass mobile subserver prefix to docker when generating mobile RPC

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -282,8 +282,8 @@ sample-conf-check:
 	for flag in $$(GO_FLAGS_COMPLETION=1 go run -tags="$(RELEASE_TAGS)" $(PKG)/cmd/lnd -- | grep -v help | cut -c3-); do if ! grep -q $$flag sample-lnd.conf; then echo "Command line flag --$$flag not added to sample-lnd.conf"; exit 1; fi; done
 
 mobile-rpc:
-	@$(call print, "Creating mobile RPC from protos.")
-	cd ./lnrpc; COMPILE_MOBILE=1 ./gen_protos_docker.sh
+	@$(call print, "Creating mobile RPC from protos (prefix=$(prefix)).")
+	cd ./lnrpc; COMPILE_MOBILE=1 SUBSERVER_PREFIX=$(prefix) ./gen_protos_docker.sh
 
 vendor:
 	@$(call print, "Re-creating vendor directory.")

--- a/lnrpc/gen_protos_docker.sh
+++ b/lnrpc/gen_protos_docker.sh
@@ -20,5 +20,6 @@ docker run \
   --user "$UID:$(id -g)" \
   -e UID=$UID \
   -e COMPILE_MOBILE \
+  -e SUBSERVER_PREFIX \
   -v "$DIR/../:/build" \
   lnd-protobuf-builder

--- a/mobile/gen_bindings.sh
+++ b/mobile/gen_bindings.sh
@@ -57,7 +57,7 @@ done
 # If prefix=1 is specified, prefix the generated methods with subserver name.
 # This must be enabled to support subservers with name conflicts.
 use_prefix="0"
-if [ "$prefix" = "1" ]
+if [ "$SUBSERVER_PREFIX" = "1" ]
 then
     echo "Prefixing methods with subserver name"
     use_prefix="1"


### PR DESCRIPTION
This PR fixes a regression after moving to generating the mobile RPCs in docker, as the `prefix` environment  variable wasn't threaded through.

cc @hsjoberg 

Fixes #5177