### PR TITLE
docs: add release notes to PR checklist and contributor guidelines

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -9,3 +9,4 @@
 - [ ] For bug fixes: If possible, code is accompanied by new tests which trigger the bug being fixed to prevent regressions
 - [ ] Any new logging statements use an appropriate subsystem and logging level
 - [ ] For code and documentation: lines are wrapped at 80 characters (the tab character should be counted as 8 characters, not 4, as some IDEs do per default)
+- [ ] A description of your changes [should be added to running the release notes](https://github.com/lightningnetwork/lnd/tree/master/docs/release-notes) for the milestone your change will land in.

--- a/docs/code_contribution_guidelines.md
+++ b/docs/code_contribution_guidelines.md
@@ -551,6 +551,12 @@ This process will continue until the code is finally accepted.
 
 ## Acceptance
 
+Before your code is accepted, the [release notes we keep in-tree for the next
+upcoming milestone should be extended to describe the changes contained in your
+PR](https://github.com/lightningnetwork/lnd/tree/master/docs/release-notes).
+Unless otherwise mentioned by the reviewers of your PR, the description of your
+changes should live in the document set for the _next_ major release. 
+
 Once your code is accepted, it will be integrated with the master branch. After
 2+ (sometimes 1) LGTM's (approvals) are given on a PR, it's eligible to land in
 master. At this final phase, it may be necessary to rebase the PR in order to

--- a/docs/release-notes/release-notes-0.14.0.md
+++ b/docs/release-notes/release-notes-0.14.0.md
@@ -127,6 +127,12 @@ A bug has been fixed that would cause `lnd` to [try to bootstrap using the
 currnet DNS seeds when in SigNet
 mode](https://github.com/lightningnetwork/lnd/pull/5564).
 
+## Documentation 
+
+The [code contribution guidelines have been updated to mention the new
+requirements surrounding updating the release notes for each new
+change](https://github.com/lightningnetwork/lnd/pull/5613). 
+
 # Contributors (Alphabetical Order)
 * Andras Banki-Horvath
 * ErikEk


### PR DESCRIPTION
This should save reviewers (and contributors!) a bit of time, by making the new requirements w.r.t population of the release notes more explicit. 