### PR TITLE
healthcheck: quit checking when max attempts are reached

### DIFF
--- a/chainntnfs/bitcoindnotify/bitcoind.go
+++ b/chainntnfs/bitcoindnotify/bitcoind.go
@@ -118,6 +118,8 @@ func (b *BitcoindNotifier) Stop() error {
 		return nil
 	}
 
+	chainntnfs.Log.Info("bitcoind notifier shutting down")
+
 	// Shutdown the rpc client, this gracefully disconnects from bitcoind,
 	// and cleans up all related resources.
 	b.chainConn.Stop()

--- a/chainntnfs/btcdnotify/btcd.go
+++ b/chainntnfs/btcdnotify/btcd.go
@@ -161,6 +161,8 @@ func (b *BtcdNotifier) Stop() error {
 		return nil
 	}
 
+	chainntnfs.Log.Info("btcd notifier shutting down")
+
 	// Shutdown the rpc client, this gracefully disconnects from btcd, and
 	// cleans up all related resources.
 	b.chainConn.Shutdown()

--- a/chainntnfs/neutrinonotify/neutrino.go
+++ b/chainntnfs/neutrinonotify/neutrino.go
@@ -136,6 +136,8 @@ func (n *NeutrinoNotifier) Stop() error {
 		return nil
 	}
 
+	chainntnfs.Log.Info("neutrino notifier shutting down")
+
 	close(n.quit)
 	n.wg.Wait()
 

--- a/channelnotifier/channelnotifier.go
+++ b/channelnotifier/channelnotifier.go
@@ -97,6 +97,7 @@ func (c *ChannelNotifier) Start() error {
 func (c *ChannelNotifier) Stop() error {
 	var err error
 	c.stopped.Do(func() {
+		log.Info("ChannelNotifier shutting down")
 		err = c.ntfnServer.Stop()
 	})
 	return err

--- a/contractcourt/chain_arbitrator.go
+++ b/contractcourt/chain_arbitrator.go
@@ -893,7 +893,7 @@ func (c *ChainArbitrator) Stop() error {
 		return nil
 	}
 
-	log.Infof("Stopping ChainArbitrator")
+	log.Info("ChainArbitrator shutting down")
 
 	close(c.quit)
 

--- a/discovery/gossiper.go
+++ b/discovery/gossiper.go
@@ -467,7 +467,10 @@ func (d *AuthenticatedGossiper) start() error {
 
 // Stop signals any active goroutines for a graceful closure.
 func (d *AuthenticatedGossiper) Stop() error {
-	d.stopped.Do(d.stop)
+	d.stopped.Do(func() {
+		log.Info("Authenticated gossiper shutting down")
+		d.stop()
+	})
 	return nil
 }
 

--- a/docs/release-notes/release-notes-0.14.0.md
+++ b/docs/release-notes/release-notes-0.14.0.md
@@ -292,6 +292,8 @@ mode](https://github.com/lightningnetwork/lnd/pull/5564).
 
 [Catches up on blocks in the router](https://github.com/lightningnetwork/lnd/pull/5315) in order to fix an "out of order" error that crops up.
 
+[Fix healthcheck might be running after the max number of attempts are reached.](https://github.com/lightningnetwork/lnd/pull/5686)
+
 ## Documentation 
 
 The [code contribution guidelines have been updated to mention the new

--- a/htlcswitch/hop/iterator.go
+++ b/htlcswitch/hop/iterator.go
@@ -137,6 +137,9 @@ func (p *OnionProcessor) Start() error {
 
 // Stop shutsdown the onion processor's sphinx router.
 func (p *OnionProcessor) Stop() error {
+
+	log.Info("Onion processor shutting down")
+
 	p.router.Stop()
 	return nil
 }

--- a/htlcswitch/htlcnotifier.go
+++ b/htlcswitch/htlcnotifier.go
@@ -91,6 +91,7 @@ func (h *HtlcNotifier) Start() error {
 func (h *HtlcNotifier) Stop() error {
 	var err error
 	h.stopped.Do(func() {
+		log.Info("HtlcNotifier shutting down")
 		if err = h.ntfnServer.Stop(); err != nil {
 			log.Warnf("error stopping htlc notifier: %v", err)
 		}

--- a/htlcswitch/switch.go
+++ b/htlcswitch/switch.go
@@ -1942,7 +1942,7 @@ func (s *Switch) Stop() error {
 		return errors.New("htlc switch already shutdown")
 	}
 
-	log.Infof("HTLC Switch shutting down")
+	log.Info("HTLC Switch shutting down")
 
 	close(s.quit)
 

--- a/invoices/invoiceregistry.go
+++ b/invoices/invoiceregistry.go
@@ -257,6 +257,8 @@ func (i *InvoiceRegistry) Start() error {
 
 // Stop signals the registry for a graceful shutdown.
 func (i *InvoiceRegistry) Stop() error {
+	log.Info("InvoiceRegistry shutting down")
+
 	i.expiryWatcher.Stop()
 
 	close(i.quit)

--- a/netann/chan_status_manager.go
+++ b/netann/chan_status_manager.go
@@ -217,6 +217,7 @@ func (m *ChanStatusManager) start() error {
 // Stop safely shuts down the ChanStatusManager.
 func (m *ChanStatusManager) Stop() error {
 	m.stopped.Do(func() {
+		log.Info("Channel Status Manager shutting down")
 		close(m.quit)
 		m.wg.Wait()
 	})

--- a/netann/host_ann.go
+++ b/netann/host_ann.go
@@ -68,6 +68,7 @@ func (h *HostAnnouncer) Start() error {
 // Stop signals the HostAnnouncer for a graceful stop.
 func (h *HostAnnouncer) Stop() error {
 	h.stopOnce.Do(func() {
+		log.Info("HostAnnouncer shutting down")
 		close(h.quit)
 		h.wg.Wait()
 	})

--- a/peernotifier/peernotifier.go
+++ b/peernotifier/peernotifier.go
@@ -52,7 +52,7 @@ func (p *PeerNotifier) Start() error {
 func (p *PeerNotifier) Stop() error {
 	var err error
 	p.stopped.Do(func() {
-		log.Info("Stopping PeerNotifier")
+		log.Info("PeerNotifier shutting down")
 		err = p.ntfnServer.Stop()
 	})
 	return err

--- a/routing/router.go
+++ b/routing/router.go
@@ -691,7 +691,7 @@ func (r *ChannelRouter) Stop() error {
 		return nil
 	}
 
-	log.Tracef("Channel Router shutting down")
+	log.Info("Channel Router shutting down")
 
 	// Our filtered chain view could've only been started if
 	// AssumeChannelValid isn't present.

--- a/sweep/sweeper.go
+++ b/sweep/sweeper.go
@@ -427,7 +427,7 @@ func (s *UtxoSweeper) Stop() error {
 		return nil
 	}
 
-	log.Debugf("Sweeper shutting down")
+	log.Info("Sweeper shutting down")
 
 	close(s.quit)
 	s.wg.Wait()


### PR DESCRIPTION
This is something I found while investigating #5667. When the shutdown cannot complete, the `healthcheck` will be polling the check forever even after the max attempts are reached. This PR fixes it, also adds shutdown logs for assisting debug. 