### PR TITLE
tlv: allow tlv streams to use large records

### DIFF
--- a/docs/release-notes/release-notes-0.16.0.md
+++ b/docs/release-notes/release-notes-0.16.0.md
@@ -76,6 +76,10 @@ minimum version needed to build the project.
 * [test: use `T.TempDir` to create temporary test 
   directory](https://github.com/lightningnetwork/lnd/pull/6710)
 
+* [The `tlv` package now allows decoding records larger than 65535 bytes. The
+  caller is expected to know that doing so with untrusted input is
+  unsafe.](https://github.com/lightningnetwork/lnd/pull/6779)
+
 ### Tooling and documentation
 
 * [The `golangci-lint` tool was updated to

--- a/tlv/tlv_test.go
+++ b/tlv/tlv_test.go
@@ -370,12 +370,6 @@ var tlvDecodingFailureTests = []struct {
 		bytes:  []byte{0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0x00, 0x00},
 		expErr: tlv.ErrStreamNotCanonical,
 	},
-	{
-		name:   "absurd record length",
-		bytes:  []byte{0xfd, 0x01, 0x91, 0xfe, 0xff, 0xff, 0xff, 0xff},
-		expErr: tlv.ErrRecordTooLarge,
-		skipN2: true,
-	},
 }
 
 // TestTLVDecodingSuccess asserts that the TLV parser fails to decode invalid


### PR DESCRIPTION
Changes the `tlv` package such that:
- `Decode` can decode records > 65535 bytes
- `DecodeWithParsedTypes` can decode records > 65535 bytes
- Introduces `DecodeP2P` which cannot decode records > 65535 bytes
- Introduces `DecodeWithParsedTypesP2P` which cannot decode records > 65535 bytes

This is necessary for future changes to lnd and for other projects that want larger record sizes. Untrusted input should _always_ use the `*P2P` variants