### PR TITLE
funding: mark tx label before notifying channel open event

### DIFF
--- a/docs/release-notes/release-notes-0.16.0.md
+++ b/docs/release-notes/release-notes-0.16.0.md
@@ -171,6 +171,9 @@ certain large transactions](https://github.com/lightningnetwork/lnd/pull/7100).
 * [A new config option, `mailboxdeliverytimeout` has been added to
   `htlcswitch`](https://github.com/lightningnetwork/lnd/pull/7066).
 
+* [Label the openchannel tx first before notifying the channel open
+  event.](https://github.com/lightningnetwork/lnd/pull/7158) 
+
 ## Code Health
 
 * [test: use `T.TempDir` to create temporary test

--- a/funding/manager.go
+++ b/funding/manager.go
@@ -2815,12 +2815,12 @@ func (f *Manager) handleFundingConfirmation(
 			"%v", err)
 	}
 
+	// Update the confirmed funding transaction label.
+	f.makeLabelForTx(completeChan)
+
 	// Inform the ChannelNotifier that the channel has transitioned from
 	// pending open to open.
 	f.cfg.NotifyOpenChannelEvent(completeChan.FundingOutpoint)
-
-	// Update the confirmed funding transaction label.
-	f.makeLabelForTx(completeChan)
 
 	// Close the discoverySignal channel, indicating to a separate
 	// goroutine that the channel now is marked as open in the database


### PR DESCRIPTION
Caught from itest. I think we need to mark the tx label first before notifying the client to properly report the state.