### PR TITLE
discovery: always add chan announcements to the reject cache if err !…

### DIFF
--- a/discovery/gossiper.go
+++ b/discovery/gossiper.go
@@ -1741,6 +1741,10 @@ func (d *AuthenticatedGossiper) processNetworkAnnouncement(
 			} else {
 				log.Tracef("Router rejected channel "+
 					"edge: %v", err)
+
+				d.rejectMtx.Lock()
+				d.recentRejects[msg.ShortChannelID.ToUint64()] = struct{}{}
+				d.rejectMtx.Unlock()
 			}
 
 			nMsg.err <- err


### PR DESCRIPTION
…= ErrIgnored

In this commit, we make a change to always add chan announcements to the reject cache if we didn't reject them for already existing.  Without this change, if we end up rejecting a channel announcement say because the channel is already spent or the funding transaction doesn't exist, then we'll end up continually re-validating the same set of channels we know will fail, when they're sent to us by peers.

Fixes #5191 ?

This seems to have been an oversight in the original PR that added the cache: https://github.com/lightningnetwork/lnd/commit/bf05e4778046643d55739a755be175ed9e9402fe