### PR TITLE
Docs: Replacing deprecated import in JS readme

### DIFF
--- a/docs/grpc/javascript.md
+++ b/docs/grpc/javascript.md
@@ -10,7 +10,7 @@ npm init (or npm init -f if you want to use the default values without prompt)
 Then you need to install the Javascript grpc and proto loader library
 dependencies:
 ```
-npm install grpc @grpc/proto-loader --save
+npm install @grpc/grpc-js @grpc/proto-loader --save
 ```
 
 You also need to copy the `lnd` `lightning.proto` file in your project directory
@@ -21,11 +21,11 @@ sources](https://github.com/lightningnetwork/lnd/blob/master/lnrpc/lightning.pro
 
 ### Imports and Client
 
-Every time you work with Javascript gRPC, you will have to import `grpc`, load
+Every time you work with Javascript gRPC, you will have to import `@grpc/grpc-js`, load
 `lightning.proto`, and create a connection to your client like so:
 
 ```js
-const grpc = require('grpc');
+const grpc = require('@grpc/grpc-js');
 const protoLoader = require('@grpc/proto-loader');
 const fs = require("fs");
 
@@ -183,7 +183,7 @@ The following snippet will add the macaroon to every request automatically:
 
 ```js
 const fs = require('fs');
-const grpc = require('grpc');
+const grpc = require('@grpc/grpc-js');
 const protoLoader = require('@grpc/proto-loader');
 const loaderOptions = {
   keepCase: true,


### PR DESCRIPTION
npm module grpc is deprecated as of April 2021. 

The recommended replacement is @grpc/grpc-js. 

The replacement is compatible with the use cases presented in JS examples and so switching examples to it requires only changes to the list of npm modules to install and changes to the imports at the beginning of the files to import.

In my own npm project I have replaced the deprecated module and not noticed any changes in grpc communication with lnd. Additionally the docs for the replacement ie. @grpc/grpc-js claim compatibility. Nonetheless I may be missing a use case or the @grpc/grpc-js developers might have missed a compatibility issue which would require more changes be made to the examples to ensure compatibility with a module being actively maintained.

Source for deprecation: https://www.npmjs.com/package/grpc
Source for replacement and compatibility information: https://www.npmjs.com/package/@grpc/grpc-js

#### Pull Request Checklist

- [n/a] All changes are Go version 1.15 compliant
- [n/a] Your PR passes all CI checks. If a check cannot be passed for a justifiable reason, that reason must be stated in the commit message and PR description.
- [x] If this is your first time contributing, we recommend you read the [Code Contribution Guidelines]()
   - [x] The code being submitted is commented according to [Code Documentation and Commenting](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#CodeDocumentation)
   - [x] Commits have a logical structure according to [Ideal Git Commit Structure](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#IdealGitCommitStructure)
- [n/a] For new code: Code is accompanied by tests which exercise both the positive and negative (error paths) conditions (if applicable)
- [n/a] For bug fixes: If possible, code is accompanied by new tests which trigger the bug being fixed to prevent regressions
- [n/a] Any new logging statements use an appropriate subsystem and logging level
- [x] For code and documentation: lines are wrapped at 80 characters (the tab character should be counted as 8 characters, not 4, as some IDEs do per default)
