### PR TITLE
release: create v0.15.1-rc2 release branch

### DIFF
--- a/build/version.go
+++ b/build/version.go
@@ -48,7 +48,7 @@ const (
 
 	// AppPreRelease MUST only contain characters from semanticAlphabet
 	// per the semantic versioning spec.
-	AppPreRelease = "beta.rc1"
+	AppPreRelease = "beta.rc2"
 )
 
 func init() {

--- a/docs/release-notes/release-notes-0.15.1.md
+++ b/docs/release-notes/release-notes-0.15.1.md
@@ -164,6 +164,9 @@ default](https://github.com/lightningnetwork/lnd/pull/6810) in most cases.
 * [Remove `ScidAliasOptional` dependency on 
 `ExplicitChannelTypeOptional`](https://github.com/lightningnetwork/lnd/pull/6809)
 
+* [Add a default case](https://github.com/lightningnetwork/lnd/pull/6847) to the
+  Address Type switch statement in the `NewAddress` rpc server method.
+
 ## Code Health
 
 ### Code cleanup, refactor, typo fixes

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -1542,6 +1542,9 @@ func (r *rpcServer) NewAddress(ctx context.Context,
 		if err != nil {
 			return nil, err
 		}
+
+	default:
+		return nil, fmt.Errorf("unknown address type: %v", in.Type)
 	}
 
 	rpcsLog.Debugf("[newaddress] account=%v type=%v addr=%v", account,


### PR DESCRIPTION
This PR is a staging ground for the second release candidate for 0.15.1. So far we have just one bug fix, but another potential candidate is including https://github.com/btcsuite/btcd/pull/1876 as that fixes a long standing issue w.r.t resolving IPv6 addresses over Tor. 