### PR TITLE
Remove `ScidAliasOptional` feature dependency on `ExplicitChannelTypeOptional`

### DIFF
--- a/docs/release-notes/release-notes-0.15.1.md
+++ b/docs/release-notes/release-notes-0.15.1.md
@@ -118,6 +118,9 @@
 * [Bitcoind cookie file path can be specified with zmq
   options](https://github.com/lightningnetwork/lnd/pull/6736)
 
+* [Remove `ScidAliasOptional` dependency on 
+`ExplicitChannelTypeOptional`](https://github.com/lightningnetwork/lnd/pull/6809)
+
 ## Code Health
 
 ### Code cleanup, refactor, typo fixes
@@ -143,6 +146,7 @@
 * Elle Mouton
 * ErikEk
 * Eugene Siegel
+* Jordi Montes
 * Matt Morehouse
 * Slyghtning
 * Oliver Gugger

--- a/feature/deps.go
+++ b/feature/deps.go
@@ -72,9 +72,6 @@ var deps = depDesc{
 	lnwire.KeysendOptional: {
 		lnwire.TLVOnionPayloadOptional: {},
 	},
-	lnwire.ScidAliasOptional: {
-		lnwire.ExplicitChannelTypeOptional: {},
-	},
 	lnwire.ZeroConfOptional: {
 		lnwire.ScidAliasOptional: {},
 	},


### PR DESCRIPTION
## Change Description

The [spec](https://github.com/lightning/bolts/blob/master/09-features.md) does not specify a dependency between `ScidAliasOptional` (47) and`ExplicitChannelTypeOptional` (45).

This bug lead to some connectivity issues with peers not setting the 45 feature bit while setting the 47. The issue [6802](https://github.com/lightningnetwork/lnd/issues/6802) is an example of this.


Fixes [#6802](https://github.com/lightningnetwork/lnd/issues/6802)

