### PR TITLE
watchtower: start using the DeleteSession message

### DIFF
--- a/docs/release-notes/release-notes-0.16.1.md
+++ b/docs/release-notes/release-notes-0.16.1.md
@@ -9,6 +9,9 @@
 
 * [Allow caller to filter sessions at the time of reading them from 
   disk](https://github.com/lightningnetwork/lnd/pull/7059)
+* [Clean up sessions once all channels for which they have updates for are
+  closed. Also start sending the `DeleteSession` message to the
+  tower.](https://github.com/lightningnetwork/lnd/pull/7069)
 
 ## Misc
 

--- a/itest/list_on_test.go
+++ b/itest/list_on_test.go
@@ -515,4 +515,8 @@ var allTestCases = []*lntest.TestCase{
 		Name:     "lookup htlc resolution",
 		TestFunc: testLookupHtlcResolution,
 	},
+	{
+		Name:     "watchtower session management",
+		TestFunc: testWatchtowerSessionManagement,
+	},
 }

--- a/itest/lnd_watchtower_test.go
+++ b/itest/lnd_watchtower_test.go
@@ -1,0 +1,172 @@
+package itest
+
+import (
+	"fmt"
+
+	"github.com/btcsuite/btcd/btcutil"
+	"github.com/lightningnetwork/lnd/funding"
+	"github.com/lightningnetwork/lnd/lnrpc"
+	"github.com/lightningnetwork/lnd/lnrpc/routerrpc"
+	"github.com/lightningnetwork/lnd/lnrpc/wtclientrpc"
+	"github.com/lightningnetwork/lnd/lntest"
+	"github.com/lightningnetwork/lnd/lntest/node"
+	"github.com/lightningnetwork/lnd/lntest/wait"
+	"github.com/stretchr/testify/require"
+)
+
+// testWatchtowerSessionManagement tests that session deletion is done
+// correctly.
+func testWatchtowerSessionManagement(ht *lntest.HarnessTest) {
+	const (
+		chanAmt           = funding.MaxBtcFundingAmount
+		paymentAmt        = 10_000
+		numInvoices       = 5
+		maxUpdates        = numInvoices * 2
+		externalIP        = "1.2.3.4"
+		sessionCloseRange = 1
+	)
+
+	// Set up Wallis the watchtower who will be used by Dave to watch over
+	// his channel commitment transactions.
+	wallis := ht.NewNode("Wallis", []string{
+		"--watchtower.active",
+		"--watchtower.externalip=" + externalIP,
+	})
+
+	wallisInfo := wallis.RPC.GetInfoWatchtower()
+
+	// Assert that Wallis has one listener and it is 0.0.0.0:9911 or
+	// [::]:9911. Since no listener is explicitly specified, one of these
+	// should be the default depending on whether the host supports IPv6 or
+	// not.
+	require.Len(ht, wallisInfo.Listeners, 1)
+	listener := wallisInfo.Listeners[0]
+	require.True(ht, listener == "0.0.0.0:9911" || listener == "[::]:9911")
+
+	// Assert the Wallis's URIs properly display the chosen external IP.
+	require.Len(ht, wallisInfo.Uris, 1)
+	require.Contains(ht, wallisInfo.Uris[0], externalIP)
+
+	// Dave will be the tower client.
+	daveArgs := []string{
+		"--wtclient.active",
+		fmt.Sprintf("--wtclient.max-updates=%d", maxUpdates),
+		fmt.Sprintf(
+			"--wtclient.session-close-range=%d", sessionCloseRange,
+		),
+	}
+	dave := ht.NewNode("Dave", daveArgs)
+
+	addTowerReq := &wtclientrpc.AddTowerRequest{
+		Pubkey:  wallisInfo.Pubkey,
+		Address: listener,
+	}
+	dave.RPC.AddTower(addTowerReq)
+
+	// Assert that there exists a session between Dave and Wallis.
+	err := wait.NoError(func() error {
+		info := dave.RPC.GetTowerInfo(&wtclientrpc.GetTowerInfoRequest{
+			Pubkey:          wallisInfo.Pubkey,
+			IncludeSessions: true,
+		})
+
+		var numSessions uint32
+		for _, sessionType := range info.SessionInfo {
+			numSessions += sessionType.NumSessions
+		}
+		if numSessions > 0 {
+			return nil
+		}
+
+		return fmt.Errorf("expected a non-zero number of sessions")
+	}, defaultTimeout)
+	require.NoError(ht, err)
+
+	// Before we make a channel, we'll load up Dave with some coins sent
+	// directly from the miner.
+	ht.FundCoins(btcutil.SatoshiPerBitcoin, dave)
+
+	// Connect Dave and Alice.
+	ht.ConnectNodes(dave, ht.Alice)
+
+	// Open a channel between Dave and Alice.
+	params := lntest.OpenChannelParams{
+		Amt: chanAmt,
+	}
+	chanPoint := ht.OpenChannel(dave, ht.Alice, params)
+
+	// Since there are 2 updates made for every payment and the maximum
+	// number of updates per session has been set to 10, make 5 payments
+	// between the pair so that the session is exhausted.
+	alicePayReqs, _, _ := ht.CreatePayReqs(
+		ht.Alice, paymentAmt, numInvoices,
+	)
+
+	send := func(node *node.HarnessNode, payReq string) {
+		stream := node.RPC.SendPayment(&routerrpc.SendPaymentRequest{
+			PaymentRequest: payReq,
+			TimeoutSeconds: 60,
+			FeeLimitMsat:   noFeeLimitMsat,
+		})
+
+		ht.AssertPaymentStatusFromStream(
+			stream, lnrpc.Payment_SUCCEEDED,
+		)
+	}
+
+	for i := 0; i < numInvoices; i++ {
+		send(dave, alicePayReqs[i])
+	}
+
+	// assertNumBackups is a closure that asserts that Dave has a certain
+	// number of backups backed up to the tower. If mineOnFail is true,
+	// then a block will be mined each time the assertion fails.
+	assertNumBackups := func(expected int, mineOnFail bool) {
+		err = wait.NoError(func() error {
+			info := dave.RPC.GetTowerInfo(
+				&wtclientrpc.GetTowerInfoRequest{
+					Pubkey:          wallisInfo.Pubkey,
+					IncludeSessions: true,
+				},
+			)
+
+			var numBackups uint32
+			for _, sessionType := range info.SessionInfo {
+				for _, session := range sessionType.Sessions {
+					numBackups += session.NumBackups
+				}
+			}
+
+			if numBackups == uint32(expected) {
+				return nil
+			}
+
+			if mineOnFail {
+				ht.Miner.MineBlocksSlow(1)
+			}
+
+			return fmt.Errorf("expected %d backups, got %d",
+				expected, numBackups)
+		}, defaultTimeout)
+		require.NoError(ht, err)
+	}
+
+	// Assert that one of the sessions now has 10 backups.
+	assertNumBackups(10, false)
+
+	// Now close the channel and wait for the close transaction to appear
+	// in the mempool so that it is included in a block when we mine.
+	ht.CloseChannelAssertPending(dave, chanPoint, false)
+
+	// Mine enough blocks to surpass the session-close-range. This should
+	// trigger the session to be deleted.
+	ht.MineBlocksAndAssertNumTxes(sessionCloseRange+6, 1)
+
+	// Wait for the session to be deleted. We know it has been deleted once
+	// the number of backups is back to zero. We check for number of backups
+	// instead of number of sessions because it is expected that the client
+	// would immediately negotiate another session after deleting the
+	// exhausted one. This time we set the "mineOnFail" parameter to true to
+	// ensure that the session deleting logic is run.
+	assertNumBackups(0, true)
+}

--- a/lncfg/wtclient.go
+++ b/lncfg/wtclient.go
@@ -17,6 +17,11 @@ type WtClient struct {
 	// SweepFeeRate specifies the fee rate in sat/byte to be used when
 	// constructing justice transactions sent to the tower.
 	SweepFeeRate uint64 `long:"sweep-fee-rate" description:"Specifies the fee rate in sat/byte to be used when constructing justice transactions sent to the watchtower."`
+
+	// SessionCloseRange is the range over which to choose a random number
+	// of blocks to wait after the last channel of a session is closed
+	// before sending the DeleteSession message to the tower server.
+	SessionCloseRange uint32 `long:"session-close-range" description:"The range over which to choose a random number of blocks to wait after the last channel of a session is closed before sending the DeleteSession message to the tower server. Set to 1 for no delay."`
 }
 
 // Validate ensures the user has provided a valid configuration.

--- a/lncfg/wtclient.go
+++ b/lncfg/wtclient.go
@@ -22,6 +22,10 @@ type WtClient struct {
 	// of blocks to wait after the last channel of a session is closed
 	// before sending the DeleteSession message to the tower server.
 	SessionCloseRange uint32 `long:"session-close-range" description:"The range over which to choose a random number of blocks to wait after the last channel of a session is closed before sending the DeleteSession message to the tower server. Set to 1 for no delay."`
+
+	// MaxUpdates is the maximum number of updates to be backed up in a
+	// single tower sessions.
+	MaxUpdates uint16 `long:"max-updates" description:"The maximum number of updates to be backed up in a single session."`
 }
 
 // Validate ensures the user has provided a valid configuration.

--- a/lnrpc/wtclientrpc/wtclient.go
+++ b/lnrpc/wtclientrpc/wtclient.go
@@ -309,6 +309,7 @@ func (c *WatchtowerClient) ListTowers(ctx context.Context,
 		}
 
 		t.SessionInfo = append(t.SessionInfo, rpcTower.SessionInfo...)
+		t.Sessions = append(t.Sessions, rpcTower.Sessions...)
 	}
 
 	towers := make([]*Tower, 0, len(rpcTowers))
@@ -364,6 +365,9 @@ func (c *WatchtowerClient) GetTowerInfo(ctx context.Context,
 
 	rpcTower.SessionInfo = append(
 		rpcTower.SessionInfo, rpcLegacyTower.SessionInfo...,
+	)
+	rpcTower.Sessions = append(
+		rpcTower.Sessions, rpcLegacyTower.Sessions...,
 	)
 
 	return rpcTower, nil

--- a/lntest/rpc/watchtower.go
+++ b/lntest/rpc/watchtower.go
@@ -24,6 +24,20 @@ func (h *HarnessRPC) GetInfoWatchtower() *watchtowerrpc.GetInfoResponse {
 	return info
 }
 
+// GetTowerInfo makes an RPC call to the watchtower client of the given node and
+// asserts.
+func (h *HarnessRPC) GetTowerInfo(
+	req *wtclientrpc.GetTowerInfoRequest) *wtclientrpc.Tower {
+
+	ctxt, cancel := context.WithTimeout(h.runCtx, DefaultTimeout)
+	defer cancel()
+
+	info, err := h.WatchtowerClient.GetTowerInfo(ctxt, req)
+	h.NoError(err, "GetTowerInfo from WatchtowerClient")
+
+	return info
+}
+
 // AddTower makes a RPC call to the WatchtowerClient of the given node and
 // asserts.
 func (h *HarnessRPC) AddTower(

--- a/sample-lnd.conf
+++ b/sample-lnd.conf
@@ -1004,6 +1004,9 @@ litecoin.node=ltcd
 ; along with reduced privacy from the tower server.
 ; wtclient.session-close-range=10
 
+; The maximum number of updates to include in a tower session.
+; wtclient.max-updates=1024
+
 [healthcheck]
 
 ; The number of times we should attempt to query our chain backend before

--- a/sample-lnd.conf
+++ b/sample-lnd.conf
@@ -997,6 +997,12 @@ litecoin.node=ltcd
 ; supported at this time, if none are provided the tower will not be enabled.
 ; wtclient.private-tower-uris=
 
+; The range over which to choose a random number of blocks to wait after the
+; last channel of a session is closed before sending the DeleteSession message
+; to the tower server. The default is currently 288. Note that setting this to
+; a lower value will result in faster session cleanup _but_ that this comes
+; along with reduced privacy from the tower server.
+; wtclient.session-close-range=10
 
 [healthcheck]
 

--- a/server.go
+++ b/server.go
@@ -1512,7 +1512,16 @@ func newServer(cfg *Config, listenAddrs []net.Addr,
 			)
 		}
 
+		fetchClosedChannel := s.chanStateDB.FetchClosedChannelForID
+
 		s.towerClient, err = wtclient.New(&wtclient.Config{
+			FetchClosedChannel: fetchClosedChannel,
+			SubscribeChannelEvents: func() (subscribe.Subscription,
+				error) {
+
+				return s.channelNotifier.
+					SubscribeChannelEvents()
+			},
 			Signer:         cc.Wallet.Cfg.Signer,
 			NewAddress:     newSweepPkScriptGen(cc.Wallet),
 			SecretKeyRing:  s.cc.KeyRing,
@@ -1536,6 +1545,13 @@ func newServer(cfg *Config, listenAddrs []net.Addr,
 			blob.Type(blob.FlagAnchorChannel)
 
 		s.anchorTowerClient, err = wtclient.New(&wtclient.Config{
+			FetchClosedChannel: fetchClosedChannel,
+			SubscribeChannelEvents: func() (subscribe.Subscription,
+				error) {
+
+				return s.channelNotifier.
+					SubscribeChannelEvents()
+			},
 			Signer:         cc.Wallet.Cfg.Signer,
 			NewAddress:     newSweepPkScriptGen(cc.Wallet),
 			SecretKeyRing:  s.cc.KeyRing,

--- a/server.go
+++ b/server.go
@@ -1497,6 +1497,11 @@ func newServer(cfg *Config, listenAddrs []net.Addr,
 			policy.SweepFeeRate = sweepRateSatPerVByte.FeePerKWeight()
 		}
 
+		sessionCloseRange := uint32(wtclient.DefaultSessionCloseRange)
+		if cfg.WtClient.SessionCloseRange != 0 {
+			sessionCloseRange = cfg.WtClient.SessionCloseRange
+		}
+
 		if err := policy.Validate(); err != nil {
 			return nil, err
 		}
@@ -1516,6 +1521,8 @@ func newServer(cfg *Config, listenAddrs []net.Addr,
 
 		s.towerClient, err = wtclient.New(&wtclient.Config{
 			FetchClosedChannel: fetchClosedChannel,
+			SessionCloseRange:  sessionCloseRange,
+			ChainNotifier:      s.cc.ChainNotifier,
 			SubscribeChannelEvents: func() (subscribe.Subscription,
 				error) {
 
@@ -1546,6 +1553,8 @@ func newServer(cfg *Config, listenAddrs []net.Addr,
 
 		s.anchorTowerClient, err = wtclient.New(&wtclient.Config{
 			FetchClosedChannel: fetchClosedChannel,
+			SessionCloseRange:  sessionCloseRange,
+			ChainNotifier:      s.cc.ChainNotifier,
 			SubscribeChannelEvents: func() (subscribe.Subscription,
 				error) {
 

--- a/server.go
+++ b/server.go
@@ -1497,6 +1497,10 @@ func newServer(cfg *Config, listenAddrs []net.Addr,
 			policy.SweepFeeRate = sweepRateSatPerVByte.FeePerKWeight()
 		}
 
+		if cfg.WtClient.MaxUpdates != 0 {
+			policy.MaxUpdates = cfg.WtClient.MaxUpdates
+		}
+
 		sessionCloseRange := uint32(wtclient.DefaultSessionCloseRange)
 		if cfg.WtClient.SessionCloseRange != 0 {
 			sessionCloseRange = cfg.WtClient.SessionCloseRange

--- a/watchtower/wtclient/addr_iterator_test.go
+++ b/watchtower/wtclient/addr_iterator_test.go
@@ -97,6 +97,11 @@ func TestAddrIterator(t *testing.T) {
 	addrList := iter.GetAll()
 	require.ElementsMatch(t, addrList, []net.Addr{addr1, addr2, addr3})
 
+	// Also check that an iterator constructed via the Copy method, also
+	// contains all the expected addresses.
+	newIterAddrs := iter.Copy().GetAll()
+	require.ElementsMatch(t, newIterAddrs, []net.Addr{addr1, addr2, addr3})
+
 	// Let's now remove addr3.
 	err = iter.Remove(addr3)
 	require.NoError(t, err)

--- a/watchtower/wtclient/candidate_iterator.go
+++ b/watchtower/wtclient/candidate_iterator.go
@@ -29,6 +29,10 @@ type TowerCandidateIterator interface {
 	// candidates available as long as they remain in the set.
 	Reset() error
 
+	// GetTower gets the tower with the given ID from the iterator. If no
+	// such tower is found then ErrTowerNotInIterator is returned.
+	GetTower(id wtdb.TowerID) (*Tower, error)
+
 	// Next returns the next candidate tower. The iterator is not required
 	// to return results in any particular order.  If no more candidates are
 	// available, ErrTowerCandidatesExhausted is returned.
@@ -74,6 +78,20 @@ func (t *towerListIterator) Reset() error {
 	t.nextCandidate = t.queue.Front()
 
 	return nil
+}
+
+// GetTower gets the tower with the given ID from the iterator. If no such tower
+// is found then ErrTowerNotInIterator is returned.
+func (t *towerListIterator) GetTower(id wtdb.TowerID) (*Tower, error) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	tower, ok := t.candidates[id]
+	if !ok {
+		return nil, ErrTowerNotInIterator
+	}
+
+	return tower, nil
 }
 
 // Next returns the next candidate tower. This iterator will always return

--- a/watchtower/wtclient/candidate_iterator_test.go
+++ b/watchtower/wtclient/candidate_iterator_test.go
@@ -52,14 +52,10 @@ func randTower(t *testing.T) *Tower {
 func copyTower(t *testing.T, tower *Tower) *Tower {
 	t.Helper()
 
-	addrs := tower.Addresses.GetAll()
-	addrIterator, err := newAddressIterator(addrs...)
-	require.NoError(t, err)
-
 	return &Tower{
 		ID:          tower.ID,
 		IdentityKey: tower.IdentityKey,
-		Addresses:   addrIterator,
+		Addresses:   tower.Addresses.Copy(),
 	}
 }
 

--- a/watchtower/wtclient/candidate_iterator_test.go
+++ b/watchtower/wtclient/candidate_iterator_test.go
@@ -83,9 +83,15 @@ func assertNextCandidate(t *testing.T, i TowerCandidateIterator, c *Tower) {
 
 	tower, err := i.Next()
 	require.NoError(t, err)
-	require.True(t, tower.IdentityKey.IsEqual(c.IdentityKey))
-	require.Equal(t, tower.ID, c.ID)
-	require.Equal(t, tower.Addresses.GetAll(), c.Addresses.GetAll())
+	assertTowersEqual(t, c, tower)
+}
+
+func assertTowersEqual(t *testing.T, expected, actual *Tower) {
+	t.Helper()
+
+	require.True(t, expected.IdentityKey.IsEqual(actual.IdentityKey))
+	require.Equal(t, expected.ID, actual.ID)
+	require.Equal(t, expected.Addresses.GetAll(), actual.Addresses.GetAll())
 }
 
 // TestTowerCandidateIterator asserts the internal state of a
@@ -155,4 +161,16 @@ func TestTowerCandidateIterator(t *testing.T) {
 	towerIterator.AddCandidate(secondTower)
 	assertActiveCandidate(t, towerIterator, secondTower, true)
 	assertNextCandidate(t, towerIterator, secondTower)
+
+	// Assert that the GetTower correctly returns the tower too.
+	tower, err := towerIterator.GetTower(secondTower.ID)
+	require.NoError(t, err)
+	assertTowersEqual(t, secondTower, tower)
+
+	// Now remove the tower and assert that GetTower returns expected error.
+	err = towerIterator.RemoveCandidate(secondTower.ID, nil)
+	require.NoError(t, err)
+
+	_, err = towerIterator.GetTower(secondTower.ID)
+	require.ErrorIs(t, err, ErrTowerNotInIterator)
 }

--- a/watchtower/wtclient/client.go
+++ b/watchtower/wtclient/client.go
@@ -271,6 +271,8 @@ type TowerClient struct {
 	sessionQueue *sessionQueue
 	prevTask     *backupTask
 
+	closableSessionQueue *sessionCloseMinHeap
+
 	backupMu          sync.Mutex
 	summaries         wtdb.ChannelSummaries
 	chanCommitHeights map[lnwire.ChannelID]uint64
@@ -322,18 +324,19 @@ func New(config *Config) (*TowerClient, error) {
 	}
 
 	c := &TowerClient{
-		cfg:               cfg,
-		log:               plog,
-		pipeline:          newTaskPipeline(plog),
-		chanCommitHeights: make(map[lnwire.ChannelID]uint64),
-		activeSessions:    make(sessionQueueSet),
-		summaries:         chanSummaries,
-		statTicker:        time.NewTicker(DefaultStatInterval),
-		stats:             new(ClientStats),
-		newTowers:         make(chan *newTowerMsg),
-		staleTowers:       make(chan *staleTowerMsg),
-		forceQuit:         make(chan struct{}),
-		quit:              make(chan struct{}),
+		cfg:                  cfg,
+		log:                  plog,
+		pipeline:             newTaskPipeline(plog),
+		chanCommitHeights:    make(map[lnwire.ChannelID]uint64),
+		activeSessions:       make(sessionQueueSet),
+		summaries:            chanSummaries,
+		closableSessionQueue: newSessionCloseMinHeap(),
+		statTicker:           time.NewTicker(DefaultStatInterval),
+		stats:                new(ClientStats),
+		newTowers:            make(chan *newTowerMsg),
+		staleTowers:          make(chan *staleTowerMsg),
+		forceQuit:            make(chan struct{}),
+		quit:                 make(chan struct{}),
 	}
 
 	// perUpdate is a callback function that will be used to inspect the

--- a/watchtower/wtclient/client.go
+++ b/watchtower/wtclient/client.go
@@ -2,8 +2,10 @@ package wtclient
 
 import (
 	"bytes"
+	"crypto/rand"
 	"errors"
 	"fmt"
+	"math/big"
 	"net"
 	"sync"
 	"time"
@@ -12,6 +14,7 @@ import (
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btclog"
 	"github.com/lightningnetwork/lnd/build"
+	"github.com/lightningnetwork/lnd/chainntnfs"
 	"github.com/lightningnetwork/lnd/channeldb"
 	"github.com/lightningnetwork/lnd/channelnotifier"
 	"github.com/lightningnetwork/lnd/input"
@@ -43,6 +46,11 @@ const (
 	// client should abandon any pending updates or session negotiations
 	// before terminating.
 	DefaultForceQuitDelay = 10 * time.Second
+
+	// DefaultSessionCloseRange is the range over which we will generate a
+	// random number of blocks to delay closing a session after its last
+	// channel has been closed.
+	DefaultSessionCloseRange = 288
 )
 
 // genSessionFilter constructs a filter that can be used to select sessions only
@@ -159,6 +167,9 @@ type Config struct {
 	FetchClosedChannel func(cid lnwire.ChannelID) (
 		*channeldb.ChannelCloseSummary, error)
 
+	// ChainNotifier can be used to subscribe to block notifications.
+	ChainNotifier chainntnfs.ChainNotifier
+
 	// NewAddress generates a new on-chain sweep pkscript.
 	NewAddress func() ([]byte, error)
 
@@ -214,6 +225,11 @@ type Config struct {
 	// watchtowers. If the exponential backoff produces a timeout greater
 	// than this value, the backoff will be clamped to MaxBackoff.
 	MaxBackoff time.Duration
+
+	// SessionCloseRange is the range over which we will generate a random
+	// number of blocks to delay closing a session after its last channel
+	// has been closed.
+	SessionCloseRange uint32
 }
 
 // newTowerMsg is an internal message we'll use within the TowerClient to signal
@@ -590,8 +606,33 @@ func (c *TowerClient) Start() error {
 			delete(c.summaries, id)
 		}
 
+		// Load all closable sessions.
+		closableSessions, err := c.cfg.DB.ListClosableSessions()
+		if err != nil {
+			returnErr = err
+			return
+		}
+
+		err = c.trackClosableSessions(closableSessions)
+		if err != nil {
+			returnErr = err
+			return
+		}
+
 		c.wg.Add(1)
 		go c.handleChannelCloses(chanSub)
+
+		// Subscribe to new block events.
+		blockEvents, err := c.cfg.ChainNotifier.RegisterBlockEpochNtfn(
+			nil,
+		)
+		if err != nil {
+			returnErr = err
+			return
+		}
+
+		c.wg.Add(1)
+		go c.handleClosableSessions(blockEvents)
 
 		// Now start the session negotiator, which will allow us to
 		// request new session as soon as the backupDispatcher starts
@@ -876,7 +917,8 @@ func (c *TowerClient) handleChannelCloses(chanSub subscribe.Subscription) {
 }
 
 // handleClosedChannel handles the closure of a single channel. It will mark the
-// channel as closed in the DB.
+// channel as closed in the DB, then it will handle all the sessions that are
+// now closable due to the channel closure.
 func (c *TowerClient) handleClosedChannel(chanID lnwire.ChannelID,
 	closeHeight uint32) error {
 
@@ -890,14 +932,142 @@ func (c *TowerClient) handleClosedChannel(chanID lnwire.ChannelID,
 
 	c.log.Debugf("Marking channel(%s) as closed", chanID)
 
-	_, err := c.cfg.DB.MarkChannelClosed(chanID, closeHeight)
+	sessions, err := c.cfg.DB.MarkChannelClosed(chanID, closeHeight)
 	if err != nil {
 		return fmt.Errorf("could not mark channel(%s) as closed: %w",
 			chanID, err)
 	}
 
+	closableSessions := make(map[wtdb.SessionID]uint32, len(sessions))
+	for _, sess := range sessions {
+		closableSessions[sess] = closeHeight
+	}
+
+	c.log.Debugf("Tracking %d new closable sessions as a result of "+
+		"closing channel %s", len(closableSessions), chanID)
+
+	err = c.trackClosableSessions(closableSessions)
+	if err != nil {
+		return fmt.Errorf("could not track closable sessions: %w", err)
+	}
+
 	delete(c.summaries, chanID)
 	delete(c.chanCommitHeights, chanID)
+
+	return nil
+}
+
+// handleClosableSessions listens for new block notifications. For each block,
+// it checks the closableSessionQueue to see if there is a closable session with
+// a delete-height smaller than or equal to the new block, if there is then the
+// tower is informed that it can delete the session, and then we also delete it
+// from our DB.
+func (c *TowerClient) handleClosableSessions(
+	blocksChan *chainntnfs.BlockEpochEvent) {
+
+	defer c.wg.Done()
+
+	c.log.Debug("Starting closable sessions handler")
+	defer c.log.Debug("Stopping closable sessions handler")
+
+	for {
+		select {
+		case newBlock := <-blocksChan.Epochs:
+			if newBlock == nil {
+				return
+			}
+
+			height := uint32(newBlock.Height)
+			for {
+				select {
+				case <-c.quit:
+					return
+				default:
+				}
+
+				// If there are no closable sessions that we
+				// need to handle, then we are done and can
+				// reevaluate when the next block comes.
+				item := c.closableSessionQueue.Top()
+				if item == nil {
+					break
+				}
+
+				// If there is closable session but the delete
+				// height we have set for it is after the
+				// current block height, then our work is done.
+				if item.deleteHeight > height {
+					break
+				}
+
+				// Otherwise, we pop this item from the heap
+				// and handle it.
+				c.closableSessionQueue.Pop()
+
+				// Fetch the session from the DB so that we can
+				// extract the Tower info.
+				sess, err := c.cfg.DB.GetClientSession(
+					item.sessionID,
+				)
+				if err != nil {
+					c.log.Errorf("error calling "+
+						"GetClientSession for "+
+						"session %s: %v",
+						item.sessionID, err)
+
+					continue
+				}
+
+				err = c.deleteSessionFromTower(sess)
+				if err != nil {
+					c.log.Errorf("error deleting "+
+						"session %s from tower: %v",
+						sess.ID, err)
+
+					continue
+				}
+
+				err = c.cfg.DB.DeleteSession(item.sessionID)
+				if err != nil {
+					c.log.Errorf("could not delete "+
+						"session(%s) from DB: %w",
+						sess.ID, err)
+
+					continue
+				}
+			}
+
+		case <-c.forceQuit:
+			return
+
+		case <-c.quit:
+			return
+		}
+	}
+}
+
+// trackClosableSessions takes in a map of session IDs to the earliest block
+// height at which the session should be deleted. For each of the sessions,
+// a random delay is added to the block height and the session is added to the
+// closableSessionQueue.
+func (c *TowerClient) trackClosableSessions(
+	sessions map[wtdb.SessionID]uint32) error {
+
+	// For each closable session, add a random delay to its close
+	// height and add it to the closableSessionQueue.
+	for sID, blockHeight := range sessions {
+		delay, err := newRandomDelay(c.cfg.SessionCloseRange)
+		if err != nil {
+			return err
+		}
+
+		deleteHeight := blockHeight + delay
+
+		c.closableSessionQueue.Push(&sessionCloseItem{
+			sessionID:    sID,
+			deleteHeight: deleteHeight,
+		})
+	}
 
 	return nil
 }
@@ -1670,4 +1840,16 @@ func (c *TowerClient) logMessage(
 	c.log.Debugf("%s %s%v %s %x@%s", action, msg.MsgType(), summary,
 		preposition, peer.RemotePub().SerializeCompressed(),
 		peer.RemoteAddr())
+}
+
+func newRandomDelay(max uint32) (uint32, error) {
+	var maxDelay big.Int
+	maxDelay.SetUint64(uint64(max))
+
+	randDelay, err := rand.Int(rand.Reader, &maxDelay)
+	if err != nil {
+		return 0, err
+	}
+
+	return uint32(randDelay.Uint64()), nil
 }

--- a/watchtower/wtclient/client.go
+++ b/watchtower/wtclient/client.go
@@ -435,27 +435,19 @@ func getTowerAndSessionCandidates(db DB, keyRing ECDHKeyRing,
 		}
 
 		for _, s := range sessions {
-			towerKeyDesc, err := keyRing.DeriveKey(
-				keychain.KeyLocator{
-					Family: keychain.KeyFamilyTowerSession,
-					Index:  s.KeyIndex,
-				},
+			if !sessionFilter(s) {
+				continue
+			}
+
+			cs, err := NewClientSessionFromDBSession(
+				s, tower, keyRing,
 			)
 			if err != nil {
 				return nil, err
 			}
 
-			sessionKeyECDH := keychain.NewPubKeyECDH(
-				towerKeyDesc, keyRing,
-			)
-
 			// Add the session to the set of candidate sessions.
-			candidateSessions[s.ID] = &ClientSession{
-				ID:                s.ID,
-				ClientSessionBody: s.ClientSessionBody,
-				Tower:             tower,
-				SessionKeyECDH:    sessionKeyECDH,
-			}
+			candidateSessions[s.ID] = cs
 
 			perActiveTower(tower)
 		}

--- a/watchtower/wtclient/errors.go
+++ b/watchtower/wtclient/errors.go
@@ -1,6 +1,8 @@
 package wtclient
 
-import "errors"
+import (
+	"errors"
+)
 
 var (
 	// ErrClientExiting signals that the watchtower client is shutting down.
@@ -10,6 +12,10 @@ var (
 	// cycled through all available candidates.
 	ErrTowerCandidatesExhausted = errors.New("exhausted all tower " +
 		"candidates")
+
+	// ErrTowerNotInIterator is returned when a requested tower was not
+	// found in the iterator.
+	ErrTowerNotInIterator = errors.New("tower not in iterator")
 
 	// ErrPermanentTowerFailure signals that the tower has reported that it
 	// has permanently failed or the client believes this has happened based

--- a/watchtower/wtclient/interface.go
+++ b/watchtower/wtclient/interface.go
@@ -83,7 +83,8 @@ type DB interface {
 	NumAckedUpdates(id *wtdb.SessionID) (uint64, error)
 
 	// FetchChanSummaries loads a mapping from all registered channels to
-	// their channel summaries.
+	// their channel summaries. Only the channels that have not yet been
+	// marked as closed will be loaded.
 	FetchChanSummaries() (wtdb.ChannelSummaries, error)
 
 	// MarkChannelClosed will mark a registered channel as closed by setting

--- a/watchtower/wtclient/interface.go
+++ b/watchtower/wtclient/interface.go
@@ -99,6 +99,12 @@ type DB interface {
 	// marked as closable.
 	ListClosableSessions() (map[wtdb.SessionID]uint32, error)
 
+	// DeleteSession can be called when a session should be deleted from the
+	// DB. All references to the session will also be deleted from the DB.
+	// A session will only be deleted if it was previously marked as
+	// closable.
+	DeleteSession(id wtdb.SessionID) error
+
 	// RegisterChannel registers a channel for use within the client
 	// database. For now, all that is stored in the channel summary is the
 	// sweep pkscript that we'd like any tower sweeps to pay into. In the

--- a/watchtower/wtclient/interface.go
+++ b/watchtower/wtclient/interface.go
@@ -198,3 +198,30 @@ type ClientSession struct {
 	// key used to connect to the watchtower.
 	SessionKeyECDH keychain.SingleKeyECDH
 }
+
+// NewClientSessionFromDBSession converts a wtdb.ClientSession to a
+// ClientSession.
+func NewClientSessionFromDBSession(s *wtdb.ClientSession, tower *Tower,
+	keyRing ECDHKeyRing) (*ClientSession, error) {
+
+	towerKeyDesc, err := keyRing.DeriveKey(
+		keychain.KeyLocator{
+			Family: keychain.KeyFamilyTowerSession,
+			Index:  s.KeyIndex,
+		},
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	sessionKeyECDH := keychain.NewPubKeyECDH(
+		towerKeyDesc, keyRing,
+	)
+
+	return &ClientSession{
+		ID:                s.ID,
+		ClientSessionBody: s.ClientSessionBody,
+		Tower:             tower,
+		SessionKeyECDH:    sessionKeyECDH,
+	}, nil
+}

--- a/watchtower/wtclient/interface.go
+++ b/watchtower/wtclient/interface.go
@@ -95,6 +95,10 @@ type DB interface {
 	MarkChannelClosed(chanID lnwire.ChannelID, blockHeight uint32) (
 		[]wtdb.SessionID, error)
 
+	// ListClosableSessions fetches and returns the IDs for all sessions
+	// marked as closable.
+	ListClosableSessions() (map[wtdb.SessionID]uint32, error)
+
 	// RegisterChannel registers a channel for use within the client
 	// database. For now, all that is stored in the channel summary is the
 	// sweep pkscript that we'd like any tower sweeps to pay into. In the

--- a/watchtower/wtclient/interface.go
+++ b/watchtower/wtclient/interface.go
@@ -86,6 +86,15 @@ type DB interface {
 	// their channel summaries.
 	FetchChanSummaries() (wtdb.ChannelSummaries, error)
 
+	// MarkChannelClosed will mark a registered channel as closed by setting
+	// its closed-height as the given block height. It returns a list of
+	// session IDs for sessions that are now considered closable due to the
+	// close of this channel. The details for this channel will be deleted
+	// from the DB if there are no more sessions in the DB that contain
+	// updates for this channel.
+	MarkChannelClosed(chanID lnwire.ChannelID, blockHeight uint32) (
+		[]wtdb.SessionID, error)
+
 	// RegisterChannel registers a channel for use within the client
 	// database. For now, all that is stored in the channel summary is the
 	// sweep pkscript that we'd like any tower sweeps to pay into. In the

--- a/watchtower/wtclient/interface.go
+++ b/watchtower/wtclient/interface.go
@@ -64,6 +64,11 @@ type DB interface {
 		...wtdb.ClientSessionListOption) (
 		map[wtdb.SessionID]*wtdb.ClientSession, error)
 
+	// GetClientSession loads the ClientSession with the given ID from the
+	// DB.
+	GetClientSession(wtdb.SessionID,
+		...wtdb.ClientSessionListOption) (*wtdb.ClientSession, error)
+
 	// FetchSessionCommittedUpdates retrieves the current set of un-acked
 	// updates of the given session.
 	FetchSessionCommittedUpdates(id *wtdb.SessionID) (

--- a/watchtower/wtclient/sess_close_min_heap.go
+++ b/watchtower/wtclient/sess_close_min_heap.go
@@ -1,0 +1,95 @@
+package wtclient
+
+import (
+	"sync"
+
+	"github.com/lightningnetwork/lnd/queue"
+	"github.com/lightningnetwork/lnd/watchtower/wtdb"
+)
+
+// sessionCloseMinHeap is a thread-safe min-heap implementation that stores
+// sessionCloseItem items and prioritises the item with the lowest block height.
+type sessionCloseMinHeap struct {
+	queue queue.PriorityQueue
+	mu    sync.Mutex
+}
+
+// newSessionCloseMinHeap constructs a new sessionCloseMineHeap.
+func newSessionCloseMinHeap() *sessionCloseMinHeap {
+	return &sessionCloseMinHeap{}
+}
+
+// Len returns the length of the queue.
+func (h *sessionCloseMinHeap) Len() int {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	return h.queue.Len()
+}
+
+// Empty returns true if the queue is empty.
+func (h *sessionCloseMinHeap) Empty() bool {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	return h.queue.Empty()
+}
+
+// Push adds an item to the priority queue.
+func (h *sessionCloseMinHeap) Push(item *sessionCloseItem) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	h.queue.Push(item)
+}
+
+// Pop removes the top most item from the queue.
+func (h *sessionCloseMinHeap) Pop() *sessionCloseItem {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	if h.queue.Empty() {
+		return nil
+	}
+
+	item := h.queue.Pop()
+
+	return item.(*sessionCloseItem) //nolint:forcetypeassert
+}
+
+// Top returns the top most item from the queue without removing it.
+func (h *sessionCloseMinHeap) Top() *sessionCloseItem {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	if h.queue.Empty() {
+		return nil
+	}
+
+	item := h.queue.Top()
+
+	return item.(*sessionCloseItem) //nolint:forcetypeassert
+}
+
+// sessionCloseItem represents a session that is ready to be deleted.
+type sessionCloseItem struct {
+	// sessionID is the ID of the session in question.
+	sessionID wtdb.SessionID
+
+	// deleteHeight is the block height after which we can delete the
+	// session.
+	deleteHeight uint32
+}
+
+// Less returns true if the current item's delete height is less than the
+// other sessionCloseItem's delete height. This results in lower block heights
+// being popped first from the heap.
+//
+// NOTE: this is part of the queue.PriorityQueueItem interface.
+func (s *sessionCloseItem) Less(other queue.PriorityQueueItem) bool {
+	o := other.(*sessionCloseItem).deleteHeight //nolint:forcetypeassert
+
+	return s.deleteHeight < o
+}
+
+var _ queue.PriorityQueueItem = (*sessionCloseItem)(nil)

--- a/watchtower/wtclient/sess_close_min_heap_test.go
+++ b/watchtower/wtclient/sess_close_min_heap_test.go
@@ -1,0 +1,52 @@
+package wtclient
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestSessionCloseMinHeap asserts that the sessionCloseMinHeap behaves as
+// expected.
+func TestSessionCloseMinHeap(t *testing.T) {
+	t.Parallel()
+
+	heap := newSessionCloseMinHeap()
+	require.Nil(t, heap.Pop())
+	require.Nil(t, heap.Top())
+	require.True(t, heap.Empty())
+	require.Zero(t, heap.Len())
+
+	// Add an item with height 10.
+	item1 := &sessionCloseItem{
+		sessionID:    [33]byte{1, 2, 3},
+		deleteHeight: 10,
+	}
+
+	heap.Push(item1)
+	require.Equal(t, item1, heap.Top())
+	require.False(t, heap.Empty())
+	require.EqualValues(t, 1, heap.Len())
+
+	// Add a bunch more items with heights 1, 2, 6, 11, 6, 30, 9.
+	heap.Push(&sessionCloseItem{deleteHeight: 1})
+	heap.Push(&sessionCloseItem{deleteHeight: 2})
+	heap.Push(&sessionCloseItem{deleteHeight: 6})
+	heap.Push(&sessionCloseItem{deleteHeight: 11})
+	heap.Push(&sessionCloseItem{deleteHeight: 6})
+	heap.Push(&sessionCloseItem{deleteHeight: 30})
+	heap.Push(&sessionCloseItem{deleteHeight: 9})
+
+	// Now pop from the queue and assert that the items are returned in
+	// ascending order.
+	require.EqualValues(t, 1, heap.Pop().deleteHeight)
+	require.EqualValues(t, 2, heap.Pop().deleteHeight)
+	require.EqualValues(t, 6, heap.Pop().deleteHeight)
+	require.EqualValues(t, 6, heap.Pop().deleteHeight)
+	require.EqualValues(t, 9, heap.Pop().deleteHeight)
+	require.EqualValues(t, 10, heap.Pop().deleteHeight)
+	require.EqualValues(t, 11, heap.Pop().deleteHeight)
+	require.EqualValues(t, 30, heap.Pop().deleteHeight)
+	require.Nil(t, heap.Pop())
+	require.Zero(t, heap.Len())
+}

--- a/watchtower/wtdb/client_db.go
+++ b/watchtower/wtdb/client_db.go
@@ -168,6 +168,10 @@ var (
 	// not pass the filter func provided by the caller.
 	ErrSessionFailedFilterFn = errors.New("session failed filter func")
 
+	// ErrSessionNotClosable is returned when a session is not found in the
+	// closable list.
+	ErrSessionNotClosable = errors.New("session is not closable")
+
 	// errSessionHasOpenChannels is an error used to indicate that a
 	// session has updates for channels that are still open.
 	errSessionHasOpenChannels = errors.New("session has open channels")
@@ -175,6 +179,11 @@ var (
 	// errSessionHasUnackedUpdates is an error used to indicate that a
 	// session has un-acked updates.
 	errSessionHasUnackedUpdates = errors.New("session has un-acked updates")
+
+	// errChannelHasMoreSessions is an error used to indicate that a channel
+	// has updates in other non-closed sessions.
+	errChannelHasMoreSessions = errors.New("channel has updates in " +
+		"other sessions")
 )
 
 // NewBoltBackendCreator returns a function that creates a new bbolt backend for
@@ -1053,6 +1062,7 @@ func (c *ClientDB) GetClientSession(id SessionID,
 		}
 
 		sess = session
+
 		return nil
 	}, func() {})
 
@@ -1423,6 +1433,177 @@ func (c *ClientDB) ListClosableSessions() (map[SessionID]uint32, error) {
 	}
 
 	return sessions, nil
+}
+
+// DeleteSession can be called when a session should be deleted from the DB.
+// All references to the session will also be deleted from the DB. Note that a
+// session will only be deleted if was previously marked as closable.
+func (c *ClientDB) DeleteSession(id SessionID) error {
+	return kvdb.Update(c.db, func(tx kvdb.RwTx) error {
+		sessionsBkt := tx.ReadWriteBucket(cSessionBkt)
+		if sessionsBkt == nil {
+			return ErrUninitializedDB
+		}
+
+		closableBkt := tx.ReadWriteBucket(cClosableSessionsBkt)
+		if closableBkt == nil {
+			return ErrUninitializedDB
+		}
+
+		chanDetailsBkt := tx.ReadWriteBucket(cChanDetailsBkt)
+		if chanDetailsBkt == nil {
+			return ErrUninitializedDB
+		}
+
+		sessIDIndexBkt := tx.ReadWriteBucket(cSessionIDIndexBkt)
+		if sessIDIndexBkt == nil {
+			return ErrUninitializedDB
+		}
+
+		chanIDIndexBkt := tx.ReadWriteBucket(cChanIDIndexBkt)
+		if chanIDIndexBkt == nil {
+			return ErrUninitializedDB
+		}
+
+		towerToSessBkt := tx.ReadWriteBucket(cTowerToSessionIndexBkt)
+		if towerToSessBkt == nil {
+			return ErrUninitializedDB
+		}
+
+		// Get the sub-bucket for this session ID. If it does not exist
+		// then the session has already been deleted and so our work is
+		// done.
+		sessionBkt := sessionsBkt.NestedReadBucket(id[:])
+		if sessionBkt == nil {
+			return nil
+		}
+
+		_, dbIDBytes, err := getDBSessionID(sessionsBkt, id)
+		if err != nil {
+			return err
+		}
+
+		// First we check if the session has actually been marked as
+		// closable.
+		if closableBkt.Get(dbIDBytes) == nil {
+			return ErrSessionNotClosable
+		}
+
+		sess, err := getClientSessionBody(sessionsBkt, id[:])
+		if err != nil {
+			return err
+		}
+
+		// Delete from the tower-to-sessionID index.
+		towerIndexBkt := towerToSessBkt.NestedReadWriteBucket(
+			sess.TowerID.Bytes(),
+		)
+		if towerIndexBkt == nil {
+			return fmt.Errorf("no entry in the tower-to-session "+
+				"index found for tower ID %v", sess.TowerID)
+		}
+
+		err = towerIndexBkt.Delete(id[:])
+		if err != nil {
+			return err
+		}
+
+		// Delete entry from session ID index.
+		err = sessIDIndexBkt.Delete(dbIDBytes)
+		if err != nil {
+			return err
+		}
+
+		// Delete the entry from the closable sessions index.
+		err = closableBkt.Delete(dbIDBytes)
+		if err != nil {
+			return err
+		}
+
+		// Get the acked updates range index for the session. This is
+		// used to get the list of channels that the session has updates
+		// for.
+		ackRanges := sessionBkt.NestedReadBucket(cSessionAckRangeIndex)
+		if ackRanges == nil {
+			// A session would only be considered closable if it
+			// was exhausted. Meaning that it should not be the
+			// case that it has no acked-updates.
+			return fmt.Errorf("cannot delete session %s since it "+
+				"is not yet exhausted", id)
+		}
+
+		// For each of the channels, delete the session ID entry.
+		err = ackRanges.ForEach(func(chanDBID, _ []byte) error {
+			chanDBIDInt, err := readBigSize(chanDBID)
+			if err != nil {
+				return err
+			}
+
+			chanID, err := getRealChannelID(
+				chanIDIndexBkt, chanDBIDInt,
+			)
+			if err != nil {
+				return err
+			}
+
+			chanDetails := chanDetailsBkt.NestedReadWriteBucket(
+				chanID[:],
+			)
+			if chanDetails == nil {
+				return ErrChannelNotRegistered
+			}
+
+			chanSessions := chanDetails.NestedReadWriteBucket(
+				cChanSessions,
+			)
+			if chanSessions == nil {
+				return fmt.Errorf("no session list found for "+
+					"channel %s", chanID)
+			}
+
+			// Check that this session was actually listed in the
+			// session list for this channel.
+			if len(chanSessions.Get(dbIDBytes)) == 0 {
+				return fmt.Errorf("session %s not found in "+
+					"the session list for channel %s", id,
+					chanID)
+			}
+
+			// If it was, then delete it.
+			err = chanSessions.Delete(dbIDBytes)
+			if err != nil {
+				return err
+			}
+
+			// If this was the last session for this channel, we can
+			// now delete the channel details for this channel
+			// completely.
+			err = chanSessions.ForEach(func(_, _ []byte) error {
+				return errChannelHasMoreSessions
+			})
+			if errors.Is(err, errChannelHasMoreSessions) {
+				return nil
+			} else if err != nil {
+				return err
+			}
+
+			// Delete the channel's entry from the channel-id-index.
+			dbID := chanDetails.Get(cChanDBID)
+			err = chanIDIndexBkt.Delete(dbID)
+			if err != nil {
+				return err
+			}
+
+			// Delete the channel details.
+			return chanDetailsBkt.DeleteNestedBucket(chanID[:])
+		})
+		if err != nil {
+			return err
+		}
+
+		// Delete the actual session.
+		return sessionsBkt.DeleteNestedBucket(id[:])
+	}, func() {})
 }
 
 // MarkChannelClosed will mark a registered channel as closed by setting its

--- a/watchtower/wtdb/client_db.go
+++ b/watchtower/wtdb/client_db.go
@@ -1284,7 +1284,8 @@ func (c *ClientDB) NumAckedUpdates(id *SessionID) (uint64, error) {
 }
 
 // FetchChanSummaries loads a mapping from all registered channels to their
-// channel summaries.
+// channel summaries. Only the channels that have not yet been marked as closed
+// will be loaded.
 func (c *ClientDB) FetchChanSummaries() (ChannelSummaries, error) {
 	var summaries map[lnwire.ChannelID]ClientChanSummary
 
@@ -1298,6 +1299,13 @@ func (c *ClientDB) FetchChanSummaries() (ChannelSummaries, error) {
 			chanDetails := chanDetailsBkt.NestedReadBucket(k)
 			if chanDetails == nil {
 				return ErrCorruptChanDetails
+			}
+
+			// If this channel has already been marked as closed,
+			// then its summary does not need to be loaded.
+			closedHeight := chanDetails.Get(cChanClosedHeight)
+			if len(closedHeight) > 0 {
+				return nil
 			}
 
 			var chanID lnwire.ChannelID

--- a/watchtower/wtdb/client_db.go
+++ b/watchtower/wtdb/client_db.go
@@ -1023,20 +1023,14 @@ func (c *ClientDB) ListClientSessions(id *TowerID,
 			return ErrUninitializedDB
 		}
 
-		towers := tx.ReadBucket(cTowerBkt)
-		if towers == nil {
-			return ErrUninitializedDB
-		}
-
 		chanIDIndexBkt := tx.ReadBucket(cChanIDIndexBkt)
 		if chanIDIndexBkt == nil {
 			return ErrUninitializedDB
 		}
 
-		var err error
-
 		// If no tower ID is specified, then fetch all the sessions
 		// known to the db.
+		var err error
 		if id == nil {
 			clientSessions, err = c.listClientAllSessions(
 				sessions, chanIDIndexBkt, filterFn, opts...,

--- a/watchtower/wtdb/client_db_test.go
+++ b/watchtower/wtdb/client_db_test.go
@@ -3,6 +3,7 @@ package wtdb_test
 import (
 	crand "crypto/rand"
 	"io"
+	"math/rand"
 	"net"
 	"testing"
 
@@ -16,6 +17,8 @@ import (
 	"github.com/lightningnetwork/lnd/watchtower/wtpolicy"
 	"github.com/stretchr/testify/require"
 )
+
+const blobType = blob.TypeAltruistCommit
 
 // pseudoAddr is a fake network address to be used for testing purposes.
 var pseudoAddr = &net.TCPAddr{IP: []byte{0x01, 0x00, 0x00, 0x00}, Port: 9911}
@@ -191,6 +194,17 @@ func (h *clientDBHarness) ackUpdate(id *wtdb.SessionID, seqNum uint16,
 
 	err := h.db.AckUpdate(id, seqNum, lastApplied)
 	require.ErrorIs(h.t, err, expErr)
+}
+
+func (h *clientDBHarness) markChannelClosed(id lnwire.ChannelID,
+	blockHeight uint32, expErr error) []wtdb.SessionID {
+
+	h.t.Helper()
+
+	closableSessions, err := h.db.MarkChannelClosed(id, blockHeight)
+	require.ErrorIs(h.t, err, expErr)
+
+	return closableSessions
 }
 
 // newTower is a helper function that creates a new tower with a randomly
@@ -605,6 +619,105 @@ func testCommitUpdate(h *clientDBHarness) {
 	}, nil)
 }
 
+// testMarkChannelClosed asserts the behaviour of MarkChannelClosed.
+func testMarkChannelClosed(h *clientDBHarness) {
+	tower := h.newTower()
+
+	// Create channel 1.
+	chanID1 := randChannelID(h.t)
+
+	// Since we have not yet registered the channel, we expect an error
+	// when attempting to mark it as closed.
+	h.markChannelClosed(chanID1, 1, wtdb.ErrChannelNotRegistered)
+
+	// Now register the channel.
+	h.registerChan(chanID1, nil, nil)
+
+	// Since there are still no sessions that would have updates for the
+	// channel, marking it as closed now should succeed.
+	h.markChannelClosed(chanID1, 1, nil)
+
+	// Register channel 2.
+	chanID2 := randChannelID(h.t)
+	h.registerChan(chanID2, nil, nil)
+
+	// Create session1 with MaxUpdates set to 5.
+	session1 := h.randSession(h.t, tower.ID, 5)
+	h.insertSession(session1, nil)
+
+	// Add an update for channel 2 in session 1 and ack it too.
+	update := randCommittedUpdateForChannel(h.t, chanID2, 1)
+	lastApplied := h.commitUpdate(&session1.ID, update, nil)
+	require.Zero(h.t, lastApplied)
+	h.ackUpdate(&session1.ID, 1, 1, nil)
+
+	// Marking channel 2 now should not result in any closable sessions
+	// since session 1 is not yet exhausted.
+	sl := h.markChannelClosed(chanID2, 1, nil)
+	require.Empty(h.t, sl)
+
+	// Create channel 3 and 4.
+	chanID3 := randChannelID(h.t)
+	h.registerChan(chanID3, nil, nil)
+
+	chanID4 := randChannelID(h.t)
+	h.registerChan(chanID4, nil, nil)
+
+	// Add an update for channel 4 and ack it.
+	update = randCommittedUpdateForChannel(h.t, chanID4, 2)
+	lastApplied = h.commitUpdate(&session1.ID, update, nil)
+	require.EqualValues(h.t, 1, lastApplied)
+	h.ackUpdate(&session1.ID, 2, 2, nil)
+
+	// Add an update for channel 3 in session 1. But dont ack it yet.
+	update = randCommittedUpdateForChannel(h.t, chanID2, 3)
+	lastApplied = h.commitUpdate(&session1.ID, update, nil)
+	require.EqualValues(h.t, 2, lastApplied)
+
+	// Mark channel 4 as closed & assert that session 1 is not seen as
+	// closable since it still has committed updates.
+	sl = h.markChannelClosed(chanID4, 1, nil)
+	require.Empty(h.t, sl)
+
+	// Now ack the update we added above.
+	h.ackUpdate(&session1.ID, 3, 3, nil)
+
+	// Mark channel 3 as closed & assert that session 1 is still not seen as
+	// closable since it is not yet exhausted.
+	sl = h.markChannelClosed(chanID3, 1, nil)
+	require.Empty(h.t, sl)
+
+	// Create channel 5 and 6.
+	chanID5 := randChannelID(h.t)
+	h.registerChan(chanID5, nil, nil)
+
+	chanID6 := randChannelID(h.t)
+	h.registerChan(chanID6, nil, nil)
+
+	// Add an update for channel 5 and ack it.
+	update = randCommittedUpdateForChannel(h.t, chanID5, 4)
+	lastApplied = h.commitUpdate(&session1.ID, update, nil)
+	require.EqualValues(h.t, 3, lastApplied)
+	h.ackUpdate(&session1.ID, 4, 4, nil)
+
+	// Add an update for channel 6 and ack it.
+	update = randCommittedUpdateForChannel(h.t, chanID6, 5)
+	lastApplied = h.commitUpdate(&session1.ID, update, nil)
+	require.EqualValues(h.t, 4, lastApplied)
+	h.ackUpdate(&session1.ID, 5, 5, nil)
+
+	// The session is no exhausted.
+	// If we now close channel 5, session 1 should still not be closable
+	// since it has an update for channel 6 which is still open.
+	sl = h.markChannelClosed(chanID5, 1, nil)
+	require.Empty(h.t, sl)
+
+	// Finally, if we close channel 6, session 1 _should_ be in the closable
+	// list.
+	sl = h.markChannelClosed(chanID6, 1, nil)
+	require.ElementsMatch(h.t, sl, []wtdb.SessionID{session1.ID})
+}
+
 // testAckUpdate asserts the behavior of AckUpdate.
 func testAckUpdate(h *clientDBHarness) {
 	const blobType = blob.TypeAltruistCommit
@@ -821,6 +934,10 @@ func TestClientDB(t *testing.T) {
 			name: "ack update",
 			run:  testAckUpdate,
 		},
+		{
+			name: "mark channel closed",
+			run:  testMarkChannelClosed,
+		},
 	}
 
 	for _, database := range dbs {
@@ -841,12 +958,32 @@ func TestClientDB(t *testing.T) {
 
 // randCommittedUpdate generates a random committed update.
 func randCommittedUpdate(t *testing.T, seqNum uint16) *wtdb.CommittedUpdate {
+	t.Helper()
+
+	chanID := randChannelID(t)
+
+	return randCommittedUpdateForChannel(t, chanID, seqNum)
+}
+
+func randChannelID(t *testing.T) lnwire.ChannelID {
+	t.Helper()
+
 	var chanID lnwire.ChannelID
 	_, err := io.ReadFull(crand.Reader, chanID[:])
 	require.NoError(t, err)
 
+	return chanID
+}
+
+// randCommittedUpdateForChannel generates a random committed update for the
+// given channel ID.
+func randCommittedUpdateForChannel(t *testing.T, chanID lnwire.ChannelID,
+	seqNum uint16) *wtdb.CommittedUpdate {
+
+	t.Helper()
+
 	var hint blob.BreachHint
-	_, err = io.ReadFull(crand.Reader, hint[:])
+	_, err := io.ReadFull(crand.Reader, hint[:])
 	require.NoError(t, err)
 
 	encBlob := make([]byte, blob.Size(blob.FlagCommitOutputs.Type()))
@@ -863,5 +1000,29 @@ func randCommittedUpdate(t *testing.T, seqNum uint16) *wtdb.CommittedUpdate {
 			Hint:          hint,
 			EncryptedBlob: encBlob,
 		},
+	}
+}
+
+func (h *clientDBHarness) randSession(t *testing.T,
+	towerID wtdb.TowerID, maxUpdates uint16) *wtdb.ClientSession {
+
+	t.Helper()
+
+	var id wtdb.SessionID
+	rand.Read(id[:])
+
+	return &wtdb.ClientSession{
+		ClientSessionBody: wtdb.ClientSessionBody{
+			TowerID: towerID,
+			Policy: wtpolicy.Policy{
+				TxPolicy: wtpolicy.TxPolicy{
+					BlobType: blobType,
+				},
+				MaxUpdates: maxUpdates,
+			},
+			RewardPkScript: []byte{0x01, 0x02, 0x03},
+			KeyIndex:       h.nextKeyIndex(towerID, blobType),
+		},
+		ID: id,
 	}
 }

--- a/watchtower/wtdb/log.go
+++ b/watchtower/wtdb/log.go
@@ -9,6 +9,7 @@ import (
 	"github.com/lightningnetwork/lnd/watchtower/wtdb/migration4"
 	"github.com/lightningnetwork/lnd/watchtower/wtdb/migration5"
 	"github.com/lightningnetwork/lnd/watchtower/wtdb/migration6"
+	"github.com/lightningnetwork/lnd/watchtower/wtdb/migration7"
 )
 
 // log is a logger that is initialized with no output filters.  This
@@ -38,6 +39,7 @@ func UseLogger(logger btclog.Logger) {
 	migration4.UseLogger(logger)
 	migration5.UseLogger(logger)
 	migration6.UseLogger(logger)
+	migration7.UseLogger(logger)
 }
 
 // logClosure is used to provide a closure over expensive logging operations so

--- a/watchtower/wtdb/log.go
+++ b/watchtower/wtdb/log.go
@@ -8,6 +8,7 @@ import (
 	"github.com/lightningnetwork/lnd/watchtower/wtdb/migration3"
 	"github.com/lightningnetwork/lnd/watchtower/wtdb/migration4"
 	"github.com/lightningnetwork/lnd/watchtower/wtdb/migration5"
+	"github.com/lightningnetwork/lnd/watchtower/wtdb/migration6"
 )
 
 // log is a logger that is initialized with no output filters.  This
@@ -36,6 +37,7 @@ func UseLogger(logger btclog.Logger) {
 	migration3.UseLogger(logger)
 	migration4.UseLogger(logger)
 	migration5.UseLogger(logger)
+	migration6.UseLogger(logger)
 }
 
 // logClosure is used to provide a closure over expensive logging operations so

--- a/watchtower/wtdb/migration6/client_db.go
+++ b/watchtower/wtdb/migration6/client_db.go
@@ -1,0 +1,114 @@
+package migration6
+
+import (
+	"bytes"
+	"encoding/binary"
+	"errors"
+
+	"github.com/lightningnetwork/lnd/kvdb"
+	"github.com/lightningnetwork/lnd/tlv"
+)
+
+var (
+	// cSessionBkt is a top-level bucket storing:
+	//   session-id => cSessionBody -> encoded ClientSessionBody
+	// 		=> cSessionDBID -> db-assigned-id
+	//              => cSessionCommits => seqnum -> encoded CommittedUpdate
+	//              => cSessionAcks => seqnum -> encoded BackupID
+	cSessionBkt = []byte("client-session-bucket")
+
+	// cSessionDBID is a key used in the cSessionBkt to store the
+	// db-assigned-id of a session.
+	cSessionDBID = []byte("client-session-db-id")
+
+	// cSessionIDIndexBkt is a top-level bucket storing:
+	//    db-assigned-id -> session-id
+	cSessionIDIndexBkt = []byte("client-session-id-index")
+
+	// cSessionBody is a sub-bucket of cSessionBkt storing only the body of
+	// the ClientSession.
+	cSessionBody = []byte("client-session-body")
+
+	// ErrUninitializedDB signals that top-level buckets for the database
+	// have not been initialized.
+	ErrUninitializedDB = errors.New("db not initialized")
+
+	// ErrCorruptClientSession signals that the client session's on-disk
+	// structure deviates from what is expected.
+	ErrCorruptClientSession = errors.New("client session corrupted")
+
+	byteOrder = binary.BigEndian
+)
+
+// MigrateSessionIDIndex adds a new session ID index to the tower client db.
+// This index is a mapping from db-assigned ID (a uint64 encoded using BigSize)
+// to real session ID (33 bytes). This mapping will allow us to persist session
+// pointers with fewer bytes in the future.
+func MigrateSessionIDIndex(tx kvdb.RwTx) error {
+	log.Infof("Migrating the tower client db to add a new session ID " +
+		"index which stores a mapping from db-assigned ID to real " +
+		"session ID")
+
+	// Create a new top-level bucket for the index.
+	indexBkt, err := tx.CreateTopLevelBucket(cSessionIDIndexBkt)
+	if err != nil {
+		return err
+	}
+
+	// Get the existing top-level sessions bucket.
+	sessionsBkt := tx.ReadWriteBucket(cSessionBkt)
+	if sessionsBkt == nil {
+		return ErrUninitializedDB
+	}
+
+	// Iterate over the sessions bucket where each key is a session-ID.
+	return sessionsBkt.ForEach(func(sessionID, _ []byte) error {
+		// Ask the DB for a new, unique, id for the index bucket.
+		nextSeq, err := indexBkt.NextSequence()
+		if err != nil {
+			return err
+		}
+
+		newIndex, err := writeBigSize(nextSeq)
+		if err != nil {
+			return err
+		}
+
+		// Add the new db-assigned-ID to real-session-ID pair to the
+		// new index bucket.
+		err = indexBkt.Put(newIndex, sessionID)
+		if err != nil {
+			return err
+		}
+
+		// Get the sub-bucket for this specific session ID.
+		sessionBkt := sessionsBkt.NestedReadWriteBucket(sessionID)
+		if sessionBkt == nil {
+			return ErrCorruptClientSession
+		}
+
+		// Here we ensure that the session bucket includes a session
+		// body. The only reason we do this is so that we can simulate
+		// a migration fail in a test to ensure that a migration fail
+		// results in an untouched db.
+		sessionBodyBytes := sessionBkt.Get(cSessionBody)
+		if sessionBodyBytes == nil {
+			return ErrCorruptClientSession
+		}
+
+		// Add the db-assigned ID of the session to the session under
+		// the cSessionDBID key.
+		return sessionBkt.Put(cSessionDBID, newIndex)
+	})
+}
+
+// writeBigSize will encode the given uint64 as a BigSize byte slice.
+func writeBigSize(i uint64) ([]byte, error) {
+	var b bytes.Buffer
+	err := tlv.WriteVarInt(&b, i, &[8]byte{})
+	if err != nil {
+		return nil, err
+	}
+
+	return b.Bytes(), nil
+}

--- a/watchtower/wtdb/migration6/client_db_test.go
+++ b/watchtower/wtdb/migration6/client_db_test.go
@@ -1,0 +1,147 @@
+package migration6
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/lightningnetwork/lnd/channeldb/migtest"
+	"github.com/lightningnetwork/lnd/kvdb"
+	"github.com/lightningnetwork/lnd/tlv"
+)
+
+var (
+	// pre is the expected data in the sessions bucket before the migration.
+	pre = map[string]interface{}{
+		sessionIDToString(100): map[string]interface{}{
+			string(cSessionBody): string([]byte{1, 2, 3}),
+		},
+		sessionIDToString(222): map[string]interface{}{
+			string(cSessionBody): string([]byte{4, 5, 6}),
+		},
+	}
+
+	// preFailCorruptDB should fail the migration due to no session body
+	// being found for a given session ID.
+	preFailCorruptDB = map[string]interface{}{
+		sessionIDToString(100): "",
+	}
+
+	// post is the expected session index after migration.
+	postIndex = map[string]interface{}{
+		indexToString(1): sessionIDToString(100),
+		indexToString(2): sessionIDToString(222),
+	}
+
+	// postSessions is the expected data in the sessions bucket after the
+	// migration.
+	postSessions = map[string]interface{}{
+		sessionIDToString(100): map[string]interface{}{
+			string(cSessionBody): string([]byte{1, 2, 3}),
+			string(cSessionDBID): indexToString(1),
+		},
+		sessionIDToString(222): map[string]interface{}{
+			string(cSessionBody): string([]byte{4, 5, 6}),
+			string(cSessionDBID): indexToString(2),
+		},
+	}
+)
+
+// TestMigrateSessionIDIndex tests that the MigrateSessionIDIndex function
+// correctly adds a new session-id index to the DB and also correctly updates
+// the existing session bucket.
+func TestMigrateSessionIDIndex(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		shouldFail   bool
+		pre          map[string]interface{}
+		postSessions map[string]interface{}
+		postIndex    map[string]interface{}
+	}{
+		{
+			name:         "migration ok",
+			shouldFail:   false,
+			pre:          pre,
+			postSessions: postSessions,
+			postIndex:    postIndex,
+		},
+		{
+			name:       "fail due to corrupt db",
+			shouldFail: true,
+			pre:        preFailCorruptDB,
+		},
+		{
+			name:         "no channel details",
+			shouldFail:   false,
+			pre:          nil,
+			postSessions: nil,
+			postIndex:    nil,
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			// Before the migration we have a details bucket.
+			before := func(tx kvdb.RwTx) error {
+				return migtest.RestoreDB(
+					tx, cSessionBkt, test.pre,
+				)
+			}
+
+			// After the migration, we should have an untouched
+			// summary bucket and a new index bucket.
+			after := func(tx kvdb.RwTx) error {
+				// If the migration fails, the details bucket
+				// should be untouched.
+				if test.shouldFail {
+					if err := migtest.VerifyDB(
+						tx, cSessionBkt, test.pre,
+					); err != nil {
+						return err
+					}
+
+					return nil
+				}
+
+				// Else, we expect an updated summary bucket
+				// and a new index bucket.
+				err := migtest.VerifyDB(
+					tx, cSessionBkt, test.postSessions,
+				)
+				if err != nil {
+					return err
+				}
+
+				return migtest.VerifyDB(
+					tx, cSessionIDIndexBkt, test.postIndex,
+				)
+			}
+
+			migtest.ApplyMigration(
+				t, before, after, MigrateSessionIDIndex,
+				test.shouldFail,
+			)
+		})
+	}
+}
+
+func indexToString(id uint64) string {
+	var newIndex bytes.Buffer
+	err := tlv.WriteVarInt(&newIndex, id, &[8]byte{})
+	if err != nil {
+		panic(err)
+	}
+
+	return newIndex.String()
+}
+
+func sessionIDToString(id uint64) string {
+	var chanID SessionID
+	byteOrder.PutUint64(chanID[:], id)
+	return chanID.String()
+}

--- a/watchtower/wtdb/migration6/codec.go
+++ b/watchtower/wtdb/migration6/codec.go
@@ -1,0 +1,17 @@
+package migration6
+
+import (
+	"encoding/hex"
+)
+
+// SessionIDSize is 33-bytes; it is a serialized, compressed public key.
+const SessionIDSize = 33
+
+// SessionID is created from the remote public key of a client, and serves as a
+// unique identifier and authentication for sending state updates.
+type SessionID [SessionIDSize]byte
+
+// String returns a hex encoding of the session id.
+func (s SessionID) String() string {
+	return hex.EncodeToString(s[:])
+}

--- a/watchtower/wtdb/migration6/log.go
+++ b/watchtower/wtdb/migration6/log.go
@@ -1,0 +1,14 @@
+package migration6
+
+import (
+	"github.com/btcsuite/btclog"
+)
+
+// log is a logger that is initialized as disabled.  This means the package will
+// not perform any logging by default until a logger is set.
+var log = btclog.Disabled
+
+// UseLogger uses a specified Logger to output package logging info.
+func UseLogger(logger btclog.Logger) {
+	log = logger
+}

--- a/watchtower/wtdb/migration7/client_db.go
+++ b/watchtower/wtdb/migration7/client_db.go
@@ -1,0 +1,202 @@
+package migration7
+
+import (
+	"bytes"
+	"encoding/binary"
+	"errors"
+	"fmt"
+
+	"github.com/lightningnetwork/lnd/kvdb"
+	"github.com/lightningnetwork/lnd/tlv"
+)
+
+var (
+	// cSessionBkt is a top-level bucket storing:
+	//   session-id => cSessionBody -> encoded ClientSessionBody
+	// 		=> cSessionDBID -> db-assigned-id
+	//              => cSessionCommits => seqnum -> encoded CommittedUpdate
+	//              => cSessionAckRangeIndex => chan-id => acked-index-range
+	cSessionBkt = []byte("client-session-bucket")
+
+	// cChanDetailsBkt is a top-level bucket storing:
+	//   channel-id => cChannelSummary -> encoded ClientChanSummary.
+	//  		=> cChanDBID -> db-assigned-id
+	// 		=> cChanSessions => db-session-id -> 1
+	cChanDetailsBkt = []byte("client-channel-detail-bucket")
+
+	// cChannelSummary is a sub-bucket of cChanDetailsBkt which stores the
+	// encoded body of ClientChanSummary.
+	cChannelSummary = []byte("client-channel-summary")
+
+	// cChanSessions is a sub-bucket of cChanDetailsBkt which stores:
+	//    session-id -> 1
+	cChanSessions = []byte("client-channel-sessions")
+
+	// cSessionAckRangeIndex is a sub-bucket of cSessionBkt storing:
+	//    chan-id => start -> end
+	cSessionAckRangeIndex = []byte("client-session-ack-range-index")
+
+	// cSessionDBID is a key used in the cSessionBkt to store the
+	// db-assigned-d of a session.
+	cSessionDBID = []byte("client-session-db-id")
+
+	// cChanIDIndexBkt is a top-level bucket storing:
+	//    db-assigned-id -> channel-ID
+	cChanIDIndexBkt = []byte("client-channel-id-index")
+
+	// ErrUninitializedDB signals that top-level buckets for the database
+	// have not been initialized.
+	ErrUninitializedDB = errors.New("db not initialized")
+
+	// ErrCorruptClientSession signals that the client session's on-disk
+	// structure deviates from what is expected.
+	ErrCorruptClientSession = errors.New("client session corrupted")
+
+	// byteOrder is the default endianness used when serializing integers.
+	byteOrder = binary.BigEndian
+)
+
+// MigrateChannelToSessionIndex migrates the tower client DB to add an index
+// from channel-to-session. This will make it easier in future to check which
+// sessions have updates for which channels.
+func MigrateChannelToSessionIndex(tx kvdb.RwTx) error {
+	log.Infof("Migrating the tower client DB to build a new " +
+		"channel-to-session index")
+
+	sessionsBkt := tx.ReadBucket(cSessionBkt)
+	if sessionsBkt == nil {
+		return ErrUninitializedDB
+	}
+
+	chanDetailsBkt := tx.ReadWriteBucket(cChanDetailsBkt)
+	if chanDetailsBkt == nil {
+		return ErrUninitializedDB
+	}
+
+	chanIDsBkt := tx.ReadBucket(cChanIDIndexBkt)
+	if chanIDsBkt == nil {
+		return ErrUninitializedDB
+	}
+
+	// First gather all the new channel-to-session pairs that we want to
+	// add.
+	index, err := collectIndex(sessionsBkt)
+	if err != nil {
+		return err
+	}
+
+	// Then persist those pairs to the db.
+	return persistIndex(chanDetailsBkt, chanIDsBkt, index)
+}
+
+// collectIndex iterates through all the sessions and uses the keys in the
+// cSessionAckRangeIndex bucket to collect all the channels that the session
+// has updates for. The function returns a map from channel ID to session ID
+// (using the db-assigned IDs for both).
+func collectIndex(sessionsBkt kvdb.RBucket) (map[uint64]map[uint64]bool,
+	error) {
+
+	index := make(map[uint64]map[uint64]bool)
+	err := sessionsBkt.ForEach(func(sessID, _ []byte) error {
+		sessionBkt := sessionsBkt.NestedReadBucket(sessID)
+		if sessionBkt == nil {
+			return ErrCorruptClientSession
+		}
+
+		ackedRanges := sessionBkt.NestedReadBucket(
+			cSessionAckRangeIndex,
+		)
+		if ackedRanges == nil {
+			return nil
+		}
+
+		sessDBIDBytes := sessionBkt.Get(cSessionDBID)
+		if sessDBIDBytes == nil {
+			return ErrCorruptClientSession
+		}
+
+		sessDBID, err := readUint64(sessDBIDBytes)
+		if err != nil {
+			return err
+		}
+
+		return ackedRanges.ForEach(func(dbChanIDBytes, _ []byte) error {
+			dbChanID, err := readUint64(dbChanIDBytes)
+			if err != nil {
+				return err
+			}
+
+			if _, ok := index[dbChanID]; !ok {
+				index[dbChanID] = make(map[uint64]bool)
+			}
+
+			index[dbChanID][sessDBID] = true
+
+			return nil
+		})
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return index, nil
+}
+
+// persistIndex adds the channel-to-session mapping in each channel's details
+// bucket.
+func persistIndex(chanDetailsBkt kvdb.RwBucket, chanIDsBkt kvdb.RBucket,
+	index map[uint64]map[uint64]bool) error {
+
+	for dbChanID, sessIDs := range index {
+		dbChanIDBytes, err := writeUint64(dbChanID)
+		if err != nil {
+			return err
+		}
+
+		realChanID := chanIDsBkt.Get(dbChanIDBytes)
+
+		chanBkt := chanDetailsBkt.NestedReadWriteBucket(realChanID)
+		if chanBkt == nil {
+			return fmt.Errorf("channel not found")
+		}
+
+		sessIDsBkt, err := chanBkt.CreateBucket(cChanSessions)
+		if err != nil {
+			return err
+		}
+
+		for id := range sessIDs {
+			sessID, err := writeUint64(id)
+			if err != nil {
+				return err
+			}
+
+			err = sessIDsBkt.Put(sessID, []byte{1})
+			if err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+func writeUint64(i uint64) ([]byte, error) {
+	var b bytes.Buffer
+	err := tlv.WriteVarInt(&b, i, &[8]byte{})
+	if err != nil {
+		return nil, err
+	}
+
+	return b.Bytes(), nil
+}
+
+func readUint64(b []byte) (uint64, error) {
+	r := bytes.NewReader(b)
+	i, err := tlv.ReadVarInt(r, &[8]byte{})
+	if err != nil {
+		return 0, err
+	}
+
+	return i, nil
+}

--- a/watchtower/wtdb/migration7/client_db_test.go
+++ b/watchtower/wtdb/migration7/client_db_test.go
@@ -1,0 +1,191 @@
+package migration7
+
+import (
+	"testing"
+
+	"github.com/lightningnetwork/lnd/channeldb/migtest"
+	"github.com/lightningnetwork/lnd/kvdb"
+)
+
+var (
+	// preDetails is the expected data of the channel details bucket before
+	// the migration.
+	preDetails = map[string]interface{}{
+		channelIDString(100): map[string]interface{}{
+			string(cChannelSummary): string([]byte{1, 2, 3}),
+		},
+		channelIDString(222): map[string]interface{}{
+			string(cChannelSummary): string([]byte{4, 5, 6}),
+		},
+	}
+
+	// preFailCorruptDB should fail the migration due to no channel summary
+	// being found for a given channel ID.
+	preFailCorruptDB = map[string]interface{}{
+		channelIDString(30): map[string]interface{}{},
+	}
+
+	// channelIDIndex is the data in the channelID index that is used to
+	// find the mapping between the db-assigned channel ID and the real
+	// channel ID.
+	channelIDIndex = map[string]interface{}{
+		uint64ToStr(10): channelIDString(100),
+		uint64ToStr(20): channelIDString(222),
+	}
+
+	// sessions is the expected data in the sessions bucket before and
+	// after the migration.
+	sessions = map[string]interface{}{
+		sessionIDString("1"): map[string]interface{}{
+			string(cSessionAckRangeIndex): map[string]interface{}{
+				uint64ToStr(10): map[string]interface{}{
+					uint64ToStr(30): uint64ToStr(32),
+					uint64ToStr(34): uint64ToStr(34),
+				},
+				uint64ToStr(20): map[string]interface{}{
+					uint64ToStr(30): uint64ToStr(30),
+				},
+			},
+			string(cSessionDBID): uint64ToStr(66),
+		},
+		sessionIDString("2"): map[string]interface{}{
+			string(cSessionAckRangeIndex): map[string]interface{}{
+				uint64ToStr(10): map[string]interface{}{
+					uint64ToStr(33): uint64ToStr(33),
+				},
+			},
+			string(cSessionDBID): uint64ToStr(77),
+		},
+	}
+
+	// postDetails is the expected data in the channel details bucket after
+	// the migration.
+	postDetails = map[string]interface{}{
+		channelIDString(100): map[string]interface{}{
+			string(cChannelSummary): string([]byte{1, 2, 3}),
+			string(cChanSessions): map[string]interface{}{
+				uint64ToStr(66): string([]byte{1}),
+				uint64ToStr(77): string([]byte{1}),
+			},
+		},
+		channelIDString(222): map[string]interface{}{
+			string(cChannelSummary): string([]byte{4, 5, 6}),
+			string(cChanSessions): map[string]interface{}{
+				uint64ToStr(66): string([]byte{1}),
+			},
+		},
+	}
+)
+
+// TestMigrateChannelToSessionIndex tests that the MigrateChannelToSessionIndex
+// function correctly builds the new channel-to-sessionID index to the tower
+// client DB.
+func TestMigrateChannelToSessionIndex(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		shouldFail   bool
+		preDetails   map[string]interface{}
+		preSessions  map[string]interface{}
+		preChanIndex map[string]interface{}
+		postDetails  map[string]interface{}
+	}{
+		{
+			name:         "migration ok",
+			shouldFail:   false,
+			preDetails:   preDetails,
+			preSessions:  sessions,
+			preChanIndex: channelIDIndex,
+			postDetails:  postDetails,
+		},
+		{
+			name:        "fail due to corrupt db",
+			shouldFail:  true,
+			preDetails:  preFailCorruptDB,
+			preSessions: sessions,
+		},
+		{
+			name:       "no sessions",
+			shouldFail: false,
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			// Before the migration we have a channel details
+			// bucket, a sessions bucket, a session ID index bucket
+			// and a channel ID index bucket.
+			before := func(tx kvdb.RwTx) error {
+				err := migtest.RestoreDB(
+					tx, cChanDetailsBkt, test.preDetails,
+				)
+				if err != nil {
+					return err
+				}
+
+				err = migtest.RestoreDB(
+					tx, cSessionBkt, test.preSessions,
+				)
+				if err != nil {
+					return err
+				}
+
+				return migtest.RestoreDB(
+					tx, cChanIDIndexBkt, test.preChanIndex,
+				)
+			}
+
+			after := func(tx kvdb.RwTx) error {
+				// If the migration fails, the details bucket
+				// should be untouched.
+				if test.shouldFail {
+					if err := migtest.VerifyDB(
+						tx, cChanDetailsBkt,
+						test.preDetails,
+					); err != nil {
+						return err
+					}
+
+					return nil
+				}
+
+				// Else, we expect an updated details bucket
+				// and a new index bucket.
+				return migtest.VerifyDB(
+					tx, cChanDetailsBkt, test.postDetails,
+				)
+			}
+
+			migtest.ApplyMigration(
+				t, before, after, MigrateChannelToSessionIndex,
+				test.shouldFail,
+			)
+		})
+	}
+}
+
+func sessionIDString(id string) string {
+	var sessID SessionID
+	copy(sessID[:], id)
+	return sessID.String()
+}
+
+func channelIDString(id uint64) string {
+	var chanID ChannelID
+	byteOrder.PutUint64(chanID[:], id)
+	return string(chanID[:])
+}
+
+func uint64ToStr(id uint64) string {
+	b, err := writeUint64(id)
+	if err != nil {
+		panic(err)
+	}
+
+	return string(b)
+}

--- a/watchtower/wtdb/migration7/codec.go
+++ b/watchtower/wtdb/migration7/codec.go
@@ -1,0 +1,29 @@
+package migration7
+
+import "encoding/hex"
+
+// SessionIDSize is 33-bytes; it is a serialized, compressed public key.
+const SessionIDSize = 33
+
+// SessionID is created from the remote public key of a client, and serves as a
+// unique identifier and authentication for sending state updates.
+type SessionID [SessionIDSize]byte
+
+// String returns a hex encoding of the session id.
+func (s SessionID) String() string {
+	return hex.EncodeToString(s[:])
+}
+
+// ChannelID is a series of 32-bytes that uniquely identifies all channels
+// within the network. The ChannelID is computed using the outpoint of the
+// funding transaction (the txid, and output index). Given a funding output the
+// ChannelID can be calculated by XOR'ing the big-endian serialization of the
+// txid and the big-endian serialization of the output index, truncated to
+// 2 bytes.
+type ChannelID [32]byte
+
+// String returns the string representation of the ChannelID. This is just the
+// hex string encoding of the ChannelID itself.
+func (c ChannelID) String() string {
+	return hex.EncodeToString(c[:])
+}

--- a/watchtower/wtdb/migration7/log.go
+++ b/watchtower/wtdb/migration7/log.go
@@ -1,0 +1,14 @@
+package migration7
+
+import (
+	"github.com/btcsuite/btclog"
+)
+
+// log is a logger that is initialized as disabled.  This means the package will
+// not perform any logging by default until a logger is set.
+var log = btclog.Disabled
+
+// UseLogger uses a specified Logger to output package logging info.
+func UseLogger(logger btclog.Logger) {
+	log = logger
+}

--- a/watchtower/wtdb/version.go
+++ b/watchtower/wtdb/version.go
@@ -11,6 +11,7 @@ import (
 	"github.com/lightningnetwork/lnd/watchtower/wtdb/migration4"
 	"github.com/lightningnetwork/lnd/watchtower/wtdb/migration5"
 	"github.com/lightningnetwork/lnd/watchtower/wtdb/migration6"
+	"github.com/lightningnetwork/lnd/watchtower/wtdb/migration7"
 )
 
 // txMigration is a function which takes a prior outdated version of the
@@ -62,6 +63,9 @@ var clientDBVersions = []version{
 	},
 	{
 		txMigration: migration6.MigrateSessionIDIndex,
+	},
+	{
+		txMigration: migration7.MigrateChannelToSessionIndex,
 	},
 }
 

--- a/watchtower/wtdb/version.go
+++ b/watchtower/wtdb/version.go
@@ -10,6 +10,7 @@ import (
 	"github.com/lightningnetwork/lnd/watchtower/wtdb/migration3"
 	"github.com/lightningnetwork/lnd/watchtower/wtdb/migration4"
 	"github.com/lightningnetwork/lnd/watchtower/wtdb/migration5"
+	"github.com/lightningnetwork/lnd/watchtower/wtdb/migration6"
 )
 
 // txMigration is a function which takes a prior outdated version of the
@@ -58,6 +59,9 @@ var clientDBVersions = []version{
 	},
 	{
 		txMigration: migration5.MigrateCompleteTowerToSessionIndex,
+	},
+	{
+		txMigration: migration6.MigrateSessionIDIndex,
 	},
 }
 

--- a/watchtower/wtmock/client_db.go
+++ b/watchtower/wtmock/client_db.go
@@ -551,6 +551,20 @@ func (m *ClientDB) AckUpdate(id *wtdb.SessionID, seqNum,
 	return wtdb.ErrCommittedUpdateNotFound
 }
 
+// ListClosableSessions fetches and returns the IDs for all sessions marked as
+// closable.
+func (m *ClientDB) ListClosableSessions() (map[wtdb.SessionID]uint32, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	cs := make(map[wtdb.SessionID]uint32, len(m.closableSessions))
+	for id, height := range m.closableSessions {
+		cs[id] = height
+	}
+
+	return cs, nil
+}
+
 // FetchChanSummaries loads a mapping from all registered channels to their
 // channel summaries.
 func (m *ClientDB) FetchChanSummaries() (wtdb.ChannelSummaries, error) {


### PR DESCRIPTION
In this PR, we start making use of of the `DeleteSession` message. This message allows a tower client to indicate to a tower server that it can delete sessions. Sessions are considered "deletable" if they are exhausted & if all the acked-updates sent on the session are for channels that are closed. 

This allows us to claim back disk space on both the client and server.

Fixes https://github.com/lightningnetwork/lnd/issues/6259

Related: https://github.com/lightningnetwork/lnd/issues/7121

# Main Changes:

## 1. Add a new Session-ID index
A new session-ID index is added. The index holds a mapping from db-assigned-ID (BigSize) to realsession-ID (33 bytes). This mapping will allow us to preserve disk space in future when persisting references to sessions.

## 2. Add a channel -> session ID index:
This is added so that it is quick to check which sessions should be checked if a channel is closed.

## 3. Channel Close handler:
The tower client now subscribes to channel closures. Once a notification is received, it is marked as closed in the tower DB along with the close block height. We then check each of the session that have acked updates for the tower to see if they are closable - if they are, then we add the sessionID to the new `closable sessions` bucket. With this change, we can now also stop loading the summaries of closed channels on startup. 

## 4. Closable Sessions handler:
We use a min-heap to store all the closable-sessions.
The tower client now subscribes to new blocks notifications. On each new block, we check the min-heap to see if there are sessions we should close. If there are, then we dial the tower and send the `DeleteSession` message and we also delete all the session info from our DB. 