### PR TITLE
Add comments for all wallet states

### DIFF
--- a/lnrpc/stateservice.pb.go
+++ b/lnrpc/stateservice.pb.go
@@ -23,12 +23,20 @@ const (
 type WalletState int32
 
 const (
+	// NON_EXISTING means that the wallet has not yet been initialized.
 	WalletState_NON_EXISTING WalletState = 0
-	WalletState_LOCKED       WalletState = 1
-	WalletState_UNLOCKED     WalletState = 2
-	WalletState_RPC_ACTIVE   WalletState = 3
+	// LOCKED means that the wallet is locked and requires a password to unlock.
+	WalletState_LOCKED WalletState = 1
+	// UNLOCKED means that the wallet was unlocked successfully, but RPC server
+	// isn't ready.
+	WalletState_UNLOCKED WalletState = 2
+	// RPC_ACTIVE means that the lnd server is active but not fully ready for
+	// calls.
+	WalletState_RPC_ACTIVE WalletState = 3
 	// SERVER_ACTIVE means that the lnd server is ready to accept calls.
-	WalletState_SERVER_ACTIVE    WalletState = 4
+	WalletState_SERVER_ACTIVE WalletState = 4
+	// WAITING_TO_START means that node is waiting to become the leader in a
+	// cluster and is not started yet.
 	WalletState_WAITING_TO_START WalletState = 255
 )
 

--- a/lnrpc/stateservice.proto
+++ b/lnrpc/stateservice.proto
@@ -36,14 +36,25 @@ service State {
 }
 
 enum WalletState {
+    // NON_EXISTING means that the wallet has not yet been initialized.
     NON_EXISTING = 0;
+
+    // LOCKED means that the wallet is locked and requires a password to unlock.
     LOCKED = 1;
+
+    // UNLOCKED means that the wallet was unlocked successfully, but RPC server
+    // isn't ready.
     UNLOCKED = 2;
+
+    // RPC_ACTIVE means that the lnd server is active but not fully ready for
+    // calls.
     RPC_ACTIVE = 3;
 
     // SERVER_ACTIVE means that the lnd server is ready to accept calls.
     SERVER_ACTIVE = 4;
 
+    // WAITING_TO_START means that node is waiting to become the leader in a
+    // cluster and is not started yet.
     WAITING_TO_START = 255;
 }
 

--- a/lnrpc/stateservice.swagger.json
+++ b/lnrpc/stateservice.swagger.json
@@ -100,7 +100,7 @@
         "WAITING_TO_START"
       ],
       "default": "NON_EXISTING",
-      "description": " - SERVER_ACTIVE: SERVER_ACTIVE means that the lnd server is ready to accept calls."
+      "description": " - NON_EXISTING: NON_EXISTING means that the wallet has not yet been initialized.\n - LOCKED: LOCKED means that the wallet is locked and requires a password to unlock.\n - UNLOCKED: UNLOCKED means that the wallet was unlocked successfully, but RPC server\nisn't ready.\n - RPC_ACTIVE: RPC_ACTIVE means that the lnd server is active but not fully ready for\ncalls.\n - SERVER_ACTIVE: SERVER_ACTIVE means that the lnd server is ready to accept calls.\n - WAITING_TO_START: WAITING_TO_START means that node is waiting to become the leader in a\ncluster and is not started yet."
     },
     "protobufAny": {
       "type": "object",


### PR DESCRIPTION
Only `SERVER_ACTIVE` had a description, I copied these descriptions from 

https://github.com/lightningnetwork/lnd/blob/2b1bb3bce041973c03e6139ce7fec47f87cfb30a/cmd/lncli/cmd_state.go#L21