### PR TITLE
makefile: bump goacc commit

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ BTCD_COMMIT := $(shell cat go.mod | \
 		awk -F "/" '{ print $$1 }')
 
 LINT_COMMIT := v1.18.0
-GOACC_COMMIT := ddc355013f90fea78d83d3a6c71f1d37ac07ecd5
+GOACC_COMMIT :=80342ae2e0fcf265e99e76bcc4efd022c7c3811b 
 GOFUZZ_COMMIT := 21309f307f61
 
 DEPGET := cd /tmp && GO111MODULE=on go get -v


### PR DESCRIPTION
`DEPGET` is failing for `go-acc` because it can't get the `ory/x` dep (tag deleted somewhere?). This dependency has been [removed](https://github.com/ory/go-acc/pull/17) from `go-acc`, although the issue on the repo that it fixes is not the same. 

```
go: github.com/ory/x@v0.0.216 requires
        github.com/ory/cli@v0.0.49 requires
        github.com/ory/kratos@v0.5.5-alpha.1.0.20210319103511-3726ed4d145a requires
        github.com/ory/kratos/corp@v0.0.0-00010101000000-000000000000: invalid version: unknown revision 000000000000
```

Bumping our `go-acc` commit to one which does not contain the problematic dep fixes `unit-cover`