### PR TITLE
itest: fix close channel context timeout

### DIFF
--- a/docs/release-notes/release-notes-0.14.0.md
+++ b/docs/release-notes/release-notes-0.14.0.md
@@ -102,6 +102,8 @@ you.
 
 * [Flake fix in async bidirectional payment test](https://github.com/lightningnetwork/lnd/pull/5607).
 
+* [Fixed context timeout when closing channels in tests](https://github.com/lightningnetwork/lnd/pull/5616).
+
 * [Fixed a missing import and git tag in the healthcheck package](https://github.com/lightningnetwork/lnd/pull/5582).
 
 * [Fixed a data race in payment unit test](https://github.com/lightningnetwork/lnd/pull/5573).

--- a/lntest/itest/assertions.go
+++ b/lntest/itest/assertions.go
@@ -194,20 +194,21 @@ func waitForGraphSync(t *harnessTest, node *lntest.HarnessNode) {
 // NOTE: This method assumes that the provided funding point is confirmed
 // on-chain AND that the edge exists in the node's channel graph. If the funding
 // transactions was reorged out at some point, use closeReorgedChannelAndAssert.
-func closeChannelAndAssert(ctx context.Context, t *harnessTest,
-	net *lntest.NetworkHarness, node *lntest.HarnessNode,
-	fundingChanPoint *lnrpc.ChannelPoint, force bool) *chainhash.Hash {
+func closeChannelAndAssert(t *harnessTest, net *lntest.NetworkHarness,
+	node *lntest.HarnessNode, fundingChanPoint *lnrpc.ChannelPoint,
+	force bool) *chainhash.Hash {
 
 	return closeChannelAndAssertType(
-		ctx, t, net, node, fundingChanPoint, false, force,
+		t, net, node, fundingChanPoint, false, force,
 	)
 }
 
-func closeChannelAndAssertType(ctxb context.Context, t *harnessTest,
+func closeChannelAndAssertType(t *harnessTest,
 	net *lntest.NetworkHarness, node *lntest.HarnessNode,
 	fundingChanPoint *lnrpc.ChannelPoint,
 	anchors, force bool) *chainhash.Hash {
 
+	ctxb := context.Background()
 	ctxt, cancel := context.WithTimeout(ctxb, channelCloseTimeout)
 	defer cancel()
 

--- a/lntest/itest/lnd_channel_backup_test.go
+++ b/lntest/itest/lnd_channel_backup_test.go
@@ -602,10 +602,7 @@ func testChannelBackupUpdates(net *lntest.NetworkHarness, t *harnessTest) {
 
 		chanPoint := chanPoints[i]
 
-		ctxt, _ := context.WithTimeout(ctxb, channelCloseTimeout)
-		closeChannelAndAssert(
-			ctxt, t, net, net.Alice, chanPoint, forceClose,
-		)
+		closeChannelAndAssert(t, net, net.Alice, chanPoint, forceClose)
 
 		// If we force closed the channel, then we'll mine enough
 		// blocks to ensure all outputs have been swept.
@@ -779,10 +776,7 @@ func testExportChannelBackup(net *lntest.NetworkHarness, t *harnessTest) {
 	// shouldn't be able to find that channel as a backup still. We should
 	// also have one less single written to disk.
 	for i, chanPoint := range chanPoints {
-		ctxt, _ = context.WithTimeout(ctxb, channelCloseTimeout)
-		closeChannelAndAssert(
-			ctxt, t, net, net.Alice, chanPoint, false,
-		)
+		closeChannelAndAssert(t, net, net.Alice, chanPoint, false)
 
 		assertNumSingleBackups(len(chanPoints) - i - 1)
 

--- a/lntest/itest/lnd_channel_balance_test.go
+++ b/lntest/itest/lnd_channel_balance_test.go
@@ -90,8 +90,7 @@ func testChannelBalance(net *lntest.NetworkHarness, t *harnessTest) {
 
 	// Finally close the channel between Alice and Bob, asserting that the
 	// channel has been properly closed on-chain.
-	ctxt, _ = context.WithTimeout(ctxb, channelCloseTimeout)
-	closeChannelAndAssert(ctxt, t, net, net.Alice, chanPoint, false)
+	closeChannelAndAssert(t, net, net.Alice, chanPoint, false)
 }
 
 // testChannelUnsettledBalance will test that the UnsettledBalance field
@@ -273,8 +272,7 @@ func testChannelUnsettledBalance(net *lntest.NetworkHarness, t *harnessTest) {
 	checkChannelBalance(carol, 0, aliceLocal, numInvoices*payAmt, 0)
 
 	// Force and assert the channel closure.
-	ctxt, _ = context.WithTimeout(ctxb, channelCloseTimeout)
-	closeChannelAndAssert(ctxt, t, net, net.Alice, chanPointAlice, true)
+	closeChannelAndAssert(t, net, net.Alice, chanPointAlice, true)
 
 	// Cleanup by mining the force close and sweep transaction.
 	cleanupForceClose(t, net, net.Alice, chanPointAlice)

--- a/lntest/itest/lnd_channel_graph_test.go
+++ b/lntest/itest/lnd_channel_graph_test.go
@@ -402,8 +402,7 @@ func testUnannouncedChannels(net *lntest.NetworkHarness, t *harnessTest) {
 	}
 
 	// Close the channel used during the test.
-	ctxt, _ = context.WithTimeout(ctxb, channelCloseTimeout)
-	closeChannelAndAssert(ctxt, t, net, net.Alice, fundingChanPoint, false)
+	closeChannelAndAssert(t, net, net.Alice, fundingChanPoint, false)
 }
 
 func testGraphTopologyNotifications(net *lntest.NetworkHarness, t *harnessTest) {
@@ -543,8 +542,7 @@ func testGraphTopologyNtfns(net *lntest.NetworkHarness, t *harnessTest, pinned b
 
 	// Now we'll test that updates are properly sent after channels are closed
 	// within the network.
-	ctxt, _ = context.WithTimeout(ctxb, channelCloseTimeout)
-	closeChannelAndAssert(ctxt, t, net, alice, chanPoint, false)
+	closeChannelAndAssert(t, net, alice, chanPoint, false)
 
 	// Now that the channel has been closed, we should receive a
 	// notification indicating so.
@@ -675,8 +673,7 @@ out:
 	}
 
 	// Close the channel between Bob and Carol.
-	ctxt, _ = context.WithTimeout(ctxb, channelCloseTimeout)
-	closeChannelAndAssert(ctxt, t, net, bob, chanPoint, false)
+	closeChannelAndAssert(t, net, bob, chanPoint, false)
 }
 
 // testNodeAnnouncement ensures that when a node is started with one or more
@@ -772,6 +769,5 @@ func testNodeAnnouncement(net *lntest.NetworkHarness, t *harnessTest) {
 	)
 
 	// Close the channel between Bob and Dave.
-	ctxt, _ = context.WithTimeout(ctxb, channelCloseTimeout)
-	closeChannelAndAssert(ctxt, t, net, net.Bob, chanPoint, false)
+	closeChannelAndAssert(t, net, net.Bob, chanPoint, false)
 }

--- a/lntest/itest/lnd_channel_policy_test.go
+++ b/lntest/itest/lnd_channel_policy_test.go
@@ -510,12 +510,9 @@ func testUpdateChannelPolicy(net *lntest.NetworkHarness, t *harnessTest) {
 	}
 
 	// Close the channels.
-	ctxt, _ = context.WithTimeout(ctxb, channelCloseTimeout)
-	closeChannelAndAssert(ctxt, t, net, net.Alice, chanPoint, false)
-	ctxt, _ = context.WithTimeout(ctxb, channelCloseTimeout)
-	closeChannelAndAssert(ctxt, t, net, net.Bob, chanPoint2, false)
-	ctxt, _ = context.WithTimeout(ctxb, channelCloseTimeout)
-	closeChannelAndAssert(ctxt, t, net, net.Alice, chanPoint3, false)
+	closeChannelAndAssert(t, net, net.Alice, chanPoint, false)
+	closeChannelAndAssert(t, net, net.Bob, chanPoint2, false)
+	closeChannelAndAssert(t, net, net.Alice, chanPoint3, false)
 }
 
 // updateChannelPolicy updates the channel policy of node to the

--- a/lntest/itest/lnd_forward_interceptor_test.go
+++ b/lntest/itest/lnd_forward_interceptor_test.go
@@ -368,10 +368,7 @@ func (c *interceptorTestContext) openChannel(from, to *lntest.HarnessNode,
 	)
 
 	c.closeChannelFuncs = append(c.closeChannelFuncs, func() {
-		ctxt, _ := context.WithTimeout(ctxb, channelCloseTimeout)
-		closeChannelAndAssert(
-			ctxt, c.t, c.net, from, chanPoint, false,
-		)
+		closeChannelAndAssert(c.t, c.net, from, chanPoint, false)
 	})
 
 	c.networkChans = append(c.networkChans, chanPoint)

--- a/lntest/itest/lnd_funding_test.go
+++ b/lntest/itest/lnd_funding_test.go
@@ -245,8 +245,7 @@ func basicChannelFundingTest(t *harnessTest, net *lntest.NetworkHarness,
 		// Finally, immediately close the channel. This function will
 		// also block until the channel is closed and will additionally
 		// assert the relevant channel closing post conditions.
-		ctxt, _ := context.WithTimeout(ctxb, channelCloseTimeout)
-		closeChannelAndAssert(ctxt, t, net, alice, chanPoint, false)
+		closeChannelAndAssert(t, net, alice, chanPoint, false)
 	}
 
 	return aliceChannel.Channels[0], bobChannel.Channels[0], closeChan, nil
@@ -373,8 +372,7 @@ func testUnconfirmedChannelFunding(net *lntest.NetworkHarness, t *harnessTest) {
 	checkChannelBalance(net.Alice, pushAmt, carolLocalBalance, 0, 0)
 
 	// Now that we're done with the test, the channel can be closed.
-	ctxt, _ = context.WithTimeout(ctxb, channelCloseTimeout)
-	closeChannelAndAssert(ctxt, t, net, carol, chanPoint, false)
+	closeChannelAndAssert(t, net, carol, chanPoint, false)
 }
 
 // testexternalfundingchanpoint tests that we're able to carry out a normal
@@ -477,8 +475,7 @@ func testExternalFundingChanPoint(net *lntest.NetworkHarness, t *harnessTest) {
 
 	// Next we'll try but this time with Dave (the responder) as the
 	// initiator. This time the channel should be closed as normal.
-	ctxt, _ = context.WithTimeout(ctxb, channelCloseTimeout)
-	closeChannelAndAssert(ctxt, t, net, dave, chanPoint2, false)
+	closeChannelAndAssert(t, net, dave, chanPoint2, false)
 
 	// As a last step, we check if we still have the pending channel hanging
 	// around because we never published the funding TX.
@@ -659,8 +656,7 @@ func testChannelFundingPersistence(net *lntest.NetworkHarness, t *harnessTest) {
 		},
 		OutputIndex: pendingUpdate.OutputIndex,
 	}
-	ctxt, _ = context.WithTimeout(ctxb, channelCloseTimeout)
-	closeChannelAndAssert(ctxt, t, net, net.Alice, chanPoint, false)
+	closeChannelAndAssert(t, net, net.Alice, chanPoint, false)
 }
 
 // deriveFundingShim creates a channel funding shim by deriving the necessary

--- a/lntest/itest/lnd_hold_invoice_force_test.go
+++ b/lntest/itest/lnd_hold_invoice_force_test.go
@@ -141,6 +141,5 @@ func testHoldInvoiceForceClose(net *lntest.NetworkHarness, t *harnessTest) {
 	require.NoError(t.t, err, "expected canceled invoice")
 
 	// Clean up the channel.
-	ctxt, _ = context.WithTimeout(ctxb, channelCloseTimeout)
-	closeChannelAndAssert(ctxt, t, net, net.Alice, chanPoint, false)
+	closeChannelAndAssert(t, net, net.Alice, chanPoint, false)
 }

--- a/lntest/itest/lnd_max_channel_size_test.go
+++ b/lntest/itest/lnd_max_channel_size_test.go
@@ -96,6 +96,6 @@ func testMaxChannelSize(net *lntest.NetworkHarness, t *harnessTest) {
 			Amt: chanAmt,
 		},
 	)
-	closeChannelAndAssert(ctxb, t, net, wumboNode, chanPoint, false)
+	closeChannelAndAssert(t, net, wumboNode, chanPoint, false)
 
 }

--- a/lntest/itest/lnd_max_htlcs_test.go
+++ b/lntest/itest/lnd_max_htlcs_test.go
@@ -126,8 +126,7 @@ func testMaxHtlcPathfind(net *lntest.NetworkHarness, t *harnessTest) {
 	}, 0)
 	require.NoError(t.t, err, "expected all htlcs canceled")
 
-	ctxt, _ = context.WithTimeout(ctxb, channelCloseTimeout)
-	closeChannelAndAssert(ctxt, t, net, net.Alice, chanPoint, false)
+	closeChannelAndAssert(t, net, net.Alice, chanPoint, false)
 }
 
 type holdSubscription struct {

--- a/lntest/itest/lnd_misc_test.go
+++ b/lntest/itest/lnd_misc_test.go
@@ -153,8 +153,7 @@ func testDisconnectingTargetPeer(net *lntest.NetworkHarness, t *harnessTest) {
 		OutputIndex: pendingUpdate.OutputIndex,
 	}
 
-	ctxt, _ = context.WithTimeout(ctxb, channelCloseTimeout)
-	closeChannelAndAssert(ctxt, t, net, alice, chanPoint, true)
+	closeChannelAndAssert(t, net, alice, chanPoint, true)
 
 	// Disconnect Alice-peer from Bob-peer without getting error about
 	// existing channels.
@@ -351,8 +350,7 @@ func testSphinxReplayPersistence(net *lntest.NetworkHarness, t *harnessTest) {
 		t.Fatalf(err.Error())
 	}
 
-	ctxt, _ = context.WithTimeout(ctxb, channelCloseTimeout)
-	closeChannelAndAssert(ctxt, t, net, carol, chanPoint, true)
+	closeChannelAndAssert(t, net, carol, chanPoint, true)
 
 	// Cleanup by mining the force close and sweep transaction.
 	cleanupForceClose(t, net, carol, chanPoint)
@@ -605,8 +603,7 @@ func testMaxPendingChannels(net *lntest.NetworkHarness, t *harnessTest) {
 	// Next, close the channel between Alice and Carol, asserting that the
 	// channel has been properly closed on-chain.
 	for _, chanPoint := range chanPoints {
-		ctxt, _ = context.WithTimeout(ctxb, channelCloseTimeout)
-		closeChannelAndAssert(ctxt, t, net, net.Alice, chanPoint, false)
+		closeChannelAndAssert(t, net, net.Alice, chanPoint, false)
 	}
 }
 
@@ -760,15 +757,13 @@ func testGarbageCollectLinkNodes(net *lntest.NetworkHarness, t *harnessTest) {
 	// Now, we'll close the channel between Alice and Bob and ensure there
 	// is no reconnection logic between the both once the channel is fully
 	// closed.
-	ctxt, _ = context.WithTimeout(ctxb, channelCloseTimeout)
-	closeChannelAndAssert(ctxt, t, net, net.Alice, coopChanPoint, false)
+	closeChannelAndAssert(t, net, net.Alice, coopChanPoint, false)
 
 	testReconnection(net.Bob)
 
 	// We'll do the same with Alice and Carol, but this time we'll force
 	// close the channel instead.
-	ctxt, _ = context.WithTimeout(ctxb, channelCloseTimeout)
-	closeChannelAndAssert(ctxt, t, net, net.Alice, forceCloseChanPoint, true)
+	closeChannelAndAssert(t, net, net.Alice, forceCloseChanPoint, true)
 
 	// Cleanup by mining the force close and sweep transaction.
 	cleanupForceClose(t, net, net.Alice, forceCloseChanPoint)
@@ -843,8 +838,7 @@ func testGarbageCollectLinkNodes(net *lntest.NetworkHarness, t *harnessTest) {
 	}
 
 	// Now that the test is done, we can also close the persistent link.
-	ctxt, _ = context.WithTimeout(ctxb, channelCloseTimeout)
-	closeChannelAndAssert(ctxt, t, net, net.Alice, persistentChanPoint, false)
+	closeChannelAndAssert(t, net, net.Alice, persistentChanPoint, false)
 }
 
 // testDataLossProtection tests that if one of the nodes in a channel
@@ -1076,8 +1070,7 @@ func testDataLossProtection(net *lntest.NetworkHarness, t *harnessTest) {
 	carolStartingBalance = carolBalResp.ConfirmedBalance
 
 	// Now let Carol force close the channel while Dave is offline.
-	ctxt, _ = context.WithTimeout(ctxb, channelCloseTimeout)
-	closeChannelAndAssert(ctxt, t, net, carol, chanPoint2, true)
+	closeChannelAndAssert(t, net, carol, chanPoint2, true)
 
 	// Wait for the channel to be marked pending force close.
 	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
@@ -1299,10 +1292,8 @@ func testRejectHTLC(net *lntest.NetworkHarness, t *harnessTest) {
 	assertLastHTLCError(t, net.Alice, lnrpc.Failure_CHANNEL_DISABLED)
 
 	// Close all channels.
-	ctxt, _ = context.WithTimeout(ctxb, channelCloseTimeout)
-	closeChannelAndAssert(ctxt, t, net, net.Alice, chanPointAlice, false)
-	ctxt, _ = context.WithTimeout(ctxb, channelCloseTimeout)
-	closeChannelAndAssert(ctxt, t, net, carol, chanPointCarol, false)
+	closeChannelAndAssert(t, net, net.Alice, chanPointAlice, false)
+	closeChannelAndAssert(t, net, carol, chanPointCarol, false)
 }
 
 func testNodeSignVerify(net *lntest.NetworkHarness, t *harnessTest) {
@@ -1377,8 +1368,7 @@ func testNodeSignVerify(net *lntest.NetworkHarness, t *harnessTest) {
 	}
 
 	// Close the channel between alice and bob.
-	ctxt, _ = context.WithTimeout(ctxb, channelCloseTimeout)
-	closeChannelAndAssert(ctxt, t, net, net.Alice, aliceBobCh, false)
+	closeChannelAndAssert(t, net, net.Alice, aliceBobCh, false)
 }
 
 // testSendUpdateDisableChannel ensures that a channel update with the disable
@@ -1734,8 +1724,7 @@ func testAbandonChannel(net *lntest.NetworkHarness, t *harnessTest) {
 	// Now that we're done with the test, the channel can be closed. This
 	// is necessary to avoid unexpected outcomes of other tests that use
 	// Bob's lnd instance.
-	ctxt, _ = context.WithTimeout(ctxb, channelCloseTimeout)
-	closeChannelAndAssert(ctxt, t, net, net.Bob, chanPoint, true)
+	closeChannelAndAssert(t, net, net.Bob, chanPoint, true)
 
 	// Cleanup by mining the force close and sweep transaction.
 	cleanupForceClose(t, net, net.Bob, chanPoint)

--- a/lntest/itest/lnd_mpp_test.go
+++ b/lntest/itest/lnd_mpp_test.go
@@ -305,10 +305,7 @@ func (c *mppTestContext) openChannel(from, to *lntest.HarnessNode, chanSize btcu
 	)
 
 	c.closeChannelFuncs = append(c.closeChannelFuncs, func() {
-		ctxt, _ := context.WithTimeout(ctxb, channelCloseTimeout)
-		closeChannelAndAssert(
-			ctxt, c.t, c.net, from, chanPoint, false,
-		)
+		closeChannelAndAssert(c.t, c.net, from, chanPoint, false)
 	})
 
 	c.networkChans = append(c.networkChans, chanPoint)

--- a/lntest/itest/lnd_multi-hop-error-propagation_test.go
+++ b/lntest/itest/lnd_multi-hop-error-propagation_test.go
@@ -401,12 +401,10 @@ out:
 	// Finally, immediately close the channel. This function will also
 	// block until the channel is closed and will additionally assert the
 	// relevant channel closing post conditions.
-	ctxt, _ = context.WithTimeout(ctxb, channelCloseTimeout)
-	closeChannelAndAssert(ctxt, t, net, net.Alice, chanPointAlice, false)
+	closeChannelAndAssert(t, net, net.Alice, chanPointAlice, false)
 
 	// Force close Bob's final channel.
-	ctxt, _ = context.WithTimeout(ctxb, channelCloseTimeout)
-	closeChannelAndAssert(ctxt, t, net, net.Bob, chanPointBob, true)
+	closeChannelAndAssert(t, net, net.Bob, chanPointBob, true)
 
 	// Cleanup by mining the force close and sweep transaction.
 	cleanupForceClose(t, net, net.Bob, chanPointBob)

--- a/lntest/itest/lnd_multi-hop-payments_test.go
+++ b/lntest/itest/lnd_multi-hop-payments_test.go
@@ -329,12 +329,9 @@ func testMultiHopPayments(net *lntest.NetworkHarness, t *harnessTest) {
 		t, 0, 0, numPayments, routerrpc.HtlcEvent_RECEIVE, bobEvents,
 	)
 
-	ctxt, _ = context.WithTimeout(ctxb, channelCloseTimeout)
-	closeChannelAndAssert(ctxt, t, net, net.Alice, chanPointAlice, false)
-	ctxt, _ = context.WithTimeout(ctxb, channelCloseTimeout)
-	closeChannelAndAssert(ctxt, t, net, dave, chanPointDave, false)
-	ctxt, _ = context.WithTimeout(ctxb, channelCloseTimeout)
-	closeChannelAndAssert(ctxt, t, net, carol, chanPointCarol, false)
+	closeChannelAndAssert(t, net, net.Alice, chanPointAlice, false)
+	closeChannelAndAssert(t, net, dave, chanPointDave, false)
+	closeChannelAndAssert(t, net, carol, chanPointCarol, false)
 }
 
 // assertHtlcEvents consumes events from a client and ensures that they are of

--- a/lntest/itest/lnd_multi-hop_htlc_aggregation_test.go
+++ b/lntest/itest/lnd_multi-hop_htlc_aggregation_test.go
@@ -428,8 +428,5 @@ func testMultiHopHtlcAggregation(net *lntest.NetworkHarness, t *harnessTest,
 	assertNodeNumChannels(t, carol, 0)
 
 	// Coop close channel, expect no anchors.
-	ctxt, _ = context.WithTimeout(ctxb, channelCloseTimeout)
-	closeChannelAndAssertType(
-		ctxt, t, net, alice, aliceChanPoint, false, false,
-	)
+	closeChannelAndAssertType(t, net, alice, aliceChanPoint, false, false)
 }

--- a/lntest/itest/lnd_multi-hop_htlc_local_chain_claim_test.go
+++ b/lntest/itest/lnd_multi-hop_htlc_local_chain_claim_test.go
@@ -85,9 +85,8 @@ func testMultiHopHtlcLocalChainClaim(net *lntest.NetworkHarness, t *harnessTest,
 
 	// At this point, Bob decides that he wants to exit the channel
 	// immediately, so he force closes his commitment transaction.
-	ctxt, _ = context.WithTimeout(ctxb, channelCloseTimeout)
 	bobForceClose := closeChannelAndAssertType(
-		ctxt, t, net, bob, aliceChanPoint, c == commitTypeAnchors, true,
+		t, net, bob, aliceChanPoint, c == commitTypeAnchors, true,
 	)
 
 	// Alice will sweep her commitment output immediately. If there are

--- a/lntest/itest/lnd_multi-hop_htlc_local_timeout_test.go
+++ b/lntest/itest/lnd_multi-hop_htlc_local_timeout_test.go
@@ -228,8 +228,5 @@ func testMultiHopHtlcLocalTimeout(net *lntest.NetworkHarness, t *harnessTest,
 	require.NoError(t.t, err)
 
 	// Coop close channel, expect no anchors.
-	ctxt, _ = context.WithTimeout(ctxb, channelCloseTimeout)
-	closeChannelAndAssertType(
-		ctxt, t, net, alice, aliceChanPoint, false, false,
-	)
+	closeChannelAndAssertType(t, net, alice, aliceChanPoint, false, false)
 }

--- a/lntest/itest/lnd_multi-hop_htlc_receiver_chain_claim_test.go
+++ b/lntest/itest/lnd_multi-hop_htlc_receiver_chain_claim_test.go
@@ -233,9 +233,5 @@ func testMultiHopReceiverChainClaim(net *lntest.NetworkHarness, t *harnessTest,
 
 	// We'll close out the channel between Alice and Bob, then shutdown
 	// carol to conclude the test.
-	ctxt, _ = context.WithTimeout(ctxb, channelCloseTimeout)
-	closeChannelAndAssertType(
-		ctxt, t, net, alice, aliceChanPoint,
-		false, false,
-	)
+	closeChannelAndAssertType(t, net, alice, aliceChanPoint, false, false)
 }

--- a/lntest/itest/lnd_multi-hop_htlc_remote_chain_claim_test.go
+++ b/lntest/itest/lnd_multi-hop_htlc_remote_chain_claim_test.go
@@ -85,10 +85,8 @@ func testMultiHopHtlcRemoteChainClaim(net *lntest.NetworkHarness, t *harnessTest
 	// Next, Alice decides that she wants to exit the channel, so she'll
 	// immediately force close the channel by broadcast her commitment
 	// transaction.
-	ctxt, _ = context.WithTimeout(ctxb, channelCloseTimeout)
 	aliceForceClose := closeChannelAndAssertType(
-		ctxt, t, net, alice, aliceChanPoint, c == commitTypeAnchors,
-		true,
+		t, net, alice, aliceChanPoint, c == commitTypeAnchors, true,
 	)
 
 	// Wait for the channel to be marked pending force close.

--- a/lntest/itest/lnd_multi-hop_local_force_close_on_chain_htlc_timeout_test.go
+++ b/lntest/itest/lnd_multi-hop_local_force_close_on_chain_htlc_timeout_test.go
@@ -71,14 +71,13 @@ func testMultiHopLocalForceCloseOnChainHtlcTimeout(net *lntest.NetworkHarness,
 	// Now that all parties have the HTLC locked in, we'll immediately
 	// force close the Bob -> Carol channel. This should trigger contract
 	// resolution mode for both of them.
-	ctxt, _ := context.WithTimeout(ctxb, channelCloseTimeout)
 	closeChannelAndAssertType(
-		ctxt, t, net, bob, bobChanPoint, c == commitTypeAnchors, true,
+		t, net, bob, bobChanPoint, c == commitTypeAnchors, true,
 	)
 
 	// At this point, Bob should have a pending force close channel as he
 	// just went to chain.
-	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
+	ctxt, _ := context.WithTimeout(ctxb, defaultTimeout)
 	err = waitForNumChannelPendingForceClose(
 		ctxt, bob, 1, func(c *lnrpcForceCloseChannel) error {
 			if c.LimboBalance == 0 {
@@ -195,8 +194,5 @@ func testMultiHopLocalForceCloseOnChainHtlcTimeout(net *lntest.NetworkHarness,
 	require.NoError(t.t, err)
 
 	// Coop close, no anchors.
-	ctxt, _ = context.WithTimeout(ctxb, channelCloseTimeout)
-	closeChannelAndAssertType(
-		ctxt, t, net, alice, aliceChanPoint, false, false,
-	)
+	closeChannelAndAssertType(t, net, alice, aliceChanPoint, false, false)
 }

--- a/lntest/itest/lnd_multi-hop_remote_force_close_on_chain_htlc_timeout_test.go
+++ b/lntest/itest/lnd_multi-hop_remote_force_close_on_chain_htlc_timeout_test.go
@@ -83,10 +83,8 @@ func testMultiHopRemoteForceCloseOnChainHtlcTimeout(net *lntest.NetworkHarness,
 	// transaction. This will let us exercise that Bob is able to sweep the
 	// expired HTLC on Carol's version of the commitment transaction. If
 	// Carol has an anchor, it will be swept too.
-	ctxt, _ = context.WithTimeout(ctxb, channelCloseTimeout)
 	closeChannelAndAssertType(
-		ctxt, t, net, carol, bobChanPoint, c == commitTypeAnchors,
-		true,
+		t, net, carol, bobChanPoint, c == commitTypeAnchors, true,
 	)
 
 	// At this point, Bob should have a pending force close channel as
@@ -185,10 +183,7 @@ func testMultiHopRemoteForceCloseOnChainHtlcTimeout(net *lntest.NetworkHarness,
 	// We'll close out the test by closing the channel from Alice to Bob,
 	// and then shutting down the new node we created as its no longer
 	// needed. Coop close, no anchors.
-	ctxt, _ = context.WithTimeout(ctxb, channelCloseTimeout)
-	closeChannelAndAssertType(
-		ctxt, t, net, alice, aliceChanPoint, false, false,
-	)
+	closeChannelAndAssertType(t, net, alice, aliceChanPoint, false, false)
 }
 
 // assertOnChainInvoiceState asserts that we have the correct state for a hold

--- a/lntest/itest/lnd_onchain_test.go
+++ b/lntest/itest/lnd_onchain_test.go
@@ -343,7 +343,7 @@ func testAnchorReservedValue(net *lntest.NetworkHarness, t *harnessTest) {
 	// Alice closes channel, should now be allowed to send everything to an
 	// external address.
 	for _, chanPoint := range chanPoints {
-		closeChannelAndAssert(ctxt, t, net, alice, chanPoint, false)
+		closeChannelAndAssert(t, net, alice, chanPoint, false)
 	}
 
 	newBalance := waitForConfirmedBalance()

--- a/lntest/itest/lnd_open_channel_test.go
+++ b/lntest/itest/lnd_open_channel_test.go
@@ -349,11 +349,9 @@ func testBasicChannelCreationAndUpdates(net *lntest.NetworkHarness, t *harnessTe
 	// Close the channels between Alice and Bob, asserting that the channels
 	// have been properly closed on-chain.
 	for i, chanPoint := range chanPoints {
-		ctx, _ := context.WithTimeout(context.Background(), defaultTimeout)
-
 		// Force close the first of the two channels.
 		force := i%2 == 0
-		closeChannelAndAssert(ctx, t, net, net.Alice, chanPoint, force)
+		closeChannelAndAssert(t, net, net.Alice, chanPoint, force)
 		if force {
 			cleanupForceClose(t, net, net.Alice, chanPoint)
 		}

--- a/lntest/itest/lnd_payment_test.go
+++ b/lntest/itest/lnd_payment_test.go
@@ -159,8 +159,7 @@ func testListPayments(net *lntest.NetworkHarness, t *harnessTest) {
 			len(paymentsRespInit.Payments), 0)
 	}
 
-	ctxt, _ = context.WithTimeout(ctxb, channelCloseTimeout)
-	closeChannelAndAssert(ctxt, t, net, net.Alice, chanPoint, false)
+	closeChannelAndAssert(t, net, net.Alice, chanPoint, false)
 }
 
 // testPaymentFollowingChannelOpen tests that the channel transition from
@@ -250,9 +249,7 @@ func testPaymentFollowingChannelOpen(net *lntest.NetworkHarness, t *harnessTest)
 		},
 		OutputIndex: pendingUpdate.OutputIndex,
 	}
-	ctxt, cancel = context.WithTimeout(ctxb, channelCloseTimeout)
-	defer cancel()
-	closeChannelAndAssert(ctxt, t, net, net.Alice, chanPoint, false)
+	closeChannelAndAssert(t, net, net.Alice, chanPoint, false)
 }
 
 // testAsyncPayments tests the performance of the async payments.
@@ -417,8 +414,7 @@ func testAsyncPayments(net *lntest.NetworkHarness, t *harnessTest) {
 	// Finally, immediately close the channel. This function will also
 	// block until the channel is closed and will additionally assert the
 	// relevant channel closing post conditions.
-	ctxt, _ = context.WithTimeout(ctxb, channelCloseTimeout)
-	closeChannelAndAssert(ctxt, t, net, net.Alice, chanPoint, false)
+	closeChannelAndAssert(t, net, net.Alice, chanPoint, false)
 }
 
 // testBidirectionalAsyncPayments tests that nodes are able to send the
@@ -613,8 +609,7 @@ func testBidirectionalAsyncPayments(net *lntest.NetworkHarness, t *harnessTest) 
 	// Finally, immediately close the channel. This function will also
 	// block until the channel is closed and will additionally assert the
 	// relevant channel closing post conditions.
-	ctxt, _ = context.WithTimeout(ctxb, channelCloseTimeout)
-	closeChannelAndAssert(ctxt, t, net, net.Alice, chanPoint, false)
+	closeChannelAndAssert(t, net, net.Alice, chanPoint, false)
 }
 
 func testInvoiceSubscriptions(net *lntest.NetworkHarness, t *harnessTest) {
@@ -846,6 +841,5 @@ func testInvoiceSubscriptions(net *lntest.NetworkHarness, t *harnessTest) {
 		t.Fatalf("not all invoices settled")
 	}
 
-	ctxt, _ = context.WithTimeout(ctxb, channelCloseTimeout)
-	closeChannelAndAssert(ctxt, t, net, net.Alice, chanPoint, false)
+	closeChannelAndAssert(t, net, net.Alice, chanPoint, false)
 }

--- a/lntest/itest/lnd_psbt_test.go
+++ b/lntest/itest/lnd_psbt_test.go
@@ -246,9 +246,7 @@ func testPsbtChanFunding(net *lntest.NetworkHarness, t *harnessTest) {
 	// Dave. This function will also block until the channel is closed and
 	// will additionally assert the relevant channel closing post
 	// conditions.
-	ctxt, cancel = context.WithTimeout(ctxb, channelCloseTimeout)
-	defer cancel()
-	closeChannelAndAssert(ctxt, t, net, carol, chanPoint, false)
+	closeChannelAndAssert(t, net, carol, chanPoint, false)
 }
 
 // openChannelPsbt attempts to open a channel between srcNode and destNode with

--- a/lntest/itest/lnd_routing_test.go
+++ b/lntest/itest/lnd_routing_test.go
@@ -429,8 +429,7 @@ func testSingleHopSendToRouteCase(net *lntest.NetworkHarness, t *harnessTest,
 	assertAmountPaid(t, "Carol(local) => Dave(remote)", carol,
 		carolFundPoint, amountPaid, int64(0))
 
-	ctxt, _ = context.WithTimeout(ctxb, channelCloseTimeout)
-	closeChannelAndAssert(ctxt, t, net, carol, chanPointCarol, false)
+	closeChannelAndAssert(t, net, carol, chanPointCarol, false)
 }
 
 // testMultiHopSendToRoute tests that payments are properly processed
@@ -606,10 +605,8 @@ func testMultiHopSendToRoute(net *lntest.NetworkHarness, t *harnessTest) {
 	assertAmountPaid(t, "Alice(local) => Bob(remote)", net.Alice,
 		aliceFundPoint, amountPaid+(baseFee*numPayments), int64(0))
 
-	ctxt, _ = context.WithTimeout(ctxb, channelCloseTimeout)
-	closeChannelAndAssert(ctxt, t, net, net.Alice, chanPointAlice, false)
-	ctxt, _ = context.WithTimeout(ctxb, channelCloseTimeout)
-	closeChannelAndAssert(ctxt, t, net, carol, chanPointBob, false)
+	closeChannelAndAssert(t, net, net.Alice, chanPointAlice, false)
+	closeChannelAndAssert(t, net, carol, chanPointBob, false)
 }
 
 // testSendToRouteErrorPropagation tests propagation of errors that occur
@@ -723,10 +720,8 @@ func testSendToRouteErrorPropagation(net *lntest.NetworkHarness, t *harnessTest)
 		t.Fatalf("payment stream has been closed but fake route has consumed: %v", err)
 	}
 
-	ctxt, _ = context.WithTimeout(ctxb, channelCloseTimeout)
-	closeChannelAndAssert(ctxt, t, net, net.Alice, chanPointAlice, false)
-	ctxt, _ = context.WithTimeout(ctxb, channelCloseTimeout)
-	closeChannelAndAssert(ctxt, t, net, carol, chanPointCarol, false)
+	closeChannelAndAssert(t, net, net.Alice, chanPointAlice, false)
+	closeChannelAndAssert(t, net, carol, chanPointCarol, false)
 }
 
 // testPrivateChannels tests that a private channel can be used for
@@ -1046,14 +1041,10 @@ func testPrivateChannels(net *lntest.NetworkHarness, t *harnessTest) {
 	}
 
 	// Close all channels.
-	ctxt, _ = context.WithTimeout(ctxb, channelCloseTimeout)
-	closeChannelAndAssert(ctxt, t, net, net.Alice, chanPointAlice, false)
-	ctxt, _ = context.WithTimeout(ctxb, channelCloseTimeout)
-	closeChannelAndAssert(ctxt, t, net, dave, chanPointDave, false)
-	ctxt, _ = context.WithTimeout(ctxb, channelCloseTimeout)
-	closeChannelAndAssert(ctxt, t, net, carol, chanPointCarol, false)
-	ctxt, _ = context.WithTimeout(ctxb, channelCloseTimeout)
-	closeChannelAndAssert(ctxt, t, net, carol, chanPointPrivate, false)
+	closeChannelAndAssert(t, net, net.Alice, chanPointAlice, false)
+	closeChannelAndAssert(t, net, dave, chanPointDave, false)
+	closeChannelAndAssert(t, net, carol, chanPointCarol, false)
+	closeChannelAndAssert(t, net, carol, chanPointPrivate, false)
 }
 
 // testUpdateChannelPolicyForPrivateChannel tests when a private channel
@@ -1082,9 +1073,7 @@ func testUpdateChannelPolicyForPrivateChannel(net *lntest.NetworkHarness,
 			Amt: chanAmt,
 		},
 	)
-	defer closeChannelAndAssert(
-		ctxt, t, net, net.Alice, chanPointAliceBob, false,
-	)
+	defer closeChannelAndAssert(t, net, net.Alice, chanPointAliceBob, false)
 
 	// Get Alice's funding point.
 	aliceChanTXID, err := lnrpc.GetChanPointFundingTxid(chanPointAliceBob)
@@ -1111,9 +1100,7 @@ func testUpdateChannelPolicyForPrivateChannel(net *lntest.NetworkHarness,
 			Private: true,
 		},
 	)
-	defer closeChannelAndAssert(
-		ctxt, t, net, net.Bob, chanPointBobCarol, false,
-	)
+	defer closeChannelAndAssert(t, net, net.Bob, chanPointBobCarol, false)
 
 	// Get Bob's funding point.
 	bobChanTXID, err := lnrpc.GetChanPointFundingTxid(chanPointBobCarol)
@@ -1393,19 +1380,14 @@ func testInvoiceRoutingHints(net *lntest.NetworkHarness, t *harnessTest) {
 
 	// Now that we've confirmed the routing hints were added correctly, we
 	// can close all the channels and shut down all the nodes created.
-	ctxt, _ = context.WithTimeout(ctxb, channelCloseTimeout)
-	closeChannelAndAssert(ctxt, t, net, net.Alice, chanPointBob, false)
-	ctxt, _ = context.WithTimeout(ctxb, channelCloseTimeout)
-	closeChannelAndAssert(ctxt, t, net, net.Alice, chanPointCarol, false)
-	ctxt, _ = context.WithTimeout(ctxb, channelCloseTimeout)
-	closeChannelAndAssert(ctxt, t, net, net.Bob, chanPointBobCarol, false)
-	ctxt, _ = context.WithTimeout(ctxb, channelCloseTimeout)
-	closeChannelAndAssert(ctxt, t, net, net.Alice, chanPointDave, false)
+	closeChannelAndAssert(t, net, net.Alice, chanPointBob, false)
+	closeChannelAndAssert(t, net, net.Alice, chanPointCarol, false)
+	closeChannelAndAssert(t, net, net.Bob, chanPointBobCarol, false)
+	closeChannelAndAssert(t, net, net.Alice, chanPointDave, false)
 
 	// The channel between Alice and Eve should be force closed since Eve
 	// is offline.
-	ctxt, _ = context.WithTimeout(ctxb, channelCloseTimeout)
-	closeChannelAndAssert(ctxt, t, net, net.Alice, chanPointEve, true)
+	closeChannelAndAssert(t, net, net.Alice, chanPointEve, true)
 
 	// Cleanup by mining the force close and sweep transaction.
 	cleanupForceClose(t, net, net.Alice, chanPointEve)
@@ -1609,12 +1591,9 @@ func testMultiHopOverPrivateChannels(net *lntest.NetworkHarness, t *harnessTest)
 
 	// At this point, the payment was successful. We can now close all the
 	// channels and shutdown the nodes created throughout this test.
-	ctxt, _ = context.WithTimeout(ctxb, channelCloseTimeout)
-	closeChannelAndAssert(ctxt, t, net, net.Alice, chanPointAlice, false)
-	ctxt, _ = context.WithTimeout(ctxb, channelCloseTimeout)
-	closeChannelAndAssert(ctxt, t, net, net.Bob, chanPointBob, false)
-	ctxt, _ = context.WithTimeout(ctxb, channelCloseTimeout)
-	closeChannelAndAssert(ctxt, t, net, carol, chanPointCarol, false)
+	closeChannelAndAssert(t, net, net.Alice, chanPointAlice, false)
+	closeChannelAndAssert(t, net, net.Bob, chanPointBob, false)
+	closeChannelAndAssert(t, net, carol, chanPointCarol, false)
 }
 
 // computeFee calculates the payment fee as specified in BOLT07
@@ -1800,12 +1779,9 @@ func testQueryRoutes(net *lntest.NetworkHarness, t *harnessTest) {
 
 	// We clean up the test case by closing channels that were created for
 	// the duration of the tests.
-	ctxt, _ = context.WithTimeout(ctxb, channelCloseTimeout)
-	closeChannelAndAssert(ctxt, t, net, net.Alice, chanPointAlice, false)
-	ctxt, _ = context.WithTimeout(ctxb, channelCloseTimeout)
-	closeChannelAndAssert(ctxt, t, net, net.Bob, chanPointBob, false)
-	ctxt, _ = context.WithTimeout(ctxb, channelCloseTimeout)
-	closeChannelAndAssert(ctxt, t, net, carol, chanPointCarol, false)
+	closeChannelAndAssert(t, net, net.Alice, chanPointAlice, false)
+	closeChannelAndAssert(t, net, net.Bob, chanPointBob, false)
+	closeChannelAndAssert(t, net, carol, chanPointCarol, false)
 }
 
 // testMissionControlCfg tests getting and setting of a node's mission control
@@ -2165,12 +2141,8 @@ func testRouteFeeCutoff(net *lntest.NetworkHarness, t *harnessTest) {
 
 	// Once we're done, close the channels and shut down the nodes created
 	// throughout this test.
-	ctxt, _ = context.WithTimeout(ctxb, channelCloseTimeout)
-	closeChannelAndAssert(ctxt, t, net, net.Alice, chanPointAliceBob, false)
-	ctxt, _ = context.WithTimeout(ctxb, channelCloseTimeout)
-	closeChannelAndAssert(ctxt, t, net, net.Alice, chanPointAliceCarol, false)
-	ctxt, _ = context.WithTimeout(ctxb, channelCloseTimeout)
-	closeChannelAndAssert(ctxt, t, net, net.Bob, chanPointBobDave, false)
-	ctxt, _ = context.WithTimeout(ctxb, channelCloseTimeout)
-	closeChannelAndAssert(ctxt, t, net, carol, chanPointCarolDave, false)
+	closeChannelAndAssert(t, net, net.Alice, chanPointAliceBob, false)
+	closeChannelAndAssert(t, net, net.Alice, chanPointAliceCarol, false)
+	closeChannelAndAssert(t, net, net.Bob, chanPointBobDave, false)
+	closeChannelAndAssert(t, net, carol, chanPointCarolDave, false)
 }

--- a/lntest/itest/lnd_single_hop_invoice_test.go
+++ b/lntest/itest/lnd_single_hop_invoice_test.go
@@ -243,6 +243,5 @@ func testSingleHopInvoice(net *lntest.NetworkHarness, t *harnessTest) {
 			hopHint.CltvExpiryDelta)
 	}
 
-	ctxt, _ = context.WithTimeout(ctxb, channelCloseTimeout)
-	closeChannelAndAssert(ctxt, t, net, net.Alice, chanPoint, false)
+	closeChannelAndAssert(t, net, net.Alice, chanPoint, false)
 }

--- a/lntest/itest/lnd_switch_test.go
+++ b/lntest/itest/lnd_switch_test.go
@@ -295,12 +295,9 @@ func testSwitchCircuitPersistence(net *lntest.NetworkHarness, t *harnessTest) {
 	assertAmountPaid(t, "Bob(local) => Alice(remote)", net.Bob,
 		aliceFundPoint, amountPaid+(baseFee*(numPayments+1))*2, int64(0))
 
-	ctxt, _ = context.WithTimeout(ctxb, channelCloseTimeout)
-	closeChannelAndAssert(ctxt, t, net, net.Alice, chanPointAlice, false)
-	ctxt, _ = context.WithTimeout(ctxb, channelCloseTimeout)
-	closeChannelAndAssert(ctxt, t, net, dave, chanPointDave, false)
-	ctxt, _ = context.WithTimeout(ctxb, channelCloseTimeout)
-	closeChannelAndAssert(ctxt, t, net, carol, chanPointCarol, false)
+	closeChannelAndAssert(t, net, net.Alice, chanPointAlice, false)
+	closeChannelAndAssert(t, net, dave, chanPointDave, false)
+	closeChannelAndAssert(t, net, carol, chanPointCarol, false)
 }
 
 // testSwitchOfflineDelivery constructs a set of multihop payments, and tests
@@ -615,12 +612,9 @@ func testSwitchOfflineDelivery(net *lntest.NetworkHarness, t *harnessTest) {
 	assertAmountPaid(t, "Bob(local) => Alice(remote)", net.Bob,
 		aliceFundPoint, amountPaid+(baseFee*(numPayments+1))*2, int64(0))
 
-	ctxt, _ = context.WithTimeout(ctxb, channelCloseTimeout)
-	closeChannelAndAssert(ctxt, t, net, net.Alice, chanPointAlice, false)
-	ctxt, _ = context.WithTimeout(ctxb, channelCloseTimeout)
-	closeChannelAndAssert(ctxt, t, net, dave, chanPointDave, false)
-	ctxt, _ = context.WithTimeout(ctxb, channelCloseTimeout)
-	closeChannelAndAssert(ctxt, t, net, carol, chanPointCarol, false)
+	closeChannelAndAssert(t, net, net.Alice, chanPointAlice, false)
+	closeChannelAndAssert(t, net, dave, chanPointDave, false)
+	closeChannelAndAssert(t, net, carol, chanPointCarol, false)
 }
 
 // testSwitchOfflineDeliveryPersistence constructs a set of multihop payments,
@@ -921,12 +915,9 @@ func testSwitchOfflineDeliveryPersistence(net *lntest.NetworkHarness, t *harness
 	assertAmountPaid(t, "Bob(local) => Alice(remote)", net.Bob,
 		aliceFundPoint, amountPaid+(baseFee*(numPayments+1))*2, int64(0))
 
-	ctxt, _ = context.WithTimeout(ctxb, channelCloseTimeout)
-	closeChannelAndAssert(ctxt, t, net, net.Alice, chanPointAlice, false)
-	ctxt, _ = context.WithTimeout(ctxb, channelCloseTimeout)
-	closeChannelAndAssert(ctxt, t, net, dave, chanPointDave, false)
-	ctxt, _ = context.WithTimeout(ctxb, channelCloseTimeout)
-	closeChannelAndAssert(ctxt, t, net, carol, chanPointCarol, false)
+	closeChannelAndAssert(t, net, net.Alice, chanPointAlice, false)
+	closeChannelAndAssert(t, net, dave, chanPointDave, false)
+	closeChannelAndAssert(t, net, carol, chanPointCarol, false)
 }
 
 // testSwitchOfflineDeliveryOutgoingOffline constructs a set of multihop payments,
@@ -1185,8 +1176,6 @@ func testSwitchOfflineDeliveryOutgoingOffline(
 	assertAmountPaid(t, "Bob(local) => Alice(remote)", net.Bob,
 		aliceFundPoint, amountPaid+(baseFee*numPayments)*2, int64(0))
 
-	ctxt, _ = context.WithTimeout(ctxb, channelCloseTimeout)
-	closeChannelAndAssert(ctxt, t, net, net.Alice, chanPointAlice, false)
-	ctxt, _ = context.WithTimeout(ctxb, channelCloseTimeout)
-	closeChannelAndAssert(ctxt, t, net, dave, chanPointDave, false)
+	closeChannelAndAssert(t, net, net.Alice, chanPointAlice, false)
+	closeChannelAndAssert(t, net, dave, chanPointDave, false)
 }

--- a/lntest/itest/lnd_wallet_import_test.go
+++ b/lntest/itest/lnd_wallet_import_test.go
@@ -524,9 +524,7 @@ func fundChanAndCloseFromImportedAccount(t *harnessTest, srcNode, destNode,
 	require.NoError(t.t, err)
 
 	// Now that we've confirmed the opened channel works, we'll close it.
-	ctxt, cancel = context.WithTimeout(ctxb, channelCloseTimeout)
-	defer cancel()
-	closeChannelAndAssert(ctxt, t, t.lndHarness, srcNode, chanPoint, false)
+	closeChannelAndAssert(t, t.lndHarness, srcNode, chanPoint, false)
 
 	// Since the channel still had funds left on the source node's side,
 	// they must've been redeemed after the close. Without a pre-negotiated

--- a/lntest/itest/lnd_wumbo_channels_test.go
+++ b/lntest/itest/lnd_wumbo_channels_test.go
@@ -68,5 +68,5 @@ func testWumboChannels(net *lntest.NetworkHarness, t *harnessTest) {
 			Amt: chanAmt,
 		},
 	)
-	closeChannelAndAssert(ctxb, t, net, wumboNode, chanPoint, false)
+	closeChannelAndAssert(t, net, wumboNode, chanPoint, false)
 }


### PR DESCRIPTION
Have seen this flake several times,
```
== RUN   TestLightningNetworkDaemon/tranche02/48-of-82/bitcoind/revoked_uncooperative_close_retribution_remote_hodl
    assertions.go:123: 
        	Error Trace:	assertions.go:123
        	            				assertions.go:224
        	            				assertions.go:201
        	            				lnd_routing_test.go:1204
        	            				test_harness.go:115
        	            				lnd_test.go:247
        	Error:      	Received unexpected error:
        	            	rpc error: code = DeadlineExceeded desc = context deadline exceeded
        	Test:       	TestLightningNetworkDaemon/tranche01/27-of-82/bitcoind/private_channel_update_policy
        	Messages:   	unable to create topology client
```

This is because the channel open and close share the same context. By the time we reach [this defer statement](https://github.com/lightningnetwork/lnd/blob/master/lntest/itest/lnd_routing_test.go#L1085), the context might have already timed out. 