### PR TITLE
walletrpc+lncli: allow zero output psbt funding

### DIFF
--- a/cmd/lncli/walletrpc_active.go
+++ b/cmd/lncli/walletrpc_active.go
@@ -659,26 +659,24 @@ func fundPsbt(ctx *cli.Context) error {
 			Psbt: psbtBytes,
 		}
 
-	// The user manually specified outputs and optional inputs in JSON
+	// The user manually specified outputs and/or inputs in JSON
 	// format.
-	case len(ctx.String("outputs")) > 0:
+	case len(ctx.String("outputs")) > 0 || len(ctx.String("inputs")) > 0:
 		var (
 			tpl          = &walletrpc.TxTemplate{}
 			amountToAddr map[string]uint64
 		)
 
-		// Parse the address to amount map as JSON now. At least one
-		// entry must be present.
-		jsonMap := []byte(ctx.String("outputs"))
-		if err := json.Unmarshal(jsonMap, &amountToAddr); err != nil {
-			return fmt.Errorf("error parsing outputs JSON: %v",
-				err)
+		if len(ctx.String("outputs")) > 0 {
+			// Parse the address to amount map as JSON now. At least one
+			// entry must be present.
+			jsonMap := []byte(ctx.String("outputs"))
+			if err := json.Unmarshal(jsonMap, &amountToAddr); err != nil {
+				return fmt.Errorf("error parsing outputs JSON: %v",
+					err)
+			}
+			tpl.Outputs = amountToAddr
 		}
-		if len(amountToAddr) == 0 {
-			return fmt.Errorf("at least one output must be " +
-				"specified")
-		}
-		tpl.Outputs = amountToAddr
 
 		// Inputs are optional.
 		if len(ctx.String("inputs")) > 0 {
@@ -707,7 +705,7 @@ func fundPsbt(ctx *cli.Context) error {
 
 	default:
 		return fmt.Errorf("must specify either template_psbt or " +
-			"outputs flag")
+			"inputs/outputs flag")
 	}
 
 	// Parse fee flags.

--- a/docs/release-notes/release-notes-0.14.0.md
+++ b/docs/release-notes/release-notes-0.14.0.md
@@ -25,6 +25,12 @@ for more information.
 * [Stub code for interacting with `lnrpc` from a WASM context through JSON 
   messages was added](https://github.com/lightningnetwork/lnd/pull/5601).
 
+## Wallet
+
+* It is now possible to fund a psbt [without specifying any
+  outputs](https://github.com/lightningnetwork/lnd/pull/5442). This option is
+  useful for CPFP bumping of unconfirmed outputs or general utxo consolidation.
+
 ## Security 
 
 ### Admin macaroon permissions

--- a/lnrpc/walletrpc/walletkit_server.go
+++ b/lnrpc/walletrpc/walletkit_server.go
@@ -996,9 +996,6 @@ func (w *WalletKit) FundPsbt(_ context.Context,
 	// PSBT and copy the RPC information over.
 	case req.GetRaw() != nil:
 		tpl := req.GetRaw()
-		if len(tpl.Outputs) == 0 {
-			return nil, fmt.Errorf("no outputs specified")
-		}
 
 		txOut := make([]*wire.TxOut, 0, len(tpl.Outputs))
 		for addrStr, amt := range tpl.Outputs {


### PR DESCRIPTION
To support the cpfp fee bump use case where no external outputs are required.

Depends on https://github.com/btcsuite/btcwallet/pull/753