### PR TITLE
sample-conf: Chain backend documentation reformat, add warning [skip ci]

### DIFF
--- a/sample-lnd.conf
+++ b/sample-lnd.conf
@@ -486,13 +486,12 @@ bitcoin.simnet=true
 ; signet network seed nodes
 ; bitcoin.signetseednode=123.45.67.89
 
-; Use the btcd back-end
+; Specify the chain back-end. Options are btcd, bitcoind and neutrino.
+;
+; NOTE: Please note that switching between a full back-end (btcd/bitcoind) and 
+; a light back-end (neutrino) is not supported.
 bitcoin.node=btcd
-
-; Use the bitcoind back-end
 ; bitcoin.node=bitcoind
-
-; Use the neutrino (light client) back-end
 ; bitcoin.node=neutrino
 
 ; The default number of confirmations a channel must have before it's considered


### PR DESCRIPTION
Change formatting of `bitcoin.node` configuration, add warning about changing BETWEEN chain back-ends

Replaces #6335 which already has 2 reviews, so going to merge right away.