### PR TITLE
lnwallet/btcwallet: use taproot addrs for change outputs from SendCoins

### DIFF
--- a/docs/release-notes/release-notes-0.15.5.md
+++ b/docs/release-notes/release-notes-0.15.5.md
@@ -5,6 +5,15 @@
 * [A Taproot related key tweak issue was fixed in `btcd` that affected remote
   signing setups](https://github.com/lightningnetwork/lnd/pull/7130).
 
+* [Taproot changes addresses are now used by default for the `SendCoins`
+  RPC](https://github.com/lightningnetwork/lnd/pull/7193).
+
+* [A 1 second interval has been added between `FundingLocked` receipt
+  checks](https://github.com/lightningnetwork/lnd/pull/7095). This reduces idle
+  CPU usage for pending/dangling funding attempts.
+
 # Contributors (Alphabetical Order)
 
+* Olaoluwa Osuntokun
 * Oliver Gugger
+* Yong Yu

--- a/go.mod
+++ b/go.mod
@@ -5,11 +5,11 @@ require (
 	github.com/Yawning/aez v0.0.0-20211027044916-e49e68abd344
 	github.com/btcsuite/btcd v0.23.4
 	github.com/btcsuite/btcd/btcec/v2 v2.2.2
-	github.com/btcsuite/btcd/btcutil v1.1.2
+	github.com/btcsuite/btcd/btcutil v1.1.3
 	github.com/btcsuite/btcd/btcutil/psbt v1.1.5
 	github.com/btcsuite/btcd/chaincfg/chainhash v1.0.1
 	github.com/btcsuite/btclog v0.0.0-20170628155309-84c8d2346e9f
-	github.com/btcsuite/btcwallet v0.16.2-0.20221109224534-84bf4e34c816
+	github.com/btcsuite/btcwallet v0.16.5
 	github.com/btcsuite/btcwallet/wallet/txauthor v1.3.2
 	github.com/btcsuite/btcwallet/wallet/txrules v1.2.0
 	github.com/btcsuite/btcwallet/walletdb v1.4.0

--- a/go.sum
+++ b/go.sum
@@ -87,8 +87,8 @@ github.com/btcsuite/btcd/btcec/v2 v2.2.2/go.mod h1:9/CSmJxmuvqzX9Wh2fXMWToLOHhPd
 github.com/btcsuite/btcd/btcutil v1.0.0/go.mod h1:Uoxwv0pqYWhD//tfTiipkxNfdhG9UrLwaeswfjfdF0A=
 github.com/btcsuite/btcd/btcutil v1.1.0/go.mod h1:5OapHB7A2hBBWLm48mmw4MOHNJCcUBTwmWH/0Jn8VHE=
 github.com/btcsuite/btcd/btcutil v1.1.1/go.mod h1:nbKlBMNm9FGsdvKvu0essceubPiAcI57pYBNnsLAa34=
-github.com/btcsuite/btcd/btcutil v1.1.2 h1:XLMbX8JQEiwMcYft2EGi8zPUkoa0abKIU6/BJSRsjzQ=
-github.com/btcsuite/btcd/btcutil v1.1.2/go.mod h1:UR7dsSJzJUfMmFiiLlIrMq1lS9jh9EdCV7FStZSnpi0=
+github.com/btcsuite/btcd/btcutil v1.1.3 h1:xfbtw8lwpp0G6NwSHb+UE67ryTFHJAiNuipusjXSohQ=
+github.com/btcsuite/btcd/btcutil v1.1.3/go.mod h1:UR7dsSJzJUfMmFiiLlIrMq1lS9jh9EdCV7FStZSnpi0=
 github.com/btcsuite/btcd/btcutil/psbt v1.1.4/go.mod h1:9AyU6EQVJ9Iw9zPyNT1lcdHd6cnEZdno5wLu5FY74os=
 github.com/btcsuite/btcd/btcutil/psbt v1.1.5 h1:x0ZRrYY8j75ThV6xBz86CkYAG82F5bzay4H5D1c8b/U=
 github.com/btcsuite/btcd/btcutil/psbt v1.1.5/go.mod h1:kA6FLH/JfUx++j9pYU0pyu+Z8XGBQuuTmuKYUf6q7/U=
@@ -98,8 +98,8 @@ github.com/btcsuite/btcd/chaincfg/chainhash v1.0.1/go.mod h1:7SFka0XMvUgj3hfZtyd
 github.com/btcsuite/btclog v0.0.0-20170628155309-84c8d2346e9f h1:bAs4lUbRJpnnkd9VhRV3jjAVU7DJVjMaK+IsvSeZvFo=
 github.com/btcsuite/btclog v0.0.0-20170628155309-84c8d2346e9f/go.mod h1:TdznJufoqS23FtqVCzL0ZqgP5MqXbb4fg/WgDys70nA=
 github.com/btcsuite/btcutil v0.0.0-20190425235716-9e5f4b9a998d/go.mod h1:+5NJ2+qvTyV9exUAL/rxXi3DcLg2Ts+ymUAY5y4NvMg=
-github.com/btcsuite/btcwallet v0.16.2-0.20221109224534-84bf4e34c816 h1:t4wbkXekvTc1eOGDv2h8l6mkLPnqP93hnRHvNtgpiHQ=
-github.com/btcsuite/btcwallet v0.16.2-0.20221109224534-84bf4e34c816/go.mod h1:d8AETQyIIWTtC9CnoCMBmDARp9P65oX4IoBdEP3fDK4=
+github.com/btcsuite/btcwallet v0.16.5 h1:4DTJ5aYAJomcR0jAb6JP8D0wNSxfz4H7WN/RBtNZY4o=
+github.com/btcsuite/btcwallet v0.16.5/go.mod h1:mM19pFB3lGVxOL+kvHhHZAhdSWXKsZGiHvpJVvxL0D8=
 github.com/btcsuite/btcwallet/wallet/txauthor v1.2.3/go.mod h1:T2xSiKGpUkSLCh68aF+FMXmKK9mFqNdHl9VaqOr+JjU=
 github.com/btcsuite/btcwallet/wallet/txauthor v1.3.2 h1:etuLgGEojecsDOYTII8rYiGHjGyV5xTqsXi+ZQ715UU=
 github.com/btcsuite/btcwallet/wallet/txauthor v1.3.2/go.mod h1:Zpk/LOb2sKqwP2lmHjaZT9AdaKsHPSbNLm2Uql5IQ/0=

--- a/lntest/itest/lnd_recovery_test.go
+++ b/lntest/itest/lnd_recovery_test.go
@@ -261,10 +261,10 @@ func testOnchainFundRecovery(ht *lntemp.HarnessTest) {
 	restoreCheckBalance(finalBalance, 9, 20, promptChangeAddr)
 
 	// We should expect a static fee of 36400 satoshis for spending 9
-	// inputs (3 P2WPKH, 3 NP2WPKH, 3 P2TR) to two P2WPKH outputs. Carol
+	// inputs (3 P2WPKH, 3 NP2WPKH, 3 P2TR) to two P2TR outputs. Carol
 	// should therefore only have one UTXO present (the change output) of
 	// 9 - 8 - fee BTC.
-	const fee = 36400
+	const fee = 37000
 	restoreCheckBalance(finalBalance-minerAmt-fee, 1, 21, nil)
 
 	// Last of all, make sure we can also restore a node from the extended

--- a/lntest/itest/lnd_wallet_import_test.go
+++ b/lntest/itest/lnd_wallet_import_test.go
@@ -276,8 +276,14 @@ func psbtSendFromImportedAccount(t *harnessTest, srcNode, destNode,
 	)
 	switch accountAddrType {
 	case walletrpc.AddressType_WITNESS_PUBKEY_HASH:
-		expTxFee = 141
-		expChangeScriptType = txscript.WitnessV0PubKeyHashTy
+		if account != defaultImportedAccount {
+			expTxFee = 141
+			expChangeScriptType = txscript.WitnessV0PubKeyHashTy
+			break
+		}
+
+		expTxFee = 153
+		expChangeScriptType = txscript.WitnessV1TaprootTy
 
 	case walletrpc.AddressType_NESTED_WITNESS_PUBKEY_HASH:
 		if account != defaultImportedAccount {
@@ -286,26 +292,16 @@ func psbtSendFromImportedAccount(t *harnessTest, srcNode, destNode,
 			break
 		}
 
-		// Spends from the default NP2WKH imported account have the same
-		// fee rate as the hybrid address type since a NP2WKH input is
-		// spent and a P2WKH change output is created.
-		fallthrough
+		expTxFee = 176
+		expChangeScriptType = txscript.WitnessV1TaprootTy
 
 	case walletrpc.AddressType_HYBRID_NESTED_WITNESS_PUBKEY_HASH:
 		expTxFee = 164
 		expChangeScriptType = txscript.WitnessV0PubKeyHashTy
 
 	case walletrpc.AddressType_TAPROOT_PUBKEY:
-		if account != defaultImportedAccount {
-			expTxFee = 143
-			expChangeScriptType = txscript.WitnessV1TaprootTy
-			break
-		}
-
-		// Spends from the default imported account fall back to a P2WKH
-		// change. We'll want to change that, but in a separate PR.
-		expTxFee = 131
-		expChangeScriptType = txscript.WitnessV0PubKeyHashTy
+		expTxFee = 143
+		expChangeScriptType = txscript.WitnessV1TaprootTy
 
 	default:
 		t.Fatalf("unsupported addr type %v", accountAddrType)
@@ -443,8 +439,14 @@ func fundChanAndCloseFromImportedAccount(t *harnessTest, srcNode, destNode,
 	)
 	switch accountAddrType {
 	case walletrpc.AddressType_WITNESS_PUBKEY_HASH:
-		expChanTxFee = 153
-		expChangeScriptType = txscript.WitnessV0PubKeyHashTy
+		if account != defaultImportedAccount {
+			expChanTxFee = 153
+			expChangeScriptType = txscript.WitnessV0PubKeyHashTy
+			break
+		}
+
+		expChanTxFee = 165
+		expChangeScriptType = txscript.WitnessV1TaprootTy
 
 	case walletrpc.AddressType_NESTED_WITNESS_PUBKEY_HASH:
 		if account != defaultImportedAccount {
@@ -453,26 +455,16 @@ func fundChanAndCloseFromImportedAccount(t *harnessTest, srcNode, destNode,
 			break
 		}
 
-		// Spends from the default NP2WKH imported account have the same
-		// fee rate as the hybrid address type since a NP2WKH input is
-		// spent and a P2WKH change output is created.
-		fallthrough
+		expChanTxFee = 188
+		expChangeScriptType = txscript.WitnessV1TaprootTy
 
 	case walletrpc.AddressType_HYBRID_NESTED_WITNESS_PUBKEY_HASH:
 		expChanTxFee = 176
 		expChangeScriptType = txscript.WitnessV0PubKeyHashTy
 
 	case walletrpc.AddressType_TAPROOT_PUBKEY:
-		if account != defaultImportedAccount {
-			expChanTxFee = 155
-			expChangeScriptType = txscript.WitnessV1TaprootTy
-			break
-		}
-
-		// Spends from the default imported account fall back to a P2WKH
-		// change. We'll want to change that, but in a separate PR.
-		expChanTxFee = 143
-		expChangeScriptType = txscript.WitnessV0PubKeyHashTy
+		expChanTxFee = 155
+		expChangeScriptType = txscript.WitnessV1TaprootTy
 
 	default:
 		t.Fatalf("unsupported addr type %v", accountAddrType)

--- a/lnwallet/test/test_interface.go
+++ b/lnwallet/test/test_interface.go
@@ -430,6 +430,8 @@ func testGetRecoveryInfo(miner *rpctest.Harness,
 func testDualFundingReservationWorkflow(miner *rpctest.Harness,
 	alice, bob *lnwallet.LightningWallet, t *testing.T) {
 
+	t.Skipf("dual funding isn't exposed on the p2p layer")
+
 	fundingAmount, err := btcutil.NewAmount(5)
 	require.NoError(t, err, "unable to create amt")
 

--- a/lnwallet/test/test_interface.go
+++ b/lnwallet/test/test_interface.go
@@ -2194,9 +2194,9 @@ func testChangeOutputSpendConfirmation(r *rpctest.Harness,
 	// TODO(wilmer): replace this once SendOutputs easily supports sending
 	// all funds in one transaction.
 	txFeeRate := chainfee.SatPerKWeight(2500)
-	txFee := btcutil.Amount(14380)
+	const txFee = int64(14500)
 	output := &wire.TxOut{
-		Value:    int64(aliceBalance - txFee),
+		Value:    int64(aliceBalance) - txFee,
 		PkScript: bobPkScript,
 	}
 	tx := sendCoins(t, r, alice, bob, output, txFeeRate, true, 1)


### PR DESCRIPTION
Replaces https://github.com/lightningnetwork/lnd/pull/7147.

In this PR, we specify the default key scope as BIP 86, which means taproot addresses will be used for default by all on chain sends.

Fixes https://github.com/lightningnetwork/lnd/issues/7144.