### PR TITLE
invoices: add height based expiry watcher

### DIFF
--- a/htlcswitch/mock.go
+++ b/htlcswitch/mock.go
@@ -797,6 +797,20 @@ type mockInvoiceRegistry struct {
 	cleanup func()
 }
 
+type mockChainNotifier struct {
+	chainntnfs.ChainNotifier
+}
+
+// RegisterBlockEpochNtfn mocks a successful call to register block
+// notifications.
+func (m *mockChainNotifier) RegisterBlockEpochNtfn(*chainntnfs.BlockEpoch) (
+	*chainntnfs.BlockEpochEvent, error) {
+
+	return &chainntnfs.BlockEpochEvent{
+		Cancel: func() {},
+	}, nil
+}
+
 func newMockRegistry(minDelta uint32) *mockInvoiceRegistry {
 	cdb, cleanup, err := newDB()
 	if err != nil {
@@ -805,7 +819,10 @@ func newMockRegistry(minDelta uint32) *mockInvoiceRegistry {
 
 	registry := invoices.NewRegistry(
 		cdb,
-		invoices.NewInvoiceExpiryWatcher(clock.NewDefaultClock()),
+		invoices.NewInvoiceExpiryWatcher(
+			clock.NewDefaultClock(), 0, 0, nil,
+			&mockChainNotifier{},
+		),
 		&invoices.RegistryConfig{
 			FinalCltvRejectDelta: 5,
 		},

--- a/invoices/invoice_expiry_watcher_test.go
+++ b/invoices/invoice_expiry_watcher_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/lightningnetwork/lnd/chainntnfs"
+	"github.com/lightningnetwork/lnd/channeldb"
 	"github.com/lightningnetwork/lnd/clock"
 	"github.com/lightningnetwork/lnd/lntypes"
 )
@@ -202,4 +203,116 @@ func TestInvoiceExpiryWhenAddingMultipleInvoices(t *testing.T) {
 	test.waitForFinish(testTimeout)
 	test.watcher.Stop()
 	test.checkExpectations()
+}
+
+// TestExpiredHodlInv tests expiration of an already-expired hodl invoice
+// which has no htlcs.
+func TestExpiredHodlInv(t *testing.T) {
+	t.Parallel()
+
+	creationDate := testTime.Add(time.Hour * -24)
+	expiry := time.Hour
+
+	test := setupHodlExpiry(
+		t, creationDate, expiry, 0, channeldb.ContractOpen, nil,
+	)
+
+	test.assertCanceled(t, test.hash)
+	test.watcher.Stop()
+}
+
+// TestAcceptedHodlNotExpired tests that hodl invoices which are in an accepted
+// state are not expired once their time-based expiry elapses, using a regular
+// invoice that expires at the same time as a control to ensure that invoices
+// with that timestamp would otherwise be expired.
+func TestAcceptedHodlNotExpired(t *testing.T) {
+	t.Parallel()
+
+	creationDate := testTime
+	expiry := time.Hour
+
+	test := setupHodlExpiry(
+		t, creationDate, expiry, 0, channeldb.ContractAccepted, nil,
+	)
+	defer test.watcher.Stop()
+
+	// Add another invoice that will expire at our expiry time as a control
+	// value.
+	tsExpires := &invoiceExpiryTs{
+		PaymentHash: lntypes.Hash{1, 2, 3},
+		Expiry:      creationDate.Add(expiry),
+		Keysend:     true,
+	}
+	test.watcher.AddInvoices(tsExpires)
+
+	test.mockClock.SetTime(creationDate.Add(expiry + 1))
+
+	// Assert that only the ts expiry invoice is expired.
+	test.assertCanceled(t, tsExpires.PaymentHash)
+}
+
+// TestHeightAlreadyExpired tests the case where we add an invoice with htlcs
+// that have already expired to the expiry watcher.
+func TestHeightAlreadyExpired(t *testing.T) {
+	t.Parallel()
+
+	expiredHtlc := []*channeldb.InvoiceHTLC{
+		{
+			State:  channeldb.HtlcStateAccepted,
+			Expiry: uint32(testCurrentHeight),
+		},
+	}
+
+	test := setupHodlExpiry(
+		t, testTime, time.Hour, 0, channeldb.ContractAccepted,
+		expiredHtlc,
+	)
+	defer test.watcher.Stop()
+
+	test.assertCanceled(t, test.hash)
+}
+
+// TestExpiryHeightArrives tests the case where we add a hodl invoice to the
+// expiry watcher when it has no htlcs, htlcs are added and then they finally
+// expire. We use a non-zero delta for this test to check that we expire with
+// sufficient buffer.
+func TestExpiryHeightArrives(t *testing.T) {
+	var (
+		creationDate        = testTime
+		expiry              = time.Hour * 2
+		delta        uint32 = 1
+	)
+
+	// Start out with a hodl invoice that is open, and has no htlcs.
+	test := setupHodlExpiry(
+		t, creationDate, expiry, delta, channeldb.ContractOpen, nil,
+	)
+	defer test.watcher.Stop()
+
+	htlc1 := uint32(testCurrentHeight + 10)
+	expiry1 := makeHeightExpiry(test.hash, htlc1)
+
+	// Add htlcs to our invoice and progress its state to accepted.
+	test.watcher.AddInvoices(expiry1)
+	test.setState(channeldb.ContractAccepted)
+
+	// Progress time so that our expiry has elapsed. We no longer expect
+	// this invoice to be canceled because it has been accepted.
+	test.mockClock.SetTime(creationDate.Add(expiry))
+
+	// Tick our mock block subscription with the next block, we don't
+	// expect anything to happen.
+	currentHeight := uint32(testCurrentHeight + 1)
+	test.announceBlock(t, currentHeight)
+
+	// Now, we add another htlc to the invoice. This one has a lower expiry
+	// height than our current ones.
+	htlc2 := currentHeight + 5
+	expiry2 := makeHeightExpiry(test.hash, htlc2)
+	test.watcher.AddInvoices(expiry2)
+
+	// Announce our lowest htlc expiry block minus our delta, the invoice
+	// should be expired now.
+	test.announceBlock(t, htlc2-delta)
+	test.assertCanceled(t, test.hash)
 }

--- a/invoices/invoiceregistry.go
+++ b/invoices/invoiceregistry.go
@@ -1101,6 +1101,16 @@ func (i *InvoiceRegistry) notifyExitHopHtlcLocked(
 
 		}
 
+		// If we have fully accepted the set of htlcs for this invoice,
+		// we can now add it to our invoice expiry watcher. We do not
+		// add invoices before they are fully accepted, because it is
+		// possible that we MppTimeout the htlcs, and then our relevant
+		// expiry height could change.
+		if res.outcome == resultAccepted {
+			expiry := makeInvoiceExpiry(ctx.hash, invoice)
+			i.expiryWatcher.AddInvoices(expiry)
+		}
+
 		i.hodlSubscribe(hodlChan, ctx.circuitKey)
 
 	default:

--- a/invoices/invoiceregistry_test.go
+++ b/invoices/invoiceregistry_test.go
@@ -352,7 +352,11 @@ func TestSettleHoldInvoice(t *testing.T) {
 		FinalCltvRejectDelta: testFinalCltvRejectDelta,
 		Clock:                clock.NewTestClock(testTime),
 	}
-	registry := NewRegistry(cdb, NewInvoiceExpiryWatcher(cfg.Clock), &cfg)
+
+	expiryWatcher := NewInvoiceExpiryWatcher(
+		cfg.Clock, 0, uint32(testCurrentHeight), nil, newMockNotifier(),
+	)
+	registry := NewRegistry(cdb, expiryWatcher, &cfg)
 
 	err = registry.Start()
 	if err != nil {
@@ -521,7 +525,10 @@ func TestCancelHoldInvoice(t *testing.T) {
 		FinalCltvRejectDelta: testFinalCltvRejectDelta,
 		Clock:                clock.NewTestClock(testTime),
 	}
-	registry := NewRegistry(cdb, NewInvoiceExpiryWatcher(cfg.Clock), &cfg)
+	expiryWatcher := NewInvoiceExpiryWatcher(
+		cfg.Clock, 0, uint32(testCurrentHeight), nil, newMockNotifier(),
+	)
+	registry := NewRegistry(cdb, expiryWatcher, &cfg)
 
 	err = registry.Start()
 	if err != nil {
@@ -946,7 +953,9 @@ func TestInvoiceExpiryWithRegistry(t *testing.T) {
 		Clock:                testClock,
 	}
 
-	expiryWatcher := NewInvoiceExpiryWatcher(cfg.Clock)
+	expiryWatcher := NewInvoiceExpiryWatcher(
+		cfg.Clock, 0, uint32(testCurrentHeight), nil, newMockNotifier(),
+	)
 	registry := NewRegistry(cdb, expiryWatcher, &cfg)
 
 	// First prefill the Channel DB with some pre-existing invoices,
@@ -1049,7 +1058,9 @@ func TestOldInvoiceRemovalOnStart(t *testing.T) {
 		GcCanceledInvoicesOnStartup: true,
 	}
 
-	expiryWatcher := NewInvoiceExpiryWatcher(cfg.Clock)
+	expiryWatcher := NewInvoiceExpiryWatcher(
+		cfg.Clock, 0, uint32(testCurrentHeight), nil, newMockNotifier(),
+	)
 	registry := NewRegistry(cdb, expiryWatcher, &cfg)
 
 	// First prefill the Channel DB with some pre-existing expired invoices.

--- a/invoices/invoiceregistry_test.go
+++ b/invoices/invoiceregistry_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/lightningnetwork/lnd/amp"
+	"github.com/lightningnetwork/lnd/chainntnfs"
 	"github.com/lightningnetwork/lnd/channeldb"
 	"github.com/lightningnetwork/lnd/clock"
 	"github.com/lightningnetwork/lnd/lntypes"
@@ -1116,6 +1117,222 @@ func TestOldInvoiceRemovalOnStart(t *testing.T) {
 	// Check that we really only kept the settled invoices after the
 	// registry start.
 	require.Equal(t, expected, response.Invoices)
+}
+
+// TestHeightExpiryWithRegistry tests our height-based invoice expiry for
+// invoices paid with single and multiple htlcs, testing the case where the
+// invoice is settled before expiry (and thus not canceled), and the case
+// where the invoice is expired.
+func TestHeightExpiryWithRegistry(t *testing.T) {
+	t.Run("single shot settled before expiry", func(t *testing.T) {
+		testHeightExpiryWithRegistry(t, 1, true)
+	})
+
+	t.Run("single shot expires", func(t *testing.T) {
+		testHeightExpiryWithRegistry(t, 1, false)
+	})
+
+	t.Run("mpp settled before expiry", func(t *testing.T) {
+		testHeightExpiryWithRegistry(t, 2, true)
+	})
+
+	t.Run("mpp expires", func(t *testing.T) {
+		testHeightExpiryWithRegistry(t, 2, false)
+	})
+}
+
+func testHeightExpiryWithRegistry(t *testing.T, numParts int, settle bool) {
+	t.Parallel()
+	defer timeout()()
+
+	ctx := newTestContext(t)
+	defer ctx.cleanup()
+
+	require.Greater(t, numParts, 0, "test requires at least one part")
+
+	// Add a hold invoice, we set a non-nil payment request so that this
+	// invoice is not considered a keysend by the expiry watcher.
+	invoice := *testInvoice
+	invoice.HodlInvoice = true
+	invoice.PaymentRequest = []byte{1, 2, 3}
+
+	_, err := ctx.registry.AddInvoice(&invoice, testInvoicePaymentHash)
+	require.NoError(t, err)
+
+	payLoad := testPayload
+	if numParts > 1 {
+		payLoad = &mockPayload{
+			mpp: record.NewMPP(testInvoiceAmt, [32]byte{}),
+		}
+	}
+
+	htlcAmt := invoice.Terms.Value / lnwire.MilliSatoshi(numParts)
+	hodlChan := make(chan interface{}, numParts)
+	for i := 0; i < numParts; i++ {
+		// We bump our expiry height for each htlc so that we can test
+		// that the lowest expiry height is used.
+		expiry := testHtlcExpiry + uint32(i)
+
+		resolution, err := ctx.registry.NotifyExitHopHtlc(
+			testInvoicePaymentHash, htlcAmt, expiry,
+			testCurrentHeight, getCircuitKey(uint64(i)), hodlChan,
+			payLoad,
+		)
+		require.NoError(t, err)
+		require.Nil(t, resolution, "did not expect direct resolution")
+	}
+
+	require.Eventually(t, func() bool {
+		inv, err := ctx.registry.LookupInvoice(testInvoicePaymentHash)
+		require.NoError(t, err)
+
+		return inv.State == channeldb.ContractAccepted
+	}, time.Second, time.Millisecond*100)
+
+	// Now that we've added our htlc(s), we tick our test clock to our
+	// invoice expiry time. We don't expect the invoice to be canceled
+	// based on its expiry time now that we have active htlcs.
+	ctx.clock.SetTime(invoice.CreationDate.Add(invoice.Terms.Expiry + 1))
+
+	// The expiry watcher loop takes some time to process the new clock
+	// time. We mine the block before our expiry height, our mock will block
+	// until the expiry watcher consumes this height, so we can be sure
+	// that the expiry loop has run at least once after this block is
+	// consumed.
+	ctx.notifier.blockChan <- &chainntnfs.BlockEpoch{
+		Height: int32(testHtlcExpiry - 1),
+	}
+
+	// If we want to settle our invoice in this test, we do so now.
+	if settle {
+		err = ctx.registry.SettleHodlInvoice(testInvoicePreimage)
+		require.NoError(t, err)
+
+		for i := 0; i < numParts; i++ {
+			htlcResolution := (<-hodlChan).(HtlcResolution)
+			require.NotNil(t, htlcResolution)
+			settleResolution := checkSettleResolution(
+				t, htlcResolution, testInvoicePreimage,
+			)
+			require.Equal(t, ResultSettled, settleResolution.Outcome)
+		}
+	}
+
+	// Now we mine our htlc's expiry height.
+	ctx.notifier.blockChan <- &chainntnfs.BlockEpoch{
+		Height: int32(testHtlcExpiry),
+	}
+
+	// If we did not settle the invoice before its expiry, we now expect
+	// a cancelation.
+	expectedState := channeldb.ContractSettled
+	if !settle {
+		expectedState = channeldb.ContractCanceled
+
+		htlcResolution := (<-hodlChan).(HtlcResolution)
+		require.NotNil(t, htlcResolution)
+		checkFailResolution(
+			t, htlcResolution, ResultCanceled,
+		)
+	}
+
+	// Finally, lookup the invoice and assert that we have the state we
+	// expect.
+	inv, err := ctx.registry.LookupInvoice(testInvoicePaymentHash)
+	require.NoError(t, err)
+	require.Equal(t, expectedState, inv.State, "expected "+
+		"hold invoice: %v, got: %v", expectedState, inv.State)
+}
+
+// TestMultipleSetHeightExpiry pays a hold invoice with two mpp sets, testing
+// that the invoice expiry watcher only uses the expiry height of the second,
+// successful set to cancel the invoice, and does not cancel early using the
+// expiry height of the first set that was canceled back due to mpp timeout.
+func TestMultipleSetHeightExpiry(t *testing.T) {
+	t.Parallel()
+	defer timeout()()
+
+	ctx := newTestContext(t)
+	defer ctx.cleanup()
+
+	// Add a hold invoice.
+	invoice := *testInvoice
+	invoice.HodlInvoice = true
+
+	_, err := ctx.registry.AddInvoice(&invoice, testInvoicePaymentHash)
+	require.NoError(t, err)
+
+	mppPayload := &mockPayload{
+		mpp: record.NewMPP(testInvoiceAmt, [32]byte{}),
+	}
+
+	// Send htlc 1.
+	hodlChan1 := make(chan interface{}, 1)
+	resolution, err := ctx.registry.NotifyExitHopHtlc(
+		testInvoicePaymentHash, invoice.Terms.Value/2,
+		testHtlcExpiry,
+		testCurrentHeight, getCircuitKey(10), hodlChan1, mppPayload,
+	)
+	require.NoError(t, err)
+	require.Nil(t, resolution, "did not expect direct resolution")
+
+	// Simulate mpp timeout releasing htlc 1.
+	ctx.clock.SetTime(testTime.Add(30 * time.Second))
+
+	htlcResolution := (<-hodlChan1).(HtlcResolution)
+	failResolution, ok := htlcResolution.(*HtlcFailResolution)
+	require.True(t, ok, "expected fail resolution, got: %T", resolution)
+	require.Equal(t, ResultMppTimeout, failResolution.Outcome,
+		"expected MPP Timeout, got: %v", failResolution.Outcome)
+
+	// Notify the expiry height for our first htlc. We don't expect the
+	// invoice to be expired based on block height because the htlc set
+	// was never completed.
+	ctx.notifier.blockChan <- &chainntnfs.BlockEpoch{
+		Height: int32(testHtlcExpiry),
+	}
+
+	// Now we will send a full set of htlcs for the invoice with a higher
+	// expiry height. We expect the invoice to move into the accepted state.
+	expiry := testHtlcExpiry + 5
+
+	// Send htlc 2.
+	hodlChan2 := make(chan interface{}, 1)
+	resolution, err = ctx.registry.NotifyExitHopHtlc(
+		testInvoicePaymentHash, invoice.Terms.Value/2, expiry,
+		testCurrentHeight, getCircuitKey(11), hodlChan2, mppPayload,
+	)
+	require.NoError(t, err)
+	require.Nil(t, resolution, "did not expect direct resolution")
+
+	// Send htlc 3.
+	hodlChan3 := make(chan interface{}, 1)
+	resolution, err = ctx.registry.NotifyExitHopHtlc(
+		testInvoicePaymentHash, invoice.Terms.Value/2, expiry,
+		testCurrentHeight, getCircuitKey(12), hodlChan3, mppPayload,
+	)
+	require.NoError(t, err)
+	require.Nil(t, resolution, "did not expect direct resolution")
+
+	// Assert that we've reached an accepted state because the invoice has
+	// been paid with a complete set.
+	inv, err := ctx.registry.LookupInvoice(testInvoicePaymentHash)
+	require.NoError(t, err)
+	require.Equal(t, channeldb.ContractAccepted, inv.State, "expected "+
+		"hold invoice accepted")
+
+	// Now we will notify the expiry height for the new set of htlcs. We
+	// expect the invoice to be canceled by the expiry watcher.
+	ctx.notifier.blockChan <- &chainntnfs.BlockEpoch{
+		Height: int32(expiry),
+	}
+
+	require.Eventuallyf(t, func() bool {
+		inv, err := ctx.registry.LookupInvoice(testInvoicePaymentHash)
+		require.NoError(t, err)
+
+		return inv.State == channeldb.ContractCanceled
+	}, testTimeout, time.Millisecond*100, "invoice not canceled")
 }
 
 // TestSettleInvoicePaymentAddrRequired tests that if an incoming payment has

--- a/invoices/test_utils_test.go
+++ b/invoices/test_utils_test.go
@@ -181,6 +181,7 @@ func newTestChannelDB(clock clock.Clock) (*channeldb.DB, func(), error) {
 type testContext struct {
 	cdb      *channeldb.DB
 	registry *InvoiceRegistry
+	notifier *mockChainNotifier
 	clock    *clock.TestClock
 
 	cleanup func()
@@ -195,8 +196,10 @@ func newTestContext(t *testing.T) *testContext {
 		t.Fatal(err)
 	}
 
+	notifier := newMockNotifier()
+
 	expiryWatcher := NewInvoiceExpiryWatcher(
-		clock, 0, uint32(testCurrentHeight), nil, newMockNotifier(),
+		clock, 0, uint32(testCurrentHeight), nil, notifier,
 	)
 
 	// Instantiate and start the invoice ctx.registry.
@@ -216,6 +219,7 @@ func newTestContext(t *testing.T) *testContext {
 	ctx := testContext{
 		cdb:      cdb,
 		registry: registry,
+		notifier: notifier,
 		clock:    clock,
 		t:        t,
 		cleanup: func() {

--- a/invoices/test_utils_test.go
+++ b/invoices/test_utils_test.go
@@ -8,11 +8,13 @@ import (
 	"io/ioutil"
 	"os"
 	"runtime/pprof"
+	"sync"
 	"testing"
 	"time"
 
 	"github.com/btcsuite/btcd/btcec"
 	"github.com/btcsuite/btcd/chaincfg"
+	"github.com/lightningnetwork/lnd/chainntnfs"
 	"github.com/lightningnetwork/lnd/channeldb"
 	"github.com/lightningnetwork/lnd/clock"
 	"github.com/lightningnetwork/lnd/lntypes"
@@ -366,4 +368,112 @@ func checkFailResolution(t *testing.T, res HtlcResolution,
 	require.Equal(t, expOutcome, failResolution.Outcome)
 
 	return failResolution
+}
+
+type hodlExpiryTest struct {
+	hash         lntypes.Hash
+	state        channeldb.ContractState
+	stateLock    sync.Mutex
+	mockNotifier *mockChainNotifier
+	mockClock    *clock.TestClock
+	cancelChan   chan lntypes.Hash
+	watcher      *InvoiceExpiryWatcher
+}
+
+func (h *hodlExpiryTest) setState(state channeldb.ContractState) {
+	h.stateLock.Lock()
+	defer h.stateLock.Unlock()
+
+	h.state = state
+}
+
+func (h *hodlExpiryTest) announceBlock(t *testing.T, height uint32) {
+	select {
+	case h.mockNotifier.blockChan <- &chainntnfs.BlockEpoch{
+		Height: int32(height),
+	}:
+
+	case <-time.After(testTimeout):
+		t.Fatalf("block %v not consumed", height)
+	}
+}
+
+func (h *hodlExpiryTest) assertCanceled(t *testing.T, expected lntypes.Hash) {
+	select {
+	case actual := <-h.cancelChan:
+		require.Equal(t, expected, actual)
+
+	case <-time.After(testTimeout):
+		t.Fatalf("invoice: %v not canceled", h.hash)
+	}
+}
+
+// setupHodlExpiry creates a hodl invoice in our expiry watcher and runs an
+// arbitrary update function which advances the invoices's state.
+func setupHodlExpiry(t *testing.T, creationDate time.Time,
+	expiry time.Duration, heightDelta uint32,
+	startState channeldb.ContractState,
+	startHtlcs []*channeldb.InvoiceHTLC) *hodlExpiryTest {
+
+	mockNotifier := newMockNotifier()
+	mockClock := clock.NewTestClock(testTime)
+
+	test := &hodlExpiryTest{
+		state: startState,
+		watcher: NewInvoiceExpiryWatcher(
+			mockClock, heightDelta, uint32(testCurrentHeight), nil,
+			mockNotifier,
+		),
+		cancelChan:   make(chan lntypes.Hash),
+		mockNotifier: mockNotifier,
+		mockClock:    mockClock,
+	}
+
+	// Use an unbuffered channel to block on cancel calls so that the test
+	// does not exit before we've processed all the invoices we expect.
+	cancelImpl := func(paymentHash lntypes.Hash, force bool) error {
+		test.stateLock.Lock()
+		currentState := test.state
+		test.stateLock.Unlock()
+
+		if currentState != channeldb.ContractOpen && !force {
+			return nil
+		}
+
+		select {
+		case test.cancelChan <- paymentHash:
+		case <-time.After(testTimeout):
+		}
+
+		return nil
+	}
+
+	require.NoError(t, test.watcher.Start(cancelImpl))
+
+	// We set preimage and hash so that we can use our existing test
+	// helpers. In practice we would only have the hash, but this does not
+	// affect what we're testing at all.
+	preimage := lntypes.Preimage{1}
+	test.hash = preimage.Hash()
+
+	invoice := newTestInvoice(t, preimage, creationDate, expiry)
+	invoice.State = startState
+	invoice.HodlInvoice = true
+	invoice.Htlcs = make(map[channeldb.CircuitKey]*channeldb.InvoiceHTLC)
+
+	// If we have any htlcs, add them with unique circult keys.
+	for i, htlc := range startHtlcs {
+		key := channeldb.CircuitKey{
+			HtlcID: uint64(i),
+		}
+
+		invoice.Htlcs[key] = htlc
+	}
+
+	// Create an expiry entry for our invoice in its starting state. This
+	// mimics adding invoices to the watcher on start.
+	entry := makeInvoiceExpiry(test.hash, invoice)
+	test.watcher.AddInvoices(entry)
+
+	return test
 }

--- a/invoices/test_utils_test.go
+++ b/invoices/test_utils_test.go
@@ -193,7 +193,9 @@ func newTestContext(t *testing.T) *testContext {
 		t.Fatal(err)
 	}
 
-	expiryWatcher := NewInvoiceExpiryWatcher(clock)
+	expiryWatcher := NewInvoiceExpiryWatcher(
+		clock, 0, uint32(testCurrentHeight), nil, newMockNotifier(),
+	)
 
 	// Instantiate and start the invoice ctx.registry.
 	cfg := RegistryConfig{

--- a/lncfg/invoices.go
+++ b/lncfg/invoices.go
@@ -1,0 +1,12 @@
+package lncfg
+
+// DefaultHoldInvoiceExpiryDelta defines the number of blocks before the expiry
+// height of a hold invoice's htlc that lnd will automatically cancel the
+// invoice to prevent the channel from force closing. This value *must* be
+// greater than DefaultIncomingBroadcastDelta to prevent force closes.
+const DefaultHoldInvoiceExpiryDelta = DefaultIncomingBroadcastDelta + 2
+
+// Invoices holds the configuration options for invoices.
+type Invoices struct {
+	HoldExpiryDelta uint32 `long:"holdexpirydelta" description:"The number of blocks before a hold invoice's htlc expires that the invoice should be canceled to prevent a force close. Force closes will not be prevented if this value is not greater than DefaultIncomingBroadcastDelta."`
+}

--- a/lntest/itest/log_error_whitelist.txt
+++ b/lntest/itest/log_error_whitelist.txt
@@ -279,3 +279,5 @@
 <time> [ERR] RPCS: [/lnrpc.State/SubscribeState]: context canceled
 <time> [ERR] NTFN: Failed to update rescan progress: database not open
 <time> [ERR] HSWC: ChannelLink(<chan>): failing link: process hodl queue: unable to update commitment: link shutting down with error: internal error
+<time> [ERR] INVC: SettleHodlInvoice with preimage <hex>: invoice already canceled
+<time> [ERR] RPCS: [/invoicesrpc.Invoices/SettleInvoice]: invoice already canceled

--- a/sample-lnd.conf
+++ b/sample-lnd.conf
@@ -1120,3 +1120,23 @@ litecoin.node=ltcd
 ; will accept over the channel update interval.
 ; gossip.max-channel-update-burst=10
 ; gossip.channel-update-interval=1m
+
+[invoices]
+; If a hold invoice has accepted htlcs that reach their expiry height and are 
+; not timed out, the channel holding the htlc is force closed to resolve the
+; invoice's htlcs. To prevent force closes, lnd automatically cancels these 
+; invoices before they reach their expiry height.
+;
+; Hold expiry delta describes the number of blocks before expiry that these 
+; invoices should be canceled. Setting this value to 0 will ensure that hold
+; invoices can be settled right up until their expiry height, but will result
+; in the channel they are on being force closed if they are not resolved before
+; expiry.
+; 
+; Lnd goes to chain before the expiry for a htlc is reached so that there is 
+; time to resolve it on chain. This value needs to be greater than the 
+; DefaultIncomingBroadcastDelta set by lnd, otherwise the channel will be force
+; closed anyway. A warning will be logged on startup if this value is not large
+; enough to prevent force closes.
+;
+; invoices.holdexpirydelta=15


### PR DESCRIPTION
This PR adds a height-based expiry watcher for hodl invoices which will cancel these invoices back before they expire. This prevents lnd from force-closing when an invoice is not released by its creator. Resolving these htlcs properly addresses two state machine issues we run into when a hodl invoice expires: 
- Fixes #4587 : clients can still settle hodl invoices which have expired (and can't be claimed)
- Fixes #4987: when a hodl invoice with active htlcs expires and goes to chain, its htlcs remain in accepted state

An alternative approach was explored in #5136, however there are multiple race issues that arise when the invoice registry does not drive changes in invoice state, so instead an expiry watcher which keeps control in the invoice registry was chosen. 