### PR TITLE
rpcperms: re-init mw lookup map after removal of one

### DIFF
--- a/docs/release-notes/release-notes-0.15.1.md
+++ b/docs/release-notes/release-notes-0.15.1.md
@@ -84,6 +84,9 @@
 * [Fixes a key scope issue preventing new remote signing setups to be created
   with `v0.15.0-beta`](https://github.com/lightningnetwork/lnd/pull/6714).
 
+* [Re-initialise registered middleware index lookup map after removal of a 
+  registered middleware](https://github.com/lightningnetwork/lnd/pull/6739)
+
 ## Code Health
 
 ### Code cleanup, refactor, typo fixes

--- a/rpcperms/interceptor.go
+++ b/rpcperms/interceptor.go
@@ -489,10 +489,17 @@ func (r *InterceptorChain) RemoveMiddleware(middlewareName string) {
 		return
 	}
 	delete(r.registeredMiddlewareNames, middlewareName)
+
 	r.registeredMiddleware = append(
 		r.registeredMiddleware[:index],
 		r.registeredMiddleware[index+1:]...,
 	)
+
+	// Re-initialise the middleware look-up map with the updated indexes.
+	r.registeredMiddlewareNames = make(map[string]int)
+	for i, mw := range r.registeredMiddleware {
+		r.registeredMiddlewareNames[mw.middlewareName] = i
+	}
 }
 
 // CustomCaveatSupported makes sure a middleware that handles the given custom


### PR DESCRIPTION
After removing a registered middleware from the slice, we need to update
the index lookup map with the updated index for each middleware.
