### PR TITLE
Add option to poll for blocks/txs via RPC instead of using ZMQ

### DIFF
--- a/chainntnfs/bitcoindnotify/bitcoind_test.go
+++ b/chainntnfs/bitcoindnotify/bitcoind_test.go
@@ -114,7 +114,7 @@ func TestHistoricalConfDetailsTxIndex(t *testing.T) {
 	defer tearDown()
 
 	bitcoindConn, cleanUp := chainntnfs.NewBitcoindBackend(
-		t, miner.P2PAddress(), true,
+		t, miner.P2PAddress(), true, false,
 	)
 	defer cleanUp()
 
@@ -206,11 +206,17 @@ func TestHistoricalConfDetailsTxIndex(t *testing.T) {
 // historical confirmation details using the set of fallback methods when the
 // backend node's txindex is disabled.
 func TestHistoricalConfDetailsNoTxIndex(t *testing.T) {
+	// Execute this test twice, once with rpcpolling off, and once on.
+	testHistoricalConfDetailsNoTxIndex(t, false)
+	testHistoricalConfDetailsNoTxIndex(t, true)
+}
+
+func testHistoricalConfDetailsNoTxIndex(t *testing.T, rpcPolling bool) {
 	miner, tearDown := chainntnfs.NewMiner(t, nil, true, 25)
 	defer tearDown()
 
 	bitcoindConn, cleanUp := chainntnfs.NewBitcoindBackend(
-		t, miner.P2PAddress(), false,
+		t, miner.P2PAddress(), false, rpcPolling,
 	)
 	defer cleanUp()
 

--- a/chainntnfs/bitcoindnotify/driver.go
+++ b/chainntnfs/bitcoindnotify/driver.go
@@ -56,13 +56,21 @@ func createNewNotifier(args ...interface{}) (chainntnfs.ChainNotifier, error) {
 // chainntnfs.ChainNotifier interface.
 func init() {
 	// Register the driver.
-	notifier := &chainntnfs.NotifierDriver{
-		NotifierType: notifierType,
-		New:          createNewNotifier,
+	notifiers := []*chainntnfs.NotifierDriver{
+		{
+			NotifierType: notifierType,
+			New:          createNewNotifier,
+		},
+		{
+			NotifierType: "bitcoind rpcpolling",
+			New:          createNewNotifier,
+		},
 	}
 
-	if err := chainntnfs.RegisterNotifier(notifier); err != nil {
-		panic(fmt.Sprintf("failed to register notifier driver '%s': %v",
-			notifierType, err))
+	for _, notifier := range notifiers {
+		if err := chainntnfs.RegisterNotifier(notifier); err != nil {
+			panic(fmt.Sprintf("failed to register notifier driver '%s': %v",
+				notifierType, err))
+		}
 	}
 }

--- a/chainntnfs/test/bitcoind/bitcoind_test.go
+++ b/chainntnfs/test/bitcoind/bitcoind_test.go
@@ -13,4 +13,5 @@ import (
 // powered chain notifier.
 func TestInterfaces(t *testing.T) {
 	chainntnfstest.TestInterfaces(t, "bitcoind")
+	chainntnfstest.TestInterfaces(t, "bitcoind rpcpolling")
 }

--- a/chainntnfs/test_utils.go
+++ b/chainntnfs/test_utils.go
@@ -196,7 +196,7 @@ func NewMiner(t *testing.T, extraArgs []string, createChain bool,
 // backend node should maintain a transaction index. A connection to the newly
 // spawned bitcoind node is returned.
 func NewBitcoindBackend(t *testing.T, minerAddr string,
-	txindex bool) (*chain.BitcoindConn, func()) {
+	txindex bool, rpcPolling bool) (*chain.BitcoindConn, func()) {
 
 	t.Helper()
 
@@ -242,6 +242,9 @@ func NewBitcoindBackend(t *testing.T, minerAddr string,
 		ZMQBlockHost:    zmqBlockHost,
 		ZMQTxHost:       zmqTxHost,
 		ZMQReadDeadline: 5 * time.Second,
+		RPCPolling:      rpcPolling,
+		PollBlockTimer:  time.Millisecond * 500,
+		PollTxTimer:     time.Millisecond * 500,
 		// Fields only required for pruned nodes, not needed for these
 		// tests.
 		Dialer:             nil,

--- a/chainreg/chainregistry.go
+++ b/chainreg/chainregistry.go
@@ -408,6 +408,9 @@ func NewPartialChainControl(cfg *Config) (*PartialChainControl, func(), error) {
 			ZMQBlockHost:       bitcoindMode.ZMQPubRawBlock,
 			ZMQTxHost:          bitcoindMode.ZMQPubRawTx,
 			ZMQReadDeadline:    5 * time.Second,
+			RPCPolling:         bitcoindMode.RPCPolling,
+			PollBlockTimer:     bitcoindMode.PollBlockTimer,
+			PollTxTimer:        bitcoindMode.PollTxTimer,
 			Dialer:             cfg.Dialer,
 			PrunedModeMaxPeers: bitcoindMode.PrunedNodeMaxPeers,
 		})

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/btcsuite/btclog v0.0.0-20170628155309-84c8d2346e9f
 	github.com/btcsuite/btcutil v1.0.3-0.20210527170813-e2ba6805a890
 	github.com/btcsuite/btcutil/psbt v1.0.3-0.20210527170813-e2ba6805a890
-	github.com/btcsuite/btcwallet v0.13.0
+	github.com/btcsuite/btcwallet v0.13.1-0.20211201210108-79de92f527dc
 	github.com/btcsuite/btcwallet/wallet/txauthor v1.1.0
 	github.com/btcsuite/btcwallet/wallet/txrules v1.1.0
 	github.com/btcsuite/btcwallet/walletdb v1.3.6-0.20210803004036-eebed51155ec
@@ -74,6 +74,8 @@ require (
 	gopkg.in/macaroon.v2 v2.0.0
 	gopkg.in/mgo.v2 v2.0.0-20190816093944-a6b53ec6cb22 // indirect
 )
+
+replace github.com/btcsuite/btcwallet => github.com/orbitalturtle/btcwallet v0.13.1-0.20220131052201-c2ded756781a
 
 replace github.com/lightningnetwork/lnd/ticker => ./ticker
 

--- a/go.sum
+++ b/go.sum
@@ -97,8 +97,8 @@ github.com/btcsuite/btcutil v1.0.3-0.20210527170813-e2ba6805a890/go.mod h1:0DVlH
 github.com/btcsuite/btcutil/psbt v1.0.3-0.20201208143702-a53e38424cce/go.mod h1:LVveMu4VaNSkIRTZu2+ut0HDBRuYjqGocxDMNS1KuGQ=
 github.com/btcsuite/btcutil/psbt v1.0.3-0.20210527170813-e2ba6805a890 h1:0xUNvvwJ7RjzBs4nCF+YrK28S5P/b4uHkpPxY1ovGY4=
 github.com/btcsuite/btcutil/psbt v1.0.3-0.20210527170813-e2ba6805a890/go.mod h1:LVveMu4VaNSkIRTZu2+ut0HDBRuYjqGocxDMNS1KuGQ=
-github.com/btcsuite/btcwallet v0.13.0 h1:gtLWwueRm27KQiHJpycybv3uMdK1eo87JexfTfzvEhk=
-github.com/btcsuite/btcwallet v0.13.0/go.mod h1:iLN1lG1MW0eREm+SikmPO8AZPz5NglBTEK/ErqkjGpo=
+github.com/btcsuite/btcwallet v0.13.1-0.20211201210108-79de92f527dc h1:lAbAEAp4eWvsSwJfcpdHXpKz78X2sVF9aDK4nJveXmY=
+github.com/btcsuite/btcwallet v0.13.1-0.20211201210108-79de92f527dc/go.mod h1:iLN1lG1MW0eREm+SikmPO8AZPz5NglBTEK/ErqkjGpo=
 github.com/btcsuite/btcwallet/wallet/txauthor v1.0.0/go.mod h1:VufDts7bd/zs3GV13f/lXc/0lXrPnvxD/NvmpG/FEKU=
 github.com/btcsuite/btcwallet/wallet/txauthor v1.1.0 h1:8pO0pvPX1rFRfRiol4oV6kX7dY5y4chPwhfVwUfvwtk=
 github.com/btcsuite/btcwallet/wallet/txauthor v1.1.0/go.mod h1:ktYuJyumYtwG+QQ832Q+kqvxWJRAei3Nqs5qhSn4nww=
@@ -643,6 +643,8 @@ github.com/onsi/gomega v1.4.2/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1Cpa
 github.com/onsi/gomega v1.4.3 h1:RE1xgDvH7imwFD45h+u2SgIfERHlS2yNG4DObb5BSKU=
 github.com/onsi/gomega v1.4.3/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
 github.com/opentracing/opentracing-go v1.1.0/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFStlNbqXla1AfSYxPUl2o=
+github.com/orbitalturtle/btcwallet v0.13.1-0.20220131052201-c2ded756781a h1:1rhrSi/7FmRknqOzxwLhCePVNWMxblTVwp4BgDe7O7A=
+github.com/orbitalturtle/btcwallet v0.13.1-0.20220131052201-c2ded756781a/go.mod h1:28pFfBjI+nrkqL8OJU8riooZidKV17f+SkF5y9dbk5g=
 github.com/ory/go-acc v0.2.6 h1:YfI+L9dxI7QCtWn2RbawqO0vXhiThdXu/RgizJBbaq0=
 github.com/ory/go-acc v0.2.6/go.mod h1:4Kb/UnPcT8qRAk3IAxta+hvVapdxTLWtrr7bFLlEgpw=
 github.com/ory/viper v1.7.5 h1:+xVdq7SU3e1vNaCsk/ixsfxE4zylk1TJUiJrY647jUE=

--- a/lncfg/bitcoind.go
+++ b/lncfg/bitcoind.go
@@ -1,14 +1,19 @@
 package lncfg
 
+import "time"
+
 // Bitcoind holds the configuration options for the daemon's connection to
 // bitcoind.
 type Bitcoind struct {
-	Dir                string `long:"dir" description:"The base directory that contains the node's data, logs, configuration file, etc."`
-	RPCHost            string `long:"rpchost" description:"The daemon's rpc listening address. If a port is omitted, then the default port for the selected chain parameters will be used."`
-	RPCUser            string `long:"rpcuser" description:"Username for RPC connections"`
-	RPCPass            string `long:"rpcpass" default-mask:"-" description:"Password for RPC connections"`
-	ZMQPubRawBlock     string `long:"zmqpubrawblock" description:"The address listening for ZMQ connections to deliver raw block notifications"`
-	ZMQPubRawTx        string `long:"zmqpubrawtx" description:"The address listening for ZMQ connections to deliver raw transaction notifications"`
-	EstimateMode       string `long:"estimatemode" description:"The fee estimate mode. Must be either ECONOMICAL or CONSERVATIVE."`
-	PrunedNodeMaxPeers int    `long:"pruned-node-max-peers" description:"The maximum number of peers lnd will choose from the backend node to retrieve pruned blocks from. This only applies to pruned nodes."`
+	Dir                string        `long:"dir" description:"The base directory that contains the node's data, logs, configuration file, etc."`
+	RPCHost            string        `long:"rpchost" description:"The daemon's rpc listening address. If a port is omitted, then the default port for the selected chain parameters will be used."`
+	RPCUser            string        `long:"rpcuser" description:"Username for RPC connections"`
+	RPCPass            string        `long:"rpcpass" default-mask:"-" description:"Password for RPC connections"`
+	ZMQPubRawBlock     string        `long:"zmqpubrawblock" description:"The address listening for ZMQ connections to deliver raw block notifications"`
+	ZMQPubRawTx        string        `long:"zmqpubrawtx" description:"The address listening for ZMQ connections to deliver raw transaction notifications"`
+	RPCPolling         bool          `long:"rpcpolling" description:"Opt to use RPC Polling to retrieve block and tx updates, instead of ZMQ"`
+	PollBlockTimer     time.Duration `long:"pollblocktimer" description:"PollBlockTimer sets how often we'll poll for fresh blocks, if rpcpolling is true."`
+	PollTxTimer        time.Duration `long:"polltxtimer" description:"PollTxTimer sets how often we'll poll for fresh blocks, if rpcpolling is true."`
+	EstimateMode       string        `long:"estimatemode" description:"The fee estimate mode. Must be either ECONOMICAL or CONSERVATIVE."`
+	PrunedNodeMaxPeers int           `long:"pruned-node-max-peers" description:"The maximum number of peers lnd will choose from the backend node to retrieve pruned blocks from. This only applies to pruned nodes."`
 }

--- a/lntest/bitcoind.go
+++ b/lntest/bitcoind.go
@@ -1,5 +1,5 @@
-//go:build bitcoind && !notxindex
-// +build bitcoind,!notxindex
+//go:build bitcoind && !notxindex && !rpcpolling
+// +build bitcoind,!notxindex,!rpcpolling
 
 package lntest
 
@@ -19,5 +19,5 @@ func NewBackend(miner string, netParams *chaincfg.Params) (
 		"-disablewallet",
 	}
 
-	return newBackend(miner, netParams, extraArgs)
+	return newBackend(miner, netParams, extraArgs, false)
 }

--- a/lntest/bitcoind_rpcpolling.go
+++ b/lntest/bitcoind_rpcpolling.go
@@ -1,5 +1,5 @@
-//go:build bitcoind && notxindex
-// +build bitcoind,notxindex
+//go:build bitcoind && rpcpolling
+// +build bitcoind,rpcpolling
 
 package lntest
 
@@ -7,8 +7,8 @@ import (
 	"github.com/btcsuite/btcd/chaincfg"
 )
 
-// NewBackend starts a bitcoind node without the txindex enabled and returns a
-// BitoindBackendConfig for that node.
+// NewBackend starts a bitcoind node with the txindex enabled and returns a
+// BitcoindBackendConfig for that node.
 func NewBackend(miner string, netParams *chaincfg.Params) (
 	*BitcoindBackendConfig, func() error, error) {
 
@@ -18,5 +18,5 @@ func NewBackend(miner string, netParams *chaincfg.Params) (
 		"-disablewallet",
 	}
 
-	return newBackend(miner, netParams, extraArgs, false)
+	return newBackend(miner, netParams, extraArgs, true)
 }

--- a/lnwallet/test/bitcoind/bitcoind_rpcpolling_test.go
+++ b/lnwallet/test/bitcoind/bitcoind_rpcpolling_test.go
@@ -1,0 +1,13 @@
+package bitcoind_test
+
+import (
+	"testing"
+
+	lnwallettest "github.com/lightningnetwork/lnd/lnwallet/test"
+)
+
+// TestLightningWallet tests LightningWallet powered by bitcoind against our
+// suite of interface tests.
+func TestLightningWalletRPCPolling(t *testing.T) {
+	lnwallettest.TestLightningWallet(t, "bitcoind rpcpolling")
+}

--- a/sample-lnd.conf
+++ b/sample-lnd.conf
@@ -579,6 +579,10 @@ bitcoin.node=btcd
 ; bitcoind.zmqpubrawblock=tcp://127.0.0.1:28332
 ; bitcoind.zmqpubrawtx=tcp://127.0.0.1:28333
 
+; RPC polling offers an alternative to ZMQ as a way to retrieve notifications
+; from bitcoind about new blocks and transactions.
+; bitcoind.rpcpolling=1
+
 ; Fee estimate mode for bitcoind. It must be either "ECONOMICAL" or "CONSERVATIVE".
 ; If unset, the default value is "CONSERVATIVE".
 ; bitcoind.estimatemode=CONSERVATIVE


### PR DESCRIPTION
Normally Bitcoin Core block notifications come in via ZMQ. This PR adds an option for polling for blocks via RPC when using Bitcoin Core as the backend for LND. To use, the flag --rpcpolling needs to be set for lnd

Requires https://github.com/btcsuite/btcwallet/pull/784 