### PR TITLE
lncli: Add json flag to trackpayment

### DIFF
--- a/cmd/lncli/cmd_payments.go
+++ b/cmd/lncli/cmd_payments.go
@@ -556,7 +556,10 @@ var trackPaymentCommand = cli.Command{
 	specified by the hash argument.
 	`,
 	ArgsUsage: "hash",
-	Action:    actionDecorator(trackPayment),
+	Flags: []cli.Flag{
+		jsonFlag,
+	},
+	Action: actionDecorator(trackPayment),
 }
 
 func trackPayment(ctx *cli.Context) error {

--- a/docs/release-notes/release-notes-0.14.2.md
+++ b/docs/release-notes/release-notes-0.14.2.md
@@ -8,6 +8,11 @@
 * [Make etcd max message size
   configurable]((https://github.com/lightningnetwork/lnd/pull/6049).
 
+## Bug fixes
+
+* [Add json flag to
+  trackpayment](https://github.com/lightningnetwork/lnd/pull/6060)
+
 # Contributors (Alphabetical Order)
 
 * Andras Banki-Horvath


### PR DESCRIPTION
## Description
Fixes [issue](https://github.com/lightningnetwork/lnd/issues/5867) by adding json flag to the cli command to allow printLivePayment method to log in json format if specified.

## Testing on `simnet` with Alice and Bob
- Flag properly shows in help ✅ 
```bash
bash-5.1# lncli --network=simnet trackpayment --help
NAME:
   lncli trackpayment - Track progress of an existing payment.

USAGE:
   lncli trackpayment [command options] hash

CATEGORY:
   Payments

DESCRIPTION:
   
  Pick up monitoring the progression of a previously initiated payment
  specified by the hash argument.
  

OPTIONS:
   --json  if set, payment updates are printed as json messages. Set by default on Windows because table formatting is unsupported.
```
- Using json flag properly logs json ✅ 
```bash
bash-5.1# lncli --network=simnet trackpayment --json f0deb18409273472d7d2a6c36056af8e9f55fce77fa3f9f76d2a095f79bd58cb
{
    "payment_hash": "f0deb18409273472d7d2a6c36056af8e9f55fce77fa3f9f76d2a095f79bd58cb",
    "value": "10000",
    "creation_date": "1638750692",
    "fee": "0",
    "payment_preimage": "968dd1e0a2ea58ab2c6feb2aa5ff5ae82d85433592a1a43958e3160f114df8b1",
    "value_sat": "10000",
    "value_msat": "10000000",
    "payment_request": "lnsb100u1ps66k2rpp57r0trpqfyu68947j5mpkq4403604tl88073lnamd9gy477datr9sdqqcqzpgxqyz5vqsp5zvxe9glz8ggqy52t0yl5fslq8dxssurycv0cczfm8lseqmu645wq9qyyssqt6aq8ga6xnqgwczk4chc7276ukl2c452guxn9dz4cruurr4da3f4ykywwg7gr4ye7mf6tcfye30syn20gl678up0eaesummpa7php9qqm62y0p",
    "status": "SUCCEEDED",
    "fee_sat": "0",
    "fee_msat": "0",
    "creation_time_ns": "1638750692188682800",
    "htlcs": [
        {
            "attempt_id": "1",
            "status": "SUCCEEDED",
            "route": {
                "total_time_lock": 446,
                "total_fees": "0",
                "total_amt": "10000",
                "hops": [
                    {
                        "chan_id": "440904162803712",
                        "chan_capacity": "1000000",
                        "amt_to_forward": "10000",
                        "fee": "0",
                        "expiry": 446,
                        "amt_to_forward_msat": "10000000",
                        "fee_msat": "0",
                        "pub_key": "02d17698f0f0f4fff30ad09fd423f6fa311b0cb9173610c9d03946b6df190ba5df",
                        "tlv_payload": true,
                        "mpp_record": {
                            "payment_addr": "130d92a3e23a1002514b793f44c3e03b4d087064c31f8c093b3fe1906f9aad1c",
                            "total_amt_msat": "10000000"
                        },
                        "amp_record": null,
                        "custom_records": {
                        }
                    }
                ],
                "total_fees_msat": "0",
                "total_amt_msat": "10000000"
            },
            "attempt_time_ns": "1638750692205254800",
            "resolve_time_ns": "1638750692328729100",
            "failure": null,
            "preimage": "968dd1e0a2ea58ab2c6feb2aa5ff5ae82d85433592a1a43958e3160f114df8b1"
        }
    ],
    "payment_index": "1",
    "failure_reason": "FAILURE_REASON_NONE"
}
```
- Table logging still works ✅ 
```bash
bash-5.1# lncli --network=simnet trackpayment f0deb18409273472d7d2a6c36056af8e9f55fce77fa3f9f76d2a095f79bd58cb
+------------+--------------+--------------+--------------+-----+----------+-----------------+-------+
| HTLC_STATE | ATTEMPT_TIME | RESOLVE_TIME | RECEIVER_AMT | FEE | TIMELOCK | CHAN_OUT        | ROUTE |
+------------+--------------+--------------+--------------+-----+----------+-----------------+-------+
| SUCCEEDED  |        0.016 |        0.140 | 10000        | 0   |      446 | 440904162803712 |       |
+------------+--------------+--------------+--------------+-----+----------+-----------------+-------+
Amount + fee:   10000 + 0 sat
Payment hash:   f0deb18409273472d7d2a6c36056af8e9f55fce77fa3f9f76d2a095f79bd58cb
Payment status: SUCCEEDED, preimage: 968dd1e0a2ea58ab2c6feb2aa5ff5ae82d85433592a1a43958e3160f114df8b1
```

#### Pull Request Checklist

- [x] All changes are Go version 1.16 compliant
- [x] Your PR passes all CI checks. If a check cannot be passed for a justifiable reason, that reason must be stated in the commit message and PR description.
- [x] If this is your first time contributing, we recommend you read the [Code Contribution Guidelines](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md)
   - [x] The code being submitted is commented according to [Code Documentation and Commenting](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#CodeDocumentation)
   - [x] Commits have a logical structure according to [Ideal Git Commit Structure](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#IdealGitCommitStructure)
- [x] For new code: Code is accompanied by tests which exercise both the positive and negative (error paths) conditions (if applicable)
- [x] For bug fixes: If possible, code is accompanied by new tests which trigger the bug being fixed to prevent regressions
- [x] Any new logging statements use an appropriate subsystem and logging level
- [x] For code and documentation: lines are wrapped at 80 characters (the tab character should be counted as 8 characters, not 4, as some IDEs do per default)
- [ ] A description of your changes [should be added to running the release notes](https://github.com/lightningnetwork/lnd/tree/master/docs/release-notes) for the milestone your change will land in, or,
- [x] If a PR only fixes a trivial issue, such as updating documentation on a small scale, fix typos, or any changes that do not modify the code, the commit message should end with [skip ci] to skip the CI checks.
