### PR TITLE
Implemented systemd notify

### DIFF
--- a/docs/release-notes/release-notes-0.14.0.md
+++ b/docs/release-notes/release-notes-0.14.0.md
@@ -25,6 +25,12 @@ for more information.
 * [Stub code for interacting with `lnrpc` from a WASM context through JSON 
   messages was added](https://github.com/lightningnetwork/lnd/pull/5601).
 
+* LND now [reports to systemd](https://github.com/lightningnetwork/lnd/pull/5536)
+  that RPC is ready (port bound, certificate generated, macaroons created,
+  in case of `wallet-unlock-password-file` wallet unlocked). This can be used to
+  avoid misleading error messages from dependent services if they use `After`
+  systemd option.
+
 ## Wallet
 
 * It is now possible to fund a psbt [without specifying any

--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/btcsuite/btcwallet/wallet/txrules v1.0.0
 	github.com/btcsuite/btcwallet/walletdb v1.3.6-0.20210803004036-eebed51155ec
 	github.com/btcsuite/btcwallet/wtxmgr v1.3.1-0.20210803004036-eebed51155ec
+	github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e
 	github.com/davecgh/go-spew v1.1.1
 	github.com/fsnotify/fsnotify v1.4.9 // indirect
 	github.com/go-errors/errors v1.0.1

--- a/lnd.go
+++ b/lnd.go
@@ -537,6 +537,10 @@ func Main(cfg *Config, lisCfg ListenerCfg, interceptor signal.Interceptor) error
 	// to the default behavior of waiting for the wallet creation/unlocking
 	// over RPC.
 	default:
+		if err := interceptor.Notifier.NotifyReady(false); err != nil {
+			return err
+		}
+
 		params, err := waitForWalletPassword(
 			cfg, pwService, []btcwallet.LoaderOption{dbs.walletDB},
 			interceptor.ShutdownChannel(),
@@ -892,6 +896,10 @@ func Main(cfg *Config, lisCfg ListenerCfg, interceptor signal.Interceptor) error
 
 	// We transition the RPC state to Active, as the RPC server is up.
 	interceptorChain.SetRPCActive()
+
+	if err := interceptor.Notifier.NotifyReady(true); err != nil {
+		return err
+	}
 
 	// If we're not in regtest or simnet mode, We'll wait until we're fully
 	// synced to continue the start up of the remainder of the daemon. This


### PR DESCRIPTION
This adds support for notifying systemd about the state of LND. It
notifies systemd just before waiting for wallet password or, if
`wallet-password-file` was specified, right after unlocking the wallet.

This means that "ready" represents RPC being available for intended use.
It's intentional, so that client services can use `After=` in `systemd`
configuration to avoid misleading error messages about missing files or
refused connections.

Part of #4470

Meta:

* I'm not sure what's your policy on dependencies - is this OK? I reviewed the code of the called function and it looks OK. It's quite short so copying it may be even reasonable but if we add socket activation it might get messy.
* I'm really not sure how to test it - docker containers usually don't have systemd. We would probably need a special one. Any ideas?
* Checklist asks about version 1.12 but [build instructions say 1.15](https://github.com/lightningnetwork/lnd/blob/master/docs/INSTALL.md#preliminaries-for-installing-from-source), does the checklist need to be updated? I built it with Go 1.15 from Debian buster-backports
* TODO: test checkboxes

#### Pull Request Checklist

- [x] If this is your first time contributing, we recommend you read the [Code
  Contribution Guidelines](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md)
- [ ] All changes are Go version 1.12 compliant
- [x] The code being submitted is commented according to [Code Documentation and Commenting](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#CodeDocumentation)
- [ ] For new code: Code is accompanied by tests which exercise both
  the positive and negative (error paths) conditions (if applicable)
- [ ] For bug fixes: Code is accompanied by new tests which trigger
  the bug being fixed to prevent regressions
- [x] Any new logging statements use an appropriate subsystem and
  logging level
- [x] Code has been formatted with `go fmt`
- [ ] Protobuf files (`lnrpc/**/*.proto`) have been formatted with
  `make rpc-format` and compiled with `make rpc`
- [ ] New configuration flags have been added to `sample-lnd.conf`
- [x] For code and documentation: lines are wrapped at 80 characters
  (the tab character should be counted as 8 characters, not 4, as some IDEs do
  per default)
- [ ] Running `make check` does not fail any tests
- [ ] Running `go vet` does not report any issues
- [ ] Running `make lint` does not report any **new** issues that did not
  already exist
- [ ] All commits build properly and pass tests. Only in exceptional
  cases it can be justifiable to violate this condition. In that case, the
  reason should be stated in the commit message.
- [ ] Commits have a logical structure according to [Ideal Git Commit Structure](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#IdealGitCommitStructure)
