### PR TITLE
lncfg: match address format restrictions with tor

### DIFF
--- a/docs/release-notes/release-notes-0.14.0.md
+++ b/docs/release-notes/release-notes-0.14.0.md
@@ -147,6 +147,8 @@ you.
 
 ## Misc
 
+* [Improved feedback from malformed tor address formats](https://github.com/lightningnetwork/lnd/pull/5327).
+
 * The direct use of certain syscalls in packages such as `bbolt` or `lnd`'s own
   `healthcheck` package made it impossible to import `lnd` code as a library
   into projects that are compiled to WASM binaries. [That problem was fixed by

--- a/lncfg/address.go
+++ b/lncfg/address.go
@@ -245,12 +245,15 @@ func ParseAddressString(strAddress string, defaultPort string,
 		// identifiable error.
 		addr, err := tcpResolver("tcp", addrWithPort)
 		if err != nil {
-			torErrStr := "tor host is unreachable"
-			if strings.Contains(err.Error(), torErrStr) {
-				return net.ResolveTCPAddr("tcp", addrWithPort)
-			}
+			switch err.Error() {
+			case "tor host is unreachable",
+				"tor general error",
+				"tor general failure":
 
-			return nil, err
+				return net.ResolveTCPAddr("tcp", addrWithPort)
+			default:
+				return nil, err
+			}
 		}
 
 		return addr, nil


### PR DESCRIPTION
This pr fixes the address format restriction issue (when using tor), outlined in #5318 .
It gives direct feedback to the user instead of returning a general failure message.

Fixes #5318 