### PR TITLE
itest: include compressed btcd backend logs from logrotate

### DIFF
--- a/docs/release-notes/release-notes-0.14.0.md
+++ b/docs/release-notes/release-notes-0.14.0.md
@@ -161,6 +161,11 @@ you.
   when encoding/decoding messages. Such that most of the heap escapes are fixed,
   resulting in less memory being used when running `lnd`.
 
+## Log system
+
+* [Save compressed log files from logrorate during 
+  itest](https://github.com/lightningnetwork/lnd/pull/5354).
+
 ## Bug Fixes
 
 A bug has been fixed that would cause `lnd` to [try to bootstrap using the


### PR DESCRIPTION
This pr adds the compressed log files (.gz) from logrorate. Right now, only the uncompressed logs are saved. Partly solves #4584. 
Second part will be addressed in a separate pr.