### PR TITLE
Use f.sync when writing files

### DIFF
--- a/cert/selfsigned.go
+++ b/cert/selfsigned.go
@@ -9,11 +9,12 @@ import (
 	"crypto/x509/pkix"
 	"encoding/pem"
 	"fmt"
-	"io/ioutil"
 	"math/big"
 	"net"
 	"os"
 	"time"
+
+	"github.com/lightningnetwork/lnd/io"
 )
 
 var (
@@ -272,10 +273,10 @@ func GenCertPair(org, certFile, keyFile string, tlsExtraIPs,
 	}
 
 	// Write cert and key files.
-	if err = ioutil.WriteFile(certFile, certBuf.Bytes(), 0644); err != nil {
+	if err = io.WriteFileToDisk(certFile, certBuf.Bytes(), 0644); err != nil {
 		return err
 	}
-	if err = ioutil.WriteFile(keyFile, keyBuf.Bytes(), 0600); err != nil {
+	if err = io.WriteFileToDisk(keyFile, keyBuf.Bytes(), 0600); err != nil {
 		os.Remove(certFile)
 		return err
 	}

--- a/cmd/lncli/cmd_macaroon.go
+++ b/cmd/lncli/cmd_macaroon.go
@@ -11,6 +11,7 @@ import (
 	"unicode"
 
 	"github.com/golang/protobuf/proto"
+	"github.com/lightningnetwork/lnd/io"
 	"github.com/lightningnetwork/lnd/lncfg"
 	"github.com/lightningnetwork/lnd/lnrpc"
 	"github.com/lightningnetwork/lnd/macaroons"
@@ -192,7 +193,7 @@ func bakeMacaroon(ctx *cli.Context) error {
 	// a file or write to the standard output using hex encoding.
 	switch {
 	case savePath != "":
-		err = ioutil.WriteFile(savePath, macBytes, 0644)
+		err = io.WriteFileToDisk(savePath, macBytes, 0644)
 		if err != nil {
 			return err
 		}
@@ -471,7 +472,7 @@ func constrainMacaroon(ctx *cli.Context) error {
 	}
 
 	// Now we can output the result.
-	err = ioutil.WriteFile(destMacFile, destMacBytes, 0644)
+	err = io.WriteFileToDisk(destMacFile, destMacBytes, 0644)
 	if err != nil {
 		return fmt.Errorf("error writing destination macaroon file "+
 			"%s: %v", destMacFile, err)

--- a/cmd/lncli/cmd_walletunlocker.go
+++ b/cmd/lncli/cmd_walletunlocker.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 
 	"github.com/lightninglabs/protobuf-hex-display/jsonpb"
+	"github.com/lightningnetwork/lnd/io"
 	"github.com/lightningnetwork/lnd/lncfg"
 	"github.com/lightningnetwork/lnd/lnrpc"
 	"github.com/lightningnetwork/lnd/lnrpc/walletrpc"
@@ -769,7 +770,7 @@ func storeOrPrintAdminMac(ctx *cli.Context, adminMac []byte) error {
 	// macaroon to that file.
 	if ctx.IsSet("save_to") {
 		macSavePath := lncfg.CleanAndExpandPath(ctx.String("save_to"))
-		err := ioutil.WriteFile(macSavePath, adminMac, 0644)
+		err := io.WriteFileToDisk(macSavePath, adminMac, 0644)
 		if err != nil {
 			_ = os.Remove(macSavePath)
 			return err

--- a/cmd/lncli/commands.go
+++ b/cmd/lncli/commands.go
@@ -20,6 +20,7 @@ import (
 	"github.com/lightninglabs/protobuf-hex-display/json"
 	"github.com/lightninglabs/protobuf-hex-display/jsonpb"
 	"github.com/lightninglabs/protobuf-hex-display/proto"
+	lnio "github.com/lightningnetwork/lnd/io"
 	"github.com/lightningnetwork/lnd/lnrpc"
 	"github.com/lightningnetwork/lnd/routing/route"
 	"github.com/lightningnetwork/lnd/signal"
@@ -2315,7 +2316,7 @@ func exportChanBackup(ctx *cli.Context) error {
 	}
 
 	if ctx.IsSet("output_file") {
-		return ioutil.WriteFile(
+		return lnio.WriteFileToDisk(
 			ctx.String("output_file"),
 			chanBackup.MultiChanBackup.MultiChanBackup,
 			0666,

--- a/cmd/lncli/profile.go
+++ b/cmd/lncli/profile.go
@@ -10,6 +10,7 @@ import (
 	"path"
 	"strings"
 
+	"github.com/lightningnetwork/lnd/io"
 	"github.com/lightningnetwork/lnd/lncfg"
 	"github.com/lightningnetwork/lnd/lnrpc"
 	"github.com/lightningnetwork/lnd/walletunlocker"
@@ -225,7 +226,7 @@ func saveProfileFile(file string, f *profileFile) error {
 	if err != nil {
 		return fmt.Errorf("could not marshal profile: %v", err)
 	}
-	return ioutil.WriteFile(file, content, 0644)
+	return io.WriteFileToDisk(file, content, 0644)
 }
 
 // profileFile is a struct that represents the whole content of a profile file.

--- a/io/io_test.go
+++ b/io/io_test.go
@@ -1,0 +1,38 @@
+package io_test
+
+import (
+	"io/ioutil"
+	"os"
+	"testing"
+
+	"github.com/lightningnetwork/lnd/io"
+)
+
+// TestWriteFileToDisk uses same scenario of ioutil asserting the content created and stored on new
+// file with the original one.
+func TestWriteFileToDisk(t *testing.T) {
+	f, err := ioutil.TempFile("", "io-test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	filename := f.Name()
+	data := "Programming today is a race between software engineers striving to " +
+		"build bigger and better idiot-proof programs, and the Universe trying " +
+		"to produce bigger and better idiots. So far, the Universe is winning."
+
+	if err := io.WriteFileToDisk(filename, []byte(data), 0644); err != nil {
+		t.Fatalf("WriteFile %s: %v", filename, err)
+	}
+
+	contents, err := ioutil.ReadFile(filename)
+	if err != nil {
+		t.Fatalf("ReadFile %s: %v", filename, err)
+	}
+
+	if string(contents) != data {
+		t.Fatalf("contents = %q\nexpected = %q", string(contents), data)
+	}
+
+	f.Close()
+	os.Remove(filename)
+}

--- a/io/write.go
+++ b/io/write.go
@@ -1,0 +1,27 @@
+package io
+
+import (
+	"io/fs"
+	"os"
+)
+
+// WriteFileToDisk writes data to specified file with perm file mode.
+// If file exists trucates it and forces new permissions; otherwise creates it with specified permission
+// This method uses same parameters as ioutil.WriteFile but persists the newly created file on storage
+// using f.sync.
+func WriteFileToDisk(file string, fileBytes []byte, perm fs.FileMode) error {
+	f, err := os.OpenFile(file, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, perm)
+	if err != nil {
+		return err
+	}
+	_, err = f.Write(fileBytes)
+	if err1 := f.Close(); err1 != nil && err == nil {
+		err = err1
+	}
+
+	if err2 := f.Sync(); err2 != nil && err == nil {
+		err = err2
+	}
+
+	return err
+}

--- a/kvdb/backend.go
+++ b/kvdb/backend.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	_ "github.com/btcsuite/btcwallet/walletdb/bdb" // Import to register backend.
+	"github.com/lightningnetwork/lnd/io"
 )
 
 const (
@@ -235,7 +236,7 @@ func updateLastCompactionDate(dbFile string) error {
 	byteOrder.PutUint64(tsBytes[:], uint64(time.Now().UnixNano()))
 
 	tsFile := fmt.Sprintf("%s%s", dbFile, LastCompactionFileNameSuffix)
-	return ioutil.WriteFile(tsFile, tsBytes[:], 0600)
+	return io.WriteFileToDisk(tsFile, tsBytes[:], 0600)
 }
 
 // GetTestBackend opens (or creates if doesn't exist) a bbolt or etcd

--- a/lnd.go
+++ b/lnd.go
@@ -26,6 +26,7 @@ import (
 	"github.com/lightningnetwork/lnd/cert"
 	"github.com/lightningnetwork/lnd/chanacceptor"
 	"github.com/lightningnetwork/lnd/channeldb"
+	"github.com/lightningnetwork/lnd/io"
 	"github.com/lightningnetwork/lnd/keychain"
 	"github.com/lightningnetwork/lnd/lncfg"
 	"github.com/lightningnetwork/lnd/lnrpc"
@@ -832,8 +833,8 @@ func genMacaroons(ctx context.Context, svc *macaroons.Service,
 	if err != nil {
 		return err
 	}
-	err = ioutil.WriteFile(invoiceFile, invoiceMacBytes, 0644)
-	if err != nil {
+
+	if err = io.WriteFileToDisk(invoiceFile, invoiceMacBytes, 0644); err != nil {
 		_ = os.Remove(invoiceFile)
 		return err
 	}
@@ -843,7 +844,8 @@ func genMacaroons(ctx context.Context, svc *macaroons.Service,
 	if err != nil {
 		return err
 	}
-	if err = ioutil.WriteFile(roFile, roBytes, 0644); err != nil {
+
+	if err = io.WriteFileToDisk(roFile, roBytes, 0644); err != nil {
 		_ = os.Remove(roFile)
 		return err
 	}
@@ -854,8 +856,7 @@ func genMacaroons(ctx context.Context, svc *macaroons.Service,
 		return err
 	}
 
-	err = ioutil.WriteFile(admFile, admBytes, adminMacaroonFilePermissions)
-	if err != nil {
+	if err = io.WriteFileToDisk(admFile, admBytes, 0644); err != nil {
 		_ = os.Remove(admFile)
 		return err
 	}

--- a/lnrpc/chainrpc/chainnotifier_server.go
+++ b/lnrpc/chainrpc/chainnotifier_server.go
@@ -7,7 +7,6 @@ import (
 	"bytes"
 	"context"
 	"errors"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"sync"
@@ -16,6 +15,7 @@ import (
 	"github.com/btcsuite/btcd/wire"
 	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
 	"github.com/lightningnetwork/lnd/chainntnfs"
+	"github.com/lightningnetwork/lnd/io"
 	"github.com/lightningnetwork/lnd/lnrpc"
 	"github.com/lightningnetwork/lnd/macaroons"
 	"google.golang.org/grpc"
@@ -135,7 +135,7 @@ func New(cfg *Config) (*Server, lnrpc.MacaroonPerms, error) {
 		if err != nil {
 			return nil, nil, err
 		}
-		err = ioutil.WriteFile(macFilePath, chainNotifierMacBytes, 0644)
+		err = io.WriteFileToDisk(macFilePath, chainNotifierMacBytes, 0644)
 		if err != nil {
 			_ = os.Remove(macFilePath)
 			return nil, nil, err

--- a/lnrpc/invoicesrpc/invoices_server.go
+++ b/lnrpc/invoicesrpc/invoices_server.go
@@ -6,12 +6,12 @@ package invoicesrpc
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
 	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
 	"github.com/lightningnetwork/lnd/channeldb"
+	"github.com/lightningnetwork/lnd/io"
 	"github.com/lightningnetwork/lnd/lnrpc"
 	"github.com/lightningnetwork/lnd/lntypes"
 	"github.com/lightningnetwork/lnd/macaroons"
@@ -131,7 +131,7 @@ func New(cfg *Config) (*Server, lnrpc.MacaroonPerms, error) {
 		if err != nil {
 			return nil, nil, err
 		}
-		err = ioutil.WriteFile(macFilePath, invoicesMacBytes, 0644)
+		err = io.WriteFileToDisk(macFilePath, invoicesMacBytes, 0644)
 		if err != nil {
 			_ = os.Remove(macFilePath)
 			return nil, nil, err

--- a/lnrpc/routerrpc/router_server.go
+++ b/lnrpc/routerrpc/router_server.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"sync/atomic"
@@ -14,6 +13,7 @@ import (
 	"github.com/btcsuite/btcd/wire"
 	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
 	"github.com/lightningnetwork/lnd/channeldb"
+	"github.com/lightningnetwork/lnd/io"
 	"github.com/lightningnetwork/lnd/lnrpc"
 	"github.com/lightningnetwork/lnd/lntypes"
 	"github.com/lightningnetwork/lnd/lnwire"
@@ -198,7 +198,7 @@ func New(cfg *Config) (*Server, lnrpc.MacaroonPerms, error) {
 		if err != nil {
 			return nil, nil, err
 		}
-		err = ioutil.WriteFile(macFilePath, routerMacBytes, 0644)
+		err = io.WriteFileToDisk(macFilePath, routerMacBytes, 0644)
 		if err != nil {
 			_ = os.Remove(macFilePath)
 			return nil, nil, err

--- a/lnrpc/signrpc/signer_server.go
+++ b/lnrpc/signrpc/signer_server.go
@@ -8,7 +8,6 @@ import (
 	"context"
 	"crypto/sha256"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -20,6 +19,7 @@ import (
 	"github.com/btcsuite/btcd/wire"
 	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
 	"github.com/lightningnetwork/lnd/input"
+	"github.com/lightningnetwork/lnd/io"
 	"github.com/lightningnetwork/lnd/keychain"
 	"github.com/lightningnetwork/lnd/lnrpc"
 	"github.com/lightningnetwork/lnd/lnwire"
@@ -164,7 +164,7 @@ func New(cfg *Config) (*Server, lnrpc.MacaroonPerms, error) {
 		if err != nil {
 			return nil, nil, err
 		}
-		err = ioutil.WriteFile(macFilePath, signerMacBytes, 0644)
+		err = io.WriteFileToDisk(macFilePath, signerMacBytes, 0644)
 		if err != nil {
 			_ = os.Remove(macFilePath)
 			return nil, nil, err

--- a/lnrpc/walletrpc/walletkit_server.go
+++ b/lnrpc/walletrpc/walletkit_server.go
@@ -27,6 +27,7 @@ import (
 	"github.com/btcsuite/btcwallet/wtxmgr"
 	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
 	"github.com/lightningnetwork/lnd/input"
+	"github.com/lightningnetwork/lnd/io"
 	"github.com/lightningnetwork/lnd/keychain"
 	"github.com/lightningnetwork/lnd/labels"
 	"github.com/lightningnetwork/lnd/lnrpc"
@@ -227,7 +228,7 @@ func New(cfg *Config) (*WalletKit, lnrpc.MacaroonPerms, error) {
 		if err != nil {
 			return nil, nil, err
 		}
-		err = ioutil.WriteFile(macFilePath, walletKitMacBytes, 0644)
+		err = io.WriteFileToDisk(macFilePath, walletKitMacBytes, 0644)
 		if err != nil {
 			_ = os.Remove(macFilePath)
 			return nil, nil, err

--- a/tor/cmd_onion.go
+++ b/tor/cmd_onion.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+
+	"github.com/lightningnetwork/lnd/io"
 )
 
 var (
@@ -63,7 +65,7 @@ func NewOnionFile(privateKeyPath string,
 
 // StorePrivateKey stores the private key at its expected path.
 func (f *OnionFile) StorePrivateKey(_ OnionType, privateKey []byte) error {
-	return ioutil.WriteFile(f.privateKeyPath, privateKey, f.privateKeyPerm)
+	return io.WriteFileToDisk(f.privateKeyPath, privateKey, f.privateKeyPerm)
 }
 
 // PrivateKey retrieves the private key from its expected path. If the file


### PR DESCRIPTION
## Change Description
On #6720 describes that  `ioutils.WriteFile` does not use f.Sync, so any failure could lead to no data or truncated data on storage.
This PR changes all `ioutils.WriteFile` operations to `io.WriteFileToDisk` function that uses os calls to sync the file to storage.

## Steps to Test
Ran some integration test (when developing macaroons part) and it seems working fine.
I used the ioutils.WriteFile tests case for this one. Any guidance is welcome.

## Pull Request Checklist
### Testing
- [ ] Your PR passes all CI checks.
- [ ] Tests covering the positive and negative (error paths) are included.
- [ ] Bug fixes contain tests triggering the bug to prevent regressions.

### Code Style and Documentation
- [ ] The change obeys the [Code Documentation and Commenting](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#CodeDocumentation) guidelines, and lines wrap at 80.
- [ ] Commits follow the [Ideal Git Commit Structure](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#IdealGitCommitStructure).
- [ ] Any new logging statements use an appropriate subsystem and logging level.
- [ ]  [There is a change description in the release notes](https://github.com/lightningnetwork/lnd/tree/master/docs/release-notes), or `[skip ci]` in the commit message for small changes.

📝 Please see our  [Contribution Guidelines](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md) for further guidance.