### PR TITLE
lncli: fix sendpayment arg parsing

### DIFF
--- a/docs/release-notes/release-notes-0.16.0.md
+++ b/docs/release-notes/release-notes-0.16.0.md
@@ -54,6 +54,9 @@ minimum version needed to build the project.
   caller to specify key-value string pairs that should be appended to the 
   outgoing context.
 
+* [Fix](https://github.com/lightningnetwork/lnd/pull/6858) command line argument
+  parsing for `lncli sendpayment`.
+
 ## Code Health
 
 * [test: use `T.TempDir` to create temporary test 


### PR DESCRIPTION
Payment address isn't parsed correctly from the unnamed args. This makes it impossible to use the unnamed format with `lncli sendpayment`.