### PR TITLE
aezeed+keychain: bump internal version of seed to 1

### DIFF
--- a/aezeed/cipherseed.go
+++ b/aezeed/cipherseed.go
@@ -254,7 +254,7 @@ func (c *CipherSeed) decode(r io.Reader) error {
 // our current enciphering operation. The AD is: version || salt.
 func encodeAD(version uint8, salt [saltSize]byte) [adSize]byte {
 	var ad [adSize]byte
-	ad[0] = byte(version)
+	ad[0] = version
 	copy(ad[1:], salt[:])
 
 	return ad
@@ -318,7 +318,7 @@ func (c *CipherSeed) encipher(pass []byte) ([EncipheredCipherSeedSize]byte,
 
 	// Finally, we'll pack the {version || ciphertext || salt || checksum}
 	// seed into a byte slice for encoding as a mnemonic.
-	cipherSeedBytes[0] = byte(CipherSeedVersion)
+	cipherSeedBytes[0] = CipherSeedVersion
 	copy(cipherSeedBytes[1:saltOffset], cipherText)
 	copy(cipherSeedBytes[saltOffset:], c.salt[:])
 
@@ -458,7 +458,7 @@ func decipherCipherSeed(cipherSeedBytes [EncipheredCipherSeedSize]byte,
 	// Before we do anything, we'll ensure that the version is one that we
 	// understand. Otherwise, we won't be able to decrypt, or even parse
 	// the cipher seed.
-	if uint8(cipherSeedBytes[0]) != CipherSeedVersion {
+	if cipherSeedBytes[0] != CipherSeedVersion {
 		return plainSeed, ErrIncorrectVersion
 	}
 

--- a/aezeed/cipherseed_test.go
+++ b/aezeed/cipherseed_test.go
@@ -84,9 +84,9 @@ func assertCipherSeedEqual(t *testing.T, cipherSeed *CipherSeed,
 func TestAezeedVersion0TestVectors(t *testing.T) {
 	t.Parallel()
 
-	// To minimize the number of tests that need to be run,
-	// go through all test vectors in the same test and also check
-	// the birthday calculation while we're at it.
+	// To minimize the number of tests that need to be run, go through all
+	// test vectors in the same test and also check the birthday calculation
+	// while we're at it.
 	for _, v := range version0TestVectors {
 		// First, we create new cipher seed with the given values
 		// from the test vector.
@@ -95,12 +95,12 @@ func TestAezeedVersion0TestVectors(t *testing.T) {
 			t.Fatalf("unable to create seed: %v", err)
 		}
 
-		// Then we need to set the salt to the pre-defined value, otherwise
-		// we'll end up with randomness in our mnemonics.
+		// Then we need to set the salt to the pre-defined value,
+		// otherwise we'll end up with randomness in our mnemonics.
 		cipherSeed.salt = testSalt
 
-		// Now that the seed has been created, we'll attempt to convert it to a
-		// valid mnemonic.
+		// Now that the seed has been created, we'll attempt to convert
+		// it to a valid mnemonic.
 		mnemonic, err := cipherSeed.ToMnemonic(v.password)
 		if err != nil {
 			t.Fatalf("unable to create mnemonic: %v", err)
@@ -189,7 +189,7 @@ func TestManualEntropyGeneration(t *testing.T) {
 }
 
 // TestInvalidPassphraseRejection tests if a caller attempts to use the
-// incorrect passprhase for an enciphered seed, then the proper error is
+// incorrect passphrase for an enciphered seed, then the proper error is
 // returned.
 func TestInvalidPassphraseRejection(t *testing.T) {
 	t.Parallel()
@@ -228,7 +228,7 @@ func TestRawEncipherDecipher(t *testing.T) {
 		t.Fatalf("unable to create seed: %v", err)
 	}
 
-	// With the cipherseed obtained, we'll now use the raw encipher method
+	// With the cipher seed obtained, we'll now use the raw encipher method
 	// to obtain our final cipher text.
 	cipherText, err := cipherSeed.Encipher(pass)
 	if err != nil {
@@ -270,7 +270,7 @@ func TestInvalidExternalVersion(t *testing.T) {
 		t.Fatalf("unable to create seed: %v", err)
 	}
 
-	// With the cipherseed obtained, we'll now use the raw encipher method
+	// With the cipher seed obtained, we'll now use the raw encipher method
 	// to obtain our final cipher text.
 	pass := []byte("newpasswhodis")
 	cipherText, err := cipherSeed.Encipher(pass)
@@ -312,16 +312,16 @@ func TestChangePassphrase(t *testing.T) {
 	}
 
 	// Now that have the mnemonic, we'll attempt to re-encipher the
-	// passphrase in order to get a brand new mnemonic.
+	// passphrase in order to get a brand-new mnemonic.
 	newPass := []byte("strongerpassyeh!")
-	newmnemonic, err := mnemonic.ChangePass(pass, newPass)
+	newMnemonic, err := mnemonic.ChangePass(pass, newPass)
 	if err != nil {
 		t.Fatalf("unable to change passphrase: %v", err)
 	}
 
 	// We'll now attempt to decipher the new mnemonic using the new
 	// passphrase to arrive at (what should be) the original cipher seed.
-	newCipherSeed, err := newmnemonic.ToCipherSeed(newPass)
+	newCipherSeed, err := newMnemonic.ToCipherSeed(newPass)
 	if err != nil {
 		t.Fatalf("unable to decipher cipher seed: %v", err)
 	}
@@ -332,7 +332,7 @@ func TestChangePassphrase(t *testing.T) {
 }
 
 // TestChangePassphraseWrongPass tests that if we have a valid enciphered
-// cipherseed, but then try to change the password with the *wrong* password,
+// cipher seed, but then try to change the password with the *wrong* password,
 // then we get an error.
 func TestChangePassphraseWrongPass(t *testing.T) {
 	t.Parallel()
@@ -352,7 +352,7 @@ func TestChangePassphraseWrongPass(t *testing.T) {
 	}
 
 	// Now that have the mnemonic, we'll attempt to re-encipher the
-	// passphrase in order to get a brand new mnemonic. However, we'll be
+	// passphrase in order to get a brand-new mnemonic. However, we'll be
 	// using the *wrong* passphrase. This should result in an
 	// ErrInvalidPass error.
 	wrongPass := []byte("kek")
@@ -397,7 +397,7 @@ func TestMnemonicEncoding(t *testing.T) {
 }
 
 // TestEncipherDecipher is a property-based test that ensures that given a
-// version, entropy, and birthday, then we're able to map that to a cipherseed
+// version, entropy, and birthday, then we're able to map that to a cipher seed
 // mnemonic, then back to the original plaintext cipher seed.
 func TestEncipherDecipher(t *testing.T) {
 	t.Parallel()
@@ -406,7 +406,7 @@ func TestEncipherDecipher(t *testing.T) {
 	// ensure that given a random seed tuple (internal version, entropy,
 	// and birthday) we're able to convert that to a valid cipher seed.
 	// Additionally, we should be able to decipher the final mnemonic, and
-	// recover the original cipherseed.
+	// recover the original cipher seed.
 	mainScenario := func(version uint8, entropy [EntropySize]byte,
 		nowInt int64, pass [20]byte) bool {
 
@@ -458,7 +458,7 @@ func TestEncipherDecipher(t *testing.T) {
 // arbitrary raw seed.
 func TestSeedEncodeDecode(t *testing.T) {
 	// mainScenario is the primary driver of our property-based test. We'll
-	// ensure that given a random cipher seed, we can encode it an decode
+	// ensure that given a random cipher seed, we can encode it and decode
 	// it precisely.
 	mainScenario := func(version uint8, nowInt int64,
 		entropy [EntropySize]byte) bool {
@@ -506,10 +506,10 @@ func TestSeedEncodeDecode(t *testing.T) {
 	}
 }
 
-// TestDecipherUnknownMnenomicWord tests that if we obtain a mnemonic, the
+// TestDecipherUnknownMnemonicWord tests that if we obtain a mnemonic, then
 // modify one of the words to not be within the word list, then it's detected
 // when we attempt to map it back to the original cipher seed.
-func TestDecipherUnknownMnenomicWord(t *testing.T) {
+func TestDecipherUnknownMnemonicWord(t *testing.T) {
 	t.Parallel()
 
 	// First, we'll create a new cipher seed with "test" ass a password.
@@ -532,15 +532,15 @@ func TestDecipherUnknownMnenomicWord(t *testing.T) {
 	mnemonic[randIndex] = "kek"
 
 	// If we attempt to map back to the original cipher seed now, then we
-	// should get ErrUnknownMnenomicWord.
+	// should get ErrUnknownMnemonicWord.
 	_, err = mnemonic.ToCipherSeed(pass)
 	if err == nil {
-		t.Fatalf("expected ErrUnknownMnenomicWord error")
+		t.Fatalf("expected ErrUnknownMnemonicWord error")
 	}
 
-	wordErr, ok := err.(ErrUnknownMnenomicWord)
+	wordErr, ok := err.(ErrUnknownMnemonicWord)
 	if !ok {
-		t.Fatalf("expected ErrUnknownMnenomicWord instead got %T", err)
+		t.Fatalf("expected ErrUnknownMnemonicWord instead got %T", err)
 	}
 
 	if wordErr.Word != "kek" {
@@ -551,24 +551,24 @@ func TestDecipherUnknownMnenomicWord(t *testing.T) {
 			randIndex, wordErr.Index)
 	}
 
-	// If the mnemonic includes a word that is not in the englishList
-	// it fails, even when it is a substring of a valid word
-	// Example: `heart` is in the list, `hear` is not
+	// If the mnemonic includes a word that is not in the englishList it
+	// fails, even when it is a substring of a valid word Example: `heart`
+	// is in the list, `hear` is not.
 	mnemonic[randIndex] = "hear"
 
 	// If we attempt to map back to the original cipher seed now, then we
-	// should get ErrUnknownMnenomicWord.
+	// should get ErrUnknownMnemonicWord.
 	_, err = mnemonic.ToCipherSeed(pass)
 	if err == nil {
-		t.Fatalf("expected ErrUnknownMnenomicWord error")
+		t.Fatalf("expected ErrUnknownMnemonicWord error")
 	}
-	_, ok = err.(ErrUnknownMnenomicWord)
+	_, ok = err.(ErrUnknownMnemonicWord)
 	if !ok {
-		t.Fatalf("expected ErrUnknownMnenomicWord instead got %T", err)
+		t.Fatalf("expected ErrUnknownMnemonicWord instead got %T", err)
 	}
 }
 
-// TestDecipherIncorrectMnemonic tests that if we obtain a cipherseed, but then
+// TestDecipherIncorrectMnemonic tests that if we obtain a cipher seed, but then
 // swap out words, then checksum fails.
 func TestDecipherIncorrectMnemonic(t *testing.T) {
 	// First, we'll create a new cipher seed with "test" ass a password.
@@ -593,7 +593,7 @@ func TestDecipherIncorrectMnemonic(t *testing.T) {
 
 	// If we attempt to decrypt now, we should get a checksum failure.
 	// If we attempt to map back to the original cipher seed now, then we
-	// should get ErrUnknownMnenomicWord.
+	// should get ErrIncorrectMnemonic.
 	_, err = mnemonic.ToCipherSeed(pass)
 	if err != ErrIncorrectMnemonic {
 		t.Fatalf("expected ErrIncorrectMnemonic error")

--- a/aezeed/errors.go
+++ b/aezeed/errors.go
@@ -18,9 +18,9 @@ var (
 		"match")
 )
 
-// ErrUnknownMnenomicWord is returned when attempting to decipher and
+// ErrUnknownMnemonicWord is returned when attempting to decipher and
 // enciphered mnemonic, but a word encountered isn't a member of our word list.
-type ErrUnknownMnenomicWord struct {
+type ErrUnknownMnemonicWord struct {
 	// Word is the unknown word in the mnemonic phrase.
 	Word string
 
@@ -29,8 +29,8 @@ type ErrUnknownMnenomicWord struct {
 	Index uint8
 }
 
-// Error returns a human readable string describing the error.
-func (e ErrUnknownMnenomicWord) Error() string {
+// Error returns a human-readable string describing the error.
+func (e ErrUnknownMnemonicWord) Error() string {
 	return fmt.Sprintf("word %v isn't a part of default word list "+
 		"(index=%v)", e.Word, e.Index)
 }

--- a/config_builder.go
+++ b/config_builder.go
@@ -965,14 +965,13 @@ func waitForWalletPassword(cfg *Config,
 		// seed. If it's greater than the current key derivation
 		// version, then we'll return an error as we don't understand
 		// this.
-		const latestVersion = keychain.KeyDerivationVersion
 		if cipherSeed != nil &&
-			cipherSeed.InternalVersion != latestVersion {
+			!keychain.IsKnownVersion(cipherSeed.InternalVersion) {
 
 			return nil, fmt.Errorf("invalid internal "+
-				"seed version %v, current version is %v",
+				"seed version %v, current max version is %v",
 				cipherSeed.InternalVersion,
-				keychain.KeyDerivationVersion)
+				keychain.CurrentKeyDerivationVersion)
 		}
 
 		loader, err := btcwallet.NewWalletLoader(

--- a/docs/release-notes/release-notes-0.15.0.md
+++ b/docs/release-notes/release-notes-0.15.0.md
@@ -29,6 +29,11 @@ The `walletrpc.SignPsbt` RPC now also supports [Taproot PSBT
 signing](https://github.com/lightningnetwork/lnd/pull/6450) to fully support
 remote signing with Taproot outputs. 
 
+The internal version of the `aezeed` [was bumped to `1` to mark new seeds that
+were created after introducing the Taproot key
+derivation](https://github.com/lightningnetwork/lnd/pull/6524) to simplify
+detecting Taproot compatibility of a seed.
+
 ## MuSig2
 
 The [`signrpc.Signer` RPC service now supports EXPERIMENTAL MuSig2

--- a/keychain/derivation.go
+++ b/keychain/derivation.go
@@ -8,11 +8,20 @@ import (
 )
 
 const (
-	// KeyDerivationVersion is the version of the key derivation schema
-	// defined below. We use a version as this means that we'll be able to
-	// accept new seed in the future and be able to discern if the software
-	// is compatible with the version of the seed.
-	KeyDerivationVersion = 0
+	// KeyDerivationVersionLegacy is the previous version of the key
+	// derivation schema defined below. We use a version as this means that
+	// we'll be able to accept new seed in the future and be able to discern
+	// if the software is compatible with the version of the seed.
+	KeyDerivationVersionLegacy = 0
+
+	// KeyDerivationVersionTaproot is the most recent version of the key
+	// derivation scheme that marks the introduction of the Taproot
+	// derivation with BIP0086 support.
+	KeyDerivationVersionTaproot = 1
+
+	// CurrentKeyDerivationVersion is the current default key derivation
+	// version that is used for new seeds.
+	CurrentKeyDerivationVersion = KeyDerivationVersionTaproot
 
 	// BIP0043Purpose is the "purpose" value that we'll use for the first
 	// version or our key derivation scheme. All keys are expected to be
@@ -24,6 +33,13 @@ const (
 	// NOTE: BRICK SQUUUUUAD.
 	BIP0043Purpose = 1017
 )
+
+// IsKnownVersion returns true if the given version is one of the known
+// derivation scheme versions as defined by this package.
+func IsKnownVersion(internalVersion uint8) bool {
+	return internalVersion == KeyDerivationVersionLegacy ||
+		internalVersion == KeyDerivationVersionTaproot
+}
 
 var (
 	// MaxKeyRangeScan is the maximum number of keys that we'll attempt to

--- a/walletunlocker/service.go
+++ b/walletunlocker/service.go
@@ -309,7 +309,7 @@ func (u *UnlockerService) GenSeed(_ context.Context,
 	// instance.
 	//
 	cipherSeed, err := aezeed.New(
-		keychain.KeyDerivationVersion, &entropy, time.Now(),
+		keychain.CurrentKeyDerivationVersion, &entropy, time.Now(),
 	)
 	if err != nil {
 		return nil, err

--- a/walletunlocker/service_test.go
+++ b/walletunlocker/service_test.go
@@ -91,7 +91,7 @@ func createSeedAndMnemonic(t *testing.T,
 	pass []byte) (*aezeed.CipherSeed, aezeed.Mnemonic) {
 
 	cipherSeed, err := aezeed.New(
-		keychain.KeyDerivationVersion, &testEntropy, time.Now(),
+		keychain.CurrentKeyDerivationVersion, &testEntropy, time.Now(),
 	)
 	require.NoError(t, err)
 


### PR DESCRIPTION
This PR bumps the internal derivation version of the seed from 0 to 1 to mark the introduction of Taproot derivation paths.
The new version doesn't actually do anything just yet, but can be used to optimize certain chain rescan scenarios in the future.