### PR TITLE
Fix typo in lncli abandonchannel description

### DIFF
--- a/cmd/lncli/commands.go
+++ b/cmd/lncli/commands.go
@@ -1133,7 +1133,7 @@ var abandonChannelCommand = cli.Command{
 	channels due to bugs fixed in newer versions of lnd.
 
 	Only available when lnd is built in debug mode. The flag
-	--i_know_what_im_doing can be set to override the debug/dev mode
+	--i_know_what_i_am_doing can be set to override the debug/dev mode
 	requirement.
 
 	To view which funding_txids/output_indexes can be used for this command,


### PR DESCRIPTION
## Change Description

Fix typo: i_know_what_im_doing --> i_know_what_i_am_doing

## Steps to Test

N/A

## Pull Request Checklist
### Testing

N/A

### Code Style and Documentation

N/A

📝 Please see our  [Contribution Guidelines](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md) for further guidance.