### PR TITLE
lndcfg: give verbose err when failed to load config

### DIFF
--- a/cmd/lnd/main.go
+++ b/cmd/lnd/main.go
@@ -23,6 +23,7 @@ func main() {
 	if err != nil {
 		if e, ok := err.(*flags.Error); !ok || e.Type != flags.ErrHelp {
 			// Print error if not due to help request.
+			err = fmt.Errorf("failed to load config: %w", err)
 			_, _ = fmt.Fprintln(os.Stderr, err)
 			os.Exit(1)
 		}

--- a/docs/release-notes/release-notes-0.14.0.md
+++ b/docs/release-notes/release-notes-0.14.0.md
@@ -223,6 +223,10 @@ you.
   `lncli deletepayments`](https://github.com/lightningnetwork/lnd/pull/5699)
   command.
 
+* [Add more verbose error printed to
+  console](https://github.com/lightningnetwork/lnd/pull/5802) when `lnd` fails
+  loading the user specified config.
+
 ## Code Health
 
 ### Code cleanup, refactor, typo fixes

--- a/lncfg/address.go
+++ b/lncfg/address.go
@@ -35,7 +35,8 @@ func NormalizeAddresses(addrs []string, defaultPort string,
 			addr, defaultPort, tcpResolver,
 		)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("parse address %s failed: %w",
+				addr, err)
 		}
 
 		if _, ok := seen[parsedAddr.String()]; !ok {


### PR DESCRIPTION
This PR prints more verbose error to the console when the given address is failed to be parsed from the config upon startup.
Fix #5318.

The new error output,
```go
failed to load config: parse address 0.0.0.0::9735 got err: tor general error
```

Fixes #5318