### PR TITLE
channeldb: copy value from boltdb's Get instead of using it directly

### DIFF
--- a/channeldb/db.go
+++ b/channeldb/db.go
@@ -1254,10 +1254,12 @@ func (c *ChannelStateDB) GetChannelOpeningState(outPoint []byte) ([]byte, error)
 			return ErrChannelNotFound
 		}
 
-		serializedState = bucket.Get(outPoint)
-		if serializedState == nil {
+		stateBytes := bucket.Get(outPoint)
+		if stateBytes == nil {
 			return ErrChannelNotFound
 		}
+
+		serializedState = append(serializedState, stateBytes...)
 
 		return nil
 	}, func() {

--- a/docs/release-notes/release-notes-0.15.0.md
+++ b/docs/release-notes/release-notes-0.15.0.md
@@ -169,6 +169,9 @@ from occurring that would result in an erroneous force close.](https://github.co
 * [Taproot wallet inputs can also be used to fund
   channels](https://github.com/lightningnetwork/lnd/pull/6521)
 
+* [Fixed an intermittent panic that would occur due to a violated assumption with our
+  underlying database.](https://github.com/lightningnetwork/lnd/pull/6547)
+
 ## Routing
 
 * [Add a new `time_pref` parameter to the QueryRoutes and SendPayment APIs](https://github.com/lightningnetwork/lnd/pull/6024) that


### PR DESCRIPTION
This can cause an intermittent panic otherwise if bbolt remaps itself
via munmap and mmap. From bbolt's documentation:

* Byte slices returned from Bolt are only valid during a transaction.
Once the transaction has been committed or rolled back then the memory
they point to can be reused by a new page or can be unmapped from
virtual memory and you'll see an unexpected fault address panic when
accessing it.

Happened in: https://github.com/lightningnetwork/lnd/runs/6462328626?check_suite_focus=true

<details>
<summary>Stack trace</summary>
<br>

```
test_harness.go:118: lnd finished with error (stderr):
        exit status 2
        unexpected fault address 0x7fee7997132d
        fatal error: fault
        [signal SIGSEGV: segmentation violation code=0x1 addr=0x7fee7997132d pc=0x1060fa7]
        
        goroutine 3997 [running]:
        runtime.throw({0x157c12c?, 0x186e360?})
        	/opt/hostedtoolcache/go/1.18.1/x64/src/runtime/panic.go:992 +0x71 fp=0xc0002f1dc8 sp=0xc0002f1d98 pc=0x435d91
        runtime.sigpanic()
        	/opt/hostedtoolcache/go/1.18.1/x64/src/runtime/signal_unix.go:825 +0x305 fp=0xc0002f1e18 sp=0xc0002f1dc8 pc=0x44c165
        encoding/binary.bigEndian.Uint16(...)
        	/opt/hostedtoolcache/go/1.18.1/x64/src/encoding/binary/binary.go:102
        github.com/lightningnetwork/lnd/funding.(*Manager).getChannelOpeningState(0xc00189ab00, 0x0?)
        	/home/runner/work/lnd/lnd/funding/manager.go:4251 +0xc7 fp=0xc0002f1e78 sp=0xc0002f1e18 pc=0x1060fa7
        github.com/lightningnetwork/lnd/funding.(*Manager).advanceFundingState(0xc00189ab00, 0xc000e1c380, {0x9c, 0x4c, 0x3f, 0x4f, 0x16, 0xf9, 0x19, 0x9a, ...}, ...)
        	/home/runner/work/lnd/lnd/funding/manager.go:902 +0x325 fp=0xc0002f1f98 sp=0xc0002f1e78 pc=0x104c3c5
        github.com/lightningnetwork/lnd/funding.(*Manager).handleFundingCreated.func2()
        	/home/runner/work/lnd/lnd/funding/manager.go:2191 +0x3d fp=0xc0002f1fe0 sp=0xc0002f1f98 pc=0x105467d
        runtime.goexit()
        	/opt/hostedtoolcache/go/1.18.1/x64/src/runtime/asm_amd64.s:1571 +0x1 fp=0xc0002f1fe8 sp=0xc0002f1fe0 pc=0x468a61
        created by github.com/lightningnetwork/lnd/funding.(*Manager).handleFundingCreated
        	/home/runner/work/lnd/lnd/funding/manager.go:2191 +0x1008
```

</details>
