### PR TITLE
lncli: closechannel chan_point flag 

### DIFF
--- a/cmd/lncli/commands.go
+++ b/cmd/lncli/commands.go
@@ -39,6 +39,9 @@ const (
 	defaultUtxoMinConf = 1
 )
 
+var errBadChanPoint = errors.New("expecting chan_point to be in format of: " +
+	"txid:index")
+
 func getContext() context.Context {
 	shutdownInterceptor, err := signal.Intercept()
 	if err != nil {
@@ -719,6 +722,12 @@ var closeChannelCommand = cli.Command{
 			Usage: "the output index for the funding output of the funding " +
 				"transaction",
 		},
+		cli.StringFlag{
+			Name: "chan_point",
+			Usage: "(optional) the channel point. If set, " +
+				"funding_txid and output_index flags and " +
+				"positional arguments will be ignored",
+		},
 		cli.BoolFlag{
 			Name:  "force",
 			Usage: "attempt an uncooperative closure",
@@ -1183,10 +1192,19 @@ func abandonChannel(ctx *cli.Context) error {
 // line. Both named options as well as unnamed parameters are supported.
 func parseChannelPoint(ctx *cli.Context) (*lnrpc.ChannelPoint, error) {
 	channelPoint := &lnrpc.ChannelPoint{}
+	var err error
 
 	args := ctx.Args()
 
 	switch {
+	case ctx.IsSet("chan_point"):
+		channelPoint, err = parseChanPoint(ctx.String("chan_point"))
+		if err != nil {
+			return nil, fmt.Errorf("unable to parse chan_point: "+
+				"%v", err)
+		}
+		return channelPoint, nil
+
 	case ctx.IsSet("funding_txid"):
 		channelPoint.FundingTxid = &lnrpc.ChannelPoint_FundingTxidStr{
 			FundingTxidStr: ctx.String("funding_txid"),
@@ -1984,9 +2002,8 @@ var updateChannelPolicyCommand = cli.Command{
 
 func parseChanPoint(s string) (*lnrpc.ChannelPoint, error) {
 	split := strings.Split(s, ":")
-	if len(split) != 2 {
-		return nil, fmt.Errorf("expecting chan_point to be in format of: " +
-			"txid:index")
+	if len(split) != 2 || len(split[0]) == 0 || len(split[1]) == 0 {
+		return nil, errBadChanPoint
 	}
 
 	index, err := strconv.ParseInt(split[1], 10, 32)
@@ -2077,7 +2094,7 @@ func updateChannelPolicy(ctx *cli.Context) error {
 	if chanPointStr != "" {
 		chanPoint, err = parseChanPoint(chanPointStr)
 		if err != nil {
-			return fmt.Errorf("unable to parse chan point: %v", err)
+			return fmt.Errorf("unable to parse chan_point: %v", err)
 		}
 	}
 
@@ -2227,7 +2244,7 @@ func exportChanBackup(ctx *cli.Context) error {
 	if chanPointStr != "" {
 		chanPointRPC, err := parseChanPoint(chanPointStr)
 		if err != nil {
-			return err
+			return fmt.Errorf("unable to parse chan_point: %v", err)
 		}
 
 		chanBackup, err := client.ExportChannelBackup(

--- a/cmd/lncli/commands_test.go
+++ b/cmd/lncli/commands_test.go
@@ -1,0 +1,70 @@
+package main
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestParseChanPoint tests parseChanPoint with various
+// valid and invalid input values and verifies the output.
+func TestParseChanPoint(t *testing.T) {
+	testCases := []struct {
+		channelPoinStr    string
+		channelPointIsNil bool
+		outputIndex       uint32
+		err               error
+	}{
+		{
+			"24581424081379576b4a7580ace91db10925d996a2a8d45c8034" +
+				"3a5a467dc0bc:0",
+			false,
+			0,
+			nil,
+		}, {
+			"24581424081379576b4a7580ace91db10925d996a2a8d45c8034" +
+				"3a5a467dc0bc:4",
+			false,
+			4,
+			nil,
+		}, {
+			":",
+			true,
+			0,
+			errBadChanPoint,
+		}, {
+			":0",
+			true,
+			0,
+			errBadChanPoint,
+		}, {
+			"24581424081379576b4a7580ace91db10925d996a2a8d45c8034" +
+				"3a5a467dc0bc:",
+			true,
+			0,
+			errBadChanPoint,
+		}, {
+			"24581424081379576b4a7580ace91db10925d996a2a8d45c8034" +
+				"3a5a467dc0bc:string",
+			true,
+			0,
+			errors.New("unable to decode output index: strconv." +
+				"ParseInt: parsing \"string\": invalid syntax"),
+		}, {
+			"not_hex:0",
+			true,
+			0,
+			errors.New("unable to parse hex string: encoding/hex:" +
+				" invalid byte: U+006E 'n'"),
+		},
+	}
+	for _, tc := range testCases {
+		cp, err := parseChanPoint(tc.channelPoinStr)
+		require.Equal(t, tc.err, err)
+		require.Equal(t, tc.channelPointIsNil, cp == nil)
+		if !tc.channelPointIsNil {
+			require.Equal(t, tc.outputIndex, cp.OutputIndex)
+		}
+	}
+}

--- a/docs/release-notes/release-notes-0.15.0.md
+++ b/docs/release-notes/release-notes-0.15.0.md
@@ -10,6 +10,9 @@
 * Add [auto-generated command-line completions](https://github.com/lightningnetwork/lnd/pull/4177) 
   for Fish shell.  
 
+* Add [chan_point flag](https://github.com/lightningnetwork/lnd/pull/6152)
+  to closechannel command.
+
 ## Bug Fixes
 
 * [Fixed an inactive invoice subscription not removed from invoice


### PR DESCRIPTION
Adds optional `chan_point` flag to lncli `closechannel` command allowing to close channels with channel point as opposed to providing `funding_txid`  and `output_index` separately (e.g. `lncli closechannel --chan_point XX:1`). In case `chan_point` is set, `funding_txid`/`output_index`  (if set) is ignored. 

Addresses issue https://github.com/lightningnetwork/lnd/issues/6131