### PR TITLE
payments-expiration-grace-period needs time unit

### DIFF
--- a/sample-lnd.conf
+++ b/sample-lnd.conf
@@ -118,9 +118,9 @@
 
 ; A period to wait before for closing channels with outgoing htlcs that have 
 ; timed out and are a result of this nodes instead payment. In addition to our 
-; current block based deadline, is specified this grace period will also be taken
-; into account.
-; payments-expiration-grace-period=30
+; current block based deadline, if specified this grace period will also be taken
+; into account. Valid time units are {s, m, h}.
+; payments-expiration-grace-period=30s
 
 ; Specify the interfaces to listen on for p2p connections. One listen
 ; address per line.


### PR DESCRIPTION
this parameter takes time unit h/m/s or else the lnd does not start.
; payments-expiration-grace-period=69h
[skip ci]