### PR TITLE
rpcserver: validate FinalCltvDelta and CltvLimit for REST

### DIFF
--- a/docs/release-notes/release-notes-0.14.0.md
+++ b/docs/release-notes/release-notes-0.14.0.md
@@ -140,6 +140,8 @@ A bug has been fixed that would cause `lnd` to [try to bootstrap using the
 currnet DNS seeds when in SigNet
 mode](https://github.com/lightningnetwork/lnd/pull/5564).
 
+[A validation check for sane `CltvLimit` and `FinalCltvDelta` has been added for `REST`-initiated payments.](https://github.com/lightningnetwork/lnd/pull/5591)
+
 ## Documentation 
 
 The [code contribution guidelines have been updated to mention the new

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -4339,6 +4339,14 @@ func (r *rpcServer) extractPaymentIntent(rpcPayReq *rpcPaymentRequest) (rpcPayme
 			return payIntent, err
 		}
 
+		// Do bounds checking with the block padding.
+		err = routing.ValidateCLTVLimit(
+			payIntent.cltvLimit, payIntent.cltvDelta, true,
+		)
+		if err != nil {
+			return payIntent, err
+		}
+
 		return payIntent, nil
 	}
 


### PR DESCRIPTION
Missed this check in PR #5293.
