### PR TITLE
server: disable chain health check if we're running without backend

### DIFF
--- a/docs/release-notes/release-notes-0.15.0.md
+++ b/docs/release-notes/release-notes-0.15.0.md
@@ -51,6 +51,8 @@
 * [A nightly build of the `lnd` docker image is now created
   automatically](https://github.com/lightningnetwork/lnd/pull/6160).
 
+* [Chain backend healthchecks disabled for --nochainbackend mode](https://github.com/lightningnetwork/lnd/pull/6184)
+
 ## RPC Server
 
 * [Add value to the field

--- a/server.go
+++ b/server.go
@@ -1501,20 +1501,28 @@ func newServer(cfg *Config, listenAddrs []net.Addr,
 // createLivenessMonitor creates a set of health checks using our configured
 // values and uses these checks to create a liveliness monitor. Available
 // health checks,
-//   - chainHealthCheck
+//   - chainHealthCheck (will be disabled for --nochainbackend mode)
 //   - diskCheck
 //   - tlsHealthCheck
 //   - torController, only created when tor is enabled.
 // If a health check has been disabled by setting attempts to 0, our monitor
 // will not run it.
 func (s *server) createLivenessMonitor(cfg *Config, cc *chainreg.ChainControl) {
+	chainBackendAttempts := cfg.HealthChecks.ChainCheck.Attempts
+	if cfg.Bitcoin.Node == "nochainbackend" {
+		srvrLog.Info("Disabling chain backend checks for " +
+			"nochainbackend mode")
+
+		chainBackendAttempts = 0
+	}
+
 	chainHealthCheck := healthcheck.NewObservation(
 		"chain backend",
 		cc.HealthCheck,
 		cfg.HealthChecks.ChainCheck.Interval,
 		cfg.HealthChecks.ChainCheck.Timeout,
 		cfg.HealthChecks.ChainCheck.Backoff,
-		cfg.HealthChecks.ChainCheck.Attempts,
+		chainBackendAttempts,
 	)
 
 	diskCheck := healthcheck.NewObservation(


### PR DESCRIPTION
We don't have a chain backend to check when we're just running a signer, so we disable the chain healthcheck. 
An alternative would be to have it off by default, but its a good check for regular nodes to have imo.