### PR TITLE
docs/INSTALL.md: add list of build tags 

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -94,7 +94,7 @@ jobs:
 
             Our release binaries are fully reproducible. Third parties are able to verify that the release binaries were produced properly without having to trust the release manager(s). See our [reproducible builds guide](https://github.com/lightningnetwork/lnd/tree/master/build/release) for how this can be achieved.
             The release binaries are compiled with `go${{ env.GO_VERSION }}`, which is required by verifiers to arrive at the same ones.
-            They include the following build tags: `autopilotrpc`, `signrpc`, `walletrpc`, `chainrpc`, `invoicesrpc`, `neutrinorpc`, `routerrpc`, `watchtowerrpc` and `monitoring`. Note that these are already included in the release script, so they do not need to be provided.
+            They include the following build tags: `autopilotrpc`, `signrpc`, `walletrpc`, `chainrpc`, `invoicesrpc`, `neutrinorpc`, `routerrpc`, `watchtowerrpc`, `monitoring`, `peersrpc`, `kvdb_postrgres`, and `kvdb_etcd`. Note that these are already included in the release script, so they do not need to be provided.
 
             The `make release` command can be used to ensure one rebuilds with all the same flags used for the release. If one wishes to build for only a single platform, then `make release sys=<OS-ARCH> tag=<tag>` can be used. 
 

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -238,6 +238,32 @@ used directly:
 ⛰  go install -v ./...
 ```
 
+**Tags**
+
+Release binaries and installations from source using `make release-install`
+will have the following tags:
+
+- [autopilotrpc](/lnrpc/autopilotrpc/autopilot.proto)
+- [signrpc](/lnrpc/signrpc/signer.proto)
+- [walletrpc](/lnrpc/walletrpc/walletkit.proto)
+- [chainrpc](/lnrpc/chainrpc/chainnotifier.proto)
+- [invoicesrpc](/lnrpc/invoicesrpc/invoices.proto)
+- [routerrpc](/lnrpc/routerrpc/router.proto)
+- [watchtowerrpc](/lnrpc/watchtowerrpc/watchtower.proto)
+- [monitoring](/monitoring) (for Prometheus integration)
+- [peersrpc](/lnrpc/peersrpc/peers.proto)
+- [kvdb_postrgres](/docs/postgres.md)
+- [kvdb_etcd](/docs/etcd.md)
+
+The `dev` tag is used for development builds, and is not included in the
+release builds & installation.
+
+You can specify a custom set of tags when installing from source using the `tags=""` parameter. For example:
+
+```shell
+make install tags="signrpc walletrpc routerrpc invoicesrpc"
+```
+
 **Updating**
 
 To update your version of `lnd` to the latest version run the following

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -248,6 +248,7 @@ will have the following tags:
 - [walletrpc](/lnrpc/walletrpc/walletkit.proto)
 - [chainrpc](/lnrpc/chainrpc/chainnotifier.proto)
 - [invoicesrpc](/lnrpc/invoicesrpc/invoices.proto)
+- [neutrinorpc](/lnrpc/neutrinorpc/neutrino.proto)
 - [routerrpc](/lnrpc/routerrpc/router.proto)
 - [watchtowerrpc](/lnrpc/watchtowerrpc/watchtower.proto)
 - [monitoring](/monitoring) (for Prometheus integration)

--- a/docs/release-notes/release-notes-0.15.0.md
+++ b/docs/release-notes/release-notes-0.15.0.md
@@ -283,6 +283,9 @@ to the htlc interceptor API.
 * Improved instructions on [how to build lnd for mobile](https://github.com/lightningnetwork/lnd/pull/6085).
 * [Log force-close related messages on "info" level](https://github.com/lightningnetwork/lnd/pull/6124).
 
+* [Add list of build tags](https://github.com/lightningnetwork/lnd/pull/6486)
+  to the install instructions.
+
 ## Monitoring
 
 A new [flag (`--prometheus.perfhistograms`) has been added to enable export of


### PR DESCRIPTION
This adds a list of tags that can be used when building or installing
lnd from source. Links to relevant code, protobuf definitions, or
documentation are included to illustrate the purpose of each tag.

Closes #3598.