### PR TITLE
contractcourt: catch error when no historical bucket exists

### DIFF
--- a/channeldb/db.go
+++ b/channeldb/db.go
@@ -329,6 +329,7 @@ var dbTopLevelBuckets = [][]byte{
 	metaBucket,
 	closeSummaryBucket,
 	outpointBucket,
+	historicalChannelBucket,
 }
 
 // Wipe completely deletes all saved state within all used buckets within the

--- a/channeldb/db_test.go
+++ b/channeldb/db_test.go
@@ -717,10 +717,11 @@ func TestFetchHistoricalChannel(t *testing.T) {
 	// Create a an open channel in the database.
 	channel := createTestChannel(t, cdb, openChannelOption())
 
-	// First, try to lookup a channel when the bucket does not
-	// exist.
+	// First, try to lookup a channel when nothing is in the bucket. As the
+	// bucket is auto-created (on start up), we'll get a channel not found
+	// error.
 	_, err = cdb.FetchHistoricalChannel(&channel.FundingOutpoint)
-	if err != ErrNoHistoricalBucket {
+	if err != ErrChannelNotFound {
 		t.Fatalf("expected no bucket, got: %v", err)
 	}
 

--- a/contractcourt/channel_arbitrator.go
+++ b/contractcourt/channel_arbitrator.go
@@ -618,6 +618,8 @@ func (c *ChannelArbitrator) relaunchResolvers(commitSet *CommitSet,
 	// If we don't find this channel, then it may be the case that it
 	// was closed before we started to retain the final state
 	// information for open channels.
+	case err == channeldb.ErrNoHistoricalBucket:
+		fallthrough
 	case err == channeldb.ErrChannelNotFound:
 		log.Warnf("ChannelArbitrator(%v): unable to fetch historical "+
 			"state", c.cfg.ChanPoint)
@@ -1947,6 +1949,8 @@ func (c *ChannelArbitrator) prepContractResolutions(
 	// If we don't find this channel, then it may be the case that it
 	// was closed before we started to retain the final state
 	// information for open channels.
+	case err == channeldb.ErrNoHistoricalBucket:
+		fallthrough
 	case err == channeldb.ErrChannelNotFound:
 		log.Warnf("ChannelArbitrator(%v): unable to fetch historical "+
 			"state", c.cfg.ChanPoint)

--- a/docs/release-notes/release-notes-0.14.2.md
+++ b/docs/release-notes/release-notes-0.14.2.md
@@ -69,7 +69,9 @@ connection from the watch-only node.
 
 * [Fix duplicate db connection close](https://github.com/lightningnetwork/lnd/pull/6140)
 
-* [Fix a memory leak introduced by the new ping-header p2p enhancement](https://github.com/lightningnetwork/lnd/pull/6144]
+* [Fix a memory leak introduced by the new ping-header p2p enhancement](https://github.com/lightningnetwork/lnd/pull/6144)
+
+* [Fix an issue that would prevent very old nodes from starting up due to lack of a historical channel bucket](https://github.com/lightningnetwork/lnd/pull/6159)
 
 
 ## RPC Server


### PR DESCRIPTION
For older nodes, this bucket was never created, so we'll get an error if
we try and query it. In this commit, we catch this error like we do when
a given channel doesn't have the information (but the bucket actually
exists).

Fixes #6155