### PR TITLE
invoices: properly set Preimage field for success resolution

### DIFF
--- a/invoices/update.go
+++ b/invoices/update.go
@@ -196,13 +196,6 @@ func updateMpp(ctx *invoiceUpdateCtx,
 	// Check whether total amt matches other htlcs in the set.
 	var newSetTotal lnwire.MilliSatoshi
 	for _, htlc := range htlcSet {
-		// Only consider accepted mpp htlcs. It is possible that there
-		// are htlcs registered in the invoice database that previously
-		// timed out and are in the canceled state now.
-		if htlc.State != channeldb.HtlcStateAccepted {
-			continue
-		}
-
 		if ctx.mpp.TotalMsat() != htlc.MppTotalAmt {
 			return nil, ctx.failRes(ResultHtlcSetTotalMismatch), nil
 		}

--- a/invoices/update.go
+++ b/invoices/update.go
@@ -108,8 +108,16 @@ func updateInvoice(ctx *invoiceUpdateCtx, inv *channeldb.Invoice) (
 			return nil, ctx.acceptRes(resultReplayToAccepted), nil
 
 		case channeldb.HtlcStateSettled:
+			pre := inv.Terms.PaymentPreimage
+
+			// Terms.PaymentPreimage will be nil for AMP invoices.
+			// Set it to the HTLC's AMP Preimage instead.
+			if pre == nil {
+				pre = htlc.AMP.Preimage
+			}
+
 			return nil, ctx.settleRes(
-				*inv.Terms.PaymentPreimage,
+				*pre,
 				ResultReplayToSettled,
 			), nil
 


### PR DESCRIPTION
Fixes https://github.com/lightningnetwork/lnd/issues/6436

Instead of setting the preimage to `inv.Terms.PaymentPreimage`, it is now set to `htlc.AMP.Preimage` if the former is nil. Also removed a redundant comparison since the `HTLCSet` logic already checks it.