### PR TITLE
Fixed typo in comment

### DIFF
--- a/tor/onionaddr.go
+++ b/tor/onionaddr.go
@@ -27,7 +27,7 @@ const (
 	// V3DecodedLen is the length of a decoded v3 onion service.
 	V3DecodedLen = 35
 
-	// V3Len is the length of a v2 onion service including the ".onion"
+	// V3Len is the length of a v3 onion service including the ".onion"
 	// suffix.
 	V3Len = 62
 )


### PR DESCRIPTION
Caught a typo in a comment.

Omitting checklist because of trivial change.