### PR TITLE
watchtower: introduce an AddressIterator

### DIFF
--- a/docs/release-notes/release-notes-0.16.0.md
+++ b/docs/release-notes/release-notes-0.16.0.md
@@ -89,6 +89,9 @@ https://github.com/lightningnetwork/lnd/pull/6963/)
 * [Fixed a flake in the TestBlockCacheMutexes unit
   test](https://github.com/lightningnetwork/lnd/pull/7029).
 
+* [Create a helper function to wait for peer to come
+  online](https://github.com/lightningnetwork/lnd/pull/6931).
+
 ## `lncli`
 * [Add an `insecure` flag to skip tls auth as well as a `metadata` string slice
   flag](https://github.com/lightningnetwork/lnd/pull/6818) that allows the
@@ -119,6 +122,12 @@ https://github.com/lightningnetwork/lnd/pull/6963/)
   caller is expected to know that doing so with untrusted input is
   unsafe.](https://github.com/lightningnetwork/lnd/pull/6779)
  
+* [test: replace defer cleanup with
+  `t.Cleanup`](https://github.com/lightningnetwork/lnd/pull/6864).
+
+* [test: fix loop variables being accessed in
+  closures](https://github.com/lightningnetwork/lnd/pull/7032).
+ 
 ## Watchtowers
 
 * [Create a towerID-to-sessionID index in the wtclient DB to improve the 
@@ -131,14 +140,10 @@ https://github.com/lightningnetwork/lnd/pull/6963/)
   struct](https://github.com/lightningnetwork/lnd/pull/6928) in order to
   improve the performance of fetching a `ClientSession` from the DB.
 
-* [Create a helper function to wait for peer to come
-  online](https://github.com/lightningnetwork/lnd/pull/6931).
-
-* [test: replace defer cleanup with
-  `t.Cleanup`](https://github.com/lightningnetwork/lnd/pull/6864).
-
-* [test: fix loop variables being accessed in
-  closures](https://github.com/lightningnetwork/lnd/pull/7032).
+* [Allow user to update tower address without requiring a restart. Also allow
+  the removal of a tower address if the current session negotiation is not
+  using the address in question](
+  https://github.com/lightningnetwork/lnd/pull/7025)
 
 ### Tooling and documentation
 

--- a/watchtower/wtclient/addr_iterator.go
+++ b/watchtower/wtclient/addr_iterator.go
@@ -1,0 +1,344 @@
+package wtclient
+
+import (
+	"container/list"
+	"errors"
+	"fmt"
+	"net"
+	"sync"
+
+	"github.com/lightningnetwork/lnd/watchtower/wtdb"
+)
+
+var (
+	// ErrAddressesExhausted signals that a addressIterator has cycled
+	// through all available addresses.
+	ErrAddressesExhausted = errors.New("exhausted all addresses")
+
+	// ErrAddrInUse indicates that an address is locked and cannot be
+	// removed from the addressIterator.
+	ErrAddrInUse = errors.New("address in use")
+)
+
+// AddressIterator handles iteration over a list of addresses. It strictly
+// disallows the list of addresses it holds to be empty. It also allows callers
+// to place locks on certain addresses in order to prevent other callers from
+// removing the addresses in question from the iterator.
+type AddressIterator interface {
+	// Next returns the next candidate address. This iterator will always
+	// return candidates in the order given when the iterator was
+	// instantiated. If no more candidates are available,
+	// ErrAddressesExhausted is returned.
+	Next() (net.Addr, error)
+
+	// NextAndLock does the same as described for Next, and it also places a
+	// lock on the returned address so that the address can not be removed
+	// until the lock on it has been released via ReleaseLock.
+	NextAndLock() (net.Addr, error)
+
+	// Peek returns the currently selected address in the iterator. If the
+	// end of the iterator has been reached then it is reset and the first
+	// item in the iterator is returned. Since the AddressIterator will
+	// never have an empty address list, this function will never return a
+	// nil value.
+	Peek() net.Addr
+
+	// PeekAndLock does the same as described for Peek, and it also places
+	// a lock on the returned address so that the address can not be removed
+	// until the lock on it has been released via ReleaseLock.
+	PeekAndLock() net.Addr
+
+	// ReleaseLock releases the lock held on the given address.
+	ReleaseLock(addr net.Addr)
+
+	// Add adds a new address to the iterator.
+	Add(addr net.Addr)
+
+	// Remove removes an existing address from the iterator. It disallows
+	// the address from being removed if it is the last address in the
+	// iterator or if there is currently a lock on the address.
+	Remove(addr net.Addr) error
+
+	// HasLocked returns true if the addressIterator has any locked
+	// addresses.
+	HasLocked() bool
+
+	// GetAll returns a copy of all the addresses in the iterator.
+	GetAll() []net.Addr
+
+	// Reset clears the iterators state, and makes the address at the front
+	// of the list the next item to be returned.
+	Reset()
+}
+
+// A compile-time check to ensure that addressIterator implements the
+// AddressIterator interface.
+var _ AddressIterator = (*addressIterator)(nil)
+
+// addressIterator is a linked-list implementation of an AddressIterator.
+type addressIterator struct {
+	mu             sync.Mutex
+	addrList       *list.List
+	currentTopAddr *list.Element
+	candidates     map[string]*candidateAddr
+	totalLockCount int
+}
+
+type candidateAddr struct {
+	addr     net.Addr
+	numLocks int
+}
+
+// newAddressIterator constructs a new addressIterator.
+func newAddressIterator(addrs ...net.Addr) (*addressIterator, error) {
+	if len(addrs) == 0 {
+		return nil, fmt.Errorf("must have at least one address")
+	}
+
+	iter := &addressIterator{
+		addrList:   list.New(),
+		candidates: make(map[string]*candidateAddr),
+	}
+
+	for _, addr := range addrs {
+		addrID := addr.String()
+		iter.addrList.PushBack(addrID)
+		iter.candidates[addrID] = &candidateAddr{addr: addr}
+	}
+	iter.Reset()
+
+	return iter, nil
+}
+
+// Reset clears the iterators state, and makes the address at the front of the
+// list the next item to be returned.
+//
+// NOTE: This is part of the AddressIterator interface.
+func (a *addressIterator) Reset() {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+
+	a.unsafeReset()
+}
+
+// unsafeReset clears the iterator state and makes the address at the front of
+// the list the next item to be returned.
+//
+// NOTE: this method is not thread safe and so should only be called if the
+// appropriate mutex is being held.
+func (a *addressIterator) unsafeReset() {
+	// Reset the next candidate to the front of the linked-list.
+	a.currentTopAddr = a.addrList.Front()
+}
+
+// Next returns the next candidate address. This iterator will always return
+// candidates in the order given when the iterator was instantiated. If no more
+// candidates are available, ErrAddressesExhausted is returned.
+//
+// NOTE: This is part of the AddressIterator interface.
+func (a *addressIterator) Next() (net.Addr, error) {
+	return a.next(false)
+}
+
+// NextAndLock does the same as described for Next, and it also places a lock on
+// the returned address so that the address can not be removed until the lock on
+// it has been released via ReleaseLock.
+//
+// NOTE: This is part of the AddressIterator interface.
+func (a *addressIterator) NextAndLock() (net.Addr, error) {
+	return a.next(true)
+}
+
+// next returns the next candidate address. This iterator will always return
+// candidates in the order given when the iterator was instantiated. If no more
+// candidates are available, ErrAddressesExhausted is returned.
+func (a *addressIterator) next(lock bool) (net.Addr, error) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+
+	// Set the next candidate to the subsequent element.
+	a.currentTopAddr = a.currentTopAddr.Next()
+
+	for a.currentTopAddr != nil {
+		// Propose the address at the front of the list.
+		addrID := a.currentTopAddr.Value.(string)
+
+		// Check whether this address is still considered a candidate.
+		// If it's not, we'll proceed to the next.
+		candidate, ok := a.candidates[addrID]
+		if !ok {
+			nextCandidate := a.currentTopAddr.Next()
+			a.addrList.Remove(a.currentTopAddr)
+			a.currentTopAddr = nextCandidate
+			continue
+		}
+
+		if lock {
+			candidate.numLocks++
+			a.totalLockCount++
+		}
+
+		return candidate.addr, nil
+	}
+
+	return nil, ErrAddressesExhausted
+}
+
+// Peek returns the currently selected address in the iterator. If the end of
+// the list has been reached then the iterator is reset and the first item in
+// the list is returned. Since the addressIterator will never have an empty
+// address list, this function will never return a nil value.
+//
+// NOTE: This is part of the AddressIterator interface.
+func (a *addressIterator) Peek() net.Addr {
+	return a.peek(false)
+}
+
+// PeekAndLock does the same as described for Peek, and it also places a lock on
+// the returned address so that the address can not be removed until the lock
+// on it has been released via ReleaseLock.
+//
+// NOTE: This is part of the AddressIterator interface.
+func (a *addressIterator) PeekAndLock() net.Addr {
+	return a.peek(true)
+}
+
+// peek returns the currently selected address in the iterator. If the end of
+// the list has been reached then the iterator is reset and the first item in
+// the list is returned. Since the addressIterator will never have an empty
+// address list, this function will never return a nil value. If lock is set to
+// true, the address will be locked for removal until ReleaseLock has been
+// called for the address.
+func (a *addressIterator) peek(lock bool) net.Addr {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+
+	for {
+		// If currentTopAddr is nil, it means we have reached the end of
+		// the list, so we reset it here. The iterator always has at
+		// least one address, so we can be sure that currentTopAddr will
+		// be non-nil after calling reset here.
+		if a.currentTopAddr == nil {
+			a.unsafeReset()
+		}
+
+		addrID := a.currentTopAddr.Value.(string)
+		candidate, ok := a.candidates[addrID]
+		if !ok {
+			nextCandidate := a.currentTopAddr.Next()
+			a.addrList.Remove(a.currentTopAddr)
+			a.currentTopAddr = nextCandidate
+			continue
+		}
+
+		if lock {
+			candidate.numLocks++
+			a.totalLockCount++
+		}
+
+		return candidate.addr
+	}
+}
+
+// ReleaseLock releases the lock held on the given address.
+//
+// NOTE: This is part of the AddressIterator interface.
+func (a *addressIterator) ReleaseLock(addr net.Addr) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+
+	candidateAddr, ok := a.candidates[addr.String()]
+	if !ok {
+		return
+	}
+
+	if candidateAddr.numLocks == 0 {
+		return
+	}
+
+	candidateAddr.numLocks--
+	a.totalLockCount--
+}
+
+// Add adds a new address to the iterator.
+//
+// NOTE: This is part of the AddressIterator interface.
+func (a *addressIterator) Add(addr net.Addr) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+
+	if _, ok := a.candidates[addr.String()]; ok {
+		return
+	}
+
+	a.addrList.PushBack(addr.String())
+	a.candidates[addr.String()] = &candidateAddr{addr: addr}
+
+	// If we've reached the end of our queue, then this candidate
+	// will become the next.
+	if a.currentTopAddr == nil {
+		a.currentTopAddr = a.addrList.Back()
+	}
+}
+
+// Remove removes an existing address from the iterator. It disallows the
+// address from being removed if it is the last address in the iterator or if
+// there is currently a lock on the address.
+//
+// NOTE: This is part of the AddressIterator interface.
+func (a *addressIterator) Remove(addr net.Addr) error {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+
+	candidate, ok := a.candidates[addr.String()]
+	if !ok {
+		return nil
+	}
+
+	if len(a.candidates) == 1 {
+		return wtdb.ErrLastTowerAddr
+	}
+
+	if candidate.numLocks > 0 {
+		return ErrAddrInUse
+	}
+
+	delete(a.candidates, addr.String())
+	return nil
+}
+
+// HasLocked returns true if the addressIterator has any locked addresses.
+//
+// NOTE: This is part of the AddressIterator interface.
+func (a *addressIterator) HasLocked() bool {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+
+	return a.totalLockCount > 0
+}
+
+// GetAll returns a copy of all the addresses in the iterator.
+//
+// NOTE: This is part of the AddressIterator interface.
+func (a *addressIterator) GetAll() []net.Addr {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+
+	var addrs []net.Addr
+	cursor := a.addrList.Front()
+
+	for cursor != nil {
+		addrID := cursor.Value.(string)
+
+		addr, ok := a.candidates[addrID]
+		if !ok {
+			cursor = cursor.Next()
+			continue
+		}
+
+		addrs = append(addrs, addr.addr)
+		cursor = cursor.Next()
+	}
+
+	return addrs
+}

--- a/watchtower/wtclient/addr_iterator_test.go
+++ b/watchtower/wtclient/addr_iterator_test.go
@@ -1,0 +1,188 @@
+package wtclient
+
+import (
+	"net"
+	"testing"
+
+	"github.com/lightningnetwork/lnd/watchtower/wtdb"
+	"github.com/stretchr/testify/require"
+)
+
+// TestAddrIterator tests the behaviour of the addressIterator.
+func TestAddrIterator(t *testing.T) {
+	// Assert that an iterator can't be initialised with an empty address
+	// list.
+	_, err := newAddressIterator()
+	require.ErrorContains(t, err, "must have at least one address")
+
+	addr1, err := net.ResolveTCPAddr("tcp", "1.2.3.4:8000")
+	require.NoError(t, err)
+
+	// Initialise the iterator with addr1.
+	iter, err := newAddressIterator(addr1)
+	require.NoError(t, err)
+
+	// Attempting to remove addr1 should fail now since it is the only
+	// address in the iterator.
+	iter.Add(addr1)
+	err = iter.Remove(addr1)
+	require.ErrorIs(t, err, wtdb.ErrLastTowerAddr)
+
+	// Adding a duplicate of addr1 and then calling Remove should still
+	// return an error.
+	err = iter.Remove(addr1)
+	require.ErrorIs(t, err, wtdb.ErrLastTowerAddr)
+
+	addr2, err := net.ResolveTCPAddr("tcp", "1.2.3.4:8001")
+	require.NoError(t, err)
+
+	// Add addr2 to the iterator.
+	iter.Add(addr2)
+
+	// Check that peek returns addr1.
+	a1 := iter.Peek()
+	require.NoError(t, err)
+	require.Equal(t, addr1, a1)
+
+	// Calling peek multiple times should return the same result.
+	a1 = iter.Peek()
+	require.Equal(t, addr1, a1)
+
+	// Calling Next should now return addr2.
+	a2, err := iter.Next()
+	require.NoError(t, err)
+	require.Equal(t, addr2, a2)
+
+	// Assert that Peek now returns addr2.
+	a2 = iter.Peek()
+	require.NoError(t, err)
+	require.Equal(t, addr2, a2)
+
+	// Calling Next should result in reaching the end of th list.
+	_, err = iter.Next()
+	require.ErrorIs(t, err, ErrAddressesExhausted)
+
+	// Calling Peek now should reset the queue and return addr1.
+	a1 = iter.Peek()
+	require.Equal(t, addr1, a1)
+
+	// Wind the list to the end again so that we can test the Reset func.
+	_, err = iter.Next()
+	require.NoError(t, err)
+
+	_, err = iter.Next()
+	require.ErrorIs(t, err, ErrAddressesExhausted)
+
+	iter.Reset()
+
+	// Now Next should return addr 2.
+	a2, err = iter.Next()
+	require.NoError(t, err)
+	require.Equal(t, addr2, a2)
+
+	addr3, err := net.ResolveTCPAddr("tcp", "1.2.3.4:8002")
+	require.NoError(t, err)
+
+	// Add addr3 now to ensure that the iteration works even if we are
+	// midway through the queue.
+	iter.Add(addr3)
+
+	// Now Next should return addr 3.
+	a3, err := iter.Next()
+	require.NoError(t, err)
+	require.Equal(t, addr3, a3)
+
+	// Quickly test that GetAll correctly returns a copy of all the
+	// addresses in the iterator.
+	addrList := iter.GetAll()
+	require.ElementsMatch(t, addrList, []net.Addr{addr1, addr2, addr3})
+
+	// Let's now remove addr3.
+	err = iter.Remove(addr3)
+	require.NoError(t, err)
+
+	// Since addr3 is gone, Peek should return addr1.
+	a1 = iter.Peek()
+	require.Equal(t, addr1, a1)
+
+	// Lastly, we will test the "locking" of addresses.
+
+	// First we test the locking of an address via the PeekAndLock function.
+	a1 = iter.PeekAndLock()
+	require.Equal(t, addr1, a1)
+	require.True(t, iter.HasLocked())
+
+	// Assert that we can't remove addr1 if there is a lock on it.
+	err = iter.Remove(addr1)
+	require.ErrorIs(t, err, ErrAddrInUse)
+
+	// Now release the lock on addr1.
+	iter.ReleaseLock(addr1)
+	require.False(t, iter.HasLocked())
+
+	// Since the lock has been released, we should now be able to remove
+	// addr1.
+	err = iter.Remove(addr1)
+	require.NoError(t, err)
+
+	// Now we test the locking of an address via the NextAndLock function.
+	// To do this, we first re-add addr3.
+	iter.Add(addr3)
+
+	a2, err = iter.NextAndLock()
+	require.NoError(t, err)
+	require.Equal(t, addr2, a2)
+	require.True(t, iter.HasLocked())
+
+	// Assert that we can't remove addr2 if there is a lock on it.
+	err = iter.Remove(addr2)
+	require.ErrorIs(t, err, ErrAddrInUse)
+
+	// Now release the lock on addr2.
+	iter.ReleaseLock(addr2)
+	require.False(t, iter.HasLocked())
+
+	// Since the lock has been released, we should now be able to remove
+	// addr1.
+	err = iter.Remove(addr2)
+	require.NoError(t, err)
+
+	// Only addr3 should still be left in the iterator.
+	addrList = iter.GetAll()
+	require.Len(t, addrList, 1)
+	require.Contains(t, addrList, addr3)
+
+	// Ensure that HasLocked acts correctly in the case where more than one
+	// address is being locked and unlock as well as the case where the same
+	// address is locked more than once.
+
+	require.False(t, iter.HasLocked())
+
+	a3 = iter.PeekAndLock()
+	require.Equal(t, addr3, a3)
+	require.True(t, iter.HasLocked())
+
+	a3 = iter.PeekAndLock()
+	require.Equal(t, addr3, a3)
+	require.True(t, iter.HasLocked())
+
+	iter.Add(addr2)
+	a2, err = iter.NextAndLock()
+	require.NoError(t, err)
+	require.Equal(t, addr2, a2)
+	require.True(t, iter.HasLocked())
+
+	// Now release addr2 and asset that HasLock is still true.
+	iter.ReleaseLock(addr2)
+	require.True(t, iter.HasLocked())
+
+	// Releasing one of the locks on addr3 now should still result in
+	// HasLocked returning true.
+	iter.ReleaseLock(addr3)
+	require.True(t, iter.HasLocked())
+
+	// Releasing it again should now result in should still result in
+	// HasLocked returning false.
+	iter.ReleaseLock(addr3)
+	require.False(t, iter.HasLocked())
+}

--- a/watchtower/wtclient/backup_task_internal_test.go
+++ b/watchtower/wtclient/backup_task_internal_test.go
@@ -2,9 +2,6 @@ package wtclient
 
 import (
 	"bytes"
-	"crypto/rand"
-	"io"
-	"reflect"
 	"testing"
 
 	"github.com/btcsuite/btcd/btcec/v2"
@@ -12,7 +9,6 @@ import (
 	"github.com/btcsuite/btcd/chaincfg"
 	"github.com/btcsuite/btcd/txscript"
 	"github.com/btcsuite/btcd/wire"
-	"github.com/davecgh/go-spew/spew"
 	"github.com/lightningnetwork/lnd/channeldb"
 	"github.com/lightningnetwork/lnd/input"
 	"github.com/lightningnetwork/lnd/keychain"
@@ -53,14 +49,6 @@ var (
 		0xe2, 0x2e, 0x68, 0x08, 0x4c, 0xb4, 0x0f, 0x4f,
 	}
 )
-
-func makeAddrSlice(size int) []byte {
-	addr := make([]byte, size)
-	if _, err := io.ReadFull(rand.Reader, addr); err != nil {
-		panic("cannot make addr")
-	}
-	return addr
-}
 
 type backupTaskTest struct {
 	name             string
@@ -502,35 +490,12 @@ func testBackupTask(t *testing.T, test backupTaskTest) {
 
 	// Assert that all parameters set during initialization are properly
 	// populated.
-	if task.id.ChanID != test.chanID {
-		t.Fatalf("channel id mismatch, want: %s, got: %s",
-			test.chanID, task.id.ChanID)
-	}
-
-	if task.id.CommitHeight != test.breachInfo.RevokedStateNum {
-		t.Fatalf("commit height mismatch, want: %d, got: %d",
-			test.breachInfo.RevokedStateNum, task.id.CommitHeight)
-	}
-
-	if task.totalAmt != test.expTotalAmt {
-		t.Fatalf("total amount mismatch, want: %d, got: %v",
-			test.expTotalAmt, task.totalAmt)
-	}
-
-	if !reflect.DeepEqual(task.breachInfo, test.breachInfo) {
-		t.Fatalf("breach info mismatch, want: %v, got: %v",
-			test.breachInfo, task.breachInfo)
-	}
-
-	if !reflect.DeepEqual(task.toLocalInput, test.expToLocalInput) {
-		t.Fatalf("to-local input mismatch, want: %v, got: %v",
-			test.expToLocalInput, task.toLocalInput)
-	}
-
-	if !reflect.DeepEqual(task.toRemoteInput, test.expToRemoteInput) {
-		t.Fatalf("to-local input mismatch, want: %v, got: %v",
-			test.expToRemoteInput, task.toRemoteInput)
-	}
+	require.Equal(t, test.chanID, task.id.ChanID)
+	require.Equal(t, test.breachInfo.RevokedStateNum, task.id.CommitHeight)
+	require.Equal(t, test.expTotalAmt, task.totalAmt)
+	require.Equal(t, test.breachInfo, task.breachInfo)
+	require.Equal(t, test.expToLocalInput, task.toLocalInput)
+	require.Equal(t, test.expToRemoteInput, task.toRemoteInput)
 
 	// Reconstruct the expected input.Inputs that will be returned by the
 	// task's inputs() method.
@@ -545,34 +510,24 @@ func testBackupTask(t *testing.T, test backupTaskTest) {
 	// Assert that the inputs method returns the correct slice of
 	// input.Inputs.
 	inputs := task.inputs()
-	if !reflect.DeepEqual(expInputs, inputs) {
-		t.Fatalf("inputs mismatch, want: %v, got: %v",
-			expInputs, inputs)
-	}
+	require.Equal(t, expInputs, inputs)
 
 	// Now, bind the session to the task. If successful, this locks in the
 	// session's negotiated parameters and allows the backup task to derive
 	// the final free variables in the justice transaction.
 	err := task.bindSession(test.session)
-	if err != test.bindErr {
-		t.Fatalf("expected: %v when binding session, got: %v",
-			test.bindErr, err)
-	}
+	require.ErrorIs(t, err, test.bindErr)
 
 	// Exit early if the bind was supposed to fail. But first, we check that
 	// all fields set during a bind are still unset. This ensure that a
 	// failed bind doesn't have side-effects if the task is retried with a
 	// different session.
 	if test.bindErr != nil {
-		if task.blobType != 0 {
-			t.Fatalf("blob type should not be set on failed bind, "+
-				"found: %s", task.blobType)
-		}
+		require.Zerof(t, task.blobType, "blob type should not be set "+
+			"on failed bind, found: %s", task.blobType)
 
-		if task.outputs != nil {
-			t.Fatalf("justice outputs should not be set on failed bind, "+
-				"found: %v", task.outputs)
-		}
+		require.Nilf(t, task.outputs, "justice outputs should not be "+
+			" set on failed bind, found: %v", task.outputs)
 
 		return
 	}
@@ -580,10 +535,7 @@ func testBackupTask(t *testing.T, test backupTaskTest) {
 	// Otherwise, the binding succeeded. Assert that all values set during
 	// the bind are properly populated.
 	policy := test.session.Policy
-	if task.blobType != policy.BlobType {
-		t.Fatalf("blob type mismatch, want: %s, got %s",
-			policy.BlobType, task.blobType)
-	}
+	require.Equal(t, policy.BlobType, task.blobType)
 
 	// Compute the expected outputs on the justice transaction.
 	var expOutputs = []*wire.TxOut{
@@ -603,10 +555,7 @@ func testBackupTask(t *testing.T, test backupTaskTest) {
 	}
 
 	// Assert that the computed outputs match our expected outputs.
-	if !reflect.DeepEqual(expOutputs, task.outputs) {
-		t.Fatalf("justice txn output mismatch, want: %v,\ngot: %v",
-			spew.Sdump(expOutputs), spew.Sdump(task.outputs))
-	}
+	require.Equal(t, expOutputs, task.outputs)
 
 	// Now, we'll construct, sign, and encrypt the blob containing the parts
 	// needed to reconstruct the justice transaction.
@@ -616,10 +565,7 @@ func testBackupTask(t *testing.T, test backupTaskTest) {
 	// Verify that the breach hint matches the breach txid's prefix.
 	breachTxID := test.breachInfo.BreachTxHash
 	expHint := blob.NewBreachHintFromHash(&breachTxID)
-	if hint != expHint {
-		t.Fatalf("breach hint mismatch, want: %x, got: %v",
-			expHint, hint)
-	}
+	require.Equal(t, expHint, hint)
 
 	// Decrypt the return blob to obtain the JusticeKit containing its
 	// contents.
@@ -634,14 +580,8 @@ func testBackupTask(t *testing.T, test backupTaskTest) {
 
 	// Assert that the blob contained the serialized revocation and to-local
 	// pubkeys.
-	if !bytes.Equal(jKit.RevocationPubKey[:], expRevPK) {
-		t.Fatalf("revocation pk mismatch, want: %x, got: %x",
-			expRevPK, jKit.RevocationPubKey[:])
-	}
-	if !bytes.Equal(jKit.LocalDelayPubKey[:], expToLocalPK) {
-		t.Fatalf("revocation pk mismatch, want: %x, got: %x",
-			expToLocalPK, jKit.LocalDelayPubKey[:])
-	}
+	require.Equal(t, expRevPK, jKit.RevocationPubKey[:])
+	require.Equal(t, expToLocalPK, jKit.LocalDelayPubKey[:])
 
 	// Determine if the breach transaction has a to-remote output and/or
 	// to-local output to spend from. Note the seemingly-reversed
@@ -650,32 +590,19 @@ func testBackupTask(t *testing.T, test backupTaskTest) {
 	hasToLocal := test.breachInfo.RemoteOutputSignDesc != nil
 
 	// If the to-remote output is present, assert that the to-remote public
-	// key was included in the blob.
-	if hasToRemote &&
-		!bytes.Equal(jKit.CommitToRemotePubKey[:], expToRemotePK) {
-		t.Fatalf("mismatch to-remote pubkey, want: %x, got: %x",
-			expToRemotePK, jKit.CommitToRemotePubKey)
-	}
-
-	// Otherwise if the to-local output is not present, assert that a blank
-	// public key was inserted.
-	if !hasToRemote &&
-		!bytes.Equal(jKit.CommitToRemotePubKey[:], zeroPK[:]) {
-		t.Fatalf("mismatch to-remote pubkey, want: %x, got: %x",
-			zeroPK, jKit.CommitToRemotePubKey)
+	// key was included in the blob. Otherwise assert that a blank public
+	// key was inserted.
+	if hasToRemote {
+		require.Equal(t, expToRemotePK, jKit.CommitToRemotePubKey[:])
+	} else {
+		require.Equal(t, zeroPK[:], jKit.CommitToRemotePubKey[:])
 	}
 
 	// Assert that the CSV is encoded in the blob.
-	if jKit.CSVDelay != test.breachInfo.RemoteDelay {
-		t.Fatalf("mismatch remote delay, want: %d, got: %v",
-			test.breachInfo.RemoteDelay, jKit.CSVDelay)
-	}
+	require.Equal(t, test.breachInfo.RemoteDelay, jKit.CSVDelay)
 
 	// Assert that the sweep pkscript is included.
-	if !bytes.Equal(jKit.SweepAddress, test.expSweepScript) {
-		t.Fatalf("sweep pkscript mismatch, want: %x, got: %x",
-			test.expSweepScript, jKit.SweepAddress)
-	}
+	require.Equal(t, test.expSweepScript, jKit.SweepAddress)
 
 	// Finally, verify that the signatures are encoded in the justice kit.
 	// We don't validate the actual signatures produced here, since at the
@@ -684,18 +611,20 @@ func testBackupTask(t *testing.T, test backupTaskTest) {
 	// TODO(conner): include signature validation checks
 
 	emptyToLocalSig := bytes.Equal(jKit.CommitToLocalSig[:], zeroSig[:])
-	switch {
-	case hasToLocal && emptyToLocalSig:
-		t.Fatalf("to-local signature should not be empty")
-	case !hasToLocal && !emptyToLocalSig:
-		t.Fatalf("to-local signature should be empty")
+	if hasToLocal {
+		require.False(t, emptyToLocalSig, "to-local signature should "+
+			"not be empty")
+	} else {
+		require.True(t, emptyToLocalSig, "to-local signature should "+
+			"be empty")
 	}
 
 	emptyToRemoteSig := bytes.Equal(jKit.CommitToRemoteSig[:], zeroSig[:])
-	switch {
-	case hasToRemote && emptyToRemoteSig:
-		t.Fatalf("to-remote signature should not be empty")
-	case !hasToRemote && !emptyToRemoteSig:
-		t.Fatalf("to-remote signature should be empty")
+	if hasToRemote {
+		require.False(t, emptyToRemoteSig, "to-remote signature "+
+			"should not be empty")
+	} else {
+		require.True(t, emptyToRemoteSig, "to-remote signature "+
+			"should be empty")
 	}
 }

--- a/watchtower/wtclient/candidate_iterator.go
+++ b/watchtower/wtclient/candidate_iterator.go
@@ -13,7 +13,7 @@ import (
 type TowerCandidateIterator interface {
 	// AddCandidate adds a new candidate tower to the iterator. If the
 	// candidate already exists, then any new addresses are added to it.
-	AddCandidate(*wtdb.Tower)
+	AddCandidate(*Tower)
 
 	// RemoveCandidate removes an existing candidate tower from the
 	// iterator. An optional address can be provided to indicate a stale
@@ -32,7 +32,7 @@ type TowerCandidateIterator interface {
 	// Next returns the next candidate tower. The iterator is not required
 	// to return results in any particular order.  If no more candidates are
 	// available, ErrTowerCandidatesExhausted is returned.
-	Next() (*wtdb.Tower, error)
+	Next() (*Tower, error)
 }
 
 // towerListIterator is a linked-list backed TowerCandidateIterator.
@@ -40,7 +40,7 @@ type towerListIterator struct {
 	mu            sync.Mutex
 	queue         *list.List
 	nextCandidate *list.Element
-	candidates    map[wtdb.TowerID]*wtdb.Tower
+	candidates    map[wtdb.TowerID]*Tower
 }
 
 // Compile-time constraint to ensure *towerListIterator implements the
@@ -49,10 +49,10 @@ var _ TowerCandidateIterator = (*towerListIterator)(nil)
 
 // newTowerListIterator initializes a new towerListIterator from a variadic list
 // of lnwire.NetAddresses.
-func newTowerListIterator(candidates ...*wtdb.Tower) *towerListIterator {
+func newTowerListIterator(candidates ...*Tower) *towerListIterator {
 	iter := &towerListIterator{
 		queue:      list.New(),
-		candidates: make(map[wtdb.TowerID]*wtdb.Tower),
+		candidates: make(map[wtdb.TowerID]*Tower),
 	}
 
 	for _, candidate := range candidates {
@@ -79,7 +79,7 @@ func (t *towerListIterator) Reset() error {
 // Next returns the next candidate tower. This iterator will always return
 // candidates in the order given when the iterator was instantiated.  If no more
 // candidates are available, ErrTowerCandidatesExhausted is returned.
-func (t *towerListIterator) Next() (*wtdb.Tower, error) {
+func (t *towerListIterator) Next() (*Tower, error) {
 	t.mu.Lock()
 	defer t.mu.Unlock()
 
@@ -107,7 +107,7 @@ func (t *towerListIterator) Next() (*wtdb.Tower, error) {
 
 // AddCandidate adds a new candidate tower to the iterator. If the candidate
 // already exists, then any new addresses are added to it.
-func (t *towerListIterator) AddCandidate(candidate *wtdb.Tower) {
+func (t *towerListIterator) AddCandidate(candidate *Tower) {
 	t.mu.Lock()
 	defer t.mu.Unlock()
 
@@ -121,8 +121,16 @@ func (t *towerListIterator) AddCandidate(candidate *wtdb.Tower) {
 			t.nextCandidate = t.queue.Back()
 		}
 	} else {
-		for _, addr := range candidate.Addresses {
-			tower.AddAddress(addr)
+		candidate.Addresses.Reset()
+		firstAddr := candidate.Addresses.Peek()
+		tower.Addresses.Add(firstAddr)
+		for {
+			next, err := candidate.Addresses.Next()
+			if err != nil {
+				break
+			}
+
+			tower.Addresses.Add(next)
 		}
 	}
 }
@@ -142,9 +150,9 @@ func (t *towerListIterator) RemoveCandidate(candidate wtdb.TowerID,
 		return nil
 	}
 	if addr != nil {
-		tower.RemoveAddress(addr)
-		if len(tower.Addresses) == 0 {
-			return wtdb.ErrLastTowerAddr
+		err := tower.Addresses.Remove(addr)
+		if err != nil {
+			return err
 		}
 	} else {
 		delete(t.candidates, candidate)

--- a/watchtower/wtclient/candidate_iterator.go
+++ b/watchtower/wtclient/candidate_iterator.go
@@ -155,6 +155,10 @@ func (t *towerListIterator) RemoveCandidate(candidate wtdb.TowerID,
 			return err
 		}
 	} else {
+		if tower.Addresses.HasLocked() {
+			return ErrAddrInUse
+		}
+
 		delete(t.candidates, candidate)
 	}
 

--- a/watchtower/wtclient/client.go
+++ b/watchtower/wtclient/client.go
@@ -45,8 +45,8 @@ const (
 
 // genActiveSessionFilter generates a filter that selects active sessions that
 // also match the desired channel type, either legacy or anchor.
-func genActiveSessionFilter(anchor bool) func(*wtdb.ClientSession) bool {
-	return func(s *wtdb.ClientSession) bool {
+func genActiveSessionFilter(anchor bool) func(*ClientSession) bool {
+	return func(s *ClientSession) bool {
 		return s.Status == wtdb.CSessionActive &&
 			anchor == s.Policy.IsAnchorChannel()
 	}
@@ -241,7 +241,7 @@ type TowerClient struct {
 
 	negotiator        SessionNegotiator
 	candidateTowers   TowerCandidateIterator
-	candidateSessions map[wtdb.SessionID]*wtdb.ClientSession
+	candidateSessions map[wtdb.SessionID]*ClientSession
 	activeSessions    sessionQueueSet
 
 	sessionQueue *sessionQueue
@@ -351,7 +351,7 @@ func New(config *Config) (*TowerClient, error) {
 	activeSessionFilter := genActiveSessionFilter(isAnchorClient)
 
 	candidateTowers := newTowerListIterator()
-	perActiveTower := func(tower *wtdb.Tower) {
+	perActiveTower := func(tower *Tower) {
 		// If the tower has already been marked as active, then there is
 		// no need to add it to the iterator again.
 		if candidateTowers.IsActive(tower.ID) {
@@ -400,18 +400,23 @@ func New(config *Config) (*TowerClient, error) {
 // sessionFilter check then the perActiveTower call-back will be called on that
 // tower.
 func getTowerAndSessionCandidates(db DB, keyRing ECDHKeyRing,
-	sessionFilter func(*wtdb.ClientSession) bool,
-	perActiveTower func(tower *wtdb.Tower),
+	sessionFilter func(*ClientSession) bool,
+	perActiveTower func(tower *Tower),
 	opts ...wtdb.ClientSessionListOption) (
-	map[wtdb.SessionID]*wtdb.ClientSession, error) {
+	map[wtdb.SessionID]*ClientSession, error) {
 
 	towers, err := db.ListTowers()
 	if err != nil {
 		return nil, err
 	}
 
-	candidateSessions := make(map[wtdb.SessionID]*wtdb.ClientSession)
-	for _, tower := range towers {
+	candidateSessions := make(map[wtdb.SessionID]*ClientSession)
+	for _, dbTower := range towers {
+		tower, err := NewTowerFromDBTower(dbTower)
+		if err != nil {
+			return nil, err
+		}
+
 		sessions, err := db.ListClientSessions(&tower.ID, opts...)
 		if err != nil {
 			return nil, err
@@ -427,16 +432,24 @@ func getTowerAndSessionCandidates(db DB, keyRing ECDHKeyRing,
 			if err != nil {
 				return nil, err
 			}
-			s.SessionKeyECDH = keychain.NewPubKeyECDH(
+
+			sessionKeyECDH := keychain.NewPubKeyECDH(
 				towerKeyDesc, keyRing,
 			)
 
-			if !sessionFilter(s) {
+			cs := &ClientSession{
+				ID:                s.ID,
+				ClientSessionBody: s.ClientSessionBody,
+				Tower:             tower,
+				SessionKeyECDH:    sessionKeyECDH,
+			}
+
+			if !sessionFilter(cs) {
 				continue
 			}
 
 			// Add the session to the set of candidate sessions.
-			candidateSessions[s.ID] = s
+			candidateSessions[s.ID] = cs
 			perActiveTower(tower)
 		}
 	}
@@ -452,11 +465,11 @@ func getTowerAndSessionCandidates(db DB, keyRing ECDHKeyRing,
 // ClientSession's SessionPrivKey field is desired, otherwise, the existing
 // ListClientSessions method should be used.
 func getClientSessions(db DB, keyRing ECDHKeyRing, forTower *wtdb.TowerID,
-	passesFilter func(*wtdb.ClientSession) bool,
+	passesFilter func(*ClientSession) bool,
 	opts ...wtdb.ClientSessionListOption) (
-	map[wtdb.SessionID]*wtdb.ClientSession, error) {
+	map[wtdb.SessionID]*ClientSession, error) {
 
-	sessions, err := db.ListClientSessions(forTower, opts...)
+	dbSessions, err := db.ListClientSessions(forTower, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -466,7 +479,13 @@ func getClientSessions(db DB, keyRing ECDHKeyRing, forTower *wtdb.TowerID,
 	// be able to communicate with the towers and authenticate session
 	// requests. This prevents us from having to store the private keys on
 	// disk.
-	for _, s := range sessions {
+	sessions := make(map[wtdb.SessionID]*ClientSession)
+	for _, s := range dbSessions {
+		dbTower, err := db.LoadTowerByID(s.TowerID)
+		if err != nil {
+			return nil, err
+		}
+
 		towerKeyDesc, err := keyRing.DeriveKey(keychain.KeyLocator{
 			Family: keychain.KeyFamilyTowerSession,
 			Index:  s.KeyIndex,
@@ -474,13 +493,27 @@ func getClientSessions(db DB, keyRing ECDHKeyRing, forTower *wtdb.TowerID,
 		if err != nil {
 			return nil, err
 		}
-		s.SessionKeyECDH = keychain.NewPubKeyECDH(towerKeyDesc, keyRing)
+		sessionKeyECDH := keychain.NewPubKeyECDH(towerKeyDesc, keyRing)
+
+		tower, err := NewTowerFromDBTower(dbTower)
+		if err != nil {
+			return nil, err
+		}
+
+		cs := &ClientSession{
+			ID:                s.ID,
+			ClientSessionBody: s.ClientSessionBody,
+			Tower:             tower,
+			SessionKeyECDH:    sessionKeyECDH,
+		}
 
 		// If an optional filter was provided, use it to filter out any
 		// undesired sessions.
-		if passesFilter != nil && !passesFilter(s) {
-			delete(sessions, s.ID)
+		if passesFilter != nil && !passesFilter(cs) {
+			continue
 		}
+
+		sessions[s.ID] = cs
 	}
 
 	return sessions, nil
@@ -710,7 +743,7 @@ func (c *TowerClient) BackupState(chanID *lnwire.ChannelID,
 func (c *TowerClient) nextSessionQueue() (*sessionQueue, error) {
 	// Select any candidate session at random, and remove it from the set of
 	// candidate sessions.
-	var candidateSession *wtdb.ClientSession
+	var candidateSession *ClientSession
 	for id, sessionInfo := range c.candidateSessions {
 		delete(c.candidateSessions, id)
 
@@ -1069,7 +1102,7 @@ func (c *TowerClient) sendMessage(peer wtserver.Peer, msg wtwire.Message) error 
 
 // newSessionQueue creates a sessionQueue from a ClientSession loaded from the
 // database and supplying it with the resources needed by the client.
-func (c *TowerClient) newSessionQueue(s *wtdb.ClientSession,
+func (c *TowerClient) newSessionQueue(s *ClientSession,
 	updates []wtdb.CommittedUpdate) *sessionQueue {
 
 	return newSessionQueue(&sessionQueueConfig{
@@ -1089,7 +1122,7 @@ func (c *TowerClient) newSessionQueue(s *wtdb.ClientSession,
 // getOrInitActiveQueue checks the activeSessions set for a sessionQueue for the
 // passed ClientSession. If it exists, the active sessionQueue is returned.
 // Otherwise, a new sessionQueue is initialized and added to the set.
-func (c *TowerClient) getOrInitActiveQueue(s *wtdb.ClientSession,
+func (c *TowerClient) getOrInitActiveQueue(s *ClientSession,
 	updates []wtdb.CommittedUpdate) *sessionQueue {
 
 	if sq, ok := c.activeSessions[s.ID]; ok {
@@ -1103,7 +1136,7 @@ func (c *TowerClient) getOrInitActiveQueue(s *wtdb.ClientSession,
 // adds the sessionQueue to the activeSessions set, and starts the sessionQueue
 // so that it can deliver any committed updates or begin accepting newly
 // assigned tasks.
-func (c *TowerClient) initActiveQueue(s *wtdb.ClientSession,
+func (c *TowerClient) initActiveQueue(s *ClientSession,
 	updates []wtdb.CommittedUpdate) *sessionQueue {
 
 	// Initialize the session queue, providing it with all the resources it
@@ -1156,10 +1189,16 @@ func (c *TowerClient) handleNewTower(msg *newTowerMsg) error {
 	// We'll start by updating our persisted state, followed by our
 	// in-memory state, with the new tower. This might not actually be a new
 	// tower, but it might include a new address at which it can be reached.
-	tower, err := c.cfg.DB.CreateTower(msg.addr)
+	dbTower, err := c.cfg.DB.CreateTower(msg.addr)
 	if err != nil {
 		return err
 	}
+
+	tower, err := NewTowerFromDBTower(dbTower)
+	if err != nil {
+		return err
+	}
+
 	c.candidateTowers.AddCandidate(tower)
 
 	// Include all of its corresponding sessions to our set of candidates.
@@ -1251,7 +1290,7 @@ func (c *TowerClient) handleStaleTower(msg *staleTowerMsg) error {
 	// If our active session queue corresponds to the stale tower, we'll
 	// proceed to negotiate a new one.
 	if c.sessionQueue != nil {
-		activeTower := c.sessionQueue.towerAddr.IdentityKey.SerializeCompressed()
+		activeTower := c.sessionQueue.tower.IdentityKey.SerializeCompressed()
 		if bytes.Equal(pubKey, activeTower) {
 			c.sessionQueue = nil
 		}

--- a/watchtower/wtclient/client_test.go
+++ b/watchtower/wtclient/client_test.go
@@ -1471,10 +1471,8 @@ var clientTests = []clientTest{
 	},
 	{
 		// Assert that if a client changes the address for a server and
-		// then tries to back up updates then the client will not switch
-		// to the new address. The client will only use the server's new
-		// address after a restart. This is a bug that will be fixed in
-		// a future commit.
+		// then tries to back up updates then the client will switch to
+		// the new address.
 		name: "change address of existing session",
 		cfg: harnessCfg{
 			localBalance:  localBalance,
@@ -1535,16 +1533,7 @@ var clientTests = []clientTest{
 			// Now attempt to back up the rest of the updates.
 			h.backupStates(chanID, numUpdates/2, maxUpdates, nil)
 
-			// Assert that the server does not receive the updates.
-			h.waitServerUpdates(nil, waitTime)
-
-			// Restart the client and attempt to back up the updates
-			// again.
-			h.client.Stop()
-			h.startClient()
-			h.backupStates(chanID, numUpdates/2, maxUpdates, nil)
-
-			// The server should now receive the updates.
+			// Assert that the server does receive the updates.
 			h.waitServerUpdates(hints[:maxUpdates], waitTime)
 		},
 	},

--- a/watchtower/wtclient/client_test.go
+++ b/watchtower/wtclient/client_test.go
@@ -449,8 +449,6 @@ func newHarness(t *testing.T, cfg harnessCfg) *testHarness {
 		MaxBackoff:     time.Second,
 		ForceQuitDelay: 10 * time.Second,
 	}
-	client, err := wtclient.New(clientCfg)
-	require.NoError(t, err, "Unable to create wtclient")
 
 	h := &testHarness{
 		t:          t,
@@ -459,7 +457,6 @@ func newHarness(t *testing.T, cfg harnessCfg) *testHarness {
 		capacity:   cfg.localBalance + cfg.remoteBalance,
 		clientDB:   clientDB,
 		clientCfg:  clientCfg,
-		client:     client,
 		serverAddr: towerAddr,
 		serverDB:   serverDB,
 		serverCfg:  serverCfg,
@@ -470,12 +467,8 @@ func newHarness(t *testing.T, cfg harnessCfg) *testHarness {
 	h.startServer()
 	t.Cleanup(h.stopServer)
 
-	err = client.Start()
-	require.NoError(t, err)
-	t.Cleanup(client.ForceQuit)
-
-	err = client.AddTower(towerAddr)
-	require.NoError(t, err)
+	h.startClient()
+	t.Cleanup(h.client.ForceQuit)
 
 	h.makeChannel(0, h.cfg.localBalance, h.cfg.remoteBalance)
 	if !cfg.noRegisterChan0 {

--- a/watchtower/wtclient/errors.go
+++ b/watchtower/wtclient/errors.go
@@ -20,10 +20,6 @@ var (
 	// down.
 	ErrNegotiatorExiting = errors.New("negotiator exiting")
 
-	// ErrNoTowerAddrs signals that the client could not be created because
-	// we have no addresses with which we can reach a tower.
-	ErrNoTowerAddrs = errors.New("no tower addresses")
-
 	// ErrFailedNegotiation signals that the session negotiator could not
 	// acquire a new session as requested.
 	ErrFailedNegotiation = errors.New("session negotiation unsuccessful")

--- a/watchtower/wtdb/client_db_test.go
+++ b/watchtower/wtdb/client_db_test.go
@@ -343,8 +343,11 @@ func testCreateTower(h *clientDBHarness) {
 	h.loadTowerByID(20, wtdb.ErrTowerNotFound)
 
 	tower := h.newTower()
-	require.Len(h.t, tower.LNAddrs(), 1)
-	towerAddr := tower.LNAddrs()[0]
+	require.Len(h.t, tower.Addresses, 1)
+	towerAddr := &lnwire.NetAddress{
+		IdentityKey: tower.IdentityKey,
+		Address:     tower.Addresses[0],
+	}
 
 	// Load the tower from the database and assert that it matches the tower
 	// we created.

--- a/watchtower/wtdb/client_session.go
+++ b/watchtower/wtdb/client_session.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/lightningnetwork/lnd/keychain"
 	"github.com/lightningnetwork/lnd/lnwire"
 	"github.com/lightningnetwork/lnd/watchtower/blob"
 	"github.com/lightningnetwork/lnd/watchtower/wtpolicy"
@@ -36,19 +35,6 @@ type ClientSession struct {
 	ID SessionID
 
 	ClientSessionBody
-
-	// Tower holds the pubkey and address of the watchtower.
-	//
-	// NOTE: This value is not serialized. It is recovered by looking up the
-	// tower with TowerID.
-	Tower *Tower
-
-	// SessionKeyECDH is the ECDH capable wrapper of the ephemeral secret
-	// key used to connect to the watchtower.
-	//
-	// NOTE: This value is not serialized. It is derived using the KeyIndex
-	// on startup to avoid storing private keys on disk.
-	SessionKeyECDH keychain.SingleKeyECDH
 }
 
 // ClientSessionBody represents the primary components of a ClientSession that

--- a/watchtower/wtdb/tower.go
+++ b/watchtower/wtdb/tower.go
@@ -7,7 +7,6 @@ import (
 	"net"
 
 	"github.com/btcsuite/btcd/btcec/v2"
-	"github.com/lightningnetwork/lnd/lnwire"
 )
 
 // TowerID is a unique 64-bit identifier allocated to each unique watchtower.
@@ -75,23 +74,6 @@ func (t *Tower) RemoveAddress(addr net.Addr) {
 		t.Addresses = append(t.Addresses[:i], t.Addresses[i+1:]...)
 		return
 	}
-}
-
-// LNAddrs generates a list of lnwire.NetAddress from a Tower instance's
-// addresses. This can be used to have a client try multiple addresses for the
-// same Tower.
-//
-// NOTE: This method is NOT safe for concurrent use.
-func (t *Tower) LNAddrs() []*lnwire.NetAddress {
-	addrs := make([]*lnwire.NetAddress, 0, len(t.Addresses))
-	for _, addr := range t.Addresses {
-		addrs = append(addrs, &lnwire.NetAddress{
-			IdentityKey: t.IdentityKey,
-			Address:     addr,
-		})
-	}
-
-	return addrs
 }
 
 // String returns a user-friendly identifier of the tower.

--- a/watchtower/wtmock/client_db.go
+++ b/watchtower/wtmock/client_db.go
@@ -231,7 +231,6 @@ func (m *ClientDB) listClientSessions(tower *wtdb.TowerID,
 		if tower != nil && *tower != session.TowerID {
 			continue
 		}
-		session.Tower = m.towers[session.TowerID]
 		sessions[session.ID] = &session
 
 		if cfg.PerAckedUpdate != nil {


### PR DESCRIPTION
This PR introduces an `AddressIterator` to the wtclient package. Each `Tower` now has an AddressIterator instead of just a list of addresses. This allows concurrent access to a tower's addresses. The iterator also allows a caller to place a lock on an address - this will prevent other callers from removing the address from the iterator. 

This fixes 2 issues:
## [Issue 1](https://github.com/lightningnetwork/lnd/issues/6650):

In this issue, the user is able to add new tower addresses but the addresses are never utilised until LND is restarted. This is fixed in this PR by passing the AddressIterator for a tower around instead of just having a fixed address for a tower.

## [Issue 2](https://github.com/lightningnetwork/lnd/issues/5361)

In this issue, users are unable to to remove _any_ towers (or tower addresses) if session negotiation is in progress _even if_ the negotiation in progress is not using the address/tower in question. This is fixed in this PR by allowing the session negotiator to lock the address it is using. So as long as the user is not trying to remove a locked address, the request is allowed.


Fixes https://github.com/lightningnetwork/lnd/issues/6650
Fixes https://github.com/lightningnetwork/lnd/issues/5361