### PR TITLE
allow watchtower to store data in remote (etcd) backend

### DIFF
--- a/lnd.go
+++ b/lnd.go
@@ -42,6 +42,7 @@ import (
 	"github.com/lightningnetwork/lnd/chanacceptor"
 	"github.com/lightningnetwork/lnd/channeldb"
 	"github.com/lightningnetwork/lnd/keychain"
+	"github.com/lightningnetwork/lnd/kvdb"
 	"github.com/lightningnetwork/lnd/lncfg"
 	"github.com/lightningnetwork/lnd/lnrpc"
 	"github.com/lightningnetwork/lnd/lnwallet"
@@ -799,19 +800,11 @@ func Main(cfg *Config, lisCfg ListenerCfg, interceptor signal.Interceptor) error
 
 	var tower *watchtower.Standalone
 	if cfg.Watchtower.Active {
-		// Segment the watchtower directory by chain and network.
-		towerDBDir := filepath.Join(
-			cfg.Watchtower.TowerDir,
-			cfg.registeredChains.PrimaryChain().String(),
-			lncfg.NormalizeNetwork(cfg.ActiveNetParams.Name),
-		)
-
-		towerDB, err := wtdb.OpenTowerDB(
-			towerDBDir, cfg.DB.Bolt.DBTimeout,
-		)
+		// Grab pointer to either local or remote tower database.
+		towerDB, err := initializeTowerDatabase(ctx, cfg)
 		if err != nil {
-			err := fmt.Errorf("unable to open watchtower "+
-				"database: %v", err)
+			err := fmt.Errorf("unable to open watchtower (%s) database: %v",
+				cfg.DB.Backend, err)
 			ltndLog.Error(err)
 			return err
 		}
@@ -1722,6 +1715,79 @@ func initializeDatabases(ctx context.Context,
 	}
 
 	return localChanDB, remoteChanDB, cleanUp, nil
+}
+
+// initializeTowerDatabase configures either a local (boltdb) or remote (etcd)
+// database for the watchtower server.
+func initializeTowerDatabase(ctx context.Context,
+	cfg *Config) (*wtdb.TowerDB, error) {
+
+	ltndLog.Infof("Opening the watchtower database, this might take a few " +
+		"minutes...")
+
+	if cfg.DB.Backend == lncfg.BoltBackend {
+		ltndLog.Infof("Opening bbolt database for watchtower, sync_freelist=%v, "+
+			"auto_compact=%v", cfg.DB.Bolt.SyncFreelist,
+			cfg.DB.Bolt.AutoCompact)
+	}
+
+	startOpenTime := time.Now()
+
+	var (
+		towerDB *wtdb.TowerDB
+		err     error
+	)
+
+	if cfg.DB.Backend == lncfg.BoltBackend {
+		// Segment the watchtower directory by chain and network.
+		towerDBDir := filepath.Join(
+			cfg.Watchtower.TowerDir,
+			cfg.registeredChains.PrimaryChain().String(),
+			lncfg.NormalizeNetwork(cfg.ActiveNetParams.Name),
+		)
+
+		// Open the towerdb, which is dedicated to storing watchtower
+		// server data.
+		towerDB, err = wtdb.OpenTowerDB(
+			towerDBDir, cfg.DB.Bolt.DBTimeout,
+		)
+		if err != nil {
+			err := fmt.Errorf("unable to open local watchtower "+
+				"database: %v", err)
+			ltndLog.Error(err)
+			return nil, err
+		}
+
+	} else if cfg.DB.Backend == lncfg.EtcdBackend {
+		ltndLog.Infof("Database replication is available! Creating " +
+			"remote towerdb instance")
+
+		// Open connection to remote etcd backend.
+		remoteDB, err := kvdb.Open(
+			kvdb.EtcdBackendName, ctx, cfg.DB.Etcd,
+		)
+		if err != nil {
+			return nil, err
+		}
+
+		// Initialize the remote watchtower db.
+		towerDB, err = wtdb.CreateWithBackend(
+			remoteDB,
+		)
+		if err != nil {
+			towerDB.Close()
+
+			err := fmt.Errorf("unable to open remote watchtower "+
+				"database: %v", err)
+			ltndLog.Error(err)
+			return nil, err
+		}
+	}
+
+	openTime := time.Since(startOpenTime)
+	ltndLog.Infof("Tower database now open (time_to_open=%v)!", openTime)
+
+	return towerDB, nil
 }
 
 // initNeutrinoBackend inits a new instance of the neutrino light client

--- a/lnd.go
+++ b/lnd.go
@@ -433,7 +433,7 @@ func Main(cfg *Config, lisCfg ListenerCfg, interceptor signal.Interceptor) error
 		ltndLog.Infof("Elected as leader (%v)", cfg.Cluster.ID)
 	}
 
-	localChanDB, remoteChanDB, cleanUp, err := initializeDatabases(ctx, cfg)
+	localChanDB, remoteChanDB, cleanUp, err := initializeChannelDatabases(ctx, cfg)
 	switch {
 	case err == channeldb.ErrDryRunMigrationOK:
 		ltndLog.Infof("%v, exiting", err)
@@ -1593,13 +1593,13 @@ func waitForWalletPassword(cfg *Config,
 	}
 }
 
-// initializeDatabases extracts the current databases that we'll use for normal
-// operation in the daemon. Two databases are returned: one remote and one
-// local. However, only if the replicated database is active will the remote
-// database point to a unique database. Otherwise, the local and remote DB will
-// both point to the same local database. A function closure that closes all
-// opened databases is also returned.
-func initializeDatabases(ctx context.Context,
+// initializeChannelDatabases extracts the current databases that we'll use for
+// normal operation in the daemon. Two databases are returned: one remote and
+// one local. However, only if the replicated database is active will the
+// remote database point to a unique database. Otherwise, the local and remote
+// DB will both point to the same local database. A function closure that
+// closes all opened databases is also returned.
+func initializeChannelDatabases(ctx context.Context,
 	cfg *Config) (*channeldb.DB, *channeldb.DB, func(), error) {
 
 	ltndLog.Infof("Opening the main database, this might take a few " +

--- a/watchtower/wtdb/version.go
+++ b/watchtower/wtdb/version.go
@@ -88,8 +88,7 @@ func putDBVersion(tx kvdb.RwTx, version uint32) error {
 // databases, permitting all versioning operations to be performed generically
 // on either.
 type versionedDB interface {
-	// bdb returns the underlying bbolt database.
-	bdb() kvdb.Backend
+	kvdb.Backend
 
 	// Version returns the current version stored in the database.
 	Version() (uint32, error)
@@ -105,7 +104,7 @@ func initOrSyncVersions(db versionedDB, init bool, versions []version) error {
 	// If the database has not yet been created, we'll initialize the
 	// database version with the latest known version.
 	if init {
-		return kvdb.Update(db.bdb(), func(tx kvdb.RwTx) error {
+		return kvdb.Update(db, func(tx kvdb.RwTx) error {
 			return initDBVersion(tx, getLatestDBVersion(versions))
 		}, func() {})
 	}
@@ -141,7 +140,7 @@ func syncVersions(db versionedDB, versions []version) error {
 	// Otherwise, apply any migrations in order to bring the database
 	// version up to the highest known version.
 	updates := getMigrations(versions, curVersion)
-	return kvdb.Update(db.bdb(), func(tx kvdb.RwTx) error {
+	return kvdb.Update(db, func(tx kvdb.RwTx) error {
 		for i, update := range updates {
 			if update.migration == nil {
 				continue


### PR DESCRIPTION
Hi, submitting this PR as an expression of interest in letting the watchtower server store data remotely.  Verified that the tower writes to the remote storage using Polar and a local etcd cluster, but still need to look at what, if anything, needs adding from an automated testing perspective.

Never touched the DB before so feel free to let me have it on this one.  


Could consider:
- putting the watchtower data in its own "namespace"/key prefix in etcd
- allowing separate configuration flag for remote watchtower storage
