### PR TITLE
mod: Upgrade to fix GO-2020-0008

### DIFF
--- a/docs/release-notes/release-notes-0.14.0.md
+++ b/docs/release-notes/release-notes-0.14.0.md
@@ -295,6 +295,8 @@ you.
 
 * [Replace reference to XZ library with CVE](https://github.com/lightningnetwork/lnd/pull/5789)
 
+* [Replace reference to DNS library with CVE](https://github.com/lightningnetwork/lnd/pull/5815)
+
 * [Fixed restore backup file test flake with bitcoind](https://github.com/lightningnetwork/lnd/pull/5637).
 
 * [Timing fix in AMP itest](https://github.com/lightningnetwork/lnd/pull/5725).

--- a/kvdb/go.mod
+++ b/kvdb/go.mod
@@ -35,4 +35,8 @@ replace github.com/ulikunitz/xz => github.com/ulikunitz/xz v0.5.8
 // https://deps.dev/advisory/OSV/GO-2021-0053?from=%2Fgo%2Fgithub.com%252Fgogo%252Fprotobuf%2Fv1.3.1
 replace github.com/gogo/protobuf => github.com/gogo/protobuf v1.3.2
 
+// This replace is for
+// https://deps.dev/advisory/OSV/GO-2020-0008
+replace github.com/miekg/dns => github.com/miekg/dns v1.1.43
+
 go 1.15

--- a/kvdb/go.sum
+++ b/kvdb/go.sum
@@ -295,7 +295,7 @@ github.com/matttproud/golang_protobuf_extensions v1.0.1 h1:4hp9jkHxhMHkqkrB3Ix0j
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
 github.com/mholt/archiver/v3 v3.5.0 h1:nE8gZIrw66cu4osS/U7UW7YDuGMHssxKutU8IfWxwWE=
 github.com/mholt/archiver/v3 v3.5.0/go.mod h1:qqTTPUK/HZPFgFQ/TJ3BzvTpF/dPtFVJXdQbCmeMxwc=
-github.com/miekg/dns v1.0.14/go.mod h1:W1PPwlIAgtquWBMBEV9nkV9Cazfe8ScdGz/Lj7v3Nrg=
+github.com/miekg/dns v1.1.43/go.mod h1:+evo5L0630/F6ca/Z9+GAqzhjGyn8/c+TBaOyfEl0V4=
 github.com/mitchellh/cli v1.0.0/go.mod h1:hNIlj7HEI86fIcpObd7a0FcrxTWetlwJDGcceTlRvqc=
 github.com/mitchellh/go-homedir v1.0.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
 github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
@@ -578,6 +578,7 @@ golang.org/x/sys v0.0.0-20200923182605-d9f96fdee20d/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210124154548-22da62e12c0c/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20210303074136-134d130e1a04/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210330210617-4fbd30eecc44/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210403161142-5e06dd20ab57/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210426080607-c94f62235c83/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=


### PR DESCRIPTION
Fixes https://deps.dev/advisory/OSV/GO-2020-0008
This is similar to https://github.com/lightningnetwork/lnd/pull/5576
where the reference to version that has CVE.

This is a indirect reference

```
go mod graph | grep dns
github.com/hashicorp/serf@v0.8.2 github.com/hashicorp/mdns@v1.0.0
github.com/hashicorp/mdns@v1.0.0 github.com/hashicorp/go.net@v0.0.1
github.com/hashicorp/mdns@v1.0.0 github.com/miekg/dns@v1.0.14
github.com/hashicorp/mdns@v1.0.0 golang.org/x/crypto@v0.0.0-20181029021203-45a5f77698d3
github.com/hashicorp/mdns@v1.0.0 golang.org/x/net@v0.0.0-20181023162649-9b4f9f5ad519
github.com/hashicorp/mdns@v1.0.0 golang.org/x/sync@v0.0.0-20181221193216-37e7f081c4d4
github.com/hashicorp/mdns@v1.0.0 golang.org/x/sys@v0.0.0-20181026203630-95b1ffbd15a5
github.com/hashicorp/memberlist@v0.1.3 github.com/miekg/dns@v1.0.14
```
