### PR TITLE
itest: fix commit deadline for neutrino backend

### DIFF
--- a/docs/release-notes/release-notes-0.14.0.md
+++ b/docs/release-notes/release-notes-0.14.0.md
@@ -114,6 +114,8 @@ you.
 
 * [Fixed context timeout when closing channels in tests](https://github.com/lightningnetwork/lnd/pull/5616).
 
+* [Fixed transaction not found in mempool flake in commitment deadline itest](https://github.com/lightningnetwork/lnd/pull/5615).
+
 * [Fixed a missing import and git tag in the healthcheck package](https://github.com/lightningnetwork/lnd/pull/5582).
 
 * [Fixed a data race in payment unit test](https://github.com/lightningnetwork/lnd/pull/5573).

--- a/lntest/itest/assertions.go
+++ b/lntest/itest/assertions.go
@@ -1613,8 +1613,9 @@ func assertActiveHtlcs(nodes []*lntest.HarnessNode, payHashes ...[]byte) error {
 
 			// Channel should have exactly the payHashes active.
 			if len(payHashes) != len(htlcHashes) {
-				return fmt.Errorf("node %x had %v htlcs active, "+
-					"expected %v", node.PubKey[:],
+				return fmt.Errorf("node [%s:%x] had %v "+
+					"htlcs active, expected %v",
+					node.Cfg.Name, node.PubKey[:],
 					len(htlcHashes), len(payHashes))
 			}
 
@@ -1624,9 +1625,9 @@ func assertActiveHtlcs(nodes []*lntest.HarnessNode, payHashes ...[]byte) error {
 				if _, ok := htlcHashes[h]; ok {
 					continue
 				}
-				return fmt.Errorf("node %x didn't have the "+
-					"payHash %v active", node.PubKey[:],
-					h)
+				return fmt.Errorf("node [%s:%x] didn't have: "+
+					"the payHash %v active", node.Cfg.Name,
+					node.PubKey[:], h)
 			}
 		}
 	}

--- a/lntest/itest/lnd_channel_force_close.go
+++ b/lntest/itest/lnd_channel_force_close.go
@@ -81,6 +81,13 @@ func testCommitmentTransactionDeadline(net *lntest.NetworkHarness,
 
 		// Send some coins to the node.
 		net.SendCoins(ctx, t.t, btcutil.SatoshiPerBitcoin, node)
+
+		// For neutrino backend, we need one additional UTXO to create
+		// the sweeping tx for the remote anchor.
+		if net.BackendCfg.Name() == lntest.NeutrinoBackendName {
+			net.SendCoins(ctx, t.t, btcutil.SatoshiPerBitcoin, node)
+		}
+
 		return node
 	}
 

--- a/lntest/itest/lnd_channel_force_close.go
+++ b/lntest/itest/lnd_channel_force_close.go
@@ -151,8 +151,7 @@ func testCommitmentTransactionDeadline(net *lntest.NetworkHarness,
 			t.t, checkNumWaitingCloseChannels(pendingChanResp, 1),
 		)
 
-		// We should see only one sweep transaction because the anchor
-		// sweep is skipped.
+		// Check our sweep transactions can be found in mempool.
 		sweepTxns, err := getNTxsFromMempool(
 			net.Miner.Client,
 			expectedSweepTxNum, minerMempoolTimeout,


### PR DESCRIPTION
The anchor sweeping tx consumes a UTXO from the closing tx (local/remote anchor output), which is an unconfirmed output when the sweep tx is created. ~~IIRC, neutrino doesn't support spending from an unconfirmed output, so this test is skipped.~~

Regarding the mempool, we should have 2 transactions there, the closing tx and the sweeping tx. Sometimes we do create yet another sweeping tx (one for local and one for remote), and it will be discarded as an orphan in `btcd` backend.

Partially fixes #5495 