### PR TITLE
docs/release-notes: add new in-tree location for release notes

### DIFF
--- a/docs/release-notes/release-notes-0.13.1.md
+++ b/docs/release-notes/release-notes-0.13.1.md
@@ -1,0 +1,41 @@
+# Release Notes
+
+## Peer to Peer Protocol
+
+Scripts received as part of an upfront shutdown script [are now properly
+sanitized](https://github.com/lightningnetwork/lnd/pull/5369) to ensure
+widespread relay of potential cooperative channel closures.
+
+## RPC Server
+
+[The `Shutdown` command will now return an
+error](https://github.com/lightningnetwork/lnd/pull/5364) if one attempts to
+call the command while `lnd` is rescanning.
+
+New clients connecting/disconnecting to the transaction subscription stream
+[are now logged](https://github.com/lightningnetwork/lnd/pull/5358).
+
+[The `MinConfs` param is now properly examined if the `SendAll` param is
+set](https://github.com/lightningnetwork/lnd/pull/5200) for the `SendCoins` RPC
+call.
+
+## Integration Test Improvements
+
+[A bug has been fixed in the `testChannelForceClosure`
+test](https://github.com/lightningnetwork/lnd/pull/5348) that would cause the
+test to assert the wrong balance (the miner fee wasn't accounted for).
+
+## Forwarding Optimizations
+
+[Decoding onion blobs is now done in
+parallel](https://github.com/lightningnetwork/lnd/pull/5248) when decoding the
+routing information for several HTLCs as once.
+
+## Build System
+
+The [`monitoring` build tag is now on by
+default](https://github.com/lightningnetwork/lnd/pull/5399) for all routine
+builds.
+
+
+# Contributors (Alphabetical Order)

--- a/docs/release-notes/release-notes-0.14.0.md
+++ b/docs/release-notes/release-notes-0.14.0.md
@@ -1,0 +1,3 @@
+# Release Notes
+
+# Contributors (Alphabetical Order)


### PR DESCRIPTION
In this commit, we add a new folder within the `docs` directory that will
house the release notes for all versions of `lnd` going forward.  Moving to
use `git` for the release notes rather than the normal drafting procedure
lets us keep track of the set of changes more consistency over time, lets
contributors add their release notes over time, and also means we'll no
longer need to do a crunch at the tail end of the release process to fill in
the set of release notes.

For the 0.13.1 release notes, I've done a scan and added anything that has
been merged since the last major version tag.  In a follow up change, we'll
add a new Github action that fails the build if an entry in the release
notes linking to the newly added PR isn't committed as well. Until then, any
PRs merged in should ensure that they add an entry within the relevant
milestone.

