### PR TITLE
scripts: account for master branch merges in release notes script

### DIFF
--- a/docs/release-notes/release-notes-0.14.0.md
+++ b/docs/release-notes/release-notes-0.14.0.md
@@ -4,7 +4,8 @@
 
 [A new pre-submit check has been
 added](https://github.com/lightningnetwork/lnd/pull/5520) to ensure that all
-PRs add an entry in the release notes folder that at leasts links to PR being
-added.
+PRs ([aside from merge
+commits](https://github.com/lightningnetwork/lnd/pull/5543)) add an entry in
+the release notes folder that at leasts links to PR being added.
 
 # Contributors (Alphabetical Order)

--- a/scripts/check-release-notes.sh
+++ b/scripts/check-release-notes.sh
@@ -6,6 +6,13 @@ set -e
 # format of the string stored in the variable is: refs/pull/:PRNUMBER/merge.
 PR_NUMBER=$(echo $GITHUB_REF | awk 'BEGIN { FS = "/" } ; { print $3 }')
 
+# If this is a PR being merged into the main repo, then the PR number will
+# actually be "master" here, so we'll ignore this case, and assume that in
+# order for it to be merged it had to pass the check in its base branch.
+if [ $PR_NUMBER == "master" ]; then
+    exit 0
+fi
+
 # Ensure that the PR number at least shows up in the release notes folder under
 # one of the contained milestones.
 if ! grep -r -q "lightningnetwork/lnd/pull/$PR_NUMBER" docs/release-notes; then


### PR DESCRIPTION
Without this commit, the build may break if a PR commit is created, as
that shows the `PR_NUMBER` field we parse out as "master", reflecting
that its a merge commit into the master branch.
