### PR TITLE
Revert "routing: no backend call to fetch best block"

### DIFF
--- a/docs/release-notes/release-notes-0.13.1.md
+++ b/docs/release-notes/release-notes-0.13.1.md
@@ -37,5 +37,12 @@ The [`monitoring` build tag is now on by
 default](https://github.com/lightningnetwork/lnd/pull/5399) for all routine
 builds.
 
+## Bug Fixes
+
+An optimization intended to speed up the payment critical path by
+eliminating an extra RPC call [has been
+reverted](https://github.com/lightningnetwork/lnd/pull/5404) as it
+introduced a regression that would cause payment failure due to mismatching
+heights.
 
 # Contributors (Alphabetical Order)

--- a/routing/router.go
+++ b/routing/router.go
@@ -10,7 +10,6 @@ import (
 	"time"
 
 	"github.com/btcsuite/btcd/btcec"
-	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcd/wire"
 	"github.com/btcsuite/btcutil"
 	"github.com/davecgh/go-spew/spew"
@@ -489,7 +488,6 @@ func (r *ChannelRouter) Start() error {
 	if err != nil {
 		return err
 	}
-	r.bestHeight = uint32(bestHeight)
 
 	// If the graph has never been pruned, or hasn't fully been created yet,
 	// then we don't treat this as an explicit error.
@@ -565,7 +563,7 @@ func (r *ChannelRouter) Start() error {
 
 		// The graph pruning might have taken a while and there could be
 		// new blocks available.
-		bestHash, bestHeight, err = r.cfg.Chain.GetBestBlock()
+		_, bestHeight, err = r.cfg.Chain.GetBestBlock()
 		if err != nil {
 			return err
 		}
@@ -574,7 +572,7 @@ func (r *ChannelRouter) Start() error {
 		// Before we begin normal operation of the router, we first need
 		// to synchronize the channel graph to the latest state of the
 		// UTXO set.
-		if err := r.syncGraphWithChain(bestHash, bestHeight); err != nil {
+		if err := r.syncGraphWithChain(); err != nil {
 			return err
 		}
 
@@ -706,11 +704,15 @@ func (r *ChannelRouter) Stop() error {
 // the latest UTXO set state. This process involves pruning from the channel
 // graph any channels which have been closed by spending their funding output
 // since we've been down.
-func (r *ChannelRouter) syncGraphWithChain(bestHash *chainhash.Hash,
-	bestHeight int32) error {
-
+func (r *ChannelRouter) syncGraphWithChain() error {
 	// First, we'll need to check to see if we're already in sync with the
 	// latest state of the UTXO set.
+	bestHash, bestHeight, err := r.cfg.Chain.GetBestBlock()
+	if err != nil {
+		return err
+	}
+	r.bestHeight = uint32(bestHeight)
+
 	pruneHash, pruneHeight, err := r.cfg.Graph.PruneTip()
 	if err != nil {
 		switch {
@@ -2200,7 +2202,10 @@ func (r *ChannelRouter) sendPayment(
 
 	// We'll also fetch the current block height so we can properly
 	// calculate the required HTLC time locks within the route.
-	currentHeight := int32(atomic.LoadUint32(&r.bestHeight))
+	_, currentHeight, err := r.cfg.Chain.GetBestBlock()
+	if err != nil {
+		return [32]byte{}, nil, err
+	}
 
 	// Now set up a paymentLifecycle struct with these params, such that we
 	// can resume the payment from the current state.


### PR DESCRIPTION
This reverts commit cdddaaca75bba03f408991702e30d581df80daad.

During further testing, we realized that at times neutrino clients may not have an up to date height, meaning they'll incorrectly use a nearer block height leading to a failed payment. We need to investigate this further, but this might be fixed by https://github.com/lightningnetwork/lnd/pull/5315. With regards to this optimization, now that we have https://github.com/lightningnetwork/lnd/pull/5156 it'll be the case that this height is already cached at this point, meaning at most we'll fetch this block twice. Reverting this lets us ensure proper consistency at the send payment call site. 

Fixes #5421
Fixes #5406
Fixes #5415