### PR TITLE
lncli: remove error logs

### DIFF
--- a/docs/release-notes/release-notes-0.14.0.md
+++ b/docs/release-notes/release-notes-0.14.0.md
@@ -175,6 +175,9 @@ you.
 
 * [Fixed timeout flakes in async payment benchmark tests](https://github.com/lightningnetwork/lnd/pull/5579).
 
+* [State, subscribechannelevents, subscribepeerevents, subscribeinvoices, subscribetransactions, 
+  subscribechannelgraph and subscribechannelbackups no longer logs certain errors](https://github.com/lightningnetwork/lnd/pull/5695).
+
 * [Flake fix in async bidirectional payment test](https://github.com/lightningnetwork/lnd/pull/5607).
 
 * [Fixed context timeout when closing channels in tests](https://github.com/lightningnetwork/lnd/pull/5616).

--- a/rpcperms/interceptor.go
+++ b/rpcperms/interceptor.go
@@ -2,6 +2,7 @@ package rpcperms
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sync"
 
@@ -272,7 +273,13 @@ func (r *InterceptorChain) SubscribeState(req *lnrpc.SubscribeStateRequest,
 				return err
 			}
 
+		// The response stream's context for whatever reason has been
+		// closed. If context is closed by an exceeded deadline we will
+		// return an error.
 		case <-stream.Context().Done():
+			if errors.Is(stream.Context().Err(), context.Canceled) {
+				return nil
+			}
 			return stream.Context().Err()
 
 		case <-r.quit:

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -2920,7 +2920,13 @@ func (r *rpcServer) SubscribePeerEvents(req *lnrpc.PeerEventSubscription,
 				return err
 			}
 
+		// The response stream's context for whatever reason has been
+		// closed. If context is closed by an exceeded deadline we will
+		// return an error.
 		case <-eventStream.Context().Done():
+			if errors.Is(eventStream.Context().Err(), context.Canceled) {
+				return nil
+			}
 			return eventStream.Context().Err()
 
 		case <-r.quit:
@@ -4210,7 +4216,13 @@ func (r *rpcServer) SubscribeChannelEvents(req *lnrpc.ChannelEventSubscription,
 				return err
 			}
 
+		// The response stream's context for whatever reason has been
+		// closed. If context is closed by an exceeded deadline we will
+		// return an error.
 		case <-updateStream.Context().Done():
+			if errors.Is(updateStream.Context().Err(), context.Canceled) {
+				return nil
+			}
 			return updateStream.Context().Err()
 
 		case <-r.quit:
@@ -5158,7 +5170,13 @@ func (r *rpcServer) SubscribeInvoices(req *lnrpc.InvoiceSubscription,
 				return err
 			}
 
+		// The response stream's context for whatever reason has been
+		// closed. If context is closed by an exceeded deadline we will
+		// return an error.
 		case <-updateStream.Context().Done():
+			if errors.Is(updateStream.Context().Err(), context.Canceled) {
+				return nil
+			}
 			return updateStream.Context().Err()
 
 		case <-r.quit:
@@ -5219,8 +5237,14 @@ func (r *rpcServer) SubscribeTransactions(req *lnrpc.GetTransactionsRequest,
 				return err
 			}
 
+		// The response stream's context for whatever reason has been
+		// closed. If context is closed by an exceeded deadline we will
+		// return an error.
 		case <-updateStream.Context().Done():
-			rpcsLog.Infof("Cancelling transaction subscription")
+			rpcsLog.Infof("Canceling transaction subscription")
+			if errors.Is(updateStream.Context().Err(), context.Canceled) {
+				return nil
+			}
 			return updateStream.Context().Err()
 
 		case <-r.quit:
@@ -5761,9 +5785,13 @@ func (r *rpcServer) SubscribeChannelGraph(req *lnrpc.GraphTopologySubscription,
 				return err
 			}
 
-		// The context was cancelled so we report a cancellation error
-		// and exit immediately.
+		// The response stream's context for whatever reason has been
+		// closed. If context is closed by an exceeded deadline
+		// we will return an error.
 		case <-updateStream.Context().Done():
+			if errors.Is(updateStream.Context().Err(), context.Canceled) {
+				return nil
+			}
 			return updateStream.Context().Err()
 
 		// The server is quitting, so we'll exit immediately. Returning
@@ -6688,7 +6716,13 @@ func (r *rpcServer) SubscribeChannelBackups(req *lnrpc.ChannelBackupSubscription
 				return err
 			}
 
+		// The response stream's context for whatever reason has been
+		// closed. If context is closed by an exceeded deadline we will
+		// return an error.
 		case <-updateStream.Context().Done():
+			if errors.Is(updateStream.Context().Err(), context.Canceled) {
+				return nil
+			}
 			return updateStream.Context().Err()
 
 		case <-r.quit:


### PR DESCRIPTION
Fixes #5694.
This PR removes error logs from the state command, subscribechannelevents, subscribepeerevents, subscribeinvoices, subscribetransactions,  subscribechannelgraph and subscribechannelbackups if context is canceled. Errors from an exceeded deadline will still be logged as before.