### PR TITLE
Update Tor module to add option to encrypt Tor key

### DIFF
--- a/docs/release-notes/release-notes-0.16.0.md
+++ b/docs/release-notes/release-notes-0.16.0.md
@@ -48,6 +48,9 @@ minimum version needed to build the project.
   [With the module updated](https://github.com/lightningnetwork/lnd/pull/6836),
   `lnd` now parses Tor control port messages correctly.
 
+* [Update Tor module](https://github.com/lightningnetwork/lnd/pull/6526) to 
+  allow the option to encrypt the private key on disk.
+
 ## `lncli`
 * [Add an `insecure` flag to skip tls auth as well as a `metadata` string slice
   flag](https://github.com/lightningnetwork/lnd/pull/6818) that allows the 

--- a/tor/onionaddr.go
+++ b/tor/onionaddr.go
@@ -45,6 +45,9 @@ type OnionAddr struct {
 
 	// Port is the port of the onion address.
 	Port int
+
+	// PrivateKey is the onion address' private key.
+	PrivateKey string
 }
 
 // A compile-time check to ensure that OnionAddr implements the net.Addr


### PR DESCRIPTION
This PR lays the groundwork for #6500, which adds the ability to encrypt a Tor private key on disk. We originally had this all in one PR, but needed to split out this refactoring up because changes to the Tor module need to be added in another PR. 

Summary of Changes:

- Lays groundwork in Tor package for encrypting private key