### PR TITLE
fuzz/lnwire: minor touch-ups, remove MaxPayloadLength

### DIFF
--- a/docs/release-notes/release-notes-0.14.0.md
+++ b/docs/release-notes/release-notes-0.14.0.md
@@ -63,6 +63,8 @@ you.
 * [A flake in the Neutrino integration tests with anchor sweeps was 
   addressed](https://github.com/lightningnetwork/lnd/pull/5509).
 
+* [The `lnwire` fuzz tests have been fixed and now run without crashing.](https://github.com/lightningnetwork/lnd/pull/5395)
+
 # Documentation
 
 * [Outdated warning about unsupported pruning was replaced with clarification that LND **does**

--- a/fuzz/lnwire/accept_channel.go
+++ b/fuzz/lnwire/accept_channel.go
@@ -13,10 +13,6 @@ func Fuzz_accept_channel(data []byte) int {
 	// Prefix with MsgAcceptChannel.
 	data = prefixWithMsgType(data, lnwire.MsgAcceptChannel)
 
-	// Create an empty message so that the FuzzHarness func can check
-	// if the max payload constraint is violated.
-	emptyMsg := lnwire.AcceptChannel{}
-
 	// We have to do this here instead of in fuzz.Harness so that
 	// reflect.DeepEqual isn't called. Because of the UpfrontShutdownScript
 	// encoding, the first message and second message aren't deeply equal since
@@ -26,12 +22,9 @@ func Fuzz_accept_channel(data []byte) int {
 	r := bytes.NewReader(data)
 
 	// Make sure byte array length (excluding 2 bytes for message type) is
-	// less than max payload size for the wire message. We check this because
-	// otherwise `go-fuzz` will keep creating inputs that crash on ReadMessage
-	// due to a large message size.
+	// less than max payload size for the wire message.
 	payloadLen := uint32(len(data)) - 2
-	if payloadLen > emptyMsg.MaxPayloadLength(0) {
-		// Ignore this input - max payload constraint violated.
+	if payloadLen > lnwire.MaxMsgBody {
 		return 1
 	}
 

--- a/fuzz/lnwire/announce_signatures.go
+++ b/fuzz/lnwire/announce_signatures.go
@@ -11,10 +11,6 @@ func Fuzz_announce_signatures(data []byte) int {
 	// Prefix with MsgAnnounceSignatures.
 	data = prefixWithMsgType(data, lnwire.MsgAnnounceSignatures)
 
-	// Create an empty message so that the FuzzHarness func can check
-	// if the max payload constraint is violated.
-	emptyMsg := lnwire.AnnounceSignatures{}
-
 	// Pass the message into our general fuzz harness for wire messages!
-	return harness(data, &emptyMsg)
+	return harness(data)
 }

--- a/fuzz/lnwire/channel_announcement.go
+++ b/fuzz/lnwire/channel_announcement.go
@@ -11,10 +11,6 @@ func Fuzz_channel_announcement(data []byte) int {
 	// Prefix with MsgChannelAnnouncement.
 	data = prefixWithMsgType(data, lnwire.MsgChannelAnnouncement)
 
-	// Create an empty message so that the FuzzHarness func can check
-	// if the max payload constraint is violated.
-	emptyMsg := lnwire.ChannelAnnouncement{}
-
 	// Pass the message into our general fuzz harness for wire messages!
-	return harness(data, &emptyMsg)
+	return harness(data)
 }

--- a/fuzz/lnwire/channel_reestablish.go
+++ b/fuzz/lnwire/channel_reestablish.go
@@ -11,10 +11,6 @@ func Fuzz_channel_reestablish(data []byte) int {
 	// Prefix with MsgChannelReestablish.
 	data = prefixWithMsgType(data, lnwire.MsgChannelReestablish)
 
-	// Create an empty message so that the FuzzHarness func can check
-	// if the max payload constraint is violated.
-	emptyMsg := lnwire.ChannelReestablish{}
-
 	// Pass the message into our general fuzz harness for wire messages!
-	return harness(data, &emptyMsg)
+	return harness(data)
 }

--- a/fuzz/lnwire/channel_update.go
+++ b/fuzz/lnwire/channel_update.go
@@ -11,10 +11,6 @@ func Fuzz_channel_update(data []byte) int {
 	// Prefix with MsgChannelUpdate.
 	data = prefixWithMsgType(data, lnwire.MsgChannelUpdate)
 
-	// Create an empty message so that the FuzzHarness func can check
-	// if the max payload constraint is violated.
-	emptyMsg := lnwire.ChannelUpdate{}
-
 	// Pass the message into our general fuzz harness for wire messages!
-	return harness(data, &emptyMsg)
+	return harness(data)
 }

--- a/fuzz/lnwire/closing_signed.go
+++ b/fuzz/lnwire/closing_signed.go
@@ -11,10 +11,6 @@ func Fuzz_closing_signed(data []byte) int {
 	// Prefix with MsgClosingSigned.
 	data = prefixWithMsgType(data, lnwire.MsgClosingSigned)
 
-	// Create an empty message so that the FuzzHarness func can check
-	// if the max payload constraint is violated.
-	emptyMsg := lnwire.ClosingSigned{}
-
 	// Pass the message into our general fuzz harness for wire messages!
-	return harness(data, &emptyMsg)
+	return harness(data)
 }

--- a/fuzz/lnwire/commit_sig.go
+++ b/fuzz/lnwire/commit_sig.go
@@ -11,10 +11,6 @@ func Fuzz_commit_sig(data []byte) int {
 	// Prefix with MsgCommitSig.
 	data = prefixWithMsgType(data, lnwire.MsgCommitSig)
 
-	// Create an empty message so that the FuzzHarness func can check
-	// if the max payload constraint is violated.
-	emptyMsg := lnwire.CommitSig{}
-
 	// Pass the message into our general fuzz harness for wire messages!
-	return harness(data, &emptyMsg)
+	return harness(data)
 }

--- a/fuzz/lnwire/error.go
+++ b/fuzz/lnwire/error.go
@@ -11,10 +11,6 @@ func Fuzz_error(data []byte) int {
 	// Prefix with MsgError.
 	data = prefixWithMsgType(data, lnwire.MsgError)
 
-	// Create an empty message so that the FuzzHarness func can check
-	// if the max payload constraint is violated.
-	emptyMsg := lnwire.Error{}
-
 	// Pass the message into our general fuzz harness for wire messages!
-	return harness(data, &emptyMsg)
+	return harness(data)
 }

--- a/fuzz/lnwire/funding_created.go
+++ b/fuzz/lnwire/funding_created.go
@@ -11,10 +11,6 @@ func Fuzz_funding_created(data []byte) int {
 	// Prefix with MsgFundingCreated.
 	data = prefixWithMsgType(data, lnwire.MsgFundingCreated)
 
-	// Create an empty message so that the FuzzHarness func can check
-	// if the max payload constraint is violated.
-	emptyMsg := lnwire.FundingCreated{}
-
 	// Pass the message into our general fuzz harness for wire messages!
-	return harness(data, &emptyMsg)
+	return harness(data)
 }

--- a/fuzz/lnwire/funding_locked.go
+++ b/fuzz/lnwire/funding_locked.go
@@ -11,10 +11,6 @@ func Fuzz_funding_locked(data []byte) int {
 	// Prefix with MsgFundingLocked.
 	data = prefixWithMsgType(data, lnwire.MsgFundingLocked)
 
-	// Create an empty message so that the FuzzHarness func can check
-	// if the max payload constraint is violated.
-	emptyMsg := lnwire.FundingLocked{}
-
 	// Pass the message into our general fuzz harness for wire messages!
-	return harness(data, &emptyMsg)
+	return harness(data)
 }

--- a/fuzz/lnwire/funding_signed.go
+++ b/fuzz/lnwire/funding_signed.go
@@ -11,10 +11,6 @@ func Fuzz_funding_signed(data []byte) int {
 	// Prefix with MsgFundingSigned.
 	prefixWithMsgType(data, lnwire.MsgFundingSigned)
 
-	// Create an empty message so that the FuzzHarness func can check
-	// if the max payload constraint is violated.
-	emptyMsg := lnwire.FundingSigned{}
-
 	// Pass the message into our general fuzz harness for wire messages!
-	return harness(data, &emptyMsg)
+	return harness(data)
 }

--- a/fuzz/lnwire/gossip_timestamp_range.go
+++ b/fuzz/lnwire/gossip_timestamp_range.go
@@ -11,10 +11,6 @@ func Fuzz_gossip_timestamp_range(data []byte) int {
 	// Prefix with MsgGossipTimestampRange.
 	data = prefixWithMsgType(data, lnwire.MsgGossipTimestampRange)
 
-	// Create an empty message so that the FuzzHarness func can check
-	// if the max payload constraint is violated.
-	emptyMsg := lnwire.GossipTimestampRange{}
-
 	// Pass the message into our general fuzz harness for wire messages!
-	return harness(data, &emptyMsg)
+	return harness(data)
 }

--- a/fuzz/lnwire/init.go
+++ b/fuzz/lnwire/init.go
@@ -11,10 +11,6 @@ func Fuzz_init(data []byte) int {
 	// Prefix with MsgInit.
 	data = prefixWithMsgType(data, lnwire.MsgInit)
 
-	// Create an empty message so that the FuzzHarness func can check
-	// if the max payload constraint is violated.
-	emptyMsg := lnwire.Init{}
-
 	// Pass the message into our general fuzz harness for wire messages!
-	return harness(data, &emptyMsg)
+	return harness(data)
 }

--- a/fuzz/lnwire/node_announcement.go
+++ b/fuzz/lnwire/node_announcement.go
@@ -14,10 +14,6 @@ func Fuzz_node_announcement(data []byte) int {
 	// Prefix with MsgNodeAnnouncement.
 	data = prefixWithMsgType(data, lnwire.MsgNodeAnnouncement)
 
-	// Create an empty message so that the FuzzHarness func can check
-	// if the max payload constraint is violated.
-	emptyMsg := lnwire.NodeAnnouncement{}
-
 	// We have to do this here instead of in fuzz.Harness so that
 	// reflect.DeepEqual isn't called. Address (de)serialization messes up
 	// the fuzzing assertions.
@@ -26,20 +22,14 @@ func Fuzz_node_announcement(data []byte) int {
 	r := bytes.NewReader(data)
 
 	// Make sure byte array length (excluding 2 bytes for message type) is
-	// less than max payload size for the wire message. We check this because
-	// otherwise `go-fuzz` will keep creating inputs that crash on ReadMessage
-	// due to a large message size.
+	// less than max payload size for the wire message.
 	payloadLen := uint32(len(data)) - 2
-	if payloadLen > emptyMsg.MaxPayloadLength(0) {
-		// Ignore this input - max payload constraint violated.
+	if payloadLen > lnwire.MaxMsgBody {
 		return 1
 	}
 
 	msg, err := lnwire.ReadMessage(r, 0)
 	if err != nil {
-		// go-fuzz generated []byte that cannot be represented as a
-		// wire message but we will return 0 so go-fuzz can modify the
-		// input.
 		return 1
 	}
 

--- a/fuzz/lnwire/ping.go
+++ b/fuzz/lnwire/ping.go
@@ -11,10 +11,6 @@ func Fuzz_ping(data []byte) int {
 	// Prefix with MsgPing.
 	data = prefixWithMsgType(data, lnwire.MsgPing)
 
-	// Create an empty message so that the FuzzHarness func can check
-	// if the max payload constraint is violated.
-	emptyMsg := lnwire.Ping{}
-
 	// Pass the message into our general fuzz harness for wire messages!
-	return harness(data, &emptyMsg)
+	return harness(data)
 }

--- a/fuzz/lnwire/pong.go
+++ b/fuzz/lnwire/pong.go
@@ -11,10 +11,6 @@ func Fuzz_pong(data []byte) int {
 	// Prefix with MsgPong.
 	data = prefixWithMsgType(data, lnwire.MsgPong)
 
-	// Create an empty message so that the FuzzHarness func can check
-	// if the max payload constraint is violated.
-	emptyMsg := lnwire.Pong{}
-
 	// Pass the message into our general fuzz harness for wire messages!
-	return harness(data, &emptyMsg)
+	return harness(data)
 }

--- a/fuzz/lnwire/query_channel_range.go
+++ b/fuzz/lnwire/query_channel_range.go
@@ -11,10 +11,6 @@ func Fuzz_query_channel_range(data []byte) int {
 	// Prefix with MsgQueryChannelRange.
 	data = prefixWithMsgType(data, lnwire.MsgQueryChannelRange)
 
-	// Create an empty message so that the FuzzHarness func can check
-	// if the max payload constraint is violated.
-	emptyMsg := lnwire.QueryChannelRange{}
-
 	// Pass the message into our general fuzz harness for wire messages!
-	return harness(data, &emptyMsg)
+	return harness(data)
 }

--- a/fuzz/lnwire/query_short_chan_ids.go
+++ b/fuzz/lnwire/query_short_chan_ids.go
@@ -11,10 +11,6 @@ func Fuzz_query_short_chan_ids(data []byte) int {
 	// Prefix with MsgQueryShortChanIDs.
 	data = prefixWithMsgType(data, lnwire.MsgQueryShortChanIDs)
 
-	// Create an empty message so that the FuzzHarness func can check
-	// if the max payload constraint is violated.
-	emptyMsg := lnwire.QueryShortChanIDs{}
-
 	// Pass the message into our general fuzz harness for wire messages!
-	return harness(data, &emptyMsg)
+	return harness(data)
 }

--- a/fuzz/lnwire/query_short_chan_ids_zlib.go
+++ b/fuzz/lnwire/query_short_chan_ids_zlib.go
@@ -42,10 +42,6 @@ func Fuzz_query_short_chan_ids_zlib(data []byte) int {
 	// Prefix with MsgQueryShortChanIDs.
 	payload = prefixWithMsgType(payload, lnwire.MsgQueryShortChanIDs)
 
-	// Create an empty message so that the FuzzHarness func can check
-	// if the max payload constraint is violated.
-	emptyMsg := lnwire.QueryShortChanIDs{}
-
 	// Pass the message into our general fuzz harness for wire messages!
-	return harness(payload, &emptyMsg)
+	return harness(payload)
 }

--- a/fuzz/lnwire/reply_channel_range.go
+++ b/fuzz/lnwire/reply_channel_range.go
@@ -11,10 +11,6 @@ func Fuzz_reply_channel_range(data []byte) int {
 	// Prefix with MsgReplyChannelRange.
 	data = prefixWithMsgType(data, lnwire.MsgReplyChannelRange)
 
-	// Create an empty message so that the FuzzHarness func can check
-	// if the max payload constraint is violated.
-	emptyMsg := lnwire.ReplyChannelRange{}
-
 	// Pass the message into our general fuzz harness for wire messages!
-	return harness(data, &emptyMsg)
+	return harness(data)
 }

--- a/fuzz/lnwire/reply_channel_range_zlib.go
+++ b/fuzz/lnwire/reply_channel_range_zlib.go
@@ -50,10 +50,6 @@ func Fuzz_reply_channel_range_zlib(data []byte) int {
 	// Prefix with MsgReplyChannelRange.
 	payload = prefixWithMsgType(payload, lnwire.MsgReplyChannelRange)
 
-	// Create an empty message so that the FuzzHarness func can check
-	// if the max payload constraint is violated.
-	emptyMsg := lnwire.ReplyChannelRange{}
-
 	// Pass the message into our general fuzz harness for wire messages!
-	return harness(payload, &emptyMsg)
+	return harness(payload)
 }

--- a/fuzz/lnwire/reply_short_chan_ids_end.go
+++ b/fuzz/lnwire/reply_short_chan_ids_end.go
@@ -11,10 +11,6 @@ func Fuzz_reply_short_chan_ids_end(data []byte) int {
 	// Prefix with MsgReplyShortChanIDsEnd.
 	data = prefixWithMsgType(data, lnwire.MsgReplyShortChanIDsEnd)
 
-	// Create an empty message so that the FuzzHarness func can check
-	// if the max payload constraint is violated.
-	emptyMsg := lnwire.ReplyShortChanIDsEnd{}
-
 	// Pass the message into our general fuzz harness for wire messages!
-	return harness(data, &emptyMsg)
+	return harness(data)
 }

--- a/fuzz/lnwire/revoke_and_ack.go
+++ b/fuzz/lnwire/revoke_and_ack.go
@@ -11,10 +11,6 @@ func Fuzz_revoke_and_ack(data []byte) int {
 	// Prefix with MsgRevokeAndAck.
 	data = prefixWithMsgType(data, lnwire.MsgRevokeAndAck)
 
-	// Create an empty message so that the FuzzHarness func can check
-	// if the max payload constraint is violated.
-	emptyMsg := lnwire.RevokeAndAck{}
-
 	// Pass the message into our general fuzz harness for wire messages!
-	return harness(data, &emptyMsg)
+	return harness(data)
 }

--- a/fuzz/lnwire/shutdown.go
+++ b/fuzz/lnwire/shutdown.go
@@ -11,10 +11,6 @@ func Fuzz_shutdown(data []byte) int {
 	// Prefix with MsgShutdown.
 	data = prefixWithMsgType(data, lnwire.MsgShutdown)
 
-	// Create an empty message so that the FuzzHarness func can check
-	// if the max payload constraint is violated.
-	emptyMsg := lnwire.Shutdown{}
-
 	// Pass the message into our general fuzz harness for wire messages!
-	return harness(data, &emptyMsg)
+	return harness(data)
 }

--- a/fuzz/lnwire/update_add_htlc.go
+++ b/fuzz/lnwire/update_add_htlc.go
@@ -11,10 +11,6 @@ func Fuzz_update_add_htlc(data []byte) int {
 	// Prefix with MsgUpdateAddHTLC.
 	data = prefixWithMsgType(data, lnwire.MsgUpdateAddHTLC)
 
-	// Create an empty message so that the FuzzHarness func can check
-	// if the max payload constraint is violated.
-	emptyMsg := lnwire.UpdateAddHTLC{}
-
 	// Pass the message into our general fuzz harness for wire messages!
-	return harness(data, &emptyMsg)
+	return harness(data)
 }

--- a/fuzz/lnwire/update_fail_htlc.go
+++ b/fuzz/lnwire/update_fail_htlc.go
@@ -11,10 +11,6 @@ func Fuzz_update_fail_htlc(data []byte) int {
 	// Prefix with MsgUpdateFailHTLC.
 	data = prefixWithMsgType(data, lnwire.MsgUpdateFailHTLC)
 
-	// Create an empty message so that the FuzzHarness func can check
-	// if the max payload constraint is violated.
-	emptyMsg := lnwire.UpdateFailHTLC{}
-
 	// Pass the message into our general fuzz harness for wire messages!
-	return harness(data, &emptyMsg)
+	return harness(data)
 }

--- a/fuzz/lnwire/update_fail_malformed_htlc.go
+++ b/fuzz/lnwire/update_fail_malformed_htlc.go
@@ -11,10 +11,6 @@ func Fuzz_update_fail_malformed_htlc(data []byte) int {
 	// Prefix with MsgUpdateFailMalformedHTLC.
 	data = prefixWithMsgType(data, lnwire.MsgUpdateFailMalformedHTLC)
 
-	// Create an empty message so that the FuzzHarness func can check
-	// if the max payload constraint is violated.
-	emptyMsg := lnwire.UpdateFailMalformedHTLC{}
-
 	// Pass the message into our general fuzz harness for wire messages!
-	return harness(data, &emptyMsg)
+	return harness(data)
 }

--- a/fuzz/lnwire/update_fee.go
+++ b/fuzz/lnwire/update_fee.go
@@ -11,10 +11,6 @@ func Fuzz_update_fee(data []byte) int {
 	// Prefix with MsgUpdateFee.
 	data = prefixWithMsgType(data, lnwire.MsgUpdateFee)
 
-	// Create an empty message so that the FuzzHarness func can check
-	// if the max payload constraint is violated.
-	emptyMsg := lnwire.UpdateFee{}
-
 	// Pass the message into our general fuzz harness for wire messages!
-	return harness(data, &emptyMsg)
+	return harness(data)
 }

--- a/fuzz/lnwire/update_fulfill_htlc.go
+++ b/fuzz/lnwire/update_fulfill_htlc.go
@@ -11,10 +11,6 @@ func Fuzz_update_fulfill_htlc(data []byte) int {
 	// Prefix with MsgUpdateFulfillHTLC.
 	data = prefixWithMsgType(data, lnwire.MsgUpdateFulfillHTLC)
 
-	// Create an empty message so that the FuzzHarness func can check
-	// if the max payload constraint is violated.
-	emptyMsg := lnwire.UpdateFulfillHTLC{}
-
 	// Pass the message into our general fuzz harness for wire messages!
-	return harness(data, &emptyMsg)
+	return harness(data)
 }


### PR DESCRIPTION
With this pull, the `fuzz/lnwire` tests build and run without crashing.