### PR TITLE
chainreg: update tapoort node awareness to account for bitcoind 19+

### DIFF
--- a/chainreg/taproot_check.go
+++ b/chainreg/taproot_check.go
@@ -14,8 +14,19 @@ func backendSupportsTaproot(rpc *rpcclient.Client) bool {
 	if err == nil {
 		// If this call worked, then we'll check that the taproot
 		// deployment is defined.
-		if chainInfo.SoftForks != nil {
+		switch {
+		// Bitcoind versions before 0.19 and also btcd use the
+		// SoftForks fields.
+		case chainInfo.SoftForks != nil:
 			_, ok := chainInfo.SoftForks.Bip9SoftForks["taproot"]
+			if ok {
+				return ok
+			}
+
+		// Bitcoind versions after 0.19 will use the UnifiedSoftForks
+		// field that factors in the set of "buried" soft forks.
+		case chainInfo.UnifiedSoftForks != nil:
+			_, ok := chainInfo.UnifiedSoftForks.SoftForks["taproot"]
 			if ok {
 				return ok
 			}

--- a/docs/release-notes/release-notes-0.15.1.md
+++ b/docs/release-notes/release-notes-0.15.1.md
@@ -30,7 +30,9 @@ of the draft BIP.
 ## Taproot
 
 [`lnd` will now refuse to start if it detects the full node backend does not
-support Tapoot](https://github.com/lightningnetwork/lnd/pull/6798).
+support Tapoot](https://github.com/lightningnetwork/lnd/pull/6798). [With this
+change](https://github.com/lightningnetwork/lnd/pull/6826), the officially
+supported versions of bitcoind are: 21, 22, and 23.
 
 [`lnd` will now use taproot addresses for co-op closes if the remote peer
 supports the feature.](https://github.com/lightningnetwork/lnd/pull/6633)


### PR DESCRIPTION
Bitcoind 23 will use the new `getdeploymentinfo` while versions after 19
(but below 23) will use the `UnifiedSoftForks` field instead of the
`SoftForks UnifiedSoftForks` field.

With this PR the taproot gating logic has been tested on bitcoind
versions: 21, 22, and 23. 21 is when the taproot logic was first added.
