### PR TITLE
itest: continued itest refactor and fix - IV

### DIFF
--- a/docs/release-notes/release-notes-0.16.0.md
+++ b/docs/release-notes/release-notes-0.16.0.md
@@ -365,7 +365,8 @@ PRs([6776](https://github.com/lightningnetwork/lnd/pull/6776),
 [7172](https://github.com/lightningnetwork/lnd/pull/7172),
 [7242](https://github.com/lightningnetwork/lnd/pull/7242),
 [7245](https://github.com/lightningnetwork/lnd/pull/7245)),
-[6823](https://github.com/lightningnetwork/lnd/pull/6823)) have been made to
+[6823](https://github.com/lightningnetwork/lnd/pull/6823),
+[6824](https://github.com/lightningnetwork/lnd/pull/6824),) have been made to
 refactor the itest for code health and maintenance.
 
 # Contributors (Alphabetical Order)

--- a/lntemp/harness.go
+++ b/lntemp/harness.go
@@ -822,6 +822,26 @@ type OpenChannelParams struct {
 	// ScidAlias denotes whether the channel will be an option-scid-alias
 	// channel type negotiation.
 	ScidAlias bool
+
+	// BaseFee is the channel base fee applied during the channel
+	// announcement phase.
+	BaseFee uint64
+
+	// FeeRate is the channel fee rate in ppm applied during the channel
+	// announcement phase.
+	FeeRate uint64
+
+	// UseBaseFee, if set, instructs the downstream logic to apply the
+	// user-specified channel base fee to the channel update announcement.
+	// If set to false it avoids applying a base fee of 0 and instead
+	// activates the default configured base fee.
+	UseBaseFee bool
+
+	// UseFeeRate, if set, instructs the downstream logic to apply the
+	// user-specified channel fee rate to the channel update announcement.
+	// If set to false it avoids applying a fee rate of 0 and instead
+	// activates the default configured fee rate.
+	UseFeeRate bool
 }
 
 // prepareOpenChannel waits for both nodes to be synced to chain and returns an
@@ -858,6 +878,10 @@ func (h *HarnessTest) prepareOpenChannel(srcNode, destNode *node.HarnessNode,
 		CommitmentType:     p.CommitmentType,
 		ZeroConf:           p.ZeroConf,
 		ScidAlias:          p.ScidAlias,
+		BaseFee:            p.BaseFee,
+		FeeRate:            p.FeeRate,
+		UseBaseFee:         p.UseBaseFee,
+		UseFeeRate:         p.UseFeeRate,
 	}
 }
 

--- a/lntemp/harness.go
+++ b/lntemp/harness.go
@@ -1944,3 +1944,26 @@ func (h *HarnessTest) ReceiveChannelEvent(
 
 	return nil
 }
+
+// GetOutputIndex returns the output index of the given address in the given
+// transaction.
+func (h *HarnessTest) GetOutputIndex(txid *chainhash.Hash, addr string) int {
+	// We'll then extract the raw transaction from the mempool in order to
+	// determine the index of the p2tr output.
+	tx := h.Miner.GetRawTransaction(txid)
+
+	p2trOutputIndex := -1
+	for i, txOut := range tx.MsgTx().TxOut {
+		_, addrs, _, err := txscript.ExtractPkScriptAddrs(
+			txOut.PkScript, h.Miner.ActiveNet,
+		)
+		require.NoError(h, err)
+
+		if addrs[0].String() == addr {
+			p2trOutputIndex = i
+		}
+	}
+	require.Greater(h, p2trOutputIndex, -1)
+
+	return p2trOutputIndex
+}

--- a/lntemp/harness_assertion.go
+++ b/lntemp/harness_assertion.go
@@ -127,6 +127,9 @@ func (h *HarnessTest) ConnectNodesPerm(a, b *node.HarnessNode) {
 func (h *HarnessTest) DisconnectNodes(a, b *node.HarnessNode) {
 	bobInfo := b.RPC.GetInfo()
 	a.RPC.DisconnectPeer(bobInfo.IdentityPubkey)
+
+	// Assert disconnected.
+	h.AssertPeerNotConnected(a, b)
 }
 
 // EnsureConnected will try to connect to two nodes, returning no error if they

--- a/lntemp/harness_miner.go
+++ b/lntemp/harness_miner.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/btcsuite/btcd/btcjson"
 	"github.com/btcsuite/btcd/btcutil"
 	"github.com/btcsuite/btcd/chaincfg"
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
@@ -250,6 +251,16 @@ func (h *HarnessMiner) MineBlocksAndAssertNumTxes(num uint32,
 func (h *HarnessMiner) GetRawTransaction(txid *chainhash.Hash) *btcutil.Tx {
 	tx, err := h.Client.GetRawTransaction(txid)
 	require.NoErrorf(h, err, "failed to get raw tx: %v", txid)
+	return tx
+}
+
+// GetRawTransactionVerbose makes a RPC call to the miner's
+// GetRawTransactionVerbose and asserts.
+func (h *HarnessMiner) GetRawTransactionVerbose(
+	txid *chainhash.Hash) *btcjson.TxRawResult {
+
+	tx, err := h.Client.GetRawTransactionVerbose(txid)
+	require.NoErrorf(h, err, "failed to get raw tx verbose: %v", txid)
 	return tx
 }
 

--- a/lntemp/node/harness_node.go
+++ b/lntemp/node/harness_node.go
@@ -164,11 +164,11 @@ func (hn *HarnessNode) String() string {
 	type nodeCfg struct {
 		LogFilenamePrefix string
 		ExtraArgs         []string
-		HasSeed           bool
+		SkipUnlock        bool
+		Password          []byte
 		P2PPort           int
 		RPCPort           int
 		RESTPort          int
-		ProfilePort       int
 		AcceptKeySend     bool
 		FeeURL            string
 	}
@@ -185,6 +185,8 @@ func (hn *HarnessNode) String() string {
 		PubKey: hn.PubKeyStr,
 		State:  hn.State,
 		NodeCfg: nodeCfg{
+			SkipUnlock:        hn.Cfg.SkipUnlock,
+			Password:          hn.Cfg.Password,
 			LogFilenamePrefix: hn.Cfg.LogFilenamePrefix,
 			ExtraArgs:         hn.Cfg.ExtraArgs,
 			P2PPort:           hn.Cfg.P2PPort,

--- a/lntemp/node/state.go
+++ b/lntemp/node/state.go
@@ -241,6 +241,14 @@ func (s *State) updatePaymentStats() {
 	}
 	resp := s.rpc.ListPayments(req)
 
+	// Exit early when the there's no payment.
+	//
+	// NOTE: we need to exit early here because when there's no invoice the
+	// `LastOffsetIndex` will be zero.
+	if len(resp.Payments) == 0 {
+		return
+	}
+
 	s.Payment.LastIndexOffset = resp.LastIndexOffset
 	for _, payment := range resp.Payments {
 		if payment.Status == lnrpc.Payment_FAILED ||
@@ -260,6 +268,14 @@ func (s *State) updateInvoiceStats() {
 		IndexOffset:    s.Invoice.LastIndexOffset,
 	}
 	resp := s.rpc.ListInvoices(req)
+
+	// Exit early when the there's no invoice.
+	//
+	// NOTE: we need to exit early here because when there's no invoice the
+	// `LastOffsetIndex` will be zero.
+	if len(resp.Invoices) == 0 {
+		return
+	}
 
 	s.Invoice.LastIndexOffset = resp.LastIndexOffset
 	for _, invoice := range resp.Invoices {

--- a/lntemp/node/state.go
+++ b/lntemp/node/state.go
@@ -344,3 +344,17 @@ func (s *State) String() string {
 
 	return fmt.Sprintf("\n%s", stateBytes)
 }
+
+// resetEphermalStates resets the current state with a new HarnessRPC and empty
+// private fields which are used to track state only valid for the last test.
+func (s *State) resetEphermalStates(rpc *rpc.HarnessRPC) {
+	s.rpc = rpc
+
+	// Reset ephermal states which are used to record info from finished
+	// tests.
+	s.openChans = &SyncMap[wire.OutPoint, []*OpenChannelUpdate]{}
+	s.closedChans = &SyncMap[wire.OutPoint, *lnrpc.ClosedChannelUpdate]{}
+	s.numChanUpdates = &SyncMap[wire.OutPoint, int]{}
+	s.nodeUpdates = &SyncMap[string, []*lnrpc.NodeUpdate]{}
+	s.policyUpdates = &SyncMap[wire.OutPoint, PolicyUpdate]{}
+}

--- a/lntemp/rpc/chain_notifier.go
+++ b/lntemp/rpc/chain_notifier.go
@@ -1,5 +1,44 @@
 package rpc
 
+import (
+	"github.com/lightningnetwork/lnd/lnrpc/chainrpc"
+)
+
 // =====================
 // ChainClient related RPCs.
 // =====================
+
+type ConfNtfnClient chainrpc.ChainNotifier_RegisterConfirmationsNtfnClient
+
+// RegisterConfirmationsNtfn creates a notification client to watch a given
+// transaction being confirmed.
+func (h *HarnessRPC) RegisterConfirmationsNtfn(
+	req *chainrpc.ConfRequest) ConfNtfnClient {
+
+	// RegisterConfirmationsNtfn needs to have the context alive for the
+	// entire test case as the returned client will be used for send and
+	// receive events stream. Thus we use runCtx here instead of a timeout
+	// context.
+	client, err := h.ChainClient.RegisterConfirmationsNtfn(
+		h.runCtx, req,
+	)
+	h.NoError(err, "RegisterConfirmationsNtfn")
+
+	return client
+}
+
+type SpendClient chainrpc.ChainNotifier_RegisterSpendNtfnClient
+
+// RegisterSpendNtfn creates a notification client to watch a given
+// transaction being spent.
+func (h *HarnessRPC) RegisterSpendNtfn(req *chainrpc.SpendRequest) SpendClient {
+	// RegisterSpendNtfn needs to have the context alive for the entire
+	// test case as the returned client will be used for send and receive
+	// events stream. Thus we use runCtx here instead of a timeout context.
+	client, err := h.ChainClient.RegisterSpendNtfn(
+		h.runCtx, req,
+	)
+	h.NoError(err, "RegisterSpendNtfn")
+
+	return client
+}

--- a/lntemp/rpc/lnd.go
+++ b/lntemp/rpc/lnd.go
@@ -648,3 +648,37 @@ func (h *HarnessRPC) SubscribeChannelEvents() ChannelEventsClient {
 
 	return client
 }
+
+type CustomMessageClient lnrpc.Lightning_SubscribeCustomMessagesClient
+
+// SubscribeCustomMessages creates a subscription client for custom messages.
+func (h *HarnessRPC) SubscribeCustomMessages() (CustomMessageClient,
+	context.CancelFunc) {
+
+	ctxt, cancel := context.WithCancel(h.runCtx)
+
+	req := &lnrpc.SubscribeCustomMessagesRequest{}
+
+	// SubscribeCustomMessages needs to have the context alive for the
+	// entire test case as the returned client will be used for send and
+	// receive events stream. Thus we use runCtx here instead of a timeout
+	// context.
+	stream, err := h.LN.SubscribeCustomMessages(ctxt, req)
+	h.NoError(err, "SubscribeCustomMessages")
+
+	return stream, cancel
+}
+
+// SendCustomMessage makes a RPC call to the node's SendCustomMessage and
+// returns the response.
+func (h *HarnessRPC) SendCustomMessage(
+	req *lnrpc.SendCustomMessageRequest) *lnrpc.SendCustomMessageResponse {
+
+	ctxt, cancel := context.WithTimeout(h.runCtx, DefaultTimeout)
+	defer cancel()
+
+	resp, err := h.LN.SendCustomMessage(ctxt, req)
+	h.NoError(err, "SendCustomMessage")
+
+	return resp
+}

--- a/lntemp/rpc/lnd.go
+++ b/lntemp/rpc/lnd.go
@@ -631,3 +631,20 @@ func (h *HarnessRPC) RegisterRPCMiddleware() (MiddlewareClient,
 
 	return stream, cancel
 }
+
+type ChannelEventsClient lnrpc.Lightning_SubscribeChannelEventsClient
+
+// SubscribeChannelEvents creates a subscription client for channel events and
+// asserts its creation.
+func (h *HarnessRPC) SubscribeChannelEvents() ChannelEventsClient {
+	req := &lnrpc.ChannelEventSubscription{}
+
+	// SubscribeChannelEvents needs to have the context alive for the
+	// entire test case as the returned client will be used for send and
+	// receive events stream. Thus we use runCtx here instead of a timeout
+	// context.
+	client, err := h.LN.SubscribeChannelEvents(h.runCtx, req)
+	h.NoError(err, "SubscribeChannelEvents")
+
+	return client
+}

--- a/lntemp/rpc/router.go
+++ b/lntemp/rpc/router.go
@@ -160,6 +160,7 @@ func (h *HarnessRPC) BuildRoute(
 
 	resp, err := h.Router.BuildRoute(ctxt, req)
 	h.NoError(err, "BuildRoute")
+
 	return resp
 }
 

--- a/lntemp/rpc/router.go
+++ b/lntemp/rpc/router.go
@@ -150,3 +150,15 @@ func (h *HarnessRPC) XImportMissionControlAssertErr(
 	_, err := h.Router.XImportMissionControl(ctxt, req)
 	require.Error(h, err, "expect an error from x import mission control")
 }
+
+// BuildRoute makes a RPC call to the node's RouterClient and asserts.
+func (h *HarnessRPC) BuildRoute(
+	req *routerrpc.BuildRouteRequest) *routerrpc.BuildRouteResponse {
+
+	ctxt, cancel := context.WithTimeout(h.runCtx, DefaultTimeout)
+	defer cancel()
+
+	resp, err := h.Router.BuildRoute(ctxt, req)
+	h.NoError(err, "BuildRoute")
+	return resp
+}

--- a/lntemp/rpc/router.go
+++ b/lntemp/rpc/router.go
@@ -162,3 +162,18 @@ func (h *HarnessRPC) BuildRoute(
 	h.NoError(err, "BuildRoute")
 	return resp
 }
+
+type InterceptorClient routerrpc.Router_HtlcInterceptorClient
+
+// HtlcInterceptor makes a RPC call to the node's RouterClient and asserts.
+func (h *HarnessRPC) HtlcInterceptor() (InterceptorClient, context.CancelFunc) {
+	// HtlcInterceptor needs to have the context alive for the entire test
+	// case as the returned client will be used for send and receive events
+	// stream. Thus we use cancel context here instead of a timeout
+	// context.
+	ctxt, cancel := context.WithCancel(h.runCtx)
+	resp, err := h.Router.HtlcInterceptor(ctxt)
+	h.NoError(err, "HtlcInterceptor")
+
+	return resp, cancel
+}

--- a/lntemp/rpc/router.go
+++ b/lntemp/rpc/router.go
@@ -177,3 +177,15 @@ func (h *HarnessRPC) HtlcInterceptor() (InterceptorClient, context.CancelFunc) {
 
 	return resp, cancel
 }
+
+type TrackPaymentsClient routerrpc.Router_TrackPaymentsClient
+
+// TrackPayments makes a RPC call to the node's RouterClient and asserts.
+func (h *HarnessRPC) TrackPayments(
+	req *routerrpc.TrackPaymentsRequest) TrackPaymentsClient {
+
+	resp, err := h.Router.TrackPayments(h.runCtx, req)
+	h.NoError(err, "TrackPayments")
+
+	return resp
+}

--- a/lntemp/rpc/signer.go
+++ b/lntemp/rpc/signer.go
@@ -147,3 +147,33 @@ func (h *HarnessRPC) MuSig2Cleanup(
 
 	return resp
 }
+
+// SignMessageSigner makes a RPC call to the node's SignerClient and asserts.
+//
+// NOTE: there's already `SignMessage` in `h.LN`.
+func (h *HarnessRPC) SignMessageSigner(
+	req *signrpc.SignMessageReq) *signrpc.SignMessageResp {
+
+	ctxt, cancel := context.WithTimeout(h.runCtx, DefaultTimeout)
+	defer cancel()
+
+	resp, err := h.Signer.SignMessage(ctxt, req)
+	h.NoError(err, "SignMessage")
+
+	return resp
+}
+
+// VerifyMessageSigner makes a RPC call to the node's SignerClient and asserts.
+//
+// NOTE: there's already `VerifyMessageSigner` in `h.LN`.
+func (h *HarnessRPC) VerifyMessageSigner(
+	req *signrpc.VerifyMessageReq) *signrpc.VerifyMessageResp {
+
+	ctxt, cancel := context.WithTimeout(h.runCtx, DefaultTimeout)
+	defer cancel()
+
+	resp, err := h.Signer.VerifyMessage(ctxt, req)
+	h.NoError(err, "VerifyMessage")
+
+	return resp
+}

--- a/lntemp/rpc/signer.go
+++ b/lntemp/rpc/signer.go
@@ -4,19 +4,146 @@ import (
 	"context"
 
 	"github.com/lightningnetwork/lnd/lnrpc/signrpc"
+	"github.com/stretchr/testify/require"
 )
 
 // =====================
 // Signer related RPCs.
 // =====================
 
-// SignOutputRaw makes a RPC call to node's SignOutputRaw and asserts.
+// DeriveSharedKey makes a RPC call to the node's SignerClient and asserts.
+func (h *HarnessRPC) DeriveSharedKey(
+	req *signrpc.SharedKeyRequest) *signrpc.SharedKeyResponse {
+
+	ctxt, cancel := context.WithTimeout(h.runCtx, DefaultTimeout)
+	defer cancel()
+
+	resp, err := h.Signer.DeriveSharedKey(ctxt, req)
+	h.NoError(err, "DeriveSharedKey")
+
+	return resp
+}
+
+// DeriveSharedKeyErr makes a RPC call to the node's SignerClient and asserts
+// there is an error.
+func (h *HarnessRPC) DeriveSharedKeyErr(req *signrpc.SharedKeyRequest) error {
+	ctxt, cancel := context.WithTimeout(h.runCtx, DefaultTimeout)
+	defer cancel()
+
+	_, err := h.Signer.DeriveSharedKey(ctxt, req)
+	require.Error(h, err, "expected error from calling DeriveSharedKey")
+	return err
+}
+
+// SignOutputRaw makes a RPC call to the node's SignerClient and asserts.
 func (h *HarnessRPC) SignOutputRaw(req *signrpc.SignReq) *signrpc.SignResp {
 	ctxt, cancel := context.WithTimeout(h.runCtx, DefaultTimeout)
 	defer cancel()
 
 	resp, err := h.Signer.SignOutputRaw(ctxt, req)
 	h.NoError(err, "SignOutputRaw")
+
+	return resp
+}
+
+// SignOutputRawErr makes a RPC call to the node's SignerClient and asserts an
+// error is returned.
+func (h *HarnessRPC) SignOutputRawErr(req *signrpc.SignReq) error {
+	ctxt, cancel := context.WithTimeout(h.runCtx, DefaultTimeout)
+	defer cancel()
+
+	_, err := h.Signer.SignOutputRaw(ctxt, req)
+	require.Error(h, err, "expect to fail to sign raw output")
+
+	return err
+}
+
+// MuSig2CreateSession makes a RPC call to the node's SignerClient and asserts.
+func (h *HarnessRPC) MuSig2CreateSession(
+	req *signrpc.MuSig2SessionRequest) *signrpc.MuSig2SessionResponse {
+
+	ctxt, cancel := context.WithTimeout(h.runCtx, DefaultTimeout)
+	defer cancel()
+
+	resp, err := h.Signer.MuSig2CreateSession(ctxt, req)
+	h.NoError(err, "MuSig2CreateSession")
+
+	return resp
+}
+
+// MuSig2CombineKeys makes a RPC call to the node's SignerClient and asserts.
+func (h *HarnessRPC) MuSig2CombineKeys(
+	req *signrpc.MuSig2CombineKeysRequest) *signrpc.MuSig2CombineKeysResponse {
+
+	ctxt, cancel := context.WithTimeout(h.runCtx, DefaultTimeout)
+	defer cancel()
+
+	resp, err := h.Signer.MuSig2CombineKeys(ctxt, req)
+	h.NoError(err, "MuSig2CombineKeys")
+
+	return resp
+}
+
+// MuSig2RegisterNonces makes a RPC call to the node's SignerClient and asserts.
+func (h *HarnessRPC) MuSig2RegisterNonces(
+	req *signrpc.MuSig2RegisterNoncesRequest) *signrpc.MuSig2RegisterNoncesResponse {
+
+	ctxt, cancel := context.WithTimeout(h.runCtx, DefaultTimeout)
+	defer cancel()
+
+	resp, err := h.Signer.MuSig2RegisterNonces(ctxt, req)
+	h.NoError(err, "MuSig2RegisterNonces")
+
+	return resp
+}
+
+// MuSig2Sign makes a RPC call to the node's SignerClient and asserts.
+func (h *HarnessRPC) MuSig2Sign(
+	req *signrpc.MuSig2SignRequest) *signrpc.MuSig2SignResponse {
+
+	ctxt, cancel := context.WithTimeout(h.runCtx, DefaultTimeout)
+	defer cancel()
+
+	resp, err := h.Signer.MuSig2Sign(ctxt, req)
+	h.NoError(err, "MuSig2Sign")
+
+	return resp
+}
+
+// MuSig2SignErr makes a RPC call to the node's SignerClient and asserts an
+// error is returned.
+func (h *HarnessRPC) MuSig2SignErr(req *signrpc.MuSig2SignRequest) error {
+	ctxt, cancel := context.WithTimeout(h.runCtx, DefaultTimeout)
+	defer cancel()
+
+	_, err := h.Signer.MuSig2Sign(ctxt, req)
+	require.Error(h, err, "expect an error")
+
+	return err
+}
+
+// MuSig2CombineSig makes a RPC call to the node's SignerClient and asserts.
+func (h *HarnessRPC) MuSig2CombineSig(
+	req *signrpc.MuSig2CombineSigRequest) *signrpc.MuSig2CombineSigResponse {
+
+	ctxt, cancel := context.WithTimeout(h.runCtx, DefaultTimeout)
+	defer cancel()
+
+	resp, err := h.Signer.MuSig2CombineSig(ctxt, req)
+	h.NoError(err, "MuSig2CombineSig")
+
+	return resp
+}
+
+// MuSig2Cleanup makes a RPC call to the node's SignerClient and asserts.
+func (h *HarnessRPC) MuSig2Cleanup(
+	req *signrpc.MuSig2CleanupRequest) *signrpc.MuSig2CleanupResponse {
+
+	ctxt, cancel := context.WithTimeout(h.runCtx, DefaultTimeout)
+	defer cancel()
+
+	resp, err := h.Signer.MuSig2Cleanup(ctxt, req)
+	h.NoError(err, "MuSig2Cleanup")
 
 	return resp
 }

--- a/lntemp/rpc/signer.go
+++ b/lntemp/rpc/signer.go
@@ -177,3 +177,16 @@ func (h *HarnessRPC) VerifyMessageSigner(
 
 	return resp
 }
+
+// ComputeInputScript makes a RPC call to the node's SignerClient and asserts.
+func (h *HarnessRPC) ComputeInputScript(
+	req *signrpc.SignReq) *signrpc.InputScriptResp {
+
+	ctxt, cancel := context.WithTimeout(h.runCtx, DefaultTimeout)
+	defer cancel()
+
+	resp, err := h.Signer.ComputeInputScript(ctxt, req)
+	h.NoError(err, "ComputeInputScript")
+
+	return resp
+}

--- a/lntemp/rpc/signer.go
+++ b/lntemp/rpc/signer.go
@@ -32,6 +32,7 @@ func (h *HarnessRPC) DeriveSharedKeyErr(req *signrpc.SharedKeyRequest) error {
 
 	_, err := h.Signer.DeriveSharedKey(ctxt, req)
 	require.Error(h, err, "expected error from calling DeriveSharedKey")
+
 	return err
 }
 
@@ -72,6 +73,8 @@ func (h *HarnessRPC) MuSig2CreateSession(
 }
 
 // MuSig2CombineKeys makes a RPC call to the node's SignerClient and asserts.
+//
+//nolint:lll
 func (h *HarnessRPC) MuSig2CombineKeys(
 	req *signrpc.MuSig2CombineKeysRequest) *signrpc.MuSig2CombineKeysResponse {
 
@@ -85,6 +88,8 @@ func (h *HarnessRPC) MuSig2CombineKeys(
 }
 
 // MuSig2RegisterNonces makes a RPC call to the node's SignerClient and asserts.
+//
+//nolint:lll
 func (h *HarnessRPC) MuSig2RegisterNonces(
 	req *signrpc.MuSig2RegisterNoncesRequest) *signrpc.MuSig2RegisterNoncesResponse {
 
@@ -124,12 +129,12 @@ func (h *HarnessRPC) MuSig2SignErr(req *signrpc.MuSig2SignRequest) error {
 
 // MuSig2CombineSig makes a RPC call to the node's SignerClient and asserts.
 func (h *HarnessRPC) MuSig2CombineSig(
-	req *signrpc.MuSig2CombineSigRequest) *signrpc.MuSig2CombineSigResponse {
+	r *signrpc.MuSig2CombineSigRequest) *signrpc.MuSig2CombineSigResponse {
 
 	ctxt, cancel := context.WithTimeout(h.runCtx, DefaultTimeout)
 	defer cancel()
 
-	resp, err := h.Signer.MuSig2CombineSig(ctxt, req)
+	resp, err := h.Signer.MuSig2CombineSig(ctxt, r)
 	h.NoError(err, "MuSig2CombineSig")
 
 	return resp

--- a/lntemp/rpc/wallet_kit.go
+++ b/lntemp/rpc/wallet_kit.go
@@ -198,7 +198,7 @@ func (h *HarnessRPC) ImportAccount(
 	defer cancel()
 
 	resp, err := h.WalletKit.ImportAccount(ctxt, req)
-	require.NoErrorf(h, err, "failed to import account")
+	h.NoError(err, "ImportAccount")
 
 	return resp
 }

--- a/lntemp/rpc/wallet_kit.go
+++ b/lntemp/rpc/wallet_kit.go
@@ -204,6 +204,8 @@ func (h *HarnessRPC) ImportAccount(
 }
 
 // ImportPublicKey makes a RPC call to the node's WalletKitClient and asserts.
+//
+//nolint:lll
 func (h *HarnessRPC) ImportPublicKey(
 	req *walletrpc.ImportPublicKeyRequest) *walletrpc.ImportPublicKeyResponse {
 
@@ -230,6 +232,8 @@ func (h *HarnessRPC) SignPsbt(
 }
 
 // ImportTapscript makes a RPC call to the node's WalletKitClient and asserts.
+//
+//nolint:lll
 func (h *HarnessRPC) ImportTapscript(
 	req *walletrpc.ImportTapscriptRequest) *walletrpc.ImportTapscriptResponse {
 

--- a/lntemp/rpc/wallet_kit.go
+++ b/lntemp/rpc/wallet_kit.go
@@ -228,3 +228,16 @@ func (h *HarnessRPC) SignPsbt(
 
 	return resp
 }
+
+// ImportTapscript makes a RPC call to the node's WalletKitClient and asserts.
+func (h *HarnessRPC) ImportTapscript(
+	req *walletrpc.ImportTapscriptRequest) *walletrpc.ImportTapscriptResponse {
+
+	ctxt, cancel := context.WithTimeout(h.runCtx, DefaultTimeout)
+	defer cancel()
+
+	resp, err := h.WalletKit.ImportTapscript(ctxt, req)
+	h.NoError(err, "ImportTapscript")
+
+	return resp
+}

--- a/lntemp/rpc/wallet_kit.go
+++ b/lntemp/rpc/wallet_kit.go
@@ -163,3 +163,68 @@ func (h *HarnessRPC) PublishTransaction(
 
 	return resp
 }
+
+// BumpFee makes a RPC call to the node's WalletKitClient and asserts.
+func (h *HarnessRPC) BumpFee(
+	req *walletrpc.BumpFeeRequest) *walletrpc.BumpFeeResponse {
+
+	ctxt, cancel := context.WithTimeout(h.runCtx, DefaultTimeout)
+	defer cancel()
+
+	resp, err := h.WalletKit.BumpFee(ctxt, req)
+	h.NoError(err, "BumpFee")
+
+	return resp
+}
+
+// ListAccounts makes a RPC call to the node's WalletKitClient and asserts.
+func (h *HarnessRPC) ListAccounts(
+	req *walletrpc.ListAccountsRequest) *walletrpc.ListAccountsResponse {
+
+	ctxt, cancel := context.WithTimeout(h.runCtx, DefaultTimeout)
+	defer cancel()
+
+	resp, err := h.WalletKit.ListAccounts(ctxt, req)
+	h.NoError(err, "ListAccounts")
+
+	return resp
+}
+
+// ImportAccount makes a RPC call to the node's WalletKitClient and asserts.
+func (h *HarnessRPC) ImportAccount(
+	req *walletrpc.ImportAccountRequest) *walletrpc.ImportAccountResponse {
+
+	ctxt, cancel := context.WithTimeout(h.runCtx, DefaultTimeout)
+	defer cancel()
+
+	resp, err := h.WalletKit.ImportAccount(ctxt, req)
+	require.NoErrorf(h, err, "failed to import account")
+
+	return resp
+}
+
+// ImportPublicKey makes a RPC call to the node's WalletKitClient and asserts.
+func (h *HarnessRPC) ImportPublicKey(
+	req *walletrpc.ImportPublicKeyRequest) *walletrpc.ImportPublicKeyResponse {
+
+	ctxt, cancel := context.WithTimeout(h.runCtx, DefaultTimeout)
+	defer cancel()
+
+	resp, err := h.WalletKit.ImportPublicKey(ctxt, req)
+	h.NoError(err, "ImportPublicKey")
+
+	return resp
+}
+
+// SignPsbt makes a RPC call to the node's WalletKitClient and asserts.
+func (h *HarnessRPC) SignPsbt(
+	req *walletrpc.SignPsbtRequest) *walletrpc.SignPsbtResponse {
+
+	ctxt, cancel := context.WithTimeout(h.runCtx, DefaultTimeout)
+	defer cancel()
+
+	resp, err := h.WalletKit.SignPsbt(ctxt, req)
+	h.NoError(err, "SignPsbt")
+
+	return resp
+}

--- a/lntest/itest/assertions.go
+++ b/lntest/itest/assertions.go
@@ -949,60 +949,6 @@ func assertNumPendingChannels(t *harnessTest, node *lntest.HarnessNode,
 	require.NoErrorf(t.t, err, "got err: %v", predErr)
 }
 
-// verifyCloseUpdate is used to verify that a closed channel update is of the
-// expected type.
-func verifyCloseUpdate(chanUpdate *lnrpc.ChannelEventUpdate,
-	closeType lnrpc.ChannelCloseSummary_ClosureType,
-	closeInitiator lnrpc.Initiator) error {
-
-	// We should receive one inactive and one closed notification
-	// for each channel.
-	switch update := chanUpdate.Channel.(type) {
-	case *lnrpc.ChannelEventUpdate_InactiveChannel:
-		if chanUpdate.Type != lnrpc.ChannelEventUpdate_INACTIVE_CHANNEL {
-			return fmt.Errorf("update type mismatch: expected %v, got %v",
-				lnrpc.ChannelEventUpdate_INACTIVE_CHANNEL,
-				chanUpdate.Type)
-		}
-
-	case *lnrpc.ChannelEventUpdate_ClosedChannel:
-		if chanUpdate.Type !=
-			lnrpc.ChannelEventUpdate_CLOSED_CHANNEL {
-
-			return fmt.Errorf("update type mismatch: expected %v, got %v",
-				lnrpc.ChannelEventUpdate_CLOSED_CHANNEL,
-				chanUpdate.Type)
-		}
-
-		if update.ClosedChannel.CloseType != closeType {
-			return fmt.Errorf("channel closure type "+
-				"mismatch: expected %v, got %v",
-				closeType,
-				update.ClosedChannel.CloseType)
-		}
-
-		if update.ClosedChannel.CloseInitiator != closeInitiator {
-			return fmt.Errorf("expected close intiator: %v, got: %v",
-				closeInitiator,
-				update.ClosedChannel.CloseInitiator)
-		}
-
-	case *lnrpc.ChannelEventUpdate_FullyResolvedChannel:
-		if chanUpdate.Type != lnrpc.ChannelEventUpdate_FULLY_RESOLVED_CHANNEL {
-			return fmt.Errorf("update type mismatch: expected %v, got %v",
-				lnrpc.ChannelEventUpdate_FULLY_RESOLVED_CHANNEL,
-				chanUpdate.Type)
-		}
-
-	default:
-		return fmt.Errorf("channel update channel of wrong type, "+
-			"expected closed channel, got %T",
-			update)
-	}
-
-	return nil
-}
-
 // assertNodeNumChannels polls the provided node's list channels rpc until it
 // reaches the desired number of total channels.
 func assertNodeNumChannels(t *harnessTest, node *lntest.HarnessNode,

--- a/lntest/itest/list_on_test.go
+++ b/lntest/itest/list_on_test.go
@@ -389,4 +389,8 @@ var allTestCasesTemp = []*lntemp.TestCase{
 		Name:     "sendtoroute multi path payment",
 		TestFunc: testSendToRouteMultiPath,
 	},
+	{
+		Name:     "send multi path payment",
+		TestFunc: testSendMultiPathPayment,
+	},
 }

--- a/lntest/itest/list_on_test.go
+++ b/lntest/itest/list_on_test.go
@@ -493,4 +493,8 @@ var allTestCasesTemp = []*lntemp.TestCase{
 		Name:     "trackpayments",
 		TestFunc: testTrackPayments,
 	},
+	{
+		Name:     "open channel fee policy",
+		TestFunc: testOpenChannelUpdateFeePolicy,
+	},
 }

--- a/lntest/itest/list_on_test.go
+++ b/lntest/itest/list_on_test.go
@@ -288,6 +288,10 @@ var allTestCasesTemp = []*lntemp.TestCase{
 		TestFunc: testPsbtChanFundingSingleStep,
 	},
 	{
+		Name:     "sign psbt",
+		TestFunc: testSignPsbt,
+	},
+	{
 		Name:     "resolution handoff",
 		TestFunc: testResHandoff,
 	},

--- a/lntest/itest/list_on_test.go
+++ b/lntest/itest/list_on_test.go
@@ -469,4 +469,12 @@ var allTestCasesTemp = []*lntemp.TestCase{
 		Name:     "taproot",
 		TestFunc: testTaproot,
 	},
+	{
+		Name:     "wallet import account",
+		TestFunc: testWalletImportAccount,
+	},
+	{
+		Name:     "wallet import pubkey",
+		TestFunc: testWalletImportPubKey,
+	},
 }

--- a/lntest/itest/list_on_test.go
+++ b/lntest/itest/list_on_test.go
@@ -385,4 +385,8 @@ var allTestCasesTemp = []*lntemp.TestCase{
 		Name:     "switch offline delivery outgoing offline",
 		TestFunc: testSwitchOfflineDeliveryOutgoingOffline,
 	},
+	{
+		Name:     "sendtoroute multi path payment",
+		TestFunc: testSendToRouteMultiPath,
+	},
 }

--- a/lntest/itest/list_on_test.go
+++ b/lntest/itest/list_on_test.go
@@ -489,4 +489,8 @@ var allTestCasesTemp = []*lntemp.TestCase{
 		Name:     "taproot coop close",
 		TestFunc: testTaprootCoopClose,
 	},
+	{
+		Name:     "trackpayments",
+		TestFunc: testTrackPayments,
+	},
 }

--- a/lntest/itest/list_on_test.go
+++ b/lntest/itest/list_on_test.go
@@ -401,4 +401,8 @@ var allTestCasesTemp = []*lntemp.TestCase{
 		Name:     "sendpayment amp invoice repeat",
 		TestFunc: testSendPaymentAMPInvoiceRepeat,
 	},
+	{
+		Name:     "send payment amp",
+		TestFunc: testSendPaymentAMP,
+	},
 }

--- a/lntest/itest/list_on_test.go
+++ b/lntest/itest/list_on_test.go
@@ -381,4 +381,8 @@ var allTestCasesTemp = []*lntemp.TestCase{
 		Name:     "switch offline delivery persistence",
 		TestFunc: testSwitchOfflineDeliveryPersistence,
 	},
+	{
+		Name:     "switch offline delivery outgoing offline",
+		TestFunc: testSwitchOfflineDeliveryOutgoingOffline,
+	},
 }

--- a/lntest/itest/list_on_test.go
+++ b/lntest/itest/list_on_test.go
@@ -373,4 +373,8 @@ var allTestCasesTemp = []*lntemp.TestCase{
 		Name:     "switch circuit persistence",
 		TestFunc: testSwitchCircuitPersistence,
 	},
+	{
+		Name:     "switch offline delivery",
+		TestFunc: testSwitchOfflineDelivery,
+	},
 }

--- a/lntest/itest/list_on_test.go
+++ b/lntest/itest/list_on_test.go
@@ -485,4 +485,8 @@ var allTestCasesTemp = []*lntemp.TestCase{
 		Name:     "remote signer",
 		TestFunc: testRemoteSigner,
 	},
+	{
+		Name:     "taproot coop close",
+		TestFunc: testTaprootCoopClose,
+	},
 }

--- a/lntest/itest/list_on_test.go
+++ b/lntest/itest/list_on_test.go
@@ -465,4 +465,8 @@ var allTestCasesTemp = []*lntemp.TestCase{
 		Name:     "cpfp",
 		TestFunc: testCPFP,
 	},
+	{
+		Name:     "taproot",
+		TestFunc: testTaproot,
+	},
 }

--- a/lntest/itest/list_on_test.go
+++ b/lntest/itest/list_on_test.go
@@ -369,4 +369,8 @@ var allTestCasesTemp = []*lntemp.TestCase{
 		Name:     "wipe forwarding packages",
 		TestFunc: testWipeForwardingPackages,
 	},
+	{
+		Name:     "switch circuit persistence",
+		TestFunc: testSwitchCircuitPersistence,
+	},
 }

--- a/lntest/itest/list_on_test.go
+++ b/lntest/itest/list_on_test.go
@@ -397,4 +397,8 @@ var allTestCasesTemp = []*lntemp.TestCase{
 		Name:     "sendpayment amp invoice",
 		TestFunc: testSendPaymentAMPInvoice,
 	},
+	{
+		Name:     "sendpayment amp invoice repeat",
+		TestFunc: testSendPaymentAMPInvoiceRepeat,
+	},
 }

--- a/lntest/itest/list_on_test.go
+++ b/lntest/itest/list_on_test.go
@@ -425,4 +425,8 @@ var allTestCasesTemp = []*lntemp.TestCase{
 		Name:     "option scid alias",
 		TestFunc: testOptionScidAlias,
 	},
+	{
+		Name:     "scid alias channel update",
+		TestFunc: testUpdateChannelPolicyScidAlias,
+	},
 }

--- a/lntest/itest/list_on_test.go
+++ b/lntest/itest/list_on_test.go
@@ -481,4 +481,8 @@ var allTestCasesTemp = []*lntemp.TestCase{
 		Name:     "async payments benchmark",
 		TestFunc: testAsyncPayments,
 	},
+	{
+		Name:     "remote signer",
+		TestFunc: testRemoteSigner,
+	},
 }

--- a/lntest/itest/list_on_test.go
+++ b/lntest/itest/list_on_test.go
@@ -477,4 +477,8 @@ var allTestCasesTemp = []*lntemp.TestCase{
 		Name:     "wallet import pubkey",
 		TestFunc: testWalletImportPubKey,
 	},
+	{
+		Name:     "async payments benchmark",
+		TestFunc: testAsyncPayments,
+	},
 }

--- a/lntest/itest/list_on_test.go
+++ b/lntest/itest/list_on_test.go
@@ -405,4 +405,8 @@ var allTestCasesTemp = []*lntemp.TestCase{
 		Name:     "send payment amp",
 		TestFunc: testSendPaymentAMP,
 	},
+	{
+		Name:     "sendtoroute amp",
+		TestFunc: testSendToRouteAMP,
+	},
 }

--- a/lntest/itest/list_on_test.go
+++ b/lntest/itest/list_on_test.go
@@ -445,4 +445,8 @@ var allTestCasesTemp = []*lntemp.TestCase{
 		Name:     "derive shared key",
 		TestFunc: testDeriveSharedKey,
 	},
+	{
+		Name:     "sign output raw",
+		TestFunc: testSignOutputRaw,
+	},
 }

--- a/lntest/itest/list_on_test.go
+++ b/lntest/itest/list_on_test.go
@@ -276,6 +276,10 @@ var allTestCasesTemp = []*lntemp.TestCase{
 		TestFunc: testOpenChannelAfterReorg,
 	},
 	{
+		Name:     "psbt channel funding",
+		TestFunc: testPsbtChanFunding,
+	},
+	{
 		Name:     "psbt channel funding external",
 		TestFunc: testPsbtChanFundingExternal,
 	},

--- a/lntest/itest/list_on_test.go
+++ b/lntest/itest/list_on_test.go
@@ -497,4 +497,8 @@ var allTestCasesTemp = []*lntemp.TestCase{
 		Name:     "open channel fee policy",
 		TestFunc: testOpenChannelUpdateFeePolicy,
 	},
+	{
+		Name:     "custom message",
+		TestFunc: testCustomMessage,
+	},
 }

--- a/lntest/itest/list_on_test.go
+++ b/lntest/itest/list_on_test.go
@@ -453,4 +453,8 @@ var allTestCasesTemp = []*lntemp.TestCase{
 		Name:     "sign verify message",
 		TestFunc: testSignVerifyMessage,
 	},
+	{
+		Name:     "cpfp",
+		TestFunc: testCPFP,
+	},
 }

--- a/lntest/itest/list_on_test.go
+++ b/lntest/itest/list_on_test.go
@@ -417,4 +417,8 @@ var allTestCasesTemp = []*lntemp.TestCase{
 		Name:     "forward interceptor",
 		TestFunc: testForwardInterceptorBasic,
 	},
+	{
+		Name:     "zero conf channel open",
+		TestFunc: testZeroConfChannelOpen,
+	},
 }

--- a/lntest/itest/list_on_test.go
+++ b/lntest/itest/list_on_test.go
@@ -409,4 +409,8 @@ var allTestCasesTemp = []*lntemp.TestCase{
 		Name:     "sendtoroute amp",
 		TestFunc: testSendToRouteAMP,
 	},
+	{
+		Name:     "forward interceptor dedup htlcs",
+		TestFunc: testForwardInterceptorDedupHtlc,
+	},
 }

--- a/lntest/itest/list_on_test.go
+++ b/lntest/itest/list_on_test.go
@@ -377,4 +377,8 @@ var allTestCasesTemp = []*lntemp.TestCase{
 		Name:     "switch offline delivery",
 		TestFunc: testSwitchOfflineDelivery,
 	},
+	{
+		Name:     "switch offline delivery persistence",
+		TestFunc: testSwitchOfflineDeliveryPersistence,
+	},
 }

--- a/lntest/itest/list_on_test.go
+++ b/lntest/itest/list_on_test.go
@@ -449,4 +449,8 @@ var allTestCasesTemp = []*lntemp.TestCase{
 		Name:     "sign output raw",
 		TestFunc: testSignOutputRaw,
 	},
+	{
+		Name:     "sign verify message",
+		TestFunc: testSignVerifyMessage,
+	},
 }

--- a/lntest/itest/list_on_test.go
+++ b/lntest/itest/list_on_test.go
@@ -433,4 +433,8 @@ var allTestCasesTemp = []*lntemp.TestCase{
 		Name:     "scid alias upgrade",
 		TestFunc: testOptionScidUpgrade,
 	},
+	{
+		Name:     "nonstd sweep",
+		TestFunc: testNonstdSweep,
+	},
 }

--- a/lntest/itest/list_on_test.go
+++ b/lntest/itest/list_on_test.go
@@ -393,4 +393,8 @@ var allTestCasesTemp = []*lntemp.TestCase{
 		Name:     "send multi path payment",
 		TestFunc: testSendMultiPathPayment,
 	},
+	{
+		Name:     "sendpayment amp invoice",
+		TestFunc: testSendPaymentAMPInvoice,
+	},
 }

--- a/lntest/itest/list_on_test.go
+++ b/lntest/itest/list_on_test.go
@@ -413,4 +413,8 @@ var allTestCasesTemp = []*lntemp.TestCase{
 		Name:     "forward interceptor dedup htlcs",
 		TestFunc: testForwardInterceptorDedupHtlc,
 	},
+	{
+		Name:     "forward interceptor",
+		TestFunc: testForwardInterceptorBasic,
+	},
 }

--- a/lntest/itest/list_on_test.go
+++ b/lntest/itest/list_on_test.go
@@ -421,4 +421,8 @@ var allTestCasesTemp = []*lntemp.TestCase{
 		Name:     "zero conf channel open",
 		TestFunc: testZeroConfChannelOpen,
 	},
+	{
+		Name:     "option scid alias",
+		TestFunc: testOptionScidAlias,
+	},
 }

--- a/lntest/itest/list_on_test.go
+++ b/lntest/itest/list_on_test.go
@@ -441,4 +441,8 @@ var allTestCasesTemp = []*lntemp.TestCase{
 		Name:     "multiple channel creation and update subscription",
 		TestFunc: testBasicChannelCreationAndUpdates,
 	},
+	{
+		Name:     "derive shared key",
+		TestFunc: testDeriveSharedKey,
+	},
 }

--- a/lntest/itest/list_on_test.go
+++ b/lntest/itest/list_on_test.go
@@ -429,4 +429,8 @@ var allTestCasesTemp = []*lntemp.TestCase{
 		Name:     "scid alias channel update",
 		TestFunc: testUpdateChannelPolicyScidAlias,
 	},
+	{
+		Name:     "scid alias upgrade",
+		TestFunc: testOptionScidUpgrade,
+	},
 }

--- a/lntest/itest/list_on_test.go
+++ b/lntest/itest/list_on_test.go
@@ -437,4 +437,8 @@ var allTestCasesTemp = []*lntemp.TestCase{
 		Name:     "nonstd sweep",
 		TestFunc: testNonstdSweep,
 	},
+	{
+		Name:     "multiple channel creation and update subscription",
+		TestFunc: testBasicChannelCreationAndUpdates,
+	},
 }

--- a/lntest/itest/lnd_amp_test.go
+++ b/lntest/itest/lnd_amp_test.go
@@ -80,7 +80,7 @@ func testSendPaymentAMPInvoiceCase(ht *lntemp.HarnessTest,
 	// Ensure we get a notification of the invoice being added by Bob.
 	rpcInvoice := ht.ReceiveInvoiceUpdate(bobInvoiceSubscription)
 
-	require.False(ht, rpcInvoice.Settled) // nolint:staticcheck
+	require.False(ht, rpcInvoice.Settled)
 	require.Equal(ht, lnrpc.Invoice_OPEN, rpcInvoice.State)
 	require.Equal(ht, int64(0), rpcInvoice.AmtPaidSat)
 	require.Equal(ht, int64(0), rpcInvoice.AmtPaidMsat)
@@ -156,7 +156,7 @@ func testSendPaymentAMPInvoiceCase(ht *lntemp.HarnessTest,
 
 	// Assert that the invoice is settled for the total payment amount and
 	// has the correct payment address.
-	require.True(ht, rpcInvoice.Settled) // nolint:staticcheck
+	require.True(ht, rpcInvoice.Settled)
 	require.Equal(ht, lnrpc.Invoice_SETTLED, rpcInvoice.State)
 	require.Equal(ht, int64(paymentAmt), rpcInvoice.AmtPaidSat)
 	require.Equal(ht, int64(paymentAmt*1000), rpcInvoice.AmtPaidMsat)
@@ -232,7 +232,7 @@ func testSendPaymentAMPInvoiceRepeat(ht *lntemp.HarnessTest) {
 
 	// We should get an initial notification that the HTLC has been added.
 	rpcInvoice := ht.ReceiveInvoiceUpdate(invSubscription)
-	require.False(ht, rpcInvoice.Settled) // nolint:staticcheck
+	require.False(ht, rpcInvoice.Settled)
 	require.Equal(ht, lnrpc.Invoice_OPEN, rpcInvoice.State)
 	require.Equal(ht, int64(0), rpcInvoice.AmtPaidSat)
 	require.Equal(ht, int64(0), rpcInvoice.AmtPaidMsat)
@@ -248,7 +248,7 @@ func testSendPaymentAMPInvoiceRepeat(ht *lntemp.HarnessTest) {
 
 	// The notification should signal that the invoice is now settled, and
 	// should also include the set ID, and show the proper amount paid.
-	require.True(ht, invoiceNtfn.Settled) // nolint:staticcheck
+	require.True(ht, invoiceNtfn.Settled)
 	require.Equal(ht, lnrpc.Invoice_SETTLED, invoiceNtfn.State)
 	require.Equal(ht, paymentAmt, int(invoiceNtfn.AmtPaidSat))
 	require.Equal(ht, 1, len(invoiceNtfn.AmpInvoiceState))
@@ -271,7 +271,7 @@ func testSendPaymentAMPInvoiceRepeat(ht *lntemp.HarnessTest) {
 	// The invoice should still be shown as settled, and also include the
 	// information about this newly generated setID, showing 2x the amount
 	// paid.
-	require.True(ht, invoiceNtfn.Settled) // nolint:staticcheck
+	require.True(ht, invoiceNtfn.Settled)
 	require.Equal(ht, paymentAmt*2, int(invoiceNtfn.AmtPaidSat))
 
 	var secondSetID []byte
@@ -347,7 +347,7 @@ func testSendPaymentAMPInvoiceRepeat(ht *lntemp.HarnessTest) {
 	backlogInv := ht.ReceiveInvoiceUpdate(invSub2)
 	require.Equal(ht, 1, len(backlogInv.Htlcs))
 	require.Equal(ht, 2, len(backlogInv.AmpInvoiceState))
-	require.True(ht, backlogInv.Settled) // nolint:staticcheck
+	require.True(ht, backlogInv.Settled)
 	require.Equal(ht, paymentAmt*2, int(backlogInv.AmtPaidSat))
 }
 
@@ -422,7 +422,7 @@ func testSendPaymentAMP(ht *lntemp.HarnessTest) {
 
 	// Assert that the invoice is settled for the total payment amount and
 	// has the correct payment address.
-	require.True(ht, rpcInvoice.Settled) // nolint:staticcheck
+	require.True(ht, rpcInvoice.Settled)
 	require.Equal(ht, lnrpc.Invoice_SETTLED, rpcInvoice.State)
 	require.Equal(ht, int64(paymentAmt), rpcInvoice.AmtPaidSat)
 	require.Equal(ht, int64(paymentAmt*1000), rpcInvoice.AmtPaidMsat)
@@ -561,7 +561,7 @@ func testSendToRouteAMP(ht *lntemp.HarnessTest) {
 	rpcInvoice, err := bobInvoiceSubscription.Recv()
 	require.NoError(ht, err)
 
-	require.False(ht, rpcInvoice.Settled) // nolint:staticcheck
+	require.False(ht, rpcInvoice.Settled)
 	require.Equal(ht, lnrpc.Invoice_OPEN, rpcInvoice.State)
 	require.Equal(ht, int64(0), rpcInvoice.AmtPaidSat)
 	require.Equal(ht, int64(0), rpcInvoice.AmtPaidMsat)
@@ -619,7 +619,7 @@ func testSendToRouteAMP(ht *lntemp.HarnessTest) {
 
 	// Assert that the invoice is settled for the total payment amount and
 	// has the correct payment address.
-	require.True(ht, rpcInvoice.Settled) // nolint:staticcheck
+	require.True(ht, rpcInvoice.Settled)
 	require.Equal(ht, lnrpc.Invoice_SETTLED, rpcInvoice.State)
 	require.Equal(ht, int64(paymentAmt), rpcInvoice.AmtPaidSat)
 	require.Equal(ht, int64(paymentAmt*1000), rpcInvoice.AmtPaidMsat)

--- a/lntest/itest/lnd_custom_message.go
+++ b/lntest/itest/lnd_custom_message.go
@@ -1,13 +1,11 @@
 package itest
 
 import (
-	"context"
 	"fmt"
-	"sync"
 	"time"
 
 	"github.com/lightningnetwork/lnd/lnrpc"
-	"github.com/lightningnetwork/lnd/lntest"
+	"github.com/lightningnetwork/lnd/lntemp"
 	"github.com/lightningnetwork/lnd/lnwire"
 	"github.com/stretchr/testify/require"
 )
@@ -15,16 +13,8 @@ import (
 // testCustomMessage tests sending and receiving of overridden custom message
 // types (within the message type range usually reserved for protocol messages)
 // via the send and subscribe custom message APIs.
-func testCustomMessage(net *lntest.NetworkHarness, t *harnessTest) {
-	ctx, cancel := context.WithCancel(context.Background())
-	var wg sync.WaitGroup
-
-	// At the end of our test, cancel our context and wait for all
-	// goroutines to exit.
-	defer func() {
-		cancel()
-		wg.Wait()
-	}()
+func testCustomMessage(ht *lntemp.HarnessTest) {
+	alice, bob := ht.Alice, ht.Bob
 
 	var (
 		overrideType1  uint32 = 554
@@ -34,28 +24,19 @@ func testCustomMessage(net *lntest.NetworkHarness, t *harnessTest) {
 
 	// Update Alice to accept custom protocol messages with type 1 but do
 	// not allow Bob to handle them yet.
-	net.Alice.Cfg.ExtraArgs = append(
-		net.Alice.Cfg.ExtraArgs,
+	extraArgs := []string{
 		fmt.Sprintf(msgOverrideArg, overrideType1),
-	)
-	require.NoError(t.t, net.RestartNode(net.Alice, nil, nil))
-
-	// Wait for Alice's server to be active after the restart before we
-	// try to subscribe to our message stream.
-	require.NoError(t.t, net.Alice.WaitUntilServerActive())
+	}
+	ht.RestartNodeWithExtraArgs(alice, extraArgs)
 
 	// Subscribe Alice to custom messages before we send any, so that we
 	// don't miss any.
-	msgClient, err := net.Alice.LightningClient.SubscribeCustomMessages(
-		ctx, &lnrpc.SubscribeCustomMessagesRequest{},
-	)
-	require.NoError(t.t, err, "alice could not subscribe")
+	msgClient, cancel := alice.RPC.SubscribeCustomMessages()
+	defer cancel()
 
 	// Create a channel to receive custom messages on.
 	messages := make(chan *lnrpc.CustomMessage)
-	wg.Add(1)
 	go func() {
-		defer wg.Done()
 		for {
 			// If we fail to receive, just exit. The test should
 			// fail elsewhere if it doesn't get a message that it
@@ -69,120 +50,108 @@ func testCustomMessage(net *lntest.NetworkHarness, t *harnessTest) {
 			// test is shutting down.
 			select {
 			case messages <- msg:
-			case <-ctx.Done():
+			case <-ht.Context().Done():
 				return
 			}
 		}
 	}()
 
 	// Connect alice and bob so that they can exchange messages.
-	net.EnsureConnected(t.t, net.Alice, net.Bob)
+	ht.EnsureConnected(alice, bob)
 
 	// Create a custom message that is within our allowed range.
 	msgType := uint32(lnwire.CustomTypeStart + 1)
 	msgData := []byte{1, 2, 3}
 
 	// Send it from Bob to Alice.
-	ctxt, _ := context.WithTimeout(ctx, defaultTimeout)
-	_, err = net.Bob.LightningClient.SendCustomMessage(
-		ctxt, &lnrpc.SendCustomMessageRequest{
-			Peer: net.Alice.PubKey[:],
-			Type: msgType,
-			Data: msgData,
-		},
-	)
-	require.NoError(t.t, err, "bob could not send")
+	bobMsg := &lnrpc.SendCustomMessageRequest{
+		Peer: alice.PubKey[:],
+		Type: msgType,
+		Data: msgData,
+	}
+	bob.RPC.SendCustomMessage(bobMsg)
 
-	// Wait for Alice to receive the message. It should come through because
-	// it is within our allowed range.
+	// Wait for Alice to receive the message. It should come through
+	// because it is within our allowed range.
 	select {
 	case msg := <-messages:
-		// Check our type and data and (sanity) check the peer we got it
-		// from.
-		require.Equal(t.t, msgType, msg.Type, "first msg type wrong")
-		require.Equal(t.t, msgData, msg.Data, "first msg data wrong")
-		require.Equal(t.t, net.Bob.PubKey[:], msg.Peer, "first msg "+
+		// Check our type and data and (sanity) check the peer we got
+		// it from.
+		require.Equal(ht, msgType, msg.Type, "first msg type wrong")
+		require.Equal(ht, msgData, msg.Data, "first msg data wrong")
+		require.Equal(ht, bob.PubKey[:], msg.Peer, "first msg "+
 			"peer wrong")
 
 	case <-time.After(defaultTimeout):
-		t.t.Fatalf("alice did not receive first custom message: %v",
+		ht.Fatalf("alice did not receive first custom message: %v",
 			msgType)
 	}
 
 	// Try to send a message from Bob to Alice which has a message type
 	// outside of the custom type range and assert that it fails.
-	ctxt, _ = context.WithTimeout(ctx, defaultTimeout)
-	_, err = net.Bob.LightningClient.SendCustomMessage(
-		ctxt, &lnrpc.SendCustomMessageRequest{
-			Peer: net.Alice.PubKey[:],
-			Type: overrideType1,
-			Data: msgData,
-		},
-	)
-	require.Error(t.t, err, "bob should not be able to send type 1")
+	bobMsg = &lnrpc.SendCustomMessageRequest{
+		Peer: alice.PubKey[:],
+		Type: overrideType1,
+		Data: msgData,
+	}
+	_, err := bob.RPC.LN.SendCustomMessage(ht.Context(), bobMsg)
+	require.Error(ht, err, "bob should not be able to send type 1")
 
 	// Now, restart Bob with the ability to send two different custom
 	// protocol messages.
-	net.Bob.Cfg.ExtraArgs = append(
-		net.Bob.Cfg.ExtraArgs,
+	extraArgs = []string{
 		fmt.Sprintf(msgOverrideArg, overrideType1),
 		fmt.Sprintf(msgOverrideArg, overrideType2),
-	)
-	require.NoError(t.t, net.RestartNode(net.Bob, nil, nil))
+	}
+	ht.RestartNodeWithExtraArgs(bob, extraArgs)
 
 	// Make sure Bob and Alice are connected after his restart.
-	net.EnsureConnected(t.t, net.Alice, net.Bob)
+	ht.EnsureConnected(alice, bob)
 
 	// Send a message from Bob to Alice with a type that Bob is allowed to
 	// send, but Alice will not handle as a custom message.
-	ctxt, _ = context.WithTimeout(ctx, defaultTimeout)
-	_, err = net.Bob.LightningClient.SendCustomMessage(
-		ctxt, &lnrpc.SendCustomMessageRequest{
-			Peer: net.Alice.PubKey[:],
-			Type: overrideType2,
-			Data: msgData,
-		},
-	)
-	require.NoError(t.t, err, "bob should be able to send type 2")
+	bobMsg = &lnrpc.SendCustomMessageRequest{
+		Peer: alice.PubKey[:],
+		Type: overrideType2,
+		Data: msgData,
+	}
+	bob.RPC.SendCustomMessage(bobMsg)
 
 	// Do a quick check that Alice did not receive this message in her
-	// stream. Note that this is an instant check, so could miss the message
-	// being received. We'll also check below that she didn't get it, this
-	// is just a sanity check.
+	// stream. Note that this is an instant check, so could miss the
+	// message being received. We'll also check below that she didn't get
+	// it, this is just a sanity check.
 	select {
 	case msg := <-messages:
-		t.t.Fatalf("unexpected message: %v", msg)
+		ht.Fatalf("unexpected message: %v", msg)
 	default:
 	}
 
 	// Finally, send a custom message with a type that Bob is allowed to
 	// send and Alice is configured to receive.
-	ctxt, _ = context.WithTimeout(ctx, defaultTimeout)
-	_, err = net.Bob.LightningClient.SendCustomMessage(
-		ctxt, &lnrpc.SendCustomMessageRequest{
-			Peer: net.Alice.PubKey[:],
-			Type: overrideType1,
-			Data: msgData,
-		},
-	)
-	require.NoError(t.t, err, "bob should be able to send type 1")
+	bobMsg = &lnrpc.SendCustomMessageRequest{
+		Peer: alice.PubKey[:],
+		Type: overrideType1,
+		Data: msgData,
+	}
+	bob.RPC.SendCustomMessage(bobMsg)
 
 	// Wait to receive a message from Bob. This check serves to ensure that
 	// our message type 1 was delivered, and assert that the preceding one
-	// was not (we could have missed it in our check above). When we receive
-	// the second message, we know that the first one did not go through,
-	// because we expect our messages to deliver in order.
+	// was not (we could have missed it in our check above). When we
+	// receive the second message, we know that the first one did not go
+	// through, because we expect our messages to deliver in order.
 	select {
 	case msg := <-messages:
-		// Check our type and data and (sanity) check the peer we got it
-		// from.
-		require.Equal(t.t, overrideType1, msg.Type, "second message "+
+		// Check our type and data and (sanity) check the peer we got
+		// it from.
+		require.Equal(ht, overrideType1, msg.Type, "second message "+
 			"type")
-		require.Equal(t.t, msgData, msg.Data, "second message data")
-		require.Equal(t.t, net.Bob.PubKey[:], msg.Peer, "second "+
+		require.Equal(ht, msgData, msg.Data, "second message data")
+		require.Equal(ht, bob.PubKey[:], msg.Peer, "second "+
 			"message peer")
 
 	case <-time.After(defaultTimeout):
-		t.t.Fatalf("alice did not receive second custom message")
+		ht.Fatalf("alice did not receive second custom message")
 	}
 }

--- a/lntest/itest/lnd_forward_interceptor_test.go
+++ b/lntest/itest/lnd_forward_interceptor_test.go
@@ -363,6 +363,7 @@ func newInterceptorTestScenario(
 
 	ht.EnsureConnected(alice, bob)
 	ht.EnsureConnected(bob, carol)
+
 	return &interceptorTestScenario{
 		ht:    ht,
 		alice: alice,
@@ -377,22 +378,28 @@ func newInterceptorTestScenario(
 // 3. settling htlc externally.
 // 4. held htlc that is resumed later.
 func (c *interceptorTestScenario) prepareTestCases() []*interceptorTestCase {
+	var (
+		actionFail   = routerrpc.ResolveHoldForwardAction_FAIL
+		actionResume = routerrpc.ResolveHoldForwardAction_RESUME
+		actionSettle = routerrpc.ResolveHoldForwardAction_SETTLE
+	)
+
 	cases := []*interceptorTestCase{
 		{
 			amountMsat: 1000, shouldHold: false,
-			interceptorAction: routerrpc.ResolveHoldForwardAction_FAIL,
+			interceptorAction: actionFail,
 		},
 		{
 			amountMsat: 1000, shouldHold: false,
-			interceptorAction: routerrpc.ResolveHoldForwardAction_RESUME,
+			interceptorAction: actionResume,
 		},
 		{
 			amountMsat: 1000, shouldHold: false,
-			interceptorAction: routerrpc.ResolveHoldForwardAction_SETTLE,
+			interceptorAction: actionSettle,
 		},
 		{
 			amountMsat: 1000, shouldHold: true,
-			interceptorAction: routerrpc.ResolveHoldForwardAction_RESUME,
+			interceptorAction: actionResume,
 		},
 	}
 
@@ -432,6 +439,7 @@ func (c *interceptorTestScenario) sendPaymentAndAssertAction(
 		PaymentHash: tc.invoice.RHash,
 		Route:       route,
 	}
+
 	return c.alice.RPC.SendToRouteV2(sendReq)
 }
 
@@ -483,5 +491,6 @@ func (c *interceptorTestScenario) buildRoute(amtMsat int64,
 	}
 
 	routeResp := c.alice.RPC.BuildRoute(req)
+
 	return routeResp.Route
 }

--- a/lntest/itest/lnd_mpp_test.go
+++ b/lntest/itest/lnd_mpp_test.go
@@ -488,7 +488,8 @@ func (m *mppTestScenario) buildRoute(amt btcutil.Amount,
 }
 
 // updatePolicy updates a Dave's global channel policy and returns the expected
-// policy for further check.
+// policy for further check. It changes Dave's `FeeBaseMsat` from 1000 msat to
+// 500,000 msat, and `FeeProportionalMillonths` from 1 msat to 1000 msat.
 func (m *mppTestScenario) updateDaveGlobalPolicy() *lnrpc.RoutingPolicy {
 	const (
 		baseFeeMsat = 500_000

--- a/lntest/itest/lnd_mpp_test.go
+++ b/lntest/itest/lnd_mpp_test.go
@@ -1,7 +1,6 @@
 package itest
 
 import (
-	"bytes"
 	"context"
 	"fmt"
 	"time"
@@ -11,17 +10,18 @@ import (
 	"github.com/lightningnetwork/lnd/chainreg"
 	"github.com/lightningnetwork/lnd/lnrpc"
 	"github.com/lightningnetwork/lnd/lnrpc/routerrpc"
+	"github.com/lightningnetwork/lnd/lntemp"
+	"github.com/lightningnetwork/lnd/lntemp/node"
 	"github.com/lightningnetwork/lnd/lntest"
+	"github.com/lightningnetwork/lnd/lntypes"
 	"github.com/lightningnetwork/lnd/routing/route"
+	"github.com/stretchr/testify/require"
 )
 
 // testSendToRouteMultiPath tests that we are able to successfully route a
 // payment using multiple shards across different paths, by using SendToRoute.
-func testSendToRouteMultiPath(net *lntest.NetworkHarness, t *harnessTest) {
-	ctxb := context.Background()
-
-	ctx := newMppTestContext(t, net)
-	defer ctx.shutdownNodes()
+func testSendToRouteMultiPath(ht *lntemp.HarnessTest) {
+	mts := newMppTestScenario(ht)
 
 	// To ensure the payment goes through separate paths, we'll set a
 	// channel size that can only carry one shard at a time. We'll divide
@@ -39,55 +39,41 @@ func testSendToRouteMultiPath(net *lntest.NetworkHarness, t *harnessTest) {
 	//      \              /
 	//       \__ Dave ____/
 	//
-	ctx.openChannel(ctx.carol, ctx.bob, chanAmt)
-	ctx.openChannel(ctx.dave, ctx.bob, chanAmt)
-	ctx.openChannel(ctx.alice, ctx.dave, chanAmt)
-	ctx.openChannel(ctx.eve, ctx.bob, chanAmt)
-	ctx.openChannel(ctx.carol, ctx.eve, chanAmt)
-
-	// Since the channel Alice-> Carol will have to carry two
-	// shards, we make it larger.
-	ctx.openChannel(ctx.alice, ctx.carol, chanAmt+shardAmt)
-
-	defer ctx.closeChannels()
-
-	ctx.waitForChannels()
+	req := &mppOpenChannelRequest{
+		// Since the channel Alice-> Carol will have to carry two
+		// shards, we make it larger.
+		amtAliceCarol: chanAmt + shardAmt,
+		amtAliceDave:  chanAmt,
+		amtCarolBob:   chanAmt,
+		amtCarolEve:   chanAmt,
+		amtDaveBob:    chanAmt,
+		amtEveBob:     chanAmt,
+	}
+	mts.openChannels(req)
 
 	// Make Bob create an invoice for Alice to pay.
-	payReqs, rHashes, invoices, err := createPayReqs(
-		ctx.bob, paymentAmt, 1,
-	)
-	if err != nil {
-		t.Fatalf("unable to create pay reqs: %v", err)
-	}
+	payReqs, rHashes, invoices := ht.CreatePayReqs(mts.bob, paymentAmt, 1)
 
 	rHash := rHashes[0]
 	payReq := payReqs[0]
 
-	ctxt, _ := context.WithTimeout(ctxb, defaultTimeout)
-	decodeResp, err := ctx.bob.DecodePayReq(
-		ctxt, &lnrpc.PayReqString{PayReq: payReq},
-	)
-	if err != nil {
-		t.Fatalf("decode pay req: %v", err)
-	}
-
+	decodeResp := mts.bob.RPC.DecodePayReq(payReq)
 	payAddr := decodeResp.PaymentAddr
 
+	// Subscribe the invoice.
+	stream := mts.bob.RPC.SubscribeSingleInvoice(rHash)
+
 	// We'll send shards along three routes from Alice.
-	sendRoutes := [][]*lntest.HarnessNode{
-		{ctx.carol, ctx.bob},
-		{ctx.dave, ctx.bob},
-		{ctx.carol, ctx.eve, ctx.bob},
+	sendRoutes := [][]*node.HarnessNode{
+		{mts.carol, mts.bob},
+		{mts.dave, mts.bob},
+		{mts.carol, mts.eve, mts.bob},
 	}
 
 	responses := make(chan *lnrpc.HTLCAttempt, len(sendRoutes))
 	for _, hops := range sendRoutes {
 		// Build a route for the specified hops.
-		r, err := ctx.buildRoute(ctxb, shardAmt, ctx.alice, hops)
-		if err != nil {
-			t.Fatalf("unable to build route: %v", err)
-		}
+		r := mts.buildRoute(shardAmt, mts.alice, hops)
 
 		// Set the MPP records to indicate this is a payment shard.
 		hop := r.Hops[len(r.Hops)-1]
@@ -103,62 +89,44 @@ func testSendToRouteMultiPath(net *lntest.NetworkHarness, t *harnessTest) {
 			Route:       r,
 		}
 
-		// We'll send all shards in their own goroutine, since SendToRoute will
-		// block as long as the payment is in flight.
+		// We'll send all shards in their own goroutine, since
+		// SendToRoute will block as long as the payment is in flight.
 		go func() {
-			ctxt, _ := context.WithTimeout(ctxb, defaultTimeout)
-			resp, err := ctx.alice.RouterClient.SendToRouteV2(ctxt, sendReq)
-			if err != nil {
-				t.Fatalf("unable to send payment: %v", err)
-			}
-
+			resp := mts.alice.RPC.SendToRouteV2(sendReq)
 			responses <- resp
 		}()
 	}
 
 	// Wait for all responses to be back, and check that they all
 	// succeeded.
+	timer := time.After(defaultTimeout)
 	for range sendRoutes {
 		var resp *lnrpc.HTLCAttempt
 		select {
 		case resp = <-responses:
-		case <-time.After(defaultTimeout):
-			t.Fatalf("response not received")
+		case <-timer:
+			require.Fail(ht, "response not received")
 		}
 
-		if resp.Failure != nil {
-			t.Fatalf("received payment failure : %v", resp.Failure)
-		}
+		require.Nil(ht, resp.Failure, "received payment failure")
 
 		// All shards should come back with the preimage.
-		if !bytes.Equal(resp.Preimage, invoices[0].RPreimage) {
-			t.Fatalf("preimage doesn't match")
-		}
+		require.Equal(ht, resp.Preimage, invoices[0].RPreimage,
+			"preimage doesn't match")
 	}
 
 	// assertNumHtlcs is a helper that checks the node's latest payment,
 	// and asserts it was split into num shards.
-	assertNumHtlcs := func(node *lntest.HarnessNode, num int) {
-		req := &lnrpc.ListPaymentsRequest{
-			IncludeIncomplete: true,
-		}
-		ctxt, _ := context.WithTimeout(ctxb, defaultTimeout)
-		paymentsResp, err := node.ListPayments(ctxt, req)
-		if err != nil {
-			t.Fatalf("error when obtaining payments: %v",
-				err)
-		}
+	assertNumHtlcs := func(hn *node.HarnessNode, num int) {
+		var preimage lntypes.Preimage
+		copy(preimage[:], invoices[0].RPreimage)
 
-		payments := paymentsResp.Payments
-		if len(payments) == 0 {
-			t.Fatalf("no payments found")
-		}
+		payment := ht.AssertPaymentStatus(
+			hn, preimage, lnrpc.Payment_SUCCEEDED,
+		)
 
-		payment := payments[len(payments)-1]
 		htlcs := payment.Htlcs
-		if len(htlcs) == 0 {
-			t.Fatalf("no htlcs")
-		}
+		require.NotEmpty(ht, htlcs, "no htlcs")
 
 		succeeded := 0
 		for _, htlc := range htlcs {
@@ -166,78 +134,32 @@ func testSendToRouteMultiPath(net *lntest.NetworkHarness, t *harnessTest) {
 				succeeded++
 			}
 		}
-
-		if succeeded != num {
-			t.Fatalf("expected %v succussful HTLCs, got %v", num,
-				succeeded)
-		}
+		require.Equal(ht, num, succeeded, "HTLCs not matched")
 	}
 
 	// assertSettledInvoice checks that the invoice for the given payment
 	// hash is settled, and has been paid using num HTLCs.
-	assertSettledInvoice := func(node *lntest.HarnessNode, rhash []byte,
-		num int) {
+	assertSettledInvoice := func(rhash []byte, num int) {
+		var payHash lntypes.Hash
+		copy(payHash[:], rhash)
+		inv := ht.AssertInvoiceState(stream, lnrpc.Invoice_SETTLED)
 
-		found := false
-		offset := uint64(0)
-		for !found {
-			ctxt, _ := context.WithTimeout(ctxb, defaultTimeout)
-			invoicesResp, err := node.ListInvoices(
-				ctxt, &lnrpc.ListInvoiceRequest{
-					IndexOffset: offset,
-				},
-			)
-			if err != nil {
-				t.Fatalf("error when obtaining payments: %v",
-					err)
-			}
+		// Assert that the amount paid to the invoice is correct.
+		require.EqualValues(ht, paymentAmt, inv.AmtPaidSat,
+			"incorrect payment amt")
 
-			if len(invoicesResp.Invoices) == 0 {
-				break
-			}
-
-			for _, inv := range invoicesResp.Invoices {
-				if !bytes.Equal(inv.RHash, rhash) {
-					continue
-				}
-
-				// Assert that the amount paid to the invoice is
-				// correct.
-				if inv.AmtPaidSat != int64(paymentAmt) {
-					t.Fatalf("incorrect payment amt for "+
-						"invoicewant: %d, got %d",
-						paymentAmt, inv.AmtPaidSat)
-				}
-
-				if inv.State != lnrpc.Invoice_SETTLED {
-					t.Fatalf("Invoice not settled: %v",
-						inv.State)
-				}
-
-				if len(inv.Htlcs) != num {
-					t.Fatalf("expected invoice to be "+
-						"settled with %v HTLCs, had %v",
-						num, len(inv.Htlcs))
-				}
-
-				found = true
-				break
-			}
-
-			offset = invoicesResp.LastIndexOffset
-		}
-
-		if !found {
-			t.Fatalf("invoice not found")
-		}
+		require.Len(ht, inv.Htlcs, num, "wrong num of HTLCs")
 	}
 
 	// Finally check that the payment shows up with three settled HTLCs in
 	// Alice's list of payments...
-	assertNumHtlcs(ctx.alice, 3)
+	assertNumHtlcs(mts.alice, 3)
 
 	// ...and in Bob's list of paid invoices.
-	assertSettledInvoice(ctx.bob, rHash, 3)
+	assertSettledInvoice(rHash, 3)
+
+	// Finally, close all channels.
+	mts.closeChannels()
 }
 
 type mppTestContext struct {
@@ -370,4 +292,217 @@ func (c *mppTestContext) buildRoute(ctxb context.Context, amt btcutil.Amount,
 	}
 
 	return routeResp.Route, nil
+}
+
+// mppTestScenario defines a test scenario used for testing MPP-related tests.
+// It has two standby nodes, alice and bob, and three new nodes, carol, dave,
+// and eve.
+type mppTestScenario struct {
+	ht *lntemp.HarnessTest
+
+	alice, bob, carol, dave, eve *node.HarnessNode
+	nodes                        []*node.HarnessNode
+
+	// Keep a list of all our active channels.
+	channelPoints []*lnrpc.ChannelPoint
+}
+
+// newMppTestScenario initializes a new mpp test scenario with five funded
+// nodes and connects them to have the following topology,
+//
+//	            _ Eve _
+//	           /       \
+//	Alice -- Carol ---- Bob
+//	    \              /
+//	     \__ Dave ____/
+func newMppTestScenario(ht *lntemp.HarnessTest) *mppTestScenario {
+	alice, bob := ht.Alice, ht.Bob
+	ht.RestartNodeWithExtraArgs(bob, []string{
+		"--maxpendingchannels=2",
+		"--accept-amp",
+	})
+
+	// Create a five-node context consisting of Alice, Bob and three new
+	// nodes.
+	carol := ht.NewNode("carol", []string{"--maxpendingchannels=2"})
+	dave := ht.NewNode("dave", nil)
+	eve := ht.NewNode("eve", nil)
+
+	// Connect nodes to ensure propagation of channels.
+	ht.EnsureConnected(alice, carol)
+	ht.EnsureConnected(alice, dave)
+	ht.EnsureConnected(carol, bob)
+	ht.EnsureConnected(carol, eve)
+	ht.EnsureConnected(dave, bob)
+	ht.EnsureConnected(eve, bob)
+
+	// Send coins to the nodes and mine 1 blocks to confirm them.
+	for i := 0; i < 2; i++ {
+		ht.FundCoinsUnconfirmed(btcutil.SatoshiPerBitcoin, carol)
+		ht.FundCoinsUnconfirmed(btcutil.SatoshiPerBitcoin, dave)
+		ht.FundCoinsUnconfirmed(btcutil.SatoshiPerBitcoin, eve)
+		ht.MineBlocks(1)
+	}
+
+	mts := &mppTestScenario{
+		ht:    ht,
+		alice: alice,
+		bob:   bob,
+		carol: carol,
+		dave:  dave,
+		eve:   eve,
+		nodes: []*node.HarnessNode{alice, bob, carol, dave, eve},
+	}
+
+	return mts
+}
+
+// mppOpenChannelRequest defines the amounts used for each channel opening.
+type mppOpenChannelRequest struct {
+	// Channel Alice=>Carol.
+	amtAliceCarol btcutil.Amount
+
+	// Channel Alice=>Dave.
+	amtAliceDave btcutil.Amount
+
+	// Channel Carol=>Bob.
+	amtCarolBob btcutil.Amount
+
+	// Channel Carol=>Eve.
+	amtCarolEve btcutil.Amount
+
+	// Channel Dave=>Bob.
+	amtDaveBob btcutil.Amount
+
+	// Channel Eve=>Bob.
+	amtEveBob btcutil.Amount
+}
+
+// openChannels is a helper to open channels that sets up a network topology
+// with three different paths Alice <-> Bob as following,
+//
+//		 _ Eve _
+//		/       \
+//	 Alice -- Carol ---- Bob
+//		\              /
+//		 \__ Dave ____/
+//
+// NOTE: all the channels are open together to save blocks mined.
+func (m *mppTestScenario) openChannels(r *mppOpenChannelRequest) {
+	reqs := []*lntemp.OpenChannelRequest{
+		{
+			Local:  m.alice,
+			Remote: m.carol,
+			Param:  lntemp.OpenChannelParams{Amt: r.amtAliceCarol},
+		},
+		{
+			Local:  m.alice,
+			Remote: m.dave,
+			Param:  lntemp.OpenChannelParams{Amt: r.amtAliceDave},
+		},
+		{
+			Local:  m.carol,
+			Remote: m.bob,
+			Param:  lntemp.OpenChannelParams{Amt: r.amtCarolBob},
+		},
+		{
+			Local:  m.carol,
+			Remote: m.eve,
+			Param:  lntemp.OpenChannelParams{Amt: r.amtCarolEve},
+		},
+		{
+			Local:  m.dave,
+			Remote: m.bob,
+			Param:  lntemp.OpenChannelParams{Amt: r.amtDaveBob},
+		},
+		{
+			Local:  m.eve,
+			Remote: m.bob,
+			Param:  lntemp.OpenChannelParams{Amt: r.amtEveBob},
+		},
+	}
+
+	m.channelPoints = m.ht.OpenMultiChannelsAsync(reqs)
+
+	// Make sure every node has heard every channel.
+	for _, hn := range m.nodes {
+		for _, cp := range m.channelPoints {
+			m.ht.AssertTopologyChannelOpen(hn, cp)
+		}
+	}
+}
+
+// closeChannels closes all the open channels from `openChannels`.
+func (m *mppTestScenario) closeChannels() {
+	if m.ht.Failed() {
+		m.ht.Log("Skipped closing channels for failed test")
+		return
+	}
+
+	// Close all channels without mining the closing transactions.
+	m.ht.CloseChannelAssertPending(m.alice, m.channelPoints[0], false)
+	m.ht.CloseChannelAssertPending(m.alice, m.channelPoints[1], false)
+	m.ht.CloseChannelAssertPending(m.carol, m.channelPoints[2], false)
+	m.ht.CloseChannelAssertPending(m.carol, m.channelPoints[3], false)
+	m.ht.CloseChannelAssertPending(m.dave, m.channelPoints[4], false)
+	m.ht.CloseChannelAssertPending(m.eve, m.channelPoints[5], false)
+
+	// Now mine a block to include all the closing transactions.
+	m.ht.MineBlocks(1)
+
+	// Assert that the channels are closed.
+	for _, hn := range m.nodes {
+		m.ht.AssertNumWaitingClose(hn, 0)
+	}
+}
+
+// Helper function for Alice to build a route from pubkeys.
+func (m *mppTestScenario) buildRoute(amt btcutil.Amount,
+	sender *node.HarnessNode, hops []*node.HarnessNode) *lnrpc.Route {
+
+	rpcHops := make([][]byte, 0, len(hops))
+	for _, hop := range hops {
+		k := hop.PubKeyStr
+		pubkey, err := route.NewVertexFromStr(k)
+		require.NoErrorf(m.ht, err, "error parsing %v: %v", k, err)
+		rpcHops = append(rpcHops, pubkey[:])
+	}
+
+	req := &routerrpc.BuildRouteRequest{
+		AmtMsat:        int64(amt * 1000),
+		FinalCltvDelta: chainreg.DefaultBitcoinTimeLockDelta,
+		HopPubkeys:     rpcHops,
+	}
+	routeResp := sender.RPC.BuildRoute(req)
+
+	return routeResp.Route
+}
+
+// updatePolicy updates a Dave's global channel policy and returns the expected
+// policy for further check.
+func (m *mppTestScenario) updateDaveGlobalPolicy() *lnrpc.RoutingPolicy {
+	const (
+		baseFeeMsat = 500_000
+		feeRate     = 0.001
+		maxHtlcMsat = 133_650_000
+	)
+
+	expectedPolicy := &lnrpc.RoutingPolicy{
+		FeeBaseMsat:      baseFeeMsat,
+		FeeRateMilliMsat: feeRate * testFeeBase,
+		TimeLockDelta:    40,
+		MinHtlc:          1000, // default value
+		MaxHtlcMsat:      maxHtlcMsat,
+	}
+
+	updateFeeReq := &lnrpc.PolicyUpdateRequest{
+		BaseFeeMsat:   baseFeeMsat,
+		FeeRate:       feeRate,
+		TimeLockDelta: 40,
+		Scope:         &lnrpc.PolicyUpdateRequest_Global{Global: true},
+		MaxHtlcMsat:   maxHtlcMsat,
+	}
+	m.dave.RPC.UpdateChannelPolicy(updateFeeReq)
+
+	return expectedPolicy
 }

--- a/lntest/itest/lnd_mpp_test.go
+++ b/lntest/itest/lnd_mpp_test.go
@@ -439,6 +439,15 @@ func (m *mppTestScenario) closeChannels() {
 		return
 	}
 
+	// TODO(yy): remove the sleep once the following bug is fixed. When the
+	// payment is reported as settled by Alice, it's expected the
+	// commitment dance is finished and all subsequent states have been
+	// updated. Yet we'd receive the error `cannot co-op close channel with
+	// active htlcs` or `link failed to shutdown` if we close the channel.
+	// We need to investigate the order of settling the payments and
+	// updating commitments to understand and fix .
+	time.Sleep(2 * time.Second)
+
 	// Close all channels without mining the closing transactions.
 	m.ht.CloseChannelAssertPending(m.alice, m.channelPoints[0], false)
 	m.ht.CloseChannelAssertPending(m.alice, m.channelPoints[1], false)

--- a/lntest/itest/lnd_mpp_test.go
+++ b/lntest/itest/lnd_mpp_test.go
@@ -188,7 +188,10 @@ func newMppTestScenario(ht *lntemp.HarnessTest) *mppTestScenario {
 
 	// Create a five-node context consisting of Alice, Bob and three new
 	// nodes.
-	carol := ht.NewNode("carol", []string{"--maxpendingchannels=2"})
+	carol := ht.NewNode("carol", []string{
+		"--maxpendingchannels=2",
+		"--accept-amp",
+	})
 	dave := ht.NewNode("dave", nil)
 	eve := ht.NewNode("eve", nil)
 

--- a/lntest/itest/lnd_onchain_test.go
+++ b/lntest/itest/lnd_onchain_test.go
@@ -2,7 +2,6 @@ package itest
 
 import (
 	"bytes"
-	"context"
 	"fmt"
 
 	"github.com/btcsuite/btcd/btcutil"
@@ -14,7 +13,6 @@ import (
 	"github.com/lightningnetwork/lnd/lnrpc/walletrpc"
 	"github.com/lightningnetwork/lnd/lntemp"
 	"github.com/lightningnetwork/lnd/lntemp/node"
-	"github.com/lightningnetwork/lnd/lntest"
 	"github.com/lightningnetwork/lnd/lntest/wait"
 	"github.com/lightningnetwork/lnd/lnwallet"
 	"github.com/lightningnetwork/lnd/sweep"
@@ -80,35 +78,28 @@ func testChainKitGetBlockHash(ht *lntemp.HarnessTest) {
 // rate by broadcasting a Child-Pays-For-Parent (CPFP) transaction.
 //
 // TODO(wilmer): Add RBF case once btcd supports it.
-func testCPFP(net *lntest.NetworkHarness, t *harnessTest) {
-	runCPFP(net, t, net.Alice, net.Bob)
+func testCPFP(ht *lntemp.HarnessTest) {
+	runCPFP(ht, ht.Alice, ht.Bob)
 }
 
 // runCPFP ensures that the daemon can bump an unconfirmed  transaction's fee
 // rate by broadcasting a Child-Pays-For-Parent (CPFP) transaction.
-func runCPFP(net *lntest.NetworkHarness, t *harnessTest,
-	alice, bob *lntest.HarnessNode) {
-
+func runCPFP(ht *lntemp.HarnessTest, alice, bob *node.HarnessNode) {
 	// Skip this test for neutrino, as it's not aware of mempool
 	// transactions.
-	if net.BackendCfg.Name() == lntest.NeutrinoBackendName {
-		t.Skipf("skipping CPFP test for neutrino backend")
+	if ht.IsNeutrinoBackend() {
+		ht.Skipf("skipping CPFP test for neutrino backend")
 	}
 
-	// We'll start the test by sending Alice some coins, which she'll use to
-	// send to Bob.
-	ctxb := context.Background()
-	net.SendCoins(t.t, btcutil.SatoshiPerBitcoin, alice)
+	// We'll start the test by sending Alice some coins, which she'll use
+	// to send to Bob.
+	ht.FundCoins(btcutil.SatoshiPerBitcoin, alice)
 
 	// Create an address for Bob to send the coins to.
-	addrReq := &lnrpc.NewAddressRequest{
+	req := &lnrpc.NewAddressRequest{
 		Type: lnrpc.AddressType_WITNESS_PUBKEY_HASH,
 	}
-	ctxt, _ := context.WithTimeout(ctxb, defaultTimeout)
-	resp, err := bob.NewAddress(ctxt, addrReq)
-	if err != nil {
-		t.Fatalf("unable to get new address for bob: %v", err)
-	}
+	resp := bob.RPC.NewAddress(req)
 
 	// Send the coins from Alice to Bob. We should expect a transaction to
 	// be broadcast and seen in the mempool.
@@ -116,46 +107,33 @@ func runCPFP(net *lntest.NetworkHarness, t *harnessTest,
 		Addr:   resp.Address,
 		Amount: btcutil.SatoshiPerBitcoin,
 	}
-	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
-	if _, err = alice.SendCoins(ctxt, sendReq); err != nil {
-		t.Fatalf("unable to send coins to bob: %v", err)
-	}
-
-	txid, err := waitForTxInMempool(net.Miner.Client, minerMempoolTimeout)
-	if err != nil {
-		t.Fatalf("expected one mempool transaction: %v", err)
-	}
+	alice.RPC.SendCoins(sendReq)
+	txid := ht.Miner.AssertNumTxsInMempool(1)[0]
 
 	// We'll then extract the raw transaction from the mempool in order to
 	// determine the index of Bob's output.
-	tx, err := net.Miner.Client.GetRawTransaction(txid)
-	if err != nil {
-		t.Fatalf("unable to extract raw transaction from mempool: %v",
-			err)
-	}
+	tx := ht.Miner.GetRawTransaction(txid)
 	bobOutputIdx := -1
 	for i, txOut := range tx.MsgTx().TxOut {
 		_, addrs, _, err := txscript.ExtractPkScriptAddrs(
-			txOut.PkScript, net.Miner.ActiveNet,
+			txOut.PkScript, ht.Miner.ActiveNet,
 		)
-		if err != nil {
-			t.Fatalf("unable to extract address from pkScript=%x: "+
-				"%v", txOut.PkScript, err)
-		}
+		require.NoErrorf(ht, err, "unable to extract address "+
+			"from pkScript=%x: %v", txOut.PkScript, err)
+
 		if addrs[0].String() == resp.Address {
 			bobOutputIdx = i
 		}
 	}
-	if bobOutputIdx == -1 {
-		t.Fatalf("bob's output was not found within the transaction")
-	}
+	require.NotEqual(ht, -1, bobOutputIdx, "bob's output was not found "+
+		"within the transaction")
 
 	// Wait until bob has seen the tx and considers it as owned.
 	op := &lnrpc.OutPoint{
 		TxidBytes:   txid[:],
 		OutputIndex: uint32(bobOutputIdx),
 	}
-	assertWalletUnspent(t, bob, op, "")
+	ht.AssertUTXOInWallet(bob, op, "")
 
 	// We'll attempt to bump the fee of this transaction by performing a
 	// CPFP from Alice's point of view.
@@ -165,68 +143,38 @@ func runCPFP(net *lntest.NetworkHarness, t *harnessTest,
 			sweep.DefaultMaxFeeRate.FeePerKVByte() / 2000,
 		),
 	}
-	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
-	_, err = bob.WalletKitClient.BumpFee(ctxt, bumpFeeReq)
-	if err != nil {
-		t.Fatalf("unable to bump fee: %v", err)
-	}
+	bob.RPC.BumpFee(bumpFeeReq)
 
 	// We should now expect to see two transactions within the mempool, a
 	// parent and its child.
-	_, err = waitForNTxsInMempool(net.Miner.Client, 2, minerMempoolTimeout)
-	if err != nil {
-		t.Fatalf("expected two mempool transactions: %v", err)
-	}
+	ht.Miner.AssertNumTxsInMempool(2)
 
 	// We should also expect to see the output being swept by the
 	// UtxoSweeper. We'll ensure it's using the fee rate specified.
-	pendingSweepsReq := &walletrpc.PendingSweepsRequest{}
-	ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
-	pendingSweepsResp, err := bob.WalletKitClient.PendingSweeps(
-		ctxt, pendingSweepsReq,
-	)
-	if err != nil {
-		t.Fatalf("unable to retrieve pending sweeps: %v", err)
-	}
-	if len(pendingSweepsResp.PendingSweeps) != 1 {
-		t.Fatalf("expected to find %v pending sweep(s), found %v", 1,
-			len(pendingSweepsResp.PendingSweeps))
-	}
+	pendingSweepsResp := bob.RPC.PendingSweeps()
+	require.Len(ht, pendingSweepsResp.PendingSweeps, 1,
+		"expected to find 1 pending sweep")
 	pendingSweep := pendingSweepsResp.PendingSweeps[0]
-	if !bytes.Equal(pendingSweep.Outpoint.TxidBytes, op.TxidBytes) {
-		t.Fatalf("expected output txid %x, got %x", op.TxidBytes,
-			pendingSweep.Outpoint.TxidBytes)
-	}
-	if pendingSweep.Outpoint.OutputIndex != op.OutputIndex {
-		t.Fatalf("expected output index %v, got %v", op.OutputIndex,
-			pendingSweep.Outpoint.OutputIndex)
-	}
-	if pendingSweep.SatPerVbyte != bumpFeeReq.SatPerVbyte {
-		t.Fatalf("expected sweep sat per vbyte %v, got %v",
-			bumpFeeReq.SatPerVbyte, pendingSweep.SatPerVbyte)
-	}
+	require.Equal(ht, pendingSweep.Outpoint.TxidBytes, op.TxidBytes,
+		"output txid not matched")
+	require.Equal(ht, pendingSweep.Outpoint.OutputIndex, op.OutputIndex,
+		"output index not matched")
+	require.Equal(ht, pendingSweep.SatPerVbyte, bumpFeeReq.SatPerVbyte,
+		"sweep sat per vbyte not matched")
 
 	// Mine a block to clean up the unconfirmed transactions.
-	mineBlocks(t, net, 1, 2)
+	ht.MineBlocksAndAssertNumTxes(1, 2)
 
 	// The input used to CPFP should no longer be pending.
-	err = wait.NoError(func() error {
-		req := &walletrpc.PendingSweepsRequest{}
-		ctxt, _ = context.WithTimeout(ctxb, defaultTimeout)
-		resp, err := bob.WalletKitClient.PendingSweeps(ctxt, req)
-		if err != nil {
-			return fmt.Errorf("unable to retrieve bob's pending "+
-				"sweeps: %v", err)
-		}
+	err := wait.NoError(func() error {
+		resp := bob.RPC.PendingSweeps()
 		if len(resp.PendingSweeps) != 0 {
 			return fmt.Errorf("expected 0 pending sweeps, found %d",
 				len(resp.PendingSweeps))
 		}
 		return nil
 	}, defaultTimeout)
-	if err != nil {
-		t.Fatalf(err.Error())
-	}
+	require.NoError(ht, err, "timeout checking bob's pending sweeps")
 }
 
 // testAnchorReservedValue tests that we won't allow sending transactions when

--- a/lntest/itest/lnd_open_channel_test.go
+++ b/lntest/itest/lnd_open_channel_test.go
@@ -347,6 +347,7 @@ func runBasicChannelCreationAndUpdates(ht *lntemp.HarnessTest,
 				if i%3 == 0 {
 					continue
 				}
+
 				return fmt.Errorf("expected open or active" +
 					"channel ntfn, got pending open " +
 					"channel ntfn instead")
@@ -355,6 +356,7 @@ func runBasicChannelCreationAndUpdates(ht *lntemp.HarnessTest,
 				if i%3 == 1 {
 					continue
 				}
+
 				return fmt.Errorf("expected pending open or " +
 					"active channel ntfn, got open" +
 					"channel ntfn instead")
@@ -494,8 +496,11 @@ func verifyCloseUpdate(chanUpdate *lnrpc.ChannelEventUpdate,
 	// for each channel.
 	switch update := chanUpdate.Channel.(type) {
 	case *lnrpc.ChannelEventUpdate_InactiveChannel:
-		if chanUpdate.Type != lnrpc.ChannelEventUpdate_INACTIVE_CHANNEL {
-			return fmt.Errorf("update type mismatch: expected %v, got %v",
+		if chanUpdate.Type !=
+			lnrpc.ChannelEventUpdate_INACTIVE_CHANNEL {
+
+			return fmt.Errorf("update type mismatch: "+
+				"expected %v, got %v",
 				lnrpc.ChannelEventUpdate_INACTIVE_CHANNEL,
 				chanUpdate.Type)
 		}
@@ -504,7 +509,8 @@ func verifyCloseUpdate(chanUpdate *lnrpc.ChannelEventUpdate,
 		if chanUpdate.Type !=
 			lnrpc.ChannelEventUpdate_CLOSED_CHANNEL {
 
-			return fmt.Errorf("update type mismatch: expected %v, got %v",
+			return fmt.Errorf("update type mismatch: "+
+				"expected %v, got %v",
 				lnrpc.ChannelEventUpdate_CLOSED_CHANNEL,
 				chanUpdate.Type)
 		}
@@ -517,14 +523,17 @@ func verifyCloseUpdate(chanUpdate *lnrpc.ChannelEventUpdate,
 		}
 
 		if update.ClosedChannel.CloseInitiator != closeInitiator {
-			return fmt.Errorf("expected close intiator: %v, got: %v",
-				closeInitiator,
+			return fmt.Errorf("expected close intiator: %v, "+
+				"got: %v", closeInitiator,
 				update.ClosedChannel.CloseInitiator)
 		}
 
 	case *lnrpc.ChannelEventUpdate_FullyResolvedChannel:
-		if chanUpdate.Type != lnrpc.ChannelEventUpdate_FULLY_RESOLVED_CHANNEL {
-			return fmt.Errorf("update type mismatch: expected %v, got %v",
+		if chanUpdate.Type !=
+			lnrpc.ChannelEventUpdate_FULLY_RESOLVED_CHANNEL {
+
+			return fmt.Errorf("update type mismatch: "+
+				"expected %v, got %v",
 				lnrpc.ChannelEventUpdate_FULLY_RESOLVED_CHANNEL,
 				chanUpdate.Type)
 		}

--- a/lntest/itest/lnd_open_channel_test.go
+++ b/lntest/itest/lnd_open_channel_test.go
@@ -1,9 +1,7 @@
 package itest
 
 import (
-	"context"
 	"fmt"
-	"time"
 
 	"github.com/btcsuite/btcd/btcjson"
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
@@ -12,6 +10,8 @@ import (
 	"github.com/lightningnetwork/lnd/funding"
 	"github.com/lightningnetwork/lnd/lnrpc"
 	"github.com/lightningnetwork/lnd/lntemp"
+	"github.com/lightningnetwork/lnd/lntemp/node"
+	"github.com/lightningnetwork/lnd/lntemp/rpc"
 	"github.com/lightningnetwork/lnd/lntest"
 	"github.com/lightningnetwork/lnd/lntest/wait"
 	"github.com/stretchr/testify/require"
@@ -308,40 +308,33 @@ func testOpenChannelUpdateFeePolicy(net *lntest.NetworkHarness,
 }
 
 // testBasicChannelCreationAndUpdates tests multiple channel opening and
-// closing, and ensures that if a node is subscribed to channel updates
-// they will be received correctly for both cooperative and force closed
-// channels.
-func testBasicChannelCreationAndUpdates(net *lntest.NetworkHarness,
-	t *harnessTest) {
-
-	runBasicChannelCreationAndUpdates(net, t, net.Alice, net.Bob)
+// closing, and ensures that if a node is subscribed to channel updates they
+// will be received correctly for both cooperative and force closed channels.
+func testBasicChannelCreationAndUpdates(ht *lntemp.HarnessTest) {
+	runBasicChannelCreationAndUpdates(ht, ht.Alice, ht.Bob)
 }
 
 // runBasicChannelCreationAndUpdates tests multiple channel opening and closing,
 // and ensures that if a node is subscribed to channel updates they will be
 // received correctly for both cooperative and force closed channels.
-func runBasicChannelCreationAndUpdates(net *lntest.NetworkHarness,
-	t *harnessTest, alice, bob *lntest.HarnessNode) {
+func runBasicChannelCreationAndUpdates(ht *lntemp.HarnessTest,
+	alice, bob *node.HarnessNode) {
 
-	ctxb := context.Background()
 	const (
 		numChannels = 2
 		amount      = funding.MaxBtcFundingAmount
 	)
 
 	// Subscribe Bob and Alice to channel event notifications.
-	bobChanSub := subscribeChannelNotifications(ctxb, t, bob)
-	defer close(bobChanSub.quit)
-
-	aliceChanSub := subscribeChannelNotifications(ctxb, t, alice)
-	defer close(aliceChanSub.quit)
+	bobChanSub := bob.RPC.SubscribeChannelEvents()
+	aliceChanSub := alice.RPC.SubscribeChannelEvents()
 
 	// Open the channels between Alice and Bob, asserting that the channels
 	// have been properly opened on-chain.
 	chanPoints := make([]*lnrpc.ChannelPoint, numChannels)
 	for i := 0; i < numChannels; i++ {
-		chanPoints[i] = openChannelAndAssert(
-			t, net, alice, bob, lntest.OpenChannelParams{
+		chanPoints[i] = ht.OpenChannel(
+			alice, bob, lntemp.OpenChannelParams{
 				Amt: amount,
 			},
 		)
@@ -350,112 +343,91 @@ func runBasicChannelCreationAndUpdates(net *lntest.NetworkHarness,
 	// Since each of the channels just became open, Bob and Alice should
 	// each receive an open and an active notification for each channel.
 	const numExpectedOpenUpdates = 3 * numChannels
-	verifyOpenUpdatesReceived := func(sub channelSubscription) error {
-		numChannelUpds := 0
-		for numChannelUpds < numExpectedOpenUpdates {
-			select {
-			case update := <-sub.updateChan:
-				switch update.Type {
-				case lnrpc.ChannelEventUpdate_PENDING_OPEN_CHANNEL:
-					if numChannelUpds%3 != 0 {
-						return fmt.Errorf("expected " +
-							"open or active" +
-							"channel ntfn, got pending open " +
-							"channel ntfn instead")
-					}
-				case lnrpc.ChannelEventUpdate_OPEN_CHANNEL:
-					if numChannelUpds%3 != 1 {
-						return fmt.Errorf("expected " +
-							"pending open or active" +
-							"channel ntfn, got open" +
-							"channel ntfn instead")
-					}
-				case lnrpc.ChannelEventUpdate_ACTIVE_CHANNEL:
-					if numChannelUpds%3 != 2 {
-						return fmt.Errorf("expected " +
-							"pending open or open" +
-							"channel ntfn, got active " +
-							"channel ntfn instead")
-					}
-				default:
-					return fmt.Errorf("update type mismatch: "+
-						"expected open or active channel "+
-						"notification, got: %v",
-						update.Type)
-				}
-				numChannelUpds++
+	verifyOpenUpdatesReceived := func(sub rpc.ChannelEventsClient) error {
+		for i := 0; i < numExpectedOpenUpdates; i++ {
+			update := ht.ReceiveChannelEvent(sub)
 
-			case <-time.After(time.Second * 10):
-				return fmt.Errorf("timeout waiting for channel "+
-					"notifications, only received %d/%d "+
-					"chanupds", numChannelUpds,
-					numExpectedOpenUpdates)
+			switch update.Type {
+			case lnrpc.ChannelEventUpdate_PENDING_OPEN_CHANNEL:
+				if i%3 == 0 {
+					continue
+				}
+				return fmt.Errorf("expected open or active" +
+					"channel ntfn, got pending open " +
+					"channel ntfn instead")
+
+			case lnrpc.ChannelEventUpdate_OPEN_CHANNEL:
+				if i%3 == 1 {
+					continue
+				}
+				return fmt.Errorf("expected pending open or " +
+					"active channel ntfn, got open" +
+					"channel ntfn instead")
+
+			case lnrpc.ChannelEventUpdate_ACTIVE_CHANNEL:
+				if i%3 == 2 {
+					continue
+				}
+
+				return fmt.Errorf("expected pending open or " +
+					"open channel ntfn, got active " +
+					"channel ntfn instead")
+
+			default:
+				return fmt.Errorf("update type mismatch: "+
+					"expected open or active channel "+
+					"notification, got: %v", update.Type)
 			}
 		}
 
 		return nil
 	}
 
-	require.NoError(
-		t.t, verifyOpenUpdatesReceived(bobChanSub), "bob open channels",
-	)
-	require.NoError(
-		t.t, verifyOpenUpdatesReceived(aliceChanSub), "alice open "+
-			"channels",
-	)
+	require.NoError(ht, verifyOpenUpdatesReceived(bobChanSub),
+		"bob open channels")
+	require.NoError(ht, verifyOpenUpdatesReceived(aliceChanSub),
+		"alice open channels")
 
-	// Close the channels between Alice and Bob, asserting that the channels
-	// have been properly closed on-chain.
+	// Close the channels between Alice and Bob, asserting that the
+	// channels have been properly closed on-chain.
 	for i, chanPoint := range chanPoints {
 		// Force close the first of the two channels.
 		force := i%2 == 0
-		closeChannelAndAssert(t, net, alice, chanPoint, force)
 		if force {
-			cleanupForceClose(t, net, alice, chanPoint)
+			ht.ForceCloseChannel(alice, chanPoint)
+		} else {
+			ht.CloseChannel(alice, chanPoint)
 		}
 	}
 
 	// verifyCloseUpdatesReceived is used to verify that Alice and Bob
 	// receive the correct channel updates in order.
 	const numExpectedCloseUpdates = 3 * numChannels
-	verifyCloseUpdatesReceived := func(sub channelSubscription,
+	verifyCloseUpdatesReceived := func(sub rpc.ChannelEventsClient,
 		forceType lnrpc.ChannelCloseSummary_ClosureType,
 		closeInitiator lnrpc.Initiator) error {
 
 		// Ensure one inactive and one closed notification is received
 		// for each closed channel.
-		numChannelUpds := 0
-		for numChannelUpds < numExpectedCloseUpdates {
-			expectedCloseType := lnrpc.ChannelCloseSummary_COOPERATIVE_CLOSE
+		for i := 0; i < numExpectedCloseUpdates; i++ {
+			expectedCloseType := lnrpc.
+				ChannelCloseSummary_COOPERATIVE_CLOSE
 
 			// Every other channel should be force closed. If this
 			// channel was force closed, set the expected close type
 			// to the type passed in.
-			force := (numChannelUpds/3)%2 == 0
+			force := (i/3)%2 == 0
 			if force {
 				expectedCloseType = forceType
 			}
 
-			select {
-			case chanUpdate := <-sub.updateChan:
-				err := verifyCloseUpdate(
-					chanUpdate, expectedCloseType,
-					closeInitiator,
-				)
-				if err != nil {
-					return err
-				}
-
-				numChannelUpds++
-
-			case err := <-sub.errChan:
+			chanUpdate := ht.ReceiveChannelEvent(sub)
+			err := verifyCloseUpdate(
+				chanUpdate, expectedCloseType,
+				closeInitiator,
+			)
+			if err != nil {
 				return err
-
-			case <-time.After(time.Second * 10):
-				return fmt.Errorf("timeout waiting "+
-					"for channel notifications, only "+
-					"received %d/%d chanupds",
-					numChannelUpds, numChannelUpds)
 			}
 		}
 
@@ -467,7 +439,7 @@ func runBasicChannelCreationAndUpdates(net *lntest.NetworkHarness,
 	// All channels (cooperatively and force closed) should have a remote
 	// close initiator because Alice closed the channels.
 	require.NoError(
-		t.t, verifyCloseUpdatesReceived(
+		ht, verifyCloseUpdatesReceived(
 			bobChanSub,
 			lnrpc.ChannelCloseSummary_REMOTE_FORCE_CLOSE,
 			lnrpc.Initiator_INITIATOR_REMOTE,
@@ -479,7 +451,7 @@ func runBasicChannelCreationAndUpdates(net *lntest.NetworkHarness,
 	// All channels (cooperatively and force closed) should have a local
 	// close initiator because Alice closed the channels.
 	require.NoError(
-		t.t, verifyCloseUpdatesReceived(
+		ht, verifyCloseUpdatesReceived(
 			aliceChanSub,
 			lnrpc.ChannelCloseSummary_LOCAL_FORCE_CLOSE,
 			lnrpc.Initiator_INITIATOR_LOCAL,
@@ -515,4 +487,58 @@ func assertMinerBlockHeightDelta(ht *lntemp.HarnessTest,
 		return nil
 	}, defaultTimeout)
 	require.NoError(ht, err, "failed to assert block height delta")
+}
+
+// verifyCloseUpdate is used to verify that a closed channel update is of the
+// expected type.
+func verifyCloseUpdate(chanUpdate *lnrpc.ChannelEventUpdate,
+	closeType lnrpc.ChannelCloseSummary_ClosureType,
+	closeInitiator lnrpc.Initiator) error {
+
+	// We should receive one inactive and one closed notification
+	// for each channel.
+	switch update := chanUpdate.Channel.(type) {
+	case *lnrpc.ChannelEventUpdate_InactiveChannel:
+		if chanUpdate.Type != lnrpc.ChannelEventUpdate_INACTIVE_CHANNEL {
+			return fmt.Errorf("update type mismatch: expected %v, got %v",
+				lnrpc.ChannelEventUpdate_INACTIVE_CHANNEL,
+				chanUpdate.Type)
+		}
+
+	case *lnrpc.ChannelEventUpdate_ClosedChannel:
+		if chanUpdate.Type !=
+			lnrpc.ChannelEventUpdate_CLOSED_CHANNEL {
+
+			return fmt.Errorf("update type mismatch: expected %v, got %v",
+				lnrpc.ChannelEventUpdate_CLOSED_CHANNEL,
+				chanUpdate.Type)
+		}
+
+		if update.ClosedChannel.CloseType != closeType {
+			return fmt.Errorf("channel closure type "+
+				"mismatch: expected %v, got %v",
+				closeType,
+				update.ClosedChannel.CloseType)
+		}
+
+		if update.ClosedChannel.CloseInitiator != closeInitiator {
+			return fmt.Errorf("expected close intiator: %v, got: %v",
+				closeInitiator,
+				update.ClosedChannel.CloseInitiator)
+		}
+
+	case *lnrpc.ChannelEventUpdate_FullyResolvedChannel:
+		if chanUpdate.Type != lnrpc.ChannelEventUpdate_FULLY_RESOLVED_CHANNEL {
+			return fmt.Errorf("update type mismatch: expected %v, got %v",
+				lnrpc.ChannelEventUpdate_FULLY_RESOLVED_CHANNEL,
+				chanUpdate.Type)
+		}
+
+	default:
+		return fmt.Errorf("channel update channel of wrong type, "+
+			"expected closed channel, got %T",
+			update)
+	}
+
+	return nil
 }

--- a/lntest/itest/lnd_psbt_test.go
+++ b/lntest/itest/lnd_psbt_test.go
@@ -1128,34 +1128,6 @@ func assertPsbtFundSignSpend(ht *lntemp.HarnessTest, alice *node.HarnessNode,
 
 // deriveInternalKey derives a signing key and returns its descriptor, full
 // derivation path and parsed public key.
-func deriveInternalKeyOld(ctx context.Context, t *harnessTest,
-	alice *lntest.HarnessNode) (*signrpc.KeyDescriptor, *btcec.PublicKey,
-	[]uint32) {
-
-	// For the next step, we need a public key. Let's use a special family
-	// for this.
-	keyDesc, err := alice.WalletKitClient.DeriveNextKey(
-		ctx, &walletrpc.KeyReq{KeyFamily: testTaprootKeyFamily},
-	)
-	require.NoError(t.t, err)
-
-	// The DeriveNextKey returns a key from the internal 1017 scope.
-	fullDerivationPath := []uint32{
-		hdkeychain.HardenedKeyStart + keychain.BIP0043Purpose,
-		hdkeychain.HardenedKeyStart + harnessNetParams.HDCoinType,
-		hdkeychain.HardenedKeyStart + uint32(keyDesc.KeyLoc.KeyFamily),
-		0,
-		uint32(keyDesc.KeyLoc.KeyIndex),
-	}
-
-	parsedPubKey, err := btcec.ParsePubKey(keyDesc.RawKeyBytes)
-	require.NoError(t.t, err)
-
-	return keyDesc, parsedPubKey, fullDerivationPath
-}
-
-// deriveInternalKey derives a signing key and returns its descriptor, full
-// derivation path and parsed public key.
 func deriveInternalKey(ht *lntemp.HarnessTest,
 	alice *node.HarnessNode) (*signrpc.KeyDescriptor, *btcec.PublicKey,
 	[]uint32) {

--- a/lntest/itest/lnd_psbt_test.go
+++ b/lntest/itest/lnd_psbt_test.go
@@ -670,7 +670,9 @@ func runSignPsbtSegWitV0P2WKH(ht *lntemp.HarnessTest, alice *node.HarnessNode) {
 
 // runSignPsbtSegWitV0NP2WKH tests that the SignPsbt RPC works correctly for a
 // SegWit v0 np2wkh input.
-func runSignPsbtSegWitV0NP2WKH(ht *lntemp.HarnessTest, alice *node.HarnessNode) {
+func runSignPsbtSegWitV0NP2WKH(ht *lntemp.HarnessTest,
+	alice *node.HarnessNode) {
+
 	// We test that we can sign a PSBT that spends funds from an input that
 	// the wallet doesn't know about. To set up that test case, we first
 	// derive an address manually that the wallet won't be watching on

--- a/lntest/itest/lnd_psbt_test.go
+++ b/lntest/itest/lnd_psbt_test.go
@@ -576,49 +576,38 @@ func testPsbtChanFundingSingleStep(ht *lntemp.HarnessTest) {
 }
 
 // testSignPsbt tests that the SignPsbt RPC works correctly.
-func testSignPsbt(net *lntest.NetworkHarness, t *harnessTest) {
-	runSignPsbtSegWitV0P2WKH(t, net, net.Alice)
-	runSignPsbtSegWitV0NP2WKH(t, net, net.Alice)
-	runSignPsbtSegWitV1KeySpendBip86(t, net, net.Alice)
-	runSignPsbtSegWitV1KeySpendRootHash(t, net, net.Alice)
-	runSignPsbtSegWitV1ScriptSpend(t, net, net.Alice)
+func testSignPsbt(ht *lntemp.HarnessTest) {
+	runSignPsbtSegWitV0P2WKH(ht, ht.Alice)
+	runSignPsbtSegWitV0NP2WKH(ht, ht.Alice)
+	runSignPsbtSegWitV1KeySpendBip86(ht, ht.Alice)
+	runSignPsbtSegWitV1KeySpendRootHash(ht, ht.Alice)
+	runSignPsbtSegWitV1ScriptSpend(ht, ht.Alice)
 
-	// The above tests all make sure we can sign for keys that aren't in the
-	// wallet. But we also want to make sure we can fund and then sign PSBTs
-	// from our wallet.
-	runFundAndSignPsbt(t, net, net.Alice)
+	// The above tests all make sure we can sign for keys that aren't in
+	// the wallet. But we also want to make sure we can fund and then sign
+	// PSBTs from our wallet.
+	runFundAndSignPsbt(ht, ht.Alice)
 }
 
 // runSignPsbtSegWitV0P2WKH tests that the SignPsbt RPC works correctly for a
 // SegWit v0 p2wkh input.
-func runSignPsbtSegWitV0P2WKH(t *harnessTest, net *lntest.NetworkHarness,
-	alice *lntest.HarnessNode) {
-
-	// Everything we do here should be done within a second or two, so we
-	// can just keep a single timeout context around for all calls.
-	ctxb := context.Background()
-	ctxt, cancel := context.WithTimeout(ctxb, defaultTimeout)
-	defer cancel()
-
+func runSignPsbtSegWitV0P2WKH(ht *lntemp.HarnessTest, alice *node.HarnessNode) {
 	// We test that we can sign a PSBT that spends funds from an input that
 	// the wallet doesn't know about. To set up that test case, we first
 	// derive an address manually that the wallet won't be watching on
 	// chain. We can do that by exporting the account xpub of lnd's main
 	// account.
-	accounts, err := alice.WalletKitClient.ListAccounts(
-		ctxt, &walletrpc.ListAccountsRequest{},
-	)
-	require.NoError(t.t, err)
-	require.NotEmpty(t.t, accounts.Accounts)
+	accounts := alice.RPC.ListAccounts(&walletrpc.ListAccountsRequest{})
+	require.NotEmpty(ht, accounts.Accounts)
 
 	// We also need to parse the accounts, so we have easy access to the
 	// parsed derivation paths.
 	parsedAccounts, err := walletrpc.AccountsToWatchOnly(accounts.Accounts)
-	require.NoError(t.t, err)
+	require.NoError(ht, err)
 
 	account := parsedAccounts[0]
 	xpub, err := hdkeychain.NewKeyFromString(account.Xpub)
-	require.NoError(t.t, err)
+	require.NoError(ht, err)
 
 	const (
 		changeIndex = 1
@@ -634,27 +623,27 @@ func runSignPsbtSegWitV0P2WKH(t *harnessTest, net *lntest.NetworkHarness,
 
 	// Let's simulate a change address.
 	change, err := xpub.DeriveNonStandard(changeIndex) // nolint:staticcheck
-	require.NoError(t.t, err)
+	require.NoError(ht, err)
 
 	// At an index that we are certainly not watching in the wallet.
 	addrKey, err := change.DeriveNonStandard(addrIndex) // nolint:staticcheck
-	require.NoError(t.t, err)
+	require.NoError(ht, err)
 
 	addrPubKey, err := addrKey.ECPubKey()
-	require.NoError(t.t, err)
+	require.NoError(ht, err)
 	pubKeyHash := btcutil.Hash160(addrPubKey.SerializeCompressed())
 	witnessAddr, err := btcutil.NewAddressWitnessPubKeyHash(
 		pubKeyHash, harnessNetParams,
 	)
-	require.NoError(t.t, err)
+	require.NoError(ht, err)
 
 	pkScript, err := txscript.PayToAddrScript(witnessAddr)
-	require.NoError(t.t, err)
+	require.NoError(ht, err)
 
 	// Send some funds to the output and then try to get a signature through
 	// the SignPsbt RPC to spend that output again.
 	assertPsbtSpend(
-		ctxt, t, net, alice, pkScript,
+		ht, alice, pkScript,
 		func(packet *psbt.Packet) {
 			in := &packet.Inputs[0]
 			in.Bip32Derivation = []*psbt.Bip32Derivation{{
@@ -664,16 +653,16 @@ func runSignPsbtSegWitV0P2WKH(t *harnessTest, net *lntest.NetworkHarness,
 			in.SighashType = txscript.SigHashAll
 		},
 		func(packet *psbt.Packet) {
-			require.Len(t.t, packet.Inputs, 1)
-			require.Len(t.t, packet.Inputs[0].PartialSigs, 1)
+			require.Len(ht, packet.Inputs, 1)
+			require.Len(ht, packet.Inputs[0].PartialSigs, 1)
 
 			partialSig := packet.Inputs[0].PartialSigs[0]
 			require.Equal(
-				t.t, partialSig.PubKey,
+				ht, partialSig.PubKey,
 				addrPubKey.SerializeCompressed(),
 			)
 			require.Greater(
-				t.t, len(partialSig.Signature), ecdsa.MinSigLen,
+				ht, len(partialSig.Signature), ecdsa.MinSigLen,
 			)
 		},
 	)
@@ -681,34 +670,23 @@ func runSignPsbtSegWitV0P2WKH(t *harnessTest, net *lntest.NetworkHarness,
 
 // runSignPsbtSegWitV0NP2WKH tests that the SignPsbt RPC works correctly for a
 // SegWit v0 np2wkh input.
-func runSignPsbtSegWitV0NP2WKH(t *harnessTest, net *lntest.NetworkHarness,
-	alice *lntest.HarnessNode) {
-
-	// Everything we do here should be done within a second or two, so we
-	// can just keep a single timeout context around for all calls.
-	ctxb := context.Background()
-	ctxt, cancel := context.WithTimeout(ctxb, defaultTimeout)
-	defer cancel()
-
+func runSignPsbtSegWitV0NP2WKH(ht *lntemp.HarnessTest, alice *node.HarnessNode) {
 	// We test that we can sign a PSBT that spends funds from an input that
 	// the wallet doesn't know about. To set up that test case, we first
 	// derive an address manually that the wallet won't be watching on
 	// chain. We can do that by exporting the account xpub of lnd's main
 	// account.
-	accounts, err := alice.WalletKitClient.ListAccounts(
-		ctxt, &walletrpc.ListAccountsRequest{},
-	)
-	require.NoError(t.t, err)
-	require.NotEmpty(t.t, accounts.Accounts)
+	accounts := alice.RPC.ListAccounts(&walletrpc.ListAccountsRequest{})
+	require.NotEmpty(ht, accounts.Accounts)
 
 	// We also need to parse the accounts, so we have easy access to the
 	// parsed derivation paths.
 	parsedAccounts, err := walletrpc.AccountsToWatchOnly(accounts.Accounts)
-	require.NoError(t.t, err)
+	require.NoError(ht, err)
 
 	account := parsedAccounts[0]
 	xpub, err := hdkeychain.NewKeyFromString(account.Xpub)
-	require.NoError(t.t, err)
+	require.NoError(ht, err)
 
 	const (
 		changeIndex = 1
@@ -724,34 +702,34 @@ func runSignPsbtSegWitV0NP2WKH(t *harnessTest, net *lntest.NetworkHarness,
 
 	// Let's simulate a change address.
 	change, err := xpub.DeriveNonStandard(changeIndex) // nolint:staticcheck
-	require.NoError(t.t, err)
+	require.NoError(ht, err)
 
 	// At an index that we are certainly not watching in the wallet.
 	addrKey, err := change.DeriveNonStandard(addrIndex) // nolint:staticcheck
-	require.NoError(t.t, err)
+	require.NoError(ht, err)
 
 	addrPubKey, err := addrKey.ECPubKey()
-	require.NoError(t.t, err)
+	require.NoError(ht, err)
 	pubKeyHash := btcutil.Hash160(addrPubKey.SerializeCompressed())
 	witnessAddr, err := btcutil.NewAddressWitnessPubKeyHash(
 		pubKeyHash, harnessNetParams,
 	)
-	require.NoError(t.t, err)
+	require.NoError(ht, err)
 
 	witnessProgram, err := txscript.PayToAddrScript(witnessAddr)
-	require.NoError(t.t, err)
+	require.NoError(ht, err)
 	np2wkhAddr, err := btcutil.NewAddressScriptHash(
 		witnessProgram, harnessNetParams,
 	)
-	require.NoError(t.t, err)
+	require.NoError(ht, err)
 
 	pkScript, err := txscript.PayToAddrScript(np2wkhAddr)
-	require.NoError(t.t, err)
+	require.NoError(ht, err)
 
 	// Send some funds to the output and then try to get a signature through
 	// the SignPsbt RPC to spend that output again.
 	assertPsbtSpend(
-		ctxt, t, net, alice, pkScript,
+		ht, alice, pkScript,
 		func(packet *psbt.Packet) {
 			in := &packet.Inputs[0]
 			in.RedeemScript = witnessProgram
@@ -762,16 +740,16 @@ func runSignPsbtSegWitV0NP2WKH(t *harnessTest, net *lntest.NetworkHarness,
 			in.SighashType = txscript.SigHashAll
 		},
 		func(packet *psbt.Packet) {
-			require.Len(t.t, packet.Inputs, 1)
-			require.Len(t.t, packet.Inputs[0].PartialSigs, 1)
+			require.Len(ht, packet.Inputs, 1)
+			require.Len(ht, packet.Inputs[0].PartialSigs, 1)
 
 			partialSig := packet.Inputs[0].PartialSigs[0]
 			require.Equal(
-				t.t, partialSig.PubKey,
+				ht, partialSig.PubKey,
 				addrPubKey.SerializeCompressed(),
 			)
 			require.Greater(
-				t.t, len(partialSig.Signature), ecdsa.MinSigLen,
+				ht, len(partialSig.Signature), ecdsa.MinSigLen,
 			)
 		},
 	)
@@ -779,19 +757,11 @@ func runSignPsbtSegWitV0NP2WKH(t *harnessTest, net *lntest.NetworkHarness,
 
 // runSignPsbtSegWitV1KeySpendBip86 tests that the SignPsbt RPC works correctly
 // for a SegWit v1 p2tr key spend BIP-0086 input.
-func runSignPsbtSegWitV1KeySpendBip86(t *harnessTest, net *lntest.NetworkHarness,
-	alice *lntest.HarnessNode) {
-
-	// Everything we do here should be done within a second or two, so we
-	// can just keep a single timeout context around for all calls.
-	ctxb := context.Background()
-	ctxt, cancel := context.WithTimeout(ctxb, defaultTimeout)
-	defer cancel()
+func runSignPsbtSegWitV1KeySpendBip86(ht *lntemp.HarnessTest,
+	alice *node.HarnessNode) {
 
 	// Derive a key we can use for signing.
-	keyDesc, internalKey, fullDerivationPath := deriveInternalKey(
-		ctxt, t, alice,
-	)
+	keyDesc, internalKey, fullDerivationPath := deriveInternalKey(ht, alice)
 
 	// Our taproot key is a BIP0086 key spend only construction that just
 	// commits to the internal key and no root hash.
@@ -799,14 +769,14 @@ func runSignPsbtSegWitV1KeySpendBip86(t *harnessTest, net *lntest.NetworkHarness
 	tapScriptAddr, err := btcutil.NewAddressTaproot(
 		schnorr.SerializePubKey(taprootKey), harnessNetParams,
 	)
-	require.NoError(t.t, err)
+	require.NoError(ht, err)
 	p2trPkScript, err := txscript.PayToAddrScript(tapScriptAddr)
-	require.NoError(t.t, err)
+	require.NoError(ht, err)
 
 	// Send some funds to the output and then try to get a signature through
 	// the SignPsbt RPC to spend that output again.
 	assertPsbtSpend(
-		ctxt, t, net, alice, p2trPkScript,
+		ht, alice, p2trPkScript,
 		func(packet *psbt.Packet) {
 			in := &packet.Inputs[0]
 			in.Bip32Derivation = []*psbt.Bip32Derivation{{
@@ -820,9 +790,9 @@ func runSignPsbtSegWitV1KeySpendBip86(t *harnessTest, net *lntest.NetworkHarness
 			in.SighashType = txscript.SigHashDefault
 		},
 		func(packet *psbt.Packet) {
-			require.Len(t.t, packet.Inputs, 1)
+			require.Len(ht, packet.Inputs, 1)
 			require.Len(
-				t.t, packet.Inputs[0].TaprootKeySpendSig, 64,
+				ht, packet.Inputs[0].TaprootKeySpendSig, 64,
 			)
 		},
 	)
@@ -831,37 +801,29 @@ func runSignPsbtSegWitV1KeySpendBip86(t *harnessTest, net *lntest.NetworkHarness
 // runSignPsbtSegWitV1KeySpendRootHash tests that the SignPsbt RPC works
 // correctly for a SegWit v1 p2tr key spend that also commits to a script tree
 // root hash.
-func runSignPsbtSegWitV1KeySpendRootHash(t *harnessTest,
-	net *lntest.NetworkHarness, alice *lntest.HarnessNode) {
-
-	// Everything we do here should be done within a second or two, so we
-	// can just keep a single timeout context around for all calls.
-	ctxb := context.Background()
-	ctxt, cancel := context.WithTimeout(ctxb, defaultTimeout)
-	defer cancel()
+func runSignPsbtSegWitV1KeySpendRootHash(ht *lntemp.HarnessTest,
+	alice *node.HarnessNode) {
 
 	// Derive a key we can use for signing.
-	keyDesc, internalKey, fullDerivationPath := deriveInternalKey(
-		ctxt, t, alice,
-	)
+	keyDesc, internalKey, fullDerivationPath := deriveInternalKey(ht, alice)
 
 	// Let's create a taproot script output now. This is a hash lock with a
 	// simple preimage of "foobar".
-	leaf1 := testScriptHashLock(t.t, []byte("foobar"))
+	leaf1 := testScriptHashLock(ht.T, []byte("foobar"))
 
 	rootHash := leaf1.TapHash()
 	taprootKey := txscript.ComputeTaprootOutputKey(internalKey, rootHash[:])
 	tapScriptAddr, err := btcutil.NewAddressTaproot(
 		schnorr.SerializePubKey(taprootKey), harnessNetParams,
 	)
-	require.NoError(t.t, err)
+	require.NoError(ht, err)
 	p2trPkScript, err := txscript.PayToAddrScript(tapScriptAddr)
-	require.NoError(t.t, err)
+	require.NoError(ht, err)
 
 	// Send some funds to the output and then try to get a signature through
 	// the SignPsbt RPC to spend that output again.
 	assertPsbtSpend(
-		ctxt, t, net, alice, p2trPkScript,
+		ht, alice, p2trPkScript,
 		func(packet *psbt.Packet) {
 			in := &packet.Inputs[0]
 			in.Bip32Derivation = []*psbt.Bip32Derivation{{
@@ -876,9 +838,9 @@ func runSignPsbtSegWitV1KeySpendRootHash(t *harnessTest,
 			in.SighashType = txscript.SigHashDefault
 		},
 		func(packet *psbt.Packet) {
-			require.Len(t.t, packet.Inputs, 1)
+			require.Len(ht, packet.Inputs, 1)
 			require.Len(
-				t.t, packet.Inputs[0].TaprootKeySpendSig, 64,
+				ht, packet.Inputs[0].TaprootKeySpendSig, 64,
 			)
 		},
 	)
@@ -886,43 +848,35 @@ func runSignPsbtSegWitV1KeySpendRootHash(t *harnessTest,
 
 // runSignPsbtSegWitV1ScriptSpend tests that the SignPsbt RPC works correctly
 // for a SegWit v1 p2tr script spend.
-func runSignPsbtSegWitV1ScriptSpend(t *harnessTest,
-	net *lntest.NetworkHarness, alice *lntest.HarnessNode) {
-
-	// Everything we do here should be done within a second or two, so we
-	// can just keep a single timeout context around for all calls.
-	ctxb := context.Background()
-	ctxt, cancel := context.WithTimeout(ctxb, defaultTimeout)
-	defer cancel()
+func runSignPsbtSegWitV1ScriptSpend(ht *lntemp.HarnessTest,
+	alice *node.HarnessNode) {
 
 	// Derive a key we can use for signing.
-	keyDesc, internalKey, fullDerivationPath := deriveInternalKey(
-		ctxt, t, alice,
-	)
+	keyDesc, internalKey, fullDerivationPath := deriveInternalKey(ht, alice)
 
 	// Let's create a taproot script output now. This is a hash lock with a
 	// simple preimage of "foobar".
-	leaf1 := testScriptSchnorrSig(t.t, internalKey)
+	leaf1 := testScriptSchnorrSig(ht.T, internalKey)
 
 	rootHash := leaf1.TapHash()
 	taprootKey := txscript.ComputeTaprootOutputKey(internalKey, rootHash[:])
 	tapScriptAddr, err := btcutil.NewAddressTaproot(
 		schnorr.SerializePubKey(taprootKey), harnessNetParams,
 	)
-	require.NoError(t.t, err)
+	require.NoError(ht, err)
 	p2trPkScript, err := txscript.PayToAddrScript(tapScriptAddr)
-	require.NoError(t.t, err)
+	require.NoError(ht, err)
 
 	// We need to assemble the control block to be able to spend through the
 	// script path.
 	tapscript := input.TapscriptPartialReveal(internalKey, leaf1, nil)
 	controlBlockBytes, err := tapscript.ControlBlock.ToBytes()
-	require.NoError(t.t, err)
+	require.NoError(ht, err)
 
 	// Send some funds to the output and then try to get a signature through
 	// the SignPsbt RPC to spend that output again.
 	assertPsbtSpend(
-		ctxt, t, net, alice, p2trPkScript,
+		ht, alice, p2trPkScript,
 		func(packet *psbt.Packet) {
 			in := &packet.Inputs[0]
 			in.Bip32Derivation = []*psbt.Bip32Derivation{{
@@ -942,32 +896,27 @@ func runSignPsbtSegWitV1ScriptSpend(t *harnessTest,
 			}}
 		},
 		func(packet *psbt.Packet) {
-			require.Len(t.t, packet.Inputs, 1)
+			require.Len(ht, packet.Inputs, 1)
 			require.Len(
-				t.t, packet.Inputs[0].TaprootScriptSpendSig, 1,
+				ht, packet.Inputs[0].TaprootScriptSpendSig, 1,
 			)
 
 			scriptSpendSig := packet.Inputs[0].TaprootScriptSpendSig[0]
-			require.Len(t.t, scriptSpendSig.Signature, 64)
+			require.Len(ht, scriptSpendSig.Signature, 64)
 		},
 	)
 }
 
 // runFundAndSignPsbt makes sure we can sign PSBTs that were funded by our
 // internal wallet.
-func runFundAndSignPsbt(t *harnessTest, net *lntest.NetworkHarness,
-	alice *lntest.HarnessNode) {
-
-	ctxb := context.Background()
-	ctxt, cancel := context.WithTimeout(ctxb, defaultTimeout)
-	defer cancel()
+func runFundAndSignPsbt(ht *lntemp.HarnessTest, alice *node.HarnessNode) {
+	alice.AddToLogf("================ runFundAndSignPsbt ===============")
 
 	// We'll be using a "main" address where we send the funds to and from
 	// several times.
-	mainAddrResp, err := alice.NewAddress(ctxt, &lnrpc.NewAddressRequest{
+	mainAddrResp := alice.RPC.NewAddress(&lnrpc.NewAddressRequest{
 		Type: lnrpc.AddressType_WITNESS_PUBKEY_HASH,
 	})
-	require.NoError(t.t, err)
 
 	fundOutputs := map[string]uint64{
 		mainAddrResp.Address: 999000,
@@ -979,56 +928,53 @@ func runFundAndSignPsbt(t *harnessTest, net *lntest.NetworkHarness,
 	}
 
 	for _, addrType := range spendAddrTypes {
-		ctxt, cancel := context.WithTimeout(ctxb, defaultTimeout)
+		ht.Logf("testing with address type %s", addrType)
 
-		// First, spend all the coins in the wallet to an address of the
-		// given type so that UTXO will be picked when funding a PSBT.
-		sendAllCoinsToAddrType(ctxt, t, net, alice, addrType)
+		// First, spend all the coins in the wallet to an address of
+		// the given type so that UTXO will be picked when funding a
+		// PSBT.
+		sendAllCoinsToAddrType(ht, alice, addrType)
 
-		// Let's fund a PSBT now where we want to send a few sats to our
-		// main address.
-		assertPsbtFundSignSpend(ctxt, t, net, alice, fundOutputs, false)
+		// Let's fund a PSBT now where we want to send a few sats to
+		// our main address.
+		assertPsbtFundSignSpend(ht, alice, fundOutputs, false)
 
 		// Send all coins back to a single address once again.
-		sendAllCoinsToAddrType(ctxt, t, net, alice, addrType)
+		sendAllCoinsToAddrType(ht, alice, addrType)
 
 		// And now make sure the alternate way of signing a PSBT, which
-		// is calling FinalizePsbt directly, also works for this address
-		// type.
-		assertPsbtFundSignSpend(ctxt, t, net, alice, fundOutputs, true)
-
-		cancel()
+		// is calling FinalizePsbt directly, also works for this
+		// address type.
+		assertPsbtFundSignSpend(ht, alice, fundOutputs, true)
 	}
 }
 
 // assertPsbtSpend creates an output with the given pkScript on chain and then
 // attempts to create a sweep transaction that is signed using the SignPsbt RPC
 // that spends that output again.
-func assertPsbtSpend(ctx context.Context, t *harnessTest,
-	net *lntest.NetworkHarness, alice *lntest.HarnessNode, pkScript []byte,
-	decorateUnsigned func(*psbt.Packet), verifySigned func(*psbt.Packet)) {
+func assertPsbtSpend(ht *lntemp.HarnessTest, alice *node.HarnessNode,
+	pkScript []byte, decorateUnsigned func(*psbt.Packet),
+	verifySigned func(*psbt.Packet)) {
 
 	// Let's send some coins to that address now.
 	utxo := &wire.TxOut{
 		Value:    600_000,
 		PkScript: pkScript,
 	}
-	resp, err := alice.WalletKitClient.SendOutputs(
-		ctx, &walletrpc.SendOutputsRequest{
-			Outputs: []*signrpc.TxOut{{
-				Value:    utxo.Value,
-				PkScript: utxo.PkScript,
-			}},
-			MinConfs:         0,
-			SpendUnconfirmed: true,
-			SatPerKw:         2500,
-		},
-	)
-	require.NoError(t.t, err)
+	req := &walletrpc.SendOutputsRequest{
+		Outputs: []*signrpc.TxOut{{
+			Value:    utxo.Value,
+			PkScript: utxo.PkScript,
+		}},
+		MinConfs:         0,
+		SpendUnconfirmed: true,
+		SatPerKw:         2500,
+	}
+	resp := alice.RPC.SendOutputs(req)
 
 	prevTx := wire.NewMsgTx(2)
-	err = prevTx.Deserialize(bytes.NewReader(resp.RawTx))
-	require.NoError(t.t, err)
+	err := prevTx.Deserialize(bytes.NewReader(resp.RawTx))
+	require.NoError(ht, err)
 
 	prevOut := -1
 	for idx, txOut := range prevTx.TxOut {
@@ -1036,7 +982,7 @@ func assertPsbtSpend(ctx context.Context, t *harnessTest,
 			prevOut = idx
 		}
 	}
-	require.Greater(t.t, prevOut, -1)
+	require.Greater(ht, prevOut, -1)
 
 	// Okay, we have everything we need to create a PSBT now.
 	pendingTx := &wire.MsgTx{
@@ -1054,7 +1000,7 @@ func assertPsbtSpend(ctx context.Context, t *harnessTest,
 		}},
 	}
 	packet, err := psbt.NewFromUnsignedTx(pendingTx)
-	require.NoError(t.t, err)
+	require.NoError(ht, err)
 
 	// Now let's add the meta information that we need for signing.
 	packet.Inputs[0].WitnessUtxo = utxo
@@ -1064,20 +1010,16 @@ func assertPsbtSpend(ctx context.Context, t *harnessTest,
 	// That's it, we should be able to sign the PSBT now.
 	var buf bytes.Buffer
 	err = packet.Serialize(&buf)
-	require.NoError(t.t, err)
+	require.NoError(ht, err)
 
-	signResp, err := alice.WalletKitClient.SignPsbt(
-		ctx, &walletrpc.SignPsbtRequest{
-			FundedPsbt: buf.Bytes(),
-		},
-	)
-	require.NoError(t.t, err)
+	signReq := &walletrpc.SignPsbtRequest{FundedPsbt: buf.Bytes()}
+	signResp := alice.RPC.SignPsbt(signReq)
 
 	// Let's make sure we have a partial signature.
 	signedPacket, err := psbt.NewFromRawBytes(
 		bytes.NewReader(signResp.SignedPsbt), false,
 	)
-	require.NoError(t.t, err)
+	require.NoError(ht, err)
 
 	// Allow the caller to also verify (and potentially move) some of the
 	// returned fields.
@@ -1085,87 +1027,72 @@ func assertPsbtSpend(ctx context.Context, t *harnessTest,
 
 	// We should be able to finalize the PSBT and extract the final TX now.
 	err = psbt.MaybeFinalizeAll(signedPacket)
-	require.NoError(t.t, err)
+	require.NoError(ht, err)
 
 	finalTx, err := psbt.Extract(signedPacket)
-	require.NoError(t.t, err)
+	require.NoError(ht, err)
 
 	// Make sure we can also sign a second time. This makes sure any key
 	// tweaking that happened for the signing didn't affect any keys in the
 	// cache.
-	signResp2, err := alice.WalletKitClient.SignPsbt(
-		ctx, &walletrpc.SignPsbtRequest{
-			FundedPsbt: buf.Bytes(),
-		},
-	)
-	require.NoError(t.t, err)
+	r := &walletrpc.SignPsbtRequest{FundedPsbt: buf.Bytes()}
+	signResp2 := alice.RPC.SignPsbt(r)
 	signedPacket2, err := psbt.NewFromRawBytes(
 		bytes.NewReader(signResp2.SignedPsbt), false,
 	)
-	require.NoError(t.t, err)
+	require.NoError(ht, err)
 	verifySigned(signedPacket2)
 
 	buf.Reset()
 	err = finalTx.Serialize(&buf)
-	require.NoError(t.t, err)
+	require.NoError(ht, err)
 
 	// Publish the second transaction and then mine both of them.
-	_, err = alice.WalletKitClient.PublishTransaction(
-		ctx, &walletrpc.Transaction{
-			TxHex: buf.Bytes(),
-		},
-	)
-	require.NoError(t.t, err)
+	txReq := &walletrpc.Transaction{TxHex: buf.Bytes()}
+	alice.RPC.PublishTransaction(txReq)
 
 	// Mine one block which should contain two transactions.
-	block := mineBlocks(t, net, 1, 2)[0]
+	block := ht.MineBlocksAndAssertNumTxes(1, 2)[0]
 	firstTxHash := prevTx.TxHash()
 	secondTxHash := finalTx.TxHash()
-	assertTxInBlock(t, block, &firstTxHash)
-	assertTxInBlock(t, block, &secondTxHash)
+	ht.Miner.AssertTxInBlock(block, &firstTxHash)
+	ht.Miner.AssertTxInBlock(block, &secondTxHash)
 }
 
 // assertPsbtFundSignSpend funds a PSBT from the internal wallet and then
 // attempts to sign it by using the SignPsbt or FinalizePsbt method.
-func assertPsbtFundSignSpend(ctx context.Context, t *harnessTest,
-	net *lntest.NetworkHarness, alice *lntest.HarnessNode,
+func assertPsbtFundSignSpend(ht *lntemp.HarnessTest, alice *node.HarnessNode,
 	fundOutputs map[string]uint64, useFinalize bool) {
 
-	fundResp, err := alice.WalletKitClient.FundPsbt(
-		ctx, &walletrpc.FundPsbtRequest{
-			Template: &walletrpc.FundPsbtRequest_Raw{
-				Raw: &walletrpc.TxTemplate{
-					Outputs: fundOutputs,
-				},
+	fundResp := alice.RPC.FundPsbt(&walletrpc.FundPsbtRequest{
+		Template: &walletrpc.FundPsbtRequest_Raw{
+			Raw: &walletrpc.TxTemplate{
+				Outputs: fundOutputs,
 			},
-			Fees: &walletrpc.FundPsbtRequest_SatPerVbyte{
-				SatPerVbyte: 2,
-			},
-			MinConfs: 1,
 		},
+		Fees: &walletrpc.FundPsbtRequest_SatPerVbyte{
+			SatPerVbyte: 2,
+		},
+		MinConfs: 1,
+	},
 	)
-	require.NoError(t.t, err)
-	require.GreaterOrEqual(
-		t.t, fundResp.ChangeOutputIndex, int32(-1),
-	)
+	require.GreaterOrEqual(ht, fundResp.ChangeOutputIndex, int32(-1))
 
 	var signedPsbt []byte
 	if useFinalize {
-		finalizeResp, err := alice.WalletKitClient.FinalizePsbt(
-			ctx, &walletrpc.FinalizePsbtRequest{
+		finalizeResp := alice.RPC.FinalizePsbt(
+			&walletrpc.FinalizePsbtRequest{
 				FundedPsbt: fundResp.FundedPsbt,
 			},
 		)
-		require.NoError(t.t, err)
 
 		signedPsbt = finalizeResp.SignedPsbt
 	} else {
-		signResp, err := alice.WalletKitClient.SignPsbt(
-			ctx, &walletrpc.SignPsbtRequest{
+		signResp := alice.RPC.SignPsbt(
+			&walletrpc.SignPsbtRequest{
 				FundedPsbt: fundResp.FundedPsbt,
 			},
 		)
-		require.NoError(t.t, err)
 
 		signedPsbt = signResp.SignedPsbt
 	}
@@ -1174,37 +1101,34 @@ func assertPsbtFundSignSpend(ctx context.Context, t *harnessTest,
 	signedPacket, err := psbt.NewFromRawBytes(
 		bytes.NewReader(signedPsbt), false,
 	)
-	require.NoError(t.t, err)
+	require.NoError(ht, err)
 
 	// We should be able to finalize the PSBT and extract the final
 	// TX now.
 	err = psbt.MaybeFinalizeAll(signedPacket)
-	require.NoError(t.t, err)
+	require.NoError(ht, err)
 
 	finalTx, err := psbt.Extract(signedPacket)
-	require.NoError(t.t, err)
+	require.NoError(ht, err)
 
 	var buf bytes.Buffer
 	err = finalTx.Serialize(&buf)
-	require.NoError(t.t, err)
+	require.NoError(ht, err)
 
 	// Publish the second transaction and then mine both of them.
-	_, err = alice.WalletKitClient.PublishTransaction(
-		ctx, &walletrpc.Transaction{
-			TxHex: buf.Bytes(),
-		},
-	)
-	require.NoError(t.t, err)
+	alice.RPC.PublishTransaction(&walletrpc.Transaction{
+		TxHex: buf.Bytes(),
+	})
 
-	// Mine one block which should contain two transactions.
-	block := mineBlocks(t, net, 1, 1)[0]
+	// Mine one block which should contain one transaction.
+	block := ht.MineBlocksAndAssertNumTxes(1, 1)[0]
 	finalTxHash := finalTx.TxHash()
-	assertTxInBlock(t, block, &finalTxHash)
+	ht.Miner.AssertTxInBlock(block, &finalTxHash)
 }
 
 // deriveInternalKey derives a signing key and returns its descriptor, full
 // derivation path and parsed public key.
-func deriveInternalKey(ctx context.Context, t *harnessTest,
+func deriveInternalKeyOld(ctx context.Context, t *harnessTest,
 	alice *lntest.HarnessNode) (*signrpc.KeyDescriptor, *btcec.PublicKey,
 	[]uint32) {
 
@@ -1226,6 +1150,32 @@ func deriveInternalKey(ctx context.Context, t *harnessTest,
 
 	parsedPubKey, err := btcec.ParsePubKey(keyDesc.RawKeyBytes)
 	require.NoError(t.t, err)
+
+	return keyDesc, parsedPubKey, fullDerivationPath
+}
+
+// deriveInternalKey derives a signing key and returns its descriptor, full
+// derivation path and parsed public key.
+func deriveInternalKey(ht *lntemp.HarnessTest,
+	alice *node.HarnessNode) (*signrpc.KeyDescriptor, *btcec.PublicKey,
+	[]uint32) {
+
+	// For the next step, we need a public key. Let's use a special family
+	// for this.
+	req := &walletrpc.KeyReq{KeyFamily: testTaprootKeyFamily}
+	keyDesc := alice.RPC.DeriveNextKey(req)
+
+	// The DeriveNextKey returns a key from the internal 1017 scope.
+	fullDerivationPath := []uint32{
+		hdkeychain.HardenedKeyStart + keychain.BIP0043Purpose,
+		hdkeychain.HardenedKeyStart + harnessNetParams.HDCoinType,
+		hdkeychain.HardenedKeyStart + uint32(keyDesc.KeyLoc.KeyFamily),
+		0,
+		uint32(keyDesc.KeyLoc.KeyIndex),
+	}
+
+	parsedPubKey, err := btcec.ParsePubKey(keyDesc.RawKeyBytes)
+	require.NoError(ht, err)
 
 	return keyDesc, parsedPubKey, fullDerivationPath
 }
@@ -1319,22 +1269,19 @@ func receiveChanUpdate(ctx context.Context,
 
 // sendAllCoinsToAddrType sweeps all coins from the wallet and sends them to a
 // new address of the given type.
-func sendAllCoinsToAddrType(ctx context.Context, t *harnessTest,
-	net *lntest.NetworkHarness, node *lntest.HarnessNode,
-	addrType lnrpc.AddressType) {
+func sendAllCoinsToAddrType(ht *lntemp.HarnessTest,
+	hn *node.HarnessNode, addrType lnrpc.AddressType) {
 
-	resp, err := node.NewAddress(ctx, &lnrpc.NewAddressRequest{
+	resp := hn.RPC.NewAddress(&lnrpc.NewAddressRequest{
 		Type: addrType,
 	})
-	require.NoError(t.t, err)
 
-	_, err = node.SendCoins(ctx, &lnrpc.SendCoinsRequest{
-		Addr:    resp.Address,
-		SendAll: true,
+	hn.RPC.SendCoins(&lnrpc.SendCoinsRequest{
+		Addr:             resp.Address,
+		SendAll:          true,
+		SpendUnconfirmed: true,
 	})
-	require.NoError(t.t, err)
 
-	_ = mineBlocks(t, net, 1, 1)[0]
-	err = node.WaitForBlockchainSync()
-	require.NoError(t.t, err)
+	ht.MineBlocksAndAssertNumTxes(1, 1)
+	ht.WaitForBlockchainSync(hn)
 }

--- a/lntest/itest/lnd_remote_signer_test.go
+++ b/lntest/itest/lnd_remote_signer_test.go
@@ -1,16 +1,12 @@
 package itest
 
 import (
-	"context"
-	"fmt"
 	"testing"
 
-	"github.com/btcsuite/btcd/btcutil"
 	"github.com/btcsuite/btcd/btcutil/hdkeychain"
 	"github.com/btcsuite/btcwallet/waddrmgr"
 	"github.com/lightningnetwork/lnd/keychain"
 	"github.com/lightningnetwork/lnd/lnrpc"
-	"github.com/lightningnetwork/lnd/lnrpc/walletrpc"
 	"github.com/lightningnetwork/lnd/lntest"
 	"github.com/stretchr/testify/require"
 )
@@ -55,192 +51,191 @@ var (
 // testRemoteSigner tests that a watch-only wallet can use a remote signing
 // wallet to perform any signing or ECDH operations.
 func testRemoteSigner(net *lntest.NetworkHarness, t *harnessTest) {
-	ctxb := context.Background()
+	// ctxb := context.Background()
 
-	subTests := []struct {
-		name       string
-		randomSeed bool
-		sendCoins  bool
-		fn         func(tt *harnessTest, wo, carol *lntest.HarnessNode)
-	}{{
-		name:       "random seed",
-		randomSeed: true,
-		fn: func(tt *harnessTest, wo, carol *lntest.HarnessNode) {
-			// Nothing more to test here.
-		},
-	}, {
-		name: "account import",
-		fn: func(tt *harnessTest, wo, carol *lntest.HarnessNode) {
-			runWalletImportAccountScenario(
-				net, tt,
-				walletrpc.AddressType_WITNESS_PUBKEY_HASH,
-				carol, wo,
-			)
-		},
-	}, {
-		name:      "basic channel open close",
-		sendCoins: true,
-		fn: func(tt *harnessTest, wo, carol *lntest.HarnessNode) {
-			runBasicChannelCreationAndUpdates(
-				net, tt, wo, carol,
-			)
-		},
-	}, {
-		name:      "async payments",
-		sendCoins: true,
-		fn: func(tt *harnessTest, wo, carol *lntest.HarnessNode) {
-			runAsyncPayments(net, tt, wo, carol)
-		},
-	}, {
-		name: "shared key",
-		fn: func(tt *harnessTest, wo, carol *lntest.HarnessNode) {
-			runDeriveSharedKey(tt, wo)
-		},
-	}, {
-		name:      "cpfp",
-		sendCoins: true,
-		fn: func(tt *harnessTest, wo, carol *lntest.HarnessNode) {
-			runCPFP(net, tt, wo, carol)
-		},
-	}, {
-		name:       "psbt",
-		randomSeed: true,
-		fn: func(tt *harnessTest, wo, carol *lntest.HarnessNode) {
-			runPsbtChanFunding(net, tt, carol, wo)
-			runSignPsbtSegWitV0P2WKH(tt, net, wo)
-			runSignPsbtSegWitV1KeySpendBip86(tt, net, wo)
-			runSignPsbtSegWitV1KeySpendRootHash(tt, net, wo)
-			runSignPsbtSegWitV1ScriptSpend(tt, net, wo)
-		},
-	}, {
-		name:      "sign output raw",
-		sendCoins: true,
-		fn: func(tt *harnessTest, wo, carol *lntest.HarnessNode) {
-			runSignOutputRaw(tt, net, wo)
-		},
-	}, {
-		name:      "sign verify msg",
-		sendCoins: true,
-		fn: func(tt *harnessTest, wo, carol *lntest.HarnessNode) {
-			runSignVerifyMessage(tt, net, wo)
-		},
-	}, {
-		name:       "taproot",
-		sendCoins:  true,
-		randomSeed: true,
-		fn: func(tt *harnessTest, wo, carol *lntest.HarnessNode) {
-			longTimeout := 3 * defaultTimeout
-			ctxt, cancel := context.WithTimeout(ctxb, longTimeout)
-			testTaprootSendCoinsKeySpendBip86(ctxt, tt, wo, net)
-			testTaprootComputeInputScriptKeySpendBip86(
-				ctxt, tt, wo, net,
-			)
-			testTaprootSignOutputRawScriptSpend(ctxt, tt, wo, net)
-			testTaprootSignOutputRawKeySpendBip86(ctxt, tt, wo, net)
-			testTaprootSignOutputRawKeySpendRootHash(
-				ctxt, tt, wo, net,
-			)
-			cancel()
+	// subTests := []struct {
+	// 	name       string
+	// 	randomSeed bool
+	// 	sendCoins  bool
+	// 	fn         func(tt *harnessTest, wo, carol *lntest.HarnessNode)
+	// }{{
+	// 	name:       "random seed",
+	// 	randomSeed: true,
+	// 	fn: func(tt *harnessTest, wo, carol *lntest.HarnessNode) {
+	// 		// Nothing more to test here.
+	// 	},
+	// }, {
+	// 	name: "account import",
+	// 	fn: func(tt *harnessTest, wo, carol *lntest.HarnessNode) {
+	// 		runWalletImportAccountScenario(
+	// 			net, tt,
+	// 			walletrpc.AddressType_WITNESS_PUBKEY_HASH,
+	// 			carol, wo,
+	// 		)
+	// 	},
+	// }, {
+	// 	name:      "basic channel open close",
+	// 	sendCoins: true,
+	// 	fn: func(tt *harnessTest, wo, carol *lntest.HarnessNode) {
+	// 		runBasicChannelCreationAndUpdates(
+	// 			net, tt, wo, carol,
+	// 		)
+	// 	},
+	// }, {
+	// 	name:      "async payments",
+	// 	sendCoins: true,
+	// 	fn: func(tt *harnessTest, wo, carol *lntest.HarnessNode) {
+	// 		runAsyncPayments(net, tt, wo, carol)
+	// 	},
+	// }, {
+	// 	name: "shared key",
+	// 	fn: func(tt *harnessTest, wo, carol *lntest.HarnessNode) {
+	// 		runDeriveSharedKey(tt, wo)
+	// 	},
+	// }, {
+	// 	name:      "cpfp",
+	// 	sendCoins: true,
+	// 	fn: func(tt *harnessTest, wo, carol *lntest.HarnessNode) {
+	// 		runCPFP(net, tt, wo, carol)
+	// 	},
+	// }, {
+	// 	name: "psbt",
+	//	randomSeed: true,
+	// 	fn: func(tt *harnessTest, wo, carol *lntest.HarnessNode) {
+	// 		runPsbtChanFunding(net, tt, carol, wo)
+	// 		runSignPsbtSegWitV0P2WKH(tt, net, wo)
+	// 		runSignPsbtSegWitV1KeySpendBip86(tt, net, wo)
+	// 		runSignPsbtSegWitV1KeySpendRootHash(tt, net, wo)
+	// 		runSignPsbtSegWitV1ScriptSpend(tt, net, wo)
+	// 	},
+	// }, {
+	// 	name:      "sign output raw",
+	// 	sendCoins: true,
+	// 	fn: func(tt *harnessTest, wo, carol *lntest.HarnessNode) {
+	// 		runSignOutputRaw(tt, net, wo)
+	// 	},
+	// }, {
+	// 	name:      "sign verify msg",
+	// 	sendCoins: true,
+	// 	fn: func(tt *harnessTest, wo, carol *lntest.HarnessNode) {
+	// 		runSignVerifyMessage(tt, net, wo)
+	// 	},
+	// }, {
+	// 	name:      "taproot",
+	// 	sendCoins: true,
+	//	randomSeed: true,
+	// 	fn: func(tt *harnessTest, wo, carol *lntest.HarnessNode) {
+	// 		ctxt, cancel := context.WithTimeout(
+	// 			ctxb, 3*defaultTimeout,
+	// 		)
+	// 		defer cancel()
 
-			ctxt, cancel = context.WithTimeout(ctxb, longTimeout)
-			testTaprootMuSig2KeySpendRootHash(ctxt, tt, wo, net)
-			testTaprootMuSig2ScriptSpend(ctxt, tt, wo, net)
-			testTaprootMuSig2KeySpendBip86(ctxt, tt, wo, net)
-			testTaprootMuSig2CombinedLeafKeySpend(ctxt, tt, wo, net)
-			cancel()
-		},
-	}}
+	// 		testTaprootSendCoinsKeySpendBip86(ctxt, tt, wo, net)
+	// 		testTaprootComputeInputScriptKeySpendBip86(
+	// 			ctxt, tt, wo, net,
+	// 		)
+	// 		testTaprootSignOutputRawScriptSpend(ctxt, tt, wo, net)
+	// 		testTaprootSignOutputRawKeySpendBip86(ctxt, tt, wo, net)
+	// 		testTaprootSignOutputRawKeySpendRootHash(
+	// 			ctxt, tt, wo, net,
+	// 		)
+	// 		testTaprootMuSig2KeySpendRootHash(ctxt, tt, wo, net)
+	// 		testTaprootMuSig2ScriptSpend(ctxt, tt, wo, net)
+	// 		testTaprootMuSig2KeySpendBip86(ctxt, tt, wo, net)
+	// 		testTaprootMuSig2CombinedLeafKeySpend(ctxt, tt, wo, net)
+	// 	},
+	// }}
 
-	for _, st := range subTests {
-		subTest := st
+	// for _, st := range subTests {
+	// 	subTest := st
 
-		// Signer is our signing node and has the wallet with the full
-		// master private key. We test that we can create the watch-only
-		// wallet from the exported accounts but also from a static key
-		// to make sure the derivation of the account public keys is
-		// correct in both cases.
-		password := []byte("itestpassword")
-		var (
-			signerNodePubKey  = nodePubKey
-			watchOnlyAccounts = deriveCustomScopeAccounts(t.t)
-			signer            *lntest.HarnessNode
-			err               error
-		)
-		if !subTest.randomSeed {
-			signer, err = net.RestoreNodeWithSeed(
-				"Signer", nil, password, nil, rootKey, 0, nil,
-			)
-			require.NoError(t.t, err)
-		} else {
-			signer = net.NewNode(t.t, "Signer", nil)
-			signerNodePubKey = signer.PubKeyStr
+	// 	// Signer is our signing node and has the wallet with the full
+	// 	// master private key. We test that we can create the watch-only
+	// 	// wallet from the exported accounts but also from a static key
+	// 	// to make sure the derivation of the account public keys is
+	// 	// correct in both cases.
+	// 	password := []byte("itestpassword")
+	// 	var (
+	// 		signerNodePubKey  = nodePubKey
+	// 		watchOnlyAccounts = deriveCustomScopeAccounts(t.t)
+	// 		signer            *lntest.HarnessNode
+	// 		err               error
+	// 	)
+	// 	if !subTest.randomSeed {
+	// 		signer, err = net.RestoreNodeWithSeed(
+	// 			"Signer", nil, password, nil, rootKey, 0, nil,
+	// 		)
+	// 		require.NoError(t.t, err)
+	// 	} else {
+	// 		signer = net.NewNode(t.t, "Signer", nil)
+	// 		signerNodePubKey = signer.PubKeyStr
 
-			rpcAccts, err := signer.WalletKitClient.ListAccounts(
-				ctxb, &walletrpc.ListAccountsRequest{},
-			)
-			require.NoError(t.t, err)
+	// 		rpcAccts, err := signer.WalletKitClient.ListAccounts(
+	// 			ctxb, &walletrpc.ListAccountsRequest{},
+	// 		)
+	// 		require.NoError(t.t, err)
 
-			watchOnlyAccounts, err = walletrpc.AccountsToWatchOnly(
-				rpcAccts.Accounts,
-			)
-			require.NoError(t.t, err)
-		}
+	// 		watchOnlyAccounts, err = walletrpc.AccountsToWatchOnly(
+	// 			rpcAccts.Accounts,
+	// 		)
+	// 		require.NoError(t.t, err)
+	// 	}
 
-		// WatchOnly is the node that has a watch-only wallet and uses
-		// the Signer node for any operation that requires access to
-		// private keys.
-		watchOnly, err := net.NewNodeRemoteSigner(
-			"WatchOnly", []string{
-				"--remotesigner.enable",
-				fmt.Sprintf(
-					"--remotesigner.rpchost=localhost:%d",
-					signer.Cfg.RPCPort,
-				),
-				fmt.Sprintf(
-					"--remotesigner.tlscertpath=%s",
-					signer.Cfg.TLSCertPath,
-				),
-				fmt.Sprintf(
-					"--remotesigner.macaroonpath=%s",
-					signer.Cfg.AdminMacPath,
-				),
-			}, password, &lnrpc.WatchOnly{
-				MasterKeyBirthdayTimestamp: 0,
-				MasterKeyFingerprint:       nil,
-				Accounts:                   watchOnlyAccounts,
-			},
-		)
-		require.NoError(t.t, err)
+	// 	// WatchOnly is the node that has a watch-only wallet and uses
+	// 	// the Signer node for any operation that requires access to
+	// 	// private keys.
+	// 	watchOnly, err := net.NewNodeRemoteSigner(
+	// 		"WatchOnly", []string{
+	// 			"--remotesigner.enable",
+	// 			fmt.Sprintf(
+	// 				"--remotesigner.rpchost=localhost:%d",
+	// 				signer.Cfg.RPCPort,
+	// 			),
+	// 			fmt.Sprintf(
+	// 				"--remotesigner.tlscertpath=%s",
+	// 				signer.Cfg.TLSCertPath,
+	// 			),
+	// 			fmt.Sprintf(
+	// 				"--remotesigner.macaroonpath=%s",
+	// 				signer.Cfg.AdminMacPath,
+	// 			),
+	// 		}, password, &lnrpc.WatchOnly{
+	// 			MasterKeyBirthdayTimestamp: 0,
+	// 			MasterKeyFingerprint:       nil,
+	// 			Accounts:                   watchOnlyAccounts,
+	// 		},
+	// 	)
+	// 	require.NoError(t.t, err)
 
-		resp, err := watchOnly.GetInfo(ctxb, &lnrpc.GetInfoRequest{})
-		require.NoError(t.t, err)
+	// 	resp, err := watchOnly.GetInfo(ctxb, &lnrpc.GetInfoRequest{})
+	// 	require.NoError(t.t, err)
 
-		require.Equal(t.t, signerNodePubKey, resp.IdentityPubkey)
+	// 	require.Equal(t.t, signerNodePubKey, resp.IdentityPubkey)
 
-		if subTest.sendCoins {
-			net.SendCoins(t.t, btcutil.SatoshiPerBitcoin, watchOnly)
-			assertAccountBalance(
-				t.t, watchOnly, "default",
-				btcutil.SatoshiPerBitcoin, 0,
-			)
-		}
+	// 	if subTest.sendCoins {
+	// 		net.SendCoins(t.t, btcutil.SatoshiPerBitcoin, watchOnly)
+	// 		assertAccountBalance(
+	// 			t.t, watchOnly, "default",
+	// 			btcutil.SatoshiPerBitcoin, 0,
+	// 		)
+	// 	}
 
-		carol := net.NewNode(t.t, "carol", nil)
-		net.EnsureConnected(t.t, watchOnly, carol)
+	// 	carol := net.NewNode(t.t, "carol", nil)
+	// 	net.EnsureConnected(t.t, watchOnly, carol)
 
-		success := t.t.Run(subTest.name, func(tt *testing.T) {
-			ht := newHarnessTest(tt, net)
-			subTest.fn(ht, watchOnly, carol)
-		})
+	// 	success := t.t.Run(subTest.name, func(tt *testing.T) {
+	// 		ht := newHarnessTest(tt, net)
+	// 		subTest.fn(ht, watchOnly, carol)
+	// 	})
 
-		shutdownAndAssert(net, t, carol)
-		shutdownAndAssert(net, t, watchOnly)
-		shutdownAndAssert(net, t, signer)
+	// 	shutdownAndAssert(net, t, carol)
+	// 	shutdownAndAssert(net, t, watchOnly)
+	// 	shutdownAndAssert(net, t, signer)
 
-		if !success {
-			return
-		}
-	}
+	// 	if !success {
+	// 		return
+	// 	}
+	// }
 }
 
 // deriveCustomScopeAccounts derives the first 255 default accounts of the custom lnd

--- a/lntest/itest/lnd_rpc_middleware_interceptor_test.go
+++ b/lntest/itest/lnd_rpc_middleware_interceptor_test.go
@@ -560,7 +560,7 @@ func middlewareMandatoryTest(ht *lntemp.HarnessTest, node *node.HarnessNode) {
 	// test case. So we need to do the wait and client setup manually here.
 	conn, err := node.ConnectRPC()
 	require.NoError(ht, err)
-	node.InitRPCClients(conn)
+	node.Initialize(conn)
 	err = node.WaitUntilServerActive()
 	require.NoError(ht, err)
 

--- a/lntest/itest/lnd_signer_test.go
+++ b/lntest/itest/lnd_signer_test.go
@@ -389,6 +389,7 @@ func runSignVerifyMessage(ht *lntemp.HarnessTest, alice *node.HarnessNode) {
 		resp := alice.RPC.DeriveKey(keyLoc)
 		pub, err := btcec.ParsePubKey(resp.RawKeyBytes)
 		require.NoError(ht, err, "failed to parse node pubkey")
+
 		return pub
 	}
 

--- a/lntest/itest/lnd_switch_test.go
+++ b/lntest/itest/lnd_switch_test.go
@@ -1,8 +1,6 @@
 package itest
 
 import (
-	"context"
-
 	"github.com/btcsuite/btcd/btcutil"
 	"github.com/btcsuite/btcd/wire"
 	"github.com/lightningnetwork/lnd/lnrpc"
@@ -10,6 +8,7 @@ import (
 	"github.com/lightningnetwork/lnd/lntemp/node"
 	"github.com/lightningnetwork/lnd/lntest"
 	"github.com/lightningnetwork/lnd/lntest/wait"
+	"github.com/stretchr/testify/require"
 )
 
 const (
@@ -178,214 +177,48 @@ func testSwitchOfflineDelivery(ht *lntemp.HarnessTest) {
 //  3. Carol --- Dave  X  Alice <-- Bob  settle last hop
 //  4. Carol --- Dave  X         X  Bob  restart Alice
 //  5. Carol <-- Dave <-- Alice --- Bob  expect settle to propagate
-func testSwitchOfflineDeliveryPersistence(net *lntest.NetworkHarness, t *harnessTest) {
-	ctxb := context.Background()
-
-	const chanAmt = btcutil.Amount(1000000)
-	const pushAmt = btcutil.Amount(900000)
-	var networkChans []*lnrpc.ChannelPoint
-
-	// Open a channel with 100k satoshis between Alice and Bob with Alice
-	// being the sole funder of the channel.
-	chanPointAlice := openChannelAndAssert(
-		t, net, net.Alice, net.Bob,
-		lntest.OpenChannelParams{
-			Amt:     chanAmt,
-			PushAmt: pushAmt,
-		},
-	)
-	networkChans = append(networkChans, chanPointAlice)
-
-	aliceChanTXID, err := lnrpc.GetChanPointFundingTxid(chanPointAlice)
-	if err != nil {
-		t.Fatalf("unable to get txid: %v", err)
-	}
-	aliceFundPoint := wire.OutPoint{
-		Hash:  *aliceChanTXID,
-		Index: chanPointAlice.OutputIndex,
-	}
-
-	// As preliminary setup, we'll create two new nodes: Carol and Dave,
-	// such that we now have a 4 ndoe, 3 channel topology. Dave will make
-	// a channel with Alice, and Carol with Dave. After this setup, the
-	// network topology should now look like:
-	//     Carol -> Dave -> Alice -> Bob
-	//
-	// First, we'll create Dave and establish a channel to Alice.
-	dave := net.NewNode(t.t, "Dave", nil)
-	defer shutdownAndAssert(net, t, dave)
-
-	net.ConnectNodes(t.t, dave, net.Alice)
-	net.SendCoins(t.t, btcutil.SatoshiPerBitcoin, dave)
-
-	chanPointDave := openChannelAndAssert(
-		t, net, dave, net.Alice,
-		lntest.OpenChannelParams{
-			Amt:     chanAmt,
-			PushAmt: pushAmt,
-		},
-	)
-
-	networkChans = append(networkChans, chanPointDave)
-	daveChanTXID, err := lnrpc.GetChanPointFundingTxid(chanPointDave)
-	if err != nil {
-		t.Fatalf("unable to get txid: %v", err)
-	}
-	daveFundPoint := wire.OutPoint{
-		Hash:  *daveChanTXID,
-		Index: chanPointDave.OutputIndex,
-	}
-
-	// Next, we'll create Carol and establish a channel to from her to
-	// Dave. Carol is started in htlchodl mode so that we can disconnect the
-	// intermediary hops before starting the settle.
-	carol := net.NewNode(t.t, "Carol", []string{"--hodl.exit-settle"})
-	defer shutdownAndAssert(net, t, carol)
-
-	net.ConnectNodes(t.t, carol, dave)
-	net.SendCoins(t.t, btcutil.SatoshiPerBitcoin, carol)
-
-	chanPointCarol := openChannelAndAssert(
-		t, net, carol, dave,
-		lntest.OpenChannelParams{
-			Amt:     chanAmt,
-			PushAmt: pushAmt,
-		},
-	)
-	networkChans = append(networkChans, chanPointCarol)
-
-	carolChanTXID, err := lnrpc.GetChanPointFundingTxid(chanPointCarol)
-	if err != nil {
-		t.Fatalf("unable to get txid: %v", err)
-	}
-	carolFundPoint := wire.OutPoint{
-		Hash:  *carolChanTXID,
-		Index: chanPointCarol.OutputIndex,
-	}
-
-	// Wait for all nodes to have seen all channels.
-	nodes := []*lntest.HarnessNode{net.Alice, net.Bob, carol, dave}
-	nodeNames := []string{"Alice", "Bob", "Carol", "Dave"}
-	for _, chanPoint := range networkChans {
-		for i, node := range nodes {
-			txid, err := lnrpc.GetChanPointFundingTxid(chanPoint)
-			if err != nil {
-				t.Fatalf("unable to get txid: %v", err)
-			}
-			point := wire.OutPoint{
-				Hash:  *txid,
-				Index: chanPoint.OutputIndex,
-			}
-
-			err = node.WaitForNetworkChannelOpen(chanPoint)
-			if err != nil {
-				t.Fatalf("%s(%d): timeout waiting for "+
-					"channel(%s) open: %v", nodeNames[i],
-					node.NodeID, point, err)
-			}
-		}
-	}
-
-	// Create 5 invoices for Carol, which expect a payment from Bob for 1k
-	// satoshis with a different preimage each time.
-	const numPayments = 5
-	const paymentAmt = 1000
-	payReqs, _, _, err := createPayReqs(
-		carol, paymentAmt, numPayments,
-	)
-	if err != nil {
-		t.Fatalf("unable to create pay reqs: %v", err)
-	}
-
-	// We'll wait for all parties to recognize the new channels within the
-	// network.
-	err = dave.WaitForNetworkChannelOpen(chanPointDave)
-	if err != nil {
-		t.Fatalf("dave didn't advertise his channel: %v", err)
-	}
-	err = carol.WaitForNetworkChannelOpen(chanPointCarol)
-	if err != nil {
-		t.Fatalf("carol didn't advertise her channel in time: %v",
-			err)
-	}
-
-	// Using Carol as the source, pay to the 5 invoices from Bob created
-	// above.
-	err = completePaymentRequests(
-		net.Bob, net.Bob.RouterClient, payReqs, false,
-	)
-	if err != nil {
-		t.Fatalf("unable to send payments: %v", err)
-	}
-
-	var predErr error
-	err = wait.Predicate(func() bool {
-		predErr = assertNumActiveHtlcs(nodes, numPayments)
-		return predErr == nil
-	}, defaultTimeout)
-	if err != nil {
-		t.Fatalf("htlc mismatch: %v", predErr)
-	}
+func testSwitchOfflineDeliveryPersistence(ht *lntemp.HarnessTest) {
+	// Setup our test scenario. We should now have four nodes running with
+	// three channels.
+	s := setupScenarioFourNodes(ht)
+	defer s.cleanUp()
 
 	// Disconnect the two intermediaries, Alice and Dave, by shutting down
 	// Alice.
-	if err := net.StopNode(net.Alice); err != nil {
-		t.Fatalf("unable to shutdown alice: %v", err)
-	}
+	restartAlice := ht.SuspendNode(s.alice)
 
 	// Now restart carol without hodl mode, to settle back the outstanding
 	// payments.
-	carol.SetExtraArgs(nil)
-	if err := net.RestartNode(carol, nil); err != nil {
-		t.Fatalf("Node restart failed: %v", err)
-	}
+	s.carol.SetExtraArgs(nil)
+	ht.RestartNode(s.carol)
 
 	// Make Carol and Dave are reconnected before waiting for the htlcs to
 	// clear.
-	net.EnsureConnected(t.t, dave, carol)
+	ht.EnsureConnected(s.dave, s.carol)
 
-	// Wait for Carol to report no outstanding htlcs, and also for Dav to
+	// Wait for Carol to report no outstanding htlcs, and also for Dave to
 	// receive all the settles from Carol.
-	carolNode := []*lntest.HarnessNode{carol}
-	err = wait.Predicate(func() bool {
-		predErr = assertNumActiveHtlcs(carolNode, 0)
-		if predErr != nil {
-			return false
-		}
-
-		predErr = assertNumActiveHtlcsChanPoint(dave, carolFundPoint, 0)
-		return predErr == nil
-	}, defaultTimeout)
-	if err != nil {
-		t.Fatalf("htlc mismatch: %v", predErr)
-	}
+	ht.AssertNumActiveHtlcs(s.carol, 0)
+	// As an intermediate node, Dave should now have zero outgoing HTLCs
+	// and 5 incoming HTLCs from Alice.
+	ht.AssertNumActiveHtlcs(s.dave, numPayments)
 
 	// Finally, restart dave who received the settles, but was unable to
 	// deliver them to Alice since they were disconnected.
-	if err := net.RestartNode(dave, nil); err != nil {
-		t.Fatalf("unable to restart dave: %v", err)
-	}
-	if err = net.RestartNode(net.Alice, nil); err != nil {
-		t.Fatalf("unable to restart alice: %v", err)
-	}
+	ht.RestartNode(s.dave)
+	require.NoError(ht, restartAlice(), "restart alice failed")
 
 	// Force Dave and Alice to reconnect before waiting for the htlcs to
 	// clear.
-	net.EnsureConnected(t.t, dave, net.Alice)
+	ht.EnsureConnected(s.dave, s.alice)
 
 	// After reconnection succeeds, the settles should be propagated all
 	// the way back to the sender. All nodes should report no active htlcs.
-	err = wait.Predicate(func() bool {
-		return assertNumActiveHtlcs(nodes, 0) == nil
-	}, defaultTimeout)
-	if err != nil {
-		t.Fatalf("htlc mismatch: %v", predErr)
-	}
+	s.assertHTLCs(ht, 0)
 
 	// When asserting the amount of satoshis moved, we'll factor in the
 	// default base fee, as we didn't modify the fee structure when
 	// creating the seed nodes in the network.
-	const baseFee = 1
 
 	// At this point all the channels within our proto network should be
 	// shifted by 5k satoshis in the direction of Carol, the sink within the
@@ -394,18 +227,7 @@ func testSwitchOfflineDeliveryPersistence(net *lntest.NetworkHarness, t *harness
 	// transaction, in channel Bob->Alice->David->Carol, order is Carol,
 	// David, Alice, Bob.
 	var amountPaid = int64(5000)
-	assertAmountPaid(t, "Dave(local) => Carol(remote)", carol,
-		carolFundPoint, int64(0), amountPaid)
-	assertAmountPaid(t, "Dave(local) => Carol(remote)", dave,
-		carolFundPoint, amountPaid, int64(0))
-	assertAmountPaid(t, "Alice(local) => Dave(remote)", dave,
-		daveFundPoint, int64(0), amountPaid+(baseFee*numPayments))
-	assertAmountPaid(t, "Alice(local) => Dave(remote)", net.Alice,
-		daveFundPoint, amountPaid+(baseFee*numPayments), int64(0))
-	assertAmountPaid(t, "Bob(local) => Alice(remote)", net.Alice,
-		aliceFundPoint, int64(0), amountPaid+((baseFee*numPayments)*2))
-	assertAmountPaid(t, "Bob(local) => Alice(remote)", net.Bob,
-		aliceFundPoint, amountPaid+(baseFee*numPayments)*2, int64(0))
+	s.assertAmoutPaid(ht, amountPaid, numPayments)
 
 	// Lastly, we will send one more payment to ensure all channels are
 	// still functioning properly.
@@ -413,44 +235,19 @@ func testSwitchOfflineDeliveryPersistence(net *lntest.NetworkHarness, t *harness
 		Memo:  "testing",
 		Value: paymentAmt,
 	}
-	ctxt, _ := context.WithTimeout(ctxb, defaultTimeout)
-	resp, err := carol.AddInvoice(ctxt, finalInvoice)
-	if err != nil {
-		t.Fatalf("unable to add invoice: %v", err)
-	}
-
-	payReqs = []string{resp.PaymentRequest}
+	resp := s.carol.RPC.AddInvoice(finalInvoice)
+	payReqs := []string{resp.PaymentRequest}
 
 	// Before completing the final payment request, ensure that the
 	// connection between Dave and Carol has been healed.
-	net.EnsureConnected(t.t, dave, carol)
+	ht.EnsureConnected(s.dave, s.carol)
 
 	// Using Carol as the source, pay to the 5 invoices from Bob created
 	// above.
-	err = completePaymentRequests(
-		net.Bob, net.Bob.RouterClient, payReqs, true,
-	)
-	if err != nil {
-		t.Fatalf("unable to send payments: %v", err)
-	}
+	ht.CompletePaymentRequests(s.bob, payReqs)
 
 	amountPaid = int64(6000)
-	assertAmountPaid(t, "Dave(local) => Carol(remote)", carol,
-		carolFundPoint, int64(0), amountPaid)
-	assertAmountPaid(t, "Dave(local) => Carol(remote)", dave,
-		carolFundPoint, amountPaid, int64(0))
-	assertAmountPaid(t, "Alice(local) => Dave(remote)", dave,
-		daveFundPoint, int64(0), amountPaid+(baseFee*(numPayments+1)))
-	assertAmountPaid(t, "Alice(local) => Dave(remote)", net.Alice,
-		daveFundPoint, amountPaid+(baseFee*(numPayments+1)), int64(0))
-	assertAmountPaid(t, "Bob(local) => Alice(remote)", net.Alice,
-		aliceFundPoint, int64(0), amountPaid+((baseFee*(numPayments+1))*2))
-	assertAmountPaid(t, "Bob(local) => Alice(remote)", net.Bob,
-		aliceFundPoint, amountPaid+(baseFee*(numPayments+1))*2, int64(0))
-
-	closeChannelAndAssert(t, net, net.Alice, chanPointAlice, false)
-	closeChannelAndAssert(t, net, dave, chanPointDave, false)
-	closeChannelAndAssert(t, net, carol, chanPointCarol, false)
+	s.assertAmoutPaid(ht, amountPaid, numPayments+1)
 }
 
 // testSwitchOfflineDeliveryOutgoingOffline constructs a set of multihop payments,

--- a/lntest/itest/lnd_switch_test.go
+++ b/lntest/itest/lnd_switch_test.go
@@ -2,14 +2,21 @@ package itest
 
 import (
 	"context"
-	"time"
 
 	"github.com/btcsuite/btcd/btcutil"
 	"github.com/btcsuite/btcd/wire"
 	"github.com/lightningnetwork/lnd/lnrpc"
+	"github.com/lightningnetwork/lnd/lntemp"
+	"github.com/lightningnetwork/lnd/lntemp/node"
 	"github.com/lightningnetwork/lnd/lntest"
 	"github.com/lightningnetwork/lnd/lntest/wait"
 	"github.com/stretchr/testify/require"
+)
+
+const (
+	numPayments = 5
+	paymentAmt  = 1000
+	baseFee     = 1
 )
 
 // testSwitchCircuitPersistence creates a multihop network to ensure the sender
@@ -19,228 +26,51 @@ import (
 //
 // The general flow of this test:
 //  1. Carol --> Dave --> Alice --> Bob  forward payment
-//  2. X        X         X  Bob  restart sender and intermediaries
+//  2. -------X       X         X   Bob  restart sender and intermediaries
 //  3. Carol <-- Dave <-- Alice <-- Bob  expect settle to propagate
-func testSwitchCircuitPersistence(net *lntest.NetworkHarness, t *harnessTest) {
-	ctxb := context.Background()
-
-	const chanAmt = btcutil.Amount(1000000)
-	const pushAmt = btcutil.Amount(900000)
-	var networkChans []*lnrpc.ChannelPoint
-
-	// Open a channel with 100k satoshis between Alice and Bob with Alice
-	// being the sole funder of the channel.
-	chanPointAlice := openChannelAndAssert(
-		t, net, net.Alice, net.Bob,
-		lntest.OpenChannelParams{
-			Amt:     chanAmt,
-			PushAmt: pushAmt,
-		},
-	)
-	networkChans = append(networkChans, chanPointAlice)
-
-	aliceChanTXID, err := lnrpc.GetChanPointFundingTxid(chanPointAlice)
-	if err != nil {
-		t.Fatalf("unable to get txid: %v", err)
-	}
-	aliceFundPoint := wire.OutPoint{
-		Hash:  *aliceChanTXID,
-		Index: chanPointAlice.OutputIndex,
-	}
-
-	// As preliminary setup, we'll create two new nodes: Carol and Dave,
-	// such that we now have a 4 ndoe, 3 channel topology. Dave will make
-	// a channel with Alice, and Carol with Dave. After this setup, the
-	// network topology should now look like:
-	//     Carol -> Dave -> Alice -> Bob
-	//
-	// First, we'll create Dave and establish a channel to Alice.
-	dave := net.NewNode(t.t, "Dave", nil)
-	defer shutdownAndAssert(net, t, dave)
-
-	net.ConnectNodes(t.t, dave, net.Alice)
-	net.SendCoins(t.t, btcutil.SatoshiPerBitcoin, dave)
-
-	chanPointDave := openChannelAndAssert(
-		t, net, dave, net.Alice,
-		lntest.OpenChannelParams{
-			Amt:     chanAmt,
-			PushAmt: pushAmt,
-		},
-	)
-	networkChans = append(networkChans, chanPointDave)
-	daveChanTXID, err := lnrpc.GetChanPointFundingTxid(chanPointDave)
-	if err != nil {
-		t.Fatalf("unable to get txid: %v", err)
-	}
-	daveFundPoint := wire.OutPoint{
-		Hash:  *daveChanTXID,
-		Index: chanPointDave.OutputIndex,
-	}
-
-	// Next, we'll create Carol and establish a channel to from her to
-	// Dave. Carol is started in htlchodl mode so that we can disconnect the
-	// intermediary hops before starting the settle.
-	carol := net.NewNode(t.t, "Carol", []string{"--hodl.exit-settle"})
-	defer shutdownAndAssert(net, t, carol)
-
-	net.ConnectNodes(t.t, carol, dave)
-	net.SendCoins(t.t, btcutil.SatoshiPerBitcoin, carol)
-
-	chanPointCarol := openChannelAndAssert(
-		t, net, carol, dave,
-		lntest.OpenChannelParams{
-			Amt:     chanAmt,
-			PushAmt: pushAmt,
-		},
-	)
-	networkChans = append(networkChans, chanPointCarol)
-
-	carolChanTXID, err := lnrpc.GetChanPointFundingTxid(chanPointCarol)
-	if err != nil {
-		t.Fatalf("unable to get txid: %v", err)
-	}
-	carolFundPoint := wire.OutPoint{
-		Hash:  *carolChanTXID,
-		Index: chanPointCarol.OutputIndex,
-	}
-
-	// Wait for all nodes to have seen all channels.
-	nodes := []*lntest.HarnessNode{net.Alice, net.Bob, carol, dave}
-	nodeNames := []string{"Alice", "Bob", "Carol", "Dave"}
-	for _, chanPoint := range networkChans {
-		for i, node := range nodes {
-			txid, err := lnrpc.GetChanPointFundingTxid(chanPoint)
-			if err != nil {
-				t.Fatalf("unable to get txid: %v", err)
-			}
-			point := wire.OutPoint{
-				Hash:  *txid,
-				Index: chanPoint.OutputIndex,
-			}
-
-			err = node.WaitForNetworkChannelOpen(chanPoint)
-			if err != nil {
-				t.Fatalf("%s(%d): timeout waiting for "+
-					"channel(%s) open: %v", nodeNames[i],
-					node.NodeID, point, err)
-			}
-		}
-	}
-
-	// Create 5 invoices for Carol, which expect a payment from Bob for 1k
-	// satoshis with a different preimage each time.
-	const numPayments = 5
-	const paymentAmt = 1000
-	payReqs, _, _, err := createPayReqs(
-		carol, paymentAmt, numPayments,
-	)
-	if err != nil {
-		t.Fatalf("unable to create pay reqs: %v", err)
-	}
-
-	// We'll wait for all parties to recognize the new channels within the
-	// network.
-	err = dave.WaitForNetworkChannelOpen(chanPointDave)
-	if err != nil {
-		t.Fatalf("dave didn't advertise his channel: %v", err)
-	}
-	err = carol.WaitForNetworkChannelOpen(chanPointCarol)
-	if err != nil {
-		t.Fatalf("carol didn't advertise her channel in time: %v",
-			err)
-	}
-
-	time.Sleep(time.Millisecond * 50)
-
-	// Using Carol as the source, pay to the 5 invoices from Bob created
-	// above.
-	err = completePaymentRequests(
-		net.Bob, net.Bob.RouterClient, payReqs, false,
-	)
-	if err != nil {
-		t.Fatalf("unable to send payments: %v", err)
-	}
-
-	// Wait until all nodes in the network have 5 outstanding htlcs.
-	var predErr error
-	err = wait.Predicate(func() bool {
-		predErr = assertNumActiveHtlcs(nodes, numPayments)
-		return predErr == nil
-	}, defaultTimeout)
-	if err != nil {
-		t.Fatalf("htlc mismatch: %v", predErr)
-	}
+//
+//nolint:dupword
+func testSwitchCircuitPersistence(ht *lntemp.HarnessTest) {
+	// Setup our test scenario. We should now have four nodes running with
+	// three channels.
+	s := setupScenarioFourNodes(ht)
+	defer s.cleanUp()
 
 	// Restart the intermediaries and the sender.
-	if err := net.RestartNode(dave, nil); err != nil {
-		t.Fatalf("Node restart failed: %v", err)
-	}
-
-	if err := net.RestartNode(net.Alice, nil); err != nil {
-		t.Fatalf("Node restart failed: %v", err)
-	}
-
-	if err := net.RestartNode(net.Bob, nil); err != nil {
-		t.Fatalf("Node restart failed: %v", err)
-	}
+	ht.RestartNode(s.dave)
+	ht.RestartNode(s.alice)
+	ht.RestartNode(s.bob)
 
 	// Ensure all of the intermediate links are reconnected.
-	net.EnsureConnected(t.t, net.Alice, dave)
-	net.EnsureConnected(t.t, net.Bob, net.Alice)
+	ht.EnsureConnected(s.alice, s.dave)
+	ht.EnsureConnected(s.bob, s.alice)
 
 	// Ensure all nodes in the network still have 5 outstanding htlcs.
-	err = wait.Predicate(func() bool {
-		predErr = assertNumActiveHtlcs(nodes, numPayments)
-		return predErr == nil
-	}, defaultTimeout)
-	if err != nil {
-		t.Fatalf("htlc mismatch: %v", predErr)
-	}
+	s.assertHTLCs(ht, numPayments)
 
 	// Now restart carol without hodl mode, to settle back the outstanding
 	// payments.
-	carol.SetExtraArgs(nil)
-	if err := net.RestartNode(carol, nil); err != nil {
-		t.Fatalf("Node restart failed: %v", err)
-	}
+	s.carol.SetExtraArgs(nil)
+	ht.RestartNode(s.carol)
 
-	net.EnsureConnected(t.t, dave, carol)
+	ht.EnsureConnected(s.dave, s.carol)
 
 	// After the payments settle, there should be no active htlcs on any of
 	// the nodes in the network.
-	err = wait.Predicate(func() bool {
-		predErr = assertNumActiveHtlcs(nodes, 0)
-		return predErr == nil
-	}, defaultTimeout)
-	if err != nil {
-		t.Fatalf("htlc mismatch: %v", predErr)
-	}
+	s.assertHTLCs(ht, 0)
 
 	// When asserting the amount of satoshis moved, we'll factor in the
 	// default base fee, as we didn't modify the fee structure when
 	// creating the seed nodes in the network.
-	const baseFee = 1
 
 	// At this point all the channels within our proto network should be
-	// shifted by 5k satoshis in the direction of Carol, the sink within the
-	// payment flow generated above. The order of asserts corresponds to
-	// increasing of time is needed to embed the HTLC in commitment
+	// shifted by 5k satoshis in the direction of Carol, the sink within
+	// the payment flow generated above. The order of asserts corresponds
+	// to increasing of time is needed to embed the HTLC in commitment
 	// transaction, in channel Bob->Alice->David->Carol, order is Carol,
 	// David, Alice, Bob.
 	var amountPaid = int64(5000)
-	assertAmountPaid(t, "Dave(local) => Carol(remote)", carol,
-		carolFundPoint, int64(0), amountPaid)
-	assertAmountPaid(t, "Dave(local) => Carol(remote)", dave,
-		carolFundPoint, amountPaid, int64(0))
-	assertAmountPaid(t, "Alice(local) => Dave(remote)", dave,
-		daveFundPoint, int64(0), amountPaid+(baseFee*numPayments))
-	assertAmountPaid(t, "Alice(local) => Dave(remote)", net.Alice,
-		daveFundPoint, amountPaid+(baseFee*numPayments), int64(0))
-	assertAmountPaid(t, "Bob(local) => Alice(remote)", net.Alice,
-		aliceFundPoint, int64(0), amountPaid+((baseFee*numPayments)*2))
-	assertAmountPaid(t, "Bob(local) => Alice(remote)", net.Bob,
-		aliceFundPoint, amountPaid+(baseFee*numPayments)*2, int64(0))
+	s.assertAmoutPaid(ht, amountPaid, numPayments)
 
 	// Lastly, we will send one more payment to ensure all channels are
 	// still functioning properly.
@@ -248,40 +78,15 @@ func testSwitchCircuitPersistence(net *lntest.NetworkHarness, t *harnessTest) {
 		Memo:  "testing",
 		Value: paymentAmt,
 	}
-	ctxt, _ := context.WithTimeout(ctxb, defaultTimeout)
-	resp, err := carol.AddInvoice(ctxt, finalInvoice)
-	if err != nil {
-		t.Fatalf("unable to add invoice: %v", err)
-	}
-
-	payReqs = []string{resp.PaymentRequest}
+	resp := s.carol.RPC.AddInvoice(finalInvoice)
+	payReqs := []string{resp.PaymentRequest}
 
 	// Using Carol as the source, pay to the 5 invoices from Bob created
 	// above.
-	err = completePaymentRequests(
-		net.Bob, net.Bob.RouterClient, payReqs, true,
-	)
-	if err != nil {
-		t.Fatalf("unable to send payments: %v", err)
-	}
+	ht.CompletePaymentRequests(s.bob, payReqs)
 
 	amountPaid = int64(6000)
-	assertAmountPaid(t, "Dave(local) => Carol(remote)", carol,
-		carolFundPoint, int64(0), amountPaid)
-	assertAmountPaid(t, "Dave(local) => Carol(remote)", dave,
-		carolFundPoint, amountPaid, int64(0))
-	assertAmountPaid(t, "Alice(local) => Dave(remote)", dave,
-		daveFundPoint, int64(0), amountPaid+(baseFee*(numPayments+1)))
-	assertAmountPaid(t, "Alice(local) => Dave(remote)", net.Alice,
-		daveFundPoint, amountPaid+(baseFee*(numPayments+1)), int64(0))
-	assertAmountPaid(t, "Bob(local) => Alice(remote)", net.Alice,
-		aliceFundPoint, int64(0), amountPaid+((baseFee*(numPayments+1))*2))
-	assertAmountPaid(t, "Bob(local) => Alice(remote)", net.Bob,
-		aliceFundPoint, amountPaid+(baseFee*(numPayments+1))*2, int64(0))
-
-	closeChannelAndAssert(t, net, net.Alice, chanPointAlice, false)
-	closeChannelAndAssert(t, net, dave, chanPointDave, false)
-	closeChannelAndAssert(t, net, carol, chanPointCarol, false)
+	s.assertAmoutPaid(ht, amountPaid, numPayments+1)
 }
 
 // testSwitchOfflineDelivery constructs a set of multihop payments, and tests
@@ -1133,4 +938,165 @@ func testSwitchOfflineDeliveryOutgoingOffline(
 
 	closeChannelAndAssert(t, net, net.Alice, chanPointAlice, false)
 	closeChannelAndAssert(t, net, dave, chanPointDave, false)
+}
+
+// scenarioFourNodes specifies a scenario which we have a topology that has
+// four nodes and three channels.
+type scenarioFourNodes struct {
+	alice *node.HarnessNode
+	bob   *node.HarnessNode
+	carol *node.HarnessNode
+	dave  *node.HarnessNode
+
+	chanPointAliceBob  *lnrpc.ChannelPoint
+	chanPointCarolDave *lnrpc.ChannelPoint
+	chanPointDaveAlice *lnrpc.ChannelPoint
+
+	cleanUp func()
+}
+
+// setupScenarioFourNodes creates a topology for switch tests. It will create
+// two new nodes: Carol and Dave, such that there will be a 4 nodes, 3 channel
+// topology. Dave will make a channel with Alice, and Carol with Dave. After
+// this setup, the network topology should now look like:
+//
+//	Carol -> Dave -> Alice -> Bob
+//
+// Once the network is created, Carol will generate 5 invoices and Bob will pay
+// them using the above path.
+//
+// NOTE: caller needs to call cleanUp to clean the nodes and channels created
+// from this setup.
+func setupScenarioFourNodes(ht *lntemp.HarnessTest) *scenarioFourNodes {
+	const (
+		chanAmt = btcutil.Amount(1000000)
+		pushAmt = btcutil.Amount(900000)
+	)
+
+	params := lntemp.OpenChannelParams{
+		Amt:     chanAmt,
+		PushAmt: pushAmt,
+	}
+
+	// Grab the standby nodes.
+	alice, bob := ht.Alice, ht.Bob
+
+	// As preliminary setup, we'll create two new nodes: Carol and Dave,
+	// such that we now have a 4 node, 3 channel topology. Dave will make
+	// a channel with Alice, and Carol with Dave. After this setup, the
+	// network topology should now look like:
+	//     Carol -> Dave -> Alice -> Bob
+	//
+	// First, we'll create Dave and establish a channel to Alice.
+	dave := ht.NewNode("Dave", nil)
+	ht.ConnectNodes(dave, alice)
+	ht.FundCoins(btcutil.SatoshiPerBitcoin, dave)
+
+	// Next, we'll create Carol and establish a channel to from her to
+	// Dave. Carol is started in htlchodl mode so that we can disconnect
+	// the intermediary hops before starting the settle.
+	carol := ht.NewNode("Carol", []string{"--hodl.exit-settle"})
+	ht.ConnectNodes(carol, dave)
+	ht.FundCoins(btcutil.SatoshiPerBitcoin, carol)
+
+	// Open channels in batch to save blocks mined.
+	reqs := []*lntemp.OpenChannelRequest{
+		{Local: alice, Remote: bob, Param: params},
+		{Local: dave, Remote: alice, Param: params},
+		{Local: carol, Remote: dave, Param: params},
+	}
+	resp := ht.OpenMultiChannelsAsync(reqs)
+
+	// Wait for all nodes to have seen all channels.
+	nodes := []*node.HarnessNode{alice, bob, carol, dave}
+	for _, chanPoint := range resp {
+		for _, node := range nodes {
+			ht.AssertTopologyChannelOpen(node, chanPoint)
+		}
+	}
+
+	chanPointAliceBob := resp[0]
+	chanPointDaveAlice := resp[1]
+	chanPointCarolDave := resp[2]
+
+	// Create 5 invoices for Carol, which expect a payment from Bob for 1k
+	// satoshis with a different preimage each time.
+	payReqs, _, _ := ht.CreatePayReqs(carol, paymentAmt, numPayments)
+
+	// Using Carol as the source, pay to the 5 invoices from Bob created
+	// above.
+	ht.CompletePaymentRequestsNoWait(bob, payReqs, chanPointAliceBob)
+
+	// Create a cleanUp to wipe the states.
+	cleanUp := func() {
+		if ht.Failed() {
+			ht.Skip("Skipped cleanup for failed test")
+			return
+		}
+
+		ht.CloseChannel(alice, chanPointAliceBob)
+		ht.CloseChannel(dave, chanPointDaveAlice)
+		ht.CloseChannel(carol, chanPointCarolDave)
+	}
+
+	s := &scenarioFourNodes{
+		alice, bob, carol, dave, chanPointAliceBob,
+		chanPointCarolDave, chanPointDaveAlice, cleanUp,
+	}
+
+	// Wait until all nodes in the network have 5 outstanding htlcs.
+	s.assertHTLCs(ht, numPayments)
+
+	return s
+}
+
+// assertHTLCs is a helper function which asserts the desired num of
+// HTLCs has been seen in the nodes.
+func (s *scenarioFourNodes) assertHTLCs(ht *lntemp.HarnessTest, num int) {
+	// Alice should have both the same number of outgoing and
+	// incoming HTLCs.
+	ht.AssertNumActiveHtlcs(s.alice, num*2)
+	// Bob should have num of incoming HTLCs.
+	ht.AssertNumActiveHtlcs(s.bob, num)
+	// Dave should have both the same number of outgoing and
+	// incoming HTLCs.
+	ht.AssertNumActiveHtlcs(s.dave, num*2)
+	// Carol should have the num of outgoing HTLCs.
+	ht.AssertNumActiveHtlcs(s.carol, num)
+}
+
+// assertAmoutPaid is a helper method which takes a given paid amount
+// and number of payments and asserts the desired payments are made in
+// the four nodes.
+func (s *scenarioFourNodes) assertAmoutPaid(ht *lntemp.HarnessTest,
+	amt int64, num int64) {
+
+	ht.AssertAmountPaid(
+		"Dave(local) => Carol(remote)", s.carol,
+		s.chanPointCarolDave, int64(0), amt,
+	)
+	ht.AssertAmountPaid(
+		"Dave(local) => Carol(remote)", s.dave,
+		s.chanPointCarolDave, amt, int64(0),
+	)
+	ht.AssertAmountPaid(
+		"Alice(local) => Dave(remote)", s.dave,
+		s.chanPointDaveAlice,
+		int64(0), amt+(baseFee*num),
+	)
+	ht.AssertAmountPaid(
+		"Alice(local) => Dave(remote)", s.alice,
+		s.chanPointDaveAlice,
+		amt+(baseFee*num), int64(0),
+	)
+	ht.AssertAmountPaid(
+		"Bob(local) => Alice(remote)", s.alice,
+		s.chanPointAliceBob,
+		int64(0), amt+((baseFee*num)*2),
+	)
+	ht.AssertAmountPaid(
+		"Bob(local) => Alice(remote)", s.bob,
+		s.chanPointAliceBob,
+		amt+(baseFee*num)*2, int64(0),
+	)
 }

--- a/lntest/itest/lnd_switch_test.go
+++ b/lntest/itest/lnd_switch_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/lightningnetwork/lnd/lntemp/node"
 	"github.com/lightningnetwork/lnd/lntest"
 	"github.com/lightningnetwork/lnd/lntest/wait"
-	"github.com/stretchr/testify/require"
 )
 
 const (
@@ -100,244 +99,41 @@ func testSwitchCircuitPersistence(ht *lntemp.HarnessTest) {
 //  2. Carol --- Dave  X  Alice --- Bob  disconnect intermediaries
 //  3. Carol --- Dave  X  Alice <-- Bob  settle last hop
 //  4. Carol <-- Dave <-- Alice --- Bob  reconnect, expect settle to propagate
-func testSwitchOfflineDelivery(net *lntest.NetworkHarness, t *harnessTest) {
-	ctxb := context.Background()
-
-	const chanAmt = btcutil.Amount(1000000)
-	const pushAmt = btcutil.Amount(900000)
-	var networkChans []*lnrpc.ChannelPoint
-
-	// Open a channel with 100k satoshis between Alice and Bob with Alice
-	// being the sole funder of the channel.
-	chanPointAlice := openChannelAndAssert(
-		t, net, net.Alice, net.Bob,
-		lntest.OpenChannelParams{
-			Amt:     chanAmt,
-			PushAmt: pushAmt,
-		},
-	)
-	networkChans = append(networkChans, chanPointAlice)
-
-	aliceChanTXID, err := lnrpc.GetChanPointFundingTxid(chanPointAlice)
-	if err != nil {
-		t.Fatalf("unable to get txid: %v", err)
-	}
-	aliceFundPoint := wire.OutPoint{
-		Hash:  *aliceChanTXID,
-		Index: chanPointAlice.OutputIndex,
-	}
-
-	// As preliminary setup, we'll create two new nodes: Carol and Dave,
-	// such that we now have a 4 ndoe, 3 channel topology. Dave will make
-	// a channel with Alice, and Carol with Dave. After this setup, the
-	// network topology should now look like:
-	//     Carol -> Dave -> Alice -> Bob
-	//
-	// First, we'll create Dave and establish a channel to Alice.
-	dave := net.NewNode(t.t, "Dave", nil)
-	defer shutdownAndAssert(net, t, dave)
-
-	net.ConnectNodes(t.t, dave, net.Alice)
-	net.SendCoins(t.t, btcutil.SatoshiPerBitcoin, dave)
-
-	chanPointDave := openChannelAndAssert(
-		t, net, dave, net.Alice,
-		lntest.OpenChannelParams{
-			Amt:     chanAmt,
-			PushAmt: pushAmt,
-		},
-	)
-	networkChans = append(networkChans, chanPointDave)
-	daveChanTXID, err := lnrpc.GetChanPointFundingTxid(chanPointDave)
-	if err != nil {
-		t.Fatalf("unable to get txid: %v", err)
-	}
-	daveFundPoint := wire.OutPoint{
-		Hash:  *daveChanTXID,
-		Index: chanPointDave.OutputIndex,
-	}
-
-	// Next, we'll create Carol and establish a channel to from her to
-	// Dave. Carol is started in htlchodl mode so that we can disconnect the
-	// intermediary hops before starting the settle.
-	carol := net.NewNode(t.t, "Carol", []string{"--hodl.exit-settle"})
-	defer shutdownAndAssert(net, t, carol)
-
-	net.ConnectNodes(t.t, carol, dave)
-	net.SendCoins(t.t, btcutil.SatoshiPerBitcoin, carol)
-
-	chanPointCarol := openChannelAndAssert(
-		t, net, carol, dave,
-		lntest.OpenChannelParams{
-			Amt:     chanAmt,
-			PushAmt: pushAmt,
-		},
-	)
-	networkChans = append(networkChans, chanPointCarol)
-
-	carolChanTXID, err := lnrpc.GetChanPointFundingTxid(chanPointCarol)
-	if err != nil {
-		t.Fatalf("unable to get txid: %v", err)
-	}
-	carolFundPoint := wire.OutPoint{
-		Hash:  *carolChanTXID,
-		Index: chanPointCarol.OutputIndex,
-	}
-
-	// Wait for all nodes to have seen all channels.
-	nodes := []*lntest.HarnessNode{net.Alice, net.Bob, carol, dave}
-	nodeNames := []string{"Alice", "Bob", "Carol", "Dave"}
-	for _, chanPoint := range networkChans {
-		for i, node := range nodes {
-			txid, err := lnrpc.GetChanPointFundingTxid(chanPoint)
-			if err != nil {
-				t.Fatalf("unable to get txid: %v", err)
-			}
-			point := wire.OutPoint{
-				Hash:  *txid,
-				Index: chanPoint.OutputIndex,
-			}
-
-			err = node.WaitForNetworkChannelOpen(chanPoint)
-			if err != nil {
-				t.Fatalf("%s(%d): timeout waiting for "+
-					"channel(%s) open: %v", nodeNames[i],
-					node.NodeID, point, err)
-			}
-		}
-	}
-
-	// Create 5 invoices for Carol, which expect a payment from Bob for 1k
-	// satoshis with a different preimage each time.
-	const numPayments = 5
-	const paymentAmt = 1000
-	payReqs, _, _, err := createPayReqs(
-		carol, paymentAmt, numPayments,
-	)
-	if err != nil {
-		t.Fatalf("unable to create pay reqs: %v", err)
-	}
-
-	// We'll wait for all parties to recognize the new channels within the
-	// network.
-	err = dave.WaitForNetworkChannelOpen(chanPointDave)
-	if err != nil {
-		t.Fatalf("dave didn't advertise his channel: %v", err)
-	}
-	err = carol.WaitForNetworkChannelOpen(chanPointCarol)
-	if err != nil {
-		t.Fatalf("carol didn't advertise her channel in time: %v",
-			err)
-	}
-
-	// Make sure all nodes are fully synced before we continue.
-	for _, node := range nodes {
-		err := node.WaitForBlockchainSync()
-		if err != nil {
-			t.Fatalf("unable to wait for sync: %v", err)
-		}
-	}
-
-	// Using Carol as the source, pay to the 5 invoices from Bob created
-	// above.
-	err = completePaymentRequests(
-		net.Bob, net.Bob.RouterClient, payReqs, false,
-	)
-	if err != nil {
-		t.Fatalf("unable to send payments: %v", err)
-	}
-
-	// Wait for all of the payments to reach Carol.
-	var predErr error
-	err = wait.Predicate(func() bool {
-		predErr = assertNumActiveHtlcs(nodes, numPayments)
-		return predErr == nil
-	}, defaultTimeout)
-	if err != nil {
-		t.Fatalf("htlc mismatch: %v", predErr)
-	}
-
-	peerReq := &lnrpc.PeerEventSubscription{}
-	peerClient, err := dave.SubscribePeerEvents(ctxb, peerReq)
-	require.NoError(t.t, err)
+func testSwitchOfflineDelivery(ht *lntemp.HarnessTest) {
+	// Setup our test scenario. We should now have four nodes running with
+	// three channels.
+	s := setupScenarioFourNodes(ht)
+	defer s.cleanUp()
 
 	// First, disconnect Dave and Alice so that their link is broken.
-	if err := net.DisconnectNodes(dave, net.Alice); err != nil {
-		t.Fatalf("unable to disconnect alice from dave: %v", err)
-	}
-
-	// Wait to receive the PEER_OFFLINE event before reconnecting them.
-	peerEvent, err := peerClient.Recv()
-	require.NoError(t.t, err)
-	require.Equal(t.t, lnrpc.PeerEvent_PEER_OFFLINE, peerEvent.GetType())
+	ht.DisconnectNodes(s.dave, s.alice)
 
 	// Then, reconnect them to ensure Dave doesn't just fail back the htlc.
-	// We use EnsureConnected here in case they have already re-connected.
-	net.EnsureConnected(t.t, dave, net.Alice)
+	ht.ConnectNodes(s.dave, s.alice)
 
 	// Wait to ensure that the payment remain are not failed back after
 	// reconnecting. All node should report the number payments initiated
 	// for the duration of the interval.
-	err = wait.Invariant(func() bool {
-		predErr = assertNumActiveHtlcs(nodes, numPayments)
-		return predErr == nil
-	}, defaultTimeout)
-	if err != nil {
-		t.Fatalf("htlc change: %v", predErr)
-	}
+	s.assertHTLCs(ht, numPayments)
 
 	// Now, disconnect Dave from Alice again before settling back the
 	// payment.
-	if err := net.DisconnectNodes(dave, net.Alice); err != nil {
-		t.Fatalf("unable to disconnect alice from dave: %v", err)
-	}
-
-	// Wait to receive the PEER_ONLINE and then the PEER_OFFLINE event
-	// before advancing.
-	peerEvent2, err := peerClient.Recv()
-	require.NoError(t.t, err)
-	require.Equal(t.t, lnrpc.PeerEvent_PEER_ONLINE, peerEvent2.GetType())
-
-	peerEvent3, err := peerClient.Recv()
-	require.NoError(t.t, err)
-	require.Equal(t.t, lnrpc.PeerEvent_PEER_OFFLINE, peerEvent3.GetType())
+	ht.DisconnectNodes(s.dave, s.alice)
 
 	// Now restart carol without hodl mode, to settle back the outstanding
 	// payments.
-	carol.SetExtraArgs(nil)
-	if err := net.RestartNode(carol, nil); err != nil {
-		t.Fatalf("Node restart failed: %v", err)
-	}
+	s.carol.SetExtraArgs(nil)
+	ht.RestartNode(s.carol)
 
 	// Wait for Carol to report no outstanding htlcs.
-	carolNode := []*lntest.HarnessNode{carol}
-	err = wait.Predicate(func() bool {
-		predErr = assertNumActiveHtlcs(carolNode, 0)
-		return predErr == nil
-	}, defaultTimeout)
-	if err != nil {
-		t.Fatalf("htlc mismatch: %v", predErr)
-	}
-
-	// Make sure all nodes are fully synced again.
-	for _, node := range nodes {
-		err := node.WaitForBlockchainSync()
-		if err != nil {
-			t.Fatalf("unable to wait for sync: %v", err)
-		}
-	}
+	ht.AssertNumActiveHtlcs(s.carol, 0)
 
 	// Now that the settles have reached Dave, reconnect him with Alice,
 	// allowing the settles to return to the sender.
-	net.EnsureConnected(t.t, dave, net.Alice)
+	ht.EnsureConnected(s.dave, s.alice)
 
 	// Wait until all outstanding htlcs in the network have been settled.
-	err = wait.Predicate(func() bool {
-		return assertNumActiveHtlcs(nodes, 0) == nil
-	}, defaultTimeout)
-	if err != nil {
-		t.Fatalf("htlc mismatch: %v", predErr)
-	}
+	s.assertHTLCs(ht, 0)
 
 	// When asserting the amount of satoshis moved, we'll factor in the
 	// default base fee, as we didn't modify the fee structure when
@@ -351,18 +147,7 @@ func testSwitchOfflineDelivery(net *lntest.NetworkHarness, t *harnessTest) {
 	// transaction, in channel Bob->Alice->David->Carol, order is Carol,
 	// David, Alice, Bob.
 	var amountPaid = int64(5000)
-	assertAmountPaid(t, "Dave(local) => Carol(remote)", carol,
-		carolFundPoint, int64(0), amountPaid)
-	assertAmountPaid(t, "Dave(local) => Carol(remote)", dave,
-		carolFundPoint, amountPaid, int64(0))
-	assertAmountPaid(t, "Alice(local) => Dave(remote)", dave,
-		daveFundPoint, int64(0), amountPaid+(baseFee*numPayments))
-	assertAmountPaid(t, "Alice(local) => Dave(remote)", net.Alice,
-		daveFundPoint, amountPaid+(baseFee*numPayments), int64(0))
-	assertAmountPaid(t, "Bob(local) => Alice(remote)", net.Alice,
-		aliceFundPoint, int64(0), amountPaid+((baseFee*numPayments)*2))
-	assertAmountPaid(t, "Bob(local) => Alice(remote)", net.Bob,
-		aliceFundPoint, amountPaid+(baseFee*numPayments)*2, int64(0))
+	s.assertAmoutPaid(ht, amountPaid, numPayments)
 
 	// Lastly, we will send one more payment to ensure all channels are
 	// still functioning properly.
@@ -370,40 +155,15 @@ func testSwitchOfflineDelivery(net *lntest.NetworkHarness, t *harnessTest) {
 		Memo:  "testing",
 		Value: paymentAmt,
 	}
-	ctxt, _ := context.WithTimeout(ctxb, defaultTimeout)
-	resp, err := carol.AddInvoice(ctxt, finalInvoice)
-	if err != nil {
-		t.Fatalf("unable to add invoice: %v", err)
-	}
-
-	payReqs = []string{resp.PaymentRequest}
+	resp := s.carol.RPC.AddInvoice(finalInvoice)
+	payReqs := []string{resp.PaymentRequest}
 
 	// Using Carol as the source, pay to the 5 invoices from Bob created
 	// above.
-	err = completePaymentRequests(
-		net.Bob, net.Bob.RouterClient, payReqs, true,
-	)
-	if err != nil {
-		t.Fatalf("unable to send payments: %v", err)
-	}
+	ht.CompletePaymentRequests(s.bob, payReqs)
 
 	amountPaid = int64(6000)
-	assertAmountPaid(t, "Dave(local) => Carol(remote)", carol,
-		carolFundPoint, int64(0), amountPaid)
-	assertAmountPaid(t, "Dave(local) => Carol(remote)", dave,
-		carolFundPoint, amountPaid, int64(0))
-	assertAmountPaid(t, "Alice(local) => Dave(remote)", dave,
-		daveFundPoint, int64(0), amountPaid+(baseFee*(numPayments+1)))
-	assertAmountPaid(t, "Alice(local) => Dave(remote)", net.Alice,
-		daveFundPoint, amountPaid+(baseFee*(numPayments+1)), int64(0))
-	assertAmountPaid(t, "Bob(local) => Alice(remote)", net.Alice,
-		aliceFundPoint, int64(0), amountPaid+((baseFee*(numPayments+1))*2))
-	assertAmountPaid(t, "Bob(local) => Alice(remote)", net.Bob,
-		aliceFundPoint, amountPaid+(baseFee*(numPayments+1))*2, int64(0))
-
-	closeChannelAndAssert(t, net, net.Alice, chanPointAlice, false)
-	closeChannelAndAssert(t, net, dave, chanPointDave, false)
-	closeChannelAndAssert(t, net, carol, chanPointCarol, false)
+	s.assertAmoutPaid(ht, amountPaid, numPayments+1)
 }
 
 // testSwitchOfflineDeliveryPersistence constructs a set of multihop payments,

--- a/lntest/itest/lnd_taproot_test.go
+++ b/lntest/itest/lnd_taproot_test.go
@@ -1136,7 +1136,7 @@ func testTaprootImportTapscriptFullTree(ctxt context.Context, t *harnessTest,
 
 	// For the next step, we need a public key. Let's use a special family
 	// for this.
-	_, internalKey, derivationPath := deriveInternalKey(ctxt, t, alice)
+	_, internalKey, derivationPath := deriveInternalKeyOld(ctxt, t, alice)
 
 	// Let's create a taproot script output now. This is a hash lock with a
 	// simple preimage of "foobar".
@@ -1213,7 +1213,7 @@ func testTaprootImportTapscriptPartialReveal(ctxt context.Context,
 
 	// For the next step, we need a public key. Let's use a special family
 	// for this.
-	_, internalKey, derivationPath := deriveInternalKey(ctxt, t, alice)
+	_, internalKey, derivationPath := deriveInternalKeyOld(ctxt, t, alice)
 
 	// Let's create a taproot script output now. This is a hash lock with a
 	// simple preimage of "foobar".
@@ -1286,7 +1286,7 @@ func testTaprootImportTapscriptRootHashOnly(ctxt context.Context,
 
 	// For the next step, we need a public key. Let's use a special family
 	// for this.
-	_, internalKey, derivationPath := deriveInternalKey(ctxt, t, alice)
+	_, internalKey, derivationPath := deriveInternalKeyOld(ctxt, t, alice)
 
 	// Let's create a taproot script output now. This is a hash lock with a
 	// simple preimage of "foobar".
@@ -1347,7 +1347,7 @@ func testTaprootImportTapscriptFullKey(ctxt context.Context, t *harnessTest,
 
 	// For the next step, we need a public key. Let's use a special family
 	// for this.
-	_, internalKey, derivationPath := deriveInternalKey(ctxt, t, alice)
+	_, internalKey, derivationPath := deriveInternalKeyOld(ctxt, t, alice)
 
 	// Let's create a taproot script output now. This is a hash lock with a
 	// simple preimage of "foobar".

--- a/lntest/itest/lnd_test_list_on_test.go
+++ b/lntest/itest/lnd_test_list_on_test.go
@@ -41,10 +41,6 @@ var allTestCases = []*testCase{
 		test: testSignPsbt,
 	},
 	{
-		name: "sendtoroute amp",
-		test: testSendToRouteAMP,
-	},
-	{
 		name: "forward interceptor",
 		test: testForwardInterceptorBasic,
 	},

--- a/lntest/itest/lnd_test_list_on_test.go
+++ b/lntest/itest/lnd_test_list_on_test.go
@@ -45,10 +45,6 @@ var allTestCases = []*testCase{
 		test: testForwardInterceptorBasic,
 	},
 	{
-		name: "forward interceptor dedup htlcs",
-		test: testForwardInterceptorDedupHtlc,
-	},
-	{
 		name: "wallet import account",
 		test: testWalletImportAccount,
 	},

--- a/lntest/itest/lnd_test_list_on_test.go
+++ b/lntest/itest/lnd_test_list_on_test.go
@@ -9,10 +9,6 @@ var allTestCases = []*testCase{
 		test: testBidirectionalAsyncPayments,
 	},
 	{
-		name: "open channel fee policy",
-		test: testOpenChannelUpdateFeePolicy,
-	},
-	{
 		name: "custom messaging",
 		test: testCustomMessage,
 	},

--- a/lntest/itest/lnd_test_list_on_test.go
+++ b/lntest/itest/lnd_test_list_on_test.go
@@ -5,10 +5,6 @@ package itest
 
 var allTestCases = []*testCase{
 	{
-		name: "sign verify message",
-		test: testSignVerifyMessage,
-	},
-	{
 		name: "async payments benchmark",
 		test: testAsyncPayments,
 	},

--- a/lntest/itest/lnd_test_list_on_test.go
+++ b/lntest/itest/lnd_test_list_on_test.go
@@ -5,10 +5,6 @@ package itest
 
 var allTestCases = []*testCase{
 	{
-		name: "sign output raw",
-		test: testSignOutputRaw,
-	},
-	{
 		name: "sign verify message",
 		test: testSignVerifyMessage,
 	},

--- a/lntest/itest/lnd_test_list_on_test.go
+++ b/lntest/itest/lnd_test_list_on_test.go
@@ -57,10 +57,6 @@ var allTestCases = []*testCase{
 		test: testTaproot,
 	},
 	{
-		name: "scid alias channel update",
-		test: testUpdateChannelPolicyScidAlias,
-	},
-	{
 		name: "scid alias upgrade",
 		test: testOptionScidUpgrade,
 	},

--- a/lntest/itest/lnd_test_list_on_test.go
+++ b/lntest/itest/lnd_test_list_on_test.go
@@ -41,10 +41,6 @@ var allTestCases = []*testCase{
 		test: testSignPsbt,
 	},
 	{
-		name: "sendtoroute multi path payment",
-		test: testSendToRouteMultiPath,
-	},
-	{
 		name: "sendtoroute amp",
 		test: testSendToRouteAMP,
 	},

--- a/lntest/itest/lnd_test_list_on_test.go
+++ b/lntest/itest/lnd_test_list_on_test.go
@@ -57,10 +57,6 @@ var allTestCases = []*testCase{
 		test: testTaproot,
 	},
 	{
-		name: "nonstd sweep",
-		test: testNonstdSweep,
-	},
-	{
 		name: "taproot coop close",
 		test: testTaprootCoopClose,
 	},

--- a/lntest/itest/lnd_test_list_on_test.go
+++ b/lntest/itest/lnd_test_list_on_test.go
@@ -57,10 +57,6 @@ var allTestCases = []*testCase{
 		test: testTaproot,
 	},
 	{
-		name: "zero conf channel open",
-		test: testZeroConfChannelOpen,
-	},
-	{
 		name: "option scid alias",
 		test: testOptionScidAlias,
 	},

--- a/lntest/itest/lnd_test_list_on_test.go
+++ b/lntest/itest/lnd_test_list_on_test.go
@@ -13,10 +13,6 @@ var allTestCases = []*testCase{
 		test: testBidirectionalAsyncPayments,
 	},
 	{
-		name: "cpfp",
-		test: testCPFP,
-	},
-	{
 		name: "psbt channel funding",
 		test: testPsbtChanFunding,
 	},

--- a/lntest/itest/lnd_test_list_on_test.go
+++ b/lntest/itest/lnd_test_list_on_test.go
@@ -25,10 +25,6 @@ var allTestCases = []*testCase{
 		test: testRemoteSigner,
 	},
 	{
-		name: "taproot",
-		test: testTaproot,
-	},
-	{
 		name: "taproot coop close",
 		test: testTaprootCoopClose,
 	},

--- a/lntest/itest/lnd_test_list_on_test.go
+++ b/lntest/itest/lnd_test_list_on_test.go
@@ -57,10 +57,6 @@ var allTestCases = []*testCase{
 		test: testTaproot,
 	},
 	{
-		name: "option scid alias",
-		test: testOptionScidAlias,
-	},
-	{
 		name: "scid alias channel update",
 		test: testUpdateChannelPolicyScidAlias,
 	},

--- a/lntest/itest/lnd_test_list_on_test.go
+++ b/lntest/itest/lnd_test_list_on_test.go
@@ -13,14 +13,6 @@ var allTestCases = []*testCase{
 		test: testBidirectionalAsyncPayments,
 	},
 	{
-		name: "wallet import account",
-		test: testWalletImportAccount,
-	},
-	{
-		name: "wallet import pubkey",
-		test: testWalletImportPubKey,
-	},
-	{
 		name: "remote signer",
 		test: testRemoteSigner,
 	},

--- a/lntest/itest/lnd_test_list_on_test.go
+++ b/lntest/itest/lnd_test_list_on_test.go
@@ -57,10 +57,6 @@ var allTestCases = []*testCase{
 		test: testTaproot,
 	},
 	{
-		name: "scid alias upgrade",
-		test: testOptionScidUpgrade,
-	},
-	{
 		name: "nonstd sweep",
 		test: testNonstdSweep,
 	},

--- a/lntest/itest/lnd_test_list_on_test.go
+++ b/lntest/itest/lnd_test_list_on_test.go
@@ -9,10 +9,6 @@ var allTestCases = []*testCase{
 		test: testBidirectionalAsyncPayments,
 	},
 	{
-		name: "remote signer",
-		test: testRemoteSigner,
-	},
-	{
 		name: "taproot coop close",
 		test: testTaprootCoopClose,
 	},

--- a/lntest/itest/lnd_test_list_on_test.go
+++ b/lntest/itest/lnd_test_list_on_test.go
@@ -13,10 +13,6 @@ var allTestCases = []*testCase{
 		test: testBidirectionalAsyncPayments,
 	},
 	{
-		name: "psbt channel funding",
-		test: testPsbtChanFunding,
-	},
-	{
 		name: "sign psbt",
 		test: testSignPsbt,
 	},

--- a/lntest/itest/lnd_test_list_on_test.go
+++ b/lntest/itest/lnd_test_list_on_test.go
@@ -13,10 +13,6 @@ var allTestCases = []*testCase{
 		test: testBidirectionalAsyncPayments,
 	},
 	{
-		name: "sign psbt",
-		test: testSignPsbt,
-	},
-	{
 		name: "wallet import account",
 		test: testWalletImportAccount,
 	},

--- a/lntest/itest/lnd_test_list_on_test.go
+++ b/lntest/itest/lnd_test_list_on_test.go
@@ -57,10 +57,6 @@ var allTestCases = []*testCase{
 		test: testSendPaymentAMPInvoiceRepeat,
 	},
 	{
-		name: "send multi path payment",
-		test: testSendMultiPathPayment,
-	},
-	{
 		name: "forward interceptor",
 		test: testForwardInterceptorBasic,
 	},

--- a/lntest/itest/lnd_test_list_on_test.go
+++ b/lntest/itest/lnd_test_list_on_test.go
@@ -49,10 +49,6 @@ var allTestCases = []*testCase{
 		test: testSendPaymentAMP,
 	},
 	{
-		name: "sendpayment amp invoice repeat",
-		test: testSendPaymentAMPInvoiceRepeat,
-	},
-	{
 		name: "forward interceptor",
 		test: testForwardInterceptorBasic,
 	},

--- a/lntest/itest/lnd_test_list_on_test.go
+++ b/lntest/itest/lnd_test_list_on_test.go
@@ -29,10 +29,6 @@ var allTestCases = []*testCase{
 		test: testBidirectionalAsyncPayments,
 	},
 	{
-		name: "switch offline delivery persistence",
-		test: testSwitchOfflineDeliveryPersistence,
-	},
-	{
 		name: "switch offline delivery outgoing offline",
 		test: testSwitchOfflineDeliveryOutgoingOffline,
 	},

--- a/lntest/itest/lnd_test_list_on_test.go
+++ b/lntest/itest/lnd_test_list_on_test.go
@@ -41,10 +41,6 @@ var allTestCases = []*testCase{
 		test: testSignPsbt,
 	},
 	{
-		name: "forward interceptor",
-		test: testForwardInterceptorBasic,
-	},
-	{
 		name: "wallet import account",
 		test: testWalletImportAccount,
 	},

--- a/lntest/itest/lnd_test_list_on_test.go
+++ b/lntest/itest/lnd_test_list_on_test.go
@@ -8,8 +8,4 @@ var allTestCases = []*testCase{
 		name: "async bidirectional payments",
 		test: testBidirectionalAsyncPayments,
 	},
-	{
-		name: "custom messaging",
-		test: testCustomMessage,
-	},
 }

--- a/lntest/itest/lnd_test_list_on_test.go
+++ b/lntest/itest/lnd_test_list_on_test.go
@@ -9,10 +9,6 @@ var allTestCases = []*testCase{
 		test: testBidirectionalAsyncPayments,
 	},
 	{
-		name: "trackpayments",
-		test: testTrackPayments,
-	},
-	{
 		name: "open channel fee policy",
 		test: testOpenChannelUpdateFeePolicy,
 	},

--- a/lntest/itest/lnd_test_list_on_test.go
+++ b/lntest/itest/lnd_test_list_on_test.go
@@ -9,10 +9,6 @@ var allTestCases = []*testCase{
 		test: testBidirectionalAsyncPayments,
 	},
 	{
-		name: "taproot coop close",
-		test: testTaprootCoopClose,
-	},
-	{
 		name: "trackpayments",
 		test: testTrackPayments,
 	},

--- a/lntest/itest/lnd_test_list_on_test.go
+++ b/lntest/itest/lnd_test_list_on_test.go
@@ -5,10 +5,6 @@ package itest
 
 var allTestCases = []*testCase{
 	{
-		name: "multiple channel creation and update subscription",
-		test: testBasicChannelCreationAndUpdates,
-	},
-	{
 		name: "derive shared key",
 		test: testDeriveSharedKey,
 	},

--- a/lntest/itest/lnd_test_list_on_test.go
+++ b/lntest/itest/lnd_test_list_on_test.go
@@ -5,10 +5,6 @@ package itest
 
 var allTestCases = []*testCase{
 	{
-		name: "async payments benchmark",
-		test: testAsyncPayments,
-	},
-	{
 		name: "async bidirectional payments",
 		test: testBidirectionalAsyncPayments,
 	},

--- a/lntest/itest/lnd_test_list_on_test.go
+++ b/lntest/itest/lnd_test_list_on_test.go
@@ -5,10 +5,6 @@ package itest
 
 var allTestCases = []*testCase{
 	{
-		name: "derive shared key",
-		test: testDeriveSharedKey,
-	},
-	{
 		name: "sign output raw",
 		test: testSignOutputRaw,
 	},

--- a/lntest/itest/lnd_test_list_on_test.go
+++ b/lntest/itest/lnd_test_list_on_test.go
@@ -45,10 +45,6 @@ var allTestCases = []*testCase{
 		test: testSendToRouteAMP,
 	},
 	{
-		name: "sendpayment amp",
-		test: testSendPaymentAMP,
-	},
-	{
 		name: "forward interceptor",
 		test: testForwardInterceptorBasic,
 	},

--- a/lntest/itest/lnd_test_list_on_test.go
+++ b/lntest/itest/lnd_test_list_on_test.go
@@ -29,10 +29,6 @@ var allTestCases = []*testCase{
 		test: testBidirectionalAsyncPayments,
 	},
 	{
-		name: "switch circuit persistence",
-		test: testSwitchCircuitPersistence,
-	},
-	{
 		name: "switch offline delivery",
 		test: testSwitchOfflineDelivery,
 	},

--- a/lntest/itest/lnd_test_list_on_test.go
+++ b/lntest/itest/lnd_test_list_on_test.go
@@ -49,10 +49,6 @@ var allTestCases = []*testCase{
 		test: testSendPaymentAMP,
 	},
 	{
-		name: "sendpayment amp invoice",
-		test: testSendPaymentAMPInvoice,
-	},
-	{
 		name: "sendpayment amp invoice repeat",
 		test: testSendPaymentAMPInvoiceRepeat,
 	},

--- a/lntest/itest/lnd_test_list_on_test.go
+++ b/lntest/itest/lnd_test_list_on_test.go
@@ -29,10 +29,6 @@ var allTestCases = []*testCase{
 		test: testBidirectionalAsyncPayments,
 	},
 	{
-		name: "switch offline delivery",
-		test: testSwitchOfflineDelivery,
-	},
-	{
 		name: "switch offline delivery persistence",
 		test: testSwitchOfflineDeliveryPersistence,
 	},

--- a/lntest/itest/lnd_test_list_on_test.go
+++ b/lntest/itest/lnd_test_list_on_test.go
@@ -29,10 +29,6 @@ var allTestCases = []*testCase{
 		test: testBidirectionalAsyncPayments,
 	},
 	{
-		name: "switch offline delivery outgoing offline",
-		test: testSwitchOfflineDeliveryOutgoingOffline,
-	},
-	{
 		name: "cpfp",
 		test: testCPFP,
 	},

--- a/lntest/itest/lnd_trackpayments_test.go
+++ b/lntest/itest/lnd_trackpayments_test.go
@@ -1,102 +1,89 @@
 package itest
 
 import (
-	"context"
 	"encoding/hex"
+	"time"
 
 	"github.com/btcsuite/btcd/btcutil"
 	"github.com/lightningnetwork/lnd/lnrpc"
 	"github.com/lightningnetwork/lnd/lnrpc/routerrpc"
-	"github.com/lightningnetwork/lnd/lntest"
+	"github.com/lightningnetwork/lnd/lntemp"
 	"github.com/stretchr/testify/require"
 )
 
 // testTrackPayments tests whether a client that calls the TrackPayments api
 // receives payment updates.
-func testTrackPayments(net *lntest.NetworkHarness, t *harnessTest) {
+func testTrackPayments(ht *lntemp.HarnessTest) {
 	// Open a channel between alice and bob.
-	net.EnsureConnected(t.t, net.Alice, net.Bob)
-	channel := openChannelAndAssert(
-		t, net, net.Alice, net.Bob,
-		lntest.OpenChannelParams{
+	alice, bob := ht.Alice, ht.Bob
+	channel := ht.OpenChannel(
+		alice, bob, lntemp.OpenChannelParams{
 			Amt: btcutil.Amount(300000),
 		},
 	)
-	defer closeChannelAndAssert(t, net, net.Alice, channel, true)
-
-	err := net.Alice.WaitForNetworkChannelOpen(channel)
-	require.NoError(t.t, err, "unable to wait for channel to open")
-
-	ctxb := context.Background()
-	ctxt, cancelTracker := context.WithCancel(ctxb)
-	defer cancelTracker()
 
 	// Call the TrackPayments api to listen for payment updates.
-	tracker, err := net.Alice.RouterClient.TrackPayments(
-		ctxt,
-		&routerrpc.TrackPaymentsRequest{
-			NoInflightUpdates: false,
-		},
-	)
-	require.NoError(t.t, err, "failed to call TrackPayments successfully.")
+	req := &routerrpc.TrackPaymentsRequest{
+		NoInflightUpdates: false,
+	}
+	tracker := alice.RPC.TrackPayments(req)
 
 	// Create an invoice from bob.
 	var amountMsat int64 = 1000
-	invoiceResp, err := net.Bob.AddInvoice(
-		ctxb,
+	invoiceResp := bob.RPC.AddInvoice(
 		&lnrpc.Invoice{
 			ValueMsat: amountMsat,
 		},
 	)
-	require.NoError(t.t, err, "unable to add invoice.")
-
-	invoice, err := net.Bob.LookupInvoice(
-		ctxb,
-		&lnrpc.PaymentHash{
-			RHashStr: hex.EncodeToString(invoiceResp.RHash),
-		},
-	)
-	require.NoError(t.t, err, "unable to find invoice.")
+	invoice := bob.RPC.LookupInvoice(invoiceResp.RHash)
 
 	// Send payment from alice to bob.
-	paymentClient, err := net.Alice.RouterClient.SendPaymentV2(
-		ctxb,
+	paymentClient := alice.RPC.SendPayment(
 		&routerrpc.SendPaymentRequest{
 			PaymentRequest: invoice.PaymentRequest,
 			TimeoutSeconds: 60,
 		},
 	)
-	require.NoError(t.t, err, "unable to send payment.")
 
 	// Make sure the payment doesn't error due to invalid parameters or so.
-	_, err = paymentClient.Recv()
-	require.NoError(t.t, err, "unable to get payment update.")
+	_, err := paymentClient.Recv()
+	require.NoError(ht, err, "unable to get payment update.")
 
 	// Assert the first payment update is an inflight update.
 	update1, err := tracker.Recv()
-	require.NoError(t.t, err, "unable to receive payment update 1.")
+	require.NoError(ht, err, "unable to receive payment update 1.")
 
 	require.Equal(
-		t.t, lnrpc.PaymentFailureReason_FAILURE_REASON_NONE,
+		ht, lnrpc.PaymentFailureReason_FAILURE_REASON_NONE,
 		update1.FailureReason,
 	)
-	require.Equal(t.t, lnrpc.Payment_IN_FLIGHT, update1.Status)
-	require.Equal(t.t, invoice.PaymentRequest, update1.PaymentRequest)
-	require.Equal(t.t, amountMsat, update1.ValueMsat)
+	require.Equal(ht, lnrpc.Payment_IN_FLIGHT, update1.Status)
+	require.Equal(ht, invoice.PaymentRequest, update1.PaymentRequest)
+	require.Equal(ht, amountMsat, update1.ValueMsat)
 
 	// Assert the second payment update is a payment success update.
 	update2, err := tracker.Recv()
-	require.NoError(t.t, err, "unable to receive payment update 2.")
+	require.NoError(ht, err, "unable to receive payment update 2.")
 
 	require.Equal(
-		t.t, lnrpc.PaymentFailureReason_FAILURE_REASON_NONE,
+		ht, lnrpc.PaymentFailureReason_FAILURE_REASON_NONE,
 		update2.FailureReason,
 	)
-	require.Equal(t.t, lnrpc.Payment_SUCCEEDED, update2.Status)
-	require.Equal(t.t, invoice.PaymentRequest, update2.PaymentRequest)
-	require.Equal(t.t, amountMsat, update2.ValueMsat)
+	require.Equal(ht, lnrpc.Payment_SUCCEEDED, update2.Status)
+	require.Equal(ht, invoice.PaymentRequest, update2.PaymentRequest)
+	require.Equal(ht, amountMsat, update2.ValueMsat)
 	require.Equal(
-		t.t, hex.EncodeToString(invoice.RPreimage),
+		ht, hex.EncodeToString(invoice.RPreimage),
 		update2.PaymentPreimage,
 	)
+
+	// TODO(yy): remove the sleep once the following bug is fixed.
+	// When the invoice is reported settled, the commitment dance is not
+	// yet finished, which can cause an error when closing the channel,
+	// saying there's active HTLCs. We need to investigate this issue and
+	// reverse the order to, first finish the commitment dance, then report
+	// the invoice as settled.
+	time.Sleep(2 * time.Second)
+
+	ht.CloseChannel(alice, channel)
 }

--- a/lntest/itest/lnd_wallet_import_test.go
+++ b/lntest/itest/lnd_wallet_import_test.go
@@ -461,12 +461,14 @@ func testWalletImportAccount(ht *lntemp.HarnessTest) {
 		addrType walletrpc.AddressType
 	}{
 		{
-			name:     "standard BIP-0049",
-			addrType: walletrpc.AddressType_NESTED_WITNESS_PUBKEY_HASH,
+			name: "standard BIP-0049",
+			addrType: walletrpc.
+				AddressType_NESTED_WITNESS_PUBKEY_HASH,
 		},
 		{
-			name:     "lnd BIP-0049 variant",
-			addrType: walletrpc.AddressType_HYBRID_NESTED_WITNESS_PUBKEY_HASH,
+			name: "lnd BIP-0049 variant",
+			addrType: walletrpc.
+				AddressType_HYBRID_NESTED_WITNESS_PUBKEY_HASH,
 		},
 		{
 			name:     "standard BIP-0084",
@@ -577,7 +579,8 @@ func runWalletImportAccountScenario(ht *lntemp.HarnessTest,
 	// some assertions we'll make later on.
 	balanceResp := dave.RPC.WalletBalance()
 	require.Contains(ht, balanceResp.AccountBalance, importedAccount)
-	confBalance := balanceResp.AccountBalance[importedAccount].ConfirmedBalance
+	confBalance := balanceResp.AccountBalance[importedAccount].
+		ConfirmedBalance
 
 	// Send coins to Carol's address and confirm them, making sure the
 	// balance updates accordingly.
@@ -588,9 +591,13 @@ func runWalletImportAccountScenario(ht *lntemp.HarnessTest,
 	}
 	alice.RPC.SendCoins(req)
 
-	ht.AssertWalletAccountBalance(dave, importedAccount, confBalance, utxoAmt)
+	ht.AssertWalletAccountBalance(
+		dave, importedAccount, confBalance, utxoAmt,
+	)
 	ht.MineBlocksAndAssertNumTxes(1, 1)
-	ht.AssertWalletAccountBalance(dave, importedAccount, confBalance+utxoAmt, 0)
+	ht.AssertWalletAccountBalance(
+		dave, importedAccount, confBalance+utxoAmt, 0,
+	)
 
 	// Now that we have enough funds, it's time to fund the channel, make a
 	// test payment, and close it. This contains several balance assertions
@@ -610,8 +617,9 @@ func testWalletImportPubKey(ht *lntemp.HarnessTest) {
 		addrType walletrpc.AddressType
 	}{
 		{
-			name:     "BIP-0049",
-			addrType: walletrpc.AddressType_NESTED_WITNESS_PUBKEY_HASH,
+			name: "BIP-0049",
+			addrType: walletrpc.
+				AddressType_NESTED_WITNESS_PUBKEY_HASH,
 		},
 		{
 			name:     "BIP-0084",
@@ -686,7 +694,9 @@ func testWalletImportPubKeyScenario(ht *lntemp.HarnessTest,
 		require.NoError(ht, err)
 		externalAccountExtKey, err := accountPubKey.Derive(0)
 		require.NoError(ht, err)
-		externalAddrExtKey, err := externalAccountExtKey.Derive(keyIndex)
+		externalAddrExtKey, err := externalAccountExtKey.Derive(
+			keyIndex,
+		)
 		require.NoError(ht, err)
 		externalAddrPubKey, err := externalAddrExtKey.ECPubKey()
 		require.NoError(ht, err)

--- a/lntest/itest/lnd_wallet_import_test.go
+++ b/lntest/itest/lnd_wallet_import_test.go
@@ -2,10 +2,6 @@ package itest
 
 import (
 	"bytes"
-	"context"
-	"crypto/rand"
-	"fmt"
-	"math"
 	"testing"
 	"time"
 
@@ -20,8 +16,8 @@ import (
 	"github.com/lightningnetwork/lnd/funding"
 	"github.com/lightningnetwork/lnd/lnrpc"
 	"github.com/lightningnetwork/lnd/lnrpc/walletrpc"
-	"github.com/lightningnetwork/lnd/lntest"
-	"github.com/lightningnetwork/lnd/lntest/wait"
+	"github.com/lightningnetwork/lnd/lntemp"
+	"github.com/lightningnetwork/lnd/lntemp/node"
 	"github.com/lightningnetwork/lnd/lnwallet"
 	"github.com/stretchr/testify/require"
 )
@@ -55,30 +51,27 @@ func walletToLNAddrType(t *testing.T,
 
 // newExternalAddr generates a new external address of an imported account for a
 // pair of nodes, where one acts as the funder and the other as the signer.
-func newExternalAddr(t *testing.T, funder, signer *lntest.HarnessNode,
+func newExternalAddr(ht *lntemp.HarnessTest, funder, signer *node.HarnessNode,
 	importedAccount string, addrType walletrpc.AddressType) string {
 
 	// We'll generate a new address for Carol from Dave's node to receive
 	// and fund a new channel.
-	ctxb := context.Background()
-	ctxt, cancel := context.WithTimeout(ctxb, defaultTimeout)
-	defer cancel()
-	funderResp, err := funder.NewAddress(ctxt, &lnrpc.NewAddressRequest{
-		Type:    walletToLNAddrType(t, addrType),
+	req := &lnrpc.NewAddressRequest{
+		Type:    walletToLNAddrType(ht.T, addrType),
 		Account: importedAccount,
-	})
-	require.NoError(t, err)
+	}
+	funderResp := funder.RPC.NewAddress(req)
 
-	// Carol also needs to generate the address for the sake of this test to
-	// be able to sign the channel funding input.
-	signerResp, err := signer.NewAddress(ctxt, &lnrpc.NewAddressRequest{
-		Type: walletToLNAddrType(t, addrType),
-	})
-	require.NoError(t, err)
+	// Carol also needs to generate the address for the sake of this test
+	// to be able to sign the channel funding input.
+	req = &lnrpc.NewAddressRequest{
+		Type: walletToLNAddrType(ht.T, addrType),
+	}
+	signerResp := signer.RPC.NewAddress(req)
 
 	// Sanity check that the generated addresses match.
-	require.Equal(t, funderResp.Address, signerResp.Address)
-	assertExternalAddrType(t, funderResp.Address, addrType)
+	require.Equal(ht, funderResp.Address, signerResp.Address)
+	assertExternalAddrType(ht.T, funderResp.Address, addrType)
 
 	return funderResp.Address
 }
@@ -130,108 +123,21 @@ func assertOutputScriptType(t *testing.T, expType txscript.ScriptClass,
 		spew.Sdump(tx))
 }
 
-// assertAccountBalance asserts that the unconfirmed and confirmed balance for
-// the given account is satisfied by the WalletBalance and ListUnspent RPCs. The
-// unconfirmed balance is not checked for neutrino nodes.
-func assertAccountBalance(t *testing.T, node *lntest.HarnessNode, account string,
-	confirmedBalance, unconfirmedBalance int64) {
-
-	err := wait.NoError(func() error {
-		balanceResp, err := node.WalletBalance(
-			context.Background(), &lnrpc.WalletBalanceRequest{},
-		)
-		if err != nil {
-			return err
-		}
-		require.Contains(t, balanceResp.AccountBalance, account)
-		accountBalance := balanceResp.AccountBalance[account]
-
-		// Check confirmed balance.
-		if accountBalance.ConfirmedBalance != confirmedBalance {
-			return fmt.Errorf("expected confirmed balance %v, "+
-				"got %v", confirmedBalance,
-				accountBalance.ConfirmedBalance)
-		}
-		listUtxosReq := &lnrpc.ListUnspentRequest{
-			MinConfs: 1,
-			MaxConfs: math.MaxInt32,
-			Account:  account,
-		}
-		confirmedUtxosResp, err := node.ListUnspent(
-			context.Background(), listUtxosReq,
-		)
-		if err != nil {
-			return err
-		}
-		var totalConfirmedVal int64
-		for _, utxo := range confirmedUtxosResp.Utxos {
-			totalConfirmedVal += utxo.AmountSat
-		}
-		if totalConfirmedVal != confirmedBalance {
-			return fmt.Errorf("expected total confirmed utxo "+
-				"balance %v, got %v", confirmedBalance,
-				totalConfirmedVal)
-		}
-
-		// Skip unconfirmed balance checks for neutrino nodes.
-		if node.Cfg.BackendCfg.Name() == lntest.NeutrinoBackendName {
-			return nil
-		}
-
-		// Check unconfirmed balance.
-		if accountBalance.UnconfirmedBalance != unconfirmedBalance {
-			return fmt.Errorf("expected unconfirmed balance %v, "+
-				"got %v", unconfirmedBalance,
-				accountBalance.UnconfirmedBalance)
-		}
-		listUtxosReq.MinConfs = 0
-		listUtxosReq.MaxConfs = 0
-		unconfirmedUtxosResp, err := node.ListUnspent(
-			context.Background(), listUtxosReq,
-		)
-		require.NoError(t, err)
-		var totalUnconfirmedVal int64
-		for _, utxo := range unconfirmedUtxosResp.Utxos {
-			totalUnconfirmedVal += utxo.AmountSat
-		}
-		if totalUnconfirmedVal != unconfirmedBalance {
-			return fmt.Errorf("expected total unconfirmed utxo "+
-				"balance %v, got %v", unconfirmedBalance,
-				totalUnconfirmedVal)
-		}
-
-		return nil
-	}, defaultTimeout)
-	require.NoError(t, err)
-}
-
 // psbtSendFromImportedAccount attempts to fund a PSBT from the given imported
 // account, originating from the source node to the destination.
-func psbtSendFromImportedAccount(t *harnessTest, srcNode, destNode,
-	signer *lntest.HarnessNode, account string,
+func psbtSendFromImportedAccount(ht *lntemp.HarnessTest, srcNode, destNode,
+	signer *node.HarnessNode, account string,
 	accountAddrType walletrpc.AddressType) {
 
-	ctxb := context.Background()
-
-	ctxt, cancel := context.WithTimeout(ctxb, defaultTimeout)
-	defer cancel()
-	balanceResp, err := srcNode.WalletBalance(
-		ctxt, &lnrpc.WalletBalanceRequest{},
-	)
-	require.NoError(t.t, err)
-	require.Contains(t.t, balanceResp.AccountBalance, account)
+	balanceResp := srcNode.RPC.WalletBalance()
+	require.Contains(ht, balanceResp.AccountBalance, account)
 	confBalance := balanceResp.AccountBalance[account].ConfirmedBalance
 
 	destAmt := confBalance - 10000
-	ctxt, cancel = context.WithTimeout(ctxb, defaultTimeout)
-	defer cancel()
-	destAddrResp, err := destNode.NewAddress(ctxt, &lnrpc.NewAddressRequest{
+	destAddrResp := destNode.RPC.NewAddress(&lnrpc.NewAddressRequest{
 		Type: lnrpc.AddressType_WITNESS_PUBKEY_HASH,
 	})
-	require.NoError(t.t, err)
 
-	ctxt, cancel = context.WithTimeout(ctxb, defaultTimeout)
-	defer cancel()
 	fundReq := &walletrpc.FundPsbtRequest{
 		Template: &walletrpc.FundPsbtRequest_Raw{
 			Raw: &walletrpc.TxTemplate{
@@ -245,29 +151,20 @@ func psbtSendFromImportedAccount(t *harnessTest, srcNode, destNode,
 		},
 		Account: account,
 	}
-	fundResp, err := srcNode.WalletKitClient.FundPsbt(ctxt, fundReq)
-	require.NoError(t.t, err)
+	fundResp := srcNode.RPC.FundPsbt(fundReq)
 
 	// Have Carol sign the PSBT input since Dave doesn't have any private
 	// key information.
-	ctxt, cancel = context.WithTimeout(ctxb, defaultTimeout)
-	defer cancel()
 	finalizeReq := &walletrpc.FinalizePsbtRequest{
 		FundedPsbt: fundResp.FundedPsbt,
 	}
-	finalizeResp, err := signer.WalletKitClient.FinalizePsbt(
-		ctxt, finalizeReq,
-	)
-	require.NoError(t.t, err)
+	finalizeResp := signer.RPC.FinalizePsbt(finalizeReq)
 
 	// With the PSBT signed, we can broadcast the resulting transaction.
-	ctxt, cancel = context.WithTimeout(ctxb, defaultTimeout)
-	defer cancel()
 	publishReq := &walletrpc.Transaction{
 		TxHex: finalizeResp.RawFinalTx,
 	}
-	_, err = srcNode.WalletKitClient.PublishTransaction(ctxt, publishReq)
-	require.NoError(t.t, err)
+	srcNode.RPC.PublishTransaction(publishReq)
 
 	// Carol's balance from Dave's perspective should update accordingly.
 	var (
@@ -304,7 +201,7 @@ func psbtSendFromImportedAccount(t *harnessTest, srcNode, destNode,
 		expChangeScriptType = txscript.WitnessV1TaprootTy
 
 	default:
-		t.Fatalf("unsupported addr type %v", accountAddrType)
+		ht.Fatalf("unsupported addr type %v", accountAddrType)
 	}
 	changeUtxoAmt := confBalance - destAmt - expTxFee
 
@@ -314,16 +211,20 @@ func psbtSendFromImportedAccount(t *harnessTest, srcNode, destNode,
 	if account == defaultImportedAccount {
 		accountWithBalance = defaultAccount
 	}
-	assertAccountBalance(t.t, srcNode, accountWithBalance, 0, changeUtxoAmt)
-	_ = mineBlocks(t, t.lndHarness, 1, 1)
-	assertAccountBalance(t.t, srcNode, accountWithBalance, changeUtxoAmt, 0)
+	ht.AssertWalletAccountBalance(
+		srcNode, accountWithBalance, 0, changeUtxoAmt,
+	)
+	ht.MineBlocksAndAssertNumTxes(1, 1)
+	ht.AssertWalletAccountBalance(
+		srcNode, accountWithBalance, changeUtxoAmt, 0,
+	)
 
 	// Finally, assert that the transaction has the expected change address
 	// type based on the account.
 	var tx wire.MsgTx
-	err = tx.Deserialize(bytes.NewReader(finalizeResp.RawFinalTx))
-	require.NoError(t.t, err)
-	assertOutputScriptType(t.t, expChangeScriptType, &tx, changeUtxoAmt)
+	err := tx.Deserialize(bytes.NewReader(finalizeResp.RawFinalTx))
+	require.NoError(ht, err)
+	assertOutputScriptType(ht.T, expChangeScriptType, &tx, changeUtxoAmt)
 }
 
 // fundChanAndCloseFromImportedAccount attempts to a fund a channel from the
@@ -331,21 +232,14 @@ func psbtSendFromImportedAccount(t *harnessTest, srcNode, destNode,
 // node. To ensure the channel is operational before closing it, a test payment
 // is made. Several balance assertions are made along the way for the sake of
 // correctness.
-func fundChanAndCloseFromImportedAccount(t *harnessTest, srcNode, destNode,
-	signer *lntest.HarnessNode, account string,
+func fundChanAndCloseFromImportedAccount(ht *lntemp.HarnessTest, srcNode,
+	destNode, signer *node.HarnessNode, account string,
 	accountAddrType walletrpc.AddressType, utxoAmt, chanSize int64) {
-
-	ctxb := context.Background()
 
 	// Retrieve the current confirmed balance to make some assertions later
 	// on.
-	ctxt, cancel := context.WithTimeout(ctxb, defaultTimeout)
-	defer cancel()
-	balanceResp, err := srcNode.WalletBalance(
-		ctxt, &lnrpc.WalletBalanceRequest{},
-	)
-	require.NoError(t.t, err)
-	require.Contains(t.t, balanceResp.AccountBalance, account)
+	balanceResp := srcNode.RPC.WalletBalance()
+	require.Contains(ht, balanceResp.AccountBalance, account)
 	accountConfBalance := balanceResp.
 		AccountBalance[account].ConfirmedBalance
 	defaultAccountConfBalance := balanceResp.
@@ -353,31 +247,23 @@ func fundChanAndCloseFromImportedAccount(t *harnessTest, srcNode, destNode,
 
 	// Now, start the channel funding process. We'll need to connect both
 	// nodes first.
-	t.lndHarness.EnsureConnected(t.t, srcNode, destNode)
+	ht.EnsureConnected(srcNode, destNode)
 
 	// The source node will then fund the channel through a PSBT shim.
-	var pendingChanID [32]byte
-	_, err = rand.Read(pendingChanID[:])
-	require.NoError(t.t, err)
-
-	ctxt, cancel = context.WithTimeout(ctxb, defaultTimeout)
-	defer cancel()
-	chanUpdates, rawPsbt, err := openChannelPsbt(
-		ctxt, srcNode, destNode, lntest.OpenChannelParams{
+	pendingChanID := ht.Random32Bytes()
+	chanUpdates, rawPsbt := ht.OpenChannelPsbt(
+		srcNode, destNode, lntemp.OpenChannelParams{
 			Amt: btcutil.Amount(chanSize),
 			FundingShim: &lnrpc.FundingShim{
 				Shim: &lnrpc.FundingShim_PsbtShim{
 					PsbtShim: &lnrpc.PsbtShim{
-						PendingChanId: pendingChanID[:],
+						PendingChanId: pendingChanID,
 					},
 				},
 			},
 		},
 	)
-	require.NoError(t.t, err)
 
-	ctxt, cancel = context.WithTimeout(ctxb, defaultTimeout)
-	defer cancel()
 	fundReq := &walletrpc.FundPsbtRequest{
 		Template: &walletrpc.FundPsbtRequest_Psbt{
 			Psbt: rawPsbt,
@@ -387,49 +273,40 @@ func fundChanAndCloseFromImportedAccount(t *harnessTest, srcNode, destNode,
 		},
 		Account: account,
 	}
-	fundResp, err := srcNode.WalletKitClient.FundPsbt(ctxt, fundReq)
-	require.NoError(t.t, err)
+	fundResp := srcNode.RPC.FundPsbt(fundReq)
 
-	_, err = srcNode.FundingStateStep(ctxb, &lnrpc.FundingTransitionMsg{
+	srcNode.RPC.FundingStateStep(&lnrpc.FundingTransitionMsg{
 		Trigger: &lnrpc.FundingTransitionMsg_PsbtVerify{
 			PsbtVerify: &lnrpc.FundingPsbtVerify{
-				PendingChanId: pendingChanID[:],
+				PendingChanId: pendingChanID,
 				FundedPsbt:    fundResp.FundedPsbt,
 			},
 		},
 	})
-	require.NoError(t.t, err)
 
 	// Now that we have a PSBT to fund the channel, our signer needs to sign
 	// it.
-	ctxt, cancel = context.WithTimeout(ctxb, defaultTimeout)
-	defer cancel()
 	finalizeReq := &walletrpc.FinalizePsbtRequest{
 		FundedPsbt: fundResp.FundedPsbt,
 	}
-	finalizeResp, err := signer.WalletKitClient.FinalizePsbt(ctxt, finalizeReq)
-	require.NoError(t.t, err)
+	finalizeResp := signer.RPC.FinalizePsbt(finalizeReq)
 
 	// The source node can then submit the signed PSBT and complete the
 	// channel funding process.
-	_, err = srcNode.FundingStateStep(ctxb, &lnrpc.FundingTransitionMsg{
+	srcNode.RPC.FundingStateStep(&lnrpc.FundingTransitionMsg{
 		Trigger: &lnrpc.FundingTransitionMsg_PsbtFinalize{
 			PsbtFinalize: &lnrpc.FundingPsbtFinalize{
-				PendingChanId: pendingChanID[:],
+				PendingChanId: pendingChanID,
 				SignedPsbt:    finalizeResp.SignedPsbt,
 			},
 		},
 	})
-	require.NoError(t.t, err)
 
 	// We should receive a notification of the channel funding transaction
 	// being broadcast.
-	ctxt, cancel = context.WithTimeout(ctxb, defaultTimeout)
-	defer cancel()
-	updateResp, err := receiveChanUpdate(ctxt, chanUpdates)
-	require.NoError(t.t, err)
+	updateResp := ht.ReceiveOpenChannelUpdate(chanUpdates)
 	upd, ok := updateResp.Update.(*lnrpc.OpenStatusUpdate_ChanPending)
-	require.True(t.t, ok)
+	require.True(ht, ok)
 
 	// Mine enough blocks to announce the channel to the network, making
 	// balance assertions along the way.
@@ -467,11 +344,11 @@ func fundChanAndCloseFromImportedAccount(t *harnessTest, srcNode, destNode,
 		expChangeScriptType = txscript.WitnessV1TaprootTy
 
 	default:
-		t.Fatalf("unsupported addr type %v", accountAddrType)
+		ht.Fatalf("unsupported addr type %v", accountAddrType)
 	}
 	chanChangeUtxoAmt := utxoAmt - chanSize - expChanTxFee
 	txHash, err := chainhash.NewHash(upd.ChanPending.Txid)
-	require.NoError(t.t, err)
+	require.NoError(ht, err)
 
 	// If we're spending from the default imported account, then any change
 	// outputs produced are moved to the default wallet account, so we
@@ -479,35 +356,35 @@ func fundChanAndCloseFromImportedAccount(t *harnessTest, srcNode, destNode,
 	var confBalanceAfterChan int64
 	if account == defaultImportedAccount {
 		confBalanceAfterChan = defaultAccountConfBalance
-		assertAccountBalance(t.t, srcNode, account, 0, 0)
-		assertAccountBalance(
-			t.t, srcNode, defaultAccount, defaultAccountConfBalance,
+		ht.AssertWalletAccountBalance(srcNode, account, 0, 0)
+		ht.AssertWalletAccountBalance(
+			srcNode, defaultAccount, defaultAccountConfBalance,
 			chanChangeUtxoAmt,
 		)
 
-		block := mineBlocks(t, t.lndHarness, 6, 1)[0]
-		assertTxInBlock(t, block, txHash)
+		block := ht.MineBlocksAndAssertNumTxes(6, 1)[0]
+		ht.Miner.AssertTxInBlock(block, txHash)
 
 		confBalanceAfterChan += chanChangeUtxoAmt
-		assertAccountBalance(t.t, srcNode, account, 0, 0)
-		assertAccountBalance(
-			t.t, srcNode, defaultAccount, confBalanceAfterChan, 0,
+		ht.AssertWalletAccountBalance(srcNode, account, 0, 0)
+		ht.AssertWalletAccountBalance(
+			srcNode, defaultAccount, confBalanceAfterChan, 0,
 		)
 	} else {
 		// Otherwise, all interactions remain within Carol's imported
 		// account.
 		confBalanceAfterChan = accountConfBalance - utxoAmt
-		assertAccountBalance(
-			t.t, srcNode, account, confBalanceAfterChan,
+		ht.AssertWalletAccountBalance(
+			srcNode, account, confBalanceAfterChan,
 			chanChangeUtxoAmt,
 		)
 
-		block := mineBlocks(t, t.lndHarness, 6, 1)[0]
-		assertTxInBlock(t, block, txHash)
+		block := ht.MineBlocksAndAssertNumTxes(6, 1)[0]
+		ht.Miner.AssertTxInBlock(block, txHash)
 
 		confBalanceAfterChan += chanChangeUtxoAmt
-		assertAccountBalance(
-			t.t, srcNode, account, confBalanceAfterChan, 0,
+		ht.AssertWalletAccountBalance(
+			srcNode, account, confBalanceAfterChan, 0,
 		)
 	}
 
@@ -515,8 +392,10 @@ func fundChanAndCloseFromImportedAccount(t *harnessTest, srcNode, destNode,
 	// based on the account.
 	var tx wire.MsgTx
 	err = tx.Deserialize(bytes.NewReader(finalizeResp.RawFinalTx))
-	require.NoError(t.t, err)
-	assertOutputScriptType(t.t, expChangeScriptType, &tx, chanChangeUtxoAmt)
+	require.NoError(ht, err)
+	assertOutputScriptType(
+		ht.T, expChangeScriptType, &tx, chanChangeUtxoAmt,
+	)
 
 	// Wait for the channel to be announced by both parties.
 	chanPoint := &lnrpc.ChannelPoint{
@@ -525,29 +404,30 @@ func fundChanAndCloseFromImportedAccount(t *harnessTest, srcNode, destNode,
 		},
 		OutputIndex: upd.ChanPending.OutputIndex,
 	}
-	err = srcNode.WaitForNetworkChannelOpen(chanPoint)
-	require.NoError(t.t, err)
-	err = destNode.WaitForNetworkChannelOpen(chanPoint)
-	require.NoError(t.t, err)
+	ht.AssertTopologyChannelOpen(srcNode, chanPoint)
+	ht.AssertTopologyChannelOpen(destNode, chanPoint)
 
 	// Send a test payment to ensure the channel is operating as normal.
 	const invoiceAmt = 100000
-	ctxt, cancel = context.WithTimeout(ctxb, defaultTimeout)
-	defer cancel()
-	resp, err := destNode.AddInvoice(ctxt, &lnrpc.Invoice{
+	invoice := &lnrpc.Invoice{
 		Memo:  "psbt import chan",
 		Value: invoiceAmt,
-	})
-	require.NoError(t.t, err)
+	}
+	resp := destNode.RPC.AddInvoice(invoice)
 
-	err = completePaymentRequests(
-		srcNode, srcNode.RouterClient,
-		[]string{resp.PaymentRequest}, true,
-	)
-	require.NoError(t.t, err)
+	ht.CompletePaymentRequests(srcNode, []string{resp.PaymentRequest})
+
+	// TODO(yy): remove the sleep once the following bug is fixed. When the
+	// payment is reported as settled by srcNode, it's expected the
+	// commitment dance is finished and all subsequent states have been
+	// updated. Yet we'd receive the error `cannot co-op close channel with
+	// active htlcs` or `link failed to shutdown` if we close the channel.
+	// We need to investigate the order of settling the payments and
+	// updating commitments to understand and fix .
+	time.Sleep(2 * time.Second)
 
 	// Now that we've confirmed the opened channel works, we'll close it.
-	closeChannelAndAssert(t, t.lndHarness, srcNode, chanPoint, false)
+	ht.CloseChannel(srcNode, chanPoint)
 
 	// Since the channel still had funds left on the source node's side,
 	// they must've been redeemed after the close. Without a pre-negotiated
@@ -557,17 +437,17 @@ func fundChanAndCloseFromImportedAccount(t *harnessTest, srcNode, destNode,
 	balanceFromClosedChan := chanSize - invoiceAmt - chanCloseTxFee
 
 	if account == defaultImportedAccount {
-		assertAccountBalance(t.t, srcNode, account, 0, 0)
-		assertAccountBalance(
-			t.t, srcNode, defaultAccount,
+		ht.AssertWalletAccountBalance(srcNode, account, 0, 0)
+		ht.AssertWalletAccountBalance(
+			srcNode, defaultAccount,
 			confBalanceAfterChan+balanceFromClosedChan, 0,
 		)
 	} else {
-		assertAccountBalance(
-			t.t, srcNode, account, confBalanceAfterChan, 0,
+		ht.AssertWalletAccountBalance(
+			srcNode, account, confBalanceAfterChan, 0,
 		)
-		assertAccountBalance(
-			t.t, srcNode, defaultAccount, balanceFromClosedChan, 0,
+		ht.AssertWalletAccountBalance(
+			srcNode, defaultAccount, balanceFromClosedChan, 0,
 		)
 	}
 }
@@ -575,7 +455,7 @@ func fundChanAndCloseFromImportedAccount(t *harnessTest, srcNode, destNode,
 // testWalletImportAccount tests that an imported account can fund transactions
 // and channels through PSBTs, by having one node (the one with the imported
 // account) craft the transactions and another node act as the signer.
-func testWalletImportAccount(net *lntest.NetworkHarness, t *harnessTest) {
+func testWalletImportAccount(ht *lntemp.HarnessTest) {
 	testCases := []struct {
 		name     string
 		addrType walletrpc.AddressType
@@ -600,23 +480,24 @@ func testWalletImportAccount(net *lntest.NetworkHarness, t *harnessTest) {
 
 	for _, tc := range testCases {
 		tc := tc
-		success := t.t.Run(tc.name, func(tt *testing.T) {
-			ht := newHarnessTest(tt, net)
-			ht.RunTestCase(&testCase{
-				name: tc.name,
-				test: func(net1 *lntest.NetworkHarness,
-					t1 *harnessTest) {
+		success := ht.Run(tc.name, func(tt *testing.T) {
+			testFunc := func(ht *lntemp.HarnessTest) {
+				testWalletImportAccountScenario(
+					ht, tc.addrType,
+				)
+			}
 
-					testWalletImportAccountScenario(
-						net, t, tc.addrType,
-					)
-				},
+			st := ht.Subtest(tt)
+
+			st.RunTestCase(&lntemp.TestCase{
+				Name:     tc.name,
+				TestFunc: testFunc,
 			})
 		})
 		if !success {
 			// Log failure time to help relate the lnd logs to the
 			// failure.
-			t.Logf("Failure time: %v", time.Now().Format(
+			ht.Logf("Failure time: %v", time.Now().Format(
 				"2006-01-02 15:04:05.000",
 			))
 			break
@@ -624,115 +505,98 @@ func testWalletImportAccount(net *lntest.NetworkHarness, t *harnessTest) {
 	}
 }
 
-func testWalletImportAccountScenario(net *lntest.NetworkHarness, t *harnessTest,
+func testWalletImportAccountScenario(ht *lntemp.HarnessTest,
 	addrType walletrpc.AddressType) {
 
 	// We'll start our test by having two nodes, Carol and Dave. Carol's
 	// default wallet account will be imported into Dave's node.
-	carol := net.NewNode(t.t, "carol", nil)
-	defer shutdownAndAssert(net, t, carol)
+	//
+	// NOTE: we won't use standby nodes here since the test will change
+	// each of the node's wallet state.
+	carol := ht.NewNode("carol", nil)
+	dave := ht.NewNode("dave", nil)
 
-	dave := net.NewNode(t.t, "dave", nil)
-	defer shutdownAndAssert(net, t, dave)
-
-	runWalletImportAccountScenario(net, t, addrType, carol, dave)
+	runWalletImportAccountScenario(ht, addrType, carol, dave)
 }
 
-func runWalletImportAccountScenario(net *lntest.NetworkHarness, t *harnessTest,
-	addrType walletrpc.AddressType, carol, dave *lntest.HarnessNode) {
+func runWalletImportAccountScenario(ht *lntemp.HarnessTest,
+	addrType walletrpc.AddressType, carol, dave *node.HarnessNode) {
 
-	ctxb := context.Background()
 	const utxoAmt int64 = btcutil.SatoshiPerBitcoin
 
-	ctxt, cancel := context.WithTimeout(ctxb, defaultTimeout)
-	defer cancel()
 	listReq := &walletrpc.ListAccountsRequest{
 		Name:        "default",
 		AddressType: addrType,
 	}
-	listResp, err := carol.WalletKitClient.ListAccounts(ctxt, listReq)
-	require.NoError(t.t, err)
-	require.Equal(t.t, len(listResp.Accounts), 1)
+	listResp := carol.RPC.ListAccounts(listReq)
+	require.Len(ht, listResp.Accounts, 1)
 	carolAccount := listResp.Accounts[0]
 
-	ctxt, cancel = context.WithTimeout(ctxb, defaultTimeout)
-	defer cancel()
 	const importedAccount = "carol"
 	importReq := &walletrpc.ImportAccountRequest{
 		Name:              importedAccount,
 		ExtendedPublicKey: carolAccount.ExtendedPublicKey,
 		AddressType:       addrType,
 	}
-	_, err = dave.WalletKitClient.ImportAccount(ctxt, importReq)
-	require.NoError(t.t, err)
+	dave.RPC.ImportAccount(importReq)
 
 	// We'll generate an address for Carol from Dave's node to receive some
 	// funds.
 	externalAddr := newExternalAddr(
-		t.t, dave, carol, importedAccount, addrType,
+		ht, dave, carol, importedAccount, addrType,
 	)
 
 	// Send coins to Carol's address and confirm them, making sure the
 	// balance updates accordingly.
-	ctxt, cancel = context.WithTimeout(ctxb, defaultTimeout)
-	defer cancel()
-	_, err = net.Alice.SendCoins(ctxt, &lnrpc.SendCoinsRequest{
+	alice := ht.Alice
+	req := &lnrpc.SendCoinsRequest{
 		Addr:       externalAddr,
 		Amount:     utxoAmt,
 		SatPerByte: 1,
-	})
-	require.NoError(t.t, err)
+	}
+	alice.RPC.SendCoins(req)
 
-	assertAccountBalance(t.t, dave, importedAccount, 0, utxoAmt)
-	_ = mineBlocks(t, net, 1, 1)
-	assertAccountBalance(t.t, dave, importedAccount, utxoAmt, 0)
+	ht.AssertWalletAccountBalance(dave, importedAccount, 0, utxoAmt)
+	ht.MineBlocksAndAssertNumTxes(1, 1)
+	ht.AssertWalletAccountBalance(dave, importedAccount, utxoAmt, 0)
 
 	// To ensure that Dave can use Carol's account as watch-only, we'll
 	// construct a PSBT that sends funds to Alice, which we'll then hand
 	// over to Carol to sign.
 	psbtSendFromImportedAccount(
-		t, dave, net.Alice, carol, importedAccount, addrType,
+		ht, dave, alice, carol, importedAccount, addrType,
 	)
 
 	// We'll generate a new address for Carol from Dave's node to receive
 	// and fund a new channel.
 	externalAddr = newExternalAddr(
-		t.t, dave, carol, importedAccount, addrType,
+		ht, dave, carol, importedAccount, addrType,
 	)
 
 	// Retrieve the current confirmed balance of the imported account for
 	// some assertions we'll make later on.
-	ctxt, cancel = context.WithTimeout(ctxb, defaultTimeout)
-	defer cancel()
-	balanceResp, err := dave.WalletBalance(
-		ctxt, &lnrpc.WalletBalanceRequest{},
-	)
-	require.NoError(t.t, err)
-	require.Contains(t.t, balanceResp.AccountBalance, importedAccount)
+	balanceResp := dave.RPC.WalletBalance()
+	require.Contains(ht, balanceResp.AccountBalance, importedAccount)
 	confBalance := balanceResp.AccountBalance[importedAccount].ConfirmedBalance
 
 	// Send coins to Carol's address and confirm them, making sure the
 	// balance updates accordingly.
-	ctxt, cancel = context.WithTimeout(ctxb, defaultTimeout)
-	defer cancel()
-	_, err = net.Alice.SendCoins(ctxt, &lnrpc.SendCoinsRequest{
+	req = &lnrpc.SendCoinsRequest{
 		Addr:       externalAddr,
 		Amount:     utxoAmt,
 		SatPerByte: 1,
-	})
-	require.NoError(t.t, err)
+	}
+	alice.RPC.SendCoins(req)
 
-	assertAccountBalance(t.t, dave, importedAccount, confBalance, utxoAmt)
-	_ = mineBlocks(t, net, 1, 1)
-	assertAccountBalance(
-		t.t, dave, importedAccount, confBalance+utxoAmt, 0,
-	)
+	ht.AssertWalletAccountBalance(dave, importedAccount, confBalance, utxoAmt)
+	ht.MineBlocksAndAssertNumTxes(1, 1)
+	ht.AssertWalletAccountBalance(dave, importedAccount, confBalance+utxoAmt, 0)
 
 	// Now that we have enough funds, it's time to fund the channel, make a
 	// test payment, and close it. This contains several balance assertions
 	// along the way.
 	fundChanAndCloseFromImportedAccount(
-		t, dave, net.Alice, carol, importedAccount, addrType, utxoAmt,
+		ht, dave, alice, carol, importedAccount, addrType, utxoAmt,
 		int64(funding.MaxBtcFundingAmount),
 	)
 }
@@ -740,7 +604,7 @@ func runWalletImportAccountScenario(net *lntest.NetworkHarness, t *harnessTest,
 // testWalletImportPubKey tests that an imported public keys can fund
 // transactions and channels through PSBTs, by having one node (the one with the
 // imported account) craft the transactions and another node act as the signer.
-func testWalletImportPubKey(net *lntest.NetworkHarness, t *harnessTest) {
+func testWalletImportPubKey(ht *lntemp.HarnessTest) {
 	testCases := []struct {
 		name     string
 		addrType walletrpc.AddressType
@@ -761,23 +625,24 @@ func testWalletImportPubKey(net *lntest.NetworkHarness, t *harnessTest) {
 
 	for _, tc := range testCases {
 		tc := tc
-		success := t.t.Run(tc.name, func(tt *testing.T) {
-			ht := newHarnessTest(tt, net)
-			ht.RunTestCase(&testCase{
-				name: tc.name,
-				test: func(net1 *lntest.NetworkHarness,
-					t1 *harnessTest) {
+		success := ht.Run(tc.name, func(tt *testing.T) {
+			testFunc := func(ht *lntemp.HarnessTest) {
+				testWalletImportPubKeyScenario(
+					ht, tc.addrType,
+				)
+			}
 
-					testWalletImportPubKeyScenario(
-						net, t, tc.addrType,
-					)
-				},
+			st := ht.Subtest(tt)
+
+			st.RunTestCase(&lntemp.TestCase{
+				Name:     tc.name,
+				TestFunc: testFunc,
 			})
 		})
 		if !success {
 			// Log failure time to help relate the lnd logs to the
 			// failure.
-			t.Logf("Failure time: %v", time.Now().Format(
+			ht.Logf("Failure time: %v", time.Now().Format(
 				"2006-01-02 15:04:05.000",
 			))
 			break
@@ -785,18 +650,18 @@ func testWalletImportPubKey(net *lntest.NetworkHarness, t *harnessTest) {
 	}
 }
 
-func testWalletImportPubKeyScenario(net *lntest.NetworkHarness, t *harnessTest,
+func testWalletImportPubKeyScenario(ht *lntemp.HarnessTest,
 	addrType walletrpc.AddressType) {
 
-	ctxb := context.Background()
 	const utxoAmt int64 = btcutil.SatoshiPerBitcoin
+	alice := ht.Alice
 
 	// We'll start our test by having two nodes, Carol and Dave.
-	carol := net.NewNode(t.t, "carol", nil)
-	defer shutdownAndAssert(net, t, carol)
-
-	dave := net.NewNode(t.t, "dave", nil)
-	defer shutdownAndAssert(net, t, dave)
+	//
+	// NOTE: we won't use standby nodes here since the test will change
+	// each of the node's wallet state.
+	carol := ht.NewNode("carol", nil)
+	dave := ht.NewNode("dave", nil)
 
 	// We'll define a helper closure that we'll use throughout the test to
 	// generate a new address of the given type from Carol's perspective,
@@ -806,30 +671,25 @@ func testWalletImportPubKeyScenario(net *lntest.NetworkHarness, t *harnessTest,
 
 		// Retrieve Carol's account public key for the corresponding
 		// address type.
-		ctxt, cancel := context.WithTimeout(ctxb, defaultTimeout)
-		defer cancel()
 		listReq := &walletrpc.ListAccountsRequest{
 			Name:        "default",
 			AddressType: addrType,
 		}
-		listResp, err := carol.WalletKitClient.ListAccounts(
-			ctxt, listReq,
-		)
-		require.NoError(t.t, err)
-		require.Equal(t.t, len(listResp.Accounts), 1)
+		listResp := carol.RPC.ListAccounts(listReq)
+		require.Len(ht, listResp.Accounts, 1)
 		p2wkhAccount := listResp.Accounts[0]
 
 		// Derive the external address at the given index.
 		accountPubKey, err := hdkeychain.NewKeyFromString(
 			p2wkhAccount.ExtendedPublicKey,
 		)
-		require.NoError(t.t, err)
+		require.NoError(ht, err)
 		externalAccountExtKey, err := accountPubKey.Derive(0)
-		require.NoError(t.t, err)
+		require.NoError(ht, err)
 		externalAddrExtKey, err := externalAccountExtKey.Derive(keyIndex)
-		require.NoError(t.t, err)
+		require.NoError(ht, err)
 		externalAddrPubKey, err := externalAddrExtKey.ECPubKey()
-		require.NoError(t.t, err)
+		require.NoError(ht, err)
 
 		// Serialize as 32-byte x-only pubkey for Taproot addresses.
 		serializedPubKey := externalAddrPubKey.SerializeCompressed()
@@ -840,44 +700,34 @@ func testWalletImportPubKeyScenario(net *lntest.NetworkHarness, t *harnessTest,
 		}
 
 		// Import the public key into Dave.
-		ctxt, cancel = context.WithTimeout(ctxb, defaultTimeout)
-		defer cancel()
 		importReq := &walletrpc.ImportPublicKeyRequest{
 			PublicKey:   serializedPubKey,
 			AddressType: addrType,
 		}
-		_, err = dave.WalletKitClient.ImportPublicKey(ctxt, importReq)
-		require.NoError(t.t, err)
+		dave.RPC.ImportPublicKey(importReq)
 
 		// We'll also generate the same address for Carol, as it'll be
 		// required later when signing.
-		ctxt, cancel = context.WithTimeout(ctxb, defaultTimeout)
-		defer cancel()
-		carolAddrResp, err := carol.NewAddress(
-			ctxt, &lnrpc.NewAddressRequest{
-				Type: walletToLNAddrType(t.t, addrType),
-			},
-		)
-		require.NoError(t.t, err)
+		carolAddrResp := carol.RPC.NewAddress(&lnrpc.NewAddressRequest{
+			Type: walletToLNAddrType(ht.T, addrType),
+		})
 
 		// Send coins to Carol's address and confirm them, making sure
 		// the balance updates accordingly.
-		ctxt, cancel = context.WithTimeout(ctxb, defaultTimeout)
-		defer cancel()
-		_, err = net.Alice.SendCoins(ctxt, &lnrpc.SendCoinsRequest{
+		req := &lnrpc.SendCoinsRequest{
 			Addr:       carolAddrResp.Address,
 			Amount:     utxoAmt,
 			SatPerByte: 1,
-		})
-		require.NoError(t.t, err)
+		}
+		alice.RPC.SendCoins(req)
 
-		assertAccountBalance(
-			t.t, dave, defaultImportedAccount, prevConfBalance,
+		ht.AssertWalletAccountBalance(
+			dave, defaultImportedAccount, prevConfBalance,
 			prevUnconfBalance+utxoAmt,
 		)
-		_ = mineBlocks(t, net, 1, 1)
-		assertAccountBalance(
-			t.t, dave, defaultImportedAccount,
+		ht.MineBlocksAndAssertNumTxes(1, 1)
+		ht.AssertWalletAccountBalance(
+			dave, defaultImportedAccount,
 			prevConfBalance+utxoAmt, prevUnconfBalance,
 		)
 	}
@@ -890,22 +740,15 @@ func testWalletImportPubKeyScenario(net *lntest.NetworkHarness, t *harnessTest,
 	// construct a PSBT that sends funds to Alice, which we'll then hand
 	// over to Carol to sign.
 	psbtSendFromImportedAccount(
-		t, dave, net.Alice, carol, defaultImportedAccount, addrType,
+		ht, dave, alice, carol, defaultImportedAccount, addrType,
 	)
 
 	// We'll now attempt to fund a channel.
 	//
 	// We'll have Carol generate another external address, which we'll
 	// import into Dave again.
-	ctxt, cancel := context.WithTimeout(ctxb, defaultTimeout)
-	defer cancel()
-	balanceResp, err := dave.WalletBalance(
-		ctxt, &lnrpc.WalletBalanceRequest{},
-	)
-	require.NoError(t.t, err)
-	require.Contains(
-		t.t, balanceResp.AccountBalance, defaultImportedAccount,
-	)
+	balanceResp := dave.RPC.WalletBalance()
+	require.Contains(ht, balanceResp.AccountBalance, defaultImportedAccount)
 	confBalance := balanceResp.
 		AccountBalance[defaultImportedAccount].ConfirmedBalance
 	importPubKey(1, confBalance, 0)
@@ -914,7 +757,7 @@ func testWalletImportPubKeyScenario(net *lntest.NetworkHarness, t *harnessTest,
 	// test payment, and close it. This contains several balance assertions
 	// along the way.
 	fundChanAndCloseFromImportedAccount(
-		t, dave, net.Alice, carol, defaultImportedAccount, addrType,
+		ht, dave, alice, carol, defaultImportedAccount, addrType,
 		utxoAmt, int64(funding.MaxBtcFundingAmount),
 	)
 }

--- a/lntest/itest/lnd_zero_conf_test.go
+++ b/lntest/itest/lnd_zero_conf_test.go
@@ -870,7 +870,6 @@ func testOptionScidUpgrade(ht *lntemp.HarnessTest) {
 // should be run in a goroutine and is used to test nodes with the zero-conf
 // feature bit.
 func acceptChannel(t *testing.T, zeroConf bool, stream rpc.AcceptorClient) {
-
 	t.Helper()
 
 	req, err := stream.Recv()

--- a/lntest/itest/utils.go
+++ b/lntest/itest/utils.go
@@ -8,9 +8,7 @@ import (
 	"time"
 
 	"github.com/btcsuite/btcd/btcutil"
-	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcd/rpcclient"
-	"github.com/btcsuite/btcd/txscript"
 	"github.com/btcsuite/btcd/wire"
 	"github.com/go-errors/errors"
 	"github.com/lightningnetwork/lnd/input"
@@ -467,32 +465,4 @@ func findTxAtHeight(t *harnessTest, height int32,
 	}
 
 	return nil
-}
-
-// getOutputIndex returns the output index of the given address in the given
-// transaction.
-func getOutputIndex(t *harnessTest, miner *lntest.HarnessMiner,
-	txid *chainhash.Hash, addr string) int {
-
-	t.t.Helper()
-
-	// We'll then extract the raw transaction from the mempool in order to
-	// determine the index of the p2tr output.
-	tx, err := miner.Client.GetRawTransaction(txid)
-	require.NoError(t.t, err)
-
-	p2trOutputIndex := -1
-	for i, txOut := range tx.MsgTx().TxOut {
-		_, addrs, _, err := txscript.ExtractPkScriptAddrs(
-			txOut.PkScript, miner.ActiveNet,
-		)
-		require.NoError(t.t, err)
-
-		if addrs[0].String() == addr {
-			p2trOutputIndex = i
-		}
-	}
-	require.Greater(t.t, p2trOutputIndex, -1)
-
-	return p2trOutputIndex
 }

--- a/lntest/itest/utils.go
+++ b/lntest/itest/utils.go
@@ -5,7 +5,6 @@ import (
 	"crypto/rand"
 	"fmt"
 	"io"
-	"testing"
 	"time"
 
 	"github.com/btcsuite/btcd/btcutil"
@@ -18,7 +17,6 @@ import (
 	"github.com/lightningnetwork/lnd/lnrpc"
 	"github.com/lightningnetwork/lnd/lnrpc/routerrpc"
 	"github.com/lightningnetwork/lnd/lntemp"
-	"github.com/lightningnetwork/lnd/lntemp/rpc"
 	"github.com/lightningnetwork/lnd/lntest"
 	"github.com/lightningnetwork/lnd/lntest/wait"
 	"github.com/lightningnetwork/lnd/lnwallet"
@@ -497,22 +495,4 @@ func getOutputIndex(t *harnessTest, miner *lntest.HarnessMiner,
 	require.Greater(t.t, p2trOutputIndex, -1)
 
 	return p2trOutputIndex
-}
-
-// acceptChannel is used to accept a single channel that comes across. This
-// should be run in a goroutine and is used to test nodes with the zero-conf
-// feature bit.
-func acceptChannel(t *testing.T, zeroConf bool, stream rpc.AcceptorClient) {
-	t.Helper()
-
-	req, err := stream.Recv()
-	require.NoError(t, err)
-
-	resp := &lnrpc.ChannelAcceptResponse{
-		Accept:        true,
-		PendingChanId: req.PendingChanId,
-		ZeroConf:      zeroConf,
-	}
-	err = stream.Send(resp)
-	require.NoError(t, err)
 }

--- a/lnwallet/channel_test.go
+++ b/lnwallet/channel_test.go
@@ -2737,10 +2737,7 @@ func TestAddHTLCNegativeBalance(t *testing.T) {
 	htlcAmt = lnwire.NewMSatFromSatoshis(2 * btcutil.SatoshiPerBitcoin)
 	htlc, _ := createHTLC(numHTLCs+1, htlcAmt)
 	_, err = aliceChannel.AddHTLC(htlc, nil)
-	if err != ErrBelowChanReserve {
-		t.Fatalf("expected balance below channel reserve, instead "+
-			"got: %v", err)
-	}
+	require.ErrorIs(t, err, ErrBelowChanReserve)
 }
 
 // assertNoChanSyncNeeded is a helper function that asserts that upon restart,
@@ -5642,10 +5639,8 @@ func TestDesyncHTLCs(t *testing.T) {
 	// balance is unavailable.
 	htlcAmt = lnwire.NewMSatFromSatoshis(1 * btcutil.SatoshiPerBitcoin)
 	htlc, _ = createHTLC(1, htlcAmt)
-	if _, err = aliceChannel.AddHTLC(htlc, nil); err != ErrBelowChanReserve {
-		t.Fatalf("expected ErrInsufficientBalance, instead received: %v",
-			err)
-	}
+	_, err = aliceChannel.AddHTLC(htlc, nil)
+	require.ErrorIs(t, err, ErrBelowChanReserve)
 
 	// Now do a state transition, which will ACK the FailHTLC, making Alice
 	// able to add the new HTLC.
@@ -6063,14 +6058,11 @@ func TestChanReserve(t *testing.T) {
 	htlc, _ = createHTLC(bobIndex, htlcAmt)
 	bobIndex++
 	_, err := bobChannel.AddHTLC(htlc, nil)
-	if err != ErrBelowChanReserve {
-		t.Fatalf("expected ErrBelowChanReserve, instead received: %v", err)
-	}
+	require.ErrorIs(t, err, ErrBelowChanReserve)
 
 	// Alice will reject this htlc upon receiving the htlc.
-	if _, err := aliceChannel.ReceiveHTLC(htlc); err != ErrBelowChanReserve {
-		t.Fatalf("expected ErrBelowChanReserve, instead received: %v", err)
-	}
+	_, err = aliceChannel.ReceiveHTLC(htlc)
+	require.ErrorIs(t, err, ErrBelowChanReserve)
 
 	// We must setup the channels again, since a violation of the channel
 	// constraints leads to channel shutdown.
@@ -6105,14 +6097,11 @@ func TestChanReserve(t *testing.T) {
 	htlc, _ = createHTLC(aliceIndex, htlcAmt)
 	aliceIndex++
 	_, err = aliceChannel.AddHTLC(htlc, nil)
-	if err != ErrBelowChanReserve {
-		t.Fatalf("expected ErrBelowChanReserve, instead received: %v", err)
-	}
+	require.ErrorIs(t, err, ErrBelowChanReserve)
 
 	// Likewise, Bob will reject receiving the htlc because of the same reason.
-	if _, err := bobChannel.ReceiveHTLC(htlc); err != ErrBelowChanReserve {
-		t.Fatalf("expected ErrBelowChanReserve, instead received: %v", err)
-	}
+	_, err = bobChannel.ReceiveHTLC(htlc)
+	require.ErrorIs(t, err, ErrBelowChanReserve)
 
 	// We must setup the channels again, since a violation of the channel
 	// constraints leads to channel shutdown.
@@ -6218,22 +6207,15 @@ func TestChanReserveRemoteInitiator(t *testing.T) {
 	// Bob should refuse to add this HTLC, since he realizes it will create
 	// an invalid commitment.
 	_, err = bobChannel.AddHTLC(htlc, nil)
-	if err != ErrBelowChanReserve {
-		t.Fatalf("expected ErrBelowChanReserve, instead received: %v",
-			err)
-	}
+	require.ErrorIs(t, err, ErrBelowChanReserve)
 
 	// Of course Alice will also not have enough balance to add it herself.
 	_, err = aliceChannel.AddHTLC(htlc, nil)
-	if err != ErrBelowChanReserve {
-		t.Fatalf("expected ErrBelowChanReserve, instead received: %v",
-			err)
-	}
+	require.ErrorIs(t, err, ErrBelowChanReserve)
 
 	// Same for Alice, she should refuse to accept this second HTLC.
-	if _, err := aliceChannel.ReceiveHTLC(htlc); err != ErrBelowChanReserve {
-		t.Fatalf("expected ErrBelowChanReserve, instead received: %v", err)
-	}
+	_, err = aliceChannel.ReceiveHTLC(htlc)
+	require.ErrorIs(t, err, ErrBelowChanReserve)
 }
 
 // TestChanReserveLocalInitiatorDustHtlc tests that fee the initiator must pay
@@ -6276,9 +6258,7 @@ func TestChanReserveLocalInitiatorDustHtlc(t *testing.T) {
 	// Alice should realize that the fee she must pay to add this HTLC to
 	// the local commitment would take her below the channel reserve.
 	_, err = aliceChannel.AddHTLC(htlc, nil)
-	if err != ErrBelowChanReserve {
-		t.Fatalf("expected ErrBelowChanReserve, instead received: %v", err)
-	}
+	require.ErrorIs(t, err, ErrBelowChanReserve)
 }
 
 // TestMinHTLC tests that the ErrBelowMinHTLC error is thrown if an HTLC is added


### PR DESCRIPTION
Please check #6825 for more context.

Depending on #6823, this PR continues the fix of the tests.

This PR starts at commit `lntemp+itest: refactor testSwitchCircuitPersistence`.