### PR TITLE
contractcourt: use "info" log level for messages leading to force-clo…

### DIFF
--- a/contractcourt/channel_arbitrator.go
+++ b/contractcourt/channel_arbitrator.go
@@ -1779,7 +1779,7 @@ func (c *ChannelArbitrator) checkRemoteDanglingActions(
 			continue
 		}
 
-		log.Tracef("ChannelArbitrator(%v): immediately failing "+
+		log.Infof("ChannelArbitrator(%v): immediately failing "+
 			"htlc=%x from remote commitment",
 			c.cfg.ChanPoint, htlc.RHash[:])
 


### PR DESCRIPTION
See #6124. This adds one log message for which I forgot to update the log level. I already added the changelog in #6124.

