### PR TITLE
chainnotifier: remove error logs

### DIFF
--- a/docs/release-notes/release-notes-0.14.0.md
+++ b/docs/release-notes/release-notes-0.14.0.md
@@ -150,6 +150,8 @@ you.
 
 * [Link channel point logging](https://github.com/lightningnetwork/lnd/pull/5508)
 
+* [Canceling the chain notifier no longer logs certain errors](https://github.com/lightningnetwork/lnd/pull/5676)
+
 * [Fixed context leak in integration tests, and properly handled context
   timeout](https://github.com/lightningnetwork/lnd/pull/5646).
 

--- a/lnrpc/chainrpc/chainnotifier_server.go
+++ b/lnrpc/chainrpc/chainnotifier_server.go
@@ -300,7 +300,7 @@ func (s *Server) RegisterConfirmationsNtfn(in *ConfRequest,
 			}
 
 		// The transaction satisfying the request has been reorged out
-		// of the chain, so we'll send an event describing so.
+		// of the chain, so we'll send an event describing it.
 		case _, ok := <-confEvent.NegativeConf:
 			if !ok {
 				return chainntnfs.ErrChainNotifierShuttingDown
@@ -324,9 +324,12 @@ func (s *Server) RegisterConfirmationsNtfn(in *ConfRequest,
 			return nil
 
 		// The response stream's context for whatever reason has been
-		// closed. We'll return the error indicated by the context
-		// itself to the caller.
+		// closed. If context is closed by an exceeded deadline we will
+		// return an error.
 		case <-confStream.Context().Done():
+			if errors.Is(confStream.Context().Err(), context.Canceled) {
+				return nil
+			}
 			return confStream.Context().Err()
 
 		// The server has been requested to shut down.
@@ -432,9 +435,12 @@ func (s *Server) RegisterSpendNtfn(in *SpendRequest,
 			return nil
 
 		// The response stream's context for whatever reason has been
-		// closed. We'll return the error indicated by the context
-		// itself to the caller.
+		// closed. If context is closed by an exceeded deadline we will
+		// return an error.
 		case <-spendStream.Context().Done():
+			if errors.Is(spendStream.Context().Err(), context.Canceled) {
+				return nil
+			}
 			return spendStream.Context().Err()
 
 		// The server has been requested to shut down.
@@ -503,9 +509,12 @@ func (s *Server) RegisterBlockEpochNtfn(in *BlockEpoch,
 			}
 
 		// The response stream's context for whatever reason has been
-		// closed. We'll return the error indicated by the context
-		// itself to the caller.
+		// closed. If context is closed by an exceeded deadline we will
+		// return an error.
 		case <-epochStream.Context().Done():
+			if errors.Is(epochStream.Context().Err(), context.Canceled) {
+				return nil
+			}
 			return epochStream.Context().Err()
 
 		// The server has been requested to shut down.


### PR DESCRIPTION
Fixes #4873
Removes error logs from chain notifier if context is canceled. Errors from an exceeded deadline will still be logged as before.