### PR TITLE
Enforce channel disable at the link level 

### DIFF
--- a/docs/release-notes/release-notes-0.15.0.md
+++ b/docs/release-notes/release-notes-0.15.0.md
@@ -16,6 +16,20 @@
 * Add [private status](https://github.com/lightningnetwork/lnd/pull/6167)
   to pendingchannels response.
 
+## Backend Enhancements & Optimizations
+
+### Channel disable now enforced
+
+The `switch`, which is responsible for routing payments from an incoming
+channel to the outgoing channel, 
+[now enforces the channel disable state](https://github.com/lightningnetwork/lnd/pull/5565).
+Previously, if a channel was disabled by autonomous or
+[manual intervention](https://github.com/lightningnetwork/lnd/pull/5033)
+the gossip layer would communicate to peers not to route through the
+aforementioned channel, however it was possible for a modified node or a
+a crafted route to bypass the disable state. With this addition the
+disabled state is now enforced and the bypass is no longer possible. 
+
 ## Bug Fixes
 
 * [Fixed an inactive invoice subscription not removed from invoice

--- a/lntest/itest/lnd_test_list_on_test.go
+++ b/lntest/itest/lnd_test_list_on_test.go
@@ -144,6 +144,10 @@ var allTestCases = []*testCase{
 		name: "reject onward htlc",
 		test: testRejectHTLC,
 	},
+	{
+		name: "disable channel forwarding",
+		test: testDisableChannelForwarding,
+	},
 	// TODO(roasbeef): multi-path integration test
 	{
 		name: "node announcement",

--- a/netann/chan_status_manager.go
+++ b/netann/chan_status_manager.go
@@ -60,7 +60,7 @@ type ChanStatusConfig struct {
 	// ApplyChannelUpdate processes new ChannelUpdates signed by our node by
 	// updating our local routing table and broadcasting the update to our
 	// peers.
-	ApplyChannelUpdate func(*lnwire.ChannelUpdate) error
+	ApplyChannelUpdate func(*lnwire.ChannelUpdate, wire.OutPoint, bool) error
 
 	// DB stores the set of channels that are to be monitored.
 	DB DB
@@ -633,7 +633,7 @@ func (m *ChanStatusManager) signAndSendNextUpdate(outpoint wire.OutPoint,
 		return err
 	}
 
-	return m.cfg.ApplyChannelUpdate(chanUpdate)
+	return m.cfg.ApplyChannelUpdate(chanUpdate, outpoint, disabled)
 }
 
 // fetchLastChanUpdateByOutPoint fetches the latest policy for our direction of

--- a/netann/chan_status_manager_test.go
+++ b/netann/chan_status_manager_test.go
@@ -174,7 +174,9 @@ func (g *mockGraph) FetchChannelEdgesByOutpoint(
 	return info, pol1, pol2, nil
 }
 
-func (g *mockGraph) ApplyChannelUpdate(update *lnwire.ChannelUpdate) error {
+func (g *mockGraph) ApplyChannelUpdate(update *lnwire.ChannelUpdate,
+	outpoint wire.OutPoint, disabled bool) error {
+
 	g.mu.Lock()
 	defer g.mu.Unlock()
 

--- a/peer/test_utils.go
+++ b/peer/test_utils.go
@@ -335,8 +335,15 @@ func createTestPeer(notifier chainntnfs.ChainNotifier,
 		MessageSigner:            nodeSignerAlice,
 		OurPubKey:                aliceKeyPub,
 		OurKeyLoc:                testKeyLoc,
-		IsChannelActive:          func(lnwire.ChannelID) bool { return true },
-		ApplyChannelUpdate:       func(*lnwire.ChannelUpdate) error { return nil },
+		IsChannelActive: func(lnwire.ChannelID) bool {
+			return true
+		},
+
+		ApplyChannelUpdate: func(*lnwire.ChannelUpdate,
+			wire.OutPoint, bool) error {
+
+			return nil
+		},
 	})
 	if err != nil {
 		return nil, nil, nil, err

--- a/routing/localchans/manager.go
+++ b/routing/localchans/manager.go
@@ -112,6 +112,7 @@ func (r *Manager) UpdatePolicy(newSchema routing.ChannelPolicy,
 			TimeLockDelta: uint32(edge.TimeLockDelta),
 			MinHTLCOut:    edge.MinHTLC,
 			MaxHTLC:       edge.MaxHTLC,
+			Disabled:      newSchema.Disabled,
 		}
 
 		return nil

--- a/routing/router.go
+++ b/routing/router.go
@@ -264,6 +264,12 @@ type ChannelPolicy struct {
 	// MinHTLC is the minimum HTLC size including fees we are allowed to
 	// forward over this channel.
 	MinHTLC *lnwire.MilliSatoshi
+
+	// Disabled represents whether or not the channel link has been
+	// manually disabled by the UpdateChannelStatus command. Disabled
+	// channels will not be able to send or forward payments, but may
+	// be able to receive them.
+	Disabled bool
 }
 
 // Config defines the configuration for the ChannelRouter. ALL elements within


### PR DESCRIPTION
This PR tackles https://github.com/lightningnetwork/lnd/issues/5088

To check for disabled channel status, we append the disabled info to `ForwardingPolicy` on the ChannelLink config and perform a check when performing an HTLC forward. 

#### Known Bugs To Fix

- [x] `rpcServer.UpdateChannelPolicy` will reset all `ForwardingPolicy` for
  specified channels (including all channels if so set) to Disabled =
  false
- [x] `UpdatePolicy` changes occasionally are not recognized by `htlc.Switch`,
  allowing for disabled channels to accept HTLC forwards
- [x] Proper failure codes are not adequately returned to peers

#### Pull Request Checklist

- [X] All changes are Go version 1.15 compliant
- [x] Your PR passes all CI checks. If a check cannot be passed for a justifiable reason, that reason must be stated in the commit message and PR description.
- [X] If this is your first time contributing, we recommend you read the [Code Contribution Guidelines](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md)
   - [X] The code being submitted is commented according to [Code Documentation and Commenting](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#CodeDocumentation)
   - [X] Commits have a logical structure according to [Ideal Git Commit Structure](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#IdealGitCommitStructure)
- [X] For new code: Code is accompanied by tests which exercise both the positive and negative (error paths) conditions (if applicable)
- [X] For bug fixes: If possible, code is accompanied by new tests which trigger the bug being fixed to prevent regressions
- [X] Any new logging statements use an appropriate subsystem and logging level
- [X] For code and documentation: lines are wrapped at 80 characters (the tab character should be counted as 8 characters, not 4, as some IDEs do per default)
