### PR TITLE
channeldb: check fetchOpenChannel() error

### DIFF
--- a/channeldb/db.go
+++ b/channeldb/db.go
@@ -1410,9 +1410,12 @@ func (c *ChannelStateDB) FetchHistoricalChannel(outPoint *wire.OutPoint) (
 		}
 
 		channel, err = fetchOpenChannel(chanBucket, outPoint)
+		if err != nil {
+			return err
+		}
 
 		channel.Db = c
-		return err
+		return nil
 	}, func() {
 		channel = nil
 	})

--- a/docs/release-notes/release-notes-0.14.1.md
+++ b/docs/release-notes/release-notes-0.14.1.md
@@ -3,7 +3,9 @@
 ## Bug Fixes
 
 * [Fixed an inaccurate log message during a compaction failure](https://github.com/lightningnetwork/lnd/issues/5937)
+* [A bug has been fixed in channeldb that uses the return value without checking error](https://github.com/lightningnetwork/lnd/pull/6012)
 
 # Contributors (Alphabetical Order)
 
 * Jamie Turley
+* nayuta-ueno


### PR DESCRIPTION
It uses the return value without checking for errors in `fetchOpenChannel()`.