### PR TITLE
htlcswitch+lntest: create resolutionStore to persist ResolutionMsg

### DIFF
--- a/contractcourt/channel_arbitrator.go
+++ b/contractcourt/channel_arbitrator.go
@@ -1092,8 +1092,6 @@ func (c *ChannelArbitrator) stateStep(
 		if len(pktsToSend) != 0 {
 			err := c.cfg.DeliverResolutionMsg(pktsToSend...)
 			if err != nil {
-				// TODO(roasbeef): make sure packet sends are
-				// idempotent
 				log.Errorf("unable to send pkts: %v", err)
 				return StateError, closeTx, err
 			}

--- a/docs/release-notes/release-notes-0.15.0.md
+++ b/docs/release-notes/release-notes-0.15.0.md
@@ -121,6 +121,9 @@ releases. Backward compatibility is not guaranteed!
 * [Fixed a spec-compliance issue where lnd was not allowing cooperative
 close to continue after a peer disconnect](https://github.com/lightningnetwork/lnd/pull/6419).
 
+* [A subsystem hand-off between the contractcourt and htlcswitch has been fixed by adding a persistence layer. This avoids a rare edge case
+from occurring that would result in an erroneous force close.](https://github.com/lightningnetwork/lnd/pull/6250)
+
 ## Routing
 
 * [Add a new `time_pref` parameter to the QueryRoutes and SendPayment APIs](https://github.com/lightningnetwork/lnd/pull/6024) that

--- a/htlcswitch/resolution_store.go
+++ b/htlcswitch/resolution_store.go
@@ -1,0 +1,202 @@
+package htlcswitch
+
+import (
+	"bytes"
+	"io"
+
+	"github.com/go-errors/errors"
+	"github.com/lightningnetwork/lnd/channeldb"
+	"github.com/lightningnetwork/lnd/contractcourt"
+	"github.com/lightningnetwork/lnd/kvdb"
+	"github.com/lightningnetwork/lnd/lnwire"
+)
+
+var (
+	// resBucketKey is used for the root level bucket that stores the
+	// CircuitKey -> ResolutionMsg mapping.
+	resBucketKey = []byte("resolution-store-bucket-key")
+
+	// errResMsgNotFound is used to let callers know that the resolution
+	// message was not found for the given CircuitKey. This is used in the
+	// checkResolutionMsg function.
+	errResMsgNotFound = errors.New("resolution message not found")
+)
+
+// resolutionStore contains ResolutionMsgs received from the contractcourt. The
+// Switch deletes these from the store when the underlying circuit has been
+// removed via DeleteCircuits. If the circuit hasn't been deleted, the Switch
+// will dispatch the ResolutionMsg to a link if this was a multi-hop HTLC or to
+// itself if the Switch initiated the payment.
+type resolutionStore struct {
+	backend kvdb.Backend
+}
+
+func newResolutionStore(db kvdb.Backend) *resolutionStore {
+	return &resolutionStore{
+		backend: db,
+	}
+}
+
+// addResolutionMsg persists a ResolutionMsg to the resolutionStore.
+func (r *resolutionStore) addResolutionMsg(
+	resMsg *contractcourt.ResolutionMsg) error {
+
+	// The outKey will be the database key.
+	outKey := &CircuitKey{
+		ChanID: resMsg.SourceChan,
+		HtlcID: resMsg.HtlcIndex,
+	}
+
+	var resBuf bytes.Buffer
+	if err := serializeResolutionMsg(&resBuf, resMsg); err != nil {
+		return err
+	}
+
+	err := kvdb.Update(r.backend, func(tx kvdb.RwTx) error {
+		resBucket, err := tx.CreateTopLevelBucket(resBucketKey)
+		if err != nil {
+			return err
+		}
+
+		return resBucket.Put(outKey.Bytes(), resBuf.Bytes())
+	}, func() {})
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// checkResolutionMsg returns nil if the resolution message is found in the
+// store. It returns an error if no resolution message was found for the
+// passed outKey or if a database error occurred.
+func (r *resolutionStore) checkResolutionMsg(outKey *CircuitKey) error {
+	err := kvdb.View(r.backend, func(tx kvdb.RTx) error {
+		resBucket := tx.ReadBucket(resBucketKey)
+		if resBucket == nil {
+			// Return an error if the bucket doesn't exist.
+			return errResMsgNotFound
+		}
+
+		msg := resBucket.Get(outKey.Bytes())
+		if msg == nil {
+			// Return the not found error since no message exists
+			// for this CircuitKey.
+			return errResMsgNotFound
+		}
+
+		// Return nil to indicate that the message was found.
+		return nil
+	}, func() {})
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// fetchAllResolutionMsg returns a slice of all stored ResolutionMsgs. This is
+// used by the Switch on start-up.
+func (r *resolutionStore) fetchAllResolutionMsg() (
+	[]*contractcourt.ResolutionMsg, error) {
+
+	var msgs []*contractcourt.ResolutionMsg
+
+	err := kvdb.View(r.backend, func(tx kvdb.RTx) error {
+		resBucket := tx.ReadBucket(resBucketKey)
+		if resBucket == nil {
+			return nil
+		}
+
+		return resBucket.ForEach(func(k, v []byte) error {
+			kr := bytes.NewReader(k)
+			outKey := &CircuitKey{}
+			if err := outKey.Decode(kr); err != nil {
+				return err
+			}
+
+			vr := bytes.NewReader(v)
+			resMsg, err := deserializeResolutionMsg(vr)
+			if err != nil {
+				return err
+			}
+
+			// Set the CircuitKey values on the ResolutionMsg.
+			resMsg.SourceChan = outKey.ChanID
+			resMsg.HtlcIndex = outKey.HtlcID
+
+			msgs = append(msgs, resMsg)
+			return nil
+		})
+	}, func() {
+		msgs = nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return msgs, nil
+}
+
+// deleteResolutionMsg removes a ResolutionMsg with the passed-in CircuitKey.
+func (r *resolutionStore) deleteResolutionMsg(outKey *CircuitKey) error {
+	err := kvdb.Update(r.backend, func(tx kvdb.RwTx) error {
+		resBucket, err := tx.CreateTopLevelBucket(resBucketKey)
+		if err != nil {
+			return err
+		}
+
+		return resBucket.Delete(outKey.Bytes())
+	}, func() {})
+	return err
+}
+
+// serializeResolutionMsg writes part of a ResolutionMsg to the passed
+// io.Writer.
+func serializeResolutionMsg(w io.Writer,
+	resMsg *contractcourt.ResolutionMsg) error {
+
+	isFail := resMsg.Failure != nil
+
+	if err := channeldb.WriteElement(w, isFail); err != nil {
+		return err
+	}
+
+	// If this is a failure message, then we're done serializing.
+	if isFail {
+		return nil
+	}
+
+	// Else this is a settle message, and we need to write the preimage.
+	return channeldb.WriteElement(w, *resMsg.PreImage)
+}
+
+// deserializeResolutionMsg reads part of a ResolutionMsg from the passed
+// io.Reader.
+func deserializeResolutionMsg(r io.Reader) (*contractcourt.ResolutionMsg,
+	error) {
+
+	resMsg := &contractcourt.ResolutionMsg{}
+	var isFail bool
+
+	if err := channeldb.ReadElements(r, &isFail); err != nil {
+		return nil, err
+	}
+
+	// If a failure resolution msg was stored, set the Failure field.
+	if isFail {
+		failureMsg := &lnwire.FailPermanentChannelFailure{}
+		resMsg.Failure = failureMsg
+		return resMsg, nil
+	}
+
+	var preimage [32]byte
+	resMsg.PreImage = &preimage
+
+	// Else this is a settle resolution msg and we will read the preimage.
+	if err := channeldb.ReadElement(r, resMsg.PreImage); err != nil {
+		return nil, err
+	}
+
+	return resMsg, nil
+}

--- a/htlcswitch/resolution_store_test.go
+++ b/htlcswitch/resolution_store_test.go
@@ -1,0 +1,154 @@
+package htlcswitch
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/lightningnetwork/lnd/contractcourt"
+	"github.com/lightningnetwork/lnd/kvdb"
+	"github.com/lightningnetwork/lnd/lnwire"
+	"github.com/stretchr/testify/require"
+)
+
+// TestInsertAndDelete tests that an inserted resolution message can be
+// deleted.
+func TestInsertAndDelete(t *testing.T) {
+	t.Parallel()
+
+	scid := lnwire.NewShortChanIDFromInt(1)
+
+	failResMsg := &contractcourt.ResolutionMsg{
+		SourceChan: scid,
+		HtlcIndex:  2,
+		Failure:    &lnwire.FailTemporaryChannelFailure{},
+	}
+
+	settleBytes := [32]byte{
+		0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+		0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+		0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+		0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01,
+	}
+
+	settleResMsg := &contractcourt.ResolutionMsg{
+		SourceChan: scid,
+		HtlcIndex:  3,
+		PreImage:   &settleBytes,
+	}
+
+	// Create the backend database and use it to create the resolution
+	// store.
+	dbDir, err := ioutil.TempDir("", "resolutionStore")
+	require.NoError(t, err)
+
+	dbPath := filepath.Join(dbDir, "testdb")
+	db, err := kvdb.Create(
+		kvdb.BoltBackendName, dbPath, true, kvdb.DefaultDBTimeout,
+	)
+	require.NoError(t, err)
+
+	cleanUp := func() {
+		db.Close()
+		os.RemoveAll(dbDir)
+	}
+	defer cleanUp()
+
+	resStore := newResolutionStore(db)
+
+	// We'll add the failure resolution message first, then check that it
+	// exists in the store.
+	err = resStore.addResolutionMsg(failResMsg)
+	require.NoError(t, err)
+
+	// Assert that checkResolutionMsg returns nil, signalling that the
+	// resolution message was properly stored.
+	outKey := &CircuitKey{
+		ChanID: failResMsg.SourceChan,
+		HtlcID: failResMsg.HtlcIndex,
+	}
+	err = resStore.checkResolutionMsg(outKey)
+	require.NoError(t, err)
+
+	resMsgs, err := resStore.fetchAllResolutionMsg()
+	require.NoError(t, err)
+	require.Equal(t, 1, len(resMsgs))
+
+	// It should match failResMsg above.
+	require.Equal(t, failResMsg.SourceChan, resMsgs[0].SourceChan)
+	require.Equal(t, failResMsg.HtlcIndex, resMsgs[0].HtlcIndex)
+	require.NotNil(t, resMsgs[0].Failure)
+	require.Nil(t, resMsgs[0].PreImage)
+
+	// We'll add the settleResMsg now.
+	err = resStore.addResolutionMsg(settleResMsg)
+	require.NoError(t, err)
+
+	// Check that checkResolutionMsg returns nil for the settle CircuitKey.
+	outKey.ChanID = settleResMsg.SourceChan
+	outKey.HtlcID = settleResMsg.HtlcIndex
+	err = resStore.checkResolutionMsg(outKey)
+	require.NoError(t, err)
+
+	// We should have two resolution messages in the store, one failure and
+	// one success.
+	resMsgs, err = resStore.fetchAllResolutionMsg()
+	require.NoError(t, err)
+	require.Equal(t, 2, len(resMsgs))
+
+	// The first resolution message should be the failure.
+	require.Equal(t, failResMsg.SourceChan, resMsgs[0].SourceChan)
+	require.Equal(t, failResMsg.HtlcIndex, resMsgs[0].HtlcIndex)
+	require.NotNil(t, resMsgs[0].Failure)
+	require.Nil(t, resMsgs[0].PreImage)
+
+	// The second resolution message should be the success.
+	require.Equal(t, settleResMsg.SourceChan, resMsgs[1].SourceChan)
+	require.Equal(t, settleResMsg.HtlcIndex, resMsgs[1].HtlcIndex)
+	require.Nil(t, resMsgs[1].Failure)
+	require.Equal(t, settleBytes, *resMsgs[1].PreImage)
+
+	// We'll now delete the failure resolution message and assert that only
+	// the success is left.
+	failKey := &CircuitKey{
+		ChanID: scid,
+		HtlcID: failResMsg.HtlcIndex,
+	}
+
+	err = resStore.deleteResolutionMsg(failKey)
+	require.NoError(t, err)
+
+	// Assert that checkResolutionMsg returns errResMsgNotFound.
+	err = resStore.checkResolutionMsg(failKey)
+	require.ErrorIs(t, err, errResMsgNotFound)
+
+	resMsgs, err = resStore.fetchAllResolutionMsg()
+	require.NoError(t, err)
+	require.Equal(t, 1, len(resMsgs))
+
+	// Assert that the success is left.
+	require.Equal(t, settleResMsg.SourceChan, resMsgs[0].SourceChan)
+	require.Equal(t, settleResMsg.HtlcIndex, resMsgs[0].HtlcIndex)
+	require.Nil(t, resMsgs[0].Failure)
+	require.Equal(t, settleBytes, *resMsgs[0].PreImage)
+
+	// Now we'll delete the settle resolution message and assert that the
+	// store is empty.
+	settleKey := &CircuitKey{
+		ChanID: scid,
+		HtlcID: settleResMsg.HtlcIndex,
+	}
+
+	err = resStore.deleteResolutionMsg(settleKey)
+	require.NoError(t, err)
+
+	// Assert that checkResolutionMsg returns errResMsgNotFound for the
+	// settle key.
+	err = resStore.checkResolutionMsg(settleKey)
+	require.ErrorIs(t, err, errResMsgNotFound)
+
+	resMsgs, err = resStore.fetchAllResolutionMsg()
+	require.NoError(t, err)
+	require.Equal(t, 0, len(resMsgs))
+}

--- a/lntest/itest/lnd_res_handoff_test.go
+++ b/lntest/itest/lnd_res_handoff_test.go
@@ -1,0 +1,200 @@
+package itest
+
+import (
+	"time"
+
+	"github.com/btcsuite/btcd/btcutil"
+	"github.com/lightningnetwork/lnd/lnrpc"
+	"github.com/lightningnetwork/lnd/lntest"
+	"github.com/lightningnetwork/lnd/lntest/wait"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/net/context"
+)
+
+// testResHandoff tests that the contractcourt is able to properly hand-off
+// resolution messages to the switch.
+func testResHandoff(net *lntest.NetworkHarness, t *harnessTest) {
+	const (
+		chanAmt    = btcutil.Amount(1000000)
+		paymentAmt = 50000
+	)
+
+	ctxb := context.Background()
+
+	// First we'll create a channel between Alice and Bob.
+	net.EnsureConnected(t.t, net.Alice, net.Bob)
+
+	chanPointAlice := openChannelAndAssert(
+		t, net, net.Alice, net.Bob,
+		lntest.OpenChannelParams{
+			Amt: chanAmt,
+		},
+	)
+	defer closeChannelAndAssert(t, net, net.Alice, chanPointAlice, false)
+
+	// Wait for Alice and Bob to receive the channel edge from the funding
+	// manager.
+	err := net.Alice.WaitForNetworkChannelOpen(chanPointAlice)
+	require.NoError(t.t, err)
+
+	err = net.Bob.WaitForNetworkChannelOpen(chanPointAlice)
+	require.NoError(t.t, err)
+
+	// Create a new node Carol that will be in hodl mode. This is used to
+	// trigger the behavior of checkRemoteDanglingActions in the
+	// contractcourt. This will cause Bob to fail the HTLC back to Alice.
+	carol := net.NewNode(t.t, "Carol", []string{"--hodl.commit"})
+	defer shutdownAndAssert(net, t, carol)
+
+	// Connect Bob to Carol.
+	net.ConnectNodes(t.t, net.Bob, carol)
+
+	// Open a channel between Bob and Carol.
+	chanPointCarol := openChannelAndAssert(
+		t, net, net.Bob, carol,
+		lntest.OpenChannelParams{
+			Amt: chanAmt,
+		},
+	)
+
+	// Wait for Bob and Carol to receive the channel edge from the funding
+	// manager.
+	err = net.Bob.WaitForNetworkChannelOpen(chanPointCarol)
+	require.NoError(t.t, err)
+
+	err = carol.WaitForNetworkChannelOpen(chanPointCarol)
+	require.NoError(t.t, err)
+
+	// Wait for Alice to see the channel edge in the graph.
+	err = net.Alice.WaitForNetworkChannelOpen(chanPointCarol)
+	require.NoError(t.t, err)
+
+	// We'll create an invoice for Carol that Alice will attempt to pay.
+	// Since Carol is in hodl.commit mode, she won't send back any commit
+	// sigs.
+	carolPayReqs, _, _, err := createPayReqs(
+		carol, paymentAmt, 1,
+	)
+	require.NoError(t.t, err)
+
+	// Alice will now attempt to fulfill the invoice.
+	err = completePaymentRequests(
+		net.Alice, net.Alice.RouterClient, carolPayReqs, false,
+	)
+	require.NoError(t.t, err)
+
+	// Wait until Carol has received the Add, CommitSig from Bob, and has
+	// responded with a RevokeAndAck. We expect NumUpdates to be 1 meaning
+	// Carol's CommitHeight is 1.
+	err = wait.Predicate(func() bool {
+		carolInfo, err := getChanInfo(carol)
+		if err != nil {
+			return false
+		}
+
+		return carolInfo.NumUpdates == 1
+	}, defaultTimeout)
+	require.NoError(t.t, err)
+
+	// Before we shutdown Alice, we'll assert that she only has 1 update.
+	err = wait.Predicate(func() bool {
+		aliceInfo, err := getChanInfo(net.Alice)
+		if err != nil {
+			return false
+		}
+
+		return aliceInfo.NumUpdates == 1
+	}, defaultTimeout)
+	require.NoError(t.t, err)
+
+	// We'll shutdown Alice so that Bob can't connect to her.
+	restartAlice, err := net.SuspendNode(net.Alice)
+	require.NoError(t.t, err)
+
+	// Bob will now force close his channel with Carol such that resolution
+	// messages are created and forwarded backwards to Alice.
+	_, _, err = net.CloseChannel(net.Bob, chanPointCarol, true)
+	require.NoError(t.t, err)
+
+	// The channel should be listed in the PendingChannels result.
+	ctxt, cancel := context.WithTimeout(ctxb, defaultTimeout)
+	defer cancel()
+
+	pendingChansRequest := &lnrpc.PendingChannelsRequest{}
+	pendingChanResp, err := net.Bob.PendingChannels(
+		ctxt, pendingChansRequest,
+	)
+	require.NoError(t.t, err)
+	require.NoError(t.t, checkNumWaitingCloseChannels(pendingChanResp, 1))
+
+	// We'll mine a block to confirm the force close transaction and to
+	// advance Bob's contract state with Carol to StateContractClosed.
+	mineBlocks(t, net, 1, 1)
+
+	// We sleep here so we can be sure that the hand-off has occurred from
+	// Bob's contractcourt to Bob's htlcswitch. This sleep could be removed
+	// if there was some feedback (i.e. API in switch) that allowed for
+	// querying the state of resolution messages.
+	time.Sleep(10 * time.Second)
+
+	// Mine blocks until Bob has no waiting close channels. This tests
+	// that the circuit-deletion logic is skipped if a resolution message
+	// exists.
+	for {
+		_, err = net.Miner.Client.Generate(1)
+		require.NoError(t.t, err)
+
+		pendingChanResp, err = net.Bob.PendingChannels(
+			ctxt, pendingChansRequest,
+		)
+		require.NoError(t.t, err)
+
+		isErr := checkNumForceClosedChannels(pendingChanResp, 0)
+		if isErr == nil {
+			break
+		}
+
+		time.Sleep(150 * time.Millisecond)
+	}
+
+	// We will now restart Bob so that we can test whether the resolution
+	// messages are re-forwarded on start-up.
+	restartBob, err := net.SuspendNode(net.Bob)
+	require.NoError(t.t, err)
+
+	err = restartBob()
+	require.NoError(t.t, err)
+
+	// We'll now also restart Alice and connect her with Bob.
+	err = restartAlice()
+	require.NoError(t.t, err)
+
+	net.EnsureConnected(t.t, net.Alice, net.Bob)
+
+	// We'll assert that Alice has received the failure resolution
+	// message.
+	err = wait.Predicate(func() bool {
+		aliceInfo, err := getChanInfo(net.Alice)
+		if err != nil {
+			return false
+		}
+
+		return aliceInfo.NumUpdates == 2
+	}, defaultTimeout)
+	require.NoError(t.t, err)
+
+	// Assert that Alice's payment failed.
+	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
+	paymentsResp, err := net.Alice.ListPayments(
+		ctxt, &lnrpc.ListPaymentsRequest{
+			IncludeIncomplete: true,
+		},
+	)
+	require.NoError(t.t, err)
+	require.Equal(t.t, 1, len(paymentsResp.Payments))
+
+	htlcs := paymentsResp.Payments[0].Htlcs
+
+	require.Equal(t.t, 1, len(htlcs))
+	require.Equal(t.t, lnrpc.HTLCAttempt_FAILED, htlcs[0].Status)
+}

--- a/lntest/itest/lnd_test_list_on_test.go
+++ b/lntest/itest/lnd_test_list_on_test.go
@@ -399,4 +399,8 @@ var allTestCases = []*testCase{
 		name: "addpeer config",
 		test: testAddPeerConfig,
 	},
+	{
+		name: "resolution handoff",
+		test: testResHandoff,
+	},
 }


### PR DESCRIPTION
This patch creates a store for `ResolutionMsg` that the `htlcswitch.Switch` receives from the `contractcourt.ChannelArbitrator` in a way that lnd going down (power loss, `SIGKILL`, anything else) at any point in the process should allow it to recover. If the `htlcswitch.ProcessContractResolution` hand-off fails for any reason, the caller (`contractcourt.ChannelArbitrator` or `contractcourt.htlcTimeoutResolver`) is notified of the error and will refuse to advance its state and will try again on another pass. On start-up the switch will cleanup the store by removing messages whose circuits have been deleted. This PR depends on https://github.com/lightningnetwork/lnd/pull/6214 to avoid deadlock on start-up but I have not included those commits. I will rebase after those changes are in. Combined with that patch, the hand-off can be repeated again on start-up if the switch failed to persist the changes.

Fixes #2998 