### PR TITLE
discovery: demote err log to debug from processZombieUpdate

### DIFF
--- a/discovery/gossiper.go
+++ b/discovery/gossiper.go
@@ -1889,7 +1889,7 @@ func (d *AuthenticatedGossiper) processNetworkAnnouncement(
 		case channeldb.ErrZombieEdge:
 			err = d.processZombieUpdate(chanInfo, msg)
 			if err != nil {
-				log.Warn(err)
+				log.Debug(err)
 				nMsg.err <- err
 				return nil, false
 			}


### PR DESCRIPTION
This log can be "spammy" while nodes throughout the network have yet to upgrade to v0.13.0-beta, which includes several enhancements to prevent the broadcast of zombie edges/updates.