### PR TITLE
wallet: use correct birthday timestamp when creating watch-only wallet

### DIFF
--- a/config_builder.go
+++ b/config_builder.go
@@ -1033,7 +1033,7 @@ func waitForWalletPassword(cfg *Config,
 					"signer config disabled")
 			}
 
-			birthday = initMsg.ExtendedKeyBirthday
+			birthday = initMsg.WatchOnlyBirthday
 			newWallet, err = loader.CreateNewWatchingOnlyWallet(
 				password, birthday,
 			)

--- a/docs/release-notes/release-notes-0.16.0.md
+++ b/docs/release-notes/release-notes-0.16.0.md
@@ -40,6 +40,10 @@
   wallet](https://github.com/lightningnetwork/lnd/pull/6775). NOTE that funding
   PSBTs from imported tap scripts is not currently possible.
 
+* [The wallet birthday is now used properly when creating a watch-only wallet
+  to avoid scanning the whole
+  chain](https://github.com/lightningnetwork/lnd/pull/7056).
+
 ## Build
 
 [The project has updated to Go


### PR DESCRIPTION
## Change Description

Use the correct wallet birthday when creating a watch-only wallet.

## Steps to Test

```
lncli createwatchonly /tmp/accounts.json

Input wallet password: 
Confirm password: 

Input an optional wallet birthday unix timestamp of first block to start scanning from (default 0): 1666033027
...
```


Check the logs to see that the wallet birthday (`timestamp=`) is used correctly:

```
Found birthday block: height=196, hash=3ebdd7b2677069982ceb3195db59d52425fa401dfce6c23fc39b6a8777a50c4d, timestamp=2022-10-14 18:32:24 +0200 CEST
```

Thanks @openoms for reporting.