### PR TITLE
lncli + docs: Add cltv_expiry flag to addinvoice

### DIFF
--- a/cmd/lncli/cmd_invoice.go
+++ b/cmd/lncli/cmd_invoice.go
@@ -3,9 +3,11 @@ package main
 import (
 	"encoding/hex"
 	"fmt"
+	"math"
 	"strconv"
 
 	"github.com/lightningnetwork/lnd/lnrpc"
+	"github.com/lightningnetwork/lnd/routing"
 	"github.com/urfave/cli"
 )
 
@@ -71,6 +73,13 @@ var addInvoiceCommand = cli.Command{
 			Usage: "creates an AMP invoice. If true, preimage " +
 				"should not be set.",
 		},
+		cli.Uint64Flag{
+			Name: "cltv_expiry",
+			Usage: fmt.Sprintf("delta to use for the time-lock of "+
+				"the CLTV extended to the final hop. It must be at least "+
+				"%d and less than or equal to %d. If not specified the chain's "+
+				"time-lock delta will be used.", routing.MinCLTVDelta, math.MaxUint16),
+		},
 	},
 	Action: actionDecorator(addInvoice),
 }
@@ -125,6 +134,7 @@ func addInvoice(ctx *cli.Context) error {
 		Expiry:          ctx.Int64("expiry"),
 		Private:         ctx.Bool("private"),
 		IsAmp:           ctx.Bool("amp"),
+		CltvExpiry:      ctx.Uint64("cltv_expiry"),
 	}
 
 	resp, err := client.AddInvoice(ctxc, invoice)

--- a/docs/release-notes/release-notes-0.14.2.md
+++ b/docs/release-notes/release-notes-0.14.2.md
@@ -30,11 +30,15 @@
 
 * [Add json flag to
   trackpayment](https://github.com/lightningnetwork/lnd/pull/6060)
+
 * [Clarify invalid config timeout
   constraints](https://github.com/lightningnetwork/lnd/pull/6073)
 
 * [Fix memory corruption in Mission Control
   Store](https://github.com/lightningnetwork/lnd/pull/6068)
+
+* [Add cltv_expiry flag to
+  addinvoice](https://github.com/lightningnetwork/lnd/pull/6086)
 
 ## RPC Server
 


### PR DESCRIPTION
## Description
Fixes [issue](https://github.com/lightningnetwork/lnd/issues/3866).

## Testing on `simnet` with Alice and Bob
- Flag properly shows in help ✅ 
```bash
bash-5.1# lncli --network=simnet addinvoice --help
NAME:
   lncli addinvoice - Add a new invoice.

USAGE:
   lncli addinvoice [command options] value preimage

CATEGORY:
   Invoices

DESCRIPTION:
   
  Add a new invoice, expressing intent for a future payment.

  Invoices without an amount can be created by not supplying any
  parameters or providing an amount of 0. These invoices allow the payee
  to specify the amount of satoshis they wish to send.

OPTIONS:
   --memo value              a description of the payment to attach along with the invoice (default="")
   --preimage value          the hex-encoded preimage (32 byte) which will allow settling an incoming HTLC payable to this preimage. If not set, a random preimage will be created.
   --amt value               the amt of satoshis in this invoice (default: 0)
   --amt_msat value          the amt of millisatoshis in this invoice (default: 0)
   --description_hash value  SHA-256 hash of the description of the payment. Used if the purpose of payment cannot naturally fit within the memo. If provided this will be used instead of the description(memo) field in the encoded invoice.
   --fallback_addr value     fallback on-chain address that can be used in case the lightning payment fails
   --expiry value            the invoice's expiry time in seconds. If not specified an expiry of 3600 seconds (1 hour) is implied. (default: 0)
   --private                 encode routing hints in the invoice with private channels in order to assist the payer in reaching you
   --amp                     creates an AMP invoice. If true, preimage should not be set.
   --cltv_expiry value       delta to use for the time-lock of the CLTV extended to the final hop. It must be at least 18 and less than or equal to 65535. If not specified the chain's time-lock delta will be used. (default: 0)
```

- addinvoice command still works without setting `cltv_expiry` flag

```bash
bash-5.1# lncli --network=simnet addinvoice --amt=10000
{
    "r_hash": "d2495e2c77843d341271b48eaac5455be48445bf3cf50226f5a119630fbacef4",
    "payment_request": "lnsb100u1psmwmxhpp56fy4utrhss7ngyn3kj824329t0jgg3dl8n6syfh45yvkxra6em6qdqqcqzpgxqyz5vqsp5xzyce6gxehd7c0eysj27wrvffyf4pwxld8703epzfp4ysle68frs9qyyssqzpyn7nhfhuk9hrez4u9255v8akqma9yplz2epk7ekpp3vtxuj2f5ry65grhl7ze68clqzt68yrqkxsmrjd955z53u7ztnhts43gzsugp8mk4pf",
    "add_index": "1",
    "payment_addr": "30898ce906cddbec3f248495e70d89491350b8df69fcf8e422486a487f3a3a47"
}
```

- Using `cltv_expiry` flag properly logs sets CltvExpiry ✅
```bash
bash-5.1# lncli --network=simnet addinvoice --amt=10000 --cltv_expiry=50
{
    "r_hash": "6ba790570ba70557b7ac030286356e64e6fc811237de420a4355f686d6042697",
    "payment_request": "lnsb100u1psmwmgrpp5dwneq4ct5uz40davqvpgvdtwvnn0eqgjxl0yyzjr2hmgd4syy6tsdqqcqzpjxqyz5vqsp5shw4y6669mm96227nq6gl0wf2jqj3y98ly38sl3759qq5knypf4s9qyyssqwftgl7nwag49tm50rcksgp4egpculplfpls88yg2gwen6aqjc5rz4y89uq2pwxhfjhc7cjlvlkelk57sa0knsenwvxclc7fwckplcmgpak22tw",
    "add_index": "2",
    "payment_addr": "85dd526b5a2ef65d295e98348fbdc954812890a7f922787e3ea1400a5a640a6b"
}
`` 