### PR TITLE
rpcserver: log connections to transaction subscription stream

### DIFF
--- a/rpcserver.go
+++ b/rpcserver.go
@@ -5015,6 +5015,7 @@ func (r *rpcServer) SubscribeTransactions(req *lnrpc.GetTransactionsRequest,
 		return err
 	}
 	defer txClient.Cancel()
+	rpcsLog.Infof("New transaction subscription")
 
 	for {
 		select {
@@ -5056,6 +5057,7 @@ func (r *rpcServer) SubscribeTransactions(req *lnrpc.GetTransactionsRequest,
 			}
 
 		case <-updateStream.Context().Done():
+			rpcsLog.Infof("Cancelling transaction subscription")
 			return updateStream.Context().Err()
 
 		case <-r.quit:


### PR DESCRIPTION
A quick fix for #4968. An alternative solution would be to create an distinct interface for SubscribeTransactions so we could use a dedicated log (TXN:) instance.
Here, the log a message will be `[INF] RPCS: New transaction subscription client`.


Fixes #4968.