### PR TITLE
make+tools: dockerize linting [skip ci]

### DIFF
--- a/tools/Dockerfile
+++ b/tools/Dockerfile
@@ -1,0 +1,16 @@
+FROM golang:1.17.3-buster
+
+RUN apt-get update && apt-get install -y git
+ENV GOCACHE=/tmp/build/.cache
+ENV GOMODCACHE=/tmp/build/.modcache
+
+COPY . /tmp/tools
+
+RUN cd /tmp \
+  && mkdir -p /tmp/build/.cache \
+  && mkdir -p /tmp/build/.modcache \
+  && cd /tmp/tools \
+  && go install -trimpath -tags=tools github.com/golangci/golangci-lint/cmd/golangci-lint \
+  && chmod -R 777 /tmp/build/
+
+WORKDIR /build


### PR DESCRIPTION
Dockerizes the use of `golangci-lint` to avoid version conflicts with other projects.