### PR TITLE
channeldb+invoices: refactor invoice logic when updating

### DIFF
--- a/docs/release-notes/release-notes-0.15.0.md
+++ b/docs/release-notes/release-notes-0.15.0.md
@@ -248,6 +248,8 @@ from occurring that would result in an erroneous force close.](https://github.co
   the in-memory state to be cleaned up early if a session isn't expected to
   succeed anymore](https://github.com/lightningnetwork/lnd/pull/6495).
 
+* [Some of the invoice update logic has been refactored to be less verbose.](https://github.com/lightningnetwork/lnd/pull/6415)
+
 ## RPC Server
 
 * [Add value to the field

--- a/invoices/update.go
+++ b/invoices/update.go
@@ -227,6 +227,10 @@ func updateMpp(ctx *invoiceUpdateCtx,
 		return nil, ctx.failRes(ResultExpiryTooSoon), nil
 	}
 
+	if setID != nil && *setID == channeldb.BlankPayAddr {
+		return nil, ctx.failRes(ResultAmpError), nil
+	}
+
 	// Record HTLC in the invoice database.
 	newHtlcs := map[channeldb.CircuitKey]*channeldb.HtlcAcceptDesc{
 		ctx.circuitKey: acceptDesc,


### PR DESCRIPTION
Noticed some things to tidy up here. The AMP copy is added to be consistent with the other invoice copying and can be used in a later PR to surface this information at the rpc layer.