### PR TITLE
Don't access loop variables in goroutines directly

### DIFF
--- a/chainntnfs/bitcoindnotify/bitcoind.go
+++ b/chainntnfs/bitcoindnotify/bitcoind.go
@@ -235,7 +235,9 @@ out:
 				//
 				// TODO(wilmer): add retry logic if rescan fails?
 				b.wg.Add(1)
-				go func() {
+
+				//nolint:lll
+				go func(msg *chainntnfs.HistoricalConfDispatch) {
 					defer b.wg.Done()
 
 					confDetails, _, err := b.historicalConfDetails(
@@ -269,7 +271,7 @@ out:
 							"details of %v: %v",
 							msg.ConfRequest, err)
 					}
-				}()
+				}(msg)
 
 			case *chainntnfs.HistoricalSpendDispatch:
 				// In order to ensure we don't block the caller
@@ -278,7 +280,9 @@ out:
 				//
 				// TODO(wilmer): add retry logic if rescan fails?
 				b.wg.Add(1)
-				go func() {
+
+				//nolint:lll
+				go func(msg *chainntnfs.HistoricalSpendDispatch) {
 					defer b.wg.Done()
 
 					spendDetails, err := b.historicalSpendDetails(
@@ -320,7 +324,7 @@ out:
 							"details of %v: %v",
 							msg.SpendRequest, err)
 					}
-				}()
+				}(msg)
 
 			case *blockEpochRegistration:
 				chainntnfs.Log.Infof("New block epoch subscription")

--- a/chainntnfs/btcdnotify/btcd.go
+++ b/chainntnfs/btcdnotify/btcd.go
@@ -347,7 +347,9 @@ out:
 				//
 				// TODO(wilmer): add retry logic if rescan fails?
 				b.wg.Add(1)
-				go func() {
+
+				//nolint:lll
+				go func(msg *chainntnfs.HistoricalConfDispatch) {
 					defer b.wg.Done()
 
 					confDetails, _, err := b.historicalConfDetails(
@@ -372,7 +374,7 @@ out:
 					if err != nil {
 						chainntnfs.Log.Error(err)
 					}
-				}()
+				}(msg)
 
 			case *blockEpochRegistration:
 				chainntnfs.Log.Infof("New block epoch subscription")

--- a/chainntnfs/neutrinonotify/neutrino.go
+++ b/chainntnfs/neutrinonotify/neutrino.go
@@ -432,7 +432,9 @@ func (n *NeutrinoNotifier) notificationDispatcher() {
 				// chain asynchronously to prevent blocking
 				// potentially long rescans.
 				n.wg.Add(1)
-				go func() {
+
+				//nolint:lll
+				go func(msg *chainntnfs.HistoricalConfDispatch) {
 					defer n.wg.Done()
 
 					confDetails, err := n.historicalConfDetails(
@@ -457,7 +459,7 @@ func (n *NeutrinoNotifier) notificationDispatcher() {
 					if err != nil {
 						chainntnfs.Log.Error(err)
 					}
-				}()
+				}(msg)
 
 			case *blockEpochRegistration:
 				chainntnfs.Log.Infof("New block epoch subscription")

--- a/discovery/gossiper.go
+++ b/discovery/gossiper.go
@@ -1325,6 +1325,7 @@ func (d *AuthenticatedGossiper) networkHandler() {
 			d.wg.Add(1)
 			go func() {
 				defer d.wg.Done()
+
 				log.Infof("Broadcasting %v new announcements in %d sub batches",
 					len(announcementBatch), len(splitAnnouncementBatch))
 
@@ -2947,6 +2948,7 @@ func (d *AuthenticatedGossiper) handleAnnSig(nMsg *networkMsg,
 			d.wg.Add(1)
 			go func() {
 				defer d.wg.Done()
+
 				log.Debugf("Received half proof for channel "+
 					"%v with existing full proof. Sending"+
 					" full proof to peer=%x",

--- a/docs/release-notes/release-notes-0.16.0.md
+++ b/docs/release-notes/release-notes-0.16.0.md
@@ -198,6 +198,9 @@ certain large transactions](https://github.com/lightningnetwork/lnd/pull/7100).
 
 * [test: fix loop variables being accessed in
   closures](https://github.com/lightningnetwork/lnd/pull/7032).
+
+* [Fix loop and other temporary variables being accessed in
+  goroutines](https://github.com/lightningnetwork/lnd/pull/7188).
  
 ## Watchtowers
 

--- a/funding/manager.go
+++ b/funding/manager.go
@@ -1969,6 +1969,7 @@ func (f *Manager) handleFundingAccept(peer lnpeer.Peer,
 		f.wg.Add(1)
 		go func() {
 			defer f.wg.Done()
+
 			f.waitForPsbt(psbtIntent, resCtx, pendingChanID)
 		}()
 

--- a/healthcheck/healthcheck.go
+++ b/healthcheck/healthcheck.go
@@ -71,10 +71,11 @@ func (m *Monitor) Start() error {
 		}
 
 		m.wg.Add(1)
-		go func() {
+		go func(check *Observation) {
 			defer m.wg.Done()
+
 			check.monitor(m.cfg.Shutdown, m.quit)
-		}()
+		}(check)
 	}
 
 	return nil

--- a/htlcswitch/switch.go
+++ b/htlcswitch/switch.go
@@ -1742,6 +1742,7 @@ func (s *Switch) htlcForwarder() {
 			wg.Add(1)
 			go func(l ChannelLink) {
 				defer wg.Done()
+
 				l.Stop()
 			}(link)
 		}

--- a/lntest/itest/utils.go
+++ b/lntest/itest/utils.go
@@ -78,13 +78,12 @@ func completePaymentRequests(client lnrpc.LightningClient,
 	// Launch all payments simultaneously.
 	results := make(chan error)
 	for _, payReq := range paymentRequests {
-		payReqCopy := payReq
-		go func() {
-			err := send(payReqCopy)
+		go func(payReq string) {
+			err := send(payReq)
 			if awaitResponse {
 				results <- err
 			}
-		}()
+		}(payReq)
 	}
 
 	// If awaiting a response, verify that all payments succeeded.

--- a/lntest/itest/utils.go
+++ b/lntest/itest/utils.go
@@ -405,6 +405,7 @@ func subscribeChannelNotifications(ctxb context.Context, t *harnessTest,
 	chanUpdates := make(chan *lnrpc.ChannelEventUpdate, 20)
 	go func() {
 		defer cancelFunc()
+
 		for {
 			select {
 			case <-quit:

--- a/lnwallet/btcwallet/btcwallet.go
+++ b/lnwallet/btcwallet/btcwallet.go
@@ -1483,9 +1483,13 @@ out:
 
 			// Launch a goroutine to re-package and send
 			// notifications for any newly confirmed transactions.
-			go func() {
+			//nolint:lll
+			go func(txNtfn *wallet.TransactionNotifications) {
 				for _, block := range txNtfn.AttachedBlocks {
-					details, err := minedTransactionsToDetails(currentHeight, block, t.w.ChainParams())
+					details, err := minedTransactionsToDetails(
+						currentHeight, block,
+						t.w.ChainParams(),
+					)
 					if err != nil {
 						continue
 					}
@@ -1499,11 +1503,11 @@ out:
 					}
 				}
 
-			}()
+			}(txNtfn)
 
 			// Launch a goroutine to re-package and send
 			// notifications for any newly unconfirmed transactions.
-			go func() {
+			go func(txNtfn *wallet.TransactionNotifications) {
 				for _, tx := range txNtfn.UnminedTransactions {
 					detail, err := unminedTransactionsToDetail(
 						tx, t.w.ChainParams(),
@@ -1518,7 +1522,7 @@ out:
 						return
 					}
 				}
-			}()
+			}(txNtfn)
 		case <-t.quit:
 			break out
 		}

--- a/rpcperms/middleware_handler.go
+++ b/rpcperms/middleware_handler.go
@@ -180,8 +180,9 @@ func (h *MiddlewareHandler) Run() error {
 	// request to the client).
 	h.wg.Add(1)
 	go func() {
+		defer h.wg.Done()
+
 		h.receiveResponses(errChan, responses)
-		h.wg.Done()
 	}()
 
 	return h.sendInterceptRequests(errChan, responses)

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -5214,7 +5214,7 @@ sendLoop:
 			// payment so we can continue to serve requests while
 			// this payment is being dispatched.
 			wg.Add(1)
-			go func() {
+			go func(payIntent *rpcPaymentIntent) {
 				defer wg.Done()
 
 				// Attempt to grab a free semaphore slot, using
@@ -5292,7 +5292,7 @@ sendLoop:
 					}
 					return
 				}
-			}()
+			}(payIntent)
 		}
 	}
 

--- a/sweep/sweeper.go
+++ b/sweep/sweeper.go
@@ -1415,6 +1415,7 @@ func (s *UtxoSweeper) waitForSpend(outpoint wire.OutPoint,
 	s.wg.Add(1)
 	go func() {
 		defer s.wg.Done()
+
 		select {
 		case spend, ok := <-spendEvent.Spend:
 			if !ok {

--- a/ticker/force.go
+++ b/ticker/force.go
@@ -39,6 +39,7 @@ func NewForce(interval time.Duration) *Force {
 	m.wg.Add(1)
 	go func() {
 		defer m.wg.Done()
+
 		for {
 			select {
 			case t := <-m.ticker:

--- a/watchtower/wtclient/session_queue.go
+++ b/watchtower/wtclient/session_queue.go
@@ -689,6 +689,7 @@ func (s *sessionQueueSet) ApplyAndWait(getApply func(*sessionQueue) func()) {
 		wg.Add(1)
 		go func(sq *sessionQueue) {
 			defer wg.Done()
+
 			getApply(sq)()
 		}(sessionq)
 	}


### PR DESCRIPTION
Inspired by https://github.com/lightningnetwork/lnd/pull/7186.
I checked all anonymous goroutines to make sure they don't access any loop or other temporary variables.
This PR fixes the found instances and also contains some readability improvements to visually highlight `defer` statements better.