### PR TITLE
rpc: fix policy order for GetNodeInfo

### DIFF
--- a/rpcserver.go
+++ b/rpcserver.go
@@ -5155,6 +5155,12 @@ func (r *rpcServer) DescribeGraph(ctx context.Context,
 func marshalDbEdge(edgeInfo *channeldb.ChannelEdgeInfo,
 	c1, c2 *channeldb.ChannelEdgePolicy) *lnrpc.ChannelEdge {
 
+	// Make sure the policies match the node they belong to. c1 should point
+	// to the policy for NodeKey1, and c2 for NodeKey2.
+	if c1.ChannelFlags&lnwire.ChanUpdateDirection == 1 {
+		c2, c1 = c1, c2
+	}
+
 	// Order the edges by increasing pubkey.
 	if bytes.Compare(edgeInfo.NodeKey2Bytes[:],
 		edgeInfo.NodeKey1Bytes[:]) < 0 {


### PR DESCRIPTION
GetNodeInfo retrieves the policies for every edge the node belongs to. When these policies are retrieved from the database, they're returned in the following order: the first policy is the outgoing policy from the node, and the second is the incoming policy to the node. This ordering is not consistent with the ordering we have within our other RPCs like GetChanInfo and DescribeGraph, where policies are sorted based on the smaller public key of the nodes within an edge.

Fixes https://github.com/lightningnetwork/lnd/issues/3426.