### PR TITLE
lnwallet/btcwallet: use taproot addrs for change outputs from SendCoins

### DIFF
--- a/docs/release-notes/release-notes-0.15.5.md
+++ b/docs/release-notes/release-notes-0.15.5.md
@@ -5,6 +5,15 @@
 * [A Taproot related key tweak issue was fixed in `btcd` that affected remote
   signing setups](https://github.com/lightningnetwork/lnd/pull/7130).
 
+* [Taproot changes addresses are now used by default for the `SendCoins`
+  RPC](https://github.com/lightningnetwork/lnd/pull/7147).
+
+* [A 1 second interval has been added between `FundingLocked` receipt
+  checks](https://github.com/lightningnetwork/lnd/pull/7095). This reduces idle
+  CPU usage for pending/dangling funding attempts.
+
 # Contributors (Alphabetical Order)
 
+* Olaoluwa Osuntokun
 * Oliver Gugger
+* Yong Yu

--- a/go.mod
+++ b/go.mod
@@ -5,11 +5,11 @@ require (
 	github.com/Yawning/aez v0.0.0-20211027044916-e49e68abd344
 	github.com/btcsuite/btcd v0.23.4
 	github.com/btcsuite/btcd/btcec/v2 v2.2.2
-	github.com/btcsuite/btcd/btcutil v1.1.2
+	github.com/btcsuite/btcd/btcutil v1.1.3
 	github.com/btcsuite/btcd/btcutil/psbt v1.1.5
 	github.com/btcsuite/btcd/chaincfg/chainhash v1.0.1
 	github.com/btcsuite/btclog v0.0.0-20170628155309-84c8d2346e9f
-	github.com/btcsuite/btcwallet v0.16.2-0.20221109224534-84bf4e34c816
+	github.com/btcsuite/btcwallet v0.16.4
 	github.com/btcsuite/btcwallet/wallet/txauthor v1.3.2
 	github.com/btcsuite/btcwallet/wallet/txrules v1.2.0
 	github.com/btcsuite/btcwallet/walletdb v1.4.0
@@ -171,3 +171,5 @@ replace github.com/gogo/protobuf => github.com/gogo/protobuf v1.3.2
 go 1.18
 
 retract v0.0.2
+
+replace github.com/btcsuite/btcwallet => github.com/roasbeef/btcwallet v0.11.1-0.20221119205231-85dadcaf909c

--- a/go.sum
+++ b/go.sum
@@ -87,8 +87,8 @@ github.com/btcsuite/btcd/btcec/v2 v2.2.2/go.mod h1:9/CSmJxmuvqzX9Wh2fXMWToLOHhPd
 github.com/btcsuite/btcd/btcutil v1.0.0/go.mod h1:Uoxwv0pqYWhD//tfTiipkxNfdhG9UrLwaeswfjfdF0A=
 github.com/btcsuite/btcd/btcutil v1.1.0/go.mod h1:5OapHB7A2hBBWLm48mmw4MOHNJCcUBTwmWH/0Jn8VHE=
 github.com/btcsuite/btcd/btcutil v1.1.1/go.mod h1:nbKlBMNm9FGsdvKvu0essceubPiAcI57pYBNnsLAa34=
-github.com/btcsuite/btcd/btcutil v1.1.2 h1:XLMbX8JQEiwMcYft2EGi8zPUkoa0abKIU6/BJSRsjzQ=
-github.com/btcsuite/btcd/btcutil v1.1.2/go.mod h1:UR7dsSJzJUfMmFiiLlIrMq1lS9jh9EdCV7FStZSnpi0=
+github.com/btcsuite/btcd/btcutil v1.1.3 h1:xfbtw8lwpp0G6NwSHb+UE67ryTFHJAiNuipusjXSohQ=
+github.com/btcsuite/btcd/btcutil v1.1.3/go.mod h1:UR7dsSJzJUfMmFiiLlIrMq1lS9jh9EdCV7FStZSnpi0=
 github.com/btcsuite/btcd/btcutil/psbt v1.1.4/go.mod h1:9AyU6EQVJ9Iw9zPyNT1lcdHd6cnEZdno5wLu5FY74os=
 github.com/btcsuite/btcd/btcutil/psbt v1.1.5 h1:x0ZRrYY8j75ThV6xBz86CkYAG82F5bzay4H5D1c8b/U=
 github.com/btcsuite/btcd/btcutil/psbt v1.1.5/go.mod h1:kA6FLH/JfUx++j9pYU0pyu+Z8XGBQuuTmuKYUf6q7/U=
@@ -98,8 +98,6 @@ github.com/btcsuite/btcd/chaincfg/chainhash v1.0.1/go.mod h1:7SFka0XMvUgj3hfZtyd
 github.com/btcsuite/btclog v0.0.0-20170628155309-84c8d2346e9f h1:bAs4lUbRJpnnkd9VhRV3jjAVU7DJVjMaK+IsvSeZvFo=
 github.com/btcsuite/btclog v0.0.0-20170628155309-84c8d2346e9f/go.mod h1:TdznJufoqS23FtqVCzL0ZqgP5MqXbb4fg/WgDys70nA=
 github.com/btcsuite/btcutil v0.0.0-20190425235716-9e5f4b9a998d/go.mod h1:+5NJ2+qvTyV9exUAL/rxXi3DcLg2Ts+ymUAY5y4NvMg=
-github.com/btcsuite/btcwallet v0.16.2-0.20221109224534-84bf4e34c816 h1:t4wbkXekvTc1eOGDv2h8l6mkLPnqP93hnRHvNtgpiHQ=
-github.com/btcsuite/btcwallet v0.16.2-0.20221109224534-84bf4e34c816/go.mod h1:d8AETQyIIWTtC9CnoCMBmDARp9P65oX4IoBdEP3fDK4=
 github.com/btcsuite/btcwallet/wallet/txauthor v1.2.3/go.mod h1:T2xSiKGpUkSLCh68aF+FMXmKK9mFqNdHl9VaqOr+JjU=
 github.com/btcsuite/btcwallet/wallet/txauthor v1.3.2 h1:etuLgGEojecsDOYTII8rYiGHjGyV5xTqsXi+ZQ715UU=
 github.com/btcsuite/btcwallet/wallet/txauthor v1.3.2/go.mod h1:Zpk/LOb2sKqwP2lmHjaZT9AdaKsHPSbNLm2Uql5IQ/0=
@@ -559,6 +557,8 @@ github.com/prometheus/procfs v0.6.0/go.mod h1:cz+aTbrPOrUb4q7XlbU9ygM+/jj0fzG6c1
 github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
 github.com/rivo/uniseg v0.2.0 h1:S1pD9weZBuJdFmowNwbpi7BJ8TNftyUImj/0WQi72jY=
 github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
+github.com/roasbeef/btcwallet v0.11.1-0.20221119205231-85dadcaf909c h1:MUxQcF73lHgJU6f3nI4yccNvD+0i6IKFPXVSEOX9WXg=
+github.com/roasbeef/btcwallet v0.11.1-0.20221119205231-85dadcaf909c/go.mod h1:mM19pFB3lGVxOL+kvHhHZAhdSWXKsZGiHvpJVvxL0D8=
 github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=
 github.com/rogpeppe/fastuuid v1.2.0 h1:Ppwyp6VYCF1nvBTXL3trRso7mXMlRrw9ooo375wvi2s=
 github.com/rogpeppe/fastuuid v1.2.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6LYCDYWNEvQ=

--- a/lntest/itest/lnd_recovery_test.go
+++ b/lntest/itest/lnd_recovery_test.go
@@ -261,7 +261,7 @@ func testOnchainFundRecovery(ht *lntemp.HarnessTest) {
 	restoreCheckBalance(finalBalance, 9, 20, promptChangeAddr)
 
 	// We should expect a static fee of 36400 satoshis for spending 9
-	// inputs (3 P2WPKH, 3 NP2WPKH, 3 P2TR) to two P2WPKH outputs. Carol
+	// inputs (3 P2WPKH, 3 NP2WPKH, 3 P2TR) to two P2TR outputs. Carol
 	// should therefore only have one UTXO present (the change output) of
 	// 9 - 8 - fee BTC.
 	const fee = 36400

--- a/lnwallet/test/test_interface.go
+++ b/lnwallet/test/test_interface.go
@@ -430,6 +430,8 @@ func testGetRecoveryInfo(miner *rpctest.Harness,
 func testDualFundingReservationWorkflow(miner *rpctest.Harness,
 	alice, bob *lnwallet.LightningWallet, t *testing.T) {
 
+	t.Skipf("dual funding isn't exposed on the p2p layer")
+
 	fundingAmount, err := btcutil.NewAmount(5)
 	require.NoError(t, err, "unable to create amt")
 

--- a/lnwallet/test/test_interface.go
+++ b/lnwallet/test/test_interface.go
@@ -2562,7 +2562,9 @@ func testCreateSimpleTx(r *rpctest.Harness, w *lnwallet.LightningWallet,
 		// _very_ similar to the one we just created being sent. The
 		// only difference is that the dry run tx is not signed, and
 		// that the change output position might be different.
-		tx, sendErr := w.SendOutputs(outputs, feeRate, minConfs, labels.External)
+		tx, sendErr := w.SendOutputs(
+			outputs, feeRate, minConfs, labels.External,
+		)
 		switch {
 		case test.valid && sendErr != nil:
 			t.Fatalf("got unexpected error when sending tx: %v",
@@ -2647,6 +2649,16 @@ func testCreateSimpleTx(r *rpctest.Harness, w *lnwallet.LightningWallet,
 		if err := assertSimilarTx(createTx.Tx, tx); err != nil {
 			t.Fatalf("transactions not similar: %v", err)
 		}
+
+		// Now that we know both transactions were essentially
+		// identical, we'll make sure that a P2TR addr was used as the
+		// change output, which is the current default.
+		changeOutputScript := createTx.Tx.TxOut[createTx.ChangeIndex].PkScript
+		changeScriptType, _, _, err := txscript.ExtractPkScriptAddrs(
+			changeOutputScript, &w.Cfg.NetParams,
+		)
+		require.NoError(t, err)
+		require.Equal(t, changeScriptType, txscript.WitnessV1TaprootTy)
 	}
 }
 

--- a/lnwallet/test/test_interface.go
+++ b/lnwallet/test/test_interface.go
@@ -2194,9 +2194,9 @@ func testChangeOutputSpendConfirmation(r *rpctest.Harness,
 	// TODO(wilmer): replace this once SendOutputs easily supports sending
 	// all funds in one transaction.
 	txFeeRate := chainfee.SatPerKWeight(2500)
-	txFee := btcutil.Amount(14380)
+	txFee := int64(14500) // nolint:gomnd
 	output := &wire.TxOut{
-		Value:    int64(aliceBalance - txFee),
+		Value:    int64(aliceBalance) - txFee,
 		PkScript: bobPkScript,
 	}
 	tx := sendCoins(t, r, alice, bob, output, txFeeRate, true, 1)


### PR DESCRIPTION
In this commit, we specify the default key scope as BIP 86, which means taproot addresses will be used for default by all on chain sends.

Fixes #7144.

