### PR TITLE
kvdb: refactor as preparation for DB migration command in lndinit

### DIFF
--- a/channeldb/db.go
+++ b/channeldb/db.go
@@ -438,7 +438,7 @@ func initChannelDB(db kvdb.Backend) error {
 	err := kvdb.Update(db, func(tx kvdb.RwTx) error {
 		meta := &Meta{}
 		// Check if DB is already initialized.
-		err := fetchMeta(meta, tx)
+		err := FetchMeta(meta, tx)
 		if err == nil {
 			return nil
 		}
@@ -1559,6 +1559,12 @@ func (d *DB) ChannelGraph() *ChannelGraph {
 // state.
 func (d *DB) ChannelStateDB() *ChannelStateDB {
 	return d.channelStateDB
+}
+
+// LatestDBVersion returns the number of the latest database version currently
+// known to the channel DB.
+func LatestDBVersion() uint32 {
+	return getLatestDBVersion(dbVersions)
 }
 
 func getLatestDBVersion(versions []mandatoryVersion) uint32 {

--- a/channeldb/db.go
+++ b/channeldb/db.go
@@ -436,6 +436,11 @@ func (d *DB) Wipe() error {
 // the database are created.
 func initChannelDB(db kvdb.Backend) error {
 	err := kvdb.Update(db, func(tx kvdb.RwTx) error {
+		// Check if DB was marked as inactive with a tomb stone.
+		if err := EnsureNoTombstone(tx); err != nil {
+			return err
+		}
+
 		meta := &Meta{}
 		// Check if DB is already initialized.
 		err := FetchMeta(meta, tx)

--- a/channeldb/db.go
+++ b/channeldb/db.go
@@ -1417,7 +1417,7 @@ func (c *ChannelStateDB) DeleteChannelOpeningState(outPoint []byte) error {
 // applies migration functions to the current database and recovers the
 // previous state of db if at least one error/panic appeared during migration.
 func (d *DB) syncVersions(versions []mandatoryVersion) error {
-	meta, err := d.FetchMeta(nil)
+	meta, err := d.FetchMeta()
 	if err != nil {
 		if err == ErrMetaNotFound {
 			meta = &Meta{}

--- a/channeldb/meta.go
+++ b/channeldb/meta.go
@@ -28,9 +28,8 @@ type Meta struct {
 	DbVersionNumber uint32
 }
 
-// FetchMeta fetches the meta data from boltdb and returns filled meta
-// structure.
-func (d *DB) FetchMeta(tx kvdb.RTx) (*Meta, error) {
+// FetchMeta fetches the metadata from boltdb and returns filled meta structure.
+func (d *DB) FetchMeta() (*Meta, error) {
 	var meta *Meta
 
 	err := kvdb.View(d, func(tx kvdb.RTx) error {

--- a/channeldb/meta_test.go
+++ b/channeldb/meta_test.go
@@ -91,7 +91,7 @@ func TestVersionFetchPut(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	meta, err := db.FetchMeta(nil)
+	meta, err := db.FetchMeta()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -107,7 +107,7 @@ func TestVersionFetchPut(t *testing.T) {
 		t.Fatalf("update of meta failed %v", err)
 	}
 
-	meta, err = db.FetchMeta(nil)
+	meta, err = db.FetchMeta()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -228,7 +228,7 @@ func TestMigrationWithPanic(t *testing.T) {
 
 	// Check that version of database and data wasn't changed.
 	afterMigrationFunc := func(d *DB) {
-		meta, err := d.FetchMeta(nil)
+		meta, err := d.FetchMeta()
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -303,7 +303,7 @@ func TestMigrationWithFatal(t *testing.T) {
 
 	// Check that version of database and initial data wasn't changed.
 	afterMigrationFunc := func(d *DB) {
-		meta, err := d.FetchMeta(nil)
+		meta, err := d.FetchMeta()
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -377,7 +377,7 @@ func TestMigrationWithoutErrors(t *testing.T) {
 
 	// Check that version of database and data was properly changed.
 	afterMigrationFunc := func(d *DB) {
-		meta, err := d.FetchMeta(nil)
+		meta, err := d.FetchMeta()
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -469,7 +469,7 @@ func TestMigrationDryRun(t *testing.T) {
 	// Check that version of database version is not modified.
 	afterMigrationFunc := func(d *DB) {
 		err := kvdb.View(d, func(tx kvdb.RTx) error {
-			meta, err := d.FetchMeta(nil)
+			meta, err := d.FetchMeta()
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/channeldb/meta_test.go
+++ b/channeldb/meta_test.go
@@ -681,4 +681,9 @@ func TestMarkerAndTombstone(t *testing.T) {
 	// cannot be used anymore.
 	err = db.View(EnsureNoTombstone, func() {})
 	require.ErrorContains(t, err, string(tombstoneText))
+
+	// Now that the DB has a tombstone, we should no longer be able to open
+	// it once we close it.
+	_, err = CreateWithBackend(db.Backend)
+	require.ErrorContains(t, err, string(tombstoneText))
 }

--- a/channeldb/meta_test.go
+++ b/channeldb/meta_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"testing"
 
+	"github.com/btcsuite/btcwallet/walletdb"
 	"github.com/go-errors/errors"
 	"github.com/lightningnetwork/lnd/kvdb"
 	"github.com/stretchr/testify/require"
@@ -573,4 +574,111 @@ func TestApplyOptionalVersions(t *testing.T) {
 	err = db.applyOptionalVersions(cfg)
 	require.NoError(t, err, "failed to apply optional migration")
 	require.Equal(t, 1, migrateCount, "expected no migration")
+}
+
+// TestFetchMeta tests that the FetchMeta returns the latest DB version for a
+// freshly created DB instance.
+func TestFetchMeta(t *testing.T) {
+	t.Parallel()
+
+	db, cleanUp, err := MakeTestDB()
+	defer cleanUp()
+	require.NoError(t, err)
+
+	meta := &Meta{}
+	err = db.View(func(tx walletdb.ReadTx) error {
+		return FetchMeta(meta, tx)
+	}, func() {
+		meta = &Meta{}
+	})
+	require.NoError(t, err)
+
+	require.Equal(t, LatestDBVersion(), meta.DbVersionNumber)
+}
+
+// TestMarkerAndTombstone tests that markers like a tombstone can be added to a
+// DB.
+func TestMarkerAndTombstone(t *testing.T) {
+	t.Parallel()
+
+	db, cleanUp, err := MakeTestDB()
+	defer cleanUp()
+	require.NoError(t, err)
+
+	// Test that a generic marker is not present in a fresh DB.
+	var marker []byte
+	err = db.View(func(tx walletdb.ReadTx) error {
+		var err error
+		marker, err = CheckMarkerPresent(tx, []byte("foo"))
+		return err
+	}, func() {
+		marker = nil
+	})
+	require.ErrorIs(t, err, ErrMarkerNotPresent)
+	require.Nil(t, marker)
+
+	// Only adding the marker bucket should not be enough to be counted as
+	// a marker, we explicitly also want the value to be set.
+	err = db.Update(func(tx walletdb.ReadWriteTx) error {
+		_, err := tx.CreateTopLevelBucket([]byte("foo"))
+		return err
+	}, func() {})
+	require.NoError(t, err)
+
+	err = db.View(func(tx walletdb.ReadTx) error {
+		var err error
+		marker, err = CheckMarkerPresent(tx, []byte("foo"))
+		return err
+	}, func() {
+		marker = nil
+	})
+	require.ErrorIs(t, err, ErrMarkerNotPresent)
+	require.Nil(t, marker)
+
+	// Test that a tombstone marker is not present in a fresh DB.
+	err = db.View(EnsureNoTombstone, func() {})
+	require.NoError(t, err)
+
+	// Add a generic marker now and assert that it can be read.
+	err = db.Update(func(tx walletdb.ReadWriteTx) error {
+		return AddMarker(tx, []byte("foo"), []byte("bar"))
+	}, func() {})
+	require.NoError(t, err)
+
+	err = db.View(func(tx walletdb.ReadTx) error {
+		var err error
+		marker, err = CheckMarkerPresent(tx, []byte("foo"))
+		return err
+	}, func() {
+		marker = nil
+	})
+	require.NoError(t, err)
+	require.Equal(t, []byte("bar"), marker)
+
+	// A tombstone should still not be present.
+	err = db.View(EnsureNoTombstone, func() {})
+	require.NoError(t, err)
+
+	// Finally, add a tombstone.
+	tombstoneText := []byte("RIP test DB")
+	err = db.Update(func(tx walletdb.ReadWriteTx) error {
+		return AddMarker(tx, TombstoneKey, tombstoneText)
+	}, func() {})
+	require.NoError(t, err)
+
+	// We can read it as a normal marker.
+	err = db.View(func(tx walletdb.ReadTx) error {
+		var err error
+		marker, err = CheckMarkerPresent(tx, TombstoneKey)
+		return err
+	}, func() {
+		marker = nil
+	})
+	require.NoError(t, err)
+	require.Equal(t, tombstoneText, marker)
+
+	// But also as a tombstone, and now we should get an error that the DB
+	// cannot be used anymore.
+	err = db.View(EnsureNoTombstone, func() {})
+	require.ErrorContains(t, err, string(tombstoneText))
 }

--- a/docs/release-notes/release-notes-0.16.0.md
+++ b/docs/release-notes/release-notes-0.16.0.md
@@ -116,6 +116,10 @@ crash](https://github.com/lightningnetwork/lnd/pull/7019).
 * Updated the github actions to use `make fmt-check` in its [build
   process](https://github.com/lightningnetwork/lnd/pull/6853).
 
+* Database related code was refactored to [allow external tools to use it more
+  easily](https://github.com/lightningnetwork/lnd/pull/5561), in preparation for
+  adding a data migration functionality to `lndinit`.
+
 # Contributors (Alphabetical Order)
 
 * Carla Kirk-Cohen

--- a/kvdb/etcd/bucket.go
+++ b/kvdb/etcd/bucket.go
@@ -130,3 +130,10 @@ func ValueKey(key string, buckets ...string) string {
 
 	return string(makeValueKey(bucket, []byte(key)))
 }
+
+// SequenceKey is a helper function used in tests or external tools to create a
+// sequence key from the passed bucket list.
+func SequenceKey(buckets ...string) string {
+	id := makeBucketID([]byte(BucketKey(buckets...)))
+	return string(makeSequenceKey(id[:]))
+}

--- a/kvdb/etcd/bucket.go
+++ b/kvdb/etcd/bucket.go
@@ -92,7 +92,7 @@ func getKeyVal(kv *KV) ([]byte, []byte) {
 	return getKey(kv.key), val
 }
 
-// BucketKey is a helper functon used in tests to create a bucket key from
+// BucketKey is a helper function used in tests to create a bucket key from
 // passed bucket list.
 func BucketKey(buckets ...string) string {
 	var bucketKey []byte

--- a/kvdb/etcd/bucket_test.go
+++ b/kvdb/etcd/bucket_test.go
@@ -1,0 +1,34 @@
+//go:build kvdb_etcd
+// +build kvdb_etcd
+
+package etcd
+
+import (
+	"crypto/sha256"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestBucketKey tests that a key for a bucket can be created correctly.
+func TestBucketKey(t *testing.T) {
+	rootID := sha256.Sum256([]byte("@"))
+	key := append(rootID[:], []byte("foo")...)
+	key = append(key, 0xff)
+	require.Equal(t, string(key), BucketKey("foo"))
+}
+
+// TestBucketVal tests that a key for a bucket value can be created correctly.
+func TestBucketVal(t *testing.T) {
+	rootID := sha256.Sum256([]byte("@"))
+	key := append(rootID[:], []byte("foo")...)
+	key = append(key, 0xff)
+
+	keyID := sha256.Sum256(key)
+	require.Equal(t, string(keyID[:]), BucketVal("foo"))
+}
+
+// TestSequenceKey tests that a key for a sequence can be created correctly.
+func TestSequenceKey(t *testing.T) {
+	require.Contains(t, SequenceKey("foo", "bar", "baz"), "$seq$")
+}

--- a/kvdb/etcd/db.go
+++ b/kvdb/etcd/db.go
@@ -22,7 +22,7 @@ const (
 	// the etcd instance.
 	etcdConnectionTimeout = 10 * time.Second
 
-	// etcdLongTimeout is a timeout for longer taking etcd operatons.
+	// etcdLongTimeout is a timeout for longer taking etcd operations.
 	etcdLongTimeout = 30 * time.Second
 
 	// etcdDefaultRootBucketId is used as the root bucket key. Note that
@@ -52,8 +52,8 @@ type commitStatsCollector struct {
 	fail map[string]*callerStats
 }
 
-// newCommitStatsColletor creates a new commitStatsCollector instance.
-func newCommitStatsColletor() *commitStatsCollector {
+// newCommitStatsCollector creates a new commitStatsCollector instance.
+func newCommitStatsCollector() *commitStatsCollector {
 	return &commitStatsCollector{
 		succ: make(map[string]*callerStats),
 		fail: make(map[string]*callerStats),
@@ -181,7 +181,7 @@ func newEtcdBackend(ctx context.Context, cfg Config) (*db, error) {
 	}
 
 	if cfg.CollectStats {
-		backend.commitStatsCollector = newCommitStatsColletor()
+		backend.commitStatsCollector = newCommitStatsCollector()
 	}
 
 	return backend, nil

--- a/kvdb/etcd/fixture.go
+++ b/kvdb/etcd/fixture.go
@@ -41,8 +41,8 @@ func NewTestEtcdInstance(t *testing.T, path string) (*Config, func()) {
 	return config, cleanup
 }
 
-// NewTestEtcdTestFixture creates a new etcd-test fixture. This is helper
-// object to facilitate etcd tests and ensure pre and post conditions.
+// NewEtcdTestFixture creates a new etcd-test fixture. This is helper
+// object to facilitate etcd tests and ensure pre- and post-conditions.
 func NewEtcdTestFixture(t *testing.T) *EtcdTestFixture {
 	tmpDir := t.TempDir()
 
@@ -128,7 +128,7 @@ func (f *EtcdTestFixture) Dump() map[string]string {
 	return result
 }
 
-// BackendConfig returns the backend config for connecting to theembedded
+// BackendConfig returns the backend config for connecting to the embedded
 // etcd instance.
 func (f *EtcdTestFixture) BackendConfig() Config {
 	return *f.config

--- a/kvdb/etcd/readwrite_bucket.go
+++ b/kvdb/etcd/readwrite_bucket.go
@@ -318,7 +318,7 @@ func (b *readWriteBucket) DeleteNestedBucket(key []byte) error {
 }
 
 // Put updates the value for the passed key.
-// Returns ErrKeyRequred if te passed key is empty.
+// Returns ErrKeyRequired if the passed key is empty.
 func (b *readWriteBucket) Put(key, value []byte) error {
 	if len(key) == 0 {
 		return walletdb.ErrKeyRequired
@@ -335,7 +335,7 @@ func (b *readWriteBucket) Put(key, value []byte) error {
 }
 
 // Delete deletes the key/value pointed to by the passed key.
-// Returns ErrKeyRequred if the passed key is empty.
+// Returns ErrKeyRequired if the passed key is empty.
 func (b *readWriteBucket) Delete(key []byte) error {
 	if key == nil {
 		return nil
@@ -360,7 +360,7 @@ func (b *readWriteBucket) Tx() walletdb.ReadWriteTx {
 	return b.tx
 }
 
-// NextSequence returns an autoincrementing sequence number for this bucket.
+// NextSequence returns an auto-incrementing sequence number for this bucket.
 // Note that this is not a thread safe function and as such it must not be used
 // for synchronization.
 func (b *readWriteBucket) NextSequence() (uint64, error) {
@@ -396,7 +396,7 @@ func (b *readWriteBucket) Sequence() uint64 {
 		return 0
 	}
 
-	// Otherwise try to parse a 64 bit unsigned integer from the value.
+	// Otherwise try to parse a 64-bit unsigned integer from the value.
 	num, _ := strconv.ParseUint(string(val), 10, 64)
 
 	return num
@@ -414,7 +414,7 @@ func flattenMap(m map[string]struct{}) []string {
 	return result
 }
 
-// Prefetch will prefetch all keys in the passed paths as well as all bucket
+// Prefetch will prefetch all keys in the passed-in paths as well as all bucket
 // keys along the paths.
 func (b *readWriteBucket) Prefetch(paths ...[]string) {
 	keys := make(map[string]struct{})

--- a/lncfg/db.go
+++ b/lncfg/db.go
@@ -12,11 +12,12 @@ import (
 )
 
 const (
-	channelDBName     = "channel.db"
-	macaroonDBName    = "macaroons.db"
-	decayedLogDbName  = "sphinxreplay.db"
-	towerClientDBName = "wtclient.db"
-	towerServerDBName = "watchtower.db"
+	ChannelDBName     = "channel.db"
+	MacaroonDBName    = "macaroons.db"
+	DecayedLogDbName  = "sphinxreplay.db"
+	TowerClientDBName = "wtclient.db"
+	TowerServerDBName = "watchtower.db"
+	WalletDBName      = "wallet.db"
 
 	BoltBackend                = "bolt"
 	EtcdBackend                = "etcd"
@@ -393,7 +394,7 @@ func (db *DB) GetBackends(ctx context.Context, chanDBPath,
 	// We're using all bbolt based databases by default.
 	boltBackend, err := kvdb.GetBoltBackend(&kvdb.BoltBackendConfig{
 		DBPath:            chanDBPath,
-		DBFileName:        channelDBName,
+		DBFileName:        ChannelDBName,
 		DBTimeout:         db.Bolt.DBTimeout,
 		NoFreelistSync:    db.Bolt.NoFreelistSync,
 		AutoCompact:       db.Bolt.AutoCompact,
@@ -406,7 +407,7 @@ func (db *DB) GetBackends(ctx context.Context, chanDBPath,
 
 	macaroonBackend, err := kvdb.GetBoltBackend(&kvdb.BoltBackendConfig{
 		DBPath:            walletDBPath,
-		DBFileName:        macaroonDBName,
+		DBFileName:        MacaroonDBName,
 		DBTimeout:         db.Bolt.DBTimeout,
 		NoFreelistSync:    db.Bolt.NoFreelistSync,
 		AutoCompact:       db.Bolt.AutoCompact,
@@ -419,7 +420,7 @@ func (db *DB) GetBackends(ctx context.Context, chanDBPath,
 
 	decayedLogBackend, err := kvdb.GetBoltBackend(&kvdb.BoltBackendConfig{
 		DBPath:            chanDBPath,
-		DBFileName:        decayedLogDbName,
+		DBFileName:        DecayedLogDbName,
 		DBTimeout:         db.Bolt.DBTimeout,
 		NoFreelistSync:    db.Bolt.NoFreelistSync,
 		AutoCompact:       db.Bolt.AutoCompact,
@@ -437,7 +438,7 @@ func (db *DB) GetBackends(ctx context.Context, chanDBPath,
 		towerClientBackend, err = kvdb.GetBoltBackend(
 			&kvdb.BoltBackendConfig{
 				DBPath:            chanDBPath,
-				DBFileName:        towerClientDBName,
+				DBFileName:        TowerClientDBName,
 				DBTimeout:         db.Bolt.DBTimeout,
 				NoFreelistSync:    db.Bolt.NoFreelistSync,
 				AutoCompact:       db.Bolt.AutoCompact,
@@ -458,7 +459,7 @@ func (db *DB) GetBackends(ctx context.Context, chanDBPath,
 		towerServerBackend, err = kvdb.GetBoltBackend(
 			&kvdb.BoltBackendConfig{
 				DBPath:            towerServerDBPath,
-				DBFileName:        towerServerDBName,
+				DBFileName:        TowerServerDBName,
 				DBTimeout:         db.Bolt.DBTimeout,
 				NoFreelistSync:    db.Bolt.NoFreelistSync,
 				AutoCompact:       db.Bolt.AutoCompact,


### PR DESCRIPTION
EDIT: The main migration tool has moved to https://github.com/lightninglabs/lndinit/pull/21 (still not ready for production/mainnet use!)

The code in this PR is now purely a refactor to allow `lndinit` to access the required library code.