### PR TITLE
cluster: fix kvdb unit test

### DIFF
--- a/cluster/etcd_elector_test.go
+++ b/cluster/etcd_elector_test.go
@@ -45,7 +45,7 @@ func TestEtcdElector(t *testing.T) {
 		t.Fatalf("unable to create temp dir: %v", err)
 	}
 
-	etcdCfg, cleanup, err := etcd.NewEmbeddedEtcdInstance(tmpDir, 0, 0)
+	etcdCfg, cleanup, err := etcd.NewEmbeddedEtcdInstance(tmpDir, 0, 0, "")
 	require.NoError(t, err)
 	defer cleanup()
 


### PR DESCRIPTION
It looks like #5702 was merged prematurely and broke the kvdb unit
tests.

