### PR TITLE
htlcswitch: fix docs on LookupCircuit

### DIFF
--- a/htlcswitch/circuit_map.go
+++ b/htlcswitch/circuit_map.go
@@ -489,8 +489,8 @@ func (cm *circuitMap) TrimOpenCircuits(chanID lnwire.ShortChannelID,
 	}, func() {})
 }
 
-// LookupByHTLC looks up the payment circuit by the outgoing channel and HTLC
-// IDs. Returns nil if there is no such circuit.
+// LookupCircuit queries the circuit map for the circuit identified by its
+// incoming circuit key. Returns nil if there is no such circuit.
 func (cm *circuitMap) LookupCircuit(inKey CircuitKey) *PaymentCircuit {
 	cm.mtx.RLock()
 	defer cm.mtx.RUnlock()

--- a/htlcswitch/switch.go
+++ b/htlcswitch/switch.go
@@ -375,9 +375,9 @@ func (s *Switch) GetPaymentResult(attemptID uint64, paymentHash lntypes.Hash,
 	deobfuscator ErrorDecrypter) (<-chan *PaymentResult, error) {
 
 	var (
-		nChan  <-chan *networkResult
-		err    error
-		outKey = CircuitKey{
+		nChan <-chan *networkResult
+		err   error
+		inKey = CircuitKey{
 			ChanID: hop.Source,
 			HtlcID: attemptID,
 		}
@@ -386,7 +386,7 @@ func (s *Switch) GetPaymentResult(attemptID uint64, paymentHash lntypes.Hash,
 	// If the payment is not found in the circuit map, check whether a
 	// result is already available.
 	// Assumption: no one will add this payment ID other than the caller.
-	if s.circuits.LookupCircuit(outKey) == nil {
+	if s.circuits.LookupCircuit(inKey) == nil {
 		res, err := s.networkResults.getResult(attemptID)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
The docs on `LookupCircuit` and its usage is a bit off, this PR fixes it.