### PR TITLE
trivial: link from readme to builder's guide [skip ci]

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,8 +55,8 @@ drastically in the near future.
 
 An automatically generated set of documentation for the RPC APIs can be found
 at [api.lightning.community](https://api.lightning.community). A set of developer
-resources including talks, articles, and example applications can be found at:
-[dev.lightning.community](https://dev.lightning.community).
+resources including guides, articles, example applications and community resources can be found at:
+[docs.lightning.engineering](https://docs.lightning.engineering).
 
 Finally, we also have an active
 [Slack](https://lightning.engineering/slack.html) where protocol developers, application developers, testers and users gather to


### PR DESCRIPTION
This PR changes a link in the section Developer Resources from dev.lightning.community (unmaintained) to docs.lightning.engineering.
It also specifies more clearly what readers can expect to find there.