### PR TITLE
multi: use taproot errwhere applicable for change/delivery/tower addresses

### DIFF
--- a/contractcourt/breacharbiter.go
+++ b/contractcourt/breacharbiter.go
@@ -1347,9 +1347,9 @@ func (b *BreachArbiter) createSweepTx(inputs []input.Input) (*wire.MsgTx,
 	spendableOutputs = make([]input.Input, 0, len(inputs))
 
 	// The justice transaction we construct will be a segwit transaction
-	// that pays to a p2wkh output. Components such as the version,
+	// that pays to a p2tr output. Components such as the version,
 	// nLockTime, and output are already included in the TxWeightEstimator.
-	weightEstimate.AddP2WKHOutput()
+	weightEstimate.AddP2TROutput()
 
 	// Next, we iterate over the breached outputs contained in the
 	// retribution info.  For each, we switch over the witness type such

--- a/docs/release-notes/release-notes-0.15.1.md
+++ b/docs/release-notes/release-notes-0.15.1.md
@@ -21,11 +21,14 @@
 
 ## Taproot
 
-[`lnd` will now refuse to start if it detects the full node backned does not
+[`lnd` will now refuse to start if it detects the full node backend does not
 support Tapoot](https://github.com/lightningnetwork/lnd/pull/6798).
 
 [`lnd` will now use taproot addresses for co-op closes if the remote peer
 supports the feature.](https://github.com/lightningnetwork/lnd/pull/6633)
+
+The [wallet also creates P2TR change addresses by
+default](https://github.com/lightningnetwork/lnd/pull/6810) in most cases.
 
 ## `lncli`
 

--- a/lnd.go
+++ b/lnd.go
@@ -458,7 +458,7 @@ func Main(cfg *Config, lisCfg ListenerCfg, implCfg *ImplementationCfg,
 			Net:            cfg.net,
 			NewAddress: func() (btcutil.Address, error) {
 				return activeChainControl.Wallet.NewAddress(
-					lnwallet.WitnessPubKey, false,
+					lnwallet.TaprootPubkey, false,
 					lnwallet.DefaultAccountName,
 				)
 			},

--- a/lnwallet/chanfunding/coin_select.go
+++ b/lnwallet/chanfunding/coin_select.go
@@ -98,8 +98,8 @@ func calculateFees(utxos []Coin, feeRate chainfee.SatPerKWeight) (btcutil.Amount
 	requiredFeeNoChange := feeRate.FeeForWeight(totalWeight)
 
 	// Estimate the fee required for a transaction with a change output.
-	// Assume that change output is a P2WKH output.
-	weightEstimate.AddP2WKHOutput()
+	// Assume that change output is a P2TR output.
+	weightEstimate.AddP2TROutput()
 
 	// Now that we have added the change output, redo the fee
 	// estimate.
@@ -209,7 +209,8 @@ func CoinSelectSubtractFees(feeRate chainfee.SatPerKWeight, amt,
 	// Obtain fee estimates both with and without using a change
 	// output.
 	requiredFeeNoChange, requiredFeeWithChange, err := calculateFees(
-		selectedUtxos, feeRate)
+		selectedUtxos, feeRate,
+	)
 	if err != nil {
 		return nil, 0, 0, err
 	}

--- a/lnwallet/chanfunding/coin_select_test.go
+++ b/lnwallet/chanfunding/coin_select_test.go
@@ -44,7 +44,7 @@ func fundingFee(feeRate chainfee.SatPerKWeight, numInput int, // nolint:unparam
 
 	// Optionally count a change output.
 	if change {
-		weightEstimate.AddP2WKHOutput()
+		weightEstimate.AddP2TROutput()
 	}
 
 	totalWeight := int64(weightEstimate.Weight())
@@ -81,7 +81,7 @@ func TestCalculateFees(t *testing.T) {
 			},
 
 			expectedFeeNoChange:   487,
-			expectedFeeWithChange: 611,
+			expectedFeeWithChange: 659,
 			expectedErr:           nil,
 		},
 
@@ -97,7 +97,7 @@ func TestCalculateFees(t *testing.T) {
 			},
 
 			expectedFeeNoChange:   579,
-			expectedFeeWithChange: 703,
+			expectedFeeWithChange: 751,
 			expectedErr:           nil,
 		},
 

--- a/lnwallet/chanfunding/wallet_assembler.go
+++ b/lnwallet/chanfunding/wallet_assembler.go
@@ -21,7 +21,7 @@ import (
 //
 // Steps to final channel provisioning:
 //  1. Call BindKeys to notify the intent which keys to use when constructing
-//  the multi-sig output.
+//     the multi-sig output.
 //  2. Call CompileFundingTx afterwards to obtain the funding transaction.
 //
 // If either of these steps fail, then the Cancel method MUST be called.

--- a/lnwallet/test/test_interface.go
+++ b/lnwallet/test/test_interface.go
@@ -2709,6 +2709,14 @@ var walletTests = []walletTestCase{
 		test: testChangeOutputSpendConfirmation,
 	},
 	{
+		// TODO(guggero): this test should remain second until dual
+		// funding can properly exchange full UTXO information and we
+		// can use P2TR change outputs as the funding inputs for a dual
+		// funded channel.
+		name: "dual funder workflow",
+		test: testDualFundingReservationWorkflow,
+	},
+	{
 		name: "spend unconfirmed outputs",
 		test: testSpendUnconfirmed,
 	},
@@ -2743,10 +2751,6 @@ var walletTests = []walletTestCase{
 	{
 		name: "single funding workflow external funding tx",
 		test: testSingleFunderExternalFundingTx,
-	},
-	{
-		name: "dual funder workflow",
-		test: testDualFundingReservationWorkflow,
 	},
 	{
 		name: "output locking",

--- a/lnwallet/wallet.go
+++ b/lnwallet/wallet.go
@@ -775,7 +775,7 @@ func (l *LightningWallet) handleFundingReserveRequest(req *InitFundingReserveMsg
 			FeeRate:      req.FundingFeePerKw,
 			ChangeAddr: func() (btcutil.Address, error) {
 				return l.NewAddress(
-					WitnessPubKey, true, DefaultAccountName,
+					TaprootPubkey, true, DefaultAccountName,
 				)
 			},
 		}

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -1330,7 +1330,7 @@ func (r *rpcServer) SendCoins(ctx context.Context,
 			// ensures this is an address the wallet knows about,
 			// allowing us to pass the reserved value check.
 			changeAddr, err := r.server.cc.Wallet.NewAddress(
-				lnwallet.WitnessPubKey, true,
+				lnwallet.TaprootPubkey, true,
 				lnwallet.DefaultAccountName,
 			)
 			if err != nil {

--- a/server.go
+++ b/server.go
@@ -4534,7 +4534,8 @@ func newSweepPkScriptGen(
 
 	return func() ([]byte, error) {
 		sweepAddr, err := wallet.NewAddress(
-			lnwallet.WitnessPubKey, false, lnwallet.DefaultAccountName,
+			lnwallet.TaprootPubkey, false,
+			lnwallet.DefaultAccountName,
 		)
 		if err != nil {
 			return nil, err

--- a/sweep/tx_input_set.go
+++ b/sweep/tx_input_set.go
@@ -139,7 +139,7 @@ func newTxInputSet(wallet Wallet, feePerKW chainfee.SatPerKWeight,
 func (t *txInputSet) enoughInput() bool {
 	// If we have a change output above dust, then we certainly have enough
 	// inputs to the transaction.
-	if t.changeOutput >= lnwallet.DustLimitForSize(input.P2WPKHSize) {
+	if t.changeOutput >= lnwallet.DustLimitForSize(input.P2TRSize) {
 		return true
 	}
 

--- a/sweep/txgenerator.go
+++ b/sweep/txgenerator.go
@@ -111,8 +111,8 @@ func generateInputPartitionings(sweepableInputs []txInput,
 		// continuing with the remaining inputs will only lead to sets
 		// with an even lower output value.
 		if !txInputs.enoughInput() {
-			// The change output is always a p2wpkh here.
-			dl := lnwallet.DustLimitForSize(input.P2WPKHSize)
+			// The change output is always a p2tr here.
+			dl := lnwallet.DustLimitForSize(input.P2TRSize)
 			log.Debugf("Set value %v (r=%v, c=%v) below dust "+
 				"limit of %v", txInputs.totalOutput(),
 				txInputs.requiredOutput, txInputs.changeOutput,

--- a/watchtower/wtclient/backup_task_internal_test.go
+++ b/watchtower/wtclient/backup_task_internal_test.go
@@ -247,7 +247,7 @@ func genTaskTest(
 			RewardPkScript: rewardScript,
 		},
 		bindErr:        bindErr,
-		expSweepScript: makeAddrSlice(22),
+		expSweepScript: sweepAddr,
 		signer:         signer,
 		chanType:       chanType,
 	}
@@ -259,10 +259,18 @@ var (
 	blobTypeCommitReward = (blob.FlagCommitOutputs | blob.FlagReward).Type()
 
 	addr, _ = btcutil.DecodeAddress(
-		"mrX9vMRYLfVy1BnZbc5gZjuyaqH3ZW2ZHz", &chaincfg.TestNet3Params,
+		"tb1pw8gzj8clt3v5lxykpgacpju5n8xteskt7gxhmudu6pa70nwfhe6s3unsyk",
+		&chaincfg.TestNet3Params,
 	)
 
 	addrScript, _ = txscript.PayToAddrScript(addr)
+
+	sweepAddrScript, _ = btcutil.DecodeAddress(
+		"tb1qs3jyc9sf5kak3x0w99cav9u605aeu3t600xxx0",
+		&chaincfg.TestNet3Params,
+	)
+
+	sweepAddr, _ = txscript.PayToAddrScript(sweepAddrScript)
 )
 
 // TestBackupTaskBind tests the initialization and binding of a backupTask to a
@@ -297,9 +305,9 @@ func TestBackupTask(t *testing.T) {
 			expSweepCommitNoRewardBoth     int64                  = 299241
 			expSweepCommitNoRewardLocal    int64                  = 199514
 			expSweepCommitNoRewardRemote   int64                  = 99561
-			expSweepCommitRewardBoth       int64                  = 296117
-			expSweepCommitRewardLocal      int64                  = 197390
-			expSweepCommitRewardRemote     int64                  = 98437
+			expSweepCommitRewardBoth       int64                  = 296069
+			expSweepCommitRewardLocal      int64                  = 197342
+			expSweepCommitRewardRemote     int64                  = 98389
 			sweepFeeRateNoRewardRemoteDust chainfee.SatPerKWeight = 227500
 			sweepFeeRateRewardRemoteDust   chainfee.SatPerKWeight = 175350
 		)
@@ -307,9 +315,9 @@ func TestBackupTask(t *testing.T) {
 			expSweepCommitNoRewardBoth = 299236
 			expSweepCommitNoRewardLocal = 199513
 			expSweepCommitNoRewardRemote = 99557
-			expSweepCommitRewardBoth = 296112
-			expSweepCommitRewardLocal = 197389
-			expSweepCommitRewardRemote = 98433
+			expSweepCommitRewardBoth = 296064
+			expSweepCommitRewardLocal = 197341
+			expSweepCommitRewardRemote = 98385
 			sweepFeeRateNoRewardRemoteDust = 225400
 			sweepFeeRateRewardRemoteDust = 174100
 		}
@@ -436,7 +444,7 @@ func TestBackupTask(t *testing.T) {
 				"commit reward, to-remote output only, creates dust",
 				1,                            // stateNum
 				0,                            // toLocalAmt
-				100000,                       // toRemoteAmt
+				108221,                       // toRemoteAmt
 				blobTypeCommitReward,         // blobType
 				sweepFeeRateRewardRemoteDust, // sweepFeeRate
 				addrScript,                   // rewardScript

--- a/watchtower/wtclient/client_test.go
+++ b/watchtower/wtclient/client_test.go
@@ -58,7 +58,8 @@ var (
 
 	// addr is the server's reward address given to watchtower clients.
 	addr, _ = btcutil.DecodeAddress(
-		"mrX9vMRYLfVy1BnZbc5gZjuyaqH3ZW2ZHz", &chaincfg.TestNet3Params,
+		"tb1pw8gzj8clt3v5lxykpgacpju5n8xteskt7gxhmudu6pa70nwfhe6s3unsyk",
+		&chaincfg.TestNet3Params,
 	)
 
 	addrScript, _ = txscript.PayToAddrScript(addr)

--- a/watchtower/wtserver/server_test.go
+++ b/watchtower/wtserver/server_test.go
@@ -22,7 +22,8 @@ import (
 var (
 	// addr is the server's reward address given to watchtower clients.
 	addr, _ = btcutil.DecodeAddress(
-		"mrX9vMRYLfVy1BnZbc5gZjuyaqH3ZW2ZHz", &chaincfg.TestNet3Params,
+		"tb1pw8gzj8clt3v5lxykpgacpju5n8xteskt7gxhmudu6pa70nwfhe6s3unsyk",
+		&chaincfg.TestNet3Params,
 	)
 
 	addrScript, _ = txscript.PayToAddrScript(addr)


### PR DESCRIPTION
With this PR, we'll start to use taproot addresses by default when: sweeping all funds from the wallet, funding channels, and sending blobs to watch towers. 

Fixes https://github.com/lightningnetwork/lnd/issues/6666