### PR TITLE
release: bump version to v0.15.5-beta

### DIFF
--- a/build/version.go
+++ b/build/version.go
@@ -48,7 +48,7 @@ const (
 
 	// AppPreRelease MUST only contain characters from semanticAlphabet
 	// per the semantic versioning spec.
-	AppPreRelease = "beta.rc2"
+	AppPreRelease = "beta"
 )
 
 func init() {


### PR DESCRIPTION
Two release candidates later, I think we're ready to drop the final release of the year! 