### PR TITLE
rpcperms: guarantee execution order of interceptors

### DIFF
--- a/docs/release-notes/release-notes-0.15.1.md
+++ b/docs/release-notes/release-notes-0.15.1.md
@@ -65,6 +65,9 @@
 ### Code cleanup, refactor, typo fixes
 
 * [Migrate instances of assert.NoError to require.NoError](https://github.com/lightningnetwork/lnd/pull/6636).
+ 
+* [Enforce the order of rpc interceptor execution](https://github.com/lightningnetwork/lnd/pull/6709) to be the same as the
+  order in which they were registered.
 
 ### Tooling and documentation
 


### PR DESCRIPTION
In this commit, we let the registered middleware interceptors be stored
in a slice rather than a map so that the order in which the interceptors
are executed is guarenteed to be the same as the order in which they
were registered.