### PR TITLE
discovery: fix panic with nil peer in node announcement

### DIFF
--- a/discovery/gossiper.go
+++ b/discovery/gossiper.go
@@ -1602,6 +1602,13 @@ func (d *AuthenticatedGossiper) processNetworkAnnouncement(
 		schedulerOp = append(schedulerOp, batch.LazyAdd())
 	}
 
+	// Avoid running into a nil pointer dereference if the peer is not set
+	// for some reason.
+	var peerPubKey [33]byte
+	if nMsg.peer != nil {
+		peerPubKey = nMsg.peer.PubKey()
+	}
+
 	var announcements []networkMsg
 
 	switch msg := nMsg.msg.(type) {
@@ -1675,8 +1682,7 @@ func (d *AuthenticatedGossiper) processNetworkAnnouncement(
 			log.Errorf(err.Error())
 
 			key := newRejectCacheKey(
-				msg.ShortChannelID.ToUint64(),
-				nMsg.peer.PubKey(),
+				msg.ShortChannelID.ToUint64(), peerPubKey,
 			)
 			_, _ = d.recentRejects.Put(key, &cachedReject{})
 
@@ -1719,7 +1725,7 @@ func (d *AuthenticatedGossiper) processNetworkAnnouncement(
 
 				key := newRejectCacheKey(
 					msg.ShortChannelID.ToUint64(),
-					nMsg.peer.PubKey(),
+					peerPubKey,
 				)
 				_, _ = d.recentRejects.Put(key, &cachedReject{})
 
@@ -1795,7 +1801,7 @@ func (d *AuthenticatedGossiper) processNetworkAnnouncement(
 
 					key := newRejectCacheKey(
 						msg.ShortChannelID.ToUint64(),
-						nMsg.peer.PubKey(),
+						peerPubKey,
 					)
 					_, _ = d.recentRejects.Put(key, &cachedReject{})
 
@@ -1822,7 +1828,7 @@ func (d *AuthenticatedGossiper) processNetworkAnnouncement(
 
 				key := newRejectCacheKey(
 					msg.ShortChannelID.ToUint64(),
-					nMsg.peer.PubKey(),
+					peerPubKey,
 				)
 				_, _ = d.recentRejects.Put(key, &cachedReject{})
 			}
@@ -1908,8 +1914,7 @@ func (d *AuthenticatedGossiper) processNetworkAnnouncement(
 			log.Errorf(err.Error())
 
 			key := newRejectCacheKey(
-				msg.ShortChannelID.ToUint64(),
-				nMsg.peer.PubKey(),
+				msg.ShortChannelID.ToUint64(), peerPubKey,
 			)
 			_, _ = d.recentRejects.Put(key, &cachedReject{})
 
@@ -2034,8 +2039,7 @@ func (d *AuthenticatedGossiper) processNetworkAnnouncement(
 			nMsg.err <- err
 
 			key := newRejectCacheKey(
-				msg.ShortChannelID.ToUint64(),
-				nMsg.peer.PubKey(),
+				msg.ShortChannelID.ToUint64(), peerPubKey,
 			)
 			_, _ = d.recentRejects.Put(key, &cachedReject{})
 
@@ -2144,7 +2148,7 @@ func (d *AuthenticatedGossiper) processNetworkAnnouncement(
 
 				key := newRejectCacheKey(
 					msg.ShortChannelID.ToUint64(),
-					nMsg.peer.PubKey(),
+					peerPubKey,
 				)
 				_, _ = d.recentRejects.Put(key, &cachedReject{})
 

--- a/docs/release-notes/release-notes-0.14.2.md
+++ b/docs/release-notes/release-notes-0.14.2.md
@@ -32,20 +32,25 @@
 ## Bug fixes
 
 * [Add json flag to
-  trackpayment](https://github.com/lightningnetwork/lnd/pull/6060)
+  trackpayment](https://github.com/lightningnetwork/lnd/pull/6060).
+
 * [Clarify invalid config timeout
-  constraints](https://github.com/lightningnetwork/lnd/pull/6073)
+  constraints](https://github.com/lightningnetwork/lnd/pull/6073).
 
 * [Fix memory corruption in Mission Control
-  Store](https://github.com/lightningnetwork/lnd/pull/6068)
+  Store](https://github.com/lightningnetwork/lnd/pull/6068).
  
 * [Ensure that the min relay fee is always clamped by our fee
-  floor](https://github.com/lightningnetwork/lnd/pull/6076)
+  floor](https://github.com/lightningnetwork/lnd/pull/6076).
 
 * [Clarify log message about not running within
-  systemd](https://github.com/lightningnetwork/lnd/pull/6096)
+  systemd](https://github.com/lightningnetwork/lnd/pull/6096).
 
-* [Fix Postgres context cancellation](https://github.com/lightningnetwork/lnd/pull/6108)
+* [Fix Postgres context
+  cancellation](https://github.com/lightningnetwork/lnd/pull/6108).
+
+* [Fix panic with nil peer when processing network
+  announcement](https://github.com/lightningnetwork/lnd/pull/6130).
 
 ## RPC Server
 


### PR DESCRIPTION
Fixes a nil pointer dereference panic introduced by #5902.
Since peer is an interface the value can actually be nil. This is
probably a symptom of another problem but I'm not really familiar with
this part of the code base, so this just adds some band aids.

Found in https://github.com/lightningnetwork/lnd/runs/4640937601?check_suite_focus=true:

```
    test_harness.go:118: lnd finished with error (stderr):
        exit status 2
        panic: runtime error: invalid memory address or nil pointer dereference
        [signal SIGSEGV: segmentation violation code=0x1 addr=0x38 pc=0xd0d6b8]
        
        goroutine 30100 [running]:
        github.com/lightningnetwork/lnd/discovery.(*AuthenticatedGossiper).processNetworkAnnouncement(0xc00102c320, 0xc0027ed0c0)
        	/home/runner/work/lnd/lnd/discovery/gossiper.go:1825 +0x64f8
        github.com/lightningnetwork/lnd/discovery.(*AuthenticatedGossiper).networkHandler.func1()
        	/home/runner/work/lnd/lnd/discovery/gossiper.go:1110 +0x256
        created by github.com/lightningnetwork/lnd/discovery.(*AuthenticatedGossiper).networkHandler
        	/home/runner/work/lnd/lnd/discovery/gossiper.go:1084 +0xa25
```