### PR TITLE
kvdb: run channeldb test suite on postgres

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -206,7 +206,8 @@ jobs:
       matrix:
         unit_type:
           - btcd unit-cover
-          - unit tags="kvdb_etcd kvdb_postgres"
+          - unit tags="kvdb_etcd"
+          - unit tags="kvdb_postgres"
           - travis-race
     steps:
       - name: git checkout

--- a/channeldb/db_test.go
+++ b/channeldb/db_test.go
@@ -25,6 +25,11 @@ import (
 func TestOpenWithCreate(t *testing.T) {
 	t.Parallel()
 
+	// Checking for db file existence is not possible with postgres.
+	if kvdb.PostgresBackend {
+		t.Skip()
+	}
+
 	// First, create a temporary directory to be used for the duration of
 	// this test.
 	tempDirName, err := ioutil.TempDir("", "channeldb")

--- a/channeldb/setup_test.go
+++ b/channeldb/setup_test.go
@@ -1,0 +1,11 @@
+package channeldb
+
+import (
+	"testing"
+
+	"github.com/lightningnetwork/lnd/kvdb"
+)
+
+func TestMain(m *testing.M) {
+	kvdb.RunTests(m)
+}

--- a/contractcourt/setup_test.go
+++ b/contractcourt/setup_test.go
@@ -1,0 +1,11 @@
+package contractcourt
+
+import (
+	"testing"
+
+	"github.com/lightningnetwork/lnd/kvdb"
+)
+
+func TestMain(m *testing.M) {
+	kvdb.RunTests(m)
+}

--- a/docs/release-notes/release-notes-0.14.0.md
+++ b/docs/release-notes/release-notes-0.14.0.md
@@ -460,6 +460,8 @@ messages directly. There is no routing/path finding involved.
 
 * [Fixed flake that occurred with the switch dust forwarding test under the data race unit build.](https://github.com/lightningnetwork/lnd/pull/5828)
 
+* [Run channeldb tests on postgres](https://github.com/lightningnetwork/lnd/pull/5550)
+
 ## Database
 
 * [Ensure single writer for legacy

--- a/kvdb/kvdb_no_postgres.go
+++ b/kvdb/kvdb_no_postgres.go
@@ -1,0 +1,19 @@
+// +build !kvdb_postgres
+
+package kvdb
+
+import (
+	"errors"
+
+	"github.com/lightningnetwork/lnd/kvdb/postgres"
+)
+
+const PostgresBackend = false
+
+func NewPostgresFixture(dbName string) (postgres.Fixture, error) {
+	return nil, errors.New("postgres backend not available")
+}
+
+func StartEmbeddedPostgres() (func() error, error) {
+	return nil, errors.New("postgres backend not available")
+}

--- a/kvdb/kvdb_postgres.go
+++ b/kvdb/kvdb_postgres.go
@@ -1,0 +1,15 @@
+// +build kvdb_postgres
+
+package kvdb
+
+import "github.com/lightningnetwork/lnd/kvdb/postgres"
+
+const PostgresBackend = true
+
+func NewPostgresFixture(dbName string) (postgres.Fixture, error) {
+	return postgres.NewFixture(dbName)
+}
+
+func StartEmbeddedPostgres() (func() error, error) {
+	return postgres.StartEmbeddedPostgres()
+}

--- a/kvdb/postgres/db.go
+++ b/kvdb/postgres/db.go
@@ -151,8 +151,15 @@ func (db *db) getPrefixedTableName(table string) string {
 func catchPanic(f func() error) (err error) {
 	defer func() {
 		if r := recover(); r != nil {
-			err = r.(error)
-			log.Criticalf("Caught unhandled error: %v", err)
+			log.Criticalf("Caught unhandled error: %v", r)
+
+			switch data := r.(type) {
+			case error:
+				err = data
+
+			default:
+				err = errors.New(fmt.Sprintf("%v", data))
+			}
 		}
 	}()
 

--- a/kvdb/postgres/fixture.go
+++ b/kvdb/postgres/fixture.go
@@ -95,6 +95,10 @@ type fixture struct {
 	Db  walletdb.DB
 }
 
+func (b *fixture) DB() walletdb.DB {
+	return b.Db
+}
+
 // Dump returns the raw contents of the database.
 func (b *fixture) Dump() (map[string]interface{}, error) {
 	dbConn, err := sql.Open("pgx", b.Dsn)

--- a/kvdb/postgres/fixture_interface.go
+++ b/kvdb/postgres/fixture_interface.go
@@ -1,0 +1,8 @@
+package postgres
+
+import "github.com/btcsuite/btcwallet/walletdb"
+
+type Fixture interface {
+	DB() walletdb.DB
+	Dump() (map[string]interface{}, error)
+}

--- a/kvdb/postgres_test.go
+++ b/kvdb/postgres_test.go
@@ -13,8 +13,9 @@ import (
 type m = map[string]interface{}
 
 func TestPostgres(t *testing.T) {
-	f := postgres.NewFixture(t)
-	defer f.Cleanup()
+	stop, err := postgres.StartEmbeddedPostgres()
+	require.NoError(t, err)
+	defer stop()
 
 	tests := []struct {
 		name       string
@@ -173,10 +174,14 @@ func TestPostgres(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			test.test(t, f.NewBackend())
+			f, err := postgres.NewFixture("")
+			require.NoError(t, err)
+
+			test.test(t, f.Db)
 
 			if test.expectedDb != nil {
-				dump := f.Dump()
+				dump, err := f.Dump()
+				require.NoError(t, err)
 				require.Equal(t, test.expectedDb, dump)
 			}
 		})

--- a/kvdb/test_utils.go
+++ b/kvdb/test_utils.go
@@ -1,0 +1,34 @@
+package kvdb
+
+import (
+	"fmt"
+	"os"
+	"testing"
+)
+
+// RunTests is a helper function to run the tests in a package with
+// initialization and tear-down of a test kvdb backend.
+func RunTests(m *testing.M) {
+	var close func() error
+	if PostgresBackend {
+		var err error
+		close, err = StartEmbeddedPostgres()
+		if err != nil {
+			fmt.Printf("Error: %v\n", err)
+			os.Exit(1)
+		}
+	}
+
+	// os.Exit() does not respect defer statements
+	code := m.Run()
+
+	if close != nil {
+		err := close()
+		if err != nil {
+			fmt.Printf("Error: %v\n", err)
+		}
+	}
+
+	os.Exit(code)
+
+}

--- a/routing/setup_test.go
+++ b/routing/setup_test.go
@@ -1,0 +1,11 @@
+package routing
+
+import (
+	"testing"
+
+	"github.com/lightningnetwork/lnd/kvdb"
+)
+
+func TestMain(m *testing.M) {
+	kvdb.RunTests(m)
+}

--- a/sweep/setup_test.go
+++ b/sweep/setup_test.go
@@ -1,0 +1,11 @@
+package sweep
+
+import (
+	"testing"
+
+	"github.com/lightningnetwork/lnd/kvdb"
+)
+
+func TestMain(m *testing.M) {
+	kvdb.RunTests(m)
+}


### PR DESCRIPTION
Extend test coverage by running the existing channeldb test suite on the postgres backend. This also includes a modest refactoring of the postgres test fixture to allow the same postgres test instance to be reused, each time with a fresh database. The channeldb tests concurrently instantiate countless databases and it wouldn't be feasible to spin up a new postgres instance on a unique port for each test.