### PR TITLE
Adds helper function lnrpc.RPCTransaction to create a single lnrpc.Transaction and refactors lnrpc.RPCTransactionDetails

### DIFF
--- a/docs/release-notes/release-notes-0.14.2.md
+++ b/docs/release-notes/release-notes-0.14.2.md
@@ -31,9 +31,13 @@
   exposed](https://github.com/lightningnetwork/lnd/pull/5971) inside
   WaitingCloseResp from calling `PendingChannels`.
 
+* [Fix missing label on streamed
+  transactions](https://github.com/lightningnetwork/lnd/pull/5854).
+
 # Contributors (Alphabetical Order)
 
 * Andras Banki-Horvath
+* Bjarne Magnussen
 * Harsha Goli
 * Naveen Srinivasan
 * Oliver Gugger

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -5314,38 +5314,13 @@ func (r *rpcServer) SubscribeTransactions(req *lnrpc.GetTransactionsRequest,
 	for {
 		select {
 		case tx := <-txClient.ConfirmedTransactions():
-			destAddresses := make([]string, 0, len(tx.DestAddresses))
-			for _, destAddress := range tx.DestAddresses {
-				destAddresses = append(destAddresses, destAddress.EncodeAddress())
-			}
-			detail := &lnrpc.Transaction{
-				TxHash:           tx.Hash.String(),
-				Amount:           int64(tx.Value),
-				NumConfirmations: tx.NumConfirmations,
-				BlockHash:        tx.BlockHash.String(),
-				BlockHeight:      tx.BlockHeight,
-				TimeStamp:        tx.Timestamp,
-				TotalFees:        tx.TotalFees,
-				DestAddresses:    destAddresses,
-				RawTxHex:         hex.EncodeToString(tx.RawTx),
-			}
+			detail := lnrpc.RPCTransaction(tx)
 			if err := updateStream.Send(detail); err != nil {
 				return err
 			}
 
 		case tx := <-txClient.UnconfirmedTransactions():
-			var destAddresses []string
-			for _, destAddress := range tx.DestAddresses {
-				destAddresses = append(destAddresses, destAddress.EncodeAddress())
-			}
-			detail := &lnrpc.Transaction{
-				TxHash:        tx.Hash.String(),
-				Amount:        int64(tx.Value),
-				TimeStamp:     tx.Timestamp,
-				TotalFees:     tx.TotalFees,
-				DestAddresses: destAddresses,
-				RawTxHex:      hex.EncodeToString(tx.RawTx),
-			}
+			detail := lnrpc.RPCTransaction(tx)
 			if err := updateStream.Send(detail); err != nil {
 				return err
 			}


### PR DESCRIPTION
## Description

Currently inside `SubscribeTransactions` the streamed `lnrpc.Transaction` structure does not get its `Label` field populated, which seems to be an oversight. 

This PR adds a helper function `lnrpc.RPCTransaction` to return a single `lnrpc.Transaction` and refactors the helper function `lnrpc.RPCTransactionDetails`. This is alos used inside `SubscribeTransactions` to make sure the `Label` field is correctly populated and have the creation of a RPC Transaction in one place.

Fixes #5853