### PR TITLE
Release notes: Move 0.15.1 item, remove duplicate headings, fix formatting

### DIFF
--- a/docs/release-notes/release-notes-0.15.0.md
+++ b/docs/release-notes/release-notes-0.15.0.md
@@ -70,11 +70,7 @@ releases. Backward compatibility is not guaranteed!
 * A new [`constrainmacaroon` command was
   added](https://github.com/lightningnetwork/lnd/pull/6529) that allows
   caveats/restrictions to be added to an existing macaroon (instead of needing
-  to bake a new one). 
-
-* [Hop hints are now opt in when using `lncli
-  addholdinvoice`](https://github.com/lightningnetwork/lnd/pull/6577). Users now
-  need to explicitly specify the `--private` flag.
+  to bake a new one).
 
 ## Neutrino
 

--- a/docs/release-notes/release-notes-0.15.1.md
+++ b/docs/release-notes/release-notes-0.15.1.md
@@ -23,8 +23,11 @@
 ## RPC Server
 
 * [Add previous_outpoints to listchaintxns](https://github.com/lightningnetwork/lnd/pull/6321)
+
 * [Fix P2TR support in
   `ComputeInputScript`](https://github.com/lightningnetwork/lnd/pull/6680).
+
+* [Add wallet reserve rpc & field in wallet balance](https://github.com/lightningnetwork/lnd/pull/6592)
 
 ## Bug Fixes
 
@@ -33,12 +36,6 @@
 
 * [Fixed a bug in the `SignPsbt` RPC that produced an invalid response when
   signing a NP2WKH input](https://github.com/lightningnetwork/lnd/pull/6687).
-
-## RPC Server
-
-* [Add wallet reserve rpc & field in wallet balance](https://github.com/lightningnetwork/lnd/pull/6592)
-
-## Bug Fixes
 
 * [Update the urfave/cli package](https://github.com/lightningnetwork/lnd/pull/6682) because
   of a flag parsing bug.

--- a/docs/release-notes/release-notes-0.15.1.md
+++ b/docs/release-notes/release-notes-0.15.1.md
@@ -11,6 +11,10 @@
 * [Add `payment_addr` flag to `buildroute`](https://github.com/lightningnetwork/lnd/pull/6576)
   so that the mpp record of the route can be set correctly.
 
+* [Hop hints are now opt in when using `lncli
+  addholdinvoice`](https://github.com/lightningnetwork/lnd/pull/6577). Users now
+  need to explicitly specify the `--private` flag.
+
 ## Documentation
 
 * [Add minor comment](https://github.com/lightningnetwork/lnd/pull/6559) on

--- a/docs/release-notes/release-notes-0.15.1.md
+++ b/docs/release-notes/release-notes-0.15.1.md
@@ -4,11 +4,12 @@
 
 * [Add the release build directory to the `.gitignore` file to avoid the release
   binary digest to be different whether that folder exists or
-  not](https://github.com/lightningnetwork/lnd/pull/6676)
+  not](https://github.com/lightningnetwork/lnd/pull/6676).
 
 ## `lncli`
 
-* [Add `payment_addr` flag to `buildroute`](https://github.com/lightningnetwork/lnd/pull/6576)
+* [Add `payment_addr` flag to
+  `buildroute`](https://github.com/lightningnetwork/lnd/pull/6576)
   so that the mpp record of the route can be set correctly.
 
 * [Hop hints are now opt in when using `lncli
@@ -22,12 +23,14 @@
   
 ## RPC Server
 
-* [Add previous_outpoints to listchaintxns](https://github.com/lightningnetwork/lnd/pull/6321)
+* [Add previous_outpoints to 
+  `GetTransactions` RPC](https://github.com/lightningnetwork/lnd/pull/6321).
 
 * [Fix P2TR support in
   `ComputeInputScript`](https://github.com/lightningnetwork/lnd/pull/6680).
 
-* [Add wallet reserve rpc & field in wallet balance](https://github.com/lightningnetwork/lnd/pull/6592)
+* [Add wallet reserve RPC & field in wallet
+  balance](https://github.com/lightningnetwork/lnd/pull/6592).
 
 ## Bug Fixes
 
@@ -37,8 +40,9 @@
 * [Fixed a bug in the `SignPsbt` RPC that produced an invalid response when
   signing a NP2WKH input](https://github.com/lightningnetwork/lnd/pull/6687).
 
-* [Update the urfave/cli package](https://github.com/lightningnetwork/lnd/pull/6682) because
-  of a flag parsing bug.
+* [Update the `urfave/cli`
+  package](https://github.com/lightningnetwork/lnd/pull/6682) because of a flag
+  parsing bug.
 
 * [DisconnectPeer no longer interferes with the peerTerminationWatcher. This previously caused
   force closes.](https://github.com/lightningnetwork/lnd/pull/6655)


### PR DESCRIPTION
Fixes a few things in the 0.15.0 and 0.15.1 release notes.