### PR TITLE
Enable chan_point flag wherever funding_txid & output_index are used in lncli

### DIFF
--- a/cmd/lncli/cmd_update_chan_status.go
+++ b/cmd/lncli/cmd_update_chan_status.go
@@ -41,6 +41,12 @@ var updateChanStatusCommand = cli.Command{
 				"transaction",
 		},
 		cli.StringFlag{
+			Name: "chan_point",
+			Usage: "(optional) the channel point. If set, " +
+				"funding_txid and output_index flags and " +
+				"positional arguments will be ignored",
+		},
+		cli.StringFlag{
 			Name: "action",
 			Usage: `the action to take: must be one of "enable", "disable", ` +
 				`or "auto"`,

--- a/cmd/lncli/commands.go
+++ b/cmd/lncli/commands.go
@@ -1150,6 +1150,12 @@ var abandonChannelCommand = cli.Command{
 			Usage: "the output index for the funding output of the funding " +
 				"transaction",
 		},
+		cli.StringFlag{
+			Name: "chan_point",
+			Usage: "(optional) the channel point. If set, " +
+				"funding_txid and output_index flags and " +
+				"positional arguments will be ignored",
+		},
 		cli.BoolFlag{
 			Name: "i_know_what_i_am_doing",
 			Usage: "override the requirement for lnd needing to " +


### PR DESCRIPTION
## Change Description

The following `lncli` functions have the ability to accept `chan_point` or the `funding_txid` & `output_index` pair, but do not have the `chan_point` flag enabled. This MR simply enables the `chan_point` flag on `lncli` commands where `funding_txid` & `output_index` are used, since I find it to be a simpler interface, given that channel points are often returned as a single `txid:vout` string rather than separate fields elsewhere. 

- `UpdateChanStatus`
- `AbandonChannel`

## Steps to Test
Steps for reviewers to follow to test the change.

## Pull Request Checklist
### Testing
- [ ] Your PR passes all CI checks.
- [ ] Tests covering the positive and negative (error paths) are included.
- [ ] Bug fixes contain tests triggering the bug to prevent regressions.

### Code Style and Documentation
- [ ] The change obeys the [Code Documentation and Commenting](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#CodeDocumentation) guidelines, and lines wrap at 80.
- [ ] Commits follow the [Ideal Git Commit Structure](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#IdealGitCommitStructure).
- [ ] Any new logging statements use an appropriate subsystem and logging level.
- [ ]  [There is a change description in the release notes](https://github.com/lightningnetwork/lnd/tree/master/docs/release-notes), or `[skip ci]` in the commit message for small changes.

📝 Please see our  [Contribution Guidelines](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md) for further guidance.