### PR TITLE
fixing inconsistent flag naming in lncli queryRoutes

### DIFF
--- a/cmd/lncli/cmd_payments.go
+++ b/cmd/lncli/cmd_payments.go
@@ -1037,7 +1037,7 @@ var queryRoutesCommand = cli.Command{
 			Usage: "use mission control probabilities",
 		},
 		cli.Uint64Flag{
-			Name: "outgoing_chanid",
+			Name: "outgoing_chan_id",
 			Usage: "(optional) the channel id of the channel " +
 				"that must be taken to the first hop",
 		},
@@ -1126,7 +1126,7 @@ func queryRoutes(ctx *cli.Context) error {
 		FinalCltvDelta:    int32(ctx.Int("final_cltv_delta")),
 		UseMissionControl: ctx.Bool("use_mc"),
 		CltvLimit:         uint32(ctx.Uint64(cltvLimitFlag.Name)),
-		OutgoingChanId:    ctx.Uint64("outgoing_chanid"),
+		OutgoingChanId:    ctx.Uint64("outgoing_chan_id"),
 		TimePref:          ctx.Float64(timePrefFlag.Name),
 		IgnoredPairs:      ignoredPairs,
 	}


### PR DESCRIPTION
outgoing chan id flag has two different namings:
- **outgoing_chanid** in queryroutes 
- **outgoing_chan_id** in payinvoice 

This PR unifies that to **outgoing_chan_id** for the sake of consistency 