### PR TITLE
lint: enable line too long check and other linters

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -47,15 +47,17 @@ linters-settings:
     go: "1.18"
     checks: ["-SA1019"]
 
+  lll:
+    # Max line length, lines longer will be reported.
+    line-length: 80
+    # Tab width in spaces.
+    tab-width: 8
+
 linters:
   enable-all: true
   disable:
   # Global variables are used in many places throughout the code base.
   - gochecknoglobals
-
-  # Some lines are over 80 characters on purpose and we don't want to make them
-  # even longer by marking them as 'nolint'.
-  - lll
 
   # We want to allow short variable names.
   - varnamelen
@@ -124,7 +126,7 @@ linters:
 
 issues:
   # Only show newly introduced problems.
-  new-from-rev: 01f696afce2f9c0d4ed854edefa3846891d01d8a
+  new-from-rev: 8c66353e4c02329abdacb5a8df29998035ec2e24
 
   exclude-rules:
     # Exclude gosec from running for tests so that tests with weak randomness

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -53,6 +53,16 @@ linters-settings:
     # Tab width in spaces.
     tab-width: 8
 
+  funlen:
+    # Checks the number of lines in a function.
+    # If lower than 0, disable the check.
+    # Default: 60
+    lines: 60 
+    # Checks the number of statements in a function.
+    # Default: 40
+    statements: 40
+
+
 linters:
   enable-all: true
   disable:
@@ -65,18 +75,6 @@ linters:
   # We want to allow TODOs.
   - godox
 
-  # We have long functions, especially in tests. Moving or renaming those would
-  # trigger funlen problems that we may not want to solve at that time.
-  - funlen
-
-  # Disable for now as we haven't yet tuned the sensitivity to our codebase
-  # yet. Enabling by default for example, would also force new contributors to
-  # potentially extensively refactor code, when they want to smaller change to
-  # land.
-  - gocyclo
-  - gocognit
-  - cyclop
-
   # Instances of table driven tests that don't pre-allocate shouldn't trigger
   # the linter.
   - prealloc
@@ -84,46 +82,23 @@ linters:
   # Init functions are used by loggers throughout the codebase.
   - gochecknoinits
   
-  # Causes stack overflow, see https://github.com/polyfloyd/go-errorlint/issues/19.
-  - errorlint
-
   # Deprecated linters. See https://golangci-lint.run/usage/linters/.
   - interfacer
   - golint
   - maligned
   - scopelint
-  
-  # New linters that need a code adjustment first.
-  - wrapcheck
-  - nolintlint
-  - paralleltest
-  - tparallel
-  - testpackage
-  - gofumpt
-  - gomoddirectives
-  - ireturn
-  - maintidx
-  - nlreturn
-  - dogsled
-  - gci
-  - containedctx
-  - contextcheck
-  - errname
   - exhaustivestruct
-  - exhaustruct
-  - goerr113
-  - gomnd
-  - ifshort
-  - noctx
-  - nestif
-  - wsl
-  - exhaustive
-  - forcetypeassert
+  - bodyclose
+  - contextcheck
   - nilerr
-  - nilnil
-  - stylecheck
-  - thelper
-
+  - noctx
+  - rowserrcheck
+  - sqlclosecheck
+  - structcheck
+  - tparallel
+  - unparam
+  - wastedassign
+  
 issues:
   # Only show newly introduced problems.
   new-from-rev: 8c66353e4c02329abdacb5a8df29998035ec2e24
@@ -134,9 +109,11 @@ issues:
     - path: _test\.go
       linters:
         - gosec
+        - funlen
     - path: test*
       linters:
         - gosec
+        - funlen
 
     # Allow duplicated code and fmt.Printf() in DB migrations.
     - path: channeldb/migration*
@@ -172,3 +149,5 @@ issues:
         - deadcode
         - unparam
         - govet
+        # itest case can be very long so we disable long function check.
+        - funlen

--- a/config.go
+++ b/config.go
@@ -253,6 +253,8 @@ var (
 //
 // See LoadConfig for further details regarding the configuration
 // loading+parsing process.
+//
+// nolint:lll
 type Config struct {
 	ShowVersion bool `short:"V" long:"version" description:"Display version information and exit"`
 

--- a/docs/release-notes/release-notes-0.16.0.md
+++ b/docs/release-notes/release-notes-0.16.0.md
@@ -165,6 +165,9 @@ https://github.com/lightningnetwork/lnd/pull/6963/)
   easily](https://github.com/lightningnetwork/lnd/pull/5561), in preparation for
   adding a data migration functionality to `lndinit`.
 
+* [`golangci-lint` will now check new code using additional
+  linters.](https://github.com/lightningnetwork/lnd/pull/7064)
+
 ### Integration test
 
 The `lntest` has been

--- a/kvdb/etcd/config.go
+++ b/kvdb/etcd/config.go
@@ -3,6 +3,8 @@ package etcd
 import "fmt"
 
 // Config holds etcd configuration alongside with configuration related to our higher level interface.
+//
+// nolint:lll
 type Config struct {
 	Embedded bool `long:"embedded" description:"Use embedded etcd instance instead of the external one. Note: use for testing only."`
 

--- a/kvdb/postgres/config.go
+++ b/kvdb/postgres/config.go
@@ -3,6 +3,8 @@ package postgres
 import "time"
 
 // Config holds postgres configuration data.
+//
+// nolint:lll
 type Config struct {
 	Dsn            string        `long:"dsn" description:"Database connection string."`
 	Timeout        time.Duration `long:"timeout" description:"Database connection timeout. Set to zero to disable."`

--- a/lncfg/autopilot.go
+++ b/lncfg/autopilot.go
@@ -1,6 +1,8 @@
 package lncfg
 
 // AutoPilot holds the configuration options for the daemon's autopilot.
+//
+// nolint:lll
 type AutoPilot struct {
 	Active         bool               `long:"active" description:"If the autopilot agent should be active or not."`
 	Heuristic      map[string]float64 `long:"heuristic" description:"Heuristic to activate, and the weight to give it during scoring."`

--- a/lncfg/bitcoind.go
+++ b/lncfg/bitcoind.go
@@ -4,6 +4,8 @@ import "time"
 
 // Bitcoind holds the configuration options for the daemon's connection to
 // bitcoind.
+//
+// nolint:lll
 type Bitcoind struct {
 	Dir                  string        `long:"dir" description:"The base directory that contains the node's data, logs, configuration file, etc."`
 	ConfigPath           string        `long:"config" description:"Configuration filepath. If not set, will default to the default filename under 'dir'."`

--- a/lncfg/btcd.go
+++ b/lncfg/btcd.go
@@ -1,6 +1,8 @@
 package lncfg
 
 // Btcd holds the configuration options for the daemon's connection to btcd.
+//
+// nolint:lll
 type Btcd struct {
 	Dir        string `long:"dir" description:"The base directory that contains the node's data, logs, configuration file, etc."`
 	RPCHost    string `long:"rpchost" description:"The daemon's rpc listening address. If a port is omitted, then the default port for the selected chain parameters will be used."`

--- a/lncfg/caches.go
+++ b/lncfg/caches.go
@@ -20,6 +20,8 @@ const (
 )
 
 // Caches holds the configuration for various caches within lnd.
+//
+// nolint:lll
 type Caches struct {
 	// RejectCacheSize is the maximum number of entries stored in lnd's
 	// reject cache, which is used for efficiently rejecting gossip updates.

--- a/lncfg/chain.go
+++ b/lncfg/chain.go
@@ -7,6 +7,8 @@ import (
 )
 
 // Chain holds the configuration options for the daemon's chain settings.
+//
+// nolint:lll
 type Chain struct {
 	Active   bool   `long:"active" description:"If the chain should be active or not."`
 	ChainDir string `long:"chaindir" description:"The directory to store the chain's data within."`

--- a/lncfg/db.go
+++ b/lncfg/db.go
@@ -50,6 +50,8 @@ const (
 )
 
 // DB holds database configuration for LND.
+//
+// nolint:lll
 type DB struct {
 	Backend string `long:"backend" description:"The selected database backend."`
 

--- a/lncfg/gossip.go
+++ b/lncfg/gossip.go
@@ -7,6 +7,7 @@ import (
 	"github.com/lightningnetwork/lnd/routing/route"
 )
 
+// nolint:lll
 type Gossip struct {
 	PinnedSyncersRaw []string `long:"pinned-syncers" description:"A set of peers that should always remain in an active sync state, which can be used to closely synchronize the routing tables of two nodes. The value should be comma separated list of hex-encoded pubkeys. Connected peers matching this pubkey will remain active for the duration of the connection and not count towards the NumActiveSyncer count."`
 

--- a/lncfg/healthcheck.go
+++ b/lncfg/healthcheck.go
@@ -22,6 +22,8 @@ var (
 
 // HealthCheckConfig contains the configuration for the different health checks
 // the lnd runs.
+//
+// nolint:lll
 type HealthCheckConfig struct {
 	ChainCheck *CheckConfig `group:"chainbackend" namespace:"chainbackend"`
 

--- a/lncfg/invoices.go
+++ b/lncfg/invoices.go
@@ -7,6 +7,8 @@ package lncfg
 const DefaultHoldInvoiceExpiryDelta = DefaultIncomingBroadcastDelta + 2
 
 // Invoices holds the configuration options for invoices.
+//
+// nolint:lll
 type Invoices struct {
 	HoldExpiryDelta uint32 `long:"holdexpirydelta" description:"The number of blocks before a hold invoice's htlc expires that the invoice should be canceled to prevent a force close. Force closes will not be prevented if this value is not greater than DefaultIncomingBroadcastDelta."`
 }

--- a/lncfg/monitoring_on.go
+++ b/lncfg/monitoring_on.go
@@ -5,6 +5,8 @@ package lncfg
 
 // Prometheus is the set of configuration data that specifies the listening
 // address of the Prometheus exporter.
+//
+// nolint:lll
 type Prometheus struct {
 	// Listen is the listening address that we should use to allow the main
 	// Prometheus server to scrape our metrics.

--- a/lncfg/neutrino.go
+++ b/lncfg/neutrino.go
@@ -4,6 +4,8 @@ import "time"
 
 // Neutrino holds the configuration options for the daemon's connection to
 // neutrino.
+//
+// nolint:lll
 type Neutrino struct {
 	AddPeers           []string      `short:"a" long:"addpeer" description:"Add a peer to connect with at startup"`
 	ConnectPeers       []string      `long:"connect" description:"Connect only to the specified peers at startup"`

--- a/lncfg/protocol.go
+++ b/lncfg/protocol.go
@@ -6,6 +6,8 @@ package lncfg
 // ProtocolOptions is a struct that we use to be able to test backwards
 // compatibility of protocol additions, while defaulting to the latest within
 // lnd, or to enable experimental protocol changes.
+//
+// nolint:lll
 type ProtocolOptions struct {
 	// LegacyProtocol is a sub-config that houses all the legacy protocol
 	// options.  These are mostly used for integration tests as most modern

--- a/lncfg/protocol_legacy_on.go
+++ b/lncfg/protocol_legacy_on.go
@@ -6,6 +6,8 @@ package lncfg
 // Legacy is a sub-config that houses all the legacy protocol options.  These
 // are mostly used for integration tests as most modern nodes should always run
 // with them on by default.
+//
+// nolint:lll
 type LegacyProtocol struct {
 	// LegacyOnionFormat if set to true, then we won't signal
 	// TLVOnionPayloadOptional. As a result, nodes that include us in the

--- a/lncfg/protocol_rpctest.go
+++ b/lncfg/protocol_rpctest.go
@@ -6,6 +6,8 @@ package lncfg
 // ProtocolOptions is a struct that we use to be able to test backwards
 // compatibility of protocol additions, while defaulting to the latest within
 // lnd, or to enable experimental protocol changes.
+//
+// nolint:lll
 type ProtocolOptions struct {
 	// LegacyProtocol is a sub-config that houses all the legacy protocol
 	// options.  These are mostly used for integration tests as most modern

--- a/lncfg/remotesigner.go
+++ b/lncfg/remotesigner.go
@@ -12,6 +12,8 @@ const (
 )
 
 // RemoteSigner holds the configuration options for a remote RPC signer.
+//
+// nolint:lll
 type RemoteSigner struct {
 	Enable           bool          `long:"enable" description:"Use a remote signer for signing any on-chain related transactions or messages. Only recommended if local wallet is initialized as watch-only. Remote signer must use the same seed/root key as the local watch-only wallet but must have private keys."`
 	RPCHost          string        `long:"rpchost" description:"The remote signer's RPC host:port"`

--- a/lncfg/routing.go
+++ b/lncfg/routing.go
@@ -1,6 +1,8 @@
 package lncfg
 
 // Routing holds the configuration options for routing.
+//
+// nolint:lll
 type Routing struct {
 	AssumeChannelValid bool `long:"assumechanvalid" description:"Skip checking channel spentness during graph validation. This speedup comes at the risk of using an unvalidated view of the network for routing. (default: false)"`
 

--- a/lncfg/rpcmiddleware.go
+++ b/lncfg/rpcmiddleware.go
@@ -15,6 +15,8 @@ const (
 )
 
 // RPCMiddleware holds the configuration for RPC interception middleware.
+//
+// nolint:lll
 type RPCMiddleware struct {
 	Enable           bool          `long:"enable" description:"Enable the RPC middleware interceptor functionality."`
 	InterceptTimeout time.Duration `long:"intercepttimeout" description:"Time after which a RPC middleware intercept request will time out and return an error if it hasn't yet received a response."`

--- a/lncfg/sweeper.go
+++ b/lncfg/sweeper.go
@@ -5,6 +5,7 @@ import (
 	"time"
 )
 
+// nolint:lll
 type Sweeper struct {
 	BatchWindowDuration time.Duration `long:"batchwindowduration" description:"Duration of the sweep batch window. The sweep is held back during the batch window to allow more inputs to be added and thereby lower the fee per input."`
 }

--- a/lncfg/tor.go
+++ b/lncfg/tor.go
@@ -1,6 +1,8 @@
 package lncfg
 
 // Tor holds the configuration options for the daemon's connection to tor.
+//
+// nolint:lll
 type Tor struct {
 	Active                      bool   `long:"active" description:"Allow outbound and inbound connections to be routed through Tor"`
 	SOCKS                       string `long:"socks" description:"The host:port that Tor's exposed SOCKS5 proxy is listening on"`

--- a/lncfg/watchtower.go
+++ b/lncfg/watchtower.go
@@ -4,6 +4,8 @@ import "github.com/lightningnetwork/lnd/watchtower"
 
 // Watchtower holds the daemon specific configuration parameters for running a
 // watchtower that shares resources with the daemon.
+//
+// nolint:lll
 type Watchtower struct {
 	Active bool `long:"active" description:"If the watchtower should be active or not"`
 

--- a/lncfg/workers.go
+++ b/lncfg/workers.go
@@ -18,6 +18,8 @@ const (
 
 // Workers exposes CLI configuration for turning resources consumed by worker
 // pools.
+//
+// nolint:lll
 type Workers struct {
 	// Read is the maximum number of concurrent read pool workers.
 	Read int `long:"read" description:"Maximum number of concurrent read pool workers. This number should be proportional to the number of peers."`

--- a/lncfg/wtclient.go
+++ b/lncfg/wtclient.go
@@ -3,6 +3,8 @@ package lncfg
 import "fmt"
 
 // WtClient holds the configuration options for the daemon's watchtower client.
+//
+// nolint:lll
 type WtClient struct {
 	// Active determines whether a watchtower client should be created to
 	// back up channel states with registered watchtowers.


### PR DESCRIPTION
This PR enables the line length check and other previously disabled linters for newly added code. The line too long check should save some reviewers' time.