### PR TITLE
Clarification sample-lnd.conf

### DIFF
--- a/sample-lnd.conf
+++ b/sample-lnd.conf
@@ -613,7 +613,7 @@ bitcoin.node=btcd
 ; instead of using the zmq interface. Only the rpcpolling option needs to
 ; be set in order to enable this, the rest of the options can be used to
 ; change the default values used for this configuration.
-; bitcoind.rpcpolling
+; bitcoind.rpcpolling=true
 ; bitcoind.blockpollinginterval=1m
 ; bitcoind.txpollinginterval=30s
 


### PR DESCRIPTION
Documentation clarification

`bitcoin.rpcpolling` has to be set to true, otherwise `malformed key=value (bitcoind.rpcpolling)` error happens during initialization, not explicitly stated right now.