### PR TITLE
Typo fixes and code cleanup

### DIFF
--- a/channeldb/channel.go
+++ b/channeldb/channel.go
@@ -1104,10 +1104,10 @@ func (c *OpenChannel) MarkBorked() error {
 // reconnection with the remote peer that we're maintaining this channel with.
 // The information contained within this message is necessary to re-sync our
 // commitment chains in the case of a last or only partially processed message.
-// When the remote party receiver this message one of three things may happen:
+// When the remote party receives this message one of three things may happen:
 //
 //   1. We're fully synced and no messages need to be sent.
-//   2. We didn't get the last CommitSig message they sent, to they'll re-send
+//   2. We didn't get the last CommitSig message they sent, so they'll re-send
 //      it.
 //   3. We didn't get the last RevokeAndAck message they sent, so they'll
 //      re-send it.

--- a/channeldb/doc.go
+++ b/channeldb/doc.go
@@ -1,1 +1,0 @@
-package channeldb

--- a/channeldb/fees.go
+++ b/channeldb/fees.go
@@ -1,1 +1,0 @@
-package channeldb

--- a/channeldb/migration/lnwire21/update_fail_htlc.go
+++ b/channeldb/migration/lnwire21/update_fail_htlc.go
@@ -14,7 +14,7 @@ type OpaqueReason []byte
 // next commitment transaction, with the UpdateFailHTLC propagated backwards in
 // the route to fully undo the HTLC.
 type UpdateFailHTLC struct {
-	// ChanIDPoint is the particular active channel that this
+	// ChanID is the particular active channel that this
 	// UpdateFailHTLC is bound to.
 	ChanID ChannelID
 

--- a/htlcswitch/link.go
+++ b/htlcswitch/link.go
@@ -919,9 +919,9 @@ func (l *channelLink) loadAndRemove() error {
 // This goroutine reads messages from the upstream (remote) peer, and also from
 // downstream channel managed by the channel link. In the event that an htlc
 // needs to be forwarded, then send-only forward handler is used which sends
-// htlc packets to the switch. Additionally, the this goroutine handles acting
-// upon all timeouts for any active HTLCs, manages the channel's revocation
-// window, and also the htlc trickle queue+timer for this active channels.
+// htlc packets to the switch. Additionally, this goroutine handles acting upon
+// all timeouts for any active HTLCs, manages the channel's revocation window,
+// and also the htlc trickle queue+timer for this active channels.
 //
 // NOTE: This MUST be run as a goroutine.
 func (l *channelLink) htlcManager() {

--- a/htlcswitch/mailbox.go
+++ b/htlcswitch/mailbox.go
@@ -25,7 +25,7 @@ var (
 
 // MailBox is an interface which represents a concurrent-safe, in-order
 // delivery queue for messages from the network and also from the main switch.
-// This struct servers as a buffer between incoming messages, and messages to
+// This struct serves as a buffer between incoming messages, and messages to
 // the handled by the link. Each of the mutating methods within this interface
 // should be implemented in a non-blocking manner.
 type MailBox interface {

--- a/lnwallet/channel.go
+++ b/lnwallet/channel.go
@@ -5414,8 +5414,7 @@ func (lc *LightningChannel) MalformedFailHTLC(htlcIndex uint64,
 // ReceiveFailHTLC attempts to cancel a targeted HTLC by its log index,
 // inserting an entry which will remove the target log entry within the next
 // commitment update. This method should be called in response to the upstream
-// party cancelling an outgoing HTLC. The value of the failed HTLC is returned
-// along with an error indicating success.
+// party cancelling an outgoing HTLC.
 func (lc *LightningChannel) ReceiveFailHTLC(htlcIndex uint64, reason []byte,
 ) error {
 

--- a/lnwire/update_fail_htlc.go
+++ b/lnwire/update_fail_htlc.go
@@ -15,7 +15,7 @@ type OpaqueReason []byte
 // next commitment transaction, with the UpdateFailHTLC propagated backwards in
 // the route to fully undo the HTLC.
 type UpdateFailHTLC struct {
-	// ChanIDPoint is the particular active channel that this
+	// ChanID is the particular active channel that this
 	// UpdateFailHTLC is bound to.
 	ChanID ChannelID
 


### PR DESCRIPTION
## Change Description
Various documentation typo fixes, a simple code modification, and removal of two empty files

## Steps to Test
None