### PR TITLE
lntest: fix possible race condition re asserting channel propagation

### DIFF
--- a/lntest/itest/lnd_mpp_test.go
+++ b/lntest/itest/lnd_mpp_test.go
@@ -346,9 +346,9 @@ func (c *mppTestContext) waitForChannels() {
 			ctxt, _ := context.WithTimeout(ctxb, defaultTimeout)
 			err = node.WaitForNetworkChannelOpen(ctxt, chanPoint)
 			if err != nil {
-				c.t.Fatalf("(%d): timeout waiting for "+
+				c.t.Fatalf("(%v:%d): timeout waiting for "+
 					"channel(%s) open: %v",
-					node.NodeID, point, err)
+					node.Cfg.Name, node.NodeID, point, err)
 			}
 		}
 	}


### PR DESCRIPTION
In this commit, we attempt to fix a race condition that may occur in the
current AMP and MPP tests.

It appears the following scenario is possible:
  * The `mppTestContext` [is used to create 6 channels back to
    back](https://github.com/lightningnetwork/lnd/blob/master/lntest/itest/lnd_amp_test.go#L43)
  * The method used to create the channel ends up calling
    [`openChannelAndAssert`](https://github.com/lightningnetwork/lnd/blob/edd4152682dc8f70e11da541cd3be4692db4b011/lntest/itest/lnd_mpp_test.go#L300)
    which'll open the channel, mine 6 blocks, [then ensure that the
    channel gets
    advertised](https://github.com/lightningnetwork/lnd/blob/edd4152682dc8f70e11da541cd3be4692db4b011/lntest/itest/assertions.go#L78)
  * Later on, [we wait for all nodes to hear about all channels on the
    network
    level](https://github.com/lightningnetwork/lnd/blob/master/lntest/itest/lnd_amp_test.go#L62)

I think the issue here is that we'll potentially already have mined 30
or so blocks before getting to the final nodes, and those nodes may have
already heard about the channel already. This may then cause their
[`lightningNetworkWatcher`](https://github.com/lightningnetwork/lnd/blob/edd4152682dc8f70e11da541cd3be4692db4b011/lntest/node.go#L1213)
goroutine to not properly dispatch this, since it's assumed that the
channel hasn't been announced (or notified) when the method is called.

One solution here is to just check if the channel is already in the
node's graph or not, when we go to register the notification. If we do
this in the same state machine as the watcher, then we ensure if the
channel is already known, the client is immediately notified. One thing
that can help us debug this more in the future is adding additional
logging in some of these helper goroutines so we can more easily track
the control flow.

This commit implements this solution by checking to ensure that the
channel isn't already known in our channel graph before attempting to
wait for its notification, as we may already have missed the

Fixes #5500 (and possibly any other instance where we see failed channel open). 

Fixes #5496 ? 