### PR TITLE
lnd: disable REST proxy HTTP method fallback

### DIFF
--- a/docs/release-notes/release-notes-0.14.3.md
+++ b/docs/release-notes/release-notes-0.14.3.md
@@ -1,0 +1,13 @@
+# Release Notes
+
+## Bug fixes
+
+* The REST proxy (`grpc-gateway` library) had a fallback that redirected `POST`
+  requests to another endpoint _with the same URI_ if no endpoint for `POST` was
+  registered. [This default behavior was turned
+  off](https://github.com/lightningnetwork/lnd/pull/6359), enabling strict
+  HTTP method matching.
+
+# Contributors (Alphabetical Order)
+
+* Oliver Gugger

--- a/lnd.go
+++ b/lnd.go
@@ -973,7 +973,16 @@ func startRestProxy(cfg *Config, rpcServer *rpcServer, restDialOpts []grpc.DialO
 			},
 		},
 	)
-	mux := proxy.NewServeMux(customMarshalerOption)
+	mux := proxy.NewServeMux(
+		customMarshalerOption,
+
+		// Don't allow falling back to other HTTP methods, we want exact
+		// matches only. The actual method to be used can be overwritten
+		// by setting X-HTTP-Method-Override so there should be no
+		// reason for not specifying the correct method in the first
+		// place.
+		proxy.WithDisablePathLengthFallback(),
+	)
 
 	// Register our services with the REST proxy.
 	err := lnrpc.RegisterStateHandlerFromEndpoint(


### PR DESCRIPTION
It turns out that when a REST call to an endpoint (in this specific
example /v1/payments, which for GET returns all payments but for DELETE
removes all payments) is made with POST instead of the correct
registered method, the grpc-gateway tried to find a fallback method.
That resulted in randomly choosing between any of the calls with the
same URI pattern.
This is of course catasrophic if the user attempts to query the list of
payments (but using POST instead of GET by accident) and then ending up
calling the DELETE endpoint instead.

## Change Description

Turn off fallback mechanis

## Steps to Test

To reproduce:
```
curl -d '{"num_max_payments": 1000000, "start_time": 0}' -X POST -k --header "$MACAROON_HEADER" https://localhost:8080/v1/payments
```

This will randomly call `ListPayments` or `DeleteAllPayments`.

After this fix, the error `{"code":12, "message":"Method Not Allowed", "details":[]}` is returned instead.

Thank you @bitromortac for reporting the problem!