### PR TITLE
config: clamp channel-commit-interval to reasonable time

### DIFF
--- a/config.go
+++ b/config.go
@@ -172,6 +172,10 @@ const (
 	// channel state update and signing a new commitment.
 	defaultChannelCommitInterval = 50 * time.Millisecond
 
+	// maxChannelCommitInterval is the maximum time the commit interval can
+	// be configured to.
+	maxChannelCommitInterval = time.Hour
+
 	// defaultChannelCommitBatchSize is the default maximum number of
 	// channel state updates that is accumulated before signing a new
 	// commitment.
@@ -1560,6 +1564,14 @@ func ValidateConfig(cfg Config, interceptor signal.Interceptor, fileParser,
 		return nil, mkErr("default-remote-max-htlcs (%v) must be "+
 			"less than %v", cfg.DefaultRemoteMaxHtlcs,
 			maxRemoteHtlcs)
+	}
+
+	// Clamp the ChannelCommitInterval so that commitment updates can still
+	// happen in a reasonable timeframe.
+	if cfg.ChannelCommitInterval > maxChannelCommitInterval {
+		return nil, mkErr("channel-commit-interval (%v) must be less "+
+			"than %v", cfg.ChannelCommitInterval,
+			maxChannelCommitInterval)
 	}
 
 	if err := cfg.Gossip.Parse(); err != nil {

--- a/docs/release-notes/release-notes-0.15.0.md
+++ b/docs/release-notes/release-notes-0.15.0.md
@@ -117,6 +117,8 @@ gRPC performance metrics (latency to process `GetInfo`, etc)](https://github.com
   was enabled to make sure multi-line `if` conditions and function/method
   declarations are followed by an empty line to improve readability.
 
+* [The channel-commit-interval is now clamped to a reasonable timeframe of 1h.](https://github.com/lightningnetwork/lnd/pull/6220)
+
 # Contributors (Alphabetical Order)
 
 * 3nprob
@@ -128,6 +130,7 @@ gRPC performance metrics (latency to process `GetInfo`, etc)](https://github.com
 * Dan Bolser
 * Daniel McNally
 * ErikEk
+* Eugene Siegel
 * henta
 * Joost Jager
 * Jordi Montes

--- a/sample-lnd.conf
+++ b/sample-lnd.conf
@@ -293,8 +293,9 @@
 
 ; The maximum time that is allowed to pass between receiving a channel state
 ; update and signing the next commitment. Setting this to a longer duration
-; allows for more efficient channel operations at the cost of latency.
-; channel-commit-interval=50ms
+; allows for more efficient channel operations at the cost of latency. This is
+; capped at 1 hour. The default is 50 milliseconds.
+; channel-commit-interval=1h
 
 ; The maximum number of channel state updates that is accumulated before signing
 ; a new commitment.


### PR DESCRIPTION
Minor change that clamps `channel-commit-interval` to a max of 1h. Probably other config options should have sensible clamps, but I decided to only do this one for now.