### PR TITLE
lnd: use change output index from authoring TX to check reserved value

### DIFF
--- a/docs/release-notes/release-notes-0.14.0.md
+++ b/docs/release-notes/release-notes-0.14.0.md
@@ -405,6 +405,9 @@ you.
   [Lnd is updated to use the version of Neutrino containing this 
   fix](https://github.com/lightningnetwork/lnd/pull/5807).
 
+* [Use the change output index when validating the reserved wallet balance for
+  SendCoins/SendMany calls](https://github.com/lightningnetwork/lnd/pull/5665)
+
 ## Documentation 
 
 The [code contribution guidelines have been updated to mention the new


### PR DESCRIPTION
### Description

Currently a whole UTXO is reserved when anchor-channels is used. This means that if the node has a single UTXO, it cannot be spend even if a change output would leave sufficient funds for the reserve in the wallet.

This PR makes use of the returned `txauthor.AuthoredTx` struct that contains a field for an eventual change index. The reason that this is not automatically detected by the `CheckReservedValueTx` function is because the authored transaction is created in dry-run, meaning it does not add the used change output to the wallet to watch for.

This PR hence assumes that the change index from the authored transaction returned by `WalletController.CreateSimpleTx` will indeed be a change output controlled by the wallet. 

Fixes #5648 