### PR TITLE
itest: increase pg database connection limit

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -177,9 +177,10 @@ ifeq ($(dbbackend),postgres)
 	# Remove a previous postgres instance if it exists.
 	docker rm lnd-postgres --force || echo "Starting new postgres container"
 
-	# Start a fresh postgres instance. Allow a maximum of 500 connections.
-	# This is required for the async benchmark to pass.
-	docker run --name lnd-postgres -e POSTGRES_PASSWORD=postgres -p 6432:5432 -d postgres:13-alpine
+	# Start a fresh postgres instance. Allow a maximum of 500 connections so
+	# that multiple lnd instances with a maximum number of connections of 50
+	# each can run concurrently.
+	docker run --name lnd-postgres -e POSTGRES_PASSWORD=postgres -p 6432:5432 -d postgres:13-alpine -N 500
 	docker logs -f lnd-postgres &
 
 	# Wait for the instance to be started.

--- a/docs/release-notes/release-notes-0.14.2.md
+++ b/docs/release-notes/release-notes-0.14.2.md
@@ -50,6 +50,8 @@
   led to an already made connection being lost. [This is now fixed so that
   bootstrapping will always ignore the peers chosen by the persistent
   connection.](https://github.com/lightningnetwork/lnd/pull/6082)
+  
+* [Fix Postgres itests max connections](https://github.com/lightningnetwork/lnd/pull/6116)
 
 ## RPC Server
 


### PR DESCRIPTION
Reverts the `Makefile` change in 274faff980a49fe8c104cb98cfe17a9ad7184e52, because that didn't take into account that itests run multiple lnd instances concurrently.