### PR TITLE
build: add PR stats to github workflow

### DIFF
--- a/.github/workflows/stats.yml
+++ b/.github/workflows/stats.yml
@@ -1,0 +1,17 @@
+name: Pull Request Stats
+
+on:
+  pull_request:
+    types: [opened]
+
+jobs:
+  stats:
+    runs-on: ubuntu-latest
+    permissions:
+        pull-request: write
+    steps:
+      - name: Run pull request stats
+        uses: flowwer-dev/pull-request-stats@v2.5.0
+        with:
+          period: 30 # 30 days of review stats
+          charts: true


### PR DESCRIPTION
In this PR, we introduce a new Github work flow tool that should help us keep better track fo reviewer load across the proejct. Ideally this can also be used as a tool to help new PRs find a reviewer, and also for us to better balance out review load, and keep track of how long it takes to do PR turnaround.