### PR TITLE
Set correct sweep transaction ID on 1st Stage Incoming HTLC resolutions

### DIFF
--- a/contractcourt/htlc_success_resolver.go
+++ b/contractcourt/htlc_success_resolver.go
@@ -188,7 +188,7 @@ func (h *htlcSuccessResolver) broadcastSuccessTx() (*wire.OutPoint, error) {
 	//
 	// TODO(roasbeef): after changing sighashes send to tx bundler
 	label := labels.MakeLabel(
-		labels.LabelTypeChannelClose, &h.ShortChanID,
+		labels.LabelTypeSweepTransaction, nil,
 	)
 	err := h.PublishTx(h.htlcResolution.SignedSuccessTx, label)
 	if err != nil {
@@ -416,7 +416,7 @@ func (h *htlcSuccessResolver) resolveRemoteCommitOutput() (
 	// Regardless of whether an existing transaction was found or newly
 	// constructed, we'll broadcast the sweep transaction to the network.
 	label := labels.MakeLabel(
-		labels.LabelTypeChannelClose, &h.ShortChanID,
+		labels.LabelTypeSweepTransaction, nil,
 	)
 	err := h.PublishTx(h.sweepTx, label)
 	if err != nil {


### PR DESCRIPTION
## Change Description
Currently the sweep transaction id shown as resolutions for 1st stage _incoming_ HTLCs in force closed channel summaries is wrong. The reason is that due to the sweeper it is not possible upfront to know the transaction ID as the actual selected inputs are unknown and hence the report should be updated accordingly.

This PR uses the correct sweep transaction ID from the information provided by `htlcResolution.ClaimOutpoint` and when the second-level HTLC is swept makes sure that this value is "retrospectively" updated accordingly. Furthermore, for the reporting the outpoint being consumed is also set accordingly.

Note: A bit unrelated to this issue I also have added a commit that corrects the label produced for the sweep transaction that claims the incoming HTLC, as it was producing the `closechannel` label instead of the `sweep` label.

## Steps to Test
This issue only arises on 1st stage _incoming_ HTLC resolutions.

To reproduce the issue with two nodes, A and B:
* Let A open a channel with B, e.g. `A$ lncli openchannel <pubKeyB> 500000`. 
* Let B create a hold-invoice, e.g. `B$ lncli addholdinvoice 34affc1885f5a94b9d0b7c4c000d665d62a98ee3ccda1a5aa2207bdc3cf3b75e --amt 50000`.
* Let A pay the invoice, e.g. `A$ lncli payinvoice <invoice>`. This creates the inflight HTLC that can be verified with `A$ lncli listchannels`.
* Now let B force close the channel, e.g. `B$ lncli closechannel <txid> <txindex> --force`.
* Then also settle the invoice on B, e.g. `B$ settleinvoice ed969942912154795f3d99d4928fad57a75a5a616c7f363527eca9c580c77d9f`.
* Now mine blocks accordingly as e.g. shown in the response of `B$ lncli pendingchannels` for B to create the resolutions. 
* After the channel has been completely closed the sweep transaction ID shown for B via `B$ lncli closedchannels` will be wrong for the 1st stage incoming HTLC resolution.