### PR TITLE
routing: add wait.NoError to TestBlockDifferenceFix assertion [skip ci]

### DIFF
--- a/docs/release-notes/release-notes-0.14.0.md
+++ b/docs/release-notes/release-notes-0.14.0.md
@@ -313,7 +313,7 @@ you.
 
 * [Catches up on blocks in the
   router](https://github.com/lightningnetwork/lnd/pull/5315) in order to fix an
-  "out of order" error that crops up.
+  "out of order" error that [crops up](https://github.com/lightningnetwork/lnd/pull/5748).
 
 * [Fix healthcheck might be running after the max number of attempts are
   reached](https://github.com/lightningnetwork/lnd/pull/5686).


### PR DESCRIPTION
This fixes a flake I've seen in the wild lately:
```
--- FAIL: TestBlockDifferenceFix (0.01s)
    router_test.go:4335: height should have been updated to 5, instead got 4
FAIL
FAIL	github.com/lightningnetwork/lnd/routing	3.865s
FAIL
```

