### PR TITLE
Allow group reading admin macaroon

### DIFF
--- a/docs/release-notes/release-notes-0.14.0.md
+++ b/docs/release-notes/release-notes-0.14.0.md
@@ -5,6 +5,19 @@
 [Return payment address and add index from
 addholdinvoice call](https://github.com/lightningnetwork/lnd/pull/5533).
 
+## Security 
+
+### Admin macaroon permissions
+
+The default file permissions of admin.macaroon were [changed from 0600 to
+0640](https://github.com/lightningnetwork/lnd/pull/5534). This makes it easier
+to allow other users to manage LND. This is safe on common Unix systems
+because they always create a new group for each user.
+
+If you use a strange system or changed group membership of the group running LND
+you may want to check your system to see if it introduces additional risk for
+you.
+
 # Build System
 
 [A new pre-submit check has been
@@ -31,4 +44,5 @@ the release notes folder that at leasts links to PR being added.
 
 # Contributors (Alphabetical Order)
 * ErikEk
+* Martin Habovstiak
 * Zero-1729

--- a/lnd.go
+++ b/lnd.go
@@ -56,6 +56,22 @@ import (
 	"github.com/lightningnetwork/lnd/watchtower/wtdb"
 )
 
+const (
+	// adminMacaroonFilePermissions is the file permission that is used for
+	// creating the admin macaroon file.
+	//
+	// Why 640 is safe:
+	// Assuming a reasonably secure Linux system, it will have a
+	// separate group for each user. E.g. a new user lnd gets assigned group
+	// lnd which nothing else belongs to. A system that does not do this is
+	// inherently broken already.
+	//
+	// Since there is no other user in the group, no other user can read
+	// admin macaroon unless the administrator explicitly allowed it. Thus
+	// there's no harm allowing group read.
+	adminMacaroonFilePermissions = 0640
+)
+
 // AdminAuthOptions returns a list of DialOptions that can be used to
 // authenticate with the RPC server with admin capabilities.
 // skipMacaroons=true should be set if we don't want to include macaroons with
@@ -1255,7 +1271,9 @@ func genMacaroons(ctx context.Context, svc *macaroons.Service,
 	if err != nil {
 		return err
 	}
-	if err = ioutil.WriteFile(admFile, admBytes, 0600); err != nil {
+
+	err = ioutil.WriteFile(admFile, admBytes, adminMacaroonFilePermissions)
+	if err != nil {
 		_ = os.Remove(admFile)
 		return err
 	}


### PR DESCRIPTION
This changes file creation mode on admin macaroon from 0600 to 0640. The
reason is to make permission management easier.

Closes #4385

**Is this safe?**

Yes, it is. Assuming a reasonably secure Linux system, it will have a
separate group for each user. E.g. a new user `lnd` gets assigned group
`lnd` which nothing else blongs to. A system that does not do this is
inherently broken already.

Since there is no other user in the group, no other user can read admin
macaroon unless the administrator explicitly allowed it. Thus there's no
harm allowing group read.

#### Pull Request Checklist

Because of how trivial the change is, I didn't bother to run tests myself, will let CI do that.

- [x] If this is your first time contributing, we recommend you read the [Code
  Contribution Guidelines](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md)
- [x] All changes are Go version 1.12 compliant
- [x] The code being submitted is commented according to [Code Documentation and Commenting](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#CodeDocumentation)
- [ ] For new code: Code is accompanied by tests which exercise both
  the positive and negative (error paths) conditions (if applicable)
- [ ] For bug fixes: Code is accompanied by new tests which trigger
  the bug being fixed to prevent regressions - *is this necessary here?*
- [ ] Any new logging statements use an appropriate subsystem and
  logging level *no new logging*
- [ ] Code has been formatted with `go fmt`
- [ ] Protobuf files (`lnrpc/**/*.proto`) have been formatted with
  `make rpc-format` and compiled with `make rpc`
- [ ] New configuration flags have been added to `sample-lnd.conf`
- [ ] For code and documentation: lines are wrapped at 80 characters
  (the tab character should be counted as 8 characters, not 4, as some IDEs do
  per default)
- [ ] Running `make check` does not fail any tests
- [ ] Running `go vet` does not report any issues
- [ ] Running `make lint` does not report any **new** issues that did not
  already exist
- [ ] All commits build properly and pass tests. Only in exceptional
  cases it can be justifiable to violate this condition. In that case, the
  reason should be stated in the commit message.
- [ ] Commits have a logical structure according to [Ideal Git Commit Structure](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#IdealGitCommitStructure)
