### PR TITLE
lncli: fix psbt fund parameter parsing

### DIFF
--- a/cmd/lncli/walletrpc_active.go
+++ b/cmd/lncli/walletrpc_active.go
@@ -651,14 +651,15 @@ func fundPsbt(ctx *cli.Context) error {
 		return fmt.Errorf("cannot set conf_target and sat_per_vbyte " +
 			"at the same time")
 
-	case ctx.Uint64("conf_target") > 0:
-		req.Fees = &walletrpc.FundPsbtRequest_TargetConf{
-			TargetConf: uint32(ctx.Uint64("conf_target")),
-		}
-
 	case ctx.Uint64("sat_per_vbyte") > 0:
 		req.Fees = &walletrpc.FundPsbtRequest_SatPerVbyte{
 			SatPerVbyte: ctx.Uint64("sat_per_vbyte"),
+		}
+
+	// Check conf_target last because it has a default value.
+	case ctx.Uint64("conf_target") > 0:
+		req.Fees = &walletrpc.FundPsbtRequest_TargetConf{
+			TargetConf: uint32(ctx.Uint64("conf_target")),
 		}
 	}
 


### PR DESCRIPTION
The sat_per_vbyte parameter was ignored because of a default value for conf_target.

As a side note: I think it may be better to do parameter validation server-side, because it needs to happen there anyway. In this case for `FundPsbt`, it doesn't seem strict enough because the server allows both `TargetConf` and `SatPerVbyte` to be set, silently ignoring the latter.