### PR TITLE
lnwallet/btcwallet: use CheckTransactionStandard to validate txns before broadcast

### DIFF
--- a/docs/release-notes/release-notes-0.15.0.md
+++ b/docs/release-notes/release-notes-0.15.0.md
@@ -122,11 +122,10 @@ compact filters and block/block headers.
 * [Fixed an issue where lnd would end up sending an Error and triggering a force
   close.](https://github.com/lightningnetwork/lnd/pull/6518)
   
-## Neutrino
+## Bug Fixes
 
-* [New neutrino sub-server](https://github.com/lightningnetwork/lnd/pull/5652)
-  capable of status checks, adding, disconnecting and listing
-  peers, fetching compact filters and block/block headers.
+* [lnd will no longer attempt to broadcast transactions the violate the size
+  policy limit](https://github.com/lightningnetwork/lnd/pull/6583).
 
 * [Added signature length
   validation](https://github.com/lightningnetwork/lnd/pull/6314) when calling

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/lightningnetwork/lnd
 require (
 	github.com/NebulousLabs/go-upnp v0.0.0-20180202185039-29b680b06c82
 	github.com/Yawning/aez v0.0.0-20211027044916-e49e68abd344
-	github.com/btcsuite/btcd v0.22.0-beta.0.20220413172512-bf64c8bdbbbf
+	github.com/btcsuite/btcd v0.22.0-beta.0.20220526215018-fd7f41cdc565
 	github.com/btcsuite/btcd/btcec/v2 v2.2.0
 	github.com/btcsuite/btcd/btcutil v1.1.1
 	github.com/btcsuite/btcd/btcutil/psbt v1.1.4

--- a/go.sum
+++ b/go.sum
@@ -77,6 +77,8 @@ github.com/btcsuite/btcd v0.22.0-beta.0.20220207191057-4dc4ff7963b4/go.mod h1:7a
 github.com/btcsuite/btcd v0.22.0-beta.0.20220316175102-8d5c75c28923/go.mod h1:taIcYprAW2g6Z9S0gGUxyR+zDwimyDMK5ePOX+iJ2ds=
 github.com/btcsuite/btcd v0.22.0-beta.0.20220413172512-bf64c8bdbbbf h1:8lTakMpAAOKTe60bNhiEjUDtcZAlrst2MF49ekuA9yI=
 github.com/btcsuite/btcd v0.22.0-beta.0.20220413172512-bf64c8bdbbbf/go.mod h1:0QJIIN1wwIXF/3G/m87gIwGniDMDQqjVn4SZgnFpsYY=
+github.com/btcsuite/btcd v0.22.0-beta.0.20220526215018-fd7f41cdc565 h1:+91Bip9OihztiSeWImHj85YTb5giatqWVtxUWOIdmEE=
+github.com/btcsuite/btcd v0.22.0-beta.0.20220526215018-fd7f41cdc565/go.mod h1:0QJIIN1wwIXF/3G/m87gIwGniDMDQqjVn4SZgnFpsYY=
 github.com/btcsuite/btcd/btcec/v2 v2.1.0/go.mod h1:2VzYrv4Gm4apmbVVsSq5bqf1Ec8v56E48Vt0Y/umPgA=
 github.com/btcsuite/btcd/btcec/v2 v2.1.1/go.mod h1:ctjw4H1kknNJmRN4iP1R7bTQ+v3GJkZBd6mui8ZsAZE=
 github.com/btcsuite/btcd/btcec/v2 v2.1.3/go.mod h1:ctjw4H1kknNJmRN4iP1R7bTQ+v3GJkZBd6mui8ZsAZE=

--- a/lnwallet/test/test_interface.go
+++ b/lnwallet/test/test_interface.go
@@ -1828,197 +1828,210 @@ func testPublishTransaction(r *rpctest.Harness,
 		t.Fatalf("unable to obtain public key: %v", err)
 	}
 
-	// We will first check that publishing a transaction already in the
-	// mempool does NOT return an error. Create the tx.
-	tx1 := newTx(t, r, keyDesc.PubKey, alice, false)
+	t.Run("no_error_on_duplicate_tx", func(t *testing.T) {
+		// We will first check that publishing a transaction already in
+		// the mempool does NOT return an error. Create the tx.
+		tx1 := newTx(t, r, keyDesc.PubKey, alice, false)
 
-	// Publish the transaction.
-	err = alice.PublishTransaction(tx1, labels.External)
-	if err != nil {
-		t.Fatalf("unable to publish: %v", err)
-	}
+		// Publish the transaction.
+		err = alice.PublishTransaction(tx1, labels.External)
+		if err != nil {
+			t.Fatalf("unable to publish: %v", err)
+		}
 
-	txid1 := tx1.TxHash()
-	err = waitForMempoolTx(r, &txid1)
-	if err != nil {
-		t.Fatalf("tx not relayed to miner: %v", err)
-	}
+		txid1 := tx1.TxHash()
+		err = waitForMempoolTx(r, &txid1)
+		if err != nil {
+			t.Fatalf("tx not relayed to miner: %v", err)
+		}
 
-	// Publish the exact same transaction again. This should not return an
-	// error, even though the transaction is already in the mempool.
-	err = alice.PublishTransaction(tx1, labels.External)
-	if err != nil {
-		t.Fatalf("unable to publish: %v", err)
-	}
-
-	// Mine the transaction.
-	if _, err := r.Client.Generate(1); err != nil {
-		t.Fatalf("unable to generate block: %v", err)
-	}
-
-	// We'll now test that we don't get an error if we try to publish a
-	// transaction that is already mined.
-	//
-	// Create a new transaction. We must do this to properly test the
-	// reject messages from our peers. They might only send us a reject
-	// message for a given tx once, so we create a new to make sure it is
-	// not just immediately rejected.
-	tx2 := newTx(t, r, keyDesc.PubKey, alice, false)
-
-	// Publish this tx.
-	err = alice.PublishTransaction(tx2, labels.External)
-	if err != nil {
-		t.Fatalf("unable to publish: %v", err)
-	}
-
-	// Mine the transaction.
-	if err := mineAndAssert(r, tx2); err != nil {
-		t.Fatalf("unable to mine tx: %v", err)
-	}
-
-	// Publish the transaction again. It is already mined, and we don't
-	// expect this to return an error.
-	err = alice.PublishTransaction(tx2, labels.External)
-	if err != nil {
-		t.Fatalf("unable to publish: %v", err)
-	}
-
-	// We'll do the next mempool check on both RBF and non-RBF enabled
-	// transactions.
-	var (
-		txFee         = btcutil.Amount(0.005 * btcutil.SatoshiPerBitcoin)
-		tx3, tx3Spend *wire.MsgTx
-	)
-
-	for _, rbf := range []bool{false, true} {
-		// Now we'll try to double spend an output with a different
-		// transaction. Create a new tx and publish it. This is the
-		// output we'll try to double spend.
-		tx3 = newTx(t, r, keyDesc.PubKey, alice, false)
-		err := alice.PublishTransaction(tx3, labels.External)
+		// Publish the exact same transaction again. This should not
+		// return an error, even though the transaction is already in
+		// the mempool.
+		err = alice.PublishTransaction(tx1, labels.External)
 		if err != nil {
 			t.Fatalf("unable to publish: %v", err)
 		}
 
 		// Mine the transaction.
-		if err := mineAndAssert(r, tx3); err != nil {
-			t.Fatalf("unable to mine tx: %v", err)
+		if _, err := r.Client.Generate(1); err != nil {
+			t.Fatalf("unable to generate block: %v", err)
 		}
+	})
 
-		// Now we create a transaction that spends the output from the
-		// tx just mined.
-		tx4, err := txFromOutput(
-			tx3, alice.Cfg.Signer, keyDesc.PubKey,
-			keyDesc.PubKey, txFee, rbf,
-		)
-		if err != nil {
-			t.Fatal(err)
-		}
+	t.Run("no_error_on_minged_tx", func(t *testing.T) {
+		// We'll now test that we don't get an error if we try to
+		// publish a transaction that is already mined.
+		//
+		// Create a new transaction. We must do this to properly test
+		// the reject messages from our peers. They might only send us
+		// a reject message for a given tx once, so we create a new to
+		// make sure it is not just immediately rejected.
+		tx2 := newTx(t, r, keyDesc.PubKey, alice, false)
 
-		// This should be accepted into the mempool.
-		err = alice.PublishTransaction(tx4, labels.External)
+		// Publish this tx.
+		err = alice.PublishTransaction(tx2, labels.External)
 		if err != nil {
 			t.Fatalf("unable to publish: %v", err)
 		}
 
-		// Keep track of the last successfully published tx to spend
-		// tx3.
-		tx3Spend = tx4
-
-		txid4 := tx4.TxHash()
-		err = waitForMempoolTx(r, &txid4)
-		if err != nil {
-			t.Fatalf("tx not relayed to miner: %v", err)
-		}
-
-		// Create a new key we'll pay to, to ensure we create a unique
-		// transaction.
-		keyDesc2, err := alice.DeriveNextKey(
-			keychain.KeyFamilyMultiSig,
-		)
-		if err != nil {
-			t.Fatalf("unable to obtain public key: %v", err)
-		}
-
-		// Create a new transaction that spends the output from tx3,
-		// and that pays to a different address. We expect this to be
-		// rejected because it is a double spend.
-		tx5, err := txFromOutput(
-			tx3, alice.Cfg.Signer, keyDesc.PubKey,
-			keyDesc2.PubKey, txFee, rbf,
-		)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		err = alice.PublishTransaction(tx5, labels.External)
-		if err != lnwallet.ErrDoubleSpend {
-			t.Fatalf("expected ErrDoubleSpend, got: %v", err)
-		}
-
-		// Create another transaction that spends the same output, but
-		// has a higher fee. We expect also this tx to be rejected for
-		// non-RBF enabled transactions, while it should succeed
-		// otherwise.
-		pubKey3, err := alice.DeriveNextKey(keychain.KeyFamilyMultiSig)
-		if err != nil {
-			t.Fatalf("unable to obtain public key: %v", err)
-		}
-		tx6, err := txFromOutput(
-			tx3, alice.Cfg.Signer, keyDesc.PubKey,
-			pubKey3.PubKey, 2*txFee, rbf,
-		)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		// Expect rejection in non-RBF case.
-		expErr := lnwallet.ErrDoubleSpend
-		if rbf {
-			// Expect success in rbf case.
-			expErr = nil
-			tx3Spend = tx6
-		}
-		err = alice.PublishTransaction(tx6, labels.External)
-		if err != expErr {
-			t.Fatalf("expected ErrDoubleSpend, got: %v", err)
-		}
-
-		// Mine the tx spending tx3.
-		if err := mineAndAssert(r, tx3Spend); err != nil {
+		// Mine the transaction.
+		if err := mineAndAssert(r, tx2); err != nil {
 			t.Fatalf("unable to mine tx: %v", err)
 		}
-	}
 
-	// At last we try to spend an output already spent by a confirmed
-	// transaction.
-	// TODO(halseth): we currently skip this test for neutrino, as the
-	// backing btcd node will consider the tx being an orphan, and will
-	// accept it. Should look into if this is the behavior also for
-	// bitcoind, and update test accordingly.
-	if alice.BackEnd() != "neutrino" {
-		// Create another tx spending tx3.
-		pubKey4, err := alice.DeriveNextKey(
-			keychain.KeyFamilyMultiSig,
-		)
+		// Publish the transaction again. It is already mined, and we
+		// don't expect this to return an error.
+		err = alice.PublishTransaction(tx2, labels.External)
 		if err != nil {
-			t.Fatalf("unable to obtain public key: %v", err)
+			t.Fatalf("unable to publish: %v", err)
 		}
-		tx7, err := txFromOutput(
-			tx3, alice.Cfg.Signer, keyDesc.PubKey,
-			pubKey4.PubKey, txFee, false,
-		)
+	})
 
-		if err != nil {
-			t.Fatal(err)
-		}
+	// We'll do the next mempool check on both RBF and non-RBF
+	// enabled transactions.
+	var (
+		txFee         = btcutil.Amount(0.005 * btcutil.SatoshiPerBitcoin)
+		tx3, tx3Spend *wire.MsgTx
+	)
+	t.Run("rbf_tests", func(t *testing.T) {
 
-		// Expect rejection.
-		err = alice.PublishTransaction(tx7, labels.External)
-		if err != lnwallet.ErrDoubleSpend {
-			t.Fatalf("expected ErrDoubleSpend, got: %v", err)
+		for _, rbf := range []bool{false, true} {
+			// Now we'll try to double spend an output with a
+			// different transaction. Create a new tx and publish
+			// it. This is the output we'll try to double spend.
+			tx3 = newTx(t, r, keyDesc.PubKey, alice, false)
+			err := alice.PublishTransaction(tx3, labels.External)
+			if err != nil {
+				t.Fatalf("unable to publish: %v", err)
+			}
+
+			// Mine the transaction.
+			if err := mineAndAssert(r, tx3); err != nil {
+				t.Fatalf("unable to mine tx: %v", err)
+			}
+
+			// Now we create a transaction that spends the output
+			// from the tx just mined.
+			tx4, err := txFromOutput(
+				tx3, alice.Cfg.Signer, keyDesc.PubKey,
+				keyDesc.PubKey, txFee, rbf,
+			)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			// This should be accepted into the mempool.
+			err = alice.PublishTransaction(tx4, labels.External)
+			if err != nil {
+				t.Fatalf("unable to publish: %v", err)
+			}
+
+			// Keep track of the last successfully published tx to
+			// spend tx3.
+			tx3Spend = tx4
+
+			txid4 := tx4.TxHash()
+			err = waitForMempoolTx(r, &txid4)
+			if err != nil {
+				t.Fatalf("tx not relayed to miner: %v", err)
+			}
+
+			// Create a new key we'll pay to, to ensure we create a
+			// unique transaction.
+			keyDesc2, err := alice.DeriveNextKey(
+				keychain.KeyFamilyMultiSig,
+			)
+			if err != nil {
+				t.Fatalf("unable to obtain public key: %v", err)
+			}
+
+			// Create a new transaction that spends the output from
+			// tx3, and that pays to a different address. We expect
+			// this to be rejected because it is a double spend.
+			tx5, err := txFromOutput(
+				tx3, alice.Cfg.Signer, keyDesc.PubKey,
+				keyDesc2.PubKey, txFee, rbf,
+			)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			err = alice.PublishTransaction(tx5, labels.External)
+			if err != lnwallet.ErrDoubleSpend {
+				t.Fatalf("expected ErrDoubleSpend, got: %v", err)
+			}
+
+			// Create another transaction that spends the same
+			// output, but has a higher fee. We expect also this tx
+			// to be rejected for non-RBF enabled transactions,
+			// while it should succeed otherwise.
+			pubKey3, err := alice.DeriveNextKey(
+				keychain.KeyFamilyMultiSig,
+			)
+			if err != nil {
+				t.Fatalf("unable to obtain public key: %v", err)
+			}
+			tx6, err := txFromOutput(
+				tx3, alice.Cfg.Signer, keyDesc.PubKey,
+				pubKey3.PubKey, 2*txFee, rbf,
+			)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			// Expect rejection in non-RBF case.
+			expErr := lnwallet.ErrDoubleSpend
+			if rbf {
+				// Expect success in rbf case.
+				expErr = nil
+				tx3Spend = tx6
+			}
+			err = alice.PublishTransaction(tx6, labels.External)
+			if err != expErr {
+				t.Fatalf("expected ErrDoubleSpend, got: %v", err)
+			}
+
+			// Mine the tx spending tx3.
+			if err := mineAndAssert(r, tx3Spend); err != nil {
+				t.Fatalf("unable to mine tx: %v", err)
+			}
 		}
-	}
+	})
+
+	t.Run("tx_double_spend", func(t *testing.T) {
+		// At last we try to spend an output already spent by a
+		// confirmed transaction.
+		//
+		// TODO(halseth): we currently skip this test for neutrino, as
+		// the backing btcd node will consider the tx being an orphan,
+		// and will accept it. Should look into if this is the behavior
+		// also for bitcoind, and update test accordingly.
+		if alice.BackEnd() != "neutrino" {
+			// Create another tx spending tx3.
+			pubKey4, err := alice.DeriveNextKey(
+				keychain.KeyFamilyMultiSig,
+			)
+			if err != nil {
+				t.Fatalf("unable to obtain public key: %v", err)
+			}
+			tx7, err := txFromOutput(
+				tx3, alice.Cfg.Signer, keyDesc.PubKey,
+				pubKey4.PubKey, txFee, false,
+			)
+
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			// Expect rejection.
+			err = alice.PublishTransaction(tx7, labels.External)
+			if err != lnwallet.ErrDoubleSpend {
+				t.Fatalf("expected ErrDoubleSpend, got: %v", err)
+			}
+		}
+	})
+	})
 }
 
 func testSignOutputUsingTweaks(r *rpctest.Harness,


### PR DESCRIPTION
In this commit, we start to use the `CheckTransactionStandard` function
from the `mempool` package to validate transactions further before
broadcast. This'll help catch instances where we make a massive
transaction, and therefor can't actually propagate it across the
network.

Fixes https://github.com/lightningnetwork/lnd/issues/4760
Fixes https://github.com/lightningnetwork/lnd/issues/6556