### PR TITLE
build: bump Golang version to v1.19.2

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,7 +29,7 @@ env:
   # /dev.Dockerfile
   # /make/builder.Dockerfile
   # /.github/workflows/release.yml
-  GO_VERSION: 1.19.0
+  GO_VERSION: 1.19.2
 
 jobs:
   ########################

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -16,7 +16,7 @@ env:
   # /dev.Dockerfile
   # /make/builder.Dockerfile
   # /.github/workflows/main.yml
-  GO_VERSION: 1.19.0
+  GO_VERSION: 1.19.2
 
 jobs:
   main:

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ go:
   # /make/builder.Dockerfile
   # /.github/workflows/main.yml
   # /.github/workflows/release.yml
-  - "1.19"
+  - "1.19.2"
 
 env:
   global:

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@
 # /make/builder.Dockerfile
 # /.github/workflows/main.yml
 # /.github/workflows/release.yml
-FROM golang:1.19-alpine as builder
+FROM golang:1.19.2-alpine as builder
 
 # Force Go to use the cgo based DNS resolver. This is required to ensure DNS
 # queries required to connect to linked containers succeed.

--- a/dev.Dockerfile
+++ b/dev.Dockerfile
@@ -4,7 +4,7 @@
 # /make/builder.Dockerfile
 # /.github/workflows/main.yml
 # /.github/workflows/release.yml
-FROM golang:1.19-alpine as builder
+FROM golang:1.19.2-alpine as builder
 
 LABEL maintainer="Olaoluwa Osuntokun <laolu@lightning.engineering>"
 

--- a/docker/btcd/Dockerfile
+++ b/docker/btcd/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.19-alpine as builder
+FROM golang:1.19.2-alpine as builder
 
 LABEL maintainer="Olaoluwa Osuntokun <laolu@lightning.engineering>"
 

--- a/docker/ltcd/Dockerfile
+++ b/docker/ltcd/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.19-alpine as builder
+FROM golang:1.19.2-alpine as builder
 
 LABEL maintainer="Olaoluwa Osuntokun <laolu@lightning.engineering>"
 

--- a/docs/release-notes/release-notes-0.16.0.md
+++ b/docs/release-notes/release-notes-0.16.0.md
@@ -43,6 +43,10 @@ transaction](https://github.com/lightningnetwork/lnd/pull/6730).
 1.19](https://github.com/lightningnetwork/lnd/pull/6795)! Go 1.18 is now the
 minimum version needed to build the project.
 
+[The minimum recommended version of the Go 1.19.x series is 1.19.2 because
+1.19.1 contained a bug that affected lnd and resulted in a
+crash](https://github.com/lightningnetwork/lnd/pull/7019).
+
 ## Misc
 
 * [Fixed a bug where the Switch did not reforward settles or fails for

--- a/lnrpc/Dockerfile
+++ b/lnrpc/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.19-buster
+FROM golang:1.19.2-buster
 
 RUN apt-get update && apt-get install -y \
   git \

--- a/make/builder.Dockerfile
+++ b/make/builder.Dockerfile
@@ -4,7 +4,7 @@
 # /dev.Dockerfile
 # /.github/workflows/main.yml
 # /.github/workflows/release.yml
-FROM golang:1.19-buster
+FROM golang:1.19.2-buster
 
 MAINTAINER Olaoluwa Osuntokun <laolu@lightning.engineering>
 

--- a/tools/Dockerfile
+++ b/tools/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.19-buster
+FROM golang:1.19.2-buster
 
 RUN apt-get update && apt-get install -y git
 ENV GOCACHE=/tmp/build/.cache


### PR DESCRIPTION
## Change Description
This PR bumps all Golang versions in our docker and CI files to v1.19.2 which aims to fix https://github.com/lightningnetwork/lnd/issues/6923.
