### PR TITLE
build: fix itest parallelism

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -73,7 +73,7 @@ jobs:
     - name: Bitcoind Integration ARM
       script:
         - bash ./scripts/install_bitcoind.sh
-        - GOARM=7 GOARCH=arm GOOS=linux make itest-parallel backend=bitcoind ITEST_PARALLELISM=2
+        - GOARM=7 GOARCH=arm GOOS=linux make itest-parallel backend=bitcoind tranches=2 parallel=2
       arch: arm64
       services:
         - docker
@@ -82,7 +82,7 @@ jobs:
       script:
         # The windows VM seems to be slower than the other Travis VMs. We only
         # run 2 test suites in parallel instead of the default 4.
-        - make itest-parallel windows=1 ITEST_PARALLELISM=2
+        - make itest-parallel windows=1 tranches=2 parallel=2
       os: windows
       before_install:
         - choco upgrade --no-progress -y make netcat curl findutils

--- a/docs/release-notes/release-notes-0.14.0.md
+++ b/docs/release-notes/release-notes-0.14.0.md
@@ -153,6 +153,8 @@ you.
 * [Reduce the number of parallel itest runs to 2 on
   ARM](https://github.com/lightningnetwork/lnd/pull/5731).
 
+* [Fix Travis itest parallelism](https://github.com/lightningnetwork/lnd/pull/5734)
+
 ## Documentation
 
 * [Outdated warning about unsupported pruning was replaced with clarification that LND **does**


### PR DESCRIPTION
The latest ARM build seems to have only ran half of the itests: https://app.travis-ci.com/github/lightningnetwork/lnd/jobs/537407681
This PR attempts to fix itest parallelism by fixing the number of tranches to the parallelism param.