### PR TITLE
config+chainreg: fix default rpc params for signet bitcoind

### DIFF
--- a/chainreg/chainregistry.go
+++ b/chainreg/chainregistry.go
@@ -378,8 +378,10 @@ func NewChainControl(cfg *Config, blockCache *blockcache.BlockCache) (
 			rpcPort -= 2
 			bitcoindHost = fmt.Sprintf("%v:%d",
 				bitcoindMode.RPCHost, rpcPort)
-			if (cfg.Bitcoin.Active && cfg.Bitcoin.RegTest) ||
+			if (cfg.Bitcoin.Active &&
+				(cfg.Bitcoin.RegTest || cfg.Bitcoin.SigNet)) ||
 				(cfg.Litecoin.Active && cfg.Litecoin.RegTest) {
+
 				conn, err := net.Dial("tcp", bitcoindHost)
 				if err != nil || conn == nil {
 					switch {

--- a/config.go
+++ b/config.go
@@ -1756,7 +1756,7 @@ func extractBitcoindRPCParams(networkName string,
 	switch networkName {
 	case "mainnet":
 		chainDir = ""
-	case "regtest", "testnet3":
+	case "regtest", "testnet3", "signet":
 		chainDir = networkName
 	default:
 		return "", "", "", "", fmt.Errorf("unexpected networkname %v", networkName)


### PR DESCRIPTION
This addresses the issue pointed out in https://github.com/lightningnetwork/lnd/pull/5025#discussion_r641044138.