### PR TITLE
lnwallet: use tail not tip in getUnsignedAckedUpdates

### DIFF
--- a/channeldb/channel.go
+++ b/channeldb/channel.go
@@ -2396,8 +2396,9 @@ func (c *OpenChannel) AdvanceCommitChainTail(fwdPkg *FwdPkg,
 		// in their new commitment.
 		updateBytes := chanBucket.Get(unsignedAckedUpdatesKey)
 		if updateBytes == nil {
-			// If there are no updates to sign, we don't need to
-			// filter out any updates.
+			// This shouldn't normally happen as we always store
+			// the number of updates, but could still be
+			// encountered by nodes that are upgrading.
 			newRemoteCommit = &newCommit.Commitment
 			return nil
 		}

--- a/lnwallet/channel.go
+++ b/lnwallet/channel.go
@@ -2120,6 +2120,8 @@ func (lc *LightningChannel) restorePendingLocalUpdates(
 	// If we did have a dangling commit, then we'll examine which updates
 	// we included in that state and re-insert them into our update log.
 	for _, logUpdate := range pendingRemoteCommitDiff.LogUpdates {
+		logUpdate := logUpdate
+
 		payDesc, err := lc.logUpdateToPayDesc(
 			&logUpdate, lc.remoteUpdateLog, pendingHeight,
 			chainfee.SatPerKWeight(pendingCommit.FeePerKw),

--- a/lnwallet/channel.go
+++ b/lnwallet/channel.go
@@ -3260,7 +3260,7 @@ func (lc *LightningChannel) getUnsignedAckedUpdates() []channeldb.LogUpdate {
 	chanID := lnwire.NewChanIDFromOutPoint(&lc.channelState.FundingOutpoint)
 
 	// Fetch the last remote update that we have signed for.
-	lastRemoteCommitted := lc.remoteCommitChain.tip().theirMessageIndex
+	lastRemoteCommitted := lc.remoteCommitChain.tail().theirMessageIndex
 
 	// Fetch the last remote update that we have acked.
 	lastLocalCommitted := lc.localCommitChain.tail().theirMessageIndex

--- a/lnwallet/channel_test.go
+++ b/lnwallet/channel_test.go
@@ -9521,3 +9521,125 @@ func TestChannelLocalUnsignedUpdatesFailure(t *testing.T) {
 	err = newAliceChannel.ReceiveNewCommitment(bobSig, bobHtlcSigs)
 	require.NoError(t, err)
 }
+
+// TestChannelSignedAckRegression tests a previously-regressing state
+// transition no longer causes channel desynchronization.
+//
+// The full state transition of this test is:
+//
+// Alice                   Bob
+//        <----add-------
+//        <----sig-------
+//        -----rev------>
+//        -----sig------>
+//        <----rev-------
+//        ----settle---->
+//        -----sig------>
+//        <----rev-------
+//        <----sig-------
+//        -----add------>
+//        -----sig------>
+//        <----rev-------
+//                        *restarts*
+//        -----rev------>
+//        <----sig-------
+//
+func TestChannelSignedAckRegression(t *testing.T) {
+	t.Parallel()
+
+	// Create test channels to test out this state transition.
+	aliceChannel, bobChannel, cleanUp, err := CreateTestChannels(
+		channeldb.SingleFunderTweaklessBit,
+	)
+	require.NoError(t, err)
+	defer cleanUp()
+
+	// Create an HTLC that Bob will send to Alice.
+	htlc, preimage := createHTLC(0, lnwire.MilliSatoshi(5000000))
+
+	// <----add------
+	_, err = bobChannel.AddHTLC(htlc, nil)
+	require.NoError(t, err)
+	_, err = aliceChannel.ReceiveHTLC(htlc)
+	require.NoError(t, err)
+
+	// Force a state transition to lock in the HTLC.
+	// <----sig------
+	// -----rev----->
+	// -----sig----->
+	// <----rev------
+	err = ForceStateTransition(bobChannel, aliceChannel)
+	require.NoError(t, err)
+
+	// Alice settles the HTLC back to Bob.
+	// ----settle--->
+	err = aliceChannel.SettleHTLC(preimage, uint64(0), nil, nil, nil)
+	require.NoError(t, err)
+	err = bobChannel.ReceiveHTLCSettle(preimage, uint64(0))
+	require.NoError(t, err)
+
+	// -----sig---->
+	aliceSig, aliceHtlcSigs, _, err := aliceChannel.SignNextCommitment()
+	require.NoError(t, err)
+	err = bobChannel.ReceiveNewCommitment(aliceSig, aliceHtlcSigs)
+	require.NoError(t, err)
+
+	// <----rev-----
+	bobRevocation, _, err := bobChannel.RevokeCurrentCommitment()
+	require.NoError(t, err)
+	_, _, _, _, err = aliceChannel.ReceiveRevocation(bobRevocation)
+	require.NoError(t, err)
+
+	// <----sig-----
+	bobSig, bobHtlcSigs, _, err := bobChannel.SignNextCommitment()
+	require.NoError(t, err)
+	err = aliceChannel.ReceiveNewCommitment(bobSig, bobHtlcSigs)
+	require.NoError(t, err)
+
+	// Create an HTLC that Alice will send to Bob.
+	htlc2, _ := createHTLC(0, lnwire.MilliSatoshi(5000000))
+
+	// -----add---->
+	_, err = aliceChannel.AddHTLC(htlc2, nil)
+	require.NoError(t, err)
+	_, err = bobChannel.ReceiveHTLC(htlc2)
+	require.NoError(t, err)
+
+	// -----sig---->
+	aliceSig, aliceHtlcSigs, _, err = aliceChannel.SignNextCommitment()
+	require.NoError(t, err)
+	err = bobChannel.ReceiveNewCommitment(aliceSig, aliceHtlcSigs)
+	require.NoError(t, err)
+
+	// <----rev-----
+	bobRevocation, _, err = bobChannel.RevokeCurrentCommitment()
+	require.NoError(t, err)
+	_, _, _, _, err = aliceChannel.ReceiveRevocation(bobRevocation)
+	require.NoError(t, err)
+
+	// Restart Bob's channel state here.
+	newBobChannel, err := NewLightningChannel(
+		bobChannel.Signer, bobChannel.channelState,
+		bobChannel.sigPool,
+	)
+	require.NoError(t, err)
+
+	// -----rev---->
+	aliceRevocation, _, err := aliceChannel.RevokeCurrentCommitment()
+	require.NoError(t, err)
+	fwdPkg, _, _, _, err := newBobChannel.ReceiveRevocation(aliceRevocation)
+	require.NoError(t, err)
+
+	// Assert that the fwdpkg is not empty.
+	require.Equal(t, len(fwdPkg.SettleFails), 1)
+
+	// Bob should no longer fail to sign this commitment due to faulty
+	// update logs.
+	// <----sig-----
+	bobSig, bobHtlcSigs, _, err = newBobChannel.SignNextCommitment()
+	require.NoError(t, err)
+
+	// Alice should receive the new commitment without hiccups.
+	err = aliceChannel.ReceiveNewCommitment(bobSig, bobHtlcSigs)
+	require.NoError(t, err)
+}


### PR DESCRIPTION
**Commits:**
- 9d0d5bdfaf130af695cbb420a774da1bf028aa8f modifies a comment
- 97007fc4faf984932b0e67a29b7fb77df3d7e9c8 fixes logUpdate scope in range loop
- 7da2080a3dfbe0ca74ff9408f29e6006c0cf05d0 is the patch (+1, -1)
- 0547364091ee8bf3f6c8ceeb925a1f625666d473 is the previously failing unit test

**Patch summary:**
- `getUnsignedAckedUpdates` is a function used to restore on channel restart the signed updates our peer has sent us, but that we haven't signed for yet.  It only includes settles and fails.  `RevokeCurrentCommitment` calls it.  The state transition looks like this, before we store them:
```
us     <----fail----  peer
       <----sig-----
       -----rev---->
```
- `getUnsignedAckedUpdates` previously would only select remote updates with `LogIndex` satisfying:
  - `< lc.localCommitChain.tail().theirMessageIndex`
       - (update is locked-in on our local commitment)
  - `>= lc.remoteCommitChain.tip().theirMessageIndex`
       - (update is not on *any* of the remote's commitments)

- This pull changes the second requirement from `tip()` to `tail()`.  This means that we restore the remote update *until* we receive a revocation covering it, at which point our logs are compacted and we can forward the settle/fail.  Otherwise, the following subsequent state transition leads to buggy behavior:
```
us     ----sig---->  peer
       <---add-----
       <---sig-----
       ----rev---->
```
   - `RevokeCurrentCommitment` will call `getUnsignedAckedUpdates` again, but this time the fail will not be stored because it is on the remote's `tip` commitment.  If we restart, we will not restore the fail, and will have a lingering add leading to channel force close.
   - With this fix, when the peer finally sends a revocation and locks in the fail, the update logs will be compacted and the fail can be forwarded. Additionally, the existing filtering logic in `AdvanceCommitChainTail` (called by `ReceiveRevocation`) will ensure that we no longer attempt to restore the update on restart.