### PR TITLE
htlcswitch: set sourceRef when resolving packets through interceptor

### DIFF
--- a/htlcswitch/interceptable_switch.go
+++ b/htlcswitch/interceptable_switch.go
@@ -179,6 +179,7 @@ func (f *interceptedForward) resolve(message lnwire.Message) error {
 		circuit:        f.packet.circuit,
 		htlc:           message,
 		obfuscator:     f.packet.obfuscator,
+		sourceRef:      f.packet.sourceRef,
 	}
 	return f.htlcSwitch.mailOrchestrator.Deliver(pkt.incomingChanID, pkt)
 }


### PR DESCRIPTION
Fixes https://github.com/lightningnetwork/lnd/issues/5115

The problem was several layers removed from the fix. The link decides to
clean up a `fwdPkg` only if it's completed, otherwise it renotifies the
HTLCs. A package is only set to complete if it's `addAck` and
`settleFail` filters are full. For forwarded HTLCs, the `addAck` was
never being set so it would never be considered complete under this
criteria.

`addAck` is set for an HTLC when signing the next commitment TX in the
`LightningChannel`. The path for this is:
* `LightningChannel#SettleHtlc` adds the HTLC to `localUpdates`
* `LightningChannel#SignNextCommitment` builds the `ackAddRef` for all
updates with `SourceRef != nil`.
* `LightningChannel#SignNextCommitment` then passes the list of
`ackAddRef` to `OpenChannel#AppendRemoteCommitChain` to persist the new
acks in the filter

Since `SourceRef` was nil for interceptor packages, `SignNextCommitment`
ignored it and the ack was never persisted.
