### PR TITLE
lntest: keep all failed payments by default for HarnessNode

### DIFF
--- a/docs/release-notes/release-notes-0.15.1.md
+++ b/docs/release-notes/release-notes-0.15.1.md
@@ -60,6 +60,8 @@
 * [The HtlcSwitch now waits for a ChannelLink to stop before replacing it. This fixes a race
   condition.](https://github.com/lightningnetwork/lnd/pull/6642)
 
+* [Integration tests now always run with nodes never deleting failed payments](https://github.com/lightningnetwork/lnd/pull/6712).
+
 ## Code Health
 
 ### Code cleanup, refactor, typo fixes
@@ -83,6 +85,7 @@
 * Eugene Siegel
 * Slyghtning
 * Oliver Gugger
+* Olaoluwa Osuntokun
 * Priyansh Rastogi
 * Tommy Volk
 * Yong Yu

--- a/lntest/harness_node.go
+++ b/lntest/harness_node.go
@@ -217,6 +217,7 @@ func (cfg *BaseNodeConfig) GenArgs() []string {
 		"--nobootstrap",
 		"--debuglevel=debug",
 		"--bitcoin.defaultchanconfs=1",
+		"--keep-failed-payment-attempts",
 		fmt.Sprintf("--db.batch-commit-interval=%v", commitInterval),
 		fmt.Sprintf("--bitcoin.defaultremotedelay=%v", DefaultCSV),
 		fmt.Sprintf("--rpclisten=%v", cfg.RPCAddr()),


### PR DESCRIPTION
In this commit, we fix a detected flake: we go to make a payment, and
then want to assert that 2 attempts we required. The existing logic
assumes that the success and the payment will still be on disk. With a
recent PR, we now delete failed payments by default, but after the fact,
in a non-atomic fashion.

We fix this issue simply by having all the nodes keep around failed
payments for the sake of all the old itests that assumed this
information would always be on disk.

Introduced in: https://github.com/lightningnetwork/lnd/pull/6438.

Fixes https://github.com/lightningnetwork/lnd/issues/6711.