### PR TITLE
trivial: walletrpc typo

### DIFF
--- a/cmd/lncli/walletrpc_active.go
+++ b/cmd/lncli/walletrpc_active.go
@@ -423,7 +423,7 @@ func listSweeps(ctx *cli.Context) error {
 
 var labelTxCommand = cli.Command{
 	Name:      "labeltx",
-	Usage:     "adds a label to a transaction",
+	Usage:     "Adds a label to a transaction.",
 	ArgsUsage: "txid label",
 	Description: `
 	Add a label to a transaction. If the transaction already has a label, 


### PR DESCRIPTION
Trivial typo fix for consistency in the usage description.