### PR TITLE
htlcswitch: fix flake in TestShutdownIfChannelClean

### DIFF
--- a/docs/release-notes/release-notes-0.14.0.md
+++ b/docs/release-notes/release-notes-0.14.0.md
@@ -297,6 +297,8 @@ you.
 
 * [Order of the start/stop on subsystems are changed to promote better safety](https://github.com/lightningnetwork/lnd/pull/1783).
 
+* [Fixed flake that occurred when testing the new optimistic link shutdown.](https://github.com/lightningnetwork/lnd/pull/5808)
+
 ## Database
 
 * [Ensure single writer for legacy

--- a/htlcswitch/link_test.go
+++ b/htlcswitch/link_test.go
@@ -6604,9 +6604,13 @@ func TestShutdownIfChannelClean(t *testing.T) {
 	ctx.sendRevAndAckBobToAlice()
 	shutdownAssert(ErrLinkFailedShutdown)
 
+	// There is currently no controllable breakpoint between Alice
+	// receiving the CommitSig and her sending out the RevokeAndAck. As
+	// soon as the RevokeAndAck is generated, the channel becomes clean.
+	// This can happen right after the CommitSig is received, so there is
+	// no shutdown assertion here.
 	// <---sig-----
 	ctx.sendCommitSigBobToAlice(0)
-	shutdownAssert(ErrLinkFailedShutdown)
 
 	// ----rev---->
 	ctx.receiveRevAndAckAliceToBob()


### PR DESCRIPTION
When Alice receives a CommitSig near the end of the test, the test assumed that she wouldn't reply with a RevokeAndAck message before shutdownAssert was called. This led to a test flake. Instead, only call shutdownAssert after we've received the RevokeAndAck.