### PR TITLE
chainntnfs: neutrinonotify patches

### DIFF
--- a/chainntnfs/neutrinonotify/neutrino.go
+++ b/chainntnfs/neutrinonotify/neutrino.go
@@ -777,6 +777,14 @@ func (n *NeutrinoNotifier) RegisterSpendNtfn(outpoint *wire.OutPoint,
 		return ntfn.Event, nil
 	}
 
+	// Grab the current best height as the height may have been updated
+	// while we were draining the chainUpdates queue.
+	n.bestBlockMtx.RLock()
+	currentHeight := uint32(n.bestBlock.Height)
+	n.bestBlockMtx.RUnlock()
+
+	ntfn.HistoricalDispatch.EndHeight = currentHeight
+
 	// With the filter updated, we'll dispatch our historical rescan to
 	// ensure we detect the spend if it happened in the past.
 	n.wg.Add(1)
@@ -928,6 +936,14 @@ func (n *NeutrinoNotifier) RegisterConfirmationsNtfn(txid *chainhash.Hash,
 	if ntfn.HistoricalDispatch == nil {
 		return ntfn.Event, nil
 	}
+
+	// Grab the current best height as the height may have been updated
+	// while we were draining the chainUpdates queue.
+	n.bestBlockMtx.RLock()
+	currentHeight := uint32(n.bestBlock.Height)
+	n.bestBlockMtx.RUnlock()
+
+	ntfn.HistoricalDispatch.EndHeight = currentHeight
 
 	// Finally, with the filter updated, we can dispatch the historical
 	// rescan to ensure we can detect if the event happened in the past.

--- a/chainntnfs/neutrinonotify/neutrino_dev.go
+++ b/chainntnfs/neutrinonotify/neutrino_dev.go
@@ -63,7 +63,6 @@ func (n *NeutrinoNotifier) UnsafeStart(bestHeight int32,
 	)
 	n.rescanErr = n.chainView.Start()
 
-	n.chainUpdates.Start()
 	n.txUpdates.Start()
 
 	if generateBlocks != nil {
@@ -80,8 +79,8 @@ func (n *NeutrinoNotifier) UnsafeStart(bestHeight int32,
 	loop:
 		for {
 			select {
-			case ntfn := <-n.chainUpdates.ChanOut():
-				lastReceivedNtfn := ntfn.(*filteredBlock)
+			case ntfn := <-n.chainUpdates:
+				lastReceivedNtfn := ntfn
 				if lastReceivedNtfn.height >= uint32(syncHeight) {
 					break loop
 				}

--- a/chainntnfs/txnotifier.go
+++ b/chainntnfs/txnotifier.go
@@ -872,10 +872,13 @@ func (n *TxNotifier) UpdateConfDetails(confRequest ConfRequest,
 func (n *TxNotifier) dispatchConfDetails(
 	ntfn *ConfNtfn, details *TxConfirmation) error {
 
-	// If no details are provided, return early as we can't dispatch.
-	if details == nil {
-		Log.Debugf("Unable to dispatch %v, no details provided",
-			ntfn.ConfRequest)
+	// If there are no conf details to dispatch or if the notification has
+	// already been dispatched, then we can skip dispatching to this
+	// client.
+	if details == nil || ntfn.dispatched {
+		Log.Debugf("Skipping dispatch of conf details(%v) for "+
+			"request %v, dispatched=%v", details, ntfn.ConfRequest,
+			ntfn.dispatched)
 
 		return nil
 	}

--- a/docs/release-notes/release-notes-0.14.0.md
+++ b/docs/release-notes/release-notes-0.14.0.md
@@ -190,6 +190,8 @@ mode](https://github.com/lightningnetwork/lnd/pull/5564).
 
 [A validation check for sane `CltvLimit` and `FinalCltvDelta` has been added for `REST`-initiated payments.](https://github.com/lightningnetwork/lnd/pull/5591)
 
+[A bug has been fixed with Neutrino's `RegisterConfirmationsNtfn` and `RegisterSpendNtfn` calls that would cause notifications to be missed.](https://github.com/lightningnetwork/lnd/pull/5453)
+
 ## Documentation 
 
 The [code contribution guidelines have been updated to mention the new


### PR DESCRIPTION
**Commit Overview:** 
- `chainntnfs: skip conf dispatch if ntfn already dispatched` is a minor change that prevents a double dispatch scenario in later logic. It mirrors the spending case.
- `chainntnfs/neutrinonotify: make chainUpdates a buffered chan` changes `chainUpdates` from `ConcurrentQueue` to `chan *filteredBlock`.
- `chainntnfs/neutrinonotify: call drainChainUpdates when updating filter` calls `drainChainUpdates` after applying the filter which will take everything off of `chainUpdates` and handle each update before giving control back to the filter update caller.
- `chainntnfs/neutrinonotify: update EndHeight after filter update` updates the `EndHeight` of a historical dispatch *after* updating the filter. This allows us to catch confirmations / spends that happened in this racing block.

**What this patch doesn't do**
- This patch doesn't handle chain reorg scenarios that are racing. There are already problems with all backends for racing chain reorgs that can be handled in a future patch. Handling these issues would be a first step towards getting the integration reorg test to pass for neutrino. This is a neutrino-specific patch that seeks to fix the issue outlined in:
   - https://github.com/lightningnetwork/lnd/issues/4866

**Race condition issue (brief description)**
- (goroutine 1) `RegisterConfirmationsNtfn` or `RegisterSpendNtfn` is called
- (goroutine 1)`RegisterConf` or `RegisterSpend` is called, updating the `txnotifier` internal state to add a confirmation or spend request.
- (goroutine 2) block is received that contains the target confirmation or spend. This block doesn't have the target filter applied and does not notify about the confirmation or spend.
- (goroutine 1) filter update request is sent to goroutine 2
- (goroutine 2) receives filter update request and sends it to Neutrino via API calls.  When the filter update is received by Neutrino, control will return back to this goroutine.  This goroutine will in turn return control back to the goroutine 1.
- (goroutine 1) starts a historical dispatch (if applicable) from `[height hint -> block height - 1]`
- Historical dispatch will not find the confirmation or spend, and the block was already received so there is no notification.

**Patch solution**
- Applying the filter update is done like so:
  - https://github.com/lightningnetwork/lnd/blob/71934ad98522a28b83b10e6560fb6309a3729c4e/chainntnfs/neutrinonotify/neutrino.go#L494-L499
  - In the neutrino repo, this function sends to a non-buffered update channel, which will receive it and update the filter.  The goroutine that receives it also dispatches connected and disconnected filtered block events.
  - This means the filter update is in some sense "atomic".  On the neutrino end, once the filter is received, all updates will have the filter applied.
- After applying the filter update via `Update`, if we drain the `chainUpdates` chan completely before allowing a historical dispatch to occur, we ensure that any updates *after* the drain *must* have the filter applied.
  - This is because `chainUpdates` is a buffered chan.
  - Neutrino uses [onFilteredBlockConnected](https://github.com/lightningnetwork/lnd/blob/71934ad98522a28b83b10e6560fb6309a3729c4e/chainntnfs/neutrinonotify/neutrino.go#L247) & [onFilteredBlockDisconnected](https://github.com/lightningnetwork/lnd/blob/71934ad98522a28b83b10e6560fb6309a3729c4e/chainntnfs/neutrinonotify/neutrino.go#L265) to notify us, which uses the `chainUpdates` chan.
  - The assumption that any updates after the drain must have the filter update applied does not hold if `chainUpdates` is a `ConcurrentQueue`. This is due to the fact that `ConcurrentQueue` may have items inside its internal data structures that are not yet reflected in the `ChanOut()` call.
- Update historical scan `EndHeight`. This allows a historical scan to re-scan the blocks that did not have the filter applied but were not included in the initial historical scan parameters generated by `RegisterConf` or `RegisterSpend`.
  - Due to the `chainUpdates` draining logic, all updates after the `EndHeight` *must* have the filter applied, so if a historical scan does not catch anything, then there was nothing to catch.

TODO: 

- [ ] In-repo test for linked issue

Fixes: https://github.com/lightningnetwork/lnd/issues/4866