### PR TITLE
discovery: resend premature messages when block height reached

### DIFF
--- a/chainntnfs/txnotifier.go
+++ b/chainntnfs/txnotifier.go
@@ -614,8 +614,8 @@ func (n *TxNotifier) RegisterConf(txid *chainhash.Hash, pkScript []byte,
 	if err == nil {
 		if hint > startHeight {
 			Log.Debugf("Using height hint %d retrieved from cache "+
-				"for %v instead of %d", hint, ntfn.ConfRequest,
-				startHeight)
+				"for %v instead of %d for conf subscription",
+				hint, ntfn.ConfRequest, startHeight)
 			startHeight = hint
 		}
 	} else if err != ErrConfirmHintNotFound {
@@ -1009,8 +1009,8 @@ func (n *TxNotifier) RegisterSpend(outpoint *wire.OutPoint, pkScript []byte,
 	if err == nil {
 		if hint > startHeight {
 			Log.Debugf("Using height hint %d retrieved from cache "+
-				"for %v instead of %d", hint, ntfn.SpendRequest,
-				startHeight)
+				"for %v instead of %d for spend subscription",
+				hint, ntfn.SpendRequest, startHeight)
 			startHeight = hint
 		}
 	} else if err != ErrSpendHintNotFound {

--- a/discovery/gossiper.go
+++ b/discovery/gossiper.go
@@ -309,6 +309,14 @@ func newRejectCacheKey(cid uint64, pub [33]byte) rejectCacheKey {
 	return k
 }
 
+// sourceToPub returns a serialized-compressed public key for use in the reject
+// cache.
+func sourceToPub(pk *btcec.PublicKey) [33]byte {
+	var pub [33]byte
+	copy(pub[:], pk.SerializeCompressed())
+	return pub
+}
+
 // cachedReject is the empty value used to track the value for rejects.
 type cachedReject struct {
 }
@@ -1167,7 +1175,8 @@ func (d *AuthenticatedGossiper) networkHandler() {
 			// If this message was recently rejected, then we won't
 			// attempt to re-process it.
 			if announcement.isRemote && d.isRecentlyRejectedMsg(
-				announcement.msg, announcement.peer.PubKey(),
+				announcement.msg,
+				sourceToPub(announcement.source),
 			) {
 				announcement.err <- fmt.Errorf("recently " +
 					"rejected")
@@ -1828,7 +1837,7 @@ func (d *AuthenticatedGossiper) processNetworkAnnouncement(
 
 			key := newRejectCacheKey(
 				msg.ShortChannelID.ToUint64(),
-				nMsg.peer.PubKey(),
+				sourceToPub(nMsg.source),
 			)
 			_, _ = d.recentRejects.Put(key, &cachedReject{})
 
@@ -1871,7 +1880,7 @@ func (d *AuthenticatedGossiper) processNetworkAnnouncement(
 
 				key := newRejectCacheKey(
 					msg.ShortChannelID.ToUint64(),
-					nMsg.peer.PubKey(),
+					sourceToPub(nMsg.source),
 				)
 				_, _ = d.recentRejects.Put(key, &cachedReject{})
 
@@ -1949,7 +1958,7 @@ func (d *AuthenticatedGossiper) processNetworkAnnouncement(
 
 					key := newRejectCacheKey(
 						msg.ShortChannelID.ToUint64(),
-						nMsg.peer.PubKey(),
+						sourceToPub(nMsg.source),
 					)
 					_, _ = d.recentRejects.Put(key, &cachedReject{})
 
@@ -1976,7 +1985,7 @@ func (d *AuthenticatedGossiper) processNetworkAnnouncement(
 
 				key := newRejectCacheKey(
 					msg.ShortChannelID.ToUint64(),
-					nMsg.peer.PubKey(),
+					sourceToPub(nMsg.source),
 				)
 				_, _ = d.recentRejects.Put(key, &cachedReject{})
 			}
@@ -2066,7 +2075,7 @@ func (d *AuthenticatedGossiper) processNetworkAnnouncement(
 
 			key := newRejectCacheKey(
 				msg.ShortChannelID.ToUint64(),
-				nMsg.peer.PubKey(),
+				sourceToPub(nMsg.source),
 			)
 			_, _ = d.recentRejects.Put(key, &cachedReject{})
 
@@ -2198,7 +2207,7 @@ func (d *AuthenticatedGossiper) processNetworkAnnouncement(
 
 			key := newRejectCacheKey(
 				msg.ShortChannelID.ToUint64(),
-				nMsg.peer.PubKey(),
+				sourceToPub(nMsg.source),
 			)
 			_, _ = d.recentRejects.Put(key, &cachedReject{})
 
@@ -2310,7 +2319,7 @@ func (d *AuthenticatedGossiper) processNetworkAnnouncement(
 			} else {
 				key := newRejectCacheKey(
 					msg.ShortChannelID.ToUint64(),
-					nMsg.peer.PubKey(),
+					sourceToPub(nMsg.source),
 				)
 				_, _ = d.recentRejects.Put(key, &cachedReject{})
 

--- a/discovery/gossiper.go
+++ b/discovery/gossiper.go
@@ -757,6 +757,8 @@ func (d *deDupedAnnouncements) reset() {
 // and the set of senders is updated to reflect which node sent us this
 // message.
 func (d *deDupedAnnouncements) addMsg(message networkMsg) {
+	log.Tracef("Adding network message: %v to batch", message.msg.MsgType())
+
 	// Depending on the message type (channel announcement, channel update,
 	// or node announcement), the message is added to the corresponding map
 	// in deDupedAnnouncements. Because each identifying key can have at
@@ -806,6 +808,10 @@ func (d *deDupedAnnouncements) addMsg(message networkMsg) {
 		// If we already had this message with a strictly newer
 		// timestamp, then we'll just discard the message we got.
 		if oldTimestamp > msg.Timestamp {
+			log.Debugf("Ignored outdated network message: "+
+				"peer=%v, source=%x, msg=%s, ", message.peer,
+				message.source.SerializeCompressed(),
+				msg.MsgType())
 			return
 		}
 
@@ -1025,6 +1031,9 @@ func (d *AuthenticatedGossiper) networkHandler() {
 		// sub-systems below us, then craft, sign, and broadcast a new
 		// ChannelUpdate for the set of affected clients.
 		case policyUpdate := <-d.chanPolicyUpdates:
+			log.Tracef("Received channel %d policy update requests",
+				len(policyUpdate.edgesToUpdate))
+
 			// First, we'll now create new fully signed updates for
 			// the affected channels and also update the underlying
 			// graph with the new state.
@@ -1044,6 +1053,13 @@ func (d *AuthenticatedGossiper) networkHandler() {
 			announcements.AddMsgs(newChanUpdates...)
 
 		case announcement := <-d.networkMsgs:
+			log.Tracef("Received network message: "+
+				"peer=%v, source=%x, msg=%s, is_remote=%v",
+				announcement.peer,
+				announcement.source.SerializeCompressed(),
+				announcement.msg.MsgType(),
+				announcement.isRemote)
+
 			// We should only broadcast this message forward if it
 			// originated from us or it wasn't received as part of
 			// our initial historical sync.
@@ -1057,6 +1073,11 @@ func (d *AuthenticatedGossiper) networkHandler() {
 				emittedAnnouncements, _ := d.processNetworkAnnouncement(
 					announcement,
 				)
+				log.Debugf("Processed network message %s, "+
+					"returned len(announcements)=%v",
+					announcement.msg.MsgType(),
+					len(emittedAnnouncements))
+
 				if emittedAnnouncements != nil {
 					announcements.AddMsgs(
 						emittedAnnouncements...,
@@ -1110,6 +1131,13 @@ func (d *AuthenticatedGossiper) networkHandler() {
 				emittedAnnouncements, allowDependents := d.processNetworkAnnouncement(
 					announcement,
 				)
+
+				log.Tracef("Processed network message %s, "+
+					"returned len(announcements)=%v, "+
+					"allowDependents=%v",
+					announcement.msg.MsgType(),
+					len(emittedAnnouncements),
+					allowDependents)
 
 				// If this message had any dependencies, then
 				// we can now signal them to continue.
@@ -1589,6 +1617,10 @@ func (d *AuthenticatedGossiper) addNode(msg *lnwire.NodeAnnouncement,
 func (d *AuthenticatedGossiper) processNetworkAnnouncement(
 	nMsg *networkMsg) ([]networkMsg, bool) {
 
+	log.Debugf("Processing network message: peer=%v, source=%x, msg=%s, "+
+		"is_remote=%v", nMsg.peer, nMsg.source.SerializeCompressed(),
+		nMsg.msg.MsgType(), nMsg.isRemote)
+
 	isPremature := func(chanID lnwire.ShortChannelID, delta uint32) bool {
 		// TODO(roasbeef) make height delta 6
 		//  * or configurable
@@ -1616,17 +1648,25 @@ func (d *AuthenticatedGossiper) processNetworkAnnouncement(
 		// newer update for this node so we can skip validating
 		// signatures if not required.
 		if d.cfg.Router.IsStaleNode(msg.NodeID, timestamp) {
+			log.Debugf("Skipped processing stale node: %x",
+				msg.NodeID)
 			nMsg.err <- nil
 			return nil, true
 		}
 
 		if err := d.addNode(msg, schedulerOp...); err != nil {
-			if routing.IsError(err, routing.ErrOutdated,
-				routing.ErrIgnored) {
+			log.Debugf("Adding node: %x got error: %v",
+				msg.NodeID, err)
 
-				log.Debug(err)
-			} else if err != routing.ErrVBarrierShuttingDown {
+			switch {
+			case routing.IsError(err, routing.ErrOutdated,
+				routing.ErrIgnored):
+
+			case err == routing.ErrVBarrierShuttingDown:
+
+			default:
 				log.Error(err)
+
 			}
 
 			nMsg.err <- err
@@ -1817,7 +1857,7 @@ func (d *AuthenticatedGossiper) processNetworkAnnouncement(
 				log.Debugf("Router rejected channel "+
 					"edge: %v", err)
 			} else {
-				log.Tracef("Router rejected channel "+
+				log.Debugf("Router rejected channel "+
 					"edge: %v", err)
 
 				key := newRejectCacheKey(
@@ -1943,6 +1983,12 @@ func (d *AuthenticatedGossiper) processNetworkAnnouncement(
 		if d.cfg.Router.IsStaleEdgePolicy(
 			msg.ShortChannelID, timestamp, msg.ChannelFlags,
 		) {
+
+			log.Debugf("Ignored stale edge policy: peer=%v, "+
+				"source=%x, msg=%s, is_remote=%v", nMsg.peer,
+				nMsg.source.SerializeCompressed(),
+				nMsg.msg.MsgType(), nMsg.isRemote)
+
 			nMsg.err <- nil
 			return nil, true
 		}
@@ -2165,6 +2211,10 @@ func (d *AuthenticatedGossiper) processNetworkAnnouncement(
 			remotePubKey := remotePubFromChanInfo(
 				chanInfo, msg.ChannelFlags,
 			)
+
+			log.Debugf("The message %v has no AuthProof, sending "+
+				"the update to remote peer %x",
+				msg.MsgType(), remotePubKey)
 
 			// Now, we'll attempt to send the channel update message
 			// reliably to the remote peer in the background, so

--- a/discovery/reliable_sender.go
+++ b/discovery/reliable_sender.go
@@ -131,10 +131,10 @@ spawnHandler:
 // spawnPeerMsgHandler spawns a peerHandler for the given peer if there isn't
 // one already active. The boolean returned signals whether there was already
 // one active or not.
-func (s *reliableSender) spawnPeerHandler(peerPubKey [33]byte) (peerManager, bool) {
-	s.activePeersMtx.Lock()
-	defer s.activePeersMtx.Unlock()
+func (s *reliableSender) spawnPeerHandler(
+	peerPubKey [33]byte) (peerManager, bool) {
 
+	s.activePeersMtx.Lock()
 	msgHandler, ok := s.activePeers[peerPubKey]
 	if !ok {
 		msgHandler = peerManager{
@@ -142,7 +142,12 @@ func (s *reliableSender) spawnPeerHandler(peerPubKey [33]byte) (peerManager, boo
 			done: make(chan struct{}),
 		}
 		s.activePeers[peerPubKey] = msgHandler
+	}
+	s.activePeersMtx.Unlock()
 
+	// If this is a newly initiated peerManager, we will create a
+	// peerHandler.
+	if !ok {
 		s.wg.Add(1)
 		go s.peerHandler(msgHandler, peerPubKey)
 	}

--- a/discovery/sync_manager.go
+++ b/discovery/sync_manager.go
@@ -398,6 +398,13 @@ func (m *SyncManager) syncerHandler() {
 				continue
 			}
 
+			// We may not even have enough inactive syncers to be
+			// transitted. In that case, we will transit all the
+			// inactive syncers.
+			if len(m.inactiveSyncers) < numActiveLeft {
+				numActiveLeft = len(m.inactiveSyncers)
+			}
+
 			log.Debugf("Attempting to transition %v passive "+
 				"GossipSyncers to active", numActiveLeft)
 

--- a/discovery/sync_manager.go
+++ b/discovery/sync_manager.go
@@ -492,6 +492,10 @@ func (m *SyncManager) createGossipSyncer(peer lnpeer.Peer) *GossipSyncer {
 	// handle any sync transitions.
 	s.setSyncState(chansSynced)
 	s.setSyncType(PassiveSync)
+
+	log.Debugf("Created new GossipSyncer[state=%s type=%s] for peer=%v",
+		s.syncState(), s.SyncType(), peer)
+
 	return s
 }
 

--- a/docs/release-notes/release-notes-0.15.0.md
+++ b/docs/release-notes/release-notes-0.15.0.md
@@ -18,6 +18,11 @@
   due to the cancel signal is processed before the creation. It is now properly
   handled by moving creation before deletion.   
 
+* When the block height+delta specified by a network message is greater than
+  the gossiper's best height, it will be considered as premature and ignored.
+  [These premature messages are now saved into a cache and processed once the
+  height has reached.](https://github.com/lightningnetwork/lnd/pull/6054)
+
 ## Misc
 
 * [An example systemd service file](https://github.com/lightningnetwork/lnd/pull/6033)

--- a/funding/manager.go
+++ b/funding/manager.go
@@ -553,6 +553,19 @@ const (
 	addedToRouterGraph
 )
 
+func (c channelOpeningState) String() string {
+	switch c {
+	case markedOpen:
+		return "markedOpen"
+	case fundingLockedSent:
+		return "fundingLocked"
+	case addedToRouterGraph:
+		return "addedToRouterGraph"
+	default:
+		return "unknown"
+	}
+}
+
 // NewFundingManager creates and initializes a new instance of the
 // fundingManager.
 func NewFundingManager(cfg Config) (*Manager, error) {

--- a/funding/manager.go
+++ b/funding/manager.go
@@ -2786,7 +2786,7 @@ func (f *Manager) annAfterSixConfs(completeChan *channeldb.OpenChannel,
 		}
 
 		log.Debugf("Channel with ChannelPoint(%v), short_chan_id=%v "+
-			"announced", &fundingPoint, shortChanID)
+			"sent to gossiper", &fundingPoint, shortChanID)
 	}
 
 	return nil

--- a/routing/errors.go
+++ b/routing/errors.go
@@ -28,6 +28,15 @@ const (
 	// ErrInvalidFundingOutput is returned if the channle funding output
 	// fails validation.
 	ErrInvalidFundingOutput
+
+	// ErrVBarrierShuttingDown signals that the barrier has been requested
+	// to shutdown, and that the caller should not treat the wait condition
+	// as fulfilled.
+	ErrVBarrierShuttingDown
+
+	// ErrParentValidationFailed signals that the validation of a
+	// dependent's parent failed, so the dependent must not be processed.
+	ErrParentValidationFailed
 )
 
 // routerError is a structure that represent the error inside the routing package,

--- a/routing/router.go
+++ b/routing/router.go
@@ -1062,13 +1062,19 @@ func (r *ChannelRouter) networkHandler() {
 					update.msg,
 				)
 				if err != nil {
-					switch err {
-					case ErrVBarrierShuttingDown:
+					switch {
+					case IsError(
+						err, ErrVBarrierShuttingDown,
+					):
 						update.err <- err
-					case ErrParentValidationFailed:
+
+					case IsError(
+						err, ErrParentValidationFailed,
+					):
 						update.err <- newErrf(
 							ErrIgnored, err.Error(),
 						)
+
 					default:
 						log.Warnf("unexpected error "+
 							"during validation "+

--- a/routing/validation_barrier.go
+++ b/routing/validation_barrier.go
@@ -1,23 +1,11 @@
 package routing
 
 import (
-	"errors"
 	"sync"
 
 	"github.com/lightningnetwork/lnd/channeldb"
 	"github.com/lightningnetwork/lnd/lnwire"
 	"github.com/lightningnetwork/lnd/routing/route"
-)
-
-var (
-	// ErrVBarrierShuttingDown signals that the barrier has been requested
-	// to shutdown, and that the caller should not treat the wait condition
-	// as fulfilled.
-	ErrVBarrierShuttingDown = errors.New("validation barrier shutting down")
-
-	// ErrParentValidationFailed signals that the validation of a
-	// dependent's parent failed, so the dependent must not be processed.
-	ErrParentValidationFailed = errors.New("parent validation failed")
 )
 
 // validationSignals contains two signals which allows the ValidationBarrier to
@@ -228,9 +216,11 @@ func (v *ValidationBarrier) WaitForDependants(job interface{}) error {
 	if ok {
 		select {
 		case <-v.quit:
-			return ErrVBarrierShuttingDown
+			return newErrf(ErrVBarrierShuttingDown,
+				"validation barrier shutting down")
 		case <-signals.deny:
-			return ErrParentValidationFailed
+			return newErrf(ErrParentValidationFailed,
+				"parent validation failed")
 		case <-signals.allow:
 			return nil
 		}

--- a/routing/validation_barrier_test.go
+++ b/routing/validation_barrier_test.go
@@ -141,14 +141,18 @@ func TestValidationBarrierQuit(t *testing.T) {
 
 		switch {
 		// First half should return without failure.
-		case i < numTasks/4 && err != routing.ErrParentValidationFailed:
+		case i < numTasks/4 && !routing.IsError(
+			err, routing.ErrParentValidationFailed,
+		):
 			t.Fatalf("unexpected failure while waiting: %v", err)
 
 		case i >= numTasks/4 && i < numTasks/2 && err != nil:
 			t.Fatalf("unexpected failure while waiting: %v", err)
 
 		// Last half should return the shutdown error.
-		case i >= numTasks/2 && err != routing.ErrVBarrierShuttingDown:
+		case i >= numTasks/2 && !routing.IsError(
+			err, routing.ErrVBarrierShuttingDown,
+		):
 			t.Fatalf("expected failure after quitting: want %v, "+
 				"got %v", routing.ErrVBarrierShuttingDown, err)
 		}


### PR DESCRIPTION
Commits cherry-picked from #5940 when attempting to fix itest flakes. Previously we've seen test failures re channel not being open after timeout. Turns out it's not a flake so much.

When a message has a height greater than the gossiper's height, the message is ignored and never processed. This PR puts the premature messages into a cache and process them when the gossiper has received new blocks.