### PR TITLE
lnrpc: migrate `go get` to `go install`

### DIFF
--- a/docs/release-notes/release-notes-0.14.0.md
+++ b/docs/release-notes/release-notes-0.14.0.md
@@ -331,6 +331,8 @@ messages directly. There is no routing/path finding involved.
   add MacChan field for passing back lnd's admin macaroon back to the program 
   calling lnd, when needed.
 
+* Using `go get` to install go executables is now deprecated. Migrate to `go install` our lnrpc proto dockerfile [Migrate `go get` to `go install`](https://github.com/lightningnetwork/lnd/pull/5879)
+
 ## Code Health
 
 ### Code cleanup, refactor, typo fixes
@@ -544,6 +546,7 @@ change](https://github.com/lightningnetwork/lnd/pull/5613).
 * Harsha Goli
 * Jesse de Wit
 * Joost Jager
+* Jordi Montes
 * Martin Habovstiak
 * Naveen Srinivasan
 * Oliver Gugger

--- a/lnrpc/Dockerfile
+++ b/lnrpc/Dockerfile
@@ -20,12 +20,12 @@ RUN cd /tmp \
   && mkdir -p /tmp/build/.cache \
   && mkdir -p /tmp/build/.modcache \
   && export GO111MODULE=on \
-  && go get google.golang.org/protobuf/cmd/protoc-gen-go@${PROTOBUF_VERSION} \
-  && go get google.golang.org/grpc/cmd/protoc-gen-go-grpc@${PROTOC_GEN_GO_GRPC_VERSION} \
-  && go get github.com/grpc-ecosystem/grpc-gateway/v2/protoc-gen-grpc-gateway@${GRPC_GATEWAY_VERSION} \
-  && go get github.com/grpc-ecosystem/grpc-gateway/v2/protoc-gen-openapiv2@${GRPC_GATEWAY_VERSION} \
-  && go get github.com/lightninglabs/falafel@${FALAFEL_VERSION} \
-  && go get golang.org/x/tools/cmd/goimports \
+  && go install google.golang.org/protobuf/cmd/protoc-gen-go@${PROTOBUF_VERSION} \
+  && go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@${PROTOC_GEN_GO_GRPC_VERSION} \
+  && go install github.com/grpc-ecosystem/grpc-gateway/v2/protoc-gen-grpc-gateway@${GRPC_GATEWAY_VERSION} \
+  && go install github.com/grpc-ecosystem/grpc-gateway/v2/protoc-gen-openapiv2@${GRPC_GATEWAY_VERSION} \
+  && go install github.com/lightninglabs/falafel@${FALAFEL_VERSION} \
+  && go install golang.org/x/tools/cmd/goimports@v0.1.7 \
   && chmod -R 777 /tmp/build/
 
 WORKDIR /build


### PR DESCRIPTION
Starting in Go 1.17, installing executables with `go get` is deprecated.
Migrate our docker file for lnrpc protos.

