### PR TITLE
mod+tools: pin down build flag dependent go.sum entry

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -66,6 +66,7 @@ github.com/btcsuite/snappy-go v1.0.0 h1:ZxaA6lo2EpxGddsA8JwWOcxlzRybb444sgmeJQMJ
 github.com/btcsuite/snappy-go v1.0.0/go.mod h1:8woku9dyThutzjeg+3xrA5iCpBRH8XEEg3lh6TiUghc=
 github.com/btcsuite/websocket v0.0.0-20150119174127-31079b680792 h1:R8vQdOQdZ9Y3SkEwmHoWBmX1DNXhXZqlTpq6s4tyJGc=
 github.com/btcsuite/websocket v0.0.0-20150119174127-31079b680792/go.mod h1:ghJtEyQwv5/p4Mg4C0fgbePVuGr935/5ddU9Z3TmDRY=
+github.com/btcsuite/winsvc v1.0.0 h1:J9B4L7e3oqhXOcm+2IuNApwzQec85lE+QaikUcCs+dk=
 github.com/btcsuite/winsvc v1.0.0/go.mod h1:jsenWakMcC0zFBFurPLEAyrnc/teJEM1O46fmI40EZs=
 github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=

--- a/tools.go
+++ b/tools.go
@@ -1,0 +1,13 @@
+// +build tools
+
+package lnd
+
+import (
+	// This is a workaround to make sure go mod keeps around the btcd
+	// dependencies in the go.sum file that we only use during integration
+	// tests and only for certain operating systems. For example, this
+	// specific import makes sure the indirect dependency
+	// github.com/btcsuite/winsvc is kept in the go.sum file. Because of the
+	// build tag, this dependency never ends up in the final lnd binary.
+	_ "github.com/btcsuite/btcd"
+)


### PR DESCRIPTION
This is a workaround to fix the windows build. Apparently there was a
change in go 1.16 in how the go.sum entries are calculated. Dependencies
that aren't directly depended on are stripped. Because we need this
indirect windows dependency for the integration tests, we add a
workaround that makes sure the entry is kept in go.sum.

