### PR TITLE
funding: fix potential data race

### DIFF
--- a/funding/manager.go
+++ b/funding/manager.go
@@ -634,7 +634,9 @@ func (f *Manager) start() error {
 			f.newChanBarriers[chanID] = make(chan struct{})
 			f.barrierMtx.Unlock()
 
+			f.localDiscoveryMtx.Lock()
 			f.localDiscoverySignals[chanID] = make(chan struct{})
+			f.localDiscoveryMtx.Unlock()
 
 			// Rebroadcast the funding transaction for any pending
 			// channel that we initiated. No error will be returned


### PR DESCRIPTION
localDiscoverySignals needs to be guarded by its mutex.  I was unable to write a test case that would trigger a race under the race detector, but better safe than sorry.