### PR TITLE
chainreg: set default fee rate to 10000ppm

### DIFF
--- a/chainreg/chainregistry.go
+++ b/chainreg/chainregistry.go
@@ -124,7 +124,7 @@ const (
 	DefaultBitcoinBaseFeeMSat = lnwire.MilliSatoshi(1000)
 
 	// DefaultBitcoinFeeRate is the default forwarding fee rate.
-	DefaultBitcoinFeeRate = lnwire.MilliSatoshi(1)
+	DefaultBitcoinFeeRate = lnwire.MilliSatoshi(10000)
 
 	// DefaultBitcoinTimeLockDelta is the default forwarding time lock
 	// delta.

--- a/docs/release-notes/release-notes-0.15.0.md
+++ b/docs/release-notes/release-notes-0.15.0.md
@@ -284,7 +284,8 @@ from occurring that would result in an erroneous force close.](https://github.co
   how bitcoind.rpccookie and bitocind.config are parsed from config file.
 
 * [Fix a data race found when running unit test for revocation log](https://github.com/lightningnetwork/lnd/pull/6594).
-
+  
+* [Set default fee rate to 10000ppm](https://github.com/lightningnetwork/lnd/pull/6610).
 
 ## RPC Server
 

--- a/lntest/itest/lnd_routing_test.go
+++ b/lntest/itest/lnd_routing_test.go
@@ -607,6 +607,7 @@ func runMultiHopSendToRoute(net *lntest.NetworkHarness, t *harnessTest,
 	// default base fee, as we didn't modify the fee structure when
 	// creating the seed nodes in the network.
 	const baseFee = 1
+	const feeRatePpm = 10000
 
 	// At this point all the channels within our proto network should be
 	// shifted by 5k satoshis in the direction of Carol, the sink within the
@@ -615,14 +616,15 @@ func runMultiHopSendToRoute(net *lntest.NetworkHarness, t *harnessTest,
 	// transaction, in channel Alice->Bob->Carol, order is Carol, Bob,
 	// Alice.
 	const amountPaid = int64(5000)
+	const fees = amountPaid*feeRatePpm/1000000 + baseFee*numPayments
 	assertAmountPaid(t, "Bob(local) => Carol(remote)", carol,
 		bobFundPoint, int64(0), amountPaid)
 	assertAmountPaid(t, "Bob(local) => Carol(remote)", net.Bob,
 		bobFundPoint, amountPaid, int64(0))
 	assertAmountPaid(t, "Alice(local) => Bob(remote)", net.Bob,
-		aliceFundPoint, int64(0), amountPaid+(baseFee*numPayments))
+		aliceFundPoint, int64(0), amountPaid+fees)
 	assertAmountPaid(t, "Alice(local) => Bob(remote)", alice,
-		aliceFundPoint, amountPaid+(baseFee*numPayments), int64(0))
+		aliceFundPoint, amountPaid+fees, int64(0))
 
 	closeChannelAndAssert(t, net, alice, chanPointAlice, false)
 	closeChannelAndAssert(t, net, carol, chanPointBob, false)

--- a/sample-lnd.conf
+++ b/sample-lnd.conf
@@ -47,8 +47,8 @@
 ; (old tls files must be deleted if changed)
 ; tlsextradomain=
 
-; If set, then all certs will automatically be refreshed if they're close to 
-; expiring, or if any parameters related to extra IPs or domains in the cert 
+; If set, then all certs will automatically be refreshed if they're close to
+; expiring, or if any parameters related to extra IPs or domains in the cert
 ; change.
 ; tlsautorefresh=true
 
@@ -116,8 +116,8 @@
 ; 'largest' and 'random'.
 ; coin-selection-strategy=largest
 
-; A period to wait before for closing channels with outgoing htlcs that have 
-; timed out and are a result of this nodes instead payment. In addition to our 
+; A period to wait before for closing channels with outgoing htlcs that have
+; timed out and are a result of this nodes instead payment. In addition to our
 ; current block based deadline, if specified this grace period will also be taken
 ; into account. Valid time units are {s, m, h}.
 ; payments-expiration-grace-period=30s
@@ -209,8 +209,8 @@
 
 ; Debug logging level.
 ; Valid levels are {trace, debug, info, warn, error, critical}
-; You may also specify <global-level>,<subsystem>=<level>,<subsystem2>=<level>,... 
-; to set log level for individual subsystems. Use lncli debuglevel --show to 
+; You may also specify <global-level>,<subsystem>=<level>,<subsystem2>=<level>,...
+; to set log level for individual subsystems. Use lncli debuglevel --show to
 ; list available subsystems.
 ; debuglevel=debug,PEER=info
 
@@ -280,7 +280,7 @@
 ; minchansize=
 
 ; The largest channel size (in satoshis) that we should accept. Incoming
-; channels larger than this will be rejected. For non-Wumbo channels this 
+; channels larger than this will be rejected. For non-Wumbo channels this
 ; limit remains 16777215 satoshis by default as specified in BOLT-0002.
 ; For wumbo channels this limit is 1,000,000,000 satoshis (10 BTC).
 ; Set this config option explicitly to restrict your maximum channel size
@@ -303,7 +303,7 @@
 ; The maximum time that is allowed to pass while waiting for the remote party
 ; to revoke a locally initiated commitment state. Setting this to a longer
 ; duration if a slow response is expected from the remote party or large
-; number of payments are attempted at the same time. 
+; number of payments are attempted at the same time.
 ; (default: 1m0s)
 ; pending-commit-interval=5m
 
@@ -321,8 +321,8 @@
 ; on the network. (default: 19m0s)
 ; chan-enable-timeout=22m
 
-; The duration that must elapse after first detecting that an already active 
-; channel is actually inactive and sending channel update disabling it to the 
+; The duration that must elapse after first detecting that an already active
+; channel is actually inactive and sending channel update disabling it to the
 ; network. The pending disable can be canceled if the peer reconnects and becomes
 ; stable for chan-enable-timeout before the disable update is sent.
 ; (default: 20m0s)
@@ -427,8 +427,8 @@
 ; can be tuned to save bandwidth for light clients or routing nodes. (default: 3)
 ; numgraphsyncpeers=9
 
-; If true, lnd will start the Prometheus exporter. Prometheus flags are 
-; behind a build/compile flag and are not available by default. lnd must be built 
+; If true, lnd will start the Prometheus exporter. Prometheus flags are
+; behind a build/compile flag and are not available by default. lnd must be built
 ; with the monitoring tag; `make && make install tags=monitoring` to activate them.
 ; prometheus.enable=true
 
@@ -520,7 +520,7 @@ bitcoin.node=btcd
 ; The fee rate used when forwarding payments on our channels. The total fee
 ; charged is basefee + (amount * feerate / 1000000), where amount is the
 ; forwarded amount.
-; bitcoin.feerate=1
+; bitcoin.feerate=10000
 
 ; The CLTV delta we will subtract from a forwarded HTLC's timelock value.
 ; bitcoin.timelockdelta=40
@@ -631,7 +631,7 @@ bitcoin.node=btcd
 ; neutrino.connect=
 
 ; Max number of inbound and outbound peers.
-; 
+;
 ; NOTE: This value is currently unused.
 ; neutrino.maxpeers=
 
@@ -640,12 +640,12 @@ bitcoin.node=btcd
 
 ; How long to ban misbehaving peers. Valid time units are {s, m, h}. Minimum 1
 ; second.
-; 
+;
 ; NOTE: This value is currently unused.
 ; neutrino.banduration=
 
 ; Maximum allowed ban score before disconnecting and banning misbehaving peers.
-; 
+;
 ; NOTE: This value is currently unused.
 ; neutrino.banthreshold=
 
@@ -1044,11 +1044,11 @@ litecoin.node=ltcd
 ; gracefully shutting down. Set this value to 0 to disable this health check.
 ; healthcheck.torconnection.attempts=3
 
-; The amount of time we allow a call to our tor connection to take before we 
+; The amount of time we allow a call to our tor connection to take before we
 ; fail the attempt. This value must be >= 1s.
 ; healthcheck.torconnection.timeout=10s
 
-; The amount of time we should backoff between failed attempts to check tor 
+; The amount of time we should backoff between failed attempts to check tor
 ; connection. This value must be >= 1s.
 ; healthcheck.torconnection.backoff=30s
 
@@ -1254,7 +1254,7 @@ litecoin.node=ltcd
 
 [bolt]
 
-; If true, prevents the database from syncing its freelist to disk. 
+; If true, prevents the database from syncing its freelist to disk.
 ; db.bolt.nofreelistsync=1
 
 ; Whether the databases used within lnd should automatically be compacted on
@@ -1289,7 +1289,7 @@ litecoin.node=ltcd
 ; cluster.id=example.com
 
 ; The session TTL in seconds after which a new leader is elected if the old
-; leader is shut down, crashed or becomes unreachable. 
+; leader is shut down, crashed or becomes unreachable.
 ; cluster.leader-session-ttl=30
 
 [rpcmiddleware]
@@ -1361,19 +1361,19 @@ litecoin.node=ltcd
 
 [invoices]
 
-; If a hold invoice has accepted htlcs that reach their expiry height and are 
+; If a hold invoice has accepted htlcs that reach their expiry height and are
 ; not timed out, the channel holding the htlc is force closed to resolve the
-; invoice's htlcs. To prevent force closes, lnd automatically cancels these 
+; invoice's htlcs. To prevent force closes, lnd automatically cancels these
 ; invoices before they reach their expiry height.
 ;
-; Hold expiry delta describes the number of blocks before expiry that these 
+; Hold expiry delta describes the number of blocks before expiry that these
 ; invoices should be canceled. Setting this value to 0 will ensure that hold
 ; invoices can be settled right up until their expiry height, but will result
 ; in the channel they are on being force closed if they are not resolved before
 ; expiry.
-; 
-; Lnd goes to chain before the expiry for a htlc is reached so that there is 
-; time to resolve it on chain. This value needs to be greater than the 
+;
+; Lnd goes to chain before the expiry for a htlc is reached so that there is
+; time to resolve it on chain. This value needs to be greater than the
 ; DefaultIncomingBroadcastDelta set by lnd, otherwise the channel will be force
 ; closed anyway. A warning will be logged on startup if this value is not large
 ; enough to prevent force closes.
@@ -1383,7 +1383,7 @@ litecoin.node=ltcd
 
 [routing]
 
-; DEPRECATED: This is now turned on by default for Neutrino (use 
+; DEPRECATED: This is now turned on by default for Neutrino (use
 ; neutrino.validatechannels=true to turn off) and shouldn't be used for any
 ; other backend!
 ; routing.assumechanvalid=true


### PR DESCRIPTION
## Change Description
Set the default fee rate to 10,000ppm. With the current default of 1ppm nodes/channels that aren't well maintained attract lots of routing attempts which will fail. As such, for routing algorithms it is very hard to find cheap channels that actually work.

Furthermore, a low default might cause frustration for the node operator, if the liquidity is forwarded before a more reasonable (higher) fee rate could be configured.

Fixing the integration tests is harder than I thought, which is why I'd like to start the discussion before I invest this work :)

## Pull Request Checklist
### Testing
- [ ] Your PR passes all CI checks.
- [x] Tests covering the positive and negative (error paths) are included.
- [x] Bug fixes contain tests triggering the bug to prevent regressions.

### Code Style and Documentation
- [x] The change obeys the [Code Documentation and Commenting](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#CodeDocumentation) guidelines, and lines wrap at 80.
- [x] Commits follow the [Ideal Git Commit Structure](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#IdealGitCommitStructure).
- [x] Any new logging statements use an appropriate subsystem and logging level.
- [x]  [There is a change description in the release notes](https://github.com/lightningnetwork/lnd/tree/master/docs/release-notes), or `[skip ci]` in the commit message for small changes.

📝 Please see our  [Contribution Guidelines](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md) for further guidance.