### PR TITLE
chainfee: return floor fee rate when a given target is not found

### DIFF
--- a/docs/release-notes/release-notes-0.14.2.md
+++ b/docs/release-notes/release-notes-0.14.2.md
@@ -1,5 +1,10 @@
 # Release Notes
 
+## Bug Fixes
+
+* [Return the nearest known fee rate when a given conf target cannot be found
+  from Web API fee estimator.](https://github.com/lightningnetwork/lnd/pull/6062)
+
 ## Build System
 
 * [Clean up Makefile by using go

--- a/lnwallet/chainfee/estimator_test.go
+++ b/lnwallet/chainfee/estimator_test.go
@@ -164,8 +164,9 @@ func TestSparseConfFeeSource(t *testing.T) {
 // as expected.
 func TestWebAPIFeeEstimator(t *testing.T) {
 	t.Parallel()
-
 	feeFloor := uint32(FeePerKwFloor.FeePerKVByte())
+	testFeeRate := feeFloor * 100
+
 	testCases := []struct {
 		name   string
 		target uint32
@@ -173,11 +174,41 @@ func TestWebAPIFeeEstimator(t *testing.T) {
 		est    uint32
 		err    string
 	}{
-		{"target_below_min", 0, 12345, 12345, "too low, minimum"},
-		{"target_w_too-low_fee", 10, 42, feeFloor, ""},
-		{"API-omitted_target", 2, 0, 0, "web API does not include"},
-		{"valid_target", 20, 54321, 54321, ""},
-		{"valid_target_extrapolated_fee", 25, 0, 54321, ""},
+		{
+			name:   "target_below_min",
+			target: 0,
+			apiEst: 0,
+			est:    0,
+			err:    "too low, minimum",
+		},
+		{
+			name:   "target_w_too-low_fee",
+			target: 100,
+			apiEst: 42,
+			est:    feeFloor,
+			err:    "",
+		},
+		{
+			name:   "API-omitted_target",
+			target: 2,
+			apiEst: 0,
+			est:    testFeeRate,
+			err:    "",
+		},
+		{
+			name:   "valid_target",
+			target: 20,
+			apiEst: testFeeRate,
+			est:    testFeeRate,
+			err:    "",
+		},
+		{
+			name:   "valid_target_extrapolated_fee",
+			target: 25,
+			apiEst: 0,
+			est:    testFeeRate,
+			err:    "",
+		},
 	}
 
 	// Construct mock fee source for the Estimator to pull fees from.
@@ -196,12 +227,10 @@ func TestWebAPIFeeEstimator(t *testing.T) {
 	estimator := NewWebAPIEstimator(feeSource, false)
 
 	// Test that requesting a fee when no fees have been cached fails.
-	_, err := estimator.EstimateFeePerKW(5)
-	if err == nil ||
-		!strings.Contains(err.Error(), "web API does not include") {
-
-		t.Fatalf("expected fee estimation to fail, instead got: %v", err)
-	}
+	feeRate, err := estimator.EstimateFeePerKW(5)
+	require.NoErrorf(t, err, "expected no error")
+	require.Equalf(t, FeePerKwFloor, feeRate, "expected fee rate floor "+
+		"returned when no cached fee rate found")
 
 	if err := estimator.Start(); err != nil {
 		t.Fatalf("unable to start fee estimator, got: %v", err)


### PR DESCRIPTION
Instead of returning an error, we now log the error and return a default fee rate when a given conf target cannot be found from the web fee estimator.

Fixes #6056.