### PR TITLE
htlcswitch: interceptor expiry check

### DIFF
--- a/docs/release-notes/release-notes-0.15.0.md
+++ b/docs/release-notes/release-notes-0.15.0.md
@@ -180,6 +180,9 @@ then watch it on chain. Taproot script spends are also supported through the
 
 * [Add new Peers subserver](https://github.com/lightningnetwork/lnd/pull/5587) with a new endpoint for updating the `NodeAnnouncement` data without having to restart the node.
 
+* Add [htlc expiry protection](https://github.com/lightningnetwork/lnd/pull/6212)
+to the htlc interceptor API.
+
 ## Documentation
 
 * Improved instructions on [how to build lnd for mobile](https://github.com/lightningnetwork/lnd/pull/6085).

--- a/htlcswitch/mock.go
+++ b/htlcswitch/mock.go
@@ -185,7 +185,7 @@ func initSwitchWithDB(startingHeight uint32, db *channeldb.DB) (*Switch, error) 
 			events: make(map[time.Time]channeldb.ForwardingEvent),
 		},
 		FetchLastChannelUpdate: func(lnwire.ShortChannelID) (*lnwire.ChannelUpdate, error) {
-			return nil, nil
+			return &lnwire.ChannelUpdate{}, nil
 		},
 		Notifier: &mock.ChainNotifier{
 			SpendChan: make(chan *chainntnfs.SpendDetail),

--- a/htlcswitch/mock.go
+++ b/htlcswitch/mock.go
@@ -690,9 +690,11 @@ func (f *mockChannelLink) completeCircuit(pkt *htlcPacket) error {
 		f.htlcID++
 
 	case *lnwire.UpdateFulfillHTLC, *lnwire.UpdateFailHTLC:
-		err := f.htlcSwitch.teardownCircuit(pkt)
-		if err != nil {
-			return err
+		if pkt.circuit != nil {
+			err := f.htlcSwitch.teardownCircuit(pkt)
+			if err != nil {
+				return err
+			}
 		}
 	}
 

--- a/peer/test_utils.go
+++ b/peer/test_utils.go
@@ -38,6 +38,10 @@ const (
 	// timeout is a timeout value to use for tests which need to wait for
 	// a return value on a channel.
 	timeout = time.Second * 5
+
+	// testCltvRejectDelta is the minimum delta between expiry and current
+	// height below which htlcs are rejected.
+	testCltvRejectDelta = 13
 )
 
 var (
@@ -368,7 +372,7 @@ func createTestPeer(notifier chainntnfs.ChainNotifier,
 
 		ChanActiveTimeout: chanActiveTimeout,
 		InterceptSwitch: htlcswitch.NewInterceptableSwitch(
-			nil, false,
+			nil, testCltvRejectDelta, false,
 		),
 
 		ChannelDB:      dbAlice.ChannelStateDB(),

--- a/server.go
+++ b/server.go
@@ -655,7 +655,8 @@ func newServer(cfg *Config, listenAddrs []net.Addr,
 		return nil, err
 	}
 	s.interceptableSwitch = htlcswitch.NewInterceptableSwitch(
-		s.htlcSwitch, s.cfg.RequireInterceptor,
+		s.htlcSwitch, lncfg.DefaultFinalCltvRejectDelta,
+		s.cfg.RequireInterceptor,
 	)
 
 	chanStatusMgrCfg := &netann.ChanStatusConfig{


### PR DESCRIPTION
Adds a basic protection to make sure that we aren't letting the interceptor handle htlcs that are too close to the channel force-close broadcast height.