### PR TITLE
server.go: dedupe pubkey output in debug/log msgs

### DIFF
--- a/docs/release-notes/release-notes-0.14.0.md
+++ b/docs/release-notes/release-notes-0.14.0.md
@@ -163,7 +163,7 @@ you.
 ## Documentation
 
 * [Outdated warning about unsupported pruning was replaced with clarification that LND **does**
-  support pruning](https://github.com/lightningnetwork/lnd/pull/5553)
+  support pruning](https://github.com/lightningnetwork/lnd/pull/5553).
 
 * [Clarified 'ErrReservedValueInvalidated' error string](https://github.com/lightningnetwork/lnd/pull/5577)
    to explain that the error is triggered by a transaction that would deplete
@@ -220,24 +220,26 @@ you.
 
 * [Missing dots in cmd interface](https://github.com/lightningnetwork/lnd/pull/5535).
 
-* [Link channel point logging](https://github.com/lightningnetwork/lnd/pull/5508)
+* [Link channel point logging](https://github.com/lightningnetwork/lnd/pull/5508).
 
-* [Canceling the chain notifier no longer logs certain errors](https://github.com/lightningnetwork/lnd/pull/5676)
+* [Canceling the chain notifier no longer logs certain errors](https://github.com/lightningnetwork/lnd/pull/5676).
 
 * [Fixed context leak in integration tests, and properly handled context
   timeout](https://github.com/lightningnetwork/lnd/pull/5646).
 
-* [Removed nested db tx](https://github.com/lightningnetwork/lnd/pull/5643)
+* [Removed nested db tx](https://github.com/lightningnetwork/lnd/pull/5643).
 
-* [Fixed wallet recovery itests on Travis ARM](https://github.com/lightningnetwork/lnd/pull/5688)
+* [Fixed wallet recovery itests on Travis ARM](https://github.com/lightningnetwork/lnd/pull/5688).
 
-* [Integration tests save embedded etcd logs to help debugging flakes](https://github.com/lightningnetwork/lnd/pull/5702)
+* [Integration tests save embedded etcd logs to help debugging flakes](https://github.com/lightningnetwork/lnd/pull/5702).
 
 * [Fixed restore backup file test flake with bitcoind](https://github.com/lightningnetwork/lnd/pull/5637).
 
-* [Timing fix in AMP itest](https://github.com/lightningnetwork/lnd/pull/5725)
+* [Timing fix in AMP itest](https://github.com/lightningnetwork/lnd/pull/5725).
 
-* [Upgraded miekg/dns to improve the security posture](https://github.com/lightningnetwork/lnd/pull/5738)
+* [Upgraded miekg/dns to improve the security posture](https://github.com/lightningnetwork/lnd/pull/5738).
+
+* [server.go: dedupe pubkey output in debug/log msgs](https://github.com/lightningnetwork/lnd/pull/5722).
 
 ## Database
 

--- a/server.go
+++ b/server.go
@@ -3659,14 +3659,13 @@ func (s *server) ConnectToPeer(addr *lnwire.NetAddress,
 	// connection.
 	if reqs, ok := s.persistentConnReqs[targetPub]; ok {
 		srvrLog.Warnf("Already have %d persistent connection "+
-			"requests for %x@%v, connecting anyway.", len(reqs),
-			targetPub, addr)
+			"requests for %v, connecting anyway.", len(reqs), addr)
 	}
 
 	// If there's not already a pending or active connection to this node,
 	// then instruct the connection manager to attempt to establish a
 	// persistent connection to the peer.
-	srvrLog.Debugf("Connecting to %x@%v", targetPub, addr)
+	srvrLog.Debugf("Connecting to %v", addr)
 	if perm {
 		connReq := &connmgr.ConnReq{
 			Addr:      addr,


### PR DESCRIPTION
Default human readable format of NetAddress already contains pubkey:
https://github.com/lightningnetwork/lnd/blob/a329c8061266418bccd797aa5d7d277c736ee930/channeldb/migration/lnwire21/netaddress.go#L38-L47

#### Pull Request Checklist

- [x] All changes are Go version 1.15 compliant
- [x] Your PR passes all CI checks. If a check cannot be passed for a justifiable reason, that reason must be stated in the commit message and PR description.
- [x] If this is your first time contributing, we recommend you read the [Code Contribution Guidelines](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md)
   - [x] The code being submitted is commented according to [Code Documentation and Commenting](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#CodeDocumentation)
   - [x] Commits have a logical structure according to [Ideal Git Commit Structure](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#IdealGitCommitStructure)
- [x] For new code: Code is accompanied by tests which exercise both the positive and negative (error paths) conditions (if applicable)
- [x] For bug fixes: If possible, code is accompanied by new tests which trigger the bug being fixed to prevent regressions
- [x] Any new logging statements use an appropriate subsystem and logging level
- [x] For code and documentation: lines are wrapped at 80 characters (the tab character should be counted as 8 characters, not 4, as some IDEs do per default)
- [x] A description of your changes [should be added to running the release notes](https://github.com/lightningnetwork/lnd/tree/master/docs/release-notes) for the milestone your change will land in.
