### PR TITLE
payments: allocate payment sequences in blocks

### DIFF
--- a/docs/release-notes/release-notes-0.14.0.md
+++ b/docs/release-notes/release-notes-0.14.0.md
@@ -24,6 +24,9 @@ the release notes folder that at leasts links to PR being added.
   code](https://github.com/lightningnetwork/lnd/pull/5547) when using etcd
   backend.
 
+[Optimized payment sequence generation](https://github.com/lightningnetwork/lnd/pull/5514/)
+to make LNDs payment throughput (and latency) with better when using etcd.
+
 # Contributors (Alphabetical Order)
 * ErikEk
 * Zero-1729


### PR DESCRIPTION
The bucket sequence we use as payment sequence makes the DB update in
InitPayment conflict and therefore queue up when many concurrent
payments happen. This change allocates payment sequences in blocks
of 1000 to avoid these conflicts.

Without this fix (`dbbackend=etcd`):
```
=== RUN   TestLightningNetworkDaemon
=== RUN   TestLightningNetworkDaemon/37-of-82/btcd/async_payments_benchmark
    test_harness.go:120: 	Benchmark info: Elapsed time:  6.222378347s
    test_harness.go:120: 	Benchmark info: TPS:  77.62305232256877
--- PASS: TestLightningNetworkDaemon (16.93s
```

With this fix  (`dbbackend=etcd`):
```
=== RUN   TestLightningNetworkDaemon
=== RUN   TestLightningNetworkDaemon/37-of-82/btcd/async_payments_benchmark
    test_harness.go:120: 	Benchmark info: Elapsed time:  4.894176887s
    test_harness.go:120: 	Benchmark info: TPS:  98.68870928693917
--- PASS: TestLightningNetworkDaemon (16.20s)
```