### PR TITLE
routing: handle failure to launch shard after permanent failure

### DIFF
--- a/channeldb/payment_control.go
+++ b/channeldb/payment_control.go
@@ -290,16 +290,17 @@ func (p *PaymentControl) RegisterAttempt(paymentHash lntypes.Hash,
 			return err
 		}
 
-		// Ensure the payment is in-flight.
-		if err := ensureInFlight(p); err != nil {
-			return err
-		}
-
 		// We cannot register a new attempt if the payment already has
-		// reached a terminal condition:
+		// reached a terminal condition. We check this before
+		// ensureInFlight because it is a more general check.
 		settle, fail := p.TerminalInfo()
 		if settle != nil || fail != nil {
 			return ErrPaymentTerminal
+		}
+
+		// Ensure the payment is in-flight.
+		if err := ensureInFlight(p); err != nil {
+			return err
 		}
 
 		// Make sure any existing shards match the new one with regards

--- a/channeldb/payment_control_test.go
+++ b/channeldb/payment_control_test.go
@@ -1013,19 +1013,15 @@ func TestPaymentControlMultiShard(t *testing.T) {
 		// up in the Succeeded state. If both failed the payment should
 		// also be Failed at this poinnt.
 		finalStatus := StatusFailed
-		expRegErr := ErrPaymentAlreadyFailed
 		if test.settleFirst || test.settleLast {
 			finalStatus = StatusSucceeded
-			expRegErr = ErrPaymentAlreadySucceeded
 		}
 
 		assertPaymentStatus(t, pControl, info.PaymentHash, finalStatus)
 
 		// Finally assert we cannot register more attempts.
 		_, err = pControl.RegisterAttempt(info.PaymentHash, &b)
-		if err != expRegErr {
-			t.Fatalf("expected error %v, got: %v", expRegErr, err)
-		}
+		require.Equal(t, ErrPaymentTerminal, err)
 	}
 
 	for _, test := range tests {

--- a/routing/mock_test.go
+++ b/routing/mock_test.go
@@ -325,16 +325,16 @@ func (m *mockControlTower) RegisterAttempt(phash lntypes.Hash,
 	_, settled := m.successful[phash]
 	_, failed := m.failed[phash]
 
+	if settled || failed {
+		return channeldb.ErrPaymentTerminal
+	}
+
 	if settled && !inFlight {
 		return channeldb.ErrPaymentAlreadySucceeded
 	}
 
 	if failed && !inFlight {
 		return channeldb.ErrPaymentAlreadyFailed
-	}
-
-	if settled || failed {
-		return channeldb.ErrPaymentTerminal
 	}
 
 	// Add attempt to payment.

--- a/routing/mock_test.go
+++ b/routing/mock_test.go
@@ -248,12 +248,12 @@ func makeMockControlTower() *mockControlTower {
 func (m *mockControlTower) InitPayment(phash lntypes.Hash,
 	c *channeldb.PaymentCreationInfo) error {
 
-	m.Lock()
-	defer m.Unlock()
-
 	if m.init != nil {
 		m.init <- initArgs{c}
 	}
+
+	m.Lock()
+	defer m.Unlock()
 
 	// Don't allow re-init a successful payment.
 	if _, ok := m.successful[phash]; ok {
@@ -279,12 +279,12 @@ func (m *mockControlTower) InitPayment(phash lntypes.Hash,
 func (m *mockControlTower) RegisterAttempt(phash lntypes.Hash,
 	a *channeldb.HTLCAttemptInfo) error {
 
-	m.Lock()
-	defer m.Unlock()
-
 	if m.registerAttempt != nil {
 		m.registerAttempt <- registerAttemptArgs{a}
 	}
+
+	m.Lock()
+	defer m.Unlock()
 
 	// Cannot register attempts for successful or failed payments.
 	if _, ok := m.successful[phash]; ok {
@@ -312,12 +312,12 @@ func (m *mockControlTower) SettleAttempt(phash lntypes.Hash,
 	pid uint64, settleInfo *channeldb.HTLCSettleInfo) (
 	*channeldb.HTLCAttempt, error) {
 
-	m.Lock()
-	defer m.Unlock()
-
 	if m.settleAttempt != nil {
 		m.settleAttempt <- settleAttemptArgs{settleInfo.Preimage}
 	}
+
+	m.Lock()
+	defer m.Unlock()
 
 	// Only allow setting attempts if the payment is known.
 	p, ok := m.payments[phash]
@@ -353,12 +353,12 @@ func (m *mockControlTower) SettleAttempt(phash lntypes.Hash,
 func (m *mockControlTower) FailAttempt(phash lntypes.Hash, pid uint64,
 	failInfo *channeldb.HTLCFailInfo) (*channeldb.HTLCAttempt, error) {
 
-	m.Lock()
-	defer m.Unlock()
-
 	if m.failAttempt != nil {
 		m.failAttempt <- failAttemptArgs{failInfo}
 	}
+
+	m.Lock()
+	defer m.Unlock()
 
 	// Only allow failing attempts if the payment is known.
 	p, ok := m.payments[phash]
@@ -437,12 +437,12 @@ func (m *mockControlTower) FetchPayment(phash lntypes.Hash) (
 func (m *mockControlTower) FetchInFlightPayments() (
 	[]*channeldb.InFlightPayment, error) {
 
-	m.Lock()
-	defer m.Unlock()
-
 	if m.fetchInFlight != nil {
 		m.fetchInFlight <- struct{}{}
 	}
+
+	m.Lock()
+	defer m.Unlock()
 
 	// In flight are all payments not successful or failed.
 	var fl []*channeldb.InFlightPayment

--- a/routing/mock_test.go
+++ b/routing/mock_test.go
@@ -333,6 +333,10 @@ func (m *mockControlTower) RegisterAttempt(phash lntypes.Hash,
 		return channeldb.ErrPaymentAlreadyFailed
 	}
 
+	if settled || failed {
+		return channeldb.ErrPaymentTerminal
+	}
+
 	// Add attempt to payment.
 	p.attempts = append(p.attempts, channeldb.HTLCAttempt{
 		HTLCAttemptInfo: *a,

--- a/routing/payment_lifecycle.go
+++ b/routing/payment_lifecycle.go
@@ -115,6 +115,7 @@ func (p *paymentLifecycle) resumePayment() ([32]byte, *route.Route, error) {
 
 	// We'll continue until either our payment succeeds, or we encounter a
 	// critical error during path finding.
+lifecycle:
 	for {
 		// Start by quickly checking if there are any outcomes already
 		// available to handle before we reevaluate our state.
@@ -171,7 +172,7 @@ func (p *paymentLifecycle) resumePayment() ([32]byte, *route.Route, error) {
 			if err := shardHandler.waitForShard(); err != nil {
 				return [32]byte{}, nil, err
 			}
-			continue
+			continue lifecycle
 		}
 
 		// Before we attempt any new shard, we'll check to see if
@@ -195,7 +196,7 @@ func (p *paymentLifecycle) resumePayment() ([32]byte, *route.Route, error) {
 				return [32]byte{}, nil, saveErr
 			}
 
-			continue
+			continue lifecycle
 
 		case <-p.router.quit:
 			return [32]byte{}, nil, ErrRouterShuttingDown
@@ -234,7 +235,7 @@ func (p *paymentLifecycle) resumePayment() ([32]byte, *route.Route, error) {
 					return [32]byte{}, nil, saveErr
 				}
 
-				continue
+				continue lifecycle
 			}
 
 			// We still have active shards, we'll wait for an
@@ -242,7 +243,7 @@ func (p *paymentLifecycle) resumePayment() ([32]byte, *route.Route, error) {
 			if err := shardHandler.waitForShard(); err != nil {
 				return [32]byte{}, nil, err
 			}
-			continue
+			continue lifecycle
 		}
 
 		// We found a route to try, launch a new shard.
@@ -256,7 +257,7 @@ func (p *paymentLifecycle) resumePayment() ([32]byte, *route.Route, error) {
 			log.Infof("Payment: %v in terminal state, abandoning "+
 				"shard", p.paymentHash)
 
-			continue
+			continue lifecycle
 
 		case err != nil:
 			return [32]byte{}, nil, err
@@ -281,7 +282,7 @@ func (p *paymentLifecycle) resumePayment() ([32]byte, *route.Route, error) {
 
 			// Error was handled successfully, continue to make a
 			// new attempt.
-			continue
+			continue lifecycle
 		}
 
 		// Now that the shard was successfully sent, launch a go

--- a/routing/payment_lifecycle_test.go
+++ b/routing/payment_lifecycle_test.go
@@ -618,10 +618,8 @@ func TestRouterPaymentStateMachine(t *testing.T) {
 		{
 			// A MP payment scenario when our path finding returns
 			// after we've just received a terminal failure, and
-			// demonstrates a bug where the payment will return with
-			// and "unexpected" ErrPaymentTerminal rather than
-			// failing with a permanent error. This results in the
-			// payment getting stuck.
+			// attempts to dispatch a new shard. Testing that we
+			// correctly abandon the shard and conclude the payment.
 			name: "MP path found after failure",
 
 			steps: []string{
@@ -648,7 +646,7 @@ func TestRouterPaymentStateMachine(t *testing.T) {
 			routes: []*route.Route{
 				shard, shard,
 			},
-			paymentErr: channeldb.ErrPaymentTerminal,
+			paymentErr: channeldb.FailureReasonPaymentDetails,
 		},
 		{
 			// A MP payment scenario when our path finding returns
@@ -698,7 +696,7 @@ func TestRouterPaymentStateMachine(t *testing.T) {
 			routes: []*route.Route{
 				shard, shard, shard, shard,
 			},
-			paymentErr: channeldb.ErrPaymentTerminal,
+			paymentErr: channeldb.FailureReasonPaymentDetails,
 		},
 	}
 

--- a/routing/payment_lifecycle_test.go
+++ b/routing/payment_lifecycle_test.go
@@ -619,7 +619,7 @@ func TestRouterPaymentStateMachine(t *testing.T) {
 			// A MP payment scenario when our path finding returns
 			// after we've just received a terminal failure, and
 			// demonstrates a bug where the payment will return with
-			// and "unexpected" ErrPaymentAlreadyFailed rather than
+			// and "unexpected" ErrPaymentTerminal rather than
 			// failing with a permanent error. This results in the
 			// payment getting stuck.
 			name: "MP path found after failure",
@@ -648,7 +648,7 @@ func TestRouterPaymentStateMachine(t *testing.T) {
 			routes: []*route.Route{
 				shard, shard,
 			},
-			paymentErr: channeldb.ErrPaymentAlreadyFailed,
+			paymentErr: channeldb.ErrPaymentTerminal,
 		},
 		{
 			// A MP payment scenario when our path finding returns

--- a/routing/payment_lifecycle_test.go
+++ b/routing/payment_lifecycle_test.go
@@ -598,12 +598,12 @@ func testPaymentLifecycle(t *testing.T, test paymentLifecycleTestCase,
 	// Create a mock control tower with channels set up, that we use to
 	// synchronize and listen for events.
 	control := makeMockControlTower()
-	control.init = make(chan initArgs, 20)
-	control.registerAttempt = make(chan registerAttemptArgs, 20)
-	control.settleAttempt = make(chan settleAttemptArgs, 20)
-	control.failAttempt = make(chan failAttemptArgs, 20)
-	control.failPayment = make(chan failPaymentArgs, 20)
-	control.fetchInFlight = make(chan struct{}, 20)
+	control.init = make(chan initArgs)
+	control.registerAttempt = make(chan registerAttemptArgs)
+	control.settleAttempt = make(chan settleAttemptArgs)
+	control.failAttempt = make(chan failAttemptArgs)
+	control.failPayment = make(chan failPaymentArgs)
+	control.fetchInFlight = make(chan struct{})
 
 	// setupRouter is a helper method that creates and starts the router in
 	// the desired configuration for this test.

--- a/routing/payment_lifecycle_test.go
+++ b/routing/payment_lifecycle_test.go
@@ -89,6 +89,10 @@ const (
 	// to call the Fail method on the control tower.
 	routerFailPayment = "Router:fail-payment"
 
+	// routeRelease is a test step where we unblock pathfinding and
+	// allow it to respond to our test with a route.
+	routeRelease = "PaymentSession:release"
+
 	// sendToSwitchSuccess is a step where we expect the router to
 	// call send the payment attempt to the switch, and we will
 	// respond with a non-error, indicating that the payment
@@ -205,6 +209,7 @@ func TestRouterPaymentStateMachine(t *testing.T) {
 
 			steps: []string{
 				routerInitPayment,
+				routeRelease,
 				routerRegisterAttempt,
 				sendToSwitchSuccess,
 				getPaymentResultSuccess,
@@ -220,6 +225,7 @@ func TestRouterPaymentStateMachine(t *testing.T) {
 
 			steps: []string{
 				routerInitPayment,
+				routeRelease,
 				routerRegisterAttempt,
 				sendToSwitchSuccess,
 
@@ -228,6 +234,7 @@ func TestRouterPaymentStateMachine(t *testing.T) {
 				routerFailAttempt,
 
 				// The router should retry.
+				routeRelease,
 				routerRegisterAttempt,
 				sendToSwitchSuccess,
 
@@ -246,6 +253,7 @@ func TestRouterPaymentStateMachine(t *testing.T) {
 
 			steps: []string{
 				routerInitPayment,
+				routeRelease,
 				routerRegisterAttempt,
 
 				// Make the first sent attempt fail.
@@ -253,6 +261,7 @@ func TestRouterPaymentStateMachine(t *testing.T) {
 				routerFailAttempt,
 
 				// The router should retry.
+				routeRelease,
 				routerRegisterAttempt,
 				sendToSwitchSuccess,
 
@@ -271,12 +280,15 @@ func TestRouterPaymentStateMachine(t *testing.T) {
 
 			steps: []string{
 				routerInitPayment,
+				routeRelease,
 				routerRegisterAttempt,
 				sendToSwitchSuccess,
 
 				// Make the first sent attempt fail.
 				getPaymentResultTempFailure,
 				routerFailAttempt,
+
+				routeRelease,
 
 				// Since there are no more routes to try, the
 				// payment should fail.
@@ -293,6 +305,7 @@ func TestRouterPaymentStateMachine(t *testing.T) {
 
 			steps: []string{
 				routerInitPayment,
+				routeRelease,
 				routerFailPayment,
 				paymentError,
 			},
@@ -308,6 +321,7 @@ func TestRouterPaymentStateMachine(t *testing.T) {
 
 			steps: []string{
 				routerInitPayment,
+				routeRelease,
 				routerRegisterAttempt,
 
 				// Manually resend the payment, the router
@@ -350,6 +364,7 @@ func TestRouterPaymentStateMachine(t *testing.T) {
 
 			steps: []string{
 				routerInitPayment,
+				routeRelease,
 				routerRegisterAttempt,
 				sendToSwitchSuccess,
 
@@ -375,6 +390,7 @@ func TestRouterPaymentStateMachine(t *testing.T) {
 
 			steps: []string{
 				routerInitPayment,
+				routeRelease,
 				routerRegisterAttempt,
 				sendToSwitchSuccess,
 
@@ -390,6 +406,7 @@ func TestRouterPaymentStateMachine(t *testing.T) {
 
 				// Since we have no more routes to try, the
 				// original payment should fail.
+				routeRelease,
 				routerFailPayment,
 				paymentError,
 
@@ -397,6 +414,7 @@ func TestRouterPaymentStateMachine(t *testing.T) {
 				// allowed, since the payment has failed.
 				resendPayment,
 				routerInitPayment,
+				routeRelease,
 				routerRegisterAttempt,
 				sendToSwitchSuccess,
 				getPaymentResultSuccess,
@@ -418,18 +436,22 @@ func TestRouterPaymentStateMachine(t *testing.T) {
 				routerInitPayment,
 
 				// shard 0
+				routeRelease,
 				routerRegisterAttempt,
 				sendToSwitchSuccess,
 
 				// shard 1
+				routeRelease,
 				routerRegisterAttempt,
 				sendToSwitchSuccess,
 
 				// shard 2
+				routeRelease,
 				routerRegisterAttempt,
 				sendToSwitchSuccess,
 
 				// shard 3
+				routeRelease,
 				routerRegisterAttempt,
 				sendToSwitchSuccess,
 
@@ -460,18 +482,22 @@ func TestRouterPaymentStateMachine(t *testing.T) {
 				routerInitPayment,
 
 				// shard 0
+				routeRelease,
 				routerRegisterAttempt,
 				sendToSwitchSuccess,
 
 				// shard 1
+				routeRelease,
 				routerRegisterAttempt,
 				sendToSwitchSuccess,
 
 				// shard 2
+				routeRelease,
 				routerRegisterAttempt,
 				sendToSwitchSuccess,
 
 				// shard 3
+				routeRelease,
 				routerRegisterAttempt,
 				sendToSwitchSuccess,
 
@@ -481,8 +507,10 @@ func TestRouterPaymentStateMachine(t *testing.T) {
 				routerFailAttempt,
 				routerFailAttempt,
 
+				routeRelease,
 				routerRegisterAttempt,
 				sendToSwitchSuccess,
+				routeRelease,
 				routerRegisterAttempt,
 				sendToSwitchSuccess,
 
@@ -512,10 +540,12 @@ func TestRouterPaymentStateMachine(t *testing.T) {
 				routerInitPayment,
 
 				// shard 0
+				routeRelease,
 				routerRegisterAttempt,
 				sendToSwitchSuccess,
 
 				// shard 1
+				routeRelease,
 				routerRegisterAttempt,
 				sendToSwitchSuccess,
 
@@ -523,6 +553,10 @@ func TestRouterPaymentStateMachine(t *testing.T) {
 				// router.
 				getPaymentResultTempFailure,
 				routerFailAttempt,
+
+				// We will try one more shard because we haven't
+				// sent the full payment amount.
+				routeRelease,
 
 				// The second shard succeed against all odds,
 				// making the overall payment succeed.
@@ -541,18 +575,22 @@ func TestRouterPaymentStateMachine(t *testing.T) {
 				routerInitPayment,
 
 				// shard 0
+				routeRelease,
 				routerRegisterAttempt,
 				sendToSwitchSuccess,
 
 				// shard 1
+				routeRelease,
 				routerRegisterAttempt,
 				sendToSwitchSuccess,
 
 				// shard 2
+				routeRelease,
 				routerRegisterAttempt,
 				sendToSwitchSuccess,
 
 				// shard 3
+				routeRelease,
 				routerRegisterAttempt,
 				sendToSwitchSuccess,
 
@@ -697,8 +735,12 @@ func testPaymentLifecycle(t *testing.T, test paymentLifecycleTestCase,
 		PaymentHash: payHash,
 	}
 
+	// Setup our payment session source to block on release of
+	// routes.
+	routeChan := make(chan struct{})
 	router.cfg.SessionSource = &mockPaymentSessionSource{
-		routes: test.routes,
+		routes:       test.routes,
+		routeRelease: routeChan,
 	}
 
 	router.cfg.MissionControl = &mockMissionControl{}
@@ -727,6 +769,14 @@ func testPaymentLifecycle(t *testing.T, test paymentLifecycleTestCase,
 
 			if args.c == nil {
 				t.Fatalf("expected non-nil CreationInfo")
+			}
+
+		case routeRelease:
+			select {
+			case <-routeChan:
+
+			case <-time.After(stepTimeout):
+				t.Fatalf("no route requested")
 			}
 
 		// In this step we expect the router to make a call to

--- a/routing/payment_lifecycle_test.go
+++ b/routing/payment_lifecycle_test.go
@@ -190,6 +190,9 @@ func TestRouterPaymentStateMachine(t *testing.T) {
 		t.Fatalf("unable to create route: %v", err)
 	}
 
+	halfShard, err := createTestRoute(paymentAmt/2, testGraph.aliasMap)
+	require.NoError(t, err, "unable to create half route")
+
 	shard, err := createTestRoute(paymentAmt/4, testGraph.aliasMap)
 	if err != nil {
 		t.Fatalf("unable to create route: %v", err)
@@ -501,10 +504,8 @@ func TestRouterPaymentStateMachine(t *testing.T) {
 			},
 		},
 		{
-			// An MP payment scenario where 3 of the shards fail.
-			// However the last shard settle, which means we get
-			// the preimage and should consider the overall payment
-			// a success.
+			// An MP payment scenario where one of the shards fails,
+			// but we still receive a single success shard.
 			name: "MP one shard success",
 
 			steps: []string{
@@ -518,30 +519,18 @@ func TestRouterPaymentStateMachine(t *testing.T) {
 				routerRegisterAttempt,
 				sendToSwitchSuccess,
 
-				// shard 2
-				routerRegisterAttempt,
-				sendToSwitchSuccess,
-
-				// shard 3
-				routerRegisterAttempt,
-				sendToSwitchSuccess,
-
-				// 3 shards fail, and should be failed by the
+				// shard 0 fails, and should be failed by the
 				// router.
 				getPaymentResultTempFailure,
-				getPaymentResultTempFailure,
-				getPaymentResultTempFailure,
-				routerFailAttempt,
-				routerFailAttempt,
 				routerFailAttempt,
 
-				// The fourth shard succeed against all odds,
+				// The second shard succeed against all odds,
 				// making the overall payment succeed.
 				getPaymentResultSuccess,
 				routerSettleAttempt,
 				paymentSuccess,
 			},
-			routes: []*route.Route{shard, shard, shard, shard},
+			routes: []*route.Route{halfShard, halfShard},
 		},
 		{
 			// An MP payment scenario a shard fail with a terminal


### PR DESCRIPTION
As per @halseth's [exceptional explanation](https://github.com/lightningnetwork/lnd/issues/4788#issuecomment-804093718), our payment lifecycle fails to cover the following scenario:
- Shard 0 is dispatched
- Shard 1 is dispatched
- Path finding for shard 2 begins
- Shard 0 returns a fatal error
- Shard 2's [`launchShard`](https://github.com/lightningnetwork/lnd/blob/master/routing/payment_lifecycle.go#L249) fails with `ErrPaymentAlreadyFailed`
- Shard 1 gets stuck in flight and the payment's state is never updated to failed

Fixes: #4788
Fixes: #4501

The [handling](https://github.com/lightningnetwork/lnd/blob/a329c8061266418bccd797aa5d7d277c736ee930/routing/router.go#L1911) in `SendToRoute` is not updated because we want to fail attempts to launch shards for already failed payments, and we don't have the problem of not following up with the other shards.

