### PR TITLE
server.go: replace call to removePeer with Disconnect in DisconnectPeer

### DIFF
--- a/docs/release-notes/release-notes-0.15.1.md
+++ b/docs/release-notes/release-notes-0.15.1.md
@@ -34,10 +34,14 @@
 * [Update the urfave/cli package](https://github.com/lightningnetwork/lnd/pull/6682) because
   of a flag parsing bug.
 
+* [DisconnectPeer no longer interferes with the peerTerminationWatcher. This previously caused
+  force closes.](https://github.com/lightningnetwork/lnd/pull/6655)
+
 # Contributors (Alphabetical Order)
 
 * Elle Mouton
 * ErikEk
+* Eugene Siegel
 * Oliver Gugger
 * Priyansh Rastogi
 * Yong Yu

--- a/server.go
+++ b/server.go
@@ -4217,11 +4217,9 @@ func (s *server) DisconnectPeer(pubKey *btcec.PublicKey) error {
 	delete(s.persistentPeers, pubStr)
 	delete(s.persistentPeersBackoff, pubStr)
 
-	// Remove the current peer from the server's internal state and signal
-	// that the peer termination watcher does not need to execute for this
-	// peer.
-	s.removePeer(peer)
-	s.ignorePeerTermination[peer] = struct{}{}
+	// Remove the peer by calling Disconnect. Previously this was done with
+	// removePeer, which bypassed the peerTerminationWatcher.
+	peer.Disconnect(fmt.Errorf("server: DisconnectPeer called"))
 
 	return nil
 }


### PR DESCRIPTION
Without this, calls to DisconnectPeer would bypass the peerTerminationWatcher and allow subsequent connect requests to go through before the peer's links were fully shut down. This could lead to force closes.

One way it could trigger a force close that made it _look_ like the user lost state is:
- The existing link has sent a `CommitSig` and is waiting for `RevokeAndAck`. The database state is persisted under the commit diff key
- The node's `peer.Brontide` object receives the `RevokeAndAck` and will attempt to pass it to the link.
- The node issues a `DisconnectPeer` call. `removePeer` is called which removes the `peer.Brontide` object from the map without waiting for the associated `ChannelLink`s to stop. This bypasses the `peerTerminationWatcher`!
- The node hands the `RevokeAndAck` to the `ChannelLink` - it is now in the link's mailbox.
- The node reconnects with the counter-party. It can do so even though the `ChannelLink` isn't stopped. It will call `FetchOpenChannels` when creating the `ChannelLink`s in `loadActiveChannels`. `FetchOpenChannels` does NOT include the pending remote commitment.
- The node's existing `ChannelLink` processes the `RevokeAndAck` and removes the pending remote commitment all before the `Init` handshake completes.
- After the `Init` handshake, `NewLightningChannel` is called for each channel that will result in a `ChannelLink`. Here NLC will fetch the pending remote commitment, which no longer exists since the existing `ChannelLink` removed it. The local and remote commitments are not updated here. So the remote commitment is behind by 1.
- Existing `ChannelLink` goes down eventually.
- New `ChannelLink` performs `ChannelReestablish` handshake and triggers DLP. No data is actually lost as the erroneous state is all in-memory and the correct data is on-disk.

Fixes https://github.com/lightningnetwork/lnd/issues/6639

This could also trigger https://github.com/lightningnetwork/lnd/issues/6593 (though there are other ways besides using `DisconnectPeer`) and probably https://github.com/lightningnetwork/lnd/issues/6617