### PR TITLE
Let gRPC SubscribeTransactions replay transactions from the request

### DIFF
--- a/lnrpc/walletrpc/walletkit_server.go
+++ b/lnrpc/walletrpc/walletkit_server.go
@@ -897,7 +897,7 @@ func (w *WalletKit) ListSweeps(ctx context.Context,
 	// the wallet is still tracking. Sweeps are currently always swept to
 	// the default wallet account.
 	transactions, err := w.cfg.Wallet.ListTransactionDetails(
-		0, btcwallet.UnconfirmedHeight, lnwallet.DefaultAccountName,
+		nil, 0, btcwallet.UnconfirmedHeight, lnwallet.DefaultAccountName,
 	)
 	if err != nil {
 		return nil, err

--- a/lntest/mock/walletcontroller.go
+++ b/lntest/mock/walletcontroller.go
@@ -153,8 +153,8 @@ func (w *WalletController) ListUnspentWitness(int32, int32,
 }
 
 // ListTransactionDetails currently returns dummy values.
-func (w *WalletController) ListTransactionDetails(int32, int32,
-	string) ([]*lnwallet.TransactionDetail, error) {
+func (w *WalletController) ListTransactionDetails(<-chan struct{}, int32,
+	int32, string) ([]*lnwallet.TransactionDetail, error) {
 
 	return nil, nil
 }

--- a/lnwallet/btcwallet/btcwallet.go
+++ b/lnwallet/btcwallet/btcwallet.go
@@ -1190,6 +1190,13 @@ func (t *txSubscriptionClient) Cancel() {
 	t.txClient.Done()
 }
 
+// Done returns a channel that is closed when the subscription is closed.
+//
+// This is part of the TransactionSubscription interface.
+func (t *txSubscriptionClient) Done() <-chan struct{} {
+	return t.quit
+}
+
 // notificationProxier proxies the notifications received by the underlying
 // wallet's notification client to a higher-level TransactionSubscription
 // client.

--- a/lnwallet/btcwallet/btcwallet.go
+++ b/lnwallet/btcwallet/btcwallet.go
@@ -1100,10 +1100,13 @@ func unminedTransactionsToDetail(
 // height (inclusive) and unconfirmed transactions. The account parameter serves
 // as a filter to retrieve the transactions relevant to a specific account. When
 // empty, transactions of all wallet accounts are returned.
+// The cancel channel provided is able to cancel this operation. If this channel
+// unblocks, the results created thus far will be returned.
 //
 // This is a part of the WalletController interface.
-func (b *BtcWallet) ListTransactionDetails(startHeight, endHeight int32,
-	accountFilter string) ([]*lnwallet.TransactionDetail, error) {
+func (b *BtcWallet) ListTransactionDetails(cancel <-chan struct{},
+	startHeight, endHeight int32, accountFilter string) (
+	[]*lnwallet.TransactionDetail, error) {
 
 	// Grab the best block the wallet knows of, we'll use this to calculate
 	// # of confirmations shortly below.
@@ -1113,7 +1116,7 @@ func (b *BtcWallet) ListTransactionDetails(startHeight, endHeight int32,
 	// We'll attempt to find all transactions from start to end height.
 	start := base.NewBlockIdentifierFromHeight(startHeight)
 	stop := base.NewBlockIdentifierFromHeight(endHeight)
-	txns, err := b.wallet.GetTransactions(start, stop, accountFilter, nil)
+	txns, err := b.wallet.GetTransactions(start, stop, accountFilter, cancel)
 	if err != nil {
 		return nil, err
 	}

--- a/lnwallet/interface.go
+++ b/lnwallet/interface.go
@@ -141,6 +141,10 @@ type TransactionSubscription interface {
 	// Cancel finalizes the subscription, cleaning up any resources
 	// allocated.
 	Cancel()
+
+	// Done returns a channel that is closed when the
+	// TransactionSubscription client has exited.
+	Done() <-chan struct{}
 }
 
 // WalletController defines an abstract interface for controlling a local Pure

--- a/lnwallet/interface.go
+++ b/lnwallet/interface.go
@@ -289,8 +289,11 @@ type WalletController interface {
 	// unconfirmed transactions. The account parameter serves as a filter to
 	// retrieve the transactions relevant to a specific account. When
 	// empty, transactions of all wallet accounts are returned.
-	ListTransactionDetails(startHeight, endHeight int32,
-		accountFilter string) ([]*TransactionDetail, error)
+	// The cancel channel provided is able to cancel this operation. If this
+	// channel unblocks, the results created thus far will be returned.
+	ListTransactionDetails(cancel <-chan struct{}, startHeight,
+		endHeight int32, accountFilter string) ([]*TransactionDetail,
+		error)
 
 	// LockOutpoint marks an outpoint as locked meaning it will no longer
 	// be deemed as eligible for coin selection. Locking outputs are

--- a/lnwallet/test/test_interface.go
+++ b/lnwallet/test/test_interface.go
@@ -209,7 +209,8 @@ func assertTxInWallet(t *testing.T, w *lnwallet.LightningWallet,
 	// We'll fetch all of our transaction and go through each one until
 	// finding the expected transaction with its expected confirmation
 	// status.
-	txs, err := w.ListTransactionDetails(0, btcwallet.UnconfirmedHeight, "")
+	txs, err := w.ListTransactionDetails(nil, 0, btcwallet.UnconfirmedHeight,
+		"")
 	if err != nil {
 		t.Fatalf("unable to retrieve transactions: %v", err)
 	}
@@ -1192,7 +1193,7 @@ func testListTransactionDetails(miner *rpctest.Harness,
 		t.Fatalf("Couldn't sync Alice's wallet: %v", err)
 	}
 	txDetails, err := alice.ListTransactionDetails(
-		startHeight, chainTip, "",
+		nil, startHeight, chainTip, "",
 	)
 	if err != nil {
 		t.Fatalf("unable to fetch tx details: %v", err)
@@ -1306,7 +1307,7 @@ func testListTransactionDetails(miner *rpctest.Harness,
 	// with a confirmation height of 0, indicating that it has not been
 	// mined yet.
 	txDetails, err = alice.ListTransactionDetails(
-		chainTip, btcwallet.UnconfirmedHeight, "",
+		nil, chainTip, btcwallet.UnconfirmedHeight, "",
 	)
 	if err != nil {
 		t.Fatalf("unable to fetch tx details: %v", err)
@@ -1362,7 +1363,7 @@ func testListTransactionDetails(miner *rpctest.Harness,
 	if err != nil {
 		t.Fatalf("Couldn't sync Alice's wallet: %v", err)
 	}
-	txDetails, err = alice.ListTransactionDetails(chainTip, chainTip, "")
+	txDetails, err = alice.ListTransactionDetails(nil, chainTip, chainTip, "")
 	if err != nil {
 		t.Fatalf("unable to fetch tx details: %v", err)
 	}
@@ -1409,7 +1410,7 @@ func testListTransactionDetails(miner *rpctest.Harness,
 
 	// Query for transactions only in the latest block. We do not expect
 	// any transactions to be returned.
-	txDetails, err = alice.ListTransactionDetails(chainTip, chainTip, "")
+	txDetails, err = alice.ListTransactionDetails(nil, chainTip, chainTip, "")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -5463,7 +5463,7 @@ func (r *rpcServer) GetTransactions(ctx context.Context,
 	}
 
 	transactions, err := r.server.cc.Wallet.ListTransactionDetails(
-		req.StartHeight, endHeight, req.Account,
+		nil, req.StartHeight, endHeight, req.Account,
 	)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Fixes #5339

This PR allows `SubscribeTransactions` to use of its `GetTransactionsRequest` argument to replay transactions before notifying of new transactions.

## Changes

Some general changes that this PR makes:
 * Add the possibility of canceling `btcwallet.ListTransactionDetail` while loading transactions from the database.
 * Expose the `quit` channel on the `SubscriptionClient` via a `Done` function and use it to cancel loading replay transactions if the client is closed before.

The `SubscribeTransactions` method of the `RPCServer` has logic added to load replay transactions. During this process it captures notifications to allow replaying of transactions before new notifications.

## Implementation details

The `RPCServer` is made responsible for replay of transactions. This way the replay transactions are loaded in the background while making this process cancel-able if the `SubscriptionClient` is closed early. 

If however there is feedback and insights into why it would make more sense to implement the logic of replaying transactions directly to the `WalletController` interface/`lnwallet.LightningWallet`, I am open to take a look at that and make those changes.

But my initial thoughts on this is that for e.g. `SubscribeInvoices` it is possible to lock the whole `InvoiceRegistry` and block invoices from being notified and created/paid (making sure that any relevant invoices are _completely_ blocked until replay is done and the client is available to listen for new invoices). This is not exactly true for the `btcwallet` dependency, which will notify of relevant transactions even if it cannot write to the db and is blocked there. If the behaviour should be to notify of replay transactions _before_ any new nofitications, then those new notifications must be captured while loading the replay transactions. This can also be done in the `lnwallet.LightningWallet`, but since this doesn't give a benefit as far as I can see and also makes canceling the process more complicated, I chose to let the `RPCServer` handle this.

The process of loading replay transactions must happen after starting the `SubscriptionClient` as otherwise there is a small but potential gap where new notifications could get lost. This however opens up a (tiny?) window where e.g. a block could be notified and directly afterwards loaded as replay transactions. Logic is implemented to filter out duplicates from those captured notifications while loading replay transactions.