### PR TITLE
breacharbiter_test: select on quit chan on publication

### DIFF
--- a/breacharbiter_test.go
+++ b/breacharbiter_test.go
@@ -2089,7 +2089,7 @@ func assertBrarCleanup(t *testing.T, brar *breachArbiter,
 
 		return fmt.Errorf("channel %v not closed", chanPoint)
 
-	}, time.Second)
+	}, 5*time.Second)
 	if err != nil {
 		t.Fatalf(err.Error())
 	}

--- a/breacharbiter_test.go
+++ b/breacharbiter_test.go
@@ -1604,7 +1604,12 @@ func testBreachSpends(t *testing.T, test breachTest) {
 		publMtx.Lock()
 		err := publErr
 		publMtx.Unlock()
-		publTx <- tx
+
+		select {
+		case publTx <- tx:
+		case <-brar.quit:
+			return fmt.Errorf("brar quit")
+		}
 
 		return err
 	}
@@ -1817,7 +1822,11 @@ func TestBreachDelayedJusticeConfirmation(t *testing.T) {
 
 	// Make PublishTransaction always return succeed.
 	brar.cfg.PublishTransaction = func(tx *wire.MsgTx, _ string) error {
-		publTx <- tx
+		select {
+		case publTx <- tx:
+		case <-brar.quit:
+			return fmt.Errorf("brar quit")
+		}
 		return nil
 	}
 


### PR DESCRIPTION
Since publication would deadlock on publishing the tx in case the test
had failed we also select on the brar quit channel.
