### PR TITLE
build: make gomobile iOS build to .xcframework folder

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ GOFUZZ_BIN := $(GO_BIN)/go-fuzz
 
 MOBILE_BUILD_DIR :=${GOPATH}/src/$(MOBILE_PKG)/build
 IOS_BUILD_DIR := $(MOBILE_BUILD_DIR)/ios
-IOS_BUILD := $(IOS_BUILD_DIR)/Lndmobile.framework
+IOS_BUILD := $(IOS_BUILD_DIR)/Lndmobile.xcframework
 ANDROID_BUILD_DIR := $(MOBILE_BUILD_DIR)/android
 ANDROID_BUILD := $(ANDROID_BUILD_DIR)/Lndmobile.aar
 

--- a/docs/release-notes/release-notes-0.14.0.md
+++ b/docs/release-notes/release-notes-0.14.0.md
@@ -227,6 +227,12 @@ you.
 * [All integration tests (except the ARM itests) were moved from Travis CI to
   GitHub Actions](https://github.com/lightningnetwork/lnd/pull/5811).
 
+* [The LndMobile iOS build has been updated to work
+  with newer gomobile versions](https://github.com/lightningnetwork/lnd/pull/5842)
+  that output in the `xcframework` packaging format.
+  Applications that use the iOS build will have to be updated to include
+  an `xcframework` instead of a `framework`.
+
 ## Documentation
 
 * [Outdated warning about unsupported pruning was replaced with clarification that LND **does**
@@ -456,6 +462,7 @@ change](https://github.com/lightningnetwork/lnd/pull/5613).
 * Elle Mouton
 * ErikEk
 * Eugene Siegel
+* Hampus Sjöberg
 * Harsha Goli
 * Jesse de Wit
 * Martin Habovstiak


### PR DESCRIPTION
Recent gomobile versions are now building for the `xcframework` packaging format instead of `framework`.

This commit addresses this by outputting to a `.xcframework` folder.
Without this gomobile fails to build.