### PR TITLE
Remove deprecated "protocol.anchors" setting from sample-lnd.conf

### DIFF
--- a/sample-lnd.conf
+++ b/sample-lnd.conf
@@ -388,11 +388,6 @@
 ; invoices will be accepted regardless of this setting.
 ; accept-amp=true
 
-; If set, lnd will use anchor channels by default if the remote channel party
-; supports them. Note that lnd will require 1 UTXO to be reserved for this
-; channel type if it is enabled.
-; protocol.anchors=true
-
 ; If true, we'll attempt to garbage collect canceled invoices upon start.
 ; gc-canceled-invoices-on-startup=true
 
@@ -1041,7 +1036,10 @@ litecoin.node=ltcd
 ; BTC
 ; protocol.wumbo-channels=true
 
-; Set to disable support for anchor commitments
+; Set to disable support for anchor commitments. If not set, lnd will use anchor
+; channels by default if the remote channel party supports them. Note that lnd
+; will require 1 UTXO to be reserved for this channel type if it is enabled.
+; (Deprecates the previous "protocol.anchors" setting.)
 ; protocol.no-anchors=true
 
 [db]


### PR DESCRIPTION
Remove deprecated "protocol.anchors" setting from sample-lnd.conf (after it has been replaced by protocol.no-anchors)

This is to avoid confusion, given that several popular guides still mention the older protocol.anchors setting (e.g., RaspiBolt).