### PR TITLE
server: use deduped addrMap for connReq creation

### DIFF
--- a/docs/release-notes/release-notes-0.14.0.md
+++ b/docs/release-notes/release-notes-0.14.0.md
@@ -460,6 +460,9 @@ you.
   certain channels couldn't be passed to `lncli getchaninfo` due to their 8-byte 
   compact ID being too large for an int64. 
 
+* [Dedup stored peer addresses before creating connection requests to prevent
+  redundant connection requests](https://github.com/lightningnetwork/lnd/pull/5839)
+
 ## Documentation 
 
 The [code contribution guidelines have been updated to mention the new

--- a/server.go
+++ b/server.go
@@ -3772,11 +3772,7 @@ func (s *server) connectToPersistentPeer(pubKeyStr string) {
 
 	// Any addresses left in addrMap are new ones that we have not made
 	// connection requests for. So create new connection requests for those.
-	for _, addr := range s.persistentPeerAddrs[pubKeyStr] {
-		if _, ok := addrMap[addr.String()]; !ok {
-			continue
-		}
-
+	for _, addr := range addrMap {
 		connReq := &connmgr.ConnReq{
 			Addr:      addr,
 			Permanent: true,


### PR DESCRIPTION
Use the addrMap for connReq creation to prevent creating duplicate
connection requests if persistentPeerAddrs contains duplicate addresses.
