### PR TITLE
routing: return err on validation barrier failure of network update

### DIFF
--- a/discovery/gossiper.go
+++ b/discovery/gossiper.go
@@ -1031,7 +1031,8 @@ func (d *AuthenticatedGossiper) networkHandler() {
 					announcement.msg,
 				)
 				if err != nil {
-					if err != routing.ErrVBarrierShuttingDown {
+					if err != routing.ErrVBarrierShuttingDown &&
+						err != routing.ErrParentValidationFailed {
 						log.Warnf("unexpected error "+
 							"during validation "+
 							"barrier shutdown: %v",
@@ -1561,7 +1562,7 @@ func (d *AuthenticatedGossiper) processNetworkAnnouncement(
 				routing.ErrIgnored) {
 
 				log.Debug(err)
-			} else {
+			} else if err != routing.ErrVBarrierShuttingDown {
 				log.Error(err)
 			}
 
@@ -2042,7 +2043,7 @@ func (d *AuthenticatedGossiper) processNetworkAnnouncement(
 			if routing.IsError(err, routing.ErrOutdated,
 				routing.ErrIgnored) {
 				log.Debug(err)
-			} else {
+			} else if err != routing.ErrVBarrierShuttingDown {
 				d.rejectMtx.Lock()
 				d.recentRejects[msg.ShortChannelID.ToUint64()] = struct{}{}
 				d.rejectMtx.Unlock()

--- a/routing/router.go
+++ b/routing/router.go
@@ -1038,12 +1038,19 @@ func (r *ChannelRouter) networkHandler() {
 					update.msg,
 				)
 				if err != nil {
-					if err != ErrVBarrierShuttingDown &&
-						err != ErrParentValidationFailed {
+					switch err {
+					case ErrVBarrierShuttingDown:
+						update.err <- err
+					case ErrParentValidationFailed:
+						update.err <- newErrf(
+							ErrIgnored, err.Error(),
+						)
+					default:
 						log.Warnf("unexpected error "+
 							"during validation "+
 							"barrier shutdown: %v",
 							err)
+						update.err <- err
 					}
 					return
 				}


### PR DESCRIPTION
This ensures the waiting receiving channel always receives an error to prevent a deadlock when processing a network update that fails due to the validation barrier.

On commit d5aedbc:

```
1000 @ 0x43a285 0x44a38f 0xc42e86 0xc80fda 0xc8682d 0xc976c9 0x46fce1
github.com/lightningnetwork/lnd/routing.(*ChannelRouter).AddNode+0x245                      github.com/lightningnetwork/lnd/routing/router.go:2218
github.com/lightningnetwork/lnd/discovery.(*AuthenticatedGossiper).addNode+0x3b9            github.com/lightningnetwork/lnd/discovery/gossiper.go:1510
github.com/lightningnetwork/lnd/discovery.(*AuthenticatedGossiper).processNetworkAnnouncement+0x574c github.com/lightningnetwork/lnd/discovery/gossiper.go:1554
github.com/lightningnetwork/lnd/discovery.(*AuthenticatedGossiper).networkHandler.func1+0x24github.com/lightningnetwork/lnd/discovery/gossiper.go:1043
```

Fixes https://github.com/lightningnetwork/lnd/issues/5251.