### PR TITLE
wtclient: replay pending and unacked updates

### DIFF
--- a/docs/release-notes/release-notes-0.17.0.md
+++ b/docs/release-notes/release-notes-0.17.0.md
@@ -18,6 +18,8 @@
  
 * [Replace in-mem task pipeline with a disk-overflow
   queue](https://github.com/lightningnetwork/lnd/pull/7380)
+* [Replay pending and un-acked updates onto the main task pipeline if a tower
+  is being removed](https://github.com/lightningnetwork/lnd/pull/6895)
  
 * [Add defaults](https://github.com/lightningnetwork/lnd/pull/7771) to the 
   wtclient and watchtower config structs and use these to populate the defaults 

--- a/htlcswitch/interfaces.go
+++ b/htlcswitch/interfaces.go
@@ -252,9 +252,8 @@ type TowerClient interface {
 
 	// BackupState initiates a request to back up a particular revoked
 	// state. If the method returns nil, the backup is guaranteed to be
-	// successful unless the tower is unavailable and client is force quit,
-	// or the justice transaction would create dust outputs when trying to
-	// abide by the negotiated policy.
+	// successful unless the justice transaction would create dust outputs
+	// when trying to abide by the negotiated policy.
 	BackupState(chanID *lnwire.ChannelID, stateNum uint64) error
 }
 

--- a/server.go
+++ b/server.go
@@ -1569,7 +1569,6 @@ func newServer(cfg *Config, listenAddrs []net.Addr,
 			ChainHash:          *s.cfg.ActiveNetParams.GenesisHash,
 			MinBackoff:         10 * time.Second,
 			MaxBackoff:         5 * time.Minute,
-			ForceQuitDelay:     wtclient.DefaultForceQuitDelay,
 			MaxTasksInMemQueue: cfg.WtClient.MaxTasksInMemQueue,
 		})
 		if err != nil {
@@ -1603,7 +1602,6 @@ func newServer(cfg *Config, listenAddrs []net.Addr,
 			ChainHash:          *s.cfg.ActiveNetParams.GenesisHash,
 			MinBackoff:         10 * time.Second,
 			MaxBackoff:         5 * time.Minute,
-			ForceQuitDelay:     wtclient.DefaultForceQuitDelay,
 			MaxTasksInMemQueue: cfg.WtClient.MaxTasksInMemQueue,
 		})
 		if err != nil {

--- a/watchtower/wtclient/client.go
+++ b/watchtower/wtclient/client.go
@@ -1739,10 +1739,10 @@ func (c *TowerClient) RemoveTower(pubKey *btcec.PublicKey,
 	}
 }
 
-// handleNewTower handles a request for an existing tower to be removed. If none
-// of the tower's sessions have pending updates, then they will become inactive
-// and removed as candidates. If the active session queue corresponds to any of
-// these sessions, a new one will be negotiated.
+// handleStaleTower handles a request for an existing tower to be removed. If
+// none of the tower's sessions have pending updates, then they will become
+// inactive and removed as candidates. If the active session queue corresponds
+// to any of these sessions, a new one will be negotiated.
 func (c *TowerClient) handleStaleTower(msg *staleTowerMsg) error {
 	// We'll load the tower before potentially removing it in order to
 	// retrieve its ID within the database.

--- a/watchtower/wtclient/client_test.go
+++ b/watchtower/wtclient/client_test.go
@@ -952,6 +952,27 @@ func (s *serverHarness) restart(op func(cfg *wtserver.Config)) {
 	op(s.cfg)
 }
 
+// assertUpdatesNotFound asserts that a set of hints are not found in the
+// server's DB.
+func (s *serverHarness) assertUpdatesNotFound(hints []blob.BreachHint) {
+	s.t.Helper()
+
+	hintSet := make(map[blob.BreachHint]struct{})
+	for _, hint := range hints {
+		hintSet[hint] = struct{}{}
+	}
+
+	time.Sleep(time.Second)
+
+	matches, err := s.db.QueryMatches(hints)
+	require.NoError(s.t, err, "unable to query for hints")
+
+	for _, match := range matches {
+		_, ok := hintSet[match.Hint]
+		require.False(s.t, ok, "breach hint was found in server DB")
+	}
+}
+
 // waitForUpdates blocks until the breach hints provided all appear in the
 // watchtower's database or the timeout expires. This is used to test that the
 // client in fact sends the updates to the server, even if it is offline.
@@ -2211,6 +2232,77 @@ var clientTests = []clientTest{
 
 			// Assert that the new tower has the remaining states.
 			server2.waitForUpdates(hints[numUpdates/2:], waitTime)
+		},
+	},
+	{
+		// Show that if a client switches to a new tower _after_ backup
+		// tasks have been bound to the session with the first old tower
+		// then these updates are _not_ replayed onto the new tower.
+		// This is a bug that will be fixed in a future commit.
+		name: "switch to new tower after tasks are bound",
+		cfg: harnessCfg{
+			localBalance:  localBalance,
+			remoteBalance: remoteBalance,
+			policy: wtpolicy.Policy{
+				TxPolicy:   defaultTxPolicy,
+				MaxUpdates: 5,
+			},
+		},
+		fn: func(h *testHarness) {
+			const (
+				numUpdates = 5
+				chanID     = 0
+			)
+
+			// Generate numUpdates retributions and back a few of
+			// them up to the main tower.
+			hints := h.advanceChannelN(chanID, numUpdates)
+			h.backupStates(chanID, 0, numUpdates/2, nil)
+
+			// Wait for all these updates to be populated in the
+			// server's database.
+			h.server.waitForUpdates(hints[:numUpdates/2], waitTime)
+
+			// Now stop the server.
+			h.server.stop()
+
+			// Back up a few more tasks. This will bind the
+			// backup tasks to the session with the old server.
+			h.backupStates(chanID, numUpdates/2, numUpdates-1, nil)
+
+			// Now we add a new tower.
+			server2 := newServerHarness(
+				h.t, h.net, towerAddr2Str, nil,
+			)
+			server2.start()
+			h.addTower(server2.addr)
+
+			// Now we can remove the old one.
+			err := wait.Predicate(func() bool {
+				err := h.client.RemoveTower(
+					h.server.addr.IdentityKey, nil,
+				)
+
+				return err == nil
+			}, waitTime)
+			require.NoError(h.t, err)
+
+			// Back up the final task.
+			h.backupStates(chanID, numUpdates-1, numUpdates, nil)
+
+			// Show that only the latest backup is backed up to the
+			// server and that the ones backed up while no tower was
+			// online were _not_ backed up to either server. This is
+			// a bug that will be fixed in a future commit.
+			server2.waitForUpdates(
+				hints[numUpdates-1:], time.Second,
+			)
+			server2.assertUpdatesNotFound(
+				hints[numUpdates/2 : numUpdates-1],
+			)
+			h.server.assertUpdatesNotFound(
+				hints[numUpdates/2 : numUpdates-1],
+			)
 		},
 	},
 }

--- a/watchtower/wtclient/client_test.go
+++ b/watchtower/wtclient/client_test.go
@@ -2168,6 +2168,51 @@ var clientTests = []clientTest{
 			h.server.waitForUpdates(hints[0:numUpdates], waitTime)
 		},
 	},
+	{
+		// Assert that the client is able to switch to a new tower if
+		// the primary one goes down.
+		name: "switch to new tower",
+		cfg: harnessCfg{
+			localBalance:  localBalance,
+			remoteBalance: remoteBalance,
+			policy: wtpolicy.Policy{
+				TxPolicy:   defaultTxPolicy,
+				MaxUpdates: 5,
+			},
+		},
+		fn: func(h *testHarness) {
+			const (
+				numUpdates = 5
+				chanID     = 0
+			)
+
+			// Generate numUpdates retributions and back a few of
+			// them up to the main tower.
+			hints := h.advanceChannelN(chanID, numUpdates)
+			h.backupStates(chanID, 0, numUpdates/2, nil)
+
+			// Wait for all the backed up updates to be populated in
+			// the server's database.
+			h.server.waitForUpdates(hints[:numUpdates/2], waitTime)
+
+			// Now we add a new tower.
+			server2 := newServerHarness(
+				h.t, h.net, towerAddr2Str, nil,
+			)
+			server2.start()
+			h.addTower(server2.addr)
+
+			// Stop the old tower and remove it from the client.
+			h.server.stop()
+			h.removeTower(h.server.addr.IdentityKey, nil)
+
+			// Back up the remaining states.
+			h.backupStates(chanID, numUpdates/2, numUpdates, nil)
+
+			// Assert that the new tower has the remaining states.
+			server2.waitForUpdates(hints[numUpdates/2:], waitTime)
+		},
+	},
 }
 
 // TestClient executes the client test suite, asserting the ability to backup

--- a/watchtower/wtclient/client_test.go
+++ b/watchtower/wtclient/client_test.go
@@ -2299,6 +2299,88 @@ var clientTests = []clientTest{
 			)
 		},
 	},
+	{
+		// Assert that a client is _unable_ to remove a tower if there
+		// are persisted un-acked updates _and_ the client is restarted
+		// before the tower is removed.
+		name: "cant remove due to un-acked updates (with client " +
+			"restart)",
+		cfg: harnessCfg{
+			localBalance:  localBalance,
+			remoteBalance: remoteBalance,
+			policy: wtpolicy.Policy{
+				TxPolicy:   defaultTxPolicy,
+				MaxUpdates: 5,
+			},
+		},
+		fn: func(h *testHarness) {
+			const (
+				numUpdates = 5
+				chanID     = 0
+			)
+
+			// Generate numUpdates retributions.
+			hints := h.advanceChannelN(chanID, numUpdates)
+
+			// Back half of the states up.
+			h.backupStates(chanID, 0, numUpdates/2, nil)
+
+			// Wait for the updates to be populated in the server's
+			// database.
+			h.server.waitForUpdates(hints[:numUpdates/2], waitTime)
+
+			// Now stop the server and restart it with the
+			// NoAckUpdates set to true.
+			h.server.restart(func(cfg *wtserver.Config) {
+				cfg.NoAckUpdates = true
+			})
+
+			// Back up the remaining tasks. This will bind the
+			// backup tasks to the session with the server. The
+			// client will also attempt to get the ack for one
+			// update which will cause a CommittedUpdate to be
+			// persisted.
+			h.backupStates(chanID, numUpdates/2, numUpdates, nil)
+
+			tower, err := h.clientDB.LoadTower(
+				h.server.addr.IdentityKey,
+			)
+			require.NoError(h.t, err)
+
+			// Wait till the updates have been persisted.
+			err = wait.Predicate(func() bool {
+				var numCommittedUpdates int
+				countUpdates := func(_ *wtdb.ClientSession,
+					update *wtdb.CommittedUpdate) {
+
+					numCommittedUpdates++
+				}
+
+				_, err := h.clientDB.ListClientSessions(
+					&tower.ID, wtdb.WithPerCommittedUpdate(
+						countUpdates,
+					),
+				)
+				require.NoError(h.t, err)
+
+				return numCommittedUpdates == 1
+
+			}, waitTime)
+			require.NoError(h.t, err)
+
+			// Now restart the client. This ensures that the
+			// updates are no longer in the pending queue.
+			require.NoError(h.t, h.client.Stop())
+			h.startClient()
+
+			// Now try removing the tower. This will fail due to
+			// the persisted CommittedUpdate.
+			err = h.client.RemoveTower(
+				h.server.addr.IdentityKey, nil,
+			)
+			require.Error(h.t, err, "tower has unacked updates")
+		},
+	},
 }
 
 // TestClient executes the client test suite, asserting the ability to backup

--- a/watchtower/wtclient/client_test.go
+++ b/watchtower/wtclient/client_test.go
@@ -988,6 +988,9 @@ func (s *serverHarness) waitForUpdates(hints []blob.BreachHint,
 		return true
 	}
 
+	require.Truef(s.t, timeout.Seconds() > 1, "timeout must be set to "+
+		"greater than 1 second")
+
 	failTimeout := time.After(timeout)
 	for {
 		select {
@@ -1139,7 +1142,7 @@ var clientTests = []clientTest{
 
 			// Wait for all the updates to be populated in the
 			// server's database.
-			h.server.waitForUpdates(hints, time.Second)
+			h.server.waitForUpdates(hints, waitTime)
 		},
 	},
 	{
@@ -1167,7 +1170,7 @@ var clientTests = []clientTest{
 
 			// Ensure that no updates are received by the server,
 			// since they should all be marked as ineligible.
-			h.server.waitForUpdates(nil, time.Second)
+			h.server.waitForUpdates(nil, waitTime)
 		},
 	},
 	{
@@ -1199,7 +1202,7 @@ var clientTests = []clientTest{
 
 			// Wait for both to be reflected in the server's
 			// database.
-			h.server.waitForUpdates(hints[:numSent], time.Second)
+			h.server.waitForUpdates(hints[:numSent], waitTime)
 
 			// Now, restart the server and prevent it from acking
 			// state updates.
@@ -1233,7 +1236,7 @@ var clientTests = []clientTest{
 
 			// Wait for the committed update to be accepted by the
 			// tower.
-			h.server.waitForUpdates(hints[:numSent], time.Second)
+			h.server.waitForUpdates(hints[:numSent], waitTime)
 
 			// Finally, send the rest of the updates and wait for
 			// the tower to receive the remaining states.
@@ -1241,7 +1244,7 @@ var clientTests = []clientTest{
 
 			// Wait for all the updates to be populated in the
 			// server's database.
-			h.server.waitForUpdates(hints, time.Second)
+			h.server.waitForUpdates(hints, waitTime)
 
 		},
 	},
@@ -1411,7 +1414,7 @@ var clientTests = []clientTest{
 
 			// Since the client is unable to create a session, the
 			// server should have no updates.
-			h.server.waitForUpdates(nil, time.Second)
+			h.server.waitForUpdates(nil, waitTime)
 
 			// Force quit the client since it has queued backups.
 			h.client.ForceQuit()
@@ -1463,7 +1466,7 @@ var clientTests = []clientTest{
 
 			// Since the client is unable to create a session, the
 			// server should have no updates.
-			h.server.waitForUpdates(nil, time.Second)
+			h.server.waitForUpdates(nil, waitTime)
 
 			// Force quit the client since it has queued backups.
 			h.client.ForceQuit()
@@ -1519,9 +1522,7 @@ var clientTests = []clientTest{
 			h.backupStates(chanID, 0, numUpdates/2, nil)
 
 			// Wait for the server to collect the first half.
-			h.server.waitForUpdates(
-				hints[:numUpdates/2], time.Second,
-			)
+			h.server.waitForUpdates(hints[:numUpdates/2], waitTime)
 
 			// Stop the client, which should have no more backups.
 			require.NoError(h.t, h.client.Stop())
@@ -1628,7 +1629,7 @@ var clientTests = []clientTest{
 			// Back up the remaining states. Since the tower has
 			// been removed, it shouldn't receive any updates.
 			h.backupStates(chanID, numUpdates/2, numUpdates, nil)
-			h.server.waitForUpdates(nil, time.Second)
+			h.server.waitForUpdates(nil, waitTime)
 
 			// Re-add the tower. We prevent the tower from acking
 			// session creation to ensure the inactive sessions are
@@ -1638,7 +1639,7 @@ var clientTests = []clientTest{
 			})
 
 			h.addTower(h.server.addr)
-			h.server.waitForUpdates(nil, time.Second)
+			h.server.waitForUpdates(nil, waitTime)
 
 			// Finally, allow the tower to ack session creation,
 			// allowing the state updates to be sent through the new

--- a/watchtower/wtclient/interface.go
+++ b/watchtower/wtclient/interface.go
@@ -135,6 +135,10 @@ type DB interface {
 	// GetDBQueue returns a BackupID Queue instance under the given name
 	// space.
 	GetDBQueue(namespace []byte) wtdb.Queue[*wtdb.BackupID]
+
+	// DeleteCommittedUpdate deletes the committed update belonging to the
+	// given session and with the given sequence number from the db.
+	DeleteCommittedUpdate(id *wtdb.SessionID, seqNum uint16) error
 }
 
 // AuthDialer connects to a remote node using an authenticated transport, such


### PR DESCRIPTION
This PR demonstrates 2 main issues and then fixes them:

1. If `backupTasks` have been "bound" to a session's `pendingQueue` and then the associated Tower is removed, those pending updates are just quietly lost at the moment. This PR makes sure that these tasks are replayed onto the main task pipeline.
2. If a `CommittedUpdate` has been persisted but the session does not respond with an Ack and then the client requests to remove the tower, this will currently fail with "tower has unacked updates". This is fixed by also replaying these updates onto the main task pipeline.

With this PR, the tower client can shutdown as soon as it is requested to since any un-acked updates or pending updates will just be persisted. This is nice since there will no longer be a 10 second wait on shutdown :) 

Fixes https://github.com/lightningnetwork/lnd/issues/4420
Fixes #7725