### PR TITLE
server.go: add peerChan to peerConnectedListeners in NotifyWhenOnline

### DIFF
--- a/docs/release-notes/release-notes-0.15.2.md
+++ b/docs/release-notes/release-notes-0.15.2.md
@@ -6,6 +6,12 @@
   (`POST /v1/graph/routes`)](https://github.com/lightningnetwork/lnd/pull/6926)
   to make it possible to specify `route_hints` over REST.
 
+## Bug Fixes
+
+* [A bug where LND wouldn't send a ChannelUpdate during a channel open has
+  been fixed.](https://github.com/lightningnetwork/lnd/pull/6892)
+
 # Contributors (Alphabetical Order)
 
+* Eugene Siegel
 * Oliver Gugger

--- a/server.go
+++ b/server.go
@@ -3195,7 +3195,13 @@ func (s *server) NotifyWhenOnline(peerKey [33]byte,
 		select {
 		case <-peer.ActiveSignal():
 		case <-peer.QuitSignal():
-			// The peer quit so we'll just return.
+			// The peer quit, so we'll add the channel to the slice
+			// and return.
+			s.mu.Lock()
+			s.peerConnectedListeners[pubStr] = append(
+				s.peerConnectedListeners[pubStr], peerChan,
+			)
+			s.mu.Unlock()
 			return
 		}
 


### PR DESCRIPTION
This fixes a bug where a caller would:
- call NotifyWhenOnline and pass in a channel
- the server's mutex is held and the pubStr is checked in peersByPub
- the peer object is in the peersByPub map
- the peer object has its quit channel closed
- QuitSignal is called in the select statement, and the function returns
- the caller is still waiting for the channel to be sent on forever since it was never sent on or added to the peerConnectedListeners slice.

This patch fixes the above bug by adding the channel to the peerConnectedListeners slice if the QuitSignal select case is called.

Fixes #6882 

An integration test that makes the bug pop up once in a while is here: https://github.com/Crypt-iQ/lnd/tree/iss6882_notifywhenonline
- The bug has occurred when there is a "peer quit signal" log soon after a "Calling NotifyWhenOnline" log and there is no "successfully added" log. If the bug has occurred, you should see that the fundinglocked message is received in the logs, but the state machine doesn't advance to adding the channel to the router graph