### PR TITLE
cmd/lncli: remove --amp-reuse flag from lncli payinvoice

### DIFF
--- a/cmd/lncli/cmd_payments.go
+++ b/cmd/lncli/cmd_payments.go
@@ -94,12 +94,6 @@ var (
 		Usage: "if set to true, then AMP will be used to complete the " +
 			"payment",
 	}
-
-	ampReuseFlag = cli.BoolFlag{
-		Name: "amp-reuse",
-		Usage: "if set to true, then a random payment address will " +
-			"be generated to enable re-use of an AMP invoice",
-	}
 )
 
 // paymentFlags returns common flags for sendpayment and payinvoice.
@@ -145,7 +139,6 @@ func paymentFlags() []cli.Flag {
 		},
 		dataFlag, inflightUpdatesFlag, maxPartsFlag, jsonFlag,
 		maxShardSizeSatFlag, maxShardSizeMsatFlag, ampFlag,
-		ampReuseFlag,
 	}
 }
 
@@ -251,15 +244,6 @@ func parsePayAddr(ctx *cli.Context) ([]byte, error) {
 	switch {
 	case ctx.IsSet("pay_addr"):
 		payAddr, err = hex.DecodeString(ctx.String("pay_addr"))
-
-	case ctx.IsSet(ampReuseFlag.Name):
-		var addrBytes [32]byte
-		if _, err := rand.Read(addrBytes[:]); err != nil {
-			return nil, fmt.Errorf("unable to generate pay "+
-				"addr: %v", err)
-		}
-
-		payAddr = addrBytes[:]
 
 	case ctx.Args().Present():
 		payAddr, err = hex.DecodeString(ctx.Args().First())

--- a/docs/release-notes/release-notes-0.14.0.md
+++ b/docs/release-notes/release-notes-0.14.0.md
@@ -370,6 +370,8 @@ messages directly. There is no routing/path finding involved.
   add MacChan field for passing back lnd's admin macaroon back to the program 
   calling lnd, when needed.
 
+* [The `--amp-reuse` CLI flag has been removed as the latest flavor of AMP now natively supports static invoices](https://github.com/lightningnetwork/lnd/pull/5991)
+
 * Using `go get` to install go executables is now deprecated. Migrate to `go install` our lnrpc proto dockerfile [Migrate `go get` to `go install`](https://github.com/lightningnetwork/lnd/pull/5879)
 
 * [The premature update map has been revamped using an LRU cache](https://github.com/lightningnetwork/lnd/pull/5902)


### PR DESCRIPTION
In this commit, we remove the `--amp-reuse` flag as with the latest
version of lnd that implements properly re-useable AMP invoices, this
flag is no longer needed.

