### PR TITLE
doc: Deprecation reason of `settled` on `Invoice`

### DIFF
--- a/lnrpc/invoicesrpc/invoices.swagger.json
+++ b/lnrpc/invoicesrpc/invoices.swagger.json
@@ -469,6 +469,7 @@
         },
         "settled": {
           "type": "boolean",
+          "description": "The field is deprecated. Use the state field instead (compare to SETTLED).",
           "title": "Whether this invoice has been fulfilled"
         },
         "creation_date": {

--- a/lnrpc/lightning.pb.go
+++ b/lnrpc/lightning.pb.go
@@ -11368,7 +11368,10 @@ type Invoice struct {
 	//
 	//The fields value and value_msat are mutually exclusive.
 	ValueMsat int64 `protobuf:"varint,23,opt,name=value_msat,json=valueMsat,proto3" json:"value_msat,omitempty"`
-	// Whether this invoice has been fulfilled
+	//
+	//Whether this invoice has been fulfilled
+	//
+	//The field is deprecated. Use the state field instead (compare to SETTLED).
 	//
 	// Deprecated: Do not use.
 	Settled bool `protobuf:"varint,6,opt,name=settled,proto3" json:"settled,omitempty"`

--- a/lnrpc/lightning.proto
+++ b/lnrpc/lightning.proto
@@ -3227,7 +3227,11 @@ message Invoice {
     */
     int64 value_msat = 23;
 
-    // Whether this invoice has been fulfilled
+    /*
+    Whether this invoice has been fulfilled
+
+    The field is deprecated. Use the state field instead (compare to SETTLED).
+    */
     bool settled = 6 [deprecated = true];
 
     /*

--- a/lnrpc/lightning.swagger.json
+++ b/lnrpc/lightning.swagger.json
@@ -4722,6 +4722,7 @@
         },
         "settled": {
           "type": "boolean",
+          "description": "The field is deprecated. Use the state field instead (compare to SETTLED).",
           "title": "Whether this invoice has been fulfilled"
         },
         "creation_date": {


### PR DESCRIPTION
This documents how to deal with `settled` being deprecated. It took me quite a bit of digging without such documentation.

## Change Description
Description of change / link to associated issue.

## Steps to Test
Steps for reviewers to follow to test the change.

## Pull Request Checklist
### Testing
- [ ] Your PR passes all CI checks.
- [ ] Tests covering the positive and negative (error paths) are included.
- [ ] Bug fixes contain tests triggering the bug to prevent regressions.

### Code Style and Documentation
- [ ] The change obeys the [Code Documentation and Commenting](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#CodeDocumentation) guidelines, and lines wrap at 80.
- [ ] Commits follow the [Ideal Git Commit Structure](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#IdealGitCommitStructure).
- [ ] Any new logging statements use an appropriate subsystem and logging level.
- [ ]  [There is a change description in the release notes](https://github.com/lightningnetwork/lnd/tree/master/docs/release-notes), or `[skip ci]` in the commit message for small changes.

📝 Please see our  [Contribution Guidelines](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md) for further guidance.