### PR TITLE
lnrpc/walletrpc: reject PSBT packets w/o any UTXO input info

### DIFF
--- a/docs/release-notes/release-notes-0.15.0.md
+++ b/docs/release-notes/release-notes-0.15.0.md
@@ -183,6 +183,8 @@ from occurring that would result in an erroneous force close.](https://github.co
 
 * [Fixes an issue related to HTLCs on lease enforced channels that can lead to itest flakes](https://github.com/lightningnetwork/lnd/pull/6605/files)
 
+* [Fixes a bug that would cause `SignPsbt` to panic w/ an underspecified packet](https://github.com/lightningnetwork/lnd/pull/6611)
+
 ## Routing
 
 * [Add a new `time_pref` parameter to the QueryRoutes and SendPayment APIs](https://github.com/lightningnetwork/lnd/pull/6024) that


### PR DESCRIPTION
Without this the RPC panics if UTXO information isn't specified. 

Fixes https://github.com/lightningnetwork/lnd/issues/6567

