### PR TITLE
config: error msg for missing bitcoind cookie file

### DIFF
--- a/config.go
+++ b/config.go
@@ -2001,10 +2001,6 @@ func extractBitcoindRPCParams(networkName, bitcoindDataDir, bitcoindConfigPath,
 		return "", "", "", "", err
 	}
 	userSubmatches := rpcUserRegexp.FindSubmatch(configContents)
-	if userSubmatches == nil {
-		return "", "", "", "", fmt.Errorf("unable to find rpcuser in " +
-			"config")
-	}
 
 	// Similarly, we'll use another regular expression to find the set
 	// rpcpass (if any). If we can't find the pass, then we'll exit with an
@@ -2014,6 +2010,18 @@ func extractBitcoindRPCParams(networkName, bitcoindDataDir, bitcoindConfigPath,
 		return "", "", "", "", err
 	}
 	passSubmatches := rpcPassRegexp.FindSubmatch(configContents)
+
+	// Exit with an error if the cookie file, is defined in config, and
+	// can not be found, with both rpcuser and rpcpassword undefined.
+	if rpcCookiePath != "" && userSubmatches == nil && passSubmatches == nil {
+		return "", "", "", "", fmt.Errorf("unable to open cookie file (%v)",
+			rpcCookiePath)
+	}
+
+	if userSubmatches == nil {
+		return "", "", "", "", fmt.Errorf("unable to find rpcuser in " +
+			"config")
+	}
 	if passSubmatches == nil {
 		return "", "", "", "", fmt.Errorf("unable to find rpcpassword " +
 			"in config")

--- a/docs/release-notes/release-notes-0.15.0.md
+++ b/docs/release-notes/release-notes-0.15.0.md
@@ -258,6 +258,8 @@ from occurring that would result in an erroneous force close.](https://github.co
 
 * [Some of the invoice update logic has been refactored to be less verbose.](https://github.com/lightningnetwork/lnd/pull/6415)
 
+* [Clarify error msg when bitcoind cookie file is missing](https://github.com/lightningnetwork/lnd/pull/6536).
+
 ## RPC Server
 
 * [Add value to the field


### PR DESCRIPTION
Fixes #6516.
Returns an error message if bitcoind.rpccookie is defined but the corresponding cookie file is not found, while both bitcoind.rpcuser and bitcoind.rpcpassword is undefined.