### PR TITLE
docs: remove PIDFile from example systemd service [skip ci]

### DIFF
--- a/contrib/init/lnd.service
+++ b/contrib/init/lnd.service
@@ -10,7 +10,6 @@ After=bitcoind.service
 [Service]
 ExecStart=/usr/local/bin/lnd
 ExecStop=/usr/local/bin/lncli stop
-PIDFile=/home/bitcoin/.lnd/lnd.pid
 
 # Replace these with the user:group that will run lnd
 User=bitcoin


### PR DESCRIPTION
Specifying `PIDFile` is not advised when using `Type=notify` for systemd services.
 
from https://www.freedesktop.org/software/systemd/man/systemd.service.html#PIDFile= :
> Note that PID files should be avoided in modern projects. Use Type=notify or Type=simple where possible, which does not require use of PID files to determine the main process of a service and avoids needless forking.
