### PR TITLE
github: cancel concurrent workflows for the same PR/push

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,6 +8,11 @@ on:
     branches:
       - "*"
 
+concurrency:
+  # Cancel any previous workflows if they are from a PR or push.
+  group: ${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 defaults:
   run:
     shell: bash


### PR DESCRIPTION
See more on [using concurrency](https://docs.github.com/en/actions/using-jobs/using-concurrency).

This PR uses `concurrency` to run a single job at a time. Intentionally left out a release note since it's small but also want to see the results.

Tested with a force push with the current PR and the [previous workflow](https://github.com/lightningnetwork/lnd/actions/runs/2877861206) was canceled by the push.