### PR TITLE
migration25+migration26: add verbose error log

### DIFF
--- a/channeldb/migration25/migration.go
+++ b/channeldb/migration25/migration.go
@@ -77,16 +77,15 @@ func findOpenChannels(openChanBucket kvdb.RBucket) ([]*OpenChannel, error) {
 		c := &OpenChannel{}
 
 		// Read the sub-bucket level 3.
-		chanBucket := chainBucket.NestedReadBucket(
-			cp,
-		)
+		chanBucket := chainBucket.NestedReadBucket(cp)
 		if chanBucket == nil {
 			log.Errorf("unable to read bucket for chanPoint=%x", cp)
 			return nil
 		}
 		// Get the old channel info.
 		if err := fetchChanInfo(chanBucket, c, true); err != nil {
-			return fmt.Errorf("unable to fetch chan info: %v", err)
+			return fmt.Errorf("chanPoint=%x, unable to fetch "+
+				"chan info: %v", cp, err)
 		}
 
 		// Fetch the channel commitments, which are useful for freshly

--- a/channeldb/migration26/migration.go
+++ b/channeldb/migration26/migration.go
@@ -67,9 +67,7 @@ func findOpenChannels(openChanBucket kvdb.RBucket) ([]*OpenChannel, error) {
 		c := &OpenChannel{}
 
 		// Read the sub-bucket level 3.
-		chanBucket := chainBucket.NestedReadBucket(
-			cp,
-		)
+		chanBucket := chainBucket.NestedReadBucket(cp)
 		if chanBucket == nil {
 			log.Errorf("unable to read bucket for chanPoint=%x", cp)
 			return nil
@@ -77,7 +75,8 @@ func findOpenChannels(openChanBucket kvdb.RBucket) ([]*OpenChannel, error) {
 
 		// Get the old channel info.
 		if err := FetchChanInfo(chanBucket, c, true); err != nil {
-			return fmt.Errorf("unable to fetch chan info: %v", err)
+			return fmt.Errorf("chanPoint=%x, unable to fetch "+
+				"chan info: %v", cp, err)
 		}
 
 		channels = append(channels, c)


### PR DESCRIPTION
Fixing a user reported error re `migration25`,

```
2022-07-21 15:59:59.362 [INF] CHDB: Checking for schema update: latest_version=27, db_version=24
2022-07-21 15:59:59.362 [INF] CHDB: Performing database schema migration
2022-07-21 15:59:59.362 [INF] CHDB: Applying migration #25
2022-07-21 15:59:59.462 [INF] CHDB: Unable to apply migration #25
2022-07-21 15:59:59.685 [ERR] LTND: unable to open graph DB: unable to fetch chan info: no chan info found
2022-07-21 15:59:59.685 [ERR] LTND: Shutting down because error in main method: unable to open databases: unable to open graph DB: unable to fetch chan info: no chan info found
2022-07-21 15:59:59.686 [INF] LTND: Shutdown complete
```