### PR TITLE
WIP: Route Blinding [1/n]: TLV Record Definition and Blind Hop Processing

### DIFF
--- a/feature/manager.go
+++ b/feature/manager.go
@@ -41,6 +41,9 @@ type Config struct {
 	// keep option-scid-alias support.
 	NoZeroConf bool
 
+	// RouteBlinding sets bit to signal support for route blinding.
+	RouteBlinding bool
+
 	// NoAnySegwit unsets any bits that signal support for using other
 	// segwit witness versions for co-op closes.
 	NoAnySegwit bool
@@ -89,7 +92,7 @@ func newManager(cfg Config, desc setDesc) (*Manager, error) {
 		}
 	}
 
-	// Now, remove any features as directed by the config.
+	// Now, add or remove any features as directed by the config.
 	for set, raw := range fsets {
 		if cfg.NoTLVOnion {
 			raw.Unset(lnwire.TLVOnionPayloadOptional)
@@ -145,6 +148,9 @@ func newManager(cfg Config, desc setDesc) (*Manager, error) {
 		if cfg.NoZeroConf {
 			raw.Unset(lnwire.ZeroConfOptional)
 			raw.Unset(lnwire.ZeroConfRequired)
+		}
+		if cfg.RouteBlinding {
+			raw.Set(lnwire.RouteBlindingOptional)
 		}
 		if cfg.NoAnySegwit {
 			raw.Unset(lnwire.ShutdownAnySegwitOptional)

--- a/go.mod
+++ b/go.mod
@@ -166,6 +166,10 @@ replace github.com/ulikunitz/xz => github.com/ulikunitz/xz v0.5.8
 // https://deps.dev/advisory/OSV/GO-2021-0053?from=%2Fgo%2Fgithub.com%252Fgogo%252Fprotobuf%2Fv1.3.1
 replace github.com/gogo/protobuf => github.com/gogo/protobuf v1.3.2
 
+// Swap to lightning-onion dependency which supports route blinding
+// replace github.com/lightningnetwork/lightning-onion => /Users/calvinzachman/Documents/Workspace/src/github.com/lightning-onion //../lightning-onion
+replace github.com/lightningnetwork/lightning-onion => github.com/calvinrzachman/lightning-onion v1.2.1-0.20220705121410-91a33c83e24d
+
 // If you change this please also update .github/pull_request_template.md and
 // docs/INSTALL.md.
 go 1.18

--- a/go.sum
+++ b/go.sum
@@ -126,6 +126,8 @@ github.com/btcsuite/websocket v0.0.0-20150119174127-31079b680792 h1:R8vQdOQdZ9Y3
 github.com/btcsuite/websocket v0.0.0-20150119174127-31079b680792/go.mod h1:ghJtEyQwv5/p4Mg4C0fgbePVuGr935/5ddU9Z3TmDRY=
 github.com/btcsuite/winsvc v1.0.0 h1:J9B4L7e3oqhXOcm+2IuNApwzQec85lE+QaikUcCs+dk=
 github.com/btcsuite/winsvc v1.0.0/go.mod h1:jsenWakMcC0zFBFurPLEAyrnc/teJEM1O46fmI40EZs=
+github.com/calvinrzachman/lightning-onion v1.2.1-0.20220705121410-91a33c83e24d h1:N2DvOgIQLyB/rFkpQUPlA+RhTc0JZJhBFM7XaqyInG0=
+github.com/calvinrzachman/lightning-onion v1.2.1-0.20220705121410-91a33c83e24d/go.mod h1:IpXmxKG482HAQC/aCn0Sd+DYmKlkfaNF/iUz298HhC0=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/certifi/gocertifi v0.0.0-20191021191039-0944d244cd40/go.mod h1:sGbDF6GwGcLpkNXPUTkMRoywsNa/ol15pxFe6ERfguA=
 github.com/certifi/gocertifi v0.0.0-20200922220541-2c3bb06c6054 h1:uH66TXeswKn5PW5zdZ39xEwfS9an067BirqA+P4QaLI=
@@ -440,8 +442,6 @@ github.com/lightninglabs/neutrino v0.14.2 h1:yrnZUCYMZ5ECtXhgDrzqPq2oX8awoAN2D/c
 github.com/lightninglabs/neutrino v0.14.2/go.mod h1:OICUeTCn+4Tu27YRJIpWvvqySxx4oH4vgdP33Sw9RDc=
 github.com/lightninglabs/protobuf-hex-display v1.4.3-hex-display h1:RZJ8H4ueU/aQ9pFtx5wqsuD3B/DezrewJeVwDKKYY8E=
 github.com/lightninglabs/protobuf-hex-display v1.4.3-hex-display/go.mod h1:2oKOBU042GKFHrdbgGiKax4xVrFiZu51lhacUZQ9MnE=
-github.com/lightningnetwork/lightning-onion v1.0.2-0.20220211021909-bb84a1ccb0c5 h1:TkKwqFcQTGYoI+VEqyxA8rxpCin8qDaYX0AfVRinT3k=
-github.com/lightningnetwork/lightning-onion v1.0.2-0.20220211021909-bb84a1ccb0c5/go.mod h1:7dDx73ApjEZA0kcknI799m2O5kkpfg4/gr7N092ojNo=
 github.com/lightningnetwork/lnd/cert v1.1.1 h1:Nsav0RlIDRbOnzz2Yu69SQlK939IKya3Q2S0mDviIN8=
 github.com/lightningnetwork/lnd/cert v1.1.1/go.mod h1:1P46svkkd73oSoeI4zjkVKgZNwGq8bkGuPR8z+5vQUs=
 github.com/lightningnetwork/lnd/clock v1.0.1/go.mod h1:KnQudQ6w0IAMZi1SgvecLZQZ43ra2vpDNj7H/aasemg=
@@ -620,6 +620,7 @@ github.com/tv42/zbase32 v0.0.0-20160707012821-501572607d02 h1:tcJ6OjwOMvExLlzrAV
 github.com/tv42/zbase32 v0.0.0-20160707012821-501572607d02/go.mod h1:tHlrkM198S068ZqfrO6S8HsoJq2bF3ETfTL+kt4tInY=
 github.com/ulikunitz/xz v0.5.8 h1:ERv8V6GKqVi23rgu5cj9pVfVzJbOqAY2Ntl88O6c2nQ=
 github.com/ulikunitz/xz v0.5.8/go.mod h1:nbz6k7qbPmH4IRqmfOplQw/tblSgqTqBwxkY0oWt/14=
+github.com/urfave/cli v1.22.5/go.mod h1:Gos4lmkARVdJ6EkW0WaNv/tZAAMe9V7XWyB60NtXRu0=
 github.com/urfave/cli v1.22.9 h1:cv3/KhXGBGjEXLC4bH0sLuJ9BewaAbpk5oyMOveu4pw=
 github.com/urfave/cli v1.22.9/go.mod h1:Gos4lmkARVdJ6EkW0WaNv/tZAAMe9V7XWyB60NtXRu0=
 github.com/xi2/xz v0.0.0-20171230120015-48954b6210f8 h1:nIPpBwaJSVYIxUFsDv3M8ofmx9yWTog9BfvIu0q41lo=

--- a/htlcswitch/hop/blind_hop.go
+++ b/htlcswitch/hop/blind_hop.go
@@ -1,0 +1,30 @@
+package hop
+
+import (
+	"github.com/btcsuite/btcd/btcec/v2"
+	sphinx "github.com/lightningnetwork/lightning-onion"
+	"github.com/lightningnetwork/lnd/keychain"
+)
+
+type BlindHopProcessor struct{}
+
+func NewBlindHopProcessor() *BlindHopProcessor {
+	return &BlindHopProcessor{}
+}
+
+func (b *BlindHopProcessor) DecryptBlindedPayload(nodeID keychain.SingleKeyECDH,
+	blindingPoint *btcec.PublicKey, payload []byte) ([]byte, error) {
+
+	return sphinx.DecryptBlindedData(
+		nodeID, blindingPoint, payload,
+	)
+}
+
+func (b *BlindHopProcessor) NextBlindingPoint(nodeID keychain.SingleKeyECDH,
+	blindingPoint *btcec.PublicKey) (*btcec.PublicKey, error) {
+
+	// NOTE(8/8/22): We have pulled the sphinx dependency
+	// out of 'htlcswitch' only to depend on it here?
+	// To what end?
+	return sphinx.NextEphemeral(nodeID, blindingPoint)
+}

--- a/htlcswitch/hop/iterator.go
+++ b/htlcswitch/hop/iterator.go
@@ -243,6 +243,10 @@ type DecodeHopIteratorRequest struct {
 	OnionReader  io.Reader
 	RHash        []byte
 	IncomingCltv uint32
+
+	// An ephemeral public key which is used to decrypt the onion
+	// when forwarding in the blinded portion of a route.
+	BlindingPoint *btcec.PublicKey
 }
 
 // DecodeHopIteratorResponse encapsulates the outcome of a batched sphinx onion
@@ -299,7 +303,7 @@ func (p *OnionProcessor) DecodeHopIterators(id []byte,
 		}
 
 		err = tx.ProcessOnionPacket(
-			seqNum, onionPkt, req.RHash, req.IncomingCltv, nil,
+			seqNum, onionPkt, req.RHash, req.IncomingCltv, req.BlindingPoint,
 		)
 		switch err {
 		case nil:

--- a/htlcswitch/hop/iterator.go
+++ b/htlcswitch/hop/iterator.go
@@ -170,7 +170,7 @@ func (p *OnionProcessor) DecodeHopIterator(r io.Reader, rHash []byte,
 	// case of a replay, an attacker is *forced* to use the same payment
 	// hash twice, thereby losing their money entirely.
 	sphinxPacket, err := p.router.ProcessOnionPacket(
-		onionPkt, rHash, incomingCltv,
+		onionPkt, rHash, incomingCltv, nil,
 	)
 	if err != nil {
 		switch err {
@@ -205,7 +205,7 @@ func (p *OnionProcessor) ReconstructHopIterator(r io.Reader, rHash []byte) (
 	// associated data in order to thwart attempts a replay attacks. In the
 	// case of a replay, an attacker is *forced* to use the same payment
 	// hash twice, thereby losing their money entirely.
-	sphinxPacket, err := p.router.ReconstructOnionPacket(onionPkt, rHash)
+	sphinxPacket, err := p.router.ReconstructOnionPacket(onionPkt, rHash, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -276,7 +276,7 @@ func (p *OnionProcessor) DecodeHopIterators(id []byte,
 		}
 
 		err = tx.ProcessOnionPacket(
-			seqNum, onionPkt, req.RHash, req.IncomingCltv,
+			seqNum, onionPkt, req.RHash, req.IncomingCltv, nil,
 		)
 		switch err {
 		case nil:
@@ -383,6 +383,8 @@ func (p *OnionProcessor) DecodeHopIterators(id []byte,
 func (p *OnionProcessor) ExtractErrorEncrypter(ephemeralKey *btcec.PublicKey) (
 	ErrorEncrypter, lnwire.FailCode) {
 
+	// TODO(9/21/22): Figure how this changes when handling
+	// errors for a blinded hop.
 	onionObfuscator, err := sphinx.NewOnionErrorEncrypter(
 		p.router, ephemeralKey,
 	)

--- a/htlcswitch/hop/iterator_test.go
+++ b/htlcswitch/hop/iterator_test.go
@@ -62,20 +62,26 @@ func TestSphinxHopIteratorForwardingInstructions(t *testing.T) {
 				},
 				Action:                 sphinx.MoreHops,
 				ForwardingInstructions: &hopData,
+				// NOTE(9/15/22): This field will only be populated iff the above Action is MoreHops.
 			},
 			expectedFwdInfo: expectedFwdInfo,
 		},
 		// A TLV payload, we can leave off the action as we'll always
 		// read the cid encoded.
+		// NOTE(9/15/22): The disconnect between sphinx and htlcswitch
+		// packages w.r.t determining the final/exit hop happened with
+		// the move to TLV payload?
 		{
 			sphinxPacket: &sphinx.ProcessedPacket{
 				Payload: sphinx.HopPayload{
 					Type:    sphinx.PayloadTLV,
 					Payload: b.Bytes(),
 				},
+				Action: sphinx.MoreHops,
 			},
 			expectedFwdInfo: expectedFwdInfo,
 		},
+		// TODO(11/16/22): Add test with TLV payload and Action: sphinx.ExitNode?
 	}
 
 	// Finally, we'll test that we get the same set of
@@ -95,6 +101,61 @@ func TestSphinxHopIteratorForwardingInstructions(t *testing.T) {
 			t.Fatalf("#%v: wrong fwding info: expected %v, got %v",
 				i, spew.Sdump(testCase.expectedFwdInfo),
 				spew.Sdump(fwdInfo))
+		}
+	}
+}
+
+// TestSphinxHopIteratorFinalHop confirms that the iterator
+// correctly passed through the signal from the underlying
+// sphinx implementation as to whether a hop is the last hop
+// in the route.
+func TestSphinxHopIteratorFinalHop(t *testing.T) {
+	t.Parallel()
+
+	var testCases = []struct {
+		sphinxPacket     *sphinx.ProcessedPacket
+		expectedFinalHop bool
+	}{
+		// A regular legacy payload that signals more hops.
+		{
+			sphinxPacket: &sphinx.ProcessedPacket{
+				Payload: sphinx.HopPayload{
+					Type: sphinx.PayloadLegacy,
+				},
+				Action: sphinx.MoreHops,
+			},
+			expectedFinalHop: false,
+		},
+		// A regular legacy payload that signals final hop.
+		{
+			sphinxPacket: &sphinx.ProcessedPacket{
+				Payload: sphinx.HopPayload{
+					Type: sphinx.PayloadLegacy,
+				},
+				Action: sphinx.ExitNode,
+			},
+			expectedFinalHop: true,
+		},
+		// A TLV payload that signals final hop.
+		{
+			sphinxPacket: &sphinx.ProcessedPacket{
+				Payload: sphinx.HopPayload{
+					Type: sphinx.PayloadTLV,
+				},
+				Action: sphinx.ExitNode,
+			},
+			expectedFinalHop: true,
+		},
+	}
+
+	iterator := sphinxHopIterator{}
+	for _, testCase := range testCases {
+		iterator.processedPacket = testCase.sphinxPacket
+
+		isFinalHop := iterator.IsFinalHop()
+		if isFinalHop != testCase.expectedFinalHop {
+			t.Fatalf("expected final hop: %t, got: %t",
+				testCase.expectedFinalHop, isFinalHop)
 		}
 	}
 }

--- a/htlcswitch/hop/payload.go
+++ b/htlcswitch/hop/payload.go
@@ -152,6 +152,24 @@ func NewLegacyPayload(f *sphinx.HopData) *Payload {
 	}
 }
 
+// NOTE(10/26/22): This function is currently only used to get around
+// the fact that customRecords is unexported and is required to be set.
+// I don't think a function like this would have much utility otherwise.
+// Given that we use TLV en/decoding I am a bit unsure how this function
+// will behave/get access to the information it would need.
+// The data included in a TLV payload is highly variable. That is why it makes
+// sense to define a struct and then TLV encode each of the structs types
+// that the user sets.
+func NewTLVPayload() *Payload {
+
+	// Set the unexported customRecords field so that we can carry
+	// on with our Link testing.
+	return &Payload{
+		FwdInfo:       ForwardingInfo{},
+		customRecords: make(record.CustomSet),
+	}
+}
+
 // BlindHopPayload encapsulates all the route blinding information
 // which will be parsed by nodes in the blinded portion of a route.
 type BlindHopPayload struct {

--- a/htlcswitch/hop/payload.go
+++ b/htlcswitch/hop/payload.go
@@ -28,6 +28,16 @@ const (
 	// RequiredViolation indicates that an unknown even type was found in
 	// the payload that we could not process.
 	RequiredViolation
+
+	// OverloadedViolation indicates that an expected type was provided
+	// in more than one place. (used only for blinding point)
+	OverloadedViolation
+
+	// InsufficientViolation indicates that the provided type does
+	// not satisfy constraints.
+	// NOTE(10/5/22): Used for payment constraints. Does this belong here?
+	// Should payment constraints be handled separately?
+	InsufficientViolation
 )
 
 // String returns a human-readable description of the violation as a verb.
@@ -41,6 +51,12 @@ func (v PayloadViolation) String() string {
 
 	case RequiredViolation:
 		return "required"
+
+	case OverloadedViolation:
+		return "overloaded"
+
+	case InsufficientViolation:
+		return "insufficient"
 
 	default:
 		return "unknown violation"

--- a/htlcswitch/hop/payload.go
+++ b/htlcswitch/hop/payload.go
@@ -61,6 +61,10 @@ type ErrInvalidPayload struct {
 	// in the route (identified by next hop id), otherwise the violation is
 	// for an intermediate hop.
 	FinalHop bool
+
+	// BlindHop indicates that the violation occurred while our node was
+	// processing a hop for a blinded route, otherwise we are a hop in a normal route.
+	BlindHop bool
 }
 
 // Error returns a human-readable description of the invalid payload error.
@@ -70,8 +74,13 @@ func (e ErrInvalidPayload) Error() string {
 		hopType = "final"
 	}
 
-	return fmt.Sprintf("onion payload for %s hop %v record with type %d",
-		hopType, e.Violation, e.Type)
+	payloadType := "onion"
+	if e.BlindHop {
+		payloadType = "route blinding"
+	}
+
+	return fmt.Sprintf("%s payload for %s hop %v record with type %d",
+		payloadType, hopType, e.Violation, e.Type)
 }
 
 // Payload encapsulates all information delivered to a hop in an onion payload.
@@ -372,6 +381,7 @@ func ValidateRouteBlindingPayloadTypes(parsedTypes tlv.TypeMap,
 				Type:      record.PaymentRelayOnionType,
 				Violation: OmittedViolation,
 				FinalHop:  false,
+				BlindHop:  true,
 			}
 		}
 
@@ -381,6 +391,7 @@ func ValidateRouteBlindingPayloadTypes(parsedTypes tlv.TypeMap,
 				Type:      record.BlindedNextHopOnionType,
 				Violation: OmittedViolation,
 				FinalHop:  false,
+				BlindHop:  true,
 			}
 		}
 	} else {
@@ -391,6 +402,7 @@ func ValidateRouteBlindingPayloadTypes(parsedTypes tlv.TypeMap,
 				Type:      record.PathIDOnionType,
 				Violation: OmittedViolation,
 				FinalHop:  true,
+				BlindHop:  true,
 			}
 		}
 	}

--- a/htlcswitch/hop/payload.go
+++ b/htlcswitch/hop/payload.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 
+	"github.com/btcsuite/btcd/btcec/v2"
 	sphinx "github.com/lightningnetwork/lightning-onion"
 	"github.com/lightningnetwork/lnd/lnwire"
 	"github.com/lightningnetwork/lnd/record"
@@ -90,6 +91,14 @@ type Payload struct {
 	// a TLV onion payload.
 	AMP *record.AMP
 
+	// RouteBlindingEncryptedData contains information needed to forward in
+	// the blinded portion of a route.
+	RouteBlindingEncryptedData []byte
+
+	// BlindingPoint delivered to the introductory node in the blinded route.
+	// NOTE: Could use [33]byte for compressed pubkey and remove btcec dependency.
+	BlindingPoint *btcec.PublicKey
+
 	// customRecords are user-defined records in the custom type range that
 	// were included in the payload.
 	customRecords record.CustomSet
@@ -97,6 +106,9 @@ type Payload struct {
 	// metadata is additional data that is sent along with the payment to
 	// the payee.
 	metadata []byte
+
+	// TotalAmountMsat is the total payment amount.
+	TotalAmountMsat lnwire.MilliSatoshi
 }
 
 // NewLegacyPayload builds a Payload from the amount, cltv, and next hop
@@ -115,16 +127,127 @@ func NewLegacyPayload(f *sphinx.HopData) *Payload {
 	}
 }
 
+// BlindHopPayload encapsulates all the route blinding information
+// which will be parsed by nodes in the blinded portion of a route.
+type BlindHopPayload struct {
+	// probably don't need to save this as it's only used to ensure
+	// all payloads on a blinded route are the same length.
+	Padding               []byte
+	NextHop               lnwire.ShortChannelID
+	NextNodeID            *btcec.PublicKey
+	PathID                []byte
+	BlindingPointOverride *btcec.PublicKey
+	PaymentRelay          *record.PaymentRelay
+	PaymentConstraints    *record.PaymentConstraints
+	// AllowedFeatures    *record.AllowedFeatures
+}
+
+// NewBlindHopPayloadFromReader parses a route blinding payload from
+// the passed io.Reader. The reader should correspond to the bytes
+// encapsulated in the encrypted route blinding payload after they
+// have been decrypted.
+func NewBlindHopPayloadFromReader(r io.Reader,
+	isFinalHop bool) (*BlindHopPayload, error) {
+
+	var (
+		padding            []byte
+		nextHop            uint64
+		nextNodeID         *btcec.PublicKey
+		pathID             []byte
+		blindingOverride   *btcec.PublicKey
+		paymentRelay       = &record.PaymentRelay{}
+		paymentConstraints = &record.PaymentConstraints{}
+	)
+
+	tlvStream, err := tlv.NewStream(
+		record.NewPaddingRecord(&padding),
+		record.NewBlindedNextHopRecord(&nextHop),
+		record.NewNextNodeIDRecord(&nextNodeID),
+		record.NewPathIDRecord(&pathID),
+		record.NewBlindingOverrideRecord(&blindingOverride),
+		paymentRelay.Record(),
+		paymentConstraints.Record(),
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	parsedTypes, err := tlvStream.DecodeWithParsedTypes(r)
+	if err != nil {
+		return nil, err
+	}
+
+	// Validate whether the sender properly included or omitted
+	// route blinding tlv records in accordance with BOLT 04 as
+	// early as possible. Additional validation will be performed later.
+	err = ValidateRouteBlindingPayloadTypes(parsedTypes, isFinalHop)
+	if err != nil {
+		return nil, err
+	}
+
+	violatingType := getMinRequiredViolation(parsedTypes)
+	if violatingType != nil {
+		return nil, ErrInvalidPayload{
+			Type:      *violatingType,
+			Violation: RequiredViolation,
+			FinalHop:  isFinalHop,
+		}
+	}
+
+	// NOTE(8/13/22): We set the fields on our struct representing the
+	// route blinding payload to nil so later we can properly validate.
+	// Reconcile this with above.
+	//
+	// If no padding field was parsed, set the padding field
+	// on the resulting payload to nil.
+	if _, ok := parsedTypes[record.PaddingOnionType]; !ok {
+		padding = nil
+	}
+
+	// If no path ID field was parsed, set the path ID field
+	// on the resulting payload to nil.
+	if _, ok := parsedTypes[record.PathIDOnionType]; !ok {
+		pathID = nil
+	}
+
+	// If no payment relay field was parsed, set the payment relay field
+	// on the resulting payload to nil.
+	if _, ok := parsedTypes[record.PaymentRelayOnionType]; !ok {
+		paymentRelay = nil
+	}
+
+	// If no payment constraints field was parsed, set the payment
+	// constraints field on the resulting payload to nil.
+	if _, ok := parsedTypes[record.PaymentConstraintsOnionType]; !ok {
+		paymentConstraints = nil
+	}
+
+	return &BlindHopPayload{
+		// NOTE: Likely do not need to expose padding to callers.
+		Padding:               padding,
+		NextHop:               lnwire.NewShortChanIDFromInt(nextHop),
+		NextNodeID:            nextNodeID,
+		PathID:                pathID,
+		BlindingPointOverride: blindingOverride,
+		PaymentRelay:          paymentRelay,
+		PaymentConstraints:    paymentConstraints,
+	}, nil
+}
+
 // NewPayloadFromReader builds a new Hop from the passed io.Reader. The reader
 // should correspond to the bytes encapsulated in a TLV onion payload.
 func NewPayloadFromReader(r io.Reader) (*Payload, error) {
 	var (
-		cid      uint64
-		amt      uint64
-		cltv     uint32
-		mpp      = &record.MPP{}
-		amp      = &record.AMP{}
-		metadata []byte
+		cid         uint64
+		amt         uint64
+		cltv        uint32
+		mpp         = &record.MPP{}
+		amp         = &record.AMP{}
+		metadata    []byte
+		totalAmount uint64
+
+		blindedData   []byte
+		blindingPoint *btcec.PublicKey
 	)
 
 	tlvStream, err := tlv.NewStream(
@@ -132,8 +255,11 @@ func NewPayloadFromReader(r io.Reader) (*Payload, error) {
 		record.NewLockTimeRecord(&cltv),
 		record.NewNextHopIDRecord(&cid),
 		mpp.Record(),
+		record.NewRouteBlindingEncryptedDataRecord(&blindedData),
+		record.NewBlindingPointRecord(&blindingPoint),
 		amp.Record(),
 		record.NewMetadataRecord(&metadata),
+		record.NewTotalAmountMsatRecord(&totalAmount),
 	)
 	if err != nil {
 		return nil, err
@@ -146,6 +272,9 @@ func NewPayloadFromReader(r io.Reader) (*Payload, error) {
 
 	// Validate whether the sender properly included or omitted tlv records
 	// in accordance with BOLT 04.
+	// NOTE(9/21/22): The 'nextHop' is passed so that our validation
+	// function can make the determination as to whether we are the
+	// final hop. We will replace this with all-zero onion HMAC.
 	nextHop := lnwire.NewShortChanIDFromInt(cid)
 	err = ValidateParsedPayloadTypes(parsedTypes, nextHop)
 	if err != nil {
@@ -168,7 +297,7 @@ func NewPayloadFromReader(r io.Reader) (*Payload, error) {
 		mpp = nil
 	}
 
-	// If no AMP field was parsed, set the MPP field on the resulting
+	// If no AMP field was parsed, set the AMP field on the resulting
 	// payload to nil.
 	if _, ok := parsedTypes[record.AMPOnionType]; !ok {
 		amp = nil
@@ -190,10 +319,15 @@ func NewPayloadFromReader(r io.Reader) (*Payload, error) {
 			AmountToForward: lnwire.MilliSatoshi(amt),
 			OutgoingCTLV:    cltv,
 		},
-		MPP:           mpp,
-		AMP:           amp,
-		metadata:      metadata,
-		customRecords: customRecords,
+		MPP: mpp,
+		AMP: amp,
+		// NOTE(9/2/22): This remains encrypted for now.
+		// We will parse (and validate) again as TLV stream after decryption.
+		RouteBlindingEncryptedData: blindedData,
+		BlindingPoint:              blindingPoint,
+		metadata:                   metadata,
+		TotalAmountMsat:            lnwire.MilliSatoshi(totalAmount),
+		customRecords:              customRecords,
 	}, nil
 }
 
@@ -216,13 +350,76 @@ func NewCustomRecords(parsedTypes tlv.TypeMap) record.CustomSet {
 	return customRecords
 }
 
+// ValidateRouteBlindingPayloadTypes checks the types parsed from a route
+// blinding payload to ensure that the proper fields are either included
+// or omitted. The requirements for this method are described in BOLT 04.
+func ValidateRouteBlindingPayloadTypes(parsedTypes tlv.TypeMap,
+	isFinalHop bool) error {
+
+	_, hasNextHop := parsedTypes[record.BlindedNextHopOnionType]
+	_, hasNextNode := parsedTypes[record.NextNodeIDOnionType]
+	_, hasPathID := parsedTypes[record.PathIDOnionType]
+	_, hasForwardingParams := parsedTypes[record.PaymentRelayOnionType]
+
+	// TODO(9/10/22): Figure out how to actually distinguish the final
+	// hop in a blinded route as TLV payload reader.
+	// UPDATE(9/15/22): Apparently this is supposed to be indicated by the
+	// sphinx implementation.
+	if !isFinalHop {
+		// An intermediate hop MUST specify how the payment is to be forwarded.
+		if !hasForwardingParams {
+			return ErrInvalidPayload{
+				Type:      record.PaymentRelayOnionType,
+				Violation: OmittedViolation,
+				FinalHop:  false,
+			}
+		}
+
+		// An intermedate hop MUST specify the node to which we should forward.
+		if !hasNextHop && !hasNextNode {
+			return ErrInvalidPayload{
+				Type:      record.BlindedNextHopOnionType,
+				Violation: OmittedViolation,
+				FinalHop:  false,
+			}
+		}
+	} else {
+		// The final hop MUST have a path_id with which we can validate
+		// this payment is for a blind route we created.
+		if !hasPathID {
+			return ErrInvalidPayload{
+				Type:      record.PathIDOnionType,
+				Violation: OmittedViolation,
+				FinalHop:  true,
+			}
+		}
+	}
+
+	return nil
+}
+
 // ValidateParsedPayloadTypes checks the types parsed from a hop payload to
 // ensure that the proper fields are either included or omitted. The finalHop
 // boolean should be true if the payload was parsed for an exit hop. The
 // requirements for this method are described in BOLT 04.
+//
+// NOTE(9/2/22): We now have validation to do across two levels of TLV
+// payloads. What is present in one payload effects our expectation of what
+// is present in the other payload. As a result, we will likely need to validate
+// the payloads together, which means waiting until after the route blinding
+// payload is decrypted. We would like to preserve the normal validation
+// in the case we are forwarding for a normal (not blinded) route.
 func ValidateParsedPayloadTypes(parsedTypes tlv.TypeMap,
 	nextHop lnwire.ShortChannelID) error {
 
+	// NOTE(9/15/22): This may not serve as a proper determination of
+	// whether this is the final hop. Processing nodes in a blinded
+	// route are permitted to have an empty next hop in the top level TLV
+	// onion payload. They MUST have a next hop in the recipient encrypted
+	// data payload however.
+	// UPDATE(9/15/22): According to BOLT-04 this is supposed to be
+	// indicated by the sphinx implementation when it encounters
+	// an all-zero onion HMAC.
 	isFinalHop := nextHop == Exit
 
 	_, hasAmt := parsedTypes[record.AmtOnionType]
@@ -230,25 +427,62 @@ func ValidateParsedPayloadTypes(parsedTypes tlv.TypeMap,
 	_, hasNextHop := parsedTypes[record.NextHopOnionType]
 	_, hasMPP := parsedTypes[record.MPPOnionType]
 	_, hasAMP := parsedTypes[record.AMPOnionType]
+	_, isBlindHop := parsedTypes[record.RouteBlindingEncryptedDataOnionType]
 
+	isNormalHop := !isBlindHop
+
+	// If this is a normal hop, fall back to our usual validation.
+	if isNormalHop {
+		switch {
+
+		// All hops must include an amount to forward,
+		// except those on blinded routes.
+		case !hasAmt:
+			return ErrInvalidPayload{
+				Type:      record.AmtOnionType,
+				Violation: OmittedViolation,
+				FinalHop:  isFinalHop,
+			}
+
+		// All normal hops must include a cltv expiry.
+		case !hasLockTime:
+			return ErrInvalidPayload{
+				Type:      record.LockTimeOnionType,
+				Violation: OmittedViolation,
+				FinalHop:  isFinalHop,
+			}
+
+		}
+
+	} else {
+		// This is a blind hop so we'll apply additional validation
+		// as per BOLT-04.
+		switch {
+
+		// Intermediate nodes in a blinded route should
+		// not contain an amount to forward.
+		case !isFinalHop && hasAmt:
+			return ErrInvalidPayload{
+				Type:      record.AmtOnionType,
+				Violation: IncludedViolation,
+				FinalHop:  false,
+			}
+
+		// Intermediate nodes in a blinded route should
+		// not contain an outgoing timelock.
+		case !isFinalHop && hasLockTime:
+			return ErrInvalidPayload{
+				Type:      record.LockTimeOnionType,
+				Violation: IncludedViolation,
+				FinalHop:  false,
+			}
+
+		}
+	}
+
+	// NOTE(11/15/22): The following 3 checks are common for both
+	// normal and blind hops.
 	switch {
-
-	// All hops must include an amount to forward.
-	case !hasAmt:
-		return ErrInvalidPayload{
-			Type:      record.AmtOnionType,
-			Violation: OmittedViolation,
-			FinalHop:  isFinalHop,
-		}
-
-	// All hops must include a cltv expiry.
-	case !hasLockTime:
-		return ErrInvalidPayload{
-			Type:      record.LockTimeOnionType,
-			Violation: OmittedViolation,
-			FinalHop:  isFinalHop,
-		}
-
 	// The exit hop should omit the next hop id. If nextHop != Exit, the
 	// sender must have included a record, so we don't need to test for its
 	// inclusion at intermediate hops directly.

--- a/htlcswitch/hop/payload_test.go
+++ b/htlcswitch/hop/payload_test.go
@@ -14,16 +14,29 @@ import (
 const testUnknownRequiredType = 0x80
 
 type decodePayloadTest struct {
-	name               string
-	payload            []byte
-	expErr             error
-	expCustomRecords   map[uint64][]byte
-	shouldHaveMPP      bool
-	shouldHaveAMP      bool
-	shouldHaveMetadata bool
+	name                        string
+	payload                     []byte
+	expErr                      error
+	expCustomRecords            map[uint64][]byte
+	shouldHaveMPP               bool
+	shouldHaveAMP               bool
+	shouldHaveMetadata          bool
+	shouldHaveRouteBlindingInfo bool
+	expRouteBlindingErr         error
+	isFinalHop                  bool
 }
 
 var decodePayloadTests = []decodePayloadTest{
+	{
+		name:    "empty hop TLV payload",
+		payload: []byte{},
+		// All normal hops (ie: not blind) are expected to have an amount.
+		expErr: hop.ErrInvalidPayload{
+			Type:      record.AmtOnionType,
+			Violation: hop.OmittedViolation,
+			FinalHop:  true,
+		},
+	},
 	{
 		name:    "final hop valid",
 		payload: []byte{0x02, 0x00, 0x04, 0x00},
@@ -271,6 +284,211 @@ var decodePayloadTests = []decodePayloadTest{
 		},
 		shouldHaveMetadata: true,
 	},
+	{
+		name: "introduction node blinded route",
+		payload: []byte{
+			// - no amount
+			// - no timelock
+			// NOTE(9/21/22): the introduction node will receive an
+			// amount and timelock on the inbound HTLC but its top
+			// level onion TLV payload should not contain an amount
+			// to be forwarded or an outgoing timelock.
+			// no unblinded next hop id in blinded portion of route
+			// (route blinding - top level TLV payload) recipient encrypted data
+			// START: route blinding TLV data
+			byte(int(record.RouteBlindingEncryptedDataOnionType)), 0x70,
+			// byte(int(record.RouteBlindingEncryptedDataOnionType)), 0x56,
+			// (route blinding) padding
+			byte(int(record.PaddingOnionType)), 0x04, 0x00, 0x01, 0x00, 0x00,
+			// (route blinding) next hop
+			byte(int(record.BlindedNextHopOnionType)), 0x08,
+			0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+			// (route blinding) next node ID
+			byte(int(record.NextNodeIDOnionType)), 0x21,
+			0x02, 0xee, 0xc7, 0x24, 0x5d, 0x6b, 0x7d, 0x2c, 0xcb, 0x30, 0x38,
+			0x0b, 0xfb, 0xe2, 0xa3, 0x64, 0x8c, 0xd7, 0xa9, 0x42, 0x65, 0x3f,
+			0x5a, 0xa3, 0x40, 0xed, 0xce, 0xa1, 0xf2, 0x83, 0x68, 0x66, 0x19,
+			// (route blinding) path ID (ONLY set for final node)
+			// 0x06, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+			// (route blinding) blinding point override
+			byte(int(record.BlindingOverrideOnionType)), 0x21,
+			0x02, 0xee, 0xc7, 0x24, 0x5d, 0x6b, 0x7d, 0x2c, 0xcb, 0x30, 0x38,
+			0x0b, 0xfb, 0xe2, 0xa3, 0x64, 0x8c, 0xd7, 0xa9, 0x42, 0x65, 0x3f,
+			0x5a, 0xa3, 0x40, 0xed, 0xce, 0xa1, 0xf2, 0x83, 0x68, 0x66, 0x19,
+			// (route blinding) payment relay
+			byte(int(record.PaymentRelayOnionType)), 0x0a,
+			0x00, 0x00, 0x4e, 0x20, 0x00,
+			0x00, 0x00, 0x00, 0x00, 0x28,
+			// (route blinding) payment constraints
+			byte(int(record.PaymentConstraintsOnionType)), 0x0c,
+			0x00, 0x00, 0x03, 0xe8,
+			0x00, 0x00, 0x00, 0x00,
+			0x00, 0x00, 0x00, 0x00,
+			// END: route blinding TLV data
+			// (route blinding - top level TLV payload) blinding point
+			byte(int(record.BlindingPointOnionType)), 0x21,
+			0x02, 0xee, 0xc7, 0x24, 0x5d, 0x6b, 0x7d, 0x2c, 0xcb, 0x30, 0x38,
+			0x0b, 0xfb, 0xe2, 0xa3, 0x64, 0x8c, 0xd7, 0xa9, 0x42, 0x65, 0x3f,
+			0x5a, 0xa3, 0x40, 0xed, 0xce, 0xa1, 0xf2, 0x83, 0x68, 0x66, 0x19,
+		},
+		shouldHaveRouteBlindingInfo: true,
+	},
+	{
+		name: "intermediate hop blinded route w/ next hop",
+		payload: []byte{
+			// - no amount
+			// - no timelock
+			// START: route blinding TLV data
+			// recipient encrypted data
+			byte(int(record.RouteBlindingEncryptedDataOnionType)), 0x1c,
+			// byte(int(record.RouteBlindingEncryptedDataOnionType)), 0x10, // test no payment relay
+			// (route blinding) padding
+			byte(int(record.PaddingOnionType)), 0x04, 0x00, 0x01, 0x00, 0x00,
+			// (route blinding) next hop
+			byte(int(record.BlindedNextHopOnionType)), 0x08,
+			0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+			// (route blinding) payment relay
+			byte(int(record.PaymentRelayOnionType)), 0x0a,
+			0x00, 0x00, 0x4e, 0x20, 0x00,
+			0x00, 0x00, 0x00, 0x00, 0x28,
+			// END: route blinding TLV data
+		},
+		shouldHaveRouteBlindingInfo: true,
+	},
+	{
+		name: "intermediate hop blinded route w/ next node ID",
+		payload: []byte{
+			// - no amount
+			// - no timelock
+			// START: route blinding TLV data
+			// recipient encrypted data
+			byte(int(record.RouteBlindingEncryptedDataOnionType)), 0x35,
+			// byte(int(record.RouteBlindingEncryptedDataOnionType)), 0x29, // test no payment relay
+			// (route blinding) padding
+			byte(int(record.PaddingOnionType)), 0x04, 0x00, 0x01, 0x00, 0x00,
+			// (route blinding) next node ID
+			byte(int(record.NextNodeIDOnionType)), 0x21,
+			0x02, 0xee, 0xc7, 0x24, 0x5d, 0x6b, 0x7d, 0x2c, 0xcb, 0x30, 0x38,
+			0x0b, 0xfb, 0xe2, 0xa3, 0x64, 0x8c, 0xd7, 0xa9, 0x42, 0x65, 0x3f,
+			0x5a, 0xa3, 0x40, 0xed, 0xce, 0xa1, 0xf2, 0x83, 0x68, 0x66, 0x19,
+			// (route blinding) payment relay
+			byte(int(record.PaymentRelayOnionType)), 0x0a,
+			0x00, 0x00, 0x4e, 0x20, 0x00,
+			0x00, 0x00, 0x00, 0x00, 0x28,
+			// END: route blinding TLV data
+		},
+		shouldHaveRouteBlindingInfo: true,
+	},
+	{
+		name: "intermediate hop blinded route missing payment relay", // error case
+		payload: []byte{
+			// - no amount
+			// - no timelock
+			// START: route blinding TLV data
+			// recipient encrypted data
+			byte(int(record.RouteBlindingEncryptedDataOnionType)), 0x10,
+			// padding
+			byte(int(record.PaddingOnionType)), 0x04, 0x00, 0x01, 0x00, 0x00,
+			// next hop
+			byte(int(record.BlindedNextHopOnionType)), 0x08,
+			0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+			//  - no payment relay (MUST be set for blind hops)
+			// END: route blinding TLV data
+		},
+		shouldHaveRouteBlindingInfo: true,
+		expRouteBlindingErr: hop.ErrInvalidPayload{
+			Type:      record.PaymentRelayOnionType,
+			Violation: hop.OmittedViolation,
+			FinalHop:  false,
+		},
+	},
+	{
+		name: "final hop blinded route",
+		payload: []byte{
+			// amount
+			0x02, 0x01, 0x0b,
+			// cltv
+			0x04, 0x01, 0x11,
+			// (route blinding - top level TLV payload) recipient encrypted data
+			// START: route blinding TLV data
+			byte(int(record.RouteBlindingEncryptedDataOnionType)), 0x0c,
+			// (route blinding) padding
+			byte(int(record.PaddingOnionType)), 0x04, 0x00, 0x01, 0x00, 0x00,
+			// (route blinding) path ID (ONLY set for final node)
+			byte(int(record.PathIDOnionType)), 0x04, 0xff, 0x00, 0xff, 0x00,
+			// END: route blinding TLV data
+		},
+		shouldHaveRouteBlindingInfo: true,
+		isFinalHop:                  true,
+	},
+	{
+		name: "final hop blinded route missing path ID", // error case
+		payload: []byte{
+			// amount
+			0x02, 0x01, 0x0b,
+			// cltv
+			0x04, 0x01, 0x11,
+			// (route blinding - top level TLV payload) recipient encrypted data
+			// START: route blinding TLV data
+			byte(int(record.RouteBlindingEncryptedDataOnionType)), 0x06,
+			// padding
+			byte(int(record.PaddingOnionType)), 0x04, 0x00, 0x01, 0x00, 0x00,
+			// - no path ID (MUST be set for final node)
+			// END: route blinding TLV data
+		},
+		shouldHaveRouteBlindingInfo: true,
+		expRouteBlindingErr: hop.ErrInvalidPayload{
+			Type:      record.PathIDOnionType,
+			Violation: hop.OmittedViolation,
+			FinalHop:  true,
+		},
+		isFinalHop: true,
+	},
+	{
+		name: "christmas tree TLV payload (all lights on)",
+		payload: []byte{
+			// amount
+			0x02, 0x01, 0x0b,
+			// cltv
+			0x04, 0x01, 0x11,
+			// (route blinding - top level TLV payload) recipient encrypted data
+			// START: route blinding TLV data
+			byte(int(record.RouteBlindingEncryptedDataOnionType)), 0x76,
+			// (route blinding) padding
+			byte(int(record.PaddingOnionType)), 0x04, 0x00, 0x01, 0x00, 0x00,
+			// (route blinding) next hop
+			byte(int(record.BlindedNextHopOnionType)), 0x08,
+			0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+			// (route blinding) next node ID
+			byte(int(record.NextNodeIDOnionType)), 0x21,
+			0x02, 0xee, 0xc7, 0x24, 0x5d, 0x6b, 0x7d, 0x2c, 0xcb, 0x30, 0x38,
+			0x0b, 0xfb, 0xe2, 0xa3, 0x64, 0x8c, 0xd7, 0xa9, 0x42, 0x65, 0x3f,
+			0x5a, 0xa3, 0x40, 0xed, 0xce, 0xa1, 0xf2, 0x83, 0x68, 0x66, 0x19,
+			// (route blinding) path ID (ONLY set for final node)
+			byte(int(record.PathIDOnionType)), 0x04, 0xff, 0x00, 0xff, 0x00,
+			// (route blinding) blinding point override
+			byte(int(record.BlindingOverrideOnionType)), 0x21,
+			0x02, 0xee, 0xc7, 0x24, 0x5d, 0x6b, 0x7d, 0x2c, 0xcb, 0x30, 0x38,
+			0x0b, 0xfb, 0xe2, 0xa3, 0x64, 0x8c, 0xd7, 0xa9, 0x42, 0x65, 0x3f,
+			0x5a, 0xa3, 0x40, 0xed, 0xce, 0xa1, 0xf2, 0x83, 0x68, 0x66, 0x19,
+			// (route blinding) payment relay
+			byte(int(record.PaymentRelayOnionType)), 0x0a,
+			0x00, 0x00, 0x4e, 0x20, 0x00,
+			0x00, 0x00, 0x00, 0x00, 0x28,
+			// (route blinding) payment constraints
+			byte(int(record.PaymentConstraintsOnionType)), 0x0c,
+			0x00, 0x00, 0x03, 0xe8,
+			0x00, 0x00, 0x00, 0x00,
+			0x00, 0x00, 0x00, 0x00,
+			// END: route blinding TLV data
+			// (route blinding - top level TLV payload) blinding point
+			byte(int(record.BlindingPointOnionType)), 0x21,
+			0x02, 0xee, 0xc7, 0x24, 0x5d, 0x6b, 0x7d, 0x2c, 0xcb, 0x30, 0x38,
+			0x0b, 0xfb, 0xe2, 0xa3, 0x64, 0x8c, 0xd7, 0xa9, 0x42, 0x65, 0x3f,
+			0x5a, 0xa3, 0x40, 0xed, 0xce, 0xa1, 0xf2, 0x83, 0x68, 0x66, 0x19,
+		},
+		shouldHaveRouteBlindingInfo: true,
+	},
 }
 
 // TestDecodeHopPayloadRecordValidation asserts that parsing the payloads in the
@@ -352,6 +570,37 @@ func testDecodeHopPayloadValidation(t *testing.T, test decodePayloadTest) {
 		require.Equal(t, testMetadata, p.Metadata())
 	} else if p.Metadata() != nil {
 		t.Fatalf("unexpected metadata")
+	}
+
+	// If the top level onion TLV payload contains a route blinding
+	// TLV payload, then we'll parse that as well.
+	// NOTE: We assume the route blinding payload has already been decrypted.
+	var blindHopPayload *hop.BlindHopPayload
+	if p.RouteBlindingEncryptedData != nil {
+		blindHopPayload, err = hop.NewBlindHopPayloadFromReader(
+			bytes.NewReader(p.RouteBlindingEncryptedData), test.isFinalHop,
+		)
+
+		if !reflect.DeepEqual(test.expRouteBlindingErr, err) {
+			t.Fatalf("expected error mismatch, want: %v, got: %v",
+				test.expRouteBlindingErr, err)
+		}
+		if err != nil {
+			return
+		}
+	}
+
+	if test.shouldHaveRouteBlindingInfo {
+		if p.RouteBlindingEncryptedData == nil {
+			t.Fatalf("payload should have encrypted data from route blinder")
+		}
+
+		if blindHopPayload == nil {
+			t.Fatalf("should have parsed route blinding payload")
+		}
+
+	} else if p.RouteBlindingEncryptedData != nil || p.BlindingPoint != nil {
+		t.Fatalf("unexpected route blinding info included in payload")
 	}
 
 	// Convert expected nil map to empty map, because we always expect an

--- a/htlcswitch/hop/payload_test.go
+++ b/htlcswitch/hop/payload_test.go
@@ -871,3 +871,7 @@ func testDecodeBlindHopPayloadValidation(t *testing.T,
 	}
 
 }
+
+// TODO(10/16/22): Test compute to amount forward requires it be exported
+// as our test code lives in a different package.
+// func TestComputeAmountToForward(t *testing.T) {}

--- a/htlcswitch/hop/payload_test.go
+++ b/htlcswitch/hop/payload_test.go
@@ -410,6 +410,7 @@ var decodePayloadTests = []decodePayloadTest{
 			Type:      record.PaymentRelayOnionType,
 			Violation: hop.OmittedViolation,
 			FinalHop:  false,
+			BlindHop:  true,
 		},
 	},
 	{
@@ -451,6 +452,7 @@ var decodePayloadTests = []decodePayloadTest{
 			Type:      record.PathIDOnionType,
 			Violation: hop.OmittedViolation,
 			FinalHop:  true,
+			BlindHop:  true,
 		},
 		isFinalHop: true,
 	},
@@ -652,6 +654,7 @@ var decodeRouteBlindingPayloadTests = []decodeRouteBlindingPayloadTest{
 			Type:      record.PaymentRelayOnionType,
 			Violation: hop.OmittedViolation,
 			FinalHop:  false,
+			BlindHop:  true,
 		},
 	},
 	{
@@ -661,6 +664,7 @@ var decodeRouteBlindingPayloadTests = []decodeRouteBlindingPayloadTest{
 			Type:      record.PathIDOnionType,
 			Violation: hop.OmittedViolation,
 			FinalHop:  true, // Needs to match what sphinx package says.
+			BlindHop:  true,
 		},
 		isFinalHop: true, // sphinx package says...
 	},
@@ -750,6 +754,7 @@ var decodeRouteBlindingPayloadTests = []decodeRouteBlindingPayloadTest{
 			Type:      record.BlindedNextHopOnionType,
 			Violation: hop.OmittedViolation,
 			FinalHop:  false,
+			BlindHop:  true,
 		},
 	},
 	{
@@ -768,6 +773,7 @@ var decodeRouteBlindingPayloadTests = []decodeRouteBlindingPayloadTest{
 			Type:      record.PaymentRelayOnionType,
 			Violation: hop.OmittedViolation,
 			FinalHop:  false,
+			BlindHop:  true,
 		},
 	},
 	{
@@ -795,6 +801,7 @@ var decodeRouteBlindingPayloadTests = []decodeRouteBlindingPayloadTest{
 			Type:      record.PathIDOnionType,
 			Violation: hop.OmittedViolation,
 			FinalHop:  true,
+			BlindHop:  true,
 		},
 		isFinalHop: true,
 	},

--- a/htlcswitch/interfaces.go
+++ b/htlcswitch/interfaces.go
@@ -1,9 +1,11 @@
 package htlcswitch
 
 import (
+	"github.com/btcsuite/btcd/btcec/v2"
 	"github.com/btcsuite/btcd/wire"
 	"github.com/lightningnetwork/lnd/channeldb"
 	"github.com/lightningnetwork/lnd/invoices"
+	"github.com/lightningnetwork/lnd/keychain"
 	"github.com/lightningnetwork/lnd/lnpeer"
 	"github.com/lightningnetwork/lnd/lntypes"
 	"github.com/lightningnetwork/lnd/lnwallet"
@@ -67,6 +69,25 @@ type dustHandler interface {
 	// getDustClosure returns a closure that can evaluate whether a passed
 	// HTLC is dust.
 	getDustClosure() dustClosure
+}
+
+// BlindHopProcessor provides the functionality necessary for
+// the channel link to process hops as part of a blinded route.
+type BlindHopProcessor interface {
+	// // DeriveBlindingFactor...
+	// // Note(8/8/22): This is not needed with Elle's current implementation.
+	// DeriveBlindingFactor(*btcec.PrivateKey, *btcec.PublicKey) (
+	// 	*btcec.PrivateKey, error)
+
+	// DecryptBlindedPayload decrypts the route blinding payload.
+	DecryptBlindedPayload(nodeID keychain.SingleKeyECDH, blindingPoint *btcec.PublicKey,
+		payload []byte) ([]byte, error)
+
+	// NextBlindingPoint computes the ephemeral blinding point
+	// that the next hop (our downstream peer) in a blinded route
+	// will need in order to decrypt the onion.
+	NextBlindingPoint(keychain.SingleKeyECDH, *btcec.PublicKey) (
+		*btcec.PublicKey, error)
 }
 
 // scidAliasHandler is an interface that the ChannelLink implements so it can

--- a/htlcswitch/link.go
+++ b/htlcswitch/link.go
@@ -20,6 +20,7 @@ import (
 	"github.com/lightningnetwork/lnd/htlcswitch/hodl"
 	"github.com/lightningnetwork/lnd/htlcswitch/hop"
 	"github.com/lightningnetwork/lnd/invoices"
+	"github.com/lightningnetwork/lnd/keychain"
 	"github.com/lightningnetwork/lnd/lnpeer"
 	"github.com/lightningnetwork/lnd/lntypes"
 	"github.com/lightningnetwork/lnd/lnwallet"
@@ -294,6 +295,10 @@ type ChannelLinkConfig struct {
 	// HtlcNotifier is an instance of a htlcNotifier which we will pipe htlc
 	// events through.
 	HtlcNotifier htlcNotifier
+
+	// NodeKeyECDH provides access to our persistent node ID private key
+	// which is needed to process onions for hops in a blinded route.
+	NodeKeyECDH keychain.SingleKeyECDH
 
 	// FailAliasUpdate is a function used to fail an HTLC for an
 	// option_scid_alias channel.

--- a/htlcswitch/mock.go
+++ b/htlcswitch/mock.go
@@ -334,6 +334,11 @@ func (r *mockHopIterator) HopPayload() (*hop.Payload, error) {
 	return h, nil
 }
 
+func (r *mockHopIterator) IsFinalHop() bool {
+
+	return len(r.hops) == 0
+}
+
 func (r *mockHopIterator) ExtraOnionBlob() []byte {
 	return nil
 }

--- a/lncfg/protocol.go
+++ b/lncfg/protocol.go
@@ -41,6 +41,10 @@ type ProtocolOptions struct {
 	// feature bit.
 	OptionZeroConf bool `long:"zero-conf" description:"enable support for zero-conf channels, must have option-scid-alias set also"`
 
+	// OptionRouteBlinding should be set if we want to signal support
+	// for route blinding.
+	OptionRouteBlinding bool `long:"route-blinding" description:"enable support for route blinding"`
+
 	// NoOptionAnySegwit should be set to true if we don't want to use any
 	// Taproot (and beyond) addresses for co-op closing.
 	NoOptionAnySegwit bool `long:"no-any-segwit" description:"disallow using any segiwt witness version as a co-op close address"`
@@ -72,6 +76,11 @@ func (l *ProtocolOptions) ScidAlias() bool {
 // ZeroConf returns true if we have enabled the zero-conf feature bit.
 func (l *ProtocolOptions) ZeroConf() bool {
 	return l.OptionZeroConf
+}
+
+// RouteBlinding returns true if we have enabled the route blinding feature bit.
+func (l *ProtocolOptions) RouteBlinding() bool {
+	return l.OptionRouteBlinding
 }
 
 // NoAnySegwit returns true if we don't signal that we understand other newer

--- a/lncfg/protocol_rpctest.go
+++ b/lncfg/protocol_rpctest.go
@@ -42,6 +42,10 @@ type ProtocolOptions struct {
 	// feature bit.
 	OptionZeroConf bool `long:"zero-conf" description:"enable support for zero-conf channels, must have option-scid-alias set also"`
 
+	// OptionRouteBlinding should be set if we want to signal support
+	// for route blinding.
+	OptionRouteBlinding bool `long:"route-blinding" description:"enable support for route blinding"`
+
 	// NoOptionAnySegwit should be set to true if we don't want to use any
 	// Taproot (and beyond) addresses for co-op closing.
 	NoOptionAnySegwit bool `long:"no-any-segwit" description:"disallow using any segiwt witness version as a co-op close address"`
@@ -73,6 +77,11 @@ func (l *ProtocolOptions) ScidAlias() bool {
 // ZeroConf returns true if we have enabled the zero-conf feature bit.
 func (l *ProtocolOptions) ZeroConf() bool {
 	return l.OptionZeroConf
+}
+
+// RouteBlinding returns true if we have enabled the route blinding feature bit.
+func (l *ProtocolOptions) RouteBlinding() bool {
+	return l.OptionRouteBlinding
 }
 
 // NoAnySegwit returns true if we don't signal that we understand other newer

--- a/lntest/itest/lnd_mpp_test.go
+++ b/lntest/itest/lnd_mpp_test.go
@@ -256,12 +256,24 @@ func newMppTestContext(t *harnessTest,
 	net *lntest.NetworkHarness) *mppTestContext {
 
 	alice := net.NewNode(t.t, "alice", nil)
-	bob := net.NewNode(t.t, "bob", []string{"--accept-amp"})
+
+	// NOTE(8/7/22): For simplicity of blinded route testing setup each node in route
+	// to charge 10 sat (10,000 msat) base forwarding fee and zero proportional fee.
+	bob := net.NewNode(t.t, "bob", []string{
+		"--accept-amp", "--bitcoin.basefee=10000",
+		"--bitcoin.feerate=0", "--protocol.route-blinding",
+	})
 
 	// Create a five-node context consisting of Alice, Bob and three new
 	// nodes.
-	carol := net.NewNode(t.t, "carol", nil)
-	dave := net.NewNode(t.t, "dave", nil)
+	carol := net.NewNode(t.t, "carol", []string{
+		"--bitcoin.basefee=10000",
+		"--bitcoin.feerate=0", "--protocol.route-blinding",
+	})
+	dave := net.NewNode(t.t, "dave", []string{
+		"--bitcoin.basefee=10000",
+		"--bitcoin.feerate=0", "--protocol.route-blinding",
+	})
 	eve := net.NewNode(t.t, "eve", nil)
 
 	// Connect nodes to ensure propagation of channels.

--- a/lnwire/blinding_point.go
+++ b/lnwire/blinding_point.go
@@ -1,0 +1,72 @@
+package lnwire
+
+import (
+	"io"
+
+	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/lightningnetwork/lnd/tlv"
+)
+
+const (
+	// BlindingPointRecordType is the type which refers to an ephemeral
+	// public key used in route blinding.
+	BlindingPointRecordType tlv.Type = 1
+)
+
+// NOTE(9/20/22): The swap from tlv.Record to tlv.RecordProducer inside
+// ExtractRecords() requires us to define this type and associated (en/de)code
+// methods, as it precludes us from being able to leverage the 'record'
+// package's "primitive" TLV types. Instead it pushes us to define our own
+// custom type so that we may satisfy the RecordProducer interface{}.
+// It might be nice to be able to take advantage of the primitive types that
+// the 'record' package offers. No type casting. The change to the
+// RecordProducer{} interface is said to "reduce line noise", but I am not yet
+// sure what this means. Are there any more details on why this was swapped?
+// https://github.com/lightningnetwork/lnd/pull/5669/commits/57b7a668c00ad3ebc049fd3517517118389238e0#diff-0352ea3877666d95afd22632bf69ef124ae1d072a206cf257a7cef618b6562b1R54
+type BlindingPoint btcec.PublicKey
+
+// Record returns a TLV record that can be used to encode/decode the
+// ephemeral (route) blinding point type from a given TLV stream.
+func (b *BlindingPoint) Record() tlv.Record {
+	return tlv.MakeStaticRecord(
+		BlindingPointRecordType, b, 33, blindingPointEncoder, blindingPointDecoder,
+	)
+}
+
+// blindingPointEncoder is a custom TLV encoder for the BlindingPoint record.
+func blindingPointEncoder(w io.Writer, val interface{}, buf *[8]byte) error {
+	if v, ok := val.(*BlindingPoint); ok {
+		// Convert from *BlindingPoint to **btcec.PublicKey
+		// so that we can use tlv.EPubKey()?
+		key := new(btcec.PublicKey)
+		*key = btcec.PublicKey(*v)
+		if err := tlv.EPubKey(w, &key, buf); err != nil {
+			return err
+		}
+
+		return nil
+	}
+
+	return tlv.NewTypeForEncodingErr(val, "lnwire.BlindingPoint")
+}
+
+// blindingPointDecoder is a custom TLV decoder for the BlindingPoint record.
+func blindingPointDecoder(r io.Reader, val interface{}, buf *[8]byte, l uint64) error {
+	if v, ok := val.(*BlindingPoint); ok {
+
+		// 1. Read bytes into internally defined variable.
+		// Define **btcec.PublicKey so that we can use tlv.DPubKey()?
+		var blindingPoint *btcec.PublicKey
+
+		if err := tlv.DPubKey(r, &blindingPoint, buf, l); err != nil {
+			return err
+		}
+
+		// 2. Convert internal variable to desired custom type.
+		*v = BlindingPoint(*blindingPoint)
+
+		return nil
+	}
+
+	return tlv.NewTypeForDecodingErr(val, "lnwire.BlindingPoint", l, 33)
+}

--- a/lnwire/blinding_point_test.go
+++ b/lnwire/blinding_point_test.go
@@ -1,0 +1,26 @@
+package lnwire
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestRouteBlindingPointEncodeDecode tests that we're able to properly
+// encode and decode a BlindingPoint type within TLV streams.
+func TestRouteBlindingPointEncodeDecode(t *testing.T) {
+	t.Parallel()
+
+	pubKey, _ := randPubKey()
+	blindingPoint := BlindingPoint(*pubKey)
+
+	var extraData ExtraOpaqueData
+	require.NoError(t, extraData.PackRecords(&blindingPoint))
+
+	var blindingPoint2 BlindingPoint
+	tlvs, err := extraData.ExtractRecords(&blindingPoint2)
+	require.NoError(t, err)
+
+	require.Contains(t, tlvs, BlindingPointRecordType)
+	require.Equal(t, blindingPoint, blindingPoint2)
+}

--- a/lnwire/features.go
+++ b/lnwire/features.go
@@ -129,6 +129,14 @@ const (
 	// transactions, which also imply anchor commitments.
 	AnchorsZeroFeeHtlcTxOptional FeatureBit = 23
 
+	// RouteBlindingRequired is a required feature bit that signals that
+	// the node supports sending to/receiving from blinded routes.
+	RouteBlindingRequired FeatureBit = 24
+
+	// RouteBlindingOptional is an optional feature bit that signals that
+	// the node supports sending to/receiving from blinded routes.
+	RouteBlindingOptional FeatureBit = 25
+
 	// ShutdownAnySegwitRequired is an required feature bit that signals
 	// that the sender is able to properly handle/parse segwit witness
 	// programs up to version 16. This enables utilization of Taproot
@@ -268,6 +276,8 @@ var Features = map[FeatureBit]string{
 	AMPOptional:                   "amp",
 	PaymentMetadataOptional:       "payment-metadata",
 	PaymentMetadataRequired:       "payment-metadata",
+	RouteBlindingRequired:         "route-blinding",
+	RouteBlindingOptional:         "route-blinding",
 	ExplicitChannelTypeOptional:   "explicit-commitment-type",
 	ExplicitChannelTypeRequired:   "explicit-commitment-type",
 	KeysendOptional:               "keysend",

--- a/lnwire/lnwire_test.go
+++ b/lnwire/lnwire_test.go
@@ -947,6 +947,7 @@ func TestLightningWireProtocol(t *testing.T) {
 
 			v[0] = reflect.ValueOf(req)
 		},
+		// TODO(9/20/22): create test to exercise route blinding field.
 	}
 
 	// With the above types defined, we'll now generate a slice of

--- a/lnwire/onion_error_test.go
+++ b/lnwire/onion_error_test.go
@@ -56,6 +56,7 @@ var onionFailures = []FailureMessage{
 	NewFinalIncorrectCltvExpiry(testCtlvExpiry),
 	NewFinalIncorrectHtlcAmount(testAmount),
 	NewInvalidOnionPayload(testType, testOffset),
+	NewInvalidOnionBlinding(testOnionHash),
 }
 
 // TestEncodeDecodeCode tests the ability of onion errors to be properly encoded

--- a/peer/brontide.go
+++ b/peer/brontide.go
@@ -31,6 +31,7 @@ import (
 	"github.com/lightningnetwork/lnd/htlcswitch/hop"
 	"github.com/lightningnetwork/lnd/input"
 	"github.com/lightningnetwork/lnd/invoices"
+	"github.com/lightningnetwork/lnd/keychain"
 	"github.com/lightningnetwork/lnd/lnpeer"
 	"github.com/lightningnetwork/lnd/lnwallet"
 	"github.com/lightningnetwork/lnd/lnwallet/chainfee"
@@ -308,6 +309,13 @@ type Config struct {
 	// It is used to determine which policy (channel edge) to pass to the
 	// ChannelLink.
 	ServerPubKey [33]byte
+
+	// NodeKeyECDH is the the ECDH capable wrapper of our persistent node
+	// ID private key. This key is needed in order to process onions for
+	// hops in a blinded route. NOTE(9/20/22): With a library change it
+	// could be had via the sphinx.Router. Does this make the above
+	// 'ServerPubKey' redundant?
+	NodeKeyECDH keychain.SingleKeyECDH
 
 	// ChannelCommitInterval is the maximum time that is allowed to pass between
 	// receiving a channel state update and signing the next commitment.
@@ -978,6 +986,7 @@ func (p *Brontide) addLink(chanPoint *wire.OutPoint,
 		NotifyInactiveChannel:   p.cfg.ChannelNotifier.NotifyInactiveChannelEvent,
 		HtlcNotifier:            p.cfg.HtlcNotifier,
 		GetAliases:              p.cfg.GetAliases,
+		NodeKeyECDH:             p.cfg.NodeKeyECDH,
 	}
 
 	// Before adding our new link, purge the switch of any pending or live

--- a/record/blind_hop.go
+++ b/record/blind_hop.go
@@ -1,0 +1,202 @@
+package record
+
+import (
+	"io"
+
+	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/lightningnetwork/lnd/tlv"
+)
+
+const (
+
+	// PaddingOnionType is used in a route blinding TLV payload
+	// to ensure that payloads are the same length across all
+	// hops in a blinded route.
+	PaddingOnionType tlv.Type = 1
+
+	// NextHopOnionType is used in a route blinding TLV payload
+	// to provide the short channel ID of the next hop.
+	BlindedNextHopOnionType tlv.Type = 2
+
+	// NextNodeIDOnionType is used in a route blinding TLV payload
+	// to provide the persistent node ID of the next hop.
+	NextNodeIDOnionType tlv.Type = 4
+
+	// PathIDOnionType is an optional field recipients can use
+	// to verify that a blinded route was used in the proper context.
+	PathIDOnionType tlv.Type = 6
+
+	// BlindingOverrideOnionType is field which can be used to
+	// concatenate several distinct blinded routes.
+	BlindingOverrideOnionType tlv.Type = 8
+
+	// PaymentRelayOnionType specifies the information
+	// necessary to compute the amount and timelock
+	// which a blinded hop must use to forward the onion.
+	PaymentRelayOnionType tlv.Type = 10
+
+	// PaymentContraintsOnionType specifies a set of constraints
+	// we are asked to honor during forwarding in the blinded
+	// portion of a route. The constraints are chosen by the
+	// route blinder in order to limit an adversary's ability to
+	// unblind nodes within the route.
+	//
+	// NOTE: These are additional constraints on forwarded payments
+	// above and beyond our usual forwarding policy.
+	PaymentConstraintsOnionType tlv.Type = 12
+
+	// AllowedFeaturesOnionType specifies the features a sender
+	// is permitted to use when paying to a blinded route.
+	AllowedFeaturesOnionType tlv.Type = 14
+)
+
+// NewPaddingRecord creates a tlv.Record that encodes the padding
+// (type 1) for a route blinding payload.
+func NewPaddingRecord(padding *[]byte) tlv.Record {
+	return tlv.MakePrimitiveRecord(PaddingOnionType, padding)
+}
+
+// NewUnblindedNextHopRecord creates a tlv.Record that encodes the short_channel_id
+// (type 2) for a route blinding payload.
+func NewBlindedNextHopRecord(cid *uint64) tlv.Record {
+	return tlv.MakePrimitiveRecord(BlindedNextHopOnionType, cid)
+}
+
+// NewNextNodeIDRecord creates a tlv.Record that encodes the next_node_id
+// (type 4) for a route blinding payload.
+func NewNextNodeIDRecord(nodeID **btcec.PublicKey) tlv.Record {
+	return tlv.MakePrimitiveRecord(NextNodeIDOnionType, nodeID)
+}
+
+// NewPathIDRecord creates a tlv.Record that encodes the path_id
+// (type 6) for a route blinding payload.
+func NewPathIDRecord(pathID *[]byte) tlv.Record {
+	return tlv.MakePrimitiveRecord(PathIDOnionType, pathID)
+}
+
+// NewBlindingOverrideRecord creates a tlv.Record that encodes the next_blinding_override
+// (type 8) for a route blinding payload.
+func NewBlindingOverrideRecord(point **btcec.PublicKey) tlv.Record {
+	return tlv.MakePrimitiveRecord(BlindingOverrideOnionType, point)
+}
+
+// PaymentRelay is a tlv.Record which defines the payment_relay
+// (type 10) for a route blinding payload.
+type PaymentRelay struct {
+	CltvExpiryDelta uint16
+	FeeRate         uint32
+	// NOTE(8/6/22): Is this in satoshis or msat?
+	// This has implications for fee computation.
+	BaseFee uint32
+}
+
+// satisfies the tlv.RecordProducer interface
+// TODO(9/7/22): check length functions.
+func (p *PaymentRelay) Record() tlv.Record {
+	return tlv.MakeDynamicRecord(PaymentRelayOnionType,
+		p, func() uint64 { return uint64(2 + 4 + 4) },
+		paymentRelayEncoder, paymentRelayDecoder,
+	)
+}
+
+func paymentRelayEncoder(w io.Writer, val interface{}, buf *[8]byte) error {
+	if v, ok := val.(*PaymentRelay); ok {
+		if err := tlv.EUint32(w, &v.BaseFee, buf); err != nil {
+			return err
+		}
+
+		if err := tlv.EUint32(w, &v.FeeRate, buf); err != nil {
+			return err
+		}
+
+		if err := tlv.EUint16(w, &v.CltvExpiryDelta, buf); err != nil {
+			return err
+		}
+
+		return nil
+	}
+
+	return tlv.NewTypeForEncodingErr(val, "routeblinding.PaymentRelay")
+}
+
+func paymentRelayDecoder(r io.Reader, val interface{}, buf *[8]byte, l uint64) error {
+	if v, ok := val.(*PaymentRelay); ok {
+		if err := tlv.DUint32(r, &v.BaseFee, buf, 4); err != nil {
+			return err
+		}
+
+		if err := tlv.DUint32(r, &v.FeeRate, buf, 4); err != nil {
+			return err
+		}
+
+		if err := tlv.DUint16(r, &v.CltvExpiryDelta, buf, 2); err != nil {
+			return err
+		}
+
+		return nil
+	}
+
+	return tlv.NewTypeForDecodingErr(val, "routeblinding.PaymentRelay", l, 10)
+}
+
+// PaymentConstraints is a tlv.Record which defines the payment_constraints
+// (type 12) for a route blinding payload.
+type PaymentConstraints struct {
+	MaxCltvExpiryDelta uint32
+	HtlcMinimumMsat    uint64
+	AllowedFeatures    []byte
+}
+
+func (p *PaymentConstraints) Record() tlv.Record {
+	return tlv.MakeDynamicRecord(PaymentConstraintsOnionType,
+		p, func() uint64 { return uint64(4 + 8 + len(p.AllowedFeatures)) },
+		paymentConstraintsEncoder, paymentConstraintsDecoder,
+	)
+}
+
+func paymentConstraintsEncoder(w io.Writer, val interface{}, buf *[8]byte) error {
+	if v, ok := val.(*PaymentConstraints); ok {
+		if err := tlv.EUint32(w, &v.MaxCltvExpiryDelta, buf); err != nil {
+			return err
+		}
+
+		if err := tlv.EUint64(w, &v.HtlcMinimumMsat, buf); err != nil {
+			return err
+		}
+
+		if err := tlv.EVarBytes(w, &v.AllowedFeatures, buf); err != nil {
+			return err
+		}
+
+		return nil
+	}
+
+	return tlv.NewTypeForEncodingErr(val, "routeblinding.PaymentConstraints")
+}
+
+func paymentConstraintsDecoder(r io.Reader, val interface{}, buf *[8]byte, l uint64) error {
+	if v, ok := val.(*PaymentConstraints); ok {
+		if err := tlv.DUint32(r, &v.MaxCltvExpiryDelta, buf, 4); err != nil {
+			return err
+		}
+
+		if err := tlv.DUint64(r, &v.HtlcMinimumMsat, buf, 8); err != nil {
+			return err
+		}
+
+		if err := tlv.DVarBytes(r, &v.AllowedFeatures, buf, 0); err != nil {
+			return err
+		}
+
+		return nil
+	}
+
+	return tlv.NewTypeForDecodingErr(val, "routeblinding.PaymentRelay", l, 10)
+}
+
+// NewAllowedFeaturesRecord creates a tlv.Record that encodes the
+// features permitted for use during forwarding inside a blinded route
+// allowed features (type 14) for route blinding payload.
+func NewAllowedFeaturesRecord(features *[]byte) tlv.Record {
+	return tlv.MakePrimitiveRecord(AllowedFeaturesOnionType, features)
+}

--- a/record/hop.go
+++ b/record/hop.go
@@ -1,6 +1,7 @@
 package record
 
 import (
+	"github.com/btcsuite/btcd/btcec/v2"
 	"github.com/lightningnetwork/lnd/tlv"
 )
 
@@ -17,9 +18,34 @@ const (
 	// of the next hop.
 	NextHopOnionType tlv.Type = 6
 
+	// RouteBlindingEncryptedDataOnionType refers to an encrypted route
+	// blinding TLV payload which contains information needed to forward
+	// in the blinded portion of a route.
+	RouteBlindingEncryptedDataOnionType tlv.Type = 10
+
+	// BlindingPointOnionType is the type used in the top level onion
+	// payload to reference an ephemeral public key which is used to
+	// establish a shared secret between a processing node in the
+	// blinded portion of a route and the node which built the blinded
+	// route (usually the recipient). The shared secret can then be used
+	// for the purpose of decrypting the route blinding payload.
+	//
+	// NOTE: The ephemeral blinding point is delivered in the onion payload
+	// for the first hop ("introduction node") of a blinded route ONLY!
+	// Other processing nodes in a blinded route receive their blinding
+	// point via TLV extension in the UpdateAddHTLC message.
+	BlindingPointOnionType tlv.Type = 12
+
 	// MetadataOnionType is the type used in the onion for the payment
 	// metadata.
 	MetadataOnionType tlv.Type = 16
+
+	// TotalAmountMsatOnionType is the type used in the onion for
+	// the total value of the payment and is intended for use with
+	// the final hop in a route only.
+	// TODO(9/11/22): Determine if this is needed or if we can use the
+	// similar sounding field available on MPP.
+	TotalAmountMsatOnionType tlv.Type = 18
 )
 
 // NewAmtToFwdRecord creates a tlv.Record that encodes the amount_to_forward
@@ -50,7 +76,19 @@ func NewNextHopIDRecord(cid *uint64) tlv.Record {
 	return tlv.MakePrimitiveRecord(NextHopOnionType, cid)
 }
 
-// NewMetadataRecord creates a tlv.Record that encodes the metadata (type 10)
+// NewRouteBlindingEncryptedDataRecord creates a tlv.Record that encodes the
+// encrypted_recipient_data (type 10) for an onion payload.
+func NewRouteBlindingEncryptedDataRecord(data *[]byte) tlv.Record {
+	return tlv.MakePrimitiveRecord(RouteBlindingEncryptedDataOnionType, data)
+}
+
+// NewBlindingPointRecord creates a tlv.Record that encodes the blinding_point
+// (type 12) for an onion payload.
+func NewBlindingPointRecord(key **btcec.PublicKey) tlv.Record {
+	return tlv.MakePrimitiveRecord(BlindingPointOnionType, key)
+}
+
+// NewMetadataRecord creates a tlv.Record that encodes the metadata (type 16)
 // for an onion payload.
 func NewMetadataRecord(metadata *[]byte) tlv.Record {
 	return tlv.MakeDynamicRecord(
@@ -59,5 +97,17 @@ func NewMetadataRecord(metadata *[]byte) tlv.Record {
 			return uint64(len(*metadata))
 		},
 		tlv.EVarBytes, tlv.DVarBytes,
+	)
+}
+
+// NewTotalAmountMsatRecord creates a tlv.Record that encodes the
+// total payment amount in millisatoshis, total_amount_msat,
+// (type 18) for an onion payload.
+func NewTotalAmountMsatRecord(amt *uint64) tlv.Record {
+	return tlv.MakeDynamicRecord(
+		TotalAmountMsatOnionType, amt, func() uint64 {
+			return tlv.SizeTUint64(*amt)
+		},
+		tlv.ETUint64, tlv.DTUint64,
 	)
 }

--- a/record/record_test.go
+++ b/record/record_test.go
@@ -22,6 +22,13 @@ var (
 	testShare      = [32]byte{0x03, 0x04}
 	testSetID      = [32]byte{0x05, 0x06}
 	testChildIndex = uint32(17)
+
+	testBaseFee    uint32 = 100
+	testFeeRate    uint32 = 100
+	testCltvExpiry uint16 = 100
+
+	testMinimumHtlc   uint64 = 1
+	testMaxCltvExpiry uint32 = uint32(testCltvExpiry)
 )
 
 var recordEncDecTests = []recordEncDecTest{
@@ -64,6 +71,56 @@ var recordEncDecTests = []recordEncDecTest{
 			if amp.ChildIndex() != testChildIndex {
 				t.Fatal("incorrect child index")
 			}
+		},
+	},
+	{
+		name: "route blinding payment relay",
+		encRecord: func() tlv.RecordProducer {
+			return &record.PaymentRelay{
+				BaseFee:         testBaseFee,
+				FeeRate:         testFeeRate,
+				CltvExpiryDelta: testCltvExpiry,
+			}
+		},
+		decRecord: func() tlv.RecordProducer {
+			return new(record.PaymentRelay)
+		},
+		assert: func(t *testing.T, r interface{}) {
+			paymentRelay := r.(*record.PaymentRelay)
+			if paymentRelay.BaseFee != testBaseFee {
+				t.Fatal("incorrect base fee")
+			}
+			if paymentRelay.FeeRate != testFeeRate {
+				t.Fatal("incorrect fee rate")
+			}
+			if paymentRelay.CltvExpiryDelta != testCltvExpiry {
+				t.Fatal("incorrect cltv expiry")
+			}
+		},
+	},
+	{
+		name: "route blinding payment constraints",
+		encRecord: func() tlv.RecordProducer {
+			return &record.PaymentConstraints{
+				MaxCltvExpiryDelta: testMaxCltvExpiry,
+				HtlcMinimumMsat:    testMinimumHtlc,
+				// AllowedFeatures:    []byte{},
+			}
+		},
+		decRecord: func() tlv.RecordProducer {
+			return new(record.PaymentConstraints)
+		},
+		assert: func(t *testing.T, r interface{}) {
+			payConstraints := r.(*record.PaymentConstraints)
+			if payConstraints.MaxCltvExpiryDelta != testMaxCltvExpiry {
+				t.Fatal("incorrect blinded route expiry")
+			}
+			if payConstraints.HtlcMinimumMsat != testMinimumHtlc {
+				t.Fatal("incorrect minimum htlc")
+			}
+			// if bytes.Equal(payConstraints.AllowedFeatures, []byte{}) {
+			// 	t.Fatal("incorrect allowed features: ", payConstraints.AllowedFeatures)
+			// }
 		},
 	},
 }

--- a/sample-lnd.conf
+++ b/sample-lnd.conf
@@ -1192,6 +1192,9 @@ litecoin.node=ltcd
 ; option-scid-alias flag to also be set.
 ; protocol.zero-conf=true
 
+; Set to enable support for route blinding.
+; protocol.route-blinding=true
+
 ; Set to disable support for using P2TR addresses (and beyond) for co-op
 ; closing.
 ; protocol.no-any-segwit

--- a/server.go
+++ b/server.go
@@ -540,6 +540,7 @@ func newServer(cfg *Config, listenAddrs []net.Addr,
 		NoKeysend:                !cfg.AcceptKeySend,
 		NoOptionScidAlias:        !cfg.ProtocolOptions.ScidAlias(),
 		NoZeroConf:               !cfg.ProtocolOptions.ZeroConf(),
+		RouteBlinding:            cfg.ProtocolOptions.RouteBlinding(),
 		NoAnySegwit:              cfg.ProtocolOptions.NoAnySegwit(),
 	})
 	if err != nil {
@@ -665,6 +666,9 @@ func newServer(cfg *Config, listenAddrs []net.Addr,
 		DustThreshold:          thresholdMSats,
 		SignAliasUpdate:        s.signAliasUpdate,
 		IsAlias:                aliasmgr.IsAlias,
+		// If route blinding is enabled, we'll configure the htlcswitch
+		// so the links we create are ready to process blinded hops.
+		RouteBlindingEnabled: cfg.ProtocolOptions.RouteBlinding(),
 	}, uint32(currentHeight))
 	if err != nil {
 		return nil, err

--- a/server.go
+++ b/server.go
@@ -506,6 +506,9 @@ func newServer(cfg *Config, listenAddrs []net.Addr,
 	replayLog := htlcswitch.NewDecayedLog(
 		dbs.DecayedLogDB, cc.ChainNotifier,
 	)
+
+	// Configure our sphinx onion packet router with
+	// our node's key pair (p, P).
 	sphinxRouter := sphinx.NewRouter(
 		nodeKeyECDH, cfg.ActiveNetParams.Params, replayLog,
 	)
@@ -3697,6 +3700,7 @@ func (s *server) peerConnected(conn net.Conn, connReq *connmgr.ConnReq,
 		WritePool:               s.writePool,
 		ReadPool:                s.readPool,
 		Switch:                  s.htlcSwitch,
+		NodeKeyECDH:             s.identityECDH, // Need access to nodeID private key (either directly or via abstraction) in order to process onions for hops in a blinded route.
 		InterceptSwitch:         s.interceptableSwitch,
 		ChannelDB:               s.chanStateDB,
 		ChannelGraph:            s.graphDB,


### PR DESCRIPTION
This (definitely draft) PR equips the `ChannelLink` to process HTLCs inside a blinded route. The bulk of the processing for blind hops in done by the *incoming* link (ie: the link on which the HTLC ADD arrives). The incoming link will: 
- Decrypt the onion using the ephemeral (route) blinding point if it is available on the *UpdateAddHTLC* TLV extension.
- Decrypt the route blinding payload and provide the forwarding information therein to the Switch.
- Compute the ephemeral (route) blinding point the next hop in the route will need to decrypt the onion and include that as a TLV extension to the *UpdateAddHTLC* message.

The *outgoing* link simply needs to forward the *UpdateAddHTLC* message it is given by the Switch. Everything will have been assembled for successful forwarding by the incoming link.

TODO: Several branches are still far too dirty to post publicly. Clean up branches for following:
- this branch
    - Consider more deeply the HTLC update retransmission (in-memory and from disk) code path & error handling.
- Route Blinding [2/n]: Dummy Hop Processing
    - May require some modifications to the HTLC Switch/Link (possibly channel state machine?) so that onions can be reprocessed.
- Route Blinding [3/n]: Blind Path Creation/Build Blind Route RPC
- Route Blinding [4/n]: Introduction Node and Blind Path Selection
    -  In attempting to define optimality and automate the discovery of a particular introduction node and blinded path, one reaches the point where the rubber seemingly really meets the road. 

### Comments
As of now this PR punts on dummy hop processing, integrating blinded routes with invoices, an algorithm for selecting the introduction node, and automated blinded route pathfinding. With this PR alone, LND won't be able to create or receive payment over a blinded route just yet, but it *will* be available for others to use while building blinded routes. Last I heard, a large portion of nodes on the network run LND, so even this modest start to an implementation could provide a boon to anonymity set sizes.

I tried to split things up such that the things I left out would not, if considered, fundamentally change the approach, though lacking a complete knowledge of BOLT-12 or Trampoline Routing, it is very possible that I did not succeed in this. 

The [route-blinding spec]() is still a living document, so I may be behind on some of the recent updates, particularly those on error handling. There is also a fair bit of cleanup left to do - far more than I would like for posting this at present - but after reading [this](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#share-early-share-often), I wanted to get this up sooner and get some information on where Lightning Labs is at in this area before spending too much more time deep in the weeds. 

## Steps to Test
- Took a stab at some automated tests at the `htlcswitch` package level.
    - go test -v -run ^TestChannelLinkBlindedPathPayment$ github.com/lightningnetwork/lnd/htlcswitch --tags=dev
- Have a local branch with an `itest` level which sets up a linear network `Alice <---> Bob <---> Carol <---> Dave`, creates a blinded route via RPC, concatenates the route to a normal `route.Route{}` and then verifies that payment can be sent successfully. Can post once it's a bit cleaner.
- TODO(11/20/22): Deploy a sim-net on Polar to test interoperability with other implementations: Use eclair or a further modified LND (which includes ability to build basic blinded routes) to generate a blinded route which routes across eclair/LND nodes, and see if the payment succeeds!

## Pull Request Checklist
### Testing
- [ ] Your PR passes all CI checks.
- [ ] Tests covering the positive and negative (error paths) are included.
- [ ] Bug fixes contain tests triggering the bug to prevent regressions.

### Code Style and Documentation
- [ ] The change obeys the [Code Documentation and Commenting](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#CodeDocumentation) guidelines, and lines wrap at 80.
- [ ] Commits follow the [Ideal Git Commit Structure](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#IdealGitCommitStructure).
- [ ] Any new logging statements use an appropriate subsystem and logging level.
- [ ]  [There is a change description in the release notes](https://github.com/lightningnetwork/lnd/tree/master/docs/release-notes), or `[skip ci]` in the commit message for small changes.

📝 Please see our  [Contribution Guidelines](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md) for further guidance.