### PR TITLE
lncli: add command for publishtransaction

### DIFF
--- a/docs/release-notes/release-notes-0.14.0.md
+++ b/docs/release-notes/release-notes-0.14.0.md
@@ -23,6 +23,9 @@ If you use a strange system or changed group membership of the group running LND
 you may want to check your system to see if it introduces additional risk for
 you.
 
+* [Makes publishtransaction, in the wallet sub-server, reachable through 
+  lncli](https://github.com/lightningnetwork/lnd/pull/5460).
+
 # Build System
 
 * [A new pre-submit check has been


### PR DESCRIPTION
This pr adds a rpc command for PublishTransaction for the wallet sub-server. As is, this feature is only available though the rest interface. This pr was requested by #5438.
Command will look like: `lncli wallet publishtx <hex-encoded_raw_transaction> --label="name"` were the flag label is optional.
