### PR TITLE
Migrate assert.NoError to require.NoError

### DIFF
--- a/blockcache/blockcache_test.go
+++ b/blockcache/blockcache_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcd/wire"
 	"github.com/lightninglabs/neutrino/cache"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -173,10 +172,10 @@ func TestBlockCacheMutexes(t *testing.T) {
 		go func(e int) {
 			if e%2 == 0 {
 				_, err := bc.GetBlock(&blockhash1, getBlockImpl)
-				assert.NoError(t, err)
+				require.NoError(t, err)
 			} else {
 				_, err := bc.GetBlock(&blockhash2, getBlockImpl)
-				assert.NoError(t, err)
+				require.NoError(t, err)
 			}
 
 			wg.Done()

--- a/channeldb/payment_control_test.go
+++ b/channeldb/payment_control_test.go
@@ -87,7 +87,7 @@ func TestPaymentControlSwitchFail(t *testing.T) {
 	// Lookup the payment so we can get its old sequence number before it is
 	// overwritten.
 	payment, err := pControl.FetchPayment(info.PaymentIdentifier)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// Sends the htlc again, which should succeed since the prior payment
 	// failed.

--- a/clock/test_clock_test.go
+++ b/clock/test_clock_test.go
@@ -87,5 +87,5 @@ func TestTickSignal(t *testing.T) {
 
 	// Once the ticker is registered, set the time to make it fire.
 	c.SetTime(testTime.Add(time.Second))
-	assert.NoError(t, <-err)
+	require.NoError(t, <-err)
 }

--- a/docs/release-notes/release-notes-0.15.1.md
+++ b/docs/release-notes/release-notes-0.15.1.md
@@ -56,6 +56,12 @@
 * [The HtlcSwitch now waits for a ChannelLink to stop before replacing it. This fixes a race
   condition.](https://github.com/lightningnetwork/lnd/pull/6642)
 
+## Code Health
+
+### Code cleanup, refactor, typo fixes
+
+* [Migrate instances of assert.NoError to require.NoError](https://github.com/lightningnetwork/lnd/pull/6636).
+
 # Contributors (Alphabetical Order)
 
 * Carsten Otto

--- a/peer/brontide_test.go
+++ b/peer/brontide_test.go
@@ -19,7 +19,6 @@ import (
 	"github.com/lightningnetwork/lnd/lnwallet/chancloser"
 	"github.com/lightningnetwork/lnd/lnwire"
 	"github.com/lightningnetwork/lnd/pool"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -1078,7 +1077,7 @@ func TestPeerCustomMessage(t *testing.T) {
 		)
 		var b bytes.Buffer
 		_, err = lnwire.WriteMessage(&b, initReplyMsg, 0)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		mockConn.readMessages <- b.Bytes()
 	}()


### PR DESCRIPTION
## Change Description
Migrate instances of `assert.NoError` to `require.NoError`. There are several thousand instances of the latter version in the codebase, but only a handful of the former. This change makes the calls consistent by always using `require`.