### PR TITLE
Allow users to set custom lock duration in lockInputs

### DIFF
--- a/lnrpc/walletrpc/walletkit.pb.go
+++ b/lnrpc/walletrpc/walletkit.pb.go
@@ -13,6 +13,7 @@ import (
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 	reflect "reflect"
 	sync "sync"
+	time "time"
 )
 
 const (
@@ -2194,6 +2195,9 @@ type FundPsbtRequest struct {
 	MinConfs int32 `protobuf:"varint,6,opt,name=min_confs,json=minConfs,proto3" json:"min_confs,omitempty"`
 	// Whether unconfirmed outputs should be used as inputs for the transaction.
 	SpendUnconfirmed bool `protobuf:"varint,7,opt,name=spend_unconfirmed,json=spendUnconfirmed,proto3" json:"spend_unconfirmed,omitempty"`
+	// The time in seconds before the wallet's lock on the selected UTXOs expires.
+  // If set to zero, the default lock duration is used.
+	UtxoLeaseExpirationSeconds int32 `protobuf:"varint,600,opt,name=utxo_lease_expiration_seconds,json=utxoLeaseExpirationSeconds,proto3" json:"utxo_lease_expiration_seconds,omitempty"`
 }
 
 func (x *FundPsbtRequest) Reset() {
@@ -2268,6 +2272,13 @@ func (x *FundPsbtRequest) GetSatPerVbyte() uint64 {
 		return x.SatPerVbyte
 	}
 	return 0
+}
+
+func (x *FundPsbtRequest) GetUtxoLeaseExpirationSeconds() time.Duration {
+	if x != nil {
+		return time.Duration(x.UtxoLeaseExpirationSeconds) * time.Second
+	}
+	return time.Duration(0)
 }
 
 func (x *FundPsbtRequest) GetAccount() string {

--- a/lnrpc/walletrpc/walletkit.proto
+++ b/lnrpc/walletrpc/walletkit.proto
@@ -768,6 +768,10 @@ message FundPsbtRequest {
 
     // Whether unconfirmed outputs should be used as inputs for the transaction.
     bool spend_unconfirmed = 7;
+
+    // The time in seconds before the wallet's lock on the selected UTXOs expires.
+    // If set to zero, the default lock duration is used.
+    int32 utxo_lease_expiration_seconds = 8;
 }
 message FundPsbtResponse {
     /*

--- a/lnrpc/walletrpc/walletkit.swagger.json
+++ b/lnrpc/walletrpc/walletkit.swagger.json
@@ -1036,7 +1036,12 @@
         "spend_unconfirmed": {
           "type": "boolean",
           "description": "Whether unconfirmed outputs should be used as inputs for the transaction."
-        }
+        },
+        "utxo_lease_expiration_seconds": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The time in seconds before the wallet's lock on the selected UTXOs expires. If set to zero, the default lock duration is used."
+        },
       }
     },
     "walletrpcFundPsbtResponse": {

--- a/lnrpc/walletrpc/walletkit_server.go
+++ b/lnrpc/walletrpc/walletkit_server.go
@@ -1121,6 +1121,11 @@ func (w *WalletKit) FundPsbt(_ context.Context,
 			}
 		}
 
+		var lockDuration time.Duration
+		if req.UtxoLeaseExpirationSeconds != 0 {
+			lockDuration = time.Duration(req.UtxoLeaseExpirationSeconds) * time.Second
+		}
+
 		// We made sure the input from the user is as sane as possible.
 		// We can now ask the wallet to fund the TX. This will not yet
 		// lock any coins but might still change the wallet DB by
@@ -1149,7 +1154,7 @@ func (w *WalletKit) FundPsbt(_ context.Context,
 		// happens in this function. If we ever need to do more after
 		// this function, we need to extract the rollback needs to be
 		// extracted into a defer.
-		locks, err = lockInputs(w.cfg.Wallet, packet)
+		locks, err = lockInputs(w.cfg.Wallet, packet, lockDuration)
 		if err != nil {
 			return fmt.Errorf("could not lock inputs: %v", err)
 		}


### PR DESCRIPTION
**Related issue** https://github.com/lightningnetwork/lnd/issues/5425

#### Pull Request Checklist

- [x] Update `lockInputs` function
- [x] Update RPC
- [x] Update interface, swagger, and protobuf

#### Questions

- Is seconds ideal? Should timelock be specified in minutes or other format instead?

#### Pull Request Checklist

- [x] All changes are Go version 1.16 compliant
- [ ] Your PR passes all CI checks. If a check cannot be passed for a justifiable reason, that reason must be stated in the commit message and PR description.
- [ ] If this is your first time contributing, we recommend you read the [Code Contribution Guidelines](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md)
   - [ ] The code being submitted is commented according to [Code Documentation and Commenting](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#CodeDocumentation)
   - [ ] Commits have a logical structure according to [Ideal Git Commit Structure](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#IdealGitCommitStructure)
- [ ] For new code: Code is accompanied by tests which exercise both the positive and negative (error paths) conditions (if applicable)
- [ ] For bug fixes: If possible, code is accompanied by new tests which trigger the bug being fixed to prevent regressions
- [ ] Any new logging statements use an appropriate subsystem and logging level
- [ ] For code and documentation: lines are wrapped at 80 characters (the tab character should be counted as 8 characters, not 4, as some IDEs do per default)
- [ ] A description of your changes [should be added to running the release notes](https://github.com/lightningnetwork/lnd/tree/master/docs/release-notes) for the milestone your change will land in.
