### PR TITLE
htlcswitch: fix duplicate close

### DIFF
--- a/docs/release-notes/release-notes-0.14.2.md
+++ b/docs/release-notes/release-notes-0.14.2.md
@@ -53,6 +53,8 @@
   
 * [Fix Postgres itests max connections](https://github.com/lightningnetwork/lnd/pull/6116)
 
+* [Fix duplicate db connection close](https://github.com/lightningnetwork/lnd/pull/6140)
+
 ## RPC Server
 
 * [ChanStatusFlags is now
@@ -68,6 +70,7 @@
 * Bjarne Magnussen
 * Elle Mouton
 * Harsha Goli
+* Joost Jager
 * Martin Habovštiak
 * Naveen Srinivasan
 * Oliver Gugger

--- a/go.mod
+++ b/go.mod
@@ -46,7 +46,7 @@ require (
 	github.com/lightningnetwork/lnd/cert v1.1.0
 	github.com/lightningnetwork/lnd/clock v1.1.0
 	github.com/lightningnetwork/lnd/healthcheck v1.2.0
-	github.com/lightningnetwork/lnd/kvdb v1.2.4
+	github.com/lightningnetwork/lnd/kvdb v1.2.5
 	github.com/lightningnetwork/lnd/queue v1.1.0
 	github.com/lightningnetwork/lnd/ticker v1.1.0
 	github.com/ltcsuite/ltcd v0.0.0-20190101042124-f37f8bf35796

--- a/htlcswitch/decayedlog.go
+++ b/htlcswitch/decayedlog.go
@@ -158,9 +158,6 @@ func (d *DecayedLog) Stop() error {
 
 	d.wg.Wait()
 
-	// Close boltdb.
-	d.db.Close()
-
 	return nil
 }
 

--- a/kvdb/postgres/db.go
+++ b/kvdb/postgres/db.go
@@ -256,5 +256,7 @@ func (db *db) Copy(w io.Writer) error {
 // Close cleanly shuts down the database and syncs all data.
 // This function is part of the walletdb.Db interface implementation.
 func (db *db) Close() error {
+	log.Infof("Closing database %v", db.prefix)
+
 	return dbConns.Close(db.cfg.Dsn)
 }


### PR DESCRIPTION
The decayed log database opening and closing is managed at a higher level in config_builder.go.
