### PR TITLE
cmd/lncli: add metadata and insecure flags

### DIFF
--- a/cmd/lncli/commands.go
+++ b/cmd/lncli/commands.go
@@ -2052,7 +2052,7 @@ func parseChanPoint(s string) (*lnrpc.ChannelPoint, error) {
 		return nil, errBadChanPoint
 	}
 
-	index, err := strconv.ParseInt(split[1], 10, 32)
+	index, err := strconv.ParseInt(split[1], 10, 64)
 	if err != nil {
 		return nil, fmt.Errorf("unable to decode output index: %v", err)
 	}

--- a/cmd/lncli/profile.go
+++ b/cmd/lncli/profile.go
@@ -33,6 +33,7 @@ type profileEntry struct {
 	TLSCert     string            `json:"tlscert"`
 	Macaroons   *macaroonJar      `json:"macaroons"`
 	Metadata    map[string]string `json:"metadata,omitempty"`
+	Insecure    bool              `json:"insecure,omitempty"`
 }
 
 // cert returns the profile's TLS certificate as a x509 certificate pool.
@@ -122,10 +123,12 @@ func profileFromContext(ctx *cli.Context, store, skipMacaroons bool) (
 		return nil, err
 	}
 
+	insecure := ctx.GlobalBool("insecure")
+
 	// Load the certificate file now, if specified. We store it as plain PEM
 	// directly.
 	var tlsCert []byte
-	if tlsCertPath != "" {
+	if tlsCertPath != "" && !insecure {
 		var err error
 		tlsCert, err = ioutil.ReadFile(tlsCertPath)
 		if err != nil {
@@ -155,6 +158,7 @@ func profileFromContext(ctx *cli.Context, store, skipMacaroons bool) (
 		NoMacaroons: ctx.GlobalBool("no-macaroons"),
 		TLSCert:     string(tlsCert),
 		Metadata:    metadata,
+		Insecure:    insecure,
 	}
 
 	// If we aren't using macaroons in general (flag --no-macaroons) or

--- a/cmd/lncli/profile.go
+++ b/cmd/lncli/profile.go
@@ -24,14 +24,15 @@ var (
 // profileEntry is a struct that represents all settings for one specific
 // profile.
 type profileEntry struct {
-	Name        string       `json:"name"`
-	RPCServer   string       `json:"rpcserver"`
-	LndDir      string       `json:"lnddir"`
-	Chain       string       `json:"chain"`
-	Network     string       `json:"network"`
-	NoMacaroons bool         `json:"no-macaroons,omitempty"` // nolint:tagliatelle
-	TLSCert     string       `json:"tlscert"`
-	Macaroons   *macaroonJar `json:"macaroons"`
+	Name        string            `json:"name"`
+	RPCServer   string            `json:"rpcserver"`
+	LndDir      string            `json:"lnddir"`
+	Chain       string            `json:"chain"`
+	Network     string            `json:"network"`
+	NoMacaroons bool              `json:"no-macaroons,omitempty"` // nolint:tagliatelle
+	TLSCert     string            `json:"tlscert"`
+	Macaroons   *macaroonJar      `json:"macaroons"`
+	Metadata    map[string]string `json:"metadata,omitempty"`
 }
 
 // cert returns the profile's TLS certificate as a x509 certificate pool.
@@ -128,17 +129,32 @@ func profileFromContext(ctx *cli.Context, store, skipMacaroons bool) (
 		var err error
 		tlsCert, err = ioutil.ReadFile(tlsCertPath)
 		if err != nil {
-			return nil, fmt.Errorf("could not load TLS cert file: %v", err)
+			return nil, fmt.Errorf("could not load TLS cert "+
+				"file: %v", err)
 		}
 	}
 
+	metadata := make(map[string]string)
+	for _, m := range ctx.GlobalStringSlice("metadata") {
+		pair := strings.Split(m, ":")
+		if len(pair) != 2 {
+			return nil, fmt.Errorf("invalid format for metadata " +
+				"flag; expected \"key:value\"")
+		}
+
+		metadata[pair[0]] = pair[1]
+	}
+
 	entry := &profileEntry{
-		RPCServer:   ctx.GlobalString("rpcserver"),
-		LndDir:      lncfg.CleanAndExpandPath(ctx.GlobalString("lnddir")),
+		RPCServer: ctx.GlobalString("rpcserver"),
+		LndDir: lncfg.CleanAndExpandPath(
+			ctx.GlobalString("lnddir"),
+		),
 		Chain:       ctx.GlobalString("chain"),
 		Network:     ctx.GlobalString("network"),
 		NoMacaroons: ctx.GlobalBool("no-macaroons"),
 		TLSCert:     string(tlsCert),
+		Metadata:    metadata,
 	}
 
 	// If we aren't using macaroons in general (flag --no-macaroons) or

--- a/docs/release-notes/release-notes-0.16.0.md
+++ b/docs/release-notes/release-notes-0.16.0.md
@@ -20,6 +20,12 @@ transaction](https://github.com/lightningnetwork/lnd/pull/6730).
 * [The macaroon key store implementation was refactored to be more generally
   usable](https://github.com/lightningnetwork/lnd/pull/6509).
 
+## `lncli`
+* [Add an `insecure` flag to skip tls auth as well as a `metadata` string slice
+  flag](https://github.com/lightningnetwork/lnd/pull/6818) that allows the 
+  caller to specify key-value string pairs that should be appended to the 
+  outgoing context.
+
 ## Code Health
 
 ### Tooling and documentation
@@ -31,6 +37,7 @@ transaction](https://github.com/lightningnetwork/lnd/pull/6730).
 
 * Carla Kirk-Cohen
 * Daniel McNally
+* Elle Mouton
 * ErikEk
 * Olaoluwa Osuntokun
 * Oliver Gugger


### PR DESCRIPTION
This PR makes 3 changes (1 per commit):

1. Add a new `metadata` string slice global flag to lncli. This allows the caller to specify key-value string pairs to append to the outgoing grpc call's context. 
2. Add an `insecure` flag to lncli that skips TLS auth when connection to the target rpc server.
3. Change the bitsize used in lncli to parse an output index from 32 to 64 in order to allow for values that would be valid given the types used in lnrpc protos for output index (uint32 and int64).