### PR TITLE
build: add itest-race build target to catch data races with itests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -143,6 +143,14 @@ build-itest:
 	@$(call print, "Building itest binary for ${backend} backend.")
 	CGO_ENABLED=0 $(GOTEST) -v ./lntest/itest -tags="$(DEV_TAGS) $(RPC_TAGS) rpctest $(backend)" -c -o lntest/itest/itest.test$(EXEC_SUFFIX)
 
+build-itest-race:
+	@$(call print, "Building itest btcd and lnd with race detector.")
+	CGO_ENABLED=0 $(GOBUILD) -tags="rpctest" -o lntest/itest/btcd-itest$(EXEC_SUFFIX) $(ITEST_LDFLAGS) $(BTCD_PKG)
+	CGO_ENABLED=1 $(GOBUILD) -race -tags="$(ITEST_TAGS)" -o lntest/itest/lnd-itest$(EXEC_SUFFIX) $(ITEST_LDFLAGS) $(PKG)/cmd/lnd
+
+	@$(call print, "Building itest binary for ${backend} backend.")
+	CGO_ENABLED=0 $(GOTEST) -v ./lntest/itest -tags="$(DEV_TAGS) $(RPC_TAGS) rpctest $(backend)" -c -o lntest/itest/itest.test$(EXEC_SUFFIX)
+
 install:
 	@$(call print, "Installing lnd and lncli.")
 	$(GOINSTALL) -tags="${tags}" $(LDFLAGS) $(PKG)/cmd/lnd
@@ -186,6 +194,8 @@ itest-only:
 	lntest/itest/log_check_errors.sh
 
 itest: build-itest itest-only
+
+itest-race: build-itest-race itest-only
 
 itest-parallel: build-itest
 	@$(call print, "Running tests")

--- a/docs/release-notes/release-notes-0.14.0.md
+++ b/docs/release-notes/release-notes-0.14.0.md
@@ -2,11 +2,14 @@
 
 # Build System
 
-[A new pre-submit check has been
-added](https://github.com/lightningnetwork/lnd/pull/5520) to ensure that all
-PRs ([aside from merge
-commits](https://github.com/lightningnetwork/lnd/pull/5543)) add an entry in
-the release notes folder that at leasts links to PR being added.
+* [A new pre-submit check has been
+  added](https://github.com/lightningnetwork/lnd/pull/5520) to ensure that all
+  PRs ([aside from merge
+  commits](https://github.com/lightningnetwork/lnd/pull/5543)) add an entry in
+  the release notes folder that at leasts links to PR being added.
+
+* [A new build target itest-race](https://github.com/lightningnetwork/lnd/pull/5542) 
+  to help uncover undetected data races with our itests.
 
 # Code Health
 


### PR DESCRIPTION
This PR adds `itest-race` build target that can be used with
individual itests to detect and catch uncovered data races.
