### PR TITLE
#4939 Add socks proxy support to lncli

### DIFF
--- a/docs/release-notes/release-notes-0.15.0.md
+++ b/docs/release-notes/release-notes-0.15.0.md
@@ -41,6 +41,9 @@ then watch it on chain. Taproot script spends are also supported through the
 * Add [update node announcement](https://github.com/lightningnetwork/lnd/pull/5587)
   for updating and propagating node information.
 
+* Add [--socksproxy](https://github.com/lightningnetwork/lnd/pull/6422)
+  to allow for RPC calls via Tor.
+
 ## Bug Fixes
 
 * [Pipelining an UpdateFulfillHTLC message now only happens when the related UpdateAddHTLC is locked-in.](https://github.com/lightningnetwork/lnd/pull/6246)
@@ -281,6 +284,7 @@ gRPC performance metrics (latency to process `GetInfo`, etc)](https://github.com
 * Eugene Siegel
 * Hampus Sjöberg
 * henta
+* hieblmi
 * Joost Jager
 * Jordi Montes
 * LightningHelper


### PR DESCRIPTION
_(This change was previously reviewed in PR https://github.com/lightningnetwork/lnd/pull/6279)_

This PR adds a `--socksproxy` option to `lncli` to allow for RPC calls via Tor. 

Example: `lncli --rpcserver=remoterpchost.onion:10009 --socksproxy=localhost:9050 --tlscertpath=/cert/path/tls.cert --macaroonpath=/macaroon/path/admin.macaroon fwdinghistory --start_time "-1h"`

I have tested the above example on two physically remote systems and was able to retrieve the forwarding history.