### PR TITLE
signrpc: fix panic with missing UTXO information when signing Taproot output

### DIFF
--- a/docs/release-notes/release-notes-0.15.0.md
+++ b/docs/release-notes/release-notes-0.15.0.md
@@ -84,6 +84,10 @@ then watch it on chain. Taproot script spends are also supported through the
 * [Fixed race condition resulting in MPP payments sometimes getting stuck
   in-flight](https://github.com/lightningnetwork/lnd/pull/6352).
 
+* [Fixed a panic in the Taproot signing part of the `SignOutputRaw` RPC that
+  occurred when not all UTXO information was
+  specified](https://github.com/lightningnetwork/lnd/pull/6407).
+
 ## Misc
 
 * [An example systemd service file](https://github.com/lightningnetwork/lnd/pull/6033)

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -2539,6 +2539,7 @@ func createRPCCloseUpdate(update interface{}) (
 			Update: &lnrpc.CloseStatusUpdate_ChanClose{
 				ChanClose: &lnrpc.ChannelCloseUpdate{
 					ClosingTxid: u.ClosingTxid,
+					Success:     u.Success,
 				},
 			},
 		}, nil


### PR DESCRIPTION
## Change Description
Fixes https://github.com/lightningnetwork/lnd/issues/6396.

Also fixes a value that wasn't copied to the RPC counterpart.