### PR TITLE
Rebase bugfix PRs, prepare for minor release

### DIFF
--- a/docs/release-notes/release-notes-0.14.1.md
+++ b/docs/release-notes/release-notes-0.14.1.md
@@ -15,6 +15,9 @@
 * [Fixes a bug that would cause lnd to be unable to start if anchors was
   disabled](https://github.com/lightningnetwork/lnd/pull/6007).
 
+* [Fixed a bug that would cause nodes with older channels to be unable to start
+  up](https://github.com/lightningnetwork/lnd/pull/6003).
+
 # Contributors (Alphabetical Order)
 
 * Jamie Turley

--- a/docs/release-notes/release-notes-0.14.1.md
+++ b/docs/release-notes/release-notes-0.14.1.md
@@ -12,8 +12,12 @@
 * [A bug has been fixed in channeldb that uses the return value without checking
   the returned error first](https://github.com/lightningnetwork/lnd/pull/6012).
 
+* [Fixes a bug that would cause lnd to be unable to start if anchors was
+  disabled](https://github.com/lightningnetwork/lnd/pull/6007).
+
 # Contributors (Alphabetical Order)
 
 * Jamie Turley
 * nayuta-ueno
+* Olaoluwa Osuntokun
 * Oliver Gugger

--- a/docs/release-notes/release-notes-0.14.1.md
+++ b/docs/release-notes/release-notes-0.14.1.md
@@ -18,6 +18,10 @@
 * [Fixed a bug that would cause nodes with older channels to be unable to start
   up](https://github.com/lightningnetwork/lnd/pull/6003).
 
+* [Addresses an issue with explicit channel type negotiation that caused
+  incompatibilities when opening channels with the latest versions of
+  c-lightning and eclair](https://github.com/lightningnetwork/lnd/pull/6026).
+
 # Contributors (Alphabetical Order)
 
 * Jamie Turley

--- a/feature/manager.go
+++ b/feature/manager.go
@@ -91,6 +91,21 @@ func newManager(cfg Config, desc setDesc) (*Manager, error) {
 		if cfg.NoAnchors {
 			raw.Unset(lnwire.AnchorsZeroFeeHtlcTxOptional)
 			raw.Unset(lnwire.AnchorsZeroFeeHtlcTxRequired)
+
+			// If anchors are disabled, then we also need to
+			// disable all other features that depend on it as
+			// well, as otherwise we may create an invalid feature
+			// bit set.
+			for bit, depFeatures := range deps {
+				for depFeature := range depFeatures {
+					switch {
+					case depFeature == lnwire.AnchorsZeroFeeHtlcTxRequired:
+						fallthrough
+					case depFeature == lnwire.AnchorsZeroFeeHtlcTxOptional:
+						raw.Unset(bit)
+					}
+				}
+			}
 		}
 		if cfg.NoWumbo {
 			raw.Unset(lnwire.WumboChannelsOptional)

--- a/feature/manager_internal_test.go
+++ b/feature/manager_internal_test.go
@@ -52,6 +52,12 @@ var managerTests = []managerTest{
 			NoStaticRemoteKey: true,
 		},
 	},
+	{
+		name: "anchors should disable anything dependent on it",
+		cfg: Config{
+			NoAnchors: true,
+		},
+	},
 }
 
 // TestManager asserts basic initialazation and operation of a feature manager,
@@ -103,6 +109,10 @@ func testManager(t *testing.T, test managerTest) {
 		}
 		if test.cfg.NoStaticRemoteKey {
 			assertUnset(lnwire.StaticRemoteKeyOptional)
+		}
+		if test.cfg.NoAnchors {
+			assertUnset(lnwire.ScriptEnforcedLeaseRequired)
+			assertUnset(lnwire.ScriptEnforcedLeaseOptional)
 		}
 
 		assertUnset(unknownFeature)

--- a/funding/commitment_type_negotiation.go
+++ b/funding/commitment_type_negotiation.go
@@ -8,12 +8,6 @@ import (
 )
 
 var (
-	// errUnsupportedExplicitNegotiation is an error returned when explicit
-	// channel commitment negotiation is attempted but either peer of the
-	// channel does not support it.
-	errUnsupportedExplicitNegotiation = errors.New("explicit channel " +
-		"type negotiation not supported")
-
 	// errUnsupportedCommitmentType is an error returned when a specific
 	// channel commitment type is being explicitly negotiated but either
 	// peer of the channel does not support it.
@@ -29,12 +23,13 @@ func negotiateCommitmentType(channelType *lnwire.ChannelType,
 	local, remote *lnwire.FeatureVector) (lnwallet.CommitmentType, error) {
 
 	if channelType != nil {
-		if !hasFeatures(local, remote, lnwire.ExplicitChannelTypeOptional) {
-			return 0, errUnsupportedExplicitNegotiation
+		// If the peer does know explicit negotiation, let's attempt
+		// that now.
+		if hasFeatures(local, remote, lnwire.ExplicitChannelTypeOptional) {
+			return explicitNegotiateCommitmentType(
+				*channelType, local, remote,
+			)
 		}
-		return explicitNegotiateCommitmentType(
-			*channelType, local, remote,
-		)
 	}
 
 	return implicitNegotiateCommitmentType(local, remote), nil

--- a/funding/commitment_type_negotiation_test.go
+++ b/funding/commitment_type_negotiation_test.go
@@ -36,7 +36,8 @@ func TestCommitmentTypeNegotiation(t *testing.T) {
 				lnwire.StaticRemoteKeyOptional,
 				lnwire.AnchorsZeroFeeHtlcTxOptional,
 			),
-			expectsErr: errUnsupportedExplicitNegotiation,
+			expectsRes: lnwallet.CommitmentTypeAnchorsZeroFeeHtlcTx,
+			expectsErr: nil,
 		},
 		{
 			name: "explicit missing remote commitment feature",
@@ -181,8 +182,14 @@ func TestCommitmentTypeNegotiation(t *testing.T) {
 				return
 			}
 
-			require.Equal(t, testCase.expectsRes, localType)
-			require.Equal(t, testCase.expectsRes, remoteType)
+			require.Equal(
+				t, testCase.expectsRes, localType,
+				testCase.name,
+			)
+			require.Equal(
+				t, testCase.expectsRes, remoteType,
+				testCase.name,
+			)
 		})
 		if !ok {
 			return


### PR DESCRIPTION
Replaces #6007.
Replaces #6003.

Fixes #6001.
Fixes #6002.
Fixes #5890.

Addresses an issue with explicit channel type negotiation that caused incompatibilities when opening channels with the latest versions of c-lightning and eclair (#5890).
