### PR TITLE
Minor improvements to C# grpc doc

### DIFF
--- a/docs/grpc/c#.md
+++ b/docs/grpc/c#.md
@@ -6,7 +6,6 @@ This section enumerates what you need to do to write a client that communicates 
 ### Prerequisites
 
 * .Net Core [SDK](https://dotnet.microsoft.com/download)
-* If using Windows, a unix terminal such as [Cygwin](https://www.cygwin.com/)
 
 
 ### Setup and Installation
@@ -17,7 +16,11 @@ This section enumerates what you need to do to write a client that communicates 
 
 This assumes you are using a Windows machine, but it applies equally to Mac and Linux.
 
-Create a new `.net core` console application called `lndclient` at your root directory (On Windows : `C:/`).
+Create a new `.net core` console application called `lndclient`:
+
+```shell
+⛰  dotnet new console --name lndclient
+```
 
 Create a folder `Grpc` in the root of your project and fetch the lnd proto files
 


### PR DESCRIPTION
Removed the cygwin prereq. As best I can tell it's not required and if a linux terminal is needed it should definitely be WSL (it's fully supported by Microsoft and has a much better Windows integration than cygwin).

There doesn't seem to be any good reason to create the demo project in the Windows root directory so I've removed that instruction.

Added the dotnet command to create the new project.