### PR TITLE
Fix bumpfee command doc, incorrect reference to pendingsweeps

### DIFF
--- a/cmd/lncli/walletrpc_active.go
+++ b/cmd/lncli/walletrpc_active.go
@@ -169,7 +169,7 @@ var bumpFeeCommand = cli.Command{
 	rely on bumping the fee on a specific transaction, since transactions
 	can change at any point with the addition of new inputs. The list of
 	inputs that currently exist within lnd's central batching engine can be
-	retrieved through lncli pendingsweeps.
+	retrieved through lncli wallet pendingsweeps.
 
 	When bumping the fee of an input that currently exists within lnd's
 	central batching engine, a higher fee transaction will be created that


### PR DESCRIPTION
## Change Description

Was reading the `bumpfee` docs and it said to check `lncli pendingsweeps`, which should be `lncli wallet pendingsweeps`. 

## Steps to Test

N/A just docstring changes

## Pull Request Checklist
### Testing
- [ ] Your PR passes all CI checks.
- [x] Tests covering the positive and negative (error paths) are included.
- [x] Bug fixes contain tests triggering the bug to prevent regressions.

### Code Style and Documentation
- [x] The change obeys the [Code Documentation and Commenting](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#CodeDocumentation) guidelines, and lines wrap at 80.
- [x] Commits follow the [Ideal Git Commit Structure](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#IdealGitCommitStructure).
- [x] Any new logging statements use an appropriate subsystem and logging level.
- [x]  [There is a change description in the release notes](https://github.com/lightningnetwork/lnd/tree/master/docs/release-notes), or `[skip ci]` in the commit message for small changes.

📝 Please see our  [Contribution Guidelines](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md) for further guidance.