### PR TITLE
mobile: Move lndStarted check to the top of the Start function

### DIFF
--- a/mobile/bindings.go
+++ b/mobile/bindings.go
@@ -31,6 +31,15 @@ var lndStarted int32
 // current app directory in order to ensure lnd has the permissions needed to
 // write to it.
 func Start(extraArgs string, rpcReady Callback) {
+	// We only support a single lnd instance at a time (singleton) for now,
+	// so we make sure to return immediately if it has already been
+	// started.
+	if !atomic.CompareAndSwapInt32(&lndStarted, 0, 1) {
+		err := errors.New("lnd already started")
+		rpcReady.OnError(err)
+		return
+	}
+
 	// (Re-)initialize the in-mem gRPC listeners we're going to give to lnd.
 	// This is required each time lnd is started, because when lnd shuts
 	// down, the in-mem listeners are closed.
@@ -58,6 +67,7 @@ func Start(extraArgs string, rpcReady Callback) {
 	// Hook interceptor for os signals.
 	shutdownInterceptor, err := signal.Intercept()
 	if err != nil {
+		atomic.StoreInt32(&lndStarted, 0)
 		_, _ = fmt.Fprintln(os.Stderr, err)
 		rpcReady.OnError(err)
 		return
@@ -67,6 +77,7 @@ func Start(extraArgs string, rpcReady Callback) {
 	// line options. This function will also set up logging properly.
 	loadedConfig, err := lnd.LoadConfig(shutdownInterceptor)
 	if err != nil {
+		atomic.StoreInt32(&lndStarted, 0)
 		_, _ = fmt.Fprintln(os.Stderr, err)
 		rpcReady.OnError(err)
 		return
@@ -86,15 +97,6 @@ func Start(extraArgs string, rpcReady Callback) {
 			Listener: lightningLis,
 			Ready:    rpcListening,
 		},
-	}
-
-	// We only support a single lnd instance at a time (singleton) for now,
-	// so we make sure to return immediately if it has already been
-	// started.
-	if !atomic.CompareAndSwapInt32(&lndStarted, 0, 1) {
-		err := errors.New("lnd already started")
-		rpcReady.OnError(err)
-		return
 	}
 
 	// Call the "real" main in a nested manner so the defers will properly


### PR DESCRIPTION
This PR moves the check if lnd has already been started to the top of the function. The reason for this is that the following code on line 59 before it would also return an error, making the lndStarted check superfluous:

```golang
shutdownInterceptor, err := signal.Intercept()
	if err != nil {
		_, _ = fmt.Fprintln(os.Stderr, err)
		rpcReady.OnError(err)
		return
}
```

Cheers!