### PR TITLE
itest: fix async payment benchmark timeout flakes

### DIFF
--- a/docs/release-notes/release-notes-0.14.0.md
+++ b/docs/release-notes/release-notes-0.14.0.md
@@ -40,6 +40,7 @@ addholdinvoice call](https://github.com/lightningnetwork/lnd/pull/5533).
 * [Fixed typo in `dest_custom_records` description comment](https://github.com/lightningnetwork/lnd/pull/5541).
 * [Bumped version of `github.com/miekg/dns` library to fix a Dependabot
   alert](https://github.com/lightningnetwork/lnd/pull/5576).
+* [Fixed timeout flakes in async payment benchmark tests](https://github.com/lightningnetwork/lnd/pull/5579).
 
 ## Database
 


### PR DESCRIPTION
Fixes timeout flakes that rarely happen when `dbbackend=etcd`:

```test_harness.go:88: Failed: (async bidirectional payments): exited with error: 
        *errors.errorString alice's remote balance is incorrect, got 771000, expected 1000000
        /home/travis/gopath/src/github.com/lightningnetwork/lnd/lntest/itest/lnd_payment_test.go:550 (0x13f6ea9)
        	testBidirectionalAsyncPayments: t.Fatalf("alice's remote balance is incorrect, got %v, "+
        /home/travis/gopath/src/github.com/lightningnetwork/lnd/lntest/itest/test_harness.go:112 (0x13a8ace)
        	(*harnessTest).RunTestCase: testCase.test(h.lndHarness, h)
        /home/travis/gopath/src/github.com/lightningnetwork/lnd/lntest/itest/lnd_test.go:247 (0x144c00f)
        	TestLightningNetworkDaemon.func4: ht.RunTestCase(testCase)
        /home/travis/.gimme/versions/go1.16.3.linux.amd64/src/testing/testing.go:1193 (0x52232f)
        	tRunner: fn(t)
        /home/travis/.gimme/versions/go1.16.3.linux.amd64/src/runtime/asm_amd64.s:1371 (0x472001)
        	goexit: BYTE	$0x90	// NOP```