### PR TITLE
chainview: fix unit test timeout

### DIFF
--- a/docs/release-notes/release-notes-0.15.0.md
+++ b/docs/release-notes/release-notes-0.15.0.md
@@ -176,7 +176,11 @@ then watch it on chain. Taproot script spends are also supported through the
 * [The CI and build infrastructure for the project has transitioned to using Go 1.18](https://github.com/lightningnetwork/lnd/pull/6340).
 
 * [Announce the keysend feature bit in NodeAnnouncement if `--accept-keysend` 
-  is set](https://github.com/lightningnetwork/lnd/pull/6414)
+  is set](https://github.com/lightningnetwork/lnd/pull/6414).
+
+* [Fix a flaky unit test in the `chainview`
+  package](https://github.com/lightningnetwork/lnd/pull/6354).
+
 
 ## RPC Server
 

--- a/routing/chainview/interface_test.go
+++ b/routing/chainview/interface_test.go
@@ -547,6 +547,14 @@ func testFilterBlockDisconnected(node *rpctest.Harness,
 	}
 	defer reorgNode.TearDown()
 
+	// We want to overwrite some of the connection settings to make the
+	// tests more robust. We might need to restart the backend while there
+	// are already blocks present, which will take a bit longer than the
+	// 1 second the default settings amount to. Doubling both values will
+	// give us retries up to 4 seconds.
+	reorgNode.MaxConnRetries = rpctest.DefaultMaxConnectionRetries * 2
+	reorgNode.ConnectionRetryTimeout = rpctest.DefaultConnectionRetryTimeout * 2
+
 	// This node's chain will be 105 blocks.
 	if err := reorgNode.SetUp(true, 5); err != nil {
 		t.Fatalf("unable to set up mining node: %v", err)

--- a/routing/chainview/interface_test.go
+++ b/routing/chainview/interface_test.go
@@ -553,8 +553,9 @@ func testFilterBlockDisconnected(node *rpctest.Harness,
 	}
 
 	// Init a chain view that has this node as its block source.
-	cleanUpFunc, reorgView, err := chainViewInit(reorgNode.RPCConfig(),
-		reorgNode.P2PAddress())
+	cleanUpFunc, reorgView, err := chainViewInit(
+		reorgNode.RPCConfig(), reorgNode.P2PAddress(),
+	)
 	if err != nil {
 		t.Fatalf("unable to create chain view: %v", err)
 	}
@@ -775,7 +776,9 @@ var interfaceImpls = []struct {
 }{
 	{
 		name: "bitcoind_zmq",
-		chainViewInit: func(_ rpcclient.ConnConfig, p2pAddr string) (func(), FilteredChainView, error) {
+		chainViewInit: func(_ rpcclient.ConnConfig,
+			p2pAddr string) (func(), FilteredChainView, error) {
+
 			// Start a bitcoind instance.
 			tempBitcoindDir, err := ioutil.TempDir("", "bitcoind")
 			if err != nil {
@@ -855,7 +858,9 @@ var interfaceImpls = []struct {
 	},
 	{
 		name: "p2p_neutrino",
-		chainViewInit: func(_ rpcclient.ConnConfig, p2pAddr string) (func(), FilteredChainView, error) {
+		chainViewInit: func(_ rpcclient.ConnConfig,
+			p2pAddr string) (func(), FilteredChainView, error) {
+
 			spvDir, err := ioutil.TempDir("", "neutrino")
 			if err != nil {
 				return nil, nil, err
@@ -908,7 +913,9 @@ var interfaceImpls = []struct {
 	},
 	{
 		name: "btcd_websockets",
-		chainViewInit: func(config rpcclient.ConnConfig, _ string) (func(), FilteredChainView, error) {
+		chainViewInit: func(config rpcclient.ConnConfig,
+			_ string) (func(), FilteredChainView, error) {
+
 			blockCache := blockcache.NewBlockCache(10000)
 			chainView, err := NewBtcdFilteredChainView(
 				config, blockCache,
@@ -943,7 +950,9 @@ func TestFilteredChainView(t *testing.T) {
 		t.Logf("Testing '%v' implementation of FilteredChainView",
 			chainViewImpl.name)
 
-		cleanUpFunc, chainView, err := chainViewImpl.chainViewInit(rpcConfig, p2pAddr)
+		cleanUpFunc, chainView, err := chainViewImpl.chainViewInit(
+			rpcConfig, p2pAddr,
+		)
 		if err != nil {
 			t.Fatalf("unable to make chain view: %v", err)
 		}
@@ -955,8 +964,10 @@ func TestFilteredChainView(t *testing.T) {
 			testName := fmt.Sprintf("%v: %v", chainViewImpl.name,
 				chainViewTest.name)
 			success := t.Run(testName, func(t *testing.T) {
-				chainViewTest.test(miner, chainView,
-					chainViewImpl.chainViewInit, t)
+				chainViewTest.test(
+					miner, chainView,
+					chainViewImpl.chainViewInit, t,
+				)
 			})
 
 			if !success {


### PR DESCRIPTION
Depends on #6353.

Attempts to fix this flake in the postgres unit test:
```
 --- FAIL: TestFilteredChainView (20.34s)
    interface_test.go:943: Testing 'bitcoind_zmq' implementation of FilteredChainView
    interface_test.go:943: Testing 'p2p_neutrino' implementation of FilteredChainView
    interface_test.go:943: Testing 'btcd_websockets' implementation of FilteredChainView
    --- FAIL: TestFilteredChainView/btcd_websockets:_filter_block_disconnected (9.53s)
        interface_test.go:552: unable to set up mining node: connection timeout
FAIL
FAIL	github.com/lightningnetwork/lnd/routing/chainview	20.362s
FAIL
```