### PR TITLE
build/version: bump to v0.13.0-beta.rc2

### DIFF
--- a/build/version.go
+++ b/build/version.go
@@ -48,7 +48,7 @@ const (
 
 	// AppPreRelease MUST only contain characters from semanticAlphabet
 	// per the semantic versioning spec.
-	AppPreRelease = "beta.rc1"
+	AppPreRelease = "beta.rc2"
 )
 
 func init() {


### PR DESCRIPTION
Includes:
 - #5260 
 - #5295 

Also fixes a bug in the release script caused by the `v0.13.0-beta.rc1` and `kvdb/v1.0.0` tags being on the same commit. This caused the release binaries to be compiled with `kvdb/v1.0.0` as the version, which fails to pass `verify-install.sh`.

`v0.13.0-beta.rc1` has been pulled.