### PR TITLE
github: re-add rolling tag 'daily-testing-only'

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -41,7 +41,7 @@ jobs:
         if: github.event.schedule == '0 0 * * *'
         run: |
           echo "RELEASE_VERSION=master" >> $GITHUB_ENV
-          echo "IMAGE_TAG=daily-testing-$(date -u +%Y%m%d)" >> $GITHUB_ENV
+          echo "IMAGE_TAG=daily-testing-$(date -u +%Y%m%d),${DOCKER_REPO}/${DOCKER_IMAGE}:daily-testing-only" >> $GITHUB_ENV
 
       - name: Build and push
         id: docker_build

--- a/docs/DOCKER.md
+++ b/docs/DOCKER.md
@@ -53,6 +53,9 @@ You can just pull those images by specifying a release tag:
 ⛰  docker run lightninglabs/lnd [command-line options]
 ```
 
+Note that **`daily-*` tags are unstable and not for production use**.
+They are only suitable for development and pre-release testing.
+
 ### Verifying docker images
 
 To verify the `lnd` and `lncli` binaries inside the docker images against the


### PR DESCRIPTION
## Change Description

Re-adds a rolling container image tag, but this one is built and pushed on every update to `master` instead of nightly.

## Steps to Test

After merging this to master, verify that an image with the `master` tag is present in https://hub.docker.com/r/lightninglabs/lnd/tags