### PR TITLE
ci: fix go version for travis jobs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ go:
   # /make/builder.Dockerfile
   # /.github/workflows/main.yml
   # /.github/workflows/release.yml
-  - "1.19.0"
+  - "1.19"
 
 env:
   global:


### PR DESCRIPTION
Golang uses semver `X.Y.Z` but when `Z` is zero it gets dropped from the
version. Ex: `1.18`, `1.19` instead of `1.18.0` and `1.19.0`.


P.S: I don't think this deserves being added to a release note.