### PR TITLE
Add tests for warning messages from peers

### DIFF
--- a/docs/release-notes/release-notes-0.16.0.md
+++ b/docs/release-notes/release-notes-0.16.0.md
@@ -4,6 +4,9 @@
 * Warning messages from peers are now recognized and
   [logged](https://github.com/lightningnetwork/lnd/pull/6546) by lnd.
 
+* [Add tests](https://github.com/lightningnetwork/lnd/pull/6805) for warning
+  messages from peers.
+
 * [Fixed error typo](https://github.com/lightningnetwork/lnd/pull/6659).
 
 * [The macaroon key store implementation was refactored to be more generally
@@ -20,5 +23,6 @@
 
 * Carla Kirk-Cohen
 * ErikEk
+* Jordi Montes
 * Olaoluwa Osuntokun
 * Oliver Gugger

--- a/htlcswitch/link_test.go
+++ b/htlcswitch/link_test.go
@@ -5341,6 +5341,22 @@ func TestChannelLinkFail(t *testing.T) {
 			false,
 		},
 		{
+			// Test that we don't force close the channel when
+			// we receive a warning message.
+			func(c *channelLink) {},
+			func(t *testing.T, c *channelLink,
+				_ *lnwallet.LightningChannel) {
+
+				// Sent a random warning message.
+				warning := &lnwire.Warning{
+					Error: *lnwire.NewError()}
+				c.handleUpstreamMsg(warning)
+			},
+			false,
+			false,
+			false,
+		},
+		{
 			// Test that we force close the channel if we receive
 			// an invalid CommitSig, not containing enough HTLC
 			// sigs.


### PR DESCRIPTION
## Change Description
Test that warning messages from our peers do not trigger any action.

## Steps to Test
`pushd htlcswitch && go test -v -run TestChannelLinkFail && popd`

## Pull Request Checklist
### Testing
- [x] Your PR passes all CI checks.
- [x] Tests covering the positive and negative (error paths) are included.

### Code Style and Documentation
- [x] The change obeys the [Code Documentation and Commenting](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#CodeDocumentation) guidelines, and lines wrap at 80.
- [x] Commits follow the [Ideal Git Commit Structure](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#IdealGitCommitStructure).
- [x]  [There is a change description in the release notes](https://github.com/lightningnetwork/lnd/tree/master/docs/release-notes), or `[skip ci]` in the commit message for small changes.
