### PR TITLE
lnwallet: don't create BIP044 key scope by default

### DIFF
--- a/docs/release-notes/release-notes-0.15.1.md
+++ b/docs/release-notes/release-notes-0.15.1.md
@@ -65,7 +65,11 @@
 * [The HtlcSwitch now waits for a ChannelLink to stop before replacing it. This fixes a race
   condition.](https://github.com/lightningnetwork/lnd/pull/6642)
 
-* [Integration tests now always run with nodes never deleting failed payments](https://github.com/lightningnetwork/lnd/pull/6712).
+* [Integration tests now always run with nodes never deleting failed
+  payments](https://github.com/lightningnetwork/lnd/pull/6712).
+
+* [Fixes a key scope issue preventing new remote signing setups to be created
+  with `v0.15.0-beta`](https://github.com/lightningnetwork/lnd/pull/6714).
 
 ## Code Health
 

--- a/lntest/itest/lnd_psbt_test.go
+++ b/lntest/itest/lnd_psbt_test.go
@@ -468,7 +468,7 @@ func testPsbtChanFundingSingleStep(net *lntest.NetworkHarness, t *harnessTest) {
 
 	// Everything we do here should be done within a second or two, so we
 	// can just keep a single timeout context around for all calls.
-	ctxt, cancel := context.WithTimeout(ctxb, defaultTimeout)
+	ctxt, cancel := context.WithTimeout(ctxb, 2*defaultTimeout)
 	defer cancel()
 
 	args := nodeArgsForCommitType(lnrpc.CommitmentType_ANCHORS)
@@ -1019,8 +1019,6 @@ func runSignPsbtSegWitV1ScriptSpend(t *harnessTest,
 func runFundAndSignPsbt(t *harnessTest, net *lntest.NetworkHarness,
 	alice *lntest.HarnessNode) {
 
-	// Everything we do here should be done within a second or two, so we
-	// can just keep a single timeout context around for all calls.
 	ctxb := context.Background()
 	ctxt, cancel := context.WithTimeout(ctxb, defaultTimeout)
 	defer cancel()
@@ -1042,6 +1040,8 @@ func runFundAndSignPsbt(t *harnessTest, net *lntest.NetworkHarness,
 	}
 
 	for _, addrType := range spendAddrTypes {
+		ctxt, cancel := context.WithTimeout(ctxb, defaultTimeout)
+
 		// First, spend all the coins in the wallet to an address of the
 		// given type so that UTXO will be picked when funding a PSBT.
 		sendAllCoinsToAddrType(ctxt, t, net, alice, addrType)
@@ -1057,6 +1057,8 @@ func runFundAndSignPsbt(t *harnessTest, net *lntest.NetworkHarness,
 		// is calling FinalizePsbt directly, also works for this address
 		// type.
 		assertPsbtFundSignSpend(ctxt, t, net, alice, fundOutputs, true)
+
+		cancel()
 	}
 }
 


### PR DESCRIPTION
With a change in #6379 we made sure that all default scopes are added to
the the wallet. Unfortunately this included the BIP044 key scope that
our wallet doesn't really use. This breaks the remote signing setup
because we don't export the account of the BIP044 scope and therefore
run into an issue on the watch-only side when attempting to create the
wallet.
