### PR TITLE
Fix default value for fee limit

### DIFF
--- a/cmd/lncli/cmd_payments.go
+++ b/cmd/lncli/cmd_payments.go
@@ -22,6 +22,7 @@ import (
 	"github.com/lightningnetwork/lnd/lnrpc"
 	"github.com/lightningnetwork/lnd/lnrpc/routerrpc"
 	"github.com/lightningnetwork/lnd/lntypes"
+	"github.com/lightningnetwork/lnd/lnwallet"
 	"github.com/lightningnetwork/lnd/lnwire"
 	"github.com/lightningnetwork/lnd/record"
 	"github.com/lightningnetwork/lnd/routing/route"
@@ -217,8 +218,10 @@ func retrieveFeeLimit(ctx *cli.Context, amt int64) (int64, error) {
 		return feeLimitRoundedUp, nil
 	}
 
-	// If no fee limit is set, use the payment amount as a limit (100%).
-	return amt, nil
+	// If no fee limit is set, use a default value based on the amount.
+	amtMsat := lnwire.NewMSatFromSatoshis(btcutil.Amount(amt))
+	limitMsat := lnwallet.DefaultRoutingFeeLimitForAmount(amtMsat)
+	return int64(limitMsat.ToSatoshis()), nil
 }
 
 func confirmPayReq(resp *lnrpc.PayReq, amt, feeLimit int64) error {

--- a/docs/release-notes/release-notes-0.14.2.md
+++ b/docs/release-notes/release-notes-0.14.2.md
@@ -19,6 +19,17 @@ connection from the watch-only node.
   In other words, freshly-installed LND can now be initialized with multiple
   channels from an external (e.g. hardware) wallet *in a single transaction*.
 
+* A bug that allowed fees to be up to 100% of the payment amount was fixed by
+  [introducing a more sane default
+  value](https://github.com/lightningnetwork/lnd/pull/6226) of 5% routing fees
+  (except for small amounts <= 50 satoshis where the 100% routing fees are kept
+  to accommodate for the base fee in channels). To avoid falling back to a
+  default value, users should always set their own fee limits by using the
+  `--fee_limit` or `--fee_limit_percent` flags on the `lncli payinvoice`,
+  `lncli sendpayment` and `lncli queryroutes` commands. Users of the gRPC or
+  REST API should set the `fee_limit` field on the corresponding calls
+  (`SendPayment`, `SendPaymentSync`, `QueryRoutes`).
+
 ## Database
 
 * [Speed up graph cache loading on startup with

--- a/lnrpc/lightning.pb.go
+++ b/lnrpc/lightning.pb.go
@@ -1938,7 +1938,8 @@ type SendRequest struct {
 	//The maximum number of satoshis that will be paid as a fee of the payment.
 	//This value can be represented either as a percentage of the amount being
 	//sent, or as a fixed amount of the maximum fee the user is willing the pay to
-	//send the payment.
+	//send the payment. If not specified, lnd will use a default value of 100%
+	//fees for small amounts (<=50 sat) or 5% fees for larger amounts.
 	FeeLimit *FeeLimit `protobuf:"bytes,8,opt,name=fee_limit,json=feeLimit,proto3" json:"fee_limit,omitempty"`
 	//
 	//The channel id of the channel that must be taken to the first hop. If zero,
@@ -8517,7 +8518,8 @@ type QueryRoutesRequest struct {
 	//The maximum number of satoshis that will be paid as a fee of the payment.
 	//This value can be represented either as a percentage of the amount being
 	//sent, or as a fixed amount of the maximum fee the user is willing the pay to
-	//send the payment.
+	//send the payment. If not specified, lnd will use a default value of 100%
+	//fees for small amounts (<=50 sat) or 5% fees for larger amounts.
 	FeeLimit *FeeLimit `protobuf:"bytes,5,opt,name=fee_limit,json=feeLimit,proto3" json:"fee_limit,omitempty"`
 	//
 	//A list of nodes to ignore during path finding. When using REST, these fields

--- a/lnrpc/lightning.proto
+++ b/lnrpc/lightning.proto
@@ -753,7 +753,8 @@ message SendRequest {
     The maximum number of satoshis that will be paid as a fee of the payment.
     This value can be represented either as a percentage of the amount being
     sent, or as a fixed amount of the maximum fee the user is willing the pay to
-    send the payment.
+    send the payment. If not specified, lnd will use a default value of 100%
+    fees for small amounts (<=50 sat) or 5% fees for larger amounts.
     */
     FeeLimit fee_limit = 8;
 
@@ -2574,7 +2575,8 @@ message QueryRoutesRequest {
     The maximum number of satoshis that will be paid as a fee of the payment.
     This value can be represented either as a percentage of the amount being
     sent, or as a fixed amount of the maximum fee the user is willing the pay to
-    send the payment.
+    send the payment. If not specified, lnd will use a default value of 100%
+    fees for small amounts (<=50 sat) or 5% fees for larger amounts.
     */
     FeeLimit fee_limit = 5;
 

--- a/lnrpc/lightning.swagger.json
+++ b/lnrpc/lightning.swagger.json
@@ -6238,7 +6238,7 @@
         },
         "fee_limit": {
           "$ref": "#/definitions/lnrpcFeeLimit",
-          "description": "The maximum number of satoshis that will be paid as a fee of the payment.\nThis value can be represented either as a percentage of the amount being\nsent, or as a fixed amount of the maximum fee the user is willing the pay to\nsend the payment."
+          "description": "The maximum number of satoshis that will be paid as a fee of the payment.\nThis value can be represented either as a percentage of the amount being\nsent, or as a fixed amount of the maximum fee the user is willing the pay to\nsend the payment. If not specified, lnd will use a default value of 100%\nfees for small amounts (\u003c=50 sat) or 5% fees for larger amounts."
         },
         "outgoing_chan_id": {
           "type": "string",

--- a/lnrpc/marshall_utils.go
+++ b/lnrpc/marshall_utils.go
@@ -40,10 +40,9 @@ func CalculateFeeLimit(feeLimit *FeeLimit,
 		return amount * lnwire.MilliSatoshi(feeLimit.GetPercent()) / 100
 
 	default:
-		// If a fee limit was not specified, we'll use the payment's
-		// amount as an upper bound in order to avoid payment attempts
-		// from incurring fees higher than the payment amount itself.
-		return amount
+		// Fall back to a sane default value that is based on the amount
+		// itself.
+		return lnwallet.DefaultRoutingFeeLimitForAmount(amount)
 	}
 }
 


### PR DESCRIPTION
## Change Description
Changes the default off-chain/routing fee to be amount dependent and no longer 100% of the payment amount in any case.

This only affects the older RPCs (`SendPayment`, `SendPaymentSync`, `QueryRoutes`) that had this default value of 100% set if the user didn't specify the limit explicitly.

The newer RPCs (`SendPaymentV2`) use a default value of 0 which forces the (API) user to set an explicit value.
We cannot do the same on the older RPCs as that would break backward compatibility of applications and annoy many users (because the symptom is a `NO_ROUTE` error instead of a more explicit `not enough fees` error).
