### PR TITLE
REST: Enable support for bi-directional streaming RPCs over REST, fix ping/pong support

### DIFF
--- a/config.go
+++ b/config.go
@@ -31,6 +31,7 @@ import (
 	"github.com/lightningnetwork/lnd/htlcswitch/hodl"
 	"github.com/lightningnetwork/lnd/input"
 	"github.com/lightningnetwork/lnd/lncfg"
+	"github.com/lightningnetwork/lnd/lnrpc"
 	"github.com/lightningnetwork/lnd/lnrpc/routerrpc"
 	"github.com/lightningnetwork/lnd/lnrpc/signrpc"
 	"github.com/lightningnetwork/lnd/lnwallet"
@@ -246,6 +247,8 @@ type Config struct {
 	DisableListen     bool          `long:"nolisten" description:"Disable listening for incoming peer connections"`
 	DisableRest       bool          `long:"norest" description:"Disable REST API"`
 	DisableRestTLS    bool          `long:"no-rest-tls" description:"Disable TLS for REST connections"`
+	WSPingInterval    time.Duration `long:"ws-ping-interval" description:"The ping interval for REST based WebSocket connections, set to 0 to disable sending ping messages from the server side"`
+	WSPongWait        time.Duration `long:"ws-pong-wait" description:"The time we wait for a pong response message on REST based WebSocket connections before the connection is closed as inactive"`
 	NAT               bool          `long:"nat" description:"Toggle NAT traversal support (using either UPnP or NAT-PMP) to automatically advertise your external IP address to the network -- NOTE this does not support devices behind multiple NATs"`
 	MinBackoff        time.Duration `long:"minbackoff" description:"Shortest backoff when reconnecting to persistent peers. Valid time units are {s, m, h}."`
 	MaxBackoff        time.Duration `long:"maxbackoff" description:"Longest backoff when reconnecting to persistent peers. Valid time units are {s, m, h}."`
@@ -390,6 +393,8 @@ func DefaultConfig() Config {
 		MaxLogFiles:       defaultMaxLogFiles,
 		MaxLogFileSize:    defaultMaxLogFileSize,
 		AcceptorTimeout:   defaultAcceptorTimeout,
+		WSPingInterval:    lnrpc.DefaultPingInterval,
+		WSPongWait:        lnrpc.DefaultPongWait,
 		Bitcoin: &lncfg.Chain{
 			MinHTLCIn:     chainreg.DefaultBitcoinMinHTLCInMSat,
 			MinHTLCOut:    chainreg.DefaultBitcoinMinHTLCOutMSat,

--- a/lnd.go
+++ b/lnd.go
@@ -1266,7 +1266,8 @@ func startRestProxy(cfg *Config, rpcServer *rpcServer, restDialOpts []grpc.DialO
 
 	// Wrap the default grpc-gateway handler with the WebSocket handler.
 	restHandler := lnrpc.NewWebSocketProxy(
-		mux, rpcsLog, lnrpc.LndClientStreamingURIs,
+		mux, rpcsLog, lnrpc.DefaultPingInterval, lnrpc.DefaultPongWait,
+		lnrpc.LndClientStreamingURIs,
 	)
 
 	// Use a WaitGroup so we can be sure the instructions on how to input the

--- a/lnd.go
+++ b/lnd.go
@@ -1265,7 +1265,9 @@ func startRestProxy(cfg *Config, rpcServer *rpcServer, restDialOpts []grpc.DialO
 	}
 
 	// Wrap the default grpc-gateway handler with the WebSocket handler.
-	restHandler := lnrpc.NewWebSocketProxy(mux, rpcsLog)
+	restHandler := lnrpc.NewWebSocketProxy(
+		mux, rpcsLog, lnrpc.LndClientStreamingURIs,
+	)
 
 	// Use a WaitGroup so we can be sure the instructions on how to input the
 	// password is the last thing to be printed to the console.

--- a/lnd.go
+++ b/lnd.go
@@ -1266,7 +1266,7 @@ func startRestProxy(cfg *Config, rpcServer *rpcServer, restDialOpts []grpc.DialO
 
 	// Wrap the default grpc-gateway handler with the WebSocket handler.
 	restHandler := lnrpc.NewWebSocketProxy(
-		mux, rpcsLog, lnrpc.DefaultPingInterval, lnrpc.DefaultPongWait,
+		mux, rpcsLog, cfg.WSPingInterval, cfg.WSPongWait,
 		lnrpc.LndClientStreamingURIs,
 	)
 

--- a/lnrpc/metadata.go
+++ b/lnrpc/metadata.go
@@ -1,0 +1,17 @@
+package lnrpc
+
+import "regexp"
+
+var (
+	// LndClientStreamingURIs is a list of all lnd RPCs that use a request-
+	// streaming interface. Those request-streaming RPCs need to be handled
+	// differently in the WebsocketProxy because of how the request body
+	// parsing is implemented in the grpc-gateway library. Unfortunately
+	// there is no straightforward way of obtaining this information on
+	// runtime so we need to keep a hard coded list here.
+	LndClientStreamingURIs = []*regexp.Regexp{
+		regexp.MustCompile("^/v1/channels/acceptor$"),
+		regexp.MustCompile("^/v1/channels/transaction-stream$"),
+		regexp.MustCompile("^/v2/router/htlcinterceptor$"),
+	}
+)

--- a/lnrpc/rest-annotations.yaml
+++ b/lnrpc/rest-annotations.yaml
@@ -1,6 +1,10 @@
 type: google.api.Service
 config_version: 3
 
+# Mapping for the grpc-gateway REST proxy.
+# Please make sure to also update the `metadata.go` file when editing this file
+# and adding a new client-streaming RPC!
+
 http:
   rules:
     # rpc.proto
@@ -61,12 +65,15 @@ http:
       post: "/v1/funding/step"
       body: "*"
     - selector: lnrpc.Lightning.ChannelAcceptor
-      # request streaming RPC, REST not supported
+      post: "/v1/channels/acceptor"
+      body: "*"
     - selector: lnrpc.Lightning.CloseChannel
       delete: "/v1/channels/{channel_point.funding_txid_str}/{channel_point.output_index}"
     - selector: lnrpc.Lightning.AbandonChannel
       delete: "/v1/channels/abandon/{channel_point.funding_txid_str}/{channel_point.output_index}"
     - selector: lnrpc.Lightning.SendPayment
+      post: "/v1/channels/transaction-stream"
+      body: "*"
     - selector: lnrpc.Lightning.SendPaymentSync
       post: "/v1/channels/transactions"
       body: "*"
@@ -228,7 +235,8 @@ http:
     - selector: routerrpc.Router.TrackPayment
       # deprecated, no REST endpoint
     - selector: routerrpc.HtlcInterceptor
-      # request streaming RPC, REST not supported
+      post: "/v2/router/htlcinterceptor"
+      body: "*"
     - selector: routerrpc.UpdateChanStatus
       post: "/v2/router/updatechanstatus"
       body: "*"

--- a/lnrpc/rpc.swagger.json
+++ b/lnrpc/rpc.swagger.json
@@ -204,6 +204,49 @@
         ]
       }
     },
+    "/v1/channels/acceptor": {
+      "post": {
+        "summary": "ChannelAcceptor dispatches a bi-directional streaming RPC in which\nOpenChannel requests are sent to the client and the client responds with\na boolean that tells LND whether or not to accept the channel. This allows\nnode operators to specify their own criteria for accepting inbound channels\nthrough a single persistent connection.",
+        "operationId": "ChannelAcceptor",
+        "responses": {
+          "200": {
+            "description": "A successful response.(streaming responses)",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "result": {
+                  "$ref": "#/definitions/lnrpcChannelAcceptRequest"
+                },
+                "error": {
+                  "$ref": "#/definitions/runtimeStreamError"
+                }
+              },
+              "title": "Stream result of lnrpcChannelAcceptRequest"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response",
+            "schema": {
+              "$ref": "#/definitions/runtimeError"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "description": " (streaming inputs)",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/lnrpcChannelAcceptResponse"
+            }
+          }
+        ],
+        "tags": [
+          "Lightning"
+        ]
+      }
+    },
     "/v1/channels/backup": {
       "get": {
         "summary": "ExportAllChannelBackups returns static channel backups for all existing\nchannels known to lnd. A set of regular singular static channel backups for\neach channel are returned. Additionally, a multi-channel backup is returned\nas well, which contains a single encrypted blob containing the backups of\neach channel.",
@@ -532,6 +575,49 @@
             }
           }
         },
+        "tags": [
+          "Lightning"
+        ]
+      }
+    },
+    "/v1/channels/transaction-stream": {
+      "post": {
+        "summary": "lncli: `sendpayment`\nDeprecated, use routerrpc.SendPaymentV2. SendPayment dispatches a\nbi-directional streaming RPC for sending payments through the Lightning\nNetwork. A single RPC invocation creates a persistent bi-directional\nstream allowing clients to rapidly send payments through the Lightning\nNetwork with a single persistent connection.",
+        "operationId": "SendPayment",
+        "responses": {
+          "200": {
+            "description": "A successful response.(streaming responses)",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "result": {
+                  "$ref": "#/definitions/lnrpcSendResponse"
+                },
+                "error": {
+                  "$ref": "#/definitions/runtimeStreamError"
+                }
+              },
+              "title": "Stream result of lnrpcSendResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response",
+            "schema": {
+              "$ref": "#/definitions/runtimeError"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "description": " (streaming inputs)",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/lnrpcSendRequest"
+            }
+          }
+        ],
         "tags": [
           "Lightning"
         ]
@@ -2926,6 +3012,59 @@
           "type": "integer",
           "format": "int64",
           "description": "A bit-field which the initiator uses to specify proposed channel\nbehavior."
+        }
+      }
+    },
+    "lnrpcChannelAcceptResponse": {
+      "type": "object",
+      "properties": {
+        "accept": {
+          "type": "boolean",
+          "format": "boolean",
+          "description": "Whether or not the client accepts the channel."
+        },
+        "pending_chan_id": {
+          "type": "string",
+          "format": "byte",
+          "description": "The pending channel id to which this response applies."
+        },
+        "error": {
+          "type": "string",
+          "description": "An optional error to send the initiating party to indicate why the channel\nwas rejected. This field *should not* contain sensitive information, it will\nbe sent to the initiating party. This field should only be set if accept is\nfalse, the channel will be rejected if an error is set with accept=true\nbecause the meaning of this response is ambiguous. Limited to 500\ncharacters."
+        },
+        "upfront_shutdown": {
+          "type": "string",
+          "description": "The upfront shutdown address to use if the initiating peer supports option\nupfront shutdown script (see ListPeers for the features supported). Note\nthat the channel open will fail if this value is set for a peer that does\nnot support this feature bit."
+        },
+        "csv_delay": {
+          "type": "integer",
+          "format": "int64",
+          "description": "The csv delay (in blocks) that we require for the remote party."
+        },
+        "reserve_sat": {
+          "type": "string",
+          "format": "uint64",
+          "description": "The reserve amount in satoshis that we require the remote peer to adhere to.\nWe require that the remote peer always have some reserve amount allocated to\nthem so that there is always a disincentive to broadcast old state (if they\nhold 0 sats on their side of the channel, there is nothing to lose)."
+        },
+        "in_flight_max_msat": {
+          "type": "string",
+          "format": "uint64",
+          "description": "The maximum amount of funds in millisatoshis that we allow the remote peer\nto have in outstanding htlcs."
+        },
+        "max_htlc_count": {
+          "type": "integer",
+          "format": "int64",
+          "description": "The maximum number of htlcs that the remote peer can offer us."
+        },
+        "min_htlc_in": {
+          "type": "string",
+          "format": "uint64",
+          "description": "The minimum value in millisatoshis for incoming htlcs on the channel."
+        },
+        "min_accept_depth": {
+          "type": "integer",
+          "format": "int64",
+          "description": "The number of confirmations we require before we consider the channel open."
         }
       }
     },

--- a/lnrpc/websocket_proxy.go
+++ b/lnrpc/websocket_proxy.go
@@ -372,6 +372,9 @@ func IsClosedConnError(err error) bool {
 	if strings.Contains(str, "broken pipe") {
 		return true
 	}
+	if strings.Contains(str, "connection reset by peer") {
+		return true
+	}
 	return websocket.IsCloseError(
 		err, websocket.CloseNormalClosure, websocket.CloseGoingAway,
 	)

--- a/lntest/itest/log_error_whitelist.txt
+++ b/lntest/itest/log_error_whitelist.txt
@@ -11,6 +11,7 @@
 <time> [ERR] BTCN: unable to get filter for hash=<hex>, retrying: unable to fetch cfilter
 <time> [ERR] BTCN: Unable to process block connected (height=<height>, hash=<hex>): out of order block <hex>: expected PrevBlock <hex>, got <hex>
 <time> [ERR] BTCN: Unknown connid=<id>
+<time> [ERR] CHAC: Received an error: rpc error: code = Canceled desc = context canceled, shutting down
 <time> [ERR] CHFT: Close channel <chan_point> unknown to store
 <time> [ERR] CNCT: ChannelArbitrator(<chan_point>): unable to advance state: channel not found
 <time> [ERR] CNCT: ChannelArbitrator(<chan_point>): unable to broadcast close tx: Transaction rejected: output already spent
@@ -182,6 +183,7 @@
 <time> [ERR] RPCS: [/lnrpc.Lightning/BakeMacaroon]: invalid permission action. supported actions are [read write generate], supported entities are [onchain offchain address message peers info invoices signer macaroon uri]
 <time> [ERR] RPCS: [/lnrpc.Lightning/BakeMacaroon]: invalid permission entity. supported actions are [read write generate], supported entities are [onchain offchain address message peers info invoices signer macaroon uri]
 <time> [ERR] RPCS: [/lnrpc.Lightning/BakeMacaroon]: permission list cannot be empty. specify at least one action/entity pair. supported actions are [read write generate], supported entities are [onchain offchain address message peers info invoices signer macaroon uri]
+<time> [ERR] RPCS: [/lnrpc.Lightning/ChannelAcceptor]: rpc error: code = Canceled desc = context canceled
 <time> [ERR] RPCS: [/lnrpc.Lightning/CloseChannel]: cannot close channel with state: ChanStatusRestored
 <time> [ERR] RPCS: [/lnrpc.Lightning/CloseChannel]: cannot co-op close frozen channel as initiator until height=3059, (current_height=3055)
 <time> [ERR] RPCS: [/lnrpc.Lightning/CloseChannel]: cannot co-op close frozen channel as initiator until height=<height>, (current_height=<height>)

--- a/sample-lnd.conf
+++ b/sample-lnd.conf
@@ -184,6 +184,15 @@
 ; Disable TLS for the REST API.
 ; no-rest-tls=true
 
+; The ping interval for REST based WebSocket connections, set to 0 to disable
+; sending ping messages from the server side. Valid time units are {s, m, h}.
+; ws-ping-interval=30s
+
+; The time we wait for a pong response message on REST based WebSocket
+; connections before the connection is closed as inactive. Valid time units are
+; {s, m, h}.
+; ws-pong-wait=5s
+
 ; Shortest backoff when reconnecting to persistent peers. Valid time units are
 ; {s, m, h}.
 ; minbackoff=1s


### PR DESCRIPTION
Fixes #4120
Fixes #4497

This PR fixes the WebSocket support for client-streaming (request-streaming) RPCs.
At the moment this is the `lnrpc.Lightning.ChannelAcceptor`, `lnrpc.Lightning.SendPayment` and `routerrpc.HtlcInterceptor`.

At the same time we also fix the keep-alive issue where the WebSocket server wouldn't respond to ping messages correctly.
