### PR TITLE
funding: ignore maxWaitNumBlocksFundingConf for zero conf channels

### DIFF
--- a/docs/release-notes/release-notes-0.15.2.md
+++ b/docs/release-notes/release-notes-0.15.2.md
@@ -8,6 +8,9 @@
 
 ## Bug Fixes
 
+* [A bug has been fixed where the responder of a zero-conf channel could forget
+  about the channel after a hard-coded 2016 blocks.](https://github.com/lightningnetwork/lnd/pull/6998)
+
 * [A bug where LND wouldn't send a ChannelUpdate during a channel open has
   been fixed.](https://github.com/lightningnetwork/lnd/pull/6892)
 

--- a/funding/manager.go
+++ b/funding/manager.go
@@ -2499,7 +2499,7 @@ func (f *Manager) waitForFundingWithTimeout(
 	// If we are not the initiator, we have no money at stake and will
 	// timeout waiting for the funding transaction to confirm after a
 	// while.
-	if !ch.IsInitiator {
+	if !ch.IsInitiator && !ch.IsZeroConf() {
 		f.wg.Add(1)
 		go f.waitForTimeout(ch, cancelChan, timeoutChan)
 	}
@@ -3251,9 +3251,7 @@ func (f *Manager) waitForZeroConfChannel(c *channeldb.OpenChannel,
 	// is already confirmed, the chainntnfs subsystem will return with the
 	// confirmed tx. Otherwise, we'll wait here until confirmation occurs.
 	confChan, err := f.waitForFundingWithTimeout(c)
-	if err == ErrConfirmationTimeout {
-		return f.fundingTimeout(c, pendingID)
-	} else if err != nil {
+	if err != nil {
 		return fmt.Errorf("error waiting for zero-conf funding "+
 			"confirmation for ChannelPoint(%v): %v",
 			c.FundingOutpoint, err)


### PR DESCRIPTION
This is so that if the funding transaction hasn't been confirmed in 2016 blocks, the channel isn't marked as closed by the responder.
