### PR TITLE
wtclient: automatically initialise while creating a watchtower server

### DIFF
--- a/config.go
+++ b/config.go
@@ -160,6 +160,10 @@ const (
 	// defaultCoinSelectionStrategy is the coin selection strategy that is
 	// used by default to fund transactions.
 	defaultCoinSelectionStrategy = "largest"
+
+	// defaultWatchTowerClientStartup sets the watchTower client to start
+	// automatically along with lnd
+	defaultWatchTowerClientStartup = true
 )
 
 var (
@@ -555,6 +559,9 @@ func DefaultConfig() Config {
 		ChannelCommitInterval:   defaultChannelCommitInterval,
 		ChannelCommitBatchSize:  defaultChannelCommitBatchSize,
 		CoinSelectionStrategy:   defaultCoinSelectionStrategy,
+		WtClient: &lncfg.WtClient{
+			Active: defaultWatchTowerClientStartup,
+		},
 	}
 }
 

--- a/lncfg/wtclient.go
+++ b/lncfg/wtclient.go
@@ -4,9 +4,9 @@ import "fmt"
 
 // WtClient holds the configuration options for the daemon's watchtower client.
 type WtClient struct {
-	// Active determines whether a watchtower client should be created to
+	// Deactivate determines whether a watchtower client should not be created to
 	// back up channel states with registered watchtowers.
-	Active bool `long:"active" description:"Whether the daemon should use private watchtowers to back up revoked channel states."`
+	Deactivate bool `long:"deactivate" description:"Whether the daemon should not use private watchtowers to back up revoked channel states."`
 
 	// PrivateTowerURIs specifies the lightning URIs of the towers the
 	// watchtower client should send new backups to.
@@ -15,6 +15,11 @@ type WtClient struct {
 	// SweepFeeRate specifies the fee rate in sat/byte to be used when
 	// constructing justice transactions sent to the tower.
 	SweepFeeRate uint64 `long:"sweep-fee-rate" description:"Specifies the fee rate in sat/byte to be used when constructing justice transactions sent to the watchtower."`
+
+	// Active determines whether a watchtower client should be created to
+	// back up channel states with registered watchtowers.
+	// Deprecated. Kept for migration purposes. Use Deactivate instead
+	Active bool `long:"active" description:"Whether the daemon should use private watchtowers to back up revoked channel states."`
 }
 
 // Validate ensures the user has provided a valid configuration.

--- a/sample-lnd.conf
+++ b/sample-lnd.conf
@@ -906,15 +906,19 @@ litecoin.node=ltcd
 
 [wtclient]
 
-; Activate Watchtower Client. To get more information or configure watchtowers
+; Deactivate  Watchtower Client. To get more information or configure watchtowers
 ; run `lncli wtclient -h`.
-; wtclient.active=true
+; wtclient.deactivate=true
 
 ; Specify the fee rate with which justice transactions will be signed. This fee
 ; rate should be chosen as a maximum fee rate one is willing to pay in order to
 ; sweep funds if a breach occurs while being offline. The fee rate should be
 ; specified in sat/byte, the default is 10 sat/byte.
 ; wtclient.sweep-fee-rate=10
+
+; (Deprecated) Activate Watchtower Client. To get more information or configure watchtowers
+; run `lncli wtclient -h`.
+; wtclient.active=true
 
 ; (Deprecated) Specifies the URIs of private watchtowers to use in backing up
 ; revoked states. URIs must be of the form <pubkey>@<addr>. Only 1 URI is

--- a/sample-lnd.conf
+++ b/sample-lnd.conf
@@ -916,7 +916,8 @@ litecoin.node=ltcd
 ; specified in sat/byte, the default is 10 sat/byte.
 ; wtclient.sweep-fee-rate=10
 
-; (Deprecated) Activate Watchtower Client. To get more information or configure watchtowers
+; (Deprecated) Activate Watchtower Client. To get more information or configure
+; watchtowers
 ; run `lncli wtclient -h`.
 ; wtclient.active=true
 

--- a/server.go
+++ b/server.go
@@ -1273,7 +1273,8 @@ func newServer(cfg *Config, listenAddrs []net.Addr,
 		FlapCountTicker: ticker.New(chanfitness.FlapCountFlushRate),
 	})
 
-	if cfg.WtClient.Active {
+	// Checking if the watchtower client server needs to be created
+	if !cfg.WtClient.Deactivate {
 		policy := wtpolicy.DefaultPolicy()
 
 		if cfg.WtClient.SweepFeeRate != 0 {


### PR DESCRIPTION
- Fixes #5344 

Initially, the `--wtclient.active` had to be passed alongside `--watchtower.active` for `lncli` to be able to connect to the watchtower

This PR inverts the functionality, now `wtclient` is automatically created, however if you do not want it it to create automatically, you can pass `--watchtower.deactivate` now instead.

**Old Command:**
`lnd --watchtower.active --wtclient.activate`

**New Command (automatically creates a wtclient):** 
`lnd --watchtower.active`

**New Command to disable creating wtclient:**
`lnd --watchtower.active --wtclient.deactivate`

**[Test]:** personally tested on local machine and passes `go test .../..`

#### Pull Request Checklist

- [X] All changes are Go version 1.15 compliant
- [ ] Your PR passes all CI checks. If a check cannot be passed for a justifiable reason, that reason must be stated in the commit message and PR description.
- [X] If this is your first time contributing, we recommend you read the [Code Contribution Guidelines](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md)
   - [X] The code being submitted is commented according to [Code Documentation and Commenting](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#CodeDocumentation)
   - [X] Commits have a logical structure according to [Ideal Git Commit Structure](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#IdealGitCommitStructure)
- [ ] For new code: Code is accompanied by tests which exercise both the positive and negative (error paths) conditions (if applicable)
- [ ] For bug fixes: If possible, code is accompanied by new tests which trigger the bug being fixed to prevent regressions
- [ ] Any new logging statements use an appropriate subsystem and logging level
- [X] For code and documentation: lines are wrapped at 80 characters (the tab character should be counted as 8 characters, not 4, as some IDEs do per default)
