### PR TITLE
config_builder: always send admin macaroon

### DIFF
--- a/docs/release-notes/release-notes-0.14.0.md
+++ b/docs/release-notes/release-notes-0.14.0.md
@@ -615,6 +615,9 @@ messages directly. There is no routing/path finding involved.
    the first one was successful](
    https://github.com/lightningnetwork/lnd/pull/5925)
 
+* [Fixed an issue with external listeners and the `--noseedbackup` development
+  flag](https://github.com/lightningnetwork/lnd/pull/5930).
+
 ## Documentation 
 
 The [code contribution guidelines have been updated to mention the new

--- a/lnd.go
+++ b/lnd.go
@@ -224,10 +224,8 @@ func Main(cfg *Config, lisCfg ListenerCfg, implCfg *ImplementationCfg,
 
 	// If we have chosen to start with a dedicated listener for the
 	// rpc server, we set it directly.
-	var grpcListeners []*ListenerWithSignal
-	if len(lisCfg.RPCListeners) > 0 {
-		grpcListeners = append(grpcListeners, lisCfg.RPCListeners...)
-	} else {
+	grpcListeners := append([]*ListenerWithSignal{}, lisCfg.RPCListeners...)
+	if len(grpcListeners) == 0 {
 		// Otherwise we create listeners from the RPCListeners defined
 		// in the config.
 		for _, grpcEndpoint := range cfg.RPCListeners {
@@ -245,7 +243,8 @@ func Main(cfg *Config, lisCfg ListenerCfg, implCfg *ImplementationCfg,
 				grpcListeners, &ListenerWithSignal{
 					Listener: lis,
 					Ready:    make(chan struct{}),
-				})
+				},
+			)
 		}
 	}
 


### PR DESCRIPTION
A follow-up change to https://github.com/lightningnetwork/lnd/pull/5777 that fixes the macaroon creation in local regtest development mode where we use `--noseedbackup` flag in LiT.