### PR TITLE
lnrpc: fix v1 switch API doc

### DIFF
--- a/lnrpc/rpc.pb.go
+++ b/lnrpc/rpc.pb.go
@@ -20123,8 +20123,9 @@ type LightningClient interface {
 	// lncli: `fwdinghistory`
 	//ForwardingHistory allows the caller to query the htlcswitch for a record of
 	//all HTLCs forwarded within the target time range, and integer offset
-	//within that time range. If no time-range is specified, then the first chunk
-	//of the past 24 hrs of forwarding history are returned.
+	//within that time range, for a maximum number of events. If no maximum number
+	//of events is specified, up to 100 events will be returned. If no time-range
+	//is specified, then events will be returned in the order that they occured.
 	//
 	//A list of forwarding events are returned. The size of each forwarding event
 	//is 40 bytes, and the max message size able to be returned in gRPC is 4 MiB.
@@ -21271,8 +21272,9 @@ type LightningServer interface {
 	// lncli: `fwdinghistory`
 	//ForwardingHistory allows the caller to query the htlcswitch for a record of
 	//all HTLCs forwarded within the target time range, and integer offset
-	//within that time range. If no time-range is specified, then the first chunk
-	//of the past 24 hrs of forwarding history are returned.
+	//within that time range, for a maximum number of events. If no maximum number
+	//of events is specified, up to 100 events will be returned. If no time-range
+	//is specified, then events will be returned in the order that they occured.
 	//
 	//A list of forwarding events are returned. The size of each forwarding event
 	//is 40 bytes, and the max message size able to be returned in gRPC is 4 MiB.

--- a/lnrpc/rpc.proto
+++ b/lnrpc/rpc.proto
@@ -426,8 +426,9 @@ service Lightning {
     /* lncli: `fwdinghistory`
     ForwardingHistory allows the caller to query the htlcswitch for a record of
     all HTLCs forwarded within the target time range, and integer offset
-    within that time range. If no time-range is specified, then the first chunk
-    of the past 24 hrs of forwarding history are returned.
+    within that time range, for a maximum number of events. If no maximum number
+    of events is specified, up to 100 events will be returned. If no time-range
+    is specified, then events will be returned in the order that they occured.
 
     A list of forwarding events are returned. The size of each forwarding event
     is 40 bytes, and the max message size able to be returned in gRPC is 4 MiB.

--- a/lnrpc/rpc.swagger.json
+++ b/lnrpc/rpc.swagger.json
@@ -1984,7 +1984,7 @@
     },
     "/v1/switch": {
       "post": {
-        "summary": "lncli: `fwdinghistory`\nForwardingHistory allows the caller to query the htlcswitch for a record of\nall HTLCs forwarded within the target time range, and integer offset\nwithin that time range. If no time-range is specified, then the first chunk\nof the past 24 hrs of forwarding history are returned.",
+        "summary": "lncli: `fwdinghistory`\nForwardingHistory allows the caller to query the htlcswitch for a record of\nall HTLCs forwarded within the target time range, and integer offset\nwithin that time range, for a maximum number of events. If no maximum number\nof events is specified, up to 100 events will be returned. If no time-range\nis specified, then events will be returned in the order that they occured.",
         "description": "A list of forwarding events are returned. The size of each forwarding event\nis 40 bytes, and the max message size able to be returned in gRPC is 4 MiB.\nAs a result each message can only contain 50k entries. Each response has\nthe index offset of the last entry. The index offset can be provided to the\nrequest to allow the caller to skip a series of records.",
         "operationId": "ForwardingHistory",
         "responses": {


### PR DESCRIPTION
Issue: https://github.com/lightningnetwork/lnd/issues/5306

Action Taken: Updated v1 switch API documentation in lnd/lnrpc/rpc.proto per discussion in issue above.  Ran make 'rpc-format' and compiled with 'make rpc' which updated rpc.pb.go and rpc.swagger.json appropriately.   Documentation only fix.

#### Pull Request Checklist

- [x] If this is your first time contributing, we recommend you read the [Code
  Contribution Guidelines](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md)
- [NA] All changes are Go version 1.12 compliant
- [x] The code being submitted is commented according to [Code Documentation and Commenting](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#CodeDocumentation)
- [NA] For new code: Code is accompanied by tests which exercise both
  the positive and negative (error paths) conditions (if applicable)
- [NA] For bug fixes: Code is accompanied by new tests which trigger
  the bug being fixed to prevent regressions
- [NA] Any new logging statements use an appropriate subsystem and
  logging level
- [x] Code has been formatted with `go fmt`
- [x] Protobuf files (`lnrpc/**/*.proto`) have been formatted with
  `make rpc-format` and compiled with `make rpc`
- [NA] New configuration flags have been added to `sample-lnd.conf`
- [x] For code and documentation: lines are wrapped at 80 characters
  (the tab character should be counted as 8 characters, not 4, as some IDEs do
  per default)
- [NA] Running `make check` does not fail any tests
- [NA] Running `go vet` does not report any issues
- [NA] Running `make lint` does not report any **new** issues that did not
  already exist
- [NA] All commits build properly and pass tests. Only in exceptional
  cases it can be justifiable to violate this condition. In that case, the
  reason should be stated in the commit message.
- [x] Commits have a logical structure according to [Ideal Git Commit Structure](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#IdealGitCommitStructure)
