### PR TITLE
channeldb: avoid locking the graph cache while iterating channels

### DIFF
--- a/docs/release-notes/release-notes-0.14.0.md
+++ b/docs/release-notes/release-notes-0.14.0.md
@@ -618,6 +618,9 @@ messages directly. There is no routing/path finding involved.
 * [Fixed an issue with external listeners and the `--noseedbackup` development
   flag](https://github.com/lightningnetwork/lnd/pull/5930).
 
+* [Fix deadlock when using the graph cache](
+  https://github.com/lightningnetwork/lnd/pull/5941)
+
 ## Documentation 
 
 The [code contribution guidelines have been updated to mention the new


### PR DESCRIPTION
Attempted fix for the deadlock reported in https://github.com/lightningnetwork/lnd/issues/5914

It may happen that we do pathfinding while also attempt to change the
graph. In this case changing the database, channel state, graph while
reading from the same sources may create deadlocks. To resolve this we
change locking policy in the graph cache when pathfinding.

An example of such deadlock inserted here to aid the review:

```
1 @ 0x489e0 0x5a7f8 0x5a7e9 0x795e0 0x678a10 0x67898d 0x70ca3c 0x740858 0x740984 0x75ff10 0x601440 0x5f185c 0x741e58 0x7490c0 0x74ab00 0x758d18 0xabdb34 0xbe6394 0xa2b22c 0xaece20 0xae6bb8 0xaec990 0xae6bb8 0xaecb30 0xae6bb8 0xaec628 0xae6bb8 0xae6d5c 0xa0b9bc 0x97fedc 0x983580 0x98f9b4
#	0x795df		sync.runtime_SemacquireMutex+0x3f										/usr/lib/go-1.16/src/runtime/sema.go:71
#	0x678a0f	sync.(*RWMutex).RLock+0xaf											/usr/lib/go-1.16/src/sync/rwmutex.go:63
=> acquiring LightningChannel mtx (read) #	0x67898c	github.com/lightningnetwork/lnd/lnwallet.(*LightningChannel).RemoteNextRevocation+0x2c				/mnt/gentoo_root/home/xmrk/programs/lnd/lnwallet/channel.go:7127
#	0x70ca3b	github.com/lightningnetwork/lnd/htlcswitch.(*channelLink).EligibleToForward+0x2b				/mnt/gentoo_root/home/xmrk/programs/lnd/htlcswitch/link.go:583
#	0x740857	github.com/lightningnetwork/lnd/routing.(*bandwidthManager).getBandwidth+0x67					/mnt/gentoo_root/home/xmrk/programs/lnd/routing/bandwidth.go:85
#	0x740983	github.com/lightningnetwork/lnd/routing.(*bandwidthManager).availableChanBandwidth+0x93				/mnt/gentoo_root/home/xmrk/programs/lnd/routing/bandwidth.go:112
#	0x75ff0f	github.com/lightningnetwork/lnd/routing.getOutgoingBalance.func1+0x5f						/mnt/gentoo_root/home/xmrk/programs/lnd/routing/pathfind.go:376
=> holding graph cache mtx (read) #	0x60143f	github.com/lightningnetwork/lnd/channeldb.(*GraphCache).ForEachChannel+0x27f					/mnt/gentoo_root/home/xmrk/programs/lnd/channeldb/graph_cache.go:442
#	0x5f185b	github.com/lightningnetwork/lnd/channeldb.(*ChannelGraph).ForEachNodeChannel+0x26b				/mnt/gentoo_root/home/xmrk/programs/lnd/channeldb/graph.go:393
#	0x741e57	github.com/lightningnetwork/lnd/routing.(*CachedGraph).forEachNodeChannel+0x67					/mnt/gentoo_root/home/xmrk/programs/lnd/routing/graph.go:70
#	0x7490bf	github.com/lightningnetwork/lnd/routing.getOutgoingBalance+0xef							/mnt/gentoo_root/home/xmrk/programs/lnd/routing/pathfind.go:397
#	0x74aaff	github.com/lightningnetwork/lnd/routing.findPath+0x199f								/mnt/gentoo_root/home/xmrk/programs/lnd/routing/pathfind.go:491
#	0x758d17	github.com/lightningnetwork/lnd/routing.(*ChannelRouter).FindRoute+0x297					/mnt/gentoo_root/home/xmrk/programs/lnd/routing/router.go:1762
#	0xabdb33	github.com/lightningnetwork/lnd/lnrpc/routerrpc.(*RouterBackend).QueryRoutes+0x8a3				/mnt/gentoo_root/home/xmrk/programs/lnd/lnrpc/routerrpc/router_backend.go:326
#	0xbe6393	github.com/lightningnetwork/lnd.(*rpcServer).QueryRoutes+0x43							/mnt/gentoo_root/home/xmrk/programs/lnd/rpcserver.go:5720
#	0xa2b22b	github.com/lightningnetwork/lnd/lnrpc._Lightning_QueryRoutes_Handler.func1+0x7b					/mnt/gentoo_root/home/xmrk/programs/lnd/lnrpc/lightning_grpc.pb.go:2763
#	0xaece1f	github.com/lightningnetwork/lnd/rpcperms.(*InterceptorChain).middlewareUnaryServerInterceptor.func1+0x1ff	/mnt/gentoo_root/home/xmrk/programs/lnd/rpcperms/interceptor.go:783
#	0xae6bb7	github.com/grpc-ecosystem/go-grpc-middleware.ChainUnaryServer.func1.1.1+0x57					/home/ubuntu/go/pkg/mod/github.com/grpc-ecosystem/go-grpc-middleware@v1.3.0/chain.go:25
#	0xaec98f	github.com/lightningnetwork/lnd/rpcperms.(*InterceptorChain).MacaroonUnaryServerInterceptor.func1+0x9f		/mnt/gentoo_root/home/xmrk/programs/lnd/rpcperms/interceptor.go:656
#	0xae6bb7	github.com/grpc-ecosystem/go-grpc-middleware.ChainUnaryServer.func1.1.1+0x57					/home/ubuntu/go/pkg/mod/github.com/grpc-ecosystem/go-grpc-middleware@v1.3.0/chain.go:25
#	0xaecb2f	github.com/lightningnetwork/lnd/rpcperms.(*InterceptorChain).rpcStateUnaryServerInterceptor.func1+0x8f		/mnt/gentoo_root/home/xmrk/programs/lnd/rpcperms/interceptor.go:747
#	0xae6bb7	github.com/grpc-ecosystem/go-grpc-middleware.ChainUnaryServer.func1.1.1+0x57					/home/ubuntu/go/pkg/mod/github.com/grpc-ecosystem/go-grpc-middleware@v1.3.0/chain.go:25
#	0xaec627	github.com/lightningnetwork/lnd/rpcperms.errorLogUnaryServerInterceptor.func1+0x57				/mnt/gentoo_root/home/xmrk/programs/lnd/rpcperms/interceptor.go:572
#	0xae6bb7	github.com/grpc-ecosystem/go-grpc-middleware.ChainUnaryServer.func1.1.1+0x57					/home/ubuntu/go/pkg/mod/github.com/grpc-ecosystem/go-grpc-middleware@v1.3.0/chain.go:25
#	0xae6d5b	github.com/grpc-ecosystem/go-grpc-middleware.ChainUnaryServer.func1+0xbb					/home/ubuntu/go/pkg/mod/github.com/grpc-ecosystem/go-grpc-middleware@v1.3.0/chain.go:34
#	0xa0b9bb	github.com/lightningnetwork/lnd/lnrpc._Lightning_QueryRoutes_Handler+0x12b					/mnt/gentoo_root/home/xmrk/programs/lnd/lnrpc/lightning_grpc.pb.go:2765
#	0x97fedb	google.golang.org/grpc.(*Server).processUnaryRPC+0x3fb								/home/ubuntu/go/pkg/mod/google.golang.org/grpc@v1.38.0/server.go:1286
#	0x98357f	google.golang.org/grpc.(*Server).handleStream+0xa6f								/home/ubuntu/go/pkg/mod/google.golang.org/grpc@v1.38.0/server.go:1609
#	0x98f9b3	google.golang.org/grpc.(*Server).serveStreams.func1.2+0x93							/home/ubuntu/go/pkg/mod/google.golang.org/grpc@v1.38.0/server.go:934

1 @ 0x489e0 0x5a7f8 0x5a7e9 0x795e0 0x948c4 0x5fff2c 0x6244f8 0x5cf768 0x532134 0x5ced34 0x5cec99 0x934bc 0x5cfa9c 0x5cfa59 0x7d4f4
#	0x795df		sync.runtime_SemacquireMutex+0x3f							/usr/lib/go-1.16/src/runtime/sema.go:71
#	0x948c3		sync.(*RWMutex).Lock+0xc3								/usr/lib/go-1.16/src/sync/rwmutex.go:116
=> acquiring graph cache mtx (write) #	0x5fff2b	github.com/lightningnetwork/lnd/channeldb.(*GraphCache).AddNode+0x6b			/mnt/gentoo_root/home/xmrk/programs/lnd/channeldb/graph_cache.go:217
#	0x6244f7	github.com/lightningnetwork/lnd/channeldb.(*ChannelGraph).AddLightningNode.func1+0x167	/mnt/gentoo_root/home/xmrk/programs/lnd/channeldb/graph.go:748
#	0x5cf767	github.com/lightningnetwork/lnd/batch.(*batch).run.func1+0x87				/mnt/gentoo_root/home/xmrk/programs/lnd/batch/batch.go:56
=> holding db mtx #	0x532133	github.com/btcsuite/btcwallet/walletdb/bdb.(*db).Update+0xa3				/home/ubuntu/go/pkg/mod/github.com/btcsuite/btcwallet/walletdb@v1.3.6-0.20210803004036-eebed51155ec/bdb/db.go:429
#	0x5ced33	github.com/lightningnetwork/lnd/kvdb.Update+0x143					/mnt/gentoo_root/home/xmrk/programs/lnd/kvdb/interface.go:16
#	0x5cec98	github.com/lightningnetwork/lnd/batch.(*batch).run+0xa8					/mnt/gentoo_root/home/xmrk/programs/lnd/batch/batch.go:54
#	0x934bb		sync.(*Once).doSlow+0x11b								/usr/lib/go-1.16/src/sync/once.go:68
#	0x5cfa9b	sync.(*Once).Do+0x6b									/usr/lib/go-1.16/src/sync/once.go:59
#	0x5cfa58	github.com/lightningnetwork/lnd/batch.(*batch).trigger+0x28				/mnt/gentoo_root/home/xmrk/programs/lnd/batch/batch.go:32


5 @ 0x489e0 0x5a7f8 0x5a7e9 0x795e0 0x92f54 0x94904 0x9481d 0x5dd494 0x66faa4 0x712fe0 0x70ea30 0x7d4f4
#	0x795df		sync.runtime_SemacquireMutex+0x3f								/usr/lib/go-1.16/src/runtime/sema.go:71
#	0x92f53		sync.(*Mutex).lockSlow+0xf3									/usr/lib/go-1.16/src/sync/mutex.go:138
#	0x94903		sync.(*Mutex).Lock+0x103									/usr/lib/go-1.16/src/sync/mutex.go:81
#	0x9481c		sync.(*RWMutex).Lock+0x1c									/usr/lib/go-1.16/src/sync/rwmutex.go:111
=> acqire OpenChannel mtx (write) #	0x5dd493	github.com/lightningnetwork/lnd/channeldb.(*OpenChannel).UpdateCommitment+0x43			/mnt/gentoo_root/home/xmrk/programs/lnd/channeldb/channel.go:1535
=> LightningChannel mtx (write) #	0x66faa3	github.com/lightningnetwork/lnd/lnwallet.(*LightningChannel).RevokeCurrentCommitment+0x2a3	/mnt/gentoo_root/home/xmrk/programs/lnd/lnwallet/channel.go:4645
#	0x712fdf	github.com/lightningnetwork/lnd/htlcswitch.(*channelLink).handleUpstreamMsg+0x133f		/mnt/gentoo_root/home/xmrk/programs/lnd/htlcswitch/link.go:1831
#	0x70ea2f	github.com/lightningnetwork/lnd/htlcswitch.(*channelLink).htlcManager+0x92f			/mnt/gentoo_root/home/xmrk/programs/lnd/htlcswitch/link.go:1189


46 @ 0x489e0 0x5a7f8 0x5a7e9 0x795e0 0x92f54 0x51e0bc 0x51defd 0x51daa0 0x530e70 0x5320e4 0x5320cd 0x5e0808 0x5e0791 0x70e0c4 0x70e0a5 0x70de08 0x7d4f4
#	0x795df		sync.runtime_SemacquireMutex+0x3f							/usr/lib/go-1.16/src/runtime/sema.go:71
#	0x92f53		sync.(*Mutex).lockSlow+0xf3								/usr/lib/go-1.16/src/sync/mutex.go:138
#	0x51e0bb	sync.(*Mutex).Lock+0x22b								/usr/lib/go-1.16/src/sync/mutex.go:81
=> acquiring db mtx #	0x51defc	go.etcd.io/bbolt.(*DB).beginRWTx+0x6c							/home/ubuntu/go/pkg/mod/go.etcd.io/bbolt@v1.3.6/db.go:640
#	0x51da9f	go.etcd.io/bbolt.(*DB).Begin+0x2f							/home/ubuntu/go/pkg/mod/go.etcd.io/bbolt@v1.3.6/db.go:589
#	0x530e6f	github.com/btcsuite/btcwallet/walletdb/bdb.(*db).beginTx+0x2f				/home/ubuntu/go/pkg/mod/github.com/btcsuite/btcwallet/walletdb@v1.3.6-0.20210803004036-eebed51155ec/bdb/db.go:323
#	0x5320e3	github.com/btcsuite/btcwallet/walletdb/bdb.(*db).BeginReadWriteTx+0x53			/home/ubuntu/go/pkg/mod/github.com/btcsuite/btcwallet/walletdb@v1.3.6-0.20210803004036-eebed51155ec/bdb/db.go:335
#	0x5320cc	github.com/btcsuite/btcwallet/walletdb/bdb.(*db).Update+0x3c				/home/ubuntu/go/pkg/mod/github.com/btcsuite/btcwallet/walletdb@v1.3.6-0.20210803004036-eebed51155ec/bdb/db.go:417
#	0x5e0807	github.com/lightningnetwork/lnd/kvdb.Update+0xd7					/mnt/gentoo_root/home/xmrk/programs/lnd/kvdb/interface.go:16
=> OpenChannel mtx (write) #	0x5e0790	github.com/lightningnetwork/lnd/channeldb.(*OpenChannel).RemoveFwdPkgs+0x60		/mnt/gentoo_root/home/xmrk/programs/lnd/channeldb/channel.go:2598
#	0x70e0c3	github.com/lightningnetwork/lnd/lnwallet.(*LightningChannel).RemoveFwdPkgs+0x123	/mnt/gentoo_root/home/xmrk/programs/lnd/lnwallet/channel.go:4936
#	0x70e0a4	github.com/lightningnetwork/lnd/htlcswitch.(*channelLink).loadAndRemove+0x104		/mnt/gentoo_root/home/xmrk/programs/lnd/htlcswitch/link.go:918
#	0x70de07	github.com/lightningnetwork/lnd/htlcswitch.(*channelLink).fwdPkgGarbager+0x127		/mnt/gentoo_root/home/xmrk/programs/lnd/htlcswitch/link.go:883```

Fixes #5914