### PR TITLE
watchtower/client: immediately negotiate session with first candidate tower

### DIFF
--- a/docs/release-notes/release-notes-0.16.0.md
+++ b/docs/release-notes/release-notes-0.16.0.md
@@ -130,6 +130,8 @@ crash](https://github.com/lightningnetwork/lnd/pull/7019).
 * [test: fix loop variables being accessed in
   closures](https://github.com/lightningnetwork/lnd/pull/7032).
 
+* [Do not delay session negotiation with first candidate tower]()
+
 ### Tooling and documentation
 
 * [The `golangci-lint` tool was updated to

--- a/watchtower/wtclient/candidate_iterator.go
+++ b/watchtower/wtclient/candidate_iterator.go
@@ -25,6 +25,10 @@ type TowerCandidateIterator interface {
 	// iterator.
 	IsActive(wtdb.TowerID) bool
 
+	// IsEmpty determines whether the iterator has any candidate towers
+	// with which we could potentially establish a session.
+	IsEmpty() bool
+
 	// Reset clears any internal iterator state, making previously taken
 	// candidates available as long as they remain in the set.
 	Reset() error
@@ -160,6 +164,15 @@ func (t *towerListIterator) IsActive(tower wtdb.TowerID) bool {
 
 	_, ok := t.candidates[tower]
 	return ok
+}
+
+// IsEmpty indicates whether the iterator has any candidate towers
+// with which we could potentially establish a session.
+func (t *towerListIterator) IsEmpty() bool {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	return len(t.candidates) == 0
 }
 
 // TODO(conner): implement graph-backed candidate iterator for public towers.

--- a/watchtower/wtclient/candidate_iterator_test.go
+++ b/watchtower/wtclient/candidate_iterator_test.go
@@ -100,6 +100,12 @@ func TestTowerCandidateIterator(t *testing.T) {
 	}
 	towerIterator := newTowerListIterator(towerCopies...)
 
+	// The iterator has towers and should report as non-empty.
+	empty := towerIterator.IsEmpty()
+	if empty {
+		t.Fatal("iterator with towers incorrectly reports as empty")
+	}
+
 	// We should expect to see all of our candidates in the order that they
 	// were added.
 	for _, expTower := range towers {
@@ -152,4 +158,11 @@ func TestTowerCandidateIterator(t *testing.T) {
 	towerIterator.AddCandidate(secondTower)
 	assertActiveCandidate(t, towerIterator, secondTower, true)
 	assertNextCandidate(t, towerIterator, secondTower)
+
+	// An empty iterator should correctly report so.
+	emptyIterator := newTowerListIterator()
+	empty = emptyIterator.IsEmpty()
+	if !empty {
+		t.Fatal("empty iterator incorrectly reports as non-empty")
+	}
 }


### PR DESCRIPTION
Whether or not we have any candidate towers, the client will request its session negotiator begin attempting to negotiate a session. While there are no candidate towers, the negotiator will just churn with exponential backoff.  Upon addition of the first tower, we won't establish a usable session until after the exponential backup delay times out. In order to avoid waiting for exponential backoff, we should not begin session negotiation until we have a candidate tower. This way we can immediately negotiate a session with the first newly added tower and promptly get to backing up those payment channel state updates!

```
# A watchtower client will churn in its session negotiation loop even when it has no candidate towers
2022-10-13 15:36:44.773 [INF] WTCL: (legacy) Starting watchtower client
2022-10-13 15:36:44.774 [DBG] WTCL: (legacy) Starting session negotiator
2022-10-13 15:36:44.786 [INF] WTCL: (legacy) Requesting new session.
2022-10-13 15:36:44.786 [DBG] WTCL: (legacy) Dispatching session negotiation
2022-10-13 15:36:44.788 [DBG] WTCL: (legacy) Unable to get new tower candidate, retrying after 10s -- reason: exhausted all tower candidates
2022-10-13 15:36:44.786 [INF] WTCL: (legacy) Watchtower client started successfully
2022-10-13 15:36:44.794 [INF] WTCL: (anchor) Starting watchtower client
2022-10-13 15:36:44.795 [DBG] WTCL: (anchor) Starting session negotiator
2022-10-13 15:36:44.797 [INF] WTCL: (anchor) Watchtower client started successfully
2022-10-13 15:36:44.797 [INF] WTCL: (anchor) Requesting new session.
2022-10-13 15:36:44.799 [DBG] WTCL: (anchor) Dispatching session negotiation
2022-10-13 15:36:44.800 [DBG] WTCL: (anchor) Unable to get new tower candidate, retrying after 10s -- reason: exhausted all tower candidates
2022-10-13 15:36:54.794 [DBG] WTCL: (legacy) Unable to get new tower candidate, retrying after 20s -- reason: exhausted all tower candidates
2022-10-13 15:36:54.802 [DBG] WTCL: (anchor) Unable to get new tower candidate, retrying after 20s -- reason: exhausted all tower candidates
2022-10-13 15:37:14.803 [DBG] WTCL: (legacy) Unable to get new tower candidate, retrying after 40s -- reason: exhausted all tower candidates
2022-10-13 15:37:14.811 [DBG] WTCL: (anchor) Unable to get new tower candidate, retrying after 40s -- reason: exhausted all tower candidates
2022-10-13 15:37:54.799 [DBG] WTCL: (legacy) Unable to get new tower candidate, retrying after 1m20s -- reason: exhausted all tower candidates
2022-10-13 15:37:54.808 [DBG] WTCL: (anchor) Unable to get new tower candidate, retrying after 1m20s -- reason: exhausted all tower candidates
2022-10-13 15:39:14.800 [DBG] WTCL: (legacy) Unable to get new tower candidate, retrying after 2m40s -- reason: exhausted all tower candidates
2022-10-13 15:39:14.807 [DBG] WTCL: (anchor) Unable to get new tower candidate, retrying after 2m40s -- reason: exhausted all tower candidates
2022-10-13 15:41:54.810 [DBG] WTCL: (legacy) Unable to get new tower candidate, retrying after 5m0s -- reason: exhausted all tower candidates
2022-10-13 15:41:54.818 [DBG] WTCL: (anchor) Unable to get new tower candidate, retrying after 5m0s -- reason: exhausted all tower candidates

# Add a tower, but notice that the client does not promptly begin session negotiation
$ lncli wtclient add 033e98efe2d4d1fc1cfa4992e98564b275bdfddf38387c7cc295954a58862da721@172.31.0.2

... 5 minutes later
2022-10-13 15:46:54.818 [DBG] WTCL: (legacy) Attempting session negotiation with tower=033e98efe2d4d1fc1cfa4992e98564b275bdfddf38387c7cc295954a58862da721
```

While this PR is not strictly necessary for correctness, it may provide a rather small quality of life improvement in the scenario in which a user is adding a first tower. Let me know if this is something others think is worth adding or if the small behavior change is not worth the addition of another similarly structured `select{}` statement.

Thanks!

See [here](https://github.com/calvinrzachman/lnd/pull/2/commits/13a299d6f056b60def7f83c9b5b91c4291e4c9d8) for alternative way to achieve the same thing, possibly with an easier to read diff, but which does add a somewhat odd method to the `SessionNegotiator` interface. 

## Pull Request Checklist
### Testing
- [ ] Your PR passes all CI checks.
- [ ] Tests covering the positive and negative (error paths) are included.
- [ ] Bug fixes contain tests triggering the bug to prevent regressions.

### Code Style and Documentation
- [ ] The change obeys the [Code Documentation and Commenting](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#CodeDocumentation) guidelines, and lines wrap at 80.
- [x] Commits follow the [Ideal Git Commit Structure](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#IdealGitCommitStructure).
- [x] Any new logging statements use an appropriate subsystem and logging level.
- [x]  [There is a change description in the release notes](https://github.com/lightningnetwork/lnd/tree/master/docs/release-notes), or `[skip ci]` in the commit message for small changes.

📝 Please see our  [Contribution Guidelines](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md) for further guidance.