### PR TITLE
GitHub: use go version that understands retract directive

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -116,6 +116,11 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: setup go ${{ env.GO_VERSION }}
+        uses: actions/setup-go@v2
+        with:
+          go-version: '${{ env.GO_VERSION }}'
+
       - name: fetch and rebase on master
         run: |
           git remote add upstream https://github.com/lightningnetwork/lnd


### PR DESCRIPTION
As is customary with new GitHub actions, they don't work on first
attempt if you don't test them *sigh*

We need to use a more recent version of golang than is pre-installed to
avoid the "unknown directive: retract" error message.

