### PR TITLE
htlcswitch: add garbage collection for batch-replay bucket

### DIFF
--- a/htlcswitch/circuit_map.go
+++ b/htlcswitch/circuit_map.go
@@ -212,7 +212,7 @@ type CircuitMapConfig struct {
 
 	// ExtractErrorEncrypter derives the shared secret used to encrypt
 	// errors from the obfuscator's ephemeral public key.
-	ExtractErrorEncrypter hop.ErrorEncrypterExtracter
+	ExtractErrorEncrypter hop.ErrorEncrypterExtractor
 
 	// CheckResolutionMsg checks whether a given resolution message exists
 	// for the passed CircuitKey.

--- a/htlcswitch/circuit_map_test.go
+++ b/htlcswitch/circuit_map_test.go
@@ -300,7 +300,7 @@ func TestCircuitMapCleanClosedChannels(t *testing.T) {
 func createTestCircuit(ks htlcswitch.Keystone, cm htlcswitch.CircuitMap) error {
 	circuit := &htlcswitch.PaymentCircuit{
 		Incoming:       ks.InKey,
-		ErrorEncrypter: testExtracter,
+		ErrorEncrypter: testExtractor,
 	}
 
 	// First we will try to add an new circuit to the circuit map, this

--- a/htlcswitch/circuit_test.go
+++ b/htlcswitch/circuit_test.go
@@ -31,9 +31,9 @@ var (
 	// create onion obfuscators.
 	testEphemeralKey *btcec.PublicKey
 
-	// testExtracter is a precomputed extraction of testEphemeralKey, using
+	// testExtractor is a precomputed extraction of testEphemeralKey, using
 	// the sphinxPrivKey.
-	testExtracter *hop.SphinxErrorEncrypter
+	testExtractor *hop.SphinxErrorEncrypter
 )
 
 func init() {
@@ -51,18 +51,18 @@ func init() {
 	}
 	testEphemeralKey = testEphemeralPriv.PubKey()
 
-	// Finally, properly initialize the test extracter
-	initTestExtracter()
+	// Finally, properly initialize the test extractor
+	initTestExtractor()
 }
 
-// initTestExtracter spins up a new onion processor specifically for the purpose
-// of generating our testExtracter, which should be derived from the
+// initTestExtractor spins up a new onion processor specifically for the purpose
+// of generating our testExtractor, which should be derived from the
 // testEphemeralKey, and which randomly-generated key is used to init the sphinx
 // router.
 //
 // NOTE: This should be called in init(), after testEphemeralKey has been
 // properly initialized.
-func initTestExtracter() {
+func initTestExtractor() {
 	onionProcessor := newOnionProcessor(nil)
 	defer onionProcessor.Stop()
 
@@ -70,16 +70,16 @@ func initTestExtracter() {
 		testEphemeralKey,
 	)
 
-	sphinxExtracter, ok := obfuscator.(*hop.SphinxErrorEncrypter)
+	sphinxExtractor, ok := obfuscator.(*hop.SphinxErrorEncrypter)
 	if !ok {
 		panic("did not extract sphinx error encrypter")
 	}
 
-	testExtracter = sphinxExtracter
+	testExtractor = sphinxExtractor
 
-	// We also set this error extracter on startup, otherwise it will be nil
+	// We also set this error extractor on startup, otherwise it will be nil
 	// at compile-time.
-	halfCircuitTests[2].encrypter = testExtracter
+	halfCircuitTests[2].encrypter = testExtractor
 }
 
 // newOnionProcessor creates starts a new htlcswitch.OnionProcessor using a temp
@@ -170,10 +170,10 @@ var halfCircuitTests = []struct {
 		outValue: 9000,
 		chanID:   lnwire.NewShortChanIDFromInt(3),
 		htlcID:   3,
-		// NOTE: The value of testExtracter is nil at compile-time, it
-		// is fully-initialized in initTestExtracter, which should
+		// NOTE: The value of testExtractor is nil at compile-time, it
+		// is fully-initialized in initTestExtractor, which should
 		// repopulate this encrypter.
-		encrypter: testExtracter,
+		encrypter: testExtractor,
 	},
 }
 
@@ -678,7 +678,7 @@ func TestCircuitMapCommitCircuits(t *testing.T) {
 			ChanID: chan1,
 			HtlcID: 3,
 		},
-		ErrorEncrypter: testExtracter,
+		ErrorEncrypter: testExtractor,
 	}
 
 	// First we will try to add an new circuit to the circuit map, this
@@ -768,7 +768,7 @@ func TestCircuitMapOpenCircuits(t *testing.T) {
 			ChanID: chan1,
 			HtlcID: 3,
 		},
-		ErrorEncrypter: testExtracter,
+		ErrorEncrypter: testExtractor,
 	}
 
 	// First we will try to add an new circuit to the circuit map, this
@@ -1200,7 +1200,7 @@ func TestCircuitMapCloseUnopenedCircuit(t *testing.T) {
 			ChanID: chan1,
 			HtlcID: 3,
 		},
-		ErrorEncrypter: testExtracter,
+		ErrorEncrypter: testExtractor,
 	}
 
 	// First we will try to add an new circuit to the circuit map, this
@@ -1255,7 +1255,7 @@ func TestCircuitMapDeleteUnopenedCircuit(t *testing.T) {
 			ChanID: chan1,
 			HtlcID: 3,
 		},
-		ErrorEncrypter: testExtracter,
+		ErrorEncrypter: testExtractor,
 	}
 
 	// First we will try to add an new circuit to the circuit map, this
@@ -1312,7 +1312,7 @@ func TestCircuitMapDeleteOpenCircuit(t *testing.T) {
 			ChanID: chan1,
 			HtlcID: 3,
 		},
-		ErrorEncrypter: testExtracter,
+		ErrorEncrypter: testExtractor,
 	}
 
 	// First we will try to add an new circuit to the circuit map, this

--- a/htlcswitch/decayedlog.go
+++ b/htlcswitch/decayedlog.go
@@ -627,6 +627,11 @@ func (d *DecayedLog) PutBatch(b *sphinx.Batch) (*sphinx.ReplaySet, error) {
 		// batch's construction.
 		replays.Merge(b.ReplaySet)
 
+		// No need to persist information for empty batches.
+		if maximumExpiryHeight == 0 && replays.Size() == 0 {
+			return nil
+		}
+
 		// Load the replay set expiry bucket, which will be used to
 		// write the expiry height for the replay set.
 		replaySetExpiryBkt := tx.ReadWriteBucket(replaySetExpiryBucket)

--- a/htlcswitch/decayedlog.go
+++ b/htlcswitch/decayedlog.go
@@ -219,7 +219,7 @@ func (d *DecayedLog) gcExpiredHashes(height uint32) (uint32, error) {
 		var expiredCltv [][]byte
 		if err := sharedHashes.ForEach(func(k, v []byte) error {
 			// Deserialize the CLTV value for this entry.
-			cltv := uint32(binary.BigEndian.Uint32(v))
+			cltv := binary.BigEndian.Uint32(v)
 
 			if cltv < height {
 				// This CLTV is expired. We must add it to an
@@ -287,7 +287,7 @@ func (d *DecayedLog) Get(hash *sphinx.HashPrefix) (uint32, error) {
 		}
 
 		// The first 4 bytes represent the CLTV, store it in value.
-		value = uint32(binary.BigEndian.Uint32(valueBytes))
+		value = binary.BigEndian.Uint32(valueBytes)
 
 		return nil
 	}, func() {

--- a/htlcswitch/decayedlog.go
+++ b/htlcswitch/decayedlog.go
@@ -162,7 +162,7 @@ func (d *DecayedLog) Stop() error {
 }
 
 // garbageCollector deletes entries from sharedHashBucket whose expiry height
-// has already past. This function MUST be run as a goroutine.
+// has already passed. This function MUST be run as a goroutine.
 func (d *DecayedLog) garbageCollector(epochClient *chainntnfs.BlockEpochEvent) {
 	defer d.wg.Done()
 	defer epochClient.Cancel()
@@ -302,7 +302,7 @@ func (d *DecayedLog) Get(hash *sphinx.HashPrefix) (uint32, error) {
 
 // Put stores a shared secret hash as the key and the CLTV as the value.
 func (d *DecayedLog) Put(hash *sphinx.HashPrefix, cltv uint32) error {
-	// Optimisitically serialize the cltv value into the scratch buffer.
+	// Optimistically serialize the cltv value into the scratch buffer.
 	var scratch [4]byte
 	binary.BigEndian.PutUint32(scratch[:], cltv)
 
@@ -334,7 +334,7 @@ func (d *DecayedLog) Put(hash *sphinx.HashPrefix, cltv uint32) error {
 func (d *DecayedLog) PutBatch(b *sphinx.Batch) (*sphinx.ReplaySet, error) {
 	// Since batched boltdb txns may be executed multiple times before
 	// succeeding, we will create a new replay set for each invocation to
-	// avoid any side-effects. If the txn is successful, this replay set
+	// avoid any side effects. If the txn is successful, this replay set
 	// will be merged with the replay set computed during batch construction
 	// to generate the complete replay set. If this batch was previously
 	// processed, the replay set will be deserialized from disk.
@@ -412,6 +412,6 @@ func (d *DecayedLog) PutBatch(b *sphinx.Batch) (*sphinx.ReplaySet, error) {
 	return replays, nil
 }
 
-// A compile time check to see if DecayedLog adheres to the PersistLog
+// A compile-time check to see if DecayedLog adheres to the PersistLog
 // interface.
 var _ sphinx.ReplayLog = (*DecayedLog)(nil)

--- a/htlcswitch/hop/error_encryptor.go
+++ b/htlcswitch/hop/error_encryptor.go
@@ -27,9 +27,9 @@ const (
 	EncrypterTypeMock = 2
 )
 
-// ErrorEncrypterExtracter defines a function signature that extracts an
-// ErrorEncrypter from an sphinx OnionPacket.
-type ErrorEncrypterExtracter func(*btcec.PublicKey) (ErrorEncrypter,
+// ErrorEncrypterExtractor defines a function signature that extracts an
+// ErrorEncrypter from a sphinx OnionPacket.
+type ErrorEncrypterExtractor func(*btcec.PublicKey) (ErrorEncrypter,
 	lnwire.FailCode)
 
 // ErrorEncrypter is an interface that is used to encrypt HTLC related errors
@@ -66,12 +66,12 @@ type ErrorEncrypter interface {
 	// given io.Reader.
 	Decode(io.Reader) error
 
-	// Reextract rederives the encrypter using the extracter, performing an
+	// Reextract rederives the encrypter using the extractor, performing an
 	// ECDH with the sphinx router's key and the ephemeral public key.
 	//
 	// NOTE: This should be called shortly after Decode to properly
 	// reinitialize the error encrypter.
-	Reextract(ErrorEncrypterExtracter) error
+	Reextract(ErrorEncrypterExtractor) error
 }
 
 // SphinxErrorEncrypter is a concrete implementation of both the ErrorEncrypter
@@ -177,7 +177,7 @@ func (s *SphinxErrorEncrypter) Decode(r io.Reader) error {
 // This intended to be used shortly after Decode, to fully initialize a
 // SphinxErrorEncrypter.
 func (s *SphinxErrorEncrypter) Reextract(
-	extract ErrorEncrypterExtracter) error {
+	extract ErrorEncrypterExtractor) error {
 
 	obfuscator, failcode := extract(s.EphemeralKey)
 	if failcode != lnwire.CodeNone {
@@ -190,7 +190,7 @@ func (s *SphinxErrorEncrypter) Reextract(
 
 	sphinxEncrypter, ok := obfuscator.(*SphinxErrorEncrypter)
 	if !ok {
-		return fmt.Errorf("incorrect onion error extracter")
+		return fmt.Errorf("incorrect onion error extractor")
 	}
 
 	// Copy the freshly extracted encrypter.

--- a/htlcswitch/hop/iterator.go
+++ b/htlcswitch/hop/iterator.go
@@ -31,13 +31,13 @@ type Iterator interface {
 
 	// ExtractErrorEncrypter returns the ErrorEncrypter needed for this hop,
 	// along with a failure code to signal if the decoding was successful.
-	ExtractErrorEncrypter(ErrorEncrypterExtracter) (ErrorEncrypter,
+	ExtractErrorEncrypter(ErrorEncrypterExtractor) (ErrorEncrypter,
 		lnwire.FailCode)
 }
 
 // sphinxHopIterator is the Sphinx implementation of hop iterator which uses
 // onion routing to encode the payment route  in such a way so that node might
-// see only the next hop in the route..
+// see only the next hop in the route.
 type sphinxHopIterator struct {
 	// ogPacket is the original packet from which the processed packet is
 	// derived.
@@ -50,7 +50,7 @@ type sphinxHopIterator struct {
 }
 
 // makeSphinxHopIterator converts a processed packet returned from a sphinx
-// router and converts it into an hop iterator for usage in the link.
+// router and converts it into a hop iterator for usage in the link.
 func makeSphinxHopIterator(ogPacket *sphinx.OnionPacket,
 	packet *sphinx.ProcessedPacket) *sphinxHopIterator {
 
@@ -60,7 +60,7 @@ func makeSphinxHopIterator(ogPacket *sphinx.OnionPacket,
 	}
 }
 
-// A compile time check to ensure sphinxHopIterator implements the HopIterator
+// A compile-time check to ensure sphinxHopIterator implements the HopIterator
 // interface.
 var _ Iterator = (*sphinxHopIterator)(nil)
 
@@ -107,9 +107,9 @@ func (r *sphinxHopIterator) HopPayload() (*Payload, error) {
 //
 // NOTE: Part of the HopIterator interface.
 func (r *sphinxHopIterator) ExtractErrorEncrypter(
-	extracter ErrorEncrypterExtracter) (ErrorEncrypter, lnwire.FailCode) {
+	extractor ErrorEncrypterExtractor) (ErrorEncrypter, lnwire.FailCode) {
 
-	return extracter(r.ogPacket.EphemeralKey)
+	return extractor(r.ogPacket.EphemeralKey)
 }
 
 // OnionProcessor is responsible for keeping all sphinx dependent parts inside
@@ -117,7 +117,7 @@ func (r *sphinxHopIterator) ExtractErrorEncrypter(
 // subsystems which wants to decode sphinx path to not be dependable from
 // sphinx at all.
 //
-// NOTE: The reason for keeping decoder separated from hop iterator is too
+// NOTE: The reason for keeping decoder separated from hop iterator is to
 // maintain the hop iterator abstraction. Without it the structures which using
 // the hop iterator should contain sphinx router which makes their creations in
 // tests dependent from the sphinx internal parts.
@@ -136,7 +136,7 @@ func (p *OnionProcessor) Start() error {
 	return p.router.Start()
 }
 
-// Stop shutsdown the onion processor's sphinx router.
+// Stop shuts down the onion processor's sphinx router.
 func (p *OnionProcessor) Stop() error {
 
 	log.Info("Onion processor shutting down")
@@ -315,7 +315,7 @@ func (p *OnionProcessor) DecodeHopIterators(id []byte,
 	wg.Wait()
 
 	// With that batch created, we will now attempt to write the shared
-	// secrets to disk. This operation will returns the set of indices that
+	// secrets to disk. This operation will return the set of indices that
 	// were detected as replays, and the computed sphinx packets for all
 	// indices that did not fail the above loop. Only indices that are not
 	// in the replay set should be considered valid, as they are

--- a/htlcswitch/hop/iterator.go
+++ b/htlcswitch/hop/iterator.go
@@ -64,7 +64,7 @@ func makeSphinxHopIterator(ogPacket *sphinx.OnionPacket,
 // interface.
 var _ Iterator = (*sphinxHopIterator)(nil)
 
-// Encode encodes iterator and writes it to the writer.
+// EncodeNextHop encodes iterator and writes it to the writer.
 //
 // NOTE: Part of the HopIterator interface.
 func (r *sphinxHopIterator) EncodeNextHop(w io.Writer) error {

--- a/htlcswitch/link.go
+++ b/htlcswitch/link.go
@@ -153,7 +153,7 @@ type ChannelLinkConfig struct {
 
 	// ExtractErrorEncrypter function is responsible for decoding HTLC
 	// Sphinx onion blob, and creating onion failure obfuscator.
-	ExtractErrorEncrypter hop.ErrorEncrypterExtracter
+	ExtractErrorEncrypter hop.ErrorEncrypterExtractor
 
 	// FetchLastChannelUpdate retrieves the latest routing policy for a
 	// target channel. This channel will typically be the outgoing channel

--- a/htlcswitch/mock.go
+++ b/htlcswitch/mock.go
@@ -337,10 +337,10 @@ func (r *mockHopIterator) ExtraOnionBlob() []byte {
 }
 
 func (r *mockHopIterator) ExtractErrorEncrypter(
-	extracter hop.ErrorEncrypterExtracter) (hop.ErrorEncrypter,
+	extractor hop.ErrorEncrypterExtractor) (hop.ErrorEncrypter,
 	lnwire.FailCode) {
 
-	return extracter(nil)
+	return extractor(nil)
 }
 
 func (r *mockHopIterator) EncodeNextHop(w io.Writer) error {
@@ -412,7 +412,7 @@ func (o *mockObfuscator) Decode(r io.Reader) error {
 }
 
 func (o *mockObfuscator) Reextract(
-	extracter hop.ErrorEncrypterExtracter) error {
+	extractor hop.ErrorEncrypterExtractor) error {
 
 	return nil
 }

--- a/htlcswitch/switch.go
+++ b/htlcswitch/switch.go
@@ -162,7 +162,7 @@ type Config struct {
 	// ExtractErrorEncrypter is an interface allowing switch to reextract
 	// error encrypters stored in the circuit map on restarts, since they
 	// are not stored directly within the database.
-	ExtractErrorEncrypter hop.ErrorEncrypterExtracter
+	ExtractErrorEncrypter hop.ErrorEncrypterExtractor
 
 	// FetchLastChannelUpdate retrieves the latest routing policy for a
 	// target channel. This channel will typically be the outgoing channel


### PR DESCRIPTION
## Change Description
Fixes #7107.

This PR introduces the `replay-set-expiry` bucket which stores the expiry height for each replay set. A garbage collector function, similar to the existing one, is added that removes entries from the `batch-replay` bucket accordingly.

The `batch-replay` bucket may already contain lots of sets without expiry information. In each GC run (once per block), for replay sets without expiry information we add the expiry information. As the persisted information does not suffice to compute the expiry, we over-approximate a set's expiry by using the maximum of all entries in the `shared-hash` bucket.

As larger nodes may have several hundred million replay sets that need to be removed, both the "set expiry for set" and "garbage collect expired sets" operations are limited to 500,000 per block. This way, assuming on average no more than 500,000 sets are added per block, eventually the algorithm will remove all old data.

In order to avoid rescanning all replay sets for those without expiry height, we store "all sets have an expiry" height in a new `meta` bucket.

## Steps to Test
Steps for reviewers to follow to test the change.

## Pull Request Checklist
### Testing
- [ ] Your PR passes all CI checks.
- [ ] Tests covering the positive and negative (error paths) are included.
- [ ] Bug fixes contain tests triggering the bug to prevent regressions.

### Code Style and Documentation
- [x] The change obeys the [Code Documentation and Commenting](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#CodeDocumentation) guidelines, and lines wrap at 80.
- [x] Commits follow the [Ideal Git Commit Structure](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#IdealGitCommitStructure).
- [x] Any new logging statements use an appropriate subsystem and logging level.
- [ ]  [There is a change description in the release notes](https://github.com/lightningnetwork/lnd/tree/master/docs/release-notes), or `[skip ci]` in the commit message for small changes.

📝 Please see our  [Contribution Guidelines](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md) for further guidance.