### PR TITLE
lnd: only set payment address if not empty in PaymentRequest

### DIFF
--- a/rpcserver.go
+++ b/rpcserver.go
@@ -4347,10 +4347,14 @@ func (r *rpcServer) extractPaymentIntent(rpcPayReq *rpcPaymentRequest) (rpcPayme
 		return payIntent, errors.New("invalid payment address length")
 	}
 
-	if payIntent.paymentAddr == nil {
+	// Set the payment address if it was explicitly defined with the
+	// rpcPaymentRequest.
+	// Note that the payment address for the payIntent should be nil if none
+	// was provided with the rpcPaymentRequest.
+	if len(rpcPayReq.PaymentAddr) != 0 {
 		payIntent.paymentAddr = &[32]byte{}
+		copy(payIntent.paymentAddr[:], rpcPayReq.PaymentAddr)
 	}
-	copy(payIntent.paymentAddr[:], rpcPayReq.PaymentAddr)
 
 	// Otherwise, If the payment request field was not specified
 	// (and a custom route wasn't specified), construct the payment


### PR DESCRIPTION
## Background

This PR addresses an issue where not defining a payment address with the `SendPaymentRequest` results in a `payment_incorrect_details` error for:
* keysend payments, and 
* in LND versions <=0.11 when defining the payment directly using the pubkey in `Dest` and `PaymentHash` instead of using an invoice with `PaymentRequest`.

The error occurs as not defining a payment address with the `SendPaymentRequest` results in an _empty_ payment address byte array in the `paymentIntent` instead of a nil-value.

fixes #5413