### PR TITLE
github: simplify PR template and add more sections

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,13 +1,19 @@
-#### Pull Request Checklist
+## Change Description
+Description of change / link to associated issue.
 
-- [ ] All changes are Go version 1.16 compliant
-- [ ] Your PR passes all CI checks. If a check cannot be passed for a justifiable reason, that reason must be stated in the commit message and PR description.
-- [ ] If this is your first time contributing, we recommend you read the [Code Contribution Guidelines](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md)
-   - [ ] The code being submitted is commented according to [Code Documentation and Commenting](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#CodeDocumentation)
-   - [ ] Commits have a logical structure according to [Ideal Git Commit Structure](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#IdealGitCommitStructure)
-- [ ] For new code: Code is accompanied by tests which exercise both the positive and negative (error paths) conditions (if applicable)
-- [ ] For bug fixes: If possible, code is accompanied by new tests which trigger the bug being fixed to prevent regressions
-- [ ] Any new logging statements use an appropriate subsystem and logging level
-- [ ] For code and documentation: lines are wrapped at 80 characters (the tab character should be counted as 8 characters, not 4, as some IDEs do per default)
-- [ ] A description of your changes [should be added to running the release notes](https://github.com/lightningnetwork/lnd/tree/master/docs/release-notes) for the milestone your change will land in, or,
-- [ ] If a PR only fixes a trivial issue, such as updating documentation on a small scale, fix typos, or any changes that do not modify the code, the commit message should end with [skip ci] to skip the CI checks.
+## Steps to Test
+Steps for reviewers to follow to test the change.
+
+## Pull Request Checklist
+### Testing
+- [ ] Your PR passes all CI checks.
+- [ ] Tests covering the positive and negative (error paths) are included.
+- [ ] Bug fixes contain tests triggering the bug to prevent regressions.
+
+### Code Style and Documentation
+- [ ] The change obeys the [Code Documentation and Commenting](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#CodeDocumentation) guidelines, and lines wrap at 80.
+- [ ] Commits follow the [Ideal Git Commit Structure](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#IdealGitCommitStructure).
+- [ ] Any new logging statements use an appropriate subsystem and logging level.
+- [ ]  [There is a change description in the release notes](https://github.com/lightningnetwork/lnd/tree/master/docs/release-notes), or `[skip ci]` in the commit message for small changes.
+
+📝 Please see our  [Contribution Guidelines](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md) for further guidance.

--- a/docs/code_contribution_guidelines.md
+++ b/docs/code_contribution_guidelines.md
@@ -687,28 +687,7 @@ default of 3 days to the given duration.
 
 ## Contribution Checklist
 
-- [&nbsp;&nbsp;] All changes are Go version 1.12 compliant
-- [&nbsp;&nbsp;] The code being submitted is commented according to
-  [Code Documentation and Commenting](#code-documentation-and-commenting)
-- [&nbsp;&nbsp;] For new code: Code is accompanied by tests which exercise both
-  the positive and negative (error paths) conditions (if applicable)
-- [&nbsp;&nbsp;] For bug fixes: Code is accompanied by new tests which trigger
-  the bug being fixed to prevent regressions
-- [&nbsp;&nbsp;] Any new logging statements use an appropriate subsystem and
-  logging level
-- [&nbsp;&nbsp;] Code has been formatted with `go fmt`
-- [&nbsp;&nbsp;] For code and documentation: lines are wrapped at 80 characters
-  (the tab character should be counted as 8 characters, not 4, as some IDEs do
-  per default)
-- [&nbsp;&nbsp;] Running `make check` does not fail any tests
-- [&nbsp;&nbsp;] Running `go vet` does not report any issues
-- [&nbsp;&nbsp;] Running `make lint` does not report any **new** issues that
-  did not already exist
-- [&nbsp;&nbsp;] All commits build properly and pass tests. Only in exceptional
-  cases it can be justifiable to violate this condition. In that case, the
-  reason should be stated in the commit message.
-- [&nbsp;&nbsp;] Commits have a logical structure according to
-  [Ideal Git Commit Structure](#ideal-git-commit-structure).
+See [template](https://github.com/lightningnetwork/lnd/blob/master/.github/pull_request_template.md).
 
 ## Licensing of Contributions
 ****


### PR DESCRIPTION
## Change Description
This PR contains a proposed change to our PR template (which has been copied in here): 
* Simplify wording on checklist so that its less to read. This makes it more likely that people will engage, with the tradeoff of being more descriptive.
* Add Description + Steps to Test sections

## Steps to Test
The template proposed has been copied into this PR as an example.

## Pull Request Checklist
### Testing
- [ ] Your PR passes all CI checks.
- [ ] Tests covering the positive and negative (error paths) are included.
- [ ] Bug fixes contain tests triggering the bug to prevent regressions.

### Code Style and Documentation
- [ ] The change obeys the [Code Documentation and Commenting](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#CodeDocumentation) guidelines, and lines wrap at 80.
- [ ] Commits follow the [Ideal Git Commit Structure](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#IdealGitCommitStructure).
- [ ] Any new logging statements use an appropriate subsystem and logging level.
- [ ]  [There is a change description in the release notes](https://github.com/lightningnetwork/lnd/tree/master/docs/release-notes), or `[skip ci]` in the commit message for small changes.

📝 Please see our  [Contribution Guidelines](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md) for further guidance.