### PR TITLE
channeldb/invoice: only allow pay-addr lookup w/ no query hash

### DIFF
--- a/channeldb/invoices.go
+++ b/channeldb/invoices.go
@@ -991,7 +991,14 @@ func fetchInvoiceNumByRef(invoiceIndex, payAddrIndex, setIDIndex kvdb.RBucket,
 		return invoiceNumByAddr, nil
 
 	// Return invoices by payment addr only.
-	case invoiceNumByAddr != nil:
+	//
+	// NOTE: We constrain this lookup to only apply if the invoice ref does
+	// not contain a payment hash. Legacy and MPP payments depend on the
+	// payment hash index to enforce that the HTLCs payment hash matches the
+	// payment hash for the invoice, without this check we would
+	// inadvertently assume the invoice contains the correct preimage for
+	// the HTLC, which we only enforce via the lookup by the invoice index.
+	case invoiceNumByAddr != nil && payHash == nil:
 		return invoiceNumByAddr, nil
 
 	// If we were only able to reference the invoice by hash, return the


### PR DESCRIPTION
This PR fixes a regression introduced in #5108.

Without this check, it's possible to send a probe HTLC w/ a valid
payment address but invalid payment hash that gets settled. Because
there was no assertion that the HTLC's payment hash matches the
invoice, the link would fail when it receives an invalid preimage for
the HTLC on its commitment.