### PR TITLE
lnwallet+docs: minrelayfee always above fee floor

### DIFF
--- a/docs/release-notes/release-notes-0.14.2.md
+++ b/docs/release-notes/release-notes-0.14.2.md
@@ -35,6 +35,9 @@
 
 * [Fix memory corruption in Mission Control
   Store](https://github.com/lightningnetwork/lnd/pull/6068)
+ 
+* [Ensure that the min relay fee is always clamped by our fee
+  floor](https://github.com/lightningnetwork/lnd/pull/6076)
 
 ## RPC Server
 
@@ -49,6 +52,7 @@
 
 * Andras Banki-Horvath
 * Bjarne Magnussen
+* Elle Mouton
 * Harsha Goli
 * Martin Habovštiak
 * Naveen Srinivasan

--- a/lnwallet/chainfee/minfeemanager.go
+++ b/lnwallet/chainfee/minfeemanager.go
@@ -32,6 +32,12 @@ func newMinFeeManager(minUpdateInterval time.Duration,
 		return nil, err
 	}
 
+	// Ensure that the minimum fee we use is always clamped by our fee
+	// floor.
+	if minFee < FeePerKwFloor {
+		minFee = FeePerKwFloor
+	}
+
 	return &minFeeManager{
 		minFeePerKW:       minFee,
 		lastUpdatedTime:   time.Now(),


### PR DESCRIPTION
The minimum relay fee is always ensured to be above our fee floor except
in the very first min relay fee query to bitcoind. This commit ensures
that the fee floor is respected in this first query.

Fixes #6072 