### PR TITLE
kvdb/bolt_compact: filter out non-ASCII from bucket name before printing

### DIFF
--- a/docs/release-notes/release-notes-0.14.0.md
+++ b/docs/release-notes/release-notes-0.14.0.md
@@ -587,6 +587,9 @@ messages directly. There is no routing/path finding involved.
 * [Do not error log when an invoice that has been canceled and GC'd is expired](
   https://github.com/lightningnetwork/lnd/pull/5913)
 
+* [Don't print bucket names with special characters when compacting](
+  https://github.com/lightningnetwork/lnd/pull/5878)
+
 ## Documentation 
 
 The [code contribution guidelines have been updated to mention the new

--- a/kvdb/bolt_compact.go
+++ b/kvdb/bolt_compact.go
@@ -8,6 +8,7 @@
 package kvdb
 
 import (
+	"encoding/hex"
 	"fmt"
 	"os"
 	"path"
@@ -226,6 +227,30 @@ func (cmd *compacter) walk(db *bbolt.DB, walkFn walkFunc) error {
 			)
 		})
 	})
+}
+
+// LoggableKeyName returns a printable name of the given key.
+func LoggableKeyName(key []byte) string {
+	strKey := string(key)
+	if hasSpecialChars(strKey) {
+		return hex.EncodeToString(key)
+	}
+
+	return strKey
+}
+
+// hasSpecialChars returns true if any of the characters in the given string
+// cannot be printed.
+func hasSpecialChars(s string) bool {
+	for _, b := range s {
+		if !(b >= 'a' && b <= 'z') && !(b >= 'A' && b <= 'Z') &&
+			!(b >= '0' && b <= '9') && b != '-' && b != '_' {
+
+			return true
+		}
+	}
+
+	return false
 }
 
 // walkBucket recursively walks through a bucket.

--- a/kvdb/bolt_compact.go
+++ b/kvdb/bolt_compact.go
@@ -220,7 +220,8 @@ func (cmd *compacter) walk(db *bbolt.DB, walkFn walkFunc) error {
 		return tx.ForEach(func(name []byte, b *bbolt.Bucket) error {
 			// This will log the top level buckets only to give the
 			// user some sense of progress.
-			log.Debugf("Compacting top level bucket %s", name)
+			log.Debugf("Compacting top level bucket '%s'",
+				LoggableKeyName(name))
 
 			return cmd.walkBucket(
 				b, nil, name, nil, b.Sequence(), walkFn,


### PR DESCRIPTION
Printing the raw bucket name lead to weird characters and even sounds
being printed.