### PR TITLE
itest: neutrino sub-server

### DIFF
--- a/docs/release-notes/release-notes-0.16.0.md
+++ b/docs/release-notes/release-notes-0.16.0.md
@@ -139,6 +139,9 @@ certain large transactions](https://github.com/lightningnetwork/lnd/pull/7100).
 * [The macaroon key store implementation was refactored to be more generally
   usable](https://github.com/lightningnetwork/lnd/pull/6509).
 
+* Add [an itest for the neutrino
+  sub-server](https://github.com/lightningnetwork/lnd/pull/6783).
+
 * [Fixed a bug where cookie authentication with Tor would fail if the cookie
   path contained spaces](https://github.com/lightningnetwork/lnd/pull/6829).
   [With the module updated](https://github.com/lightningnetwork/lnd/pull/6836),

--- a/lntemp/rpc/harness_rpc.go
+++ b/lntemp/rpc/harness_rpc.go
@@ -8,6 +8,7 @@ import (
 	"github.com/lightningnetwork/lnd/lnrpc"
 	"github.com/lightningnetwork/lnd/lnrpc/chainrpc"
 	"github.com/lightningnetwork/lnd/lnrpc/invoicesrpc"
+	"github.com/lightningnetwork/lnd/lnrpc/neutrinorpc"
 	"github.com/lightningnetwork/lnd/lnrpc/peersrpc"
 	"github.com/lightningnetwork/lnd/lnrpc/routerrpc"
 	"github.com/lightningnetwork/lnd/lnrpc/signrpc"
@@ -40,6 +41,7 @@ type HarnessRPC struct {
 	State            lnrpc.StateClient
 	ChainClient      chainrpc.ChainNotifierClient
 	ChainKit         chainrpc.ChainKitClient
+	NeutrinoKit      neutrinorpc.NeutrinoKitClient
 	Peer             peersrpc.PeersClient
 
 	// Name is the HarnessNode's name.
@@ -70,6 +72,7 @@ func NewHarnessRPC(ctxt context.Context, t *testing.T, c *grpc.ClientConn,
 		State:            lnrpc.NewStateClient(c),
 		ChainClient:      chainrpc.NewChainNotifierClient(c),
 		ChainKit:         chainrpc.NewChainKitClient(c),
+		NeutrinoKit:      neutrinorpc.NewNeutrinoKitClient(c),
 		Peer:             peersrpc.NewPeersClient(c),
 		Name:             name,
 	}

--- a/lntemp/rpc/neutrino_kit.go
+++ b/lntemp/rpc/neutrino_kit.go
@@ -1,0 +1,54 @@
+package rpc
+
+import (
+	"context"
+
+	"github.com/lightningnetwork/lnd/lnrpc/neutrinorpc"
+)
+
+// =====================
+// NeutrinoKitClient related RPCs.
+// =====================
+
+// Status makes an RPC call to neutrino kit client's Status and asserts.
+func (h *HarnessRPC) Status(
+	req *neutrinorpc.StatusRequest) *neutrinorpc.StatusResponse {
+
+	if req == nil {
+		req = &neutrinorpc.StatusRequest{}
+	}
+
+	ctxt, cancel := context.WithTimeout(h.runCtx, DefaultTimeout)
+	defer cancel()
+
+	resp, err := h.NeutrinoKit.Status(ctxt, req)
+	h.NoError(err, "Status")
+
+	return resp
+}
+
+// GetCFilter makes an RPC call to neutrino kit client's GetCFilter and asserts.
+func (h *HarnessRPC) GetCFilter(
+	req *neutrinorpc.GetCFilterRequest) *neutrinorpc.GetCFilterResponse {
+
+	ctxt, cancel := context.WithTimeout(h.runCtx, DefaultTimeout)
+	defer cancel()
+
+	resp, err := h.NeutrinoKit.GetCFilter(ctxt, req)
+	h.NoError(err, "GetCFilter")
+
+	return resp
+}
+
+// AddPeer makes an RPC call to neutrino kit client's AddPeer and asserts.
+func (h *HarnessRPC) AddPeer(
+	req *neutrinorpc.AddPeerRequest) *neutrinorpc.AddPeerResponse {
+
+	ctxt, cancel := context.WithTimeout(h.runCtx, DefaultTimeout)
+	defer cancel()
+
+	resp, err := h.NeutrinoKit.AddPeer(ctxt, req)
+	h.NoError(err, "AddPeer")
+
+	return resp
+}

--- a/lntest/harness_node.go
+++ b/lntest/harness_node.go
@@ -25,6 +25,7 @@ import (
 	"github.com/lightningnetwork/lnd/lnrpc"
 	"github.com/lightningnetwork/lnd/lnrpc/chainrpc"
 	"github.com/lightningnetwork/lnd/lnrpc/invoicesrpc"
+	"github.com/lightningnetwork/lnd/lnrpc/neutrinorpc"
 	"github.com/lightningnetwork/lnd/lnrpc/peersrpc"
 	"github.com/lightningnetwork/lnd/lnrpc/routerrpc"
 	"github.com/lightningnetwork/lnd/lnrpc/signrpc"
@@ -368,6 +369,7 @@ type HarnessNode struct {
 	StateClient      lnrpc.StateClient
 	ChainClient      chainrpc.ChainNotifierClient
 	ChainKit         chainrpc.ChainKitClient
+	NeutrinoClient   neutrinorpc.NeutrinoKitClient
 }
 
 // RPCClients wraps a list of RPC clients into a single struct for easier
@@ -387,6 +389,7 @@ type RPCClients struct {
 	State            lnrpc.StateClient
 	ChainClient      chainrpc.ChainNotifierClient
 	ChainKit         chainrpc.ChainKitClient
+	NeutrinoClient   neutrinorpc.NeutrinoKitClient
 }
 
 // Assert *HarnessNode implements the lnrpc.LightningClient interface.
@@ -941,6 +944,7 @@ func (hn *HarnessNode) InitRPCClients(c *grpc.ClientConn) {
 		State:            lnrpc.NewStateClient(c),
 		ChainClient:      chainrpc.NewChainNotifierClient(c),
 		ChainKit:         chainrpc.NewChainKitClient(c),
+		NeutrinoClient:   neutrinorpc.NewNeutrinoKitClient(c),
 	}
 }
 
@@ -964,6 +968,7 @@ func (hn *HarnessNode) initLightningClient() error {
 	hn.StateClient = lnrpc.NewStateClient(conn)
 	hn.ChainClient = chainrpc.NewChainNotifierClient(conn)
 	hn.ChainKit = chainrpc.NewChainKitClient(conn)
+	hn.NeutrinoClient = neutrinorpc.NewNeutrinoKitClient(conn)
 
 	// Wait until the server is fully started.
 	if err := hn.WaitUntilServerActive(); err != nil {
@@ -1183,6 +1188,7 @@ func (hn *HarnessNode) stop() error {
 	hn.WalletUnlockerClient = nil
 	hn.Watchtower = nil
 	hn.WatchtowerClient = nil
+	hn.NeutrinoClient = nil
 
 	// Close any attempts at further grpc connections.
 	if hn.rpc.conn != nil {

--- a/lntest/itest/list_on_test.go
+++ b/lntest/itest/list_on_test.go
@@ -227,4 +227,8 @@ var allTestCasesTemp = []*lntemp.TestCase{
 		Name:     "chain kit",
 		TestFunc: testChainKit,
 	},
+	{
+		Name:     "neutrino kit",
+		TestFunc: testNeutrino,
+	},
 }

--- a/lntest/itest/lnd_neutrino_test.go
+++ b/lntest/itest/lnd_neutrino_test.go
@@ -1,0 +1,33 @@
+package itest
+
+import (
+	"github.com/lightningnetwork/lnd/lnrpc/neutrinorpc"
+	"github.com/lightningnetwork/lnd/lntemp"
+	"github.com/lightningnetwork/lnd/lntest"
+	"github.com/stretchr/testify/require"
+)
+
+// testNeutrino checks that the neutrino sub-server can fetch compact
+// block filters, server status and connect to a connected peer.
+func testNeutrino(ht *lntemp.HarnessTest) {
+	if ht.ChainBackendName() != lntest.NeutrinoBackendName {
+		ht.Skipf("skipping test for non neutrino backends")
+	}
+
+	// Check if the neutrino sub server is running.
+	statusRes := ht.Alice.RPC.Status(nil)
+	require.True(ht, statusRes.Active)
+	require.Len(ht, statusRes.Peers, 1, "unable to find a peer")
+
+	// Request the compact block filter of the best block.
+	cFilterReq := &neutrinorpc.GetCFilterRequest{
+		Hash: statusRes.GetBlockHash(),
+	}
+	ht.Alice.RPC.GetCFilter(cFilterReq)
+
+	// Try to reconnect to a connected peer.
+	addPeerReq := &neutrinorpc.AddPeerRequest{
+		PeerAddrs: statusRes.Peers[0],
+	}
+	ht.Alice.RPC.AddPeer(addPeerReq)
+}


### PR DESCRIPTION
Requested by @yyforyongyu. This PR add an itest for some of the functions (excluding isbanned and disconnect peer) of the neutrino sub-server, and incorporate the neutrino sub-server as a client in the harnessnode. For this to work neutrino has to be chosen as the backend (`make itest backend=neutrino`).
I did not include t.Skip messages for non-neutrino backend tests.