### PR TITLE
watchtower: reduce AckedUpdate storage footprint

### DIFF
--- a/channeldb/migration30/migration_test.go
+++ b/channeldb/migration30/migration_test.go
@@ -108,6 +108,7 @@ func TestMigrateRevocationLog(t *testing.T) {
 				beforeMigration,
 				afterMigration,
 				MigrateRevocationLog,
+				false,
 			)
 		})
 		if !success {
@@ -569,5 +570,6 @@ func BenchmarkMigration(b *testing.B) {
 
 			return MigrateRevocationLog(db)
 		},
+		false,
 	)
 }

--- a/channeldb/migtest/migtest.go
+++ b/channeldb/migtest/migtest.go
@@ -90,7 +90,7 @@ func ApplyMigration(t *testing.T,
 // supplied migration functions to take a db instance and construct their own
 // database transactions.
 func ApplyMigrationWithDb(t testing.TB, beforeMigration, afterMigration,
-	migrationFunc func(db kvdb.Backend) error) {
+	migrationFunc func(db kvdb.Backend) error, shouldFail bool) {
 
 	t.Helper()
 
@@ -106,8 +106,11 @@ func ApplyMigrationWithDb(t testing.TB, beforeMigration, afterMigration,
 	}
 
 	// Apply migration.
-	if err := migrationFunc(cdb); err != nil {
-		t.Fatalf("migrationFunc error: %v", err)
+	err = migrationFunc(cdb)
+	if shouldFail {
+		require.Error(t, err)
+	} else {
+		require.NoError(t, err)
 	}
 
 	// If there's no afterMigration, exit here.

--- a/docs/release-notes/release-notes-0.16.0.md
+++ b/docs/release-notes/release-notes-0.16.0.md
@@ -289,6 +289,9 @@ certain large transactions](https://github.com/lightningnetwork/lnd/pull/7100).
   using the address in question](
   https://github.com/lightningnetwork/lnd/pull/7025)
 
+* [Store AckedUpdates in a more compact
+  way](https://github.com/lightningnetwork/lnd/pull/7055)
+
 ## Pathfinding
 
 * [Pathfinding takes capacity of edges into account to improve success

--- a/watchtower/log.go
+++ b/watchtower/log.go
@@ -4,6 +4,8 @@ import (
 	"github.com/btcsuite/btclog"
 	"github.com/lightningnetwork/lnd/build"
 	"github.com/lightningnetwork/lnd/watchtower/lookout"
+	"github.com/lightningnetwork/lnd/watchtower/wtclient"
+	"github.com/lightningnetwork/lnd/watchtower/wtdb"
 	"github.com/lightningnetwork/lnd/watchtower/wtserver"
 )
 
@@ -30,4 +32,6 @@ func UseLogger(logger btclog.Logger) {
 	log = logger
 	lookout.UseLogger(logger)
 	wtserver.UseLogger(logger)
+	wtclient.UseLogger(logger)
+	wtdb.UseLogger(logger)
 }

--- a/watchtower/wtclient/interface.go
+++ b/watchtower/wtclient/interface.go
@@ -68,6 +68,14 @@ type DB interface {
 	FetchSessionCommittedUpdates(id *wtdb.SessionID) (
 		[]wtdb.CommittedUpdate, error)
 
+	// IsAcked returns true if the given backup has been backed up using
+	// the given session.
+	IsAcked(id *wtdb.SessionID, backupID *wtdb.BackupID) (bool, error)
+
+	// NumAckedUpdates returns the number of backups that have been
+	// successfully backed up using the given session.
+	NumAckedUpdates(id *wtdb.SessionID) (uint64, error)
+
 	// FetchChanSummaries loads a mapping from all registered channels to
 	// their channel summaries.
 	FetchChanSummaries() (wtdb.ChannelSummaries, error)

--- a/watchtower/wtdb/codec_test.go
+++ b/watchtower/wtdb/codec_test.go
@@ -125,9 +125,9 @@ type dbObject interface {
 	Decode(io.Reader) error
 }
 
-// TestCodec serializes and deserializes wtdb objects in order to test that that
-// the codec understands all of the required field types. The test also asserts
-// that decoding an object into another results in an equivalent object.
+// TestCodec serializes and deserializes wtdb objects in order to test that the
+// codec understands all of the required field types. The test also asserts that
+// decoding an object into another results in an equivalent object.
 func TestCodec(tt *testing.T) {
 
 	var t *testing.T

--- a/watchtower/wtdb/log.go
+++ b/watchtower/wtdb/log.go
@@ -6,6 +6,7 @@ import (
 	"github.com/lightningnetwork/lnd/watchtower/wtdb/migration1"
 	"github.com/lightningnetwork/lnd/watchtower/wtdb/migration2"
 	"github.com/lightningnetwork/lnd/watchtower/wtdb/migration3"
+	"github.com/lightningnetwork/lnd/watchtower/wtdb/migration4"
 )
 
 // log is a logger that is initialized with no output filters.  This
@@ -32,6 +33,7 @@ func UseLogger(logger btclog.Logger) {
 	migration1.UseLogger(logger)
 	migration2.UseLogger(logger)
 	migration3.UseLogger(logger)
+	migration4.UseLogger(logger)
 }
 
 // logClosure is used to provide a closure over expensive logging operations so

--- a/watchtower/wtdb/log.go
+++ b/watchtower/wtdb/log.go
@@ -5,6 +5,7 @@ import (
 	"github.com/lightningnetwork/lnd/build"
 	"github.com/lightningnetwork/lnd/watchtower/wtdb/migration1"
 	"github.com/lightningnetwork/lnd/watchtower/wtdb/migration2"
+	"github.com/lightningnetwork/lnd/watchtower/wtdb/migration3"
 )
 
 // log is a logger that is initialized with no output filters.  This
@@ -30,6 +31,7 @@ func UseLogger(logger btclog.Logger) {
 	log = logger
 	migration1.UseLogger(logger)
 	migration2.UseLogger(logger)
+	migration3.UseLogger(logger)
 }
 
 // logClosure is used to provide a closure over expensive logging operations so

--- a/watchtower/wtdb/log.go
+++ b/watchtower/wtdb/log.go
@@ -4,6 +4,7 @@ import (
 	"github.com/btcsuite/btclog"
 	"github.com/lightningnetwork/lnd/build"
 	"github.com/lightningnetwork/lnd/watchtower/wtdb/migration1"
+	"github.com/lightningnetwork/lnd/watchtower/wtdb/migration2"
 )
 
 // log is a logger that is initialized with no output filters.  This
@@ -28,6 +29,7 @@ func DisableLog() {
 func UseLogger(logger btclog.Logger) {
 	log = logger
 	migration1.UseLogger(logger)
+	migration2.UseLogger(logger)
 }
 
 // logClosure is used to provide a closure over expensive logging operations so

--- a/watchtower/wtdb/migration2/client_db.go
+++ b/watchtower/wtdb/migration2/client_db.go
@@ -1,0 +1,82 @@
+package migration2
+
+import (
+	"errors"
+
+	"github.com/lightningnetwork/lnd/kvdb"
+)
+
+var (
+	// cChanSummaryBkt is a top-level bucket storing:
+	//   channel-id -> encoded ClientChanSummary.
+	cChanSummaryBkt = []byte("client-channel-summary-bucket")
+
+	// cChanDetailsBkt is a top-level bucket storing:
+	//   channel-id => cChannelSummary -> encoded ClientChanSummary.
+	cChanDetailsBkt = []byte("client-channel-detail-bucket")
+
+	// cChannelSummary is a key used in cChanDetailsBkt to store the encoded
+	// body of ClientChanSummary.
+	cChannelSummary = []byte("client-channel-summary")
+
+	// ErrUninitializedDB signals that top-level buckets for the database
+	// have not been initialized.
+	ErrUninitializedDB = errors.New("db not initialized")
+
+	// ErrCorruptChanSummary signals that the clients channel summary's
+	// on-disk structure deviates from what is expected.
+	ErrCorruptChanSummary = errors.New("channel summary corrupted")
+)
+
+// MigrateClientChannelDetails creates a new channel-details bucket that uses
+// channel IDs as sub-buckets where the channel summaries are moved to from the
+// channel summary bucket. If the migration is successful then the channel
+// summary bucket is deleted.
+func MigrateClientChannelDetails(tx kvdb.RwTx) error {
+	log.Infof("Migrating the tower client db to move the channel " +
+		"summaries to the new channel-details bucket")
+
+	// Create the new top level cChanDetailsBkt.
+	chanDetailsBkt, err := tx.CreateTopLevelBucket(cChanDetailsBkt)
+	if err != nil {
+		return err
+	}
+
+	// Get the top-level channel summaries bucket.
+	chanSummaryBkt := tx.ReadWriteBucket(cChanSummaryBkt)
+	if chanSummaryBkt == nil {
+		return ErrUninitializedDB
+	}
+
+	// Iterate over the cChanSummaryBkt's keys. Each key is a channel-id.
+	// For each of these, create a new sub-bucket with this key in
+	// cChanDetailsBkt. In this sub-bucket, add the cChannelSummary key with
+	// the encoded ClientChanSummary as the value.
+	err = chanSummaryBkt.ForEach(func(chanID, summary []byte) error {
+		// Force the migration to fail if the summary is empty. This
+		// should never be the case, but it is added so that we can
+		// force the migration to fail in a test so that we can test
+		// that the db remains unaffected if a migration failure takes
+		// place.
+		if len(summary) == 0 {
+			return ErrCorruptChanSummary
+		}
+
+		// Create a new sub-bucket in the channel details bucket using
+		// this channel ID.
+		channelBkt, err := chanDetailsBkt.CreateBucket(chanID)
+		if err != nil {
+			return err
+		}
+
+		// Add the encoded channel summary in the new bucket under the
+		// channel-summary key.
+		return channelBkt.Put(cChannelSummary, summary)
+	})
+	if err != nil {
+		return err
+	}
+
+	// Now delete the cChanSummaryBkt from the DB.
+	return tx.DeleteTopLevelBucket(cChanSummaryBkt)
+}

--- a/watchtower/wtdb/migration2/client_db_test.go
+++ b/watchtower/wtdb/migration2/client_db_test.go
@@ -1,0 +1,124 @@
+package migration2
+
+import (
+	"encoding/binary"
+	"testing"
+
+	"github.com/lightningnetwork/lnd/channeldb/migtest"
+	"github.com/lightningnetwork/lnd/kvdb"
+	"github.com/stretchr/testify/require"
+)
+
+var (
+
+	// pre is the expected data in the cChanSummaryBkt bucket before the
+	// migration.
+	pre = map[string]interface{}{
+		channelIDString(1): string([]byte{1, 2, 3}),
+		channelIDString(2): string([]byte{3, 4, 5}),
+	}
+
+	// pre should fail the migration due to no channel summary being found
+	// for a given channel ID.
+	preFailCorruptDB = map[string]interface{}{
+		channelIDString(1): string([]byte{1, 2, 3}),
+		channelIDString(2): "",
+	}
+
+	// post is the expected data after migration.
+	post = map[string]interface{}{
+		channelIDString(1): map[string]interface{}{
+			string(cChannelSummary): string([]byte{1, 2, 3}),
+		},
+		channelIDString(2): map[string]interface{}{
+			string(cChannelSummary): string([]byte{3, 4, 5}),
+		},
+	}
+)
+
+// TestMigrateClientChannelDetails tests that the MigrateClientChannelDetails
+// function correctly moves channel-summaries from the channel-summaries bucket
+// to the new channel-details bucket.
+func TestMigrateClientChannelDetails(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		shouldFail bool
+		pre        map[string]interface{}
+		post       map[string]interface{}
+	}{
+		{
+			name:       "migration ok",
+			shouldFail: false,
+			pre:        pre,
+			post:       post,
+		},
+		{
+			name:       "fail due to corrupt db",
+			shouldFail: true,
+			pre:        preFailCorruptDB,
+			post:       nil,
+		},
+		{
+			name:       "no channel summaries",
+			shouldFail: false,
+			pre:        nil,
+			post:       nil,
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			// Before the migration we have a channel summary
+			// bucket.
+			before := func(tx kvdb.RwTx) error {
+				return migtest.RestoreDB(
+					tx, cChanSummaryBkt, test.pre,
+				)
+			}
+
+			// After the migration, we should have a new channel
+			// details bucket and no longer have a channel summary
+			// bucket.
+			after := func(tx kvdb.RwTx) error {
+				// If we expect our migration to fail, we
+				// expect our channel summary bucket to remain
+				// intact.
+				if test.shouldFail {
+					return migtest.VerifyDB(
+						tx, cChanSummaryBkt, test.pre,
+					)
+				}
+
+				// Otherwise, we expect the channel summary
+				// bucket to be deleted.
+				err := migtest.VerifyDB(
+					tx, cChanSummaryBkt, test.pre,
+				)
+				require.ErrorContains(t, err, "not found")
+
+				// We also expect the new channel details bucket
+				// to be present.
+				return migtest.VerifyDB(
+					tx, cChanDetailsBkt, test.post,
+				)
+			}
+
+			migtest.ApplyMigration(
+				t, before, after, MigrateClientChannelDetails,
+				test.shouldFail,
+			)
+		})
+	}
+}
+
+func channelIDString(id uint64) string {
+	var chanID ChannelID
+	binary.BigEndian.PutUint64(chanID[:], id)
+	return chanID.String()
+}

--- a/watchtower/wtdb/migration2/codec.go
+++ b/watchtower/wtdb/migration2/codec.go
@@ -1,0 +1,17 @@
+package migration2
+
+import "encoding/hex"
+
+// ChannelID is a series of 32-bytes that uniquely identifies all channels
+// within the network. The ChannelID is computed using the outpoint of the
+// funding transaction (the txid, and output index). Given a funding output the
+// ChannelID can be calculated by XOR'ing the big-endian serialization of the
+// txid and the big-endian serialization of the output index, truncated to
+// 2 bytes.
+type ChannelID [32]byte
+
+// String returns the string representation of the ChannelID. This is just the
+// hex string encoding of the ChannelID itself.
+func (c ChannelID) String() string {
+	return hex.EncodeToString(c[:])
+}

--- a/watchtower/wtdb/migration2/log.go
+++ b/watchtower/wtdb/migration2/log.go
@@ -1,0 +1,14 @@
+package migration2
+
+import (
+	"github.com/btcsuite/btclog"
+)
+
+// log is a logger that is initialized as disabled.  This means the package will
+// not perform any logging by default until a logger is set.
+var log = btclog.Disabled
+
+// UseLogger uses a specified Logger to output package logging info.
+func UseLogger(logger btclog.Logger) {
+	log = logger
+}

--- a/watchtower/wtdb/migration3/client_db.go
+++ b/watchtower/wtdb/migration3/client_db.go
@@ -1,0 +1,104 @@
+package migration3
+
+import (
+	"bytes"
+	"encoding/binary"
+	"errors"
+
+	"github.com/lightningnetwork/lnd/kvdb"
+	"github.com/lightningnetwork/lnd/tlv"
+)
+
+var (
+	// cChanDetailsBkt is a top-level bucket storing:
+	//   channel-id => cChannelSummary -> encoded ClientChanSummary.
+	// 		=> cChanDBID -> db-assigned-id
+	cChanDetailsBkt = []byte("client-channel-detail-bucket")
+
+	// cChanDBID is a key used in the cChanDetailsBkt to store the
+	// db-assigned-id of a channel.
+	cChanDBID = []byte("client-channel-db-id")
+
+	// cChanIDIndexBkt is a top-level bucket storing:
+	//    db-assigned-id -> channel-ID
+	cChanIDIndexBkt = []byte("client-channel-id-index")
+
+	// cChannelSummary is a key used in cChanDetailsBkt to store the encoded
+	// body of ClientChanSummary.
+	cChannelSummary = []byte("client-channel-summary")
+
+	// ErrUninitializedDB signals that top-level buckets for the database
+	// have not been initialized.
+	ErrUninitializedDB = errors.New("db not initialized")
+
+	// ErrCorruptChanDetails signals that the clients channel detail's
+	// on-disk structure deviates from what is expected.
+	ErrCorruptChanDetails = errors.New("channel details corrupted")
+
+	byteOrder = binary.BigEndian
+)
+
+// MigrateChannelIDIndex adds a new channel ID index to the tower client db.
+// This index is a mapping from db-assigned ID (a uint64 encoded using BigSize
+// encoding) to real channel ID (32 bytes). This mapping will allow us to
+// persist channel pointers with fewer bytes in the future.
+func MigrateChannelIDIndex(tx kvdb.RwTx) error {
+	log.Infof("Migrating the tower client db to add a new channel ID " +
+		"index which stores a mapping from db-assigned ID to real " +
+		"channel ID")
+
+	// Create a new top-level bucket for the new index.
+	indexBkt, err := tx.CreateTopLevelBucket(cChanIDIndexBkt)
+	if err != nil {
+		return err
+	}
+
+	// Get the top-level channel-details bucket. The keys of this bucket
+	// are the real channel IDs.
+	chanDetailsBkt := tx.ReadWriteBucket(cChanDetailsBkt)
+	if chanDetailsBkt == nil {
+		return ErrUninitializedDB
+	}
+
+	// Iterate over the keys of the channel-details bucket.
+	return chanDetailsBkt.ForEach(func(chanID, _ []byte) error {
+		// Ask the db for a new, unique, ID for the index bucket.
+		nextSeq, err := indexBkt.NextSequence()
+		if err != nil {
+			return err
+		}
+
+		// Encode the sequence number using BigSize encoding.
+		var newIndex bytes.Buffer
+		err = tlv.WriteVarInt(&newIndex, nextSeq, &[8]byte{})
+		if err != nil {
+			return err
+		}
+
+		// Add the mapping from the db-assigned ID to the channel ID
+		// to the new index.
+		newIndexBytes := newIndex.Bytes()
+		err = indexBkt.Put(newIndexBytes, chanID)
+		if err != nil {
+			return err
+		}
+
+		chanDetails := chanDetailsBkt.NestedReadWriteBucket(chanID)
+		if chanDetails == nil {
+			return ErrCorruptChanDetails
+		}
+
+		// Here we ensure that the channel-details bucket includes a
+		// channel summary. The only reason we do this is so that we can
+		// simulate a migration fail in a test to ensure that a
+		// migration fail results in an untouched db.
+		chanSummaryBytes := chanDetails.Get(cChannelSummary)
+		if chanSummaryBytes == nil {
+			return ErrCorruptChanDetails
+		}
+
+		// In the channel-details sub-bucket for this channel, add the
+		// new DB-assigned ID for this channel under the cChanDBID key.
+		return chanDetails.Put(cChanDBID, newIndexBytes)
+	})
+}

--- a/watchtower/wtdb/migration3/client_db_test.go
+++ b/watchtower/wtdb/migration3/client_db_test.go
@@ -1,0 +1,149 @@
+package migration3
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/lightningnetwork/lnd/channeldb/migtest"
+	"github.com/lightningnetwork/lnd/kvdb"
+	"github.com/lightningnetwork/lnd/tlv"
+)
+
+var (
+
+	// pre is the expected data in the cChanDetailsBkt bucket before the
+	// migration.
+	pre = map[string]interface{}{
+		channelIDString(100): map[string]interface{}{
+			string(cChannelSummary): string([]byte{1, 2, 3}),
+		},
+		channelIDString(222): map[string]interface{}{
+			string(cChannelSummary): string([]byte{4, 5, 6}),
+		},
+	}
+
+	// preFailCorruptDB should fail the migration due to no channel summary
+	// being found for a given channel ID.
+	preFailCorruptDB = map[string]interface{}{
+		channelIDString(100): map[string]interface{}{},
+	}
+
+	// post is the expected data in the new index after migration.
+	postIndex = map[string]interface{}{
+		indexToString(1): channelIDString(100),
+		indexToString(2): channelIDString(222),
+	}
+
+	// postDetails is the expected data in the cChanDetailsBkt bucket after
+	// the migration.
+	postDetails = map[string]interface{}{
+		channelIDString(100): map[string]interface{}{
+			string(cChannelSummary): string([]byte{1, 2, 3}),
+			string(cChanDBID):       indexToString(1),
+		},
+		channelIDString(222): map[string]interface{}{
+			string(cChannelSummary): string([]byte{4, 5, 6}),
+			string(cChanDBID):       indexToString(2),
+		},
+	}
+)
+
+// TestMigrateChannelIDIndex tests that the MigrateChannelIDIndex function
+// correctly adds a new channel-id index to the DB and also correctly updates
+// the existing channel-details bucket.
+func TestMigrateChannelIDIndex(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		shouldFail  bool
+		pre         map[string]interface{}
+		postDetails map[string]interface{}
+		postIndex   map[string]interface{}
+	}{
+		{
+			name:        "migration ok",
+			shouldFail:  false,
+			pre:         pre,
+			postDetails: postDetails,
+			postIndex:   postIndex,
+		},
+		{
+			name:       "fail due to corrupt db",
+			shouldFail: true,
+			pre:        preFailCorruptDB,
+		},
+		{
+			name:        "no channel details",
+			shouldFail:  false,
+			pre:         nil,
+			postDetails: nil,
+			postIndex:   nil,
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			// Before the migration we have a details bucket.
+			before := func(tx kvdb.RwTx) error {
+				return migtest.RestoreDB(
+					tx, cChanDetailsBkt, test.pre,
+				)
+			}
+
+			// After the migration, we should have an untouched
+			// summary bucket and a new index bucket.
+			after := func(tx kvdb.RwTx) error {
+				// If the migration fails, the details bucket
+				// should be untouched.
+				if test.shouldFail {
+					if err := migtest.VerifyDB(
+						tx, cChanDetailsBkt, test.pre,
+					); err != nil {
+						return err
+					}
+
+					return nil
+				}
+
+				// Else, we expect an updated summary bucket
+				// and a new index bucket.
+				err := migtest.VerifyDB(
+					tx, cChanDetailsBkt, test.postDetails,
+				)
+				if err != nil {
+					return err
+				}
+
+				return migtest.VerifyDB(
+					tx, cChanIDIndexBkt, test.postIndex,
+				)
+			}
+
+			migtest.ApplyMigration(
+				t, before, after, MigrateChannelIDIndex,
+				test.shouldFail,
+			)
+		})
+	}
+}
+
+func indexToString(id uint64) string {
+	var newIndex bytes.Buffer
+	err := tlv.WriteVarInt(&newIndex, id, &[8]byte{})
+	if err != nil {
+		panic(err)
+	}
+
+	return newIndex.String()
+}
+
+func channelIDString(id uint64) string {
+	var chanID ChannelID
+	byteOrder.PutUint64(chanID[:], id)
+	return chanID.String()
+}

--- a/watchtower/wtdb/migration3/codec.go
+++ b/watchtower/wtdb/migration3/codec.go
@@ -1,0 +1,19 @@
+package migration3
+
+import (
+	"encoding/hex"
+)
+
+// ChannelID is a series of 32-bytes that uniquely identifies all channels
+// within the network. The ChannelID is computed using the outpoint of the
+// funding transaction (the txid, and output index). Given a funding output the
+// ChannelID can be calculated by XOR'ing the big-endian serialization of the
+// txid and the big-endian serialization of the output index, truncated to
+// 2 bytes.
+type ChannelID [32]byte
+
+// String returns the string representation of the ChannelID. This is just the
+// hex string encoding of the ChannelID itself.
+func (c ChannelID) String() string {
+	return hex.EncodeToString(c[:])
+}

--- a/watchtower/wtdb/migration3/log.go
+++ b/watchtower/wtdb/migration3/log.go
@@ -1,0 +1,14 @@
+package migration3
+
+import (
+	"github.com/btcsuite/btclog"
+)
+
+// log is a logger that is initialized as disabled.  This means the package will
+// not perform any logging by default until a logger is set.
+var log = btclog.Disabled
+
+// UseLogger uses a specified Logger to output package logging info.
+func UseLogger(logger btclog.Logger) {
+	log = logger
+}

--- a/watchtower/wtdb/migration4/client_db.go
+++ b/watchtower/wtdb/migration4/client_db.go
@@ -1,0 +1,628 @@
+package migration4
+
+import (
+	"bytes"
+	"encoding/binary"
+	"errors"
+	"fmt"
+
+	"github.com/lightningnetwork/lnd/kvdb"
+	"github.com/lightningnetwork/lnd/tlv"
+)
+
+var (
+	// cChanDetailsBkt is a top-level bucket storing:
+	//   channel-id => cChannelSummary -> encoded ClientChanSummary.
+	// 		=> cChanDBID -> db-assigned-id
+	cChanDetailsBkt = []byte("client-channel-detail-bucket")
+
+	// cChanDBID is a key used in the cChanDetailsBkt to store the
+	// db-assigned-id of a channel.
+	cChanDBID = []byte("client-channel-db-id")
+
+	// cSessionBkt is a top-level bucket storing:
+	//   session-id => cSessionBody -> encoded ClientSessionBody
+	//              => cSessionCommits => seqnum -> encoded CommittedUpdate
+	//              => cSessionAcks => seqnum -> encoded BackupID
+	cSessionBkt = []byte("client-session-bucket")
+
+	// cSessionAcks is a sub-bucket of cSessionBkt storing:
+	//    seqnum -> encoded BackupID.
+	cSessionAcks = []byte("client-session-acks")
+
+	// cSessionAckRangeIndex is a sub-bucket of cSessionBkt storing:
+	//    chan-id => start -> end
+	cSessionAckRangeIndex = []byte("client-session-ack-range-index")
+
+	// ErrUninitializedDB signals that top-level buckets for the database
+	// have not been initialized.
+	ErrUninitializedDB = errors.New("db not initialized")
+
+	// ErrClientSessionNotFound signals that the requested client session
+	// was not found in the database.
+	ErrClientSessionNotFound = errors.New("client session not found")
+
+	// ErrCorruptChanDetails signals that the clients channel detail's
+	// on-disk structure deviates from what is expected.
+	ErrCorruptChanDetails = errors.New("channel details corrupted")
+
+	// ErrChannelNotRegistered signals a channel has not yet been registered
+	// in the client database.
+	ErrChannelNotRegistered = errors.New("channel not registered")
+
+	// byteOrder is the default endianness used when serializing integers.
+	byteOrder = binary.BigEndian
+
+	// errExit is an error used to signal that the sessionIterator should
+	// exit.
+	errExit = errors.New("the exit condition has been met")
+)
+
+// DefaultSessionsPerTx is the default number of sessions that should be
+// migrated per db transaction.
+const DefaultSessionsPerTx = 5000
+
+// MigrateAckedUpdates migrates the tower client DB. It takes the individual
+// Acked Updates that are stored for each session and re-stores them using the
+// RangeIndex representation.
+func MigrateAckedUpdates(sessionsPerTx int) func(kvdb.Backend) error {
+	return func(db kvdb.Backend) error {
+		log.Infof("Migrating the tower client db to move all Acked " +
+			"Updates to the new Range Index representation.")
+
+		// Migrate the old acked-updates.
+		err := migrateAckedUpdates(db, sessionsPerTx)
+		if err != nil {
+			return fmt.Errorf("migration failed: %w", err)
+		}
+
+		log.Infof("Migrating old session acked updates finished, now " +
+			"checking the migration results...")
+
+		// Before we can safety delete the old buckets, we perform a
+		// check to make sure the sessions have been migrated as
+		// expected.
+		err = kvdb.View(db, validateMigration, func() {})
+		if err != nil {
+			return fmt.Errorf("validate migration failed: %w", err)
+		}
+
+		// Delete old acked updates.
+		err = kvdb.Update(db, deleteOldAckedUpdates, func() {})
+		if err != nil {
+			return fmt.Errorf("failed to delete old acked "+
+				"updates: %w", err)
+		}
+
+		return nil
+	}
+}
+
+// migrateAckedUpdates migrates the acked updates of each session in the
+// wtclient db into the new RangeIndex form. This is done over multiple db
+// transactions in order to prevent the migration from taking up too much RAM.
+// The sessionsPerTx parameter can be used to set the maximum number of sessions
+// that should be migrated per transaction.
+func migrateAckedUpdates(db kvdb.Backend, sessionsPerTx int) error {
+	// Get migration progress stats.
+	total, migrated, err := logMigrationStats(db)
+	if err != nil {
+		return err
+	}
+	log.Infof("Total sessions=%d, migrated=%d", total, migrated)
+
+	// Exit early if the old session acked updates have already been
+	// migrated and deleted.
+	if total == 0 {
+		log.Info("Migration already finished!")
+		return nil
+	}
+
+	var (
+		finished bool
+		startKey []byte
+	)
+	for {
+		// Process the migration.
+		err = kvdb.Update(db, func(tx kvdb.RwTx) error {
+			startKey, finished, err = processMigration(
+				tx, startKey, sessionsPerTx,
+			)
+
+			return err
+		}, func() {})
+		if err != nil {
+			return err
+		}
+
+		if finished {
+			break
+		}
+
+		// Each time we finished the above process, we'd read the stats
+		// again to understand the current progress.
+		total, migrated, err = logMigrationStats(db)
+		if err != nil {
+			return err
+		}
+
+		// Calculate and log the progress if the progress is less than
+		// one hundred percent.
+		//nolint:gomnd
+		progress := float64(migrated) / float64(total) * 100
+		if progress >= 100 { //nolint:gomnd
+			break
+		}
+
+		log.Infof("Migration progress: %.3f%%, still have: %d",
+			progress, total-migrated)
+	}
+
+	return nil
+}
+
+func validateMigration(tx kvdb.RTx) error {
+	mainSessionsBkt := tx.ReadBucket(cSessionBkt)
+	if mainSessionsBkt == nil {
+		return ErrUninitializedDB
+	}
+
+	chanDetailsBkt := tx.ReadBucket(cChanDetailsBkt)
+	if chanDetailsBkt == nil {
+		return ErrUninitializedDB
+	}
+
+	return mainSessionsBkt.ForEach(func(sessID, _ []byte) error {
+		// Get the bucket for this particular session.
+		sessionBkt := mainSessionsBkt.NestedReadBucket(sessID)
+		if sessionBkt == nil {
+			return ErrClientSessionNotFound
+		}
+
+		// Get the bucket where any old acked updates would be stored.
+		oldAcksBucket := sessionBkt.NestedReadBucket(cSessionAcks)
+
+		// Get the bucket where any new acked updates would be stored.
+		newAcksBucket := sessionBkt.NestedReadBucket(
+			cSessionAckRangeIndex,
+		)
+
+		switch {
+		// If both the old and new acked updates buckets are nil, then
+		// we can safely skip this session.
+		case oldAcksBucket == nil && newAcksBucket == nil:
+			return nil
+
+		case oldAcksBucket == nil:
+			return fmt.Errorf("no old acks but do have new acks")
+
+		case newAcksBucket == nil:
+			return fmt.Errorf("no new acks but have old acks")
+
+		default:
+		}
+
+		// Collect acked ranges for this session.
+		ackedRanges := make(map[uint64]*RangeIndex)
+		err := newAcksBucket.ForEach(func(dbChanID, _ []byte) error {
+			rangeIndexBkt := newAcksBucket.NestedReadBucket(
+				dbChanID,
+			)
+			if rangeIndexBkt == nil {
+				return fmt.Errorf("no acked updates bucket "+
+					"found for channel %x", dbChanID)
+			}
+
+			// Read acked ranges from new bucket.
+			ri, err := readRangeIndex(rangeIndexBkt)
+			if err != nil {
+				return err
+			}
+
+			dbChanIDNum, err := readBigSize(dbChanID)
+			if err != nil {
+				return err
+			}
+
+			ackedRanges[dbChanIDNum] = ri
+
+			return nil
+		})
+		if err != nil {
+			return err
+		}
+
+		// Now we will iterate through each of the old acked updates and
+		// make sure that the update appears in the new bucket.
+		return oldAcksBucket.ForEach(func(_, v []byte) error {
+			var backupID BackupID
+			err := backupID.Decode(bytes.NewReader(v))
+			if err != nil {
+				return err
+			}
+
+			dbChanID, _, err := getDBChanID(
+				chanDetailsBkt, backupID.ChanID,
+			)
+			if err != nil {
+				return err
+			}
+
+			index, ok := ackedRanges[dbChanID]
+			if !ok {
+				return fmt.Errorf("no index found for this " +
+					"channel")
+			}
+
+			if !index.IsInIndex(backupID.CommitHeight) {
+				return fmt.Errorf("commit height not found " +
+					"in index")
+			}
+
+			return nil
+		})
+	})
+}
+
+func readRangeIndex(rangesBkt kvdb.RBucket) (*RangeIndex, error) {
+	ranges := make(map[uint64]uint64)
+	err := rangesBkt.ForEach(func(k, v []byte) error {
+		start, err := readBigSize(k)
+		if err != nil {
+			return err
+		}
+
+		end, err := readBigSize(v)
+		if err != nil {
+			return err
+		}
+
+		ranges[start] = end
+
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return NewRangeIndex(ranges, WithSerializeUint64Fn(writeBigSize))
+}
+
+func deleteOldAckedUpdates(tx kvdb.RwTx) error {
+	mainSessionsBkt := tx.ReadWriteBucket(cSessionBkt)
+	if mainSessionsBkt == nil {
+		return ErrUninitializedDB
+	}
+
+	return mainSessionsBkt.ForEach(func(sessID, _ []byte) error {
+		// Get the bucket for this particular session.
+		sessionBkt := mainSessionsBkt.NestedReadWriteBucket(
+			sessID,
+		)
+		if sessionBkt == nil {
+			return ErrClientSessionNotFound
+		}
+
+		// Get the bucket where any old acked updates would be stored.
+		oldAcksBucket := sessionBkt.NestedReadBucket(cSessionAcks)
+		if oldAcksBucket == nil {
+			return nil
+		}
+
+		// Now that we have read everything that we need to from
+		// the cSessionAcks sub-bucket, we can delete it.
+		return sessionBkt.DeleteNestedBucket(cSessionAcks)
+	})
+}
+
+// processMigration uses the given transaction to perform a maximum of
+// sessionsPerTx session migrations. If startKey is non-nil, it is used to
+// determine the first session to start the migration at. The first return
+// item is the key of the last session that was migrated successfully and the
+// boolean is true if there are no more sessions left to migrate.
+func processMigration(tx kvdb.RwTx, startKey []byte, sessionsPerTx int) ([]byte,
+	bool, error) {
+
+	chanDetailsBkt := tx.ReadWriteBucket(cChanDetailsBkt)
+	if chanDetailsBkt == nil {
+		return nil, false, ErrUninitializedDB
+	}
+
+	// sessionCount keeps track of the number of sessions that have been
+	// migrated under the current db transaction.
+	var sessionCount int
+
+	// migrateSessionCB is a callback function that calls migrateSession
+	// in order to migrate a single session. Upon success, the sessionCount
+	// is incremented and is then compared against sessionsPerTx to
+	// determine if we should continue migrating more sessions in this db
+	// transaction.
+	migrateSessionCB := func(sessionBkt kvdb.RwBucket) error {
+		err := migrateSession(chanDetailsBkt, sessionBkt)
+		if err != nil {
+			return err
+		}
+
+		sessionCount++
+
+		// If we have migrated sessionsPerTx sessions in this tx, then
+		// we return errExit in order to signal that this tx should be
+		// committed and the migration should be continued in a new
+		// transaction.
+		if sessionCount >= sessionsPerTx {
+			return errExit
+		}
+
+		return nil
+	}
+
+	// Starting at startKey, iterate over the sessions in the db and migrate
+	// them until either all are migrated or until the errExit signal is
+	// received.
+	lastKey, err := sessionIterator(tx, startKey, migrateSessionCB)
+	if err != nil && errors.Is(err, errExit) {
+		return lastKey, false, nil
+	} else if err != nil {
+		return nil, false, err
+	}
+
+	// The migration is complete.
+	return nil, true, nil
+}
+
+// migrateSession migrates a single session's acked-updates to the new
+// RangeIndex form.
+func migrateSession(chanDetailsBkt kvdb.RBucket,
+	sessionBkt kvdb.RwBucket) error {
+
+	// Get the existing cSessionAcks bucket. If there is no such bucket,
+	// then there are no acked-updates to migrate for this session.
+	sessionAcks := sessionBkt.NestedReadBucket(cSessionAcks)
+	if sessionAcks == nil {
+		return nil
+	}
+
+	// If there is already a new cSessionAckedRangeIndex bucket, then this
+	// session has already been migrated.
+	sessionAckRangesBkt := sessionBkt.NestedReadBucket(
+		cSessionAckRangeIndex,
+	)
+	if sessionAckRangesBkt != nil {
+		return nil
+	}
+
+	// Otherwise, we will iterate over each of the acked-updates, and we
+	// will construct a new RangeIndex for each channel.
+	m := make(map[ChannelID]*RangeIndex)
+	if err := sessionAcks.ForEach(func(_, v []byte) error {
+		var backupID BackupID
+		err := backupID.Decode(bytes.NewReader(v))
+		if err != nil {
+			return err
+		}
+
+		if _, ok := m[backupID.ChanID]; !ok {
+			index, err := NewRangeIndex(nil)
+			if err != nil {
+				return err
+			}
+
+			m[backupID.ChanID] = index
+		}
+
+		return m[backupID.ChanID].Add(backupID.CommitHeight, nil)
+	}); err != nil {
+		return err
+	}
+
+	// Create a new sub-bucket that will be used to store the new RangeIndex
+	// representation of the acked updates.
+	ackRangeBkt, err := sessionBkt.CreateBucket(cSessionAckRangeIndex)
+	if err != nil {
+		return err
+	}
+
+	// Iterate over each of the new range indexes that we will add for this
+	// session.
+	for chanID, rangeIndex := range m {
+		// Get db chanID.
+		chanDetails := chanDetailsBkt.NestedReadBucket(chanID[:])
+		if chanDetails == nil {
+			return ErrCorruptChanDetails
+		}
+
+		// Create a sub-bucket for this channel using the db-assigned ID
+		// for the channel.
+		dbChanID := chanDetails.Get(cChanDBID)
+		chanAcksBkt, err := ackRangeBkt.CreateBucket(dbChanID)
+		if err != nil {
+			return err
+		}
+
+		// Iterate over the range pairs that we need to add to the DB.
+		for k, v := range rangeIndex.GetAllRanges() {
+			start, err := writeBigSize(k)
+			if err != nil {
+				return err
+			}
+
+			end, err := writeBigSize(v)
+			if err != nil {
+				return err
+			}
+
+			err = chanAcksBkt.Put(start, end)
+			if err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+// logMigrationStats reads the buckets to provide stats over current migration
+// progress. The returned values are the numbers of total records and already
+// migrated records.
+func logMigrationStats(db kvdb.Backend) (uint64, uint64, error) {
+	var (
+		err        error
+		total      uint64
+		unmigrated uint64
+	)
+
+	err = kvdb.View(db, func(tx kvdb.RTx) error {
+		total, unmigrated, err = getMigrationStats(tx)
+
+		return err
+	}, func() {})
+
+	log.Debugf("Total sessions=%d, unmigrated=%d", total, unmigrated)
+
+	return total, total - unmigrated, err
+}
+
+// getMigrationStats iterates over all sessions. It counts the total number of
+// sessions as well as the total number of unmigrated sessions.
+func getMigrationStats(tx kvdb.RTx) (uint64, uint64, error) {
+	var (
+		total      uint64
+		unmigrated uint64
+	)
+
+	// Get sessions bucket.
+	mainSessionsBkt := tx.ReadBucket(cSessionBkt)
+	if mainSessionsBkt == nil {
+		return 0, 0, ErrUninitializedDB
+	}
+
+	// Iterate over each session ID in the bucket.
+	err := mainSessionsBkt.ForEach(func(sessID, _ []byte) error {
+		// Get the bucket for this particular session.
+		sessionBkt := mainSessionsBkt.NestedReadBucket(sessID)
+		if sessionBkt == nil {
+			return ErrClientSessionNotFound
+		}
+
+		total++
+
+		// Get the cSessionAckRangeIndex bucket.
+		sessionAcksBkt := sessionBkt.NestedReadBucket(cSessionAcks)
+
+		// Get the cSessionAckRangeIndex bucket.
+		sessionAckRangesBkt := sessionBkt.NestedReadBucket(
+			cSessionAckRangeIndex,
+		)
+
+		// If both buckets do not exist, then this session is empty and
+		// does not need to be migrated.
+		if sessionAckRangesBkt == nil && sessionAcksBkt == nil {
+			return nil
+		}
+
+		// If the sessionAckRangesBkt is not nil, then the session has
+		// already been migrated.
+		if sessionAckRangesBkt != nil {
+			return nil
+		}
+
+		// Else the session has not yet been migrated.
+		unmigrated++
+
+		return nil
+	})
+	if err != nil {
+		return 0, 0, err
+	}
+
+	return total, unmigrated, nil
+}
+
+// getDBChanID returns the db-assigned channel ID for the given real channel ID.
+// It returns both the uint64 and byte representation.
+func getDBChanID(chanDetailsBkt kvdb.RBucket, chanID ChannelID) (uint64,
+	[]byte, error) {
+
+	chanDetails := chanDetailsBkt.NestedReadBucket(chanID[:])
+	if chanDetails == nil {
+		return 0, nil, ErrChannelNotRegistered
+	}
+
+	idBytes := chanDetails.Get(cChanDBID)
+	if len(idBytes) == 0 {
+		return 0, nil, fmt.Errorf("no db-assigned ID found for "+
+			"channel ID %s", chanID)
+	}
+
+	id, err := readBigSize(idBytes)
+	if err != nil {
+		return 0, nil, err
+	}
+
+	return id, idBytes, nil
+}
+
+// callback defines a type that's used by the sessionIterator.
+type callback func(bkt kvdb.RwBucket) error
+
+// sessionIterator is a helper function that iterates over the main sessions
+// bucket and performs the callback function on each individual session. If a
+// seeker is specified, it will move the cursor to the given position otherwise
+// it will start from the first item.
+func sessionIterator(tx kvdb.RwTx, seeker []byte, cb callback) ([]byte, error) {
+	// Get sessions bucket.
+	mainSessionsBkt := tx.ReadWriteBucket(cSessionBkt)
+	if mainSessionsBkt == nil {
+		return nil, ErrUninitializedDB
+	}
+
+	c := mainSessionsBkt.ReadCursor()
+	k, _ := c.First()
+
+	// Move the cursor to the specified position if seeker is non-nil.
+	if seeker != nil {
+		k, _ = c.Seek(seeker)
+	}
+
+	// Start the iteration and exit on condition.
+	for k := k; k != nil; k, _ = c.Next() {
+		// Get the bucket for this particular session.
+		bkt := mainSessionsBkt.NestedReadWriteBucket(k)
+		if bkt == nil {
+			return nil, ErrClientSessionNotFound
+		}
+
+		// Call the callback function with the session's bucket.
+		if err := cb(bkt); err != nil {
+			// return k, err
+			lastIndex := make([]byte, len(k))
+			copy(lastIndex, k)
+			return lastIndex, err
+		}
+	}
+
+	return nil, nil
+}
+
+// writeBigSize will encode the given uint64 as a BigSize byte slice.
+func writeBigSize(i uint64) ([]byte, error) {
+	var b bytes.Buffer
+	err := tlv.WriteVarInt(&b, i, &[8]byte{})
+	if err != nil {
+		return nil, err
+	}
+
+	return b.Bytes(), nil
+}
+
+// readBigSize converts the given byte slice into a uint64 and assumes that the
+// bytes slice is using BigSize encoding.
+func readBigSize(b []byte) (uint64, error) {
+	r := bytes.NewReader(b)
+	i, err := tlv.ReadVarInt(r, &[8]byte{})
+	if err != nil {
+		return 0, err
+	}
+
+	return i, nil
+}

--- a/watchtower/wtdb/migration4/client_db_test.go
+++ b/watchtower/wtdb/migration4/client_db_test.go
@@ -1,0 +1,329 @@
+package migration4
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/btcsuite/btcwallet/walletdb"
+	"github.com/lightningnetwork/lnd/channeldb/migtest"
+	"github.com/lightningnetwork/lnd/kvdb"
+)
+
+var (
+	// details is the expected data of the channel details bucket. This
+	// bucket should not be changed during the migration, but it is used
+	// to find the db-assigned ID for each channel.
+	details = map[string]interface{}{
+		channelIDString(1): map[string]interface{}{
+			string(cChanDBID): uint64ToStr(10),
+		},
+		channelIDString(2): map[string]interface{}{
+			string(cChanDBID): uint64ToStr(20),
+		},
+	}
+
+	// preSessions is the expected data in the sessions bucket before the
+	// migration.
+	preSessions = map[string]interface{}{
+		sessionIDString("1"): map[string]interface{}{
+			string(cSessionAcks): map[string]interface{}{
+				"1": backupIDToString(&BackupID{
+					ChanID:       intToChannelID(1),
+					CommitHeight: 30,
+				}),
+				"2": backupIDToString(&BackupID{
+					ChanID:       intToChannelID(1),
+					CommitHeight: 31,
+				}),
+				"3": backupIDToString(&BackupID{
+					ChanID:       intToChannelID(1),
+					CommitHeight: 32,
+				}),
+				"4": backupIDToString(&BackupID{
+					ChanID:       intToChannelID(1),
+					CommitHeight: 34,
+				}),
+				"5": backupIDToString(&BackupID{
+					ChanID:       intToChannelID(2),
+					CommitHeight: 30,
+				}),
+			},
+		},
+		sessionIDString("2"): map[string]interface{}{
+			string(cSessionAcks): map[string]interface{}{
+				"1": backupIDToString(&BackupID{
+					ChanID:       intToChannelID(1),
+					CommitHeight: 33,
+				}),
+			},
+		},
+		sessionIDString("3"): map[string]interface{}{
+			string(cSessionAcks): map[string]interface{}{
+				"1": backupIDToString(&BackupID{
+					ChanID:       intToChannelID(1),
+					CommitHeight: 35,
+				}),
+				"2": backupIDToString(&BackupID{
+					ChanID:       intToChannelID(1),
+					CommitHeight: 36,
+				}),
+				"3": backupIDToString(&BackupID{
+					ChanID:       intToChannelID(2),
+					CommitHeight: 28,
+				}),
+				"4": backupIDToString(&BackupID{
+					ChanID:       intToChannelID(2),
+					CommitHeight: 29,
+				}),
+			},
+		},
+	}
+
+	// preMidStateDB is a possible state that the db could be in if the
+	// migration started but was interrupted before completing. In this
+	// state, some sessions still have the old cSessionAcks bucket along
+	// with the new cSessionAckRangeIndex. This is a valid pre-state and
+	// a migration on this state should succeed.
+	preMidStateDB = map[string]interface{}{
+		sessionIDString("1"): map[string]interface{}{
+			string(cSessionAcks): map[string]interface{}{
+				"1": backupIDToString(&BackupID{
+					ChanID:       intToChannelID(1),
+					CommitHeight: 30,
+				}),
+				"2": backupIDToString(&BackupID{
+					ChanID:       intToChannelID(1),
+					CommitHeight: 31,
+				}),
+				"3": backupIDToString(&BackupID{
+					ChanID:       intToChannelID(1),
+					CommitHeight: 32,
+				}),
+				"4": backupIDToString(&BackupID{
+					ChanID:       intToChannelID(1),
+					CommitHeight: 34,
+				}),
+				"5": backupIDToString(&BackupID{
+					ChanID:       intToChannelID(2),
+					CommitHeight: 30,
+				}),
+			},
+			string(cSessionAckRangeIndex): map[string]interface{}{
+				uint64ToStr(10): map[string]interface{}{
+					uint64ToStr(30): uint64ToStr(32),
+					uint64ToStr(34): uint64ToStr(34),
+				},
+				uint64ToStr(20): map[string]interface{}{
+					uint64ToStr(30): uint64ToStr(30),
+				},
+			},
+		},
+		sessionIDString("2"): map[string]interface{}{
+			string(cSessionAcks): map[string]interface{}{
+				"1": backupIDToString(&BackupID{
+					ChanID:       intToChannelID(1),
+					CommitHeight: 33,
+				}),
+			},
+		},
+		sessionIDString("3"): map[string]interface{}{
+			string(cSessionAcks): map[string]interface{}{
+				"1": backupIDToString(&BackupID{
+					ChanID:       intToChannelID(1),
+					CommitHeight: 35,
+				}),
+				"2": backupIDToString(&BackupID{
+					ChanID:       intToChannelID(1),
+					CommitHeight: 36,
+				}),
+				"3": backupIDToString(&BackupID{
+					ChanID:       intToChannelID(2),
+					CommitHeight: 28,
+				}),
+				"4": backupIDToString(&BackupID{
+					ChanID:       intToChannelID(2),
+					CommitHeight: 29,
+				}),
+			},
+		},
+	}
+
+	// preFailCorruptDB should fail the migration due to no session data
+	// being found for a given session ID.
+	preFailCorruptDB = map[string]interface{}{
+		sessionIDString("2"): "",
+	}
+
+	// postSessions is the expected data in the sessions bucket after the
+	// migration.
+	postSessions = map[string]interface{}{
+		sessionIDString("1"): map[string]interface{}{
+			string(cSessionAckRangeIndex): map[string]interface{}{
+				uint64ToStr(10): map[string]interface{}{
+					uint64ToStr(30): uint64ToStr(32),
+					uint64ToStr(34): uint64ToStr(34),
+				},
+				uint64ToStr(20): map[string]interface{}{
+					uint64ToStr(30): uint64ToStr(30),
+				},
+			},
+		},
+		sessionIDString("2"): map[string]interface{}{
+			string(cSessionAckRangeIndex): map[string]interface{}{
+				uint64ToStr(10): map[string]interface{}{
+					uint64ToStr(33): uint64ToStr(33),
+				},
+			},
+		},
+		sessionIDString("3"): map[string]interface{}{
+			string(cSessionAckRangeIndex): map[string]interface{}{
+				uint64ToStr(10): map[string]interface{}{
+					uint64ToStr(35): uint64ToStr(36),
+				},
+				uint64ToStr(20): map[string]interface{}{
+					uint64ToStr(28): uint64ToStr(29),
+				},
+			},
+		},
+	}
+)
+
+// TestMigrateAckedUpdates tests that the MigrateAckedUpdates function correctly
+// migrates the existing AckedUpdates bucket for each session to the new
+// RangeIndex representation.
+func TestMigrateAckedUpdates(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		shouldFail bool
+		pre        map[string]interface{}
+		post       map[string]interface{}
+	}{
+		{
+			name:       "migration ok",
+			shouldFail: false,
+			pre:        preSessions,
+			post:       postSessions,
+		},
+		{
+			name:       "migration ok after re-starting",
+			shouldFail: false,
+			pre:        preMidStateDB,
+			post:       postSessions,
+		},
+		{
+			name:       "fail due to corrupt db",
+			shouldFail: true,
+			pre:        preFailCorruptDB,
+		},
+		{
+			name:       "no sessions details",
+			shouldFail: false,
+			pre:        nil,
+			post:       nil,
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			before := before(test.pre)
+
+			// After the migration, we should have an untouched
+			// summary bucket and a new index bucket.
+			after := after(test.shouldFail, test.pre, test.post)
+
+			migtest.ApplyMigrationWithDb(
+				t, before, after, MigrateAckedUpdates(2),
+				test.shouldFail,
+			)
+		})
+	}
+}
+
+// before returns a call-back function that can be used to set up a db's
+// cChanDetailsBkt along with the cSessionBkt using the passed preMigDB
+// structure.
+func before(preMigDB map[string]interface{}) func(backend kvdb.Backend) error {
+	return func(db kvdb.Backend) error {
+		return db.Update(func(tx walletdb.ReadWriteTx) error {
+			err := migtest.RestoreDB(
+				tx, cChanDetailsBkt, details,
+			)
+			if err != nil {
+				return err
+			}
+
+			return migtest.RestoreDB(
+				tx, cSessionBkt, preMigDB,
+			)
+		}, func() {})
+	}
+}
+
+// after returns a call-back function that can be used to verify the state of
+// a db post migration.
+func after(shouldFail bool, preMigDB,
+	postMigDB map[string]interface{}) func(backend kvdb.Backend) error {
+
+	return func(db kvdb.Backend) error {
+		return db.Update(func(tx walletdb.ReadWriteTx) error {
+			// The channel details bucket should remain untouched.
+			err := migtest.VerifyDB(tx, cChanDetailsBkt, details)
+			if err != nil {
+				return err
+			}
+
+			// If the migration fails, the sessions bucket should be
+			// untouched.
+			if shouldFail {
+				if err := migtest.VerifyDB(
+					tx, cSessionBkt, preMigDB,
+				); err != nil {
+					return err
+				}
+
+				return nil
+			}
+
+			return migtest.VerifyDB(tx, cSessionBkt, postMigDB)
+		}, func() {})
+	}
+}
+
+func sessionIDString(id string) string {
+	var sessID SessionID
+	copy(sessID[:], id)
+	return sessID.String()
+}
+
+func intToChannelID(id uint64) ChannelID {
+	var chanID ChannelID
+	byteOrder.PutUint64(chanID[:], id)
+	return chanID
+}
+
+func channelIDString(id uint64) string {
+	var chanID ChannelID
+	byteOrder.PutUint64(chanID[:], id)
+	return string(chanID[:])
+}
+
+func uint64ToStr(id uint64) string {
+	b, err := writeBigSize(id)
+	if err != nil {
+		panic(err)
+	}
+
+	return string(b)
+}
+
+func backupIDToString(backup *BackupID) string {
+	var b bytes.Buffer
+	_ = backup.Encode(&b)
+	return b.String()
+}

--- a/watchtower/wtdb/migration4/codec.go
+++ b/watchtower/wtdb/migration4/codec.go
@@ -1,0 +1,129 @@
+package migration4
+
+import (
+	"encoding/binary"
+	"encoding/hex"
+	"fmt"
+	"io"
+)
+
+// SessionIDSize is 33-bytes; it is a serialized, compressed public key.
+const SessionIDSize = 33
+
+// SessionID is created from the remote public key of a client, and serves as a
+// unique identifier and authentication for sending state updates.
+type SessionID [SessionIDSize]byte
+
+// String returns a hex encoding of the session id.
+func (s SessionID) String() string {
+	return hex.EncodeToString(s[:])
+}
+
+// ChannelID is a series of 32-bytes that uniquely identifies all channels
+// within the network. The ChannelID is computed using the outpoint of the
+// funding transaction (the txid, and output index). Given a funding output the
+// ChannelID can be calculated by XOR'ing the big-endian serialization of the
+// txid and the big-endian serialization of the output index, truncated to
+// 2 bytes.
+type ChannelID [32]byte
+
+// String returns the string representation of the ChannelID. This is just the
+// hex string encoding of the ChannelID itself.
+func (c ChannelID) String() string {
+	return hex.EncodeToString(c[:])
+}
+
+// BackupID identifies a particular revoked, remote commitment by channel id and
+// commitment height.
+type BackupID struct {
+	// ChanID is the channel id of the revoked commitment.
+	ChanID ChannelID
+
+	// CommitHeight is the commitment height of the revoked commitment.
+	CommitHeight uint64
+}
+
+// Encode writes the BackupID from the passed io.Writer.
+func (b *BackupID) Encode(w io.Writer) error {
+	return WriteElements(w,
+		b.ChanID,
+		b.CommitHeight,
+	)
+}
+
+// Decode reads a BackupID from the passed io.Reader.
+func (b *BackupID) Decode(r io.Reader) error {
+	return ReadElements(r,
+		&b.ChanID,
+		&b.CommitHeight,
+	)
+}
+
+// String returns a human-readable encoding of a BackupID.
+func (b BackupID) String() string {
+	return fmt.Sprintf("backup(%v, %d)", b.ChanID, b.CommitHeight)
+}
+
+// WriteElements serializes a variadic list of elements into the given
+// io.Writer.
+func WriteElements(w io.Writer, elements ...interface{}) error {
+	for _, element := range elements {
+		if err := WriteElement(w, element); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// ReadElements deserializes the provided io.Reader into a variadic list of
+// target elements.
+func ReadElements(r io.Reader, elements ...interface{}) error {
+	for _, element := range elements {
+		if err := ReadElement(r, element); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// WriteElement serializes a single element into the provided io.Writer.
+func WriteElement(w io.Writer, element interface{}) error {
+	switch e := element.(type) {
+	case ChannelID:
+		if _, err := w.Write(e[:]); err != nil {
+			return err
+		}
+
+	case uint64:
+		if err := binary.Write(w, byteOrder, e); err != nil {
+			return err
+		}
+
+	default:
+		return fmt.Errorf("unexpected type")
+	}
+
+	return nil
+}
+
+// ReadElement deserializes a single element from the provided io.Reader.
+func ReadElement(r io.Reader, element interface{}) error {
+	switch e := element.(type) {
+	case *ChannelID:
+		if _, err := io.ReadFull(r, e[:]); err != nil {
+			return err
+		}
+
+	case *uint64:
+		if err := binary.Read(r, byteOrder, e); err != nil {
+			return err
+		}
+
+	default:
+		return fmt.Errorf("unexpected type")
+	}
+
+	return nil
+}

--- a/watchtower/wtdb/migration4/log.go
+++ b/watchtower/wtdb/migration4/log.go
@@ -1,0 +1,14 @@
+package migration4
+
+import (
+	"github.com/btcsuite/btclog"
+)
+
+// log is a logger that is initialized as disabled.  This means the package will
+// not perform any logging by default until a logger is set.
+var log = btclog.Disabled
+
+// UseLogger uses a specified Logger to output package logging info.
+func UseLogger(logger btclog.Logger) {
+	log = logger
+}

--- a/watchtower/wtdb/migration4/range_index.go
+++ b/watchtower/wtdb/migration4/range_index.go
@@ -1,0 +1,619 @@
+package migration4
+
+import (
+	"fmt"
+	"sync"
+)
+
+// rangeItem represents the start and end values of a range.
+type rangeItem struct {
+	start uint64
+	end   uint64
+}
+
+// RangeIndexOption describes the signature of a functional option that can be
+// used to modify the behaviour of a RangeIndex.
+type RangeIndexOption func(*RangeIndex)
+
+// WithSerializeUint64Fn is a functional option that can be used to set the
+// function to be used to do the serialization of a uint64 into a byte slice.
+func WithSerializeUint64Fn(fn func(uint64) ([]byte, error)) RangeIndexOption {
+	return func(index *RangeIndex) {
+		index.serializeUint64 = fn
+	}
+}
+
+// RangeIndex can be used to keep track of which numbers have been added to a
+// set. It does so by keeping track of a sorted list of rangeItems. Each
+// rangeItem has a start and end value of a range where all values in-between
+// have been added to the set. It works well in situations where it is expected
+// numbers in the set are not sparse.
+type RangeIndex struct {
+	// set is a sorted list of rangeItem.
+	set []rangeItem
+
+	// mu is used to ensure safe access to set.
+	mu sync.Mutex
+
+	// serializeUint64 is the function that can be used to convert a uint64
+	// to a byte slice.
+	serializeUint64 func(uint64) ([]byte, error)
+}
+
+// NewRangeIndex constructs a new RangeIndex. An initial set of ranges may be
+// passed to the function in the form of a map.
+func NewRangeIndex(ranges map[uint64]uint64,
+	opts ...RangeIndexOption) (*RangeIndex, error) {
+
+	index := &RangeIndex{
+		serializeUint64: defaultSerializeUint64,
+		set:             make([]rangeItem, 0),
+	}
+
+	// Apply any functional options.
+	for _, o := range opts {
+		o(index)
+	}
+
+	for s, e := range ranges {
+		if err := index.addRange(s, e); err != nil {
+			return nil, err
+		}
+	}
+
+	return index, nil
+}
+
+// addRange can be used to add an entire new range to the set. This method
+// should only ever be called by NewRangeIndex to initialise the in-memory
+// structure and so the RangeIndex mutex is not held during this method.
+func (a *RangeIndex) addRange(start, end uint64) error {
+	// Check that the given range is valid.
+	if start > end {
+		return fmt.Errorf("invalid range. Start height %d is larger "+
+			"than end height %d", start, end)
+	}
+
+	// min is a helper closure that will return the minimum of two uint64s.
+	min := func(a, b uint64) uint64 {
+		if a < b {
+			return a
+		}
+
+		return b
+	}
+
+	// max is a helper closure that will return the maximum of two uint64s.
+	max := func(a, b uint64) uint64 {
+		if a > b {
+			return a
+		}
+
+		return b
+	}
+
+	// Collect the ranges that fall before and after the new range along
+	// with the start and end values of the new range.
+	var before, after []rangeItem
+	for _, x := range a.set {
+		// If the new start value can't extend the current ranges end
+		// value, then the two cannot be merged. The range is added to
+		// the group of ranges that fall before the new range.
+		if x.end+1 < start {
+			before = append(before, x)
+			continue
+		}
+
+		// If the current ranges start value does not follow on directly
+		// from the new end value, then the two cannot be merged. The
+		// range is added to the group of ranges that fall after the new
+		// range.
+		if end+1 < x.start {
+			after = append(after, x)
+			continue
+		}
+
+		// Otherwise, there is an overlap and so the two can be merged.
+		start = min(start, x.start)
+		end = max(end, x.end)
+	}
+
+	// Re-construct the range index set.
+	a.set = append(append(before, rangeItem{
+		start: start,
+		end:   end,
+	}), after...)
+
+	return nil
+}
+
+// IsInIndex returns true if the given number is in the range set.
+func (a *RangeIndex) IsInIndex(n uint64) bool {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+
+	_, isCovered := a.lowerBoundIndex(n)
+
+	return isCovered
+}
+
+// NumInSet returns the number of items covered by the range set.
+func (a *RangeIndex) NumInSet() uint64 {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+
+	var numItems uint64
+	for _, r := range a.set {
+		numItems += r.end - r.start + 1
+	}
+
+	return numItems
+}
+
+// MaxHeight returns the highest number covered in the range.
+func (a *RangeIndex) MaxHeight() uint64 {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+
+	if len(a.set) == 0 {
+		return 0
+	}
+
+	return a.set[len(a.set)-1].end
+}
+
+// GetAllRanges returns a copy of the range set in the form of a map.
+func (a *RangeIndex) GetAllRanges() map[uint64]uint64 {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+
+	cp := make(map[uint64]uint64, len(a.set))
+	for _, item := range a.set {
+		cp[item.start] = item.end
+	}
+
+	return cp
+}
+
+// lowerBoundIndex returns the index of the RangeIndex that is most appropriate
+// for the new value, n. In other words, it returns the index of the rangeItem
+// set of the range where the start value is the highest start value in the set
+// that is still lower than or equal to the given number, n. The returned
+// boolean is true if the given number is already covered in the RangeIndex.
+// A returned index of -1 indicates that no lower bound range exists in the set.
+// Since the most likely case is that the new number will just extend the
+// highest range, a check is first done to see if this is the case which will
+// make the methods' computational complexity O(1). Otherwise, a binary search
+// is done which brings the computational complexity to O(log N).
+func (a *RangeIndex) lowerBoundIndex(n uint64) (int, bool) {
+	// If the set is empty, then there is no such index and the value
+	// definitely is not in the set.
+	if len(a.set) == 0 {
+		return -1, false
+	}
+
+	// In most cases, the last index item will be the one we want. So just
+	// do a quick check on that index first to avoid doing the binary
+	// search.
+	lastIndex := len(a.set) - 1
+	lastRange := a.set[lastIndex]
+	if lastRange.start <= n {
+		return lastIndex, lastRange.end >= n
+	}
+
+	// Otherwise, do a binary search to find the index of interest.
+	var (
+		low        = 0
+		high       = len(a.set) - 1
+		rangeIndex = -1
+	)
+	for {
+		mid := (low + high) / 2 //nolint: gomnd
+		currentRange := a.set[mid]
+
+		switch {
+		case currentRange.start > n:
+			// If the start of the range is greater than n, we can
+			// completely cut out that entire part of the array.
+			high = mid
+
+		case currentRange.start < n:
+			// If the range already includes the given height, we
+			// can stop searching now.
+			if currentRange.end >= n {
+				return mid, true
+			}
+
+			// If the start of the range is smaller than n, we can
+			// store this as the new best index to return.
+			rangeIndex = mid
+
+			// If low and mid are already equal, then increment low
+			// by 1. Exit if this means that low is now greater than
+			// high.
+			if low == mid {
+				low = mid + 1
+				if low > high {
+					return rangeIndex, false
+				}
+			} else {
+				low = mid
+			}
+
+			continue
+
+		default:
+			// If the height is equal to the start value of the
+			// current range that mid is pointing to, then the
+			// height is already covered.
+			return mid, true
+		}
+
+		// Exit if we have checked all the ranges.
+		if low == high {
+			break
+		}
+	}
+
+	return rangeIndex, false
+}
+
+// KVStore is an interface representing a key-value store.
+type KVStore interface {
+	// Put saves the specified key/value pair to the store. Keys that do not
+	// already exist are added and keys that already exist are overwritten.
+	Put(key, value []byte) error
+
+	// Delete removes the specified key from the bucket. Deleting a key that
+	// does not exist does not return an error.
+	Delete(key []byte) error
+}
+
+// Add adds a single number to the range set. It first attempts to apply the
+// necessary changes to the passed KV store and then only if this succeeds, will
+// the changes be applied to the in-memory structure.
+func (a *RangeIndex) Add(newHeight uint64, kv KVStore) error {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+
+	// Compute the changes that will need to be applied to both the sorted
+	// rangeItem array representation and the key-value store representation
+	// of the range index.
+	arrayChanges, kvStoreChanges := a.getChanges(newHeight)
+
+	// First attempt to apply the KV store changes. Only if this succeeds
+	// will we apply the changes to our in-memory range index structure.
+	err := a.applyKVChanges(kv, kvStoreChanges)
+	if err != nil {
+		return err
+	}
+
+	// Since the DB changes were successful, we can now commit the
+	// changes to our in-memory representation of the range set.
+	a.applyArrayChanges(arrayChanges)
+
+	return nil
+}
+
+// applyKVChanges applies the given set of kvChanges to a KV store. It is
+// assumed that a transaction is being held on the kv store so that if any
+// of the actions of the function fails, the changes will be reverted.
+func (a *RangeIndex) applyKVChanges(kv KVStore, changes *kvChanges) error {
+	// Exit early if there are no changes to apply.
+	if kv == nil || changes == nil {
+		return nil
+	}
+
+	// Check if any range pair needs to be deleted.
+	if changes.deleteKVKey != nil {
+		del, err := a.serializeUint64(*changes.deleteKVKey)
+		if err != nil {
+			return err
+		}
+
+		if err := kv.Delete(del); err != nil {
+			return err
+		}
+	}
+
+	start, err := a.serializeUint64(changes.key)
+	if err != nil {
+		return err
+	}
+
+	end, err := a.serializeUint64(changes.value)
+	if err != nil {
+		return err
+	}
+
+	return kv.Put(start, end)
+}
+
+// applyArrayChanges applies the given arrayChanges to the in-memory RangeIndex
+// itself. This should only be done once the persisted kv store changes have
+// already been applied.
+func (a *RangeIndex) applyArrayChanges(changes *arrayChanges) {
+	if changes == nil {
+		return
+	}
+
+	if changes.indexToDelete != nil {
+		a.set = append(
+			a.set[:*changes.indexToDelete],
+			a.set[*changes.indexToDelete+1:]...,
+		)
+	}
+
+	if changes.newIndex != nil {
+		switch {
+		case *changes.newIndex == 0:
+			a.set = append([]rangeItem{{
+				start: changes.start,
+				end:   changes.end,
+			}}, a.set...)
+
+		case *changes.newIndex == len(a.set):
+			a.set = append(a.set, rangeItem{
+				start: changes.start,
+				end:   changes.end,
+			})
+
+		default:
+			a.set = append(
+				a.set[:*changes.newIndex+1],
+				a.set[*changes.newIndex:]...,
+			)
+			a.set[*changes.newIndex] = rangeItem{
+				start: changes.start,
+				end:   changes.end,
+			}
+		}
+
+		return
+	}
+
+	if changes.indexToEdit != nil {
+		a.set[*changes.indexToEdit] = rangeItem{
+			start: changes.start,
+			end:   changes.end,
+		}
+	}
+}
+
+// arrayChanges encompasses the diff to apply to the sorted rangeItem array
+// representation of a range index. Such a diff will either include adding a
+// new range or editing an existing range. If an existing range is edited, then
+// the diff might also include deleting an index (this will be the case if the
+// editing of the one range results in the merge of another range).
+type arrayChanges struct {
+	start uint64
+	end   uint64
+
+	// newIndex, if set, is the index of the in-memory range array where a
+	// new range, [start:end], should be added. newIndex should never be
+	// set at the same time as indexToEdit or indexToDelete.
+	newIndex *int
+
+	// indexToDelete, if set, is the index of the sorted rangeItem array
+	// that should be deleted. This should be applied before reading the
+	// index value of indexToEdit. This should not be set at the same time
+	// as newIndex.
+	indexToDelete *int
+
+	// indexToEdit is the index of the in-memory range array that should be
+	// edited. The range at this index will be changed to [start:end]. This
+	// should only be read after indexToDelete index has been deleted.
+	indexToEdit *int
+}
+
+// kvChanges encompasses the diff to apply to a KV-store representation of a
+// range index. A kv-store diff for the addition of a single number to the range
+// index will include either a brand new key-value pair or the altering of the
+// value of an existing key. Optionally, the diff may also include the deletion
+// of an existing key. A deletion will be required if the addition of the new
+// number results in the merge of two ranges.
+type kvChanges struct {
+	key   uint64
+	value uint64
+
+	// deleteKVKey, if set, is the key of the kv store representation that
+	// should be deleted.
+	deleteKVKey *uint64
+}
+
+// getChanges will calculate and return the changes that need to be applied to
+// both the sorted-rangeItem-array representation and the key-value store
+// representation of the range index.
+func (a *RangeIndex) getChanges(n uint64) (*arrayChanges, *kvChanges) {
+	// If the set is empty then a new range item is added.
+	if len(a.set) == 0 {
+		// For the array representation, a new range [n:n] is added to
+		// the first index of the array.
+		firstIndex := 0
+		ac := &arrayChanges{
+			newIndex: &firstIndex,
+			start:    n,
+			end:      n,
+		}
+
+		// For the KV representation, a new [n:n] pair is added.
+		kvc := &kvChanges{
+			key:   n,
+			value: n,
+		}
+
+		return ac, kvc
+	}
+
+	// Find the index of the lower bound range to the new number.
+	indexOfRangeBelow, alreadyCovered := a.lowerBoundIndex(n)
+
+	switch {
+	// The new number is already covered by the range index. No changes are
+	// required.
+	case alreadyCovered:
+		return nil, nil
+
+	// No lower bound index exists.
+	case indexOfRangeBelow < 0:
+		// Check if the very first range can be merged into this new
+		// one.
+		if n+1 == a.set[0].start {
+			// If so, the two ranges can be merged and so the start
+			// value of the range is n and the end value is the end
+			// of the existing first range.
+			start := n
+			end := a.set[0].end
+
+			// For the array representation, we can just edit the
+			// first entry of the array
+			editIndex := 0
+			ac := &arrayChanges{
+				indexToEdit: &editIndex,
+				start:       start,
+				end:         end,
+			}
+
+			// For the KV store representation, we add a new kv pair
+			// and delete the range with the key equal to the start
+			// value of the range we are merging.
+			kvKeyToDelete := a.set[0].start
+			kvc := &kvChanges{
+				key:         start,
+				value:       end,
+				deleteKVKey: &kvKeyToDelete,
+			}
+
+			return ac, kvc
+		}
+
+		// Otherwise, we add a new index.
+
+		// For the array representation, a new range [n:n] is added to
+		// the first index of the array.
+		newIndex := 0
+		ac := &arrayChanges{
+			newIndex: &newIndex,
+			start:    n,
+			end:      n,
+		}
+
+		// For the KV representation, a new [n:n] pair is added.
+		kvc := &kvChanges{
+			key:   n,
+			value: n,
+		}
+
+		return ac, kvc
+
+	// A lower range does exist, and it can be extended to include this new
+	// number.
+	case a.set[indexOfRangeBelow].end+1 == n:
+		start := a.set[indexOfRangeBelow].start
+		end := n
+		indexToChange := indexOfRangeBelow
+
+		// If there are no intervals above this one or if there are, but
+		// they can't be merged into this one then we just need to edit
+		// this interval.
+		if indexOfRangeBelow == len(a.set)-1 ||
+			a.set[indexOfRangeBelow+1].start != n+1 {
+
+			// For the array representation, we just edit the index.
+			ac := &arrayChanges{
+				indexToEdit: &indexToChange,
+				start:       start,
+				end:         end,
+			}
+
+			// For the key-value representation, we just overwrite
+			// the end value at the existing start key.
+			kvc := &kvChanges{
+				key:   start,
+				value: end,
+			}
+
+			return ac, kvc
+		}
+
+		// There is a range above this one that we need to merge into
+		// this one.
+		delIndex := indexOfRangeBelow + 1
+		end = a.set[delIndex].end
+
+		// For the array representation, we delete the range above this
+		// one and edit this range to include the end value of the range
+		// above.
+		ac := &arrayChanges{
+			indexToDelete: &delIndex,
+			indexToEdit:   &indexToChange,
+			start:         start,
+			end:           end,
+		}
+
+		// For the kv representation, we tweak the end value of an
+		// existing key and delete the key of the range we are deleting.
+		deleteKey := a.set[delIndex].start
+		kvc := &kvChanges{
+			key:         start,
+			value:       end,
+			deleteKVKey: &deleteKey,
+		}
+
+		return ac, kvc
+
+	// A lower range does exist, but it can't be extended to include this
+	// new number, and so we need to add a new range after the lower bound
+	// range.
+	default:
+		newIndex := indexOfRangeBelow + 1
+
+		// If there are no ranges above this new one or if there are,
+		// but they can't be merged into this new one, then we can just
+		// add the new one as is.
+		if newIndex == len(a.set) || a.set[newIndex].start != n+1 {
+			ac := &arrayChanges{
+				newIndex: &newIndex,
+				start:    n,
+				end:      n,
+			}
+
+			kvc := &kvChanges{
+				key:   n,
+				value: n,
+			}
+
+			return ac, kvc
+		}
+
+		// Else, we merge the above index.
+		start := n
+		end := a.set[newIndex].end
+		toEdit := newIndex
+
+		// For the array representation, we edit the range above to
+		// include the new start value.
+		ac := &arrayChanges{
+			indexToEdit: &toEdit,
+			start:       start,
+			end:         end,
+		}
+
+		// For the kv representation, we insert the new start-end key
+		// value pair and delete the key using the old start value.
+		delKey := a.set[newIndex].start
+		kvc := &kvChanges{
+			key:         start,
+			value:       end,
+			deleteKVKey: &delKey,
+		}
+
+		return ac, kvc
+	}
+}
+
+func defaultSerializeUint64(i uint64) ([]byte, error) {
+	var b [8]byte
+	byteOrder.PutUint64(b[:], i)
+	return b[:], nil
+}

--- a/watchtower/wtdb/range_index.go
+++ b/watchtower/wtdb/range_index.go
@@ -1,0 +1,619 @@
+package wtdb
+
+import (
+	"fmt"
+	"sync"
+)
+
+// rangeItem represents the start and end values of a range.
+type rangeItem struct {
+	start uint64
+	end   uint64
+}
+
+// RangeIndexOption describes the signature of a functional option that can be
+// used to modify the behaviour of a RangeIndex.
+type RangeIndexOption func(*RangeIndex)
+
+// WithSerializeUint64Fn is a functional option that can be used to set the
+// function to be used to do the serialization of a uint64 into a byte slice.
+func WithSerializeUint64Fn(fn func(uint64) ([]byte, error)) RangeIndexOption {
+	return func(index *RangeIndex) {
+		index.serializeUint64 = fn
+	}
+}
+
+// RangeIndex can be used to keep track of which numbers have been added to a
+// set. It does so by keeping track of a sorted list of rangeItems. Each
+// rangeItem has a start and end value of a range where all values in-between
+// have been added to the set. It works well in situations where it is expected
+// numbers in the set are not sparse.
+type RangeIndex struct {
+	// set is a sorted list of rangeItem.
+	set []rangeItem
+
+	// mu is used to ensure safe access to set.
+	mu sync.Mutex
+
+	// serializeUint64 is the function that can be used to convert a uint64
+	// to a byte slice.
+	serializeUint64 func(uint64) ([]byte, error)
+}
+
+// NewRangeIndex constructs a new RangeIndex. An initial set of ranges may be
+// passed to the function in the form of a map.
+func NewRangeIndex(ranges map[uint64]uint64,
+	opts ...RangeIndexOption) (*RangeIndex, error) {
+
+	index := &RangeIndex{
+		serializeUint64: defaultSerializeUint64,
+		set:             make([]rangeItem, 0),
+	}
+
+	// Apply any functional options.
+	for _, o := range opts {
+		o(index)
+	}
+
+	for s, e := range ranges {
+		if err := index.addRange(s, e); err != nil {
+			return nil, err
+		}
+	}
+
+	return index, nil
+}
+
+// addRange can be used to add an entire new range to the set. This method
+// should only ever be called by NewRangeIndex to initialise the in-memory
+// structure and so the RangeIndex mutex is not held during this method.
+func (a *RangeIndex) addRange(start, end uint64) error {
+	// Check that the given range is valid.
+	if start > end {
+		return fmt.Errorf("invalid range. Start height %d is larger "+
+			"than end height %d", start, end)
+	}
+
+	// min is a helper closure that will return the minimum of two uint64s.
+	min := func(a, b uint64) uint64 {
+		if a < b {
+			return a
+		}
+
+		return b
+	}
+
+	// max is a helper closure that will return the maximum of two uint64s.
+	max := func(a, b uint64) uint64 {
+		if a > b {
+			return a
+		}
+
+		return b
+	}
+
+	// Collect the ranges that fall before and after the new range along
+	// with the start and end values of the new range.
+	var before, after []rangeItem
+	for _, x := range a.set {
+		// If the new start value can't extend the current ranges end
+		// value, then the two cannot be merged. The range is added to
+		// the group of ranges that fall before the new range.
+		if x.end+1 < start {
+			before = append(before, x)
+			continue
+		}
+
+		// If the current ranges start value does not follow on directly
+		// from the new end value, then the two cannot be merged. The
+		// range is added to the group of ranges that fall after the new
+		// range.
+		if end+1 < x.start {
+			after = append(after, x)
+			continue
+		}
+
+		// Otherwise, there is an overlap and so the two can be merged.
+		start = min(start, x.start)
+		end = max(end, x.end)
+	}
+
+	// Re-construct the range index set.
+	a.set = append(append(before, rangeItem{
+		start: start,
+		end:   end,
+	}), after...)
+
+	return nil
+}
+
+// IsInIndex returns true if the given number is in the range set.
+func (a *RangeIndex) IsInIndex(n uint64) bool {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+
+	_, isCovered := a.lowerBoundIndex(n)
+
+	return isCovered
+}
+
+// NumInSet returns the number of items covered by the range set.
+func (a *RangeIndex) NumInSet() uint64 {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+
+	var numItems uint64
+	for _, r := range a.set {
+		numItems += r.end - r.start + 1
+	}
+
+	return numItems
+}
+
+// MaxHeight returns the highest number covered in the range.
+func (a *RangeIndex) MaxHeight() uint64 {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+
+	if len(a.set) == 0 {
+		return 0
+	}
+
+	return a.set[len(a.set)-1].end
+}
+
+// GetAllRanges returns a copy of the range set in the form of a map.
+func (a *RangeIndex) GetAllRanges() map[uint64]uint64 {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+
+	cp := make(map[uint64]uint64, len(a.set))
+	for _, item := range a.set {
+		cp[item.start] = item.end
+	}
+
+	return cp
+}
+
+// lowerBoundIndex returns the index of the RangeIndex that is most appropriate
+// for the new value, n. In other words, it returns the index of the rangeItem
+// set of the range where the start value is the highest start value in the set
+// that is still lower than or equal to the given number, n. The returned
+// boolean is true if the given number is already covered in the RangeIndex.
+// A returned index of -1 indicates that no lower bound range exists in the set.
+// Since the most likely case is that the new number will just extend the
+// highest range, a check is first done to see if this is the case which will
+// make the methods' computational complexity O(1). Otherwise, a binary search
+// is done which brings the computational complexity to O(log N).
+func (a *RangeIndex) lowerBoundIndex(n uint64) (int, bool) {
+	// If the set is empty, then there is no such index and the value
+	// definitely is not in the set.
+	if len(a.set) == 0 {
+		return -1, false
+	}
+
+	// In most cases, the last index item will be the one we want. So just
+	// do a quick check on that index first to avoid doing the binary
+	// search.
+	lastIndex := len(a.set) - 1
+	lastRange := a.set[lastIndex]
+	if lastRange.start <= n {
+		return lastIndex, lastRange.end >= n
+	}
+
+	// Otherwise, do a binary search to find the index of interest.
+	var (
+		low        = 0
+		high       = len(a.set) - 1
+		rangeIndex = -1
+	)
+	for {
+		mid := (low + high) / 2 //nolint: gomnd
+		currentRange := a.set[mid]
+
+		switch {
+		case currentRange.start > n:
+			// If the start of the range is greater than n, we can
+			// completely cut out that entire part of the array.
+			high = mid
+
+		case currentRange.start < n:
+			// If the range already includes the given height, we
+			// can stop searching now.
+			if currentRange.end >= n {
+				return mid, true
+			}
+
+			// If the start of the range is smaller than n, we can
+			// store this as the new best index to return.
+			rangeIndex = mid
+
+			// If low and mid are already equal, then increment low
+			// by 1. Exit if this means that low is now greater than
+			// high.
+			if low == mid {
+				low = mid + 1
+				if low > high {
+					return rangeIndex, false
+				}
+			} else {
+				low = mid
+			}
+
+			continue
+
+		default:
+			// If the height is equal to the start value of the
+			// current range that mid is pointing to, then the
+			// height is already covered.
+			return mid, true
+		}
+
+		// Exit if we have checked all the ranges.
+		if low == high {
+			break
+		}
+	}
+
+	return rangeIndex, false
+}
+
+// KVStore is an interface representing a key-value store.
+type KVStore interface {
+	// Put saves the specified key/value pair to the store. Keys that do not
+	// already exist are added and keys that already exist are overwritten.
+	Put(key, value []byte) error
+
+	// Delete removes the specified key from the bucket. Deleting a key that
+	// does not exist does not return an error.
+	Delete(key []byte) error
+}
+
+// Add adds a single number to the range set. It first attempts to apply the
+// necessary changes to the passed KV store and then only if this succeeds, will
+// the changes be applied to the in-memory structure.
+func (a *RangeIndex) Add(newHeight uint64, kv KVStore) error {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+
+	// Compute the changes that will need to be applied to both the sorted
+	// rangeItem array representation and the key-value store representation
+	// of the range index.
+	arrayChanges, kvStoreChanges := a.getChanges(newHeight)
+
+	// First attempt to apply the KV store changes. Only if this succeeds
+	// will we apply the changes to our in-memory range index structure.
+	err := a.applyKVChanges(kv, kvStoreChanges)
+	if err != nil {
+		return err
+	}
+
+	// Since the DB changes were successful, we can now commit the
+	// changes to our in-memory representation of the range set.
+	a.applyArrayChanges(arrayChanges)
+
+	return nil
+}
+
+// applyKVChanges applies the given set of kvChanges to a KV store. It is
+// assumed that a transaction is being held on the kv store so that if any
+// of the actions of the function fails, the changes will be reverted.
+func (a *RangeIndex) applyKVChanges(kv KVStore, changes *kvChanges) error {
+	// Exit early if there are no changes to apply.
+	if kv == nil || changes == nil {
+		return nil
+	}
+
+	// Check if any range pair needs to be deleted.
+	if changes.deleteKVKey != nil {
+		del, err := a.serializeUint64(*changes.deleteKVKey)
+		if err != nil {
+			return err
+		}
+
+		if err := kv.Delete(del); err != nil {
+			return err
+		}
+	}
+
+	start, err := a.serializeUint64(changes.key)
+	if err != nil {
+		return err
+	}
+
+	end, err := a.serializeUint64(changes.value)
+	if err != nil {
+		return err
+	}
+
+	return kv.Put(start, end)
+}
+
+// applyArrayChanges applies the given arrayChanges to the in-memory RangeIndex
+// itself. This should only be done once the persisted kv store changes have
+// already been applied.
+func (a *RangeIndex) applyArrayChanges(changes *arrayChanges) {
+	if changes == nil {
+		return
+	}
+
+	if changes.indexToDelete != nil {
+		a.set = append(
+			a.set[:*changes.indexToDelete],
+			a.set[*changes.indexToDelete+1:]...,
+		)
+	}
+
+	if changes.newIndex != nil {
+		switch {
+		case *changes.newIndex == 0:
+			a.set = append([]rangeItem{{
+				start: changes.start,
+				end:   changes.end,
+			}}, a.set...)
+
+		case *changes.newIndex == len(a.set):
+			a.set = append(a.set, rangeItem{
+				start: changes.start,
+				end:   changes.end,
+			})
+
+		default:
+			a.set = append(
+				a.set[:*changes.newIndex+1],
+				a.set[*changes.newIndex:]...,
+			)
+			a.set[*changes.newIndex] = rangeItem{
+				start: changes.start,
+				end:   changes.end,
+			}
+		}
+
+		return
+	}
+
+	if changes.indexToEdit != nil {
+		a.set[*changes.indexToEdit] = rangeItem{
+			start: changes.start,
+			end:   changes.end,
+		}
+	}
+}
+
+// arrayChanges encompasses the diff to apply to the sorted rangeItem array
+// representation of a range index. Such a diff will either include adding a
+// new range or editing an existing range. If an existing range is edited, then
+// the diff might also include deleting an index (this will be the case if the
+// editing of the one range results in the merge of another range).
+type arrayChanges struct {
+	start uint64
+	end   uint64
+
+	// newIndex, if set, is the index of the in-memory range array where a
+	// new range, [start:end], should be added. newIndex should never be
+	// set at the same time as indexToEdit or indexToDelete.
+	newIndex *int
+
+	// indexToDelete, if set, is the index of the sorted rangeItem array
+	// that should be deleted. This should be applied before reading the
+	// index value of indexToEdit. This should not be set at the same time
+	// as newIndex.
+	indexToDelete *int
+
+	// indexToEdit is the index of the in-memory range array that should be
+	// edited. The range at this index will be changed to [start:end]. This
+	// should only be read after indexToDelete index has been deleted.
+	indexToEdit *int
+}
+
+// kvChanges encompasses the diff to apply to a KV-store representation of a
+// range index. A kv-store diff for the addition of a single number to the range
+// index will include either a brand new key-value pair or the altering of the
+// value of an existing key. Optionally, the diff may also include the deletion
+// of an existing key. A deletion will be required if the addition of the new
+// number results in the merge of two ranges.
+type kvChanges struct {
+	key   uint64
+	value uint64
+
+	// deleteKVKey, if set, is the key of the kv store representation that
+	// should be deleted.
+	deleteKVKey *uint64
+}
+
+// getChanges will calculate and return the changes that need to be applied to
+// both the sorted-rangeItem-array representation and the key-value store
+// representation of the range index.
+func (a *RangeIndex) getChanges(n uint64) (*arrayChanges, *kvChanges) {
+	// If the set is empty then a new range item is added.
+	if len(a.set) == 0 {
+		// For the array representation, a new range [n:n] is added to
+		// the first index of the array.
+		firstIndex := 0
+		ac := &arrayChanges{
+			newIndex: &firstIndex,
+			start:    n,
+			end:      n,
+		}
+
+		// For the KV representation, a new [n:n] pair is added.
+		kvc := &kvChanges{
+			key:   n,
+			value: n,
+		}
+
+		return ac, kvc
+	}
+
+	// Find the index of the lower bound range to the new number.
+	indexOfRangeBelow, alreadyCovered := a.lowerBoundIndex(n)
+
+	switch {
+	// The new number is already covered by the range index. No changes are
+	// required.
+	case alreadyCovered:
+		return nil, nil
+
+	// No lower bound index exists.
+	case indexOfRangeBelow < 0:
+		// Check if the very first range can be merged into this new
+		// one.
+		if n+1 == a.set[0].start {
+			// If so, the two ranges can be merged and so the start
+			// value of the range is n and the end value is the end
+			// of the existing first range.
+			start := n
+			end := a.set[0].end
+
+			// For the array representation, we can just edit the
+			// first entry of the array
+			editIndex := 0
+			ac := &arrayChanges{
+				indexToEdit: &editIndex,
+				start:       start,
+				end:         end,
+			}
+
+			// For the KV store representation, we add a new kv pair
+			// and delete the range with the key equal to the start
+			// value of the range we are merging.
+			kvKeyToDelete := a.set[0].start
+			kvc := &kvChanges{
+				key:         start,
+				value:       end,
+				deleteKVKey: &kvKeyToDelete,
+			}
+
+			return ac, kvc
+		}
+
+		// Otherwise, we add a new index.
+
+		// For the array representation, a new range [n:n] is added to
+		// the first index of the array.
+		newIndex := 0
+		ac := &arrayChanges{
+			newIndex: &newIndex,
+			start:    n,
+			end:      n,
+		}
+
+		// For the KV representation, a new [n:n] pair is added.
+		kvc := &kvChanges{
+			key:   n,
+			value: n,
+		}
+
+		return ac, kvc
+
+	// A lower range does exist, and it can be extended to include this new
+	// number.
+	case a.set[indexOfRangeBelow].end+1 == n:
+		start := a.set[indexOfRangeBelow].start
+		end := n
+		indexToChange := indexOfRangeBelow
+
+		// If there are no intervals above this one or if there are, but
+		// they can't be merged into this one then we just need to edit
+		// this interval.
+		if indexOfRangeBelow == len(a.set)-1 ||
+			a.set[indexOfRangeBelow+1].start != n+1 {
+
+			// For the array representation, we just edit the index.
+			ac := &arrayChanges{
+				indexToEdit: &indexToChange,
+				start:       start,
+				end:         end,
+			}
+
+			// For the key-value representation, we just overwrite
+			// the end value at the existing start key.
+			kvc := &kvChanges{
+				key:   start,
+				value: end,
+			}
+
+			return ac, kvc
+		}
+
+		// There is a range above this one that we need to merge into
+		// this one.
+		delIndex := indexOfRangeBelow + 1
+		end = a.set[delIndex].end
+
+		// For the array representation, we delete the range above this
+		// one and edit this range to include the end value of the range
+		// above.
+		ac := &arrayChanges{
+			indexToDelete: &delIndex,
+			indexToEdit:   &indexToChange,
+			start:         start,
+			end:           end,
+		}
+
+		// For the kv representation, we tweak the end value of an
+		// existing key and delete the key of the range we are deleting.
+		deleteKey := a.set[delIndex].start
+		kvc := &kvChanges{
+			key:         start,
+			value:       end,
+			deleteKVKey: &deleteKey,
+		}
+
+		return ac, kvc
+
+	// A lower range does exist, but it can't be extended to include this
+	// new number, and so we need to add a new range after the lower bound
+	// range.
+	default:
+		newIndex := indexOfRangeBelow + 1
+
+		// If there are no ranges above this new one or if there are,
+		// but they can't be merged into this new one, then we can just
+		// add the new one as is.
+		if newIndex == len(a.set) || a.set[newIndex].start != n+1 {
+			ac := &arrayChanges{
+				newIndex: &newIndex,
+				start:    n,
+				end:      n,
+			}
+
+			kvc := &kvChanges{
+				key:   n,
+				value: n,
+			}
+
+			return ac, kvc
+		}
+
+		// Else, we merge the above index.
+		start := n
+		end := a.set[newIndex].end
+		toEdit := newIndex
+
+		// For the array representation, we edit the range above to
+		// include the new start value.
+		ac := &arrayChanges{
+			indexToEdit: &toEdit,
+			start:       start,
+			end:         end,
+		}
+
+		// For the kv representation, we insert the new start-end key
+		// value pair and delete the key using the old start value.
+		delKey := a.set[newIndex].start
+		kvc := &kvChanges{
+			key:         start,
+			value:       end,
+			deleteKVKey: &delKey,
+		}
+
+		return ac, kvc
+	}
+}
+
+func defaultSerializeUint64(i uint64) ([]byte, error) {
+	var b [8]byte
+	byteOrder.PutUint64(b[:], i)
+	return b[:], nil
+}

--- a/watchtower/wtdb/range_index_test.go
+++ b/watchtower/wtdb/range_index_test.go
@@ -1,0 +1,349 @@
+package wtdb
+
+import (
+	"fmt"
+	"math/rand"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestRangeIndex tests that the RangeIndex works as expected.
+func TestRangeIndex(t *testing.T) {
+	t.Parallel()
+
+	assertRanges := func(index *RangeIndex, kvStore *mockKVStore,
+		v map[uint64]uint64) {
+
+		require.EqualValues(t, v, index.GetAllRanges())
+		require.EqualValues(t, v, kvStore.kv)
+	}
+
+	t.Run("test zero value height", func(t *testing.T) {
+		t.Parallel()
+
+		kvStore := newMockKVStore(nil)
+		index, err := NewRangeIndex(nil)
+		require.NoError(t, err)
+
+		// Since zero values are tricky, assert that the empty index
+		// does not include zero.
+		require.False(t, index.IsInIndex(0))
+
+		// Now add zero to the index.
+		_ = index.Add(0, kvStore)
+		assertRanges(index, kvStore, map[uint64]uint64{0: 0})
+		require.True(t, index.IsInIndex(0))
+	})
+
+	t.Run("add duplicates", func(t *testing.T) {
+		t.Parallel()
+
+		kvStore := newMockKVStore(nil)
+		index, err := NewRangeIndex(nil)
+		require.NoError(t, err)
+
+		require.False(t, index.IsInIndex(1))
+
+		// Add 1 to the range.
+		err = index.Add(1, kvStore)
+		require.NoError(t, err)
+
+		assertRanges(index, kvStore, map[uint64]uint64{1: 1})
+		require.EqualValues(t, 1, index.MaxHeight())
+		require.True(t, index.IsInIndex(1))
+
+		// Add 1 again and assert that nothing has changed.
+		err = index.Add(1, kvStore)
+		require.NoError(t, err)
+
+		assertRanges(index, kvStore, map[uint64]uint64{1: 1})
+		require.EqualValues(t, 1, index.MaxHeight())
+		require.True(t, index.IsInIndex(1))
+	})
+
+	t.Run("extend an existing range", func(t *testing.T) {
+		t.Parallel()
+
+		kvStore := newMockKVStore(nil)
+		index, err := NewRangeIndex(nil)
+		require.NoError(t, err)
+
+		assertRanges(index, kvStore, map[uint64]uint64{})
+
+		// Add 2.
+		_ = index.Add(2, kvStore)
+		assertRanges(index, kvStore, map[uint64]uint64{
+			2: 2,
+		})
+
+		// Add 3, 4 and 5 and assert that these just extend the existing
+		// range by incrementing its end value.
+		_ = index.Add(3, kvStore)
+		_ = index.Add(4, kvStore)
+		_ = index.Add(5, kvStore)
+		assertRanges(index, kvStore, map[uint64]uint64{
+			2: 5,
+		})
+
+		// Now add 1 and 0 and assert that these just extend the
+		// existing range by decrementing its start value.
+		_ = index.Add(1, kvStore)
+		_ = index.Add(0, kvStore)
+		assertRanges(index, kvStore, map[uint64]uint64{
+			0: 5,
+		})
+
+		// Assert various other properties of the current range.
+		require.True(t, index.IsInIndex(3))
+		require.EqualValues(t, 5, index.MaxHeight())
+	})
+
+	t.Run("add new ranges above and below", func(t *testing.T) {
+		t.Parallel()
+
+		// Initialise the index with an initial range.
+		initialState := map[uint64]uint64{
+			4: 10,
+		}
+
+		kvStore := newMockKVStore(initialState)
+		index, err := NewRangeIndex(initialState)
+		require.NoError(t, err)
+
+		// Add 2 and 12. This should create two new ranges in the index.
+		_ = index.Add(12, kvStore)
+		_ = index.Add(2, kvStore)
+		assertRanges(index, kvStore, map[uint64]uint64{
+			2:  2,
+			4:  10,
+			12: 12,
+		})
+
+		// Assert various other properties of the current range.
+		require.EqualValues(t, 12, index.MaxHeight())
+		require.False(t, index.IsInIndex(3))
+		require.False(t, index.IsInIndex(11))
+		require.True(t, index.IsInIndex(2))
+		require.True(t, index.IsInIndex(5))
+		require.True(t, index.IsInIndex(12))
+	})
+
+	t.Run("merging two ranges", func(t *testing.T) {
+		t.Parallel()
+
+		// Initialise the index with an initial set of ranges.
+		initialState := map[uint64]uint64{
+			2:  2,
+			4:  10,
+			12: 12,
+		}
+
+		kvStore := newMockKVStore(initialState)
+		index, err := NewRangeIndex(initialState)
+		require.NoError(t, err)
+
+		// Adding 3 should merge the first and second ranges.
+		_ = index.Add(3, kvStore)
+		assertRanges(index, kvStore, map[uint64]uint64{
+			2:  10,
+			12: 12,
+		})
+
+		// Adding 11 should merge the first and second ranges.
+		_ = index.Add(11, kvStore)
+		assertRanges(index, kvStore, map[uint64]uint64{
+			2: 12,
+		})
+
+		// Assert various other properties of the current range.
+		require.EqualValues(t, 12, index.MaxHeight())
+		require.True(t, index.IsInIndex(2))
+		require.True(t, index.IsInIndex(5))
+		require.True(t, index.IsInIndex(12))
+		require.False(t, index.IsInIndex(1))
+	})
+
+	t.Run("failure applying KV store updates", func(t *testing.T) {
+		t.Parallel()
+
+		kvStore := newMockKVStore(nil)
+		index, err := NewRangeIndex(nil)
+		require.NoError(t, err)
+
+		assertRanges(index, kvStore, map[uint64]uint64{})
+
+		// Ensure that the kv store will return an error when its
+		// methods are called.
+		kvStore.setError(fmt.Errorf("db error"))
+
+		// Now attempt to add a new item to the range.
+		err = index.Add(20, kvStore)
+		require.Error(t, err)
+
+		// Assert that the update failed for both the kv store and the
+		// array store.
+		assertRanges(index, kvStore, map[uint64]uint64{})
+
+		// Now let the kv store again not return an error.
+		kvStore.setError(nil)
+
+		// Again attempt to add a new item to the range.
+		err = index.Add(20, kvStore)
+		require.NoError(t, err)
+
+		// It should now succeed.
+		assertRanges(index, kvStore, map[uint64]uint64{
+			20: 20,
+		})
+	})
+
+	t.Run("initialising with different ranges", func(t *testing.T) {
+		t.Parallel()
+
+		tests := []struct {
+			name          string
+			input         map[uint64]uint64
+			expectErr     bool
+			expectedIndex map[uint64]uint64
+		}{
+			{
+				name: "invalid ranges",
+				input: map[uint64]uint64{
+					1: 5,
+					6: 4,
+				},
+				expectErr: true,
+			},
+			{
+				name: "non-overlapping ranges",
+				input: map[uint64]uint64{
+					1: 2,
+					4: 6,
+					8: 20,
+				},
+				expectedIndex: map[uint64]uint64{
+					1: 2,
+					4: 6,
+					8: 20,
+				},
+			},
+			{
+				name: "merge-able ranges",
+				input: map[uint64]uint64{
+					1: 2,
+					3: 6,
+					7: 20,
+				},
+				expectedIndex: map[uint64]uint64{
+					1: 20,
+				},
+			},
+			{
+				name: "overlapping ranges",
+				input: map[uint64]uint64{
+					1: 4,
+					3: 7,
+					6: 20,
+				},
+				expectedIndex: map[uint64]uint64{
+					1: 20,
+				},
+			},
+		}
+
+		for _, test := range tests {
+			index, err := NewRangeIndex(test.input)
+			if test.expectErr {
+				require.Error(t, err)
+				continue
+			}
+			require.NoError(t, err)
+
+			require.EqualValues(
+				t, test.expectedIndex, index.GetAllRanges(),
+			)
+		}
+	})
+
+	t.Run("test large number of random inserts", func(t *testing.T) {
+		t.Parallel()
+
+		size := 10000
+
+		// Construct an array with values from 0 to size.
+		arr := make([]uint64, size)
+		for i := 0; i < size; i++ {
+			arr[i] = uint64(i)
+		}
+
+		// Shuffle the array so that the values are not added in order.
+		rand.Seed(time.Now().UnixNano())
+		rand.Shuffle(len(arr), func(i, j int) {
+			arr[i], arr[j] = arr[j], arr[i]
+		})
+
+		kvStore := newMockKVStore(nil)
+		index, err := NewRangeIndex(nil)
+		require.NoError(t, err)
+
+		// Now add each item in the array to the index.
+		for _, n := range arr {
+			_ = index.Add(n, kvStore)
+		}
+
+		// Assert that in the end, there is only a single range.
+		assertRanges(index, kvStore, map[uint64]uint64{
+			0: uint64(size - 1),
+		})
+
+		require.EqualValues(t, uint64(size-1), index.MaxHeight())
+	})
+}
+
+type mockKVStore struct {
+	kv map[uint64]uint64
+
+	err error
+}
+
+func newMockKVStore(initialRanges map[uint64]uint64) *mockKVStore {
+	if initialRanges != nil {
+		return &mockKVStore{
+			kv: initialRanges,
+		}
+	}
+
+	return &mockKVStore{
+		kv: make(map[uint64]uint64),
+	}
+}
+
+func (m *mockKVStore) setError(err error) {
+	m.err = err
+}
+
+func (m *mockKVStore) Put(key, value []byte) error {
+	if m.err != nil {
+		return m.err
+	}
+
+	k := byteOrder.Uint64(key)
+	v := byteOrder.Uint64(value)
+
+	m.kv[k] = v
+
+	return nil
+}
+
+func (m *mockKVStore) Delete(key []byte) error {
+	if m.err != nil {
+		return m.err
+	}
+
+	k := byteOrder.Uint64(key)
+	delete(m.kv, k)
+
+	return nil
+}

--- a/watchtower/wtdb/version.go
+++ b/watchtower/wtdb/version.go
@@ -5,6 +5,7 @@ import (
 	"github.com/lightningnetwork/lnd/kvdb"
 	"github.com/lightningnetwork/lnd/watchtower/wtdb/migration1"
 	"github.com/lightningnetwork/lnd/watchtower/wtdb/migration2"
+	"github.com/lightningnetwork/lnd/watchtower/wtdb/migration3"
 )
 
 // migration is a function which takes a prior outdated version of the database
@@ -32,6 +33,9 @@ var clientDBVersions = []version{
 	},
 	{
 		migration: migration2.MigrateClientChannelDetails,
+	},
+	{
+		migration: migration3.MigrateChannelIDIndex,
 	},
 }
 

--- a/watchtower/wtdb/version.go
+++ b/watchtower/wtdb/version.go
@@ -4,6 +4,7 @@ import (
 	"github.com/lightningnetwork/lnd/channeldb"
 	"github.com/lightningnetwork/lnd/kvdb"
 	"github.com/lightningnetwork/lnd/watchtower/wtdb/migration1"
+	"github.com/lightningnetwork/lnd/watchtower/wtdb/migration2"
 )
 
 // migration is a function which takes a prior outdated version of the database
@@ -28,6 +29,9 @@ var towerDBVersions = []version{}
 var clientDBVersions = []version{
 	{
 		migration: migration1.MigrateTowerToSessionIndex,
+	},
+	{
+		migration: migration2.MigrateClientChannelDetails,
 	},
 }
 

--- a/watchtower/wtdb/version.go
+++ b/watchtower/wtdb/version.go
@@ -8,6 +8,7 @@ import (
 	"github.com/lightningnetwork/lnd/watchtower/wtdb/migration1"
 	"github.com/lightningnetwork/lnd/watchtower/wtdb/migration2"
 	"github.com/lightningnetwork/lnd/watchtower/wtdb/migration3"
+	"github.com/lightningnetwork/lnd/watchtower/wtdb/migration4"
 )
 
 // txMigration is a function which takes a prior outdated version of the
@@ -48,6 +49,11 @@ var clientDBVersions = []version{
 	},
 	{
 		txMigration: migration3.MigrateChannelIDIndex,
+	},
+	{
+		dbMigration: migration4.MigrateAckedUpdates(
+			migration4.DefaultSessionsPerTx,
+		),
 	},
 }
 


### PR DESCRIPTION
This PR contains a few migrations of the watchtower client DB. 

# Main Achievements:

1. It greatly reduces the storage requirements of the session `AckedUpdates` through the use of a new `RangeIndex` model.
2. The various indexes added in this PR nicely sets us up for a follow up PR in which we we will be able to determine which sessions we can delete (and tell the tower server that it can delete) based on if all channels that the session has updates for have been deleted. (Ie, this is a step towards #6259, #7035)

# Change Log:

## 1. Migrate ChanDetails Bucket
A `ChannelDetails` bucket is added and each registered channel gets its own sub-bucket in this bucket. The existing channel summaries are moved here under the `cChannelSummary` key and the old top-level `cChanSummaryBkt` is deleted. This is done so that we can store more details about a channel without needing to add new info to the encoded ChannelSummary.

## 2. Add a new Channel-ID index
A new channel-ID index is added. The index holds a mapping from db-assigned-ID (8 bytes) to real channel-ID (32 bytes). This mapping will allow us to preserve disk space in future when persisting references to channels. 
 
## 3. Migrate AckedUpdates to the RangeIndex model.
This is the main meat of the PR. 

Currently, for each session, we store its acked updates as follows:

```
seqNum (2 bytes) -> encoded BackupID{channelID (32 bytes) + commitHeight (8 bytes)}
```
The default number of backups per session is 1024 and so this means that regardless of the number of channels the session is actually covering, it takes 1024 * (2 + 32 + 8) bytes per session. Depending on how busy your node is, you could have many thousands of sessions ([this user has 60k](https://github.com/lightningnetwork/lnd/pull/6928#discussion_r974413948) which would mean 2.5GB!). 

The only reason that we want to keep track of AckedUpdates imo is if we need to determine which updates of a channel have/have not been backed up or if we want to replay backups to a different tower. So I argue that knowing the sequence number associated with each back up is not necessary. 

Given this assumption, we can store the `AckedUpdates` using a `RangeIndex` (per channel). We will also make use of the new channel index described above (in point 2 of the change log) so that we only need 8 bytes per channel. 
The `RangeIndex` is just a map from start height to end height of a range. This means that in the best case where all commit heights are present, we only need to store the start and end height. And if there are holes, we store separate ranges and that will still be more efficient since each range only requires 16 bytes (8 byte key for the start value and 8 bytes for the end value of the range). Our session can thus store its AckedUpdates as follows:

```
"acked-updates" => channel-ID (8 byte key sub-bucket) => start height (8 byte key) -> end-height (8 byte value)
```

Here is a quick example showing the the change of an index that starts empty and then gets the numbers 1, 2, 4, 3:
```
add 1:
    1 -> 1

add 2:
    1 -> 2

add 4:
    1 -> 2
    4 -> 4

add 3:
    1 -> 4
```

This means that every session only refers to a channel once and then just stores the index of ranges for that channel that is covered by the session. 

Any additions to the index will at most require one value update & one key deletion. 

The PR contains the necessary logic to make sure that the calculation of how to update an index given a new commit height is as efficient as possible. 

## Note:
I originally had the changes in #7059 here too since the bug in wtclientrpc makes it difficult to use the rpc to check the correctness of this PR. Separated it into its own PR now just to make the diff of this PR a bit smaller. But suggest we get that PR in first even though the two are not dependant on each other.

Fixes https://github.com/lightningnetwork/lnd/issues/6886