### PR TITLE
mod+docs: bump btcutil/psbt library to v1.1.3

### DIFF
--- a/docs/release-notes/release-notes-0.15.0.md
+++ b/docs/release-notes/release-notes-0.15.0.md
@@ -102,6 +102,9 @@ then watch it on chain. Taproot script spends are also supported through the
 * [Fixed P2TR addresses not correctly being detected as
   used](https://github.com/lightningnetwork/lnd/pull/6389).
 
+* [Fixed incorrect PSBT de-serialization for transactions with no
+  inputs](https://github.com/lightningnetwork/lnd/pull/6428).
+
 ## Routing
 
 * [Add a new `time_pref` parameter to the QueryRoutes and SendPayment APIs](https://github.com/lightningnetwork/lnd/pull/6024) that

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/btcsuite/btcd v0.22.0-beta.0.20220330201728-074266215c26
 	github.com/btcsuite/btcd/btcec/v2 v2.1.3
 	github.com/btcsuite/btcd/btcutil v1.1.1
-	github.com/btcsuite/btcd/btcutil/psbt v1.1.2
+	github.com/btcsuite/btcd/btcutil/psbt v1.1.3
 	github.com/btcsuite/btcd/chaincfg/chainhash v1.0.1
 	github.com/btcsuite/btclog v0.0.0-20170628155309-84c8d2346e9f
 	github.com/btcsuite/btcwallet v0.14.1-0.20220412233800-3a6d5d0702b7

--- a/go.sum
+++ b/go.sum
@@ -86,8 +86,8 @@ github.com/btcsuite/btcd/btcutil v1.1.0/go.mod h1:5OapHB7A2hBBWLm48mmw4MOHNJCcUB
 github.com/btcsuite/btcd/btcutil v1.1.1 h1:hDcDaXiP0uEzR8Biqo2weECKqEw0uHDZ9ixIWevVQqY=
 github.com/btcsuite/btcd/btcutil v1.1.1/go.mod h1:nbKlBMNm9FGsdvKvu0essceubPiAcI57pYBNnsLAa34=
 github.com/btcsuite/btcd/btcutil/psbt v1.1.1/go.mod h1:KsGzRAzAdEimzgERpK9Xm+RhuCMvc4j2ctK0BEQ8JV0=
-github.com/btcsuite/btcd/btcutil/psbt v1.1.2 h1:ffAjA0v6Kr1UGYK86s15X/W6ZD3H9XZRpOmi3XxDj1c=
-github.com/btcsuite/btcd/btcutil/psbt v1.1.2/go.mod h1:GMJ40RHh0brZmhAKjltvYjakbVg9wQqfH+hZF96jIRE=
+github.com/btcsuite/btcd/btcutil/psbt v1.1.3 h1:fMVX0CHlVkI3VSkwMZTArfdVUkfzLuJA+ElQTfqekOU=
+github.com/btcsuite/btcd/btcutil/psbt v1.1.3/go.mod h1:GMJ40RHh0brZmhAKjltvYjakbVg9wQqfH+hZF96jIRE=
 github.com/btcsuite/btcd/chaincfg/chainhash v1.0.0/go.mod h1:7SFka0XMvUgj3hfZtydOrQY2mwhPclbT2snogU7SQQc=
 github.com/btcsuite/btcd/chaincfg/chainhash v1.0.1 h1:q0rUy8C/TYNBQS1+CGKw68tLOFYSNEs0TFnxxnS9+4U=
 github.com/btcsuite/btcd/chaincfg/chainhash v1.0.1/go.mod h1:7SFka0XMvUgj3hfZtydOrQY2mwhPclbT2snogU7SQQc=


### PR DESCRIPTION
Fixes #6386.
Bumps the btcutil/psbt library to the latest version v1.1.3 that fixes
an issue with de-serializing a PSBT that contains an unsigned
transaction with no inputs.
