### PR TITLE
routing: fix memory corruption in MC store

### DIFF
--- a/docs/release-notes/release-notes-0.14.2.md
+++ b/docs/release-notes/release-notes-0.14.2.md
@@ -17,6 +17,9 @@
 * [Add json flag to
   trackpayment](https://github.com/lightningnetwork/lnd/pull/6060)
 
+* [Fix memory corruption in Mission Control
+  Store](https://github.com/lightningnetwork/lnd/pull/6068)
+
 ## RPC Server
 
 * [ChanStatusFlags is now

--- a/routing/missioncontrol_store.go
+++ b/routing/missioncontrol_store.go
@@ -82,7 +82,7 @@ func newMissionControlStore(db kvdb.Backend, maxRecords int,
 		// difference when updating the DB state.
 		c := resultsBucket.ReadCursor()
 		for k, _ := c.First(); k != nil; k, _ = c.Next() {
-			keys.PushBack(k)
+			keys.PushBack(string(k))
 			keysMap[string(k)] = struct{}{}
 		}
 
@@ -334,7 +334,7 @@ func (b *missionControlStore) storeResults() error {
 				return err
 			}
 
-			keys.PushBack(k)
+			keys.PushBack(string(k))
 			keysMap[string(k)] = struct{}{}
 		}
 
@@ -345,14 +345,14 @@ func (b *missionControlStore) storeResults() error {
 			}
 
 			front := keys.Front()
-			key := front.Value.([]byte)
+			key := front.Value.(string)
 
-			if err := bucket.Delete(key); err != nil {
+			if err := bucket.Delete([]byte(key)); err != nil {
 				return err
 			}
 
 			keys.Remove(front)
-			delete(keysMap, string(key))
+			delete(keysMap, key)
 		}
 
 		return nil


### PR DESCRIPTION
Potential fix for https://github.com/lightningnetwork/lnd/issues/6061

The crash in the linked issue may have happened due our local references of bbolt's internal data.