### PR TITLE
Not right description for Peer/inbound field

### DIFF
--- a/lnrpc/rpc.proto
+++ b/lnrpc/rpc.proto
@@ -1504,7 +1504,7 @@ message Peer {
     // Satoshis received from this peer
     int64 sat_recv = 7;
 
-    // A channel is inbound if the counterparty initiated the channel
+    // The inbound is true if this peer was the initiator of the connection to us
     bool inbound = 8;
 
     // Ping time to this peer


### PR DESCRIPTION
By the `listpeers` command I see that if `inbound` === `true` then the TCP port of "address" firld is not 9735 and vice versa. Therefore, the mention of the channel may be a copy-paste error. If the initiator of the connection is the remote side, then its port will be one of the free ones in the remote system and not 9735. And if we are the initiator, the remote port will usually be 9735. Therefore, I suppose that my description is what was intended by the meaning.

#### Pull Request Checklist

- [ ] If this is your first time contributing, we recommend you read the [Code
  Contribution Guidelines](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md)
- [ ] All changes are Go version 1.12 compliant
- [ ] The code being submitted is commented according to [Code Documentation and Commenting](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#CodeDocumentation)
- [ ] For new code: Code is accompanied by tests which exercise both
  the positive and negative (error paths) conditions (if applicable)
- [ ] For bug fixes: Code is accompanied by new tests which trigger
  the bug being fixed to prevent regressions
- [ ] Any new logging statements use an appropriate subsystem and
  logging level
- [ ] Code has been formatted with `go fmt`
- [ ] Protobuf files (`lnrpc/**/*.proto`) have been formatted with
  `make rpc-format` and compiled with `make rpc`
- [ ] New configuration flags have been added to `sample-lnd.conf`
- [ ] For code and documentation: lines are wrapped at 80 characters
  (the tab character should be counted as 8 characters, not 4, as some IDEs do
  per default)
- [ ] Running `make check` does not fail any tests
- [ ] Running `go vet` does not report any issues
- [ ] Running `make lint` does not report any **new** issues that did not
  already exist
- [ ] All commits build properly and pass tests. Only in exceptional
  cases it can be justifiable to violate this condition. In that case, the
  reason should be stated in the commit message.
- [ ] Commits have a logical structure according to [Ideal Git Commit Structure](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#IdealGitCommitStructure)
