### PR TITLE
docs: Chain backend documentation reformat, add warning

### DIFF
--- a/sample-lnd.conf
+++ b/sample-lnd.conf
@@ -486,13 +486,12 @@ bitcoin.simnet=true
 ; signet network seed nodes
 ; bitcoin.signetseednode=123.45.67.89
 
-; Use the btcd back-end
+; Specify the chain back-end. Options are btcd, bitcoind and neutrino.
+;
+; NOTE: Please note that switching between a full back-end (btcd/bitcoind) and 
+; a light back-end (neutrino) is not supported.
 bitcoin.node=btcd
-
-; Use the bitcoind back-end
 ; bitcoin.node=bitcoind
-
-; Use the neutrino (light client) back-end
 ; bitcoin.node=neutrino
 
 ; The default number of confirmations a channel must have before it's considered


### PR DESCRIPTION
Change formatting of `bitcoin.node` configuration, add warning about changing chain back-ends.
This is my second try, messed up a bit with rebases, should read my git book again.

## Change Description
Related to #6901 -- warn about backend change (partial<>full)

## Steps to Test
N/A: docs

## Pull Request Checklist
### Testing
- [ ] Your PR passes all CI checks.
- [ ] Tests covering the positive and negative (error paths) are included.
- [ ] Bug fixes contain tests triggering the bug to prevent regressions.

### Code Style and Documentation
- [ ] The change obeys the [Code Documentation and Commenting](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#CodeDocumentation) guidelines, and lines wrap at 80.
- [ ] Commits follow the [Ideal Git Commit Structure](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#IdealGitCommitStructure).
- [ ] Any new logging statements use an appropriate subsystem and logging level.
- [ ]  [There is a change description in the release notes](https://github.com/lightningnetwork/lnd/tree/master/docs/release-notes), or `[skip ci]` in the commit message for small changes.

📝 Please see our  [Contribution Guidelines](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md) for further guidance.