### PR TITLE
docs: fix inconsistent naming of channel.backup [skip ci]

### DIFF
--- a/cmd/lncli/commands.go
+++ b/cmd/lncli/commands.go
@@ -2487,7 +2487,7 @@ var exportChanBackupCommand = cli.Command{
 			of the static channel backup, a serialized version of
 			the backup (either Single or Multi) will be written to
 			the target file, this is the same format used by lnd in
-			its channels.backup file `,
+			its channel.backup file `,
 		},
 	},
 	Action: actionDecorator(exportChanBackup),
@@ -2616,7 +2616,7 @@ var verifyChanBackupCommand = cli.Command{
 	 static channel backups in single blob.
 
        * A file path which points to a packed multi-channel backup within a
-	 file, using the same format that lnd does in its channels.backup
+	 file, using the same format that lnd does in its channel.backup
 	 file.
     `,
 	Flags: []cli.Flag{
@@ -2683,7 +2683,7 @@ var restoreChanBackupCommand = cli.Command{
 	Description: `
 	Allows a user to restore a Static Channel Backup (SCB) that was
 	obtained either via the exportchanbackup command, or from lnd's
-	automatically managed channels.backup file. This command should be used
+	automatically managed channel.backup file. This command should be used
 	if a user is attempting to restore a channel due to data loss on a
 	running node restored with the same seed as the node that created the
 	channel. If successful, this command will allows the user to recover
@@ -2698,7 +2698,7 @@ var restoreChanBackupCommand = cli.Command{
 	     static channel backups in single blob.
 
 	   * A file path which points to a packed multi-channel backup within a
-	     file, using the same format that lnd does in its channels.backup
+	     file, using the same format that lnd does in its channel.backup
 	     file.
 	`,
 	Flags: []cli.Flag{

--- a/docs/recovery.md
+++ b/docs/recovery.md
@@ -242,7 +242,7 @@ process.
 #### On-Disk `channel.backup`
 
 There are multiple ways of obtaining SCBs from `lnd`. The most commonly used
-method will likely be via the `channels.backup` file that's stored on-disk
+method will likely be via the `channel.backup` file that's stored on-disk
 alongside the rest of the chain data. This is a special file that contains SCB
 entries for _all_ currently open channels. Each time a channel is opened or
 closed, this file is updated on disk in a safe manner (atomic file rename). As
@@ -273,7 +273,7 @@ Another way to obtain SCBS for all or a target channel is via the new
     "multi_chan_backup": "fd73e992e5133aa085c8e45548e0189c411c8cfe42e902b0ee2dec528a18fb472c3375447868ffced0d4812125e4361d667b7e6a18b2357643e09bbe7e9110c6b28d74f4f55e7c29e92419b52509e5c367cf2d977b670a2ff7560f5fe24021d246abe30542e6c6e3aa52f903453c3a2389af918249dbdb5f1199aaecf4931c0366592165b10bdd58eaf706d6df02a39d9323a0c65260ffcc84776f2705e4942d89e4dbefa11c693027002c35582d56e295dcf74d27e90873699657337696b32c05c8014911a7ec8eb03bdbe526fe658be8abdf50ab12c4fec9ddeefc489cf817721c8e541d28fbe71e32137b5ea066a9f4e19814deedeb360def90eff2965570aab5fedd0ebfcd783ce3289360953680ac084b2e988c9cbd0912da400861467d7bb5ad4b42a95c2d541653e805cbfc84da401baf096fba43300358421ae1b43fd25f3289c8c73489977592f75bc9f73781f41718a752ab325b70c8eb2011c5d979f6efc7a76e16492566e43d94dbd42698eb06ff8ad4fd3f2baabafded"
 }
 
-⛰  lncli --network=simnet exportchanbackup --all --output_file=channels.backup
+⛰  lncli --network=simnet exportchanbackup --all --output_file=channel.backup
 ```
 
 As shown above, a user can either: specify a specific channel to backup, backup
@@ -293,7 +293,7 @@ schemes, compared to the file system notification based approach.
 If a node is being created from scratch, then it's possible to pass in an
 existing SCB using the `lncli create` or `lncli unlock` commands:
 ```shell
-⛰  lncli create -multi_file=channels.backup
+⛰  lncli create -multi_file=channel.backup
 ```
 
 Alternatively, the `restorechanbackup` command can be used if `lnd` has already
@@ -313,7 +313,7 @@ DESCRIPTION:
 
   Allows a user to restore a Static Channel Backup (SCB) that was
   obtained either via the exportchanbackup command, or from lnd's
-  automatically managed channels.backup file. This command should be used
+  automatically managed channel.backup file. This command should be used
   if a user is attempting to restore a channel due to data loss on a
   running node restored with the same seed as the node that created the
   channel. If successful, this command will allows the user to recover
@@ -328,7 +328,7 @@ DESCRIPTION:
        static channel backups in single blob.
 
      * A file path which points to a packed multi-channel backup within a
-       file, using the same format that lnd does in its channels.backup
+       file, using the same format that lnd does in its channel.backup
        file.
 
 

--- a/lntest/itest/lnd_channel_backup_test.go
+++ b/lntest/itest/lnd_channel_backup_test.go
@@ -79,7 +79,7 @@ func testChannelBackupRestore(net *lntest.NetworkHarness, t *harnessTest) {
 				mnemonic []string) (nodeRestorer, error) {
 
 				// Read the entire Multi backup stored within
-				// this node's channels.backup file.
+				// this node's channel.backup file.
 				multi, err := ioutil.ReadFile(backupFilePath)
 				if err != nil {
 					return nil, err
@@ -87,7 +87,7 @@ func testChannelBackupRestore(net *lntest.NetworkHarness, t *harnessTest) {
 
 				// Now that we have Dave's backup file, we'll
 				// create a new nodeRestorer that will restore
-				// using the on-disk channels.backup.
+				// using the on-disk channel.backup.
 				return chanRestoreViaRPC(
 					net, password, mnemonic, multi, oldNode,
 				)
@@ -190,7 +190,7 @@ func testChannelBackupRestore(net *lntest.NetworkHarness, t *harnessTest) {
 				mnemonic []string) (nodeRestorer, error) {
 
 				// Read the entire Multi backup stored within
-				// this node's channels.backup file.
+				// this node's channel.backup file.
 				multi, err := ioutil.ReadFile(backupFilePath)
 				if err != nil {
 					return nil, err
@@ -198,7 +198,7 @@ func testChannelBackupRestore(net *lntest.NetworkHarness, t *harnessTest) {
 
 				// Now that we have Dave's backup file, we'll
 				// create a new nodeRestorer that will restore
-				// using the on-disk channels.backup.
+				// using the on-disk channel.backup.
 				backup := &lnrpc.RestoreChanBackupRequest_MultiChanBackup{
 					MultiChanBackup: multi,
 				}
@@ -258,7 +258,7 @@ func testChannelBackupRestore(net *lntest.NetworkHarness, t *harnessTest) {
 				mnemonic []string) (nodeRestorer, error) {
 
 				// Read the entire Multi backup stored within
-				// this node's channels.backup file.
+				// this node's channel.backup file.
 				multi, err := ioutil.ReadFile(backupFilePath)
 				if err != nil {
 					return nil, err
@@ -345,7 +345,7 @@ func testChannelBackupRestore(net *lntest.NetworkHarness, t *harnessTest) {
 				mnemonic []string) (nodeRestorer, error) {
 
 				// Read the entire Multi backup stored within
-				// this node's channels.backup file.
+				// this node's channel.backup file.
 				multi, err := ioutil.ReadFile(backupFilePath)
 				if err != nil {
 					return nil, err
@@ -353,7 +353,7 @@ func testChannelBackupRestore(net *lntest.NetworkHarness, t *harnessTest) {
 
 				// Now that we have Dave's backup file, we'll
 				// create a new nodeRestorer that will restore
-				// using the on-disk channels.backup.
+				// using the on-disk channel.backup.
 				return chanRestoreViaRPC(
 					net, password, mnemonic, multi, oldNode,
 				)
@@ -405,7 +405,7 @@ func testChannelBackupRestore(net *lntest.NetworkHarness, t *harnessTest) {
 				mnemonic []string) (nodeRestorer, error) {
 
 				// Read the entire Multi backup stored within
-				// this node's channels.backup file.
+				// this node's channel.backup file.
 				multi, err := ioutil.ReadFile(backupFilePath)
 				if err != nil {
 					return nil, err
@@ -413,7 +413,7 @@ func testChannelBackupRestore(net *lntest.NetworkHarness, t *harnessTest) {
 
 				// Now that we have Dave's backup file, we'll
 				// create a new nodeRestorer that will restore
-				// using the on-disk channels.backup.
+				// using the on-disk channel.backup.
 				return chanRestoreViaRPC(
 					net, password, mnemonic, multi, oldNode,
 				)
@@ -443,7 +443,7 @@ func testChannelBackupRestore(net *lntest.NetworkHarness, t *harnessTest) {
 }
 
 // testChannelBackupUpdates tests that both the streaming channel update RPC,
-// and the on-disk channels.backup are updated each time a channel is
+// and the on-disk channel.backup are updated each time a channel is
 // opened/closed.
 func testChannelBackupUpdates(net *lntest.NetworkHarness, t *harnessTest) {
 	ctxb := context.Background()

--- a/lntest/node.go
+++ b/lntest/node.go
@@ -521,7 +521,7 @@ func (hn *HarnessNode) TLSKeyStr() string {
 	return hn.Cfg.TLSKeyPath
 }
 
-// ChanBackupPath returns the fielpath to the on-disk channels.backup file for
+// ChanBackupPath returns the fielpath to the on-disk channel.backup file for
 // this node.
 func (hn *HarnessNode) ChanBackupPath() string {
 	return hn.Cfg.ChanBackupPath()


### PR DESCRIPTION
I bumped into this earlier when looking at SCB.

Default SCB file name is `channel.backup`, but several bits of documentation and code comments reference `channels.backup` (which is the incorrect file name).

Let me know if you need me to split the commits in a different way, but looking through your contribution guidelines I think I have it right.


#### Pull Request Checklist

- [x] All changes are Go version 1.15 compliant
- [x] Your PR passes all CI checks. If a check cannot be passed for a justifiable reason, that reason must be stated in the commit message and PR description.
- [x] If this is your first time contributing, we recommend you read the [Code Contribution Guidelines](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md)
   - [x] The code being submitted is commented according to [Code Documentation and Commenting](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#CodeDocumentation)
   - [x] Commits have a logical structure according to [Ideal Git Commit Structure](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#IdealGitCommitStructure)
- [ ] For new code: Code is accompanied by tests which exercise both the positive and negative (error paths) conditions (if applicable)
- [ ] For bug fixes: If possible, code is accompanied by new tests which trigger the bug being fixed to prevent regressions
- [ ] Any new logging statements use an appropriate subsystem and logging level
- [x] For code and documentation: lines are wrapped at 80 characters (the tab character should be counted as 8 characters, not 4, as some IDEs do per default)
- [ ] A description of your changes [should be added to running the release notes](https://github.com/lightningnetwork/lnd/tree/master/docs/release-notes) for the milestone your change will land in.
