### PR TITLE
lntest/test: ensure nodes connected before disconnecting

### DIFF
--- a/lntest/itest/lnd_channel_policy_test.go
+++ b/lntest/itest/lnd_channel_policy_test.go
@@ -605,6 +605,10 @@ func testSendUpdateDisableChannel(net *lntest.NetworkHarness, t *harnessTest) {
 	expectedPolicy.Disabled = false
 	assertPolicyUpdate(eve, expectedPolicy, chanPointEveCarol)
 
+	// Wait until Carol and Eve are reconnected before we disconnect them
+	// again.
+	net.EnsureConnected(t.t, eve, carol)
+
 	// Now we'll test a long disconnection. Disconnect Carol and Eve and
 	// ensure they both detect each other as disabled. Their min backoffs
 	// are high enough to not interfere with disabling logic.


### PR DESCRIPTION
Ran into a flake [here](https://github.com/lightningnetwork/lnd/runs/4936505456?check_suite_focus=true), fix is to just make sure we're connected before we disconnect.
```
=== RUN   TestLightningNetworkDaemon/tranche01/37-of-92/neutrino/derive_shared_key
    test_harness.go:90: Failed: (send update disable channel): exited with error: 
        *errors.errorString unable to disconnect Carol from Eve: rpc error: code = Unknown desc = unable to disconnect peer: peer 03fc352c7aa5d0bfa5b49d74db1434e9b54fec3b6ee4d4c14a44a9fec9bf42f95a is not connected
        /home/runner/work/lnd/lnd/lntest/itest/lnd_channel_policy_test.go:612 (0xee2f1c)
        	testSendUpdateDisableChannel: t.Fatalf("unable to disconnect Carol from Eve: %v", err)
        /home/runner/work/lnd/lnd/lntest/itest/test_harness.go:114 (0xec153c)
        	(*harnessTest).RunTestCase: testCase.test(h.lndHarness, h)
        /home/runner/work/lnd/lnd/lntest/itest/lnd_test.go:245 (0xf4753a)
        	TestLightningNetworkDaemon.func4: ht.RunTestCase(testCase)
        /opt/hostedtoolcache/go/1.17.3/x64/src/testing/testing.go:1259 (0x50a162)
        	tRunner: fn(t)
        /opt/hostedtoolcache/go/1.17.3/x64/src/runtime/asm_amd64.s:1581 (0x468741)
        	goexit: BYTE	$0x90	// NOP
```