### PR TITLE
itest: use require inside net.SendCoins

### DIFF
--- a/lntest/harness.go
+++ b/lntest/harness.go
@@ -12,6 +12,7 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
+	"testing"
 	"time"
 
 	"github.com/btcsuite/btcd/chaincfg"
@@ -26,6 +27,7 @@ import (
 	"github.com/lightningnetwork/lnd/lntest/wait"
 	"github.com/lightningnetwork/lnd/lnwallet/chainfee"
 	"github.com/lightningnetwork/lnd/lnwire"
+	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc/grpclog"
 )
 
@@ -144,7 +146,9 @@ func (f *fakeLogger) Println(args ...interface{})               {}
 // rpc clients capable of communicating with the initial seeder nodes are
 // created. Nodes are initialized with the given extra command line flags, which
 // should be formatted properly - "--arg=value".
-func (n *NetworkHarness) SetUp(testCase string, lndArgs []string) error {
+func (n *NetworkHarness) SetUp(t *testing.T,
+	testCase string, lndArgs []string) error {
+
 	// Swap out grpc's default logger with out fake logger which drops the
 	// statements on the floor.
 	grpclog.SetLogger(&fakeLogger{})
@@ -153,32 +157,16 @@ func (n *NetworkHarness) SetUp(testCase string, lndArgs []string) error {
 	// Start the initial seeder nodes within the test network, then connect
 	// their respective RPC clients.
 	var wg sync.WaitGroup
-	errChan := make(chan error, 2)
 	wg.Add(2)
 	go func() {
 		defer wg.Done()
-		node, err := n.NewNode("Alice", lndArgs)
-		if err != nil {
-			errChan <- err
-			return
-		}
-		n.Alice = node
+		n.Alice = n.NewNode(t, "Alice", lndArgs)
 	}()
 	go func() {
 		defer wg.Done()
-		node, err := n.NewNode("Bob", lndArgs)
-		if err != nil {
-			errChan <- err
-			return
-		}
-		n.Bob = node
+		n.Bob = n.NewNode(t, "Bob", lndArgs)
 	}()
 	wg.Wait()
-	select {
-	case err := <-errChan:
-		return err
-	default:
-	}
 
 	// First, make a connection between the two nodes. This will wait until
 	// both nodes are fully started since the Connect RPC is guarded behind
@@ -346,10 +334,15 @@ func (n *NetworkHarness) NewNodeEtcd(name string, etcdCfg *etcd.Config,
 // NewNode fully initializes a returns a new HarnessNode bound to the
 // current instance of the network harness. The created node is running, but
 // not yet connected to other nodes within the network.
-func (n *NetworkHarness) NewNode(name string, extraArgs []string) (*HarnessNode,
-	error) {
+func (n *NetworkHarness) NewNode(t *testing.T,
+	name string, extraArgs []string) *HarnessNode {
 
-	return n.newNode(name, extraArgs, false, nil, n.embeddedEtcd, true)
+	node, err := n.newNode(
+		name, extraArgs, false, nil, n.embeddedEtcd, true,
+	)
+	require.NoErrorf(t, err, "unable to create new node for %s", name)
+
+	return node
 }
 
 // NewNodeWithSeed fully initializes a new HarnessNode after creating a fresh

--- a/lntest/harness.go
+++ b/lntest/harness.go
@@ -1351,35 +1351,44 @@ func (n *NetworkHarness) DumpLogs(node *HarnessNode) (string, error) {
 // SendCoins attempts to send amt satoshis from the internal mining node to the
 // targeted lightning node using a P2WKH address. 6 blocks are mined after in
 // order to confirm the transaction.
-func (n *NetworkHarness) SendCoins(ctx context.Context, amt btcutil.Amount,
-	target *HarnessNode) error {
+func (n *NetworkHarness) SendCoins(ctx context.Context, t *testing.T,
+	amt btcutil.Amount, target *HarnessNode) {
 
-	return n.sendCoins(
+	err := n.sendCoins(
 		ctx, amt, target, lnrpc.AddressType_WITNESS_PUBKEY_HASH,
 		true,
 	)
+	require.NoErrorf(t, err, "unable to send coins for %s", target.Cfg.Name)
 }
 
 // SendCoinsUnconfirmed sends coins from the internal mining node to the target
 // lightning node using a P2WPKH address. No blocks are mined after, so the
 // transaction remains unconfirmed.
 func (n *NetworkHarness) SendCoinsUnconfirmed(ctx context.Context,
-	amt btcutil.Amount, target *HarnessNode) error {
+	t *testing.T, amt btcutil.Amount, target *HarnessNode) {
 
-	return n.sendCoins(
+	err := n.sendCoins(
 		ctx, amt, target, lnrpc.AddressType_WITNESS_PUBKEY_HASH,
 		false,
+	)
+	require.NoErrorf(
+		t, err, "unable to send unconfirmed coins for %s",
+		target.Cfg.Name,
 	)
 }
 
 // SendCoinsNP2WKH attempts to send amt satoshis from the internal mining node
 // to the targeted lightning node using a NP2WKH address.
 func (n *NetworkHarness) SendCoinsNP2WKH(ctx context.Context,
-	amt btcutil.Amount, target *HarnessNode) error {
+	t *testing.T, amt btcutil.Amount, target *HarnessNode) {
 
-	return n.sendCoins(
+	err := n.sendCoins(
 		ctx, amt, target, lnrpc.AddressType_NESTED_PUBKEY_HASH,
 		true,
+	)
+	require.NoErrorf(
+		t, err, "unable to send NP2WKH coins for %s",
+		target.Cfg.Name,
 	)
 }
 

--- a/lntest/itest/lnd_channel_backup_test.go
+++ b/lntest/itest/lnd_channel_backup_test.go
@@ -849,15 +849,10 @@ func testChanRestoreScenario(t *harnessTest, net *lntest.NetworkHarness,
 	// Now that our new nodes are created, we'll give them some coins for
 	// channel opening and anchor sweeping.
 	ctxt, _ := context.WithTimeout(ctxb, defaultTimeout)
-	err = net.SendCoins(ctxt, btcutil.SatoshiPerBitcoin, carol)
-	if err != nil {
-		t.Fatalf("unable to send coins to dave: %v", err)
-	}
+	net.SendCoins(ctxt, t.t, btcutil.SatoshiPerBitcoin, carol)
+
 	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
-	err = net.SendCoins(ctxt, btcutil.SatoshiPerBitcoin, dave)
-	if err != nil {
-		t.Fatalf("unable to send coins to dave: %v", err)
-	}
+	net.SendCoins(ctxt, t.t, btcutil.SatoshiPerBitcoin, dave)
 
 	var from, to *lntest.HarnessNode
 	if testCase.initiator {

--- a/lntest/itest/lnd_channel_backup_test.go
+++ b/lntest/itest/lnd_channel_backup_test.go
@@ -433,10 +433,7 @@ func testChannelBackupUpdates(net *lntest.NetworkHarness, t *harnessTest) {
 		backupDir, chanbackup.DefaultBackupFileName,
 	)
 	carolArgs := fmt.Sprintf("--backupfilepath=%v", backupFilePath)
-	carol, err := net.NewNode("carol", []string{carolArgs})
-	if err != nil {
-		t.Fatalf("unable to create new node: %v", err)
-	}
+	carol := net.NewNode(t.t, "carol", []string{carolArgs})
 	defer shutdownAndAssert(net, t, carol)
 
 	// Next, we'll register for streaming notifications for changes to the
@@ -605,10 +602,7 @@ func testExportChannelBackup(net *lntest.NetworkHarness, t *harnessTest) {
 	// First, we'll create our primary test node: Carol. We'll use Carol to
 	// open channels and also export backups that we'll examine throughout
 	// the test.
-	carol, err := net.NewNode("carol", nil)
-	if err != nil {
-		t.Fatalf("unable to create new node: %v", err)
-	}
+	carol := net.NewNode(t.t, "carol", nil)
 	defer shutdownAndAssert(net, t, carol)
 
 	// With Carol up, we'll now connect her to Alice, and open a channel
@@ -849,10 +843,7 @@ func testChanRestoreScenario(t *harnessTest, net *lntest.NetworkHarness,
 	defer func() {
 		shutdownAndAssert(net, t, dave)
 	}()
-	carol, err := net.NewNode("carol", nodeArgs)
-	if err != nil {
-		t.Fatalf("unable to make new node: %v", err)
-	}
+	carol := net.NewNode(t.t, "carol", nodeArgs)
 	defer shutdownAndAssert(net, t, carol)
 
 	// Now that our new nodes are created, we'll give them some coins for

--- a/lntest/itest/lnd_forward_interceptor_test.go
+++ b/lntest/itest/lnd_forward_interceptor_test.go
@@ -313,8 +313,7 @@ func (c *interceptorTestContext) openChannel(from, to *lntest.HarnessNode,
 	ctxb := context.Background()
 
 	ctxt, _ := context.WithTimeout(ctxb, defaultTimeout)
-	err := c.net.SendCoins(ctxt, btcutil.SatoshiPerBitcoin, from)
-	require.NoError(c.t.t, err, "unable to send coins")
+	c.net.SendCoins(ctxt, c.t.t, btcutil.SatoshiPerBitcoin, from)
 
 	ctxt, _ = context.WithTimeout(ctxb, channelOpenTimeout)
 	chanPoint := openChannelAndAssert(

--- a/lntest/itest/lnd_forward_interceptor_test.go
+++ b/lntest/itest/lnd_forward_interceptor_test.go
@@ -44,16 +44,13 @@ type interceptorTestCase struct {
 //    valid payment (invoice is settled).
 func testForwardInterceptor(net *lntest.NetworkHarness, t *harnessTest) {
 	// Initialize the test context with 3 connected nodes.
-	alice, err := net.NewNode("alice", nil)
-	require.NoError(t.t, err, "unable to create alice")
+	alice := net.NewNode(t.t, "alice", nil)
 	defer shutdownAndAssert(net, t, alice)
 
-	bob, err := net.NewNode("bob", nil)
-	require.NoError(t.t, err, "unable to create bob")
+	bob := net.NewNode(t.t, "bob", nil)
 	defer shutdownAndAssert(net, t, alice)
 
-	carol, err := net.NewNode("carol", nil)
-	require.NoError(t.t, err, "unable to create carol")
+	carol := net.NewNode(t.t, "carol", nil)
 	defer shutdownAndAssert(net, t, alice)
 
 	testContext := newInterceptorTestContext(t, net, alice, bob, carol)

--- a/lntest/itest/lnd_funding_test.go
+++ b/lntest/itest/lnd_funding_test.go
@@ -43,8 +43,7 @@ func testBasicChannelFunding(net *lntest.NetworkHarness, t *harnessTest) {
 		// Each time, we'll send Carol a new set of coins in order to
 		// fund the channel.
 		ctxt, _ := context.WithTimeout(ctxb, defaultTimeout)
-		err := net.SendCoins(ctxt, btcutil.SatoshiPerBitcoin, carol)
-		require.NoError(t.t, err, "unable to send coins to carol")
+		net.SendCoins(ctxt, t.t, btcutil.SatoshiPerBitcoin, carol)
 
 		daveArgs := daveCommitType.Args()
 		dave := net.NewNode(t.t, "Dave", daveArgs)
@@ -53,7 +52,7 @@ func testBasicChannelFunding(net *lntest.NetworkHarness, t *harnessTest) {
 		// Before we start the test, we'll ensure both sides are
 		// connected to the funding flow can properly be executed.
 		ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
-		err = net.EnsureConnected(ctxt, carol, dave)
+		err := net.EnsureConnected(ctxt, carol, dave)
 		require.NoError(t.t, err, "unable to connect peers")
 
 		carolChan, daveChan, closeChan, err := basicChannelFundingTest(
@@ -263,8 +262,7 @@ func testUnconfirmedChannelFunding(net *lntest.NetworkHarness, t *harnessTest) {
 
 	// We'll send her some confirmed funds.
 	ctxt, _ := context.WithTimeout(ctxb, defaultTimeout)
-	err := net.SendCoins(ctxt, 2*chanAmt, carol)
-	require.NoError(t.t, err, "unable to send coins to carol")
+	net.SendCoins(ctxt, t.t, 2*chanAmt, carol)
 
 	// Now let Carol send some funds to herself, making a unconfirmed
 	// change output.
@@ -391,13 +389,12 @@ func testExternalFundingChanPoint(net *lntest.NetworkHarness, t *harnessTest) {
 	// Carol will be funding the channel, so we'll send some coins over to
 	// her and ensure they have enough confirmations before we proceed.
 	ctxt, _ := context.WithTimeout(ctxb, defaultTimeout)
-	err := net.SendCoins(ctxt, btcutil.SatoshiPerBitcoin, carol)
-	require.NoError(t.t, err)
+	net.SendCoins(ctxt, t.t, btcutil.SatoshiPerBitcoin, carol)
 
 	// Before we start the test, we'll ensure both sides are connected to
 	// the funding flow can properly be executed.
 	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
-	err = net.EnsureConnected(ctxt, carol, dave)
+	err := net.EnsureConnected(ctxt, carol, dave)
 	require.NoError(t.t, err)
 
 	// At this point, we're ready to simulate our external channel funding

--- a/lntest/itest/lnd_funding_test.go
+++ b/lntest/itest/lnd_funding_test.go
@@ -37,19 +37,17 @@ func testBasicChannelFunding(net *lntest.NetworkHarness, t *harnessTest) {
 		// preferentially signal the legacy commitment format.  We do
 		// the same for Dave shortly below.
 		carolArgs := carolCommitType.Args()
-		carol, err := net.NewNode("Carol", carolArgs)
-		require.NoError(t.t, err, "unable to create new node")
+		carol := net.NewNode(t.t, "Carol", carolArgs)
 		defer shutdownAndAssert(net, t, carol)
 
 		// Each time, we'll send Carol a new set of coins in order to
 		// fund the channel.
 		ctxt, _ := context.WithTimeout(ctxb, defaultTimeout)
-		err = net.SendCoins(ctxt, btcutil.SatoshiPerBitcoin, carol)
+		err := net.SendCoins(ctxt, btcutil.SatoshiPerBitcoin, carol)
 		require.NoError(t.t, err, "unable to send coins to carol")
 
 		daveArgs := daveCommitType.Args()
-		dave, err := net.NewNode("Dave", daveArgs)
-		require.NoError(t.t, err, "unable to create new node")
+		dave := net.NewNode(t.t, "Dave", daveArgs)
 		defer shutdownAndAssert(net, t, dave)
 
 		// Before we start the test, we'll ensure both sides are
@@ -260,13 +258,12 @@ func testUnconfirmedChannelFunding(net *lntest.NetworkHarness, t *harnessTest) {
 	)
 
 	// We'll start off by creating a node for Carol.
-	carol, err := net.NewNode("Carol", nil)
-	require.NoError(t.t, err, "unable to create carol's node")
+	carol := net.NewNode(t.t, "Carol", nil)
 	defer shutdownAndAssert(net, t, carol)
 
 	// We'll send her some confirmed funds.
 	ctxt, _ := context.WithTimeout(ctxb, defaultTimeout)
-	err = net.SendCoins(ctxt, 2*chanAmt, carol)
+	err := net.SendCoins(ctxt, 2*chanAmt, carol)
 	require.NoError(t.t, err, "unable to send coins to carol")
 
 	// Now let Carol send some funds to herself, making a unconfirmed
@@ -385,18 +382,16 @@ func testExternalFundingChanPoint(net *lntest.NetworkHarness, t *harnessTest) {
 
 	// First, we'll create two new nodes that we'll use to open channel
 	// between for this test.
-	carol, err := net.NewNode("carol", nil)
-	require.NoError(t.t, err)
+	carol := net.NewNode(t.t, "carol", nil)
 	defer shutdownAndAssert(net, t, carol)
 
-	dave, err := net.NewNode("dave", nil)
-	require.NoError(t.t, err)
+	dave := net.NewNode(t.t, "dave", nil)
 	defer shutdownAndAssert(net, t, dave)
 
 	// Carol will be funding the channel, so we'll send some coins over to
 	// her and ensure they have enough confirmations before we proceed.
 	ctxt, _ := context.WithTimeout(ctxb, defaultTimeout)
-	err = net.SendCoins(ctxt, btcutil.SatoshiPerBitcoin, carol)
+	err := net.SendCoins(ctxt, btcutil.SatoshiPerBitcoin, carol)
 	require.NoError(t.t, err)
 
 	// Before we start the test, we'll ensure both sides are connected to

--- a/lntest/itest/lnd_hold_persistence_test.go
+++ b/lntest/itest/lnd_hold_persistence_test.go
@@ -30,10 +30,7 @@ func testHoldInvoicePersistence(net *lntest.NetworkHarness, t *harnessTest) {
 	)
 
 	// Create carol, and clean up when the test finishes.
-	carol, err := net.NewNode("Carol", nil)
-	if err != nil {
-		t.Fatalf("unable to create new nodes: %v", err)
-	}
+	carol := net.NewNode(t.t, "Carol", nil)
 	defer shutdownAndAssert(net, t, carol)
 
 	// Connect Alice to Carol.
@@ -56,7 +53,7 @@ func testHoldInvoicePersistence(net *lntest.NetworkHarness, t *harnessTest) {
 	// Wait for Alice and Carol to receive the channel edge from the
 	// funding manager.
 	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
-	err = net.Alice.WaitForNetworkChannelOpen(ctxt, chanPointAlice)
+	err := net.Alice.WaitForNetworkChannelOpen(ctxt, chanPointAlice)
 	if err != nil {
 		t.Fatalf("alice didn't see the alice->carol channel before "+
 			"timeout: %v", err)

--- a/lntest/itest/lnd_max_channel_size_test.go
+++ b/lntest/itest/lnd_max_channel_size_test.go
@@ -18,25 +18,19 @@ import (
 func testMaxChannelSize(net *lntest.NetworkHarness, t *harnessTest) {
 	// We'll make two new nodes, both wumbo but with the default
 	// limit on maximum channel size (10 BTC)
-	wumboNode, err := net.NewNode(
-		"wumbo", []string{"--protocol.wumbo-channels"},
+	wumboNode := net.NewNode(
+		t.t, "wumbo", []string{"--protocol.wumbo-channels"},
 	)
-	if err != nil {
-		t.Fatalf("unable to create new node: %v", err)
-	}
 	defer shutdownAndAssert(net, t, wumboNode)
 
-	wumboNode2, err := net.NewNode(
-		"wumbo2", []string{"--protocol.wumbo-channels"},
+	wumboNode2 := net.NewNode(
+		t.t, "wumbo2", []string{"--protocol.wumbo-channels"},
 	)
-	if err != nil {
-		t.Fatalf("unable to create new node: %v", err)
-	}
 	defer shutdownAndAssert(net, t, wumboNode2)
 
 	// We'll send 11 BTC to the wumbo node so it can test the wumbo soft limit.
 	ctxb := context.Background()
-	err = net.SendCoins(ctxb, 11*btcutil.SatoshiPerBitcoin, wumboNode)
+	err := net.SendCoins(ctxb, 11*btcutil.SatoshiPerBitcoin, wumboNode)
 	if err != nil {
 		t.Fatalf("unable to send coins to wumbo node: %v", err)
 	}
@@ -67,10 +61,7 @@ func testMaxChannelSize(net *lntest.NetworkHarness, t *harnessTest) {
 
 	// Next we'll create a non-wumbo node to verify that it enforces the
 	// BOLT-02 channel size limit and rejects our funding request.
-	miniNode, err := net.NewNode("mini", nil)
-	if err != nil {
-		t.Fatalf("unable to create new node: %v", err)
-	}
+	miniNode := net.NewNode(t.t, "mini", nil)
 	defer shutdownAndAssert(net, t, miniNode)
 
 	err = net.EnsureConnected(ctxb, wumboNode, miniNode)
@@ -95,13 +86,15 @@ func testMaxChannelSize(net *lntest.NetworkHarness, t *harnessTest) {
 
 	// We'll now make another wumbo node with appropriate maximum channel size
 	// to accept our wumbo channel funding.
-	wumboNode3, err := net.NewNode(
-		"wumbo3", []string{"--protocol.wumbo-channels",
-			fmt.Sprintf("--maxchansize=%v", int64(funding.MaxBtcFundingAmountWumbo+1))},
+	wumboNode3 := net.NewNode(
+		t.t, "wumbo3", []string{
+			"--protocol.wumbo-channels",
+			fmt.Sprintf(
+				"--maxchansize=%v",
+				int64(funding.MaxBtcFundingAmountWumbo+1),
+			),
+		},
 	)
-	if err != nil {
-		t.Fatalf("unable to create new node: %v", err)
-	}
 	defer shutdownAndAssert(net, t, wumboNode3)
 
 	// Creating a wumbo channel between these two nodes should succeed.

--- a/lntest/itest/lnd_max_channel_size_test.go
+++ b/lntest/itest/lnd_max_channel_size_test.go
@@ -30,15 +30,12 @@ func testMaxChannelSize(net *lntest.NetworkHarness, t *harnessTest) {
 
 	// We'll send 11 BTC to the wumbo node so it can test the wumbo soft limit.
 	ctxb := context.Background()
-	err := net.SendCoins(ctxb, 11*btcutil.SatoshiPerBitcoin, wumboNode)
-	if err != nil {
-		t.Fatalf("unable to send coins to wumbo node: %v", err)
-	}
+	net.SendCoins(ctxb, t.t, 11*btcutil.SatoshiPerBitcoin, wumboNode)
 
 	// Next we'll connect both nodes, then attempt to make a wumbo channel
 	// funding request, which should fail as it exceeds the default wumbo
 	// soft limit of 10 BTC.
-	err = net.EnsureConnected(ctxb, wumboNode, wumboNode2)
+	err := net.EnsureConnected(ctxb, wumboNode, wumboNode2)
 	if err != nil {
 		t.Fatalf("unable to connect peers: %v", err)
 	}

--- a/lntest/itest/lnd_mpp_test.go
+++ b/lntest/itest/lnd_mpp_test.go
@@ -257,32 +257,14 @@ func newMppTestContext(t *harnessTest,
 
 	ctxb := context.Background()
 
-	alice, err := net.NewNode("alice", nil)
-	if err != nil {
-		t.Fatalf("unable to create alice: %v", err)
-	}
-
-	bob, err := net.NewNode("bob", []string{"--accept-amp"})
-	if err != nil {
-		t.Fatalf("unable to create bob: %v", err)
-	}
+	alice := net.NewNode(t.t, "alice", nil)
+	bob := net.NewNode(t.t, "bob", []string{"--accept-amp"})
 
 	// Create a five-node context consisting of Alice, Bob and three new
 	// nodes.
-	carol, err := net.NewNode("carol", nil)
-	if err != nil {
-		t.Fatalf("unable to create carol: %v", err)
-	}
-
-	dave, err := net.NewNode("dave", nil)
-	if err != nil {
-		t.Fatalf("unable to create dave: %v", err)
-	}
-
-	eve, err := net.NewNode("eve", nil)
-	if err != nil {
-		t.Fatalf("unable to create eve: %v", err)
-	}
+	carol := net.NewNode(t.t, "carol", nil)
+	dave := net.NewNode(t.t, "dave", nil)
+	eve := net.NewNode(t.t, "eve", nil)
 
 	// Connect nodes to ensure propagation of channels.
 	nodes := []*lntest.HarnessNode{alice, bob, carol, dave, eve}

--- a/lntest/itest/lnd_mpp_test.go
+++ b/lntest/itest/lnd_mpp_test.go
@@ -296,10 +296,7 @@ func (c *mppTestContext) openChannel(from, to *lntest.HarnessNode, chanSize btcu
 	ctxb := context.Background()
 
 	ctxt, _ := context.WithTimeout(ctxb, defaultTimeout)
-	err := c.net.SendCoins(ctxt, btcutil.SatoshiPerBitcoin, from)
-	if err != nil {
-		c.t.Fatalf("unable to send coins : %v", err)
-	}
+	c.net.SendCoins(ctxt, c.t.t, btcutil.SatoshiPerBitcoin, from)
 
 	ctxt, _ = context.WithTimeout(ctxb, channelOpenTimeout)
 	chanPoint := openChannelAndAssert(

--- a/lntest/itest/lnd_multi-hop-error-propagation_test.go
+++ b/lntest/itest/lnd_multi-hop-error-propagation_test.go
@@ -88,10 +88,7 @@ func testHtlcErrorPropagation(net *lntest.NetworkHarness, t *harnessTest) {
 
 	// Since we'd like to test some multi-hop failure scenarios, we'll
 	// introduce another node into our test network: Carol.
-	carol, err := net.NewNode("Carol", nil)
-	if err != nil {
-		t.Fatalf("unable to create new nodes: %v", err)
-	}
+	carol := net.NewNode(t.t, "Carol", nil)
 
 	// Next, we'll create a connection from Bob to Carol, and open a
 	// channel between them so we have the topology: Alice -> Bob -> Carol.

--- a/lntest/itest/lnd_multi-hop-payments_test.go
+++ b/lntest/itest/lnd_multi-hop-payments_test.go
@@ -47,10 +47,7 @@ func testMultiHopPayments(net *lntest.NetworkHarness, t *harnessTest) {
 	// First, we'll create Dave and establish a channel to Alice. Dave will
 	// be running an older node that requires the legacy onion payload.
 	daveArgs := []string{"--protocol.legacy.onion"}
-	dave, err := net.NewNode("Dave", daveArgs)
-	if err != nil {
-		t.Fatalf("unable to create new nodes: %v", err)
-	}
+	dave := net.NewNode(t.t, "Dave", daveArgs)
 	defer shutdownAndAssert(net, t, dave)
 
 	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
@@ -81,10 +78,7 @@ func testMultiHopPayments(net *lntest.NetworkHarness, t *harnessTest) {
 
 	// Next, we'll create Carol and establish a channel to from her to
 	// Dave.
-	carol, err := net.NewNode("Carol", nil)
-	if err != nil {
-		t.Fatalf("unable to create new nodes: %v", err)
-	}
+	carol := net.NewNode(t.t, "Carol", nil)
 	defer shutdownAndAssert(net, t, carol)
 
 	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)

--- a/lntest/itest/lnd_multi-hop-payments_test.go
+++ b/lntest/itest/lnd_multi-hop-payments_test.go
@@ -55,10 +55,8 @@ func testMultiHopPayments(net *lntest.NetworkHarness, t *harnessTest) {
 		t.Fatalf("unable to connect dave to alice: %v", err)
 	}
 	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
-	err = net.SendCoins(ctxt, btcutil.SatoshiPerBitcoin, dave)
-	if err != nil {
-		t.Fatalf("unable to send coins to dave: %v", err)
-	}
+	net.SendCoins(ctxt, t.t, btcutil.SatoshiPerBitcoin, dave)
+
 	ctxt, _ = context.WithTimeout(ctxb, channelOpenTimeout)
 	chanPointDave := openChannelAndAssert(
 		ctxt, t, net, dave, net.Alice,
@@ -86,10 +84,8 @@ func testMultiHopPayments(net *lntest.NetworkHarness, t *harnessTest) {
 		t.Fatalf("unable to connect carol to dave: %v", err)
 	}
 	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
-	err = net.SendCoins(ctxt, btcutil.SatoshiPerBitcoin, carol)
-	if err != nil {
-		t.Fatalf("unable to send coins to carol: %v", err)
-	}
+	net.SendCoins(ctxt, t.t, btcutil.SatoshiPerBitcoin, carol)
+
 	ctxt, _ = context.WithTimeout(ctxb, channelOpenTimeout)
 	chanPointCarol := openChannelAndAssert(
 		ctxt, t, net, carol, dave,

--- a/lntest/itest/lnd_multi-hop_test.go
+++ b/lntest/itest/lnd_multi-hop_test.go
@@ -219,16 +219,10 @@ func createThreeHopNetwork(t *harnessTest, net *lntest.NetworkHarness,
 	// Make sure there are enough utxos for anchoring.
 	for i := 0; i < 2; i++ {
 		ctxt, _ = context.WithTimeout(context.Background(), defaultTimeout)
-		err = net.SendCoins(ctxt, btcutil.SatoshiPerBitcoin, alice)
-		if err != nil {
-			t.Fatalf("unable to send coins to Alice: %v", err)
-		}
+		net.SendCoins(ctxt, t.t, btcutil.SatoshiPerBitcoin, alice)
 
 		ctxt, _ = context.WithTimeout(context.Background(), defaultTimeout)
-		err = net.SendCoins(ctxt, btcutil.SatoshiPerBitcoin, bob)
-		if err != nil {
-			t.Fatalf("unable to send coins to Bob: %v", err)
-		}
+		net.SendCoins(ctxt, t.t, btcutil.SatoshiPerBitcoin, bob)
 	}
 
 	// We'll start the test by creating a channel between Alice and Bob,
@@ -274,10 +268,7 @@ func createThreeHopNetwork(t *harnessTest, net *lntest.NetworkHarness,
 	// positively-yielding transaction.
 	for i := 0; i < 2; i++ {
 		ctxt, _ = context.WithTimeout(context.Background(), defaultTimeout)
-		err = net.SendCoins(ctxt, btcutil.SatoshiPerBitcoin, carol)
-		if err != nil {
-			t.Fatalf("unable to send coins to Carol: %v", err)
-		}
+		net.SendCoins(ctxt, t.t, btcutil.SatoshiPerBitcoin, carol)
 	}
 
 	// We'll then create a channel from Bob to Carol. After this channel is

--- a/lntest/itest/lnd_multi-hop_test.go
+++ b/lntest/itest/lnd_multi-hop_test.go
@@ -81,16 +81,10 @@ func testMultiHopHtlcClaims(net *lntest.NetworkHarness, t *harnessTest) {
 			ht := newHarnessTest(t, net)
 
 			args := commitType.Args()
-			alice, err := net.NewNode("Alice", args)
-			if err != nil {
-				t.Fatalf("unable to create new node: %v", err)
-			}
+			alice := net.NewNode(t, "Alice", args)
 			defer shutdownAndAssert(net, ht, alice)
 
-			bob, err := net.NewNode("Bob", args)
-			if err != nil {
-				t.Fatalf("unable to create new node: %v", err)
-			}
+			bob := net.NewNode(t, "Bob", args)
 			defer shutdownAndAssert(net, ht, bob)
 
 			ctxb := context.Background()
@@ -267,10 +261,8 @@ func createThreeHopNetwork(t *harnessTest, net *lntest.NetworkHarness,
 	if carolHodl {
 		carolFlags = append(carolFlags, "--hodl.exit-settle")
 	}
-	carol, err := net.NewNode("Carol", carolFlags)
-	if err != nil {
-		t.Fatalf("unable to create new node: %v", err)
-	}
+	carol := net.NewNode(t.t, "Carol", carolFlags)
+
 	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
 	if err := net.ConnectNodes(ctxt, bob, carol); err != nil {
 		t.Fatalf("unable to connect bob to carol: %v", err)

--- a/lntest/itest/lnd_network_test.go
+++ b/lntest/itest/lnd_network_test.go
@@ -30,10 +30,7 @@ func testNetworkConnectionTimeout(net *lntest.NetworkHarness, t *harnessTest) {
 
 	// First, test the global timeout settings.
 	// Create Carol with a connection timeout of 1 millisecond.
-	carol, err := net.NewNode("Carol", []string{"--connectiontimeout=1ms"})
-	if err != nil {
-		t.Fatalf("unable to create new node carol: %v", err)
-	}
+	carol := net.NewNode(t.t, "Carol", []string{"--connectiontimeout=1ms"})
 	defer shutdownAndAssert(net, t, carol)
 
 	// Try to connect Carol to a non-routable IP address, which should give
@@ -48,10 +45,7 @@ func testNetworkConnectionTimeout(net *lntest.NetworkHarness, t *harnessTest) {
 
 	// Second, test timeout on the connect peer request.
 	// Create Dave with the default timeout setting.
-	dave, err := net.NewNode("Dave", nil)
-	if err != nil {
-		t.Fatalf("unable to create new node dave: %v", err)
-	}
+	dave := net.NewNode(t.t, "Dave", nil)
 	defer shutdownAndAssert(net, t, dave)
 
 	// Try to connect Dave to a non-routable IP address, using a timeout

--- a/lntest/itest/lnd_onchain_test.go
+++ b/lntest/itest/lnd_onchain_test.go
@@ -32,10 +32,7 @@ func testCPFP(net *lntest.NetworkHarness, t *harnessTest) {
 	// send to Bob.
 	ctxb := context.Background()
 	ctxt, _ := context.WithTimeout(ctxb, defaultTimeout)
-	err := net.SendCoins(ctxt, btcutil.SatoshiPerBitcoin, net.Alice)
-	if err != nil {
-		t.Fatalf("unable to send coins to alice: %v", err)
-	}
+	net.SendCoins(ctxt, t.t, btcutil.SatoshiPerBitcoin, net.Alice)
 
 	// Create an address for Bob to send the coins to.
 	addrReq := &lnrpc.NewAddressRequest{
@@ -190,10 +187,8 @@ func testAnchorReservedValue(net *lntest.NetworkHarness, t *harnessTest) {
 	)
 
 	ctxt, _ = context.WithTimeout(context.Background(), defaultTimeout)
-	err = net.SendCoins(ctxt, chanAmt+feeEst, alice)
-	require.NoError(t.t, err)
+	net.SendCoins(ctxt, t.t, chanAmt+feeEst, alice)
 
-	// Alice opens a channel that would consume all the funds in her
 	// wallet, without a change output. This should not be allowed.
 	resErr := lnwallet.ErrReservedValueInvalidated.Error()
 

--- a/lntest/itest/lnd_onchain_test.go
+++ b/lntest/itest/lnd_onchain_test.go
@@ -172,19 +172,15 @@ func testCPFP(net *lntest.NetworkHarness, t *harnessTest) {
 func testAnchorReservedValue(net *lntest.NetworkHarness, t *harnessTest) {
 	// Start two nodes supporting anchor channels.
 	args := commitTypeAnchors.Args()
-	alice, err := net.NewNode("Alice", args)
-	require.NoError(t.t, err)
-
+	alice := net.NewNode(t.t, "Alice", args)
 	defer shutdownAndAssert(net, t, alice)
 
-	bob, err := net.NewNode("Bob", args)
-	require.NoError(t.t, err)
-
+	bob := net.NewNode(t.t, "Bob", args)
 	defer shutdownAndAssert(net, t, bob)
 
 	ctxb := context.Background()
 	ctxt, _ := context.WithTimeout(ctxb, defaultTimeout)
-	err = net.ConnectNodes(ctxt, alice, bob)
+	err := net.ConnectNodes(ctxt, alice, bob)
 	require.NoError(t.t, err)
 
 	// Send just enough coins for Alice to open a channel without a change output.

--- a/lntest/itest/lnd_psbt_test.go
+++ b/lntest/itest/lnd_psbt_test.go
@@ -25,14 +25,13 @@ func testPsbtChanFunding(net *lntest.NetworkHarness, t *harnessTest) {
 	// First, we'll create two new nodes that we'll use to open channels
 	// between for this test. Dave gets some coins that will be used to
 	// fund the PSBT, just to make sure that Carol has an empty wallet.
-	carol, err := net.NewNode("carol", nil)
-	require.NoError(t.t, err)
+	carol := net.NewNode(t.t, "carol", nil)
 	defer shutdownAndAssert(net, t, carol)
 
-	dave, err := net.NewNode("dave", nil)
-	require.NoError(t.t, err)
+	dave := net.NewNode(t.t, "dave", nil)
 	defer shutdownAndAssert(net, t, dave)
-	err = net.SendCoins(ctxb, btcutil.SatoshiPerBitcoin, dave)
+
+	err := net.SendCoins(ctxb, btcutil.SatoshiPerBitcoin, dave)
 	if err != nil {
 		t.Fatalf("unable to send coins to dave: %v", err)
 	}

--- a/lntest/itest/lnd_psbt_test.go
+++ b/lntest/itest/lnd_psbt_test.go
@@ -31,16 +31,13 @@ func testPsbtChanFunding(net *lntest.NetworkHarness, t *harnessTest) {
 	dave := net.NewNode(t.t, "dave", nil)
 	defer shutdownAndAssert(net, t, dave)
 
-	err := net.SendCoins(ctxb, btcutil.SatoshiPerBitcoin, dave)
-	if err != nil {
-		t.Fatalf("unable to send coins to dave: %v", err)
-	}
+	net.SendCoins(ctxb, t.t, btcutil.SatoshiPerBitcoin, dave)
 
 	// Before we start the test, we'll ensure both sides are connected so
 	// the funding flow can be properly executed.
 	ctxt, cancel := context.WithTimeout(ctxb, defaultTimeout)
 	defer cancel()
-	err = net.EnsureConnected(ctxt, carol, dave)
+	err := net.EnsureConnected(ctxt, carol, dave)
 	require.NoError(t.t, err)
 	err = net.EnsureConnected(ctxt, carol, net.Alice)
 	require.NoError(t.t, err)

--- a/lntest/itest/lnd_test.go
+++ b/lntest/itest/lnd_test.go
@@ -1641,15 +1641,12 @@ func testUpdateChannelPolicy(net *lntest.NetworkHarness, t *harnessTest) {
 
 	// Create Carol with options to rate limit channel updates up to 2 per
 	// day, and create a new channel Bob->Carol.
-	carol, err := net.NewNode(
-		"Carol", []string{
+	carol := net.NewNode(
+		t.t, "Carol", []string{
 			"--gossip.max-channel-update-burst=2",
 			"--gossip.channel-update-interval=24h",
 		},
 	)
-	if err != nil {
-		t.Fatalf("unable to create new nodes: %v", err)
-	}
 
 	// Clean up carol's node when the test finishes.
 	defer shutdownAndAssert(net, t, carol)
@@ -2392,16 +2389,10 @@ func testDisconnectingTargetPeer(net *lntest.NetworkHarness, t *harnessTest) {
 		"--maxbackoff=1m",
 	}
 
-	alice, err := net.NewNode("Alice", args)
-	if err != nil {
-		t.Fatalf("unable to create new node: %v", err)
-	}
+	alice := net.NewNode(t.t, "Alice", args)
 	defer shutdownAndAssert(net, t, alice)
 
-	bob, err := net.NewNode("Bob", args)
-	if err != nil {
-		t.Fatalf("unable to create new node: %v", err)
-	}
+	bob := net.NewNode(t.t, "Bob", args)
 	defer shutdownAndAssert(net, t, bob)
 
 	// Start by connecting Alice and Bob with no channels.
@@ -2415,7 +2406,7 @@ func testDisconnectingTargetPeer(net *lntest.NetworkHarness, t *harnessTest) {
 
 	// Give Alice some coins so she can fund a channel.
 	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
-	err = net.SendCoins(ctxt, btcutil.SatoshiPerBitcoin, alice)
+	err := net.SendCoins(ctxt, btcutil.SatoshiPerBitcoin, alice)
 	if err != nil {
 		t.Fatalf("unable to send coins to alice: %v", err)
 	}
@@ -2563,10 +2554,7 @@ func testChannelFundingPersistence(net *lntest.NetworkHarness, t *harnessTest) {
 	// we'll need to create a new node instance.
 	const numConfs = 5
 	carolArgs := []string{fmt.Sprintf("--bitcoin.defaultchanconfs=%v", numConfs)}
-	carol, err := net.NewNode("Carol", carolArgs)
-	if err != nil {
-		t.Fatalf("unable to create new node: %v", err)
-	}
+	carol := net.NewNode(t.t, "Carol", carolArgs)
 
 	// Clean up carol's node when the test finishes.
 	defer shutdownAndAssert(net, t, carol)
@@ -2865,10 +2853,7 @@ func testChannelUnsettledBalance(net *lntest.NetworkHarness, t *harnessTest) {
 	}
 
 	// Create carol in hodl mode.
-	carol, err := net.NewNode("Carol", []string{"--hodl.exit-settle"})
-	if err != nil {
-		t.Fatalf("unable to create new nodes: %v", err)
-	}
+	carol := net.NewNode(t.t, "Carol", []string{"--hodl.exit-settle"})
 	defer shutdownAndAssert(net, t, carol)
 
 	// Connect Alice to Carol.
@@ -2889,7 +2874,7 @@ func testChannelUnsettledBalance(net *lntest.NetworkHarness, t *harnessTest) {
 	// Wait for Alice and Carol to receive the channel edge from the
 	// funding manager.
 	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
-	err = net.Alice.WaitForNetworkChannelOpen(ctxt, chanPointAlice)
+	err := net.Alice.WaitForNetworkChannelOpen(ctxt, chanPointAlice)
 	if err != nil {
 		t.Fatalf("alice didn't see the alice->carol channel before "+
 			"timeout: %v", err)
@@ -3165,10 +3150,7 @@ func testChannelForceClosure(net *lntest.NetworkHarness, t *harnessTest) {
 			ht := newHarnessTest(t, net)
 
 			args := channelType.Args()
-			alice, err := net.NewNode("Alice", args)
-			if err != nil {
-				t.Fatalf("unable to create new node: %v", err)
-			}
+			alice := net.NewNode(ht.t, "Alice", args)
 			defer shutdownAndAssert(net, ht, alice)
 
 			// Since we'd like to test failure scenarios with
@@ -3176,10 +3158,7 @@ func testChannelForceClosure(net *lntest.NetworkHarness, t *harnessTest) {
 			// our test network: Carol.
 			carolArgs := []string{"--hodl.exit-settle"}
 			carolArgs = append(carolArgs, args...)
-			carol, err := net.NewNode("Carol", carolArgs)
-			if err != nil {
-				t.Fatalf("unable to create new nodes: %v", err)
-			}
+			carol := net.NewNode(ht.t, "Carol", carolArgs)
 			defer shutdownAndAssert(net, ht, carol)
 
 			// Each time, we'll send Alice  new set of coins in
@@ -3187,7 +3166,7 @@ func testChannelForceClosure(net *lntest.NetworkHarness, t *harnessTest) {
 			ctxt, _ := context.WithTimeout(
 				context.Background(), defaultTimeout,
 			)
-			err = net.SendCoins(
+			err := net.SendCoins(
 				ctxt, btcutil.SatoshiPerBitcoin, alice,
 			)
 			if err != nil {
@@ -4480,10 +4459,7 @@ func testSphinxReplayPersistence(net *lntest.NetworkHarness, t *harnessTest) {
 	chanAmt := btcutil.Amount(100000)
 
 	// First, we'll create Dave, the receiver, and start him in hodl mode.
-	dave, err := net.NewNode("Dave", []string{"--hodl.exit-settle"})
-	if err != nil {
-		t.Fatalf("unable to create new nodes: %v", err)
-	}
+	dave := net.NewNode(t.t, "Dave", []string{"--hodl.exit-settle"})
 
 	// We must remember to shutdown the nodes we created for the duration
 	// of the tests, only leaving the two seed nodes (Alice and Bob) within
@@ -4493,10 +4469,7 @@ func testSphinxReplayPersistence(net *lntest.NetworkHarness, t *harnessTest) {
 	// Next, we'll create Carol and establish a channel to from her to
 	// Dave. Carol is started in both unsafe-replay which will cause her to
 	// replay any pending Adds held in memory upon reconnection.
-	carol, err := net.NewNode("Carol", []string{"--unsafe-replay"})
-	if err != nil {
-		t.Fatalf("unable to create new nodes: %v", err)
-	}
+	carol := net.NewNode(t.t, "Carol", []string{"--unsafe-replay"})
 	defer shutdownAndAssert(net, t, carol)
 
 	ctxt, _ := context.WithTimeout(ctxb, defaultTimeout)
@@ -4504,7 +4477,7 @@ func testSphinxReplayPersistence(net *lntest.NetworkHarness, t *harnessTest) {
 		t.Fatalf("unable to connect carol to dave: %v", err)
 	}
 	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
-	err = net.SendCoins(ctxt, btcutil.SatoshiPerBitcoin, carol)
+	err := net.SendCoins(ctxt, btcutil.SatoshiPerBitcoin, carol)
 	if err != nil {
 		t.Fatalf("unable to send coins to carol: %v", err)
 	}
@@ -4521,10 +4494,7 @@ func testSphinxReplayPersistence(net *lntest.NetworkHarness, t *harnessTest) {
 	// by paying from Carol directly to Dave, because the '--unsafe-replay'
 	// setup doesn't apply to locally added htlcs. In that case, the
 	// mailbox, that is responsible for generating the replay, is bypassed.
-	fred, err := net.NewNode("Fred", nil)
-	if err != nil {
-		t.Fatalf("unable to create new nodes: %v", err)
-	}
+	fred := net.NewNode(t.t, "Fred", nil)
 	defer shutdownAndAssert(net, t, fred)
 
 	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
@@ -4718,18 +4688,17 @@ func testListChannels(net *lntest.NetworkHarness, t *harnessTest) {
 	const bobRemoteMaxHtlcs = 100
 
 	// Create two fresh nodes and open a channel between them.
-	alice, err := net.NewNode("Alice", nil)
-	if err != nil {
-		t.Fatalf("unable to create new node: %v", err)
-	}
+	alice := net.NewNode(t.t, "Alice", nil)
 	defer shutdownAndAssert(net, t, alice)
 
-	bob, err := net.NewNode("Bob", []string{
-		fmt.Sprintf("--default-remote-max-htlcs=%v", bobRemoteMaxHtlcs),
-	})
-	if err != nil {
-		t.Fatalf("unable to create new node: %v", err)
-	}
+	bob := net.NewNode(
+		t.t, "Bob", []string{
+			fmt.Sprintf(
+				"--default-remote-max-htlcs=%v",
+				bobRemoteMaxHtlcs,
+			),
+		},
+	)
 	defer shutdownAndAssert(net, t, bob)
 
 	// Connect Alice to Bob.
@@ -4739,7 +4708,7 @@ func testListChannels(net *lntest.NetworkHarness, t *harnessTest) {
 
 	// Give Alice some coins so she can fund a channel.
 	ctxt, _ := context.WithTimeout(ctxb, defaultTimeout)
-	err = net.SendCoins(ctxt, btcutil.SatoshiPerBitcoin, alice)
+	err := net.SendCoins(ctxt, btcutil.SatoshiPerBitcoin, alice)
 	if err != nil {
 		t.Fatalf("unable to send coins to alice: %v", err)
 	}
@@ -4860,26 +4829,24 @@ func testUpdateChanStatus(net *lntest.NetworkHarness, t *harnessTest) {
 	ctxb := context.Background()
 
 	// Create two fresh nodes and open a channel between them.
-	alice, err := net.NewNode("Alice", []string{
-		"--minbackoff=10s",
-		"--chan-enable-timeout=1.5s",
-		"--chan-disable-timeout=3s",
-		"--chan-status-sample-interval=.5s",
-	})
-	if err != nil {
-		t.Fatalf("unable to create new node: %v", err)
-	}
+	alice := net.NewNode(
+		t.t, "Alice", []string{
+			"--minbackoff=10s",
+			"--chan-enable-timeout=1.5s",
+			"--chan-disable-timeout=3s",
+			"--chan-status-sample-interval=.5s",
+		},
+	)
 	defer shutdownAndAssert(net, t, alice)
 
-	bob, err := net.NewNode("Bob", []string{
-		"--minbackoff=10s",
-		"--chan-enable-timeout=1.5s",
-		"--chan-disable-timeout=3s",
-		"--chan-status-sample-interval=.5s",
-	})
-	if err != nil {
-		t.Fatalf("unable to create new node: %v", err)
-	}
+	bob := net.NewNode(
+		t.t, "Bob", []string{
+			"--minbackoff=10s",
+			"--chan-enable-timeout=1.5s",
+			"--chan-disable-timeout=3s",
+			"--chan-status-sample-interval=.5s",
+		},
+	)
 	defer shutdownAndAssert(net, t, bob)
 
 	// Connect Alice to Bob.
@@ -4889,7 +4856,7 @@ func testUpdateChanStatus(net *lntest.NetworkHarness, t *harnessTest) {
 
 	// Give Alice some coins so she can fund a channel.
 	ctxt, _ := context.WithTimeout(ctxb, defaultTimeout)
-	err = net.SendCoins(ctxt, btcutil.SatoshiPerBitcoin, alice)
+	err := net.SendCoins(ctxt, btcutil.SatoshiPerBitcoin, alice)
 	if err != nil {
 		t.Fatalf("unable to send coins to alice: %v", err)
 	}
@@ -4924,10 +4891,7 @@ func testUpdateChanStatus(net *lntest.NetworkHarness, t *harnessTest) {
 	// Launch a node for Carol which will connect to Alice and Bob in
 	// order to receive graph updates. This will ensure that the
 	// channel updates are propagated throughout the network.
-	carol, err := net.NewNode("Carol", nil)
-	if err != nil {
-		t.Fatalf("unable to create Carol's node: %v", err)
-	}
+	carol := net.NewNode(t.t, "Carol", nil)
 	defer shutdownAndAssert(net, t, carol)
 
 	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
@@ -5486,16 +5450,10 @@ func testSingleHopSendToRouteCase(net *lntest.NetworkHarness, t *harnessTest,
 	// is the sole funder of the channel with 100k satoshis. The network
 	// topology should look like:
 	// Carol -> 100k -> Dave
-	carol, err := net.NewNode("Carol", nil)
-	if err != nil {
-		t.Fatalf("unable to create new nodes: %v", err)
-	}
+	carol := net.NewNode(t.t, "Carol", nil)
 	defer shutdownAndAssert(net, t, carol)
 
-	dave, err := net.NewNode("Dave", nil)
-	if err != nil {
-		t.Fatalf("unable to create new nodes: %v", err)
-	}
+	dave := net.NewNode(t.t, "Dave", nil)
 	defer shutdownAndAssert(net, t, dave)
 
 	ctxt, _ := context.WithTimeout(ctxb, defaultTimeout)
@@ -5503,7 +5461,7 @@ func testSingleHopSendToRouteCase(net *lntest.NetworkHarness, t *harnessTest,
 		t.Fatalf("unable to connect carol to dave: %v", err)
 	}
 	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
-	err = net.SendCoins(ctxt, btcutil.SatoshiPerBitcoin, carol)
+	err := net.SendCoins(ctxt, btcutil.SatoshiPerBitcoin, carol)
 	if err != nil {
 		t.Fatalf("unable to send coins to carol: %v", err)
 	}
@@ -5867,10 +5825,7 @@ func testMultiHopSendToRoute(net *lntest.NetworkHarness, t *harnessTest) {
 	// Create Carol and establish a channel from Bob. Bob is the sole funder
 	// of the channel with 100k satoshis. The network topology should look like:
 	// Alice -> Bob -> Carol
-	carol, err := net.NewNode("Carol", nil)
-	if err != nil {
-		t.Fatalf("unable to create new nodes: %v", err)
-	}
+	carol := net.NewNode(t.t, "Carol", nil)
 	defer shutdownAndAssert(net, t, carol)
 
 	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
@@ -6049,10 +6004,7 @@ func testSendToRouteErrorPropagation(net *lntest.NetworkHarness, t *harnessTest)
 	// Bob graph.
 	//
 	// The network topology should now look like: Alice -> Bob; Carol -> Charlie.
-	carol, err := net.NewNode("Carol", nil)
-	if err != nil {
-		t.Fatalf("unable to create new nodes: %v", err)
-	}
+	carol := net.NewNode(t.t, "Carol", nil)
 	defer shutdownAndAssert(net, t, carol)
 
 	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
@@ -6061,10 +6013,7 @@ func testSendToRouteErrorPropagation(net *lntest.NetworkHarness, t *harnessTest)
 		t.Fatalf("unable to send coins to carol: %v", err)
 	}
 
-	charlie, err := net.NewNode("Charlie", nil)
-	if err != nil {
-		t.Fatalf("unable to create new nodes: %v", err)
-	}
+	charlie := net.NewNode(t.t, "Charlie", nil)
 	defer shutdownAndAssert(net, t, charlie)
 
 	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
@@ -6297,10 +6246,7 @@ func testPrivateChannels(net *lntest.NetworkHarness, t *harnessTest) {
 	}
 
 	// Create Dave, and a channel to Alice of 100k.
-	dave, err := net.NewNode("Dave", nil)
-	if err != nil {
-		t.Fatalf("unable to create new nodes: %v", err)
-	}
+	dave := net.NewNode(t.t, "Dave", nil)
 	defer shutdownAndAssert(net, t, dave)
 
 	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
@@ -6331,10 +6277,7 @@ func testPrivateChannels(net *lntest.NetworkHarness, t *harnessTest) {
 
 	// Next, we'll create Carol and establish a channel from her to
 	// Dave of 100k.
-	carol, err := net.NewNode("Carol", nil)
-	if err != nil {
-		t.Fatalf("unable to create new nodes: %v", err)
-	}
+	carol := net.NewNode(t.t, "Carol", nil)
 	defer shutdownAndAssert(net, t, carol)
 
 	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
@@ -6628,10 +6571,7 @@ func testInvoiceRoutingHints(net *lntest.NetworkHarness, t *harnessTest) {
 	// Then, we'll create Carol's node and open a public channel between her
 	// and Alice. This channel will not be considered as a routing hint due
 	// to it being public.
-	carol, err := net.NewNode("Carol", nil)
-	if err != nil {
-		t.Fatalf("unable to create carol's node: %v", err)
-	}
+	carol := net.NewNode(t.t, "Carol", nil)
 	defer shutdownAndAssert(net, t, carol)
 
 	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
@@ -6669,10 +6609,7 @@ func testInvoiceRoutingHints(net *lntest.NetworkHarness, t *harnessTest) {
 	// and Alice. We will not include a push amount in order to not consider
 	// this channel as a routing hint as it will not have enough remote
 	// balance for the invoice's amount.
-	dave, err := net.NewNode("Dave", nil)
-	if err != nil {
-		t.Fatalf("unable to create dave's node: %v", err)
-	}
+	dave := net.NewNode(t.t, "Dave", nil)
 	defer shutdownAndAssert(net, t, dave)
 
 	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
@@ -6692,10 +6629,7 @@ func testInvoiceRoutingHints(net *lntest.NetworkHarness, t *harnessTest) {
 	// her and Alice. This time though, we'll take Eve's node down after the
 	// channel has been created to avoid populating routing hints for
 	// inactive channels.
-	eve, err := net.NewNode("Eve", nil)
-	if err != nil {
-		t.Fatalf("unable to create eve's node: %v", err)
-	}
+	eve := net.NewNode(t.t, "Eve", nil)
 	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
 	if err := net.ConnectNodes(ctxt, net.Alice, eve); err != nil {
 		t.Fatalf("unable to connect alice to eve: %v", err)
@@ -6721,7 +6655,7 @@ func testInvoiceRoutingHints(net *lntest.NetworkHarness, t *harnessTest) {
 	}
 	for i, chanPoint := range aliceChans {
 		ctxt, _ := context.WithTimeout(ctxb, defaultTimeout)
-		err = net.Alice.WaitForNetworkChannelOpen(ctxt, chanPoint)
+		err := net.Alice.WaitForNetworkChannelOpen(ctxt, chanPoint)
 		if err != nil {
 			t.Fatalf("timed out waiting for channel open %s: %v",
 				chanNames[i], err)
@@ -6742,7 +6676,7 @@ func testInvoiceRoutingHints(net *lntest.NetworkHarness, t *harnessTest) {
 	// Alice and Bob should be the only channel used as a routing hint.
 	var predErr error
 	var decoded *lnrpc.PayReq
-	err = wait.Predicate(func() bool {
+	err := wait.Predicate(func() bool {
 		ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
 		resp, err := net.Alice.AddInvoice(ctxt, invoice)
 		if err != nil {
@@ -6872,10 +6806,7 @@ func testMultiHopOverPrivateChannels(net *lntest.NetworkHarness, t *harnessTest)
 
 	// Next, we'll create Carol's node and open a public channel between
 	// her and Bob with Bob being the funder.
-	carol, err := net.NewNode("Carol", nil)
-	if err != nil {
-		t.Fatalf("unable to create carol's node: %v", err)
-	}
+	carol := net.NewNode(t.t, "Carol", nil)
 	defer shutdownAndAssert(net, t, carol)
 
 	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
@@ -6921,10 +6852,7 @@ func testMultiHopOverPrivateChannels(net *lntest.NetworkHarness, t *harnessTest)
 
 	// Next, we'll create Dave's node and open a private channel between him
 	// and Carol with Carol being the funder.
-	dave, err := net.NewNode("Dave", nil)
-	if err != nil {
-		t.Fatalf("unable to create dave's node: %v", err)
-	}
+	dave := net.NewNode(t.t, "Dave", nil)
 	defer shutdownAndAssert(net, t, dave)
 
 	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
@@ -7568,10 +7496,7 @@ func testMaxPendingChannels(net *lntest.NetworkHarness, t *harnessTest) {
 	args := []string{
 		fmt.Sprintf("--maxpendingchannels=%v", maxPendingChannels),
 	}
-	carol, err := net.NewNode("Carol", args)
-	if err != nil {
-		t.Fatalf("unable to create new nodes: %v", err)
-	}
+	carol := net.NewNode(t.t, "Carol", args)
 	defer shutdownAndAssert(net, t, carol)
 
 	ctxt, _ := context.WithTimeout(ctxb, defaultTimeout)
@@ -7603,7 +7528,7 @@ func testMaxPendingChannels(net *lntest.NetworkHarness, t *harnessTest) {
 	// Carol exhausted available amount of pending channels, next open
 	// channel request should cause ErrorGeneric to be sent back to Alice.
 	ctxt, _ = context.WithTimeout(ctxb, channelOpenTimeout)
-	_, err = net.OpenChannel(
+	_, err := net.OpenChannel(
 		ctxt, net.Alice, carol,
 		lntest.OpenChannelParams{
 			Amt: amount,
@@ -7730,10 +7655,7 @@ func testFailingChannel(net *lntest.NetworkHarness, t *harnessTest) {
 
 	// We'll introduce Carol, which will settle any incoming invoice with a
 	// totally unrelated preimage.
-	carol, err := net.NewNode("Carol", []string{"--hodl.bogus-settle"})
-	if err != nil {
-		t.Fatalf("unable to create new nodes: %v", err)
-	}
+	carol := net.NewNode(t.t, "Carol", []string{"--hodl.bogus-settle"})
 	defer shutdownAndAssert(net, t, carol)
 
 	// Let Alice connect and open a channel to Carol,
@@ -7934,10 +7856,7 @@ func testGarbageCollectLinkNodes(net *lntest.NetworkHarness, t *harnessTest) {
 	)
 
 	// Create Carol's node and connect Alice to her.
-	carol, err := net.NewNode("Carol", nil)
-	if err != nil {
-		t.Fatalf("unable to create carol's node: %v", err)
-	}
+	carol := net.NewNode(t.t, "Carol", nil)
 	defer shutdownAndAssert(net, t, carol)
 	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
 	if err := net.ConnectNodes(ctxt, net.Alice, carol); err != nil {
@@ -7957,11 +7876,9 @@ func testGarbageCollectLinkNodes(net *lntest.NetworkHarness, t *harnessTest) {
 	// Now, create Dave's a node and also open a channel between Alice and
 	// him. This link will serve as the only persistent link throughout
 	// restarts in this test.
-	dave, err := net.NewNode("Dave", nil)
-	if err != nil {
-		t.Fatalf("unable to create dave's node: %v", err)
-	}
+	dave := net.NewNode(t.t, "Dave", nil)
 	defer shutdownAndAssert(net, t, dave)
+
 	if err := net.ConnectNodes(ctxt, net.Alice, dave); err != nil {
 		t.Fatalf("unable to connect alice to dave: %v", err)
 	}
@@ -8023,7 +7940,7 @@ func testGarbageCollectLinkNodes(net *lntest.NetworkHarness, t *harnessTest) {
 	require.Eventually(t.t, func() bool {
 		return isConnected(dave.PubKeyStr)
 	}, defaultTimeout, 20*time.Millisecond)
-	err = wait.Predicate(func() bool {
+	err := wait.Predicate(func() bool {
 		return isConnected(dave.PubKeyStr)
 	}, defaultTimeout)
 
@@ -8182,13 +8099,10 @@ func testRevokedCloseRetribution(net *lntest.NetworkHarness, t *harnessTest) {
 	// protection logic automatically. We also can't have Carol
 	// automatically re-connect too early, otherwise DLP would be initiated
 	// instead of the breach we want to provoke.
-	carol, err := net.NewNode(
-		"Carol",
+	carol := net.NewNode(
+		t.t, "Carol",
 		[]string{"--hodl.exit-settle", "--nolisten", "--minbackoff=1h"},
 	)
-	if err != nil {
-		t.Fatalf("unable to create new carol node: %v", err)
-	}
 	defer shutdownAndAssert(net, t, carol)
 
 	// We must let Bob communicate with Carol before they are able to open
@@ -8201,7 +8115,7 @@ func testRevokedCloseRetribution(net *lntest.NetworkHarness, t *harnessTest) {
 	// Before we make a channel, we'll load up Carol with some coins sent
 	// directly from the miner.
 	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
-	err = net.SendCoins(ctxt, btcutil.SatoshiPerBitcoin, carol)
+	err := net.SendCoins(ctxt, btcutil.SatoshiPerBitcoin, carol)
 	if err != nil {
 		t.Fatalf("unable to send coins to carol: %v", err)
 	}
@@ -8448,10 +8362,7 @@ func testRevokedCloseRetributionZeroValueRemoteOutput(net *lntest.NetworkHarness
 
 	// Since we'd like to test some multi-hop failure scenarios, we'll
 	// introduce another node into our test network: Carol.
-	carol, err := net.NewNode("Carol", []string{"--hodl.exit-settle"})
-	if err != nil {
-		t.Fatalf("unable to create new nodes: %v", err)
-	}
+	carol := net.NewNode(t.t, "Carol", []string{"--hodl.exit-settle"})
 	defer shutdownAndAssert(net, t, carol)
 
 	// Dave will be the breached party. We set --nolisten to ensure Carol
@@ -8459,13 +8370,10 @@ func testRevokedCloseRetributionZeroValueRemoteOutput(net *lntest.NetworkHarness
 	// protection logic automatically. We also can't have Dave automatically
 	// re-connect too early, otherwise DLP would be initiated instead of the
 	// breach we want to provoke.
-	dave, err := net.NewNode(
-		"Dave",
+	dave := net.NewNode(
+		t.t, "Dave",
 		[]string{"--hodl.exit-settle", "--nolisten", "--minbackoff=1h"},
 	)
-	if err != nil {
-		t.Fatalf("unable to create new node: %v", err)
-	}
 	defer shutdownAndAssert(net, t, dave)
 
 	// We must let Dave have an open channel before she can send a node
@@ -8478,7 +8386,7 @@ func testRevokedCloseRetributionZeroValueRemoteOutput(net *lntest.NetworkHarness
 	// Before we make a channel, we'll load up Dave with some coins sent
 	// directly from the miner.
 	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
-	err = net.SendCoins(ctxt, btcutil.SatoshiPerBitcoin, dave)
+	err := net.SendCoins(ctxt, btcutil.SatoshiPerBitcoin, dave)
 	if err != nil {
 		t.Fatalf("unable to send coins to dave: %v", err)
 	}
@@ -8699,10 +8607,7 @@ func testRevokedCloseRetributionRemoteHodl(net *lntest.NetworkHarness,
 	// Since this test will result in the counterparty being left in a
 	// weird state, we will introduce another node into our test network:
 	// Carol.
-	carol, err := net.NewNode("Carol", []string{"--hodl.exit-settle"})
-	if err != nil {
-		t.Fatalf("unable to create new nodes: %v", err)
-	}
+	carol := net.NewNode(t.t, "Carol", []string{"--hodl.exit-settle"})
 	defer shutdownAndAssert(net, t, carol)
 
 	// We'll also create a new node Dave, who will have a channel with
@@ -8710,13 +8615,10 @@ func testRevokedCloseRetributionRemoteHodl(net *lntest.NetworkHarness,
 	// with active HTLCs. Dave will be the breached party. We set
 	// --nolisten to ensure Carol won't be able to connect to him and
 	// trigger the channel data protection logic automatically.
-	dave, err := net.NewNode(
-		"Dave",
+	dave := net.NewNode(
+		t.t, "Dave",
 		[]string{"--hodl.exit-settle", "--nolisten"},
 	)
-	if err != nil {
-		t.Fatalf("unable to create new dave node: %v", err)
-	}
 	defer shutdownAndAssert(net, t, dave)
 
 	// We must let Dave communicate with Carol before they are able to open
@@ -8729,7 +8631,7 @@ func testRevokedCloseRetributionRemoteHodl(net *lntest.NetworkHarness,
 	// Before we make a channel, we'll load up Dave with some coins sent
 	// directly from the miner.
 	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
-	err = net.SendCoins(ctxt, btcutil.SatoshiPerBitcoin, dave)
+	err := net.SendCoins(ctxt, btcutil.SatoshiPerBitcoin, dave)
 	if err != nil {
 		t.Fatalf("unable to send coins to dave: %v", err)
 	}
@@ -9166,22 +9068,16 @@ func testRevokedCloseRetributionAltruistWatchtowerCase(
 	if anchors {
 		carolArgs = append(carolArgs, "--protocol.anchors")
 	}
-	carol, err := net.NewNode("Carol", carolArgs)
-	if err != nil {
-		t.Fatalf("unable to create new nodes: %v", err)
-	}
+	carol := net.NewNode(t.t, "Carol", carolArgs)
 	defer shutdownAndAssert(net, t, carol)
 
 	// Willy the watchtower will protect Dave from Carol's breach. He will
 	// remain online in order to punish Carol on Dave's behalf, since the
 	// breach will happen while Dave is offline.
-	willy, err := net.NewNode("Willy", []string{
+	willy := net.NewNode(t.t, "Willy", []string{
 		"--watchtower.active",
 		"--watchtower.externalip=" + externalIP,
 	})
-	if err != nil {
-		t.Fatalf("unable to create new nodes: %v", err)
-	}
 	defer shutdownAndAssert(net, t, willy)
 
 	ctxt, _ := context.WithTimeout(ctxb, defaultTimeout)
@@ -9226,10 +9122,7 @@ func testRevokedCloseRetributionAltruistWatchtowerCase(
 	if anchors {
 		daveArgs = append(daveArgs, "--protocol.anchors")
 	}
-	dave, err := net.NewNode("Dave", daveArgs)
-	if err != nil {
-		t.Fatalf("unable to create new node: %v", err)
-	}
+	dave := net.NewNode(t.t, "Dave", daveArgs)
 	defer shutdownAndAssert(net, t, dave)
 
 	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
@@ -9746,25 +9639,19 @@ func testDataLossProtection(net *lntest.NetworkHarness, t *harnessTest) {
 	// protection logic automatically. We also can't have Carol
 	// automatically re-connect too early, otherwise DLP would be initiated
 	// at the wrong moment.
-	carol, err := net.NewNode(
-		"Carol", []string{"--nolisten", "--minbackoff=1h"},
+	carol := net.NewNode(
+		t.t, "Carol", []string{"--nolisten", "--minbackoff=1h"},
 	)
-	if err != nil {
-		t.Fatalf("unable to create new carol node: %v", err)
-	}
 	defer shutdownAndAssert(net, t, carol)
 
 	// Dave will be the party losing his state.
-	dave, err := net.NewNode("Dave", nil)
-	if err != nil {
-		t.Fatalf("unable to create new node: %v", err)
-	}
+	dave := net.NewNode(t.t, "Dave", nil)
 	defer shutdownAndAssert(net, t, dave)
 
 	// Before we make a channel, we'll load up Carol with some coins sent
 	// directly from the miner.
 	ctxt, _ := context.WithTimeout(ctxb, defaultTimeout)
-	err = net.SendCoins(ctxt, btcutil.SatoshiPerBitcoin, carol)
+	err := net.SendCoins(ctxt, btcutil.SatoshiPerBitcoin, carol)
 	if err != nil {
 		t.Fatalf("unable to send coins to carol: %v", err)
 	}
@@ -10102,10 +9989,7 @@ func testRejectHTLC(net *lntest.NetworkHarness, t *harnessTest) {
 	ctxb := context.Background()
 
 	// Create Carol with reject htlc flag.
-	carol, err := net.NewNode("Carol", []string{"--rejecthtlc"})
-	if err != nil {
-		t.Fatalf("unable to create new node: %v", err)
-	}
+	carol := net.NewNode(t.t, "Carol", []string{"--rejecthtlc"})
 	defer shutdownAndAssert(net, t, carol)
 
 	// Connect Alice to Carol.
@@ -10119,7 +10003,7 @@ func testRejectHTLC(net *lntest.NetworkHarness, t *harnessTest) {
 	}
 
 	// Send coins to Carol.
-	err = net.SendCoins(ctxb, btcutil.SatoshiPerBitcoin, carol)
+	err := net.SendCoins(ctxb, btcutil.SatoshiPerBitcoin, carol)
 	if err != nil {
 		t.Fatalf("unable to send coins to carol: %v", err)
 	}
@@ -10377,8 +10261,7 @@ func testGraphTopologyNtfns(net *lntest.NetworkHarness, t *harnessTest, pinned b
 
 	// Spin up Bob first, since we will need to grab his pubkey when
 	// starting Alice to test pinned syncing.
-	bob, err := net.NewNode("bob", nil)
-	require.NoError(t.t, err)
+	bob := net.NewNode(t.t, "bob", nil)
 	defer shutdownAndAssert(net, t, bob)
 
 	ctxt, _ := context.WithTimeout(ctxb, defaultTimeout)
@@ -10396,8 +10279,7 @@ func testGraphTopologyNtfns(net *lntest.NetworkHarness, t *harnessTest, pinned b
 		}
 	}
 
-	alice, err := net.NewNode("alice", aliceArgs)
-	require.NoError(t.t, err)
+	alice := net.NewNode(t.t, "alice", aliceArgs)
 	defer shutdownAndAssert(net, t, alice)
 
 	// Connect Alice and Bob.
@@ -10562,10 +10444,7 @@ out:
 	if err := net.DisconnectNodes(ctxt, alice, bob); err != nil {
 		t.Fatalf("unable to disconnect alice and bob: %v", err)
 	}
-	carol, err := net.NewNode("Carol", nil)
-	if err != nil {
-		t.Fatalf("unable to create new nodes: %v", err)
-	}
+	carol := net.NewNode(t.t, "Carol", nil)
 	defer shutdownAndAssert(net, t, carol)
 
 	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
@@ -10667,10 +10546,7 @@ func testNodeAnnouncement(net *lntest.NetworkHarness, t *harnessTest) {
 		lndArgs = append(lndArgs, "--externalip="+addr)
 	}
 
-	dave, err := net.NewNode("Dave", lndArgs)
-	if err != nil {
-		t.Fatalf("unable to create new nodes: %v", err)
-	}
+	dave := net.NewNode(t.t, "Dave", lndArgs)
 	defer shutdownAndAssert(net, t, dave)
 
 	// We must let Dave have an open channel before he can send a node
@@ -10791,10 +10667,7 @@ func testNodeSignVerify(net *lntest.NetworkHarness, t *harnessTest) {
 	}
 
 	// carol is a new node that is unconnected to alice or bob.
-	carol, err := net.NewNode("Carol", nil)
-	if err != nil {
-		t.Fatalf("unable to create new node: %v", err)
-	}
+	carol := net.NewNode(t.t, "Carol", nil)
 	defer shutdownAndAssert(net, t, carol)
 
 	carolMsg := []byte("carol msg")
@@ -11348,10 +11221,7 @@ func testSwitchCircuitPersistence(net *lntest.NetworkHarness, t *harnessTest) {
 	//     Carol -> Dave -> Alice -> Bob
 	//
 	// First, we'll create Dave and establish a channel to Alice.
-	dave, err := net.NewNode("Dave", nil)
-	if err != nil {
-		t.Fatalf("unable to create new nodes: %v", err)
-	}
+	dave := net.NewNode(t.t, "Dave", nil)
 	defer shutdownAndAssert(net, t, dave)
 
 	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
@@ -11384,10 +11254,7 @@ func testSwitchCircuitPersistence(net *lntest.NetworkHarness, t *harnessTest) {
 	// Next, we'll create Carol and establish a channel to from her to
 	// Dave. Carol is started in htlchodl mode so that we can disconnect the
 	// intermediary hops before starting the settle.
-	carol, err := net.NewNode("Carol", []string{"--hodl.exit-settle"})
-	if err != nil {
-		t.Fatalf("unable to create new nodes: %v", err)
-	}
+	carol := net.NewNode(t.t, "Carol", []string{"--hodl.exit-settle"})
 	defer shutdownAndAssert(net, t, carol)
 
 	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
@@ -11668,10 +11535,7 @@ func testSwitchOfflineDelivery(net *lntest.NetworkHarness, t *harnessTest) {
 	//     Carol -> Dave -> Alice -> Bob
 	//
 	// First, we'll create Dave and establish a channel to Alice.
-	dave, err := net.NewNode("Dave", nil)
-	if err != nil {
-		t.Fatalf("unable to create new nodes: %v", err)
-	}
+	dave := net.NewNode(t.t, "Dave", nil)
 	defer shutdownAndAssert(net, t, dave)
 
 	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
@@ -11704,10 +11568,7 @@ func testSwitchOfflineDelivery(net *lntest.NetworkHarness, t *harnessTest) {
 	// Next, we'll create Carol and establish a channel to from her to
 	// Dave. Carol is started in htlchodl mode so that we can disconnect the
 	// intermediary hops before starting the settle.
-	carol, err := net.NewNode("Carol", []string{"--hodl.exit-settle"})
-	if err != nil {
-		t.Fatalf("unable to create new nodes: %v", err)
-	}
+	carol := net.NewNode(t.t, "Carol", []string{"--hodl.exit-settle"})
 	defer shutdownAndAssert(net, t, carol)
 
 	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
@@ -12007,10 +11868,7 @@ func testSwitchOfflineDeliveryPersistence(net *lntest.NetworkHarness, t *harness
 	//     Carol -> Dave -> Alice -> Bob
 	//
 	// First, we'll create Dave and establish a channel to Alice.
-	dave, err := net.NewNode("Dave", nil)
-	if err != nil {
-		t.Fatalf("unable to create new nodes: %v", err)
-	}
+	dave := net.NewNode(t.t, "Dave", nil)
 	defer shutdownAndAssert(net, t, dave)
 
 	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
@@ -12044,10 +11902,7 @@ func testSwitchOfflineDeliveryPersistence(net *lntest.NetworkHarness, t *harness
 	// Next, we'll create Carol and establish a channel to from her to
 	// Dave. Carol is started in htlchodl mode so that we can disconnect the
 	// intermediary hops before starting the settle.
-	carol, err := net.NewNode("Carol", []string{"--hodl.exit-settle"})
-	if err != nil {
-		t.Fatalf("unable to create new nodes: %v", err)
-	}
+	carol := net.NewNode(t.t, "Carol", []string{"--hodl.exit-settle"})
 	defer shutdownAndAssert(net, t, carol)
 
 	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
@@ -12340,10 +12195,7 @@ func testSwitchOfflineDeliveryOutgoingOffline(
 	//     Carol -> Dave -> Alice -> Bob
 	//
 	// First, we'll create Dave and establish a channel to Alice.
-	dave, err := net.NewNode("Dave", nil)
-	if err != nil {
-		t.Fatalf("unable to create new nodes: %v", err)
-	}
+	dave := net.NewNode(t.t, "Dave", nil)
 	defer shutdownAndAssert(net, t, dave)
 
 	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
@@ -12376,10 +12228,7 @@ func testSwitchOfflineDeliveryOutgoingOffline(
 	// Next, we'll create Carol and establish a channel to from her to
 	// Dave. Carol is started in htlchodl mode so that we can disconnect the
 	// intermediary hops before starting the settle.
-	carol, err := net.NewNode("Carol", []string{"--hodl.exit-settle"})
-	if err != nil {
-		t.Fatalf("unable to create new nodes: %v", err)
-	}
+	carol := net.NewNode(t.t, "Carol", []string{"--hodl.exit-settle"})
 	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
 	if err := net.ConnectNodes(ctxt, carol, dave); err != nil {
 		t.Fatalf("unable to connect carol to dave: %v", err)
@@ -12597,10 +12446,7 @@ func testQueryRoutes(net *lntest.NetworkHarness, t *harnessTest) {
 	networkChans = append(networkChans, chanPointAlice)
 
 	// Create Carol and establish a channel from Bob.
-	carol, err := net.NewNode("Carol", nil)
-	if err != nil {
-		t.Fatalf("unable to create new nodes: %v", err)
-	}
+	carol := net.NewNode(t.t, "Carol", nil)
 	defer shutdownAndAssert(net, t, carol)
 
 	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
@@ -12608,7 +12454,7 @@ func testQueryRoutes(net *lntest.NetworkHarness, t *harnessTest) {
 		t.Fatalf("unable to connect carol to bob: %v", err)
 	}
 	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
-	err = net.SendCoins(ctxt, btcutil.SatoshiPerBitcoin, net.Bob)
+	err := net.SendCoins(ctxt, btcutil.SatoshiPerBitcoin, net.Bob)
 	if err != nil {
 		t.Fatalf("unable to send coins to bob: %v", err)
 	}
@@ -12622,10 +12468,7 @@ func testQueryRoutes(net *lntest.NetworkHarness, t *harnessTest) {
 	networkChans = append(networkChans, chanPointBob)
 
 	// Create Dave and establish a channel from Carol.
-	dave, err := net.NewNode("Dave", nil)
-	if err != nil {
-		t.Fatalf("unable to create new nodes: %v", err)
-	}
+	dave := net.NewNode(t.t, "Dave", nil)
 	defer shutdownAndAssert(net, t, dave)
 
 	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
@@ -12906,10 +12749,7 @@ func testRouteFeeCutoff(net *lntest.NetworkHarness, t *harnessTest) {
 
 	// Create Carol's node and open a channel between her and Alice with
 	// Alice being the funder.
-	carol, err := net.NewNode("Carol", nil)
-	if err != nil {
-		t.Fatalf("unable to create carol's node: %v", err)
-	}
+	carol := net.NewNode(t.t, "Carol", nil)
 	defer shutdownAndAssert(net, t, carol)
 
 	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
@@ -12917,7 +12757,7 @@ func testRouteFeeCutoff(net *lntest.NetworkHarness, t *harnessTest) {
 		t.Fatalf("unable to connect carol to alice: %v", err)
 	}
 	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
-	err = net.SendCoins(ctxt, btcutil.SatoshiPerBitcoin, carol)
+	err := net.SendCoins(ctxt, btcutil.SatoshiPerBitcoin, carol)
 	if err != nil {
 		t.Fatalf("unable to send coins to carol: %v", err)
 	}
@@ -12931,10 +12771,7 @@ func testRouteFeeCutoff(net *lntest.NetworkHarness, t *harnessTest) {
 
 	// Create Dave's node and open a channel between him and Bob with Bob
 	// being the funder.
-	dave, err := net.NewNode("Dave", nil)
-	if err != nil {
-		t.Fatalf("unable to create dave's node: %v", err)
-	}
+	dave := net.NewNode(t.t, "Dave", nil)
 	defer shutdownAndAssert(net, t, dave)
 
 	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
@@ -13178,15 +13015,13 @@ func testSendUpdateDisableChannel(net *lntest.NetworkHarness, t *harnessTest) {
 		},
 	)
 
-	carol, err := net.NewNode("Carol", []string{
-		"--minbackoff=10s",
-		"--chan-enable-timeout=1.5s",
-		"--chan-disable-timeout=3s",
-		"--chan-status-sample-interval=.5s",
-	})
-	if err != nil {
-		t.Fatalf("unable to create carol's node: %v", err)
-	}
+	carol := net.NewNode(
+		t.t, "Carol", []string{
+			"--minbackoff=10s",
+			"--chan-enable-timeout=1.5s",
+			"--chan-disable-timeout=3s",
+			"--chan-status-sample-interval=.5s",
+		})
 	defer shutdownAndAssert(net, t, carol)
 
 	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
@@ -13204,20 +13039,18 @@ func testSendUpdateDisableChannel(net *lntest.NetworkHarness, t *harnessTest) {
 	// We create a new node Eve that has an inactive channel timeout of
 	// just 2 seconds (down from the default 20m). It will be used to test
 	// channel updates for channels going inactive.
-	eve, err := net.NewNode("Eve", []string{
-		"--minbackoff=10s",
-		"--chan-enable-timeout=1.5s",
-		"--chan-disable-timeout=3s",
-		"--chan-status-sample-interval=.5s",
-	})
-	if err != nil {
-		t.Fatalf("unable to create eve's node: %v", err)
-	}
+	eve := net.NewNode(
+		t.t, "Eve", []string{
+			"--minbackoff=10s",
+			"--chan-enable-timeout=1.5s",
+			"--chan-disable-timeout=3s",
+			"--chan-status-sample-interval=.5s",
+		})
 	defer shutdownAndAssert(net, t, eve)
 
 	// Give Eve some coins.
 	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
-	err = net.SendCoins(ctxt, btcutil.SatoshiPerBitcoin, eve)
+	err := net.SendCoins(ctxt, btcutil.SatoshiPerBitcoin, eve)
 	if err != nil {
 		t.Fatalf("unable to send coins to eve: %v", err)
 	}
@@ -13243,10 +13076,7 @@ func testSendUpdateDisableChannel(net *lntest.NetworkHarness, t *harnessTest) {
 	// Launch a node for Dave which will connect to Bob in order to receive
 	// graph updates from. This will ensure that the channel updates are
 	// propagated throughout the network.
-	dave, err := net.NewNode("Dave", nil)
-	if err != nil {
-		t.Fatalf("unable to create dave's node: %v", err)
-	}
+	dave := net.NewNode(t.t, "Dave", nil)
 	defer shutdownAndAssert(net, t, dave)
 
 	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
@@ -13568,16 +13398,13 @@ func testSweepAllCoins(net *lntest.NetworkHarness, t *harnessTest) {
 
 	// First, we'll make a new node, ainz who'll we'll use to test wallet
 	// sweeping.
-	ainz, err := net.NewNode("Ainz", nil)
-	if err != nil {
-		t.Fatalf("unable to create new node: %v", err)
-	}
+	ainz := net.NewNode(t.t, "Ainz", nil)
 	defer shutdownAndAssert(net, t, ainz)
 
 	// Next, we'll give Ainz exactly 2 utxos of 1 BTC each, with one of
 	// them being p2wkh and the other being a n2wpkh address.
 	ctxt, _ := context.WithTimeout(ctxb, defaultTimeout)
-	err = net.SendCoins(ctxt, btcutil.SatoshiPerBitcoin, ainz)
+	err := net.SendCoins(ctxt, btcutil.SatoshiPerBitcoin, ainz)
 	if err != nil {
 		t.Fatalf("unable to send coins to eve: %v", err)
 	}
@@ -14103,7 +13930,9 @@ func TestLightningNetworkDaemon(t *testing.T) {
 				testCase.name, " ", "_",
 			)
 
-			err = lndHarness.SetUp(cleanTestCaseName, aliceBobArgs)
+			err = lndHarness.SetUp(
+				t1, cleanTestCaseName, aliceBobArgs,
+			)
 			require.NoError(t1,
 				err, "unable to set up test lightning network",
 			)

--- a/lntest/itest/lnd_test.go
+++ b/lntest/itest/lnd_test.go
@@ -1004,23 +1004,15 @@ func testOnchainFundRecovery(net *lntest.NetworkHarness, t *harnessTest) {
 
 			// Send one BTC to the next P2WKH address.
 			ctxt, _ := context.WithTimeout(ctxb, defaultTimeout)
-			err = net.SendCoins(
-				ctxt, btcutil.SatoshiPerBitcoin, node,
+			net.SendCoins(
+				ctxt, t.t, btcutil.SatoshiPerBitcoin, node,
 			)
-			if err != nil {
-				t.Fatalf("unable to send coins to node: %v",
-					err)
-			}
 
 			// And another to the next NP2WKH address.
 			ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
-			err = net.SendCoinsNP2WKH(
-				ctxt, btcutil.SatoshiPerBitcoin, node,
+			net.SendCoinsNP2WKH(
+				ctxt, t.t, btcutil.SatoshiPerBitcoin, node,
 			)
-			if err != nil {
-				t.Fatalf("unable to send coins to node: %v",
-					err)
-			}
 		}
 	}
 
@@ -1659,10 +1651,7 @@ func testUpdateChannelPolicy(net *lntest.NetworkHarness, t *harnessTest) {
 
 	// Send some coins to Carol that can be used for channel funding.
 	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
-	err = net.SendCoins(ctxt, btcutil.SatoshiPerBitcoin, carol)
-	if err != nil {
-		t.Fatalf("unable to send coins to carol: %v", err)
-	}
+	net.SendCoins(ctxt, t.t, btcutil.SatoshiPerBitcoin, carol)
 
 	if err := net.ConnectNodes(ctxb, carol, net.Bob); err != nil {
 		t.Fatalf("unable to connect dave to alice: %v", err)
@@ -2406,10 +2395,7 @@ func testDisconnectingTargetPeer(net *lntest.NetworkHarness, t *harnessTest) {
 
 	// Give Alice some coins so she can fund a channel.
 	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
-	err := net.SendCoins(ctxt, btcutil.SatoshiPerBitcoin, alice)
-	if err != nil {
-		t.Fatalf("unable to send coins to alice: %v", err)
-	}
+	net.SendCoins(ctxt, t.t, btcutil.SatoshiPerBitcoin, alice)
 
 	chanAmt := funding.MaxBtcFundingAmount
 	pushAmt := btcutil.Amount(0)
@@ -3166,23 +3152,11 @@ func testChannelForceClosure(net *lntest.NetworkHarness, t *harnessTest) {
 			ctxt, _ := context.WithTimeout(
 				context.Background(), defaultTimeout,
 			)
-			err := net.SendCoins(
-				ctxt, btcutil.SatoshiPerBitcoin, alice,
-			)
-			if err != nil {
-				t.Fatalf("unable to send coins to Alice: %v",
-					err)
-			}
+			net.SendCoins(ctxt, t, btcutil.SatoshiPerBitcoin, alice)
 
 			// Also give Carol some coins to allow her to sweep her
 			// anchor.
-			err = net.SendCoins(
-				ctxt, btcutil.SatoshiPerBitcoin, carol,
-			)
-			if err != nil {
-				t.Fatalf("unable to send coins to Alice: %v",
-					err)
-			}
+			net.SendCoins(ctxt, t, btcutil.SatoshiPerBitcoin, carol)
 
 			channelForceClosureTest(
 				net, ht, alice, carol, channelType,
@@ -4477,10 +4451,8 @@ func testSphinxReplayPersistence(net *lntest.NetworkHarness, t *harnessTest) {
 		t.Fatalf("unable to connect carol to dave: %v", err)
 	}
 	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
-	err := net.SendCoins(ctxt, btcutil.SatoshiPerBitcoin, carol)
-	if err != nil {
-		t.Fatalf("unable to send coins to carol: %v", err)
-	}
+	net.SendCoins(ctxt, t.t, btcutil.SatoshiPerBitcoin, carol)
+
 	ctxt, _ = context.WithTimeout(ctxb, channelOpenTimeout)
 	chanPoint := openChannelAndAssert(
 		ctxt, t, net, carol, dave,
@@ -4502,10 +4474,8 @@ func testSphinxReplayPersistence(net *lntest.NetworkHarness, t *harnessTest) {
 		t.Fatalf("unable to connect fred to carol: %v", err)
 	}
 	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
-	err = net.SendCoins(ctxt, btcutil.SatoshiPerBitcoin, fred)
-	if err != nil {
-		t.Fatalf("unable to send coins to fred: %v", err)
-	}
+	net.SendCoins(ctxt, t.t, btcutil.SatoshiPerBitcoin, fred)
+
 	ctxt, _ = context.WithTimeout(ctxb, channelOpenTimeout)
 	chanPointFC := openChannelAndAssert(
 		ctxt, t, net, fred, carol,
@@ -4708,10 +4678,7 @@ func testListChannels(net *lntest.NetworkHarness, t *harnessTest) {
 
 	// Give Alice some coins so she can fund a channel.
 	ctxt, _ := context.WithTimeout(ctxb, defaultTimeout)
-	err := net.SendCoins(ctxt, btcutil.SatoshiPerBitcoin, alice)
-	if err != nil {
-		t.Fatalf("unable to send coins to alice: %v", err)
-	}
+	net.SendCoins(ctxt, t.t, btcutil.SatoshiPerBitcoin, alice)
 
 	// Open a channel with 100k satoshis between Alice and Bob with Alice
 	// being the sole funder of the channel. The minial HTLC amount is set to
@@ -4732,7 +4699,7 @@ func testListChannels(net *lntest.NetworkHarness, t *harnessTest) {
 	// Wait for Alice and Bob to receive the channel edge from the
 	// funding manager.
 	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
-	err = alice.WaitForNetworkChannelOpen(ctxt, chanPoint)
+	err := alice.WaitForNetworkChannelOpen(ctxt, chanPoint)
 	if err != nil {
 		t.Fatalf("alice didn't see the alice->bob channel before "+
 			"timeout: %v", err)
@@ -4856,10 +4823,7 @@ func testUpdateChanStatus(net *lntest.NetworkHarness, t *harnessTest) {
 
 	// Give Alice some coins so she can fund a channel.
 	ctxt, _ := context.WithTimeout(ctxb, defaultTimeout)
-	err := net.SendCoins(ctxt, btcutil.SatoshiPerBitcoin, alice)
-	if err != nil {
-		t.Fatalf("unable to send coins to alice: %v", err)
-	}
+	net.SendCoins(ctxt, t.t, btcutil.SatoshiPerBitcoin, alice)
 
 	// Open a channel with 100k satoshis between Alice and Bob with Alice
 	// being the sole funder of the channel.
@@ -4875,7 +4839,7 @@ func testUpdateChanStatus(net *lntest.NetworkHarness, t *harnessTest) {
 	// Wait for Alice and Bob to receive the channel edge from the
 	// funding manager.
 	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
-	err = alice.WaitForNetworkChannelOpen(ctxt, chanPoint)
+	err := alice.WaitForNetworkChannelOpen(ctxt, chanPoint)
 	if err != nil {
 		t.Fatalf("alice didn't see the alice->bob channel before "+
 			"timeout: %v", err)
@@ -5461,10 +5425,7 @@ func testSingleHopSendToRouteCase(net *lntest.NetworkHarness, t *harnessTest,
 		t.Fatalf("unable to connect carol to dave: %v", err)
 	}
 	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
-	err := net.SendCoins(ctxt, btcutil.SatoshiPerBitcoin, carol)
-	if err != nil {
-		t.Fatalf("unable to send coins to carol: %v", err)
-	}
+	net.SendCoins(ctxt, t.t, btcutil.SatoshiPerBitcoin, carol)
 
 	// Open a channel with 100k satoshis between Carol and Dave with Carol
 	// being the sole funder of the channel.
@@ -5833,10 +5794,8 @@ func testMultiHopSendToRoute(net *lntest.NetworkHarness, t *harnessTest) {
 		t.Fatalf("unable to connect carol to alice: %v", err)
 	}
 	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
-	err = net.SendCoins(ctxt, btcutil.SatoshiPerBitcoin, net.Bob)
-	if err != nil {
-		t.Fatalf("unable to send coins to bob: %v", err)
-	}
+	net.SendCoins(ctxt, t.t, btcutil.SatoshiPerBitcoin, net.Bob)
+
 	ctxt, _ = context.WithTimeout(ctxb, channelOpenTimeout)
 	chanPointBob := openChannelAndAssert(
 		ctxt, t, net, net.Bob, carol,
@@ -6008,19 +5967,13 @@ func testSendToRouteErrorPropagation(net *lntest.NetworkHarness, t *harnessTest)
 	defer shutdownAndAssert(net, t, carol)
 
 	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
-	err = net.SendCoins(ctxt, btcutil.SatoshiPerBitcoin, carol)
-	if err != nil {
-		t.Fatalf("unable to send coins to carol: %v", err)
-	}
+	net.SendCoins(ctxt, t.t, btcutil.SatoshiPerBitcoin, carol)
 
 	charlie := net.NewNode(t.t, "Charlie", nil)
 	defer shutdownAndAssert(net, t, charlie)
 
 	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
-	err = net.SendCoins(ctxt, btcutil.SatoshiPerBitcoin, charlie)
-	if err != nil {
-		t.Fatalf("unable to send coins to charlie: %v", err)
-	}
+	net.SendCoins(ctxt, t.t, btcutil.SatoshiPerBitcoin, charlie)
 
 	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
 	if err := net.ConnectNodes(ctxt, carol, charlie); err != nil {
@@ -6254,10 +6207,8 @@ func testPrivateChannels(net *lntest.NetworkHarness, t *harnessTest) {
 		t.Fatalf("unable to connect dave to alice: %v", err)
 	}
 	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
-	err = net.SendCoins(ctxt, btcutil.SatoshiPerBitcoin, dave)
-	if err != nil {
-		t.Fatalf("unable to send coins to dave: %v", err)
-	}
+	net.SendCoins(ctxt, t.t, btcutil.SatoshiPerBitcoin, dave)
+
 	ctxt, _ = context.WithTimeout(ctxb, channelOpenTimeout)
 	chanPointDave := openChannelAndAssert(
 		ctxt, t, net, dave, net.Alice,
@@ -6285,10 +6236,8 @@ func testPrivateChannels(net *lntest.NetworkHarness, t *harnessTest) {
 		t.Fatalf("unable to connect carol to dave: %v", err)
 	}
 	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
-	err = net.SendCoins(ctxt, btcutil.SatoshiPerBitcoin, carol)
-	if err != nil {
-		t.Fatalf("unable to send coins to carol: %v", err)
-	}
+	net.SendCoins(ctxt, t.t, btcutil.SatoshiPerBitcoin, carol)
+
 	ctxt, _ = context.WithTimeout(ctxb, channelOpenTimeout)
 	chanPointCarol := openChannelAndAssert(
 		ctxt, t, net, carol, dave,
@@ -6860,10 +6809,8 @@ func testMultiHopOverPrivateChannels(net *lntest.NetworkHarness, t *harnessTest)
 		t.Fatalf("unable to connect carol to dave: %v", err)
 	}
 	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
-	err = net.SendCoins(ctxt, btcutil.SatoshiPerBitcoin, carol)
-	if err != nil {
-		t.Fatalf("unable to send coins to carol: %v", err)
-	}
+	net.SendCoins(ctxt, t.t, btcutil.SatoshiPerBitcoin, carol)
+
 	ctxt, _ = context.WithTimeout(ctxb, channelOpenTimeout)
 	chanPointCarol := openChannelAndAssert(
 		ctxt, t, net, carol, dave,
@@ -7506,9 +7453,7 @@ func testMaxPendingChannels(net *lntest.NetworkHarness, t *harnessTest) {
 
 	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
 	carolBalance := btcutil.Amount(maxPendingChannels) * amount
-	if err := net.SendCoins(ctxt, carolBalance, carol); err != nil {
-		t.Fatalf("unable to send coins to carol: %v", err)
-	}
+	net.SendCoins(ctxt, t.t, carolBalance, carol)
 
 	// Send open channel requests without generating new blocks thereby
 	// increasing pool of pending channels. Then check that we can't open
@@ -8115,10 +8060,7 @@ func testRevokedCloseRetribution(net *lntest.NetworkHarness, t *harnessTest) {
 	// Before we make a channel, we'll load up Carol with some coins sent
 	// directly from the miner.
 	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
-	err := net.SendCoins(ctxt, btcutil.SatoshiPerBitcoin, carol)
-	if err != nil {
-		t.Fatalf("unable to send coins to carol: %v", err)
-	}
+	net.SendCoins(ctxt, t.t, btcutil.SatoshiPerBitcoin, carol)
 
 	// In order to test Carol's response to an uncooperative channel
 	// closure by Bob, we'll first open up a channel between them with a
@@ -8386,10 +8328,7 @@ func testRevokedCloseRetributionZeroValueRemoteOutput(net *lntest.NetworkHarness
 	// Before we make a channel, we'll load up Dave with some coins sent
 	// directly from the miner.
 	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
-	err := net.SendCoins(ctxt, btcutil.SatoshiPerBitcoin, dave)
-	if err != nil {
-		t.Fatalf("unable to send coins to dave: %v", err)
-	}
+	net.SendCoins(ctxt, t.t, btcutil.SatoshiPerBitcoin, dave)
 
 	// In order to test Dave's response to an uncooperative channel
 	// closure by Carol, we'll first open up a channel between them with a
@@ -8631,10 +8570,7 @@ func testRevokedCloseRetributionRemoteHodl(net *lntest.NetworkHarness,
 	// Before we make a channel, we'll load up Dave with some coins sent
 	// directly from the miner.
 	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
-	err := net.SendCoins(ctxt, btcutil.SatoshiPerBitcoin, dave)
-	if err != nil {
-		t.Fatalf("unable to send coins to dave: %v", err)
-	}
+	net.SendCoins(ctxt, t.t, btcutil.SatoshiPerBitcoin, dave)
 
 	// In order to test Dave's response to an uncooperative channel closure
 	// by Carol, we'll first open up a channel between them with a
@@ -9142,10 +9078,7 @@ func testRevokedCloseRetributionAltruistWatchtowerCase(
 
 	// Before we make a channel, we'll load up Dave with some coins sent
 	// directly from the miner.
-	err = net.SendCoins(ctxb, btcutil.SatoshiPerBitcoin, dave)
-	if err != nil {
-		t.Fatalf("unable to send coins to dave: %v", err)
-	}
+	net.SendCoins(ctxb, t.t, btcutil.SatoshiPerBitcoin, dave)
 
 	// In order to test Dave's response to an uncooperative channel
 	// closure by Carol, we'll first open up a channel between them with a
@@ -9651,10 +9584,7 @@ func testDataLossProtection(net *lntest.NetworkHarness, t *harnessTest) {
 	// Before we make a channel, we'll load up Carol with some coins sent
 	// directly from the miner.
 	ctxt, _ := context.WithTimeout(ctxb, defaultTimeout)
-	err := net.SendCoins(ctxt, btcutil.SatoshiPerBitcoin, carol)
-	if err != nil {
-		t.Fatalf("unable to send coins to carol: %v", err)
-	}
+	net.SendCoins(ctxt, t.t, btcutil.SatoshiPerBitcoin, carol)
 
 	// timeTravel is a method that will make Carol open a channel to the
 	// passed node, settle a series of payments, then reset the node back
@@ -10003,16 +9933,10 @@ func testRejectHTLC(net *lntest.NetworkHarness, t *harnessTest) {
 	}
 
 	// Send coins to Carol.
-	err := net.SendCoins(ctxb, btcutil.SatoshiPerBitcoin, carol)
-	if err != nil {
-		t.Fatalf("unable to send coins to carol: %v", err)
-	}
+	net.SendCoins(ctxb, t.t, btcutil.SatoshiPerBitcoin, carol)
 
 	// Send coins to Alice.
-	err = net.SendCoins(ctxb, btcutil.SatoshiPerBitcent, net.Alice)
-	if err != nil {
-		t.Fatalf("unable to send coins to alice: %v", err)
-	}
+	net.SendCoins(ctxb, t.t, btcutil.SatoshiPerBitcent, net.Alice)
 
 	// Open a channel between Alice and Carol.
 	ctxt, _ := context.WithTimeout(ctxb, channelOpenTimeout)
@@ -10039,7 +9963,7 @@ func testRejectHTLC(net *lntest.NetworkHarness, t *harnessTest) {
 	genPreImage := func() []byte {
 		preimage := make([]byte, 32)
 
-		_, err = rand.Read(preimage)
+		_, err := rand.Read(preimage)
 		if err != nil {
 			t.Fatalf("unable to generate preimage: %v", err)
 		}
@@ -10289,13 +10213,11 @@ func testGraphTopologyNtfns(net *lntest.NetworkHarness, t *harnessTest, pinned b
 
 	// Alice stimmy.
 	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
-	err = net.SendCoins(ctxt, btcutil.SatoshiPerBitcoin, alice)
-	require.NoError(t.t, err)
+	net.SendCoins(ctxt, t.t, btcutil.SatoshiPerBitcoin, alice)
 
 	// Bob stimmy.
 	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
-	err = net.SendCoins(ctxt, btcutil.SatoshiPerBitcoin, bob)
-	require.NoError(t.t, err)
+	net.SendCoins(ctxt, t.t, btcutil.SatoshiPerBitcoin, bob)
 
 	// Assert that Bob has the correct sync type before proceeeding.
 	if pinned {
@@ -11229,10 +11151,8 @@ func testSwitchCircuitPersistence(net *lntest.NetworkHarness, t *harnessTest) {
 		t.Fatalf("unable to connect dave to alice: %v", err)
 	}
 	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
-	err = net.SendCoins(ctxt, btcutil.SatoshiPerBitcoin, dave)
-	if err != nil {
-		t.Fatalf("unable to send coins to dave: %v", err)
-	}
+	net.SendCoins(ctxt, t.t, btcutil.SatoshiPerBitcoin, dave)
+
 	ctxt, _ = context.WithTimeout(ctxb, channelOpenTimeout)
 	chanPointDave := openChannelAndAssert(
 		ctxt, t, net, dave, net.Alice,
@@ -11262,10 +11182,8 @@ func testSwitchCircuitPersistence(net *lntest.NetworkHarness, t *harnessTest) {
 		t.Fatalf("unable to connect carol to dave: %v", err)
 	}
 	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
-	err = net.SendCoins(ctxt, btcutil.SatoshiPerBitcoin, carol)
-	if err != nil {
-		t.Fatalf("unable to send coins to carol: %v", err)
-	}
+	net.SendCoins(ctxt, t.t, btcutil.SatoshiPerBitcoin, carol)
+
 	ctxt, _ = context.WithTimeout(ctxb, channelOpenTimeout)
 	chanPointCarol := openChannelAndAssert(
 		ctxt, t, net, carol, dave,
@@ -11543,10 +11461,8 @@ func testSwitchOfflineDelivery(net *lntest.NetworkHarness, t *harnessTest) {
 		t.Fatalf("unable to connect dave to alice: %v", err)
 	}
 	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
-	err = net.SendCoins(ctxt, btcutil.SatoshiPerBitcoin, dave)
-	if err != nil {
-		t.Fatalf("unable to send coins to dave: %v", err)
-	}
+	net.SendCoins(ctxt, t.t, btcutil.SatoshiPerBitcoin, dave)
+
 	ctxt, _ = context.WithTimeout(ctxb, channelOpenTimeout)
 	chanPointDave := openChannelAndAssert(
 		ctxt, t, net, dave, net.Alice,
@@ -11576,10 +11492,8 @@ func testSwitchOfflineDelivery(net *lntest.NetworkHarness, t *harnessTest) {
 		t.Fatalf("unable to connect carol to dave: %v", err)
 	}
 	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
-	err = net.SendCoins(ctxt, btcutil.SatoshiPerBitcoin, carol)
-	if err != nil {
-		t.Fatalf("unable to send coins to carol: %v", err)
-	}
+	net.SendCoins(ctxt, t.t, btcutil.SatoshiPerBitcoin, carol)
+
 	ctxt, _ = context.WithTimeout(ctxb, channelOpenTimeout)
 	chanPointCarol := openChannelAndAssert(
 		ctxt, t, net, carol, dave,
@@ -11876,10 +11790,8 @@ func testSwitchOfflineDeliveryPersistence(net *lntest.NetworkHarness, t *harness
 		t.Fatalf("unable to connect dave to alice: %v", err)
 	}
 	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
-	err = net.SendCoins(ctxt, btcutil.SatoshiPerBitcoin, dave)
-	if err != nil {
-		t.Fatalf("unable to send coins to dave: %v", err)
-	}
+	net.SendCoins(ctxt, t.t, btcutil.SatoshiPerBitcoin, dave)
+
 	ctxt, _ = context.WithTimeout(ctxb, channelOpenTimeout)
 	chanPointDave := openChannelAndAssert(
 		ctxt, t, net, dave, net.Alice,
@@ -11910,10 +11822,8 @@ func testSwitchOfflineDeliveryPersistence(net *lntest.NetworkHarness, t *harness
 		t.Fatalf("unable to connect carol to dave: %v", err)
 	}
 	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
-	err = net.SendCoins(ctxt, btcutil.SatoshiPerBitcoin, carol)
-	if err != nil {
-		t.Fatalf("unable to send coins to carol: %v", err)
-	}
+	net.SendCoins(ctxt, t.t, btcutil.SatoshiPerBitcoin, carol)
+
 	ctxt, _ = context.WithTimeout(ctxb, channelOpenTimeout)
 	chanPointCarol := openChannelAndAssert(
 		ctxt, t, net, carol, dave,
@@ -12203,10 +12113,8 @@ func testSwitchOfflineDeliveryOutgoingOffline(
 		t.Fatalf("unable to connect dave to alice: %v", err)
 	}
 	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
-	err = net.SendCoins(ctxt, btcutil.SatoshiPerBitcoin, dave)
-	if err != nil {
-		t.Fatalf("unable to send coins to dave: %v", err)
-	}
+	net.SendCoins(ctxt, t.t, btcutil.SatoshiPerBitcoin, dave)
+
 	ctxt, _ = context.WithTimeout(ctxb, channelOpenTimeout)
 	chanPointDave := openChannelAndAssert(
 		ctxt, t, net, dave, net.Alice,
@@ -12234,10 +12142,8 @@ func testSwitchOfflineDeliveryOutgoingOffline(
 		t.Fatalf("unable to connect carol to dave: %v", err)
 	}
 	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
-	err = net.SendCoins(ctxt, btcutil.SatoshiPerBitcoin, carol)
-	if err != nil {
-		t.Fatalf("unable to send coins to carol: %v", err)
-	}
+	net.SendCoins(ctxt, t.t, btcutil.SatoshiPerBitcoin, carol)
+
 	ctxt, _ = context.WithTimeout(ctxb, channelOpenTimeout)
 	chanPointCarol := openChannelAndAssert(
 		ctxt, t, net, carol, dave,
@@ -12454,10 +12360,8 @@ func testQueryRoutes(net *lntest.NetworkHarness, t *harnessTest) {
 		t.Fatalf("unable to connect carol to bob: %v", err)
 	}
 	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
-	err := net.SendCoins(ctxt, btcutil.SatoshiPerBitcoin, net.Bob)
-	if err != nil {
-		t.Fatalf("unable to send coins to bob: %v", err)
-	}
+	net.SendCoins(ctxt, t.t, btcutil.SatoshiPerBitcoin, net.Bob)
+
 	ctxt, _ = context.WithTimeout(ctxb, channelOpenTimeout)
 	chanPointBob := openChannelAndAssert(
 		ctxt, t, net, net.Bob, carol,
@@ -12476,10 +12380,8 @@ func testQueryRoutes(net *lntest.NetworkHarness, t *harnessTest) {
 		t.Fatalf("unable to connect dave to carol: %v", err)
 	}
 	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
-	err = net.SendCoins(ctxt, btcutil.SatoshiPerBitcoin, carol)
-	if err != nil {
-		t.Fatalf("unable to send coins to carol: %v", err)
-	}
+	net.SendCoins(ctxt, t.t, btcutil.SatoshiPerBitcoin, carol)
+
 	ctxt, _ = context.WithTimeout(ctxb, channelOpenTimeout)
 	chanPointCarol := openChannelAndAssert(
 		ctxt, t, net, carol, dave,
@@ -12757,10 +12659,8 @@ func testRouteFeeCutoff(net *lntest.NetworkHarness, t *harnessTest) {
 		t.Fatalf("unable to connect carol to alice: %v", err)
 	}
 	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
-	err := net.SendCoins(ctxt, btcutil.SatoshiPerBitcoin, carol)
-	if err != nil {
-		t.Fatalf("unable to send coins to carol: %v", err)
-	}
+	net.SendCoins(ctxt, t.t, btcutil.SatoshiPerBitcoin, carol)
+
 	ctxt, _ = context.WithTimeout(ctxb, channelOpenTimeout)
 	chanPointAliceCarol := openChannelAndAssert(
 		ctxt, t, net, net.Alice, carol,
@@ -13050,10 +12950,7 @@ func testSendUpdateDisableChannel(net *lntest.NetworkHarness, t *harnessTest) {
 
 	// Give Eve some coins.
 	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
-	err := net.SendCoins(ctxt, btcutil.SatoshiPerBitcoin, eve)
-	if err != nil {
-		t.Fatalf("unable to send coins to eve: %v", err)
-	}
+	net.SendCoins(ctxt, t.t, btcutil.SatoshiPerBitcoin, eve)
 
 	// Connect Eve to Carol and Bob, and open a channel to carol.
 	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
@@ -13404,15 +13301,10 @@ func testSweepAllCoins(net *lntest.NetworkHarness, t *harnessTest) {
 	// Next, we'll give Ainz exactly 2 utxos of 1 BTC each, with one of
 	// them being p2wkh and the other being a n2wpkh address.
 	ctxt, _ := context.WithTimeout(ctxb, defaultTimeout)
-	err := net.SendCoins(ctxt, btcutil.SatoshiPerBitcoin, ainz)
-	if err != nil {
-		t.Fatalf("unable to send coins to eve: %v", err)
-	}
+	net.SendCoins(ctxt, t.t, btcutil.SatoshiPerBitcoin, ainz)
+
 	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
-	err = net.SendCoinsNP2WKH(ctxt, btcutil.SatoshiPerBitcoin, ainz)
-	if err != nil {
-		t.Fatalf("unable to send coins to eve: %v", err)
-	}
+	net.SendCoinsNP2WKH(ctxt, t.t, btcutil.SatoshiPerBitcoin, ainz)
 
 	// Ensure that we can't send coins to our own Pubkey.
 	info, err := ainz.GetInfo(ctxt, &lnrpc.GetInfoRequest{})

--- a/lntest/itest/lnd_wallet_import_test.go
+++ b/lntest/itest/lnd_wallet_import_test.go
@@ -606,12 +606,10 @@ func testWalletImportAccountScenario(net *lntest.NetworkHarness, t *harnessTest,
 
 	// We'll start our test by having two nodes, Carol and Dave. Carol's
 	// default wallet account will be imported into Dave's node.
-	carol, err := net.NewNode("carol", nil)
-	require.NoError(t.t, err)
+	carol := net.NewNode(t.t, "carol", nil)
 	defer shutdownAndAssert(net, t, carol)
 
-	dave, err := net.NewNode("dave", nil)
-	require.NoError(t.t, err)
+	dave := net.NewNode(t.t, "dave", nil)
 	defer shutdownAndAssert(net, t, dave)
 
 	ctxt, cancel := context.WithTimeout(ctxb, defaultTimeout)
@@ -754,12 +752,10 @@ func testWalletImportPubKeyScenario(net *lntest.NetworkHarness, t *harnessTest,
 	const utxoAmt int64 = btcutil.SatoshiPerBitcoin
 
 	// We'll start our test by having two nodes, Carol and Dave.
-	carol, err := net.NewNode("carol", nil)
-	require.NoError(t.t, err)
+	carol := net.NewNode(t.t, "carol", nil)
 	defer shutdownAndAssert(net, t, carol)
 
-	dave, err := net.NewNode("dave", nil)
-	require.NoError(t.t, err)
+	dave := net.NewNode(t.t, "dave", nil)
 	defer shutdownAndAssert(net, t, dave)
 
 	// We'll define a helper closure that we'll use throughout the test to

--- a/lntest/itest/lnd_wumbo_channels_test.go
+++ b/lntest/itest/lnd_wumbo_channels_test.go
@@ -29,15 +29,12 @@ func testWumboChannels(net *lntest.NetworkHarness, t *harnessTest) {
 	// We'll send coins to the wumbo node, as it'll be the one imitating
 	// the channel funding.
 	ctxb := context.Background()
-	err := net.SendCoins(ctxb, btcutil.SatoshiPerBitcoin, wumboNode)
-	if err != nil {
-		t.Fatalf("unable to send coins to carol: %v", err)
-	}
+	net.SendCoins(ctxb, t.t, btcutil.SatoshiPerBitcoin, wumboNode)
 
 	// Next we'll connect both nodes, then attempt to make a wumbo channel
 	// funding request to the mini node we created above. The wumbo request
 	// should fail as the node isn't advertising wumbo channels.
-	err = net.EnsureConnected(ctxb, wumboNode, miniNode)
+	err := net.EnsureConnected(ctxb, wumboNode, miniNode)
 	if err != nil {
 		t.Fatalf("unable to connect peers: %v", err)
 	}

--- a/lntest/itest/lnd_wumbo_channels_test.go
+++ b/lntest/itest/lnd_wumbo_channels_test.go
@@ -19,23 +19,17 @@ func testWumboChannels(net *lntest.NetworkHarness, t *harnessTest) {
 	//
 	// We'll make two new nodes, with one of them signalling support for
 	// wumbo channels while the other doesn't.
-	wumboNode, err := net.NewNode(
-		"wumbo", []string{"--protocol.wumbo-channels"},
+	wumboNode := net.NewNode(
+		t.t, "wumbo", []string{"--protocol.wumbo-channels"},
 	)
-	if err != nil {
-		t.Fatalf("unable to create new node: %v", err)
-	}
 	defer shutdownAndAssert(net, t, wumboNode)
-	miniNode, err := net.NewNode("mini", nil)
-	if err != nil {
-		t.Fatalf("unable to create new node: %v", err)
-	}
+	miniNode := net.NewNode(t.t, "mini", nil)
 	defer shutdownAndAssert(net, t, miniNode)
 
 	// We'll send coins to the wumbo node, as it'll be the one imitating
 	// the channel funding.
 	ctxb := context.Background()
-	err = net.SendCoins(ctxb, btcutil.SatoshiPerBitcoin, wumboNode)
+	err := net.SendCoins(ctxb, btcutil.SatoshiPerBitcoin, wumboNode)
 	if err != nil {
 		t.Fatalf("unable to send coins to carol: %v", err)
 	}
@@ -67,12 +61,9 @@ func testWumboChannels(net *lntest.NetworkHarness, t *harnessTest) {
 
 	// We'll now make another wumbo node to accept our wumbo channel
 	// funding.
-	wumboNode2, err := net.NewNode(
-		"wumbo2", []string{"--protocol.wumbo-channels"},
+	wumboNode2 := net.NewNode(
+		t.t, "wumbo2", []string{"--protocol.wumbo-channels"},
 	)
-	if err != nil {
-		t.Fatalf("unable to create new node: %v", err)
-	}
 	defer shutdownAndAssert(net, t, wumboNode2)
 
 	// Creating a wumbo channel between these two nodes should succeed.


### PR DESCRIPTION
Depends on #5365 , only the second commit is relevant.
This is the second step in this stage, that we no longer need to check the err returned from `net.SendCoins`.