### PR TITLE
Taproot: Fix p2tr support in `ComputeInputScript`

### DIFF
--- a/docs/release-notes/release-notes-0.15.1.md
+++ b/docs/release-notes/release-notes-0.15.1.md
@@ -19,6 +19,8 @@
 ## RPC Server
 
 * [Add previous_outpoints to listchaintxns](https://github.com/lightningnetwork/lnd/pull/6321)
+* [Fix P2TR support in
+  `ComputeInputScript`](https://github.com/lightningnetwork/lnd/pull/6680).
 
 ## Bug Fixes
 

--- a/input/signer.go
+++ b/input/signer.go
@@ -25,12 +25,12 @@ type Signer interface {
 	// ComputeInputScript generates a complete InputIndex for the passed
 	// transaction with the signature as defined within the passed
 	// SignDescriptor. This method should be capable of generating the
-	// proper input script for both regular p2wkh output and p2wkh outputs
-	// nested within a regular p2sh output.
+	// proper input script for both regular p2wkh/p2tr outputs and p2wkh
+	// outputs nested within a regular p2sh output.
 	//
 	// NOTE: This method will ignore any tweak parameters set within the
 	// passed SignDescriptor as it assumes a set of typical script
-	// templates (p2wkh, np2wkh, etc).
+	// templates (p2wkh, p2tr, np2wkh, etc).
 	ComputeInputScript(tx *wire.MsgTx, signDesc *SignDescriptor) (*Script,
 		error)
 }

--- a/lnrpc/signrpc/signer.proto
+++ b/lnrpc/signrpc/signer.proto
@@ -22,8 +22,8 @@ service Signer {
     /*
     ComputeInputScript generates a complete InputIndex for the passed
     transaction with the signature as defined within the passed SignDescriptor.
-    This method should be capable of generating the proper input script for
-    both regular p2wkh output and p2wkh outputs nested within a regular p2sh
+    This method should be capable of generating the proper input script for both
+    regular p2wkh/p2tr outputs and p2wkh outputs nested within a regular p2sh
     output.
 
     Note that when using this method to sign inputs belonging to the wallet,

--- a/lnrpc/signrpc/signer.swagger.json
+++ b/lnrpc/signrpc/signer.swagger.json
@@ -18,7 +18,7 @@
   "paths": {
     "/v2/signer/inputscript": {
       "post": {
-        "summary": "ComputeInputScript generates a complete InputIndex for the passed\ntransaction with the signature as defined within the passed SignDescriptor.\nThis method should be capable of generating the proper input script for\nboth regular p2wkh output and p2wkh outputs nested within a regular p2sh\noutput.",
+        "summary": "ComputeInputScript generates a complete InputIndex for the passed\ntransaction with the signature as defined within the passed SignDescriptor.\nThis method should be capable of generating the proper input script for both\nregular p2wkh/p2tr outputs and p2wkh outputs nested within a regular p2sh\noutput.",
         "description": "Note that when using this method to sign inputs belonging to the wallet,\nthe only items of the SignDescriptor that need to be populated are pkScript\nin the TxOut field, the value in that same field, and finally the input\nindex.",
         "operationId": "Signer_ComputeInputScript",
         "responses": {

--- a/lnrpc/signrpc/signer_grpc.pb.go
+++ b/lnrpc/signrpc/signer_grpc.pb.go
@@ -31,8 +31,8 @@ type SignerClient interface {
 	//
 	//ComputeInputScript generates a complete InputIndex for the passed
 	//transaction with the signature as defined within the passed SignDescriptor.
-	//This method should be capable of generating the proper input script for
-	//both regular p2wkh output and p2wkh outputs nested within a regular p2sh
+	//This method should be capable of generating the proper input script for both
+	//regular p2wkh/p2tr outputs and p2wkh outputs nested within a regular p2sh
 	//output.
 	//
 	//Note that when using this method to sign inputs belonging to the wallet,
@@ -255,8 +255,8 @@ type SignerServer interface {
 	//
 	//ComputeInputScript generates a complete InputIndex for the passed
 	//transaction with the signature as defined within the passed SignDescriptor.
-	//This method should be capable of generating the proper input script for
-	//both regular p2wkh output and p2wkh outputs nested within a regular p2sh
+	//This method should be capable of generating the proper input script for both
+	//regular p2wkh/p2tr outputs and p2wkh outputs nested within a regular p2sh
 	//output.
 	//
 	//Note that when using this method to sign inputs belonging to the wallet,

--- a/lntest/itest/lnd_remote_signer_test.go
+++ b/lntest/itest/lnd_remote_signer_test.go
@@ -126,9 +126,7 @@ func testRemoteSigner(net *lntest.NetworkHarness, t *harnessTest) {
 			)
 			defer cancel()
 
-			testTaprootComputeInputScriptKeySpendBip86(
-				ctxt, tt, wo, net,
-			)
+			testTaprootSendCoinsKeySpendBip86(ctxt, tt, wo, net)
 			testTaprootSignOutputRawScriptSpend(ctxt, tt, wo, net)
 			testTaprootSignOutputRawKeySpendBip86(ctxt, tt, wo, net)
 			testTaprootSignOutputRawKeySpendRootHash(

--- a/lntest/itest/lnd_remote_signer_test.go
+++ b/lntest/itest/lnd_remote_signer_test.go
@@ -127,6 +127,9 @@ func testRemoteSigner(net *lntest.NetworkHarness, t *harnessTest) {
 			defer cancel()
 
 			testTaprootSendCoinsKeySpendBip86(ctxt, tt, wo, net)
+			testTaprootComputeInputScriptKeySpendBip86(
+				ctxt, tt, wo, net,
+			)
 			testTaprootSignOutputRawScriptSpend(ctxt, tt, wo, net)
 			testTaprootSignOutputRawKeySpendBip86(ctxt, tt, wo, net)
 			testTaprootSignOutputRawKeySpendRootHash(

--- a/lntest/itest/lnd_taproot_test.go
+++ b/lntest/itest/lnd_taproot_test.go
@@ -1043,20 +1043,20 @@ func newAddrWithScript(ctx context.Context, t *testing.T,
 	node *lntest.HarnessNode, addrType lnrpc.AddressType) (btcutil.Address,
 	[]byte) {
 
-	p2wkhResp, err := node.NewAddress(ctx, &lnrpc.NewAddressRequest{
+	newAddrResp, err := node.NewAddress(ctx, &lnrpc.NewAddressRequest{
 		Type: addrType,
 	})
 	require.NoError(t, err)
 
-	p2wkhAddr, err := btcutil.DecodeAddress(
-		p2wkhResp.Address, harnessNetParams,
+	addr, err := btcutil.DecodeAddress(
+		newAddrResp.Address, harnessNetParams,
 	)
 	require.NoError(t, err)
 
-	p2wkhPkScript, err := txscript.PayToAddrScript(p2wkhAddr)
+	pkScript, err := txscript.PayToAddrScript(addr)
 	require.NoError(t, err)
 
-	return p2wkhAddr, p2wkhPkScript
+	return addr, pkScript
 }
 
 // sendToTaprootOutput sends coins to a p2tr output of the given taproot key and

--- a/lntest/itest/lnd_taproot_test.go
+++ b/lntest/itest/lnd_taproot_test.go
@@ -46,7 +46,7 @@ func testTaproot(net *lntest.NetworkHarness, t *harnessTest) {
 	ctxt, cancel := context.WithTimeout(ctxb, 2*defaultTimeout)
 	defer cancel()
 
-	testTaprootComputeInputScriptKeySpendBip86(ctxt, t, net.Alice, net)
+	testTaprootSendCoinsKeySpendBip86(ctxt, t, net.Alice, net)
 	testTaprootSignOutputRawScriptSpend(ctxt, t, net.Alice, net)
 	testTaprootSignOutputRawKeySpendBip86(ctxt, t, net.Alice, net)
 	testTaprootSignOutputRawKeySpendRootHash(ctxt, t, net.Alice, net)
@@ -56,10 +56,10 @@ func testTaproot(net *lntest.NetworkHarness, t *harnessTest) {
 	testTaprootMuSig2CombinedLeafKeySpend(ctxt, t, net.Alice, net)
 }
 
-// testTaprootComputeInputScriptKeySpendBip86 tests sending to and spending from
+// testTaprootSendCoinsKeySpendBip86 tests sending to and spending from
 // p2tr key spend only (BIP-0086) addresses through the SendCoins RPC which
 // internally uses the ComputeInputScript method for signing.
-func testTaprootComputeInputScriptKeySpendBip86(ctxt context.Context,
+func testTaprootSendCoinsKeySpendBip86(ctxt context.Context,
 	t *harnessTest, alice *lntest.HarnessNode, net *lntest.NetworkHarness) {
 
 	// We'll start the test by sending Alice some coins, which she'll use to

--- a/lntest/itest/lnd_taproot_test.go
+++ b/lntest/itest/lnd_taproot_test.go
@@ -47,6 +47,7 @@ func testTaproot(net *lntest.NetworkHarness, t *harnessTest) {
 	defer cancel()
 
 	testTaprootSendCoinsKeySpendBip86(ctxt, t, net.Alice, net)
+	testTaprootComputeInputScriptKeySpendBip86(ctxt, t, net.Alice, net)
 	testTaprootSignOutputRawScriptSpend(ctxt, t, net.Alice, net)
 	testTaprootSignOutputRawKeySpendBip86(ctxt, t, net.Alice, net)
 	testTaprootSignOutputRawKeySpendRootHash(ctxt, t, net.Alice, net)
@@ -115,6 +116,108 @@ func testTaprootSendCoinsKeySpendBip86(ctxt context.Context,
 	// Make sure the coins sent to the address are confirmed correctly,
 	// including the confirmation notification.
 	confirmAddress(ctxt, t, net, alice, p2trResp.Address)
+}
+
+// testTaprootComputeInputScriptKeySpendBip86 tests sending to and spending
+// from p2tr key spend only (BIP-0086) addresses through the ComputeInputScript
+// RPC.
+func testTaprootComputeInputScriptKeySpendBip86(ctxt context.Context,
+	t *harnessTest, alice *lntest.HarnessNode, net *lntest.NetworkHarness) {
+
+	// We'll start the test by sending Alice some coins, which she'll use to
+	// send to herself on a p2tr output.
+	net.SendCoins(t.t, btcutil.SatoshiPerBitcoin, alice)
+
+	// Let's create a p2tr address now.
+	p2trAddr, p2trPkScript := newAddrWithScript(
+		ctxt, t.t, alice, lnrpc.AddressType_TAPROOT_PUBKEY,
+	)
+
+	// Send the coins from Alice's wallet to her own, but to the new p2tr
+	// address.
+	_, err := alice.SendCoins(ctxt, &lnrpc.SendCoinsRequest{
+		Addr:   p2trAddr.String(),
+		Amount: testAmount,
+	})
+	require.NoError(t.t, err)
+
+	txid, err := waitForTxInMempool(net.Miner.Client, defaultTimeout)
+	require.NoError(t.t, err)
+
+	// Wait until bob has seen the tx and considers it as owned.
+	p2trOutputIndex := getOutputIndex(t, net.Miner, txid, p2trAddr.String())
+	op := &lnrpc.OutPoint{
+		TxidBytes:   txid[:],
+		OutputIndex: uint32(p2trOutputIndex),
+	}
+	assertWalletUnspent(t, alice, op)
+
+	p2trOutpoint := wire.OutPoint{
+		Hash:  *txid,
+		Index: uint32(p2trOutputIndex),
+	}
+
+	// Mine a block to clean up the mempool.
+	mineBlocks(t, net, 1, 1)
+
+	// We'll send the coins back to a p2wkh address.
+	p2wkhAddr, p2wkhPkScript := newAddrWithScript(
+		ctxt, t.t, alice, lnrpc.AddressType_WITNESS_PUBKEY_HASH,
+	)
+
+	// Create fee estimation for a p2tr input and p2wkh output.
+	feeRate := chainfee.SatPerKWeight(12500)
+	estimator := input.TxWeightEstimator{}
+	estimator.AddTaprootKeySpendInput(txscript.SigHashDefault)
+	estimator.AddP2WKHOutput()
+	estimatedWeight := int64(estimator.Weight())
+	requiredFee := feeRate.FeeForWeight(estimatedWeight)
+
+	tx := wire.NewMsgTx(2)
+	tx.TxIn = []*wire.TxIn{{
+		PreviousOutPoint: p2trOutpoint,
+	}}
+	value := int64(testAmount - requiredFee)
+	tx.TxOut = []*wire.TxOut{{
+		PkScript: p2wkhPkScript,
+		Value:    value,
+	}}
+
+	var buf bytes.Buffer
+	require.NoError(t.t, tx.Serialize(&buf))
+
+	utxoInfo := []*signrpc.TxOut{{
+		PkScript: p2trPkScript,
+		Value:    testAmount,
+	}}
+	signResp, err := alice.SignerClient.ComputeInputScript(
+		ctxt, &signrpc.SignReq{
+			RawTxBytes: buf.Bytes(),
+			SignDescs: []*signrpc.SignDescriptor{{
+				Output:     utxoInfo[0],
+				InputIndex: 0,
+				Sighash:    uint32(txscript.SigHashDefault),
+			}},
+			PrevOutputs: utxoInfo,
+		},
+	)
+	require.NoError(t.t, err)
+
+	tx.TxIn[0].Witness = signResp.InputScripts[0].Witness
+
+	// Serialize, weigh and publish the TX now, then make sure the
+	// coins are sent and confirmed to the final sweep destination address.
+	publishTxAndConfirmSweep(
+		ctxt, t, net, alice, tx, estimatedWeight,
+		&chainrpc.SpendRequest{
+			Outpoint: &chainrpc.Outpoint{
+				Hash:  p2trOutpoint.Hash[:],
+				Index: p2trOutpoint.Index,
+			},
+			Script: p2trPkScript,
+		},
+		p2wkhAddr.String(),
+	)
 }
 
 // testTaprootSignOutputRawScriptSpend tests sending to and spending from p2tr


### PR DESCRIPTION
## Change Description
Fixes https://github.com/lightningnetwork/lnd/issues/6678 by correctly using the `PrevOutputs` parameter.
