### PR TITLE
config: Add bitcoind.{config,rpccookie} configuration options

### DIFF
--- a/docs/release-notes/release-notes-0.15.0.md
+++ b/docs/release-notes/release-notes-0.15.0.md
@@ -189,6 +189,10 @@ then watch it on chain. Taproot script spends are also supported through the
 * [Add a new method in `tlv` to encode an uint64/uint32 field using `BigSize`
   format.](https://github.com/lightningnetwork/lnd/pull/6421)
 
+* [Add new `bitcoind.config` and `bitcoind.rpccookie`
+  options](https://github.com/lightningnetwork/lnd/pull/6064) to allow
+  specifying non-default paths for the configuration and RPC cookie files.
+
 ## RPC Server
 
 * [Add value to the field
@@ -287,6 +291,7 @@ gRPC performance metrics (latency to process `GetInfo`, etc)](https://github.com
 * bitromortac
 * Bjarne Magnussen
 * BTCparadigm
+* Carl Dong
 * Carla Kirk-Cohen
 * Carsten Otto
 * Dan Bolser

--- a/lncfg/bitcoind.go
+++ b/lncfg/bitcoind.go
@@ -4,6 +4,8 @@ package lncfg
 // bitcoind.
 type Bitcoind struct {
 	Dir                string `long:"dir" description:"The base directory that contains the node's data, logs, configuration file, etc."`
+	ConfigPath         string `long:"config" description:"Configuration filepath. If not set, will default to the default filename under 'dir'."`
+	RPCCookie          string `long:"rpccookie" description:"Authentication cookie file for RPC connections. If not set, will default to .cookie under 'dir'."`
 	RPCHost            string `long:"rpchost" description:"The daemon's rpc listening address. If a port is omitted, then the default port for the selected chain parameters will be used."`
 	RPCUser            string `long:"rpcuser" description:"Username for RPC connections"`
 	RPCPass            string `long:"rpcpass" default-mask:"-" description:"Password for RPC connections"`

--- a/sample-lnd.conf
+++ b/sample-lnd.conf
@@ -578,6 +578,12 @@ bitcoin.node=btcd
 ; etc.
 ; bitcoind.dir=~/.bitcoin
 
+; Configuration filepath.
+; bitcoind.config=~/.bitcoin/bitcoin.conf
+
+; Authentication cookie file for RPC connections.
+; bitcoind.rpccookie=~/.bitcoin/.cookie
+
 ; The host that your local bitcoind daemon is listening on. By default, this
 ; setting is assumed to be localhost with the default port for the current
 ; network.
@@ -778,6 +784,12 @@ litecoin.node=ltcd
 ; The base directory that contains the node's data, logs, configuration file,
 ; etc.
 ; litecoind.dir=~/.litecoin
+
+; Configuration filepath.
+; litecoind.config=~/.litecoin/litecoin.conf
+
+; Authentication cookie file for RPC connections.
+; litecoind.rpccookie=~/.litecoin/.cookie
 
 ; The host that your local litecoind daemon is listening on. By default, this
 ; setting is assumed to be localhost with the default port for the current


### PR DESCRIPTION
```
Currently, the Bitcoind.Dir configuration option is used as the base
directory for locating both the bitcoind configuration file and the RPC
cookie file. However, it is quite common for Bitcoin Core to be packaged
in such a way that the configuration file and the RPC cookie file reside
in different directories: "/etc/bitcoin/bitcoin.conf" and
"/var/lib/bitcoind/.cookie".

This change makes it such that --bitcoind.config and
--bitcoind.rpccookie options can be specified to override the default
auto-detection logic, and if either is unspecified, the auto-detection
logic will still do its job.
```

Fixes https://github.com/lightningnetwork/lnd/issues/4439