### PR TITLE
build: update btcwallet to latest version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/btcsuite/btclog v0.0.0-20170628155309-84c8d2346e9f
 	github.com/btcsuite/btcutil v1.0.3-0.20201208143702-a53e38424cce
 	github.com/btcsuite/btcutil/psbt v1.0.3-0.20201208143702-a53e38424cce
-	github.com/btcsuite/btcwallet v0.11.1-0.20210413223001-fe61cc5d7886
+	github.com/btcsuite/btcwallet v0.11.1-0.20210421021904-50978fcf79f8
 	github.com/btcsuite/btcwallet/wallet/txauthor v1.0.1-0.20210329233242-e0607006dce6
 	github.com/btcsuite/btcwallet/wallet/txrules v1.0.0
 	github.com/btcsuite/btcwallet/wallet/txsizes v1.0.1-0.20210329233242-e0607006dce6 // indirect

--- a/go.sum
+++ b/go.sum
@@ -37,8 +37,8 @@ github.com/btcsuite/btcutil v1.0.3-0.20201208143702-a53e38424cce h1:YtWJF7RHm2pY
 github.com/btcsuite/btcutil v1.0.3-0.20201208143702-a53e38424cce/go.mod h1:0DVlHczLPewLcPGEIeUEzfOJhqGPQ0mJJRDBtD307+o=
 github.com/btcsuite/btcutil/psbt v1.0.3-0.20201208143702-a53e38424cce h1:3PRwz+js0AMMV1fHRrCdQ55akoomx4Q3ulozHC3BDDY=
 github.com/btcsuite/btcutil/psbt v1.0.3-0.20201208143702-a53e38424cce/go.mod h1:LVveMu4VaNSkIRTZu2+ut0HDBRuYjqGocxDMNS1KuGQ=
-github.com/btcsuite/btcwallet v0.11.1-0.20210413223001-fe61cc5d7886 h1:d4TeT2g352rPwBIKaJmO2DnsrBgJL6Yy/+CtoS9NU78=
-github.com/btcsuite/btcwallet v0.11.1-0.20210413223001-fe61cc5d7886/go.mod h1:CevOfPKvF6kHr+JXhWD3TtqLbsJrD1CzrtDqZ+5G6ss=
+github.com/btcsuite/btcwallet v0.11.1-0.20210421021904-50978fcf79f8 h1:oNhbEF2hWQOHf8SIaUPZJH6Xq+9LQ6PMqCT9eiBVObE=
+github.com/btcsuite/btcwallet v0.11.1-0.20210421021904-50978fcf79f8/go.mod h1:CevOfPKvF6kHr+JXhWD3TtqLbsJrD1CzrtDqZ+5G6ss=
 github.com/btcsuite/btcwallet/wallet/txauthor v1.0.0/go.mod h1:VufDts7bd/zs3GV13f/lXc/0lXrPnvxD/NvmpG/FEKU=
 github.com/btcsuite/btcwallet/wallet/txauthor v1.0.1-0.20210329233242-e0607006dce6 h1:mO7NxcfgLe75paLDHx+LWNG5BskiDQigHnSVT2KvNZA=
 github.com/btcsuite/btcwallet/wallet/txauthor v1.0.1-0.20210329233242-e0607006dce6/go.mod h1:VufDts7bd/zs3GV13f/lXc/0lXrPnvxD/NvmpG/FEKU=


### PR DESCRIPTION
This version includes a fix to a regression that caused simnet wallets
to no longer operate in certain conditions.

Fixes #5233. 