### PR TITLE
Bug/fix race neutrinotest

### DIFF
--- a/docs/release-notes/release-notes-0.17.0.md
+++ b/docs/release-notes/release-notes-0.17.0.md
@@ -21,6 +21,9 @@
 * [Fix Benchmark Test (BenchmarkReadMessage/Channel_Ready) in the lnwire 
 package](https://github.com/lightningnetwork/lnd/pull/7356)
 
+* [Fix unit test flake (TestLightningWallet) in the neutrino package via
+  version bump of btcsuite/btcwallet](https://github.com/lightningnetwork/lnd/pull/7049)
+
 ## RPC
 
 * [SendOutputs](https://github.com/lightningnetwork/lnd/pull/7631) now adheres
@@ -59,5 +62,6 @@ unlock or create.
 * Erik Arvstedt
 * hieblmi
 * Jordi Montes
+* Michael Street
 * Oliver Gugger
 * ziggie1984

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/btcsuite/btcd/btcutil/psbt v1.1.8
 	github.com/btcsuite/btcd/chaincfg/chainhash v1.0.2
 	github.com/btcsuite/btclog v0.0.0-20170628155309-84c8d2346e9f
-	github.com/btcsuite/btcwallet v0.16.9
+	github.com/btcsuite/btcwallet v0.16.10-0.20230510075312-4383930e9c4c
 	github.com/btcsuite/btcwallet/wallet/txauthor v1.3.2
 	github.com/btcsuite/btcwallet/wallet/txrules v1.2.0
 	github.com/btcsuite/btcwallet/walletdb v1.4.0

--- a/go.sum
+++ b/go.sum
@@ -89,8 +89,8 @@ github.com/btcsuite/btcd/chaincfg/chainhash v1.0.2/go.mod h1:7SFka0XMvUgj3hfZtyd
 github.com/btcsuite/btclog v0.0.0-20170628155309-84c8d2346e9f h1:bAs4lUbRJpnnkd9VhRV3jjAVU7DJVjMaK+IsvSeZvFo=
 github.com/btcsuite/btclog v0.0.0-20170628155309-84c8d2346e9f/go.mod h1:TdznJufoqS23FtqVCzL0ZqgP5MqXbb4fg/WgDys70nA=
 github.com/btcsuite/btcutil v0.0.0-20190425235716-9e5f4b9a998d/go.mod h1:+5NJ2+qvTyV9exUAL/rxXi3DcLg2Ts+ymUAY5y4NvMg=
-github.com/btcsuite/btcwallet v0.16.9 h1:hLAzEJvsiSn+r6j374G7ThnrYD/toa+Lv7l1Rm6+0oM=
-github.com/btcsuite/btcwallet v0.16.9/go.mod h1:T3DjEAMZYIqQ28l+ixlB6DX4mFJXCX8Pzz+yACQcLsc=
+github.com/btcsuite/btcwallet v0.16.10-0.20230510075312-4383930e9c4c h1:+eIyeqQWLRwobTmMkjb3EknTcz8L8AZFhd8Qir01E4s=
+github.com/btcsuite/btcwallet v0.16.10-0.20230510075312-4383930e9c4c/go.mod h1:T3DjEAMZYIqQ28l+ixlB6DX4mFJXCX8Pzz+yACQcLsc=
 github.com/btcsuite/btcwallet/wallet/txauthor v1.3.2 h1:etuLgGEojecsDOYTII8rYiGHjGyV5xTqsXi+ZQ715UU=
 github.com/btcsuite/btcwallet/wallet/txauthor v1.3.2/go.mod h1:Zpk/LOb2sKqwP2lmHjaZT9AdaKsHPSbNLm2Uql5IQ/0=
 github.com/btcsuite/btcwallet/wallet/txrules v1.2.0 h1:BtEN5Empw62/RVnZ0VcJaVtVlBijnLlJY+dwjAye2Bg=


### PR DESCRIPTION
## Change Description

This PR bumps `lnd` to use the latest version of `btcwallet` @ `4383930e9c4c07dba5cf7444b0c08c47bd2be30a`.