### PR TITLE
build: set Go version to 1.15 remove retract

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -89,6 +89,4 @@ replace github.com/lightningnetwork/lnd/clock => ./clock
 
 replace git.schwanenlied.me/yawning/bsaes.git => github.com/Yawning/bsaes v0.0.0-20180720073208-c0276d75487e
 
-go 1.13
-
-retract v0.0.2
+go 1.15


### PR DESCRIPTION
We need to remove the retract as it's a new directive that isn't
understood by Go versions < 1.16.
