### PR TITLE
routing: fix race in TestSendMPPaymentFailed

### DIFF
--- a/docs/release-notes/release-notes-0.14.0.md
+++ b/docs/release-notes/release-notes-0.14.0.md
@@ -60,6 +60,7 @@ you.
   alert](https://github.com/lightningnetwork/lnd/pull/5576).
 * [Fixed timeout flakes in async payment benchmark tests](https://github.com/lightningnetwork/lnd/pull/5579).
 * [Fixed a missing import and git tag in the healthcheck package](https://github.com/lightningnetwork/lnd/pull/5582).
+* [Fixed a data race in payment unit test](https://github.com/lightningnetwork/lnd/pull/5573).
 
 ## Database
 
@@ -80,3 +81,4 @@ to make LNDs payment throughput (and latency) with better when using etcd.
 * Martin Habovstiak
 * Zero-1729
 * Oliver Gugger
+* Yong Yu

--- a/routing/mock_test.go
+++ b/routing/mock_test.go
@@ -591,8 +591,6 @@ func (m *mockPaymentSessionSource) NewPaymentSessionEmpty() PaymentSession {
 
 type mockMissionControl struct {
 	mock.Mock
-
-	failReason *channeldb.FailureReason
 }
 
 var _ MissionController = (*mockMissionControl)(nil)
@@ -603,7 +601,13 @@ func (m *mockMissionControl) ReportPaymentFail(
 	*channeldb.FailureReason, error) {
 
 	args := m.Called(paymentID, rt, failureSourceIdx, failure)
-	return m.failReason, args.Error(1)
+
+	// Type assertion on nil will fail, so we check and return here.
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+
+	return args.Get(0).(*channeldb.FailureReason), args.Error(1)
 }
 
 func (m *mockMissionControl) ReportPaymentSuccess(paymentID uint64,

--- a/routing/router_test.go
+++ b/routing/router_test.go
@@ -4023,17 +4023,16 @@ func TestSendMPPaymentFailed(t *testing.T) {
 	failureReason := channeldb.FailureReasonPaymentDetails
 	missionControl.On("ReportPaymentFail",
 		mock.Anything, mock.Anything, mock.Anything, mock.Anything,
-	).Return(nil, nil).Run(func(args mock.Arguments) {
+	).Return(&failureReason, nil).Run(func(args mock.Arguments) {
 		// We only return the terminal error once, thus when the method
 		// is called, we will return it with a nil error.
 		if called {
-			missionControl.failReason = nil
+			args[0] = nil
 			return
 		}
 
 		// If it's the first time calling this method, we will return a
 		// terminal error.
-		missionControl.failReason = &failureReason
 		payment.FailureReason = &failureReason
 		called = true
 	})
@@ -4213,8 +4212,7 @@ func TestSendMPPaymentFailedWithShardsInFlight(t *testing.T) {
 	failureReason := channeldb.FailureReasonPaymentDetails
 	missionControl.On("ReportPaymentFail",
 		mock.Anything, mock.Anything, mock.Anything, mock.Anything,
-	).Return(failureReason, nil).Run(func(args mock.Arguments) {
-		missionControl.failReason = &failureReason
+	).Return(&failureReason, nil).Run(func(args mock.Arguments) {
 		payment.FailureReason = &failureReason
 	}).Once()
 


### PR DESCRIPTION
Fix #5530. Turns out there's a better way to manage what to return in the mock call. Previously the `failReason` was accessed by concurrent `ReportPaymentFail` calls which ended in a data race. This change also makes `MissionController` mock "cleaner" as it needs to worry about the internal state (`failReason`) no more.