### PR TITLE
routing: rename method and add err check when launch shard

### DIFF
--- a/routing/payment_lifecycle_test.go
+++ b/routing/payment_lifecycle_test.go
@@ -1083,7 +1083,7 @@ func TestUpdatePaymentState(t *testing.T) {
 			}
 
 			// Call the method that updates the payment state.
-			_, state, err := pl.updatePaymentState()
+			_, state, err := pl.fetchPaymentState()
 
 			// Assert that the mock method is called as
 			// intended.


### PR DESCRIPTION
A follow-up commit for PR #5332 . In this commit we add more docs, rename
function updatePaymentState to fetchePaymentState, and add back the
check for `channeldb.ErrPaymentTerminal` after we launch shard.
