### PR TITLE
etcd: kvdb fixes

### DIFF
--- a/kvdb/debug.go
+++ b/kvdb/debug.go
@@ -1,0 +1,8 @@
+// +build dev
+
+package kvdb
+
+const (
+	// Switch on extra debug code.
+	etcdDebug = true
+)

--- a/kvdb/etcd/debug.go
+++ b/kvdb/etcd/debug.go
@@ -1,0 +1,8 @@
+// +build dev
+
+package etcd
+
+const (
+	// Switch on extra debug code.
+	etcdDebug = true
+)

--- a/kvdb/etcd/nodebug.go
+++ b/kvdb/etcd/nodebug.go
@@ -1,0 +1,8 @@
+// +build !dev
+
+package etcd
+
+const (
+	// Switch off extra debug code.
+	etcdDebug = false
+)

--- a/kvdb/etcd/readwrite_cursor.go
+++ b/kvdb/etcd/readwrite_cursor.go
@@ -116,22 +116,10 @@ func (c *readWriteCursor) Seek(seek []byte) (key, value []byte) {
 // invalidating the cursor.  Returns ErrIncompatibleValue if attempted
 // when the cursor points to a nested bucket.
 func (c *readWriteCursor) Delete() error {
-	// Get the next key after the current one. We could do this
-	// after deletion too but it's one step more efficient here.
-	nextKey, err := c.bucket.tx.stm.Next(c.prefix, c.currKey)
-	if err != nil {
-		return err
-	}
-
 	if isBucketKey(c.currKey) {
 		c.bucket.DeleteNestedBucket(getKey(c.currKey))
 	} else {
 		c.bucket.Delete(getKey(c.currKey))
-	}
-
-	if nextKey != nil {
-		// Set current key to the next one.
-		c.currKey = nextKey.key
 	}
 
 	return nil

--- a/kvdb/etcd_test.go
+++ b/kvdb/etcd_test.go
@@ -19,6 +19,7 @@ var (
 func TestEtcd(t *testing.T) {
 	tests := []struct {
 		name       string
+		debugOnly  bool
 		test       func(*testing.T, walletdb.DB)
 		expectedDb map[string]string
 	}{
@@ -103,8 +104,9 @@ func TestEtcd(t *testing.T) {
 			test: testBucketSequence,
 		},
 		{
-			name: "key clash",
-			test: testKeyClash,
+			name:      "key clash",
+			debugOnly: true,
+			test:      testKeyClash,
 			expectedDb: map[string]string{
 				bkey("apple"):           bval("apple"),
 				bkey("apple", "banana"): bval("apple", "banana"),
@@ -136,6 +138,10 @@ func TestEtcd(t *testing.T) {
 
 	for _, test := range tests {
 		test := test
+
+		if test.debugOnly && !etcdDebug {
+			continue
+		}
 
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()

--- a/kvdb/nodebug.go
+++ b/kvdb/nodebug.go
@@ -1,0 +1,8 @@
+// +build !dev
+
+package kvdb
+
+const (
+	// Switch off extra debug code.
+	etcdDebug = false
+)


### PR DESCRIPTION
This PR fixes a bug in the cursor where `Delete` would step the cursor to the next element after the deleted one which is incompatible with bbolt. 

Furthermore we remove an assertion that would prevent us from creating a value with a key that already is used for a bucket.  While enforcing this rule is helpful it's impractical as we don't have such buckets and values. Removing this assertion improves etcd Put performance considerably.

Benchmark with the fix (`dbbackend=etcd`):
```
=== RUN   TestLightningNetworkDaemon
=== RUN   TestLightningNetworkDaemon/37-of-82/btcd/async_payments_benchmark
    test_harness.go:120: 	Benchmark info: Elapsed time:  6.096842747s
    test_harness.go:120: 	Benchmark info: TPS:  79.22133144038592
--- PASS: TestLightningNetworkDaemon (17.10s)
    --- PASS: TestLightningNetworkDaemon/37-of-82/btcd/async_payments_benchmark (16.42s)
```

Without the fix:
```
=== RUN   TestLightningNetworkDaemon
=== RUN   TestLightningNetworkDaemon/37-of-82/btcd/async_payments_benchmark
    test_harness.go:120: 	Benchmark info: Elapsed time:  6.222378347s
    test_harness.go:120: 	Benchmark info: TPS:  77.62305232256877
--- PASS: TestLightningNetworkDaemon (16.93s)
```
