### PR TITLE
log: zero cltv delta warnings removed

### DIFF
--- a/docs/release-notes/release-notes-0.15.0.md
+++ b/docs/release-notes/release-notes-0.15.0.md
@@ -88,6 +88,8 @@
   allows code external to lnd to call the function, where previously it would 
   require access to lnd's internals.
 
+* [Zero cltv delta warnings removed](https://github.com/lightningnetwork/lnd/pull/6242).
+
 * [rpc-check fails if it finds any changes](https://github.com/lightningnetwork/lnd/pull/6207/)
   including new and deleted files.
 

--- a/routing/pathfind.go
+++ b/routing/pathfind.go
@@ -699,13 +699,6 @@ func findPath(g *graphParams, r *RestrictParams, cfg *PathFindingConfig,
 			}
 		}
 
-		// Every edge should have a positive time lock delta. If we
-		// encounter a zero delta, log a warning line.
-		if edge.TimeLockDelta == 0 {
-			log.Warnf("Channel %v has zero cltv delta",
-				edge.ChannelID)
-		}
-
 		// Calculate the total routing info size if this hop were to be
 		// included. If we are coming from the source hop, the payload
 		// size is zero, because the original htlc isn't in the onion


### PR DESCRIPTION
The client might encounters edges that have a policy specifying a zero CLTV delta (possibly because of no/outdated gossip?). Every time an edge like this is used in the path finding code, a warning is logged. This pr removes that warning message. 

Fixes: #6069