### PR TITLE
channeldb: fix data race in TestSerializeRevocationLog

### DIFF
--- a/channeldb/revocation_log_test.go
+++ b/channeldb/revocation_log_test.go
@@ -213,6 +213,7 @@ func TestSerializeRevocationLog(t *testing.T) {
 
 	// Copy the testRevocationLog.
 	rl := testRevocationLog
+	rl.HTLCEntries = []*HTLCEntry{&testHTLCEntry}
 
 	// Write the tlv stream.
 	buf := bytes.NewBuffer([]byte{})

--- a/docs/release-notes/release-notes-0.15.0.md
+++ b/docs/release-notes/release-notes-0.15.0.md
@@ -283,6 +283,9 @@ from occurring that would result in an erroneous force close.](https://github.co
 * [Minor fix](https://github.com/lightningnetwork/lnd/pull/6535) to
   how bitcoind.rpccookie and bitocind.config are parsed from config file.
 
+* [Fix a data race found when running unit test for revocation log](https://github.com/lightningnetwork/lnd/pull/6594).
+
+
 ## RPC Server
 
 * [Add value to the field


### PR DESCRIPTION
When testing serializing revocation log, we need to also copy its
`HTLCEntries` as the serialization of the HTLC involves a writing to the
`htlc.amtTlv` field.

The build,
```
WARNING: DATA RACE
Read at 0x000000eba590 by goroutine 169:
  reflect.Value.Uint()
      /opt/hostedtoolcache/go/1.18.2/x64/src/reflect/value.go:2506 +0xb0d
  reflect.deepValueEqual()
      /opt/hostedtoolcache/go/1.18.2/x64/src/reflect/deepequal.go:162 +0xa60
  reflect.deepValueEqual()
      /opt/hostedtoolcache/go/1.18.2/x64/src/reflect/deepequal.go:130 +0x209b
  reflect.deepValueEqual()
      /opt/hostedtoolcache/go/1.18.2/x64/src/reflect/deepequal.go:127 +0xf79
  reflect.deepValueEqual()
      /opt/hostedtoolcache/go/1.18.2/x64/src/reflect/deepequal.go:113 +0x1f35
  reflect.deepValueEqual()
      /opt/hostedtoolcache/go/1.18.2/x64/src/reflect/deepequal.go:130 +0x209b
  reflect.DeepEqual()
      /opt/hostedtoolcache/go/1.18.2/x64/src/reflect/deepequal.go:237 +0x3f9
  github.com/stretchr/testify/assert.ObjectsAreEqual()
      /home/runner/work/go/pkg/mod/github.com/stretchr/testify@v1.7.1/assert/assertions.go:65 +0x184
  github.com/stretchr/testify/assert.Equal()
      /home/runner/work/go/pkg/mod/github.com/stretchr/testify@v1.7.1/assert/assertions.go:343 +0x212
  github.com/stretchr/testify/require.Equal()
      /home/runner/work/go/pkg/mod/github.com/stretchr/testify@v1.7.1/require/require.go:162 +0xc8
  github.com/lightningnetwork/lnd/channeldb.TestPutRevocationLog.func2()
      /home/runner/work/lnd/lnd/channeldb/revocation_log_test.go:459 +0x314
  testing.tRunner()
      /opt/hostedtoolcache/go/1.18.2/x64/src/testing/testing.go:1439 +0x213
  testing.(*T).Run.func1()
      /opt/hostedtoolcache/go/1.18.2/x64/src/testing/testing.go:1486 +0x47

Previous write at 0x000000eba590 by goroutine 115:
  github.com/lightningnetwork/lnd/channeldb.serializeHTLCEntries()
      /home/runner/work/lnd/lnd/channeldb/revocation_log.go:320 +0xc4
  github.com/lightningnetwork/lnd/channeldb.serializeRevocationLog()
      /home/runner/work/lnd/lnd/channeldb/revocation_log.go:307 +0xba
  github.com/lightningnetwork/lnd/channeldb.TestSerializeRevocationLog()
      /home/runner/work/lnd/lnd/channeldb/revocation_log_test.go:219 +0x170
  testing.tRunner()
      /opt/hostedtoolcache/go/1.18.2/x64/src/testing/testing.go:1439 +0x213
  testing.(*T).Run.func1()
      /opt/hostedtoolcache/go/1.18.2/x64/src/testing/testing.go:1486 +0x47

Goroutine 169 (running) created at:
  testing.(*T).Run()
      /opt/hostedtoolcache/go/1.18.2/x64/src/testing/testing.go:1486 +0x724
  github.com/lightningnetwork/lnd/channeldb.TestPutRevocationLog()
      /home/runner/work/lnd/lnd/channeldb/revocation_log_test.go:450 +0x89e
  testing.tRunner()
      /opt/hostedtoolcache/go/1.18.2/x64/src/testing/testing.go:1439 +0x213
  testing.(*T).Run.func1()
      /opt/hostedtoolcache/go/1.18.2/x64/src/testing/testing.go:1486 +0x47

Goroutine 115 (finished) created at:
  testing.(*T).Run()
      /opt/hostedtoolcache/go/1.18.2/x64/src/testing/testing.go:1486 +0x724
  testing.runTests.func1()
      /opt/hostedtoolcache/go/1.18.2/x64/src/testing/testing.go:1839 +0x99
  testing.tRunner()
      /opt/hostedtoolcache/go/1.18.2/x64/src/testing/testing.go:1439 +0x213
  testing.runTests()
      /opt/hostedtoolcache/go/1.18.2/x64/src/testing/testing.go:1837 +0x7e4
  testing.(*M).Run()
      /opt/hostedtoolcache/go/1.18.2/x64/src/testing/testing.go:1719 +0xa71
  github.com/lightningnetwork/lnd/kvdb.RunTests()
      /home/runner/work/go/pkg/mod/github.com/lightningnetwork/lnd/kvdb@v1.3.1/test_utils.go:23 +0x2e
  github.com/lightningnetwork/lnd/channeldb.TestMain()
      /home/runner/work/lnd/lnd/channeldb/setup_test.go:10 +0x318
  main.main()
      _testmain.go:333 +0x313
==================
==================
WARNING: DATA RACE
Read at 0x000000eba598 by goroutine 169:
  reflect.Value.Uint()
      /opt/hostedtoolcache/go/1.18.2/x64/src/reflect/value.go:2500 +0xa[54](https://github.com/lightningnetwork/lnd/runs/6648963749?check_suite_focus=true#step:6:55)
  reflect.deepValueEqual()
      /opt/hostedtoolcache/go/1.18.2/x64/src/reflect/deepequal.go:162 +0xa60
  reflect.deepValueEqual()
      /opt/hostedtoolcache/go/1.18.2/x64/src/reflect/deepequal.go:130 +0x209b
  reflect.deepValueEqual()
      /opt/hostedtoolcache/go/1.18.2/x64/src/reflect/deepequal.go:127 +0xf79
  reflect.deepValueEqual()
      /opt/hostedtoolcache/go/1.18.2/x64/src/reflect/deepequal.go:113 +0x1f35
  reflect.deepValueEqual()
      /opt/hostedtoolcache/go/1.18.2/x64/src/reflect/deepequal.go:130 +0x209b
  reflect.DeepEqual()
      /opt/hostedtoolcache/go/1.18.2/x64/src/reflect/deepequal.go:237 +0x3f9
  github.com/stretchr/testify/assert.ObjectsAreEqual()
      /home/runner/work/go/pkg/mod/github.com/stretchr/testify@v1.7.1/assert/assertions.go:65 +0x184
  github.com/stretchr/testify/assert.Equal()
      /home/runner/work/go/pkg/mod/github.com/stretchr/testify@v1.7.1/assert/assertions.go:343 +0x212
  github.com/stretchr/testify/require.Equal()
      /home/runner/work/go/pkg/mod/github.com/stretchr/testify@v1.7.1/require/require.go:162 +0xc8
  github.com/lightningnetwork/lnd/channeldb.TestPutRevocationLog.func2()
      /home/runner/work/lnd/lnd/channeldb/revocation_log_test.go:4[59](https://github.com/lightningnetwork/lnd/runs/6648963749?check_suite_focus=true#step:6:60) +0x314
  testing.tRunner()
      /opt/hostedtoolcache/go/1.18.2/x[64](https://github.com/lightningnetwork/lnd/runs/6648963749?check_suite_focus=true#step:6:65)/src/testing/testing.go:1439 +0x213
  testing.(*T).Run.func1()
      /opt/hostedtoolcache/go/1.18.2/x64/src/testing/testing.go:1486 +0x47

Previous write at 0x000000eba598 by goroutine 115:
  github.com/lightningnetwork/lnd/channeldb.serializeHTLCEntries()
      /home/runner/work/lnd/lnd/channeldb/revocation_log.go:316 +0x98
  github.com/lightningnetwork/lnd/channeldb.serializeRevocationLog()
      /home/runner/work/lnd/lnd/channeldb/revocation_log.go:307 +0xba
  github.com/lightningnetwork/lnd/channeldb.TestSerializeRevocationLog()
      /home/runner/work/lnd/lnd/channeldb/revocation_log_test.go:219 +0x170
  testing.tRunner()
      /opt/hostedtoolcache/go/1.18.2/x64/src/testing/testing.go:1439 +0x213
  testing.(*T).Run.func1()
      /opt/hostedtoolcache/go/1.18.2/x64/src/testing/testing.go:1486 +0x47

Goroutine 1[69](https://github.com/lightningnetwork/lnd/runs/6648963749?check_suite_focus=true#step:6:70) (running) created at:
  testing.(*T).Run()
      /opt/hostedtoolcache/go/1.18.2/x64/src/testing/testing.go:1486 +0x724
  github.com/lightningnetwork/lnd/channeldb.TestPutRevocationLog()
      /home/runner/work/lnd/lnd/channeldb/revocation_log_test.go:450 +0x89e
  testing.tRunner()
      /opt/hostedtoolcache/go/1.18.2/x64/src/testing/testing.go:1439 +0x213
  testing.(*T).Run.func1()
      /opt/hostedtoolcache/go/1.18.2/x64/src/testing/testing.go:1486 +0x47

Goroutine 115 (finished) created at:
  testing.(*T).Run()
      /opt/hostedtoolcache/go/1.18.2/x64/src/testing/testing.go:1486 +0x724
  testing.runTests.func1()
      /opt/hostedtoolcache/go/1.18.2/x64/src/testing/testing.go:1839 +0x99
  testing.tRunner()
      /opt/hostedtoolcache/go/1.18.2/x64/src/testing/testing.go:1439 +0x213
  testing.runTests()
      /opt/hostedtoolcache/go/1.18.2/x64/src/testing/testing.go:1837 +0x7e4
  testing.(*M).Run()
      /opt/hostedtoolcache/go/1.18.2/x64/src/testing/testing.go:1[71](https://github.com/lightningnetwork/lnd/runs/6648963749?check_suite_focus=true#step:6:72)9 +0xa71
  github.com/lightningnetwork/lnd/kvdb.RunTests()
      /home/runner/work/go/pkg/mod/github.com/lightningnetwork/lnd/kvdb@v1.3.1/test_utils.go:23 +0x2e
  github.com/lightningnetwork/lnd/channeldb.TestMain()
      /home/runner/work/lnd/lnd/channeldb/setup_test.go:10 +0x318
  main.main()
      _testmain.go:333 +0x313
==================
--- FAIL: TestPutRevocationLog (0.07s)
    --- FAIL: TestPutRevocationLog/dust_htlc_not_saved (0.00s)
        testing.go:[131](https://github.com/lightningnetwork/lnd/runs/6648963749?check_suite_focus=true#step:6:132)2: race detected during execution of test
    testing.go:1312: race detected during execution of test
```