### PR TITLE
mobile: add tlsdisableautofill to sample config

### DIFF
--- a/mobile/sample_lnd.conf
+++ b/mobile/sample_lnd.conf
@@ -3,6 +3,7 @@ debuglevel=info
 maxbackoff=2s
 nolisten=1
 norest=1
+tlsdisableautofill=1
 
 [Routing]
 routing.assumechanvalid=1


### PR DESCRIPTION
This PR addresses new restrictions in Android 11 which causes `net.InterfaceAddrs()` to return an error, which in turn causes lnd to crash. Adding `tlsdisableautofill=1` makes sure that the code-path concerned is [never executed](https://github.com/lightningnetwork/lnd/blob/213b264e4c0f92a23c7dd8a42e0b68e4958a7e3a/cert/selfsigned.go#L47-L52). In fact it doesn't even have to as the code to make in-mem gRPC to work is [here](https://github.com/lightningnetwork/lnd/blob/213b264e4c0f92a23c7dd8a42e0b68e4958a7e3a/cert/selfsigned.go#L108).

For more context see this issue: https://github.com/golang/go/issues/40569.

Cheers.