### PR TITLE
GitHub: remove build cache for release builder

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -28,17 +28,6 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: go cache
-        uses: actions/cache@v1
-        with:
-          path: /home/runner/work/go
-          key: lnd-${{ runner.os }}-go-${{ env.GO_VERSION }}-${{ github.job }}-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            lnd-${{ runner.os }}-go-${{ env.GO_VERSION }}-${{ github.job }}-${{ hashFiles('**/go.sum') }}
-            lnd-${{ runner.os }}-go-${{ env.GO_VERSION }}-${{ github.job }}-
-            lnd-${{ runner.os }}-go-${{ env.GO_VERSION }}-
-            lnd-${{ runner.os }}-go-
-
       - name: setup go ${{ env.GO_VERSION }}
         uses: actions/setup-go@v2
         with:


### PR DESCRIPTION
The golang build cache seems to only grow over time and is now causing
disk space issues on the release builder. Since the release build has to
build for targets that aren't built during other GH actions and our
releases are too far apart to be hitting the cache anyway we suspect the
cache doesn't actually help that much.
Removing it might mean the build takes a bit longer but at least won't
cause any problems with full virtual disks anymore.

