### PR TITLE
multi: send P2TR addrs by default for co-op close, add new `option_any_segwit` feature bit

### DIFF
--- a/docs/release-notes/release-notes-0.15.1.md
+++ b/docs/release-notes/release-notes-0.15.1.md
@@ -20,6 +20,8 @@
 [`lnd` will now refuse to start if it detects the full node backned does not
 support Tapoot](https://github.com/lightningnetwork/lnd/pull/6798).
 
+[`lnd` will now use taproot addresses for co-op closes if the remote peer
+supports the feature.](https://github.com/lightningnetwork/lnd/pull/6633)
 
 ## `lncli`
 

--- a/feature/default_sets.go
+++ b/feature/default_sets.go
@@ -79,4 +79,8 @@ var defaultSetDesc = setDesc{
 		SetInit:    {}, // I
 		SetNodeAnn: {}, // N
 	},
+	lnwire.ShutdownAnySegwitOptional: {
+		SetInit:    {}, // I
+		SetNodeAnn: {}, // N
+	},
 }

--- a/feature/manager.go
+++ b/feature/manager.go
@@ -40,6 +40,10 @@ type Config struct {
 	// channels. This should be used instead of NoOptionScidAlias to still
 	// keep option-scid-alias support.
 	NoZeroConf bool
+
+	// NoAnySegwit unsets any bits that signal support for using other
+	// segwit witness versions for co-op closes.
+	NoAnySegwit bool
 }
 
 // Manager is responsible for generating feature vectors for different requested
@@ -141,6 +145,10 @@ func newManager(cfg Config, desc setDesc) (*Manager, error) {
 		if cfg.NoZeroConf {
 			raw.Unset(lnwire.ZeroConfOptional)
 			raw.Unset(lnwire.ZeroConfRequired)
+		}
+		if cfg.NoAnySegwit {
+			raw.Unset(lnwire.ShutdownAnySegwitOptional)
+			raw.Unset(lnwire.ShutdownAnySegwitRequired)
 		}
 
 		// Ensure that all of our feature sets properly set any

--- a/funding/manager.go
+++ b/funding/manager.go
@@ -131,7 +131,7 @@ var (
 // via a local signal such as RPC.
 //
 // TODO(roasbeef): actually use the context package
-//  * deadlines, etc.
+//   - deadlines, etc.
 type reservationWithCtx struct {
 	reservation *lnwallet.ChannelReservation
 	peer        lnpeer.Peer
@@ -1486,16 +1486,7 @@ func (f *Manager) handleFundingOpen(peer lnpeer.Peer,
 	// (if any) in lieu of user input.
 	shutdown, err := getUpfrontShutdownScript(
 		f.cfg.EnableUpfrontShutdown, peer, acceptorResp.UpfrontShutdown,
-		func() (lnwire.DeliveryAddress, error) {
-			addr, err := f.cfg.Wallet.NewAddress(
-				lnwallet.WitnessPubKey, false,
-				lnwallet.DefaultAccountName,
-			)
-			if err != nil {
-				return nil, err
-			}
-			return txscript.PayToAddrScript(addr)
-		},
+		f.selectShutdownScript,
 	)
 	if err != nil {
 		f.failFundingFlow(
@@ -3689,7 +3680,7 @@ func (f *Manager) InitFundingWorkflow(msg *InitFundingMsg) {
 // upfront shutdown scripts automatically.
 func getUpfrontShutdownScript(enableUpfrontShutdown bool, peer lnpeer.Peer,
 	script lnwire.DeliveryAddress,
-	getScript func() (lnwire.DeliveryAddress, error)) (lnwire.DeliveryAddress,
+	getScript func(bool) (lnwire.DeliveryAddress, error)) (lnwire.DeliveryAddress,
 	error) {
 
 	// Check whether the remote peer supports upfront shutdown scripts.
@@ -3721,7 +3712,12 @@ func getUpfrontShutdownScript(enableUpfrontShutdown bool, peer lnpeer.Peer,
 		return nil, nil
 	}
 
-	return getScript()
+	// We can safely send a taproot address iff, both sides have negotiated
+	// the shutdown-any-segwit feature.
+	taprootOK := peer.RemoteFeatures().HasFeature(lnwire.ShutdownAnySegwitOptional) &&
+		peer.LocalFeatures().HasFeature(lnwire.ShutdownAnySegwitOptional)
+
+	return getScript(taprootOK)
 }
 
 // handleInitFundingMsg creates a channel reservation within the daemon's
@@ -3780,18 +3776,8 @@ func (f *Manager) handleInitFundingMsg(msg *InitFundingMsg) {
 	// address from the wallet if our node is configured to set shutdown
 	// address by default).
 	shutdown, err := getUpfrontShutdownScript(
-		f.cfg.EnableUpfrontShutdown, msg.Peer,
-		msg.ShutdownScript,
-		func() (lnwire.DeliveryAddress, error) {
-			addr, err := f.cfg.Wallet.NewAddress(
-				lnwallet.WitnessPubKey, false,
-				lnwallet.DefaultAccountName,
-			)
-			if err != nil {
-				return nil, err
-			}
-			return txscript.PayToAddrScript(addr)
-		},
+		f.cfg.EnableUpfrontShutdown, msg.Peer, msg.ShutdownScript,
+		f.selectShutdownScript,
 	)
 	if err != nil {
 		msg.Err <- err
@@ -4269,4 +4255,25 @@ func (f *Manager) deleteChannelOpeningState(chanPoint *wire.OutPoint) error {
 	return f.cfg.Wallet.Cfg.Database.DeleteChannelOpeningState(
 		outpointBytes.Bytes(),
 	)
+}
+
+// selectShutdownScript selects the shutdown script we should send to the peer.
+// If we can use taproot, then we prefer that, otherwise we'll use a p2wkh
+// script.
+func (f *Manager) selectShutdownScript(taprootOK bool,
+) (lnwire.DeliveryAddress, error) {
+
+	addrType := lnwallet.WitnessPubKey
+	if taprootOK {
+		addrType = lnwallet.TaprootPubkey
+	}
+
+	addr, err := f.cfg.Wallet.NewAddress(
+		addrType, false, lnwallet.DefaultAccountName,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	return txscript.PayToAddrScript(addr)
 }

--- a/funding/manager_test.go
+++ b/funding/manager_test.go
@@ -3331,13 +3331,13 @@ func TestGetUpfrontShutdownScript(t *testing.T) {
 	upfrontScript := []byte("upfront script")
 	generatedScript := []byte("generated script")
 
-	getScript := func() (lnwire.DeliveryAddress, error) {
+	getScript := func(_ bool) (lnwire.DeliveryAddress, error) {
 		return generatedScript, nil
 	}
 
 	tests := []struct {
 		name           string
-		getScript      func() (lnwire.DeliveryAddress, error)
+		getScript      func(bool) (lnwire.DeliveryAddress, error)
 		upfrontScript  lnwire.DeliveryAddress
 		peerEnabled    bool
 		localEnabled   bool
@@ -3628,14 +3628,14 @@ func TestFundingManagerUpfrontShutdown(t *testing.T) {
 			pkscript: []byte("\xa9\x14\xfe\x44\x10\x65\xb6\x53" +
 				"\x22\x31\xde\x2f\xac\x56\x31\x52\x20\x5e" +
 				"\xc4\xf5\x9c\x74\x87"),
-			expectErr: false,
+			expectErr: true,
 		},
 		{
 			name: "p2pkh script",
 			pkscript: []byte("\x76\xa9\x14\x64\x1a\xd5\x05\x1e" +
 				"\xdd\x97\x02\x9a\x00\x3f\xe9\xef\xb2\x93" +
 				"\x59\xfc\xee\x40\x9d\x88\xac"),
-			expectErr: false,
+			expectErr: true,
 		},
 		{
 			name: "p2wpkh script",

--- a/lncfg/protocol.go
+++ b/lncfg/protocol.go
@@ -38,6 +38,10 @@ type ProtocolOptions struct {
 	// OptionZeroConf should be set if we want to signal the zero-conf
 	// feature bit.
 	OptionZeroConf bool `long:"zero-conf" description:"enable support for zero-conf channels, must have option-scid-alias set also"`
+
+	// NoOptionAnySegwit should be set to true if we don't want to use any
+	// Taproot (and beyond) addresses for co-op closing.
+	NoOptionAnySegwit bool `long:"no-any-segwit" description:"disallow using any segiwt witness version as a co-op close address"`
 }
 
 // Wumbo returns true if lnd should permit the creation and acceptance of wumbo
@@ -66,4 +70,10 @@ func (l *ProtocolOptions) ScidAlias() bool {
 // ZeroConf returns true if we have enabled the zero-conf feature bit.
 func (l *ProtocolOptions) ZeroConf() bool {
 	return l.OptionZeroConf
+}
+
+// NoAnySegwit returns true if we don't signal that we understand other newer
+// segwit witness versions for co-op close addresses.
+func (l *ProtocolOptions) NoAnySegwit() bool {
+	return l.NoOptionAnySegwit
 }

--- a/lncfg/protocol_rpctest.go
+++ b/lncfg/protocol_rpctest.go
@@ -39,6 +39,10 @@ type ProtocolOptions struct {
 	// OptionZeroConf should be set if we want to signal the zero-conf
 	// feature bit.
 	OptionZeroConf bool `long:"zero-conf" description:"enable support for zero-conf channels, must have option-scid-alias set also"`
+
+	// NoOptionAnySegwit should be set to true if we don't want to use any
+	// Taproot (and beyond) addresses for co-op closing.
+	NoOptionAnySegwit bool `long:"no-any-segwit" description:"disallow using any segiwt witness version as a co-op close address"`
 }
 
 // Wumbo returns true if lnd should permit the creation and acceptance of wumbo
@@ -67,4 +71,10 @@ func (l *ProtocolOptions) ScidAlias() bool {
 // ZeroConf returns true if we have enabled the zero-conf feature bit.
 func (l *ProtocolOptions) ZeroConf() bool {
 	return l.OptionZeroConf
+}
+
+// NoAnySegwit returns true if we don't signal that we understand other newer
+// segwit witness versions for co-op close addresses.
+func (l *ProtocolOptions) NoAnySegwit() bool {
+	return l.NoOptionAnySegwit
 }

--- a/lntest/itest/lnd_test_list_on_test.go
+++ b/lntest/itest/lnd_test_list_on_test.go
@@ -431,4 +431,8 @@ var allTestCases = []*testCase{
 		name: "nonstd sweep",
 		test: testNonstdSweep,
 	},
+	{
+		name: "taproot coop close",
+		test: testTaprootCoopClose,
+	},
 }

--- a/lnwire/features.go
+++ b/lnwire/features.go
@@ -129,6 +129,18 @@ const (
 	// transactions, which also imply anchor commitments.
 	AnchorsZeroFeeHtlcTxOptional FeatureBit = 23
 
+	// ShutdownAnySegwitRequired is an required feature bit that signals
+	// that the sender is able to properly handle/parse segwit witness
+	// programs up to version 16. This enables utilization of Taproot
+	// addresses for cooperative closure addresses.
+	ShutdownAnySegwitRequired FeatureBit = 26
+
+	// ShutdownAnySegwitOptional is an optional feature bit that signals
+	// that the sender is able to properly handle/parse segwit witness
+	// programs up to version 16. This enables utilization of Taproot
+	// addresses for cooperative closure addresses.
+	ShutdownAnySegwitOptional FeatureBit = 27
+
 	// AMPRequired is a required feature bit that signals that the receiver
 	// of a payment supports accepts spontaneous payments, i.e.
 	// sender-generated preimages according to BOLT XX.
@@ -266,6 +278,8 @@ var Features = map[FeatureBit]string{
 	ScidAliasOptional:             "scid-alias",
 	ZeroConfRequired:              "zero-conf",
 	ZeroConfOptional:              "zero-conf",
+	ShutdownAnySegwitRequired:     "shutdown-any-segwit",
+	ShutdownAnySegwitOptional:     "shutdown-any-segwit",
 }
 
 // RawFeatureVector represents a set of feature bits as defined in BOLT-09.  A

--- a/peer/brontide.go
+++ b/peer/brontide.go
@@ -2716,7 +2716,8 @@ func (p *Brontide) createChanCloser(channel *lnwallet.LightningChannel,
 			Disconnect: func() error {
 				return p.cfg.DisconnectPeer(p.IdentityKey())
 			},
-			Quit: p.quit,
+			ChainParams: &p.cfg.Wallet.Cfg.NetParams,
+			Quit:        p.quit,
 		},
 		deliveryScript,
 		fee,

--- a/peer/brontide.go
+++ b/peer/brontide.go
@@ -657,6 +657,13 @@ func (p *Brontide) initGossipSync() {
 	}
 }
 
+// taprootShutdownAllowed returns true if both parties have negotiated the
+// shutdown-any-segwit feature.
+func (p *Brontide) taprootShutdownAllowed() bool {
+	return p.RemoteFeatures().HasFeature(lnwire.ShutdownAnySegwitOptional) &&
+		p.LocalFeatures().HasFeature(lnwire.ShutdownAnySegwitOptional)
+}
+
 // QuitSignal is a method that should return a channel which will be sent upon
 // or closed once the backing peer exits. This allows callers using the
 // interface to cancel any processing in the event the backing implementation
@@ -2244,8 +2251,15 @@ func (p *Brontide) ChannelSnapshots() []*channeldb.ChannelSnapshot {
 // genDeliveryScript returns a new script to be used to send our funds to in
 // the case of a cooperative channel close negotiation.
 func (p *Brontide) genDeliveryScript() ([]byte, error) {
+	// We'll send a normal p2wkh address unless we've negotiated the
+	// shutdown-any-segwit feature.
+	addrType := lnwallet.WitnessPubKey
+	if p.taprootShutdownAllowed() {
+		addrType = lnwallet.TaprootPubkey
+	}
+
 	deliveryAddr, err := p.cfg.Wallet.NewAddress(
-		lnwallet.WitnessPubKey, false, lnwallet.DefaultAccountName,
+		addrType, false, lnwallet.DefaultAccountName,
 	)
 	if err != nil {
 		return nil, err

--- a/peer/brontide_test.go
+++ b/peer/brontide_test.go
@@ -55,6 +55,8 @@ func TestPeerChannelClosureAcceptFeeResponder(t *testing.T) {
 	mockLink := newMockUpdateHandler(chanID)
 	mockSwitch.links = append(mockSwitch.links, mockLink)
 
+	dummyDeliveryScript := genScript(t, p2wshAddress)
+
 	// We send a shutdown request to Alice. She will now be the responding
 	// node in this shutdown procedure. We first expect Alice to answer
 	// this shutdown request with a Shutdown message.
@@ -155,6 +157,8 @@ func TestPeerChannelClosureAcceptFeeInitiator(t *testing.T) {
 	chanID := lnwire.NewChanIDFromOutPoint(bobChan.ChannelPoint())
 	mockLink := newMockUpdateHandler(chanID)
 	mockSwitch.links = append(mockSwitch.links, mockLink)
+
+	dummyDeliveryScript := genScript(t, p2wshAddress)
 
 	// We make Alice send a shutdown request.
 	updateChan := make(chan interface{}, 1)
@@ -281,6 +285,7 @@ func TestPeerChannelClosureFeeNegotiationsResponder(t *testing.T) {
 	// Bob sends a shutdown request to Alice. She will now be the responding
 	// node in this shutdown procedure. We first expect Alice to answer this
 	// Shutdown request with a Shutdown message.
+	dummyDeliveryScript := genScript(t, p2wshAddress)
 	alicePeer.chanCloseMsgs <- &closeMsg{
 		cid: chanID,
 		msg: lnwire.NewShutdown(chanID,
@@ -492,6 +497,7 @@ func TestPeerChannelClosureFeeNegotiationsInitiator(t *testing.T) {
 	aliceDeliveryScript := shutdownMsg.Address
 
 	// Bob will answer the Shutdown message with his own Shutdown.
+	dummyDeliveryScript := genScript(t, p2wshAddress)
 	respShutdown := lnwire.NewShutdown(chanID, dummyDeliveryScript)
 	alicePeer.chanCloseMsgs <- &closeMsg{
 		cid: chanID,

--- a/peer/test_utils.go
+++ b/peer/test_utils.go
@@ -45,9 +45,6 @@ const (
 )
 
 var (
-	// Just use some arbitrary bytes as delivery script.
-	dummyDeliveryScript = channels.AlicesPrivKey
-
 	testKeyLoc = keychain.KeyLocator{Family: keychain.KeyFamilyNodeKey}
 )
 
@@ -368,26 +365,26 @@ func createTestPeer(notifier chainntnfs.ChainNotifier,
 	}
 
 	cfg := &Config{
-		Addr:        cfgAddr,
-		PubKeyBytes: pubKey,
-		ErrorBuffer: errBuffer,
-		ChainIO:     chainIO,
-		Switch:      mockSwitch,
-
+		Addr:              cfgAddr,
+		PubKeyBytes:       pubKey,
+		ErrorBuffer:       errBuffer,
+		ChainIO:           chainIO,
+		Switch:            mockSwitch,
 		ChanActiveTimeout: chanActiveTimeout,
 		InterceptSwitch: htlcswitch.NewInterceptableSwitch(
 			nil, testCltvRejectDelta, false,
 		),
-
 		ChannelDB:      dbAlice.ChannelStateDB(),
 		FeeEstimator:   estimator,
 		Wallet:         wallet,
 		ChainNotifier:  notifier,
 		ChanStatusMgr:  chanStatusMgr,
+		Features:       lnwire.NewFeatureVector(nil, lnwire.Features),
 		DisconnectPeer: func(b *btcec.PublicKey) error { return nil },
 	}
 
 	alicePeer := NewBrontide(*cfg)
+	alicePeer.remoteFeatures = lnwire.NewFeatureVector(nil, lnwire.Features)
 
 	chanID := lnwire.NewChanIDFromOutPoint(channelAlice.ChannelPoint())
 	alicePeer.activeChannels[chanID] = channelAlice

--- a/sample-lnd.conf
+++ b/sample-lnd.conf
@@ -1191,6 +1191,10 @@ litecoin.node=ltcd
 ; option-scid-alias flag to also be set.
 ; protocol.zero-conf=true
 
+; Set to disable support for using P2TR addresses (and beyond) for co-op
+; closing.
+; protocol.no-any-segwit
+
 [db]
 
 ; The selected database backend. The current default backend is "bolt". lnd

--- a/server.go
+++ b/server.go
@@ -536,6 +536,7 @@ func newServer(cfg *Config, listenAddrs []net.Addr,
 		NoKeysend:                !cfg.AcceptKeySend,
 		NoOptionScidAlias:        !cfg.ProtocolOptions.ScidAlias(),
 		NoZeroConf:               !cfg.ProtocolOptions.ZeroConf(),
+		NoAnySegwit:              cfg.ProtocolOptions.NoAnySegwit(),
 	})
 	if err != nil {
 		return nil, err
@@ -1577,6 +1578,7 @@ func (s *server) signAliasUpdate(u *lnwire.ChannelUpdate) (*ecdsa.Signature,
 //   - diskCheck
 //   - tlsHealthCheck
 //   - torController, only created when tor is enabled.
+//
 // If a health check has been disabled by setting attempts to 0, our monitor
 // will not run it.
 func (s *server) createLivenessMonitor(cfg *Config, cc *chainreg.ChainControl) {


### PR DESCRIPTION
In this commit, we implement the new `option_any_segwit` feature bit which enables us to start sending P2TR addresses for co-op closes as well as for upfront shutdown addresses. Along the way, we tighten up our validation a bit to only allow segwit v0 and v1 addresses. 

