### PR TITLE
lncfg: fix gossip.pinned-syncers flag description

### DIFF
--- a/docs/release-notes/release-notes-0.16.0.md
+++ b/docs/release-notes/release-notes-0.16.0.md
@@ -143,7 +143,13 @@ certain large transactions](https://github.com/lightningnetwork/lnd/pull/7100).
 * [Added missing wire tests for Warning
   message](https://github.com/lightningnetwork/lnd/pull/7143).
 
+* [The description for the `--gossip.pinned-syncers` flag was fixed to explain
+  that multiple peers can be specified by using the flag multiple times instead
+  of using a comma separated list of
+  values](https://github.com/lightningnetwork/lnd/pull/7207).
+
 ## `lncli`
+
 * [Add an `insecure` flag to skip tls auth as well as a `metadata` string slice
   flag](https://github.com/lightningnetwork/lnd/pull/6818) that allows the
   caller to specify key-value string pairs that should be appended to the

--- a/lncfg/gossip.go
+++ b/lncfg/gossip.go
@@ -9,7 +9,7 @@ import (
 
 //nolint:lll
 type Gossip struct {
-	PinnedSyncersRaw []string `long:"pinned-syncers" description:"A set of peers that should always remain in an active sync state, which can be used to closely synchronize the routing tables of two nodes. The value should be comma separated list of hex-encoded pubkeys. Connected peers matching this pubkey will remain active for the duration of the connection and not count towards the NumActiveSyncer count."`
+	PinnedSyncersRaw []string `long:"pinned-syncers" description:"A set of peers that should always remain in an active sync state, which can be used to closely synchronize the routing tables of two nodes. The value should be a hex-encoded pubkey, the flag can be specified multiple times to add multiple peers. Connected peers matching this pubkey will remain active for the duration of the connection and not count towards the NumActiveSyncer count."`
 
 	PinnedSyncers discovery.PinnedSyncers
 


### PR DESCRIPTION
Fixes https://github.com/lightningnetwork/lnd/issues/7205.

The gossip.pinned-syncers flag is declared as a string slice which means
it should not be a comma separated list of elements but the flag should
be specified multiple times instead.