### PR TITLE
makefile: fail rpc-check after finding any changes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -280,7 +280,7 @@ rpc-format:
 rpc-check: rpc
 	@$(call print, "Verifying protos.")
 	cd ./lnrpc; ../scripts/check-rest-annotations.sh
-	if test -n "$$(git describe --dirty | grep dirty)"; then echo "Protos not properly formatted or not compiled with v3.4.0"; git status; git diff; exit 1; fi
+	if test -n "$$(git status --porcelain)"; then echo "Protos not properly formatted or not compiled with v3.4.0"; git status; git diff; exit 1; fi
 
 rpc-js-compile:
 	@$(call print, "Compiling JSON/WASM stubs.")

--- a/docs/release-notes/release-notes-0.15.0.md
+++ b/docs/release-notes/release-notes-0.15.0.md
@@ -83,6 +83,9 @@
   allows code external to lnd to call the function, where previously it would 
   require access to lnd's internals.
 
+* [rpc-check fails if it finds any changes](https://github.com/lightningnetwork/lnd/pull/6207/)
+  including new and deleted files.
+
 # Contributors (Alphabetical Order)
 
 * 3nprob
@@ -96,6 +99,7 @@
 * ErikEk
 * henta
 * Joost Jager
+* Jordi Montes
 * LightningHelper
 * Liviu
 * mateuszmp


### PR DESCRIPTION
`rpc-check` is used in our CI pipeline to detect any difference
between the committed and the automatically generated rpc files.
Unfortunately, the current method only detects changes in the
already existing files and won't fail if `make rpc` generates
a totally new file.

`git status --porcelain` makes the trick, it returns a line for
each file that has been modified, created or deleted.

How to test this: 
- Delete any `***.pb.gw.go` from a subserver in the `lnrpc` folder
- Commit the change and push to a new branch
- See the `rpc-check` pass in CI
- Rebase this branch (or apply the change in the Makefile)
- Commit the changes, push it and see the step fail