### PR TITLE
funding: forget funding tx if conflict tx confirms

### DIFF
--- a/lntest/harness_net.go
+++ b/lntest/harness_net.go
@@ -1110,8 +1110,7 @@ func (n *NetworkHarness) OpenChannel(srcNode, destNode *HarnessNode,
 // timeout, then if the timeout is reached before the channel pending
 // notification is received, an error is returned.
 func (n *NetworkHarness) OpenPendingChannel(srcNode, destNode *HarnessNode,
-	amt btcutil.Amount,
-	pushAmt btcutil.Amount) (*lnrpc.PendingUpdate, error) {
+	openReq *lnrpc.OpenChannelRequest) (*lnrpc.PendingUpdate, error) {
 
 	// Wait until srcNode and destNode have blockchain synced
 	if err := srcNode.WaitForBlockchainSync(); err != nil {
@@ -1121,12 +1120,7 @@ func (n *NetworkHarness) OpenPendingChannel(srcNode, destNode *HarnessNode,
 		return nil, fmt.Errorf("unable to sync destNode chain: %v", err)
 	}
 
-	openReq := &lnrpc.OpenChannelRequest{
-		NodePubkey:         destNode.PubKey[:],
-		LocalFundingAmount: int64(amt),
-		PushSat:            int64(pushAmt),
-		Private:            false,
-	}
+	openReq.NodePubkey = destNode.PubKey[:]
 
 	// We need to use n.runCtx here to keep the response stream alive after
 	// the function is returned.

--- a/lntest/itest/lnd_open_channel_test.go
+++ b/lntest/itest/lnd_open_channel_test.go
@@ -79,8 +79,12 @@ func testOpenChannelAfterReorg(net *lntest.NetworkHarness, t *harnessTest) {
 	// open, then broadcast the funding transaction
 	chanAmt := funding.MaxBtcFundingAmount
 	pushAmt := btcutil.Amount(0)
+	openReq := &lnrpc.OpenChannelRequest{
+		LocalFundingAmount: int64(chanAmt),
+		PushSat:            int64(pushAmt),
+	}
 	pendingUpdate, err := net.OpenPendingChannel(
-		net.Alice, net.Bob, chanAmt, pushAmt,
+		net.Alice, net.Bob, openReq,
 	)
 	if err != nil {
 		t.Fatalf("unable to open channel: %v", err)

--- a/lntest/itest/lnd_test_list_on_test.go
+++ b/lntest/itest/lnd_test_list_on_test.go
@@ -274,4 +274,8 @@ var allTestCases = []*testCase{
 		name: "open channel fee policy",
 		test: testOpenChannelUpdateFeePolicy,
 	},
+	{
+		name: "funding conflict",
+		test: testFundingConflict,
+	},
 }


### PR DESCRIPTION
Replaces #5567 
Fixes #1494
Fixes #1623
Fixes #386 

Tried to give commit credit, but it didn't seem to work. This allows the initiator to forget the funding transaction a conflict transaction has confirmed.