### PR TITLE
invoicesrpc: expose selectHopHints

### DIFF
--- a/docs/release-notes/release-notes-0.14.0.md
+++ b/docs/release-notes/release-notes-0.14.0.md
@@ -152,6 +152,10 @@ you.
   into projects that are compiled to WASM binaries. [That problem was fixed by
   guarding those syscalls with build tags](https://github.com/lightningnetwork/lnd/pull/5526).
 
+* The only way to retrieve hophints for a given node was to create an invoice
+  with the `addInvoice` rpc interface. However, now the function has been
+  [exposed in the go package `invoicesrpc`](https://github.com/lightningnetwork/lnd/pull/5697).
+
 ## Code Health
 
 ### Code cleanup, refactor, typo fixes
@@ -256,6 +260,7 @@ change](https://github.com/lightningnetwork/lnd/pull/5613).
 * de6df1re
 * ErikEk
 * Eugene Siegel
+* Harsha Goli
 * Martin Habovstiak
 * Oliver Gugger
 * Wilmer Paulino

--- a/lnrpc/invoicesrpc/addinvoice.go
+++ b/lnrpc/invoicesrpc/addinvoice.go
@@ -391,7 +391,7 @@ func AddInvoice(ctx context.Context, cfg *AddInvoiceConfig,
 			// We'll restrict the number of individual route hints
 			// to 20 to avoid creating overly large invoices.
 			numMaxHophints := 20 - len(forcedHints)
-			hopHints := selectHopHints(
+			hopHints := SelectHopHints(
 				amtMSat, cfg, filteredChannels, numMaxHophints,
 			)
 
@@ -553,12 +553,12 @@ func addHopHint(hopHints *[]func(*zpay32.Invoice),
 	)
 }
 
-// selectHopHints will select up to numMaxHophints from the set of passed open
+// SelectHopHints will select up to numMaxHophints from the set of passed open
 // channels. The set of hop hints will be returned as a slice of functional
 // options that'll append the route hint to the set of all route hints.
 //
 // TODO(roasbeef): do proper sub-set sum max hints usually << numChans
-func selectHopHints(amtMSat lnwire.MilliSatoshi, cfg *AddInvoiceConfig,
+func SelectHopHints(amtMSat lnwire.MilliSatoshi, cfg *AddInvoiceConfig,
 	openChannels []*channeldb.OpenChannel,
 	numMaxHophints int) []func(*zpay32.Invoice) {
 


### PR DESCRIPTION
selectHopHints is the function which constructs hophints otherwise found
in an invoice created with the private flag.

In this commit, we expose that functionality a little more to workaround
needing to create an invoice to retrieve routing hints.

#### Pull Request Checklist

- [x] All changes are Go version 1.15 compliant
- [x] Your PR passes all CI checks. If a check cannot be passed for a justifiable reason, that reason must be stated in the commit message and PR description.
- [x] If this is your first time contributing, we recommend you read the [Code Contribution Guidelines](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md)
   - [x] The code being submitted is commented according to [Code Documentation and Commenting](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#CodeDocumentation)
   - [x] Commits have a logical structure according to [Ideal Git Commit Structure](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#IdealGitCommitStructure)
- [x] For new code: Code is accompanied by tests which exercise both the positive and negative (error paths) conditions (if applicable)
- [x] For bug fixes: If possible, code is accompanied by new tests which trigger the bug being fixed to prevent regressions
- [x] Any new logging statements use an appropriate subsystem and logging level
- [x] For code and documentation: lines are wrapped at 80 characters (the tab character should be counted as 8 characters, not 4, as some IDEs do per default)
- [ ] A description of your changes [should be added to running the release notes](https://github.com/lightningnetwork/lnd/tree/master/docs/release-notes) for the milestone your change will land in.
