### PR TITLE
channeldb+rpc: optimize graph related RPC calls 

### DIFF
--- a/channeldb/graph_cache_test.go
+++ b/channeldb/graph_cache_test.go
@@ -120,6 +120,24 @@ func TestGraphCacheAddNode(t *testing.T) {
 
 		require.Equal(t, inPolicy1 != nil, toChannels[0].OutPolicySet)
 		assertCachedPolicyEqual(t, outPolicy1, toChannels[0].InPolicy)
+
+		// Now that we've inserted two nodes into the graph, check that
+		// we'll recover the same set of channels during ForEachNode.
+		nodes := make(map[route.Vertex]struct{})
+		chans := make(map[uint64]struct{})
+		_ = cache.ForEachNode(func(node route.Vertex,
+			edges map[uint64]*DirectedChannel) error {
+
+			nodes[node] = struct{}{}
+			for chanID := range edges {
+				chans[chanID] = struct{}{}
+			}
+
+			return nil
+		})
+
+		require.Len(t, nodes, 2)
+		require.Len(t, chans, 1)
 	}
 
 	runTest(pubKey1, pubKey2)

--- a/docs/release-notes/release-notes-0.14.0.md
+++ b/docs/release-notes/release-notes-0.14.0.md
@@ -515,6 +515,11 @@ messages directly. There is no routing/path finding involved.
   buffer each time we decrypt an incoming message, as we
   recycle these buffers in the peer.
 
+* [The `DescribeGraph` and `GetNetworkInfo` calls have been
+  optimized](https://github.com/lightningnetwork/lnd/pull/5873) by caching the
+  response periodically, or using the new channel graph cache directly.  This
+  should significantly cut down on the garbage these two calls generate.
+
 ## Log system
 
 * [Save compressed log files from logrorate during 

--- a/lncfg/caches.go
+++ b/lncfg/caches.go
@@ -1,6 +1,9 @@
 package lncfg
 
-import "fmt"
+import (
+	"fmt"
+	"time"
+)
 
 const (
 	// MinRejectCacheSize is a floor on the maximum capacity allowed for
@@ -10,6 +13,10 @@ const (
 	// MinChannelCacheSize is a floor on the maximum capacity allowed for
 	// channeldb's channel cache. This amounts to roughly 2 MB when full.
 	MinChannelCacheSize = 1000
+
+	// DefaultRPCGraphCacheDuration is the default interval that the RPC
+	// response to DescribeGraph should be cached for.
+	DefaultRPCGraphCacheDuration = time.Minute
 )
 
 // Caches holds the configuration for various caches within lnd.
@@ -24,6 +31,10 @@ type Caches struct {
 	// peers querying for gossip traffic. Memory usage is roughly 2Kb per
 	// entry.
 	ChannelCacheSize int `long:"channel-cache-size" description:"Maximum number of entries contained in the channel cache, which is used to reduce memory allocations from gossip queries from peers. Each entry requires roughly 2Kb."`
+
+	// RPCGraphCacheDuration is used to control the flush interval of the
+	// channel graph cache.
+	RPCGraphCacheDuration time.Duration `long:"rpc-graph-cache-duration" description:"The period of time expressed as a duration (1s, 1m, 1h, etc) that the RPC response to DescribeGraph should be cached for."`
 }
 
 // Validate checks the Caches configuration for values that are too small to be

--- a/lntest/node.go
+++ b/lntest/node.go
@@ -303,6 +303,7 @@ func (cfg NodeConfig) genArgs() []string {
 	args = append(args, fmt.Sprintf("--invoicemacaroonpath=%v", cfg.InvoiceMacPath))
 	args = append(args, fmt.Sprintf("--trickledelay=%v", trickleDelay))
 	args = append(args, fmt.Sprintf("--profile=%d", cfg.ProfilePort))
+	args = append(args, fmt.Sprintf("--caches.rpc-graph-cache-duration=0"))
 
 	if !cfg.HasSeed {
 		args = append(args, "--noseedbackup")

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -5708,7 +5708,9 @@ func (r *rpcServer) GetNetworkInfo(ctx context.Context,
 	// network, tallying up the total number of nodes, and also gathering
 	// each node so we can measure the graph diameter and degree stats
 	// below.
-	if err := graph.ForEachNode(func(tx kvdb.RTx, node *channeldb.LightningNode) error {
+	err := graph.ForEachNodeCached(func(node route.Vertex,
+		edges map[uint64]*channeldb.DirectedChannel) error {
+
 		// Increment the total number of nodes with each iteration.
 		numNodes++
 
@@ -5718,9 +5720,7 @@ func (r *rpcServer) GetNetworkInfo(ctx context.Context,
 		// through the db transaction from the outer view so we can
 		// re-use it within this inner view.
 		var outDegree uint32
-		if err := node.ForEachChannel(tx, func(_ kvdb.RTx,
-			edge *channeldb.ChannelEdgeInfo, _, _ *channeldb.ChannelEdgePolicy) error {
-
+		for _, edge := range edges {
 			// Bump up the out degree for this node for each
 			// channel encountered.
 			outDegree++
@@ -5751,9 +5751,6 @@ func (r *rpcServer) GetNetworkInfo(ctx context.Context,
 
 			seenChans[edge.ChannelID] = struct{}{}
 			allChans = append(allChans, edge.Capacity)
-			return nil
-		}); err != nil {
-			return err
 		}
 
 		// Finally, if the out degree of this node is greater than what
@@ -5763,7 +5760,8 @@ func (r *rpcServer) GetNetworkInfo(ctx context.Context,
 		}
 
 		return nil
-	}); err != nil {
+	})
+	if err != nil {
 		return nil, err
 	}
 

--- a/sample-lnd.conf
+++ b/sample-lnd.conf
@@ -1088,6 +1088,10 @@ litecoin.node=ltcd
 ; roughly 2Kb. (default: 20000)
 ; caches.channel-cache-size=9000000
 
+; The duration that the response to DescribeGraph should be cached for. Setting
+; the value to zero disables the cache. (default: 1m)
+; caches.rpc-graph-cache-duration=10m
+
 
 [protocol]
 


### PR DESCRIPTION
This PR moves to optimize our two heaviest RPC calls (`DescribeGraph` and `GetNetworkInfo`) by cache either the raw data or using the existing channel graph cache. A new command line flag has been added to enable/disable the cache for `DescribeGraph`. This PR is meant to significantly reduce the memory overhead of running `lndmon` as it tends to hit these RPC calls pretty frequently. 