### PR TITLE
cmd/lncli: always parse the pay_addr field for sendpayment

### DIFF
--- a/cmd/lncli/cmd_pay.go
+++ b/cmd/lncli/cmd_pay.go
@@ -93,6 +93,12 @@ var (
 		Usage: "if set to true, then AMP will be used to complete the " +
 			"payment",
 	}
+
+	ampReuseFlag = cli.BoolFlag{
+		Name: "amp-reuse",
+		Usage: "if set to true, then a random payment address will " +
+			"be generated to enable re-use of an AMP invoice",
+	}
 )
 
 // paymentFlags returns common flags for sendpayment and payinvoice.
@@ -138,6 +144,7 @@ func paymentFlags() []cli.Flag {
 		},
 		dataFlag, inflightUpdatesFlag, maxPartsFlag, jsonFlag,
 		maxShardSizeSatFlag, maxShardSizeMsatFlag, ampFlag,
+		ampReuseFlag,
 	}
 }
 
@@ -243,6 +250,16 @@ func parsePayAddr(ctx *cli.Context) ([]byte, error) {
 	switch {
 	case ctx.IsSet("pay_addr"):
 		payAddr, err = hex.DecodeString(ctx.String("pay_addr"))
+
+	case ctx.IsSet(ampReuseFlag.Name):
+		var addrBytes [32]byte
+		if _, err := rand.Read(addrBytes[:]); err != nil {
+			return nil, fmt.Errorf("unable to generate pay "+
+				"addr: %v", err)
+		}
+
+		payAddr = addrBytes[:]
+
 	case ctx.Args().Present():
 		payAddr, err = hex.DecodeString(ctx.Args().First())
 	}

--- a/docs/release-notes/release-notes-0.13.2.md
+++ b/docs/release-notes/release-notes-0.13.2.md
@@ -1,6 +1,12 @@
 # Release Notes
 
-# Bug Fixes
+## AMP
+
+A new command line option (`--amp-reuse`) has been added to make it easier for
+users to re-use AMP invoice on the command line using either the `payinvoice`
+or `sendpayment` command.
+
+## Bug Fixes
 
 [A bug has been fixed in the command line argument parsing for the
 `sendpayment` command that previously prevented users from being able to re-use

--- a/docs/release-notes/release-notes-0.13.2.md
+++ b/docs/release-notes/release-notes-0.13.2.md
@@ -1,0 +1,12 @@
+# Release Notes
+
+# Bug Fixes
+
+[A bug has been fixed in the command line argument parsing for the
+`sendpayment` command that previously prevented users from being able to re-use
+a fully
+specified AMP](https://github.com/lightningnetwork/lnd/pull/5554) invoice by
+generating a new `pay_addr` and including it as a CLI arg.
+
+# Contributors (Alphabetical Order)
+* Olaoluwa Osuntokun


### PR DESCRIPTION
In this commit, we fix a bug that would cause attempts to re-use an AMP
invoice to fail. Without this commit, we would only attempt to parse the
payment addr if no invoice was specified, so a user manually specifying the
pubkey of the detonation. The fix is straight forward: always parse the
`pay_addr` field as the user may be attempting to re-use an AMP invoice w/o
open coding each of the sections.

