### PR TITLE
switch+test: fix race condition in the interceptor unit test

### DIFF
--- a/docs/release-notes/release-notes-0.15.0.md
+++ b/docs/release-notes/release-notes-0.15.0.md
@@ -101,6 +101,10 @@
 * [Make etcd leader election session
   TTL](https://github.com/lightningnetwork/lnd/pull/6342) configurable.
 
+
+* [Fix race condition in the htlc interceptor unit
+  test](https://github.com/lightningnetwork/lnd/pull/6353).
+
 ## RPC Server
 
 * [Add value to the field

--- a/htlcswitch/switch_test.go
+++ b/htlcswitch/switch_test.go
@@ -3287,7 +3287,7 @@ func TestSwitchHoldForward(t *testing.T) {
 	assertNumCircuits(t, s, 0, 0)
 	assertOutgoingLinkReceive(t, bobChannelLink, false)
 
-	require.NoError(t, switchForwardInterceptor.resolve(&FwdResolution{
+	require.NoError(t, switchForwardInterceptor.Resolve(&FwdResolution{
 		Action: FwdActionResume,
 		Key:    forwardInterceptor.getIntercepted().IncomingCircuit,
 	}))
@@ -3347,7 +3347,7 @@ func TestSwitchHoldForward(t *testing.T) {
 	assertNumCircuits(t, s, 0, 0)
 	assertOutgoingLinkReceive(t, bobChannelLink, false)
 
-	require.NoError(t, switchForwardInterceptor.resolve(&FwdResolution{
+	require.NoError(t, switchForwardInterceptor.Resolve(&FwdResolution{
 		Action:      FwdActionFail,
 		Key:         forwardInterceptor.getIntercepted().IncomingCircuit,
 		FailureCode: lnwire.CodeTemporaryChannelFailure,
@@ -3364,7 +3364,7 @@ func TestSwitchHoldForward(t *testing.T) {
 	assertOutgoingLinkReceive(t, bobChannelLink, false)
 
 	reason := lnwire.OpaqueReason([]byte{1, 2, 3})
-	require.NoError(t, switchForwardInterceptor.resolve(&FwdResolution{
+	require.NoError(t, switchForwardInterceptor.Resolve(&FwdResolution{
 		Action:         FwdActionFail,
 		Key:            forwardInterceptor.getIntercepted().IncomingCircuit,
 		FailureMessage: reason,
@@ -3385,7 +3385,7 @@ func TestSwitchHoldForward(t *testing.T) {
 	assertOutgoingLinkReceive(t, bobChannelLink, false)
 
 	code := lnwire.CodeInvalidOnionKey
-	require.NoError(t, switchForwardInterceptor.resolve(&FwdResolution{
+	require.NoError(t, switchForwardInterceptor.Resolve(&FwdResolution{
 		Action:      FwdActionFail,
 		Key:         forwardInterceptor.getIntercepted().IncomingCircuit,
 		FailureCode: code,
@@ -3413,7 +3413,7 @@ func TestSwitchHoldForward(t *testing.T) {
 	assertNumCircuits(t, s, 0, 0)
 	assertOutgoingLinkReceive(t, bobChannelLink, false)
 
-	require.NoError(t, switchForwardInterceptor.resolve(&FwdResolution{
+	require.NoError(t, switchForwardInterceptor.Resolve(&FwdResolution{
 		Key:      forwardInterceptor.getIntercepted().IncomingCircuit,
 		Action:   FwdActionSettle,
 		Preimage: preimage,
@@ -3473,7 +3473,7 @@ func TestSwitchHoldForward(t *testing.T) {
 	intercepted := forwardInterceptor.getIntercepted()
 
 	// Settle the packet.
-	require.NoError(t, switchForwardInterceptor.resolve(&FwdResolution{
+	require.NoError(t, switchForwardInterceptor.Resolve(&FwdResolution{
 		Key:      intercepted.IncomingCircuit,
 		Action:   FwdActionSettle,
 		Preimage: preimage,


### PR DESCRIPTION
Fixes:

```
==================
WARNING: DATA RACE
Read at 0x00c071c8dcb0 by goroutine 1594:
  runtime.mapiternext()
      /opt/hostedtoolcache/go/1.17.3/x64/src/runtime/map.go:851 +0x0
  github.com/lightningnetwork/lnd/htlcswitch.(*InterceptableSwitch).setInterceptor()
      /home/runner/work/lnd/lnd/htlcswitch/interceptable_switch.go:205 +0x3b8
  github.com/lightningnetwork/lnd/htlcswitch.(*InterceptableSwitch).run()
      /home/runner/work/lnd/lnd/htlcswitch/interceptable_switch.go:161 +0x20a
  github.com/lightningnetwork/lnd/htlcswitch.(*InterceptableSwitch).Start.func1()
      /home/runner/work/lnd/lnd/htlcswitch/interceptable_switch.go:143 +0x76

Previous write at 0x00c071c8dcb0 by goroutine 103:
  runtime.mapdelete()
      /opt/hostedtoolcache/go/1.17.3/x64/src/runtime/map.go:685 +0x0
  github.com/lightningnetwork/lnd/htlcswitch.(*InterceptableSwitch).resolve()
      /home/runner/work/lnd/lnd/htlcswitch/interceptable_switch.go:236 +0xea
  github.com/lightningnetwork/lnd/htlcswitch.TestSwitchHoldForward()
      /home/runner/work/lnd/lnd/htlcswitch/switch_test.go:3476 +0x2d84
  testing.tRunner()
      /opt/hostedtoolcache/go/1.17.3/x64/src/testing/testing.go:1259 +0x22f
  testing.(*T).Run·dwrap·21()
      /opt/hostedtoolcache/go/1.17.3/x64/src/testing/testing.go:1306 +0x47

Goroutine 1594 (running) created at:
  github.com/lightningnetwork/lnd/htlcswitch.(*InterceptableSwitch).Start()
      /home/runner/work/lnd/lnd/htlcswitch/interceptable_switch.go:140 +0xa4
  github.com/lightningnetwork/lnd/htlcswitch.TestSwitchHoldForward()
      /home/runner/work/lnd/lnd/htlcswitch/switch_test.go:3429 +0x2868
  testing.tRunner()
      /opt/hostedtoolcache/go/1.17.3/x64/src/testing/testing.go:1259 +0x22f
  testing.(*T).Run·dwrap·21()
      /opt/hostedtoolcache/go/1.17.3/x64/src/testing/testing.go:1306 +0x47

Goroutine 103 (running) created at:
  testing.(*T).Run()
      /opt/hostedtoolcache/go/1.17.3/x64/src/testing/testing.go:1306 +0x726
  testing.runTests.func1()
      /opt/hostedtoolcache/go/1.17.3/x64/src/testing/testing.go:1598 +0x99
  testing.tRunner()
      /opt/hostedtoolcache/go/1.17.3/x64/src/testing/testing.go:1259 +0x22f
  testing.runTests()
      /opt/hostedtoolcache/go/1.17.3/x64/src/testing/testing.go:1596 +0x7ca
  testing.(*M).Run()
      /opt/hostedtoolcache/go/1.17.3/x64/src/testing/testing.go:1504 +0x9d1
  main.main()
      _testmain.go:245 +0x22b
==================
--- FAIL: TestSwitchHoldForward (13.53s)
    testing.go:1152: race detected during execution of test
--- FAIL: TestChannelLinkCancelFullCommitment (122.80s)
    testing.go:1152: race detected during execution of test
FAIL
FAIL	github.com/lightningnetwork/lnd/htlcswitch	218.652s
FAIL```