### PR TITLE
mod: bump version of kvdb submodule

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -105,6 +105,29 @@ jobs:
         run: scripts/check-each-commit.sh upstream/master
 
   ########################
+  # check submodules
+  ########################
+  check-submodules:
+    name: check submodules
+    runs-on: ubuntu-latest
+    steps:
+      - name: git checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: fetch and rebase on master
+        run: |
+          git remote add upstream https://github.com/lightningnetwork/lnd
+          git fetch upstream
+          export GIT_COMMITTER_EMAIL="lnd-ci@example.com"
+          export GIT_COMMITTER_NAME="LND CI"
+          git rebase upstream/master
+
+      - name: check submodules
+        run: scripts/check-submodule-version.sh upstream/master
+
+  ########################
   # lint code
   ########################
   lint:

--- a/go.mod
+++ b/go.mod
@@ -43,7 +43,7 @@ require (
 	github.com/lightningnetwork/lnd/cert v1.1.0
 	github.com/lightningnetwork/lnd/clock v1.1.0
 	github.com/lightningnetwork/lnd/healthcheck v1.2.0
-	github.com/lightningnetwork/lnd/kvdb v1.2.0
+	github.com/lightningnetwork/lnd/kvdb v1.2.1
 	github.com/lightningnetwork/lnd/queue v1.1.0
 	github.com/lightningnetwork/lnd/ticker v1.1.0
 	github.com/ltcsuite/ltcd v0.0.0-20190101042124-f37f8bf35796

--- a/scripts/check-submodule-version.sh
+++ b/scripts/check-submodule-version.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+ROOT_MODULE="github.com/lightningnetwork/lnd"
+
+# The command 'go list -m all' returns all imports in the following format:
+#   github.com/lightningnetwork/lnd/cert v1.1.0 => ./cert
+# The two cut then first split by spaces and then by slashes to extract the
+# submodule names.
+SUBMODULES="$(go list -m all | grep $ROOT_MODULE/ | cut -d' ' -f1 | cut -d'/' -f4-)"
+BRANCH=$1
+
+for m in $SUBMODULES; do
+  has_changes=0
+  git diff --stat $BRANCH.. | grep -q " $m/" && has_changes=1
+  
+  if [[ $has_changes -eq 1 ]]; then
+    has_bump=0
+    git diff $BRANCH.. -- go.mod | \
+      grep -q "^\+[[:space:]]*$ROOT_MODULE/$m " && has_bump=1
+    
+    if [[ $has_bump -eq 0 ]]; then
+      echo "Submodule '$m' has changes but no version bump in go.mod was found"
+      echo "If you update code in a submodule, you must bump its version in "
+      echo "go.mod to the _next_ version so a tag for that version can be"
+      echo "pushed after merging the PR."
+      exit 1
+    else
+      echo "Submodule '$m' has changes but go.mod bumps it to: "
+      git diff $BRANCH.. -- go.mod | grep $m
+    fi
+  else
+    echo "Submodule '$m' has no changes, skipping"
+  fi
+done


### PR DESCRIPTION
PR #5992 was merged without a bump in the kvdb version which results in
an error when trying to pull in lnd 0.14.0-beta as a library in other
projects.

I already pushed the kvdb/v1.2.1 tag, so this just fixes the import in external projects.

To avoid this problem in the future, a new script is added that checks for changes in submodules without a bump in the version.
The new procedure for changing submodules now is:
 1. Create a PR with the changes to a submodule, for example `kvdb`.
 2. In the PR, bump the version of that submodule in the root `go.mod`. That version will not exist as a tag yet. But because of our local `replace` directives, that will not matter to any of the CI scripts as they all just follow the `replace` directive.
 3. Once the PR is merged, all that needs to be done is to push a tag for the new submodule version, pointing to the merge commit of the PR.
 
