### PR TITLE
lncli: add payment-addr flag to buildroute 

### DIFF
--- a/cmd/lncli/cmd_payments.go
+++ b/cmd/lncli/cmd_payments.go
@@ -1360,6 +1360,11 @@ var buildRouteCommand = cli.Command{
 				"use for the first hop of the payment",
 			Value: 0,
 		},
+		cli.StringFlag{
+			Name: "payment_addr",
+			Usage: "hex encoded payment address to set in the " +
+				"last hop's mpp record",
+		},
 	},
 }
 
@@ -1394,12 +1399,24 @@ func buildRoute(ctx *cli.Context) error {
 		}
 	}
 
+	var (
+		payAddr []byte
+		err     error
+	)
+	if ctx.IsSet("payment_addr") {
+		payAddr, err = hex.DecodeString(ctx.String("payment_addr"))
+		if err != nil {
+			return fmt.Errorf("error parsing payment_addr: %v", err)
+		}
+	}
+
 	// Call BuildRoute rpc.
 	req := &routerrpc.BuildRouteRequest{
 		AmtMsat:        amtMsat,
 		FinalCltvDelta: int32(ctx.Int64("final_cltv_delta")),
 		HopPubkeys:     rpcHops,
 		OutgoingChanId: ctx.Uint64("outgoing_chan_id"),
+		PaymentAddr:    payAddr,
 	}
 
 	route, err := client.BuildRoute(ctxc, req)

--- a/docs/release-notes/release-notes-0.15.0.md
+++ b/docs/release-notes/release-notes-0.15.0.md
@@ -72,6 +72,9 @@ releases. Backward compatibility is not guaranteed!
   caveats/restrictions to be added to an existing macaroon (instead of needing
   to bake a new one). 
 
+* [Add `payment_addr` flag to `buildroute`](https://github.com/lightningnetwork/lnd/pull/6576)
+  so that the mpp record of the route can be set correctly.
+
 ## Neutrino
 
 [Neutrino now suports BIP


### PR DESCRIPTION
## Change Description

Fixes #6575 

In this PR, the `payment_addr` flag is added for the `buildroute` lncli command so that the mpp record doesnt need to be manually set.

## Steps to Test

1. Generate an invoice (should contain a payment address) at a destination.
2. Query a route to the destination and use this to construct a route using `buildroute`. Use the payment_addr field here.
3. now use `sendtoroute` to send to the above route.
4. if the payment_addr field was _not_ specified in step 2 then step 3 will fail with `incorrect payment details` and if the `payment_addr` field _is_ specified in step 2 (along with the correct amt flag), then the payment should succeed 
