### PR TITLE
mod+GitHub: shorten PR template, bump golang to 1.15

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,27 +1,11 @@
 #### Pull Request Checklist
 
-- [ ] If this is your first time contributing, we recommend you read the [Code
-  Contribution Guidelines](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md)
-- [ ] All changes are Go version 1.12 compliant
-- [ ] The code being submitted is commented according to [Code Documentation and Commenting](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#CodeDocumentation)
-- [ ] For new code: Code is accompanied by tests which exercise both
-  the positive and negative (error paths) conditions (if applicable)
-- [ ] For bug fixes: Code is accompanied by new tests which trigger
-  the bug being fixed to prevent regressions
-- [ ] Any new logging statements use an appropriate subsystem and
-  logging level
-- [ ] Code has been formatted with `go fmt`
-- [ ] Protobuf files (`lnrpc/**/*.proto`) have been formatted with
-  `make rpc-format` and compiled with `make rpc`
-- [ ] New configuration flags have been added to `sample-lnd.conf`
-- [ ] For code and documentation: lines are wrapped at 80 characters
-  (the tab character should be counted as 8 characters, not 4, as some IDEs do
-  per default)
-- [ ] Running `make check` does not fail any tests
-- [ ] Running `go vet` does not report any issues
-- [ ] Running `make lint` does not report any **new** issues that did not
-  already exist
-- [ ] All commits build properly and pass tests. Only in exceptional
-  cases it can be justifiable to violate this condition. In that case, the
-  reason should be stated in the commit message.
-- [ ] Commits have a logical structure according to [Ideal Git Commit Structure](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#IdealGitCommitStructure)
+- [ ] All changes are Go version 1.15 compliant
+- [ ] Your PR passes all CI checks. If a check cannot be passed for a justifiable reason, that reason must be stated in the commit message and PR description.
+- [ ] If this is your first time contributing, we recommend you read the [Code Contribution Guidelines](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md)
+   - [ ] The code being submitted is commented according to [Code Documentation and Commenting](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#CodeDocumentation)
+   - [ ] Commits have a logical structure according to [Ideal Git Commit Structure](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#IdealGitCommitStructure)
+- [ ] For new code: Code is accompanied by tests which exercise both the positive and negative (error paths) conditions (if applicable)
+- [ ] For bug fixes: If possible, code is accompanied by new tests which trigger the bug being fixed to prevent regressions
+- [ ] Any new logging statements use an appropriate subsystem and logging level
+- [ ] For code and documentation: lines are wrapped at 80 characters (the tab character should be counted as 8 characters, not 4, as some IDEs do per default)

--- a/docs/release-notes/release-notes-0.14.0.md
+++ b/docs/release-notes/release-notes-0.14.0.md
@@ -10,8 +10,11 @@ added.
 # Code Health
 
 ## Code cleanup, refactor, typo fixes
+
 * [Unused error check 
-removed](https://github.com/lightningnetwork/lnd/pull/5537).
+  removed](https://github.com/lightningnetwork/lnd/pull/5537).
+* [Shorten Pull Request check list by referring to the CI checks that are 
+  in place](https://github.com/lightningnetwork/lnd/pull/5545)
 
 # Contributors (Alphabetical Order)
 ErikEk

--- a/go.mod
+++ b/go.mod
@@ -83,4 +83,6 @@ replace git.schwanenlied.me/yawning/bsaes.git => github.com/Yawning/bsaes v0.0.0
 // See https://github.com/etcd-io/etcd/issues/11154
 replace go.etcd.io/etcd => go.etcd.io/etcd v0.5.0-alpha.5.0.20201125193152-8a03d2e9614b
 
+// If you change this please also update .github/pull_request_template.md and
+// docs/INSTALL.md.
 go 1.15


### PR DESCRIPTION
The golang version always needs to be in sync between the go.mod, the PR
checklist and the installation instructions.

We also add a new entry to the PR checklist for the recently added
release notes check.

#### Pull Request Checklist

- [ ] All changes are Go version 1.15 compliant
- [ ] Your PR passes all CI checks
- [ ] If this is your first time contributing, we recommend you read the [Code
  Contribution Guidelines](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md)
   - [ ] The code being submitted is commented according to [Code Documentation and
  Commenting](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#CodeDocumentation)
   - [ ] Commits have a logical structure according to [Ideal Git Commit
  Structure](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#IdealGitCommitStructure)
- [ ] For new code: Code is accompanied by tests which exercise both
  the positive and negative (error paths) conditions (if applicable)
- [ ] For bug fixes: Code is accompanied by new tests which trigger the bug
  being fixed to prevent regressions
- [ ] Any new logging statements use an appropriate subsystem and logging level
- [ ] For code and documentation: lines are wrapped at 80 characters
  (the tab character should be counted as 8 characters, not 4, as some IDEs do
  per default)
- [ ] All commits build properly and pass tests. Only in exceptional
  cases it can be justifiable to violate this condition. In that case, the
  reason should be stated in the commit message.
