### PR TITLE
contractcourt: only supplement resolvers if channel has historical state

### DIFF
--- a/docs/release-notes/release-notes-0.14.1.md
+++ b/docs/release-notes/release-notes-0.14.1.md
@@ -1,0 +1,5 @@
+# Release Notes
+
+# Bug Fixes
+
+[Fixed a bug that would cause nodes with older channels to be unable to start up](https://github.com/lightningnetwork/lnd/pull/6003).


### PR DESCRIPTION
In this commit, we fix a bug that would cause newly updated nodes to be
unable to start up, if they have an older channel that was closed before
we started to store all the historical state for each channel.

The issue is that we started to write the complete state to disk, but
newer channels don't have it, so when we try to supplement the
resolvers, we run into this error.

Ultimately, we only need this new supplemented information for script
enforcement channels. Ideally we would instead check the channel type
there instead, but it doesn't appear to be available in this context as
is, without further changes.

Fixes https://github.com/lightningnetwork/lnd/issues/6001.

