### PR TITLE
[WIP]: structured error codes

### DIFF
--- a/funding/manager.go
+++ b/funding/manager.go
@@ -788,9 +788,6 @@ func (f *Manager) failFundingFlow(peer lnpeer.Peer, tempChanID [32]byte,
 			errMsg.Data = lnwire.ErrorData(e.Error())
 		}
 
-	case lnwallet.ReservationError:
-		errMsg.Data = lnwire.ErrorData(e.Error())
-
 	case chanacceptor.ChanAcceptError:
 		errMsg.Data = lnwire.ErrorData(e.Error())
 
@@ -1235,7 +1232,7 @@ func (f *Manager) handleFundingOpen(peer lnpeer.Peer,
 	if amt < f.cfg.MinChanSize {
 		f.failFundingFlow(
 			peer, msg.PendingChannelID,
-			lnwallet.ErrChanTooSmall(amt, btcutil.Amount(f.cfg.MinChanSize)),
+			lnwallet.ErrChanTooSmall(amt, f.cfg.MinChanSize),
 		)
 		return
 	}
@@ -1245,7 +1242,7 @@ func (f *Manager) handleFundingOpen(peer lnpeer.Peer,
 	if f.cfg.RejectPush && msg.PushAmount > 0 {
 		f.failFundingFlow(
 			peer, msg.PendingChannelID,
-			lnwallet.ErrNonZeroPushAmount(),
+			lnwallet.ErrNonZeroPushAmount(uint64(msg.PushAmount)),
 		)
 		return
 	}

--- a/htlcswitch/link.go
+++ b/htlcswitch/link.go
@@ -1833,22 +1833,10 @@ func (l *channelLink) handleUpstreamMsg(msg lnwire.Message) {
 		// invalid.
 		err = l.channel.ReceiveNewCommitment(msg.CommitSig, msg.HtlcSigs)
 		if err != nil {
-			// If we were unable to reconstruct their proposed
-			// commitment, then we'll examine the type of error. If
-			// it's an InvalidCommitSigError, then we'll send a
-			// direct error.
-			var sendData []byte
-			switch err.(type) {
-			case *lnwallet.InvalidCommitSigError:
-				sendData = []byte(err.Error())
-			case *lnwallet.InvalidHtlcSigError:
-				sendData = []byte(err.Error())
-			}
 			l.fail(
 				LinkFailureError{
-					failure:    ErrInvalidCommitment,
+					failure:    err,
 					ForceClose: true,
-					SendData:   sendData,
 				},
 				"ChannelPoint(%v): unable to accept new "+
 					"commitment: %v",

--- a/htlcswitch/link.go
+++ b/htlcswitch/link.go
@@ -985,7 +985,9 @@ func (l *channelLink) htlcManager() {
 				// storing the transaction in the db.
 				l.fail(
 					LinkFailureError{
-						failure:    ErrSyncError,
+						failure: lnwire.NewCodedError(
+							lnwire.CodeSyncError,
+						),
 						ForceClose: true,
 					},
 					"unable to synchronize channel "+
@@ -1026,7 +1028,9 @@ func (l *channelLink) htlcManager() {
 
 			l.fail(
 				LinkFailureError{
-					failure:    ErrRecoveryError,
+					failure: lnwire.NewCodedError(
+						lnwire.CodeRecoveryError,
+					),
 					ForceClose: false,
 				},
 				"unable to synchronize channel "+
@@ -1062,7 +1066,11 @@ func (l *channelLink) htlcManager() {
 	// reforward.
 	if l.ShortChanID() != hop.Source {
 		if err := l.resolveFwdPkgs(); err != nil {
-			l.fail(LinkFailureError{failure: ErrInternalError},
+			l.fail(LinkFailureError{
+				failure: lnwire.NewCodedError(
+					lnwire.CodeInternalError,
+				),
+			},
 				"unable to resolve fwd pkgs: %v", err)
 			return
 		}
@@ -1168,7 +1176,9 @@ func (l *channelLink) htlcManager() {
 			}
 
 		case <-l.cfg.PendingCommitTicker.Ticks():
-			l.fail(LinkFailureError{failure: ErrRemoteUnresponsive},
+			l.fail(LinkFailureError{
+				failure: ErrRemoteUnresponsive,
+			},
 				"unable to complete dance")
 			return
 
@@ -1194,7 +1204,11 @@ func (l *channelLink) htlcManager() {
 			htlcResolution := hodlItem.(invoices.HtlcResolution)
 			err := l.processHodlQueue(htlcResolution)
 			if err != nil {
-				l.fail(LinkFailureError{failure: ErrInternalError},
+				l.fail(LinkFailureError{
+					failure: lnwire.NewCodedError(
+						lnwire.CodeInternalError,
+					),
+				},
 					fmt.Sprintf("process hodl queue: %v",
 						err.Error()),
 				)
@@ -1664,7 +1678,11 @@ func (l *channelLink) handleUpstreamMsg(msg lnwire.Message) {
 		// "settle" list in the event that we know the preimage.
 		index, err := l.channel.ReceiveHTLC(msg)
 		if err != nil {
-			l.fail(LinkFailureError{failure: ErrInvalidUpdate},
+			l.fail(LinkFailureError{
+				failure: lnwire.NewCodedError(
+					lnwire.CodeInvalidUpdate,
+				),
+			},
 				"unable to handle upstream add HTLC: %v", err)
 			return
 		}
@@ -1678,7 +1696,9 @@ func (l *channelLink) handleUpstreamMsg(msg lnwire.Message) {
 		if err := l.channel.ReceiveHTLCSettle(pre, idx); err != nil {
 			l.fail(
 				LinkFailureError{
-					failure:    ErrInvalidUpdate,
+					failure: lnwire.NewCodedError(
+						lnwire.CodeInvalidUpdate,
+					),
 					ForceClose: true,
 				},
 				"unable to handle upstream settle HTLC: %v", err,
@@ -1752,7 +1772,11 @@ func (l *channelLink) handleUpstreamMsg(msg lnwire.Message) {
 		// message to the usual HTLC fail message.
 		err := l.channel.ReceiveFailHTLC(msg.ID, b.Bytes())
 		if err != nil {
-			l.fail(LinkFailureError{failure: ErrInvalidUpdate},
+			l.fail(LinkFailureError{
+				failure: lnwire.NewCodedError(
+					lnwire.CodeInvalidUpdate,
+				),
+			},
 				"unable to handle upstream fail HTLC: %v", err)
 			return
 		}
@@ -1761,7 +1785,11 @@ func (l *channelLink) handleUpstreamMsg(msg lnwire.Message) {
 		idx := msg.ID
 		err := l.channel.ReceiveFailHTLC(idx, msg.Reason[:])
 		if err != nil {
-			l.fail(LinkFailureError{failure: ErrInvalidUpdate},
+			l.fail(LinkFailureError{
+				failure: lnwire.NewCodedError(
+					lnwire.CodeInvalidUpdate,
+				),
+			},
 				"unable to handle upstream fail HTLC: %v", err)
 			return
 		}
@@ -1781,7 +1809,11 @@ func (l *channelLink) handleUpstreamMsg(msg lnwire.Message) {
 		)
 		if err != nil {
 			l.fail(
-				LinkFailureError{failure: ErrInternalError},
+				LinkFailureError{
+					failure: lnwire.NewCodedError(
+						lnwire.CodeInternalError,
+					),
+				},
 				"unable to add preimages=%v to cache: %v",
 				l.uncommittedPreimages, err,
 			)
@@ -1870,7 +1902,11 @@ func (l *channelLink) handleUpstreamMsg(msg lnwire.Message) {
 		)
 		if err != nil {
 			// TODO(halseth): force close?
-			l.fail(LinkFailureError{failure: ErrInvalidRevocation},
+			l.fail(LinkFailureError{
+				failure: lnwire.NewCodedError(
+					lnwire.CodeInvalidRevocation,
+				),
+			},
 				"unable to accept revocation: %v", err)
 			return
 		}
@@ -1894,7 +1930,11 @@ func (l *channelLink) handleUpstreamMsg(msg lnwire.Message) {
 				state, state.RemoteCommitment.CommitHeight-1, 0,
 			)
 			if err != nil {
-				l.fail(LinkFailureError{failure: ErrInternalError},
+				l.fail(LinkFailureError{
+					failure: lnwire.NewCodedError(
+						lnwire.CodeInternalError,
+					),
+				},
 					"failed to load breach info: %v", err)
 				return
 			}
@@ -1904,7 +1944,11 @@ func (l *channelLink) handleUpstreamMsg(msg lnwire.Message) {
 				&chanID, breachInfo, state.ChanType,
 			)
 			if err != nil {
-				l.fail(LinkFailureError{failure: ErrInternalError},
+				l.fail(LinkFailureError{
+					failure: lnwire.NewCodedError(
+						lnwire.CodeInternalError,
+					),
+				},
 					"unable to queue breach backup: %v", err)
 				return
 			}
@@ -1938,7 +1982,11 @@ func (l *channelLink) handleUpstreamMsg(msg lnwire.Message) {
 		// will fail the channel, if not we will apply the update.
 		fee := chainfee.SatPerKWeight(msg.FeePerKw)
 		if err := l.channel.ReceiveUpdateFee(fee); err != nil {
-			l.fail(LinkFailureError{failure: ErrInvalidUpdate},
+			l.fail(LinkFailureError{
+				failure: lnwire.NewCodedError(
+					lnwire.CodeInvalidUpdate,
+				),
+			},
 				"error receiving fee update: %v", err)
 			return
 		}
@@ -1952,7 +2000,9 @@ func (l *channelLink) handleUpstreamMsg(msg lnwire.Message) {
 		// characters are printable ASCII.
 		l.fail(
 			LinkFailureError{
-				failure: ErrRemoteError,
+				failure: lnwire.NewCodedError(
+					lnwire.CodeRemoteError,
+				),
 
 				// TODO(halseth): we currently don't fail the
 				// channel permanently, as there are some sync
@@ -2032,7 +2082,11 @@ func (l *channelLink) ackDownStreamPackets() error {
 // the link.
 func (l *channelLink) updateCommitTxOrFail() bool {
 	if err := l.updateCommitTx(); err != nil {
-		l.fail(LinkFailureError{failure: ErrInternalError},
+		l.fail(LinkFailureError{
+			failure: lnwire.NewCodedError(
+				lnwire.CodeInternalError,
+			),
+		},
 			"unable to update commitment: %v", err)
 		return false
 	}
@@ -2752,7 +2806,11 @@ func (l *channelLink) processRemoteAdds(fwdPkg *channeldb.FwdPkg,
 		fwdPkg.ID(), decodeReqs,
 	)
 	if sphinxErr != nil {
-		l.fail(LinkFailureError{failure: ErrInternalError},
+		l.fail(LinkFailureError{
+			failure: lnwire.NewCodedError(
+				lnwire.CodeInternalError,
+			),
+		},
 			"unable to decode hop iterators: %v", sphinxErr)
 		return
 	}
@@ -2855,7 +2913,11 @@ func (l *channelLink) processRemoteAdds(fwdPkg *channeldb.FwdPkg,
 				pd, obfuscator, fwdInfo, heightNow, pld,
 			)
 			if err != nil {
-				l.fail(LinkFailureError{failure: ErrInternalError},
+				l.fail(LinkFailureError{
+					failure: lnwire.NewCodedError(
+						lnwire.CodeInternalError,
+					),
+				},
 					err.Error(),
 				)
 
@@ -2993,7 +3055,11 @@ func (l *channelLink) processRemoteAdds(fwdPkg *channeldb.FwdPkg,
 	if fwdPkg.State == channeldb.FwdStateLockedIn {
 		err := l.channel.SetFwdFilter(fwdPkg.Height, fwdPkg.FwdFilter)
 		if err != nil {
-			l.fail(LinkFailureError{failure: ErrInternalError},
+			l.fail(LinkFailureError{
+				failure: lnwire.NewCodedError(
+					lnwire.CodeInternalError,
+				),
+			},
 				"unable to set fwd filter: %v", err)
 			return
 		}

--- a/htlcswitch/link_test.go
+++ b/htlcswitch/link_test.go
@@ -6559,10 +6559,10 @@ func TestPendingCommitTicker(t *testing.T) {
 	// Assert that we get the expected link failure from Alice.
 	select {
 	case linkErr := <-linkErrs:
-		if linkErr.code != ErrRemoteUnresponsive {
+		if linkErr.failure != ErrRemoteUnresponsive {
 			t.Fatalf("error code mismatch, "+
 				"want: ErrRemoteUnresponsive, got: %v",
-				linkErr.code)
+				linkErr.failure)
 		}
 
 	case <-time.After(time.Second):

--- a/htlcswitch/linkfailure.go
+++ b/htlcswitch/linkfailure.go
@@ -13,31 +13,9 @@ var (
 
 	// ErrLinkFailedShutdown signals that a requested shutdown failed.
 	ErrLinkFailedShutdown = errors.New("link failed to shutdown")
+
+	ErrRemoteUnresponsive = errors.New("remote unresponsive")
 )
-
-// errorCode encodes the possible types of errors that will make us fail the
-// current link.
-type errorCode uint8
-
-// A compile time check to ensure errorCode implements the error
-// interface.
-var _ error = (*errorCode)(nil)
-
-const (
-	// ErrRemoteUnresponsive indicates that our peer took too long to
-	// complete a commitment dance.
-	ErrRemoteUnresponsive errorCode = iota
-)
-
-// Error returns an error string for an error code.
-func (e errorCode) Error() string {
-	switch e {
-	case ErrRemoteUnresponsive:
-		return "remote unresponsive"
-	default:
-		return "unknown error"
-	}
-}
 
 // LinkFailureError encapsulates an error that will make us fail the current
 // link. It contains the necessary information needed to determine if we should

--- a/lntest/itest/lnd_misc_test.go
+++ b/lntest/itest/lnd_misc_test.go
@@ -523,14 +523,10 @@ func testMaxPendingChannels(net *lntest.NetworkHarness, t *harnessTest) {
 			Amt: amount,
 		},
 	)
+	require.NotNil(t.t, err, "expect pending channels error")
 
-	if err == nil {
-		t.Fatalf("error wasn't received")
-	} else if !strings.Contains(
-		err.Error(), lnwire.ErrMaxPendingChannels.Error(),
-	) {
-		t.Fatalf("not expected error was received: %v", err)
-	}
+	expectedErr := lnwire.NewCodedError(lnwire.CodeMaxPendingChannels)
+	require.Contains(t.t, err.Error(), expectedErr.Error())
 
 	// For now our channels are in pending state, in order to not interfere
 	// with other tests we should clean up - complete opening of the

--- a/lntest/itest/lnd_wumbo_channels_test.go
+++ b/lntest/itest/lnd_wumbo_channels_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/btcsuite/btcutil"
 	"github.com/lightningnetwork/lnd/funding"
 	"github.com/lightningnetwork/lnd/lntest"
+	"github.com/lightningnetwork/lnd/lnwire"
 )
 
 // testWumboChannels tests that only a node that signals wumbo channel
@@ -46,7 +47,12 @@ func testWumboChannels(net *lntest.NetworkHarness, t *harnessTest) {
 
 	// The test should indicate a failure due to the channel being too
 	// large.
-	if !strings.Contains(err.Error(), "exceeds maximum chan size") {
+	expectedErr := lnwire.NewErroneousFieldErr(
+		lnwire.MsgOpenChannel, 2, uint64(chanAmt),
+		uint64(funding.MaxBtcFundingAmount),
+	)
+
+	if !strings.Contains(err.Error(), expectedErr.Error()) {
 		t.Fatalf("channel should be rejected due to size, instead "+
 			"error was: %v", err)
 	}

--- a/lnwallet/channel.go
+++ b/lnwallet/channel.go
@@ -43,17 +43,6 @@ var (
 	ErrMaxWeightCost = fmt.Errorf("commitment transaction exceed max " +
 		"available cost")
 
-	// ErrMaxHTLCNumber is returned when a proposed HTLC would exceed the
-	// maximum number of allowed HTLC's if committed in a state transition
-	ErrMaxHTLCNumber = fmt.Errorf("commitment transaction exceed max " +
-		"htlc number")
-
-	// ErrMaxPendingAmount is returned when a proposed HTLC would exceed
-	// the overall maximum pending value of all HTLCs if committed in a
-	// state transition.
-	ErrMaxPendingAmount = fmt.Errorf("commitment transaction exceed max" +
-		"overall pending htlc value")
-
 	// ErrBelowChanReserve is returned when a proposed HTLC would cause
 	// one of the peer's funds to dip below the channel reserve limit.
 	ErrBelowChanReserve = fmt.Errorf("commitment transaction dips peer " +
@@ -3462,14 +3451,18 @@ func (lc *LightningChannel) validateCommitmentSanity(theirLogCounter,
 		// Now that we know the total value of added HTLCs, we check
 		// that this satisfy the MaxPendingAmont contraint.
 		if amtInFlight > constraints.MaxPendingAmount {
-			return ErrMaxPendingAmount
+			return lnwire.NewCodedError(
+				lnwire.CodePendingHtlcAmountExceeded,
+			)
 		}
 
 		// In this step, we verify that the total number of active
 		// HTLCs does not exceed the constraint of the maximum number
 		// of HTLCs in flight.
 		if numInFlight > constraints.MaxAcceptedHtlcs {
-			return ErrMaxHTLCNumber
+			return lnwire.NewCodedError(
+				lnwire.CodePendingHtlcCountExceeded,
+			)
 		}
 
 		return nil

--- a/lnwallet/channel_test.go
+++ b/lnwallet/channel_test.go
@@ -6926,16 +6926,12 @@ func TestMinHTLC(t *testing.T) {
 	amt := minValue - 100
 	htlc, _ = createHTLC(1, amt)
 	_, err = aliceChannel.AddHTLC(htlc, nil)
-	if err != ErrBelowMinHTLC {
-		t.Fatalf("expected ErrBelowMinHTLC, instead received: %v", err)
-	}
+	require.Equal(t, ErrBelowMinHtlc(amt, minValue), err)
 
 	// Bob will receive this HTLC, but reject the next received htlc, since
 	// the htlc is too small.
 	_, err = bobChannel.ReceiveHTLC(htlc)
-	if err != ErrBelowMinHTLC {
-		t.Fatalf("expected ErrBelowMinHTLC, instead received: %v", err)
-	}
+	require.Equal(t, ErrBelowMinHtlc(amt, minValue), err)
 }
 
 // TestInvalidHTLCAmt tests that ErrInvalidHTLCAmt is returned when trying to
@@ -6964,13 +6960,10 @@ func TestInvalidHTLCAmt(t *testing.T) {
 
 	// Sending or receiving the HTLC should fail with ErrInvalidHTLCAmt.
 	_, err = aliceChannel.AddHTLC(htlc, nil)
-	if err != ErrInvalidHTLCAmt {
-		t.Fatalf("expected ErrInvalidHTLCAmt, got: %v", err)
-	}
+	require.Equal(t, ErrZeroHtlc(), err)
+
 	_, err = bobChannel.ReceiveHTLC(htlc)
-	if err != ErrInvalidHTLCAmt {
-		t.Fatalf("expected ErrInvalidHTLCAmt, got: %v", err)
-	}
+	require.Equal(t, ErrZeroHtlc(), err)
 }
 
 // TestNewBreachRetributionSkipsDustHtlcs ensures that in the case of a

--- a/lnwallet/channel_test.go
+++ b/lnwallet/channel_test.go
@@ -5860,10 +5860,9 @@ func TestInvalidCommitSigError(t *testing.T) {
 	if err == nil {
 		t.Fatalf("bob accepted invalid state but shouldn't have")
 	}
-	if _, ok := err.(*InvalidCommitSigError); !ok {
-		t.Fatalf("bob sent incorrect error, expected %T, got %T",
-			&InvalidCommitSigError{}, err)
-	}
+	coded, ok := err.(*lnwire.CodedError)
+	require.True(t, ok, "expected coded wire error")
+	require.Equal(t, lnwire.CodeInvalidCommitSig, coded.ErrorCode)
 }
 
 // TestChannelUnilateralCloseHtlcResolution tests that in the case of a

--- a/lnwallet/errors.go
+++ b/lnwallet/errors.go
@@ -1,7 +1,6 @@
 package lnwallet
 
 import (
-	"errors"
 	"fmt"
 
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
@@ -9,155 +8,146 @@ import (
 	"github.com/lightningnetwork/lnd/lnwire"
 )
 
-// ReservationError wraps certain errors returned during channel reservation
-// that can be sent across the wire to the remote peer. Errors not being
-// ReservationErrors will not be sent to the remote in case of a failed channel
-// reservation, as they may contain private information.
-type ReservationError struct {
-	error
-}
-
-// A compile time check to ensure ReservationError implements the error
-// interface.
-var _ error = (*ReservationError)(nil)
-
 // ErrZeroCapacity returns an error indicating the funder attempted to put zero
 // funds into the channel.
-func ErrZeroCapacity() ReservationError {
-	return ReservationError{
-		errors.New("zero channel funds"),
-	}
+func ErrZeroCapacity() *lnwire.CodedError {
+	return lnwire.NewErroneousFieldErr(lnwire.MsgOpenChannel, 2, 0, nil)
 }
 
 // ErrChainMismatch returns an error indicating that the initiator tried to
 // open a channel for an unknown chain.
 func ErrChainMismatch(knownChain,
-	unknownChain *chainhash.Hash) ReservationError {
-	return ReservationError{
-		fmt.Errorf("unknown chain=%v, supported chain=%v",
-			unknownChain, knownChain),
-	}
+	unknownChain *chainhash.Hash) *lnwire.CodedError {
+
+	return lnwire.NewErroneousFieldErr(
+		lnwire.MsgOpenChannel, 0, unknownChain, knownChain,
+	)
 }
 
 // ErrFunderBalanceDust returns an error indicating the initial balance of the
 // funder is considered dust at the current commitment fee.
 func ErrFunderBalanceDust(commitFee, funderBalance,
-	minBalance int64) ReservationError {
-	return ReservationError{
-		fmt.Errorf("funder balance too small (%v) with fee=%v sat, "+
-			"minimum=%v sat required", funderBalance,
-			commitFee, minBalance),
-	}
+	minBalance uint64) *lnwire.CodedError {
+
+	return lnwire.NewErroneousFieldErr(
+		lnwire.MsgOpenChannel, 4, funderBalance, minBalance,
+	)
 }
 
 // ErrCsvDelayTooLarge returns an error indicating that the CSV delay was to
 // large to be accepted, along with the current max.
-func ErrCsvDelayTooLarge(remoteDelay, maxDelay uint16) ReservationError {
-	return ReservationError{
-		fmt.Errorf("CSV delay too large: %v, max is %v",
-			remoteDelay, maxDelay),
-	}
+func ErrCsvDelayTooLarge(remoteDelay,
+	maxDelay uint16) *lnwire.CodedError {
+
+	return lnwire.NewErroneousFieldErr(
+		lnwire.MsgOpenChannel, 9, remoteDelay, maxDelay,
+	)
 }
 
 // ErrChanReserveTooSmall returns an error indicating that the channel reserve
 // the remote is requiring is too small to be accepted.
-func ErrChanReserveTooSmall(reserve, dustLimit btcutil.Amount) ReservationError {
-	return ReservationError{
-		fmt.Errorf("channel reserve of %v sat is too small, min is %v "+
-			"sat", int64(reserve), int64(dustLimit)),
-	}
+func ErrChanReserveTooSmall(reserve,
+	dustLimit btcutil.Amount) *lnwire.CodedError {
+
+	return lnwire.NewErroneousFieldErr(
+		lnwire.MsgOpenChannel, 6, uint64(reserve), uint64(dustLimit),
+	)
 }
 
 // ErrChanReserveTooLarge returns an error indicating that the chan reserve the
 // remote is requiring, is too large to be accepted.
 func ErrChanReserveTooLarge(reserve,
-	maxReserve btcutil.Amount) ReservationError {
-	return ReservationError{
-		fmt.Errorf("channel reserve is too large: %v sat, max "+
-			"is %v sat", int64(reserve), int64(maxReserve)),
-	}
+	maxReserve btcutil.Amount) *lnwire.CodedError {
+
+	return lnwire.NewErroneousFieldErr(
+		lnwire.MsgOpenChannel, 6, uint64(reserve), uint64(maxReserve),
+	)
 }
 
 // ErrNonZeroPushAmount is returned by a remote peer that receives a
 // FundingOpen request for a channel with non-zero push amount while
 // they have 'rejectpush' enabled.
-func ErrNonZeroPushAmount() ReservationError {
-	return ReservationError{errors.New("non-zero push amounts are disabled")}
+func ErrNonZeroPushAmount(amt uint64) *lnwire.CodedError {
+	return lnwire.NewErroneousFieldErr(
+		lnwire.MsgOpenChannel, 3, amt, uint64(0),
+	)
 }
 
 // ErrMinHtlcTooLarge returns an error indicating that the MinHTLC value the
 // remote required is too large to be accepted.
 func ErrMinHtlcTooLarge(minHtlc,
-	maxMinHtlc lnwire.MilliSatoshi) ReservationError {
-	return ReservationError{
-		fmt.Errorf("minimum HTLC value is too large: %v, max is %v",
-			minHtlc, maxMinHtlc),
-	}
+	maxMinHtlc lnwire.MilliSatoshi) *lnwire.CodedError {
+
+	return lnwire.NewErroneousFieldErr(
+		lnwire.MsgOpenChannel, 7, uint64(minHtlc), uint64(maxMinHtlc),
+	)
 }
 
 // ErrMaxHtlcNumTooLarge returns an error indicating that the 'max HTLCs in
 // flight' value the remote required is too large to be accepted.
-func ErrMaxHtlcNumTooLarge(maxHtlc, maxMaxHtlc uint16) ReservationError {
-	return ReservationError{
-		fmt.Errorf("maxHtlcs is too large: %d, max is %d",
-			maxHtlc, maxMaxHtlc),
-	}
+func ErrMaxHtlcNumTooLarge(maxHtlc, maxMaxHtlc uint16) *lnwire.CodedError {
+	return lnwire.NewErroneousFieldErr(
+		lnwire.MsgOpenChannel, 10, maxMaxHtlc, maxMaxHtlc,
+	)
 }
 
 // ErrMaxHtlcNumTooSmall returns an error indicating that the 'max HTLCs in
 // flight' value the remote required is too small to be accepted.
-func ErrMaxHtlcNumTooSmall(maxHtlc, minMaxHtlc uint16) ReservationError {
-	return ReservationError{
-		fmt.Errorf("maxHtlcs is too small: %d, min is %d",
-			maxHtlc, minMaxHtlc),
-	}
+func ErrMaxHtlcNumTooSmall(maxHtlc, minMaxHtlc uint16) *lnwire.CodedError {
+	return lnwire.NewErroneousFieldErr(
+		lnwire.MsgOpenChannel, 10, maxHtlc, minMaxHtlc,
+	)
 }
 
 // ErrMaxValueInFlightTooSmall returns an error indicating that the 'max HTLC
 // value in flight' the remote required is too small to be accepted.
 func ErrMaxValueInFlightTooSmall(maxValInFlight,
-	minMaxValInFlight lnwire.MilliSatoshi) ReservationError {
-	return ReservationError{
-		fmt.Errorf("maxValueInFlight too small: %v, min is %v",
-			maxValInFlight, minMaxValInFlight),
-	}
+	minMaxValInFlight lnwire.MilliSatoshi) *lnwire.CodedError {
+
+	return lnwire.NewErroneousFieldErr(
+		lnwire.MsgOpenChannel, 5, maxValInFlight, minMaxValInFlight,
+	)
 }
 
 // ErrNumConfsTooLarge returns an error indicating that the number of
 // confirmations required for a channel is too large.
-func ErrNumConfsTooLarge(numConfs, maxNumConfs uint32) error {
-	return ReservationError{
-		fmt.Errorf("minimum depth of %d is too large, max is %d",
-			numConfs, maxNumConfs),
-	}
+func ErrNumConfsTooLarge(numConfs, maxNumConfs uint32) *lnwire.CodedError {
+	return lnwire.NewErroneousFieldErr(
+		lnwire.MsgAcceptChannel, 5, numConfs, maxNumConfs,
+	)
 }
 
 // ErrChanTooSmall returns an error indicating that an incoming channel request
 // was too small. We'll reject any incoming channels if they're below our
 // configured value for the min channel size we'll accept.
-func ErrChanTooSmall(chanSize, minChanSize btcutil.Amount) ReservationError {
-	return ReservationError{
-		fmt.Errorf("chan size of %v is below min chan size of %v",
-			chanSize, minChanSize),
-	}
+func ErrChanTooSmall(chanSize,
+	minChanSize btcutil.Amount) *lnwire.CodedError {
+
+	return lnwire.NewErroneousFieldErr(
+		lnwire.MsgOpenChannel, 2, uint64(chanSize), uint64(minChanSize),
+	)
 }
 
 // ErrChanTooLarge returns an error indicating that an incoming channel request
 // was too large. We'll reject any incoming channels if they're above our
 // configured value for the max channel size we'll accept.
-func ErrChanTooLarge(chanSize, maxChanSize btcutil.Amount) ReservationError {
-	return ReservationError{
-		fmt.Errorf("chan size of %v exceeds maximum chan size of %v",
-			chanSize, maxChanSize),
-	}
+func ErrChanTooLarge(chanSize,
+	maxChanSize btcutil.Amount) *lnwire.CodedError {
+
+	return lnwire.NewErroneousFieldErr(
+		lnwire.MsgOpenChannel, 2, uint64(chanSize), uint64(maxChanSize),
+	)
 }
 
 // ErrInvalidDustLimit returns an error indicating that a proposed DustLimit
 // was rejected.
-func ErrInvalidDustLimit(dustLimit btcutil.Amount) ReservationError {
-	return ReservationError{
-		fmt.Errorf("dust limit %v is invalid", dustLimit),
-	}
+func ErrInvalidDustLimit(dustLimit,
+	recommended btcutil.Amount) *lnwire.CodedError {
+
+	return lnwire.NewErroneousFieldErr(
+		lnwire.MsgOpenChannel, 2, uint64(dustLimit),
+		uint64(recommended),
+	)
 }
 
 // ErrHtlcIndexAlreadyFailed is returned when the HTLC index has already been

--- a/lnwallet/reservation.go
+++ b/lnwallet/reservation.go
@@ -255,8 +255,9 @@ func NewChannelReservation(capacity, localFundingAmt btcutil.Amount,
 		// the fees, then we'll bail our early.
 		if int64(theirBalance) < 0 {
 			return nil, ErrFunderBalanceDust(
-				int64(commitFee), int64(theirBalance.ToSatoshis()),
-				int64(2*defaultDust),
+				uint64(commitFee),
+				uint64(theirBalance.ToSatoshis()),
+				uint64(defaultDust),
 			)
 		}
 	} else {
@@ -284,8 +285,9 @@ func NewChannelReservation(capacity, localFundingAmt btcutil.Amount,
 		// the fees, then we'll exit with an error.
 		if int64(ourBalance) < 0 {
 			return nil, ErrFunderBalanceDust(
-				int64(commitFee), int64(ourBalance),
-				int64(2*defaultDust),
+				uint64(commitFee),
+				uint64(ourBalance),
+				uint64(defaultDust),
 			)
 		}
 	}
@@ -297,9 +299,9 @@ func NewChannelReservation(capacity, localFundingAmt btcutil.Amount,
 	// TODO(roasbeef): reject if 30% goes to fees? dust channel
 	if initiator && ourBalance.ToSatoshis() <= 2*defaultDust {
 		return nil, ErrFunderBalanceDust(
-			int64(commitFee),
-			int64(ourBalance.ToSatoshis()),
-			int64(2*defaultDust),
+			uint64(commitFee),
+			uint64(ourBalance.ToSatoshis()),
+			uint64(defaultDust),
 		)
 	}
 
@@ -307,9 +309,9 @@ func NewChannelReservation(capacity, localFundingAmt btcutil.Amount,
 	// initiator.
 	if !initiator && theirBalance.ToSatoshis() <= 2*defaultDust {
 		return nil, ErrFunderBalanceDust(
-			int64(commitFee),
-			int64(theirBalance.ToSatoshis()),
-			int64(2*defaultDust),
+			uint64(commitFee),
+			uint64(theirBalance.ToSatoshis()),
+			uint64(defaultDust),
 		)
 	}
 
@@ -453,7 +455,7 @@ func (r *ChannelReservation) CommitConstraints(c *channeldb.ChannelConstraints,
 	// also ensure that the DustLimit is not too large.
 	maxWitnessLimit := DustLimitForSize(input.UnknownWitnessSize)
 	if c.DustLimit < maxWitnessLimit || c.DustLimit > 3*maxWitnessLimit {
-		return ErrInvalidDustLimit(c.DustLimit)
+		return ErrInvalidDustLimit(c.DustLimit, maxWitnessLimit)
 	}
 
 	// Fail if we consider the channel reserve to be too large.  We

--- a/lnwallet/test/test_interface.go
+++ b/lnwallet/test/test_interface.go
@@ -803,13 +803,19 @@ func testReservationInitiatorBalanceBelowDustCancel(miner *rpctest.Harness,
 		Flags:            lnwire.FFAnnounceChannel,
 		CommitType:       lnwallet.CommitmentTypeTweakless,
 	}
+
+	expectedErr := lnwallet.ErrFunderBalanceDust(
+		uint64(req.CommitFeePerKw), uint64(req.LocalFundingAmt),
+		uint64(alice.Cfg.DefaultConstraints.DustLimit),
+	)
+
 	_, err = alice.InitChannelReservation(req)
 	switch {
 	case err == nil:
 		t.Fatalf("initialization should have failed due to " +
 			"insufficient local amount")
 
-	case !strings.Contains(err.Error(), "funder balance too small"):
+	case !strings.Contains(err.Error(), expectedErr.Error()):
 		t.Fatalf("incorrect error: %v", err)
 	}
 }

--- a/lnwire/error.go
+++ b/lnwire/error.go
@@ -6,47 +6,6 @@ import (
 	"io"
 )
 
-// FundingError represents a set of errors that can be encountered and sent
-// during the funding workflow.
-type FundingError uint8
-
-const (
-	// ErrMaxPendingChannels is returned by remote peer when the number of
-	// active pending channels exceeds their maximum policy limit.
-	ErrMaxPendingChannels FundingError = 1
-
-	// ErrSynchronizingChain is returned by a remote peer that receives a
-	// channel update or a funding request while it's still syncing to the
-	// latest state of the blockchain.
-	ErrSynchronizingChain FundingError = 2
-
-	// ErrChanTooLarge is returned by a remote peer that receives a
-	// FundingOpen request for a channel that is above their current
-	// soft-limit.
-	ErrChanTooLarge FundingError = 3
-)
-
-// String returns a human readable version of the target FundingError.
-func (e FundingError) String() string {
-	switch e {
-	case ErrMaxPendingChannels:
-		return "Number of pending channels exceed maximum"
-	case ErrSynchronizingChain:
-		return "Synchronizing blockchain"
-	case ErrChanTooLarge:
-		return "channel too large"
-	default:
-		return "unknown error"
-	}
-}
-
-// Error returns the human readable version of the target FundingError.
-//
-// NOTE: Satisfies the Error interface.
-func (e FundingError) Error() string {
-	return e.String()
-}
-
 // ErrorData is a set of bytes associated with a particular sent error. A
 // receiving node SHOULD only print out data verbatim if the string is composed
 // solely of printable ASCII characters. For reference, the printable character

--- a/lnwire/error.go
+++ b/lnwire/error.go
@@ -66,6 +66,11 @@ type Error struct {
 	// Data is the attached error data that describes the exact failure
 	// which caused the error message to be sent.
 	Data ErrorData
+
+	// ExtraData is the set of data that was appended to this message to
+	// fill out the full maximum transport message size. These fields can
+	// be used to specify optional data such as custom TLV fields.
+	ExtraData ExtraOpaqueData
 }
 
 // NewError creates a new Error message.
@@ -97,6 +102,7 @@ func (c *Error) Decode(r io.Reader, pver uint32) error {
 	return ReadElements(r,
 		&c.ChanID,
 		&c.Data,
+		&c.ExtraData,
 	)
 }
 
@@ -109,7 +115,11 @@ func (c *Error) Encode(w *bytes.Buffer, pver uint32) error {
 		return err
 	}
 
-	return WriteErrorData(w, c.Data)
+	if err := WriteErrorData(w, c.Data); err != nil {
+		return err
+	}
+
+	return WriteBytes(w, c.ExtraData)
 }
 
 // MsgType returns the integer uniquely identifying an Error message on the

--- a/lnwire/error_coded.go
+++ b/lnwire/error_coded.go
@@ -1,0 +1,81 @@
+package lnwire
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/lightningnetwork/lnd/tlv"
+)
+
+// ErrorCode is an enum that defines the different types of error codes that
+// are used to enrich the meaning of errors.
+type ErrorCode uint16
+
+// Compile time assertion that CodedError implements the ExtendedError
+// interface.
+var _ ExtendedError = (*CodedError)(nil)
+
+// CodedError is an error that has been enriched with an error code, and
+// optional additional information.
+type CodedError struct {
+	// ErrorCode is the error code that defines the type of error this is.
+	ErrorCode
+}
+
+// NewCodedError creates an error with the code provided.
+func NewCodedError(e ErrorCode) *CodedError {
+	return &CodedError{
+		ErrorCode: e,
+	}
+}
+
+// Error provides a string representation of a coded error.
+func (e *CodedError) Error() string {
+	return fmt.Sprintf("Error code: %d", e.ErrorCode)
+}
+
+// Record provides a tlv record for coded errors.
+func (e *CodedError) Record() tlv.Record {
+	return tlv.MakeDynamicRecord(
+		typeErrorCode, e, e.sizeFunc, codedErrorEncoder,
+		codedErrorDecoder,
+	)
+}
+
+func (e *CodedError) sizeFunc() uint64 {
+	return 2
+}
+
+func codedErrorEncoder(w io.Writer, val interface{}, buf *[8]byte) error {
+	v, ok := val.(*CodedError)
+	if ok {
+		code := uint16(v.ErrorCode)
+		if err := tlv.EUint16(w, &code, buf); err != nil {
+			return err
+		}
+
+		return nil
+	}
+
+	return tlv.NewTypeForEncodingErr(val, "lnwire.CodedError")
+}
+
+func codedErrorDecoder(r io.Reader, val interface{}, buf *[8]byte,
+	l uint64) error {
+
+	v, ok := val.(*CodedError)
+	if ok {
+		var errCode uint16
+		if err := tlv.DUint16(r, &errCode, buf, l); err != nil {
+			return err
+		}
+
+		*v = CodedError{
+			ErrorCode: ErrorCode(errCode),
+		}
+
+		return nil
+	}
+
+	return tlv.NewTypeForEncodingErr(val, "lnwire.CodedError")
+}

--- a/lnwire/error_coded.go
+++ b/lnwire/error_coded.go
@@ -11,6 +11,16 @@ import (
 // are used to enrich the meaning of errors.
 type ErrorCode uint16
 
+const (
+	// CodeMaxPendingChannels indicates that the number of active pending
+	// channels exceeds their maximum policy limit.
+	CodeMaxPendingChannels ErrorCode = 1
+
+	// CodeSynchronizingChain indicates that the peer is still busy syncing
+	// the latest state of the blockchain.
+	CodeSynchronizingChain ErrorCode = 3
+)
+
 // Compile time assertion that CodedError implements the ExtendedError
 // interface.
 var _ ExtendedError = (*CodedError)(nil)
@@ -31,7 +41,20 @@ func NewCodedError(e ErrorCode) *CodedError {
 
 // Error provides a string representation of a coded error.
 func (e *CodedError) Error() string {
-	return fmt.Sprintf("Error code: %d", e.ErrorCode)
+	var errStr string
+
+	switch e.ErrorCode {
+	case CodeMaxPendingChannels:
+		errStr = "number of pending channels exceed maximum"
+
+	case CodeSynchronizingChain:
+		errStr = "synchronizing blockchain"
+
+	default:
+		errStr = "unknown"
+	}
+
+	return fmt.Sprintf("Error code: %d: %v", e.ErrorCode, errStr)
 }
 
 // Record provides a tlv record for coded errors.

--- a/lnwire/error_coded.go
+++ b/lnwire/error_coded.go
@@ -53,6 +53,14 @@ const (
 	// CodeInvalidRevocation indicates that the remote peer send us an
 	// invalid revocation message.
 	CodeInvalidRevocation ErrorCode = 19
+
+	// CodeInvalidCommitSig indicates that we have received an invalid
+	// commitment signature.
+	CodeInvalidCommitSig ErrorCode = 21
+
+	// CodeInvalidHtlcSig indicates that we have received an invalid htlc
+	// signature.
+	CodeInvalidHtlcSig ErrorCode = 23
 )
 
 // Compile time assertion that CodedError implements the ExtendedError
@@ -111,6 +119,13 @@ func (e *CodedError) Error() string {
 	case CodeInvalidRevocation:
 		errStr = "invalid revocation"
 
+	// TODO(carla): better error string here using other info?
+	case CodeInvalidCommitSig:
+		errStr = "invalid commit sig"
+
+	case CodeInvalidHtlcSig:
+		errStr = "invalid htlc sig"
+
 	default:
 		errStr = "unknown"
 	}
@@ -136,7 +151,10 @@ type ErrContext interface {
 
 // knownErrorCodeContext maps known error codes to additional information that
 // is included in tlvs.
-var knownErrorCodeContext = map[ErrorCode]ErrContext{}
+var knownErrorCodeContext = map[ErrorCode]ErrContext{
+	CodeInvalidCommitSig: &InvalidCommitSigError{},
+	CodeInvalidHtlcSig:   &InvalidHtlcSigError{},
+}
 
 // Record provides a tlv record for coded errors.
 func (e *CodedError) Record() tlv.Record {
@@ -269,4 +287,102 @@ func codedErrorDecoder(r io.Reader, val interface{}, buf *[8]byte,
 	}
 
 	return tlv.NewTypeForEncodingErr(val, "lnwire.CodedError")
+}
+
+// InvalidCommitSigError contains the error information we transmit upon
+// receiving an invalid commit signature
+type InvalidCommitSigError struct {
+	commitHeight uint64
+	commitSig    []byte
+	sigHash      []byte
+	commitTx     []byte
+}
+
+// A compile time flag to ensure that InvalidCommitSigError implements the
+// ErrContext interface.
+var _ ErrContext = (*InvalidCommitSigError)(nil)
+
+// NewInvalidCommitSigError creates an invalid sig error.
+func NewInvalidCommitSigError(commitHeight uint64, commitSig, sigHash,
+	commitTx []byte) *CodedError {
+
+	return &CodedError{
+		ErrorCode: CodeInvalidCommitSig,
+		ErrContext: &InvalidCommitSigError{
+			commitHeight: commitHeight,
+			commitSig:    commitSig,
+			sigHash:      sigHash,
+			commitTx:     commitTx,
+		},
+	}
+}
+
+// String returns a string representing an invalid sig error.
+func (i *InvalidCommitSigError) String() string {
+	return fmt.Sprintf("rejected commitment: commit_height=%v, "+
+		"invalid_commit_sig=%x, commit_tx=%x, sig_hash=%x",
+		i.commitHeight, i.commitSig, i.commitTx, i.sigHash)
+}
+
+// Records returns a set of record producers for the tlvs associated
+// with an enriched error.
+func (i *InvalidCommitSigError) Records() []tlv.Record {
+	return []tlv.Record{
+		tlv.MakePrimitiveRecord(typeNestedCommitHeight, &i.commitHeight),
+		tlv.MakePrimitiveRecord(typeNestedCommitSig, &i.commitSig),
+		tlv.MakePrimitiveRecord(typeNestedSigHash, &i.sigHash),
+		tlv.MakePrimitiveRecord(typeNestedCommitTx, &i.commitTx),
+	}
+}
+
+// InvalidHtlcSigError is a struct that implements the error interface to
+// report a failure to validate an htlc signature from a remote peer. We'll use
+// the items in this struct to generate a rich error message for the remote
+// peer when we receive an invalid signature from it. Doing so can greatly aide
+// in debugging across implementation issues.
+type InvalidHtlcSigError struct {
+	commitHeight uint64
+	htlcSig      []byte
+	htlcIndex    uint64
+	sigHash      []byte
+	commitTx     []byte
+}
+
+// A compile time flag to ensure that InvalidHtlcSigError implements the
+// ErrContext interface.
+var _ ErrContext = (*InvalidHtlcSigError)(nil)
+
+// NewInvalidHtlcSigError creates an invalid htlc signature error.
+func NewInvalidHtlcSigError(commitHeight, htlcIndex uint64, htlcSig, sigHash,
+	commitTx []byte) *CodedError {
+
+	return &CodedError{
+		ErrorCode: CodeInvalidHtlcSig,
+		ErrContext: &InvalidHtlcSigError{
+			commitHeight: commitHeight,
+			htlcIndex:    htlcIndex,
+			htlcSig:      htlcSig,
+			sigHash:      sigHash,
+			commitTx:     commitTx,
+		},
+	}
+}
+
+// String returns a string representing an invalid htlc sig error.
+func (i *InvalidHtlcSigError) String() string {
+	return fmt.Sprintf("rejected commitment: commit_height=%v, "+
+		"invalid_htlc_sig=%x, commit_tx=%x, sig_hash=%x",
+		i.commitHeight, i.htlcSig, i.commitTx, i.sigHash)
+}
+
+// Records returns a set of record producers for the tlvs associated with
+// an enriched error.
+func (i *InvalidHtlcSigError) Records() []tlv.Record {
+	return []tlv.Record{
+		tlv.MakePrimitiveRecord(typeNestedCommitHeight, &i.commitHeight),
+		tlv.MakePrimitiveRecord(typeNestedHtlcIndex, &i.htlcIndex),
+		tlv.MakePrimitiveRecord(typeNestedHtlcSig, &i.htlcSig),
+		tlv.MakePrimitiveRecord(typeNestedSigHash, &i.sigHash),
+		tlv.MakePrimitiveRecord(typeNestedCommitTx, &i.commitTx),
+	}
 }

--- a/lnwire/error_coded.go
+++ b/lnwire/error_coded.go
@@ -28,6 +28,30 @@ const (
 	// tried to add more than our pending amount in flight local policy
 	// limit to a commitment.
 	CodePendingHtlcAmountExceeded ErrorCode = 7
+
+	// CodeInternalError indicates that something internal has failed, and
+	// we do not want to provide our peer with further information.
+	CodeInternalError ErrorCode = 9
+
+	// CodeRemoteError indicates that our peer sent an error, prompting us
+	// to fail the connection.
+	CodeRemoteError ErrorCode = 11
+
+	// CodeSyncError indicates that we failed synchronizing the state of the
+	// channel with our peer.
+	CodeSyncError ErrorCode = 13
+
+	// CodeRecoveryError the channel was unable to be resumed, we need the
+	// remote party to force close the channel out on chain now as a
+	// result.
+	CodeRecoveryError ErrorCode = 15
+
+	// CodeInvalidUpdate indicates that the peer send us an invalid update.
+	CodeInvalidUpdate ErrorCode = 17
+
+	// CodeInvalidRevocation indicates that the remote peer send us an
+	// invalid revocation message.
+	CodeInvalidRevocation ErrorCode = 19
 )
 
 // Compile time assertion that CodedError implements the ExtendedError
@@ -64,6 +88,24 @@ func (e *CodedError) Error() string {
 
 	case CodePendingHtlcAmountExceeded:
 		errStr = "commitment exceeds max in flight value"
+
+	case CodeInternalError:
+		errStr = "internal error"
+
+	case CodeRemoteError:
+		errStr = "remote error"
+
+	case CodeSyncError:
+		errStr = "sync error"
+
+	case CodeRecoveryError:
+		errStr = "unable to resume channel, recovery required"
+
+	case CodeInvalidUpdate:
+		errStr = "invalid update"
+
+	case CodeInvalidRevocation:
+		errStr = "invalid revocation"
 
 	default:
 		errStr = "unknown"

--- a/lnwire/error_coded.go
+++ b/lnwire/error_coded.go
@@ -547,7 +547,60 @@ type errFieldHelper struct {
 // Field number is defined as follows:
 // * For fixed fields: 0-based index of the field as defined in #BOLT 1
 // * For TLV fields: number of fixed fields + TLV field number
-var supportedErroneousFields = map[MessageType]map[uint16]*errFieldHelper{}
+var supportedErroneousFields = map[MessageType]map[uint16]*errFieldHelper{
+	MsgOpenChannel: {
+		0: {
+			fieldName: "chain hash",
+			decode:    decode32Byte,
+		},
+		1: {
+			fieldName: "channel id",
+			decode:    decode32Byte,
+		},
+		2: {
+			fieldName: "funding sats",
+			decode:    decodeUint64,
+		},
+		3: {
+			fieldName: "push amount",
+			decode:    decodeUint64,
+		},
+		4: {
+			fieldName: "dust limit",
+			decode:    decodeUint64,
+		},
+		5: {
+			fieldName: "max htlc value in flight msat",
+			decode:    decodeUint64,
+		},
+		6: {
+			fieldName: "channel reserve",
+			decode:    decodeUint64,
+		},
+		7: {
+			fieldName: "htlc minimum msat",
+			decode:    decodeUint64,
+		},
+		8: {
+			fieldName: "feerate per kw",
+			decode:    decodeUint32,
+		},
+		9: {
+			fieldName: "to self delay",
+			decode:    decodeUint16,
+		},
+		10: {
+			fieldName: "max accepted htlcs",
+			decode:    decodeUint16,
+		},
+	},
+	MsgAcceptChannel: {
+		5: {
+			fieldName: "min depth",
+			decode:    decodeUint32,
+		},
+	},
+}
 
 // getFieldHelper looks up the helper struct for a message/ field combination
 // in our map of known structured errors, returning a nil struct if the
@@ -652,4 +705,56 @@ func (e *ErroneousFieldErr) SuggestedValue() (interface{}, error) {
 	}
 
 	return fieldHelper.decode(e.suggestedValue)
+}
+
+func decode32Byte(value []byte) (interface{}, error) {
+	var (
+		val [32]byte
+		r   = bytes.NewBuffer(value)
+	)
+
+	if err := ReadElements(r, &val); err != nil {
+		return nil, err
+	}
+
+	return val, nil
+}
+
+func decodeUint64(value []byte) (interface{}, error) {
+	var (
+		val uint64
+		r   = bytes.NewBuffer(value)
+	)
+
+	if err := ReadElements(r, &val); err != nil {
+		return nil, err
+	}
+
+	return val, nil
+}
+
+func decodeUint32(value []byte) (interface{}, error) {
+	var (
+		val uint32
+		r   = bytes.NewBuffer(value)
+	)
+
+	if err := ReadElements(r, &val); err != nil {
+		return nil, err
+	}
+
+	return val, nil
+}
+
+func decodeUint16(value []byte) (interface{}, error) {
+	var (
+		val uint16
+		r   = bytes.NewBuffer(value)
+	)
+
+	if err := ReadElements(r, &val); err != nil {
+		return nil, err
+	}
+
+	return val, nil
 }

--- a/lnwire/error_coded.go
+++ b/lnwire/error_coded.go
@@ -19,6 +19,15 @@ const (
 	// CodeSynchronizingChain indicates that the peer is still busy syncing
 	// the latest state of the blockchain.
 	CodeSynchronizingChain ErrorCode = 3
+
+	// CodePendingHtlcCountExceeded indicates that the remote peer has tried
+	// to add more htlcs that our local policy allows to a commitment.
+	CodePendingHtlcCountExceeded ErrorCode = 5
+
+	// CodePendingHtlcAmountExceeded indicates that the remote peer has
+	// tried to add more than our pending amount in flight local policy
+	// limit to a commitment.
+	CodePendingHtlcAmountExceeded ErrorCode = 7
 )
 
 // Compile time assertion that CodedError implements the ExtendedError
@@ -49,6 +58,12 @@ func (e *CodedError) Error() string {
 
 	case CodeSynchronizingChain:
 		errStr = "synchronizing blockchain"
+
+	case CodePendingHtlcCountExceeded:
+		errStr = "commitment exceeds max htlcs"
+
+	case CodePendingHtlcAmountExceeded:
+		errStr = "commitment exceeds max in flight value"
 
 	default:
 		errStr = "unknown"

--- a/lnwire/error_coded.go
+++ b/lnwire/error_coded.go
@@ -600,6 +600,12 @@ var supportedErroneousFields = map[MessageType]map[uint16]*errFieldHelper{
 			decode:    decodeUint32,
 		},
 	},
+	MsgUpdateAddHTLC: {
+		2: {
+			fieldName: "htlc amount",
+			decode:    decodeUint64,
+		},
+	},
 }
 
 // getFieldHelper looks up the helper struct for a message/ field combination

--- a/lnwire/error_extended.go
+++ b/lnwire/error_extended.go
@@ -8,6 +8,15 @@ const (
 	// typeErrorCode contains an error code, and additional nested tlvs
 	// that provide more context for the error.
 	typeErrorCode tlv.Type = 1
+
+	// The following TLVs are _nested_ within the typeErrorCode tlv to
+	// provide more context for errors.
+	typeNestedCommitHeight tlv.Type = 1
+	typeNestedCommitSig    tlv.Type = 3
+	typeNestedSigHash      tlv.Type = 5
+	typeNestedCommitTx     tlv.Type = 7
+	typeNestedHtlcSig      tlv.Type = 9
+	typeNestedHtlcIndex    tlv.Type = 11
 )
 
 // ExtendedError is an interface implemented by any error that adds more

--- a/lnwire/error_extended.go
+++ b/lnwire/error_extended.go
@@ -11,12 +11,14 @@ const (
 
 	// The following TLVs are _nested_ within the typeErrorCode tlv to
 	// provide more context for errors.
-	typeNestedCommitHeight tlv.Type = 1
-	typeNestedCommitSig    tlv.Type = 3
-	typeNestedSigHash      tlv.Type = 5
-	typeNestedCommitTx     tlv.Type = 7
-	typeNestedHtlcSig      tlv.Type = 9
-	typeNestedHtlcIndex    tlv.Type = 11
+	typeNestedCommitHeight   tlv.Type = 1
+	typeNestedCommitSig      tlv.Type = 3
+	typeNestedSigHash        tlv.Type = 5
+	typeNestedCommitTx       tlv.Type = 7
+	typeNestedHtlcSig        tlv.Type = 9
+	typeNestedHtlcIndex      tlv.Type = 11
+	typeNestedErroneousField tlv.Type = 13
+	typeNestedSuggestedValue tlv.Type = 15
 )
 
 // ExtendedError is an interface implemented by any error that adds more

--- a/lnwire/error_extended.go
+++ b/lnwire/error_extended.go
@@ -1,0 +1,75 @@
+package lnwire
+
+import (
+	"github.com/lightningnetwork/lnd/tlv"
+)
+
+const (
+	// typeErrorCode contains an error code, and additional nested tlvs
+	// that provide more context for the error.
+	typeErrorCode tlv.Type = 1
+)
+
+// ExtendedError is an interface implemented by any error that adds more
+// information using tlv values.
+type ExtendedError interface {
+	// Record provides a tlv record which contains the additional
+	// information for the error.
+	Record() tlv.Record
+
+	error
+}
+
+// WireErrorFromExtended creates a wire error with additional fields packed into
+// its tlvs.
+func WireErrorFromExtended(extendedError ExtendedError,
+	chanID ChannelID) (*Error, error) {
+
+	resp := &Error{
+		ChanID: chanID,
+		Data:   ErrorData(extendedError.Error()),
+	}
+
+	records := []tlv.RecordProducer{
+		extendedError,
+	}
+
+	if err := resp.ExtraData.PackRecords(records...); err != nil {
+		return nil, err
+	}
+
+	return resp, nil
+}
+
+// ExtendedErrorFromWire extracts an enriched error from our error's extra
+// data, if present.
+func ExtendedErrorFromWire(err *Error) (ExtendedError, error) {
+	if err == nil {
+		return nil, nil
+	}
+
+	if len(err.ExtraData) == 0 {
+		return nil, nil
+	}
+
+	// Try to extract coded error, if present.
+	codedError := &CodedError{}
+	records := []tlv.RecordProducer{
+		codedError,
+	}
+
+	extractedTypes, extractErr := err.ExtraData.ExtractRecords(records...)
+	if extractErr != nil {
+		return nil, extractErr
+	}
+
+	// If we extracted an error code tlv, return the coded error that we
+	// read the record values in.
+	if val, ok := extractedTypes[typeErrorCode]; ok && val == nil {
+		return codedError, nil
+	}
+
+	// Otherwise, return nil because there is no additional information
+	// included in this error that we understand.
+	return nil, nil
+}

--- a/lnwire/error_extended_test.go
+++ b/lnwire/error_extended_test.go
@@ -1,0 +1,41 @@
+package lnwire
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestExtendedError tests packing and extracting of additional information in
+// error message TLVs.
+func TestExtendedError(t *testing.T) {
+	// Create a test error code that we'll pack into our error, and a fake
+	// channel ID for our tests.
+	var (
+		testErrCode = ErrorCode(999)
+		testChanID  = ChannelID([32]byte{1, 2, 3})
+	)
+
+	codedErr := NewCodedError(testErrCode)
+
+	// Assert that we can pack this coded error into a wire error.
+	wireErr, err := WireErrorFromExtended(codedErr, testChanID)
+	require.NoError(t, err)
+
+	// Assert that we can extract our error code from the wire error we
+	// just packed.
+	actual, err := ExtendedErrorFromWire(wireErr)
+	require.NoError(t, err)
+
+	actualCoded, ok := actual.(*CodedError)
+	require.True(t, ok)
+	require.Equal(t, codedErr, actualCoded)
+
+	// Create a wire error that does not have any additional information.
+	legacyErr := &Error{
+		ChanID: testChanID,
+	}
+	empty, err := ExtendedErrorFromWire(legacyErr)
+	require.NoError(t, err)
+	require.Nil(t, empty)
+}

--- a/lnwire/error_extended_test.go
+++ b/lnwire/error_extended_test.go
@@ -38,4 +38,22 @@ func TestExtendedError(t *testing.T) {
 	empty, err := ExtendedErrorFromWire(legacyErr)
 	require.NoError(t, err)
 	require.Nil(t, empty)
+
+	// Next, we create an invalid commit sig error which has additional
+	// information attached to it, and test that we can pack and unpack it.
+	invalidCommit := NewInvalidCommitSigError(
+		1, []byte{1}, []byte{2}, []byte{3},
+	)
+
+	wireErr, err = WireErrorFromExtended(invalidCommit, testChanID)
+	require.NoError(t, err)
+
+	// Assert that when we extract the tlv records for this error, they are
+	// the same as the ones that we originally packed.
+	actual, err = ExtendedErrorFromWire(wireErr)
+	require.NoError(t, err)
+
+	actualCoded, ok = actual.(*CodedError)
+	require.True(t, ok)
+	require.Equal(t, invalidCommit, actualCoded)
 }

--- a/lnwire/error_extended_test.go
+++ b/lnwire/error_extended_test.go
@@ -1,6 +1,7 @@
 package lnwire
 
 import (
+	"bytes"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -56,4 +57,104 @@ func TestExtendedError(t *testing.T) {
 	actualCoded, ok = actual.(*CodedError)
 	require.True(t, ok)
 	require.Equal(t, invalidCommit, actualCoded)
+
+	// Now we test the class of errors that just indicate that a message/
+	// field combination are undesirable.
+	var (
+		errValue       = uint32(100)
+		suggestedValue = uint32(101)
+
+		helper = &errFieldHelper{
+			fieldName: "uint32",
+			decode: func(value []byte) (interface{}, error) {
+				var (
+					val uint32
+					r   = bytes.NewBuffer(value)
+				)
+
+				if err := ReadElements(r, &val); err != nil {
+					return nil, err
+				}
+
+				return val, nil
+			},
+		}
+
+		knownField uint16 = 2
+	)
+
+	// Populate our lookup map so that we can encode/decode full values.
+	supportedErroneousFields = map[MessageType]map[uint16]*errFieldHelper{
+		MsgOpenChannel: {
+			knownField: helper,
+		},
+	}
+
+	// Create an error where we know the message/field combination.
+	allFieldsKnown := NewErroneousFieldErr(
+		MsgOpenChannel, knownField, errValue, suggestedValue,
+	)
+
+	// Start by encoding an error that we know all the fields for.
+	wireErr, err = WireErrorFromExtended(allFieldsKnown, testChanID)
+	require.Nil(t, err)
+
+	// Retrieve a structured error from the encoded error and assert equal.
+	actual, err = ExtendedErrorFromWire(wireErr)
+	require.Nil(t, err)
+
+	actualCoded, ok = actual.(*CodedError)
+	require.True(t, ok)
+	require.Equal(t, allFieldsKnown, actualCoded)
+
+	// Access the fields and assert that we get our uint32 values again.
+	errValues, ok := actualCoded.ErrContext.(*ErroneousFieldErr)
+	require.True(t, ok)
+
+	decodedErrVal, err := errValues.ErroneousValue()
+	require.NoError(t, err)
+	require.Equal(t, errValue, decodedErrVal)
+
+	decodedSuggestedVal, err := errValues.SuggestedValue()
+	require.NoError(t, err)
+	require.Equal(t, suggestedValue, decodedSuggestedVal)
+
+	// Now we create an error that we don't know the message type for.
+	// Pack records manually because we're testing a case where our own
+	// packing would fail because we don't know the message type.
+	unknownMessage := &CodedError{
+		ErrorCode: CodeErroneousField,
+		ErrContext: &ErroneousFieldErr{
+			erroneousField: erroneousField{
+				messageType: 999,
+				fieldNumber: 1,
+				value:       []byte{1},
+			},
+			suggestedValue: []byte{2},
+		},
+	}
+
+	// Manually pack so that we can test unknown decode.
+	wireErr, err = WireErrorFromExtended(unknownMessage, testChanID)
+	require.NoError(t, err)
+
+	actual, err = ExtendedErrorFromWire(wireErr)
+	require.NoError(t, err)
+
+	actualCoded, ok = actual.(*CodedError)
+	require.True(t, ok)
+	require.Equal(t, unknownMessage, actualCoded)
+
+	// Access the value fields and assert that we get nil value because we
+	// don't know this message type.
+	errValues, ok = actualCoded.ErrContext.(*ErroneousFieldErr)
+	require.True(t, ok)
+
+	decodedErrVal, err = errValues.ErroneousValue()
+	require.NoError(t, err)
+	require.Nil(t, decodedErrVal)
+
+	decodedSuggestedVal, err = errValues.SuggestedValue()
+	require.NoError(t, err)
+	require.Nil(t, decodedSuggestedVal)
 }

--- a/peer/brontide.go
+++ b/peer/brontide.go
@@ -1560,6 +1560,23 @@ func (p *Brontide) storeError(err error) {
 //
 // NOTE: This method should only be called from within the readHandler.
 func (p *Brontide) handleError(msg *lnwire.Error) bool {
+	// Since we don't have any handling of additional error fields yet,
+	// just log the values here so that we know we can process them.
+	// TODO(carla): remove this!
+
+	sErr, err := lnwire.ExtendedErrorFromWire(msg)
+	if err != nil {
+		peerLog.Infof("Could not get structured error: %v", err)
+	}
+
+	switch s := sErr.(type) {
+	case *lnwire.CodedError:
+		peerLog.Infof("Extended error: %v", s)
+
+	case nil:
+		peerLog.Info("No additional fields provided with error")
+	}
+
 	// Store the error we have received.
 	p.storeError(msg)
 


### PR DESCRIPTION
This PR is a POC for the addition of TLVs to our `Error` message. It defines a single `error_code` TLV, which can optionally be extended with _nested_ tlvs to provide more context to the errors we return.
```
    1. type: 1 (`error_code`)
    2. data:
        * [`u16`:`code_value`]
        * [`u16`:`nested_len`]
        * [`...*byte`:`nested_tlvs...`]
```

Some examples of error codes are: 
* `CodeMaxPendingChannels`: returned when we already have too many pending channels open, no extra TLVs
* `CodeErroneousField`: returned when we don't like a specific field, has TLV for the problematic message/field/value and an optional suggested value (inspired by Rusy's [post](https://lists.linuxfoundation.org/pipermail/lightning-dev/2021-July/003110.html))
* `CodeInvalidCommitSig`: enriched with commit height, sig hash and other error information

One thing *not* implemented in this PR is any type of "ok to be odd" rule, I made all of the error codes odd, but there is no enforcement.