### PR TITLE
config: add commit time parameter

### DIFF
--- a/config.go
+++ b/config.go
@@ -145,6 +145,11 @@ const (
 	// defaultChannelCommitInterval is the default maximum time between receiving a
 	// channel state update and signing a new commitment.
 	defaultChannelCommitInterval = 50 * time.Millisecond
+
+	// defaultChannelCommitBatchSize is the default maximum number of
+	// channel state updates that is accumulated before signing a new
+	// commitment.
+	defaultChannelCommitBatchSize = 10
 )
 
 var (
@@ -293,7 +298,8 @@ type Config struct {
 	MaxChanSize                   int64         `long:"maxchansize" description:"The largest channel size (in satoshis) that we should accept. Incoming channels larger than this will be rejected"`
 	CoopCloseTargetConfs          uint32        `long:"coop-close-target-confs" description:"The target number of blocks that a cooperative channel close transaction should confirm in. This is used to estimate the fee to use as the lower bound during fee negotiation for the channel closure."`
 
-	ChannelCommitInterval time.Duration `long:"channel-commit-interval" description:"The maximum time that is allowed to pass between receiving a channel state update and signing the next commitment. Setting this to a longer duration allows for more efficient channel operations at the cost of latency."`
+	ChannelCommitInterval  time.Duration `long:"channel-commit-interval" description:"The maximum time that is allowed to pass between receiving a channel state update and signing the next commitment. Setting this to a longer duration allows for more efficient channel operations at the cost of latency."`
+	ChannelCommitBatchSize uint32        `long:"channel-commit-batch-size" description:"The maximum number of channel state updates that is accumulated before signing a new commitment."`
 
 	DefaultRemoteMaxHtlcs uint16 `long:"default-remote-max-htlcs" description:"The default max_htlc applied when opening or accepting channels. This value limits the number of concurrent HTLCs that the remote party can add to the commitment. The maximum possible value is 483."`
 
@@ -514,6 +520,7 @@ func DefaultConfig() Config {
 		registeredChains:        chainreg.NewChainRegistry(),
 		ActiveNetParams:         chainreg.BitcoinTestNetParams,
 		ChannelCommitInterval:   defaultChannelCommitInterval,
+		ChannelCommitBatchSize:  defaultChannelCommitBatchSize,
 	}
 }
 

--- a/config.go
+++ b/config.go
@@ -141,6 +141,10 @@ const (
 	// commitment output.
 	// TODO(halseth): find a more scientific choice of value.
 	defaultMaxLocalCSVDelay = 10000
+
+	// defaultChannelCommitInterval is the default maximum time between receiving a
+	// channel state update and signing a new commitment.
+	defaultChannelCommitInterval = 50 * time.Millisecond
 )
 
 var (
@@ -288,6 +292,8 @@ type Config struct {
 	MinChanSize                   int64         `long:"minchansize" description:"The smallest channel size (in satoshis) that we should accept. Incoming channels smaller than this will be rejected"`
 	MaxChanSize                   int64         `long:"maxchansize" description:"The largest channel size (in satoshis) that we should accept. Incoming channels larger than this will be rejected"`
 	CoopCloseTargetConfs          uint32        `long:"coop-close-target-confs" description:"The target number of blocks that a cooperative channel close transaction should confirm in. This is used to estimate the fee to use as the lower bound during fee negotiation for the channel closure."`
+
+	ChannelCommitInterval time.Duration `long:"channel-commit-interval" description:"The maximum time that is allowed to pass between receiving a channel state update and signing the next commitment. Setting this to a longer duration allows for more efficient channel operations at the cost of latency."`
 
 	DefaultRemoteMaxHtlcs uint16 `long:"default-remote-max-htlcs" description:"The default max_htlc applied when opening or accepting channels. This value limits the number of concurrent HTLCs that the remote party can add to the commitment. The maximum possible value is 483."`
 
@@ -507,6 +513,7 @@ func DefaultConfig() Config {
 		DB:                      lncfg.DefaultDB(),
 		registeredChains:        chainreg.NewChainRegistry(),
 		ActiveNetParams:         chainreg.BitcoinTestNetParams,
+		ChannelCommitInterval:   defaultChannelCommitInterval,
 	}
 }
 

--- a/peer/brontide.go
+++ b/peer/brontide.go
@@ -308,6 +308,12 @@ type Config struct {
 	// ChannelLink.
 	ServerPubKey [33]byte
 
+	// ChannelCommitInterval is the maximum time that is allowed to pass between
+	// receiving a channel state update and signing the next commitment.
+	// Setting this to a longer duration allows for more efficient channel
+	// operations at the cost of latency.
+	ChannelCommitInterval time.Duration
+
 	// Quit is the server's quit channel. If this is closed, we halt operation.
 	Quit chan struct{}
 }
@@ -813,7 +819,7 @@ func (p *Brontide) addLink(chanPoint *wire.OutPoint,
 		UpdateContractSignals:   updateContractSignals,
 		OnChannelFailure:        onChannelFailure,
 		SyncStates:              syncStates,
-		BatchTicker:             ticker.New(50 * time.Millisecond),
+		BatchTicker:             ticker.New(p.cfg.ChannelCommitInterval),
 		FwdPkgGCTicker:          ticker.New(time.Hour),
 		PendingCommitTicker:     ticker.New(time.Minute),
 		BatchSize:               10,

--- a/peer/brontide.go
+++ b/peer/brontide.go
@@ -314,6 +314,10 @@ type Config struct {
 	// operations at the cost of latency.
 	ChannelCommitInterval time.Duration
 
+	// ChannelCommitBatchSize is the maximum number of channel state updates
+	// that is accumulated before signing a new commitment.
+	ChannelCommitBatchSize uint32
+
 	// Quit is the server's quit channel. If this is closed, we halt operation.
 	Quit chan struct{}
 }
@@ -822,7 +826,7 @@ func (p *Brontide) addLink(chanPoint *wire.OutPoint,
 		BatchTicker:             ticker.New(p.cfg.ChannelCommitInterval),
 		FwdPkgGCTicker:          ticker.New(time.Hour),
 		PendingCommitTicker:     ticker.New(time.Minute),
-		BatchSize:               10,
+		BatchSize:               p.cfg.ChannelCommitBatchSize,
 		UnsafeReplay:            p.cfg.UnsafeReplay,
 		MinFeeUpdateTimeout:     htlcswitch.DefaultMinLinkFeeUpdateTimeout,
 		MaxFeeUpdateTimeout:     htlcswitch.DefaultMaxLinkFeeUpdateTimeout,

--- a/sample-lnd.conf
+++ b/sample-lnd.conf
@@ -264,6 +264,11 @@
 ; for the channel closure is not set.
 ; coop-close-target-confs=10
 
+; The maximum time that is allowed to pass between receiving a channel state
+; update and signing the next commitment. Setting this to a longer duration
+; allows for more efficient channel operations at the cost of latency.
+; channel-commit-interval=50ms
+
 ; The default max_htlc applied when opening or accepting channels. This value
 ; limits the number of concurrent HTLCs that the remote party can add to the
 ; commitment. The maximum possible value is 483.

--- a/sample-lnd.conf
+++ b/sample-lnd.conf
@@ -269,6 +269,10 @@
 ; allows for more efficient channel operations at the cost of latency.
 ; channel-commit-interval=50ms
 
+; The maximum number of channel state updates that is accumulated before signing
+; a new commitment.
+; channel-commit-batch-size=10
+
 ; The default max_htlc applied when opening or accepting channels. This value
 ; limits the number of concurrent HTLCs that the remote party can add to the
 ; commitment. The maximum possible value is 483.

--- a/server.go
+++ b/server.go
@@ -3137,8 +3137,9 @@ func (s *server) peerConnected(conn net.Conn, connReq *connmgr.ConnReq,
 		CoopCloseTargetConfs:    s.cfg.CoopCloseTargetConfs,
 		MaxAnchorsCommitFeeRate: chainfee.SatPerKVByte(
 			s.cfg.MaxCommitFeeRateAnchors * 1000).FeePerKWeight(),
-		ChannelCommitInterval: s.cfg.ChannelCommitInterval,
-		Quit:                  s.quit,
+		ChannelCommitInterval:  s.cfg.ChannelCommitInterval,
+		ChannelCommitBatchSize: s.cfg.ChannelCommitBatchSize,
+		Quit:                   s.quit,
 	}
 
 	copy(pCfg.PubKeyBytes[:], peerAddr.IdentityKey.SerializeCompressed())

--- a/server.go
+++ b/server.go
@@ -3137,7 +3137,8 @@ func (s *server) peerConnected(conn net.Conn, connReq *connmgr.ConnReq,
 		CoopCloseTargetConfs:    s.cfg.CoopCloseTargetConfs,
 		MaxAnchorsCommitFeeRate: chainfee.SatPerKVByte(
 			s.cfg.MaxCommitFeeRateAnchors * 1000).FeePerKWeight(),
-		Quit: s.quit,
+		ChannelCommitInterval: s.cfg.ChannelCommitInterval,
+		Quit:                  s.quit,
 	}
 
 	copy(pCfg.PubKeyBytes[:], peerAddr.IdentityKey.SerializeCompressed())


### PR DESCRIPTION
Channel state update batching is an important mechanism to increase the throughput of a Lightning node. With high degrees of batching many synchronous and expensive disk writes can be avoided. Batching comes at the cost of increased latency. For high-frequency (streaming) applications this may be an acceptable trade-off. 

This PR simply makes the batch timer configurable to allow node operators to tune their node to a particular traffic pattern.

As a follow-up it could be worth to consider a dynamic batch interval based on system load ("commit on idle").