### PR TITLE
build: get binary build info from `debug/buildinfo`

### DIFF
--- a/build/version.go
+++ b/build/version.go
@@ -7,6 +7,7 @@ package build
 
 import (
 	"fmt"
+	"runtime/debug"
 	"strings"
 )
 
@@ -17,16 +18,14 @@ var (
 	// -ldflags during compilation.
 	Commit string
 
-	// CommitHash stores the current commit hash of this build, this should
-	// be set using the -ldflags during compilation.
+	// CommitHash stores the current commit hash of this build.
 	CommitHash string
 
-	// RawTags contains the raw set of build tags, separated by commas. This
-	// should be set using -ldflags during compilation.
+	// RawTags contains the raw set of build tags, separated by commas.
 	RawTags string
 
 	// GoVersion stores the go version that the executable was compiled
-	// with. This should be set using -ldflags during compilation.
+	// with.
 	GoVersion string
 )
 
@@ -60,6 +59,20 @@ func init() {
 		if !strings.ContainsRune(semanticAlphabet, r) {
 			panic(fmt.Errorf("rune: %v is not in the semantic "+
 				"alphabet", r))
+		}
+	}
+
+	// Get build information from the runtime.
+	if info, ok := debug.ReadBuildInfo(); ok {
+		GoVersion = info.GoVersion
+		for _, setting := range info.Settings {
+			switch setting.Key {
+			case "vcs.revision":
+				CommitHash = setting.Value
+
+			case "-tags":
+				RawTags = setting.Value
+			}
 		}
 	}
 }

--- a/docs/release-notes/release-notes-0.16.0.md
+++ b/docs/release-notes/release-notes-0.16.0.md
@@ -50,6 +50,9 @@ minimum version needed to build the project.
 1.19.1 contained a bug that affected lnd and resulted in a
 crash](https://github.com/lightningnetwork/lnd/pull/7019).
 
+[Use Go's `runtime/debug` package to get information about the build](
+https://github.com/lightningnetwork/lnd/pull/6963/)
+
 ## Misc
 
 * [Fixed a bug where the Switch did not reforward settles or fails for
@@ -155,6 +158,7 @@ crash](https://github.com/lightningnetwork/lnd/pull/7019).
 * Graham Krizek
 * hieblmi
 * Jesse de Wit
+* Jordi Montes
 * Matt Morehouse
 * Michael Street
 * Olaoluwa Osuntokun


### PR DESCRIPTION
Since `go1.18` the runtime has a package that provides information about module versions, version control information, and build flags embedded in executable files built by the go command.

The new packages allows us to get information needed by the `version` command without having to rely on `ldflags` set at build time.

This can be really helpful while debugging errors from people using custom binaries. For example a build from master.

## Steps to Test
- Build binaries from this branch
- run lnd
- call `lncli version`

You can see what information the binary contains with `go version -m {lnd,lncli}`, this already works in the latest lnd versions that have been compiled with `>go1.18` 
