### PR TITLE
invoices: fix deadlock in the invoice registry

### DIFF
--- a/docs/release-notes/release-notes-0.15.0.md
+++ b/docs/release-notes/release-notes-0.15.0.md
@@ -121,7 +121,10 @@ compact filters and block/block headers.
 
 * [Fixed an issue where lnd would end up sending an Error and triggering a force
   close.](https://github.com/lightningnetwork/lnd/pull/6518)
-  
+
+* [Fixed deadlock in the invoice registry](
+  https://github.com/lightningnetwork/lnd/pull/6600)
+
 ## Neutrino
 
 * [New neutrino sub-server](https://github.com/lightningnetwork/lnd/pull/5652)


### PR DESCRIPTION
## Change Description

This PR fixes two deadlocks, both resulting from interaction between the invoice registry event loop and different internal data structures. Found while checking CI logs (https://github.com/lightningnetwork/lnd/runs/6659386315?check_suite_focus=true).

The deadlock in the first commit is presented below, the second one didn't manifest. It is not easy to reproduce as we need to fill up the `invoiceEvents` channel too.

```
goroutine 3483 [semacquire, 59 minutes]:
sync.runtime_SemacquireMutex(0x0?, 0xa0?, 0x0?)
	/opt/hostedtoolcache/go/1.18.2/x64/src/runtime/sema.go:71 +0x25
sync.(*RWMutex).RLock(...)
	/opt/hostedtoolcache/go/1.18.2/x64/src/sync/rwmutex.go:63
github.com/lightningnetwork/lnd/invoices.(*InvoiceRegistry).copySingleClients(0xc0281da980)
	/home/runner/work/lnd/lnd/invoices/invoiceregistry.go:1742 +0x6b
github.com/lightningnetwork/lnd/invoices.(*InvoiceRegistry).dispatchToSingleClients(0xc0281da980, 0xc0211aa210)
	/home/runner/work/lnd/lnd/invoices/invoiceregistry.go:350 +0x3b
github.com/lightningnetwork/lnd/invoices.(*InvoiceRegistry).invoiceEventLoop(0xc0281da980)
	/home/runner/work/lnd/lnd/invoices/invoiceregistry.go:315 +0x20e
created by github.com/lightningnetwork/lnd/invoices.(*InvoiceRegistry).Start
	/home/runner/work/lnd/lnd/invoices/invoiceregistry.go:244 +0x105

goroutine 3676 [semacquire, 59 minutes]:
sync.runtime_SemacquireMutex(0x8?, 0x8?, 0x7f69c61fe108?)
	/opt/hostedtoolcache/go/1.18.2/x64/src/runtime/sema.go:71 +0x25
sync.(*Mutex).lockSlow(0xc0281da980)
	/opt/hostedtoolcache/go/1.18.2/x64/src/sync/mutex.go:162 +0x165
sync.(*Mutex).Lock(...)
	/opt/hostedtoolcache/go/1.18.2/x64/src/sync/mutex.go:81
sync.(*RWMutex).Lock(0xe0?)
	/opt/hostedtoolcache/go/1.18.2/x64/src/sync/rwmutex.go:139 +0x36
github.com/lightningnetwork/lnd/invoices.(*InvoiceRegistry).AddInvoice(0xc0281da980, 0xc00633d340, {0xd5, 0xc3, 0x4d, 0x81, 0xb5, 0xe5, 0xcf, 0x3f, ...})
	/home/runner/work/lnd/lnd/invoices/invoiceregistry.go:563 +0x3d
```
