### PR TITLE
make: don't optimize debug binaries

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,6 +53,7 @@ make_ldflags = $(2) -X $(PKG)/build.Commit=$(COMMIT) \
 	-X $(PKG)/build.GoVersion=$(GOVERSION) \
 	-X $(PKG)/build.RawTags=$(shell echo $(1) | sed -e 's/ /,/g')
 
+DEV_GCFLAGS := -gcflags "all=-N -l"
 LDFLAGS := -ldflags "$(call make_ldflags, ${tags}, -s -w)"
 DEV_LDFLAGS := -ldflags "$(call make_ldflags, $(DEV_TAGS))"
 ITEST_LDFLAGS := -ldflags "$(call make_ldflags, $(ITEST_TAGS))"
@@ -116,8 +117,8 @@ $(GOFUZZ_DEP_BIN):
 
 build:
 	@$(call print, "Building debug lnd and lncli.")
-	$(GOBUILD) -tags="$(DEV_TAGS)" -o lnd-debug $(DEV_LDFLAGS) $(PKG)/cmd/lnd
-	$(GOBUILD) -tags="$(DEV_TAGS)" -o lncli-debug $(DEV_LDFLAGS) $(PKG)/cmd/lncli
+	$(GOBUILD) -tags="$(DEV_TAGS)" -o lnd-debug $(DEV_GCFLAGS) $(DEV_LDFLAGS) $(PKG)/cmd/lnd
+	$(GOBUILD) -tags="$(DEV_TAGS)" -o lncli-debug $(DEV_GCFLAGS) $(DEV_LDFLAGS) $(PKG)/cmd/lncli
 
 build-itest:
 	@$(call print, "Building itest btcd and lnd.")

--- a/docs/release-notes/release-notes-0.15.0.md
+++ b/docs/release-notes/release-notes-0.15.0.md
@@ -19,6 +19,10 @@
 * [Allow disabling migrations if the database backend passed to `channeldb` was
   opened in read-only mode](https://github.com/lightningnetwork/lnd/pull/6084).
 
+* [Disable compiler optimizations](https://github.com/lightningnetwork/lnd/pull/6105)
+  when building `lnd-debug` and `lncli-debug`. It helps when stepping through the code
+  with a debugger like Delve.
+
 ## RPC Server
 
 * [Add value to the field
@@ -41,4 +45,5 @@
 * Andreas Schjønhaug
 * Daniel McNally
 * ErikEk
+* Liviu
 * Torkel Rogstad


### PR DESCRIPTION
Disable compiler optimizations and function inlining on a debug build to
improve debugging experience.