### PR TITLE
docs: Improvements to mobile instructions [skip ci]

### DIFF
--- a/docs/release-notes/release-notes-0.15.0.md
+++ b/docs/release-notes/release-notes-0.15.0.md
@@ -26,6 +26,10 @@
   `pending_force_closing_channels` under `pendingchannels` whereas before was
   empty(zero).
 
+## Documentation
+
+* Improved instructions on [how to build lnd for mobile](https://github.com/lightningnetwork/lnd/pull/6085).
+
 ## Code Health
 
 ### Code cleanup, refactor, typo fixes
@@ -34,6 +38,7 @@
 
 # Contributors (Alphabetical Order)
 
+* Andreas Schjønhaug
 * Daniel McNally
 * ErikEk
 * Torkel Rogstad

--- a/mobile/README.md
+++ b/mobile/README.md
@@ -1,54 +1,76 @@
-## Building mobile libraries
+# Building mobile libraries
 
-### Prerequisites
-#### protoc
-Install the dependencies for generating protobuf definitions as stated in
-[lnrpc docs]( ../lnrpc/README.md#generate-protobuf-definitions)
+## Prerequisites
 
-#### gomobile
-Follow [gomobile](https://github.com/golang/go/wiki/Mobile) in order to install
-`gomobile` and dependencies.
+### Docker
 
-Remember to run `gomobile init` (otherwise the `lnd` build might just hang).
+- Install and run [Docker](https://www.docker.com/products/docker-desktop).
+
+### Make
+
+- Check that `make` is available by running the following command without errors:
+
+```shell
+⛰  make --version
+```
+
+### Go mobile
+
+Install [gomobile](https://github.com/golang/go/wiki/Mobile) and initialize it:
+
+```shell
+⛰  go install golang.org/x/mobile/cmd/gomobile@latest
+⛰  gomobile init
+```
+
+## Building the libraries
 
 Note that `gomobile` only supports building projects from `GOPATH` at this
-point.
+point. So, before continuing, be sure to be in the `src` folder:
 
-#### falafel
-Install [`falafel`](https://github.com/lightninglabs/falafel):
 ```shell
-⛰  go get -u -v github.com/lightninglabs/falafel
+⛰  cd $GOPATH/src/github.com/lightningnetwork/lnd
+```
+
+To checkout the latest tagged release of lnd, run
+
+```shell
+⛰  git checkout $(git describe --tags --abbrev=0)
 ```
 
 ### Building `lnd` for iOS
+
 ```shell
 ⛰  make ios
 ```
 
 ### Building `lnd` for Android
+
 ```shell
 ⛰  make android
 ```
 
-`make mobile` will build both iOS and Android libs.
+`make mobile` will build both iOS and Android libraries.
 
 ### Libraries
+
 After the build has succeeded, the libraries will be found in
-`mobile/build/ios/Lndmobile.framework` and
+`mobile/build/ios/Lndmobile.xcframework` and
 `mobile/build/android/Lndmobile.aar`. Reference your platforms' SDK
 documentation for how to add the library to your project.
 
-#### Generating proto definitions for your language.
+## Generating proto definitions
+
 In order to call the methods in the generated library, the serialized proto for
 the given RPC call must be provided. Similarly, the response will be a
 serialized proto.
 
-##### iOS
+### iOS
 
 In order to generate protobuf definitions for iOS, add `--swift_out=.` to the
-first `protoc` invocation found in [`gen_protos.sh`](../lnrpc/gen_protos.sh).
+first `protoc` invocation found in [ `gen_protos.sh` ](../lnrpc/gen_protos.sh).
 
-Then, some changes to [Dockerfile]((../lnrpc/Dockerfile)) need to be done in
+Then, some changes to [Dockerfile](../lnrpc/Dockerfile) need to be done in
 order to use the [Swift protobuf](https://github.com/apple/swift-protobuf)
 plugin with protoc:
 
@@ -60,7 +82,7 @@ following commands:
 
 ```
 RUN apt-get install -y wget \
-    && wget -c https://golang.org/dl/go1.17.2.linux-amd64.tar.gz -O - \
+    && wget -c https://golang.org/dl/go1.17.3.linux-amd64.tar.gz -O - \
     | tar -xz -C /usr/local
 ENV GOPATH=/go
 ENV PATH=$PATH:/usr/local/go/bin:/go/bin
@@ -79,13 +101,26 @@ RUN git clone https://github.com/apple/swift-protobuf.git \
 
 Finally, run `make rpc`.
 
-##### Android
+Tip: The generated Swift files will be found in various folders. If you’d like
+to move them to the same folder as the framework file, run
+
+```shell
+⛰  `find . -name "*.swift" -print0 | xargs -0 -I {} mv {} mobile/build/ios`.
+```
+
+`Lndmobile.xcframework` and all Swift files should now be added to your Xcode
+project. You will also need to add [Swift Protobuf](https://github.com/apple/swift-protobuf)
+to your project to support the generated code.  
+
+### Android
 
 In order to generate protobuf definitions for Android, add `--java_out=.`
-to the first `protoc` invocation found in
-[`gen_protos.sh`](../lnrpc/gen_protos.sh). Then, run `make rpc`.
 
-### Options
+to the first `protoc` invocation found in
+[ `gen_protos.sh` ](../lnrpc/gen_protos.sh). Then, run `make rpc`.
+
+## Options
+
 Similar to lnd, subservers can be conditionally compiled with the build by
 setting the tags argument:
 
@@ -100,5 +135,8 @@ flag. This will add the subserver name as a prefix to each method name:
 ⛰  make ios prefix=1
 ```
 
-### API docs
+## API docs
+
+[LND gRPC API Reference](https://api.lightning.community)
+
 TODO(halseth)


### PR DESCRIPTION
Improvements on instructions on how to build for mobile:
* Cleaned up markdown headings
* Included necessary commands to install and init gomobile
* Added command on how to go to the correct src folder before building libraries (due to a known limitation in gomobile)
* Added command on how to checkout the last tagged release of lnd before building libraries
* Fixed incorrect link to Dockerfile
* Use go 1.17.3 instead of 1.17.2 in the Dockerfile.
* For convenience, added command on how to move all the generated Swift protoc definition files to the  same directory as the framework file.