### PR TITLE
signal: custom exit code status for interceptor

### DIFF
--- a/cmd/lnd/main.go
+++ b/cmd/lnd/main.go
@@ -19,7 +19,7 @@ func main() {
 
 	// Load the configuration, and parse any command line options. This
 	// function will also set up logging properly.
-	loadedConfig, err := lnd.LoadConfig(shutdownInterceptor)
+	loadedConfig, err := lnd.LoadConfig(*shutdownInterceptor)
 	if err != nil {
 		if e, ok := err.(*flags.Error); !ok || e.Type != flags.ErrHelp {
 			// Print error if not due to help request.
@@ -34,9 +34,10 @@ func main() {
 	// Call the "real" main in a nested manner so the defers will properly
 	// be executed in the case of a graceful shutdown.
 	if err = lnd.Main(
-		loadedConfig, lnd.ListenerCfg{}, shutdownInterceptor,
+		loadedConfig, lnd.ListenerCfg{}, *shutdownInterceptor,
 	); err != nil {
 		_, _ = fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
 	}
+	os.Exit(shutdownInterceptor.GetExitCode())
 }

--- a/lnd.go
+++ b/lnd.go
@@ -199,7 +199,6 @@ func Main(cfg *Config, lisCfg ListenerCfg, interceptor signal.Interceptor) error
 			ltndLog.Errorf("Could not close log rotator: %v", err)
 		}
 	}()
-
 	// Show version at startup.
 	ltndLog.Infof("Version: %s commit=%s, build=%s, logging=%s, debuglevel=%s",
 		build.Version(), build.Commit, build.Deployment,

--- a/mobile/bindings.go
+++ b/mobile/bindings.go
@@ -75,7 +75,7 @@ func Start(extraArgs string, rpcReady Callback) {
 
 	// Load the configuration, and parse the extra arguments as command
 	// line options. This function will also set up logging properly.
-	loadedConfig, err := lnd.LoadConfig(shutdownInterceptor)
+	loadedConfig, err := lnd.LoadConfig(*shutdownInterceptor)
 	if err != nil {
 		atomic.StoreInt32(&lndStarted, 0)
 		_, _ = fmt.Fprintln(os.Stderr, err)
@@ -106,7 +106,7 @@ func Start(extraArgs string, rpcReady Callback) {
 		defer close(quit)
 
 		if err := lnd.Main(
-			loadedConfig, cfg, shutdownInterceptor,
+			loadedConfig, cfg, *shutdownInterceptor,
 		); err != nil {
 			if e, ok := err.(*flags.Error); ok &&
 				e.Type == flags.ErrHelp {

--- a/signal/signal.go
+++ b/signal/signal.go
@@ -34,13 +34,16 @@ type Interceptor struct {
 
 	// quit is closed when instructing the main interrupt handler to exit.
 	quit chan struct{}
+
+	// exitCode is the exit code status when the main interrupt handler exits
+	exitCode chan int
 }
 
 // Intercept starts the interception of interrupt signals and returns an `Interceptor` instance.
 // Note that any previous active interceptor must be stopped before a new one can be created
-func Intercept() (Interceptor, error) {
+func Intercept() (*Interceptor, error) {
 	if !atomic.CompareAndSwapInt32(&started, 0, 1) {
-		return Interceptor{}, errors.New("intercept already started")
+		return &Interceptor{}, errors.New("intercept already started")
 	}
 
 	channels := Interceptor{
@@ -48,6 +51,7 @@ func Intercept() (Interceptor, error) {
 		shutdownChannel:        make(chan struct{}),
 		shutdownRequestChannel: make(chan struct{}),
 		quit:                   make(chan struct{}),
+		exitCode:               make(chan int, 1),
 	}
 
 	signalsToCatch := []os.Signal{
@@ -59,7 +63,7 @@ func Intercept() (Interceptor, error) {
 	signal.Notify(channels.interruptChannel, signalsToCatch...)
 	go channels.mainInterruptHandler()
 
-	return channels, nil
+	return &channels, nil
 }
 
 // mainInterruptHandler listens for SIGINT (Ctrl+C) signals on the
@@ -95,16 +99,22 @@ func (c *Interceptor) mainInterruptHandler() {
 		select {
 		case signal := <-c.interruptChannel:
 			log.Infof("Received %v", signal)
+			// Adding exit status code 0 as this will quit after graceful shutdown
+			c.setExitCode(0)
 			shutdown()
 
 		case <-c.shutdownRequestChannel:
 			log.Infof("Received shutdown request.")
+			// Adding exit status code 0 as this will quit after graceful shutdown
+			c.setExitCode(1)
 			shutdown()
 
 		case <-c.quit:
 			log.Infof("Gracefully shutting down.")
 			close(c.shutdownChannel)
 			signal.Stop(c.interruptChannel)
+			// Adding exit status code 0 as this will quit after graceful shutdown
+			c.setExitCode(0)
 			return
 		}
 	}
@@ -146,4 +156,13 @@ func (c *Interceptor) RequestShutdown() {
 // interrupt handler has exited.
 func (c *Interceptor) ShutdownChannel() <-chan struct{} {
 	return c.shutdownChannel
+}
+
+// GetExitCode fetches the exit code that has been set of the Interceptor
+func (c *Interceptor) GetExitCode() int {
+	return <-c.exitCode
+}
+
+func (c *Interceptor) setExitCode(exitCode int) {
+	c.exitCode <- exitCode
 }


### PR DESCRIPTION
- fixes #5625 

## Outline and Challenge
 
This issue was required `lnd` to exit with `status code 1` where there was an request to `shutdownRequestChannel`

https://github.com/lightningnetwork/lnd/blob/52767a7567afe1a96e275a8659f77467ac0fe72f/signal/signal.go#L100-L102

The challenge was that we had to do an `os.exit(1)` **after** an graceful shutdown. 

An graceful shutdown occurs when all the deferred go function in the `Main()` function clean up, but there is no way that we can pass the data or tell the function that cleans up last to exit with a particular status code. 

## Approach

I pulled the defer function of `Main()` outside from `lnd` package and put it under `cmd/lnd.go` where the `Main()` get's called (giving us parental access to shutdownInterceptor) and added an additional parameter to Interceptor struct so that we can pass data when an graceful shutdown has occurred. 

I am passing a pointer reference in-order to retain the modifications (setting exit code) in the Intercept struct in `goroutines`. 


| Before | After 
| :---:   | :-: |
| ![lnd_before](https://user-images.githubusercontent.com/31009634/129782284-c947186c-dc8f-47b9-89b7-5fc84493a653.jpeg) | ![lnd_after](https://user-images.githubusercontent.com/31009634/129782294-d4bb64c3-966d-48d8-a32c-bd99b4d7a5d0.jpeg) | 


## Steps to test this PR

- run bitcoind server
- run the following `./lnd-debug --rpclisten=localhost:10001 --listen=localhost:10011 --restlisten=localhost:8001 --debuglevel=debug --healthcheck.chainbackend.backoff=1s --healthcheck.chainbackend.interval=1m0s --healthcheck.chainbackend.timeout=3s`
- create a wallet ` ./lncli-debug --rpcserver=localhost:10001 --macaroonpath=data/chain/bitcoin/simnet/admin.macaroon unlock`
- Press `ctrl+c` and shutdown your `bitcoind` server
- Wait for 1 min, `lnd` will **exit gracefully** with an exit status code 1

#### Pull Request Checklist

- [x] All changes are Go version 1.15 compliant
- [x] Your PR passes all CI checks. If a check cannot be passed for a justifiable reason, that reason must be stated in the commit message and PR description.
- [ ] If this is your first time contributing, we recommend you read the [Code Contribution Guidelines](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md)
   - [ ] The code being submitted is commented according to [Code Documentation and Commenting](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#CodeDocumentation)
   - [ ] Commits have a logical structure according to [Ideal Git Commit Structure](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#IdealGitCommitStructure)
- [ ] For new code: Code is accompanied by tests which exercise both the positive and negative (error paths) conditions (if applicable)
- [ ] For bug fixes: If possible, code is accompanied by new tests which trigger the bug being fixed to prevent regressions
- [ ] Any new logging statements use an appropriate subsystem and logging level
- [x] For code and documentation: lines are wrapped at 80 characters (the tab character should be counted as 8 characters, not 4, as some IDEs do per default)
- [x] A description of your changes [should be added to running the release notes](https://github.com/lightningnetwork/lnd/tree/master/docs/release-notes) for the milestone your change will land in.
