### PR TITLE
trivial: skip release note for trivial fixes

### DIFF
--- a/docs/code_contribution_guidelines.md
+++ b/docs/code_contribution_guidelines.md
@@ -316,6 +316,9 @@ Examples of common patterns w.r.t commit structures within the project:
     be a single commit which adds the new functionality, with follow up
     induvidual commits that begin to intergrate the functionality within the
     codebase.
+  * If a PR only fixes a trivial issue, such as updating documentations on a
+    small scale, fix typo, or any changes that do not modify the code, the
+    commit message should end with `[skip ci]` to skip the CI checks.
 
 ## Code Spacing 
 


### PR DESCRIPTION
This PR tries to skip the release note check for trivial fix. This is accomplished in the github actions by checking the git message.