### PR TITLE
cmd/lncli: fix linter issues after contributor PR [skip ci]

### DIFF
--- a/cmd/lncli/commands.go
+++ b/cmd/lncli/commands.go
@@ -101,10 +101,10 @@ func actionDecorator(f func(*cli.Context) error) func(*cli.Context) error {
 			// two commands.
 			if s.Code() == codes.Unimplemented &&
 				(c.Command.Name == "create" ||
-					c.Command.Name == "unlock" || 
+					c.Command.Name == "unlock" ||
 					c.Command.Name == "changepassword" ||
 					c.Command.Name == "createwatchonly") {
-					
+
 				return fmt.Errorf("Wallet is already unlocked")
 			}
 


### PR DESCRIPTION
Fixes linter issue that was merged with a contributor PR that had the `[skip ci]` suffix. I guess we shouldn't allow that for new contributors if actual code is changed.

I confirmed locally that the linter doesn't complain anymore.