### PR TITLE
itest: temporary fix for taproot test failing on bitcoind

### DIFF
--- a/docs/release-notes/release-notes-0.16.0.md
+++ b/docs/release-notes/release-notes-0.16.0.md
@@ -248,7 +248,8 @@ implemented, please refer to
 [README](https://github.com/lightningnetwork/lnd/tree/master/lntemp) for more
 details. Along the way, several
 PRs([6776](https://github.com/lightningnetwork/lnd/pull/6776),
-[6822](https://github.com/lightningnetwork/lnd/pull/6822)) have been made to
+[6822](https://github.com/lightningnetwork/lnd/pull/6822),
+[7172](https://github.com/lightningnetwork/lnd/pull/7172)) have been made to
 refactor the itest for code health and maintenance.
 
 # Contributors (Alphabetical Order)

--- a/lntest/itest/lnd_remote_signer_test.go
+++ b/lntest/itest/lnd_remote_signer_test.go
@@ -129,11 +129,8 @@ func testRemoteSigner(net *lntest.NetworkHarness, t *harnessTest) {
 		sendCoins:  true,
 		randomSeed: true,
 		fn: func(tt *harnessTest, wo, carol *lntest.HarnessNode) {
-			ctxt, cancel := context.WithTimeout(
-				ctxb, 3*defaultTimeout,
-			)
-			defer cancel()
-
+			longTimeout := 3 * defaultTimeout
+			ctxt, cancel := context.WithTimeout(ctxb, longTimeout)
 			testTaprootSendCoinsKeySpendBip86(ctxt, tt, wo, net)
 			testTaprootComputeInputScriptKeySpendBip86(
 				ctxt, tt, wo, net,
@@ -143,10 +140,14 @@ func testRemoteSigner(net *lntest.NetworkHarness, t *harnessTest) {
 			testTaprootSignOutputRawKeySpendRootHash(
 				ctxt, tt, wo, net,
 			)
+			cancel()
+
+			ctxt, cancel = context.WithTimeout(ctxb, longTimeout)
 			testTaprootMuSig2KeySpendRootHash(ctxt, tt, wo, net)
 			testTaprootMuSig2ScriptSpend(ctxt, tt, wo, net)
 			testTaprootMuSig2KeySpendBip86(ctxt, tt, wo, net)
 			testTaprootMuSig2CombinedLeafKeySpend(ctxt, tt, wo, net)
+			cancel()
 		},
 	}}
 

--- a/lntest/itest/lnd_taproot_test.go
+++ b/lntest/itest/lnd_taproot_test.go
@@ -46,23 +46,29 @@ var (
 // outputs.
 func testTaproot(net *lntest.NetworkHarness, t *harnessTest) {
 	ctxb := context.Background()
-	ctxt, cancel := context.WithTimeout(ctxb, 2*defaultTimeout)
-	defer cancel()
 
+	longTimeout := 2 * defaultTimeout
+	ctxt, cancel := context.WithTimeout(ctxb, longTimeout)
 	testTaprootSendCoinsKeySpendBip86(ctxt, t, net.Alice, net)
 	testTaprootComputeInputScriptKeySpendBip86(ctxt, t, net.Alice, net)
 	testTaprootSignOutputRawScriptSpend(ctxt, t, net.Alice, net)
 	testTaprootSignOutputRawKeySpendBip86(ctxt, t, net.Alice, net)
 	testTaprootSignOutputRawKeySpendRootHash(ctxt, t, net.Alice, net)
+	cancel()
+
+	ctxt, cancel = context.WithTimeout(ctxb, longTimeout)
 	testTaprootMuSig2KeySpendBip86(ctxt, t, net.Alice, net)
 	testTaprootMuSig2KeySpendRootHash(ctxt, t, net.Alice, net)
 	testTaprootMuSig2ScriptSpend(ctxt, t, net.Alice, net)
 	testTaprootMuSig2CombinedLeafKeySpend(ctxt, t, net.Alice, net)
+	cancel()
 
+	ctxt, cancel = context.WithTimeout(ctxb, longTimeout)
 	testTaprootImportTapscriptFullTree(ctxt, t, net.Alice, net)
 	testTaprootImportTapscriptPartialReveal(ctxt, t, net.Alice, net)
 	testTaprootImportTapscriptRootHashOnly(ctxt, t, net.Alice, net)
 	testTaprootImportTapscriptFullKey(ctxt, t, net.Alice, net)
+	cancel()
 }
 
 // testTaprootSendCoinsKeySpendBip86 tests sending to and spending from


### PR DESCRIPTION
This is a temporary fix for my lazyness (re-using the same context for multiple tests) until this is properly fixed in https://github.com/lightningnetwork/lnd/pull/6824. This should turn some of the old itests green until we fully migrate to the new itests.