### PR TITLE
lnwallet: fix payment regression introduced by MayAddOutgoingHtlc

### DIFF
--- a/lnwallet/channel.go
+++ b/lnwallet/channel.go
@@ -4940,13 +4940,22 @@ func (lc *LightningChannel) MayAddOutgoingHtlc() error {
 	lc.Lock()
 	defer lc.Unlock()
 
+	// As this is a mock HTLC, we'll attempt to add the smallest possible
+	// HTLC permitted in the channel. However certain implementations may
+	// set this value to zero, so we'll catch that and increment things so
+	// we always use a non-zero value.
+	mockHtlcAmt := lc.channelState.LocalChanCfg.MinHTLC
+	if mockHtlcAmt == 0 {
+		mockHtlcAmt++
+	}
+
 	// Create a "mock" outgoing htlc, using the smallest amount we can add
 	// to the commitment so that we validate commitment slots rather than
 	// available balance, since our actual htlc amount is unknown at this
 	// stage.
 	pd := lc.htlcAddDescriptor(
 		&lnwire.UpdateAddHTLC{
-			Amount: lc.channelState.LocalChanCfg.MinHTLC,
+			Amount: mockHtlcAmt,
 		},
 		&channeldb.CircuitKey{},
 	)

--- a/lnwallet/channel_test.go
+++ b/lnwallet/channel_test.go
@@ -9648,3 +9648,24 @@ func TestChannelSignedAckRegression(t *testing.T) {
 	err = aliceChannel.ReceiveNewCommitment(bobSig, bobHtlcSigs)
 	require.NoError(t, err)
 }
+
+// TestMayAddOutgoingHtlcZeroValue tests that if the minHTLC value of the
+// channel is zero, then the MayAddOutgoingHtlc doesn't exit early due to
+// running into a zero valued HTLC.
+func TestMayAddOutgoingHtlcZeroValue(t *testing.T) {
+	t.Parallel()
+
+	// The default channel created as a part of the test fixture already
+	// has a MinHTLC value of zero, so we don't need to do anything here
+	// other than create it.
+	aliceChannel, bobChannel, cleanUp, err := CreateTestChannels(
+		channeldb.SingleFunderTweaklessBit,
+	)
+	require.NoError(t, err)
+	defer cleanUp()
+
+	// The channels start out with a 50/50 balance, so both sides should be
+	// able to add an outgoing HTLC.
+	require.NoError(t, aliceChannel.MayAddOutgoingHtlc())
+	require.NoError(t, bobChannel.MayAddOutgoingHtlc())
+}


### PR DESCRIPTION
In this PR, we fix a payment regression introduced by https://github.com/lightningnetwork/lnd/pull/5355. The newly added `MayAddOutgoingHtlc` method uses the min HTLC value to add a "mock HTLC" to see if any constraints are violated. However in practice, it's possible that an implementation sends over a min HTLC amount of `0 mSAT`. This would cause us to add a zero value HTLC, which would then trigger the `ErrInvalidHTLCAmt` error, causing the bandwidth hints for the link to show up as "zero". 

The initial fix is straight forward: ensure zero is never used. 

The proper fix here is to use the actual HTLC amount as discuseed in #5355. 

Fixes #5468.