### PR TITLE
Return `FEE_INSUFFICIENT` before checking balance for incoming low-fee HTLCs

### DIFF
--- a/docs/release-notes/release-notes-0.16.0.md
+++ b/docs/release-notes/release-notes-0.16.0.md
@@ -1,0 +1,10 @@
+# Release Notes
+
+## Misc
+
+* [Return `FEE_INSUFFICIENT` before checking balance for incoming low-fee
+  HTLCs.](https://github.com/lightningnetwork/lnd/pull/6417).
+
+# Contributors (Alphabetical Order)
+
+* Tommy Volk

--- a/htlcswitch/link.go
+++ b/htlcswitch/link.go
@@ -2404,24 +2404,17 @@ func (l *channelLink) CheckHtlcForward(payHash [32]byte,
 	policy := l.cfg.FwrdingPolicy
 	l.RUnlock()
 
-	// First check whether the outgoing htlc satisfies the channel policy.
-	err := l.canSendHtlc(
-		policy, payHash, amtToForward, outgoingTimeout, heightNow,
-	)
-	if err != nil {
-		return err
-	}
-
-	// Next, using the amount of the incoming HTLC, we'll calculate the
-	// expected fee this incoming HTLC must carry in order to satisfy the
-	// constraints of the outgoing link.
+	// Using the amount of the incoming HTLC, we'll calculate the expected
+	// fee this incoming HTLC must carry in order to satisfy the constraints
+	// of the outgoing link.
 	expectedFee := ExpectedFee(policy, amtToForward)
 
 	// If the actual fee is less than our expected fee, then we'll reject
 	// this HTLC as it didn't provide a sufficient amount of fees, or the
 	// values have been tampered with, or the send used incorrect/dated
 	// information to construct the forwarding information for this hop. In
-	// any case, we'll cancel this HTLC.
+	// any case, we'll cancel this HTLC. We're checking for this case first
+	// to prevent any information from leaking through 0-fee channel probing.
 	actualFee := incomingHtlcAmt - amtToForward
 	if incomingHtlcAmt < amtToForward || actualFee < expectedFee {
 		l.log.Warnf("outgoing htlc(%x) has insufficient fee: "+
@@ -2438,6 +2431,14 @@ func (l *channelLink) CheckHtlcForward(payHash [32]byte,
 			},
 		)
 		return NewLinkError(failure)
+	}
+
+	// Check whether the outgoing htlc satisfies the channel policy.
+	err := l.canSendHtlc(
+		policy, payHash, amtToForward, outgoingTimeout, heightNow,
+	)
+	if err != nil {
+		return err
 	}
 
 	// Finally, we'll ensure that the time-lock on the outgoing HTLC meets

--- a/htlcswitch/link_test.go
+++ b/htlcswitch/link_test.go
@@ -5630,6 +5630,14 @@ func TestCheckHtlcForward(t *testing.T) {
 		}
 	})
 
+	t.Run("insufficient fee and insufficient channel balance", func(t *testing.T) {
+		result := link.CheckHtlcForward(hash, 100005, 100000,
+			200, 150, 0)
+		if _, ok := result.WireMessage().(*lnwire.FailFeeInsufficient); !ok {
+			t.Fatalf("expected FailFeeInsufficient failure code")
+		}
+	})
+
 	t.Run("expiry too soon", func(t *testing.T) {
 		result := link.CheckHtlcForward(hash, 1500, 1000,
 			200, 150, 190)


### PR DESCRIPTION
## Change Description
Incoming HTLCs with lower-than-advertised fees are rejected before checking if the channel balance is sufficient to route the payment. This helps to prevent channel probing.

Fixes #5721.

## Steps to Test
Undoing the changes in `link.go` (basically moving the call to `canSendHtlc` above `if incomingHtlcAmt < amtToForward || actualFee < expectedFee ...`) should cause the new test in `link_test.go` to fail.