### PR TITLE
funding: ensure a local funding w/ explicit type can't be downgraded

### DIFF
--- a/docs/release-notes/release-notes-0.14.1.md
+++ b/docs/release-notes/release-notes-0.14.1.md
@@ -22,6 +22,10 @@
   incompatibilities when opening channels with the latest versions of
   c-lightning and eclair](https://github.com/lightningnetwork/lnd/pull/6026).
 
+* [Ensure that if a user specifies explicit channel funding on the API level,
+  then it can't be
+  downgraded](https://github.com/lightningnetwork/lnd/pull/6027).
+
 # Contributors (Alphabetical Order)
 
 * Jamie Turley


### PR DESCRIPTION
In this commit, we fix an API inconsistency introduced by a recent fix.
Without this commit, it would be possible for a local user to attempt an
explicit funding type, but then _fallback_ to implicit negotiation if
the remote party didn't have the bit set.

We resolve this by adding a new bit of information to ensure that if
we're the funder and want explicit chan negotiation, we don't settle
for anything less. A new test case has been added to exercise this
behavior.

To recap for posterity, the following issues were found and fixed in the
negotiation logic:

  1. If the remote party sent a channel type (in accept channel), but we
     didn't, then we would error out. [We no longer error out and instead
     ensure the channel type they sent matches what we derived via
     implicit funding](https://github.com/lightningnetwork/lnd/pull/6026/commits/328e3361ffce9646e49740258452e100d6696000).

  2. If the remote party _did not_ have the bit set, but they sent a
     chan type (in open channel), we would error out. [We no longer error
     out, but instead will fall back to implicit negotiation](https://github.com/lightningnetwork/lnd/commit/6ee79136622d3ac89d8135bffadc1f111728e241#diff-dd1d4a81d2bdd954f6fbc81797615948b32d990dc12ad25a9d697886770cd0a9).

Ultimately we want to eventually flip the explicit funding bit to
_required_ to eliminate any other future ambiguities and also ensure
that it isn't possible to inadvertently fall back to implicit funding,
when the _user_ expects explicit funding.