### PR TITLE
Allow setting password as default password

### DIFF
--- a/walletunlocker/service.go
+++ b/walletunlocker/service.go
@@ -652,8 +652,8 @@ func (u *UnlockerService) ChangePassword(ctx context.Context,
 
 // ValidatePassword assures the password meets all of our constraints.
 func ValidatePassword(password []byte) error {
-	// Passwords should have a length of at least 8 characters.
-	if len(password) < 8 {
+	// Passwords should have a length of at least 8 characters, but allow default password.
+	if len(password) < 8 && string(password) != string(lnwallet.DefaultPrivatePassphrase) && string(password) != string(lnwallet.DefaultPublicPassphrase) {
 		return errors.New("password must have at least 8 characters")
 	}
 


### PR DESCRIPTION
I have a testnet wallet that I wanted to enable `noseedbackup` for, however, since I already have the wallet created I needed to change my password to the default, this is not allowed currently.

This fixes this so you can change or set your wallet password to the default one, instead of having to create a whole new lightning wallet.