### PR TITLE
routing: store missioncontrol state in blocks and eliminate cursor use

### DIFF
--- a/docs/release-notes/release-notes-0.14.0.md
+++ b/docs/release-notes/release-notes-0.14.0.md
@@ -43,6 +43,11 @@ addholdinvoice call](https://github.com/lightningnetwork/lnd/pull/5533).
 [Optimized payment sequence generation](https://github.com/lightningnetwork/lnd/pull/5514/)
 to make LNDs payment throughput (and latency) with better when using etcd.
 
+## Performance improvements
+
+* [Update MC store in blocks](https://github.com/lightningnetwork/lnd/pull/5515)
+  to make payment throughput better when using etcd.
+
 # Contributors (Alphabetical Order)
 * ErikEk
 * Zero-1729

--- a/lnrpc/routerrpc/config.go
+++ b/lnrpc/routerrpc/config.go
@@ -49,6 +49,7 @@ func DefaultConfig() *Config {
 		AttemptCost:           routing.DefaultAttemptCost.ToSatoshis(),
 		AttemptCostPPM:        routing.DefaultAttemptCostPPM,
 		MaxMcHistory:          routing.DefaultMaxMcHistory,
+		McFlushInterval:       routing.DefaultMcFlushInterval,
 	}
 
 	return &Config{
@@ -66,5 +67,6 @@ func GetRoutingConfig(cfg *Config) *RoutingConfig {
 		AttemptCostPPM:        cfg.AttemptCostPPM,
 		PenaltyHalfLife:       cfg.PenaltyHalfLife,
 		MaxMcHistory:          cfg.MaxMcHistory,
+		McFlushInterval:       cfg.McFlushInterval,
 	}
 }

--- a/lnrpc/routerrpc/routing_config.go
+++ b/lnrpc/routerrpc/routing_config.go
@@ -43,4 +43,8 @@ type RoutingConfig struct {
 	// MaxMcHistory defines the maximum number of payment results that
 	// are held on disk by mission control.
 	MaxMcHistory int `long:"maxmchistory" description:"the maximum number of payment results that are held on disk by mission control"`
+
+	// McFlushInterval defines the timer interval to use to flush mission
+	// control state to the DB.
+	McFlushInterval time.Duration `long:"mcflushinterval" description:"the timer interval to use to flush mission control state to the DB"`
 }

--- a/routing/missioncontrol_store_test.go
+++ b/routing/missioncontrol_store_test.go
@@ -10,8 +10,8 @@ import (
 	"github.com/davecgh/go-spew/spew"
 	"github.com/lightningnetwork/lnd/kvdb"
 	"github.com/lightningnetwork/lnd/lnwire"
-
 	"github.com/lightningnetwork/lnd/routing/route"
+	"github.com/stretchr/testify/require"
 )
 
 const testMaxRecords = 2
@@ -40,7 +40,7 @@ func TestMissionControlStore(t *testing.T) {
 	defer db.Close()
 	defer os.Remove(dbPath)
 
-	store, err := newMissionControlStore(db, testMaxRecords)
+	store, err := newMissionControlStore(db, testMaxRecords, time.Second)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -80,27 +80,21 @@ func TestMissionControlStore(t *testing.T) {
 	result2.id = 2
 
 	// Store result.
-	err = store.AddResult(&result2)
-	if err != nil {
-		t.Fatal(err)
-	}
+	store.AddResult(&result2)
 
 	// Store again to test idempotency.
-	err = store.AddResult(&result2)
-	if err != nil {
-		t.Fatal(err)
-	}
+	store.AddResult(&result2)
 
 	// Store second result which has an earlier timestamp.
-	err = store.AddResult(&result1)
-	if err != nil {
-		t.Fatal(err)
-	}
+	store.AddResult(&result1)
+	require.NoError(t, store.storeResults())
 
 	results, err = store.fetchAll()
 	if err != nil {
 		t.Fatal(err)
 	}
+	require.Equal(t, 2, len(results))
+
 	if len(results) != 2 {
 		t.Fatal("expected two results")
 	}
@@ -116,7 +110,7 @@ func TestMissionControlStore(t *testing.T) {
 	}
 
 	// Recreate store to test pruning.
-	store, err = newMissionControlStore(db, testMaxRecords)
+	store, err = newMissionControlStore(db, testMaxRecords, time.Second)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -128,16 +122,15 @@ func TestMissionControlStore(t *testing.T) {
 	result3.id = 3
 	result3.failure = &lnwire.FailMPPTimeout{}
 
-	err = store.AddResult(&result3)
-	if err != nil {
-		t.Fatal(err)
-	}
+	store.AddResult(&result3)
+	require.NoError(t, store.storeResults())
 
 	// Check that results are pruned.
 	results, err = store.fetchAll()
 	if err != nil {
 		t.Fatal(err)
 	}
+	require.Equal(t, 2, len(results))
 	if len(results) != 2 {
 		t.Fatal("expected two results")
 	}

--- a/routing/missioncontrol_test.go
+++ b/routing/missioncontrol_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/lightningnetwork/lnd/kvdb"
 	"github.com/lightningnetwork/lnd/lnwire"
 	"github.com/lightningnetwork/lnd/routing/route"
+	"github.com/stretchr/testify/require"
 )
 
 var (
@@ -77,6 +78,12 @@ func createMcTestContext(t *testing.T) *mcTestContext {
 
 // restartMc creates a new instances of mission control on the same database.
 func (ctx *mcTestContext) restartMc() {
+	// Since we don't run a timer to store results in unit tests, we store
+	// them here before fetching back everything in NewMissionControl.
+	if ctx.mc != nil {
+		require.NoError(ctx.t, ctx.mc.store.storeResults())
+	}
+
 	mc, err := NewMissionControl(
 		ctx.db, mcTestSelf,
 		&MissionControlConfig{

--- a/sample-lnd.conf
+++ b/sample-lnd.conf
@@ -1023,6 +1023,9 @@ litecoin.node=ltcd
 ; (default: 1000)
 ; routerrpc.maxmchistory=900
 
+; The time interval with which the MC store state is flushed to the DB.
+; routerrpc.mcflushinterval=1m
+
 ; Path to the router macaroon
 ; routerrpc.routermacaroonpath=~/.lnd/data/chain/bitcoin/simnet/router.macaroon
 


### PR DESCRIPTION
This PR changes missioncontrol's store update from per payment to
every second. Updating the missioncontrol store on every payment caused
gradual slowdown when using etcd.
We also completely eliminate the use of the cursor, further reducing
the performance bottleneck. One more Get could be removed if we don't care
about idempotency check (we really shouldn't as it's not efficient to do
so with a remote DB).

Using the `itest=aync_payments_benchmark dbbackend=etcd`:
```
=== RUN   TestLightningNetworkDaemon
=== RUN   TestLightningNetworkDaemon/37-of-82/btcd/async_payments_benchmark
    test_harness.go:120: 	Benchmark info: Elapsed time:  5.808059726s
    test_harness.go:120: 	Benchmark info: TPS:  83.16030185396204
--- PASS: TestLightningNetworkDaemon (15.93s)
    --- PASS: TestLightningNetworkDaemon/37-of-82/btcd/async_payments_benchmark (15.25s)
PASS
```

Without the fix:
```
=== RUN   TestLightningNetworkDaemon
=== RUN   TestLightningNetworkDaemon/37-of-82/btcd/async_payments_benchmark
    test_harness.go:120: 	Benchmark info: Elapsed time:  6.222378347s
    test_harness.go:120: 	Benchmark info: TPS:  77.62305232256877
--- PASS: TestLightningNetworkDaemon (16.93s)
```