### PR TITLE
server: disable DNS boostrap for SigNet nodes

### DIFF
--- a/docs/release-notes/release-notes-0.14.0.md
+++ b/docs/release-notes/release-notes-0.14.0.md
@@ -106,6 +106,12 @@ you.
 * [Update MC store in blocks](https://github.com/lightningnetwork/lnd/pull/5515)
   to make payment throughput better when using etcd.
 
+## Bug Fixes
+
+A bug has been fixed that would cause `lnd` to [try to bootstrap using the
+currnet DNS seeds when in SigNet
+mode](https://github.com/lightningnetwork/lnd/pull/5564).
+
 # Contributors (Alphabetical Order)
 * ErikEk
 * Martin Habovstiak

--- a/server.go
+++ b/server.go
@@ -1788,10 +1788,11 @@ func (s *server) Start() error {
 		// configure the set of active bootstrappers, and launch a
 		// dedicated goroutine to maintain a set of persistent
 		// connections.
-		if !s.cfg.NoNetBootstrap &&
-			!(s.cfg.Bitcoin.SimNet || s.cfg.Litecoin.SimNet) &&
-			!(s.cfg.Bitcoin.RegTest || s.cfg.Litecoin.RegTest) {
-
+		isSimnet := (s.cfg.Bitcoin.SimNet || s.cfg.Litecoin.SimNet)
+		isSignet := (s.cfg.Bitcoin.SigNet || s.cfg.Litecoin.SigNet)
+		isRegtest := (s.cfg.Bitcoin.RegTest || s.cfg.Litecoin.RegTest)
+		isDevNetwork := isSimnet || isSignet || isRegtest
+		if !s.cfg.NoNetBootstrap && !isDevNetwork {
 			bootstrappers, err := initNetworkBootstrappers(s)
 			if err != nil {
 				startErr = err

--- a/server.go
+++ b/server.go
@@ -1788,11 +1788,7 @@ func (s *server) Start() error {
 		// configure the set of active bootstrappers, and launch a
 		// dedicated goroutine to maintain a set of persistent
 		// connections.
-		isSimnet := (s.cfg.Bitcoin.SimNet || s.cfg.Litecoin.SimNet)
-		isSignet := (s.cfg.Bitcoin.SigNet || s.cfg.Litecoin.SigNet)
-		isRegtest := (s.cfg.Bitcoin.RegTest || s.cfg.Litecoin.RegTest)
-		isDevNetwork := isSimnet || isSignet || isRegtest
-		if !s.cfg.NoNetBootstrap && !isDevNetwork {
+		if shouldPeerBootstrap(s.cfg) {
 			bootstrappers, err := initNetworkBootstrappers(s)
 			if err != nil {
 				startErr = err
@@ -3963,4 +3959,16 @@ func newSweepPkScriptGen(
 
 		return txscript.PayToAddrScript(sweepAddr)
 	}
+}
+
+// shouldPeerBootstrap returns true if we should attempt to perform peer
+// boostrapping to actively seek our peers using the set of active network
+// bootsrappers.
+func shouldPeerBootstrap(cfg *Config) bool {
+	isSimnet := (cfg.Bitcoin.SimNet || cfg.Litecoin.SimNet)
+	isSignet := (cfg.Bitcoin.SigNet || cfg.Litecoin.SigNet)
+	isRegtest := (cfg.Bitcoin.RegTest || cfg.Litecoin.RegTest)
+	isDevNetwork := isSimnet || isSignet || isRegtest
+
+	return !cfg.NoNetBootstrap && !isDevNetwork
 }


### PR DESCRIPTION
In this commit, we fix a bug that would cause nodes attempting to run
using the signet chain, to waste CPU as they attempted to boostrap to a
non-existent DNS seed. We fix this by ignoring the DNS boostrapper is
signet is active. Along the way, we refactor the conditional sightly to
be more readable, and easily extensible.

