### PR TITLE
multi: add docker build with monitoring tag

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Set env
         run: echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
 
-      - name: Build and push
+      - name: Build and push without monitoring
         id: docker_build
         uses: lightninglabs/gh-actions/build-push-action@2021.01.25.00
         with:
@@ -40,6 +40,18 @@ jobs:
           platforms: linux/amd64,linux/arm64
           tags: "${{ env.DOCKER_REPO }}/${{ env.DOCKER_IMAGE }}:${{ env.RELEASE_VERSION }}"
           build-args: checkout=${{ env.RELEASE_VERSION }}
+
+      - name: Image digest
+        run: echo ${{ steps.docker_build.outputs.digest }}
+
+      - name: Build and push with monitoring
+        id: docker_monitoring_build
+        uses: lightninglabs/gh-actions/build-push-action@2021.01.25.00
+        with:
+          push: true
+          platforms: linux/amd64,linux/arm64
+          tags: "${{ env.DOCKER_REPO }}/${{ env.DOCKER_IMAGE }}:monitoring-${{ env.RELEASE_VERSION }}"
+          build-args: checkout=${{ env.RELEASE_VERSION }} monitoring=true
 
       - name: Image digest
         run: echo ${{ steps.docker_build.outputs.digest }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,10 @@ ENV GODEBUG netdns=cgo
 # will use the Git tip of master by default.
 ARG checkout="master"
 
+# If the monitoring argument is set, we will make lnd with the monitoring tag.
+# This is off by default.
+ARG monitoring
+
 # Add an org tag so that this Dockerfile can be used to build forks.
 ARG org="lightningnetwork"
 
@@ -26,7 +30,7 @@ RUN apk add --no-cache --update alpine-sdk \
 &&  git clone https://github.com/$org/lnd /go/src/github.com/lightningnetwork/lnd \
 &&  cd /go/src/github.com/lightningnetwork/lnd \
 &&  git checkout $checkout \
-&&  make release-install
+&&  if [[ -z $monitoring ]] ; then make release-install ; else make release-install monitoring=true ; fi
 
 # Start a new, final image.
 FROM alpine as final

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,12 +15,15 @@ ENV GODEBUG netdns=cgo
 # will use the Git tip of master by default.
 ARG checkout="master"
 
+# Add an org tag so that this Dockerfile can be used to build forks.
+ARG org="lightningnetwork"
+
 # Install dependencies and build the binaries.
 RUN apk add --no-cache --update alpine-sdk \
     git \
     make \
     gcc \
-&&  git clone https://github.com/lightningnetwork/lnd /go/src/github.com/lightningnetwork/lnd \
+&&  git clone https://github.com/$org/lnd /go/src/github.com/lightningnetwork/lnd \
 &&  cd /go/src/github.com/lightningnetwork/lnd \
 &&  git checkout $checkout \
 &&  make release-install

--- a/make/release_flags.mk
+++ b/make/release_flags.mk
@@ -40,6 +40,11 @@ windows-arm
 
 RELEASE_TAGS = autopilotrpc signrpc walletrpc chainrpc invoicesrpc watchtowerrpc
 
+# If monitoring is set, add it to our set of tags.
+ifneq ($(monitoring),)
+RELEASE_TAGS += monitoring
+endif
+
 # One can either specify a git tag as the version suffix or one is generated
 # from the current date.
 ifneq ($(tag),)


### PR DESCRIPTION
This PR is a WIP that demonstrates a path towards shipping a docker image which has the `monitoring` tag enabled. 
An alternative to this would just be to ship with `monitoring` on by default. See lightninglabs/lndmon/issues/69.

Things we would need to do per-release if we go with this: 
- [Required/Automated] include manifest for release with `monitoring` 
- Optionally also include release binaries for m
- Upload sigs for regular and monitoring releases (each team member would need to do both)

The verification script hasn't been tested properly, difficult to do since we need stuff uploaded to a release. Also GH workflow could be streamlined to have a matrix.