### PR TITLE
Travis: reduce ARM itest parallelism to 2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -73,7 +73,7 @@ jobs:
     - name: Bitcoind Integration ARM
       script:
         - bash ./scripts/install_bitcoind.sh
-        - GOARM=7 GOARCH=arm GOOS=linux make itest-parallel backend=bitcoind
+        - GOARM=7 GOARCH=arm GOOS=linux make itest-parallel backend=bitcoind ITEST_PARALLELISM=2
       arch: arm64
       services:
         - docker

--- a/docs/release-notes/release-notes-0.14.0.md
+++ b/docs/release-notes/release-notes-0.14.0.md
@@ -150,6 +150,9 @@ you.
   lead to failed tests sometimes when the CPU of the GitHub CI runner was
   strained too much.
 
+* [Reduce the number of parallel itest runs to 2 on
+  ARM](https://github.com/lightningnetwork/lnd/pull/5731).
+
 ## Documentation
 
 * [Outdated warning about unsupported pruning was replaced with clarification that LND **does**


### PR DESCRIPTION
Reduces the number of concurrent tranches of itests running to two on
ARM in an attempt to make the tests less flaky because of very high CPU
usage with the default 4 parallel tranches.
