### PR TITLE
docs: clarify --externalhosts usage

### DIFF
--- a/config.go
+++ b/config.go
@@ -256,7 +256,7 @@ type Config struct {
 	RawRESTListeners  []string `long:"restlisten" description:"Add an interface/port/socket to listen for REST connections"`
 	RawListeners      []string `long:"listen" description:"Add an interface/port to listen for peer connections"`
 	RawExternalIPs    []string `long:"externalip" description:"Add an ip:port to the list of local addresses we claim to listen on to peers. If a port is not specified, the default (9735) will be used regardless of other parameters"`
-	ExternalHosts     []string `long:"externalhosts" description:"A set of hosts that should be periodically resolved to announce IPs for"`
+	ExternalHosts     []string `long:"externalhosts" description:"Add a hostname:port that should be periodically resolved to announce IPs for. If a port is not specified, the default (9735) will be used."`
 	RPCListeners      []net.Addr
 	RESTListeners     []net.Addr
 	RestCORS          []string `long:"restcors" description:"Add an ip:port/hostname to allow cross origin access from. To allow all origins, set as \"*\"."`


### PR DESCRIPTION
This clarifies the usage of the `externalhosts` option and brings its documentation in line with similar options such as `externalip`.

Related issue: #6141

Note: I skipped ci for this commit since it's just a 1 line documentation change and I didn't want to have to update the change log just for this, but I don't mind to re-enable ci and update the change log if that's preferable.