### PR TITLE
Removed deprecated interfacer linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -58,6 +58,9 @@ linters:
   # Init functions are used by loggers throughout the codebase.
   - gochecknoinits
 
+  # interfacer has been archived.
+  - interfacer
+
 issues:
   # Only show newly introduced problems.
   new-from-rev: 01f696afce2f9c0d4ed854edefa3846891d01d8a

--- a/channeldb/channel.go
+++ b/channeldb/channel.go
@@ -872,7 +872,7 @@ func fetchChanBucket(tx kvdb.RTx, nodeKey *btcec.PublicKey,
 // channel's data resides in given: the public key for the node, the outpoint,
 // and the chainhash that the channel resides on. This differs from
 // fetchChanBucket in that it returns a writeable bucket.
-func fetchChanBucketRw(tx kvdb.RwTx, nodeKey *btcec.PublicKey, // nolint:interfacer
+func fetchChanBucketRw(tx kvdb.RwTx, nodeKey *btcec.PublicKey,
 	outPoint *wire.OutPoint, chainHash chainhash.Hash) (kvdb.RwBucket, error) {
 
 	readBucket, err := fetchChanBucket(tx, nodeKey, outPoint, chainHash)
@@ -1848,7 +1848,7 @@ func (k *CircuitKey) SetBytes(bs []byte) error {
 
 // Bytes returns the serialized bytes for this circuit key.
 func (k CircuitKey) Bytes() []byte {
-	var bs = make([]byte, 16)
+	bs := make([]byte, 16)
 	binary.BigEndian.PutUint64(bs[:8], k.ChanID.ToUint64())
 	binary.BigEndian.PutUint64(bs[8:], k.HtlcID)
 	return bs
@@ -3417,7 +3417,6 @@ func putChanCommitments(chanBucket kvdb.RwBucket, channel *OpenChannel) error {
 }
 
 func putChanRevocationState(chanBucket kvdb.RwBucket, channel *OpenChannel) error {
-
 	var b bytes.Buffer
 	err := WriteElements(
 		&b, channel.RemoteCurrentRevocation, channel.RevocationProducer,
@@ -3608,7 +3607,6 @@ func fetchChanRevocationState(chanBucket kvdb.RBucket, channel *OpenChannel) err
 }
 
 func deleteOpenChannel(chanBucket kvdb.RwBucket) error {
-
 	if err := chanBucket.Delete(chanInfoKey); err != nil {
 		return err
 	}
@@ -3631,7 +3629,6 @@ func deleteOpenChannel(chanBucket kvdb.RwBucket) error {
 	}
 
 	return nil
-
 }
 
 // makeLogKey converts a uint64 into an 8 byte array.

--- a/channeldb/graph.go
+++ b/channeldb/graph.go
@@ -341,7 +341,7 @@ func (c *ChannelGraph) DisabledChannelIDs() ([]uint64, error) {
 //
 // TODO(roasbeef): add iterator interface to allow for memory efficient graph
 // traversal when graph gets mega
-func (c *ChannelGraph) ForEachNode(cb func(kvdb.RTx, *LightningNode) error) error { // nolint:interfacer
+func (c *ChannelGraph) ForEachNode(cb func(kvdb.RTx, *LightningNode) error) error {
 	traversal := func(tx kvdb.RTx) error {
 		// First grab the nodes bucket which stores the mapping from
 		// pubKey to node information.
@@ -570,7 +570,6 @@ func (c *ChannelGraph) deleteLightningNode(nodes kvdb.RwBucket,
 	}
 
 	if err := nodes.Delete(compressedPubKey); err != nil {
-
 		return err
 	}
 
@@ -684,7 +683,6 @@ func (c *ChannelGraph) addChannelEdge(tx kvdb.RwTx, edge *ChannelEdgeInfo) error
 		if err != nil {
 			return fmt.Errorf("unable to create shell node "+
 				"for: %x", edge.NodeKey1Bytes)
-
 		}
 	case node1Err != nil:
 		return err
@@ -701,7 +699,6 @@ func (c *ChannelGraph) addChannelEdge(tx kvdb.RwTx, edge *ChannelEdgeInfo) error
 		if err != nil {
 			return fmt.Errorf("unable to create shell node "+
 				"for: %x", edge.NodeKey2Bytes)
-
 		}
 	case node2Err != nil:
 		return err
@@ -716,8 +713,10 @@ func (c *ChannelGraph) addChannelEdge(tx kvdb.RwTx, edge *ChannelEdgeInfo) error
 
 	// Mark edge policies for both sides as unknown. This is to enable
 	// efficient incoming channel lookup for a node.
-	for _, key := range []*[33]byte{&edge.NodeKey1Bytes,
-		&edge.NodeKey2Bytes} {
+	for _, key := range []*[33]byte{
+		&edge.NodeKey1Bytes,
+		&edge.NodeKey2Bytes,
+	} {
 
 		err := putChanEdgePolicyUnknown(edges, edge.ChannelID,
 			key[:])
@@ -2142,7 +2141,6 @@ func updateEdgePolicy(tx kvdb.RwTx, edge *ChannelEdgePolicy) (bool, error) {
 	edges := tx.ReadWriteBucket(edgeBucket)
 	if edges == nil {
 		return false, ErrEdgeNotFound
-
 	}
 	edgeIndex := edges.NestedReadWriteBucket(edgeIndexBucket)
 	if edgeIndex == nil {
@@ -2634,7 +2632,6 @@ type ChannelEdgeInfo struct {
 // keys for the target ChannelEdgeInfo.
 func (c *ChannelEdgeInfo) AddNodeKeys(nodeKey1, nodeKey2, bitcoinKey1,
 	bitcoinKey2 *btcec.PublicKey) {
-
 	c.nodeKey1 = nodeKey1
 	copy(c.NodeKey1Bytes[:], c.nodeKey1.SerializeCompressed())
 
@@ -2751,7 +2748,6 @@ func (c *ChannelEdgeInfo) OtherNodeKeyBytes(thisNodeKey []byte) (
 // one of the nodes, and wishes to obtain the full LightningNode for the other
 // end of the channel.
 func (c *ChannelEdgeInfo) FetchOtherNode(tx kvdb.RTx, thisNodeKey []byte) (*LightningNode, error) {
-
 	// Ensure that the node passed in is actually a member of the channel.
 	var targetNodeBytes [33]byte
 	switch {

--- a/channeldb/payments.go
+++ b/channeldb/payments.go
@@ -315,7 +315,6 @@ func fetchPayment(bucket kvdb.RBucket) (*MPPayment, error) {
 	creationInfo, err := fetchCreationInfo(bucket)
 	if err != nil {
 		return nil, err
-
 	}
 
 	var htlcs []HTLCAttempt
@@ -732,7 +731,7 @@ func fetchPaymentWithSequenceNumber(tx kvdb.RTx, paymentHash lntypes.Hash,
 // DeletePayment deletes a payment from the DB given its payment hash. If
 // failedHtlcsOnly is set, only failed HTLC attempts of the payment will be
 // deleted.
-func (d *DB) DeletePayment(paymentHash lntypes.Hash, failedHtlcsOnly bool) error { // nolint:interfacer
+func (d *DB) DeletePayment(paymentHash lntypes.Hash, failedHtlcsOnly bool) error {
 	return kvdb.Update(d, func(tx kvdb.RwTx) error {
 		payments := tx.ReadWriteBucket(paymentsRootBucket)
 		if payments == nil {

--- a/docs/release-notes/release-notes-0.14.0.md
+++ b/docs/release-notes/release-notes-0.14.0.md
@@ -160,6 +160,8 @@ you.
 
 * [Fix Travis itest parallelism](https://github.com/lightningnetwork/lnd/pull/5734)
 
+* [Removed the deprecated interfacer linter](https://github.com/lightningnetwork/lnd/pull/5747)
+
 ## Documentation
 
 * [Outdated warning about unsupported pruning was replaced with clarification that LND **does**

--- a/lntest/harness.go
+++ b/lntest/harness.go
@@ -291,7 +291,6 @@ func extraArgsEtcd(etcdCfg *etcd.Config, name string, cluster bool) []string {
 
 	if etcdCfg.InsecureSkipVerify {
 		extraArgs = append(extraArgs, "--db.etcd.insecure_skip_verify")
-
 	}
 
 	if cluster {
@@ -597,7 +596,6 @@ func (n *NetworkHarness) EnsureConnected(t *testing.T, a, b *HarnessNode) {
 				predErr = err
 				return false
 			}
-
 		}, DefaultTimeout)
 		if err != nil {
 			return fmt.Errorf("connection not succeeded within 15 "+
@@ -1362,7 +1360,6 @@ func (n *NetworkHarness) WaitForChannelClose(
 // an optional set of check functions which can be used to make further
 // assertions using channel's values. These functions are responsible for
 // failing the test themselves if they do not pass.
-// nolint: interfacer
 func (n *NetworkHarness) AssertChannelExists(node *HarnessNode,
 	chanPoint *wire.OutPoint, checks ...func(*lnrpc.Channel)) error {
 

--- a/lntest/itest/assertions.go
+++ b/lntest/itest/assertions.go
@@ -598,7 +598,6 @@ func assertNumConnections(t *harnessTest, alice, bob *lntest.HarnessNode,
 		}
 
 		return nil
-
 	}, defaultTimeout)
 	require.NoError(t.t, err)
 }
@@ -620,7 +619,7 @@ func shutdownAndAssert(net *lntest.NetworkHarness, t *harnessTest,
 // returned response matches the expected.
 func assertChannelBalanceResp(t *harnessTest,
 	node *lntest.HarnessNode,
-	expected *lnrpc.ChannelBalanceResponse) { // nolint:interfacer
+	expected *lnrpc.ChannelBalanceResponse) {
 
 	resp := getChannelBalance(t, node)
 	require.True(t.t, proto.Equal(expected, resp), "balance is incorrect")

--- a/lnwire/writer.go
+++ b/lnwire/writer.go
@@ -50,32 +50,20 @@ func ErrOutpointIndexTooBig(index uint32) error {
 }
 
 // WriteBytes appends the given bytes to the provided buffer.
-//
-// Note: We intentionally skip the interfacer linter check here because we want
-// to have concrete type (bytes.Buffer) rather than interface type (io.Write)
-// due to performance concern.
-func WriteBytes(buf *bytes.Buffer, b []byte) error { // nolint: interfacer
+func WriteBytes(buf *bytes.Buffer, b []byte) error {
 	_, err := buf.Write(b)
 	return err
 }
 
 // WriteUint8 appends the uint8 to the provided buffer.
-//
-// Note: We intentionally skip the interfacer linter check here because we want
-// to have concrete type (bytes.Buffer) rather than interface type (io.Write)
-// due to performance concern.
-func WriteUint8(buf *bytes.Buffer, n uint8) error { // nolint: interfacer
+func WriteUint8(buf *bytes.Buffer, n uint8) error {
 	_, err := buf.Write([]byte{n})
 	return err
 }
 
 // WriteUint16 appends the uint16 to the provided buffer. It encodes the
 // integer using big endian byte order.
-//
-// Note: We intentionally skip the interfacer linter check here because we want
-// to have concrete type (bytes.Buffer) rather than interface type (io.Write)
-// due to performance concern.
-func WriteUint16(buf *bytes.Buffer, n uint16) error { // nolint: interfacer
+func WriteUint16(buf *bytes.Buffer, n uint16) error {
 	var b [2]byte
 	binary.BigEndian.PutUint16(b[:], n)
 	_, err := buf.Write(b[:])
@@ -93,11 +81,7 @@ func WriteUint32(buf *bytes.Buffer, n uint32) error {
 
 // WriteUint64 appends the uint64 to the provided buffer. It encodes the
 // integer using big endian byte order.
-//
-// Note: We intentionally skip the interfacer linter check here because we want
-// to have concrete type (bytes.Buffer) rather than interface type (io.Write)
-// due to performance concern.
-func WriteUint64(buf *bytes.Buffer, n uint64) error { // nolint: interfacer
+func WriteUint64(buf *bytes.Buffer, n uint64) error {
 	var b [8]byte
 	binary.BigEndian.PutUint64(b[:], n)
 	_, err := buf.Write(b[:])
@@ -122,7 +106,6 @@ func WritePublicKey(buf *bytes.Buffer, pub *btcec.PublicKey) error {
 
 	serializedPubkey := pub.SerializeCompressed()
 	return WriteBytes(buf, serializedPubkey)
-
 }
 
 // WriteChannelID appends the ChannelID to the provided buffer.
@@ -195,11 +178,7 @@ func WriteFailCode(buf *bytes.Buffer, e FailCode) error {
 // WriteRawFeatureVector encodes the feature using the feature's Encode method
 // and appends the data to the provided buffer. An error will return if the
 // passed feature is nil.
-//
-// Note: We intentionally skip the interfacer linter check here because we want
-// to have concrete type (bytes.Buffer) rather than interface type (io.Write)
-// due to performance concern.
-func WriteRawFeatureVector(buf *bytes.Buffer, // nolint: interfacer
+func WriteRawFeatureVector(buf *bytes.Buffer,
 	feature *RawFeatureVector) error {
 
 	if feature == nil {
@@ -281,11 +260,7 @@ func WriteBool(buf *bytes.Buffer, b bool) error {
 
 // WritePkScript appends the script to the provided buffer. Returns an error if
 // the provided script exceeds 34 bytes.
-//
-// Note: We intentionally skip the interfacer linter check here because we want
-// to have concrete type (bytes.Buffer) rather than interface type (io.Write)
-// due to performance concern.
-func WritePkScript(buf *bytes.Buffer, s PkScript) error { // nolint: interfacer
+func WritePkScript(buf *bytes.Buffer, s PkScript) error {
 	// The largest script we'll accept is a p2wsh which is exactly
 	// 34 bytes long.
 	scriptLength := len(s)
@@ -413,11 +388,7 @@ func WriteNetAddrs(buf *bytes.Buffer, addresses []net.Addr) error {
 }
 
 // writeDataWithLength writes the data and its length to the buffer.
-//
-// Note: We intentionally skip the interfacer linter check here because we want
-// to have concrete type (bytes.Buffer) rather than interface type (io.Write)
-// due to performance concern.
-func writeDataWithLength(buf *bytes.Buffer, // nolint: interfacer
+func writeDataWithLength(buf *bytes.Buffer,
 	data []byte) error {
 
 	var l [2]byte


### PR DESCRIPTION
Removed the deprecated interfacer linter from being called for linting.

https://github.com/lightningnetwork/lnd/issues/5741

