### PR TITLE
lncli+docs: fix and document remote signing setup upgrade to lnd v0.15.2-beta

### DIFF
--- a/cmd/lncli/walletrpc_active.go
+++ b/cmd/lncli/walletrpc_active.go
@@ -93,9 +93,11 @@ func parseAddrType(addrTypeStr string) (walletrpc.AddressType, error) {
 		return walletrpc.AddressType_NESTED_WITNESS_PUBKEY_HASH, nil
 	case "np2wkh-p2wkh":
 		return walletrpc.AddressType_HYBRID_NESTED_WITNESS_PUBKEY_HASH, nil
+	case "p2tr":
+		return walletrpc.AddressType_TAPROOT_PUBKEY, nil
 	default:
 		return 0, errors.New("invalid address type, supported address " +
-			"types are: p2wkh, np2wkh, and np2wkh-p2wkh")
+			"types are: p2wkh, p2tr, np2wkh, and np2wkh-p2wkh")
 	}
 }
 

--- a/docs/release-notes/release-notes-0.15.0.md
+++ b/docs/release-notes/release-notes-0.15.0.md
@@ -34,6 +34,12 @@ were created after introducing the Taproot key
 derivation](https://github.com/lightningnetwork/lnd/pull/6524) to simplify
 detecting Taproot compatibility of a seed.
 
+**NOTE** for users running a remote signing setup: A manual account import is
+necessary when upgrading from `lnd v0.14.x-beta` to `lnd v0.15.x-beta`, see [the
+remote signing documentation for more
+details](../remote-signing.md#migrating-a-remote-signing-setup-from-014x-to-015x).
+Please upgrade to `lnd v0.15.2-beta` or later directly!
+
 ## MuSig2
 
 The [`signrpc.Signer` RPC service now supports EXPERIMENTAL MuSig2

--- a/docs/release-notes/release-notes-0.15.1.md
+++ b/docs/release-notes/release-notes-0.15.1.md
@@ -44,6 +44,12 @@ supports the feature.](https://github.com/lightningnetwork/lnd/pull/6633)
 The [wallet also creates P2TR change addresses by
 default](https://github.com/lightningnetwork/lnd/pull/6810) in most cases.
 
+**NOTE** for users running a remote signing setup: A manual account import is
+necessary when upgrading from `lnd v0.14.x-beta` to `lnd v0.15.x-beta`, see [the
+remote signing documentation for more
+details](../remote-signing.md#migrating-a-remote-signing-setup-from-014x-to-015x).
+Please upgrade to `lnd v0.15.2-beta` or later directly!
+
 ## `lncli`
 
 * [Add `payment_addr` flag to

--- a/docs/release-notes/release-notes-0.15.2.md
+++ b/docs/release-notes/release-notes-0.15.2.md
@@ -14,14 +14,18 @@
 * [A bug has been fixed that caused fee estimation to be incorrect for taproot
   inputs when using the `SendOutputs` call.](https://github.com/lightningnetwork/lnd/pull/6941)
 
-# Contributors (Alphabetical Order)
+## Taproot
 
+
+**NOTE** for users running a remote signing setup: A manual account import is
+necessary when upgrading from `lnd v0.14.x-beta` to `lnd v0.15.x-beta`, see [the
+remote signing documentation for more
+details](../remote-signing.md#migrating-a-remote-signing-setup-from-014x-to-015x).
 
 ## Performance improvements
 
 * [Refactor hop hint selection
   algorithm](https://github.com/lightningnetwork/lnd/pull/6914)
-
 
 # Contributors (Alphabetical Order)
 

--- a/docs/release-notes/release-notes-0.15.2.md
+++ b/docs/release-notes/release-notes-0.15.2.md
@@ -16,6 +16,8 @@
 
 ## Taproot
 
+* [Add `p2tr` address type to account
+  import](https://github.com/lightningnetwork/lnd/pull/6966).
 
 **NOTE** for users running a remote signing setup: A manual account import is
 necessary when upgrading from `lnd v0.14.x-beta` to `lnd v0.15.x-beta`, see [the

--- a/docs/remote-signing.md
+++ b/docs/remote-signing.md
@@ -153,6 +153,28 @@ To migrate an existing node, follow these steps:
    a watch-only one (by purging all private key material from it) by adding the
   `remotesigner.migrate-wallet-to-watch-only=true` configuration entry.
 
+## Migrating a remote signing setup from 0.14.x to 0.15.x
+
+If you were running a remote signing setup with `lnd v0.14.x-beta` and want to
+upgrade to `lnd v0.15.x-beta`, you need to manually import the newly added
+Taproot account to the watch-only node, otherwise you will encounter errors such
+as `account 0 not found` when doing on-chain operations that require creating
+(change) P2TR addresses.
+
+**NOTE**: For this to work, you need to upgrade to at least `lnd v0.15.2-beta`
+or later!
+
+The upgrade process should look like this:
+1. Upgrade the "signer" node to `lnd v0.15.x-beta` and unlock it.
+2. Run `lncli wallet accounts list | grep -A5 TAPROOT` on the **"signer"** node
+   and copy the `xpub...` value from `extended_public_key`.
+3. Upgrade the "watch-only" node to `lnd v0.15.x-beta` and unlock it.
+4. Run `lncli wallet accounts import --address_type p2tr <xpub...> default` on
+   the **"watch-only"** node (notice the `default` account name at the end,
+   that's important).
+5. Run `lncli newaddress p2tr` on the "watch-only" node to test that everything
+   works as expected.
+
 ## Example initialization script
 
 This section shows an example script that initializes the watch-only wallet of


### PR DESCRIPTION
## Change Description
Fixes the `lncli wallet accounts import` command to accept the address type `p2tr` which is required in order to upgrade a remote signing setup to `lnd v0.15.x-beta`.
We also add an instruction on how to upgrade such a setup to the latest `lnd` release.

### Migrating a remote signing setup from 0.14.x to 0.15.x

If you were running a remote signing setup with `lnd v0.14.x-beta` and want to
upgrade to `lnd v0.15.x-beta`, you need to manually import the newly added
Taproot account to the watch-only node, otherwise you will encounter errors such
as `account 0 not found` when doing on-chain operations that require creating
(change) P2TR addresses.

**NOTE**: For this to work, you need to upgrade to at least `lnd v0.15.2-beta`
or later!

The upgrade process should look like this:
1. Upgrade the "signer" node to `lnd v0.15.x-beta` and unlock it.
2. Run `lncli wallet accounts list | grep -A5 TAPROOT` on the **"signer"** node
   and copy the `xpub...` value from `extended_public_key`.
3. Upgrade the "watch-only" node to `lnd v0.15.x-beta` and unlock it.
4. Run `lncli wallet accounts import --address_type p2tr <xpub...> default` on
   the **"watch-only"** node (notice the `default` account name at the end,
   that's important).
5. Run `lncli newaddress p2tr` on the "watch-only" node to test that everything
   works as expected.


## Steps to Test

1. Create a watch-only and signer node pair on `lnd v0.14.3-beta`.
2. Upgrade both watch-only and signer node to `lnd v0.15.1-beta` and attempt to create a new P2TR address on the watch-only node. Expect an error to be returned (`account 0 not found`).
3. Upgrade both nodes to run this PR, then run the above migration step.
4. Check that creating a P2TR address now works.

## Pull Request Checklist

:heavy_check_mark: 