### PR TITLE
mobile: Add macos and apple Makefile tasks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -299,7 +299,7 @@ vendor:
 	rm -r vendor/; go mod vendor
 
 ios: vendor mobile-rpc
-	@$(call print, "Building iOS framework ($(IOS_BUILD)).")
+	@$(call print, "Building iOS cxframework ($(IOS_BUILD)).")
 	mkdir -p $(IOS_BUILD_DIR)
 	$(GOMOBILE_BIN) bind -target=ios -tags="mobile $(DEV_TAGS) autopilotrpc" $(LDFLAGS) -v -o $(IOS_BUILD) $(MOBILE_PKG)
 

--- a/Makefile
+++ b/Makefile
@@ -303,6 +303,11 @@ ios: vendor mobile-rpc
 	mkdir -p $(IOS_BUILD_DIR)
 	$(GOMOBILE_BIN) bind -target=ios -tags="mobile $(DEV_TAGS) autopilotrpc" $(LDFLAGS) -v -o $(IOS_BUILD) $(MOBILE_PKG)
 
+macos: vendor mobile-rpc
+	@$(call print, "Building macOS cxframework ($(IOS_BUILD)).")
+	mkdir -p $(IOS_BUILD_DIR)
+	$(GOMOBILE_BIN) bind -target=macos -tags="mobile $(DEV_TAGS) autopilotrpc" $(LDFLAGS) -v -o $(IOS_BUILD) $(MOBILE_PKG)
+
 android: vendor mobile-rpc
 	@$(call print, "Building Android library ($(ANDROID_BUILD)).")
 	mkdir -p $(ANDROID_BUILD_DIR)

--- a/Makefile
+++ b/Makefile
@@ -298,6 +298,11 @@ vendor:
 	@$(call print, "Re-creating vendor directory.")
 	rm -r vendor/; go mod vendor
 
+apple: vendor mobile-rpc
+	@$(call print, "Building iOS and macOS cxframework ($(IOS_BUILD)).")
+	mkdir -p $(IOS_BUILD_DIR)
+	$(GOMOBILE_BIN) bind -target=ios,iossimulator,macos -tags="mobile $(DEV_TAGS) autopilotrpc" $(LDFLAGS) -v -o $(IOS_BUILD) $(MOBILE_PKG)
+
 ios: vendor mobile-rpc
 	@$(call print, "Building iOS cxframework ($(IOS_BUILD)).")
 	mkdir -p $(IOS_BUILD_DIR)

--- a/Makefile
+++ b/Makefile
@@ -306,7 +306,7 @@ apple: vendor mobile-rpc
 ios: vendor mobile-rpc
 	@$(call print, "Building iOS cxframework ($(IOS_BUILD)).")
 	mkdir -p $(IOS_BUILD_DIR)
-	$(GOMOBILE_BIN) bind -target=ios -tags="mobile $(DEV_TAGS) autopilotrpc" $(LDFLAGS) -v -o $(IOS_BUILD) $(MOBILE_PKG)
+	$(GOMOBILE_BIN) bind -target=ios,iossimulator -tags="mobile $(DEV_TAGS) autopilotrpc" $(LDFLAGS) -v -o $(IOS_BUILD) $(MOBILE_PKG)
 
 macos: vendor mobile-rpc
 	@$(call print, "Building macOS cxframework ($(IOS_BUILD)).")

--- a/docs/release-notes/release-notes-0.15.0.md
+++ b/docs/release-notes/release-notes-0.15.0.md
@@ -120,6 +120,15 @@ then watch it on chain. Taproot script spends are also supported through the
   specifies the maximum duration it allows for a remote peer to respond to a
   locally initiated commitment update.
 
+* [`macos` and `apple` Makefile tasks have been added.](https://github.com/lightningnetwork/lnd/pull/6373)
+
+  The `macos` task uses `gomobile` to build an `XCFramework` that can be used to
+  embed lnd to macOS apps, similar to how the `ios` task builds for iOS.
+
+  The `apple` task uses `gomobile` to build an `XCFramework` that can be used to
+  embed lnd to both iOS and macOS apps.
+
+
 ## RPC Server
 
 * [Add value to the field
@@ -213,6 +222,7 @@ gRPC performance metrics (latency to process `GetInfo`, etc)](https://github.com
 * Daniel McNally
 * ErikEk
 * Eugene Siegel
+* Hampus Sjöberg
 * henta
 * Joost Jager
 * Jordi Montes


### PR DESCRIPTION
Hey.

This PR adds two new gomobile related Makefile tasks:
`macos` task: compiles lnd to an XCFramework that can then be embedded into macOS apps.
`apple` task: compiles lnd to an XCFramework that can then be embedded into both iOS and macOS apps.  

I've also updated the `ios` task to build for iOS simulator too.

I separated the commits for clarity, could probably be squashed into master.