### PR TITLE
rpc: verify address is for correct net

### DIFF
--- a/docs/release-notes/release-notes-0.15.0.md
+++ b/docs/release-notes/release-notes-0.15.0.md
@@ -108,6 +108,9 @@ then watch it on chain. Taproot script spends are also supported through the
 * [Fixed incorrect PSBT de-serialization for transactions with no
   inputs](https://github.com/lightningnetwork/lnd/pull/6428).
 
+* [Fixed a bug where we didn't check for correct networks when 
+  submitting onchain transactions](https://github.com/lightningnetwork/lnd/pull/6448).
+
 ## Routing
 
 * [Add a new `time_pref` parameter to the QueryRoutes and SendPayment APIs](https://github.com/lightningnetwork/lnd/pull/6024) that

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -979,6 +979,10 @@ func addrPairsToOutputs(addrPairs map[string]int64,
 			return nil, err
 		}
 
+		if !addr.IsForNet(params) {
+			return nil, fmt.Errorf("address is not for %s", params.Name)
+		}
+
 		pkscript, err := txscript.PayToAddrScript(addr)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
## Change Description

Verify that the addresses we're decoding when sending coins onchain are
for the correct network. Without this check we'll convert the users
addresses to their equivalent on other networks, which is a gross
violation of the principle of least astonishment.

## Steps to Test

Prior to this commit:

1. Run a node on regtest
2. Issue either a `sendmany` or `sendcoins` RPC, with a _mainnet or testnet_ address
3. Observe that the address is accepted, and converted into a regtest address.

After this commit, step 2 fails. 

## Pull Request Checklist
### Testing
- [ ] Your PR passes all CI checks.
- [ ] Tests covering the positive and negative (error paths) are included.
- [ ] Bug fixes contain tests triggering the bug to prevent regressions.
  There doesn't seem to be any tests for this, at least not based on a quick code search. Would be happy to implement if I'm wrong. 

### Code Style and Documentation
- [x] The change obeys the [Code Documentation and Commenting](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#CodeDocumentation) guidelines, and lines wrap at 80.
- [x] Commits follow the [Ideal Git Commit Structure](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#IdealGitCommitStructure).
- [x] ~Any new logging statements use an appropriate subsystem and logging level.~
- [x]  [There is a change description in the release notes](https://github.com/lightningnetwork/lnd/tree/master/docs/release-notes), or `[skip ci]` in the commit message for small changes.

📝 Please see our  [Contribution Guidelines](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md) for further guidance.