### PR TITLE
GitHub: show issue triage page when submitting an issue

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,3 +1,11 @@
+---
+name: Bug report
+about: Create a bug report. Please use the discussions section for general or troubleshooting questions.
+title: '[bug]: '
+labels: ["bug", "needs triage"]
+assignees: ''
+---
+
 ### Background
 
 Describe your issue here.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,8 @@
 blank_issues_enabled: false
 contact_links:
+  - name: Discussions
+    url: https://github.com/lightningnetwork/lnd/discussions
+    about: For general or troubleshooting questions or if you're not sure what issue type to pick.
   - name: Documentation for lnd and lightning-terminal
     url: https://docs.lightning.engineering/
     about: Please make sure the documentation cannot answer your question first.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,11 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Documentation for lnd and lightning-terminal
+    url: https://docs.lightning.engineering/
+    about: Please make sure the documentation cannot answer your question first.
+  - name: Lightning Community Slack
+    url: https://lightning.engineering/slack.html
+    about: Please ask and answer questions here.
+  - name: Security issue disclosure policy
+    url: https://github.com/lightningnetwork/lnd#security
+    about: Please refer to this document when reporting security related issues.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,19 @@
+---
+name: Feature request
+about: Suggest a new feature for `lnd`.
+title: '[feature]: '
+labels: enhancement
+assignees: ''
+---
+
+**Is your feature request related to a problem? Please describe.**
+<!-- A clear and concise description of what the problem is. Ex. I'm always frustrated when [...] -->
+
+**Describe the solution you'd like**
+<!-- A clear and concise description of what you want to happen. -->
+
+**Describe alternatives you've considered**
+<!-- A clear and concise description of any alternative solutions or features you've considered. -->
+
+**Additional context**
+<!-- Add any other context or screenshots about the feature request here. -->


### PR DESCRIPTION
## Change Description
With this PR we configure GitHub to show a new "triage" page when the user clicks the "New Issue" button in the repository·
That page will show the following choices:
 - "Bug report": Create a new issue with today's issue template, the `[bug]: ` title prefix and `bug, triage` labels applied.
 - "Feature request": Create a new issue with a new template, the `[feature]: ` title prefix and `enhancement` label applied.
 - "Discussions": Link to https://github.com/lightningnetwork/lnd/discussions
 - "Documentation for lnd and lightning-terminal": Link to https://docs.lightning.engineering/
 - "Lightning Community Slack": Link to https://lightning.engineering/slack.html
 - "Security issue disclosure policy": Link to https://github.com/lightningnetwork/lnd#security

An example for such a triage page can be found in the [Lightning Terminal](https://github.com/lightninglabs/lightning-terminal/issues/new/choose) repository.

## Steps to Test
Not sure how to test this without merging the PR.

## Pull Request Checklist

:heavy_check_mark: 