### PR TITLE
itest: fix sign_psbt failure

### DIFF
--- a/docs/release-notes/release-notes-0.15.1.md
+++ b/docs/release-notes/release-notes-0.15.1.md
@@ -73,6 +73,8 @@
 * [Fixed a bug in the `SignPsbt` RPC that produced an invalid response when
   signing a NP2WKH input](https://github.com/lightningnetwork/lnd/pull/6687).
 
+* [Fix race condition in `sign_psbt` test](https://github.com/lightningnetwork/lnd/pull/6741).
+
 * [Update the `urfave/cli`
   package](https://github.com/lightningnetwork/lnd/pull/6682) because of a flag
   parsing bug.
@@ -116,6 +118,7 @@
 * Elle Mouton
 * ErikEk
 * Eugene Siegel
+* Matt Morehouse
 * Slyghtning
 * Oliver Gugger
 * Olaoluwa Osuntokun

--- a/lntest/itest/lnd_psbt_test.go
+++ b/lntest/itest/lnd_psbt_test.go
@@ -1381,4 +1381,6 @@ func sendAllCoinsToAddrType(ctx context.Context, t *harnessTest,
 	require.NoError(t.t, err)
 
 	_ = mineBlocks(t, net, 1, 1)[0]
+	err = node.WaitForBlockchainSync()
+	require.NoError(t.t, err)
 }


### PR DESCRIPTION
Ensure the wallet has synced the blockchain before attempting to spend
funds.

Prior to this fix, I get the following error:
```
  rpc error: code = Unknown desc = wallet couldn't fund PSBT: error
      creating funding TX: insufficient funds available to construct
      transaction
```