### PR TITLE
config: fix path to bitcoind/litecoind rpccookie and config

### DIFF
--- a/config.go
+++ b/config.go
@@ -859,7 +859,17 @@ func ValidateConfig(cfg Config, interceptor signal.Interceptor, fileParser,
 	cfg.BtcdMode.Dir = CleanAndExpandPath(cfg.BtcdMode.Dir)
 	cfg.LtcdMode.Dir = CleanAndExpandPath(cfg.LtcdMode.Dir)
 	cfg.BitcoindMode.Dir = CleanAndExpandPath(cfg.BitcoindMode.Dir)
+	cfg.BitcoindMode.ConfigPath = CleanAndExpandPath(
+		cfg.BitcoindMode.ConfigPath,
+	)
+	cfg.BitcoindMode.RPCCookie = CleanAndExpandPath(cfg.BitcoindMode.RPCCookie)
 	cfg.LitecoindMode.Dir = CleanAndExpandPath(cfg.LitecoindMode.Dir)
+	cfg.LitecoindMode.ConfigPath = CleanAndExpandPath(
+		cfg.LitecoindMode.ConfigPath,
+	)
+	cfg.LitecoindMode.RPCCookie = CleanAndExpandPath(
+		cfg.LitecoindMode.RPCCookie,
+	)
 	cfg.Tor.PrivateKeyPath = CleanAndExpandPath(cfg.Tor.PrivateKeyPath)
 	cfg.Tor.WatchtowerKeyPath = CleanAndExpandPath(cfg.Tor.WatchtowerKeyPath)
 	cfg.Watchtower.TowerDir = CleanAndExpandPath(cfg.Watchtower.TowerDir)

--- a/docs/release-notes/release-notes-0.15.0.md
+++ b/docs/release-notes/release-notes-0.15.0.md
@@ -260,6 +260,9 @@ from occurring that would result in an erroneous force close.](https://github.co
 
 * [Clarify error msg when bitcoind cookie file is missing](https://github.com/lightningnetwork/lnd/pull/6536).
 
+* [Minor fix](https://github.com/lightningnetwork/lnd/pull/6535) to
+  how bitcoind.rpccookie and bitocind.config are parsed from config file.
+
 ## RPC Server
 
 * [Add value to the field


### PR DESCRIPTION
Minor fix to how bitcoind.rpccookie and bitcoind.config are parsed from config file. Had issues with the tilde sign in a linux setup.
This applies to litecoind too.