### PR TITLE
lntest: set --lnddir instead of --datadir

### DIFF
--- a/docs/release-notes/release-notes-0.15.0.md
+++ b/docs/release-notes/release-notes-0.15.0.md
@@ -73,6 +73,9 @@
 
 * [Refactored itest to better manage contexts inside integration tests](https://github.com/lightningnetwork/lnd/pull/5756).
 
+* [Fix itest not picking up local config file or creating directories in home
+  dir of the user](https://github.com/lightningnetwork/lnd/pull/6202).
+
 # Contributors (Alphabetical Order)
 
 * 3nprob

--- a/lntest/harness_node.go
+++ b/lntest/harness_node.go
@@ -222,10 +222,7 @@ func (cfg *BaseNodeConfig) GenArgs() []string {
 		fmt.Sprintf("--restcors=https://%v", cfg.RESTAddr()),
 		fmt.Sprintf("--listen=%v", cfg.P2PAddr()),
 		fmt.Sprintf("--externalip=%v", cfg.P2PAddr()),
-		fmt.Sprintf("--logdir=%v", cfg.LogDir),
-		fmt.Sprintf("--datadir=%v", cfg.DataDir),
-		fmt.Sprintf("--tlscertpath=%v", cfg.TLSCertPath),
-		fmt.Sprintf("--tlskeypath=%v", cfg.TLSKeyPath),
+		fmt.Sprintf("--lnddir=%v", cfg.BaseDir),
 		fmt.Sprintf("--adminmacaroonpath=%v", cfg.AdminMacPath),
 		fmt.Sprintf("--readonlymacaroonpath=%v", cfg.ReadMacPath),
 		fmt.Sprintf("--invoicemacaroonpath=%v", cfg.InvoiceMacPath),
@@ -408,9 +405,9 @@ func newNode(cfg *BaseNodeConfig) (*HarnessNode, error) {
 		}
 	}
 	cfg.DataDir = filepath.Join(cfg.BaseDir, "data")
-	cfg.LogDir = filepath.Join(cfg.BaseDir, "log")
-	cfg.TLSCertPath = filepath.Join(cfg.DataDir, "tls.cert")
-	cfg.TLSKeyPath = filepath.Join(cfg.DataDir, "tls.key")
+	cfg.LogDir = filepath.Join(cfg.BaseDir, "logs")
+	cfg.TLSCertPath = filepath.Join(cfg.BaseDir, "tls.cert")
+	cfg.TLSKeyPath = filepath.Join(cfg.BaseDir, "tls.key")
 
 	networkDir := filepath.Join(
 		cfg.DataDir, "chain", "bitcoin", cfg.NetParams.Name,


### PR DESCRIPTION
Fixes https://github.com/lightningnetwork/lnd/issues/6199.

If we only set the --datadir flag then lnd will create empty directories
(for letsencrypt and watchtower client) in the default user's home .lnd
directory and will also pick up a config file from there if one exists.
To instruct lnd to only act within the temp itest directory, we need to
use the --lnddir flag instead.
Using the --lnddir flag also overwrites the TLS cert/key path and the
log dir, so we don't need to explicitly set those anymore.
But we need to make sure the node's variables point to the correct
default files/directories.
