### PR TITLE
kvdb+channeldb: speed up graph cache

### DIFF
--- a/channeldb/graph.go
+++ b/channeldb/graph.go
@@ -232,6 +232,71 @@ func NewChannelGraph(db kvdb.Backend, rejectCacheSize, chanCacheSize int,
 	return g, nil
 }
 
+// channelMapKey is the key structure used for storing channel edge policies.
+type channelMapKey struct {
+	nodeKey route.Vertex
+	chanID  [8]byte
+}
+
+// getChannelMap loads all channel edge policies from the database and stores
+// them in a map.
+func (c *ChannelGraph) getChannelMap(edges kvdb.RBucket) (
+	map[channelMapKey]*ChannelEdgePolicy, error) {
+
+	// Create a map to store all channel edge policies.
+	channelMap := make(map[channelMapKey]*ChannelEdgePolicy)
+
+	err := kvdb.ForAll(edges, func(k, edgeBytes []byte) error {
+		// Skip embedded buckets.
+		if bytes.Equal(k, edgeIndexBucket) ||
+			bytes.Equal(k, edgeUpdateIndexBucket) ||
+			bytes.Equal(k, zombieBucket) ||
+			bytes.Equal(k, disabledEdgePolicyBucket) ||
+			bytes.Equal(k, channelPointBucket) {
+
+			return nil
+		}
+
+		// Validate key length.
+		if len(k) != 33+8 {
+			return fmt.Errorf("invalid edge key %x encountered", k)
+		}
+
+		var key channelMapKey
+		copy(key.nodeKey[:], k[:33])
+		copy(key.chanID[:], k[33:])
+
+		// No need to deserialize unknown policy.
+		if bytes.Equal(edgeBytes, unknownPolicy) {
+			return nil
+		}
+
+		edgeReader := bytes.NewReader(edgeBytes)
+		edge, err := deserializeChanEdgePolicyRaw(
+			edgeReader,
+		)
+
+		switch {
+		// If the db policy was missing an expected optional field, we
+		// return nil as if the policy was unknown.
+		case err == ErrEdgePolicyOptionalFieldNotFound:
+			return nil
+
+		case err != nil:
+			return err
+		}
+
+		channelMap[key] = edge
+
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return channelMap, nil
+}
+
 var graphTopLevelBuckets = [][]byte{
 	nodeBucket,
 	edgeBucket,
@@ -332,50 +397,47 @@ func (c *ChannelGraph) NewPathFindTx() (kvdb.RTx, error) {
 func (c *ChannelGraph) ForEachChannel(cb func(*ChannelEdgeInfo,
 	*ChannelEdgePolicy, *ChannelEdgePolicy) error) error {
 
-	// TODO(roasbeef): ptr map to reduce # of allocs? no duplicates
-
-	return kvdb.View(c.db, func(tx kvdb.RTx) error {
-		// First, grab the node bucket. This will be used to populate
-		// the Node pointers in each edge read from disk.
-		nodes := tx.ReadBucket(nodeBucket)
-		if nodes == nil {
-			return ErrGraphNotFound
-		}
-
-		// Next, grab the edge bucket which stores the edges, and also
-		// the index itself so we can group the directed edges together
-		// logically.
+	return c.db.View(func(tx kvdb.RTx) error {
 		edges := tx.ReadBucket(edgeBucket)
 		if edges == nil {
 			return ErrGraphNoEdgesFound
 		}
+
+		// First, load all edges in memory indexed by node and channel
+		// id.
+		channelMap, err := c.getChannelMap(edges)
+		if err != nil {
+			return err
+		}
+
 		edgeIndex := edges.NestedReadBucket(edgeIndexBucket)
 		if edgeIndex == nil {
 			return ErrGraphNoEdgesFound
 		}
 
-		// For each edge pair within the edge index, we fetch each edge
-		// itself and also the node information in order to fully
-		// populated the object.
-		return edgeIndex.ForEach(func(chanID, edgeInfoBytes []byte) error {
-			infoReader := bytes.NewReader(edgeInfoBytes)
-			edgeInfo, err := deserializeChanEdgeInfo(infoReader)
-			if err != nil {
-				return err
-			}
-			edgeInfo.db = c.db
+		// Load edge index, recombine each channel with the policies
+		// loaded above and invoke the callback.
+		return kvdb.ForAll(edgeIndex, func(k, edgeInfoBytes []byte) error {
+			var chanID [8]byte
+			copy(chanID[:], k)
 
-			edge1, edge2, err := fetchChanEdgePolicies(
-				edgeIndex, edges, nodes, chanID, c.db,
-			)
+			edgeInfoReader := bytes.NewReader(edgeInfoBytes)
+			info, err := deserializeChanEdgeInfo(edgeInfoReader)
 			if err != nil {
 				return err
 			}
 
-			// With both edges read, execute the call back. IF this
-			// function returns an error then the transaction will
-			// be aborted.
-			return cb(&edgeInfo, edge1, edge2)
+			policy1 := channelMap[channelMapKey{
+				nodeKey: info.NodeKey1Bytes,
+				chanID:  chanID,
+			}]
+
+			policy2 := channelMap[channelMapKey{
+				nodeKey: info.NodeKey2Bytes,
+				chanID:  chanID,
+			}]
+
+			return cb(&info, policy1, policy2)
 		})
 	}, func() {})
 }

--- a/channeldb/graph.go
+++ b/channeldb/graph.go
@@ -216,11 +216,25 @@ func NewChannelGraph(db kvdb.Backend, rejectCacheSize, chanCacheSize int,
 		startTime := time.Now()
 		log.Debugf("Populating in-memory channel graph, this might " +
 			"take a while...")
+
 		err := g.ForEachNodeCacheable(
 			func(tx kvdb.RTx, node GraphCacheNode) error {
-				return g.graphCache.AddNode(tx, node)
+				g.graphCache.AddNodeFeatures(node)
+
+				return nil
 			},
 		)
+		if err != nil {
+			return nil, err
+		}
+
+		err = g.ForEachChannel(func(info *ChannelEdgeInfo,
+			policy1, policy2 *ChannelEdgePolicy) error {
+
+			g.graphCache.AddChannel(info, policy1, policy2)
+
+			return nil
+		})
 		if err != nil {
 			return nil, err
 		}

--- a/channeldb/graph_cache.go
+++ b/channeldb/graph_cache.go
@@ -205,9 +205,8 @@ func (c *GraphCache) Stats() string {
 		numChannels)
 }
 
-// AddNode adds a graph node, including all the (directed) channels of that
-// node.
-func (c *GraphCache) AddNode(tx kvdb.RTx, node GraphCacheNode) error {
+// AddNodeFeatures adds a graph node and its features to the cache.
+func (c *GraphCache) AddNodeFeatures(node GraphCacheNode) {
 	nodePubKey := node.PubKey()
 
 	// Only hold the lock for a short time. The `ForEachChannel()` below is
@@ -217,6 +216,12 @@ func (c *GraphCache) AddNode(tx kvdb.RTx, node GraphCacheNode) error {
 	c.mtx.Lock()
 	c.nodeFeatures[nodePubKey] = node.Features()
 	c.mtx.Unlock()
+}
+
+// AddNode adds a graph node, including all the (directed) channels of that
+// node.
+func (c *GraphCache) AddNode(tx kvdb.RTx, node GraphCacheNode) error {
+	c.AddNodeFeatures(node)
 
 	return node.ForEachChannel(
 		tx, func(tx kvdb.RTx, info *ChannelEdgeInfo,

--- a/docs/release-notes/release-notes-0.14.2.md
+++ b/docs/release-notes/release-notes-0.14.2.md
@@ -19,6 +19,11 @@ connection from the watch-only node.
   In other words, freshly-installed LND can now be initialized with multiple
   channels from an external (e.g. hardware) wallet *in a single transaction*.
 
+## Database
+
+* [Speed up graph cache loading on startup with
+Postgres](https://github.com/lightningnetwork/lnd/pull/6111)
+
 ## Build System
 
 * [Clean up Makefile by using go

--- a/go.mod
+++ b/go.mod
@@ -46,7 +46,7 @@ require (
 	github.com/lightningnetwork/lnd/cert v1.1.0
 	github.com/lightningnetwork/lnd/clock v1.1.0
 	github.com/lightningnetwork/lnd/healthcheck v1.2.0
-	github.com/lightningnetwork/lnd/kvdb v1.2.5
+	github.com/lightningnetwork/lnd/kvdb v1.3.0
 	github.com/lightningnetwork/lnd/queue v1.1.0
 	github.com/lightningnetwork/lnd/ticker v1.1.0
 	github.com/ltcsuite/ltcd v0.0.0-20190101042124-f37f8bf35796

--- a/kvdb/etcd/readwrite_bucket.go
+++ b/kvdb/etcd/readwrite_bucket.go
@@ -406,3 +406,9 @@ func (b *readWriteBucket) Prefetch(paths ...[]string) {
 
 	b.tx.stm.Prefetch(flattenMap(keys), flattenMap(ranges))
 }
+
+// ForAll is an optimized version of ForEach with the limitation that no
+// additional queries can be executed within the callback.
+func (b *readWriteBucket) ForAll(cb func(k, v []byte) error) error {
+	return b.ForEach(cb)
+}

--- a/kvdb/interface.go
+++ b/kvdb/interface.go
@@ -109,6 +109,12 @@ type ExtendedRBucket interface {
 
 	// Prefetch will attempt to prefetch all values under a path.
 	Prefetch(paths ...[]string)
+
+	// ForAll is an optimized version of ForEach.
+	//
+	// NOTE: ForAll differs from ForEach in that no additional queries can
+	// be executed within the callback.
+	ForAll(func(k, v []byte) error) error
 }
 
 // Prefetch will attempt to prefetch all values under a path from the passed
@@ -117,6 +123,16 @@ func Prefetch(b RBucket, paths ...[]string) {
 	if bucket, ok := b.(ExtendedRBucket); ok {
 		bucket.Prefetch(paths...)
 	}
+}
+
+// ForAll is an optimized version of ForEach with the limitation that no
+// additional queries can be executed within the callback.
+func ForAll(b RBucket, cb func(k, v []byte) error) error {
+	if bucket, ok := b.(ExtendedRBucket); ok {
+		return bucket.ForAll(cb)
+	}
+
+	return b.ForEach(cb)
 }
 
 // RootBucket is a wrapper to ExtendedRTx.RootBucket which does nothing if

--- a/kvdb/postgres/readwrite_tx.go
+++ b/kvdb/postgres/readwrite_tx.go
@@ -175,6 +175,21 @@ func (tx *readWriteTx) QueryRow(query string, args ...interface{}) (*sql.Row,
 	return tx.tx.QueryRowContext(ctx, query, args...), cancel
 }
 
+// Query executes a multi-row query call with a timeout context.
+func (tx *readWriteTx) Query(query string, args ...interface{}) (*sql.Rows,
+	func(), error) {
+
+	ctx, cancel := tx.db.getTimeoutCtx()
+	rows, err := tx.tx.QueryContext(ctx, query, args...)
+	if err != nil {
+		cancel()
+
+		return nil, func() {}, err
+	}
+
+	return rows, cancel, nil
+}
+
 // Exec executes a Exec call with a timeout context.
 func (tx *readWriteTx) Exec(query string, args ...interface{}) (sql.Result,
 	error) {

--- a/kvdb/postgres_test.go
+++ b/kvdb/postgres_test.go
@@ -84,7 +84,35 @@ func TestPostgres(t *testing.T) {
 		},
 		{
 			name: "bucket for each",
-			test: testBucketForEach,
+			test: func(t *testing.T, db walletdb.DB) {
+				testBucketIterator(t, db, func(bucket walletdb.ReadWriteBucket,
+					callback func(key, val []byte) error) error {
+
+					return bucket.ForEach(callback)
+				})
+			},
+			expectedDb: m{
+				"test_kv": []m{
+					{"id": int64(1), "key": "apple", "parent_id": nil, "sequence": nil, "value": nil},
+					{"id": int64(2), "key": "banana", "parent_id": int64(1), "sequence": nil, "value": nil},
+					{"id": int64(3), "key": "key1", "parent_id": int64(1), "sequence": nil, "value": "val1"},
+					{"id": int64(4), "key": "key1", "parent_id": int64(2), "sequence": nil, "value": "val1"},
+					{"id": int64(5), "key": "key2", "parent_id": int64(1), "sequence": nil, "value": "val2"},
+					{"id": int64(6), "key": "key2", "parent_id": int64(2), "sequence": nil, "value": "val2"},
+					{"id": int64(7), "key": "key3", "parent_id": int64(1), "sequence": nil, "value": "val3"},
+					{"id": int64(8), "key": "key3", "parent_id": int64(2), "sequence": nil, "value": "val3"},
+				},
+			},
+		},
+		{
+			name: "bucket for all",
+			test: func(t *testing.T, db walletdb.DB) {
+				testBucketIterator(t, db, func(bucket walletdb.ReadWriteBucket,
+					callback func(key, val []byte) error) error {
+
+					return ForAll(bucket, callback)
+				})
+			},
 			expectedDb: m{
 				"test_kv": []m{
 					{"id": int64(1), "key": "apple", "parent_id": nil, "sequence": nil, "value": nil},

--- a/routing/router.go
+++ b/routing/router.go
@@ -157,11 +157,6 @@ type ChannelGraphSource interface {
 
 	// ForEachNode is used to iterate over every node in the known graph.
 	ForEachNode(func(node *channeldb.LightningNode) error) error
-
-	// ForEachChannel is used to iterate over every channel in the known
-	// graph.
-	ForEachChannel(func(chanInfo *channeldb.ChannelEdgeInfo,
-		e1, e2 *channeldb.ChannelEdgePolicy) error) error
 }
 
 // PaymentAttemptDispatcher is used by the router to send payment attempts onto
@@ -2539,16 +2534,6 @@ func (r *ChannelRouter) ForAllOutgoingChannels(cb func(kvdb.RTx,
 
 		return cb(tx, c, e)
 	})
-}
-
-// ForEachChannel is used to iterate over every known edge (channel) within our
-// view of the channel graph.
-//
-// NOTE: This method is part of the ChannelGraphSource interface.
-func (r *ChannelRouter) ForEachChannel(cb func(chanInfo *channeldb.ChannelEdgeInfo,
-	e1, e2 *channeldb.ChannelEdgePolicy) error) error {
-
-	return r.cfg.Graph.ForEachChannel(cb)
 }
 
 // AddProof updates the channel edge info with proof which is needed to


### PR DESCRIPTION
This PR adds `ForAll` to `kvdb` to allow for efficient range queries. The graph cache loader is rewritten to take advantage of this new method, improving loading time on my machine by approx 150x.

Fixes https://github.com/lightningnetwork/lnd/issues/6041
Fixes https://github.com/lightningnetwork/lnd/issues/6107