### PR TITLE
peer+brontide: when decrypting re-use the allocated ciphertext buf & ensure buf pool buf doesn't escape

### DIFF
--- a/brontide/bench_test.go
+++ b/brontide/bench_test.go
@@ -1,0 +1,66 @@
+package brontide
+
+import (
+	"bytes"
+	"math"
+	"math/rand"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func BenchmarkReadHeaderAndBody(t *testing.B) {
+	// Create a test connection, grabbing either side of the connection
+	// into local variables. If the initial crypto handshake fails, then
+	// we'll get a non-nil error here.
+	localConn, remoteConn, cleanUp, err := establishTestConnection()
+	require.NoError(t, err, "unable to establish test connection: %v", err)
+	defer cleanUp()
+
+	rand.Seed(time.Now().Unix())
+
+	noiseRemoteConn := remoteConn.(*Conn)
+	noiseLocalConn := localConn.(*Conn)
+
+	// Now that we have a local and remote side (to set up the initial
+	// handshake state, we'll have the remote side write out something
+	// similar to a large message in the protocol.
+	const pktSize = 60_000
+	msg := bytes.Repeat([]byte("a"), pktSize)
+	err = noiseRemoteConn.WriteMessage(msg)
+	require.NoError(t, err, "unable to write encrypted message: %v", err)
+
+	cipherHeader := noiseRemoteConn.noise.nextHeaderSend
+	cipherMsg := noiseRemoteConn.noise.nextBodySend
+
+	var (
+		benchErr error
+		msgBuf   [math.MaxUint16]byte
+	)
+
+	t.ReportAllocs()
+	t.ResetTimer()
+
+	nonceValue := noiseLocalConn.noise.recvCipher.nonce
+	for i := 0; i < t.N; i++ {
+		pktLen, benchErr := noiseLocalConn.noise.ReadHeader(
+			bytes.NewReader(cipherHeader),
+		)
+		require.NoError(
+			t, benchErr, "#%v: failed decryption: %v", i, benchErr,
+		)
+		_, benchErr = noiseLocalConn.noise.ReadBody(
+			bytes.NewReader(cipherMsg), msgBuf[:pktLen],
+		)
+		require.NoError(
+			t, benchErr, "#%v: failed decryption: %v", i, benchErr,
+		)
+
+		// We reset the internal nonce each time as otherwise, we'd
+		// continue to increment it which would cause a decryption
+		// failure.
+		noiseLocalConn.noise.recvCipher.nonce = nonceValue
+	}
+	require.NoError(t, benchErr)
+}

--- a/docs/release-notes/release-notes-0.14.0.md
+++ b/docs/release-notes/release-notes-0.14.0.md
@@ -200,7 +200,13 @@ you.
   transaction each time a private key needs to be derived for signing or ECDH
   operations]https://github.com/lightningnetwork/lnd/pull/5629). This results
   in a massive performance improvement across several routine operations at the
-  cost of a small amount of memory allocated for a new cache.
+
+* [When decrypting incoming encrypted brontide messages on the wire, we'll now
+  properly re-use the buffer that was allocated for the ciphertext to store the
+  plaintext]https://github.com/lightningnetwork/lnd/pull/5622). When combined
+  with the buffer pool, this ensures that we no longer need to allocate a new
+  buffer each time we decrypt an incoming message, as we
+  recycle these buffers in the peer.
 
 ## Log system
 


### PR DESCRIPTION
In this commit, we implement a simple optimization that dramatically
reduces reduces the number of allocations we need to make when we
decrypt a new message. Before this commit, we would pass in a `nil`
value to the `Decrypt` method which meant that it would always allocate
a new buffers.

Rather than force this behavior, in this commit, we pass in the
ciphertext buffer (with a length of zero), such that the decryption
operation will simply copy the plaintext bytes over the cipher text in
place. This works as the cipher text is always larger than the
plaintext, since the plaintext doesn't have a MAC attached.

The amount the perf increase, amount of allocations, and amount of bytes
allocated are pretty nice:
```
benchmark                        old ns/op     new ns/op     delta
BenchmarkReadHeaderAndBody-8     88652         75896         -14.39%

benchmark                        old allocs     new allocs     delta
BenchmarkReadHeaderAndBody-8     6              4              -33.33%

benchmark                        old bytes     new bytes     delta
BenchmarkReadHeaderAndBody-8     65664         128           -99.81%
```

Building on top of the prior commit, rather than
using the returned buffer outside of the closure (which means it'll be
copied), we instead use it within the `Submit` closure instead. With the
recent changes to the `brontide` package, we won't allocate any new
buffer when we decrypt, as a result, the `rawMsg` byte slice actually
just slices into the passed `buf` slice (obtained from the pool)`.

With this change, we ensure that the buffer pool can release the slice
back to the pool and eliminate any extra allocations along the way.