### PR TITLE
multi: optimistically shutdown link during coop close

### DIFF
--- a/docs/release-notes/release-notes-0.14.0.md
+++ b/docs/release-notes/release-notes-0.14.0.md
@@ -112,6 +112,8 @@ you.
 * Locally force closed channels are now [kept in the channel.backup file until
   their time lock has fully matured](https://github.com/lightningnetwork/lnd/pull/5528).
 
+* [Cooperative closes optimistically shutdown the associated `link` before closing the channel.](https://github.com/lightningnetwork/lnd/pull/5618)
+
 ## Build System
 
 * [A new pre-submit check has been

--- a/htlcswitch/interfaces.go
+++ b/htlcswitch/interfaces.go
@@ -88,6 +88,11 @@ type ChannelUpdateHandler interface {
 	// MayAddOutgoingHtlc returns an error if we may not add an outgoing
 	// htlc to the channel.
 	MayAddOutgoingHtlc() error
+
+	// ShutdownIfChannelClean shuts the link down if the channel state is
+	// clean. This can be used with dynamic commitment negotiation or coop
+	// close negotiation which require a clean channel state.
+	ShutdownIfChannelClean() error
 }
 
 // ChannelLink is an interface which represents the subsystem for managing the

--- a/htlcswitch/linkfailure.go
+++ b/htlcswitch/linkfailure.go
@@ -5,6 +5,9 @@ import "github.com/go-errors/errors"
 var (
 	// ErrLinkShuttingDown signals that the link is shutting down.
 	ErrLinkShuttingDown = errors.New("link shutting down")
+
+	// ErrLinkFailedShutdown signals that a requested shutdown failed.
+	ErrLinkFailedShutdown = errors.New("link failed to shutdown")
 )
 
 // errorCode encodes the possible types of errors that will make us fail the

--- a/htlcswitch/mock.go
+++ b/htlcswitch/mock.go
@@ -757,6 +757,7 @@ func (f *mockChannelLink) ChannelPoint() *wire.OutPoint                 { return
 func (f *mockChannelLink) Stop()                                        {}
 func (f *mockChannelLink) EligibleToForward() bool                      { return f.eligible }
 func (f *mockChannelLink) MayAddOutgoingHtlc() error                    { return nil }
+func (f *mockChannelLink) ShutdownIfChannelClean() error                { return nil }
 func (f *mockChannelLink) setLiveShortChanID(sid lnwire.ShortChannelID) { f.shortChanID = sid }
 func (f *mockChannelLink) UpdateShortChanID() (lnwire.ShortChannelID, error) {
 	f.eligible = true

--- a/peer/brontide.go
+++ b/peer/brontide.go
@@ -1184,11 +1184,9 @@ func waitUntilLinkActive(p *Brontide,
 
 	// The link may already be active by this point, and we may have missed the
 	// ActiveLinkEvent. Check if the link exists.
-	links, _ := p.cfg.Switch.GetLinksByInterface(p.cfg.PubKeyBytes)
-	for _, link := range links {
-		if link.ChanID() == cid {
-			return link
-		}
+	link := p.fetchLinkFromKeyAndCid(cid)
+	if link != nil {
+		return link
 	}
 
 	// If the link is nil, we must wait for it to be active.
@@ -1216,16 +1214,7 @@ func waitUntilLinkActive(p *Brontide,
 			// The link shouldn't be nil as we received an
 			// ActiveLinkEvent. If it is nil, we return nil and the
 			// calling function should catch it.
-			links, _ = p.cfg.Switch.GetLinksByInterface(
-				p.cfg.PubKeyBytes,
-			)
-			for _, link := range links {
-				if link.ChanID() == cid {
-					return link
-				}
-			}
-
-			return nil
+			return p.fetchLinkFromKeyAndCid(cid)
 
 		case <-p.quit:
 			return nil
@@ -2408,12 +2397,11 @@ func (p *Brontide) fetchActiveChanCloser(chanID lnwire.ChannelID) (
 	// cooperative channel closure.
 	chanCloser, ok := p.activeChanCloses[chanID]
 	if !ok {
-		// If we need to create a chan closer for the first time, then
-		// we'll check to ensure that the channel is even in the proper
-		// state to allow a co-op channel closure.
-		if len(channel.ActiveHtlcs()) != 0 {
-			return nil, fmt.Errorf("cannot co-op close " +
-				"channel w/ active htlcs")
+		// Optimistically try a link shutdown, erroring out if it
+		// failed.
+		if err := p.tryLinkShutdown(chanID); err != nil {
+			peerLog.Errorf("failed link shutdown: %v", err)
+			return nil, err
 		}
 
 		// We'll create a valid closing state machine in order to
@@ -2453,9 +2441,8 @@ func (p *Brontide) fetchActiveChanCloser(chanID lnwire.ChannelID) (
 
 		chanCloser = chancloser.NewChanCloser(
 			chancloser.ChanCloseCfg{
-				Channel:           channel,
-				UnregisterChannel: p.cfg.Switch.RemoveLink,
-				BroadcastTx:       p.cfg.Wallet.PublishTransaction,
+				Channel:     channel,
+				BroadcastTx: p.cfg.Wallet.PublishTransaction,
 				DisableChannel: func(chanPoint wire.OutPoint) error {
 					return p.cfg.ChanStatusMgr.RequestDisable(chanPoint, false)
 				},
@@ -2569,11 +2556,18 @@ func (p *Brontide) handleLocalCloseReq(req *htlcswitch.ChanClose) {
 			return
 		}
 
+		// Optimistically try a link shutdown, erroring out if it
+		// failed.
+		if err := p.tryLinkShutdown(chanID); err != nil {
+			peerLog.Errorf("failed link shutdown: %v", err)
+			req.Err <- err
+			return
+		}
+
 		chanCloser := chancloser.NewChanCloser(
 			chancloser.ChanCloseCfg{
-				Channel:           channel,
-				UnregisterChannel: p.cfg.Switch.RemoveLink,
-				BroadcastTx:       p.cfg.Wallet.PublishTransaction,
+				Channel:     channel,
+				BroadcastTx: p.cfg.Wallet.PublishTransaction,
 				DisableChannel: func(chanPoint wire.OutPoint) error {
 					return p.cfg.ChanStatusMgr.RequestDisable(chanPoint, false)
 				},
@@ -2698,6 +2692,55 @@ func (p *Brontide) handleLinkFailure(failure linkFailureReport) {
 				"remote peer: %v", err)
 		}
 	}
+}
+
+// tryLinkShutdown attempts to fetch a target link from the switch, calls
+// ShutdownIfChannelClean to optimistically trigger a link shutdown, and
+// removes the link from the switch. It returns an error if any step failed.
+func (p *Brontide) tryLinkShutdown(cid lnwire.ChannelID) error {
+	// Fetch the appropriate link and call ShutdownIfChannelClean to ensure
+	// no other updates can occur.
+	chanLink := p.fetchLinkFromKeyAndCid(cid)
+
+	// If the link happens to be nil, return ErrChannelNotFound so we can
+	// ignore the close message.
+	if chanLink == nil {
+		return ErrChannelNotFound
+	}
+
+	// Else, the link exists, so attempt to trigger shutdown. If this
+	// fails, we'll send an error message to the remote peer.
+	if err := chanLink.ShutdownIfChannelClean(); err != nil {
+		return err
+	}
+
+	// Next, we remove the link from the switch to shut down all of the
+	// link's goroutines and remove it from the switch's internal maps. We
+	// don't call WipeChannel as the channel must still be in the
+	// activeChannels map to process coop close messages.
+	p.cfg.Switch.RemoveLink(cid)
+
+	return nil
+}
+
+// fetchLinkFromKeyAndCid fetches a link from the switch via the remote's
+// public key and the channel id.
+func (p *Brontide) fetchLinkFromKeyAndCid(
+	cid lnwire.ChannelID) htlcswitch.ChannelUpdateHandler {
+
+	var chanLink htlcswitch.ChannelUpdateHandler
+
+	// We don't need to check the error here, and can instead just loop
+	// over the slice and return nil.
+	links, _ := p.cfg.Switch.GetLinksByInterface(p.cfg.PubKeyBytes)
+	for _, link := range links {
+		if link.ChanID() == cid {
+			chanLink = link
+			break
+		}
+	}
+
+	return chanLink
 }
 
 // finalizeChanClosure performs the final clean up steps once the cooperative

--- a/peer/brontide_test.go
+++ b/peer/brontide_test.go
@@ -40,7 +40,7 @@ func TestPeerChannelClosureAcceptFeeResponder(t *testing.T) {
 	broadcastTxChan := make(chan *wire.MsgTx)
 
 	alicePeer, bobChan, cleanUp, err := createTestPeer(
-		notifier, broadcastTxChan, noUpdate,
+		notifier, broadcastTxChan, noUpdate, nil,
 	)
 	if err != nil {
 		t.Fatalf("unable to create test channels: %v", err)
@@ -143,7 +143,7 @@ func TestPeerChannelClosureAcceptFeeInitiator(t *testing.T) {
 	broadcastTxChan := make(chan *wire.MsgTx)
 
 	alicePeer, bobChan, cleanUp, err := createTestPeer(
-		notifier, broadcastTxChan, noUpdate,
+		notifier, broadcastTxChan, noUpdate, nil,
 	)
 	if err != nil {
 		t.Fatalf("unable to create test channels: %v", err)
@@ -265,7 +265,7 @@ func TestPeerChannelClosureFeeNegotiationsResponder(t *testing.T) {
 	broadcastTxChan := make(chan *wire.MsgTx)
 
 	alicePeer, bobChan, cleanUp, err := createTestPeer(
-		notifier, broadcastTxChan, noUpdate,
+		notifier, broadcastTxChan, noUpdate, nil,
 	)
 	if err != nil {
 		t.Fatalf("unable to create test channels: %v", err)
@@ -459,7 +459,7 @@ func TestPeerChannelClosureFeeNegotiationsInitiator(t *testing.T) {
 	broadcastTxChan := make(chan *wire.MsgTx)
 
 	alicePeer, bobChan, cleanUp, err := createTestPeer(
-		notifier, broadcastTxChan, noUpdate,
+		notifier, broadcastTxChan, noUpdate, nil,
 	)
 	if err != nil {
 		t.Fatalf("unable to create test channels: %v", err)
@@ -795,7 +795,7 @@ func TestCustomShutdownScript(t *testing.T) {
 
 			// Open a channel.
 			alicePeer, bobChan, cleanUp, err := createTestPeer(
-				notifier, broadcastTxChan, test.update,
+				notifier, broadcastTxChan, test.update, nil,
 			)
 			if err != nil {
 				t.Fatalf("unable to create test channels: %v", err)

--- a/peer/brontide_test.go
+++ b/peer/brontide_test.go
@@ -39,8 +39,10 @@ func TestPeerChannelClosureAcceptFeeResponder(t *testing.T) {
 	}
 	broadcastTxChan := make(chan *wire.MsgTx)
 
+	mockSwitch := &mockMessageSwitch{}
+
 	alicePeer, bobChan, cleanUp, err := createTestPeer(
-		notifier, broadcastTxChan, noUpdate, nil,
+		notifier, broadcastTxChan, noUpdate, mockSwitch,
 	)
 	if err != nil {
 		t.Fatalf("unable to create test channels: %v", err)
@@ -48,6 +50,9 @@ func TestPeerChannelClosureAcceptFeeResponder(t *testing.T) {
 	defer cleanUp()
 
 	chanID := lnwire.NewChanIDFromOutPoint(bobChan.ChannelPoint())
+
+	mockLink := newMockUpdateHandler(chanID)
+	mockSwitch.links = append(mockSwitch.links, mockLink)
 
 	// We send a shutdown request to Alice. She will now be the responding
 	// node in this shutdown procedure. We first expect Alice to answer
@@ -142,13 +147,19 @@ func TestPeerChannelClosureAcceptFeeInitiator(t *testing.T) {
 	}
 	broadcastTxChan := make(chan *wire.MsgTx)
 
+	mockSwitch := &mockMessageSwitch{}
+
 	alicePeer, bobChan, cleanUp, err := createTestPeer(
-		notifier, broadcastTxChan, noUpdate, nil,
+		notifier, broadcastTxChan, noUpdate, mockSwitch,
 	)
 	if err != nil {
 		t.Fatalf("unable to create test channels: %v", err)
 	}
 	defer cleanUp()
+
+	chanID := lnwire.NewChanIDFromOutPoint(bobChan.ChannelPoint())
+	mockLink := newMockUpdateHandler(chanID)
+	mockSwitch.links = append(mockSwitch.links, mockLink)
 
 	// We make Alice send a shutdown request.
 	updateChan := make(chan interface{}, 1)
@@ -179,7 +190,6 @@ func TestPeerChannelClosureAcceptFeeInitiator(t *testing.T) {
 	aliceDeliveryScript := shutdownMsg.Address
 
 	// Bob will respond with his own Shutdown message.
-	chanID := shutdownMsg.ChannelID
 	alicePeer.chanCloseMsgs <- &closeMsg{
 		cid: chanID,
 		msg: lnwire.NewShutdown(chanID,
@@ -264,8 +274,10 @@ func TestPeerChannelClosureFeeNegotiationsResponder(t *testing.T) {
 	}
 	broadcastTxChan := make(chan *wire.MsgTx)
 
+	mockSwitch := &mockMessageSwitch{}
+
 	alicePeer, bobChan, cleanUp, err := createTestPeer(
-		notifier, broadcastTxChan, noUpdate, nil,
+		notifier, broadcastTxChan, noUpdate, mockSwitch,
 	)
 	if err != nil {
 		t.Fatalf("unable to create test channels: %v", err)
@@ -273,6 +285,9 @@ func TestPeerChannelClosureFeeNegotiationsResponder(t *testing.T) {
 	defer cleanUp()
 
 	chanID := lnwire.NewChanIDFromOutPoint(bobChan.ChannelPoint())
+
+	mockLink := newMockUpdateHandler(chanID)
+	mockSwitch.links = append(mockSwitch.links, mockLink)
 
 	// Bob sends a shutdown request to Alice. She will now be the responding
 	// node in this shutdown procedure. We first expect Alice to answer this
@@ -458,13 +473,19 @@ func TestPeerChannelClosureFeeNegotiationsInitiator(t *testing.T) {
 	}
 	broadcastTxChan := make(chan *wire.MsgTx)
 
+	mockSwitch := &mockMessageSwitch{}
+
 	alicePeer, bobChan, cleanUp, err := createTestPeer(
-		notifier, broadcastTxChan, noUpdate, nil,
+		notifier, broadcastTxChan, noUpdate, mockSwitch,
 	)
 	if err != nil {
 		t.Fatalf("unable to create test channels: %v", err)
 	}
 	defer cleanUp()
+
+	chanID := lnwire.NewChanIDFromOutPoint(bobChan.ChannelPoint())
+	mockLink := newMockUpdateHandler(chanID)
+	mockSwitch.links = append(mockSwitch.links, mockLink)
 
 	// We make the initiator send a shutdown request.
 	updateChan := make(chan interface{}, 1)
@@ -496,7 +517,6 @@ func TestPeerChannelClosureFeeNegotiationsInitiator(t *testing.T) {
 	aliceDeliveryScript := shutdownMsg.Address
 
 	// Bob will answer the Shutdown message with his own Shutdown.
-	chanID := lnwire.NewChanIDFromOutPoint(bobChan.ChannelPoint())
 	respShutdown := lnwire.NewShutdown(chanID, dummyDeliveryScript)
 	alicePeer.chanCloseMsgs <- &closeMsg{
 		cid: chanID,
@@ -793,20 +813,27 @@ func TestCustomShutdownScript(t *testing.T) {
 			}
 			broadcastTxChan := make(chan *wire.MsgTx)
 
+			mockSwitch := &mockMessageSwitch{}
+
 			// Open a channel.
 			alicePeer, bobChan, cleanUp, err := createTestPeer(
-				notifier, broadcastTxChan, test.update, nil,
+				notifier, broadcastTxChan, test.update,
+				mockSwitch,
 			)
 			if err != nil {
 				t.Fatalf("unable to create test channels: %v", err)
 			}
 			defer cleanUp()
 
+			chanPoint := bobChan.ChannelPoint()
+			chanID := lnwire.NewChanIDFromOutPoint(chanPoint)
+			mockLink := newMockUpdateHandler(chanID)
+			mockSwitch.links = append(mockSwitch.links, mockLink)
+
 			// Request initiator to cooperatively close the channel, with
 			// a specified delivery address.
 			updateChan := make(chan interface{}, 1)
 			errChan := make(chan error, 1)
-			chanPoint := bobChan.ChannelPoint()
 			closeCommand := htlcswitch.ChanClose{
 				CloseType:      htlcswitch.CloseRegular,
 				ChanPoint:      chanPoint,

--- a/peer/test_utils.go
+++ b/peer/test_utils.go
@@ -54,7 +54,8 @@ var noUpdate = func(a, b *channeldb.OpenChannel) {}
 // an updateChan function which can be used to modify the default values on
 // the channel states for each peer.
 func createTestPeer(notifier chainntnfs.ChainNotifier,
-	publTx chan *wire.MsgTx, updateChan func(a, b *channeldb.OpenChannel)) (
+	publTx chan *wire.MsgTx, updateChan func(a, b *channeldb.OpenChannel),
+	mockSwitch *mockMessageSwitch) (
 	*Brontide, *lnwallet.LightningChannel, func(), error) {
 
 	aliceKeyPriv, aliceKeyPub := btcec.PrivKeyFromBytes(
@@ -306,7 +307,11 @@ func createTestPeer(notifier chainntnfs.ChainNotifier,
 		},
 	}
 
-	htlcSwitch := &mockMessageSwitch{}
+	// If mockSwitch is not set by the caller, set it to the default as the
+	// caller does not need to control it.
+	if mockSwitch == nil {
+		mockSwitch = &mockMessageSwitch{}
+	}
 
 	nodeSignerAlice := netann.NewNodeSigner(aliceKeySigner)
 
@@ -349,7 +354,7 @@ func createTestPeer(notifier chainntnfs.ChainNotifier,
 		PubKeyBytes: pubKey,
 		ErrorBuffer: errBuffer,
 		ChainIO:     chainIO,
-		Switch:      htlcSwitch,
+		Switch:      mockSwitch,
 
 		ChanActiveTimeout: chanActiveTimeout,
 		InterceptSwitch:   htlcswitch.NewInterceptableSwitch(nil),
@@ -403,6 +408,37 @@ func (m *mockMessageSwitch) GetLinksByInterface(pub [33]byte) (
 
 	return nil, nil
 }
+
+// mockUpdateHandler is a mock implementation of the ChannelUpdateHandler
+// interface. It is used in mockMessageSwitch's GetLinksByInterface method.
+type mockUpdateHandler struct {
+	cid lnwire.ChannelID
+}
+
+// newMockUpdateHandler creates a new mockUpdateHandler.
+func newMockUpdateHandler(cid lnwire.ChannelID) *mockUpdateHandler {
+	return &mockUpdateHandler{
+		cid: cid,
+	}
+}
+
+// HandleChannelUpdate currently does nothing.
+func (m *mockUpdateHandler) HandleChannelUpdate(msg lnwire.Message) {}
+
+// ChanID returns the mockUpdateHandler's cid.
+func (m *mockUpdateHandler) ChanID() lnwire.ChannelID { return m.cid }
+
+// Bandwidth currently returns a dummy value.
+func (m *mockUpdateHandler) Bandwidth() lnwire.MilliSatoshi { return 0 }
+
+// EligibleToForward currently returns a dummy value.
+func (m *mockUpdateHandler) EligibleToForward() bool { return false }
+
+// MayAddOutgoingHtlc currently returns nil.
+func (m *mockUpdateHandler) MayAddOutgoingHtlc() error { return nil }
+
+// ShutdownIfChannelClean currently returns nil.
+func (m *mockUpdateHandler) ShutdownIfChannelClean() error { return nil }
 
 type mockMessageConn struct {
 	t *testing.T

--- a/peer/test_utils.go
+++ b/peer/test_utils.go
@@ -380,7 +380,9 @@ func createTestPeer(notifier chainntnfs.ChainNotifier,
 
 // mockMessageSwitch is a mock implementation of the messageSwitch interface
 // used for testing without relying on a *htlcswitch.Switch in unit tests.
-type mockMessageSwitch struct{}
+type mockMessageSwitch struct {
+	links []htlcswitch.ChannelUpdateHandler
+}
 
 // BestHeight currently returns a dummy value.
 func (m *mockMessageSwitch) BestHeight() uint32 {
@@ -402,11 +404,11 @@ func (m *mockMessageSwitch) CreateAndAddLink(cfg htlcswitch.ChannelLinkConfig,
 	return nil
 }
 
-// GetLinksByInterface currently returns dummy values.
+// GetLinksByInterface returns the active links.
 func (m *mockMessageSwitch) GetLinksByInterface(pub [33]byte) (
 	[]htlcswitch.ChannelUpdateHandler, error) {
 
-	return nil, nil
+	return m.links, nil
 }
 
 // mockUpdateHandler is a mock implementation of the ChannelUpdateHandler


### PR DESCRIPTION
**Commit overview**:

- `lnwallet: add IsChannelClean method and related tests` modifies `LightningChannel` with a method that returns a boolean indicating whether the channel state is clean or not.  Clean in this case means that no side has lingering updates, no HTLC's, and no pending commitments.  This can be used in dynamic commitments or to ensure cooperative close can start.
- `htlcswitch: extend ChannelLink interface with ShutdownIfChannelClean` exports a method that allows the caller to optimistically shutdown the link if and only if the underlying channel state is clean.
- `peer: add mockUpdateHandler for use in mockMessageSwitch` allows link mocking in the peer unit tests by implementing the `htlcswitch.ChannelUpdateHandler` interface.
- `peer+chancloser: tryLinkShutdown during cooperative close process` makes the peer responsible for optimistically shutting down the link if a coop close is initiated. If the link cannot shutdown, then the coop close process fails.

Note: The spec is vague in the shutdown phase of coop close, so this pull opts to implement the strictest possible version and ensures that both sides channel states are clean.

Fixes https://github.com/lightningnetwork/lnd/issues/5385