### PR TITLE
itest+funding: decrease sleep time and add a temporary fix for itest

### DIFF
--- a/docs/release-notes/release-notes-0.16.0.md
+++ b/docs/release-notes/release-notes-0.16.0.md
@@ -149,8 +149,8 @@ certain large transactions](https://github.com/lightningnetwork/lnd/pull/7100).
   so that the user can specify fees during channel creation time in addition
   to the default configuration.
 
-* [Sleep for one second when funding locked message is not
-  received](https://github.com/lightningnetwork/lnd/pull/7095) to avoid CPU
+* [Sleep for 10ms when funding locked message is not
+  received](https://github.com/lightningnetwork/lnd/pull/7126) to avoid CPU
   spike.
 
 ## Code Health

--- a/funding/config_rpctest.go
+++ b/funding/config_rpctest.go
@@ -1,0 +1,11 @@
+//go:build rpctest
+
+package funding
+
+import "time"
+
+func init() {
+	// For itest, we will use a much shorter checking interval here as
+	// local communications are very fast.
+	checkPeerFundingLockInterval = 10 * time.Millisecond
+}

--- a/funding/manager.go
+++ b/funding/manager.go
@@ -39,6 +39,13 @@ var (
 	// byteOrder defines the endian-ness we use for encoding to and from
 	// buffers.
 	byteOrder = binary.BigEndian
+
+	// checkPeerFundingLockInterval is used when we are waiting for the
+	// peer to send us FundingLocked. We will check every 1 second to see
+	// if the message is received.
+	//
+	// NOTE: for itest, this value is changed to 10ms.
+	checkPeerFundingLockInterval = 1 * time.Second
 )
 
 // WriteOutpoint writes an outpoint to an io.Writer. This is not the same as
@@ -1022,9 +1029,9 @@ func (f *Manager) stateStep(channel *channeldb.OpenChannel,
 		if !received {
 			// We haven't received FundingLocked, so we'll continue
 			// to the next iteration of the loop after sleeping for
-			// one second.
+			// checkPeerFundingLockInterval.
 			select {
-			case <-time.After(1 * time.Second):
+			case <-time.After(checkPeerFundingLockInterval):
 			case <-f.quit:
 				return ErrFundingManagerShuttingDown
 			}

--- a/lntest/itest/assertions.go
+++ b/lntest/itest/assertions.go
@@ -90,6 +90,13 @@ func openChannelAndAssert(t *harnessTest, net *lntest.NetworkHarness,
 		"unable to assert channel existence",
 	)
 
+	// They should also notice this channel from topology subscription.
+	err = alice.WaitForNetworkChannelOpen(fundingChanPoint)
+	require.NoError(t.t, err)
+
+	err = bob.WaitForNetworkChannelOpen(fundingChanPoint)
+	require.NoError(t.t, err)
+
 	return fundingChanPoint
 }
 

--- a/lntest/itest/lnd_channel_policy_test.go
+++ b/lntest/itest/lnd_channel_policy_test.go
@@ -739,6 +739,10 @@ func testUpdateChannelPolicyForPrivateChannel(net *lntest.NetworkHarness,
 	)
 	defer closeChannelAndAssert(t, net, net.Bob, chanPointBobCarol, false)
 
+	// Carol should be aware of the channel between Alice and Bob.
+	err = carol.WaitForNetworkChannelOpen(chanPointAliceBob)
+	require.NoError(t.t, err)
+
 	// Get Bob's funding point.
 	bobChanTXID, err := lnrpc.GetChanPointFundingTxid(chanPointBobCarol)
 	require.NoError(t.t, err, "unable to get txid")


### PR DESCRIPTION
This PR adds a temporary fix to the itest before our new itest is merged, also decreases the sleep interval used in checking funding lock message.