### PR TITLE
script: update CI to bitcoind 22

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,7 +16,7 @@ env:
   # go needs absolute directories, using the $HOME variable doesn't work here.
   GOCACHE: /home/runner/work/go/pkg/build
   GOPATH: /home/runner/work/go
-  BITCOIN_VERSION: 0.20.1
+  BITCOIN_VERSION: "22.0"
 
   # If you change this value, please change it in the following files as well:
   # /.travis.yml

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ go:
 env:
   global:
     - GOCACHE=$HOME/.go-build
-    - BITCOIN_VERSION=0.20.1
+    - BITCOIN_VERSION="22.0"
 
 sudo: required
 

--- a/docs/release-notes/release-notes-0.14.0.md
+++ b/docs/release-notes/release-notes-0.14.0.md
@@ -323,6 +323,8 @@ messages directly. There is no routing/path finding involved.
 
 * [Upgrade the sub packages to 1.16](https://github.com/lightningnetwork/lnd/pull/5813)
 
+* [CI has been upgraded to build against bitcoind 22.0](https://github.com/lightningnetwork/lnd/pull/5928)
+
 ## Documentation
 
 * [Outdated warning about unsupported pruning was replaced with clarification that LND **does**

--- a/scripts/install_bitcoind.sh
+++ b/scripts/install_bitcoind.sh
@@ -2,9 +2,9 @@
 
 set -ev
 
-BITCOIND_VERSION=${BITCOIN_VERSION:-0.20.1}
+BITCOIND_VERSION=${BITCOIN_VERSION:-22.0}
 
-docker pull ruimarinho/bitcoin-core:$BITCOIND_VERSION
-CONTAINER_ID=$(docker create ruimarinho/bitcoin-core:$BITCOIND_VERSION)
+docker pull lightninglabs/bitcoin-core:$BITCOIND_VERSION
+CONTAINER_ID=$(docker create lightninglabs/bitcoin-core:$BITCOIND_VERSION)
 sudo docker cp $CONTAINER_ID:/opt/bitcoin-$BITCOIND_VERSION/bin/bitcoind /usr/local/bin/bitcoind
 docker rm $CONTAINER_ID


### PR DESCRIPTION
Also switches things over to our own image generated by this repo: https://github.com/lightninglabs/docker-bitcoin-core 