### PR TITLE
Add p2tr to supported address help message

### DIFF
--- a/cmd/lncli/commands.go
+++ b/cmd/lncli/commands.go
@@ -169,7 +169,7 @@ func newAddress(ctx *cli.Context) error {
 		addrType = lnrpc.AddressType_TAPROOT_PUBKEY
 	default:
 		return fmt.Errorf("invalid address type %v, support address type "+
-			"are: p2wkh and np2wkh", stringAddrType)
+			"are: p2wkh, np2wkh, and p2tr", stringAddrType)
 	}
 
 	client, cleanUp := getClient(ctx)


### PR DESCRIPTION
Looks like this was missed when p2tr support was added.