### PR TITLE
multi: send channel update for failed interceptor packets

### DIFF
--- a/htlcswitch/interceptable_switch.go
+++ b/htlcswitch/interceptable_switch.go
@@ -139,7 +139,16 @@ func (f *interceptedForward) Resume() error {
 
 // Fail forward a failed packet to the switch.
 func (f *interceptedForward) Fail() error {
-	reason, err := f.packet.obfuscator.EncryptFirstHop(lnwire.NewTemporaryChannelFailure(nil))
+	update, err := f.htlcSwitch.cfg.FetchLastChannelUpdate(
+		f.packet.incomingChanID,
+	)
+	if err != nil {
+		return err
+	}
+
+	reason, err := f.packet.obfuscator.EncryptFirstHop(
+		lnwire.NewTemporaryChannelFailure(update),
+	)
 	if err != nil {
 		return fmt.Errorf("failed to encrypt failure reason %v", err)
 	}

--- a/lntest/itest/lnd_forward_interceptor_test.go
+++ b/lntest/itest/lnd_forward_interceptor_test.go
@@ -128,6 +128,15 @@ func testForwardInterceptor(net *lntest.NetworkHarness, t *harnessTest) {
 				require.Equal(t.t, lnrpc.HTLCAttempt_FAILED,
 					attempt.Status, "expected payment to fail")
 
+				// Assert that we get a temporary channel
+				// failure which has a channel update.
+				require.NotNil(t.t, attempt.Failure)
+				require.NotNil(t.t, attempt.Failure.ChannelUpdate)
+
+				require.Equal(t.t,
+					lnrpc.Failure_TEMPORARY_CHANNEL_FAILURE,
+					attempt.Failure.Code)
+
 			// For settle and resume we make sure the payment is successful.
 			case routerrpc.ResolveHoldForwardAction_SETTLE:
 				fallthrough


### PR DESCRIPTION
This PR updates intercepted payments to send channel updates with `TemporaryChannelFailure` as is required by the spec. 

Replaces #5059.