### PR TITLE
rpcserver: error on zero local balance in openchan req

### DIFF
--- a/docs/release-notes/release-notes-0.16.0.md
+++ b/docs/release-notes/release-notes-0.16.0.md
@@ -27,6 +27,9 @@ transaction](https://github.com/lightningnetwork/lnd/pull/6730).
   method to the RPC to allow subscribing to updates from any inflight payment.
   Similar to TrackPaymentV2, but for any inflight payment.
 
+* [Catch and throw an error](https://github.com/lightningnetwork/lnd/pull/6945)
+  during `openchannel` if the local funding amount given is zero. 
+
 ## Wallet
 
 * [Allows Taproot public keys and tap scripts to be imported as watch-only

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -1913,6 +1913,11 @@ func (r *rpcServer) parseOpenChannelReq(in *lnrpc.OpenChannelRequest,
 
 	globalFeatureSet := r.server.featureMgr.Get(feature.SetNodeAnn)
 
+	// Ensure that a local funding amount has been specified.
+	if localFundingAmt == 0 {
+		return nil, fmt.Errorf("local funding amount must be non-zero")
+	}
+
 	// Ensure that the initial balance of the remote party (if pushing
 	// satoshis) does not exceed the amount the local party has requested
 	// for funding.


### PR DESCRIPTION
In this commit, we catch and error on the specific case where an openchannel request has a zero-value local funding amount. This is just to ensure that the error message returned makes more sense.

Fixes https://github.com/lightningnetwork/lnd/issues/6943