### PR TITLE
funding: fix channel type negotiation bug

### DIFF
--- a/docs/release-notes/release-notes-0.17.0.md
+++ b/docs/release-notes/release-notes-0.17.0.md
@@ -53,6 +53,9 @@ unlock or create.
   all macaroon DB root keys on `ChangePassword`/`GenerateNewRootKey` 
   respectively.
 
+* [Fixed a validation bug](https://github.com/lightningnetwork/lnd/pull/7177) in
+  `channel_type` negotiation.
+
 ## Code Health
 
 * Updated [our fork for serializing protobuf as JSON to be based on the

--- a/funding/commitment_type_negotiation.go
+++ b/funding/commitment_type_negotiation.go
@@ -22,16 +22,16 @@ var (
 )
 
 // negotiateCommitmentType negotiates the commitment type of a newly opened
-// channel. If a channelType is provided, explicit negotiation for said type
+// channel. If a desiredChanType is provided, explicit negotiation for said type
 // will be attempted if the set of both local and remote features support it.
 // Otherwise, implicit negotiation will be attempted. Two booleans are
 // returned letting the caller know if the option-scid-alias or zero-conf
 // channel types were negotiated.
-func negotiateCommitmentType(channelType *lnwire.ChannelType, local,
+func negotiateCommitmentType(desiredChanType *lnwire.ChannelType, local,
 	remote *lnwire.FeatureVector, mustBeExplicit bool) (bool,
 	*lnwire.ChannelType, lnwallet.CommitmentType, error) {
 
-	if channelType != nil {
+	if desiredChanType != nil {
 		// If the peer does know explicit negotiation, let's attempt
 		// that now.
 		if hasFeatures(
@@ -39,9 +39,9 @@ func negotiateCommitmentType(channelType *lnwire.ChannelType, local,
 		) {
 
 			chanType, err := explicitNegotiateCommitmentType(
-				*channelType, local, remote,
+				*desiredChanType, local, remote,
 			)
-			return true, channelType, chanType, err
+			return true, desiredChanType, chanType, err
 		}
 
 		// If we're the funder, and we are attempting to use an

--- a/funding/commitment_type_negotiation.go
+++ b/funding/commitment_type_negotiation.go
@@ -38,10 +38,10 @@ func negotiateCommitmentType(desiredChanType *lnwire.ChannelType, local,
 			local, remote, lnwire.ExplicitChannelTypeOptional,
 		) {
 
-			chanType, err := explicitNegotiateCommitmentType(
+			commitType, err := explicitNegotiateCommitmentType(
 				*desiredChanType, local, remote,
 			)
-			return true, desiredChanType, chanType, err
+			return true, desiredChanType, commitType, err
 		}
 
 		// If we're the funder, and we are attempting to use an

--- a/funding/commitment_type_negotiation_test.go
+++ b/funding/commitment_type_negotiation_test.go
@@ -20,7 +20,7 @@ func TestCommitmentTypeNegotiation(t *testing.T) {
 		localFeatures     *lnwire.RawFeatureVector
 		remoteFeatures    *lnwire.RawFeatureVector
 		expectsCommitType lnwallet.CommitmentType
-		expectsChanType   lnwire.ChannelType
+		expectsChanType   *lnwire.ChannelType
 		zeroConf          bool
 		scidAlias         bool
 		expectsErr        error
@@ -41,10 +41,12 @@ func TestCommitmentTypeNegotiation(t *testing.T) {
 				lnwire.AnchorsZeroFeeHtlcTxOptional,
 			),
 			expectsCommitType: lnwallet.CommitmentTypeAnchorsZeroFeeHtlcTx,
-			expectsChanType: lnwire.ChannelType(*lnwire.NewRawFeatureVector(
-				lnwire.StaticRemoteKeyRequired,
-				lnwire.AnchorsZeroFeeHtlcTxRequired,
-			)),
+			expectsChanType: (*lnwire.ChannelType)(
+				lnwire.NewRawFeatureVector(
+					lnwire.StaticRemoteKeyRequired,
+					lnwire.AnchorsZeroFeeHtlcTxRequired,
+				),
+			),
 			expectsErr: nil,
 		},
 		{
@@ -106,8 +108,8 @@ func TestCommitmentTypeNegotiation(t *testing.T) {
 				lnwire.ExplicitChannelTypeOptional,
 			),
 			expectsCommitType: lnwallet.CommitmentTypeScriptEnforcedLease,
-			expectsChanType: lnwire.ChannelType(
-				*lnwire.NewRawFeatureVector(
+			expectsChanType: (*lnwire.ChannelType)(
+				lnwire.NewRawFeatureVector(
 					lnwire.ZeroConfRequired,
 					lnwire.StaticRemoteKeyRequired,
 					lnwire.AnchorsZeroFeeHtlcTxRequired,
@@ -137,8 +139,8 @@ func TestCommitmentTypeNegotiation(t *testing.T) {
 				lnwire.ExplicitChannelTypeOptional,
 			),
 			expectsCommitType: lnwallet.CommitmentTypeAnchorsZeroFeeHtlcTx,
-			expectsChanType: lnwire.ChannelType(
-				*lnwire.NewRawFeatureVector(
+			expectsChanType: (*lnwire.ChannelType)(
+				lnwire.NewRawFeatureVector(
 					lnwire.ZeroConfRequired,
 					lnwire.StaticRemoteKeyRequired,
 					lnwire.AnchorsZeroFeeHtlcTxRequired,
@@ -170,8 +172,8 @@ func TestCommitmentTypeNegotiation(t *testing.T) {
 				lnwire.ExplicitChannelTypeOptional,
 			),
 			expectsCommitType: lnwallet.CommitmentTypeScriptEnforcedLease,
-			expectsChanType: lnwire.ChannelType(
-				*lnwire.NewRawFeatureVector(
+			expectsChanType: (*lnwire.ChannelType)(
+				lnwire.NewRawFeatureVector(
 					lnwire.ScidAliasRequired,
 					lnwire.StaticRemoteKeyRequired,
 					lnwire.AnchorsZeroFeeHtlcTxRequired,
@@ -201,8 +203,8 @@ func TestCommitmentTypeNegotiation(t *testing.T) {
 				lnwire.ExplicitChannelTypeOptional,
 			),
 			expectsCommitType: lnwallet.CommitmentTypeAnchorsZeroFeeHtlcTx,
-			expectsChanType: lnwire.ChannelType(
-				*lnwire.NewRawFeatureVector(
+			expectsChanType: (*lnwire.ChannelType)(
+				lnwire.NewRawFeatureVector(
 					lnwire.ScidAliasRequired,
 					lnwire.StaticRemoteKeyRequired,
 					lnwire.AnchorsZeroFeeHtlcTxRequired,
@@ -228,10 +230,12 @@ func TestCommitmentTypeNegotiation(t *testing.T) {
 				lnwire.ExplicitChannelTypeOptional,
 			),
 			expectsCommitType: lnwallet.CommitmentTypeAnchorsZeroFeeHtlcTx,
-			expectsChanType: lnwire.ChannelType(*lnwire.NewRawFeatureVector(
-				lnwire.StaticRemoteKeyRequired,
-				lnwire.AnchorsZeroFeeHtlcTxRequired,
-			)),
+			expectsChanType: (*lnwire.ChannelType)(
+				lnwire.NewRawFeatureVector(
+					lnwire.StaticRemoteKeyRequired,
+					lnwire.AnchorsZeroFeeHtlcTxRequired,
+				),
+			),
 			expectsErr: nil,
 		},
 		{
@@ -250,9 +254,11 @@ func TestCommitmentTypeNegotiation(t *testing.T) {
 				lnwire.ExplicitChannelTypeOptional,
 			),
 			expectsCommitType: lnwallet.CommitmentTypeTweakless,
-			expectsChanType: lnwire.ChannelType(*lnwire.NewRawFeatureVector(
-				lnwire.StaticRemoteKeyRequired,
-			)),
+			expectsChanType: (*lnwire.ChannelType)(
+				lnwire.NewRawFeatureVector(
+					lnwire.StaticRemoteKeyRequired,
+				),
+			),
 			expectsErr: nil,
 		},
 		{
@@ -269,8 +275,10 @@ func TestCommitmentTypeNegotiation(t *testing.T) {
 				lnwire.ExplicitChannelTypeOptional,
 			),
 			expectsCommitType: lnwallet.CommitmentTypeLegacy,
-			expectsChanType:   lnwire.ChannelType(*lnwire.NewRawFeatureVector()),
-			expectsErr:        nil,
+			expectsChanType: (*lnwire.ChannelType)(
+				lnwire.NewRawFeatureVector(),
+			),
+			expectsErr: nil,
 		},
 		// Both sides signal the explicit chan type bit, so we expect
 		// that we return the corresponding chan type feature bits,
@@ -289,10 +297,12 @@ func TestCommitmentTypeNegotiation(t *testing.T) {
 				lnwire.ExplicitChannelTypeOptional,
 			),
 			expectsCommitType: lnwallet.CommitmentTypeAnchorsZeroFeeHtlcTx,
-			expectsChanType: lnwire.ChannelType(*lnwire.NewRawFeatureVector(
-				lnwire.StaticRemoteKeyRequired,
-				lnwire.AnchorsZeroFeeHtlcTxRequired,
-			)),
+			expectsChanType: (*lnwire.ChannelType)(
+				lnwire.NewRawFeatureVector(
+					lnwire.StaticRemoteKeyRequired,
+					lnwire.AnchorsZeroFeeHtlcTxRequired,
+				),
+			),
 			expectsErr: nil,
 		},
 		{
@@ -306,9 +316,11 @@ func TestCommitmentTypeNegotiation(t *testing.T) {
 				lnwire.StaticRemoteKeyOptional,
 			),
 			expectsCommitType: lnwallet.CommitmentTypeTweakless,
-			expectsChanType: lnwire.ChannelType(*lnwire.NewRawFeatureVector(
-				lnwire.StaticRemoteKeyRequired,
-			)),
+			expectsChanType: (*lnwire.ChannelType)(
+				lnwire.NewRawFeatureVector(
+					lnwire.StaticRemoteKeyRequired,
+				),
+			),
 			expectsErr: nil,
 		},
 		{
@@ -320,8 +332,10 @@ func TestCommitmentTypeNegotiation(t *testing.T) {
 				lnwire.AnchorsZeroFeeHtlcTxOptional,
 			),
 			expectsCommitType: lnwallet.CommitmentTypeLegacy,
-			expectsChanType:   lnwire.ChannelType(*lnwire.NewRawFeatureVector()),
-			expectsErr:        nil,
+			expectsChanType: (*lnwire.ChannelType)(
+				lnwire.NewRawFeatureVector(),
+			),
+			expectsErr: nil,
 		},
 	}
 
@@ -402,11 +416,11 @@ func TestCommitmentTypeNegotiation(t *testing.T) {
 			)
 
 			require.Equal(
-				t, testCase.expectsChanType, *lChan,
+				t, testCase.expectsChanType, lChan,
 				testCase.name,
 			)
 			require.Equal(
-				t, testCase.expectsChanType, *rChan,
+				t, testCase.expectsChanType, rChan,
 				testCase.name,
 			)
 		})

--- a/funding/manager.go
+++ b/funding/manager.go
@@ -1883,14 +1883,14 @@ func (f *Manager) handleFundingAccept(peer lnpeer.Peer,
 		// channel type in the accept_channel response if we didn't
 		// explicitly set it in the open_channel message. For now, let's
 		// just log the problem instead of failing the funding flow.
-		_, implicitChannelType := implicitNegotiateCommitmentType(
+		_, implicitCommitType := implicitNegotiateCommitmentType(
 			peer.LocalFeatures(), peer.RemoteFeatures(),
 		)
 
 		// We pass in false here as the funder since at this point, we
 		// didn't set a chan type ourselves, so falling back to
 		// implicit funding is acceptable.
-		_, _, negotiatedChannelType, err := negotiateCommitmentType(
+		_, _, negotiatedCommitType, err := negotiateCommitmentType(
 			msg.ChannelType, peer.LocalFeatures(),
 			peer.RemoteFeatures(), false,
 		)
@@ -1904,7 +1904,7 @@ func (f *Manager) handleFundingAccept(peer lnpeer.Peer,
 		// didn't send one in the first place, we check that it's the
 		// same type we'd have arrived through implicit negotiation. If
 		// it's another type, we fail the flow.
-		if implicitChannelType != negotiatedChannelType {
+		if implicitCommitType != negotiatedCommitType {
 			err := errors.New("negotiated unexpected channel type")
 			f.failFundingFlow(peer, msg.PendingChannelID, err)
 			return

--- a/funding/manager.go
+++ b/funding/manager.go
@@ -1881,8 +1881,9 @@ func (f *Manager) handleFundingAccept(peer lnpeer.Peer,
 	} else if msg.ChannelType != nil {
 		// The spec isn't too clear about whether it's okay to set the
 		// channel type in the accept_channel response if we didn't
-		// explicitly set it in the open_channel message. For now, let's
-		// just log the problem instead of failing the funding flow.
+		// explicitly set it in the open_channel message. For now, we
+		// check that it's the same type we'd have arrived through
+		// implicit negotiation. If it's another type, we fail the flow.
 		_, implicitCommitType := implicitNegotiateCommitmentType(
 			peer.LocalFeatures(), peer.RemoteFeatures(),
 		)
@@ -1900,10 +1901,6 @@ func (f *Manager) handleFundingAccept(peer lnpeer.Peer,
 			return
 		}
 
-		// Even though we don't expect a channel type to be set when we
-		// didn't send one in the first place, we check that it's the
-		// same type we'd have arrived through implicit negotiation. If
-		// it's another type, we fail the flow.
 		if implicitCommitType != negotiatedCommitType {
 			err := errors.New("negotiated unexpected channel type")
 			f.failFundingFlow(peer, msg.PendingChannelID, err)


### PR DESCRIPTION
The bug manifests when a nil `ChannelType` is passed to the funding manager in `InitFundingMsg`. A default value for `ChannelType` is selected and sent in the `OpenChannel` message. However, a nil `ChannelType` is stored in the reservation context. This causes our `ChannelType` checks in `handleFundingAccept` to be bypassed.

Usually this makes us end up in the "peer unexpectedly sent explicit `ChannelType`" case, where we can still recover by reselecting a default `ChannelType` and verifying it matches the one the peer sent. But if the peer sends a nil `ChannelType`, we miss it.

While fixing the bug, I also tried to simplify the negotiation logic, as the complexity is likely what hid the bug in the first place.

Now `negotiateCommitmentType` only returns the `ChannelType` to be used in `OpenChannel`/`AcceptChannel` and the `CommitmentType` to pass to the wallet. It will even return a nil `ChannelType` when we're supposed to use implicit negotiation, so we don't need to manually set it to nil for `OpenChannel` and `AcceptChannel`.