### PR TITLE
lntest/itest: fix SendPaymentAMP test

### DIFF
--- a/docs/release-notes/release-notes-0.14.0.md
+++ b/docs/release-notes/release-notes-0.14.0.md
@@ -225,6 +225,8 @@ you.
 
 * [Fixed restore backup file test flake with bitcoind](https://github.com/lightningnetwork/lnd/pull/5637).
 
+* [Timing fix in AMP itest](https://github.com/lightningnetwork/lnd/pull/5725)
+
 ## Database
 
 * [Ensure single writer for legacy


### PR DESCRIPTION
Fixes timing issue that caused missed invoice notification.