### PR TITLE
rpcperms: set CustomCaveatCondition on middleware req

### DIFF
--- a/docs/release-notes/release-notes-0.14.2.md
+++ b/docs/release-notes/release-notes-0.14.2.md
@@ -92,6 +92,10 @@ Postgres](https://github.com/lightningnetwork/lnd/pull/6111)
   exposed](https://github.com/lightningnetwork/lnd/pull/6146) inside
   WaitingCloseResp from calling `PendingChannels`.
 
+* [CustomCaveatCondition is now properly
+  set](https://github.com/lightningnetwork/lnd/pull/6185) on
+  `RPCMiddlewareRequest` messages.
+
 
 ## Routing
 
@@ -104,6 +108,7 @@ Postgres](https://github.com/lightningnetwork/lnd/pull/6111)
 
 * Andras Banki-Horvath
 * Bjarne Magnussen
+* Daniel McNally
 * Elle Mouton
 * Harsha Goli
 * Joost Jager

--- a/macaroons/constraints.go
+++ b/macaroons/constraints.go
@@ -216,3 +216,37 @@ func HasCustomCaveat(mac *macaroon.Macaroon, customCaveatName string) bool {
 
 	return false
 }
+
+// GetCustomCaveatCondition returns the custom caveat condition for the given
+// custom caveat name from the given macaroon.
+func GetCustomCaveatCondition(mac *macaroon.Macaroon,
+	customCaveatName string) string {
+
+	if mac == nil {
+		return ""
+	}
+
+	caveatPrefix := []byte(fmt.Sprintf(
+		"%s %s ", CondLndCustom, customCaveatName,
+	))
+	for _, caveat := range mac.Caveats() {
+
+		// The caveat id has a format of
+		// "lnd-custom [custom-caveat-name] [custom-caveat-condition]"
+		// and we only want the condition part. If we match the prefix
+		// part we return the condition that comes after the prefix.
+		if bytes.HasPrefix(caveat.Id, caveatPrefix) {
+			caveatSplit := strings.SplitN(
+				string(caveat.Id),
+				string(caveatPrefix),
+				2,
+			)
+			if len(caveatSplit) == 2 {
+				return caveatSplit[1]
+			}
+		}
+	}
+
+	// We didn't find a condition for the given custom caveat name.
+	return ""
+}

--- a/macaroons/constraints_test.go
+++ b/macaroons/constraints_test.go
@@ -132,6 +132,11 @@ func TestCustomConstraint(t *testing.T) {
 	require.False(t, macaroons.HasCustomCaveat(testMacaroon, "something"))
 	require.False(t, macaroons.HasCustomCaveat(nil, "foo"))
 
+	customCaveatCondition := macaroons.GetCustomCaveatCondition(
+		testMacaroon, "unit-test",
+	)
+	require.Equal(t, customCaveatCondition, "test-value")
+
 	// Custom caveats don't necessarily need a value, just the name is fine
 	// too to create a tagged macaroon.
 	constraintFunc = macaroons.CustomConstraint("unit-test", "")
@@ -144,4 +149,9 @@ func TestCustomConstraint(t *testing.T) {
 	require.True(t, macaroons.HasCustomCaveat(testMacaroon, "unit-test"))
 	require.False(t, macaroons.HasCustomCaveat(testMacaroon, "test-value"))
 	require.False(t, macaroons.HasCustomCaveat(testMacaroon, "something"))
+
+	customCaveatCondition = macaroons.GetCustomCaveatCondition(
+		testMacaroon, "unit-test",
+	)
+	require.Equal(t, customCaveatCondition, "")
 }

--- a/rpcperms/interceptor.go
+++ b/rpcperms/interceptor.go
@@ -910,7 +910,7 @@ func (r *InterceptorChain) middlewareRegistered() bool {
 
 // acceptRequest sends an intercept request to all middlewares that have
 // registered for it. This means either a middleware has requested read-only
-// access or the request actually has a macaroon which a caveat the middleware
+// access or the request actually has a macaroon with a caveat the middleware
 // registered for.
 func (r *InterceptorChain) acceptRequest(requestID uint64,
 	msg *InterceptionRequest) error {
@@ -928,6 +928,10 @@ func (r *InterceptorChain) acceptRequest(requestID uint64,
 		if !hasCustomCaveat && !middleware.readOnly {
 			continue
 		}
+
+		msg.CustomCaveatCondition = macaroons.GetCustomCaveatCondition(
+			msg.Macaroon, middleware.customCaveatName,
+		)
 
 		resp, err := middleware.intercept(requestID, msg)
 
@@ -974,6 +978,10 @@ func (r *InterceptorChain) interceptResponse(ctx context.Context,
 		if !hasCustomCaveat && !middleware.readOnly {
 			continue
 		}
+
+		msg.CustomCaveatCondition = macaroons.GetCustomCaveatCondition(
+			msg.Macaroon, middleware.customCaveatName,
+		)
 
 		resp, err := middleware.intercept(requestID, msg)
 


### PR DESCRIPTION
macaroons: add GetCustomCaveatCondition func 

This adds a `GetCustomCaveatCondition` function that returns the custom
caveat condition for a given macaroon and caveat name. Previously there
was no function for getting the custom caveat condition from a macaroon,
only for setting one.

rpcperms: set CustomCaveatCondition on middleware req 

This sets the `CustomCaveatCondition` value on rpc middleware requests
if one exists. Previously, this value was always blank even if the
macaroon had a value set for its custom caveat condition.

Fixes #6164.

Edit: I have tested this locally with a grpc interceptor service and verified that it fixed the related issue, the `custom_caveat_condition` field has a value as expected (and no value when none is set while baking the macaroon).