### PR TITLE
multi+refactor: persistent peer manager

### DIFF
--- a/docs/release-notes/release-notes-0.15.0.md
+++ b/docs/release-notes/release-notes-0.15.0.md
@@ -404,6 +404,9 @@ gRPC performance metrics (latency to process `GetInfo`, etc)](https://github.com
 * [The channel-commit-interval is now clamped to a reasonable timeframe of 1h.](https://github.com/lightningnetwork/lnd/pull/6220)
 
 * [A function in the gossiper `processNetworkAnnouncements` has been refactored for readability and for future deduplication efforts.](https://github.com/lightningnetwork/lnd/pull/6278)
+ 
+* [Refactor of all persistent peer related management to the new
+    PersistentPeerManager](https://github.com/lightningnetwork/lnd/pull/5700).
 
 # Contributors (Alphabetical Order)
 

--- a/peer/persistentpeer_mgr.go
+++ b/peer/persistentpeer_mgr.go
@@ -1,0 +1,95 @@
+package peer
+
+import (
+	"sync"
+
+	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/lightningnetwork/lnd/routing/route"
+)
+
+// PersistentPeerManager manages persistent peers.
+type PersistentPeerManager struct {
+	// conns maps a peer's public key to a persistentPeer object.
+	conns map[route.Vertex]*persistentPeer
+
+	sync.RWMutex
+}
+
+// persistentPeer holds all the info about a peer that the
+// PersistentPeerManager needs.
+type persistentPeer struct {
+	// pubKey is the public key identifier of the peer.
+	pubKey *btcec.PublicKey
+
+	// perm indicates if a connection to the peer should be maintained even
+	// if there are no channels with the peer.
+	perm bool
+}
+
+// NewPersistentPeerManager creates a new PersistentPeerManager instance.
+func NewPersistentPeerManager() *PersistentPeerManager {
+	return &PersistentPeerManager{
+		conns: make(map[route.Vertex]*persistentPeer),
+	}
+}
+
+// AddPeer adds a new persistent peer for the PersistentPeerManager to keep
+// track of.
+func (m *PersistentPeerManager) AddPeer(pubKey *btcec.PublicKey, perm bool) {
+	m.Lock()
+	defer m.Unlock()
+
+	m.conns[route.NewVertex(pubKey)] = &persistentPeer{
+		pubKey: pubKey,
+		perm:   perm,
+	}
+}
+
+// IsPersistentPeer returns true if the given peer is a peer that the
+// PersistentPeerManager manages.
+func (m *PersistentPeerManager) IsPersistentPeer(pubKey *btcec.PublicKey) bool {
+	m.RLock()
+	defer m.RUnlock()
+
+	_, ok := m.conns[route.NewVertex(pubKey)]
+	return ok
+}
+
+// IsNonPermPersistentPeer returns true if the peer is a persistent peer but
+// has been marked as non-permanent.
+func (m *PersistentPeerManager) IsNonPermPersistentPeer(
+	pubKey *btcec.PublicKey) bool {
+
+	m.RLock()
+	defer m.RUnlock()
+
+	peer, ok := m.conns[route.NewVertex(pubKey)]
+	if !ok {
+		return false
+	}
+
+	return !peer.perm
+}
+
+// DelPeer removes a peer from the list of persistent peers that the
+// PersistentPeerManager will manage.
+func (m *PersistentPeerManager) DelPeer(pubKey *btcec.PublicKey) {
+	m.Lock()
+	defer m.Unlock()
+
+	delete(m.conns, route.NewVertex(pubKey))
+}
+
+// PersistentPeers returns the list of public keys of the peers it is currently
+// keeping track of.
+func (m *PersistentPeerManager) PersistentPeers() []*btcec.PublicKey {
+	m.RLock()
+	defer m.RUnlock()
+
+	peers := make([]*btcec.PublicKey, 0, len(m.conns))
+	for _, p := range m.conns {
+		peers = append(peers, p.pubKey)
+	}
+
+	return peers
+}

--- a/peer/persistentpeer_mgr.go
+++ b/peer/persistentpeer_mgr.go
@@ -110,12 +110,10 @@ func (p *persistentPeer) cancelRetries() {
 	p.retryCanceller = nil
 }
 
-// getRetryCanceller returns the existing retry canceller channel of the peer
-// or creates a new one if none exists.
+// getRetryCanceller cancels any existing retry canceler and then creates and
+// returns a new one.
 func (p *persistentPeer) getRetryCanceller() chan struct{} {
-	if p.retryCanceller != nil {
-		return *p.retryCanceller
-	}
+	p.cancelRetries()
 
 	cancelChan := make(chan struct{})
 	p.retryCanceller = &cancelChan

--- a/peer/persistentpeer_mgr.go
+++ b/peer/persistentpeer_mgr.go
@@ -62,6 +62,10 @@ type persistentPeer struct {
 
 	// backoff is the time to wait before trying to reconnect to a peer.
 	backoff time.Duration
+
+	// retryCanceller is used to cancel any retry attempt with backoff
+	// that is still maturing.
+	retryCanceller *chan struct{}
 }
 
 // NewPersistentPeerManager creates a new PersistentPeerManager instance.
@@ -362,4 +366,47 @@ func computeNextBackoff(currBackoff, maxBackoff time.Duration) time.Duration {
 	// Otherwise add in our wiggle, but subtract out half of the margin so
 	// that the backoff can tweaked by 1/20 in either direction.
 	return nextBackoff + (time.Duration(wiggle.Uint64()) - margin/2)
+}
+
+// CancelRetries closes the retry canceller channel of the given peer.
+func (m *PersistentPeerManager) CancelRetries(pubKey *btcec.PublicKey) {
+	m.Lock()
+	defer m.Unlock()
+
+	peer, ok := m.conns[route.NewVertex(pubKey)]
+	if !ok {
+		return
+	}
+
+	if peer.retryCanceller == nil {
+		return
+	}
+
+	// Cancel any lingering persistent retry attempts, which will
+	// prevent retries for any with backoffs that are still maturing.
+	close(*peer.retryCanceller)
+	peer.retryCanceller = nil
+}
+
+// GetRetryCanceller returns the existing retry canceller channel of the peer
+// or creates one if one does not exist yet.
+func (m *PersistentPeerManager) GetRetryCanceller(
+	pubKey *btcec.PublicKey) chan struct{} {
+
+	m.Lock()
+	defer m.Unlock()
+
+	peer, ok := m.conns[route.NewVertex(pubKey)]
+	if !ok {
+		return nil
+	}
+
+	if peer.retryCanceller != nil {
+		return *peer.retryCanceller
+	}
+
+	cancelChan := make(chan struct{})
+	peer.retryCanceller = &cancelChan
+
+	return cancelChan
 }

--- a/peer/persistentpeer_mgr.go
+++ b/peer/persistentpeer_mgr.go
@@ -240,22 +240,6 @@ func (m *PersistentPeerManager) DelPeerConnReqs(pubKey *btcec.PublicKey) {
 	peer.connReqs = nil
 }
 
-// AddPeerConnReq appends the given connection request to the existing list for the
-// given peer.
-func (m *PersistentPeerManager) AddPeerConnReq(pubKey *btcec.PublicKey,
-	connReq *connmgr.ConnReq) {
-
-	m.Lock()
-	defer m.Unlock()
-
-	peer, ok := m.conns[route.NewVertex(pubKey)]
-	if !ok {
-		return
-	}
-
-	peer.connReqs = append(peer.connReqs, connReq)
-}
-
 // NumPeerConnReqs returns the number of connection requests for the given peer.
 func (m *PersistentPeerManager) NumPeerConnReqs(pubKey *btcec.PublicKey) int {
 	m.RLock()

--- a/peer/persistentpeer_mgr.go
+++ b/peer/persistentpeer_mgr.go
@@ -184,8 +184,10 @@ func (m *PersistentPeerManager) Stop() {
 }
 
 // AddPeer adds a new persistent peer for the PersistentPeerManager to keep
-// track of.
-func (m *PersistentPeerManager) AddPeer(pubKey *btcec.PublicKey, perm bool) {
+// track of. The peer may be initialised with an initial set of addresses.
+func (m *PersistentPeerManager) AddPeer(pubKey *btcec.PublicKey, perm bool,
+	addrs ...*lnwire.NetAddress) {
+
 	m.Lock()
 	defer m.Unlock()
 
@@ -196,10 +198,15 @@ func (m *PersistentPeerManager) AddPeer(pubKey *btcec.PublicKey, perm bool) {
 		backoff = peer.backoff
 	}
 
+	addrMap := make(map[string]*lnwire.NetAddress)
+	for _, addr := range addrs {
+		addrMap[addr.String()] = addr
+	}
+
 	m.conns[peerKey] = &persistentPeer{
 		pubKey:  pubKey,
 		perm:    perm,
-		addrs:   make(map[string]*lnwire.NetAddress),
+		addrs:   addrMap,
 		backoff: backoff,
 	}
 }

--- a/peer/persistentpeer_mgr.go
+++ b/peer/persistentpeer_mgr.go
@@ -4,6 +4,7 @@ import (
 	"crypto/rand"
 	"fmt"
 	"math/big"
+	"net"
 	"sync"
 	"time"
 
@@ -47,6 +48,10 @@ type PersistentPeerMgrConfig struct {
 	// MaxBackoff is the longest backoff when reconnecting to a persistent
 	// peer.
 	MaxBackoff time.Duration
+
+	// AddrTypeIsSupported returns true if we can connect to this type of
+	// address.
+	AddrTypeIsSupported func(addr net.Addr) bool
 }
 
 // PersistentPeerManager manages persistent peers.
@@ -198,17 +203,13 @@ func (m *PersistentPeerManager) AddPeer(pubKey *btcec.PublicKey, perm bool,
 		backoff = peer.backoff
 	}
 
-	addrMap := make(map[string]*lnwire.NetAddress)
-	for _, addr := range addrs {
-		addrMap[addr.String()] = addr
-	}
-
 	m.conns[peerKey] = &persistentPeer{
 		pubKey:  pubKey,
 		perm:    perm,
-		addrs:   addrMap,
 		backoff: backoff,
 	}
+
+	m.setPeerAddrsUnsafe(peerKey, nil, addrs)
 }
 
 // IsPersistentPeer returns true if the given peer is a peer that the
@@ -270,14 +271,19 @@ func (m *PersistentPeerManager) AddPeerAddresses(pubKey *btcec.PublicKey,
 	m.Lock()
 	defer m.Unlock()
 
-	peer, ok := m.conns[route.NewVertex(pubKey)]
+	peerKey := route.NewVertex(pubKey)
+
+	peer, ok := m.conns[peerKey]
 	if !ok {
 		return
 	}
 
-	for _, addr := range addrs {
-		peer.addrs[addr.String()] = addr
+	peerAddrs := make([]*lnwire.NetAddress, 0, len(peer.addrs))
+	for _, addr := range peer.addrs {
+		peerAddrs = append(peerAddrs, addr)
 	}
+
+	m.setPeerAddrsUnsafe(peerKey, nil, append(peerAddrs, addrs...))
 }
 
 // NumPeerConnReqs returns the number of connection requests for the given peer.
@@ -585,21 +591,44 @@ func (m *PersistentPeerManager) processSingleNodeUpdate(
 		return false
 	}
 
-	addrs := make(map[string]*lnwire.NetAddress)
-	for _, addr := range update.Addresses {
-		lnAddr := &lnwire.NetAddress{
-			IdentityKey: update.IdentityKey,
-			Address:     addr,
-			ChainNet:    m.cfg.ChainNet,
-		}
-
-		addrs[lnAddr.String()] = lnAddr
-	}
-
-	peer.addrs = addrs
+	m.setPeerAddrsUnsafe(peerKey, update.Addresses, nil)
 
 	// If there are no outstanding connection requests for this peer then
 	// our work is done since we are not currently trying to connect to
 	// them.
 	return len(peer.connReqs) != 0
+}
+
+// setPeerAddrsUnsafe can be used to set the addresses of a peer. It only adds
+// supported addresses.
+// NOTE: that this is the method is not thread safe and should only be called
+// if the PersistentPeerManager mutex lock is held.
+func (m *PersistentPeerManager) setPeerAddrsUnsafe(peerKey route.Vertex,
+	addrs []net.Addr, lnwireAddrs []*lnwire.NetAddress) {
+
+	peer := m.conns[peerKey]
+
+	peer.addrs = make(map[string]*lnwire.NetAddress)
+
+	for _, addr := range lnwireAddrs {
+		if !m.cfg.AddrTypeIsSupported(addr) {
+			continue
+		}
+
+		peer.addrs[addr.String()] = addr
+	}
+
+	for _, addr := range addrs {
+		if !m.cfg.AddrTypeIsSupported(addr) {
+			continue
+		}
+
+		lnAddr := &lnwire.NetAddress{
+			IdentityKey: peer.pubKey,
+			Address:     addr,
+			ChainNet:    m.cfg.ChainNet,
+		}
+
+		peer.addrs[lnAddr.String()] = lnAddr
+	}
 }

--- a/peer/persistentpeer_mgr.go
+++ b/peer/persistentpeer_mgr.go
@@ -18,10 +18,18 @@ const (
 	// durations exceeding this value will be eligible to have their
 	// backoffs reduced.
 	defaultStableConnDuration = 10 * time.Minute
+
+	// multiAddrConnectionStagger is the number of seconds to wait between
+	// attempting to a peer with each of its advertised addresses.
+	multiAddrConnectionStagger = 10 * time.Second
 )
 
 // PersistentPeerMgrConfig holds the config of the PersistentPeerManager.
 type PersistentPeerMgrConfig struct {
+	// ConnMgr is used to manage the creation and removal of connection
+	// requests. It handles the actual connection to a peer.
+	ConnMgr connMgr
+
 	// MinBackoff is the shortest backoff when reconnecting to a persistent
 	// peer.
 	MinBackoff time.Duration
@@ -39,6 +47,8 @@ type PersistentPeerManager struct {
 	// conns maps a peer's public key to a persistentPeer object.
 	conns map[route.Vertex]*persistentPeer
 
+	quit chan struct{}
+	wg   sync.WaitGroup
 	sync.RWMutex
 }
 
@@ -68,6 +78,13 @@ type persistentPeer struct {
 	retryCanceller *chan struct{}
 }
 
+// connMgr is what the PersistentPeerManager will use to create and remove
+// connection requests. The purpose of this interface is to make testing easier.
+type connMgr interface {
+	Connect(c *connmgr.ConnReq)
+	Remove(id uint64)
+}
+
 // NewPersistentPeerManager creates a new PersistentPeerManager instance.
 func NewPersistentPeerManager(
 	cfg *PersistentPeerMgrConfig) *PersistentPeerManager {
@@ -75,7 +92,15 @@ func NewPersistentPeerManager(
 	return &PersistentPeerManager{
 		cfg:   cfg,
 		conns: make(map[route.Vertex]*persistentPeer),
+		quit:  make(chan struct{}),
 	}
+}
+
+// Stop closes the quit channel of the PersistentPeerManager and waits for all
+// goroutines to exit.
+func (m *PersistentPeerManager) Stop() {
+	close(m.quit)
+	m.wg.Wait()
 }
 
 // AddPeer adds a new persistent peer for the PersistentPeerManager to keep
@@ -186,26 +211,6 @@ func (m *PersistentPeerManager) AddPeerAddresses(pubKey *btcec.PublicKey,
 	}
 }
 
-// GetPeerAddresses returns all the addresses stored for the peer.
-func (m *PersistentPeerManager) GetPeerAddresses(
-	pubKey *btcec.PublicKey) []*lnwire.NetAddress {
-
-	m.RLock()
-	defer m.RUnlock()
-
-	peer, ok := m.conns[route.NewVertex(pubKey)]
-	if !ok {
-		return nil
-	}
-
-	addrs := make([]*lnwire.NetAddress, 0, len(peer.addrs))
-	for _, addr := range peer.addrs {
-		addrs = append(addrs, addr)
-	}
-
-	return addrs
-}
-
 // GetPeerConnReqs returns all the pending connection requests we have for the
 // given peer.
 func (m *PersistentPeerManager) GetPeerConnReqs(
@@ -233,22 +238,6 @@ func (m *PersistentPeerManager) DelPeerConnReqs(pubKey *btcec.PublicKey) {
 	}
 
 	peer.connReqs = nil
-}
-
-// SetPeerConnReqs sets the connection requests for the given peer. Note that it
-// overrides any previously stored connection requests for the peer.
-func (m *PersistentPeerManager) SetPeerConnReqs(pubKey *btcec.PublicKey,
-	connReqs ...*connmgr.ConnReq) {
-
-	m.Lock()
-	defer m.Unlock()
-
-	peer, ok := m.conns[route.NewVertex(pubKey)]
-	if !ok {
-		return
-	}
-
-	peer.connReqs = connReqs
 }
 
 // AddPeerConnReq appends the given connection request to the existing list for the
@@ -401,12 +390,121 @@ func (m *PersistentPeerManager) GetRetryCanceller(
 		return nil
 	}
 
-	if peer.retryCanceller != nil {
-		return *peer.retryCanceller
+	return peer.getRetryCanceller()
+}
+
+// getRetryCanceller returns the existing retry canceller channel of the peer
+// or creates a new one if none exists.
+func (p *persistentPeer) getRetryCanceller() chan struct{} {
+	if p.retryCanceller != nil {
+		return *p.retryCanceller
 	}
 
 	cancelChan := make(chan struct{})
-	peer.retryCanceller = &cancelChan
+	p.retryCanceller = &cancelChan
 
 	return cancelChan
+}
+
+// ConnectPeer uses all the stored addresses for a peer to attempt to connect
+// to the peer. It creates connection requests if there are currently none for
+// a given address, and it removes old connection requests if the associated
+// address is no longer in the latest address list for the peer.
+func (m *PersistentPeerManager) ConnectPeer(pubKey *btcec.PublicKey) {
+	m.Lock()
+	defer m.Unlock()
+
+	peer, ok := m.conns[route.NewVertex(pubKey)]
+	if !ok {
+		peerLog.Debugf("Peer %x is not a persistent peer. Ignoring "+
+			"connection attempt", pubKey.SerializeCompressed())
+		return
+	}
+
+	if len(peer.addrs) == 0 {
+		peerLog.Debugf("Ignoring connection attempt to peer %s "+
+			"without any stored address",
+			pubKey.SerializeCompressed())
+		return
+	}
+
+	// Create an easy lookup map of the addresses we have stored for the
+	// peer. We will remove entries from this map if we have existing
+	// connection requests for the associated address and then any leftover
+	// entries will indicate which addresses we should create new
+	// connection requests for.
+	addrMap := make(map[string]*lnwire.NetAddress)
+	for key, addr := range peer.addrs {
+		addrMap[key] = addr
+	}
+
+	// Go through each of the existing connection requests and
+	// check if they correspond to the latest set of addresses. If there is
+	// a connection requests that does not use one of the latest advertised
+	// addresses then remove that connection request.
+	var updatedConnReqs []*connmgr.ConnReq
+	for _, connReq := range peer.connReqs {
+		lnAddr := connReq.Addr.(*lnwire.NetAddress).String()
+
+		switch _, ok := addrMap[lnAddr]; ok {
+		// If the existing connection request is using one of the
+		// latest advertised addresses for the peer then we add it to
+		// updatedConnReqs and remove the associated address from
+		// addrMap so that we don't recreate this connReq later on.
+		case true:
+			updatedConnReqs = append(
+				updatedConnReqs, connReq,
+			)
+			delete(addrMap, lnAddr)
+
+		// If the existing connection request is using an address that
+		// is not one of the latest advertised addresses for the peer
+		// then we remove the connecting request from the connection
+		// manager.
+		case false:
+			peerLog.Info(
+				"Removing conn req:", connReq.Addr.String(),
+			)
+			m.cfg.ConnMgr.Remove(connReq.ID())
+		}
+	}
+
+	peer.connReqs = updatedConnReqs
+	cancelChan := peer.getRetryCanceller()
+
+	// Any addresses left in addrMap are new ones that we have not made
+	// connection requests for. So create new connection requests for those.
+	// If there is more than one address in the address map, stagger the
+	// creation of the connection requests for those.
+	go func() {
+		ticker := time.NewTicker(multiAddrConnectionStagger)
+		defer ticker.Stop()
+
+		for _, addr := range addrMap {
+			// Send the persistent connection request to the
+			// connection manager, saving the request itself so we
+			// can cancel/restart the process as needed.
+			connReq := &connmgr.ConnReq{
+				Addr:      addr,
+				Permanent: true,
+			}
+
+			m.Lock()
+			peer.connReqs = append(peer.connReqs, connReq)
+			m.Unlock()
+
+			peerLog.Debugf("Attempting persistent connection to "+
+				"channel peer %v", addr)
+
+			go m.cfg.ConnMgr.Connect(connReq)
+
+			select {
+			case <-m.quit:
+				return
+			case <-cancelChan:
+				return
+			case <-ticker.C:
+			}
+		}
+	}()
 }

--- a/peer/persistentpeer_mgr.go
+++ b/peer/persistentpeer_mgr.go
@@ -2,13 +2,16 @@ package peer
 
 import (
 	"crypto/rand"
+	"fmt"
 	"math/big"
 	"sync"
 	"time"
 
 	"github.com/btcsuite/btcd/btcec/v2"
 	"github.com/btcsuite/btcd/connmgr"
+	"github.com/btcsuite/btcd/wire"
 	"github.com/lightningnetwork/lnd/lnwire"
+	"github.com/lightningnetwork/lnd/routing"
 	"github.com/lightningnetwork/lnd/routing/route"
 )
 
@@ -29,6 +32,13 @@ type PersistentPeerMgrConfig struct {
 	// ConnMgr is used to manage the creation and removal of connection
 	// requests. It handles the actual connection to a peer.
 	ConnMgr connMgr
+
+	// SubscribeTopology will be used to listen for updates to a persistent
+	// peer's advertised addresses.
+	SubscribeTopology func() (*routing.TopologyClient, error)
+
+	// ChainNet is the Bitcoin network this node is associated with.
+	ChainNet wire.BitcoinNet
 
 	// MinBackoff is the shortest backoff when reconnecting to a persistent
 	// peer.
@@ -121,6 +131,51 @@ func NewPersistentPeerManager(
 	}
 }
 
+// Start begins the processes of PersistentPeerManager. It subscribes to graph
+// updates and listens for any NodeAnnouncement messages that indicate that the
+// addresses of one of the persistent peers has changed and then updates the
+// peer's addresses and connection requests accordingly.
+func (m *PersistentPeerManager) Start() error {
+	graphSub, err := m.cfg.SubscribeTopology()
+	if err != nil {
+		return fmt.Errorf("could not subscribe to graph: %v", err)
+	}
+
+	m.wg.Add(1)
+	go func() {
+		defer func() {
+			graphSub.Cancel()
+			m.wg.Done()
+		}()
+
+		for {
+			select {
+			case topChange, ok := <-graphSub.TopologyChanges:
+				// If the router is shutting down, then we will
+				// as well.
+				if !ok {
+					peerLog.Errorf("graph subscription " +
+						"channel has been closed")
+					return
+				}
+
+				for _, update := range topChange.NodeUpdates {
+					if !m.processSingleNodeUpdate(update) {
+						continue
+					}
+
+					m.ConnectPeer(update.IdentityKey)
+				}
+
+			case <-m.quit:
+				return
+			}
+		}
+	}()
+
+	return nil
+}
+
 // Stop closes the quit channel of the PersistentPeerManager and waits for all
 // goroutines to exit.
 func (m *PersistentPeerManager) Stop() {
@@ -198,26 +253,6 @@ func (m *PersistentPeerManager) PersistentPeers() []*btcec.PublicKey {
 	}
 
 	return peers
-}
-
-// SetPeerAddresses can be used to manually set the addresses for the persistent
-// peer. These will then be used during connection request creation. This
-// function overwrites any previously stored addresses for the peer.
-func (m *PersistentPeerManager) SetPeerAddresses(pubKey *btcec.PublicKey,
-	addrs ...*lnwire.NetAddress) {
-
-	m.Lock()
-	defer m.Unlock()
-
-	peer, ok := m.conns[route.NewVertex(pubKey)]
-	if !ok {
-		return
-	}
-
-	peer.addrs = make(map[string]*lnwire.NetAddress)
-	for _, addr := range addrs {
-		peer.addrs[addr.String()] = addr
-	}
 }
 
 // AddPeerAddresses is used to add addresses to a peers existing list of
@@ -524,4 +559,40 @@ func (m *PersistentPeerManager) cancelConnReqsUnsafe(pubKey *btcec.PublicKey,
 	}
 
 	peer.connReqs = nil
+}
+
+// processSingeNodeUpdate processes a single network node update. It updates
+// our persistent peer addresses if the node update is relevant. It returns
+// true if we should attempt to update our connection to this node.
+func (m *PersistentPeerManager) processSingleNodeUpdate(
+	update *routing.NetworkNodeUpdate) bool {
+
+	m.Lock()
+	defer m.Unlock()
+
+	// We only care about updates from the persistent peers that we
+	// are keeping track of.
+	peerKey := route.NewVertex(update.IdentityKey)
+	peer, ok := m.conns[peerKey]
+	if !ok {
+		return false
+	}
+
+	addrs := make(map[string]*lnwire.NetAddress)
+	for _, addr := range update.Addresses {
+		lnAddr := &lnwire.NetAddress{
+			IdentityKey: update.IdentityKey,
+			Address:     addr,
+			ChainNet:    m.cfg.ChainNet,
+		}
+
+		addrs[lnAddr.String()] = lnAddr
+	}
+
+	peer.addrs = addrs
+
+	// If there are no outstanding connection requests for this peer then
+	// our work is done since we are not currently trying to connect to
+	// them.
+	return len(peer.connReqs) != 0
 }

--- a/peer/persistentpeer_mgr_test.go
+++ b/peer/persistentpeer_mgr_test.go
@@ -3,6 +3,7 @@ package peer
 import (
 	"net"
 	"testing"
+	"time"
 
 	"github.com/btcsuite/btcd/btcec/v2"
 	"github.com/btcsuite/btcd/connmgr"
@@ -32,7 +33,10 @@ func TestPersistentPeerManager(t *testing.T) {
 	_, alicePubKey := btcec.PrivKeyFromBytes(channels.AlicesPrivKey)
 	_, bobPubKey := btcec.PrivKeyFromBytes(channels.BobsPrivKey)
 
-	m := NewPersistentPeerManager()
+	m := NewPersistentPeerManager(&PersistentPeerMgrConfig{
+		MinBackoff: time.Millisecond * 10,
+		MaxBackoff: time.Millisecond * 100,
+	})
 
 	// Alice should not initially be a persistent peer.
 	require.False(t, m.IsPersistentPeer(alicePubKey))

--- a/peer/persistentpeer_mgr_test.go
+++ b/peer/persistentpeer_mgr_test.go
@@ -41,6 +41,9 @@ func TestPersistentPeerManagerBasics(t *testing.T) {
 	m := NewPersistentPeerManager(&PersistentPeerMgrConfig{
 		MinBackoff: time.Millisecond * 10,
 		MaxBackoff: time.Millisecond * 100,
+		AddrTypeIsSupported: func(addr net.Addr) bool {
+			return true
+		},
 	})
 	defer m.Stop()
 
@@ -200,6 +203,9 @@ func TestConnectionLogic(t *testing.T) {
 		ChainNet:          wire.MainNet,
 		MinBackoff:        time.Millisecond * 10,
 		MaxBackoff:        time.Millisecond * 100,
+		AddrTypeIsSupported: func(addr net.Addr) bool {
+			return true
+		},
 	})
 	require.NoError(t, m.Start())
 	defer m.Stop()

--- a/peer/persistentpeer_mgr_test.go
+++ b/peer/persistentpeer_mgr_test.go
@@ -3,15 +3,20 @@ package peer
 import (
 	"fmt"
 	"net"
+	"sync"
 	"testing"
 	"time"
 
 	"github.com/btcsuite/btcd/btcec/v2"
 	"github.com/btcsuite/btcd/connmgr"
 	"github.com/lightningnetwork/lnd/lntest/channels"
+	"github.com/lightningnetwork/lnd/lntest/wait"
 	"github.com/lightningnetwork/lnd/lnwire"
+	"github.com/lightningnetwork/lnd/routing/route"
 	"github.com/stretchr/testify/require"
 )
+
+const defaultTimeout = 30 * time.Second
 
 var (
 	testAddr1 = &net.TCPAddr{IP: (net.IP)([]byte{0xA, 0x0, 0x0, 0x1}),
@@ -38,6 +43,7 @@ func TestPersistentPeerManager(t *testing.T) {
 		MinBackoff: time.Millisecond * 10,
 		MaxBackoff: time.Millisecond * 100,
 	})
+	defer m.Stop()
 
 	// Alice should not initially be a persistent peer.
 	require.False(t, m.IsPersistentPeer(alicePubKey))
@@ -87,7 +93,10 @@ func TestPersistentPeerManager(t *testing.T) {
 	})
 
 	// Both addresses should appear in Bob's address list.
-	addrs := m.GetPeerAddresses(bobPubKey)
+	var addrs []*lnwire.NetAddress
+	for _, addr := range m.conns[route.NewVertex(bobPubKey)].addrs {
+		addrs = append(addrs, addr)
+	}
 	require.Len(t, addrs, 2)
 	if addrs[0].Address.String() == testAddr1.String() {
 		require.Equal(t, addrs[1].Address.String(), testAddr2.String())
@@ -102,7 +111,10 @@ func TestPersistentPeerManager(t *testing.T) {
 		IdentityKey: bobPubKey,
 		Address:     testAddr3,
 	})
-	addrs = m.GetPeerAddresses(bobPubKey)
+	addrs = []*lnwire.NetAddress{}
+	for _, addr := range m.conns[route.NewVertex(bobPubKey)].addrs {
+		addrs = append(addrs, addr)
+	}
 	require.Len(t, addrs, 1)
 	require.Equal(t, addrs[0].Address.String(), testAddr3.String())
 
@@ -125,14 +137,6 @@ func TestPersistentPeerManager(t *testing.T) {
 		require.Equal(t, reqs[1].String(), connReq1.String())
 	}
 
-	// If SetPeerConnReqs is used, however, then this should overwrite any
-	// previously stored connection requests for Bob.
-	m.SetPeerConnReqs(bobPubKey, connReq3)
-	reqs = m.GetPeerConnReqs(bobPubKey)
-	require.Equal(t, m.NumPeerConnReqs(bobPubKey), 1)
-	require.Len(t, reqs, 1)
-	require.Equal(t, reqs[0].String(), connReq3.String())
-
 	// Delete Bob.
 	m.DelPeer(bobPubKey)
 	peers = m.PersistentPeers()
@@ -146,6 +150,7 @@ func TestRetryCanceller(t *testing.T) {
 		MinBackoff: time.Millisecond * 10,
 		MaxBackoff: time.Millisecond * 100,
 	})
+	defer m.Stop()
 
 	_, alicePubKey := btcec.PrivKeyFromBytes(channels.AlicesPrivKey)
 	m.AddPeer(alicePubKey, false)
@@ -183,4 +188,184 @@ func TestRetryCanceller(t *testing.T) {
 	// Calling cancel again should not cause any closing-of-nil-channel
 	// panics.
 	m.CancelRetries(alicePubKey)
+}
+
+// TestConnectPeer tests that the PersistentPeerManager's ConnectPeer function
+// correctly creates and cancels connection requests.
+func TestConnectPeer(t *testing.T) {
+	// Create and a new mock connection manager.
+	cm := newMockConnMgr(t)
+	defer cm.stop()
+
+	// Create a new PersistentPeerManager.
+	m := NewPersistentPeerManager(&PersistentPeerMgrConfig{
+		ConnMgr:    cm,
+		MinBackoff: time.Millisecond * 10,
+		MaxBackoff: time.Millisecond * 100,
+	})
+	defer m.Stop()
+
+	_, alicePubKey := btcec.PrivKeyFromBytes(channels.AlicesPrivKey)
+
+	// Add Alice as a persistent peer.
+	m.AddPeer(alicePubKey, false)
+
+	// There are currently no addresses stored for Alice, so calling
+	// ConnectPeer should not result in any connection requests.
+	m.ConnectPeer(alicePubKey)
+	require.Equal(t, cm.totalNumConnReqs(), 0)
+
+	// Now we add an address for Alice and attempt to connect again. This
+	// should result in 1 connection request for the given address.
+	m.AddPeerAddresses(alicePubKey, &lnwire.NetAddress{
+		IdentityKey: alicePubKey,
+		Address:     testAddr1,
+	})
+	m.ConnectPeer(alicePubKey)
+	assertOneConnReqPerAddress(t, cm, testAddr1)
+
+	// If we now add a second address for Alice, calling ConnectPeer again
+	// should result in one more connection request for the new address.
+	// The connection for the first address should remain intact.
+	m.AddPeerAddresses(alicePubKey, &lnwire.NetAddress{
+		IdentityKey: alicePubKey,
+		Address:     testAddr2,
+	})
+	m.ConnectPeer(alicePubKey)
+	assertOneConnReqPerAddress(t, cm, testAddr1, testAddr2)
+
+	// If we use SetAddresses to overwrite the current list of addresses
+	// stored for Alice and then call ConnectPeer again, the appropriate
+	// connection requests should be added and removed. We will set
+	// addresses 2 and 3. We then expect the connection request for address
+	// 1 to be removed, the connReq for 2 to remain and a connReq for 3
+	// to be added.
+	m.SetPeerAddresses(
+		alicePubKey,
+		&lnwire.NetAddress{
+			IdentityKey: alicePubKey,
+			Address:     testAddr2,
+		}, &lnwire.NetAddress{
+			IdentityKey: alicePubKey,
+			Address:     testAddr3,
+		},
+	)
+	m.ConnectPeer(alicePubKey)
+	assertOneConnReqPerAddress(t, cm, testAddr2, testAddr3)
+	assertNoConnReqs(t, cm, testAddr1)
+}
+
+var _ connMgr = (*mockConnMgr)(nil)
+
+// mockConnMgr mocks the connmgr.
+type mockConnMgr struct {
+	// reqs holds the active connection requests. It is a map from conn req
+	// ID to conn req object.
+	reqs map[uint64]*connmgr.ConnReq
+
+	// cm is a real ConnManager. It is used (but not started) so that ID's
+	// can be assigned to connmgr.ConnReq objects. We cannot manually
+	// assign IDs since the id field is an unexported field.
+	cm *connmgr.ConnManager
+
+	sync.Mutex
+}
+
+// newMockConnMgr constructs a new mockConnMgr.
+func newMockConnMgr(t *testing.T) *mockConnMgr {
+	cm, err := connmgr.New(&connmgr.Config{
+		Dial: func(addr net.Addr) (net.Conn, error) {
+			return nil, nil
+		},
+	})
+	require.NoError(t, err)
+	cm.Start()
+
+	return &mockConnMgr{
+		reqs: make(map[uint64]*connmgr.ConnReq),
+		cm:   cm,
+	}
+}
+
+// stop cleans up any resources managed by the mockConnMgr.
+func (m *mockConnMgr) stop() {
+	m.cm.Stop()
+}
+
+// totalNumConnReqs returns the number of connection requests that the
+// mockConnMgr is keeping track of.
+func (m *mockConnMgr) totalNumConnReqs() int {
+	m.Lock()
+	defer m.Unlock()
+
+	return len(m.reqs)
+}
+
+// numConnReqs returns the number of active connection requests to the given
+// address.
+func (m *mockConnMgr) numConnReqs(addr net.Addr) int {
+	m.Lock()
+	defer m.Unlock()
+
+	count := 0
+	for _, cr := range m.reqs {
+		if cr.Addr.(*lnwire.NetAddress).Address.String() ==
+			addr.String() {
+
+			count++
+		}
+	}
+
+	return count
+}
+
+// Connect adds the given connection request to the active set and generates
+// a unique ID for it.
+func (m *mockConnMgr) Connect(c *connmgr.ConnReq) {
+	m.Lock()
+	defer m.Unlock()
+
+	m.cm.Connect(c)
+	m.reqs[c.ID()] = c
+}
+
+// Remove removes the connection request with the given ID from the active set.
+func (m *mockConnMgr) Remove(id uint64) {
+	m.Lock()
+	defer m.Unlock()
+
+	m.cm.Remove(id)
+	delete(m.reqs, id)
+}
+
+var _ connMgr = (*mockConnMgr)(nil)
+
+// assertNoConnReqs ensures that the connection manager has no connection
+// requests for any of the given addresses.
+func assertNoConnReqs(t *testing.T, cm *mockConnMgr, addrs ...net.Addr) {
+	err := wait.Predicate(func() bool {
+		for _, addr := range addrs {
+			if cm.numConnReqs(addr) != 0 {
+				return false
+			}
+		}
+		return true
+	}, defaultTimeout)
+	require.NoError(t, err)
+}
+
+// assertOneConnReqPerAddress ensures that the mock connection manager has one
+// connection request for each address given.
+func assertOneConnReqPerAddress(t *testing.T, cm *mockConnMgr,
+	addrs ...net.Addr) {
+
+	err := wait.Predicate(func() bool {
+		for _, addr := range addrs {
+			if cm.numConnReqs(addr) != 1 {
+				return false
+			}
+		}
+		return true
+	}, defaultTimeout)
+	require.NoError(t, err)
 }

--- a/peer/persistentpeer_mgr_test.go
+++ b/peer/persistentpeer_mgr_test.go
@@ -44,6 +44,11 @@ func TestPersistentPeerManagerBasics(t *testing.T) {
 		AddrTypeIsSupported: func(addr net.Addr) bool {
 			return true
 		},
+		FetchNodeAdvertisedAddrs: func(vertex route.Vertex) ([]net.Addr,
+			error) {
+
+			return nil, nil
+		},
 	})
 	defer m.Stop()
 
@@ -82,31 +87,6 @@ func TestPersistentPeerManagerBasics(t *testing.T) {
 	require.Len(t, peers, 1)
 	require.True(t, peers[0].IsEqual(bobPubKey))
 
-	// Add an address for Bob.
-	m.AddPeerAddresses(bobPubKey, &lnwire.NetAddress{
-		IdentityKey: bobPubKey,
-		Address:     testAddr1,
-	})
-
-	// Add another address for Bob.
-	m.AddPeerAddresses(bobPubKey, &lnwire.NetAddress{
-		IdentityKey: bobPubKey,
-		Address:     testAddr2,
-	})
-
-	// Both addresses should appear in Bob's address list.
-	var addrs []*lnwire.NetAddress
-	for _, addr := range m.conns[route.NewVertex(bobPubKey)].addrs {
-		addrs = append(addrs, addr)
-	}
-	require.Len(t, addrs, 2)
-	if addrs[0].Address.String() == testAddr1.String() {
-		require.Equal(t, addrs[1].Address.String(), testAddr2.String())
-	} else {
-		require.Equal(t, addrs[0].Address.String(), testAddr2.String())
-		require.Equal(t, addrs[1].Address.String(), testAddr1.String())
-	}
-
 	// Delete Bob.
 	m.DelPeer(bobPubKey)
 	peers = m.PersistentPeers()
@@ -119,6 +99,11 @@ func TestRetryCanceller(t *testing.T) {
 	m := NewPersistentPeerManager(&PersistentPeerMgrConfig{
 		MinBackoff: time.Millisecond * 10,
 		MaxBackoff: time.Millisecond * 100,
+		FetchNodeAdvertisedAddrs: func(_ route.Vertex) ([]net.Addr,
+			error) {
+
+			return nil, nil
+		},
 	})
 	defer m.Stop()
 
@@ -196,6 +181,8 @@ func TestConnectionLogic(t *testing.T) {
 	cm := newMockConnMgr(t)
 	defer cm.stop()
 
+	_, alicePubKey := btcec.PrivKeyFromBytes(channels.AlicesPrivKey)
+
 	// Create a new PersistentPeerManager.
 	m := NewPersistentPeerManager(&PersistentPeerMgrConfig{
 		ConnMgr:           cm,
@@ -206,37 +193,37 @@ func TestConnectionLogic(t *testing.T) {
 		AddrTypeIsSupported: func(addr net.Addr) bool {
 			return true
 		},
+		FetchNodeAdvertisedAddrs: func(vertex route.Vertex) ([]net.Addr,
+			error) {
+
+			switch vertex {
+			case route.NewVertex(alicePubKey):
+				return []net.Addr{testAddr1}, nil
+			default:
+				return nil, fmt.Errorf("unknown node")
+			}
+		},
 	})
 	require.NoError(t, m.Start())
 	defer m.Stop()
 
-	_, alicePubKey := btcec.PrivKeyFromBytes(channels.AlicesPrivKey)
-
 	// Add Alice as a persistent peer.
 	m.AddPeer(alicePubKey, false)
 
-	// There are currently no addresses stored for Alice, so calling
-	// ConnectPeer should not result in any connection requests.
-	m.ConnectPeer(alicePubKey)
-	require.Equal(t, cm.totalNumConnReqs(), 0)
-
-	// Now we add an address for Alice and attempt to connect again. This
-	// should result in 1 connection request for the given address.
-	m.AddPeerAddresses(alicePubKey, &lnwire.NetAddress{
-		IdentityKey: alicePubKey,
-		Address:     testAddr1,
-	})
+	// Since an address from FetchNodeAdvertisedAddrs would have been found
+	// for Alice, calling ConnectPeer should result in a connection request
+	// for that address.
 	m.ConnectPeer(alicePubKey)
 	assertOneConnReqPerAddress(t, cm, testAddr1)
 
-	// If we now add a second address for Alice, calling ConnectPeer again
-	// should result in one more connection request for the new address.
-	// The connection for the first address should remain intact.
-	m.AddPeerAddresses(alicePubKey, &lnwire.NetAddress{
-		IdentityKey: alicePubKey,
-		Address:     testAddr2,
-	})
-	m.ConnectPeer(alicePubKey)
+	// Advertise the same address for Alice in a new NodeAnnouncement.
+	// There should still only be one connection request for this address.
+	addUpdate(alicePubKey, testAddr1)
+	assertOneConnReqPerAddress(t, cm, testAddr1)
+
+	// Advertise new addresses for Alice, one being the same as what she
+	// had before and the other being a new one.
+	addUpdate(alicePubKey, testAddr1, testAddr2)
 	assertOneConnReqPerAddress(t, cm, testAddr1, testAddr2)
 
 	// If addresses come through from NodeAnnouncement updates, they should
@@ -294,15 +281,6 @@ func newMockConnMgr(t *testing.T) *mockConnMgr {
 // stop cleans up any resources managed by the mockConnMgr.
 func (m *mockConnMgr) stop() {
 	m.cm.Stop()
-}
-
-// totalNumConnReqs returns the number of connection requests that the
-// mockConnMgr is keeping track of.
-func (m *mockConnMgr) totalNumConnReqs() int {
-	m.Lock()
-	defer m.Unlock()
-
-	return len(m.reqs)
 }
 
 // numConnReqs returns the number of active connection requests to the given

--- a/peer/persistentpeer_mgr_test.go
+++ b/peer/persistentpeer_mgr_test.go
@@ -110,7 +110,7 @@ func TestRetryCanceller(t *testing.T) {
 	_, alicePubKey := btcec.PrivKeyFromBytes(channels.AlicesPrivKey)
 	m.AddPeer(alicePubKey, false)
 
-	rc := m.GetRetryCanceller(alicePubKey)
+	rc := m.conns[route.NewVertex(alicePubKey)].getRetryCanceller()
 
 	// retryFunction represents a function that should be canceled if the
 	// retry canceller channel is closed.

--- a/peer/persistentpeer_mgr_test.go
+++ b/peer/persistentpeer_mgr_test.go
@@ -27,10 +27,6 @@ var (
 
 	testAddr3 = &net.TCPAddr{IP: (net.IP)([]byte{0xA, 0x0, 0x0, 0x1}),
 		Port: 9003}
-
-	connReq1 = &connmgr.ConnReq{Addr: testAddr1}
-	connReq2 = &connmgr.ConnReq{Addr: testAddr2}
-	connReq3 = &connmgr.ConnReq{Addr: testAddr3}
 )
 
 // TestPersistentPeerManager tests that the PersistentPeerManager correctly
@@ -117,25 +113,6 @@ func TestPersistentPeerManager(t *testing.T) {
 	}
 	require.Len(t, addrs, 1)
 	require.Equal(t, addrs[0].Address.String(), testAddr3.String())
-
-	// Add a connection request for Bob.
-	m.AddPeerConnReq(bobPubKey, connReq1)
-	require.Equal(t, m.NumPeerConnReqs(bobPubKey), 1)
-
-	// Add another connection request for Bob.
-	m.AddPeerConnReq(bobPubKey, connReq2)
-	require.Equal(t, m.NumPeerConnReqs(bobPubKey), 2)
-
-	// Both connection requests should appear in Bob's connection request
-	// list.
-	reqs := m.GetPeerConnReqs(bobPubKey)
-	require.Len(t, reqs, 2)
-	if reqs[0].String() == connReq1.String() {
-		require.Equal(t, reqs[1].String(), connReq2.String())
-	} else {
-		require.Equal(t, reqs[0].String(), connReq2.String())
-		require.Equal(t, reqs[1].String(), connReq1.String())
-	}
 
 	// Delete Bob.
 	m.DelPeer(bobPubKey)

--- a/peer/persistentpeer_mgr_test.go
+++ b/peer/persistentpeer_mgr_test.go
@@ -1,0 +1,58 @@
+package peer
+
+import (
+	"testing"
+
+	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/lightningnetwork/lnd/lntest/channels"
+	"github.com/stretchr/testify/require"
+)
+
+// TestPersistentPeerManager tests that the PersistentPeerManager correctly
+// manages the persistent peers.
+func TestPersistentPeerManager(t *testing.T) {
+	_, alicePubKey := btcec.PrivKeyFromBytes(channels.AlicesPrivKey)
+	_, bobPubKey := btcec.PrivKeyFromBytes(channels.BobsPrivKey)
+
+	m := NewPersistentPeerManager()
+
+	// Alice should not initially be a persistent peer.
+	require.False(t, m.IsPersistentPeer(alicePubKey))
+
+	// Now add Alice as a non-permanent persistent peer.
+	m.AddPeer(alicePubKey, false)
+	require.True(t, m.IsPersistentPeer(alicePubKey))
+	require.True(t, m.IsNonPermPersistentPeer(alicePubKey))
+
+	// Bob should not yet be a persistent peer.
+	require.False(t, m.IsPersistentPeer(bobPubKey))
+
+	// Now add Bob as a permanent persistent peer.
+	m.AddPeer(bobPubKey, true)
+	require.True(t, m.IsPersistentPeer(bobPubKey))
+	require.False(t, m.IsNonPermPersistentPeer(bobPubKey))
+
+	// Both Alice and Bob should be listed as persistent peers.
+	peers := m.PersistentPeers()
+	require.Len(t, peers, 2)
+
+	if peers[0].IsEqual(alicePubKey) {
+		require.True(t, peers[1].IsEqual(bobPubKey))
+	} else {
+		require.True(t, peers[0].IsEqual(bobPubKey))
+		require.True(t, peers[1].IsEqual(alicePubKey))
+	}
+
+	// Delete Alice.
+	m.DelPeer(alicePubKey)
+	require.False(t, m.IsPersistentPeer(alicePubKey))
+
+	peers = m.PersistentPeers()
+	require.Len(t, peers, 1)
+	require.True(t, peers[0].IsEqual(bobPubKey))
+
+	// Delete Bob.
+	m.DelPeer(bobPubKey)
+	peers = m.PersistentPeers()
+	require.Len(t, peers, 0)
+}

--- a/peer/persistentpeer_mgr_test.go
+++ b/peer/persistentpeer_mgr_test.go
@@ -1,6 +1,7 @@
 package peer
 
 import (
+	"context"
 	"fmt"
 	"net"
 	"sync"
@@ -9,9 +10,11 @@ import (
 
 	"github.com/btcsuite/btcd/btcec/v2"
 	"github.com/btcsuite/btcd/connmgr"
+	"github.com/btcsuite/btcd/wire"
 	"github.com/lightningnetwork/lnd/lntest/channels"
 	"github.com/lightningnetwork/lnd/lntest/wait"
 	"github.com/lightningnetwork/lnd/lnwire"
+	"github.com/lightningnetwork/lnd/routing"
 	"github.com/lightningnetwork/lnd/routing/route"
 	"github.com/stretchr/testify/require"
 )
@@ -29,9 +32,9 @@ var (
 		Port: 9003}
 )
 
-// TestPersistentPeerManager tests that the PersistentPeerManager correctly
-// manages the persistent peers.
-func TestPersistentPeerManager(t *testing.T) {
+// TestPersistentPeerManagerBasics tests the basic getters and setters of the
+// PersistentPeerManager.
+func TestPersistentPeerManagerBasics(t *testing.T) {
 	_, alicePubKey := btcec.PrivKeyFromBytes(channels.AlicesPrivKey)
 	_, bobPubKey := btcec.PrivKeyFromBytes(channels.BobsPrivKey)
 
@@ -101,19 +104,6 @@ func TestPersistentPeerManager(t *testing.T) {
 		require.Equal(t, addrs[1].Address.String(), testAddr1.String())
 	}
 
-	// If SetAddresses is used, however, then this should overwrite any
-	// previous addresses stored for Bob.
-	m.SetPeerAddresses(bobPubKey, &lnwire.NetAddress{
-		IdentityKey: bobPubKey,
-		Address:     testAddr3,
-	})
-	addrs = []*lnwire.NetAddress{}
-	for _, addr := range m.conns[route.NewVertex(bobPubKey)].addrs {
-		addrs = append(addrs, addr)
-	}
-	require.Len(t, addrs, 1)
-	require.Equal(t, addrs[0].Address.String(), testAddr3.String())
-
 	// Delete Bob.
 	m.DelPeer(bobPubKey)
 	peers = m.PersistentPeers()
@@ -167,19 +157,51 @@ func TestRetryCanceller(t *testing.T) {
 	m.conns[route.NewVertex(alicePubKey)].cancelRetries()
 }
 
-// TestConnectPeer tests that the PersistentPeerManager's ConnectPeer function
-// correctly creates and cancels connection requests.
-func TestConnectPeer(t *testing.T) {
+// TestConnectionLogic tests that the PersistentPeerManager's correctly adds
+// and removes connection requests.
+func TestConnectionLogic(t *testing.T) {
+	_, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// topChangeChan is a channel that will be used to send network updates
+	// on.
+	topChangeChan := make(chan *routing.TopologyChange)
+
+	// addUpdate is a closure helper used to send mock NodeAnnouncement
+	// network updates.
+	addUpdate := func(pubKey *btcec.PublicKey, addrs ...net.Addr) {
+		topChangeChan <- &routing.TopologyChange{
+			NodeUpdates: []*routing.NetworkNodeUpdate{
+				{
+					IdentityKey: pubKey,
+					Addresses:   addrs,
+				},
+			},
+		}
+	}
+
+	// updates will be used by the PersistentPeerManger to subscribe to
+	// network updates from topChangeChan.
+	updates := func() (*routing.TopologyClient, error) {
+		return &routing.TopologyClient{
+			TopologyChanges: topChangeChan,
+			Cancel:          cancel,
+		}, nil
+	}
+
 	// Create and a new mock connection manager.
 	cm := newMockConnMgr(t)
 	defer cm.stop()
 
 	// Create a new PersistentPeerManager.
 	m := NewPersistentPeerManager(&PersistentPeerMgrConfig{
-		ConnMgr:    cm,
-		MinBackoff: time.Millisecond * 10,
-		MaxBackoff: time.Millisecond * 100,
+		ConnMgr:           cm,
+		SubscribeTopology: updates,
+		ChainNet:          wire.MainNet,
+		MinBackoff:        time.Millisecond * 10,
+		MaxBackoff:        time.Millisecond * 100,
 	})
+	require.NoError(t, m.Start())
 	defer m.Stop()
 
 	_, alicePubKey := btcec.PrivKeyFromBytes(channels.AlicesPrivKey)
@@ -211,22 +233,13 @@ func TestConnectPeer(t *testing.T) {
 	m.ConnectPeer(alicePubKey)
 	assertOneConnReqPerAddress(t, cm, testAddr1, testAddr2)
 
-	// If we use SetAddresses to overwrite the current list of addresses
-	// stored for Alice and then call ConnectPeer again, the appropriate
-	// connection requests should be added and removed. We will set
-	// addresses 2 and 3. We then expect the connection request for address
-	// 1 to be removed, the connReq for 2 to remain and a connReq for 3
-	// to be added.
-	m.SetPeerAddresses(
-		alicePubKey,
-		&lnwire.NetAddress{
-			IdentityKey: alicePubKey,
-			Address:     testAddr2,
-		}, &lnwire.NetAddress{
-			IdentityKey: alicePubKey,
-			Address:     testAddr3,
-		},
-	)
+	// If addresses come through from NodeAnnouncement updates, they should
+	// overwrite the current list of addresses stored for Alice and then
+	// call ConnectPeer again, the appropriate connection requests should
+	// be added and removed. We will set addresses 2 and 3. We then expect
+	// the connection request for address 1 to be removed, the connReq for
+	// 2 to remain and a connReq for 3 to be added.
+	addUpdate(alicePubKey, testAddr2, testAddr3)
 	m.ConnectPeer(alicePubKey)
 	assertOneConnReqPerAddress(t, cm, testAddr2, testAddr3)
 	assertNoConnReqs(t, cm, testAddr1)

--- a/server.go
+++ b/server.go
@@ -3953,20 +3953,15 @@ func (s *server) ConnectToPeer(addr *lnwire.NetAddress,
 	// persistent connection to the peer.
 	srvrLog.Debugf("Connecting to %v", addr)
 	if perm {
-		connReq := &connmgr.ConnReq{
-			Addr:      addr,
-			Permanent: true,
-		}
-
 		// Since the user requested a permanent connection, we'll set
 		// the entry to true which will tell the server to continue
 		// reconnecting even if the number of channels with this peer is
 		// zero.
 		s.persistentPeerMgr.AddPeer(addr.IdentityKey, true)
-		s.persistentPeerMgr.AddPeerConnReq(addr.IdentityKey, connReq)
+		s.persistentPeerMgr.AddPeerAddresses(addr.IdentityKey, addr)
 		s.mu.Unlock()
 
-		go s.connMgr.Connect(connReq)
+		go s.persistentPeerMgr.ConnectPeer(addr.IdentityKey)
 
 		return nil
 	}

--- a/server.go
+++ b/server.go
@@ -3021,7 +3021,6 @@ func (s *server) prunePersistentPeerConnection(compressedPubKey [33]byte) {
 	}
 
 	if s.persistentPeerMgr.IsNonPermPersistentPeer(pubKey) {
-		s.persistentPeerMgr.CancelConnReqs(pubKey, nil)
 		s.persistentPeerMgr.DelPeer(pubKey)
 
 		srvrLog.Infof("Pruned peer %x from persistent connections, "+
@@ -3981,8 +3980,6 @@ func (s *server) DisconnectPeer(pubKey *btcec.PublicKey) error {
 	}
 
 	srvrLog.Infof("Disconnecting from %v", peer)
-
-	s.persistentPeerMgr.CancelConnReqs(pubKey, nil)
 
 	// If this peer was formerly a persistent connection, then we'll remove
 	// them from this map so we don't attempt to re-connect after we

--- a/server.go
+++ b/server.go
@@ -1392,6 +1392,21 @@ func newServer(cfg *Config, listenAddrs []net.Addr,
 			ChainNet:          s.cfg.ActiveNetParams.Net,
 			MinBackoff:        cfg.MinBackoff,
 			MaxBackoff:        cfg.MaxBackoff,
+			AddrTypeIsSupported: func(addr net.Addr) bool {
+				switch addr.(type) {
+				case *net.TCPAddr:
+					return true
+
+				// We'll only attempt to connect to Tor
+				// addresses if Tor outbound support is enabled.
+				case *tor.OnionAddr:
+					if s.cfg.Tor.Active {
+						return true
+					}
+				}
+
+				return false
+			},
 		},
 	)
 


### PR DESCRIPTION
This PR adds a `PersistentPeerManager` to the server and refactors all persistent peer logic to be handled by the `PersistentPeerManager`. The end result is that  `persistentPeers`, `persistentPeersBackoff`, `persistentConnReqs` and `persistentRetryCancels` are all removed from the `server` struct and replaced by a `PersistentPeerManager`.
