### PR TITLE
contractcourt: onchain htlc interceptor

### DIFF
--- a/contractcourt/channel_arbitrator.go
+++ b/contractcourt/channel_arbitrator.go
@@ -14,6 +14,7 @@ import (
 	"github.com/btcsuite/btcd/wire"
 	"github.com/davecgh/go-spew/spew"
 	"github.com/lightningnetwork/lnd/channeldb"
+	"github.com/lightningnetwork/lnd/htlcswitch/hop"
 	"github.com/lightningnetwork/lnd/input"
 	"github.com/lightningnetwork/lnd/kvdb"
 	"github.com/lightningnetwork/lnd/labels"
@@ -75,7 +76,9 @@ type WitnessSubscription struct {
 type WitnessBeacon interface {
 	// SubscribeUpdates returns a channel that will be sent upon *each* time
 	// a new preimage is discovered.
-	SubscribeUpdates() *WitnessSubscription
+	SubscribeUpdates(chanID lnwire.ShortChannelID, htlc *channeldb.HTLC,
+		payload *hop.Payload,
+		nextHopOnionBlob []byte) (*WitnessSubscription, error)
 
 	// LookupPreImage attempts to lookup a preimage in the global cache.
 	// True is returned for the second argument if the preimage is found.

--- a/contractcourt/htlc_incoming_resolver_test.go
+++ b/contractcourt/htlc_incoming_resolver_test.go
@@ -276,6 +276,10 @@ func (h *mockHopIterator) HopPayload() (*hop.Payload, error) {
 	}), nil
 }
 
+func (h *mockHopIterator) EncodeNextHop(w io.Writer) error {
+	return nil
+}
+
 type mockOnionProcessor struct {
 	isExit           bool
 	offeredOnionBlob []byte

--- a/contractcourt/htlc_timeout_resolver_test.go
+++ b/contractcourt/htlc_timeout_resolver_test.go
@@ -14,11 +14,13 @@ import (
 	"github.com/btcsuite/btcd/wire"
 	"github.com/lightningnetwork/lnd/chainntnfs"
 	"github.com/lightningnetwork/lnd/channeldb"
+	"github.com/lightningnetwork/lnd/htlcswitch/hop"
 	"github.com/lightningnetwork/lnd/input"
 	"github.com/lightningnetwork/lnd/kvdb"
 	"github.com/lightningnetwork/lnd/lntest/mock"
 	"github.com/lightningnetwork/lnd/lntypes"
 	"github.com/lightningnetwork/lnd/lnwallet"
+	"github.com/lightningnetwork/lnd/lnwire"
 	"github.com/stretchr/testify/require"
 )
 
@@ -36,11 +38,15 @@ func newMockWitnessBeacon() *mockWitnessBeacon {
 	}
 }
 
-func (m *mockWitnessBeacon) SubscribeUpdates() *WitnessSubscription {
+func (m *mockWitnessBeacon) SubscribeUpdates(
+	chanID lnwire.ShortChannelID, htlc *channeldb.HTLC,
+	payload *hop.Payload,
+	nextHopOnionBlob []byte) (*WitnessSubscription, error) {
+
 	return &WitnessSubscription{
 		WitnessUpdates:     m.preImageUpdates,
 		CancelSubscription: func() {},
-	}
+	}, nil
 }
 
 func (m *mockWitnessBeacon) LookupPreimage(payhash lntypes.Hash) (lntypes.Preimage, bool) {

--- a/docs/release-notes/release-notes-0.15.0.md
+++ b/docs/release-notes/release-notes-0.15.0.md
@@ -178,6 +178,9 @@ then watch it on chain. Taproot script spends are also supported through the
 
 * [Support for making routes with the legacy onion payload format via `SendToRoute` has been removed.](https://github.com/lightningnetwork/lnd/pull/6385)
 
+* Close a gap in the HTLC interceptor API by [intercepting htlcs in the on-chain
+  resolution flow](https://github.com/lightningnetwork/lnd/pull/6219) too.
+
 ## Database
 
 * [Add ForAll implementation for etcd to speed up

--- a/htlcswitch/mock.go
+++ b/htlcswitch/mock.go
@@ -65,8 +65,12 @@ func (m *mockPreimageCache) AddPreimages(preimages ...lntypes.Preimage) error {
 	return nil
 }
 
-func (m *mockPreimageCache) SubscribeUpdates() *contractcourt.WitnessSubscription {
-	return nil
+func (m *mockPreimageCache) SubscribeUpdates(
+	chanID lnwire.ShortChannelID, htlc *channeldb.HTLC,
+	payload *hop.Payload,
+	nextHopOnionBlob []byte) (*contractcourt.WitnessSubscription, error) {
+
+	return nil, nil
 }
 
 type mockFeeEstimator struct {

--- a/intercepted_forward.go
+++ b/intercepted_forward.go
@@ -1,0 +1,80 @@
+package lnd
+
+import (
+	"errors"
+
+	"github.com/lightningnetwork/lnd/htlcswitch"
+	"github.com/lightningnetwork/lnd/lntypes"
+	"github.com/lightningnetwork/lnd/lnwire"
+)
+
+var (
+	// ErrCannotResume is returned when an intercepted forward cannot be
+	// resumed. This is the case in the on-chain resolution flow.
+	ErrCannotResume = errors.New("cannot resume in the on-chain flow")
+
+	// ErrCannotFail is returned when an intercepted forward cannot be failed.
+	// This is the case in the on-chain resolution flow.
+	ErrCannotFail = errors.New("cannot fail in the on-chain flow")
+
+	// ErrPreimageMismatch is returned when the preimage that is specified to
+	// settle an htlc doesn't match the htlc hash.
+	ErrPreimageMismatch = errors.New("preimage does not match hash")
+)
+
+// interceptedForward implements the on-chain behavior for the resolution of
+// a forwarded htlc.
+type interceptedForward struct {
+	packet *htlcswitch.InterceptedPacket
+	beacon *preimageBeacon
+}
+
+func newInterceptedForward(
+	packet *htlcswitch.InterceptedPacket,
+	beacon *preimageBeacon) *interceptedForward {
+
+	return &interceptedForward{
+		beacon: beacon,
+		packet: packet,
+	}
+}
+
+// Packet returns the intercepted htlc packet.
+func (f *interceptedForward) Packet() htlcswitch.InterceptedPacket {
+	return *f.packet
+}
+
+// Resume notifies the intention to resume an existing hold forward. This
+// basically means the caller wants to resume with the default behavior for this
+// htlc which usually means forward it.
+func (f *interceptedForward) Resume() error {
+	return ErrCannotResume
+}
+
+// Fail notifies the intention to fail an existing hold forward with an
+// encrypted failure reason.
+func (f *interceptedForward) Fail(_ []byte) error {
+	// We can't actively fail an htlc. The best we could do is abandon the
+	// resolver, but this wouldn't be a safe operation. There may be a race
+	// with the preimage beacon supplying a preimage. Therefore we don't
+	// attempt to fail and just return an error here.
+	return ErrCannotFail
+}
+
+// FailWithCode notifies the intention to fail an existing hold forward with the
+// specified failure code.
+func (f *interceptedForward) FailWithCode(_ lnwire.FailCode) error {
+	return ErrCannotFail
+}
+
+// Settle notifies the intention to settle an existing hold forward with a given
+// preimage.
+func (f *interceptedForward) Settle(preimage lntypes.Preimage) error {
+	if !preimage.Matches(f.packet.Hash) {
+		return ErrPreimageMismatch
+	}
+
+	// Add preimage to the preimage beacon. The onchain resolver will pick
+	// up the preimage from the beacon.
+	return f.beacon.AddPreimages(preimage)
+}

--- a/server.go
+++ b/server.go
@@ -595,10 +595,7 @@ func newServer(cfg *Config, listenAddrs []net.Addr,
 		quit:       make(chan struct{}),
 	}
 
-	s.witnessBeacon = &preimageBeacon{
-		wCache:      dbs.ChanStateDB.NewWitnessCache(),
-		subscribers: make(map[uint64]*preimageSubscriber),
-	}
+	s.witnessBeacon = newPreimageBeacon(dbs.ChanStateDB.NewWitnessCache())
 
 	currentHash, currentHeight, err := s.cc.ChainIO.GetBestBlock()
 	if err != nil {

--- a/server.go
+++ b/server.go
@@ -595,8 +595,6 @@ func newServer(cfg *Config, listenAddrs []net.Addr,
 		quit:       make(chan struct{}),
 	}
 
-	s.witnessBeacon = newPreimageBeacon(dbs.ChanStateDB.NewWitnessCache())
-
 	currentHash, currentHeight, err := s.cc.ChainIO.GetBestBlock()
 	if err != nil {
 		return nil, err
@@ -654,6 +652,11 @@ func newServer(cfg *Config, listenAddrs []net.Addr,
 	s.interceptableSwitch = htlcswitch.NewInterceptableSwitch(
 		s.htlcSwitch, lncfg.DefaultFinalCltvRejectDelta,
 		s.cfg.RequireInterceptor,
+	)
+
+	s.witnessBeacon = newPreimageBeacon(
+		dbs.ChanStateDB.NewWitnessCache(),
+		s.interceptableSwitch.ForwardPacket,
 	)
 
 	chanStatusMgrCfg := &netann.ChanStatusConfig{

--- a/witness_beacon.go
+++ b/witness_beacon.go
@@ -28,6 +28,13 @@ type preimageBeacon struct {
 	subscribers   map[uint64]*preimageSubscriber
 }
 
+func newPreimageBeacon(wCache *channeldb.WitnessCache) *preimageBeacon {
+	return &preimageBeacon{
+		wCache:      wCache,
+		subscribers: make(map[uint64]*preimageSubscriber),
+	}
+}
+
 // SubscribeUpdates returns a channel that will be sent upon *each* time a new
 // preimage is discovered.
 func (p *preimageBeacon) SubscribeUpdates() *contractcourt.WitnessSubscription {

--- a/witness_beacon_test.go
+++ b/witness_beacon_test.go
@@ -1,0 +1,57 @@
+package lnd
+
+import (
+	"testing"
+
+	"github.com/lightningnetwork/lnd/channeldb"
+	"github.com/lightningnetwork/lnd/htlcswitch"
+	"github.com/lightningnetwork/lnd/htlcswitch/hop"
+	"github.com/lightningnetwork/lnd/lntypes"
+	"github.com/lightningnetwork/lnd/lnwire"
+	"github.com/stretchr/testify/require"
+)
+
+// TestWitnessBeaconIntercept tests that the beacon passes on subscriptions to
+// the interceptor correctly.
+func TestWitnessBeaconIntercept(t *testing.T) {
+	var interceptedFwd htlcswitch.InterceptedForward
+	interceptor := func(fwd htlcswitch.InterceptedForward) error {
+		interceptedFwd = fwd
+
+		return nil
+	}
+
+	p := newPreimageBeacon(
+		&mockWitnessCache{}, interceptor,
+	)
+
+	preimage := lntypes.Preimage{1, 2, 3}
+	hash := preimage.Hash()
+
+	subscription, err := p.SubscribeUpdates(
+		lnwire.NewShortChanIDFromInt(1),
+		&channeldb.HTLC{
+			RHash: hash,
+		},
+		&hop.Payload{},
+		[]byte{2},
+	)
+	require.NoError(t, err)
+
+	defer subscription.CancelSubscription()
+
+	require.NoError(t, interceptedFwd.Settle(preimage))
+
+	update := <-subscription.WitnessUpdates
+	require.Equal(t, preimage, update)
+}
+
+type mockWitnessCache struct {
+	witnessCache
+}
+
+func (w *mockWitnessCache) AddSha256Witnesses(
+	preimages ...lntypes.Preimage) error {
+
+	return nil
+}


### PR DESCRIPTION
Adds interception functionality for the onchain resolution flow.

Fixes #6040 