### PR TITLE
mod+lncli: remove deprecated package [skip ci]

### DIFF
--- a/cmd/lncli/main.go
+++ b/cmd/lncli/main.go
@@ -19,7 +19,7 @@ import (
 	"github.com/lightningnetwork/lnd/macaroons"
 	"github.com/urfave/cli"
 
-	"golang.org/x/crypto/ssh/terminal"
+	"golang.org/x/term"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
 )
@@ -406,7 +406,7 @@ func readPassword(text string) ([]byte, error) {
 	// The variable syscall.Stdin is of a different type in the Windows API
 	// that's why we need the explicit cast. And of course the linter
 	// doesn't like it either.
-	pw, err := terminal.ReadPassword(int(syscall.Stdin)) // nolint:unconvert
+	pw, err := term.ReadPassword(int(syscall.Stdin)) // nolint:unconvert
 	fmt.Println()
 	return pw, err
 }

--- a/go.mod
+++ b/go.mod
@@ -60,6 +60,7 @@ require (
 	golang.org/x/net v0.0.0-20210913180222-943fd674d43e
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c
 	golang.org/x/sys v0.0.0-20210915083310-ed5796bab164 // indirect
+	golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1
 	golang.org/x/time v0.0.0-20210220033141-f8bda1e9f3ba
 	google.golang.org/grpc v1.38.0
 	google.golang.org/protobuf v1.26.0


### PR DESCRIPTION
The use of golang.org/x/crypto/ssh/terminal was marked as deprecated
since that code was moved to its own repo golang.org/x/term.
With this commit we use the new package name directly, which was already
pulled in under its new name anyway.
