### PR TITLE
lnd+config+sample-lnd.conf: add wallet-unlock-allow-create flag

### DIFF
--- a/sample-lnd.conf
+++ b/sample-lnd.conf
@@ -260,8 +260,16 @@
 
 ; The full path to a file (or pipe/device) that contains the password for
 ; unlocking the wallet; if set, no unlocking through RPC is possible and lnd
-; will exit if no wallet exists or the password is incorrect
+; will exit if no wallet exists or the password is incorrect; if
+; wallet-unlock-allow-create is also set then lnd will ignore this flag if no
+; wallet exists and allow a wallet to be created through RPC.
 ; wallet-unlock-password-file=/tmp/example.password
+
+; Don't fail with an error if wallet-unlock-password-file is set but no wallet
+; exists yet. Not recommended for auto-provisioned or high-security systems
+; because the wallet creation RPC is unauthenticated and an attacker could
+; inject a seed while lnd is in that state.
+; wallet-unlock-allow-create=true
 
 ; Removes all transaction history from the on-chain wallet on startup, forcing a
 ; full chain rescan starting at the wallet's birthday. Implements the same


### PR DESCRIPTION
As requested by users of node bundle software. They want to use the
wallet-unlock-password-file configuration option in their
default/template config file. This makes the first-time lnd setup a bit
more tricky since lnd will fail with an error if no wallet exists yet
while that config option is used.
The new wallet-unlock-allow-create option instructs lnd to not fail if
no wallet exists yet but instead spin up its unlocker RPC as it would
without the wallet-unlock-password-file being present.
This is not recommended for auto-provisioned or high-security systems
because the wallet creation RPC is unauthenticated and an attacker could
inject a seed while lnd is in that state.

