### PR TITLE
peer: allow restart during cooperative close

### DIFF
--- a/docs/release-notes/release-notes-0.15.0.md
+++ b/docs/release-notes/release-notes-0.15.0.md
@@ -108,6 +108,9 @@ then watch it on chain. Taproot script spends are also supported through the
 * [Fixed incorrect PSBT de-serialization for transactions with no
   inputs](https://github.com/lightningnetwork/lnd/pull/6428).
 
+* [Fixed a spec-compliance issue where lnd was not allowing cooperative
+close to continue after a peer disconnect](https://github.com/lightningnetwork/lnd/pull/6419).
+
 ## Routing
 
 * [Add a new `time_pref` parameter to the QueryRoutes and SendPayment APIs](https://github.com/lightningnetwork/lnd/pull/6024) that

--- a/lnwallet/chancloser/chancloser.go
+++ b/lnwallet/chancloser/chancloser.go
@@ -483,6 +483,10 @@ func (c *ChanCloser) ProcessCloseMsg(msg lnwire.Message) ([]lnwire.Message,
 			feeProposal := calcCompromiseFee(c.chanPoint, c.idealFeeSat,
 				c.lastFeeProposal, remoteProposedFee,
 			)
+			if feeProposal > c.idealFeeSat*3 {
+				return nil, false, fmt.Errorf("couldn't find" +
+					" compromise fee")
+			}
 
 			// With our new fee proposal calculated, we'll craft a new close
 			// signed signature to send to the other party so we can continue

--- a/peer/brontide.go
+++ b/peer/brontide.go
@@ -60,11 +60,6 @@ const (
 	// message.
 	handshakeTimeout = 15 * time.Second
 
-	// outgoingQueueLen is the buffer size of the channel which houses
-	// messages to be sent across the wire, requested by objects outside
-	// this struct.
-	outgoingQueueLen = 50
-
 	// ErrorBufferSize is the number of historic peer errors that we store.
 	ErrorBufferSize = 10
 )
@@ -348,7 +343,7 @@ type Config struct {
 // several helper goroutines to handle events such as HTLC timeouts, new
 // funding workflow, and detecting an uncooperative closure of any active
 // channels.
-// TODO(roasbeef): proper reconnection logic
+// TODO(roasbeef): proper reconnection logic.
 type Brontide struct {
 	// MUST be used atomically.
 	started    int32
@@ -709,6 +704,7 @@ func (p *Brontide) loadActiveChannels(chans []*channeldb.OpenChannel) (
 			if dbChan.HasChanStatus(
 				channeldb.ChanStatusCoopBroadcasted,
 			) {
+
 				shutdownMsg, err := p.restartCoopClose(lnChan)
 				if err != nil {
 					peerLog.Errorf("Unable to restart "+
@@ -1055,7 +1051,7 @@ func (p *Brontide) readNextMessage() (lnwire.Message, error) {
 // delivered via closure to a receiver. These messages MUST be in order due to
 // the nature of the lightning channel commitment and gossiper state machines.
 // TODO(conner): use stream handler interface to abstract out stream
-// state/logging
+// state/logging.
 type msgStream struct {
 	streamShutdown int32 // To be used atomically.
 
@@ -2664,7 +2660,6 @@ func (p *Brontide) handleLocalCloseReq(req *htlcswitch.ChanClose) {
 	}
 
 	switch req.CloseType {
-
 	// A type of CloseRegular indicates that the user has opted to close
 	// out this channel on-chain, so we execute the cooperative channel
 	// closure workflow.
@@ -2924,7 +2919,6 @@ func (p *Brontide) finalizeChanClosure(chanCloser *chancloser.ChanCloser) {
 
 	go WaitForChanToClose(chanCloser.NegotiationHeight(), notifier, errChan,
 		chanPoint, &closingTxid, closingTx.TxOut[0].PkScript, func() {
-
 			// Respond to the local subsystem which requested the
 			// channel closure.
 			if closeReq != nil {


### PR DESCRIPTION
Fixes https://github.com/lightningnetwork/lnd/issues/4819

Fixes https://github.com/lightningnetwork/lnd/issues/6458

This is done by checking if a cooperative close transaction exists in the database and the channel has the CoopBroadcasted status flag. Most of it is actually a refactor to de-dupe some code. There is one downside to this change:
- If we go down after sending ClosingSigned and the counter-party receives it and broadcasts the coop close txn, on restart we will populate a `ChanCloser` and think we are in the negotiation phase. Even when the channel is fully closed on-chain, this will be the case until another peer disconnect + connect. This is benign, but not elegant.

Another thing I noticed that doesn't seem straightforward to fix given some interactions with the `server` during a restart is that if a cooperative close is rpc-initiated and the peer goes down, the `CloseChannel` command will hang as no response (error or not) is ever received. This isn't specific to this PR and can be deferred to another one.