### PR TITLE
btcwallet: always make sure default scopes exist

### DIFF
--- a/docs/release-notes/release-notes-0.15.0.md
+++ b/docs/release-notes/release-notes-0.15.0.md
@@ -68,6 +68,10 @@ then watch it on chain. Taproot script spends are also supported through the
 
 * [Fixed a bug that would cause lnd to be unable to parse certain PSBT blobs](https://github.com/lightningnetwork/lnd/pull/6383).
 
+* [Fixed a bug in the `btcwallet` that caused an error to be shown for
+  `lncli walletbalance` in existing wallets after upgrading to
+  Taproot](https://github.com/lightningnetwork/lnd/pull/6379).
+
 ## Misc
 
 * [An example systemd service file](https://github.com/lightningnetwork/lnd/pull/6033)


### PR DESCRIPTION
## Change Description

If new default scopes are added to the underlying btcwallet
implementation, then they aren't automatically created for _existing_
wallets, only for new ones. So on startup we need to make sure all
scopes are present.

Fixes https://github.com/lightningnetwork/lnd/issues/6377.


## Steps to Test

1. Create a regtest wallet with `lnd v0.14.2-beta`
2. Upgrade to `master`
3. Start `lnd` and then run `lncli walletbalance`
4. The wallet balance should show, no error should be shown

