### PR TITLE
devrpc: remove lncli API docs tag [skip ci]

### DIFF
--- a/lnrpc/devrpc/dev.proto
+++ b/lnrpc/devrpc/dev.proto
@@ -7,7 +7,7 @@ package devrpc;
 option go_package = "github.com/lightningnetwork/lnd/lnrpc/devrpc";
 
 service Dev {
-    /* lncli: `importgraph`
+    /*
     ImportGraph imports a ChannelGraph into the graph database. Should only be
     used for development.
     */

--- a/lnrpc/devrpc/dev.swagger.json
+++ b/lnrpc/devrpc/dev.swagger.json
@@ -18,7 +18,7 @@
   "paths": {
     "/v2/dev/importgraph": {
       "post": {
-        "summary": "lncli: `importgraph`\nImportGraph imports a ChannelGraph into the graph database. Should only be\nused for development.",
+        "summary": "ImportGraph imports a ChannelGraph into the graph database. Should only be\nused for development.",
         "operationId": "Dev_ImportGraph",
         "responses": {
           "200": {

--- a/lnrpc/devrpc/dev_grpc.pb.go
+++ b/lnrpc/devrpc/dev_grpc.pb.go
@@ -19,7 +19,7 @@ const _ = grpc.SupportPackageIsVersion7
 //
 // For semantics around ctx use and closing/ending streaming RPCs, please refer to https://pkg.go.dev/google.golang.org/grpc/?tab=doc#ClientConn.NewStream.
 type DevClient interface {
-	// lncli: `importgraph`
+	//
 	//ImportGraph imports a ChannelGraph into the graph database. Should only be
 	//used for development.
 	ImportGraph(ctx context.Context, in *lnrpc.ChannelGraph, opts ...grpc.CallOption) (*ImportGraphResponse, error)
@@ -46,7 +46,7 @@ func (c *devClient) ImportGraph(ctx context.Context, in *lnrpc.ChannelGraph, opt
 // All implementations must embed UnimplementedDevServer
 // for forward compatibility
 type DevServer interface {
-	// lncli: `importgraph`
+	//
 	//ImportGraph imports a ChannelGraph into the graph database. Should only be
 	//used for development.
 	ImportGraph(context.Context, *lnrpc.ChannelGraph) (*ImportGraphResponse, error)


### PR DESCRIPTION
## Change Description

The API doc generator failed after merging #6149 because of the `lncli
importgraph` tag in the proto file.
We could also fix the API doc generator by adding the "dev" build tag,
but not including any dev only features in the API docs is probably the
preferred path.

## Steps to Test
None
