### PR TITLE
multi: Update licenses to 2022 [skip ci]

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (C) 2015-2018 Lightning Labs and The Lightning Network Developers
+Copyright (C) 2015-2022 Lightning Labs and The Lightning Network Developers
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/build/version.go
+++ b/build/version.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2013-2017 The btcsuite developers
 // Copyright (c) 2015-2016 The Decred developers
 // Heavily inspired by https://github.com/btcsuite/btcd/blob/master/version.go
-// Copyright (C) 2015-2017 The Lightning Network Developers
+// Copyright (C) 2015-2022 The Lightning Network Developers
 
 package build
 

--- a/channeldb/migration/lnwire21/message.go
+++ b/channeldb/migration/lnwire21/message.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2013-2017 The btcsuite developers
 // Copyright (c) 2015-2016 The Decred developers
 // code derived from https://github .com/btcsuite/btcd/blob/master/wire/message.go
-// Copyright (C) 2015-2017 The Lightning Network Developers
+// Copyright (C) 2015-2022 The Lightning Network Developers
 
 package lnwire
 

--- a/cmd/lncli/main.go
+++ b/cmd/lncli/main.go
@@ -1,6 +1,6 @@
 // Copyright (c) 2013-2017 The btcsuite developers
 // Copyright (c) 2015-2016 The Decred developers
-// Copyright (C) 2015-2017 The Lightning Network Developers
+// Copyright (C) 2015-2022 The Lightning Network Developers
 
 package main
 

--- a/config.go
+++ b/config.go
@@ -1,6 +1,6 @@
 // Copyright (c) 2013-2017 The btcsuite developers
 // Copyright (c) 2015-2016 The Decred developers
-// Copyright (C) 2015-2020 The Lightning Network Developers
+// Copyright (C) 2015-2022 The Lightning Network Developers
 
 package lnd
 

--- a/lnd.go
+++ b/lnd.go
@@ -1,6 +1,6 @@
 // Copyright (c) 2013-2017 The btcsuite developers
 // Copyright (c) 2015-2016 The Decred developers
-// Copyright (C) 2015-2017 The Lightning Network Developers
+// Copyright (C) 2015-2022 The Lightning Network Developers
 
 package lnd
 

--- a/lnwire/message.go
+++ b/lnwire/message.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2013-2017 The btcsuite developers
 // Copyright (c) 2015-2016 The Decred developers
 // code derived from https://github .com/btcsuite/btcd/blob/master/wire/message.go
-// Copyright (C) 2015-2017 The Lightning Network Developers
+// Copyright (C) 2015-2022 The Lightning Network Developers
 
 package lnwire
 

--- a/signal/signal.go
+++ b/signal/signal.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2013-2017 The btcsuite developers
 // Copyright (c) 2015-2016 The Decred developers
 // Heavily inspired by https://github.com/btcsuite/btcd/blob/master/signal.go
-// Copyright (C) 2015-2017 The Lightning Network Developers
+// Copyright (C) 2015-2022 The Lightning Network Developers
 
 package signal
 


### PR DESCRIPTION
## Change Description
Update licenses to 2022.
Mention license updates in release notes.
