### PR TITLE
lncli: check for existence of tls file

### DIFF
--- a/cmd/lncli/profile.go
+++ b/cmd/lncli/profile.go
@@ -124,12 +124,11 @@ func profileFromContext(ctx *cli.Context, store, skipMacaroons bool) (
 	// Load the certificate file now, if specified. We store it as plain PEM
 	// directly.
 	var tlsCert []byte
-	if lnrpc.FileExists(tlsCertPath) {
+	if tlsCertPath != "" {
 		var err error
 		tlsCert, err = ioutil.ReadFile(tlsCertPath)
 		if err != nil {
-			return nil, fmt.Errorf("could not load TLS cert file "+
-				"%s: %v", tlsCertPath, err)
+			return nil, fmt.Errorf("could not load TLS cert file: %v", err)
 		}
 	}
 


### PR DESCRIPTION
Fixes #5109.
Instead of checking the existence of the tls file, from global options, we are looking at the string itself. If the file is missing it will return the error message:
`[lncli] could not load global options: could not load TLS cert file: open .lnd/missing_tls.cert: no such file or directory`
If the tls cert path string is empty we proceed like before.