### PR TITLE
cmd/lncli: add new delpayments command line option

### DIFF
--- a/cmd/lncli/main.go
+++ b/cmd/lncli/main.go
@@ -383,6 +383,7 @@ func main() {
 		versionCommand,
 		profileSubCommand,
 		getStateCommand,
+		deletePaymentsCommand,
 	}
 
 	// Add any extra commands determined by build flags.

--- a/docs/release-notes/release-notes-0.14.0.md
+++ b/docs/release-notes/release-notes-0.14.0.md
@@ -70,7 +70,7 @@ the remote peer supports said channel type and agrees, the previous implicit
 negotiation based on the shared set of feature bits is bypassed, and the
 proposed channel type is used.
 
-## RPC Server
+## RPC Server & `lncli`
 
 * [Return payment address and add index from
   addholdinvoice call](https://github.com/lightningnetwork/lnd/pull/5533).
@@ -105,6 +105,10 @@ proposed channel type is used.
   allows external tools to hook into `lnd`'s RPC server and intercept any
   requests made with custom macaroons (and also the responses to those
   requests).
+
+  * [A new lncli command has been added to expose the RPC command to delete
+    payments over the command
+    line](https://github.com/lightningnetwork/lnd/pull/5778): `delpayments`.
 
 ### Batched channel funding
 

--- a/lnrpc/lightning.proto
+++ b/lnrpc/lightning.proto
@@ -345,7 +345,7 @@ service Lightning {
     */
     rpc DeletePayment (DeletePaymentRequest) returns (DeletePaymentResponse);
 
-    /*
+    /* lncli: `delpayments`
     DeleteAllPayments deletes all outgoing payments from DB. Note that it will
     not attempt to delete In-Flight payments, since that would be unsafe.
     */

--- a/lnrpc/lightning.swagger.json
+++ b/lnrpc/lightning.swagger.json
@@ -1859,7 +1859,7 @@
         ]
       },
       "delete": {
-        "summary": "DeleteAllPayments deletes all outgoing payments from DB. Note that it will\nnot attempt to delete In-Flight payments, since that would be unsafe.",
+        "summary": "lncli: `delpayments`\nDeleteAllPayments deletes all outgoing payments from DB. Note that it will\nnot attempt to delete In-Flight payments, since that would be unsafe.",
         "operationId": "Lightning_DeleteAllPayments",
         "responses": {
           "200": {

--- a/lnrpc/lightning_grpc.pb.go
+++ b/lnrpc/lightning_grpc.pb.go
@@ -252,7 +252,7 @@ type LightningClient interface {
 	//DeletePayment deletes an outgoing payment from DB. Note that it will not
 	//attempt to delete an In-Flight payment, since that would be unsafe.
 	DeletePayment(ctx context.Context, in *DeletePaymentRequest, opts ...grpc.CallOption) (*DeletePaymentResponse, error)
-	//
+	// lncli: `delpayments`
 	//DeleteAllPayments deletes all outgoing payments from DB. Note that it will
 	//not attempt to delete In-Flight payments, since that would be unsafe.
 	DeleteAllPayments(ctx context.Context, in *DeleteAllPaymentsRequest, opts ...grpc.CallOption) (*DeleteAllPaymentsResponse, error)
@@ -1492,7 +1492,7 @@ type LightningServer interface {
 	//DeletePayment deletes an outgoing payment from DB. Note that it will not
 	//attempt to delete an In-Flight payment, since that would be unsafe.
 	DeletePayment(context.Context, *DeletePaymentRequest) (*DeletePaymentResponse, error)
-	//
+	// lncli: `delpayments`
 	//DeleteAllPayments deletes all outgoing payments from DB. Note that it will
 	//not attempt to delete In-Flight payments, since that would be unsafe.
 	DeleteAllPayments(context.Context, *DeleteAllPaymentsRequest) (*DeleteAllPaymentsResponse, error)


### PR DESCRIPTION
In this commit, we add a new CLI command to `lncli`: `delpayments`. This
command exposes the `DeleteAllPayments` command over command line, with
a set of arguments that should make it difficult to use improperly. We
require that the user _explicitly_ specify if they want to delta all
payments, just failed payments, or failed HTLC payments.

