### PR TITLE
Fix release reproducibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -77,3 +77,7 @@ coverage.txt
 
 # Visual Studio cache/options directory
 .vs/
+
+# Release build directory (to avoid build.vcs.modified Golang build tag to be
+# set to true by having untracked files in the working directory).
+/lnd-*/

--- a/docs/release-notes/release-notes-0.15.1.md
+++ b/docs/release-notes/release-notes-0.15.1.md
@@ -1,5 +1,11 @@
 # Release Notes
 
+## Build system
+
+* [Add the release build directory to the `.gitignore` file to avoid the release
+  binary digest to be different whether that folder exists or
+  not](https://github.com/lightningnetwork/lnd/pull/6676)
+
 ## `lncli`
 
 * [Add `payment_addr` flag to `buildroute`](https://github.com/lightningnetwork/lnd/pull/6576)
@@ -19,4 +25,5 @@
 
 * Elle Mouton
 * ErikEk
+* Oliver Gugger
 * Priyansh Rastogi


### PR DESCRIPTION
## Change Description

Fixes #6672.
A new metadata tag called `build.vcs.modified` was added in Go 1.18.x that
indicates whether there were any untracked files present during the
build or not.
Because the `make release` command creates a directory in which the
output packages are created, and because that directory was not added
to git and also not ignored by it, the build.vcs.modified flag was
different to the docker build which resulted in a different digest of
the resulting binary.
