### PR TITLE
build: add new GH actions to require release note updates

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -258,3 +258,16 @@ jobs:
 
       - name: ensure dependences at correct version
         run:   if ! grep -q "${{ matrix.pinned_dep }}" go.mod; then echo dependency ${{ matrix.pinned_dep }} should not be altered ; exit 1 ; fi
+
+  ########################
+  # check PR updates release notes
+  ########################
+  milestone-check:
+    name: check release notes updated
+    runs-on: ubuntu-latest
+    steps:
+      - name: git checkout
+        uses: actions/checkout@v2
+
+      - name: release notes check
+        run: scripts/check-release-notes.sh

--- a/docs/release-notes/release-notes-0.14.0.md
+++ b/docs/release-notes/release-notes-0.14.0.md
@@ -1,3 +1,10 @@
 # Release Notes
 
+# Build System
+
+[A new pre-submit check has been
+added](https://github.com/lightningnetwork/lnd/pull/5520) to ensure that all
+PRs add an entry in the release notes folder that at leasts links to PR being
+added.
+
 # Contributors (Alphabetical Order)

--- a/scripts/check-release-notes.sh
+++ b/scripts/check-release-notes.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+set -e
+
+# Extract the PR number which is stored in the $GITHUB_REF env variable. The
+# format of the string stored in the variable is: refs/pull/:PRNUMBER/merge.
+PR_NUMBER=$(echo $GITHUB_REF | awk 'BEGIN { FS = "/" } ; { print $3 }')
+
+# Ensure that the PR number at least shows up in the release notes folder under
+# one of the contained milestones.
+if ! grep -r -q "lightningnetwork/lnd/pull/$PR_NUMBER" docs/release-notes; then
+    echo "PR $PR_NUMBER didn't update release notes"
+    exit 1
+fi


### PR DESCRIPTION
In this commit, we add a simple bash script to parse out the current PR
number from an environment variable in the GH actions context, and use
that to check to see if the PR has been referenced in the release notes
or not. This isn't 100% fool proof, but it should catch most of the
common cases.
