### PR TITLE
chainreg: shutdown if backend node doesn't support taproot

### DIFF
--- a/chainreg/chainregistry.go
+++ b/chainreg/chainregistry.go
@@ -496,6 +496,14 @@ func NewPartialChainControl(cfg *Config) (*PartialChainControl, func(), error) {
 			return nil, nil, err
 		}
 
+		// Before we continue any further, we'll ensure that the
+		// backend understands Taproot. If not, then all the default
+		// features can't be used.
+		if !backendSupportsTaproot(chainConn) {
+			return nil, nil, fmt.Errorf("node backend does not " +
+				"support taproot")
+		}
+
 		// The api we will use for our health check depends on the
 		// bitcoind version.
 		cmd, ver, err := getBitcoindHealthCheckCmd(chainConn)
@@ -673,6 +681,21 @@ func NewPartialChainControl(cfg *Config) (*PartialChainControl, func(), error) {
 		)
 		if err != nil {
 			return nil, nil, err
+		}
+
+		// Before we continue any further, we'll ensure that the
+		// backend understands Taproot. If not, then all the default
+		// features can't be used.
+		restConfCopy := *rpcConfig
+		restConfCopy.Endpoint = ""
+		restConfCopy.HTTPPostMode = true
+		chainConn, err := rpcclient.New(&restConfCopy, nil)
+		if err != nil {
+			return nil, nil, err
+		}
+		if !backendSupportsTaproot(chainConn) {
+			return nil, nil, fmt.Errorf("node backend does not " +
+				"support taproot")
 		}
 
 		cc.ChainSource = chainRPC

--- a/chainreg/taproot_check.go
+++ b/chainreg/taproot_check.go
@@ -1,0 +1,53 @@
+package chainreg
+
+import (
+	"encoding/json"
+
+	"github.com/btcsuite/btcd/rpcclient"
+)
+
+// backendSupportsTaproot returns true if the backend understands the taproot
+// soft fork.
+func backendSupportsTaproot(rpc *rpcclient.Client) bool {
+	// First, we'll try to access the normal getblockchaininfo call.
+	chainInfo, err := rpc.GetBlockChainInfo()
+	if err == nil {
+		// If this call worked, then we'll check that the taproot
+		// deployment is defined.
+		if chainInfo.SoftForks != nil {
+			_, ok := chainInfo.SoftForks.Bip9SoftForks["taproot"]
+			if ok {
+				return ok
+			}
+		}
+	}
+
+	// The user might be running a newer version of bitcoind that doesn't
+	// implement the getblockchaininfo call any longer, so we'll fall back
+	// here.
+	//
+	// Alternatively, the fork wasn't specified, but the user might be
+	// running a newer version of bitcoind that still has the
+	// getblockchaininfo call, but doesn't populate the data, so we'll hit
+	// the new getdeploymentinfo call.
+	resp, err := rpc.RawRequest("getdeploymentinfo", nil)
+	if err != nil {
+		log.Warnf("unable to make getdeploymentinfo request: %v", err)
+		return false
+	}
+
+	info := struct {
+		Deployments map[string]struct {
+			Type   string `json:"type"`
+			Active bool   `json:"active"`
+			Height int32  `json:"height"`
+		} `json:"deployments"`
+	}{}
+	if err := json.Unmarshal(resp, &info); err != nil {
+		log.Warnf("unable to decode getdeploymentinfo resp: %v", err)
+		return false
+	}
+
+	_, ok := info.Deployments["taproot"]
+	return ok
+}

--- a/docs/release-notes/release-notes-0.15.1.md
+++ b/docs/release-notes/release-notes-0.15.1.md
@@ -11,6 +11,12 @@
   binary digest to be different whether that folder exists or
   not](https://github.com/lightningnetwork/lnd/pull/6676).
 
+## Taproot
+
+[`lnd` will now refuse to start if it detects the full node backned does not
+support Tapoot](https://github.com/lightningnetwork/lnd/pull/6798).
+
+
 ## `lncli`
 
 * [Add `payment_addr` flag to


### PR DESCRIPTION
In this commit, we add a check during normal node construction to see if
the backend node supports Taproot. If it doesn't, then we want to
shutdown and force the user to take note.

To check if the node supports Taproot, we'll first try the normal
getblockchaininfo call. If this works, cool, then we can rely on the
value. If it doesn't, then we'll fall back to the getdeploymentinfo call
which was added in a recent version of bitcoind [1]. Newer versions of
bitcoind might also have this call, and the getblockchaininfo call, but
not actually populate the softforks field [2]. In this case, we'll fall
back, and we also account for the case when the getblockchaininfo RPC is
removed all together.

[1]: https://github.com/bitcoin/bitcoin/pull/23508
[2]: https://github.com/bitcoin/bitcoin/pull/25114


Fixes https://github.com/lightningnetwork/lnd/issues/6773