### PR TITLE
itest: fix documentation for LookupNodeByPub [skip ci]

### DIFF
--- a/lntest/harness_net.go
+++ b/lntest/harness_net.go
@@ -117,8 +117,7 @@ func NewNetworkHarness(m *HarnessMiner, b BackendConfig, lndBinary string,
 }
 
 // LookUpNodeByPub queries the set of active nodes to locate a node according
-// to its public key. The second value will be true if the node was found, and
-// false otherwise.
+// to its public key. The error is returned if the node was not found.
 func (n *NetworkHarness) LookUpNodeByPub(pubStr string) (*HarnessNode, error) {
 	n.mtx.Lock()
 	defer n.mtx.Unlock()


### PR DESCRIPTION
The previous comment assumed use of boolean as a second return parameter, but it is an error instead.

#### Pull Request Checklist

- [x] All changes are Go version 1.16 compliant
- [ ] Your PR passes all CI checks. If a check cannot be passed for a justifiable reason, that reason must be stated in the commit message and PR description.
- [x] If this is your first time contributing, we recommend you read the [Code Contribution Guidelines](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md)
   - [x] The code being submitted is commented according to [Code Documentation and Commenting](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#CodeDocumentation)
   - [x] Commits have a logical structure according to [Ideal Git Commit Structure](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#IdealGitCommitStructure)
- [ ] For new code: Code is accompanied by tests which exercise both the positive and negative (error paths) conditions (if applicable)
- [ ] For bug fixes: If possible, code is accompanied by new tests which trigger the bug being fixed to prevent regressions
- [ ] Any new logging statements use an appropriate subsystem and logging level
- [x] For code and documentation: lines are wrapped at 80 characters (the tab character should be counted as 8 characters, not 4, as some IDEs do per default)
- [ ] A description of your changes [should be added to running the release notes](https://github.com/lightningnetwork/lnd/tree/master/docs/release-notes) for the milestone your change will land in, or,
- [x] If a PR only fixes a trivial issue, such as updating documentation on a small scale, fix typos, or any changes that do not modify the code, the commit message should end with [skip ci] to skip the CI checks.
