### PR TITLE
multi: Add ability to set custom node announcement feature bits in config

### DIFF
--- a/cmd/lncli/peersrpc_active.go
+++ b/cmd/lncli/peersrpc_active.go
@@ -126,7 +126,7 @@ func updateNodeAnnouncement(ctx *cli.Context) error {
 
 	if ctx.IsSet("feature_bit_add") {
 		change = true
-		for _, feature := range ctx.IntSlice("feature_bit_add") {
+		for _, feature := range ctx.Int64Slice("feature_bit_add") {
 			action := &peersrpc.UpdateFeatureAction{
 				Action:     peersrpc.UpdateAction_ADD,
 				FeatureBit: lnrpc.FeatureBit(feature),
@@ -137,7 +137,7 @@ func updateNodeAnnouncement(ctx *cli.Context) error {
 
 	if ctx.IsSet("feature_bit_remove") {
 		change = true
-		for _, feature := range ctx.IntSlice("feature_bit_remove") {
+		for _, feature := range ctx.Int64Slice("feature_bit_remove") {
 			action := &peersrpc.UpdateFeatureAction{
 				Action:     peersrpc.UpdateAction_REMOVE,
 				FeatureBit: lnrpc.FeatureBit(feature),

--- a/docs/release-notes/release-notes-0.16.0.md
+++ b/docs/release-notes/release-notes-0.16.0.md
@@ -130,6 +130,14 @@ current gossip sync query status.
 * [A bug has been fixed which could cause `lnd` to crash when parsing a
   malformed HTLC intercept message](https://github.com/lightningnetwork/lnd/pull/7392).
 
+* The [UpdateNodeAnnouncement](https://github.com/lightningnetwork/lnd/pull/7168)
+  API can no longer be used to set/unset protocol features that are defined by 
+  LND. A bug in the `updatenodeannouncement` peers cli which did not allow 
+  setting/unsetting of feature bits also has been fixed. 
+
+  Custom node announcement feature bits can also be specified in config using 
+  the `dev` build tag and `--protocol.custom-nodeann-feature`  flag. 
+
 ## Wallet
 
 * [Allows Taproot public keys and tap scripts to be imported as watch-only

--- a/lncfg/protocol_experimental_off.go
+++ b/lncfg/protocol_experimental_off.go
@@ -3,6 +3,8 @@
 
 package lncfg
 
+import "github.com/lightningnetwork/lnd/lnwire"
+
 // ExperimentalProtocol is a sub-config that houses any experimental protocol
 // features that also require a build-tag to activate.
 type ExperimentalProtocol struct {
@@ -11,5 +13,11 @@ type ExperimentalProtocol struct {
 // CustomMessageOverrides returns the set of protocol messages that we override
 // to allow custom handling.
 func (p ExperimentalProtocol) CustomMessageOverrides() []uint16 {
+	return nil
+}
+
+// CustomAnnFeatures returns a set of protocol feature bits to set in the node's
+// announcement.
+func (p ExperimentalProtocol) CustomAnnFeatures() []lnwire.FeatureBit {
 	return nil
 }

--- a/lncfg/protocol_experimental_on.go
+++ b/lncfg/protocol_experimental_on.go
@@ -3,16 +3,31 @@
 
 package lncfg
 
+import "github.com/lightningnetwork/lnd/lnwire"
+
 // ExperimentalProtocol is a sub-config that houses any experimental protocol
 // features that also require a build-tag to activate.
 //
 //nolint:lll
 type ExperimentalProtocol struct {
 	CustomMessage []uint16 `long:"custom-message" description:"allows the custom message apis to send and report messages with the protocol number provided that fall outside of the custom message number range."`
+
+	CustomFeature []uint64 `long:"custom-nodeann-feature" description:"a protocol feature bit to set in our node's announcement"`
 }
 
 // CustomMessageOverrides returns the set of protocol messages that we override
 // to allow custom handling.
 func (p ExperimentalProtocol) CustomMessageOverrides() []uint16 {
 	return p.CustomMessage
+}
+
+// CustomAnnFeatures returns a set of protocol feature bits to add to the node's
+// announcement.
+func (p ExperimentalProtocol) CustomAnnFeatures() []lnwire.FeatureBit {
+	features := make([]lnwire.FeatureBit, len(p.CustomFeature))
+	for i, f := range p.CustomFeature {
+		features[i] = lnwire.FeatureBit(f)
+	}
+
+	return features
 }

--- a/lnrpc/peersrpc/config_active.go
+++ b/lnrpc/peersrpc/config_active.go
@@ -26,4 +26,8 @@ type Config struct {
 	// UpdateNodeAnnouncement updates our node announcement applying the
 	// given NodeAnnModifiers and broadcasts the new version to the network.
 	UpdateNodeAnnouncement func(...netann.NodeAnnModifier) error
+
+	// ConfigFeatures holds a set of features that are set in lnd's top
+	// level config.
+	ConfigFeatures []lnwire.FeatureBit
 }

--- a/lnrpc/peersrpc/peers_server.go
+++ b/lnrpc/peersrpc/peers_server.go
@@ -281,7 +281,9 @@ func (s *Server) updateFeatures(currentfeatures *lnwire.RawFeatureVector,
 		}
 	}
 
-	raw, err := lnwire.MergeFeatureVector(currentfeatures, add, remove)
+	raw, err := lnwire.MergeFeatureVector(
+		currentfeatures, add, remove, nil,
+	)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/lnrpc/peersrpc/peers_server.go
+++ b/lnrpc/peersrpc/peers_server.go
@@ -282,7 +282,7 @@ func (s *Server) updateFeatures(currentfeatures *lnwire.RawFeatureVector,
 	}
 
 	raw, err := lnwire.MergeFeatureVector(
-		currentfeatures, add, remove, nil,
+		currentfeatures, add, remove, s.cfg.ConfigFeatures,
 	)
 	if err != nil {
 		return nil, nil, err

--- a/lnrpc/peersrpc/peers_server.go
+++ b/lnrpc/peersrpc/peers_server.go
@@ -254,6 +254,12 @@ func (s *Server) updateFeatures(currentfeatures *lnwire.RawFeatureVector,
 	for _, update := range updates {
 		bit := lnwire.FeatureBit(update.FeatureBit)
 
+		if name, known := lnwire.Features[bit]; known {
+			return nil, nil, fmt.Errorf("can't modify feature "+
+				"bit: %d already used in LND for: %v", bit,
+				name)
+		}
+
 		switch update.Action {
 		case UpdateAction_ADD:
 			if raw.IsSet(bit) {

--- a/lntest/itest/lnd_channel_graph_test.go
+++ b/lntest/itest/lnd_channel_graph_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/lightningnetwork/lnd/lntemp"
 	"github.com/lightningnetwork/lnd/lntemp/node"
 	"github.com/lightningnetwork/lnd/lntest/wait"
+	"github.com/lightningnetwork/lnd/lnwire"
 	"github.com/stretchr/testify/require"
 )
 
@@ -478,10 +479,30 @@ func testUpdateNodeAnnouncement(ht *lntemp.HarnessTest) {
 		)
 	}
 
-	// This feature bit is used to test that our endpoint sets/unsets
-	// feature bits properly. If the current FeatureBit is set by default
-	// update this one for another one unset by default at random.
-	featureBit := lnrpc.FeatureBit_WUMBO_CHANNELS_REQ
+	// Test that we can't modify a feature bit that is known to LND.
+	reservedFeatureBit := lnrpc.FeatureBit_WUMBO_CHANNELS_REQ
+	_, known := lnwire.Features[lnwire.FeatureBit(reservedFeatureBit)]
+	require.True(ht, known, "feature bit should be known to lnd")
+
+	nodeAnnReq := &peersrpc.NodeAnnouncementUpdateRequest{
+		FeatureUpdates: []*peersrpc.UpdateFeatureAction{
+			{
+				Action:     peersrpc.UpdateAction_ADD,
+				FeatureBit: reservedFeatureBit,
+			},
+		},
+	}
+
+	// Node announcement should fail because we're not allowed to alter
+	// "known" feature bits.
+	dave.RPC.UpdateNodeAnnouncementErr(nodeAnnReq)
+
+	// We also set an unknown feature bit (which we should be able to
+	// set/unset) and test that we can update it accordingly.
+	featureBit := lnrpc.FeatureBit(999)
+	_, known = lnwire.Features[lnwire.FeatureBit(featureBit)]
+	require.False(ht, known, "feature bit should be unknown to lnd")
+
 	featureIdx := uint32(featureBit)
 	_, ok := resp.Features[featureIdx]
 	require.False(ht, ok, "unexpected feature bit enabled by default")
@@ -553,7 +574,7 @@ func testUpdateNodeAnnouncement(ht *lntemp.HarnessTest) {
 		},
 	}
 
-	nodeAnnReq := &peersrpc.NodeAnnouncementUpdateRequest{
+	nodeAnnReq = &peersrpc.NodeAnnouncementUpdateRequest{
 		Alias:          newAlias,
 		Color:          newColor,
 		AddressUpdates: updateAddressActions,

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -787,7 +787,9 @@ func (r *rpcServer) addDeps(s *server, macService *macaroons.Service,
 		s.sweeper, tower, s.towerClient, s.anchorTowerClient,
 		r.cfg.net.ResolveTCPAddr, genInvoiceFeatures,
 		genAmpInvoiceFeatures, getNodeAnnouncement,
-		s.updateAndBrodcastSelfNode, parseAddr, rpcsLog,
+		s.updateAndBrodcastSelfNode,
+		s.cfg.ProtocolOptions.ExperimentalProtocol.CustomAnnFeatures(),
+		parseAddr, rpcsLog,
 		s.aliasMgr.GetPeerAlias,
 	)
 	if err != nil {

--- a/subrpcserver_config.go
+++ b/subrpcserver_config.go
@@ -120,6 +120,7 @@ func (s *subRPCServerConfigs) PopulateDependencies(cfg *Config,
 	genAmpInvoiceFeatures func() *lnwire.FeatureVector,
 	getNodeAnnouncement func() (lnwire.NodeAnnouncement, error),
 	updateNodeAnnouncement func(modifiers ...netann.NodeAnnModifier) error,
+	configFeatures []lnwire.FeatureBit,
 	parseAddr func(addr string) (net.Addr, error),
 	rpcLogger btclog.Logger,
 	getAlias func(lnwire.ChannelID) (lnwire.ShortChannelID, error)) error {
@@ -331,6 +332,10 @@ func (s *subRPCServerConfigs) PopulateDependencies(cfg *Config,
 
 			subCfgValue.FieldByName("UpdateNodeAnnouncement").Set(
 				reflect.ValueOf(updateNodeAnnouncement),
+			)
+
+			subCfgValue.FieldByName("ConfigFeatures").Set(
+				reflect.ValueOf(configFeatures),
 			)
 
 		default:


### PR DESCRIPTION
## Change Description
This PR adds the ability to set feature bits as an experimental protocol config option to allow developers to build solutions that required advertised feature bits on top of LND. Feature bits that are set in config options will be used by the node on startup, and can later be modified via rpc if required.  It does not cover persisting of RPC-set values (as requested in #7123).

This change does not allow users to set or unset any of the feature bits that are already known to LND, to protect our current set of in-use feature bits, limiting use to protocol extensions (rather than modifying current capability). 

This functionality is already accessible via RPC (behind the `peersrpc` build tag added by #5587) using the `UpdateNodeAnnouncement` API. This change also restricts the API to only modifying features bits that are unknown to LND - **this is a breaking change for this API, and can be removed from the PR.** 

The set of feature bits returned by `GetInfo` are updated to report the _actual_ set of feature bits that the node is supporting, rather than just listing all of the feature bits that are known to lnd, so that custom features will be reported there. This will have make a minor difference for end-users - eg, a node that _does not_ support keysend will no longer have that feature bit listed in its `GetInfo` output (previously it would be listed even if not enabled).

It also includes a small bugfix for the `updatenodeannouncement` cli. 

Fixes #7094

## Steps to Test
Bugfix: 
* `lncli peers updatenodeannouncement --feature_bit_add=100`: succeeds now, previously would fail with `[lncli] rpc error: code = Unknown desc = unable detect any new values to update the node announcement`

Configurable Feature Bits: 
* Build LND with `dev` tag, run with: `lnd --protocol.set-feature=1001` 
* `lncli getinfo` should display feature bit

## Pull Request Checklist
### Testing
- [ ] Your PR passes all CI checks.
- [ ] Tests covering the positive and negative (error paths) are included.
- [ ] Bug fixes contain tests triggering the bug to prevent regressions.

### Code Style and Documentation
- [ ] The change obeys the [Code Documentation and Commenting](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#CodeDocumentation) guidelines, and lines wrap at 80.
- [ ] Commits follow the [Ideal Git Commit Structure](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#IdealGitCommitStructure).
- [ ] Any new logging statements use an appropriate subsystem and logging level.
- [ ]  [There is a change description in the release notes](https://github.com/lightningnetwork/lnd/tree/master/docs/release-notes), or `[skip ci]` in the commit message for small changes.

📝 Please see our  [Contribution Guidelines](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md) for further guidance.