### PR TITLE
itests: payments test flake fix

### DIFF
--- a/docs/release-notes/release-notes-0.14.0.md
+++ b/docs/release-notes/release-notes-0.14.0.md
@@ -92,6 +92,8 @@ you.
 
 * [Fixed timeout flakes in async payment benchmark tests](https://github.com/lightningnetwork/lnd/pull/5579).
 
+* [Flake fix in async bidirectional payment test](https://github.com/lightningnetwork/lnd/pull/5607).
+
 * [Fixed a missing import and git tag in the healthcheck package](https://github.com/lightningnetwork/lnd/pull/5582).
 
 * [Fixed a data race in payment unit test](https://github.com/lightningnetwork/lnd/pull/5573).


### PR DESCRIPTION
This issue has been fixed before in https://github.com/lightningnetwork/lnd/pull/5579 but it seems like one more left flaking occasionally.