### PR TITLE
rpcserver: add nil check to policy ordering

### DIFF
--- a/rpcserver.go
+++ b/rpcserver.go
@@ -5166,13 +5166,8 @@ func marshalDbEdge(edgeInfo *channeldb.ChannelEdgeInfo,
 
 	// Make sure the policies match the node they belong to. c1 should point
 	// to the policy for NodeKey1, and c2 for NodeKey2.
-	if c1.ChannelFlags&lnwire.ChanUpdateDirection == 1 {
-		c2, c1 = c1, c2
-	}
-
-	// Order the edges by increasing pubkey.
-	if bytes.Compare(edgeInfo.NodeKey2Bytes[:],
-		edgeInfo.NodeKey1Bytes[:]) < 0 {
+	if c1 != nil && c1.ChannelFlags&lnwire.ChanUpdateDirection == 1 ||
+		c2 != nil && c2.ChannelFlags&lnwire.ChanUpdateDirection == 0 {
 
 		c2, c1 = c1, c2
 	}


### PR DESCRIPTION
Fixes #5301.
This was introduced with #5295. Since either policies can be nil, we
need to always check that first.

I'm not sure if this is sufficient to still get the correct ordering. Do we perhaps also need to check the `ChanUpdateDirection` of `c2`, just in case `c1` is nil?


