### PR TITLE
lntest: avoid global ServeMux

### DIFF
--- a/docs/release-notes/release-notes-0.13.1.md
+++ b/docs/release-notes/release-notes-0.13.1.md
@@ -42,6 +42,10 @@ tag](https://github.com/lightningnetwork/lnd/pull/5335). A new flag
 test](https://github.com/lightningnetwork/lnd/pull/5348) that would cause the
 test to assert the wrong balance (the miner fee wasn't accounted for).
 
+A bug has been [fixed](https://github.com/lightningnetwork/lnd/pull/5674) in 
+the `lntest` package that prevented multiple test harnesses to be created from 
+the same process.
+
 ## Forwarding Optimizations
 
 [Decoding onion blobs is now done in

--- a/lntest/fee_service.go
+++ b/lntest/fee_service.go
@@ -46,11 +46,13 @@ func startFeeService() *feeService {
 	f.Fees = map[uint32]uint32{feeServiceTarget: 50000}
 
 	listenAddr := fmt.Sprintf(":%v", port)
-	f.srv = &http.Server{
-		Addr: listenAddr,
-	}
+	mux := http.NewServeMux()
+	mux.HandleFunc("/fee-estimates.json", f.handleRequest)
 
-	http.HandleFunc("/fee-estimates.json", f.handleRequest)
+	f.srv = &http.Server{
+		Addr:    listenAddr,
+		Handler: mux,
+	}
 
 	f.wg.Add(1)
 	go func() {


### PR DESCRIPTION
Using the default, global ServeMux prevents the same process from
calling `lntest.NewNetworkHarness` multiple times, because we get a
panic when registering HTTP routes.

Instead, we use the ServeMux belonging to the fee service struct.

#### Pull Request Checklist

- [x] All changes are Go version 1.15 compliant
- [ ] Your PR passes all CI checks. If a check cannot be passed for a justifiable reason, that reason must be stated in the commit message and PR description.
- [x] If this is your first time contributing, we recommend you read the [Code Contribution Guidelines](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md)
   - [x] The code being submitted is commented according to [Code Documentation and Commenting](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#CodeDocumentation)
   - [x] Commits have a logical structure according to [Ideal Git Commit Structure](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#IdealGitCommitStructure)
- [ ] For bug fixes: If possible, code is accompanied by new tests which trigger the bug being fixed to prevent regressions
I could add a new test that calls `lntest.NewNetworkHarness` twice, but that sounds like a slow/expensive test for little benefit...
- [x] Any new logging statements use an appropriate subsystem and logging level
- [x] For code and documentation: lines are wrapped at 80 characters (the tab character should be counted as 8 characters, not 4, as some IDEs do per default)
- [x] A description of your changes [should be added to running the release notes](https://github.com/lightningnetwork/lnd/tree/master/docs/release-notes) for the milestone your change will land in.
