### PR TITLE
discovery: refactor processNetworkAnnouncement into smaller functions

### DIFF
--- a/docs/release-notes/release-notes-0.15.0.md
+++ b/docs/release-notes/release-notes-0.15.0.md
@@ -152,6 +152,8 @@ gRPC performance metrics (latency to process `GetInfo`, etc)](https://github.com
 
 * [The channel-commit-interval is now clamped to a reasonable timeframe of 1h.](https://github.com/lightningnetwork/lnd/pull/6220)
 
+* [A function in the gossiper `processNetworkAnnouncements` has been refactored for readability and for future deduplication efforts.](https://github.com/lightningnetwork/lnd/pull/6278)
+
 # Contributors (Alphabetical Order)
 
 * 3nprob


### PR DESCRIPTION
To improve the readability of the massive function. It may be possible to split them even further.