### PR TITLE
Remove ErrSynchronizingChain

### DIFF
--- a/docs/release-notes/release-notes-0.16.0.md
+++ b/docs/release-notes/release-notes-0.16.0.md
@@ -119,6 +119,9 @@ https://github.com/lightningnetwork/lnd/pull/6963/)
 
 * [Stop handling peer warning messages as errors](https://github.com/lightningnetwork/lnd/pull/6840)
 
+* [Stop sending a synchronizing error on the wire when out of
+  sync](https://github.com/lightningnetwork/lnd/pull/7039).
+
 ## `lncli`
 * [Add an `insecure` flag to skip tls auth as well as a `metadata` string slice
   flag](https://github.com/lightningnetwork/lnd/pull/6818) that allows the

--- a/funding/manager.go
+++ b/funding/manager.go
@@ -1306,9 +1306,10 @@ func (f *Manager) handleFundingOpen(peer lnpeer.Peer,
 		if err != nil {
 			log.Errorf("unable to query wallet: %v", err)
 		}
+		err := errors.New("Synchronizing blockchain")
 		f.failFundingFlow(
 			peer, msg.PendingChannelID,
-			lnwire.ErrSynchronizingChain,
+			err,
 		)
 		return
 	}

--- a/lnwire/error.go
+++ b/lnwire/error.go
@@ -15,15 +15,10 @@ const (
 	// active pending channels exceeds their maximum policy limit.
 	ErrMaxPendingChannels FundingError = 1
 
-	// ErrSynchronizingChain is returned by a remote peer that receives a
-	// channel update or a funding request while it's still syncing to the
-	// latest state of the blockchain.
-	ErrSynchronizingChain FundingError = 2
-
 	// ErrChanTooLarge is returned by a remote peer that receives a
 	// FundingOpen request for a channel that is above their current
 	// soft-limit.
-	ErrChanTooLarge FundingError = 3
+	ErrChanTooLarge FundingError = 2
 )
 
 // String returns a human readable version of the target FundingError.
@@ -31,8 +26,6 @@ func (e FundingError) String() string {
 	switch e {
 	case ErrMaxPendingChannels:
 		return "Number of pending channels exceed maximum"
-	case ErrSynchronizingChain:
-		return "Synchronizing blockchain"
 	case ErrChanTooLarge:
 		return "channel too large"
 	default:


### PR DESCRIPTION
## Change Description
This fixes https://github.com/lightningnetwork/lnd/issues/7034 where an LND node reveals that is it vulnerable to chain tip sync problems such as https://github.com/lightningnetwork/lnd/issues/7002, which may be exploited by those with existing channels with the node by broadcasting a previous channel state. It would be better if other actors do not know if a node is synced or not. 

## Steps to Test
1. Be out of sync
2. Attempt to open channel with out of sync node
3. See what error is returned on the wire (should now be `funding failed due to internal error`)