### PR TITLE
itest flakes: fix multiple issues around router subsystem being out of sync

### DIFF
--- a/lntest/itest/log_error_whitelist.txt
+++ b/lntest/itest/log_error_whitelist.txt
@@ -155,6 +155,7 @@
 <time> [ERR] NTFN: unable to get hash from block with height 790
 <time> [ERR] NTFN: unable to get missed blocks: starting height <height> is greater than ending height <height>
 <time> [ERR] NTFN: Unable to rewind chain from height <height> to height <height>: unable to find blockhash for disconnected height=<height>: -1: Block number out of range
+<time> [ERR] NTFN: Unable to rewind chain from height <height> to height <height>: unable to find blockhash for disconnected height=<height>: -8: Block height out of range
 <time> [ERR] NTNF: unable to get hash from block with height <height>
 <time> [ERR] PEER: Allowed test error from <ip> (inbound): ReadMessage: unhandled command [sendaddrv2]
 <time> [ERR] PEER: resend failed: unable to fetch channel sync messages for peer <hex>@<ip>: unable to find closed channel summary

--- a/lntest/itest/log_substitutions.txt
+++ b/lntest/itest/log_substitutions.txt
@@ -10,7 +10,7 @@ s/HTLC ID = [[:digit:]]+/HTLC ID = <id>/g
 s/height=[[:digit:]]+/height=<height>/g
 s/collecting result for shard [[:digit:]]+/collecting result for shard <number>/g
 s/sending attempt [[:digit:]]+/sending attempt <number>/g
-s/Unable to rewind chain from height [[:digit:]]+ to height [[:digit:]]+/Unable to rewind chain from height <height> to height <height>/g
+s/Unable to rewind chain from height [[:digit:]]+ to height -?[[:digit:]]+/Unable to rewind chain from height <height> to height <height>/g
 s/NTFN: unable to get missed blocks: starting height [[:digit:]]+ is greater than ending height [[:digit:]]+/NTFN: unable to get missed blocks: starting height <height> is greater than ending height <height>/g
 s/BTCN: Broadcast attempt failed: rejected by <ip>: replacement transaction <hex> has an insufficient fee rate: needs more than [[:digit:]]+, has [[:digit:]]+/BTCN: Broadcast attempt failed: rejected by <ip>: replacement transaction <hex> has an insufficient fee rate: needs more than <amt>, has <amt>/g
 s/pid=[[:digit:]]+/pid=<pid>/g

--- a/routing/router.go
+++ b/routing/router.go
@@ -2479,6 +2479,13 @@ func (r *ChannelRouter) CurrentBlockHeight() (uint32, error) {
 	return uint32(height), err
 }
 
+// SyncedHeight returns the block height to which the router subsystem currently
+// is synced to. This can differ from the above chain height if the goroutine
+// responsible for processing the blocks isn't yet up to speed.
+func (r *ChannelRouter) SyncedHeight() uint32 {
+	return atomic.LoadUint32(&r.bestHeight)
+}
+
 // GetChannelByID return the channel by the channel id.
 //
 // NOTE: This method is part of the ChannelGraphSource interface.

--- a/routing/router.go
+++ b/routing/router.go
@@ -563,6 +563,14 @@ func (r *ChannelRouter) Start() error {
 			}
 		}
 
+		// The graph pruning might have taken a while and there could be
+		// new blocks available.
+		bestHash, bestHeight, err = r.cfg.Chain.GetBestBlock()
+		if err != nil {
+			return err
+		}
+		r.bestHeight = uint32(bestHeight)
+
 		// Before we begin normal operation of the router, we first need
 		// to synchronize the channel graph to the latest state of the
 		// UTXO set.


### PR DESCRIPTION
This PR makes sure the router subsystem is always in sync with the wallet during our itests by adding a condition to the `synced_to_graph` flag in the `GetInfo` RPC.
It also fixes a small issue that #5246 seems to have introduced (based upon a comment I made) that caused the router to sometimes miss the first few blocks during the itests and then error out continuously with `out of order block: expecting height=1, got height=XXX`.