### PR TITLE
sample-lnd.conf: fix, move astray neutrino and routing options

### DIFF
--- a/sample-lnd.conf
+++ b/sample-lnd.conf
@@ -517,37 +517,6 @@ bitcoin.node=btcd
 ; bitcoin.dnsseed=seed1.test.lightning
 ; bitcoin.dnsseed=seed2.test.lightning,soa.seed2.test.lightning
 
-; Used to help identify ourselves to other bitcoin peers (default: neutrino).
-; neutrino.useragentname=neutrino
-
-; Used to help identify ourselves to other bitcoin peers (default: 0.11.0-beta).
-; neutrino.useragentversion=0.11.0-beta
-
-; The amount of time to wait before giving up on a transaction broadcast attempt.
-; neutrino.broadcasttimeout=5s
-
-; Whether compact filters fetched from the P2P network should be persisted to disk.
-; neutrino.persistfilters=true
-
-; Validate every channel in the graph during sync by downloading the containing
-; block. This is the inverse of routing.assumechanvalid, meaning that for
-; Neutrino the validation is turned off by default for massively increased graph
-; sync performance. This speedup comes at the risk of using an unvalidated view
-; of the network for routing. Overwrites the value of routing.assumechanvalid if
-; Neutrino is used. (default: false)
-; neutrino.validatechannels=false
-
-; DEPRECATED: This is now turned on by default for Neutrino (use 
-; neutrino.validatechannels=true to turn off) and shouldn't be used for any
-; other backend!
-; --routing.assumechanvalid=true
-
-; If set to true, then we'll prune a channel if only a single edge is seen as
-; being stale. This results in a more compact channel graph, and also is helpful
-; for neutrino nodes as it means they'll only maintain edges where both nodes are
-; seen as being live from it's PoV.
-; --routing.strictgraphpruning=true
-
 [Btcd]
 
 ; The base directory that contains the node's data, logs, configuration file,
@@ -648,6 +617,26 @@ bitcoin.node=btcd
 ; filter header chain on startup. If the assertion does not hold, then the
 ; filter header chain will be re-synced from the genesis block.
 ; neutrino.assertfilterheader=
+
+; Used to help identify ourselves to other bitcoin peers (default: neutrino).
+; neutrino.useragentname=neutrino
+
+; Used to help identify ourselves to other bitcoin peers (default: 0.11.0-beta).
+; neutrino.useragentversion=0.11.0-beta
+
+; The amount of time to wait before giving up on a transaction broadcast attempt.
+; neutrino.broadcasttimeout=5s
+
+; Whether compact filters fetched from the P2P network should be persisted to disk.
+; neutrino.persistfilters=true
+
+; Validate every channel in the graph during sync by downloading the containing
+; block. This is the inverse of routing.assumechanvalid, meaning that for
+; Neutrino the validation is turned off by default for massively increased graph
+; sync performance. This speedup comes at the risk of using an unvalidated view
+; of the network for routing. Overwrites the value of routing.assumechanvalid if
+; Neutrino is used. (default: false)
+; neutrino.validatechannels=false
 
 [Litecoin]
 
@@ -1176,3 +1165,15 @@ litecoin.node=ltcd
 ; enough to prevent force closes.
 ;
 ; invoices.holdexpirydelta=15
+
+[routing]
+; DEPRECATED: This is now turned on by default for Neutrino (use 
+; neutrino.validatechannels=true to turn off) and shouldn't be used for any
+; other backend!
+; routing.assumechanvalid=true
+
+; If set to true, then we'll prune a channel if only a single edge is seen as
+; being stale. This results in a more compact channel graph, and also is helpful
+; for neutrino nodes as it means they'll only maintain edges where both nodes are
+; seen as being live from it's PoV.
+; routing.strictgraphpruning=true


### PR DESCRIPTION
Fixes the routing.strictgraphpruning example which doesn't work. It should be in the routing section and not have the -- command line prefix.

While at it, moved the nearby neutrino and other routing options to their respective sections.