### PR TITLE
build: make it possible to use extra tags when building LND

### DIFF
--- a/docs/etcd.md
+++ b/docs/etcd.md
@@ -15,7 +15,7 @@ on bitcoin mainnet.
 To create a dev build of LND with etcd support use the following command:
 
 ```shell
-⛰  make tags="kvdb_etcd"
+⛰  make extratags="kvdb_etcd"
 ```
 
 The important tag is the `kvdb_etcd`, without which the binary is built without

--- a/docs/leader_election.md
+++ b/docs/leader_election.md
@@ -20,7 +20,7 @@ itself and for the replicated data store.
 To create a dev build of LND with leader election support use the following command:
 
 ```shell
-⛰  make tags="kvdb_etcd"
+⛰  make extratags="kvdb_etcd"
 ```
 
 ## Running a local etcd instance for testing

--- a/docs/postgres.md
+++ b/docs/postgres.md
@@ -9,7 +9,7 @@ describes how it can be configured.
 To build LND with postgres support, include the following build tag:
 
 ```shell
-⛰  make tags="kvdb_postgres"
+⛰  make extratags="kvdb_postgres"
 ```
 
 ## Configuring Postgres for LND

--- a/docs/release-notes/release-notes-0.14.0.md
+++ b/docs/release-notes/release-notes-0.14.0.md
@@ -327,6 +327,7 @@ messages directly. There is no routing/path finding involved.
 
 * [Update to the latest neutrino version](https://github.com/lightningnetwork/lnd/pull/5933)
 
+* [Provide extra build tags for additional features](https://github.com/lightningnetwork/lnd/pull/5976)
 
 ## Documentation
 

--- a/make/release_flags.mk
+++ b/make/release_flags.mk
@@ -58,3 +58,7 @@ endif
 ifneq ($(tags),)
 RELEASE_TAGS = $(tags)
 endif
+
+ifneq ($(extratags),)
+RELEASE_TAGS += $(extratags)
+endif

--- a/make/testing_flags.mk
+++ b/make/testing_flags.mk
@@ -67,6 +67,10 @@ ifneq ($(tags),)
 DEV_TAGS += ${tags}
 endif
 
+ifneq ($(extratags),)
+DEV_TAGS += $(extratags)
+endif
+
 # Define the log tags that will be applied only when running unit tests. If none
 # are provided, we default to "nolog" which will be silent.
 ifneq ($(log),)


### PR DESCRIPTION
This PR adds the `extratags` option to our build such that the default tags won't be overwritten when using it.
An example where this is useful is when building with support for the remote kvdb backends:

`make extratags=kvdb_postgres kvdb_etcd`

(Realized it's difficult to do this while discussing https://github.com/lightningnetwork/lnd/issues/5975)