### PR TITLE
lnwallet+htlcswitch: make Switch dust-aware

### DIFF
--- a/config.go
+++ b/config.go
@@ -355,6 +355,8 @@ type Config struct {
 
 	GcCanceledInvoicesOnTheFly bool `long:"gc-canceled-invoices-on-the-fly" description:"If true, we'll delete newly canceled invoices on the fly."`
 
+	DustThreshold uint64 `long:"dust-threshold" description:"Sets the dust sum threshold in satoshis for a channel after which dust HTLC's will be failed."`
+
 	Invoices *lncfg.Invoices `group:"invoices" namespace:"invoices"`
 
 	Routing *lncfg.Routing `group:"routing" namespace:"routing"`
@@ -550,6 +552,7 @@ func DefaultConfig() Config {
 		MaxOutgoingCltvExpiry:   htlcswitch.DefaultMaxOutgoingCltvExpiry,
 		MaxChannelFeeAllocation: htlcswitch.DefaultMaxLinkFeeAllocation,
 		MaxCommitFeeRateAnchors: lnwallet.DefaultAnchorsCommitMaxFeeRateSatPerVByte,
+		DustThreshold:           uint64(htlcswitch.DefaultDustThreshold.ToSatoshis()),
 		LogWriter:               build.NewRotatingLogWriter(),
 		DB:                      lncfg.DefaultDB(),
 		Cluster:                 lncfg.DefaultCluster(),

--- a/docs/release-notes/release-notes-0.13.3.md
+++ b/docs/release-notes/release-notes-0.13.3.md
@@ -4,6 +4,10 @@
 
 * [The `DefaultDustLimit` method has been removed in favor of `DustLimitForSize` which calculates the proper network dust limit for a given output size. This also fixes certain APIs like SendCoins to be able to send 294 sats to a P2WPKH script.](https://github.com/lightningnetwork/lnd/pull/5781)
 
+## Safety
+
+* [The `htlcswitch.Switch` has been modified to take into account the total dust sum on the incoming and outgoing channels before forwarding. After the defined threshold is reached, dust HTLC's will start to be failed. The default threshold is 500K satoshis and can be modified by setting `--dust-threshold=` when running `lnd`.](https://github.com/lightningnetwork/lnd/pull/5770)
+
 # Contributors (Alphabetical Order)
 
 * Eugene Siegel

--- a/htlcswitch/mock.go
+++ b/htlcswitch/mock.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/btcsuite/btcd/btcec"
 	"github.com/btcsuite/btcd/wire"
+	"github.com/btcsuite/btcutil"
 	"github.com/go-errors/errors"
 	sphinx "github.com/lightningnetwork/lightning-onion"
 	"github.com/lightningnetwork/lnd/chainntnfs"
@@ -717,6 +718,21 @@ func (f *mockChannelLink) handleLocalAddPacket(pkt *htlcPacket) error {
 	return nil
 }
 
+func (f *mockChannelLink) getDustSum(remote bool) lnwire.MilliSatoshi {
+	return 0
+}
+
+func (f *mockChannelLink) getFeeRate() chainfee.SatPerKWeight {
+	return 0
+}
+
+func (f *mockChannelLink) getDustClosure() dustClosure {
+	dustLimit := btcutil.Amount(400)
+	return dustHelper(
+		channeldb.SingleFunderTweaklessBit, dustLimit, dustLimit,
+	)
+}
+
 func (f *mockChannelLink) HandleChannelUpdate(lnwire.Message) {
 }
 
@@ -742,6 +758,7 @@ func (f *mockChannelLink) Stats() (uint64, lnwire.MilliSatoshi, lnwire.MilliSato
 func (f *mockChannelLink) AttachMailBox(mailBox MailBox) {
 	f.mailBox = mailBox
 	f.packets = mailBox.PacketOutBox()
+	mailBox.SetDustClosure(f.getDustClosure())
 }
 
 func (f *mockChannelLink) Start() error {

--- a/htlcswitch/mock.go
+++ b/htlcswitch/mock.go
@@ -189,6 +189,7 @@ func initSwitchWithDB(startingHeight uint32, db *channeldb.DB) (*Switch, error) 
 		HtlcNotifier:   &mockHTLCNotifier{},
 		Clock:          clock.NewDefaultClock(),
 		HTLCExpiry:     time.Hour,
+		DustThreshold:  DefaultDustThreshold,
 	}
 
 	return New(cfg, startingHeight)

--- a/htlcswitch/switch.go
+++ b/htlcswitch/switch.go
@@ -77,9 +77,9 @@ var (
 	// threshold.
 	errDustThresholdExceeded = errors.New("dust threshold exceeded")
 
-	// defaultDustThreshold is the default threshold after which we'll fail
-	// payments if they are dust. This is currently set to 500k sats.
-	defaultDustThreshold = lnwire.MilliSatoshi(500_000_000)
+	// DefaultDustThreshold is the default threshold after which we'll fail
+	// payments if they are dust. This is currently set to 500m msats.
+	DefaultDustThreshold = lnwire.MilliSatoshi(500_000_000)
 )
 
 // plexPacket encapsulates switch packet and adds error channel to receive
@@ -187,6 +187,10 @@ type Config struct {
 	// will expiry this long after the Adds are added to a mailbox via
 	// AddPacket.
 	HTLCExpiry time.Duration
+
+	// DustThreshold is the threshold in milli-satoshis after which we'll
+	// fail incoming or outgoing dust payments for a particular channel.
+	DustThreshold lnwire.MilliSatoshi
 }
 
 // Switch is the central messaging bus for all incoming/outgoing HTLCs.
@@ -2375,7 +2379,7 @@ func (s *Switch) evaluateDustThreshold(link ChannelLink,
 		}
 
 		// Finally check against the defined dust threshold.
-		if localSum > defaultDustThreshold {
+		if localSum > s.cfg.DustThreshold {
 			return true
 		}
 	}
@@ -2393,7 +2397,7 @@ func (s *Switch) evaluateDustThreshold(link ChannelLink,
 		}
 
 		// Finally check against the defined dust threshold.
-		if remoteSum > defaultDustThreshold {
+		if remoteSum > s.cfg.DustThreshold {
 			return true
 		}
 	}

--- a/htlcswitch/switch.go
+++ b/htlcswitch/switch.go
@@ -71,6 +71,15 @@ var (
 	// ErrLocalAddFailed signals that the ADD htlc for a local payment
 	// failed to be processed.
 	ErrLocalAddFailed = errors.New("local add HTLC failed")
+
+	// errDustThresholdExceeded is only surfaced to callers of SendHTLC and
+	// signals that sending the HTLC would exceed the outgoing link's dust
+	// threshold.
+	errDustThresholdExceeded = errors.New("dust threshold exceeded")
+
+	// defaultDustThreshold is the default threshold after which we'll fail
+	// payments if they are dust. This is currently set to 500k sats.
+	defaultDustThreshold = lnwire.MilliSatoshi(500_000_000)
 )
 
 // plexPacket encapsulates switch packet and adds error channel to receive
@@ -455,6 +464,51 @@ func (s *Switch) SendHTLC(firstHop lnwire.ShortChannelID, attemptID uint64,
 		htlc:           htlc,
 	}
 
+	// Attempt to fetch the target link before creating a circuit so that
+	// we don't leave dangling circuits. The getLocalLink method does not
+	// require the circuit variable to be set on the *htlcPacket.
+	link, linkErr := s.getLocalLink(packet, htlc)
+	if linkErr != nil {
+		// Notify the htlc notifier of a link failure on our outgoing
+		// link. Incoming timelock/amount values are not set because
+		// they are not present for local sends.
+		s.cfg.HtlcNotifier.NotifyLinkFailEvent(
+			newHtlcKey(packet),
+			HtlcInfo{
+				OutgoingTimeLock: htlc.Expiry,
+				OutgoingAmt:      htlc.Amount,
+			},
+			HtlcEventTypeSend,
+			linkErr,
+			false,
+		)
+
+		return linkErr
+	}
+
+	// Evaluate whether this HTLC would increase our exposure to dust. If
+	// it does, don't send it out and instead return an error.
+	if s.evaluateDustThreshold(link, htlc.Amount, false) {
+		// Notify the htlc notifier of a link failure on our outgoing
+		// link. We use the FailTemporaryChannelFailure in place of a
+		// more descriptive error message.
+		linkErr := NewLinkError(
+			&lnwire.FailTemporaryChannelFailure{},
+		)
+		s.cfg.HtlcNotifier.NotifyLinkFailEvent(
+			newHtlcKey(packet),
+			HtlcInfo{
+				OutgoingTimeLock: htlc.Expiry,
+				OutgoingAmt:      htlc.Amount,
+			},
+			HtlcEventTypeSend,
+			linkErr,
+			false,
+		)
+
+		return errDustThresholdExceeded
+	}
+
 	circuit := newPaymentCircuit(&htlc.PaymentHash, packet)
 	actions, err := s.circuits.CommitCircuits(circuit)
 	if err != nil {
@@ -473,27 +527,6 @@ func (s *Switch) SendHTLC(firstHop lnwire.ShortChannelID, attemptID uint64,
 
 	// Send packet to link.
 	packet.circuit = circuit
-
-	// User has created the htlc update therefore we should find the
-	// appropriate channel link and send the payment over this link.
-	link, linkErr := s.getLocalLink(packet, htlc)
-	if linkErr != nil {
-		// Notify the htlc notifier of a link failure on our
-		// outgoing link. Incoming timelock/amount values are
-		// not set because they are not present for local sends.
-		s.cfg.HtlcNotifier.NotifyLinkFailEvent(
-			newHtlcKey(packet),
-			HtlcInfo{
-				OutgoingTimeLock: htlc.Expiry,
-				OutgoingAmt:      htlc.Amount,
-			},
-			HtlcEventTypeSend,
-			linkErr,
-			false,
-		)
-
-		return linkErr
-	}
 
 	return link.handleLocalAddPacket(packet)
 }
@@ -1083,6 +1116,50 @@ func (s *Switch) handlePacketForward(packet *htlcPacket) error {
 		// distribute the htlc load without making assumptions about
 		// what the best channel is.
 		destination := destinations[rand.Intn(len(destinations))]
+
+		// Retrieve the incoming link by its ShortChannelID. Note that
+		// the incomingChanID is never set to hop.Source here.
+		s.indexMtx.RLock()
+		incomingLink, err := s.getLinkByShortID(packet.incomingChanID)
+		s.indexMtx.RUnlock()
+		if err != nil {
+			// If we couldn't find the incoming link, we can't
+			// evaluate the incoming's exposure to dust, so we just
+			// fail the HTLC back.
+			linkErr := NewLinkError(
+				&lnwire.FailTemporaryChannelFailure{},
+			)
+
+			return s.failAddPacket(packet, linkErr)
+		}
+
+		// Evaluate whether this HTLC would increase our exposure to
+		// dust on the incoming link. If it does, fail it backwards.
+		if s.evaluateDustThreshold(
+			incomingLink, packet.incomingAmount, true,
+		) {
+			// The incoming dust exceeds the threshold, so we fail
+			// the add back.
+			linkErr := NewLinkError(
+				&lnwire.FailTemporaryChannelFailure{},
+			)
+
+			return s.failAddPacket(packet, linkErr)
+		}
+
+		// Also evaluate whether this HTLC would increase our exposure
+		// to dust on the destination link. If it does, fail it back.
+		if s.evaluateDustThreshold(
+			destination, packet.amount, false,
+		) {
+			// The outgoing dust exceeds the threshold, so we fail
+			// the add back.
+			linkErr := NewLinkError(
+				&lnwire.FailTemporaryChannelFailure{},
+			)
+
+			return s.failAddPacket(packet, linkErr)
+		}
 
 		// Send the packet to the destination channel link which
 		// manages the channel.
@@ -2253,4 +2330,74 @@ func (s *Switch) FlushForwardingEvents() error {
 // BestHeight returns the best height known to the switch.
 func (s *Switch) BestHeight() uint32 {
 	return atomic.LoadUint32(&s.bestHeight)
+}
+
+// evaluateDustThreshold takes in a ChannelLink, HTLC amount, and a boolean to
+// determine whether the default dust threshold has been exceeded. This
+// heuristic takes into account the trimmed-to-dust mechanism. The sum of the
+// commitment's dust with the mailbox's dust with the amount is checked against
+// the default threshold. If incoming is true, then the amount is not included
+// in the sum as it was already included in the commitment's dust. A boolean is
+// returned telling the caller whether the HTLC should be failed back.
+func (s *Switch) evaluateDustThreshold(link ChannelLink,
+	amount lnwire.MilliSatoshi, incoming bool) bool {
+
+	// Retrieve the link's current commitment feerate and dustClosure.
+	feeRate := link.getFeeRate()
+	isDust := link.getDustClosure()
+
+	// Evaluate if the HTLC is dust on either sides' commitment.
+	isLocalDust := isDust(feeRate, incoming, true, amount.ToSatoshis())
+	isRemoteDust := isDust(feeRate, incoming, false, amount.ToSatoshis())
+
+	if !(isLocalDust || isRemoteDust) {
+		// If the HTLC is not dust on either commitment, it's fine to
+		// forward.
+		return false
+	}
+
+	// Fetch the dust sums currently in the mailbox for this link.
+	cid := link.ChanID()
+	sid := link.ShortChanID()
+	mailbox := s.mailOrchestrator.GetOrCreateMailBox(cid, sid)
+	localMailDust, remoteMailDust := mailbox.DustPackets()
+
+	// If the htlc is dust on the local commitment, we'll obtain the dust
+	// sum for it.
+	if isLocalDust {
+		localSum := link.getDustSum(false)
+		localSum += localMailDust
+
+		// Optionally include the HTLC amount only for outgoing
+		// HTLCs.
+		if !incoming {
+			localSum += amount
+		}
+
+		// Finally check against the defined dust threshold.
+		if localSum > defaultDustThreshold {
+			return true
+		}
+	}
+
+	// Also check if the htlc is dust on the remote commitment, if we've
+	// reached this point.
+	if isRemoteDust {
+		remoteSum := link.getDustSum(true)
+		remoteSum += remoteMailDust
+
+		// Optionally include the HTLC amount only for outgoing
+		// HTLCs.
+		if !incoming {
+			remoteSum += amount
+		}
+
+		// Finally check against the defined dust threshold.
+		if remoteSum > defaultDustThreshold {
+			return true
+		}
+	}
+
+	// If we reached this point, this HTLC is fine to forward.
+	return false
 }

--- a/lntest/itest/lnd_test.go
+++ b/lntest/itest/lnd_test.go
@@ -203,6 +203,7 @@ func TestLightningNetworkDaemon(t *testing.T) {
 	// TODO(roasbeef): create master balanced channel with all the monies?
 	aliceBobArgs := []string{
 		"--default-remote-max-htlcs=483",
+		"--dust-threshold=5000000",
 	}
 
 	// Run the subset of the test cases selected in this tranche.

--- a/lnwallet/commitment.go
+++ b/lnwallet/commitment.go
@@ -440,7 +440,7 @@ func (cb *CommitmentBuilder) createUnsignedCommitmentTx(ourBalance,
 
 	numHTLCs := int64(0)
 	for _, htlc := range filteredHTLCView.ourUpdates {
-		if htlcIsDust(
+		if HtlcIsDust(
 			cb.chanState.ChanType, false, isOurs, feePerKw,
 			htlc.Amount.ToSatoshis(), dustLimit,
 		) {
@@ -450,7 +450,7 @@ func (cb *CommitmentBuilder) createUnsignedCommitmentTx(ourBalance,
 		numHTLCs++
 	}
 	for _, htlc := range filteredHTLCView.theirUpdates {
-		if htlcIsDust(
+		if HtlcIsDust(
 			cb.chanState.ChanType, true, isOurs, feePerKw,
 			htlc.Amount.ToSatoshis(), dustLimit,
 		) {
@@ -529,7 +529,7 @@ func (cb *CommitmentBuilder) createUnsignedCommitmentTx(ourBalance,
 	// purposes of sorting.
 	cltvs := make([]uint32, len(commitTx.TxOut))
 	for _, htlc := range filteredHTLCView.ourUpdates {
-		if htlcIsDust(
+		if HtlcIsDust(
 			cb.chanState.ChanType, false, isOurs, feePerKw,
 			htlc.Amount.ToSatoshis(), dustLimit,
 		) {
@@ -546,7 +546,7 @@ func (cb *CommitmentBuilder) createUnsignedCommitmentTx(ourBalance,
 		cltvs = append(cltvs, htlc.Timeout)
 	}
 	for _, htlc := range filteredHTLCView.theirUpdates {
-		if htlcIsDust(
+		if HtlcIsDust(
 			cb.chanState.ChanType, true, isOurs, feePerKw,
 			htlc.Amount.ToSatoshis(), dustLimit,
 		) {

--- a/lnwallet/test_utils.go
+++ b/lnwallet/test_utils.go
@@ -93,6 +93,9 @@ var (
 		0xc5, 0x6c, 0xbb, 0xac, 0x46, 0x22, 0x08, 0x22,
 		0x21, 0xa8, 0x76, 0x8d, 0x1d, 0x09,
 	}
+
+	aliceDustLimit = btcutil.Amount(200)
+	bobDustLimit   = btcutil.Amount(1300)
 )
 
 // CreateTestChannels creates to fully populated channels to be used within
@@ -112,8 +115,6 @@ func CreateTestChannels(chanType channeldb.ChannelType) (
 	}
 
 	channelBal := channelCapacity / 2
-	aliceDustLimit := btcutil.Amount(200)
-	bobDustLimit := btcutil.Amount(1300)
 	csvTimeoutAlice := uint32(5)
 	csvTimeoutBob := uint32(4)
 

--- a/sample-lnd.conf
+++ b/sample-lnd.conf
@@ -365,6 +365,11 @@
 ; propagation (default: 10)
 ; max-commit-fee-rate-anchors=5
 
+; A threshold defining the maximum amount of dust a given channel can have
+; after which forwarding and sending dust HTLC's to and from the channel will
+; fail. This amount is expressed in satoshis. (default: 500000)
+; dust-threshold=1000000
+
 ; If true, lnd will abort committing a migration if it would otherwise have been
 ; successful. This leaves the database unmodified, and still compatible with the
 ; previously active version of lnd.

--- a/server.go
+++ b/server.go
@@ -490,6 +490,9 @@ func newServer(cfg *Config, listenAddrs []net.Addr,
 
 	s.htlcNotifier = htlcswitch.NewHtlcNotifier(time.Now)
 
+	thresholdSats := btcutil.Amount(cfg.DustThreshold)
+	thresholdMSats := lnwire.NewMSatFromSatoshis(thresholdSats)
+
 	s.htlcSwitch, err = htlcswitch.New(htlcswitch.Config{
 		DB: dbs.chanStateDB,
 		LocalChannelClose: func(pubKey []byte,
@@ -519,6 +522,7 @@ func newServer(cfg *Config, listenAddrs []net.Addr,
 		RejectHTLC:             cfg.RejectHTLC,
 		Clock:                  clock.NewDefaultClock(),
 		HTLCExpiry:             htlcswitch.DefaultHTLCExpiry,
+		DustThreshold:          thresholdMSats,
 	}, uint32(currentHeight))
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
**Commit overview**:
- `lnwallet: introduce GetDustSum method to calculate worst-case dust sum` adds a method on `LightningChannel` to calculate worst-case dust on a commitment. It uses an over-estimation currently, but can be changed if somebody can figure out an exact method to count dust w/o under-counting.
- `htlcswitch: extend Mailbox iface with dust, fee methods` allows the mailbox to be dust-aware.  Dust is tracked from the time a packet is added (`AddPacket`) to the time it's removed (`AckPacket`).
- `htlcswitch: extend ChannelLink iface with dustHandler iface` allows the link to call `Mailbox.SetDustLimits` and bubble up results from `LightningChannel.GetDustSum`.
- `htlcswitch: call evaluateDustThreshold in SendHTLC, handlePacketForward` modifies the switch to be dust-aware so that `SendHTLC` or `handlePacketForward` may fail if dust sum exceeds the new default dust threshold of `500000` satoshis.
- `multi: introduce config-level DustThreshold for defining threshold` allows lnd to be started with a command-line option `--dust-threshold=` that lets a user define their acceptable dust threshold.

**Questions:**
- Should the dust threshold be configurable per-channel? A default was easier to implement, but user-configurable may be better.  It would, however, make this diff bigger.
- The `htlcswitch/switch_test.go` test in this diff is quite slow due to a looping call to `SendHTLC` which itself is mostly synchronous.  Any way to speed it up?  Is this test complete?
- There is over-counting in the `GetDustSum` method because some HTLC's in the update logs may be removed after a call to `compactLogs`. Is there a way to fix this? There is a double-counting of mailbox dust since packets that are in the mailbox and not yet signed for will also be in the channel's update logs. This decreases the dust through-put of channels.
- Pathfinding is not aware of dust errors from `SendHTLC`, should that be modified as well?

**Related:** 
- https://github.com/lightningnetwork/lightning-rfc/pull/894
- https://github.com/rust-bitcoin/rust-lightning/pull/1009