### PR TITLE
funding: wait for one sec if funding locked is not received

### DIFF
--- a/docs/release-notes/release-notes-0.16.0.md
+++ b/docs/release-notes/release-notes-0.16.0.md
@@ -146,6 +146,10 @@ certain large transactions](https://github.com/lightningnetwork/lnd/pull/7100).
   so that the user can specify fees during channel creation time in addition
   to the default configuration.
 
+* [Sleep for one second when funding locked message is not
+  received](https://github.com/lightningnetwork/lnd/pull/7095) to avoid CPU
+  spike.
+
 ## Code Health
 
 * [test: use `T.TempDir` to create temporary test

--- a/funding/manager.go
+++ b/funding/manager.go
@@ -1021,7 +1021,14 @@ func (f *Manager) stateStep(channel *channeldb.OpenChannel,
 
 		if !received {
 			// We haven't received FundingLocked, so we'll continue
-			// to the next iteration of the loop.
+			// to the next iteration of the loop after sleeping for
+			// one second.
+			select {
+			case <-time.After(1 * time.Second):
+			case <-f.quit:
+				return ErrFundingManagerShuttingDown
+			}
+
 			return nil
 		}
 
@@ -2952,6 +2959,7 @@ func (f *Manager) receivedFundingLocked(node *btcec.PublicKey,
 
 	// Avoid a tight loop if peer is offline.
 	if _, err := f.waitForPeerOnline(node); err != nil {
+		log.Errorf("Wait for peer online failed: %v", err)
 		return false, err
 	}
 


### PR DESCRIPTION
In the itest this log is seen over 3k times before a channel advanced its state,
```
2022-10-29 11:06:16.931 [DBG] FNDG: Channel(fa5d17f622c8f4345bc3bdb867051721483f3090ad41fefe449fe52497d8a071) with ShortChanID 697:1:0 has opening state fundingLocked
```

A dummy time sleep is added to avoid the CPU spike.