### PR TITLE
wtclient: decrement pending tasks stats upon accepted task

### DIFF
--- a/lnrpc/wtclientrpc/wtclient.go
+++ b/lnrpc/wtclientrpc/wtclient.go
@@ -336,7 +336,7 @@ func (c *WatchtowerClient) Stats(ctx context.Context,
 
 		stats.NumTasksAccepted += stat.NumTasksAccepted
 		stats.NumTasksIneligible += stat.NumTasksIneligible
-		stats.NumTasksReceived += stat.NumTasksReceived
+		stats.NumTasksPending += stat.NumTasksPending
 		stats.NumSessionsAcquired += stat.NumSessionsAcquired
 		stats.NumSessionsExhausted += stat.NumSessionsExhausted
 	}
@@ -344,7 +344,7 @@ func (c *WatchtowerClient) Stats(ctx context.Context,
 	return &StatsResponse{
 		NumBackups:           uint32(stats.NumTasksAccepted),
 		NumFailedBackups:     uint32(stats.NumTasksIneligible),
-		NumPendingBackups:    uint32(stats.NumTasksReceived),
+		NumPendingBackups:    uint32(stats.NumTasksPending),
 		NumSessionsAcquired:  uint32(stats.NumSessionsAcquired),
 		NumSessionsExhausted: uint32(stats.NumSessionsExhausted),
 	}, nil

--- a/watchtower/wtclient/stats.go
+++ b/watchtower/wtclient/stats.go
@@ -10,9 +10,9 @@ import (
 type ClientStats struct {
 	mu sync.Mutex
 
-	// NumTasksReceived is the total number of backups that are pending to
+	// NumTasksPending is the total number of backups that are pending to
 	// be acknowledged by all active and exhausted watchtower sessions.
-	NumTasksReceived int
+	NumTasksPending int
 
 	// NumTasksAccepted is the total number of backups made to all active
 	// and exhausted watchtower sessions.
@@ -36,7 +36,7 @@ type ClientStats struct {
 func (s *ClientStats) taskReceived() {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	s.NumTasksReceived++
+	s.NumTasksPending++
 }
 
 // taskAccepted increments the number of tasks that have been assigned to active
@@ -45,6 +45,7 @@ func (s *ClientStats) taskAccepted() {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.NumTasksAccepted++
+	s.NumTasksPending--
 }
 
 // taskIneligible increments the number of tasks that were unable to satisfy the
@@ -78,7 +79,7 @@ func (s *ClientStats) String() string {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	return fmt.Sprintf("tasks(received=%d accepted=%d ineligible=%d) "+
-		"sessions(acquired=%d exhausted=%d)", s.NumTasksReceived,
+		"sessions(acquired=%d exhausted=%d)", s.NumTasksPending,
 		s.NumTasksAccepted, s.NumTasksIneligible, s.NumSessionsAcquired,
 		s.NumSessionsExhausted)
 }
@@ -88,7 +89,7 @@ func (s *ClientStats) Copy() ClientStats {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	return ClientStats{
-		NumTasksReceived:     s.NumTasksReceived,
+		NumTasksPending:      s.NumTasksPending,
 		NumTasksAccepted:     s.NumTasksAccepted,
 		NumTasksIneligible:   s.NumTasksIneligible,
 		NumSessionsAcquired:  s.NumSessionsAcquired,


### PR DESCRIPTION
We'd never decrement the number of pending backups upon a watchtower accepting one, making it confusing for users to determine whether their backups have actually been accepted. Along the way, we also rename NumTasksReceived to NumTasksPending to better reflect its purpose.

Fixes https://github.com/lightningnetwork/lnd/issues/5183.