### PR TITLE
Do not enforce new reserved value in PSBT midstep

### DIFF
--- a/docs/release-notes/release-notes-0.14.2.md
+++ b/docs/release-notes/release-notes-0.14.2.md
@@ -5,6 +5,15 @@
 * [Return the nearest known fee rate when a given conf target cannot be found
   from Web API fee estimator.](https://github.com/lightningnetwork/lnd/pull/6062)
 
+## Wallet
+
+* A bug that prevented opening anchor-based channels from external wallets when
+  the internal wallet was empty even though the transaction contained a
+  sufficiently large output belonging to the internal wallet
+  [was fixed](https://github.com/lightningnetwork/lnd/pull/5539)
+  In other words, freshly-installed LND can now be initailized with multiple
+  channels from an external (e.g. hardware) wallet *in a single transaction*.
+
 ## Build System
 
 * [Clean up Makefile by using go
@@ -35,6 +44,7 @@
 
 * Andras Banki-Horvath
 * Harsha Goli
+* Martin Habovštiak
 * Naveen Srinivasan
 * Oliver Gugger
 * Yong Yu

--- a/lntest/itest/lnd_test_list_on_test.go
+++ b/lntest/itest/lnd_test_list_on_test.go
@@ -288,6 +288,10 @@ var allTestCases = []*testCase{
 		test: testBatchChanFunding,
 	},
 	{
+		name: "psbt channel funding single step",
+		test: testPsbtChanFundingSingleStep,
+	},
+	{
 		name: "sendtoroute multi path payment",
 		test: testSendToRouteMultiPath,
 	},

--- a/lnwallet/wallet.go
+++ b/lnwallet/wallet.go
@@ -706,6 +706,12 @@ func (l *LightningWallet) handleFundingReserveRequest(req *InitFundingReserveMsg
 		return
 	}
 
+	// We need to avoid enforcing reserved value in the middle of PSBT
+	// funding because some of the following steps may add UTXOs funding
+	// the on-chain wallet.
+	// The enforcement still happens at the last step - in PsbtFundingVerify
+	enforceNewReservedValue := true
+
 	// If no chanFunder was provided, then we'll assume the default
 	// assembler, which is backed by the wallet's internal coin selection.
 	if req.ChanFunder == nil {
@@ -720,6 +726,9 @@ func (l *LightningWallet) handleFundingReserveRequest(req *InitFundingReserveMsg
 			DustLimit:        DustLimitForSize(input.P2WSHSize),
 		}
 		req.ChanFunder = chanfunding.NewWalletAssembler(cfg)
+	} else {
+		_, isPsbtFunder := req.ChanFunder.(*chanfunding.PsbtAssembler)
+		enforceNewReservedValue = !isPsbtFunder
 	}
 
 	localFundingAmt := req.LocalFundingAmt
@@ -819,13 +828,15 @@ func (l *LightningWallet) handleFundingReserveRequest(req *InitFundingReserveMsg
 	// when the PSBT has been verified.
 	isPublic := req.Flags&lnwire.FFAnnounceChannel != 0
 	hasAnchors := req.CommitType.HasAnchors()
-	err = l.enforceNewReservedValue(fundingIntent, isPublic, hasAnchors)
-	if err != nil {
-		fundingIntent.Cancel()
+	if enforceNewReservedValue {
+		err = l.enforceNewReservedValue(fundingIntent, isPublic, hasAnchors)
+		if err != nil {
+			fundingIntent.Cancel()
 
-		req.err <- err
-		req.resp <- nil
-		return
+			req.err <- err
+			req.resp <- nil
+			return
+		}
 	}
 
 	// The total channel capacity will be the size of the funding output we


### PR DESCRIPTION
This change avoids enforcing new reserved value when PSBT funding is not
finished yet as new inputs and outputs may still be added that could
change the outcome of the check.

This originally failed in the scenario when funding a channel from
external wallet *and depositing to on-chain wallet* was done
simultaneously in a single transaction. If such transaction confirms
then reserved UTXO is guaranteed to be available but the check didn't
take it into account.

The enforcement still occurs in the final step of PSBT funding flow, so
it is safe. It also occurs in case of non-PSBT funding.

This partially fixes https://github.com/lightningnetwork/lnd/pull/5363#issuecomment-875766968
For full fix it'd be great to be able to optionally avoid anchor commitments (to improve privacy).

I will look at tests later, I mainly wanted to get initial feedback on this. If anyone would like to help with writing tests I'd be happy to accept. :)

#### Pull Request Checklist

- [x] If this is your first time contributing, we recommend you read the [Code
  Contribution Guidelines](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md)
- [ ] All changes are Go version 1.12 compliant
- [x] The code being submitted is commented according to [Code Documentation and Commenting](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#CodeDocumentation)
- [ ] For new code: Code is accompanied by tests which exercise both
  the positive and negative (error paths) conditions (if applicable)
- [x] For bug fixes: Code is accompanied by new tests which trigger
  the bug being fixed to prevent regressions
- [ ] Any new logging statements use an appropriate subsystem and
  logging level
- [x] Code has been formatted with `go fmt`
- [ ] Protobuf files (`lnrpc/**/*.proto`) have been formatted with
  `make rpc-format` and compiled with `make rpc`
- [ ] New configuration flags have been added to `sample-lnd.conf`
- [x] For code and documentation: lines are wrapped at 80 characters
  (the tab character should be counted as 8 characters, not 4, as some IDEs do
  per default)
- [ ] Running `make check` does not fail any tests
- [ ] Running `go vet` does not report any issues
- [x] Running `make lint` does not report any **new** issues that did not
  already exist
- [ ] All commits build properly and pass tests. Only in exceptional
  cases it can be justifiable to violate this condition. In that case, the
  reason should be stated in the commit message.
- [x] Commits have a logical structure according to [Ideal Git Commit Structure](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#IdealGitCommitStructure)
