### PR TITLE
itest: fix on-chain recovery flake caused by short timeout/btcd on ARM

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -70,10 +70,13 @@ jobs:
       script:
         - make itest-parallel backend=neutrino
 
-    - name: Btcd Integration ARM
+    - name: Bitcoind Integration ARM
       script:
-        - GOARM=7 GOARCH=arm GOOS=linux make itest-parallel
+        - bash ./scripts/install_bitcoind.sh
+        - GOARM=7 GOARCH=arm GOOS=linux make itest-parallel backend=bitcoind
       arch: arm64
+      services:
+        - docker
 
     - name: Btcd Integration Windows
       script:

--- a/docs/release-notes/release-notes-0.14.0.md
+++ b/docs/release-notes/release-notes-0.14.0.md
@@ -187,6 +187,8 @@ you.
 
 * [Removed nested db tx](https://github.com/lightningnetwork/lnd/pull/5643)
 
+* [Fixed wallet recovery itests on Travis ARM](https://github.com/lightningnetwork/lnd/pull/5688)
+
 ## Database
 
 * [Ensure single writer for legacy


### PR DESCRIPTION
Attempted fix for: https://github.com/lightningnetwork/lnd/issues/5532

~Timeout flake has been appearing on Travis lately due to possible performance degradation. In the log it clearly shows that while we scan the chain while running the wallet recovery we do run out of the 30 sec default timeout window: https://termbin.com/ytdy~

Edit:
After some discussion it turned out to be a `btcd` issue so the attempted solution for this flake is to (at least temporarily) switch the ARM itest build on Travis to use `bitcoind`.