### PR TITLE
multi: remove AckedUpdates & CommittedUpdates from ClientSession struct

### DIFF
--- a/docs/release-notes/release-notes-0.16.0.md
+++ b/docs/release-notes/release-notes-0.16.0.md
@@ -111,6 +111,10 @@ crash](https://github.com/lightningnetwork/lnd/pull/7019).
   closer coupling of Towers and Sessions and ensures that a session cannot be
   added if the tower it is referring to does not exist.
 
+* [Remove `AckedUpdates` & `CommittedUpdates` from the `ClientSession`
+  struct](https://github.com/lightningnetwork/lnd/pull/6928) in order to
+  improve the performance of fetching a `ClientSession` from the DB.
+
 * [Create a helper function to wait for peer to come
   online](https://github.com/lightningnetwork/lnd/pull/6931).
 

--- a/lnrpc/wtclientrpc/wtclient.go
+++ b/lnrpc/wtclientrpc/wtclient.go
@@ -265,12 +265,16 @@ func (c *WatchtowerClient) ListTowers(ctx context.Context,
 		return nil, err
 	}
 
-	anchorTowers, err := c.cfg.AnchorClient.RegisteredTowers()
+	opts, ackCounts, committedUpdateCounts := constructFunctionalOptions(
+		req.IncludeSessions,
+	)
+
+	anchorTowers, err := c.cfg.AnchorClient.RegisteredTowers(opts...)
 	if err != nil {
 		return nil, err
 	}
 
-	legacyTowers, err := c.cfg.Client.RegisteredTowers()
+	legacyTowers, err := c.cfg.Client.RegisteredTowers(opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -286,7 +290,10 @@ func (c *WatchtowerClient) ListTowers(ctx context.Context,
 
 	rpcTowers := make([]*Tower, 0, len(towers))
 	for _, tower := range towers {
-		rpcTower := marshallTower(tower, req.IncludeSessions)
+		rpcTower := marshallTower(
+			tower, req.IncludeSessions, ackCounts,
+			committedUpdateCounts,
+		)
 		rpcTowers = append(rpcTowers, rpcTower)
 	}
 
@@ -306,16 +313,59 @@ func (c *WatchtowerClient) GetTowerInfo(ctx context.Context,
 		return nil, err
 	}
 
+	opts, ackCounts, committedUpdateCounts := constructFunctionalOptions(
+		req.IncludeSessions,
+	)
+
 	var tower *wtclient.RegisteredTower
-	tower, err = c.cfg.Client.LookupTower(pubKey)
+	tower, err = c.cfg.Client.LookupTower(pubKey, opts...)
 	if err == wtdb.ErrTowerNotFound {
-		tower, err = c.cfg.AnchorClient.LookupTower(pubKey)
+		tower, err = c.cfg.AnchorClient.LookupTower(pubKey, opts...)
 	}
 	if err != nil {
 		return nil, err
 	}
 
-	return marshallTower(tower, req.IncludeSessions), nil
+	return marshallTower(
+		tower, req.IncludeSessions, ackCounts, committedUpdateCounts,
+	), nil
+}
+
+// constructFunctionalOptions is a helper function that constructs a list of
+// functional options to be used when fetching a tower from the DB. It also
+// returns a map of acked-update counts and one for un-acked-update counts that
+// will be populated once the db call has been made.
+func constructFunctionalOptions(includeSessions bool) (
+	[]wtdb.ClientSessionListOption, map[wtdb.SessionID]uint16,
+	map[wtdb.SessionID]uint16) {
+
+	var (
+		opts                  []wtdb.ClientSessionListOption
+		ackCounts             = make(map[wtdb.SessionID]uint16)
+		committedUpdateCounts = make(map[wtdb.SessionID]uint16)
+	)
+	if !includeSessions {
+		return opts, ackCounts, committedUpdateCounts
+	}
+
+	perAckedUpdate := func(s *wtdb.ClientSession, _ uint16,
+		_ wtdb.BackupID) {
+
+		ackCounts[s.ID]++
+	}
+
+	perCommittedUpdate := func(s *wtdb.ClientSession,
+		_ *wtdb.CommittedUpdate) {
+
+		committedUpdateCounts[s.ID]++
+	}
+
+	opts = []wtdb.ClientSessionListOption{
+		wtdb.WithPerAckedUpdate(perAckedUpdate),
+		wtdb.WithPerCommittedUpdate(perCommittedUpdate),
+	}
+
+	return opts, ackCounts, committedUpdateCounts
 }
 
 // Stats returns the in-memory statistics of the client since startup.
@@ -387,7 +437,9 @@ func (c *WatchtowerClient) Policy(ctx context.Context,
 
 // marshallTower converts a client registered watchtower into its corresponding
 // RPC type.
-func marshallTower(tower *wtclient.RegisteredTower, includeSessions bool) *Tower {
+func marshallTower(tower *wtclient.RegisteredTower, includeSessions bool,
+	ackCounts, pendingCounts map[wtdb.SessionID]uint16) *Tower {
+
 	rpcAddrs := make([]string, 0, len(tower.Addresses))
 	for _, addr := range tower.Addresses {
 		rpcAddrs = append(rpcAddrs, addr.String())
@@ -399,8 +451,8 @@ func marshallTower(tower *wtclient.RegisteredTower, includeSessions bool) *Tower
 		for _, session := range tower.Sessions {
 			satPerVByte := session.Policy.SweepFeeRate.FeePerKVByte() / 1000
 			rpcSessions = append(rpcSessions, &TowerSession{
-				NumBackups:        uint32(len(session.AckedUpdates)),
-				NumPendingBackups: uint32(len(session.CommittedUpdates)),
+				NumBackups:        uint32(ackCounts[session.ID]),
+				NumPendingBackups: uint32(pendingCounts[session.ID]),
 				MaxBackups:        uint32(session.Policy.MaxUpdates),
 				SweepSatPerVbyte:  uint32(satPerVByte),
 

--- a/watchtower/wtclient/client.go
+++ b/watchtower/wtclient/client.go
@@ -289,12 +289,67 @@ func New(config *Config) (*TowerClient, error) {
 	}
 	plog := build.NewPrefixLog(prefix, log)
 
-	// Next, load all candidate towers and sessions from the database into
-	// the client. We will use any of these sessions if their policies match
-	// the current policy of the client, otherwise they will be ignored and
-	// new sessions will be requested.
+	// Load the sweep pkscripts that have been generated for all previously
+	// registered channels.
+	chanSummaries, err := cfg.DB.FetchChanSummaries()
+	if err != nil {
+		return nil, err
+	}
+
+	c := &TowerClient{
+		cfg:               cfg,
+		log:               plog,
+		pipeline:          newTaskPipeline(plog),
+		chanCommitHeights: make(map[lnwire.ChannelID]uint64),
+		activeSessions:    make(sessionQueueSet),
+		summaries:         chanSummaries,
+		statTicker:        time.NewTicker(DefaultStatInterval),
+		stats:             new(ClientStats),
+		newTowers:         make(chan *newTowerMsg),
+		staleTowers:       make(chan *staleTowerMsg),
+		forceQuit:         make(chan struct{}),
+	}
+
+	// perUpdate is a callback function that will be used to inspect the
+	// full set of candidate client sessions loaded from disk, and to
+	// determine the highest known commit height for each channel. This
+	// allows the client to reject backups that it has already processed for
+	// its active policy.
+	perUpdate := func(policy wtpolicy.Policy, id wtdb.BackupID) {
+		// We only want to consider accepted updates that have been
+		// accepted under an identical policy to the client's current
+		// policy.
+		if policy != c.cfg.Policy {
+			return
+		}
+
+		// Take the highest commit height found in the session's acked
+		// updates.
+		height, ok := c.chanCommitHeights[id.ChanID]
+		if !ok || id.CommitHeight > height {
+			c.chanCommitHeights[id.ChanID] = id.CommitHeight
+		}
+	}
+
+	perAckedUpdate := func(s *wtdb.ClientSession, _ uint16,
+		id wtdb.BackupID) {
+
+		perUpdate(s.Policy, id)
+	}
+
+	perCommittedUpdate := func(s *wtdb.ClientSession,
+		u *wtdb.CommittedUpdate) {
+
+		perUpdate(s.Policy, u.BackupID)
+	}
+
+	// Load all candidate sessions and towers from the database into the
+	// client. We will use any of these sessions if their policies match the
+	// current policy of the client, otherwise they will be ignored and new
+	// sessions will be requested.
 	isAnchorClient := cfg.Policy.IsAnchorChannel()
 	activeSessionFilter := genActiveSessionFilter(isAnchorClient)
+
 	candidateTowers := newTowerListIterator()
 	perActiveTower := func(tower *wtdb.Tower) {
 		// If the tower has already been marked as active, then there is
@@ -309,34 +364,19 @@ func New(config *Config) (*TowerClient, error) {
 		// Add the tower to the set of candidate towers.
 		candidateTowers.AddCandidate(tower)
 	}
+
 	candidateSessions, err := getTowerAndSessionCandidates(
 		cfg.DB, cfg.SecretKeyRing, activeSessionFilter, perActiveTower,
+		wtdb.WithPerAckedUpdate(perAckedUpdate),
+		wtdb.WithPerCommittedUpdate(perCommittedUpdate),
 	)
 	if err != nil {
 		return nil, err
 	}
 
-	// Load the sweep pkscripts that have been generated for all previously
-	// registered channels.
-	chanSummaries, err := cfg.DB.FetchChanSummaries()
-	if err != nil {
-		return nil, err
-	}
+	c.candidateTowers = candidateTowers
+	c.candidateSessions = candidateSessions
 
-	c := &TowerClient{
-		cfg:               cfg,
-		log:               plog,
-		pipeline:          newTaskPipeline(plog),
-		candidateTowers:   candidateTowers,
-		candidateSessions: candidateSessions,
-		activeSessions:    make(sessionQueueSet),
-		summaries:         chanSummaries,
-		statTicker:        time.NewTicker(DefaultStatInterval),
-		stats:             new(ClientStats),
-		newTowers:         make(chan *newTowerMsg),
-		staleTowers:       make(chan *staleTowerMsg),
-		forceQuit:         make(chan struct{}),
-	}
 	c.negotiator = newSessionNegotiator(&NegotiatorConfig{
 		DB:            cfg.DB,
 		SecretKeyRing: cfg.SecretKeyRing,
@@ -350,10 +390,6 @@ func New(config *Config) (*TowerClient, error) {
 		MaxBackoff:    cfg.MaxBackoff,
 		Log:           plog,
 	})
-
-	// Reconstruct the highest commit height processed for each channel
-	// under the client's current policy.
-	c.buildHighestCommitHeights()
 
 	return c, nil
 }
@@ -448,44 +484,6 @@ func getClientSessions(db DB, keyRing ECDHKeyRing, forTower *wtdb.TowerID,
 	}
 
 	return sessions, nil
-}
-
-// buildHighestCommitHeights inspects the full set of candidate client sessions
-// loaded from disk, and determines the highest known commit height for each
-// channel. This allows the client to reject backups that it has already
-// processed for it's active policy.
-func (c *TowerClient) buildHighestCommitHeights() {
-	chanCommitHeights := make(map[lnwire.ChannelID]uint64)
-	for _, s := range c.candidateSessions {
-		// We only want to consider accepted updates that have been
-		// accepted under an identical policy to the client's current
-		// policy.
-		if s.Policy != c.cfg.Policy {
-			continue
-		}
-
-		// Take the highest commit height found in the session's
-		// committed updates.
-		for _, committedUpdate := range s.CommittedUpdates {
-			bid := committedUpdate.BackupID
-
-			height, ok := chanCommitHeights[bid.ChanID]
-			if !ok || bid.CommitHeight > height {
-				chanCommitHeights[bid.ChanID] = bid.CommitHeight
-			}
-		}
-
-		// Take the heights commit height found in the session's acked
-		// updates.
-		for _, bid := range s.AckedUpdates {
-			height, ok := chanCommitHeights[bid.ChanID]
-			if !ok || bid.CommitHeight > height {
-				chanCommitHeights[bid.ChanID] = bid.CommitHeight
-			}
-		}
-	}
-
-	c.chanCommitHeights = chanCommitHeights
 }
 
 // Start initializes the watchtower client by loading or negotiating an active

--- a/watchtower/wtclient/interface.go
+++ b/watchtower/wtclient/interface.go
@@ -62,7 +62,7 @@ type DB interface {
 	// still be able to accept state updates. An optional tower ID can be
 	// used to filter out any client sessions in the response that do not
 	// correspond to this tower.
-	ListClientSessions(*wtdb.TowerID) (
+	ListClientSessions(*wtdb.TowerID, ...wtdb.ClientSessionListOption) (
 		map[wtdb.SessionID]*wtdb.ClientSession, error)
 
 	// FetchChanSummaries loads a mapping from all registered channels to

--- a/watchtower/wtclient/interface.go
+++ b/watchtower/wtclient/interface.go
@@ -65,6 +65,11 @@ type DB interface {
 	ListClientSessions(*wtdb.TowerID, ...wtdb.ClientSessionListOption) (
 		map[wtdb.SessionID]*wtdb.ClientSession, error)
 
+	// FetchSessionCommittedUpdates retrieves the current set of un-acked
+	// updates of the given session.
+	FetchSessionCommittedUpdates(id *wtdb.SessionID) (
+		[]wtdb.CommittedUpdate, error)
+
 	// FetchChanSummaries loads a mapping from all registered channels to
 	// their channel summaries.
 	FetchChanSummaries() (wtdb.ChannelSummaries, error)

--- a/watchtower/wtclient/session_queue.go
+++ b/watchtower/wtclient/session_queue.go
@@ -109,7 +109,9 @@ type sessionQueue struct {
 }
 
 // newSessionQueue intiializes a fresh sessionQueue.
-func newSessionQueue(cfg *sessionQueueConfig) *sessionQueue {
+func newSessionQueue(cfg *sessionQueueConfig,
+	updates []wtdb.CommittedUpdate) *sessionQueue {
+
 	localInit := wtwire.NewInitMessage(
 		lnwire.NewRawFeatureVector(wtwire.AltruistSessionsRequired),
 		cfg.ChainHash,
@@ -137,7 +139,7 @@ func newSessionQueue(cfg *sessionQueueConfig) *sessionQueue {
 
 	// The database should return them in sorted order, and session queue's
 	// sequence number will be equal to that of the last committed update.
-	for _, update := range sq.cfg.ClientSession.CommittedUpdates {
+	for _, update := range updates {
 		sq.commitQueue.PushBack(update)
 	}
 

--- a/watchtower/wtdb/client_db.go
+++ b/watchtower/wtdb/client_db.go
@@ -1174,14 +1174,17 @@ func getClientSession(sessions, towers kvdb.RBucket,
 		return nil, err
 	}
 
+	// Can't fail because client session body has already been read.
+	sessionBkt := sessions.NestedReadBucket(idBytes)
+
 	// Fetch the committed updates for this session.
-	commitedUpdates, err := getClientSessionCommits(sessions, idBytes)
+	commitedUpdates, err := getClientSessionCommits(sessionBkt)
 	if err != nil {
 		return nil, err
 	}
 
 	// Fetch the acked updates for this session.
-	ackedUpdates, err := getClientSessionAcks(sessions, idBytes)
+	ackedUpdates, err := getClientSessionAcks(sessionBkt)
 	if err != nil {
 		return nil, err
 	}
@@ -1195,11 +1198,8 @@ func getClientSession(sessions, towers kvdb.RBucket,
 
 // getClientSessionCommits retrieves all committed updates for the session
 // identified by the serialized session id.
-func getClientSessionCommits(sessions kvdb.RBucket,
-	idBytes []byte) ([]CommittedUpdate, error) {
-
-	// Can't fail because client session body has already been read.
-	sessionBkt := sessions.NestedReadBucket(idBytes)
+func getClientSessionCommits(sessionBkt kvdb.RBucket) ([]CommittedUpdate,
+	error) {
 
 	// Initialize commitedUpdates so that we can return an initialized map
 	// if no committed updates exist.
@@ -1231,11 +1231,8 @@ func getClientSessionCommits(sessions kvdb.RBucket,
 
 // getClientSessionAcks retrieves all acked updates for the session identified
 // by the serialized session id.
-func getClientSessionAcks(sessions kvdb.RBucket,
-	idBytes []byte) (map[uint16]BackupID, error) {
-
-	// Can't fail because client session body has already been read.
-	sessionBkt := sessions.NestedReadBucket(idBytes)
+func getClientSessionAcks(sessionBkt kvdb.RBucket) (map[uint16]BackupID,
+	error) {
 
 	// Initialize ackedUpdates so that we can return an initialized map if
 	// no acked updates exist.

--- a/watchtower/wtdb/client_db.go
+++ b/watchtower/wtdb/client_db.go
@@ -420,8 +420,17 @@ func (c *ClientDB) RemoveTower(pubKey *btcec.PublicKey, addr net.Addr) error {
 			return ErrUninitializedDB
 		}
 		towerID := TowerIDFromBytes(towerIDBytes)
+
+		committedUpdateCount := make(map[SessionID]uint16)
+		perCommittedUpdate := func(s *ClientSession,
+			_ *CommittedUpdate) {
+
+			committedUpdateCount[s.ID]++
+		}
+
 		towerSessions, err := listTowerSessions(
 			towerID, sessions, towers, towersToSessionsIndex,
+			WithPerCommittedUpdate(perCommittedUpdate),
 		)
 		if err != nil {
 			return err
@@ -447,7 +456,7 @@ func (c *ClientDB) RemoveTower(pubKey *btcec.PublicKey, addr net.Addr) error {
 		// have any pending updates to ensure we don't load them upon
 		// restarts.
 		for _, session := range towerSessions {
-			if len(session.CommittedUpdates) > 0 {
+			if committedUpdateCount[session.ID] > 0 {
 				return ErrTowerUnackedUpdates
 			}
 			err := markSessionStatus(
@@ -1257,12 +1266,14 @@ func getClientSession(sessions, towers kvdb.RBucket, idBytes []byte,
 	if err != nil {
 		return nil, err
 	}
+	session.Tower = tower
 
 	// Can't fail because client session body has already been read.
 	sessionBkt := sessions.NestedReadBucket(idBytes)
 
-	// Fetch the committed updates for this session.
-	commitedUpdates, err := getClientSessionCommits(
+	// Pass the session's committed (un-acked) updates through the call-back
+	// if one is provided.
+	err = filterClientSessionCommits(
 		sessionBkt, session, cfg.PerCommittedUpdate,
 	)
 	if err != nil {
@@ -1275,9 +1286,6 @@ func getClientSession(sessions, towers kvdb.RBucket, idBytes []byte,
 	if err != nil {
 		return nil, err
 	}
-
-	session.Tower = tower
-	session.CommittedUpdates = commitedUpdates
 
 	return session, nil
 }
@@ -1345,6 +1353,39 @@ func filterClientSessionAcks(sessionBkt kvdb.RBucket, s *ClientSession,
 		}
 
 		cb(s, seqNum, backupID)
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// filterClientSessionCommits retrieves all committed updates for the session
+// identified by the serialized session id and passes them to the given
+// PerCommittedUpdateCB callback.
+func filterClientSessionCommits(sessionBkt kvdb.RBucket, s *ClientSession,
+	cb PerCommittedUpdateCB) error {
+
+	if cb == nil {
+		return nil
+	}
+
+	sessionCommits := sessionBkt.NestedReadBucket(cSessionCommits)
+	if sessionCommits == nil {
+		return nil
+	}
+
+	err := sessionCommits.ForEach(func(k, v []byte) error {
+		var committedUpdate CommittedUpdate
+		err := committedUpdate.Decode(bytes.NewReader(v))
+		if err != nil {
+			return err
+		}
+		committedUpdate.SeqNum = byteOrder.Uint16(k)
+
+		cb(s, &committedUpdate)
 		return nil
 	})
 	if err != nil {

--- a/watchtower/wtdb/client_db_test.go
+++ b/watchtower/wtdb/client_db_test.go
@@ -48,12 +48,12 @@ func (h *clientDBHarness) insertSession(session *wtdb.ClientSession,
 	require.ErrorIs(h.t, err, expErr)
 }
 
-func (h *clientDBHarness) listSessions(
-	id *wtdb.TowerID) map[wtdb.SessionID]*wtdb.ClientSession {
+func (h *clientDBHarness) listSessions(id *wtdb.TowerID,
+	opts ...wtdb.ClientSessionListOption) map[wtdb.SessionID]*wtdb.ClientSession {
 
 	h.t.Helper()
 
-	sessions, err := h.db.ListClientSessions(id)
+	sessions, err := h.db.ListClientSessions(id, opts...)
 	require.NoError(h.t, err, "unable to list client sessions")
 
 	return sessions
@@ -520,11 +520,7 @@ func testCommitUpdate(h *clientDBHarness) {
 	// Assert that the committed update appears in the client session's
 	// CommittedUpdates map when loaded from disk and that there are no
 	// AckedUpdates.
-	dbSession := h.listSessions(nil)[session.ID]
-	checkCommittedUpdates(h.t, dbSession, []wtdb.CommittedUpdate{
-		*update1,
-	})
-	checkAckedUpdates(h.t, dbSession, nil)
+	h.assertUpdates(session.ID, []wtdb.CommittedUpdate{*update1}, nil)
 
 	// Try to commit the same update, which should succeed due to
 	// idempotency (which is preserved when the breach hint is identical to
@@ -534,11 +530,7 @@ func testCommitUpdate(h *clientDBHarness) {
 	require.Equal(h.t, lastApplied, lastApplied2)
 
 	// Assert that the loaded ClientSession is the same as before.
-	dbSession = h.listSessions(nil)[session.ID]
-	checkCommittedUpdates(h.t, dbSession, []wtdb.CommittedUpdate{
-		*update1,
-	})
-	checkAckedUpdates(h.t, dbSession, nil)
+	h.assertUpdates(session.ID, []wtdb.CommittedUpdate{*update1}, nil)
 
 	// Generate another random update and try to commit it at the identical
 	// sequence number. Since the breach hint has changed, this should fail.
@@ -553,12 +545,10 @@ func testCommitUpdate(h *clientDBHarness) {
 
 	// Check that both updates now appear as committed on the ClientSession
 	// loaded from disk.
-	dbSession = h.listSessions(nil)[session.ID]
-	checkCommittedUpdates(h.t, dbSession, []wtdb.CommittedUpdate{
+	h.assertUpdates(session.ID, []wtdb.CommittedUpdate{
 		*update1,
 		*update2,
-	})
-	checkAckedUpdates(h.t, dbSession, nil)
+	}, nil)
 
 	// Finally, create one more random update and try to commit it at index
 	// 4, which should be rejected since 3 is the next slot the database
@@ -567,12 +557,20 @@ func testCommitUpdate(h *clientDBHarness) {
 	h.commitUpdate(&session.ID, update4, wtdb.ErrCommitUnorderedUpdate)
 
 	// Assert that the ClientSession loaded from disk remains unchanged.
-	dbSession = h.listSessions(nil)[session.ID]
-	checkCommittedUpdates(h.t, dbSession, []wtdb.CommittedUpdate{
+	h.assertUpdates(session.ID, []wtdb.CommittedUpdate{
 		*update1,
 		*update2,
-	})
-	checkAckedUpdates(h.t, dbSession, nil)
+	}, nil)
+}
+
+func perAckedUpdate(updates map[uint16]wtdb.BackupID) func(
+	_ *wtdb.ClientSession, seq uint16, id wtdb.BackupID) {
+
+	return func(_ *wtdb.ClientSession, seq uint16,
+		id wtdb.BackupID) {
+
+		updates[seq] = id
+	}
 }
 
 // testAckUpdate asserts the behavior of AckUpdate.
@@ -628,9 +626,7 @@ func testAckUpdate(h *clientDBHarness) {
 
 	// Assert that the ClientSession loaded from disk has one update in it's
 	// AckedUpdates map, and that the committed update has been removed.
-	dbSession := h.listSessions(nil)[session.ID]
-	checkCommittedUpdates(h.t, dbSession, nil)
-	checkAckedUpdates(h.t, dbSession, map[uint16]wtdb.BackupID{
+	h.assertUpdates(session.ID, nil, map[uint16]wtdb.BackupID{
 		1: update1.BackupID,
 	})
 
@@ -645,9 +641,7 @@ func testAckUpdate(h *clientDBHarness) {
 	h.ackUpdate(&session.ID, 2, 2, nil)
 
 	// Assert that both updates exist as AckedUpdates when loaded from disk.
-	dbSession = h.listSessions(nil)[session.ID]
-	checkCommittedUpdates(h.t, dbSession, nil)
-	checkAckedUpdates(h.t, dbSession, map[uint16]wtdb.BackupID{
+	h.assertUpdates(session.ID, nil, map[uint16]wtdb.BackupID{
 		1: update1.BackupID,
 		2: update2.BackupID,
 	})
@@ -661,6 +655,19 @@ func testAckUpdate(h *clientDBHarness) {
 	// Acking with a last applied greater than any allocated seqnum should
 	// fail.
 	h.ackUpdate(&session.ID, 4, 3, wtdb.ErrUnallocatedLastApplied)
+}
+
+func (h *clientDBHarness) assertUpdates(id wtdb.SessionID,
+	expectedPending []wtdb.CommittedUpdate,
+	expectedAcked map[uint16]wtdb.BackupID) {
+
+	ackedUpdates := make(map[uint16]wtdb.BackupID)
+	_ = h.listSessions(
+		nil, wtdb.WithPerAckedUpdate(perAckedUpdate(ackedUpdates)),
+	)
+	dbSession := h.listSessions(nil)[id]
+	checkCommittedUpdates(h.t, dbSession, expectedPending)
+	checkAckedUpdates(h.t, ackedUpdates, expectedAcked)
 }
 
 // checkCommittedUpdates asserts that the CommittedUpdates on session match the
@@ -682,7 +689,7 @@ func checkCommittedUpdates(t *testing.T, session *wtdb.ClientSession,
 
 // checkAckedUpdates asserts that the AckedUpdates on a session match the
 // expUpdates provided.
-func checkAckedUpdates(t *testing.T, session *wtdb.ClientSession,
+func checkAckedUpdates(t *testing.T, actualUpdates,
 	expUpdates map[uint16]wtdb.BackupID) {
 
 	// We promote nil expUpdates to an initialized map since the database
@@ -692,7 +699,7 @@ func checkAckedUpdates(t *testing.T, session *wtdb.ClientSession,
 		expUpdates = make(map[uint16]wtdb.BackupID)
 	}
 
-	require.Equal(t, expUpdates, session.AckedUpdates)
+	require.Equal(t, expUpdates, actualUpdates)
 }
 
 // TestClientDB asserts the behavior of a fresh client db, a reopened client db,

--- a/watchtower/wtdb/client_db_test.go
+++ b/watchtower/wtdb/client_db_test.go
@@ -207,6 +207,20 @@ func (h *clientDBHarness) newTower() *wtdb.Tower {
 	}, nil)
 }
 
+func (h *clientDBHarness) fetchSessionCommittedUpdates(id *wtdb.SessionID,
+	expErr error) []wtdb.CommittedUpdate {
+
+	h.t.Helper()
+
+	updates, err := h.db.FetchSessionCommittedUpdates(id)
+	if err != expErr {
+		h.t.Fatalf("expected fetch session committed updates error: "+
+			"%v, got: %v", expErr, err)
+	}
+
+	return updates
+}
+
 // testCreateClientSession asserts various conditions regarding the creation of
 // a new ClientSession. The test asserts:
 //   - client sessions can only be created if a session key index is reserved.
@@ -506,6 +520,9 @@ func testCommitUpdate(h *clientDBHarness) {
 	// session, which should fail.
 	update1 := randCommittedUpdate(h.t, 1)
 	h.commitUpdate(&session.ID, update1, wtdb.ErrClientSessionNotFound)
+	h.fetchSessionCommittedUpdates(
+		&session.ID, wtdb.ErrClientSessionNotFound,
+	)
 
 	// Reserve a session key index and insert the session.
 	session.KeyIndex = h.nextKeyIndex(session.TowerID, blobType)
@@ -665,14 +682,14 @@ func (h *clientDBHarness) assertUpdates(id wtdb.SessionID,
 	_ = h.listSessions(
 		nil, wtdb.WithPerAckedUpdate(perAckedUpdate(ackedUpdates)),
 	)
-	dbSession := h.listSessions(nil)[id]
-	checkCommittedUpdates(h.t, dbSession, expectedPending)
+	committedUpates := h.fetchSessionCommittedUpdates(&id, nil)
+	checkCommittedUpdates(h.t, committedUpates, expectedPending)
 	checkAckedUpdates(h.t, ackedUpdates, expectedAcked)
 }
 
 // checkCommittedUpdates asserts that the CommittedUpdates on session match the
 // expUpdates provided.
-func checkCommittedUpdates(t *testing.T, session *wtdb.ClientSession,
+func checkCommittedUpdates(t *testing.T, actualUpdates,
 	expUpdates []wtdb.CommittedUpdate) {
 
 	t.Helper()
@@ -684,7 +701,7 @@ func checkCommittedUpdates(t *testing.T, session *wtdb.ClientSession,
 		expUpdates = make([]wtdb.CommittedUpdate, 0)
 	}
 
-	require.Equal(t, expUpdates, session.CommittedUpdates)
+	require.Equal(t, expUpdates, actualUpdates)
 }
 
 // checkAckedUpdates asserts that the AckedUpdates on a session match the

--- a/watchtower/wtdb/client_session.go
+++ b/watchtower/wtdb/client_session.go
@@ -47,13 +47,6 @@ type ClientSession struct {
 	// insertion and retrieval.
 	CommittedUpdates []CommittedUpdate
 
-	// AckedUpdates is a map from sequence number to backup id to record
-	// which revoked states were uploaded via this session.
-	//
-	// NOTE: This map is serialized in it's own bucket, separate from the
-	// body of the ClientSession.
-	AckedUpdates map[uint16]BackupID
-
 	// Tower holds the pubkey and address of the watchtower.
 	//
 	// NOTE: This value is not serialized. It is recovered by looking up the

--- a/watchtower/wtdb/client_session.go
+++ b/watchtower/wtdb/client_session.go
@@ -37,16 +37,6 @@ type ClientSession struct {
 
 	ClientSessionBody
 
-	// CommittedUpdates is a sorted list of unacked updates. These updates
-	// can be resent after a restart if the updates failed to send or
-	// receive an acknowledgment.
-	//
-	// NOTE: This list is serialized in it's own bucket, separate from the
-	// body of the ClientSession. The representation on disk is a key value
-	// map from sequence number to CommittedUpdateBody to allow efficient
-	// insertion and retrieval.
-	CommittedUpdates []CommittedUpdate
-
 	// Tower holds the pubkey and address of the watchtower.
 	//
 	// NOTE: This value is not serialized. It is recovered by looking up the

--- a/watchtower/wtmock/client_db.go
+++ b/watchtower/wtmock/client_db.go
@@ -242,6 +242,22 @@ func (m *ClientDB) listClientSessions(tower *wtdb.TowerID,
 	return sessions, nil
 }
 
+// FetchSessionCommittedUpdates retrieves the current set of un-acked updates
+// of the given session.
+func (m *ClientDB) FetchSessionCommittedUpdates(id *wtdb.SessionID) (
+	[]wtdb.CommittedUpdate, error) {
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	sess, ok := m.activeSessions[*id]
+	if !ok {
+		return nil, wtdb.ErrClientSessionNotFound
+	}
+
+	return sess.CommittedUpdates, nil
+}
+
 // CreateClientSession records a newly negotiated client session in the set of
 // active sessions. The session can be identified by its SessionID.
 func (m *ClientDB) CreateClientSession(session *wtdb.ClientSession) error {

--- a/watchtower/wtmock/client_db.go
+++ b/watchtower/wtmock/client_db.go
@@ -26,6 +26,7 @@ type ClientDB struct {
 	mu             sync.Mutex
 	summaries      map[lnwire.ChannelID]wtdb.ClientChanSummary
 	activeSessions map[wtdb.SessionID]wtdb.ClientSession
+	ackedUpdates   map[wtdb.SessionID]map[uint16]wtdb.BackupID
 	towerIndex     map[towerPK]wtdb.TowerID
 	towers         map[wtdb.TowerID]*wtdb.Tower
 
@@ -39,6 +40,7 @@ func NewClientDB() *ClientDB {
 	return &ClientDB{
 		summaries:      make(map[lnwire.ChannelID]wtdb.ClientChanSummary),
 		activeSessions: make(map[wtdb.SessionID]wtdb.ClientSession),
+		ackedUpdates:   make(map[wtdb.SessionID]map[uint16]wtdb.BackupID),
 		towerIndex:     make(map[towerPK]wtdb.TowerID),
 		towers:         make(map[wtdb.TowerID]*wtdb.Tower),
 		indexes:        make(map[keyIndexKey]uint32),
@@ -75,7 +77,7 @@ func (m *ClientDB) CreateTower(lnAddr *lnwire.NetAddress) (*wtdb.Tower, error) {
 	} else {
 		towerID = wtdb.TowerID(atomic.AddUint64(&m.nextTowerID, 1))
 		tower = &wtdb.Tower{
-			ID:          wtdb.TowerID(towerID),
+			ID:          towerID,
 			IdentityKey: lnAddr.IdentityKey,
 			Addresses:   []net.Addr{lnAddr.Address},
 		}
@@ -193,7 +195,7 @@ func (m *ClientDB) ListTowers() ([]*wtdb.Tower, error) {
 // MarkBackupIneligible records that particular commit height is ineligible for
 // backup. This allows the client to track which updates it should not attempt
 // to retry after startup.
-func (m *ClientDB) MarkBackupIneligible(chanID lnwire.ChannelID, commitHeight uint64) error {
+func (m *ClientDB) MarkBackupIneligible(_ lnwire.ChannelID, _ uint64) error {
 	return nil
 }
 
@@ -213,8 +215,13 @@ func (m *ClientDB) ListClientSessions(tower *wtdb.TowerID,
 // optional tower ID can be used to filter out any client sessions in the
 // response that do not correspond to this tower.
 func (m *ClientDB) listClientSessions(tower *wtdb.TowerID,
-	_ ...wtdb.ClientSessionListOption) (
+	opts ...wtdb.ClientSessionListOption) (
 	map[wtdb.SessionID]*wtdb.ClientSession, error) {
+
+	cfg := wtdb.NewClientSessionCfg()
+	for _, o := range opts {
+		o(cfg)
+	}
 
 	sessions := make(map[wtdb.SessionID]*wtdb.ClientSession)
 	for _, session := range m.activeSessions {
@@ -224,6 +231,12 @@ func (m *ClientDB) listClientSessions(tower *wtdb.TowerID,
 		}
 		session.Tower = m.towers[session.TowerID]
 		sessions[session.ID] = &session
+
+		if cfg.PerAckedUpdate != nil {
+			for seq, id := range m.ackedUpdates[session.ID] {
+				cfg.PerAckedUpdate(&session, seq, id)
+			}
+		}
 	}
 
 	return sessions, nil
@@ -274,8 +287,8 @@ func (m *ClientDB) CreateClientSession(session *wtdb.ClientSession) error {
 			RewardPkScript:   cloneBytes(session.RewardPkScript),
 		},
 		CommittedUpdates: make([]wtdb.CommittedUpdate, 0),
-		AckedUpdates:     make(map[uint16]wtdb.BackupID),
 	}
+	m.ackedUpdates[session.ID] = make(map[uint16]wtdb.BackupID)
 
 	return nil
 }
@@ -402,7 +415,7 @@ func (m *ClientDB) AckUpdate(id *wtdb.SessionID, seqNum, lastApplied uint16) err
 		updates[len(updates)-1] = wtdb.CommittedUpdate{}
 		session.CommittedUpdates = updates[:len(updates)-1]
 
-		session.AckedUpdates[seqNum] = update.BackupID
+		m.ackedUpdates[*id][seqNum] = update.BackupID
 		session.TowerLastApplied = lastApplied
 
 		m.activeSessions[*id] = session

--- a/watchtower/wtmock/client_db.go
+++ b/watchtower/wtmock/client_db.go
@@ -200,19 +200,21 @@ func (m *ClientDB) MarkBackupIneligible(chanID lnwire.ChannelID, commitHeight ui
 // ListClientSessions returns the set of all client sessions known to the db. An
 // optional tower ID can be used to filter out any client sessions in the
 // response that do not correspond to this tower.
-func (m *ClientDB) ListClientSessions(
-	tower *wtdb.TowerID) (map[wtdb.SessionID]*wtdb.ClientSession, error) {
+func (m *ClientDB) ListClientSessions(tower *wtdb.TowerID,
+	opts ...wtdb.ClientSessionListOption) (
+	map[wtdb.SessionID]*wtdb.ClientSession, error) {
 
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	return m.listClientSessions(tower)
+	return m.listClientSessions(tower, opts...)
 }
 
 // listClientSessions returns the set of all client sessions known to the db. An
 // optional tower ID can be used to filter out any client sessions in the
 // response that do not correspond to this tower.
-func (m *ClientDB) listClientSessions(
-	tower *wtdb.TowerID) (map[wtdb.SessionID]*wtdb.ClientSession, error) {
+func (m *ClientDB) listClientSessions(tower *wtdb.TowerID,
+	_ ...wtdb.ClientSessionListOption) (
+	map[wtdb.SessionID]*wtdb.ClientSession, error) {
 
 	sessions := make(map[wtdb.SessionID]*wtdb.ClientSession)
 	for _, session := range m.activeSessions {


### PR DESCRIPTION
In this PR, the `AckedUpdates` and `CommittedUpdate` fields are removed from `ClientSession` so that these are not populated each time we fetch a `ClientSession` from the DB. Instead, we now provide the caller with some functional options that they can use to pass in their own callback functions to act on the session's `AckedUpdates` and `CommittedUpdates`. 

Fixes https://github.com/lightningnetwork/lnd/issues/6660

Shout-out to @C-Otto for the [PoC PR](https://github.com/lightningnetwork/lnd/pull/6885) that got the momentum going 🙏 
