### PR TITLE
Clarify misleading updatechanpolicy cli help

### DIFF
--- a/docs/release-notes/release-notes-0.16.0.md
+++ b/docs/release-notes/release-notes-0.16.0.md
@@ -153,6 +153,9 @@ certain large transactions](https://github.com/lightningnetwork/lnd/pull/7100).
   received](https://github.com/lightningnetwork/lnd/pull/7095) to avoid CPU
   spike.
 
+* [Clarify CLI help and make setting CLTV value optional for updatechanpolicy 
+  command](https://github.com/lightningnetwork/lnd/pull/6762)
+
 ## Code Health
 
 * [test: use `T.TempDir` to create temporary test
@@ -237,4 +240,5 @@ to refactor the itest for code health and maintenance.
 * Oliver Gugger
 * Priyansh Rastogi
 * Roei Erez
+* Sachin Meier
 * Yong Yu

--- a/routing/localchans/manager.go
+++ b/routing/localchans/manager.go
@@ -180,7 +180,9 @@ func (r *Manager) updateEdge(tx kvdb.RTx, chanPoint wire.OutPoint,
 	edge.FeeProportionalMillionths = lnwire.MilliSatoshi(
 		newSchema.FeeRate,
 	)
-	edge.TimeLockDelta = uint16(newSchema.TimeLockDelta)
+	if newSchema.TimeLockDelta != 0 {
+		edge.TimeLockDelta = uint16(newSchema.TimeLockDelta)
+	}
 
 	// Retrieve negotiated channel htlc amt limits.
 	amtMin, amtMax, err := r.getHtlcAmtLimits(tx, chanPoint)

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -6736,7 +6736,8 @@ func (r *rpcServer) UpdateChannelPolicy(ctx context.Context,
 
 	// We'll also ensure that the user isn't setting a CLTV delta that
 	// won't give outgoing HTLCs enough time to fully resolve if needed.
-	if req.TimeLockDelta < minTimeLockDelta {
+	// We allow a zero CLTV to leave this value unchanged.
+	if req.TimeLockDelta != 0 && req.TimeLockDelta < minTimeLockDelta {
 		return nil, fmt.Errorf("time lock delta of %v is too small, "+
 			"minimum supported is %v", req.TimeLockDelta,
 			minTimeLockDelta)


### PR DESCRIPTION
## Change Description

Associated Issue: https://github.com/lightningnetwork/lnd/issues/1523

The `updatechanpolicy` cli command uses `IntFlag` and `FloatFlag`, which autopopulate a `(default: 0)` at the end of flag descriptions. These are unhelpful since we ignore flags that are not set by this command, and do not set them to zero. 

## Steps to Test

No `lnd` behavior should change. For `lncli`, no behavior outside of the help message for `updatechanpolicy` should change. 

To test: 
- Run lnd with at least one channel. 
- Set fees to a specific non-zero rate using `fee_rate` flag.
- Verify that fees were accurately set using the `feereport` command. 
- Set fees to zero by setting `fee_rate` to `0.0`.
- Verify that fees on that channel are now 0. 
- Set fees to non-zero rate using `fee_rate_ppm` flag.
- Verify that fee rate updated using `feereport` command.
- Set fees to zero by setting `fee_rate_ppm` to `0`.
- Verify that fees on that channel are now 0. 


## Pull Request Checklist
### Testing
- [ ] Your PR passes all CI checks.
- [ ] Tests covering the positive and negative (error paths) are included.
- [ ] Bug fixes contain tests triggering the bug to prevent regressions.

### Code Style and Documentation
- [x] The change obeys the [Code Documentation and Commenting](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#CodeDocumentation) guidelines, and lines wrap at 80.
- [x] Commits follow the [Ideal Git Commit Structure](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#IdealGitCommitStructure).
- [ ] Any new logging statements use an appropriate subsystem and logging level.
- [x]  [There is a change description in the release notes](https://github.com/lightningnetwork/lnd/tree/master/docs/release-notes), or `[skip ci]` in the commit message for small changes.

📝 Please see our  [Contribution Guidelines](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md) for further guidance.