### PR TITLE
server+contractcourt: create breachResolver to ensure htlc's are failed back

### DIFF
--- a/contractcourt/breach_resolver.go
+++ b/contractcourt/breach_resolver.go
@@ -1,0 +1,121 @@
+package contractcourt
+
+import (
+	"encoding/binary"
+	"io"
+
+	"github.com/lightningnetwork/lnd/channeldb"
+)
+
+// breachResolver is a resolver that will handle breached closes. In the
+// future, this will likely take over the duties the current breacharbiter has.
+type breachResolver struct {
+	// resolved reflects if the contract has been fully resolved or not.
+	resolved bool
+
+	// subscribed denotes whether or not the breach resolver has subscribed
+	// to the breacharbiter for breach resolution.
+	subscribed bool
+
+	// replyChan is closed when the breach arbiter has completed serving
+	// justice.
+	replyChan chan struct{}
+
+	contractResolverKit
+}
+
+// newBreachResolver instantiates a new breach resolver.
+func newBreachResolver(resCfg ResolverConfig) *breachResolver {
+	r := &breachResolver{
+		contractResolverKit: *newContractResolverKit(resCfg),
+		replyChan:           make(chan struct{}),
+	}
+
+	r.initLogger(r)
+
+	return r
+}
+
+// ResolverKey returns the unique identifier for this resolver.
+func (b *breachResolver) ResolverKey() []byte {
+	key := newResolverID(b.ChanPoint)
+	return key[:]
+}
+
+// Resolve queries the breacharbiter to see if the justice transaction has been
+// broadcast.
+func (b *breachResolver) Resolve() (ContractResolver, error) {
+	if !b.subscribed {
+		complete, err := b.SubscribeBreachComplete(
+			&b.ChanPoint, b.replyChan,
+		)
+		if err != nil {
+			return nil, err
+		}
+
+		// If the breach resolution process is already complete, then
+		// we can cleanup and checkpoint the resolved state.
+		if complete {
+			b.resolved = true
+			return nil, b.Checkpoint(b)
+		}
+
+		// Prevent duplicate subscriptions.
+		b.subscribed = true
+	}
+
+	select {
+	case <-b.replyChan:
+		// The replyChan has been closed, signalling that the breach
+		// has been fully resolved. Checkpoint the resolved state and
+		// exit.
+		b.resolved = true
+		return nil, b.Checkpoint(b)
+	case <-b.quit:
+	}
+
+	return nil, errResolverShuttingDown
+}
+
+// Stop signals the breachResolver to stop.
+func (b *breachResolver) Stop() {
+	close(b.quit)
+}
+
+// IsResolved returns true if the breachResolver is fully resolved and cleanup
+// can occur.
+func (b *breachResolver) IsResolved() bool {
+	return b.resolved
+}
+
+// SupplementState adds additional state to the breachResolver.
+func (b *breachResolver) SupplementState(_ *channeldb.OpenChannel) {
+}
+
+// Encode encodes the breachResolver to the passed writer.
+func (b *breachResolver) Encode(w io.Writer) error {
+	return binary.Write(w, endian, b.resolved)
+}
+
+// newBreachResolverFromReader attempts to decode an encoded breachResolver
+// from the passed Reader instance, returning an active breachResolver.
+func newBreachResolverFromReader(r io.Reader, resCfg ResolverConfig) (
+	*breachResolver, error) {
+
+	b := &breachResolver{
+		contractResolverKit: *newContractResolverKit(resCfg),
+		replyChan:           make(chan struct{}),
+	}
+
+	if err := binary.Read(r, endian, &b.resolved); err != nil {
+		return nil, err
+	}
+
+	b.initLogger(b)
+
+	return b, nil
+}
+
+// A compile time assertion to ensure breachResolver meets the ContractResolver
+// interface.
+var _ ContractResolver = (*breachResolver)(nil)

--- a/contractcourt/briefcase.go
+++ b/contractcourt/briefcase.go
@@ -147,7 +147,7 @@ const (
 	// |   |   |
 	// |   |   |-> StateCommitmentBroadcasted: chain/user trigger
 	// |   |   |
-	// |   |   |-> StateContractClosed: local/remote close trigger
+	// |   |   |-> StateContractClosed: local/remote/breach close trigger
 	// |   |   |   |
 	// |   |   |   |-> StateWaitingFullResolution: contract resolutions not empty
 	// |   |   |   |   |
@@ -157,9 +157,9 @@ const (
 	// |   |   |   |
 	// |   |   |   |-> StateFullyResolved: contract resolutions empty
 	// |   |   |
-	// |   |   |-> StateFullyResolved: coop/breach close trigger
+	// |   |   |-> StateFullyResolved: coop/breach(legacy) close trigger
 	// |   |
-	// |   |-> StateContractClosed: local/remote close trigger
+	// |   |-> StateContractClosed: local/remote/breach close trigger
 	// |   |   |
 	// |   |   |-> StateWaitingFullResolution: contract resolutions not empty
 	// |   |   |   |
@@ -169,11 +169,11 @@ const (
 	// |   |   |
 	// |   |   |-> StateFullyResolved: contract resolutions empty
 	// |   |
-	// |   |-> StateFullyResolved: coop/breach close trigger
+	// |   |-> StateFullyResolved: coop/breach(legacy) close trigger
 	// |
-	// |-> StateContractClosed: local/remote close trigger
+	// |-> StateContractClosed: local/remote/breach close trigger
 	// |   |
-	// |   |-> StateWaitingFullResolution: contract resolutions empty
+	// |   |-> StateWaitingFullResolution: contract resolutions not empty
 	// |   |   |
 	// |   |   |-> StateWaitingFullResolution: contract resolutions not empty
 	// |   |   |
@@ -181,7 +181,7 @@ const (
 	// |   |
 	// |   |-> StateFullyResolved: contract resolutions empty
 	// |
-	// |-> StateFullyResolved: coop/breach close trigger
+	// |-> StateFullyResolved: coop/breach(legacy) close trigger
 
 	// StateDefault is the default state. In this state, no major actions
 	// need to be executed.

--- a/contractcourt/briefcase.go
+++ b/contractcourt/briefcase.go
@@ -36,16 +36,21 @@ type ContractResolutions struct {
 	// output. If the channel type doesn't include anchors, the value of
 	// this field will be nil.
 	AnchorResolution *lnwallet.AnchorResolution
+
+	// BreachResolution contains the data required to manage the lifecycle
+	// of a breach in the ChannelArbitrator.
+	BreachResolution *BreachResolution
 }
 
 // IsEmpty returns true if the set of resolutions is "empty". A resolution is
-// empty if: our commitment output has been trimmed, and we don't have any
-// incoming or outgoing HTLC's active.
+// empty if: our commitment output has been trimmed, we don't have any
+// incoming or outgoing HTLC's active, there is no anchor output to sweep, or
+// there are no breached outputs to resolve.
 func (c *ContractResolutions) IsEmpty() bool {
 	return c.CommitResolution == nil &&
 		len(c.HtlcResolutions.IncomingHTLCs) == 0 &&
 		len(c.HtlcResolutions.OutgoingHTLCs) == 0 &&
-		c.AnchorResolution == nil
+		c.AnchorResolution == nil && c.BreachResolution == nil
 }
 
 // ArbitratorLog is the primary source of persistent storage for the
@@ -269,6 +274,10 @@ const (
 	// sweeping out direct commitment output form the remote party's
 	// commitment transaction.
 	resolverUnilateralSweep resolverType = 4
+
+	// resolverBreach is the type of resolver that manages a contract
+	// breach on-chain.
+	resolverBreach resolverType = 5
 )
 
 // resolverIDLen is the size of the resolver ID key. This is 36 bytes as we get
@@ -340,6 +349,11 @@ var (
 	// anchorResolutionKey is the key under the logScope that we'll use to
 	// store the anchor resolution, if any.
 	anchorResolutionKey = []byte("anchor-resolution")
+
+	// breachResolutionKey is the key under the logScope that we'll use to
+	// store the breach resolution, if any. This is used rather than the
+	// resolutionsKey.
+	breachResolutionKey = []byte("breach-resolution")
 
 	// actionsBucketKey is the key under the logScope that we'll use to
 	// store all chain actions once they're determined.
@@ -464,6 +478,8 @@ func (b *boltArbitratorLog) writeResolver(contractBucket kvdb.RwBucket,
 		rType = resolverIncomingContest
 	case *commitSweepResolver:
 		rType = resolverUnilateralSweep
+	case *breachResolver:
+		rType = resolverBreach
 	}
 	if _, err := buf.Write([]byte{byte(rType)}); err != nil {
 		return err
@@ -590,6 +606,11 @@ func (b *boltArbitratorLog) FetchUnresolvedContracts() ([]ContractResolver, erro
 
 			case resolverUnilateralSweep:
 				res, err = newCommitSweepResolverFromReader(
+					resReader, resolverCfg,
+				)
+
+			case resolverBreach:
+				res, err = newBreachResolverFromReader(
 					resReader, resolverCfg,
 				)
 
@@ -785,6 +806,20 @@ func (b *boltArbitratorLog) LogContractResolutions(c *ContractResolutions) error
 			}
 		}
 
+		// Write out the breach resolution if present.
+		if c.BreachResolution != nil {
+			var b bytes.Buffer
+			err := encodeBreachResolution(&b, c.BreachResolution)
+			if err != nil {
+				return err
+			}
+
+			err = scopeBucket.Put(breachResolutionKey, b.Bytes())
+			if err != nil {
+				return err
+			}
+		}
+
 		return nil
 	})
 }
@@ -898,6 +933,18 @@ func (b *boltArbitratorLog) FetchContractResolutions() (*ContractResolutions, er
 			resReader := bytes.NewReader(anchorResBytes)
 			err := decodeAnchorResolution(
 				resReader, c.AnchorResolution,
+			)
+			if err != nil {
+				return err
+			}
+		}
+
+		breachResBytes := scopeBucket.Get(breachResolutionKey)
+		if breachResBytes != nil {
+			c.BreachResolution = &BreachResolution{}
+			resReader := bytes.NewReader(breachResBytes)
+			err := decodeBreachResolution(
+				resReader, c.BreachResolution,
 			)
 			if err != nil {
 				return err
@@ -1370,6 +1417,21 @@ func decodeAnchorResolution(r io.Reader,
 	}
 
 	return input.ReadSignDescriptor(r, &a.AnchorSignDescriptor)
+}
+
+func encodeBreachResolution(w io.Writer, b *BreachResolution) error {
+	if _, err := w.Write(b.FundingOutPoint.Hash[:]); err != nil {
+		return err
+	}
+	return binary.Write(w, endian, b.FundingOutPoint.Index)
+}
+
+func decodeBreachResolution(r io.Reader, b *BreachResolution) error {
+	_, err := io.ReadFull(r, b.FundingOutPoint.Hash[:])
+	if err != nil {
+		return err
+	}
+	return binary.Read(r, endian, &b.FundingOutPoint.Index)
 }
 
 func encodeHtlcSetKey(w io.Writer, h *HtlcSetKey) error {

--- a/contractcourt/chain_arbitrator.go
+++ b/contractcourt/chain_arbitrator.go
@@ -183,6 +183,12 @@ type ChainArbitratorConfig struct {
 	// Clock is the clock implementation that ChannelArbitrator uses.
 	// It is useful for testing.
 	Clock clock.Clock
+
+	// SubscribeBreachComplete is used by the breachResolver to register a
+	// subscription that notifies when the breach resolution process is
+	// complete.
+	SubscribeBreachComplete func(op *wire.OutPoint, c chan struct{}) (
+		bool, error)
 }
 
 // ChainArbitrator is a sub-system that oversees the on-chain resolution of all

--- a/contractcourt/chain_watcher.go
+++ b/contractcourt/chain_watcher.go
@@ -57,6 +57,11 @@ type RemoteUnilateralCloseInfo struct {
 	CommitSet CommitSet
 }
 
+// BreachResolution wraps the outpoint of the breached channel.
+type BreachResolution struct {
+	FundingOutPoint wire.OutPoint
+}
+
 // CommitSet is a collection of the set of known valid commitments at a given
 // instant. If ConfCommitKey is set, then the commitment identified by the
 // HtlcSetKey has hit the chain. This struct will be used to examine all live

--- a/contractcourt/channel_arbitrator_test.go
+++ b/contractcourt/channel_arbitrator_test.go
@@ -205,6 +205,9 @@ type chanArbTestCtx struct {
 	log ArbitratorLog
 
 	sweeper *mockSweeper
+
+	breachSubscribed     chan struct{}
+	breachResolutionChan chan struct{}
 }
 
 func (c *chanArbTestCtx) CleanUp() {
@@ -303,13 +306,17 @@ func withMarkClosed(markClosed func(*channeldb.ChannelCloseSummary,
 func createTestChannelArbitrator(t *testing.T, log ArbitratorLog,
 	opts ...testChanArbOption) (*chanArbTestCtx, error) {
 
+	chanArbCtx := &chanArbTestCtx{
+		breachSubscribed: make(chan struct{}),
+	}
+
 	chanPoint := wire.OutPoint{}
 	shortChanID := lnwire.ShortChannelID{}
 	chanEvents := &ChainEventSubscription{
 		RemoteUnilateralClosure: make(chan *RemoteUnilateralCloseInfo, 1),
 		LocalUnilateralClosure:  make(chan *LocalUnilateralCloseInfo, 1),
 		CooperativeClosure:      make(chan *CooperativeCloseInfo, 1),
-		ContractBreach:          make(chan *lnwallet.BreachRetribution, 1),
+		ContractBreach:          make(chan *BreachCloseInfo, 1),
 	}
 
 	resolutionChan := make(chan []ResolutionMsg, 1)
@@ -345,6 +352,13 @@ func createTestChannelArbitrator(t *testing.T, log ArbitratorLog,
 			htlcIndex uint64) bool {
 
 			return true
+		},
+		SubscribeBreachComplete: func(op *wire.OutPoint,
+			c chan struct{}) (bool, error) {
+
+			chanArbCtx.breachResolutionChan = c
+			chanArbCtx.breachSubscribed <- struct{}{}
+			return false, nil
 		},
 		Clock:   clock.NewDefaultClock(),
 		Sweeper: mockSweeper,
@@ -425,16 +439,16 @@ func createTestChannelArbitrator(t *testing.T, log ArbitratorLog,
 
 	chanArb := NewChannelArbitrator(*arbCfg, htlcSets, log)
 
-	return &chanArbTestCtx{
-		t:                  t,
-		chanArb:            chanArb,
-		cleanUp:            cleanUp,
-		resolvedChan:       resolvedChan,
-		resolutions:        resolutionChan,
-		log:                log,
-		incubationRequests: incubateChan,
-		sweeper:            mockSweeper,
-	}, nil
+	chanArbCtx.t = t
+	chanArbCtx.chanArb = chanArb
+	chanArbCtx.cleanUp = cleanUp
+	chanArbCtx.resolvedChan = resolvedChan
+	chanArbCtx.resolutions = resolutionChan
+	chanArbCtx.log = log
+	chanArbCtx.incubationRequests = incubateChan
+	chanArbCtx.sweeper = mockSweeper
+
+	return chanArbCtx, nil
 }
 
 // TestChannelArbitratorCooperativeClose tests that the ChannelArbitertor
@@ -661,11 +675,13 @@ func TestChannelArbitratorLocalForceClose(t *testing.T) {
 
 // TestChannelArbitratorBreachClose tests that the ChannelArbitrator goes
 // through the expected states in case we notice a breach in the chain, and
-// gracefully exits.
+// is able to properly progress the breachResolver and anchorResolver to a
+// successful resolution.
 func TestChannelArbitratorBreachClose(t *testing.T) {
 	log := &mockArbitratorLog{
 		state:     StateDefault,
 		newStates: make(chan ArbitratorState, 5),
+		resolvers: make(map[ContractResolver]struct{}),
 	}
 
 	chanArbCtx, err := createTestChannelArbitrator(t, log)
@@ -673,6 +689,8 @@ func TestChannelArbitratorBreachClose(t *testing.T) {
 		t.Fatalf("unable to create ChannelArbitrator: %v", err)
 	}
 	chanArb := chanArbCtx.chanArb
+	chanArb.cfg.PreimageDB = newMockWitnessBeacon()
+	chanArb.cfg.Registry = &mockRegistry{}
 
 	if err := chanArb.Start(nil); err != nil {
 		t.Fatalf("unable to start ChannelArbitrator: %v", err)
@@ -686,13 +704,99 @@ func TestChannelArbitratorBreachClose(t *testing.T) {
 	// It should start out in the default state.
 	chanArbCtx.AssertState(StateDefault)
 
-	// Send a breach close event.
-	chanArb.cfg.ChainEvents.ContractBreach <- &lnwallet.BreachRetribution{}
+	// We create two HTLCs, one incoming and one outgoing. We will later
+	// assert that we only receive a ResolutionMsg for the outgoing HTLC.
+	outgoingIdx := uint64(2)
 
-	// It should transition StateDefault -> StateFullyResolved.
-	chanArbCtx.AssertStateTransitions(
-		StateFullyResolved,
-	)
+	rHash1 := [lntypes.PreimageSize]byte{1, 2, 3}
+	htlc1 := channeldb.HTLC{
+		RHash:       rHash1,
+		OutputIndex: 2,
+		Incoming:    false,
+		HtlcIndex:   outgoingIdx,
+		LogIndex:    2,
+	}
+
+	rHash2 := [lntypes.PreimageSize]byte{2, 2, 2}
+	htlc2 := channeldb.HTLC{
+		RHash:       rHash2,
+		OutputIndex: 3,
+		Incoming:    true,
+		HtlcIndex:   3,
+		LogIndex:    3,
+	}
+
+	anchorRes := &lnwallet.AnchorResolution{
+		AnchorSignDescriptor: input.SignDescriptor{
+			Output: &wire.TxOut{Value: 1},
+		},
+	}
+
+	// Create the BreachCloseInfo that the chain_watcher would normally
+	// send to the channel_arbitrator.
+	breachInfo := &BreachCloseInfo{
+		BreachResolution: &BreachResolution{
+			FundingOutPoint: wire.OutPoint{},
+		},
+		AnchorResolution: anchorRes,
+		CommitSet: CommitSet{
+			ConfCommitKey: &RemoteHtlcSet,
+			HtlcSets: map[HtlcSetKey][]channeldb.HTLC{
+				RemoteHtlcSet: {htlc1, htlc2},
+			},
+		},
+		CommitHash: chainhash.Hash{},
+	}
+
+	// Send a breach close event.
+	chanArb.cfg.ChainEvents.ContractBreach <- breachInfo
+
+	// It should transition StateDefault -> StateContractClosed.
+	chanArbCtx.AssertStateTransitions(StateContractClosed)
+
+	// We should receive one ResolutionMsg as there was only one outgoing
+	// HTLC at the time of the breach.
+	select {
+	case res := <-chanArbCtx.resolutions:
+		require.Equal(t, 1, len(res))
+		require.Equal(t, outgoingIdx, res[0].HtlcIndex)
+	case <-time.After(5 * time.Second):
+		t.Fatal("expected to receive a resolution msg")
+	}
+
+	// We should now transition from StateContractClosed to
+	// StateWaitingFullResolution.
+	chanArbCtx.AssertStateTransitions(StateWaitingFullResolution)
+
+	// One of the resolvers should be an anchor resolver and the other
+	// should be a breach resolver.
+	require.Equal(t, 2, len(chanArb.activeResolvers))
+
+	var anchorExists, breachExists bool
+	for _, resolver := range chanArb.activeResolvers {
+		switch resolver.(type) {
+		case *anchorResolver:
+			anchorExists = true
+		case *breachResolver:
+			breachExists = true
+		default:
+			t.Fatalf("did not expect resolver %T", resolver)
+		}
+	}
+	require.True(t, anchorExists && breachExists)
+
+	// The anchor resolver is expected to re-offer the anchor input to the
+	// sweeper.
+	<-chanArbCtx.sweeper.sweptInputs
+
+	// Wait for SubscribeBreachComplete to be called.
+	<-chanArbCtx.breachSubscribed
+
+	// We'll now close the breach channel so that the state transitions to
+	// StateFullyResolved.
+	close(chanArbCtx.breachResolutionChan)
+
+	chanArbCtx.AssertStateTransitions(StateFullyResolved)
 
 	// It should also mark the channel as resolved.
 	select {
@@ -1318,12 +1422,14 @@ func TestChannelArbitratorPersistence(t *testing.T) {
 // TestChannelArbitratorForceCloseBreachedChannel tests that the channel
 // arbitrator is able to handle a channel in the process of being force closed
 // is breached by the remote node. In these cases we expect the
-// ChannelArbitrator to gracefully exit, as the breach is handled by other
-// subsystems.
+// ChannelArbitrator to properly execute the breachResolver flow and then
+// gracefully exit once the breachResolver receives the signal from what would
+// normally be the breacharbiter.
 func TestChannelArbitratorForceCloseBreachedChannel(t *testing.T) {
 	log := &mockArbitratorLog{
 		state:     StateDefault,
 		newStates: make(chan ArbitratorState, 5),
+		resolvers: make(map[ContractResolver]struct{}),
 	}
 
 	chanArbCtx, err := createTestChannelArbitrator(t, log)
@@ -1389,6 +1495,20 @@ func TestChannelArbitratorForceCloseBreachedChannel(t *testing.T) {
 		t.Fatalf("no response received")
 	}
 
+	// Before restarting, we'll need to modify the arbitrator log to have
+	// a set of contract resolutions and a commit set.
+	log.resolutions = &ContractResolutions{
+		BreachResolution: &BreachResolution{
+			FundingOutPoint: wire.OutPoint{},
+		},
+	}
+	log.commitSet = &CommitSet{
+		ConfCommitKey: &RemoteHtlcSet,
+		HtlcSets: map[HtlcSetKey][]channeldb.HTLC{
+			RemoteHtlcSet: {},
+		},
+	}
+
 	// We mimic that the channel is breached while the channel arbitrator
 	// is down. This means that on restart it will be started with a
 	// pending close channel, of type BreachClose.
@@ -1402,7 +1522,18 @@ func TestChannelArbitratorForceCloseBreachedChannel(t *testing.T) {
 	}
 	defer chanArbCtx.CleanUp()
 
-	// Finally it should advance to StateFullyResolved.
+	// We should transition to StateContractClosed.
+	chanArbCtx.AssertStateTransitions(
+		StateContractClosed, StateWaitingFullResolution,
+	)
+
+	// Wait for SubscribeBreachComplete to be called.
+	<-chanArbCtx.breachSubscribed
+
+	// We'll close the breachResolutionChan to cleanup the breachResolver
+	// and make the state transition to StateFullyResolved.
+	close(chanArbCtx.breachResolutionChan)
+
 	chanArbCtx.AssertStateTransitions(StateFullyResolved)
 
 	// It should also mark the channel as resolved.

--- a/docs/release-notes/release-notes-0.14.2.md
+++ b/docs/release-notes/release-notes-0.14.2.md
@@ -41,6 +41,9 @@ Postgres](https://github.com/lightningnetwork/lnd/pull/6111)
 
 ## Bug fixes
 
+* [A new resolver for breach closes was introduced that handles sweeping
+  anchor outputs and failing back HTLCs.](https://github.com/lightningnetwork/lnd/pull/6158)
+
 * [Return the nearest known fee rate when a given conf target cannot be found
   from Web API fee estimator.](https://github.com/lightningnetwork/lnd/pull/6062)
 

--- a/server.go
+++ b/server.go
@@ -1088,8 +1088,7 @@ func newServer(cfg *Config, listenAddrs []net.Addr,
 		},
 		IsOurAddress: cc.Wallet.IsOurAddress,
 		ContractBreach: func(chanPoint wire.OutPoint,
-			breachRet *lnwallet.BreachRetribution,
-			markClosed func() error) error {
+			breachRet *lnwallet.BreachRetribution) error {
 
 			// processACK will handle the breachArbiter ACKing the
 			// event.
@@ -1101,8 +1100,9 @@ func newServer(cfg *Config, listenAddrs []net.Addr,
 				}
 
 				// If the breachArbiter successfully handled
-				// the event, we can mark the channel closed.
-				finalErr <- markClosed()
+				// the event, we can signal that the handoff
+				// was successful.
+				finalErr <- nil
 			}
 
 			event := &contractcourt.ContractBreachEvent{
@@ -1118,9 +1118,8 @@ func newServer(cfg *Config, listenAddrs []net.Addr,
 				return ErrServerShuttingDown
 			}
 
-			// We'll wait for a final error to be available, either
-			// from the breachArbiter or from our markClosed
-			// function closure.
+			// We'll wait for a final error to be available from
+			// the breachArbiter.
 			select {
 			case err := <-finalErr:
 				return err


### PR DESCRIPTION
This pull request fails back HTLCs if we detect our remote party has broadcasted a breach transaction. This is accomplished by launching a `breachResolver` like any other resolver. A nice bonus is that since the breach-lifecycle is now tracked in the channel arbitrator, we can tack on an `anchorResolver` and sweep the anchor output. This would also allow the breacharbiter code to be moved into this `breachResolver` in a later changeset.

Fixes https://github.com/lightningnetwork/lnd/issues/3494