### PR TITLE
addinvoice: provide hop hints for no-amount invoice

### DIFF
--- a/cmd/lncli/cmd_invoice.go
+++ b/cmd/lncli/cmd_invoice.go
@@ -64,7 +64,10 @@ var addInvoiceCommand = cli.Command{
 			Name: "private",
 			Usage: "encode routing hints in the invoice with " +
 				"private channels in order to assist the " +
-				"payer in reaching you",
+				"payer in reaching you. If amt and amt_msat " +
+				"are zero, a large number of hints with " +
+				"these channels can be included, which " +
+				"might not be desirable.",
 		},
 		cli.BoolFlag{
 			Name: "amp",

--- a/docs/release-notes/release-notes-0.16.0.md
+++ b/docs/release-notes/release-notes-0.16.0.md
@@ -61,6 +61,10 @@
   Final resolution data will only be available for htlcs that are resolved
   after upgrading lnd.
 
+* Zero-amount private invoices [now provide hop
+  hints](https://github.com/lightningnetwork/lnd/pull/7082), up to `maxHopHints`
+  (20 currently).
+
 ## Wallet
 
 * [Allows Taproot public keys and tap scripts to be imported as watch-only
@@ -227,6 +231,7 @@ to refactor the itest for code health and maintenance.
 
 # Contributors (Alphabetical Order)
 
+* Alejandro Pedraza
 * andreihod
 * Carla Kirk-Cohen
 * Conner Babinchak

--- a/lnrpc/invoicesrpc/addinvoice.go
+++ b/lnrpc/invoicesrpc/addinvoice.go
@@ -655,9 +655,9 @@ func newSelectHopHintsCfg(invoicesCfg *AddInvoiceConfig,
 // sufficientHints checks whether we have sufficient hop hints, based on the
 // any of the following criteria:
 //   - Hop hint count: the number of hints have reach our max target.
-//   - Total incoming capacity: the sum of the remote balance amount in the
-//     hints is bigger of equal than our target (currently twice the invoice
-//     amount)
+//   - Total incoming capacity (for non-zero invoice amounts): the sum of the
+//     remote balance amount in the hints is bigger of equal than our target
+//     (currently twice the invoice amount)
 //
 // We limit our number of hop hints like this to keep our invoice size down,
 // and to avoid leaking all our private channels when we don't need to.
@@ -669,7 +669,7 @@ func sufficientHints(nHintsLeft int, currentAmount,
 		return true
 	}
 
-	if currentAmount >= targetAmount {
+	if targetAmount != 0 && currentAmount >= targetAmount {
 		log.Debugf("Total hint amount: %v has reached target hint "+
 			"bandwidth: %v", currentAmount, targetAmount)
 		return true

--- a/lnrpc/invoicesrpc/addinvoice_test.go
+++ b/lnrpc/invoicesrpc/addinvoice_test.go
@@ -668,38 +668,7 @@ var populateHopHintsTestCases = []struct {
 	name: "populate hop hints stops after having considered all the open " +
 		"channels",
 	setupMock: func(h *hopHintsConfigMock) {
-		fundingOutpoint1 := wire.OutPoint{Index: 9}
-		chanID1 := lnwire.NewChanIDFromOutPoint(&fundingOutpoint1)
-		remoteBalance1 := lnwire.MilliSatoshi(10_000_000)
-
-		fundingOutpoint2 := wire.OutPoint{Index: 2}
-		chanID2 := lnwire.NewChanIDFromOutPoint(&fundingOutpoint2)
-		remoteBalance2 := lnwire.MilliSatoshi(1_000_000)
-
-		allChannels := []*channeldb.OpenChannel{
-			// After sorting we will first process chanID1 and then
-			// chanID2.
-			{
-				LocalCommitment: channeldb.ChannelCommitment{
-					RemoteBalance: remoteBalance2,
-				},
-				FundingOutpoint: fundingOutpoint2,
-				ShortChannelID:  lnwire.NewShortChanIDFromInt(2),
-				IdentityPub:     getTestPubKey(),
-			},
-			{
-				LocalCommitment: channeldb.ChannelCommitment{
-					RemoteBalance: remoteBalance1,
-				},
-				FundingOutpoint: fundingOutpoint1,
-				ShortChannelID:  lnwire.NewShortChanIDFromInt(9),
-				IdentityPub:     getTestPubKey(),
-			},
-		}
-
-		h.Mock.On(
-			"FetchAllChannels",
-		).Once().Return(allChannels, nil)
+		chanID1, chanID2 := setupMockTwoChannels(h)
 
 		// Prepare the mock for the first channel.
 		h.Mock.On(
@@ -751,6 +720,45 @@ var populateHopHintsTestCases = []struct {
 		},
 	},
 }}
+
+func setupMockTwoChannels(h *hopHintsConfigMock) (lnwire.ChannelID,
+	lnwire.ChannelID) {
+
+	fundingOutpoint1 := wire.OutPoint{Index: 9}
+	chanID1 := lnwire.NewChanIDFromOutPoint(&fundingOutpoint1)
+	remoteBalance1 := lnwire.MilliSatoshi(10_000_000)
+
+	fundingOutpoint2 := wire.OutPoint{Index: 2}
+	chanID2 := lnwire.NewChanIDFromOutPoint(&fundingOutpoint2)
+	remoteBalance2 := lnwire.MilliSatoshi(1_000_000)
+
+	allChannels := []*channeldb.OpenChannel{
+		// After sorting we will first process chanID1 and then
+		// chanID2.
+		{
+			LocalCommitment: channeldb.ChannelCommitment{
+				RemoteBalance: remoteBalance2,
+			},
+			FundingOutpoint: fundingOutpoint2,
+			ShortChannelID:  lnwire.NewShortChanIDFromInt(2),
+			IdentityPub:     getTestPubKey(),
+		},
+		{
+			LocalCommitment: channeldb.ChannelCommitment{
+				RemoteBalance: remoteBalance1,
+			},
+			FundingOutpoint: fundingOutpoint1,
+			ShortChannelID:  lnwire.NewShortChanIDFromInt(9),
+			IdentityPub:     getTestPubKey(),
+		},
+	}
+
+	h.Mock.On(
+		"FetchAllChannels",
+	).Once().Return(allChannels, nil)
+
+	return chanID1, chanID2
+}
 
 func TestPopulateHopHints(t *testing.T) {
 	for _, tc := range populateHopHintsTestCases {

--- a/lnrpc/invoicesrpc/addinvoice_test.go
+++ b/lnrpc/invoicesrpc/addinvoice_test.go
@@ -463,7 +463,7 @@ var sufficientHintsTestCases = []struct {
 	targetAmount  lnwire.MilliSatoshi
 	done          bool
 }{{
-	name:          "not enoguh hints neither bandwidth",
+	name:          "not enough hints neither bandwidth",
 	nHintsLeft:    3,
 	currentAmount: 100,
 	targetAmount:  200,
@@ -473,7 +473,7 @@ var sufficientHintsTestCases = []struct {
 	nHintsLeft: 0,
 	done:       true,
 }, {
-	name:          "enoguh bandwidth",
+	name:          "enough bandwidth",
 	nHintsLeft:    1,
 	currentAmount: 200,
 	targetAmount:  200,

--- a/lnrpc/invoicesrpc/addinvoice_test.go
+++ b/lnrpc/invoicesrpc/addinvoice_test.go
@@ -478,6 +478,12 @@ var sufficientHintsTestCases = []struct {
 	currentAmount: 200,
 	targetAmount:  200,
 	done:          true,
+}, {
+	name:          "no amount provided",
+	nHintsLeft:    1,
+	currentAmount: 100,
+	targetAmount:  0,
+	done:          false,
 }}
 
 func TestSufficientHints(t *testing.T) {
@@ -716,6 +722,93 @@ var populateHopHintsTestCases = []struct {
 			{
 				NodeID:    getTestPubKey(),
 				ChannelID: 2,
+			},
+		},
+	},
+}, {
+	name: "consider all the open channels when amount is zero",
+	setupMock: func(h *hopHintsConfigMock) {
+		chanID1, chanID2 := setupMockTwoChannels(h)
+
+		// Prepare the mock for the first channel.
+		h.Mock.On(
+			"IsChannelActive", chanID1,
+		).Once().Return(true)
+
+		h.Mock.On(
+			"IsPublicNode", mock.Anything,
+		).Once().Return(true, nil)
+
+		h.Mock.On(
+			"FetchChannelEdgesByID", mock.Anything,
+		).Once().Return(
+			&channeldb.ChannelEdgeInfo{},
+			&channeldb.ChannelEdgePolicy{},
+			&channeldb.ChannelEdgePolicy{}, nil,
+		)
+
+		// Prepare the mock for the second channel.
+		h.Mock.On(
+			"IsChannelActive", chanID2,
+		).Once().Return(true)
+
+		h.Mock.On(
+			"IsPublicNode", mock.Anything,
+		).Once().Return(true, nil)
+
+		h.Mock.On(
+			"FetchChannelEdgesByID", mock.Anything,
+		).Once().Return(
+			&channeldb.ChannelEdgeInfo{},
+			&channeldb.ChannelEdgePolicy{},
+			&channeldb.ChannelEdgePolicy{}, nil,
+		)
+	},
+	maxHopHints: 10,
+	amount:      0,
+	expectedHopHints: [][]zpay32.HopHint{
+		{
+			{
+				NodeID:    getTestPubKey(),
+				ChannelID: 9,
+			},
+		}, {
+			{
+				NodeID:    getTestPubKey(),
+				ChannelID: 2,
+			},
+		},
+	},
+}, {
+	name: "consider all the open channels when amount is zero" +
+		" up to maxHopHints",
+	setupMock: func(h *hopHintsConfigMock) {
+		chanID1, _ := setupMockTwoChannels(h)
+
+		// Prepare the mock for the first channel.
+		h.Mock.On(
+			"IsChannelActive", chanID1,
+		).Once().Return(true)
+
+		h.Mock.On(
+			"IsPublicNode", mock.Anything,
+		).Once().Return(true, nil)
+
+		h.Mock.On(
+			"FetchChannelEdgesByID", mock.Anything,
+		).Once().Return(
+			&channeldb.ChannelEdgeInfo{},
+			&channeldb.ChannelEdgePolicy{},
+			&channeldb.ChannelEdgePolicy{}, nil,
+		)
+	},
+	maxHopHints: 1,
+	amount:      0,
+	expectedHopHints: [][]zpay32.HopHint{
+		{
+			{
+				NodeID:    getTestPubKey(),
+				ChannelID: 9,
 			},
 		},
 	},

--- a/lnrpc/invoicesrpc/invoices.swagger.json
+++ b/lnrpc/invoicesrpc/invoices.swagger.json
@@ -514,7 +514,7 @@
         },
         "private": {
           "type": "boolean",
-          "description": "Whether this invoice should include routing hints for private channels."
+          "description": "Whether this invoice should include routing hints for private channels.\nNote: When enabled, if value and value_msat are zero, a large number of\nhints with these channels can be included, which might not be desirable."
         },
         "add_index": {
           "type": "string",

--- a/lnrpc/lightning.pb.go
+++ b/lnrpc/lightning.pb.go
@@ -11640,6 +11640,8 @@ type Invoice struct {
 	// invoice's destination.
 	RouteHints []*RouteHint `protobuf:"bytes,14,rep,name=route_hints,json=routeHints,proto3" json:"route_hints,omitempty"`
 	// Whether this invoice should include routing hints for private channels.
+	// Note: When enabled, if value and value_msat are zero, a large number of
+	// hints with these channels can be included, which might not be desirable.
 	Private bool `protobuf:"varint,15,opt,name=private,proto3" json:"private,omitempty"`
 	// The "add" index of this invoice. Each newly created invoice will increment
 	// this index making it monotonically increasing. Callers to the

--- a/lnrpc/lightning.proto
+++ b/lnrpc/lightning.proto
@@ -3401,6 +3401,8 @@ message Invoice {
     repeated RouteHint route_hints = 14;
 
     // Whether this invoice should include routing hints for private channels.
+    // Note: When enabled, if value and value_msat are zero, a large number of
+    // hints with these channels can be included, which might not be desirable.
     bool private = 15;
 
     /*

--- a/lnrpc/lightning.swagger.json
+++ b/lnrpc/lightning.swagger.json
@@ -5048,7 +5048,7 @@
         },
         "private": {
           "type": "boolean",
-          "description": "Whether this invoice should include routing hints for private channels."
+          "description": "Whether this invoice should include routing hints for private channels.\nNote: When enabled, if value and value_msat are zero, a large number of\nhints with these channels can be included, which might not be desirable."
         },
         "add_index": {
           "type": "string",

--- a/lntest/itest/lnd_routing_test.go
+++ b/lntest/itest/lnd_routing_test.go
@@ -1233,6 +1233,15 @@ func testInvoiceRoutingHints(net *lntest.NetworkHarness, t *harnessTest) {
 	}
 	checkInvoiceHints(invoice)
 
+	// Create another invoice for Alice with no value and ensure it still
+	// populates routing hints.
+	invoice = &lnrpc.Invoice{
+		Memo:    "routing hints with no amount",
+		Value:   0,
+		Private: true,
+	}
+	checkInvoiceHints(invoice)
+
 	// Now that we've confirmed the routing hints were added correctly, we
 	// can close all the channels and shut down all the nodes created.
 	closeChannelAndAssert(t, net, net.Alice, chanPointBob, false)


### PR DESCRIPTION
## Change Description

This change allows creating no-amount private invoices that do provide hop hints, up to `maxHopHints`.

Fixes #6738

## Steps to Test

The `testInvoiceRoutingHints` itest was expanded to account for this use case.
If someone can provide some pointers on how to easily decode the payment request response from `lncli addinvoice`, I'd be glad to provide an example from the end-user's perspective.

This itest and the added unit test case fail before the change to `addinvoice.go` (given that change was so minimal, I clubbed it together in the same commit with the unit test change, but I can separate them if deemed necessary :slightly_smiling_face: ).

## Pull Request Checklist
### Testing
- [ ] Your PR passes all CI checks.
- [ ] Tests covering the positive and negative (error paths) are included.
- [ ] Bug fixes contain tests triggering the bug to prevent regressions.

### Code Style and Documentation
- [ ] The change obeys the [Code Documentation and Commenting](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#CodeDocumentation) guidelines, and lines wrap at 80.
- [ ] Commits follow the [Ideal Git Commit Structure](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#IdealGitCommitStructure).
- [ ] Any new logging statements use an appropriate subsystem and logging level.
- [ ]  [There is a change description in the release notes](https://github.com/lightningnetwork/lnd/tree/master/docs/release-notes), or `[skip ci]` in the commit message for small changes.

📝 Please see our  [Contribution Guidelines](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md) for further guidance.