### PR TITLE
build: bump version to v0.15.99

### DIFF
--- a/build/version.go
+++ b/build/version.go
@@ -44,7 +44,7 @@ const (
 	AppMinor uint = 15
 
 	// AppPatch defines the application patch for this binary.
-	AppPatch uint = 0
+	AppPatch uint = 99
 
 	// AppPreRelease MUST only contain characters from semanticAlphabet
 	// per the semantic versioning spec.


### PR DESCRIPTION
We forgot to do this after 0.15 was tagged, but usually we use a x.99
version to indicate that the commits in master are between releases.
This might also make it easier to help identify exactly which version a
user is running in issue reports.

[skip-ci]

