### PR TITLE
rpcserver: add remote balance for pending force close

### DIFF
--- a/docs/release-notes/release-notes-0.15.0.md
+++ b/docs/release-notes/release-notes-0.15.0.md
@@ -19,6 +19,13 @@
 * [Allow disabling migrations if the database backend passed to `channeldb` was
   opened in read-only mode](https://github.com/lightningnetwork/lnd/pull/6084).
 
+## RPC Server
+
+* [Add value to the field
+  `remote_balance`](https://github.com/lightningnetwork/lnd/pull/5931) in
+  `pending_force_closing_channels` under `pendingchannels` whereas before was
+  empty(zero).
+
 ## Code Health
 
 ### Code cleanup, refactor, typo fixes

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -3317,6 +3317,10 @@ func (r *rpcServer) PendingChannels(ctx context.Context,
 			}
 			channel.NumForwardingPackages = int64(len(fwdPkgs))
 
+			channel.RemoteBalance = int64(
+				historical.LocalCommitment.RemoteBalance.ToSatoshis(),
+			)
+
 		// If the error is non-nil, and not due to older versions of lnd
 		// not persisting historical channels, return it.
 		default:


### PR DESCRIPTION
Add the missing field `RemoteBalance`. Fixes #5924.

Not sure if this balance is accurate?