### PR TITLE
channeldb: fix data race in TestSerializeHTLCEntries

### DIFF
--- a/channeldb/revocation_log_test.go
+++ b/channeldb/revocation_log_test.go
@@ -211,9 +211,10 @@ func TestSerializeHTLCEntries(t *testing.T) {
 func TestSerializeRevocationLog(t *testing.T) {
 	t.Parallel()
 
-	// Copy the testRevocationLog.
+	// Copy the testRevocationLog and testHTLCEntry.
 	rl := testRevocationLog
-	rl.HTLCEntries = []*HTLCEntry{&testHTLCEntry}
+	htlc := testHTLCEntry
+	rl.HTLCEntries = []*HTLCEntry{&htlc}
 
 	// Write the tlv stream.
 	buf := bytes.NewBuffer([]byte{})

--- a/docs/release-notes/release-notes-0.15.1.md
+++ b/docs/release-notes/release-notes-0.15.1.md
@@ -15,8 +15,14 @@
 * [Add previous_outpoints to listchaintxns](https://github.com/lightningnetwork/lnd/pull/6321)
 
 
+## Bug Fixes
+
+* Fixed data race found in
+  [`TestSerializeHTLCEntries`](https://github.com/lightningnetwork/lnd/pull/6673).
+
 # Contributors (Alphabetical Order)
 
 * Elle Mouton
 * ErikEk
 * Priyansh Rastogi
+* Yong Yu


### PR DESCRIPTION
Fixes #6661.