### PR TITLE
PendingChannels() sets confirmation_height

### DIFF
--- a/lnrpc/lightning.pb.go
+++ b/lnrpc/lightning.pb.go
@@ -16259,7 +16259,10 @@ type PendingChannelsResponse_PendingOpenChannel struct {
 
 	// The pending channel
 	Channel *PendingChannelsResponse_PendingChannel `protobuf:"bytes,1,opt,name=channel,proto3" json:"channel,omitempty"`
-	// The height at which this channel will be confirmed
+	//
+	//The height at which this channel will be confirmed. Set to 0
+	//if the funding transaction has not yet been added to a
+	//block.
 	ConfirmationHeight uint32 `protobuf:"varint,2,opt,name=confirmation_height,json=confirmationHeight,proto3" json:"confirmation_height,omitempty"`
 	//
 	//The amount calculated to be paid in fees for the current set of

--- a/lnrpc/lightning.proto
+++ b/lnrpc/lightning.proto
@@ -2364,7 +2364,11 @@ message PendingChannelsResponse {
         // The pending channel
         PendingChannel channel = 1;
 
-        // The height at which this channel will be confirmed
+        /*
+        The height at which this channel will be confirmed. Set to 0
+        if the funding transaction has not yet been added to a
+        block.
+        */
         uint32 confirmation_height = 2;
 
         /*

--- a/lnrpc/lightning.swagger.json
+++ b/lnrpc/lightning.swagger.json
@@ -2788,7 +2788,7 @@
         "confirmation_height": {
           "type": "integer",
           "format": "int64",
-          "title": "The height at which this channel will be confirmed"
+          "description": "The height at which this channel will be confirmed. Set to 0\nif the funding transaction has not yet been added to a\nblock."
         },
         "commit_fee": {
           "type": "string",

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -3269,7 +3269,8 @@ func (r *rpcServer) fetchPendingOpenChannels() (pendingOpenChannels, error) {
 		commitWeight := commitBaseWeight + input.WitnessCommitmentTxWeight
 		confirmationHeight := uint32(0)
 		if pendingChan.ShortChannelID.BlockHeight > 0 {
-			confirmationHeight = pendingChan.ShortChannelID.BlockHeight + uint32(pendingChan.NumConfsRequired)
+			confirmationHeight = pendingChan.ShortChannelID.BlockHeight +
+				uint32(pendingChan.NumConfsRequired)
 		}
 
 		result[i] = &lnrpc.PendingChannelsResponse_PendingOpenChannel{
@@ -3286,9 +3287,9 @@ func (r *rpcServer) fetchPendingOpenChannels() (pendingOpenChannels, error) {
 				Private:              isPrivate(pendingChan),
 			},
 			ConfirmationHeight: confirmationHeight,
-			CommitWeight: commitWeight,
-			CommitFee:    int64(localCommitment.CommitFee),
-			FeePerKw:     int64(localCommitment.FeePerKw),
+			CommitWeight:       commitWeight,
+			CommitFee:          int64(localCommitment.CommitFee),
+			FeePerKw:           int64(localCommitment.FeePerKw),
 		}
 	}
 

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -3267,6 +3267,10 @@ func (r *rpcServer) fetchPendingOpenChannels() (pendingOpenChannels, error) {
 		utx := btcutil.NewTx(localCommitment.CommitTx)
 		commitBaseWeight := blockchain.GetTransactionWeight(utx)
 		commitWeight := commitBaseWeight + input.WitnessCommitmentTxWeight
+		confirmationHeight := uint32(0)
+		if pendingChan.ShortChannelID.BlockHeight > 0 {
+			confirmationHeight = pendingChan.ShortChannelID.BlockHeight + uint32(pendingChan.NumConfsRequired)
+		}
 
 		result[i] = &lnrpc.PendingChannelsResponse_PendingOpenChannel{
 			Channel: &lnrpc.PendingChannelsResponse_PendingChannel{
@@ -3281,10 +3285,10 @@ func (r *rpcServer) fetchPendingOpenChannels() (pendingOpenChannels, error) {
 				CommitmentType:       rpcCommitmentType(pendingChan.ChanType),
 				Private:              isPrivate(pendingChan),
 			},
+			ConfirmationHeight: confirmationHeight,
 			CommitWeight: commitWeight,
 			CommitFee:    int64(localCommitment.CommitFee),
 			FeePerKw:     int64(localCommitment.FeePerKw),
-			// TODO(roasbeef): need to track confirmation height
 		}
 	}
 


### PR DESCRIPTION
Fixes #1217

Once a channel's funding transaction is included in a block, the `confirmation_height` field is set to the correct value.

Note: I attempted to add test coverage for these changes, but `rpcserver_test.go` is basically empty... If anyone can point towards a good place to add a test, I'm happy to do so.