### PR TITLE
build: update to Go 1.18 

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,7 +24,7 @@ env:
   # /dev.Dockerfile
   # /make/builder.Dockerfile
   # /.github/workflows/release.yml
-  GO_VERSION: 1.17.3
+  GO_VERSION: 1.18
 
 jobs:
   ########################

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -16,7 +16,7 @@ env:
   # /dev.Dockerfile
   # /make/builder.Dockerfile
   # /.github/workflows/main.yml
-  GO_VERSION: 1.17.3
+  GO_VERSION: 1.18
 
 jobs:
   main:

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ go:
   # /make/builder.Dockerfile
   # /.github/workflows/main.yml
   # /.github/workflows/release.yml
-  - "1.17.x"
+  - "1.18.x"
 
 env:
   global:

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@
 # /make/builder.Dockerfile
 # /.github/workflows/main.yml
 # /.github/workflows/release.yml
-FROM golang:1.17.3-alpine as builder
+FROM golang:1.18-alpine as builder
 
 # Force Go to use the cgo based DNS resolver. This is required to ensure DNS
 # queries required to connect to linked containers succeed.

--- a/chainntnfs/bitcoindnotify/bitcoind_test.go
+++ b/chainntnfs/bitcoindnotify/bitcoind_test.go
@@ -175,7 +175,7 @@ func TestHistoricalConfDetailsTxIndex(t *testing.T) {
 	switch txStatus {
 	case chainntnfs.TxFoundMempool:
 	default:
-		t.Fatal("should have found the transaction within the "+
+		t.Fatalf("should have found the transaction within the "+
 			"mempool, but did not: %v", txStatus)
 	}
 

--- a/discovery/gossiper_test.go
+++ b/discovery/gossiper_test.go
@@ -2009,7 +2009,7 @@ func TestDeDuplicatedAnnouncements(t *testing.T) {
 	// indexes as due to the randomized order of map iteration they may be
 	// in either place.
 	if !reflect.DeepEqual(batch[2].msg, na) && !reflect.DeepEqual(batch[3].msg, na) {
-		t.Fatal("first node announcement not in last part of batch: "+
+		t.Fatalf("first node announcement not in last part of batch: "+
 			"got %v, expected %v", batch[2].msg,
 			na)
 	}

--- a/discovery/syncer_test.go
+++ b/discovery/syncer_test.go
@@ -2125,7 +2125,7 @@ func TestGossipSyncerSyncTransitions(t *testing.T) {
 		select {
 		case msgs := <-msgChan:
 			if len(msgs) != 1 {
-				t.Fatal("expected to send a single message at "+
+				t.Fatalf("expected to send a single message at "+
 					"a time, got %d", len(msgs))
 			}
 			msgSent = msgs[0]

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -93,23 +93,23 @@ following build dependencies are required:
 
 ### Installing Go
 
-`lnd` is written in Go, with a minimum version of 1.16. To install, run one of 
+`lnd` is written in Go, with a minimum version of 1.18. To install, run one of 
 the following commands for your OS:
 
 <details>
   <summary>Linux (x86-64)</summary>
   
   ```
-  wget https://dl.google.com/go/go1.17.1.linux-amd64.tar.gz
-  sha256sum go1.17.1.linux-amd64.tar.gz | awk -F " " '{ print $1 }'
+  wget https://dl.google.com/go/go1.18.linux-amd64.tar.gz
+  sha256sum go1.18.linux-amd64.tar.gz | awk -F " " '{ print $1 }'
   ```
 
   The final output of the command above should be
-  `dab7d9c34361dc21ec237d584590d72500652e7c909bf082758fb63064fca0ef`. If it
+  `e85278e98f57cdb150fe8409e6e5df5343ecb13cebf03a5d5ff12bd55a80264f`. If it
   isn't, then the target REPO HAS BEEN MODIFIED, and you shouldn't install
   this version of Go. If it matches, then proceed to install Go:
   ```
-  sudo tar -C /usr/local -xzf go1.17.1.linux-amd64.tar.gz
+  sudo tar -C /usr/local -xzf go1.18.linux-amd64.tar.gz
   export PATH=$PATH:/usr/local/go/bin
   ```
 </details>
@@ -118,12 +118,12 @@ the following commands for your OS:
   <summary>Linux (ARMv6)</summary>
   
   ```
-  wget https://dl.google.com/go/go1.17.1.linux-armv6l.tar.gz
-  sha256sum go1.17.1.linux-armv6l.tar.gz | awk -F " " '{ print $1 }'
+  wget https://dl.google.com/go/go1.18.linux-armv6l.tar.gz
+  sha256sum go1.18.linux-armv6l.tar.gz | awk -F " " '{ print $1 }'
   ```
 
   The final output of the command above should be
-  `ed3e4dbc9b80353f6482c441d65b51808290e94ff1d15d56da5f4a7be7353758`. If it
+  `a80fa43d1f4575fb030adbfbaa94acd860c6847820764eecb06c63b7c103612b`. If it
   isn't, then the target REPO HAS BEEN MODIFIED, and you shouldn't install
   this version of Go. If it matches, then proceed to install Go:
   ```

--- a/docs/release-notes/release-notes-0.15.0.md
+++ b/docs/release-notes/release-notes-0.15.0.md
@@ -150,6 +150,7 @@ then watch it on chain. Taproot script spends are also supported through the
   The `apple` task uses `gomobile` to build an `XCFramework` that can be used to
   embed lnd to both iOS and macOS apps.
 
+* [The CI and build infrastructure for the project has transitioned to using Go 1.18](https://github.com/lightningnetwork/lnd/pull/6340).
 
 ## RPC Server
 

--- a/htlcswitch/circuit_test.go
+++ b/htlcswitch/circuit_test.go
@@ -490,7 +490,7 @@ func TestCircuitMapPersistence(t *testing.T) {
 	// Removing already-removed circuit should return an error.
 	err = circuitMap.DeleteCircuits(circuit1.Incoming)
 	if err != nil {
-		t.Fatal("Unexpected failure when deleting already "+
+		t.Fatalf("Unexpected failure when deleting already "+
 			"deleted circuit: %v", err)
 	}
 

--- a/lnrpc/routerrpc/router_backend_test.go
+++ b/lnrpc/routerrpc/router_backend_test.go
@@ -203,7 +203,7 @@ func testQueryRoutes(t *testing.T, useMissionControl bool, useMsat bool,
 			route.Vertex, error) {
 
 			if chanID != 555 {
-				t.Fatal("expected endpoints to be fetched for "+
+				t.Fatalf("expected endpoints to be fetched for "+
 					"channel 555, but got %v instead",
 					chanID)
 			}

--- a/make/builder.Dockerfile
+++ b/make/builder.Dockerfile
@@ -4,7 +4,7 @@
 # /dev.Dockerfile
 # /.github/workflows/main.yml
 # /.github/workflows/release.yml
-FROM golang:1.17.3-buster
+FROM golang:1.18-buster
 
 MAINTAINER Olaoluwa Osuntokun <laolu@lightning.engineering>
 


### PR DESCRIPTION
In this PR, we update our build scripts to always use Go 1.18 which was released today. We also update the posted min Go version to 1.18, so we can use the new features packaged in this release sooner (the new fuzzing package, type params, etc). 