### PR TITLE
invoicesrpc: limit first pass of hop hint selection

### DIFF
--- a/docs/release-notes/release-notes-0.15.0.md
+++ b/docs/release-notes/release-notes-0.15.0.md
@@ -29,6 +29,13 @@
   [These premature messages are now saved into a cache and processed once the
   height has reached.](https://github.com/lightningnetwork/lnd/pull/6054)
 
+* [Fixed failure to limit our number of hop hints in private invoices](https://github.com/lightningnetwork/lnd/pull/6236).
+  When a private invoice is created, and the node had > 20 (our hop hint limit)
+  private channels with inbound > invoice amount, hop hint selection would add
+  too many hop hints. When a node had many channels meeting this criteria, it 
+  could result in an "invoice too large" error when creating invoices. Hints 
+  are now properly limited to our maximum of 20.
+
 ## Misc
 
 * [An example systemd service file](https://github.com/lightningnetwork/lnd/pull/6033)

--- a/lnrpc/invoicesrpc/addinvoice_test.go
+++ b/lnrpc/invoicesrpc/addinvoice_test.go
@@ -308,6 +308,36 @@ func TestSelectHopHints(t *testing.T) {
 			expectedHints: nil,
 		},
 		{
+			// This test case reproduces a bug where we have too
+			// many hop hints for our maximum hint number.
+			name: "too many hints",
+			setupMock: func(h *hopHintsConfigMock) {
+				setMockChannelUsed(
+					h, private1ShortID, privateChan1Policy,
+				)
+
+				setMockChannelUsed(
+					h, private2ShortID, privateChan2Policy,
+				)
+
+			},
+			// Set our amount to less than our channel balance of
+			// 100.
+			amount: 30,
+			channels: []*HopHintInfo{
+				privateChannel1, privateChannel2,
+			},
+			numHints: 1,
+			expectedHints: [][]zpay32.HopHint{
+				{
+					privateChannel1Hint,
+				},
+				{
+					privateChannel2Hint,
+				},
+			},
+		},
+		{
 			// If a channel has more balance than the amount we're
 			// looking for, it'll be added in our first pass. We
 			// can be sure we're adding it in our first pass because


### PR DESCRIPTION
## Change Description
This PR adds limits to our first pass of adding hop hints to invoices. 
- Previously: if we had 100 channels where `remoteBalance > invoice amount` , we would add 100 hints
- Now: we will add up to 20 channels, or enough hints to each incoming bandwidth 2 * invoice amount

The first commit also updates one of our existing itests to ensure we have hop hint coverage, where previously we said that we were adding coverage but did not check that our invoice actually had hints. 

Fixes #6225.

## Steps to Test
There is an itest reproducing this issue on [this branch](https://github.com/carlaKC/lnd/tree/6225-invoicetoolarge). 
- Run the itest against master -> fails with "invoice too large"
- Run the itest against this branch -> only adds 20 hop hints + passes

Note: the itest takes quite long because it creates many channels. It can be decreased to create > 20 channels to demonstrate that we just create too many hints. 