### PR TITLE
Allow lnd to be imported into projects that are compiled to WASM

### DIFF
--- a/docs/release-notes/release-notes-0.14.0.md
+++ b/docs/release-notes/release-notes-0.14.0.md
@@ -13,6 +13,13 @@ PRs ([aside from merge
 commits](https://github.com/lightningnetwork/lnd/pull/5543)) add an entry in
 the release notes folder that at leasts links to PR being added.
 
+# Misc
+
+* The direct use of certain syscalls in packages such as `bbolt` or `lnd`'s own
+  `healthcheck` package made it impossible to import `lnd` code as a library
+  into projects that are compiled to WASM binaries. [That problem was fixed by
+  guarding those syscalls with build tags](https://github.com/lightningnetwork/lnd/pull/5526).
+
 # Code Health
 
 ## Code cleanup, refactor, typo fixes
@@ -32,3 +39,4 @@ the release notes folder that at leasts links to PR being added.
 # Contributors (Alphabetical Order)
 * ErikEk
 * Zero-1729
+* Oliver Gugger

--- a/go.sum
+++ b/go.sum
@@ -53,7 +53,6 @@ github.com/btcsuite/btcwallet/walletdb v1.3.4/go.mod h1:oJDxAEUHVtnmIIBaa22wSBPT
 github.com/btcsuite/btcwallet/walletdb v1.3.5-0.20210513043850-3a2f12e3a954/go.mod h1:oJDxAEUHVtnmIIBaa22wSBPTVcs6hUp5NKWmI8xDwwU=
 github.com/btcsuite/btcwallet/walletdb v1.3.5 h1:SoxUPLgJUkyO1XqON6X7x+rjHJoIpRQov8o8X6gNoz8=
 github.com/btcsuite/btcwallet/walletdb v1.3.5/go.mod h1:oJDxAEUHVtnmIIBaa22wSBPTVcs6hUp5NKWmI8xDwwU=
-github.com/btcsuite/btcwallet/wtxmgr v1.3.0 h1:lrZaZXGJjDedYTV7s5UgU9xBe8+N+cIDW7BYwI/B8Fs=
 github.com/btcsuite/btcwallet/wtxmgr v1.3.0/go.mod h1:awQsh1n/0ZrEQ+JZgWvHeo153ubzEisf/FyNtwI0dDk=
 github.com/btcsuite/btcwallet/wtxmgr v1.3.1-0.20210706234807-aaf03fee735a h1:25oMK8eFUTVMyKGHc2xX7pNkU4u208Dpf6IPVh5E+cA=
 github.com/btcsuite/btcwallet/wtxmgr v1.3.1-0.20210706234807-aaf03fee735a/go.mod h1:UM38ixX8VwJ9qey4umf//0H3ndn5kSImFZ46V54Nd5Q=

--- a/healthcheck/diskcheck.go
+++ b/healthcheck/diskcheck.go
@@ -1,4 +1,4 @@
-// +build !windows,!solaris,!netbsd,!openbsd
+// +build !windows,!solaris,!netbsd,!openbsd,!js
 
 package healthcheck
 

--- a/healthcheck/diskcheck_js.go
+++ b/healthcheck/diskcheck_js.go
@@ -1,0 +1,13 @@
+package healthcheck
+
+// AvailableDiskSpaceRatio returns ratio of available disk space to total
+// capacity.
+func AvailableDiskSpaceRatio(path string) (float64, error) {
+	return 0, fmt.Errorf("disk space check not supported in WebAssembly")
+}
+
+// AvailableDiskSpace returns the available disk space in bytes of the given
+// file system.
+func AvailableDiskSpace(path string) (uint64, error) {
+	return 0, fmt.Errorf("disk space check not supported in WebAssembly")
+}

--- a/kvdb/backend.go
+++ b/kvdb/backend.go
@@ -1,3 +1,5 @@
+// +build !js
+
 package kvdb
 
 import (

--- a/kvdb/backend_js.go
+++ b/kvdb/backend_js.go
@@ -1,0 +1,48 @@
+package kvdb
+
+import (
+	"fmt"
+	"time"
+)
+
+// BoltBackendConfig is a struct that holds settings specific to the bolt
+// database backend.
+type BoltBackendConfig struct {
+	// DBPath is the directory path in which the database file should be
+	// stored.
+	DBPath string
+
+	// DBFileName is the name of the database file.
+	DBFileName string
+
+	// NoFreelistSync, if true, prevents the database from syncing its
+	// freelist to disk, resulting in improved performance at the expense of
+	// increased startup time.
+	NoFreelistSync bool
+
+	// AutoCompact specifies if a Bolt based database backend should be
+	// automatically compacted on startup (if the minimum age of the
+	// database file is reached). This will require additional disk space
+	// for the compacted copy of the database but will result in an overall
+	// lower database size after the compaction.
+	AutoCompact bool
+
+	// AutoCompactMinAge specifies the minimum time that must have passed
+	// since a bolt database file was last compacted for the compaction to
+	// be considered again.
+	AutoCompactMinAge time.Duration
+
+	// DBTimeout specifies the timeout value to use when opening the wallet
+	// database.
+	DBTimeout time.Duration
+}
+
+// GetBoltBackend opens (or creates if doesn't exits) a bbolt backed database
+// and returns a kvdb.Backend wrapping it.
+func GetBoltBackend(cfg *BoltBackendConfig) (Backend, error) {
+	return nil, fmt.Errorf("bolt backend not supported in WebAssembly")
+}
+
+func GetTestBackend(path, name string) (Backend, func(), error) {
+	return nil, nil, fmt.Errorf("bolt backend not supported in WebAssembly")
+}

--- a/kvdb/bolt_compact.go
+++ b/kvdb/bolt_compact.go
@@ -2,6 +2,8 @@
 // implemented in this file:
 // https://github.com/etcd-io/bbolt/blob/master/cmd/bbolt/main.go
 
+// +build !js
+
 package kvdb
 
 import (

--- a/kvdb/interface.go
+++ b/kvdb/interface.go
@@ -2,7 +2,6 @@ package kvdb
 
 import (
 	"github.com/btcsuite/btcwallet/walletdb"
-	_ "github.com/btcsuite/btcwallet/walletdb/bdb" // Import to register backend.
 )
 
 // Update opens a database read/write transaction and executes the function f

--- a/lnwallet/btcwallet/config.go
+++ b/lnwallet/btcwallet/config.go
@@ -9,12 +9,6 @@ import (
 
 	"github.com/btcsuite/btcwallet/chain"
 	"github.com/btcsuite/btcwallet/wallet"
-
-	// This is required to register bdb as a valid walletdb driver. In the
-	// init function of the package, it registers itself. The import is used
-	// to activate the side effects w/o actually binding the package name to
-	// a file-level variable.
-	_ "github.com/btcsuite/btcwallet/walletdb/bdb"
 )
 
 var (


### PR DESCRIPTION
When using parts of `lnd` as a library in other projects that are compiled to WASM, there can't be any direct uses of non-supported syscalls. The main place where such syscalls currently exist are the `bbolt` library and our own `healthcheck` package.
We prevent those packages to be pulled in by guarding them with specific build tags.