### PR TITLE
github: daily builds use a unique tag

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -41,7 +41,7 @@ jobs:
         if: github.event.schedule == '0 0 * * *'
         run: |
           echo "RELEASE_VERSION=master" >> $GITHUB_ENV
-          echo "IMAGE_TAG=daily-testing-only" >> $GITHUB_ENV
+          echo "IMAGE_TAG=daily-testing-$(date -u +%Y%m%d)" >> $GITHUB_ENV
 
       - name: Build and push
         id: docker_build


### PR DESCRIPTION
## Change Description

Changes the daily testing build to use a unique tag `daily-testing-<YYYYmmdd>` instead of re-using `daily-testing-only`. This provides better compatibility for image registries with immutable tags enabled.

## Steps to Test

After merging this to master, check the daily build for the new tag format in https://hub.docker.com/r/lightninglabs/lnd/tags