### PR TITLE
github: only check commits on PR events

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -92,6 +92,7 @@ jobs:
   # check commits
   ########################
   check-commits:
+    if: github.event_name == 'pull_request'
     name: check commits
     runs-on: ubuntu-latest
     steps:

--- a/docs/release-notes/release-notes-0.16.0.md
+++ b/docs/release-notes/release-notes-0.16.0.md
@@ -204,7 +204,9 @@ certain large transactions](https://github.com/lightningnetwork/lnd/pull/7100).
 
 * Update github actions to [check commits against the target base 
   branch](https://github.com/lightningnetwork/lnd/pull/7103) rather than just 
-  using the master branch. 
+  using the master branch. And [skip the commit 
+  check](https://github.com/lightningnetwork/lnd/pull/7114) for all non-PR 
+  events.
 
 ### Integration test
 


### PR DESCRIPTION
For push actions (as opposed to pull-requests), there is no base reference and so the commit-check doesnt work in this case. Realised this mistake when seeing the result of the "check-commits" when PRs are merged into master. 

But we in any case dont need this check on anything but PR actions. Push actions result in a rebase against nothing. 