### PR TITLE
htlcswitch: add p2p inbound fee

### DIFF
--- a/htlcswitch/link_test.go
+++ b/htlcswitch/link_test.go
@@ -6649,3 +6649,17 @@ func assertFailureCode(t *testing.T, err error, code lnwire.FailCode) {
 			code, rtErr.WireMessage().Code())
 	}
 }
+
+func TestCalculateInboundFee(t *testing.T) {
+	const (
+		amt     = 10000000
+		feeBase = -10000
+		feeRate = -20000
+	)
+
+	fee := calculateInboundFee(amt, feeBase, feeRate)
+	require.Equal(t, -210000, int(fee))
+
+	fee = calculateInboundFeeFromIncoming(amt+fee, feeBase, feeRate)
+	require.Equal(t, -210000, int(fee))
+}

--- a/lnwallet/channel.go
+++ b/lnwallet/channel.go
@@ -5366,6 +5366,8 @@ func (lc *LightningChannel) ReceiveHTLC(htlc *lnwire.UpdateAddHTLC) (uint64, err
 		return 0, err
 	}
 
+	lc.log.Infof("DEBUG: receiving amount %v", htlc.Amount)
+
 	lc.remoteUpdateLog.appendHtlc(pd)
 
 	return pd.HtlcIndex, nil
@@ -5406,6 +5408,8 @@ func (lc *LightningChannel) SettleHTLC(preimage [32]byte,
 	if htlc == nil {
 		return ErrUnknownHtlcIndex{lc.ShortChanID(), htlcIndex}
 	}
+
+	lc.log.Infof("DEBUG: settling amount %v", htlc.Amount)
 
 	// Now that we know the HTLC exists, before checking to see if the
 	// preimage matches, we'll ensure that we haven't already attempted to

--- a/lnwire/message.go
+++ b/lnwire/message.go
@@ -42,6 +42,7 @@ const (
 	MsgUpdateFee                           = 134
 	MsgUpdateFailMalformedHTLC             = 135
 	MsgChannelReestablish                  = 136
+	MsgUpdateInboundFee                    = 32768
 	MsgChannelAnnouncement                 = 256
 	MsgNodeAnnouncement                    = 257
 	MsgChannelUpdate                       = 258
@@ -96,6 +97,8 @@ func (t MessageType) String() string {
 		return "ClosingSigned"
 	case MsgUpdateAddHTLC:
 		return "UpdateAddHTLC"
+	case MsgUpdateInboundFee:
+		return "UpdateInboundFee"
 	case MsgUpdateFailHTLC:
 		return "UpdateFailHTLC"
 	case MsgUpdateFulfillHTLC:
@@ -198,6 +201,8 @@ func makeEmptyMessage(msgType MessageType) (Message, error) {
 		msg = &ClosingSigned{}
 	case MsgUpdateAddHTLC:
 		msg = &UpdateAddHTLC{}
+	case MsgUpdateInboundFee:
+		msg = &UpdateInboundFee{}
 	case MsgUpdateFailHTLC:
 		msg = &UpdateFailHTLC{}
 	case MsgUpdateFulfillHTLC:

--- a/lnwire/update_inbound_fee.go
+++ b/lnwire/update_inbound_fee.go
@@ -1,0 +1,86 @@
+package lnwire
+
+import (
+	"bytes"
+	"io"
+)
+
+type UpdateInboundFee struct {
+	// ChanID is the particular active channel that this
+	// UpdateInboundDiscount is bound to.
+	ChanID ChannelID
+
+	BaseFee int32
+
+	FeeRate int32
+
+	ExtraData ExtraOpaqueData
+}
+
+// NewUpdateAddHTLC returns a new empty UpdateAddHTLC message.
+func NewUpdateInboundDiscount() *UpdateInboundFee {
+	return &UpdateInboundFee{}
+}
+
+// A compile time check to ensure UpdateAddHTLC implements the lnwire.Message
+// interface.
+var _ Message = (*UpdateInboundFee)(nil)
+
+// Decode deserializes a serialized UpdateAddHTLC message stored in the passed
+// io.Reader observing the specified protocol version.
+//
+// This is part of the lnwire.Message interface.
+func (c *UpdateInboundFee) Decode(r io.Reader, pver uint32) error {
+	var baseFee, feeRate uint32
+
+	err := ReadElements(r,
+		&c.ChanID,
+		&baseFee,
+		&feeRate,
+	)
+	if err != nil {
+		return err
+	}
+
+	c.BaseFee = int32(baseFee)
+	c.FeeRate = int32(feeRate)
+
+	return c.ExtraData.Decode(r)
+}
+
+// Encode serializes the target UpdateAddHTLC into the passed io.Writer
+// observing the protocol version specified.
+//
+// This is part of the lnwire.Message interface.
+func (c *UpdateInboundFee) Encode(w *bytes.Buffer, pver uint32) error {
+	if err := WriteChannelID(w, c.ChanID); err != nil {
+		return err
+	}
+
+	if err := WriteUint32(w, uint32(c.BaseFee)); err != nil {
+		return err
+	}
+
+	if err := WriteUint32(w, uint32(c.FeeRate)); err != nil {
+		return err
+	}
+
+	// Finally, append any extra opaque data.
+	return WriteBytes(w, c.ExtraData)
+}
+
+// MsgType returns the integer uniquely identifying this message type on the
+// wire.
+//
+// This is part of the lnwire.Message interface.
+func (c *UpdateInboundFee) MsgType() MessageType {
+	return MsgUpdateInboundFee
+}
+
+// TargetChanID returns the channel id of the link for which this message is
+// intended.
+//
+// NOTE: Part of peer.LinkUpdater interface.
+func (c *UpdateInboundFee) TargetChanID() ChannelID {
+	return c.ChanID
+}


### PR DESCRIPTION
Alternative to gossip-based inbound routing fees as implemented in #6703. Idea mentioned in https://github.com/lightning/blips/pull/18#issuecomment-1230466350, apparently originally proposed by @rustyrussell.

### Summary

A node A can give its peer B a discount for routing through them. Assuming market forces do their work, this allows the peer B to lower its outbound fee with the difference being made up by the discount. The lowered outbound fee of B is picked up by senders who may then favor that connection. Node A recovers the discount by raising its outbound fees.

### Routing node vs final destination

When a node isn't exclusively a routing node, but also a payment destination, the node operator needs to take into account that the discount will also apply to incoming payments. This means that the paid amount may be below the invoice amount. There doesn't seem to be a way around this without its predecessor knowing whether they are forwarding to an intermediate or a final hop.

An alternative is to set up a virtual destination node and charge an outbound fee for the virtual channel. Note that in that configuration, there is only a single outbound fee. WIth differing fees on the incoming side, it won't be possible to match those exactly with the outbound fee. To ensure that at least the invoice amount is always received, the outbound fee for the virtual channel will have to be at least the maximum inbound fee (max inbound base fee + max inbound fee rate).

### Incentives to upgrade

A incentive to upgrade exists, because it allows routing nodes to collect the discount. They can initially keep their own discount to zero.

The p2p inbound fee could also be positive, but that would force the counterparty to monitor the fee actively and increase their outbound rate if necessary to not lose money. If it is always negative (a discount), the routing fee earned by the counterparty can only be zero or positive.

### Implementation

This PR adds a new message `UpdateInboundFee` that a node can send to its peer to update the inbound fee that it requires. Because htlcs to which this fee apply are travelling in the other direction, there can be race conditions. If the inbound fee is lowered (more discount), there is no problem because a higher total routing fee is accepted as well. If the inbound fee is raised, this may result in the occasional `fee_insufficient` failure going back to the sender. There is nothing to update for the sender though, but a retry will likely succeed as time has passed.

The remote inbound fee isn't persisted, but instead transmitted every time the link connection is re-established.

Todo:
* [ ] Set/view own inbound fees
* [ ] View remote inbound fees
* [ ] Test coverage