### PR TITLE
sweep,rpc: honor minConfs paramater when SendAll is set

### DIFF
--- a/rpcserver.go
+++ b/rpcserver.go
@@ -1194,6 +1194,7 @@ func (r *rpcServer) SendCoins(ctx context.Context,
 			uint32(bestHeight), nil, targetAddr, wallet,
 			wallet, wallet.WalletController,
 			r.server.cc.FeeEstimator, r.server.cc.Signer,
+			minConfs,
 		)
 		if err != nil {
 			return nil, err
@@ -1246,6 +1247,7 @@ func (r *rpcServer) SendCoins(ctx context.Context,
 				uint32(bestHeight), outputs, targetAddr, wallet,
 				wallet, wallet.WalletController,
 				r.server.cc.FeeEstimator, r.server.cc.Signer,
+				minConfs,
 			)
 			if err != nil {
 				return nil, err

--- a/sweep/walletsweep.go
+++ b/sweep/walletsweep.go
@@ -169,7 +169,7 @@ func CraftSweepAllTx(feeRate chainfee.SatPerKWeight, dustLimit btcutil.Amount,
 	blockHeight uint32, deliveryAddrs []DeliveryAddr, changeAddr btcutil.Address,
 	coinSelectLocker CoinSelectionLocker, utxoSource UtxoSource,
 	outpointLocker OutpointLocker, feeEstimator chainfee.Estimator,
-	signer input.Signer) (*WalletSweepPackage, error) {
+	signer input.Signer, minConfs int32) (*WalletSweepPackage, error) {
 
 	// TODO(roasbeef): turn off ATPL as well when available?
 
@@ -194,7 +194,7 @@ func CraftSweepAllTx(feeRate chainfee.SatPerKWeight, dustLimit btcutil.Amount,
 		// operations are going on, we can grab a clean snapshot of the
 		// current UTXO state of the wallet.
 		utxos, err := utxoSource.ListUnspentWitnessFromDefaultAccount(
-			1, math.MaxInt32,
+			minConfs, math.MaxInt32,
 		)
 		if err != nil {
 			return err

--- a/sweep/walletsweep_test.go
+++ b/sweep/walletsweep_test.go
@@ -289,7 +289,7 @@ func TestCraftSweepAllTxCoinSelectFail(t *testing.T) {
 
 	_, err := CraftSweepAllTx(
 		0, 100, 10, nil, nil, coinSelectLocker, utxoSource,
-		utxoLocker, nil, nil,
+		utxoLocker, nil, nil, 0,
 	)
 
 	// Since we instructed the coin select locker to fail above, we should
@@ -315,7 +315,7 @@ func TestCraftSweepAllTxUnknownWitnessType(t *testing.T) {
 
 	_, err := CraftSweepAllTx(
 		0, 100, 10, nil, nil, coinSelectLocker, utxoSource,
-		utxoLocker, nil, nil,
+		utxoLocker, nil, nil, 0,
 	)
 
 	// Since passed in a p2wsh output, which is unknown, we should fail to
@@ -350,7 +350,7 @@ func TestCraftSweepAllTx(t *testing.T) {
 
 	sweepPkg, err := CraftSweepAllTx(
 		0, 100, 10, nil, deliveryAddr, coinSelectLocker, utxoSource,
-		utxoLocker, feeEstimator, signer,
+		utxoLocker, feeEstimator, signer, 0,
 	)
 	if err != nil {
 		t.Fatalf("unable to make sweep tx: %v", err)


### PR DESCRIPTION
`SendCoins` ignored the parameter when `SendAll` was set. We now propagate `minConfs` down to `sweeper.CraftSweepAllTx`. 