### PR TITLE
channeldb: read HtlcAttemptInfo session key raw bytes

### DIFF
--- a/channeldb/duplicate_payments.go
+++ b/channeldb/duplicate_payments.go
@@ -181,7 +181,7 @@ func fetchDuplicatePayment(bucket kvdb.RBucket) (*MPPayment, error) {
 			HTLCAttemptInfo: HTLCAttemptInfo{
 				AttemptID:  attempt.attemptID,
 				Route:      attempt.route,
-				SessionKey: attempt.sessionKey,
+				sessionKey: attempt.sessionKey,
 			},
 		}
 

--- a/channeldb/duplicate_payments.go
+++ b/channeldb/duplicate_payments.go
@@ -53,7 +53,7 @@ type duplicateHTLCAttemptInfo struct {
 	attemptID uint64
 
 	// sessionKey is the ephemeral key used for this attempt.
-	sessionKey *btcec.PrivateKey
+	sessionKey [btcec.PrivKeyBytesLen]byte
 
 	// route is the route attempted to send the HTLC.
 	route route.Route

--- a/channeldb/mp_payment.go
+++ b/channeldb/mp_payment.go
@@ -21,8 +21,8 @@ type HTLCAttemptInfo struct {
 	// AttemptID is the unique ID used for this attempt.
 	AttemptID uint64
 
-	// SessionKey is the ephemeral key used for this attempt.
-	SessionKey *btcec.PrivateKey
+	// sessionKey is the ephemeral key used for this attempt.
+	sessionKey *btcec.PrivateKey
 
 	// Route is the route attempted to send the HTLC.
 	Route route.Route
@@ -36,6 +36,25 @@ type HTLCAttemptInfo struct {
 	// in which the payment's PaymentHash in the PaymentCreationInfo should
 	// be used.
 	Hash *lntypes.Hash
+}
+
+// NewHtlcAttemptInfo creates a htlc attempt.
+func NewHtlcAttemptInfo(attemptID uint64, sessionKey *btcec.PrivateKey,
+	route route.Route, attemptTime time.Time,
+	hash *lntypes.Hash) *HTLCAttemptInfo {
+
+	return &HTLCAttemptInfo{
+		AttemptID:   attemptID,
+		sessionKey:  sessionKey,
+		Route:       route,
+		AttemptTime: attemptTime,
+		Hash:        hash,
+	}
+}
+
+// SessionKey returns the ephemeral key used for a htlc attempt.
+func (h *HTLCAttemptInfo) SessionKey() *btcec.PrivateKey {
+	return h.sessionKey
 }
 
 // HTLCAttempt contains information about a specific HTLC attempt for a given

--- a/channeldb/mp_payment_test.go
+++ b/channeldb/mp_payment_test.go
@@ -1,0 +1,27 @@
+package channeldb
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestLazySessionKeyDeserialize tests that we can read htlc attempt session
+// keys that were previously serialized as a private key as raw bytes.
+func TestLazySessionKeyDeserialize(t *testing.T) {
+	var b bytes.Buffer
+
+	// Serialize as a private key.
+	err := WriteElements(&b, priv)
+	require.NoError(t, err)
+
+	// Deserialize into [btcec.PrivKeyBytesLen]byte.
+	attempt := HTLCAttemptInfo{}
+	err = ReadElements(&b, &attempt.sessionKey)
+	require.NoError(t, err)
+	require.Zero(t, b.Len())
+
+	sessionKey := attempt.SessionKey()
+	require.Equal(t, priv, sessionKey)
+}

--- a/channeldb/payment_control_test.go
+++ b/channeldb/payment_control_test.go
@@ -45,7 +45,7 @@ func genInfo() (*PaymentCreationInfo, *HTLCAttemptInfo,
 		},
 		&HTLCAttemptInfo{
 			AttemptID:  0,
-			SessionKey: priv,
+			sessionKey: priv,
 			Route:      *testRoute.Copy(),
 		}, preimage, nil
 }

--- a/channeldb/payment_control_test.go
+++ b/channeldb/payment_control_test.go
@@ -37,17 +37,15 @@ func genInfo() (*PaymentCreationInfo, *HTLCAttemptInfo,
 	}
 
 	rhash := sha256.Sum256(preimage[:])
+	attempt := NewHtlcAttemptInfo(
+		0, priv, *testRoute.Copy(), time.Time{}, nil,
+	)
 	return &PaymentCreationInfo{
-			PaymentIdentifier: rhash,
-			Value:             testRoute.ReceiverAmt(),
-			CreationTime:      time.Unix(time.Now().Unix(), 0),
-			PaymentRequest:    []byte("hola"),
-		},
-		&HTLCAttemptInfo{
-			AttemptID:  0,
-			sessionKey: priv,
-			Route:      *testRoute.Copy(),
-		}, preimage, nil
+		PaymentIdentifier: rhash,
+		Value:             testRoute.ReceiverAmt(),
+		CreationTime:      time.Unix(time.Now().Unix(), 0),
+		PaymentRequest:    []byte("hola"),
+	}, attempt, preimage, nil
 }
 
 // TestPaymentControlSwitchFail checks that payment status returns to Failed

--- a/channeldb/payments.go
+++ b/channeldb/payments.go
@@ -919,7 +919,7 @@ func deserializePaymentCreationInfo(r io.Reader) (*PaymentCreationInfo, error) {
 }
 
 func serializeHTLCAttemptInfo(w io.Writer, a *HTLCAttemptInfo) error {
-	if err := WriteElements(w, a.SessionKey); err != nil {
+	if err := WriteElements(w, a.sessionKey); err != nil {
 		return err
 	}
 
@@ -945,7 +945,7 @@ func serializeHTLCAttemptInfo(w io.Writer, a *HTLCAttemptInfo) error {
 
 func deserializeHTLCAttemptInfo(r io.Reader) (*HTLCAttemptInfo, error) {
 	a := &HTLCAttemptInfo{}
-	err := ReadElements(r, &a.SessionKey)
+	err := ReadElements(r, &a.sessionKey)
 	if err != nil {
 		return nil, err
 	}

--- a/channeldb/payments_test.go
+++ b/channeldb/payments_test.go
@@ -70,7 +70,7 @@ func makeFakeInfo() (*PaymentCreationInfo, *HTLCAttemptInfo) {
 
 	a := &HTLCAttemptInfo{
 		AttemptID:   44,
-		SessionKey:  priv,
+		sessionKey:  priv,
 		Route:       testRoute,
 		AttemptTime: time.Unix(100, 0),
 		Hash:        &hash,
@@ -124,8 +124,6 @@ func TestSentPaymentSerialization(t *testing.T) {
 	s.Route = route.Route{}
 
 	if !reflect.DeepEqual(s, newWireInfo) {
-		s.SessionKey.Curve = nil
-		newWireInfo.SessionKey.Curve = nil
 		t.Fatalf("Payments do not match after "+
 			"serialization/deserialization %v vs %v",
 			spew.Sdump(s), spew.Sdump(newWireInfo),

--- a/channeldb/payments_test.go
+++ b/channeldb/payments_test.go
@@ -68,13 +68,10 @@ func makeFakeInfo() (*PaymentCreationInfo, *HTLCAttemptInfo) {
 		PaymentRequest: []byte(""),
 	}
 
-	a := &HTLCAttemptInfo{
-		AttemptID:   44,
-		sessionKey:  priv,
-		Route:       testRoute,
-		AttemptTime: time.Unix(100, 0),
-		Hash:        &hash,
-	}
+	a := NewHtlcAttemptInfo(
+		44, priv, testRoute, time.Unix(100, 0), &hash,
+	)
+
 	return c, a
 }
 

--- a/channeldb/payments_test.go
+++ b/channeldb/payments_test.go
@@ -120,6 +120,10 @@ func TestSentPaymentSerialization(t *testing.T) {
 	newWireInfo.Route = route.Route{}
 	s.Route = route.Route{}
 
+	// Call session key method to set our cached session key so we can use
+	// DeepEqual, and assert that our key equals the original key.
+	require.Equal(t, s.cachedSessionKey, newWireInfo.SessionKey())
+
 	if !reflect.DeepEqual(s, newWireInfo) {
 		t.Fatalf("Payments do not match after "+
 			"serialization/deserialization %v vs %v",

--- a/routing/control_tower_test.go
+++ b/routing/control_tower_test.go
@@ -331,11 +331,9 @@ func genInfo() (*channeldb.PaymentCreationInfo, *channeldb.HTLCAttemptInfo,
 			CreationTime:      time.Unix(time.Now().Unix(), 0),
 			PaymentRequest:    []byte("hola"),
 		},
-		&channeldb.HTLCAttemptInfo{
-			AttemptID:  1,
-			SessionKey: priv,
-			Route:      testRoute,
-		}, preimage, nil
+		channeldb.NewHtlcAttemptInfo(
+			1, priv, testRoute, time.Time{}, nil,
+		), preimage, nil
 }
 
 func genPreimage() ([32]byte, error) {

--- a/routing/payment_lifecycle.go
+++ b/routing/payment_lifecycle.go
@@ -499,7 +499,7 @@ func (p *shardHandler) collectResult(attempt *channeldb.HTLCAttemptInfo) (
 
 	// Regenerate the circuit for this attempt.
 	_, circuit, err := generateSphinxPacket(
-		&attempt.Route, hash[:], attempt.SessionKey,
+		&attempt.Route, hash[:], attempt.SessionKey(),
 	)
 	if err != nil {
 		return nil, err
@@ -677,15 +677,11 @@ func (p *shardHandler) createNewPaymentAttempt(rt *route.Route, lastShard bool) 
 		rt.Hops[0].ChannelID,
 	)
 
-	// We now have all the information needed to populate
-	// the current attempt information.
-	attempt := &channeldb.HTLCAttemptInfo{
-		AttemptID:   attemptID,
-		AttemptTime: p.router.cfg.Clock.Now(),
-		SessionKey:  sessionKey,
-		Route:       *rt,
-		Hash:        &hash,
-	}
+	// We now have all the information needed to populate the current
+	// attempt information.
+	attempt := channeldb.NewHtlcAttemptInfo(
+		attemptID, sessionKey, *rt, p.router.cfg.Clock.Now(), &hash,
+	)
 
 	return firstHop, htlcAdd, attempt, nil
 }


### PR DESCRIPTION
When running on a node with a lot of payments (+900k), we see a significant performance slowdown from the ec ops in `btcec.PrivKeyFromBytes` used to deserialize the session key for the attempt. 

Part of profile for `ListPayments` (can't take full screenshot at high enough res): 
![Screenshot 2021-05-17 at 14 27 51](https://user-images.githubusercontent.com/42311294/118488614-34ef5700-b71c-11eb-80de-45a3a35ed024.png)


We don't actually need this value after it's been read off disk, except for when we resume an in-flight payment and [regenerate its sphinx packet](https://github.com/lightningnetwork/lnd/blob/d771ed761678f8074bd396db1d77c7b7b859abdc/routing/payment_lifecycle.go#L501) so we can lazily read the raw bytes off disk, and perform the expensive EC ops only when required. Since the serialized session key is just `[32]byte`, we can just swap out the field in the `HtlcAttemptInfo` without a migration. 

PR is can probably be squashed down to 1 commit after review, thought it was more readable this way. 