### PR TITLE
Skipping path when cltv delta is 0 instead of logging it

### DIFF
--- a/routing/pathfind.go
+++ b/routing/pathfind.go
@@ -735,10 +735,9 @@ func findPath(g *graphParams, r *RestrictParams, cfg *PathFindingConfig,
 		}
 
 		// Every edge should have a positive time lock delta. If we
-		// encounter a zero delta, log a warning line.
+		// encounter a zero delta, skip this route.
 		if edge.TimeLockDelta == 0 {
-			log.Warnf("Channel %v has zero cltv delta",
-				edge.ChannelID)
+			return
 		}
 
 		// Calculate the total routing info size if this hop were to be


### PR DESCRIPTION
## Change Description
As part of pathfinding, lnd might encounter edges that have a policy specifying a zero CLTV delta (possibly because of no/outdated gossip?). Every time an edge like this is used in the pathfinding code, a warning is logged.
This should never happen as the node that is setting this value to zero can be stolen from as any HTLC they forward is instantly at risk for an on-chain race to claim funds.

This PR will skip the path instead of logging when cltv delta is 0

Fixes: #6069

## Steps to Test
Run QueryRoutes a few times.

## Pull Request Checklist
### Testing
- [ ] Your PR passes all CI checks.
- [ ] Tests covering the positive and negative (error paths) are included.
- [ ] Bug fixes contain tests triggering the bug to prevent regressions.

### Code Style and Documentation
- [ ] The change obeys the [Code Documentation and Commenting](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#CodeDocumentation) guidelines, and lines wrap at 80.
- [ ] Commits follow the [Ideal Git Commit Structure](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#IdealGitCommitStructure).
- [ ] Any new logging statements use an appropriate subsystem and logging level.
- [ ]  [There is a change description in the release notes](https://github.com/lightningnetwork/lnd/tree/master/docs/release-notes), or `[skip ci]` in the commit message for small changes.

📝 Please see our  [Contribution Guidelines](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md) for further guidance.