### PR TITLE
tor+healthcheck: fix healthcheck for multiple services

### DIFF
--- a/docs/release-notes/release-notes-0.14.1.md
+++ b/docs/release-notes/release-notes-0.14.1.md
@@ -2,10 +2,18 @@
 
 ## Bug Fixes
 
-* [Fixed an inaccurate log message during a compaction failure](https://github.com/lightningnetwork/lnd/issues/5937)
-* [A bug has been fixed in channeldb that uses the return value without checking error](https://github.com/lightningnetwork/lnd/pull/6012)
+* [Fixed an inaccurate log message during a compaction
+  failure](https://github.com/lightningnetwork/lnd/pull/5961).
+
+* [Fixed a bug in the Tor controller that would cause the health check to fail
+  if there was more than one hidden service
+  configured](https://github.com/lightningnetwork/lnd/pull/6016).
+
+* [A bug has been fixed in channeldb that uses the return value without checking
+  the returned error first](https://github.com/lightningnetwork/lnd/pull/6012).
 
 # Contributors (Alphabetical Order)
 
 * Jamie Turley
 * nayuta-ueno
+* Oliver Gugger

--- a/healthcheck/tor_connection.go
+++ b/healthcheck/tor_connection.go
@@ -48,7 +48,7 @@ func CheckTorServiceStatus(tc *tor.Controller,
 		return restartTorController(tc, createService)
 
 	// If this is not a connection layer error, such as
-	// ErrServiceNotCreated or ErrServiceIDUnmatch, there's little we can
+	// ErrServiceNotCreated or ErrServiceIDMismatch, there's little we can
 	// do but to report the error to the user.
 	default:
 		return err


### PR DESCRIPTION
Fixes #6013.
This commit fixes the Tor healthcheck that would previously fail if
there were multiple hidden service registered.
In the controller, we only need to know that our service is contained in
the list of active services. But we can't do a string equality check
since there might be multiple services, comma separated.
