### PR TITLE
Multi-node receive [PoC]

### DIFF
--- a/config.go
+++ b/config.go
@@ -421,6 +421,15 @@ type Config struct {
 
 	// ActiveNetParams contains parameters of the target chain.
 	ActiveNetParams chainreg.BitcoinNetParams
+
+	Gateway *GatewayConfig `group:"gateway" namespace:"gateway"`
+}
+
+type GatewayConfig struct {
+	PubKey      string `long:"pubkey" description:"Node pubkey for which to produce coordinator invoices"`
+	Host        string `long:"host" description:"Gateway host"`
+	TlsCertPath string `long:"tls" description:"Gateway tls cert path"`
+	MacPath     string `long:"mac" description:"Gateway macaroon path"`
 }
 
 // DefaultConfig returns all default values for the Config struct.

--- a/invoice_coordinator.go
+++ b/invoice_coordinator.go
@@ -1,0 +1,240 @@
+package lnd
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"sync"
+
+	"github.com/lightningnetwork/lnd/channeldb"
+	"github.com/lightningnetwork/lnd/htlcswitch/hop"
+	"github.com/lightningnetwork/lnd/invoices"
+	"github.com/lightningnetwork/lnd/lnrpc"
+	"github.com/lightningnetwork/lnd/lnrpc/chainrpc"
+	"github.com/lightningnetwork/lnd/lnrpc/routerrpc"
+	"github.com/lightningnetwork/lnd/lntypes"
+	"github.com/lightningnetwork/lnd/lnwire"
+	"github.com/lightningnetwork/lnd/routing/route"
+	"google.golang.org/grpc"
+)
+
+type InvoiceCoordinator struct {
+	registry *invoices.InvoiceRegistry
+	sphinx   *hop.OnionProcessor
+
+	gwPubKey                         route.Vertex
+	gwHost, gwTlsCertPath, gwMacPath string
+
+	conn *grpc.ClientConn
+
+	wg   sync.WaitGroup
+	quit chan struct{}
+}
+
+type InvoiceCoordinatorConfig struct {
+	registry *invoices.InvoiceRegistry
+	sphinx   *hop.OnionProcessor
+	gwPubKey route.Vertex
+
+	gwHost, gwTlsCertPath, gwMacPath string
+}
+
+func NewInvoiceCoordinator(cfg *InvoiceCoordinatorConfig) *InvoiceCoordinator {
+	return &InvoiceCoordinator{
+		registry: cfg.registry,
+		sphinx:   cfg.sphinx,
+
+		gwPubKey:      cfg.gwPubKey,
+		gwHost:        cfg.gwHost,
+		gwTlsCertPath: cfg.gwTlsCertPath,
+		gwMacPath:     cfg.gwMacPath,
+
+		quit: make(chan struct{}),
+	}
+}
+
+func (p *InvoiceCoordinator) Start() error {
+	conn, err := getClientConn(p.gwHost, p.gwMacPath, p.gwTlsCertPath)
+	if err != nil {
+		return err
+	}
+	p.conn = conn
+
+	infoResp, err := lnrpc.NewLightningClient(conn).GetInfo(context.Background(), &lnrpc.GetInfoRequest{})
+	if err != nil {
+		return err
+	}
+
+	srvrLog.Infof("Invoice coordinator started for gateway %v (%v)",
+		p.gwPubKey, infoResp.Alias)
+
+	p.wg.Add(1)
+	go func() {
+		defer p.wg.Done()
+
+		err := p.run()
+		if err != nil {
+			srvrLog.Errorf("Invoice coordinator error: %v", err)
+		}
+	}()
+
+	return nil
+}
+
+func (p *InvoiceCoordinator) Stop() error {
+	close(p.quit)
+	p.wg.Wait()
+
+	return nil
+}
+
+func (p *InvoiceCoordinator) run() error {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	notifierClient := chainrpc.NewChainNotifierClient(p.conn)
+	blockStream, err := notifierClient.RegisterBlockEpochNtfn(
+		ctx, &chainrpc.BlockEpoch{},
+	)
+	if err != nil {
+		return err
+	}
+
+	routerClient := routerrpc.NewRouterClient(p.conn)
+	stream, err := routerClient.HtlcInterceptor(context.Background())
+	if err != nil {
+		return err
+	}
+
+	var (
+		errChan   = make(chan error)
+		htlcChan  = make(chan *routerrpc.ForwardHtlcInterceptRequest)
+		blockChan = make(chan uint32)
+	)
+
+	p.wg.Add(1)
+	go func() {
+		defer p.wg.Done()
+		for {
+			event, err := stream.Recv()
+			if err != nil {
+				errChan <- err
+			}
+
+			htlcChan <- event
+		}
+	}()
+
+	p.wg.Add(1)
+	go func() {
+		defer p.wg.Done()
+		for {
+			event, err := blockStream.Recv()
+			if err != nil {
+				errChan <- err
+			}
+
+			blockChan <- event.Height
+		}
+	}()
+
+	height := <-blockChan
+
+	hodlChan := make(chan interface{})
+
+	for {
+		select {
+		case err := <-errChan:
+			return err
+
+		case height = <-blockChan:
+
+		case htlc := <-htlcChan:
+			circuitKey := channeldb.CircuitKey{
+				ChanID: lnwire.NewShortChanIDFromInt(
+					htlc.IncomingCircuitKey.ChanId,
+				),
+				HtlcID: htlc.IncomingCircuitKey.HtlcId,
+			}
+
+			fail := func() error {
+				srvrLog.Debugf("Failing htlc %v", circuitKey)
+
+				return stream.Send(&routerrpc.ForwardHtlcInterceptResponse{
+					Action:             routerrpc.ResolveHoldForwardAction_FAIL,
+					IncomingCircuitKey: htlc.IncomingCircuitKey,
+				})
+			}
+
+			hash, err := lntypes.MakeHash(htlc.PaymentHash)
+			if err != nil {
+				return err
+			}
+
+			// Try decode final hop onion.
+			onionReader := bytes.NewReader(htlc.OnionBlob)
+			iterator, failCode := p.sphinx.DecodeHopIterator(
+				onionReader, htlc.PaymentHash,
+				htlc.IncomingExpiry,
+			)
+			if failCode != lnwire.CodeNone {
+				if err := fail(); err != nil {
+					return err
+				}
+			}
+
+			payload, err := iterator.HopPayload()
+			if err != nil {
+				return err
+			}
+
+			resolution, err := p.registry.NotifyExitHopHtlc(
+				hash,
+				lnwire.MilliSatoshi(htlc.OutgoingAmountMsat),
+				htlc.OutgoingExpiry,
+				int32(height), circuitKey,
+				hodlChan,
+				payload,
+			)
+			if err != nil {
+				return err
+			}
+
+			// Determine required action for the resolution based on the type of
+			// resolution we have received.
+			switch res := resolution.(type) {
+			// Settle htlcs that returned a settle resolution using the preimage
+			// in the resolution.
+			case *invoices.HtlcSettleResolution:
+				srvrLog.Debugf("received settle resolution for %v "+
+					"with outcome: %v", circuitKey, res.Outcome)
+
+				err := stream.Send(&routerrpc.ForwardHtlcInterceptResponse{
+					Action:             routerrpc.ResolveHoldForwardAction_SETTLE,
+					IncomingCircuitKey: htlc.IncomingCircuitKey,
+					Preimage:           res.Preimage[:],
+				})
+				if err != nil {
+					return err
+				}
+
+			// For htlc failures, we get the relevant failure message based
+			// on the failure resolution and then fail the htlc.
+			case *invoices.HtlcFailResolution:
+				if err := fail(); err != nil {
+					return err
+				}
+
+			// Fail if we do not get a settle of fail resolution, since we
+			// are only expecting to handle settles and fails.
+			default:
+				return fmt.Errorf("unknown htlc resolution type: %T",
+					resolution)
+			}
+
+		case <-p.quit:
+			return nil
+
+		}
+	}
+}

--- a/invoice_coordinator_conn.go
+++ b/invoice_coordinator_conn.go
@@ -1,0 +1,97 @@
+package lnd
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"os/user"
+	"path/filepath"
+	"strings"
+
+	"github.com/lightningnetwork/lnd/lncfg"
+	"github.com/lightningnetwork/lnd/macaroons"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials"
+	"gopkg.in/macaroon.v2"
+)
+
+var (
+	maxMsgRecvSize = grpc.MaxCallRecvMsgSize(1 * 1024 * 1024 * 200)
+)
+
+func getClientConn(host, macPath, tlsCertPath string) (*grpc.ClientConn,
+	error) {
+
+	tlsCertPath = cleanAndExpandPath(tlsCertPath)
+	macPath = cleanAndExpandPath(macPath)
+
+	// Load the specified TLS certificate and build transport credentials
+	// with it.
+	creds, err := credentials.NewClientTLSFromFile(tlsCertPath, "")
+	if err != nil {
+		return nil, err
+	}
+
+	// Create a dial options array.
+	opts := []grpc.DialOption{
+		grpc.WithTransportCredentials(creds),
+	}
+
+	// Load the specified macaroon file.
+	macBytes, err := ioutil.ReadFile(macPath)
+	if err != nil {
+		return nil, fmt.Errorf("unable to read macaroon path (check "+
+			"the network setting!): %v", err)
+	}
+
+	mac := &macaroon.Macaroon{}
+	if err = mac.UnmarshalBinary(macBytes); err != nil {
+		return nil, fmt.Errorf("unable to decode macaroon: %v", err)
+	}
+
+	// Now we append the macaroon credentials to the dial options.
+	cred, err := macaroons.NewMacaroonCredential(mac)
+	if err != nil {
+		return nil, err
+	}
+	opts = append(opts, grpc.WithPerRPCCredentials(cred))
+
+	// We need to use a custom dialer so we can also connect to unix sockets
+	// and not just TCP addresses.
+	genericDialer := lncfg.ClientAddressDialer(fmt.Sprintf("%d", defaultRPCPort))
+	opts = append(opts, grpc.WithContextDialer(genericDialer))
+	opts = append(opts, grpc.WithDefaultCallOptions(maxMsgRecvSize))
+
+	conn, err := grpc.Dial(host, opts...)
+	if err != nil {
+		return nil, fmt.Errorf("unable to connect to RPC server: %v", err)
+	}
+
+	return conn, nil
+}
+
+// cleanAndExpandPath expands environment variables and leading ~ in the
+// passed path, cleans the result, and returns it.
+// This function is taken from https://github.com/btcsuite/btcd
+func cleanAndExpandPath(path string) string {
+	if path == "" {
+		return ""
+	}
+
+	// Expand initial ~ to OS specific home directory.
+	if strings.HasPrefix(path, "~") {
+		var homeDir string
+		user, err := user.Current()
+		if err == nil {
+			homeDir = user.HomeDir
+		} else {
+			homeDir = os.Getenv("HOME")
+		}
+
+		path = strings.Replace(path, "~", homeDir, 1)
+	}
+
+	// NOTE: The os.ExpandEnv doesn't work with Windows-style %VARIABLE%,
+	// but the variables can still be expanded via POSIX-style $VARIABLE.
+	return filepath.Clean(os.ExpandEnv(path))
+}

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -5203,6 +5203,7 @@ func (r *rpcServer) AddInvoice(ctx context.Context,
 		GenAmpInvoiceFeatures: func() *lnwire.FeatureVector {
 			return r.server.featureMgr.Get(feature.SetInvoiceAmp)
 		},
+		GatewayPubKey: r.server.gwPubKey,
 	}
 
 	value, err := lnrpc.UnmarshallAmt(invoice.Value, invoice.ValueMsat)


### PR DESCRIPTION
This PR is an exploration of the design space for multi-node receive.

The idea is to run a standalone process (working title: `invoice coordinator`) that connects to a cluster of lnd nodes via the htlc interceptor API. The coordinator is backed by a replicated database that contains all invoices. It has its own node key and every invoice is generated by the coordinator. Invoices contain a hop hint for each node in the cluster with a dummy scid.

When an htlc comes in on one of the cluster nodes, it is intercepted by the coordinator. The coordinator matches the hash with the invoice database and if there is one, it signals the lnd node to settle the htlc.

This allows invoices to be paid through any of the cluster nodes. When one node goes down, senders will retry with one of the other nodes listed in the route hints. Also shards of a multi-part payment may use multiple nodes.

Current implementation is an adaptation to LND. It allows LND to be run in a mode where it acts as the coordinator. To do that, the gateway node needs to be specified (only one supported atm):

`lnd --gateway.pubkey=0314aaf9b2547682b81977b3ac0c5585c3521a0a5430fb410cb572d5c72364edf3 --gateway.tls=~/.lnd/tls.cert --gateway.mac=~/.lnd-bob/data/chain/bitcoin/regtest/admin.macaroon --gateway.host=localhost:10002`

What you can do with this is set up Alice and Bob with a channel between them and then connect the coordinator to Bob. This allows Alice to pay invoices created by the coordinator.

For production, it seems unlikely that we want to run a customized lnd as the coordinator. Instead the coordinator code can live in a fresh stand-alone repo. This also allows the database backend (`channeldb/invoices.go`) to be re-implemented using structured sql.