### PR TITLE
lnrpc: fix websocket proxy data race

### DIFF
--- a/docs/release-notes/release-notes-0.15.0.md
+++ b/docs/release-notes/release-notes-0.15.0.md
@@ -72,6 +72,9 @@ then watch it on chain. Taproot script spends are also supported through the
   `lncli walletbalance` in existing wallets after upgrading to
   Taproot](https://github.com/lightningnetwork/lnd/pull/6379).
 
+* [Fixed a data race in the websocket proxy
+  code](https://github.com/lightningnetwork/lnd/pull/6380).
+
 ## Misc
 
 * [An example systemd service file](https://github.com/lightningnetwork/lnd/pull/6033)

--- a/lnrpc/websocket_proxy.go
+++ b/lnrpc/websocket_proxy.go
@@ -253,7 +253,7 @@ func (p *WebsocketProxy) upgradeToWebSocketProxy(w http.ResponseWriter,
 				payload = newPayload
 			}
 
-			_, err = requestForwarder.Write(payload)
+			_, err := requestForwarder.Write(payload)
 			if err != nil {
 				p.logger.Errorf("WS: error writing message "+
 					"to upstream http server: %v", err)
@@ -338,7 +338,7 @@ func (p *WebsocketProxy) upgradeToWebSocketProxy(w http.ResponseWriter,
 			continue
 		}
 
-		err = conn.WriteMessage(
+		err := conn.WriteMessage(
 			websocket.TextMessage, responseForwarder.Bytes(),
 		)
 		if err != nil {


### PR DESCRIPTION
Was discovered in a race unit test in lightning node connect that uses
the websocket proxy to connect to the hashmail server on the client
side.
By not shadowing the err variable we end up reading and writing to the
same variable from two different goroutines, which causes the data race.
