### PR TITLE
routing: inbound fees send support

### DIFF
--- a/channeldb/graph.go
+++ b/channeldb/graph.go
@@ -490,6 +490,16 @@ func (c *ChannelGraph) ForEachNodeDirectedChannel(tx kvdb.RTx,
 			cachedInPolicy.ToNodeFeatures = toNodeFeatures
 		}
 
+		var inboundFee lnwire.Fee
+		if p1 != nil {
+			// Extract inbound fee. If there is a decoding error,
+			// skip this edge.
+			_, err := p1.ExtraOpaqueData.ExtractRecords(&inboundFee)
+			if err != nil {
+				return nil
+			}
+		}
+
 		directedChannel := &DirectedChannel{
 			ChannelID:    e.ChannelID,
 			IsNode1:      node == e.NodeKey1Bytes,
@@ -497,6 +507,7 @@ func (c *ChannelGraph) ForEachNodeDirectedChannel(tx kvdb.RTx,
 			Capacity:     e.Capacity,
 			OutPolicySet: p1 != nil,
 			InPolicy:     cachedInPolicy,
+			InboundFee:   inboundFee,
 		}
 
 		if node == e.NodeKey2Bytes {

--- a/channeldb/graph_cache_test.go
+++ b/channeldb/graph_cache_test.go
@@ -75,6 +75,10 @@ func TestGraphCacheAddNode(t *testing.T) {
 			ChannelID:    1000,
 			ChannelFlags: lnwire.ChanUpdateChanFlags(channelFlagA),
 			ToNode:       nodeB,
+			// Define an inbound fee.
+			ExtraOpaqueData: []byte{
+				253, 217, 3, 8, 0, 0, 0, 10, 0, 0, 0, 20,
+			},
 		}
 		inPolicy1 := &models.ChannelEdgePolicy{
 			ChannelID:    1000,
@@ -124,8 +128,18 @@ func TestGraphCacheAddNode(t *testing.T) {
 			edges map[uint64]*DirectedChannel) error {
 
 			nodes[node] = struct{}{}
-			for chanID := range edges {
+			for chanID, directedChannel := range edges {
 				chans[chanID] = struct{}{}
+
+				if node == nodeA {
+					require.NotZero(
+						t, directedChannel.InboundFee,
+					)
+				} else {
+					require.Zero(
+						t, directedChannel.InboundFee,
+					)
+				}
 			}
 
 			return nil

--- a/channeldb/graph_test.go
+++ b/channeldb/graph_test.go
@@ -3934,19 +3934,24 @@ func TestGraphCacheForEachNodeChannel(t *testing.T) {
 	// Add the channel, but only insert a single edge into the graph.
 	require.NoError(t, graph.AddChannelEdge(edgeInfo))
 
+	getSingleChannel := func() *DirectedChannel {
+		var ch *DirectedChannel
+		err = graph.ForEachNodeDirectedChannel(nil, node1.PubKeyBytes,
+			func(c *DirectedChannel) error {
+				require.Nil(t, ch)
+				ch = c
+
+				return nil
+			},
+		)
+		require.NoError(t, err)
+
+		return ch
+	}
+
 	// We should be able to accumulate the single channel added, even
 	// though we have a nil edge policy here.
-	var numChans int
-	err = graph.ForEachNodeDirectedChannel(nil, node1.PubKeyBytes,
-		func(_ *DirectedChannel) error {
-			numChans++
-
-			return nil
-		},
-	)
-	require.NoError(t, err)
-
-	require.Equal(t, numChans, 1)
+	require.NotNil(t, getSingleChannel())
 }
 
 // TestGraphLoading asserts that the cache is properly reconstructed after a

--- a/docs/release-notes/release-notes-0.18.0.md
+++ b/docs/release-notes/release-notes-0.18.0.md
@@ -117,9 +117,8 @@
   node operators to require senders to pay an inbound fee for forwards and
   payments. It is recommended to only use negative fees (an inbound "discount")
   initially to keep the channels open for senders that do not recognize inbound
-  fees. In this release, no send support for pathfinding and route building is
-  added yet. We first want to learn more about the impact that inbound fees have
-  on the routing economy.
+  fees. [Send support](https://github.com/lightningnetwork/lnd/pull/6934) is
+  implemented as well.
 
 * A new config value,
   [sweeper.maxfeerate](https://github.com/lightningnetwork/lnd/pull/7823), is

--- a/routing/graph.go
+++ b/routing/graph.go
@@ -103,7 +103,10 @@ func (g *CachedGraph) FetchAmountPairCapacity(nodeFrom, nodeTo route.Vertex,
 	amount lnwire.MilliSatoshi) (btcutil.Amount, error) {
 
 	// Create unified edges for all incoming connections.
-	u := newNodeEdgeUnifier(g.sourceNode(), nodeTo, nil)
+	//
+	// Note: Inbound fees are not used here because this method is only used
+	// by a deprecated router rpc.
+	u := newNodeEdgeUnifier(g.sourceNode(), nodeTo, false, nil)
 
 	err := u.addGraphPolicies(g)
 	if err != nil {
@@ -116,7 +119,7 @@ func (g *CachedGraph) FetchAmountPairCapacity(nodeFrom, nodeTo route.Vertex,
 			nodeFrom, nodeTo)
 	}
 
-	edge := edgeUnifier.getEdgeNetwork(amount)
+	edge := edgeUnifier.getEdgeNetwork(amount, 0)
 	if edge == nil {
 		return 0, fmt.Errorf("no edge for node pair %v -> %v "+
 			"(amount %v)", nodeFrom, nodeTo, amount)

--- a/routing/heap.go
+++ b/routing/heap.go
@@ -3,7 +3,6 @@ package routing
 import (
 	"container/heap"
 
-	"github.com/lightningnetwork/lnd/channeldb/models"
 	"github.com/lightningnetwork/lnd/lnwire"
 	"github.com/lightningnetwork/lnd/routing/route"
 )
@@ -39,7 +38,7 @@ type nodeWithDist struct {
 	weight int64
 
 	// nextHop is the edge this route comes from.
-	nextHop *models.CachedEdgePolicy
+	nextHop *unifiedEdge
 
 	// routingInfoSize is the total size requirement for the payloads field
 	// in the onion packet from this hop towards the final destination.

--- a/routing/heap.go
+++ b/routing/heap.go
@@ -18,10 +18,16 @@ type nodeWithDist struct {
 	// outgoing edges (channels) emanating from a node.
 	node route.Vertex
 
-	// amountToReceive is the amount that should be received by this node.
+	// netAmountReceived is the amount that should be received by this node.
 	// Either as final payment to the final node or as an intermediate
-	// amount that includes also the fees for subsequent hops.
-	amountToReceive lnwire.MilliSatoshi
+	// amount that includes also the fees for subsequent hops. This node's
+	// inbound fee is already subtracted from the htlc amount - if
+	// applicable.
+	netAmountReceived lnwire.MilliSatoshi
+
+	// outboundFee is the fee that this node charges on the outgoing
+	// channel.
+	outboundFee lnwire.MilliSatoshi
 
 	// incomingCltv is the expected absolute expiry height for the incoming
 	// htlc of this node. This value should already include the final cltv

--- a/routing/pathfind.go
+++ b/routing/pathfind.go
@@ -11,6 +11,7 @@ import (
 	"github.com/btcsuite/btcd/btcutil"
 	sphinx "github.com/lightningnetwork/lightning-onion"
 	"github.com/lightningnetwork/lnd/channeldb"
+	"github.com/lightningnetwork/lnd/channeldb/models"
 	"github.com/lightningnetwork/lnd/feature"
 	"github.com/lightningnetwork/lnd/lnwire"
 	"github.com/lightningnetwork/lnd/record"
@@ -118,7 +119,7 @@ type finalHopParams struct {
 // makes calculating the totals during route construction difficult if we
 // include blinded paths on the first pass).
 //
-// NOTE: The passed slice of ChannelHops MUST be sorted in forward order: from
+// NOTE: The passed slice of unified edges MUST be sorted in forward order: from
 // the source to the target node of the path finding attempt. It is assumed that
 // any feature vectors on all hops have been validated for transitive
 // dependencies.
@@ -157,7 +158,7 @@ func newRoute(sourceVertex route.Vertex,
 		// we compute the route in reverse.
 		var (
 			amtToForward        lnwire.MilliSatoshi
-			fee                 lnwire.MilliSatoshi
+			fee                 int64
 			totalAmtMsatBlinded lnwire.MilliSatoshi
 			outgoingTimeLock    uint32
 			tlvPayload          bool
@@ -195,7 +196,7 @@ func newRoute(sourceVertex route.Vertex,
 
 			// Fee is not part of the hop payload, but only used for
 			// reporting through RPC. Set to zero for the final hop.
-			fee = lnwire.MilliSatoshi(0)
+			fee = 0
 
 			// As this is the last hop, we'll use the specified
 			// final CLTV delta value instead of the value from the
@@ -244,7 +245,18 @@ func newRoute(sourceVertex route.Vertex,
 			// and its policy for the outgoing channel. This policy
 			// is stored as part of the incoming channel of
 			// the next hop.
-			fee = pathEdges[i+1].policy.ComputeFee(amtToForward)
+			outboundFee := pathEdges[i+1].policy.ComputeFee(
+				amtToForward,
+			)
+
+			inboundFee := pathEdges[i].inboundFees.CalcFee(
+				amtToForward + outboundFee,
+			)
+
+			fee = int64(outboundFee) + inboundFee
+			if fee < 0 {
+				fee = 0
+			}
 
 			// We'll take the total timelock of the preceding hop as
 			// the outgoing timelock or this hop. Then we'll
@@ -275,7 +287,7 @@ func newRoute(sourceVertex route.Vertex,
 		// Finally, we update the amount that needs to flow into the
 		// *next* hop, which is the amount this hop needs to forward,
 		// accounting for the fee that it takes.
-		nextIncomingAmount = amtToForward + fee
+		nextIncomingAmount = amtToForward + lnwire.MilliSatoshi(fee)
 	}
 
 	// If we are creating a route to a blinded path, we need to add some
@@ -660,13 +672,13 @@ func findPath(g *graphParams, r *RestrictParams, cfg *PathFindingConfig,
 	// Don't record the initial partial path in the distance map and reserve
 	// that key for the source key in the case we route to ourselves.
 	partialPath := &nodeWithDist{
-		dist:            0,
-		weight:          0,
-		node:            target,
-		amountToReceive: amt,
-		incomingCltv:    finalHtlcExpiry,
-		probability:     1,
-		routingInfoSize: lastHopPayloadSize,
+		dist:              0,
+		weight:            0,
+		node:              target,
+		netAmountReceived: amt,
+		incomingCltv:      finalHtlcExpiry,
+		probability:       1,
+		routingInfoSize:   lastHopPayloadSize,
 	}
 
 	// Calculate the absolute cltv limit. Use uint64 to prevent an overflow
@@ -703,9 +715,27 @@ func findPath(g *graphParams, r *RestrictParams, cfg *PathFindingConfig,
 
 		edgesExpanded++
 
+		// Calculate inbound fee charged by "to" node. The exit hop
+		// doesn't charge inbound fees. If the "to" node is the exit
+		// hop, its inbound fees have already been set to zero by
+		// nodeEdgeUnifier.
+		inboundFee := edge.inboundFees.CalcFee(
+			toNodeDist.netAmountReceived,
+		)
+
+		// Make sure that the node total fee is never negative.
+		// Routing nodes treat a total fee that turns out
+		// negative as a zero fee and pathfinding should do the
+		// same.
+		minInboundFee := -int64(toNodeDist.outboundFee)
+		if inboundFee < minInboundFee {
+			inboundFee = minInboundFee
+		}
+
 		// Calculate amount that the candidate node would have to send
 		// out.
-		amountToSend := toNodeDist.amountToReceive
+		amountToSend := toNodeDist.netAmountReceived +
+			lnwire.MilliSatoshi(inboundFee)
 
 		// Request the success probability for this edge.
 		edgeProbability := r.ProbabilitySource(
@@ -735,10 +765,15 @@ func findPath(g *graphParams, r *RestrictParams, cfg *PathFindingConfig,
 		// Also determine the time lock delta that will be added to the
 		// route if fromVertex is selected. If fromVertex is the source
 		// node, no additional timelock is required.
-		var fee lnwire.MilliSatoshi
-		var timeLockDelta uint16
+		var (
+			timeLockDelta uint16
+			outboundFee   int64
+		)
+
 		if fromVertex != source {
-			fee = edge.policy.ComputeFee(amountToSend)
+			outboundFee = int64(
+				edge.policy.ComputeFee(amountToSend),
+			)
 			timeLockDelta = edge.policy.TimeLockDelta
 		}
 
@@ -749,17 +784,19 @@ func findPath(g *graphParams, r *RestrictParams, cfg *PathFindingConfig,
 			return
 		}
 
-		// amountToReceive is the amount that the node that is added to
-		// the distance map needs to receive from a (to be found)
-		// previous node in the route. That previous node will need to
-		// pay the amount that this node forwards plus the fee it
-		// charges.
-		amountToReceive := amountToSend + fee
+		// netAmountToReceive is the amount that the node that is added
+		// to the distance map needs to receive from a (to be found)
+		// previous node in the route. The inbound fee of the receiving
+		// node is already subtracted from this value. The previous node
+		// will need to pay the amount that this node forwards plus the
+		// fee it charges plus this node's inbound fee.
+		netAmountToReceive := amountToSend +
+			lnwire.MilliSatoshi(outboundFee)
 
 		// Check if accumulated fees would exceed fee limit when this
 		// node would be added to the path.
-		totalFee := amountToReceive - amt
-		if totalFee > r.FeeLimit {
+		totalFee := int64(netAmountToReceive) - int64(amt)
+		if totalFee > 0 && lnwire.MilliSatoshi(totalFee) > r.FeeLimit {
 			return
 		}
 
@@ -775,11 +812,21 @@ func findPath(g *graphParams, r *RestrictParams, cfg *PathFindingConfig,
 			return
 		}
 
+		// Calculate the combined fee for this edge. Dijkstra does not
+		// support negative edge weights. Because this fee feeds into
+		// the edge weight calculation, we don't allow it to be
+		// negative.
+		signedFee := inboundFee + outboundFee
+		fee := lnwire.MilliSatoshi(0)
+		if signedFee > 0 {
+			fee = lnwire.MilliSatoshi(signedFee)
+		}
+
 		// By adding fromVertex in the route, there will be an extra
 		// weight composed of the fee that this node will charge and
 		// the amount that will be locked for timeLockDelta blocks in
 		// the HTLC that is handed out to fromVertex.
-		weight := edgeWeight(amountToReceive, fee, timeLockDelta)
+		weight := edgeWeight(netAmountToReceive, fee, timeLockDelta)
 
 		// Compute the tentative weight to this new channel/edge
 		// which is the weight from our toNode to the target node
@@ -787,7 +834,10 @@ func findPath(g *graphParams, r *RestrictParams, cfg *PathFindingConfig,
 		tempWeight := toNodeDist.weight + weight
 
 		// Add an extra factor to the weight to take into account the
-		// probability.
+		// probability. Another reason why we rounded the fee up to zero
+		// is to prevent a highly negative fee from cancelling out the
+		// extra factor. We don't want an always-failing node to attract
+		// traffic using a highly negative fee and escape penalization.
 		tempDist := getProbabilityBasedDist(
 			tempWeight, probability,
 			absoluteAttemptCost,
@@ -854,14 +904,15 @@ func findPath(g *graphParams, r *RestrictParams, cfg *PathFindingConfig,
 		// The new better distance is recorded, and also our "next hop"
 		// map is populated with this edge.
 		withDist := &nodeWithDist{
-			dist:            tempDist,
-			weight:          tempWeight,
-			node:            fromVertex,
-			amountToReceive: amountToReceive,
-			incomingCltv:    incomingCltv,
-			probability:     probability,
-			nextHop:         edge,
-			routingInfoSize: routingInfoSize,
+			dist:              tempDist,
+			weight:            tempWeight,
+			node:              fromVertex,
+			netAmountReceived: netAmountToReceive,
+			outboundFee:       lnwire.MilliSatoshi(outboundFee),
+			incomingCltv:      incomingCltv,
+			probability:       probability,
+			nextHop:           edge,
+			routingInfoSize:   routingInfoSize,
 		}
 		distance[fromVertex] = withDist
 
@@ -920,9 +971,13 @@ func findPath(g *graphParams, r *RestrictParams, cfg *PathFindingConfig,
 		nodesVisited++
 
 		pivot := partialPath.node
+		isExitHop := partialPath.nextHop == nil
 
-		// Create unified edges for all incoming connections.
-		u := newNodeEdgeUnifier(self, pivot, outgoingChanMap)
+		// Create unified policies for all incoming connections. Don't
+		// use inbound fees for the exit hop.
+		u := newNodeEdgeUnifier(
+			self, pivot, !isExitHop, outgoingChanMap,
+		)
 
 		err := u.addGraphPolicies(g.graph)
 		if err != nil {
@@ -931,6 +986,11 @@ func findPath(g *graphParams, r *RestrictParams, cfg *PathFindingConfig,
 
 		// We add hop hints that were supplied externally.
 		for _, reverseEdge := range additionalEdgesWithSrc[pivot] {
+			// Assume zero inbound fees for route hints. If inbound
+			// fees would apply, they couldn't be communicated in
+			// bolt11 invoices currently.
+			inboundFee := models.InboundFee{}
+
 			// Hop hints don't contain a capacity. We set one here,
 			// since a capacity is needed for probability
 			// calculations. We set a high capacity to act as if
@@ -942,12 +1002,13 @@ func findPath(g *graphParams, r *RestrictParams, cfg *PathFindingConfig,
 			u.addPolicy(
 				reverseEdge.sourceNode,
 				reverseEdge.edge.EdgePolicy(),
+				inboundFee,
 				fakeHopHintCapacity,
 				reverseEdge.edge.IntermediatePayloadSize,
 			)
 		}
 
-		amtToSend := partialPath.amountToReceive
+		netAmountReceived := partialPath.netAmountReceived
 
 		// Expand all connections using the optimal policy for each
 		// connection.
@@ -969,7 +1030,8 @@ func findPath(g *graphParams, r *RestrictParams, cfg *PathFindingConfig,
 			}
 
 			edge := edgeUnifier.getEdge(
-				amtToSend, g.bandwidthHints,
+				netAmountReceived, g.bandwidthHints,
+				partialPath.outboundFee,
 			)
 
 			if edge == nil {
@@ -1050,7 +1112,7 @@ func findPath(g *graphParams, r *RestrictParams, cfg *PathFindingConfig,
 
 	log.Debugf("Found route: probability=%v, hops=%v, fee=%v",
 		distance[source].probability, len(pathEdges),
-		distance[source].amountToReceive-amt)
+		distance[source].netAmountReceived-amt)
 
 	return pathEdges, distance[source].probability, nil
 }

--- a/routing/pathfind_test.go
+++ b/routing/pathfind_test.go
@@ -1225,7 +1225,7 @@ func runPathFindingWithAdditionalEdges(t *testing.T, useCache bool) {
 	}
 
 	find := func(r *RestrictParams) (
-		[]*models.CachedEdgePolicy, error) {
+		[]*unifiedEdge, error) {
 
 		return dbFindPath(
 			graph.graph, additionalEdges, &mockBandwidthHints{},
@@ -1437,7 +1437,7 @@ func runPathFindingWithRedundantAdditionalEdges(t *testing.T, useCache bool) {
 	require.NoError(t, err, "unable to find path to bob")
 	require.Len(t, path, 1)
 
-	require.Equal(t, realChannelID, path[0].ChannelID,
+	require.Equal(t, realChannelID, path[0].policy.ChannelID,
 		"additional edge for known edge wasn't ignored")
 }
 
@@ -1723,8 +1723,17 @@ func TestNewRoute(t *testing.T) {
 		}
 
 		t.Run(testCase.name, func(t *testing.T) {
+			var unifiedHops []*unifiedEdge
+			for _, hop := range testCase.hops {
+				unifiedHops = append(unifiedHops,
+					&unifiedEdge{
+						policy: hop,
+					},
+				)
+			}
+
 			route, err := newRoute(
-				sourceVertex, testCase.hops, startingHeight,
+				sourceVertex, unifiedHops, startingHeight,
 				finalHopParams{
 					amt:         testCase.paymentAmount,
 					totalAmt:    testCase.paymentAmount,
@@ -1864,7 +1873,7 @@ func runDestTLVGraphFallback(t *testing.T, useCache bool) {
 	require.NoError(t, err, "unable to fetch source node")
 
 	find := func(r *RestrictParams,
-		target route.Vertex) ([]*models.CachedEdgePolicy, error) {
+		target route.Vertex) ([]*unifiedEdge, error) {
 
 		return dbFindPath(
 			ctx.graph, nil, &mockBandwidthHints{},
@@ -2522,7 +2531,7 @@ func TestPathFindSpecExample(t *testing.T) {
 }
 
 func assertExpectedPath(t *testing.T, aliasMap map[string]route.Vertex,
-	path []*models.CachedEdgePolicy, nodeAliases ...string) {
+	path []*unifiedEdge, nodeAliases ...string) {
 
 	if len(path) != len(nodeAliases) {
 		t.Fatalf("number of hops=(%v) and number of aliases=(%v) do "+
@@ -2530,9 +2539,10 @@ func assertExpectedPath(t *testing.T, aliasMap map[string]route.Vertex,
 	}
 
 	for i, hop := range path {
-		if hop.ToNodePubKey() != aliasMap[nodeAliases[i]] {
+		if hop.policy.ToNodePubKey() != aliasMap[nodeAliases[i]] {
 			t.Fatalf("expected %v to be pos #%v in hop, instead "+
-				"%v was", nodeAliases[i], i, hop.ToNodePubKey())
+				"%v was", nodeAliases[i], i,
+				hop.policy.ToNodePubKey())
 		}
 	}
 }
@@ -2606,10 +2616,10 @@ func runRestrictOutgoingChannel(t *testing.T, useCache bool) {
 
 	// Assert that the route starts with channel chanSourceB1, in line with
 	// the specified restriction.
-	if path[0].ChannelID != chanSourceB1 {
+	if path[0].policy.ChannelID != chanSourceB1 {
 		t.Fatalf("expected route to pass through channel %v, "+
 			"but channel %v was selected instead", chanSourceB1,
-			path[0].ChannelID)
+			path[0].policy.ChannelID)
 	}
 
 	// If a direct channel to target is allowed as well, that channel is
@@ -2619,7 +2629,7 @@ func runRestrictOutgoingChannel(t *testing.T, useCache bool) {
 	}
 	path, err = ctx.findPath(target, paymentAmt)
 	require.NoError(t, err, "unable to find path")
-	if path[0].ChannelID != chanSourceTarget {
+	if path[0].policy.ChannelID != chanSourceTarget {
 		t.Fatalf("expected route to pass through channel %v",
 			chanSourceTarget)
 	}
@@ -2658,10 +2668,10 @@ func runRestrictLastHop(t *testing.T, useCache bool) {
 	ctx.restrictParams.LastHop = &lastHop
 	path, err := ctx.findPath(target, paymentAmt)
 	require.NoError(t, err, "unable to find path")
-	if path[0].ChannelID != 3 {
+	if path[0].policy.ChannelID != 3 {
 		t.Fatalf("expected route to pass through channel 3, "+
 			"but channel %v was selected instead",
-			path[0].ChannelID)
+			path[0].policy.ChannelID)
 	}
 }
 
@@ -2941,10 +2951,10 @@ func testProbabilityRouting(t *testing.T, useCache bool,
 	}
 
 	// Assert that the route passes through the expected channel.
-	if path[1].ChannelID != expectedChan {
+	if path[1].policy.ChannelID != expectedChan {
 		t.Fatalf("expected route to pass through channel %v, "+
 			"but channel %v was selected instead", expectedChan,
-			path[1].ChannelID)
+			path[1].policy.ChannelID)
 	}
 }
 
@@ -3005,10 +3015,10 @@ func runEqualCostRouteSelection(t *testing.T, useCache bool) {
 		t.Fatal(err)
 	}
 
-	if path[1].ChannelID != 2 {
+	if path[1].policy.ChannelID != 2 {
 		t.Fatalf("expected route to pass through channel %v, "+
 			"but channel %v was selected instead", 2,
-			path[1].ChannelID)
+			path[1].policy.ChannelID)
 	}
 }
 
@@ -3168,7 +3178,7 @@ func (c *pathFindingTestContext) aliasFromKey(pubKey route.Vertex) string {
 }
 
 func (c *pathFindingTestContext) findPath(target route.Vertex,
-	amt lnwire.MilliSatoshi) ([]*models.CachedEdgePolicy,
+	amt lnwire.MilliSatoshi) ([]*unifiedEdge,
 	error) {
 
 	return dbFindPath(
@@ -3177,7 +3187,7 @@ func (c *pathFindingTestContext) findPath(target route.Vertex,
 	)
 }
 
-func (c *pathFindingTestContext) assertPath(path []*models.CachedEdgePolicy,
+func (c *pathFindingTestContext) assertPath(path []*unifiedEdge,
 	expected []uint64) {
 
 	if len(path) != len(expected) {
@@ -3186,9 +3196,10 @@ func (c *pathFindingTestContext) assertPath(path []*models.CachedEdgePolicy,
 	}
 
 	for i, edge := range path {
-		if edge.ChannelID != expected[i] {
+		if edge.policy.ChannelID != expected[i] {
 			c.t.Fatalf("expected hop %v to be channel %v, "+
-				"but got %v", i, expected[i], edge.ChannelID)
+				"but got %v", i, expected[i],
+				edge.policy.ChannelID)
 		}
 	}
 }
@@ -3200,7 +3211,7 @@ func dbFindPath(graph *channeldb.ChannelGraph,
 	bandwidthHints bandwidthHints,
 	r *RestrictParams, cfg *PathFindingConfig,
 	source, target route.Vertex, amt lnwire.MilliSatoshi, timePref float64,
-	finalHtlcExpiry int32) ([]*models.CachedEdgePolicy, error) {
+	finalHtlcExpiry int32) ([]*unifiedEdge, error) {
 
 	sourceNode, err := graph.SourceNode()
 	if err != nil {
@@ -3351,11 +3362,11 @@ func TestBlindedRouteConstruction(t *testing.T) {
 	carolDaveEdge := blindedEdges[carolVertex][0]
 	daveEveEdge := blindedEdges[daveBlindedVertex][0]
 
-	edges := []*models.CachedEdgePolicy{
-		aliceBobEdge,
-		bobCarolEdge,
-		carolDaveEdge.EdgePolicy(),
-		daveEveEdge.EdgePolicy(),
+	edges := []*unifiedEdge{
+		{policy: aliceBobEdge},
+		{policy: bobCarolEdge},
+		{policy: carolDaveEdge.EdgePolicy()},
+		{policy: daveEveEdge.EdgePolicy()},
 	}
 
 	// Total timelock for the route should include:

--- a/routing/payment_session_test.go
+++ b/routing/payment_session_test.go
@@ -212,7 +212,7 @@ func TestRequestRoute(t *testing.T) {
 	// Override pathfinder with a mock.
 	session.pathFinder = func(_ *graphParams, r *RestrictParams,
 		_ *PathFindingConfig, _, _ route.Vertex, _ lnwire.MilliSatoshi,
-		_ float64, _ int32) ([]*models.CachedEdgePolicy, float64,
+		_ float64, _ int32) ([]*unifiedEdge, float64,
 		error) {
 
 		// We expect find path to receive a cltv limit excluding the
@@ -221,14 +221,16 @@ func TestRequestRoute(t *testing.T) {
 			t.Fatal("wrong cltv limit")
 		}
 
-		path := []*models.CachedEdgePolicy{
+		path := []*unifiedEdge{
 			{
-				ToNodePubKey: func() route.Vertex {
-					return route.Vertex{}
+				policy: &models.CachedEdgePolicy{
+					ToNodePubKey: func() route.Vertex {
+						return route.Vertex{}
+					},
+					ToNodeFeatures: lnwire.NewFeatureVector(
+						nil, nil,
+					),
 				},
-				ToNodeFeatures: lnwire.NewFeatureVector(
-					nil, nil,
-				),
 			},
 		}
 

--- a/routing/router.go
+++ b/routing/router.go
@@ -3161,9 +3161,13 @@ func getRouteUnifiers(source route.Vertex, hops []route.Vertex,
 
 		localChan := i == 0
 
-		// Build unified edges for this hop based on the channels known
-		// in the graph.
-		u := newNodeEdgeUnifier(source, toNode, outgoingChans)
+		// Build unified policies for this hop based on the channels
+		// known in the graph. Don't use inbound fees.
+		//
+		// TODO: Add inbound fees support for BuildRoute.
+		u := newNodeEdgeUnifier(
+			source, toNode, false, outgoingChans,
+		)
 
 		err := u.addGraphPolicies(graph)
 		if err != nil {
@@ -3189,7 +3193,7 @@ func getRouteUnifiers(source route.Vertex, hops []route.Vertex,
 		}
 
 		// Get an edge for the specific amount that we want to forward.
-		edge := edgeUnifier.getEdge(runningAmt, bandwidthHints)
+		edge := edgeUnifier.getEdge(runningAmt, bandwidthHints, 0)
 		if edge == nil {
 			log.Errorf("Cannot find policy with amt=%v for node %v",
 				runningAmt, fromNode)
@@ -3227,7 +3231,7 @@ func getPathEdges(source route.Vertex, receiverAmt lnwire.MilliSatoshi,
 	// amount ranges re-checked.
 	var pathEdges []*unifiedEdge
 	for i, unifier := range unifiers {
-		edge := unifier.getEdge(receiverAmt, bandwidthHints)
+		edge := unifier.getEdge(receiverAmt, bandwidthHints, 0)
 		if edge == nil {
 			fromNode := source
 			if i > 0 {

--- a/routing/router.go
+++ b/routing/router.go
@@ -3218,14 +3218,14 @@ func getRouteUnifiers(source route.Vertex, hops []route.Vertex,
 // including fees, to send the payment.
 func getPathEdges(source route.Vertex, receiverAmt lnwire.MilliSatoshi,
 	unifiers []*edgeUnifier, bandwidthHints *bandwidthManager,
-	hops []route.Vertex) ([]*models.CachedEdgePolicy,
+	hops []route.Vertex) ([]*unifiedEdge,
 	lnwire.MilliSatoshi, error) {
 
 	// Now that we arrived at the start of the route and found out the route
 	// total amount, we make a forward pass. Because the amount may have
 	// been increased in the backward pass, fees need to be recalculated and
 	// amount ranges re-checked.
-	var pathEdges []*models.CachedEdgePolicy
+	var pathEdges []*unifiedEdge
 	for i, unifier := range unifiers {
 		edge := unifier.getEdge(receiverAmt, bandwidthHints)
 		if edge == nil {
@@ -3247,7 +3247,7 @@ func getPathEdges(source route.Vertex, receiverAmt lnwire.MilliSatoshi,
 			)
 		}
 
-		pathEdges = append(pathEdges, edge.policy)
+		pathEdges = append(pathEdges, edge)
 	}
 
 	return pathEdges, receiverAmt, nil

--- a/routing/router_test.go
+++ b/routing/router_test.go
@@ -2450,8 +2450,8 @@ func TestFindPathFeeWeighting(t *testing.T) {
 	if len(path) != 1 {
 		t.Fatalf("expected path length of 1, instead was: %v", len(path))
 	}
-	if path[0].ToNodePubKey() != ctx.aliases["luoji"] {
-		t.Fatalf("wrong node: %v", path[0].ToNodePubKey())
+	if path[0].policy.ToNodePubKey() != ctx.aliases["luoji"] {
+		t.Fatalf("wrong node: %v", path[0].policy.ToNodePubKey())
 	}
 }
 

--- a/routing/unified_edges_test.go
+++ b/routing/unified_edges_test.go
@@ -46,31 +46,75 @@ func TestNodeEdgeUnifier(t *testing.T) {
 	c1 := btcutil.Amount(7)
 	c2 := btcutil.Amount(8)
 
-	unifierFilled := newNodeEdgeUnifier(source, toNode, nil)
-	unifierFilled.addPolicy(fromNode, &p1, c1, defaultHopPayloadSize)
-	unifierFilled.addPolicy(fromNode, &p2, c2, defaultHopPayloadSize)
+	inboundFee1 := models.InboundFee{
+		Base: 5,
+		Rate: 10000,
+	}
 
-	unifierNoCapacity := newNodeEdgeUnifier(source, toNode, nil)
-	unifierNoCapacity.addPolicy(fromNode, &p1, 0, defaultHopPayloadSize)
-	unifierNoCapacity.addPolicy(fromNode, &p2, 0, defaultHopPayloadSize)
+	inboundFee2 := models.InboundFee{
+		Base: 10,
+		Rate: 10000,
+	}
 
-	unifierNoInfo := newNodeEdgeUnifier(source, toNode, nil)
-	unifierNoInfo.addPolicy(
-		fromNode, &models.CachedEdgePolicy{}, 0, defaultHopPayloadSize,
+	unifierFilled := newNodeEdgeUnifier(source, toNode, false, nil)
+
+	unifierFilled.addPolicy(
+		fromNode, &p1, inboundFee1, c1, defaultHopPayloadSize,
+	)
+	unifierFilled.addPolicy(
+		fromNode, &p2, inboundFee2, c2, defaultHopPayloadSize,
 	)
 
-	unifierLocal := newNodeEdgeUnifier(fromNode, toNode, nil)
-	unifierLocal.addPolicy(fromNode, &p1, c1, defaultHopPayloadSize)
+	unifierNoCapacity := newNodeEdgeUnifier(source, toNode, false, nil)
+	unifierNoCapacity.addPolicy(
+		fromNode, &p1, inboundFee1, 0, defaultHopPayloadSize,
+	)
+	unifierNoCapacity.addPolicy(
+		fromNode, &p2, inboundFee2, 0, defaultHopPayloadSize,
+	)
+
+	unifierNoInfo := newNodeEdgeUnifier(source, toNode, false, nil)
+	unifierNoInfo.addPolicy(
+		fromNode, &models.CachedEdgePolicy{}, models.InboundFee{},
+		0, defaultHopPayloadSize,
+	)
+
+	unifierInboundFee := newNodeEdgeUnifier(source, toNode, true, nil)
+	unifierInboundFee.addPolicy(
+		fromNode, &p1, inboundFee1, c1, defaultHopPayloadSize,
+	)
+	unifierInboundFee.addPolicy(
+		fromNode, &p2, inboundFee2, c2, defaultHopPayloadSize,
+	)
+
+	unifierLocal := newNodeEdgeUnifier(fromNode, toNode, true, nil)
+	unifierLocal.addPolicy(
+		fromNode, &p1, inboundFee1, c1, defaultHopPayloadSize,
+	)
+
+	inboundFeeZero := models.InboundFee{}
+	inboundFeeNegative := models.InboundFee{
+		Base: -150,
+	}
+	unifierNegInboundFee := newNodeEdgeUnifier(source, toNode, true, nil)
+	unifierNegInboundFee.addPolicy(
+		fromNode, &p1, inboundFeeZero, c1, defaultHopPayloadSize,
+	)
+	unifierNegInboundFee.addPolicy(
+		fromNode, &p2, inboundFeeNegative, c2, defaultHopPayloadSize,
+	)
 
 	tests := []struct {
-		name             string
-		unifier          *nodeEdgeUnifier
-		amount           lnwire.MilliSatoshi
-		expectedFeeBase  lnwire.MilliSatoshi
-		expectedFeeRate  lnwire.MilliSatoshi
-		expectedTimeLock uint16
-		expectNoPolicy   bool
-		expectedCapacity btcutil.Amount
+		name               string
+		unifier            *nodeEdgeUnifier
+		amount             lnwire.MilliSatoshi
+		expectedFeeBase    lnwire.MilliSatoshi
+		expectedFeeRate    lnwire.MilliSatoshi
+		expectedInboundFee models.InboundFee
+		expectedTimeLock   uint16
+		expectNoPolicy     bool
+		expectedCapacity   btcutil.Amount
+		nextOutFee         lnwire.MilliSatoshi
 	}{
 		{
 			name:           "amount below min htlc",
@@ -132,13 +176,49 @@ func TestNodeEdgeUnifier(t *testing.T) {
 			expectNoPolicy: true,
 		},
 		{
-			name:             "local",
-			unifier:          unifierLocal,
-			amount:           100,
-			expectedFeeBase:  p1.FeeBaseMSat,
-			expectedFeeRate:  p1.FeeProportionalMillionths,
-			expectedTimeLock: p1.TimeLockDelta,
-			expectedCapacity: c1,
+			name:               "local",
+			unifier:            unifierLocal,
+			amount:             100,
+			expectedFeeBase:    p1.FeeBaseMSat,
+			expectedFeeRate:    p1.FeeProportionalMillionths,
+			expectedTimeLock:   p1.TimeLockDelta,
+			expectedCapacity:   c1,
+			expectedInboundFee: inboundFee1,
+		},
+		{
+			name: "use p2 with highest fee " +
+				"including inbound",
+			unifier:            unifierInboundFee,
+			amount:             200,
+			expectedFeeBase:    p2.FeeBaseMSat,
+			expectedFeeRate:    p2.FeeProportionalMillionths,
+			expectedInboundFee: inboundFee2,
+			expectedTimeLock:   p1.TimeLockDelta,
+			expectedCapacity:   c2,
+		},
+		// Choose inbound fee exactly so that max htlc is just exceeded.
+		// In this test, the amount that must be sent is 5001 msat.
+		{
+			name:           "inbound fee exceeds max htlc",
+			unifier:        unifierInboundFee,
+			amount:         4947,
+			expectNoPolicy: true,
+		},
+		// The outbound fee of p2 is higher than p1, but because of the
+		// inbound fee on p2 it is brought down to 0. Purely based on
+		// total channel fee, p1 would be selected as the highest fee
+		// channel. However, because the total node fee can never be
+		// negative and the next outgoing fee is zero, the effect of the
+		// inbound discount is cancelled out.
+		{
+			name:               "inbound fee that is rounded up",
+			unifier:            unifierNegInboundFee,
+			amount:             500,
+			expectedFeeBase:    p2.FeeBaseMSat,
+			expectedFeeRate:    p2.FeeProportionalMillionths,
+			expectedInboundFee: inboundFeeNegative,
+			expectedTimeLock:   p1.TimeLockDelta,
+			expectedCapacity:   c2,
 		},
 	}
 
@@ -149,7 +229,7 @@ func TestNodeEdgeUnifier(t *testing.T) {
 			t.Parallel()
 
 			edge := test.unifier.edgeUnifiers[fromNode].getEdge(
-				test.amount, bandwidthHints,
+				test.amount, bandwidthHints, test.nextOutFee,
 			)
 
 			if test.expectNoPolicy {
@@ -163,6 +243,8 @@ func TestNodeEdgeUnifier(t *testing.T) {
 				policy.FeeBaseMSat, "base fee")
 			require.Equal(t, test.expectedFeeRate,
 				policy.FeeProportionalMillionths, "fee rate")
+			require.Equal(t, test.expectedInboundFee,
+				edge.inboundFees, "inbound fee")
 			require.Equal(t, test.expectedTimeLock,
 				policy.TimeLockDelta, "timelock")
 			require.Equal(t, test.expectedCapacity, edge.capacity,


### PR DESCRIPTION
Implements send support for inbound routing fees. The receiver side is implemented in #6703 and this PR is based off of that.

### Implementation details

* The `channel_update` extra opaque data isn't validated before it was stored in the database. This means that everywhere we read this data, a tlv error might be encountered. In this PR, this case is handled in a mostly defensive way, skipping over the channel policy.

Based on #6703. Review first commits there.

Support for inbound fees in `BuildRoute` is explored in #7060.
