### PR TITLE
routing: include htlc amount in bandwidth hint queries

### DIFF
--- a/htlcswitch/interfaces.go
+++ b/htlcswitch/interfaces.go
@@ -146,8 +146,10 @@ type ChannelLink interface {
 	EligibleToForward() bool
 
 	// MayAddOutgoingHtlc returns an error if we may not add an outgoing
-	// htlc to the channel.
-	MayAddOutgoingHtlc() error
+	// htlc to the channel. This check does not reserve a space, since
+	// forwards or other payments may use the available slot, so it should
+	// be considered best effort.
+	MayAddOutgoingHtlc(amt lnwire.MilliSatoshi) error
 
 	// AttachMailBox delivers an active MailBox to the link. The MailBox may
 	// have buffered messages.

--- a/htlcswitch/link.go
+++ b/htlcswitch/link.go
@@ -2157,10 +2157,12 @@ func (l *channelLink) Bandwidth() lnwire.MilliSatoshi {
 	return l.channel.AvailableBalance()
 }
 
-// MayAddOutgoingHtlc indicates whether we may add any more outgoing htlcs to
-// this channel.
-func (l *channelLink) MayAddOutgoingHtlc() error {
-	return l.channel.MayAddOutgoingHtlc()
+// MayAddOutgoingHtlc indicates whether we can add an outgoing htlc with the
+// amount provided to the link. This check does not reserve  a space, since
+// forwards or other payments may use the available slot, so it should be
+// considered best-effort.
+func (l *channelLink) MayAddOutgoingHtlc(amt lnwire.MilliSatoshi) error {
+	return l.channel.MayAddOutgoingHtlc(amt)
 }
 
 // AttachMailBox updates the current mailbox used by this link, and hooks up

--- a/htlcswitch/mock.go
+++ b/htlcswitch/mock.go
@@ -749,15 +749,15 @@ func (f *mockChannelLink) Start() error {
 	return nil
 }
 
-func (f *mockChannelLink) ChanID() lnwire.ChannelID                     { return f.chanID }
-func (f *mockChannelLink) ShortChanID() lnwire.ShortChannelID           { return f.shortChanID }
-func (f *mockChannelLink) Bandwidth() lnwire.MilliSatoshi               { return 99999999 }
-func (f *mockChannelLink) Peer() lnpeer.Peer                            { return f.peer }
-func (f *mockChannelLink) ChannelPoint() *wire.OutPoint                 { return &wire.OutPoint{} }
-func (f *mockChannelLink) Stop()                                        {}
-func (f *mockChannelLink) EligibleToForward() bool                      { return f.eligible }
-func (f *mockChannelLink) MayAddOutgoingHtlc() error                    { return nil }
-func (f *mockChannelLink) setLiveShortChanID(sid lnwire.ShortChannelID) { f.shortChanID = sid }
+func (f *mockChannelLink) ChanID() lnwire.ChannelID                       { return f.chanID }
+func (f *mockChannelLink) ShortChanID() lnwire.ShortChannelID             { return f.shortChanID }
+func (f *mockChannelLink) Bandwidth() lnwire.MilliSatoshi                 { return 99999999 }
+func (f *mockChannelLink) Peer() lnpeer.Peer                              { return f.peer }
+func (f *mockChannelLink) ChannelPoint() *wire.OutPoint                   { return &wire.OutPoint{} }
+func (f *mockChannelLink) Stop()                                          {}
+func (f *mockChannelLink) EligibleToForward() bool                        { return f.eligible }
+func (f *mockChannelLink) MayAddOutgoingHtlc(_ lnwire.MilliSatoshi) error { return nil }
+func (f *mockChannelLink) setLiveShortChanID(sid lnwire.ShortChannelID)   { f.shortChanID = sid }
 func (f *mockChannelLink) UpdateShortChanID() (lnwire.ShortChannelID, error) {
 	f.eligible = true
 	return f.shortChanID, nil

--- a/lnwallet/channel.go
+++ b/lnwallet/channel.go
@@ -4936,26 +4936,16 @@ func (lc *LightningChannel) AddHTLC(htlc *lnwire.UpdateAddHTLC,
 // channel. We don't have a value or circuit for this htlc, because we just
 // want to test that we have slots for a potential htlc so we use a "mock"
 // htlc to validate a potential commitment state with one more outgoing htlc.
-func (lc *LightningChannel) MayAddOutgoingHtlc() error {
+func (lc *LightningChannel) MayAddOutgoingHtlc(amt lnwire.MilliSatoshi) error {
 	lc.Lock()
 	defer lc.Unlock()
 
-	// As this is a mock HTLC, we'll attempt to add the smallest possible
-	// HTLC permitted in the channel. However certain implementations may
-	// set this value to zero, so we'll catch that and increment things so
-	// we always use a non-zero value.
-	mockHtlcAmt := lc.channelState.LocalChanCfg.MinHTLC
-	if mockHtlcAmt == 0 {
-		mockHtlcAmt++
-	}
-
-	// Create a "mock" outgoing htlc, using the smallest amount we can add
-	// to the commitment so that we validate commitment slots rather than
-	// available balance, since our actual htlc amount is unknown at this
-	// stage.
+	// Create a "mock" outgoing htlc with the amount provided, we do not
+	// add a zero check here because we expect sane callers to add non-zero
+	// htlc amounts.
 	pd := lc.htlcAddDescriptor(
 		&lnwire.UpdateAddHTLC{
-			Amount: mockHtlcAmt,
+			Amount: amt,
 		},
 		&channeldb.CircuitKey{},
 	)

--- a/routing/bandwidth.go
+++ b/routing/bandwidth.go
@@ -1,0 +1,73 @@
+package routing
+
+import (
+	"github.com/lightningnetwork/lnd/channeldb"
+	"github.com/lightningnetwork/lnd/kvdb"
+	"github.com/lightningnetwork/lnd/lnwire"
+)
+
+// bandwidthHints is provides hints about the currently available balance in
+// our channels.
+type bandwidthHints interface {
+	// availableChanBandwidth returns the total available bandwidth for a
+	// channel and a bool indicating whether the channel hint was found.
+	// If the channel is unavailable, a zero amount is returned.
+	availableChanBandwidth(channelID uint64) (lnwire.MilliSatoshi, bool)
+}
+
+// linkBandwidthQuery is the function signature used to query the link for the
+// currently available bandwidth for an edge.
+type linkBandwidthQuery func(*channeldb.ChannelEdgeInfo) lnwire.MilliSatoshi
+
+// bandwidthManager is an implementation of the bandwidthHints interface which
+// uses the linkBandwidthQuery provided to query the link for our latest local
+// channel balances.
+type bandwidthManager struct {
+	getBandwidth linkBandwidthQuery
+	localChans   map[uint64]*channeldb.ChannelEdgeInfo
+}
+
+// newBandwidthManager creates a bandwidth manager for the source node provided
+// which is used to obtain hints from the lower layer w.r.t the available
+// bandwidth of edges on the network. Currently, we'll only obtain bandwidth
+// hints for the edges we directly have open ourselves. Obtaining these hints
+// allows us to reduce the number of extraneous attempts as we can skip channels
+// that are inactive, or just don't have enough bandwidth to carry the payment.
+func newBandwidthManager(sourceNode *channeldb.LightningNode,
+	linkQuery linkBandwidthQuery) (*bandwidthManager, error) {
+
+	manager := &bandwidthManager{
+		getBandwidth: linkQuery,
+		localChans:   make(map[uint64]*channeldb.ChannelEdgeInfo),
+	}
+
+	// First, we'll collect the set of outbound edges from the target
+	// source node and add them to our bandwidth manager's map of channels.
+	err := sourceNode.ForEachChannel(nil, func(tx kvdb.RTx,
+		edgeInfo *channeldb.ChannelEdgeInfo,
+		_, _ *channeldb.ChannelEdgePolicy) error {
+
+		manager.localChans[edgeInfo.ChannelID] = edgeInfo
+
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return manager, nil
+}
+
+// availableChanBandwidth returns the total available bandwidth for a channel
+// and a bool indicating whether the channel hint was found. If the channel is
+// unavailable, a zero amount is returned.
+func (b *bandwidthManager) availableChanBandwidth(channelID uint64) (
+	lnwire.MilliSatoshi, bool) {
+
+	channel, ok := b.localChans[channelID]
+	if !ok {
+		return 0, false
+	}
+
+	return b.getBandwidth(channel), true
+}

--- a/routing/integrated_routing_context_test.go
+++ b/routing/integrated_routing_context_test.go
@@ -18,6 +18,21 @@ const (
 	targetNodeID = 2
 )
 
+type mockBandwidthHints struct {
+	hints map[uint64]lnwire.MilliSatoshi
+}
+
+func (m *mockBandwidthHints) availableChanBandwidth(channelID uint64) (
+	lnwire.MilliSatoshi, bool) {
+
+	if m.hints == nil {
+		return 0, false
+	}
+
+	balance, ok := m.hints[channelID]
+	return balance, ok
+}
+
 // integratedRoutingContext defines the context in which integrated routing
 // tests run.
 type integratedRoutingContext struct {
@@ -130,14 +145,16 @@ func (c *integratedRoutingContext) testPayment(maxParts uint32,
 		c.t.Fatal(err)
 	}
 
-	getBandwidthHints := func() (map[uint64]lnwire.MilliSatoshi, error) {
+	getBandwidthHints := func() (bandwidthHints, error) {
 		// Create bandwidth hints based on local channel balances.
 		bandwidthHints := map[uint64]lnwire.MilliSatoshi{}
 		for _, ch := range c.graph.nodes[c.source.pubkey].channels {
 			bandwidthHints[ch.id] = ch.balance
 		}
 
-		return bandwidthHints, nil
+		return &mockBandwidthHints{
+			hints: bandwidthHints,
+		}, nil
 	}
 
 	var paymentAddr [32]byte

--- a/routing/integrated_routing_context_test.go
+++ b/routing/integrated_routing_context_test.go
@@ -33,6 +33,14 @@ func (m *mockBandwidthHints) availableChanBandwidth(channelID uint64) (
 	return balance, ok
 }
 
+func (m *mockBandwidthHints) availableHtlcBandwidth(channelID uint64,
+	_ lnwire.MilliSatoshi) (lnwire.MilliSatoshi, bool) {
+
+	// We just return our available bandwidth value here because our mock
+	// is not built out to have additional logic for adding specific htlcs.
+	return m.availableChanBandwidth(channelID)
+}
+
 // integratedRoutingContext defines the context in which integrated routing
 // tests run.
 type integratedRoutingContext struct {

--- a/routing/payment_lifecycle_test.go
+++ b/routing/payment_lifecycle_test.go
@@ -472,7 +472,9 @@ func testPaymentLifecycle(t *testing.T, test paymentLifecycleTestCase,
 			Payer:              payer,
 			ChannelPruneExpiry: time.Hour * 24,
 			GraphPruneInterval: time.Hour * 2,
-			QueryBandwidth: func(e *channeldb.ChannelEdgeInfo) lnwire.MilliSatoshi {
+			QueryBandwidth: func(e *channeldb.ChannelEdgeInfo,
+				_ *lnwire.MilliSatoshi) lnwire.MilliSatoshi {
+
 				return lnwire.NewMSatFromSatoshis(e.Capacity)
 			},
 			NextPaymentID: func() (uint64, error) {

--- a/routing/payment_session.go
+++ b/routing/payment_session.go
@@ -164,7 +164,7 @@ type PaymentSession interface {
 type paymentSession struct {
 	additionalEdges map[route.Vertex][]*channeldb.ChannelEdgePolicy
 
-	getBandwidthHints func() (map[uint64]lnwire.MilliSatoshi, error)
+	getBandwidthHints func() (bandwidthHints, error)
 
 	payment *LightningPayment
 
@@ -192,7 +192,7 @@ type paymentSession struct {
 
 // newPaymentSession instantiates a new payment session.
 func newPaymentSession(p *LightningPayment,
-	getBandwidthHints func() (map[uint64]lnwire.MilliSatoshi, error),
+	getBandwidthHints func() (bandwidthHints, error),
 	getRoutingGraph func() (routingGraph, func(), error),
 	missionControl MissionController, pathFindingConfig PathFindingConfig) (
 	*paymentSession, error) {

--- a/routing/payment_session_source.go
+++ b/routing/payment_session_source.go
@@ -24,7 +24,7 @@ type SessionSource struct {
 	// to be traversed. If the link isn't available, then a value of zero
 	// should be returned. Otherwise, the current up to date knowledge of
 	// the available bandwidth of the link should be returned.
-	QueryBandwidth func(*channeldb.ChannelEdgeInfo) lnwire.MilliSatoshi
+	QueryBandwidth linkBandwidthQuery
 
 	// MissionControl is a shared memory of sorts that executions of payment
 	// path finding use in order to remember which vertexes/edges were
@@ -67,10 +67,8 @@ func (m *SessionSource) NewPaymentSession(p *LightningPayment) (
 		return nil, err
 	}
 
-	getBandwidthHints := func() (map[uint64]lnwire.MilliSatoshi,
-		error) {
-
-		return generateBandwidthHints(sourceNode, m.QueryBandwidth)
+	getBandwidthHints := func() (bandwidthHints, error) {
+		return newBandwidthManager(sourceNode, m.QueryBandwidth)
 	}
 
 	session, err := newPaymentSession(

--- a/routing/payment_session_test.go
+++ b/routing/payment_session_test.go
@@ -116,10 +116,8 @@ func TestUpdateAdditionalEdge(t *testing.T) {
 	// Create the paymentsession.
 	session, err := newPaymentSession(
 		payment,
-		func() (map[uint64]lnwire.MilliSatoshi,
-			error) {
-
-			return nil, nil
+		func() (bandwidthHints, error) {
+			return &mockBandwidthHints{}, nil
 		},
 		func() (routingGraph, func(), error) {
 			return &sessionGraph{}, func() {}, nil
@@ -198,10 +196,8 @@ func TestRequestRoute(t *testing.T) {
 
 	session, err := newPaymentSession(
 		payment,
-		func() (map[uint64]lnwire.MilliSatoshi,
-			error) {
-
-			return nil, nil
+		func() (bandwidthHints, error) {
+			return &mockBandwidthHints{}, nil
 		},
 		func() (routingGraph, func(), error) {
 			return &sessionGraph{}, func() {}, nil

--- a/routing/router.go
+++ b/routing/router.go
@@ -333,7 +333,7 @@ type Config struct {
 	// a value of zero should be returned. Otherwise, the current up to
 	// date knowledge of the available bandwidth of the link should be
 	// returned.
-	QueryBandwidth func(edge *channeldb.ChannelEdgeInfo) lnwire.MilliSatoshi
+	QueryBandwidth linkBandwidthQuery
 
 	// NextPaymentID is a method that guarantees to return a new, unique ID
 	// each time it is called. This is used by the router to generate a
@@ -1638,7 +1638,7 @@ func (r *ChannelRouter) FindRoute(source, target route.Vertex,
 
 	// We'll attempt to obtain a set of bandwidth hints that can help us
 	// eliminate certain routes early on in the path finding process.
-	bandwidthHints, err := generateBandwidthHints(
+	bandwidthHints, err := newBandwidthManager(
 		r.selfNode, r.cfg.QueryBandwidth,
 	)
 	if err != nil {
@@ -2557,41 +2557,6 @@ func (r *ChannelRouter) MarkEdgeLive(chanID lnwire.ShortChannelID) error {
 	return r.cfg.Graph.MarkEdgeLive(chanID.ToUint64())
 }
 
-// generateBandwidthHints is a helper function that's utilized the main
-// findPath function in order to obtain hints from the lower layer w.r.t to the
-// available bandwidth of edges on the network. Currently, we'll only obtain
-// bandwidth hints for the edges we directly have open ourselves. Obtaining
-// these hints allows us to reduce the number of extraneous attempts as we can
-// skip channels that are inactive, or just don't have enough bandwidth to
-// carry the payment.
-func generateBandwidthHints(sourceNode *channeldb.LightningNode,
-	queryBandwidth func(*channeldb.ChannelEdgeInfo) lnwire.MilliSatoshi) (map[uint64]lnwire.MilliSatoshi, error) {
-
-	// First, we'll collect the set of outbound edges from the target
-	// source node.
-	var localChans []*channeldb.ChannelEdgeInfo
-	err := sourceNode.ForEachChannel(nil, func(tx kvdb.RTx,
-		edgeInfo *channeldb.ChannelEdgeInfo,
-		_, _ *channeldb.ChannelEdgePolicy) error {
-
-		localChans = append(localChans, edgeInfo)
-		return nil
-	})
-	if err != nil {
-		return nil, err
-	}
-
-	// Now that we have all of our outbound edges, we'll populate the set
-	// of bandwidth hints, querying the lower switch layer for the most up
-	// to date values.
-	bandwidthHints := make(map[uint64]lnwire.MilliSatoshi)
-	for _, localChan := range localChans {
-		bandwidthHints[localChan.ChannelID] = queryBandwidth(localChan)
-	}
-
-	return bandwidthHints, nil
-}
-
 // ErrNoChannel is returned when a route cannot be built because there are no
 // channels that satisfy all requirements.
 type ErrNoChannel struct {
@@ -2628,7 +2593,7 @@ func (r *ChannelRouter) BuildRoute(amt *lnwire.MilliSatoshi,
 
 	// We'll attempt to obtain a set of bandwidth hints that helps us select
 	// the best outgoing channel to use in case no outgoing channel is set.
-	bandwidthHints, err := generateBandwidthHints(
+	bandwidthHints, err := newBandwidthManager(
 		r.selfNode, r.cfg.QueryBandwidth,
 	)
 	if err != nil {

--- a/routing/router_test.go
+++ b/routing/router_test.go
@@ -127,8 +127,8 @@ func createTestCtxFromGraphInstanceAssumeValid(t *testing.T,
 
 	sessionSource := &SessionSource{
 		Graph: graphInstance.graph,
-		QueryBandwidth: func(
-			e *channeldb.ChannelEdgeInfo) lnwire.MilliSatoshi {
+		QueryBandwidth: func(e *channeldb.ChannelEdgeInfo,
+			_ *lnwire.MilliSatoshi) lnwire.MilliSatoshi {
 
 			return lnwire.NewMSatFromSatoshis(e.Capacity)
 		},
@@ -146,8 +146,8 @@ func createTestCtxFromGraphInstanceAssumeValid(t *testing.T,
 		SessionSource:      sessionSource,
 		ChannelPruneExpiry: time.Hour * 24,
 		GraphPruneInterval: time.Hour * 2,
-		QueryBandwidth: func(
-			e *channeldb.ChannelEdgeInfo) lnwire.MilliSatoshi {
+		QueryBandwidth: func(e *channeldb.ChannelEdgeInfo,
+			_ *lnwire.MilliSatoshi) lnwire.MilliSatoshi {
 
 			return lnwire.NewMSatFromSatoshis(e.Capacity)
 		},

--- a/routing/router_test.go
+++ b/routing/router_test.go
@@ -2441,7 +2441,7 @@ func TestFindPathFeeWeighting(t *testing.T) {
 	// the edge weighting, we should select the direct path over the 2 hop
 	// path even though the direct path has a higher potential time lock.
 	path, err := dbFindPath(
-		ctx.graph, nil, nil,
+		ctx.graph, nil, &mockBandwidthHints{},
 		noRestrictions,
 		testPathFindingConfig,
 		sourceNode.PubKeyBytes, target, amt, 0,

--- a/routing/unified_policies.go
+++ b/routing/unified_policies.go
@@ -139,7 +139,7 @@ type unifiedPolicy struct {
 // specific amount to send. It differentiates between local and network
 // channels.
 func (u *unifiedPolicy) getPolicy(amt lnwire.MilliSatoshi,
-	bandwidthHints map[uint64]lnwire.MilliSatoshi) *channeldb.ChannelEdgePolicy {
+	bandwidthHints bandwidthHints) *channeldb.ChannelEdgePolicy {
 
 	if u.localChan {
 		return u.getPolicyLocal(amt, bandwidthHints)
@@ -151,7 +151,7 @@ func (u *unifiedPolicy) getPolicy(amt lnwire.MilliSatoshi,
 // getPolicyLocal returns the optimal policy to use for this local connection
 // given a specific amount to send.
 func (u *unifiedPolicy) getPolicyLocal(amt lnwire.MilliSatoshi,
-	bandwidthHints map[uint64]lnwire.MilliSatoshi) *channeldb.ChannelEdgePolicy {
+	bandwidthHints bandwidthHints) *channeldb.ChannelEdgePolicy {
 
 	var (
 		bestPolicy   *channeldb.ChannelEdgePolicy
@@ -175,7 +175,9 @@ func (u *unifiedPolicy) getPolicyLocal(amt lnwire.MilliSatoshi,
 		// TODO(joostjager): Possibly change to skipping this
 		// channel. The bandwidth hint is expected to be
 		// available.
-		bandwidth, ok := bandwidthHints[edge.policy.ChannelID]
+		bandwidth, ok := bandwidthHints.availableChanBandwidth(
+			edge.policy.ChannelID,
+		)
 		if !ok {
 			bandwidth = lnwire.MaxMilliSatoshi
 		}

--- a/routing/unified_policies.go
+++ b/routing/unified_policies.go
@@ -175,8 +175,8 @@ func (u *unifiedPolicy) getPolicyLocal(amt lnwire.MilliSatoshi,
 		// TODO(joostjager): Possibly change to skipping this
 		// channel. The bandwidth hint is expected to be
 		// available.
-		bandwidth, ok := bandwidthHints.availableChanBandwidth(
-			edge.policy.ChannelID,
+		bandwidth, ok := bandwidthHints.availableHtlcBandwidth(
+			edge.policy.ChannelID, amt,
 		)
 		if !ok {
 			bandwidth = lnwire.MaxMilliSatoshi

--- a/routing/unified_policies_test.go
+++ b/routing/unified_policies_test.go
@@ -15,7 +15,7 @@ func TestUnifiedPolicies(t *testing.T) {
 	toNode := route.Vertex{2}
 	fromNode := route.Vertex{3}
 
-	bandwidthHints := map[uint64]lnwire.MilliSatoshi{}
+	bandwidthHints := &mockBandwidthHints{}
 
 	u := newUnifiedPolicies(source, toNode, nil)
 

--- a/server.go
+++ b/server.go
@@ -702,7 +702,9 @@ func newServer(cfg *Config, listenAddrs []net.Addr,
 		return nil, err
 	}
 
-	queryBandwidth := func(edge *channeldb.ChannelEdgeInfo) lnwire.MilliSatoshi {
+	queryBandwidth := func(edge *channeldb.ChannelEdgeInfo,
+		amount *lnwire.MilliSatoshi) lnwire.MilliSatoshi {
+
 		cid := lnwire.NewChanIDFromOutPoint(&edge.ChannelPoint)
 		link, err := s.htlcSwitch.GetLink(cid)
 		if err != nil {
@@ -718,10 +720,16 @@ func newServer(cfg *Config, listenAddrs []net.Addr,
 			return 0
 		}
 
-		// If our link isn't currently in a state where it can
-		// add another outgoing htlc, treat the link as unusable.
-		if err := link.MayAddOutgoingHtlc(); err != nil {
-			return 0
+		// If an amount was specified, we're querying available
+		// bandwidth for the addition of a specific hltc, so we want
+		// to validate that the link has a payment slot available for
+		// this amount. If not, we return a 0 bandwidth because the
+		// link is unusable for this htlc.
+		if amount != nil {
+			err := link.MayAddOutgoingHtlc()
+			if err != nil {
+				return 0
+			}
 		}
 
 		// Otherwise, we'll return the current best estimate

--- a/server.go
+++ b/server.go
@@ -726,7 +726,7 @@ func newServer(cfg *Config, listenAddrs []net.Addr,
 		// this amount. If not, we return a 0 bandwidth because the
 		// link is unusable for this htlc.
 		if amount != nil {
-			err := link.MayAddOutgoingHtlc()
+			err := link.MayAddOutgoingHtlc(*amount)
 			if err != nil {
 				return 0
 			}


### PR DESCRIPTION
This PR bubbles our htlc amount all the way down to `MayAddOutgoingHtlc` , implementing the full fix for #5468 (replacing the temporary fix introduced in #5478 to account for nodes that set a 0 `minHtlc`). 

This change updates our bandwidth check to only check whether we can add a htlc to our channel when we're actually adding one; `availableChanBalance` queries for the total bandwidth of the channel do not check any flow constraints. I think this is ok because we just get our channel balance when we're doing a very quick [getOutgoingBalance](https://github.com/lightningnetwork/lnd/blob/d771ed761678f8074bd396db1d77c7b7b859abdc/routing/pathfind.go#L357) check our [own channels](https://github.com/lightningnetwork/lnd/blob/d771ed761678f8074bd396db1d77c7b7b859abdc/routing/pathfind.go#L493). If we continue with pathfinding, the actual htlc addition check itself will kick in when we [getPolicyLocal](https://github.com/lightningnetwork/lnd/blob/a329c8061266418bccd797aa5d7d277c736ee930/routing/unified_policies.go#L145) anyway. An alternative would be to continue to query using (potentially padded) `minHtlc` and calling `MayAddOutoingHtlc` on all bandwidth checks.