### PR TITLE
rpcwallet: disallow empty UTXO pk script [skip ci]

### DIFF
--- a/lnwallet/rpcwallet/rpcwallet.go
+++ b/lnwallet/rpcwallet/rpcwallet.go
@@ -618,6 +618,16 @@ func (r *RPCKeyRing) remoteSign(tx *wire.MsgTx, signDesc *input.SignDescriptor,
 			PubKey: signDesc.KeyDesc.PubKey.SerializeCompressed(),
 		}}
 
+		// We need to specify a pk script in the witness UTXO, otherwise
+		// the field becomes invalid when serialized as a PSBT. To avoid
+		// running into a generic "Invalid PSBT serialization format"
+		// error later, we return a more descriptive error now.
+		if len(in.WitnessUtxo.PkScript) == 0 {
+			return nil, fmt.Errorf("error assembling UTXO " +
+				"information, output not known to wallet and " +
+				"no UTXO pk script provided in sign descriptor")
+		}
+
 	default:
 		return nil, fmt.Errorf("error assembling UTXO information, "+
 			"wallet returned err='%v' and sign descriptor is "+


### PR DESCRIPTION
If we're signing for an UTXO that isn't known to the wallet, then the
UTXO's pk script _must_ be set in the sign descriptor. Otherwise we run
into a generic PSBT serialization error when running in a remote signing
setup.

Fixes https://github.com/lightningnetwork/lnd/issues/6227 (at least as far as the error message goes, actual fix needs to be done in Loop: https://github.com/lightninglabs/loop/issues/457).