### PR TITLE
itest: continued itest refactor and fix - II

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -401,7 +401,7 @@ jobs:
             args: backend=neutrino
     steps:
       - name: git checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: go cache
         uses: actions/cache@v1
@@ -415,7 +415,7 @@ jobs:
             lnd-${{ runner.os }}-go-
 
       - name: setup go ${{ env.GO_VERSION }}
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         with:
           go-version: '${{ env.GO_VERSION }}'
 
@@ -449,7 +449,7 @@ jobs:
       GOPATH: ${{ github.workspace }}/go
     steps:
       - name: git checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: go cache
         uses: actions/cache@v1
@@ -463,7 +463,7 @@ jobs:
             lnd-${{ runner.os }}-go-
 
       - name: setup go ${{ env.GO_VERSION }}
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         with:
           go-version: '${{ env.GO_VERSION }}'
 
@@ -472,6 +472,7 @@ jobs:
 
       - name: Zip log files on failure
         if: ${{ failure() }}
+        timeout-minutes: 1 # timeout after 1 minute
         run: 7z a logs-itest-windows.zip lntest/itest/**/*.log
 
       - name: Upload log files on failure

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -78,6 +78,22 @@ linters-settings:
     # so no return split required.
     block-size: 3
 
+  gomnd:
+    # List of numbers to exclude from analysis.
+    # The numbers should be written as string.
+    # Values always ignored: "1", "1.0", "0" and "0.0"
+    # Default: []
+    ignored-numbers:
+      - '0666'
+      - '0755'
+
+    # List of function patterns to exclude from analysis.
+    # Values always ignored: `time.Date`
+    # Default: []
+    ignored-functions:
+      - 'math.*'
+      - 'strconv.ParseInt'
+
 
 linters:
   enable-all: true

--- a/docs/release-notes/release-notes-0.16.0.md
+++ b/docs/release-notes/release-notes-0.16.0.md
@@ -247,8 +247,9 @@ better testing suite for writing integration tests. A new defined structure is
 implemented, please refer to
 [README](https://github.com/lightningnetwork/lnd/tree/master/lntemp) for more
 details. Along the way, several
-PRs([6776](https://github.com/lightningnetwork/lnd/pull/6776)) have been made
-to refactor the itest for code health and maintenance.
+PRs([6776](https://github.com/lightningnetwork/lnd/pull/6776),
+[6822](https://github.com/lightningnetwork/lnd/pull/6822)) have been made to
+refactor the itest for code health and maintenance.
 
 # Contributors (Alphabetical Order)
 

--- a/lntemp/harness.go
+++ b/lntemp/harness.go
@@ -1321,3 +1321,26 @@ func (h *HarnessTest) QueryChannelByChanPoint(hn *node.HarnessNode,
 	require.NoError(h, err, "failed to query channel")
 	return channel
 }
+
+// SendPaymentAndAssertStatus sends a payment from the passed node and asserts
+// the desired status is reached.
+func (h *HarnessTest) SendPaymentAndAssertStatus(hn *node.HarnessNode,
+	req *routerrpc.SendPaymentRequest,
+	status lnrpc.Payment_PaymentStatus) *lnrpc.Payment {
+
+	stream := hn.RPC.SendPayment(req)
+	return h.AssertPaymentStatusFromStream(stream, status)
+}
+
+// SendPaymentAssertFail sends a payment from the passed node and asserts the
+// payment is failed with the specified failure reason .
+func (h *HarnessTest) SendPaymentAssertFail(hn *node.HarnessNode,
+	req *routerrpc.SendPaymentRequest,
+	reason lnrpc.PaymentFailureReason) *lnrpc.Payment {
+
+	payment := h.SendPaymentAndAssertStatus(hn, req, lnrpc.Payment_FAILED)
+	require.Equal(h, reason, payment.FailureReason,
+		"payment failureReason not matched")
+
+	return payment
+}

--- a/lntemp/harness.go
+++ b/lntemp/harness.go
@@ -1259,3 +1259,13 @@ func (h *HarnessTest) MineBlocksAndAssertNumTxes(num uint32,
 
 	return blocks
 }
+
+// QueryChannelByChanPoint tries to find a channel matching the channel point
+// and asserts. It returns the channel found.
+func (h *HarnessTest) QueryChannelByChanPoint(hn *node.HarnessNode,
+	chanPoint *lnrpc.ChannelPoint) *lnrpc.Channel {
+
+	channel, err := h.findChannel(hn, chanPoint)
+	require.NoError(h, err, "failed to query channel")
+	return channel
+}

--- a/lntemp/harness.go
+++ b/lntemp/harness.go
@@ -971,6 +971,22 @@ func (h *HarnessTest) FundCoinsUnconfirmed(amt btcutil.Amount,
 	h.fundCoins(amt, hn, lnrpc.AddressType_WITNESS_PUBKEY_HASH, false)
 }
 
+// FundCoinsNP2WKH attempts to send amt satoshis from the internal mining node
+// to the targeted lightning node using a NP2WKH address.
+func (h *HarnessTest) FundCoinsNP2WKH(amt btcutil.Amount,
+	target *node.HarnessNode) {
+
+	h.fundCoins(amt, target, lnrpc.AddressType_NESTED_PUBKEY_HASH, true)
+}
+
+// FundCoinsP2TR attempts to send amt satoshis from the internal mining node to
+// the targeted lightning node using a P2TR address.
+func (h *HarnessTest) FundCoinsP2TR(amt btcutil.Amount,
+	target *node.HarnessNode) {
+
+	h.fundCoins(amt, target, lnrpc.AddressType_TAPROOT_PUBKEY, true)
+}
+
 // CompletePaymentRequests sends payments from a node to complete all payment
 // requests. This function does not return until all payments successfully
 // complete without errors.

--- a/lntemp/harness_assertion.go
+++ b/lntemp/harness_assertion.go
@@ -1295,3 +1295,37 @@ func (h *HarnessTest) AssertActiveNodesSynced() {
 		h.WaitForBlockchainSync(node)
 	}
 }
+
+// AssertPeerNotConnected asserts that the given node b is not connected to a.
+func (h *HarnessTest) AssertPeerNotConnected(a, b *node.HarnessNode) {
+	err := wait.NoError(func() error {
+		// We require the RPC call to be succeeded and won't wait for
+		// it as it's an unexpected behavior.
+		resp := a.RPC.ListPeers()
+
+		// If node B is seen in the ListPeers response from node A,
+		// then we return false as the connection has been fully
+		// established.
+		for _, peer := range resp.Peers {
+			if peer.PubKey == b.PubKeyStr {
+				return fmt.Errorf("peers %s and %s still "+
+					"connected", a.Name(), b.Name())
+			}
+		}
+
+		return nil
+	}, DefaultTimeout)
+	require.NoError(h, err, "timeout checking peers not connected")
+}
+
+// AssertNotConnected asserts that two peers are not connected.
+func (h *HarnessTest) AssertNotConnected(a, b *node.HarnessNode) {
+	h.AssertPeerNotConnected(a, b)
+	h.AssertPeerNotConnected(b, a)
+}
+
+// AssertConnected asserts that two peers are connected.
+func (h *HarnessTest) AssertConnected(a, b *node.HarnessNode) {
+	h.AssertPeerConnected(a, b)
+	h.AssertPeerConnected(b, a)
+}

--- a/lntemp/harness_assertion.go
+++ b/lntemp/harness_assertion.go
@@ -1479,3 +1479,27 @@ func (h *HarnessTest) AssertZombieChannel(hn *node.HarnessNode, chanID uint64) {
 	}, DefaultTimeout)
 	require.NoError(h, err, "timeout while checking zombie channel")
 }
+
+// AssertTxAtHeight gets all of the transactions that a node's wallet has a
+// record of at the target height, and finds and returns the tx with the target
+// txid, failing if it is not found.
+func (h *HarnessTest) AssertTxAtHeight(hn *node.HarnessNode, height int32,
+	txid *chainhash.Hash) *lnrpc.Transaction {
+
+	req := &lnrpc.GetTransactionsRequest{
+		StartHeight: height,
+		EndHeight:   height,
+	}
+	txns := hn.RPC.GetTransactions(req)
+
+	for _, tx := range txns.Transactions {
+		if tx.TxHash == txid.String() {
+			return tx
+		}
+	}
+
+	require.Failf(h, "fail to find tx", "tx:%v not found at height:%v",
+		txid, height)
+
+	return nil
+}

--- a/lntemp/harness_assertion.go
+++ b/lntemp/harness_assertion.go
@@ -1624,3 +1624,16 @@ func (h *HarnessTest) AssertNumPayments(hn *node.HarnessNode,
 
 	return payments
 }
+
+// AssertNumNodeAnns asserts that a given number of node announcements has been
+// seen in the specified node.
+func (h *HarnessTest) AssertNumNodeAnns(hn *node.HarnessNode,
+	pubkey string, num int) []*lnrpc.NodeUpdate {
+
+	// We will get the current number of channel updates first and add it
+	// to our expected number of newly created channel updates.
+	anns, err := hn.Watcher.WaitForNumNodeUpdates(pubkey, num)
+	require.NoError(h, err, "failed to assert num of channel updates")
+
+	return anns
+}

--- a/lntemp/harness_assertion.go
+++ b/lntemp/harness_assertion.go
@@ -1637,3 +1637,13 @@ func (h *HarnessTest) AssertNumNodeAnns(hn *node.HarnessNode,
 
 	return anns
 }
+
+// AssertNumChannelUpdates asserts that a given number of channel updates has
+// been seen in the specified node's network topology.
+func (h *HarnessTest) AssertNumChannelUpdates(hn *node.HarnessNode,
+	chanPoint *lnrpc.ChannelPoint, num int) {
+
+	op := h.OutPointFromChannelPoint(chanPoint)
+	err := hn.Watcher.WaitForNumChannelUpdates(op, num)
+	require.NoError(h, err, "failed to assert num of channel updates")
+}

--- a/lntemp/harness_assertion.go
+++ b/lntemp/harness_assertion.go
@@ -1606,6 +1606,7 @@ func (h *HarnessTest) AssertNumPayments(hn *node.HarnessNode,
 
 	req := &lnrpc.ListPaymentsRequest{
 		IncludeIncomplete: true,
+		IndexOffset:       hn.State.Payment.LastIndexOffset,
 	}
 
 	var payments []*lnrpc.Payment

--- a/lntemp/harness_miner.go
+++ b/lntemp/harness_miner.go
@@ -376,3 +376,10 @@ func (h *HarnessMiner) GetNumTxsFromMempool(n int) []*wire.MsgTx {
 
 	return txes
 }
+
+// NewMinerAddress creates a new address for the miner and asserts.
+func (h *HarnessMiner) NewMinerAddress() btcutil.Address {
+	addr, err := h.NewAddress()
+	require.NoError(h, err, "failed to create new miner address")
+	return addr
+}

--- a/lntemp/harness_node_manager.go
+++ b/lntemp/harness_node_manager.go
@@ -156,7 +156,7 @@ func (nm *nodeManager) restartNode(ctxt context.Context, node *node.HarnessNode,
 	}
 	if len(chanBackups) != 0 {
 		unlockReq.ChannelBackups = chanBackups[0]
-		unlockReq.RecoveryWindow = 1000
+		unlockReq.RecoveryWindow = 100
 	}
 
 	err = wait.NoError(func() error {

--- a/lntemp/node/config.go
+++ b/lntemp/node/config.go
@@ -166,6 +166,7 @@ func (cfg *BaseNodeConfig) GenArgs() []string {
 		"--debuglevel=debug",
 		"--bitcoin.defaultchanconfs=1",
 		"--accept-keysend",
+		"--keep-failed-payment-attempts",
 		fmt.Sprintf("--db.batch-commit-interval=%v", commitInterval),
 		fmt.Sprintf("--bitcoin.defaultremotedelay=%v",
 			lntest.DefaultCSV),

--- a/lntemp/node/state.go
+++ b/lntemp/node/state.go
@@ -103,20 +103,6 @@ type invoiceCount struct {
 	LastIndexOffset uint64
 }
 
-// balanceCount provides a summary over balances related to channels.
-type balanceCount struct {
-	LocalBalance             *lnrpc.Amount
-	RemoteBalance            *lnrpc.Amount
-	UnsettledLocalBalance    *lnrpc.Amount
-	UnsettledRemoteBalance   *lnrpc.Amount
-	PendingOpenLocalBalance  *lnrpc.Amount
-	PendingOpenRemoteBalance *lnrpc.Amount
-
-	// Deprecated fields.
-	Balance            int64
-	PendingOpenBalance int64
-}
-
 // walletBalance provides a summary over balances related the node's wallet.
 type walletBalance struct {
 	TotalBalance       int64
@@ -138,9 +124,6 @@ type State struct {
 
 	// CloseChannel gives the summary of close channel related counts.
 	CloseChannel closedChannelCount
-
-	// Balance gives the summary of the channel balance.
-	Balance balanceCount
 
 	// Wallet gives the summary of the wallet balance.
 	Wallet walletBalance
@@ -315,18 +298,6 @@ func (s *State) updateEdgeStats() {
 	s.Edge.Public = len(resp.Edges)
 }
 
-// updateChannelBalance creates stats for the node's channel balance.
-func (s *State) updateChannelBalance() {
-	resp := s.rpc.ChannelBalance()
-
-	s.Balance.LocalBalance = resp.LocalBalance
-	s.Balance.RemoteBalance = resp.RemoteBalance
-	s.Balance.UnsettledLocalBalance = resp.UnsettledLocalBalance
-	s.Balance.UnsettledRemoteBalance = resp.UnsettledRemoteBalance
-	s.Balance.PendingOpenLocalBalance = resp.PendingOpenLocalBalance
-	s.Balance.PendingOpenRemoteBalance = resp.PendingOpenRemoteBalance
-}
-
 // updateWalletBalance creates stats for the node's wallet balance.
 func (s *State) updateWalletBalance() {
 	resp := s.rpc.WalletBalance()
@@ -345,7 +316,6 @@ func (s *State) updateState() {
 	s.updateInvoiceStats()
 	s.updateUTXOStats()
 	s.updateEdgeStats()
-	s.updateChannelBalance()
 	s.updateWalletBalance()
 }
 

--- a/lntemp/node/watcher.go
+++ b/lntemp/node/watcher.go
@@ -559,7 +559,7 @@ func (nw *nodeWatcher) handlePolicyUpdateWatchRequest(req *chanWatchRequest) {
 
 	// Check if the latest policy is matched.
 	policy := policies[len(policies)-1]
-	if checkChannelPolicy(policy.RoutingPolicy, req.policy) == nil {
+	if CheckChannelPolicy(policy.RoutingPolicy, req.policy) == nil {
 		close(req.eventChan)
 		return
 	}
@@ -653,8 +653,8 @@ func (nw *nodeWatcher) getChannelPolicies(include bool) policyUpdateMap {
 	return policyUpdates
 }
 
-// checkChannelPolicy checks that the policy matches the expected one.
-func checkChannelPolicy(policy, expectedPolicy *lnrpc.RoutingPolicy) error {
+// CheckChannelPolicy checks that the policy matches the expected one.
+func CheckChannelPolicy(policy, expectedPolicy *lnrpc.RoutingPolicy) error {
 	if policy.FeeBaseMsat != expectedPolicy.FeeBaseMsat {
 		return fmt.Errorf("expected base fee %v, got %v",
 			expectedPolicy.FeeBaseMsat, policy.FeeBaseMsat)

--- a/lntemp/node/watcher.go
+++ b/lntemp/node/watcher.go
@@ -124,10 +124,12 @@ func (nw *nodeWatcher) WaitForNumChannelUpdates(op wire.OutPoint,
 // WaitForNumNodeUpdates will block until a given number of node updates has
 // been seen in the node's network topology.
 func (nw *nodeWatcher) WaitForNumNodeUpdates(pubkey string,
-	expected int) error {
+	expected int) ([]*lnrpc.NodeUpdate, error) {
 
+	updates := make([]*lnrpc.NodeUpdate, 0)
 	checkNumUpdates := func() error {
-		num := len(nw.GetNodeUpdates(pubkey))
+		updates = nw.GetNodeUpdates(pubkey)
+		num := len(updates)
 		if num >= expected {
 			return nil
 		}
@@ -136,7 +138,9 @@ func (nw *nodeWatcher) WaitForNumNodeUpdates(pubkey string,
 			"want %d, got %d", expected, num)
 	}
 
-	return wait.NoError(checkNumUpdates, DefaultTimeout)
+	err := wait.NoError(checkNumUpdates, DefaultTimeout)
+
+	return updates, err
 }
 
 // WaitForChannelOpen will block until a channel with the target outpoint is

--- a/lntemp/rpc/lnd.go
+++ b/lntemp/rpc/lnd.go
@@ -494,3 +494,26 @@ func (h *HarnessRPC) UpdateChannelPolicy(
 
 	return resp
 }
+
+type InvoiceUpdateClient lnrpc.Lightning_SubscribeInvoicesClient
+
+// SubscribeInvoices creates a subscription client for invoice events and
+// asserts its creation.
+//
+// NOTE: make sure to subscribe an invoice as early as possible as it takes
+// some time for the lnd to create the subscription client. If an invoice is
+// added right after the subscription, it may be missed. However, if AddIndex
+// or SettleIndex is used in the request, it will be fine as a backlog will
+// always be sent.
+func (h *HarnessRPC) SubscribeInvoices(
+	req *lnrpc.InvoiceSubscription) InvoiceUpdateClient {
+
+	// SubscribeInvoices needs to have the context alive for the
+	// entire test case as the returned client will be used for send and
+	// receive events stream. Thus we use runCtx here instead of a timeout
+	// context.
+	client, err := h.LN.SubscribeInvoices(h.runCtx, req)
+	require.NoError(h, err, "unable to create invoice subscription client")
+
+	return client
+}

--- a/lntemp/rpc/lnd.go
+++ b/lntemp/rpc/lnd.go
@@ -346,11 +346,17 @@ func (h *HarnessRPC) SendCoinsAssertErr(req *lnrpc.SendCoinsRequest) {
 }
 
 // GetTransactions makes a RPC call to GetTransactions and asserts.
-func (h *HarnessRPC) GetTransactions() *lnrpc.TransactionDetails {
+func (h *HarnessRPC) GetTransactions(
+	req *lnrpc.GetTransactionsRequest) *lnrpc.TransactionDetails {
+
 	ctxt, cancel := context.WithTimeout(h.runCtx, DefaultTimeout)
 	defer cancel()
 
-	resp, err := h.LN.GetTransactions(ctxt, &lnrpc.GetTransactionsRequest{})
+	if req == nil {
+		req = &lnrpc.GetTransactionsRequest{}
+	}
+
+	resp, err := h.LN.GetTransactions(ctxt, req)
 	require.NoErrorf(h, err, "failed to GetTransactions for %s", h.Name)
 
 	return resp

--- a/lntemp/rpc/lnd.go
+++ b/lntemp/rpc/lnd.go
@@ -405,3 +405,30 @@ func (h *HarnessRPC) GetRecoveryInfo(
 
 	return resp
 }
+
+// BatchOpenChannel makes a RPC call to BatchOpenChannel and asserts.
+func (h *HarnessRPC) BatchOpenChannel(
+	req *lnrpc.BatchOpenChannelRequest) *lnrpc.BatchOpenChannelResponse {
+
+	ctxt, cancel := context.WithTimeout(h.runCtx, DefaultTimeout)
+	defer cancel()
+
+	resp, err := h.LN.BatchOpenChannel(ctxt, req)
+	require.NoErrorf(h, err, "failed to batch open channel")
+
+	return resp
+}
+
+// BatchOpenChannelAssertErr makes a RPC call to BatchOpenChannel and asserts
+// there's an error returned.
+func (h *HarnessRPC) BatchOpenChannelAssertErr(
+	req *lnrpc.BatchOpenChannelRequest) error {
+
+	ctxt, cancel := context.WithTimeout(h.runCtx, DefaultTimeout)
+	defer cancel()
+
+	_, err := h.LN.BatchOpenChannel(ctxt, req)
+	require.Error(h, err, "expecte batch open channel fail")
+
+	return err
+}

--- a/lntemp/rpc/lnd.go
+++ b/lntemp/rpc/lnd.go
@@ -365,8 +365,7 @@ func (h *HarnessRPC) SendCoins(
 	defer cancel()
 
 	resp, err := h.LN.SendCoins(ctxt, req)
-	require.NoErrorf(h, err, "node %s failed to send coins to address %s",
-		h.Name, req.Addr)
+	h.NoError(err, "SendCoins")
 
 	return resp
 }
@@ -393,7 +392,7 @@ func (h *HarnessRPC) GetTransactions(
 	}
 
 	resp, err := h.LN.GetTransactions(ctxt, req)
-	require.NoErrorf(h, err, "failed to GetTransactions for %s", h.Name)
+	h.NoError(err, "GetTransactions")
 
 	return resp
 }
@@ -405,7 +404,7 @@ func (h *HarnessRPC) SignMessage(msg []byte) *lnrpc.SignMessageResponse {
 
 	req := &lnrpc.SignMessageRequest{Msg: msg}
 	resp, err := h.LN.SignMessage(ctxt, req)
-	require.NoErrorf(h, err, "SignMessage rpc call failed")
+	h.NoError(err, "SignMessage")
 
 	return resp
 }
@@ -419,7 +418,7 @@ func (h *HarnessRPC) VerifyMessage(msg []byte,
 
 	req := &lnrpc.VerifyMessageRequest{Msg: msg, Signature: sig}
 	resp, err := h.LN.VerifyMessage(ctxt, req)
-	require.NoErrorf(h, err, "VerifyMessage failed")
+	h.NoError(err, "VerifyMessage")
 
 	return resp
 }
@@ -437,7 +436,7 @@ func (h *HarnessRPC) GetRecoveryInfo(
 	}
 
 	resp, err := h.LN.GetRecoveryInfo(ctxt, req)
-	require.NoErrorf(h, err, "failed to GetRecoveryInfo")
+	h.NoError(err, "GetRecoveryInfo")
 
 	return resp
 }
@@ -450,7 +449,7 @@ func (h *HarnessRPC) BatchOpenChannel(
 	defer cancel()
 
 	resp, err := h.LN.BatchOpenChannel(ctxt, req)
-	require.NoErrorf(h, err, "failed to batch open channel")
+	h.NoError(err, "BatchOpenChannel")
 
 	return resp
 }
@@ -477,7 +476,7 @@ func (h *HarnessRPC) QueryRoutes(
 	defer cancel()
 
 	routes, err := h.LN.QueryRoutes(ctxt, req)
-	require.NoErrorf(h, err, "failed to query routes")
+	h.NoError(err, "QueryRoutes")
 
 	return routes
 }
@@ -501,7 +500,7 @@ func (h *HarnessRPC) SendToRouteSync(
 	defer cancel()
 
 	resp, err := h.LN.SendToRouteSync(ctxt, req)
-	require.NoErrorf(h, err, "unable to send to route for %s", h.Name)
+	h.NoError(err, "SendToRouteSync")
 
 	return resp
 }
@@ -514,7 +513,7 @@ func (h *HarnessRPC) UpdateChannelPolicy(
 	defer cancel()
 
 	resp, err := h.LN.UpdateChannelPolicy(ctxt, req)
-	require.NoErrorf(h, err, "failed to update policy")
+	h.NoError(err, "UpdateChannelPolicy")
 
 	return resp
 }
@@ -537,7 +536,7 @@ func (h *HarnessRPC) SubscribeInvoices(
 	// receive events stream. Thus we use runCtx here instead of a timeout
 	// context.
 	client, err := h.LN.SubscribeInvoices(h.runCtx, req)
-	require.NoError(h, err, "unable to create invoice subscription client")
+	h.NoError(err, "SubscribeInvoices")
 
 	return client
 }
@@ -551,7 +550,7 @@ func (h *HarnessRPC) SubscribeChannelBackups() BackupSubscriber {
 	backupStream, err := h.LN.SubscribeChannelBackups(
 		h.runCtx, &lnrpc.ChannelBackupSubscription{},
 	)
-	require.NoErrorf(h, err, "unable to create backup stream")
+	h.NoError(err, "SubscribeChannelBackups")
 
 	return backupStream
 }
@@ -564,7 +563,7 @@ func (h *HarnessRPC) VerifyChanBackup(
 	defer cancel()
 
 	resp, err := h.LN.VerifyChanBackup(ctxt, ss)
-	require.NoErrorf(h, err, "unable to verify backup")
+	h.NoError(err, "VerifyChanBackup")
 
 	return resp
 }

--- a/lntemp/rpc/lnd.go
+++ b/lntemp/rpc/lnd.go
@@ -381,3 +381,21 @@ func (h *HarnessRPC) VerifyMessage(msg []byte,
 
 	return resp
 }
+
+// GetRecoveryInfo uses the specified node to make a RPC call to
+// GetRecoveryInfo and asserts.
+func (h *HarnessRPC) GetRecoveryInfo(
+	req *lnrpc.GetRecoveryInfoRequest) *lnrpc.GetRecoveryInfoResponse {
+
+	ctxt, cancel := context.WithTimeout(h.runCtx, DefaultTimeout)
+	defer cancel()
+
+	if req == nil {
+		req = &lnrpc.GetRecoveryInfoRequest{}
+	}
+
+	resp, err := h.LN.GetRecoveryInfo(ctxt, req)
+	require.NoErrorf(h, err, "failed to GetRecoveryInfo")
+
+	return resp
+}

--- a/lntemp/rpc/lnd.go
+++ b/lntemp/rpc/lnd.go
@@ -355,3 +355,29 @@ func (h *HarnessRPC) GetTransactions() *lnrpc.TransactionDetails {
 
 	return resp
 }
+
+// SignMessage makes a RPC call to node's SignMessage and asserts.
+func (h *HarnessRPC) SignMessage(msg []byte) *lnrpc.SignMessageResponse {
+	ctxt, cancel := context.WithTimeout(h.runCtx, DefaultTimeout)
+	defer cancel()
+
+	req := &lnrpc.SignMessageRequest{Msg: msg}
+	resp, err := h.LN.SignMessage(ctxt, req)
+	require.NoErrorf(h, err, "SignMessage rpc call failed")
+
+	return resp
+}
+
+// VerifyMessage makes a RPC call to node's VerifyMessage and asserts.
+func (h *HarnessRPC) VerifyMessage(msg []byte,
+	sig string) *lnrpc.VerifyMessageResponse {
+
+	ctxt, cancel := context.WithTimeout(h.runCtx, DefaultTimeout)
+	defer cancel()
+
+	req := &lnrpc.VerifyMessageRequest{Msg: msg, Signature: sig}
+	resp, err := h.LN.VerifyMessage(ctxt, req)
+	require.NoErrorf(h, err, "VerifyMessage failed")
+
+	return resp
+}

--- a/lntemp/rpc/lnd.go
+++ b/lntemp/rpc/lnd.go
@@ -319,3 +319,39 @@ func (h *HarnessRPC) ChannelAcceptor() (AcceptorClient, context.CancelFunc) {
 
 	return resp, cancel
 }
+
+// SendCoins sends a given amount of money to the specified address from the
+// passed node.
+func (h *HarnessRPC) SendCoins(
+	req *lnrpc.SendCoinsRequest) *lnrpc.SendCoinsResponse {
+
+	ctxt, cancel := context.WithTimeout(h.runCtx, DefaultTimeout)
+	defer cancel()
+
+	resp, err := h.LN.SendCoins(ctxt, req)
+	require.NoErrorf(h, err, "node %s failed to send coins to address %s",
+		h.Name, req.Addr)
+
+	return resp
+}
+
+// SendCoinsAssertErr sends a given amount of money to the specified address
+// from the passed node and asserts an error has returned.
+func (h *HarnessRPC) SendCoinsAssertErr(req *lnrpc.SendCoinsRequest) {
+	ctxt, cancel := context.WithTimeout(h.runCtx, DefaultTimeout)
+	defer cancel()
+
+	_, err := h.LN.SendCoins(ctxt, req)
+	require.Error(h, err, "node %s didn't not return an error", h.Name)
+}
+
+// GetTransactions makes a RPC call to GetTransactions and asserts.
+func (h *HarnessRPC) GetTransactions() *lnrpc.TransactionDetails {
+	ctxt, cancel := context.WithTimeout(h.runCtx, DefaultTimeout)
+	defer cancel()
+
+	resp, err := h.LN.GetTransactions(ctxt, &lnrpc.GetTransactionsRequest{})
+	require.NoErrorf(h, err, "failed to GetTransactions for %s", h.Name)
+
+	return resp
+}

--- a/lntemp/rpc/lnd.go
+++ b/lntemp/rpc/lnd.go
@@ -98,6 +98,18 @@ func (h *HarnessRPC) ConnectPeer(
 	return resp
 }
 
+// ConnectPeerAssertErr makes a RPC call to ConnectPeer and asserts an error
+// returned.
+func (h *HarnessRPC) ConnectPeerAssertErr(req *lnrpc.ConnectPeerRequest) error {
+	ctxt, cancel := context.WithTimeout(h.runCtx, DefaultTimeout)
+	defer cancel()
+
+	_, err := h.LN.ConnectPeer(ctxt, req)
+	require.Error(h, err, "expected an error from ConnectPeer")
+
+	return err
+}
+
 // ListChannels list the channels for the given node and asserts it's
 // successful.
 func (h *HarnessRPC) ListChannels(

--- a/lntemp/rpc/lnd.go
+++ b/lntemp/rpc/lnd.go
@@ -432,3 +432,53 @@ func (h *HarnessRPC) BatchOpenChannelAssertErr(
 
 	return err
 }
+
+// QueryRoutes makes a RPC call to QueryRoutes and asserts.
+func (h *HarnessRPC) QueryRoutes(
+	req *lnrpc.QueryRoutesRequest) *lnrpc.QueryRoutesResponse {
+
+	ctxt, cancel := context.WithTimeout(h.runCtx, DefaultTimeout)
+	defer cancel()
+
+	routes, err := h.LN.QueryRoutes(ctxt, req)
+	require.NoErrorf(h, err, "failed to query routes")
+
+	return routes
+}
+
+// SendToRoute makes a RPC call to SendToRoute and asserts.
+func (h *HarnessRPC) SendToRoute() lnrpc.Lightning_SendToRouteClient {
+	// SendToRoute needs to have the context alive for the entire test case
+	// as the returned client will be used for send and receive payment
+	// stream. Thus we use runCtx here instead of a timeout context.
+	client, err := h.LN.SendToRoute(h.runCtx)
+	h.NoError(err, "SendToRoute")
+
+	return client
+}
+
+// SendToRouteSync makes a RPC call to SendToRouteSync and asserts.
+func (h *HarnessRPC) SendToRouteSync(
+	req *lnrpc.SendToRouteRequest) *lnrpc.SendResponse {
+
+	ctxt, cancel := context.WithTimeout(h.runCtx, DefaultTimeout)
+	defer cancel()
+
+	resp, err := h.LN.SendToRouteSync(ctxt, req)
+	require.NoErrorf(h, err, "unable to send to route for %s", h.Name)
+
+	return resp
+}
+
+// UpdateChannelPolicy makes a RPC call to UpdateChannelPolicy and asserts.
+func (h *HarnessRPC) UpdateChannelPolicy(
+	req *lnrpc.PolicyUpdateRequest) *lnrpc.PolicyUpdateResponse {
+
+	ctxt, cancel := context.WithTimeout(h.runCtx, DefaultTimeout)
+	defer cancel()
+
+	resp, err := h.LN.UpdateChannelPolicy(ctxt, req)
+	require.NoErrorf(h, err, "failed to update policy")
+
+	return resp
+}

--- a/lntemp/rpc/peers.go
+++ b/lntemp/rpc/peers.go
@@ -1,5 +1,39 @@
 package rpc
 
+import (
+	"context"
+
+	"github.com/lightningnetwork/lnd/lnrpc/peersrpc"
+	"github.com/stretchr/testify/require"
+)
+
 // =====================
 // PeerClient related RPCs.
 // =====================
+
+type (
+	AnnReq  *peersrpc.NodeAnnouncementUpdateRequest
+	AnnResp *peersrpc.NodeAnnouncementUpdateResponse
+)
+
+// UpdateNodeAnnouncement makes an UpdateNodeAnnouncement RPC call the the
+// peersrpc client and asserts.
+func (h *HarnessRPC) UpdateNodeAnnouncement(req AnnReq) AnnResp {
+	ctxt, cancel := context.WithTimeout(h.runCtx, DefaultTimeout)
+	defer cancel()
+
+	resp, err := h.Peer.UpdateNodeAnnouncement(ctxt, req)
+	require.NoErrorf(h, err, "failed to update announcement")
+
+	return resp
+}
+
+// UpdateNodeAnnouncementErr makes an UpdateNodeAnnouncement RPC call the the
+// peersrpc client and asserts an error is returned.
+func (h *HarnessRPC) UpdateNodeAnnouncementErr(req AnnReq) {
+	ctxt, cancel := context.WithTimeout(h.runCtx, DefaultTimeout)
+	defer cancel()
+
+	_, err := h.Peer.UpdateNodeAnnouncement(ctxt, req)
+	require.Error(h, err, "expect an error from update announcement")
+}

--- a/lntemp/rpc/peers.go
+++ b/lntemp/rpc/peers.go
@@ -23,7 +23,7 @@ func (h *HarnessRPC) UpdateNodeAnnouncement(req AnnReq) AnnResp {
 	defer cancel()
 
 	resp, err := h.Peer.UpdateNodeAnnouncement(ctxt, req)
-	require.NoErrorf(h, err, "failed to update announcement")
+	h.NoError(err, "UpdateNodeAnnouncement")
 
 	return resp
 }

--- a/lntemp/rpc/wallet_kit.go
+++ b/lntemp/rpc/wallet_kit.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/lightningnetwork/lnd/lnrpc/signrpc"
 	"github.com/lightningnetwork/lnd/lnrpc/walletrpc"
+	"github.com/stretchr/testify/require"
 )
 
 // =====================
@@ -72,4 +73,28 @@ func (h *HarnessRPC) FinalizePsbt(
 	h.NoError(err, "FinalizePsbt")
 
 	return resp
+}
+
+// LabelTransactionAssertErr makes a RPC call to the node's LabelTransaction
+// and asserts an error is returned. It then returns the error.
+func (h *HarnessRPC) LabelTransactionAssertErr(
+	req *walletrpc.LabelTransactionRequest) error {
+
+	ctxt, cancel := context.WithTimeout(h.runCtx, DefaultTimeout)
+	defer cancel()
+
+	_, err := h.WalletKit.LabelTransaction(ctxt, req)
+	require.Error(h, err, "expected error returned")
+
+	return err
+}
+
+// LabelTransaction makes a RPC call to the node's LabelTransaction
+// and asserts no error is returned.
+func (h *HarnessRPC) LabelTransaction(req *walletrpc.LabelTransactionRequest) {
+	ctxt, cancel := context.WithTimeout(h.runCtx, DefaultTimeout)
+	defer cancel()
+
+	_, err := h.WalletKit.LabelTransaction(ctxt, req)
+	h.NoError(err, "LabelTransaction")
 }

--- a/lntemp/rpc/wallet_kit.go
+++ b/lntemp/rpc/wallet_kit.go
@@ -98,3 +98,29 @@ func (h *HarnessRPC) LabelTransaction(req *walletrpc.LabelTransactionRequest) {
 	_, err := h.WalletKit.LabelTransaction(ctxt, req)
 	h.NoError(err, "LabelTransaction")
 }
+
+// DeriveNextKey makes a RPC call to the DeriveNextKey and asserts.
+func (h *HarnessRPC) DeriveNextKey(
+	req *walletrpc.KeyReq) *signrpc.KeyDescriptor {
+
+	ctxt, cancel := context.WithTimeout(h.runCtx, DefaultTimeout)
+	defer cancel()
+
+	key, err := h.WalletKit.DeriveNextKey(ctxt, req)
+	h.NoError(err, "DeriveNextKey")
+
+	return key
+}
+
+// ListAddresses makes a RPC call to the ListAddresses and asserts.
+func (h *HarnessRPC) ListAddresses(
+	req *walletrpc.ListAddressesRequest) *walletrpc.ListAddressesResponse {
+
+	ctxt, cancel := context.WithTimeout(h.runCtx, DefaultTimeout)
+	defer cancel()
+
+	key, err := h.WalletKit.ListAddresses(ctxt, req)
+	h.NoError(err, "ListAddresses")
+
+	return key
+}

--- a/lntemp/rpc/wallet_kit.go
+++ b/lntemp/rpc/wallet_kit.go
@@ -124,3 +124,28 @@ func (h *HarnessRPC) ListAddresses(
 
 	return key
 }
+
+// ListSweeps makes a ListSweeps RPC call to the node's WalletKit client.
+func (h *HarnessRPC) ListSweeps(verbose bool) *walletrpc.ListSweepsResponse {
+	ctxt, cancel := context.WithTimeout(h.runCtx, DefaultTimeout)
+	defer cancel()
+
+	req := &walletrpc.ListSweepsRequest{Verbose: verbose}
+	resp, err := h.WalletKit.ListSweeps(ctxt, req)
+	h.NoError(err, "ListSweeps")
+
+	return resp
+}
+
+// PendingSweeps makes a RPC call to the node's WalletKitClient and asserts.
+func (h *HarnessRPC) PendingSweeps() *walletrpc.PendingSweepsResponse {
+	ctxt, cancel := context.WithTimeout(h.runCtx, DefaultTimeout)
+	defer cancel()
+
+	req := &walletrpc.PendingSweepsRequest{}
+
+	resp, err := h.WalletKit.PendingSweeps(ctxt, req)
+	h.NoError(err, "PendingSweeps")
+
+	return resp
+}

--- a/lntemp/utils.go
+++ b/lntemp/utils.go
@@ -8,6 +8,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/lightningnetwork/lnd/lnrpc"
 	"github.com/lightningnetwork/lnd/lntest"
 )
 
@@ -91,4 +92,17 @@ func ParseDerivationPath(path string) ([]uint32, error) {
 	}
 
 	return indices, nil
+}
+
+// ChanPointFromPendingUpdate constructs a channel point from a lnrpc pending
+// update.
+func ChanPointFromPendingUpdate(pu *lnrpc.PendingUpdate) *lnrpc.ChannelPoint {
+	chanPoint := &lnrpc.ChannelPoint{
+		FundingTxid: &lnrpc.ChannelPoint_FundingTxidBytes{
+			FundingTxidBytes: pu.Txid,
+		},
+		OutputIndex: pu.OutputIndex,
+	}
+
+	return chanPoint
 }

--- a/lntemp/utils.go
+++ b/lntemp/utils.go
@@ -8,6 +8,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/btcsuite/btcd/wire"
 	"github.com/lightningnetwork/lnd/lnrpc"
 	"github.com/lightningnetwork/lnd/lntest"
 )
@@ -105,4 +106,19 @@ func ChanPointFromPendingUpdate(pu *lnrpc.PendingUpdate) *lnrpc.ChannelPoint {
 	}
 
 	return chanPoint
+}
+
+// channelPointStr returns the string representation of the channel's
+// funding transaction.
+func channelPointStr(chanPoint *lnrpc.ChannelPoint) string {
+	fundingTxID, err := lnrpc.GetChanPointFundingTxid(chanPoint)
+	if err != nil {
+		return ""
+	}
+	cp := wire.OutPoint{
+		Hash:  *fundingTxID,
+		Index: chanPoint.OutputIndex,
+	}
+
+	return cp.String()
 }

--- a/lntest/itest/assertions.go
+++ b/lntest/itest/assertions.go
@@ -1171,28 +1171,6 @@ func assertNodeNumChannels(t *harnessTest, node *lntest.HarnessNode,
 	)
 }
 
-func assertSyncType(t *harnessTest, node *lntest.HarnessNode,
-	peer string, syncType lnrpc.Peer_SyncType) {
-
-	t.t.Helper()
-
-	ctxb := context.Background()
-	ctxt, _ := context.WithTimeout(ctxb, defaultTimeout)
-	resp, err := node.ListPeers(ctxt, &lnrpc.ListPeersRequest{})
-	require.NoError(t.t, err)
-
-	for _, rpcPeer := range resp.Peers {
-		if rpcPeer.PubKey != peer {
-			continue
-		}
-
-		require.Equal(t.t, syncType, rpcPeer.SyncType)
-		return
-	}
-
-	t.t.Fatalf("unable to find peer: %s", peer)
-}
-
 // assertActiveHtlcs makes sure all the passed nodes have the _exact_ HTLCs
 // matching payHashes on _all_ their channels.
 func assertActiveHtlcs(nodes []*lntest.HarnessNode, payHashes ...[]byte) error {

--- a/lntest/itest/assertions.go
+++ b/lntest/itest/assertions.go
@@ -16,7 +16,6 @@ import (
 	"github.com/go-errors/errors"
 	"github.com/lightningnetwork/lnd/channeldb"
 	"github.com/lightningnetwork/lnd/lnrpc"
-	"github.com/lightningnetwork/lnd/lnrpc/peersrpc"
 	"github.com/lightningnetwork/lnd/lnrpc/routerrpc"
 	"github.com/lightningnetwork/lnd/lnrpc/walletrpc"
 	"github.com/lightningnetwork/lnd/lntest"
@@ -1561,30 +1560,6 @@ func assertNodeAnnouncement(t *harnessTest, n1, n2 *lnrpc.NodeUpdate) {
 		if _, ok := addrs[nodeAddr.Addr]; !ok {
 			t.Fatalf("address %v not found in node announcement",
 				nodeAddr.Addr)
-		}
-	}
-}
-
-// assertUpdateNodeAnnouncementResponse is a helper function to assert
-// the response expected values.
-func assertUpdateNodeAnnouncementResponse(t *harnessTest,
-	response *peersrpc.NodeAnnouncementUpdateResponse,
-	expectedOps map[string]int) {
-
-	require.Equal(
-		t.t, len(response.Ops), len(expectedOps),
-		"unexpected number of Ops updating dave's node announcement",
-	)
-
-	ops := make(map[string]int, len(response.Ops))
-	for _, op := range response.Ops {
-		ops[op.Entity] = len(op.Actions)
-	}
-
-	for k, v := range expectedOps {
-		if v != ops[k] {
-			t.Fatalf("unexpected number of actions for operation "+
-				"%s: got %d wanted %d", k, ops[k], v)
 		}
 	}
 }

--- a/lntest/itest/assertions.go
+++ b/lntest/itest/assertions.go
@@ -977,34 +977,6 @@ func assertLastHTLCError(t *harnessTest, node *lntest.HarnessNode,
 	require.Equal(t.t, code, htlc.Failure.Code, "unexpected failure code")
 }
 
-func assertChannelConstraintsEqual(
-	t *harnessTest, want, got *lnrpc.ChannelConstraints) {
-
-	t.t.Helper()
-
-	require.Equal(t.t, want.CsvDelay, got.CsvDelay, "CsvDelay mismatched")
-	require.Equal(
-		t.t, want.ChanReserveSat, got.ChanReserveSat,
-		"ChanReserveSat mismatched",
-	)
-	require.Equal(
-		t.t, want.DustLimitSat, got.DustLimitSat,
-		"DustLimitSat mismatched",
-	)
-	require.Equal(
-		t.t, want.MaxPendingAmtMsat, got.MaxPendingAmtMsat,
-		"MaxPendingAmtMsat mismatched",
-	)
-	require.Equal(
-		t.t, want.MinHtlcMsat, got.MinHtlcMsat,
-		"MinHtlcMsat mismatched",
-	)
-	require.Equal(
-		t.t, want.MaxAcceptedHtlcs, got.MaxAcceptedHtlcs,
-		"MaxAcceptedHtlcs mismatched",
-	)
-}
-
 // assertAmountPaid checks that the ListChannels command of the provided
 // node list the total amount sent and received as expected for the
 // provided channel.

--- a/lntest/itest/list_on_test.go
+++ b/lntest/itest/list_on_test.go
@@ -207,4 +207,8 @@ var allTestCasesTemp = []*lntemp.TestCase{
 		Name:     "channel unsettled balance",
 		TestFunc: testChannelUnsettledBalance,
 	},
+	{
+		Name:     "commitment deadline",
+		TestFunc: testCommitmentTransactionDeadline,
+	},
 }

--- a/lntest/itest/list_on_test.go
+++ b/lntest/itest/list_on_test.go
@@ -99,4 +99,8 @@ var allTestCasesTemp = []*lntemp.TestCase{
 		Name:     "reject onward htlc",
 		TestFunc: testRejectHTLC,
 	},
+	{
+		Name:     "node sign verify",
+		TestFunc: testNodeSignVerify,
+	},
 }

--- a/lntest/itest/list_on_test.go
+++ b/lntest/itest/list_on_test.go
@@ -127,4 +127,8 @@ var allTestCasesTemp = []*lntemp.TestCase{
 		Name:     "unconfirmed channel funding",
 		TestFunc: testUnconfirmedChannelFunding,
 	},
+	{
+		Name:     "funding flow persistence",
+		TestFunc: testChannelFundingPersistence,
+	},
 }

--- a/lntest/itest/list_on_test.go
+++ b/lntest/itest/list_on_test.go
@@ -159,4 +159,8 @@ var allTestCasesTemp = []*lntemp.TestCase{
 		Name:     "reconnect after ip change",
 		TestFunc: testReconnectAfterIPChange,
 	},
+	{
+		Name:     "addpeer config",
+		TestFunc: testAddPeerConfig,
+	},
 }

--- a/lntest/itest/list_on_test.go
+++ b/lntest/itest/list_on_test.go
@@ -175,4 +175,8 @@ var allTestCasesTemp = []*lntemp.TestCase{
 		Name:     "node announcement",
 		TestFunc: testNodeAnnouncement,
 	},
+	{
+		Name:     "update node announcement rpc",
+		TestFunc: testUpdateNodeAnnouncement,
+	},
 }

--- a/lntest/itest/list_on_test.go
+++ b/lntest/itest/list_on_test.go
@@ -191,4 +191,8 @@ var allTestCasesTemp = []*lntemp.TestCase{
 		Name:     "invoice update subscription",
 		TestFunc: testInvoiceSubscriptions,
 	},
+	{
+		Name:     "streaming channel backup update",
+		TestFunc: testChannelBackupUpdates,
+	},
 }

--- a/lntest/itest/list_on_test.go
+++ b/lntest/itest/list_on_test.go
@@ -211,4 +211,8 @@ var allTestCasesTemp = []*lntemp.TestCase{
 		Name:     "commitment deadline",
 		TestFunc: testCommitmentTransactionDeadline,
 	},
+	{
+		Name:     "channel force closure",
+		TestFunc: testChannelForceClosure,
+	},
 }

--- a/lntest/itest/list_on_test.go
+++ b/lntest/itest/list_on_test.go
@@ -131,4 +131,8 @@ var allTestCasesTemp = []*lntemp.TestCase{
 		Name:     "funding flow persistence",
 		TestFunc: testChannelFundingPersistence,
 	},
+	{
+		Name:     "batch channel funding",
+		TestFunc: testBatchChanFunding,
+	},
 }

--- a/lntest/itest/list_on_test.go
+++ b/lntest/itest/list_on_test.go
@@ -79,4 +79,8 @@ var allTestCasesTemp = []*lntemp.TestCase{
 		Name:     "disconnecting target peer",
 		TestFunc: testDisconnectingTargetPeer,
 	},
+	{
+		Name:     "sphinx replay persistence",
+		TestFunc: testSphinxReplayPersistence,
+	},
 }

--- a/lntest/itest/list_on_test.go
+++ b/lntest/itest/list_on_test.go
@@ -215,4 +215,8 @@ var allTestCasesTemp = []*lntemp.TestCase{
 		Name:     "channel force closure",
 		TestFunc: testChannelForceClosure,
 	},
+	{
+		Name:     "failing link",
+		TestFunc: testFailingChannel,
+	},
 }

--- a/lntest/itest/list_on_test.go
+++ b/lntest/itest/list_on_test.go
@@ -71,4 +71,8 @@ var allTestCasesTemp = []*lntemp.TestCase{
 		Name:     "data loss protection",
 		TestFunc: testDataLossProtection,
 	},
+	{
+		Name:     "sweep coins",
+		TestFunc: testSweepAllCoins,
+	},
 }

--- a/lntest/itest/list_on_test.go
+++ b/lntest/itest/list_on_test.go
@@ -103,4 +103,8 @@ var allTestCasesTemp = []*lntemp.TestCase{
 		Name:     "node sign verify",
 		TestFunc: testNodeSignVerify,
 	},
+	{
+		Name:     "list addresses",
+		TestFunc: testListAddresses,
+	},
 }

--- a/lntest/itest/list_on_test.go
+++ b/lntest/itest/list_on_test.go
@@ -119,4 +119,8 @@ var allTestCasesTemp = []*lntemp.TestCase{
 		Name:     "onchain fund recovery",
 		TestFunc: testOnchainFundRecovery,
 	},
+	{
+		Name:     "basic funding flow with all input types",
+		TestFunc: testChannelFundingInputTypes,
+	},
 }

--- a/lntest/itest/list_on_test.go
+++ b/lntest/itest/list_on_test.go
@@ -183,4 +183,8 @@ var allTestCasesTemp = []*lntemp.TestCase{
 		Name:     "list outgoing payments",
 		TestFunc: testListPayments,
 	},
+	{
+		Name:     "immediate payment after channel opened",
+		TestFunc: testPaymentFollowingChannelOpen,
+	},
 }

--- a/lntest/itest/list_on_test.go
+++ b/lntest/itest/list_on_test.go
@@ -115,4 +115,8 @@ var allTestCasesTemp = []*lntemp.TestCase{
 		Name:     "recovery info",
 		TestFunc: testGetRecoveryInfo,
 	},
+	{
+		Name:     "onchain fund recovery",
+		TestFunc: testOnchainFundRecovery,
+	},
 }

--- a/lntest/itest/list_on_test.go
+++ b/lntest/itest/list_on_test.go
@@ -151,4 +151,8 @@ var allTestCasesTemp = []*lntemp.TestCase{
 		Name:     "update channel policy fee rate accuracy",
 		TestFunc: testUpdateChannelPolicyFeeRateAccuracy,
 	},
+	{
+		Name:     "connection timeout",
+		TestFunc: testNetworkConnectionTimeout,
+	},
 }

--- a/lntest/itest/list_on_test.go
+++ b/lntest/itest/list_on_test.go
@@ -187,4 +187,8 @@ var allTestCasesTemp = []*lntemp.TestCase{
 		Name:     "immediate payment after channel opened",
 		TestFunc: testPaymentFollowingChannelOpen,
 	},
+	{
+		Name:     "invoice update subscription",
+		TestFunc: testInvoiceSubscriptions,
+	},
 }

--- a/lntest/itest/list_on_test.go
+++ b/lntest/itest/list_on_test.go
@@ -139,4 +139,8 @@ var allTestCasesTemp = []*lntemp.TestCase{
 		Name:     "update channel policy",
 		TestFunc: testUpdateChannelPolicy,
 	},
+	{
+		Name:     "send update disable channel",
+		TestFunc: testSendUpdateDisableChannel,
+	},
 }

--- a/lntest/itest/list_on_test.go
+++ b/lntest/itest/list_on_test.go
@@ -111,4 +111,8 @@ var allTestCasesTemp = []*lntemp.TestCase{
 		Name:     "abandonchannel",
 		TestFunc: testAbandonChannel,
 	},
+	{
+		Name:     "recovery info",
+		TestFunc: testGetRecoveryInfo,
+	},
 }

--- a/lntest/itest/list_on_test.go
+++ b/lntest/itest/list_on_test.go
@@ -155,4 +155,8 @@ var allTestCasesTemp = []*lntemp.TestCase{
 		Name:     "connection timeout",
 		TestFunc: testNetworkConnectionTimeout,
 	},
+	{
+		Name:     "reconnect after ip change",
+		TestFunc: testReconnectAfterIPChange,
+	},
 }

--- a/lntest/itest/list_on_test.go
+++ b/lntest/itest/list_on_test.go
@@ -91,4 +91,8 @@ var allTestCasesTemp = []*lntemp.TestCase{
 		Name:     "max pending channel",
 		TestFunc: testMaxPendingChannels,
 	},
+	{
+		Name:     "garbage collect link nodes",
+		TestFunc: testGarbageCollectLinkNodes,
+	},
 }

--- a/lntest/itest/list_on_test.go
+++ b/lntest/itest/list_on_test.go
@@ -95,4 +95,8 @@ var allTestCasesTemp = []*lntemp.TestCase{
 		Name:     "garbage collect link nodes",
 		TestFunc: testGarbageCollectLinkNodes,
 	},
+	{
+		Name:     "reject onward htlc",
+		TestFunc: testRejectHTLC,
+	},
 }

--- a/lntest/itest/list_on_test.go
+++ b/lntest/itest/list_on_test.go
@@ -163,4 +163,8 @@ var allTestCasesTemp = []*lntemp.TestCase{
 		Name:     "addpeer config",
 		TestFunc: testAddPeerConfig,
 	},
+	{
+		Name:     "unannounced channels",
+		TestFunc: testUnannouncedChannels,
+	},
 }

--- a/lntest/itest/list_on_test.go
+++ b/lntest/itest/list_on_test.go
@@ -107,4 +107,8 @@ var allTestCasesTemp = []*lntemp.TestCase{
 		Name:     "list addresses",
 		TestFunc: testListAddresses,
 	},
+	{
+		Name:     "abandonchannel",
+		TestFunc: testAbandonChannel,
+	},
 }

--- a/lntest/itest/list_on_test.go
+++ b/lntest/itest/list_on_test.go
@@ -147,4 +147,8 @@ var allTestCasesTemp = []*lntemp.TestCase{
 		Name:     "private channel update policy",
 		TestFunc: testUpdateChannelPolicyForPrivateChannel,
 	},
+	{
+		Name:     "update channel policy fee rate accuracy",
+		TestFunc: testUpdateChannelPolicyFeeRateAccuracy,
+	},
 }

--- a/lntest/itest/list_on_test.go
+++ b/lntest/itest/list_on_test.go
@@ -195,4 +195,8 @@ var allTestCasesTemp = []*lntemp.TestCase{
 		Name:     "streaming channel backup update",
 		TestFunc: testChannelBackupUpdates,
 	},
+	{
+		Name:     "export channel backup",
+		TestFunc: testExportChannelBackup,
+	},
 }

--- a/lntest/itest/list_on_test.go
+++ b/lntest/itest/list_on_test.go
@@ -179,4 +179,8 @@ var allTestCasesTemp = []*lntemp.TestCase{
 		Name:     "update node announcement rpc",
 		TestFunc: testUpdateNodeAnnouncement,
 	},
+	{
+		Name:     "list outgoing payments",
+		TestFunc: testListPayments,
+	},
 }

--- a/lntest/itest/list_on_test.go
+++ b/lntest/itest/list_on_test.go
@@ -203,4 +203,8 @@ var allTestCasesTemp = []*lntemp.TestCase{
 		Name:     "channel balance",
 		TestFunc: testChannelBalance,
 	},
+	{
+		Name:     "channel unsettled balance",
+		TestFunc: testChannelUnsettledBalance,
+	},
 }

--- a/lntest/itest/list_on_test.go
+++ b/lntest/itest/list_on_test.go
@@ -83,4 +83,8 @@ var allTestCasesTemp = []*lntemp.TestCase{
 		Name:     "sphinx replay persistence",
 		TestFunc: testSphinxReplayPersistence,
 	},
+	{
+		Name:     "list channels",
+		TestFunc: testListChannels,
+	},
 }

--- a/lntest/itest/list_on_test.go
+++ b/lntest/itest/list_on_test.go
@@ -171,4 +171,8 @@ var allTestCasesTemp = []*lntemp.TestCase{
 		Name:     "graph topology notifications",
 		TestFunc: testGraphTopologyNotifications,
 	},
+	{
+		Name:     "node announcement",
+		TestFunc: testNodeAnnouncement,
+	},
 }

--- a/lntest/itest/list_on_test.go
+++ b/lntest/itest/list_on_test.go
@@ -199,4 +199,8 @@ var allTestCasesTemp = []*lntemp.TestCase{
 		Name:     "export channel backup",
 		TestFunc: testExportChannelBackup,
 	},
+	{
+		Name:     "channel balance",
+		TestFunc: testChannelBalance,
+	},
 }

--- a/lntest/itest/list_on_test.go
+++ b/lntest/itest/list_on_test.go
@@ -167,4 +167,8 @@ var allTestCasesTemp = []*lntemp.TestCase{
 		Name:     "unannounced channels",
 		TestFunc: testUnannouncedChannels,
 	},
+	{
+		Name:     "graph topology notifications",
+		TestFunc: testGraphTopologyNotifications,
+	},
 }

--- a/lntest/itest/list_on_test.go
+++ b/lntest/itest/list_on_test.go
@@ -123,4 +123,8 @@ var allTestCasesTemp = []*lntemp.TestCase{
 		Name:     "basic funding flow with all input types",
 		TestFunc: testChannelFundingInputTypes,
 	},
+	{
+		Name:     "unconfirmed channel funding",
+		TestFunc: testUnconfirmedChannelFunding,
+	},
 }

--- a/lntest/itest/list_on_test.go
+++ b/lntest/itest/list_on_test.go
@@ -143,4 +143,8 @@ var allTestCasesTemp = []*lntemp.TestCase{
 		Name:     "send update disable channel",
 		TestFunc: testSendUpdateDisableChannel,
 	},
+	{
+		Name:     "private channel update policy",
+		TestFunc: testUpdateChannelPolicyForPrivateChannel,
+	},
 }

--- a/lntest/itest/list_on_test.go
+++ b/lntest/itest/list_on_test.go
@@ -87,4 +87,8 @@ var allTestCasesTemp = []*lntemp.TestCase{
 		Name:     "list channels",
 		TestFunc: testListChannels,
 	},
+	{
+		Name:     "max pending channel",
+		TestFunc: testMaxPendingChannels,
+	},
 }

--- a/lntest/itest/list_on_test.go
+++ b/lntest/itest/list_on_test.go
@@ -135,4 +135,8 @@ var allTestCasesTemp = []*lntemp.TestCase{
 		Name:     "batch channel funding",
 		TestFunc: testBatchChanFunding,
 	},
+	{
+		Name:     "update channel policy",
+		TestFunc: testUpdateChannelPolicy,
+	},
 }

--- a/lntest/itest/list_on_test.go
+++ b/lntest/itest/list_on_test.go
@@ -75,4 +75,8 @@ var allTestCasesTemp = []*lntemp.TestCase{
 		Name:     "sweep coins",
 		TestFunc: testSweepAllCoins,
 	},
+	{
+		Name:     "disconnecting target peer",
+		TestFunc: testDisconnectingTargetPeer,
+	},
 }

--- a/lntest/itest/lnd_channel_force_close_test.go
+++ b/lntest/itest/lnd_channel_force_close_test.go
@@ -554,8 +554,8 @@ func channelForceClosureTest(ht *lntemp.HarnessTest,
 	// the commitment transaction which was broadcast on-chain.
 	sweepTx := ht.Miner.GetRawTransaction(sweepingTXID)
 	for _, txIn := range sweepTx.MsgTx().TxIn {
-		require.Equal(ht, &txIn.PreviousOutPoint.Hash,
-			closingTxID, "sweep transaction not spending from commit")
+		require.Equal(ht, &txIn.PreviousOutPoint.Hash, closingTxID,
+			"sweep transaction not spending from commit")
 	}
 
 	// We expect a resolution which spends our commit output.

--- a/lntest/itest/lnd_channel_force_close_test.go
+++ b/lntest/itest/lnd_channel_force_close_test.go
@@ -14,6 +14,8 @@ import (
 	"github.com/lightningnetwork/lnd/chainreg"
 	"github.com/lightningnetwork/lnd/lnrpc"
 	"github.com/lightningnetwork/lnd/lnrpc/routerrpc"
+	"github.com/lightningnetwork/lnd/lntemp"
+	"github.com/lightningnetwork/lnd/lntemp/node"
 	"github.com/lightningnetwork/lnd/lntest"
 	"github.com/lightningnetwork/lnd/lntest/wait"
 	"github.com/lightningnetwork/lnd/lnwallet"
@@ -30,9 +32,7 @@ import (
 //
 // Note that whether the deadline is used or not is implicitly checked by its
 // corresponding fee rates.
-func testCommitmentTransactionDeadline(net *lntest.NetworkHarness,
-	t *harnessTest) {
-
+func testCommitmentTransactionDeadline(ht *lntemp.HarnessTest) {
 	// Get the default max fee rate used in sweeping the commitment
 	// transaction.
 	defaultMax := lnwallet.DefaultAnchorsCommitMaxFeeRateSatPerVByte
@@ -65,27 +65,27 @@ func testCommitmentTransactionDeadline(net *lntest.NetworkHarness,
 	// transaction to CPFP our commitment transaction.
 	feeRateLarge := maxPerKw * 2
 
-	ctxb := context.Background()
-
 	// Before we start, set up the default fee rate and we will test the
 	// actual fee rate against it to decide whether we are using the
 	// deadline to perform fee estimation.
-	net.SetFeeEstimate(feeRateDefault)
+	ht.SetFeeEstimate(feeRateDefault)
 
 	// setupNode creates a new node and sends 1 btc to the node.
-	setupNode := func(name string) *lntest.HarnessNode {
+	setupNode := func(name string) *node.HarnessNode {
 		// Create the node.
 		args := []string{"--hodl.exit-settle"}
-		args = append(args, nodeArgsForCommitType(lnrpc.CommitmentType_ANCHORS)...)
-		node := net.NewNode(t.t, name, args)
+		args = append(args, nodeArgsForCommitType(
+			lnrpc.CommitmentType_ANCHORS)...,
+		)
+		node := ht.NewNode(name, args)
 
 		// Send some coins to the node.
-		net.SendCoins(t.t, btcutil.SatoshiPerBitcoin, node)
+		ht.FundCoins(btcutil.SatoshiPerBitcoin, node)
 
 		// For neutrino backend, we need one additional UTXO to create
 		// the sweeping tx for the remote anchor.
-		if net.BackendCfg.Name() == lntest.NeutrinoBackendName {
-			net.SendCoins(t.t, btcutil.SatoshiPerBitcoin, node)
+		if ht.IsNeutrinoBackend() {
+			ht.FundCoins(btcutil.SatoshiPerBitcoin, node)
 		}
 
 		return node
@@ -96,17 +96,17 @@ func testCommitmentTransactionDeadline(net *lntest.NetworkHarness,
 	calculateSweepFeeRate := func(expectedSweepTxNum int) int64 {
 		// Create two nodes, Alice and Bob.
 		alice := setupNode("Alice")
-		defer shutdownAndAssert(net, t, alice)
+		defer ht.Shutdown(alice)
 
 		bob := setupNode("Bob")
-		defer shutdownAndAssert(net, t, bob)
+		defer ht.Shutdown(bob)
 
 		// Connect Alice to Bob.
-		net.ConnectNodes(t.t, alice, bob)
+		ht.ConnectNodes(alice, bob)
 
 		// Open a channel between Alice and Bob.
-		chanPoint := openChannelAndAssert(
-			t, net, alice, bob, lntest.OpenChannelParams{
+		chanPoint := ht.OpenChannel(
+			alice, bob, lntemp.OpenChannelParams{
 				Amt:     10e6,
 				PushAmt: 5e6,
 			},
@@ -115,64 +115,38 @@ func testCommitmentTransactionDeadline(net *lntest.NetworkHarness,
 		// Send a payment with a specified finalCTLVDelta, which will
 		// be used as our deadline later on when Alice force closes the
 		// channel.
-		ctxt, cancel := context.WithTimeout(ctxb, defaultTimeout)
-		defer cancel()
-		_, err := alice.RouterClient.SendPaymentV2(
-			ctxt, &routerrpc.SendPaymentRequest{
-				Dest:           bob.PubKey[:],
-				Amt:            10e4,
-				PaymentHash:    makeFakePayHash(t),
-				FinalCltvDelta: finalCTLV,
-				TimeoutSeconds: 60,
-				FeeLimitMsat:   noFeeLimitMsat,
-			},
-		)
-		require.NoError(t.t, err, "unable to send alice htlc")
+		req := &routerrpc.SendPaymentRequest{
+			Dest:           bob.PubKey[:],
+			Amt:            10e4,
+			PaymentHash:    ht.Random32Bytes(),
+			FinalCltvDelta: finalCTLV,
+			TimeoutSeconds: 60,
+			FeeLimitMsat:   noFeeLimitMsat,
+		}
+		alice.RPC.SendPayment(req)
 
 		// Once the HTLC has cleared, all the nodes in our mini network
 		// should show that the HTLC has been locked in.
-		nodes := []*lntest.HarnessNode{alice, bob}
-		err = wait.NoError(func() error {
-			return assertNumActiveHtlcs(nodes, 1)
-		}, defaultTimeout)
-		require.NoError(t.t, err, "htlc mismatch")
+		ht.AssertNumActiveHtlcs(alice, 1)
+		ht.AssertNumActiveHtlcs(bob, 1)
 
 		// Alice force closes the channel.
-		_, _, err = net.CloseChannel(alice, chanPoint, true)
-		require.NoError(t.t, err, "unable to force close channel")
+		ht.CloseChannelAssertPending(alice, chanPoint, true)
 
 		// Now that the channel has been force closed, it should show
 		// up in the PendingChannels RPC under the waiting close
 		// section.
-		ctxt, cancel = context.WithTimeout(ctxb, defaultTimeout)
-		defer cancel()
-		pendingChansRequest := &lnrpc.PendingChannelsRequest{}
-		pendingChanResp, err := alice.PendingChannels(
-			ctxt, pendingChansRequest,
-		)
-		require.NoError(
-			t.t, err, "unable to query for pending channels",
-		)
-		require.NoError(
-			t.t, checkNumWaitingCloseChannels(pendingChanResp, 1),
-		)
+		ht.AssertChannelWaitingClose(alice, chanPoint)
 
 		// Check our sweep transactions can be found in mempool.
-		sweepTxns, err := getNTxsFromMempool(
-			net.Miner.Client,
-			expectedSweepTxNum, minerMempoolTimeout,
-		)
-		require.NoError(
-			t.t, err, "failed to find commitment tx in mempool",
-		)
+		sweepTxns := ht.Miner.GetNumTxsFromMempool(expectedSweepTxNum)
 
 		// Mine a block to confirm these transactions such that they
 		// don't remain in the mempool for any subsequent tests.
-		_, err = net.Miner.Client.Generate(1)
-		require.NoError(t.t, err, "unable to mine blocks")
+		ht.MineBlocks(1)
 
 		// Calculate the fee rate used.
-		feeRate := calculateTxnsFeeRate(t.t, net.Miner, sweepTxns)
+		feeRate := ht.CalculateTxesFeeRate(sweepTxns)
 
 		return feeRate
 	}
@@ -180,7 +154,7 @@ func testCommitmentTransactionDeadline(net *lntest.NetworkHarness,
 	// Setup our fee estimation for the deadline. Because the fee rate is
 	// smaller than the parent tx's fee rate, this value won't be used and
 	// we should see only one sweep tx in the mempool.
-	net.SetFeeEstimateWithConf(feeRateSmall, deadline)
+	ht.SetFeeEstimateWithConf(feeRateSmall, deadline)
 
 	// Calculate fee rate used.
 	feeRate := calculateSweepFeeRate(1)
@@ -188,7 +162,7 @@ func testCommitmentTransactionDeadline(net *lntest.NetworkHarness,
 	// We expect the default max fee rate is used. Allow some deviation
 	// because weight estimates during tx generation are estimates.
 	require.InEpsilonf(
-		t.t, int64(maxPerKw), feeRate, 0.01,
+		ht, int64(maxPerKw), feeRate, 0.01,
 		"expected fee rate:%d, got fee rate:%d", maxPerKw, feeRate,
 	)
 
@@ -196,7 +170,7 @@ func testCommitmentTransactionDeadline(net *lntest.NetworkHarness,
 	// greater than the parent tx's fee rate, this value will be used to
 	// sweep the anchor transaction and we should see two sweep
 	// transactions in the mempool.
-	net.SetFeeEstimateWithConf(feeRateLarge, deadline)
+	ht.SetFeeEstimateWithConf(feeRateLarge, deadline)
 
 	// Calculate fee rate used.
 	feeRate = calculateSweepFeeRate(2)
@@ -204,29 +178,9 @@ func testCommitmentTransactionDeadline(net *lntest.NetworkHarness,
 	// We expect the anchor to be swept with the deadline, which has the
 	// fee rate of feeRateLarge.
 	require.InEpsilonf(
-		t.t, int64(feeRateLarge), feeRate, 0.01,
+		ht, int64(feeRateLarge), feeRate, 0.01,
 		"expected fee rate:%d, got fee rate:%d", feeRateLarge, feeRate,
 	)
-}
-
-// calculateTxnsFeeRate takes a list of transactions and estimates the fee rate
-// used to sweep them.
-func calculateTxnsFeeRate(t *testing.T,
-	miner *lntest.HarnessMiner, txns []*wire.MsgTx) int64 {
-
-	var totalWeight, totalFee int64
-	for _, tx := range txns {
-		utx := btcutil.NewTx(tx)
-		totalWeight += blockchain.GetTransactionWeight(utx)
-
-		fee, err := getTxFee(miner.Client, tx)
-		require.NoError(t, err)
-
-		totalFee += int64(fee)
-	}
-	feeRate := totalFee * 1000 / totalWeight
-
-	return feeRate
 }
 
 // testChannelForceClosure performs a test to exercise the behavior of "force"

--- a/lntest/itest/lnd_channel_force_close_test.go
+++ b/lntest/itest/lnd_channel_force_close_test.go
@@ -2,7 +2,6 @@ package itest
 
 import (
 	"bytes"
-	"context"
 	"fmt"
 	"testing"
 
@@ -1036,31 +1035,23 @@ func findCommitAndAnchor(t *harnessTest, net *lntest.NetworkHarness,
 	return commitSweep, anchorSweep
 }
 
-// testFailingChannel tests that we will fail the channel by force closing ii
+// testFailingChannel tests that we will fail the channel by force closing it
 // in the case where a counterparty tries to settle an HTLC with the wrong
 // preimage.
-func testFailingChannel(net *lntest.NetworkHarness, t *harnessTest) {
-	ctxb := context.Background()
-
-	const (
-		paymentAmt = 10000
-	)
+func testFailingChannel(ht *lntemp.HarnessTest) {
+	const paymentAmt = 10000
 
 	chanAmt := lnd.MaxFundingAmount
 
 	// We'll introduce Carol, which will settle any incoming invoice with a
 	// totally unrelated preimage.
-	carol := net.NewNode(t.t, "Carol", []string{"--hodl.bogus-settle"})
-	defer shutdownAndAssert(net, t, carol)
+	carol := ht.NewNode("Carol", []string{"--hodl.bogus-settle"})
+
+	alice := ht.Alice
+	ht.ConnectNodes(alice, carol)
 
 	// Let Alice connect and open a channel to Carol,
-	net.ConnectNodes(t.t, net.Alice, carol)
-	chanPoint := openChannelAndAssert(
-		t, net, net.Alice, carol,
-		lntest.OpenChannelParams{
-			Amt: chanAmt,
-		},
-	)
+	ht.OpenChannel(alice, carol, lntemp.OpenChannelParams{Amt: chanAmt})
 
 	// With the channel open, we'll create a invoice for Carol that Alice
 	// will attempt to pay.
@@ -1070,159 +1061,49 @@ func testFailingChannel(net *lntest.NetworkHarness, t *harnessTest) {
 		RPreimage: preimage,
 		Value:     paymentAmt,
 	}
-	ctxt, _ := context.WithTimeout(ctxb, defaultTimeout)
-	resp, err := carol.AddInvoice(ctxt, invoice)
-	if err != nil {
-		t.Fatalf("unable to add invoice: %v", err)
-	}
-	carolPayReqs := []string{resp.PaymentRequest}
-
-	// Wait for Alice to receive the channel edge from the funding manager.
-	err = net.Alice.WaitForNetworkChannelOpen(chanPoint)
-	if err != nil {
-		t.Fatalf("alice didn't see the alice->carol channel before "+
-			"timeout: %v", err)
-	}
+	resp := carol.RPC.AddInvoice(invoice)
 
 	// Send the payment from Alice to Carol. We expect Carol to attempt to
 	// settle this payment with the wrong preimage.
-	err = completePaymentRequests(
-		net.Alice, net.Alice.RouterClient, carolPayReqs, false,
-	)
-	if err != nil {
-		t.Fatalf("unable to send payments: %v", err)
+	//
+	// NOTE: cannot use `CompletePaymentRequestsNoWait` here as the channel
+	// will be force closed, so the num of updates check in that function
+	// won't work as the channel cannot be found.
+	req := &routerrpc.SendPaymentRequest{
+		PaymentRequest: resp.PaymentRequest,
+		TimeoutSeconds: 60,
+		FeeLimitMsat:   noFeeLimitMsat,
 	}
+	ht.SendPaymentAndAssertStatus(alice, req, lnrpc.Payment_IN_FLIGHT)
 
 	// Since Alice detects that Carol is trying to trick her by providing a
 	// fake preimage, she should fail and force close the channel.
-	var predErr error
-	err = wait.Predicate(func() bool {
-		pendingChansRequest := &lnrpc.PendingChannelsRequest{}
-		ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
-		pendingChanResp, err := net.Alice.PendingChannels(ctxt,
-			pendingChansRequest)
-		if err != nil {
-			predErr = fmt.Errorf("unable to query for pending "+
-				"channels: %v", err)
-			return false
-		}
-		n := len(pendingChanResp.WaitingCloseChannels)
-		if n != 1 {
-			predErr = fmt.Errorf("expected to find %d channels "+
-				"waiting close, found %d", 1, n)
-			return false
-		}
-		return true
-	}, defaultTimeout)
-	if err != nil {
-		t.Fatalf("%v", predErr)
-	}
+	ht.AssertNumWaitingClose(alice, 1)
 
 	// Mine a block to confirm the broadcasted commitment.
-	block := mineBlocks(t, net, 1, 1)[0]
-	if len(block.Transactions) != 2 {
-		t.Fatalf("transaction wasn't mined")
-	}
+	block := ht.MineBlocksAndAssertNumTxes(1, 1)[0]
+	require.Len(ht, block.Transactions, 2, "transaction wasn't mined")
 
 	// The channel should now show up as force closed both for Alice and
 	// Carol.
-	err = wait.Predicate(func() bool {
-		pendingChansRequest := &lnrpc.PendingChannelsRequest{}
-		ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
-		pendingChanResp, err := net.Alice.PendingChannels(ctxt,
-			pendingChansRequest)
-		if err != nil {
-			predErr = fmt.Errorf("unable to query for pending "+
-				"channels: %v", err)
-			return false
-		}
-		n := len(pendingChanResp.WaitingCloseChannels)
-		if n != 0 {
-			predErr = fmt.Errorf("expected to find %d channels "+
-				"waiting close, found %d", 0, n)
-			return false
-		}
-		n = len(pendingChanResp.PendingForceClosingChannels)
-		if n != 1 {
-			predErr = fmt.Errorf("expected to find %d channel "+
-				"pending force close, found %d", 1, n)
-			return false
-		}
-		return true
-	}, defaultTimeout)
-	if err != nil {
-		t.Fatalf("%v", predErr)
-	}
-
-	err = wait.Predicate(func() bool {
-		pendingChansRequest := &lnrpc.PendingChannelsRequest{}
-		ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
-		pendingChanResp, err := carol.PendingChannels(ctxt,
-			pendingChansRequest)
-		if err != nil {
-			predErr = fmt.Errorf("unable to query for pending "+
-				"channels: %v", err)
-			return false
-		}
-		n := len(pendingChanResp.PendingForceClosingChannels)
-		if n != 1 {
-			predErr = fmt.Errorf("expected to find %d channel "+
-				"pending force close, found %d", 1, n)
-			return false
-		}
-		return true
-	}, defaultTimeout)
-	if err != nil {
-		t.Fatalf("%v", predErr)
-	}
+	ht.AssertNumPendingForceClose(alice, 1)
+	ht.AssertNumPendingForceClose(carol, 1)
 
 	// Carol will use the correct preimage to resolve the HTLC on-chain.
-	_, err = waitForTxInMempool(net.Miner.Client, minerMempoolTimeout)
-	if err != nil {
-		t.Fatalf("unable to find Carol's resolve tx in mempool: %v", err)
-	}
+	ht.Miner.AssertNumTxsInMempool(1)
 
 	// Mine enough blocks for Alice to sweep her funds from the force
 	// closed channel.
-	_, err = net.Miner.Client.Generate(defaultCSV - 1)
-	if err != nil {
-		t.Fatalf("unable to generate blocks: %v", err)
-	}
+	ht.MineBlocks(defaultCSV - 1)
 
 	// Wait for the sweeping tx to be broadcast.
-	_, err = waitForTxInMempool(net.Miner.Client, minerMempoolTimeout)
-	if err != nil {
-		t.Fatalf("unable to find Alice's sweep tx in mempool: %v", err)
-	}
+	ht.Miner.AssertNumTxsInMempool(1)
 
 	// Mine the sweep.
-	_, err = net.Miner.Client.Generate(1)
-	if err != nil {
-		t.Fatalf("unable to generate blocks: %v", err)
-	}
+	ht.MineBlocks(1)
 
 	// No pending channels should be left.
-	err = wait.Predicate(func() bool {
-		pendingChansRequest := &lnrpc.PendingChannelsRequest{}
-		ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
-		pendingChanResp, err := net.Alice.PendingChannels(ctxt,
-			pendingChansRequest)
-		if err != nil {
-			predErr = fmt.Errorf("unable to query for pending "+
-				"channels: %v", err)
-			return false
-		}
-		n := len(pendingChanResp.PendingForceClosingChannels)
-		if n != 0 {
-			predErr = fmt.Errorf("expected to find %d channel "+
-				"pending force close, found %d", 0, n)
-			return false
-		}
-		return true
-	}, defaultTimeout)
-	if err != nil {
-		t.Fatalf("%v", predErr)
-	}
+	ht.AssertNumPendingForceClose(alice, 0)
 }
 
 // assertReports checks that the count of resolutions we have present per

--- a/lntest/itest/lnd_channel_policy_test.go
+++ b/lntest/itest/lnd_channel_policy_test.go
@@ -2,6 +2,7 @@ package itest
 
 import (
 	"context"
+	"fmt"
 	"math"
 	"time"
 
@@ -435,71 +436,92 @@ func testUpdateChannelPolicy(ht *lntemp.HarnessTest) {
 // testSendUpdateDisableChannel ensures that a channel update with the disable
 // flag set is sent once a channel has been either unilaterally or cooperatively
 // closed.
-func testSendUpdateDisableChannel(net *lntest.NetworkHarness, t *harnessTest) {
-	const (
-		chanAmt = 100000
-	)
+//
+// NOTE: this test can be flaky as we are testing the chan-enable-timeout and
+// chan-disable-timeout flags here. For instance, if some operations take more
+// than 6 seconds to finish, the channel will be marked as disabled, thus a
+// following operation will fail if it relies on the channel being enabled.
+func testSendUpdateDisableChannel(ht *lntemp.HarnessTest) {
+	const chanAmt = 100000
 
-	// Open a channel between Alice and Bob and Alice and Carol. These will
-	// be closed later on in order to trigger channel update messages
-	// marking the channels as disabled.
-	chanPointAliceBob := openChannelAndAssert(
-		t, net, net.Alice, net.Bob,
-		lntest.OpenChannelParams{
-			Amt: chanAmt,
-		},
-	)
+	alice, bob := ht.Alice, ht.Bob
 
-	carol := net.NewNode(
-		t.t, "Carol", []string{
-			"--minbackoff=10s",
-			"--chan-enable-timeout=1.5s",
-			"--chan-disable-timeout=3s",
-			"--chan-status-sample-interval=.5s",
-		})
-	defer shutdownAndAssert(net, t, carol)
+	// Create a new node Eve, which will be restarted later with a config
+	// that has an inactive channel timeout of just 6 seconds (down from
+	// the default 20m). It will be used to test channel updates for
+	// channels going inactive.
+	//
+	// NOTE: we don't create Eve with the chan-disable-timeout here because
+	// the following channel openings might take longer than that timeout
+	// value, which will cause the channel Eve=>Carol being marked as
+	// disabled.
+	eve := ht.NewNode("Eve", nil)
 
-	net.ConnectNodes(t.t, net.Alice, carol)
-	chanPointAliceCarol := openChannelAndAssert(
-		t, net, net.Alice, carol,
-		lntest.OpenChannelParams{
-			Amt: chanAmt,
-		},
-	)
-
-	// We create a new node Eve that has an inactive channel timeout of
-	// just 2 seconds (down from the default 20m). It will be used to test
-	// channel updates for channels going inactive.
-	eve := net.NewNode(
-		t.t, "Eve", []string{
-			"--minbackoff=10s",
-			"--chan-enable-timeout=1.5s",
-			"--chan-disable-timeout=3s",
-			"--chan-status-sample-interval=.5s",
-		})
-	defer shutdownAndAssert(net, t, eve)
-
-	// Give Eve some coins.
-	net.SendCoins(t.t, btcutil.SatoshiPerBitcoin, eve)
-
-	// Connect Eve to Carol and Bob, and open a channel to carol.
-	net.ConnectNodes(t.t, eve, carol)
-	net.ConnectNodes(t.t, eve, net.Bob)
-
-	chanPointEveCarol := openChannelAndAssert(
-		t, net, eve, carol,
-		lntest.OpenChannelParams{
-			Amt: chanAmt,
-		},
-	)
+	// Create a new node Carol, which will later be restarted with the same
+	// config as Eve's.
+	carol := ht.NewNode("Carol", nil)
 
 	// Launch a node for Dave which will connect to Bob in order to receive
 	// graph updates from. This will ensure that the channel updates are
 	// propagated throughout the network.
-	dave := net.NewNode(t.t, "Dave", nil)
-	defer shutdownAndAssert(net, t, dave)
+	dave := ht.NewNode("Dave", nil)
 
-	net.ConnectNodes(t.t, net.Bob, dave)
+	// We will start our test by creating the following topology,
+	// Alice --- Bob --- Dave
+	//   |       |
+	// Carol --- Eve
+	ht.EnsureConnected(alice, bob)
+	ht.ConnectNodes(alice, carol)
+	ht.ConnectNodes(bob, dave)
+	ht.ConnectNodes(eve, carol)
+
+	// Connect Eve and Bob using a persistent connection. Later after Eve
+	// is restarted, they will connect again automatically.
+	ht.ConnectNodesPerm(bob, eve)
+
+	// Give Eve some coins.
+	ht.FundCoins(btcutil.SatoshiPerBitcoin, eve)
+
+	// We now proceed to open channels: Alice=>Bob, Alice=>Carol and
+	// Eve=>Carol.
+	p := lntemp.OpenChannelParams{Amt: chanAmt}
+	reqs := []*lntemp.OpenChannelRequest{
+		{Local: alice, Remote: bob, Param: p},
+		{Local: alice, Remote: carol, Param: p},
+		{Local: eve, Remote: carol, Param: p},
+	}
+	resp := ht.OpenMultiChannelsAsync(reqs)
+
+	// Extract channel points from the response.
+	chanPointAliceBob := resp[0]
+	chanPointAliceCarol := resp[1]
+	chanPointEveCarol := resp[2]
+
+	// We will use 10 seconds as the disable timeout.
+	chanDisableTimeout := 10
+	chanEnableTimeout := 5
+
+	// waitChanDisabled is a helper closure to wait the chanDisableTimeout
+	// seconds such that the channel disable logic is taking effect.
+	waitChanDisabled := func() {
+		time.Sleep(time.Duration(chanDisableTimeout) * time.Second)
+	}
+
+	// With the channels open, we now restart Carol and Eve to use
+	// customized timeout values.
+	nodeCfg := []string{
+		"--minbackoff=60s",
+		fmt.Sprintf("--chan-enable-timeout=%ds", chanEnableTimeout),
+		fmt.Sprintf("--chan-disable-timeout=%ds", chanDisableTimeout),
+		"--chan-status-sample-interval=.5s",
+	}
+	ht.RestartNodeWithExtraArgs(carol, nodeCfg)
+	ht.RestartNodeWithExtraArgs(eve, nodeCfg)
+
+	// Dave should know all the channels.
+	ht.AssertTopologyChannelOpen(dave, chanPointAliceBob)
+	ht.AssertTopologyChannelOpen(dave, chanPointAliceCarol)
+	ht.AssertTopologyChannelOpen(dave, chanPointEveCarol)
 
 	// We should expect to see a channel update with the default routing
 	// policy, except that it should indicate the channel is disabled.
@@ -514,110 +536,132 @@ func testSendUpdateDisableChannel(net *lntest.NetworkHarness, t *harnessTest) {
 
 	// assertPolicyUpdate checks that the required policy update has
 	// happened on the given node.
-	assertPolicyUpdate := func(node *lntest.HarnessNode,
-		policy *lnrpc.RoutingPolicy, chanPoint *lnrpc.ChannelPoint) {
+	assertPolicyUpdate := func(node *node.HarnessNode,
+		policy *lnrpc.RoutingPolicy, chanPoint *lnrpc.ChannelPoint,
+		numUpdates int) {
 
-		require.NoError(
-			t.t, dave.WaitForChannelPolicyUpdate(
-				node.PubKeyStr, policy, chanPoint, false,
-			), "error while waiting for channel update",
+		ht.AssertNumPolicyUpdates(dave, chanPoint, node, numUpdates)
+		ht.AssertChannelPolicyUpdate(
+			dave, node, policy, chanPoint, false,
 		)
 	}
 
-	// Let Carol go offline. Since Eve has an inactive timeout of 2s, we
+	// Let Carol go offline. Since Eve has an inactive timeout of 6s, we
 	// expect her to send an update disabling the channel.
-	restartCarol, err := net.SuspendNode(carol)
-	if err != nil {
-		t.Fatalf("unable to suspend carol: %v", err)
-	}
+	restartCarol := ht.SuspendNode(carol)
 
-	assertPolicyUpdate(eve, expectedPolicy, chanPointEveCarol)
+	// We expect to see a total of 2 channel policy updates from the
+	// channel Carol <-> Eve and advertised by Eve using the route
+	// Eve->Bob->Dave.
+	waitChanDisabled()
+	assertPolicyUpdate(eve, expectedPolicy, chanPointEveCarol, 2)
 
 	// We restart Carol. Since the channel now becomes active again, Eve
 	// should send a ChannelUpdate setting the channel no longer disabled.
-	if err := restartCarol(); err != nil {
-		t.Fatalf("unable to restart carol: %v", err)
-	}
+	require.NoError(ht, restartCarol(), "unable to restart carol")
 
 	expectedPolicy.Disabled = false
-	assertPolicyUpdate(eve, expectedPolicy, chanPointEveCarol)
+	// We expect to see a total of 3 channel policy updates from the
+	// channel Carol <-> Eve and advertised by Eve using the route
+	// Eve->Bob->Dave.
+	assertPolicyUpdate(eve, expectedPolicy, chanPointEveCarol, 3)
 
 	// Wait until Carol and Eve are reconnected before we disconnect them
 	// again.
-	net.EnsureConnected(t.t, eve, carol)
+	ht.EnsureConnected(eve, carol)
 
 	// Now we'll test a long disconnection. Disconnect Carol and Eve and
 	// ensure they both detect each other as disabled. Their min backoffs
 	// are high enough to not interfere with disabling logic.
-	if err := net.DisconnectNodes(carol, eve); err != nil {
-		t.Fatalf("unable to disconnect Carol from Eve: %v", err)
-	}
+	ht.DisconnectNodes(carol, eve)
 
 	// Wait for a disable from both Carol and Eve to come through.
 	expectedPolicy.Disabled = true
-	assertPolicyUpdate(eve, expectedPolicy, chanPointEveCarol)
-	assertPolicyUpdate(carol, expectedPolicy, chanPointEveCarol)
+	// We expect to see a total of 4 channel policy updates from the
+	// channel Carol <-> Eve and advertised by Eve using the route
+	// Eve->Bob->Dave.
+	waitChanDisabled()
+	assertPolicyUpdate(eve, expectedPolicy, chanPointEveCarol, 4)
+
+	// Because Carol has restarted twice before, depending on how much time
+	// it has taken, she might mark the channel disabled and enable it
+	// multiple times.  Thus we could see a total of 2 or 4 or 6 channel
+	// policy updates from the channel Carol <-> Eve and advertised by
+	// Carol using the route Carol->Alice->Bob->Dave.
+	//
+	// Assume there are 2 channel policy updates from Carol, and update it
+	// if more has found
+	numCarol := 2
+	op := ht.OutPointFromChannelPoint(chanPointEveCarol)
+	policyMap := dave.Watcher.GetPolicyUpdates(op)
+	nodePolicy, ok := policyMap[carol.PubKeyStr]
+	switch {
+	case !ok:
+		break
+	case len(nodePolicy) > 2:
+		numCarol = 4
+	case len(nodePolicy) > 4:
+		numCarol = 6
+	}
+	assertPolicyUpdate(carol, expectedPolicy, chanPointEveCarol, numCarol)
 
 	// Reconnect Carol and Eve, this should cause them to reenable the
 	// channel from both ends after a short delay.
-	net.EnsureConnected(t.t, carol, eve)
+	ht.EnsureConnected(carol, eve)
 
 	expectedPolicy.Disabled = false
-	assertPolicyUpdate(eve, expectedPolicy, chanPointEveCarol)
-	assertPolicyUpdate(carol, expectedPolicy, chanPointEveCarol)
+	// We expect to see a total of 5 channel policy updates from the
+	// channel Carol <-> Eve and advertised by Eve using the route
+	// Eve->Bob->Dave.
+	assertPolicyUpdate(eve, expectedPolicy, chanPointEveCarol, 5)
+	// We expect to see a total of 3 or 5 channel policy updates from the
+	// channel Carol <-> Eve and advertised by Carol using the route
+	// Carol->Alice->Bob->Dave.
+	numCarol++
+	assertPolicyUpdate(carol, expectedPolicy, chanPointEveCarol, numCarol)
 
 	// Now we'll test a short disconnection. Disconnect Carol and Eve, then
 	// reconnect them after one second so that their scheduled disables are
 	// aborted. One second is twice the status sample interval, so this
 	// should allow for the disconnect to be detected, but still leave time
-	// to cancel the announcement before the 3 second inactive timeout is
+	// to cancel the announcement before the 6 second inactive timeout is
 	// hit.
-	if err := net.DisconnectNodes(carol, eve); err != nil {
-		t.Fatalf("unable to disconnect Carol from Eve: %v", err)
-	}
+	ht.DisconnectNodes(carol, eve)
 	time.Sleep(time.Second)
-	net.EnsureConnected(t.t, eve, carol)
+	ht.EnsureConnected(eve, carol)
 
-	// Since the disable should have been canceled by both Carol and Eve, we
-	// expect no channel updates to appear on the network, which means we
-	// expect the polices stay unchanged(Disable == false).
-	assertPolicyUpdate(eve, expectedPolicy, chanPointEveCarol)
-	assertPolicyUpdate(carol, expectedPolicy, chanPointEveCarol)
+	// Since the disable should have been canceled by both Carol and Eve,
+	// we expect no channel updates to appear on the network, which means
+	// we expect the polices stay unchanged(Disable == false).
+	assertPolicyUpdate(eve, expectedPolicy, chanPointEveCarol, 5)
+	assertPolicyUpdate(carol, expectedPolicy, chanPointEveCarol, numCarol)
 
 	// Close Alice's channels with Bob and Carol cooperatively and
-	// unilaterally respectively.
-	_, _, err = net.CloseChannel(net.Alice, chanPointAliceBob, false)
-	if err != nil {
-		t.Fatalf("unable to close channel: %v", err)
-	}
-
-	_, _, err = net.CloseChannel(net.Alice, chanPointAliceCarol, true)
-	if err != nil {
-		t.Fatalf("unable to close channel: %v", err)
-	}
+	// unilaterally respectively. Note that the CloseChannel will mine a
+	// block and check that the closing transaction can be found in both
+	// the mempool and the block.
+	ht.CloseChannel(alice, chanPointAliceBob)
+	ht.ForceCloseChannel(alice, chanPointAliceCarol)
 
 	// Now that the channel close processes have been started, we should
 	// receive an update marking each as disabled.
 	expectedPolicy.Disabled = true
-	assertPolicyUpdate(net.Alice, expectedPolicy, chanPointAliceBob)
-	assertPolicyUpdate(net.Alice, expectedPolicy, chanPointAliceCarol)
-
-	// Finally, close the channels by mining the closing transactions.
-	mineBlocks(t, net, 1, 2)
+	// We expect to see a total of 2 channel policy updates from the
+	// channel Alice <-> Bob and advertised by Alice using the route
+	// Alice->Bob->Dave.
+	assertPolicyUpdate(alice, expectedPolicy, chanPointAliceBob, 2)
+	// We expect to see a total of 2 channel policy updates from the
+	// channel Alice <-> Carol and advertised by Alice using the route
+	// Alice->Bob->Dave.
+	assertPolicyUpdate(alice, expectedPolicy, chanPointAliceCarol, 2)
 
 	// Also do this check for Eve's channel with Carol.
-	_, _, err = net.CloseChannel(eve, chanPointEveCarol, false)
-	if err != nil {
-		t.Fatalf("unable to close channel: %v", err)
-	}
+	ht.CloseChannel(eve, chanPointEveCarol)
 
-	assertPolicyUpdate(eve, expectedPolicy, chanPointEveCarol)
-
-	mineBlocks(t, net, 1, 1)
-
-	// And finally, clean up the force closed channel by mining the
-	// sweeping transaction.
-	cleanupForceClose(t, net, net.Alice, chanPointAliceCarol)
+	// We expect to see a total of 5 channel policy updates from the
+	// channel Carol <-> Eve and advertised by Eve using the route
+	// Eve->Bob->Dave.
+	assertPolicyUpdate(eve, expectedPolicy, chanPointEveCarol, 6)
 }
 
 // testUpdateChannelPolicyForPrivateChannel tests when a private channel

--- a/lntest/itest/lnd_channel_policy_test.go
+++ b/lntest/itest/lnd_channel_policy_test.go
@@ -3,7 +3,6 @@ package itest
 import (
 	"context"
 	"math"
-	"strings"
 	"time"
 
 	"github.com/btcsuite/btcd/btcutil"
@@ -11,6 +10,9 @@ import (
 	"github.com/lightningnetwork/lnd/chainreg"
 	"github.com/lightningnetwork/lnd/funding"
 	"github.com/lightningnetwork/lnd/lnrpc"
+	"github.com/lightningnetwork/lnd/lnrpc/routerrpc"
+	"github.com/lightningnetwork/lnd/lntemp"
+	"github.com/lightningnetwork/lnd/lntemp/node"
 	"github.com/lightningnetwork/lnd/lntest"
 	"github.com/lightningnetwork/lnd/lnwire"
 	"github.com/stretchr/testify/require"
@@ -18,6 +20,7 @@ import (
 
 // assertPolicyUpdate checks that a given policy update has been received by a
 // list of given nodes.
+// TODO(yy): delete.
 func assertPolicyUpdate(t *harnessTest, nodes []*lntest.HarnessNode,
 	advertisingNode string, policy *lnrpc.RoutingPolicy,
 	chanPoint *lnrpc.ChannelPoint) {
@@ -30,10 +33,8 @@ func assertPolicyUpdate(t *harnessTest, nodes []*lntest.HarnessNode,
 }
 
 // testUpdateChannelPolicy tests that policy updates made to a channel
-// get propagated to other nodes in the network.
-func testUpdateChannelPolicy(net *lntest.NetworkHarness, t *harnessTest) {
-	ctxb := context.Background()
-
+// gets propagated to other nodes in the network.
+func testUpdateChannelPolicy(ht *lntemp.HarnessTest) {
 	const (
 		defaultFeeBase       = 1000
 		defaultFeeRate       = 1
@@ -45,19 +46,19 @@ func testUpdateChannelPolicy(net *lntest.NetworkHarness, t *harnessTest) {
 	chanAmt := funding.MaxBtcFundingAmount
 	pushAmt := chanAmt / 2
 
+	alice, bob := ht.Alice, ht.Bob
+
 	// Create a channel Alice->Bob.
-	chanPoint := openChannelAndAssert(
-		t, net, net.Alice, net.Bob,
-		lntest.OpenChannelParams{
+	chanPoint := ht.OpenChannel(
+		alice, bob, lntemp.OpenChannelParams{
 			Amt:     chanAmt,
 			PushAmt: pushAmt,
 		},
 	)
-	defer closeChannelAndAssert(t, net, net.Alice, chanPoint, false)
 
 	// We add all the nodes' update channels to a slice, such that we can
 	// make sure they all receive the expected updates.
-	nodes := []*lntest.HarnessNode{net.Alice, net.Bob}
+	nodes := []*node.HarnessNode{alice, bob}
 
 	// Alice and Bob should see each other's ChannelUpdates, advertising the
 	// default routing policies.
@@ -69,65 +70,45 @@ func testUpdateChannelPolicy(net *lntest.NetworkHarness, t *harnessTest) {
 		MaxHtlcMsat:      defaultMaxHtlc,
 	}
 
-	assertPolicyUpdate(
-		t, nodes, net.Alice.PubKeyStr, expectedPolicy, chanPoint,
-	)
-	assertPolicyUpdate(
-		t, nodes, net.Bob.PubKeyStr, expectedPolicy, chanPoint,
-	)
+	assertNodesPolicyUpdate(ht, nodes, alice, expectedPolicy, chanPoint)
+	assertNodesPolicyUpdate(ht, nodes, bob, expectedPolicy, chanPoint)
 
 	// They should now know about the default policies.
 	for _, node := range nodes {
-		assertChannelPolicy(
-			t, node, net.Alice.PubKeyStr, expectedPolicy, chanPoint,
+		ht.AssertChannelPolicy(
+			node, alice.PubKeyStr, expectedPolicy, chanPoint,
 		)
-		assertChannelPolicy(
-			t, node, net.Bob.PubKeyStr, expectedPolicy, chanPoint,
+		ht.AssertChannelPolicy(
+			node, bob.PubKeyStr, expectedPolicy, chanPoint,
 		)
-	}
-
-	err := net.Alice.WaitForNetworkChannelOpen(chanPoint)
-	if err != nil {
-		t.Fatalf("alice didn't report channel: %v", err)
-	}
-	err = net.Bob.WaitForNetworkChannelOpen(chanPoint)
-	if err != nil {
-		t.Fatalf("bob didn't report channel: %v", err)
 	}
 
 	// Create Carol with options to rate limit channel updates up to 2 per
 	// day, and create a new channel Bob->Carol.
-	carol := net.NewNode(
-		t.t, "Carol", []string{
+	carol := ht.NewNode(
+		"Carol", []string{
 			"--gossip.max-channel-update-burst=2",
 			"--gossip.channel-update-interval=24h",
 		},
 	)
-
-	// Clean up carol's node when the test finishes.
-	defer shutdownAndAssert(net, t, carol)
-
+	ht.ConnectNodes(carol, bob)
 	nodes = append(nodes, carol)
 
 	// Send some coins to Carol that can be used for channel funding.
-	net.SendCoins(t.t, btcutil.SatoshiPerBitcoin, carol)
-
-	net.ConnectNodes(t.t, carol, net.Bob)
+	ht.FundCoins(btcutil.SatoshiPerBitcoin, carol)
 
 	// Open the channel Carol->Bob with a custom min_htlc value set. Since
 	// Carol is opening the channel, she will require Bob to not forward
 	// HTLCs smaller than this value, and hence he should advertise it as
 	// part of his ChannelUpdate.
 	const customMinHtlc = 5000
-	chanPoint2 := openChannelAndAssert(
-		t, net, carol, net.Bob,
-		lntest.OpenChannelParams{
+	chanPoint2 := ht.OpenChannel(
+		carol, bob, lntemp.OpenChannelParams{
 			Amt:     chanAmt,
 			PushAmt: pushAmt,
 			MinHtlc: customMinHtlc,
 		},
 	)
-	defer closeChannelAndAssert(t, net, net.Bob, chanPoint2, false)
 
 	expectedPolicyBob := &lnrpc.RoutingPolicy{
 		FeeBaseMsat:      defaultFeeBase,
@@ -144,37 +125,24 @@ func testUpdateChannelPolicy(net *lntest.NetworkHarness, t *harnessTest) {
 		MaxHtlcMsat:      defaultMaxHtlc,
 	}
 
-	assertPolicyUpdate(
-		t, nodes, net.Bob.PubKeyStr, expectedPolicyBob, chanPoint2,
-	)
-	assertPolicyUpdate(
-		t, nodes, carol.PubKeyStr, expectedPolicyCarol, chanPoint2,
+	assertNodesPolicyUpdate(ht, nodes, bob, expectedPolicyBob, chanPoint2)
+	assertNodesPolicyUpdate(
+		ht, nodes, carol, expectedPolicyCarol, chanPoint2,
 	)
 
 	// Check that all nodes now know about the updated policies.
 	for _, node := range nodes {
-		assertChannelPolicy(
-			t, node, net.Bob.PubKeyStr, expectedPolicyBob,
-			chanPoint2,
+		ht.AssertChannelPolicy(
+			node, bob.PubKeyStr, expectedPolicyBob, chanPoint2,
 		)
-		assertChannelPolicy(
-			t, node, carol.PubKeyStr, expectedPolicyCarol,
-			chanPoint2,
+		ht.AssertChannelPolicy(
+			node, carol.PubKeyStr, expectedPolicyCarol, chanPoint2,
 		)
 	}
 
-	err = net.Alice.WaitForNetworkChannelOpen(chanPoint2)
-	if err != nil {
-		t.Fatalf("alice didn't report channel: %v", err)
-	}
-	err = net.Bob.WaitForNetworkChannelOpen(chanPoint2)
-	if err != nil {
-		t.Fatalf("bob didn't report channel: %v", err)
-	}
-	err = carol.WaitForNetworkChannelOpen(chanPoint2)
-	if err != nil {
-		t.Fatalf("carol didn't report channel: %v", err)
-	}
+	// Make sure Alice and Carol have seen each other's channels.
+	ht.AssertTopologyChannelOpen(alice, chanPoint2)
+	ht.AssertTopologyChannelOpen(carol, chanPoint)
 
 	// First we'll try to send a payment from Alice to Carol with an amount
 	// less than the min_htlc value required by Carol. This payment should
@@ -184,23 +152,19 @@ func testUpdateChannelPolicy(net *lntest.NetworkHarness, t *harnessTest) {
 		Memo:  "testing",
 		Value: int64(payAmt),
 	}
-	ctxt, _ := context.WithTimeout(ctxb, defaultTimeout)
-	resp, err := carol.AddInvoice(ctxt, invoice)
-	if err != nil {
-		t.Fatalf("unable to add invoice: %v", err)
-	}
-
-	err = completePaymentRequests(
-		net.Alice, net.Alice.RouterClient,
-		[]string{resp.PaymentRequest}, true,
-	)
+	resp := carol.RPC.AddInvoice(invoice)
 
 	// Alice knows about the channel policy of Carol and should therefore
 	// not be able to find a path during routing.
-	expErr := lnrpc.PaymentFailureReason_FAILURE_REASON_NO_ROUTE
-	if err.Error() != expErr.String() {
-		t.Fatalf("expected %v, instead got %v", expErr, err)
+	payReq := &routerrpc.SendPaymentRequest{
+		PaymentRequest: resp.PaymentRequest,
+		TimeoutSeconds: 60,
+		FeeLimitMsat:   noFeeLimitMsat,
 	}
+	ht.SendPaymentAssertFail(
+		alice, payReq,
+		lnrpc.PaymentFailureReason_FAILURE_REASON_NO_ROUTE,
+	)
 
 	// Now we try to send a payment over the channel with a value too low
 	// to be accepted. First we query for a route to route a payment of
@@ -211,16 +175,8 @@ func testUpdateChannelPolicy(net *lntest.NetworkHarness, t *harnessTest) {
 		Amt:            int64(payAmt),
 		FinalCltvDelta: defaultTimeLockDelta,
 	}
-
-	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
-	routes, err := net.Alice.QueryRoutes(ctxt, routesReq)
-	if err != nil {
-		t.Fatalf("unable to get route: %v", err)
-	}
-
-	if len(routes.Routes) != 1 {
-		t.Fatalf("expected to find 1 route, got %v", len(routes.Routes))
-	}
+	routes := alice.RPC.QueryRoutes(routesReq)
+	require.Len(ht, routes.Routes, 1)
 
 	// We change the route to carry a payment of 4000 mSAT instead of 5000
 	// mSAT.
@@ -233,27 +189,19 @@ func testUpdateChannelPolicy(net *lntest.NetworkHarness, t *harnessTest) {
 	routes.Routes[0].Hops[1].AmtToForwardMsat = amtMSat
 
 	// Send the payment with the modified value.
-	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
-	alicePayStream, err := net.Alice.SendToRoute(ctxt) // nolint:staticcheck
-	if err != nil {
-		t.Fatalf("unable to create payment stream for alice: %v", err)
-	}
+	alicePayStream := alice.RPC.SendToRoute()
+
 	sendReq := &lnrpc.SendToRouteRequest{
 		PaymentHash: resp.RHash,
 		Route:       routes.Routes[0],
 	}
-
-	err = alicePayStream.Send(sendReq)
-	if err != nil {
-		t.Fatalf("unable to send payment: %v", err)
-	}
+	err := alicePayStream.Send(sendReq)
+	require.NoError(ht, err, "unable to send payment")
 
 	// We expect this payment to fail, and that the min_htlc value is
 	// communicated back to us, since the attempted HTLC value was too low.
 	sendResp, err := alicePayStream.Recv()
-	if err != nil {
-		t.Fatalf("unable to send payment: %v", err)
-	}
+	require.NoError(ht, err, "unable to receive payment stream")
 
 	// Expected as part of the error message.
 	substrs := []string{
@@ -261,10 +209,7 @@ func testUpdateChannelPolicy(net *lntest.NetworkHarness, t *harnessTest) {
 		"HtlcMinimumMsat: (lnwire.MilliSatoshi) 5000 mSAT",
 	}
 	for _, s := range substrs {
-		if !strings.Contains(sendResp.PaymentError, s) {
-			t.Fatalf("expected error to contain \"%v\", instead "+
-				"got %v", s, sendResp.PaymentError)
-		}
+		require.Contains(ht, sendResp.PaymentError, s)
 	}
 
 	// Make sure sending using the original value succeeds.
@@ -292,22 +237,14 @@ func testUpdateChannelPolicy(net *lntest.NetworkHarness, t *harnessTest) {
 	}
 
 	err = alicePayStream.Send(sendReq)
-	if err != nil {
-		t.Fatalf("unable to send payment: %v", err)
-	}
+	require.NoError(ht, err, "unable to send payment")
 
 	sendResp, err = alicePayStream.Recv()
-	if err != nil {
-		t.Fatalf("unable to send payment: %v", err)
-	}
+	require.NoError(ht, err, "unable to receive payment stream")
+	require.Empty(ht, sendResp.PaymentError, "expected payment to succeed")
 
-	if sendResp.PaymentError != "" {
-		t.Fatalf("expected payment to succeed, instead got %v",
-			sendResp.PaymentError)
-	}
-
-	// With our little cluster set up, we'll update the fees and the max htlc
-	// size for the Bob side of the Alice->Bob channel, and make sure
+	// With our little cluster set up, we'll update the fees and the max
+	// htlc size for the Bob side of the Alice->Bob channel, and make sure
 	// all nodes learn about it.
 	baseFee := int64(1500)
 	feeRate := int64(12)
@@ -331,21 +268,15 @@ func testUpdateChannelPolicy(net *lntest.NetworkHarness, t *harnessTest) {
 			ChanPoint: chanPoint,
 		},
 	}
-
-	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
-	if _, err := net.Bob.UpdateChannelPolicy(ctxt, req); err != nil {
-		t.Fatalf("unable to get alice's balance: %v", err)
-	}
+	bob.RPC.UpdateChannelPolicy(req)
 
 	// Wait for all nodes to have seen the policy update done by Bob.
-	assertPolicyUpdate(
-		t, nodes, net.Bob.PubKeyStr, expectedPolicy, chanPoint,
-	)
+	assertNodesPolicyUpdate(ht, nodes, bob, expectedPolicy, chanPoint)
 
 	// Check that all nodes now know about Bob's updated policy.
 	for _, node := range nodes {
-		assertChannelPolicy(
-			t, node, net.Bob.PubKeyStr, expectedPolicy, chanPoint,
+		ht.AssertChannelPolicy(
+			node, bob.PubKeyStr, expectedPolicy, chanPoint,
 		)
 	}
 
@@ -361,39 +292,21 @@ func testUpdateChannelPolicy(net *lntest.NetworkHarness, t *harnessTest) {
 		Memo:  "testing",
 		Value: int64(payAmt),
 	}
-	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
-	resp, err = carol.AddInvoice(ctxt, invoice)
-	if err != nil {
-		t.Fatalf("unable to add invoice: %v", err)
-	}
+	resp = carol.RPC.AddInvoice(invoice)
 
-	err = completePaymentRequests(
-		net.Alice, net.Alice.RouterClient,
-		[]string{resp.PaymentRequest}, true,
-	)
-	if err != nil {
-		t.Fatalf("unable to send payment: %v", err)
-	}
+	ht.CompletePaymentRequests(alice, []string{resp.PaymentRequest})
 
 	// We'll now open a channel from Alice directly to Carol.
-	net.ConnectNodes(t.t, net.Alice, carol)
-	chanPoint3 := openChannelAndAssert(
-		t, net, net.Alice, carol,
-		lntest.OpenChannelParams{
+	ht.ConnectNodes(alice, carol)
+	chanPoint3 := ht.OpenChannel(
+		alice, carol, lntemp.OpenChannelParams{
 			Amt:     chanAmt,
 			PushAmt: pushAmt,
 		},
 	)
-	defer closeChannelAndAssert(t, net, net.Alice, chanPoint3, false)
 
-	err = net.Alice.WaitForNetworkChannelOpen(chanPoint3)
-	if err != nil {
-		t.Fatalf("alice didn't report channel: %v", err)
-	}
-	err = carol.WaitForNetworkChannelOpen(chanPoint3)
-	if err != nil {
-		t.Fatalf("bob didn't report channel: %v", err)
-	}
+	// Make sure Bob knows this channel.
+	ht.AssertTopologyChannelOpen(bob, chanPoint3)
 
 	// Make a global update, and check that both channels' new policies get
 	// propagated.
@@ -414,28 +327,21 @@ func testUpdateChannelPolicy(net *lntest.NetworkHarness, t *harnessTest) {
 		MaxHtlcMsat:   maxHtlc,
 	}
 	req.Scope = &lnrpc.PolicyUpdateRequest_Global{}
-
-	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
-	_, err = net.Alice.UpdateChannelPolicy(ctxt, req)
-	if err != nil {
-		t.Fatalf("unable to update alice's channel policy: %v", err)
-	}
+	alice.RPC.UpdateChannelPolicy(req)
 
 	// Wait for all nodes to have seen the policy updates for both of
 	// Alice's channels.
-	assertPolicyUpdate(
-		t, nodes, net.Alice.PubKeyStr, expectedPolicy, chanPoint,
-	)
-	assertPolicyUpdate(
-		t, nodes, net.Alice.PubKeyStr, expectedPolicy, chanPoint3,
-	)
+	assertNodesPolicyUpdate(ht, nodes, alice, expectedPolicy, chanPoint)
+	assertNodesPolicyUpdate(ht, nodes, alice, expectedPolicy, chanPoint3)
 
 	// And finally check that all nodes remembers the policy update they
 	// received.
 	for _, node := range nodes {
-		assertChannelPolicy(
-			t, node, net.Alice.PubKeyStr, expectedPolicy,
-			chanPoint, chanPoint3,
+		ht.AssertChannelPolicy(
+			node, alice.PubKeyStr, expectedPolicy, chanPoint,
+		)
+		ht.AssertChannelPolicy(
+			node, alice.PubKeyStr, expectedPolicy, chanPoint3,
 		)
 	}
 
@@ -443,60 +349,87 @@ func testUpdateChannelPolicy(net *lntest.NetworkHarness, t *harnessTest) {
 	// we'll send two more update from Alice. Carol should accept the first,
 	// but not the second, as she only allows two updates per day and a day
 	// has yet to elapse from the previous update.
-	const numUpdatesTilRateLimit = 2
-	for i := 0; i < numUpdatesTilRateLimit; i++ {
-		prevAlicePolicy := *expectedPolicy
-		baseFee *= 2
-		expectedPolicy.FeeBaseMsat = baseFee
-		req.BaseFeeMsat = baseFee
 
-		ctxt, cancel := context.WithTimeout(ctxb, defaultTimeout)
-		defer cancel()
-		_, err = net.Alice.UpdateChannelPolicy(ctxt, req)
-		require.NoError(t.t, err)
+	// assertAliceAndBob is a helper closure which updates Alice's policy
+	// and asserts that both Alice and Bob have heard and updated the
+	// policy in their graph.
+	assertAliceAndBob := func(req *lnrpc.PolicyUpdateRequest,
+		expectedPolicy *lnrpc.RoutingPolicy) {
+
+		alice.RPC.UpdateChannelPolicy(req)
 
 		// Wait for all nodes to have seen the policy updates for both
 		// of Alice's channels. Carol will not see the last update as
 		// the limit has been reached.
-		assertPolicyUpdate(
-			t, []*lntest.HarnessNode{net.Alice, net.Bob},
-			net.Alice.PubKeyStr, expectedPolicy, chanPoint,
+		assertNodesPolicyUpdate(
+			ht, []*node.HarnessNode{alice, bob},
+			alice, expectedPolicy, chanPoint,
 		)
-		assertPolicyUpdate(
-			t, []*lntest.HarnessNode{net.Alice, net.Bob},
-			net.Alice.PubKeyStr, expectedPolicy, chanPoint3,
+		assertNodesPolicyUpdate(
+			ht, []*node.HarnessNode{alice, bob},
+			alice, expectedPolicy, chanPoint3,
 		)
 
 		// Check that all nodes remember the policy update
 		// they received.
-		assertChannelPolicy(
-			t, net.Alice, net.Alice.PubKeyStr,
-			expectedPolicy, chanPoint, chanPoint3,
+		ht.AssertChannelPolicy(
+			alice, alice.PubKeyStr, expectedPolicy, chanPoint,
 		)
-		assertChannelPolicy(
-			t, net.Bob, net.Alice.PubKeyStr,
-			expectedPolicy, chanPoint, chanPoint3,
+		ht.AssertChannelPolicy(
+			alice, alice.PubKeyStr, expectedPolicy, chanPoint3,
 		)
-
-		// Carol was added last, which is why we check the last index.
-		// Since Carol didn't receive the last update, she still has
-		// Alice's old policy.
-		if i == numUpdatesTilRateLimit-1 {
-			expectedPolicy = &prevAlicePolicy
-		}
-		assertPolicyUpdate(
-			t, []*lntest.HarnessNode{carol},
-			net.Alice.PubKeyStr, expectedPolicy, chanPoint,
+		ht.AssertChannelPolicy(
+			bob, alice.PubKeyStr, expectedPolicy, chanPoint,
 		)
-		assertPolicyUpdate(
-			t, []*lntest.HarnessNode{carol},
-			net.Alice.PubKeyStr, expectedPolicy, chanPoint3,
-		)
-		assertChannelPolicy(
-			t, carol, net.Alice.PubKeyStr,
-			expectedPolicy, chanPoint, chanPoint3,
+		ht.AssertChannelPolicy(
+			bob, alice.PubKeyStr, expectedPolicy, chanPoint3,
 		)
 	}
+
+	// Double the base fee and attach to the policy.
+	baseFee1 := baseFee * 2
+	expectedPolicy.FeeBaseMsat = baseFee1
+	req.BaseFeeMsat = baseFee1
+	assertAliceAndBob(req, expectedPolicy)
+
+	// Check that Carol has both heard the policy and updated it in her
+	// graph.
+	assertNodesPolicyUpdate(
+		ht, []*node.HarnessNode{carol},
+		alice, expectedPolicy, chanPoint,
+	)
+	assertNodesPolicyUpdate(
+		ht, []*node.HarnessNode{carol},
+		alice, expectedPolicy, chanPoint3,
+	)
+	ht.AssertChannelPolicy(
+		carol, alice.PubKeyStr, expectedPolicy, chanPoint,
+	)
+	ht.AssertChannelPolicy(
+		carol, alice.PubKeyStr, expectedPolicy, chanPoint3,
+	)
+
+	// Double the base fee and attach to the policy.
+	baseFee2 := baseFee1 * 2
+	expectedPolicy.FeeBaseMsat = baseFee2
+	req.BaseFeeMsat = baseFee2
+	assertAliceAndBob(req, expectedPolicy)
+
+	// Since Carol didn't receive the last update, she still has Alice's
+	// old policy. We validate this by checking the base fee is the older
+	// one.
+	expectedPolicy.FeeBaseMsat = baseFee1
+	ht.AssertChannelPolicy(
+		carol, alice.PubKeyStr, expectedPolicy, chanPoint,
+	)
+	ht.AssertChannelPolicy(
+		carol, alice.PubKeyStr, expectedPolicy, chanPoint3,
+	)
+
+	// Close all channels.
+	ht.CloseChannel(alice, chanPoint)
+	ht.CloseChannel(bob, chanPoint2)
+	ht.CloseChannel(alice, chanPoint3)
 }
 
 // testSendUpdateDisableChannel ensures that a channel update with the disable
@@ -914,4 +847,17 @@ func testUpdateChannelPolicyFeeRateAccuracy(net *lntest.NetworkHarness,
 	assertPolicyUpdate(
 		t, nodes, net.Alice.PubKeyStr, expectedPolicy, chanPoint,
 	)
+}
+
+// assertNodesPolicyUpdate checks that a given policy update has been received
+// by a list of given nodes.
+func assertNodesPolicyUpdate(ht *lntemp.HarnessTest, nodes []*node.HarnessNode,
+	advertisingNode *node.HarnessNode, policy *lnrpc.RoutingPolicy,
+	chanPoint *lnrpc.ChannelPoint) {
+
+	for _, node := range nodes {
+		ht.AssertChannelPolicyUpdate(
+			node, advertisingNode, policy, chanPoint, false,
+		)
+	}
 }

--- a/lntest/itest/lnd_channel_policy_test.go
+++ b/lntest/itest/lnd_channel_policy_test.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	"github.com/btcsuite/btcd/btcutil"
-	"github.com/btcsuite/btcd/wire"
 	"github.com/lightningnetwork/lnd/chainreg"
 	"github.com/lightningnetwork/lnd/funding"
 	"github.com/lightningnetwork/lnd/lnrpc"
@@ -672,80 +671,53 @@ func testSendUpdateDisableChannel(ht *lntemp.HarnessTest) {
 // Bob will update the base fee via UpdateChannelPolicy, we will test that
 // Alice will not fail the payment and send it using the updated channel
 // policy.
-func testUpdateChannelPolicyForPrivateChannel(net *lntest.NetworkHarness,
-	t *harnessTest) {
-
-	ctxb := context.Background()
-	defer ctxb.Done()
+func testUpdateChannelPolicyForPrivateChannel(ht *lntemp.HarnessTest) {
+	const (
+		chanAmt     = btcutil.Amount(100000)
+		paymentAmt  = 20000
+		baseFeeMSat = 33000
+	)
 
 	// We'll create the following topology first,
 	// Alice <--public:100k--> Bob <--private:100k--> Carol
-	const chanAmt = btcutil.Amount(100000)
+	alice, bob := ht.Alice, ht.Bob
 
 	// Open a channel with 100k satoshis between Alice and Bob.
-	chanPointAliceBob := openChannelAndAssert(
-		t, net, net.Alice, net.Bob,
-		lntest.OpenChannelParams{
+	chanPointAliceBob := ht.OpenChannel(
+		alice, bob, lntemp.OpenChannelParams{
 			Amt: chanAmt,
 		},
 	)
-	defer closeChannelAndAssert(t, net, net.Alice, chanPointAliceBob, false)
-
-	// Get Alice's funding point.
-	aliceChanTXID, err := lnrpc.GetChanPointFundingTxid(chanPointAliceBob)
-	require.NoError(t.t, err, "unable to get txid")
-	aliceFundPoint := wire.OutPoint{
-		Hash:  *aliceChanTXID,
-		Index: chanPointAliceBob.OutputIndex,
-	}
 
 	// Create a new node Carol.
-	carol := net.NewNode(t.t, "Carol", nil)
-	defer shutdownAndAssert(net, t, carol)
+	carol := ht.NewNode("Carol", nil)
 
 	// Connect Carol to Bob.
-	net.ConnectNodes(t.t, carol, net.Bob)
+	ht.ConnectNodes(carol, bob)
 
 	// Open a channel with 100k satoshis between Bob and Carol.
-	chanPointBobCarol := openChannelAndAssert(
-		t, net, net.Bob, carol,
-		lntest.OpenChannelParams{
+	chanPointBobCarol := ht.OpenChannel(
+		bob, carol, lntemp.OpenChannelParams{
 			Amt:     chanAmt,
 			Private: true,
 		},
 	)
-	defer closeChannelAndAssert(t, net, net.Bob, chanPointBobCarol, false)
 
 	// Carol should be aware of the channel between Alice and Bob.
-	err = carol.WaitForNetworkChannelOpen(chanPointAliceBob)
-	require.NoError(t.t, err)
-
-	// Get Bob's funding point.
-	bobChanTXID, err := lnrpc.GetChanPointFundingTxid(chanPointBobCarol)
-	require.NoError(t.t, err, "unable to get txid")
-	bobFundPoint := wire.OutPoint{
-		Hash:  *bobChanTXID,
-		Index: chanPointBobCarol.OutputIndex,
-	}
+	ht.AssertTopologyChannelOpen(carol, chanPointAliceBob)
 
 	// We should have the following topology now,
 	// Alice <--public:100k--> Bob <--private:100k--> Carol
 	//
 	// Now we will create an invoice for Carol.
-	const paymentAmt = 20000
 	invoice := &lnrpc.Invoice{
 		Memo:    "routing hints",
 		Value:   paymentAmt,
 		Private: true,
 	}
-	ctxt, _ := context.WithTimeout(ctxb, defaultTimeout)
-	resp, err := carol.AddInvoice(ctxt, invoice)
-	require.NoError(t.t, err, "unable to create invoice for carol")
+	resp := carol.RPC.AddInvoice(invoice)
 
 	// Bob now updates the channel edge policy for the private channel.
-	const (
-		baseFeeMSat = 33000
-	)
 	timeLockDelta := uint32(chainreg.DefaultBitcoinTimeLockDelta)
 	updateFeeReq := &lnrpc.PolicyUpdateRequest{
 		BaseFeeMsat:   baseFeeMSat,
@@ -754,58 +726,46 @@ func testUpdateChannelPolicyForPrivateChannel(net *lntest.NetworkHarness,
 			ChanPoint: chanPointBobCarol,
 		},
 	}
-	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
-	_, err = net.Bob.UpdateChannelPolicy(ctxt, updateFeeReq)
-	require.NoError(t.t, err, "unable to update chan policy")
+	bob.RPC.UpdateChannelPolicy(updateFeeReq)
 
 	// Alice pays the invoices. She will use the updated baseFeeMSat in the
 	// payment
-	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
 	payReqs := []string{resp.PaymentRequest}
-	require.NoError(t.t,
-		completePaymentRequests(
-			net.Alice, net.Alice.RouterClient, payReqs, true,
-		), "unable to send payment",
-	)
+	ht.CompletePaymentRequests(alice, payReqs)
 
 	// Check that Alice did make the payment with two HTLCs, one failed and
 	// one succeeded.
-	ctxt, _ = context.WithTimeout(ctxt, defaultTimeout)
-	paymentsResp, err := net.Alice.ListPayments(
-		ctxt, &lnrpc.ListPaymentsRequest{},
-	)
-	require.NoError(t.t, err, "failed to obtain payments for Alice")
-	require.Equal(t.t, 1, len(paymentsResp.Payments), "expected 1 payment")
+	payment := ht.AssertNumPayments(alice, 1)[0]
 
-	htlcs := paymentsResp.Payments[0].Htlcs
-	require.Equal(t.t, 2, len(htlcs), "expected to have 2 HTLCs")
-	require.Equal(
-		t.t, lnrpc.HTLCAttempt_FAILED, htlcs[0].Status,
-		"the first HTLC attempt should fail",
-	)
-	require.Equal(
-		t.t, lnrpc.HTLCAttempt_SUCCEEDED, htlcs[1].Status,
-		"the second HTLC attempt should succeed",
-	)
+	htlcs := payment.Htlcs
+	require.Equal(ht, 2, len(htlcs), "expected to have 2 HTLCs")
+	require.Equal(ht, lnrpc.HTLCAttempt_FAILED, htlcs[0].Status,
+		"the first HTLC attempt should fail")
+	require.Equal(ht, lnrpc.HTLCAttempt_SUCCEEDED, htlcs[1].Status,
+		"the second HTLC attempt should succeed")
 
 	// Carol should have received 20k satoshis from Bob.
-	assertAmountPaid(t, "Carol(remote) [<=private] Bob(local)",
-		carol, bobFundPoint, 0, paymentAmt)
+	ht.AssertAmountPaid("Carol(remote) [<=private] Bob(local)",
+		carol, chanPointBobCarol, 0, paymentAmt)
 
 	// Bob should have sent 20k satoshis to Carol.
-	assertAmountPaid(t, "Bob(local) [private=>] Carol(remote)",
-		net.Bob, bobFundPoint, paymentAmt, 0)
+	ht.AssertAmountPaid("Bob(local) [private=>] Carol(remote)",
+		bob, chanPointBobCarol, paymentAmt, 0)
 
 	// Calculate the amount in satoshis.
 	amtExpected := int64(paymentAmt + baseFeeMSat/1000)
 
 	// Bob should have received 20k satoshis + fee from Alice.
-	assertAmountPaid(t, "Bob(remote) <= Alice(local)",
-		net.Bob, aliceFundPoint, 0, amtExpected)
+	ht.AssertAmountPaid("Bob(remote) <= Alice(local)",
+		bob, chanPointAliceBob, 0, amtExpected)
 
 	// Alice should have sent 20k satoshis + fee to Bob.
-	assertAmountPaid(t, "Alice(local) => Bob(remote)",
-		net.Alice, aliceFundPoint, amtExpected, 0)
+	ht.AssertAmountPaid("Alice(local) => Bob(remote)",
+		alice, chanPointAliceBob, amtExpected, 0)
+
+	// Finally, close the channels.
+	ht.CloseChannel(alice, chanPointAliceBob)
+	ht.CloseChannel(bob, chanPointBobCarol)
 }
 
 // testUpdateChannelPolicyFeeRateAccuracy tests that updating the channel policy

--- a/lntest/itest/lnd_channel_policy_test.go
+++ b/lntest/itest/lnd_channel_policy_test.go
@@ -1,7 +1,6 @@
 package itest
 
 import (
-	"context"
 	"fmt"
 	"math"
 	"time"
@@ -771,24 +770,21 @@ func testUpdateChannelPolicyForPrivateChannel(ht *lntemp.HarnessTest) {
 // testUpdateChannelPolicyFeeRateAccuracy tests that updating the channel policy
 // rounds fee rate values correctly as well as setting fee rate with ppm works
 // as expected.
-func testUpdateChannelPolicyFeeRateAccuracy(net *lntest.NetworkHarness,
-	t *harnessTest) {
-
+func testUpdateChannelPolicyFeeRateAccuracy(ht *lntemp.HarnessTest) {
 	chanAmt := funding.MaxBtcFundingAmount
 	pushAmt := chanAmt / 2
 
 	// Create a channel Alice -> Bob.
-	chanPoint := openChannelAndAssert(
-		t, net, net.Alice, net.Bob,
-		lntest.OpenChannelParams{
+	alice, bob := ht.Alice, ht.Bob
+	chanPoint := ht.OpenChannel(
+		alice, bob, lntemp.OpenChannelParams{
 			Amt:     chanAmt,
 			PushAmt: pushAmt,
 		},
 	)
-	defer closeChannelAndAssert(t, net, net.Alice, chanPoint, false)
 
 	// Nodes that we need to make sure receive the channel updates.
-	nodes := []*lntest.HarnessNode{net.Alice, net.Bob}
+	nodes := []*node.HarnessNode{alice, bob}
 
 	baseFee := int64(1500)
 	timeLockDelta := uint32(66)
@@ -823,17 +819,10 @@ func testUpdateChannelPolicyFeeRateAccuracy(net *lntest.NetworkHarness,
 			ChanPoint: chanPoint,
 		},
 	}
-
-	ctxb := context.Background()
-	ctxt, _ := context.WithTimeout(ctxb, defaultTimeout)
-	if _, err := net.Alice.UpdateChannelPolicy(ctxt, req); err != nil {
-		t.Fatalf("unable to get alice's balance: %v", err)
-	}
+	alice.RPC.UpdateChannelPolicy(req)
 
 	// Make sure that both Alice and Bob sees the same policy after update.
-	assertPolicyUpdate(
-		t, nodes, net.Alice.PubKeyStr, expectedPolicy, chanPoint,
-	)
+	assertNodesPolicyUpdate(ht, nodes, alice, expectedPolicy, chanPoint)
 
 	// Now use the new PPM feerate field and make sure that the feerate is
 	// correctly set.
@@ -842,15 +831,12 @@ func testUpdateChannelPolicyFeeRateAccuracy(net *lntest.NetworkHarness,
 	req.FeeRatePpm = feeRatePPM
 	expectedPolicy.FeeRateMilliMsat = int64(feeRatePPM)
 
-	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
-	if _, err := net.Alice.UpdateChannelPolicy(ctxt, req); err != nil {
-		t.Fatalf("unable to get alice's balance: %v", err)
-	}
+	alice.RPC.UpdateChannelPolicy(req)
 
 	// Make sure that both Alice and Bob sees the same policy after update.
-	assertPolicyUpdate(
-		t, nodes, net.Alice.PubKeyStr, expectedPolicy, chanPoint,
-	)
+	assertNodesPolicyUpdate(ht, nodes, alice, expectedPolicy, chanPoint)
+
+	ht.CloseChannel(alice, chanPoint)
 }
 
 // assertNodesPolicyUpdate checks that a given policy update has been received

--- a/lntest/itest/lnd_funding_test.go
+++ b/lntest/itest/lnd_funding_test.go
@@ -237,7 +237,7 @@ func testUnconfirmedChannelFunding(ht *lntemp.HarnessTest) {
 	// as she doesn't have any other funds since it's a new node.
 	ht.ConnectNodes(carol, alice)
 
-	chanOpenUpdate := ht.OpenChannelAssertPending(
+	chanOpenUpdate := ht.OpenChannelAssertStream(
 		carol, alice, lntemp.OpenChannelParams{
 			Amt:              chanAmt,
 			PushAmt:          pushAmt,
@@ -391,7 +391,7 @@ func testChannelFundingInputTypes(ht *lntemp.HarnessTest) {
 		// We'll send her some confirmed funds.
 		funder(chanAmt*2, carol)
 
-		chanOpenUpdate := ht.OpenChannelAssertPending(
+		chanOpenUpdate := ht.OpenChannelAssertStream(
 			carol, alice, lntemp.OpenChannelParams{
 				Amt: chanAmt,
 			},
@@ -572,7 +572,7 @@ func testExternalFundingChanPoint(ht *lntemp.HarnessTest) {
 // representation of channels if the system is restarted or disconnected.
 // testFundingPersistence mirrors testBasicChannelFunding, but adds restarts
 // and checks for the state of channels with unconfirmed funding transactions.
-func testChannelFundingPersistence(net *lntest.NetworkHarness, t *harnessTest) {
+func testChannelFundingPersistence(ht *lntemp.HarnessTest) {
 	chanAmt := funding.MaxBtcFundingAmount
 	pushAmt := btcutil.Amount(0)
 
@@ -580,140 +580,102 @@ func testChannelFundingPersistence(net *lntest.NetworkHarness, t *harnessTest) {
 	// confirmation before it's open, with the current set of defaults,
 	// we'll need to create a new node instance.
 	const numConfs = 5
-	carolArgs := []string{fmt.Sprintf("--bitcoin.defaultchanconfs=%v", numConfs)}
-	carol := net.NewNode(t.t, "Carol", carolArgs)
+	carolArgs := []string{
+		fmt.Sprintf("--bitcoin.defaultchanconfs=%v", numConfs),
+	}
+	carol := ht.NewNode("Carol", carolArgs)
 
-	// Clean up carol's node when the test finishes.
-	defer shutdownAndAssert(net, t, carol)
-
-	net.ConnectNodes(t.t, net.Alice, carol)
+	alice := ht.Alice
+	ht.ConnectNodes(alice, carol)
 
 	// Create a new channel that requires 5 confs before it's considered
 	// open, then broadcast the funding transaction
-	pendingUpdate, err := net.OpenPendingChannel(
-		net.Alice, carol, chanAmt, pushAmt,
-	)
-	if err != nil {
-		t.Fatalf("unable to open channel: %v", err)
+	param := lntemp.OpenChannelParams{
+		Amt:     chanAmt,
+		PushAmt: pushAmt,
 	}
+	update := ht.OpenChannelAssertPending(alice, carol, param)
 
 	// At this point, the channel's funding transaction will have been
 	// broadcast, but not confirmed. Alice and Bob's nodes should reflect
 	// this when queried via RPC.
-	assertNumOpenChannelsPending(t, net.Alice, carol, 1)
+	ht.AssertNumPendingOpenChannels(alice, 1)
+	ht.AssertNumPendingOpenChannels(carol, 1)
 
 	// Restart both nodes to test that the appropriate state has been
 	// persisted and that both nodes recover gracefully.
-	if err := net.RestartNode(net.Alice, nil); err != nil {
-		t.Fatalf("Node restart failed: %v", err)
-	}
-	if err := net.RestartNode(carol, nil); err != nil {
-		t.Fatalf("Node restart failed: %v", err)
-	}
+	ht.RestartNode(alice)
+	ht.RestartNode(carol)
 
-	fundingTxID, err := chainhash.NewHash(pendingUpdate.Txid)
-	if err != nil {
-		t.Fatalf("unable to convert funding txid into chainhash.Hash:"+
-			" %v", err)
-	}
-	fundingTxStr := fundingTxID.String()
+	fundingTxID, err := chainhash.NewHash(update.Txid)
+	require.NoError(ht, err, "unable to convert funding txid "+
+		"into chainhash.Hash")
 
 	// Mine a block, then wait for Alice's node to notify us that the
 	// channel has been opened. The funding transaction should be found
 	// within the newly mined block.
-	block := mineBlocks(t, net, 1, 1)[0]
-	assertTxInBlock(t, block, fundingTxID)
+	block := ht.MineBlocksAndAssertNumTxes(1, 1)[0]
+	ht.Miner.AssertTxInBlock(block, fundingTxID)
 
 	// Get the height that our transaction confirmed at.
-	_, height, err := net.Miner.Client.GetBestBlock()
-	require.NoError(t.t, err, "could not get best block")
+	_, height := ht.Miner.GetBestBlock()
 
 	// Restart both nodes to test that the appropriate state has been
 	// persisted and that both nodes recover gracefully.
-	if err := net.RestartNode(net.Alice, nil); err != nil {
-		t.Fatalf("Node restart failed: %v", err)
-	}
-	if err := net.RestartNode(carol, nil); err != nil {
-		t.Fatalf("Node restart failed: %v", err)
-	}
+	ht.RestartNode(alice)
+	ht.RestartNode(carol)
 
 	// The following block ensures that after both nodes have restarted,
 	// they have reconnected before the execution of the next test.
-	net.EnsureConnected(t.t, net.Alice, carol)
+	ht.EnsureConnected(alice, carol)
 
 	// Next, mine enough blocks s.t the channel will open with a single
 	// additional block mined.
-	if _, err := net.Miner.Client.Generate(3); err != nil {
-		t.Fatalf("unable to mine blocks: %v", err)
-	}
+	ht.MineBlocks(3)
 
 	// Assert that our wallet has our opening transaction with a label
 	// that does not have a channel ID set yet, because we have not
 	// reached our required confirmations.
-	tx := findTxAtHeight(t, height, fundingTxStr, net.Alice)
+	tx := ht.AssertTxAtHeight(alice, height, fundingTxID)
 
 	// At this stage, we expect the transaction to be labelled, but not with
 	// our channel ID because our transaction has not yet confirmed.
 	label := labels.MakeLabel(labels.LabelTypeChannelOpen, nil)
-	require.Equal(t.t, label, tx.Label, "open channel label wrong")
+	require.Equal(ht, label, tx.Label, "open channel label wrong")
 
 	// Both nodes should still show a single channel as pending.
-	time.Sleep(time.Second * 1)
-	assertNumOpenChannelsPending(t, net.Alice, carol, 1)
+	ht.AssertNumPendingOpenChannels(alice, 1)
+	ht.AssertNumPendingOpenChannels(carol, 1)
 
 	// Finally, mine the last block which should mark the channel as open.
-	if _, err := net.Miner.Client.Generate(1); err != nil {
-		t.Fatalf("unable to mine blocks: %v", err)
-	}
+	ht.MineBlocks(1)
 
 	// At this point, the channel should be fully opened and there should
 	// be no pending channels remaining for either node.
-	time.Sleep(time.Second * 1)
-	assertNumOpenChannelsPending(t, net.Alice, carol, 0)
+	ht.AssertNumPendingOpenChannels(alice, 0)
+	ht.AssertNumPendingOpenChannels(carol, 0)
 
 	// The channel should be listed in the peer information returned by
 	// both peers.
-	outPoint := wire.OutPoint{
-		Hash:  *fundingTxID,
-		Index: pendingUpdate.OutputIndex,
-	}
+	chanPoint := lntemp.ChanPointFromPendingUpdate(update)
 
 	// Re-lookup our transaction in the block that it confirmed in.
-	tx = findTxAtHeight(t, height, fundingTxStr, net.Alice)
+	tx = ht.AssertTxAtHeight(alice, height, fundingTxID)
+
+	// Check both nodes to ensure that the channel is ready for operation.
+	chanAlice := ht.AssertChannelExists(alice, chanPoint)
+	ht.AssertChannelExists(carol, chanPoint)
 
 	// Create an additional check for our channel assertion that will
 	// check that our label is as expected.
-	check := func(channel *lnrpc.Channel) {
-		shortChanID := lnwire.NewShortChanIDFromInt(
-			channel.ChanId,
-		)
-
-		label := labels.MakeLabel(
-			labels.LabelTypeChannelOpen, &shortChanID,
-		)
-		require.Equal(t.t, label, tx.Label,
-			"open channel label not updated")
-	}
-
-	// Check both nodes to ensure that the channel is ready for operation.
-	err = net.AssertChannelExists(net.Alice, &outPoint, check)
-	if err != nil {
-		t.Fatalf("unable to assert channel existence: %v", err)
-	}
-	if err := net.AssertChannelExists(carol, &outPoint); err != nil {
-		t.Fatalf("unable to assert channel existence: %v", err)
-	}
+	shortChanID := lnwire.NewShortChanIDFromInt(chanAlice.ChanId)
+	label = labels.MakeLabel(labels.LabelTypeChannelOpen, &shortChanID)
+	require.Equal(ht, label, tx.Label, "open channel label not updated")
 
 	// Finally, immediately close the channel. This function will also
 	// block until the channel is closed and will additionally assert the
 	// relevant channel closing post conditions.
-	chanPoint := &lnrpc.ChannelPoint{
-		FundingTxid: &lnrpc.ChannelPoint_FundingTxidBytes{
-			FundingTxidBytes: pendingUpdate.Txid,
-		},
-		OutputIndex: pendingUpdate.OutputIndex,
-	}
-	closeChannelAndAssert(t, net, net.Alice, chanPoint, false)
+	ht.CloseChannel(alice, chanPoint)
 }
 
 // testBatchChanFunding makes sure multiple channels can be opened in one batch

--- a/lntest/itest/lnd_misc_test.go
+++ b/lntest/itest/lnd_misc_test.go
@@ -53,7 +53,7 @@ func testDisconnectingTargetPeer(ht *lntemp.HarnessTest) {
 		Amt:     chanAmt,
 		PushAmt: pushAmt,
 	}
-	stream := ht.OpenChannelAssertPending(alice, bob, p)
+	stream := ht.OpenChannelAssertStream(alice, bob, p)
 
 	// At this point, the channel's funding transaction will have been
 	// broadcast, but not confirmed. Alice and Bob's nodes should reflect
@@ -361,7 +361,7 @@ func testMaxPendingChannels(ht *lntemp.HarnessTest) {
 		[]lnrpc.Lightning_OpenChannelClient, maxPendingChannels,
 	)
 	for i := 0; i < maxPendingChannels; i++ {
-		stream := ht.OpenChannelAssertPending(
+		stream := ht.OpenChannelAssertStream(
 			alice, carol, lntemp.OpenChannelParams{
 				Amt: amount,
 			},
@@ -823,7 +823,7 @@ func testSweepAllCoins(ht *lntemp.HarnessTest) {
 	assertTxLabel := func(targetTx, label string) error {
 		// List all transactions relevant to our wallet, and find the
 		// tx so that we can check the correct label has been set.
-		txResp := ainz.RPC.GetTransactions()
+		txResp := ainz.RPC.GetTransactions(nil)
 
 		var target *lnrpc.Transaction
 

--- a/lntest/itest/lnd_payment_test.go
+++ b/lntest/itest/lnd_payment_test.go
@@ -511,182 +511,86 @@ func testBidirectionalAsyncPayments(net *lntest.NetworkHarness, t *harnessTest) 
 	closeChannelAndAssert(t, net, net.Alice, chanPoint, false)
 }
 
-func testInvoiceSubscriptions(net *lntest.NetworkHarness, t *harnessTest) {
-	ctxb := context.Background()
-
+func testInvoiceSubscriptions(ht *lntemp.HarnessTest) {
 	const chanAmt = btcutil.Amount(500000)
 
-	// Open a channel with 500k satoshis between Alice and Bob with Alice
-	// being the sole funder of the channel.
-	chanPoint := openChannelAndAssert(
-		t, net, net.Alice, net.Bob,
-		lntest.OpenChannelParams{
-			Amt: chanAmt,
-		},
-	)
-
-	// Next create a new invoice for Bob requesting 1k satoshis.
-	// TODO(roasbeef): make global list of invoices for each node to re-use
-	// and avoid collisions
-	const paymentAmt = 1000
-	invoice := &lnrpc.Invoice{
-		Memo:      "testing",
-		RPreimage: makeFakePayHash(t),
-		Value:     paymentAmt,
-	}
-	ctxt, _ := context.WithTimeout(ctxb, defaultTimeout)
-	invoiceResp, err := net.Bob.AddInvoice(ctxt, invoice)
-	if err != nil {
-		t.Fatalf("unable to add invoice: %v", err)
-	}
-	lastAddIndex := invoiceResp.AddIndex
+	alice, bob := ht.Alice, ht.Bob
 
 	// Create a new invoice subscription client for Bob, the notification
 	// should be dispatched shortly below.
 	req := &lnrpc.InvoiceSubscription{}
-	ctx, cancelInvoiceSubscription := context.WithCancel(ctxb)
-	bobInvoiceSubscription, err := net.Bob.SubscribeInvoices(ctx, req)
-	if err != nil {
-		t.Fatalf("unable to subscribe to bob's invoice updates: %v", err)
+	bobInvoiceSubscription := bob.RPC.SubscribeInvoices(req)
+
+	// Open a channel with 500k satoshis between Alice and Bob with Alice
+	// being the sole funder of the channel.
+	chanPoint := ht.OpenChannel(
+		alice, bob, lntemp.OpenChannelParams{Amt: chanAmt},
+	)
+
+	// Next create a new invoice for Bob requesting 1k satoshis.
+	const paymentAmt = 1000
+	invoice := &lnrpc.Invoice{
+		Memo:      "testing",
+		RPreimage: ht.Random32Bytes(),
+		Value:     paymentAmt,
 	}
+	invoiceResp := bob.RPC.AddInvoice(invoice)
+	lastAddIndex := invoiceResp.AddIndex
 
-	var settleIndex uint64
-	quit := make(chan struct{})
-	updateSent := make(chan struct{})
-	go func() {
-		invoiceUpdate, err := bobInvoiceSubscription.Recv()
-		select {
-		case <-quit:
-			// Received cancellation
-			return
-		default:
-		}
-
-		if err != nil {
-			t.Fatalf("unable to recv invoice update: %v", err)
-		}
-
-		// The invoice update should exactly match the invoice created
-		// above, but should now be settled and have SettleDate
-		if !invoiceUpdate.Settled { // nolint:staticcheck
-			t.Fatalf("invoice not settled but should be")
-		}
-		if invoiceUpdate.SettleDate == 0 {
-			t.Fatalf("invoice should have non zero settle date, but doesn't")
-		}
-
-		if !bytes.Equal(invoiceUpdate.RPreimage, invoice.RPreimage) {
-			t.Fatalf("payment preimages don't match: expected %v, got %v",
-				invoice.RPreimage, invoiceUpdate.RPreimage)
-		}
-
-		if invoiceUpdate.SettleIndex == 0 {
-			t.Fatalf("invoice should have settle index")
-		}
-
-		settleIndex = invoiceUpdate.SettleIndex
-
-		close(updateSent)
-	}()
-
-	// Wait for the channel to be recognized by both Alice and Bob before
-	// continuing the rest of the test.
-	err = net.Alice.WaitForNetworkChannelOpen(chanPoint)
-	if err != nil {
-		// TODO(roasbeef): will need to make num blocks to advertise a
-		// node param
-		close(quit)
-		t.Fatalf("channel not seen by alice before timeout: %v", err)
-	}
+	// With the above invoice added, we should receive an update event.
+	invoiceUpdate := ht.ReceiveInvoiceUpdate(bobInvoiceSubscription)
+	require.NotEqual(ht, lnrpc.Invoice_SETTLED, invoiceUpdate.State,
+		"invoice should not be settled")
 
 	// With the assertion above set up, send a payment from Alice to Bob
 	// which should finalize and settle the invoice.
-	sendReq := &routerrpc.SendPaymentRequest{
-		PaymentRequest: invoiceResp.PaymentRequest,
-		TimeoutSeconds: 60,
-		FeeLimitMsat:   noFeeLimitMsat,
-	}
-	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
-	stream, err := net.Alice.RouterClient.SendPaymentV2(ctxt, sendReq)
-	if err != nil {
-		close(quit)
-		t.Fatalf("unable to send payment: %v", err)
-	}
-	result, err := getPaymentResult(stream)
-	if err != nil {
-		close(quit)
-		t.Fatalf("cannot get payment result: %v", err)
-	}
-	if result.Status != lnrpc.Payment_SUCCEEDED {
-		close(quit)
-		t.Fatalf("error when attempting recv: %v", result.Status)
-	}
+	ht.CompletePaymentRequests(alice, []string{invoiceResp.PaymentRequest})
 
-	select {
-	case <-time.After(time.Second * 10):
-		close(quit)
-		t.Fatalf("update not sent after 10 seconds")
-	case <-updateSent: // Fall through on success
-	}
-
-	// With the base case working, we'll now cancel Bob's current
-	// subscription in order to exercise the backlog fill behavior.
-	cancelInvoiceSubscription()
+	// The invoice update should exactly match the invoice created
+	// above, but should now be settled and have SettleDate
+	invoiceUpdate = ht.ReceiveInvoiceUpdate(bobInvoiceSubscription)
+	require.Equal(ht, lnrpc.Invoice_SETTLED, invoiceUpdate.State,
+		"invoice not settled but should be")
+	require.NotZero(ht, invoiceUpdate.SettleDate,
+		"invoice should have non zero settle date, but doesn't")
+	require.Equal(ht, invoice.RPreimage, invoiceUpdate.RPreimage,
+		"payment preimages don't match")
+	require.NotZero(ht, invoiceUpdate.SettleIndex,
+		"invoice should have settle index")
+	settleIndex := invoiceUpdate.SettleIndex
 
 	// We'll now add 3 more invoices to Bob's invoice registry.
 	const numInvoices = 3
-	payReqs, _, newInvoices, err := createPayReqs(
-		net.Bob, paymentAmt, numInvoices,
+	payReqs, _, newInvoices := ht.CreatePayReqs(
+		bob, paymentAmt, numInvoices,
 	)
-	if err != nil {
-		t.Fatalf("unable to create pay reqs: %v", err)
-	}
 
 	// Now that the set of invoices has been added, we'll re-register for
 	// streaming invoice notifications for Bob, this time specifying the
 	// add invoice of the last prior invoice.
-	req = &lnrpc.InvoiceSubscription{
-		AddIndex: lastAddIndex,
-	}
-	ctx, cancelInvoiceSubscription = context.WithCancel(ctxb)
-	bobInvoiceSubscription, err = net.Bob.SubscribeInvoices(ctx, req)
-	if err != nil {
-		t.Fatalf("unable to subscribe to bob's invoice updates: %v", err)
-	}
+	req = &lnrpc.InvoiceSubscription{AddIndex: lastAddIndex}
+	bobInvoiceSubscription = bob.RPC.SubscribeInvoices(req)
 
 	// Since we specified a value of the prior add index above, we should
 	// now immediately get the invoices we just added as we should get the
 	// backlog of notifications.
 	for i := 0; i < numInvoices; i++ {
-		invoiceUpdate, err := bobInvoiceSubscription.Recv()
-		if err != nil {
-			t.Fatalf("unable to receive subscription")
-		}
+		invoiceUpdate := ht.ReceiveInvoiceUpdate(bobInvoiceSubscription)
 
 		// We should now get the ith invoice we added, as they should
 		// be returned in order.
-		if invoiceUpdate.Settled { // nolint:staticcheck
-			t.Fatalf("should have only received add events")
-		}
+		require.NotEqual(ht, lnrpc.Invoice_SETTLED, invoiceUpdate.State,
+			"should have only received add events")
+
 		originalInvoice := newInvoices[i]
 		rHash := sha256.Sum256(originalInvoice.RPreimage)
-		if !bytes.Equal(invoiceUpdate.RHash, rHash[:]) {
-			t.Fatalf("invoices have mismatched payment hashes: "+
-				"expected %x, got %x", rHash[:],
-				invoiceUpdate.RHash)
-		}
+		require.Equal(ht, rHash[:], invoiceUpdate.RHash,
+			"invoices have mismatched payment hashes")
 	}
-
-	cancelInvoiceSubscription()
 
 	// We'll now have Bob settle out the remainder of these invoices so we
 	// can test that all settled invoices are properly notified.
-	err = completePaymentRequests(
-		net.Alice, net.Alice.RouterClient, payReqs, true,
-	)
-	if err != nil {
-		t.Fatalf("unable to send payment: %v", err)
-	}
+	ht.CompletePaymentRequests(alice, payReqs)
 
 	// With the set of invoices paid, we'll now cancel the old
 	// subscription, and create a new one for Bob, this time using the
@@ -694,13 +598,7 @@ func testInvoiceSubscriptions(net *lntest.NetworkHarness, t *harnessTest) {
 	req = &lnrpc.InvoiceSubscription{
 		SettleIndex: settleIndex,
 	}
-	ctx, cancelInvoiceSubscription = context.WithCancel(ctxb)
-	bobInvoiceSubscription, err = net.Bob.SubscribeInvoices(ctx, req)
-	if err != nil {
-		t.Fatalf("unable to subscribe to bob's invoice updates: %v", err)
-	}
-
-	defer cancelInvoiceSubscription()
+	bobInvoiceSubscription = bob.RPC.SubscribeInvoices(req)
 
 	// As we specified the index of the past settle index, we should now
 	// receive notifications for the three HTLCs that we just settled. As
@@ -712,30 +610,31 @@ func testInvoiceSubscriptions(net *lntest.NetworkHarness, t *harnessTest) {
 		settledInvoices[rHash] = struct{}{}
 	}
 	for i := 0; i < numInvoices; i++ {
-		invoiceUpdate, err := bobInvoiceSubscription.Recv()
-		if err != nil {
-			t.Fatalf("unable to receive subscription")
-		}
+		invoiceUpdate := ht.ReceiveInvoiceUpdate(bobInvoiceSubscription)
 
 		// We should now get the ith invoice we added, as they should
 		// be returned in order.
-		if !invoiceUpdate.Settled { // nolint:staticcheck
-			t.Fatalf("should have only received settle events")
-		}
+		require.Equal(ht, lnrpc.Invoice_SETTLED, invoiceUpdate.State,
+			"should have only received settle events")
 
 		var rHash [32]byte
 		copy(rHash[:], invoiceUpdate.RHash)
-		if _, ok := settledInvoices[rHash]; !ok {
-			t.Fatalf("unknown invoice settled: %x", rHash)
-		}
+		require.Contains(ht, settledInvoices, rHash,
+			"unknown invoice settled")
 
 		delete(settledInvoices, rHash)
 	}
 
 	// At this point, all the invoices should be fully settled.
-	if len(settledInvoices) != 0 {
-		t.Fatalf("not all invoices settled")
-	}
+	require.Empty(ht, settledInvoices, "not all invoices settled")
 
-	closeChannelAndAssert(t, net, net.Alice, chanPoint, false)
+	// TODO(yy): remove the sleep once the following bug is fixed.
+	// When the invoice is reported settled, the commitment dance is not
+	// yet finished, which can cause an error when closing the channel,
+	// saying there's active HTLCs. We need to investigate this issue and
+	// reverse the order to, first finish the commitment dance, then report
+	// the invoice as settled.
+	time.Sleep(2 * time.Second)
+
+	ht.CloseChannel(alice, chanPoint)
 }

--- a/lntest/itest/lnd_test_list_on_test.go
+++ b/lntest/itest/lnd_test_list_on_test.go
@@ -171,10 +171,6 @@ var allTestCases = []*testCase{
 		test: testDeleteMacaroonID,
 	},
 	{
-		name: "immediate payment after channel opened",
-		test: testPaymentFollowingChannelOpen,
-	},
-	{
 		name: "psbt channel funding",
 		test: testPsbtChanFunding,
 	},

--- a/lntest/itest/lnd_test_list_on_test.go
+++ b/lntest/itest/lnd_test_list_on_test.go
@@ -65,10 +65,6 @@ var allTestCases = []*testCase{
 		test: testSingleHopInvoice,
 	},
 	{
-		name: "list channels",
-		test: testListChannels,
-	},
-	{
 		name: "test update node announcement rpc",
 		test: testUpdateNodeAnnouncement,
 	},

--- a/lntest/itest/lnd_test_list_on_test.go
+++ b/lntest/itest/lnd_test_list_on_test.go
@@ -127,10 +127,6 @@ var allTestCases = []*testCase{
 		test: testHoldInvoiceForceClose,
 	},
 	{
-		name: "commitment deadline",
-		test: testCommitmentTransactionDeadline,
-	},
-	{
 		name: "cpfp",
 		test: testCPFP,
 	},

--- a/lntest/itest/lnd_test_list_on_test.go
+++ b/lntest/itest/lnd_test_list_on_test.go
@@ -127,10 +127,6 @@ var allTestCases = []*testCase{
 		test: testRouteFeeCutoff,
 	},
 	{
-		name: "streaming channel backup update",
-		test: testChannelBackupUpdates,
-	},
-	{
 		name: "export channel backup",
 		test: testExportChannelBackup,
 	},

--- a/lntest/itest/lnd_test_list_on_test.go
+++ b/lntest/itest/lnd_test_list_on_test.go
@@ -180,10 +180,6 @@ var allTestCases = []*testCase{
 		test: testFailingChannel,
 	},
 	{
-		name: "garbage collect link nodes",
-		test: testGarbageCollectLinkNodes,
-	},
-	{
 		name: "abandonchannel",
 		test: testAbandonChannel,
 	},

--- a/lntest/itest/lnd_test_list_on_test.go
+++ b/lntest/itest/lnd_test_list_on_test.go
@@ -13,10 +13,6 @@ var allTestCases = []*testCase{
 		test: testChannelForceClosure,
 	},
 	{
-		name: "channel balance",
-		test: testChannelBalance,
-	},
-	{
 		name: "channel unsettled balance",
 		test: testChannelUnsettledBalance,
 	},

--- a/lntest/itest/lnd_test_list_on_test.go
+++ b/lntest/itest/lnd_test_list_on_test.go
@@ -25,10 +25,6 @@ var allTestCases = []*testCase{
 		test: testGraphTopologyNotifications,
 	},
 	{
-		name: "funding flow persistence",
-		test: testChannelFundingPersistence,
-	},
-	{
 		name: "channel force closure",
 		test: testChannelForceClosure,
 	},

--- a/lntest/itest/lnd_test_list_on_test.go
+++ b/lntest/itest/lnd_test_list_on_test.go
@@ -120,10 +120,6 @@ var allTestCases = []*testCase{
 		name: "multi-hop htlc error propagation",
 		test: testHtlcErrorPropagation,
 	},
-	{
-		name: "reject onward htlc",
-		test: testRejectHTLC,
-	},
 	// TODO(roasbeef): multi-path integration test
 	{
 		name: "node announcement",

--- a/lntest/itest/lnd_test_list_on_test.go
+++ b/lntest/itest/lnd_test_list_on_test.go
@@ -5,10 +5,6 @@ package itest
 
 var allTestCases = []*testCase{
 	{
-		name: "onchain fund recovery",
-		test: testOnchainFundRecovery,
-	},
-	{
 		name: "basic funding flow with all input types",
 		test: testChannelFundingInputTypes,
 	},

--- a/lntest/itest/lnd_test_list_on_test.go
+++ b/lntest/itest/lnd_test_list_on_test.go
@@ -5,10 +5,6 @@ package itest
 
 var allTestCases = []*testCase{
 	{
-		name: "list addresses",
-		test: testListAddresses,
-	},
-	{
 		name: "recovery info",
 		test: testGetRecoveryInfo,
 	},

--- a/lntest/itest/lnd_test_list_on_test.go
+++ b/lntest/itest/lnd_test_list_on_test.go
@@ -72,11 +72,6 @@ var allTestCases = []*testCase{
 		name: "multi-hop htlc error propagation",
 		test: testHtlcErrorPropagation,
 	},
-	// TODO(roasbeef): multi-path integration test
-	{
-		name: "node announcement",
-		test: testNodeAnnouncement,
-	},
 	{
 		name: "derive shared key",
 		test: testDeriveSharedKey,

--- a/lntest/itest/lnd_test_list_on_test.go
+++ b/lntest/itest/lnd_test_list_on_test.go
@@ -5,10 +5,6 @@ package itest
 
 var allTestCases = []*testCase{
 	{
-		name: "recovery info",
-		test: testGetRecoveryInfo,
-	},
-	{
 		name: "onchain fund recovery",
 		test: testOnchainFundRecovery,
 	},

--- a/lntest/itest/lnd_test_list_on_test.go
+++ b/lntest/itest/lnd_test_list_on_test.go
@@ -25,10 +25,6 @@ var allTestCases = []*testCase{
 		test: testSingleHopInvoice,
 	},
 	{
-		name: "test update node announcement rpc",
-		test: testUpdateNodeAnnouncement,
-	},
-	{
 		name: "list outgoing payments",
 		test: testListPayments,
 	},

--- a/lntest/itest/lnd_test_list_on_test.go
+++ b/lntest/itest/lnd_test_list_on_test.go
@@ -260,10 +260,6 @@ var allTestCases = []*testCase{
 		test: testMaxChannelSize,
 	},
 	{
-		name: "connection timeout",
-		test: testNetworkConnectionTimeout,
-	},
-	{
 		name: "stateless init",
 		test: testStatelessInit,
 	},

--- a/lntest/itest/lnd_test_list_on_test.go
+++ b/lntest/itest/lnd_test_list_on_test.go
@@ -5,10 +5,6 @@ package itest
 
 var allTestCases = []*testCase{
 	{
-		name: "unconfirmed channel funding",
-		test: testUnconfirmedChannelFunding,
-	},
-	{
 		name: "update channel policy",
 		test: testUpdateChannelPolicy,
 	},

--- a/lntest/itest/lnd_test_list_on_test.go
+++ b/lntest/itest/lnd_test_list_on_test.go
@@ -5,10 +5,6 @@ package itest
 
 var allTestCases = []*testCase{
 	{
-		name: "sweep coins",
-		test: testSweepAllCoins,
-	},
-	{
 		name: "list addresses",
 		test: testListAddresses,
 	},

--- a/lntest/itest/lnd_test_list_on_test.go
+++ b/lntest/itest/lnd_test_list_on_test.go
@@ -5,10 +5,6 @@ package itest
 
 var allTestCases = []*testCase{
 	{
-		name: "basic funding flow with all input types",
-		test: testChannelFundingInputTypes,
-	},
-	{
 		name: "unconfirmed channel funding",
 		test: testUnconfirmedChannelFunding,
 	},

--- a/lntest/itest/lnd_test_list_on_test.go
+++ b/lntest/itest/lnd_test_list_on_test.go
@@ -168,10 +168,6 @@ var allTestCases = []*testCase{
 		test: testFailingChannel,
 	},
 	{
-		name: "abandonchannel",
-		test: testAbandonChannel,
-	},
-	{
 		name: "revoked uncooperative close retribution zero value remote output",
 		test: testRevokedCloseRetributionZeroValueRemoteOutput,
 	},

--- a/lntest/itest/lnd_test_list_on_test.go
+++ b/lntest/itest/lnd_test_list_on_test.go
@@ -91,10 +91,6 @@ var allTestCases = []*testCase{
 		test: testRevokedCloseRetribution,
 	},
 	{
-		name: "failing link",
-		test: testFailingChannel,
-	},
-	{
 		name: "revoked uncooperative close retribution zero value remote output",
 		test: testRevokedCloseRetributionZeroValueRemoteOutput,
 	},

--- a/lntest/itest/lnd_test_list_on_test.go
+++ b/lntest/itest/lnd_test_list_on_test.go
@@ -37,10 +37,6 @@ var allTestCases = []*testCase{
 		test: testOpenChannelAfterReorg,
 	},
 	{
-		name: "disconnecting target peer",
-		test: testDisconnectingTargetPeer,
-	},
-	{
 		name: "reconnect after ip change",
 		test: testReconnectAfterIPChange,
 	},

--- a/lntest/itest/lnd_test_list_on_test.go
+++ b/lntest/itest/lnd_test_list_on_test.go
@@ -127,10 +127,6 @@ var allTestCases = []*testCase{
 		test: testRouteFeeCutoff,
 	},
 	{
-		name: "export channel backup",
-		test: testExportChannelBackup,
-	},
-	{
 		name: "hold invoice sender persistence",
 		test: testHoldInvoicePersistence,
 	},

--- a/lntest/itest/lnd_test_list_on_test.go
+++ b/lntest/itest/lnd_test_list_on_test.go
@@ -53,10 +53,6 @@ var allTestCases = []*testCase{
 		test: testSendToRouteErrorPropagation,
 	},
 	{
-		name: "unannounced channels",
-		test: testUnannouncedChannels,
-	},
-	{
 		name: "private channels",
 		test: testPrivateChannels,
 	},

--- a/lntest/itest/lnd_test_list_on_test.go
+++ b/lntest/itest/lnd_test_list_on_test.go
@@ -73,10 +73,6 @@ var allTestCases = []*testCase{
 		test: testListPayments,
 	},
 	{
-		name: "max pending channel",
-		test: testMaxPendingChannels,
-	},
-	{
 		name: "multi-hop payments",
 		test: testMultiHopPayments,
 	},

--- a/lntest/itest/lnd_test_list_on_test.go
+++ b/lntest/itest/lnd_test_list_on_test.go
@@ -126,10 +126,6 @@ var allTestCases = []*testCase{
 		test: testNodeAnnouncement,
 	},
 	{
-		name: "node sign verify",
-		test: testNodeSignVerify,
-	},
-	{
 		name: "derive shared key",
 		test: testDeriveSharedKey,
 	},

--- a/lntest/itest/lnd_test_list_on_test.go
+++ b/lntest/itest/lnd_test_list_on_test.go
@@ -25,10 +25,6 @@ var allTestCases = []*testCase{
 		test: testSingleHopInvoice,
 	},
 	{
-		name: "list outgoing payments",
-		test: testListPayments,
-	},
-	{
 		name: "multi-hop payments",
 		test: testMultiHopPayments,
 	},

--- a/lntest/itest/lnd_test_list_on_test.go
+++ b/lntest/itest/lnd_test_list_on_test.go
@@ -13,10 +13,6 @@ var allTestCases = []*testCase{
 		test: testChannelForceClosure,
 	},
 	{
-		name: "channel unsettled balance",
-		test: testChannelUnsettledBalance,
-	},
-	{
 		name: "single hop invoice",
 		test: testSingleHopInvoice,
 	},

--- a/lntest/itest/lnd_test_list_on_test.go
+++ b/lntest/itest/lnd_test_list_on_test.go
@@ -9,10 +9,6 @@ var allTestCases = []*testCase{
 		test: testOpenChannelAfterReorg,
 	},
 	{
-		name: "graph topology notifications",
-		test: testGraphTopologyNotifications,
-	},
-	{
 		name: "channel force closure",
 		test: testChannelForceClosure,
 	},

--- a/lntest/itest/lnd_test_list_on_test.go
+++ b/lntest/itest/lnd_test_list_on_test.go
@@ -57,10 +57,6 @@ var allTestCases = []*testCase{
 		test: testBasicChannelCreationAndUpdates,
 	},
 	{
-		name: "invoice update subscription",
-		test: testInvoiceSubscriptions,
-	},
-	{
 		name: "multi-hop htlc error propagation",
 		test: testHtlcErrorPropagation,
 	},

--- a/lntest/itest/lnd_test_list_on_test.go
+++ b/lntest/itest/lnd_test_list_on_test.go
@@ -228,10 +228,6 @@ var allTestCases = []*testCase{
 		test: testSignPsbt,
 	},
 	{
-		name: "batch channel funding",
-		test: testBatchChanFunding,
-	},
-	{
 		name: "psbt channel funding single step",
 		test: testPsbtChanFundingSingleStep,
 	},

--- a/lntest/itest/lnd_test_list_on_test.go
+++ b/lntest/itest/lnd_test_list_on_test.go
@@ -69,10 +69,6 @@ var allTestCases = []*testCase{
 		test: testPrivateChannels,
 	},
 	{
-		name: "private channel update policy",
-		test: testUpdateChannelPolicyForPrivateChannel,
-	},
-	{
 		name: "invoice routing hints",
 		test: testInvoiceRoutingHints,
 	},

--- a/lntest/itest/lnd_test_list_on_test.go
+++ b/lntest/itest/lnd_test_list_on_test.go
@@ -296,10 +296,6 @@ var allTestCases = []*testCase{
 		test: testTaproot,
 	},
 	{
-		name: "addpeer config",
-		test: testAddPeerConfig,
-	},
-	{
 		name: "resolution handoff",
 		test: testResHandoff,
 	},

--- a/lntest/itest/lnd_test_list_on_test.go
+++ b/lntest/itest/lnd_test_list_on_test.go
@@ -164,10 +164,6 @@ var allTestCases = []*testCase{
 		test: testRouteFeeCutoff,
 	},
 	{
-		name: "send update disable channel",
-		test: testSendUpdateDisableChannel,
-	},
-	{
 		name: "streaming channel backup update",
 		test: testChannelBackupUpdates,
 	},

--- a/lntest/itest/lnd_test_list_on_test.go
+++ b/lntest/itest/lnd_test_list_on_test.go
@@ -65,10 +65,6 @@ var allTestCases = []*testCase{
 		test: testSingleHopInvoice,
 	},
 	{
-		name: "sphinx replay persistence",
-		test: testSphinxReplayPersistence,
-	},
-	{
 		name: "list channels",
 		test: testListChannels,
 	},

--- a/lntest/itest/lnd_test_list_on_test.go
+++ b/lntest/itest/lnd_test_list_on_test.go
@@ -9,10 +9,6 @@ var allTestCases = []*testCase{
 		test: testOpenChannelAfterReorg,
 	},
 	{
-		name: "reconnect after ip change",
-		test: testReconnectAfterIPChange,
-	},
-	{
 		name: "graph topology notifications",
 		test: testGraphTopologyNotifications,
 	},

--- a/lntest/itest/lnd_test_list_on_test.go
+++ b/lntest/itest/lnd_test_list_on_test.go
@@ -5,10 +5,6 @@ package itest
 
 var allTestCases = []*testCase{
 	{
-		name: "update channel policy",
-		test: testUpdateChannelPolicy,
-	},
-	{
 		name: "update channel policy fee rate accuracy",
 		test: testUpdateChannelPolicyFeeRateAccuracy,
 	},

--- a/lntest/itest/lnd_test_list_on_test.go
+++ b/lntest/itest/lnd_test_list_on_test.go
@@ -9,10 +9,6 @@ var allTestCases = []*testCase{
 		test: testOpenChannelAfterReorg,
 	},
 	{
-		name: "channel force closure",
-		test: testChannelForceClosure,
-	},
-	{
 		name: "single hop invoice",
 		test: testSingleHopInvoice,
 	},

--- a/lntest/itest/lnd_test_list_on_test.go
+++ b/lntest/itest/lnd_test_list_on_test.go
@@ -5,10 +5,6 @@ package itest
 
 var allTestCases = []*testCase{
 	{
-		name: "update channel policy fee rate accuracy",
-		test: testUpdateChannelPolicyFeeRateAccuracy,
-	},
-	{
 		name: "open channel reorg test",
 		test: testOpenChannelAfterReorg,
 	},

--- a/lntest/itest/utils.go
+++ b/lntest/itest/utils.go
@@ -5,8 +5,6 @@ import (
 	"crypto/rand"
 	"fmt"
 	"io"
-	"strconv"
-	"strings"
 	"testing"
 	"time"
 
@@ -499,42 +497,6 @@ func getOutputIndex(t *harnessTest, miner *lntest.HarnessMiner,
 	require.Greater(t.t, p2trOutputIndex, -1)
 
 	return p2trOutputIndex
-}
-
-// parseDerivationPath parses a path in the form of m/x'/y'/z'/a/b into a slice
-// of [x, y, z, a, b], meaning that the apostrophe is ignored and 2^31 is _not_
-// added to the numbers.
-func parseDerivationPath(path string) ([]uint32, error) {
-	path = strings.TrimSpace(path)
-	if len(path) == 0 {
-		return nil, fmt.Errorf("path cannot be empty")
-	}
-	if !strings.HasPrefix(path, "m/") {
-		return nil, fmt.Errorf("path must start with m/")
-	}
-
-	// Just the root key, no path was provided. This is valid but not useful
-	// in most cases.
-	rest := strings.ReplaceAll(path, "m/", "")
-	if rest == "" {
-		return []uint32{}, nil
-	}
-
-	parts := strings.Split(rest, "/")
-	indices := make([]uint32, len(parts))
-	for i := 0; i < len(parts); i++ {
-		part := parts[i]
-		if strings.Contains(parts[i], "'") {
-			part = strings.TrimRight(parts[i], "'")
-		}
-		parsed, err := strconv.ParseInt(part, 10, 32)
-		if err != nil {
-			return nil, fmt.Errorf("could not parse part \"%s\": "+
-				"%v", part, err)
-		}
-		indices[i] = uint32(parsed)
-	}
-	return indices, nil
 }
 
 // acceptChannel is used to accept a single channel that comes across. This

--- a/lntest/timeouts.go
+++ b/lntest/timeouts.go
@@ -28,5 +28,5 @@ const (
 
 	// NodeStartTimeout is the timeout value when waiting for a node to
 	// become fully started.
-	NodeStartTimeout = time.Second * 60
+	NodeStartTimeout = time.Second * 120
 )

--- a/lntest/timeouts_remote_db.go
+++ b/lntest/timeouts_remote_db.go
@@ -28,5 +28,5 @@ const (
 
 	// NodeStartTimeout is the timeout value when waiting for a node to
 	// become fully started.
-	NodeStartTimeout = time.Second * 60
+	NodeStartTimeout = time.Second * 120
 )

--- a/lntest/wait/wait.go
+++ b/lntest/wait/wait.go
@@ -13,6 +13,9 @@ const PollInterval = 200 * time.Millisecond
 // timing doesn't always line up well when running integration tests with
 // several running lnd nodes. This function gives callers a way to assert that
 // some property is upheld within a particular time frame.
+//
+// TODO(yy): build a counter here so we know how many times we've tried the
+// `pred`.
 func Predicate(pred func() bool, timeout time.Duration) error {
 	exitTimer := time.After(timeout)
 	result := make(chan bool, 1)

--- a/make/testing_flags.mk
+++ b/make/testing_flags.mk
@@ -81,11 +81,11 @@ LOG_TAGS := nolog
 endif
 
 # If a timeout was requested, construct initialize the proper flag for the go
-# test command. If not, we set 60m (up from the default 10m).
+# test command. If not, we set 120m (up from the default 10m).
 ifneq ($(timeout),)
 TEST_FLAGS += -test.timeout=$(timeout)
 else
-TEST_FLAGS += -test.timeout=60m
+TEST_FLAGS += -test.timeout=120m
 endif
 
 GOLIST := go list -tags="$(DEV_TAGS)" -deps $(PKG)/... | grep '$(PKG)'| grep -v '/vendor/'


### PR DESCRIPTION
Please check #6825 for more context.

Depending on #6776, this PR continues the fix of the tests. Each commit has the pattern of, refactoring one test and adding supporting assertions/methods when needed, to reduce the commit size.