### PR TITLE
docs : Moved security to security.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,23 +74,16 @@ discuss various aspects of `lnd` and also Lightning in general.
   * channel #lnd
   * [webchat](https://web.libera.chat/#lnd)
 
+## Security
+
+  [security](./docs/security.md)
+
 ## Safety
 
 When operating a mainnet `lnd` node, please refer to our [operational safety
 guidelines](docs/safety.md). It is important to note that `lnd` is still
 **beta** software and that ignoring these operational guidelines can lead to
 loss of funds.
-
-## Security
-
-The developers of `lnd` take security _very_ seriously. The disclosure of
-security vulnerabilities helps us secure the health of `lnd`, privacy of our
-users, and also the health of the Lightning Network as a whole.  If you find
-any issues regarding security or privacy, please disclose the information
-responsibly by sending an email to security at lightning dot engineering,
-preferably encrypted using our designated PGP key
-(`91FE464CD75101DA6B6BAB60555C6465E5BCB3AF`) which can be found
-[here](https://gist.githubusercontent.com/Roasbeef/6fb5b52886183239e4aa558f83d085d3/raw/5fa96010af201628bcfa61e9309d9b13d23d220f/security@lightning.engineering).
 
 ## Further reading
 * [Step-by-step send payment guide with docker](https://github.com/lightningnetwork/lnd/tree/master/docker)

--- a/docs/release-notes/release-notes-0.14.0.md
+++ b/docs/release-notes/release-notes-0.14.0.md
@@ -255,6 +255,8 @@ you.
 
 * [Order of the start/stop on subsystems are changed to promote better safety](https://github.com/lightningnetwork/lnd/pull/1783).
 
+* [Move security to security.md](https://github.com/lightningnetwork/lnd/pull/5773).
+
 ## Database
 
 * [Ensure single writer for legacy

--- a/docs/security.md
+++ b/docs/security.md
@@ -1,0 +1,10 @@
+# Security
+
+The developers of `lnd` take security _very_ seriously. The disclosure of
+security vulnerabilities helps us secure the health of `lnd`, privacy of our
+users, and also the health of the Lightning Network as a whole.  If you find
+any issues regarding security or privacy, please disclose the information
+responsibly by sending an email to security at lightning dot engineering,
+preferably encrypted using our designated PGP key
+(`91FE464CD75101DA6B6BAB60555C6465E5BCB3AF`) which can be found
+[here](https://gist.githubusercontent.com/Roasbeef/6fb5b52886183239e4aa558f83d085d3/raw/5fa96010af201628bcfa61e9309d9b13d23d220f/security@lightning.engineering).


### PR DESCRIPTION
As per GitHub standards moving the security to
recommended folder https://docs.github.com/en/code-security/getting-started/adding-a-security-policy-to-your-repository
instead of README.md

### Why should I follow GitHub Standards?
> “I’m not trying to make money off this thing, which came about after chatting with quite a few people at DEFCON [the annual security conference in Las Vegas] who were struggling to report security issues to vendors,” Foudil said. “The main reason I don’t go out of my way to promote it now is because it’s not yet an official standard.”

Here is an example of https://krebsonsecurity.com/2021/09/does-your-organization-have-a-security-txt-file/

Following standards helps people report stuff much easily.

