### PR TITLE
feature: if a bit is unset, then all other features that dep it should be 

### DIFF
--- a/docs/release-notes/release-notes-0.14.1.md
+++ b/docs/release-notes/release-notes-0.14.1.md
@@ -1,0 +1,3 @@
+# Release Notes
+
+[Fixes a bug that would cause lnd to be unable to start if anchors was disabled](https://github.com/lightningnetwork/lnd/pull/6007).

--- a/feature/manager.go
+++ b/feature/manager.go
@@ -91,6 +91,21 @@ func newManager(cfg Config, desc setDesc) (*Manager, error) {
 		if cfg.NoAnchors {
 			raw.Unset(lnwire.AnchorsZeroFeeHtlcTxOptional)
 			raw.Unset(lnwire.AnchorsZeroFeeHtlcTxRequired)
+
+			// If anchors are disabled, then we also need to
+			// disable all other features that depend on it as
+			// well, as otherwise we may create an invalid feature
+			// bit set.
+			for bit, depFeatures := range deps {
+				for depFeature := range depFeatures {
+					switch {
+					case depFeature == lnwire.AnchorsZeroFeeHtlcTxRequired:
+						fallthrough
+					case depFeature == lnwire.AnchorsZeroFeeHtlcTxOptional:
+						raw.Unset(bit)
+					}
+				}
+			}
 		}
 		if cfg.NoWumbo {
 			raw.Unset(lnwire.WumboChannelsOptional)

--- a/feature/manager_internal_test.go
+++ b/feature/manager_internal_test.go
@@ -52,6 +52,12 @@ var managerTests = []managerTest{
 			NoStaticRemoteKey: true,
 		},
 	},
+	{
+		name: "anchors should disable anything dependent on it",
+		cfg: Config{
+			NoAnchors: true,
+		},
+	},
 }
 
 // TestManager asserts basic initialazation and operation of a feature manager,
@@ -103,6 +109,10 @@ func testManager(t *testing.T, test managerTest) {
 		}
 		if test.cfg.NoStaticRemoteKey {
 			assertUnset(lnwire.StaticRemoteKeyOptional)
+		}
+		if test.cfg.NoAnchors {
+			assertUnset(lnwire.ScriptEnforcedLeaseRequired)
+			assertUnset(lnwire.ScriptEnforcedLeaseOptional)
 		}
 
 		assertUnset(unknownFeature)


### PR DESCRIPTION
This fixes an issue where if one tries to unset a feature like anchors,
and other feature depend on it, then `lnd` fails to start as it realizes
that its dependnacy set is inconsistent.

Fixes https://github.com/lightningnetwork/lnd/issues/6002