### PR TITLE
lnwallet: increase legacy fee limit threshold to 1k sats

### DIFF
--- a/docs/release-notes/release-notes-0.14.2.md
+++ b/docs/release-notes/release-notes-0.14.2.md
@@ -22,13 +22,14 @@ connection from the watch-only node.
 * A bug that allowed fees to be up to 100% of the payment amount was fixed by
   [introducing a more sane default
   value](https://github.com/lightningnetwork/lnd/pull/6226) of 5% routing fees
-  (except for small amounts <= 50 satoshis where the 100% routing fees are kept
-  to accommodate for the base fee in channels). To avoid falling back to a
-  default value, users should always set their own fee limits by using the
-  `--fee_limit` or `--fee_limit_percent` flags on the `lncli payinvoice`,
-  `lncli sendpayment` and `lncli queryroutes` commands. Users of the gRPC or
-  REST API should set the `fee_limit` field on the corresponding calls
-  (`SendPayment`, `SendPaymentSync`, `QueryRoutes`).
+  (except for small amounts <= [1k
+  satoshis](https://github.com/lightningnetwork/lnd/pull/6234) where the 100%
+  routing fees are kept to accommodate for the base fee in channels). To avoid
+  falling back to a default value, users should always set their own fee limits
+  by using the `--fee_limit` or `--fee_limit_percent` flags on the `lncli
+  payinvoice`, `lncli sendpayment` and `lncli queryroutes` commands. Users of
+  the gRPC or REST API should set the `fee_limit` field on the corresponding
+  calls (`SendPayment`, `SendPaymentSync`, `QueryRoutes`).
 
 ## Database
 

--- a/lnrpc/lightning.pb.go
+++ b/lnrpc/lightning.pb.go
@@ -1939,7 +1939,7 @@ type SendRequest struct {
 	//This value can be represented either as a percentage of the amount being
 	//sent, or as a fixed amount of the maximum fee the user is willing the pay to
 	//send the payment. If not specified, lnd will use a default value of 100%
-	//fees for small amounts (<=50 sat) or 5% fees for larger amounts.
+	//fees for small amounts (<=1k sat) or 5% fees for larger amounts.
 	FeeLimit *FeeLimit `protobuf:"bytes,8,opt,name=fee_limit,json=feeLimit,proto3" json:"fee_limit,omitempty"`
 	//
 	//The channel id of the channel that must be taken to the first hop. If zero,
@@ -8519,7 +8519,7 @@ type QueryRoutesRequest struct {
 	//This value can be represented either as a percentage of the amount being
 	//sent, or as a fixed amount of the maximum fee the user is willing the pay to
 	//send the payment. If not specified, lnd will use a default value of 100%
-	//fees for small amounts (<=50 sat) or 5% fees for larger amounts.
+	//fees for small amounts (<=1k sat) or 5% fees for larger amounts.
 	FeeLimit *FeeLimit `protobuf:"bytes,5,opt,name=fee_limit,json=feeLimit,proto3" json:"fee_limit,omitempty"`
 	//
 	//A list of nodes to ignore during path finding. When using REST, these fields

--- a/lnrpc/lightning.proto
+++ b/lnrpc/lightning.proto
@@ -754,7 +754,7 @@ message SendRequest {
     This value can be represented either as a percentage of the amount being
     sent, or as a fixed amount of the maximum fee the user is willing the pay to
     send the payment. If not specified, lnd will use a default value of 100%
-    fees for small amounts (<=50 sat) or 5% fees for larger amounts.
+    fees for small amounts (<=1k sat) or 5% fees for larger amounts.
     */
     FeeLimit fee_limit = 8;
 
@@ -2576,7 +2576,7 @@ message QueryRoutesRequest {
     This value can be represented either as a percentage of the amount being
     sent, or as a fixed amount of the maximum fee the user is willing the pay to
     send the payment. If not specified, lnd will use a default value of 100%
-    fees for small amounts (<=50 sat) or 5% fees for larger amounts.
+    fees for small amounts (<=1k sat) or 5% fees for larger amounts.
     */
     FeeLimit fee_limit = 5;
 

--- a/lnrpc/lightning.swagger.json
+++ b/lnrpc/lightning.swagger.json
@@ -6238,7 +6238,7 @@
         },
         "fee_limit": {
           "$ref": "#/definitions/lnrpcFeeLimit",
-          "description": "The maximum number of satoshis that will be paid as a fee of the payment.\nThis value can be represented either as a percentage of the amount being\nsent, or as a fixed amount of the maximum fee the user is willing the pay to\nsend the payment. If not specified, lnd will use a default value of 100%\nfees for small amounts (\u003c=50 sat) or 5% fees for larger amounts."
+          "description": "The maximum number of satoshis that will be paid as a fee of the payment.\nThis value can be represented either as a percentage of the amount being\nsent, or as a fixed amount of the maximum fee the user is willing the pay to\nsend the payment. If not specified, lnd will use a default value of 100%\nfees for small amounts (\u003c=1k sat) or 5% fees for larger amounts."
         },
         "outgoing_chan_id": {
           "type": "string",

--- a/lnwallet/parameters.go
+++ b/lnwallet/parameters.go
@@ -8,10 +8,13 @@ import (
 	"github.com/lightningnetwork/lnd/lnwire"
 )
 
-const (
+var (
 	// RoutingFee100PercentUpTo is the cut-off amount we allow 100% fees to
 	// be charged up to.
-	RoutingFee100PercentUpTo lnwire.MilliSatoshi = 50_000
+	RoutingFee100PercentUpTo = lnwire.NewMSatFromSatoshis(1_000)
+)
+
+const (
 
 	// DefaultRoutingFeePercentage is the default off-chain routing fee we
 	// allow to be charged for a payment over the RoutingFee100PercentUpTo

--- a/lnwallet/parameters_test.go
+++ b/lnwallet/parameters_test.go
@@ -24,12 +24,12 @@ func TestDefaultRoutingFeeLimitForAmount(t *testing.T) {
 			expectedLimit: 1,
 		},
 		{
-			amount:        50_000,
-			expectedLimit: 50_000,
+			amount:        lnwire.NewMSatFromSatoshis(1_000),
+			expectedLimit: lnwire.NewMSatFromSatoshis(1_000),
 		},
 		{
-			amount:        50_001,
-			expectedLimit: 2_500,
+			amount:        lnwire.NewMSatFromSatoshis(1_001),
+			expectedLimit: 50_050,
 		},
 		{
 			amount:        5_000_000_000,
@@ -42,7 +42,7 @@ func TestDefaultRoutingFeeLimitForAmount(t *testing.T) {
 
 		t.Run(fmt.Sprintf("%d sats", test.amount), func(t *testing.T) {
 			feeLimit := DefaultRoutingFeeLimitForAmount(test.amount)
-			require.Equal(t, test.expectedLimit, feeLimit)
+			require.Equal(t, int64(test.expectedLimit), int64(feeLimit))
 		})
 	}
 }


### PR DESCRIPTION
In this commit, we increase the legacy fee limit threshold (the amount
below which we'll allow 100% of funds to go to fees for the non-v2 RPC
calls) from 50 sats to 1k sats.

