### PR TITLE
cert: fix the wrong file is removed

### DIFF
--- a/cert/selfsigned.go
+++ b/cert/selfsigned.go
@@ -276,7 +276,7 @@ func GenCertPair(org, certFile, keyFile string, tlsExtraIPs,
 		return err
 	}
 	if err = ioutil.WriteFile(keyFile, keyBuf.Bytes(), 0600); err != nil {
-		os.Remove(certFile)
+		os.Remove(keyFile)
 		return err
 	}
 


### PR DESCRIPTION
## Change Description

Fix a bug where the wrong file name is used. I suggested a way to fix this issue by making the code DRY [here](https://github.com/lightningnetwork/lnd/pull/6723#discussion_r929455188).

## Steps to Test

This is difficult to test. It would require mocking the file system writes or injecting faults into them.

## Pull Request Checklist
### Testing
- [ ] Your PR passes all CI checks.
- [ ] Tests covering the positive and negative (error paths) are included.
- [ ] Bug fixes contain tests triggering the bug to prevent regressions.

### Code Style and Documentation

- [x] Commits follow the [Ideal Git Commit Structure](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#IdealGitCommitStructure).
- [x]  [There is a change description in the release notes](https://github.com/lightningnetwork/lnd/tree/master/docs/release-notes), or `[skip ci]` in the commit message for small changes.

📝 Please see our  [Contribution Guidelines](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md) for further guidance.