### PR TITLE
routing: make shardHandler timeout aware

### DIFF
--- a/cmd/lncli/cmd_pay.go
+++ b/cmd/lncli/cmd_pay.go
@@ -23,6 +23,7 @@ import (
 	"github.com/lightningnetwork/lnd/lntypes"
 	"github.com/lightningnetwork/lnd/lnwire"
 	"github.com/lightningnetwork/lnd/record"
+	"github.com/lightningnetwork/lnd/routing"
 	"github.com/lightningnetwork/lnd/routing/route"
 	"github.com/urfave/cli"
 )
@@ -30,7 +31,7 @@ import (
 const (
 	// paymentTimeout is the default timeout for the payment loop in lnd.
 	// No new attempts will be started after the timeout.
-	paymentTimeout = time.Second * 60
+	paymentTimeout = routing.DefaultPayAttemptTimeout
 )
 
 var (

--- a/routing/router.go
+++ b/routing/router.go
@@ -649,14 +649,14 @@ func (r *ChannelRouter) Start() error {
 			// result for the in-flight attempt is received.
 			paySession := r.cfg.SessionSource.NewPaymentSessionEmpty()
 
-			// We pass in a zero timeout value, to indicate we
-			// don't need it to timeout. It will stop immediately
-			// after the existing attempt has finished anyway. We
-			// also set a zero fee limit, as no more routes should
-			// be tried.
+			// We pass in a default timeout value, and it should
+			// stop immediately after the existing attempt has
+			// finished. We also set a zero fee limit, as no more
+			// routes should be tried.
 			_, _, err := r.sendPayment(
 				payment.Info.Value, 0,
-				payment.Info.PaymentIdentifier, 0, paySession,
+				payment.Info.PaymentIdentifier,
+				DefaultPayAttemptTimeout, paySession,
 				shardTracker,
 			)
 			if err != nil {

--- a/routing/router.go
+++ b/routing/router.go
@@ -2217,14 +2217,7 @@ func (r *ChannelRouter) sendPayment(
 		currentHeight: currentHeight,
 	}
 
-	// If a timeout is specified, create a timeout channel. If no timeout is
-	// specified, the channel is left nil and will never abort the payment
-	// loop.
-	if timeout != 0 {
-		p.timeoutChan = time.After(timeout)
-	}
-
-	return p.resumePayment()
+	return p.resumePayment(timeout)
 
 }
 


### PR DESCRIPTION
This PR is meant to fix #5396. It is a mitigation given the current layout of the `routing` package.

Because [we consider a payment in flight as long as it has at least one HTLC attempt that's in flight, even the payment has a failure reason](https://github.com/lightningnetwork/lnd/blob/master/channeldb/payments.go#L365), this causes several edge cases that might cause the issue mentioned above.

When the `resultChan` from `GetPaymentResult` never sends back the result, this will cause our payment to stuck in flight even we have the timeout value set. The loop will be blocked by the line `shardHandler.waitForShard()`. Thus we need to make sure the shard is also aware of the timeout.
