### PR TITLE
(trivial) signal: clarify the log message about systemd

### DIFF
--- a/docs/release-notes/release-notes-0.14.2.md
+++ b/docs/release-notes/release-notes-0.14.2.md
@@ -42,6 +42,9 @@
 * [Ensure that the min relay fee is always clamped by our fee
   floor](https://github.com/lightningnetwork/lnd/pull/6076)
 
+* [Clarify log message about not running within
+  systemd](https://github.com/lightningnetwork/lnd/pull/6096)
+
 ## RPC Server
 
 * [ChanStatusFlags is now

--- a/signal/signal.go
+++ b/signal/signal.go
@@ -42,7 +42,8 @@ func systemdNotifyReady() error {
 	if notified {
 		log.Info("Systemd was notified about our readiness")
 	} else {
-		log.Info("We're not running within systemd")
+		log.Info("We're not running within systemd or the service " +
+			"type is not 'notify'")
 	}
 	return nil
 }


### PR DESCRIPTION
The log message was confusing because it was emitted even when running
within systemd if the service type was **not** `notify`. This clarifies
the message by mentioning the edge case.

Being able to distinguish the two cases would be nicer but there doesn't
seem to be a reasonably simple, obvious, reliable way to do it.
Complicated solutions are most likely not worth it for a simple log
message.

#### Pull Request Checklist

- [x] All changes are Go version 1.16 compliant
- [ ] Your PR passes all CI checks. If a check cannot be passed for a justifiable reason, that reason must be stated in the commit message and PR description.
- [ ] If this is your first time contributing, we recommend you read the [Code Contribution Guidelines](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md)
   - [ ] The code being submitted is commented according to [Code Documentation and Commenting](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#CodeDocumentation)
   - [ ] Commits have a logical structure according to [Ideal Git Commit Structure](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#IdealGitCommitStructure)
- [ ] For new code: Code is accompanied by tests which exercise both the positive and negative (error paths) conditions (if applicable)
- [ ] For bug fixes: If possible, code is accompanied by new tests which trigger the bug being fixed to prevent regressions
- [ ] Any new logging statements use an appropriate subsystem and logging level
- [ ] For code and documentation: lines are wrapped at 80 characters (the tab character should be counted as 8 characters, not 4, as some IDEs do per default)
- [ ] A description of your changes [should be added to running the release notes](https://github.com/lightningnetwork/lnd/tree/master/docs/release-notes) for the milestone your change will land in, or,
- [ ] If a PR only fixes a trivial issue, such as updating documentation on a small scale, fix typos, or any changes that do not modify the code, the commit message should end with [skip ci] to skip the CI checks.
