### PR TITLE
lint: ignore a typecheck error

### DIFF
--- a/rpcserver.go
+++ b/rpcserver.go
@@ -2557,6 +2557,9 @@ func createRPCCloseUpdate(update interface{}) (
 	*lnrpc.CloseStatusUpdate, error) {
 
 	switch u := update.(type) {
+	// nolint: typecheck
+	// The linter error "previous case (typecheck)" can be given.
+	// This doesn't make sense since this is the first case of the switch.
 	case *peer.ChannelCloseUpdate:
 		return &lnrpc.CloseStatusUpdate{
 			Update: &lnrpc.CloseStatusUpdate_ChanClose{


### PR DESCRIPTION
## Change Description

This lint error was causing builds of some pull requests to show up as failed. I also reproduced this on my local computer.

One thing I read is that it could be related to a go version mismatch. But it is odd to only show up in one file.
The error is certainly spurious because it is an error that the case has already been seen, but the cases are in fact unique types. It must be confused and saying the type of both is a pointer or interface{}.

Ignoring it means that the switch statement may not be properly linted.

## Steps to Test

Does this pass the lint step of the CI build? Run locally (works on my Mac!) with:

```
golangci-lint run -v
```

Or faster is to disable the `.golangci.yml` and run:

```
golangci-lint run -v --disable-all -E typecheck ./.
```

## Pull Request Checklist
### Testing
- [ ] Your PR passes all CI checks.
- [ ] Tests covering the positive and negative (error paths) are included.
- [ ] Bug fixes contain tests triggering the bug to prevent regressions.

### Code Style and Documentation
- [x] The change obeys the [Code Documentation and Commenting](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#CodeDocumentation) guidelines, and lines wrap at 80.
- [x] Commits follow the [Ideal Git Commit Structure](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#IdealGitCommitStructure).
- [x]  [There is a change description in the release notes](https://github.com/lightningnetwork/lnd/tree/master/docs/release-notes), or `[skip ci]` in the commit message for small changes.

📝 Please see our  [Contribution Guidelines](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md) for further guidance.