### PR TITLE
cmd/lncli: fix nil map in payment req [skip ci]

### DIFF
--- a/cmd/lncli/cmd_payments.go
+++ b/cmd/lncli/cmd_payments.go
@@ -291,8 +291,9 @@ func sendPayment(ctx *cli.Context) error {
 	// details of the payment are encoded within the request.
 	if ctx.IsSet("pay_req") {
 		req := &routerrpc.SendPaymentRequest{
-			PaymentRequest: ctx.String("pay_req"),
-			Amt:            ctx.Int64("amt"),
+			PaymentRequest:    ctx.String("pay_req"),
+			Amt:               ctx.Int64("amt"),
+			DestCustomRecords: make(map[uint64][]byte),
 		}
 
 		// We'll attempt to parse a payment address as well, given that


### PR DESCRIPTION
Fixes #5989.
Fixes a panic in lncli if a payment request and the --data flag is used
at the same time.
