### PR TITLE
invoices: do not fail DeleteInvoice if payment addr isn't indexed

### DIFF
--- a/channeldb/invoice_test.go
+++ b/channeldb/invoice_test.go
@@ -2425,15 +2425,6 @@ func TestDeleteInvoices(t *testing.T) {
 	// Restore the hash.
 	invoicesToDelete[0].PayHash[2] ^= 3
 
-	// XOR one byte of one of the references' payment address and attempt
-	// to delete.
-	invoicesToDelete[1].PayAddr[5] ^= 7
-	require.Error(t, db.DeleteInvoice(invoicesToDelete))
-	assertInvoiceCount(3)
-
-	// Restore the payment address.
-	invoicesToDelete[1].PayAddr[5] ^= 7
-
 	// XOR the second invoice's payment settle index as it is settled, and
 	// attempt to delete.
 	invoicesToDelete[1].SettleIndex ^= 11

--- a/invoices/invoiceregistry.go
+++ b/invoices/invoiceregistry.go
@@ -213,8 +213,15 @@ func (i *InvoiceRegistry) scanInvoicesOnStart() error {
 		len(pending))
 	i.expiryWatcher.AddInvoices(pending...)
 
-	if err := i.cdb.DeleteInvoice(removable); err != nil {
-		log.Warnf("Deleting old invoices failed: %v", err)
+	if len(removable) > 0 {
+		log.Infof("Attempting to delete %v canceled invoices",
+			len(removable))
+		if err := i.cdb.DeleteInvoice(removable); err != nil {
+			log.Warnf("Deleting canceled invoices failed: %v", err)
+		} else {
+			log.Infof("Deleted %v canceled invoices",
+				len(removable))
+		}
 	}
 
 	return nil


### PR DESCRIPTION
This PR relaxes `DeleteInvoice` failure cases by removing the requirement that the invoice needs to be indexed by the payment address. Since payment address index was introduced with an empty migration it is possible that users have old invoices which were never added to this index causing invoice garbage collection to get stuck.

Migration reference (with discussion):  https://github.com/lightningnetwork/lnd/pull/4285/commits/cbf71b5452fa1d3036a43309e490787c5f7f08dc#r426368127
