### PR TITLE
macaroons: futher abstract NewService from root key store impl

### DIFF
--- a/config_builder.go
+++ b/config_builder.go
@@ -394,8 +394,12 @@ func (d *DefaultWalletImpl) BuildWalletConfig(ctx context.Context,
 	var macaroonService *macaroons.Service
 	if !d.cfg.NoMacaroons {
 		// Create the macaroon authentication/authorization service.
+		rootKeyStore, err := macaroons.NewRootKeyStorage(dbs.MacaroonDB)
+		if err != nil {
+			return nil, nil, nil, err
+		}
 		macaroonService, err = macaroons.NewService(
-			dbs.MacaroonDB, "lnd", walletInitParams.StatelessInit,
+			rootKeyStore, "lnd", walletInitParams.StatelessInit,
 			macaroons.IPLockChecker,
 			macaroons.CustomChecker(interceptorChain),
 		)

--- a/docs/release-notes/release-notes-0.16.0.md
+++ b/docs/release-notes/release-notes-0.16.0.md
@@ -5,7 +5,9 @@
 
 * [Fixed error typo](https://github.com/lightningnetwork/lnd/pull/6659).
 
+* [The macaroon key store implementation was refactored to be more generally useable](https://github.com/lightningnetwork/lnd/pull/6509).
+
 # Contributors (Alphabetical Order)
 * Carla Kirk-Cohen
 * ErikEk
-
+* Olaoluwa Osuntokun

--- a/macaroons/service_test.go
+++ b/macaroons/service_test.go
@@ -59,10 +59,13 @@ func TestNewService(t *testing.T) {
 	tempDir, db := setupTestRootKeyStorage(t)
 	defer os.RemoveAll(tempDir)
 
+	rootKeyStore, err := macaroons.NewRootKeyStorage(db)
+	require.NoError(t, err)
+
 	// Second, create the new service instance, unlock it and pass in a
 	// checker that we expect it to add to the bakery.
 	service, err := macaroons.NewService(
-		db, "lnd", false, macaroons.IPLockChecker,
+		rootKeyStore, "lnd", false, macaroons.IPLockChecker,
 	)
 	require.NoError(t, err, "Error creating new service")
 	defer service.Close()
@@ -106,8 +109,10 @@ func TestValidateMacaroon(t *testing.T) {
 	// First, initialize the service and unlock it.
 	tempDir, db := setupTestRootKeyStorage(t)
 	defer os.RemoveAll(tempDir)
+	rootKeyStore, err := macaroons.NewRootKeyStorage(db)
+	require.NoError(t, err)
 	service, err := macaroons.NewService(
-		db, "lnd", false, macaroons.IPLockChecker,
+		rootKeyStore, "lnd", false, macaroons.IPLockChecker,
 	)
 	require.NoError(t, err, "Error creating new service")
 	defer service.Close()
@@ -154,8 +159,10 @@ func TestListMacaroonIDs(t *testing.T) {
 
 	// Second, create the new service instance, unlock it and pass in a
 	// checker that we expect it to add to the bakery.
+	rootKeyStore, err := macaroons.NewRootKeyStorage(db)
+	require.NoError(t, err)
 	service, err := macaroons.NewService(
-		db, "lnd", false, macaroons.IPLockChecker,
+		rootKeyStore, "lnd", false, macaroons.IPLockChecker,
 	)
 	require.NoError(t, err, "Error creating new service")
 	defer service.Close()
@@ -186,8 +193,10 @@ func TestDeleteMacaroonID(t *testing.T) {
 
 	// Second, create the new service instance, unlock it and pass in a
 	// checker that we expect it to add to the bakery.
+	rootKeyStore, err := macaroons.NewRootKeyStorage(db)
+	require.NoError(t, err)
 	service, err := macaroons.NewService(
-		db, "lnd", false, macaroons.IPLockChecker,
+		rootKeyStore, "lnd", false, macaroons.IPLockChecker,
 	)
 	require.NoError(t, err, "Error creating new service")
 	defer service.Close()

--- a/walletunlocker/service.go
+++ b/walletunlocker/service.go
@@ -807,8 +807,12 @@ func (u *UnlockerService) ChangePassword(ctx context.Context,
 	// then close it again.
 	// Attempt to open the macaroon DB, unlock it and then change
 	// the passphrase.
+	rootKeyStore, err := macaroons.NewRootKeyStorage(u.macaroonDB)
+	if err != nil {
+		return nil, err
+	}
 	macaroonService, err := macaroons.NewService(
-		u.macaroonDB, "lnd", in.StatelessInit,
+		rootKeyStore, "lnd", in.StatelessInit,
 	)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
In this commit, we modify the `macaroons.NewService` consturctor to
accept the main interface rather than the raw DB. This allows us to use
other backends other than bolt or the kvdb interface to store the
macaroon root keys.

We also create a new ExtendedRootKeyStore interface that implements some
of the more advanced features we use such as macaroon encryption and
password rotation.
