### PR TITLE
Add Prometheus flags to sample-lnd.conf

### DIFF
--- a/sample-lnd.conf
+++ b/sample-lnd.conf
@@ -406,6 +406,14 @@
 ; can be tuned to save bandwidth for light clients or routing nodes. (default: 3)
 ; numgraphsyncpeers=9
 
+; If true, lnd will start the Prometheus exporter. Prometheus flags are 
+; behind a build/compile flag and are not available by default. lnd must be built 
+; with the monitoring tag; `make && make install tags=monitoring` to activate them.
+; prometheus.enable=true
+
+; Specify the interface to listen on for Prometheus connections.
+; prometheus.listen=0.0.0.0:8989
+
 ; The alias your node will use, which can be up to 32 UTF-8 characters in
 ; length.
 ; alias=My Lightning ☇


### PR DESCRIPTION
As requested by issue #5323. This pr adds both Prometheus flags to sample-lnd.conf.
