### PR TITLE
itest: continued itest refactor and fix - III

### DIFF
--- a/docs/release-notes/release-notes-0.16.0.md
+++ b/docs/release-notes/release-notes-0.16.0.md
@@ -348,7 +348,8 @@ PRs([6776](https://github.com/lightningnetwork/lnd/pull/6776),
 [6822](https://github.com/lightningnetwork/lnd/pull/6822),
 [7172](https://github.com/lightningnetwork/lnd/pull/7172),
 [7242](https://github.com/lightningnetwork/lnd/pull/7242),
-[7245](https://github.com/lightningnetwork/lnd/pull/7245)) have been made to
+[7245](https://github.com/lightningnetwork/lnd/pull/7245)),
+[6823](https://github.com/lightningnetwork/lnd/pull/6823)) have been made to
 refactor the itest for code health and maintenance.
 
 # Contributors (Alphabetical Order)

--- a/funding/manager.go
+++ b/funding/manager.go
@@ -1505,6 +1505,10 @@ func (f *Manager) handleFundingOpen(peer lnpeer.Peer,
 		return
 	}
 
+	log.Debugf("Initialized channel reservation: zeroConf=%v, psbt=%v, "+
+		"cannedShim=%v", reservation.IsZeroConf(),
+		reservation.IsPsbt(), reservation.IsCannedShim())
+
 	if zeroConf {
 		// Store an alias for zero-conf channels. Other option-scid
 		// channels will do this at a later point.

--- a/lntemp/harness.go
+++ b/lntemp/harness.go
@@ -294,6 +294,9 @@ func (h *HarnessTest) resetStandbyNodes(t *testing.T) {
 		// config for the coming test. This will also inherit the
 		// test's running context.
 		h.RestartNodeWithExtraArgs(hn, hn.Cfg.OriginalExtraArgs)
+
+		// Update the node's internal state.
+		hn.UpdateState()
 	}
 }
 
@@ -404,9 +407,6 @@ func (h *HarnessTest) cleanupStandbyNode(hn *node.HarnessNode) {
 
 	// Delete all payments made from this test.
 	hn.RPC.DeleteAllPayments()
-
-	// Update the node's internal state.
-	hn.UpdateState()
 
 	// Finally, check the node is in a clean state for the following tests.
 	h.validateNodeState(hn)

--- a/lntemp/harness.go
+++ b/lntemp/harness.go
@@ -1709,3 +1709,16 @@ func findSweepInDetails(ht *HarnessTest, sweepTxid string,
 
 	return false
 }
+
+// ConnectMiner connects the miner with the chain backend in the network.
+func (h *HarnessTest) ConnectMiner() {
+	err := h.manager.chainBackend.ConnectMiner()
+	require.NoError(h, err, "failed to connect miner")
+}
+
+// DisconnectMiner removes the connection between the miner and the chain
+// backend in the network.
+func (h *HarnessTest) DisconnectMiner() {
+	err := h.manager.chainBackend.DisconnectMiner()
+	require.NoError(h, err, "failed to disconnect miner")
+}

--- a/lntemp/harness.go
+++ b/lntemp/harness.go
@@ -502,6 +502,12 @@ func (h *HarnessTest) RestartNode(hn *node.HarnessNode) {
 	}
 }
 
+// RestartNodeNoUnlock restarts a given node without unlocking its wallet.
+func (h *HarnessTest) RestartNodeNoUnlock(hn *node.HarnessNode) {
+	err := h.manager.restartNode(h.runCtx, hn, nil)
+	require.NoErrorf(h, err, "failed to restart node %s", hn.Name())
+}
+
 // RestartNodeWithChanBackups restarts a given node with the specified channel
 // backups.
 func (h *HarnessTest) RestartNodeWithChanBackups(hn *node.HarnessNode,

--- a/lntemp/harness.go
+++ b/lntemp/harness.go
@@ -1439,6 +1439,14 @@ func (h *HarnessTest) SendPaymentAssertFail(hn *node.HarnessNode,
 	return payment
 }
 
+// SendPaymentAssertSettled sends a payment from the passed node and asserts the
+// payment is settled.
+func (h *HarnessTest) SendPaymentAssertSettled(hn *node.HarnessNode,
+	req *routerrpc.SendPaymentRequest) *lnrpc.Payment {
+
+	return h.SendPaymentAndAssertStatus(hn, req, lnrpc.Payment_SUCCEEDED)
+}
+
 // OpenChannelRequest is used to open a channel using the method
 // OpenMultiChannelsAsync.
 type OpenChannelRequest struct {

--- a/lntemp/harness.go
+++ b/lntemp/harness.go
@@ -349,10 +349,6 @@ func (h *HarnessTest) Subtest(t *testing.T) *HarnessTest {
 			return
 		}
 
-		// We require the mempool to be cleaned from the test.
-		require.Empty(st, st.Miner.GetRawMempool(), "mempool not "+
-			"cleaned, please mine blocks to clean them all.")
-
 		// When we finish the test, reset the nodes' configs and take a
 		// snapshot of each of the nodes' internal states.
 		for _, node := range st.manager.standbyNodes {
@@ -362,8 +358,9 @@ func (h *HarnessTest) Subtest(t *testing.T) *HarnessTest {
 		// If found running nodes, shut them down.
 		st.shutdownNonStandbyNodes()
 
-		// Assert that mempool is cleaned
-		st.Miner.AssertNumTxsInMempool(0)
+		// We require the mempool to be cleaned from the test.
+		require.Empty(st, st.Miner.GetRawMempool(), "mempool not "+
+			"cleaned, please mine blocks to clean them all.")
 
 		// Finally, cancel the run context. We have to do it here
 		// because we need to keep the context alive for the above

--- a/lntemp/harness.go
+++ b/lntemp/harness.go
@@ -480,7 +480,12 @@ func (h *HarnessTest) SuspendNode(node *node.HarnessNode) func() error {
 	return func() error {
 		h.manager.registerNode(node)
 
-		return node.Start(h.runCtx)
+		if err := node.Start(h.runCtx); err != nil {
+			return err
+		}
+		h.WaitForBlockchainSync(node)
+
+		return nil
 	}
 }
 

--- a/lntemp/harness.go
+++ b/lntemp/harness.go
@@ -216,7 +216,8 @@ func (h *HarnessTest) SetupStandbyNodes() {
 
 	// We generate several blocks in order to give the outputs created
 	// above a good number of confirmations.
-	h.MineBlocks(numBlocksSendOutput)
+	const totalTxes = 20
+	h.MineBlocksAndAssertNumTxes(numBlocksSendOutput, totalTxes)
 
 	// Now we want to wait for the nodes to catch up.
 	h.WaitForBlockchainSync(h.Alice)

--- a/lntemp/harness.go
+++ b/lntemp/harness.go
@@ -1391,6 +1391,19 @@ func (h *HarnessTest) MineBlocksAndAssertNumTxes(num uint32,
 	return blocks
 }
 
+// MineEmptyBlocks mines a given number of empty blocks.
+//
+// NOTE: this differs from miner's `MineEmptyBlocks` as it requires the nodes
+// to be synced.
+func (h *HarnessTest) MineEmptyBlocks(num int) []*wire.MsgBlock {
+	blocks := h.Miner.MineEmptyBlocks(num)
+
+	// Finally, make sure all the active nodes are synced.
+	h.AssertActiveNodesSynced()
+
+	return blocks
+}
+
 // QueryChannelByChanPoint tries to find a channel matching the channel point
 // and asserts. It returns the channel found.
 func (h *HarnessTest) QueryChannelByChanPoint(hn *node.HarnessNode,

--- a/lntemp/harness_assertion.go
+++ b/lntemp/harness_assertion.go
@@ -2042,3 +2042,35 @@ func (h *HarnessTest) AssertNumInvoices(hn *node.HarnessNode,
 
 	return invoices
 }
+
+// ReceiveSendToRouteUpdate waits until a message is received on the
+// SendToRoute client stream or the timeout is reached.
+func (h *HarnessTest) ReceiveSendToRouteUpdate(
+	stream rpc.SendToRouteClient) (*lnrpc.SendResponse, error) {
+
+	chanMsg := make(chan *lnrpc.SendResponse, 1)
+	errChan := make(chan error, 1)
+	go func() {
+		// Consume one message. This will block until the message is
+		// received.
+		resp, err := stream.Recv()
+		if err != nil {
+			errChan <- err
+
+			return
+		}
+		chanMsg <- resp
+	}()
+
+	select {
+	case <-time.After(DefaultTimeout):
+		require.Fail(h, "timeout", "timeout waiting for send resp")
+		return nil, nil
+
+	case err := <-errChan:
+		return nil, err
+
+	case updateMsg := <-chanMsg:
+		return updateMsg, nil
+	}
+}

--- a/lntemp/harness_assertion.go
+++ b/lntemp/harness_assertion.go
@@ -1992,3 +1992,25 @@ func (h *HarnessTest) WaitForNodeBlockHeight(hn *node.HarnessNode,
 	require.NoErrorf(h, err, "%s: timeout while waiting for height",
 		hn.Name())
 }
+
+// AssertChannelCommitHeight asserts the given channel for the node has the
+// expected commit height(`NumUpdates`).
+func (h *HarnessTest) AssertChannelCommitHeight(hn *node.HarnessNode,
+	cp *lnrpc.ChannelPoint, height int) {
+
+	err := wait.NoError(func() error {
+		c, err := h.findChannel(hn, cp)
+		if err != nil {
+			return err
+		}
+
+		if int(c.NumUpdates) == height {
+			return nil
+		}
+
+		return fmt.Errorf("expected commit height to be %v, was %v",
+			height, c.NumUpdates)
+	}, DefaultTimeout)
+
+	require.NoError(h, err, "timeout while waiting for commit height")
+}

--- a/lntemp/harness_miner.go
+++ b/lntemp/harness_miner.go
@@ -57,6 +57,16 @@ func NewMiner(ctxt context.Context, t *testing.T) *HarnessMiner {
 	return newMiner(ctxt, t, minerLogDir, minerLogFilename)
 }
 
+// NewTempMiner creates a new miner using btcd backend with the specified log
+// file dir and name.
+func NewTempMiner(ctxt context.Context, t *testing.T,
+	tempDir, tempLogFilename string) *HarnessMiner {
+
+	t.Helper()
+
+	return newMiner(ctxt, t, tempDir, tempLogFilename)
+}
+
 // newMiner creates a new miner using btcd's rpctest.
 func newMiner(ctxb context.Context, t *testing.T, minerDirName,
 	logFilename string) *HarnessMiner {

--- a/lntemp/harness_miner.go
+++ b/lntemp/harness_miner.go
@@ -383,3 +383,35 @@ func (h *HarnessMiner) NewMinerAddress() btcutil.Address {
 	require.NoError(h, err, "failed to create new miner address")
 	return addr
 }
+
+// MineBlocksWithTxes mines a single block to include the specifies
+// transactions only.
+func (h *HarnessMiner) MineBlockWithTxes(txes []*btcutil.Tx) *wire.MsgBlock {
+	var emptyTime time.Time
+
+	// Generate a block.
+	b, err := h.GenerateAndSubmitBlock(txes, -1, emptyTime)
+	require.NoError(h, err, "unable to mine block")
+
+	block, err := h.Client.GetBlock(b.Hash())
+	require.NoError(h, err, "unable to get block")
+
+	return block
+}
+
+// MineEmptyBlocks mines a given number of empty blocks.
+func (h *HarnessMiner) MineEmptyBlocks(num int) []*wire.MsgBlock {
+	var emptyTime time.Time
+
+	blocks := make([]*wire.MsgBlock, num)
+	for i := 0; i < num; i++ {
+		// Generate an empty block.
+		b, err := h.GenerateAndSubmitBlock(nil, -1, emptyTime)
+		require.NoError(h, err, "unable to mine empty block")
+
+		block := h.GetBlock(b.Hash())
+		blocks[i] = block
+	}
+
+	return blocks
+}

--- a/lntemp/harness_node_manager.go
+++ b/lntemp/harness_node_manager.go
@@ -71,8 +71,7 @@ func (nm *nodeManager) nextNodeID() uint32 {
 // node can be used immediately. Otherwise, the node will require an additional
 // initialization phase where the wallet is either created or restored.
 func (nm *nodeManager) newNode(t *testing.T, name string, extraArgs []string,
-	password []byte, useSeed bool,
-	opts ...node.Option) (*node.HarnessNode, error) {
+	password []byte, useSeed bool) (*node.HarnessNode, error) {
 
 	cfg := &node.BaseNodeConfig{
 		Name:              name,
@@ -86,9 +85,6 @@ func (nm *nodeManager) newNode(t *testing.T, name string, extraArgs []string,
 		LndBinary:         nm.lndBinary,
 		NetParams:         harnessNetParams,
 		HasSeed:           useSeed,
-	}
-	for _, opt := range opts {
-		opt(cfg)
 	}
 
 	node, err := node.NewHarnessNode(t, cfg)

--- a/lntemp/node/config.go
+++ b/lntemp/node/config.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/btcsuite/btcd/chaincfg"
 	"github.com/lightningnetwork/lnd/chanbackup"
+	"github.com/lightningnetwork/lnd/kvdb/etcd"
 	"github.com/lightningnetwork/lnd/lntest"
 )
 
@@ -231,4 +232,34 @@ func (cfg *BaseNodeConfig) GenArgs() []string {
 	}
 
 	return args
+}
+
+// ExtraArgsEtcd returns extra args for configuring LND to use an external etcd
+// database (for remote channel DB and wallet DB).
+func ExtraArgsEtcd(etcdCfg *etcd.Config, name string, cluster bool,
+	leaderSessionTTL int) []string {
+
+	extraArgs := []string{
+		"--db.backend=etcd",
+		fmt.Sprintf("--db.etcd.host=%v", etcdCfg.Host),
+		fmt.Sprintf("--db.etcd.user=%v", etcdCfg.User),
+		fmt.Sprintf("--db.etcd.pass=%v", etcdCfg.Pass),
+		fmt.Sprintf("--db.etcd.namespace=%v", etcdCfg.Namespace),
+	}
+
+	if etcdCfg.InsecureSkipVerify {
+		extraArgs = append(extraArgs, "--db.etcd.insecure_skip_verify")
+	}
+
+	if cluster {
+		clusterArgs := []string{
+			"--cluster.enable-leader-election",
+			fmt.Sprintf("--cluster.id=%v", name),
+			fmt.Sprintf("--cluster.leader-session-ttl=%v",
+				leaderSessionTTL),
+		}
+		extraArgs = append(extraArgs, clusterArgs...)
+	}
+
+	return extraArgs
 }

--- a/lntemp/node/config.go
+++ b/lntemp/node/config.go
@@ -63,8 +63,8 @@ type BaseNodeConfig struct {
 	ReadMacPath    string
 	InvoiceMacPath string
 
-	HasSeed  bool
-	Password []byte
+	SkipUnlock bool
+	Password   []byte
 
 	P2PPort     int
 	RPCPort     int
@@ -190,7 +190,7 @@ func (cfg *BaseNodeConfig) GenArgs() []string {
 	}
 	args = append(args, nodeArgs...)
 
-	if !cfg.HasSeed {
+	if cfg.Password == nil {
 		args = append(args, "--noseedbackup")
 	}
 

--- a/lntemp/node/harness_node.go
+++ b/lntemp/node/harness_node.go
@@ -488,6 +488,19 @@ func (hn *HarnessNode) InitNode(macBytes []byte) error {
 	return hn.initLightningClient()
 }
 
+// InitChangePassword initializes a harness node by passing the change password
+// request via RPC. After the request is submitted, this method will block until
+// a macaroon-authenticated RPC connection can be established to the harness
+// node. Once established, the new connection is used to initialize the
+// RPC clients and subscribes the HarnessNode to topology changes.
+func (hn *HarnessNode) ChangePasswordAndInit(
+	req *lnrpc.ChangePasswordRequest) (
+	*lnrpc.ChangePasswordResponse, error) {
+
+	response := hn.RPC.ChangePassword(req)
+	return response, hn.InitNode(response.AdminMacaroon)
+}
+
 // waitTillServerState makes a subscription to the server's state change and
 // blocks until the server is in the targeted state.
 func (hn *HarnessNode) waitTillServerState(

--- a/lntemp/node/harness_node.go
+++ b/lntemp/node/harness_node.go
@@ -387,12 +387,12 @@ func (hn *HarnessNode) StartLndCmd(ctxb context.Context) error {
 	return nil
 }
 
-// StartWithSeed will start the lnd process, creates the grpc connection
+// StartWithNoAuth will start the lnd process, creates the grpc connection
 // without macaroon auth, and waits until the server is reported as waiting to
 // start.
 //
 // NOTE: caller needs to take extra step to create and unlock the wallet.
-func (hn *HarnessNode) StartWithSeed(ctxt context.Context) error {
+func (hn *HarnessNode) StartWithNoAuth(ctxt context.Context) error {
 	// Start lnd process and prepare logs.
 	if err := hn.StartLndCmd(ctxt); err != nil {
 		return fmt.Errorf("start lnd error: %w", err)

--- a/lntemp/rpc/invoices.go
+++ b/lntemp/rpc/invoices.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/lightningnetwork/lnd/lnrpc"
 	"github.com/lightningnetwork/lnd/lnrpc/invoicesrpc"
+	"github.com/lightningnetwork/lnd/lnrpc/routerrpc"
 )
 
 // =====================
@@ -79,6 +80,22 @@ func (h *HarnessRPC) SubscribeSingleInvoice(rHash []byte) SingleInvoiceClient {
 	// context.
 	client, err := h.Invoice.SubscribeSingleInvoice(h.runCtx, req)
 	h.NoError(err, "SubscribeSingleInvoice")
+
+	return client
+}
+
+type TrackPaymentClient routerrpc.Router_TrackPaymentV2Client
+
+// TrackPaymentV2 creates a subscription client for given invoice and
+// asserts its creation.
+func (h *HarnessRPC) TrackPaymentV2(payHash []byte) TrackPaymentClient {
+	req := &routerrpc.TrackPaymentRequest{PaymentHash: payHash}
+
+	// TrackPaymentV2 needs to have the context alive for the entire test
+	// case as the returned client will be used for send and receive events
+	// stream. Thus we use runCtx here instead of a timeout context.
+	client, err := h.Router.TrackPaymentV2(h.runCtx, req)
+	h.NoError(err, "TrackPaymentV2")
 
 	return client
 }

--- a/lntemp/rpc/lnd.go
+++ b/lntemp/rpc/lnd.go
@@ -567,3 +567,15 @@ func (h *HarnessRPC) VerifyChanBackup(
 
 	return resp
 }
+
+// LookupInvoice queries the node's invoices using the specified rHash.
+func (h *HarnessRPC) LookupInvoice(rHash []byte) *lnrpc.Invoice {
+	ctxt, cancel := context.WithTimeout(h.runCtx, DefaultTimeout)
+	defer cancel()
+
+	payHash := &lnrpc.PaymentHash{RHash: rHash}
+	resp, err := h.LN.LookupInvoice(ctxt, payHash)
+	h.NoError(err, "LookupInvoice")
+
+	return resp
+}

--- a/lntemp/rpc/lnd.go
+++ b/lntemp/rpc/lnd.go
@@ -579,3 +579,15 @@ func (h *HarnessRPC) LookupInvoice(rHash []byte) *lnrpc.Invoice {
 
 	return resp
 }
+
+// DecodePayReq makes a RPC call to node's DecodePayReq and asserts.
+func (h *HarnessRPC) DecodePayReq(req string) *lnrpc.PayReq {
+	ctxt, cancel := context.WithTimeout(h.runCtx, DefaultTimeout)
+	defer cancel()
+
+	payReq := &lnrpc.PayReqString{PayReq: req}
+	resp, err := h.LN.DecodePayReq(ctxt, payReq)
+	h.NoError(err, "DecodePayReq")
+
+	return resp
+}

--- a/lntemp/rpc/lnd.go
+++ b/lntemp/rpc/lnd.go
@@ -591,3 +591,21 @@ func (h *HarnessRPC) DecodePayReq(req string) *lnrpc.PayReq {
 
 	return resp
 }
+
+// ForwardingHistory makes a RPC call to the node's ForwardingHistory and
+// asserts.
+func (h *HarnessRPC) ForwardingHistory(
+	req *lnrpc.ForwardingHistoryRequest) *lnrpc.ForwardingHistoryResponse {
+
+	ctxt, cancel := context.WithTimeout(h.runCtx, DefaultTimeout)
+	defer cancel()
+
+	if req == nil {
+		req = &lnrpc.ForwardingHistoryRequest{}
+	}
+
+	resp, err := h.LN.ForwardingHistory(ctxt, req)
+	h.NoError(err, "ForwardingHistory")
+
+	return resp
+}

--- a/lntemp/rpc/lnd.go
+++ b/lntemp/rpc/lnd.go
@@ -481,8 +481,10 @@ func (h *HarnessRPC) QueryRoutes(
 	return routes
 }
 
+type SendToRouteClient lnrpc.Lightning_SendToRouteClient
+
 // SendToRoute makes a RPC call to SendToRoute and asserts.
-func (h *HarnessRPC) SendToRoute() lnrpc.Lightning_SendToRouteClient {
+func (h *HarnessRPC) SendToRoute() SendToRouteClient {
 	// SendToRoute needs to have the context alive for the entire test case
 	// as the returned client will be used for send and receive payment
 	// stream. Thus we use runCtx here instead of a timeout context.

--- a/lntemp/rpc/lnd.go
+++ b/lntemp/rpc/lnd.go
@@ -611,3 +611,19 @@ func (h *HarnessRPC) ForwardingHistory(
 
 	return resp
 }
+
+type MiddlewareClient lnrpc.Lightning_RegisterRPCMiddlewareClient
+
+// RegisterRPCMiddleware makes a RPC call to the node's RegisterRPCMiddleware
+// and asserts. It also returns a cancel context which can cancel the context
+// used by the client.
+func (h *HarnessRPC) RegisterRPCMiddleware() (MiddlewareClient,
+	context.CancelFunc) {
+
+	ctxt, cancel := context.WithCancel(h.runCtx)
+
+	stream, err := h.LN.RegisterRPCMiddleware(ctxt)
+	h.NoError(err, "RegisterRPCMiddleware")
+
+	return stream, cancel
+}

--- a/lntemp/rpc/lnd.go
+++ b/lntemp/rpc/lnd.go
@@ -194,6 +194,10 @@ func (h *HarnessRPC) ListInvoices(
 	ctxt, cancel := context.WithTimeout(h.runCtx, DefaultTimeout)
 	defer cancel()
 
+	if req == nil {
+		req = &lnrpc.ListInvoiceRequest{}
+	}
+
 	resp, err := h.LN.ListInvoices(ctxt, req)
 	h.NoError(err, "ListInvoice")
 

--- a/lntemp/rpc/router.go
+++ b/lntemp/rpc/router.go
@@ -39,3 +39,56 @@ func (h *HarnessRPC) SendPayment(
 
 	return stream
 }
+
+type HtlcEventsClient routerrpc.Router_SubscribeHtlcEventsClient
+
+// SubscribeHtlcEvents makes a subscription to the HTLC events and returns a
+// htlc event client.
+func (h *HarnessRPC) SubscribeHtlcEvents() HtlcEventsClient {
+	// Use runCtx here to keep the client alive for the scope of the test.
+	client, err := h.Router.SubscribeHtlcEvents(
+		h.runCtx, &routerrpc.SubscribeHtlcEventsRequest{},
+	)
+	h.NoError(err, "SubscribeHtlcEvents")
+
+	return client
+}
+
+// GetMissionControlConfig makes a RPC call to the node's
+// GetMissionControlConfig and asserts.
+//
+//nolint:lll
+func (h *HarnessRPC) GetMissionControlConfig() *routerrpc.GetMissionControlConfigResponse {
+	ctxt, cancel := context.WithTimeout(h.runCtx, DefaultTimeout)
+	defer cancel()
+
+	req := &routerrpc.GetMissionControlConfigRequest{}
+	resp, err := h.Router.GetMissionControlConfig(ctxt, req)
+	h.NoError(err, "GetMissionControlConfig")
+
+	return resp
+}
+
+// SetMissionControlConfig makes a RPC call to the node's
+// SetMissionControlConfig and asserts.
+func (h *HarnessRPC) SetMissionControlConfig(
+	config *routerrpc.MissionControlConfig) {
+
+	ctxt, cancel := context.WithTimeout(h.runCtx, DefaultTimeout)
+	defer cancel()
+
+	req := &routerrpc.SetMissionControlConfigRequest{Config: config}
+	_, err := h.Router.SetMissionControlConfig(ctxt, req)
+	h.NoError(err, "SetMissionControlConfig")
+}
+
+// ResetMissionControl makes a RPC call to the node's ResetMissionControl and
+// asserts.
+func (h *HarnessRPC) ResetMissionControl() {
+	ctxt, cancel := context.WithTimeout(h.runCtx, DefaultTimeout)
+	defer cancel()
+
+	req := &routerrpc.ResetMissionControlRequest{}
+	_, err := h.Router.ResetMissionControl(ctxt, req)
+	h.NoError(err, "ResetMissionControl")
+}

--- a/lntemp/rpc/router.go
+++ b/lntemp/rpc/router.go
@@ -14,6 +14,8 @@ import (
 
 // UpdateChanStatus makes a UpdateChanStatus RPC call to node's RouterClient
 // and asserts.
+//
+//nolint:lll
 func (h *HarnessRPC) UpdateChanStatus(
 	req *routerrpc.UpdateChanStatusRequest) *routerrpc.UpdateChanStatusResponse {
 

--- a/lntemp/rpc/router.go
+++ b/lntemp/rpc/router.go
@@ -3,6 +3,7 @@ package rpc
 import (
 	"context"
 
+	"github.com/lightningnetwork/lnd/lnrpc"
 	"github.com/lightningnetwork/lnd/lnrpc/routerrpc"
 )
 
@@ -91,4 +92,17 @@ func (h *HarnessRPC) ResetMissionControl() {
 	req := &routerrpc.ResetMissionControlRequest{}
 	_, err := h.Router.ResetMissionControl(ctxt, req)
 	h.NoError(err, "ResetMissionControl")
+}
+
+// SendToRouteV2 makes a RPC call to SendToRouteV2 and asserts.
+func (h *HarnessRPC) SendToRouteV2(
+	req *routerrpc.SendToRouteRequest) *lnrpc.HTLCAttempt {
+
+	ctxt, cancel := context.WithTimeout(h.runCtx, DefaultTimeout)
+	defer cancel()
+
+	resp, err := h.Router.SendToRouteV2(ctxt, req)
+	h.NoError(err, "SendToRouteV2")
+
+	return resp
 }

--- a/lntemp/rpc/router.go
+++ b/lntemp/rpc/router.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/lightningnetwork/lnd/lnrpc"
 	"github.com/lightningnetwork/lnd/lnrpc/routerrpc"
+	"github.com/stretchr/testify/require"
 )
 
 // =====================
@@ -105,4 +106,45 @@ func (h *HarnessRPC) SendToRouteV2(
 	h.NoError(err, "SendToRouteV2")
 
 	return resp
+}
+
+// QueryProbability makes a RPC call to the node's QueryProbability and
+// asserts.
+//
+//nolint:lll
+func (h *HarnessRPC) QueryProbability(
+	req *routerrpc.QueryProbabilityRequest) *routerrpc.QueryProbabilityResponse {
+
+	ctxt, cancel := context.WithTimeout(h.runCtx, DefaultTimeout)
+	defer cancel()
+
+	resp, err := h.Router.QueryProbability(ctxt, req)
+	h.NoError(err, "QueryProbability")
+
+	return resp
+}
+
+// XImportMissionControl makes a RPC call to the node's XImportMissionControl
+// and asserts.
+func (h *HarnessRPC) XImportMissionControl(
+	req *routerrpc.XImportMissionControlRequest) {
+
+	ctxt, cancel := context.WithTimeout(h.runCtx, DefaultTimeout)
+	defer cancel()
+
+	_, err := h.Router.XImportMissionControl(ctxt, req)
+	h.NoError(err, "XImportMissionControl")
+}
+
+// XImportMissionControlAssertErr makes a RPC call to the node's
+// XImportMissionControl
+// and asserts an error occurred.
+func (h *HarnessRPC) XImportMissionControlAssertErr(
+	req *routerrpc.XImportMissionControlRequest) {
+
+	ctxt, cancel := context.WithTimeout(h.runCtx, DefaultTimeout)
+	defer cancel()
+
+	_, err := h.Router.XImportMissionControl(ctxt, req)
+	require.Error(h, err, "expect an error from x import mission control")
 }

--- a/lntemp/rpc/wallet_unlocker.go
+++ b/lntemp/rpc/wallet_unlocker.go
@@ -48,3 +48,17 @@ func (h *HarnessRPC) GenSeed(req *lnrpc.GenSeedRequest) *lnrpc.GenSeedResponse {
 
 	return resp
 }
+
+// ChangePassword makes a RPC request to WalletUnlocker and asserts there's no
+// error.
+func (h *HarnessRPC) ChangePassword(
+	req *lnrpc.ChangePasswordRequest) *lnrpc.ChangePasswordResponse {
+
+	ctxt, cancel := context.WithTimeout(h.runCtx, DefaultTimeout)
+	defer cancel()
+
+	resp, err := h.WalletUnlocker.ChangePassword(ctxt, req)
+	h.NoError(err, "ChangePassword")
+
+	return resp
+}

--- a/lntemp/rpc/watchtower.go
+++ b/lntemp/rpc/watchtower.go
@@ -1,5 +1,52 @@
 package rpc
 
+import (
+	"context"
+
+	"github.com/lightningnetwork/lnd/lnrpc/watchtowerrpc"
+	"github.com/lightningnetwork/lnd/lnrpc/wtclientrpc"
+)
+
 // =====================
 // WatchtowerClient and WatchtowerClientClient related RPCs.
 // =====================
+
+// GetInfoWatchtower makes a RPC call to the watchtower of the given node and
+// asserts.
+func (h *HarnessRPC) GetInfoWatchtower() *watchtowerrpc.GetInfoResponse {
+	ctxt, cancel := context.WithTimeout(h.runCtx, DefaultTimeout)
+	defer cancel()
+
+	req := &watchtowerrpc.GetInfoRequest{}
+	info, err := h.Watchtower.GetInfo(ctxt, req)
+	h.NoError(err, "GetInfo from Watchtower")
+
+	return info
+}
+
+// AddTower makes a RPC call to the WatchtowerClient of the given node and
+// asserts.
+func (h *HarnessRPC) AddTower(
+	req *wtclientrpc.AddTowerRequest) *wtclientrpc.AddTowerResponse {
+
+	ctxt, cancel := context.WithTimeout(h.runCtx, DefaultTimeout)
+	defer cancel()
+
+	resp, err := h.WatchtowerClient.AddTower(ctxt, req)
+	h.NoError(err, "AddTower")
+
+	return resp
+}
+
+// WatchtowerStats makes a RPC call to the WatchtowerClient of the given node
+// and asserts.
+func (h *HarnessRPC) WatchtowerStats() *wtclientrpc.StatsResponse {
+	ctxt, cancel := context.WithTimeout(h.runCtx, DefaultTimeout)
+	defer cancel()
+
+	req := &wtclientrpc.StatsRequest{}
+	resp, err := h.WatchtowerClient.Stats(ctxt, req)
+	h.NoError(err, "Stats from Watchtower")
+
+	return resp
+}

--- a/lntest/harness_node.go
+++ b/lntest/harness_node.go
@@ -487,7 +487,7 @@ func executePgQuery(query string) error {
 		postgresDatabaseDsn("postgres"),
 	)
 	if err != nil {
-		return fmt.Errorf("unable to connect to database: %v", err)
+		return fmt.Errorf("unable to connect to database: %w", err)
 	}
 	defer pool.Close()
 

--- a/lntest/itest/assertions.go
+++ b/lntest/itest/assertions.go
@@ -1418,30 +1418,6 @@ func assertTransactionNotInWallet(t *testing.T, node *lntest.HarnessNode,
 	)
 }
 
-func assertAnchorOutputLost(t *harnessTest, node *lntest.HarnessNode,
-	chanPoint wire.OutPoint) {
-
-	pendingChansRequest := &lnrpc.PendingChannelsRequest{}
-	err := wait.Predicate(func() bool {
-		resp, pErr := node.PendingChannels(
-			context.Background(), pendingChansRequest,
-		)
-		if pErr != nil {
-			return false
-		}
-
-		for _, pendingChan := range resp.PendingForceClosingChannels {
-			if pendingChan.Channel.ChannelPoint == chanPoint.String() {
-				return (pendingChan.Anchor ==
-					lnrpc.PendingChannelsResponse_ForceClosedChannel_LOST)
-			}
-		}
-
-		return false
-	}, defaultTimeout)
-	require.NoError(t.t, err, "anchor doesn't show as being lost")
-}
-
 // assertNodeAnnouncement compares that two node announcements match.
 func assertNodeAnnouncement(t *harnessTest, n1, n2 *lnrpc.NodeUpdate) {
 	// Alias should match.

--- a/lntest/itest/assertions.go
+++ b/lntest/itest/assertions.go
@@ -690,41 +690,6 @@ func assertChannelPolicy(t *harnessTest, node *lntest.HarnessNode,
 	}
 }
 
-// assertMinerBlockHeightDelta ensures that tempMiner is 'delta' blocks ahead
-// of miner.
-func assertMinerBlockHeightDelta(t *harnessTest,
-	miner, tempMiner *lntest.HarnessMiner, delta int32) {
-
-	// Ensure the chain lengths are what we expect.
-	var predErr error
-	err := wait.Predicate(func() bool {
-		_, tempMinerHeight, err := tempMiner.Client.GetBestBlock()
-		if err != nil {
-			predErr = fmt.Errorf("unable to get current "+
-				"blockheight %v", err)
-			return false
-		}
-
-		_, minerHeight, err := miner.Client.GetBestBlock()
-		if err != nil {
-			predErr = fmt.Errorf("unable to get current "+
-				"blockheight %v", err)
-			return false
-		}
-
-		if tempMinerHeight != minerHeight+delta {
-			predErr = fmt.Errorf("expected new miner(%d) to be %d "+
-				"blocks ahead of original miner(%d)",
-				tempMinerHeight, delta, minerHeight)
-			return false
-		}
-		return true
-	}, defaultTimeout)
-	if err != nil {
-		t.Fatalf(predErr.Error())
-	}
-}
-
 func checkCommitmentMaturity(
 	forceClose *lnrpc.PendingChannelsResponse_ForceClosedChannel,
 	maturityHeight uint32, blocksTilMaturity int32) error {

--- a/lntest/itest/list_on_test.go
+++ b/lntest/itest/list_on_test.go
@@ -321,4 +321,8 @@ var allTestCasesTemp = []*lntemp.TestCase{
 		Name:     "send to route error propagation",
 		TestFunc: testSendToRouteErrorPropagation,
 	},
+	{
+		Name:     "private channels",
+		TestFunc: testPrivateChannels,
+	},
 }

--- a/lntest/itest/list_on_test.go
+++ b/lntest/itest/list_on_test.go
@@ -235,4 +235,8 @@ var allTestCasesTemp = []*lntemp.TestCase{
 		Name:     "etcd failover",
 		TestFunc: testEtcdFailover,
 	},
+	{
+		Name:     "hold invoice force close",
+		TestFunc: testHoldInvoiceForceClose,
+	},
 }

--- a/lntest/itest/list_on_test.go
+++ b/lntest/itest/list_on_test.go
@@ -341,4 +341,8 @@ var allTestCasesTemp = []*lntemp.TestCase{
 		Name:     "route fee cutoff",
 		TestFunc: testRouteFeeCutoff,
 	},
+	{
+		Name:     "rpc middleware interceptor",
+		TestFunc: testRPCMiddlewareInterceptor,
+	},
 }

--- a/lntest/itest/list_on_test.go
+++ b/lntest/itest/list_on_test.go
@@ -345,4 +345,8 @@ var allTestCasesTemp = []*lntemp.TestCase{
 		Name:     "rpc middleware interceptor",
 		TestFunc: testRPCMiddlewareInterceptor,
 	},
+	{
+		Name:     "macaroon authentication",
+		TestFunc: testMacaroonAuthentication,
+	},
 }

--- a/lntest/itest/list_on_test.go
+++ b/lntest/itest/list_on_test.go
@@ -263,4 +263,8 @@ var allTestCasesTemp = []*lntemp.TestCase{
 		Name:     "multi-hop payments",
 		TestFunc: testMultiHopPayments,
 	},
+	{
+		Name:     "anchors reserved value",
+		TestFunc: testAnchorReservedValue,
+	},
 }

--- a/lntest/itest/list_on_test.go
+++ b/lntest/itest/list_on_test.go
@@ -275,4 +275,8 @@ var allTestCasesTemp = []*lntemp.TestCase{
 		Name:     "open channel reorg test",
 		TestFunc: testOpenChannelAfterReorg,
 	},
+	{
+		Name:     "psbt channel funding external",
+		TestFunc: testPsbtChanFundingExternal,
+	},
 }

--- a/lntest/itest/list_on_test.go
+++ b/lntest/itest/list_on_test.go
@@ -333,4 +333,8 @@ var allTestCasesTemp = []*lntemp.TestCase{
 		Name:     "multi-hop payments over private channels",
 		TestFunc: testMultiHopOverPrivateChannels,
 	},
+	{
+		Name:     "query routes",
+		TestFunc: testQueryRoutes,
+	},
 }

--- a/lntest/itest/list_on_test.go
+++ b/lntest/itest/list_on_test.go
@@ -305,7 +305,12 @@ var allTestCasesTemp = []*lntemp.TestCase{
 		TestFunc: testRevokedCloseRetributionRemoteHodl,
 	},
 	{
-		Name:     "revoked uncooperative close retribution altruist watchtower",
+		Name: "revoked uncooperative close retribution altruist " +
+			"watchtower",
 		TestFunc: testRevokedCloseRetributionAltruistWatchtower,
+	},
+	{
+		Name:     "single-hop send to route",
+		TestFunc: testSingleHopSendToRoute,
 	},
 }

--- a/lntest/itest/list_on_test.go
+++ b/lntest/itest/list_on_test.go
@@ -251,4 +251,8 @@ var allTestCasesTemp = []*lntemp.TestCase{
 		Name:     "wumbo channels",
 		TestFunc: testWumboChannels,
 	},
+	{
+		Name:     "max htlc pathfind",
+		TestFunc: testMaxHtlcPathfind,
+	},
 }

--- a/lntest/itest/list_on_test.go
+++ b/lntest/itest/list_on_test.go
@@ -291,4 +291,8 @@ var allTestCasesTemp = []*lntemp.TestCase{
 		Name:     "REST API",
 		TestFunc: testRestAPI,
 	},
+	{
+		Name:     "revoked uncooperative close retribution",
+		TestFunc: testRevokedCloseRetribution,
+	},
 }

--- a/lntest/itest/list_on_test.go
+++ b/lntest/itest/list_on_test.go
@@ -283,4 +283,8 @@ var allTestCasesTemp = []*lntemp.TestCase{
 		Name:     "psbt channel funding single step",
 		TestFunc: testPsbtChanFundingSingleStep,
 	},
+	{
+		Name:     "resolution handoff",
+		TestFunc: testResHandoff,
+	},
 }

--- a/lntest/itest/list_on_test.go
+++ b/lntest/itest/list_on_test.go
@@ -287,4 +287,8 @@ var allTestCasesTemp = []*lntemp.TestCase{
 		Name:     "resolution handoff",
 		TestFunc: testResHandoff,
 	},
+	{
+		Name:     "REST API",
+		TestFunc: testRestAPI,
+	},
 }

--- a/lntest/itest/list_on_test.go
+++ b/lntest/itest/list_on_test.go
@@ -337,4 +337,8 @@ var allTestCasesTemp = []*lntemp.TestCase{
 		Name:     "query routes",
 		TestFunc: testQueryRoutes,
 	},
+	{
+		Name:     "route fee cutoff",
+		TestFunc: testRouteFeeCutoff,
+	},
 }

--- a/lntest/itest/list_on_test.go
+++ b/lntest/itest/list_on_test.go
@@ -271,4 +271,8 @@ var allTestCasesTemp = []*lntemp.TestCase{
 		Name:     "3rd party anchor spend",
 		TestFunc: testAnchorThirdPartySpend,
 	},
+	{
+		Name:     "open channel reorg test",
+		TestFunc: testOpenChannelAfterReorg,
+	},
 }

--- a/lntest/itest/list_on_test.go
+++ b/lntest/itest/list_on_test.go
@@ -349,4 +349,8 @@ var allTestCasesTemp = []*lntemp.TestCase{
 		Name:     "macaroon authentication",
 		TestFunc: testMacaroonAuthentication,
 	},
+	{
+		Name:     "bake macaroon",
+		TestFunc: testBakeMacaroon,
+	},
 }

--- a/lntest/itest/list_on_test.go
+++ b/lntest/itest/list_on_test.go
@@ -317,4 +317,8 @@ var allTestCasesTemp = []*lntemp.TestCase{
 		Name:     "multi-hop send to route",
 		TestFunc: testMultiHopSendToRoute,
 	},
+	{
+		Name:     "send to route error propagation",
+		TestFunc: testSendToRouteErrorPropagation,
+	},
 }

--- a/lntest/itest/list_on_test.go
+++ b/lntest/itest/list_on_test.go
@@ -329,4 +329,8 @@ var allTestCasesTemp = []*lntemp.TestCase{
 		Name:     "invoice routing hints",
 		TestFunc: testInvoiceRoutingHints,
 	},
+	{
+		Name:     "multi-hop payments over private channels",
+		TestFunc: testMultiHopOverPrivateChannels,
+	},
 }

--- a/lntest/itest/list_on_test.go
+++ b/lntest/itest/list_on_test.go
@@ -231,4 +231,8 @@ var allTestCasesTemp = []*lntemp.TestCase{
 		Name:     "neutrino kit",
 		TestFunc: testNeutrino,
 	},
+	{
+		Name:     "etcd failover",
+		TestFunc: testEtcdFailover,
+	},
 }

--- a/lntest/itest/list_on_test.go
+++ b/lntest/itest/list_on_test.go
@@ -295,4 +295,9 @@ var allTestCasesTemp = []*lntemp.TestCase{
 		Name:     "revoked uncooperative close retribution",
 		TestFunc: testRevokedCloseRetribution,
 	},
+	{
+		Name: "revoked uncooperative close retribution zero value " +
+			"remote output",
+		TestFunc: testRevokedCloseRetributionZeroValueRemoteOutput,
+	},
 }

--- a/lntest/itest/list_on_test.go
+++ b/lntest/itest/list_on_test.go
@@ -259,4 +259,8 @@ var allTestCasesTemp = []*lntemp.TestCase{
 		Name:     "multi-hop htlc error propagation",
 		TestFunc: testHtlcErrorPropagation,
 	},
+	{
+		Name:     "multi-hop payments",
+		TestFunc: testMultiHopPayments,
+	},
 }

--- a/lntest/itest/list_on_test.go
+++ b/lntest/itest/list_on_test.go
@@ -304,4 +304,8 @@ var allTestCasesTemp = []*lntemp.TestCase{
 		Name:     "revoked uncooperative close retribution remote hodl",
 		TestFunc: testRevokedCloseRetributionRemoteHodl,
 	},
+	{
+		Name:     "revoked uncooperative close retribution altruist watchtower",
+		TestFunc: testRevokedCloseRetributionAltruistWatchtower,
+	},
 }

--- a/lntest/itest/list_on_test.go
+++ b/lntest/itest/list_on_test.go
@@ -365,4 +365,8 @@ var allTestCasesTemp = []*lntemp.TestCase{
 		Name:     "single hop invoice",
 		TestFunc: testSingleHopInvoice,
 	},
+	{
+		Name:     "wipe forwarding packages",
+		TestFunc: testWipeForwardingPackages,
+	},
 }

--- a/lntest/itest/list_on_test.go
+++ b/lntest/itest/list_on_test.go
@@ -255,4 +255,8 @@ var allTestCasesTemp = []*lntemp.TestCase{
 		Name:     "max htlc pathfind",
 		TestFunc: testMaxHtlcPathfind,
 	},
+	{
+		Name:     "multi-hop htlc error propagation",
+		TestFunc: testHtlcErrorPropagation,
+	},
 }

--- a/lntest/itest/list_on_test.go
+++ b/lntest/itest/list_on_test.go
@@ -247,4 +247,8 @@ var allTestCasesTemp = []*lntemp.TestCase{
 		Name:     "maximum channel size",
 		TestFunc: testMaxChannelSize,
 	},
+	{
+		Name:     "wumbo channels",
+		TestFunc: testWumboChannels,
+	},
 }

--- a/lntest/itest/list_on_test.go
+++ b/lntest/itest/list_on_test.go
@@ -313,4 +313,8 @@ var allTestCasesTemp = []*lntemp.TestCase{
 		Name:     "single-hop send to route",
 		TestFunc: testSingleHopSendToRoute,
 	},
+	{
+		Name:     "multi-hop send to route",
+		TestFunc: testMultiHopSendToRoute,
+	},
 }

--- a/lntest/itest/list_on_test.go
+++ b/lntest/itest/list_on_test.go
@@ -243,4 +243,8 @@ var allTestCasesTemp = []*lntemp.TestCase{
 		Name:     "hold invoice sender persistence",
 		TestFunc: testHoldInvoicePersistence,
 	},
+	{
+		Name:     "maximum channel size",
+		TestFunc: testMaxChannelSize,
+	},
 }

--- a/lntest/itest/list_on_test.go
+++ b/lntest/itest/list_on_test.go
@@ -325,4 +325,8 @@ var allTestCasesTemp = []*lntemp.TestCase{
 		Name:     "private channels",
 		TestFunc: testPrivateChannels,
 	},
+	{
+		Name:     "invoice routing hints",
+		TestFunc: testInvoiceRoutingHints,
+	},
 }

--- a/lntest/itest/list_on_test.go
+++ b/lntest/itest/list_on_test.go
@@ -267,4 +267,8 @@ var allTestCasesTemp = []*lntemp.TestCase{
 		Name:     "anchors reserved value",
 		TestFunc: testAnchorReservedValue,
 	},
+	{
+		Name:     "3rd party anchor spend",
+		TestFunc: testAnchorThirdPartySpend,
+	},
 }

--- a/lntest/itest/list_on_test.go
+++ b/lntest/itest/list_on_test.go
@@ -239,4 +239,8 @@ var allTestCasesTemp = []*lntemp.TestCase{
 		Name:     "hold invoice force close",
 		TestFunc: testHoldInvoiceForceClose,
 	},
+	{
+		Name:     "hold invoice sender persistence",
+		TestFunc: testHoldInvoicePersistence,
+	},
 }

--- a/lntest/itest/list_on_test.go
+++ b/lntest/itest/list_on_test.go
@@ -353,4 +353,8 @@ var allTestCasesTemp = []*lntemp.TestCase{
 		Name:     "bake macaroon",
 		TestFunc: testBakeMacaroon,
 	},
+	{
+		Name:     "delete macaroon id",
+		TestFunc: testDeleteMacaroonID,
+	},
 }

--- a/lntest/itest/list_on_test.go
+++ b/lntest/itest/list_on_test.go
@@ -279,4 +279,8 @@ var allTestCasesTemp = []*lntemp.TestCase{
 		Name:     "psbt channel funding external",
 		TestFunc: testPsbtChanFundingExternal,
 	},
+	{
+		Name:     "psbt channel funding single step",
+		TestFunc: testPsbtChanFundingSingleStep,
+	},
 }

--- a/lntest/itest/list_on_test.go
+++ b/lntest/itest/list_on_test.go
@@ -361,4 +361,8 @@ var allTestCasesTemp = []*lntemp.TestCase{
 		Name:     "stateless init",
 		TestFunc: testStatelessInit,
 	},
+	{
+		Name:     "single hop invoice",
+		TestFunc: testSingleHopInvoice,
+	},
 }

--- a/lntest/itest/list_on_test.go
+++ b/lntest/itest/list_on_test.go
@@ -357,4 +357,8 @@ var allTestCasesTemp = []*lntemp.TestCase{
 		Name:     "delete macaroon id",
 		TestFunc: testDeleteMacaroonID,
 	},
+	{
+		Name:     "stateless init",
+		TestFunc: testStatelessInit,
+	},
 }

--- a/lntest/itest/list_on_test.go
+++ b/lntest/itest/list_on_test.go
@@ -300,4 +300,8 @@ var allTestCasesTemp = []*lntemp.TestCase{
 			"remote output",
 		TestFunc: testRevokedCloseRetributionZeroValueRemoteOutput,
 	},
+	{
+		Name:     "revoked uncooperative close retribution remote hodl",
+		TestFunc: testRevokedCloseRetributionRemoteHodl,
+	},
 }

--- a/lntest/itest/lnd_channel_backup_test.go
+++ b/lntest/itest/lnd_channel_backup_test.go
@@ -349,8 +349,9 @@ func testChannelBackupRestoreBasic(ht *lntemp.HarnessTest) {
 						"", revocationWindow, nil,
 						copyPorts(oldNode),
 					)
-
-					st.RestartNode(newNode, backupSnapshot)
+					st.RestartNodeWithChanBackups(
+						newNode, backupSnapshot,
+					)
 
 					return newNode
 				}

--- a/lntest/itest/lnd_channel_policy_test.go
+++ b/lntest/itest/lnd_channel_policy_test.go
@@ -199,7 +199,7 @@ func testUpdateChannelPolicy(ht *lntemp.HarnessTest) {
 
 	// We expect this payment to fail, and that the min_htlc value is
 	// communicated back to us, since the attempted HTLC value was too low.
-	sendResp, err := alicePayStream.Recv()
+	sendResp, err := ht.ReceiveSendToRouteUpdate(alicePayStream)
 	require.NoError(ht, err, "unable to receive payment stream")
 
 	// Expected as part of the error message.
@@ -238,7 +238,7 @@ func testUpdateChannelPolicy(ht *lntemp.HarnessTest) {
 	err = alicePayStream.Send(sendReq)
 	require.NoError(ht, err, "unable to send payment")
 
-	sendResp, err = alicePayStream.Recv()
+	sendResp, err = ht.ReceiveSendToRouteUpdate(alicePayStream)
 	require.NoError(ht, err, "unable to receive payment stream")
 	require.Empty(ht, sendResp.PaymentError, "expected payment to succeed")
 

--- a/lntest/itest/lnd_macaroons_test.go
+++ b/lntest/itest/lnd_macaroons_test.go
@@ -296,8 +296,8 @@ func testMacaroonAuthentication(ht *lntemp.HarnessTest) {
 // testBakeMacaroon checks that when creating macaroons, the permissions param
 // in the request must be set correctly, and the baked macaroon has the intended
 // permissions.
-func testBakeMacaroon(net *lntest.NetworkHarness, t *harnessTest) {
-	var testNode = net.Alice
+func testBakeMacaroon(ht *lntemp.HarnessTest) {
+	var testNode = ht.Alice
 
 	testCases := []struct {
 		name string
@@ -429,7 +429,7 @@ func testBakeMacaroon(net *lntest.NetworkHarness, t *harnessTest) {
 
 			newMac, err := readMacaroonFromHex(bakeResp.Macaroon)
 			require.NoError(t, err)
-			cleanup, readOnlyClient := macaroonClientOld(
+			cleanup, readOnlyClient := macaroonClient(
 				t, testNode, newMac,
 			)
 			defer cleanup()
@@ -498,17 +498,17 @@ func testBakeMacaroon(net *lntest.NetworkHarness, t *harnessTest) {
 
 	for _, tc := range testCases {
 		tc := tc
-		t.t.Run(tc.name, func(tt *testing.T) {
+		ht.Run(tc.name, func(tt *testing.T) {
 			ctxt, cancel := context.WithTimeout(
-				context.Background(), defaultTimeout,
+				ht.Context(), defaultTimeout,
 			)
 			defer cancel()
 
 			adminMac, err := testNode.ReadMacaroon(
-				testNode.AdminMacPath(), defaultTimeout,
+				testNode.Cfg.AdminMacPath, defaultTimeout,
 			)
 			require.NoError(tt, err)
-			cleanup, client := macaroonClientOld(tt, testNode, adminMac)
+			cleanup, client := macaroonClient(tt, testNode, adminMac)
 			defer cleanup()
 
 			tc.run(ctxt, tt, client)

--- a/lntest/itest/lnd_max_channel_size_test.go
+++ b/lntest/itest/lnd_max_channel_size_test.go
@@ -5,79 +5,50 @@ package itest
 
 import (
 	"fmt"
-	"strings"
 
 	"github.com/btcsuite/btcd/btcutil"
 	"github.com/lightningnetwork/lnd/funding"
-	"github.com/lightningnetwork/lnd/lntest"
+	"github.com/lightningnetwork/lnd/lntemp"
+	"github.com/lightningnetwork/lnd/lnwallet"
 )
 
-// testMaxChannelSize tests that lnd handles --maxchansize parameter
-// correctly. Wumbo nodes should enforce a default soft limit of 10 BTC by
-// default. This limit can be adjusted with --maxchansize config option
-func testMaxChannelSize(net *lntest.NetworkHarness, t *harnessTest) {
-	// We'll make two new nodes, both wumbo but with the default
-	// limit on maximum channel size (10 BTC)
-	wumboNode := net.NewNode(
-		t.t, "wumbo", []string{"--protocol.wumbo-channels"},
+// testMaxChannelSize tests that lnd handles --maxchansize parameter correctly.
+// Wumbo nodes should enforce a default soft limit of 10 BTC by default. This
+// limit can be adjusted with --maxchansize config option.
+func testMaxChannelSize(ht *lntemp.HarnessTest) {
+	// We'll make two new nodes, both wumbo but with the default limit on
+	// maximum channel size (10 BTC)
+	wumboNode := ht.NewNode(
+		"wumbo", []string{"--protocol.wumbo-channels"},
 	)
-	defer shutdownAndAssert(net, t, wumboNode)
-
-	wumboNode2 := net.NewNode(
-		t.t, "wumbo2", []string{"--protocol.wumbo-channels"},
+	wumboNode2 := ht.NewNode(
+		"wumbo2", []string{"--protocol.wumbo-channels"},
 	)
-	defer shutdownAndAssert(net, t, wumboNode2)
 
-	// We'll send 11 BTC to the wumbo node so it can test the wumbo soft limit.
-	net.SendCoins(t.t, 11*btcutil.SatoshiPerBitcoin, wumboNode)
+	// We'll send 11 BTC to the wumbo node so it can test the wumbo soft
+	// limit.
+	ht.FundCoins(11*btcutil.SatoshiPerBitcoin, wumboNode)
 
 	// Next we'll connect both nodes, then attempt to make a wumbo channel
 	// funding request, which should fail as it exceeds the default wumbo
 	// soft limit of 10 BTC.
-	net.EnsureConnected(t.t, wumboNode, wumboNode2)
+	ht.EnsureConnected(wumboNode, wumboNode2)
 
 	chanAmt := funding.MaxBtcFundingAmountWumbo + 1
-	_, err := net.OpenChannel(
-		wumboNode, wumboNode2, lntest.OpenChannelParams{
-			Amt: chanAmt,
-		},
+	// The test should show failure due to the channel exceeding our max
+	// size.
+	expectedErr := lnwallet.ErrChanTooLarge(
+		chanAmt, funding.MaxBtcFundingAmountWumbo,
 	)
-	if err == nil {
-		t.Fatalf("expected channel funding to fail as it exceeds 10 BTC limit")
-	}
-
-	// The test should show failure due to the channel exceeding our max size.
-	if !strings.Contains(err.Error(), "exceeds maximum chan size") {
-		t.Fatalf("channel should be rejected due to size, instead "+
-			"error was: %v", err)
-	}
-
-	// Next we'll create a non-wumbo node to verify that it enforces the
-	// BOLT-02 channel size limit and rejects our funding request.
-	miniNode := net.NewNode(t.t, "mini", nil)
-	defer shutdownAndAssert(net, t, miniNode)
-
-	net.EnsureConnected(t.t, wumboNode, miniNode)
-
-	_, err = net.OpenChannel(
-		wumboNode, miniNode, lntest.OpenChannelParams{
-			Amt: chanAmt,
-		},
+	ht.OpenChannelAssertErr(
+		wumboNode, wumboNode2,
+		lntemp.OpenChannelParams{Amt: chanAmt}, expectedErr,
 	)
-	if err == nil {
-		t.Fatalf("expected channel funding to fail as it exceeds 0.16 BTC limit")
-	}
 
-	// The test should show failure due to the channel exceeding our max size.
-	if !strings.Contains(err.Error(), "exceeds maximum chan size") {
-		t.Fatalf("channel should be rejected due to size, instead "+
-			"error was: %v", err)
-	}
-
-	// We'll now make another wumbo node with appropriate maximum channel size
-	// to accept our wumbo channel funding.
-	wumboNode3 := net.NewNode(
-		t.t, "wumbo3", []string{
+	// We'll now make another wumbo node with appropriate maximum channel
+	// size to accept our wumbo channel funding.
+	wumboNode3 := ht.NewNode(
+		"wumbo3", []string{
 			"--protocol.wumbo-channels",
 			fmt.Sprintf(
 				"--maxchansize=%v",
@@ -85,16 +56,12 @@ func testMaxChannelSize(net *lntest.NetworkHarness, t *harnessTest) {
 			),
 		},
 	)
-	defer shutdownAndAssert(net, t, wumboNode3)
 
 	// Creating a wumbo channel between these two nodes should succeed.
-	net.EnsureConnected(t.t, wumboNode, wumboNode3)
-	chanPoint := openChannelAndAssert(
-		t, net, wumboNode, wumboNode3,
-		lntest.OpenChannelParams{
-			Amt: chanAmt,
-		},
+	ht.EnsureConnected(wumboNode, wumboNode3)
+	chanPoint := ht.OpenChannel(
+		wumboNode, wumboNode3, lntemp.OpenChannelParams{Amt: chanAmt},
 	)
-	closeChannelAndAssert(t, net, wumboNode, chanPoint, false)
 
+	ht.CloseChannel(wumboNode, chanPoint)
 }

--- a/lntest/itest/lnd_max_htlcs_test.go
+++ b/lntest/itest/lnd_max_htlcs_test.go
@@ -1,13 +1,11 @@
 package itest
 
 import (
-	"context"
-	"testing"
-
 	"github.com/lightningnetwork/lnd/lnrpc"
 	"github.com/lightningnetwork/lnd/lnrpc/invoicesrpc"
 	"github.com/lightningnetwork/lnd/lnrpc/routerrpc"
-	"github.com/lightningnetwork/lnd/lntest"
+	"github.com/lightningnetwork/lnd/lntemp"
+	"github.com/lightningnetwork/lnd/lntemp/node"
 	"github.com/lightningnetwork/lnd/lntypes"
 	"github.com/stretchr/testify/require"
 )
@@ -16,118 +14,69 @@ import (
 // channel where we have already reached the limit of the number of htlcs that
 // we may add to the remote party's commitment. This test asserts that we do
 // not attempt to use the full channel at all in our pathfinding.
-func testMaxHtlcPathfind(net *lntest.NetworkHarness, t *harnessTest) {
-	ctxb := context.Background()
-
+func testMaxHtlcPathfind(ht *lntemp.HarnessTest) {
 	// Setup a channel between Alice and Bob where Alice will only allow
 	// Bob to add a maximum of 5 htlcs to her commitment.
 	maxHtlcs := 5
 
-	chanPoint := openChannelAndAssert(
-		t, net, net.Alice, net.Bob,
-		lntest.OpenChannelParams{
+	alice, bob := ht.Alice, ht.Bob
+	chanPoint := ht.OpenChannel(
+		alice, bob, lntemp.OpenChannelParams{
 			Amt:            1000000,
 			PushAmt:        800000,
 			RemoteMaxHtlcs: uint16(maxHtlcs),
 		},
 	)
 
-	// Wait for Alice and Bob to receive the channel edge from the
-	// funding manager.
-	err := net.Alice.WaitForNetworkChannelOpen(chanPoint)
-	require.NoError(t.t, err, "alice does not have open channel")
-
-	err = net.Bob.WaitForNetworkChannelOpen(chanPoint)
-	require.NoError(t.t, err, "bob does not have open channel")
-
 	// Alice and bob should have one channel open with each other now.
-	assertNodeNumChannels(t, net.Alice, 1)
-	assertNodeNumChannels(t, net.Bob, 1)
+	ht.AssertNodeNumChannels(alice, 1)
+	ht.AssertNodeNumChannels(bob, 1)
 
 	// Send our maximum number of htlcs from Bob -> Alice so that we get
 	// to a point where Alice won't accept any more htlcs on the channel.
 	subscriptions := make([]*holdSubscription, maxHtlcs)
-	cancelCtxs := make([]func(), maxHtlcs)
 
 	for i := 0; i < maxHtlcs; i++ {
-		subCtx, cancel := context.WithTimeout(ctxb, defaultTimeout)
-		cancelCtxs[i] = cancel
-
-		subscriptions[i] = acceptHoldInvoice(
-			subCtx, t.t, i, net.Bob, net.Alice,
-		)
+		subscriptions[i] = acceptHoldInvoice(ht, i, bob, alice)
 	}
 
-	// Cancel all of our subscriptions on exit.
-	defer func() {
-		for _, cancel := range cancelCtxs {
-			cancel()
-		}
-	}()
-
-	err = assertNumActiveHtlcs([]*lntest.HarnessNode{
-		net.Alice, net.Bob,
-	}, maxHtlcs)
-	require.NoError(t.t, err, "htlcs not active")
+	ht.AssertNumActiveHtlcs(alice, maxHtlcs)
+	ht.AssertNumActiveHtlcs(bob, maxHtlcs)
 
 	// Now we send a payment from Alice -> Bob to sanity check that our
 	// commitment limit is not applied in the opposite direction.
-	subCtx, cancel := context.WithTimeout(ctxb, defaultTimeout)
-	defer cancel()
-	aliceBobSub := acceptHoldInvoice(
-		subCtx, t.t, maxHtlcs, net.Alice, net.Bob,
-	)
-	err = assertNumActiveHtlcs([]*lntest.HarnessNode{
-		net.Alice, net.Bob,
-	}, maxHtlcs+1)
-	require.NoError(t.t, err, "htlcs not active")
+	aliceBobSub := acceptHoldInvoice(ht, maxHtlcs, alice, bob)
+	ht.AssertNumActiveHtlcs(alice, maxHtlcs+1)
+	ht.AssertNumActiveHtlcs(bob, maxHtlcs+1)
 
 	// Now, we're going to try to send another payment from Bob -> Alice.
 	// We've hit our max remote htlcs, so we expect this payment to spin
 	// out dramatically with pathfinding.
-	ctxt, _ := context.WithTimeout(ctxb, defaultTimeout)
-	payment, err := net.Bob.RouterClient.SendPaymentV2(
-		ctxt, &routerrpc.SendPaymentRequest{
-			Amt:            1000,
-			Dest:           net.Alice.PubKey[:],
-			TimeoutSeconds: 60,
-			FeeLimitSat:    1000000,
-			MaxParts:       10,
-			Amp:            true,
-		},
-	)
-	require.NoError(t.t, err, "send payment failed")
-
-	update, err := payment.Recv()
-	require.NoError(t.t, err, "no payment in flight update")
-	require.Equal(t.t, lnrpc.Payment_IN_FLIGHT, update.Status,
-		"payment not inflight")
-
-	update, err = payment.Recv()
-	require.NoError(t.t, err, "no payment failed update")
-	require.Equal(t.t, lnrpc.Payment_FAILED, update.Status)
-	require.Len(t.t, update.Htlcs, 0, "expected no htlcs dispatched")
+	sendReq := &routerrpc.SendPaymentRequest{
+		Amt:            1000,
+		Dest:           alice.PubKey[:],
+		TimeoutSeconds: 60,
+		FeeLimitSat:    1000000,
+		MaxParts:       10,
+		Amp:            true,
+	}
+	ht.SendPaymentAndAssertStatus(bob, sendReq, lnrpc.Payment_FAILED)
 
 	// Now that we're done, we cancel all our pending htlcs so that we
 	// can cleanup the channel with a coop close.
 	for _, sub := range subscriptions {
-		ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
-		sub.cancel(ctxt, t.t)
+		sub.cancel(ht)
 	}
+	aliceBobSub.cancel(ht)
 
-	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
-	aliceBobSub.cancel(ctxt, t.t)
+	ht.AssertNumActiveHtlcs(alice, 0)
+	ht.AssertNumActiveHtlcs(bob, 0)
 
-	err = assertNumActiveHtlcs([]*lntest.HarnessNode{
-		net.Alice, net.Bob,
-	}, 0)
-	require.NoError(t.t, err, "expected all htlcs canceled")
-
-	closeChannelAndAssert(t, net, net.Alice, chanPoint, false)
+	ht.CloseChannel(alice, chanPoint)
 }
 
 type holdSubscription struct {
-	recipient           invoicesrpc.InvoicesClient
+	recipient           *node.HarnessNode
 	hash                lntypes.Hash
 	invSubscription     invoicesrpc.Invoices_SubscribeSingleInvoiceClient
 	paymentSubscription routerrpc.Router_SendPaymentV2Client
@@ -135,89 +84,73 @@ type holdSubscription struct {
 
 // cancel updates a hold invoice to cancel from the recipient and consumes
 // updates from the payer until it has reached a final, failed state.
-func (h *holdSubscription) cancel(ctx context.Context, t *testing.T) {
-	_, err := h.recipient.CancelInvoice(ctx, &invoicesrpc.CancelInvoiceMsg{
-		PaymentHash: h.hash[:],
-	})
-	require.NoError(t, err, "invoice cancel failed")
+func (h *holdSubscription) cancel(ht *lntemp.HarnessTest) {
+	h.recipient.RPC.CancelInvoice(h.hash[:])
 
-	invUpdate, err := h.invSubscription.Recv()
-	require.NoError(t, err, "cancel invoice subscribe failed")
-	require.Equal(t, lnrpc.Invoice_CANCELED, invUpdate.State,
+	invUpdate := ht.ReceiveSingleInvoice(h.invSubscription)
+	require.Equal(ht, lnrpc.Invoice_CANCELED, invUpdate.State,
 		"expected invoice canceled")
 
 	// We expect one in flight update when our htlc is canceled back, and
 	// another when we fail the payment as a whole.
-	payUpdate, err := h.paymentSubscription.Recv()
-	require.NoError(t, err, "cancel payment subscribe failed")
-	require.Len(t, payUpdate.Htlcs, 1)
-	require.Equal(t, lnrpc.Payment_IN_FLIGHT, payUpdate.Status)
+	payUpdate := ht.AssertPaymentStatusFromStream(
+		h.paymentSubscription, lnrpc.Payment_IN_FLIGHT,
+	)
+	require.Len(ht, payUpdate.Htlcs, 1)
 
-	payUpdate, err = h.paymentSubscription.Recv()
-	require.NoError(t, err, "cancel payment subscribe failed")
-	require.Equal(t, lnrpc.Payment_FAILED, payUpdate.Status,
+	payUpdate = ht.AssertPaymentStatusFromStream(
+		h.paymentSubscription, lnrpc.Payment_FAILED,
+	)
+	require.Equal(ht, lnrpc.Payment_FAILED, payUpdate.Status,
 		"expected payment failed")
-	require.Equal(t, lnrpc.PaymentFailureReason_FAILURE_REASON_INCORRECT_PAYMENT_DETAILS,
+	require.Equal(ht, lnrpc.PaymentFailureReason_FAILURE_REASON_INCORRECT_PAYMENT_DETAILS, //nolint:lll
 		payUpdate.FailureReason, "expected unknown details")
 }
 
 // acceptHoldInvoice adds a hold invoice to the recipient node, pays it from
 // the sender and asserts that we have reached the accepted state where htlcs
 // are locked in for the payment.
-func acceptHoldInvoice(ctx context.Context, t *testing.T, idx int, sender,
-	receiver *lntest.HarnessNode) *holdSubscription {
+func acceptHoldInvoice(ht *lntemp.HarnessTest, idx int, sender,
+	receiver *node.HarnessNode) *holdSubscription {
 
 	hash := [lntypes.HashSize]byte{byte(idx + 1)}
 
-	invoice, err := receiver.AddHoldInvoice(
-		ctx, &invoicesrpc.AddHoldInvoiceRequest{
-			ValueMsat: 10000,
-			Hash:      hash[:],
-		},
-	)
-	require.NoError(t, err, "couldn't add invoice")
+	req := &invoicesrpc.AddHoldInvoiceRequest{
+		ValueMsat: 10000,
+		Hash:      hash[:],
+	}
+	invoice := receiver.RPC.AddHoldInvoice(req)
 
-	invStream, err := receiver.InvoicesClient.SubscribeSingleInvoice(
-		ctx, &invoicesrpc.SubscribeSingleInvoiceRequest{
-			RHash: hash[:],
-		},
-	)
-	require.NoError(t, err, "could not subscribe to invoice")
+	invStream := receiver.RPC.SubscribeSingleInvoice(hash[:])
+	inv := ht.ReceiveSingleInvoice(invStream)
+	require.Equal(ht, lnrpc.Invoice_OPEN, inv.State, "expect open")
 
-	inv, err := invStream.Recv()
-	require.NoError(t, err, "invoice open stream failed")
-	require.Equal(t, lnrpc.Invoice_OPEN, inv.State,
-		"expected open")
-
-	payStream, err := sender.RouterClient.SendPaymentV2(
-		ctx, &routerrpc.SendPaymentRequest{
-			PaymentRequest: invoice.PaymentRequest,
-			TimeoutSeconds: 60,
-			FeeLimitSat:    1000000,
-		},
-	)
-	require.NoError(t, err, "send payment failed")
+	sendReq := &routerrpc.SendPaymentRequest{
+		PaymentRequest: invoice.PaymentRequest,
+		TimeoutSeconds: 60,
+		FeeLimitSat:    1000000,
+	}
+	payStream := sender.RPC.SendPayment(sendReq)
 
 	// Finally, assert that we progress to an accepted state. We expect
 	// the payer to get one update for the creation of the payment, and
 	// another when a htlc is dispatched.
-	payment, err := payStream.Recv()
-	require.NoError(t, err, "payment in flight stream failed")
-	require.Equal(t, lnrpc.Payment_IN_FLIGHT, payment.Status)
-	require.Len(t, payment.Htlcs, 0)
+	payment := ht.AssertPaymentStatusFromStream(
+		payStream, lnrpc.Payment_IN_FLIGHT,
+	)
+	require.Empty(ht, payment.Htlcs)
 
-	payment, err = payStream.Recv()
-	require.NoError(t, err, "payment in flight stream failed")
-	require.Equal(t, lnrpc.Payment_IN_FLIGHT, payment.Status)
-	require.Len(t, payment.Htlcs, 1)
+	payment = ht.AssertPaymentStatusFromStream(
+		payStream, lnrpc.Payment_IN_FLIGHT,
+	)
+	require.Len(ht, payment.Htlcs, 1)
 
-	inv, err = invStream.Recv()
-	require.NoError(t, err, "invoice accepted stream failed")
-	require.Equal(t, lnrpc.Invoice_ACCEPTED, inv.State,
-		"expected accepted invoice")
+	inv = ht.ReceiveSingleInvoice(invStream)
+	require.Equal(ht, lnrpc.Invoice_ACCEPTED, inv.State,
+		"expected accepted")
 
 	return &holdSubscription{
-		recipient:           receiver.InvoicesClient,
+		recipient:           receiver,
 		hash:                hash,
 		invSubscription:     invStream,
 		paymentSubscription: payStream,

--- a/lntest/itest/lnd_no_etcd_dummy_failover_test.go
+++ b/lntest/itest/lnd_no_etcd_dummy_failover_test.go
@@ -3,10 +3,8 @@
 
 package itest
 
-import (
-	"github.com/lightningnetwork/lnd/lntest"
-)
+import "github.com/lightningnetwork/lnd/lntemp"
 
 // testEtcdFailover is an empty itest when LND is not compiled with etcd
 // support.
-func testEtcdFailover(net *lntest.NetworkHarness, ht *harnessTest) {}
+func testEtcdFailover(ht *lntemp.HarnessTest) {}

--- a/lntest/itest/lnd_onchain_test.go
+++ b/lntest/itest/lnd_onchain_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"strings"
 	"time"
 
 	"github.com/btcsuite/btcd/btcutil"
@@ -233,17 +232,17 @@ func runCPFP(net *lntest.NetworkHarness, t *harnessTest,
 // testAnchorReservedValue tests that we won't allow sending transactions when
 // that would take the value we reserve for anchor fee bumping out of our
 // wallet.
-func testAnchorReservedValue(net *lntest.NetworkHarness, t *harnessTest) {
+func testAnchorReservedValue(ht *lntemp.HarnessTest) {
 	// Start two nodes supporting anchor channels.
 	args := nodeArgsForCommitType(lnrpc.CommitmentType_ANCHORS)
-	alice := net.NewNode(t.t, "Alice", args)
-	defer shutdownAndAssert(net, t, alice)
 
-	bob := net.NewNode(t.t, "Bob", args)
-	defer shutdownAndAssert(net, t, bob)
+	// NOTE: we cannot reuse the standby node here as the test requires the
+	// node to start with no UTXOs.
+	alice := ht.NewNode("Alice", args)
+	bob := ht.Bob
+	ht.RestartNodeWithExtraArgs(bob, args)
 
-	ctxb := context.Background()
-	net.ConnectNodes(t.t, alice, bob)
+	ht.ConnectNodes(alice, bob)
 
 	// Send just enough coins for Alice to open a channel without a change
 	// output.
@@ -252,100 +251,73 @@ func testAnchorReservedValue(net *lntest.NetworkHarness, t *harnessTest) {
 		feeEst  = 8000
 	)
 
-	net.SendCoins(t.t, chanAmt+feeEst, alice)
+	ht.FundCoins(chanAmt+feeEst, alice)
 
 	// wallet, without a change output. This should not be allowed.
-	resErr := lnwallet.ErrReservedValueInvalidated.Error()
-
-	_, err := net.OpenChannel(
-		alice, bob, lntest.OpenChannelParams{
+	ht.OpenChannelAssertErr(
+		alice, bob, lntemp.OpenChannelParams{
 			Amt: chanAmt,
-		},
+		}, lnwallet.ErrReservedValueInvalidated,
 	)
-	if err == nil || !strings.Contains(err.Error(), resErr) {
-		t.Fatalf("expected failure, got: %v", err)
-	}
 
 	// Alice opens a smaller channel. This works since it will have a
 	// change output.
-	aliceChanPoint1 := openChannelAndAssert(
-		t, net, alice, bob, lntest.OpenChannelParams{
-			Amt: chanAmt / 4,
-		},
+	chanPoint1 := ht.OpenChannel(
+		alice, bob, lntemp.OpenChannelParams{Amt: chanAmt / 4},
 	)
 
 	// If Alice tries to open another anchor channel to Bob, Bob should not
 	// reject it as he is not contributing any funds.
-	aliceChanPoint2 := openChannelAndAssert(
-		t, net, alice, bob, lntest.OpenChannelParams{
-			Amt: chanAmt / 4,
-		},
+	chanPoint2 := ht.OpenChannel(
+		alice, bob, lntemp.OpenChannelParams{Amt: chanAmt / 4},
 	)
 
-	// Similarly, if Alice tries to open a legacy channel to Bob, Bob should
-	// not reject it as he is not contributing any funds. We'll restart Bob
-	// to remove his support for anchors.
-	err = net.RestartNode(bob, nil)
-	require.NoError(t.t, err)
-	aliceChanPoint3 := openChannelAndAssert(
-		t, net, alice, bob, lntest.OpenChannelParams{
-			Amt: chanAmt / 4,
-		},
+	// Similarly, if Alice tries to open a legacy channel to Bob, Bob
+	// should not reject it as he is not contributing any funds. We'll
+	// restart Bob to remove his support for anchors.
+	ht.RestartNode(bob)
+
+	// Before opening the channel, make sure the nodes are connected.
+	ht.EnsureConnected(alice, bob)
+
+	chanPoint3 := ht.OpenChannel(
+		alice, bob, lntemp.OpenChannelParams{Amt: chanAmt / 4},
 	)
-
-	chanPoints := []*lnrpc.ChannelPoint{
-		aliceChanPoint1, aliceChanPoint2, aliceChanPoint3,
-	}
-	for _, chanPoint := range chanPoints {
-		err = alice.WaitForNetworkChannelOpen(chanPoint)
-		require.NoError(t.t, err)
-
-		err = bob.WaitForNetworkChannelOpen(chanPoint)
-		require.NoError(t.t, err)
-	}
+	chanPoints := []*lnrpc.ChannelPoint{chanPoint1, chanPoint2, chanPoint3}
 
 	// Alice tries to send all coins to an internal address. This is
 	// allowed, since the final wallet balance will still be above the
 	// reserved value.
-	addrReq := &lnrpc.NewAddressRequest{
+	req := &lnrpc.NewAddressRequest{
 		Type: lnrpc.AddressType_WITNESS_PUBKEY_HASH,
 	}
-	ctxt, _ := context.WithTimeout(ctxb, defaultTimeout)
-	resp, err := alice.NewAddress(ctxt, addrReq)
-	require.NoError(t.t, err)
+	resp := alice.RPC.NewAddress(req)
 
 	sweepReq := &lnrpc.SendCoinsRequest{
 		Addr:    resp.Address,
 		SendAll: true,
 	}
-	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
-	_, err = alice.SendCoins(ctxt, sweepReq)
-	require.NoError(t.t, err)
+	alice.RPC.SendCoins(sweepReq)
 
-	block := mineBlocks(t, net, 1, 1)[0]
+	block := ht.MineBlocksAndAssertNumTxes(1, 1)[0]
+
+	assertNumTxInAndTxOut := func(tx *wire.MsgTx, in, out int) {
+		require.Len(ht, tx.TxIn, in, "num inputs not matched")
+		require.Len(ht, tx.TxOut, out, "num outputs not matched")
+	}
 
 	// The sweep transaction should have exactly one input, the change from
 	// the previous SendCoins call.
 	sweepTx := block.Transactions[1]
-	if len(sweepTx.TxIn) != 1 {
-		t.Fatalf("expected 1 inputs instead have %v", len(sweepTx.TxIn))
-	}
 
 	// It should have a single output.
-	if len(sweepTx.TxOut) != 1 {
-		t.Fatalf("expected 1 output instead have %v", len(sweepTx.TxOut))
-	}
+	assertNumTxInAndTxOut(sweepTx, 1, 1)
 
 	// Wait for Alice to see her balance as confirmed.
 	waitForConfirmedBalance := func() int64 {
 		var balance int64
 		err := wait.NoError(func() error {
-			req := &lnrpc.WalletBalanceRequest{}
-			ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
-			resp, err := alice.WalletBalance(ctxt, req)
-			if err != nil {
-				return err
-			}
+			resp := alice.RPC.WalletBalance()
 
 			if resp.TotalBalance == 0 {
 				return fmt.Errorf("no balance")
@@ -358,93 +330,51 @@ func testAnchorReservedValue(net *lntest.NetworkHarness, t *harnessTest) {
 			balance = resp.TotalBalance
 			return nil
 		}, defaultTimeout)
-		require.NoError(t.t, err)
+		require.NoError(ht, err, "timeout checking alice's balance")
 
 		return balance
 	}
 
-	_ = waitForConfirmedBalance()
+	waitForConfirmedBalance()
 
 	// Alice tries to send all funds to an external address, the reserved
 	// value must stay in her wallet.
-	minerAddr, err := net.Miner.NewAddress()
-	require.NoError(t.t, err)
+	minerAddr := ht.Miner.NewMinerAddress()
 
 	sweepReq = &lnrpc.SendCoinsRequest{
 		Addr:    minerAddr.String(),
 		SendAll: true,
 	}
-	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
-	_, err = alice.SendCoins(ctxt, sweepReq)
-	require.NoError(t.t, err)
+	alice.RPC.SendCoins(sweepReq)
 
 	// We'll mine a block which should include the sweep transaction we
 	// generated above.
-	block = mineBlocks(t, net, 1, 1)[0]
+	block = ht.MineBlocksAndAssertNumTxes(1, 1)[0]
 
 	// The sweep transaction should have exactly one inputs as we only had
 	// the single output from above in the wallet.
 	sweepTx = block.Transactions[1]
-	if len(sweepTx.TxIn) != 1 {
-		t.Fatalf("expected 1 inputs instead have %v", len(sweepTx.TxIn))
-	}
 
 	// It should have two outputs, one being the miner address, the other
 	// one being the reserve going back to our wallet.
-	if len(sweepTx.TxOut) != 2 {
-		t.Fatalf("expected 2 outputs instead have %v", len(sweepTx.TxOut))
-	}
+	assertNumTxInAndTxOut(sweepTx, 1, 2)
 
 	// The reserved value is now back in Alice's wallet.
 	aliceBalance := waitForConfirmedBalance()
 
-	// The reserved value should be equal to the required reserve for anchor
-	// channels.
-	walletBalanceResp, err := alice.WalletBalance(
-		ctxb, &lnrpc.WalletBalanceRequest{},
-	)
-	require.NoError(t.t, err)
-	require.Equal(
-		t.t, aliceBalance, walletBalanceResp.ReservedBalanceAnchorChan,
-	)
-
-	additionalChannels := int64(1)
-
-	// Required reserve when additional channels are provided.
-	requiredReserveResp, err := alice.WalletKitClient.RequiredReserve(
-		ctxb, &walletrpc.RequiredReserveRequest{
-			AdditionalPublicChannels: uint32(additionalChannels),
-		},
-	)
-	require.NoError(t.t, err)
-
-	additionalReservedValue := btcutil.Amount(additionalChannels *
-		int64(lnwallet.AnchorChanReservedValue))
-	totalReserved := btcutil.Amount(aliceBalance) + additionalReservedValue
-
-	// The total reserved value should not exceed the maximum value reserved
-	// for anchor channels.
-	if totalReserved > lnwallet.MaxAnchorChanReservedValue {
-		totalReserved = lnwallet.MaxAnchorChanReservedValue
-	}
-	require.Equal(
-		t.t, int64(totalReserved), requiredReserveResp.RequiredReserve,
-	)
-
 	// Alice closes channel, should now be allowed to send everything to an
 	// external address.
 	for _, chanPoint := range chanPoints {
-		closeChannelAndAssert(t, net, alice, chanPoint, false)
+		ht.CloseChannel(alice, chanPoint)
 	}
 
 	newBalance := waitForConfirmedBalance()
-	if newBalance <= aliceBalance {
-		t.Fatalf("Alice's balance did not increase after channel close")
-	}
+	require.Greater(ht, newBalance, aliceBalance,
+		"Alice's balance did not increase after channel close")
 
 	// Assert there are no open or pending channels anymore.
-	assertNumPendingChannels(t, alice, 0, 0)
-	assertNodeNumChannels(t, alice, 0)
+	ht.AssertNumWaitingClose(alice, 0)
+	ht.AssertNodeNumChannels(alice, 0)
 
 	// We'll wait for the balance to reflect that the channel has been
 	// closed and the funds are in the wallet.
@@ -452,25 +382,18 @@ func testAnchorReservedValue(net *lntest.NetworkHarness, t *harnessTest) {
 		Addr:    minerAddr.String(),
 		SendAll: true,
 	}
-	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
-	_, err = alice.SendCoins(ctxt, sweepReq)
-	require.NoError(t.t, err)
+	alice.RPC.SendCoins(sweepReq)
 
 	// We'll mine a block which should include the sweep transaction we
 	// generated above.
-	block = mineBlocks(t, net, 1, 1)[0]
+	block = ht.MineBlocksAndAssertNumTxes(1, 1)[0]
 
 	// The sweep transaction should have four inputs, the change output from
 	// the previous sweep, and the outputs from the coop closed channels.
 	sweepTx = block.Transactions[1]
-	if len(sweepTx.TxIn) != 4 {
-		t.Fatalf("expected 4 inputs instead have %v", len(sweepTx.TxIn))
-	}
 
 	// It should have a single output.
-	if len(sweepTx.TxOut) != 1 {
-		t.Fatalf("expected 1 output instead have %v", len(sweepTx.TxOut))
-	}
+	assertNumTxInAndTxOut(sweepTx, 4, 1)
 }
 
 // genAnchorSweep generates a "3rd party" anchor sweeping from an existing one.

--- a/lntest/itest/lnd_psbt_test.go
+++ b/lntest/itest/lnd_psbt_test.go
@@ -435,73 +435,68 @@ func testPsbtChanFundingExternal(ht *lntemp.HarnessTest) {
 	ht.CloseChannel(carol, chanPoint2)
 }
 
-// testPsbtChanFundingSingleStep checks whether PSBT funding works also when the
-// wallet of both nodes are empty and one of them uses PSBT and an external
+// testPsbtChanFundingSingleStep checks whether PSBT funding works also when
+// the wallet of both nodes are empty and one of them uses PSBT and an external
 // wallet to fund the channel while creating reserve output in the same
 // transaction.
-func testPsbtChanFundingSingleStep(net *lntest.NetworkHarness, t *harnessTest) {
-	ctxb := context.Background()
+func testPsbtChanFundingSingleStep(ht *lntemp.HarnessTest) {
 	const chanSize = funding.MaxBtcFundingAmount
-
-	// Everything we do here should be done within a second or two, so we
-	// can just keep a single timeout context around for all calls.
-	ctxt, cancel := context.WithTimeout(ctxb, 2*defaultTimeout)
-	defer cancel()
 
 	args := nodeArgsForCommitType(lnrpc.CommitmentType_ANCHORS)
 
 	// First, we'll create two new nodes that we'll use to open channels
 	// between for this test. But in this case both nodes have an empty
 	// wallet.
-	carol := net.NewNode(t.t, "carol", args)
-	defer shutdownAndAssert(net, t, carol)
+	carol := ht.NewNode("carol", args)
+	defer ht.Shutdown(carol)
 
-	dave := net.NewNode(t.t, "dave", args)
-	defer shutdownAndAssert(net, t, dave)
+	dave := ht.NewNode("dave", args)
+	defer ht.Shutdown(dave)
 
-	net.SendCoins(t.t, btcutil.SatoshiPerBitcoin, net.Alice)
+	alice := ht.Alice
+	ht.FundCoins(btcutil.SatoshiPerBitcoin, alice)
 
 	// Get new address for anchor reserve.
-	reserveAddrReq := &lnrpc.NewAddressRequest{
+	req := &lnrpc.NewAddressRequest{
 		Type: lnrpc.AddressType_WITNESS_PUBKEY_HASH,
 	}
-	addrResp, err := carol.NewAddress(ctxb, reserveAddrReq)
-	require.NoError(t.t, err)
-	reserveAddr, err := btcutil.DecodeAddress(addrResp.Address, harnessNetParams)
-	require.NoError(t.t, err)
+	addrResp := carol.RPC.NewAddress(req)
+	reserveAddr, err := btcutil.DecodeAddress(
+		addrResp.Address, harnessNetParams,
+	)
+	require.NoError(ht, err)
 	reserveAddrScript, err := txscript.PayToAddrScript(reserveAddr)
-	require.NoError(t.t, err)
+	require.NoError(ht, err)
 
 	// Before we start the test, we'll ensure both sides are connected so
 	// the funding flow can be properly executed.
-	net.EnsureConnected(t.t, carol, dave)
+	ht.EnsureConnected(carol, dave)
 
 	// At this point, we can begin our PSBT channel funding workflow. We'll
 	// start by generating a pending channel ID externally that will be used
 	// to track this new funding type.
-	var pendingChanID [32]byte
-	_, err = rand.Read(pendingChanID[:])
-	require.NoError(t.t, err)
+	pendingChanID := ht.Random32Bytes()
 
 	// Now that we have the pending channel ID, Carol will open the channel
 	// by specifying a PSBT shim.
-	chanUpdates, tempPsbt, err := openChannelPsbt(
-		ctxt, carol, dave, lntest.OpenChannelParams{
+	chanUpdates, tempPsbt := ht.OpenChannelPsbt(
+		carol, dave, lntemp.OpenChannelParams{
 			Amt: chanSize,
 			FundingShim: &lnrpc.FundingShim{
 				Shim: &lnrpc.FundingShim_PsbtShim{
 					PsbtShim: &lnrpc.PsbtShim{
-						PendingChanId: pendingChanID[:],
+						PendingChanId: pendingChanID,
 						NoPublish:     false,
 					},
 				},
 			},
 		},
 	)
-	require.NoError(t.t, err)
 
-	decodedPsbt, err := psbt.NewFromRawBytes(bytes.NewReader(tempPsbt), false)
-	require.NoError(t.t, err)
+	decodedPsbt, err := psbt.NewFromRawBytes(
+		bytes.NewReader(tempPsbt), false,
+	)
+	require.NoError(ht, err)
 
 	reserveTxOut := wire.TxOut{
 		Value:    10000,
@@ -515,7 +510,7 @@ func testPsbtChanFundingSingleStep(net *lntest.NetworkHarness, t *harnessTest) {
 
 	var psbtBytes bytes.Buffer
 	err = decodedPsbt.Serialize(&psbtBytes)
-	require.NoError(t.t, err)
+	require.NoError(ht, err)
 
 	fundReq := &walletrpc.FundPsbtRequest{
 		Template: &walletrpc.FundPsbtRequest_Psbt{
@@ -525,55 +520,45 @@ func testPsbtChanFundingSingleStep(net *lntest.NetworkHarness, t *harnessTest) {
 			SatPerVbyte: 2,
 		},
 	}
-	fundResp, err := net.Alice.WalletKitClient.FundPsbt(ctxt, fundReq)
-	require.NoError(t.t, err)
+	fundResp := alice.RPC.FundPsbt(fundReq)
 
 	// Make sure the wallets are actually empty
-	unspentCarol, err := carol.ListUnspent(ctxb, &lnrpc.ListUnspentRequest{})
-	require.NoError(t.t, err)
-	require.Len(t.t, unspentCarol.Utxos, 0)
-
-	unspentDave, err := dave.ListUnspent(ctxb, &lnrpc.ListUnspentRequest{})
-	require.NoError(t.t, err)
-	require.Len(t.t, unspentDave.Utxos, 0)
+	ht.AssertNumUTXOsUnconfirmed(alice, 0)
+	ht.AssertNumUTXOsUnconfirmed(dave, 0)
 
 	// We have a PSBT that has no witness data yet, which is exactly what we
 	// need for the next step: Verify the PSBT with the funding intents.
-	_, err = carol.FundingStateStep(ctxb, &lnrpc.FundingTransitionMsg{
+	carol.RPC.FundingStateStep(&lnrpc.FundingTransitionMsg{
 		Trigger: &lnrpc.FundingTransitionMsg_PsbtVerify{
 			PsbtVerify: &lnrpc.FundingPsbtVerify{
-				PendingChanId: pendingChanID[:],
+				PendingChanId: pendingChanID,
 				FundedPsbt:    fundResp.FundedPsbt,
 			},
 		},
 	})
-	require.NoError(t.t, err)
 
 	// Now we'll ask Alice's wallet to sign the PSBT so we can finish the
 	// funding flow.
 	finalizeReq := &walletrpc.FinalizePsbtRequest{
 		FundedPsbt: fundResp.FundedPsbt,
 	}
-	finalizeRes, err := net.Alice.WalletKitClient.FinalizePsbt(ctxt, finalizeReq)
-	require.NoError(t.t, err)
+	finalizeRes := alice.RPC.FinalizePsbt(finalizeReq)
 
 	// We've signed our PSBT now, let's pass it to the intent again.
-	_, err = carol.FundingStateStep(ctxb, &lnrpc.FundingTransitionMsg{
+	carol.RPC.FundingStateStep(&lnrpc.FundingTransitionMsg{
 		Trigger: &lnrpc.FundingTransitionMsg_PsbtFinalize{
 			PsbtFinalize: &lnrpc.FundingPsbtFinalize{
-				PendingChanId: pendingChanID[:],
+				PendingChanId: pendingChanID,
 				SignedPsbt:    finalizeRes.SignedPsbt,
 			},
 		},
 	})
-	require.NoError(t.t, err)
 
 	// Consume the "channel pending" update. This waits until the funding
 	// transaction was fully compiled.
-	updateResp, err := receiveChanUpdate(ctxt, chanUpdates)
-	require.NoError(t.t, err)
+	updateResp := ht.ReceiveOpenChannelUpdate(chanUpdates)
 	upd, ok := updateResp.Update.(*lnrpc.OpenStatusUpdate_ChanPending)
-	require.True(t.t, ok)
+	require.True(ht, ok)
 	chanPoint := &lnrpc.ChannelPoint{
 		FundingTxid: &lnrpc.ChannelPoint_FundingTxidBytes{
 			FundingTxidBytes: upd.ChanPending.Txid,
@@ -583,13 +568,12 @@ func testPsbtChanFundingSingleStep(net *lntest.NetworkHarness, t *harnessTest) {
 
 	var finalTx wire.MsgTx
 	err = finalTx.Deserialize(bytes.NewReader(finalizeRes.RawFinalTx))
-	require.NoError(t.t, err)
+	require.NoError(ht, err)
 
 	txHash := finalTx.TxHash()
-	block := mineBlocks(t, net, 6, 1)[0]
-	assertTxInBlock(t, block, &txHash)
-	err = carol.WaitForNetworkChannelOpen(chanPoint)
-	require.NoError(t.t, err)
+	block := ht.MineBlocksAndAssertNumTxes(6, 1)[0]
+	ht.Miner.AssertTxInBlock(block, &txHash)
+	ht.AssertTopologyChannelOpen(carol, chanPoint)
 
 	// Next, to make sure the channel functions as normal, we'll make some
 	// payments within the channel.
@@ -598,19 +582,23 @@ func testPsbtChanFundingSingleStep(net *lntest.NetworkHarness, t *harnessTest) {
 		Memo:  "new chans",
 		Value: int64(payAmt),
 	}
-	resp, err := dave.AddInvoice(ctxt, invoice)
-	require.NoError(t.t, err)
-	err = completePaymentRequests(
-		carol, carol.RouterClient, []string{resp.PaymentRequest},
-		true,
-	)
-	require.NoError(t.t, err)
+	resp := dave.RPC.AddInvoice(invoice)
+	ht.CompletePaymentRequests(carol, []string{resp.PaymentRequest})
+
+	// TODO(yy): remove the sleep once the following bug is fixed. When the
+	// payment is reported as settled by Carol, it's expected the
+	// commitment dance is finished and all subsequent states have been
+	// updated. Yet we'd receive the error `cannot co-op close channel with
+	// active htlcs` or `link failed to shutdown` if we close the channel.
+	// We need to investigate the order of settling the payments and
+	// updating commitments to understand and fix .
+	time.Sleep(2 * time.Second)
 
 	// To conclude, we'll close the newly created channel between Carol and
 	// Dave. This function will also block until the channel is closed and
 	// will additionally assert the relevant channel closing post
 	// conditions.
-	closeChannelAndAssert(t, net, carol, chanPoint, false)
+	ht.CloseChannel(carol, chanPoint)
 }
 
 // testSignPsbt tests that the SignPsbt RPC works correctly.

--- a/lntest/itest/lnd_psbt_test.go
+++ b/lntest/itest/lnd_psbt_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"crypto/rand"
 	"fmt"
+	"time"
 
 	"github.com/btcsuite/btcd/btcec/v2"
 	"github.com/btcsuite/btcd/btcec/v2/ecdsa"
@@ -20,6 +21,7 @@ import (
 	"github.com/lightningnetwork/lnd/lnrpc"
 	"github.com/lightningnetwork/lnd/lnrpc/signrpc"
 	"github.com/lightningnetwork/lnd/lnrpc/walletrpc"
+	"github.com/lightningnetwork/lnd/lntemp"
 	"github.com/lightningnetwork/lnd/lntest"
 	"github.com/stretchr/testify/require"
 )
@@ -255,69 +257,56 @@ func runPsbtChanFunding(net *lntest.NetworkHarness, t *harnessTest, carol,
 // and dave by using a Partially Signed Bitcoin Transaction that funds the
 // channel multisig funding output and is fully funded by an external third
 // party.
-func testPsbtChanFundingExternal(net *lntest.NetworkHarness, t *harnessTest) {
-	ctxb := context.Background()
+func testPsbtChanFundingExternal(ht *lntemp.HarnessTest) {
 	const chanSize = funding.MaxBtcFundingAmount
-
-	// Everything we do here should be done within a second or two, so we
-	// can just keep a single timeout context around for all calls.
-	ctxt, cancel := context.WithTimeout(ctxb, defaultTimeout)
-	defer cancel()
 
 	// First, we'll create two new nodes that we'll use to open channels
 	// between for this test. Both these nodes have an empty wallet as Alice
 	// will be funding the channel.
-	carol := net.NewNode(t.t, "carol", nil)
-	defer shutdownAndAssert(net, t, carol)
-
-	dave := net.NewNode(t.t, "dave", nil)
-	defer shutdownAndAssert(net, t, dave)
+	carol := ht.NewNode("carol", nil)
+	dave := ht.NewNode("dave", nil)
 
 	// Before we start the test, we'll ensure both sides are connected so
 	// the funding flow can be properly executed.
-	net.EnsureConnected(t.t, carol, dave)
-	net.EnsureConnected(t.t, carol, net.Alice)
+	alice := ht.Alice
+	ht.EnsureConnected(carol, dave)
+	ht.EnsureConnected(carol, alice)
 
 	// At this point, we can begin our PSBT channel funding workflow. We'll
 	// start by generating a pending channel ID externally that will be used
 	// to track this new funding type.
-	var pendingChanID [32]byte
-	_, err := rand.Read(pendingChanID[:])
-	require.NoError(t.t, err)
+	pendingChanID := ht.Random32Bytes()
 
 	// We'll also test batch funding of two channels so we need another ID.
-	var pendingChanID2 [32]byte
-	_, err = rand.Read(pendingChanID2[:])
-	require.NoError(t.t, err)
+	pendingChanID2 := ht.Random32Bytes()
 
 	// Now that we have the pending channel ID, Carol will open the channel
 	// by specifying a PSBT shim. We use the NoPublish flag here to avoid
 	// publishing the whole batch TX too early.
-	chanUpdates, tempPsbt, err := openChannelPsbt(
-		ctxt, carol, dave, lntest.OpenChannelParams{
+	chanUpdates, tempPsbt := ht.OpenChannelPsbt(
+		carol, dave, lntemp.OpenChannelParams{
 			Amt: chanSize,
 			FundingShim: &lnrpc.FundingShim{
 				Shim: &lnrpc.FundingShim_PsbtShim{
 					PsbtShim: &lnrpc.PsbtShim{
-						PendingChanId: pendingChanID[:],
+						PendingChanId: pendingChanID,
 						NoPublish:     true,
 					},
 				},
 			},
 		},
 	)
-	require.NoError(t.t, err)
 
 	// Let's add a second channel to the batch. This time between Carol and
 	// Alice. We will publish the batch TX once this channel funding is
 	// complete.
-	chanUpdates2, psbtBytes2, err := openChannelPsbt(
-		ctxt, carol, net.Alice, lntest.OpenChannelParams{
+	chanUpdates2, psbtBytes2 := ht.OpenChannelPsbt(
+		carol, alice, lntemp.OpenChannelParams{
 			Amt: chanSize,
 			FundingShim: &lnrpc.FundingShim{
 				Shim: &lnrpc.FundingShim_PsbtShim{
 					PsbtShim: &lnrpc.PsbtShim{
-						PendingChanId: pendingChanID2[:],
+						PendingChanId: pendingChanID2,
 						NoPublish:     true,
 						BasePsbt:      tempPsbt,
 					},
@@ -325,7 +314,6 @@ func testPsbtChanFundingExternal(net *lntest.NetworkHarness, t *harnessTest) {
 			},
 		},
 	)
-	require.NoError(t.t, err)
 
 	// We'll now ask Alice's wallet to fund the PSBT for us. This will
 	// return a packet with inputs and outputs set but without any witness
@@ -338,8 +326,7 @@ func testPsbtChanFundingExternal(net *lntest.NetworkHarness, t *harnessTest) {
 			SatPerVbyte: 2,
 		},
 	}
-	fundResp, err := net.Alice.WalletKitClient.FundPsbt(ctxt, fundReq)
-	require.NoError(t.t, err)
+	fundResp := alice.RPC.FundPsbt(fundReq)
 
 	// We have a PSBT that has no witness data yet, which is exactly what we
 	// need for the next step: Verify the PSBT with the funding intents.
@@ -349,92 +336,77 @@ func testPsbtChanFundingExternal(net *lntest.NetworkHarness, t *harnessTest) {
 	// direct communication with Carol and won't send the signed TX to her
 	// before broadcasting it. So we cannot call the finalize step but
 	// instead just tell lnd to wait for a TX to be published/confirmed.
-	_, err = carol.FundingStateStep(ctxb, &lnrpc.FundingTransitionMsg{
+	carol.RPC.FundingStateStep(&lnrpc.FundingTransitionMsg{
 		Trigger: &lnrpc.FundingTransitionMsg_PsbtVerify{
 			PsbtVerify: &lnrpc.FundingPsbtVerify{
-				PendingChanId: pendingChanID[:],
+				PendingChanId: pendingChanID,
 				FundedPsbt:    fundResp.FundedPsbt,
 				SkipFinalize:  true,
 			},
 		},
 	})
-	require.NoError(t.t, err)
-	_, err = carol.FundingStateStep(ctxb, &lnrpc.FundingTransitionMsg{
+	carol.RPC.FundingStateStep(&lnrpc.FundingTransitionMsg{
 		Trigger: &lnrpc.FundingTransitionMsg_PsbtVerify{
 			PsbtVerify: &lnrpc.FundingPsbtVerify{
-				PendingChanId: pendingChanID2[:],
+				PendingChanId: pendingChanID2,
 				FundedPsbt:    fundResp.FundedPsbt,
 				SkipFinalize:  true,
 			},
 		},
 	})
-	require.NoError(t.t, err)
 
 	// Consume the "channel pending" update. This waits until the funding
 	// transaction was fully compiled for both channels.
-	updateResp, err := receiveChanUpdate(ctxt, chanUpdates)
-	require.NoError(t.t, err)
+	updateResp := ht.ReceiveOpenChannelUpdate(chanUpdates)
 	upd, ok := updateResp.Update.(*lnrpc.OpenStatusUpdate_ChanPending)
-	require.True(t.t, ok)
+	require.True(ht, ok)
 	chanPoint := &lnrpc.ChannelPoint{
 		FundingTxid: &lnrpc.ChannelPoint_FundingTxidBytes{
 			FundingTxidBytes: upd.ChanPending.Txid,
 		},
 		OutputIndex: upd.ChanPending.OutputIndex,
 	}
-	updateResp2, err := receiveChanUpdate(ctxt, chanUpdates2)
-	require.NoError(t.t, err)
+	updateResp2 := ht.ReceiveOpenChannelUpdate(chanUpdates2)
 	upd2, ok := updateResp2.Update.(*lnrpc.OpenStatusUpdate_ChanPending)
-	require.True(t.t, ok)
+	require.True(ht, ok)
 	chanPoint2 := &lnrpc.ChannelPoint{
 		FundingTxid: &lnrpc.ChannelPoint_FundingTxidBytes{
 			FundingTxidBytes: upd2.ChanPending.Txid,
 		},
 		OutputIndex: upd2.ChanPending.OutputIndex,
 	}
-	numPending, err := numOpenChannelsPending(ctxt, carol)
-	require.NoError(t.t, err)
-	require.Equal(t.t, 2, numPending)
+	ht.AssertNumPendingOpenChannels(carol, 2)
 
 	// Now we'll ask Alice's wallet to sign the PSBT so we can finish the
 	// funding flow.
 	finalizeReq := &walletrpc.FinalizePsbtRequest{
 		FundedPsbt: fundResp.FundedPsbt,
 	}
-	finalizeRes, err := net.Alice.WalletKitClient.FinalizePsbt(
-		ctxt, finalizeReq,
-	)
-	require.NoError(t.t, err)
+	finalizeRes := alice.RPC.FinalizePsbt(finalizeReq)
 
 	// No transaction should have been published yet.
-	mempool, err := net.Miner.Client.GetRawMempool()
-	require.NoError(t.t, err)
-	require.Equal(t.t, 0, len(mempool))
+	ht.Miner.AssertNumTxsInMempool(0)
 
 	// Great, now let's publish the final raw transaction.
 	var finalTx wire.MsgTx
-	err = finalTx.Deserialize(bytes.NewReader(finalizeRes.RawFinalTx))
-	require.NoError(t.t, err)
+	err := finalTx.Deserialize(bytes.NewReader(finalizeRes.RawFinalTx))
+	require.NoError(ht, err)
 
 	txHash := finalTx.TxHash()
-	_, err = net.Miner.Client.SendRawTransaction(&finalTx, false)
-	require.NoError(t.t, err)
+	_, err = ht.Miner.Client.SendRawTransaction(&finalTx, false)
+	require.NoError(ht, err)
 
 	// Now we can mine a block to get the transaction confirmed, then wait
 	// for the new channel to be propagated through the network.
-	block := mineBlocks(t, net, 6, 1)[0]
-	assertTxInBlock(t, block, &txHash)
-	err = carol.WaitForNetworkChannelOpen(chanPoint)
-	require.NoError(t.t, err)
-	err = carol.WaitForNetworkChannelOpen(chanPoint2)
-	require.NoError(t.t, err)
+	block := ht.MineBlocksAndAssertNumTxes(6, 1)[0]
+	ht.Miner.AssertTxInBlock(block, &txHash)
+	ht.AssertTopologyChannelOpen(carol, chanPoint)
+	ht.AssertTopologyChannelOpen(carol, chanPoint2)
 
 	// With the channel open, ensure that it is counted towards Carol's
 	// total channel balance.
-	balReq := &lnrpc.ChannelBalanceRequest{}
-	balRes, err := carol.ChannelBalance(ctxt, balReq)
-	require.NoError(t.t, err)
-	require.NotEqual(t.t, int64(0), balRes.LocalBalance.Sat)
+	balRes := carol.RPC.ChannelBalance()
+	require.NotZero(ht, balRes.LocalBalance.Sat)
 
 	// Next, to make sure the channel functions as normal, we'll make some
 	// payments within the channel.
@@ -443,19 +415,24 @@ func testPsbtChanFundingExternal(net *lntest.NetworkHarness, t *harnessTest) {
 		Memo:  "new chans",
 		Value: int64(payAmt),
 	}
-	resp, err := dave.AddInvoice(ctxt, invoice)
-	require.NoError(t.t, err)
-	err = completePaymentRequests(
-		carol, carol.RouterClient, []string{resp.PaymentRequest}, true,
-	)
-	require.NoError(t.t, err)
+	resp := dave.RPC.AddInvoice(invoice)
+	ht.CompletePaymentRequests(carol, []string{resp.PaymentRequest})
+
+	// TODO(yy): remove the sleep once the following bug is fixed. When the
+	// payment is reported as settled by Carol, it's expected the
+	// commitment dance is finished and all subsequent states have been
+	// updated. Yet we'd receive the error `cannot co-op close channel with
+	// active htlcs` or `link failed to shutdown` if we close the channel.
+	// We need to investigate the order of settling the payments and
+	// updating commitments to understand and fix .
+	time.Sleep(2 * time.Second)
 
 	// To conclude, we'll close the newly created channel between Carol and
 	// Dave. This function will also block until the channels are closed and
 	// will additionally assert the relevant channel closing post
 	// conditions.
-	closeChannelAndAssert(t, net, carol, chanPoint, false)
-	closeChannelAndAssert(t, net, carol, chanPoint2, false)
+	ht.CloseChannel(carol, chanPoint)
+	ht.CloseChannel(carol, chanPoint2)
 }
 
 // testPsbtChanFundingSingleStep checks whether PSBT funding works also when the

--- a/lntest/itest/lnd_res_handoff_test.go
+++ b/lntest/itest/lnd_res_handoff_test.go
@@ -5,131 +5,69 @@ import (
 
 	"github.com/btcsuite/btcd/btcutil"
 	"github.com/lightningnetwork/lnd/lnrpc"
-	"github.com/lightningnetwork/lnd/lntest"
-	"github.com/lightningnetwork/lnd/lntest/wait"
+	"github.com/lightningnetwork/lnd/lntemp"
 	"github.com/stretchr/testify/require"
-	"golang.org/x/net/context"
 )
 
 // testResHandoff tests that the contractcourt is able to properly hand-off
 // resolution messages to the switch.
-func testResHandoff(net *lntest.NetworkHarness, t *harnessTest) {
+func testResHandoff(ht *lntemp.HarnessTest) {
 	const (
 		chanAmt    = btcutil.Amount(1000000)
 		paymentAmt = 50000
 	)
 
-	ctxb := context.Background()
+	alice, bob := ht.Alice, ht.Bob
 
 	// First we'll create a channel between Alice and Bob.
-	net.EnsureConnected(t.t, net.Alice, net.Bob)
+	ht.EnsureConnected(alice, bob)
 
-	chanPointAlice := openChannelAndAssert(
-		t, net, net.Alice, net.Bob,
-		lntest.OpenChannelParams{
-			Amt: chanAmt,
-		},
-	)
-	defer closeChannelAndAssert(t, net, net.Alice, chanPointAlice, false)
-
-	// Wait for Alice and Bob to receive the channel edge from the funding
-	// manager.
-	err := net.Alice.WaitForNetworkChannelOpen(chanPointAlice)
-	require.NoError(t.t, err)
-
-	err = net.Bob.WaitForNetworkChannelOpen(chanPointAlice)
-	require.NoError(t.t, err)
+	params := lntemp.OpenChannelParams{Amt: chanAmt}
+	chanPointAlice := ht.OpenChannel(alice, bob, params)
 
 	// Create a new node Carol that will be in hodl mode. This is used to
 	// trigger the behavior of checkRemoteDanglingActions in the
 	// contractcourt. This will cause Bob to fail the HTLC back to Alice.
-	carol := net.NewNode(t.t, "Carol", []string{"--hodl.commit"})
-	defer shutdownAndAssert(net, t, carol)
+	carol := ht.NewNode("Carol", []string{"--hodl.commit"})
+	defer ht.Shutdown(carol)
 
 	// Connect Bob to Carol.
-	net.ConnectNodes(t.t, net.Bob, carol)
+	ht.ConnectNodes(bob, carol)
 
 	// Open a channel between Bob and Carol.
-	chanPointCarol := openChannelAndAssert(
-		t, net, net.Bob, carol,
-		lntest.OpenChannelParams{
-			Amt: chanAmt,
-		},
-	)
-
-	// Wait for Bob and Carol to receive the channel edge from the funding
-	// manager.
-	err = net.Bob.WaitForNetworkChannelOpen(chanPointCarol)
-	require.NoError(t.t, err)
-
-	err = carol.WaitForNetworkChannelOpen(chanPointCarol)
-	require.NoError(t.t, err)
+	chanPointCarol := ht.OpenChannel(bob, carol, params)
 
 	// Wait for Alice to see the channel edge in the graph.
-	err = net.Alice.WaitForNetworkChannelOpen(chanPointCarol)
-	require.NoError(t.t, err)
+	ht.AssertTopologyChannelOpen(alice, chanPointCarol)
 
 	// We'll create an invoice for Carol that Alice will attempt to pay.
 	// Since Carol is in hodl.commit mode, she won't send back any commit
 	// sigs.
-	carolPayReqs, _, _, err := createPayReqs(
-		carol, paymentAmt, 1,
-	)
-	require.NoError(t.t, err)
+	carolPayReqs, _, _ := ht.CreatePayReqs(carol, paymentAmt, 1)
 
 	// Alice will now attempt to fulfill the invoice.
-	err = completePaymentRequests(
-		net.Alice, net.Alice.RouterClient, carolPayReqs, false,
-	)
-	require.NoError(t.t, err)
+	ht.CompletePaymentRequestsNoWait(alice, carolPayReqs, chanPointAlice)
 
 	// Wait until Carol has received the Add, CommitSig from Bob, and has
 	// responded with a RevokeAndAck. We expect NumUpdates to be 1 meaning
 	// Carol's CommitHeight is 1.
-	err = wait.Predicate(func() bool {
-		carolInfo, err := getChanInfo(carol)
-		if err != nil {
-			return false
-		}
-
-		return carolInfo.NumUpdates == 1
-	}, defaultTimeout)
-	require.NoError(t.t, err)
+	ht.AssertChannelCommitHeight(carol, chanPointCarol, 1)
 
 	// Before we shutdown Alice, we'll assert that she only has 1 update.
-	err = wait.Predicate(func() bool {
-		aliceInfo, err := getChanInfo(net.Alice)
-		if err != nil {
-			return false
-		}
-
-		return aliceInfo.NumUpdates == 1
-	}, defaultTimeout)
-	require.NoError(t.t, err)
+	ht.AssertChannelCommitHeight(alice, chanPointAlice, 1)
 
 	// We'll shutdown Alice so that Bob can't connect to her.
-	restartAlice, err := net.SuspendNode(net.Alice)
-	require.NoError(t.t, err)
+	restartAlice := ht.SuspendNode(alice)
 
 	// Bob will now force close his channel with Carol such that resolution
 	// messages are created and forwarded backwards to Alice.
-	_, _, err = net.CloseChannel(net.Bob, chanPointCarol, true)
-	require.NoError(t.t, err)
+	ht.CloseChannelAssertPending(bob, chanPointCarol, true)
 
 	// The channel should be listed in the PendingChannels result.
-	ctxt, cancel := context.WithTimeout(ctxb, defaultTimeout)
-	defer cancel()
+	ht.AssertNumWaitingClose(bob, 1)
 
-	pendingChansRequest := &lnrpc.PendingChannelsRequest{}
-	pendingChanResp, err := net.Bob.PendingChannels(
-		ctxt, pendingChansRequest,
-	)
-	require.NoError(t.t, err)
-	require.NoError(t.t, checkNumWaitingCloseChannels(pendingChanResp, 1))
-
-	// We'll mine a block to confirm the force close transaction and to
-	// advance Bob's contract state with Carol to StateContractClosed.
-	mineBlocks(t, net, 1, 1)
+	// Mine a block to confirm the closing tx.
+	ht.MineBlocks(1)
 
 	// We sleep here so we can be sure that the hand-off has occurred from
 	// Bob's contractcourt to Bob's htlcswitch. This sleep could be removed
@@ -137,64 +75,25 @@ func testResHandoff(net *lntest.NetworkHarness, t *harnessTest) {
 	// querying the state of resolution messages.
 	time.Sleep(10 * time.Second)
 
-	// Mine blocks until Bob has no waiting close channels. This tests
-	// that the circuit-deletion logic is skipped if a resolution message
+	// Mine blocks until Bob has no waiting close channels. This tests that
+	// the circuit-deletion logic is skipped if a resolution message
 	// exists.
-	for {
-		_, err = net.Miner.Client.Generate(1)
-		require.NoError(t.t, err)
-
-		pendingChanResp, err = net.Bob.PendingChannels(
-			ctxt, pendingChansRequest,
-		)
-		require.NoError(t.t, err)
-
-		isErr := checkNumForceClosedChannels(pendingChanResp, 0)
-		if isErr == nil {
-			break
-		}
-
-		time.Sleep(150 * time.Millisecond)
-	}
+	ht.CleanupForceClose(bob, chanPointCarol)
 
 	// We will now restart Bob so that we can test whether the resolution
 	// messages are re-forwarded on start-up.
-	restartBob, err := net.SuspendNode(net.Bob)
-	require.NoError(t.t, err)
-
-	err = restartBob()
-	require.NoError(t.t, err)
+	ht.RestartNode(bob)
 
 	// We'll now also restart Alice and connect her with Bob.
-	err = restartAlice()
-	require.NoError(t.t, err)
+	require.NoError(ht, restartAlice())
 
-	net.EnsureConnected(t.t, net.Alice, net.Bob)
+	ht.EnsureConnected(alice, bob)
 
-	// We'll assert that Alice has received the failure resolution
-	// message.
-	err = wait.Predicate(func() bool {
-		aliceInfo, err := getChanInfo(net.Alice)
-		if err != nil {
-			return false
-		}
-
-		return aliceInfo.NumUpdates == 2
-	}, defaultTimeout)
-	require.NoError(t.t, err)
+	// We'll assert that Alice has received the failure resolution message.
+	ht.AssertChannelCommitHeight(alice, chanPointAlice, 2)
 
 	// Assert that Alice's payment failed.
-	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
-	paymentsResp, err := net.Alice.ListPayments(
-		ctxt, &lnrpc.ListPaymentsRequest{
-			IncludeIncomplete: true,
-		},
-	)
-	require.NoError(t.t, err)
-	require.Equal(t.t, 1, len(paymentsResp.Payments))
+	ht.AssertFirstHTLCError(alice, lnrpc.Failure_PERMANENT_CHANNEL_FAILURE)
 
-	htlcs := paymentsResp.Payments[0].Htlcs
-
-	require.Equal(t.t, 1, len(htlcs))
-	require.Equal(t.t, lnrpc.HTLCAttempt_FAILED, htlcs[0].Status)
+	ht.CloseChannel(alice, chanPointAlice)
 }

--- a/lntest/itest/lnd_rest_api_test.go
+++ b/lntest/itest/lnd_rest_api_test.go
@@ -2,7 +2,6 @@ package itest
 
 import (
 	"bytes"
-	"context"
 	"crypto/tls"
 	"encoding/base64"
 	"encoding/hex"
@@ -24,8 +23,8 @@ import (
 	"github.com/lightningnetwork/lnd/lnrpc/routerrpc"
 	"github.com/lightningnetwork/lnd/lnrpc/verrpc"
 	"github.com/lightningnetwork/lnd/lnrpc/walletrpc"
-	"github.com/lightningnetwork/lnd/lntest"
-	"github.com/stretchr/testify/assert"
+	"github.com/lightningnetwork/lnd/lntemp"
+	"github.com/lightningnetwork/lnd/lntemp/node"
 	"github.com/stretchr/testify/require"
 )
 
@@ -57,19 +56,21 @@ var (
 
 // testRestAPI tests that the most important features of the REST API work
 // correctly.
-func testRestAPI(net *lntest.NetworkHarness, ht *harnessTest) {
+func testRestAPI(ht *lntemp.HarnessTest) {
 	testCases := []struct {
 		name string
-		run  func(*testing.T, *lntest.HarnessNode, *lntest.HarnessNode)
+		run  func(*testing.T, *node.HarnessNode, *node.HarnessNode)
 	}{{
 		name: "simple GET",
-		run: func(t *testing.T, a, b *lntest.HarnessNode) {
+		run: func(t *testing.T, a, b *node.HarnessNode) {
+			t.Helper()
+
 			// Check that the parsing into the response proto
 			// message works.
 			resp := &lnrpc.GetInfoResponse{}
 			err := invokeGET(a, "/v1/getinfo", resp)
 			require.Nil(t, err, "getinfo")
-			assert.Equal(t, "#3399ff", resp.Color, "node color")
+			require.Equal(t, "#3399ff", resp.Color, "node color")
 
 			// Make sure we get the correct field names (snake
 			// case).
@@ -77,20 +78,22 @@ func testRestAPI(net *lntest.NetworkHarness, ht *harnessTest) {
 				a, "/v1/getinfo", "GET", nil, nil,
 			)
 			require.Nil(t, err, "getinfo")
-			assert.Contains(
+			require.Contains(
 				t, string(resp2), "best_header_timestamp",
 				"getinfo",
 			)
 		},
 	}, {
 		name: "simple POST and GET with query param",
-		run: func(t *testing.T, a, b *lntest.HarnessNode) {
+		run: func(t *testing.T, a, b *node.HarnessNode) {
+			t.Helper()
+
 			// Add an invoice, testing POST in the process.
 			req := &lnrpc.Invoice{Value: 1234}
 			resp := &lnrpc.AddInvoiceResponse{}
 			err := invokePOST(a, "/v1/invoices", req, resp)
 			require.Nil(t, err, "add invoice")
-			assert.Equal(t, 32, len(resp.RHash), "invoice rhash")
+			require.Equal(t, 32, len(resp.RHash), "invoice rhash")
 
 			// Make sure we can call a GET endpoint with a hex
 			// encoded URL part.
@@ -98,11 +101,14 @@ func testRestAPI(net *lntest.NetworkHarness, ht *harnessTest) {
 			resp2 := &lnrpc.Invoice{}
 			err = invokeGET(a, url, resp2)
 			require.Nil(t, err, "query invoice")
-			assert.Equal(t, int64(1234), resp2.Value, "invoice amt")
+			require.Equal(t, int64(1234), resp2.Value,
+				"invoice amt")
 		},
 	}, {
 		name: "GET with base64 encoded byte slice in path",
-		run: func(t *testing.T, a, b *lntest.HarnessNode) {
+		run: func(t *testing.T, a, b *node.HarnessNode) {
+			t.Helper()
+
 			url := "/v2/router/mc/probability/%s/%s/%d"
 			url = fmt.Sprintf(
 				url, urlEnc.EncodeToString(a.PubKey[:]),
@@ -115,38 +121,37 @@ func testRestAPI(net *lntest.NetworkHarness, ht *harnessTest) {
 		},
 	}, {
 		name: "GET with map type query param",
-		run: func(t *testing.T, a, b *lntest.HarnessNode) {
-			// Get a new wallet address from Alice.
-			ctxb := context.Background()
-			newAddrReq := &lnrpc.NewAddressRequest{
-				Type: lnrpc.AddressType_WITNESS_PUBKEY_HASH,
-			}
-			addrRes, err := a.NewAddress(ctxb, newAddrReq)
-			require.Nil(t, err, "get address")
+		run: func(t *testing.T, a, b *node.HarnessNode) {
+			t.Helper()
+
+			// Use a fake address.
+			addr := "bcrt1qlutnwklt4u2548cufrjmsjclewugr9lcpnkzag"
 
 			// Create the full URL with the map query param.
 			url := "/v1/transactions/fee?target_conf=%d&" +
 				"AddrToAmount[%s]=%d"
-			url = fmt.Sprintf(url, 2, addrRes.Address, 50000)
+			url = fmt.Sprintf(url, 2, addr, 50000)
 			resp := &lnrpc.EstimateFeeResponse{}
-			err = invokeGET(a, url, resp)
+			err := invokeGET(a, url, resp)
 			require.Nil(t, err, "estimate fee")
-			assert.Greater(t, resp.FeeSat, int64(253), "fee")
+			require.Greater(t, resp.FeeSat, int64(253), "fee")
 		},
 	}, {
 		name: "sub RPC servers REST support",
-		run: func(t *testing.T, a, b *lntest.HarnessNode) {
+		run: func(t *testing.T, a, b *node.HarnessNode) {
+			t.Helper()
+
 			// Query autopilot status.
 			res1 := &autopilotrpc.StatusResponse{}
 			err := invokeGET(a, "/v2/autopilot/status", res1)
 			require.Nil(t, err, "autopilot status")
-			assert.Equal(t, false, res1.Active, "autopilot status")
+			require.Equal(t, false, res1.Active, "autopilot status")
 
 			// Query the version RPC.
 			res2 := &verrpc.Version{}
 			err = invokeGET(a, "/v2/versioner/version", res2)
 			require.Nil(t, err, "version")
-			assert.Greater(
+			require.Greater(
 				t, res2.AppMinor, uint32(0), "lnd minor version",
 			)
 
@@ -157,11 +162,13 @@ func testRestAPI(net *lntest.NetworkHarness, ht *harnessTest) {
 				a, "/v2/wallet/address/next", req1, res3,
 			)
 			require.Nil(t, err, "address")
-			assert.NotEmpty(t, res3.Addr, "address")
+			require.NotEmpty(t, res3.Addr, "address")
 		},
 	}, {
 		name: "CORS headers",
-		run: func(t *testing.T, a, b *lntest.HarnessNode) {
+		run: func(t *testing.T, a, b *node.HarnessNode) {
+			t.Helper()
+
 			// Alice allows all origins. Make sure we get the same
 			// value back in the CORS header that we send in the
 			// Origin header.
@@ -171,12 +178,12 @@ func testRestAPI(net *lntest.NetworkHarness, ht *harnessTest) {
 				a, "/v1/getinfo", "OPTIONS", nil, reqHeaders,
 			)
 			require.Nil(t, err, "getinfo")
-			assert.Equal(
+			require.Equal(
 				t, "https://foo.bar:9999",
 				resHeaders.Get("Access-Control-Allow-Origin"),
 				"CORS header",
 			)
-			assert.Equal(t, 0, len(body))
+			require.Equal(t, 0, len(body))
 
 			// Make sure that we don't get a value set for Bob which
 			// doesn't allow any CORS origin.
@@ -184,17 +191,17 @@ func testRestAPI(net *lntest.NetworkHarness, ht *harnessTest) {
 				b, "/v1/getinfo", "OPTIONS", nil, reqHeaders,
 			)
 			require.Nil(t, err, "getinfo")
-			assert.Equal(
+			require.Equal(
 				t, "",
 				resHeaders.Get("Access-Control-Allow-Origin"),
 				"CORS header",
 			)
-			assert.Equal(t, 0, len(body))
+			require.Equal(t, 0, len(body))
 		},
 	}}
 	wsTestCases := []struct {
 		name string
-		run  func(ht *harnessTest, net *lntest.NetworkHarness)
+		run  func(ht *lntemp.HarnessTest)
 	}{{
 		name: "websocket subscription",
 		run:  wsTestCaseSubscription,
@@ -212,39 +219,33 @@ func testRestAPI(net *lntest.NetworkHarness, ht *harnessTest) {
 	// Make sure Alice allows all CORS origins. Bob will keep the default.
 	// We also make sure the ping/pong messages are sent very often, so we
 	// can test them without waiting half a minute.
-	net.Alice.Cfg.ExtraArgs = append(
-		net.Alice.Cfg.ExtraArgs, "--restcors=\"*\"",
+	alice, bob := ht.Alice, ht.Bob
+	alice.Cfg.ExtraArgs = append(
+		alice.Cfg.ExtraArgs, "--restcors=\"*\"",
 		fmt.Sprintf("--ws-ping-interval=%s", pingInterval),
 		fmt.Sprintf("--ws-pong-wait=%s", pongWait),
 	)
-	err := net.RestartNode(net.Alice, nil)
-	if err != nil {
-		ht.t.Fatalf("Could not restart Alice to set CORS config: %v",
-			err)
-	}
+	ht.RestartNode(alice)
 
 	for _, tc := range testCases {
 		tc := tc
-		ht.t.Run(tc.name, func(t *testing.T) {
-			tc.run(t, net.Alice, net.Bob)
+		ht.Run(tc.name, func(t *testing.T) {
+			tc.run(t, alice, bob)
 		})
 	}
 
 	for _, tc := range wsTestCases {
 		tc := tc
-		ht.t.Run(tc.name, func(t *testing.T) {
-			ht := &harnessTest{
-				t: t, testCase: ht.testCase, lndHarness: net,
-			}
-			tc.run(ht, net)
+		ht.Run(tc.name, func(t *testing.T) {
+			st := ht.Subtest(t)
+			tc.run(st)
 		})
 	}
 }
 
-func wsTestCaseSubscription(ht *harnessTest, net *lntest.NetworkHarness) {
+func wsTestCaseSubscription(ht *lntemp.HarnessTest) {
 	// Find out the current best block so we can subscribe to the next one.
-	hash, height, err := net.Miner.Client.GetBestBlock()
-	require.Nil(ht.t, err, "get best block")
+	hash, height := ht.Miner.GetBestBlock()
 
 	// Create a new subscription to get block epoch events.
 	req := &chainrpc.BlockEpoch{
@@ -252,11 +253,11 @@ func wsTestCaseSubscription(ht *harnessTest, net *lntest.NetworkHarness) {
 		Height: uint32(height),
 	}
 	url := "/v2/chainnotifier/register/blocks"
-	c, err := openWebSocket(net.Alice, url, "POST", req, nil)
-	require.Nil(ht.t, err, "websocket")
+	c, err := openWebSocket(ht.Alice, url, "POST", req, nil)
+	require.NoError(ht, err, "websocket")
 	defer func() {
 		err := c.WriteMessage(websocket.CloseMessage, closeMsg)
-		require.NoError(ht.t, err)
+		require.NoError(ht, err)
 		_ = c.Close()
 	}()
 
@@ -300,30 +301,25 @@ func wsTestCaseSubscription(ht *harnessTest, net *lntest.NetworkHarness) {
 	}()
 
 	// Mine a block and make sure we get a message for it.
-	blockHashes, err := net.Miner.Client.Generate(1)
-	require.Nil(ht.t, err, "generate blocks")
-	assert.Equal(ht.t, 1, len(blockHashes), "num blocks")
+	blockHashes := ht.Miner.GenerateBlocks(1)
 	select {
 	case msg := <-msgChan:
-		assert.Equal(
-			ht.t, blockHashes[0].CloneBytes(), msg.Hash,
+		require.Equal(
+			ht, blockHashes[0].CloneBytes(), msg.Hash,
 			"block hash",
 		)
 
 	case err := <-errChan:
-		ht.t.Fatalf("Received error from WS: %v", err)
+		ht.Fatalf("Received error from WS: %v", err)
 
 	case <-timeout:
-		ht.t.Fatalf("Timeout before message was received")
+		ht.Fatalf("Timeout before message was received")
 	}
 }
 
-func wsTestCaseSubscriptionMacaroon(ht *harnessTest,
-	net *lntest.NetworkHarness) {
-
+func wsTestCaseSubscriptionMacaroon(ht *lntemp.HarnessTest) {
 	// Find out the current best block so we can subscribe to the next one.
-	hash, height, err := net.Miner.Client.GetBestBlock()
-	require.Nil(ht.t, err, "get best block")
+	hash, height := ht.Miner.GetBestBlock()
 
 	// Create a new subscription to get block epoch events.
 	req := &chainrpc.BlockEpoch{
@@ -335,22 +331,23 @@ func wsTestCaseSubscriptionMacaroon(ht *harnessTest,
 	// This time we send the macaroon in the special header
 	// Sec-Websocket-Protocol which is the only header field available to
 	// browsers when opening a WebSocket.
-	mac, err := net.Alice.ReadMacaroon(
-		net.Alice.AdminMacPath(), defaultTimeout,
+	alice := ht.Alice
+	mac, err := alice.ReadMacaroon(
+		alice.Cfg.AdminMacPath, defaultTimeout,
 	)
-	require.NoError(ht.t, err, "read admin mac")
+	require.NoError(ht, err, "read admin mac")
 	macBytes, err := mac.MarshalBinary()
-	require.NoError(ht.t, err, "marshal admin mac")
+	require.NoError(ht, err, "marshal admin mac")
 
 	customHeader := make(http.Header)
 	customHeader.Set(lnrpc.HeaderWebSocketProtocol, fmt.Sprintf(
 		"Grpc-Metadata-Macaroon+%s", hex.EncodeToString(macBytes),
 	))
-	c, err := openWebSocket(net.Alice, url, "POST", req, customHeader)
-	require.Nil(ht.t, err, "websocket")
+	c, err := openWebSocket(alice, url, "POST", req, customHeader)
+	require.Nil(ht, err, "websocket")
 	defer func() {
 		err := c.WriteMessage(websocket.CloseMessage, closeMsg)
-		require.NoError(ht.t, err)
+		require.NoError(ht, err)
 		_ = c.Close()
 	}()
 
@@ -394,52 +391,49 @@ func wsTestCaseSubscriptionMacaroon(ht *harnessTest,
 	}()
 
 	// Mine a block and make sure we get a message for it.
-	blockHashes, err := net.Miner.Client.Generate(1)
-	require.Nil(ht.t, err, "generate blocks")
-	assert.Equal(ht.t, 1, len(blockHashes), "num blocks")
+	blockHashes := ht.Miner.GenerateBlocks(1)
 	select {
 	case msg := <-msgChan:
-		assert.Equal(
-			ht.t, blockHashes[0].CloneBytes(), msg.Hash,
+		require.Equal(
+			ht, blockHashes[0].CloneBytes(), msg.Hash,
 			"block hash",
 		)
 
 	case err := <-errChan:
-		ht.t.Fatalf("Received error from WS: %v", err)
+		ht.Fatalf("Received error from WS: %v", err)
 
 	case <-timeout:
-		ht.t.Fatalf("Timeout before message was received")
+		ht.Fatalf("Timeout before message was received")
 	}
 }
 
-func wsTestCaseBiDirectionalSubscription(ht *harnessTest,
-	net *lntest.NetworkHarness) {
-
+func wsTestCaseBiDirectionalSubscription(ht *lntemp.HarnessTest) {
 	initialRequest := &lnrpc.ChannelAcceptResponse{}
 	url := "/v1/channels/acceptor"
 
 	// This time we send the macaroon in the special header
 	// Sec-Websocket-Protocol which is the only header field available to
 	// browsers when opening a WebSocket.
-	mac, err := net.Alice.ReadMacaroon(
-		net.Alice.AdminMacPath(), defaultTimeout,
+	alice := ht.Alice
+	mac, err := alice.ReadMacaroon(
+		alice.Cfg.AdminMacPath, defaultTimeout,
 	)
-	require.NoError(ht.t, err, "read admin mac")
+	require.NoError(ht, err, "read admin mac")
 	macBytes, err := mac.MarshalBinary()
-	require.NoError(ht.t, err, "marshal admin mac")
+	require.NoError(ht, err, "marshal admin mac")
 
 	customHeader := make(http.Header)
 	customHeader.Set(lnrpc.HeaderWebSocketProtocol, fmt.Sprintf(
 		"Grpc-Metadata-Macaroon+%s", hex.EncodeToString(macBytes),
 	))
 	conn, err := openWebSocket(
-		net.Alice, url, "POST", initialRequest, customHeader,
+		alice, url, "POST", initialRequest, customHeader,
 	)
-	require.Nil(ht.t, err, "websocket")
+	require.Nil(ht, err, "websocket")
 	defer func() {
 		err := conn.WriteMessage(websocket.CloseMessage, closeMsg)
 		_ = conn.Close()
-		require.NoError(ht.t, err)
+		require.NoError(ht, err)
 	}()
 
 	// Buffer the message channel to make sure we're always blocking on
@@ -528,29 +522,30 @@ func wsTestCaseBiDirectionalSubscription(ht *harnessTest,
 
 	// Before we start opening channels, make sure the two nodes are
 	// connected.
-	net.EnsureConnected(ht.t, net.Alice, net.Bob)
+	bob := ht.Bob
+	ht.EnsureConnected(alice, bob)
 
 	// Open 3 channels to make sure multiple requests and responses can be
 	// sent over the web socket.
 	const numChannels = 3
 	for i := 0; i < numChannels; i++ {
-		openChannelAndAssert(
-			ht, net, net.Bob, net.Alice,
-			lntest.OpenChannelParams{Amt: 500000},
+		chanPoint := ht.OpenChannel(
+			bob, alice, lntemp.OpenChannelParams{Amt: 500000},
 		)
+		defer ht.CloseChannel(bob, chanPoint)
 
 		select {
 		case <-msgChan:
 		case err := <-errChan:
-			ht.t.Fatalf("Received error from WS: %v", err)
+			ht.Fatalf("Received error from WS: %v", err)
 
 		case <-timeout:
-			ht.t.Fatalf("Timeout before message was received")
+			ht.Fatalf("Timeout before message was received")
 		}
 	}
 }
 
-func wsTestPingPongTimeout(ht *harnessTest, net *lntest.NetworkHarness) {
+func wsTestPingPongTimeout(ht *lntemp.HarnessTest) {
 	initialRequest := &lnrpc.InvoiceSubscription{
 		AddIndex: 1, SettleIndex: 1,
 	}
@@ -559,25 +554,26 @@ func wsTestPingPongTimeout(ht *harnessTest, net *lntest.NetworkHarness) {
 	// This time we send the macaroon in the special header
 	// Sec-Websocket-Protocol which is the only header field available to
 	// browsers when opening a WebSocket.
-	mac, err := net.Alice.ReadMacaroon(
-		net.Alice.AdminMacPath(), defaultTimeout,
+	alice := ht.Alice
+	mac, err := alice.ReadMacaroon(
+		alice.Cfg.AdminMacPath, defaultTimeout,
 	)
-	require.NoError(ht.t, err, "read admin mac")
+	require.NoError(ht, err, "read admin mac")
 	macBytes, err := mac.MarshalBinary()
-	require.NoError(ht.t, err, "marshal admin mac")
+	require.NoError(ht, err, "marshal admin mac")
 
 	customHeader := make(http.Header)
 	customHeader.Set(lnrpc.HeaderWebSocketProtocol, fmt.Sprintf(
 		"Grpc-Metadata-Macaroon+%s", hex.EncodeToString(macBytes),
 	))
 	conn, err := openWebSocket(
-		net.Alice, url, "GET", initialRequest, customHeader,
+		alice, url, "GET", initialRequest, customHeader,
 	)
-	require.Nil(ht.t, err, "websocket")
+	require.Nil(ht, err, "websocket")
 	defer func() {
 		err := conn.WriteMessage(websocket.CloseMessage, closeMsg)
 		_ = conn.Close()
-		require.NoError(ht.t, err)
+		require.NoError(ht, err)
 	}()
 
 	// We want to be able to read invoices for a long time, making sure we
@@ -650,27 +646,26 @@ func wsTestPingPongTimeout(ht *harnessTest, net *lntest.NetworkHarness) {
 
 	// Let's create five invoices and wait for them to arrive. We'll wait
 	// for at least one ping/pong cycle between each invoice.
-	ctxb := context.Background()
 	const numInvoices = 5
 	const value = 123
 	const memo = "websocket"
 	for i := 0; i < numInvoices; i++ {
-		_, err := net.Alice.AddInvoice(ctxb, &lnrpc.Invoice{
+		invoice := &lnrpc.Invoice{
 			Value: value,
 			Memo:  memo,
-		})
-		require.NoError(ht.t, err)
+		}
+		alice.RPC.AddInvoice(invoice)
 
 		select {
 		case streamMsg := <-invoices:
-			require.Equal(ht.t, int64(value), streamMsg.Value)
-			require.Equal(ht.t, memo, streamMsg.Memo)
+			require.Equal(ht, int64(value), streamMsg.Value)
+			require.Equal(ht, memo, streamMsg.Memo)
 
 		case err := <-errChan:
-			require.Fail(ht.t, "Error reading invoice: %v", err)
+			require.Fail(ht, "Error reading invoice: %v", err)
 
 		case <-timeout:
-			require.Fail(ht.t, "No invoice msg received in time")
+			require.Fail(ht, "No invoice msg received in time")
 		}
 
 		// Let's wait for at least a whole ping/pong cycle to happen, so
@@ -683,7 +678,7 @@ func wsTestPingPongTimeout(ht *harnessTest, net *lntest.NetworkHarness) {
 // invokeGET calls the given URL with the GET method and appropriate macaroon
 // header fields then tries to unmarshal the response into the given response
 // proto message.
-func invokeGET(node *lntest.HarnessNode, url string, resp proto.Message) error {
+func invokeGET(node *node.HarnessNode, url string, resp proto.Message) error {
 	_, rawResp, err := makeRequest(node, url, "GET", nil, nil)
 	if err != nil {
 		return err
@@ -695,7 +690,7 @@ func invokeGET(node *lntest.HarnessNode, url string, resp proto.Message) error {
 // invokePOST calls the given URL with the POST method, request body and
 // appropriate macaroon header fields then tries to unmarshal the response into
 // the given response proto message.
-func invokePOST(node *lntest.HarnessNode, url string, req,
+func invokePOST(node *node.HarnessNode, url string, req,
 	resp proto.Message) error {
 
 	// Marshal the request to JSON using the jsonpb marshaler to get correct
@@ -715,7 +710,7 @@ func invokePOST(node *lntest.HarnessNode, url string, req,
 
 // makeRequest calls the given URL with the given method, request body and
 // appropriate macaroon header fields and returns the raw response body.
-func makeRequest(node *lntest.HarnessNode, url, method string,
+func makeRequest(node *node.HarnessNode, url, method string,
 	request io.Reader, additionalHeaders http.Header) (http.Header, []byte,
 	error) {
 
@@ -748,7 +743,7 @@ func makeRequest(node *lntest.HarnessNode, url, method string,
 
 // openWebSocket opens a new WebSocket connection to the given URL with the
 // appropriate macaroon headers and sends the request message over the socket.
-func openWebSocket(node *lntest.HarnessNode, url, method string,
+func openWebSocket(node *node.HarnessNode, url, method string,
 	req proto.Message, customHeader http.Header) (*websocket.Conn, error) {
 
 	// Prepare our macaroon headers and assemble the full URL from the
@@ -785,8 +780,8 @@ func openWebSocket(node *lntest.HarnessNode, url, method string,
 
 // addAdminMacaroon reads the admin macaroon from the node and appends it to
 // the HTTP header fields.
-func addAdminMacaroon(node *lntest.HarnessNode, header http.Header) error {
-	mac, err := node.ReadMacaroon(node.AdminMacPath(), defaultTimeout)
+func addAdminMacaroon(node *node.HarnessNode, header http.Header) error {
+	mac, err := node.ReadMacaroon(node.Cfg.AdminMacPath, defaultTimeout)
 	if err != nil {
 		return err
 	}

--- a/lntest/itest/lnd_revocation_test.go
+++ b/lntest/itest/lnd_revocation_test.go
@@ -688,6 +688,11 @@ func testRevokedCloseRetributionAltruistWatchtowerCase(ht *lntemp.HarnessTest,
 	// directly from the miner.
 	ht.FundCoins(btcutil.SatoshiPerBitcoin, dave)
 
+	// Send one more UTXOs if this is a neutrino backend.
+	if ht.IsNeutrinoBackend() {
+		ht.FundCoins(btcutil.SatoshiPerBitcoin, dave)
+	}
+
 	// In order to test Dave's response to an uncooperative channel
 	// closure by Carol, we'll first open up a channel between them with a
 	// 0.5 BTC value.

--- a/lntest/itest/lnd_revocation_test.go
+++ b/lntest/itest/lnd_revocation_test.go
@@ -849,6 +849,11 @@ func testRevokedCloseRetributionAltruistWatchtowerCase(ht *lntemp.HarnessTest,
 
 	ht.AssertNumPendingForceClose(dave, 0)
 
+	// If this is an anchor channel, Dave would sweep the anchor.
+	if anchors {
+		ht.MineBlocksAndAssertNumTxes(1, 1)
+	}
+
 	// Check that Dave's wallet balance is increased.
 	err = wait.NoError(func() error {
 		daveBalResp := dave.RPC.WalletBalance()

--- a/lntest/itest/lnd_revocation_test.go
+++ b/lntest/itest/lnd_revocation_test.go
@@ -301,9 +301,7 @@ func testRevokedCloseRetributionZeroValueRemoteOutput(ht *lntemp.HarnessTest) {
 // testRevokedCloseRetributionRemoteHodl tests that Dave properly responds to a
 // channel breach made by the remote party, specifically in the case that the
 // remote party breaches before settling extended HTLCs.
-func testRevokedCloseRetributionRemoteHodl(net *lntest.NetworkHarness,
-	t *harnessTest) {
-
+func testRevokedCloseRetributionRemoteHodl(ht *lntemp.HarnessTest) {
 	const (
 		chanAmt     = funding.MaxBtcFundingAmount
 		pushAmt     = 200000
@@ -314,34 +312,31 @@ func testRevokedCloseRetributionRemoteHodl(net *lntest.NetworkHarness,
 	// Since this test will result in the counterparty being left in a
 	// weird state, we will introduce another node into our test network:
 	// Carol.
-	carol := net.NewNode(t.t, "Carol", []string{"--hodl.exit-settle"})
-	defer shutdownAndAssert(net, t, carol)
+	carol := ht.NewNode("Carol", []string{"--hodl.exit-settle"})
 
 	// We'll also create a new node Dave, who will have a channel with
 	// Carol, and also use similar settings so we can broadcast a commit
 	// with active HTLCs. Dave will be the breached party. We set
 	// --nolisten to ensure Carol won't be able to connect to him and
 	// trigger the channel data protection logic automatically.
-	dave := net.NewNode(
-		t.t, "Dave",
+	dave := ht.NewNode(
+		"Dave",
 		[]string{"--hodl.exit-settle", "--nolisten"},
 	)
-	defer shutdownAndAssert(net, t, dave)
 
 	// We must let Dave communicate with Carol before they are able to open
 	// channel, so we connect Dave and Carol,
-	net.ConnectNodes(t.t, dave, carol)
+	ht.ConnectNodes(dave, carol)
 
 	// Before we make a channel, we'll load up Dave with some coins sent
 	// directly from the miner.
-	net.SendCoins(t.t, btcutil.SatoshiPerBitcoin, dave)
+	ht.FundCoins(btcutil.SatoshiPerBitcoin, dave)
 
 	// In order to test Dave's response to an uncooperative channel closure
 	// by Carol, we'll first open up a channel between them with a
 	// funding.MaxBtcFundingAmount (2^24) satoshis value.
-	chanPoint := openChannelAndAssert(
-		t, net, dave, carol,
-		lntest.OpenChannelParams{
+	chanPoint := ht.OpenChannel(
+		dave, carol, lntemp.OpenChannelParams{
 			Amt:     chanAmt,
 			PushAmt: pushAmt,
 		},
@@ -349,206 +344,122 @@ func testRevokedCloseRetributionRemoteHodl(net *lntest.NetworkHarness,
 
 	// With the channel open, we'll create a few invoices for Carol that
 	// Dave will pay to in order to advance the state of the channel.
-	carolPayReqs, _, _, err := createPayReqs(
-		carol, paymentAmt, numInvoices,
-	)
-	if err != nil {
-		t.Fatalf("unable to create pay reqs: %v", err)
-	}
+	carolPayReqs, _, _ := ht.CreatePayReqs(carol, paymentAmt, numInvoices)
 
-	// We'll introduce a closure to validate that Carol's current balance
-	// matches the given expected amount.
-	checkCarolBalance := func(expectedAmt int64) {
-		carolChan, err := getChanInfo(carol)
-		if err != nil {
-			t.Fatalf("unable to get carol's channel info: %v", err)
-		}
-		if carolChan.LocalBalance != expectedAmt {
-			t.Fatalf("carol's balance is incorrect, "+
-				"got %v, expected %v", carolChan.LocalBalance,
-				expectedAmt)
-		}
-	}
-
-	// We'll introduce another closure to validate that Carol's current
+	// We'll introduce an closure to validate that Carol's current
 	// number of updates is at least as large as the provided minimum
 	// number.
-	checkCarolNumUpdatesAtLeast := func(minimum uint64) {
-		carolChan, err := getChanInfo(carol)
-		if err != nil {
-			t.Fatalf("unable to get carol's channel info: %v", err)
-		}
-		if carolChan.NumUpdates < minimum {
-			t.Fatalf("carol's numupdates is incorrect, want %v "+
-				"to be at least %v", carolChan.NumUpdates,
-				minimum)
-		}
-	}
+	checkCarolNumUpdatesAtLeast := func(carolChan *lnrpc.Channel,
+		minimum int) {
 
-	// Wait for Dave to receive the channel edge from the funding manager.
-	err = dave.WaitForNetworkChannelOpen(chanPoint)
-	if err != nil {
-		t.Fatalf("dave didn't see the dave->carol channel before "+
-			"timeout: %v", err)
+		require.GreaterOrEqual(ht, int(carolChan.NumUpdates), minimum,
+			"carol's numupdates is incorrect")
 	}
 
 	// Ensure that carol's balance starts with the amount we pushed to her.
-	checkCarolBalance(pushAmt)
+	ht.AssertChannelLocalBalance(carol, chanPoint, pushAmt)
 
 	// Send payments from Dave to Carol using 3 of Carol's payment hashes
 	// generated above.
-	err = completePaymentRequests(
-		dave, dave.RouterClient, carolPayReqs[:numInvoices/2], false,
+	ht.CompletePaymentRequestsNoWait(
+		dave, carolPayReqs[:numInvoices/2], chanPoint,
 	)
-	if err != nil {
-		t.Fatalf("unable to send payments: %v", err)
-	}
 
 	// At this point, we'll also send over a set of HTLC's from Carol to
 	// Dave. This ensures that the final revoked transaction has HTLC's in
 	// both directions.
-	davePayReqs, _, _, err := createPayReqs(
-		dave, paymentAmt, numInvoices,
-	)
-	if err != nil {
-		t.Fatalf("unable to create pay reqs: %v", err)
-	}
+	davePayReqs, _, _ := ht.CreatePayReqs(dave, paymentAmt, numInvoices)
 
 	// Send payments from Carol to Dave using 3 of Dave's payment hashes
 	// generated above.
-	err = completePaymentRequests(
-		carol, carol.RouterClient, davePayReqs[:numInvoices/2], false,
+	ht.CompletePaymentRequestsNoWait(
+		carol, davePayReqs[:numInvoices/2], chanPoint,
 	)
-	if err != nil {
-		t.Fatalf("unable to send payments: %v", err)
-	}
 
 	// Next query for Carol's channel state, as we sent 3 payments of 10k
 	// satoshis each, however Carol should now see her balance as being
 	// equal to the push amount in satoshis since she has not settled.
-	carolChan, err := getChanInfo(carol)
-	if err != nil {
-		t.Fatalf("unable to get carol's channel info: %v", err)
-	}
+
+	// Ensure that carol's balance still reflects the original amount we
+	// pushed to her, minus the HTLCs she just sent to Dave.
+	carolChan := ht.AssertChannelLocalBalance(
+		carol, chanPoint, pushAmt-3*paymentAmt,
+	)
 
 	// Grab Carol's current commitment height (update number), we'll later
 	// revert her to this state after additional updates to force her to
 	// broadcast this soon to be revoked state.
-	carolStateNumPreCopy := carolChan.NumUpdates
-
-	// Ensure that carol's balance still reflects the original amount we
-	// pushed to her, minus the HTLCs she just sent to Dave.
-	checkCarolBalance(pushAmt - 3*paymentAmt)
+	carolStateNumPreCopy := int(carolChan.NumUpdates)
 
 	// Since Carol has not settled, she should only see at least one update
 	// to her channel.
-	checkCarolNumUpdatesAtLeast(1)
+	checkCarolNumUpdatesAtLeast(carolChan, 1)
 
 	// With the temporary file created, copy Carol's current state into the
 	// temporary file we created above. Later after more updates, we'll
 	// restore this state.
-	if err := net.BackupDb(carol); err != nil {
-		t.Fatalf("unable to copy database files: %v", err)
-	}
+	ht.BackupDB(carol)
 
 	// Reconnect the peers after the restart that was needed for the db
 	// backup.
-	net.EnsureConnected(t.t, dave, carol)
+	ht.EnsureConnected(dave, carol)
 
 	// Finally, send payments from Dave to Carol, consuming Carol's
 	// remaining payment hashes.
-	err = completePaymentRequests(
-		dave, dave.RouterClient, carolPayReqs[numInvoices/2:], false,
+	ht.CompletePaymentRequestsNoWait(
+		dave, carolPayReqs[numInvoices/2:], chanPoint,
 	)
-	if err != nil {
-		t.Fatalf("unable to send payments: %v", err)
-	}
 
 	// Ensure that carol's balance still shows the amount we originally
 	// pushed to her (minus the HTLCs she sent to Bob), and that at least
 	// one more update has occurred.
-	time.Sleep(500 * time.Millisecond)
-	checkCarolBalance(pushAmt - 3*paymentAmt)
-	checkCarolNumUpdatesAtLeast(carolStateNumPreCopy + 1)
+	carolChan = ht.AssertChannelLocalBalance(
+		carol, chanPoint, pushAmt-3*paymentAmt,
+	)
+	checkCarolNumUpdatesAtLeast(carolChan, carolStateNumPreCopy+1)
 
 	// Suspend Dave, such that Carol won't reconnect at startup, triggering
 	// the data loss protection.
-	restartDave, err := net.SuspendNode(dave)
-	if err != nil {
-		t.Fatalf("unable to suspend Dave: %v", err)
-	}
+	restartDave := ht.SuspendNode(dave)
 
 	// Now we shutdown Carol, copying over the her temporary database state
 	// which has the *prior* channel state over her current most up to date
 	// state. With this, we essentially force Carol to travel back in time
 	// within the channel's history.
-	if err = net.RestartNode(carol, func() error {
-		return net.RestoreDb(carol)
-	}); err != nil {
-		t.Fatalf("unable to restart node: %v", err)
-	}
-
-	time.Sleep(200 * time.Millisecond)
+	ht.RestartNodeAndRestoreDB(carol)
 
 	// Ensure that Carol's view of the channel is consistent with the state
 	// of the channel just before it was snapshotted.
-	checkCarolBalance(pushAmt - 3*paymentAmt)
-	checkCarolNumUpdatesAtLeast(1)
+	carolChan = ht.AssertChannelLocalBalance(
+		carol, chanPoint, pushAmt-3*paymentAmt,
+	)
+	checkCarolNumUpdatesAtLeast(carolChan, 1)
 
 	// Now query for Carol's channel state, it should show that she's at a
 	// state number in the past, *not* the latest state.
-	carolChan, err = getChanInfo(carol)
-	if err != nil {
-		t.Fatalf("unable to get carol chan info: %v", err)
-	}
-	if carolChan.NumUpdates != carolStateNumPreCopy {
-		t.Fatalf("db copy failed: %v", carolChan.NumUpdates)
-	}
+	ht.AssertChannelCommitHeight(carol, chanPoint, carolStateNumPreCopy)
 
 	// Now force Carol to execute a *force* channel closure by unilaterally
 	// broadcasting her current channel state. This is actually the
 	// commitment transaction of a prior *revoked* state, so she'll soon
 	// feel the wrath of Dave's retribution.
-	force := true
-	closeUpdates, closeTxID, err := net.CloseChannel(
-		carol, chanPoint, force,
+	closeUpdates, closeTxID := ht.CloseChannelAssertPending(
+		carol, chanPoint, true,
 	)
-	if err != nil {
-		t.Fatalf("unable to close channel: %v", err)
-	}
-
-	// Query the mempool for the breaching closing transaction, this should
-	// be broadcast by Carol when she force closes the channel above.
-	txid, err := waitForTxInMempool(net.Miner.Client, minerMempoolTimeout)
-	if err != nil {
-		t.Fatalf("unable to find Carol's force close tx in mempool: %v",
-			err)
-	}
-	if *txid != *closeTxID {
-		t.Fatalf("expected closeTx(%v) in mempool, instead found %v",
-			closeTxID, txid)
-	}
 
 	// Generate a single block to mine the breach transaction.
-	block := mineBlocks(t, net, 1, 1)[0]
+	block := ht.MineBlocksAndAssertNumTxes(1, 1)[0]
 
 	// We resurrect Dave to ensure he will be exacting justice after his
 	// node restarts.
-	if err := restartDave(); err != nil {
-		t.Fatalf("unable to stop Dave's node: %v", err)
-	}
+	require.NoError(ht, restartDave(), "unable to restart Dave's node")
 
 	// Finally, wait for the final close status update, then ensure that
 	// the closing transaction was included in the block.
-	breachTXID, err := net.WaitForChannelClose(closeUpdates)
-	if err != nil {
-		t.Fatalf("error while waiting for channel close: %v", err)
-	}
-	if *breachTXID != *closeTxID {
-		t.Fatalf("expected breach ID(%v) to be equal to close ID (%v)",
-			breachTXID, closeTxID)
-	}
-	assertTxInBlock(t, block, breachTXID)
+	breachTXID := ht.WaitForChannelCloseEvent(closeUpdates)
+	require.Equal(ht, closeTxID[:], breachTXID[:],
+		"expected breach ID to be equal to close ID")
+	ht.Miner.AssertTxInBlock(block, breachTXID)
 
 	// Query the mempool for Dave's justice transaction, this should be
 	// broadcast as Carol's contract breaching transaction gets confirmed
@@ -556,24 +467,15 @@ func testRevokedCloseRetributionRemoteHodl(net *lntest.NetworkHarness,
 	// outputs to the second level before Dave broadcasts his justice tx,
 	// we'll search through the mempool for a tx that matches the number of
 	// expected inputs in the justice tx.
-	var predErr error
 	var justiceTxid *chainhash.Hash
 	errNotFound := errors.New("justice tx not found")
 	findJusticeTx := func() (*chainhash.Hash, error) {
-		mempool, err := net.Miner.Client.GetRawMempool()
-		if err != nil {
-			return nil, fmt.Errorf("unable to get mempool from "+
-				"miner: %v", err)
-		}
+		mempool := ht.Miner.GetRawMempool()
 
 		for _, txid := range mempool {
 			// Check that the justice tx has the appropriate number
 			// of inputs.
-			tx, err := net.Miner.Client.GetRawTransaction(txid)
-			if err != nil {
-				return nil, fmt.Errorf("unable to query for "+
-					"txs: %v", err)
-			}
+			tx := ht.Miner.GetRawTransaction(txid)
 
 			exNumInputs := 2 + numInvoices
 			if len(tx.MsgTx().TxIn) == exNumInputs {
@@ -583,17 +485,17 @@ func testRevokedCloseRetributionRemoteHodl(net *lntest.NetworkHarness,
 		return nil, errNotFound
 	}
 
-	err = wait.Predicate(func() bool {
+	err := wait.NoError(func() error {
 		txid, err := findJusticeTx()
 		if err != nil {
-			predErr = err
-			return false
+			return err
 		}
-
 		justiceTxid = txid
-		return true
+
+		return nil
 	}, defaultTimeout)
-	if err != nil && predErr == errNotFound {
+
+	if err != nil && errors.Is(err, errNotFound) {
 		// If Dave is unable to broadcast his justice tx on first
 		// attempt because of the second layer transactions, he will
 		// wait until the next block epoch before trying again. Because
@@ -602,35 +504,28 @@ func testRevokedCloseRetributionRemoteHodl(net *lntest.NetworkHarness,
 		// transactions will be in the mempool at this point, we pass 0
 		// as the last argument, indicating we don't care what's in the
 		// mempool.
-		mineBlocks(t, net, 1, 0)
-		err = wait.Predicate(func() bool {
+		ht.MineBlocks(1)
+		err = wait.NoError(func() error {
 			txid, err := findJusticeTx()
 			if err != nil {
-				predErr = err
-				return false
+				return err
 			}
 
 			justiceTxid = txid
-			return true
+
+			return nil
 		}, defaultTimeout)
 	}
-	if err != nil {
-		t.Fatalf(predErr.Error())
-	}
+	require.NoError(ht, err, "timeout finding justice tx")
 
-	justiceTx, err := net.Miner.Client.GetRawTransaction(justiceTxid)
-	if err != nil {
-		t.Fatalf("unable to query for justice tx: %v", err)
-	}
+	justiceTx := ht.Miner.GetRawTransaction(justiceTxid)
 
 	// isSecondLevelSpend checks that the passed secondLevelTxid is a
 	// potentitial second level spend spending from the commit tx.
-	isSecondLevelSpend := func(commitTxid, secondLevelTxid *chainhash.Hash) bool {
-		secondLevel, err := net.Miner.Client.GetRawTransaction(
-			secondLevelTxid)
-		if err != nil {
-			t.Fatalf("unable to query for tx: %v", err)
-		}
+	isSecondLevelSpend := func(commitTxid,
+		secondLevelTxid *chainhash.Hash) bool {
+
+		secondLevel := ht.Miner.GetRawTransaction(secondLevelTxid)
 
 		// A second level spend should have only one input, and one
 		// output.
@@ -661,27 +556,23 @@ func testRevokedCloseRetributionRemoteHodl(net *lntest.NetworkHarness,
 		if isSecondLevelSpend(breachTXID, &txIn.PreviousOutPoint.Hash) {
 			continue
 		}
-		t.Fatalf("justice tx not spending commitment utxo "+
+		require.Fail(ht, "justice tx not spending commitment utxo "+
 			"instead is: %v", txIn.PreviousOutPoint)
 	}
-	time.Sleep(100 * time.Millisecond)
 
 	// We restart Dave here to ensure that he persists he retribution state
 	// and successfully continues exacting retribution after restarting. At
 	// this point, Dave has broadcast the justice transaction, but it
 	// hasn't been confirmed yet; when Dave restarts, he should start
 	// waiting for the justice transaction to confirm again.
-	if err := net.RestartNode(dave, nil); err != nil {
-		t.Fatalf("unable to restart Dave's node: %v", err)
-	}
+	ht.RestartNode(dave)
 
 	// Now mine a block, this transaction should include Dave's justice
 	// transaction which was just accepted into the mempool.
-	block = mineBlocks(t, net, 1, 1)[0]
-	assertTxInBlock(t, block, justiceTxid)
+	ht.MineBlocksAndAssertNumTxes(1, 1)
 
 	// Dave should have no open channels.
-	assertNodeNumChannels(t, dave, 0)
+	ht.AssertNodeNumChannels(dave, 0)
 }
 
 // testRevokedCloseRetributionAltruistWatchtower establishes a channel between

--- a/lntest/itest/lnd_routing_test.go
+++ b/lntest/itest/lnd_routing_test.go
@@ -746,9 +746,7 @@ func testInvoiceRoutingHints(ht *lntemp.HarnessTest) {
 
 // testMultiHopOverPrivateChannels tests that private channels can be used as
 // intermediate hops in a route for payments.
-func testMultiHopOverPrivateChannels(net *lntest.NetworkHarness, t *harnessTest) {
-	ctxb := context.Background()
-
+func testMultiHopOverPrivateChannels(ht *lntemp.HarnessTest) {
 	// We'll test that multi-hop payments over private channels work as
 	// intended. To do so, we'll create the following topology:
 	//         private        public           private
@@ -757,115 +755,42 @@ func testMultiHopOverPrivateChannels(net *lntest.NetworkHarness, t *harnessTest)
 
 	// First, we'll open a private channel between Alice and Bob with Alice
 	// being the funder.
-	chanPointAlice := openChannelAndAssert(
-		t, net, net.Alice, net.Bob,
-		lntest.OpenChannelParams{
+	alice, bob := ht.Alice, ht.Bob
+	chanPointAlice := ht.OpenChannel(
+		alice, bob, lntemp.OpenChannelParams{
 			Amt:     chanAmt,
 			Private: true,
 		},
 	)
 
-	err := net.Alice.WaitForNetworkChannelOpen(chanPointAlice)
-	if err != nil {
-		t.Fatalf("alice didn't see the channel alice <-> bob before "+
-			"timeout: %v", err)
-	}
-	err = net.Bob.WaitForNetworkChannelOpen(chanPointAlice)
-	if err != nil {
-		t.Fatalf("bob didn't see the channel alice <-> bob before "+
-			"timeout: %v", err)
-	}
-
-	// Retrieve Alice's funding outpoint.
-	aliceChanTXID, err := lnrpc.GetChanPointFundingTxid(chanPointAlice)
-	if err != nil {
-		t.Fatalf("unable to get txid: %v", err)
-	}
-	aliceFundPoint := wire.OutPoint{
-		Hash:  *aliceChanTXID,
-		Index: chanPointAlice.OutputIndex,
-	}
-
 	// Next, we'll create Carol's node and open a public channel between
 	// her and Bob with Bob being the funder.
-	carol := net.NewNode(t.t, "Carol", nil)
-	defer shutdownAndAssert(net, t, carol)
-
-	net.ConnectNodes(t.t, net.Bob, carol)
-	chanPointBob := openChannelAndAssert(
-		t, net, net.Bob, carol,
-		lntest.OpenChannelParams{
+	carol := ht.NewNode("Carol", nil)
+	ht.ConnectNodes(bob, carol)
+	chanPointBob := ht.OpenChannel(
+		bob, carol, lntemp.OpenChannelParams{
 			Amt: chanAmt,
 		},
 	)
 
-	err = net.Bob.WaitForNetworkChannelOpen(chanPointBob)
-	if err != nil {
-		t.Fatalf("bob didn't see the channel bob <-> carol before "+
-			"timeout: %v", err)
-	}
-	err = carol.WaitForNetworkChannelOpen(chanPointBob)
-	if err != nil {
-		t.Fatalf("carol didn't see the channel bob <-> carol before "+
-			"timeout: %v", err)
-	}
-	err = net.Alice.WaitForNetworkChannelOpen(chanPointBob)
-	if err != nil {
-		t.Fatalf("alice didn't see the channel bob <-> carol before "+
-			"timeout: %v", err)
-	}
+	// Alice should know the new channel from Bob.
+	ht.AssertTopologyChannelOpen(alice, chanPointBob)
 
-	// Retrieve Bob's funding outpoint.
-	bobChanTXID, err := lnrpc.GetChanPointFundingTxid(chanPointBob)
-	if err != nil {
-		t.Fatalf("unable to get txid: %v", err)
-	}
-	bobFundPoint := wire.OutPoint{
-		Hash:  *bobChanTXID,
-		Index: chanPointBob.OutputIndex,
-	}
+	// Next, we'll create Dave's node and open a private channel between
+	// him and Carol with Carol being the funder.
+	dave := ht.NewNode("Dave", nil)
+	ht.ConnectNodes(carol, dave)
+	ht.FundCoins(btcutil.SatoshiPerBitcoin, carol)
 
-	// Next, we'll create Dave's node and open a private channel between him
-	// and Carol with Carol being the funder.
-	dave := net.NewNode(t.t, "Dave", nil)
-	defer shutdownAndAssert(net, t, dave)
-
-	net.ConnectNodes(t.t, carol, dave)
-	net.SendCoins(t.t, btcutil.SatoshiPerBitcoin, carol)
-
-	chanPointCarol := openChannelAndAssert(
-		t, net, carol, dave,
-		lntest.OpenChannelParams{
+	chanPointCarol := ht.OpenChannel(
+		carol, dave, lntemp.OpenChannelParams{
 			Amt:     chanAmt,
 			Private: true,
 		},
 	)
 
-	err = carol.WaitForNetworkChannelOpen(chanPointCarol)
-	if err != nil {
-		t.Fatalf("carol didn't see the channel carol <-> dave before "+
-			"timeout: %v", err)
-	}
-	err = dave.WaitForNetworkChannelOpen(chanPointCarol)
-	if err != nil {
-		t.Fatalf("dave didn't see the channel carol <-> dave before "+
-			"timeout: %v", err)
-	}
-	err = dave.WaitForNetworkChannelOpen(chanPointBob)
-	if err != nil {
-		t.Fatalf("dave didn't see the channel bob <-> carol before "+
-			"timeout: %v", err)
-	}
-
-	// Retrieve Carol's funding point.
-	carolChanTXID, err := lnrpc.GetChanPointFundingTxid(chanPointCarol)
-	if err != nil {
-		t.Fatalf("unable to get txid: %v", err)
-	}
-	carolFundPoint := wire.OutPoint{
-		Hash:  *carolChanTXID,
-		Index: chanPointCarol.OutputIndex,
-	}
+	// Dave should know the channel[Bob<->Carol] from Carol.
+	ht.AssertTopologyChannelOpen(dave, chanPointBob)
 
 	// Now that all the channels are set up according to the topology from
 	// above, we can proceed to test payments. We'll create an invoice for
@@ -880,21 +805,11 @@ func testMultiHopOverPrivateChannels(net *lntest.NetworkHarness, t *harnessTest)
 		Value:   paymentAmt,
 		Private: true,
 	}
-
-	ctxt, _ := context.WithTimeout(ctxb, defaultTimeout)
-	resp, err := dave.AddInvoice(ctxt, invoice)
-	if err != nil {
-		t.Fatalf("unable to add invoice for dave: %v", err)
-	}
+	resp := dave.RPC.AddInvoice(invoice)
 
 	// Let Alice pay the invoice.
 	payReqs := []string{resp.PaymentRequest}
-	err = completePaymentRequests(
-		net.Alice, net.Alice.RouterClient, payReqs, true,
-	)
-	if err != nil {
-		t.Fatalf("unable to send payments from alice to dave: %v", err)
-	}
+	ht.CompletePaymentRequests(alice, payReqs)
 
 	// When asserting the amount of satoshis moved, we'll factor in the
 	// default base fee, as we didn't modify the fee structure when opening
@@ -902,39 +817,34 @@ func testMultiHopOverPrivateChannels(net *lntest.NetworkHarness, t *harnessTest)
 	const baseFee = 1
 
 	// Dave should have received 20k satoshis from Carol.
-	assertAmountPaid(t, "Carol(local) [private=>] Dave(remote)",
-		dave, carolFundPoint, 0, paymentAmt)
+	ht.AssertAmountPaid("Carol(local) [private=>] Dave(remote)",
+		dave, chanPointCarol, 0, paymentAmt)
 
 	// Carol should have sent 20k satoshis to Dave.
-	assertAmountPaid(t, "Carol(local) [private=>] Dave(remote)",
-		carol, carolFundPoint, paymentAmt, 0)
+	ht.AssertAmountPaid("Carol(local) [private=>] Dave(remote)",
+		carol, chanPointCarol, paymentAmt, 0)
 
 	// Carol should have received 20k satoshis + fee for one hop from Bob.
-	assertAmountPaid(t, "Bob(local) => Carol(remote)",
-		carol, bobFundPoint, 0, paymentAmt+baseFee)
+	ht.AssertAmountPaid("Bob(local) => Carol(remote)",
+		carol, chanPointBob, 0, paymentAmt+baseFee)
 
 	// Bob should have sent 20k satoshis + fee for one hop to Carol.
-	assertAmountPaid(t, "Bob(local) => Carol(remote)",
-		net.Bob, bobFundPoint, paymentAmt+baseFee, 0)
+	ht.AssertAmountPaid("Bob(local) => Carol(remote)",
+		bob, chanPointBob, paymentAmt+baseFee, 0)
 
 	// Bob should have received 20k satoshis + fee for two hops from Alice.
-	assertAmountPaid(t, "Alice(local) [private=>] Bob(remote)", net.Bob,
-		aliceFundPoint, 0, paymentAmt+baseFee*2)
+	ht.AssertAmountPaid("Alice(local) [private=>] Bob(remote)", bob,
+		chanPointAlice, 0, paymentAmt+baseFee*2)
 
 	// Alice should have sent 20k satoshis + fee for two hops to Bob.
-	assertAmountPaid(t, "Alice(local) [private=>] Bob(remote)", net.Alice,
-		aliceFundPoint, paymentAmt+baseFee*2, 0)
+	ht.AssertAmountPaid("Alice(local) [private=>] Bob(remote)", alice,
+		chanPointAlice, paymentAmt+baseFee*2, 0)
 
 	// At this point, the payment was successful. We can now close all the
 	// channels and shutdown the nodes created throughout this test.
-	closeChannelAndAssert(t, net, net.Alice, chanPointAlice, false)
-	closeChannelAndAssert(t, net, net.Bob, chanPointBob, false)
-	closeChannelAndAssert(t, net, carol, chanPointCarol, false)
-}
-
-// computeFee calculates the payment fee as specified in BOLT07.
-func computeFee(baseFee, feeRate, amt lnwire.MilliSatoshi) lnwire.MilliSatoshi {
-	return baseFee + amt*feeRate/1000000
+	ht.CloseChannel(alice, chanPointAlice)
+	ht.CloseChannel(bob, chanPointBob)
+	ht.CloseChannel(carol, chanPointCarol)
 }
 
 // testQueryRoutes checks the response of queryroutes.
@@ -1459,4 +1369,9 @@ func testRouteFeeCutoff(net *lntest.NetworkHarness, t *harnessTest) {
 	closeChannelAndAssert(t, net, net.Alice, chanPointAliceCarol, false)
 	closeChannelAndAssert(t, net, net.Bob, chanPointBobDave, false)
 	closeChannelAndAssert(t, net, carol, chanPointCarolDave, false)
+}
+
+// computeFee calculates the payment fee as specified in BOLT07.
+func computeFee(baseFee, feeRate, amt lnwire.MilliSatoshi) lnwire.MilliSatoshi {
+	return baseFee + amt*feeRate/1000000
 }

--- a/lntest/itest/lnd_routing_test.go
+++ b/lntest/itest/lnd_routing_test.go
@@ -173,7 +173,7 @@ func testSingleHopSendToRouteCase(ht *lntemp.HarnessTest,
 			err := alicePayStream.Send(sendReq)
 			require.NoError(ht, err, "unable to send payment")
 
-			resp, err := alicePayStream.Recv()
+			resp, err := ht.ReceiveSendToRouteUpdate(alicePayStream)
 			require.NoError(ht, err, "unable to receive stream")
 			require.Emptyf(ht, resp.PaymentError,
 				"received payment error from %s: %v",

--- a/lntest/itest/lnd_routing_test.go
+++ b/lntest/itest/lnd_routing_test.go
@@ -901,73 +901,86 @@ func testQueryRoutes(ht *lntemp.HarnessTest) {
 	for i, route := range routesRes.Routes {
 		expectedTotalFeesMSat :=
 			lnwire.MilliSatoshi(len(route.Hops)-1) * feePerHopMSat
-		expectedTotalAmtMSat := (paymentAmt * mSat) + expectedTotalFeesMSat
 
-		if route.TotalFees != route.TotalFeesMsat/mSat { // nolint:staticcheck
+		expectedTotalAmtMSat :=
+			(paymentAmt * mSat) + expectedTotalFeesMSat
+
+		if route.TotalFees != route.TotalFeesMsat/mSat {
 			ht.Fatalf("route %v: total fees %v (msat) does not "+
 				"round down to %v (sat)",
-				i, route.TotalFeesMsat, route.TotalFees) // nolint:staticcheck
+				i, route.TotalFeesMsat, route.TotalFees)
 		}
 		if route.TotalFeesMsat != int64(expectedTotalFeesMSat) {
-			ht.Fatalf("route %v: total fees in msat expected %v got %v",
-				i, expectedTotalFeesMSat, route.TotalFeesMsat)
+			ht.Fatalf("route %v: total fees in msat expected %v "+
+				"got %v", i, expectedTotalFeesMSat,
+				route.TotalFeesMsat)
 		}
 
-		if route.TotalAmt != route.TotalAmtMsat/mSat { // nolint:staticcheck
+		if route.TotalAmt != route.TotalAmtMsat/mSat {
 			ht.Fatalf("route %v: total amt %v (msat) does not "+
 				"round down to %v (sat)",
-				i, route.TotalAmtMsat, route.TotalAmt) // nolint:staticcheck
+				i, route.TotalAmtMsat, route.TotalAmt)
 		}
 		if route.TotalAmtMsat != int64(expectedTotalAmtMSat) {
-			ht.Fatalf("route %v: total amt in msat expected %v got %v",
-				i, expectedTotalAmtMSat, route.TotalAmtMsat)
+			ht.Fatalf("route %v: total amt in msat expected %v "+
+				"got %v", i, expectedTotalAmtMSat,
+				route.TotalAmtMsat)
 		}
 
-		// For all hops except the last, we check that fee equals feePerHop
-		// and amount to forward deducts feePerHop on each hop.
+		// For all hops except the last, we check that fee equals
+		// feePerHop and amount to forward deducts feePerHop on each
+		// hop.
 		expectedAmtToForwardMSat := expectedTotalAmtMSat
 		for j, hop := range route.Hops[:len(route.Hops)-1] {
 			expectedAmtToForwardMSat -= feePerHopMSat
 
-			if hop.Fee != hop.FeeMsat/mSat { // nolint:staticcheck
-				ht.Fatalf("route %v hop %v: fee %v (msat) does not "+
-					"round down to %v (sat)",
-					i, j, hop.FeeMsat, hop.Fee) // nolint:staticcheck
+			if hop.Fee != hop.FeeMsat/mSat {
+				ht.Fatalf("route %v hop %v: fee %v (msat) "+
+					"does not round down to %v (sat)",
+					i, j, hop.FeeMsat, hop.Fee)
 			}
 			if hop.FeeMsat != int64(feePerHopMSat) {
-				ht.Fatalf("route %v hop %v: fee in msat expected %v got %v",
+				ht.Fatalf("route %v hop %v: fee in msat "+
+					"expected %v got %v",
 					i, j, feePerHopMSat, hop.FeeMsat)
 			}
 
-			if hop.AmtToForward != hop.AmtToForwardMsat/mSat { // nolint:staticcheck
-				ht.Fatalf("route %v hop %v: amt to forward %v (msat) does not "+
-					"round down to %v (sat)",
-					i, j, hop.AmtToForwardMsat, hop.AmtToForward) // nolint:staticcheck
+			if hop.AmtToForward != hop.AmtToForwardMsat/mSat {
+				ht.Fatalf("route %v hop %v: amt to forward %v"+
+					"(msat) does not round down to %v(sat)",
+					i, j, hop.AmtToForwardMsat,
+					hop.AmtToForward)
 			}
-			if hop.AmtToForwardMsat != int64(expectedAmtToForwardMSat) {
-				ht.Fatalf("route %v hop %v: amt to forward in msat "+
-					"expected %v got %v",
-					i, j, expectedAmtToForwardMSat, hop.AmtToForwardMsat)
+			if hop.AmtToForwardMsat !=
+				int64(expectedAmtToForwardMSat) {
+
+				ht.Fatalf("route %v hop %v: amt to forward "+
+					"in msat expected %v got %v",
+					i, j, expectedAmtToForwardMSat,
+					hop.AmtToForwardMsat)
 			}
 		}
-		// Last hop should have zero fee and amount to forward should equal
-		// payment amount.
+
+		// Last hop should have zero fee and amount to forward should
+		// equal payment amount.
 		hop := route.Hops[len(route.Hops)-1]
 
-		if hop.Fee != 0 || hop.FeeMsat != 0 { // nolint:staticcheck
-			ht.Fatalf("route %v hop %v: fee expected 0 got %v (sat) %v (msat)",
-				i, len(route.Hops)-1, hop.Fee, hop.FeeMsat) // nolint:staticcheck
+		if hop.Fee != 0 || hop.FeeMsat != 0 {
+			ht.Fatalf("route %v hop %v: fee expected 0 got %v "+
+				"(sat) %v (msat)", i, len(route.Hops)-1,
+				hop.Fee, hop.FeeMsat)
 		}
 
-		if hop.AmtToForward != hop.AmtToForwardMsat/mSat { // nolint:staticcheck
-			ht.Fatalf("route %v hop %v: amt to forward %v (msat) does not "+
-				"round down to %v (sat)",
-				i, len(route.Hops)-1, hop.AmtToForwardMsat, hop.AmtToForward) // nolint:staticcheck
+		if hop.AmtToForward != hop.AmtToForwardMsat/mSat {
+			ht.Fatalf("route %v hop %v: amt to forward %v (msat) "+
+				"does not round down to %v (sat)", i,
+				len(route.Hops)-1, hop.AmtToForwardMsat,
+				hop.AmtToForward)
 		}
 		if hop.AmtToForwardMsat != paymentAmt*mSat {
 			ht.Fatalf("route %v hop %v: amt to forward in msat "+
-				"expected %v got %v",
-				i, len(route.Hops)-1, paymentAmt*mSat, hop.AmtToForwardMsat)
+				"expected %v got %v", i, len(route.Hops)-1,
+				paymentAmt*mSat, hop.AmtToForwardMsat)
 		}
 	}
 

--- a/lntest/itest/lnd_single_hop_invoice_test.go
+++ b/lntest/itest/lnd_single_hop_invoice_test.go
@@ -2,34 +2,33 @@ package itest
 
 import (
 	"bytes"
-	"context"
 	"encoding/hex"
-	"time"
 
 	"github.com/btcsuite/btcd/btcutil"
-	"github.com/davecgh/go-spew/spew"
 	"github.com/lightningnetwork/lnd/lnrpc"
 	"github.com/lightningnetwork/lnd/lnrpc/routerrpc"
-	"github.com/lightningnetwork/lnd/lntest"
-	"github.com/lightningnetwork/lnd/lntest/wait"
+	"github.com/lightningnetwork/lnd/lntemp"
 	"github.com/lightningnetwork/lnd/lntypes"
 	"github.com/lightningnetwork/lnd/lnwire"
 	"github.com/lightningnetwork/lnd/record"
 	"github.com/stretchr/testify/require"
 )
 
-func testSingleHopInvoice(net *lntest.NetworkHarness, t *harnessTest) {
-	ctxb := context.Background()
-
-	// Open a channel with 100k satoshis between Alice and Bob with Alice being
-	// the sole funder of the channel.
+func testSingleHopInvoice(ht *lntemp.HarnessTest) {
+	// Open a channel with 100k satoshis between Alice and Bob with Alice
+	// being the sole funder of the channel.
 	chanAmt := btcutil.Amount(100000)
-	chanPoint := openChannelAndAssert(
-		t, net, net.Alice, net.Bob,
-		lntest.OpenChannelParams{
-			Amt: chanAmt,
-		},
+	alice, bob := ht.Alice, ht.Bob
+	cp := ht.OpenChannel(
+		alice, bob, lntemp.OpenChannelParams{Amt: chanAmt},
 	)
+
+	// assertAmountPaid is a helper closure that asserts the amount paid by
+	// Alice and received by Bob are expected.
+	assertAmountPaid := func(expected int64) {
+		ht.AssertAmountPaid("alice -> bob", alice, cp, expected, 0)
+		ht.AssertAmountPaid("bob <- alice", bob, cp, 0, expected)
+	}
 
 	// Now that the channel is open, create an invoice for Bob which
 	// expects a payment of 1000 satoshis from Alice paid via a particular
@@ -41,61 +40,20 @@ func testSingleHopInvoice(net *lntest.NetworkHarness, t *harnessTest) {
 		RPreimage: preimage,
 		Value:     paymentAmt,
 	}
-	invoiceResp, err := net.Bob.AddInvoice(ctxb, invoice)
-	if err != nil {
-		t.Fatalf("unable to add invoice: %v", err)
-	}
-
-	// Wait for Alice to recognize and advertise the new channel generated
-	// above.
-	err = net.Alice.WaitForNetworkChannelOpen(chanPoint)
-	if err != nil {
-		t.Fatalf("alice didn't advertise channel before "+
-			"timeout: %v", err)
-	}
-	err = net.Bob.WaitForNetworkChannelOpen(chanPoint)
-	if err != nil {
-		t.Fatalf("bob didn't advertise channel before "+
-			"timeout: %v", err)
-	}
+	invoiceResp := bob.RPC.AddInvoice(invoice)
 
 	// With the invoice for Bob added, send a payment towards Alice paying
 	// to the above generated invoice.
-	resp := sendAndAssertSuccess(
-		t, net.Alice, &routerrpc.SendPaymentRequest{
-			PaymentRequest: invoiceResp.PaymentRequest,
-			TimeoutSeconds: 60,
-			FeeLimitMsat:   noFeeLimitMsat,
-		},
-	)
-	if hex.EncodeToString(preimage) != resp.PaymentPreimage {
-		t.Fatalf("preimage mismatch: expected %v, got %v", preimage,
-			resp.PaymentPreimage)
-	}
+	ht.CompletePaymentRequests(alice, []string{invoiceResp.PaymentRequest})
 
 	// Bob's invoice should now be found and marked as settled.
-	payHash := &lnrpc.PaymentHash{
-		RHash: invoiceResp.RHash,
-	}
-	ctxt, _ := context.WithTimeout(ctxb, defaultTimeout)
-	dbInvoice, err := net.Bob.LookupInvoice(ctxt, payHash)
-	if err != nil {
-		t.Fatalf("unable to lookup invoice: %v", err)
-	}
-	if !dbInvoice.Settled { // nolint:staticcheck
-		t.Fatalf("bob's invoice should be marked as settled: %v",
-			spew.Sdump(dbInvoice))
-	}
+	dbInvoice := bob.RPC.LookupInvoice(invoiceResp.RHash)
+	require.Equal(ht, lnrpc.Invoice_SETTLED, dbInvoice.State,
+		"bob's invoice should be marked as settled")
 
 	// With the payment completed all balance related stats should be
 	// properly updated.
-	err = wait.NoError(
-		assertAmountSent(paymentAmt, net.Alice, net.Bob),
-		3*time.Second,
-	)
-	if err != nil {
-		t.Fatalf(err.Error())
-	}
+	assertAmountPaid(paymentAmt)
 
 	// Create another invoice for Bob, this time leaving off the preimage
 	// to one will be randomly generated. We'll test the proper
@@ -104,92 +62,58 @@ func testSingleHopInvoice(net *lntest.NetworkHarness, t *harnessTest) {
 		Memo:  "test3",
 		Value: paymentAmt,
 	}
-	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
-	invoiceResp, err = net.Bob.AddInvoice(ctxt, invoice)
-	if err != nil {
-		t.Fatalf("unable to add invoice: %v", err)
-	}
+	invoiceResp = bob.RPC.AddInvoice(invoice)
 
 	// Next send another payment, but this time using a zpay32 encoded
 	// invoice rather than manually specifying the payment details.
-	sendAndAssertSuccess(
-		t, net.Alice, &routerrpc.SendPaymentRequest{
-			PaymentRequest: invoiceResp.PaymentRequest,
-			TimeoutSeconds: 60,
-			FeeLimitMsat:   noFeeLimitMsat,
-		},
-	)
+	ht.CompletePaymentRequests(alice, []string{invoiceResp.PaymentRequest})
 
 	// The second payment should also have succeeded, with the balances
 	// being update accordingly.
-	err = wait.NoError(
-		assertAmountSent(2*paymentAmt, net.Alice, net.Bob),
-		3*time.Second,
-	)
-	if err != nil {
-		t.Fatalf(err.Error())
-	}
+	assertAmountPaid(paymentAmt * 2)
 
 	// Next send a keysend payment.
 	keySendPreimage := lntypes.Preimage{3, 4, 5, 11}
 	keySendHash := keySendPreimage.Hash()
 
-	sendAndAssertSuccess(
-		t, net.Alice, &routerrpc.SendPaymentRequest{
-			Dest:           net.Bob.PubKey[:],
-			Amt:            paymentAmt,
-			FinalCltvDelta: 40,
-			PaymentHash:    keySendHash[:],
-			DestCustomRecords: map[uint64][]byte{
-				record.KeySendType: keySendPreimage[:],
-			},
-			TimeoutSeconds: 60,
-			FeeLimitMsat:   noFeeLimitMsat,
+	req := &routerrpc.SendPaymentRequest{
+		Dest:           bob.PubKey[:],
+		Amt:            paymentAmt,
+		FinalCltvDelta: 40,
+		PaymentHash:    keySendHash[:],
+		DestCustomRecords: map[uint64][]byte{
+			record.KeySendType: keySendPreimage[:],
 		},
-	)
+		TimeoutSeconds: 60,
+		FeeLimitMsat:   noFeeLimitMsat,
+	}
+	ht.SendPaymentAssertSettled(alice, req)
 
 	// The keysend payment should also have succeeded, with the balances
 	// being update accordingly.
-	err = wait.NoError(
-		assertAmountSent(3*paymentAmt, net.Alice, net.Bob),
-		3*time.Second,
-	)
-	if err != nil {
-		t.Fatalf(err.Error())
-	}
+	assertAmountPaid(paymentAmt * 3)
 
 	// Assert that the invoice has the proper AMP fields set, since the
 	// legacy keysend payment should have been promoted into an AMP payment
 	// internally.
-	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
-	keysendInvoice, err := net.Bob.LookupInvoice(
-		ctxt, &lnrpc.PaymentHash{
-			RHash: keySendHash[:],
-		},
-	)
-	require.NoError(t.t, err)
-	require.Equal(t.t, 1, len(keysendInvoice.Htlcs))
+	keysendInvoice := bob.RPC.LookupInvoice(keySendHash[:])
+	require.Len(ht, keysendInvoice.Htlcs, 1)
 	htlc := keysendInvoice.Htlcs[0]
-	require.Equal(t.t, uint64(0), htlc.MppTotalAmtMsat)
-	require.Nil(t.t, htlc.Amp)
+	require.Zero(ht, htlc.MppTotalAmtMsat)
+	require.Nil(ht, htlc.Amp)
 
 	// Now create an invoice and specify routing hints.
 	// We will test that the routing hints are encoded properly.
 	hintChannel := lnwire.ShortChannelID{BlockHeight: 10}
-	bobPubKey := hex.EncodeToString(net.Bob.PubKey[:])
-	hints := []*lnrpc.RouteHint{
-		{
-			HopHints: []*lnrpc.HopHint{
-				{
-					NodeId:                    bobPubKey,
-					ChanId:                    hintChannel.ToUint64(),
-					FeeBaseMsat:               1,
-					FeeProportionalMillionths: 1000000,
-					CltvExpiryDelta:           20,
-				},
-			},
-		},
+	bobPubKey := hex.EncodeToString(bob.PubKey[:])
+	hint := &lnrpc.HopHint{
+		NodeId:                    bobPubKey,
+		ChanId:                    hintChannel.ToUint64(),
+		FeeBaseMsat:               1,
+		FeeProportionalMillionths: 1000000,
+		CltvExpiryDelta:           20,
 	}
+	hints := []*lnrpc.RouteHint{{HopHints: []*lnrpc.HopHint{hint}}}
 
 	invoice = &lnrpc.Invoice{
 		Memo:       "hints",
@@ -197,43 +121,21 @@ func testSingleHopInvoice(net *lntest.NetworkHarness, t *harnessTest) {
 		RouteHints: hints,
 	}
 
-	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
-	invoiceResp, err = net.Bob.AddInvoice(ctxt, invoice)
-	if err != nil {
-		t.Fatalf("unable to add invoice: %v", err)
-	}
-	payreq, err := net.Bob.DecodePayReq(ctxt, &lnrpc.PayReqString{PayReq: invoiceResp.PaymentRequest})
-	if err != nil {
-		t.Fatalf("failed to decode payment request %v", err)
-	}
-	if len(payreq.RouteHints) != 1 {
-		t.Fatalf("expected one routing hint")
-	}
+	invoiceResp = bob.RPC.AddInvoice(invoice)
+	payreq := bob.RPC.DecodePayReq(invoiceResp.PaymentRequest)
+	require.Len(ht, payreq.RouteHints, 1, "expected one routing hint")
 	routingHint := payreq.RouteHints[0]
-	if len(routingHint.HopHints) != 1 {
-		t.Fatalf("expected one hop hint")
-	}
-	hopHint := routingHint.HopHints[0]
-	if hopHint.FeeProportionalMillionths != 1000000 {
-		t.Fatalf("wrong FeeProportionalMillionths %v",
-			hopHint.FeeProportionalMillionths)
-	}
-	if hopHint.NodeId != bobPubKey {
-		t.Fatalf("wrong NodeId %v",
-			hopHint.NodeId)
-	}
-	if hopHint.ChanId != hintChannel.ToUint64() {
-		t.Fatalf("wrong ChanId %v",
-			hopHint.ChanId)
-	}
-	if hopHint.FeeBaseMsat != 1 {
-		t.Fatalf("wrong FeeBaseMsat %v",
-			hopHint.FeeBaseMsat)
-	}
-	if hopHint.CltvExpiryDelta != 20 {
-		t.Fatalf("wrong CltvExpiryDelta %v",
-			hopHint.CltvExpiryDelta)
-	}
+	require.Len(ht, routingHint.HopHints, 1, "expected one hop hint")
 
-	closeChannelAndAssert(t, net, net.Alice, chanPoint, false)
+	hopHint := routingHint.HopHints[0]
+	require.EqualValues(ht, 1000000, hopHint.FeeProportionalMillionths,
+		"wrong FeeProportionalMillionths")
+	require.Equal(ht, bobPubKey, hopHint.NodeId, "wrong NodeId")
+	require.Equal(ht, hintChannel.ToUint64(), hopHint.ChanId,
+		"wrong ChanId")
+	require.EqualValues(ht, 1, hopHint.FeeBaseMsat, "wrong FeeBaseMsat")
+	require.EqualValues(ht, 20, hopHint.CltvExpiryDelta,
+		"wrong CltvExpiryDelta")
+
+	ht.CloseChannel(alice, cp)
 }

--- a/lntest/itest/lnd_test_list_on_test.go
+++ b/lntest/itest/lnd_test_list_on_test.go
@@ -195,10 +195,6 @@ var allTestCases = []*testCase{
 		test: testWalletImportPubKey,
 	},
 	{
-		name: "max htlc pathfind",
-		test: testMaxHtlcPathfind,
-	},
-	{
 		name: "rpc middleware interceptor",
 		test: testRPCMiddlewareInterceptor,
 	},

--- a/lntest/itest/lnd_test_list_on_test.go
+++ b/lntest/itest/lnd_test_list_on_test.go
@@ -49,10 +49,6 @@ var allTestCases = []*testCase{
 		test: testSwitchOfflineDeliveryOutgoingOffline,
 	},
 	{
-		name: "route fee cutoff",
-		test: testRouteFeeCutoff,
-	},
-	{
 		name: "cpfp",
 		test: testCPFP,
 	},

--- a/lntest/itest/lnd_test_list_on_test.go
+++ b/lntest/itest/lnd_test_list_on_test.go
@@ -53,10 +53,6 @@ var allTestCases = []*testCase{
 		test: testCPFP,
 	},
 	{
-		name: "delete macaroon id",
-		test: testDeleteMacaroonID,
-	},
-	{
 		name: "psbt channel funding",
 		test: testPsbtChanFunding,
 	},

--- a/lntest/itest/lnd_test_list_on_test.go
+++ b/lntest/itest/lnd_test_list_on_test.go
@@ -73,10 +73,6 @@ var allTestCases = []*testCase{
 		test: testSwitchOfflineDeliveryOutgoingOffline,
 	},
 	{
-		name: "revoked uncooperative close retribution altruist watchtower",
-		test: testRevokedCloseRetributionAltruistWatchtower,
-	},
-	{
 		name: "query routes",
 		test: testQueryRoutes,
 	},

--- a/lntest/itest/lnd_test_list_on_test.go
+++ b/lntest/itest/lnd_test_list_on_test.go
@@ -195,10 +195,6 @@ var allTestCases = []*testCase{
 		test: testRemoteSigner,
 	},
 	{
-		name: "3rd party anchor spend",
-		test: testAnchorThirdPartySpend,
-	},
-	{
 		name: "taproot",
 		test: testTaproot,
 	},

--- a/lntest/itest/lnd_test_list_on_test.go
+++ b/lntest/itest/lnd_test_list_on_test.go
@@ -147,10 +147,6 @@ var allTestCases = []*testCase{
 		test: testSendMultiPathPayment,
 	},
 	{
-		name: "REST API",
-		test: testRestAPI,
-	},
-	{
 		name: "forward interceptor",
 		test: testForwardInterceptorBasic,
 	},

--- a/lntest/itest/lnd_test_list_on_test.go
+++ b/lntest/itest/lnd_test_list_on_test.go
@@ -93,10 +93,6 @@ var allTestCases = []*testCase{
 		test: testForwardInterceptorDedupHtlc,
 	},
 	{
-		name: "stateless init",
-		test: testStatelessInit,
-	},
-	{
 		name: "wallet import account",
 		test: testWalletImportAccount,
 	},

--- a/lntest/itest/lnd_test_list_on_test.go
+++ b/lntest/itest/lnd_test_list_on_test.go
@@ -107,10 +107,6 @@ var allTestCases = []*testCase{
 		test: testCPFP,
 	},
 	{
-		name: "anchors reserved value",
-		test: testAnchorReservedValue,
-	},
-	{
 		name: "macaroon authentication",
 		test: testMacaroonAuthentication,
 	},

--- a/lntest/itest/lnd_test_list_on_test.go
+++ b/lntest/itest/lnd_test_list_on_test.go
@@ -111,10 +111,6 @@ var allTestCases = []*testCase{
 		test: testRouteFeeCutoff,
 	},
 	{
-		name: "hold invoice sender persistence",
-		test: testHoldInvoicePersistence,
-	},
-	{
 		name: "cpfp",
 		test: testCPFP,
 	},

--- a/lntest/itest/lnd_test_list_on_test.go
+++ b/lntest/itest/lnd_test_list_on_test.go
@@ -119,10 +119,6 @@ var allTestCases = []*testCase{
 		test: testPsbtChanFunding,
 	},
 	{
-		name: "psbt channel funding external",
-		test: testPsbtChanFundingExternal,
-	},
-	{
 		name: "sign psbt",
 		test: testSignPsbt,
 	},

--- a/lntest/itest/lnd_test_list_on_test.go
+++ b/lntest/itest/lnd_test_list_on_test.go
@@ -45,10 +45,6 @@ var allTestCases = []*testCase{
 		test: testBasicChannelCreationAndUpdates,
 	},
 	{
-		name: "multi-hop htlc error propagation",
-		test: testHtlcErrorPropagation,
-	},
-	{
 		name: "derive shared key",
 		test: testDeriveSharedKey,
 	},

--- a/lntest/itest/lnd_test_list_on_test.go
+++ b/lntest/itest/lnd_test_list_on_test.go
@@ -187,10 +187,6 @@ var allTestCases = []*testCase{
 		test: testWumboChannels,
 	},
 	{
-		name: "maximum channel size",
-		test: testMaxChannelSize,
-	},
-	{
 		name: "stateless init",
 		test: testStatelessInit,
 	},

--- a/lntest/itest/lnd_test_list_on_test.go
+++ b/lntest/itest/lnd_test_list_on_test.go
@@ -183,10 +183,6 @@ var allTestCases = []*testCase{
 		test: testForwardInterceptorDedupHtlc,
 	},
 	{
-		name: "wumbo channels",
-		test: testWumboChannels,
-	},
-	{
 		name: "stateless init",
 		test: testStatelessInit,
 	},

--- a/lntest/itest/lnd_test_list_on_test.go
+++ b/lntest/itest/lnd_test_list_on_test.go
@@ -53,10 +53,6 @@ var allTestCases = []*testCase{
 		test: testCPFP,
 	},
 	{
-		name: "bake macaroon",
-		test: testBakeMacaroon,
-	},
-	{
 		name: "delete macaroon id",
 		test: testDeleteMacaroonID,
 	},

--- a/lntest/itest/lnd_test_list_on_test.go
+++ b/lntest/itest/lnd_test_list_on_test.go
@@ -187,10 +187,6 @@ var allTestCases = []*testCase{
 		test: testTaproot,
 	},
 	{
-		name: "resolution handoff",
-		test: testResHandoff,
-	},
-	{
 		name: "zero conf channel open",
 		test: testZeroConfChannelOpen,
 	},

--- a/lntest/itest/lnd_test_list_on_test.go
+++ b/lntest/itest/lnd_test_list_on_test.go
@@ -73,10 +73,6 @@ var allTestCases = []*testCase{
 		test: testSwitchOfflineDeliveryOutgoingOffline,
 	},
 	{
-		name: "revoked uncooperative close retribution remote hodl",
-		test: testRevokedCloseRetributionRemoteHodl,
-	},
-	{
 		name: "revoked uncooperative close retribution altruist watchtower",
 		test: testRevokedCloseRetributionAltruistWatchtower,
 	},

--- a/lntest/itest/lnd_test_list_on_test.go
+++ b/lntest/itest/lnd_test_list_on_test.go
@@ -73,12 +73,6 @@ var allTestCases = []*testCase{
 		test: testSwitchOfflineDeliveryOutgoingOffline,
 	},
 	{
-		// TODO(roasbeef): test always needs to be last as Bob's state
-		// is borked since we trick him into attempting to cheat Alice?
-		name: "revoked uncooperative close retribution",
-		test: testRevokedCloseRetribution,
-	},
-	{
 		name: "revoked uncooperative close retribution zero value remote output",
 		test: testRevokedCloseRetributionZeroValueRemoteOutput,
 	},

--- a/lntest/itest/lnd_test_list_on_test.go
+++ b/lntest/itest/lnd_test_list_on_test.go
@@ -9,10 +9,6 @@ var allTestCases = []*testCase{
 		test: testSingleHopInvoice,
 	},
 	{
-		name: "invoice routing hints",
-		test: testInvoiceRoutingHints,
-	},
-	{
 		name: "multi-hop payments over private channels",
 		test: testMultiHopOverPrivateChannels,
 	},

--- a/lntest/itest/lnd_test_list_on_test.go
+++ b/lntest/itest/lnd_test_list_on_test.go
@@ -211,10 +211,6 @@ var allTestCases = []*testCase{
 		test: testWalletImportPubKey,
 	},
 	{
-		name: "etcd_failover",
-		test: testEtcdFailover,
-	},
-	{
 		name: "max htlc pathfind",
 		test: testMaxHtlcPathfind,
 	},

--- a/lntest/itest/lnd_test_list_on_test.go
+++ b/lntest/itest/lnd_test_list_on_test.go
@@ -97,10 +97,6 @@ var allTestCases = []*testCase{
 		test: testWalletImportPubKey,
 	},
 	{
-		name: "wipe forwarding packages",
-		test: testWipeForwardingPackages,
-	},
-	{
 		name: "remote signer",
 		test: testRemoteSigner,
 	},

--- a/lntest/itest/lnd_test_list_on_test.go
+++ b/lntest/itest/lnd_test_list_on_test.go
@@ -49,10 +49,6 @@ var allTestCases = []*testCase{
 		test: testSwitchOfflineDeliveryOutgoingOffline,
 	},
 	{
-		name: "query routes",
-		test: testQueryRoutes,
-	},
-	{
 		name: "route fee cutoff",
 		test: testRouteFeeCutoff,
 	},

--- a/lntest/itest/lnd_test_list_on_test.go
+++ b/lntest/itest/lnd_test_list_on_test.go
@@ -5,10 +5,6 @@ package itest
 
 var allTestCases = []*testCase{
 	{
-		name: "open channel reorg test",
-		test: testOpenChannelAfterReorg,
-	},
-	{
 		name: "single hop invoice",
 		test: testSingleHopInvoice,
 	},

--- a/lntest/itest/lnd_test_list_on_test.go
+++ b/lntest/itest/lnd_test_list_on_test.go
@@ -9,10 +9,6 @@ var allTestCases = []*testCase{
 		test: testSingleHopInvoice,
 	},
 	{
-		name: "private channels",
-		test: testPrivateChannels,
-	},
-	{
 		name: "invoice routing hints",
 		test: testInvoiceRoutingHints,
 	},

--- a/lntest/itest/lnd_test_list_on_test.go
+++ b/lntest/itest/lnd_test_list_on_test.go
@@ -13,10 +13,6 @@ var allTestCases = []*testCase{
 		test: testSingleHopInvoice,
 	},
 	{
-		name: "multi-hop payments",
-		test: testMultiHopPayments,
-	},
-	{
 		name: "single-hop send to route",
 		test: testSingleHopSendToRoute,
 	},

--- a/lntest/itest/lnd_test_list_on_test.go
+++ b/lntest/itest/lnd_test_list_on_test.go
@@ -9,10 +9,6 @@ var allTestCases = []*testCase{
 		test: testSingleHopInvoice,
 	},
 	{
-		name: "send to route error propagation",
-		test: testSendToRouteErrorPropagation,
-	},
-	{
 		name: "private channels",
 		test: testPrivateChannels,
 	},

--- a/lntest/itest/lnd_test_list_on_test.go
+++ b/lntest/itest/lnd_test_list_on_test.go
@@ -9,10 +9,6 @@ var allTestCases = []*testCase{
 		test: testSingleHopInvoice,
 	},
 	{
-		name: "multi-hop send to route",
-		test: testMultiHopSendToRoute,
-	},
-	{
 		name: "send to route error propagation",
 		test: testSendToRouteErrorPropagation,
 	},

--- a/lntest/itest/lnd_test_list_on_test.go
+++ b/lntest/itest/lnd_test_list_on_test.go
@@ -9,10 +9,6 @@ var allTestCases = []*testCase{
 		test: testSingleHopInvoice,
 	},
 	{
-		name: "single-hop send to route",
-		test: testSingleHopSendToRoute,
-	},
-	{
 		name: "multi-hop send to route",
 		test: testMultiHopSendToRoute,
 	},

--- a/lntest/itest/lnd_test_list_on_test.go
+++ b/lntest/itest/lnd_test_list_on_test.go
@@ -123,10 +123,6 @@ var allTestCases = []*testCase{
 		test: testSignPsbt,
 	},
 	{
-		name: "psbt channel funding single step",
-		test: testPsbtChanFundingSingleStep,
-	},
-	{
 		name: "sendtoroute multi path payment",
 		test: testSendToRouteMultiPath,
 	},

--- a/lntest/itest/lnd_test_list_on_test.go
+++ b/lntest/itest/lnd_test_list_on_test.go
@@ -115,10 +115,6 @@ var allTestCases = []*testCase{
 		test: testHoldInvoicePersistence,
 	},
 	{
-		name: "hold invoice force close",
-		test: testHoldInvoiceForceClose,
-	},
-	{
 		name: "cpfp",
 		test: testCPFP,
 	},

--- a/lntest/itest/lnd_test_list_on_test.go
+++ b/lntest/itest/lnd_test_list_on_test.go
@@ -5,10 +5,6 @@ package itest
 
 var allTestCases = []*testCase{
 	{
-		name: "single hop invoice",
-		test: testSingleHopInvoice,
-	},
-	{
 		name: "multiple channel creation and update subscription",
 		test: testBasicChannelCreationAndUpdates,
 	},

--- a/lntest/itest/lnd_test_list_on_test.go
+++ b/lntest/itest/lnd_test_list_on_test.go
@@ -53,10 +53,6 @@ var allTestCases = []*testCase{
 		test: testCPFP,
 	},
 	{
-		name: "macaroon authentication",
-		test: testMacaroonAuthentication,
-	},
-	{
 		name: "bake macaroon",
 		test: testBakeMacaroon,
 	},

--- a/lntest/itest/lnd_test_list_on_test.go
+++ b/lntest/itest/lnd_test_list_on_test.go
@@ -9,10 +9,6 @@ var allTestCases = []*testCase{
 		test: testSingleHopInvoice,
 	},
 	{
-		name: "multi-hop payments over private channels",
-		test: testMultiHopOverPrivateChannels,
-	},
-	{
 		name: "multiple channel creation and update subscription",
 		test: testBasicChannelCreationAndUpdates,
 	},

--- a/lntest/itest/lnd_test_list_on_test.go
+++ b/lntest/itest/lnd_test_list_on_test.go
@@ -73,10 +73,6 @@ var allTestCases = []*testCase{
 		test: testSwitchOfflineDeliveryOutgoingOffline,
 	},
 	{
-		name: "revoked uncooperative close retribution zero value remote output",
-		test: testRevokedCloseRetributionZeroValueRemoteOutput,
-	},
-	{
 		name: "revoked uncooperative close retribution remote hodl",
 		test: testRevokedCloseRetributionRemoteHodl,
 	},

--- a/lntest/itest/lnd_test_list_on_test.go
+++ b/lntest/itest/lnd_test_list_on_test.go
@@ -117,10 +117,6 @@ var allTestCases = []*testCase{
 		test: testWalletImportPubKey,
 	},
 	{
-		name: "rpc middleware interceptor",
-		test: testRPCMiddlewareInterceptor,
-	},
-	{
 		name: "wipe forwarding packages",
 		test: testWipeForwardingPackages,
 	},

--- a/lntest/itest/lnd_wipe_fwdpkgs_test.go
+++ b/lntest/itest/lnd_wipe_fwdpkgs_test.go
@@ -1,14 +1,11 @@
 package itest
 
 import (
-	"context"
-	"testing"
 	"time"
 
 	"github.com/lightningnetwork/lnd/chainreg"
 	"github.com/lightningnetwork/lnd/lnrpc"
-	"github.com/lightningnetwork/lnd/lnrpc/routerrpc"
-	"github.com/lightningnetwork/lnd/lntest"
+	"github.com/lightningnetwork/lnd/lntemp"
 	"github.com/stretchr/testify/require"
 )
 
@@ -22,91 +19,9 @@ type pendingChan *lnrpc.PendingChannelsResponse_PendingChannel
 //   - Bob force closes the channel Alice->Bob, and checks from both Bob's
 //     PoV(local force close) and Alice's Pov(remote close) that the forwarding
 //     packages are wiped.
-//   - Bob coop closes the channel Bob->Carol, and checks from both Bob PoVs that
-//     the forwarding packages are wiped.
-func testWipeForwardingPackages(net *lntest.NetworkHarness,
-	t *harnessTest) {
-
-	// Setup the test and get the channel points.
-	pointAB, pointBC, carol, cleanUp := setupFwdPkgTest(net, t)
-	defer cleanUp()
-
-	// Firstly, Bob force closes the channel.
-	_, _, err := net.CloseChannel(net.Bob, pointAB, true)
-	require.NoError(t.t, err, "unable to force close channel")
-
-	// Now that the channel has been force closed, it should show up in
-	// bob's PendingChannels RPC under the waiting close section.
-	pendingChan := assertWaitingCloseChannel(t.t, net.Bob)
-
-	// Check that Bob has created forwarding packages. We don't care the
-	// exact number here as long as these packages are deleted when the
-	// channel is closed.
-	require.NotZero(t.t, pendingChan.NumForwardingPackages)
-
-	// Mine 1 block to get the closing transaction confirmed.
-	_, err = net.Miner.Client.Generate(1)
-	require.NoError(t.t, err, "unable to mine blocks")
-
-	// Now that the closing transaction is confirmed, the above waiting
-	// close channel should now become pending force closed channel.
-	pendingChan = assertPendingForceClosedChannel(t.t, net.Bob)
-
-	// Check the forwarding packages are deleted.
-	require.Zero(t.t, pendingChan.NumForwardingPackages)
-
-	// For Alice, the forwarding packages should have been wiped too.
-	pendingChanAlice := assertPendingForceClosedChannel(t.t, net.Alice)
-	require.Zero(t.t, pendingChanAlice.NumForwardingPackages)
-
-	// Secondly, Bob coop closes the channel.
-	_, _, err = net.CloseChannel(net.Bob, pointBC, false)
-	require.NoError(t.t, err, "unable to coop close channel")
-
-	// Now that the channel has been coop closed, it should show up in
-	// bob's PendingChannels RPC under the waiting close section.
-	pendingChan = assertWaitingCloseChannel(t.t, net.Bob)
-
-	// Check that Bob has created forwarding packages. We don't care the
-	// exact number here as long as these packages are deleted when the
-	// channel is closed.
-	require.NotZero(t.t, pendingChan.NumForwardingPackages)
-
-	// Since it's a coop close, Carol should see the waiting close channel
-	// too.
-	pendingChanCarol := assertWaitingCloseChannel(t.t, carol)
-	require.NotZero(t.t, pendingChanCarol.NumForwardingPackages)
-
-	// Mine 1 block to get the closing transaction confirmed.
-	_, err = net.Miner.Client.Generate(1)
-	require.NoError(t.t, err, "unable to mine blocks")
-
-	// Now that the closing transaction is confirmed, the above waiting
-	// close channel should now become pending closed channel. Note that
-	// the name PendingForceClosingChannels is a bit confusing, what it
-	// really contains is channels whose closing tx has been broadcast.
-	pendingChan = assertPendingForceClosedChannel(t.t, net.Bob)
-
-	// Check the forwarding packages are deleted.
-	require.Zero(t.t, pendingChan.NumForwardingPackages)
-
-	// Mine a block to confirm sweep transactions such that they
-	// don't remain in the mempool for any subsequent tests.
-	_, err = net.Miner.Client.Generate(1)
-	require.NoError(t.t, err, "unable to mine blocks")
-}
-
-// setupFwdPkgTest prepares the wipe forwarding packages tests. It creates a
-// network topology that has a channel direction: Alice -> Bob -> Carol, sends
-// several payments from Alice to Carol, and returns the two channel points(one
-// for Alice and Bob, the other for Bob and Carol), the node Carol, and a
-// cleanup function to be used when the test finishes.
-func setupFwdPkgTest(net *lntest.NetworkHarness,
-	t *harnessTest) (*lnrpc.ChannelPoint, *lnrpc.ChannelPoint,
-	*lntest.HarnessNode, func()) {
-
-	ctxb := context.Background()
-
+//   - Bob coop closes the channel Bob->Carol, and checks from both Bob PoVs
+//     that the forwarding packages are wiped.
+func testWipeForwardingPackages(ht *lntemp.HarnessTest) {
 	const (
 		chanAmt        = 10e6
 		paymentAmt     = 10e4
@@ -114,114 +29,96 @@ func setupFwdPkgTest(net *lntest.NetworkHarness,
 		numInvoices    = 3
 	)
 
-	// Grab Alice and Bob from harness net.
-	alice, bob := net.Alice, net.Bob
+	// Grab Alice and Bob from HarnessTest.
+	alice, bob := ht.Alice, ht.Bob
 
 	// Create a new node Carol, which will create invoices that require
 	// Alice to pay.
-	carol := net.NewNode(t.t, "Carol", nil)
+	carol := ht.NewNode("Carol", nil)
 
 	// Connect Bob to Carol.
-	net.ConnectNodes(t.t, bob, carol)
+	ht.ConnectNodes(bob, carol)
 
 	// Open a channel between Alice and Bob.
-	chanPointAB := openChannelAndAssert(
-		t, net, alice, bob, lntest.OpenChannelParams{
-			Amt: chanAmt,
-		},
+	chanPointAB := ht.OpenChannel(
+		alice, bob, lntemp.OpenChannelParams{Amt: chanAmt},
 	)
 
 	// Open a channel between Bob and Carol.
-	chanPointBC := openChannelAndAssert(
-		t, net, bob, carol, lntest.OpenChannelParams{
-			Amt: chanAmt,
-		},
+	chanPointBC := ht.OpenChannel(
+		bob, carol, lntemp.OpenChannelParams{Amt: chanAmt},
 	)
 
-	ctxt, cancel := context.WithTimeout(ctxb, defaultTimeout)
-	defer cancel()
+	// Before we continue, make sure Alice has seen the channel between Bob
+	// and Carol.
+	ht.AssertTopologyChannelOpen(alice, chanPointBC)
 
 	// Alice sends several payments to Carol through Bob, which triggers
 	// Bob to create forwarding packages.
 	for i := 0; i < numInvoices; i++ {
 		// Add an invoice for Carol.
 		invoice := &lnrpc.Invoice{Memo: "testing", Value: paymentAmt}
-		invoiceResp, err := carol.AddInvoice(ctxt, invoice)
-		require.NoError(t.t, err, "unable to add invoice")
+		resp := carol.RPC.AddInvoice(invoice)
 
 		// Alice sends a payment to Carol through Bob.
-		sendAndAssertSuccess(
-			t, net.Alice, &routerrpc.SendPaymentRequest{
-				PaymentRequest: invoiceResp.PaymentRequest,
-				TimeoutSeconds: 60,
-				FeeLimitSat:    noFeeLimitMsat,
-			},
-		)
+		ht.CompletePaymentRequests(alice, []string{resp.PaymentRequest})
 	}
 
-	return chanPointAB, chanPointBC, carol, func() {
-		shutdownAndAssert(net, t, alice)
-		shutdownAndAssert(net, t, bob)
-		shutdownAndAssert(net, t, carol)
-	}
-}
+	// TODO(yy): remove the sleep once the following bug is fixed.
+	// When the invoice is reported settled, the commitment dance is not
+	// yet finished, which can cause an error when closing the channel,
+	// saying there's active HTLCs. We need to investigate this issue and
+	// reverse the order to, first finish the commitment dance, then report
+	// the invoice as settled.
+	time.Sleep(2 * time.Second)
 
-// assertWaitingCloseChannel checks there is a single channel that is waiting
-// for close and returns the channel found.
-func assertWaitingCloseChannel(t *testing.T,
-	node *lntest.HarnessNode) pendingChan {
+	// Firstly, Bob force closes the channel.
+	ht.CloseChannelAssertPending(bob, chanPointAB, true)
 
-	ctxb := context.Background()
+	// Now that the channel has been force closed, it should show up in
+	// bob's PendingChannels RPC under the waiting close section.
+	pendingAB := ht.AssertChannelWaitingClose(bob, chanPointAB).Channel
 
-	var channel pendingChan
-	require.Eventually(t, func() bool {
-		ctxt, cancel := context.WithTimeout(ctxb, defaultTimeout)
-		defer cancel()
+	// Check that Bob has created forwarding packages. We don't care the
+	// exact number here as long as these packages are deleted when the
+	// channel is closed.
+	require.NotZero(ht, pendingAB.NumForwardingPackages)
 
-		req := &lnrpc.PendingChannelsRequest{}
-		resp, err := node.PendingChannels(ctxt, req)
+	// Secondly, Bob coop closes the channel.
+	ht.CloseChannelAssertPending(bob, chanPointBC, false)
 
-		// We require the RPC call to be succeeded and won't retry upon
-		// an error.
-		require.NoError(t, err, "unable to query for pending channels")
+	// Now that the channel has been coop closed, it should show up in
+	// bob's PendingChannels RPC under the waiting close section.
+	pendingBC := ht.AssertChannelWaitingClose(bob, chanPointBC).Channel
 
-		if err := checkNumWaitingCloseChannels(resp, 1); err != nil {
-			return false
-		}
+	// Check that Bob has created forwarding packages. We don't care the
+	// exact number here as long as these packages are deleted when the
+	// channel is closed.
+	require.NotZero(ht, pendingBC.NumForwardingPackages)
 
-		channel = resp.WaitingCloseChannels[0].Channel
-		return true
-	}, defaultTimeout, 200*time.Millisecond)
+	// Since it's a coop close, Carol should see the waiting close channel
+	// too.
+	pendingBC = ht.AssertChannelWaitingClose(carol, chanPointBC).Channel
+	require.NotZero(ht, pendingBC.NumForwardingPackages)
 
-	return channel
-}
+	// Mine 1 block to get the two closing transactions confirmed.
+	ht.MineBlocksAndAssertNumTxes(1, 2)
 
-// assertForceClosedChannel checks there is a single channel that is pending
-// force closed and returns the channel found.
-func assertPendingForceClosedChannel(t *testing.T,
-	node *lntest.HarnessNode) pendingChan {
+	// Now that the closing transaction is confirmed, the above waiting
+	// close channel should now become pending force closed channel.
+	pendingAB = ht.AssertChannelPendingForceClose(bob, chanPointAB).Channel
 
-	ctxb := context.Background()
+	// Check the forwarding pacakges are deleted.
+	require.Zero(ht, pendingAB.NumForwardingPackages)
 
-	var channel pendingChan
-	require.Eventually(t, func() bool {
-		ctxt, cancel := context.WithTimeout(ctxb, defaultTimeout)
-		defer cancel()
+	// For Alice, the forwarding packages should have been wiped too.
+	pending := ht.AssertChannelPendingForceClose(alice, chanPointAB)
+	pendingAB = pending.Channel
+	require.Zero(ht, pendingAB.NumForwardingPackages)
 
-		req := &lnrpc.PendingChannelsRequest{}
-		resp, err := node.PendingChannels(ctxt, req)
+	// Mine 1 block to get Alice's sweeping tx confirmed.
+	ht.MineBlocksAndAssertNumTxes(1, 1)
 
-		// We require the RPC call to be succeeded and won't retry upon
-		// an error.
-		require.NoError(t, err, "unable to query for pending channels")
-
-		if err := checkNumForceClosedChannels(resp, 1); err != nil {
-			return false
-		}
-
-		channel = resp.PendingForceClosingChannels[0].Channel
-		return true
-	}, defaultTimeout, 200*time.Millisecond)
-
-	return channel
+	// Clean up the force closed channel.
+	ht.CleanupForceClose(bob, chanPointAB)
 }

--- a/lntest/itest/lnd_wumbo_channels_test.go
+++ b/lntest/itest/lnd_wumbo_channels_test.go
@@ -1,70 +1,52 @@
 package itest
 
 import (
-	"strings"
-
 	"github.com/btcsuite/btcd/btcutil"
 	"github.com/lightningnetwork/lnd/funding"
-	"github.com/lightningnetwork/lnd/lntest"
+	"github.com/lightningnetwork/lnd/lntemp"
+	"github.com/lightningnetwork/lnd/lnwallet"
 )
 
 // testWumboChannels tests that only a node that signals wumbo channel
 // acceptances will allow a wumbo channel to be created. Additionally, if a
 // node is running with mini channels only enabled, then they should reject any
 // inbound wumbo channel requests.
-func testWumboChannels(net *lntest.NetworkHarness, t *harnessTest) {
+func testWumboChannels(ht *lntemp.HarnessTest) {
 	// With all the channel types exercised, we'll now make sure the wumbo
 	// signalling support works properly.
 	//
 	// We'll make two new nodes, with one of them signalling support for
 	// wumbo channels while the other doesn't.
-	wumboNode := net.NewNode(
-		t.t, "wumbo", []string{"--protocol.wumbo-channels"},
-	)
-	defer shutdownAndAssert(net, t, wumboNode)
-	miniNode := net.NewNode(t.t, "mini", nil)
-	defer shutdownAndAssert(net, t, miniNode)
+	wumboNode := ht.NewNode("wumbo", []string{"--protocol.wumbo-channels"})
+	miniNode := ht.NewNode("mini", nil)
 
 	// We'll send coins to the wumbo node, as it'll be the one imitating
 	// the channel funding.
-	net.SendCoins(t.t, btcutil.SatoshiPerBitcoin, wumboNode)
+	ht.FundCoins(btcutil.SatoshiPerBitcoin, wumboNode)
 
 	// Next we'll connect both nodes, then attempt to make a wumbo channel
 	// funding request to the mini node we created above. The wumbo request
 	// should fail as the node isn't advertising wumbo channels.
-	net.EnsureConnected(t.t, wumboNode, miniNode)
+	ht.EnsureConnected(wumboNode, miniNode)
 
 	chanAmt := funding.MaxBtcFundingAmount + 1
-	_, err := net.OpenChannel(
-		wumboNode, miniNode, lntest.OpenChannelParams{
-			Amt: chanAmt,
-		},
-	)
-	if err == nil {
-		t.Fatalf("expected wumbo channel funding to fail")
-	}
-
 	// The test should indicate a failure due to the channel being too
 	// large.
-	if !strings.Contains(err.Error(), "exceeds maximum chan size") {
-		t.Fatalf("channel should be rejected due to size, instead "+
-			"error was: %v", err)
-	}
+	ht.OpenChannelAssertErr(
+		wumboNode, miniNode, lntemp.OpenChannelParams{Amt: chanAmt},
+		lnwallet.ErrChanTooLarge(chanAmt, funding.MaxBtcFundingAmount),
+	)
 
 	// We'll now make another wumbo node to accept our wumbo channel
 	// funding.
-	wumboNode2 := net.NewNode(
-		t.t, "wumbo2", []string{"--protocol.wumbo-channels"},
+	wumboNode2 := ht.NewNode(
+		"wumbo2", []string{"--protocol.wumbo-channels"},
 	)
-	defer shutdownAndAssert(net, t, wumboNode2)
 
 	// Creating a wumbo channel between these two nodes should succeed.
-	net.EnsureConnected(t.t, wumboNode, wumboNode2)
-	chanPoint := openChannelAndAssert(
-		t, net, wumboNode, wumboNode2,
-		lntest.OpenChannelParams{
-			Amt: chanAmt,
-		},
+	ht.EnsureConnected(wumboNode, wumboNode2)
+	chanPoint := ht.OpenChannel(
+		wumboNode, wumboNode2, lntemp.OpenChannelParams{Amt: chanAmt},
 	)
-	closeChannelAndAssert(t, net, wumboNode, chanPoint, false)
+	ht.CloseChannel(wumboNode, chanPoint)
 }

--- a/lnwallet/wallet.go
+++ b/lnwallet/wallet.go
@@ -798,6 +798,9 @@ func (l *LightningWallet) handleFundingReserveRequest(req *InitFundingReserveMsg
 			return
 		}
 
+		walletLog.Debugf("Registered funding intent for "+
+			"PendingChanID: %x", req.PendingChanID)
+
 		localFundingAmt = fundingIntent.LocalFundingAmt()
 		remoteFundingAmt = fundingIntent.RemoteFundingAmt()
 	}
@@ -891,6 +894,10 @@ func (l *LightningWallet) handleFundingReserveRequest(req *InitFundingReserveMsg
 	// completed, or canceled.
 	req.resp <- reservation
 	req.err <- nil
+
+	walletLog.Debugf("Successfully handled funding reservation with "+
+		"pendingChanID: %x, reservationID: %v",
+		reservation.pendingChanID, reservation.reservationID)
 }
 
 // enforceReservedValue enforces that the wallet, upon a new channel being

--- a/routing/bandwidth.go
+++ b/routing/bandwidth.go
@@ -77,6 +77,7 @@ func (b *bandwidthManager) getBandwidth(cid lnwire.ShortChannelID,
 	if err != nil {
 		// If the link isn't online, then we'll report that it has
 		// zero bandwidth.
+		log.Warnf("ShortChannelID=%v: link not found: %v", cid, err)
 		return 0
 	}
 
@@ -84,12 +85,15 @@ func (b *bandwidthManager) getBandwidth(cid lnwire.ShortChannelID,
 	// to forward any HTLCs, then we'll treat it as if it isn't online in
 	// the first place.
 	if !link.EligibleToForward() {
+		log.Warnf("ShortChannelID=%v: not eligible to forward", cid)
 		return 0
 	}
 
 	// If our link isn't currently in a state where it can  add another
 	// outgoing htlc, treat the link as unusable.
 	if err := link.MayAddOutgoingHtlc(amount); err != nil {
+		log.Warnf("ShortChannelID=%v: cannot add outgoing htlc: %v",
+			cid, err)
 		return 0
 	}
 


### PR DESCRIPTION
Please check #6825 for more context.

Depending on #6822, this PR continues the fix of the tests.

This PR starts at commit `lntemp+itest: refactor testEtcdFailover`