### PR TITLE
make: disable itest error whitelist check

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -191,7 +191,6 @@ itest-only:
 	@$(call print, "Running integration tests with ${backend} backend.")
 	rm -rf lntest/itest/*.log lntest/itest/.logs-*; date
 	EXEC_SUFFIX=$(EXEC_SUFFIX) scripts/itest_part.sh 0 1 $(TEST_FLAGS) $(ITEST_FLAGS)
-	lntest/itest/log_check_errors.sh
 
 itest: build-itest itest-only
 
@@ -201,7 +200,6 @@ itest-parallel: build-itest
 	@$(call print, "Running tests")
 	rm -rf lntest/itest/*.log lntest/itest/.logs-*; date
 	EXEC_SUFFIX=$(EXEC_SUFFIX) echo "$$(seq 0 $$(expr $(ITEST_PARALLELISM) - 1))" | xargs -P $(ITEST_PARALLELISM) -n 1 -I {} scripts/itest_part.sh {} $(NUM_ITEST_TRANCHES) $(TEST_FLAGS) $(ITEST_FLAGS)
-	lntest/itest/log_check_errors.sh
 
 unit: btcd
 	@$(call print, "Running unit tests.")

--- a/docs/release-notes/release-notes-0.14.0.md
+++ b/docs/release-notes/release-notes-0.14.0.md
@@ -33,6 +33,8 @@ you.
 
 * [A new build target itest-race](https://github.com/lightningnetwork/lnd/pull/5542) 
   to help uncover undetected data races with our itests.
+* [The itest error whitelist check was removed to reduce the number of failed
+  Travis builds](https://github.com/lightningnetwork/lnd/pull/5588).
 
 # Documentation
 


### PR DESCRIPTION
Since we don't really do anything with the errors we check in the itest
error whitelist but get a lot of failed Travis runs because of it, we
disable the check for the moment.
