### PR TITLE
rpc: add --notls to disable TLS for RPC

### DIFF
--- a/config.go
+++ b/config.go
@@ -289,7 +289,8 @@ type Config struct {
 	ExternalIPs       []net.Addr
 	DisableListen     bool          `long:"nolisten" description:"Disable listening for incoming peer connections"`
 	DisableRest       bool          `long:"norest" description:"Disable REST API"`
-	DisableRestTLS    bool          `long:"no-rest-tls" description:"Disable TLS for REST connections"`
+	DisableTLS        bool          `long:"notls" description:"Disable TLS encryption for RPC"`
+	DisableRestTLS    bool          `long:"no-rest-tls" description:"Disable TLS for REST connections only"`
 	WSPingInterval    time.Duration `long:"ws-ping-interval" description:"The ping interval for REST based WebSocket connections, set to 0 to disable sending ping messages from the server side"`
 	WSPongWait        time.Duration `long:"ws-pong-wait" description:"The time we wait for a pong response message on REST based WebSocket connections before the connection is closed as inactive"`
 	NAT               bool          `long:"nat" description:"Toggle NAT traversal support (using either UPnP or NAT-PMP) to automatically advertise your external IP address to the network -- NOTE this does not support devices behind multiple NATs"`

--- a/docs/release-notes/release-notes-0.15.0.md
+++ b/docs/release-notes/release-notes-0.15.0.md
@@ -239,6 +239,9 @@ close to continue after a peer disconnect](https://github.com/lightningnetwork/l
 * [Expose](https://github.com/lightningnetwork/lnd/pull/6454) always on mode of
   the HTLC interceptor API through GetInfo.
 
+* [Add --notls config option to disable TLS encryption for
+  RPC](https://github.com/lightningnetwork/lnd/pull/6479)
+
 ## Database
 
 * [Add ForAll implementation for etcd to speed up

--- a/lnd.go
+++ b/lnd.go
@@ -626,6 +626,18 @@ func Main(cfg *Config, lisCfg ListenerCfg, implCfg *ImplementationCfg,
 func getTLSConfig(cfg *Config) ([]grpc.ServerOption, []grpc.DialOption,
 	func(net.Addr) (net.Listener, error), func(), error) {
 
+	if cfg.DisableTLS {
+		rpcsLog.Infof("TLS encryption is disabled")
+		restDialOpts := []grpc.DialOption{
+			grpc.WithInsecure(),
+			grpc.WithDefaultCallOptions(
+				grpc.MaxCallRecvMsgSize(1 * 1024 * 1024 * 200),
+			),
+		}
+
+		return nil, restDialOpts, lncfg.ListenOnAddress, func() {}, nil
+	}
+
 	// Ensure we create TLS key and certificate if they don't exist.
 	if !fileExists(cfg.TLSCertPath) && !fileExists(cfg.TLSKeyPath) {
 		rpcsLog.Infof("Generating TLS certificates...")

--- a/sample-lnd.conf
+++ b/sample-lnd.conf
@@ -180,6 +180,9 @@
 ; Disable REST API.
 ; norest=true
 
+; Disable TLS encryption for RPC.
+; notls=true
+
 ; Disable TLS for the REST API.
 ; no-rest-tls=true
 


### PR DESCRIPTION
## Change Description

This adds a `--notls` config option that disables TLS encryption for both gRPC and REST connections.

This may be useful for when RPC communication happens only over `localhost` or a LAN. It may also be used in conjunction with a reverse proxy to enable TLS.

This PR expands on a previous change to add `--noresttls` which disables TLS encryption for REST connections only. That PR originally disabled TLS altogether, but was changed to REST only after a comment was raised about compatibility with `lncli`, see: https://github.com/lightningnetwork/lnd/pull/4648#discussion_r494798090

This PR makes the accompanying changes to `lncli` to support unencrypted requests.

## Steps to Test

Run lnd from this branch using `--notls`. Observe that `lncli` commands with `--notls` work as expected and that without `--notls` they fail. Observe that REST connections (using `curl`) succeed with `http` but fail with `https`.