### PR TITLE
server: stagger connReqs to multi-address peers

### DIFF
--- a/docs/release-notes/release-notes-0.14.0.md
+++ b/docs/release-notes/release-notes-0.14.0.md
@@ -600,6 +600,11 @@ messages directly. There is no routing/path finding involved.
 * [Fix pathfinding crash when inbound policy is unknown](
   https://github.com/lightningnetwork/lnd/pull/5922)
 
+* [Stagger connection attempts to multi-address peers to ensure that the peer
+   doesn't close the first successful connection in favour of the next if 
+   the first one was successful](
+   https://github.com/lightningnetwork/lnd/pull/5925)
+
 ## Documentation 
 
 The [code contribution guidelines have been updated to mention the new

--- a/server.go
+++ b/server.go
@@ -2858,6 +2858,7 @@ func (s *server) prunePersistentPeerConnection(compressedPubKey [33]byte) {
 	if perm, ok := s.persistentPeers[pubKeyStr]; ok && !perm {
 		delete(s.persistentPeers, pubKeyStr)
 		delete(s.persistentPeersBackoff, pubKeyStr)
+		delete(s.persistentPeerAddrs, pubKeyStr)
 		s.cancelConnReqs(pubKeyStr, nil)
 		s.mu.Unlock()
 


### PR DESCRIPTION
Currently if a peer has multiple working addresses (like 1 clearnet & 1 tor) we will, on startup and during reconnection, attempt to connect to all their advertised addresses at once. The peer will then accept the first connection and so we will cancel the second one _but_ it already reaches the peer and so then _they_ close the first connection in favour of the second one. 

I have tested that this would also happen pre #5538 when `establishPersistentConnections` would kickoff all the connReqs at once but it would then recover since `peerTerminationWatcher` would only try to connect to a single address. With #5538, `peerTerminationWatcher` also uses all the advertised addresses during it's reconnection attempt and so the issue just keeps repeating itself.

In this PR: if we have multiple addresses stored for a peer, we stagger the creation of the connReqs for those addrs.

Fixes #5887 
