### PR TITLE
wtclient: Activate watchtower client by default and also add a Deactivate flag

### DIFF
--- a/config.go
+++ b/config.go
@@ -203,6 +203,10 @@ const (
 	// defaultKeepFailedPaymentAttempts is the default setting for whether
 	// to keep failed payments in the database.
 	defaultKeepFailedPaymentAttempts = false
+
+	// deafultWtClientActive sets the watchTower client to start
+	// automatically along with lnd.
+	deafultWtClientActive = true
 )
 
 var (
@@ -634,6 +638,9 @@ func DefaultConfig() Config {
 		KeepFailedPaymentAttempts: defaultKeepFailedPaymentAttempts,
 		RemoteSigner: &lncfg.RemoteSigner{
 			Timeout: lncfg.DefaultRemoteSignerRPCTimeout,
+		},
+		WtClient: &lncfg.WtClient{
+			Active: deafultWtClientActive,
 		},
 	}
 }

--- a/config_builder.go
+++ b/config_builder.go
@@ -815,7 +815,7 @@ func (d *DefaultDatabaseBuilder) BuildDatabase(
 			cfg.Watchtower.TowerDir,
 			cfg.registeredChains.PrimaryChain().String(),
 			lncfg.NormalizeNetwork(cfg.ActiveNetParams.Name),
-		), cfg.WtClient.Active, cfg.Watchtower.Active,
+		), !cfg.WtClient.Deactivate, cfg.Watchtower.Active,
 	)
 	if err != nil {
 		return nil, nil, fmt.Errorf("unable to obtain database "+
@@ -904,7 +904,7 @@ func (d *DefaultDatabaseBuilder) BuildDatabase(
 	dbs.ChanStateDB = dbs.GraphDB
 
 	// Wrap the watchtower client DB and make sure we clean up.
-	if cfg.WtClient.Active {
+	if !cfg.WtClient.Deactivate {
 		dbs.TowerClientDB, err = wtdb.OpenClientDB(
 			databaseBackends.TowerClientDB,
 		)

--- a/docs/release-notes/release-notes-0.16.0.md
+++ b/docs/release-notes/release-notes-0.16.0.md
@@ -7,7 +7,10 @@
 
 * [The macaroon key store implementation was refactored to be more generally useable](https://github.com/lightningnetwork/lnd/pull/6509).
 
+* [Adds `wtclient.deactivate` flag and defaults `wtclient.active` to `true`](https://github.com/lightningnetwork/lnd/pull/6733).
+
 # Contributors (Alphabetical Order)
 * Carla Kirk-Cohen
 * ErikEk
 * Olaoluwa Osuntokun
+* Priyansh Rastogi

--- a/docs/watchtower.md
+++ b/docs/watchtower.md
@@ -55,7 +55,7 @@ Retrieving information about your tower’s configurations can be done using
 }
 ```
 
-The entire set of watchtower configuration options can be found using 
+The entire set of watchtower configuration options can be found using
 `lnd -h`:
 
 ```shell
@@ -84,7 +84,7 @@ properly configured to point to an active listener.
 
 Additionally, users can specify their tower’s external IP address(es) using
 `watchtower.externalip=`, which will expose the full tower URIs
-(pubkey@host:port) over RPC or `lncli tower info`: 
+(pubkey@host:port) over RPC or `lncli tower info`:
 
 ```shell
 ⛰  lncli tower info
@@ -102,9 +102,9 @@ tower with the following command:
 ```
 
 If the watchtower's clients will need remote access, be sure to either:
- - Open port 9911 or a port chosen via `watchtower.listen`.
- - Use a proxy to direct traffic from an open port to the watchtower's listening
-   address.
+- Open port 9911 or a port chosen via `watchtower.listen`.
+- Use a proxy to direct traffic from an open port to the watchtower's listening
+  address.
 
 ### Tor Hidden Services
 
@@ -147,6 +147,7 @@ On Linux, for example, the default watchtower database will be located at:
 In order to set up a watchtower client, you’ll need two things:
 
 1. The watchtower client must be enabled with the `--wtclient.active` flag.
+(Deprecated, default value is true)
 
 ```shell
 ⛰  lnd --wtclient.active
@@ -236,4 +237,12 @@ COMMANDS:
 
 OPTIONS:
    --help, -h  show help
+```
+
+## Disabling a Watchtower Client
+
+The watchtower client can be disabled with the `--wtclient.deactivate` flag.
+
+```shell
+⛰  lnd --wtclient.deactivate
 ```

--- a/lncfg/wtclient.go
+++ b/lncfg/wtclient.go
@@ -6,7 +6,8 @@ import "fmt"
 type WtClient struct {
 	// Active determines whether a watchtower client should be created to
 	// back up channel states with registered watchtowers.
-	Active bool `long:"active" description:"Whether the daemon should use private watchtowers to back up revoked channel states."`
+	// Note: Default value is true.
+	Active bool `long:"active" description:"(Deprecated) Whether the daemon should use private watchtowers to back up revoked channel states. This will always be set to true by default, and is here for backwards compatibility."`
 
 	// PrivateTowerURIs specifies the lightning URIs of the towers the
 	// watchtower client should send new backups to.
@@ -15,6 +16,9 @@ type WtClient struct {
 	// SweepFeeRate specifies the fee rate in sat/byte to be used when
 	// constructing justice transactions sent to the tower.
 	SweepFeeRate uint64 `long:"sweep-fee-rate" description:"Specifies the fee rate in sat/byte to be used when constructing justice transactions sent to the watchtower."`
+
+	// Deactivate determines whether the watchtower client be stopped
+	Deactivate bool `long:"deactivate" description:"Whether the daemon should not use private watchtowers to back up revoked channel states."`
 }
 
 // Validate ensures the user has provided a valid configuration.

--- a/sample-lnd.conf
+++ b/sample-lnd.conf
@@ -975,9 +975,12 @@ litecoin.node=ltcd
 
 [wtclient]
 
-; Activate Watchtower Client. To get more information or configure watchtowers
+; (Deprecated) Activate Watchtower Client. To get more information or configure watchtowers
 ; run `lncli wtclient -h`.
 ; wtclient.active=true
+
+; Deactivate Watchtower Client.
+; wtclient.deactivate=true
 
 ; Specify the fee rate with which justice transactions will be signed. This fee
 ; rate should be chosen as a maximum fee rate one is willing to pay in order to

--- a/server.go
+++ b/server.go
@@ -1444,7 +1444,7 @@ func newServer(cfg *Config, listenAddrs []net.Addr,
 		FlapCountTicker: ticker.New(chanfitness.FlapCountFlushRate),
 	})
 
-	if cfg.WtClient.Active {
+	if !cfg.WtClient.Deactivate {
 		policy := wtpolicy.DefaultPolicy()
 
 		if cfg.WtClient.SweepFeeRate != 0 {


### PR DESCRIPTION
## Change Description
Fixes: #5344 

At present, the `--wtclient.active` has to be passed to enable the watchtower client but with this PR `wtclient` is automatically created, however, if not needed it could be disabled using `--wtclient.deactivate` flag.

<img src="https://user-images.githubusercontent.com/43826321/178978684-8a81368a-d5af-4cb1-815f-1b5d4b071931.png" width="600" height="250">

