### PR TITLE
GitHub: fix daily docker build

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -33,11 +33,15 @@ jobs:
           password: ${{ secrets.DOCKER_API_KEY }}
 
       - name: Set env
-        run: echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
+        run: |
+          echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
+          echo "IMAGE_TAG=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
       
       - name: Set daily tag
         if: github.event.schedule == '0 0 * * *'
-        run: echo "RELEASE_VERSION=daily-testing-only" >> $GITHUB_ENV
+        run: |
+          echo "RELEASE_VERSION=master" >> $GITHUB_ENV
+          echo "IMAGE_TAG=daily-testing-only" >> $GITHUB_ENV
 
       - name: Build and push
         id: docker_build
@@ -45,7 +49,7 @@ jobs:
         with:
           push: true
           platforms: linux/amd64,linux/arm64
-          tags: "${{ env.DOCKER_REPO }}/${{ env.DOCKER_IMAGE }}:${{ env.RELEASE_VERSION }}"
+          tags: "${{ env.DOCKER_REPO }}/${{ env.DOCKER_IMAGE }}:${{ env.IMAGE_TAG }}"
           build-args: checkout=${{ env.RELEASE_VERSION }}
 
       - name: Image digest


### PR DESCRIPTION
Testing GitHub Actions is hard. Testing schedule based actions is even harder... So naturally, it didn't work on first attempt...
Not adding release notes because we already had those for https://github.com/lightningnetwork/lnd/pull/6160. Also not adding `[skip ci]` to make sure the cron job isn't ignored because of it.