### PR TITLE
cmd+docs: fix cap out of range error in profile command

### DIFF
--- a/cmd/lncli/cmd_profile.go
+++ b/cmd/lncli/cmd_profile.go
@@ -199,6 +199,10 @@ func profileRemove(ctx *cli.Context) error {
 		return fmt.Errorf("name argument missing")
 	}
 
+	if len(f.Profiles) == 0 {
+		return fmt.Errorf("there are no existing profiles")
+	}
+
 	// Create a copy of all profiles but don't include the one to delete.
 	newProfiles := make([]*profileEntry, 0, len(f.Profiles)-1)
 	for _, p := range f.Profiles {

--- a/docs/release-notes/release-notes-0.16.0.md
+++ b/docs/release-notes/release-notes-0.16.0.md
@@ -57,6 +57,9 @@ minimum version needed to build the project.
 * [Fix](https://github.com/lightningnetwork/lnd/pull/6858) command line argument
   parsing for `lncli sendpayment`.
 
+* [Fix](https://github.com/lightningnetwork/lnd/pull/6875) mapslice cap out of 
+  range error that occurs if the number of profiles is zero.
+
 ## Code Health
 
 * [test: use `T.TempDir` to create temporary test 


### PR DESCRIPTION
If `lncli profile remove` is called when there are no existing profiles,
it will cause a "cap out of range" panic. So in this commit, a length
check is added to avoid this.