### PR TITLE
multi: add golang 1.17 compatible build tags

### DIFF
--- a/aezeed/cipherseed_rpctest.go
+++ b/aezeed/cipherseed_rpctest.go
@@ -1,3 +1,4 @@
+//go:build rpctest
 // +build rpctest
 
 package aezeed

--- a/breacharbiter_test.go
+++ b/breacharbiter_test.go
@@ -1,3 +1,4 @@
+//go:build !rpctest
 // +build !rpctest
 
 package lnd

--- a/build/deployment_dev.go
+++ b/build/deployment_dev.go
@@ -1,3 +1,4 @@
+//go:build dev
 // +build dev
 
 package build

--- a/build/deployment_prod.go
+++ b/build/deployment_prod.go
@@ -1,3 +1,4 @@
+//go:build !dev
 // +build !dev
 
 package build

--- a/build/log_default.go
+++ b/build/log_default.go
@@ -1,3 +1,4 @@
+//go:build !stdlog && !nolog
 // +build !stdlog,!nolog
 
 package build

--- a/build/log_nolog.go
+++ b/build/log_nolog.go
@@ -1,3 +1,4 @@
+//go:build nolog
 // +build nolog
 
 package build

--- a/build/log_stdlog.go
+++ b/build/log_stdlog.go
@@ -1,3 +1,4 @@
+//go:build stdlog
 // +build stdlog
 
 package build

--- a/build/loglevel_critical.go
+++ b/build/loglevel_critical.go
@@ -1,3 +1,4 @@
+//go:build dev && critical
 // +build dev,critical
 
 package build

--- a/build/loglevel_debug.go
+++ b/build/loglevel_debug.go
@@ -1,3 +1,4 @@
+//go:build dev && debug
 // +build dev,debug
 
 package build

--- a/build/loglevel_default.go
+++ b/build/loglevel_default.go
@@ -1,3 +1,4 @@
+//go:build !info && !debug && !trace && !warn && !error && !critical && !off
 // +build !info,!debug,!trace,!warn,!error,!critical,!off
 
 package build

--- a/build/loglevel_error.go
+++ b/build/loglevel_error.go
@@ -1,3 +1,4 @@
+//go:build dev && error
 // +build dev,error
 
 package build

--- a/build/loglevel_info.go
+++ b/build/loglevel_info.go
@@ -1,3 +1,4 @@
+//go:build dev && info
 // +build dev,info
 
 package build

--- a/build/loglevel_off.go
+++ b/build/loglevel_off.go
@@ -1,3 +1,4 @@
+//go:build dev && off
 // +build dev,off
 
 package build

--- a/build/loglevel_trace.go
+++ b/build/loglevel_trace.go
@@ -1,3 +1,4 @@
+//go:build dev && trace
 // +build dev,trace
 
 package build

--- a/build/loglevel_warn.go
+++ b/build/loglevel_warn.go
@@ -1,3 +1,4 @@
+//go:build dev && warn
 // +build dev,warn
 
 package build

--- a/chainntnfs/bitcoindnotify/bitcoind_dev.go
+++ b/chainntnfs/bitcoindnotify/bitcoind_dev.go
@@ -1,3 +1,4 @@
+//go:build dev
 // +build dev
 
 package bitcoindnotify

--- a/chainntnfs/bitcoindnotify/bitcoind_test.go
+++ b/chainntnfs/bitcoindnotify/bitcoind_test.go
@@ -1,3 +1,4 @@
+//go:build dev
 // +build dev
 
 package bitcoindnotify

--- a/chainntnfs/btcdnotify/btcd_dev.go
+++ b/chainntnfs/btcdnotify/btcd_dev.go
@@ -1,3 +1,4 @@
+//go:build dev
 // +build dev
 
 package btcdnotify

--- a/chainntnfs/btcdnotify/btcd_test.go
+++ b/chainntnfs/btcdnotify/btcd_test.go
@@ -1,3 +1,4 @@
+//go:build dev
 // +build dev
 
 package btcdnotify

--- a/chainntnfs/interface_dev.go
+++ b/chainntnfs/interface_dev.go
@@ -1,3 +1,4 @@
+//go:build dev
 // +build dev
 
 package chainntnfs

--- a/chainntnfs/neutrinonotify/neutrino_dev.go
+++ b/chainntnfs/neutrinonotify/neutrino_dev.go
@@ -1,3 +1,4 @@
+//go:build dev
 // +build dev
 
 package neutrinonotify

--- a/chainntnfs/test/bitcoind/bitcoind_test.go
+++ b/chainntnfs/test/bitcoind/bitcoind_test.go
@@ -1,3 +1,4 @@
+//go:build dev
 // +build dev
 
 package bitcoind_test

--- a/chainntnfs/test/btcd/btcd_test.go
+++ b/chainntnfs/test/btcd/btcd_test.go
@@ -1,3 +1,4 @@
+//go:build dev
 // +build dev
 
 package btcd_test

--- a/chainntnfs/test/neutrino/neutrino_test.go
+++ b/chainntnfs/test/neutrino/neutrino_test.go
@@ -1,3 +1,4 @@
+//go:build dev
 // +build dev
 
 package neutrino_test

--- a/chainntnfs/test/test_interface.go
+++ b/chainntnfs/test/test_interface.go
@@ -1,3 +1,4 @@
+//go:build dev
 // +build dev
 
 package chainntnfstest

--- a/chainntnfs/test_utils.go
+++ b/chainntnfs/test_utils.go
@@ -1,3 +1,4 @@
+//go:build dev
 // +build dev
 
 package chainntnfs

--- a/cluster/etcd_elector.go
+++ b/cluster/etcd_elector.go
@@ -1,3 +1,4 @@
+//go:build kvdb_etcd
 // +build kvdb_etcd
 
 package cluster

--- a/cluster/etcd_elector_factory.go
+++ b/cluster/etcd_elector_factory.go
@@ -1,3 +1,4 @@
+//go:build kvdb_etcd
 // +build kvdb_etcd
 
 package cluster

--- a/cluster/etcd_elector_test.go
+++ b/cluster/etcd_elector_test.go
@@ -1,3 +1,4 @@
+//go:build kvdb_etcd
 // +build kvdb_etcd
 
 package cluster

--- a/cmd/lncli/autopilotrpc_active.go
+++ b/cmd/lncli/autopilotrpc_active.go
@@ -1,3 +1,4 @@
+//go:build autopilotrpc
 // +build autopilotrpc
 
 package main

--- a/cmd/lncli/autopilotrpc_default.go
+++ b/cmd/lncli/autopilotrpc_default.go
@@ -1,3 +1,4 @@
+//go:build !autopilotrpc
 // +build !autopilotrpc
 
 package main

--- a/cmd/lncli/invoicesrpc_active.go
+++ b/cmd/lncli/invoicesrpc_active.go
@@ -1,3 +1,4 @@
+//go:build invoicesrpc
 // +build invoicesrpc
 
 package main

--- a/cmd/lncli/invoicesrpc_default.go
+++ b/cmd/lncli/invoicesrpc_default.go
@@ -1,3 +1,4 @@
+//go:build !invoicesrpc
 // +build !invoicesrpc
 
 package main

--- a/cmd/lncli/walletrpc_active.go
+++ b/cmd/lncli/walletrpc_active.go
@@ -1,3 +1,4 @@
+//go:build walletrpc
 // +build walletrpc
 
 package main

--- a/cmd/lncli/walletrpc_default.go
+++ b/cmd/lncli/walletrpc_default.go
@@ -1,3 +1,4 @@
+//go:build !walletrpc
 // +build !walletrpc
 
 package main

--- a/cmd/lncli/watchtower_active.go
+++ b/cmd/lncli/watchtower_active.go
@@ -1,3 +1,4 @@
+//go:build watchtowerrpc
 // +build watchtowerrpc
 
 package main

--- a/cmd/lncli/watchtower_default.go
+++ b/cmd/lncli/watchtower_default.go
@@ -1,3 +1,4 @@
+//go:build !watchtowerrpc
 // +build !watchtowerrpc
 
 package main

--- a/funding/manager_test.go
+++ b/funding/manager_test.go
@@ -1,3 +1,4 @@
+//go:build !rpctest
 // +build !rpctest
 
 package funding

--- a/fuzz/brontide/fuzz_utils.go
+++ b/fuzz/brontide/fuzz_utils.go
@@ -1,3 +1,4 @@
+//go:build gofuzz
 // +build gofuzz
 
 package brontidefuzz

--- a/fuzz/brontide/random_actone.go
+++ b/fuzz/brontide/random_actone.go
@@ -1,3 +1,4 @@
+//go:build gofuzz
 // +build gofuzz
 
 package brontidefuzz

--- a/fuzz/brontide/random_actthree.go
+++ b/fuzz/brontide/random_actthree.go
@@ -1,3 +1,4 @@
+//go:build gofuzz
 // +build gofuzz
 
 package brontidefuzz

--- a/fuzz/brontide/random_acttwo.go
+++ b/fuzz/brontide/random_acttwo.go
@@ -1,3 +1,4 @@
+//go:build gofuzz
 // +build gofuzz
 
 package brontidefuzz

--- a/fuzz/brontide/random_init_decrypt.go
+++ b/fuzz/brontide/random_init_decrypt.go
@@ -1,3 +1,4 @@
+//go:build gofuzz
 // +build gofuzz
 
 package brontidefuzz

--- a/fuzz/brontide/random_init_enc_dec.go
+++ b/fuzz/brontide/random_init_enc_dec.go
@@ -1,3 +1,4 @@
+//go:build gofuzz
 // +build gofuzz
 
 package brontidefuzz

--- a/fuzz/brontide/random_init_encrypt.go
+++ b/fuzz/brontide/random_init_encrypt.go
@@ -1,3 +1,4 @@
+//go:build gofuzz
 // +build gofuzz
 
 package brontidefuzz

--- a/fuzz/brontide/random_resp_decrypt.go
+++ b/fuzz/brontide/random_resp_decrypt.go
@@ -1,3 +1,4 @@
+//go:build gofuzz
 // +build gofuzz
 
 package brontidefuzz

--- a/fuzz/brontide/random_resp_enc_dec.go
+++ b/fuzz/brontide/random_resp_enc_dec.go
@@ -1,3 +1,4 @@
+//go:build gofuzz
 // +build gofuzz
 
 package brontidefuzz

--- a/fuzz/brontide/random_resp_encrypt.go
+++ b/fuzz/brontide/random_resp_encrypt.go
@@ -1,3 +1,4 @@
+//go:build gofuzz
 // +build gofuzz
 
 package brontidefuzz

--- a/fuzz/brontide/static_actone.go
+++ b/fuzz/brontide/static_actone.go
@@ -1,3 +1,4 @@
+//go:build gofuzz
 // +build gofuzz
 
 package brontidefuzz

--- a/fuzz/brontide/static_actthree.go
+++ b/fuzz/brontide/static_actthree.go
@@ -1,3 +1,4 @@
+//go:build gofuzz
 // +build gofuzz
 
 package brontidefuzz

--- a/fuzz/brontide/static_acttwo.go
+++ b/fuzz/brontide/static_acttwo.go
@@ -1,3 +1,4 @@
+//go:build gofuzz
 // +build gofuzz
 
 package brontidefuzz

--- a/fuzz/brontide/static_init_decrypt.go
+++ b/fuzz/brontide/static_init_decrypt.go
@@ -1,3 +1,4 @@
+//go:build gofuzz
 // +build gofuzz
 
 package brontidefuzz

--- a/fuzz/brontide/static_init_enc_dec.go
+++ b/fuzz/brontide/static_init_enc_dec.go
@@ -1,3 +1,4 @@
+//go:build gofuzz
 // +build gofuzz
 
 package brontidefuzz

--- a/fuzz/brontide/static_init_encrypt.go
+++ b/fuzz/brontide/static_init_encrypt.go
@@ -1,3 +1,4 @@
+//go:build gofuzz
 // +build gofuzz
 
 package brontidefuzz

--- a/fuzz/brontide/static_resp_decrypt.go
+++ b/fuzz/brontide/static_resp_decrypt.go
@@ -1,3 +1,4 @@
+//go:build gofuzz
 // +build gofuzz
 
 package brontidefuzz

--- a/fuzz/brontide/static_resp_enc_dec.go
+++ b/fuzz/brontide/static_resp_enc_dec.go
@@ -1,3 +1,4 @@
+//go:build gofuzz
 // +build gofuzz
 
 package brontidefuzz

--- a/fuzz/brontide/static_resp_encrypt.go
+++ b/fuzz/brontide/static_resp_encrypt.go
@@ -1,3 +1,4 @@
+//go:build gofuzz
 // +build gofuzz
 
 package brontidefuzz

--- a/fuzz/lnwire/accept_channel.go
+++ b/fuzz/lnwire/accept_channel.go
@@ -1,3 +1,4 @@
+//go:build gofuzz
 // +build gofuzz
 
 package lnwirefuzz

--- a/fuzz/lnwire/announce_signatures.go
+++ b/fuzz/lnwire/announce_signatures.go
@@ -1,3 +1,4 @@
+//go:build gofuzz
 // +build gofuzz
 
 package lnwirefuzz

--- a/fuzz/lnwire/channel_announcement.go
+++ b/fuzz/lnwire/channel_announcement.go
@@ -1,3 +1,4 @@
+//go:build gofuzz
 // +build gofuzz
 
 package lnwirefuzz

--- a/fuzz/lnwire/channel_reestablish.go
+++ b/fuzz/lnwire/channel_reestablish.go
@@ -1,3 +1,4 @@
+//go:build gofuzz
 // +build gofuzz
 
 package lnwirefuzz

--- a/fuzz/lnwire/channel_update.go
+++ b/fuzz/lnwire/channel_update.go
@@ -1,3 +1,4 @@
+//go:build gofuzz
 // +build gofuzz
 
 package lnwirefuzz

--- a/fuzz/lnwire/closing_signed.go
+++ b/fuzz/lnwire/closing_signed.go
@@ -1,3 +1,4 @@
+//go:build gofuzz
 // +build gofuzz
 
 package lnwirefuzz

--- a/fuzz/lnwire/commit_sig.go
+++ b/fuzz/lnwire/commit_sig.go
@@ -1,3 +1,4 @@
+//go:build gofuzz
 // +build gofuzz
 
 package lnwirefuzz

--- a/fuzz/lnwire/error.go
+++ b/fuzz/lnwire/error.go
@@ -1,3 +1,4 @@
+//go:build gofuzz
 // +build gofuzz
 
 package lnwirefuzz

--- a/fuzz/lnwire/funding_created.go
+++ b/fuzz/lnwire/funding_created.go
@@ -1,3 +1,4 @@
+//go:build gofuzz
 // +build gofuzz
 
 package lnwirefuzz

--- a/fuzz/lnwire/funding_locked.go
+++ b/fuzz/lnwire/funding_locked.go
@@ -1,3 +1,4 @@
+//go:build gofuzz
 // +build gofuzz
 
 package lnwirefuzz

--- a/fuzz/lnwire/funding_signed.go
+++ b/fuzz/lnwire/funding_signed.go
@@ -1,3 +1,4 @@
+//go:build gofuzz
 // +build gofuzz
 
 package lnwirefuzz

--- a/fuzz/lnwire/fuzz_utils.go
+++ b/fuzz/lnwire/fuzz_utils.go
@@ -1,3 +1,4 @@
+//go:build gofuzz
 // +build gofuzz
 
 package lnwirefuzz

--- a/fuzz/lnwire/gossip_timestamp_range.go
+++ b/fuzz/lnwire/gossip_timestamp_range.go
@@ -1,3 +1,4 @@
+//go:build gofuzz
 // +build gofuzz
 
 package lnwirefuzz

--- a/fuzz/lnwire/init.go
+++ b/fuzz/lnwire/init.go
@@ -1,3 +1,4 @@
+//go:build gofuzz
 // +build gofuzz
 
 package lnwirefuzz

--- a/fuzz/lnwire/node_announcement.go
+++ b/fuzz/lnwire/node_announcement.go
@@ -1,3 +1,4 @@
+//go:build gofuzz
 // +build gofuzz
 
 package lnwirefuzz

--- a/fuzz/lnwire/open_channel.go
+++ b/fuzz/lnwire/open_channel.go
@@ -1,3 +1,4 @@
+//go:build gofuzz
 // +build gofuzz
 
 package lnwirefuzz

--- a/fuzz/lnwire/ping.go
+++ b/fuzz/lnwire/ping.go
@@ -1,3 +1,4 @@
+//go:build gofuzz
 // +build gofuzz
 
 package lnwirefuzz

--- a/fuzz/lnwire/pong.go
+++ b/fuzz/lnwire/pong.go
@@ -1,3 +1,4 @@
+//go:build gofuzz
 // +build gofuzz
 
 package lnwirefuzz

--- a/fuzz/lnwire/query_channel_range.go
+++ b/fuzz/lnwire/query_channel_range.go
@@ -1,3 +1,4 @@
+//go:build gofuzz
 // +build gofuzz
 
 package lnwirefuzz

--- a/fuzz/lnwire/query_short_chan_ids.go
+++ b/fuzz/lnwire/query_short_chan_ids.go
@@ -1,3 +1,4 @@
+//go:build gofuzz
 // +build gofuzz
 
 package lnwirefuzz

--- a/fuzz/lnwire/query_short_chan_ids_zlib.go
+++ b/fuzz/lnwire/query_short_chan_ids_zlib.go
@@ -1,3 +1,4 @@
+//go:build gofuzz
 // +build gofuzz
 
 package lnwirefuzz

--- a/fuzz/lnwire/reply_channel_range.go
+++ b/fuzz/lnwire/reply_channel_range.go
@@ -1,3 +1,4 @@
+//go:build gofuzz
 // +build gofuzz
 
 package lnwirefuzz

--- a/fuzz/lnwire/reply_channel_range_zlib.go
+++ b/fuzz/lnwire/reply_channel_range_zlib.go
@@ -1,3 +1,4 @@
+//go:build gofuzz
 // +build gofuzz
 
 package lnwirefuzz

--- a/fuzz/lnwire/reply_short_chan_ids_end.go
+++ b/fuzz/lnwire/reply_short_chan_ids_end.go
@@ -1,3 +1,4 @@
+//go:build gofuzz
 // +build gofuzz
 
 package lnwirefuzz

--- a/fuzz/lnwire/revoke_and_ack.go
+++ b/fuzz/lnwire/revoke_and_ack.go
@@ -1,3 +1,4 @@
+//go:build gofuzz
 // +build gofuzz
 
 package lnwirefuzz

--- a/fuzz/lnwire/shutdown.go
+++ b/fuzz/lnwire/shutdown.go
@@ -1,3 +1,4 @@
+//go:build gofuzz
 // +build gofuzz
 
 package lnwirefuzz

--- a/fuzz/lnwire/update_add_htlc.go
+++ b/fuzz/lnwire/update_add_htlc.go
@@ -1,3 +1,4 @@
+//go:build gofuzz
 // +build gofuzz
 
 package lnwirefuzz

--- a/fuzz/lnwire/update_fail_htlc.go
+++ b/fuzz/lnwire/update_fail_htlc.go
@@ -1,3 +1,4 @@
+//go:build gofuzz
 // +build gofuzz
 
 package lnwirefuzz

--- a/fuzz/lnwire/update_fail_malformed_htlc.go
+++ b/fuzz/lnwire/update_fail_malformed_htlc.go
@@ -1,3 +1,4 @@
+//go:build gofuzz
 // +build gofuzz
 
 package lnwirefuzz

--- a/fuzz/lnwire/update_fee.go
+++ b/fuzz/lnwire/update_fee.go
@@ -1,3 +1,4 @@
+//go:build gofuzz
 // +build gofuzz
 
 package lnwirefuzz

--- a/fuzz/lnwire/update_fulfill_htlc.go
+++ b/fuzz/lnwire/update_fulfill_htlc.go
@@ -1,3 +1,4 @@
+//go:build gofuzz
 // +build gofuzz
 
 package lnwirefuzz

--- a/fuzz/wtwire/create_session.go
+++ b/fuzz/wtwire/create_session.go
@@ -1,3 +1,4 @@
+//go:build gofuzz
 // +build gofuzz
 
 package wtwirefuzz

--- a/fuzz/wtwire/create_session_reply.go
+++ b/fuzz/wtwire/create_session_reply.go
@@ -1,3 +1,4 @@
+//go:build gofuzz
 // +build gofuzz
 
 package wtwirefuzz

--- a/fuzz/wtwire/delete_session.go
+++ b/fuzz/wtwire/delete_session.go
@@ -1,3 +1,4 @@
+//go:build gofuzz
 // +build gofuzz
 
 package wtwirefuzz

--- a/fuzz/wtwire/delete_session_reply.go
+++ b/fuzz/wtwire/delete_session_reply.go
@@ -1,3 +1,4 @@
+//go:build gofuzz
 // +build gofuzz
 
 package wtwirefuzz

--- a/fuzz/wtwire/error.go
+++ b/fuzz/wtwire/error.go
@@ -1,3 +1,4 @@
+//go:build gofuzz
 // +build gofuzz
 
 package wtwirefuzz

--- a/fuzz/wtwire/fuzz_utils.go
+++ b/fuzz/wtwire/fuzz_utils.go
@@ -1,3 +1,4 @@
+//go:build gofuzz
 // +build gofuzz
 
 package wtwirefuzz

--- a/fuzz/wtwire/init.go
+++ b/fuzz/wtwire/init.go
@@ -1,3 +1,4 @@
+//go:build gofuzz
 // +build gofuzz
 
 package wtwirefuzz

--- a/fuzz/wtwire/state_update.go
+++ b/fuzz/wtwire/state_update.go
@@ -1,3 +1,4 @@
+//go:build gofuzz
 // +build gofuzz
 
 package wtwirefuzz

--- a/fuzz/wtwire/state_update_reply.go
+++ b/fuzz/wtwire/state_update_reply.go
@@ -1,3 +1,4 @@
+//go:build gofuzz
 // +build gofuzz
 
 package wtwirefuzz

--- a/fuzz/zpay32/decode.go
+++ b/fuzz/zpay32/decode.go
@@ -1,3 +1,4 @@
+//go:build gofuzz
 // +build gofuzz
 
 package zpay32fuzz

--- a/fuzz/zpay32/encode.go
+++ b/fuzz/zpay32/encode.go
@@ -1,3 +1,4 @@
+//go:build gofuzz
 // +build gofuzz
 
 package zpay32fuzz

--- a/healthcheck/diskcheck.go
+++ b/healthcheck/diskcheck.go
@@ -1,3 +1,4 @@
+//go:build !windows && !solaris && !netbsd && !openbsd && !js
 // +build !windows,!solaris,!netbsd,!openbsd,!js
 
 package healthcheck

--- a/htlcswitch/hodl/config_dev.go
+++ b/htlcswitch/hodl/config_dev.go
@@ -1,3 +1,4 @@
+//go:build dev
 // +build dev
 
 package hodl

--- a/htlcswitch/hodl/config_prod.go
+++ b/htlcswitch/hodl/config_prod.go
@@ -1,3 +1,4 @@
+//go:build !dev
 // +build !dev
 
 package hodl

--- a/htlcswitch/hodl/mask_dev.go
+++ b/htlcswitch/hodl/mask_dev.go
@@ -1,3 +1,4 @@
+//go:build dev
 // +build dev
 
 package hodl

--- a/htlcswitch/hodl/mask_prod.go
+++ b/htlcswitch/hodl/mask_prod.go
@@ -1,3 +1,4 @@
+//go:build !dev
 // +build !dev
 
 package hodl

--- a/kvdb/backend.go
+++ b/kvdb/backend.go
@@ -1,3 +1,4 @@
+//go:build !js
 // +build !js
 
 package kvdb

--- a/kvdb/bolt_compact.go
+++ b/kvdb/bolt_compact.go
@@ -2,6 +2,7 @@
 // implemented in this file:
 // https://github.com/etcd-io/bbolt/blob/master/cmd/bbolt/main.go
 
+//go:build !js
 // +build !js
 
 package kvdb

--- a/kvdb/debug.go
+++ b/kvdb/debug.go
@@ -1,3 +1,4 @@
+//go:build dev
 // +build dev
 
 package kvdb

--- a/kvdb/etcd/bucket.go
+++ b/kvdb/etcd/bucket.go
@@ -1,3 +1,4 @@
+//go:build kvdb_etcd
 // +build kvdb_etcd
 
 package etcd

--- a/kvdb/etcd/commit_queue.go
+++ b/kvdb/etcd/commit_queue.go
@@ -1,3 +1,4 @@
+//go:build kvdb_etcd
 // +build kvdb_etcd
 
 package etcd

--- a/kvdb/etcd/commit_queue_test.go
+++ b/kvdb/etcd/commit_queue_test.go
@@ -1,3 +1,4 @@
+//go:build kvdb_etcd
 // +build kvdb_etcd
 
 package etcd

--- a/kvdb/etcd/db.go
+++ b/kvdb/etcd/db.go
@@ -1,3 +1,4 @@
+//go:build kvdb_etcd
 // +build kvdb_etcd
 
 package etcd

--- a/kvdb/etcd/db_test.go
+++ b/kvdb/etcd/db_test.go
@@ -1,3 +1,4 @@
+//go:build kvdb_etcd
 // +build kvdb_etcd
 
 package etcd

--- a/kvdb/etcd/debug.go
+++ b/kvdb/etcd/debug.go
@@ -1,3 +1,4 @@
+//go:build dev
 // +build dev
 
 package etcd

--- a/kvdb/etcd/driver.go
+++ b/kvdb/etcd/driver.go
@@ -1,3 +1,4 @@
+//go:build kvdb_etcd
 // +build kvdb_etcd
 
 package etcd

--- a/kvdb/etcd/driver_test.go
+++ b/kvdb/etcd/driver_test.go
@@ -1,3 +1,4 @@
+//go:build kvdb_etcd
 // +build kvdb_etcd
 
 package etcd

--- a/kvdb/etcd/embed.go
+++ b/kvdb/etcd/embed.go
@@ -1,3 +1,4 @@
+//go:build kvdb_etcd
 // +build kvdb_etcd
 
 package etcd

--- a/kvdb/etcd/fixture.go
+++ b/kvdb/etcd/fixture.go
@@ -1,3 +1,4 @@
+//go:build kvdb_etcd
 // +build kvdb_etcd
 
 package etcd

--- a/kvdb/etcd/nodebug.go
+++ b/kvdb/etcd/nodebug.go
@@ -1,3 +1,4 @@
+//go:build !dev
 // +build !dev
 
 package etcd

--- a/kvdb/etcd/readwrite_bucket.go
+++ b/kvdb/etcd/readwrite_bucket.go
@@ -1,3 +1,4 @@
+//go:build kvdb_etcd
 // +build kvdb_etcd
 
 package etcd

--- a/kvdb/etcd/readwrite_cursor.go
+++ b/kvdb/etcd/readwrite_cursor.go
@@ -1,3 +1,4 @@
+//go:build kvdb_etcd
 // +build kvdb_etcd
 
 package etcd

--- a/kvdb/etcd/readwrite_tx.go
+++ b/kvdb/etcd/readwrite_tx.go
@@ -1,3 +1,4 @@
+//go:build kvdb_etcd
 // +build kvdb_etcd
 
 package etcd

--- a/kvdb/etcd/readwrite_tx_test.go
+++ b/kvdb/etcd/readwrite_tx_test.go
@@ -1,3 +1,4 @@
+//go:build kvdb_etcd
 // +build kvdb_etcd
 
 package etcd

--- a/kvdb/etcd/stm.go
+++ b/kvdb/etcd/stm.go
@@ -1,3 +1,4 @@
+//go:build kvdb_etcd
 // +build kvdb_etcd
 
 package etcd

--- a/kvdb/etcd/stm_test.go
+++ b/kvdb/etcd/stm_test.go
@@ -1,3 +1,4 @@
+//go:build kvdb_etcd
 // +build kvdb_etcd
 
 package etcd

--- a/kvdb/etcd/walletdb_interface_test.go
+++ b/kvdb/etcd/walletdb_interface_test.go
@@ -1,3 +1,4 @@
+//go:build kvdb_etcd
 // +build kvdb_etcd
 
 package etcd

--- a/kvdb/etcd_test.go
+++ b/kvdb/etcd_test.go
@@ -1,3 +1,4 @@
+//go:build kvdb_etcd
 // +build kvdb_etcd
 
 package kvdb

--- a/kvdb/kvdb_etcd.go
+++ b/kvdb/kvdb_etcd.go
@@ -1,3 +1,4 @@
+//go:build kvdb_etcd
 // +build kvdb_etcd
 
 package kvdb

--- a/kvdb/kvdb_no_etcd.go
+++ b/kvdb/kvdb_no_etcd.go
@@ -1,3 +1,4 @@
+//go:build !kvdb_etcd
 // +build !kvdb_etcd
 
 package kvdb

--- a/kvdb/nodebug.go
+++ b/kvdb/nodebug.go
@@ -1,3 +1,4 @@
+//go:build !dev
 // +build !dev
 
 package kvdb

--- a/lncfg/address_test.go
+++ b/lncfg/address_test.go
@@ -1,3 +1,4 @@
+//go:build !rpctest
 // +build !rpctest
 
 package lncfg

--- a/lncfg/monitoring_off.go
+++ b/lncfg/monitoring_off.go
@@ -1,3 +1,4 @@
+//go:build !monitoring
 // +build !monitoring
 
 package lncfg

--- a/lncfg/monitoring_on.go
+++ b/lncfg/monitoring_on.go
@@ -1,3 +1,4 @@
+//go:build monitoring
 // +build monitoring
 
 package lncfg

--- a/lncfg/protocol.go
+++ b/lncfg/protocol.go
@@ -1,3 +1,4 @@
+//go:build !rpctest
 // +build !rpctest
 
 package lncfg

--- a/lncfg/protocol_experimental_off.go
+++ b/lncfg/protocol_experimental_off.go
@@ -1,3 +1,4 @@
+//go:build !dev
 // +build !dev
 
 package lncfg

--- a/lncfg/protocol_experimental_on.go
+++ b/lncfg/protocol_experimental_on.go
@@ -1,3 +1,4 @@
+//go:build dev
 // +build dev
 
 package lncfg

--- a/lncfg/protocol_legacy_off.go
+++ b/lncfg/protocol_legacy_off.go
@@ -1,3 +1,4 @@
+//go:build !dev
 // +build !dev
 
 package lncfg

--- a/lncfg/protocol_legacy_on.go
+++ b/lncfg/protocol_legacy_on.go
@@ -1,3 +1,4 @@
+//go:build dev
 // +build dev
 
 package lncfg

--- a/lncfg/protocol_rpctest.go
+++ b/lncfg/protocol_rpctest.go
@@ -1,3 +1,4 @@
+//go:build rpctest
 // +build rpctest
 
 package lncfg

--- a/lnrpc/autopilotrpc/autopilot_server.go
+++ b/lnrpc/autopilotrpc/autopilot_server.go
@@ -1,3 +1,4 @@
+//go:build autopilotrpc
 // +build autopilotrpc
 
 package autopilotrpc

--- a/lnrpc/autopilotrpc/config_active.go
+++ b/lnrpc/autopilotrpc/config_active.go
@@ -1,3 +1,4 @@
+//go:build autopilotrpc
 // +build autopilotrpc
 
 package autopilotrpc

--- a/lnrpc/autopilotrpc/config_default.go
+++ b/lnrpc/autopilotrpc/config_default.go
@@ -1,3 +1,4 @@
+//go:build !autopilotrpc
 // +build !autopilotrpc
 
 package autopilotrpc

--- a/lnrpc/autopilotrpc/driver.go
+++ b/lnrpc/autopilotrpc/driver.go
@@ -1,3 +1,4 @@
+//go:build autopilotrpc
 // +build autopilotrpc
 
 package autopilotrpc

--- a/lnrpc/chainrpc/chainnotifier_server.go
+++ b/lnrpc/chainrpc/chainnotifier_server.go
@@ -1,3 +1,4 @@
+//go:build chainrpc
 // +build chainrpc
 
 package chainrpc

--- a/lnrpc/chainrpc/config_active.go
+++ b/lnrpc/chainrpc/config_active.go
@@ -1,3 +1,4 @@
+//go:build chainrpc
 // +build chainrpc
 
 package chainrpc

--- a/lnrpc/chainrpc/config_default.go
+++ b/lnrpc/chainrpc/config_default.go
@@ -1,3 +1,4 @@
+//go:build !chainrpc
 // +build !chainrpc
 
 package chainrpc

--- a/lnrpc/chainrpc/driver.go
+++ b/lnrpc/chainrpc/driver.go
@@ -1,3 +1,4 @@
+//go:build chainrpc
 // +build chainrpc
 
 package chainrpc

--- a/lnrpc/invoicesrpc/config_active.go
+++ b/lnrpc/invoicesrpc/config_active.go
@@ -1,3 +1,4 @@
+//go:build invoicesrpc
 // +build invoicesrpc
 
 package invoicesrpc

--- a/lnrpc/invoicesrpc/config_default.go
+++ b/lnrpc/invoicesrpc/config_default.go
@@ -1,3 +1,4 @@
+//go:build !invoicesrpc
 // +build !invoicesrpc
 
 package invoicesrpc

--- a/lnrpc/invoicesrpc/driver.go
+++ b/lnrpc/invoicesrpc/driver.go
@@ -1,3 +1,4 @@
+//go:build invoicesrpc
 // +build invoicesrpc
 
 package invoicesrpc

--- a/lnrpc/invoicesrpc/invoices_server.go
+++ b/lnrpc/invoicesrpc/invoices_server.go
@@ -1,3 +1,4 @@
+//go:build invoicesrpc
 // +build invoicesrpc
 
 package invoicesrpc

--- a/lnrpc/signrpc/config_active.go
+++ b/lnrpc/signrpc/config_active.go
@@ -1,3 +1,4 @@
+//go:build signrpc
 // +build signrpc
 
 package signrpc

--- a/lnrpc/signrpc/config_default.go
+++ b/lnrpc/signrpc/config_default.go
@@ -1,3 +1,4 @@
+//go:build !signrpc
 // +build !signrpc
 
 package signrpc

--- a/lnrpc/signrpc/driver.go
+++ b/lnrpc/signrpc/driver.go
@@ -1,3 +1,4 @@
+//go:build signrpc
 // +build signrpc
 
 package signrpc

--- a/lnrpc/signrpc/signer_server.go
+++ b/lnrpc/signrpc/signer_server.go
@@ -1,3 +1,4 @@
+//go:build signrpc
 // +build signrpc
 
 package signrpc

--- a/lnrpc/walletrpc/config_active.go
+++ b/lnrpc/walletrpc/config_active.go
@@ -1,3 +1,4 @@
+//go:build walletrpc
 // +build walletrpc
 
 package walletrpc

--- a/lnrpc/walletrpc/config_default.go
+++ b/lnrpc/walletrpc/config_default.go
@@ -1,3 +1,4 @@
+//go:build !walletrpc
 // +build !walletrpc
 
 package walletrpc

--- a/lnrpc/walletrpc/driver.go
+++ b/lnrpc/walletrpc/driver.go
@@ -1,3 +1,4 @@
+//go:build walletrpc
 // +build walletrpc
 
 package walletrpc

--- a/lnrpc/walletrpc/psbt.go
+++ b/lnrpc/walletrpc/psbt.go
@@ -1,3 +1,4 @@
+//go:build walletrpc
 // +build walletrpc
 
 package walletrpc

--- a/lnrpc/walletrpc/walletkit_server.go
+++ b/lnrpc/walletrpc/walletkit_server.go
@@ -1,3 +1,4 @@
+//go:build walletrpc
 // +build walletrpc
 
 package walletrpc

--- a/lnrpc/watchtowerrpc/config_active.go
+++ b/lnrpc/watchtowerrpc/config_active.go
@@ -1,3 +1,4 @@
+//go:build watchtowerrpc
 // +build watchtowerrpc
 
 package watchtowerrpc

--- a/lnrpc/watchtowerrpc/config_default.go
+++ b/lnrpc/watchtowerrpc/config_default.go
@@ -1,3 +1,4 @@
+//go:build !watchtowerrpc
 // +build !watchtowerrpc
 
 package watchtowerrpc

--- a/lnrpc/watchtowerrpc/driver.go
+++ b/lnrpc/watchtowerrpc/driver.go
@@ -1,3 +1,4 @@
+//go:build watchtowerrpc
 // +build watchtowerrpc
 
 package watchtowerrpc

--- a/lnrpc/watchtowerrpc/handler.go
+++ b/lnrpc/watchtowerrpc/handler.go
@@ -1,3 +1,4 @@
+//go:build watchtowerrpc
 // +build watchtowerrpc
 
 package watchtowerrpc

--- a/lntest/bitcoind.go
+++ b/lntest/bitcoind.go
@@ -1,5 +1,5 @@
-// +build bitcoind
-// +build !notxindex
+//go:build bitcoind && !notxindex
+// +build bitcoind,!notxindex
 
 package lntest
 

--- a/lntest/bitcoind_common.go
+++ b/lntest/bitcoind_common.go
@@ -1,3 +1,4 @@
+//go:build bitcoind
 // +build bitcoind
 
 package lntest

--- a/lntest/bitcoind_notxindex.go
+++ b/lntest/bitcoind_notxindex.go
@@ -1,5 +1,5 @@
-// +build bitcoind
-// +build notxindex
+//go:build bitcoind && notxindex
+// +build bitcoind,notxindex
 
 package lntest
 

--- a/lntest/btcd.go
+++ b/lntest/btcd.go
@@ -1,3 +1,4 @@
+//go:build !bitcoind && !neutrino
 // +build !bitcoind,!neutrino
 
 package lntest

--- a/lntest/itest/lnd_etcd_failover_test.go
+++ b/lntest/itest/lnd_etcd_failover_test.go
@@ -1,3 +1,4 @@
+//go:build kvdb_etcd
 // +build kvdb_etcd
 
 package itest

--- a/lntest/itest/lnd_max_channel_size_test.go
+++ b/lntest/itest/lnd_max_channel_size_test.go
@@ -1,3 +1,4 @@
+//go:build rpctest
 // +build rpctest
 
 package itest

--- a/lntest/itest/lnd_no_etcd_dummy_failover_test.go
+++ b/lntest/itest/lnd_no_etcd_dummy_failover_test.go
@@ -1,3 +1,4 @@
+//go:build !kvdb_etcd
 // +build !kvdb_etcd
 
 package itest

--- a/lntest/itest/lnd_test_list_off_test.go
+++ b/lntest/itest/lnd_test_list_off_test.go
@@ -1,3 +1,4 @@
+//go:build !rpctest
 // +build !rpctest
 
 package itest

--- a/lntest/itest/lnd_test_list_on_test.go
+++ b/lntest/itest/lnd_test_list_on_test.go
@@ -1,3 +1,4 @@
+//go:build rpctest
 // +build rpctest
 
 package itest

--- a/lntest/neutrino.go
+++ b/lntest/neutrino.go
@@ -1,3 +1,4 @@
+//go:build neutrino
 // +build neutrino
 
 package lntest

--- a/lntest/timeouts.go
+++ b/lntest/timeouts.go
@@ -1,3 +1,4 @@
+//go:build !darwin && !kvdb_etcd
 // +build !darwin,!kvdb_etcd
 
 package lntest

--- a/lntest/timeouts_darwin.go
+++ b/lntest/timeouts_darwin.go
@@ -1,3 +1,4 @@
+//go:build darwin && !kvdb_etcd
 // +build darwin,!kvdb_etcd
 
 package lntest

--- a/lntest/timeouts_etcd.go
+++ b/lntest/timeouts_etcd.go
@@ -1,3 +1,4 @@
+//go:build kvdb_etcd
 // +build kvdb_etcd
 
 package lntest

--- a/lnwallet/btcwallet/btcwallet_rpctest.go
+++ b/lnwallet/btcwallet/btcwallet_rpctest.go
@@ -1,3 +1,4 @@
+//go:build rpctest || lowscrypt
 // +build rpctest lowscrypt
 
 package btcwallet

--- a/lnwallet/revocation_producer.go
+++ b/lnwallet/revocation_producer.go
@@ -1,3 +1,4 @@
+//go:build !rpctest
 // +build !rpctest
 
 package lnwallet

--- a/lnwallet/revocation_producer_itest.go
+++ b/lnwallet/revocation_producer_itest.go
@@ -1,3 +1,4 @@
+//go:build rpctest
 // +build rpctest
 
 package lnwallet

--- a/macaroons/security.go
+++ b/macaroons/security.go
@@ -1,3 +1,4 @@
+//go:build !rpctest
 // +build !rpctest
 
 package macaroons

--- a/macaroons/security_rpctest.go
+++ b/macaroons/security_rpctest.go
@@ -1,3 +1,4 @@
+//go:build rpctest
 // +build rpctest
 
 package macaroons

--- a/mobile/bindings.go
+++ b/mobile/bindings.go
@@ -1,3 +1,4 @@
+//go:build mobile
 // +build mobile
 
 package lndmobile

--- a/monitoring/monitoring_off.go
+++ b/monitoring/monitoring_off.go
@@ -1,3 +1,4 @@
+//go:build !monitoring
 // +build !monitoring
 
 package monitoring

--- a/monitoring/monitoring_on.go
+++ b/monitoring/monitoring_on.go
@@ -1,3 +1,4 @@
+//go:build monitoring
 // +build monitoring
 
 package monitoring

--- a/nursery_store_test.go
+++ b/nursery_store_test.go
@@ -1,3 +1,4 @@
+//go:build !rpctest
 // +build !rpctest
 
 package lnd

--- a/server_test.go
+++ b/server_test.go
@@ -1,3 +1,4 @@
+//go:build !rpctest
 // +build !rpctest
 
 package lnd

--- a/sweep/defaults.go
+++ b/sweep/defaults.go
@@ -1,3 +1,4 @@
+//go:build !rpctest
 // +build !rpctest
 
 package sweep

--- a/sweep/defaults_rpctest.go
+++ b/sweep/defaults_rpctest.go
@@ -1,3 +1,4 @@
+//go:build rpctest
 // +build rpctest
 
 package sweep

--- a/tools.go
+++ b/tools.go
@@ -1,3 +1,4 @@
+//go:build tools
 // +build tools
 
 package lnd

--- a/utxonursery_test.go
+++ b/utxonursery_test.go
@@ -1,3 +1,4 @@
+//go:build !rpctest
 // +build !rpctest
 
 package lnd


### PR DESCRIPTION
With go 1.17 a change to the build flags was implemented:
https://go.googlesource.com/proposal/+/master/design/draft-gobuild.md

The formatter now automatically adds the forward-compatible build tag
format and the linter checks for them, so we need to include them in our
code.

