### PR TITLE
golangci: fine-tune enabled linters

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -29,21 +29,26 @@ linters-settings:
   govet:
     # Don't report about shadowed variables
     check-shadowing: false
+
   gofmt:
     # simplify code: gofmt with `-s` option, true by default
     simplify: true
+
   tagliatelle:
     case:
       rules:
         json: snake
+
   whitespace:
     multi-func: true
     multi-if: true
+
   gosec:
     excludes:
       - G402 # Look for bad TLS connection settings.
       - G306 # Poor file permissions used when writing to a new file.
-  staticcheck: 
+
+  staticcheck:
     go: "1.18"
     checks: ["-SA1019"]
 
@@ -57,7 +62,7 @@ linters-settings:
     # Checks the number of lines in a function.
     # If lower than 0, disable the check.
     # Default: 60
-    lines: 60 
+    lines: 60
     # Checks the number of statements in a function.
     # Default: 40
     statements: 40
@@ -66,39 +71,88 @@ linters-settings:
 linters:
   enable-all: true
   disable:
-  # Global variables are used in many places throughout the code base.
-  - gochecknoglobals
+    # Global variables are used in many places throughout the code base.
+    - gochecknoglobals
 
-  # We want to allow short variable names.
-  - varnamelen
+    # We want to allow short variable names.
+    - varnamelen
 
-  # We want to allow TODOs.
-  - godox
+    # We want to allow TODOs.
+    - godox
 
-  # Instances of table driven tests that don't pre-allocate shouldn't trigger
-  # the linter.
-  - prealloc
+    # Instances of table driven tests that don't pre-allocate shouldn't trigger
+    # the linter.
+    - prealloc
 
-  # Init functions are used by loggers throughout the codebase.
-  - gochecknoinits
-  
-  # Deprecated linters. See https://golangci-lint.run/usage/linters/.
-  - interfacer
-  - golint
-  - maligned
-  - scopelint
-  - exhaustivestruct
-  - bodyclose
-  - contextcheck
-  - nilerr
-  - noctx
-  - rowserrcheck
-  - sqlclosecheck
-  - structcheck
-  - tparallel
-  - unparam
-  - wastedassign
-  
+    # Init functions are used by loggers throughout the codebase.
+    - gochecknoinits
+
+    # Deprecated linters. See https://golangci-lint.run/usage/linters/.
+    - interfacer
+    - golint
+    - maligned
+    - scopelint
+    - exhaustivestruct
+    - bodyclose
+    - contextcheck
+    - nilerr
+    - noctx
+    - rowserrcheck
+    - sqlclosecheck
+    - structcheck
+    - tparallel
+    - unparam
+    - wastedassign
+    - ifshort
+    - varcheck
+    - deadcode
+
+    # Disable gofumpt as it has weird behavior regarding formatting multiple
+    # lines for a function which is in conflict with our contribution
+    # guidelines. See https://github.com/mvdan/gofumpt/issues/235.
+    - gofumpt
+
+    # Disable whitespace linter as it has conflict rules against our
+    # contribution guidelines. See https://github.com/bombsimon/wsl/issues/109.
+    #
+    # TODO(yy): bring it back when the above issue is fixed.
+    - wsl
+
+    # Allow using default empty values.
+    - exhaustruct
+
+    # Allow exiting case select faster by putting everything in default.
+    - exhaustive
+
+    # Allow tests to be put in the same package.
+    - testpackage
+
+    # Don't run the cognitive related linters.
+    - gocognit
+    - gocyclo
+    - maintidx
+    - cyclop
+
+    # Allow customized interfaces to be returned from functions.
+    - ireturn
+
+    # Disable too many blank identifiers check. We won't be able to run this
+    # unless a large refactor has been applied to old code.
+    - dogsled
+
+    # We don't wrap errors.
+    - wrapcheck
+
+    # Allow dynamic errors.
+    - goerr113
+
+    # We use ErrXXX instead.
+    - errname
+
+    # Disable nil check to allow returning multiple nil values.
+    - nilnil
+
+
 issues:
   # Only show newly introduced problems.
   new-from-rev: 8c66353e4c02329abdacb5a8df29998035ec2e24
@@ -110,6 +164,7 @@ issues:
       linters:
         - gosec
         - funlen
+
     - path: test*
       linters:
         - gosec
@@ -146,7 +201,6 @@ issues:
     - path: lntest/itest/.*
       linters:
         - unused
-        - deadcode
         - unparam
         - govet
         # itest case can be very long so we disable long function check.

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -61,11 +61,22 @@ linters-settings:
   funlen:
     # Checks the number of lines in a function.
     # If lower than 0, disable the check.
-    # Default: 60
-    lines: 60
+    lines: 200
     # Checks the number of statements in a function.
-    # Default: 40
-    statements: 40
+    statements: 80
+
+  dupl:
+    # Tokens count to trigger issue.
+    threshold: 200
+
+  nestif:
+    # Minimal complexity of if statements to report.
+    min-complexity: 10
+
+  nlreturn:
+    # Size of the block (including return statement that is still "OK")
+    # so no return split required.
+    block-size: 3
 
 
 linters:


### PR DESCRIPTION
In this PR we further disable two linters, `gofumpt` and `wsl`, due to the known issues(see the comments). Unless we are willing to accept the following format,
```go
// LookupInvoiceV2 queries the node's invoices using the invoice client's.
func (h *HarnessRPC) LookupInvoiceV2(
	req *invoicesrpc.LookupInvoiceMsg,
) *lnrpc.Invoice {

	ctxt, cancel := context.WithTimeout(h.runCtx, DefaultTimeout)
	defer cancel()

	resp, err := h.Invoice.LookupInvoiceV2(ctxt, req)
	h.NoError(err, "LookupInvoiceV2")

	return resp
}
```
`gofumpt` will **sometimes** report failure if it's not formatted as above. And `wsl` will **sometimes** report `block should not start with a whitespace` error for the above code, which means we cannot add a newline when a function signature is defined in multiple lines.
This means these two linters don't report similar results for similar coding formats. And this failure is only partially seen in the format,
```go
func foo(a, b, c,
	d, e) error {

	var a int
}
```
And we could either,
1. disable the two linters, or,
2. skip the linters at specific functions by applying `//nolint:wsl,gofumpt`

I'd prefer option 2 as it still takes advantage of the linters, while it does become annoying to specify this flag whenever long functions are wrapped. This PR, however, uses option 1 in the hope that the linters' bugs will soon be fixed(they won't🤦🏻). 

So please share your thoughts here.

We also disable several linters for tests to suit the needs.