### PR TITLE
lnrpc: add public key detail to signrpc KeyDescriptor [skip ci]

### DIFF
--- a/lnrpc/signrpc/signer.pb.go
+++ b/lnrpc/signrpc/signer.pb.go
@@ -83,12 +83,12 @@ type KeyDescriptor struct {
 	unknownFields protoimpl.UnknownFields
 
 	//
-	//The raw bytes of the key being identified. Either this or the KeyLocator
-	//must be specified.
+	//The raw bytes of the public key in the key pair being identified. Either
+	//this or the KeyLocator must be specified.
 	RawKeyBytes []byte `protobuf:"bytes,1,opt,name=raw_key_bytes,json=rawKeyBytes,proto3" json:"raw_key_bytes,omitempty"`
 	//
-	//The key locator that identifies which key to use for signing. Either this
-	//or the raw bytes of the target key must be specified.
+	//The key locator that identifies which private key to use for signing.
+	//Either this or the raw bytes of the target public key must be specified.
 	KeyLoc *KeyLocator `protobuf:"bytes,2,opt,name=key_loc,json=keyLoc,proto3" json:"key_loc,omitempty"`
 }
 

--- a/lnrpc/signrpc/signer.proto
+++ b/lnrpc/signrpc/signer.proto
@@ -74,14 +74,14 @@ message KeyLocator {
 
 message KeyDescriptor {
     /*
-    The raw bytes of the key being identified. Either this or the KeyLocator
-    must be specified.
+    The raw bytes of the public key in the key pair being identified. Either
+    this or the KeyLocator must be specified.
     */
     bytes raw_key_bytes = 1;
 
     /*
-    The key locator that identifies which key to use for signing. Either this
-    or the raw bytes of the target key must be specified.
+    The key locator that identifies which private key to use for signing.
+    Either this or the raw bytes of the target public key must be specified.
     */
     KeyLocator key_loc = 2;
 }

--- a/lnrpc/signrpc/signer.swagger.json
+++ b/lnrpc/signrpc/signer.swagger.json
@@ -253,11 +253,11 @@
         "raw_key_bytes": {
           "type": "string",
           "format": "byte",
-          "description": "The raw bytes of the key being identified. Either this or the KeyLocator\nmust be specified."
+          "description": "The raw bytes of the public key in the key pair being identified. Either\nthis or the KeyLocator must be specified."
         },
         "key_loc": {
           "$ref": "#/definitions/signrpcKeyLocator",
-          "description": "The key locator that identifies which key to use for signing. Either this\nor the raw bytes of the target key must be specified."
+          "description": "The key locator that identifies which private key to use for signing.\nEither this or the raw bytes of the target public key must be specified."
         }
       }
     },

--- a/lnrpc/walletrpc/walletkit.swagger.json
+++ b/lnrpc/walletrpc/walletkit.swagger.json
@@ -818,11 +818,11 @@
         "raw_key_bytes": {
           "type": "string",
           "format": "byte",
-          "description": "The raw bytes of the key being identified. Either this or the KeyLocator\nmust be specified."
+          "description": "The raw bytes of the public key in the key pair being identified. Either\nthis or the KeyLocator must be specified."
         },
         "key_loc": {
           "$ref": "#/definitions/signrpcKeyLocator",
-          "description": "The key locator that identifies which key to use for signing. Either this\nor the raw bytes of the target key must be specified."
+          "description": "The key locator that identifies which private key to use for signing.\nEither this or the raw bytes of the target public key must be specified."
         }
       }
     },


### PR DESCRIPTION
Clarification that KeyDescriptor describes the public key in
raw_key_bytes and the key_loc identifies the private key. Helps
clarify responses from calls like DeriveKey and DeriveNextKey from
WalletKit.

Fixes #5899