### PR TITLE
zmq: remove port checker

### DIFF
--- a/chainreg/chainregistry.go
+++ b/chainreg/chainregistry.go
@@ -530,7 +530,7 @@ func NewPartialChainControl(cfg *Config) (*PartialChainControl, func(), error) {
 						return nil, nil, err
 					}
 					if url.Port() != zmqPubRawBlockURL.Port() {
-						return nil, nil, fmt.Errorf(
+						log.Warnf(
 							"unable to subscribe to zmq block events on "+
 								"%s (bitcoind is running on %s)",
 							zmqPubRawBlockURL.Host,
@@ -545,7 +545,7 @@ func NewPartialChainControl(cfg *Config) (*PartialChainControl, func(), error) {
 						return nil, nil, err
 					}
 					if url.Port() != zmqPubRawTxURL.Port() {
-						return nil, nil, fmt.Errorf(
+						log.Warnf(
 							"unable to subscribe to zmq tx events on "+
 								"%s (bitcoind is running on %s)",
 							zmqPubRawTxURL.Host,

--- a/docs/release-notes/release-notes-0.15.0.md
+++ b/docs/release-notes/release-notes-0.15.0.md
@@ -14,7 +14,7 @@ invoices](https://lists.linuxfoundation.org/pipermail/lightning-dev/2021-Septemb
 ## Security
 
 * [Misconfigured ZMQ
-  setup now gets reported](https://github.com/lightningnetwork/lnd/pull/5710).
+  setup now logs a warning](https://github.com/lightningnetwork/lnd/pull/5710).
 
 ## Taproot
 


### PR DESCRIPTION
Fixes #6333.
This pr reverse the changes in #5710. 
As is, lnd can not connect to a bitcoind node, through zmq, running inside a docker container.
#5710 was added as a safeguard against mixing up the port values of zmqpubrawtx and zmqpubrawblock, which would result in lnd not being notified of new transactions and/or blocks.