### PR TITLE
peer: add pubkey to log messages

### DIFF
--- a/docs/release-notes/release-notes-0.15.1.md
+++ b/docs/release-notes/release-notes-0.15.1.md
@@ -9,6 +9,7 @@
 
 * [Add minor comment](https://github.com/lightningnetwork/lnd/pull/6559) on
   subscribe/cancel/lookup invoice parameter encoding.
+* [Log pubkey for peer related messages](https://github.com/lightningnetwork/lnd/pull/6588).
   
 ## RPC Server
 
@@ -17,6 +18,7 @@
 
 # Contributors (Alphabetical Order)
 
+* Carsten Otto
 * Elle Mouton
 * ErikEk
 * Priyansh Rastogi

--- a/peer/brontide_test.go
+++ b/peer/brontide_test.go
@@ -961,6 +961,7 @@ func TestStaticRemoteDowngrade(t *testing.T) {
 					WritePool:      writePool,
 					PongBuf:        make([]byte, lnwire.MaxPongBytes),
 				},
+				log: peerLog,
 			}
 
 			var b bytes.Buffer


### PR DESCRIPTION
## Change Description

Fixes #6589

This adds the peer's pubkey as a prefix to most log messages in "brontide.go". One example that is improved by this:

BEFORE:
```
[INF] CHCL: ChannelPoint(123:1): computing fee compromise, ideal=284, last_sent=804, remote_offer=1327
[ERR] PEER: unable to process close msg: couldn't find compromise fee
```

AFTER (where abc is the peer's pubkey):
```
[INF] CHCL: ChannelPoint(123:1): computing fee compromise, ideal=284, last_sent=804, remote_offer=1327
[ERR] PEER: Peer(abc): unable to process close msg: couldn't find compromise fee
```

## Pull Request Checklist
### Testing
- [ ] Your PR passes all CI checks.
- [x] Tests covering the positive and negative (error paths) are included.
- [x] Bug fixes contain tests triggering the bug to prevent regressions.

### Code Style and Documentation
- [x] The change obeys the [Code Documentation and Commenting](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#CodeDocumentation) guidelines, and lines wrap at 80.
- [x] Commits follow the [Ideal Git Commit Structure](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#IdealGitCommitStructure).
- [x] Any new logging statements use an appropriate subsystem and logging level.
- [x]  [There is a change description in the release notes](https://github.com/lightningnetwork/lnd/tree/master/docs/release-notes), or `[skip ci]` in the commit message for small changes.

📝 Please see our  [Contribution Guidelines](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md) for further guidance.