### PR TITLE
router: do not fail MPP if shard runs into a temporary channel failure 

### DIFF
--- a/routing/router.go
+++ b/routing/router.go
@@ -2270,18 +2270,9 @@ func (r *ChannelRouter) SendToRoute(htlcHash lntypes.Hash, rt *route.Route) (
 	var failureReason *channeldb.FailureReason
 	err = sh.handleSendError(attempt, shardError)
 
-	switch {
-	// If we weren't able to extract a proper failure reason (which can
-	// happen if the second chance logic is triggered), then we'll use the
-	// normal no route error.
-	case err == nil:
-		err = r.cfg.Control.Fail(
-			paymentIdentifier, channeldb.FailureReasonNoRoute,
-		)
-
 	// If this is a failure reason, then we'll apply the failure directly
 	// to the control tower, and return the normal response to the caller.
-	case goErrors.As(err, &failureReason):
+	if goErrors.As(err, &failureReason) {
 		err = r.cfg.Control.Fail(paymentIdentifier, *failureReason)
 	}
 	if err != nil {

--- a/routing/router.go
+++ b/routing/router.go
@@ -169,7 +169,7 @@ type PaymentAttemptDispatcher interface {
 		attemptID uint64,
 		htlcAdd *lnwire.UpdateAddHTLC) error
 
-	// GetPaymentResult returns the the result of the payment attempt with
+	// GetPaymentResult returns the result of the payment attempt with
 	// the given attemptID. The paymentHash should be set to the payment's
 	// overall hash, or in case of AMP payments the payment's unique
 	// identifier.
@@ -186,7 +186,7 @@ type PaymentAttemptDispatcher interface {
 
 	// CleanStore calls the underlying result store, telling it is safe to
 	// delete all entries except the ones in the keepPids map. This should
-	// be called preiodically to let the switch clean up payment results
+	// be called periodically to let the switch clean up payment results
 	// that we have handled.
 	// NOTE: New payment attempts MUST NOT be made after the keepPids map
 	// has been created and this method has returned.
@@ -409,7 +409,7 @@ type ChannelRouter struct {
 	// UpdateFilter.
 	newBlocks <-chan *chainview.FilteredBlock
 
-	// staleBlocks is a channel in which blocks disconnected fromt the end
+	// staleBlocks is a channel in which blocks disconnected from the end
 	// of our currently known best chain are sent over.
 	staleBlocks <-chan *chainview.FilteredBlock
 
@@ -1040,7 +1040,7 @@ func (r *ChannelRouter) networkHandler() {
 		// on the exact type of the message.
 		case update := <-r.networkUpdates:
 			// We'll set up any dependants, and wait until a free
-			// slot for this job opens up, this allow us to not
+			// slot for this job opens up, this allows us to not
 			// have thousands of goroutines active.
 			validationBarrier.InitJobDependencies(update.msg)
 
@@ -1820,7 +1820,7 @@ func generateSphinxPacket(rt *route.Route, paymentHash []byte,
 	sessionKey *btcec.PrivateKey) ([]byte, *sphinx.Circuit, error) {
 
 	// Now that we know we have an actual route, we'll map the route into a
-	// sphinx payument path which includes per-hop paylods for each hop
+	// sphinx payment path which includes per-hop payloads for each hop
 	// that give each node within the route the necessary information
 	// (fees, CLTV value, etc) to properly forward the payment.
 	sphinxPath, err := rt.ToSphinxPath()
@@ -2357,7 +2357,7 @@ func (r *ChannelRouter) extractChannelUpdate(
 }
 
 // applyChannelUpdate validates a channel update and if valid, applies it to the
-// database. It returns a bool indicating whether the updates was successful.
+// database. It returns a bool indicating whether the updates were successful.
 func (r *ChannelRouter) applyChannelUpdate(msg *lnwire.ChannelUpdate,
 	pubKey *btcec.PublicKey) bool {
 


### PR DESCRIPTION
## Change Description
See #5746 and #5733 for a discussion. On testnet this change allows me to use `SendToRouteV2` to send MPPs and replace failing shards with new shards, so that the total payment amount, over time, reaches the destination.

As far as I understand the code, the failure previously returned is treated as a terminal/final failure, which causes the whole MPP to fail. This is OK/necessary for failures sent by the destination node, for example if the MPP timed out.

However, the omnipresent "temporary channel failure" should not have this influence on the whole MPP.

As I don't know a lot about the internals of lnd, please let this PR serve as an inspiration so that a proper fix can be implemented.

## Pull Request Checklist
### Testing
- [ ] Your PR passes all CI checks.
- [ ] Tests covering the positive and negative (error paths) are included.
- [ ] Bug fixes contain tests triggering the bug to prevent regressions.

### Code Style and Documentation
- [x] The change obeys the [Code Documentation and Commenting](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#CodeDocumentation) guidelines, and lines wrap at 80.
- [x] Commits follow the [Ideal Git Commit Structure](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#IdealGitCommitStructure).
- [x] Any new logging statements use an appropriate subsystem and logging level.
- [ ]  [There is a change description in the release notes](https://github.com/lightningnetwork/lnd/tree/master/docs/release-notes), or `[skip ci]` in the commit message for small changes.

📝 Please see our  [Contribution Guidelines](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md) for further guidance.