### PR TITLE
Fix batchopenchannel help text

### DIFF
--- a/cmd/lncli/cmd_open_channel.go
+++ b/cmd/lncli/cmd_open_channel.go
@@ -653,11 +653,11 @@ var batchOpenChannelCommand = cli.Command{
 	All nodes listed must already be connected peers, otherwise funding will
 	fail.
 
-	The channel will be initialized with local-amt satoshis local and
-	push-amt satoshis for the remote node. Note that specifying push-amt
-	means you give that amount to the remote node as part of the channel
-	opening. Once the channel is open, a channelPoint (txid:vout) of the
-	funding output is returned.
+	The channel will be initialized with local_funding_amount satoshis 
+	locally and push_sat satoshis for the remote node. Note that specifying 
+	push_sat means you give that amount to the remote node as part of the 
+	channel	opening. Once the channel is open, a channelPoint (txid:vout) of 
+	the funding output is returned.
 
 	If the remote peer supports the option upfront shutdown feature bit
 	(query listpeers to see their supported feature bits), an address to


### PR DESCRIPTION
This corrects the help text described in #6697 