### PR TITLE
mod+docs: bump btcd version to v0.23.3 on master branch

### DIFF
--- a/docs/release-notes/release-notes-0.15.4.md
+++ b/docs/release-notes/release-notes-0.15.4.md
@@ -1,0 +1,10 @@
+# Release Notes
+
+## Bug Fixes
+
+* [A wire parsing bug has been fixed that would cause lnd to be unable _decode_
+  certain large transactions](https://github.com/lightningnetwork/lnd/pull/7098).
+
+# Contributors (Alphabetical Order)
+
+* Oliver Gugger

--- a/docs/release-notes/release-notes-0.16.0.md
+++ b/docs/release-notes/release-notes-0.16.0.md
@@ -85,6 +85,9 @@ crash](https://github.com/lightningnetwork/lnd/pull/7019).
 [Use Go's `runtime/debug` package to get information about the build](
 https://github.com/lightningnetwork/lnd/pull/6963/)
 
+[A wire parsing bug has been fixed that would cause lnd to be unable _decode_
+certain large transactions](https://github.com/lightningnetwork/lnd/pull/7100).
+
 ## Misc
 
 * [Fixed a bug where the Switch did not reforward settles or fails for

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/lightningnetwork/lnd
 require (
 	github.com/NebulousLabs/go-upnp v0.0.0-20180202185039-29b680b06c82
 	github.com/Yawning/aez v0.0.0-20211027044916-e49e68abd344
-	github.com/btcsuite/btcd v0.23.2
+	github.com/btcsuite/btcd v0.23.3
 	github.com/btcsuite/btcd/btcec/v2 v2.2.1
 	github.com/btcsuite/btcd/btcutil v1.1.2
 	github.com/btcsuite/btcd/btcutil/psbt v1.1.5

--- a/go.sum
+++ b/go.sum
@@ -77,8 +77,8 @@ github.com/btcsuite/btcd v0.22.0-beta.0.20220207191057-4dc4ff7963b4/go.mod h1:7a
 github.com/btcsuite/btcd v0.22.0-beta.0.20220316175102-8d5c75c28923/go.mod h1:taIcYprAW2g6Z9S0gGUxyR+zDwimyDMK5ePOX+iJ2ds=
 github.com/btcsuite/btcd v0.23.0/go.mod h1:0QJIIN1wwIXF/3G/m87gIwGniDMDQqjVn4SZgnFpsYY=
 github.com/btcsuite/btcd v0.23.1/go.mod h1:0QJIIN1wwIXF/3G/m87gIwGniDMDQqjVn4SZgnFpsYY=
-github.com/btcsuite/btcd v0.23.2 h1:/YOgUp25sdCnP5ho6Hl3s0E438zlX+Kak7E6TgBgoT0=
-github.com/btcsuite/btcd v0.23.2/go.mod h1:0QJIIN1wwIXF/3G/m87gIwGniDMDQqjVn4SZgnFpsYY=
+github.com/btcsuite/btcd v0.23.3 h1:4KH/JKy9WiCd+iUS9Mu0Zp7Dnj17TGdKrg9xc/FGj24=
+github.com/btcsuite/btcd v0.23.3/go.mod h1:0QJIIN1wwIXF/3G/m87gIwGniDMDQqjVn4SZgnFpsYY=
 github.com/btcsuite/btcd/btcec/v2 v2.1.0/go.mod h1:2VzYrv4Gm4apmbVVsSq5bqf1Ec8v56E48Vt0Y/umPgA=
 github.com/btcsuite/btcd/btcec/v2 v2.1.1/go.mod h1:ctjw4H1kknNJmRN4iP1R7bTQ+v3GJkZBd6mui8ZsAZE=
 github.com/btcsuite/btcd/btcec/v2 v2.1.3/go.mod h1:ctjw4H1kknNJmRN4iP1R7bTQ+v3GJkZBd6mui8ZsAZE=


### PR DESCRIPTION
## Change Description

Ports over the changes from #7098 onto the master branch too.
