### PR TITLE
htlcswitch+lnwallet: ReceiveMalformedFailHTLC

### DIFF
--- a/htlcswitch/mock.go
+++ b/htlcswitch/mock.go
@@ -417,12 +417,16 @@ func (o *mockObfuscator) Reextract(
 	return nil
 }
 
+var fakeHmac = []byte("hmachmachmachmachmachmachmachmac")
+
 func (o *mockObfuscator) EncryptFirstHop(failure lnwire.FailureMessage) (
 	lnwire.OpaqueReason, error) {
 
 	o.failure = failure
 
 	var b bytes.Buffer
+	b.Write(fakeHmac)
+
 	if err := lnwire.EncodeFailure(&b, failure, 0); err != nil {
 		return nil, err
 	}
@@ -434,6 +438,11 @@ func (o *mockObfuscator) IntermediateEncrypt(reason lnwire.OpaqueReason) lnwire.
 }
 
 func (o *mockObfuscator) EncryptMalformedError(reason lnwire.OpaqueReason) lnwire.OpaqueReason {
+	var b bytes.Buffer
+	b.Write(fakeHmac)
+
+	b.Write(reason)
+
 	return reason
 }
 
@@ -445,7 +454,13 @@ func newMockDeobfuscator() ErrorDecrypter {
 	return &mockDeobfuscator{}
 }
 
-func (o *mockDeobfuscator) DecryptError(reason lnwire.OpaqueReason) (*ForwardingError, error) {
+func (o *mockDeobfuscator) DecryptError(reason lnwire.OpaqueReason) (
+	*ForwardingError, error) {
+
+	if !bytes.Equal(reason[:32], fakeHmac) {
+		return nil, errors.New("fake decryption error")
+	}
+	reason = reason[32:]
 
 	r := bytes.NewReader(reason)
 	failure, err := lnwire.DecodeFailure(r, 0)


### PR DESCRIPTION
Reviving a three year old idea described in https://github.com/lightningnetwork/lnd/pull/3027#discussion_r280013085.

Variable failure length messages force us to rethink the previously chosen solution that depends on a fixed length, see https://github.com/lightningnetwork/lnd/pull/6913 