### PR TITLE
chanfunding: properly support p2tr inputs in funding TX

### DIFF
--- a/docs/release-notes/release-notes-0.15.0.md
+++ b/docs/release-notes/release-notes-0.15.0.md
@@ -60,6 +60,10 @@ releases. Backward compatibility is not guaranteed!
 155](https://github.com/lightningnetwork/lnd/pull/6468), allowing it to connect
 to Bitcoin nodes that advertise a Tor v3 onion service address.
 
+[A new neutrino sub-server](https://github.com/lightningnetwork/lnd/pull/5652)
+capable of status checks, adding, disconnecting and listing peers, fetching
+compact filters and block/block headers.
+
 ## Bug Fixes
 
 * [Pipelining an UpdateFulfillHTLC message now only happens when the related UpdateAddHTLC is locked-in.](https://github.com/lightningnetwork/lnd/pull/6246)
@@ -87,12 +91,6 @@ to Bitcoin nodes that advertise a Tor v3 onion service address.
   first](https://github.com/lightningnetwork/lnd/pull/6214).
 
 * [Fixed crash in MuSig2Combine](https://github.com/lightningnetwork/lnd/pull/6502)
-  
-## Neutrino
-
-* [New neutrino sub-server](https://github.com/lightningnetwork/lnd/pull/5652)
-  capable of status checks, adding, disconnecting and listing
-  peers, fetching compact filters and block/block headers.
 
 * [Added signature length
   validation](https://github.com/lightningnetwork/lnd/pull/6314) when calling
@@ -140,6 +138,9 @@ from occurring that would result in an erroneous force close.](https://github.co
 
 * [Ignore addresses with unknown types in NodeAnnouncements](
   https://github.com/lightningnetwork/lnd/pull/6435)
+
+* [Taproot wallet inputs can also be used to fund
+  channels](https://github.com/lightningnetwork/lnd/pull/6521)
 
 ## Routing
 

--- a/lntest/harness_net.go
+++ b/lntest/harness_net.go
@@ -1417,7 +1417,7 @@ func (n *NetworkHarness) DumpLogs(node *HarnessNode) (string, error) {
 func (n *NetworkHarness) SendCoins(t *testing.T, amt btcutil.Amount,
 	target *HarnessNode) {
 
-	err := n.sendCoins(
+	err := n.SendCoinsOfType(
 		amt, target, lnrpc.AddressType_WITNESS_PUBKEY_HASH, true,
 	)
 	require.NoErrorf(t, err, "unable to send coins for %s", target.Cfg.Name)
@@ -1429,7 +1429,7 @@ func (n *NetworkHarness) SendCoins(t *testing.T, amt btcutil.Amount,
 func (n *NetworkHarness) SendCoinsUnconfirmed(t *testing.T, amt btcutil.Amount,
 	target *HarnessNode) {
 
-	err := n.sendCoins(
+	err := n.SendCoinsOfType(
 		amt, target, lnrpc.AddressType_WITNESS_PUBKEY_HASH, false,
 	)
 	require.NoErrorf(
@@ -1443,7 +1443,7 @@ func (n *NetworkHarness) SendCoinsUnconfirmed(t *testing.T, amt btcutil.Amount,
 func (n *NetworkHarness) SendCoinsNP2WKH(t *testing.T, amt btcutil.Amount,
 	target *HarnessNode) {
 
-	err := n.sendCoins(
+	err := n.SendCoinsOfType(
 		amt, target, lnrpc.AddressType_NESTED_PUBKEY_HASH, true,
 	)
 	require.NoErrorf(
@@ -1457,16 +1457,18 @@ func (n *NetworkHarness) SendCoinsNP2WKH(t *testing.T, amt btcutil.Amount,
 func (n *NetworkHarness) SendCoinsP2TR(t *testing.T, amt btcutil.Amount,
 	target *HarnessNode) {
 
-	err := n.sendCoins(amt, target, lnrpc.AddressType_TAPROOT_PUBKEY, true)
+	err := n.SendCoinsOfType(
+		amt, target, lnrpc.AddressType_TAPROOT_PUBKEY, true,
+	)
 	require.NoErrorf(
 		t, err, "unable to send P2TR coins for %s", target.Cfg.Name,
 	)
 }
 
-// sendCoins attempts to send amt satoshis from the internal mining node to the
-// targeted lightning node. The confirmed boolean indicates whether the
+// SendCoinsOfType attempts to send amt satoshis from the internal mining node
+// to the targeted lightning node. The confirmed boolean indicates whether the
 // transaction that pays to the target should confirm.
-func (n *NetworkHarness) sendCoins(amt btcutil.Amount, target *HarnessNode,
+func (n *NetworkHarness) SendCoinsOfType(amt btcutil.Amount, target *HarnessNode,
 	addrType lnrpc.AddressType, confirmed bool) error {
 
 	ctx, cancel := context.WithTimeout(n.runCtx, DefaultTimeout)

--- a/lntest/itest/lnd_test_list_on_test.go
+++ b/lntest/itest/lnd_test_list_on_test.go
@@ -25,6 +25,10 @@ var allTestCases = []*testCase{
 		test: testBasicChannelFunding,
 	},
 	{
+		name: "basic funding flow with all input types",
+		test: testChannelFundingInputTypes,
+	},
+	{
 		name: "unconfirmed channel funding",
 		test: testUnconfirmedChannelFunding,
 	},

--- a/lnwallet/btcwallet/signer.go
+++ b/lnwallet/btcwallet/signer.go
@@ -41,6 +41,8 @@ func (b *BtcWallet) FetchInputInfo(prevOut *wire.OutPoint) (*lnwallet.Utxo, erro
 		addressType = lnwallet.WitnessPubKey
 	case txscript.IsPayToScriptHash(txOut.PkScript):
 		addressType = lnwallet.NestedWitnessPubKey
+	case txscript.IsPayToTaproot(txOut.PkScript):
+		addressType = lnwallet.TaprootPubkey
 	}
 
 	return &lnwallet.Utxo{

--- a/lnwallet/chanfunding/coin_select.go
+++ b/lnwallet/chanfunding/coin_select.go
@@ -79,6 +79,11 @@ func calculateFees(utxos []Coin, feeRate chainfee.SatPerKWeight) (btcutil.Amount
 		case txscript.IsPayToScriptHash(utxo.PkScript):
 			weightEstimate.AddNestedP2WKHInput()
 
+		case txscript.IsPayToTaproot(utxo.PkScript):
+			weightEstimate.AddTaprootKeySpendInput(
+				txscript.SigHashDefault,
+			)
+
 		default:
 			return 0, 0, &errUnsupportedInput{utxo.PkScript}
 		}


### PR DESCRIPTION
Fixes https://github.com/lightningnetwork/lnd/issues/6519 by properly detecting and supporting p2tr inputs in channel funding transactions.