### PR TITLE
htlcswitch: remove synchronous link handoff, special-case keystone err

### DIFF
--- a/docs/release-notes/release-notes-0.15.0.md
+++ b/docs/release-notes/release-notes-0.15.0.md
@@ -106,6 +106,15 @@ compact filters and block/block headers.
 
 * [Fixed crash in MuSig2Combine](https://github.com/lightningnetwork/lnd/pull/6502)
 
+* [Fixed an issue where lnd would end up sending an Error and triggering a force
+  close.](https://github.com/lightningnetwork/lnd/pull/6518)
+  
+## Neutrino
+
+* [New neutrino sub-server](https://github.com/lightningnetwork/lnd/pull/5652)
+  capable of status checks, adding, disconnecting and listing
+  peers, fetching compact filters and block/block headers.
+
 * [Added signature length
   validation](https://github.com/lightningnetwork/lnd/pull/6314) when calling
   `NewSigFromRawSignature`.

--- a/htlcswitch/interfaces.go
+++ b/htlcswitch/interfaces.go
@@ -52,10 +52,6 @@ type packetHandler interface {
 	//
 	// NOTE: This function should block as little as possible.
 	handleSwitchPacket(*htlcPacket) error
-
-	// handleLocalAddPacket handles a locally-initiated UpdateAddHTLC
-	// packet. It will be processed synchronously.
-	handleLocalAddPacket(*htlcPacket) error
 }
 
 // dustHandler is an interface used exclusively by the Switch to evaluate

--- a/htlcswitch/linkfailure.go
+++ b/htlcswitch/linkfailure.go
@@ -46,6 +46,11 @@ const (
 	// remote party to force close the channel out on chain now as a
 	// result.
 	ErrRecoveryError
+
+	// ErrCircuitError indicates a duplicate keystone error was hit in the
+	// circuit map. This is non-fatal and will resolve itself (usually
+	// within several minutes).
+	ErrCircuitError
 )
 
 // LinkFailureError encapsulates an error that will make us fail the current
@@ -94,6 +99,8 @@ func (e LinkFailureError) Error() string {
 		return "invalid revocation"
 	case ErrRecoveryError:
 		return "unable to resume channel, recovery required"
+	case ErrCircuitError:
+		return "non-fatal circuit map error"
 	default:
 		return "unknown error"
 	}

--- a/htlcswitch/mock.go
+++ b/htlcswitch/mock.go
@@ -729,11 +729,6 @@ func (f *mockChannelLink) handleSwitchPacket(pkt *htlcPacket) error {
 	return nil
 }
 
-func (f *mockChannelLink) handleLocalAddPacket(pkt *htlcPacket) error {
-	_ = f.mailBox.AddPacket(pkt)
-	return nil
-}
-
 func (f *mockChannelLink) getDustSum(remote bool) lnwire.MilliSatoshi {
 	return 0
 }

--- a/htlcswitch/switch.go
+++ b/htlcswitch/switch.go
@@ -484,6 +484,7 @@ func (s *Switch) SendHTLC(firstHop lnwire.ShortChannelID, attemptID uint64,
 		incomingHTLCID: attemptID,
 		outgoingChanID: firstHop,
 		htlc:           htlc,
+		amount:         htlc.Amount,
 	}
 
 	// Attempt to fetch the target link before creating a circuit so that
@@ -547,10 +548,11 @@ func (s *Switch) SendHTLC(firstHop lnwire.ShortChannelID, attemptID uint64,
 		return ErrLocalAddFailed
 	}
 
-	// Send packet to link.
+	// Give the packet to the link's mailbox so that HTLC's are properly
+	// canceled back if the mailbox timeout elapses.
 	packet.circuit = circuit
 
-	return link.handleLocalAddPacket(packet)
+	return link.handleSwitchPacket(packet)
 }
 
 // UpdateForwardingPolicies sends a message to the switch to update the


### PR DESCRIPTION
This allows Switch-initiated payments to be failed back if they don't
make it into a commitment. Prior to this commit, a Switch-initiated
HTLC could get "lost" meaning the circuit wouldn't get deleted except
if conditions were "right" and the network result store would never
be made aware of the HTLC's fate. Switch-initiated HTLC's are now
passed to the link's mailbox to ensure they can be failed back.

This change also special-cases the ErrDuplicateKeystone error from
OpenCircuits(...) so that callers of updateCommitTx() in the link
don't send an Error to the peer if they encounter the keystone error.
With the first async change, the keystone error should now always
be recoverable.

Fixes https://github.com/lightningnetwork/lnd/issues/6485
Fixes https://github.com/lightningnetwork/lnd/issues/6442 
Fixes https://github.com/lightningnetwork/lnd/issues/6564