### PR TITLE
funding: defer sending channel_update until received funding_locked

### DIFF
--- a/docs/release-notes/release-notes-0.15.1.md
+++ b/docs/release-notes/release-notes-0.15.1.md
@@ -16,6 +16,10 @@
 * [Adds a `ZeroConfAcceptor` that rejects any zero-conf channel opens unless an RPC `ChannelAcceptor` is
   active. This is a safety measure to avoid funds loss.](https://github.com/lightningnetwork/lnd/pull/6716)
 
+### Interoperability 
+* [LND now waits until the peer's `funding_locked` is received before sending the initial
+  `channel_update`. The BOLT specification requires this.](https://github.com/lightningnetwork/lnd/pull/6664)
+
 ## Build system
 
 * [Add the release build directory to the `.gitignore` file to avoid the release


### PR DESCRIPTION
This is required by BOLT#07 as otherwise the counter-party will
discard the channel_update as they may not consider the channel
"ready" or reorg-safe. Most other implementations besides eclair
have work-arounds for this, but it is nice to be spec-compliant.

Fixes https://github.com/lightningnetwork/lnd/issues/3651