### PR TITLE
htlcswitch: add linkStopIndex to cleanly shutdown ChannelLink

### DIFF
--- a/docs/release-notes/release-notes-0.15.1.md
+++ b/docs/release-notes/release-notes-0.15.1.md
@@ -42,6 +42,9 @@
 * [DisconnectPeer no longer interferes with the peerTerminationWatcher. This previously caused
   force closes.](https://github.com/lightningnetwork/lnd/pull/6655)
 
+* [The HtlcSwitch now waits for a ChannelLink to stop before replacing it. This fixes a race
+  condition.](https://github.com/lightningnetwork/lnd/pull/6642)
+
 # Contributors (Alphabetical Order)
 
 * Elle Mouton


### PR DESCRIPTION
With this, extra calls to RemoveLink will wait for the link to
fully stop. This is accomplished by a map that stores a single stop
channel that callers to RemoveLink will listen on. This map is not
consulted when the Switch is shutting down and calls Stop on each
individual link. Though that could be added in the future, it is
not necessary.

Fixes #6593 