### PR TITLE
channeldb: allow to be used read-only in external tools

### DIFF
--- a/channeldb/graph.go
+++ b/channeldb/graph.go
@@ -189,10 +189,12 @@ type ChannelGraph struct {
 // returned instance has its own unique reject cache and channel cache.
 func NewChannelGraph(db kvdb.Backend, rejectCacheSize, chanCacheSize int,
 	batchCommitInterval time.Duration, preAllocCacheNumNodes int,
-	useGraphCache bool) (*ChannelGraph, error) {
+	useGraphCache, noMigrations bool) (*ChannelGraph, error) {
 
-	if err := initChannelGraph(db); err != nil {
-		return nil, err
+	if !noMigrations {
+		if err := initChannelGraph(db); err != nil {
+			return nil, err
+		}
 	}
 
 	g := &ChannelGraph{

--- a/channeldb/graph_test.go
+++ b/channeldb/graph_test.go
@@ -77,7 +77,7 @@ func MakeTestGraph(modifiers ...OptionModifier) (*ChannelGraph, func(), error) {
 	graph, err := NewChannelGraph(
 		backend, opts.RejectCacheSize, opts.ChannelCacheSize,
 		opts.BatchCommitInterval, opts.PreAllocCacheNumNodes,
-		true,
+		true, false,
 	)
 	if err != nil {
 		backendCleanup()

--- a/channeldb/options.go
+++ b/channeldb/options.go
@@ -50,6 +50,11 @@ type Options struct {
 	// path finding.
 	UseGraphCache bool
 
+	// NoMigration specifies that underlying backend was opened in read-only
+	// mode and migrations shouldn't be performed. This can be useful for
+	// applications that use the channeldb package as a library.
+	NoMigration bool
+
 	// clock is the time source used by the database.
 	clock clock.Clock
 
@@ -71,6 +76,7 @@ func DefaultOptions() Options {
 		ChannelCacheSize:      DefaultChannelCacheSize,
 		PreAllocCacheNumNodes: DefaultPreAllocCacheNumNodes,
 		UseGraphCache:         true,
+		NoMigration:           false,
 		clock:                 clock.NewDefaultClock(),
 	}
 }
@@ -133,6 +139,14 @@ func OptionAutoCompactMinAge(minAge time.Duration) OptionModifier {
 func OptionSetBatchCommitInterval(interval time.Duration) OptionModifier {
 	return func(o *Options) {
 		o.BatchCommitInterval = interval
+	}
+}
+
+// OptionNoMigration allows the database to be opened in read only mode by
+// disabling migrations.
+func OptionNoMigration(b bool) OptionModifier {
+	return func(o *Options) {
+		o.NoMigration = b
 	}
 }
 

--- a/docs/release-notes/release-notes-0.15.0.md
+++ b/docs/release-notes/release-notes-0.15.0.md
@@ -16,6 +16,9 @@
   for running lnd alongside a bitcoind service is now provided in
   `contrib/init/lnd.service`.
 
+* [Allow disabling migrations if the database backend passed to `channeldb` was
+  opened in read-only mode](https://github.com/lightningnetwork/lnd/pull/6084).
+
 ## Code Health
 
 ### Code cleanup, refactor, typo fixes

--- a/routing/pathfind_test.go
+++ b/routing/pathfind_test.go
@@ -175,7 +175,7 @@ func makeTestGraph(useCache bool) (*channeldb.ChannelGraph, kvdb.Backend,
 	graph, err := channeldb.NewChannelGraph(
 		backend, opts.RejectCacheSize, opts.ChannelCacheSize,
 		opts.BatchCommitInterval, opts.PreAllocCacheNumNodes,
-		useCache,
+		useCache, false,
 	)
 	if err != nil {
 		cleanUp()


### PR DESCRIPTION
Allow read-only access to a DB backend if the `channeldb` package is used as a library in external projects. For example, this is very useful in `chantools`.