### PR TITLE
walletkit+sweeper: add forgotten P2TR address type

### DIFF
--- a/lnwallet/rpcwallet/rpcwallet.go
+++ b/lnwallet/rpcwallet/rpcwallet.go
@@ -259,7 +259,8 @@ func (r *RPCKeyRing) FinalizePsbt(packet *psbt.Packet, _ string) error {
 	// ones to sign. If there is any input without witness data that we
 	// cannot sign because it's not our UTXO, this will be a hard failure.
 	tx := packet.UnsignedTx
-	sigHashes := input.NewTxSigHashesV0Only(tx)
+	prevOutFetcher := basewallet.PsbtPrevOutputFetcher(packet)
+	sigHashes := txscript.NewTxSigHashes(tx, prevOutFetcher)
 	for idx, txIn := range tx.TxIn {
 		in := packet.Inputs[idx]
 

--- a/sweep/tx_input_set.go
+++ b/sweep/tx_input_set.go
@@ -355,23 +355,26 @@ func (t *txInputSet) tryAddWalletInputsIfNeeded() error {
 // createWalletTxInput converts a wallet utxo into an object that can be added
 // to the other inputs to sweep.
 func createWalletTxInput(utxo *lnwallet.Utxo) (input.Input, error) {
-	var witnessType input.WitnessType
-	switch utxo.AddressType {
-	case lnwallet.WitnessPubKey:
-		witnessType = input.WitnessKeyHash
-	case lnwallet.NestedWitnessPubKey:
-		witnessType = input.NestedWitnessKeyHash
-	default:
-		return nil, fmt.Errorf("unknown address type %v",
-			utxo.AddressType)
-	}
-
 	signDesc := &input.SignDescriptor{
 		Output: &wire.TxOut{
 			PkScript: utxo.PkScript,
 			Value:    int64(utxo.Value),
 		},
 		HashType: txscript.SigHashAll,
+	}
+
+	var witnessType input.WitnessType
+	switch utxo.AddressType {
+	case lnwallet.WitnessPubKey:
+		witnessType = input.WitnessKeyHash
+	case lnwallet.NestedWitnessPubKey:
+		witnessType = input.NestedWitnessKeyHash
+	case lnwallet.TaprootPubkey:
+		witnessType = input.TaprootPubKeySpend
+		signDesc.HashType = txscript.SigHashDefault
+	default:
+		return nil, fmt.Errorf("unknown address type %v",
+			utxo.AddressType)
 	}
 
 	// A height hint doesn't need to be set, because we don't monitor these


### PR DESCRIPTION
## Change Description
Fixed three more occurrences of address type enums that didn't yet support P2TR inputs.

NOTE: I didn't add anything to the release notes since this should've been added by any of the previous P2TR pull requests.
