### PR TITLE
rpcserver+docs: add default case to addr type switch

### DIFF
--- a/docs/release-notes/release-notes-0.15.1.md
+++ b/docs/release-notes/release-notes-0.15.1.md
@@ -164,6 +164,9 @@ default](https://github.com/lightningnetwork/lnd/pull/6810) in most cases.
 * [Remove `ScidAliasOptional` dependency on 
 `ExplicitChannelTypeOptional`](https://github.com/lightningnetwork/lnd/pull/6809)
 
+* [Add a default case](https://github.com/lightningnetwork/lnd/pull/6847) to the
+  Address Type switch statement in the `NewAddress` rpc server method.
+
 ## Code Health
 
 ### Code cleanup, refactor, typo fixes

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -1542,6 +1542,9 @@ func (r *rpcServer) NewAddress(ctx context.Context,
 		if err != nil {
 			return nil, err
 		}
+
+	default:
+		return nil, fmt.Errorf("unknown address type: %v", in.Type)
 	}
 
 	rpcsLog.Debugf("[newaddress] account=%v type=%v addr=%v", account,


### PR DESCRIPTION
This commit adds a default case to the address type switch statement in
the NewAddress rpc server function. This catches any invalid address
types and returns an error.

Fixex https://github.com/lightningnetwork/lnd/issues/6846