### PR TITLE
docs: update remote signing update hint to v0.15.3-beta [skip ci]

### DIFF
--- a/docs/release-notes/release-notes-0.15.0.md
+++ b/docs/release-notes/release-notes-0.15.0.md
@@ -38,7 +38,7 @@ detecting Taproot compatibility of a seed.
 necessary when upgrading from `lnd v0.14.x-beta` to `lnd v0.15.x-beta`, see [the
 remote signing documentation for more
 details](../remote-signing.md#migrating-a-remote-signing-setup-from-014x-to-015x).
-Please upgrade to `lnd v0.15.2-beta` or later directly!
+Please upgrade to `lnd v0.15.3-beta` or later directly!
 
 ## MuSig2
 

--- a/docs/release-notes/release-notes-0.15.1.md
+++ b/docs/release-notes/release-notes-0.15.1.md
@@ -48,7 +48,7 @@ default](https://github.com/lightningnetwork/lnd/pull/6810) in most cases.
 necessary when upgrading from `lnd v0.14.x-beta` to `lnd v0.15.x-beta`, see [the
 remote signing documentation for more
 details](../remote-signing.md#migrating-a-remote-signing-setup-from-014x-to-015x).
-Please upgrade to `lnd v0.15.2-beta` or later directly!
+Please upgrade to `lnd v0.15.3-beta` or later directly!
 
 ## `lncli`
 

--- a/docs/remote-signing.md
+++ b/docs/remote-signing.md
@@ -161,7 +161,7 @@ Taproot account to the watch-only node, otherwise you will encounter errors such
 as `account 0 not found` when doing on-chain operations that require creating
 (change) P2TR addresses.
 
-**NOTE**: For this to work, you need to upgrade to at least `lnd v0.15.2-beta`
+**NOTE**: For this to work, you need to upgrade to at least `lnd v0.15.3-beta`
 or later!
 
 The upgrade process should look like this:


### PR DESCRIPTION
This PR bumps the recommended version to upgrade to for remote signing setups.
