### PR TITLE
lnrpc,routing: add an always on mode to HTLC interceptor

### DIFF
--- a/lnrpc/routerrpc/config.go
+++ b/lnrpc/routerrpc/config.go
@@ -50,6 +50,7 @@ func DefaultConfig() *Config {
 		AttemptCostPPM:        routing.DefaultAttemptCostPPM,
 		MaxMcHistory:          routing.DefaultMaxMcHistory,
 		McFlushInterval:       routing.DefaultMcFlushInterval,
+		AlwaysIntercept:       routing.DefaultAlwaysIntercept,
 	}
 
 	return &Config{
@@ -68,5 +69,6 @@ func GetRoutingConfig(cfg *Config) *RoutingConfig {
 		PenaltyHalfLife:       cfg.PenaltyHalfLife,
 		MaxMcHistory:          cfg.MaxMcHistory,
 		McFlushInterval:       cfg.McFlushInterval,
+		AlwaysIntercept:       cfg.AlwaysIntercept,
 	}
 }

--- a/lnrpc/routerrpc/config.go
+++ b/lnrpc/routerrpc/config.go
@@ -50,7 +50,7 @@ func DefaultConfig() *Config {
 		AttemptCostPPM:        routing.DefaultAttemptCostPPM,
 		MaxMcHistory:          routing.DefaultMaxMcHistory,
 		McFlushInterval:       routing.DefaultMcFlushInterval,
-		AlwaysIntercept:       routing.DefaultAlwaysIntercept,
+		RequireInterceptor:    routing.DefaultRequireInterceptor,
 	}
 
 	return &Config{
@@ -69,6 +69,6 @@ func GetRoutingConfig(cfg *Config) *RoutingConfig {
 		PenaltyHalfLife:       cfg.PenaltyHalfLife,
 		MaxMcHistory:          cfg.MaxMcHistory,
 		McFlushInterval:       cfg.McFlushInterval,
-		AlwaysIntercept:       cfg.AlwaysIntercept,
+		RequireInterceptor:    cfg.RequireInterceptor,
 	}
 }

--- a/lnrpc/routerrpc/forward_interceptor.go
+++ b/lnrpc/routerrpc/forward_interceptor.go
@@ -64,7 +64,7 @@ func (r *forwardInterceptor) attachStream(stream Router_HtlcInterceptorServer) e
 
 	r.stream = stream
 
-	if !r.server.cfg.AlwaysIntercept {
+	if !r.server.cfg.RequireInterceptor {
 		// Register our interceptor so we receive all forwarded packets.
 		interceptableForwarder := r.server.cfg.RouterBackend.InterceptableForwarder
 		interceptableForwarder.SetInterceptor(r.onIntercept)
@@ -121,7 +121,7 @@ func (r *forwardInterceptor) attachStream(stream Router_HtlcInterceptorServer) e
 // to deliver the packet to the main loop.
 func (r *forwardInterceptor) onIntercept(p htlcswitch.InterceptedForward) bool {
 
-	if r.stream == nil && !r.server.cfg.AlwaysIntercept {
+	if r.stream == nil && !r.server.cfg.RequireInterceptor {
 		return false
 	}
 
@@ -229,7 +229,7 @@ func (r *forwardInterceptor) resolveFromClient(
 // behavior.
 func (r *forwardInterceptor) onDisconnect() {
 
-	if !r.server.cfg.AlwaysIntercept {
+	if !r.server.cfg.RequireInterceptor {
 		log.Infof("RPC interceptor disconnected, resolving held packets")
 		for key, forward := range r.holdForwards {
 			if err := forward.Resume(); err != nil {
@@ -244,8 +244,8 @@ func (r *forwardInterceptor) onDisconnect() {
 }
 
 func (r *forwardInterceptor) start() {
-	if r.server.cfg.AlwaysIntercept {
-		log.Infof("Registering RPC interceptor early due to AlwaysIntercept")
+	if r.server.cfg.RequireInterceptor {
+		log.Infof("Registering RPC interceptor early due to RequireInterceptor")
 		// Register our interceptor so we receive all forwarded packets.
 		interceptableForwarder := r.server.cfg.RouterBackend.InterceptableForwarder
 		interceptableForwarder.SetInterceptor(r.onIntercept)

--- a/lnrpc/routerrpc/routing_config.go
+++ b/lnrpc/routerrpc/routing_config.go
@@ -48,7 +48,7 @@ type RoutingConfig struct {
 	// control state to the DB.
 	McFlushInterval time.Duration `long:"mcflushinterval" description:"the timer interval to use to flush mission control state to the DB"`
 
-	// AlwaysIntercept determines whether the HTLC interceptor is registered
+	// RequireInterceptor determines whether the HTLC interceptor is registered
 	// regardless of whether the RPC is called or not.
-	AlwaysIntercept bool `long:"alwaysintercept" description:"Whether to always intercept HTLCs, even if no stream is attached"`
+	RequireInterceptor bool `long:"requireinterceptor" description:"Whether to always intercept HTLCs, even if no stream is attached"`
 }

--- a/lnrpc/routerrpc/routing_config.go
+++ b/lnrpc/routerrpc/routing_config.go
@@ -47,4 +47,8 @@ type RoutingConfig struct {
 	// McFlushInterval defines the timer interval to use to flush mission
 	// control state to the DB.
 	McFlushInterval time.Duration `long:"mcflushinterval" description:"the timer interval to use to flush mission control state to the DB"`
+
+	// AlwaysIntercept determines whether the HTLC interceptor is registered
+	// regardless of whether the RPC is called or not.
+	AlwaysIntercept bool `long:"alwaysintercept" description:"Whether to always intercept HTLCs, even if no stream is attached"`
 }

--- a/routing/missioncontrol.go
+++ b/routing/missioncontrol.go
@@ -61,6 +61,11 @@ const (
 	// have passed since the previously recorded failure before the failure
 	// amount may be raised.
 	DefaultMinFailureRelaxInterval = time.Minute
+
+	// DefaultAlwaysIntercept controls whether the HTLC are held before an
+	// interceptor is registered. If set, HTLC are not resumed automatically
+	// when the interceptor disconnects.
+	DefaultAlwaysIntercept = false
 )
 
 var (

--- a/routing/missioncontrol.go
+++ b/routing/missioncontrol.go
@@ -62,10 +62,10 @@ const (
 	// amount may be raised.
 	DefaultMinFailureRelaxInterval = time.Minute
 
-	// DefaultAlwaysIntercept controls whether the HTLC are held before an
+	// DefaultRequireInterceptor controls whether the HTLC are held before an
 	// interceptor is registered. If set, HTLC are not resumed automatically
 	// when the interceptor disconnects.
-	DefaultAlwaysIntercept = false
+	DefaultRequireInterceptor = false
 )
 
 var (

--- a/sample-lnd.conf
+++ b/sample-lnd.conf
@@ -1077,6 +1077,9 @@ litecoin.node=ltcd
 ; Path to the router macaroon
 ; routerrpc.routermacaroonpath=~/.lnd/data/chain/bitcoin/simnet/router.macaroon
 
+; If true, all HTLCs will be held until they are handled by an interceptor
+; routerrpc.requireinterceptor=true
+
 
 [workers]
 


### PR DESCRIPTION
Adds a flag that makes the interceptor be registered on startup. HTLCs will be queued for notification until the RPC stream is connected. If the stream disconnects for any reason, HTLCs waiting for resolution will not be resumed and will be held until the stream reconnects and resolves them.

Solves #6161 