### PR TITLE
itest: neutrino anchor output flake fix

### DIFF
--- a/docs/release-notes/release-notes-0.14.0.md
+++ b/docs/release-notes/release-notes-0.14.0.md
@@ -52,6 +52,9 @@ you.
 * [The itest error whitelist check was removed to reduce the number of failed
   Travis builds](https://github.com/lightningnetwork/lnd/pull/5588).
 
+* [A flake in the Neutrino integration tests with anchor sweeps was 
+  addressed](https://github.com/lightningnetwork/lnd/pull/5509).
+
 # Documentation
 
 * [Outdated warning about unsupported pruning was replaced with clarification that LND **does**

--- a/lntest/harness.go
+++ b/lntest/harness.go
@@ -840,7 +840,7 @@ func (n *NetworkHarness) StopNode(node *HarnessNode) error {
 
 // SaveProfilesPages hits profiles pages of all active nodes and writes it to
 // disk using a similar naming scheme as to the regular set of logs.
-func (n *NetworkHarness) SaveProfilesPages() {
+func (n *NetworkHarness) SaveProfilesPages(t *testing.T) {
 	// Only write gorutine dumps if flag is active.
 	if !(*goroutineDump) {
 		return
@@ -848,7 +848,8 @@ func (n *NetworkHarness) SaveProfilesPages() {
 
 	for _, node := range n.activeNodes {
 		if err := saveProfilesPage(node); err != nil {
-			fmt.Printf("Error: %v\n", err)
+			t.Logf("Logging follow-up error only, see rest of "+
+				"the log for actual cause: %v\n", err)
 		}
 	}
 }

--- a/lntest/itest/assertions.go
+++ b/lntest/itest/assertions.go
@@ -1305,7 +1305,6 @@ func assertDLPExecuted(net *lntest.NetworkHarness, t *harnessTest,
 
 	// Dave should sweep his funds immediately, as they are not timelocked.
 	// We also expect Dave to sweep his anchor, if present.
-
 	_, err = waitForNTxsInMempool(
 		net.Miner.Client, expectedTxes, minerMempoolTimeout,
 	)
@@ -1341,7 +1340,7 @@ func assertDLPExecuted(net *lntest.NetworkHarness, t *harnessTest,
 	// After the Carol's output matures, she should also reclaim her funds.
 	//
 	// The commit sweep resolver publishes the sweep tx at defaultCSV-1 and
-	// we already mined one block after the commitmment was published, so
+	// we already mined one block after the commitment was published, so
 	// take that into account.
 	mineBlocks(t, net, defaultCSV-1-1, 0)
 	carolSweep, err := waitForTxInMempool(
@@ -1363,6 +1362,16 @@ func assertDLPExecuted(net *lntest.NetworkHarness, t *harnessTest,
 		}
 
 		carolBalance := carolBalResp.ConfirmedBalance
+
+		// With Neutrino we don't get a backend error when trying to
+		// publish an orphan TX (which is what the sweep for the remote
+		// anchor is since the remote commitment TX was not broadcast).
+		// That's why the wallet still sees that as unconfirmed and we
+		// need to count the total balance instead of the confirmed.
+		if net.BackendCfg.Name() == lntest.NeutrinoBackendName {
+			carolBalance = carolBalResp.TotalBalance
+		}
+
 		if carolBalance <= carolStartingBalance {
 			return fmt.Errorf("expected carol to have balance "+
 				"above %d, instead had %v", carolStartingBalance,

--- a/lntest/itest/lnd_channel_backup_test.go
+++ b/lntest/itest/lnd_channel_backup_test.go
@@ -847,6 +847,12 @@ func testChanRestoreScenario(t *harnessTest, net *lntest.NetworkHarness,
 	ctxt, _ := context.WithTimeout(ctxb, defaultTimeout)
 	net.SendCoins(ctxt, t.t, btcutil.SatoshiPerBitcoin, carol)
 
+	// For the anchor output case we need two UTXOs for Carol so she can
+	// sweep both the local and remote anchor.
+	if testCase.anchorCommit {
+		net.SendCoins(ctxt, t.t, btcutil.SatoshiPerBitcoin, carol)
+	}
+
 	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
 	net.SendCoins(ctxt, t.t, btcutil.SatoshiPerBitcoin, dave)
 
@@ -1076,6 +1082,12 @@ func testChanRestoreScenario(t *harnessTest, net *lntest.NetworkHarness,
 	// let's start up Carol again.
 	err = restartCarol()
 	require.NoError(t.t, err)
+
+	numUTXOs := 1
+	if testCase.anchorCommit {
+		numUTXOs = 2
+	}
+	assertNumUTXOs(t.t, carol, numUTXOs)
 
 	// Now that we have our new node up, we expect that it'll re-connect to
 	// Carol automatically based on the restored backup.

--- a/lntest/itest/log_error_whitelist.txt
+++ b/lntest/itest/log_error_whitelist.txt
@@ -18,7 +18,9 @@
 <time> [ERR] CNCT: ChannelArbitrator(<chan_point>): unable to advance state: channel not found
 <time> [ERR] CNCT: ChannelArbitrator(<chan_point>): unable to broadcast close tx: Transaction rejected: output already spent
 <time> [ERR] CNCT: ChannelArbitrator(<chan_point>): unable to force close: channel not found
+<time> [ERR] CNCT: ChannelArbitrator(<chan_point>): unable to mark commitment broadcasted: channel not found
 <time> [ERR] CNCT: ChannelArbitrator(<chan_point>): unable to progress *contractcourt.commitSweepResolver: remote party swept utxo
+<time> [ERR] CNCT: ChannelArbitrator(<chan_point>): unable to progress *contractcourt.commitSweepResolver: chainntnfs: system interrupt while attempting to register for block epoch notification.
 <time> [ERR] CNCT: ChannelArbitrator(<chan_point>): unable to progress *contractcourt.htlcOutgoingContestResolver: chain notifier shutting down
 <time> [ERR] CNCT: ChannelArbitrator(<chan_point>): unable to progress *contractcourt.htlcOutgoingContestResolver: chainntnfs: system interrupt while attempting to register for block epoch notification.
 <time> [ERR] CNCT: ChannelArbitrator(<chan_point>): unable to progress *contractcourt.htlcOutgoingContestResolver: resolver canceled
@@ -83,8 +85,10 @@
 <time> [ERR] FNDG: Unable to advance state(<chan_point>): error sending channel announcement: unable to register for confirmation of ChannelPoint(<chan_point>): TxNotifier is exiting
 <time> [ERR] FNDG: Unable to advance state(<chan_point>): failed adding to router graph: error sending channel announcement: gossiper is shutting down
 <time> [ERR] FNDG: Unable to advance state(<chan_point>): failed adding to router graph: error sending channel announcement: router shutting down
+<time> [ERR] FNDG: Unable to advance state(<chan_point>): failed adding to router graph: error sending channel update: router shutting down
 <time> [ERR] FNDG: Unable to advance state(<chan_point>): failed adding to router graph: funding manager shutting down
 <time> [ERR] FNDG: Unable to advance state(<chan_point>): failed sending fundingLocked: funding manager shutting down
+<time> [ERR] FNDG: Unable to advance state(<chan_point>): funding manager shutting down
 <time> [ERR] FNDG: unable to cancel reservation: no active reservations for peer(<hex>)
 <time> [ERR] FNDG: unable to report short chan id: link <hex> not found
 <time> [ERR] FNDG: Unable to send channel proof: channel  announcement proof for short_chan_id=<cid> isn't valid: can't verify first bitcoin signature
@@ -191,6 +195,8 @@
 <time> [ERR] RPCS: [/lnrpc.Lightning/CloseChannel]: cannot co-op close frozen channel as initiator until height=<height>, (current_height=<height>)
 <time> [ERR] RPCS: [/lnrpc.Lightning/CloseChannel]: chain notifier shutting down
 <time> [ERR] RPCS: [/lnrpc.Lightning/CloseChannel]: must specify channel point in close channel
+<time> [ERR] RPCS: [/lnrpc.Lightning/CloseChannel]: rpc error: code = DeadlineExceeded desc = context deadline exceeded
+<time> [ERR] RPCS: [/lnrpc.Lightning/CloseChannel]: server is still in the process of starting
 <time> [ERR] RPCS: [/lnrpc.Lightning/ConnectPeer]: already connected to peer: <hex>@<ip>
 <time> [ERR] RPCS: [/lnrpc.Lightning/ConnectPeer]: dial tcp <ip>: i/o timeout
 <time> [ERR] RPCS: [/lnrpc.Lightning/ConnectPeer]: dial tcp <ip>: i/o timeout
@@ -199,6 +205,7 @@
 <time> [ERR] RPCS: [/lnrpc.Lightning/DeleteMacaroonID]: the specified ID cannot be deleted
 <time> [ERR] RPCS: [/lnrpc.Lightning/FundingStateStep]: pendingChanID(<hex>) already has intent registered
 <time> [ERR] RPCS: [/lnrpc.Lightning/GetChanInfo]: edge marked as zombie
+<time> [ERR] RPCS: [/lnrpc.Lightning/GetChanInfo]: edge not found
 <time> [ERR] RPCS: [/lnrpc.Lightning/OpenChannel]: channels cannot be created before the wallet is fully synced
 <time> [ERR] RPCS: [/lnrpc.Lightning/OpenChannel]: received funding error from <hex>: chan_id=<hex>, err=channel too large
 <time> [ERR] RPCS: [/lnrpc.Lightning/OpenChannel]: received funding error from <hex>: chan_id=<hex>, err=chan size of 0.16777216 BTC exceeds maximum chan size of 0.16777215 BTC
@@ -231,6 +238,7 @@
 <time> [ERR] RPCS: [/routerrpc.Router/SendPaymentV2]: routerrpc server shutting down
 <time> [ERR] RPCS: [/routerrpc.Router/SubscribeHtlcEvents]: context canceled
 <time> [ERR] RPCS: [/routerrpc.Router/SubscribeHtlcEvents]: htlc event subscription terminated
+<time> [ERR] RPCS: [/routerrpc.Router/SubscribeHtlcEvents]: context deadline exceeded
 <time> [ERR] RPCS: [/routerrpc.Route<time> [INF] LTND: Listening on the p2p interface is disabled!
 <time> [ERR] RPCS: [/signrpc.Signer/DeriveSharedKey]: must provide ephemeral pubkey
 <time> [ERR] RPCS: [/signrpc.Signer/DeriveSharedKey]: use either key_desc or key_loc

--- a/lntest/itest/test_harness.go
+++ b/lntest/itest/test_harness.go
@@ -82,7 +82,7 @@ func (h *harnessTest) Skipf(format string, args ...interface{}) {
 // the error stack traces it produces.
 func (h *harnessTest) Fatalf(format string, a ...interface{}) {
 	if h.lndHarness != nil {
-		h.lndHarness.SaveProfilesPages()
+		h.lndHarness.SaveProfilesPages(h.t)
 	}
 
 	stacktrace := errors.Wrap(fmt.Sprintf(format, a...), 1).ErrorStack()

--- a/lntest/node.go
+++ b/lntest/node.go
@@ -1167,7 +1167,8 @@ func (hn *HarnessNode) stop() error {
 	if hn.conn != nil {
 		err := hn.conn.Close()
 		if err != nil {
-			return fmt.Errorf("error attempting to stop grpc client: %v", err)
+			return fmt.Errorf("error attempting to stop grpc "+
+				"client: %v", err)
 		}
 	}
 


### PR DESCRIPTION
Fixes #5015.
Fixes #5492 (though indirectly, that never caused the tests to fail in the first place).

Fixes two of our most elusive neutrino itest flakes, both in context of anchor output channels.

I'm not 100% sure I can explain properly _why_ this seems to only happen with Neutrino, but this is what I got so far:
 - for anchor outputs, we always try to sweep our anchor of our local commit TX and our anchor in the remote commit TX (since we possibly don't know who force closed)
 - so if we force close from our end, we always create 1 valid sweep TX (our anchor in the local commitment) and an orphaned one (our anchor in the remote commitment)
- normally the first sweep succeeds and the second sweep fails because we don't have a spare UTXO to anchor it down. so we never actually publish the orphaned TX
 - sometimes (hence the flake), the orphaned sweep (remote commitment anchor) is published first and the UTXO is marked as used (even if it's in an orphaned TX) and then the actual "good" sweep TX can't go through because we don't have a spare UTXO

The easy solution to fix the flakes in the itest is to just add another UTXO. That actually makes all those anchor tests quite stable. But I'm pretty sure this just gets rid of the symptoms of a possible underlying problem.