### PR TITLE
lnwallet/chancloser: properly compute initial fee of cop close txn

### DIFF
--- a/docs/release-notes/release-notes-0.15.3.md
+++ b/docs/release-notes/release-notes-0.15.3.md
@@ -17,6 +17,12 @@
 * [A bug has been fixed that caused fee estimation to be incorrect for taproot
   inputs when using the `SendOutputs` call.](https://github.com/lightningnetwork/lnd/pull/6941)
 
+
+* [A bug has been fixed that could cause lnd to underpay for co-op close
+  transaction when or both of the outputs used a P2TR
+  addresss.](https://github.com/lightningnetwork/lnd/pull/6957)
+
+
 ## Taproot
 
 * [Add `p2tr` address type to account

--- a/lntest/itest/lnd_wallet_import_test.go
+++ b/lntest/itest/lnd_wallet_import_test.go
@@ -561,7 +561,7 @@ func fundChanAndCloseFromImportedAccount(t *harnessTest, srcNode, destNode,
 	// they must've been redeemed after the close. Without a pre-negotiated
 	// close address, the funds will go into the source node's wallet
 	// instead of the imported account.
-	const chanCloseTxFee = 9050
+	const chanCloseTxFee = 9650
 	balanceFromClosedChan := chanSize - invoiceAmt - chanCloseTxFee
 
 	if account == defaultImportedAccount {

--- a/lnwallet/chancloser/chancloser_test.go
+++ b/lnwallet/chancloser/chancloser_test.go
@@ -268,6 +268,8 @@ func TestMaxFeeBailOut(t *testing.T) {
 	)
 
 	for _, isInitiator := range []bool{true, false} {
+		isInitiator := isInitiator
+
 		t.Run(fmt.Sprintf("initiator=%v", isInitiator), func(t *testing.T) {
 			t.Parallel()
 

--- a/peer/brontide.go
+++ b/peer/brontide.go
@@ -2719,8 +2719,9 @@ func (p *Brontide) createChanCloser(channel *lnwallet.LightningChannel,
 
 	chanCloser := chancloser.NewChanCloser(
 		chancloser.ChanCloseCfg{
-			Channel:     channel,
-			BroadcastTx: p.cfg.Wallet.PublishTransaction,
+			Channel:      channel,
+			FeeEstimator: &chancloser.SimpleCoopFeeEstimator{},
+			BroadcastTx:  p.cfg.Wallet.PublishTransaction,
 			DisableChannel: func(op wire.OutPoint) error {
 				return p.cfg.ChanStatusMgr.RequestDisable(
 					op, false,


### PR DESCRIPTION
In this commit, we modify the way we compute the starting ideal fee for the co-op close transaction. Before this commit, channel.CalcFee was used, which'll compute the fee based on the commitment transaction itself, rathern than the co-op close transaction. As the co-op close transaction is potentailly bigger (two P2TR outputs) than the commitment transaction, this can cause us to under estimate the fee, which can result in the fee rate being too low to propagate.

To remedy this, we now compute a fee estimate from scratch, based on the delivery fees of the two parties.

Fixes #6953