### PR TITLE
sample-lnd.conf: remove duplicate setting and clean up section separators

### DIFF
--- a/sample-lnd.conf
+++ b/sample-lnd.conf
@@ -177,9 +177,6 @@
 ; support devices behind multiple NATs.
 ; nat=true
 
-; Disable listening for incoming peer connections.
-; nolisten=true
-
 ; Disable REST API.
 ; norest=true
 

--- a/sample-lnd.conf
+++ b/sample-lnd.conf
@@ -14,9 +14,9 @@
 ; The directory that lnd stores all wallet, chain, and channel related data
 ; within The default is ~/.lnd/data on POSIX OSes, $LOCALAPPDATA/Lnd/data on
 ; Windows, ~/Library/Application Support/Lnd/data on Mac OS, and $home/lnd/data
-; on Plan9.  Environment variables are expanded so they may be used.  NOTE:
+; on Plan9. Environment variables are expanded so they may be used. NOTE:
 ; Windows environment variables are typically %VARIABLE%, but they must be
-; accessed with $VARIABLE here.  Also, ~ is expanded to $LOCALAPPDATA on Windows.
+; accessed with $VARIABLE here. Also, ~ is expanded to $LOCALAPPDATA on Windows.
 ; datadir=~/.lnd/data
 
 ; The directory that logs are stored in. The logs are auto-rotated by default.
@@ -122,8 +122,7 @@
 ; into account.
 ; payments-expiration-grace-period=30
 
-
-; Specify the interfaces to listen on for p2p connections.  One listen
+; Specify the interfaces to listen on for p2p connections. One listen
 ; address per line.
 ; All ipv4 on port 9735:
 ;   listen=0.0.0.0:9735
@@ -131,11 +130,11 @@
 ;   listen=0.0.0.0:9735
 ;   listen=[::1]:9736
 
-; Disable listening for incoming p2p connections.  This will override all
+; Disable listening for incoming p2p connections. This will override all
 ; listeners.
 ; nolisten=true
 
-; Specify the interfaces to listen on for gRPC connections.  One listen
+; Specify the interfaces to listen on for gRPC connections. One listen
 ; address per line.
 ; Only ipv4 localhost on port 10009:
 ;   rpclisten=localhost:10009
@@ -145,7 +144,7 @@
 ; On an Unix socket:
 ;   rpclisten=unix:///var/run/lnd/lnd-rpclistener.sock
 
-; Specify the interfaces to listen on for REST connections.  One listen
+; Specify the interfaces to listen on for REST connections. One listen
 ; address per line.
 ; All ipv4 interfaces on port 8080:
 ;   restlisten=0.0.0.0:8080
@@ -158,7 +157,6 @@
 ; A series of domains to allow cross origin access from. This controls the CORs
 ; policy of the REST RPC proxy.
 ; restcors=https://my-special-site.com
-
 
 ; Adding an external IP will advertise your node to the network. This signals
 ; that your node is available to accept incoming channels. If you don't wish to
@@ -212,7 +210,7 @@
 ; Debug logging level.
 ; Valid levels are {trace, debug, info, warn, error, critical}
 ; You may also specify <global-level>,<subsystem>=<level>,<subsystem2>=<level>,... 
-; to set log level for individual subsystems.  Use lncli debuglevel --show to 
+; to set log level for individual subsystems. Use lncli debuglevel --show to 
 ; list available subsystems.
 ; debuglevel=debug,PEER=info
 
@@ -512,6 +510,7 @@ bitcoin.node=btcd
 ; bitcoin.dnsseed=seed1.test.lightning
 ; bitcoin.dnsseed=seed2.test.lightning,soa.seed2.test.lightning
 
+
 [Btcd]
 
 ; The base directory that contains the node's data, logs, configuration file,
@@ -578,6 +577,7 @@ bitcoin.node=btcd
 ; pruned blocks from. This only applies to pruned nodes.
 ; bitcoind.pruned-node-max-peers=4
 
+
 [neutrino]
 
 ; Connect only to the specified peers at startup. This creates a persistent
@@ -632,6 +632,7 @@ bitcoin.node=btcd
 ; of the network for routing. Overwrites the value of routing.assumechanvalid if
 ; Neutrino is used. (default: false)
 ; neutrino.validatechannels=false
+
 
 [Litecoin]
 
@@ -710,6 +711,7 @@ litecoin.node=ltcd
 ; litecoin.dnsseed=seed1.test-ltc.lightning
 ; litecoin.dnsseed=seed2.test-ltc.lightning,soa.seed2.test-ltc.lightning
 
+
 [Ltcd]
 
 ; The base directory that contains the node's data, logs, configuration file,
@@ -776,6 +778,7 @@ litecoin.node=ltcd
 ; pruned blocks from. This only applies to pruned nodes.
 ; litecoind.pruned-node-max-peers=4
 
+
 [autopilot]
 
 ; If the autopilot agent should be active or not. The autopilot agent will
@@ -813,6 +816,7 @@ litecoin.node=ltcd
 ; The confirmation target (in blocks) for channels opened by autopilot. (default:
 ; 3)
 ; autopilot.conftarget=2
+
 
 [tor]
 ; Allow outbound and inbound connections to be routed through Tor
@@ -858,11 +862,13 @@ litecoin.node=ltcd
 ;The path to the private key of the watchtower onion service being created
 ; tor.watchtowerkeypath=/other/path/
 
+
 [watchtower]
+
 ; Enable integrated watchtower listening on :9911 by default.
 ; watchtower.active=true
 
-; Specify the interfaces to listen on for watchtower client connections.  One
+; Specify the interfaces to listen on for watchtower client connections. One
 ; listen address per line. If no port is specified the default port of 9911 will
 ; be added implicitly.
 ; All ipv4 on port 9911:
@@ -892,7 +898,9 @@ litecoin.node=ltcd
 ; hanging up on client connections
 ; watchtower.writetimeout=15s
 
+
 [wtclient]
+
 ; Activate Watchtower Client. To get more information or configure watchtowers
 ; run `lncli wtclient -h`.
 ; wtclient.active=true
@@ -908,7 +916,9 @@ litecoin.node=ltcd
 ; supported at this time, if none are provided the tower will not be enabled.
 ; wtclient.private-tower-uris=
 
+
 [healthcheck]
+
 ; The number of times we should attempt to query our chain backend before
 ; gracefully shutting down. Set this value to 0 to disable this health check.
 ; healthcheck.chainbackend.attempts=3
@@ -960,22 +970,27 @@ litecoin.node=ltcd
 ; This value must be >= 1m.
 ; healthcheck.tls.interval=1m
 
+
 [signrpc]
 
 ; Path to the signer macaroon.
 ; signrpc.signermacaroonpath=~/.lnd/data/chain/bitcoin/simnet/signer.macaroon
+
 
 [walletrpc]
 
 ; Path to the wallet kit macaroon.
 ; walletrpc.walletkitmacaroonpath=~/.lnd/data/chain/bitcoin/simnet/walletkit.macaroon
 
+
 [chainrpc]
 
 ; Path to the chain notifier macaroon.
 ; chainrpc.notifiermacaroonpath=~/.lnd/data/chain/bitcoin/simnet/chainnotifier.macaroon
 
+
 [routerrpc]
+
 ; Minimum required route success probability to attempt the payment (default:
 ; 0.01)
 ; routerrpc.minrtprob=1
@@ -1006,18 +1021,21 @@ litecoin.node=ltcd
 ; Path to the router macaroon
 ; routerrpc.routermacaroonpath=~/.lnd/data/chain/bitcoin/simnet/router.macaroon
 
+
 [workers]
+
 ; Maximum number of concurrent read pool workers. This number should be
 ; proportional to the number of peers. (default: 100)
 ; workers.read=200
 
 ; Maximum number of concurrent write pool workers. This number should be
-; proportional to the number of CPUs on the host.  (default: 8)
+; proportional to the number of CPUs on the host. (default: 8)
 ; workers.write=8
 
 ; Maximum number of concurrent sig pool workers. This number should be
 ; proportional to the number of CPUs on the host. (default: 8)
 ; workers.sig=4
+
 
 [caches]
 
@@ -1031,7 +1049,9 @@ litecoin.node=ltcd
 ; roughly 2Kb. (default: 20000)
 ; caches.channel-cache-size=9000000
 
+
 [protocol]
+
 ; If set, then lnd will create and accept requests for channels larger than 0.16
 ; BTC
 ; protocol.wumbo-channels=true
@@ -1042,7 +1062,9 @@ litecoin.node=ltcd
 ; (Deprecates the previous "protocol.anchors" setting.)
 ; protocol.no-anchors=true
 
+
 [db]
+
 ; The selected database backend. The current default backend is "bolt". lnd
 ; also has experimental support for etcd, a replicated backend.
 ; db.backend=bolt
@@ -1051,7 +1073,9 @@ litecoin.node=ltcd
 ; a batch of modifications to disk. Defaults to 500 milliseconds.
 ; db.batch-commit-interval=500ms
 
+
 [etcd]
+
 ; Etcd database host.
 ; db.etcd.host=localhost:2379
 
@@ -1089,7 +1113,9 @@ litecoin.node=ltcd
 ; If non zero, LND will use this as peer port for the embedded etcd instance.
 ; db.etcd.embedded_peer_port=1235
 
+
 [cluster]
+
 ; Enables leader election if set.
 ; cluster.enable-leader-election=true
 
@@ -1103,7 +1129,9 @@ litecoin.node=ltcd
 ; Defaults to the hostname.
 ; cluster.id=example.com
 
+
 [bolt]
+
 ; If true, prevents the database from syncing its freelist to disk. 
 ; db.bolt.nofreelistsync=1
 
@@ -1122,7 +1150,9 @@ litecoin.node=ltcd
 ; Specify the timeout to be used when opening the database.
 ; db.bolt.dbtimeout=60s
 
+
 [gossip]
+
 ; Specify a set of pinned gossip syncers, which will always be actively syncing
 ; whenever the corresponding peer is online. A pinned syncer does not count
 ; towards the configured `numgraphsyncpeers` since pinned syncers are not
@@ -1144,7 +1174,9 @@ litecoin.node=ltcd
 ; gossip.max-channel-update-burst=10
 ; gossip.channel-update-interval=1m
 
+
 [invoices]
+
 ; If a hold invoice has accepted htlcs that reach their expiry height and are 
 ; not timed out, the channel holding the htlc is force closed to resolve the
 ; invoice's htlcs. To prevent force closes, lnd automatically cancels these 
@@ -1164,7 +1196,9 @@ litecoin.node=ltcd
 ;
 ; invoices.holdexpirydelta=15
 
+
 [routing]
+
 ; DEPRECATED: This is now turned on by default for Neutrino (use 
 ; neutrino.validatechannels=true to turn off) and shouldn't be used for any
 ; other backend!


### PR DESCRIPTION
973e87b remove extra whitespace and harmonizes the separators between config sections

2c92958 deletes a duplicate "nolisten=true" line + comment