### PR TITLE
rpcserver: fix wrong unit used in PushAmountSat

### DIFF
--- a/lntest/itest/lnd_misc_test.go
+++ b/lntest/itest/lnd_misc_test.go
@@ -374,10 +374,12 @@ func testListChannels(net *lntest.NetworkHarness, t *harnessTest) {
 	const customizedMinHtlc = 4200
 
 	chanAmt := btcutil.Amount(100000)
+	pushAmt := btcutil.Amount(1000)
 	chanPoint := openChannelAndAssert(
 		t, net, alice, bob,
 		lntest.OpenChannelParams{
 			Amt:            chanAmt,
+			PushAmt:        pushAmt,
 			MinHtlc:        customizedMinHtlc,
 			RemoteMaxHtlcs: aliceRemoteMaxHtlcs,
 		},
@@ -415,12 +417,12 @@ func testListChannels(net *lntest.NetworkHarness, t *harnessTest) {
 	aliceChannel := resp.Channels[0]
 
 	// Since Alice is the initiator, she pays the commit fee.
-	aliceBalance := int64(chanAmt) - aliceChannel.CommitFee
+	aliceBalance := int64(chanAmt) - aliceChannel.CommitFee - int64(pushAmt)
 
 	// Check the balance related fields are correct.
 	require.Equal(t.t, aliceBalance, aliceChannel.LocalBalance)
-	require.Zero(t.t, aliceChannel.RemoteBalance)
-	require.Zero(t.t, aliceChannel.PushAmountSat)
+	require.EqualValues(t.t, pushAmt, aliceChannel.RemoteBalance)
+	require.EqualValues(t.t, pushAmt, aliceChannel.PushAmountSat)
 
 	// Calculate the dust limit we'll use for the test.
 	dustLimit := lnwallet.DustLimitForSize(input.UnknownWitnessSize)
@@ -474,8 +476,8 @@ func testListChannels(net *lntest.NetworkHarness, t *harnessTest) {
 
 	// Check the balance related fields are correct.
 	require.Equal(t.t, aliceBalance, bobChannel.RemoteBalance)
-	require.Zero(t.t, bobChannel.LocalBalance)
-	require.Zero(t.t, bobChannel.PushAmountSat)
+	require.EqualValues(t.t, pushAmt, bobChannel.LocalBalance)
+	require.EqualValues(t.t, pushAmt, bobChannel.PushAmountSat)
 
 	// Check channel constraints match. Alice's local channel constraint
 	// should be equal to Bob's remote channel constraint, and her remote

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -4085,9 +4085,11 @@ func createRPCOpenChannel(r *rpcServer, dbChannel *channeldb.OpenChannel,
 	// is the push amount. Otherwise, our starting balance is the push
 	// amount. If there is no push amount, these values will simply be zero.
 	if dbChannel.IsInitiator {
-		channel.PushAmountSat = uint64(dbChannel.InitialRemoteBalance)
+		amt := dbChannel.InitialRemoteBalance.ToSatoshis()
+		channel.PushAmountSat = uint64(amt)
 	} else {
-		channel.PushAmountSat = uint64(dbChannel.InitialLocalBalance)
+		amt := dbChannel.InitialLocalBalance.ToSatoshis()
+		channel.PushAmountSat = uint64(amt)
 	}
 
 	if len(dbChannel.LocalShutdownScript) > 0 {


### PR DESCRIPTION
Fixes #6537.

NOTE: skipped the release note as it's fixing a merge that happened in the same release.