### PR TITLE
config: allow independent rpccookie config

### DIFF
--- a/docs/release-notes/release-notes-0.15.1.md
+++ b/docs/release-notes/release-notes-0.15.1.md
@@ -115,6 +115,9 @@
 * [Re-initialise registered middleware index lookup map after removal of a 
   registered middleware](https://github.com/lightningnetwork/lnd/pull/6739)
 
+* [Bitcoind cookie file path can be specified with zmq
+  options](https://github.com/lightningnetwork/lnd/pull/6736)
+
 ## Code Health
 
 ### Code cleanup, refactor, typo fixes
@@ -135,6 +138,7 @@
 
 # Contributors (Alphabetical Order)
 
+* bitromortac
 * Carsten Otto
 * Elle Mouton
 * ErikEk


### PR DESCRIPTION
## Change Description
Fixes #6613. The bitcoind `.cookie` file contains an auto generated user (`__cookie__`) and password (random string), which can be used instead of the rpc user name and password. This commit allows for running against bitcoind without having to access `bitcoin.conf` like in the case for pure user/password/zmq configuration.

Note that here we check explicitly that rpc password/user is not set at the same time with the cookie path (could break some malconfigured setups, previously that was allowed because one took precedence over the other).

## Steps to Test
The path for the bitcoind cookie file can be specified with `rpccookiefile` (see #6613).

## Pull Request Checklist
### Testing
- [ ] Your PR passes all CI checks.

### Code Style and Documentation
- [x] The change obeys the [Code Documentation and Commenting](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#CodeDocumentation) guidelines, and lines wrap at 80.
- [x] Commits follow the [Ideal Git Commit Structure](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#IdealGitCommitStructure).
- [x] Any new logging statements use an appropriate subsystem and logging level.
- [x]  [There is a change description in the release notes](https://github.com/lightningnetwork/lnd/tree/master/docs/release-notes), or `[skip ci]` in the commit message for small changes.

📝 Please see our  [Contribution Guidelines](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md) for further guidance.