### PR TITLE
chancloser+lnwire: add range-based negotiation

### DIFF
--- a/htlcswitch/interfaces.go
+++ b/htlcswitch/interfaces.go
@@ -132,10 +132,9 @@ type ChannelUpdateHandler interface {
 	// parameter.
 	MayAddOutgoingHtlc(lnwire.MilliSatoshi) error
 
-	// ShutdownIfChannelClean shuts the link down if the channel state is
-	// clean. This can be used with dynamic commitment negotiation or coop
-	// close negotiation which require a clean channel state.
-	ShutdownIfChannelClean() error
+	// NotifyShouldShutdown is used by the Switch to inform the link that
+	// it should begin the shutdown flow.
+	NotifyShouldShutdown(req *ChanClose) error
 }
 
 // ChannelLink is an interface which represents the subsystem for managing the

--- a/htlcswitch/linkfailure.go
+++ b/htlcswitch/linkfailure.go
@@ -8,6 +8,10 @@ var (
 
 	// ErrLinkFailedShutdown signals that a requested shutdown failed.
 	ErrLinkFailedShutdown = errors.New("link failed to shutdown")
+
+	// ErrLinkCoopClosing signals that the link is in the shutdown phase of
+	// the coop close flow.
+	ErrLinkCoopClosing = errors.New("link coop closing")
 )
 
 // errorCode encodes the possible types of errors that will make us fail the

--- a/htlcswitch/mock.go
+++ b/htlcswitch/mock.go
@@ -616,6 +616,8 @@ func (s *mockServer) readHandler(message lnwire.Message) error {
 		targetChan = msg.ChanID
 	case *lnwire.UpdateFee:
 		targetChan = msg.ChanID
+	case *lnwire.Shutdown:
+		targetChan = msg.ChannelID
 	default:
 		return fmt.Errorf("unknown message type: %T", msg)
 	}
@@ -878,12 +880,14 @@ func (f *mockChannelLink) ChannelPoint() *wire.OutPoint                 { return
 func (f *mockChannelLink) Stop()                                        {}
 func (f *mockChannelLink) EligibleToForward() bool                      { return f.eligible }
 func (f *mockChannelLink) MayAddOutgoingHtlc(lnwire.MilliSatoshi) error { return nil }
-func (f *mockChannelLink) ShutdownIfChannelClean() error                { return nil }
 func (f *mockChannelLink) setLiveShortChanID(sid lnwire.ShortChannelID) { f.shortChanID = sid }
 func (f *mockChannelLink) IsUnadvertised() bool                         { return f.unadvertised }
 func (f *mockChannelLink) UpdateShortChanID() (lnwire.ShortChannelID, error) {
 	f.eligible = true
 	return f.shortChanID, nil
+}
+func (f *mockChannelLink) NotifyShouldShutdown(req *ChanClose) error {
+	return nil
 }
 
 var _ ChannelLink = (*mockChannelLink)(nil)

--- a/htlcswitch/test_utils.go
+++ b/htlcswitch/test_utils.go
@@ -498,6 +498,8 @@ func getChanID(msg lnwire.Message) (lnwire.ChannelID, error) {
 		chanID = msg.ChanID
 	case *lnwire.UpdateFee:
 		chanID = msg.ChanID
+	case *lnwire.Shutdown:
+		chanID = msg.ChannelID
 	default:
 		return chanID, fmt.Errorf("unknown type: %T", msg)
 	}

--- a/lntest/itest/lnd_coopclose_test.go
+++ b/lntest/itest/lnd_coopclose_test.go
@@ -1,0 +1,146 @@
+package itest
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"github.com/lightningnetwork/lnd/lnrpc"
+	"github.com/lightningnetwork/lnd/lnrpc/invoicesrpc"
+	"github.com/lightningnetwork/lnd/lnrpc/routerrpc"
+	"github.com/lightningnetwork/lnd/lntest"
+	"github.com/lightningnetwork/lnd/lntest/wait"
+	"github.com/lightningnetwork/lnd/lntypes"
+	"github.com/stretchr/testify/require"
+)
+
+// testCoopClose tests that the coop close process adheres to the BOLT#02
+// specification.
+func testCoopClose(net *lntest.NetworkHarness, t *harnessTest) {
+	ctxb := context.Background()
+
+	chanReq := lntest.OpenChannelParams{
+		Amt: 300000,
+	}
+
+	chanPoint := openChannelAndAssert(
+		t, net, net.Alice, net.Bob, chanReq,
+	)
+
+	// Create a hodl invoice for Bob. This will allow us to exercise the
+	// Shutdown logic.
+	var (
+		preimage = lntypes.Preimage{1, 2, 3}
+		payHash  = preimage.Hash()
+	)
+
+	invoiceReq := &invoicesrpc.AddHoldInvoiceRequest{
+		Value:      30000,
+		CltvExpiry: 40,
+		Hash:       payHash[:],
+	}
+
+	ctxt, cancel := context.WithTimeout(ctxb, defaultTimeout)
+	defer cancel()
+	bobInvoice, err := net.Bob.AddHoldInvoice(ctxt, invoiceReq)
+	require.NoError(t.t, err)
+
+	// Alice will now pay this invoice and get a single HTLC locked-in on
+	// each of the commitment transactions.
+	_, err = net.Alice.RouterClient.SendPaymentV2(
+		ctxb, &routerrpc.SendPaymentRequest{
+			PaymentRequest: bobInvoice.PaymentRequest,
+			TimeoutSeconds: 60,
+			FeeLimitMsat:   noFeeLimitMsat,
+		},
+	)
+	require.NoError(t.t, err)
+
+	waitForInvoiceAccepted(t, net.Bob, payHash)
+
+	// Alice and Bob should both have a single HTLC locked in.
+	nodes := []*lntest.HarnessNode{net.Alice, net.Bob}
+	err = wait.NoError(func() error {
+		return assertActiveHtlcs(nodes, payHash[:])
+	}, defaultTimeout)
+	require.NoError(t.t, err)
+
+	closeReq := &lnrpc.CloseChannelRequest{
+		ChannelPoint: chanPoint,
+	}
+
+	// Alice will initiate the coop close and we'll obtain the close
+	// channel client to assert that the channel is closed once the htlc is
+	// settled.
+	ctxt, cancel = context.WithTimeout(ctxb, defaultTimeout)
+	defer cancel()
+	closeRespStream, err := net.Alice.CloseChannel(ctxt, closeReq)
+	require.NoError(t.t, err)
+
+	time.Sleep(time.Second * 10)
+
+	// Bob will now settle the invoice.
+	settle := &invoicesrpc.SettleInvoiceMsg{
+		Preimage: preimage[:],
+	}
+	_, err = net.Bob.SettleInvoice(ctxt, settle)
+	require.NoError(t.t, err)
+
+	// The coop close negotiation should now complete.
+	var closeTxid *chainhash.Hash
+	err = wait.NoError(func() error {
+		closeResp, err := closeRespStream.Recv()
+		if err != nil {
+			return fmt.Errorf("unable to Recv() from stream: %v",
+				err)
+		}
+
+		pendingClose, ok := closeResp.Update.(*lnrpc.CloseStatusUpdate_ClosePending)
+		if !ok {
+			return fmt.Errorf("expected channel close update, "+
+				"instead got %v", pendingClose)
+		}
+
+		closeTxid, err = chainhash.NewHash(
+			pendingClose.ClosePending.Txid,
+		)
+		if err != nil {
+			return fmt.Errorf("unable to decode closeTxid: %v",
+				err)
+		}
+
+		coopTx, err := waitForTxInMempool(
+			net.Miner.Client, minerMempoolTimeout,
+		)
+		if err != nil {
+			return err
+		}
+
+		if !coopTx.IsEqual(closeTxid) {
+			return fmt.Errorf("mempool tx is not coop close tx")
+		}
+
+		return nil
+	}, channelCloseTimeout)
+	require.NoError(t.t, err)
+
+	// The closing transaction will be mined and Alice and Bob should both
+	// see the channel as successfully resolved.
+	block := mineBlocks(t, net, 1, 1)[0]
+	assertTxInBlock(t, block, closeTxid)
+
+	// Sleep again to ensure the ChannelArbitrator can advance to
+	// StateFullyResolved.
+	time.Sleep(10 * time.Second)
+
+	aliceReq := &lnrpc.ClosedChannelsRequest{}
+	aliceClosedList, err := net.Alice.ClosedChannels(ctxt, aliceReq)
+	require.NoError(t.t, err, "alice list closed channels")
+	require.Len(t.t, aliceClosedList.Channels, 1, "alice closed channels")
+
+	bobReq := &lnrpc.ClosedChannelsRequest{}
+	bobClosedList, err := net.Bob.ClosedChannels(ctxt, bobReq)
+	require.NoError(t.t, err, "bob list closed channels")
+	require.Len(t.t, bobClosedList.Channels, 1, "bob closed channels")
+}

--- a/lntest/itest/lnd_test_list_on_test.go
+++ b/lntest/itest/lnd_test_list_on_test.go
@@ -423,4 +423,8 @@ var allTestCases = []*testCase{
 		name: "open channel fee policy",
 		test: testOpenChannelUpdateFeePolicy,
 	},
+	{
+		name: "coop close",
+		test: testCoopClose,
+	},
 }

--- a/lnwallet/chancloser/chancloser.go
+++ b/lnwallet/chancloser/chancloser.go
@@ -375,6 +375,17 @@ func (c *ChanCloser) initChanShutdown() (*lnwire.Shutdown, error) {
 			c.chanPoint, err)
 	}
 
+	// Persist the delivery script used before marking the state as coop
+	// broadcasted so we can recover in case of a crash.
+	if len(c.Channel().LocalUpfrontShutdownScript()) == 0 {
+		err := c.Channel().State().PersistDeliveryScript(
+			c.localDeliveryScript,
+		)
+		if err != nil {
+			return nil, err
+		}
+	}
+
 	// Before continuing, mark the channel as cooperatively closed with a nil
 	// txn. Even though we haven't negotiated the final txn, this guarantees
 	// that our listchannels rpc will be externally consistent, and reflect

--- a/lnwallet/chancloser/chancloser.go
+++ b/lnwallet/chancloser/chancloser.go
@@ -828,7 +828,7 @@ func (c *ChanCloser) proposeCloseSigned(fee btcutil.Amount) (*lnwire.ClosingSign
 	// We'll assemble a ClosingSigned message using this information and return
 	// it to the caller so we can kick off the final stage of the channel
 	// closure process.
-	closeSignedMsg := lnwire.NewClosingSigned(c.cid, fee, parsedSig)
+	closeSignedMsg := lnwire.NewClosingSigned(c.cid, fee, parsedSig, nil)
 
 	// We'll also save this close signed, in the case that the remote party
 	// accepts our offer. This way, we don't have to re-sign.

--- a/lnwallet/channel.go
+++ b/lnwallet/channel.go
@@ -5654,7 +5654,7 @@ func (lc *LightningChannel) ShortChanID() lnwire.ShortChannelID {
 // LocalUpfrontShutdownScript returns the local upfront shutdown script for the
 // channel. If it was not set, an empty byte array is returned.
 func (lc *LightningChannel) LocalUpfrontShutdownScript() lnwire.DeliveryAddress {
-	return lc.channelState.LocalShutdownScript
+	return lc.channelState.GetLocalShutdownScript()
 }
 
 // RemoteUpfrontShutdownScript returns the remote upfront shutdown script for the

--- a/lnwire/closing_signed.go
+++ b/lnwire/closing_signed.go
@@ -2,10 +2,115 @@ package lnwire
 
 import (
 	"bytes"
+	"fmt"
 	"io"
 
 	"github.com/btcsuite/btcd/btcutil"
+	"github.com/lightningnetwork/lnd/tlv"
 )
+
+const (
+	// FeeRangeType is the type used to store the optional fee range field
+	// in the ClosingSigned message.
+	FeeRangeType tlv.Type = 1
+
+	// FeeRangeRecordSize is the amount of bytes the fee range record size
+	// occupies (two uint64s).
+	FeeRangeRecordSize uint64 = 16
+)
+
+// FeeRange is a TLV in the ClosingSigned message that allows the sender to
+// specify the minimum and maximum fee it will accept for a coop closing
+// transaction. This version of the coop closing flow will usually complete in
+// 2 or 3 rounds, but may take more if each side's fee range doesn't overlap.
+type FeeRange struct {
+	// MinFeeSats is the minimum fee that the sender will accept.
+	MinFeeSats btcutil.Amount
+
+	// MaxFeeSats is the maximum fee that the sender will accept.
+	MaxFeeSats btcutil.Amount
+}
+
+// InRange returns whether a fee is in the fee range.
+func (f *FeeRange) InRange(fee btcutil.Amount) bool {
+	return f.MinFeeSats <= fee && fee <= f.MaxFeeSats
+}
+
+// GetOverlap takes two FeeRanges and returns the overlapping FeeRange between
+// the two. If there is no overlap, nil is returned.
+func (f *FeeRange) GetOverlap(other *FeeRange) *FeeRange {
+	var (
+		minOfUpper btcutil.Amount
+		maxOfLower btcutil.Amount
+	)
+
+	// Determine the maximum of the lower bounds.
+	if f.MinFeeSats >= other.MinFeeSats {
+		maxOfLower = f.MinFeeSats
+	} else {
+		maxOfLower = other.MinFeeSats
+	}
+
+	// Determine the minimum of the upper bounds.
+	if f.MaxFeeSats <= other.MaxFeeSats {
+		minOfUpper = f.MaxFeeSats
+	} else {
+		minOfUpper = other.MaxFeeSats
+	}
+
+	// If the maximum of the lower bounds is greater than the minimum of the
+	// upper bounds, then there is no overlap.
+	if maxOfLower > minOfUpper {
+		return nil
+	}
+
+	// There is an overlap, so return the range.
+	return &FeeRange{
+		MinFeeSats: maxOfLower,
+		MaxFeeSats: minOfUpper,
+	}
+}
+
+// NewRecord returns a TLV record that can be used to optionally encode a fee
+// range that allows the fee negotiation process to use less rounds.
+func (f *FeeRange) Record() tlv.Record {
+	return tlv.MakeStaticRecord(
+		FeeRangeType, f, FeeRangeRecordSize, eFeeRange, dFeeRange,
+	)
+}
+
+// eFeeRange is used to encode the fee range struct as a TLV record.
+func eFeeRange(w io.Writer, val interface{}, buf *[8]byte) error {
+	if feeRange, ok := val.(*FeeRange); ok {
+		err := tlv.EUint64T(w, uint64(feeRange.MinFeeSats), buf)
+		if err != nil {
+			return err
+		}
+
+		return tlv.EUint64T(w, uint64(feeRange.MaxFeeSats), buf)
+	}
+
+	return tlv.NewTypeForEncodingErr(val, "FeeRange")
+}
+
+// dFeeRange is used to decode the fee range TLV record into a FeeRange struct.
+func dFeeRange(r io.Reader, val interface{}, buf *[8]byte, l uint64) error {
+	if feeRange, ok := val.(*FeeRange); ok && l == FeeRangeRecordSize {
+		var min, max uint64
+
+		if err := tlv.DUint64(r, &min, buf, 8); err != nil {
+			return err
+		}
+		if err := tlv.DUint64(r, &max, buf, 8); err != nil {
+			return err
+		}
+
+		feeRange.MinFeeSats = btcutil.Amount(min)
+		feeRange.MaxFeeSats = btcutil.Amount(max)
+		return nil
+	}
+	return tlv.NewTypeForDecodingErr(val, "FeeRange", l, FeeRangeRecordSize)
+}
 
 // ClosingSigned is sent by both parties to a channel once the channel is clear
 // of HTLCs, and is primarily concerned with negotiating fees for the close
@@ -29,6 +134,10 @@ type ClosingSigned struct {
 	// Signature is for the proposed channel close transaction.
 	Signature Sig
 
+	// FeeRange is an optional range that the sender can set to compress the
+	// number of rounds in the coop close process.
+	FeeRange *FeeRange
+
 	// ExtraData is the set of data that was appended to this message to
 	// fill out the full maximum transport message size. These fields can
 	// be used to specify optional data such as custom TLV fields.
@@ -36,11 +145,12 @@ type ClosingSigned struct {
 }
 
 // NewClosingSigned creates a new empty ClosingSigned message.
-func NewClosingSigned(cid ChannelID, fs btcutil.Amount,
-	sig Sig) *ClosingSigned {
+func NewClosingSigned(cid ChannelID, fs btcutil.Amount, sig Sig,
+	fr *FeeRange) *ClosingSigned {
 
 	return &ClosingSigned{
 		ChannelID:   cid,
+		FeeRange:    fr,
 		FeeSatoshis: fs,
 		Signature:   sig,
 	}
@@ -55,9 +165,40 @@ var _ Message = (*ClosingSigned)(nil)
 //
 // This is part of the lnwire.Message interface.
 func (c *ClosingSigned) Decode(r io.Reader, pver uint32) error {
-	return ReadElements(
+	err := ReadElements(
 		r, &c.ChannelID, &c.FeeSatoshis, &c.Signature, &c.ExtraData,
 	)
+	if err != nil {
+		return err
+	}
+
+	// Attempt to parse out the FeeRange record.
+	var fr FeeRange
+	typeMap, err := c.ExtraData.ExtractRecords(&fr)
+	if err != nil {
+		return err
+	}
+
+	// Only set the FeeRange record if the TLV type was included in the
+	// stream.
+	if val, ok := typeMap[FeeRangeType]; ok && val == nil {
+		// Check that the fee range is sane before setting it.
+		if fr.MinFeeSats > fr.MaxFeeSats {
+			return fmt.Errorf("MinFeeSats greater than " +
+				"MaxFeeSats")
+		}
+
+		// Check that FeeSatoshis is in the FeeRange.
+		if c.FeeSatoshis < fr.MinFeeSats ||
+			c.FeeSatoshis > fr.MaxFeeSats {
+
+			return fmt.Errorf("FeeSatoshis is not in FeeRange")
+		}
+
+		c.FeeRange = &fr
+	}
+
+	return nil
 }
 
 // Encode serializes the target ClosingSigned into the passed io.Writer
@@ -75,6 +216,15 @@ func (c *ClosingSigned) Encode(w *bytes.Buffer, pver uint32) error {
 
 	if err := WriteSig(w, c.Signature); err != nil {
 		return err
+	}
+
+	// We'll only encode the FeeRange in a TLV segment if it exists.
+	if c.FeeRange != nil {
+		recordProducers := []tlv.RecordProducer{c.FeeRange}
+		err := EncodeMessageExtraData(&c.ExtraData, recordProducers...)
+		if err != nil {
+			return err
+		}
 	}
 
 	return WriteBytes(w, c.ExtraData)

--- a/lnwire/lnwire_test.go
+++ b/lnwire/lnwire_test.go
@@ -601,6 +601,14 @@ func TestLightningWireProtocol(t *testing.T) {
 				return
 			}
 
+			// With a 50% chance, add the FeeRange TLV record.
+			if r.Intn(2) == 0 {
+				req.FeeRange = &FeeRange{
+					MinFeeSats: btcutil.Amount(uint64(r.Int63())),
+					MaxFeeSats: btcutil.Amount(uint64(r.Int63())),
+				}
+			}
+
 			v[0] = reflect.ValueOf(req)
 		},
 		MsgCommitSig: func(v []reflect.Value, r *rand.Rand) {

--- a/peer/brontide_test.go
+++ b/peer/brontide_test.go
@@ -102,7 +102,9 @@ func TestPeerChannelClosureAcceptFeeResponder(t *testing.T) {
 
 	parsedSig, err := lnwire.NewSigFromSignature(bobSig)
 	require.NoError(t, err, "error parsing signature")
-	closingSigned := lnwire.NewClosingSigned(chanID, aliceFee, parsedSig)
+	closingSigned := lnwire.NewClosingSigned(
+		chanID, aliceFee, parsedSig, nil,
+	)
 	alicePeer.chanCloseMsgs <- &closeMsg{
 		cid: chanID,
 		msg: closingSigned,
@@ -204,8 +206,9 @@ func TestPeerChannelClosureAcceptFeeInitiator(t *testing.T) {
 	parsedSig, err := lnwire.NewSigFromSignature(bobSig)
 	require.NoError(t, err, "unable to parse signature")
 
-	closingSigned := lnwire.NewClosingSigned(chanID,
-		bobFee, parsedSig)
+	closingSigned := lnwire.NewClosingSigned(
+		chanID, bobFee, parsedSig, nil,
+	)
 	alicePeer.chanCloseMsgs <- &closeMsg{
 		cid: chanID,
 		msg: closingSigned,
@@ -318,7 +321,9 @@ func TestPeerChannelClosureFeeNegotiationsResponder(t *testing.T) {
 
 	parsedSig, err := lnwire.NewSigFromSignature(bobSig)
 	require.NoError(t, err, "error parsing signature")
-	closingSigned := lnwire.NewClosingSigned(chanID, increasedFee, parsedSig)
+	closingSigned := lnwire.NewClosingSigned(
+		chanID, increasedFee, parsedSig, nil,
+	)
 	alicePeer.chanCloseMsgs <- &closeMsg{
 		cid: chanID,
 		msg: closingSigned,
@@ -358,7 +363,9 @@ func TestPeerChannelClosureFeeNegotiationsResponder(t *testing.T) {
 
 	parsedSig, err = lnwire.NewSigFromSignature(bobSig)
 	require.NoError(t, err, "error parsing signature")
-	closingSigned = lnwire.NewClosingSigned(chanID, increasedFee, parsedSig)
+	closingSigned = lnwire.NewClosingSigned(
+		chanID, increasedFee, parsedSig, nil,
+	)
 	alicePeer.chanCloseMsgs <- &closeMsg{
 		cid: chanID,
 		msg: closingSigned,
@@ -400,7 +407,9 @@ func TestPeerChannelClosureFeeNegotiationsResponder(t *testing.T) {
 
 	parsedSig, err = lnwire.NewSigFromSignature(bobSig)
 	require.NoError(t, err, "error parsing signature")
-	closingSigned = lnwire.NewClosingSigned(chanID, aliceFee, parsedSig)
+	closingSigned = lnwire.NewClosingSigned(
+		chanID, aliceFee, parsedSig, nil,
+	)
 	alicePeer.chanCloseMsgs <- &closeMsg{
 		cid: chanID,
 		msg: closingSigned,
@@ -508,7 +517,9 @@ func TestPeerChannelClosureFeeNegotiationsInitiator(t *testing.T) {
 	parsedSig, err := lnwire.NewSigFromSignature(bobSig)
 	require.NoError(t, err, "unable to parse signature")
 
-	closingSigned := lnwire.NewClosingSigned(chanID, increasedFee, parsedSig)
+	closingSigned := lnwire.NewClosingSigned(
+		chanID, increasedFee, parsedSig, nil,
+	)
 	alicePeer.chanCloseMsgs <- &closeMsg{
 		cid: chanID,
 		msg: closingSigned,
@@ -551,7 +562,9 @@ func TestPeerChannelClosureFeeNegotiationsInitiator(t *testing.T) {
 	parsedSig, err = lnwire.NewSigFromSignature(bobSig)
 	require.NoError(t, err, "error parsing signature")
 
-	closingSigned = lnwire.NewClosingSigned(chanID, increasedFee, parsedSig)
+	closingSigned = lnwire.NewClosingSigned(
+		chanID, increasedFee, parsedSig, nil,
+	)
 	alicePeer.chanCloseMsgs <- &closeMsg{
 		cid: chanID,
 		msg: closingSigned,
@@ -590,7 +603,9 @@ func TestPeerChannelClosureFeeNegotiationsInitiator(t *testing.T) {
 
 	parsedSig, err = lnwire.NewSigFromSignature(bobSig)
 	require.NoError(t, err, "error parsing signature")
-	closingSigned = lnwire.NewClosingSigned(chanID, aliceFee, parsedSig)
+	closingSigned = lnwire.NewClosingSigned(
+		chanID, aliceFee, parsedSig, nil,
+	)
 	alicePeer.chanCloseMsgs <- &closeMsg{
 		cid: chanID,
 		msg: closingSigned,

--- a/peer/test_utils.go
+++ b/peer/test_utils.go
@@ -467,8 +467,12 @@ func (m *mockUpdateHandler) EligibleToForward() bool { return false }
 // MayAddOutgoingHtlc currently returns nil.
 func (m *mockUpdateHandler) MayAddOutgoingHtlc(lnwire.MilliSatoshi) error { return nil }
 
-// ShutdownIfChannelClean currently returns nil.
-func (m *mockUpdateHandler) ShutdownIfChannelClean() error { return nil }
+// NotifyShouldShutdown currently returns nil.
+func (m *mockUpdateHandler) NotifyShouldShutdown(
+	req *htlcswitch.ChanClose) error {
+
+	return nil
+}
 
 type mockMessageConn struct {
 	t *testing.T

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -4210,9 +4210,10 @@ func createRPCOpenChannel(r *rpcServer, dbChannel *channeldb.OpenChannel,
 		channel.PushAmountSat = uint64(amt)
 	}
 
-	if len(dbChannel.LocalShutdownScript) > 0 {
+	if len(dbChannel.GetLocalShutdownScript()) > 0 {
 		_, addresses, _, err := txscript.ExtractPkScriptAddrs(
-			dbChannel.LocalShutdownScript, r.cfg.ActiveNetParams.Params,
+			dbChannel.GetLocalShutdownScript(),
+			r.cfg.ActiveNetParams.Params,
 		)
 		if err != nil {
 			return nil, err

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -2513,14 +2513,6 @@ func (r *rpcServer) CloseChannel(in *lnrpc.CloseChannelRequest,
 		rpcsLog.Debugf("Target sat/kw for closing transaction: %v",
 			int64(feeRate))
 
-		// Before we attempt the cooperative channel closure, we'll
-		// examine the channel to ensure that it doesn't have a
-		// lingering HTLC.
-		if len(channel.ActiveHtlcs()) != 0 {
-			return fmt.Errorf("cannot co-op close channel " +
-				"with active htlcs")
-		}
-
 		// Otherwise, the caller has requested a regular interactive
 		// cooperative channel closure. So we'll forward the request to
 		// the htlc switch which will handle the negotiation and

--- a/server.go
+++ b/server.go
@@ -628,24 +628,10 @@ func newServer(cfg *Config, listenAddrs []net.Addr,
 	}
 
 	s.htlcSwitch, err = htlcswitch.New(htlcswitch.Config{
-		DB:                   dbs.ChanStateDB,
-		FetchAllOpenChannels: s.chanStateDB.FetchAllOpenChannels,
-		FetchAllChannels:     s.chanStateDB.FetchAllChannels,
-		FetchClosedChannels:  s.chanStateDB.FetchClosedChannels,
-		LocalChannelClose: func(pubKey []byte,
-			request *htlcswitch.ChanClose) {
-
-			peer, err := s.FindPeerByPubStr(string(pubKey))
-			if err != nil {
-				srvrLog.Errorf("unable to close channel, peer"+
-					" with %v id can't be found: %v",
-					pubKey, err,
-				)
-				return
-			}
-
-			peer.HandleLocalCloseChanReqs(request)
-		},
+		DB:                     dbs.ChanStateDB,
+		FetchAllOpenChannels:   s.chanStateDB.FetchAllOpenChannels,
+		FetchAllChannels:       s.chanStateDB.FetchAllChannels,
+		FetchClosedChannels:    s.chanStateDB.FetchClosedChannels,
 		FwdingLog:              dbs.ChanStateDB.ForwardingLog(),
 		SwitchPackager:         channeldb.NewSwitchPackager(),
 		ExtractErrorEncrypter:  s.sphinx.ExtractErrorEncrypter,


### PR DESCRIPTION
This PR adds FeeRange to ClosingSigned and makes lnd spec-compliant wrt FeeRange. Last 3 commits are new. 

This patch also introduces the first place we'll send out a warning in lnd per the [spec](https://github.com/lightning/bolts/blob/master/02-peer-protocol.md#closing-negotiation-closing_signed):
```
- if the message contains a fee_range:
  - if there is no overlap between that and its own fee_range:
    - SHOULD send a warning
```
Handling the warning is left for a future PR, since it is unclear what the funder should do as the `FeeRange` is already set and shouldn't change.

- [x] needs tests
- [x] depends on https://github.com/lightningnetwork/lnd/pull/6840
- [ ] depends on https://github.com/lightningnetwork/lnd/pull/6760
- [ ] probably should wait for https://github.com/lightning/bolts/issues/1013
- [ ] testing with other impls

Fixes #4413 