### PR TITLE
Fix potential channel announcements missing

### DIFF
--- a/discovery/gossiper.go
+++ b/discovery/gossiper.go
@@ -2372,11 +2372,12 @@ func (d *AuthenticatedGossiper) handleChanAnnouncement(nMsg *networkMsg,
 			// If while processing this rejected edge, we realized
 			// there's a set of announcements we could extract,
 			// then we'll return those directly.
-			if len(anns) != 0 {
-				nMsg.err <- nil
-				return anns, true
-			}
+			//
+			// NOTE: since this is an ErrIgnored, we can return
+			// true here to signal "allow" to its dependants.
+			nMsg.err <- nil
 
+			return anns, true
 		} else {
 			// Otherwise, this is just a regular rejected edge.
 			key := newRejectCacheKey(

--- a/discovery/gossiper.go
+++ b/discovery/gossiper.go
@@ -658,6 +658,7 @@ func (d *AuthenticatedGossiper) Stop() error {
 
 func (d *AuthenticatedGossiper) stop() {
 	log.Info("Authenticated Gossiper is stopping")
+	defer log.Info("Authenticated Gossiper stopped")
 
 	d.blockEpochs.Cancel()
 

--- a/discovery/reliable_sender.go
+++ b/discovery/reliable_sender.go
@@ -84,6 +84,9 @@ func (s *reliableSender) Start() error {
 // Stop halts the reliable sender from sending messages to peers.
 func (s *reliableSender) Stop() {
 	s.stop.Do(func() {
+		log.Debugf("reliableSender is stopping")
+		defer log.Debugf("reliableSender stopped")
+
 		close(s.quit)
 		s.wg.Wait()
 	})

--- a/discovery/sync_manager.go
+++ b/discovery/sync_manager.go
@@ -183,6 +183,9 @@ func (m *SyncManager) Start() {
 // Stop stops the SyncManager from performing its duties.
 func (m *SyncManager) Stop() {
 	m.stop.Do(func() {
+		log.Debugf("SyncManager is stopping")
+		defer log.Debugf("SyncManager stopped")
+
 		close(m.quit)
 		m.wg.Wait()
 

--- a/discovery/syncer.go
+++ b/discovery/syncer.go
@@ -450,6 +450,9 @@ func (g *GossipSyncer) Start() {
 // exited.
 func (g *GossipSyncer) Stop() {
 	g.stopped.Do(func() {
+		log.Debugf("Stopping GossipSyncer(%x)", g.cfg.peerPub[:])
+		defer log.Debugf("GossipSyncer(%x) stopped", g.cfg.peerPub[:])
+
 		close(g.quit)
 		g.wg.Wait()
 	})

--- a/docs/release-notes/release-notes-0.16.0.md
+++ b/docs/release-notes/release-notes-0.16.0.md
@@ -215,6 +215,9 @@ certain large transactions](https://github.com/lightningnetwork/lnd/pull/7100).
   `getblockhash`, and `getbestblock`. These commands provide access to chain
   block data.
 
+* [Fixed a bug](https://github.com/lightningnetwork/lnd/pull/7186) that might
+  lead to channel updates being missed, causing channel graph being incomplete.
+
 ## Code Health
 
 * [test: use `T.TempDir` to create temporary test

--- a/peer/brontide.go
+++ b/peer/brontide.go
@@ -1401,6 +1401,8 @@ func newChanMsgStream(p *Brontide, cid lnwire.ChannelID) *msgStream {
 // channel announcements.
 func newDiscMsgStream(p *Brontide) *msgStream {
 	apply := func(msg lnwire.Message) {
+		// TODO(yy): `ProcessRemoteAnnouncement` returns an error chan
+		// and we need to process it.
 		p.cfg.AuthGossiper.ProcessRemoteAnnouncement(msg, p)
 	}
 


### PR DESCRIPTION
[This failure](https://github.com/lightningnetwork/lnd/actions/runs/3509259108/jobs/5878235809) has been seen in the refactored itest quite often, leading to an investigation over the gossip/routing package. This PR refactored the related code to the point where the potential bug finally manifested itself in the logs.

The actual fix was simple, as shown in the last commit. Basically, we may get a deny signal from `handleChanAnnouncement` when processing an announcement that is ignored by routing because the channel edge info was already created. Please check the commit message for details.

Another fix is to replace the pattern,
```go
select {
case variable := <-channel:
    go func() {
        // Some actions here...
        // Now access the variable, which might be referencing to a different one.
        foo(variable)
        // More actions here...
    }()
}
```
with
```go
select {
case variable := <-channel:
    go func(v variable) {
        // Some actions here...
        // Now access the variable passed from the function.
        foo(v)
        // More actions here...
    }(v)
}
```
To make sure the variable stays the same in the goroutine.
