### PR TITLE
lncli: chan_point option for abandonchannel

### DIFF
--- a/cmd/lncli/commands.go
+++ b/cmd/lncli/commands.go
@@ -1150,6 +1150,12 @@ var abandonChannelCommand = cli.Command{
 			Usage: "the output index for the funding output of the funding " +
 				"transaction",
 		},
+		cli.StringFlag{
+			Name: "chan_point",
+			Usage: "(optional) the channel point. If set, " +
+				"funding_txid and output_index flags and " +
+				"positional arguments will be ignored",
+		},
 		cli.BoolFlag{
 			Name: "i_know_what_i_am_doing",
 			Usage: "override the requirement for lnd needing to " +

--- a/docs/release-notes/release-notes-0.15.1.md
+++ b/docs/release-notes/release-notes-0.15.1.md
@@ -22,7 +22,7 @@
   need to explicitly specify the `--private` flag.
 
 * [Add `chan_point` flag to
-  `updatechanstatus`](https://github.com/lightningnetwork/lnd/pull/6705)
+  `updatechanstatus` and `abandonchannel`](https://github.com/lightningnetwork/lnd/pull/6705)
   to offer a convenient way to specify the channel to be updated.
 
 * [Add `ignore_pair` flag to 


### PR DESCRIPTION
This PR adds a `--chan_point` option to `lncli abandonchannel` in the same fashion that it was added for `lncli updatechanpolicy` which was addressed here: https://github.com/lightningnetwork/lnd/issues/6699
