### PR TITLE
lnrpc: use request context in WebSocket proxy

### DIFF
--- a/docs/release-notes/release-notes-0.14.0.md
+++ b/docs/release-notes/release-notes-0.14.0.md
@@ -29,6 +29,11 @@ the release notes folder that at leasts links to PR being added.
   code](https://github.com/lightningnetwork/lnd/pull/5547) when using etcd
   backend.
 
+# Bug fixes
+
+* The underlying gRPC connection is now [properly closed when the WebSocket
+  end of a connection is closed](https://github.com/lightningnetwork/lnd/pull/5555).
+
 # Contributors (Alphabetical Order)
 * ErikEk
 * Zero-1729

--- a/lnrpc/websocket_proxy.go
+++ b/lnrpc/websocket_proxy.go
@@ -147,12 +147,12 @@ func (p *WebsocketProxy) upgradeToWebSocketProxy(w http.ResponseWriter,
 		}
 	}()
 
-	ctx, cancelFn := context.WithCancel(context.Background())
+	ctx, cancelFn := context.WithCancel(r.Context())
 	defer cancelFn()
 
 	requestForwarder := newRequestForwardingReader()
 	request, err := http.NewRequestWithContext(
-		r.Context(), r.Method, r.URL.String(), requestForwarder,
+		ctx, r.Method, r.URL.String(), requestForwarder,
 	)
 	if err != nil {
 		p.logger.Errorf("WS: error preparing request:", err)
@@ -181,6 +181,7 @@ func (p *WebsocketProxy) upgradeToWebSocketProxy(w http.ResponseWriter,
 	go func() {
 		<-ctx.Done()
 		responseForwarder.Close()
+		requestForwarder.CloseWriter()
 	}()
 
 	go func() {


### PR DESCRIPTION
The request context was not properly used to pass it along to the gRPC
endpoint which caused streaming calls to still be active on the gRPC
side even if the WS side already hung up.
We also issue an explicit close on the forwarding writer to signal when
the WS side was closed.

