### PR TITLE
Docs: fix language ambiguity in key import

### DIFF
--- a/docs/key_import.md
+++ b/docs/key_import.md
@@ -117,7 +117,8 @@ default until a key has been imported into them.
 * `external_key_count`: The number of external addresses generated.
 * `internal_key_count`: The number of change addresses generated.
 * `watch_only`: Whether the wallet has private key information for the account.
-  This is always true for `lnd`'s default wallet accounts.
+  `lnd`'s default wallet accounts always have private key information, so this
+  value is `false`.
 
 # Key Import
 


### PR DESCRIPTION
Documentation update to fix English language ambiguity in key import docs describing `watch_only` parameter.

#### Pull Request Checklist

- [X] For code and documentation: lines are wrapped at 80 characters (the tab character should be counted as 8 characters, not 4, as some IDEs do per default)
- [ ] A description of your changes [should be added to running the release notes](https://github.com/lightningnetwork/lnd/tree/master/docs/release-notes) for the milestone your change will land in.

Seems too trivial to add to `release-notes`, but let me know if you disagree.
