### PR TITLE
channeldb: fix crash when inbound policy is unset

### DIFF
--- a/channeldb/graph.go
+++ b/channeldb/graph.go
@@ -405,9 +405,12 @@ func (c *ChannelGraph) ForEachNodeChannel(tx kvdb.RTx, node route.Vertex,
 	dbCallback := func(tx kvdb.RTx, e *ChannelEdgeInfo, p1,
 		p2 *ChannelEdgePolicy) error {
 
-		cachedInPolicy := NewCachedPolicy(p2)
-		cachedInPolicy.ToNodePubKey = toNodeCallback
-		cachedInPolicy.ToNodeFeatures = toNodeFeatures
+		var cachedInPolicy *CachedEdgePolicy
+		if p2 != nil {
+			cachedInPolicy = NewCachedPolicy(p2)
+			cachedInPolicy.ToNodePubKey = toNodeCallback
+			cachedInPolicy.ToNodeFeatures = toNodeFeatures
+		}
 
 		directedChannel := &DirectedChannel{
 			ChannelID:    e.ChannelID,

--- a/docs/release-notes/release-notes-0.14.0.md
+++ b/docs/release-notes/release-notes-0.14.0.md
@@ -584,6 +584,9 @@ messages directly. There is no routing/path finding involved.
   re-notified](https://github.com/lightningnetwork/lnd/pull/5901), which could
   lead to higher-level HTLC mismanagement issues.
 
+* [Fix pathfinding crash when inbound policy is unknown](
+  https://github.com/lightningnetwork/lnd/pull/5919)
+
 ## Documentation 
 
 The [code contribution guidelines have been updated to mention the new


### PR DESCRIPTION
Attempted partial fix for: https://github.com/lightningnetwork/lnd/issues/5914