### PR TITLE
invoices: add client to map before delivering backlog notif

### DIFF
--- a/docs/release-notes/release-notes-0.15.0.md
+++ b/docs/release-notes/release-notes-0.15.0.md
@@ -104,6 +104,11 @@ compact filters and block/block headers.
   arbitrator relying on htlcswitch to be started
   first](https://github.com/lightningnetwork/lnd/pull/6214).
 
+* [Fixed an issue where invoice notifications could be missed when using the
+   SubscribeSingleInvoice or SubscribeNotifications rpcs.](https://github.com/lightningnetwork/lnd/pull/6477)
+  
+## Neutrino
+
 * [Fixed crash in MuSig2Combine](https://github.com/lightningnetwork/lnd/pull/6502)
 
 * [Added signature length

--- a/invoices/invoiceregistry.go
+++ b/invoices/invoiceregistry.go
@@ -1403,8 +1403,6 @@ type invoiceSubscriptionKit struct {
 	// backlogDelivered is closed when the backlog events have been
 	// delivered.
 	backlogDelivered chan struct{}
-
-	wg sync.WaitGroup
 }
 
 // InvoiceSubscription represents an intent to receive updates for newly added
@@ -1460,8 +1458,6 @@ func (i *invoiceSubscriptionKit) Cancel() {
 
 	i.ntfnQueue.Stop()
 	close(i.cancelChan)
-
-	i.wg.Wait()
 }
 
 func (i *invoiceSubscriptionKit) notify(event *invoiceEvent) error {

--- a/invoices/invoiceregistry.go
+++ b/invoices/invoiceregistry.go
@@ -1543,6 +1543,10 @@ func (i *InvoiceRegistry) SubscribeNotifications(
 		}
 	}()
 
+	i.Lock()
+	i.notificationClients[client.id] = client
+	i.Unlock()
+
 	// Query the database to see if based on the provided addIndex and
 	// settledIndex we need to deliver any backlog notifications.
 	err := i.deliverBacklogEvents(client)
@@ -1551,12 +1555,6 @@ func (i *InvoiceRegistry) SubscribeNotifications(
 	}
 
 	log.Infof("New invoice subscription client: id=%v", client.id)
-
-	i.Lock()
-	// With the backlog notifications delivered (if any), we'll add this to
-	// our active subscriptions.
-	i.notificationClients[client.id] = client
-	i.Unlock()
 
 	return client, nil
 }
@@ -1617,6 +1615,10 @@ func (i *InvoiceRegistry) SubscribeSingleInvoice(
 		}
 	}()
 
+	i.Lock()
+	i.singleNotificationClients[client.id] = client
+	i.Unlock()
+
 	err := i.deliverSingleBacklogEvents(client)
 	if err != nil {
 		return nil, err
@@ -1624,10 +1626,6 @@ func (i *InvoiceRegistry) SubscribeSingleInvoice(
 
 	log.Infof("New single invoice subscription client: id=%v, ref=%v",
 		client.id, client.invoiceRef)
-
-	i.Lock()
-	i.singleNotificationClients[client.id] = client
-	i.Unlock()
 
 	return client, nil
 }


### PR DESCRIPTION
Prior to this change, if SubscribeSingleInvoice was called, it was possible that a state change would never be delivered to the client. The sequence of events would be:
- deliverSingleBacklogEvents called with invoice in Open state
- invoice goes to the Accepted state, no client to notify
- client added to map

This is fixed by adding the client to the map first. However, with this change it then becomes possible (though perhaps unlikely) that the client receives an Accepted and then an Open notification since the notifications occur in different goroutines. Whether this is an acceptable tradeoff is an Open question

Fixes https://github.com/lightningnetwork/lnd/issues/6475
