### PR TITLE
lnwire/peer: add ability to read + log peer warning messages

### DIFF
--- a/docs/release-notes/release-notes-0.16.0.md
+++ b/docs/release-notes/release-notes-0.16.0.md
@@ -1,0 +1,8 @@
+# Release Notes
+
+## Misc
+* Warning messages from peers are now recognized and [logged](https://github.com/lightningnetwork/lnd/pull/6546) by lnd.
+
+# Contributors (Alphabetical Order)
+* Carla Kirk-Cohen
+

--- a/htlcswitch/link.go
+++ b/htlcswitch/link.go
@@ -1996,6 +1996,13 @@ func (l *channelLink) handleUpstreamMsg(msg lnwire.Message) {
 		// Update the mailbox's feerate as well.
 		l.mailBox.SetFeeRate(fee)
 
+	// In the case where we receive a warning message from our peer, just
+	// log it and move on. We choose not to disconnect from our peer,
+	// although we "MAY" do so according to the specification.
+	case *lnwire.Warning:
+		l.log.Warnf("received warning message from peer: %v",
+			msg.Error.Error())
+
 	case *lnwire.Error:
 		// Error received from remote, MUST fail channel, but should
 		// only print the contents of the error message if all

--- a/lnwire/lnwire_test.go
+++ b/lnwire/lnwire_test.go
@@ -965,6 +965,12 @@ func TestLightningWireProtocol(t *testing.T) {
 			},
 		},
 		{
+			msgType: MsgWarning,
+			scenario: func(m Warning) bool {
+				return mainScenario(&m)
+			},
+		},
+		{
 			msgType: MsgError,
 			scenario: func(m Error) bool {
 				return mainScenario(&m)

--- a/lnwire/message.go
+++ b/lnwire/message.go
@@ -22,7 +22,8 @@ type MessageType uint16
 // The currently defined message types within this current version of the
 // Lightning protocol.
 const (
-	MsgInit                    MessageType = 16
+	MsgWarning                 MessageType = 1
+	MsgInit                                = 16
 	MsgError                               = 17
 	MsgPing                                = 18
 	MsgPong                                = 19
@@ -75,6 +76,8 @@ func ErrorPayloadTooLarge(size int) error {
 // String return the string representation of message type.
 func (t MessageType) String() string {
 	switch t {
+	case MsgWarning:
+		return "Warning"
 	case MsgInit:
 		return "Init"
 	case MsgOpenChannel:
@@ -175,6 +178,8 @@ func makeEmptyMessage(msgType MessageType) (Message, error) {
 	var msg Message
 
 	switch msgType {
+	case MsgWarning:
+		msg = &Warning{}
 	case MsgInit:
 		msg = &Init{}
 	case MsgOpenChannel:

--- a/lnwire/warning.go
+++ b/lnwire/warning.go
@@ -1,0 +1,22 @@
+package lnwire
+
+// A compile time check to ensure Warning implements the lnwire.Message
+// interface.
+var _ Message = (*Warning)(nil)
+
+// Warning is used to express non-critical errors in the protocol, providing
+// a "soft" way for nodes to communicate failures. Since it has the same
+// structure as errors, warnings simply include an Error so that we can leverage
+// their encode/decode functionality, and over write the MsgType function to
+// differentiate them.
+type Warning struct {
+	Error
+}
+
+// MsgType returns the integer uniquely identifying an Warning message on the
+// wire.
+//
+// This is part of the lnwire.Message interface.
+func (c *Warning) MsgType() MessageType {
+	return MsgWarning
+}

--- a/peer/brontide.go
+++ b/peer/brontide.go
@@ -1455,6 +1455,10 @@ out:
 				break out
 			}
 
+		case *lnwire.Warning:
+			targetChan = msg.ChanID
+			isLinkUpdate = p.handleError(&msg.Error)
+
 		case *lnwire.Error:
 			targetChan = msg.ChanID
 			isLinkUpdate = p.handleError(msg)
@@ -1687,6 +1691,9 @@ func messageSummary(msg lnwire.Message) string {
 	case *lnwire.UpdateFailMalformedHTLC:
 		return fmt.Sprintf("chan_id=%v, id=%v, fail_code=%v",
 			msg.ChanID, msg.ID, msg.FailureCode)
+
+	case *lnwire.Warning:
+		return fmt.Sprintf("%v", msg.Error.Error())
 
 	case *lnwire.Error:
 		return fmt.Sprintf("%v", msg.Error())


### PR DESCRIPTION
## Change Description
This PR updates LND to recognize [warning messages](https://github.com/lightning/bolts/blob/master/01-messaging.md#the-error-and-warning-messages) and log them when they are received from peers. 

This PR does not update LND to _send_ warnings itself, that will be done in a follow up. The benefit of this PR in isolation is that it will clear the "unknown message" logs that nodes see when they receive warnings from implementations that do send them. 

Partially addresses #5602. 

## Steps to Test
* Run two LND nodes and open a channel between them: 
  * `Alice` - running the code in this PR
  * `Bob` - running [testing code](https://github.com/carlaKC/lnd/tree/test-950-warningmessages) which sends an error every 5 seconds
* Observe that Alice logs warnings: `Received Warning(chan_id=000...00000, err=test {x}) from {peer}`
* 
Note: the testing code sends to a zero channel ID, so we won't cache the warning (which would show up in `listpeers --list_errors`), this will be better tested in the follow up when we can trigger sending of warnings. 

## Pull Request Checklist
### Testing
- [x] Your PR passes all CI checks (failures appear unrleated)

### Code Style and Documentation
- [x] The change obeys the [Code Documentation and Commenting](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#CodeDocumentation) guidelines, and lines wrap at 80.
- [x] Commits follow the [Ideal Git Commit Structure](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#IdealGitCommitStructure).
- [x] Any new logging statements use an appropriate subsystem and logging level.
- [x]  [There is a change description in the release notes](https://github.com/lightningnetwork/lnd/tree/master/docs/release-notes), or `[skip ci]` in the commit message for small changes.

📝 Please see our  [Contribution Guidelines](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md) for further guidance.