### PR TITLE
[anchors] cap value reserved for anchor fee bumping

### DIFF
--- a/lncfg/protocol_rpctest.go
+++ b/lncfg/protocol_rpctest.go
@@ -1,4 +1,4 @@
-// +build !rpctest
+// +build rpctest
 
 package lncfg
 
@@ -20,9 +20,9 @@ type ProtocolOptions struct {
 	// mini.
 	WumboChans bool `long:"wumbo-channels" description:"if set, then lnd will create and accept requests for channels larger chan 0.16 BTC"`
 
-	// NoAnchors should be set if we don't want to support opening or accepting
-	// channels having the anchor commitment type.
-	NoAnchors bool `long:"no-anchors" description:"disable support for anchor commitments"`
+	// Anchors enables anchor commitments.
+	// TODO(halseth): transition itests to anchors instead!
+	Anchors bool `long:"anchors" description:"enable support for anchor commitments"`
 }
 
 // Wumbo returns true if lnd should permit the creation and acceptance of wumbo
@@ -34,5 +34,5 @@ func (l *ProtocolOptions) Wumbo() bool {
 // NoAnchorCommitments returns true if we have disabled support for the anchor
 // commitment type.
 func (l *ProtocolOptions) NoAnchorCommitments() bool {
-	return l.NoAnchors
+	return !l.Anchors
 }

--- a/lnwallet/wallet.go
+++ b/lnwallet/wallet.go
@@ -39,6 +39,13 @@ const (
 	// TODO(halseth): update constant to target a specific commit size at
 	// set fee rate.
 	anchorChanReservedValue = btcutil.Amount(10_000)
+
+	// maxAnchorChanReservedValue is the maximum value we'll reserve for
+	// anchor channel fee bumping. We cap it at 10 times the per-channel
+	// amount such that nodes with a high number of channels don't have to
+	// keep around a very large amount for the unlikely scenario that they
+	// all close at the same time.
+	maxAnchorChanReservedValue = 10 * anchorChanReservedValue
 )
 
 var (
@@ -1000,6 +1007,9 @@ func (l *LightningWallet) CheckReservedValue(in []wire.OutPoint,
 
 	// We reserve a given amount for each anchor channel.
 	reserved := btcutil.Amount(numAnchorChans) * anchorChanReservedValue
+	if reserved > maxAnchorChanReservedValue {
+		reserved = maxAnchorChanReservedValue
+	}
 
 	if walletBalance < reserved {
 		walletLog.Debugf("Reserved value=%v above final "+

--- a/lnwallet/wallet.go
+++ b/lnwallet/wallet.go
@@ -604,9 +604,11 @@ func (l *LightningWallet) PsbtFundingVerify(pendingChanID [32]byte,
 	// If this commit type is an anchor channel we add that to our counter,
 	// but only if we are contributing funds to the channel. This is done
 	// to still allow incoming channels even though we have no UTXOs
-	// available, as in bootstrapping phases.
+	// available, as in bootstrapping phases. We only count public
+	// channels.
+	isPublic := pendingReservation.partialState.ChannelFlags&lnwire.FFAnnounceChannel != 0
 	if pendingReservation.partialState.ChanType.HasAnchors() &&
-		intent.LocalFundingAmt() > 0 {
+		intent.LocalFundingAmt() > 0 && isPublic {
 		numAnchors++
 	}
 
@@ -819,9 +821,11 @@ func (l *LightningWallet) handleFundingReserveRequest(req *InitFundingReserveMsg
 	// If this commit type is an anchor channel we add that to our counter,
 	// but only if we are contributing funds to the channel. This is done
 	// to still allow incoming channels even though we have no UTXOs
-	// available, as in bootstrapping phases.
+	// available, as in bootstrapping phases. We only count public
+	// channels.
+	isPublic := req.Flags&lnwire.FFAnnounceChannel != 0
 	if req.CommitType == CommitmentTypeAnchorsZeroFeeHtlcTx &&
-		fundingIntent.LocalFundingAmt() > 0 {
+		fundingIntent.LocalFundingAmt() > 0 && isPublic {
 		numAnchors++
 	}
 
@@ -888,8 +892,8 @@ func (l *LightningWallet) handleFundingReserveRequest(req *InitFundingReserveMsg
 	req.err <- nil
 }
 
-// currentNumAnchorChans returns the current number of anchor channels the
-// wallet should be ready to fee bump if needed.
+// currentNumAnchorChans returns the current number of non-private anchor
+// channels the wallet should be ready to fee bump if needed.
 func (l *LightningWallet) currentNumAnchorChans() (int, error) {
 	// Count all anchor channels that are open or pending
 	// open, or waiting close.
@@ -899,10 +903,22 @@ func (l *LightningWallet) currentNumAnchorChans() (int, error) {
 	}
 
 	var numAnchors int
-	for _, c := range chans {
+	cntChannel := func(c *channeldb.OpenChannel) {
+		// We skip private channels, as we assume they won't be used
+		// for routing.
+		if c.ChannelFlags&lnwire.FFAnnounceChannel == 0 {
+			return
+		}
+
+		// Count anchor channels.
 		if c.ChanType.HasAnchors() {
 			numAnchors++
 		}
+
+	}
+
+	for _, c := range chans {
+		cntChannel(c)
 	}
 
 	// We also count pending close channels.
@@ -925,9 +941,7 @@ func (l *LightningWallet) currentNumAnchorChans() (int, error) {
 			continue
 		}
 
-		if c.ChanType.HasAnchors() {
-			numAnchors++
-		}
+		cntChannel(c)
 	}
 
 	return numAnchors, nil


### PR DESCRIPTION
We cap the maximum value we'll reserve for anchor channel fee bumping at
10 times the per-channel amount such that nodes with a high number of
channels don't have to keep around a very large amount for the unlikely
scanario that they all close at the same time.
