### PR TITLE
bugfix: avoid panic with empty graph

### DIFF
--- a/autopilot/simple_graph.go
+++ b/autopilot/simple_graph.go
@@ -132,6 +132,11 @@ func (graph *SimpleGraph) shortestPathLengths(node int) map[int]uint32 {
 	// thisLevel contains the nodes that are explored in the round.
 	thisLevel := make([]int, 0, graphOrder)
 
+	// Abort if we have an empty graph.
+	if len(graph.Adj) == 0 {
+		return seen
+	}
+
 	// We discover other nodes in a ring-like structure as long as we don't
 	// have more nodes to explore.
 	for len(nextLevel) > 0 {

--- a/docs/release-notes/release-notes-0.15.0.md
+++ b/docs/release-notes/release-notes-0.15.0.md
@@ -185,6 +185,9 @@ from occurring that would result in an erroneous force close.](https://github.co
 
 * [Fixes a bug that would cause `SignPsbt` to panic w/ an underspecified packet](https://github.com/lightningnetwork/lnd/pull/6611)
 
+* [Fixes a panic in the graph diameter calculation if the graph is
+  empty](https://github.com/lightningnetwork/lnd/pull/6647).
+
 ## Routing
 
 * [Add a new `time_pref` parameter to the QueryRoutes and SendPayment APIs](https://github.com/lightningnetwork/lnd/pull/6024) that


### PR DESCRIPTION
## Change Description

Fixes an `index out of range [0] with length 0` error when running `lncli getnetworkinfo` with an empty graph (on the remote signing instance for example).
