### PR TITLE
itest: fix node shutdown in interceptor itests

### DIFF
--- a/docs/release-notes/release-notes-0.15.0.md
+++ b/docs/release-notes/release-notes-0.15.0.md
@@ -55,6 +55,8 @@
   party sweeps our anchor
   output](https://github.com/lightningnetwork/lnd/pull/6274).
 
+* [Fixed node shutdown in forward interceptor itests](https://github.com/lightningnetwork/lnd/pull/6362).
+
 ## Misc
 
 * [An example systemd service file](https://github.com/lightningnetwork/lnd/pull/6033)

--- a/lntest/itest/lnd_forward_interceptor_test.go
+++ b/lntest/itest/lnd_forward_interceptor_test.go
@@ -41,10 +41,10 @@ func testForwardInterceptorDedupHtlc(net *lntest.NetworkHarness, t *harnessTest)
 	defer shutdownAndAssert(net, t, alice)
 
 	bob := net.NewNode(t.t, "bob", nil)
-	defer shutdownAndAssert(net, t, alice)
+	defer shutdownAndAssert(net, t, bob)
 
 	carol := net.NewNode(t.t, "carol", nil)
-	defer shutdownAndAssert(net, t, alice)
+	defer shutdownAndAssert(net, t, carol)
 
 	tc := newInterceptorTestContext(t, net, alice, bob, carol)
 
@@ -210,10 +210,10 @@ func testForwardInterceptorBasic(net *lntest.NetworkHarness, t *harnessTest) {
 	defer shutdownAndAssert(net, t, alice)
 
 	bob := net.NewNode(t.t, "bob", nil)
-	defer shutdownAndAssert(net, t, alice)
+	defer shutdownAndAssert(net, t, bob)
 
 	carol := net.NewNode(t.t, "carol", nil)
-	defer shutdownAndAssert(net, t, alice)
+	defer shutdownAndAssert(net, t, carol)
 
 	testContext := newInterceptorTestContext(t, net, alice, bob, carol)
 


### PR DESCRIPTION
Don't shut down the same test node multiple times.