### PR TITLE
lncli: update `lncli state` description

### DIFF
--- a/cmd/lncli/cmd_state.go
+++ b/cmd/lncli/cmd_state.go
@@ -13,11 +13,13 @@ var getStateCommand = cli.Command{
 	Usage:    "Get the current state of the wallet and RPC",
 	Description: `
 	Get the current state of the wallet. The possible states are:
+	 - WAITING_TO_START: node is waiting to become the leader in a cluster
+	   and is not started yet.
 	 - NON_EXISTING: wallet has not yet been initialized.
 	 - LOCKED: wallet is locked.
-	 - UNLOCKED: wallet has been unlocked successfully, but the full RPC is
-	   not yet ready.
-	 - RPC_READY: the daemon has started and the RPC is fully available.
+	 - UNLOCKED: wallet was unlocked successfully, but RPC server isn't ready.
+	 - RPC_ACTIVE: RPC server is active but not fully ready for calls.
+	 - SERVER_ACTIVE: RPC server is available and ready to accept calls.
 	`,
 	Flags:  []cli.Flag{},
 	Action: actionDecorator(getState),

--- a/docs/release-notes/release-notes-0.15.0.md
+++ b/docs/release-notes/release-notes-0.15.0.md
@@ -16,6 +16,8 @@
 * Add [private status](https://github.com/lightningnetwork/lnd/pull/6167)
   to pendingchannels response.
 
+* [Update description for `state` command](https://github.com/lightningnetwork/lnd/pull/6237).
+
 ## Bug Fixes
 
 * [Fixed an inactive invoice subscription not removed from invoice


### PR DESCRIPTION
This updates the description that is provided for `lncli state` to match
the states that are currently returned by lnd. `RPC_READY` no longer
exists and is replaced by `RPC_ACTIVE` with a revised description, and
`SERVER_ACTIVE` is added as the status that indicates lnd is fully
ready to accept RPC calls.

See `enum WalletState` in `stateservice.proto`.