### PR TITLE
github: check commits against base branch

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -116,16 +116,16 @@ jobs:
         with:
           go-version: '${{ env.GO_VERSION }}'
 
-      - name: fetch and rebase on master
+      - name: fetch and rebase on ${{ github.base_ref }}
         run: |
-          git remote add upstream https://github.com/lightningnetwork/lnd
+          git remote add upstream https://github.com/${{ github.repository }}
           git fetch upstream
           export GIT_COMMITTER_EMAIL="lnd-ci@example.com"
           export GIT_COMMITTER_NAME="LND CI"
-          git rebase upstream/master
+          git rebase upstream/${{ github.base_ref }}
 
       - name: check commits
-        run: scripts/check-each-commit.sh upstream/master
+        run: scripts/check-each-commit.sh upstream/${{ github.base_ref }}
 
   ########################
   # lint code

--- a/docs/release-notes/release-notes-0.16.0.md
+++ b/docs/release-notes/release-notes-0.16.0.md
@@ -195,6 +195,10 @@ certain large transactions](https://github.com/lightningnetwork/lnd/pull/7100).
 * [`golangci-lint` will now check new code using additional
   linters.](https://github.com/lightningnetwork/lnd/pull/7064)
 
+* Update github actions to [check commits against the target base 
+  branch](https://github.com/lightningnetwork/lnd/pull/7103) rather than just 
+  using the master branch. 
+
 ### Integration test
 
 The `lntest` has been


### PR DESCRIPTION
Instead of always checking commits against upstream master, check them against the target base branch. 