### PR TITLE
server+htlcswitch: check waiting-close fwdpkgs in reforwardResponses

### DIFF
--- a/docs/release-notes/release-notes-0.16.0.md
+++ b/docs/release-notes/release-notes-0.16.0.md
@@ -45,6 +45,9 @@ minimum version needed to build the project.
 
 ## Misc
 
+* [Fixed a bug where the Switch did not reforward settles or fails for
+  waiting-close channels](https://github.com/lightningnetwork/lnd/pull/6789)
+
 * [Fixed a flake in the TestChannelLinkCancelFullCommitment unit
   test](https://github.com/lightningnetwork/lnd/pull/6792).
 

--- a/htlcswitch/mock.go
+++ b/htlcswitch/mock.go
@@ -194,6 +194,7 @@ func initSwitchWithDB(startingHeight uint32, db *channeldb.DB) (*Switch, error) 
 	cfg := Config{
 		DB:                   db,
 		FetchAllOpenChannels: db.ChannelStateDB().FetchAllOpenChannels,
+		FetchAllChannels:     db.ChannelStateDB().FetchAllChannels,
 		FetchClosedChannels:  db.ChannelStateDB().FetchClosedChannels,
 		SwitchPackager:       channeldb.NewSwitchPackager(),
 		FwdingLog: &mockForwardingLog{

--- a/htlcswitch/switch.go
+++ b/htlcswitch/switch.go
@@ -145,6 +145,10 @@ type Config struct {
 	// channels from the channel database.
 	FetchAllOpenChannels func() ([]*channeldb.OpenChannel, error)
 
+	// FetchAllChannels is a function that fetches all pending open, open,
+	// and waiting close channels from the database.
+	FetchAllChannels func() ([]*channeldb.OpenChannel, error)
+
 	// FetchClosedChannels is a function that fetches all closed channels
 	// from the channel database.
 	FetchClosedChannels func(
@@ -2083,9 +2087,11 @@ func (s *Switch) reforwardResolutions() error {
 
 // reforwardResponses for every known, non-pending channel, loads all associated
 // forwarding packages and reforwards any Settle or Fail HTLCs found. This is
-// used to resurrect the switch's mailboxes after a restart.
+// used to resurrect the switch's mailboxes after a restart. This also runs for
+// waiting close channels since there may be settles or fails that need to be
+// reforwarded before they completely close.
 func (s *Switch) reforwardResponses() error {
-	openChannels, err := s.cfg.FetchAllOpenChannels()
+	openChannels, err := s.cfg.FetchAllChannels()
 	if err != nil {
 		return err
 	}

--- a/server.go
+++ b/server.go
@@ -630,6 +630,7 @@ func newServer(cfg *Config, listenAddrs []net.Addr,
 	s.htlcSwitch, err = htlcswitch.New(htlcswitch.Config{
 		DB:                   dbs.ChanStateDB,
 		FetchAllOpenChannels: s.chanStateDB.FetchAllOpenChannels,
+		FetchAllChannels:     s.chanStateDB.FetchAllChannels,
 		FetchClosedChannels:  s.chanStateDB.FetchClosedChannels,
 		LocalChannelClose: func(pubKey []byte,
 			request *htlcswitch.ChanClose) {


### PR DESCRIPTION
Previously, the Switch would not check waiting-close channels' fwdpkgs
for settles or fails to reforward. This could result in a force close
in a rare edge case if a restart occurred at the wrong time. Now,
waiting-close fwdpkgs are checked and the issue is avoided.