### PR TITLE
lnwire: add missing tests for Warning

### DIFF
--- a/docs/release-notes/release-notes-0.16.0.md
+++ b/docs/release-notes/release-notes-0.16.0.md
@@ -134,6 +134,9 @@ certain large transactions](https://github.com/lightningnetwork/lnd/pull/7100).
 * [Migrated from go-fuzz to Go 1.18's new standard fuzz testing
   library](https://github.com/lightningnetwork/lnd/pull/7127).
 
+* [Added missing wire tests for Warning
+  message](https://github.com/lightningnetwork/lnd/pull/7143).
+
 ## `lncli`
 * [Add an `insecure` flag to skip tls auth as well as a `metadata` string slice
   flag](https://github.com/lightningnetwork/lnd/pull/6818) that allows the

--- a/lnwire/fuzz_test.go
+++ b/lnwire/fuzz_test.go
@@ -264,6 +264,17 @@ func FuzzError(f *testing.F) {
 	})
 }
 
+func FuzzWarning(f *testing.F) {
+	f.Fuzz(func(t *testing.T, data []byte) {
+		// Prefix with MsgWarning.
+		data = prefixWithMsgType(data, MsgWarning)
+
+		// Pass the message into our general fuzz harness for wire
+		// messages!
+		harness(t, data)
+	})
+}
+
 func FuzzFundingCreated(f *testing.F) {
 	f.Fuzz(func(t *testing.T, data []byte) {
 		// Prefix with MsgFundingCreated.

--- a/lnwire/message_test.go
+++ b/lnwire/message_test.go
@@ -259,6 +259,7 @@ func BenchmarkReadMessage(b *testing.B) {
 func makeAllMessages(t testing.TB, r *rand.Rand) []lnwire.Message {
 	msgAll := []lnwire.Message{}
 
+	msgAll = append(msgAll, newMsgWarning(t, r))
 	msgAll = append(msgAll, newMsgInit(t, r))
 	msgAll = append(msgAll, newMsgError(t, r))
 	msgAll = append(msgAll, newMsgPing(t, r))
@@ -291,6 +292,19 @@ func makeAllMessages(t testing.TB, r *rand.Rand) []lnwire.Message {
 	msgAll = append(msgAll, newMsgReplyChannelRangeZlib(t, r))
 
 	return msgAll
+}
+
+func newMsgWarning(tb testing.TB, r io.Reader) *lnwire.Warning {
+	tb.Helper()
+
+	msg := lnwire.NewWarning()
+
+	_, err := r.Read(msg.ChanID[:])
+	require.NoError(tb, err, "unable to generate chan id")
+
+	msg.Data = createExtraData(tb, r)
+
+	return msg
 }
 
 func newMsgInit(t testing.TB, r io.Reader) *lnwire.Init {


### PR DESCRIPTION
Adds a missing benchmark and fuzz test for the warning message.

Tested with:
```shell
$ cd lnwire
$ go test -bench=Benchmark
...
$ go test -fuzz=FuzzWarning
```
Fixes #7141.