### PR TITLE
multi: announce Keysend feature bit

### DIFF
--- a/docs/release-notes/release-notes-0.15.0.md
+++ b/docs/release-notes/release-notes-0.15.0.md
@@ -172,6 +172,9 @@ then watch it on chain. Taproot script spends are also supported through the
 
 * [The CI and build infrastructure for the project has transitioned to using Go 1.18](https://github.com/lightningnetwork/lnd/pull/6340).
 
+* [Announce the keysend feature bit in NodeAnnouncement if `--accept-keysend` 
+  is set](https://github.com/lightningnetwork/lnd/pull/6414)
+
 ## RPC Server
 
 * [Add value to the field

--- a/feature/default_sets.go
+++ b/feature/default_sets.go
@@ -64,6 +64,9 @@ var defaultSetDesc = setDesc{
 		SetInit:    {}, // I
 		SetNodeAnn: {}, // N
 	},
+	lnwire.KeysendOptional: {
+		SetNodeAnn: {}, // N
+	},
 	lnwire.ScriptEnforcedLeaseOptional: {
 		SetInit:    {}, // I
 		SetNodeAnn: {}, // N

--- a/feature/deps.go
+++ b/feature/deps.go
@@ -69,6 +69,9 @@ var deps = depDesc{
 		lnwire.ExplicitChannelTypeOptional:  {},
 		lnwire.AnchorsZeroFeeHtlcTxOptional: {},
 	},
+	lnwire.KeysendOptional: {
+		lnwire.TLVOnionPayloadOptional: {},
+	},
 }
 
 // ValidateDeps asserts that a feature vector sets all features and their

--- a/feature/manager.go
+++ b/feature/manager.go
@@ -27,6 +27,10 @@ type Config struct {
 	// NoScriptEnforcementLease unsets any bits signaling support for script
 	// enforced leases.
 	NoScriptEnforcementLease bool
+
+	// NoKeysend unsets any bits signaling support for accepting keysend
+	// payments.
+	NoKeysend bool
 }
 
 // Manager is responsible for generating feature vectors for different requested
@@ -83,6 +87,8 @@ func newManager(cfg Config, desc setDesc) (*Manager, error) {
 			raw.Unset(lnwire.MPPRequired)
 			raw.Unset(lnwire.AMPOptional)
 			raw.Unset(lnwire.AMPRequired)
+			raw.Unset(lnwire.KeysendOptional)
+			raw.Unset(lnwire.KeysendRequired)
 		}
 		if cfg.NoStaticRemoteKey {
 			raw.Unset(lnwire.StaticRemoteKeyOptional)
@@ -114,6 +120,10 @@ func newManager(cfg Config, desc setDesc) (*Manager, error) {
 		if cfg.NoScriptEnforcementLease {
 			raw.Unset(lnwire.ScriptEnforcedLeaseOptional)
 			raw.Unset(lnwire.ScriptEnforcedLeaseRequired)
+		}
+		if cfg.NoKeysend {
+			raw.Unset(lnwire.KeysendOptional)
+			raw.Unset(lnwire.KeysendRequired)
 		}
 
 		// Ensure that all of our feature sets properly set any

--- a/lnwire/features.go
+++ b/lnwire/features.go
@@ -165,7 +165,15 @@ const (
 	// htlc(s).
 	PaymentMetadataOptional = 49
 
-	// ScriptEnforcedLeaseOptional is an optional feature bit that signals
+	// KeysendRequired is a required bit that indicates that the node is
+	// able and willing to accept keysend payments.
+	KeysendRequired = 54
+
+	// KeysendOptional is an optional bit that indicates that the node is
+	// able and willing to accept keysend payments.
+	KeysendOptional = 55
+
+	// ScriptEnforcedLeaseRequired is a required feature bit that signals
 	// that the node requires channels having zero-fee second-level HTLC
 	// transactions, which also imply anchor commitments, along with an
 	// additional CLTV constraint of a channel lease's expiration height
@@ -174,7 +182,7 @@ const (
 	// TODO: Decide on actual feature bit value.
 	ScriptEnforcedLeaseRequired FeatureBit = 2022
 
-	// ScriptEnforcedLeaseOptional is a required feature bit that signals
+	// ScriptEnforcedLeaseOptional is an optional feature bit that signals
 	// that the node requires channels having zero-fee second-level HTLC
 	// transactions, which also imply anchor commitments, along with an
 	// additional CLTV constraint of a channel lease's expiration height
@@ -232,6 +240,8 @@ var Features = map[FeatureBit]string{
 	PaymentMetadataRequired:       "payment-metadata",
 	ExplicitChannelTypeOptional:   "explicit-commitment-type",
 	ExplicitChannelTypeRequired:   "explicit-commitment-type",
+	KeysendOptional:               "keysend",
+	KeysendRequired:               "keysend",
 	ScriptEnforcedLeaseRequired:   "script-enforced-lease",
 	ScriptEnforcedLeaseOptional:   "script-enforced-lease",
 }

--- a/server.go
+++ b/server.go
@@ -529,6 +529,7 @@ func newServer(cfg *Config, listenAddrs []net.Addr,
 		NoAnchors:                cfg.ProtocolOptions.NoAnchorCommitments(),
 		NoWumbo:                  !cfg.ProtocolOptions.Wumbo(),
 		NoScriptEnforcementLease: cfg.ProtocolOptions.NoScriptEnforcementLease(),
+		NoKeysend:                !cfg.AcceptKeySend,
 	})
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
In this commit, we add the keysend feature bit to our NodeAnnouncement
if the accept-keysend option is set.

Fixes #5044 

Note that since many nodes out there currently support keysend without signalling for the feature bit, I think we should (for now at least) not require the optional feature bit before sending a keyspend payment to the peer. This mimics CL's behaviour too: https://github.com/ElementsProject/lightning/commit/8252ac5a6e1a382b6fd68b0fc429dd517c811889

When majority of nodes start announcing the bit, we can make this more strict in order to not unnecessarily lock up liquidity