### PR TITLE
routerrpc: de-duplicate htlc held by interceptor

### DIFF
--- a/lnrpc/routerrpc/forward_interceptor.go
+++ b/lnrpc/routerrpc/forward_interceptor.go
@@ -150,6 +150,11 @@ func (r *forwardInterceptor) holdAndForwardToClient(
 	htlc := forward.Packet()
 	inKey := htlc.IncomingCircuit
 
+	// ignore already held htlcs.
+	if _, ok := r.holdForwards[inKey]; ok {
+		return nil
+	}
+
 	// First hold the forward, then send to client.
 	r.holdForwards[inKey] = forward
 	interceptionRequest := &ForwardHtlcInterceptRequest{


### PR DESCRIPTION
This PR ensures htlcs currently held by the interceptor won't be intercepted. This prevents potential races in the user code that may lead to loosing funds.
For example:
1. htlc is passed to the interceptor and held for a long. period (such as for opening a channel).
2. Peer disconnects and reconnects again which causes the link to send the htlc again to the switch.
3. In the meantime the original htlc interception is resumed by the interceptor.
4. The re-sent htlc lands at the interceptor which now decides to cancel it causes an issue of lost funds.

This PR solves such cases by preventing the htlc from being intercepted simultaneously.