### PR TITLE
Remove GO111MODULE env variable in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,10 +39,10 @@ LINT_COMMIT := v1.18.0
 GOACC_COMMIT :=80342ae2e0fcf265e99e76bcc4efd022c7c3811b 
 GOFUZZ_COMMIT := b1f3d6f
 
-DEPGET := cd /tmp && GO111MODULE=on go get -v
-GOBUILD := GO111MODULE=on go build -v
-GOINSTALL := GO111MODULE=on go install -v
-GOTEST := GO111MODULE=on go test 
+DEPGET := cd /tmp && go get -v
+GOBUILD := go build -v
+GOINSTALL := go install -v
+GOTEST := go test 
 
 GOVERSION := $(shell go version | awk '{print $$3}')
 GOFILES_NOVENDOR = $(shell find . -type f -name '*.go' -not -path "./vendor/*" -not -name "*pb.go" -not -name "*pb.gw.go")
@@ -317,7 +317,7 @@ mobile-rpc:
 
 vendor:
 	@$(call print, "Re-creating vendor directory.")
-	rm -r vendor/; GO111MODULE=on go mod vendor
+	rm -r vendor/; go mod vendor
 
 ios: vendor mobile-rpc
 	@$(call print, "Building iOS framework ($(IOS_BUILD)).")

--- a/docker/btcd/Dockerfile
+++ b/docker/btcd/Dockerfile
@@ -13,7 +13,7 @@ ARG BTCD_VERSION=v0.20.1-beta
 # Grab and install the latest version of of btcd and all related dependencies.
 RUN git clone https://github.com/btcsuite/btcd.git . \
     && git checkout $BTCD_VERSION \
-    &&  GO111MODULE=on go install -v . ./cmd/...
+    && go install -v . ./cmd/...
 
 # Start a new image
 FROM alpine as final

--- a/docker/ltcd/Dockerfile
+++ b/docker/ltcd/Dockerfile
@@ -7,8 +7,8 @@ LABEL maintainer="Olaoluwa Osuntokun <laolu@lightning.engineering>"
 WORKDIR $GOPATH/src/github.com/ltcsuite/ltcd
 RUN apk add --no-cache --update alpine-sdk git
 RUN git clone https://github.com/ltcsuite/ltcd ./
-RUN GO111MODULE=on go install -v . ./cmd/...
-RUN GO111MODULE=on go install . ./cmd/ltcctl ./cmd/gencerts
+RUN go install -v . ./cmd/...
+RUN go install . ./cmd/ltcctl ./cmd/gencerts
 
 # Start a new image
 FROM alpine as final

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -208,7 +208,7 @@ On FreeBSD, use gmake instead of make.
 Alternatively, if one doesn't wish to use `make`, then the `go` commands can be
 used directly:
 ```shell
-⛰  GO111MODULE=on go install -v ./...
+⛰  go install -v ./...
 ```
 
 **Updating**
@@ -228,7 +228,7 @@ used directly:
 ```shell
 ⛰  cd $GOPATH/src/github.com/lightningnetwork/lnd
 ⛰  git pull
-⛰  GO111MODULE=on go install -v ./...
+⛰  go install -v ./...
 ```
 
 **Tests**

--- a/docs/release-notes/release-notes-0.14.0.md
+++ b/docs/release-notes/release-notes-0.14.0.md
@@ -309,6 +309,8 @@ you.
 
 * [Replace reference to mongo library with CVE](https://github.com/lightningnetwork/lnd/pull/5761)
 
+* [Clean up reference to ENV variable GO111MODULE](https://github.com/lightningnetwork/lnd/pull/5816)
+
 * [Fixed restore backup file test flake with bitcoind](https://github.com/lightningnetwork/lnd/pull/5637).
 
 * [Timing fix in AMP itest](https://github.com/lightningnetwork/lnd/pull/5725).

--- a/lnrpc/Dockerfile
+++ b/lnrpc/Dockerfile
@@ -19,7 +19,6 @@ ENV GOMODCACHE=/tmp/build/.modcache
 RUN cd /tmp \
   && mkdir -p /tmp/build/.cache \
   && mkdir -p /tmp/build/.modcache \
-  && export GO111MODULE=on \
   && go get google.golang.org/protobuf/cmd/protoc-gen-go@${PROTOBUF_VERSION} \
   && go get google.golang.org/grpc/cmd/protoc-gen-go-grpc@${PROTOC_GEN_GO_GRPC_VERSION} \
   && go get github.com/grpc-ecosystem/grpc-gateway/v2/protoc-gen-grpc-gateway@${GRPC_GATEWAY_VERSION} \


### PR DESCRIPTION
The `GO111MODULE` variable is not required from go 1.16  https://go.dev/blog/go116-module-changes

