### PR TITLE
invoices+channeldb: introduce InvoicesDB interface

### DIFF
--- a/config_builder.go
+++ b/config_builder.go
@@ -764,6 +764,9 @@ type DatabaseInstances struct {
 	// HeightHintDB is the database that stores height hints for spends.
 	HeightHintDB kvdb.Backend
 
+	// InvoicesDB is the database that stores invoices.
+	InvoicesDB channeldb.InvoicesDB
+
 	// MacaroonDB is the database that stores macaroon root keys.
 	MacaroonDB kvdb.Backend
 
@@ -914,6 +917,9 @@ func (d *DefaultDatabaseBuilder) BuildDatabase(
 	// channel state DB should be created here individually instead of just
 	// using the same struct (and DB backend) instance.
 	dbs.ChanStateDB = dbs.GraphDB
+
+	// InvoicesDB is implemented by channeldb.DB currently.
+	dbs.InvoicesDB = dbs.GraphDB
 
 	// Wrap the watchtower client DB and make sure we clean up.
 	if cfg.WtClient.Active {

--- a/server.go
+++ b/server.go
@@ -614,7 +614,7 @@ func newServer(cfg *Config, listenAddrs []net.Addr,
 		uint32(currentHeight), currentHash, cc.ChainNotifier,
 	)
 	s.invoices = invoices.NewRegistry(
-		dbs.ChanStateDB, expiryWatcher, &registryConfig,
+		dbs.InvoicesDB, expiryWatcher, &registryConfig,
 	)
 
 	s.htlcNotifier = htlcswitch.NewHtlcNotifier(time.Now)


### PR DESCRIPTION
## Change Description
Deals with the first two points of issue #6288.
* Eliminate the invoice registry's dependency on the raw channel db pointer
* Expose the new interface as part of the set of defined `DatabaseInstances`

This is a minimal version, I'm currently researching what would be needed to invert the dependency relation between `channeldb` and `invoices` packages. Ideally `InvoicesDB` would live in the `invoices` package.