### PR TITLE
github: add timeout when zipping log files

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -321,6 +321,7 @@ jobs:
 
       - name: Zip log files on failure
         if: ${{ failure() }}
+        timeout-minutes: 1 # timeout after 1 minute
         run: 7z a logs-itest-${{ matrix.name }}.zip lntest/itest/**/*.log
 
       - name: Upload log files on failure


### PR DESCRIPTION
Zipping logs usually take a few seconds. This commit adds a step timeout in case anything goes wrong with `7z` which has caused the build to run for over 6 hours. 

`[skip ci]` is not used to see the build results, and it might be too trivial to add a release note...