### PR TITLE
itest: save etcd logs along node logs in separate files

### DIFF
--- a/docs/release-notes/release-notes-0.14.0.md
+++ b/docs/release-notes/release-notes-0.14.0.md
@@ -198,6 +198,8 @@ you.
 
 * [Fixed wallet recovery itests on Travis ARM](https://github.com/lightningnetwork/lnd/pull/5688)
 
+* [Integration tests save embedded etcd logs to help debugging flakes](https://github.com/lightningnetwork/lnd/pull/5702)
+
 ## Database
 
 * [Ensure single writer for legacy

--- a/kvdb/backend.go
+++ b/kvdb/backend.go
@@ -256,7 +256,7 @@ func GetTestBackend(path, name string) (Backend, func(), error) {
 		}
 		return db, empty, nil
 	} else if TestBackend == EtcdBackendName {
-		etcdConfig, cancel, err := StartEtcdTestBackend(path, 0, 0)
+		etcdConfig, cancel, err := StartEtcdTestBackend(path, 0, 0, "")
 		if err != nil {
 			return nil, empty, err
 		}

--- a/kvdb/etcd/config.go
+++ b/kvdb/etcd/config.go
@@ -10,6 +10,8 @@ type Config struct {
 
 	EmbeddedPeerPort uint16 `long:"embedded_peer_port" description:"Peer port to use for the embedded instance. Note: use for testing only."`
 
+	EmbeddedLogFile string `long:"embedded_log_file" description:"Optional log file to use for embedded instance logs. note: use for testing only."`
+
 	Host string `long:"host" description:"Etcd database host."`
 
 	User string `long:"user" description:"Etcd database user."`

--- a/kvdb/etcd/embed.go
+++ b/kvdb/etcd/embed.go
@@ -60,8 +60,8 @@ func getFreePort() int {
 // NewEmbeddedEtcdInstance creates an embedded etcd instance for testing,
 // listening on random open ports. Returns the backend config and a cleanup
 // func that will stop the etcd instance.
-func NewEmbeddedEtcdInstance(path string, clientPort, peerPort uint16) (
-	*Config, func(), error) {
+func NewEmbeddedEtcdInstance(path string, clientPort, peerPort uint16,
+	logFile string) (*Config, func(), error) {
 
 	cfg := embed.NewConfig()
 	cfg.Dir = path
@@ -70,7 +70,12 @@ func NewEmbeddedEtcdInstance(path string, clientPort, peerPort uint16) (
 	cfg.MaxTxnOps = 8192
 	cfg.MaxRequestBytes = 16384 * 1024
 	cfg.Logger = "zap"
-	cfg.LogLevel = "error"
+	if logFile != "" {
+		cfg.LogLevel = "info"
+		cfg.LogOutputs = []string{logFile}
+	} else {
+		cfg.LogLevel = "error"
+	}
 
 	// Listen on random free ports if no ports were specified.
 	if clientPort == 0 {

--- a/kvdb/etcd/fixture.go
+++ b/kvdb/etcd/fixture.go
@@ -34,7 +34,7 @@ type EtcdTestFixture struct {
 func NewTestEtcdInstance(t *testing.T, path string) (*Config, func()) {
 	t.Helper()
 
-	config, cleanup, err := NewEmbeddedEtcdInstance(path, 0, 0)
+	config, cleanup, err := NewEmbeddedEtcdInstance(path, 0, 0, "")
 	if err != nil {
 		t.Fatalf("error while staring embedded etcd instance: %v", err)
 	}

--- a/kvdb/kvdb_etcd.go
+++ b/kvdb/kvdb_etcd.go
@@ -12,10 +12,10 @@ const TestBackend = EtcdBackendName
 
 // GetEtcdTestBackend creates an embedded etcd backend for testing
 // storig the database at the passed path.
-func StartEtcdTestBackend(path string, clientPort, peerPort uint16) (
-	*etcd.Config, func(), error) {
+func StartEtcdTestBackend(path string, clientPort, peerPort uint16,
+	logFile string) (*etcd.Config, func(), error) {
 
 	return etcd.NewEmbeddedEtcdInstance(
-		path, clientPort, peerPort,
+		path, clientPort, peerPort, logFile,
 	)
 }

--- a/kvdb/kvdb_no_etcd.go
+++ b/kvdb/kvdb_no_etcd.go
@@ -15,8 +15,8 @@ const TestBackend = BoltBackendName
 var errEtcdNotAvailable = fmt.Errorf("etcd backend not available")
 
 // StartEtcdTestBackend  is a stub returning nil, and errEtcdNotAvailable error.
-func StartEtcdTestBackend(path string, clientPort, peerPort uint16) (
-	*etcd.Config, func(), error) {
+func StartEtcdTestBackend(path string, clientPort, peerPort uint16,
+	logFile string) (*etcd.Config, func(), error) {
 
 	return nil, func() {}, errEtcdNotAvailable
 }

--- a/lncfg/db.go
+++ b/lncfg/db.go
@@ -92,7 +92,7 @@ func (db *DB) Init(ctx context.Context, dbPath string) error {
 	if db.Backend == EtcdBackend && db.Etcd.Embedded {
 		cfg, _, err := kvdb.StartEtcdTestBackend(
 			dbPath, db.Etcd.EmbeddedClientPort,
-			db.Etcd.EmbeddedPeerPort,
+			db.Etcd.EmbeddedPeerPort, db.Etcd.EmbeddedLogFile,
 		)
 		if err != nil {
 			return err

--- a/lntest/itest/lnd_etcd_failover_test.go
+++ b/lntest/itest/lnd_etcd_failover_test.go
@@ -70,7 +70,7 @@ func testEtcdFailoverCase(net *lntest.NetworkHarness, ht *harnessTest,
 	tmpDir, err := ioutil.TempDir("", "etcd")
 	etcdCfg, cleanup, err := kvdb.StartEtcdTestBackend(
 		tmpDir, uint16(lntest.NextAvailablePort()),
-		uint16(lntest.NextAvailablePort()),
+		uint16(lntest.NextAvailablePort()), "",
 	)
 	if err != nil {
 		ht.Fatalf("Failed to start etcd instance: %v", err)

--- a/sample-lnd.conf
+++ b/sample-lnd.conf
@@ -1131,6 +1131,10 @@ litecoin.node=ltcd
 ; If non zero, LND will use this as peer port for the embedded etcd instance.
 ; db.etcd.embedded_peer_port=1235
 
+; If set the embedded etcd instance will log to the specified file. Useful when
+; testing with embedded etcd.
+; db.etcd.embedded_log_file=/path/etcd.log
+
 
 [cluster]
 


### PR DESCRIPTION
To help debugging issues where the embedded etcd server might fail we redirect etcd logs (info and above) to a node specific log file in itests and will copy it next to the node logs when the test has finished.