### PR TITLE
tor: fix parsing replies

### DIFF
--- a/docs/release-notes/release-notes-0.16.0.md
+++ b/docs/release-notes/release-notes-0.16.0.md
@@ -20,6 +20,10 @@ transaction](https://github.com/lightningnetwork/lnd/pull/6730).
 * [The macaroon key store implementation was refactored to be more generally
   usable](https://github.com/lightningnetwork/lnd/pull/6509).
 
+* [Fixed a bug where cookie authentication with Tor would fail if the cookie
+  path contained spaces](https://github.com/lightningnetwork/lnd/pull/6829).
+  Now it parses Tor control port messages correctly.
+
 ## `lncli`
 * [Add an `insecure` flag to skip tls auth as well as a `metadata` string slice
   flag](https://github.com/lightningnetwork/lnd/pull/6818) that allows the 
@@ -36,6 +40,7 @@ transaction](https://github.com/lightningnetwork/lnd/pull/6730).
 # Contributors (Alphabetical Order)
 
 * Carla Kirk-Cohen
+* cutiful
 * Daniel McNally
 * Elle Mouton
 * ErikEk

--- a/tor/controller_test.go
+++ b/tor/controller_test.go
@@ -359,3 +359,64 @@ func TestReconnectSucceed(t *testing.T) {
 	// Check that the connection has been updated.
 	require.NotEqual(t, proxy.clientConn, c.conn)
 }
+
+// TestParseTorReply tests that Tor replies are parsed correctly.
+func TestParseTorReply(t *testing.T) {
+	testCase := []struct {
+		reply          string
+		expectedParams map[string]string
+	}{
+		{
+			// Test a regular reply.
+			reply: `VERSION Tor="0.4.7.8"`,
+			expectedParams: map[string]string{
+				"Tor": "0.4.7.8",
+			},
+		},
+		{
+			// Test a reply with multiple values, one of them
+			// containing spaces.
+			reply: `AUTH METHODS=COOKIE,SAFECOOKIE,HASHEDPASSWORD` +
+				` COOKIEFILE="/path/with/spaces/Tor Browser/c` +
+				`ontrol_auth_cookie"`,
+			expectedParams: map[string]string{
+				"METHODS": "COOKIE,SAFECOOKIE,HASHEDPASSWORD",
+				"COOKIEFILE": "/path/with/spaces/Tor Browser/" +
+					"control_auth_cookie",
+			},
+		},
+		{
+			// Test a multiline reply.
+			reply:          "ServiceID=id\r\nOK",
+			expectedParams: map[string]string{"ServiceID": "id"},
+		},
+		{
+			// Test a reply with invalid parameters.
+			reply:          "AUTH =invalid",
+			expectedParams: map[string]string{},
+		},
+		{
+			// Test escaping arbitrary characters.
+			reply: `PARAM="esca\ped \"doub\lequotes\""`,
+			expectedParams: map[string]string{
+				`PARAM`: `escaped "doublequotes"`,
+			},
+		},
+		{
+			// Test escaping backslashes. Each single backslash
+			// should be removed, each double backslash replaced
+			// with a single one. Note that the single backslash
+			// before the space escapes the space character, so
+			// there's two spaces in a row.
+			reply: `PARAM="escaped \\ \ \\\\"`,
+			expectedParams: map[string]string{
+				`PARAM`: `escaped \  \\`,
+			},
+		},
+	}
+
+	for _, tc := range testCase {
+		params := parseTorReply(tc.reply)
+		require.Equal(t, tc.expectedParams, params)
+	}
+}


### PR DESCRIPTION
Replies may contain quoted values that include spaces, newlines and/or escaped characters (including doublequote itself). Not accounting for that leads to errors when e. g. `COOKIEFILE` path contains spaces.

## Change Description
https://github.com/lightningnetwork/lnd/issues/1697#issuecomment-487238128

## Steps to Test
- Configure Tor to store the cookie in a directory path to which contains spaces
- Run the current version, it'll crash
- Build the package with this patch applied, it'll run successfully

## Pull Request Checklist
### Testing
- [ ] Your PR passes all CI checks.
- [x] Tests covering the positive and negative (error paths) are included.
- [x] Bug fixes contain tests triggering the bug to prevent regressions.

### Code Style and Documentation
- [x] The change obeys the [Code Documentation and Commenting](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#CodeDocumentation) guidelines, and lines wrap at 80.
- [x] Commits follow the [Ideal Git Commit Structure](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#IdealGitCommitStructure).
- [x] Any new logging statements use an appropriate subsystem and logging level.
- [x]  [There is a change description in the release notes](https://github.com/lightningnetwork/lnd/tree/master/docs/release-notes), or `[skip ci]` in the commit message for small changes.

📝 Please see our  [Contribution Guidelines](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md) for further guidance.