### PR TITLE
etcd: optionally reduce concurrency to single writer for legacy code

### DIFF
--- a/docs/release-notes/release-notes-0.14.0.md
+++ b/docs/release-notes/release-notes-0.14.0.md
@@ -17,6 +17,12 @@ added.
   in place](https://github.com/lightningnetwork/lnd/pull/5545).
 * [Added minor fixes to contribution guidelines](https://github.com/lightningnetwork/lnd/pull/5503).
 
+## Database
+
+* [Ensure single writer for legacy
+  code](https://github.com/lightningnetwork/lnd/pull/5547) when using etcd
+  backend.
+
 # Contributors (Alphabetical Order)
 * ErikEk
 * Zero-1729

--- a/kvdb/etcd/config.go
+++ b/kvdb/etcd/config.go
@@ -25,4 +25,8 @@ type Config struct {
 	InsecureSkipVerify bool `long:"insecure_skip_verify" description:"Whether we intend to skip TLS verification"`
 
 	CollectStats bool `long:"collect_stats" description:"Whether to collect etcd commit stats."`
+
+	// SingleWriter should be set to true if we intend to only allow a
+	// single writer to the database at a time.
+	SingleWriter bool
 }

--- a/kvdb/etcd/fixture.go
+++ b/kvdb/etcd/fixture.go
@@ -78,8 +78,13 @@ func NewEtcdTestFixture(t *testing.T) *EtcdTestFixture {
 	}
 }
 
-func (f *EtcdTestFixture) NewBackend() walletdb.DB {
-	db, err := newEtcdBackend(context.TODO(), f.BackendConfig())
+func (f *EtcdTestFixture) NewBackend(singleWriter bool) walletdb.DB {
+	cfg := f.BackendConfig()
+	if singleWriter {
+		cfg.SingleWriter = true
+	}
+
+	db, err := newEtcdBackend(context.TODO(), cfg)
 	require.NoError(f.t, err)
 
 	return db

--- a/kvdb/etcd/readwrite_tx.go
+++ b/kvdb/etcd/readwrite_tx.go
@@ -3,6 +3,8 @@
 package etcd
 
 import (
+	"sync"
+
 	"github.com/btcsuite/btcwallet/walletdb"
 )
 
@@ -17,13 +19,18 @@ type readWriteTx struct {
 
 	// active is true if the transaction hasn't been committed yet.
 	active bool
+
+	// lock is passed on for manual txns when the backend is instantiated
+	// such that we read/write lock transactions to ensure a single writer.
+	lock sync.Locker
 }
 
 // newReadWriteTx creates an rw transaction with the passed STM.
-func newReadWriteTx(stm STM, prefix string) *readWriteTx {
+func newReadWriteTx(stm STM, prefix string, lock sync.Locker) *readWriteTx {
 	return &readWriteTx{
 		stm:          stm,
 		active:       true,
+		lock:         lock,
 		rootBucketID: makeBucketID([]byte(prefix)),
 	}
 }
@@ -65,6 +72,10 @@ func (tx *readWriteTx) Rollback() error {
 		return walletdb.ErrTxClosed
 	}
 
+	if tx.lock != nil {
+		defer tx.lock.Unlock()
+	}
+
 	// Rollback the STM and set the tx to inactive.
 	tx.stm.Rollback()
 	tx.active = false
@@ -97,6 +108,10 @@ func (tx *readWriteTx) Commit() error {
 	// Commit will fail if the transaction is already committed.
 	if !tx.active {
 		return walletdb.ErrTxClosed
+	}
+
+	if tx.lock != nil {
+		defer tx.lock.Unlock()
 	}
 
 	// Try committing the transaction.

--- a/kvdb/etcd_test.go
+++ b/kvdb/etcd_test.go
@@ -3,6 +3,7 @@
 package kvdb
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/btcsuite/btcwallet/walletdb"
@@ -143,18 +144,23 @@ func TestEtcd(t *testing.T) {
 			continue
 		}
 
-		t.Run(test.name, func(t *testing.T) {
-			t.Parallel()
+		rwLock := []bool{false, true}
+		for _, doRwLock := range rwLock {
+			name := fmt.Sprintf("%v/RWLock=%v", test.name, doRwLock)
 
-			f := etcd.NewEtcdTestFixture(t)
-			defer f.Cleanup()
+			t.Run(name, func(t *testing.T) {
+				t.Parallel()
 
-			test.test(t, f.NewBackend())
+				f := etcd.NewEtcdTestFixture(t)
+				defer f.Cleanup()
 
-			if test.expectedDb != nil {
-				dump := f.Dump()
-				require.Equal(t, test.expectedDb, dump)
-			}
-		})
+				test.test(t, f.NewBackend(doRwLock))
+
+				if test.expectedDb != nil {
+					dump := f.Dump()
+					require.Equal(t, test.expectedDb, dump)
+				}
+			})
+		}
 	}
 }


### PR DESCRIPTION
This PR adds a new configuration option to the etcd kvdb backend that allows us to reduce concurrency to single writer (and multiple readers) vs the default commit queue based key set defined concurrency. This will make sure that in a fully remote mode we can instantiate separate backend for legacy code, eg. the wallet database to ensure reverse compatibility.