### PR TITLE
chainntnfs: populate spendsByHeight during historical dispatch

### DIFF
--- a/chainntnfs/txnotifier.go
+++ b/chainntnfs/txnotifier.go
@@ -1325,6 +1325,19 @@ func (n *TxNotifier) dispatchSpendDetails(ntfn *SpendNtfn, details *SpendDetail)
 		return ErrTxNotifierExiting
 	}
 
+	spendHeight := uint32(details.SpendingHeight)
+
+	// We also add to spendsByHeight to notify on chain reorgs.
+	reorgSafeHeight := spendHeight + n.reorgSafetyLimit
+	if reorgSafeHeight > n.currentHeight {
+		txSet, exists := n.spendsByHeight[spendHeight]
+		if !exists {
+			txSet = make(map[SpendRequest]struct{})
+			n.spendsByHeight[spendHeight] = txSet
+		}
+		txSet[ntfn.SpendRequest] = struct{}{}
+	}
+
 	return nil
 }
 

--- a/docs/release-notes/release-notes-0.14.0.md
+++ b/docs/release-notes/release-notes-0.14.0.md
@@ -236,6 +236,8 @@ mode](https://github.com/lightningnetwork/lnd/pull/5564).
 
 [A bug has been fixed with Neutrino's `RegisterConfirmationsNtfn` and `RegisterSpendNtfn` calls that would cause notifications to be missed.](https://github.com/lightningnetwork/lnd/pull/5453)
 
+[A bug has been fixed when registering for spend notifications in the `txnotifier`. A re-org notification would previously not be dispatched in certain scenarios.](https://github.com/lightningnetwork/lnd/pull/5465)
+
 ## Documentation 
 
 The [code contribution guidelines have been updated to mention the new


### PR DESCRIPTION
If lnd restarts, a historical dispatch is performed, and then a
re-org of the spend occurs at tip, the caller would never be
notified of the re-org.