### PR TITLE
multi: reliable hand-off from htlcswitch to contractcourt

### DIFF
--- a/contractcourt/chain_arbitrator.go
+++ b/contractcourt/chain_arbitrator.go
@@ -964,16 +964,9 @@ type ContractUpdate struct {
 	Htlcs []channeldb.HTLC
 }
 
-// ContractSignals wraps the two signals that affect the state of a channel
-// being watched by an arbitrator. The two signals we care about are: the
-// channel has a new set of HTLC's, and the remote party has just broadcast
-// their version of the commitment transaction.
+// ContractSignals is used by outside subsystems to notify a channel arbitrator
+// of its ShortChannelID.
 type ContractSignals struct {
-	// HtlcUpdates is a channel that the link will use to update the
-	// designated channel arbitrator when the set of HTLCs on any valid
-	// commitment changes.
-	HtlcUpdates chan *ContractUpdate
-
 	// ShortChanID is the up to date short channel ID for a contract. This
 	// can change either if when the contract was added it didn't yet have
 	// a stable identifier, or in the case of a reorg.
@@ -999,6 +992,25 @@ func (c *ChainArbitrator) UpdateContractSignals(chanPoint wire.OutPoint,
 	arbitrator.UpdateContractSignals(signals)
 
 	return nil
+}
+
+// NotifyContractUpdate lets a channel arbitrator know that a new
+// ContractUpdate is available. This calls the ChannelArbitrator's internal
+// method NotifyContractUpdate which waits for a response on a done chan before
+// returning. This method will return an error if the ChannelArbitrator is not
+// in the activeChannels map. However, this only happens if the arbitrator is
+// resolved and the related link would already be shut down.
+func (c *ChainArbitrator) NotifyContractUpdate(chanPoint wire.OutPoint,
+	update *ContractUpdate) error {
+
+	c.Lock()
+	arbitrator, ok := c.activeChannels[chanPoint]
+	c.Unlock()
+	if !ok {
+		return fmt.Errorf("can't find arbitrator for %v", chanPoint)
+	}
+
+	return arbitrator.notifyContractUpdate(update)
 }
 
 // GetChannelArbitrator safely returns the channel arbitrator for a given

--- a/contractcourt/channel_arbitrator.go
+++ b/contractcourt/channel_arbitrator.go
@@ -28,6 +28,12 @@ var (
 	// close a channel that's already in the process of doing so.
 	errAlreadyForceClosed = errors.New("channel is already in the " +
 		"process of being force closed")
+
+	// errChanArbShuttingDown is an error returned when the channel arb is
+	// shutting down during the hand-off in notifyContractUpdate. This is
+	// mainly used to be able to notify the original caller (the link) that
+	// an error occurred.
+	errChanArbShuttingDown = errors.New("channel arb shutting down")
 )
 
 const (
@@ -342,7 +348,7 @@ type ChannelArbitrator struct {
 	// htlcUpdates is a channel that is sent upon with new updates from the
 	// active channel. Each time a new commitment state is accepted, the
 	// set of HTLC's on the new state should be sent across this channel.
-	htlcUpdates <-chan *ContractUpdate
+	htlcUpdates chan *contractUpdateSignal
 
 	// activeResolvers is a slice of any active resolvers. This is used to
 	// be able to signal them for shutdown in the case that we shutdown.
@@ -378,7 +384,7 @@ func NewChannelArbitrator(cfg ChannelArbitratorConfig,
 		log:              log,
 		blocks:           make(chan int32, arbitratorBlockBufferSize),
 		signalUpdates:    make(chan *signalUpdateMsg),
-		htlcUpdates:      make(<-chan *ContractUpdate),
+		htlcUpdates:      make(chan *contractUpdateSignal),
 		resolutionSignal: make(chan struct{}),
 		forceCloseReqs:   make(chan *forceCloseReq),
 		activeHTLCs:      htlcSets,
@@ -2387,6 +2393,41 @@ func (c *ChannelArbitrator) UpdateContractSignals(newSignals *ContractSignals) {
 	}
 }
 
+// contractUpdateSignal is a struct that carries the latest set of
+// ContractUpdate for a particular key. It also carries a done chan that should
+// be closed by the recipient.
+type contractUpdateSignal struct {
+	// newUpdate contains the latest ContractUpdate for a key.
+	newUpdate *ContractUpdate
+
+	// doneChan is an acknowledgement channel.
+	doneChan chan struct{}
+}
+
+// notifyContractUpdate notifies the ChannelArbitrator that a new
+// ContractUpdate is available from the link. The link will be paused until
+// this function returns.
+func (c *ChannelArbitrator) notifyContractUpdate(upd *ContractUpdate) error {
+	done := make(chan struct{})
+
+	select {
+	case c.htlcUpdates <- &contractUpdateSignal{
+		newUpdate: upd,
+		doneChan:  done,
+	}:
+	case <-c.quit:
+		return errChanArbShuttingDown
+	}
+
+	select {
+	case <-done:
+	case <-c.quit:
+		return errChanArbShuttingDown
+	}
+
+	return nil
+}
+
 // channelAttendant is the primary goroutine that acts at the judicial
 // arbitrator between our channel state, the remote channel peer, and the
 // blockchain (Our judge). This goroutine will ensure that we faithfully execute
@@ -2448,13 +2489,12 @@ func (c *ChannelArbitrator) channelAttendant(bestHeight int32) {
 			log.Tracef("ChannelArbitrator(%v) got new signal "+
 				"update!", c.cfg.ChanPoint)
 
-			// First, we'll update our set of signals.
-			c.htlcUpdates = signalUpdate.newSignals.HtlcUpdates
+			// We'll update the ShortChannelID.
 			c.cfg.ShortChanID = signalUpdate.newSignals.ShortChanID
 
-			// Now that the signals have been updated, we'll now
+			// Now that the signal has been updated, we'll now
 			// close the done channel to signal to the caller we've
-			// registered the new contracts.
+			// registered the new ShortChannelID.
 			close(signalUpdate.doneChan)
 
 		// A new set of HTLC's has been added or removed from the
@@ -2465,14 +2505,19 @@ func (c *ChannelArbitrator) channelAttendant(bestHeight int32) {
 			// htlcSetKey type included in this update in order to
 			// only monitor the HTLCs that are still active on this
 			// target commitment.
-			c.activeHTLCs[htlcUpdate.HtlcKey] = newHtlcSet(
-				htlcUpdate.Htlcs,
+			htlcKey := htlcUpdate.newUpdate.HtlcKey
+			c.activeHTLCs[htlcKey] = newHtlcSet(
+				htlcUpdate.newUpdate.Htlcs,
 			)
+
+			// Now that the activeHTLCs have been updated, we'll
+			// close the done channel.
+			close(htlcUpdate.doneChan)
 
 			log.Tracef("ChannelArbitrator(%v): fresh set of htlcs=%v",
 				c.cfg.ChanPoint,
 				newLogClosure(func() string {
-					return spew.Sdump(htlcUpdate)
+					return spew.Sdump(htlcUpdate.newUpdate)
 				}),
 			)
 

--- a/docs/release-notes/release-notes-0.15.0.md
+++ b/docs/release-notes/release-notes-0.15.0.md
@@ -116,6 +116,11 @@ gRPC performance metrics (latency to process `GetInfo`, etc)](https://github.com
 * The [`whitespace` linter](https://github.com/lightningnetwork/lnd/pull/6270)
   was enabled to make sure multi-line `if` conditions and function/method
   declarations are followed by an empty line to improve readability.
+  **Note to developers**: please make sure you delete the old version of
+  `golangci-lint` in your `$GOPATH/bin` directory. `make lint` does not
+  automatically replace it with the new version if the binary already exists!
+  
+* [`ChannelLink` in the `htlcswitch` now performs a 2-way handoff instead of a 1-way handoff with its `ChannelArbitrator`.](https://github.com/lightningnetwork/lnd/pull/6221)
 
 # Contributors (Alphabetical Order)
 
@@ -128,6 +133,7 @@ gRPC performance metrics (latency to process `GetInfo`, etc)](https://github.com
 * Dan Bolser
 * Daniel McNally
 * ErikEk
+* Eugene Siegel
 * henta
 * Joost Jager
 * Jordi Montes

--- a/peer/brontide.go
+++ b/peer/brontide.go
@@ -815,6 +815,10 @@ func (p *Brontide) addLink(chanPoint *wire.OutPoint,
 		return p.cfg.ChainArb.UpdateContractSignals(*chanPoint, signals)
 	}
 
+	notifyContractUpdate := func(update *contractcourt.ContractUpdate) error {
+		return p.cfg.ChainArb.NotifyContractUpdate(*chanPoint, update)
+	}
+
 	chanType := lnChan.State().ChanType
 
 	// Select the appropriate tower client based on the channel type. It's
@@ -842,6 +846,7 @@ func (p *Brontide) addLink(chanPoint *wire.OutPoint,
 		PreimageCache:           p.cfg.WitnessBeacon,
 		ChainEvents:             chainEvents,
 		UpdateContractSignals:   updateContractSignals,
+		NotifyContractUpdate:    notifyContractUpdate,
 		OnChannelFailure:        onChannelFailure,
 		SyncStates:              syncStates,
 		BatchTicker:             ticker.New(p.cfg.ChannelCommitInterval),


### PR DESCRIPTION
This is achieved by changing the 1-way handoff to a 2-way handoff with a done channel. This is a more ideal pattern for subsystem handoff than the existing way and is ideally how all of our existing 1-way handoffs should be. This is done, for example, in the breacharbiter & chain_watcher handoff.