### PR TITLE
multi: export channel status field in migration25

### DIFF
--- a/channeldb/migration25/channel.go
+++ b/channeldb/migration25/channel.go
@@ -277,9 +277,13 @@ type OpenChannel struct {
 	// ChanType denotes which type of channel this is.
 	ChanType ChannelType
 
-	// chanStatus is the current status of this channel. If it is not in
+	// ChanStatus is the current status of this channel. If it is not in
 	// the state Default, it should not be used for forwarding payments.
-	chanStatus ChannelStatus
+	//
+	// NOTE: In `channeldb.OpenChannel`, this field is private. We choose
+	// to export this private field such that following migrations can
+	// access this field directly.
+	ChanStatus ChannelStatus
 
 	// InitialLocalBalance is the balance we have during the channel
 	// opening. When we are not the initiator, this value represents the
@@ -320,10 +324,10 @@ func (c *OpenChannel) hasChanStatus(status ChannelStatus) bool {
 	// Special case ChanStatusDefualt since it isn't actually flag, but a
 	// particular combination (or lack-there-of) of flags.
 	if status == ChanStatusDefault {
-		return c.chanStatus == ChanStatusDefault
+		return c.ChanStatus == ChanStatusDefault
 	}
 
-	return c.chanStatus&status == status
+	return c.ChanStatus&status == status
 }
 
 // FundingTxPresent returns true if expect the funding transcation to be found
@@ -361,7 +365,7 @@ func fetchChanInfo(chanBucket kvdb.RBucket, c *OpenChannel, legacy bool) error {
 	}
 
 	c.ChanType = ChannelType(chanType)
-	c.chanStatus = ChannelStatus(chanStatus)
+	c.ChanStatus = ChannelStatus(chanStatus)
 
 	// If this is not the legacy format, we need to read the extra two new
 	// fields.
@@ -432,7 +436,7 @@ func putChanInfo(chanBucket kvdb.RwBucket, c *OpenChannel, legacy bool) error {
 	if err := mig.WriteElements(&w,
 		mig.ChannelType(c.ChanType), c.ChainHash, c.FundingOutpoint,
 		c.ShortChannelID, c.IsPending, c.IsInitiator,
-		mig.ChannelStatus(c.chanStatus), c.FundingBroadcastHeight,
+		mig.ChannelStatus(c.ChanStatus), c.FundingBroadcastHeight,
 		c.NumConfsRequired, c.ChannelFlags,
 		c.IdentityPub, c.Capacity, c.TotalMSatSent,
 		c.TotalMSatReceived,

--- a/channeldb/migration26/channel.go
+++ b/channeldb/migration26/channel.go
@@ -70,10 +70,6 @@ var (
 // NOTE: doesn't have the Packager field as it's not used in current migration.
 type OpenChannel struct {
 	mig25.OpenChannel
-
-	// chanStatus is the current status of this channel. If it is not in
-	// the state Default, it should not be used for forwarding payments.
-	chanStatus mig25.ChannelStatus
 }
 
 // FetchChanInfo deserializes the channel info based on the legacy boolean.
@@ -104,7 +100,7 @@ func FetchChanInfo(chanBucket kvdb.RBucket, c *OpenChannel, legacy bool) error {
 	}
 
 	c.ChanType = mig25.ChannelType(chanType)
-	c.chanStatus = mig25.ChannelStatus(chanStatus)
+	c.ChanStatus = mig25.ChannelStatus(chanStatus)
 
 	// If this is the legacy format, we need to read the extra two new
 	// fields.
@@ -239,7 +235,7 @@ func PutChanInfo(chanBucket kvdb.RwBucket, c *OpenChannel, legacy bool) error {
 	if err := mig.WriteElements(&w,
 		mig.ChannelType(c.ChanType), c.ChainHash, c.FundingOutpoint,
 		c.ShortChannelID, c.IsPending, c.IsInitiator,
-		mig.ChannelStatus(c.chanStatus), c.FundingBroadcastHeight,
+		mig.ChannelStatus(c.ChanStatus), c.FundingBroadcastHeight,
 		c.NumConfsRequired, c.ChannelFlags,
 		c.IdentityPub, c.Capacity, c.TotalMSatSent,
 		c.TotalMSatReceived,

--- a/channeldb/migration27/channel.go
+++ b/channeldb/migration27/channel.go
@@ -59,10 +59,6 @@ var (
 // NOTE: doesn't have the Packager field as it's not used in current migration.
 type OpenChannel struct {
 	mig26.OpenChannel
-
-	// chanStatus is the current status of this channel. If it is not in
-	// the state Default, it should not be used for forwarding payments.
-	chanStatus mig25.ChannelStatus
 }
 
 // FetchChanInfo deserializes the channel info based on the legacy boolean.
@@ -90,7 +86,7 @@ func FetchChanInfo(chanBucket kvdb.RBucket, c *OpenChannel, legacy bool) error {
 	}
 
 	c.ChanType = mig25.ChannelType(chanType)
-	c.chanStatus = mig25.ChannelStatus(chanStatus)
+	c.ChanStatus = mig25.ChannelStatus(chanStatus)
 
 	// For single funder channels that we initiated and have the funding
 	// transaction to, read the funding txn.
@@ -182,7 +178,7 @@ func PutChanInfo(chanBucket kvdb.RwBucket, c *OpenChannel, legacy bool) error {
 	if err := mig.WriteElements(&w,
 		mig.ChannelType(c.ChanType), c.ChainHash, c.FundingOutpoint,
 		c.ShortChannelID, c.IsPending, c.IsInitiator,
-		mig.ChannelStatus(c.chanStatus), c.FundingBroadcastHeight,
+		mig.ChannelStatus(c.ChanStatus), c.FundingBroadcastHeight,
 		c.NumConfsRequired, c.ChannelFlags,
 		c.IdentityPub, c.Capacity, c.TotalMSatSent,
 		c.TotalMSatReceived,

--- a/docs/release-notes/release-notes-0.15.0.md
+++ b/docs/release-notes/release-notes-0.15.0.md
@@ -172,6 +172,9 @@ from occurring that would result in an erroneous force close.](https://github.co
 * [Fixed an intermittent panic that would occur due to a violated assumption with our
   underlying database.](https://github.com/lightningnetwork/lnd/pull/6547)
 
+* [Fixed a wrong channel status inheritance used in `migration26` and
+  `migration27`](https://github.com/lightningnetwork/lnd/pull/6563).
+
 ## Routing
 
 * [Add a new `time_pref` parameter to the QueryRoutes and SendPayment APIs](https://github.com/lightningnetwork/lnd/pull/6024) that


### PR DESCRIPTION
Fixes #6558.

Previously, in `migration25.OpenChannel`, there was a private field `chanStatus` used to keep track of the channel status. The following migrations, `migration26` and `migration27` also have their own `OpenChannel` defined, with `migration26` inherited from `migration25`, and `migration27` inherited from `migration26`. The private field `chanStatus`, however, is NOT inherited and each of the migrations uses its own. This is fine for reading and writing as, under the hood, the `chanStatus` is just a `uint8` value. Because each migration has its own fetcher and putter, it can safely access its private field to read and write it correctly.

The issue pops up when we use the method `migration25.FundingTxPresent()`. Because it's evaluating its channel status using its own private field `chanStatus`, this field would always be the default value(`ChanStatusDefault`), leading the statement `!c.hasChanStatus(ChanStatusRestored)` to always be true. Thus a restored channel will be mistakenly considered to have funding tx present, causing failures in reading the channel info in the following migrations.

We fix this by exporting the `ChanStatus` field so its value can be set by following migrations.


### Affected migrations

Migration 26 and 27 will fail at decoding the funding tx step if we are the channel funder and the channel is restored. If they succeed, it means either,

1. we are not the channel funder, or,
2. the channel is funded externally, or,
3. the channel is not restored

And the data has been migrated correctly. Otherwise, the migrations will halt and `lnd` will quit with an error.