### PR TITLE
itest: properly handle the creation of timeout context

### DIFF
--- a/docs/release-notes/release-notes-0.14.0.md
+++ b/docs/release-notes/release-notes-0.14.0.md
@@ -139,6 +139,9 @@ you.
 
 * [Link channel point logging](https://github.com/lightningnetwork/lnd/pull/5508)
 
+* [Fixed context leak in integration tests, and properly handled context
+  timeout](https://github.com/lightningnetwork/lnd/pull/5646).
+
 ## Database
 
 * [Ensure single writer for legacy

--- a/lntest/harness.go
+++ b/lntest/harness.go
@@ -1123,8 +1123,12 @@ func (n *NetworkHarness) OpenPendingChannel(ctx context.Context,
 // consuming a message from the past open channel stream. If the passed context
 // has a timeout, then if the timeout is reached before the channel has been
 // opened, then an error is returned.
-func (n *NetworkHarness) WaitForChannelOpen(ctx context.Context,
+func (n *NetworkHarness) WaitForChannelOpen(
 	openChanStream lnrpc.Lightning_OpenChannelClient) (*lnrpc.ChannelPoint, error) {
+
+	ctxb := context.Background()
+	ctx, cancel := context.WithTimeout(ctxb, ChannelOpenTimeout)
+	defer cancel()
 
 	errChan := make(chan error)
 	respChan := make(chan *lnrpc.ChannelPoint)
@@ -1294,8 +1298,12 @@ func (n *NetworkHarness) CloseChannel(ctx context.Context,
 // stream that the node has deemed the channel has been fully closed. If the
 // passed context has a timeout, then if the timeout is reached before the
 // notification is received then an error is returned.
-func (n *NetworkHarness) WaitForChannelClose(ctx context.Context,
+func (n *NetworkHarness) WaitForChannelClose(
 	closeChanStream lnrpc.Lightning_CloseChannelClient) (*chainhash.Hash, error) {
+
+	ctxb := context.Background()
+	ctx, cancel := context.WithTimeout(ctxb, ChannelCloseTimeout)
+	defer cancel()
 
 	errChan := make(chan error)
 	updateChan := make(chan *lnrpc.CloseStatusUpdate_ChanClose)

--- a/lntest/harness.go
+++ b/lntest/harness.go
@@ -548,8 +548,10 @@ tryconnect:
 // behave the same as ConnectNodes. If a pending connection request has already
 // been made, the method will block until the two nodes appear in each other's
 // peers list, or until the 15s timeout expires.
-func (n *NetworkHarness) EnsureConnected(ctx context.Context,
-	t *testing.T, a, b *HarnessNode) {
+func (n *NetworkHarness) EnsureConnected(t *testing.T, a, b *HarnessNode) {
+	ctxb := context.Background()
+	ctx, cancel := context.WithTimeout(ctxb, DefaultTimeout)
+	defer cancel()
 
 	// errConnectionRequested is used to signal that a connection was
 	// requested successfully, which is distinct from already being

--- a/lntest/harness.go
+++ b/lntest/harness.go
@@ -1386,12 +1386,11 @@ func (n *NetworkHarness) DumpLogs(node *HarnessNode) (string, error) {
 // SendCoins attempts to send amt satoshis from the internal mining node to the
 // targeted lightning node using a P2WKH address. 6 blocks are mined after in
 // order to confirm the transaction.
-func (n *NetworkHarness) SendCoins(ctx context.Context, t *testing.T,
-	amt btcutil.Amount, target *HarnessNode) {
+func (n *NetworkHarness) SendCoins(t *testing.T, amt btcutil.Amount,
+	target *HarnessNode) {
 
 	err := n.sendCoins(
-		ctx, amt, target, lnrpc.AddressType_WITNESS_PUBKEY_HASH,
-		true,
+		amt, target, lnrpc.AddressType_WITNESS_PUBKEY_HASH, true,
 	)
 	require.NoErrorf(t, err, "unable to send coins for %s", target.Cfg.Name)
 }
@@ -1399,12 +1398,11 @@ func (n *NetworkHarness) SendCoins(ctx context.Context, t *testing.T,
 // SendCoinsUnconfirmed sends coins from the internal mining node to the target
 // lightning node using a P2WPKH address. No blocks are mined after, so the
 // transaction remains unconfirmed.
-func (n *NetworkHarness) SendCoinsUnconfirmed(ctx context.Context,
-	t *testing.T, amt btcutil.Amount, target *HarnessNode) {
+func (n *NetworkHarness) SendCoinsUnconfirmed(t *testing.T, amt btcutil.Amount,
+	target *HarnessNode) {
 
 	err := n.sendCoins(
-		ctx, amt, target, lnrpc.AddressType_WITNESS_PUBKEY_HASH,
-		false,
+		amt, target, lnrpc.AddressType_WITNESS_PUBKEY_HASH, false,
 	)
 	require.NoErrorf(
 		t, err, "unable to send unconfirmed coins for %s",
@@ -1414,12 +1412,11 @@ func (n *NetworkHarness) SendCoinsUnconfirmed(ctx context.Context,
 
 // SendCoinsNP2WKH attempts to send amt satoshis from the internal mining node
 // to the targeted lightning node using a NP2WKH address.
-func (n *NetworkHarness) SendCoinsNP2WKH(ctx context.Context,
-	t *testing.T, amt btcutil.Amount, target *HarnessNode) {
+func (n *NetworkHarness) SendCoinsNP2WKH(t *testing.T, amt btcutil.Amount,
+	target *HarnessNode) {
 
 	err := n.sendCoins(
-		ctx, amt, target, lnrpc.AddressType_NESTED_PUBKEY_HASH,
-		true,
+		amt, target, lnrpc.AddressType_NESTED_PUBKEY_HASH, true,
 	)
 	require.NoErrorf(
 		t, err, "unable to send NP2WKH coins for %s",
@@ -1430,9 +1427,12 @@ func (n *NetworkHarness) SendCoinsNP2WKH(ctx context.Context,
 // sendCoins attempts to send amt satoshis from the internal mining node to the
 // targeted lightning node. The confirmed boolean indicates whether the
 // transaction that pays to the target should confirm.
-func (n *NetworkHarness) sendCoins(ctx context.Context, amt btcutil.Amount,
-	target *HarnessNode, addrType lnrpc.AddressType,
-	confirmed bool) error {
+func (n *NetworkHarness) sendCoins(amt btcutil.Amount, target *HarnessNode,
+	addrType lnrpc.AddressType, confirmed bool) error {
+
+	ctxb := context.Background()
+	ctx, cancel := context.WithTimeout(ctxb, DefaultTimeout)
+	defer cancel()
 
 	balReq := &lnrpc.WalletBalanceRequest{}
 	initialBalance, err := target.WalletBalance(ctx, balReq)

--- a/lntest/harness.go
+++ b/lntest/harness.go
@@ -910,10 +910,10 @@ func saveProfilesPage(node *HarnessNode) error {
 	return nil
 }
 
-// WaitForTxInMempool blocks until the target txid is seen in the mempool. If
+// waitForTxInMempool blocks until the target txid is seen in the mempool. If
 // the transaction isn't seen within the network before the passed timeout,
 // then an error is returned.
-func (n *NetworkHarness) WaitForTxInMempool(ctx context.Context,
+func (n *NetworkHarness) waitForTxInMempool(ctx context.Context,
 	txid chainhash.Hash) error {
 
 	// Return immediately if harness has been torn down.
@@ -1280,7 +1280,7 @@ func (n *NetworkHarness) CloseChannel(lnNode *HarnessNode,
 				"%v", err)
 			return
 		}
-		if err := n.WaitForTxInMempool(ctx, *closeTxid); err != nil {
+		if err := n.waitForTxInMempool(ctx, *closeTxid); err != nil {
 			errChan <- fmt.Errorf("error while waiting for "+
 				"broadcast tx: %v", err)
 			return

--- a/lntest/harness.go
+++ b/lntest/harness.go
@@ -178,7 +178,7 @@ func (n *NetworkHarness) SetUp(t *testing.T,
 	// both nodes are fully started since the Connect RPC is guarded behind
 	// the server.Started() flag that waits for all subsystems to be ready.
 	ctxb := context.Background()
-	n.ConnectNodes(ctxb, t, n.Alice, n.Bob)
+	n.ConnectNodes(t, n.Alice, n.Bob)
 
 	// Load up the wallets of the seeder nodes with 10 outputs of 1 BTC
 	// each.
@@ -670,8 +670,10 @@ func (n *NetworkHarness) EnsureConnected(ctx context.Context,
 //
 // NOTE: This function may block for up to 15-seconds as it will not return
 // until the new connection is detected as being known to both nodes.
-func (n *NetworkHarness) ConnectNodes(ctx context.Context, t *testing.T,
-	a, b *HarnessNode) {
+func (n *NetworkHarness) ConnectNodes(t *testing.T, a, b *HarnessNode) {
+	ctxb := context.Background()
+	ctx, cancel := context.WithTimeout(ctxb, DefaultTimeout)
+	defer cancel()
 
 	bobInfo, err := b.GetInfo(ctx, &lnrpc.GetInfoRequest{})
 	require.NoErrorf(

--- a/lntest/harness.go
+++ b/lntest/harness.go
@@ -723,7 +723,11 @@ func (n *NetworkHarness) ConnectNodes(t *testing.T, a, b *HarnessNode) {
 
 // DisconnectNodes disconnects node a from node b by sending RPC message
 // from a node to b node
-func (n *NetworkHarness) DisconnectNodes(ctx context.Context, a, b *HarnessNode) error {
+func (n *NetworkHarness) DisconnectNodes(a, b *HarnessNode) error {
+	ctxb := context.Background()
+	ctx, cancel := context.WithTimeout(ctxb, DefaultTimeout)
+	defer cancel()
+
 	bobInfo, err := b.GetInfo(ctx, &lnrpc.GetInfoRequest{})
 	if err != nil {
 		return err
@@ -988,9 +992,12 @@ type OpenChannelParams struct {
 // if the timeout is reached before the channel pending notification is
 // received, an error is returned. The confirmed boolean determines whether we
 // should fund the channel with confirmed outputs or not.
-func (n *NetworkHarness) OpenChannel(ctx context.Context,
-	srcNode, destNode *HarnessNode, p OpenChannelParams) (
-	lnrpc.Lightning_OpenChannelClient, error) {
+func (n *NetworkHarness) OpenChannel(srcNode, destNode *HarnessNode,
+	p OpenChannelParams) (lnrpc.Lightning_OpenChannelClient, error) {
+
+	ctxb := context.Background()
+	ctx, cancel := context.WithTimeout(ctxb, ChannelOpenTimeout)
+	defer cancel()
 
 	// Wait until srcNode and destNode have the latest chain synced.
 	// Otherwise, we may run into a check within the funding manager that
@@ -1062,9 +1069,13 @@ func (n *NetworkHarness) OpenChannel(ctx context.Context,
 // passed channel funding parameters. If the passed context has a timeout, then
 // if the timeout is reached before the channel pending notification is
 // received, an error is returned.
-func (n *NetworkHarness) OpenPendingChannel(ctx context.Context,
-	srcNode, destNode *HarnessNode, amt btcutil.Amount,
+func (n *NetworkHarness) OpenPendingChannel(srcNode, destNode *HarnessNode,
+	amt btcutil.Amount,
 	pushAmt btcutil.Amount) (*lnrpc.PendingUpdate, error) {
+
+	ctxb := context.Background()
+	ctx, cancel := context.WithTimeout(ctxb, ChannelOpenTimeout)
+	defer cancel()
 
 	// Wait until srcNode and destNode have blockchain synced
 	if err := srcNode.WaitForBlockchainSync(ctx); err != nil {

--- a/lntest/harness.go
+++ b/lntest/harness.go
@@ -1163,9 +1163,13 @@ func (n *NetworkHarness) WaitForChannelOpen(
 // passed channel point, initiated by the passed lnNode. If the passed context
 // has a timeout, an error is returned if that timeout is reached before the
 // channel close is pending.
-func (n *NetworkHarness) CloseChannel(ctx context.Context,
-	lnNode *HarnessNode, cp *lnrpc.ChannelPoint,
+func (n *NetworkHarness) CloseChannel(lnNode *HarnessNode,
+	cp *lnrpc.ChannelPoint,
 	force bool) (lnrpc.Lightning_CloseChannelClient, *chainhash.Hash, error) {
+
+	ctxb := context.Background()
+	ctx, cancel := context.WithTimeout(ctxb, ChannelCloseTimeout)
+	defer cancel()
 
 	// Create a channel outpoint that we can use to compare to channels
 	// from the ListChannelsResponse.
@@ -1342,9 +1346,12 @@ func (n *NetworkHarness) WaitForChannelClose(
 // assertions using channel's values. These functions are responsible for
 // failing the test themselves if they do not pass.
 // nolint: interfacer
-func (n *NetworkHarness) AssertChannelExists(ctx context.Context,
-	node *HarnessNode, chanPoint *wire.OutPoint,
-	checks ...func(*lnrpc.Channel)) error {
+func (n *NetworkHarness) AssertChannelExists(node *HarnessNode,
+	chanPoint *wire.OutPoint, checks ...func(*lnrpc.Channel)) error {
+
+	ctxb := context.Background()
+	ctx, cancel := context.WithTimeout(ctxb, ChannelCloseTimeout)
+	defer cancel()
 
 	req := &lnrpc.ListChannelsRequest{}
 

--- a/lntest/itest/assertions.go
+++ b/lntest/itest/assertions.go
@@ -62,11 +62,15 @@ func openChannelStream(ctx context.Context, t *harnessTest,
 // after the channel is considered open: the funding transaction should be
 // found within a block, and that Alice can report the status of the new
 // channel.
-func openChannelAndAssert(ctx context.Context, t *harnessTest,
-	net *lntest.NetworkHarness, alice, bob *lntest.HarnessNode,
+func openChannelAndAssert(t *harnessTest, net *lntest.NetworkHarness,
+	alice, bob *lntest.HarnessNode,
 	p lntest.OpenChannelParams) *lnrpc.ChannelPoint {
 
 	t.t.Helper()
+
+	ctxb := context.Background()
+	ctx, cancel := context.WithTimeout(ctxb, channelOpenTimeout)
+	defer cancel()
 
 	chanOpenUpdate := openChannelStream(ctx, t, net, alice, bob, p)
 

--- a/lntest/itest/assertions.go
+++ b/lntest/itest/assertions.go
@@ -84,7 +84,7 @@ func openChannelAndAssert(t *harnessTest, net *lntest.NetworkHarness,
 	// case that the channel is public, it is announced to the network.
 	block := mineBlocks(t, net, 6, 1)[0]
 
-	fundingChanPoint, err := net.WaitForChannelOpen(ctx, chanOpenUpdate)
+	fundingChanPoint, err := net.WaitForChannelOpen(chanOpenUpdate)
 	require.NoError(t.t, err, "error while waiting for channel open")
 
 	fundingTxID, err := lnrpc.GetChanPointFundingTxid(fundingChanPoint)
@@ -343,7 +343,7 @@ func assertChannelClosed(ctx context.Context, t *harnessTest,
 
 	block := mineBlocks(t, net, 1, expectedTxes)[0]
 
-	closingTxid, err := net.WaitForChannelClose(ctx, closeUpdates)
+	closingTxid, err := net.WaitForChannelClose(closeUpdates)
 	require.NoError(t.t, err, "error while waiting for channel close")
 
 	assertTxInBlock(t, block, closingTxid)

--- a/lntest/itest/assertions.go
+++ b/lntest/itest/assertions.go
@@ -976,11 +976,11 @@ func checkPendingHtlcStageAndMaturity(
 
 // assertReports checks that the count of resolutions we have present per
 // type matches a set of expected resolutions.
-func assertReports(ctxb context.Context, t *harnessTest,
-	node *lntest.HarnessNode, channelPoint wire.OutPoint,
-	expected map[string]*lnrpc.Resolution) {
+func assertReports(t *harnessTest, node *lntest.HarnessNode,
+	channelPoint wire.OutPoint, expected map[string]*lnrpc.Resolution) {
 
 	// Get our node's closed channels.
+	ctxb := context.Background()
 	ctxt, cancel := context.WithTimeout(ctxb, defaultTimeout)
 	defer cancel()
 
@@ -1011,11 +1011,13 @@ func assertReports(ctxb context.Context, t *harnessTest,
 }
 
 // assertSweepFound looks up a sweep in a nodes list of broadcast sweeps.
-func assertSweepFound(ctx context.Context, t *testing.T, node *lntest.HarnessNode,
+func assertSweepFound(t *testing.T, node *lntest.HarnessNode,
 	sweep string, verbose bool) {
 
 	// List all sweeps that alice's node had broadcast.
-	ctx, _ = context.WithTimeout(ctx, defaultTimeout)
+	ctxb := context.Background()
+	ctx, cancel := context.WithTimeout(ctxb, defaultTimeout)
+	defer cancel()
 	sweepResp, err := node.WalletKitClient.ListSweeps(
 		ctx, &walletrpc.ListSweepsRequest{
 			Verbose: verbose,
@@ -1641,6 +1643,7 @@ func assertActiveHtlcs(nodes []*lntest.HarnessNode, payHashes ...[]byte) error {
 
 func assertNumActiveHtlcsChanPoint(node *lntest.HarnessNode,
 	chanPoint wire.OutPoint, numHtlcs int) error {
+
 	ctxb := context.Background()
 
 	req := &lnrpc.ListChannelsRequest{}
@@ -1732,12 +1735,13 @@ func getSpendingTxInMempool(t *harnessTest, miner *rpcclient.Client,
 
 // assertTxLabel is a helper function which finds a target tx in our set
 // of transactions and checks that it has the desired label.
-func assertTxLabel(ctx context.Context, t *harnessTest,
-	node *lntest.HarnessNode, targetTx, label string) {
+func assertTxLabel(t *harnessTest, node *lntest.HarnessNode,
+	targetTx, label string) {
 
 	// List all transactions relevant to our wallet, and find the tx so that
 	// we can check the correct label has been set.
-	ctxt, cancel := context.WithTimeout(ctx, defaultTimeout)
+	ctxb := context.Background()
+	ctxt, cancel := context.WithTimeout(ctxb, defaultTimeout)
 	defer cancel()
 
 	txResp, err := node.GetTransactions(
@@ -1756,8 +1760,12 @@ func assertTxLabel(ctx context.Context, t *harnessTest,
 
 // sendAndAssertSuccess sends the given payment requests and asserts that the
 // payment completes successfully.
-func sendAndAssertSuccess(ctx context.Context, t *harnessTest, node *lntest.HarnessNode,
+func sendAndAssertSuccess(t *harnessTest, node *lntest.HarnessNode,
 	req *routerrpc.SendPaymentRequest) *lnrpc.Payment {
+
+	ctxb := context.Background()
+	ctx, cancel := context.WithTimeout(ctxb, defaultTimeout)
+	defer cancel()
 
 	var result *lnrpc.Payment
 	err := wait.NoError(func() error {

--- a/lntest/itest/assertions.go
+++ b/lntest/itest/assertions.go
@@ -72,10 +72,6 @@ func openChannelAndAssert(t *harnessTest, net *lntest.NetworkHarness,
 
 	t.t.Helper()
 
-	ctxb := context.Background()
-	ctx, cancel := context.WithTimeout(ctxb, channelOpenTimeout)
-	defer cancel()
-
 	chanOpenUpdate := openChannelStream(t, net, alice, bob, p)
 
 	// Mine 6 blocks, then wait for Alice's node to notify us that the
@@ -99,11 +95,11 @@ func openChannelAndAssert(t *harnessTest, net *lntest.NetworkHarness,
 		Index: fundingChanPoint.OutputIndex,
 	}
 	require.NoError(
-		t.t, net.AssertChannelExists(ctx, alice, &chanPoint),
+		t.t, net.AssertChannelExists(alice, &chanPoint),
 		"unable to assert channel existence",
 	)
 	require.NoError(
-		t.t, net.AssertChannelExists(ctx, bob, &chanPoint),
+		t.t, net.AssertChannelExists(bob, &chanPoint),
 		"unable to assert channel existence",
 	)
 
@@ -238,9 +234,7 @@ func closeChannelAndAssertType(t *harnessTest,
 		defer close(graphSub.quit)
 	}
 
-	closeUpdates, _, err := net.CloseChannel(
-		ctxt, node, fundingChanPoint, force,
-	)
+	closeUpdates, _, err := net.CloseChannel(node, fundingChanPoint, force)
 	require.NoError(t.t, err, "unable to close channel")
 
 	// If the channel policy was enabled prior to the closure, wait until we
@@ -277,7 +271,7 @@ func closeReorgedChannelAndAssert(t *harnessTest,
 	ctx, cancel := context.WithTimeout(ctxb, channelCloseTimeout)
 	defer cancel()
 
-	closeUpdates, _, err := net.CloseChannel(ctx, node, fundingChanPoint, force)
+	closeUpdates, _, err := net.CloseChannel(node, fundingChanPoint, force)
 	require.NoError(t.t, err, "unable to close channel")
 
 	return assertChannelClosed(

--- a/lntest/itest/assertions.go
+++ b/lntest/itest/assertions.go
@@ -288,9 +288,8 @@ func assertChannelClosed(ctx context.Context, t *harnessTest,
 
 	// If the channel appears in list channels, ensure that its state
 	// contains ChanStatusCoopBroadcasted.
-	ctxt, _ := context.WithTimeout(ctx, defaultTimeout)
 	listChansRequest := &lnrpc.ListChannelsRequest{}
-	listChansResp, err := node.ListChannels(ctxt, listChansRequest)
+	listChansResp, err := node.ListChannels(ctx, listChansRequest)
 	require.NoError(t.t, err, "unable to query for list channels")
 
 	for _, channel := range listChansResp.Channels {
@@ -309,9 +308,8 @@ func assertChannelClosed(ctx context.Context, t *harnessTest,
 
 	// At this point, the channel should now be marked as being in the
 	// state of "waiting close".
-	ctxt, _ = context.WithTimeout(ctx, defaultTimeout)
 	pendingChansRequest := &lnrpc.PendingChannelsRequest{}
-	pendingChanResp, err := node.PendingChannels(ctxt, pendingChansRequest)
+	pendingChanResp, err := node.PendingChannels(ctx, pendingChansRequest)
 	require.NoError(t.t, err, "unable to query for pending channels")
 
 	var found bool

--- a/lntest/itest/assertions.go
+++ b/lntest/itest/assertions.go
@@ -43,17 +43,13 @@ func openChannelStream(t *harnessTest, net *lntest.NetworkHarness,
 
 	t.t.Helper()
 
-	ctxb := context.Background()
-	ctx, cancel := context.WithTimeout(ctxb, channelOpenTimeout)
-	defer cancel()
-
 	// Wait until we are able to fund a channel successfully. This wait
 	// prevents us from erroring out when trying to create a channel while
 	// the node is starting up.
 	var chanOpenUpdate lnrpc.Lightning_OpenChannelClient
 	err := wait.NoError(func() error {
 		var err error
-		chanOpenUpdate, err = net.OpenChannel(ctx, alice, bob, p)
+		chanOpenUpdate, err = net.OpenChannel(alice, bob, p)
 		return err
 	}, defaultTimeout)
 	require.NoError(t.t, err, "unable to open channel")

--- a/lntest/itest/assertions.go
+++ b/lntest/itest/assertions.go
@@ -1279,7 +1279,7 @@ func assertDLPExecuted(net *lntest.NetworkHarness, t *harnessTest,
 	// To make sure the nodes are initiating DLP now, we have to manually
 	// re-connect them.
 	ctxb := context.Background()
-	net.EnsureConnected(ctxb, t.t, carol, dave)
+	net.EnsureConnected(t.t, carol, dave)
 
 	// Upon reconnection, the nodes should detect that Dave is out of sync.
 	// Carol should force close the channel using her latest commitment.

--- a/lntest/itest/lnd_amp_test.go
+++ b/lntest/itest/lnd_amp_test.go
@@ -117,10 +117,8 @@ func testSendPaymentAMPInvoiceCase(net *lntest.NetworkHarness, t *harnessTest,
 		require.NoError(t.t, err)
 	}
 
-	ctxt, _ := context.WithTimeout(context.Background(), 4*defaultTimeout)
 	payment := sendAndAssertSuccess(
-		ctxt, t, ctx.alice,
-		&routerrpc.SendPaymentRequest{
+		t, ctx.alice, &routerrpc.SendPaymentRequest{
 			PaymentRequest: addInvoiceResp.PaymentRequest,
 			PaymentAddr:    externalPayAddr,
 			TimeoutSeconds: 60,
@@ -249,10 +247,8 @@ func testSendPaymentAMP(net *lntest.NetworkHarness, t *harnessTest) {
 		t.Fatalf("dave policy update: %v", err)
 	}
 
-	ctxt, _ := context.WithTimeout(context.Background(), 4*defaultTimeout)
 	payment := sendAndAssertSuccess(
-		ctxt, t, ctx.alice,
-		&routerrpc.SendPaymentRequest{
+		t, ctx.alice, &routerrpc.SendPaymentRequest{
 			Dest:           ctx.bob.PubKey[:],
 			Amt:            int64(paymentAmt),
 			FinalCltvDelta: chainreg.DefaultBitcoinTimeLockDelta,

--- a/lntest/itest/lnd_channel_backup_test.go
+++ b/lntest/itest/lnd_channel_backup_test.go
@@ -902,9 +902,8 @@ func testChanRestoreScenario(t *harnessTest, net *lntest.NetworkHarness,
 	var chanPoint *lnrpc.ChannelPoint
 	switch {
 	case testCase.unconfirmed:
-		ctxt, _ := context.WithTimeout(ctxb, channelOpenTimeout)
 		_, err := net.OpenPendingChannel(
-			ctxt, from, to, chanAmt, pushAmt,
+			from, to, chanAmt, pushAmt,
 		)
 		if err != nil {
 			t.Fatalf("couldn't open pending channel: %v", err)

--- a/lntest/itest/lnd_channel_backup_test.go
+++ b/lntest/itest/lnd_channel_backup_test.go
@@ -968,7 +968,7 @@ func testChanRestoreScenario(t *harnessTest, net *lntest.NetworkHarness,
 		}
 
 		err = completePaymentRequests(
-			ctxt, from, from.RouterClient,
+			from, from.RouterClient,
 			[]string{invoiceResp.PaymentRequest}, true,
 		)
 		if err != nil {

--- a/lntest/itest/lnd_channel_backup_test.go
+++ b/lntest/itest/lnd_channel_backup_test.go
@@ -505,8 +505,7 @@ func testChannelBackupUpdates(net *lntest.NetworkHarness, t *harnessTest) {
 
 	// With Carol up, we'll now connect her to Alice, and open a channel
 	// between them.
-	ctxt, _ := context.WithTimeout(ctxb, defaultTimeout)
-	net.ConnectNodes(ctxt, t.t, carol, net.Alice)
+	net.ConnectNodes(t.t, carol, net.Alice)
 
 	// Next, we'll open two channels between Alice and Carol back to back.
 	var chanPoints []*lnrpc.ChannelPoint
@@ -641,8 +640,7 @@ func testExportChannelBackup(net *lntest.NetworkHarness, t *harnessTest) {
 
 	// With Carol up, we'll now connect her to Alice, and open a channel
 	// between them.
-	ctxt, _ := context.WithTimeout(ctxb, defaultTimeout)
-	net.ConnectNodes(ctxt, t.t, carol, net.Alice)
+	net.ConnectNodes(t.t, carol, net.Alice)
 
 	// Next, we'll open two channels between Alice and Carol back to back.
 	var chanPoints []*lnrpc.ChannelPoint
@@ -899,7 +897,7 @@ func testChanRestoreScenario(t *harnessTest, net *lntest.NetworkHarness,
 
 	// Next, we'll connect Dave to Carol, and open a new channel to her
 	// with a portion pushed.
-	net.ConnectNodes(ctxt, t.t, dave, carol)
+	net.ConnectNodes(t.t, dave, carol)
 
 	// We will either open a confirmed or unconfirmed channel, depending on
 	// the requirements of the test case.

--- a/lntest/itest/lnd_channel_backup_test.go
+++ b/lntest/itest/lnd_channel_backup_test.go
@@ -876,17 +876,15 @@ func testChanRestoreScenario(t *harnessTest, net *lntest.NetworkHarness,
 
 	// Now that our new nodes are created, we'll give them some coins for
 	// channel opening and anchor sweeping.
-	ctxt, _ := context.WithTimeout(ctxb, defaultTimeout)
-	net.SendCoins(ctxt, t.t, btcutil.SatoshiPerBitcoin, carol)
+	net.SendCoins(t.t, btcutil.SatoshiPerBitcoin, carol)
 
 	// For the anchor output case we need two UTXOs for Carol so she can
 	// sweep both the local and remote anchor.
 	if testCase.anchorCommit {
-		net.SendCoins(ctxt, t.t, btcutil.SatoshiPerBitcoin, carol)
+		net.SendCoins(t.t, btcutil.SatoshiPerBitcoin, carol)
 	}
 
-	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
-	net.SendCoins(ctxt, t.t, btcutil.SatoshiPerBitcoin, dave)
+	net.SendCoins(t.t, btcutil.SatoshiPerBitcoin, dave)
 
 	var from, to *lntest.HarnessNode
 	if testCase.initiator {
@@ -904,7 +902,7 @@ func testChanRestoreScenario(t *harnessTest, net *lntest.NetworkHarness,
 	var chanPoint *lnrpc.ChannelPoint
 	switch {
 	case testCase.unconfirmed:
-		ctxt, _ = context.WithTimeout(ctxb, channelOpenTimeout)
+		ctxt, _ := context.WithTimeout(ctxb, channelOpenTimeout)
 		_, err := net.OpenPendingChannel(
 			ctxt, from, to, chanAmt, pushAmt,
 		)
@@ -945,7 +943,7 @@ func testChanRestoreScenario(t *harnessTest, net *lntest.NetworkHarness,
 		)
 
 		// Wait for both sides to see the opened channel.
-		ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
+		ctxt, _ := context.WithTimeout(ctxb, defaultTimeout)
 		err = dave.WaitForNetworkChannelOpen(ctxt, chanPoint)
 		if err != nil {
 			t.Fatalf("dave didn't report channel: %v", err)
@@ -959,6 +957,8 @@ func testChanRestoreScenario(t *harnessTest, net *lntest.NetworkHarness,
 	// If both parties should start with existing channel updates, then
 	// we'll send+settle an HTLC between 'from' and 'to' now.
 	if testCase.channelsUpdated {
+		ctxt, _ := context.WithTimeout(ctxb, defaultTimeout)
+
 		invoice := &lnrpc.Invoice{
 			Memo:  "testing",
 			Value: 100000,
@@ -968,7 +968,6 @@ func testChanRestoreScenario(t *harnessTest, net *lntest.NetworkHarness,
 			t.Fatalf("unable to add invoice: %v", err)
 		}
 
-		ctxt, _ := context.WithTimeout(ctxb, defaultTimeout)
 		err = completePaymentRequests(
 			ctxt, from, from.RouterClient,
 			[]string{invoiceResp.PaymentRequest}, true,
@@ -1007,7 +1006,7 @@ func testChanRestoreScenario(t *harnessTest, net *lntest.NetworkHarness,
 	// Before we start the recovery, we'll record the balances of both
 	// Carol and Dave to ensure they both sweep their coins at the end.
 	balReq := &lnrpc.WalletBalanceRequest{}
-	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
+	ctxt, _ := context.WithTimeout(ctxb, defaultTimeout)
 	carolBalResp, err := carol.WalletBalance(ctxt, balReq)
 	if err != nil {
 		t.Fatalf("unable to get carol's balance: %v", err)

--- a/lntest/itest/lnd_channel_backup_test.go
+++ b/lntest/itest/lnd_channel_backup_test.go
@@ -1079,8 +1079,7 @@ func testChanRestoreScenario(t *harnessTest, net *lntest.NetworkHarness,
 		// Now that we have our new node up, we expect that it'll
 		// re-connect to Carol automatically based on the restored
 		// backup.
-		ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
-		net.EnsureConnected(ctxt, t.t, dave, carol)
+		net.EnsureConnected(t.t, dave, carol)
 
 		assertTimeLockSwept(
 			net, t, carol, carolStartingBalance, dave,
@@ -1172,8 +1171,7 @@ func testChanRestoreScenario(t *harnessTest, net *lntest.NetworkHarness,
 
 	// Now that we have our new node up, we expect that it'll re-connect to
 	// Carol automatically based on the restored backup.
-	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
-	net.EnsureConnected(ctxt, t.t, dave, carol)
+	net.EnsureConnected(t.t, dave, carol)
 
 	// TODO(roasbeef): move dave restarts?
 

--- a/lntest/itest/lnd_channel_backup_test.go
+++ b/lntest/itest/lnd_channel_backup_test.go
@@ -513,12 +513,9 @@ func testChannelBackupUpdates(net *lntest.NetworkHarness, t *harnessTest) {
 	numChans := 2
 	chanAmt := btcutil.Amount(1000000)
 	for i := 0; i < numChans; i++ {
-		ctxt, _ := context.WithTimeout(ctxb, channelOpenTimeout)
 		chanPoint := openChannelAndAssert(
-			ctxt, t, net, net.Alice, carol,
-			lntest.OpenChannelParams{
-				Amt: chanAmt,
-			},
+			t, net, net.Alice, carol,
+			lntest.OpenChannelParams{Amt: chanAmt},
 		)
 
 		chanPoints = append(chanPoints, chanPoint)
@@ -652,12 +649,9 @@ func testExportChannelBackup(net *lntest.NetworkHarness, t *harnessTest) {
 	numChans := 2
 	chanAmt := btcutil.Amount(1000000)
 	for i := 0; i < numChans; i++ {
-		ctxt, _ := context.WithTimeout(ctxb, channelOpenTimeout)
 		chanPoint := openChannelAndAssert(
-			ctxt, t, net, net.Alice, carol,
-			lntest.OpenChannelParams{
-				Amt: chanAmt,
-			},
+			t, net, net.Alice, carol,
+			lntest.OpenChannelParams{Amt: chanAmt},
 		)
 
 		chanPoints = append(chanPoints, chanPoint)
@@ -943,9 +937,8 @@ func testChanRestoreScenario(t *harnessTest, net *lntest.NetworkHarness,
 		)
 
 	default:
-		ctxt, _ = context.WithTimeout(ctxb, channelOpenTimeout)
 		chanPoint = openChannelAndAssert(
-			ctxt, t, net, from, to,
+			t, net, from, to,
 			lntest.OpenChannelParams{
 				Amt:     chanAmt,
 				PushAmt: pushAmt,

--- a/lntest/itest/lnd_channel_balance_test.go
+++ b/lntest/itest/lnd_channel_balance_test.go
@@ -54,9 +54,8 @@ func testChannelBalance(net *lntest.NetworkHarness, t *harnessTest) {
 	ctxt, _ := context.WithTimeout(ctxb, defaultTimeout)
 	net.EnsureConnected(ctxt, t.t, net.Alice, net.Bob)
 
-	ctxt, _ = context.WithTimeout(ctxb, channelOpenTimeout)
 	chanPoint := openChannelAndAssert(
-		ctxt, t, net, net.Alice, net.Bob,
+		t, net, net.Alice, net.Bob,
 		lntest.OpenChannelParams{
 			Amt: amount,
 		},
@@ -149,9 +148,8 @@ func testChannelUnsettledBalance(net *lntest.NetworkHarness, t *harnessTest) {
 	net.ConnectNodes(ctxb, t.t, net.Alice, carol)
 
 	// Open a channel between Alice and Carol.
-	ctxt, _ = context.WithTimeout(ctxb, channelOpenTimeout)
 	chanPointAlice := openChannelAndAssert(
-		ctxt, t, net, net.Alice, carol,
+		t, net, net.Alice, carol,
 		lntest.OpenChannelParams{
 			Amt: chanAmt,
 		},

--- a/lntest/itest/lnd_channel_balance_test.go
+++ b/lntest/itest/lnd_channel_balance_test.go
@@ -51,8 +51,7 @@ func testChannelBalance(net *lntest.NetworkHarness, t *harnessTest) {
 	}
 
 	// Before beginning, make sure alice and bob are connected.
-	ctxt, _ := context.WithTimeout(ctxb, defaultTimeout)
-	net.EnsureConnected(ctxt, t.t, net.Alice, net.Bob)
+	net.EnsureConnected(t.t, net.Alice, net.Bob)
 
 	chanPoint := openChannelAndAssert(
 		t, net, net.Alice, net.Bob,
@@ -62,7 +61,7 @@ func testChannelBalance(net *lntest.NetworkHarness, t *harnessTest) {
 	)
 
 	// Wait for both Alice and Bob to recognize this new channel.
-	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
+	ctxt, _ := context.WithTimeout(ctxb, defaultTimeout)
 	err := net.Alice.WaitForNetworkChannelOpen(ctxt, chanPoint)
 	if err != nil {
 		t.Fatalf("alice didn't advertise channel before "+

--- a/lntest/itest/lnd_channel_balance_test.go
+++ b/lntest/itest/lnd_channel_balance_test.go
@@ -144,8 +144,7 @@ func testChannelUnsettledBalance(net *lntest.NetworkHarness, t *harnessTest) {
 	defer shutdownAndAssert(net, t, carol)
 
 	// Connect Alice to Carol.
-	ctxt, _ := context.WithTimeout(ctxb, defaultTimeout)
-	net.ConnectNodes(ctxb, t.t, net.Alice, carol)
+	net.ConnectNodes(t.t, net.Alice, carol)
 
 	// Open a channel between Alice and Carol.
 	chanPointAlice := openChannelAndAssert(
@@ -157,7 +156,7 @@ func testChannelUnsettledBalance(net *lntest.NetworkHarness, t *harnessTest) {
 
 	// Wait for Alice and Carol to receive the channel edge from the
 	// funding manager.
-	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
+	ctxt, _ := context.WithTimeout(ctxb, defaultTimeout)
 	err := net.Alice.WaitForNetworkChannelOpen(ctxt, chanPointAlice)
 	if err != nil {
 		t.Fatalf("alice didn't see the alice->carol channel before "+

--- a/lntest/itest/lnd_channel_balance_test.go
+++ b/lntest/itest/lnd_channel_balance_test.go
@@ -227,8 +227,7 @@ func testChannelUnsettledBalance(net *lntest.NetworkHarness, t *harnessTest) {
 		// Check each nodes UnsettledBalance field.
 		for _, node := range nodes {
 			// Get channel info for the node.
-			ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
-			chanInfo, err := getChanInfo(ctxt, node)
+			chanInfo, err := getChanInfo(node)
 			if err != nil {
 				unsettledErr = err
 				return false

--- a/lntest/itest/lnd_channel_force_close.go
+++ b/lntest/itest/lnd_channel_force_close.go
@@ -109,7 +109,7 @@ func testCommitmentTransactionDeadline(net *lntest.NetworkHarness,
 
 		// Open a channel between Alice and Bob.
 		chanPoint := openChannelAndAssert(
-			ctxt, t, net, alice, bob, lntest.OpenChannelParams{
+			t, net, alice, bob, lntest.OpenChannelParams{
 				Amt:     10e6,
 				PushAmt: 5e6,
 			},
@@ -335,9 +335,8 @@ func channelForceClosureTest(net *lntest.NetworkHarness, t *harnessTest,
 
 	carolStartingBalance := carolBalResp.ConfirmedBalance
 
-	ctxt, _ = context.WithTimeout(ctxb, channelOpenTimeout)
 	chanPoint := openChannelAndAssert(
-		ctxt, t, net, alice, carol,
+		t, net, alice, carol,
 		lntest.OpenChannelParams{
 			Amt:     chanAmt,
 			PushAmt: pushAmt,
@@ -1421,9 +1420,8 @@ func testFailingChannel(net *lntest.NetworkHarness, t *harnessTest) {
 	// Let Alice connect and open a channel to Carol,
 	ctxt, _ := context.WithTimeout(ctxb, defaultTimeout)
 	net.ConnectNodes(ctxt, t.t, net.Alice, carol)
-	ctxt, _ = context.WithTimeout(ctxb, channelOpenTimeout)
 	chanPoint := openChannelAndAssert(
-		ctxt, t, net, net.Alice, carol,
+		t, net, net.Alice, carol,
 		lntest.OpenChannelParams{
 			Amt: chanAmt,
 		},

--- a/lntest/itest/lnd_channel_force_close.go
+++ b/lntest/itest/lnd_channel_force_close.go
@@ -785,7 +785,7 @@ func channelForceClosureTest(net *lntest.NetworkHarness, t *harnessTest,
 
 	// Check that we can find the commitment sweep in our set of known
 	// sweeps, using the simple transaction id ListSweeps output.
-	assertSweepFound(ctxb, t.t, alice, sweepingTXID.String(), false)
+	assertSweepFound(t.t, alice, sweepingTXID.String(), false)
 
 	// Restart Alice to ensure that she resumes watching the finalized
 	// commitment sweep txid.
@@ -1218,7 +1218,7 @@ func channelForceClosureTest(net *lntest.NetworkHarness, t *harnessTest,
 
 	// Check that we can find the htlc sweep in our set of sweeps using
 	// the verbose output of the listsweeps output.
-	assertSweepFound(ctxb, t.t, alice, htlcSweepTx.Hash().String(), true)
+	assertSweepFound(t.t, alice, htlcSweepTx.Hash().String(), true)
 
 	// The following restart checks to ensure that the nursery store is
 	// storing the txid of the previously broadcast htlc sweep txn, and that
@@ -1336,8 +1336,8 @@ func channelForceClosureTest(net *lntest.NetworkHarness, t *harnessTest,
 
 	// Finally, we check that alice and carol have the set of resolutions
 	// we expect.
-	assertReports(ctxb, t, alice, op, aliceReports)
-	assertReports(ctxb, t, carol, op, carolReports)
+	assertReports(t, alice, op, aliceReports)
+	assertReports(t, carol, op, carolReports)
 }
 
 // padCLTV is a small helper function that pads a cltv value with a block

--- a/lntest/itest/lnd_channel_force_close.go
+++ b/lntest/itest/lnd_channel_force_close.go
@@ -1444,9 +1444,8 @@ func testFailingChannel(net *lntest.NetworkHarness, t *harnessTest) {
 
 	// Send the payment from Alice to Carol. We expect Carol to attempt to
 	// settle this payment with the wrong preimage.
-	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
 	err = completePaymentRequests(
-		ctxt, net.Alice, net.Alice.RouterClient, carolPayReqs, false,
+		net.Alice, net.Alice.RouterClient, carolPayReqs, false,
 	)
 	if err != nil {
 		t.Fatalf("unable to send payments: %v", err)

--- a/lntest/itest/lnd_channel_force_close.go
+++ b/lntest/itest/lnd_channel_force_close.go
@@ -73,19 +73,19 @@ func testCommitmentTransactionDeadline(net *lntest.NetworkHarness,
 	net.SetFeeEstimate(feeRateDefault)
 
 	// setupNode creates a new node and sends 1 btc to the node.
-	setupNode := func(ctx context.Context, name string) *lntest.HarnessNode {
+	setupNode := func(name string) *lntest.HarnessNode {
 		// Create the node.
 		args := []string{"--hodl.exit-settle"}
 		args = append(args, commitTypeAnchors.Args()...)
 		node := net.NewNode(t.t, name, args)
 
 		// Send some coins to the node.
-		net.SendCoins(ctx, t.t, btcutil.SatoshiPerBitcoin, node)
+		net.SendCoins(t.t, btcutil.SatoshiPerBitcoin, node)
 
 		// For neutrino backend, we need one additional UTXO to create
 		// the sweeping tx for the remote anchor.
 		if net.BackendCfg.Name() == lntest.NeutrinoBackendName {
-			net.SendCoins(ctx, t.t, btcutil.SatoshiPerBitcoin, node)
+			net.SendCoins(t.t, btcutil.SatoshiPerBitcoin, node)
 		}
 
 		return node
@@ -98,10 +98,10 @@ func testCommitmentTransactionDeadline(net *lntest.NetworkHarness,
 		defer cancel()
 
 		// Create two nodes, Alice and Bob.
-		alice := setupNode(ctxt, "Alice")
+		alice := setupNode("Alice")
 		defer shutdownAndAssert(net, t, alice)
 
-		bob := setupNode(ctxt, "Bob")
+		bob := setupNode("Bob")
 		defer shutdownAndAssert(net, t, bob)
 
 		// Connect Alice to Bob.
@@ -277,14 +277,11 @@ func testChannelForceClosure(net *lntest.NetworkHarness, t *harnessTest) {
 
 			// Each time, we'll send Alice  new set of coins in
 			// order to fund the channel.
-			ctxt, _ := context.WithTimeout(
-				context.Background(), defaultTimeout,
-			)
-			net.SendCoins(ctxt, t, btcutil.SatoshiPerBitcoin, alice)
+			net.SendCoins(t, btcutil.SatoshiPerBitcoin, alice)
 
 			// Also give Carol some coins to allow her to sweep her
 			// anchor.
-			net.SendCoins(ctxt, t, btcutil.SatoshiPerBitcoin, carol)
+			net.SendCoins(t, btcutil.SatoshiPerBitcoin, carol)
 
 			channelForceClosureTest(
 				net, ht, alice, carol, channelType,
@@ -320,14 +317,13 @@ func channelForceClosureTest(net *lntest.NetworkHarness, t *harnessTest,
 	net.ConnectNodes(t.t, alice, carol)
 
 	// We need one additional UTXO for sweeping the remote anchor.
-	ctxt, _ := context.WithTimeout(ctxb, defaultTimeout)
-	net.SendCoins(ctxt, t.t, btcutil.SatoshiPerBitcoin, alice)
+	net.SendCoins(t.t, btcutil.SatoshiPerBitcoin, alice)
 
 	// Before we start, obtain Carol's current wallet balance, we'll check
 	// to ensure that at the end of the force closure by Alice, Carol
 	// recognizes his new on-chain output.
 	carolBalReq := &lnrpc.WalletBalanceRequest{}
-	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
+	ctxt, _ := context.WithTimeout(ctxb, defaultTimeout)
 	carolBalResp, err := carol.WalletBalance(ctxt, carolBalReq)
 	if err != nil {
 		t.Fatalf("unable to get carol's balance: %v", err)

--- a/lntest/itest/lnd_channel_force_close.go
+++ b/lntest/itest/lnd_channel_force_close.go
@@ -413,8 +413,7 @@ func channelForceClosureTest(net *lntest.NetworkHarness, t *harnessTest,
 		)
 	}
 
-	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
-	aliceChan, err := getChanInfo(ctxt, alice)
+	aliceChan, err := getChanInfo(alice)
 	if err != nil {
 		t.Fatalf("unable to get alice's channel info: %v", err)
 	}

--- a/lntest/itest/lnd_channel_force_close.go
+++ b/lntest/itest/lnd_channel_force_close.go
@@ -105,7 +105,7 @@ func testCommitmentTransactionDeadline(net *lntest.NetworkHarness,
 		defer shutdownAndAssert(net, t, bob)
 
 		// Connect Alice to Bob.
-		net.ConnectNodes(ctxt, t.t, alice, bob)
+		net.ConnectNodes(t.t, alice, bob)
 
 		// Open a channel between Alice and Bob.
 		chanPoint := openChannelAndAssert(
@@ -317,10 +317,10 @@ func channelForceClosureTest(net *lntest.NetworkHarness, t *harnessTest,
 
 	// We must let Alice have an open channel before she can send a node
 	// announcement, so we open a channel with Carol,
-	ctxt, _ := context.WithTimeout(ctxb, defaultTimeout)
-	net.ConnectNodes(ctxt, t.t, alice, carol)
+	net.ConnectNodes(t.t, alice, carol)
 
 	// We need one additional UTXO for sweeping the remote anchor.
+	ctxt, _ := context.WithTimeout(ctxb, defaultTimeout)
 	net.SendCoins(ctxt, t.t, btcutil.SatoshiPerBitcoin, alice)
 
 	// Before we start, obtain Carol's current wallet balance, we'll check
@@ -1418,8 +1418,7 @@ func testFailingChannel(net *lntest.NetworkHarness, t *harnessTest) {
 	defer shutdownAndAssert(net, t, carol)
 
 	// Let Alice connect and open a channel to Carol,
-	ctxt, _ := context.WithTimeout(ctxb, defaultTimeout)
-	net.ConnectNodes(ctxt, t.t, net.Alice, carol)
+	net.ConnectNodes(t.t, net.Alice, carol)
 	chanPoint := openChannelAndAssert(
 		t, net, net.Alice, carol,
 		lntest.OpenChannelParams{
@@ -1435,7 +1434,7 @@ func testFailingChannel(net *lntest.NetworkHarness, t *harnessTest) {
 		RPreimage: preimage,
 		Value:     paymentAmt,
 	}
-	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
+	ctxt, _ := context.WithTimeout(ctxb, defaultTimeout)
 	resp, err := carol.AddInvoice(ctxt, invoice)
 	if err != nil {
 		t.Fatalf("unable to add invoice: %v", err)

--- a/lntest/itest/lnd_channel_force_close.go
+++ b/lntest/itest/lnd_channel_force_close.go
@@ -139,9 +139,7 @@ func testCommitmentTransactionDeadline(net *lntest.NetworkHarness,
 		require.NoError(t.t, err, "htlc mismatch")
 
 		// Alice force closes the channel.
-		ctxt, cancel = context.WithTimeout(ctxb, defaultTimeout)
-		defer cancel()
-		_, _, err = net.CloseChannel(ctxt, alice, chanPoint, true)
+		_, _, err = net.CloseChannel(alice, chanPoint, true)
 		require.NoError(t.t, err, "unable to force close channel")
 
 		// Now that the channel has been force closed, it should show
@@ -431,8 +429,7 @@ func channelForceClosureTest(net *lntest.NetworkHarness, t *harnessTest,
 	const actualFeeRate = 30000
 	net.SetFeeEstimate(actualFeeRate)
 
-	ctxt, _ = context.WithTimeout(ctxb, channelCloseTimeout)
-	_, closingTxID, err := net.CloseChannel(ctxt, alice, chanPoint, true)
+	_, closingTxID, err := net.CloseChannel(alice, chanPoint, true)
 	if err != nil {
 		t.Fatalf("unable to execute force channel closure: %v", err)
 	}

--- a/lntest/itest/lnd_channel_graph_test.go
+++ b/lntest/itest/lnd_channel_graph_test.go
@@ -190,8 +190,7 @@ func testUpdateChanStatus(net *lntest.NetworkHarness, t *harnessTest) {
 	// disconnections from automatically disabling the channel again
 	// (we don't want to clutter the network with channels that are
 	// falsely advertised as enabled when they don't work).
-	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
-	if err := net.DisconnectNodes(ctxt, alice, bob); err != nil {
+	if err := net.DisconnectNodes(alice, bob); err != nil {
 		t.Fatalf("unable to disconnect Alice from Bob: %v", err)
 	}
 	expectedPolicy.Disabled = true
@@ -230,8 +229,7 @@ func testUpdateChanStatus(net *lntest.NetworkHarness, t *harnessTest) {
 		},
 	)
 
-	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
-	if err := net.DisconnectNodes(ctxt, alice, bob); err != nil {
+	if err := net.DisconnectNodes(alice, bob); err != nil {
 		t.Fatalf("unable to disconnect Alice from Bob: %v", err)
 	}
 
@@ -261,8 +259,7 @@ func testUpdateChanStatus(net *lntest.NetworkHarness, t *harnessTest) {
 	// note the asymmetry between manual enable and manual disable!
 	assertEdgeDisabled(alice, chanPoint, true)
 
-	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
-	if err := net.DisconnectNodes(ctxt, alice, bob); err != nil {
+	if err := net.DisconnectNodes(alice, bob); err != nil {
 		t.Fatalf("unable to disconnect Alice from Bob: %v", err)
 	}
 
@@ -583,8 +580,7 @@ out:
 	// that a node that does not have any channels open is ignored, so first
 	// we disconnect Alice and Bob, open a channel between Bob and Carol,
 	// and finally connect Alice to Bob again.
-	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
-	if err := net.DisconnectNodes(ctxt, alice, bob); err != nil {
+	if err := net.DisconnectNodes(alice, bob); err != nil {
 		t.Fatalf("unable to disconnect alice and bob: %v", err)
 	}
 	carol := net.NewNode(t.t, "Carol", nil)

--- a/lntest/itest/lnd_channel_graph_test.go
+++ b/lntest/itest/lnd_channel_graph_test.go
@@ -301,9 +301,8 @@ func testUnannouncedChannels(net *lntest.NetworkHarness, t *harnessTest) {
 
 	// Open a channel between Alice and Bob, ensuring the
 	// channel has been opened properly.
-	ctxt, _ := context.WithTimeout(ctxb, channelOpenTimeout)
 	chanOpenUpdate := openChannelStream(
-		ctxt, t, net, net.Alice, net.Bob,
+		t, net, net.Alice, net.Bob,
 		lntest.OpenChannelParams{
 			Amt: amount,
 		},
@@ -315,7 +314,7 @@ func testUnannouncedChannels(net *lntest.NetworkHarness, t *harnessTest) {
 
 	// One block is enough to make the channel ready for use, since the
 	// nodes have defaultNumConfs=1 set.
-	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
+	ctxt, _ := context.WithTimeout(ctxb, defaultTimeout)
 	fundingChanPoint, err := net.WaitForChannelOpen(ctxt, chanOpenUpdate)
 	if err != nil {
 		t.Fatalf("error while waiting for channel open: %v", err)

--- a/lntest/itest/lnd_channel_graph_test.go
+++ b/lntest/itest/lnd_channel_graph_test.go
@@ -204,8 +204,7 @@ func testUpdateChanStatus(net *lntest.NetworkHarness, t *harnessTest) {
 	)
 
 	// Reconnecting the nodes should propagate a "Disabled = false" update.
-	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
-	net.EnsureConnected(ctxt, t.t, alice, bob)
+	net.EnsureConnected(t.t, alice, bob)
 	expectedPolicy.Disabled = false
 	waitForChannelUpdate(
 		t, carolSub,
@@ -248,8 +247,7 @@ func testUpdateChanStatus(net *lntest.NetworkHarness, t *harnessTest) {
 
 	// Bob sends a "Disabled = false" update upon detecting the
 	// reconnect.
-	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
-	net.EnsureConnected(ctxt, t.t, alice, bob)
+	net.EnsureConnected(t.t, alice, bob)
 	expectedPolicy.Disabled = false
 	waitForChannelUpdate(
 		t, carolSub,
@@ -282,7 +280,7 @@ func testUpdateChanStatus(net *lntest.NetworkHarness, t *harnessTest) {
 	// BOTH Alice and Bob should set the channel state back to "enabled"
 	// on reconnect.
 	sendReq(alice, chanPoint, routerrpc.ChanStatusAction_AUTO)
-	net.EnsureConnected(ctxt, t.t, alice, bob)
+	net.EnsureConnected(t.t, alice, bob)
 	expectedPolicy.Disabled = false
 	waitForChannelUpdate(
 		t, carolSub,
@@ -440,8 +438,7 @@ func testGraphTopologyNtfns(net *lntest.NetworkHarness, t *harnessTest, pinned b
 	defer shutdownAndAssert(net, t, alice)
 
 	// Connect Alice and Bob.
-	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
-	net.EnsureConnected(ctxt, t.t, alice, bob)
+	net.EnsureConnected(t.t, alice, bob)
 
 	// Alice stimmy.
 	net.SendCoins(t.t, btcutil.SatoshiPerBitcoin, alice)
@@ -609,8 +606,7 @@ out:
 	// and Carol. Note that we will also receive a node announcement from
 	// Bob, since a node will update its node announcement after a new
 	// channel is opened.
-	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
-	net.EnsureConnected(ctxt, t.t, alice, bob)
+	net.EnsureConnected(t.t, alice, bob)
 
 	// We should receive an update advertising the newly connected node,
 	// Bob's new node announcement, and the channel between Bob and Carol.

--- a/lntest/itest/lnd_channel_graph_test.go
+++ b/lntest/itest/lnd_channel_graph_test.go
@@ -54,9 +54,8 @@ func testUpdateChanStatus(net *lntest.NetworkHarness, t *harnessTest) {
 	// Open a channel with 100k satoshis between Alice and Bob with Alice
 	// being the sole funder of the channel.
 	chanAmt := btcutil.Amount(100000)
-	ctxt, _ = context.WithTimeout(ctxb, channelOpenTimeout)
 	chanPoint := openChannelAndAssert(
-		ctxt, t, net, alice, bob,
+		t, net, alice, bob,
 		lntest.OpenChannelParams{
 			Amt: chanAmt,
 		},
@@ -472,9 +471,8 @@ func testGraphTopologyNtfns(net *lntest.NetworkHarness, t *harnessTest, pinned b
 	defer close(graphSub.quit)
 
 	// Open a new channel between Alice and Bob.
-	ctxt, _ = context.WithTimeout(ctxb, channelOpenTimeout)
 	chanPoint := openChannelAndAssert(
-		ctxt, t, net, alice, bob,
+		t, net, alice, bob,
 		lntest.OpenChannelParams{
 			Amt: chanAmt,
 		},
@@ -605,9 +603,8 @@ out:
 
 	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
 	net.ConnectNodes(ctxt, t.t, bob, carol)
-	ctxt, _ = context.WithTimeout(ctxb, channelOpenTimeout)
 	chanPoint = openChannelAndAssert(
-		ctxt, t, net, bob, carol,
+		t, net, bob, carol,
 		lntest.OpenChannelParams{
 			Amt: chanAmt,
 		},
@@ -716,9 +713,8 @@ func testNodeAnnouncement(net *lntest.NetworkHarness, t *harnessTest) {
 	// We'll then go ahead and open a channel between Bob and Dave. This
 	// ensures that Alice receives the node announcement from Bob as part of
 	// the announcement broadcast.
-	ctxt, _ = context.WithTimeout(ctxb, channelOpenTimeout)
 	chanPoint := openChannelAndAssert(
-		ctxt, t, net, net.Bob, dave,
+		t, net, net.Bob, dave,
 		lntest.OpenChannelParams{
 			Amt: 1000000,
 		},

--- a/lntest/itest/lnd_channel_graph_test.go
+++ b/lntest/itest/lnd_channel_graph_test.go
@@ -314,8 +314,7 @@ func testUnannouncedChannels(net *lntest.NetworkHarness, t *harnessTest) {
 
 	// One block is enough to make the channel ready for use, since the
 	// nodes have defaultNumConfs=1 set.
-	ctxt, _ := context.WithTimeout(ctxb, defaultTimeout)
-	fundingChanPoint, err := net.WaitForChannelOpen(ctxt, chanOpenUpdate)
+	fundingChanPoint, err := net.WaitForChannelOpen(chanOpenUpdate)
 	if err != nil {
 		t.Fatalf("error while waiting for channel open: %v", err)
 	}
@@ -324,7 +323,7 @@ func testUnannouncedChannels(net *lntest.NetworkHarness, t *harnessTest) {
 	req := &lnrpc.ChannelGraphRequest{
 		IncludeUnannounced: true,
 	}
-	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
+	ctxt, _ := context.WithTimeout(ctxb, defaultTimeout)
 	chanGraph, err := net.Alice.DescribeGraph(ctxt, req)
 	if err != nil {
 		t.Fatalf("unable to query alice's graph: %v", err)

--- a/lntest/itest/lnd_channel_graph_test.go
+++ b/lntest/itest/lnd_channel_graph_test.go
@@ -48,8 +48,7 @@ func testUpdateChanStatus(net *lntest.NetworkHarness, t *harnessTest) {
 	net.ConnectNodes(t.t, alice, bob)
 
 	// Give Alice some coins so she can fund a channel.
-	ctxt, _ := context.WithTimeout(ctxb, defaultTimeout)
-	net.SendCoins(ctxt, t.t, btcutil.SatoshiPerBitcoin, alice)
+	net.SendCoins(t.t, btcutil.SatoshiPerBitcoin, alice)
 
 	// Open a channel with 100k satoshis between Alice and Bob with Alice
 	// being the sole funder of the channel.
@@ -63,7 +62,7 @@ func testUpdateChanStatus(net *lntest.NetworkHarness, t *harnessTest) {
 
 	// Wait for Alice and Bob to receive the channel edge from the
 	// funding manager.
-	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
+	ctxt, _ := context.WithTimeout(ctxb, defaultTimeout)
 	err := alice.WaitForNetworkChannelOpen(ctxt, chanPoint)
 	if err != nil {
 		t.Fatalf("alice didn't see the alice->bob channel before "+
@@ -445,12 +444,10 @@ func testGraphTopologyNtfns(net *lntest.NetworkHarness, t *harnessTest, pinned b
 	net.EnsureConnected(ctxt, t.t, alice, bob)
 
 	// Alice stimmy.
-	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
-	net.SendCoins(ctxt, t.t, btcutil.SatoshiPerBitcoin, alice)
+	net.SendCoins(t.t, btcutil.SatoshiPerBitcoin, alice)
 
 	// Bob stimmy.
-	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
-	net.SendCoins(ctxt, t.t, btcutil.SatoshiPerBitcoin, bob)
+	net.SendCoins(t.t, btcutil.SatoshiPerBitcoin, bob)
 
 	// Assert that Bob has the correct sync type before proceeeding.
 	if pinned {

--- a/lntest/itest/lnd_channel_graph_test.go
+++ b/lntest/itest/lnd_channel_graph_test.go
@@ -45,7 +45,7 @@ func testUpdateChanStatus(net *lntest.NetworkHarness, t *harnessTest) {
 	defer shutdownAndAssert(net, t, bob)
 
 	// Connect Alice to Bob.
-	net.ConnectNodes(ctxb, t.t, alice, bob)
+	net.ConnectNodes(t.t, alice, bob)
 
 	// Give Alice some coins so she can fund a channel.
 	ctxt, _ := context.WithTimeout(ctxb, defaultTimeout)
@@ -83,11 +83,8 @@ func testUpdateChanStatus(net *lntest.NetworkHarness, t *harnessTest) {
 	carol := net.NewNode(t.t, "Carol", nil)
 	defer shutdownAndAssert(net, t, carol)
 
-	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
-	net.ConnectNodes(ctxt, t.t, alice, carol)
-
-	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
-	net.ConnectNodes(ctxt, t.t, bob, carol)
+	net.ConnectNodes(t.t, alice, carol)
+	net.ConnectNodes(t.t, bob, carol)
 
 	carolSub := subscribeGraphNotifications(ctxb, t, carol)
 	defer close(carolSub.quit)
@@ -601,8 +598,7 @@ out:
 	carol := net.NewNode(t.t, "Carol", nil)
 	defer shutdownAndAssert(net, t, carol)
 
-	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
-	net.ConnectNodes(ctxt, t.t, bob, carol)
+	net.ConnectNodes(t.t, bob, carol)
 	chanPoint = openChannelAndAssert(
 		t, net, bob, carol,
 		lntest.OpenChannelParams{
@@ -699,8 +695,7 @@ func testNodeAnnouncement(net *lntest.NetworkHarness, t *harnessTest) {
 
 	// We must let Dave have an open channel before he can send a node
 	// announcement, so we open a channel with Bob,
-	ctxt, _ := context.WithTimeout(ctxb, defaultTimeout)
-	net.ConnectNodes(ctxt, t.t, net.Bob, dave)
+	net.ConnectNodes(t.t, net.Bob, dave)
 
 	// Alice shouldn't receive any new updates yet since the channel has yet
 	// to be opened.

--- a/lntest/itest/lnd_channel_policy_test.go
+++ b/lntest/itest/lnd_channel_policy_test.go
@@ -109,8 +109,7 @@ func testUpdateChannelPolicy(net *lntest.NetworkHarness, t *harnessTest) {
 	nodes = append(nodes, carol)
 
 	// Send some coins to Carol that can be used for channel funding.
-	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
-	net.SendCoins(ctxt, t.t, btcutil.SatoshiPerBitcoin, carol)
+	net.SendCoins(t.t, btcutil.SatoshiPerBitcoin, carol)
 
 	net.ConnectNodes(t.t, carol, net.Bob)
 

--- a/lntest/itest/lnd_channel_policy_test.go
+++ b/lntest/itest/lnd_channel_policy_test.go
@@ -37,9 +37,8 @@ func testUpdateChannelPolicy(net *lntest.NetworkHarness, t *harnessTest) {
 	pushAmt := chanAmt / 2
 
 	// Create a channel Alice->Bob.
-	ctxt, _ := context.WithTimeout(ctxb, channelOpenTimeout)
 	chanPoint := openChannelAndAssert(
-		ctxt, t, net, net.Alice, net.Bob,
+		t, net, net.Alice, net.Bob,
 		lntest.OpenChannelParams{
 			Amt:     chanAmt,
 			PushAmt: pushAmt,
@@ -81,7 +80,7 @@ func testUpdateChannelPolicy(net *lntest.NetworkHarness, t *harnessTest) {
 		)
 	}
 
-	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
+	ctxt, _ := context.WithTimeout(ctxb, defaultTimeout)
 	err := net.Alice.WaitForNetworkChannelOpen(ctxt, chanPoint)
 	if err != nil {
 		t.Fatalf("alice didn't report channel: %v", err)
@@ -120,9 +119,8 @@ func testUpdateChannelPolicy(net *lntest.NetworkHarness, t *harnessTest) {
 	// HTLCs smaller than this value, and hence he should advertise it as
 	// part of his ChannelUpdate.
 	const customMinHtlc = 5000
-	ctxt, _ = context.WithTimeout(ctxb, channelOpenTimeout)
 	chanPoint2 := openChannelAndAssert(
-		ctxt, t, net, carol, net.Bob,
+		t, net, carol, net.Bob,
 		lntest.OpenChannelParams{
 			Amt:     chanAmt,
 			PushAmt: pushAmt,
@@ -391,9 +389,8 @@ func testUpdateChannelPolicy(net *lntest.NetworkHarness, t *harnessTest) {
 
 	// We'll now open a channel from Alice directly to Carol.
 	net.ConnectNodes(ctxb, t.t, net.Alice, carol)
-	ctxt, _ = context.WithTimeout(ctxb, channelOpenTimeout)
 	chanPoint3 := openChannelAndAssert(
-		ctxt, t, net, net.Alice, carol,
+		t, net, net.Alice, carol,
 		lntest.OpenChannelParams{
 			Amt:     chanAmt,
 			PushAmt: pushAmt,

--- a/lntest/itest/lnd_channel_policy_test.go
+++ b/lntest/itest/lnd_channel_policy_test.go
@@ -194,9 +194,8 @@ func testUpdateChannelPolicy(net *lntest.NetworkHarness, t *harnessTest) {
 		t.Fatalf("unable to add invoice: %v", err)
 	}
 
-	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
 	err = completePaymentRequests(
-		ctxt, net.Alice, net.Alice.RouterClient,
+		net.Alice, net.Alice.RouterClient,
 		[]string{resp.PaymentRequest}, true,
 	)
 
@@ -377,9 +376,8 @@ func testUpdateChannelPolicy(net *lntest.NetworkHarness, t *harnessTest) {
 		t.Fatalf("unable to add invoice: %v", err)
 	}
 
-	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
 	err = completePaymentRequests(
-		ctxt, net.Alice, net.Alice.RouterClient,
+		net.Alice, net.Alice.RouterClient,
 		[]string{resp.PaymentRequest}, true,
 	)
 	if err != nil {

--- a/lntest/itest/lnd_channel_policy_test.go
+++ b/lntest/itest/lnd_channel_policy_test.go
@@ -112,7 +112,7 @@ func testUpdateChannelPolicy(net *lntest.NetworkHarness, t *harnessTest) {
 	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
 	net.SendCoins(ctxt, t.t, btcutil.SatoshiPerBitcoin, carol)
 
-	net.ConnectNodes(ctxb, t.t, carol, net.Bob)
+	net.ConnectNodes(t.t, carol, net.Bob)
 
 	// Open the channel Carol->Bob with a custom min_htlc value set. Since
 	// Carol is opening the channel, she will require Bob to not forward
@@ -388,7 +388,7 @@ func testUpdateChannelPolicy(net *lntest.NetworkHarness, t *harnessTest) {
 	}
 
 	// We'll now open a channel from Alice directly to Carol.
-	net.ConnectNodes(ctxb, t.t, net.Alice, carol)
+	net.ConnectNodes(t.t, net.Alice, carol)
 	chanPoint3 := openChannelAndAssert(
 		t, net, net.Alice, carol,
 		lntest.OpenChannelParams{

--- a/lntest/itest/lnd_etcd_failover_test.go
+++ b/lntest/itest/lnd_etcd_failover_test.go
@@ -106,9 +106,8 @@ func testEtcdFailoverCase(net *lntest.NetworkHarness, ht *harnessTest,
 	// Open a channel with 100k satoshis between Carol and Alice with Alice
 	// being the sole funder of the channel.
 	chanAmt := btcutil.Amount(100000)
-	ctxt, _ = context.WithTimeout(ctxb, channelOpenTimeout)
 	_ = openChannelAndAssert(
-		ctxt, ht, net, net.Alice, carol1,
+		ht, net, net.Alice, carol1,
 		lntest.OpenChannelParams{
 			Amt: chanAmt,
 		},

--- a/lntest/itest/lnd_etcd_failover_test.go
+++ b/lntest/itest/lnd_etcd_failover_test.go
@@ -129,11 +129,13 @@ func testEtcdFailoverCase(net *lntest.NetworkHarness, ht *harnessTest,
 		ht.Fatalf("Carol-2 is unable to create payment requests: %v",
 			err)
 	}
-	sendAndAssertSuccess(ctxb, ht, net.Alice, &routerrpc.SendPaymentRequest{
-		PaymentRequest: payReqs[0],
-		TimeoutSeconds: 60,
-		FeeLimitSat:    noFeeLimitMsat,
-	})
+	sendAndAssertSuccess(
+		ht, net.Alice, &routerrpc.SendPaymentRequest{
+			PaymentRequest: payReqs[0],
+			TimeoutSeconds: 60,
+			FeeLimitSat:    noFeeLimitMsat,
+		},
+	)
 
 	// Shut down or kill Carol-1 and wait for Carol-2 to become the leader.
 	var failoverTimeout time.Duration
@@ -177,11 +179,13 @@ func testEtcdFailoverCase(net *lntest.NetworkHarness, ht *harnessTest,
 
 	// Now let Alice pay the second invoice but this time we expect Carol-2
 	// to receive the payment.
-	sendAndAssertSuccess(ctxb, ht, net.Alice, &routerrpc.SendPaymentRequest{
-		PaymentRequest: payReqs[1],
-		TimeoutSeconds: 60,
-		FeeLimitSat:    noFeeLimitMsat,
-	})
+	sendAndAssertSuccess(
+		ht, net.Alice, &routerrpc.SendPaymentRequest{
+			PaymentRequest: payReqs[1],
+			TimeoutSeconds: 60,
+			FeeLimitSat:    noFeeLimitMsat,
+		},
+	)
 
 	shutdownAndAssert(net, ht, carol2)
 }

--- a/lntest/itest/lnd_etcd_failover_test.go
+++ b/lntest/itest/lnd_etcd_failover_test.go
@@ -100,8 +100,7 @@ func testEtcdFailoverCase(net *lntest.NetworkHarness, ht *harnessTest,
 	ctxt, _ := context.WithTimeout(ctxb, defaultTimeout)
 	info1, err := carol1.GetInfo(ctxt, &lnrpc.GetInfoRequest{})
 
-	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
-	net.ConnectNodes(ctxt, ht.t, carol1, net.Alice)
+	net.ConnectNodes(ht.t, carol1, net.Alice)
 
 	// Open a channel with 100k satoshis between Carol and Alice with Alice
 	// being the sole funder of the channel.

--- a/lntest/itest/lnd_forward_interceptor_test.go
+++ b/lntest/itest/lnd_forward_interceptor_test.go
@@ -286,14 +286,11 @@ func newInterceptorTestContext(t *harnessTest,
 	net *lntest.NetworkHarness,
 	alice, bob, carol *lntest.HarnessNode) *interceptorTestContext {
 
-	ctxb := context.Background()
-
 	// Connect nodes
 	nodes := []*lntest.HarnessNode{alice, bob, carol}
 	for i := 0; i < len(nodes); i++ {
 		for j := i + 1; j < len(nodes); j++ {
-			ctxt, _ := context.WithTimeout(ctxb, defaultTimeout)
-			net.EnsureConnected(ctxt, t.t, nodes[i], nodes[j])
+			net.EnsureConnected(t.t, nodes[i], nodes[j])
 		}
 	}
 

--- a/lntest/itest/lnd_forward_interceptor_test.go
+++ b/lntest/itest/lnd_forward_interceptor_test.go
@@ -354,10 +354,7 @@ func (c *interceptorTestContext) prepareTestCases() []*interceptorTestCase {
 func (c *interceptorTestContext) openChannel(from, to *lntest.HarnessNode,
 	chanSize btcutil.Amount) {
 
-	ctxb := context.Background()
-
-	ctxt, _ := context.WithTimeout(ctxb, defaultTimeout)
-	c.net.SendCoins(ctxt, c.t.t, btcutil.SatoshiPerBitcoin, from)
+	c.net.SendCoins(c.t.t, btcutil.SatoshiPerBitcoin, from)
 
 	chanPoint := openChannelAndAssert(
 		c.t, c.net, from, to,

--- a/lntest/itest/lnd_forward_interceptor_test.go
+++ b/lntest/itest/lnd_forward_interceptor_test.go
@@ -67,8 +67,8 @@ func testForwardInterceptor(net *lntest.NetworkHarness, t *harnessTest) {
 	testContext.waitForChannels()
 
 	// Connect the interceptor.
-	ctx := context.Background()
-	ctxt, cancelInterceptor := context.WithTimeout(ctx, defaultTimeout)
+	ctxb := context.Background()
+	ctxt, cancelInterceptor := context.WithTimeout(ctxb, defaultTimeout)
 	interceptor, err := testContext.bob.RouterClient.HtlcInterceptor(ctxt)
 	require.NoError(t.t, err, "failed to create HtlcInterceptor")
 
@@ -230,8 +230,7 @@ func testForwardInterceptor(net *lntest.NetworkHarness, t *harnessTest) {
 	restartAlice, err := net.SuspendNode(alice)
 	require.NoError(t.t, err, "failed to suspend alice")
 
-	ctx = context.Background()
-	ctxt, cancelInterceptor = context.WithTimeout(ctx, defaultTimeout)
+	ctxt, cancelInterceptor = context.WithTimeout(ctxb, defaultTimeout)
 	defer cancelInterceptor()
 	interceptor, err = testContext.bob.RouterClient.HtlcInterceptor(ctxt)
 	require.NoError(t.t, err, "failed to create HtlcInterceptor")
@@ -259,7 +258,7 @@ func testForwardInterceptor(net *lntest.NetworkHarness, t *harnessTest) {
 	}()
 
 	err = wait.Predicate(func() bool {
-		channels, err := bob.ListChannels(ctx, &lnrpc.ListChannelsRequest{
+		channels, err := bob.ListChannels(ctxt, &lnrpc.ListChannelsRequest{
 			ActiveOnly: true, Peer: alice.PubKey[:],
 		})
 		return err == nil && len(channels.Channels) > 0

--- a/lntest/itest/lnd_forward_interceptor_test.go
+++ b/lntest/itest/lnd_forward_interceptor_test.go
@@ -359,9 +359,8 @@ func (c *interceptorTestContext) openChannel(from, to *lntest.HarnessNode,
 	ctxt, _ := context.WithTimeout(ctxb, defaultTimeout)
 	c.net.SendCoins(ctxt, c.t.t, btcutil.SatoshiPerBitcoin, from)
 
-	ctxt, _ = context.WithTimeout(ctxb, channelOpenTimeout)
 	chanPoint := openChannelAndAssert(
-		ctxt, c.t, c.net, from, to,
+		c.t, c.net, from, to,
 		lntest.OpenChannelParams{
 			Amt: chanSize,
 		},

--- a/lntest/itest/lnd_funding_test.go
+++ b/lntest/itest/lnd_funding_test.go
@@ -202,9 +202,8 @@ func basicChannelFundingTest(t *harnessTest, net *lntest.NetworkHarness,
 	// assertions will be executed to ensure the funding process completed
 	// successfully.
 	ctxb := context.Background()
-	ctxt, _ := context.WithTimeout(ctxb, channelOpenTimeout)
 	chanPoint := openChannelAndAssert(
-		ctxt, t, net, alice, bob,
+		t, net, alice, bob,
 		lntest.OpenChannelParams{
 			Amt:         chanAmt,
 			PushAmt:     pushAmt,
@@ -213,7 +212,7 @@ func basicChannelFundingTest(t *harnessTest, net *lntest.NetworkHarness,
 		},
 	)
 
-	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
+	ctxt, _ := context.WithTimeout(ctxb, defaultTimeout)
 
 	err := alice.WaitForNetworkChannelOpen(ctxt, chanPoint)
 	require.NoError(t.t, err, "alice didn't report channel")

--- a/lntest/itest/lnd_funding_test.go
+++ b/lntest/itest/lnd_funding_test.go
@@ -491,8 +491,6 @@ func testExternalFundingChanPoint(net *lntest.NetworkHarness, t *harnessTest) {
 // testFundingPersistence mirrors testBasicChannelFunding, but adds restarts
 // and checks for the state of channels with unconfirmed funding transactions.
 func testChannelFundingPersistence(net *lntest.NetworkHarness, t *harnessTest) {
-	ctxb := context.Background()
-
 	chanAmt := funding.MaxBtcFundingAmount
 	pushAmt := btcutil.Amount(0)
 
@@ -570,8 +568,7 @@ func testChannelFundingPersistence(net *lntest.NetworkHarness, t *harnessTest) {
 	// Assert that our wallet has our opening transaction with a label
 	// that does not have a channel ID set yet, because we have not
 	// reached our required confirmations.
-	ctxt, _ := context.WithTimeout(ctxb, defaultTimeout)
-	tx := findTxAtHeight(ctxt, t, height, fundingTxStr, net.Alice)
+	tx := findTxAtHeight(t, height, fundingTxStr, net.Alice)
 
 	// At this stage, we expect the transaction to be labelled, but not with
 	// our channel ID because our transaction has not yet confirmed.
@@ -600,7 +597,7 @@ func testChannelFundingPersistence(net *lntest.NetworkHarness, t *harnessTest) {
 	}
 
 	// Re-lookup our transaction in the block that it confirmed in.
-	tx = findTxAtHeight(ctxt, t, height, fundingTxStr, net.Alice)
+	tx = findTxAtHeight(t, height, fundingTxStr, net.Alice)
 
 	// Create an additional check for our channel assertion that will
 	// check that our label is as expected.

--- a/lntest/itest/lnd_funding_test.go
+++ b/lntest/itest/lnd_funding_test.go
@@ -512,9 +512,9 @@ func testChannelFundingPersistence(net *lntest.NetworkHarness, t *harnessTest) {
 
 	// Create a new channel that requires 5 confs before it's considered
 	// open, then broadcast the funding transaction
-	ctxt, _ := context.WithTimeout(ctxb, channelOpenTimeout)
-	pendingUpdate, err := net.OpenPendingChannel(ctxt, net.Alice, carol,
-		chanAmt, pushAmt)
+	pendingUpdate, err := net.OpenPendingChannel(
+		net.Alice, carol, chanAmt, pushAmt,
+	)
 	if err != nil {
 		t.Fatalf("unable to open channel: %v", err)
 	}
@@ -572,6 +572,7 @@ func testChannelFundingPersistence(net *lntest.NetworkHarness, t *harnessTest) {
 	// Assert that our wallet has our opening transaction with a label
 	// that does not have a channel ID set yet, because we have not
 	// reached our required confirmations.
+	ctxt, _ := context.WithTimeout(ctxb, defaultTimeout)
 	tx := findTxAtHeight(ctxt, t, height, fundingTxStr, net.Alice)
 
 	// At this stage, we expect the transaction to be labelled, but not with

--- a/lntest/itest/lnd_funding_test.go
+++ b/lntest/itest/lnd_funding_test.go
@@ -27,8 +27,6 @@ import (
 // transaction was mined.
 func testBasicChannelFunding(net *lntest.NetworkHarness, t *harnessTest) {
 
-	ctxb := context.Background()
-
 	// Run through the test with combinations of all the different
 	// commitment types.
 	allTypes := []commitType{
@@ -57,8 +55,7 @@ func testBasicChannelFunding(net *lntest.NetworkHarness, t *harnessTest) {
 
 		// Before we start the test, we'll ensure both sides are
 		// connected to the funding flow can properly be executed.
-		ctxt, _ := context.WithTimeout(ctxb, defaultTimeout)
-		net.EnsureConnected(ctxt, t.t, carol, dave)
+		net.EnsureConnected(t.t, carol, dave)
 
 		carolChan, daveChan, closeChan, err := basicChannelFundingTest(
 			t, net, carol, dave, nil,
@@ -390,8 +387,7 @@ func testExternalFundingChanPoint(net *lntest.NetworkHarness, t *harnessTest) {
 
 	// Before we start the test, we'll ensure both sides are connected to
 	// the funding flow can properly be executed.
-	ctxt, _ := context.WithTimeout(ctxb, defaultTimeout)
-	net.EnsureConnected(ctxt, t.t, carol, dave)
+	net.EnsureConnected(t.t, carol, dave)
 
 	// At this point, we're ready to simulate our external channel funding
 	// flow. To start with, we'll create a pending channel with a shim for
@@ -407,7 +403,7 @@ func testExternalFundingChanPoint(net *lntest.NetworkHarness, t *harnessTest) {
 			FundingShim: fundingShim1,
 		},
 	)
-	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
+	ctxt, _ := context.WithTimeout(ctxb, defaultTimeout)
 	assertNumOpenChannelsPending(ctxt, t, carol, dave, 1)
 
 	// That channel is now pending forever and normally would saturate the
@@ -570,8 +566,7 @@ func testChannelFundingPersistence(net *lntest.NetworkHarness, t *harnessTest) {
 
 	// The following block ensures that after both nodes have restarted,
 	// they have reconnected before the execution of the next test.
-	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
-	net.EnsureConnected(ctxt, t.t, net.Alice, carol)
+	net.EnsureConnected(t.t, net.Alice, carol)
 
 	// Next, mine enough blocks s.t the channel will open with a single
 	// additional block mined.

--- a/lntest/itest/lnd_funding_test.go
+++ b/lntest/itest/lnd_funding_test.go
@@ -49,8 +49,7 @@ func testBasicChannelFunding(net *lntest.NetworkHarness, t *harnessTest) {
 
 		// Each time, we'll send Carol a new set of coins in order to
 		// fund the channel.
-		ctxt, _ := context.WithTimeout(ctxb, defaultTimeout)
-		net.SendCoins(ctxt, t.t, btcutil.SatoshiPerBitcoin, carol)
+		net.SendCoins(t.t, btcutil.SatoshiPerBitcoin, carol)
 
 		daveArgs := daveCommitType.Args()
 		dave := net.NewNode(t.t, "Dave", daveArgs)
@@ -58,7 +57,7 @@ func testBasicChannelFunding(net *lntest.NetworkHarness, t *harnessTest) {
 
 		// Before we start the test, we'll ensure both sides are
 		// connected to the funding flow can properly be executed.
-		ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
+		ctxt, _ := context.WithTimeout(ctxb, defaultTimeout)
 		net.EnsureConnected(ctxt, t.t, carol, dave)
 
 		carolChan, daveChan, closeChan, err := basicChannelFundingTest(
@@ -265,15 +264,14 @@ func testUnconfirmedChannelFunding(net *lntest.NetworkHarness, t *harnessTest) {
 	defer shutdownAndAssert(net, t, carol)
 
 	// We'll send her some confirmed funds.
-	ctxt, _ := context.WithTimeout(ctxb, defaultTimeout)
-	net.SendCoins(ctxt, t.t, 2*chanAmt, carol)
+	net.SendCoins(t.t, 2*chanAmt, carol)
 
 	// Now let Carol send some funds to herself, making a unconfirmed
 	// change output.
 	addrReq := &lnrpc.NewAddressRequest{
 		Type: lnrpc.AddressType_WITNESS_PUBKEY_HASH,
 	}
-	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
+	ctxt, _ := context.WithTimeout(ctxb, defaultTimeout)
 	resp, err := carol.NewAddress(ctxt, addrReq)
 	require.NoError(t.t, err, "unable to get new address")
 
@@ -388,12 +386,11 @@ func testExternalFundingChanPoint(net *lntest.NetworkHarness, t *harnessTest) {
 
 	// Carol will be funding the channel, so we'll send some coins over to
 	// her and ensure they have enough confirmations before we proceed.
-	ctxt, _ := context.WithTimeout(ctxb, defaultTimeout)
-	net.SendCoins(ctxt, t.t, btcutil.SatoshiPerBitcoin, carol)
+	net.SendCoins(t.t, btcutil.SatoshiPerBitcoin, carol)
 
 	// Before we start the test, we'll ensure both sides are connected to
 	// the funding flow can properly be executed.
-	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
+	ctxt, _ := context.WithTimeout(ctxb, defaultTimeout)
 	net.EnsureConnected(ctxt, t.t, carol, dave)
 
 	// At this point, we're ready to simulate our external channel funding

--- a/lntest/itest/lnd_funding_test.go
+++ b/lntest/itest/lnd_funding_test.go
@@ -440,10 +440,8 @@ func testExternalFundingChanPoint(net *lntest.NetworkHarness, t *harnessTest) {
 	ctxt, _ := context.WithTimeout(ctxb, defaultTimeout)
 	resp, err := dave.AddInvoice(ctxt, invoice)
 	require.NoError(t.t, err)
-	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
 	err = completePaymentRequests(
-		ctxt, carol, carol.RouterClient, []string{resp.PaymentRequest},
-		true,
+		carol, carol.RouterClient, []string{resp.PaymentRequest}, true,
 	)
 	require.NoError(t.t, err)
 

--- a/lntest/itest/lnd_funding_test.go
+++ b/lntest/itest/lnd_funding_test.go
@@ -290,7 +290,7 @@ func testUnconfirmedChannelFunding(net *lntest.NetworkHarness, t *harnessTest) {
 	net.ConnectNodes(t.t, carol, net.Alice)
 
 	chanOpenUpdate := openChannelStream(
-		ctxt, t, net, carol, net.Alice,
+		t, net, carol, net.Alice,
 		lntest.OpenChannelParams{
 			Amt:              chanAmt,
 			PushAmt:          pushAmt,
@@ -398,13 +398,12 @@ func testExternalFundingChanPoint(net *lntest.NetworkHarness, t *harnessTest) {
 		net, t, carol, dave, chanSize, thawHeight, 1, false,
 	)
 	_ = openChannelStream(
-		ctxb, t, net, carol, dave, lntest.OpenChannelParams{
+		t, net, carol, dave, lntest.OpenChannelParams{
 			Amt:         chanSize,
 			FundingShim: fundingShim1,
 		},
 	)
-	ctxt, _ := context.WithTimeout(ctxb, defaultTimeout)
-	assertNumOpenChannelsPending(ctxt, t, carol, dave, 1)
+	assertNumOpenChannelsPending(t, carol, dave, 1)
 
 	// That channel is now pending forever and normally would saturate the
 	// max pending channel limit for both nodes. But because the channel is
@@ -439,7 +438,7 @@ func testExternalFundingChanPoint(net *lntest.NetworkHarness, t *harnessTest) {
 		Memo:  "new chans",
 		Value: int64(payAmt),
 	}
-	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
+	ctxt, _ := context.WithTimeout(ctxb, defaultTimeout)
 	resp, err := dave.AddInvoice(ctxt, invoice)
 	require.NoError(t.t, err)
 	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
@@ -469,8 +468,7 @@ func testExternalFundingChanPoint(net *lntest.NetworkHarness, t *harnessTest) {
 
 	// As a last step, we check if we still have the pending channel hanging
 	// around because we never published the funding TX.
-	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
-	assertNumOpenChannelsPending(ctxt, t, carol, dave, 1)
+	assertNumOpenChannelsPending(t, carol, dave, 1)
 
 	// Let's make sure we can abandon it.
 	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
@@ -487,7 +485,7 @@ func testExternalFundingChanPoint(net *lntest.NetworkHarness, t *harnessTest) {
 	require.NoError(t.t, err)
 
 	// It should now not appear in the pending channels anymore.
-	assertNumOpenChannelsPending(ctxt, t, carol, dave, 0)
+	assertNumOpenChannelsPending(t, carol, dave, 0)
 }
 
 // testFundingPersistence is intended to ensure that the Funding Manager
@@ -526,8 +524,7 @@ func testChannelFundingPersistence(net *lntest.NetworkHarness, t *harnessTest) {
 	// At this point, the channel's funding transaction will have been
 	// broadcast, but not confirmed. Alice and Bob's nodes should reflect
 	// this when queried via RPC.
-	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
-	assertNumOpenChannelsPending(ctxt, t, net.Alice, carol, 1)
+	assertNumOpenChannelsPending(t, net.Alice, carol, 1)
 
 	// Restart both nodes to test that the appropriate state has been
 	// persisted and that both nodes recover gracefully.
@@ -586,8 +583,7 @@ func testChannelFundingPersistence(net *lntest.NetworkHarness, t *harnessTest) {
 
 	// Both nodes should still show a single channel as pending.
 	time.Sleep(time.Second * 1)
-	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
-	assertNumOpenChannelsPending(ctxt, t, net.Alice, carol, 1)
+	assertNumOpenChannelsPending(t, net.Alice, carol, 1)
 
 	// Finally, mine the last block which should mark the channel as open.
 	if _, err := net.Miner.Client.Generate(1); err != nil {
@@ -597,8 +593,7 @@ func testChannelFundingPersistence(net *lntest.NetworkHarness, t *harnessTest) {
 	// At this point, the channel should be fully opened and there should
 	// be no pending channels remaining for either node.
 	time.Sleep(time.Second * 1)
-	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
-	assertNumOpenChannelsPending(ctxt, t, net.Alice, carol, 0)
+	assertNumOpenChannelsPending(t, net.Alice, carol, 0)
 
 	// The channel should be listed in the peer information returned by
 	// both peers.

--- a/lntest/itest/lnd_funding_test.go
+++ b/lntest/itest/lnd_funding_test.go
@@ -292,9 +292,7 @@ func testUnconfirmedChannelFunding(net *lntest.NetworkHarness, t *harnessTest) {
 	// Now, we'll connect her to Alice so that they can open a channel
 	// together. The funding flow should select Carol's unconfirmed output
 	// as she doesn't have any other funds since it's a new node.
-
-	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
-	net.ConnectNodes(ctxt, t.t, carol, net.Alice)
+	net.ConnectNodes(t.t, carol, net.Alice)
 
 	chanOpenUpdate := openChannelStream(
 		ctxt, t, net, carol, net.Alice,
@@ -521,12 +519,11 @@ func testChannelFundingPersistence(net *lntest.NetworkHarness, t *harnessTest) {
 	// Clean up carol's node when the test finishes.
 	defer shutdownAndAssert(net, t, carol)
 
-	ctxt, _ := context.WithTimeout(ctxb, defaultTimeout)
-	net.ConnectNodes(ctxt, t.t, net.Alice, carol)
+	net.ConnectNodes(t.t, net.Alice, carol)
 
 	// Create a new channel that requires 5 confs before it's considered
 	// open, then broadcast the funding transaction
-	ctxt, _ = context.WithTimeout(ctxb, channelOpenTimeout)
+	ctxt, _ := context.WithTimeout(ctxb, channelOpenTimeout)
 	pendingUpdate, err := net.OpenPendingChannel(ctxt, net.Alice, carol,
 		chanAmt, pushAmt)
 	if err != nil {

--- a/lntest/itest/lnd_funding_test.go
+++ b/lntest/itest/lnd_funding_test.go
@@ -354,8 +354,7 @@ func testUnconfirmedChannelFunding(net *lntest.NetworkHarness, t *harnessTest) {
 	// parties. Two transactions should be mined, the unconfirmed spend and
 	// the funding tx.
 	mineBlocks(t, net, 6, 2)
-	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
-	chanPoint, err := net.WaitForChannelOpen(ctxt, chanOpenUpdate)
+	chanPoint, err := net.WaitForChannelOpen(chanOpenUpdate)
 	require.NoError(t.t, err, "error while waitinng for channel open")
 
 	// With the channel open, we'll check the balances on each side of the

--- a/lntest/itest/lnd_funding_test.go
+++ b/lntest/itest/lnd_funding_test.go
@@ -454,8 +454,7 @@ func testExternalFundingChanPoint(net *lntest.NetworkHarness, t *harnessTest) {
 	// First, we'll try to close the channel as Carol, the initiator. This
 	// should fail as a frozen channel only allows the responder to
 	// initiate a channel close.
-	ctxt, _ = context.WithTimeout(ctxb, channelCloseTimeout)
-	_, _, err = net.CloseChannel(ctxt, carol, chanPoint2, false)
+	_, _, err = net.CloseChannel(carol, chanPoint2, false)
 	require.Error(t.t, err,
 		"carol wasn't denied a co-op close attempt "+
 			"for a frozen channel",
@@ -619,13 +618,11 @@ func testChannelFundingPersistence(net *lntest.NetworkHarness, t *harnessTest) {
 	}
 
 	// Check both nodes to ensure that the channel is ready for operation.
-	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
-	err = net.AssertChannelExists(ctxt, net.Alice, &outPoint, check)
+	err = net.AssertChannelExists(net.Alice, &outPoint, check)
 	if err != nil {
 		t.Fatalf("unable to assert channel existence: %v", err)
 	}
-	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
-	if err := net.AssertChannelExists(ctxt, carol, &outPoint); err != nil {
+	if err := net.AssertChannelExists(carol, &outPoint); err != nil {
 		t.Fatalf("unable to assert channel existence: %v", err)
 	}
 

--- a/lntest/itest/lnd_hold_invoice_force_test.go
+++ b/lntest/itest/lnd_hold_invoice_force_test.go
@@ -25,10 +25,8 @@ func testHoldInvoiceForceClose(net *lntest.NetworkHarness, t *harnessTest) {
 		Amt: 300000,
 	}
 
-	ctxt, cancel := context.WithTimeout(ctxb, channelOpenTimeout)
-	defer cancel()
 	chanPoint := openChannelAndAssert(
-		ctxt, t, net, net.Alice, net.Bob, chanReq,
+		t, net, net.Alice, net.Bob, chanReq,
 	)
 
 	// Create a non-dust hold invoice for bob.
@@ -42,7 +40,7 @@ func testHoldInvoiceForceClose(net *lntest.NetworkHarness, t *harnessTest) {
 		Hash:       payHash[:],
 	}
 
-	ctxt, cancel = context.WithTimeout(ctxb, defaultTimeout)
+	ctxt, cancel := context.WithTimeout(ctxb, defaultTimeout)
 	defer cancel()
 	bobInvoice, err := net.Bob.AddHoldInvoice(ctxt, invoiceReq)
 	require.NoError(t.t, err)

--- a/lntest/itest/lnd_hold_invoice_force_test.go
+++ b/lntest/itest/lnd_hold_invoice_force_test.go
@@ -105,8 +105,7 @@ func testHoldInvoiceForceClose(net *lntest.NetworkHarness, t *harnessTest) {
 	// Our channel should not have been force closed, instead we expect our
 	// channel to still be open and our invoice to have been canceled before
 	// expiry.
-	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
-	chanInfo, err := getChanInfo(ctxt, net.Alice)
+	chanInfo, err := getChanInfo(net.Alice)
 	require.NoError(t.t, err)
 
 	fundingTxID, err := lnrpc.GetChanPointFundingTxid(chanPoint)

--- a/lntest/itest/lnd_hold_persistence_test.go
+++ b/lntest/itest/lnd_hold_persistence_test.go
@@ -39,9 +39,8 @@ func testHoldInvoicePersistence(net *lntest.NetworkHarness, t *harnessTest) {
 
 	// Open a channel between Alice and Carol which is private so that we
 	// cover the addition of hop hints for hold invoices.
-	ctxt, _ = context.WithTimeout(ctxb, channelOpenTimeout)
 	chanPointAlice := openChannelAndAssert(
-		ctxt, t, net, net.Alice, carol,
+		t, net, net.Alice, carol,
 		lntest.OpenChannelParams{
 			Amt:     chanAmt,
 			Private: true,

--- a/lntest/itest/lnd_hold_persistence_test.go
+++ b/lntest/itest/lnd_hold_persistence_test.go
@@ -34,8 +34,7 @@ func testHoldInvoicePersistence(net *lntest.NetworkHarness, t *harnessTest) {
 	defer shutdownAndAssert(net, t, carol)
 
 	// Connect Alice to Carol.
-	ctxt, _ := context.WithTimeout(ctxb, defaultTimeout)
-	net.ConnectNodes(ctxb, t.t, net.Alice, carol)
+	net.ConnectNodes(t.t, net.Alice, carol)
 
 	// Open a channel between Alice and Carol which is private so that we
 	// cover the addition of hop hints for hold invoices.
@@ -49,7 +48,7 @@ func testHoldInvoicePersistence(net *lntest.NetworkHarness, t *harnessTest) {
 
 	// Wait for Alice and Carol to receive the channel edge from the
 	// funding manager.
-	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
+	ctxt, _ := context.WithTimeout(ctxb, defaultTimeout)
 	err := net.Alice.WaitForNetworkChannelOpen(ctxt, chanPointAlice)
 	if err != nil {
 		t.Fatalf("alice didn't see the alice->carol channel before "+

--- a/lntest/itest/lnd_hold_persistence_test.go
+++ b/lntest/itest/lnd_hold_persistence_test.go
@@ -165,7 +165,7 @@ func testHoldInvoicePersistence(net *lntest.NetworkHarness, t *harnessTest) {
 		req := &lnrpc.ListPaymentsRequest{
 			IncludeIncomplete: true,
 		}
-		ctxt, _ = context.WithTimeout(ctxt, defaultTimeout)
+		ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
 		paymentsResp, err := net.Alice.ListPayments(ctxt, req)
 		if err != nil {
 			return fmt.Errorf("error when obtaining payments: %v",
@@ -368,7 +368,7 @@ func testHoldInvoicePersistence(net *lntest.NetworkHarness, t *harnessTest) {
 	req := &lnrpc.ListPaymentsRequest{
 		IncludeIncomplete: true,
 	}
-	ctxt, _ = context.WithTimeout(ctxt, defaultTimeout)
+	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
 	paymentsResp, err := net.Alice.ListPayments(ctxt, req)
 	if err != nil {
 		t.Fatalf("error when obtaining Alice payments: %v", err)

--- a/lntest/itest/lnd_max_channel_size_test.go
+++ b/lntest/itest/lnd_max_channel_size_test.go
@@ -30,7 +30,7 @@ func testMaxChannelSize(net *lntest.NetworkHarness, t *harnessTest) {
 
 	// We'll send 11 BTC to the wumbo node so it can test the wumbo soft limit.
 	ctxb := context.Background()
-	net.SendCoins(ctxb, t.t, 11*btcutil.SatoshiPerBitcoin, wumboNode)
+	net.SendCoins(t.t, 11*btcutil.SatoshiPerBitcoin, wumboNode)
 
 	// Next we'll connect both nodes, then attempt to make a wumbo channel
 	// funding request, which should fail as it exceeds the default wumbo

--- a/lntest/itest/lnd_max_channel_size_test.go
+++ b/lntest/itest/lnd_max_channel_size_test.go
@@ -35,7 +35,7 @@ func testMaxChannelSize(net *lntest.NetworkHarness, t *harnessTest) {
 	// Next we'll connect both nodes, then attempt to make a wumbo channel
 	// funding request, which should fail as it exceeds the default wumbo
 	// soft limit of 10 BTC.
-	net.EnsureConnected(ctxb, t.t, wumboNode, wumboNode2)
+	net.EnsureConnected(t.t, wumboNode, wumboNode2)
 
 	chanAmt := funding.MaxBtcFundingAmountWumbo + 1
 	_, err := net.OpenChannel(
@@ -58,7 +58,7 @@ func testMaxChannelSize(net *lntest.NetworkHarness, t *harnessTest) {
 	miniNode := net.NewNode(t.t, "mini", nil)
 	defer shutdownAndAssert(net, t, miniNode)
 
-	net.EnsureConnected(ctxb, t.t, wumboNode, miniNode)
+	net.EnsureConnected(t.t, wumboNode, miniNode)
 
 	_, err = net.OpenChannel(
 		ctxb, wumboNode, miniNode, lntest.OpenChannelParams{
@@ -89,7 +89,7 @@ func testMaxChannelSize(net *lntest.NetworkHarness, t *harnessTest) {
 	defer shutdownAndAssert(net, t, wumboNode3)
 
 	// Creating a wumbo channel between these two nodes should succeed.
-	net.EnsureConnected(ctxb, t.t, wumboNode, wumboNode3)
+	net.EnsureConnected(t.t, wumboNode, wumboNode3)
 	chanPoint := openChannelAndAssert(
 		t, net, wumboNode, wumboNode3,
 		lntest.OpenChannelParams{

--- a/lntest/itest/lnd_max_channel_size_test.go
+++ b/lntest/itest/lnd_max_channel_size_test.go
@@ -3,7 +3,6 @@
 package itest
 
 import (
-	"context"
 	"fmt"
 	"strings"
 
@@ -29,7 +28,6 @@ func testMaxChannelSize(net *lntest.NetworkHarness, t *harnessTest) {
 	defer shutdownAndAssert(net, t, wumboNode2)
 
 	// We'll send 11 BTC to the wumbo node so it can test the wumbo soft limit.
-	ctxb := context.Background()
 	net.SendCoins(t.t, 11*btcutil.SatoshiPerBitcoin, wumboNode)
 
 	// Next we'll connect both nodes, then attempt to make a wumbo channel
@@ -39,7 +37,7 @@ func testMaxChannelSize(net *lntest.NetworkHarness, t *harnessTest) {
 
 	chanAmt := funding.MaxBtcFundingAmountWumbo + 1
 	_, err := net.OpenChannel(
-		ctxb, wumboNode, wumboNode2, lntest.OpenChannelParams{
+		wumboNode, wumboNode2, lntest.OpenChannelParams{
 			Amt: chanAmt,
 		},
 	)
@@ -61,7 +59,7 @@ func testMaxChannelSize(net *lntest.NetworkHarness, t *harnessTest) {
 	net.EnsureConnected(t.t, wumboNode, miniNode)
 
 	_, err = net.OpenChannel(
-		ctxb, wumboNode, miniNode, lntest.OpenChannelParams{
+		wumboNode, miniNode, lntest.OpenChannelParams{
 			Amt: chanAmt,
 		},
 	)

--- a/lntest/itest/lnd_max_channel_size_test.go
+++ b/lntest/itest/lnd_max_channel_size_test.go
@@ -91,7 +91,7 @@ func testMaxChannelSize(net *lntest.NetworkHarness, t *harnessTest) {
 	// Creating a wumbo channel between these two nodes should succeed.
 	net.EnsureConnected(ctxb, t.t, wumboNode, wumboNode3)
 	chanPoint := openChannelAndAssert(
-		ctxb, t, net, wumboNode, wumboNode3,
+		t, net, wumboNode, wumboNode3,
 		lntest.OpenChannelParams{
 			Amt: chanAmt,
 		},

--- a/lntest/itest/lnd_max_htlcs_test.go
+++ b/lntest/itest/lnd_max_htlcs_test.go
@@ -23,9 +23,8 @@ func testMaxHtlcPathfind(net *lntest.NetworkHarness, t *harnessTest) {
 	// Bob to add a maximum of 5 htlcs to her commitment.
 	maxHtlcs := 5
 
-	ctxt, _ := context.WithTimeout(ctxb, channelOpenTimeout)
 	chanPoint := openChannelAndAssert(
-		ctxt, t, net, net.Alice, net.Bob,
+		t, net, net.Alice, net.Bob,
 		lntest.OpenChannelParams{
 			Amt:            1000000,
 			PushAmt:        800000,
@@ -35,7 +34,7 @@ func testMaxHtlcPathfind(net *lntest.NetworkHarness, t *harnessTest) {
 
 	// Wait for Alice and Bob to receive the channel edge from the
 	// funding manager.
-	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
+	ctxt, _ := context.WithTimeout(ctxb, defaultTimeout)
 	err := net.Alice.WaitForNetworkChannelOpen(ctxt, chanPoint)
 	require.NoError(t.t, err, "alice does not have open channel")
 

--- a/lntest/itest/lnd_misc_test.go
+++ b/lntest/itest/lnd_misc_test.go
@@ -115,12 +115,10 @@ func testDisconnectingTargetPeer(net *lntest.NetworkHarness, t *harnessTest) {
 	}
 
 	// Check both nodes to ensure that the channel is ready for operation.
-	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
-	if err := net.AssertChannelExists(ctxt, alice, &outPoint); err != nil {
+	if err := net.AssertChannelExists(alice, &outPoint); err != nil {
 		t.Fatalf("unable to assert channel existence: %v", err)
 	}
-	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
-	if err := net.AssertChannelExists(ctxt, bob, &outPoint); err != nil {
+	if err := net.AssertChannelExists(bob, &outPoint); err != nil {
 		t.Fatalf("unable to assert channel existence: %v", err)
 	}
 
@@ -573,10 +571,8 @@ func testMaxPendingChannels(net *lntest.NetworkHarness, t *harnessTest) {
 			Hash:  *fundingTxID,
 			Index: fundingChanPoint.OutputIndex,
 		}
-		ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
-		if err := net.AssertChannelExists(ctxt, net.Alice, &chanPoint); err != nil {
-			t.Fatalf("unable to assert channel existence: %v", err)
-		}
+		err = net.AssertChannelExists(net.Alice, &chanPoint)
+		require.NoError(t.t, err, "unable to assert channel existence")
 
 		chanPoints[i] = fundingChanPoint
 	}
@@ -1503,14 +1499,12 @@ func testSendUpdateDisableChannel(net *lntest.NetworkHarness, t *harnessTest) {
 
 	// Close Alice's channels with Bob and Carol cooperatively and
 	// unilaterally respectively.
-	ctxt, _ = context.WithTimeout(ctxb, channelCloseTimeout)
-	_, _, err = net.CloseChannel(ctxt, net.Alice, chanPointAliceBob, false)
+	_, _, err = net.CloseChannel(net.Alice, chanPointAliceBob, false)
 	if err != nil {
 		t.Fatalf("unable to close channel: %v", err)
 	}
 
-	ctxt, _ = context.WithTimeout(ctxb, channelCloseTimeout)
-	_, _, err = net.CloseChannel(ctxt, net.Alice, chanPointAliceCarol, true)
+	_, _, err = net.CloseChannel(net.Alice, chanPointAliceCarol, true)
 	if err != nil {
 		t.Fatalf("unable to close channel: %v", err)
 	}
@@ -1530,8 +1524,7 @@ func testSendUpdateDisableChannel(net *lntest.NetworkHarness, t *harnessTest) {
 	mineBlocks(t, net, 1, 2)
 
 	// Also do this check for Eve's channel with Carol.
-	ctxt, _ = context.WithTimeout(ctxb, channelCloseTimeout)
-	_, _, err = net.CloseChannel(ctxt, eve, chanPointEveCarol, false)
+	_, _, err = net.CloseChannel(eve, chanPointEveCarol, false)
 	if err != nil {
 		t.Fatalf("unable to close channel: %v", err)
 	}

--- a/lntest/itest/lnd_misc_test.go
+++ b/lntest/itest/lnd_misc_test.go
@@ -1806,7 +1806,7 @@ func testSweepAllCoins(net *lntest.NetworkHarness, t *harnessTest) {
 	}
 
 	sweepTxStr := sweepTx.TxHash().String()
-	assertTxLabel(ctxb, t, ainz, sweepTxStr, sendCoinsLabel)
+	assertTxLabel(t, ainz, sweepTxStr, sendCoinsLabel)
 
 	// While we are looking at labels, we test our label transaction command
 	// to make sure it is behaving as expected. First, we try to label our
@@ -1865,7 +1865,7 @@ func testSweepAllCoins(net *lntest.NetworkHarness, t *harnessTest) {
 		t.Fatalf("could not label tx: %v", err)
 	}
 
-	assertTxLabel(ctxb, t, ainz, sweepTxStr, newLabel)
+	assertTxLabel(t, ainz, sweepTxStr, newLabel)
 
 	// Finally, Ainz should now have no coins at all within his wallet.
 	balReq := &lnrpc.WalletBalanceRequest{}

--- a/lntest/itest/lnd_misc_test.go
+++ b/lntest/itest/lnd_misc_test.go
@@ -72,8 +72,7 @@ func testDisconnectingTargetPeer(net *lntest.NetworkHarness, t *harnessTest) {
 	// At this point, the channel's funding transaction will have been
 	// broadcast, but not confirmed. Alice and Bob's nodes should reflect
 	// this when queried via RPC.
-	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
-	assertNumOpenChannelsPending(ctxt, t, alice, bob, 1)
+	assertNumOpenChannelsPending(t, alice, bob, 1)
 
 	// Disconnect Alice-peer from Bob-peer and get error causes by one
 	// pending channel with detach node is existing.
@@ -102,9 +101,8 @@ func testDisconnectingTargetPeer(net *lntest.NetworkHarness, t *harnessTest) {
 	// At this point, the channel should be fully opened and there should be
 	// no pending channels remaining for either node.
 	time.Sleep(time.Millisecond * 300)
-	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
 
-	assertNumOpenChannelsPending(ctxt, t, alice, bob, 0)
+	assertNumOpenChannelsPending(t, alice, bob, 0)
 
 	// Reconnect the nodes so that the channel can become active.
 	net.ConnectNodes(t.t, alice, bob)
@@ -510,9 +508,8 @@ func testMaxPendingChannels(net *lntest.NetworkHarness, t *harnessTest) {
 	// the channel if the number of pending channels exceed max value.
 	openStreams := make([]lnrpc.Lightning_OpenChannelClient, maxPendingChannels)
 	for i := 0; i < maxPendingChannels; i++ {
-		ctxt, _ := context.WithTimeout(ctxb, channelOpenTimeout)
 		stream := openChannelStream(
-			ctxt, t, net, net.Alice, carol,
+			t, net, net.Alice, carol,
 			lntest.OpenChannelParams{
 				Amt: amount,
 			},
@@ -1051,8 +1048,7 @@ func testDataLossProtection(net *lntest.NetworkHarness, t *harnessTest) {
 	closeChannelAndAssert(t, net, carol, chanPoint2, true)
 
 	// Wait for the channel to be marked pending force close.
-	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
-	err = waitForChannelPendingForceClose(ctxt, carol, chanPoint2)
+	err = waitForChannelPendingForceClose(carol, chanPoint2)
 	if err != nil {
 		t.Fatalf("channel not pending force close: %v", err)
 	}

--- a/lntest/itest/lnd_misc_test.go
+++ b/lntest/itest/lnd_misc_test.go
@@ -883,9 +883,8 @@ func testDataLossProtection(net *lntest.NetworkHarness, t *harnessTest) {
 
 		// Send payments from Carol using 3 of the payment hashes
 		// generated above.
-		ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
 		err = completePaymentRequests(
-			ctxt, carol, carol.RouterClient,
+			carol, carol.RouterClient,
 			payReqs[:numInvoices/2], true,
 		)
 		if err != nil {
@@ -931,10 +930,8 @@ func testDataLossProtection(net *lntest.NetworkHarness, t *harnessTest) {
 
 		// Finally, send more payments from , using the remaining
 		// payment hashes.
-		ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
 		err = completePaymentRequests(
-			ctxt, carol, carol.RouterClient,
-			payReqs[numInvoices/2:], true,
+			carol, carol.RouterClient, payReqs[numInvoices/2:], true,
 		)
 		if err != nil {
 			t.Fatalf("unable to send payments: %v", err)
@@ -1185,9 +1182,8 @@ func testRejectHTLC(net *lntest.NetworkHarness, t *harnessTest) {
 	}
 
 	// Alice pays Carols invoice.
-	ctxt, _ := context.WithTimeout(ctxb, defaultTimeout)
 	err = completePaymentRequests(
-		ctxt, net.Alice, net.Alice.RouterClient,
+		net.Alice, net.Alice.RouterClient,
 		[]string{resp.PaymentRequest}, true,
 	)
 	if err != nil {
@@ -1211,9 +1207,8 @@ func testRejectHTLC(net *lntest.NetworkHarness, t *harnessTest) {
 	}
 
 	// Carol pays Bobs invoice.
-	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
 	err = completePaymentRequests(
-		ctxt, carol, carol.RouterClient,
+		carol, carol.RouterClient,
 		[]string{resp.PaymentRequest}, true,
 	)
 	if err != nil {
@@ -1240,9 +1235,8 @@ func testRejectHTLC(net *lntest.NetworkHarness, t *harnessTest) {
 	// Alice attempts to pay Bobs invoice. This payment should be rejected since
 	// we are using Carol as an intermediary hop, Carol is running lnd with
 	// --rejecthtlc.
-	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
 	err = completePaymentRequests(
-		ctxt, net.Alice, net.Alice.RouterClient,
+		net.Alice, net.Alice.RouterClient,
 		[]string{resp.PaymentRequest}, true,
 	)
 	if err == nil {

--- a/lntest/itest/lnd_misc_test.go
+++ b/lntest/itest/lnd_misc_test.go
@@ -862,8 +862,7 @@ func testDataLossProtection(net *lntest.NetworkHarness, t *harnessTest) {
 
 		// We must let the node communicate with Carol before they are
 		// able to open channel, so we connect them.
-		ctxt, _ := context.WithTimeout(ctxb, defaultTimeout)
-		net.EnsureConnected(ctxt, t.t, carol, node)
+		net.EnsureConnected(t.t, carol, node)
 
 		// We'll first open up a channel between them with a 0.5 BTC
 		// value.
@@ -888,7 +887,7 @@ func testDataLossProtection(net *lntest.NetworkHarness, t *harnessTest) {
 
 		// Wait for Carol to receive the channel edge from the funding
 		// manager.
-		ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
+		ctxt, _ := context.WithTimeout(ctxb, defaultTimeout)
 		err = carol.WaitForNetworkChannelOpen(ctxt, chanPoint)
 		if err != nil {
 			t.Fatalf("carol didn't see the carol->%s channel "+
@@ -1479,8 +1478,7 @@ func testSendUpdateDisableChannel(net *lntest.NetworkHarness, t *harnessTest) {
 
 	// Reconnect Carol and Eve, this should cause them to reenable the
 	// channel from both ends after a short delay.
-	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
-	net.EnsureConnected(ctxt, t.t, carol, eve)
+	net.EnsureConnected(t.t, carol, eve)
 
 	expectedPolicy.Disabled = false
 	waitForChannelUpdate(
@@ -1502,8 +1500,7 @@ func testSendUpdateDisableChannel(net *lntest.NetworkHarness, t *harnessTest) {
 		t.Fatalf("unable to disconnect Carol from Eve: %v", err)
 	}
 	time.Sleep(time.Second)
-	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
-	net.EnsureConnected(ctxt, t.t, eve, carol)
+	net.EnsureConnected(t.t, eve, carol)
 
 	// Since the disable should have been canceled by both Carol and Eve, we
 	// expect no channel updates to appear on the network.

--- a/lntest/itest/lnd_misc_test.go
+++ b/lntest/itest/lnd_misc_test.go
@@ -47,14 +47,13 @@ func testDisconnectingTargetPeer(net *lntest.NetworkHarness, t *harnessTest) {
 	defer shutdownAndAssert(net, t, bob)
 
 	// Start by connecting Alice and Bob with no channels.
-	ctxt, _ := context.WithTimeout(ctxb, defaultTimeout)
-	net.ConnectNodes(ctxt, t.t, alice, bob)
+	net.ConnectNodes(t.t, alice, bob)
 
 	// Check existing connection.
 	assertNumConnections(t, alice, bob, 1)
 
 	// Give Alice some coins so she can fund a channel.
-	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
+	ctxt, _ := context.WithTimeout(ctxb, defaultTimeout)
 	net.SendCoins(ctxt, t.t, btcutil.SatoshiPerBitcoin, alice)
 
 	chanAmt := funding.MaxBtcFundingAmount
@@ -109,8 +108,7 @@ func testDisconnectingTargetPeer(net *lntest.NetworkHarness, t *harnessTest) {
 	assertNumOpenChannelsPending(ctxt, t, alice, bob, 0)
 
 	// Reconnect the nodes so that the channel can become active.
-	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
-	net.ConnectNodes(ctxt, t.t, alice, bob)
+	net.ConnectNodes(t.t, alice, bob)
 
 	// The channel should be listed in the peer information returned by both
 	// peers.
@@ -140,8 +138,7 @@ func testDisconnectingTargetPeer(net *lntest.NetworkHarness, t *harnessTest) {
 	assertNumConnections(t, alice, bob, 0)
 
 	// Reconnect both nodes before force closing the channel.
-	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
-	net.ConnectNodes(ctxt, t.t, alice, bob)
+	net.ConnectNodes(t.t, alice, bob)
 
 	// Finally, immediately close the channel. This function will also block
 	// until the channel is closed and will additionally assert the relevant
@@ -166,8 +163,7 @@ func testDisconnectingTargetPeer(net *lntest.NetworkHarness, t *harnessTest) {
 	assertNumConnections(t, alice, bob, 0)
 
 	// Finally, re-connect both nodes.
-	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
-	net.ConnectNodes(ctxt, t.t, alice, bob)
+	net.ConnectNodes(t.t, alice, bob)
 
 	// Check existing connection.
 	assertNumConnections(t, alice, net.Bob, 1)
@@ -202,9 +198,8 @@ func testSphinxReplayPersistence(net *lntest.NetworkHarness, t *harnessTest) {
 	carol := net.NewNode(t.t, "Carol", []string{"--unsafe-replay"})
 	defer shutdownAndAssert(net, t, carol)
 
+	net.ConnectNodes(t.t, carol, dave)
 	ctxt, _ := context.WithTimeout(ctxb, defaultTimeout)
-	net.ConnectNodes(ctxt, t.t, carol, dave)
-	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
 	net.SendCoins(ctxt, t.t, btcutil.SatoshiPerBitcoin, carol)
 
 	chanPoint := openChannelAndAssert(
@@ -222,8 +217,7 @@ func testSphinxReplayPersistence(net *lntest.NetworkHarness, t *harnessTest) {
 	fred := net.NewNode(t.t, "Fred", nil)
 	defer shutdownAndAssert(net, t, fred)
 
-	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
-	net.ConnectNodes(ctxt, t.t, fred, carol)
+	net.ConnectNodes(t.t, fred, carol)
 	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
 	net.SendCoins(ctxt, t.t, btcutil.SatoshiPerBitcoin, fred)
 
@@ -379,7 +373,7 @@ func testListChannels(net *lntest.NetworkHarness, t *harnessTest) {
 	defer shutdownAndAssert(net, t, bob)
 
 	// Connect Alice to Bob.
-	net.ConnectNodes(ctxb, t.t, alice, bob)
+	net.ConnectNodes(t.t, alice, bob)
 
 	// Give Alice some coins so she can fund a channel.
 	ctxt, _ := context.WithTimeout(ctxb, defaultTimeout)
@@ -510,10 +504,9 @@ func testMaxPendingChannels(net *lntest.NetworkHarness, t *harnessTest) {
 	carol := net.NewNode(t.t, "Carol", args)
 	defer shutdownAndAssert(net, t, carol)
 
-	ctxt, _ := context.WithTimeout(ctxb, defaultTimeout)
-	net.ConnectNodes(ctxt, t.t, net.Alice, carol)
+	net.ConnectNodes(t.t, net.Alice, carol)
 
-	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
+	ctxt, _ := context.WithTimeout(ctxb, defaultTimeout)
 	carolBalance := btcutil.Amount(maxPendingChannels) * amount
 	net.SendCoins(ctxt, t.t, carolBalance, carol)
 
@@ -624,8 +617,7 @@ func testGarbageCollectLinkNodes(net *lntest.NetworkHarness, t *harnessTest) {
 	// Create Carol's node and connect Alice to her.
 	carol := net.NewNode(t.t, "Carol", nil)
 	defer shutdownAndAssert(net, t, carol)
-	ctxt, _ := context.WithTimeout(ctxb, defaultTimeout)
-	net.ConnectNodes(ctxt, t.t, net.Alice, carol)
+	net.ConnectNodes(t.t, net.Alice, carol)
 
 	// Open a channel between Alice and Carol which will later be force
 	// closed.
@@ -641,7 +633,7 @@ func testGarbageCollectLinkNodes(net *lntest.NetworkHarness, t *harnessTest) {
 	dave := net.NewNode(t.t, "Dave", nil)
 	defer shutdownAndAssert(net, t, dave)
 
-	net.ConnectNodes(ctxt, t.t, net.Alice, dave)
+	net.ConnectNodes(t.t, net.Alice, dave)
 	persistentChanPoint := openChannelAndAssert(
 		t, net, net.Alice, dave, lntest.OpenChannelParams{
 			Amt: chanAmt,
@@ -652,7 +644,7 @@ func testGarbageCollectLinkNodes(net *lntest.NetworkHarness, t *harnessTest) {
 	// Alice.
 	isConnected := func(pubKey string) bool {
 		req := &lnrpc.ListPeersRequest{}
-		ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
+		ctxt, _ := context.WithTimeout(ctxb, defaultTimeout)
 		resp, err := net.Alice.ListPeers(ctxt, req)
 		if err != nil {
 			t.Fatalf("unable to retrieve alice's peers: %v", err)
@@ -774,7 +766,7 @@ func testGarbageCollectLinkNodes(net *lntest.NetworkHarness, t *harnessTest) {
 	var predErr error
 	pendingChansRequest := &lnrpc.PendingChannelsRequest{}
 	err = wait.Predicate(func() bool {
-		ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
+		ctxt, _ := context.WithTimeout(ctxb, defaultTimeout)
 		pendingChanResp, err := net.Alice.PendingChannels(
 			ctxt, pendingChansRequest,
 		)
@@ -815,7 +807,7 @@ func testGarbageCollectLinkNodes(net *lntest.NetworkHarness, t *harnessTest) {
 	describeGraphReq := &lnrpc.ChannelGraphRequest{
 		IncludeUnannounced: true,
 	}
-	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
+	ctxt, _ := context.WithTimeout(ctxb, defaultTimeout)
 	channelGraph, err := net.Alice.DescribeGraph(ctxt, describeGraphReq)
 	if err != nil {
 		t.Fatalf("unable to query for alice's channel graph: %v", err)
@@ -1155,10 +1147,10 @@ func testRejectHTLC(net *lntest.NetworkHarness, t *harnessTest) {
 	defer shutdownAndAssert(net, t, carol)
 
 	// Connect Alice to Carol.
-	net.ConnectNodes(ctxb, t.t, net.Alice, carol)
+	net.ConnectNodes(t.t, net.Alice, carol)
 
 	// Connect Carol to Bob.
-	net.ConnectNodes(ctxb, t.t, carol, net.Bob)
+	net.ConnectNodes(t.t, carol, net.Bob)
 
 	// Send coins to Carol.
 	net.SendCoins(ctxb, t.t, btcutil.SatoshiPerBitcoin, carol)
@@ -1390,8 +1382,7 @@ func testSendUpdateDisableChannel(net *lntest.NetworkHarness, t *harnessTest) {
 		})
 	defer shutdownAndAssert(net, t, carol)
 
-	ctxt, _ := context.WithTimeout(ctxb, defaultTimeout)
-	net.ConnectNodes(ctxt, t.t, net.Alice, carol)
+	net.ConnectNodes(t.t, net.Alice, carol)
 	chanPointAliceCarol := openChannelAndAssert(
 		t, net, net.Alice, carol,
 		lntest.OpenChannelParams{
@@ -1412,14 +1403,12 @@ func testSendUpdateDisableChannel(net *lntest.NetworkHarness, t *harnessTest) {
 	defer shutdownAndAssert(net, t, eve)
 
 	// Give Eve some coins.
-	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
+	ctxt, _ := context.WithTimeout(ctxb, defaultTimeout)
 	net.SendCoins(ctxt, t.t, btcutil.SatoshiPerBitcoin, eve)
 
 	// Connect Eve to Carol and Bob, and open a channel to carol.
-	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
-	net.ConnectNodes(ctxt, t.t, eve, carol)
-	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
-	net.ConnectNodes(ctxt, t.t, eve, net.Bob)
+	net.ConnectNodes(t.t, eve, carol)
+	net.ConnectNodes(t.t, eve, net.Bob)
 
 	chanPointEveCarol := openChannelAndAssert(
 		t, net, eve, carol,
@@ -1434,8 +1423,7 @@ func testSendUpdateDisableChannel(net *lntest.NetworkHarness, t *harnessTest) {
 	dave := net.NewNode(t.t, "Dave", nil)
 	defer shutdownAndAssert(net, t, dave)
 
-	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
-	net.ConnectNodes(ctxt, t.t, net.Bob, dave)
+	net.ConnectNodes(t.t, net.Bob, dave)
 
 	daveSub := subscribeGraphNotifications(ctxb, t, dave)
 	defer close(daveSub.quit)

--- a/lntest/itest/lnd_misc_test.go
+++ b/lntest/itest/lnd_misc_test.go
@@ -897,8 +897,7 @@ func testDataLossProtection(net *lntest.NetworkHarness, t *harnessTest) {
 		var nodeChan *lnrpc.Channel
 		var predErr error
 		err = wait.Predicate(func() bool {
-			ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
-			bChan, err := getChanInfo(ctxt, node)
+			bChan, err := getChanInfo(node)
 			if err != nil {
 				t.Fatalf("unable to get channel info: %v", err)
 			}
@@ -937,8 +936,7 @@ func testDataLossProtection(net *lntest.NetworkHarness, t *harnessTest) {
 			t.Fatalf("unable to send payments: %v", err)
 		}
 
-		ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
-		nodeChan, err = getChanInfo(ctxt, node)
+		nodeChan, err = getChanInfo(node)
 		if err != nil {
 			t.Fatalf("unable to get dave chan info: %v", err)
 		}
@@ -960,8 +958,7 @@ func testDataLossProtection(net *lntest.NetworkHarness, t *harnessTest) {
 
 		// Now query for the channel state, it should show that it's at
 		// a state number in the past, not the *latest* state.
-		ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
-		nodeChan, err = getChanInfo(ctxt, node)
+		nodeChan, err = getChanInfo(node)
 		if err != nil {
 			t.Fatalf("unable to get dave chan info: %v", err)
 		}

--- a/lntest/itest/lnd_misc_test.go
+++ b/lntest/itest/lnd_misc_test.go
@@ -547,8 +547,7 @@ func testMaxPendingChannels(net *lntest.NetworkHarness, t *harnessTest) {
 
 	chanPoints := make([]*lnrpc.ChannelPoint, maxPendingChannels)
 	for i, stream := range openStreams {
-		ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
-		fundingChanPoint, err := net.WaitForChannelOpen(ctxt, stream)
+		fundingChanPoint, err := net.WaitForChannelOpen(stream)
 		if err != nil {
 			t.Fatalf("error while waiting for channel open: %v", err)
 		}

--- a/lntest/itest/lnd_misc_test.go
+++ b/lntest/itest/lnd_misc_test.go
@@ -53,8 +53,7 @@ func testDisconnectingTargetPeer(net *lntest.NetworkHarness, t *harnessTest) {
 	assertNumConnections(t, alice, bob, 1)
 
 	// Give Alice some coins so she can fund a channel.
-	ctxt, _ := context.WithTimeout(ctxb, defaultTimeout)
-	net.SendCoins(ctxt, t.t, btcutil.SatoshiPerBitcoin, alice)
+	net.SendCoins(t.t, btcutil.SatoshiPerBitcoin, alice)
 
 	chanAmt := funding.MaxBtcFundingAmount
 	pushAmt := btcutil.Amount(0)
@@ -62,7 +61,7 @@ func testDisconnectingTargetPeer(net *lntest.NetworkHarness, t *harnessTest) {
 	// Create a new channel that requires 1 confs before it's considered
 	// open, then broadcast the funding transaction
 	const numConfs = 1
-	ctxt, _ = context.WithTimeout(ctxb, channelOpenTimeout)
+	ctxt, _ := context.WithTimeout(ctxb, channelOpenTimeout)
 	pendingUpdate, err := net.OpenPendingChannel(
 		ctxt, alice, bob, chanAmt, pushAmt,
 	)
@@ -199,8 +198,7 @@ func testSphinxReplayPersistence(net *lntest.NetworkHarness, t *harnessTest) {
 	defer shutdownAndAssert(net, t, carol)
 
 	net.ConnectNodes(t.t, carol, dave)
-	ctxt, _ := context.WithTimeout(ctxb, defaultTimeout)
-	net.SendCoins(ctxt, t.t, btcutil.SatoshiPerBitcoin, carol)
+	net.SendCoins(t.t, btcutil.SatoshiPerBitcoin, carol)
 
 	chanPoint := openChannelAndAssert(
 		t, net, carol, dave,
@@ -218,8 +216,7 @@ func testSphinxReplayPersistence(net *lntest.NetworkHarness, t *harnessTest) {
 	defer shutdownAndAssert(net, t, fred)
 
 	net.ConnectNodes(t.t, fred, carol)
-	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
-	net.SendCoins(ctxt, t.t, btcutil.SatoshiPerBitcoin, fred)
+	net.SendCoins(t.t, btcutil.SatoshiPerBitcoin, fred)
 
 	chanPointFC := openChannelAndAssert(
 		t, net, fred, carol,
@@ -238,7 +235,7 @@ func testSphinxReplayPersistence(net *lntest.NetworkHarness, t *harnessTest) {
 		RPreimage: preimage,
 		Value:     paymentAmt,
 	}
-	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
+	ctxt, _ := context.WithTimeout(ctxb, defaultTimeout)
 	invoiceResp, err := dave.AddInvoice(ctxt, invoice)
 	if err != nil {
 		t.Fatalf("unable to add invoice: %v", err)
@@ -376,8 +373,7 @@ func testListChannels(net *lntest.NetworkHarness, t *harnessTest) {
 	net.ConnectNodes(t.t, alice, bob)
 
 	// Give Alice some coins so she can fund a channel.
-	ctxt, _ := context.WithTimeout(ctxb, defaultTimeout)
-	net.SendCoins(ctxt, t.t, btcutil.SatoshiPerBitcoin, alice)
+	net.SendCoins(t.t, btcutil.SatoshiPerBitcoin, alice)
 
 	// Open a channel with 100k satoshis between Alice and Bob with Alice
 	// being the sole funder of the channel. The minial HTLC amount is set to
@@ -396,7 +392,7 @@ func testListChannels(net *lntest.NetworkHarness, t *harnessTest) {
 
 	// Wait for Alice and Bob to receive the channel edge from the
 	// funding manager.
-	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
+	ctxt, _ := context.WithTimeout(ctxb, defaultTimeout)
 	err := alice.WaitForNetworkChannelOpen(ctxt, chanPoint)
 	if err != nil {
 		t.Fatalf("alice didn't see the alice->bob channel before "+
@@ -506,16 +502,15 @@ func testMaxPendingChannels(net *lntest.NetworkHarness, t *harnessTest) {
 
 	net.ConnectNodes(t.t, net.Alice, carol)
 
-	ctxt, _ := context.WithTimeout(ctxb, defaultTimeout)
 	carolBalance := btcutil.Amount(maxPendingChannels) * amount
-	net.SendCoins(ctxt, t.t, carolBalance, carol)
+	net.SendCoins(t.t, carolBalance, carol)
 
 	// Send open channel requests without generating new blocks thereby
 	// increasing pool of pending channels. Then check that we can't open
 	// the channel if the number of pending channels exceed max value.
 	openStreams := make([]lnrpc.Lightning_OpenChannelClient, maxPendingChannels)
 	for i := 0; i < maxPendingChannels; i++ {
-		ctxt, _ = context.WithTimeout(ctxb, channelOpenTimeout)
+		ctxt, _ := context.WithTimeout(ctxb, channelOpenTimeout)
 		stream := openChannelStream(
 			ctxt, t, net, net.Alice, carol,
 			lntest.OpenChannelParams{
@@ -527,7 +522,7 @@ func testMaxPendingChannels(net *lntest.NetworkHarness, t *harnessTest) {
 
 	// Carol exhausted available amount of pending channels, next open
 	// channel request should cause ErrorGeneric to be sent back to Alice.
-	ctxt, _ = context.WithTimeout(ctxb, channelOpenTimeout)
+	ctxt, _ := context.WithTimeout(ctxb, channelOpenTimeout)
 	_, err := net.OpenChannel(
 		ctxt, net.Alice, carol,
 		lntest.OpenChannelParams{
@@ -855,8 +850,7 @@ func testDataLossProtection(net *lntest.NetworkHarness, t *harnessTest) {
 
 	// Before we make a channel, we'll load up Carol with some coins sent
 	// directly from the miner.
-	ctxt, _ := context.WithTimeout(ctxb, defaultTimeout)
-	net.SendCoins(ctxt, t.t, btcutil.SatoshiPerBitcoin, carol)
+	net.SendCoins(t.t, btcutil.SatoshiPerBitcoin, carol)
 
 	// timeTravel is a method that will make Carol open a channel to the
 	// passed node, settle a series of payments, then reset the node back
@@ -868,7 +862,7 @@ func testDataLossProtection(net *lntest.NetworkHarness, t *harnessTest) {
 
 		// We must let the node communicate with Carol before they are
 		// able to open channel, so we connect them.
-		ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
+		ctxt, _ := context.WithTimeout(ctxb, defaultTimeout)
 		net.EnsureConnected(ctxt, t.t, carol, node)
 
 		// We'll first open up a channel between them with a 0.5 BTC
@@ -1016,7 +1010,7 @@ func testDataLossProtection(net *lntest.NetworkHarness, t *harnessTest) {
 	// We make a note of the nodes' current on-chain balances, to make sure
 	// they are able to retrieve the channel funds eventually,
 	balReq := &lnrpc.WalletBalanceRequest{}
-	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
+	ctxt, _ := context.WithTimeout(ctxb, defaultTimeout)
 	carolBalResp, err := carol.WalletBalance(ctxt, balReq)
 	if err != nil {
 		t.Fatalf("unable to get carol's balance: %v", err)
@@ -1153,10 +1147,10 @@ func testRejectHTLC(net *lntest.NetworkHarness, t *harnessTest) {
 	net.ConnectNodes(t.t, carol, net.Bob)
 
 	// Send coins to Carol.
-	net.SendCoins(ctxb, t.t, btcutil.SatoshiPerBitcoin, carol)
+	net.SendCoins(t.t, btcutil.SatoshiPerBitcoin, carol)
 
 	// Send coins to Alice.
-	net.SendCoins(ctxb, t.t, btcutil.SatoshiPerBitcent, net.Alice)
+	net.SendCoins(t.t, btcutil.SatoshiPerBitcent, net.Alice)
 
 	// Open a channel between Alice and Carol.
 	chanPointAlice := openChannelAndAssert(
@@ -1403,8 +1397,7 @@ func testSendUpdateDisableChannel(net *lntest.NetworkHarness, t *harnessTest) {
 	defer shutdownAndAssert(net, t, eve)
 
 	// Give Eve some coins.
-	ctxt, _ := context.WithTimeout(ctxb, defaultTimeout)
-	net.SendCoins(ctxt, t.t, btcutil.SatoshiPerBitcoin, eve)
+	net.SendCoins(t.t, btcutil.SatoshiPerBitcoin, eve)
 
 	// Connect Eve to Carol and Bob, and open a channel to carol.
 	net.ConnectNodes(t.t, eve, carol)
@@ -1469,7 +1462,7 @@ func testSendUpdateDisableChannel(net *lntest.NetworkHarness, t *harnessTest) {
 	// Now we'll test a long disconnection. Disconnect Carol and Eve and
 	// ensure they both detect each other as disabled. Their min backoffs
 	// are high enough to not interfere with disabling logic.
-	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
+	ctxt, _ := context.WithTimeout(ctxb, defaultTimeout)
 	if err := net.DisconnectNodes(ctxt, carol, eve); err != nil {
 		t.Fatalf("unable to disconnect Carol from Eve: %v", err)
 	}
@@ -1716,13 +1709,12 @@ func testSweepAllCoins(net *lntest.NetworkHarness, t *harnessTest) {
 
 	// Next, we'll give Ainz exactly 2 utxos of 1 BTC each, with one of
 	// them being p2wkh and the other being a n2wpkh address.
-	ctxt, _ := context.WithTimeout(ctxb, defaultTimeout)
-	net.SendCoins(ctxt, t.t, btcutil.SatoshiPerBitcoin, ainz)
+	net.SendCoins(t.t, btcutil.SatoshiPerBitcoin, ainz)
 
-	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
-	net.SendCoinsNP2WKH(ctxt, t.t, btcutil.SatoshiPerBitcoin, ainz)
+	net.SendCoinsNP2WKH(t.t, btcutil.SatoshiPerBitcoin, ainz)
 
 	// Ensure that we can't send coins to our own Pubkey.
+	ctxt, _ := context.WithTimeout(ctxb, defaultTimeout)
 	info, err := ainz.GetInfo(ctxt, &lnrpc.GetInfoRequest{})
 	if err != nil {
 		t.Fatalf("unable to get node info: %v", err)

--- a/lntest/itest/lnd_misc_test.go
+++ b/lntest/itest/lnd_misc_test.go
@@ -207,9 +207,8 @@ func testSphinxReplayPersistence(net *lntest.NetworkHarness, t *harnessTest) {
 	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
 	net.SendCoins(ctxt, t.t, btcutil.SatoshiPerBitcoin, carol)
 
-	ctxt, _ = context.WithTimeout(ctxb, channelOpenTimeout)
 	chanPoint := openChannelAndAssert(
-		ctxt, t, net, carol, dave,
+		t, net, carol, dave,
 		lntest.OpenChannelParams{
 			Amt: chanAmt,
 		},
@@ -228,9 +227,8 @@ func testSphinxReplayPersistence(net *lntest.NetworkHarness, t *harnessTest) {
 	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
 	net.SendCoins(ctxt, t.t, btcutil.SatoshiPerBitcoin, fred)
 
-	ctxt, _ = context.WithTimeout(ctxb, channelOpenTimeout)
 	chanPointFC := openChannelAndAssert(
-		ctxt, t, net, fred, carol,
+		t, net, fred, carol,
 		lntest.OpenChannelParams{
 			Amt: chanAmt,
 		},
@@ -393,9 +391,8 @@ func testListChannels(net *lntest.NetworkHarness, t *harnessTest) {
 	const customizedMinHtlc = 4200
 
 	chanAmt := btcutil.Amount(100000)
-	ctxt, _ = context.WithTimeout(ctxb, channelOpenTimeout)
 	chanPoint := openChannelAndAssert(
-		ctxt, t, net, alice, bob,
+		t, net, alice, bob,
 		lntest.OpenChannelParams{
 			Amt:            chanAmt,
 			MinHtlc:        customizedMinHtlc,
@@ -618,9 +615,8 @@ func testGarbageCollectLinkNodes(net *lntest.NetworkHarness, t *harnessTest) {
 
 	// Open a channel between Alice and Bob which will later be
 	// cooperatively closed.
-	ctxt, _ := context.WithTimeout(ctxb, channelOpenTimeout)
 	coopChanPoint := openChannelAndAssert(
-		ctxt, t, net, net.Alice, net.Bob, lntest.OpenChannelParams{
+		t, net, net.Alice, net.Bob, lntest.OpenChannelParams{
 			Amt: chanAmt,
 		},
 	)
@@ -628,14 +624,13 @@ func testGarbageCollectLinkNodes(net *lntest.NetworkHarness, t *harnessTest) {
 	// Create Carol's node and connect Alice to her.
 	carol := net.NewNode(t.t, "Carol", nil)
 	defer shutdownAndAssert(net, t, carol)
-	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
+	ctxt, _ := context.WithTimeout(ctxb, defaultTimeout)
 	net.ConnectNodes(ctxt, t.t, net.Alice, carol)
 
 	// Open a channel between Alice and Carol which will later be force
 	// closed.
-	ctxt, _ = context.WithTimeout(ctxb, channelOpenTimeout)
 	forceCloseChanPoint := openChannelAndAssert(
-		ctxt, t, net, net.Alice, carol, lntest.OpenChannelParams{
+		t, net, net.Alice, carol, lntest.OpenChannelParams{
 			Amt: chanAmt,
 		},
 	)
@@ -647,9 +642,8 @@ func testGarbageCollectLinkNodes(net *lntest.NetworkHarness, t *harnessTest) {
 	defer shutdownAndAssert(net, t, dave)
 
 	net.ConnectNodes(ctxt, t.t, net.Alice, dave)
-	ctxt, _ = context.WithTimeout(ctxb, channelOpenTimeout)
 	persistentChanPoint := openChannelAndAssert(
-		ctxt, t, net, net.Alice, dave, lntest.OpenChannelParams{
+		t, net, net.Alice, dave, lntest.OpenChannelParams{
 			Amt: chanAmt,
 		},
 	)
@@ -887,9 +881,8 @@ func testDataLossProtection(net *lntest.NetworkHarness, t *harnessTest) {
 
 		// We'll first open up a channel between them with a 0.5 BTC
 		// value.
-		ctxt, _ := context.WithTimeout(ctxb, channelOpenTimeout)
 		chanPoint := openChannelAndAssert(
-			ctxt, t, net, carol, node,
+			t, net, carol, node,
 			lntest.OpenChannelParams{
 				Amt: chanAmt,
 			},
@@ -1174,18 +1167,16 @@ func testRejectHTLC(net *lntest.NetworkHarness, t *harnessTest) {
 	net.SendCoins(ctxb, t.t, btcutil.SatoshiPerBitcent, net.Alice)
 
 	// Open a channel between Alice and Carol.
-	ctxt, _ := context.WithTimeout(ctxb, channelOpenTimeout)
 	chanPointAlice := openChannelAndAssert(
-		ctxt, t, net, net.Alice, carol,
+		t, net, net.Alice, carol,
 		lntest.OpenChannelParams{
 			Amt: chanAmt,
 		},
 	)
 
 	// Open a channel between Carol and Bob.
-	ctxt, _ = context.WithTimeout(ctxb, channelOpenTimeout)
 	chanPointCarol := openChannelAndAssert(
-		ctxt, t, net, carol, net.Bob,
+		t, net, carol, net.Bob,
 		lntest.OpenChannelParams{
 			Amt: chanAmt,
 		},
@@ -1223,7 +1214,7 @@ func testRejectHTLC(net *lntest.NetworkHarness, t *harnessTest) {
 	}
 
 	// Alice pays Carols invoice.
-	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
+	ctxt, _ := context.WithTimeout(ctxb, defaultTimeout)
 	err = completePaymentRequests(
 		ctxt, net.Alice, net.Alice.RouterClient,
 		[]string{resp.PaymentRequest}, true,
@@ -1303,9 +1294,8 @@ func testNodeSignVerify(net *lntest.NetworkHarness, t *harnessTest) {
 	pushAmt := btcutil.Amount(100000)
 
 	// Create a channel between alice and bob.
-	ctxt, _ := context.WithTimeout(ctxb, channelOpenTimeout)
 	aliceBobCh := openChannelAndAssert(
-		ctxt, t, net, net.Alice, net.Bob,
+		t, net, net.Alice, net.Bob,
 		lntest.OpenChannelParams{
 			Amt:     chanAmt,
 			PushAmt: pushAmt,
@@ -1316,7 +1306,7 @@ func testNodeSignVerify(net *lntest.NetworkHarness, t *harnessTest) {
 
 	// alice signs "alice msg" and sends her signature to bob.
 	sigReq := &lnrpc.SignMessageRequest{Msg: aliceMsg}
-	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
+	ctxt, _ := context.WithTimeout(ctxb, defaultTimeout)
 	sigResp, err := net.Alice.SignMessage(ctxt, sigReq)
 	if err != nil {
 		t.Fatalf("SignMessage rpc call failed: %v", err)
@@ -1384,9 +1374,8 @@ func testSendUpdateDisableChannel(net *lntest.NetworkHarness, t *harnessTest) {
 	// Open a channel between Alice and Bob and Alice and Carol. These will
 	// be closed later on in order to trigger channel update messages
 	// marking the channels as disabled.
-	ctxt, _ := context.WithTimeout(ctxb, channelOpenTimeout)
 	chanPointAliceBob := openChannelAndAssert(
-		ctxt, t, net, net.Alice, net.Bob,
+		t, net, net.Alice, net.Bob,
 		lntest.OpenChannelParams{
 			Amt: chanAmt,
 		},
@@ -1401,11 +1390,10 @@ func testSendUpdateDisableChannel(net *lntest.NetworkHarness, t *harnessTest) {
 		})
 	defer shutdownAndAssert(net, t, carol)
 
-	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
+	ctxt, _ := context.WithTimeout(ctxb, defaultTimeout)
 	net.ConnectNodes(ctxt, t.t, net.Alice, carol)
-	ctxt, _ = context.WithTimeout(ctxb, channelOpenTimeout)
 	chanPointAliceCarol := openChannelAndAssert(
-		ctxt, t, net, net.Alice, carol,
+		t, net, net.Alice, carol,
 		lntest.OpenChannelParams{
 			Amt: chanAmt,
 		},
@@ -1433,9 +1421,8 @@ func testSendUpdateDisableChannel(net *lntest.NetworkHarness, t *harnessTest) {
 	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
 	net.ConnectNodes(ctxt, t.t, eve, net.Bob)
 
-	ctxt, _ = context.WithTimeout(ctxb, channelOpenTimeout)
 	chanPointEveCarol := openChannelAndAssert(
-		ctxt, t, net, eve, carol,
+		t, net, eve, carol,
 		lntest.OpenChannelParams{
 			Amt: chanAmt,
 		},
@@ -1602,16 +1589,15 @@ func testAbandonChannel(net *lntest.NetworkHarness, t *harnessTest) {
 		PushAmt: btcutil.Amount(100000),
 	}
 
-	ctxt, _ := context.WithTimeout(ctxb, channelOpenTimeout)
 	chanPoint := openChannelAndAssert(
-		ctxt, t, net, net.Alice, net.Bob, channelParam,
+		t, net, net.Alice, net.Bob, channelParam,
 	)
 	txid, err := lnrpc.GetChanPointFundingTxid(chanPoint)
 	require.NoError(t.t, err, "alice bob get channel funding txid")
 	chanPointStr := fmt.Sprintf("%v:%v", txid, chanPoint.OutputIndex)
 
 	// Wait for channel to be confirmed open.
-	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
+	ctxt, _ := context.WithTimeout(ctxb, defaultTimeout)
 	err = net.Alice.WaitForNetworkChannelOpen(ctxt, chanPoint)
 	require.NoError(t.t, err, "alice wait for network channel open")
 	err = net.Bob.WaitForNetworkChannelOpen(ctxt, chanPoint)

--- a/lntest/itest/lnd_misc_test.go
+++ b/lntest/itest/lnd_misc_test.go
@@ -31,8 +31,6 @@ import (
 // Bob-peer and then re-connects them again. We expect Alice to be able to
 // disconnect at any point.
 func testDisconnectingTargetPeer(net *lntest.NetworkHarness, t *harnessTest) {
-	ctxb := context.Background()
-
 	// We'll start both nodes with a high backoff so that they don't
 	// reconnect automatically during our test.
 	args := []string{
@@ -61,9 +59,8 @@ func testDisconnectingTargetPeer(net *lntest.NetworkHarness, t *harnessTest) {
 	// Create a new channel that requires 1 confs before it's considered
 	// open, then broadcast the funding transaction
 	const numConfs = 1
-	ctxt, _ := context.WithTimeout(ctxb, channelOpenTimeout)
 	pendingUpdate, err := net.OpenPendingChannel(
-		ctxt, alice, bob, chanAmt, pushAmt,
+		alice, bob, chanAmt, pushAmt,
 	)
 	if err != nil {
 		t.Fatalf("unable to open channel: %v", err)
@@ -76,7 +73,7 @@ func testDisconnectingTargetPeer(net *lntest.NetworkHarness, t *harnessTest) {
 
 	// Disconnect Alice-peer from Bob-peer and get error causes by one
 	// pending channel with detach node is existing.
-	if err := net.DisconnectNodes(ctxt, alice, bob); err != nil {
+	if err := net.DisconnectNodes(alice, bob); err != nil {
 		t.Fatalf("Bob's peer was disconnected from Alice's"+
 			" while one pending channel is existing: err %v", err)
 	}
@@ -124,7 +121,7 @@ func testDisconnectingTargetPeer(net *lntest.NetworkHarness, t *harnessTest) {
 
 	// Disconnect Alice-peer from Bob-peer and get error causes by one
 	// active channel with detach node is existing.
-	if err := net.DisconnectNodes(ctxt, alice, bob); err != nil {
+	if err := net.DisconnectNodes(alice, bob); err != nil {
 		t.Fatalf("Bob's peer was disconnected from Alice's"+
 			" while one active channel is existing: err %v", err)
 	}
@@ -149,7 +146,7 @@ func testDisconnectingTargetPeer(net *lntest.NetworkHarness, t *harnessTest) {
 
 	// Disconnect Alice-peer from Bob-peer without getting error about
 	// existing channels.
-	if err := net.DisconnectNodes(ctxt, alice, bob); err != nil {
+	if err := net.DisconnectNodes(alice, bob); err != nil {
 		t.Fatalf("unable to disconnect Bob's peer from Alice's: err %v",
 			err)
 	}
@@ -517,10 +514,8 @@ func testMaxPendingChannels(net *lntest.NetworkHarness, t *harnessTest) {
 
 	// Carol exhausted available amount of pending channels, next open
 	// channel request should cause ErrorGeneric to be sent back to Alice.
-	ctxt, _ := context.WithTimeout(ctxb, channelOpenTimeout)
 	_, err := net.OpenChannel(
-		ctxt, net.Alice, carol,
-		lntest.OpenChannelParams{
+		net.Alice, carol, lntest.OpenChannelParams{
 			Amt: amount,
 		},
 	)
@@ -558,7 +553,7 @@ func testMaxPendingChannels(net *lntest.NetworkHarness, t *harnessTest) {
 		// Ensure that the funding transaction enters a block, and is
 		// properly advertised by Alice.
 		assertTxInBlock(t, block, fundingTxID)
-		ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
+		ctxt, _ := context.WithTimeout(ctxb, defaultTimeout)
 		err = net.Alice.WaitForNetworkChannelOpen(ctxt, fundingChanPoint)
 		if err != nil {
 			t.Fatalf("channel not seen on network before "+
@@ -1452,8 +1447,7 @@ func testSendUpdateDisableChannel(net *lntest.NetworkHarness, t *harnessTest) {
 	// Now we'll test a long disconnection. Disconnect Carol and Eve and
 	// ensure they both detect each other as disabled. Their min backoffs
 	// are high enough to not interfere with disabling logic.
-	ctxt, _ := context.WithTimeout(ctxb, defaultTimeout)
-	if err := net.DisconnectNodes(ctxt, carol, eve); err != nil {
+	if err := net.DisconnectNodes(carol, eve); err != nil {
 		t.Fatalf("unable to disconnect Carol from Eve: %v", err)
 	}
 
@@ -1486,8 +1480,7 @@ func testSendUpdateDisableChannel(net *lntest.NetworkHarness, t *harnessTest) {
 	// should allow for the disconnect to be detected, but still leave time
 	// to cancel the announcement before the 3 second inactive timeout is
 	// hit.
-	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
-	if err := net.DisconnectNodes(ctxt, carol, eve); err != nil {
+	if err := net.DisconnectNodes(carol, eve); err != nil {
 		t.Fatalf("unable to disconnect Carol from Eve: %v", err)
 	}
 	time.Sleep(time.Second)

--- a/lntest/itest/lnd_mpp_test.go
+++ b/lntest/itest/lnd_mpp_test.go
@@ -255,8 +255,6 @@ type mppTestContext struct {
 func newMppTestContext(t *harnessTest,
 	net *lntest.NetworkHarness) *mppTestContext {
 
-	ctxb := context.Background()
-
 	alice := net.NewNode(t.t, "alice", nil)
 	bob := net.NewNode(t.t, "bob", []string{"--accept-amp"})
 
@@ -270,8 +268,7 @@ func newMppTestContext(t *harnessTest,
 	nodes := []*lntest.HarnessNode{alice, bob, carol, dave, eve}
 	for i := 0; i < len(nodes); i++ {
 		for j := i + 1; j < len(nodes); j++ {
-			ctxt, _ := context.WithTimeout(ctxb, defaultTimeout)
-			net.EnsureConnected(ctxt, t.t, nodes[i], nodes[j])
+			net.EnsureConnected(t.t, nodes[i], nodes[j])
 		}
 	}
 

--- a/lntest/itest/lnd_mpp_test.go
+++ b/lntest/itest/lnd_mpp_test.go
@@ -290,11 +290,10 @@ func newMppTestContext(t *harnessTest,
 }
 
 // openChannel is a helper to open a channel from->to.
-func (c *mppTestContext) openChannel(from, to *lntest.HarnessNode, chanSize btcutil.Amount) {
-	ctxb := context.Background()
+func (c *mppTestContext) openChannel(from, to *lntest.HarnessNode,
+	chanSize btcutil.Amount) {
 
-	ctxt, _ := context.WithTimeout(ctxb, defaultTimeout)
-	c.net.SendCoins(ctxt, c.t.t, btcutil.SatoshiPerBitcoin, from)
+	c.net.SendCoins(c.t.t, btcutil.SatoshiPerBitcoin, from)
 
 	chanPoint := openChannelAndAssert(
 		c.t, c.net, from, to,

--- a/lntest/itest/lnd_mpp_test.go
+++ b/lntest/itest/lnd_mpp_test.go
@@ -296,12 +296,9 @@ func (c *mppTestContext) openChannel(from, to *lntest.HarnessNode, chanSize btcu
 	ctxt, _ := context.WithTimeout(ctxb, defaultTimeout)
 	c.net.SendCoins(ctxt, c.t.t, btcutil.SatoshiPerBitcoin, from)
 
-	ctxt, _ = context.WithTimeout(ctxb, channelOpenTimeout)
 	chanPoint := openChannelAndAssert(
-		ctxt, c.t, c.net, from, to,
-		lntest.OpenChannelParams{
-			Amt: chanSize,
-		},
+		c.t, c.net, from, to,
+		lntest.OpenChannelParams{Amt: chanSize},
 	)
 
 	c.closeChannelFuncs = append(c.closeChannelFuncs, func() {

--- a/lntest/itest/lnd_multi-hop-error-propagation_test.go
+++ b/lntest/itest/lnd_multi-hop-error-propagation_test.go
@@ -23,14 +23,13 @@ func testHtlcErrorPropagation(net *lntest.NetworkHarness, t *harnessTest) {
 
 	// First establish a channel with a capacity of 0.5 BTC between Alice
 	// and Bob.
-	ctxt, _ := context.WithTimeout(ctxb, channelOpenTimeout)
 	chanPointAlice := openChannelAndAssert(
-		ctxt, t, net, net.Alice, net.Bob,
+		t, net, net.Alice, net.Bob,
 		lntest.OpenChannelParams{
 			Amt: chanAmt,
 		},
 	)
-	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
+	ctxt, _ := context.WithTimeout(ctxb, defaultTimeout)
 	if err := net.Alice.WaitForNetworkChannelOpen(ctxt, chanPointAlice); err != nil {
 		t.Fatalf("channel not seen by alice before timeout: %v", err)
 	}
@@ -96,10 +95,9 @@ func testHtlcErrorPropagation(net *lntest.NetworkHarness, t *harnessTest) {
 	// above.
 	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
 	net.ConnectNodes(ctxt, t.t, net.Bob, carol)
-	ctxt, _ = context.WithTimeout(ctxb, channelOpenTimeout)
 	const bobChanAmt = funding.MaxBtcFundingAmount
 	chanPointBob := openChannelAndAssert(
-		ctxt, t, net, net.Bob, carol,
+		t, net, net.Bob, carol,
 		lntest.OpenChannelParams{
 			Amt: chanAmt,
 		},

--- a/lntest/itest/lnd_multi-hop-error-propagation_test.go
+++ b/lntest/itest/lnd_multi-hop-error-propagation_test.go
@@ -93,8 +93,7 @@ func testHtlcErrorPropagation(net *lntest.NetworkHarness, t *harnessTest) {
 	// channel between them so we have the topology: Alice -> Bob -> Carol.
 	// The channel created will be of lower capacity that the one created
 	// above.
-	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
-	net.ConnectNodes(ctxt, t.t, net.Bob, carol)
+	net.ConnectNodes(t.t, net.Bob, carol)
 	const bobChanAmt = funding.MaxBtcFundingAmount
 	chanPointBob := openChannelAndAssert(
 		t, net, net.Bob, carol,

--- a/lntest/itest/lnd_multi-hop-error-propagation_test.go
+++ b/lntest/itest/lnd_multi-hop-error-propagation_test.go
@@ -289,10 +289,8 @@ out:
 			t.Fatalf("unable to generate carol invoice: %v", err)
 		}
 
-		ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
 		sendAndAssertSuccess(
-			ctxt, t, net.Bob,
-			&routerrpc.SendPaymentRequest{
+			t, net.Bob, &routerrpc.SendPaymentRequest{
 				PaymentRequest: carolInvoice2.PaymentRequest,
 				TimeoutSeconds: 60,
 				FeeLimitMsat:   noFeeLimitMsat,

--- a/lntest/itest/lnd_multi-hop-payments_test.go
+++ b/lntest/itest/lnd_multi-hop-payments_test.go
@@ -49,9 +49,8 @@ func testMultiHopPayments(net *lntest.NetworkHarness, t *harnessTest) {
 	dave := net.NewNode(t.t, "Dave", daveArgs)
 	defer shutdownAndAssert(net, t, dave)
 
+	net.ConnectNodes(t.t, dave, net.Alice)
 	ctxt, _ := context.WithTimeout(ctxb, defaultTimeout)
-	net.ConnectNodes(ctxt, t.t, dave, net.Alice)
-	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
 	net.SendCoins(ctxt, t.t, btcutil.SatoshiPerBitcoin, dave)
 
 	chanPointDave := openChannelAndAssert(
@@ -75,8 +74,7 @@ func testMultiHopPayments(net *lntest.NetworkHarness, t *harnessTest) {
 	carol := net.NewNode(t.t, "Carol", nil)
 	defer shutdownAndAssert(net, t, carol)
 
-	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
-	net.ConnectNodes(ctxt, t.t, carol, dave)
+	net.ConnectNodes(t.t, carol, dave)
 	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
 	net.SendCoins(ctxt, t.t, btcutil.SatoshiPerBitcoin, carol)
 

--- a/lntest/itest/lnd_multi-hop-payments_test.go
+++ b/lntest/itest/lnd_multi-hop-payments_test.go
@@ -50,8 +50,7 @@ func testMultiHopPayments(net *lntest.NetworkHarness, t *harnessTest) {
 	defer shutdownAndAssert(net, t, dave)
 
 	net.ConnectNodes(t.t, dave, net.Alice)
-	ctxt, _ := context.WithTimeout(ctxb, defaultTimeout)
-	net.SendCoins(ctxt, t.t, btcutil.SatoshiPerBitcoin, dave)
+	net.SendCoins(t.t, btcutil.SatoshiPerBitcoin, dave)
 
 	chanPointDave := openChannelAndAssert(
 		t, net, dave, net.Alice,
@@ -75,8 +74,7 @@ func testMultiHopPayments(net *lntest.NetworkHarness, t *harnessTest) {
 	defer shutdownAndAssert(net, t, carol)
 
 	net.ConnectNodes(t.t, carol, dave)
-	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
-	net.SendCoins(ctxt, t.t, btcutil.SatoshiPerBitcoin, carol)
+	net.SendCoins(t.t, btcutil.SatoshiPerBitcoin, carol)
 
 	chanPointCarol := openChannelAndAssert(
 		t, net, carol, dave,
@@ -109,7 +107,7 @@ func testMultiHopPayments(net *lntest.NetworkHarness, t *harnessTest) {
 				Index: chanPoint.OutputIndex,
 			}
 
-			ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
+			ctxt, _ := context.WithTimeout(ctxb, defaultTimeout)
 			err = node.WaitForNetworkChannelOpen(ctxt, chanPoint)
 			if err != nil {
 				t.Fatalf("%s(%d): timeout waiting for "+
@@ -132,7 +130,7 @@ func testMultiHopPayments(net *lntest.NetworkHarness, t *harnessTest) {
 
 	// We'll wait for all parties to recognize the new channels within the
 	// network.
-	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
+	ctxt, _ := context.WithTimeout(ctxb, defaultTimeout)
 	err = dave.WaitForNetworkChannelOpen(ctxt, chanPointDave)
 	if err != nil {
 		t.Fatalf("dave didn't advertise his channel: %v", err)

--- a/lntest/itest/lnd_multi-hop-payments_test.go
+++ b/lntest/itest/lnd_multi-hop-payments_test.go
@@ -20,9 +20,8 @@ func testMultiHopPayments(net *lntest.NetworkHarness, t *harnessTest) {
 
 	// Open a channel with 100k satoshis between Alice and Bob with Alice
 	// being the sole funder of the channel.
-	ctxt, _ := context.WithTimeout(ctxb, channelOpenTimeout)
 	chanPointAlice := openChannelAndAssert(
-		ctxt, t, net, net.Alice, net.Bob,
+		t, net, net.Alice, net.Bob,
 		lntest.OpenChannelParams{
 			Amt: chanAmt,
 		},
@@ -50,14 +49,13 @@ func testMultiHopPayments(net *lntest.NetworkHarness, t *harnessTest) {
 	dave := net.NewNode(t.t, "Dave", daveArgs)
 	defer shutdownAndAssert(net, t, dave)
 
-	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
+	ctxt, _ := context.WithTimeout(ctxb, defaultTimeout)
 	net.ConnectNodes(ctxt, t.t, dave, net.Alice)
 	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
 	net.SendCoins(ctxt, t.t, btcutil.SatoshiPerBitcoin, dave)
 
-	ctxt, _ = context.WithTimeout(ctxb, channelOpenTimeout)
 	chanPointDave := openChannelAndAssert(
-		ctxt, t, net, dave, net.Alice,
+		t, net, dave, net.Alice,
 		lntest.OpenChannelParams{
 			Amt: chanAmt,
 		},
@@ -82,9 +80,8 @@ func testMultiHopPayments(net *lntest.NetworkHarness, t *harnessTest) {
 	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
 	net.SendCoins(ctxt, t.t, btcutil.SatoshiPerBitcoin, carol)
 
-	ctxt, _ = context.WithTimeout(ctxb, channelOpenTimeout)
 	chanPointCarol := openChannelAndAssert(
-		ctxt, t, net, carol, dave,
+		t, net, carol, dave,
 		lntest.OpenChannelParams{
 			Amt: chanAmt,
 		},

--- a/lntest/itest/lnd_multi-hop-payments_test.go
+++ b/lntest/itest/lnd_multi-hop-payments_test.go
@@ -198,10 +198,7 @@ func testMultiHopPayments(net *lntest.NetworkHarness, t *harnessTest) {
 
 	// Using Carol as the source, pay to the 5 invoices from Bob created
 	// above.
-	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
-	err = completePaymentRequests(
-		ctxt, carol, carol.RouterClient, payReqs, true,
-	)
+	err = completePaymentRequests(carol, carol.RouterClient, payReqs, true)
 	if err != nil {
 		t.Fatalf("unable to send payments: %v", err)
 	}

--- a/lntest/itest/lnd_multi-hop_htlc_aggregation_test.go
+++ b/lntest/itest/lnd_multi-hop_htlc_aggregation_test.go
@@ -318,9 +318,8 @@ func testMultiHopHtlcAggregation(net *lntest.NetworkHarness, t *harnessTest,
 	// At this point, Bob should have broadcast his second layer success
 	// transaction, and should have sent it to the nursery for incubation,
 	// or to the sweeper for sweeping.
-	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
 	err = waitForNumChannelPendingForceClose(
-		ctxt, bob, 1, func(c *lnrpcForceCloseChannel) error {
+		bob, 1, func(c *lnrpcForceCloseChannel) error {
 			if c.Channel.LocalBalance != 0 {
 				return nil
 			}
@@ -415,15 +414,14 @@ func testMultiHopHtlcAggregation(net *lntest.NetworkHarness, t *harnessTest,
 	block = mineBlocks(t, net, 1, 1)[0]
 	assertTxInBlock(t, block, bobSweep)
 
-	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
-	err = waitForNumChannelPendingForceClose(ctxt, bob, 0, nil)
+	err = waitForNumChannelPendingForceClose(bob, 0, nil)
 	require.NoError(t.t, err)
 
 	// THe channel with Alice is still open.
 	assertNodeNumChannels(t, bob, 1)
 
 	// Carol should have no channels left (open nor pending).
-	err = waitForNumChannelPendingForceClose(ctxt, carol, 0, nil)
+	err = waitForNumChannelPendingForceClose(carol, 0, nil)
 	require.NoError(t.t, err)
 	assertNodeNumChannels(t, carol, 0)
 

--- a/lntest/itest/lnd_multi-hop_htlc_local_chain_claim_test.go
+++ b/lntest/itest/lnd_multi-hop_htlc_local_chain_claim_test.go
@@ -219,9 +219,8 @@ func testMultiHopHtlcLocalChainClaim(net *lntest.NetworkHarness, t *harnessTest,
 
 	// At this point, Bob should have broadcast his second layer success
 	// transaction, and should have sent it to the nursery for incubation.
-	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
 	err = waitForNumChannelPendingForceClose(
-		ctxt, bob, 1, func(c *lnrpcForceCloseChannel) error {
+		bob, 1, func(c *lnrpcForceCloseChannel) error {
 			if c.Channel.LocalBalance != 0 {
 				return nil
 			}
@@ -288,13 +287,12 @@ func testMultiHopHtlcLocalChainClaim(net *lntest.NetworkHarness, t *harnessTest,
 	block = mineBlocks(t, net, 1, 1)[0]
 	assertTxInBlock(t, block, bobSweep)
 
-	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
-	err = waitForNumChannelPendingForceClose(ctxt, bob, 0, nil)
+	err = waitForNumChannelPendingForceClose(bob, 0, nil)
 	require.NoError(t.t, err)
 	assertNodeNumChannels(t, bob, 0)
 
 	// Also Carol should have no channels left (open nor pending).
-	err = waitForNumChannelPendingForceClose(ctxt, carol, 0, nil)
+	err = waitForNumChannelPendingForceClose(carol, 0, nil)
 	require.NoError(t.t, err)
 	assertNodeNumChannels(t, carol, 0)
 

--- a/lntest/itest/lnd_multi-hop_htlc_local_chain_claim_test.go
+++ b/lntest/itest/lnd_multi-hop_htlc_local_chain_claim_test.go
@@ -298,9 +298,6 @@ func testMultiHopHtlcLocalChainClaim(net *lntest.NetworkHarness, t *harnessTest,
 
 	// Finally, check that the Alice's payment is correctly marked
 	// succeeded.
-	ctxt, _ = context.WithTimeout(ctxt, defaultTimeout)
-	err = checkPaymentStatus(
-		ctxt, alice, preimage, lnrpc.Payment_SUCCEEDED,
-	)
+	err = checkPaymentStatus(alice, preimage, lnrpc.Payment_SUCCEEDED)
 	require.NoError(t.t, err)
 }

--- a/lntest/itest/lnd_multi-hop_htlc_local_timeout_test.go
+++ b/lntest/itest/lnd_multi-hop_htlc_local_timeout_test.go
@@ -223,8 +223,7 @@ func testMultiHopHtlcLocalTimeout(net *lntest.NetworkHarness, t *harnessTest,
 
 	// Once this transaction has been confirmed, Bob should detect that he
 	// no longer has any pending channels.
-	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
-	err = waitForNumChannelPendingForceClose(ctxt, bob, 0, nil)
+	err = waitForNumChannelPendingForceClose(bob, 0, nil)
 	require.NoError(t.t, err)
 
 	// Coop close channel, expect no anchors.

--- a/lntest/itest/lnd_multi-hop_htlc_receiver_chain_claim_test.go
+++ b/lntest/itest/lnd_multi-hop_htlc_receiver_chain_claim_test.go
@@ -209,8 +209,7 @@ func testMultiHopReceiverChainClaim(net *lntest.NetworkHarness, t *harnessTest,
 	// afterwards.
 	_, err = net.Miner.Client.Generate(1)
 	require.NoError(t.t, err)
-	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
-	err = waitForNumChannelPendingForceClose(ctxt, carol, 0, nil)
+	err = waitForNumChannelPendingForceClose(carol, 0, nil)
 	require.NoError(t.t, err)
 
 	// The invoice should show as settled for Carol, indicating that it was

--- a/lntest/itest/lnd_multi-hop_htlc_receiver_chain_claim_test.go
+++ b/lntest/itest/lnd_multi-hop_htlc_receiver_chain_claim_test.go
@@ -224,10 +224,7 @@ func testMultiHopReceiverChainClaim(net *lntest.NetworkHarness, t *harnessTest,
 
 	// Finally, check that the Alice's payment is correctly marked
 	// succeeded.
-	ctxt, _ = context.WithTimeout(ctxt, defaultTimeout)
-	err = checkPaymentStatus(
-		ctxt, alice, preimage, lnrpc.Payment_SUCCEEDED,
-	)
+	err = checkPaymentStatus(alice, preimage, lnrpc.Payment_SUCCEEDED)
 	require.NoError(t.t, err)
 
 	// We'll close out the channel between Alice and Bob, then shutdown

--- a/lntest/itest/lnd_multi-hop_htlc_remote_chain_claim_test.go
+++ b/lntest/itest/lnd_multi-hop_htlc_remote_chain_claim_test.go
@@ -90,8 +90,7 @@ func testMultiHopHtlcRemoteChainClaim(net *lntest.NetworkHarness, t *harnessTest
 	)
 
 	// Wait for the channel to be marked pending force close.
-	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
-	err = waitForChannelPendingForceClose(ctxt, alice, aliceChanPoint)
+	err = waitForChannelPendingForceClose(alice, aliceChanPoint)
 	require.NoError(t.t, err)
 
 	// After closeChannelAndAssertType returns, it has mined a block so now
@@ -230,8 +229,7 @@ func testMultiHopHtlcRemoteChainClaim(net *lntest.NetworkHarness, t *harnessTest
 	// Now that the sweeping transaction has been confirmed, Bob should now
 	// recognize that all contracts have been fully resolved, and show no
 	// pending close channels.
-	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
-	err = waitForNumChannelPendingForceClose(ctxt, bob, 0, nil)
+	err = waitForNumChannelPendingForceClose(bob, 0, nil)
 	require.NoError(t.t, err)
 
 	// If we then mine 3 additional blocks, Carol's second level tx will
@@ -249,8 +247,7 @@ func testMultiHopHtlcRemoteChainClaim(net *lntest.NetworkHarness, t *harnessTest
 	block = mineBlocks(t, net, 1, 1)[0]
 	assertTxInBlock(t, block, carolSweep)
 
-	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
-	err = waitForNumChannelPendingForceClose(ctxt, carol, 0, nil)
+	err = waitForNumChannelPendingForceClose(carol, 0, nil)
 	require.NoError(t.t, err)
 
 	// The invoice should show as settled for Carol, indicating that it was

--- a/lntest/itest/lnd_multi-hop_htlc_remote_chain_claim_test.go
+++ b/lntest/itest/lnd_multi-hop_htlc_remote_chain_claim_test.go
@@ -262,9 +262,6 @@ func testMultiHopHtlcRemoteChainClaim(net *lntest.NetworkHarness, t *harnessTest
 
 	// Finally, check that the Alice's payment is correctly marked
 	// succeeded.
-	ctxt, _ = context.WithTimeout(ctxt, defaultTimeout)
-	err = checkPaymentStatus(
-		ctxt, alice, preimage, lnrpc.Payment_SUCCEEDED,
-	)
+	err = checkPaymentStatus(alice, preimage, lnrpc.Payment_SUCCEEDED)
 	require.NoError(t.t, err)
 }

--- a/lntest/itest/lnd_multi-hop_local_force_close_on_chain_htlc_timeout_test.go
+++ b/lntest/itest/lnd_multi-hop_local_force_close_on_chain_htlc_timeout_test.go
@@ -77,9 +77,8 @@ func testMultiHopLocalForceCloseOnChainHtlcTimeout(net *lntest.NetworkHarness,
 
 	// At this point, Bob should have a pending force close channel as he
 	// just went to chain.
-	ctxt, _ := context.WithTimeout(ctxb, defaultTimeout)
 	err = waitForNumChannelPendingForceClose(
-		ctxt, bob, 1, func(c *lnrpcForceCloseChannel) error {
+		bob, 1, func(c *lnrpcForceCloseChannel) error {
 			if c.LimboBalance == 0 {
 				return fmt.Errorf("bob should have nonzero "+
 					"limbo balance instead has: %v",
@@ -117,9 +116,8 @@ func testMultiHopLocalForceCloseOnChainHtlcTimeout(net *lntest.NetworkHarness,
 
 	// Bob's pending channel report should show that he has a single HTLC
 	// that's now in stage one.
-	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
 	err = waitForNumChannelPendingForceClose(
-		ctxt, bob, 1, func(c *lnrpcForceCloseChannel) error {
+		bob, 1, func(c *lnrpcForceCloseChannel) error {
 			if len(c.PendingHtlcs) != 1 {
 				return fmt.Errorf("bob should have pending " +
 					"htlc but doesn't")
@@ -155,9 +153,8 @@ func testMultiHopLocalForceCloseOnChainHtlcTimeout(net *lntest.NetworkHarness,
 
 	// Additionally, Bob should now show that HTLC as being advanced to the
 	// second stage.
-	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
 	err = waitForNumChannelPendingForceClose(
-		ctxt, bob, 1, func(c *lnrpcForceCloseChannel) error {
+		bob, 1, func(c *lnrpcForceCloseChannel) error {
 			if len(c.PendingHtlcs) != 1 {
 				return fmt.Errorf("bob should have pending " +
 					"htlc but doesn't")
@@ -189,8 +186,7 @@ func testMultiHopLocalForceCloseOnChainHtlcTimeout(net *lntest.NetworkHarness,
 
 	// At this point, Bob should no longer show any channels as pending
 	// close.
-	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
-	err = waitForNumChannelPendingForceClose(ctxt, bob, 0, nil)
+	err = waitForNumChannelPendingForceClose(bob, 0, nil)
 	require.NoError(t.t, err)
 
 	// Coop close, no anchors.

--- a/lntest/itest/lnd_multi-hop_remote_force_close_on_chain_htlc_timeout_test.go
+++ b/lntest/itest/lnd_multi-hop_remote_force_close_on_chain_htlc_timeout_test.go
@@ -89,8 +89,7 @@ func testMultiHopRemoteForceCloseOnChainHtlcTimeout(net *lntest.NetworkHarness,
 
 	// At this point, Bob should have a pending force close channel as
 	// Carol has gone directly to chain.
-	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
-	err = waitForNumChannelPendingForceClose(ctxt, bob, 1, nil)
+	err = waitForNumChannelPendingForceClose(bob, 1, nil)
 	require.NoError(t.t, err)
 
 	// Bob can sweep his output immediately. If there is an anchor, Bob will
@@ -115,9 +114,8 @@ func testMultiHopRemoteForceCloseOnChainHtlcTimeout(net *lntest.NetworkHarness,
 	// If we check Bob's pending channel report, it should show that he has
 	// a single HTLC that's now in the second stage, as skip the initial
 	// first stage since this is a direct HTLC.
-	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
 	err = waitForNumChannelPendingForceClose(
-		ctxt, bob, 1, func(c *lnrpcForceCloseChannel) error {
+		bob, 1, func(c *lnrpcForceCloseChannel) error {
 			if len(c.PendingHtlcs) != 1 {
 				return fmt.Errorf("bob should have pending " +
 					"htlc but doesn't")
@@ -172,8 +170,7 @@ func testMultiHopRemoteForceCloseOnChainHtlcTimeout(net *lntest.NetworkHarness,
 	// Now we'll check Bob's pending channel report. Since this was Carol's
 	// commitment, he doesn't have to wait for any CSV delays. As a result,
 	// he should show no additional pending transactions.
-	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
-	err = waitForNumChannelPendingForceClose(ctxt, bob, 0, nil)
+	err = waitForNumChannelPendingForceClose(bob, 0, nil)
 	require.NoError(t.t, err)
 
 	// While we're here, we assert that our expired invoice's state is

--- a/lntest/itest/lnd_multi-hop_test.go
+++ b/lntest/itest/lnd_multi-hop_test.go
@@ -206,8 +206,7 @@ func createThreeHopNetwork(t *harnessTest, net *lntest.NetworkHarness,
 
 	ctxb := context.Background()
 
-	ctxt, _ := context.WithTimeout(ctxb, defaultTimeout)
-	net.EnsureConnected(ctxt, t.t, alice, bob)
+	net.EnsureConnected(t.t, alice, bob)
 
 	// Make sure there are enough utxos for anchoring.
 	for i := 0; i < 2; i++ {
@@ -225,7 +224,7 @@ func createThreeHopNetwork(t *harnessTest, net *lntest.NetworkHarness,
 		},
 	)
 
-	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
+	ctxt, _ := context.WithTimeout(ctxb, defaultTimeout)
 	err := alice.WaitForNetworkChannelOpen(ctxt, aliceChanPoint)
 	if err != nil {
 		t.Fatalf("alice didn't report channel: %v", err)

--- a/lntest/itest/lnd_multi-hop_test.go
+++ b/lntest/itest/lnd_multi-hop_test.go
@@ -148,8 +148,12 @@ func waitForInvoiceAccepted(t *harnessTest, node *lntest.HarnessNode,
 
 // checkPaymentStatus asserts that the given node list a payment with the given
 // preimage has the expected status.
-func checkPaymentStatus(ctxt context.Context, node *lntest.HarnessNode,
-	preimage lntypes.Preimage, status lnrpc.Payment_PaymentStatus) error {
+func checkPaymentStatus(node *lntest.HarnessNode, preimage lntypes.Preimage,
+	status lnrpc.Payment_PaymentStatus) error {
+
+	ctxb := context.Background()
+	ctxt, cancel := context.WithTimeout(ctxb, defaultTimeout)
+	defer cancel()
 
 	req := &lnrpc.ListPaymentsRequest{
 		IncludeIncomplete: true,

--- a/lntest/itest/lnd_multi-hop_test.go
+++ b/lntest/itest/lnd_multi-hop_test.go
@@ -87,9 +87,7 @@ func testMultiHopHtlcClaims(net *lntest.NetworkHarness, t *harnessTest) {
 			bob := net.NewNode(t, "Bob", args)
 			defer shutdownAndAssert(net, ht, bob)
 
-			ctxb := context.Background()
-			ctxt, _ := context.WithTimeout(ctxb, defaultTimeout)
-			net.ConnectNodes(ctxt, t, alice, bob)
+			net.ConnectNodes(t, alice, bob)
 
 			for _, subTest := range subTests {
 				subTest := subTest
@@ -251,8 +249,7 @@ func createThreeHopNetwork(t *harnessTest, net *lntest.NetworkHarness,
 	}
 	carol := net.NewNode(t.t, "Carol", carolFlags)
 
-	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
-	net.ConnectNodes(ctxt, t.t, bob, carol)
+	net.ConnectNodes(t.t, bob, carol)
 
 	// Make sure Carol has enough utxos for anchoring. Because the anchor by
 	// itself often doesn't meet the dust limit, a utxo from the wallet

--- a/lntest/itest/lnd_multi-hop_test.go
+++ b/lntest/itest/lnd_multi-hop_test.go
@@ -211,11 +211,8 @@ func createThreeHopNetwork(t *harnessTest, net *lntest.NetworkHarness,
 
 	// Make sure there are enough utxos for anchoring.
 	for i := 0; i < 2; i++ {
-		ctxt, _ = context.WithTimeout(context.Background(), defaultTimeout)
-		net.SendCoins(ctxt, t.t, btcutil.SatoshiPerBitcoin, alice)
-
-		ctxt, _ = context.WithTimeout(context.Background(), defaultTimeout)
-		net.SendCoins(ctxt, t.t, btcutil.SatoshiPerBitcoin, bob)
+		net.SendCoins(t.t, btcutil.SatoshiPerBitcoin, alice)
+		net.SendCoins(t.t, btcutil.SatoshiPerBitcoin, bob)
 	}
 
 	// We'll start the test by creating a channel between Alice and Bob,
@@ -256,8 +253,7 @@ func createThreeHopNetwork(t *harnessTest, net *lntest.NetworkHarness,
 	// needs to be attached as an additional input. This can still lead to a
 	// positively-yielding transaction.
 	for i := 0; i < 2; i++ {
-		ctxt, _ = context.WithTimeout(context.Background(), defaultTimeout)
-		net.SendCoins(ctxt, t.t, btcutil.SatoshiPerBitcoin, carol)
+		net.SendCoins(t.t, btcutil.SatoshiPerBitcoin, carol)
 	}
 
 	// We'll then create a channel from Bob to Carol. After this channel is

--- a/lntest/itest/lnd_multi-hop_test.go
+++ b/lntest/itest/lnd_multi-hop_test.go
@@ -223,9 +223,8 @@ func createThreeHopNetwork(t *harnessTest, net *lntest.NetworkHarness,
 	// We'll start the test by creating a channel between Alice and Bob,
 	// which will act as the first leg for out multi-hop HTLC.
 	const chanAmt = 1000000
-	ctxt, _ = context.WithTimeout(ctxb, channelOpenTimeout)
 	aliceChanPoint := openChannelAndAssert(
-		ctxt, t, net, alice, bob,
+		t, net, alice, bob,
 		lntest.OpenChannelParams{
 			Amt: chanAmt,
 		},
@@ -266,9 +265,8 @@ func createThreeHopNetwork(t *harnessTest, net *lntest.NetworkHarness,
 
 	// We'll then create a channel from Bob to Carol. After this channel is
 	// open, our topology looks like:  A -> B -> C.
-	ctxt, _ = context.WithTimeout(ctxb, channelOpenTimeout)
 	bobChanPoint := openChannelAndAssert(
-		ctxt, t, net, bob, carol,
+		t, net, bob, carol,
 		lntest.OpenChannelParams{
 			Amt: chanAmt,
 		},

--- a/lntest/itest/lnd_network_test.go
+++ b/lntest/itest/lnd_network_test.go
@@ -69,10 +69,6 @@ func assertTimeoutError(ctxt context.Context, t *harnessTest,
 
 	t.t.Helper()
 
-	// Create a context with a timeout value.
-	ctxt, cancel := context.WithTimeout(ctxt, defaultTimeout)
-	defer cancel()
-
 	err := connect(ctxt, node, req)
 
 	// a DeadlineExceeded error will appear in the context if the above

--- a/lntest/itest/lnd_onchain_test.go
+++ b/lntest/itest/lnd_onchain_test.go
@@ -31,14 +31,13 @@ func testCPFP(net *lntest.NetworkHarness, t *harnessTest) {
 	// We'll start the test by sending Alice some coins, which she'll use to
 	// send to Bob.
 	ctxb := context.Background()
-	ctxt, _ := context.WithTimeout(ctxb, defaultTimeout)
-	net.SendCoins(ctxt, t.t, btcutil.SatoshiPerBitcoin, net.Alice)
+	net.SendCoins(t.t, btcutil.SatoshiPerBitcoin, net.Alice)
 
 	// Create an address for Bob to send the coins to.
 	addrReq := &lnrpc.NewAddressRequest{
 		Type: lnrpc.AddressType_WITNESS_PUBKEY_HASH,
 	}
-	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
+	ctxt, _ := context.WithTimeout(ctxb, defaultTimeout)
 	resp, err := net.Bob.NewAddress(ctxt, addrReq)
 	if err != nil {
 		t.Fatalf("unable to get new address for bob: %v", err)
@@ -185,13 +184,12 @@ func testAnchorReservedValue(net *lntest.NetworkHarness, t *harnessTest) {
 		feeEst  = 8000
 	)
 
-	ctxt, _ := context.WithTimeout(context.Background(), defaultTimeout)
-	net.SendCoins(ctxt, t.t, chanAmt+feeEst, alice)
+	net.SendCoins(t.t, chanAmt+feeEst, alice)
 
 	// wallet, without a change output. This should not be allowed.
 	resErr := lnwallet.ErrReservedValueInvalidated.Error()
 
-	ctxt, _ = context.WithTimeout(context.Background(), defaultTimeout)
+	ctxt, _ := context.WithTimeout(context.Background(), defaultTimeout)
 	_, err := net.OpenChannel(
 		ctxt, alice, bob,
 		lntest.OpenChannelParams{

--- a/lntest/itest/lnd_onchain_test.go
+++ b/lntest/itest/lnd_onchain_test.go
@@ -189,10 +189,8 @@ func testAnchorReservedValue(net *lntest.NetworkHarness, t *harnessTest) {
 	// wallet, without a change output. This should not be allowed.
 	resErr := lnwallet.ErrReservedValueInvalidated.Error()
 
-	ctxt, _ := context.WithTimeout(context.Background(), defaultTimeout)
 	_, err := net.OpenChannel(
-		ctxt, alice, bob,
-		lntest.OpenChannelParams{
+		alice, bob, lntest.OpenChannelParams{
 			Amt: chanAmt,
 		},
 	)
@@ -232,7 +230,7 @@ func testAnchorReservedValue(net *lntest.NetworkHarness, t *harnessTest) {
 		aliceChanPoint1, aliceChanPoint2, aliceChanPoint3,
 	}
 	for _, chanPoint := range chanPoints {
-		ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
+		ctxt, _ := context.WithTimeout(ctxb, defaultTimeout)
 		err = alice.WaitForNetworkChannelOpen(ctxt, chanPoint)
 		require.NoError(t.t, err)
 
@@ -247,7 +245,7 @@ func testAnchorReservedValue(net *lntest.NetworkHarness, t *harnessTest) {
 	addrReq := &lnrpc.NewAddressRequest{
 		Type: lnrpc.AddressType_WITNESS_PUBKEY_HASH,
 	}
-	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
+	ctxt, _ := context.WithTimeout(ctxb, defaultTimeout)
 	resp, err := alice.NewAddress(ctxt, addrReq)
 	require.NoError(t.t, err)
 

--- a/lntest/itest/lnd_onchain_test.go
+++ b/lntest/itest/lnd_onchain_test.go
@@ -176,8 +176,7 @@ func testAnchorReservedValue(net *lntest.NetworkHarness, t *harnessTest) {
 	defer shutdownAndAssert(net, t, bob)
 
 	ctxb := context.Background()
-	ctxt, _ := context.WithTimeout(ctxb, defaultTimeout)
-	net.ConnectNodes(ctxt, t.t, alice, bob)
+	net.ConnectNodes(t.t, alice, bob)
 
 	// Send just enough coins for Alice to open a channel without a change
 	// output.
@@ -186,7 +185,7 @@ func testAnchorReservedValue(net *lntest.NetworkHarness, t *harnessTest) {
 		feeEst  = 8000
 	)
 
-	ctxt, _ = context.WithTimeout(context.Background(), defaultTimeout)
+	ctxt, _ := context.WithTimeout(context.Background(), defaultTimeout)
 	net.SendCoins(ctxt, t.t, chanAmt+feeEst, alice)
 
 	// wallet, without a change output. This should not be allowed.

--- a/lntest/itest/lnd_onchain_test.go
+++ b/lntest/itest/lnd_onchain_test.go
@@ -205,9 +205,8 @@ func testAnchorReservedValue(net *lntest.NetworkHarness, t *harnessTest) {
 
 	// Alice opens a smaller channel. This works since it will have a
 	// change output.
-	ctxt, _ = context.WithTimeout(context.Background(), defaultTimeout)
 	aliceChanPoint1 := openChannelAndAssert(
-		ctxt, t, net, alice, bob,
+		t, net, alice, bob,
 		lntest.OpenChannelParams{
 			Amt: chanAmt / 4,
 		},
@@ -216,7 +215,7 @@ func testAnchorReservedValue(net *lntest.NetworkHarness, t *harnessTest) {
 	// If Alice tries to open another anchor channel to Bob, Bob should not
 	// reject it as he is not contributing any funds.
 	aliceChanPoint2 := openChannelAndAssert(
-		ctxt, t, net, alice, bob, lntest.OpenChannelParams{
+		t, net, alice, bob, lntest.OpenChannelParams{
 			Amt: chanAmt / 4,
 		},
 	)
@@ -226,9 +225,8 @@ func testAnchorReservedValue(net *lntest.NetworkHarness, t *harnessTest) {
 	// to remove his support for anchors.
 	err = net.RestartNode(bob, nil)
 	require.NoError(t.t, err)
-	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
 	aliceChanPoint3 := openChannelAndAssert(
-		ctxt, t, net, alice, bob, lntest.OpenChannelParams{
+		t, net, alice, bob, lntest.OpenChannelParams{
 			Amt: chanAmt / 4,
 		},
 	)

--- a/lntest/itest/lnd_open_channel_test.go
+++ b/lntest/itest/lnd_open_channel_test.go
@@ -125,8 +125,7 @@ func testOpenChannelAfterReorg(net *lntest.NetworkHarness, t *harnessTest) {
 	if err != nil {
 		t.Fatalf("unable to get current blockheight %v", err)
 	}
-	ctxt, _ := context.WithTimeout(ctxb, defaultTimeout)
-	err = waitForNodeBlockHeight(ctxt, net.Alice, minerHeight)
+	err = waitForNodeBlockHeight(net.Alice, minerHeight)
 	if err != nil {
 		t.Fatalf("unable to sync to chain: %v", err)
 	}
@@ -143,7 +142,7 @@ func testOpenChannelAfterReorg(net *lntest.NetworkHarness, t *harnessTest) {
 
 	// Wait for Alice and Bob to recognize and advertise the new channel
 	// generated above.
-	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
+	ctxt, _ := context.WithTimeout(ctxb, defaultTimeout)
 	err = net.Alice.WaitForNetworkChannelOpen(ctxt, chanPoint)
 	if err != nil {
 		t.Fatalf("alice didn't advertise channel before "+
@@ -217,8 +216,7 @@ func testOpenChannelAfterReorg(net *lntest.NetworkHarness, t *harnessTest) {
 	if err != nil {
 		t.Fatalf("unable to get current blockheight %v", err)
 	}
-	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
-	err = waitForNodeBlockHeight(ctxt, net.Alice, tempMinerHeight)
+	err = waitForNodeBlockHeight(net.Alice, tempMinerHeight)
 	if err != nil {
 		t.Fatalf("unable to sync to chain: %v", err)
 	}

--- a/lntest/itest/lnd_open_channel_test.go
+++ b/lntest/itest/lnd_open_channel_test.go
@@ -82,9 +82,9 @@ func testOpenChannelAfterReorg(net *lntest.NetworkHarness, t *harnessTest) {
 	// open, then broadcast the funding transaction
 	chanAmt := funding.MaxBtcFundingAmount
 	pushAmt := btcutil.Amount(0)
-	ctxt, _ := context.WithTimeout(ctxb, channelOpenTimeout)
-	pendingUpdate, err := net.OpenPendingChannel(ctxt, net.Alice, net.Bob,
-		chanAmt, pushAmt)
+	pendingUpdate, err := net.OpenPendingChannel(
+		net.Alice, net.Bob, chanAmt, pushAmt,
+	)
 	if err != nil {
 		t.Fatalf("unable to open channel: %v", err)
 	}
@@ -125,7 +125,7 @@ func testOpenChannelAfterReorg(net *lntest.NetworkHarness, t *harnessTest) {
 	if err != nil {
 		t.Fatalf("unable to get current blockheight %v", err)
 	}
-	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
+	ctxt, _ := context.WithTimeout(ctxb, defaultTimeout)
 	err = waitForNodeBlockHeight(ctxt, net.Alice, minerHeight)
 	if err != nil {
 		t.Fatalf("unable to sync to chain: %v", err)

--- a/lntest/itest/lnd_open_channel_test.go
+++ b/lntest/itest/lnd_open_channel_test.go
@@ -98,8 +98,7 @@ func testOpenChannelAfterReorg(net *lntest.NetworkHarness, t *harnessTest) {
 
 	// At this point, the channel's funding transaction will have been
 	// broadcast, but not confirmed, and the channel should be pending.
-	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
-	assertNumOpenChannelsPending(ctxt, t, net.Alice, net.Bob, 1)
+	assertNumOpenChannelsPending(t, net.Alice, net.Bob, 1)
 
 	fundingTxID, err := chainhash.NewHash(pendingUpdate.Txid)
 	if err != nil {
@@ -140,7 +139,7 @@ func testOpenChannelAfterReorg(net *lntest.NetworkHarness, t *harnessTest) {
 	}
 
 	// Ensure channel is no longer pending.
-	assertNumOpenChannelsPending(ctxt, t, net.Alice, net.Bob, 0)
+	assertNumOpenChannelsPending(t, net.Alice, net.Bob, 0)
 
 	// Wait for Alice and Bob to recognize and advertise the new channel
 	// generated above.
@@ -255,8 +254,7 @@ func testOpenChannelAfterReorg(net *lntest.NetworkHarness, t *harnessTest) {
 	block = mineBlocks(t, net, 1, 1)[0]
 	assertTxInBlock(t, block, fundingTxID)
 
-	ctxt, _ = context.WithTimeout(ctxb, channelCloseTimeout)
-	closeReorgedChannelAndAssert(ctxt, t, net, net.Alice, chanPoint, false)
+	closeReorgedChannelAndAssert(t, net, net.Alice, chanPoint, false)
 }
 
 // testBasicChannelCreationAndUpdates tests multiple channel opening and closing,

--- a/lntest/itest/lnd_open_channel_test.go
+++ b/lntest/itest/lnd_open_channel_test.go
@@ -280,9 +280,8 @@ func testBasicChannelCreationAndUpdates(net *lntest.NetworkHarness, t *harnessTe
 	// have been properly opened on-chain.
 	chanPoints := make([]*lnrpc.ChannelPoint, numChannels)
 	for i := 0; i < numChannels; i++ {
-		ctxt, _ := context.WithTimeout(ctxb, channelOpenTimeout)
 		chanPoints[i] = openChannelAndAssert(
-			ctxt, t, net, net.Alice, net.Bob,
+			t, net, net.Alice, net.Bob,
 			lntest.OpenChannelParams{
 				Amt: amount,
 			},

--- a/lntest/itest/lnd_payment_test.go
+++ b/lntest/itest/lnd_payment_test.go
@@ -260,8 +260,7 @@ func testAsyncPayments(net *lntest.NetworkHarness, t *harnessTest) {
 		},
 	)
 
-	ctxt, _ := context.WithTimeout(ctxb, defaultTimeout)
-	info, err := getChanInfo(ctxt, net.Alice)
+	info, err := getChanInfo(net.Alice)
 	if err != nil {
 		t.Fatalf("unable to get alice channel info: %v", err)
 	}
@@ -286,7 +285,7 @@ func testAsyncPayments(net *lntest.NetworkHarness, t *harnessTest) {
 	}
 
 	// Wait for Alice to receive the channel edge from the funding manager.
-	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
+	ctxt, _ := context.WithTimeout(ctxb, defaultTimeout)
 	err = net.Alice.WaitForNetworkChannelOpen(ctxt, chanPoint)
 	if err != nil {
 		t.Fatalf("alice didn't see the alice->bob channel before "+
@@ -345,8 +344,7 @@ func testAsyncPayments(net *lntest.NetworkHarness, t *harnessTest) {
 	// htlcs listed and has correct balances. This is needed due to the fact
 	// that we now pipeline the settles.
 	err = wait.Predicate(func() bool {
-		ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
-		aliceChan, err := getChanInfo(ctxt, net.Alice)
+		aliceChan, err := getChanInfo(net.Alice)
 		if err != nil {
 			return false
 		}
@@ -368,8 +366,7 @@ func testAsyncPayments(net *lntest.NetworkHarness, t *harnessTest) {
 
 	// Wait for Bob to receive revocation from Alice.
 	err = wait.NoError(func() error {
-		ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
-		bobChan, err := getChanInfo(ctxt, net.Bob)
+		bobChan, err := getChanInfo(net.Bob)
 		if err != nil {
 			t.Fatalf("unable to get bob's channel info: %v", err)
 		}
@@ -425,8 +422,7 @@ func testBidirectionalAsyncPayments(net *lntest.NetworkHarness, t *harnessTest) 
 		},
 	)
 
-	ctxt, _ := context.WithTimeout(ctxb, defaultTimeout)
-	info, err := getChanInfo(ctxt, net.Alice)
+	info, err := getChanInfo(net.Alice)
 	if err != nil {
 		t.Fatalf("unable to get alice channel info: %v", err)
 	}
@@ -462,7 +458,7 @@ func testBidirectionalAsyncPayments(net *lntest.NetworkHarness, t *harnessTest) 
 	}
 
 	// Wait for Alice to receive the channel edge from the funding manager.
-	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
+	ctxt, _ := context.WithTimeout(ctxb, defaultTimeout)
 	if err = net.Alice.WaitForNetworkChannelOpen(ctxt, chanPoint); err != nil {
 		t.Fatalf("alice didn't see the alice->bob channel before "+
 			"timeout: %v", err)
@@ -534,8 +530,7 @@ func testBidirectionalAsyncPayments(net *lntest.NetworkHarness, t *harnessTest) 
 	// Wait for Alice and Bob to receive revocations messages, and update
 	// states, i.e. balance info.
 	err = wait.NoError(func() error {
-		ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
-		aliceInfo, err := getChanInfo(ctxt, net.Alice)
+		aliceInfo, err := getChanInfo(net.Alice)
 		if err != nil {
 			t.Fatalf("unable to get alice's channel info: %v", err)
 		}
@@ -565,8 +560,7 @@ func testBidirectionalAsyncPayments(net *lntest.NetworkHarness, t *harnessTest) 
 	// Next query for Bob's and Alice's channel states, in order to confirm
 	// that all payment have been successful transmitted.
 	err = wait.NoError(func() error {
-		ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
-		bobInfo, err := getChanInfo(ctxt, net.Bob)
+		bobInfo, err := getChanInfo(net.Bob)
 		if err != nil {
 			t.Fatalf("unable to get bob's channel info: %v", err)
 		}

--- a/lntest/itest/lnd_payment_test.go
+++ b/lntest/itest/lnd_payment_test.go
@@ -44,9 +44,8 @@ func testListPayments(net *lntest.NetworkHarness, t *harnessTest) {
 	// Open a channel with 100k satoshis between Alice and Bob with Alice
 	// being the sole funder of the channel.
 	chanAmt := btcutil.Amount(100000)
-	ctxt, _ = context.WithTimeout(ctxb, channelOpenTimeout)
 	chanPoint := openChannelAndAssert(
-		ctxt, t, net, net.Alice, net.Bob,
+		t, net, net.Alice, net.Bob,
 		lntest.OpenChannelParams{
 			Amt: chanAmt,
 		},
@@ -263,16 +262,15 @@ func testAsyncPayments(net *lntest.NetworkHarness, t *harnessTest) {
 	// First establish a channel with a capacity equals to the overall
 	// amount of payments, between Alice and Bob, at the end of the test
 	// Alice should send all money from her side to Bob.
-	ctxt, _ := context.WithTimeout(ctxb, channelOpenTimeout)
 	channelCapacity := btcutil.Amount(paymentAmt * 2000)
 	chanPoint := openChannelAndAssert(
-		ctxt, t, net, net.Alice, net.Bob,
+		t, net, net.Alice, net.Bob,
 		lntest.OpenChannelParams{
 			Amt: channelCapacity,
 		},
 	)
 
-	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
+	ctxt, _ := context.WithTimeout(ctxb, defaultTimeout)
 	info, err := getChanInfo(ctxt, net.Alice)
 	if err != nil {
 		t.Fatalf("unable to get alice channel info: %v", err)
@@ -429,16 +427,15 @@ func testBidirectionalAsyncPayments(net *lntest.NetworkHarness, t *harnessTest) 
 	// First establish a channel with a capacity equals to the overall
 	// amount of payments, between Alice and Bob, at the end of the test
 	// Alice should send all money from her side to Bob.
-	ctxt, _ := context.WithTimeout(ctxb, channelOpenTimeout)
 	chanPoint := openChannelAndAssert(
-		ctxt, t, net, net.Alice, net.Bob,
+		t, net, net.Alice, net.Bob,
 		lntest.OpenChannelParams{
 			Amt:     paymentAmt * 2000,
 			PushAmt: paymentAmt * 1000,
 		},
 	)
 
-	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
+	ctxt, _ := context.WithTimeout(ctxb, defaultTimeout)
 	info, err := getChanInfo(ctxt, net.Alice)
 	if err != nil {
 		t.Fatalf("unable to get alice channel info: %v", err)
@@ -619,9 +616,8 @@ func testInvoiceSubscriptions(net *lntest.NetworkHarness, t *harnessTest) {
 
 	// Open a channel with 500k satoshis between Alice and Bob with Alice
 	// being the sole funder of the channel.
-	ctxt, _ := context.WithTimeout(ctxb, channelOpenTimeout)
 	chanPoint := openChannelAndAssert(
-		ctxt, t, net, net.Alice, net.Bob,
+		t, net, net.Alice, net.Bob,
 		lntest.OpenChannelParams{
 			Amt: chanAmt,
 		},
@@ -636,7 +632,7 @@ func testInvoiceSubscriptions(net *lntest.NetworkHarness, t *harnessTest) {
 		RPreimage: makeFakePayHash(t),
 		Value:     paymentAmt,
 	}
-	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
+	ctxt, _ := context.WithTimeout(ctxb, defaultTimeout)
 	invoiceResp, err := net.Bob.AddInvoice(ctxt, invoice)
 	if err != nil {
 		t.Fatalf("unable to add invoice: %v", err)

--- a/lntest/itest/lnd_payment_test.go
+++ b/lntest/itest/lnd_payment_test.go
@@ -770,9 +770,8 @@ func testInvoiceSubscriptions(net *lntest.NetworkHarness, t *harnessTest) {
 
 	// We'll now have Bob settle out the remainder of these invoices so we
 	// can test that all settled invoices are properly notified.
-	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
 	err = completePaymentRequests(
-		ctxt, net.Alice, net.Alice.RouterClient, payReqs, true,
+		net.Alice, net.Alice.RouterClient, payReqs, true,
 	)
 	if err != nil {
 		t.Fatalf("unable to send payment: %v", err)

--- a/lntest/itest/lnd_payment_test.go
+++ b/lntest/itest/lnd_payment_test.go
@@ -183,9 +183,7 @@ func testPaymentFollowingChannelOpen(net *lntest.NetworkHarness, t *harnessTest)
 	// At this point, the channel's funding transaction will have been
 	// broadcast, but not confirmed. Alice and Bob's nodes
 	// should reflect this when queried via RPC.
-	ctxt, cancel = context.WithTimeout(ctxb, defaultTimeout)
-	defer cancel()
-	assertNumOpenChannelsPending(ctxt, t, net.Alice, net.Bob, 1)
+	assertNumOpenChannelsPending(t, net.Alice, net.Bob, 1)
 
 	// We are restarting Bob's node to let the link be created for the
 	// pending channel.
@@ -200,9 +198,7 @@ func testPaymentFollowingChannelOpen(net *lntest.NetworkHarness, t *harnessTest)
 	_ = mineBlocks(t, net, 6, 1)[0]
 
 	// We verify that the channel is open from both nodes point of view.
-	ctxt, cancel = context.WithTimeout(ctxb, defaultTimeout)
-	defer cancel()
-	assertNumOpenChannelsPending(ctxt, t, net.Alice, net.Bob, 0)
+	assertNumOpenChannelsPending(t, net.Alice, net.Bob, 0)
 
 	// With the channel open, we'll create invoices for Bob that Alice will
 	// pay to in order to advance the state of the channel.

--- a/lntest/itest/lnd_payment_test.go
+++ b/lntest/itest/lnd_payment_test.go
@@ -81,10 +81,8 @@ func testListPayments(net *lntest.NetworkHarness, t *harnessTest) {
 
 	// With the invoice for Bob added, send a payment towards Alice paying
 	// to the above generated invoice.
-	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
 	sendAndAssertSuccess(
-		ctxt, t, net.Alice,
-		&routerrpc.SendPaymentRequest{
+		t, net.Alice, &routerrpc.SendPaymentRequest{
 			PaymentRequest: invoiceResp.PaymentRequest,
 			TimeoutSeconds: 60,
 			FeeLimitSat:    1000000,
@@ -217,9 +215,8 @@ func testPaymentFollowingChannelOpen(net *lntest.NetworkHarness, t *harnessTest)
 
 	// Send payment to Bob so that a channel update to disk will be
 	// executed.
-	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
 	sendAndAssertSuccess(
-		ctxt, t, net.Alice, &routerrpc.SendPaymentRequest{
+		t, net.Alice, &routerrpc.SendPaymentRequest{
 			PaymentRequest: bobPayReqs[0],
 			TimeoutSeconds: 60,
 			FeeLimitSat:    1000000,

--- a/lntest/itest/lnd_payment_test.go
+++ b/lntest/itest/lnd_payment_test.go
@@ -31,7 +31,7 @@ func testListPayments(net *lntest.NetworkHarness, t *harnessTest) {
 
 	// Check that there are no payments before test.
 	reqInit := &lnrpc.ListPaymentsRequest{}
-	ctxt, _ = context.WithTimeout(ctxt, defaultTimeout)
+	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
 	paymentsRespInit, err := net.Alice.ListPayments(ctxt, reqInit)
 	if err != nil {
 		t.Fatalf("error when obtaining Alice payments: %v", err)
@@ -92,7 +92,7 @@ func testListPayments(net *lntest.NetworkHarness, t *harnessTest) {
 	// Grab Alice's list of payments, she should show the existence of
 	// exactly one payment.
 	req := &lnrpc.ListPaymentsRequest{}
-	ctxt, _ = context.WithTimeout(ctxt, defaultTimeout)
+	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
 	paymentsResp, err := net.Alice.ListPayments(ctxt, req)
 	if err != nil {
 		t.Fatalf("error when obtaining Alice payments: %v", err)
@@ -138,7 +138,7 @@ func testListPayments(net *lntest.NetworkHarness, t *harnessTest) {
 
 	// Delete all payments from Alice. DB should have no payments.
 	delReq := &lnrpc.DeleteAllPaymentsRequest{}
-	ctxt, _ = context.WithTimeout(ctxt, defaultTimeout)
+	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
 	_, err = net.Alice.DeleteAllPayments(ctxt, delReq)
 	if err != nil {
 		t.Fatalf("Can't delete payments at the end: %v", err)
@@ -146,7 +146,7 @@ func testListPayments(net *lntest.NetworkHarness, t *harnessTest) {
 
 	// Check that there are no payments after test.
 	listReq := &lnrpc.ListPaymentsRequest{}
-	ctxt, _ = context.WithTimeout(ctxt, defaultTimeout)
+	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
 	paymentsResp, err = net.Alice.ListPayments(ctxt, listReq)
 	if err != nil {
 		t.Fatalf("error when obtaining Alice payments: %v", err)

--- a/lntest/itest/lnd_payment_test.go
+++ b/lntest/itest/lnd_payment_test.go
@@ -196,8 +196,7 @@ func testPaymentFollowingChannelOpen(net *lntest.NetworkHarness, t *harnessTest)
 	}
 
 	// We ensure that Bob reconnects to Alice.
-	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
-	net.EnsureConnected(ctxt, t.t, net.Bob, net.Alice)
+	net.EnsureConnected(t.t, net.Bob, net.Alice)
 
 	// We mine one block for the channel to be confirmed.
 	_ = mineBlocks(t, net, 6, 1)[0]

--- a/lntest/itest/lnd_payment_test.go
+++ b/lntest/itest/lnd_payment_test.go
@@ -171,10 +171,8 @@ func testPaymentFollowingChannelOpen(net *lntest.NetworkHarness, t *harnessTest)
 	channelCapacity := paymentAmt * 1000
 
 	// We first establish a channel between Alice and Bob.
-	ctxt, cancel := context.WithTimeout(ctxb, channelOpenTimeout)
-	defer cancel()
 	pendingUpdate, err := net.OpenPendingChannel(
-		ctxt, net.Alice, net.Bob, channelCapacity, 0,
+		net.Alice, net.Bob, channelCapacity, 0,
 	)
 	if err != nil {
 		t.Fatalf("unable to open channel: %v", err)
@@ -221,7 +219,7 @@ func testPaymentFollowingChannelOpen(net *lntest.NetworkHarness, t *harnessTest)
 
 	// At this point we want to make sure the channel is opened and not
 	// pending.
-	ctxt, cancel = context.WithTimeout(ctxb, defaultTimeout)
+	ctxt, cancel := context.WithTimeout(ctxb, defaultTimeout)
 	defer cancel()
 	res, err := net.Bob.ListChannels(ctxt, &lnrpc.ListChannelsRequest{})
 	if err != nil {

--- a/lntest/itest/lnd_psbt_test.go
+++ b/lntest/itest/lnd_psbt_test.go
@@ -31,7 +31,7 @@ func testPsbtChanFunding(net *lntest.NetworkHarness, t *harnessTest) {
 	dave := net.NewNode(t.t, "dave", nil)
 	defer shutdownAndAssert(net, t, dave)
 
-	net.SendCoins(ctxb, t.t, btcutil.SatoshiPerBitcoin, dave)
+	net.SendCoins(t.t, btcutil.SatoshiPerBitcoin, dave)
 
 	// Before we start the test, we'll ensure both sides are connected so
 	// the funding flow can be properly executed.

--- a/lntest/itest/lnd_psbt_test.go
+++ b/lntest/itest/lnd_psbt_test.go
@@ -35,10 +35,8 @@ func testPsbtChanFunding(net *lntest.NetworkHarness, t *harnessTest) {
 
 	// Before we start the test, we'll ensure both sides are connected so
 	// the funding flow can be properly executed.
-	ctxt, cancel := context.WithTimeout(ctxb, defaultTimeout)
-	defer cancel()
-	net.EnsureConnected(ctxt, t.t, carol, dave)
-	net.EnsureConnected(ctxt, t.t, carol, net.Alice)
+	net.EnsureConnected(t.t, carol, dave)
+	net.EnsureConnected(t.t, carol, net.Alice)
 
 	// At this point, we can begin our PSBT channel funding workflow. We'll
 	// start by generating a pending channel ID externally that will be used
@@ -55,7 +53,7 @@ func testPsbtChanFunding(net *lntest.NetworkHarness, t *harnessTest) {
 	// Now that we have the pending channel ID, Carol will open the channel
 	// by specifying a PSBT shim. We use the NoPublish flag here to avoid
 	// publishing the whole batch TX too early.
-	ctxt, cancel = context.WithTimeout(ctxb, defaultTimeout)
+	ctxt, cancel := context.WithTimeout(ctxb, defaultTimeout)
 	defer cancel()
 	chanUpdates, tempPsbt, err := openChannelPsbt(
 		ctxt, carol, dave, lntest.OpenChannelParams{

--- a/lntest/itest/lnd_psbt_test.go
+++ b/lntest/itest/lnd_psbt_test.go
@@ -233,10 +233,8 @@ func testPsbtChanFunding(net *lntest.NetworkHarness, t *harnessTest) {
 	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
 	resp, err := dave.AddInvoice(ctxt, invoice)
 	require.NoError(t.t, err)
-	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
 	err = completePaymentRequests(
-		ctxt, carol, carol.RouterClient, []string{resp.PaymentRequest},
-		true,
+		carol, carol.RouterClient, []string{resp.PaymentRequest}, true,
 	)
 	require.NoError(t.t, err)
 

--- a/lntest/itest/lnd_recovery_test.go
+++ b/lntest/itest/lnd_recovery_test.go
@@ -45,8 +45,7 @@ func testGetRecoveryInfo(net *lntest.NetworkHarness, t *harnessTest) {
 		if err != nil {
 			t.Fatalf("unable to get current blockheight %v", err)
 		}
-		ctxt, _ := context.WithTimeout(ctxb, defaultTimeout)
-		err = waitForNodeBlockHeight(ctxt, node, minerHeight)
+		err = waitForNodeBlockHeight(node, minerHeight)
 		if err != nil {
 			t.Fatalf("unable to sync to chain: %v", err)
 		}

--- a/lntest/itest/lnd_recovery_test.go
+++ b/lntest/itest/lnd_recovery_test.go
@@ -233,15 +233,11 @@ func testOnchainFundRecovery(net *lntest.NetworkHarness, t *harnessTest) {
 			}
 
 			// Send one BTC to the next P2WKH address.
-			ctxt, _ := context.WithTimeout(ctxb, defaultTimeout)
-			net.SendCoins(
-				ctxt, t.t, btcutil.SatoshiPerBitcoin, node,
-			)
+			net.SendCoins(t.t, btcutil.SatoshiPerBitcoin, node)
 
 			// And another to the next NP2WKH address.
-			ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
 			net.SendCoinsNP2WKH(
-				ctxt, t.t, btcutil.SatoshiPerBitcoin, node,
+				t.t, btcutil.SatoshiPerBitcoin, node,
 			)
 		}
 	}

--- a/lntest/itest/lnd_rest_api_test.go
+++ b/lntest/itest/lnd_rest_api_test.go
@@ -506,10 +506,8 @@ func wsTestCaseBiDirectionalSubscription(ht *harnessTest,
 	const numChannels = 3
 	for i := 0; i < numChannels; i++ {
 		openChannelAndAssert(
-			context.Background(), ht, net, net.Bob, net.Alice,
-			lntest.OpenChannelParams{
-				Amt: 500000,
-			},
+			ht, net, net.Bob, net.Alice,
+			lntest.OpenChannelParams{Amt: 500000},
 		)
 
 		select {

--- a/lntest/itest/lnd_rest_api_test.go
+++ b/lntest/itest/lnd_rest_api_test.go
@@ -499,7 +499,7 @@ func wsTestCaseBiDirectionalSubscription(ht *harnessTest,
 
 	// Before we start opening channels, make sure the two nodes are
 	// connected.
-	net.EnsureConnected(context.Background(), ht.t, net.Alice, net.Bob)
+	net.EnsureConnected(ht.t, net.Alice, net.Bob)
 
 	// Open 3 channels to make sure multiple requests and responses can be
 	// sent over the web socket.

--- a/lntest/itest/lnd_revocation_test.go
+++ b/lntest/itest/lnd_revocation_test.go
@@ -203,8 +203,7 @@ func testRevokedCloseRetribution(net *lntest.NetworkHarness, t *harnessTest) {
 	// block.
 	block := mineBlocks(t, net, 1, 1)[0]
 
-	ctxt, _ = context.WithTimeout(ctxb, channelCloseTimeout)
-	breachTXID, err := net.WaitForChannelClose(ctxt, closeUpdates)
+	breachTXID, err := net.WaitForChannelClose(closeUpdates)
 	if err != nil {
 		t.Fatalf("error while waiting for channel close: %v", err)
 	}
@@ -439,8 +438,7 @@ func testRevokedCloseRetributionZeroValueRemoteOutput(net *lntest.NetworkHarness
 		t.Fatalf("unable to stop Dave's node: %v", err)
 	}
 
-	ctxt, _ = context.WithTimeout(ctxb, channelCloseTimeout)
-	breachTXID, err := net.WaitForChannelClose(ctxt, closeUpdates)
+	breachTXID, err := net.WaitForChannelClose(closeUpdates)
 	if err != nil {
 		t.Fatalf("error while waiting for channel close: %v", err)
 	}
@@ -746,8 +744,7 @@ func testRevokedCloseRetributionRemoteHodl(net *lntest.NetworkHarness,
 
 	// Finally, wait for the final close status update, then ensure that
 	// the closing transaction was included in the block.
-	ctxt, _ = context.WithTimeout(ctxb, channelCloseTimeout)
-	breachTXID, err := net.WaitForChannelClose(ctxt, closeUpdates)
+	breachTXID, err := net.WaitForChannelClose(closeUpdates)
 	if err != nil {
 		t.Fatalf("error while waiting for channel close: %v", err)
 	}
@@ -1181,8 +1178,7 @@ func testRevokedCloseRetributionAltruistWatchtowerCase(
 	// block.
 	block := mineBlocks(t, net, 1, 1)[0]
 
-	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
-	breachTXID, err := net.WaitForChannelClose(ctxt, closeUpdates)
+	breachTXID, err := net.WaitForChannelClose(closeUpdates)
 	if err != nil {
 		t.Fatalf("error while waiting for channel close: %v", err)
 	}

--- a/lntest/itest/lnd_revocation_test.go
+++ b/lntest/itest/lnd_revocation_test.go
@@ -44,12 +44,11 @@ func testRevokedCloseRetribution(net *lntest.NetworkHarness, t *harnessTest) {
 
 	// We must let Bob communicate with Carol before they are able to open
 	// channel, so we connect Bob and Carol,
-	ctxt, _ := context.WithTimeout(ctxb, defaultTimeout)
-	net.ConnectNodes(ctxt, t.t, carol, net.Bob)
+	net.ConnectNodes(t.t, carol, net.Bob)
 
 	// Before we make a channel, we'll load up Carol with some coins sent
 	// directly from the miner.
-	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
+	ctxt, _ := context.WithTimeout(ctxb, defaultTimeout)
 	net.SendCoins(ctxt, t.t, btcutil.SatoshiPerBitcoin, carol)
 
 	// In order to test Carol's response to an uncooperative channel
@@ -301,12 +300,11 @@ func testRevokedCloseRetributionZeroValueRemoteOutput(net *lntest.NetworkHarness
 
 	// We must let Dave have an open channel before she can send a node
 	// announcement, so we open a channel with Carol,
-	ctxt, _ := context.WithTimeout(ctxb, defaultTimeout)
-	net.ConnectNodes(ctxt, t.t, dave, carol)
+	net.ConnectNodes(t.t, dave, carol)
 
 	// Before we make a channel, we'll load up Dave with some coins sent
 	// directly from the miner.
-	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
+	ctxt, _ := context.WithTimeout(ctxb, defaultTimeout)
 	net.SendCoins(ctxt, t.t, btcutil.SatoshiPerBitcoin, dave)
 
 	// In order to test Dave's response to an uncooperative channel
@@ -533,12 +531,11 @@ func testRevokedCloseRetributionRemoteHodl(net *lntest.NetworkHarness,
 
 	// We must let Dave communicate with Carol before they are able to open
 	// channel, so we connect Dave and Carol,
-	ctxt, _ := context.WithTimeout(ctxb, defaultTimeout)
-	net.ConnectNodes(ctxt, t.t, dave, carol)
+	net.ConnectNodes(t.t, dave, carol)
 
 	// Before we make a channel, we'll load up Dave with some coins sent
 	// directly from the miner.
-	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
+	ctxt, _ := context.WithTimeout(ctxb, defaultTimeout)
 	net.SendCoins(ctxt, t.t, btcutil.SatoshiPerBitcoin, dave)
 
 	// In order to test Dave's response to an uncooperative channel closure
@@ -1029,7 +1026,7 @@ func testRevokedCloseRetributionAltruistWatchtowerCase(
 
 	// We must let Dave have an open channel before she can send a node
 	// announcement, so we open a channel with Carol,
-	net.ConnectNodes(ctxb, t.t, dave, carol)
+	net.ConnectNodes(t.t, dave, carol)
 
 	// Before we make a channel, we'll load up Dave with some coins sent
 	// directly from the miner.

--- a/lntest/itest/lnd_revocation_test.go
+++ b/lntest/itest/lnd_revocation_test.go
@@ -48,8 +48,7 @@ func testRevokedCloseRetribution(net *lntest.NetworkHarness, t *harnessTest) {
 
 	// Before we make a channel, we'll load up Carol with some coins sent
 	// directly from the miner.
-	ctxt, _ := context.WithTimeout(ctxb, defaultTimeout)
-	net.SendCoins(ctxt, t.t, btcutil.SatoshiPerBitcoin, carol)
+	net.SendCoins(t.t, btcutil.SatoshiPerBitcoin, carol)
 
 	// In order to test Carol's response to an uncooperative channel
 	// closure by Bob, we'll first open up a channel between them with a
@@ -71,7 +70,7 @@ func testRevokedCloseRetribution(net *lntest.NetworkHarness, t *harnessTest) {
 	}
 
 	// Wait for Carol to receive the channel edge from the funding manager.
-	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
+	ctxt, _ := context.WithTimeout(ctxb, defaultTimeout)
 	err = carol.WaitForNetworkChannelOpen(ctxt, chanPoint)
 	if err != nil {
 		t.Fatalf("carol didn't see the carol->bob channel before "+
@@ -304,8 +303,7 @@ func testRevokedCloseRetributionZeroValueRemoteOutput(net *lntest.NetworkHarness
 
 	// Before we make a channel, we'll load up Dave with some coins sent
 	// directly from the miner.
-	ctxt, _ := context.WithTimeout(ctxb, defaultTimeout)
-	net.SendCoins(ctxt, t.t, btcutil.SatoshiPerBitcoin, dave)
+	net.SendCoins(t.t, btcutil.SatoshiPerBitcoin, dave)
 
 	// In order to test Dave's response to an uncooperative channel
 	// closure by Carol, we'll first open up a channel between them with a
@@ -327,7 +325,7 @@ func testRevokedCloseRetributionZeroValueRemoteOutput(net *lntest.NetworkHarness
 	}
 
 	// Wait for Dave to receive the channel edge from the funding manager.
-	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
+	ctxt, _ := context.WithTimeout(ctxb, defaultTimeout)
 	err = dave.WaitForNetworkChannelOpen(ctxt, chanPoint)
 	if err != nil {
 		t.Fatalf("dave didn't see the dave->carol channel before "+
@@ -535,8 +533,7 @@ func testRevokedCloseRetributionRemoteHodl(net *lntest.NetworkHarness,
 
 	// Before we make a channel, we'll load up Dave with some coins sent
 	// directly from the miner.
-	ctxt, _ := context.WithTimeout(ctxb, defaultTimeout)
-	net.SendCoins(ctxt, t.t, btcutil.SatoshiPerBitcoin, dave)
+	net.SendCoins(t.t, btcutil.SatoshiPerBitcoin, dave)
 
 	// In order to test Dave's response to an uncooperative channel closure
 	// by Carol, we'll first open up a channel between them with a
@@ -561,7 +558,7 @@ func testRevokedCloseRetributionRemoteHodl(net *lntest.NetworkHarness,
 	// We'll introduce a closure to validate that Carol's current balance
 	// matches the given expected amount.
 	checkCarolBalance := func(expectedAmt int64) {
-		ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
+		ctxt, _ := context.WithTimeout(ctxb, defaultTimeout)
 		carolChan, err := getChanInfo(ctxt, carol)
 		if err != nil {
 			t.Fatalf("unable to get carol's channel info: %v", err)
@@ -577,7 +574,7 @@ func testRevokedCloseRetributionRemoteHodl(net *lntest.NetworkHarness,
 	// number of updates is at least as large as the provided minimum
 	// number.
 	checkCarolNumUpdatesAtLeast := func(minimum uint64) {
-		ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
+		ctxt, _ := context.WithTimeout(ctxb, defaultTimeout)
 		carolChan, err := getChanInfo(ctxt, carol)
 		if err != nil {
 			t.Fatalf("unable to get carol's channel info: %v", err)
@@ -590,7 +587,7 @@ func testRevokedCloseRetributionRemoteHodl(net *lntest.NetworkHarness,
 	}
 
 	// Wait for Dave to receive the channel edge from the funding manager.
-	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
+	ctxt, _ := context.WithTimeout(ctxb, defaultTimeout)
 	err = dave.WaitForNetworkChannelOpen(ctxt, chanPoint)
 	if err != nil {
 		t.Fatalf("dave didn't see the dave->carol channel before "+
@@ -1030,7 +1027,7 @@ func testRevokedCloseRetributionAltruistWatchtowerCase(
 
 	// Before we make a channel, we'll load up Dave with some coins sent
 	// directly from the miner.
-	net.SendCoins(ctxb, t.t, btcutil.SatoshiPerBitcoin, dave)
+	net.SendCoins(t.t, btcutil.SatoshiPerBitcoin, dave)
 
 	// In order to test Dave's response to an uncooperative channel
 	// closure by Carol, we'll first open up a channel between them with a

--- a/lntest/itest/lnd_revocation_test.go
+++ b/lntest/itest/lnd_revocation_test.go
@@ -169,8 +169,9 @@ func testRevokedCloseRetribution(net *lntest.NetworkHarness, t *harnessTest) {
 	var closeUpdates lnrpc.Lightning_CloseChannelClient
 	force := true
 	err = wait.Predicate(func() bool {
-		ctxt, _ := context.WithTimeout(ctxb, channelCloseTimeout)
-		closeUpdates, _, err = net.CloseChannel(ctxt, net.Bob, chanPoint, force)
+		closeUpdates, _, err = net.CloseChannel(
+			net.Bob, chanPoint, force,
+		)
 		if err != nil {
 			predErr = err
 			return false
@@ -404,9 +405,8 @@ func testRevokedCloseRetributionZeroValueRemoteOutput(net *lntest.NetworkHarness
 
 	force := true
 	err = wait.Predicate(func() bool {
-		ctxt, _ := context.WithTimeout(ctxb, channelCloseTimeout)
 		closeUpdates, closeTxID, closeErr = net.CloseChannel(
-			ctxt, carol, chanPoint, force,
+			carol, chanPoint, force,
 		)
 		return closeErr == nil
 	}, defaultTimeout)
@@ -714,9 +714,9 @@ func testRevokedCloseRetributionRemoteHodl(net *lntest.NetworkHarness,
 	// commitment transaction of a prior *revoked* state, so she'll soon
 	// feel the wrath of Dave's retribution.
 	force := true
-	ctxt, _ = context.WithTimeout(ctxb, channelCloseTimeout)
-	closeUpdates, closeTxID, err := net.CloseChannel(ctxt, carol,
-		chanPoint, force)
+	closeUpdates, closeTxID, err := net.CloseChannel(
+		carol, chanPoint, force,
+	)
 	if err != nil {
 		t.Fatalf("unable to close channel: %v", err)
 	}
@@ -1154,9 +1154,7 @@ func testRevokedCloseRetributionAltruistWatchtowerCase(
 	// broadcasting his current channel state. This is actually the
 	// commitment transaction of a prior *revoked* state, so he'll soon
 	// feel the wrath of Dave's retribution.
-	closeUpdates, closeTxID, err := net.CloseChannel(
-		ctxb, carol, chanPoint, true,
-	)
+	closeUpdates, closeTxID, err := net.CloseChannel(carol, chanPoint, true)
 	if err != nil {
 		t.Fatalf("unable to close channel: %v", err)
 	}

--- a/lntest/itest/lnd_revocation_test.go
+++ b/lntest/itest/lnd_revocation_test.go
@@ -79,10 +79,8 @@ func testRevokedCloseRetribution(net *lntest.NetworkHarness, t *harnessTest) {
 
 	// Send payments from Carol to Bob using 3 of Bob's payment hashes
 	// generated above.
-	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
 	err = completePaymentRequests(
-		ctxt, carol, carol.RouterClient, bobPayReqs[:numInvoices/2],
-		true,
+		carol, carol.RouterClient, bobPayReqs[:numInvoices/2], true,
 	)
 	if err != nil {
 		t.Fatalf("unable to send payments: %v", err)
@@ -126,10 +124,8 @@ func testRevokedCloseRetribution(net *lntest.NetworkHarness, t *harnessTest) {
 
 	// Finally, send payments from Carol to Bob, consuming Bob's remaining
 	// payment hashes.
-	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
 	err = completePaymentRequests(
-		ctxt, carol, carol.RouterClient, bobPayReqs[numInvoices/2:],
-		true,
+		carol, carol.RouterClient, bobPayReqs[numInvoices/2:], true,
 	)
 	if err != nil {
 		t.Fatalf("unable to send payments: %v", err)
@@ -358,9 +354,8 @@ func testRevokedCloseRetributionZeroValueRemoteOutput(net *lntest.NetworkHarness
 
 	// Finally, send payments from Dave to Carol, consuming Carol's remaining
 	// payment hashes.
-	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
 	err = completePaymentRequests(
-		ctxt, dave, dave.RouterClient, carolPayReqs, false,
+		dave, dave.RouterClient, carolPayReqs, false,
 	)
 	if err != nil {
 		t.Fatalf("unable to send payments: %v", err)
@@ -597,10 +592,8 @@ func testRevokedCloseRetributionRemoteHodl(net *lntest.NetworkHarness,
 
 	// Send payments from Dave to Carol using 3 of Carol's payment hashes
 	// generated above.
-	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
 	err = completePaymentRequests(
-		ctxt, dave, dave.RouterClient, carolPayReqs[:numInvoices/2],
-		false,
+		dave, dave.RouterClient, carolPayReqs[:numInvoices/2], false,
 	)
 	if err != nil {
 		t.Fatalf("unable to send payments: %v", err)
@@ -618,10 +611,8 @@ func testRevokedCloseRetributionRemoteHodl(net *lntest.NetworkHarness,
 
 	// Send payments from Carol to Dave using 3 of Dave's payment hashes
 	// generated above.
-	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
 	err = completePaymentRequests(
-		ctxt, carol, carol.RouterClient, davePayReqs[:numInvoices/2],
-		false,
+		carol, carol.RouterClient, davePayReqs[:numInvoices/2], false,
 	)
 	if err != nil {
 		t.Fatalf("unable to send payments: %v", err)
@@ -658,10 +649,8 @@ func testRevokedCloseRetributionRemoteHodl(net *lntest.NetworkHarness,
 
 	// Finally, send payments from Dave to Carol, consuming Carol's
 	// remaining payment hashes.
-	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
 	err = completePaymentRequests(
-		ctxt, dave, dave.RouterClient, carolPayReqs[numInvoices/2:],
-		false,
+		dave, dave.RouterClient, carolPayReqs[numInvoices/2:], false,
 	)
 	if err != nil {
 		t.Fatalf("unable to send payments: %v", err)
@@ -1082,7 +1071,7 @@ func testRevokedCloseRetributionAltruistWatchtowerCase(
 	// Finally, send payments from Dave to Carol, consuming Carol's remaining
 	// payment hashes.
 	err = completePaymentRequests(
-		ctxb, dave, dave.RouterClient, carolPayReqs, false,
+		dave, dave.RouterClient, carolPayReqs, false,
 	)
 	if err != nil {
 		t.Fatalf("unable to send payments: %v", err)

--- a/lntest/itest/lnd_revocation_test.go
+++ b/lntest/itest/lnd_revocation_test.go
@@ -55,9 +55,8 @@ func testRevokedCloseRetribution(net *lntest.NetworkHarness, t *harnessTest) {
 	// In order to test Carol's response to an uncooperative channel
 	// closure by Bob, we'll first open up a channel between them with a
 	// 0.5 BTC value.
-	ctxt, _ = context.WithTimeout(ctxb, channelOpenTimeout)
 	chanPoint := openChannelAndAssert(
-		ctxt, t, net, carol, net.Bob,
+		t, net, carol, net.Bob,
 		lntest.OpenChannelParams{
 			Amt: chanAmt,
 		},
@@ -313,9 +312,8 @@ func testRevokedCloseRetributionZeroValueRemoteOutput(net *lntest.NetworkHarness
 	// In order to test Dave's response to an uncooperative channel
 	// closure by Carol, we'll first open up a channel between them with a
 	// 0.5 BTC value.
-	ctxt, _ = context.WithTimeout(ctxb, channelOpenTimeout)
 	chanPoint := openChannelAndAssert(
-		ctxt, t, net, dave, carol,
+		t, net, dave, carol,
 		lntest.OpenChannelParams{
 			Amt: chanAmt,
 		},
@@ -546,9 +544,8 @@ func testRevokedCloseRetributionRemoteHodl(net *lntest.NetworkHarness,
 	// In order to test Dave's response to an uncooperative channel closure
 	// by Carol, we'll first open up a channel between them with a
 	// funding.MaxBtcFundingAmount (2^24) satoshis value.
-	ctxt, _ = context.WithTimeout(ctxb, channelOpenTimeout)
 	chanPoint := openChannelAndAssert(
-		ctxt, t, net, dave, carol,
+		t, net, dave, carol,
 		lntest.OpenChannelParams{
 			Amt:     chanAmt,
 			PushAmt: pushAmt,
@@ -1041,9 +1038,8 @@ func testRevokedCloseRetributionAltruistWatchtowerCase(
 	// In order to test Dave's response to an uncooperative channel
 	// closure by Carol, we'll first open up a channel between them with a
 	// 0.5 BTC value.
-	ctxt, _ = context.WithTimeout(ctxb, channelOpenTimeout)
 	chanPoint := openChannelAndAssert(
-		ctxt, t, net, dave, carol,
+		t, net, dave, carol,
 		lntest.OpenChannelParams{
 			Amt:     3 * (chanAmt / 4),
 			PushAmt: chanAmt / 4,

--- a/lntest/itest/lnd_revocation_test.go
+++ b/lntest/itest/lnd_revocation_test.go
@@ -91,8 +91,7 @@ func testRevokedCloseRetribution(net *lntest.NetworkHarness, t *harnessTest) {
 	var bobChan *lnrpc.Channel
 	var predErr error
 	err = wait.Predicate(func() bool {
-		ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
-		bChan, err := getChanInfo(ctxt, net.Bob)
+		bChan, err := getChanInfo(net.Bob)
 		if err != nil {
 			t.Fatalf("unable to get bob's channel info: %v", err)
 		}
@@ -131,8 +130,7 @@ func testRevokedCloseRetribution(net *lntest.NetworkHarness, t *harnessTest) {
 		t.Fatalf("unable to send payments: %v", err)
 	}
 
-	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
-	bobChan, err = getChanInfo(ctxt, net.Bob)
+	bobChan, err = getChanInfo(net.Bob)
 	if err != nil {
 		t.Fatalf("unable to get bob chan info: %v", err)
 	}
@@ -149,8 +147,7 @@ func testRevokedCloseRetribution(net *lntest.NetworkHarness, t *harnessTest) {
 
 	// Now query for Bob's channel state, it should show that he's at a
 	// state number in the past, not the *latest* state.
-	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
-	bobChan, err = getChanInfo(ctxt, net.Bob)
+	bobChan, err = getChanInfo(net.Bob)
 	if err != nil {
 		t.Fatalf("unable to get bob chan info: %v", err)
 	}
@@ -330,8 +327,7 @@ func testRevokedCloseRetributionZeroValueRemoteOutput(net *lntest.NetworkHarness
 
 	// Next query for Carol's channel state, as we sent 0 payments, Carol
 	// should now see her balance as being 0 satoshis.
-	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
-	carolChan, err := getChanInfo(ctxt, carol)
+	carolChan, err := getChanInfo(carol)
 	if err != nil {
 		t.Fatalf("unable to get carol's channel info: %v", err)
 	}
@@ -361,8 +357,7 @@ func testRevokedCloseRetributionZeroValueRemoteOutput(net *lntest.NetworkHarness
 		t.Fatalf("unable to send payments: %v", err)
 	}
 
-	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
-	_, err = getChanInfo(ctxt, carol)
+	_, err = getChanInfo(carol)
 	if err != nil {
 		t.Fatalf("unable to get carol chan info: %v", err)
 	}
@@ -379,8 +374,7 @@ func testRevokedCloseRetributionZeroValueRemoteOutput(net *lntest.NetworkHarness
 
 	// Now query for Carol's channel state, it should show that he's at a
 	// state number in the past, not the *latest* state.
-	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
-	carolChan, err = getChanInfo(ctxt, carol)
+	carolChan, err = getChanInfo(carol)
 	if err != nil {
 		t.Fatalf("unable to get carol chan info: %v", err)
 	}
@@ -551,8 +545,7 @@ func testRevokedCloseRetributionRemoteHodl(net *lntest.NetworkHarness,
 	// We'll introduce a closure to validate that Carol's current balance
 	// matches the given expected amount.
 	checkCarolBalance := func(expectedAmt int64) {
-		ctxt, _ := context.WithTimeout(ctxb, defaultTimeout)
-		carolChan, err := getChanInfo(ctxt, carol)
+		carolChan, err := getChanInfo(carol)
 		if err != nil {
 			t.Fatalf("unable to get carol's channel info: %v", err)
 		}
@@ -567,8 +560,7 @@ func testRevokedCloseRetributionRemoteHodl(net *lntest.NetworkHarness,
 	// number of updates is at least as large as the provided minimum
 	// number.
 	checkCarolNumUpdatesAtLeast := func(minimum uint64) {
-		ctxt, _ := context.WithTimeout(ctxb, defaultTimeout)
-		carolChan, err := getChanInfo(ctxt, carol)
+		carolChan, err := getChanInfo(carol)
 		if err != nil {
 			t.Fatalf("unable to get carol's channel info: %v", err)
 		}
@@ -621,8 +613,7 @@ func testRevokedCloseRetributionRemoteHodl(net *lntest.NetworkHarness,
 	// Next query for Carol's channel state, as we sent 3 payments of 10k
 	// satoshis each, however Carol should now see her balance as being
 	// equal to the push amount in satoshis since she has not settled.
-	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
-	carolChan, err := getChanInfo(ctxt, carol)
+	carolChan, err := getChanInfo(carol)
 	if err != nil {
 		t.Fatalf("unable to get carol's channel info: %v", err)
 	}
@@ -689,8 +680,7 @@ func testRevokedCloseRetributionRemoteHodl(net *lntest.NetworkHarness,
 
 	// Now query for Carol's channel state, it should show that she's at a
 	// state number in the past, *not* the latest state.
-	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
-	carolChan, err = getChanInfo(ctxt, carol)
+	carolChan, err = getChanInfo(carol)
 	if err != nil {
 		t.Fatalf("unable to get carol chan info: %v", err)
 	}
@@ -1046,8 +1036,7 @@ func testRevokedCloseRetributionAltruistWatchtowerCase(
 	// Next query for Carol's channel state, as we sent 0 payments, Carol
 	// should still see her balance as the push amount, which is 1/4 of the
 	// capacity.
-	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
-	carolChan, err := getChanInfo(ctxt, carol)
+	carolChan, err := getChanInfo(carol)
 	if err != nil {
 		t.Fatalf("unable to get carol's channel info: %v", err)
 	}
@@ -1130,8 +1119,7 @@ func testRevokedCloseRetributionAltruistWatchtowerCase(
 
 	// Now query for Carol's channel state, it should show that he's at a
 	// state number in the past, not the *latest* state.
-	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
-	carolChan, err = getChanInfo(ctxt, carol)
+	carolChan, err = getChanInfo(carol)
 	if err != nil {
 		t.Fatalf("unable to get carol chan info: %v", err)
 	}

--- a/lntest/itest/lnd_routing_test.go
+++ b/lntest/itest/lnd_routing_test.go
@@ -103,9 +103,8 @@ func testSingleHopSendToRouteCase(net *lntest.NetworkHarness, t *harnessTest,
 	dave := net.NewNode(t.t, "Dave", nil)
 	defer shutdownAndAssert(net, t, dave)
 
+	net.ConnectNodes(t.t, carol, dave)
 	ctxt, _ := context.WithTimeout(ctxb, defaultTimeout)
-	net.ConnectNodes(ctxt, t.t, carol, dave)
-	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
 	net.SendCoins(ctxt, t.t, btcutil.SatoshiPerBitcoin, carol)
 
 	// Open a channel with 100k satoshis between Carol and Dave with Carol
@@ -467,9 +466,8 @@ func testMultiHopSendToRoute(net *lntest.NetworkHarness, t *harnessTest) {
 	carol := net.NewNode(t.t, "Carol", nil)
 	defer shutdownAndAssert(net, t, carol)
 
+	net.ConnectNodes(t.t, carol, net.Bob)
 	ctxt, _ := context.WithTimeout(ctxb, defaultTimeout)
-	net.ConnectNodes(ctxt, t.t, carol, net.Bob)
-	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
 	net.SendCoins(ctxt, t.t, btcutil.SatoshiPerBitcoin, net.Bob)
 
 	chanPointBob := openChannelAndAssert(
@@ -647,8 +645,7 @@ func testSendToRouteErrorPropagation(net *lntest.NetworkHarness, t *harnessTest)
 	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
 	net.SendCoins(ctxt, t.t, btcutil.SatoshiPerBitcoin, charlie)
 
-	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
-	net.ConnectNodes(ctxt, t.t, carol, charlie)
+	net.ConnectNodes(t.t, carol, charlie)
 
 	chanPointCarol := openChannelAndAssert(
 		t, net, carol, charlie,
@@ -761,9 +758,8 @@ func testPrivateChannels(net *lntest.NetworkHarness, t *harnessTest) {
 	dave := net.NewNode(t.t, "Dave", nil)
 	defer shutdownAndAssert(net, t, dave)
 
+	net.ConnectNodes(t.t, dave, net.Alice)
 	ctxt, _ := context.WithTimeout(ctxb, defaultTimeout)
-	net.ConnectNodes(ctxt, t.t, dave, net.Alice)
-	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
 	net.SendCoins(ctxt, t.t, btcutil.SatoshiPerBitcoin, dave)
 
 	chanPointDave := openChannelAndAssert(
@@ -787,8 +783,7 @@ func testPrivateChannels(net *lntest.NetworkHarness, t *harnessTest) {
 	carol := net.NewNode(t.t, "Carol", nil)
 	defer shutdownAndAssert(net, t, carol)
 
-	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
-	net.ConnectNodes(ctxt, t.t, carol, dave)
+	net.ConnectNodes(t.t, carol, dave)
 	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
 	net.SendCoins(ctxt, t.t, btcutil.SatoshiPerBitcoin, carol)
 
@@ -835,8 +830,7 @@ func testPrivateChannels(net *lntest.NetworkHarness, t *harnessTest) {
 	}
 	// Now create a _private_ channel directly between Carol and
 	// Alice of 100k.
-	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
-	net.ConnectNodes(ctxt, t.t, carol, net.Alice)
+	net.ConnectNodes(t.t, carol, net.Alice)
 	ctxt, _ = context.WithTimeout(ctxb, channelOpenTimeout)
 	chanOpenUpdate := openChannelStream(
 		ctxt, t, net, carol, net.Alice,
@@ -1079,8 +1073,7 @@ func testUpdateChannelPolicyForPrivateChannel(net *lntest.NetworkHarness,
 	defer shutdownAndAssert(net, t, carol)
 
 	// Connect Carol to Bob.
-	ctxt, _ := context.WithTimeout(ctxb, defaultTimeout)
-	net.ConnectNodes(ctxt, t.t, carol, net.Bob)
+	net.ConnectNodes(t.t, carol, net.Bob)
 
 	// Open a channel with 100k satoshis between Bob and Carol.
 	chanPointBobCarol := openChannelAndAssert(
@@ -1110,7 +1103,7 @@ func testUpdateChannelPolicyForPrivateChannel(net *lntest.NetworkHarness,
 		Value:   paymentAmt,
 		Private: true,
 	}
-	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
+	ctxt, _ := context.WithTimeout(ctxb, defaultTimeout)
 	resp, err := carol.AddInvoice(ctxt, invoice)
 	require.NoError(t.t, err, "unable to create invoice for carol")
 
@@ -1210,8 +1203,7 @@ func testInvoiceRoutingHints(net *lntest.NetworkHarness, t *harnessTest) {
 	carol := net.NewNode(t.t, "Carol", nil)
 	defer shutdownAndAssert(net, t, carol)
 
-	ctxt, _ := context.WithTimeout(ctxb, defaultTimeout)
-	net.ConnectNodes(ctxt, t.t, net.Alice, carol)
+	net.ConnectNodes(t.t, net.Alice, carol)
 	chanPointCarol := openChannelAndAssert(
 		t, net, net.Alice, carol,
 		lntest.OpenChannelParams{
@@ -1225,8 +1217,7 @@ func testInvoiceRoutingHints(net *lntest.NetworkHarness, t *harnessTest) {
 	// we should only include routing hints for nodes that are publicly
 	// advertised, otherwise we'd end up leaking information about nodes
 	// that wish to stay unadvertised.
-	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
-	net.ConnectNodes(ctxt, t.t, net.Bob, carol)
+	net.ConnectNodes(t.t, net.Bob, carol)
 	chanPointBobCarol := openChannelAndAssert(
 		t, net, net.Bob, carol,
 		lntest.OpenChannelParams{
@@ -1242,8 +1233,7 @@ func testInvoiceRoutingHints(net *lntest.NetworkHarness, t *harnessTest) {
 	dave := net.NewNode(t.t, "Dave", nil)
 	defer shutdownAndAssert(net, t, dave)
 
-	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
-	net.ConnectNodes(ctxt, t.t, net.Alice, dave)
+	net.ConnectNodes(t.t, net.Alice, dave)
 	chanPointDave := openChannelAndAssert(
 		t, net, net.Alice, dave,
 		lntest.OpenChannelParams{
@@ -1257,8 +1247,7 @@ func testInvoiceRoutingHints(net *lntest.NetworkHarness, t *harnessTest) {
 	// channel has been created to avoid populating routing hints for
 	// inactive channels.
 	eve := net.NewNode(t.t, "Eve", nil)
-	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
-	net.ConnectNodes(ctxt, t.t, net.Alice, eve)
+	net.ConnectNodes(t.t, net.Alice, eve)
 	chanPointEve := openChannelAndAssert(
 		t, net, net.Alice, eve,
 		lntest.OpenChannelParams{
@@ -1301,7 +1290,7 @@ func testInvoiceRoutingHints(net *lntest.NetworkHarness, t *harnessTest) {
 	var predErr error
 	var decoded *lnrpc.PayReq
 	err := wait.Predicate(func() bool {
-		ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
+		ctxt, _ := context.WithTimeout(ctxb, defaultTimeout)
 		resp, err := net.Alice.AddInvoice(ctxt, invoice)
 		if err != nil {
 			predErr = fmt.Errorf("unable to add invoice: %v", err)
@@ -1341,7 +1330,7 @@ func testInvoiceRoutingHints(net *lntest.NetworkHarness, t *harnessTest) {
 	// We'll need the short channel ID of the channel between Alice and Bob
 	// to make sure the routing hint is for this channel.
 	listReq := &lnrpc.ListChannelsRequest{}
-	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
+	ctxt, _ := context.WithTimeout(ctxb, defaultTimeout)
 	listResp, err := net.Alice.ListChannels(ctxt, listReq)
 	if err != nil {
 		t.Fatalf("unable to retrieve alice's channels: %v", err)
@@ -1427,8 +1416,7 @@ func testMultiHopOverPrivateChannels(net *lntest.NetworkHarness, t *harnessTest)
 	carol := net.NewNode(t.t, "Carol", nil)
 	defer shutdownAndAssert(net, t, carol)
 
-	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
-	net.ConnectNodes(ctxt, t.t, net.Bob, carol)
+	net.ConnectNodes(t.t, net.Bob, carol)
 	chanPointBob := openChannelAndAssert(
 		t, net, net.Bob, carol,
 		lntest.OpenChannelParams{
@@ -1470,8 +1458,7 @@ func testMultiHopOverPrivateChannels(net *lntest.NetworkHarness, t *harnessTest)
 	dave := net.NewNode(t.t, "Dave", nil)
 	defer shutdownAndAssert(net, t, dave)
 
-	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
-	net.ConnectNodes(ctxt, t.t, carol, dave)
+	net.ConnectNodes(t.t, carol, dave)
 	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
 	net.SendCoins(ctxt, t.t, btcutil.SatoshiPerBitcoin, carol)
 
@@ -1606,9 +1593,8 @@ func testQueryRoutes(net *lntest.NetworkHarness, t *harnessTest) {
 	carol := net.NewNode(t.t, "Carol", nil)
 	defer shutdownAndAssert(net, t, carol)
 
+	net.ConnectNodes(t.t, carol, net.Bob)
 	ctxt, _ := context.WithTimeout(ctxb, defaultTimeout)
-	net.ConnectNodes(ctxt, t.t, carol, net.Bob)
-	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
 	net.SendCoins(ctxt, t.t, btcutil.SatoshiPerBitcoin, net.Bob)
 
 	chanPointBob := openChannelAndAssert(
@@ -1623,8 +1609,7 @@ func testQueryRoutes(net *lntest.NetworkHarness, t *harnessTest) {
 	dave := net.NewNode(t.t, "Dave", nil)
 	defer shutdownAndAssert(net, t, dave)
 
-	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
-	net.ConnectNodes(ctxt, t.t, dave, carol)
+	net.ConnectNodes(t.t, dave, carol)
 	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
 	net.SendCoins(ctxt, t.t, btcutil.SatoshiPerBitcoin, carol)
 
@@ -1895,9 +1880,8 @@ func testRouteFeeCutoff(net *lntest.NetworkHarness, t *harnessTest) {
 	carol := net.NewNode(t.t, "Carol", nil)
 	defer shutdownAndAssert(net, t, carol)
 
+	net.ConnectNodes(t.t, carol, net.Alice)
 	ctxt, _ := context.WithTimeout(ctxb, defaultTimeout)
-	net.ConnectNodes(ctxt, t.t, carol, net.Alice)
-	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
 	net.SendCoins(ctxt, t.t, btcutil.SatoshiPerBitcoin, carol)
 
 	chanPointAliceCarol := openChannelAndAssert(
@@ -1912,8 +1896,7 @@ func testRouteFeeCutoff(net *lntest.NetworkHarness, t *harnessTest) {
 	dave := net.NewNode(t.t, "Dave", nil)
 	defer shutdownAndAssert(net, t, dave)
 
-	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
-	net.ConnectNodes(ctxt, t.t, dave, net.Bob)
+	net.ConnectNodes(t.t, dave, net.Bob)
 	chanPointBobDave := openChannelAndAssert(
 		t, net, net.Bob, dave,
 		lntest.OpenChannelParams{
@@ -1922,8 +1905,7 @@ func testRouteFeeCutoff(net *lntest.NetworkHarness, t *harnessTest) {
 	)
 
 	// Open a channel between Carol and Dave.
-	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
-	net.ConnectNodes(ctxt, t.t, carol, dave)
+	net.ConnectNodes(t.t, carol, dave)
 	chanPointCarolDave := openChannelAndAssert(
 		t, net, carol, dave,
 		lntest.OpenChannelParams{

--- a/lntest/itest/lnd_routing_test.go
+++ b/lntest/itest/lnd_routing_test.go
@@ -2060,8 +2060,7 @@ func testRouteFeeCutoff(net *lntest.NetworkHarness, t *harnessTest) {
 			sendReq.FeeLimitMsat = 1000 * paymentAmt * limit.Percent / 100
 		}
 
-		ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
-		result := sendAndAssertSuccess(ctxt, t, net.Alice, sendReq)
+		result := sendAndAssertSuccess(t, net.Alice, sendReq)
 
 		checkRoute(result.Htlcs[0].Route)
 	}

--- a/lntest/itest/lnd_routing_test.go
+++ b/lntest/itest/lnd_routing_test.go
@@ -179,10 +179,8 @@ func testSingleHopSendToRouteCase(net *lntest.NetworkHarness, t *harnessTest,
 	if err != nil {
 		t.Fatalf("unable to get best height: %v", err)
 	}
-	ctxt, cancel := context.WithTimeout(ctxb, defaultTimeout)
-	defer cancel()
-	require.NoError(t.t, waitForNodeBlockHeight(ctxt, carol, minerHeight))
-	require.NoError(t.t, waitForNodeBlockHeight(ctxt, dave, minerHeight))
+	require.NoError(t.t, waitForNodeBlockHeight(carol, minerHeight))
+	require.NoError(t.t, waitForNodeBlockHeight(dave, minerHeight))
 
 	// Query for routes to pay from Carol to Dave using the default CLTV
 	// config.
@@ -190,7 +188,7 @@ func testSingleHopSendToRouteCase(net *lntest.NetworkHarness, t *harnessTest,
 		PubKey: dave.PubKeyStr,
 		Amt:    paymentAmtSat,
 	}
-	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
+	ctxt, _ := context.WithTimeout(ctxb, defaultTimeout)
 	routes, err := carol.QueryRoutes(ctxt, routesReq)
 	if err != nil {
 		t.Fatalf("unable to get route from %s: %v",

--- a/lntest/itest/lnd_routing_test.go
+++ b/lntest/itest/lnd_routing_test.go
@@ -825,9 +825,8 @@ func testPrivateChannels(net *lntest.NetworkHarness, t *harnessTest) {
 	// Now create a _private_ channel directly between Carol and
 	// Alice of 100k.
 	net.ConnectNodes(t.t, carol, net.Alice)
-	ctxt, _ := context.WithTimeout(ctxb, channelOpenTimeout)
 	chanOpenUpdate := openChannelStream(
-		ctxt, t, net, carol, net.Alice,
+		t, net, carol, net.Alice,
 		lntest.OpenChannelParams{
 			Amt:     chanAmt,
 			Private: true,
@@ -841,7 +840,7 @@ func testPrivateChannels(net *lntest.NetworkHarness, t *harnessTest) {
 	// nodes have defaultNumConfs=1 set.
 	block := mineBlocks(t, net, 1, 1)[0]
 
-	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
+	ctxt, _ := context.WithTimeout(ctxb, defaultTimeout)
 	chanPointPrivate, err := net.WaitForChannelOpen(ctxt, chanOpenUpdate)
 	if err != nil {
 		t.Fatalf("error while waiting for channel open: %v", err)

--- a/lntest/itest/lnd_routing_test.go
+++ b/lntest/itest/lnd_routing_test.go
@@ -856,13 +856,11 @@ func testPrivateChannels(net *lntest.NetworkHarness, t *harnessTest) {
 		Hash:  *fundingTxID,
 		Index: chanPointPrivate.OutputIndex,
 	}
-	ctxt, _ := context.WithTimeout(ctxb, defaultTimeout)
-	err = net.AssertChannelExists(ctxt, carol, &privateFundPoint)
+	err = net.AssertChannelExists(carol, &privateFundPoint)
 	if err != nil {
 		t.Fatalf("unable to assert channel existence: %v", err)
 	}
-	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
-	err = net.AssertChannelExists(ctxt, net.Alice, &privateFundPoint)
+	err = net.AssertChannelExists(net.Alice, &privateFundPoint)
 	if err != nil {
 		t.Fatalf("unable to assert channel existence: %v", err)
 	}
@@ -886,7 +884,7 @@ func testPrivateChannels(net *lntest.NetworkHarness, t *harnessTest) {
 	time.Sleep(time.Millisecond * 50)
 
 	// Let Carol pay the invoices.
-	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
+	ctxt, _ := context.WithTimeout(ctxb, defaultTimeout)
 	err = completePaymentRequests(
 		ctxt, carol, carol.RouterClient, payReqs, true,
 	)

--- a/lntest/itest/lnd_routing_test.go
+++ b/lntest/itest/lnd_routing_test.go
@@ -305,7 +305,7 @@ func testSingleHopSendToRouteCase(net *lntest.NetworkHarness, t *harnessTest,
 
 	// Verify that the payment's from Carol's PoV have the correct payment
 	// hash and amount.
-	ctxt, _ = context.WithTimeout(ctxt, defaultTimeout)
+	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
 	paymentsResp, err := carol.ListPayments(
 		ctxt, &lnrpc.ListPaymentsRequest{},
 	)
@@ -385,7 +385,7 @@ func testSingleHopSendToRouteCase(net *lntest.NetworkHarness, t *harnessTest,
 
 	// Verify that the invoices's from Dave's PoV have the correct payment
 	// hash and amount.
-	ctxt, _ = context.WithTimeout(ctxt, defaultTimeout)
+	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
 	invoicesResp, err := dave.ListInvoices(
 		ctxt, &lnrpc.ListInvoiceRequest{},
 	)
@@ -1118,7 +1118,7 @@ func testUpdateChannelPolicyForPrivateChannel(net *lntest.NetworkHarness,
 
 	// Check that Alice did make the payment with two HTLCs, one failed and
 	// one succeeded.
-	ctxt, _ = context.WithTimeout(ctxt, defaultTimeout)
+	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
 	paymentsResp, err := net.Alice.ListPayments(
 		ctxt, &lnrpc.ListPaymentsRequest{},
 	)

--- a/lntest/itest/lnd_routing_test.go
+++ b/lntest/itest/lnd_routing_test.go
@@ -110,9 +110,8 @@ func testSingleHopSendToRouteCase(net *lntest.NetworkHarness, t *harnessTest,
 
 	// Open a channel with 100k satoshis between Carol and Dave with Carol
 	// being the sole funder of the channel.
-	ctxt, _ = context.WithTimeout(ctxb, channelOpenTimeout)
 	chanPointCarol := openChannelAndAssert(
-		ctxt, t, net, carol, dave,
+		t, net, carol, dave,
 		lntest.OpenChannelParams{
 			Amt: chanAmt,
 		},
@@ -445,9 +444,8 @@ func testMultiHopSendToRoute(net *lntest.NetworkHarness, t *harnessTest) {
 
 	// Open a channel with 100k satoshis between Alice and Bob with Alice
 	// being the sole funder of the channel.
-	ctxt, _ := context.WithTimeout(ctxb, channelOpenTimeout)
 	chanPointAlice := openChannelAndAssert(
-		ctxt, t, net, net.Alice, net.Bob,
+		t, net, net.Alice, net.Bob,
 		lntest.OpenChannelParams{
 			Amt: chanAmt,
 		},
@@ -469,14 +467,13 @@ func testMultiHopSendToRoute(net *lntest.NetworkHarness, t *harnessTest) {
 	carol := net.NewNode(t.t, "Carol", nil)
 	defer shutdownAndAssert(net, t, carol)
 
-	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
+	ctxt, _ := context.WithTimeout(ctxb, defaultTimeout)
 	net.ConnectNodes(ctxt, t.t, carol, net.Bob)
 	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
 	net.SendCoins(ctxt, t.t, btcutil.SatoshiPerBitcoin, net.Bob)
 
-	ctxt, _ = context.WithTimeout(ctxb, channelOpenTimeout)
 	chanPointBob := openChannelAndAssert(
-		ctxt, t, net, net.Bob, carol,
+		t, net, net.Bob, carol,
 		lntest.OpenChannelParams{
 			Amt: chanAmt,
 		},
@@ -618,15 +615,14 @@ func testSendToRouteErrorPropagation(net *lntest.NetworkHarness, t *harnessTest)
 
 	// Open a channel with 100k satoshis between Alice and Bob with Alice
 	// being the sole funder of the channel.
-	ctxt, _ := context.WithTimeout(ctxb, channelOpenTimeout)
 	chanPointAlice := openChannelAndAssert(
-		ctxt, t, net, net.Alice, net.Bob,
+		t, net, net.Alice, net.Bob,
 		lntest.OpenChannelParams{
 			Amt: chanAmt,
 		},
 	)
 
-	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
+	ctxt, _ := context.WithTimeout(ctxb, defaultTimeout)
 	err := net.Alice.WaitForNetworkChannelOpen(ctxt, chanPointAlice)
 	if err != nil {
 		t.Fatalf("alice didn't advertise her channel: %v", err)
@@ -654,9 +650,8 @@ func testSendToRouteErrorPropagation(net *lntest.NetworkHarness, t *harnessTest)
 	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
 	net.ConnectNodes(ctxt, t.t, carol, charlie)
 
-	ctxt, _ = context.WithTimeout(ctxb, channelOpenTimeout)
 	chanPointCarol := openChannelAndAssert(
-		ctxt, t, net, carol, charlie,
+		t, net, carol, charlie,
 		lntest.OpenChannelParams{
 			Amt: chanAmt,
 		},
@@ -745,9 +740,8 @@ func testPrivateChannels(net *lntest.NetworkHarness, t *harnessTest) {
 	// where the 100k channel between Carol and Alice is private.
 
 	// Open a channel with 200k satoshis between Alice and Bob.
-	ctxt, _ := context.WithTimeout(ctxb, channelOpenTimeout)
 	chanPointAlice := openChannelAndAssert(
-		ctxt, t, net, net.Alice, net.Bob,
+		t, net, net.Alice, net.Bob,
 		lntest.OpenChannelParams{
 			Amt: chanAmt * 2,
 		},
@@ -767,14 +761,13 @@ func testPrivateChannels(net *lntest.NetworkHarness, t *harnessTest) {
 	dave := net.NewNode(t.t, "Dave", nil)
 	defer shutdownAndAssert(net, t, dave)
 
-	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
+	ctxt, _ := context.WithTimeout(ctxb, defaultTimeout)
 	net.ConnectNodes(ctxt, t.t, dave, net.Alice)
 	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
 	net.SendCoins(ctxt, t.t, btcutil.SatoshiPerBitcoin, dave)
 
-	ctxt, _ = context.WithTimeout(ctxb, channelOpenTimeout)
 	chanPointDave := openChannelAndAssert(
-		ctxt, t, net, dave, net.Alice,
+		t, net, dave, net.Alice,
 		lntest.OpenChannelParams{
 			Amt: chanAmt,
 		},
@@ -799,9 +792,8 @@ func testPrivateChannels(net *lntest.NetworkHarness, t *harnessTest) {
 	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
 	net.SendCoins(ctxt, t.t, btcutil.SatoshiPerBitcoin, carol)
 
-	ctxt, _ = context.WithTimeout(ctxb, channelOpenTimeout)
 	chanPointCarol := openChannelAndAssert(
-		ctxt, t, net, carol, dave,
+		t, net, carol, dave,
 		lntest.OpenChannelParams{
 			Amt: chanAmt,
 		},
@@ -1066,9 +1058,8 @@ func testUpdateChannelPolicyForPrivateChannel(net *lntest.NetworkHarness,
 	const chanAmt = btcutil.Amount(100000)
 
 	// Open a channel with 100k satoshis between Alice and Bob.
-	ctxt, _ := context.WithTimeout(ctxb, channelOpenTimeout)
 	chanPointAliceBob := openChannelAndAssert(
-		ctxt, t, net, net.Alice, net.Bob,
+		t, net, net.Alice, net.Bob,
 		lntest.OpenChannelParams{
 			Amt: chanAmt,
 		},
@@ -1088,13 +1079,12 @@ func testUpdateChannelPolicyForPrivateChannel(net *lntest.NetworkHarness,
 	defer shutdownAndAssert(net, t, carol)
 
 	// Connect Carol to Bob.
-	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
+	ctxt, _ := context.WithTimeout(ctxb, defaultTimeout)
 	net.ConnectNodes(ctxt, t.t, carol, net.Bob)
 
 	// Open a channel with 100k satoshis between Bob and Carol.
-	ctxt, _ = context.WithTimeout(ctxb, channelOpenTimeout)
 	chanPointBobCarol := openChannelAndAssert(
-		ctxt, t, net, net.Bob, carol,
+		t, net, net.Bob, carol,
 		lntest.OpenChannelParams{
 			Amt:     chanAmt,
 			Private: true,
@@ -1205,9 +1195,8 @@ func testInvoiceRoutingHints(net *lntest.NetworkHarness, t *harnessTest) {
 	// throughout this test. We'll include a push amount since we currently
 	// require channels to have enough remote balance to cover the invoice's
 	// payment.
-	ctxt, _ := context.WithTimeout(ctxb, channelOpenTimeout)
 	chanPointBob := openChannelAndAssert(
-		ctxt, t, net, net.Alice, net.Bob,
+		t, net, net.Alice, net.Bob,
 		lntest.OpenChannelParams{
 			Amt:     chanAmt,
 			PushAmt: chanAmt / 2,
@@ -1221,11 +1210,10 @@ func testInvoiceRoutingHints(net *lntest.NetworkHarness, t *harnessTest) {
 	carol := net.NewNode(t.t, "Carol", nil)
 	defer shutdownAndAssert(net, t, carol)
 
-	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
+	ctxt, _ := context.WithTimeout(ctxb, defaultTimeout)
 	net.ConnectNodes(ctxt, t.t, net.Alice, carol)
-	ctxt, _ = context.WithTimeout(ctxb, channelOpenTimeout)
 	chanPointCarol := openChannelAndAssert(
-		ctxt, t, net, net.Alice, carol,
+		t, net, net.Alice, carol,
 		lntest.OpenChannelParams{
 			Amt:     chanAmt,
 			PushAmt: chanAmt / 2,
@@ -1239,9 +1227,8 @@ func testInvoiceRoutingHints(net *lntest.NetworkHarness, t *harnessTest) {
 	// that wish to stay unadvertised.
 	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
 	net.ConnectNodes(ctxt, t.t, net.Bob, carol)
-	ctxt, _ = context.WithTimeout(ctxb, channelOpenTimeout)
 	chanPointBobCarol := openChannelAndAssert(
-		ctxt, t, net, net.Bob, carol,
+		t, net, net.Bob, carol,
 		lntest.OpenChannelParams{
 			Amt:     chanAmt,
 			PushAmt: chanAmt / 2,
@@ -1257,9 +1244,8 @@ func testInvoiceRoutingHints(net *lntest.NetworkHarness, t *harnessTest) {
 
 	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
 	net.ConnectNodes(ctxt, t.t, net.Alice, dave)
-	ctxt, _ = context.WithTimeout(ctxb, channelOpenTimeout)
 	chanPointDave := openChannelAndAssert(
-		ctxt, t, net, net.Alice, dave,
+		t, net, net.Alice, dave,
 		lntest.OpenChannelParams{
 			Amt:     chanAmt,
 			Private: true,
@@ -1273,9 +1259,8 @@ func testInvoiceRoutingHints(net *lntest.NetworkHarness, t *harnessTest) {
 	eve := net.NewNode(t.t, "Eve", nil)
 	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
 	net.ConnectNodes(ctxt, t.t, net.Alice, eve)
-	ctxt, _ = context.WithTimeout(ctxb, channelOpenTimeout)
 	chanPointEve := openChannelAndAssert(
-		ctxt, t, net, net.Alice, eve,
+		t, net, net.Alice, eve,
 		lntest.OpenChannelParams{
 			Amt:     chanAmt,
 			PushAmt: chanAmt / 2,
@@ -1406,16 +1391,15 @@ func testMultiHopOverPrivateChannels(net *lntest.NetworkHarness, t *harnessTest)
 
 	// First, we'll open a private channel between Alice and Bob with Alice
 	// being the funder.
-	ctxt, _ := context.WithTimeout(ctxb, channelOpenTimeout)
 	chanPointAlice := openChannelAndAssert(
-		ctxt, t, net, net.Alice, net.Bob,
+		t, net, net.Alice, net.Bob,
 		lntest.OpenChannelParams{
 			Amt:     chanAmt,
 			Private: true,
 		},
 	)
 
-	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
+	ctxt, _ := context.WithTimeout(ctxb, defaultTimeout)
 	err := net.Alice.WaitForNetworkChannelOpen(ctxt, chanPointAlice)
 	if err != nil {
 		t.Fatalf("alice didn't see the channel alice <-> bob before "+
@@ -1445,9 +1429,8 @@ func testMultiHopOverPrivateChannels(net *lntest.NetworkHarness, t *harnessTest)
 
 	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
 	net.ConnectNodes(ctxt, t.t, net.Bob, carol)
-	ctxt, _ = context.WithTimeout(ctxb, channelOpenTimeout)
 	chanPointBob := openChannelAndAssert(
-		ctxt, t, net, net.Bob, carol,
+		t, net, net.Bob, carol,
 		lntest.OpenChannelParams{
 			Amt: chanAmt,
 		},
@@ -1492,9 +1475,8 @@ func testMultiHopOverPrivateChannels(net *lntest.NetworkHarness, t *harnessTest)
 	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
 	net.SendCoins(ctxt, t.t, btcutil.SatoshiPerBitcoin, carol)
 
-	ctxt, _ = context.WithTimeout(ctxb, channelOpenTimeout)
 	chanPointCarol := openChannelAndAssert(
-		ctxt, t, net, carol, dave,
+		t, net, carol, dave,
 		lntest.OpenChannelParams{
 			Amt:     chanAmt,
 			Private: true,
@@ -1612,9 +1594,8 @@ func testQueryRoutes(net *lntest.NetworkHarness, t *harnessTest) {
 	var networkChans []*lnrpc.ChannelPoint
 
 	// Open a channel between Alice and Bob.
-	ctxt, _ := context.WithTimeout(ctxb, channelOpenTimeout)
 	chanPointAlice := openChannelAndAssert(
-		ctxt, t, net, net.Alice, net.Bob,
+		t, net, net.Alice, net.Bob,
 		lntest.OpenChannelParams{
 			Amt: chanAmt,
 		},
@@ -1625,14 +1606,13 @@ func testQueryRoutes(net *lntest.NetworkHarness, t *harnessTest) {
 	carol := net.NewNode(t.t, "Carol", nil)
 	defer shutdownAndAssert(net, t, carol)
 
-	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
+	ctxt, _ := context.WithTimeout(ctxb, defaultTimeout)
 	net.ConnectNodes(ctxt, t.t, carol, net.Bob)
 	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
 	net.SendCoins(ctxt, t.t, btcutil.SatoshiPerBitcoin, net.Bob)
 
-	ctxt, _ = context.WithTimeout(ctxb, channelOpenTimeout)
 	chanPointBob := openChannelAndAssert(
-		ctxt, t, net, net.Bob, carol,
+		t, net, net.Bob, carol,
 		lntest.OpenChannelParams{
 			Amt: chanAmt,
 		},
@@ -1648,9 +1628,8 @@ func testQueryRoutes(net *lntest.NetworkHarness, t *harnessTest) {
 	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
 	net.SendCoins(ctxt, t.t, btcutil.SatoshiPerBitcoin, carol)
 
-	ctxt, _ = context.WithTimeout(ctxb, channelOpenTimeout)
 	chanPointCarol := openChannelAndAssert(
-		ctxt, t, net, carol, dave,
+		t, net, carol, dave,
 		lntest.OpenChannelParams{
 			Amt: chanAmt,
 		},
@@ -1904,9 +1883,8 @@ func testRouteFeeCutoff(net *lntest.NetworkHarness, t *harnessTest) {
 	const chanAmt = btcutil.Amount(100000)
 
 	// Open a channel between Alice and Bob.
-	ctxt, _ := context.WithTimeout(ctxb, channelOpenTimeout)
 	chanPointAliceBob := openChannelAndAssert(
-		ctxt, t, net, net.Alice, net.Bob,
+		t, net, net.Alice, net.Bob,
 		lntest.OpenChannelParams{
 			Amt: chanAmt,
 		},
@@ -1917,14 +1895,13 @@ func testRouteFeeCutoff(net *lntest.NetworkHarness, t *harnessTest) {
 	carol := net.NewNode(t.t, "Carol", nil)
 	defer shutdownAndAssert(net, t, carol)
 
-	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
+	ctxt, _ := context.WithTimeout(ctxb, defaultTimeout)
 	net.ConnectNodes(ctxt, t.t, carol, net.Alice)
 	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
 	net.SendCoins(ctxt, t.t, btcutil.SatoshiPerBitcoin, carol)
 
-	ctxt, _ = context.WithTimeout(ctxb, channelOpenTimeout)
 	chanPointAliceCarol := openChannelAndAssert(
-		ctxt, t, net, net.Alice, carol,
+		t, net, net.Alice, carol,
 		lntest.OpenChannelParams{
 			Amt: chanAmt,
 		},
@@ -1937,9 +1914,8 @@ func testRouteFeeCutoff(net *lntest.NetworkHarness, t *harnessTest) {
 
 	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
 	net.ConnectNodes(ctxt, t.t, dave, net.Bob)
-	ctxt, _ = context.WithTimeout(ctxb, channelOpenTimeout)
 	chanPointBobDave := openChannelAndAssert(
-		ctxt, t, net, net.Bob, dave,
+		t, net, net.Bob, dave,
 		lntest.OpenChannelParams{
 			Amt: chanAmt,
 		},
@@ -1948,9 +1924,8 @@ func testRouteFeeCutoff(net *lntest.NetworkHarness, t *harnessTest) {
 	// Open a channel between Carol and Dave.
 	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
 	net.ConnectNodes(ctxt, t.t, carol, dave)
-	ctxt, _ = context.WithTimeout(ctxb, channelOpenTimeout)
 	chanPointCarolDave := openChannelAndAssert(
-		ctxt, t, net, carol, dave,
+		t, net, carol, dave,
 		lntest.OpenChannelParams{
 			Amt: chanAmt,
 		},

--- a/lntest/itest/lnd_routing_test.go
+++ b/lntest/itest/lnd_routing_test.go
@@ -884,10 +884,7 @@ func testPrivateChannels(net *lntest.NetworkHarness, t *harnessTest) {
 	time.Sleep(time.Millisecond * 50)
 
 	// Let Carol pay the invoices.
-	ctxt, _ := context.WithTimeout(ctxb, defaultTimeout)
-	err = completePaymentRequests(
-		ctxt, carol, carol.RouterClient, payReqs, true,
-	)
+	err = completePaymentRequests(carol, carol.RouterClient, payReqs, true)
 	if err != nil {
 		t.Fatalf("unable to send payments: %v", err)
 	}
@@ -942,9 +939,8 @@ func testPrivateChannels(net *lntest.NetworkHarness, t *harnessTest) {
 	time.Sleep(time.Millisecond * 50)
 
 	// Let Bob pay the invoices.
-	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
 	err = completePaymentRequests(
-		ctxt, net.Alice, net.Alice.RouterClient, payReqs, true,
+		net.Alice, net.Alice.RouterClient, payReqs, true,
 	)
 	if err != nil {
 		t.Fatalf("unable to send payments: %v", err)
@@ -1115,11 +1111,10 @@ func testUpdateChannelPolicyForPrivateChannel(net *lntest.NetworkHarness,
 
 	// Alice pays the invoices. She will use the updated baseFeeMSat in the
 	// payment
-	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
 	payReqs := []string{resp.PaymentRequest}
 	require.NoError(t.t,
 		completePaymentRequests(
-			ctxt, net.Alice, net.Alice.RouterClient, payReqs, true,
+			net.Alice, net.Alice.RouterClient, payReqs, true,
 		), "unable to send payment",
 	)
 
@@ -1510,9 +1505,8 @@ func testMultiHopOverPrivateChannels(net *lntest.NetworkHarness, t *harnessTest)
 
 	// Let Alice pay the invoice.
 	payReqs := []string{resp.PaymentRequest}
-	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
 	err = completePaymentRequests(
-		ctxt, net.Alice, net.Alice.RouterClient, payReqs, true,
+		net.Alice, net.Alice.RouterClient, payReqs, true,
 	)
 	if err != nil {
 		t.Fatalf("unable to send payments from alice to dave: %v", err)

--- a/lntest/itest/lnd_routing_test.go
+++ b/lntest/itest/lnd_routing_test.go
@@ -840,8 +840,7 @@ func testPrivateChannels(net *lntest.NetworkHarness, t *harnessTest) {
 	// nodes have defaultNumConfs=1 set.
 	block := mineBlocks(t, net, 1, 1)[0]
 
-	ctxt, _ := context.WithTimeout(ctxb, defaultTimeout)
-	chanPointPrivate, err := net.WaitForChannelOpen(ctxt, chanOpenUpdate)
+	chanPointPrivate, err := net.WaitForChannelOpen(chanOpenUpdate)
 	if err != nil {
 		t.Fatalf("error while waiting for channel open: %v", err)
 	}
@@ -857,7 +856,7 @@ func testPrivateChannels(net *lntest.NetworkHarness, t *harnessTest) {
 		Hash:  *fundingTxID,
 		Index: chanPointPrivate.OutputIndex,
 	}
-	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
+	ctxt, _ := context.WithTimeout(ctxb, defaultTimeout)
 	err = net.AssertChannelExists(ctxt, carol, &privateFundPoint)
 	if err != nil {
 		t.Fatalf("unable to assert channel existence: %v", err)

--- a/lntest/itest/lnd_routing_test.go
+++ b/lntest/itest/lnd_routing_test.go
@@ -104,8 +104,7 @@ func testSingleHopSendToRouteCase(net *lntest.NetworkHarness, t *harnessTest,
 	defer shutdownAndAssert(net, t, dave)
 
 	net.ConnectNodes(t.t, carol, dave)
-	ctxt, _ := context.WithTimeout(ctxb, defaultTimeout)
-	net.SendCoins(ctxt, t.t, btcutil.SatoshiPerBitcoin, carol)
+	net.SendCoins(t.t, btcutil.SatoshiPerBitcoin, carol)
 
 	// Open a channel with 100k satoshis between Carol and Dave with Carol
 	// being the sole funder of the channel.
@@ -139,7 +138,7 @@ func testSingleHopSendToRouteCase(net *lntest.NetworkHarness, t *harnessTest,
 				Index: chanPoint.OutputIndex,
 			}
 
-			ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
+			ctxt, _ := context.WithTimeout(ctxb, defaultTimeout)
 			err = node.WaitForNetworkChannelOpen(ctxt, chanPoint)
 			if err != nil {
 				t.Fatalf("%s(%d): timeout waiting for "+
@@ -467,8 +466,7 @@ func testMultiHopSendToRoute(net *lntest.NetworkHarness, t *harnessTest) {
 	defer shutdownAndAssert(net, t, carol)
 
 	net.ConnectNodes(t.t, carol, net.Bob)
-	ctxt, _ := context.WithTimeout(ctxb, defaultTimeout)
-	net.SendCoins(ctxt, t.t, btcutil.SatoshiPerBitcoin, net.Bob)
+	net.SendCoins(t.t, btcutil.SatoshiPerBitcoin, net.Bob)
 
 	chanPointBob := openChannelAndAssert(
 		t, net, net.Bob, carol,
@@ -500,7 +498,7 @@ func testMultiHopSendToRoute(net *lntest.NetworkHarness, t *harnessTest) {
 				Index: chanPoint.OutputIndex,
 			}
 
-			ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
+			ctxt, _ := context.WithTimeout(ctxb, defaultTimeout)
 			err = node.WaitForNetworkChannelOpen(ctxt, chanPoint)
 			if err != nil {
 				t.Fatalf("%s(%d): timeout waiting for "+
@@ -532,7 +530,7 @@ func testMultiHopSendToRoute(net *lntest.NetworkHarness, t *harnessTest) {
 		Amt:            paymentAmt,
 		FinalCltvDelta: chainreg.DefaultBitcoinTimeLockDelta,
 	}
-	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
+	ctxt, _ := context.WithTimeout(ctxb, defaultTimeout)
 	routes, err := net.Alice.QueryRoutes(ctxt, routesReq)
 	if err != nil {
 		t.Fatalf("unable to get route: %v", err)
@@ -636,14 +634,12 @@ func testSendToRouteErrorPropagation(net *lntest.NetworkHarness, t *harnessTest)
 	carol := net.NewNode(t.t, "Carol", nil)
 	defer shutdownAndAssert(net, t, carol)
 
-	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
-	net.SendCoins(ctxt, t.t, btcutil.SatoshiPerBitcoin, carol)
+	net.SendCoins(t.t, btcutil.SatoshiPerBitcoin, carol)
 
 	charlie := net.NewNode(t.t, "Charlie", nil)
 	defer shutdownAndAssert(net, t, charlie)
 
-	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
-	net.SendCoins(ctxt, t.t, btcutil.SatoshiPerBitcoin, charlie)
+	net.SendCoins(t.t, btcutil.SatoshiPerBitcoin, charlie)
 
 	net.ConnectNodes(t.t, carol, charlie)
 
@@ -759,8 +755,7 @@ func testPrivateChannels(net *lntest.NetworkHarness, t *harnessTest) {
 	defer shutdownAndAssert(net, t, dave)
 
 	net.ConnectNodes(t.t, dave, net.Alice)
-	ctxt, _ := context.WithTimeout(ctxb, defaultTimeout)
-	net.SendCoins(ctxt, t.t, btcutil.SatoshiPerBitcoin, dave)
+	net.SendCoins(t.t, btcutil.SatoshiPerBitcoin, dave)
 
 	chanPointDave := openChannelAndAssert(
 		t, net, dave, net.Alice,
@@ -784,8 +779,7 @@ func testPrivateChannels(net *lntest.NetworkHarness, t *harnessTest) {
 	defer shutdownAndAssert(net, t, carol)
 
 	net.ConnectNodes(t.t, carol, dave)
-	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
-	net.SendCoins(ctxt, t.t, btcutil.SatoshiPerBitcoin, carol)
+	net.SendCoins(t.t, btcutil.SatoshiPerBitcoin, carol)
 
 	chanPointCarol := openChannelAndAssert(
 		t, net, carol, dave,
@@ -819,7 +813,7 @@ func testPrivateChannels(net *lntest.NetworkHarness, t *harnessTest) {
 				Index: chanPoint.OutputIndex,
 			}
 
-			ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
+			ctxt, _ := context.WithTimeout(ctxb, defaultTimeout)
 			err = node.WaitForNetworkChannelOpen(ctxt, chanPoint)
 			if err != nil {
 				t.Fatalf("%s(%d): timeout waiting for "+
@@ -831,7 +825,7 @@ func testPrivateChannels(net *lntest.NetworkHarness, t *harnessTest) {
 	// Now create a _private_ channel directly between Carol and
 	// Alice of 100k.
 	net.ConnectNodes(t.t, carol, net.Alice)
-	ctxt, _ = context.WithTimeout(ctxb, channelOpenTimeout)
+	ctxt, _ := context.WithTimeout(ctxb, channelOpenTimeout)
 	chanOpenUpdate := openChannelStream(
 		ctxt, t, net, carol, net.Alice,
 		lntest.OpenChannelParams{
@@ -1459,8 +1453,7 @@ func testMultiHopOverPrivateChannels(net *lntest.NetworkHarness, t *harnessTest)
 	defer shutdownAndAssert(net, t, dave)
 
 	net.ConnectNodes(t.t, carol, dave)
-	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
-	net.SendCoins(ctxt, t.t, btcutil.SatoshiPerBitcoin, carol)
+	net.SendCoins(t.t, btcutil.SatoshiPerBitcoin, carol)
 
 	chanPointCarol := openChannelAndAssert(
 		t, net, carol, dave,
@@ -1594,8 +1587,7 @@ func testQueryRoutes(net *lntest.NetworkHarness, t *harnessTest) {
 	defer shutdownAndAssert(net, t, carol)
 
 	net.ConnectNodes(t.t, carol, net.Bob)
-	ctxt, _ := context.WithTimeout(ctxb, defaultTimeout)
-	net.SendCoins(ctxt, t.t, btcutil.SatoshiPerBitcoin, net.Bob)
+	net.SendCoins(t.t, btcutil.SatoshiPerBitcoin, net.Bob)
 
 	chanPointBob := openChannelAndAssert(
 		t, net, net.Bob, carol,
@@ -1610,8 +1602,7 @@ func testQueryRoutes(net *lntest.NetworkHarness, t *harnessTest) {
 	defer shutdownAndAssert(net, t, dave)
 
 	net.ConnectNodes(t.t, dave, carol)
-	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
-	net.SendCoins(ctxt, t.t, btcutil.SatoshiPerBitcoin, carol)
+	net.SendCoins(t.t, btcutil.SatoshiPerBitcoin, carol)
 
 	chanPointCarol := openChannelAndAssert(
 		t, net, carol, dave,
@@ -1635,7 +1626,7 @@ func testQueryRoutes(net *lntest.NetworkHarness, t *harnessTest) {
 				Index: chanPoint.OutputIndex,
 			}
 
-			ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
+			ctxt, _ := context.WithTimeout(ctxb, defaultTimeout)
 			err = node.WaitForNetworkChannelOpen(ctxt, chanPoint)
 			if err != nil {
 				t.Fatalf("%s(%d): timeout waiting for "+
@@ -1651,7 +1642,7 @@ func testQueryRoutes(net *lntest.NetworkHarness, t *harnessTest) {
 		PubKey: dave.PubKeyStr,
 		Amt:    paymentAmt,
 	}
-	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
+	ctxt, _ := context.WithTimeout(ctxb, defaultTimeout)
 	routesRes, err := net.Alice.QueryRoutes(ctxt, routesReq)
 	if err != nil {
 		t.Fatalf("unable to get route: %v", err)
@@ -1881,8 +1872,7 @@ func testRouteFeeCutoff(net *lntest.NetworkHarness, t *harnessTest) {
 	defer shutdownAndAssert(net, t, carol)
 
 	net.ConnectNodes(t.t, carol, net.Alice)
-	ctxt, _ := context.WithTimeout(ctxb, defaultTimeout)
-	net.SendCoins(ctxt, t.t, btcutil.SatoshiPerBitcoin, carol)
+	net.SendCoins(t.t, btcutil.SatoshiPerBitcoin, carol)
 
 	chanPointAliceCarol := openChannelAndAssert(
 		t, net, net.Alice, carol,
@@ -1969,7 +1959,7 @@ func testRouteFeeCutoff(net *lntest.NetworkHarness, t *harnessTest) {
 			ChanPoint: chanPointCarolDave,
 		},
 	}
-	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
+	ctxt, _ := context.WithTimeout(ctxb, defaultTimeout)
 	if _, err := carol.UpdateChannelPolicy(ctxt, updateFeeReq); err != nil {
 		t.Fatalf("unable to update chan policy: %v", err)
 	}

--- a/lntest/itest/lnd_send_multi_path_payment_test.go
+++ b/lntest/itest/lnd_send_multi_path_payment_test.go
@@ -68,10 +68,8 @@ func testSendMultiPathPayment(net *lntest.NetworkHarness, t *harnessTest) {
 	rHash := rHashes[0]
 	payReq := payReqs[0]
 
-	ctxt, _ := context.WithTimeout(ctxb, defaultTimeout)
 	payment := sendAndAssertSuccess(
-		ctxt, t, ctx.alice,
-		&routerrpc.SendPaymentRequest{
+		t, ctx.alice, &routerrpc.SendPaymentRequest{
 			PaymentRequest: payReq,
 			MaxParts:       10,
 			TimeoutSeconds: 60,
@@ -106,7 +104,7 @@ func testSendMultiPathPayment(net *lntest.NetworkHarness, t *harnessTest) {
 
 	// Make sure Bob show the invoice as settled for the full
 	// amount.
-	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
+	ctxt, _ := context.WithTimeout(ctxb, defaultTimeout)
 	inv, err := ctx.bob.LookupInvoice(
 		ctxt, &lnrpc.PaymentHash{
 			RHash: rHash,

--- a/lntest/itest/lnd_single_hop_invoice_test.go
+++ b/lntest/itest/lnd_single_hop_invoice_test.go
@@ -78,7 +78,7 @@ func testSingleHopInvoice(net *lntest.NetworkHarness, t *harnessTest) {
 	payHash := &lnrpc.PaymentHash{
 		RHash: invoiceResp.RHash,
 	}
-	ctxt, _ = context.WithTimeout(ctxt, defaultTimeout)
+	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
 	dbInvoice, err := net.Bob.LookupInvoice(ctxt, payHash)
 	if err != nil {
 		t.Fatalf("unable to lookup invoice: %v", err)
@@ -105,7 +105,7 @@ func testSingleHopInvoice(net *lntest.NetworkHarness, t *harnessTest) {
 		Memo:  "test3",
 		Value: paymentAmt,
 	}
-	ctxt, _ = context.WithTimeout(ctxt, defaultTimeout)
+	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
 	invoiceResp, err = net.Bob.AddInvoice(ctxt, invoice)
 	if err != nil {
 		t.Fatalf("unable to add invoice: %v", err)
@@ -198,7 +198,7 @@ func testSingleHopInvoice(net *lntest.NetworkHarness, t *harnessTest) {
 		RouteHints: hints,
 	}
 
-	ctxt, _ = context.WithTimeout(ctxt, defaultTimeout)
+	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
 	invoiceResp, err = net.Bob.AddInvoice(ctxt, invoice)
 	if err != nil {
 		t.Fatalf("unable to add invoice: %v", err)

--- a/lntest/itest/lnd_single_hop_invoice_test.go
+++ b/lntest/itest/lnd_single_hop_invoice_test.go
@@ -23,10 +23,9 @@ func testSingleHopInvoice(net *lntest.NetworkHarness, t *harnessTest) {
 
 	// Open a channel with 100k satoshis between Alice and Bob with Alice being
 	// the sole funder of the channel.
-	ctxt, _ := context.WithTimeout(ctxb, channelOpenTimeout)
 	chanAmt := btcutil.Amount(100000)
 	chanPoint := openChannelAndAssert(
-		ctxt, t, net, net.Alice, net.Bob,
+		t, net, net.Alice, net.Bob,
 		lntest.OpenChannelParams{
 			Amt: chanAmt,
 		},
@@ -49,7 +48,7 @@ func testSingleHopInvoice(net *lntest.NetworkHarness, t *harnessTest) {
 
 	// Wait for Alice to recognize and advertise the new channel generated
 	// above.
-	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
+	ctxt, _ := context.WithTimeout(ctxb, defaultTimeout)
 	err = net.Alice.WaitForNetworkChannelOpen(ctxt, chanPoint)
 	if err != nil {
 		t.Fatalf("alice didn't advertise channel before "+

--- a/lntest/itest/lnd_single_hop_invoice_test.go
+++ b/lntest/itest/lnd_single_hop_invoice_test.go
@@ -62,10 +62,8 @@ func testSingleHopInvoice(net *lntest.NetworkHarness, t *harnessTest) {
 
 	// With the invoice for Bob added, send a payment towards Alice paying
 	// to the above generated invoice.
-	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
 	resp := sendAndAssertSuccess(
-		ctxt, t, net.Alice,
-		&routerrpc.SendPaymentRequest{
+		t, net.Alice, &routerrpc.SendPaymentRequest{
 			PaymentRequest: invoiceResp.PaymentRequest,
 			TimeoutSeconds: 60,
 			FeeLimitMsat:   noFeeLimitMsat,
@@ -115,10 +113,8 @@ func testSingleHopInvoice(net *lntest.NetworkHarness, t *harnessTest) {
 
 	// Next send another payment, but this time using a zpay32 encoded
 	// invoice rather than manually specifying the payment details.
-	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
 	sendAndAssertSuccess(
-		ctxt, t, net.Alice,
-		&routerrpc.SendPaymentRequest{
+		t, net.Alice, &routerrpc.SendPaymentRequest{
 			PaymentRequest: invoiceResp.PaymentRequest,
 			TimeoutSeconds: 60,
 			FeeLimitMsat:   noFeeLimitMsat,
@@ -139,10 +135,8 @@ func testSingleHopInvoice(net *lntest.NetworkHarness, t *harnessTest) {
 	keySendPreimage := lntypes.Preimage{3, 4, 5, 11}
 	keySendHash := keySendPreimage.Hash()
 
-	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
 	sendAndAssertSuccess(
-		ctxt, t, net.Alice,
-		&routerrpc.SendPaymentRequest{
+		t, net.Alice, &routerrpc.SendPaymentRequest{
 			Dest:           net.Bob.PubKey[:],
 			Amt:            paymentAmt,
 			FinalCltvDelta: 40,

--- a/lntest/itest/lnd_switch_test.go
+++ b/lntest/itest/lnd_switch_test.go
@@ -464,8 +464,7 @@ func testSwitchOfflineDelivery(net *lntest.NetworkHarness, t *harnessTest) {
 	}
 
 	// First, disconnect Dave and Alice so that their link is broken.
-	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
-	if err := net.DisconnectNodes(ctxt, dave, net.Alice); err != nil {
+	if err := net.DisconnectNodes(dave, net.Alice); err != nil {
 		t.Fatalf("unable to disconnect alice from dave: %v", err)
 	}
 
@@ -485,8 +484,7 @@ func testSwitchOfflineDelivery(net *lntest.NetworkHarness, t *harnessTest) {
 
 	// Now, disconnect Dave from Alice again before settling back the
 	// payment.
-	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
-	if err := net.DisconnectNodes(ctxt, dave, net.Alice); err != nil {
+	if err := net.DisconnectNodes(dave, net.Alice); err != nil {
 		t.Fatalf("unable to disconnect alice from dave: %v", err)
 	}
 

--- a/lntest/itest/lnd_switch_test.go
+++ b/lntest/itest/lnd_switch_test.go
@@ -58,8 +58,7 @@ func testSwitchCircuitPersistence(net *lntest.NetworkHarness, t *harnessTest) {
 	defer shutdownAndAssert(net, t, dave)
 
 	net.ConnectNodes(t.t, dave, net.Alice)
-	ctxt, _ := context.WithTimeout(ctxb, defaultTimeout)
-	net.SendCoins(ctxt, t.t, btcutil.SatoshiPerBitcoin, dave)
+	net.SendCoins(t.t, btcutil.SatoshiPerBitcoin, dave)
 
 	chanPointDave := openChannelAndAssert(
 		t, net, dave, net.Alice,
@@ -85,8 +84,7 @@ func testSwitchCircuitPersistence(net *lntest.NetworkHarness, t *harnessTest) {
 	defer shutdownAndAssert(net, t, carol)
 
 	net.ConnectNodes(t.t, carol, dave)
-	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
-	net.SendCoins(ctxt, t.t, btcutil.SatoshiPerBitcoin, carol)
+	net.SendCoins(t.t, btcutil.SatoshiPerBitcoin, carol)
 
 	chanPointCarol := openChannelAndAssert(
 		t, net, carol, dave,
@@ -120,7 +118,7 @@ func testSwitchCircuitPersistence(net *lntest.NetworkHarness, t *harnessTest) {
 				Index: chanPoint.OutputIndex,
 			}
 
-			ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
+			ctxt, _ := context.WithTimeout(ctxb, defaultTimeout)
 			err = node.WaitForNetworkChannelOpen(ctxt, chanPoint)
 			if err != nil {
 				t.Fatalf("%s(%d): timeout waiting for "+
@@ -143,7 +141,7 @@ func testSwitchCircuitPersistence(net *lntest.NetworkHarness, t *harnessTest) {
 
 	// We'll wait for all parties to recognize the new channels within the
 	// network.
-	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
+	ctxt, _ := context.WithTimeout(ctxb, defaultTimeout)
 	err = dave.WaitForNetworkChannelOpen(ctxt, chanPointDave)
 	if err != nil {
 		t.Fatalf("dave didn't advertise his channel: %v", err)
@@ -344,8 +342,7 @@ func testSwitchOfflineDelivery(net *lntest.NetworkHarness, t *harnessTest) {
 	defer shutdownAndAssert(net, t, dave)
 
 	net.ConnectNodes(t.t, dave, net.Alice)
-	ctxt, _ := context.WithTimeout(ctxb, defaultTimeout)
-	net.SendCoins(ctxt, t.t, btcutil.SatoshiPerBitcoin, dave)
+	net.SendCoins(t.t, btcutil.SatoshiPerBitcoin, dave)
 
 	chanPointDave := openChannelAndAssert(
 		t, net, dave, net.Alice,
@@ -371,8 +368,7 @@ func testSwitchOfflineDelivery(net *lntest.NetworkHarness, t *harnessTest) {
 	defer shutdownAndAssert(net, t, carol)
 
 	net.ConnectNodes(t.t, carol, dave)
-	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
-	net.SendCoins(ctxt, t.t, btcutil.SatoshiPerBitcoin, carol)
+	net.SendCoins(t.t, btcutil.SatoshiPerBitcoin, carol)
 
 	chanPointCarol := openChannelAndAssert(
 		t, net, carol, dave,
@@ -406,7 +402,7 @@ func testSwitchOfflineDelivery(net *lntest.NetworkHarness, t *harnessTest) {
 				Index: chanPoint.OutputIndex,
 			}
 
-			ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
+			ctxt, _ := context.WithTimeout(ctxb, defaultTimeout)
 			err = node.WaitForNetworkChannelOpen(ctxt, chanPoint)
 			if err != nil {
 				t.Fatalf("%s(%d): timeout waiting for "+
@@ -429,7 +425,7 @@ func testSwitchOfflineDelivery(net *lntest.NetworkHarness, t *harnessTest) {
 
 	// We'll wait for all parties to recognize the new channels within the
 	// network.
-	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
+	ctxt, _ := context.WithTimeout(ctxb, defaultTimeout)
 	err = dave.WaitForNetworkChannelOpen(ctxt, chanPointDave)
 	if err != nil {
 		t.Fatalf("dave didn't advertise his channel: %v", err)
@@ -656,8 +652,7 @@ func testSwitchOfflineDeliveryPersistence(net *lntest.NetworkHarness, t *harness
 	defer shutdownAndAssert(net, t, dave)
 
 	net.ConnectNodes(t.t, dave, net.Alice)
-	ctxt, _ := context.WithTimeout(ctxb, defaultTimeout)
-	net.SendCoins(ctxt, t.t, btcutil.SatoshiPerBitcoin, dave)
+	net.SendCoins(t.t, btcutil.SatoshiPerBitcoin, dave)
 
 	chanPointDave := openChannelAndAssert(
 		t, net, dave, net.Alice,
@@ -684,8 +679,7 @@ func testSwitchOfflineDeliveryPersistence(net *lntest.NetworkHarness, t *harness
 	defer shutdownAndAssert(net, t, carol)
 
 	net.ConnectNodes(t.t, carol, dave)
-	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
-	net.SendCoins(ctxt, t.t, btcutil.SatoshiPerBitcoin, carol)
+	net.SendCoins(t.t, btcutil.SatoshiPerBitcoin, carol)
 
 	chanPointCarol := openChannelAndAssert(
 		t, net, carol, dave,
@@ -719,7 +713,7 @@ func testSwitchOfflineDeliveryPersistence(net *lntest.NetworkHarness, t *harness
 				Index: chanPoint.OutputIndex,
 			}
 
-			ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
+			ctxt, _ := context.WithTimeout(ctxb, defaultTimeout)
 			err = node.WaitForNetworkChannelOpen(ctxt, chanPoint)
 			if err != nil {
 				t.Fatalf("%s(%d): timeout waiting for "+
@@ -742,7 +736,7 @@ func testSwitchOfflineDeliveryPersistence(net *lntest.NetworkHarness, t *harness
 
 	// We'll wait for all parties to recognize the new channels within the
 	// network.
-	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
+	ctxt, _ := context.WithTimeout(ctxb, defaultTimeout)
 	err = dave.WaitForNetworkChannelOpen(ctxt, chanPointDave)
 	if err != nil {
 		t.Fatalf("dave didn't advertise his channel: %v", err)
@@ -955,8 +949,7 @@ func testSwitchOfflineDeliveryOutgoingOffline(
 	defer shutdownAndAssert(net, t, dave)
 
 	net.ConnectNodes(t.t, dave, net.Alice)
-	ctxt, _ := context.WithTimeout(ctxb, defaultTimeout)
-	net.SendCoins(ctxt, t.t, btcutil.SatoshiPerBitcoin, dave)
+	net.SendCoins(t.t, btcutil.SatoshiPerBitcoin, dave)
 
 	chanPointDave := openChannelAndAssert(
 		t, net, dave, net.Alice,
@@ -980,8 +973,7 @@ func testSwitchOfflineDeliveryOutgoingOffline(
 	// intermediary hops before starting the settle.
 	carol := net.NewNode(t.t, "Carol", []string{"--hodl.exit-settle"})
 	net.ConnectNodes(t.t, carol, dave)
-	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
-	net.SendCoins(ctxt, t.t, btcutil.SatoshiPerBitcoin, carol)
+	net.SendCoins(t.t, btcutil.SatoshiPerBitcoin, carol)
 
 	chanPointCarol := openChannelAndAssert(
 		t, net, carol, dave,
@@ -1015,7 +1007,7 @@ func testSwitchOfflineDeliveryOutgoingOffline(
 				Index: chanPoint.OutputIndex,
 			}
 
-			ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
+			ctxt, _ := context.WithTimeout(ctxb, defaultTimeout)
 			err = node.WaitForNetworkChannelOpen(ctxt, chanPoint)
 			if err != nil {
 				t.Fatalf("%s(%d): timeout waiting for "+
@@ -1038,7 +1030,7 @@ func testSwitchOfflineDeliveryOutgoingOffline(
 
 	// We'll wait for all parties to recognize the new channels within the
 	// network.
-	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
+	ctxt, _ := context.WithTimeout(ctxb, defaultTimeout)
 	err = dave.WaitForNetworkChannelOpen(ctxt, chanPointDave)
 	if err != nil {
 		t.Fatalf("dave didn't advertise his channel: %v", err)

--- a/lntest/itest/lnd_switch_test.go
+++ b/lntest/itest/lnd_switch_test.go
@@ -189,11 +189,8 @@ func testSwitchCircuitPersistence(net *lntest.NetworkHarness, t *harnessTest) {
 	}
 
 	// Ensure all of the intermediate links are reconnected.
-	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
-	net.EnsureConnected(ctxt, t.t, net.Alice, dave)
-
-	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
-	net.EnsureConnected(ctxt, t.t, net.Bob, net.Alice)
+	net.EnsureConnected(t.t, net.Alice, dave)
+	net.EnsureConnected(t.t, net.Bob, net.Alice)
 
 	// Ensure all nodes in the network still have 5 outstanding htlcs.
 	err = wait.Predicate(func() bool {
@@ -211,8 +208,7 @@ func testSwitchCircuitPersistence(net *lntest.NetworkHarness, t *harnessTest) {
 		t.Fatalf("Node restart failed: %v", err)
 	}
 
-	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
-	net.EnsureConnected(ctxt, t.t, dave, carol)
+	net.EnsureConnected(t.t, dave, carol)
 
 	// After the payments settle, there should be no active htlcs on any of
 	// the nodes in the network.
@@ -523,8 +519,7 @@ func testSwitchOfflineDelivery(net *lntest.NetworkHarness, t *harnessTest) {
 
 	// Now that the settles have reached Dave, reconnect him with Alice,
 	// allowing the settles to return to the sender.
-	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
-	net.EnsureConnected(ctxt, t.t, dave, net.Alice)
+	net.EnsureConnected(t.t, dave, net.Alice)
 
 	// Wait until all outstanding htlcs in the network have been settled.
 	err = wait.Predicate(func() bool {
@@ -783,8 +778,7 @@ func testSwitchOfflineDeliveryPersistence(net *lntest.NetworkHarness, t *harness
 
 	// Make Carol and Dave are reconnected before waiting for the htlcs to
 	// clear.
-	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
-	net.EnsureConnected(ctxt, t.t, dave, carol)
+	net.EnsureConnected(t.t, dave, carol)
 
 	// Wait for Carol to report no outstanding htlcs, and also for Dav to
 	// receive all the settles from Carol.
@@ -813,8 +807,7 @@ func testSwitchOfflineDeliveryPersistence(net *lntest.NetworkHarness, t *harness
 
 	// Force Dave and Alice to reconnect before waiting for the htlcs to
 	// clear.
-	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
-	net.EnsureConnected(ctxt, t.t, dave, net.Alice)
+	net.EnsureConnected(t.t, dave, net.Alice)
 
 	// After reconnection succeeds, the settles should be propagated all
 	// the way back to the sender. All nodes should report no active htlcs.
@@ -866,8 +859,7 @@ func testSwitchOfflineDeliveryPersistence(net *lntest.NetworkHarness, t *harness
 
 	// Before completing the final payment request, ensure that the
 	// connection between Dave and Carol has been healed.
-	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
-	net.EnsureConnected(ctxt, t.t, dave, carol)
+	net.EnsureConnected(t.t, dave, carol)
 
 	// Using Carol as the source, pay to the 5 invoices from Bob created
 	// above.
@@ -1114,8 +1106,7 @@ func testSwitchOfflineDeliveryOutgoingOffline(
 
 	// Ensure that Dave is reconnected to Alice before waiting for the
 	// htlcs to clear.
-	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
-	net.EnsureConnected(ctxt, t.t, dave, net.Alice)
+	net.EnsureConnected(t.t, dave, net.Alice)
 
 	// Since Carol has been shutdown permanently, we will wait until all
 	// other nodes in the network report no active htlcs.

--- a/lntest/itest/lnd_switch_test.go
+++ b/lntest/itest/lnd_switch_test.go
@@ -57,9 +57,8 @@ func testSwitchCircuitPersistence(net *lntest.NetworkHarness, t *harnessTest) {
 	dave := net.NewNode(t.t, "Dave", nil)
 	defer shutdownAndAssert(net, t, dave)
 
+	net.ConnectNodes(t.t, dave, net.Alice)
 	ctxt, _ := context.WithTimeout(ctxb, defaultTimeout)
-	net.ConnectNodes(ctxt, t.t, dave, net.Alice)
-	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
 	net.SendCoins(ctxt, t.t, btcutil.SatoshiPerBitcoin, dave)
 
 	chanPointDave := openChannelAndAssert(
@@ -85,8 +84,7 @@ func testSwitchCircuitPersistence(net *lntest.NetworkHarness, t *harnessTest) {
 	carol := net.NewNode(t.t, "Carol", []string{"--hodl.exit-settle"})
 	defer shutdownAndAssert(net, t, carol)
 
-	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
-	net.ConnectNodes(ctxt, t.t, carol, dave)
+	net.ConnectNodes(t.t, carol, dave)
 	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
 	net.SendCoins(ctxt, t.t, btcutil.SatoshiPerBitcoin, carol)
 
@@ -345,9 +343,8 @@ func testSwitchOfflineDelivery(net *lntest.NetworkHarness, t *harnessTest) {
 	dave := net.NewNode(t.t, "Dave", nil)
 	defer shutdownAndAssert(net, t, dave)
 
+	net.ConnectNodes(t.t, dave, net.Alice)
 	ctxt, _ := context.WithTimeout(ctxb, defaultTimeout)
-	net.ConnectNodes(ctxt, t.t, dave, net.Alice)
-	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
 	net.SendCoins(ctxt, t.t, btcutil.SatoshiPerBitcoin, dave)
 
 	chanPointDave := openChannelAndAssert(
@@ -373,8 +370,7 @@ func testSwitchOfflineDelivery(net *lntest.NetworkHarness, t *harnessTest) {
 	carol := net.NewNode(t.t, "Carol", []string{"--hodl.exit-settle"})
 	defer shutdownAndAssert(net, t, carol)
 
-	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
-	net.ConnectNodes(ctxt, t.t, carol, dave)
+	net.ConnectNodes(t.t, carol, dave)
 	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
 	net.SendCoins(ctxt, t.t, btcutil.SatoshiPerBitcoin, carol)
 
@@ -482,8 +478,7 @@ func testSwitchOfflineDelivery(net *lntest.NetworkHarness, t *harnessTest) {
 	}
 
 	// Then, reconnect them to ensure Dave doesn't just fail back the htlc.
-	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
-	net.ConnectNodes(ctxt, t.t, dave, net.Alice)
+	net.ConnectNodes(t.t, dave, net.Alice)
 
 	// Wait to ensure that the payment remain are not failed back after
 	// reconnecting. All node should report the number payments initiated
@@ -660,9 +655,8 @@ func testSwitchOfflineDeliveryPersistence(net *lntest.NetworkHarness, t *harness
 	dave := net.NewNode(t.t, "Dave", nil)
 	defer shutdownAndAssert(net, t, dave)
 
+	net.ConnectNodes(t.t, dave, net.Alice)
 	ctxt, _ := context.WithTimeout(ctxb, defaultTimeout)
-	net.ConnectNodes(ctxt, t.t, dave, net.Alice)
-	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
 	net.SendCoins(ctxt, t.t, btcutil.SatoshiPerBitcoin, dave)
 
 	chanPointDave := openChannelAndAssert(
@@ -689,8 +683,7 @@ func testSwitchOfflineDeliveryPersistence(net *lntest.NetworkHarness, t *harness
 	carol := net.NewNode(t.t, "Carol", []string{"--hodl.exit-settle"})
 	defer shutdownAndAssert(net, t, carol)
 
-	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
-	net.ConnectNodes(ctxt, t.t, carol, dave)
+	net.ConnectNodes(t.t, carol, dave)
 	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
 	net.SendCoins(ctxt, t.t, btcutil.SatoshiPerBitcoin, carol)
 
@@ -961,9 +954,8 @@ func testSwitchOfflineDeliveryOutgoingOffline(
 	dave := net.NewNode(t.t, "Dave", nil)
 	defer shutdownAndAssert(net, t, dave)
 
+	net.ConnectNodes(t.t, dave, net.Alice)
 	ctxt, _ := context.WithTimeout(ctxb, defaultTimeout)
-	net.ConnectNodes(ctxt, t.t, dave, net.Alice)
-	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
 	net.SendCoins(ctxt, t.t, btcutil.SatoshiPerBitcoin, dave)
 
 	chanPointDave := openChannelAndAssert(
@@ -987,8 +979,7 @@ func testSwitchOfflineDeliveryOutgoingOffline(
 	// Dave. Carol is started in htlchodl mode so that we can disconnect the
 	// intermediary hops before starting the settle.
 	carol := net.NewNode(t.t, "Carol", []string{"--hodl.exit-settle"})
-	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
-	net.ConnectNodes(ctxt, t.t, carol, dave)
+	net.ConnectNodes(t.t, carol, dave)
 	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
 	net.SendCoins(ctxt, t.t, btcutil.SatoshiPerBitcoin, carol)
 

--- a/lntest/itest/lnd_switch_test.go
+++ b/lntest/itest/lnd_switch_test.go
@@ -157,9 +157,8 @@ func testSwitchCircuitPersistence(net *lntest.NetworkHarness, t *harnessTest) {
 
 	// Using Carol as the source, pay to the 5 invoices from Bob created
 	// above.
-	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
 	err = completePaymentRequests(
-		ctxt, net.Bob, net.Bob.RouterClient, payReqs, false,
+		net.Bob, net.Bob.RouterClient, payReqs, false,
 	)
 	if err != nil {
 		t.Fatalf("unable to send payments: %v", err)
@@ -262,9 +261,8 @@ func testSwitchCircuitPersistence(net *lntest.NetworkHarness, t *harnessTest) {
 
 	// Using Carol as the source, pay to the 5 invoices from Bob created
 	// above.
-	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
 	err = completePaymentRequests(
-		ctxt, net.Bob, net.Bob.RouterClient, payReqs, true,
+		net.Bob, net.Bob.RouterClient, payReqs, true,
 	)
 	if err != nil {
 		t.Fatalf("unable to send payments: %v", err)
@@ -445,9 +443,8 @@ func testSwitchOfflineDelivery(net *lntest.NetworkHarness, t *harnessTest) {
 
 	// Using Carol as the source, pay to the 5 invoices from Bob created
 	// above.
-	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
 	err = completePaymentRequests(
-		ctxt, net.Bob, net.Bob.RouterClient, payReqs, false,
+		net.Bob, net.Bob.RouterClient, payReqs, false,
 	)
 	if err != nil {
 		t.Fatalf("unable to send payments: %v", err)
@@ -568,9 +565,8 @@ func testSwitchOfflineDelivery(net *lntest.NetworkHarness, t *harnessTest) {
 
 	// Using Carol as the source, pay to the 5 invoices from Bob created
 	// above.
-	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
 	err = completePaymentRequests(
-		ctxt, net.Bob, net.Bob.RouterClient, payReqs, true,
+		net.Bob, net.Bob.RouterClient, payReqs, true,
 	)
 	if err != nil {
 		t.Fatalf("unable to send payments: %v", err)
@@ -743,9 +739,8 @@ func testSwitchOfflineDeliveryPersistence(net *lntest.NetworkHarness, t *harness
 
 	// Using Carol as the source, pay to the 5 invoices from Bob created
 	// above.
-	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
 	err = completePaymentRequests(
-		ctxt, net.Bob, net.Bob.RouterClient, payReqs, false,
+		net.Bob, net.Bob.RouterClient, payReqs, false,
 	)
 	if err != nil {
 		t.Fatalf("unable to send payments: %v", err)
@@ -861,9 +856,8 @@ func testSwitchOfflineDeliveryPersistence(net *lntest.NetworkHarness, t *harness
 
 	// Using Carol as the source, pay to the 5 invoices from Bob created
 	// above.
-	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
 	err = completePaymentRequests(
-		ctxt, net.Bob, net.Bob.RouterClient, payReqs, true,
+		net.Bob, net.Bob.RouterClient, payReqs, true,
 	)
 	if err != nil {
 		t.Fatalf("unable to send payments: %v", err)
@@ -1034,9 +1028,8 @@ func testSwitchOfflineDeliveryOutgoingOffline(
 
 	// Using Carol as the source, pay to the 5 invoices from Bob created
 	// above.
-	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
 	err = completePaymentRequests(
-		ctxt, net.Bob, net.Bob.RouterClient, payReqs, false,
+		net.Bob, net.Bob.RouterClient, payReqs, false,
 	)
 	if err != nil {
 		t.Fatalf("unable to send payments: %v", err)

--- a/lntest/itest/lnd_switch_test.go
+++ b/lntest/itest/lnd_switch_test.go
@@ -29,9 +29,8 @@ func testSwitchCircuitPersistence(net *lntest.NetworkHarness, t *harnessTest) {
 
 	// Open a channel with 100k satoshis between Alice and Bob with Alice
 	// being the sole funder of the channel.
-	ctxt, _ := context.WithTimeout(ctxb, channelOpenTimeout)
 	chanPointAlice := openChannelAndAssert(
-		ctxt, t, net, net.Alice, net.Bob,
+		t, net, net.Alice, net.Bob,
 		lntest.OpenChannelParams{
 			Amt:     chanAmt,
 			PushAmt: pushAmt,
@@ -58,14 +57,13 @@ func testSwitchCircuitPersistence(net *lntest.NetworkHarness, t *harnessTest) {
 	dave := net.NewNode(t.t, "Dave", nil)
 	defer shutdownAndAssert(net, t, dave)
 
-	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
+	ctxt, _ := context.WithTimeout(ctxb, defaultTimeout)
 	net.ConnectNodes(ctxt, t.t, dave, net.Alice)
 	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
 	net.SendCoins(ctxt, t.t, btcutil.SatoshiPerBitcoin, dave)
 
-	ctxt, _ = context.WithTimeout(ctxb, channelOpenTimeout)
 	chanPointDave := openChannelAndAssert(
-		ctxt, t, net, dave, net.Alice,
+		t, net, dave, net.Alice,
 		lntest.OpenChannelParams{
 			Amt:     chanAmt,
 			PushAmt: pushAmt,
@@ -92,9 +90,8 @@ func testSwitchCircuitPersistence(net *lntest.NetworkHarness, t *harnessTest) {
 	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
 	net.SendCoins(ctxt, t.t, btcutil.SatoshiPerBitcoin, carol)
 
-	ctxt, _ = context.WithTimeout(ctxb, channelOpenTimeout)
 	chanPointCarol := openChannelAndAssert(
-		ctxt, t, net, carol, dave,
+		t, net, carol, dave,
 		lntest.OpenChannelParams{
 			Amt:     chanAmt,
 			PushAmt: pushAmt,
@@ -320,9 +317,8 @@ func testSwitchOfflineDelivery(net *lntest.NetworkHarness, t *harnessTest) {
 
 	// Open a channel with 100k satoshis between Alice and Bob with Alice
 	// being the sole funder of the channel.
-	ctxt, _ := context.WithTimeout(ctxb, channelOpenTimeout)
 	chanPointAlice := openChannelAndAssert(
-		ctxt, t, net, net.Alice, net.Bob,
+		t, net, net.Alice, net.Bob,
 		lntest.OpenChannelParams{
 			Amt:     chanAmt,
 			PushAmt: pushAmt,
@@ -349,14 +345,13 @@ func testSwitchOfflineDelivery(net *lntest.NetworkHarness, t *harnessTest) {
 	dave := net.NewNode(t.t, "Dave", nil)
 	defer shutdownAndAssert(net, t, dave)
 
-	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
+	ctxt, _ := context.WithTimeout(ctxb, defaultTimeout)
 	net.ConnectNodes(ctxt, t.t, dave, net.Alice)
 	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
 	net.SendCoins(ctxt, t.t, btcutil.SatoshiPerBitcoin, dave)
 
-	ctxt, _ = context.WithTimeout(ctxb, channelOpenTimeout)
 	chanPointDave := openChannelAndAssert(
-		ctxt, t, net, dave, net.Alice,
+		t, net, dave, net.Alice,
 		lntest.OpenChannelParams{
 			Amt:     chanAmt,
 			PushAmt: pushAmt,
@@ -383,9 +378,8 @@ func testSwitchOfflineDelivery(net *lntest.NetworkHarness, t *harnessTest) {
 	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
 	net.SendCoins(ctxt, t.t, btcutil.SatoshiPerBitcoin, carol)
 
-	ctxt, _ = context.WithTimeout(ctxb, channelOpenTimeout)
 	chanPointCarol := openChannelAndAssert(
-		ctxt, t, net, carol, dave,
+		t, net, carol, dave,
 		lntest.OpenChannelParams{
 			Amt:     chanAmt,
 			PushAmt: pushAmt,
@@ -638,9 +632,8 @@ func testSwitchOfflineDeliveryPersistence(net *lntest.NetworkHarness, t *harness
 
 	// Open a channel with 100k satoshis between Alice and Bob with Alice
 	// being the sole funder of the channel.
-	ctxt, _ := context.WithTimeout(ctxb, channelOpenTimeout)
 	chanPointAlice := openChannelAndAssert(
-		ctxt, t, net, net.Alice, net.Bob,
+		t, net, net.Alice, net.Bob,
 		lntest.OpenChannelParams{
 			Amt:     chanAmt,
 			PushAmt: pushAmt,
@@ -667,14 +660,13 @@ func testSwitchOfflineDeliveryPersistence(net *lntest.NetworkHarness, t *harness
 	dave := net.NewNode(t.t, "Dave", nil)
 	defer shutdownAndAssert(net, t, dave)
 
-	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
+	ctxt, _ := context.WithTimeout(ctxb, defaultTimeout)
 	net.ConnectNodes(ctxt, t.t, dave, net.Alice)
 	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
 	net.SendCoins(ctxt, t.t, btcutil.SatoshiPerBitcoin, dave)
 
-	ctxt, _ = context.WithTimeout(ctxb, channelOpenTimeout)
 	chanPointDave := openChannelAndAssert(
-		ctxt, t, net, dave, net.Alice,
+		t, net, dave, net.Alice,
 		lntest.OpenChannelParams{
 			Amt:     chanAmt,
 			PushAmt: pushAmt,
@@ -702,9 +694,8 @@ func testSwitchOfflineDeliveryPersistence(net *lntest.NetworkHarness, t *harness
 	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
 	net.SendCoins(ctxt, t.t, btcutil.SatoshiPerBitcoin, carol)
 
-	ctxt, _ = context.WithTimeout(ctxb, channelOpenTimeout)
 	chanPointCarol := openChannelAndAssert(
-		ctxt, t, net, carol, dave,
+		t, net, carol, dave,
 		lntest.OpenChannelParams{
 			Amt:     chanAmt,
 			PushAmt: pushAmt,
@@ -942,9 +933,8 @@ func testSwitchOfflineDeliveryOutgoingOffline(
 
 	// Open a channel with 100k satoshis between Alice and Bob with Alice
 	// being the sole funder of the channel.
-	ctxt, _ := context.WithTimeout(ctxb, channelOpenTimeout)
 	chanPointAlice := openChannelAndAssert(
-		ctxt, t, net, net.Alice, net.Bob,
+		t, net, net.Alice, net.Bob,
 		lntest.OpenChannelParams{
 			Amt:     chanAmt,
 			PushAmt: pushAmt,
@@ -971,14 +961,13 @@ func testSwitchOfflineDeliveryOutgoingOffline(
 	dave := net.NewNode(t.t, "Dave", nil)
 	defer shutdownAndAssert(net, t, dave)
 
-	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
+	ctxt, _ := context.WithTimeout(ctxb, defaultTimeout)
 	net.ConnectNodes(ctxt, t.t, dave, net.Alice)
 	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
 	net.SendCoins(ctxt, t.t, btcutil.SatoshiPerBitcoin, dave)
 
-	ctxt, _ = context.WithTimeout(ctxb, channelOpenTimeout)
 	chanPointDave := openChannelAndAssert(
-		ctxt, t, net, dave, net.Alice,
+		t, net, dave, net.Alice,
 		lntest.OpenChannelParams{
 			Amt:     chanAmt,
 			PushAmt: pushAmt,
@@ -1003,9 +992,8 @@ func testSwitchOfflineDeliveryOutgoingOffline(
 	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
 	net.SendCoins(ctxt, t.t, btcutil.SatoshiPerBitcoin, carol)
 
-	ctxt, _ = context.WithTimeout(ctxb, channelOpenTimeout)
 	chanPointCarol := openChannelAndAssert(
-		ctxt, t, net, carol, dave,
+		t, net, carol, dave,
 		lntest.OpenChannelParams{
 			Amt:     chanAmt,
 			PushAmt: pushAmt,

--- a/lntest/itest/lnd_test.go
+++ b/lntest/itest/lnd_test.go
@@ -1,7 +1,6 @@
 package itest
 
 import (
-	"context"
 	"flag"
 	"fmt"
 	"os"
@@ -225,8 +224,7 @@ func TestLightningNetworkDaemon(t *testing.T) {
 			}()
 
 			lndHarness.EnsureConnected(
-				context.Background(), t1,
-				lndHarness.Alice, lndHarness.Bob,
+				t1, lndHarness.Alice, lndHarness.Bob,
 			)
 
 			logLine := fmt.Sprintf(

--- a/lntest/itest/lnd_wallet_import_test.go
+++ b/lntest/itest/lnd_wallet_import_test.go
@@ -513,10 +513,8 @@ func fundChanAndCloseFromImportedAccount(t *harnessTest, srcNode, destNode,
 	})
 	require.NoError(t.t, err)
 
-	ctxt, cancel = context.WithTimeout(ctxb, defaultTimeout)
-	defer cancel()
 	err = completePaymentRequests(
-		ctxt, srcNode, srcNode.RouterClient,
+		srcNode, srcNode.RouterClient,
 		[]string{resp.PaymentRequest}, true,
 	)
 	require.NoError(t.t, err)

--- a/lntest/itest/lnd_wallet_import_test.go
+++ b/lntest/itest/lnd_wallet_import_test.go
@@ -332,9 +332,7 @@ func fundChanAndCloseFromImportedAccount(t *harnessTest, srcNode, destNode,
 
 	// Now, start the channel funding process. We'll need to connect both
 	// nodes first.
-	ctxt, cancel = context.WithTimeout(ctxb, defaultTimeout)
-	defer cancel()
-	t.lndHarness.EnsureConnected(ctxt, t.t, srcNode, destNode)
+	t.lndHarness.EnsureConnected(t.t, srcNode, destNode)
 
 	// The source node will then fund the channel through a PSBT shim.
 	var pendingChanID [32]byte

--- a/lntest/itest/lnd_wumbo_channels_test.go
+++ b/lntest/itest/lnd_wumbo_channels_test.go
@@ -1,7 +1,6 @@
 package itest
 
 import (
-	"context"
 	"strings"
 
 	"github.com/btcsuite/btcutil"
@@ -28,7 +27,6 @@ func testWumboChannels(net *lntest.NetworkHarness, t *harnessTest) {
 
 	// We'll send coins to the wumbo node, as it'll be the one imitating
 	// the channel funding.
-	ctxb := context.Background()
 	net.SendCoins(t.t, btcutil.SatoshiPerBitcoin, wumboNode)
 
 	// Next we'll connect both nodes, then attempt to make a wumbo channel
@@ -38,7 +36,7 @@ func testWumboChannels(net *lntest.NetworkHarness, t *harnessTest) {
 
 	chanAmt := funding.MaxBtcFundingAmount + 1
 	_, err := net.OpenChannel(
-		ctxb, wumboNode, miniNode, lntest.OpenChannelParams{
+		wumboNode, miniNode, lntest.OpenChannelParams{
 			Amt: chanAmt,
 		},
 	)

--- a/lntest/itest/lnd_wumbo_channels_test.go
+++ b/lntest/itest/lnd_wumbo_channels_test.go
@@ -34,7 +34,7 @@ func testWumboChannels(net *lntest.NetworkHarness, t *harnessTest) {
 	// Next we'll connect both nodes, then attempt to make a wumbo channel
 	// funding request to the mini node we created above. The wumbo request
 	// should fail as the node isn't advertising wumbo channels.
-	net.EnsureConnected(ctxb, t.t, wumboNode, miniNode)
+	net.EnsureConnected(t.t, wumboNode, miniNode)
 
 	chanAmt := funding.MaxBtcFundingAmount + 1
 	_, err := net.OpenChannel(
@@ -61,7 +61,7 @@ func testWumboChannels(net *lntest.NetworkHarness, t *harnessTest) {
 	defer shutdownAndAssert(net, t, wumboNode2)
 
 	// Creating a wumbo channel between these two nodes should succeed.
-	net.EnsureConnected(ctxb, t.t, wumboNode, wumboNode2)
+	net.EnsureConnected(t.t, wumboNode, wumboNode2)
 	chanPoint := openChannelAndAssert(
 		t, net, wumboNode, wumboNode2,
 		lntest.OpenChannelParams{

--- a/lntest/itest/lnd_wumbo_channels_test.go
+++ b/lntest/itest/lnd_wumbo_channels_test.go
@@ -29,7 +29,7 @@ func testWumboChannels(net *lntest.NetworkHarness, t *harnessTest) {
 	// We'll send coins to the wumbo node, as it'll be the one imitating
 	// the channel funding.
 	ctxb := context.Background()
-	net.SendCoins(ctxb, t.t, btcutil.SatoshiPerBitcoin, wumboNode)
+	net.SendCoins(t.t, btcutil.SatoshiPerBitcoin, wumboNode)
 
 	// Next we'll connect both nodes, then attempt to make a wumbo channel
 	// funding request to the mini node we created above. The wumbo request

--- a/lntest/itest/lnd_wumbo_channels_test.go
+++ b/lntest/itest/lnd_wumbo_channels_test.go
@@ -63,7 +63,7 @@ func testWumboChannels(net *lntest.NetworkHarness, t *harnessTest) {
 	// Creating a wumbo channel between these two nodes should succeed.
 	net.EnsureConnected(ctxb, t.t, wumboNode, wumboNode2)
 	chanPoint := openChannelAndAssert(
-		ctxb, t, net, wumboNode, wumboNode2,
+		t, net, wumboNode, wumboNode2,
 		lntest.OpenChannelParams{
 			Amt: chanAmt,
 		},

--- a/lntest/itest/test_harness.go
+++ b/lntest/itest/test_harness.go
@@ -39,8 +39,8 @@ const (
 	defaultCSV          = lntest.DefaultCSV
 	defaultTimeout      = lntest.DefaultTimeout
 	minerMempoolTimeout = lntest.MinerMempoolTimeout
-	channelOpenTimeout  = lntest.ChannelOpenTimeout
 	channelCloseTimeout = lntest.ChannelCloseTimeout
+	channelOpenTimeout  = lntest.ChannelOpenTimeout
 	itestLndBinary      = "../../lnd-itest"
 	anchorSize          = 330
 	noFeeLimitMsat      = math.MaxInt64

--- a/lntest/itest/test_harness.go
+++ b/lntest/itest/test_harness.go
@@ -40,7 +40,6 @@ const (
 	defaultTimeout      = lntest.DefaultTimeout
 	minerMempoolTimeout = lntest.MinerMempoolTimeout
 	channelCloseTimeout = lntest.ChannelCloseTimeout
-	channelOpenTimeout  = lntest.ChannelOpenTimeout
 	itestLndBinary      = "../../lnd-itest"
 	anchorSize          = 330
 	noFeeLimitMsat      = math.MaxInt64

--- a/lntest/itest/utils.go
+++ b/lntest/itest/utils.go
@@ -190,8 +190,11 @@ func createPayReqs(node *lntest.HarnessNode, paymentAmt btcutil.Amount,
 
 // getChanInfo is a helper method for getting channel info for a node's sole
 // channel.
-func getChanInfo(ctx context.Context, node *lntest.HarnessNode) (
-	*lnrpc.Channel, error) {
+func getChanInfo(node *lntest.HarnessNode) (*lnrpc.Channel, error) {
+
+	ctxb := context.Background()
+	ctx, cancel := context.WithTimeout(ctxb, defaultTimeout)
+	defer cancel()
 
 	req := &lnrpc.ListChannelsRequest{}
 	channelInfo, err := node.ListChannels(ctx, req)
@@ -326,8 +329,12 @@ func calculateMaxHtlc(chanCap btcutil.Amount) uint64 {
 
 // waitForNodeBlockHeight queries the node for its current block height until
 // it reaches the passed height.
-func waitForNodeBlockHeight(ctx context.Context, node *lntest.HarnessNode,
-	height int32) error {
+func waitForNodeBlockHeight(node *lntest.HarnessNode, height int32) error {
+
+	ctxb := context.Background()
+	ctx, cancel := context.WithTimeout(ctxb, defaultTimeout)
+	defer cancel()
+
 	var predErr error
 	err := wait.Predicate(func() bool {
 		ctxt, _ := context.WithTimeout(ctx, defaultTimeout)
@@ -465,8 +472,12 @@ func subscribeChannelNotifications(ctxb context.Context, t *harnessTest,
 // findTxAtHeight gets all of the transactions that a node's wallet has a record
 // of at the target height, and finds and returns the tx with the target txid,
 // failing if it is not found.
-func findTxAtHeight(ctx context.Context, t *harnessTest, height int32,
+func findTxAtHeight(t *harnessTest, height int32,
 	target string, node *lntest.HarnessNode) *lnrpc.Transaction {
+
+	ctxb := context.Background()
+	ctx, cancel := context.WithTimeout(ctxb, defaultTimeout)
+	defer cancel()
 
 	txns, err := node.LightningClient.GetTransactions(
 		ctx, &lnrpc.GetTransactionsRequest{

--- a/lntest/itest/utils.go
+++ b/lntest/itest/utils.go
@@ -98,8 +98,7 @@ func completePaymentRequests(client lnrpc.LightningClient,
 	// the send before cancelling the request. We wait for the number of
 	// updates to one of our channels has increased before we return.
 	err = wait.Predicate(func() bool {
-		ctxt, _ := context.WithTimeout(ctx, defaultTimeout)
-		newListResp, err := client.ListChannels(ctxt, req)
+		newListResp, err := client.ListChannels(ctx, req)
 		if err != nil {
 			return false
 		}
@@ -337,8 +336,7 @@ func waitForNodeBlockHeight(node *lntest.HarnessNode, height int32) error {
 
 	var predErr error
 	err := wait.Predicate(func() bool {
-		ctxt, _ := context.WithTimeout(ctx, defaultTimeout)
-		info, err := node.GetInfo(ctxt, &lnrpc.GetInfoRequest{})
+		info, err := node.GetInfo(ctx, &lnrpc.GetInfoRequest{})
 		if err != nil {
 			predErr = err
 			return false


### PR DESCRIPTION
This PR is a continued work of #5616. It tries to move the context creation out of the tests. Also fix the `context canceled` flakes by properly inheriting parent context when creating a timeout context.