### PR TITLE
Invoices: invert package dependency with `channeldb`

### DIFF
--- a/chainntnfs/bitcoindnotify/bitcoind_test.go
+++ b/chainntnfs/bitcoindnotify/bitcoind_test.go
@@ -31,7 +31,7 @@ var (
 	}
 )
 
-func initHintCache(t *testing.T) *chainntnfs.HeightHintCache {
+func initHintCache(t *testing.T) *channeldb.HeightHintCache {
 	t.Helper()
 
 	db, err := channeldb.Open(t.TempDir())
@@ -40,10 +40,10 @@ func initHintCache(t *testing.T) *chainntnfs.HeightHintCache {
 		require.NoError(t, db.Close())
 	})
 
-	testCfg := chainntnfs.CacheConfig{
+	testCfg := channeldb.CacheConfig{
 		QueryDisable: false,
 	}
-	hintCache, err := chainntnfs.NewHeightHintCache(testCfg, db.Backend)
+	hintCache, err := channeldb.NewHeightHintCache(testCfg, db.Backend)
 	require.NoError(t, err, "unable to create hint cache")
 
 	return hintCache

--- a/chainntnfs/btcdnotify/btcd_test.go
+++ b/chainntnfs/btcdnotify/btcd_test.go
@@ -29,7 +29,7 @@ var (
 	}
 )
 
-func initHintCache(t *testing.T) *chainntnfs.HeightHintCache {
+func initHintCache(t *testing.T) *channeldb.HeightHintCache {
 	t.Helper()
 
 	db, err := channeldb.Open(t.TempDir())
@@ -38,10 +38,10 @@ func initHintCache(t *testing.T) *chainntnfs.HeightHintCache {
 		require.NoError(t, db.Close())
 	})
 
-	testCfg := chainntnfs.CacheConfig{
+	testCfg := channeldb.CacheConfig{
 		QueryDisable: false,
 	}
-	hintCache, err := chainntnfs.NewHeightHintCache(testCfg, db.Backend)
+	hintCache, err := channeldb.NewHeightHintCache(testCfg, db.Backend)
 	require.NoError(t, err, "unable to create hint cache")
 
 	return hintCache

--- a/chainntnfs/errors.go
+++ b/chainntnfs/errors.go
@@ -1,0 +1,18 @@
+package chainntnfs
+
+import "errors"
+
+var (
+	// ErrCorruptedHeightHintCache indicates that the on-disk representation
+	// has altered since the height hint cache instance was initialized.
+	ErrCorruptedHeightHintCache = errors.New("height hint cache has been " +
+		"corrupted")
+
+	// ErrSpendHintNotFound is an error returned when a spend hint for an
+	// outpoint was not found.
+	ErrSpendHintNotFound = errors.New("spend hint not found")
+
+	// ErrConfirmHintNotFound is an error returned when a confirm hint for a
+	// transaction was not found.
+	ErrConfirmHintNotFound = errors.New("confirm hint not found")
+)

--- a/chainntnfs/interface.go
+++ b/chainntnfs/interface.go
@@ -773,3 +773,38 @@ func ConfDetailsFromTxIndex(chainConn TxIndexConn, r ConfRequest,
 	return nil, TxNotFoundIndex, fmt.Errorf("unable to locate "+
 		"tx %v in block %v", r.TxID, blockHash)
 }
+
+// SpendHintCache is an interface whose duty is to cache spend hints for
+// outpoints. A spend hint is defined as the earliest height in the chain at
+// which an outpoint could have been spent within.
+type SpendHintCache interface {
+	// CommitSpendHint commits a spend hint for the outpoints to the cache.
+	CommitSpendHint(height uint32, spendRequests ...SpendRequest) error
+
+	// QuerySpendHint returns the latest spend hint for an outpoint.
+	// ErrSpendHintNotFound is returned if a spend hint does not exist
+	// within the cache for the outpoint.
+	QuerySpendHint(spendRequest SpendRequest) (uint32, error)
+
+	// PurgeSpendHint removes the spend hint for the outpoints from the
+	// cache.
+	PurgeSpendHint(spendRequests ...SpendRequest) error
+}
+
+// ConfirmHintCache is an interface whose duty is to cache confirm hints for
+// transactions. A confirm hint is defined as the earliest height in the chain
+// at which a transaction could have been included in a block.
+type ConfirmHintCache interface {
+	// CommitConfirmHint commits a confirm hint for the transactions to the
+	// cache.
+	CommitConfirmHint(height uint32, confRequests ...ConfRequest) error
+
+	// QueryConfirmHint returns the latest confirm hint for a transaction
+	// hash. ErrConfirmHintNotFound is returned if a confirm hint does not
+	// exist within the cache for the transaction hash.
+	QueryConfirmHint(confRequest ConfRequest) (uint32, error)
+
+	// PurgeConfirmHint removes the confirm hint for the transactions from
+	// the cache.
+	PurgeConfirmHint(confRequests ...ConfRequest) error
+}

--- a/chainntnfs/test/test_interface.go
+++ b/chainntnfs/test/test_interface.go
@@ -1836,10 +1836,10 @@ func TestInterfaces(t *testing.T, targetBackEnd string) {
 		if err != nil {
 			t.Fatalf("unable to create db: %v", err)
 		}
-		testCfg := chainntnfs.CacheConfig{
+		testCfg := channeldb.CacheConfig{
 			QueryDisable: false,
 		}
-		hintCache, err := chainntnfs.NewHeightHintCache(
+		hintCache, err := channeldb.NewHeightHintCache(
 			testCfg, db.Backend,
 		)
 		if err != nil {

--- a/chainntnfs/txnotifier.go
+++ b/chainntnfs/txnotifier.go
@@ -11,7 +11,6 @@ import (
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcd/txscript"
 	"github.com/btcsuite/btcd/wire"
-	"github.com/lightningnetwork/lnd/channeldb"
 )
 
 const (
@@ -201,21 +200,6 @@ func (r ConfRequest) String() string {
 	return fmt.Sprintf("script=%v", r.PkScript)
 }
 
-// ConfHintKey returns the key that will be used to index the confirmation
-// request's hint within the height hint cache.
-func (r ConfRequest) ConfHintKey() ([]byte, error) {
-	if r.TxID == ZeroHash {
-		return r.PkScript.Script(), nil
-	}
-
-	var txid bytes.Buffer
-	if err := channeldb.WriteElement(&txid, r.TxID); err != nil {
-		return nil, err
-	}
-
-	return txid.Bytes(), nil
-}
-
 // MatchesTx determines whether the given transaction satisfies the confirmation
 // request. If the confirmation request is for a script, then we'll check all of
 // the outputs of the transaction to determine if it matches. Otherwise, we'll
@@ -367,22 +351,6 @@ func (r SpendRequest) String() string {
 			r.PkScript)
 	}
 	return fmt.Sprintf("outpoint=<zero>, script=%v", r.PkScript)
-}
-
-// SpendHintKey returns the key that will be used to index the spend request's
-// hint within the height hint cache.
-func (r SpendRequest) SpendHintKey() ([]byte, error) {
-	if r.OutPoint == ZeroOutPoint {
-		return r.PkScript.Script(), nil
-	}
-
-	var outpoint bytes.Buffer
-	err := channeldb.WriteElement(&outpoint, r.OutPoint)
-	if err != nil {
-		return nil, err
-	}
-
-	return outpoint.Bytes(), nil
 }
 
 // MatchesTx determines whether the given transaction satisfies the spend

--- a/chainreg/chainregistry.go
+++ b/chainreg/chainregistry.go
@@ -292,7 +292,7 @@ func NewPartialChainControl(cfg *Config) (*PartialChainControl, func(), error) {
 	}
 
 	var err error
-	heightHintCacheConfig := chainntnfs.CacheConfig{
+	heightHintCacheConfig := channeldb.CacheConfig{
 		QueryDisable: cfg.HeightHintCacheQueryDisable,
 	}
 	if cfg.HeightHintCacheQueryDisable {
@@ -300,7 +300,7 @@ func NewPartialChainControl(cfg *Config) (*PartialChainControl, func(), error) {
 	}
 
 	// Initialize the height hint cache within the chain directory.
-	hintCache, err := chainntnfs.NewHeightHintCache(
+	hintCache, err := channeldb.NewHeightHintCache(
 		heightHintCacheConfig, cfg.HeightHintDB,
 	)
 	if err != nil {

--- a/channeldb/channel_test.go
+++ b/channeldb/channel_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/btcsuite/btcd/wire"
 	_ "github.com/btcsuite/btcwallet/walletdb/bdb"
 	"github.com/davecgh/go-spew/spew"
+	"github.com/lightningnetwork/lnd/channeldb/models"
 	"github.com/lightningnetwork/lnd/clock"
 	"github.com/lightningnetwork/lnd/keychain"
 	"github.com/lightningnetwork/lnd/kvdb"
@@ -716,8 +717,8 @@ func TestChannelStateTransition(t *testing.T) {
 				},
 			},
 		},
-		OpenedCircuitKeys: []CircuitKey{},
-		ClosedCircuitKeys: []CircuitKey{},
+		OpenedCircuitKeys: []models.CircuitKey{},
+		ClosedCircuitKeys: []models.CircuitKey{},
 	}
 	copy(commitDiff.LogUpdates[0].UpdateMsg.(*lnwire.UpdateAddHTLC).PaymentHash[:],
 		bytes.Repeat([]byte{1}, 32))

--- a/channeldb/error.go
+++ b/channeldb/error.go
@@ -31,30 +31,6 @@ var (
 	// created.
 	ErrNoPastDeltas = fmt.Errorf("channel has no recorded deltas")
 
-	// ErrInvoiceNotFound is returned when a targeted invoice can't be
-	// found.
-	ErrInvoiceNotFound = fmt.Errorf("unable to locate invoice")
-
-	// ErrNoInvoicesCreated is returned when we don't have invoices in
-	// our database to return.
-	ErrNoInvoicesCreated = fmt.Errorf("there are no existing invoices")
-
-	// ErrDuplicateInvoice is returned when an invoice with the target
-	// payment hash already exists.
-	ErrDuplicateInvoice = fmt.Errorf("invoice with payment hash already exists")
-
-	// ErrDuplicatePayAddr is returned when an invoice with the target
-	// payment addr already exists.
-	ErrDuplicatePayAddr = fmt.Errorf("invoice with payemnt addr already exists")
-
-	// ErrInvRefEquivocation is returned when an InvoiceRef targets
-	// multiple, distinct invoices.
-	ErrInvRefEquivocation = errors.New("inv ref matches multiple invoices")
-
-	// ErrNoPaymentsCreated is returned when bucket of payments hasn't been
-	// created.
-	ErrNoPaymentsCreated = fmt.Errorf("there are no existing payments")
-
 	// ErrNodeNotFound is returned when node bucket exists, but node with
 	// specific identity can't be found.
 	ErrNodeNotFound = fmt.Errorf("link node with target identity not found")

--- a/channeldb/height_hint_test.go
+++ b/channeldb/height_hint_test.go
@@ -1,4 +1,4 @@
-package chainntnfs
+package channeldb
 
 import (
 	"bytes"
@@ -6,7 +6,7 @@ import (
 
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcd/wire"
-	"github.com/lightningnetwork/lnd/channeldb"
+	"github.com/lightningnetwork/lnd/chainntnfs"
 	"github.com/stretchr/testify/require"
 )
 
@@ -23,7 +23,7 @@ func initHintCache(t *testing.T) *HeightHintCache {
 func initHintCacheWithConfig(t *testing.T, cfg CacheConfig) *HeightHintCache {
 	t.Helper()
 
-	db, err := channeldb.Open(t.TempDir())
+	db, err := Open(t.TempDir())
 	require.NoError(t, err, "unable to create db")
 	hintCache, err := NewHeightHintCache(cfg, db.Backend)
 	require.NoError(t, err, "unable to create hint cache")
@@ -46,21 +46,19 @@ func TestHeightHintCacheConfirms(t *testing.T) {
 	// return an error indication so.
 	var unknownHash chainhash.Hash
 	copy(unknownHash[:], bytes.Repeat([]byte{0x01}, 32))
-	unknownConfRequest := ConfRequest{TxID: unknownHash}
+	unknownConfRequest := chainntnfs.ConfRequest{TxID: unknownHash}
 	_, err := hintCache.QueryConfirmHint(unknownConfRequest)
-	if err != ErrConfirmHintNotFound {
-		t.Fatalf("expected ErrConfirmHintNotFound, got: %v", err)
-	}
+	require.ErrorIs(t, err, chainntnfs.ErrConfirmHintNotFound)
 
 	// Now, we'll create some transaction hashes and commit them to the
 	// cache with the same confirm hint.
 	const height = 100
 	const numHashes = 5
-	confRequests := make([]ConfRequest, numHashes)
+	confRequests := make([]chainntnfs.ConfRequest, numHashes)
 	for i := 0; i < numHashes; i++ {
 		var txHash chainhash.Hash
 		copy(txHash[:], bytes.Repeat([]byte{byte(i + 1)}, 32))
-		confRequests[i] = ConfRequest{TxID: txHash}
+		confRequests[i] = chainntnfs.ConfRequest{TxID: txHash}
 	}
 
 	err = hintCache.CommitConfirmHint(height, confRequests...)
@@ -70,28 +68,20 @@ func TestHeightHintCacheConfirms(t *testing.T) {
 	// we're able to properly retrieve the confirm hints.
 	for _, confRequest := range confRequests {
 		confirmHint, err := hintCache.QueryConfirmHint(confRequest)
-		if err != nil {
-			t.Fatalf("unable to query for hint of %v: %v", confRequest, err)
-		}
-		if confirmHint != height {
-			t.Fatalf("expected confirm hint %d, got %d", height,
-				confirmHint)
-		}
+		require.NoError(t, err)
+		require.EqualValues(t, height, confirmHint)
 	}
 
 	// We'll also attempt to purge all of them in a single database
 	// transaction.
-	if err := hintCache.PurgeConfirmHint(confRequests...); err != nil {
-		t.Fatalf("unable to remove confirm hints: %v", err)
-	}
+	err = hintCache.PurgeConfirmHint(confRequests...)
+	require.NoError(t, err)
 
 	// Finally, we'll attempt to query for each hash. We should expect not
 	// to find a hint for any of them.
 	for _, confRequest := range confRequests {
 		_, err := hintCache.QueryConfirmHint(confRequest)
-		if err != ErrConfirmHintNotFound {
-			t.Fatalf("expected ErrConfirmHintNotFound, got :%v", err)
-		}
+		require.ErrorIs(t, err, chainntnfs.ErrConfirmHintNotFound)
 	}
 }
 
@@ -105,19 +95,19 @@ func TestHeightHintCacheSpends(t *testing.T) {
 	// Querying for an outpoint not found within the cache should return an
 	// error indication so.
 	unknownOutPoint := wire.OutPoint{Index: 1}
-	unknownSpendRequest := SpendRequest{OutPoint: unknownOutPoint}
-	_, err := hintCache.QuerySpendHint(unknownSpendRequest)
-	if err != ErrSpendHintNotFound {
-		t.Fatalf("expected ErrSpendHintNotFound, got: %v", err)
+	unknownSpendRequest := chainntnfs.SpendRequest{
+		OutPoint: unknownOutPoint,
 	}
+	_, err := hintCache.QuerySpendHint(unknownSpendRequest)
+	require.ErrorIs(t, err, chainntnfs.ErrSpendHintNotFound)
 
 	// Now, we'll create some outpoints and commit them to the cache with
 	// the same spend hint.
 	const height = 100
 	const numOutpoints = 5
-	spendRequests := make([]SpendRequest, numOutpoints)
+	spendRequests := make([]chainntnfs.SpendRequest, numOutpoints)
 	for i := uint32(0); i < numOutpoints; i++ {
-		spendRequests[i] = SpendRequest{
+		spendRequests[i] = chainntnfs.SpendRequest{
 			OutPoint: wire.OutPoint{Index: i + 1},
 		}
 	}
@@ -129,28 +119,20 @@ func TestHeightHintCacheSpends(t *testing.T) {
 	// that we're able to properly retrieve the confirm hints.
 	for _, spendRequest := range spendRequests {
 		spendHint, err := hintCache.QuerySpendHint(spendRequest)
-		if err != nil {
-			t.Fatalf("unable to query for hint: %v", err)
-		}
-		if spendHint != height {
-			t.Fatalf("expected spend hint %d, got %d", height,
-				spendHint)
-		}
+		require.NoError(t, err)
+		require.EqualValues(t, height, spendHint)
 	}
 
 	// We'll also attempt to purge all of them in a single database
 	// transaction.
-	if err := hintCache.PurgeSpendHint(spendRequests...); err != nil {
-		t.Fatalf("unable to remove spend hint: %v", err)
-	}
+	err = hintCache.PurgeSpendHint(spendRequests...)
+	require.NoError(t, err)
 
 	// Finally, we'll attempt to query for each outpoint. We should expect
 	// not to find a hint for any of them.
 	for _, spendRequest := range spendRequests {
 		_, err = hintCache.QuerySpendHint(spendRequest)
-		if err != ErrSpendHintNotFound {
-			t.Fatalf("expected ErrSpendHintNotFound, got: %v", err)
-		}
+		require.ErrorIs(t, err, chainntnfs.ErrSpendHintNotFound)
 	}
 }
 
@@ -165,7 +147,7 @@ func TestQueryDisable(t *testing.T) {
 
 	// Insert a new confirmation hint with a non-zero height.
 	const confHeight = 100
-	confRequest := ConfRequest{
+	confRequest := chainntnfs.ConfRequest{
 		TxID: chainhash.Hash{0x01, 0x02, 0x03},
 	}
 	err := hintCache.CommitConfirmHint(confHeight, confRequest)
@@ -178,7 +160,7 @@ func TestQueryDisable(t *testing.T) {
 
 	// Insert a new spend hint with a non-zero height.
 	const spendHeight = 200
-	spendRequest := SpendRequest{
+	spendRequest := chainntnfs.SpendRequest{
 		OutPoint: wire.OutPoint{
 			Hash:  chainhash.Hash{0x4, 0x05, 0x06},
 			Index: 42,

--- a/channeldb/invoice_test.go
+++ b/channeldb/invoice_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/lightningnetwork/lnd/channeldb/models"
 	"github.com/lightningnetwork/lnd/clock"
 	"github.com/lightningnetwork/lnd/feature"
+	invpkg "github.com/lightningnetwork/lnd/invoices"
 	"github.com/lightningnetwork/lnd/lntypes"
 	"github.com/lightningnetwork/lnd/lnwire"
 	"github.com/lightningnetwork/lnd/record"
@@ -31,7 +32,7 @@ var (
 	testNow = time.Unix(1, 0)
 )
 
-func randInvoice(value lnwire.MilliSatoshi) (*Invoice, error) {
+func randInvoice(value lnwire.MilliSatoshi) (*invpkg.Invoice, error) {
 	var (
 		pre     lntypes.Preimage
 		payAddr [32]byte
@@ -43,24 +44,24 @@ func randInvoice(value lnwire.MilliSatoshi) (*Invoice, error) {
 		return nil, err
 	}
 
-	i := &Invoice{
+	i := &invpkg.Invoice{
 		CreationDate: testNow,
-		Terms: ContractTerm{
+		Terms: invpkg.ContractTerm{
 			Expiry:          4000,
 			PaymentPreimage: &pre,
 			PaymentAddr:     payAddr,
 			Value:           value,
 			Features:        emptyFeatures,
 		},
-		Htlcs:    map[models.CircuitKey]*InvoiceHTLC{},
-		AMPState: map[SetID]InvoiceStateAMP{},
+		Htlcs:    map[models.CircuitKey]*invpkg.InvoiceHTLC{},
+		AMPState: map[invpkg.SetID]invpkg.InvoiceStateAMP{},
 	}
 	i.Memo = []byte("memo")
 
 	// Create a random byte slice of MaxPaymentRequestSize bytes to be used
 	// as a dummy paymentrequest, and  determine if it should be set based
 	// on one of the random bytes.
-	var r [MaxPaymentRequestSize]byte
+	var r [invpkg.MaxPaymentRequestSize]byte
 	if _, err := rand.Read(r[:]); err != nil {
 		return nil, err
 	}
@@ -74,15 +75,15 @@ func randInvoice(value lnwire.MilliSatoshi) (*Invoice, error) {
 }
 
 // settleTestInvoice settles a test invoice.
-func settleTestInvoice(invoice *Invoice, settleIndex uint64) {
+func settleTestInvoice(invoice *invpkg.Invoice, settleIndex uint64) {
 	invoice.SettleDate = testNow
 	invoice.AmtPaid = invoice.Terms.Value
-	invoice.State = ContractSettled
-	invoice.Htlcs[models.CircuitKey{}] = &InvoiceHTLC{
+	invoice.State = invpkg.ContractSettled
+	invoice.Htlcs[models.CircuitKey{}] = &invpkg.InvoiceHTLC{
 		Amt:           invoice.Terms.Value,
 		AcceptTime:    testNow,
 		ResolveTime:   testNow,
-		State:         HtlcStateSettled,
+		State:         invpkg.HtlcStateSettled,
 		CustomRecords: make(record.CustomSet),
 	}
 	invoice.SettleIndex = settleIndex
@@ -91,23 +92,23 @@ func settleTestInvoice(invoice *Invoice, settleIndex uint64) {
 // Tests that pending invoices are those which are either in ContractOpen or
 // in ContractAccepted state.
 func TestInvoiceIsPending(t *testing.T) {
-	contractStates := []ContractState{
-		ContractOpen, ContractSettled, ContractCanceled, ContractAccepted,
+	contractStates := []invpkg.ContractState{
+		invpkg.ContractOpen, invpkg.ContractSettled,
+		invpkg.ContractCanceled, invpkg.ContractAccepted,
 	}
 
 	for _, state := range contractStates {
-		invoice := Invoice{
+		invoice := invpkg.Invoice{
 			State: state,
 		}
 
-		// We expect that an invoice is pending if it's either in ContractOpen
-		// or ContractAccepted state.
-		pending := (state == ContractOpen || state == ContractAccepted)
+		// We expect that an invoice is pending if it's either in
+		// ContractOpen or ContractAccepted state.
+		open := invpkg.ContractOpen
+		accepted := invpkg.ContractAccepted
+		pending := (state == open || state == accepted)
 
-		if invoice.IsPending() != pending {
-			t.Fatalf("expected pending: %v, got: %v, invoice: %v",
-				pending, invoice.IsPending(), invoice)
-		}
+		require.Equal(t, pending, invoice.IsPending())
 	}
 }
 
@@ -164,16 +165,16 @@ func testInvoiceWorkflow(t *testing.T, test invWorkflowTest) {
 	var (
 		payHash lntypes.Hash
 		payAddr *[32]byte
-		ref     InvoiceRef
+		ref     invpkg.InvoiceRef
 	)
 	switch {
 	case test.queryPayHash && test.queryPayAddr:
 		payHash = invPayHash
 		payAddr = &fakeInvoice.Terms.PaymentAddr
-		ref = InvoiceRefByHashAndAddr(payHash, *payAddr)
+		ref = invpkg.InvoiceRefByHashAndAddr(payHash, *payAddr)
 	case test.queryPayHash:
 		payHash = invPayHash
-		ref = InvoiceRefByHash(payHash)
+		ref = invpkg.InvoiceRefByHash(payHash)
 	}
 
 	// Add the invoice to the database, this should succeed as there aren't
@@ -188,9 +189,7 @@ func testInvoiceWorkflow(t *testing.T, test invWorkflowTest) {
 	// identical to the one created above.
 	dbInvoice, err := db.LookupInvoice(ref)
 	if !test.queryPayAddr && !test.queryPayHash {
-		if err != ErrInvoiceNotFound {
-			t.Fatalf("invoice should not exist: %v", err)
-		}
+		require.ErrorIs(t, err, invpkg.ErrInvoiceNotFound)
 		return
 	}
 
@@ -215,7 +214,7 @@ func testInvoiceWorkflow(t *testing.T, test invWorkflowTest) {
 	require.NoError(t, err, "unable to settle invoice")
 	dbInvoice2, err := db.LookupInvoice(ref)
 	require.NoError(t, err, "unable to fetch invoice")
-	if dbInvoice2.State != ContractSettled {
+	if dbInvoice2.State != invpkg.ContractSettled {
 		t.Fatalf("invoice should now be settled but isn't")
 	}
 	if dbInvoice2.SettleDate.IsZero() {
@@ -235,24 +234,20 @@ func testInvoiceWorkflow(t *testing.T, test invWorkflowTest) {
 
 	// Attempt to insert generated above again, this should fail as
 	// duplicates are rejected by the processing logic.
-	if _, err := db.AddInvoice(fakeInvoice, payHash); err != ErrDuplicateInvoice {
-		t.Fatalf("invoice insertion should fail due to duplication, "+
-			"instead %v", err)
-	}
+	_, err = db.AddInvoice(fakeInvoice, payHash)
+	require.ErrorIs(t, err, invpkg.ErrDuplicateInvoice)
 
 	// Attempt to look up a non-existent invoice, this should also fail but
 	// with a "not found" error.
 	var fakeHash [32]byte
-	fakeRef := InvoiceRefByHash(fakeHash)
+	fakeRef := invpkg.InvoiceRefByHash(fakeHash)
 	_, err = db.LookupInvoice(fakeRef)
-	if err != ErrInvoiceNotFound {
-		t.Fatalf("lookup should have failed, instead %v", err)
-	}
+	require.ErrorIs(t, err, invpkg.ErrInvoiceNotFound)
 
 	// Add 10 random invoices.
 	const numInvoices = 10
 	amt := lnwire.NewMSatFromSatoshis(1000)
-	invoices := make([]*Invoice, numInvoices+1)
+	invoices := make([]*invpkg.Invoice, numInvoices+1)
 	invoices[0] = &dbInvoice2
 	for i := 1; i < len(invoices); i++ {
 		invoice, err := randInvoice(amt)
@@ -269,7 +264,7 @@ func testInvoiceWorkflow(t *testing.T, test invWorkflowTest) {
 	}
 
 	// Perform a scan to collect all the active invoices.
-	query := InvoiceQuery{
+	query := invpkg.InvoiceQuery{
 		IndexOffset:    0,
 		NumMaxInvoices: math.MaxUint64,
 		PendingOnly:    false,
@@ -312,7 +307,7 @@ func TestAddDuplicatePayAddr(t *testing.T) {
 	// Second insert should fail with duplicate payment addr.
 	inv2Hash := invoice2.Terms.PaymentPreimage.Hash()
 	_, err = db.AddInvoice(invoice2, inv2Hash)
-	require.Error(t, err, ErrDuplicatePayAddr)
+	require.Error(t, err, invpkg.ErrDuplicatePayAddr)
 }
 
 // TestAddDuplicateKeysendPayAddr asserts that we permit duplicate payment
@@ -325,11 +320,11 @@ func TestAddDuplicateKeysendPayAddr(t *testing.T) {
 	// Create two invoices with the same _blank_ payment addr.
 	invoice1, err := randInvoice(1000)
 	require.NoError(t, err)
-	invoice1.Terms.PaymentAddr = BlankPayAddr
+	invoice1.Terms.PaymentAddr = invpkg.BlankPayAddr
 
 	invoice2, err := randInvoice(20000)
 	require.NoError(t, err)
-	invoice2.Terms.PaymentAddr = BlankPayAddr
+	invoice2.Terms.PaymentAddr = invpkg.BlankPayAddr
 
 	// Inserting both should succeed without a duplicate payment address
 	// failure.
@@ -345,12 +340,12 @@ func TestAddDuplicateKeysendPayAddr(t *testing.T) {
 	// the lookup will fail if the hash and addr point to different
 	// invoices, so if both succeed we can be assured they aren't included
 	// in the payment address index.
-	ref1 := InvoiceRefByHashAndAddr(inv1Hash, BlankPayAddr)
+	ref1 := invpkg.InvoiceRefByHashAndAddr(inv1Hash, invpkg.BlankPayAddr)
 	dbInv1, err := db.LookupInvoice(ref1)
 	require.NoError(t, err)
 	require.Equal(t, invoice1, &dbInv1)
 
-	ref2 := InvoiceRefByHashAndAddr(inv2Hash, BlankPayAddr)
+	ref2 := invpkg.InvoiceRefByHashAndAddr(inv2Hash, invpkg.BlankPayAddr)
 	dbInv2, err := db.LookupInvoice(ref2)
 	require.NoError(t, err)
 	require.Equal(t, invoice2, &dbInv2)
@@ -380,9 +375,9 @@ func TestFailInvoiceLookupMPPPayAddrOnly(t *testing.T) {
 	// lookup should fail since we require the payment hash to match for
 	// legacy/MPP invoices, as this guarantees that the preimage is valid
 	// for the given HTLC.
-	ref := InvoiceRefByHashAndAddr(payHash, payAddr)
+	ref := invpkg.InvoiceRefByHashAndAddr(payHash, payAddr)
 	_, err = db.LookupInvoice(ref)
-	require.Equal(t, ErrInvoiceNotFound, err)
+	require.Equal(t, invpkg.ErrInvoiceNotFound, err)
 }
 
 // TestInvRefEquivocation asserts that retrieving or updating an invoice using
@@ -409,17 +404,19 @@ func TestInvRefEquivocation(t *testing.T) {
 	// Now, query using invoice 1's payment address, but invoice 2's payment
 	// hash. We expect an error since the invref points to multiple
 	// invoices.
-	ref := InvoiceRefByHashAndAddr(inv2Hash, invoice1.Terms.PaymentAddr)
+	ref := invpkg.InvoiceRefByHashAndAddr(
+		inv2Hash, invoice1.Terms.PaymentAddr,
+	)
 	_, err = db.LookupInvoice(ref)
-	require.Error(t, err, ErrInvRefEquivocation)
+	require.Error(t, err, invpkg.ErrInvRefEquivocation)
 
 	// The same error should be returned when updating an equivocating
 	// reference.
-	nop := func(_ *Invoice) (*InvoiceUpdateDesc, error) {
+	nop := func(_ *invpkg.Invoice) (*invpkg.InvoiceUpdateDesc, error) {
 		return nil, nil
 	}
 	_, err = db.UpdateInvoice(ref, nil, nop)
-	require.Error(t, err, ErrInvRefEquivocation)
+	require.Error(t, err, invpkg.ErrInvRefEquivocation)
 }
 
 // TestInvoiceCancelSingleHtlc tests that a single htlc can be canceled on the
@@ -433,9 +430,9 @@ func TestInvoiceCancelSingleHtlc(t *testing.T) {
 	preimage := lntypes.Preimage{1}
 	paymentHash := preimage.Hash()
 
-	testInvoice := &Invoice{
-		Htlcs: map[models.CircuitKey]*InvoiceHTLC{},
-		Terms: ContractTerm{
+	testInvoice := &invpkg.Invoice{
+		Htlcs: map[models.CircuitKey]*invpkg.InvoiceHTLC{},
+		Terms: invpkg.ContractTerm{
 			Value:           lnwire.NewMSatFromSatoshis(10000),
 			Features:        emptyFeatures,
 			PaymentPreimage: &preimage,
@@ -451,42 +448,50 @@ func TestInvoiceCancelSingleHtlc(t *testing.T) {
 		ChanID: lnwire.NewShortChanIDFromInt(1),
 		HtlcID: 4,
 	}
-	htlc := HtlcAcceptDesc{
+	htlc := invpkg.HtlcAcceptDesc{
 		Amt:           500,
 		CustomRecords: make(record.CustomSet),
 	}
 
-	ref := InvoiceRefByHash(paymentHash)
-	invoice, err := db.UpdateInvoice(ref, nil,
-		func(invoice *Invoice) (*InvoiceUpdateDesc, error) {
-			return &InvoiceUpdateDesc{
-				AddHtlcs: map[models.CircuitKey]*HtlcAcceptDesc{
-					key: &htlc,
-				},
-			}, nil
-		})
+	callback := func(
+		invoice *invpkg.Invoice) (*invpkg.InvoiceUpdateDesc, error) {
+
+		htlcs := map[models.CircuitKey]*invpkg.HtlcAcceptDesc{
+			key: &htlc,
+		}
+
+		return &invpkg.InvoiceUpdateDesc{
+			AddHtlcs: htlcs,
+		}, nil
+	}
+
+	ref := invpkg.InvoiceRefByHash(paymentHash)
+	invoice, err := db.UpdateInvoice(ref, nil, callback)
 	require.NoError(t, err, "unable to add invoice htlc")
 	if len(invoice.Htlcs) != 1 {
 		t.Fatalf("expected the htlc to be added")
 	}
-	if invoice.Htlcs[key].State != HtlcStateAccepted {
+	if invoice.Htlcs[key].State != invpkg.HtlcStateAccepted {
 		t.Fatalf("expected htlc in state accepted")
 	}
 
+	callback = func(
+		invoice *invpkg.Invoice) (*invpkg.InvoiceUpdateDesc, error) {
+
+		return &invpkg.InvoiceUpdateDesc{
+			CancelHtlcs: map[models.CircuitKey]struct{}{
+				key: {},
+			},
+		}, nil
+	}
+
 	// Cancel the htlc again.
-	invoice, err = db.UpdateInvoice(ref, nil,
-		func(invoice *Invoice) (*InvoiceUpdateDesc, error) {
-			return &InvoiceUpdateDesc{
-				CancelHtlcs: map[models.CircuitKey]struct{}{
-					key: {},
-				},
-			}, nil
-		})
+	invoice, err = db.UpdateInvoice(ref, nil, callback)
 	require.NoError(t, err, "unable to cancel htlc")
 	if len(invoice.Htlcs) != 1 {
 		t.Fatalf("expected the htlc to be present")
 	}
-	if invoice.Htlcs[key].State != HtlcStateCanceled {
+	if invoice.Htlcs[key].State != invpkg.HtlcStateCanceled {
 		t.Fatalf("expected htlc in state canceled")
 	}
 }
@@ -518,21 +523,26 @@ func TestInvoiceCancelSingleHtlcAMP(t *testing.T) {
 	setID1 := &[32]byte{1}
 	setID2 := &[32]byte{2}
 
-	ref := InvoiceRefByHashAndAddr(payHash, invoice.Terms.PaymentAddr)
+	ref := invpkg.InvoiceRefByHashAndAddr(
+		payHash, invoice.Terms.PaymentAddr,
+	)
 
 	// The first set ID with a single HTLC added.
 	_, err = db.UpdateInvoice(
-		ref, (*SetID)(setID1), updateAcceptAMPHtlc(0, amt, setID1, true),
+		ref, (*invpkg.SetID)(setID1),
+		updateAcceptAMPHtlc(0, amt, setID1, true),
 	)
 	require.Nil(t, err)
 
 	// The second set ID with two HTLCs added.
 	_, err = db.UpdateInvoice(
-		ref, (*SetID)(setID2), updateAcceptAMPHtlc(1, amt, setID2, true),
+		ref, (*invpkg.SetID)(setID2),
+		updateAcceptAMPHtlc(1, amt, setID2, true),
 	)
 	require.Nil(t, err)
 	dbInvoice, err := db.UpdateInvoice(
-		ref, (*SetID)(setID2), updateAcceptAMPHtlc(2, amt, setID2, true),
+		ref, (*invpkg.SetID)(setID2),
+		updateAcceptAMPHtlc(2, amt, setID2, true),
 	)
 	require.Nil(t, err)
 
@@ -540,18 +550,21 @@ func TestInvoiceCancelSingleHtlcAMP(t *testing.T) {
 	// paid.
 	require.Equal(t, dbInvoice.AmtPaid, amt*3)
 
+	callback := func(
+		invoice *invpkg.Invoice) (*invpkg.InvoiceUpdateDesc, error) {
+
+		return &invpkg.InvoiceUpdateDesc{
+			CancelHtlcs: map[models.CircuitKey]struct{}{
+				{HtlcID: 0}: {},
+			},
+			SetID: (*invpkg.SetID)(setID1),
+		}, nil
+	}
+
 	// Now we'll cancel a single invoice, and assert that the amount paid
 	// is decremented, and the state for that HTLC set reflects that is
 	// been cancelled.
-	_, err = db.UpdateInvoice(ref, (*SetID)(setID1),
-		func(invoice *Invoice) (*InvoiceUpdateDesc, error) {
-			return &InvoiceUpdateDesc{
-				CancelHtlcs: map[models.CircuitKey]struct{}{
-					{HtlcID: 0}: {},
-				},
-				SetID: (*SetID)(setID1),
-			}, nil
-		})
+	_, err = db.UpdateInvoice(ref, (*invpkg.SetID)(setID1), callback)
 	require.NoError(t, err, "unable to cancel htlc")
 
 	freshInvoice, err := db.LookupInvoice(ref)
@@ -563,22 +576,27 @@ func TestInvoiceCancelSingleHtlcAMP(t *testing.T) {
 
 	// The HTLC and AMP state should also show that only one HTLC set is
 	// left.
-	invoice.State = ContractOpen
+	invoice.State = invpkg.ContractOpen
 	invoice.AmtPaid = 2 * amt
 	invoice.SettleDate = dbInvoice.SettleDate
-	invoice.Htlcs = map[models.CircuitKey]*InvoiceHTLC{
-		{HtlcID: 0}: makeAMPInvoiceHTLC(amt, *setID1, payHash, &preimage),
-		{HtlcID: 1}: makeAMPInvoiceHTLC(amt, *setID2, payHash, &preimage),
-		{HtlcID: 2}: makeAMPInvoiceHTLC(amt, *setID2, payHash, &preimage),
+
+	htlc0 := models.CircuitKey{HtlcID: 0}
+	htlc1 := models.CircuitKey{HtlcID: 1}
+	htlc2 := models.CircuitKey{HtlcID: 2}
+
+	invoice.Htlcs = map[models.CircuitKey]*invpkg.InvoiceHTLC{
+		htlc0: makeAMPInvoiceHTLC(amt, *setID1, payHash, &preimage),
+		htlc1: makeAMPInvoiceHTLC(amt, *setID2, payHash, &preimage),
+		htlc2: makeAMPInvoiceHTLC(amt, *setID2, payHash, &preimage),
 	}
-	invoice.AMPState[*setID1] = InvoiceStateAMP{
-		State: HtlcStateCanceled,
+	invoice.AMPState[*setID1] = invpkg.InvoiceStateAMP{
+		State: invpkg.HtlcStateCanceled,
 		InvoiceKeys: map[models.CircuitKey]struct{}{
 			{HtlcID: 0}: {},
 		},
 	}
-	invoice.AMPState[*setID2] = InvoiceStateAMP{
-		State:   HtlcStateAccepted,
+	invoice.AMPState[*setID2] = invpkg.InvoiceStateAMP{
+		State:   invpkg.HtlcStateAccepted,
 		AmtPaid: amt * 2,
 		InvoiceKeys: map[models.CircuitKey]struct{}{
 			{HtlcID: 1}: {},
@@ -586,21 +604,22 @@ func TestInvoiceCancelSingleHtlcAMP(t *testing.T) {
 		},
 	}
 
-	htlc0 := models.CircuitKey{HtlcID: 0}
-	invoice.Htlcs[htlc0].State = HtlcStateCanceled
+	invoice.Htlcs[htlc0].State = invpkg.HtlcStateCanceled
 	invoice.Htlcs[htlc0].ResolveTime = time.Unix(1, 0)
 
 	require.Equal(t, invoice, dbInvoice)
 
 	// Next, we'll cancel the _other_ HTLCs active, but we'll do them one
 	// by one.
-	_, err = db.UpdateInvoice(ref, (*SetID)(setID2),
-		func(invoice *Invoice) (*InvoiceUpdateDesc, error) {
-			return &InvoiceUpdateDesc{
+	_, err = db.UpdateInvoice(ref, (*invpkg.SetID)(setID2),
+		func(invoice *invpkg.Invoice) (*invpkg.InvoiceUpdateDesc,
+			error) {
+
+			return &invpkg.InvoiceUpdateDesc{
 				CancelHtlcs: map[models.CircuitKey]struct{}{
 					{HtlcID: 1}: {},
 				},
-				SetID: (*SetID)(setID2),
+				SetID: (*invpkg.SetID)(setID2),
 			}, nil
 		})
 	require.NoError(t, err, "unable to cancel htlc")
@@ -609,29 +628,31 @@ func TestInvoiceCancelSingleHtlcAMP(t *testing.T) {
 	require.Nil(t, err)
 	dbInvoice = &freshInvoice
 
-	htlc1 := models.CircuitKey{HtlcID: 1}
-	invoice.Htlcs[htlc1].State = HtlcStateCanceled
+	invoice.Htlcs[htlc1].State = invpkg.HtlcStateCanceled
 	invoice.Htlcs[htlc1].ResolveTime = time.Unix(1, 0)
 	invoice.AmtPaid = amt
 
 	ampState := invoice.AMPState[*setID2]
-	ampState.State = HtlcStateCanceled
+	ampState.State = invpkg.HtlcStateCanceled
 	ampState.AmtPaid = amt
 	invoice.AMPState[*setID2] = ampState
 
 	require.Equal(t, invoice, dbInvoice)
 
+	callback = func(
+		invoice *invpkg.Invoice) (*invpkg.InvoiceUpdateDesc, error) {
+
+		return &invpkg.InvoiceUpdateDesc{
+			CancelHtlcs: map[models.CircuitKey]struct{}{
+				{HtlcID: 2}: {},
+			},
+			SetID: (*invpkg.SetID)(setID2),
+		}, nil
+	}
+
 	// Now we'll cancel the final HTLC, which should cause all the active
 	// HTLCs to transition to the cancelled state.
-	_, err = db.UpdateInvoice(ref, (*SetID)(setID2),
-		func(invoice *Invoice) (*InvoiceUpdateDesc, error) {
-			return &InvoiceUpdateDesc{
-				CancelHtlcs: map[models.CircuitKey]struct{}{
-					{HtlcID: 2}: {},
-				},
-				SetID: (*SetID)(setID2),
-			}, nil
-		})
+	_, err = db.UpdateInvoice(ref, (*invpkg.SetID)(setID2), callback)
 	require.NoError(t, err, "unable to cancel htlc")
 
 	freshInvoice, err = db.LookupInvoice(ref)
@@ -642,8 +663,7 @@ func TestInvoiceCancelSingleHtlcAMP(t *testing.T) {
 	ampState.AmtPaid = 0
 	invoice.AMPState[*setID2] = ampState
 
-	htlc2 := models.CircuitKey{HtlcID: 2}
-	invoice.Htlcs[htlc2].State = HtlcStateCanceled
+	invoice.Htlcs[htlc2].State = invpkg.HtlcStateCanceled
 	invoice.Htlcs[htlc2].ResolveTime = time.Unix(1, 0)
 	invoice.AmtPaid = 0
 
@@ -666,7 +686,7 @@ func TestInvoiceAddTimeSeries(t *testing.T) {
 	// into the database.
 	const numInvoices = 20
 	amt := lnwire.NewMSatFromSatoshis(1000)
-	invoices := make([]Invoice, numInvoices)
+	invoices := make([]invpkg.Invoice, numInvoices)
 	for i := 0; i < len(invoices); i++ {
 		invoice, err := randInvoice(amt)
 		if err != nil {
@@ -688,7 +708,7 @@ func TestInvoiceAddTimeSeries(t *testing.T) {
 	addQueries := []struct {
 		sinceAddIndex uint64
 
-		resp []Invoice
+		resp []invpkg.Invoice
 	}{
 		// If we specify a value of zero, we shouldn't get any invoices
 		// back.
@@ -736,7 +756,7 @@ func TestInvoiceAddTimeSeries(t *testing.T) {
 	_, err = db.InvoicesSettledSince(0)
 	require.NoError(t, err)
 
-	var settledInvoices []Invoice
+	var settledInvoices []invpkg.Invoice
 	var settleIndex uint64 = 1
 	// We'll now only settle the latter half of each of those invoices.
 	for i := 10; i < len(invoices); i++ {
@@ -744,7 +764,7 @@ func TestInvoiceAddTimeSeries(t *testing.T) {
 
 		paymentHash := invoice.Terms.PaymentPreimage.Hash()
 
-		ref := InvoiceRefByHash(paymentHash)
+		ref := invpkg.InvoiceRefByHash(paymentHash)
 		_, err := db.UpdateInvoice(
 			ref, nil, getUpdateInvoice(invoice.Terms.Value),
 		)
@@ -764,7 +784,7 @@ func TestInvoiceAddTimeSeries(t *testing.T) {
 	settleQueries := []struct {
 		sinceSettleIndex uint64
 
-		resp []Invoice
+		resp []invpkg.Invoice
 	}{
 		// If we specify a value of zero, we shouldn't get any settled
 		// invoices back.
@@ -835,17 +855,22 @@ func TestSettleIndexAmpPayments(t *testing.T) {
 	setID2 := &[32]byte{2}
 	setID3 := &[32]byte{3}
 
-	ref := InvoiceRefByHashAndAddr(payHash, testInvoice.Terms.PaymentAddr)
+	ref := invpkg.InvoiceRefByHashAndAddr(
+		payHash, testInvoice.Terms.PaymentAddr,
+	)
 	_, err = db.UpdateInvoice(
-		ref, (*SetID)(setID1), updateAcceptAMPHtlc(1, amt, setID1, true),
+		ref, (*invpkg.SetID)(setID1),
+		updateAcceptAMPHtlc(1, amt, setID1, true),
 	)
 	require.Nil(t, err)
 	_, err = db.UpdateInvoice(
-		ref, (*SetID)(setID2), updateAcceptAMPHtlc(2, amt, setID2, true),
+		ref, (*invpkg.SetID)(setID2),
+		updateAcceptAMPHtlc(2, amt, setID2, true),
 	)
 	require.Nil(t, err)
 	_, err = db.UpdateInvoice(
-		ref, (*SetID)(setID3), updateAcceptAMPHtlc(3, amt, setID3, true),
+		ref, (*invpkg.SetID)(setID3),
+		updateAcceptAMPHtlc(3, amt, setID3, true),
 	)
 	require.Nil(t, err)
 
@@ -855,7 +880,9 @@ func TestSettleIndexAmpPayments(t *testing.T) {
 	//
 	// First, we'll query for the invoice with just the payment addr, but
 	// specify no HTLcs are to be included.
-	refNoHtlcs := InvoiceRefByAddrBlankHtlc(testInvoice.Terms.PaymentAddr)
+	refNoHtlcs := invpkg.InvoiceRefByAddrBlankHtlc(
+		testInvoice.Terms.PaymentAddr,
+	)
 	invoiceNoHTLCs, err := db.LookupInvoice(refNoHtlcs)
 	require.Nil(t, err)
 
@@ -864,7 +891,7 @@ func TestSettleIndexAmpPayments(t *testing.T) {
 	// We'll now look up the HTLCs based on the individual setIDs added
 	// above.
 	for i, setID := range []*[32]byte{setID1, setID2, setID3} {
-		refFiltered := InvoiceRefBySetIDFiltered(*setID)
+		refFiltered := invpkg.InvoiceRefBySetIDFiltered(*setID)
 		invoiceFiltered, err := db.LookupInvoice(refFiltered)
 		require.Nil(t, err)
 
@@ -877,27 +904,27 @@ func TestSettleIndexAmpPayments(t *testing.T) {
 		require.Equal(t, *setID, htlc.AMP.Record.SetID())
 
 		// The HTLC should show that it's in the accepted state.
-		require.Equal(t, htlc.State, HtlcStateAccepted)
+		require.Equal(t, htlc.State, invpkg.HtlcStateAccepted)
 	}
 
 	// Now that we know the invoices are in the proper state, we'll settle
 	// them on by one in distinct updates.
 	_, err = db.UpdateInvoice(
-		ref, (*SetID)(setID1),
+		ref, (*invpkg.SetID)(setID1),
 		getUpdateInvoiceAMPSettle(
 			setID1, preimage, models.CircuitKey{HtlcID: 1},
 		),
 	)
 	require.Nil(t, err)
 	_, err = db.UpdateInvoice(
-		ref, (*SetID)(setID2),
+		ref, (*invpkg.SetID)(setID2),
 		getUpdateInvoiceAMPSettle(
 			setID2, preimage, models.CircuitKey{HtlcID: 2},
 		),
 	)
 	require.Nil(t, err)
 	_, err = db.UpdateInvoice(
-		ref, (*SetID)(setID3),
+		ref, (*invpkg.SetID)(setID3),
 		getUpdateInvoiceAMPSettle(
 			setID3, preimage, models.CircuitKey{HtlcID: 3},
 		),
@@ -914,9 +941,13 @@ func TestSettleIndexAmpPayments(t *testing.T) {
 	// To get around the settle index quirk, we'll fetch the very first
 	// invoice in the HTLC filtered mode and append it to the set of
 	// invoices.
-	firstInvoice, err := db.LookupInvoice(InvoiceRefBySetIDFiltered(*setID1))
+	firstInvoice, err := db.LookupInvoice(
+		invpkg.InvoiceRefBySetIDFiltered(*setID1),
+	)
 	require.Nil(t, err)
-	settledInvoices = append([]Invoice{firstInvoice}, settledInvoices...)
+	settledInvoices = append(
+		[]invpkg.Invoice{firstInvoice}, settledInvoices...,
+	)
 
 	// There should be 3 invoices settled, as we created 3 "sub-invoices"
 	// above.
@@ -935,7 +966,7 @@ func TestSettleIndexAmpPayments(t *testing.T) {
 		subInvoiceState, ok := settledInvoice.AMPState[*invSetID]
 		require.True(t, ok)
 
-		require.Equal(t, subInvoiceState.State, HtlcStateSettled)
+		require.Equal(t, subInvoiceState.State, invpkg.HtlcStateSettled)
 		require.Equal(t, int(subInvoiceState.SettleIndex), i+1)
 
 		invoiceKey := models.CircuitKey{HtlcID: uint64(i + 1)}
@@ -945,14 +976,14 @@ func TestSettleIndexAmpPayments(t *testing.T) {
 
 	// If we attempt to look up the invoice by the payment addr, with all
 	// the HTLCs, the main invoice should have 3 HTLCs present.
-	refWithHtlcs := InvoiceRefByAddr(testInvoice.Terms.PaymentAddr)
+	refWithHtlcs := invpkg.InvoiceRefByAddr(testInvoice.Terms.PaymentAddr)
 	invoiceWithHTLCs, err := db.LookupInvoice(refWithHtlcs)
 	require.Nil(t, err)
 	require.Equal(t, numInvoices, len(invoiceWithHTLCs.Htlcs))
 
 	// Finally, delete the invoice. If we query again, then nothing should
 	// be found.
-	err = db.DeleteInvoice([]InvoiceDeleteRef{
+	err = db.DeleteInvoice([]invpkg.InvoiceDeleteRef{
 		{
 			PayHash:  payHash,
 			PayAddr:  &testInvoice.Terms.PaymentAddr,
@@ -970,7 +1001,7 @@ func TestScanInvoices(t *testing.T) {
 	db, err := MakeTestDB(t)
 	require.NoError(t, err, "unable to make test db")
 
-	var invoices map[lntypes.Hash]*Invoice
+	var invoices map[lntypes.Hash]*invpkg.Invoice
 	callCount := 0
 	resetCount := 0
 
@@ -978,12 +1009,14 @@ func TestScanInvoices(t *testing.T) {
 	// upon calling ScanInvoices and when the underlying transaction is
 	// retried.
 	reset := func() {
-		invoices = make(map[lntypes.Hash]*Invoice)
+		invoices = make(map[lntypes.Hash]*invpkg.Invoice)
 		callCount = 0
 		resetCount++
 	}
 
-	scanFunc := func(paymentHash lntypes.Hash, invoice *Invoice) error {
+	scanFunc := func(paymentHash lntypes.Hash,
+		invoice *invpkg.Invoice) error {
+
 		invoices[paymentHash] = invoice
 		callCount++
 
@@ -997,7 +1030,7 @@ func TestScanInvoices(t *testing.T) {
 	require.Equal(t, 1, resetCount)
 
 	numInvoices := 5
-	testInvoices := make(map[lntypes.Hash]*Invoice)
+	testInvoices := make(map[lntypes.Hash]*invpkg.Invoice)
 
 	// Now populate the DB and check if we can get all invoices with their
 	// payment hashes as expected.
@@ -1040,22 +1073,22 @@ func TestDuplicateSettleInvoice(t *testing.T) {
 	}
 
 	// With the invoice in the DB, we'll now attempt to settle the invoice.
-	ref := InvoiceRefByHash(payHash)
+	ref := invpkg.InvoiceRefByHash(payHash)
 	dbInvoice, err := db.UpdateInvoice(ref, nil, getUpdateInvoice(amt))
 	require.NoError(t, err, "unable to settle invoice")
 
 	// We'll update what we expect the settle invoice to be so that our
 	// comparison below has the correct assumption.
 	invoice.SettleIndex = 1
-	invoice.State = ContractSettled
+	invoice.State = invpkg.ContractSettled
 	invoice.AmtPaid = amt
 	invoice.SettleDate = dbInvoice.SettleDate
-	invoice.Htlcs = map[models.CircuitKey]*InvoiceHTLC{
+	invoice.Htlcs = map[models.CircuitKey]*invpkg.InvoiceHTLC{
 		{}: {
 			Amt:           amt,
 			AcceptTime:    time.Unix(1, 0),
 			ResolveTime:   time.Unix(1, 0),
-			State:         HtlcStateSettled,
+			State:         invpkg.HtlcStateSettled,
 			CustomRecords: make(record.CustomSet),
 		},
 	}
@@ -1066,16 +1099,16 @@ func TestDuplicateSettleInvoice(t *testing.T) {
 	// If we try to settle the invoice again, then we should get the very
 	// same invoice back, but with an error this time.
 	dbInvoice, err = db.UpdateInvoice(ref, nil, getUpdateInvoice(amt))
-	if err != ErrInvoiceAlreadySettled {
-		t.Fatalf("expected ErrInvoiceAlreadySettled")
-	}
+	require.ErrorIs(t, err, invpkg.ErrInvoiceAlreadySettled)
 
 	if dbInvoice == nil {
 		t.Fatalf("invoice from db is nil after settle!")
 	}
 
 	invoice.SettleDate = dbInvoice.SettleDate
-	require.Equal(t, invoice, dbInvoice, "wrong invoice after second settle")
+	require.Equal(
+		t, invoice, dbInvoice, "wrong invoice after second settle",
+	)
 }
 
 // TestQueryInvoices ensures that we can properly query the invoice database for
@@ -1091,8 +1124,8 @@ func TestQueryInvoices(t *testing.T) {
 	// as the amount of the invoice itself.
 	const numInvoices = 50
 	var settleIndex uint64 = 1
-	var invoices []Invoice
-	var pendingInvoices []Invoice
+	var invoices []invpkg.Invoice
+	var pendingInvoices []invpkg.Invoice
 
 	for i := 1; i <= numInvoices; i++ {
 		amt := lnwire.MilliSatoshi(i)
@@ -1112,8 +1145,10 @@ func TestQueryInvoices(t *testing.T) {
 
 		// We'll only settle half of all invoices created.
 		if i%2 == 0 {
-			ref := InvoiceRefByHash(paymentHash)
-			_, err := db.UpdateInvoice(ref, nil, getUpdateInvoice(amt))
+			ref := invpkg.InvoiceRefByHash(paymentHash)
+			_, err := db.UpdateInvoice(
+				ref, nil, getUpdateInvoice(amt),
+			)
 			if err != nil {
 				t.Fatalf("unable to settle invoice: %v", err)
 			}
@@ -1131,19 +1166,19 @@ func TestQueryInvoices(t *testing.T) {
 	// The test will consist of several queries along with their respective
 	// expected response. Each query response should match its expected one.
 	testCases := []struct {
-		query    InvoiceQuery
-		expected []Invoice
+		query    invpkg.InvoiceQuery
+		expected []invpkg.Invoice
 	}{
 		// Fetch all invoices with a single query.
 		{
-			query: InvoiceQuery{
+			query: invpkg.InvoiceQuery{
 				NumMaxInvoices: numInvoices,
 			},
 			expected: invoices,
 		},
 		// Fetch all invoices with a single query, reversed.
 		{
-			query: InvoiceQuery{
+			query: invpkg.InvoiceQuery{
 				Reversed:       true,
 				NumMaxInvoices: numInvoices,
 			},
@@ -1151,7 +1186,7 @@ func TestQueryInvoices(t *testing.T) {
 		},
 		// Fetch the first 25 invoices.
 		{
-			query: InvoiceQuery{
+			query: invpkg.InvoiceQuery{
 				NumMaxInvoices: numInvoices / 2,
 			},
 			expected: invoices[:numInvoices/2],
@@ -1159,7 +1194,7 @@ func TestQueryInvoices(t *testing.T) {
 		// Fetch the first 10 invoices, but this time iterating
 		// backwards.
 		{
-			query: InvoiceQuery{
+			query: invpkg.InvoiceQuery{
 				IndexOffset:    11,
 				Reversed:       true,
 				NumMaxInvoices: numInvoices,
@@ -1168,7 +1203,7 @@ func TestQueryInvoices(t *testing.T) {
 		},
 		// Fetch the last 40 invoices.
 		{
-			query: InvoiceQuery{
+			query: invpkg.InvoiceQuery{
 				IndexOffset:    10,
 				NumMaxInvoices: numInvoices,
 			},
@@ -1176,7 +1211,7 @@ func TestQueryInvoices(t *testing.T) {
 		},
 		// Fetch all but the first invoice.
 		{
-			query: InvoiceQuery{
+			query: invpkg.InvoiceQuery{
 				IndexOffset:    1,
 				NumMaxInvoices: numInvoices,
 			},
@@ -1185,7 +1220,7 @@ func TestQueryInvoices(t *testing.T) {
 		// Fetch one invoice, reversed, with index offset 3. This
 		// should give us the second invoice in the array.
 		{
-			query: InvoiceQuery{
+			query: invpkg.InvoiceQuery{
 				IndexOffset:    3,
 				Reversed:       true,
 				NumMaxInvoices: 1,
@@ -1194,7 +1229,7 @@ func TestQueryInvoices(t *testing.T) {
 		},
 		// Same as above, at index 2.
 		{
-			query: InvoiceQuery{
+			query: invpkg.InvoiceQuery{
 				IndexOffset:    2,
 				Reversed:       true,
 				NumMaxInvoices: 1,
@@ -1205,7 +1240,7 @@ func TestQueryInvoices(t *testing.T) {
 		// the very first, there won't be any left in a reverse search,
 		// so we expect no invoices to be returned.
 		{
-			query: InvoiceQuery{
+			query: invpkg.InvoiceQuery{
 				IndexOffset:    1,
 				Reversed:       true,
 				NumMaxInvoices: 1,
@@ -1215,7 +1250,7 @@ func TestQueryInvoices(t *testing.T) {
 		// Same as above, but don't restrict the number of invoices to
 		// 1.
 		{
-			query: InvoiceQuery{
+			query: invpkg.InvoiceQuery{
 				IndexOffset:    1,
 				Reversed:       true,
 				NumMaxInvoices: numInvoices,
@@ -1225,7 +1260,7 @@ func TestQueryInvoices(t *testing.T) {
 		// Fetch one invoice, reversed, with no offset set. We expect
 		// the last invoice in the response.
 		{
-			query: InvoiceQuery{
+			query: invpkg.InvoiceQuery{
 				Reversed:       true,
 				NumMaxInvoices: 1,
 			},
@@ -1234,7 +1269,7 @@ func TestQueryInvoices(t *testing.T) {
 		// Fetch one invoice, reversed, the offset set at numInvoices+1.
 		// We expect this to return the last invoice.
 		{
-			query: InvoiceQuery{
+			query: invpkg.InvoiceQuery{
 				IndexOffset:    numInvoices + 1,
 				Reversed:       true,
 				NumMaxInvoices: 1,
@@ -1243,7 +1278,7 @@ func TestQueryInvoices(t *testing.T) {
 		},
 		// Same as above, at offset numInvoices.
 		{
-			query: InvoiceQuery{
+			query: invpkg.InvoiceQuery{
 				IndexOffset:    numInvoices,
 				Reversed:       true,
 				NumMaxInvoices: 1,
@@ -1253,14 +1288,14 @@ func TestQueryInvoices(t *testing.T) {
 		// Fetch one invoice, at no offset (same as offset 0). We
 		// expect the first invoice only in the response.
 		{
-			query: InvoiceQuery{
+			query: invpkg.InvoiceQuery{
 				NumMaxInvoices: 1,
 			},
 			expected: invoices[:1],
 		},
 		// Same as above, at offset 1.
 		{
-			query: InvoiceQuery{
+			query: invpkg.InvoiceQuery{
 				IndexOffset:    1,
 				NumMaxInvoices: 1,
 			},
@@ -1268,7 +1303,7 @@ func TestQueryInvoices(t *testing.T) {
 		},
 		// Same as above, at offset 2.
 		{
-			query: InvoiceQuery{
+			query: invpkg.InvoiceQuery{
 				IndexOffset:    2,
 				NumMaxInvoices: 1,
 			},
@@ -1277,7 +1312,7 @@ func TestQueryInvoices(t *testing.T) {
 		// Same as above, at offset numInvoices-1. Expect the last
 		// invoice to be returned.
 		{
-			query: InvoiceQuery{
+			query: invpkg.InvoiceQuery{
 				IndexOffset:    numInvoices - 1,
 				NumMaxInvoices: 1,
 			},
@@ -1286,7 +1321,7 @@ func TestQueryInvoices(t *testing.T) {
 		// Same as above, at offset numInvoices. No invoices should be
 		// returned, as there are no invoices after this offset.
 		{
-			query: InvoiceQuery{
+			query: invpkg.InvoiceQuery{
 				IndexOffset:    numInvoices,
 				NumMaxInvoices: 1,
 			},
@@ -1294,7 +1329,7 @@ func TestQueryInvoices(t *testing.T) {
 		},
 		// Fetch all pending invoices with a single query.
 		{
-			query: InvoiceQuery{
+			query: invpkg.InvoiceQuery{
 				PendingOnly:    true,
 				NumMaxInvoices: numInvoices,
 			},
@@ -1302,7 +1337,7 @@ func TestQueryInvoices(t *testing.T) {
 		},
 		// Fetch the first 12 pending invoices.
 		{
-			query: InvoiceQuery{
+			query: invpkg.InvoiceQuery{
 				PendingOnly:    true,
 				NumMaxInvoices: numInvoices / 4,
 			},
@@ -1311,7 +1346,7 @@ func TestQueryInvoices(t *testing.T) {
 		// Fetch the first 5 pending invoices, but this time iterating
 		// backwards.
 		{
-			query: InvoiceQuery{
+			query: invpkg.InvoiceQuery{
 				IndexOffset:    10,
 				PendingOnly:    true,
 				Reversed:       true,
@@ -1325,7 +1360,7 @@ func TestQueryInvoices(t *testing.T) {
 		},
 		// Fetch the last 15 invoices.
 		{
-			query: InvoiceQuery{
+			query: invpkg.InvoiceQuery{
 				IndexOffset:    20,
 				PendingOnly:    true,
 				NumMaxInvoices: numInvoices,
@@ -1339,7 +1374,7 @@ func TestQueryInvoices(t *testing.T) {
 		// that is beyond our last offset. We expect all invoices to be
 		// returned.
 		{
-			query: InvoiceQuery{
+			query: invpkg.InvoiceQuery{
 				IndexOffset:    numInvoices * 2,
 				PendingOnly:    false,
 				Reversed:       true,
@@ -1349,7 +1384,7 @@ func TestQueryInvoices(t *testing.T) {
 		},
 		// Fetch invoices <= 25 by creation date.
 		{
-			query: InvoiceQuery{
+			query: invpkg.InvoiceQuery{
 				NumMaxInvoices:  numInvoices,
 				CreationDateEnd: time.Unix(25, 0),
 			},
@@ -1357,7 +1392,7 @@ func TestQueryInvoices(t *testing.T) {
 		},
 		// Fetch invoices >= 26 creation date.
 		{
-			query: InvoiceQuery{
+			query: invpkg.InvoiceQuery{
 				NumMaxInvoices:    numInvoices,
 				CreationDateStart: time.Unix(26, 0),
 			},
@@ -1365,7 +1400,7 @@ func TestQueryInvoices(t *testing.T) {
 		},
 		// Fetch pending invoices <= 25 by creation date.
 		{
-			query: InvoiceQuery{
+			query: invpkg.InvoiceQuery{
 				PendingOnly:     true,
 				NumMaxInvoices:  numInvoices,
 				CreationDateEnd: time.Unix(25, 0),
@@ -1374,7 +1409,7 @@ func TestQueryInvoices(t *testing.T) {
 		},
 		// Fetch pending invoices >= 26 creation date.
 		{
-			query: InvoiceQuery{
+			query: invpkg.InvoiceQuery{
 				PendingOnly:       true,
 				NumMaxInvoices:    numInvoices,
 				CreationDateStart: time.Unix(26, 0),
@@ -1383,7 +1418,7 @@ func TestQueryInvoices(t *testing.T) {
 		},
 		// Fetch pending invoices with offset and end creation date.
 		{
-			query: InvoiceQuery{
+			query: invpkg.InvoiceQuery{
 				IndexOffset:     20,
 				NumMaxInvoices:  numInvoices,
 				CreationDateEnd: time.Unix(30, 0),
@@ -1395,7 +1430,7 @@ func TestQueryInvoices(t *testing.T) {
 		// Fetch pending invoices with offset and start creation date
 		// in reversed order.
 		{
-			query: InvoiceQuery{
+			query: invpkg.InvoiceQuery{
 				IndexOffset:       21,
 				Reversed:          true,
 				NumMaxInvoices:    numInvoices,
@@ -1407,7 +1442,7 @@ func TestQueryInvoices(t *testing.T) {
 		},
 		// Fetch invoices with start and end creation date.
 		{
-			query: InvoiceQuery{
+			query: invpkg.InvoiceQuery{
 				NumMaxInvoices:    numInvoices,
 				CreationDateStart: time.Unix(11, 0),
 				CreationDateEnd:   time.Unix(20, 0),
@@ -1416,7 +1451,7 @@ func TestQueryInvoices(t *testing.T) {
 		},
 		// Fetch pending invoices with start and end creation date.
 		{
-			query: InvoiceQuery{
+			query: invpkg.InvoiceQuery{
 				PendingOnly:       true,
 				NumMaxInvoices:    numInvoices,
 				CreationDateStart: time.Unix(11, 0),
@@ -1427,7 +1462,7 @@ func TestQueryInvoices(t *testing.T) {
 		// Fetch invoices with start and end creation date in reverse
 		// order.
 		{
-			query: InvoiceQuery{
+			query: invpkg.InvoiceQuery{
 				Reversed:          true,
 				NumMaxInvoices:    numInvoices,
 				CreationDateStart: time.Unix(11, 0),
@@ -1438,7 +1473,7 @@ func TestQueryInvoices(t *testing.T) {
 		// Fetch pending invoices with start and end creation date in
 		// reverse order.
 		{
-			query: InvoiceQuery{
+			query: invpkg.InvoiceQuery{
 				PendingOnly:       true,
 				Reversed:          true,
 				NumMaxInvoices:    numInvoices,
@@ -1450,7 +1485,7 @@ func TestQueryInvoices(t *testing.T) {
 		// Fetch invoices with a start date greater than end date
 		// should result in an empty slice.
 		{
-			query: InvoiceQuery{
+			query: invpkg.InvoiceQuery{
 				NumMaxInvoices:    numInvoices,
 				CreationDateStart: time.Unix(20, 0),
 				CreationDateEnd:   time.Unix(11, 0),
@@ -1478,25 +1513,27 @@ func TestQueryInvoices(t *testing.T) {
 
 // getUpdateInvoice returns an invoice update callback that, when called,
 // settles the invoice with the given amount.
-func getUpdateInvoice(amt lnwire.MilliSatoshi) InvoiceUpdateCallback {
-	return func(invoice *Invoice) (*InvoiceUpdateDesc, error) {
-		if invoice.State == ContractSettled {
-			return nil, ErrInvoiceAlreadySettled
+func getUpdateInvoice(amt lnwire.MilliSatoshi) invpkg.InvoiceUpdateCallback {
+	return func(invoice *invpkg.Invoice) (*invpkg.InvoiceUpdateDesc,
+		error) {
+
+		if invoice.State == invpkg.ContractSettled {
+			return nil, invpkg.ErrInvoiceAlreadySettled
 		}
 
 		noRecords := make(record.CustomSet)
-
-		update := &InvoiceUpdateDesc{
-			State: &InvoiceStateUpdateDesc{
+		htlcs := map[models.CircuitKey]*invpkg.HtlcAcceptDesc{
+			{}: {
+				Amt:           amt,
+				CustomRecords: noRecords,
+			},
+		}
+		update := &invpkg.InvoiceUpdateDesc{
+			State: &invpkg.InvoiceStateUpdateDesc{
 				Preimage: invoice.Terms.PaymentPreimage,
-				NewState: ContractSettled,
+				NewState: invpkg.ContractSettled,
 			},
-			AddHtlcs: map[models.CircuitKey]*HtlcAcceptDesc{
-				{}: {
-					Amt:           amt,
-					CustomRecords: noRecords,
-				},
-			},
+			AddHtlcs: htlcs,
 		}
 
 		return update, nil
@@ -1514,9 +1551,9 @@ func TestCustomRecords(t *testing.T) {
 	preimage := lntypes.Preimage{1}
 	paymentHash := preimage.Hash()
 
-	testInvoice := &Invoice{
-		Htlcs: map[models.CircuitKey]*InvoiceHTLC{},
-		Terms: ContractTerm{
+	testInvoice := &invpkg.Invoice{
+		Htlcs: map[models.CircuitKey]*invpkg.InvoiceHTLC{},
+		Terms: invpkg.ContractTerm{
 			Value:           lnwire.NewMSatFromSatoshis(10000),
 			Features:        emptyFeatures,
 			PaymentPreimage: &preimage,
@@ -1538,19 +1575,21 @@ func TestCustomRecords(t *testing.T) {
 		100001: []byte{1, 2},
 	}
 
-	ref := InvoiceRefByHash(paymentHash)
-	_, err = db.UpdateInvoice(ref, nil,
-		func(invoice *Invoice) (*InvoiceUpdateDesc, error) {
-			htlcs := map[models.CircuitKey]*HtlcAcceptDesc{
-				key: {
-					Amt:           500,
-					CustomRecords: records,
-				},
-			}
+	ref := invpkg.InvoiceRefByHash(paymentHash)
+	callback := func(invoice *invpkg.Invoice) (*invpkg.InvoiceUpdateDesc,
+		error) {
 
-			return &InvoiceUpdateDesc{AddHtlcs: htlcs}, nil
-		},
-	)
+		htlcs := map[models.CircuitKey]*invpkg.HtlcAcceptDesc{
+			key: {
+				Amt:           500,
+				CustomRecords: records,
+			},
+		}
+
+		return &invpkg.InvoiceUpdateDesc{AddHtlcs: htlcs}, nil
+	}
+
+	_, err = db.UpdateInvoice(ref, nil, callback)
 	require.NoError(t, err, "unable to add invoice htlc")
 
 	// Retrieve the invoice from that database and verify that the custom
@@ -1601,31 +1640,34 @@ func testInvoiceHtlcAMPFields(t *testing.T, isAMP bool) {
 	}
 	records := make(map[uint64][]byte)
 
-	var ampData *InvoiceHtlcAMPData
+	var ampData *invpkg.InvoiceHtlcAMPData
 	if isAMP {
 		amp := record.NewAMP([32]byte{1}, [32]byte{2}, 3)
 		preimage := &lntypes.Preimage{4}
 
-		ampData = &InvoiceHtlcAMPData{
+		ampData = &invpkg.InvoiceHtlcAMPData{
 			Record:   *amp,
 			Hash:     preimage.Hash(),
 			Preimage: preimage,
 		}
 	}
 
-	ref := InvoiceRefByHash(payHash)
-	_, err = db.UpdateInvoice(ref, nil,
-		func(invoice *Invoice) (*InvoiceUpdateDesc, error) {
-			htlcs := map[models.CircuitKey]*HtlcAcceptDesc{
-				key: {
-					Amt:           500,
-					AMP:           ampData,
-					CustomRecords: records,
-				},
-			}
-			return &InvoiceUpdateDesc{AddHtlcs: htlcs}, nil
-		},
-	)
+	callback := func(invoice *invpkg.Invoice) (*invpkg.InvoiceUpdateDesc,
+		error) {
+
+		htlcs := map[models.CircuitKey]*invpkg.HtlcAcceptDesc{
+			key: {
+				Amt:           500,
+				AMP:           ampData,
+				CustomRecords: records,
+			},
+		}
+
+		return &invpkg.InvoiceUpdateDesc{AddHtlcs: htlcs}, nil
+	}
+
+	ref := invpkg.InvoiceRefByHash(payHash)
+	_, err = db.UpdateInvoice(ref, nil, callback)
 	require.Nil(t, err)
 
 	// Retrieve the invoice from that database and verify that the AMP
@@ -1646,28 +1688,28 @@ func TestInvoiceRef(t *testing.T) {
 
 	// An InvoiceRef by hash should return the provided hash and a nil
 	// payment addr.
-	refByHash := InvoiceRefByHash(payHash)
+	refByHash := invpkg.InvoiceRefByHash(payHash)
 	require.Equal(t, &payHash, refByHash.PayHash())
 	require.Equal(t, (*[32]byte)(nil), refByHash.PayAddr())
 	require.Equal(t, (*[32]byte)(nil), refByHash.SetID())
 
 	// An InvoiceRef by hash and addr should return the payment hash and
 	// payment addr passed to the constructor.
-	refByHashAndAddr := InvoiceRefByHashAndAddr(payHash, payAddr)
+	refByHashAndAddr := invpkg.InvoiceRefByHashAndAddr(payHash, payAddr)
 	require.Equal(t, &payHash, refByHashAndAddr.PayHash())
 	require.Equal(t, &payAddr, refByHashAndAddr.PayAddr())
 	require.Equal(t, (*[32]byte)(nil), refByHashAndAddr.SetID())
 
 	// An InvoiceRef by set id should return an empty pay hash, a nil pay
 	// addr, and a reference to the given set id.
-	refBySetID := InvoiceRefBySetID(setID)
+	refBySetID := invpkg.InvoiceRefBySetID(setID)
 	require.Equal(t, (*lntypes.Hash)(nil), refBySetID.PayHash())
 	require.Equal(t, (*[32]byte)(nil), refBySetID.PayAddr())
 	require.Equal(t, &setID, refBySetID.SetID())
 
 	// An InvoiceRef by pay addr should only return a pay addr, but nil for
 	// pay hash and set id.
-	refByAddr := InvoiceRefByAddr(payAddr)
+	refByAddr := invpkg.InvoiceRefByAddr(payAddr)
 	require.Equal(t, (*lntypes.Hash)(nil), refByAddr.PayHash())
 	require.Equal(t, &payAddr, refByAddr.PayAddr())
 	require.Equal(t, (*[32]byte)(nil), refByAddr.SetID())
@@ -1678,8 +1720,8 @@ func TestInvoiceRef(t *testing.T) {
 // not comingle, and also that HTLCs with disjoint set ids appear in different
 // sets.
 func TestHTLCSet(t *testing.T) {
-	inv := &Invoice{
-		Htlcs: make(map[models.CircuitKey]*InvoiceHTLC),
+	inv := &invpkg.Invoice{
+		Htlcs: make(map[models.CircuitKey]*invpkg.InvoiceHTLC),
 	}
 
 	// Construct two distinct set id's, in this test we'll also track the
@@ -1689,14 +1731,24 @@ func TestHTLCSet(t *testing.T) {
 
 	// Create the expected htlc sets for each group, these will be updated
 	// as the invoice is modified.
-	expSetNil := make(map[models.CircuitKey]*InvoiceHTLC)
-	expSet1 := make(map[models.CircuitKey]*InvoiceHTLC)
-	expSet2 := make(map[models.CircuitKey]*InvoiceHTLC)
+
+	expSetNil := make(map[models.CircuitKey]*invpkg.InvoiceHTLC)
+	expSet1 := make(map[models.CircuitKey]*invpkg.InvoiceHTLC)
+	expSet2 := make(map[models.CircuitKey]*invpkg.InvoiceHTLC)
 
 	checkHTLCSets := func() {
-		require.Equal(t, expSetNil, inv.HTLCSet(nil, HtlcStateAccepted))
-		require.Equal(t, expSet1, inv.HTLCSet(setID1, HtlcStateAccepted))
-		require.Equal(t, expSet2, inv.HTLCSet(setID2, HtlcStateAccepted))
+		require.Equal(
+			t, expSetNil,
+			inv.HTLCSet(nil, invpkg.HtlcStateAccepted),
+		)
+		require.Equal(
+			t, expSet1,
+			inv.HTLCSet(setID1, invpkg.HtlcStateAccepted),
+		)
+		require.Equal(
+			t, expSet2,
+			inv.HTLCSet(setID2, invpkg.HtlcStateAccepted),
+		)
 	}
 
 	// All HTLC sets should be empty initially.
@@ -1709,33 +1761,35 @@ func TestHTLCSet(t *testing.T) {
 	//   - only accepted htlcs are returned as part of the set.
 	htlcs := []struct {
 		setID *[32]byte
-		state HtlcState
+		state invpkg.HtlcState
 	}{
-		{nil, HtlcStateAccepted},
-		{nil, HtlcStateAccepted},
-		{setID1, HtlcStateAccepted},
-		{setID1, HtlcStateAccepted},
-		{setID2, HtlcStateAccepted},
-		{setID2, HtlcStateAccepted},
-		{nil, HtlcStateCanceled},
-		{setID1, HtlcStateCanceled},
-		{setID2, HtlcStateCanceled},
-		{nil, HtlcStateSettled},
-		{setID1, HtlcStateSettled},
-		{setID2, HtlcStateSettled},
+		{nil, invpkg.HtlcStateAccepted},
+		{nil, invpkg.HtlcStateAccepted},
+		{setID1, invpkg.HtlcStateAccepted},
+		{setID1, invpkg.HtlcStateAccepted},
+		{setID2, invpkg.HtlcStateAccepted},
+		{setID2, invpkg.HtlcStateAccepted},
+		{nil, invpkg.HtlcStateCanceled},
+		{setID1, invpkg.HtlcStateCanceled},
+		{setID2, invpkg.HtlcStateCanceled},
+		{nil, invpkg.HtlcStateSettled},
+		{setID1, invpkg.HtlcStateSettled},
+		{setID2, invpkg.HtlcStateSettled},
 	}
 
 	for i, h := range htlcs {
-		var ampData *InvoiceHtlcAMPData
+		var ampData *invpkg.InvoiceHtlcAMPData
 		if h.setID != nil {
-			ampData = &InvoiceHtlcAMPData{
-				Record: *record.NewAMP([32]byte{0}, *h.setID, 0),
+			ampData = &invpkg.InvoiceHtlcAMPData{
+				Record: *record.NewAMP(
+					[32]byte{0}, *h.setID, 0,
+				),
 			}
 		}
 
 		// Add the HTLC to the invoice's set of HTLCs.
 		key := models.CircuitKey{HtlcID: uint64(i)}
-		htlc := &InvoiceHTLC{
+		htlc := &invpkg.InvoiceHTLC{
 			AMP:   ampData,
 			State: h.state,
 		}
@@ -1743,7 +1797,7 @@ func TestHTLCSet(t *testing.T) {
 
 		// Update our expected htlc set if the htlc is accepted,
 		// otherwise it shouldn't be reflected.
-		if h.state == HtlcStateAccepted {
+		if h.state == invpkg.HtlcStateAccepted {
 			switch h.setID {
 			case nil:
 				expSetNil[key] = htlc
@@ -1770,11 +1824,11 @@ func TestAddInvoiceWithHTLCs(t *testing.T) {
 	require.Nil(t, err)
 
 	key := models.CircuitKey{HtlcID: 1}
-	testInvoice.Htlcs[key] = &InvoiceHTLC{}
+	testInvoice.Htlcs[key] = &invpkg.InvoiceHTLC{}
 
 	payHash := testInvoice.Terms.PaymentPreimage.Hash()
 	_, err = db.AddInvoice(testInvoice, payHash)
-	require.Equal(t, ErrInvoiceHasHtlcs, err)
+	require.Equal(t, invpkg.ErrInvoiceHasHtlcs, err)
 }
 
 // TestSetIDIndex asserts that the set id index properly adds new invoices as we
@@ -1803,26 +1857,30 @@ func TestSetIDIndex(t *testing.T) {
 
 	// Update the invoice with an accepted HTLC that also accepts the
 	// invoice.
-	ref := InvoiceRefByHashAndAddr(payHash, invoice.Terms.PaymentAddr)
+	ref := invpkg.InvoiceRefByHashAndAddr(
+		payHash, invoice.Terms.PaymentAddr,
+	)
 	dbInvoice, err := db.UpdateInvoice(
-		ref, (*SetID)(setID), updateAcceptAMPHtlc(0, amt, setID, true),
+		ref, (*invpkg.SetID)(setID),
+		updateAcceptAMPHtlc(0, amt, setID, true),
 	)
 	require.Nil(t, err)
 
 	// We'll update what we expect the accepted invoice to be so that our
 	// comparison below has the correct assumption.
-	invoice.State = ContractOpen
+	invoice.State = invpkg.ContractOpen
 	invoice.AmtPaid = amt
 	invoice.SettleDate = dbInvoice.SettleDate
-	invoice.Htlcs = map[models.CircuitKey]*InvoiceHTLC{
-		{HtlcID: 0}: makeAMPInvoiceHTLC(amt, *setID, payHash, &preimage),
+	htlc0 := models.CircuitKey{HtlcID: 0}
+	invoice.Htlcs = map[models.CircuitKey]*invpkg.InvoiceHTLC{
+		htlc0: makeAMPInvoiceHTLC(amt, *setID, payHash, &preimage),
 	}
-	invoice.AMPState = map[SetID]InvoiceStateAMP{}
-	invoice.AMPState[*setID] = InvoiceStateAMP{
-		State:   HtlcStateAccepted,
+	invoice.AMPState = map[invpkg.SetID]invpkg.InvoiceStateAMP{}
+	invoice.AMPState[*setID] = invpkg.InvoiceStateAMP{
+		State:   invpkg.HtlcStateAccepted,
 		AmtPaid: amt,
 		InvoiceKeys: map[models.CircuitKey]struct{}{
-			{HtlcID: 0}: {},
+			htlc0: {},
 		},
 	}
 
@@ -1830,7 +1888,7 @@ func TestSetIDIndex(t *testing.T) {
 	require.Equal(t, invoice, dbInvoice)
 
 	// Now lookup the invoice by set id and see that we get the same one.
-	refBySetID := InvoiceRefBySetID(*setID)
+	refBySetID := invpkg.InvoiceRefBySetID(*setID)
 	dbInvoiceBySetID, err := db.LookupInvoice(refBySetID)
 	require.Nil(t, err)
 	require.Equal(t, invoice, &dbInvoiceBySetID)
@@ -1848,48 +1906,55 @@ func TestSetIDIndex(t *testing.T) {
 	_, err = db.AddInvoice(invoice2, payHash2)
 	require.Nil(t, err)
 
-	ref2 := InvoiceRefByHashAndAddr(payHash2, invoice2.Terms.PaymentAddr)
-	_, err = db.UpdateInvoice(
-		ref2, (*SetID)(setID), updateAcceptAMPHtlc(0, amt, setID, true),
+	ref2 := invpkg.InvoiceRefByHashAndAddr(
+		payHash2, invoice2.Terms.PaymentAddr,
 	)
-	require.Equal(t, ErrDuplicateSetID{setID: *setID}, err)
+	_, err = db.UpdateInvoice(
+		ref2, (*invpkg.SetID)(setID),
+		updateAcceptAMPHtlc(0, amt, setID, true),
+	)
+	require.Equal(t, invpkg.ErrDuplicateSetID{SetID: *setID}, err)
 
 	// Now, begin constructing a second htlc set under a different set id.
 	// This set will contain two distinct HTLCs.
 	setID2 := &[32]byte{2}
 
 	_, err = db.UpdateInvoice(
-		ref, (*SetID)(setID2), updateAcceptAMPHtlc(1, amt, setID2, false),
+		ref, (*invpkg.SetID)(setID2),
+		updateAcceptAMPHtlc(1, amt, setID2, false),
 	)
 	require.Nil(t, err)
 	dbInvoice, err = db.UpdateInvoice(
-		ref, (*SetID)(setID2), updateAcceptAMPHtlc(2, amt, setID2, false),
+		ref, (*invpkg.SetID)(setID2),
+		updateAcceptAMPHtlc(2, amt, setID2, false),
 	)
 	require.Nil(t, err)
 
 	// We'll update what we expect the settle invoice to be so that our
 	// comparison below has the correct assumption.
-	invoice.State = ContractOpen
+	invoice.State = invpkg.ContractOpen
 	invoice.AmtPaid += 2 * amt
 	invoice.SettleDate = dbInvoice.SettleDate
-	invoice.Htlcs = map[models.CircuitKey]*InvoiceHTLC{
-		{HtlcID: 0}: makeAMPInvoiceHTLC(amt, *setID, payHash, &preimage),
-		{HtlcID: 1}: makeAMPInvoiceHTLC(amt, *setID2, payHash, nil),
-		{HtlcID: 2}: makeAMPInvoiceHTLC(amt, *setID2, payHash, nil),
+	htlc1 := models.CircuitKey{HtlcID: 1}
+	htlc2 := models.CircuitKey{HtlcID: 2}
+	invoice.Htlcs = map[models.CircuitKey]*invpkg.InvoiceHTLC{
+		htlc0: makeAMPInvoiceHTLC(amt, *setID, payHash, &preimage),
+		htlc1: makeAMPInvoiceHTLC(amt, *setID2, payHash, nil),
+		htlc2: makeAMPInvoiceHTLC(amt, *setID2, payHash, nil),
 	}
-	invoice.AMPState[*setID] = InvoiceStateAMP{
-		State:   HtlcStateAccepted,
+	invoice.AMPState[*setID] = invpkg.InvoiceStateAMP{
+		State:   invpkg.HtlcStateAccepted,
 		AmtPaid: amt,
 		InvoiceKeys: map[models.CircuitKey]struct{}{
-			{HtlcID: 0}: {},
+			htlc0: {},
 		},
 	}
-	invoice.AMPState[*setID2] = InvoiceStateAMP{
-		State:   HtlcStateAccepted,
+	invoice.AMPState[*setID2] = invpkg.InvoiceStateAMP{
+		State:   invpkg.HtlcStateAccepted,
 		AmtPaid: amt * 2,
 		InvoiceKeys: map[models.CircuitKey]struct{}{
-			{HtlcID: 1}: {},
-			{HtlcID: 2}: {},
+			htlc1: {},
+			htlc2: {},
 		},
 	}
 
@@ -1904,7 +1969,7 @@ func TestSetIDIndex(t *testing.T) {
 
 	// Now lookup the invoice by second set id and see that we get the same
 	// index, including the htlcs under the first set id.
-	refBySetID = InvoiceRefBySetID(*setID2)
+	refBySetID = invpkg.InvoiceRefBySetID(*setID2)
 	dbInvoiceBySetID, err = db.LookupInvoice(refBySetID)
 	require.Nil(t, err)
 	require.Equal(t, invoice, &dbInvoiceBySetID)
@@ -1918,13 +1983,13 @@ func TestSetIDIndex(t *testing.T) {
 			models.CircuitKey{HtlcID: 99},
 		),
 	)
-	require.Equal(t, ErrEmptyHTLCSet, err)
+	require.Equal(t, invpkg.ErrEmptyHTLCSet, err)
 
 	// Now settle the first htlc set. The existing HTLCs should remain in
 	// the accepted state and shouldn't be canceled, since we permit an
 	// invoice to be settled multiple times.
 	_, err = db.UpdateInvoice(
-		ref, (*SetID)(setID),
+		ref, (*invpkg.SetID)(setID),
 		getUpdateInvoiceAMPSettle(
 			setID, preimage, models.CircuitKey{HtlcID: 0},
 		),
@@ -1935,21 +2000,20 @@ func TestSetIDIndex(t *testing.T) {
 	require.Nil(t, err)
 	dbInvoice = &freshInvoice
 
-	invoice.State = ContractOpen
+	invoice.State = invpkg.ContractOpen
 
 	// The amount paid should reflect that we have 3 present HTLCs, each
 	// with an amount of the original invoice.
 	invoice.AmtPaid = amt * 3
 
 	ampState := invoice.AMPState[*setID]
-	ampState.State = HtlcStateSettled
+	ampState.State = invpkg.HtlcStateSettled
 	ampState.SettleDate = testNow
 	ampState.SettleIndex = 1
 
 	invoice.AMPState[*setID] = ampState
 
-	htlc0 := models.CircuitKey{HtlcID: 0}
-	invoice.Htlcs[htlc0].State = HtlcStateSettled
+	invoice.Htlcs[htlc0].State = invpkg.HtlcStateSettled
 	invoice.Htlcs[htlc0].ResolveTime = time.Unix(1, 0)
 
 	require.Equal(t, invoice, dbInvoice)
@@ -1957,19 +2021,19 @@ func TestSetIDIndex(t *testing.T) {
 	// If we try to settle the same set ID again, then we should get an
 	// error, as it's already been settled.
 	_, err = db.UpdateInvoice(
-		ref, (*SetID)(setID),
+		ref, (*invpkg.SetID)(setID),
 		getUpdateInvoiceAMPSettle(
 			setID, preimage, models.CircuitKey{HtlcID: 0},
 		),
 	)
-	require.Equal(t, ErrEmptyHTLCSet, err)
+	require.Equal(t, invpkg.ErrEmptyHTLCSet, err)
 
 	// Next, let's attempt to settle the other active set ID for this
 	// invoice. This will allow us to exercise the case where we go to
 	// settle an invoice with a new setID after one has already been fully
 	// settled.
 	_, err = db.UpdateInvoice(
-		ref, (*SetID)(setID2),
+		ref, (*invpkg.SetID)(setID2),
 		getUpdateInvoiceAMPSettle(
 			setID2, preimage, models.CircuitKey{HtlcID: 1},
 			models.CircuitKey{HtlcID: 2},
@@ -1983,40 +2047,38 @@ func TestSetIDIndex(t *testing.T) {
 
 	// Now the rest of the HTLCs should show as fully settled.
 	ampState = invoice.AMPState[*setID2]
-	ampState.State = HtlcStateSettled
+	ampState.State = invpkg.HtlcStateSettled
 	ampState.SettleDate = testNow
 	ampState.SettleIndex = 2
 
 	invoice.AMPState[*setID2] = ampState
 
-	htlc1 := models.CircuitKey{HtlcID: 1}
-	htlc2 := models.CircuitKey{HtlcID: 2}
-	invoice.Htlcs[htlc1].State = HtlcStateSettled
+	invoice.Htlcs[htlc1].State = invpkg.HtlcStateSettled
 	invoice.Htlcs[htlc1].ResolveTime = time.Unix(1, 0)
 	invoice.Htlcs[htlc1].AMP.Preimage = &preimage
 
-	invoice.Htlcs[htlc2].State = HtlcStateSettled
+	invoice.Htlcs[htlc2].State = invpkg.HtlcStateSettled
 	invoice.Htlcs[htlc2].ResolveTime = time.Unix(1, 0)
 	invoice.Htlcs[htlc2].AMP.Preimage = &preimage
 
 	require.Equal(t, invoice, dbInvoice)
 
 	// Lastly, querying for an unknown set id should fail.
-	refUnknownSetID := InvoiceRefBySetID([32]byte{})
+	refUnknownSetID := invpkg.InvoiceRefBySetID([32]byte{})
 	_, err = db.LookupInvoice(refUnknownSetID)
-	require.Equal(t, ErrInvoiceNotFound, err)
+	require.Equal(t, invpkg.ErrInvoiceNotFound, err)
 }
 
 func makeAMPInvoiceHTLC(amt lnwire.MilliSatoshi, setID [32]byte,
-	hash lntypes.Hash, preimage *lntypes.Preimage) *InvoiceHTLC {
+	hash lntypes.Hash, preimage *lntypes.Preimage) *invpkg.InvoiceHTLC {
 
-	return &InvoiceHTLC{
+	return &invpkg.InvoiceHTLC{
 		Amt:           amt,
 		AcceptTime:    testNow,
 		ResolveTime:   time.Time{},
-		State:         HtlcStateAccepted,
+		State:         invpkg.HtlcStateAccepted,
 		CustomRecords: make(record.CustomSet),
-		AMP: &InvoiceHtlcAMPData{
+		AMP: &invpkg.InvoiceHtlcAMPData{
 			Record:   *record.NewAMP([32]byte{}, setID, 0),
 			Hash:     hash,
 			Preimage: preimage,
@@ -2027,42 +2089,47 @@ func makeAMPInvoiceHTLC(amt lnwire.MilliSatoshi, setID [32]byte,
 // updateAcceptAMPHtlc returns an invoice update callback that, when called,
 // settles the invoice with the given amount.
 func updateAcceptAMPHtlc(id uint64, amt lnwire.MilliSatoshi,
-	setID *[32]byte, accept bool) InvoiceUpdateCallback {
+	setID *[32]byte, accept bool) invpkg.InvoiceUpdateCallback {
 
-	return func(invoice *Invoice) (*InvoiceUpdateDesc, error) {
-		if invoice.State == ContractSettled {
-			return nil, ErrInvoiceAlreadySettled
+	return func(invoice *invpkg.Invoice) (*invpkg.InvoiceUpdateDesc,
+		error) {
+
+		if invoice.State == invpkg.ContractSettled {
+			return nil, invpkg.ErrInvoiceAlreadySettled
 		}
 
 		noRecords := make(record.CustomSet)
 
 		var (
-			state    *InvoiceStateUpdateDesc
+			state    *invpkg.InvoiceStateUpdateDesc
 			preimage *lntypes.Preimage
 		)
 		if accept {
-			state = &InvoiceStateUpdateDesc{
-				NewState: ContractAccepted,
+			state = &invpkg.InvoiceStateUpdateDesc{
+				NewState: invpkg.ContractAccepted,
 				SetID:    setID,
 			}
 			pre := *invoice.Terms.PaymentPreimage
 			preimage = &pre
 		}
 
-		ampData := &InvoiceHtlcAMPData{
+		ampData := &invpkg.InvoiceHtlcAMPData{
 			Record:   *record.NewAMP([32]byte{}, *setID, 0),
 			Hash:     invoice.Terms.PaymentPreimage.Hash(),
 			Preimage: preimage,
 		}
-		update := &InvoiceUpdateDesc{
-			State: state,
-			AddHtlcs: map[models.CircuitKey]*HtlcAcceptDesc{
-				{HtlcID: id}: {
-					Amt:           amt,
-					CustomRecords: noRecords,
-					AMP:           ampData,
-				},
+
+		htlcs := map[models.CircuitKey]*invpkg.HtlcAcceptDesc{
+			{HtlcID: id}: {
+				Amt:           amt,
+				CustomRecords: noRecords,
+				AMP:           ampData,
 			},
+		}
+
+		update := &invpkg.InvoiceUpdateDesc{
+			State:    state,
+			AddHtlcs: htlcs,
 		}
 
 		return update, nil
@@ -2070,11 +2137,13 @@ func updateAcceptAMPHtlc(id uint64, amt lnwire.MilliSatoshi,
 }
 
 func getUpdateInvoiceAMPSettle(setID *[32]byte, preimage [32]byte,
-	circuitKeys ...models.CircuitKey) InvoiceUpdateCallback {
+	circuitKeys ...models.CircuitKey) invpkg.InvoiceUpdateCallback {
 
-	return func(invoice *Invoice) (*InvoiceUpdateDesc, error) {
-		if invoice.State == ContractSettled {
-			return nil, ErrInvoiceAlreadySettled
+	return func(invoice *invpkg.Invoice) (*invpkg.InvoiceUpdateDesc,
+		error) {
+
+		if invoice.State == invpkg.ContractSettled {
+			return nil, invpkg.ErrInvoiceAlreadySettled
 		}
 
 		preImageSet := make(map[models.CircuitKey]lntypes.Preimage)
@@ -2082,10 +2151,10 @@ func getUpdateInvoiceAMPSettle(setID *[32]byte, preimage [32]byte,
 			preImageSet[key] = preimage
 		}
 
-		update := &InvoiceUpdateDesc{
-			State: &InvoiceStateUpdateDesc{
+		update := &invpkg.InvoiceUpdateDesc{
+			State: &invpkg.InvoiceStateUpdateDesc{
 				Preimage:      nil,
-				NewState:      ContractSettled,
+				NewState:      invpkg.ContractSettled,
 				SetID:         setID,
 				HTLCPreimages: preImageSet,
 			},
@@ -2118,12 +2187,12 @@ func TestUnexpectedInvoicePreimage(t *testing.T) {
 	// in order to settle an MPP invoice, the InvoiceRef must present a
 	// payment hash against which to validate the preimage.
 	_, err = db.UpdateInvoice(
-		InvoiceRefByAddr(invoice.Terms.PaymentAddr), nil,
+		invpkg.InvoiceRefByAddr(invoice.Terms.PaymentAddr), nil,
 		getUpdateInvoice(invoice.Terms.Value),
 	)
 
 	// Assert that we get ErrUnexpectedInvoicePreimage.
-	require.Error(t, ErrUnexpectedInvoicePreimage, err)
+	require.Error(t, invpkg.ErrUnexpectedInvoicePreimage, err)
 }
 
 type updateHTLCPreimageTestCase struct {
@@ -2146,7 +2215,7 @@ func TestUpdateHTLCPreimages(t *testing.T) {
 		{
 			name:               "diff preimage on settle",
 			settleSamePreimage: false,
-			expError:           ErrHTLCPreimageAlreadyExists,
+			expError:           invpkg.ErrHTLCPreimageAlreadyExists,
 		},
 	}
 
@@ -2181,9 +2250,10 @@ func testUpdateHTLCPreimages(t *testing.T, test updateHTLCPreimageTestCase) {
 
 	// Update the invoice with an accepted HTLC that also accepts the
 	// invoice.
-	ref := InvoiceRefByAddr(invoice.Terms.PaymentAddr)
+	ref := invpkg.InvoiceRefByAddr(invoice.Terms.PaymentAddr)
 	dbInvoice, err := db.UpdateInvoice(
-		ref, (*SetID)(setID), updateAcceptAMPHtlc(0, amt, setID, true),
+		ref, (*invpkg.SetID)(setID),
+		updateAcceptAMPHtlc(0, amt, setID, true),
 	)
 	require.Nil(t, err)
 
@@ -2198,11 +2268,13 @@ func testUpdateHTLCPreimages(t *testing.T, test updateHTLCPreimageTestCase) {
 		htlcPreimages[key] = pre
 	}
 
-	updateInvoice := func(invoice *Invoice) (*InvoiceUpdateDesc, error) {
-		update := &InvoiceUpdateDesc{
-			State: &InvoiceStateUpdateDesc{
+	updateInvoice := func(
+		invoice *invpkg.Invoice) (*invpkg.InvoiceUpdateDesc, error) {
+
+		update := &invpkg.InvoiceUpdateDesc{
+			State: &invpkg.InvoiceStateUpdateDesc{
 				Preimage:      nil,
-				NewState:      ContractSettled,
+				NewState:      invpkg.ContractSettled,
 				HTLCPreimages: htlcPreimages,
 				SetID:         setID,
 			},
@@ -2212,16 +2284,16 @@ func testUpdateHTLCPreimages(t *testing.T, test updateHTLCPreimageTestCase) {
 	}
 
 	// Now settle the HTLC set and assert the resulting error.
-	_, err = db.UpdateInvoice(ref, (*SetID)(setID), updateInvoice)
+	_, err = db.UpdateInvoice(ref, (*invpkg.SetID)(setID), updateInvoice)
 	require.Equal(t, test.expError, err)
 }
 
 type updateHTLCTest struct {
 	name     string
-	input    InvoiceHTLC
-	invState ContractState
+	input    invpkg.InvoiceHTLC
+	invState invpkg.ContractState
 	setID    *[32]byte
-	output   InvoiceHTLC
+	output   invpkg.InvoiceHTLC
 	expErr   error
 }
 
@@ -2242,27 +2314,27 @@ func TestUpdateHTLC(t *testing.T) {
 	tests := []updateHTLCTest{
 		{
 			name: "MPP accept",
-			input: InvoiceHTLC{
+			input: invpkg.InvoiceHTLC{
 				Amt:           5000,
 				MppTotalAmt:   5000,
 				AcceptHeight:  100,
 				AcceptTime:    testNow,
 				ResolveTime:   time.Time{},
 				Expiry:        40,
-				State:         HtlcStateAccepted,
+				State:         invpkg.HtlcStateAccepted,
 				CustomRecords: make(record.CustomSet),
 				AMP:           nil,
 			},
-			invState: ContractAccepted,
+			invState: invpkg.ContractAccepted,
 			setID:    nil,
-			output: InvoiceHTLC{
+			output: invpkg.InvoiceHTLC{
 				Amt:           5000,
 				MppTotalAmt:   5000,
 				AcceptHeight:  100,
 				AcceptTime:    testNow,
 				ResolveTime:   time.Time{},
 				Expiry:        40,
-				State:         HtlcStateAccepted,
+				State:         invpkg.HtlcStateAccepted,
 				CustomRecords: make(record.CustomSet),
 				AMP:           nil,
 			},
@@ -2270,27 +2342,27 @@ func TestUpdateHTLC(t *testing.T) {
 		},
 		{
 			name: "MPP settle",
-			input: InvoiceHTLC{
+			input: invpkg.InvoiceHTLC{
 				Amt:           5000,
 				MppTotalAmt:   5000,
 				AcceptHeight:  100,
 				AcceptTime:    testNow,
 				ResolveTime:   time.Time{},
 				Expiry:        40,
-				State:         HtlcStateAccepted,
+				State:         invpkg.HtlcStateAccepted,
 				CustomRecords: make(record.CustomSet),
 				AMP:           nil,
 			},
-			invState: ContractSettled,
+			invState: invpkg.ContractSettled,
 			setID:    nil,
-			output: InvoiceHTLC{
+			output: invpkg.InvoiceHTLC{
 				Amt:           5000,
 				MppTotalAmt:   5000,
 				AcceptHeight:  100,
 				AcceptTime:    testNow,
 				ResolveTime:   testNow,
 				Expiry:        40,
-				State:         HtlcStateSettled,
+				State:         invpkg.HtlcStateSettled,
 				CustomRecords: make(record.CustomSet),
 				AMP:           nil,
 			},
@@ -2298,27 +2370,27 @@ func TestUpdateHTLC(t *testing.T) {
 		},
 		{
 			name: "MPP cancel",
-			input: InvoiceHTLC{
+			input: invpkg.InvoiceHTLC{
 				Amt:           5000,
 				MppTotalAmt:   5000,
 				AcceptHeight:  100,
 				AcceptTime:    testNow,
 				ResolveTime:   time.Time{},
 				Expiry:        40,
-				State:         HtlcStateAccepted,
+				State:         invpkg.HtlcStateAccepted,
 				CustomRecords: make(record.CustomSet),
 				AMP:           nil,
 			},
-			invState: ContractCanceled,
+			invState: invpkg.ContractCanceled,
 			setID:    nil,
-			output: InvoiceHTLC{
+			output: invpkg.InvoiceHTLC{
 				Amt:           5000,
 				MppTotalAmt:   5000,
 				AcceptHeight:  100,
 				AcceptTime:    testNow,
 				ResolveTime:   testNow,
 				Expiry:        40,
-				State:         HtlcStateCanceled,
+				State:         invpkg.HtlcStateCanceled,
 				CustomRecords: make(record.CustomSet),
 				AMP:           nil,
 			},
@@ -2326,105 +2398,105 @@ func TestUpdateHTLC(t *testing.T) {
 		},
 		{
 			name: "AMP accept missing preimage",
-			input: InvoiceHTLC{
+			input: invpkg.InvoiceHTLC{
 				Amt:           5000,
 				MppTotalAmt:   5000,
 				AcceptHeight:  100,
 				AcceptTime:    testNow,
 				ResolveTime:   time.Time{},
 				Expiry:        40,
-				State:         HtlcStateAccepted,
+				State:         invpkg.HtlcStateAccepted,
 				CustomRecords: make(record.CustomSet),
-				AMP: &InvoiceHtlcAMPData{
+				AMP: &invpkg.InvoiceHtlcAMPData{
 					Record:   *ampRecord,
 					Hash:     hash,
 					Preimage: nil,
 				},
 			},
-			invState: ContractAccepted,
+			invState: invpkg.ContractAccepted,
 			setID:    &setID,
-			output: InvoiceHTLC{
+			output: invpkg.InvoiceHTLC{
 				Amt:           5000,
 				MppTotalAmt:   5000,
 				AcceptHeight:  100,
 				AcceptTime:    testNow,
 				ResolveTime:   time.Time{},
 				Expiry:        40,
-				State:         HtlcStateAccepted,
+				State:         invpkg.HtlcStateAccepted,
 				CustomRecords: make(record.CustomSet),
-				AMP: &InvoiceHtlcAMPData{
+				AMP: &invpkg.InvoiceHtlcAMPData{
 					Record:   *ampRecord,
 					Hash:     hash,
 					Preimage: nil,
 				},
 			},
-			expErr: ErrHTLCPreimageMissing,
+			expErr: invpkg.ErrHTLCPreimageMissing,
 		},
 		{
 			name: "AMP accept invalid preimage",
-			input: InvoiceHTLC{
+			input: invpkg.InvoiceHTLC{
 				Amt:           5000,
 				MppTotalAmt:   5000,
 				AcceptHeight:  100,
 				AcceptTime:    testNow,
 				ResolveTime:   time.Time{},
 				Expiry:        40,
-				State:         HtlcStateAccepted,
+				State:         invpkg.HtlcStateAccepted,
 				CustomRecords: make(record.CustomSet),
-				AMP: &InvoiceHtlcAMPData{
+				AMP: &invpkg.InvoiceHtlcAMPData{
 					Record:   *ampRecord,
 					Hash:     hash,
 					Preimage: &fakePreimage,
 				},
 			},
-			invState: ContractAccepted,
+			invState: invpkg.ContractAccepted,
 			setID:    &setID,
-			output: InvoiceHTLC{
+			output: invpkg.InvoiceHTLC{
 				Amt:           5000,
 				MppTotalAmt:   5000,
 				AcceptHeight:  100,
 				AcceptTime:    testNow,
 				ResolveTime:   time.Time{},
 				Expiry:        40,
-				State:         HtlcStateAccepted,
+				State:         invpkg.HtlcStateAccepted,
 				CustomRecords: make(record.CustomSet),
-				AMP: &InvoiceHtlcAMPData{
+				AMP: &invpkg.InvoiceHtlcAMPData{
 					Record:   *ampRecord,
 					Hash:     hash,
 					Preimage: &fakePreimage,
 				},
 			},
-			expErr: ErrHTLCPreimageMismatch,
+			expErr: invpkg.ErrHTLCPreimageMismatch,
 		},
 		{
 			name: "AMP accept valid preimage",
-			input: InvoiceHTLC{
+			input: invpkg.InvoiceHTLC{
 				Amt:           5000,
 				MppTotalAmt:   5000,
 				AcceptHeight:  100,
 				AcceptTime:    testNow,
 				ResolveTime:   time.Time{},
 				Expiry:        40,
-				State:         HtlcStateAccepted,
+				State:         invpkg.HtlcStateAccepted,
 				CustomRecords: make(record.CustomSet),
-				AMP: &InvoiceHtlcAMPData{
+				AMP: &invpkg.InvoiceHtlcAMPData{
 					Record:   *ampRecord,
 					Hash:     hash,
 					Preimage: &preimage,
 				},
 			},
-			invState: ContractAccepted,
+			invState: invpkg.ContractAccepted,
 			setID:    &setID,
-			output: InvoiceHTLC{
+			output: invpkg.InvoiceHTLC{
 				Amt:           5000,
 				MppTotalAmt:   5000,
 				AcceptHeight:  100,
 				AcceptTime:    testNow,
 				ResolveTime:   time.Time{},
 				Expiry:        40,
-				State:         HtlcStateAccepted,
+				State:         invpkg.HtlcStateAccepted,
 				CustomRecords: make(record.CustomSet),
-				AMP: &InvoiceHtlcAMPData{
+				AMP: &invpkg.InvoiceHtlcAMPData{
 					Record:   *ampRecord,
 					Hash:     hash,
 					Preimage: &preimage,
@@ -2434,33 +2506,33 @@ func TestUpdateHTLC(t *testing.T) {
 		},
 		{
 			name: "AMP accept valid preimage different htlc set",
-			input: InvoiceHTLC{
+			input: invpkg.InvoiceHTLC{
 				Amt:           5000,
 				MppTotalAmt:   5000,
 				AcceptHeight:  100,
 				AcceptTime:    testNow,
 				ResolveTime:   time.Time{},
 				Expiry:        40,
-				State:         HtlcStateAccepted,
+				State:         invpkg.HtlcStateAccepted,
 				CustomRecords: make(record.CustomSet),
-				AMP: &InvoiceHtlcAMPData{
+				AMP: &invpkg.InvoiceHtlcAMPData{
 					Record:   *ampRecord,
 					Hash:     hash,
 					Preimage: &preimage,
 				},
 			},
-			invState: ContractAccepted,
+			invState: invpkg.ContractAccepted,
 			setID:    &diffSetID,
-			output: InvoiceHTLC{
+			output: invpkg.InvoiceHTLC{
 				Amt:           5000,
 				MppTotalAmt:   5000,
 				AcceptHeight:  100,
 				AcceptTime:    testNow,
 				ResolveTime:   time.Time{},
 				Expiry:        40,
-				State:         HtlcStateAccepted,
+				State:         invpkg.HtlcStateAccepted,
 				CustomRecords: make(record.CustomSet),
-				AMP: &InvoiceHtlcAMPData{
+				AMP: &invpkg.InvoiceHtlcAMPData{
 					Record:   *ampRecord,
 					Hash:     hash,
 					Preimage: &preimage,
@@ -2470,105 +2542,105 @@ func TestUpdateHTLC(t *testing.T) {
 		},
 		{
 			name: "AMP settle missing preimage",
-			input: InvoiceHTLC{
+			input: invpkg.InvoiceHTLC{
 				Amt:           5000,
 				MppTotalAmt:   5000,
 				AcceptHeight:  100,
 				AcceptTime:    testNow,
 				ResolveTime:   time.Time{},
 				Expiry:        40,
-				State:         HtlcStateAccepted,
+				State:         invpkg.HtlcStateAccepted,
 				CustomRecords: make(record.CustomSet),
-				AMP: &InvoiceHtlcAMPData{
+				AMP: &invpkg.InvoiceHtlcAMPData{
 					Record:   *ampRecord,
 					Hash:     hash,
 					Preimage: nil,
 				},
 			},
-			invState: ContractSettled,
+			invState: invpkg.ContractSettled,
 			setID:    &setID,
-			output: InvoiceHTLC{
+			output: invpkg.InvoiceHTLC{
 				Amt:           5000,
 				MppTotalAmt:   5000,
 				AcceptHeight:  100,
 				AcceptTime:    testNow,
 				ResolveTime:   time.Time{},
 				Expiry:        40,
-				State:         HtlcStateAccepted,
+				State:         invpkg.HtlcStateAccepted,
 				CustomRecords: make(record.CustomSet),
-				AMP: &InvoiceHtlcAMPData{
+				AMP: &invpkg.InvoiceHtlcAMPData{
 					Record:   *ampRecord,
 					Hash:     hash,
 					Preimage: nil,
 				},
 			},
-			expErr: ErrHTLCPreimageMissing,
+			expErr: invpkg.ErrHTLCPreimageMissing,
 		},
 		{
 			name: "AMP settle invalid preimage",
-			input: InvoiceHTLC{
+			input: invpkg.InvoiceHTLC{
 				Amt:           5000,
 				MppTotalAmt:   5000,
 				AcceptHeight:  100,
 				AcceptTime:    testNow,
 				ResolveTime:   time.Time{},
 				Expiry:        40,
-				State:         HtlcStateAccepted,
+				State:         invpkg.HtlcStateAccepted,
 				CustomRecords: make(record.CustomSet),
-				AMP: &InvoiceHtlcAMPData{
+				AMP: &invpkg.InvoiceHtlcAMPData{
 					Record:   *ampRecord,
 					Hash:     hash,
 					Preimage: &fakePreimage,
 				},
 			},
-			invState: ContractSettled,
+			invState: invpkg.ContractSettled,
 			setID:    &setID,
-			output: InvoiceHTLC{
+			output: invpkg.InvoiceHTLC{
 				Amt:           5000,
 				MppTotalAmt:   5000,
 				AcceptHeight:  100,
 				AcceptTime:    testNow,
 				ResolveTime:   time.Time{},
 				Expiry:        40,
-				State:         HtlcStateAccepted,
+				State:         invpkg.HtlcStateAccepted,
 				CustomRecords: make(record.CustomSet),
-				AMP: &InvoiceHtlcAMPData{
+				AMP: &invpkg.InvoiceHtlcAMPData{
 					Record:   *ampRecord,
 					Hash:     hash,
 					Preimage: &fakePreimage,
 				},
 			},
-			expErr: ErrHTLCPreimageMismatch,
+			expErr: invpkg.ErrHTLCPreimageMismatch,
 		},
 		{
 			name: "AMP settle valid preimage",
-			input: InvoiceHTLC{
+			input: invpkg.InvoiceHTLC{
 				Amt:           5000,
 				MppTotalAmt:   5000,
 				AcceptHeight:  100,
 				AcceptTime:    testNow,
 				ResolveTime:   time.Time{},
 				Expiry:        40,
-				State:         HtlcStateAccepted,
+				State:         invpkg.HtlcStateAccepted,
 				CustomRecords: make(record.CustomSet),
-				AMP: &InvoiceHtlcAMPData{
+				AMP: &invpkg.InvoiceHtlcAMPData{
 					Record:   *ampRecord,
 					Hash:     hash,
 					Preimage: &preimage,
 				},
 			},
-			invState: ContractSettled,
+			invState: invpkg.ContractSettled,
 			setID:    &setID,
-			output: InvoiceHTLC{
+			output: invpkg.InvoiceHTLC{
 				Amt:           5000,
 				MppTotalAmt:   5000,
 				AcceptHeight:  100,
 				AcceptTime:    testNow,
 				ResolveTime:   testNow,
 				Expiry:        40,
-				State:         HtlcStateSettled,
+				State:         invpkg.HtlcStateSettled,
 				CustomRecords: make(record.CustomSet),
-				AMP: &InvoiceHtlcAMPData{
+				AMP: &invpkg.InvoiceHtlcAMPData{
 					Record:   *ampRecord,
 					Hash:     hash,
 					Preimage: &preimage,
@@ -2582,33 +2654,33 @@ func TestUpdateHTLC(t *testing.T) {
 			// to a given pay_addr. In this case, the HTLC should
 			// remain in the accepted state.
 			name: "AMP settle valid preimage different htlc set",
-			input: InvoiceHTLC{
+			input: invpkg.InvoiceHTLC{
 				Amt:           5000,
 				MppTotalAmt:   5000,
 				AcceptHeight:  100,
 				AcceptTime:    testNow,
 				ResolveTime:   time.Time{},
 				Expiry:        40,
-				State:         HtlcStateAccepted,
+				State:         invpkg.HtlcStateAccepted,
 				CustomRecords: make(record.CustomSet),
-				AMP: &InvoiceHtlcAMPData{
+				AMP: &invpkg.InvoiceHtlcAMPData{
 					Record:   *ampRecord,
 					Hash:     hash,
 					Preimage: &preimage,
 				},
 			},
-			invState: ContractSettled,
+			invState: invpkg.ContractSettled,
 			setID:    &diffSetID,
-			output: InvoiceHTLC{
+			output: invpkg.InvoiceHTLC{
 				Amt:           5000,
 				MppTotalAmt:   5000,
 				AcceptHeight:  100,
 				AcceptTime:    testNow,
 				ResolveTime:   time.Time{},
 				Expiry:        40,
-				State:         HtlcStateAccepted,
+				State:         invpkg.HtlcStateAccepted,
 				CustomRecords: make(record.CustomSet),
-				AMP: &InvoiceHtlcAMPData{
+				AMP: &invpkg.InvoiceHtlcAMPData{
 					Record:   *ampRecord,
 					Hash:     hash,
 					Preimage: &preimage,
@@ -2618,105 +2690,105 @@ func TestUpdateHTLC(t *testing.T) {
 		},
 		{
 			name: "accept invoice htlc already settled",
-			input: InvoiceHTLC{
+			input: invpkg.InvoiceHTLC{
 				Amt:           5000,
 				MppTotalAmt:   5000,
 				AcceptHeight:  100,
 				AcceptTime:    testNow,
 				ResolveTime:   testAlreadyNow,
 				Expiry:        40,
-				State:         HtlcStateSettled,
+				State:         invpkg.HtlcStateSettled,
 				CustomRecords: make(record.CustomSet),
-				AMP: &InvoiceHtlcAMPData{
+				AMP: &invpkg.InvoiceHtlcAMPData{
 					Record:   *ampRecord,
 					Hash:     hash,
 					Preimage: &preimage,
 				},
 			},
-			invState: ContractAccepted,
+			invState: invpkg.ContractAccepted,
 			setID:    &setID,
-			output: InvoiceHTLC{
+			output: invpkg.InvoiceHTLC{
 				Amt:           5000,
 				MppTotalAmt:   5000,
 				AcceptHeight:  100,
 				AcceptTime:    testNow,
 				ResolveTime:   testAlreadyNow,
 				Expiry:        40,
-				State:         HtlcStateSettled,
+				State:         invpkg.HtlcStateSettled,
 				CustomRecords: make(record.CustomSet),
-				AMP: &InvoiceHtlcAMPData{
+				AMP: &invpkg.InvoiceHtlcAMPData{
 					Record:   *ampRecord,
 					Hash:     hash,
 					Preimage: &preimage,
 				},
 			},
-			expErr: ErrHTLCAlreadySettled,
+			expErr: invpkg.ErrHTLCAlreadySettled,
 		},
 		{
 			name: "cancel invoice htlc already settled",
-			input: InvoiceHTLC{
+			input: invpkg.InvoiceHTLC{
 				Amt:           5000,
 				MppTotalAmt:   5000,
 				AcceptHeight:  100,
 				AcceptTime:    testNow,
 				ResolveTime:   testAlreadyNow,
 				Expiry:        40,
-				State:         HtlcStateSettled,
+				State:         invpkg.HtlcStateSettled,
 				CustomRecords: make(record.CustomSet),
-				AMP: &InvoiceHtlcAMPData{
+				AMP: &invpkg.InvoiceHtlcAMPData{
 					Record:   *ampRecord,
 					Hash:     hash,
 					Preimage: &preimage,
 				},
 			},
-			invState: ContractCanceled,
+			invState: invpkg.ContractCanceled,
 			setID:    &setID,
-			output: InvoiceHTLC{
+			output: invpkg.InvoiceHTLC{
 				Amt:           5000,
 				MppTotalAmt:   5000,
 				AcceptHeight:  100,
 				AcceptTime:    testNow,
 				ResolveTime:   testAlreadyNow,
 				Expiry:        40,
-				State:         HtlcStateSettled,
+				State:         invpkg.HtlcStateSettled,
 				CustomRecords: make(record.CustomSet),
-				AMP: &InvoiceHtlcAMPData{
+				AMP: &invpkg.InvoiceHtlcAMPData{
 					Record:   *ampRecord,
 					Hash:     hash,
 					Preimage: &preimage,
 				},
 			},
-			expErr: ErrHTLCAlreadySettled,
+			expErr: invpkg.ErrHTLCAlreadySettled,
 		},
 		{
 			name: "settle invoice htlc already settled",
-			input: InvoiceHTLC{
+			input: invpkg.InvoiceHTLC{
 				Amt:           5000,
 				MppTotalAmt:   5000,
 				AcceptHeight:  100,
 				AcceptTime:    testNow,
 				ResolveTime:   testAlreadyNow,
 				Expiry:        40,
-				State:         HtlcStateSettled,
+				State:         invpkg.HtlcStateSettled,
 				CustomRecords: make(record.CustomSet),
-				AMP: &InvoiceHtlcAMPData{
+				AMP: &invpkg.InvoiceHtlcAMPData{
 					Record:   *ampRecord,
 					Hash:     hash,
 					Preimage: &preimage,
 				},
 			},
-			invState: ContractSettled,
+			invState: invpkg.ContractSettled,
 			setID:    &setID,
-			output: InvoiceHTLC{
+			output: invpkg.InvoiceHTLC{
 				Amt:           5000,
 				MppTotalAmt:   5000,
 				AcceptHeight:  100,
 				AcceptTime:    testNow,
 				ResolveTime:   testAlreadyNow,
 				Expiry:        40,
-				State:         HtlcStateSettled,
+				State:         invpkg.HtlcStateSettled,
 				CustomRecords: make(record.CustomSet),
-				AMP: &InvoiceHtlcAMPData{
+				AMP: &invpkg.InvoiceHtlcAMPData{
 					Record:   *ampRecord,
 					Hash:     hash,
 					Preimage: &preimage,
@@ -2726,33 +2798,33 @@ func TestUpdateHTLC(t *testing.T) {
 		},
 		{
 			name: "cancel invoice",
-			input: InvoiceHTLC{
+			input: invpkg.InvoiceHTLC{
 				Amt:           5000,
 				MppTotalAmt:   5000,
 				AcceptHeight:  100,
 				AcceptTime:    testNow,
 				ResolveTime:   time.Time{},
 				Expiry:        40,
-				State:         HtlcStateAccepted,
+				State:         invpkg.HtlcStateAccepted,
 				CustomRecords: make(record.CustomSet),
-				AMP: &InvoiceHtlcAMPData{
+				AMP: &invpkg.InvoiceHtlcAMPData{
 					Record:   *ampRecord,
 					Hash:     hash,
 					Preimage: &preimage,
 				},
 			},
-			invState: ContractCanceled,
+			invState: invpkg.ContractCanceled,
 			setID:    &setID,
-			output: InvoiceHTLC{
+			output: invpkg.InvoiceHTLC{
 				Amt:           5000,
 				MppTotalAmt:   5000,
 				AcceptHeight:  100,
 				AcceptTime:    testNow,
 				ResolveTime:   testNow,
 				Expiry:        40,
-				State:         HtlcStateCanceled,
+				State:         invpkg.HtlcStateCanceled,
 				CustomRecords: make(record.CustomSet),
-				AMP: &InvoiceHtlcAMPData{
+				AMP: &invpkg.InvoiceHtlcAMPData{
 					Record:   *ampRecord,
 					Hash:     hash,
 					Preimage: &preimage,
@@ -2762,33 +2834,33 @@ func TestUpdateHTLC(t *testing.T) {
 		},
 		{
 			name: "accept invoice htlc already canceled",
-			input: InvoiceHTLC{
+			input: invpkg.InvoiceHTLC{
 				Amt:           5000,
 				MppTotalAmt:   5000,
 				AcceptHeight:  100,
 				AcceptTime:    testNow,
 				ResolveTime:   testAlreadyNow,
 				Expiry:        40,
-				State:         HtlcStateCanceled,
+				State:         invpkg.HtlcStateCanceled,
 				CustomRecords: make(record.CustomSet),
-				AMP: &InvoiceHtlcAMPData{
+				AMP: &invpkg.InvoiceHtlcAMPData{
 					Record:   *ampRecord,
 					Hash:     hash,
 					Preimage: &preimage,
 				},
 			},
-			invState: ContractAccepted,
+			invState: invpkg.ContractAccepted,
 			setID:    &setID,
-			output: InvoiceHTLC{
+			output: invpkg.InvoiceHTLC{
 				Amt:           5000,
 				MppTotalAmt:   5000,
 				AcceptHeight:  100,
 				AcceptTime:    testNow,
 				ResolveTime:   testAlreadyNow,
 				Expiry:        40,
-				State:         HtlcStateCanceled,
+				State:         invpkg.HtlcStateCanceled,
 				CustomRecords: make(record.CustomSet),
-				AMP: &InvoiceHtlcAMPData{
+				AMP: &invpkg.InvoiceHtlcAMPData{
 					Record:   *ampRecord,
 					Hash:     hash,
 					Preimage: &preimage,
@@ -2798,33 +2870,33 @@ func TestUpdateHTLC(t *testing.T) {
 		},
 		{
 			name: "cancel invoice htlc already canceled",
-			input: InvoiceHTLC{
+			input: invpkg.InvoiceHTLC{
 				Amt:           5000,
 				MppTotalAmt:   5000,
 				AcceptHeight:  100,
 				AcceptTime:    testNow,
 				ResolveTime:   testAlreadyNow,
 				Expiry:        40,
-				State:         HtlcStateCanceled,
+				State:         invpkg.HtlcStateCanceled,
 				CustomRecords: make(record.CustomSet),
-				AMP: &InvoiceHtlcAMPData{
+				AMP: &invpkg.InvoiceHtlcAMPData{
 					Record:   *ampRecord,
 					Hash:     hash,
 					Preimage: &preimage,
 				},
 			},
-			invState: ContractCanceled,
+			invState: invpkg.ContractCanceled,
 			setID:    &setID,
-			output: InvoiceHTLC{
+			output: invpkg.InvoiceHTLC{
 				Amt:           5000,
 				MppTotalAmt:   5000,
 				AcceptHeight:  100,
 				AcceptTime:    testNow,
 				ResolveTime:   testAlreadyNow,
 				Expiry:        40,
-				State:         HtlcStateCanceled,
+				State:         invpkg.HtlcStateCanceled,
 				CustomRecords: make(record.CustomSet),
-				AMP: &InvoiceHtlcAMPData{
+				AMP: &invpkg.InvoiceHtlcAMPData{
 					Record:   *ampRecord,
 					Hash:     hash,
 					Preimage: &preimage,
@@ -2834,33 +2906,33 @@ func TestUpdateHTLC(t *testing.T) {
 		},
 		{
 			name: "settle invoice htlc already canceled",
-			input: InvoiceHTLC{
+			input: invpkg.InvoiceHTLC{
 				Amt:           5000,
 				MppTotalAmt:   5000,
 				AcceptHeight:  100,
 				AcceptTime:    testNow,
 				ResolveTime:   testAlreadyNow,
 				Expiry:        40,
-				State:         HtlcStateCanceled,
+				State:         invpkg.HtlcStateCanceled,
 				CustomRecords: make(record.CustomSet),
-				AMP: &InvoiceHtlcAMPData{
+				AMP: &invpkg.InvoiceHtlcAMPData{
 					Record:   *ampRecord,
 					Hash:     hash,
 					Preimage: &preimage,
 				},
 			},
-			invState: ContractSettled,
+			invState: invpkg.ContractSettled,
 			setID:    &setID,
-			output: InvoiceHTLC{
+			output: invpkg.InvoiceHTLC{
 				Amt:           5000,
 				MppTotalAmt:   5000,
 				AcceptHeight:  100,
 				AcceptTime:    testNow,
 				ResolveTime:   testAlreadyNow,
 				Expiry:        40,
-				State:         HtlcStateCanceled,
+				State:         invpkg.HtlcStateCanceled,
 				CustomRecords: make(record.CustomSet),
-				AMP: &InvoiceHtlcAMPData{
+				AMP: &invpkg.InvoiceHtlcAMPData{
 					Record:   *ampRecord,
 					Hash:     hash,
 					Preimage: &preimage,
@@ -2895,7 +2967,7 @@ func TestDeleteInvoices(t *testing.T) {
 
 	// Add some invoices to the test db.
 	numInvoices := 3
-	invoicesToDelete := make([]InvoiceDeleteRef, numInvoices)
+	invoicesToDelete := make([]invpkg.InvoiceDeleteRef, numInvoices)
 
 	for i := 0; i < numInvoices; i++ {
 		invoice, err := randInvoice(lnwire.MilliSatoshi(i + 1))
@@ -2908,14 +2980,14 @@ func TestDeleteInvoices(t *testing.T) {
 		// Settle the second invoice.
 		if i == 1 {
 			invoice, err = db.UpdateInvoice(
-				InvoiceRefByHash(paymentHash), nil,
+				invpkg.InvoiceRefByHash(paymentHash), nil,
 				getUpdateInvoice(invoice.Terms.Value),
 			)
 			require.NoError(t, err, "unable to settle invoice")
 		}
 
 		// store the delete ref for later.
-		invoicesToDelete[i] = InvoiceDeleteRef{
+		invoicesToDelete[i] = invpkg.InvoiceDeleteRef{
 			PayHash:     paymentHash,
 			PayAddr:     &invoice.Terms.PaymentAddr,
 			AddIndex:    addIndex,
@@ -2927,7 +2999,7 @@ func TestDeleteInvoices(t *testing.T) {
 	// to the passed count.
 	assertInvoiceCount := func(count int) {
 		// Query to collect all invoices.
-		query := InvoiceQuery{
+		query := invpkg.InvoiceQuery{
 			IndexOffset:    0,
 			NumMaxInvoices: math.MaxUint64,
 		}
@@ -3015,9 +3087,9 @@ func TestEncodeDecodeAmpInvoiceState(t *testing.T) {
 
 	// Make a sample invoice state map that we'll encode then decode to
 	// assert equality of.
-	ampState := AMPInvoiceState{
-		setID1: InvoiceStateAMP{
-			State:       HtlcStateSettled,
+	ampState := invpkg.AMPInvoiceState{
+		setID1: invpkg.InvoiceStateAMP{
+			State:       invpkg.HtlcStateSettled,
 			SettleDate:  testNow,
 			SettleIndex: 1,
 			InvoiceKeys: map[models.CircuitKey]struct{}{
@@ -3026,8 +3098,8 @@ func TestEncodeDecodeAmpInvoiceState(t *testing.T) {
 			},
 			AmtPaid: 5,
 		},
-		setID2: InvoiceStateAMP{
-			State:       HtlcStateCanceled,
+		setID2: invpkg.InvoiceStateAMP{
+			State:       invpkg.HtlcStateCanceled,
 			SettleDate:  testNow,
 			SettleIndex: 2,
 			InvoiceKeys: map[models.CircuitKey]struct{}{
@@ -3035,8 +3107,8 @@ func TestEncodeDecodeAmpInvoiceState(t *testing.T) {
 			},
 			AmtPaid: 6,
 		},
-		setID3: InvoiceStateAMP{
-			State:       HtlcStateAccepted,
+		setID3: invpkg.InvoiceStateAMP{
+			State:       invpkg.HtlcStateAccepted,
 			SettleDate:  testNow,
 			SettleIndex: 3,
 			InvoiceKeys: map[models.CircuitKey]struct{}{
@@ -3052,8 +3124,9 @@ func TestEncodeDecodeAmpInvoiceState(t *testing.T) {
 	// amp state we created above.
 	tlvStream, err := tlv.NewStream(
 		tlv.MakeDynamicRecord(
-			invoiceAmpStateType, &ampState, ampState.recordSize,
-			ampStateEncoder, ampStateDecoder,
+			invoiceAmpStateType, &ampState,
+			ampRecordSize(&ampState), ampStateEncoder,
+			ampStateDecoder,
 		),
 	)
 	require.Nil(t, err)
@@ -3065,7 +3138,7 @@ func TestEncodeDecodeAmpInvoiceState(t *testing.T) {
 
 	// Now create a new blank ampState map, which we'll use to decode the
 	// bytes into.
-	ampState2 := make(AMPInvoiceState)
+	ampState2 := make(invpkg.AMPInvoiceState)
 
 	// Decode from the raw stream into this blank mpa.
 	tlvStream, err = tlv.NewStream(

--- a/channeldb/models/channel.go
+++ b/channeldb/models/channel.go
@@ -1,0 +1,92 @@
+package models
+
+import (
+	"encoding/binary"
+	"fmt"
+	"io"
+
+	"github.com/lightningnetwork/lnd/lnwire"
+)
+
+const (
+	// serializedCircuitKeyLen is the exact length needed to encode a
+	// serialized CircuitKey.
+	serializedCircuitKeyLen = 16
+)
+
+var (
+	// ErrInvalidCircuitKeyLen signals that a circuit key could not be
+	// decoded because the byte slice is of an invalid length.
+	ErrInvalidCircuitKeyLen = fmt.Errorf("length of serialized circuit " +
+		"key must be 16 bytes")
+)
+
+// CircuitKey is used by a channel to uniquely identify the HTLCs it receives
+// from the switch, and is used to purge our in-memory state of HTLCs that have
+// already been processed by a link. Two list of CircuitKeys are included in
+// each CommitDiff to allow a link to determine which in-memory htlcs directed
+// the opening and closing of circuits in the switch's circuit map.
+type CircuitKey struct {
+	// ChanID is the short chanid indicating the HTLC's origin.
+	//
+	// NOTE: It is fine for this value to be blank, as this indicates a
+	// locally-sourced payment.
+	ChanID lnwire.ShortChannelID
+
+	// HtlcID is the unique htlc index predominately assigned by links,
+	// though can also be assigned by switch in the case of locally-sourced
+	// payments.
+	HtlcID uint64
+}
+
+// SetBytes deserializes the given bytes into this CircuitKey.
+func (k *CircuitKey) SetBytes(bs []byte) error {
+	if len(bs) != serializedCircuitKeyLen {
+		return ErrInvalidCircuitKeyLen
+	}
+
+	k.ChanID = lnwire.NewShortChanIDFromInt(
+		binary.BigEndian.Uint64(bs[:8]))
+	k.HtlcID = binary.BigEndian.Uint64(bs[8:])
+
+	return nil
+}
+
+// Bytes returns the serialized bytes for this circuit key.
+func (k CircuitKey) Bytes() []byte {
+	bs := make([]byte, serializedCircuitKeyLen)
+	binary.BigEndian.PutUint64(bs[:8], k.ChanID.ToUint64())
+	binary.BigEndian.PutUint64(bs[8:], k.HtlcID)
+
+	return bs
+}
+
+// Encode writes a CircuitKey to the provided io.Writer.
+func (k *CircuitKey) Encode(w io.Writer) error {
+	var scratch [serializedCircuitKeyLen]byte
+	binary.BigEndian.PutUint64(scratch[:8], k.ChanID.ToUint64())
+	binary.BigEndian.PutUint64(scratch[8:], k.HtlcID)
+
+	_, err := w.Write(scratch[:])
+
+	return err
+}
+
+// Decode reads a CircuitKey from the provided io.Reader.
+func (k *CircuitKey) Decode(r io.Reader) error {
+	var scratch [serializedCircuitKeyLen]byte
+
+	if _, err := io.ReadFull(r, scratch[:]); err != nil {
+		return err
+	}
+	k.ChanID = lnwire.NewShortChanIDFromInt(
+		binary.BigEndian.Uint64(scratch[:8]))
+	k.HtlcID = binary.BigEndian.Uint64(scratch[8:])
+
+	return nil
+}
+
+// String returns a string representation of the CircuitKey.
+func (k CircuitKey) String() string {
+	return fmt.Sprintf("(Chan ID=%s, HTLC ID=%d)", k.ChanID, k.HtlcID)
+}

--- a/config_builder.go
+++ b/config_builder.go
@@ -25,6 +25,7 @@ import (
 	"github.com/lightningnetwork/lnd/blockcache"
 	"github.com/lightningnetwork/lnd/chainreg"
 	"github.com/lightningnetwork/lnd/channeldb"
+	"github.com/lightningnetwork/lnd/invoices"
 	"github.com/lightningnetwork/lnd/keychain"
 	"github.com/lightningnetwork/lnd/kvdb"
 	"github.com/lightningnetwork/lnd/lncfg"
@@ -764,6 +765,9 @@ type DatabaseInstances struct {
 	// HeightHintDB is the database that stores height hints for spends.
 	HeightHintDB kvdb.Backend
 
+	// InvoiceDB is the database that stores information about invoices.
+	InvoiceDB invoices.InvoiceDB
+
 	// MacaroonDB is the database that stores macaroon root keys.
 	MacaroonDB kvdb.Backend
 
@@ -914,6 +918,12 @@ func (d *DefaultDatabaseBuilder) BuildDatabase(
 	// channel state DB should be created here individually instead of just
 	// using the same struct (and DB backend) instance.
 	dbs.ChanStateDB = dbs.GraphDB
+
+	// For now the only InvoiceDB implementation is the *channeldb.DB.
+	//
+	// TODO(positiveblue): use a sql first implementation for this
+	// interface.
+	dbs.InvoiceDB = dbs.GraphDB
 
 	// Wrap the watchtower client DB and make sure we clean up.
 	if cfg.WtClient.Active {

--- a/contractcourt/channel_arbitrator.go
+++ b/contractcourt/channel_arbitrator.go
@@ -17,6 +17,7 @@ import (
 	"github.com/lightningnetwork/lnd/channeldb/models"
 	"github.com/lightningnetwork/lnd/htlcswitch/hop"
 	"github.com/lightningnetwork/lnd/input"
+	"github.com/lightningnetwork/lnd/invoices"
 	"github.com/lightningnetwork/lnd/kvdb"
 	"github.com/lightningnetwork/lnd/labels"
 	"github.com/lightningnetwork/lnd/lntypes"
@@ -1748,7 +1749,7 @@ func (c *ChannelArbitrator) isPreimageAvailable(hash lntypes.Hash) (bool,
 	invoice, err := c.cfg.Registry.LookupInvoice(hash)
 	switch err {
 	case nil:
-	case channeldb.ErrInvoiceNotFound, channeldb.ErrNoInvoicesCreated:
+	case invoices.ErrInvoiceNotFound, invoices.ErrNoInvoicesCreated:
 		return false, nil
 	default:
 		return false, err

--- a/contractcourt/channel_arbitrator.go
+++ b/contractcourt/channel_arbitrator.go
@@ -14,6 +14,7 @@ import (
 	"github.com/btcsuite/btcd/wire"
 	"github.com/davecgh/go-spew/spew"
 	"github.com/lightningnetwork/lnd/channeldb"
+	"github.com/lightningnetwork/lnd/channeldb/models"
 	"github.com/lightningnetwork/lnd/htlcswitch/hop"
 	"github.com/lightningnetwork/lnd/input"
 	"github.com/lightningnetwork/lnd/kvdb"
@@ -2230,7 +2231,7 @@ func (c *ChannelArbitrator) prepContractResolutions(
 			for _, htlc := range htlcs {
 				htlc := htlc
 
-				key := channeldb.CircuitKey{
+				key := models.CircuitKey{
 					ChanID: c.cfg.ShortChanID,
 					HtlcID: htlc.HtlcIndex,
 				}

--- a/contractcourt/htlc_incoming_contest_resolver.go
+++ b/contractcourt/htlc_incoming_contest_resolver.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/btcsuite/btcd/btcutil"
 	"github.com/lightningnetwork/lnd/channeldb"
+	"github.com/lightningnetwork/lnd/channeldb/models"
 	"github.com/lightningnetwork/lnd/htlcswitch/hop"
 	"github.com/lightningnetwork/lnd/invoices"
 	"github.com/lightningnetwork/lnd/lntypes"
@@ -61,7 +62,7 @@ func (h *htlcIncomingContestResolver) processFinalHtlcFail() error {
 
 	// Send notification.
 	h.ChainArbitratorConfig.HtlcNotifier.NotifyFinalHtlcEvent(
-		channeldb.CircuitKey{
+		models.CircuitKey{
 			ChanID: h.ShortChanID,
 			HtlcID: h.htlc.HtlcIndex,
 		},
@@ -265,7 +266,7 @@ func (h *htlcIncomingContestResolver) Resolve() (ContractResolver, error) {
 		// hop on-chain. If this HTLC indeed pays to an existing
 		// invoice, the invoice registry will tell us what to do with
 		// the HTLC. This is identical to HTLC resolution in the link.
-		circuitKey := channeldb.CircuitKey{
+		circuitKey := models.CircuitKey{
 			ChanID: h.ShortChanID,
 			HtlcID: h.htlc.HtlcIndex,
 		}

--- a/contractcourt/htlc_incoming_resolver_test.go
+++ b/contractcourt/htlc_incoming_resolver_test.go
@@ -9,6 +9,7 @@ import (
 	sphinx "github.com/lightningnetwork/lightning-onion"
 	"github.com/lightningnetwork/lnd/chainntnfs"
 	"github.com/lightningnetwork/lnd/channeldb"
+	"github.com/lightningnetwork/lnd/channeldb/models"
 	"github.com/lightningnetwork/lnd/htlcswitch/hop"
 	"github.com/lightningnetwork/lnd/invoices"
 	"github.com/lightningnetwork/lnd/kvdb"
@@ -27,7 +28,7 @@ const (
 var (
 	testResPreimage         = lntypes.Preimage{1, 2, 3}
 	testResHash             = testResPreimage.Hash()
-	testResCircuitKey       = channeldb.CircuitKey{}
+	testResCircuitKey       = models.CircuitKey{}
 	testOnionBlob           = []byte{4, 5, 6}
 	testAcceptHeight  int32 = 1234
 	testHtlcAmount          = 2300

--- a/contractcourt/htlc_success_resolver.go
+++ b/contractcourt/htlc_success_resolver.go
@@ -11,6 +11,7 @@ import (
 	"github.com/davecgh/go-spew/spew"
 	"github.com/lightningnetwork/lnd/chainntnfs"
 	"github.com/lightningnetwork/lnd/channeldb"
+	"github.com/lightningnetwork/lnd/channeldb/models"
 	"github.com/lightningnetwork/lnd/input"
 	"github.com/lightningnetwork/lnd/labels"
 	"github.com/lightningnetwork/lnd/lnwallet"
@@ -479,7 +480,7 @@ func (h *htlcSuccessResolver) checkpointClaim(spendTx *chainhash.Hash,
 
 	// Send notification.
 	h.ChainArbitratorConfig.HtlcNotifier.NotifyFinalHtlcEvent(
-		channeldb.CircuitKey{
+		models.CircuitKey{
 			ChanID: h.ShortChanID,
 			HtlcID: h.htlc.HtlcIndex,
 		},

--- a/contractcourt/interfaces.go
+++ b/contractcourt/interfaces.go
@@ -19,7 +19,7 @@ import (
 type Registry interface {
 	// LookupInvoice attempts to look up an invoice according to its 32
 	// byte payment hash.
-	LookupInvoice(lntypes.Hash) (channeldb.Invoice, error)
+	LookupInvoice(lntypes.Hash) (invoices.Invoice, error)
 
 	// NotifyExitHopHtlc attempts to mark an invoice as settled. If the
 	// invoice is a debug invoice, then this method is a noop as debug

--- a/contractcourt/interfaces.go
+++ b/contractcourt/interfaces.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/btcsuite/btcd/wire"
 	"github.com/lightningnetwork/lnd/channeldb"
+	"github.com/lightningnetwork/lnd/channeldb/models"
 	"github.com/lightningnetwork/lnd/htlcswitch/hop"
 	"github.com/lightningnetwork/lnd/input"
 	"github.com/lightningnetwork/lnd/invoices"
@@ -27,7 +28,7 @@ type Registry interface {
 	// the resolution is sent on the passed in hodlChan later.
 	NotifyExitHopHtlc(payHash lntypes.Hash, paidAmount lnwire.MilliSatoshi,
 		expiry uint32, currentHeight int32,
-		circuitKey channeldb.CircuitKey, hodlChan chan<- interface{},
+		circuitKey models.CircuitKey, hodlChan chan<- interface{},
 		payload invoices.Payload) (invoices.HtlcResolution, error)
 
 	// HodlUnsubscribeAll unsubscribes from all htlc resolutions.
@@ -70,6 +71,6 @@ type UtxoSweeper interface {
 type HtlcNotifier interface {
 	// NotifyFinalHtlcEvent notifies the HtlcNotifier that the final outcome
 	// for an htlc has been determined.
-	NotifyFinalHtlcEvent(key channeldb.CircuitKey,
+	NotifyFinalHtlcEvent(key models.CircuitKey,
 		info channeldb.FinalHtlcInfo)
 }

--- a/contractcourt/mock_htlcnotifier_test.go
+++ b/contractcourt/mock_htlcnotifier_test.go
@@ -1,11 +1,14 @@
 package contractcourt
 
-import "github.com/lightningnetwork/lnd/channeldb"
+import (
+	"github.com/lightningnetwork/lnd/channeldb"
+	"github.com/lightningnetwork/lnd/channeldb/models"
+)
 
 type mockHTLCNotifier struct {
 	HtlcNotifier
 }
 
-func (m *mockHTLCNotifier) NotifyFinalHtlcEvent(key channeldb.CircuitKey,
+func (m *mockHTLCNotifier) NotifyFinalHtlcEvent(key models.CircuitKey,
 	info channeldb.FinalHtlcInfo) { //nolint:whitespace
 }

--- a/contractcourt/mock_registry_test.go
+++ b/contractcourt/mock_registry_test.go
@@ -2,6 +2,7 @@ package contractcourt
 
 import (
 	"github.com/lightningnetwork/lnd/channeldb"
+	"github.com/lightningnetwork/lnd/channeldb/models"
 	"github.com/lightningnetwork/lnd/invoices"
 	"github.com/lightningnetwork/lnd/lntypes"
 	"github.com/lightningnetwork/lnd/lnwire"
@@ -23,7 +24,7 @@ type mockRegistry struct {
 
 func (r *mockRegistry) NotifyExitHopHtlc(payHash lntypes.Hash,
 	paidAmount lnwire.MilliSatoshi, expiry uint32, currentHeight int32,
-	circuitKey channeldb.CircuitKey, hodlChan chan<- interface{},
+	circuitKey models.CircuitKey, hodlChan chan<- interface{},
 	payload invoices.Payload) (invoices.HtlcResolution, error) {
 
 	r.notifyChan <- notifyExitHopData{

--- a/contractcourt/mock_registry_test.go
+++ b/contractcourt/mock_registry_test.go
@@ -1,7 +1,6 @@
 package contractcourt
 
 import (
-	"github.com/lightningnetwork/lnd/channeldb"
 	"github.com/lightningnetwork/lnd/channeldb/models"
 	"github.com/lightningnetwork/lnd/invoices"
 	"github.com/lightningnetwork/lnd/lntypes"
@@ -40,8 +39,8 @@ func (r *mockRegistry) NotifyExitHopHtlc(payHash lntypes.Hash,
 
 func (r *mockRegistry) HodlUnsubscribeAll(subscriber chan<- interface{}) {}
 
-func (r *mockRegistry) LookupInvoice(lntypes.Hash) (channeldb.Invoice,
+func (r *mockRegistry) LookupInvoice(lntypes.Hash) (invoices.Invoice,
 	error) {
 
-	return channeldb.Invoice{}, channeldb.ErrInvoiceNotFound
+	return invoices.Invoice{}, invoices.ErrInvoiceNotFound
 }

--- a/docs/release-notes/release-notes-0.16.0.md
+++ b/docs/release-notes/release-notes-0.16.0.md
@@ -117,19 +117,25 @@ current gossip sync query status.
 
 ## Build
 
-[The project has updated to Go
+* [The project has updated to Go
 1.19](https://github.com/lightningnetwork/lnd/pull/6795)! Go 1.18 is now the
 minimum version needed to build the project.
 
-[The minimum recommended version of the Go 1.19.x series is 1.19.2 because
+* [The minimum recommended version of the Go 1.19.x series is 1.19.2 because
 1.19.1 contained a bug that affected lnd and resulted in a
 crash](https://github.com/lightningnetwork/lnd/pull/7019).
 
-[Use Go's `runtime/debug` package to get information about the build](
+* [Use Go's `runtime/debug` package to get information about the build](
 https://github.com/lightningnetwork/lnd/pull/6963/)
 
-[A wire parsing bug has been fixed that would cause lnd to be unable _decode_
+* [A wire parsing bug has been fixed that would cause lnd to be unable _decode_
 certain large transactions](https://github.com/lightningnetwork/lnd/pull/7100).
+
+## Invoices
+
+* Define a new [InvoiceDB](https://github.com/lightningnetwork/lnd/pull/7215) 
+interface to be used in all the packages that need to interact with invoice 
+data.
 
 ## Misc
 
@@ -338,7 +344,7 @@ certain large transactions](https://github.com/lightningnetwork/lnd/pull/7100).
 
 ### Integration test
 
-The `lntest` has been
+* The `lntest` has been
 [refactored](https://github.com/lightningnetwork/lnd/pull/6759) to provide a
 better testing suite for writing integration tests. A new defined structure is
 implemented, please refer to
@@ -371,7 +377,6 @@ refactor the itest for code health and maintenance.
 * lsunsi
 * Matt Morehouse
 * Michael Street
-* Jordi Montes
 * Olaoluwa Osuntokun
 * Oliver Gugger
 * Priyansh Rastogi

--- a/htlcswitch/circuit.go
+++ b/htlcswitch/circuit.go
@@ -5,6 +5,7 @@ import (
 	"io"
 
 	"github.com/lightningnetwork/lnd/channeldb"
+	"github.com/lightningnetwork/lnd/channeldb/models"
 	"github.com/lightningnetwork/lnd/htlcswitch/hop"
 	"github.com/lightningnetwork/lnd/lnwire"
 )
@@ -19,7 +20,7 @@ var EmptyCircuitKey CircuitKey
 // HTLCs in a circuit. Circuits are identified primarily by the circuit key of
 // the incoming HTLC. However, a circuit may also be referenced by its outgoing
 // circuit key after the HTLC has been forwarded via the outgoing link.
-type CircuitKey = channeldb.CircuitKey
+type CircuitKey = models.CircuitKey
 
 // PaymentCircuit is used by the switch as placeholder between when the
 // switch makes a forwarding decision and the outgoing link determines the

--- a/htlcswitch/held_htlc_set.go
+++ b/htlcswitch/held_htlc_set.go
@@ -4,19 +4,19 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/lightningnetwork/lnd/channeldb"
+	"github.com/lightningnetwork/lnd/channeldb/models"
 )
 
 // heldHtlcSet keeps track of outstanding intercepted forwards. It exposes
 // several methods to manipulate the underlying map structure in a consistent
 // way.
 type heldHtlcSet struct {
-	set map[channeldb.CircuitKey]InterceptedForward
+	set map[models.CircuitKey]InterceptedForward
 }
 
 func newHeldHtlcSet() *heldHtlcSet {
 	return &heldHtlcSet{
-		set: make(map[channeldb.CircuitKey]InterceptedForward),
+		set: make(map[models.CircuitKey]InterceptedForward),
 	}
 }
 
@@ -34,7 +34,7 @@ func (h *heldHtlcSet) popAll(cb func(InterceptedForward)) {
 		cb(fwd)
 	}
 
-	h.set = make(map[channeldb.CircuitKey]InterceptedForward)
+	h.set = make(map[models.CircuitKey]InterceptedForward)
 }
 
 // popAutoFails calls the callback for each forward that has an auto-fail height
@@ -52,7 +52,7 @@ func (h *heldHtlcSet) popAutoFails(height uint32, cb func(InterceptedForward)) {
 }
 
 // pop returns the specified forward and removes it from the set.
-func (h *heldHtlcSet) pop(key channeldb.CircuitKey) (InterceptedForward, error) {
+func (h *heldHtlcSet) pop(key models.CircuitKey) (InterceptedForward, error) {
 	intercepted, ok := h.set[key]
 	if !ok {
 		return nil, fmt.Errorf("fwd %v not found", key)
@@ -64,7 +64,7 @@ func (h *heldHtlcSet) pop(key channeldb.CircuitKey) (InterceptedForward, error) 
 }
 
 // exists tests whether the specified forward is part of the set.
-func (h *heldHtlcSet) exists(key channeldb.CircuitKey) bool {
+func (h *heldHtlcSet) exists(key models.CircuitKey) bool {
 	_, ok := h.set[key]
 
 	return ok
@@ -72,7 +72,7 @@ func (h *heldHtlcSet) exists(key channeldb.CircuitKey) bool {
 
 // push adds the specified forward to the set. An error is returned if the
 // forward exists already.
-func (h *heldHtlcSet) push(key channeldb.CircuitKey,
+func (h *heldHtlcSet) push(key models.CircuitKey,
 	fwd InterceptedForward) error {
 
 	if fwd == nil {

--- a/htlcswitch/held_htlc_set_test.go
+++ b/htlcswitch/held_htlc_set_test.go
@@ -3,7 +3,7 @@ package htlcswitch
 import (
 	"testing"
 
-	"github.com/lightningnetwork/lnd/channeldb"
+	"github.com/lightningnetwork/lnd/channeldb/models"
 	"github.com/lightningnetwork/lnd/lnwire"
 	"github.com/stretchr/testify/require"
 )
@@ -12,9 +12,9 @@ func TestHeldHtlcSetEmpty(t *testing.T) {
 	set := newHeldHtlcSet()
 
 	// Test operations on an empty set.
-	require.False(t, set.exists(channeldb.CircuitKey{}))
+	require.False(t, set.exists(models.CircuitKey{}))
 
-	_, err := set.pop(channeldb.CircuitKey{})
+	_, err := set.pop(models.CircuitKey{})
 	require.Error(t, err)
 
 	set.popAll(
@@ -27,7 +27,7 @@ func TestHeldHtlcSetEmpty(t *testing.T) {
 func TestHeldHtlcSet(t *testing.T) {
 	set := newHeldHtlcSet()
 
-	key := channeldb.CircuitKey{
+	key := models.CircuitKey{
 		ChanID: lnwire.NewShortChanIDFromInt(1),
 		HtlcID: 2,
 	}
@@ -82,7 +82,7 @@ func TestHeldHtlcSet(t *testing.T) {
 func TestHeldHtlcSetAutoFails(t *testing.T) {
 	set := newHeldHtlcSet()
 
-	key := channeldb.CircuitKey{
+	key := models.CircuitKey{
 		ChanID: lnwire.NewShortChanIDFromInt(1),
 		HtlcID: 2,
 	}

--- a/htlcswitch/htlcnotifier.go
+++ b/htlcswitch/htlcnotifier.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/lightningnetwork/lnd/channeldb"
+	"github.com/lightningnetwork/lnd/channeldb/models"
 	"github.com/lightningnetwork/lnd/htlcswitch/hop"
 	"github.com/lightningnetwork/lnd/lntypes"
 	"github.com/lightningnetwork/lnd/lnwire"
@@ -108,10 +109,10 @@ func (h *HtlcNotifier) SubscribeHtlcEvents() (*subscribe.Client, error) {
 // HtlcKey uniquely identifies the htlc.
 type HtlcKey struct {
 	// IncomingCircuit is the channel an htlc id of the incoming htlc.
-	IncomingCircuit channeldb.CircuitKey
+	IncomingCircuit models.CircuitKey
 
 	// OutgoingCircuit is the channel and htlc id of the outgoing htlc.
-	OutgoingCircuit channeldb.CircuitKey
+	OutgoingCircuit models.CircuitKey
 }
 
 // String returns a string representation of a htlc key.
@@ -398,7 +399,7 @@ func (h *HtlcNotifier) NotifySettleEvent(key HtlcKey,
 // htlc has been determined.
 //
 // Note this is part of the htlcNotifier interface.
-func (h *HtlcNotifier) NotifyFinalHtlcEvent(key channeldb.CircuitKey,
+func (h *HtlcNotifier) NotifyFinalHtlcEvent(key models.CircuitKey,
 	info channeldb.FinalHtlcInfo) {
 
 	event := &FinalHtlcEvent{
@@ -423,7 +424,7 @@ func (h *HtlcNotifier) NotifyFinalHtlcEvent(key channeldb.CircuitKey,
 // originate at our node.
 func newHtlcKey(pkt *htlcPacket) HtlcKey {
 	htlcKey := HtlcKey{
-		IncomingCircuit: channeldb.CircuitKey{
+		IncomingCircuit: models.CircuitKey{
 			ChanID: pkt.incomingChanID,
 			HtlcID: pkt.incomingHTLCID,
 		},

--- a/htlcswitch/interceptable_switch.go
+++ b/htlcswitch/interceptable_switch.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/go-errors/errors"
 	"github.com/lightningnetwork/lnd/chainntnfs"
-	"github.com/lightningnetwork/lnd/channeldb"
+	"github.com/lightningnetwork/lnd/channeldb/models"
 	"github.com/lightningnetwork/lnd/htlcswitch/hop"
 	"github.com/lightningnetwork/lnd/lntypes"
 	"github.com/lightningnetwork/lnd/lnwire"
@@ -110,7 +110,7 @@ const (
 // FwdResolution defines the action to be taken on an intercepted packet.
 type FwdResolution struct {
 	// Key is the incoming circuit key of the htlc.
-	Key channeldb.CircuitKey
+	Key models.CircuitKey
 
 	// Action is the action to take on the intercepted htlc.
 	Action FwdAction
@@ -592,7 +592,7 @@ type interceptedForward struct {
 // Packet returns the intercepted htlc packet.
 func (f *interceptedForward) Packet() InterceptedPacket {
 	return InterceptedPacket{
-		IncomingCircuit: channeldb.CircuitKey{
+		IncomingCircuit: models.CircuitKey{
 			ChanID: f.packet.incomingChanID,
 			HtlcID: f.packet.incomingHTLCID,
 		},

--- a/htlcswitch/interfaces.go
+++ b/htlcswitch/interfaces.go
@@ -3,6 +3,7 @@ package htlcswitch
 import (
 	"github.com/btcsuite/btcd/wire"
 	"github.com/lightningnetwork/lnd/channeldb"
+	"github.com/lightningnetwork/lnd/channeldb/models"
 	"github.com/lightningnetwork/lnd/invoices"
 	"github.com/lightningnetwork/lnd/lnpeer"
 	"github.com/lightningnetwork/lnd/lntypes"
@@ -28,7 +29,7 @@ type InvoiceDatabase interface {
 	// for decoding purposes.
 	NotifyExitHopHtlc(payHash lntypes.Hash, paidAmount lnwire.MilliSatoshi,
 		expiry uint32, currentHeight int32,
-		circuitKey channeldb.CircuitKey, hodlChan chan<- interface{},
+		circuitKey models.CircuitKey, hodlChan chan<- interface{},
 		payload invoices.Payload) (invoices.HtlcResolution, error)
 
 	// CancelInvoice attempts to cancel the invoice corresponding to the
@@ -284,7 +285,7 @@ type ForwardInterceptor func(InterceptedPacket) error
 type InterceptedPacket struct {
 	// IncomingCircuit contains the incoming channel and htlc id of the
 	// packet.
-	IncomingCircuit channeldb.CircuitKey
+	IncomingCircuit models.CircuitKey
 
 	// OutgoingChanID is the destination channel for this packet.
 	OutgoingChanID lnwire.ShortChannelID
@@ -373,6 +374,6 @@ type htlcNotifier interface {
 
 	// NotifyFinalHtlcEvent notifies the HtlcNotifier that the final outcome
 	// for an htlc has been determined.
-	NotifyFinalHtlcEvent(key channeldb.CircuitKey,
+	NotifyFinalHtlcEvent(key models.CircuitKey,
 		info channeldb.FinalHtlcInfo)
 }

--- a/htlcswitch/interfaces.go
+++ b/htlcswitch/interfaces.go
@@ -18,7 +18,7 @@ import (
 type InvoiceDatabase interface {
 	// LookupInvoice attempts to look up an invoice according to its 32
 	// byte payment hash.
-	LookupInvoice(lntypes.Hash) (channeldb.Invoice, error)
+	LookupInvoice(lntypes.Hash) (invoices.Invoice, error)
 
 	// NotifyExitHopHtlc attempts to mark an invoice as settled. If the
 	// invoice is a debug invoice, then this method is a noop as debug

--- a/htlcswitch/link.go
+++ b/htlcswitch/link.go
@@ -17,6 +17,7 @@ import (
 	"github.com/go-errors/errors"
 	"github.com/lightningnetwork/lnd/build"
 	"github.com/lightningnetwork/lnd/channeldb"
+	"github.com/lightningnetwork/lnd/channeldb/models"
 	"github.com/lightningnetwork/lnd/contractcourt"
 	"github.com/lightningnetwork/lnd/htlcswitch/hodl"
 	"github.com/lightningnetwork/lnd/htlcswitch/hop"
@@ -395,7 +396,7 @@ type channelLink struct {
 
 	// hodlMap stores related htlc data for a circuit key. It allows
 	// resolving those htlcs when we receive a message on hodlQueue.
-	hodlMap map[channeldb.CircuitKey]hodlHtlc
+	hodlMap map[models.CircuitKey]hodlHtlc
 
 	// log is a link-specific logging instance.
 	log btclog.Logger
@@ -422,7 +423,7 @@ func NewChannelLink(cfg ChannelLinkConfig,
 		channel:         channel,
 		shortChanID:     channel.ShortChanID(),
 		shutdownRequest: make(chan *shutdownReq),
-		hodlMap:         make(map[channeldb.CircuitKey]hodlHtlc),
+		hodlMap:         make(map[models.CircuitKey]hodlHtlc),
 		hodlQueue:       queue.NewConcurrentQueue(10),
 		log:             build.NewPrefixLog(logPrefix, log),
 		quit:            make(chan struct{}),
@@ -1962,7 +1963,7 @@ func (l *channelLink) handleUpstreamMsg(msg lnwire.Message) {
 		// locked in.
 		for id, settled := range finalHTLCs {
 			l.cfg.HtlcNotifier.NotifyFinalHtlcEvent(
-				channeldb.CircuitKey{
+				models.CircuitKey{
 					ChanID: l.shortChanID,
 					HtlcID: id,
 				},
@@ -3260,7 +3261,7 @@ func (l *channelLink) processExitHop(pd *lnwallet.PaymentDescriptor,
 	// receive back a resolution event.
 	invoiceHash := lntypes.Hash(pd.RHash)
 
-	circuitKey := channeldb.CircuitKey{
+	circuitKey := models.CircuitKey{
 		ChanID: l.ShortChanID(),
 		HtlcID: pd.HtlcIndex,
 	}
@@ -3324,7 +3325,7 @@ func (l *channelLink) settleHTLC(preimage lntypes.Preimage,
 	// Once we have successfully settled the htlc, notify a settle event.
 	l.cfg.HtlcNotifier.NotifySettleEvent(
 		HtlcKey{
-			IncomingCircuit: channeldb.CircuitKey{
+			IncomingCircuit: models.CircuitKey{
 				ChanID: l.ShortChanID(),
 				HtlcID: pd.HtlcIndex,
 			},
@@ -3394,7 +3395,7 @@ func (l *channelLink) sendHTLCError(pd *lnwallet.PaymentDescriptor,
 
 	l.cfg.HtlcNotifier.NotifyLinkFailEvent(
 		HtlcKey{
-			IncomingCircuit: channeldb.CircuitKey{
+			IncomingCircuit: models.CircuitKey{
 				ChanID: l.ShortChanID(),
 				HtlcID: pd.HtlcIndex,
 			},

--- a/htlcswitch/link_test.go
+++ b/htlcswitch/link_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/lightningnetwork/lnd/htlcswitch/hodl"
 	"github.com/lightningnetwork/lnd/htlcswitch/hop"
 	"github.com/lightningnetwork/lnd/input"
+	invpkg "github.com/lightningnetwork/lnd/invoices"
 	"github.com/lightningnetwork/lnd/kvdb"
 	"github.com/lightningnetwork/lnd/lnpeer"
 	"github.com/lightningnetwork/lnd/lntest/wait"
@@ -479,7 +480,7 @@ func TestChannelLinkSingleHopPayment(t *testing.T) {
 	// links was changed.
 	invoice, err := receiver.registry.LookupInvoice(rhash)
 	require.NoError(t, err, "unable to get invoice")
-	if invoice.State != channeldb.ContractSettled {
+	if invoice.State != invpkg.ContractSettled {
 		t.Fatal("alice invoice wasn't settled")
 	}
 
@@ -597,7 +598,7 @@ func testChannelLinkMultiHopPayment(t *testing.T,
 	// links were changed.
 	invoice, err := receiver.registry.LookupInvoice(rhash)
 	require.NoError(t, err, "unable to get invoice")
-	if invoice.State != channeldb.ContractSettled {
+	if invoice.State != invpkg.ContractSettled {
 		t.Fatal("carol invoice haven't been settled")
 	}
 
@@ -1080,7 +1081,7 @@ func TestUpdateForwardingPolicy(t *testing.T) {
 	// succeeded.
 	invoice, err := n.carolServer.registry.LookupInvoice(payResp)
 	require.NoError(t, err, "unable to get invoice")
-	if invoice.State != channeldb.ContractSettled {
+	if invoice.State != invpkg.ContractSettled {
 		t.Fatal("carol invoice haven't been settled")
 	}
 
@@ -1234,7 +1235,7 @@ func TestChannelLinkMultiHopInsufficientPayment(t *testing.T) {
 	// links hasn't been changed.
 	invoice, err := receiver.registry.LookupInvoice(rhash)
 	require.NoError(t, err, "unable to get invoice")
-	if invoice.State == channeldb.ContractSettled {
+	if invoice.State == invpkg.ContractSettled {
 		t.Fatal("carol invoice have been settled")
 	}
 
@@ -1412,7 +1413,7 @@ func TestChannelLinkMultiHopUnknownNextHop(t *testing.T) {
 	// links hasn't been changed.
 	invoice, err := receiver.registry.LookupInvoice(rhash)
 	require.NoError(t, err, "unable to get invoice")
-	if invoice.State == channeldb.ContractSettled {
+	if invoice.State == invpkg.ContractSettled {
 		t.Fatal("carol invoice have been settled")
 	}
 
@@ -1520,7 +1521,7 @@ func TestChannelLinkMultiHopDecodeError(t *testing.T) {
 	// links hasn't been changed.
 	invoice, err := receiver.registry.LookupInvoice(rhash)
 	require.NoError(t, err, "unable to get invoice")
-	if invoice.State == channeldb.ContractSettled {
+	if invoice.State == invpkg.ContractSettled {
 		t.Fatal("carol invoice have been settled")
 	}
 
@@ -3498,7 +3499,7 @@ func TestChannelRetransmission(t *testing.T) {
 		// TODO(andrew.shvv) Will be removed if we move the notification center
 		// to the channel link itself.
 
-		var invoice channeldb.Invoice
+		var invoice invpkg.Invoice
 		for i := 0; i < 20; i++ {
 			select {
 			case <-time.After(time.Millisecond * 200):
@@ -3513,7 +3514,7 @@ func TestChannelRetransmission(t *testing.T) {
 				err = errors.Errorf("unable to get invoice: %v", err)
 				continue
 			}
-			if invoice.State != channeldb.ContractSettled {
+			if invoice.State != invpkg.ContractSettled {
 				err = errors.Errorf("alice invoice haven't been settled")
 				continue
 			}
@@ -4059,7 +4060,7 @@ func TestChannelLinkAcceptOverpay(t *testing.T) {
 	// accepted the payment and marked it as settled.
 	invoice, err := receiver.registry.LookupInvoice(rhash)
 	require.NoError(t, err, "unable to get invoice")
-	if invoice.State != channeldb.ContractSettled {
+	if invoice.State != invpkg.ContractSettled {
 		t.Fatal("carol invoice haven't been settled")
 	}
 
@@ -4383,7 +4384,7 @@ func generateHtlc(t *testing.T, coreLink *channelLink,
 // generateHtlcAndInvoice generates an invoice and a single hop htlc to send to
 // the receiver.
 func generateHtlcAndInvoice(t *testing.T,
-	id uint64) (*lnwire.UpdateAddHTLC, *channeldb.Invoice) {
+	id uint64) (*lnwire.UpdateAddHTLC, *invpkg.Invoice) {
 
 	t.Helper()
 
@@ -4778,7 +4779,7 @@ func testChannelLinkBatchPreimageWrite(t *testing.T, disconnect bool) {
 	// We will send 10 HTLCs in total, from Bob to Alice.
 	numHtlcs := 10
 	var htlcs []*lnwire.UpdateAddHTLC
-	var invoices []*channeldb.Invoice
+	var invoices []*invpkg.Invoice
 	for i := 0; i < numHtlcs; i++ {
 		htlc, invoice := generateHtlcAndInvoice(t, uint64(i))
 		htlcs = append(htlcs, htlc)

--- a/htlcswitch/mock.go
+++ b/htlcswitch/mock.go
@@ -980,7 +980,7 @@ func newMockRegistry(minDelta uint32) *mockInvoiceRegistry {
 }
 
 func (i *mockInvoiceRegistry) LookupInvoice(rHash lntypes.Hash) (
-	channeldb.Invoice, error) {
+	invoices.Invoice, error) {
 
 	return i.registry.LookupInvoice(rHash)
 }
@@ -1014,7 +1014,7 @@ func (i *mockInvoiceRegistry) CancelInvoice(payHash lntypes.Hash) error {
 	return i.registry.CancelInvoice(payHash)
 }
 
-func (i *mockInvoiceRegistry) AddInvoice(invoice channeldb.Invoice,
+func (i *mockInvoiceRegistry) AddInvoice(invoice invoices.Invoice,
 	paymentHash lntypes.Hash) error {
 
 	_, err := i.registry.AddInvoice(&invoice, paymentHash)

--- a/htlcswitch/mock.go
+++ b/htlcswitch/mock.go
@@ -23,6 +23,7 @@ import (
 	sphinx "github.com/lightningnetwork/lightning-onion"
 	"github.com/lightningnetwork/lnd/chainntnfs"
 	"github.com/lightningnetwork/lnd/channeldb"
+	"github.com/lightningnetwork/lnd/channeldb/models"
 	"github.com/lightningnetwork/lnd/clock"
 	"github.com/lightningnetwork/lnd/contractcourt"
 	"github.com/lightningnetwork/lnd/htlcswitch/hop"
@@ -845,7 +846,9 @@ func (f *mockChannelLink) CheckHtlcTransit(payHash [32]byte,
 	return f.checkHtlcTransitResult
 }
 
-func (f *mockChannelLink) Stats() (uint64, lnwire.MilliSatoshi, lnwire.MilliSatoshi) {
+func (f *mockChannelLink) Stats() (
+	uint64, lnwire.MilliSatoshi, lnwire.MilliSatoshi) {
+
 	return 0, 0, 0
 }
 
@@ -982,13 +985,15 @@ func (i *mockInvoiceRegistry) LookupInvoice(rHash lntypes.Hash) (
 	return i.registry.LookupInvoice(rHash)
 }
 
-func (i *mockInvoiceRegistry) SettleHodlInvoice(preimage lntypes.Preimage) error {
+func (i *mockInvoiceRegistry) SettleHodlInvoice(
+	preimage lntypes.Preimage) error {
+
 	return i.registry.SettleHodlInvoice(preimage)
 }
 
 func (i *mockInvoiceRegistry) NotifyExitHopHtlc(rhash lntypes.Hash,
 	amt lnwire.MilliSatoshi, expiry uint32, currentHeight int32,
-	circuitKey channeldb.CircuitKey, hodlChan chan<- interface{},
+	circuitKey models.CircuitKey, hodlChan chan<- interface{},
 	payload invoices.Payload) (invoices.HtlcResolution, error) {
 
 	event, err := i.registry.NotifyExitHopHtlc(
@@ -1016,7 +1021,9 @@ func (i *mockInvoiceRegistry) AddInvoice(invoice channeldb.Invoice,
 	return err
 }
 
-func (i *mockInvoiceRegistry) HodlUnsubscribeAll(subscriber chan<- interface{}) {
+func (i *mockInvoiceRegistry) HodlUnsubscribeAll(
+	subscriber chan<- interface{}) {
+
 	i.registry.HodlUnsubscribeAll(subscriber)
 }
 
@@ -1099,22 +1106,22 @@ type mockHTLCNotifier struct {
 }
 
 func (h *mockHTLCNotifier) NotifyForwardingEvent(key HtlcKey, info HtlcInfo,
-	eventType HtlcEventType) { // nolint:whitespace
+	eventType HtlcEventType) { //nolint:whitespace
 }
 
 func (h *mockHTLCNotifier) NotifyLinkFailEvent(key HtlcKey, info HtlcInfo,
 	eventType HtlcEventType, linkErr *LinkError,
-	incoming bool) { // nolint:whitespace
+	incoming bool) { //nolint:whitespace
 }
 
 func (h *mockHTLCNotifier) NotifyForwardingFailEvent(key HtlcKey,
-	eventType HtlcEventType) { // nolint:whitespace
+	eventType HtlcEventType) { //nolint:whitespace
 }
 
 func (h *mockHTLCNotifier) NotifySettleEvent(key HtlcKey,
-	preimage lntypes.Preimage, eventType HtlcEventType) { // nolint:whitespace
+	preimage lntypes.Preimage, eventType HtlcEventType) { //nolint:whitespace,lll
 }
 
-func (h *mockHTLCNotifier) NotifyFinalHtlcEvent(key channeldb.CircuitKey,
+func (h *mockHTLCNotifier) NotifyFinalHtlcEvent(key models.CircuitKey,
 	info channeldb.FinalHtlcInfo) { //nolint:whitespace
 }

--- a/htlcswitch/switch.go
+++ b/htlcswitch/switch.go
@@ -15,6 +15,7 @@ import (
 	"github.com/davecgh/go-spew/spew"
 	"github.com/lightningnetwork/lnd/chainntnfs"
 	"github.com/lightningnetwork/lnd/channeldb"
+	"github.com/lightningnetwork/lnd/channeldb/models"
 	"github.com/lightningnetwork/lnd/clock"
 	"github.com/lightningnetwork/lnd/contractcourt"
 	"github.com/lightningnetwork/lnd/htlcswitch/hop"
@@ -640,7 +641,7 @@ func (s *Switch) UpdateForwardingPolicies(
 func (s *Switch) IsForwardedHTLC(chanID lnwire.ShortChannelID,
 	htlcIndex uint64) bool {
 
-	circuit := s.circuits.LookupOpenCircuit(channeldb.CircuitKey{
+	circuit := s.circuits.LookupOpenCircuit(models.CircuitKey{
 		ChanID: chanID,
 		HtlcID: htlcIndex,
 	})

--- a/htlcswitch/switch_test.go
+++ b/htlcswitch/switch_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/go-errors/errors"
 	"github.com/lightningnetwork/lnd/chainntnfs"
 	"github.com/lightningnetwork/lnd/channeldb"
+	"github.com/lightningnetwork/lnd/channeldb/models"
 	"github.com/lightningnetwork/lnd/contractcourt"
 	"github.com/lightningnetwork/lnd/htlcswitch/hodl"
 	"github.com/lightningnetwork/lnd/htlcswitch/hop"
@@ -25,7 +26,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-var zeroCircuit = channeldb.CircuitKey{}
+var zeroCircuit = models.CircuitKey{}
 var emptyScid = lnwire.ShortChannelID{}
 
 func genPreimage() ([32]byte, error) {
@@ -3585,7 +3586,7 @@ func getThreeHopEvents(channels *clusterChannels, htlcID uint64,
 
 	aliceKey := HtlcKey{
 		IncomingCircuit: zeroCircuit,
-		OutgoingCircuit: channeldb.CircuitKey{
+		OutgoingCircuit: models.CircuitKey{
 			ChanID: channels.aliceToBob.ShortChanID(),
 			HtlcID: htlcID,
 		},
@@ -3606,11 +3607,11 @@ func getThreeHopEvents(channels *clusterChannels, htlcID uint64,
 	}
 
 	bobKey := HtlcKey{
-		IncomingCircuit: channeldb.CircuitKey{
+		IncomingCircuit: models.CircuitKey{
 			ChanID: channels.bobToAlice.ShortChanID(),
 			HtlcID: htlcID,
 		},
-		OutgoingCircuit: channeldb.CircuitKey{
+		OutgoingCircuit: models.CircuitKey{
 			ChanID: channels.bobToCarol.ShortChanID(),
 			HtlcID: htlcID,
 		},
@@ -3691,7 +3692,7 @@ func getThreeHopEvents(channels *clusterChannels, htlcID uint64,
 	carolEvents := []interface{}{
 		&SettleEvent{
 			HtlcKey: HtlcKey{
-				IncomingCircuit: channeldb.CircuitKey{
+				IncomingCircuit: models.CircuitKey{
 					ChanID: channels.carolToBob.ShortChanID(),
 					HtlcID: htlcID,
 				},
@@ -3701,7 +3702,7 @@ func getThreeHopEvents(channels *clusterChannels, htlcID uint64,
 			HtlcEventType: HtlcEventTypeReceive,
 			Timestamp:     ts,
 		}, &FinalHtlcEvent{
-			CircuitKey: channeldb.CircuitKey{
+			CircuitKey: models.CircuitKey{
 				ChanID: channels.carolToBob.ShortChanID(),
 				HtlcID: htlcID,
 			},

--- a/htlcswitch/test_utils.go
+++ b/htlcswitch/test_utils.go
@@ -26,6 +26,7 @@ import (
 	"github.com/lightningnetwork/lnd/contractcourt"
 	"github.com/lightningnetwork/lnd/htlcswitch/hop"
 	"github.com/lightningnetwork/lnd/input"
+	"github.com/lightningnetwork/lnd/invoices"
 	"github.com/lightningnetwork/lnd/keychain"
 	"github.com/lightningnetwork/lnd/kvdb"
 	"github.com/lightningnetwork/lnd/lnpeer"
@@ -510,7 +511,7 @@ func getChanID(msg lnwire.Message) (lnwire.ChannelID, error) {
 func generatePaymentWithPreimage(invoiceAmt, htlcAmt lnwire.MilliSatoshi,
 	timelock uint32, blob [lnwire.OnionPacketSize]byte,
 	preimage *lntypes.Preimage, rhash, payAddr [32]byte) (
-	*channeldb.Invoice, *lnwire.UpdateAddHTLC, uint64, error) {
+	*invoices.Invoice, *lnwire.UpdateAddHTLC, uint64, error) {
 
 	// Create the db invoice. Normally the payment requests needs to be set,
 	// because it is decoded in InvoiceRegistry to obtain the cltv expiry.
@@ -519,9 +520,9 @@ func generatePaymentWithPreimage(invoiceAmt, htlcAmt lnwire.MilliSatoshi,
 	// don't need to bother here with creating and signing a payment
 	// request.
 
-	invoice := &channeldb.Invoice{
+	invoice := &invoices.Invoice{
 		CreationDate: time.Now(),
-		Terms: channeldb.ContractTerm{
+		Terms: invoices.ContractTerm{
 			FinalCltvDelta:  testInvoiceCltvExpiry,
 			Value:           invoiceAmt,
 			PaymentPreimage: preimage,
@@ -552,7 +553,7 @@ func generatePaymentWithPreimage(invoiceAmt, htlcAmt lnwire.MilliSatoshi,
 // generatePayment generates the htlc add request by given path blob and
 // invoice which should be added by destination peer.
 func generatePayment(invoiceAmt, htlcAmt lnwire.MilliSatoshi, timelock uint32,
-	blob [lnwire.OnionPacketSize]byte) (*channeldb.Invoice,
+	blob [lnwire.OnionPacketSize]byte) (*invoices.Invoice,
 	*lnwire.UpdateAddHTLC, uint64, error) {
 
 	var preimage lntypes.Preimage
@@ -753,7 +754,7 @@ func makePayment(sendingPeer, receivingPeer lnpeer.Peer,
 func preparePayment(sendingPeer, receivingPeer lnpeer.Peer,
 	firstHop lnwire.ShortChannelID, hops []*hop.Payload,
 	invoiceAmt, htlcAmt lnwire.MilliSatoshi,
-	timelock uint32) (*channeldb.Invoice, func() error, error) {
+	timelock uint32) (*invoices.Invoice, func() error, error) {
 
 	sender := sendingPeer.(*mockServer)
 	receiver := receivingPeer.(*mockServer)

--- a/invoices/errors.go
+++ b/invoices/errors.go
@@ -1,0 +1,108 @@
+package invoices
+
+import (
+	"errors"
+	"fmt"
+)
+
+var (
+	// ErrInvoiceAlreadySettled is returned when the invoice is already
+	// settled.
+	ErrInvoiceAlreadySettled = errors.New("invoice already settled")
+
+	// ErrInvoiceAlreadyCanceled is returned when the invoice is already
+	// canceled.
+	ErrInvoiceAlreadyCanceled = errors.New("invoice already canceled")
+
+	// ErrInvoiceAlreadyAccepted is returned when the invoice is already
+	// accepted.
+	ErrInvoiceAlreadyAccepted = errors.New("invoice already accepted")
+
+	// ErrInvoiceStillOpen is returned when the invoice is still open.
+	ErrInvoiceStillOpen = errors.New("invoice still open")
+
+	// ErrInvoiceCannotOpen is returned when an attempt is made to move an
+	// invoice to the open state.
+	ErrInvoiceCannotOpen = errors.New("cannot move invoice to open")
+
+	// ErrInvoiceCannotAccept is returned when an attempt is made to accept
+	// an invoice while the invoice is not in the open state.
+	ErrInvoiceCannotAccept = errors.New("cannot accept invoice")
+
+	// ErrInvoicePreimageMismatch is returned when the preimage doesn't
+	// match the invoice hash.
+	ErrInvoicePreimageMismatch = errors.New("preimage does not match")
+
+	// ErrHTLCPreimageMissing is returned when trying to accept/settle an
+	// AMP HTLC but the HTLC-level preimage has not been set.
+	ErrHTLCPreimageMissing = errors.New("AMP htlc missing preimage")
+
+	// ErrHTLCPreimageMismatch is returned when trying to accept/settle an
+	// AMP HTLC but the HTLC-level preimage does not satisfying the
+	// HTLC-level payment hash.
+	ErrHTLCPreimageMismatch = errors.New("htlc preimage mismatch")
+
+	// ErrHTLCAlreadySettled is returned when trying to settle an invoice
+	// but HTLC already exists in the settled state.
+	ErrHTLCAlreadySettled = errors.New("htlc already settled")
+
+	// ErrInvoiceHasHtlcs is returned when attempting to insert an invoice
+	// that already has HTLCs.
+	ErrInvoiceHasHtlcs = errors.New("cannot add invoice with htlcs")
+
+	// ErrEmptyHTLCSet is returned when attempting to accept or settle and
+	// HTLC set that has no HTLCs.
+	ErrEmptyHTLCSet = errors.New("cannot settle/accept empty HTLC set")
+
+	// ErrUnexpectedInvoicePreimage is returned when an invoice-level
+	// preimage is provided when trying to settle an invoice that shouldn't
+	// have one, e.g. an AMP invoice.
+	ErrUnexpectedInvoicePreimage = errors.New(
+		"unexpected invoice preimage provided on settle",
+	)
+
+	// ErrHTLCPreimageAlreadyExists is returned when trying to set an
+	// htlc-level preimage but one is already known.
+	ErrHTLCPreimageAlreadyExists = errors.New(
+		"htlc-level preimage already exists",
+	)
+
+	// ErrInvoiceNotFound is returned when a targeted invoice can't be
+	// found.
+	ErrInvoiceNotFound = errors.New("unable to locate invoice")
+
+	// ErrNoInvoicesCreated is returned when we don't have invoices in
+	// our database to return.
+	ErrNoInvoicesCreated = errors.New("there are no existing invoices")
+
+	// ErrDuplicateInvoice is returned when an invoice with the target
+	// payment hash already exists.
+	ErrDuplicateInvoice = errors.New(
+		"invoice with payment hash already exists",
+	)
+
+	// ErrDuplicatePayAddr is returned when an invoice with the target
+	// payment addr already exists.
+	ErrDuplicatePayAddr = errors.New(
+		"invoice with payemnt addr already exists",
+	)
+
+	// ErrInvRefEquivocation is returned when an InvoiceRef targets
+	// multiple, distinct invoices.
+	ErrInvRefEquivocation = errors.New("inv ref matches multiple invoices")
+
+	// ErrNoPaymentsCreated is returned when bucket of payments hasn't been
+	// created.
+	ErrNoPaymentsCreated = errors.New("there are no existing payments")
+)
+
+// ErrDuplicateSetID is an error returned when attempting to adding an AMP HTLC
+// to an invoice, but another invoice is already indexed by the same set id.
+type ErrDuplicateSetID struct {
+	SetID [32]byte
+}
+
+// Error returns a human-readable description of ErrDuplicateSetID.
+func (e ErrDuplicateSetID) Error() string {
+	return fmt.Sprintf("invoice with set_id=%x already exists", e.SetID)
+}

--- a/invoices/interface.go
+++ b/invoices/interface.go
@@ -1,8 +1,90 @@
 package invoices
 
 import (
+	"time"
+
+	"github.com/lightningnetwork/lnd/channeldb/models"
+	"github.com/lightningnetwork/lnd/lntypes"
 	"github.com/lightningnetwork/lnd/record"
 )
+
+// InvScanFunc is a helper type used to specify the type used in the
+// ScanInvoices methods (part of the InvoiceDB interface).
+type InvScanFunc func(lntypes.Hash, *Invoice) error
+
+// InvoiceDB is the database that stores the information about invoices.
+type InvoiceDB interface {
+	// AddInvoice inserts the targeted invoice into the database.
+	// If the invoice has *any* payment hashes which already exists within
+	// the database, then the insertion will be aborted and rejected due to
+	// the strict policy banning any duplicate payment hashes.
+	//
+	// NOTE: A side effect of this function is that it sets AddIndex on
+	// newInvoice.
+	AddInvoice(invoice *Invoice, paymentHash lntypes.Hash) (uint64, error)
+
+	// InvoicesAddedSince can be used by callers to seek into the event
+	// time series of all the invoices added in the database. The specified
+	// sinceAddIndex should be the highest add index that the caller knows
+	// of. This method will return all invoices with an add index greater
+	// than the specified sinceAddIndex.
+	//
+	// NOTE: The index starts from 1, as a result. We enforce that
+	// specifying a value below the starting index value is a noop.
+	InvoicesAddedSince(sinceAddIndex uint64) ([]Invoice, error)
+
+	// LookupInvoice attempts to look up an invoice according to its 32 byte
+	// payment hash. If an invoice which can settle the HTLC identified by
+	// the passed payment hash isn't found, then an error is returned.
+	// Otherwise, the full invoice is returned.
+	// Before setting the incoming HTLC, the values SHOULD be checked to
+	// ensure the payer meets the agreed upon contractual terms of the
+	// payment.
+	LookupInvoice(ref InvoiceRef) (Invoice, error)
+
+	// ScanInvoices scans through all invoices and calls the passed scanFunc
+	// for each invoice with its respective payment hash. Additionally a
+	// reset() closure is passed which is used to reset/initialize partial
+	// results and also to signal if the kvdb.View transaction has been
+	// retried.
+	//
+	// TODO(positiveblue): abstract this functionality so it makes sense for
+	// other backends like sql.
+	ScanInvoices(scanFunc InvScanFunc, reset func()) error
+
+	// QueryInvoices allows a caller to query the invoice database for
+	// invoices within the specified add index range.
+	QueryInvoices(q InvoiceQuery) (InvoiceSlice, error)
+
+	// UpdateInvoice attempts to update an invoice corresponding to the
+	// passed payment hash. If an invoice matching the passed payment hash
+	// doesn't exist within the database, then the action will fail with a
+	// "not found" error.
+	//
+	// The update is performed inside the same database transaction that
+	// fetches the invoice and is therefore atomic. The fields to update
+	// are controlled by the supplied callback.
+	//
+	// TODO(positiveblue): abstract this functionality so it makes sense for
+	// other backends like sql.
+	UpdateInvoice(ref InvoiceRef, setIDHint *SetID,
+		callback InvoiceUpdateCallback) (*Invoice, error)
+
+	// InvoicesSettledSince can be used by callers to catch up any settled
+	// invoices they missed within the settled invoice time series. We'll
+	// return all known settled invoice that have a settle index higher than
+	// the passed sinceSettleIndex.
+	//
+	// NOTE: The index starts from 1, as a result. We enforce that
+	// specifying a value below the starting index value is a noop.
+	InvoicesSettledSince(sinceSettleIndex uint64) ([]Invoice, error)
+
+	// DeleteInvoice attempts to delete the passed invoices from the
+	// database in one transaction. The passed delete references hold all
+	// keys required to delete the invoices without also needing to
+	// deserialze them.
+	DeleteInvoice(invoicesToDelete []InvoiceDeleteRef) error
+}
 
 // Payload abstracts access to any additional fields provided in the final hop's
 // TLV onion payload.
@@ -23,3 +105,61 @@ type Payload interface {
 	// payment to the payee.
 	Metadata() []byte
 }
+
+// InvoiceQuery represents a query to the invoice database. The query allows a
+// caller to retrieve all invoices starting from a particular add index and
+// limit the number of results returned.
+type InvoiceQuery struct {
+	// IndexOffset is the offset within the add indices to start at. This
+	// can be used to start the response at a particular invoice.
+	IndexOffset uint64
+
+	// NumMaxInvoices is the maximum number of invoices that should be
+	// starting from the add index.
+	NumMaxInvoices uint64
+
+	// PendingOnly, if set, returns unsettled invoices starting from the
+	// add index.
+	PendingOnly bool
+
+	// Reversed, if set, indicates that the invoices returned should start
+	// from the IndexOffset and go backwards.
+	Reversed bool
+
+	// CreationDateStart, if set, filters out all invoices with a creation
+	// date greater than or euqal to it.
+	CreationDateStart time.Time
+
+	// CreationDateEnd, if set, filters out all invoices with a creation
+	// date less than or euqal to it.
+	CreationDateEnd time.Time
+}
+
+// InvoiceSlice is the response to a invoice query. It includes the original
+// query, the set of invoices that match the query, and an integer which
+// represents the offset index of the last item in the set of returned invoices.
+// This integer allows callers to resume their query using this offset in the
+// event that the query's response exceeds the maximum number of returnable
+// invoices.
+type InvoiceSlice struct {
+	InvoiceQuery
+
+	// Invoices is the set of invoices that matched the query above.
+	Invoices []Invoice
+
+	// FirstIndexOffset is the index of the first element in the set of
+	// returned Invoices above. Callers can use this to resume their query
+	// in the event that the slice has too many events to fit into a single
+	// response.
+	FirstIndexOffset uint64
+
+	// LastIndexOffset is the index of the last element in the set of
+	// returned Invoices above. Callers can use this to resume their query
+	// in the event that the slice has too many events to fit into a single
+	// response.
+	LastIndexOffset uint64
+}
+
+// CircuitKey is a tuple of channel ID and HTLC ID, used to uniquely identify
+// HTLCs in a circuit.
+type CircuitKey = models.CircuitKey

--- a/invoices/invoiceregistry.go
+++ b/invoices/invoiceregistry.go
@@ -7,8 +7,6 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/lightningnetwork/lnd/channeldb"
-	"github.com/lightningnetwork/lnd/channeldb/models"
 	"github.com/lightningnetwork/lnd/clock"
 	"github.com/lightningnetwork/lnd/lntypes"
 	"github.com/lightningnetwork/lnd/lnwire"
@@ -17,13 +15,15 @@ import (
 )
 
 var (
-	// ErrInvoiceExpiryTooSoon is returned when an invoice is attempted to be
-	// accepted or settled with not enough blocks remaining.
+	// ErrInvoiceExpiryTooSoon is returned when an invoice is attempted to
+	// be accepted or settled with not enough blocks remaining.
 	ErrInvoiceExpiryTooSoon = errors.New("invoice expiry too soon")
 
-	// ErrInvoiceAmountTooLow is returned  when an invoice is attempted to be
-	// accepted or settled with an amount that is too low.
-	ErrInvoiceAmountTooLow = errors.New("paid amount less than invoice amount")
+	// ErrInvoiceAmountTooLow is returned  when an invoice is attempted to
+	// be accepted or settled with an amount that is too low.
+	ErrInvoiceAmountTooLow = errors.New(
+		"paid amount less than invoice amount",
+	)
 
 	// ErrShuttingDown is returned when an operation failed because the
 	// invoice registry is shutting down.
@@ -79,10 +79,10 @@ type RegistryConfig struct {
 // mpp htlcs for which the complete set didn't arrive in time.
 type htlcReleaseEvent struct {
 	// invoiceRef identifiers the invoice this htlc belongs to.
-	invoiceRef channeldb.InvoiceRef
+	invoiceRef InvoiceRef
 
 	// key is the circuit key of the htlc to release.
-	key models.CircuitKey
+	key CircuitKey
 
 	// releaseTime is the time at which to release the htlc.
 	releaseTime time.Time
@@ -104,7 +104,7 @@ type InvoiceRegistry struct {
 
 	nextClientID uint32 // must be used atomically
 
-	cdb *channeldb.DB
+	idb InvoiceDB
 
 	// cfg contains the registry's configuration parameters.
 	cfg *RegistryConfig
@@ -130,13 +130,14 @@ type InvoiceRegistry struct {
 	// necessary to avoid deadlocks in the registry when processing invoice
 	// events.
 	hodlSubscriptionsMux sync.RWMutex
-	// subscriptions is a map from a circuit key to a list of subscribers.
-	// It is used for efficient notification of links.
-	hodlSubscriptions map[models.CircuitKey]map[chan<- interface{}]struct{}
+
+	// hodlSubscriptions is a map from a circuit key to a list of
+	// subscribers. It is used for efficient notification of links.
+	hodlSubscriptions map[CircuitKey]map[chan<- interface{}]struct{}
 
 	// reverseSubscriptions tracks circuit keys subscribed to per
 	// subscriber. This is used to unsubscribe from all hashes efficiently.
-	hodlReverseSubscriptions map[chan<- interface{}]map[models.CircuitKey]struct{}
+	hodlReverseSubscriptions map[chan<- interface{}]map[CircuitKey]struct{}
 
 	// htlcAutoReleaseChan contains the new htlcs that need to be
 	// auto-released.
@@ -152,19 +153,21 @@ type InvoiceRegistry struct {
 // wraps the persistent on-disk invoice storage with an additional in-memory
 // layer. The in-memory layer is in place such that debug invoices can be added
 // which are volatile yet available system wide within the daemon.
-func NewRegistry(cdb *channeldb.DB, expiryWatcher *InvoiceExpiryWatcher,
+func NewRegistry(idb InvoiceDB, expiryWatcher *InvoiceExpiryWatcher,
 	cfg *RegistryConfig) *InvoiceRegistry {
 
+	notificationClients := make(map[uint32]*InvoiceSubscription)
+	singleNotificationClients := make(map[uint32]*SingleInvoiceSubscription)
 	return &InvoiceRegistry{
-		cdb:                       cdb,
-		notificationClients:       make(map[uint32]*InvoiceSubscription),
-		singleNotificationClients: make(map[uint32]*SingleInvoiceSubscription),
+		idb:                       idb,
+		notificationClients:       notificationClients,
+		singleNotificationClients: singleNotificationClients,
 		invoiceEvents:             make(chan *invoiceEvent, 100),
 		hodlSubscriptions: make(
-			map[models.CircuitKey]map[chan<- interface{}]struct{},
+			map[CircuitKey]map[chan<- interface{}]struct{},
 		),
 		hodlReverseSubscriptions: make(
-			map[chan<- interface{}]map[models.CircuitKey]struct{},
+			map[chan<- interface{}]map[CircuitKey]struct{},
 		),
 		cfg:                 cfg,
 		htlcAutoReleaseChan: make(chan *htlcReleaseEvent),
@@ -179,7 +182,7 @@ func NewRegistry(cdb *channeldb.DB, expiryWatcher *InvoiceExpiryWatcher,
 func (i *InvoiceRegistry) scanInvoicesOnStart() error {
 	var (
 		pending   []invoiceExpiry
-		removable []channeldb.InvoiceDeleteRef
+		removable []InvoiceDeleteRef
 	)
 
 	reset := func() {
@@ -189,11 +192,11 @@ func (i *InvoiceRegistry) scanInvoicesOnStart() error {
 		// using the etcd driver, where all transactions are allowed
 		// to retry for serializability).
 		pending = nil
-		removable = make([]channeldb.InvoiceDeleteRef, 0)
+		removable = make([]InvoiceDeleteRef, 0)
 	}
 
 	scanFunc := func(paymentHash lntypes.Hash,
-		invoice *channeldb.Invoice) error {
+		invoice *Invoice) error {
 
 		if invoice.IsPending() {
 			expiryRef := makeInvoiceExpiry(paymentHash, invoice)
@@ -201,19 +204,19 @@ func (i *InvoiceRegistry) scanInvoicesOnStart() error {
 				pending = append(pending, expiryRef)
 			}
 		} else if i.cfg.GcCanceledInvoicesOnStartup &&
-			invoice.State == channeldb.ContractCanceled {
+			invoice.State == ContractCanceled {
 
 			// Consider invoice for removal if it is already
 			// canceled. Invoices that are expired but not yet
 			// canceled, will be queued up for cancellation after
 			// startup and will be deleted afterwards.
-			ref := channeldb.InvoiceDeleteRef{
+			ref := InvoiceDeleteRef{
 				PayHash:     paymentHash,
 				AddIndex:    invoice.AddIndex,
 				SettleIndex: invoice.SettleIndex,
 			}
 
-			if invoice.Terms.PaymentAddr != channeldb.BlankPayAddr {
+			if invoice.Terms.PaymentAddr != BlankPayAddr {
 				ref.PayAddr = &invoice.Terms.PaymentAddr
 			}
 
@@ -222,7 +225,7 @@ func (i *InvoiceRegistry) scanInvoicesOnStart() error {
 		return nil
 	}
 
-	err := i.cdb.ScanInvoices(scanFunc, reset)
+	err := i.idb.ScanInvoices(scanFunc, reset)
 	if err != nil {
 		return err
 	}
@@ -234,7 +237,7 @@ func (i *InvoiceRegistry) scanInvoicesOnStart() error {
 	if len(removable) > 0 {
 		log.Infof("Attempting to delete %v canceled invoices",
 			len(removable))
-		if err := i.cdb.DeleteInvoice(removable); err != nil {
+		if err := i.idb.DeleteInvoice(removable); err != nil {
 			log.Warnf("Deleting canceled invoices failed: %v", err)
 		} else {
 			log.Infof("Deleted %v canceled invoices",
@@ -287,7 +290,7 @@ func (i *InvoiceRegistry) Stop() error {
 // instance where invoices are settled.
 type invoiceEvent struct {
 	hash    lntypes.Hash
-	invoice *channeldb.Invoice
+	invoice *Invoice
 	setID   *[32]byte
 }
 
@@ -323,8 +326,8 @@ func (i *InvoiceRegistry) invoiceEventLoop() {
 			// For backwards compatibility, do not notify all
 			// invoice subscribers of cancel and accept events.
 			state := event.invoice.State
-			if state != channeldb.ContractCanceled &&
-				state != channeldb.ContractAccepted {
+			if state != ContractCanceled &&
+				state != ContractAccepted {
 
 				i.dispatchToClients(event)
 			}
@@ -401,7 +404,7 @@ func (i *InvoiceRegistry) dispatchToClients(event *invoiceEvent) {
 		switch {
 		// If we've already sent this settle event to
 		// the client, then we can skip this.
-		case state == channeldb.ContractSettled &&
+		case state == ContractSettled &&
 			client.settleIndex >= invoice.SettleIndex:
 			continue
 
@@ -409,14 +412,14 @@ func (i *InvoiceRegistry) dispatchToClients(event *invoiceEvent) {
 		// the client then we can skip this one, but only if this isn't
 		// an AMP invoice. AMP invoices always remain in the settle
 		// state as a base invoice.
-		case event.setID == nil && state == channeldb.ContractOpen &&
+		case event.setID == nil && state == ContractOpen &&
 			client.addIndex >= invoice.AddIndex:
 			continue
 
 		// These two states should never happen, but we
 		// log them just in case so we can detect this
 		// instance.
-		case state == channeldb.ContractOpen &&
+		case state == ContractOpen &&
 			client.addIndex+1 != invoice.AddIndex:
 			log.Warnf("client=%v for invoice "+
 				"notifications missed an update, "+
@@ -424,7 +427,7 @@ func (i *InvoiceRegistry) dispatchToClients(event *invoiceEvent) {
 				clientID, client.addIndex,
 				invoice.AddIndex)
 
-		case state == channeldb.ContractSettled &&
+		case state == ContractSettled &&
 			client.settleIndex+1 != invoice.SettleIndex:
 			log.Warnf("client=%v for invoice "+
 				"notifications missed an update, "+
@@ -456,10 +459,10 @@ func (i *InvoiceRegistry) dispatchToClients(event *invoiceEvent) {
 		// event is added while we're catching up a new client.
 		invState := event.invoice.State
 		switch {
-		case invState == channeldb.ContractSettled:
+		case invState == ContractSettled:
 			client.settleIndex = invoice.SettleIndex
 
-		case invState == channeldb.ContractOpen && event.setID == nil:
+		case invState == ContractOpen && event.setID == nil:
 			client.addIndex = invoice.AddIndex
 
 		// If this is an AMP invoice, then we'll need to use the set ID
@@ -467,7 +470,7 @@ func (i *InvoiceRegistry) dispatchToClients(event *invoiceEvent) {
 		// invoices never go to the open state, but if a setID is
 		// passed, then we know it was just settled and will track the
 		// highest settle index so far.
-		case invState == channeldb.ContractOpen && event.setID != nil:
+		case invState == ContractOpen && event.setID != nil:
 			setID := *event.setID
 			client.settleIndex = invoice.AMPState[setID].SettleIndex
 
@@ -480,13 +483,15 @@ func (i *InvoiceRegistry) dispatchToClients(event *invoiceEvent) {
 
 // deliverBacklogEvents will attempts to query the invoice database for any
 // notifications that the client has missed since it reconnected last.
-func (i *InvoiceRegistry) deliverBacklogEvents(client *InvoiceSubscription) error {
-	addEvents, err := i.cdb.InvoicesAddedSince(client.addIndex)
+func (i *InvoiceRegistry) deliverBacklogEvents(
+	client *InvoiceSubscription) error {
+
+	addEvents, err := i.idb.InvoicesAddedSince(client.addIndex)
 	if err != nil {
 		return err
 	}
 
-	settleEvents, err := i.cdb.InvoicesSettledSince(client.settleIndex)
+	settleEvents, err := i.idb.InvoicesSettledSince(client.settleIndex)
 	if err != nil {
 		return err
 	}
@@ -533,13 +538,13 @@ func (i *InvoiceRegistry) deliverBacklogEvents(client *InvoiceSubscription) erro
 func (i *InvoiceRegistry) deliverSingleBacklogEvents(
 	client *SingleInvoiceSubscription) error {
 
-	invoice, err := i.cdb.LookupInvoice(client.invoiceRef)
+	invoice, err := i.idb.LookupInvoice(client.invoiceRef)
 
 	// It is possible that the invoice does not exist yet, but the client is
 	// already watching it in anticipation.
-	if err == channeldb.ErrInvoiceNotFound ||
-		err == channeldb.ErrNoInvoicesCreated {
-
+	isNotFound := errors.Is(err, ErrInvoiceNotFound)
+	isNotCreated := errors.Is(err, ErrNoInvoicesCreated)
+	if isNotFound || isNotCreated {
 		return nil
 	}
 	if err != nil {
@@ -573,15 +578,15 @@ func (i *InvoiceRegistry) deliverSingleBacklogEvents(
 // addIndex of the newly created invoice which monotonically increases for each
 // new invoice added.  A side effect of this function is that it also sets
 // AddIndex on the invoice argument.
-func (i *InvoiceRegistry) AddInvoice(invoice *channeldb.Invoice,
+func (i *InvoiceRegistry) AddInvoice(invoice *Invoice,
 	paymentHash lntypes.Hash) (uint64, error) {
 
 	i.Lock()
 
-	ref := channeldb.InvoiceRefByHash(paymentHash)
+	ref := InvoiceRefByHash(paymentHash)
 	log.Debugf("Invoice%v: added with terms %v", ref, invoice.Terms)
 
-	addIndex, err := i.cdb.AddInvoice(invoice, paymentHash)
+	addIndex, err := i.idb.AddInvoice(invoice, paymentHash)
 	if err != nil {
 		i.Unlock()
 		return 0, err
@@ -607,27 +612,23 @@ func (i *InvoiceRegistry) AddInvoice(invoice *channeldb.Invoice,
 // then we're able to pull the funds pending within an HTLC.
 //
 // TODO(roasbeef): ignore if settled?
-func (i *InvoiceRegistry) LookupInvoice(rHash lntypes.Hash) (channeldb.Invoice,
-	error) {
-
+func (i *InvoiceRegistry) LookupInvoice(rHash lntypes.Hash) (Invoice, error) {
 	// We'll check the database to see if there's an existing matching
 	// invoice.
-	ref := channeldb.InvoiceRefByHash(rHash)
-	return i.cdb.LookupInvoice(ref)
+	ref := InvoiceRefByHash(rHash)
+	return i.idb.LookupInvoice(ref)
 }
 
 // LookupInvoiceByRef looks up an invoice by the given reference, if found
 // then we're able to pull the funds pending within an HTLC.
-func (i *InvoiceRegistry) LookupInvoiceByRef(
-	ref channeldb.InvoiceRef) (channeldb.Invoice, error) {
-
-	return i.cdb.LookupInvoice(ref)
+func (i *InvoiceRegistry) LookupInvoiceByRef(ref InvoiceRef) (Invoice, error) {
+	return i.idb.LookupInvoice(ref)
 }
 
 // startHtlcTimer starts a new timer via the invoice registry main loop that
 // cancels a single htlc on an invoice when the htlc hold duration has passed.
-func (i *InvoiceRegistry) startHtlcTimer(invoiceRef channeldb.InvoiceRef,
-	key models.CircuitKey, acceptTime time.Time) error {
+func (i *InvoiceRegistry) startHtlcTimer(invoiceRef InvoiceRef,
+	key CircuitKey, acceptTime time.Time) error {
 
 	releaseTime := acceptTime.Add(i.cfg.HtlcHoldDuration)
 	event := &htlcReleaseEvent{
@@ -648,14 +649,12 @@ func (i *InvoiceRegistry) startHtlcTimer(invoiceRef channeldb.InvoiceRef,
 // cancelSingleHtlc cancels a single accepted htlc on an invoice. It takes
 // a resolution result which will be used to notify subscribed links and
 // resolvers of the details of the htlc cancellation.
-func (i *InvoiceRegistry) cancelSingleHtlc(invoiceRef channeldb.InvoiceRef,
-	key models.CircuitKey, result FailResolutionResult) error {
+func (i *InvoiceRegistry) cancelSingleHtlc(invoiceRef InvoiceRef,
+	key CircuitKey, result FailResolutionResult) error {
 
-	updateInvoice := func(invoice *channeldb.Invoice) (
-		*channeldb.InvoiceUpdateDesc, error) {
-
+	updateInvoice := func(invoice *Invoice) (*InvoiceUpdateDesc, error) {
 		// Only allow individual htlc cancellation on open invoices.
-		if invoice.State != channeldb.ContractOpen {
+		if invoice.State != ContractOpen {
 			log.Debugf("cancelSingleHtlc: invoice %v no longer "+
 				"open", invoiceRef)
 
@@ -664,8 +663,8 @@ func (i *InvoiceRegistry) cancelSingleHtlc(invoiceRef channeldb.InvoiceRef,
 
 		// Lookup the current status of the htlc in the database.
 		var (
-			htlcState channeldb.HtlcState
-			setID     *channeldb.SetID
+			htlcState HtlcState
+			setID     *SetID
 		)
 		htlc, ok := invoice.Htlcs[key]
 		if !ok {
@@ -695,7 +694,7 @@ func (i *InvoiceRegistry) cancelSingleHtlc(invoiceRef channeldb.InvoiceRef,
 
 		// Cancellation is only possible if the htlc wasn't already
 		// resolved.
-		if htlcState != channeldb.HtlcStateAccepted {
+		if htlcState != HtlcStateAccepted {
 			log.Debugf("cancelSingleHtlc: htlc %v on invoice %v "+
 				"is already resolved", key, invoiceRef)
 
@@ -707,11 +706,11 @@ func (i *InvoiceRegistry) cancelSingleHtlc(invoiceRef channeldb.InvoiceRef,
 
 		// Return an update descriptor that cancels htlc and keeps
 		// invoice open.
-		canceledHtlcs := map[models.CircuitKey]struct{}{
+		canceledHtlcs := map[CircuitKey]struct{}{
 			key: {},
 		}
 
-		return &channeldb.InvoiceUpdateDesc{
+		return &InvoiceUpdateDesc{
 			CancelHtlcs: canceledHtlcs,
 			SetID:       setID,
 		}, nil
@@ -720,11 +719,11 @@ func (i *InvoiceRegistry) cancelSingleHtlc(invoiceRef channeldb.InvoiceRef,
 	// Try to mark the specified htlc as canceled in the invoice database.
 	// Intercept the update descriptor to set the local updated variable. If
 	// no invoice update is performed, we can return early.
-	setID := (*channeldb.SetID)(invoiceRef.SetID())
+	setID := (*SetID)(invoiceRef.SetID())
 	var updated bool
-	invoice, err := i.cdb.UpdateInvoice(invoiceRef, setID,
-		func(invoice *channeldb.Invoice) (
-			*channeldb.InvoiceUpdateDesc, error) {
+	invoice, err := i.idb.UpdateInvoice(invoiceRef, setID,
+		func(invoice *Invoice) (
+			*InvoiceUpdateDesc, error) {
 
 			updateDesc, err := updateInvoice(invoice)
 			if err != nil {
@@ -748,7 +747,7 @@ func (i *InvoiceRegistry) cancelSingleHtlc(invoiceRef channeldb.InvoiceRef,
 	if !ok {
 		return fmt.Errorf("htlc %v not found", key)
 	}
-	if htlc.State == channeldb.HtlcStateCanceled {
+	if htlc.State == HtlcStateCanceled {
 		resolution := NewFailResolution(
 			key, int32(htlc.AcceptHeight), result,
 		)
@@ -808,12 +807,12 @@ func (i *InvoiceRegistry) processKeySend(ctx invoiceUpdateCtx) error {
 	// to not be indexed. In the future, once AMP is merged, this should be
 	// replaced by generating a random payment address on the behalf of the
 	// sender.
-	payAddr := channeldb.BlankPayAddr
+	payAddr := BlankPayAddr
 
 	// Create placeholder invoice.
-	invoice := &channeldb.Invoice{
+	invoice := &Invoice{
 		CreationDate: i.cfg.Clock.Now(),
-		Terms: channeldb.ContractTerm{
+		Terms: ContractTerm{
 			FinalCltvDelta:  finalCltvDelta,
 			Value:           amt,
 			PaymentPreimage: &preimage,
@@ -830,7 +829,7 @@ func (i *InvoiceRegistry) processKeySend(ctx invoiceUpdateCtx) error {
 	// Insert invoice into database. Ignore duplicates, because this
 	// may be a replay.
 	_, err = i.AddInvoice(invoice, ctx.hash)
-	if err != nil && err != channeldb.ErrDuplicateInvoice {
+	if err != nil && !errors.Is(err, ErrDuplicateInvoice) {
 		return err
 	}
 
@@ -873,9 +872,9 @@ func (i *InvoiceRegistry) processAMP(ctx invoiceUpdateCtx) error {
 	payAddr := ctx.mpp.PaymentAddr()
 
 	// Create placeholder invoice.
-	invoice := &channeldb.Invoice{
+	invoice := &Invoice{
 		CreationDate: i.cfg.Clock.Now(),
-		Terms: channeldb.ContractTerm{
+		Terms: ContractTerm{
 			FinalCltvDelta:  finalCltvDelta,
 			Value:           amt,
 			PaymentPreimage: nil,
@@ -888,10 +887,10 @@ func (i *InvoiceRegistry) processAMP(ctx invoiceUpdateCtx) error {
 	// payment addrs, this may be a replay or a different HTLC for the AMP
 	// invoice.
 	_, err := i.AddInvoice(invoice, ctx.hash)
+	isDuplicatedInvoice := errors.Is(err, ErrDuplicateInvoice)
+	isDuplicatedPayAddr := errors.Is(err, ErrDuplicatePayAddr)
 	switch {
-	case err == channeldb.ErrDuplicateInvoice:
-		return nil
-	case err == channeldb.ErrDuplicatePayAddr:
+	case isDuplicatedInvoice || isDuplicatedPayAddr:
 		return nil
 	default:
 		return err
@@ -915,7 +914,7 @@ func (i *InvoiceRegistry) processAMP(ctx invoiceUpdateCtx) error {
 // held htlc.
 func (i *InvoiceRegistry) NotifyExitHopHtlc(rHash lntypes.Hash,
 	amtPaid lnwire.MilliSatoshi, expiry uint32, currentHeight int32,
-	circuitKey models.CircuitKey, hodlChan chan<- interface{},
+	circuitKey CircuitKey, hodlChan chan<- interface{},
 	payload Payload) (HtlcResolution, error) {
 
 	// Create the update context containing the relevant details of the
@@ -982,9 +981,9 @@ func (i *InvoiceRegistry) NotifyExitHopHtlc(rHash lntypes.Hash,
 	// main event loop.
 	case *htlcAcceptResolution:
 		if r.autoRelease {
-			var invRef channeldb.InvoiceRef
+			var invRef InvoiceRef
 			if ctx.amp != nil {
-				invRef = channeldb.InvoiceRefBySetID(*ctx.setID())
+				invRef = InvoiceRefBySetID(*ctx.setID())
 			} else {
 				invRef = ctx.invoiceRef()
 			}
@@ -1025,29 +1024,29 @@ func (i *InvoiceRegistry) notifyExitHopHtlcLocked(
 		resolution        HtlcResolution
 		updateSubscribers bool
 	)
-	invoice, err := i.cdb.UpdateInvoice(
-		ctx.invoiceRef(),
-		(*channeldb.SetID)(ctx.setID()),
-		func(inv *channeldb.Invoice) (
-			*channeldb.InvoiceUpdateDesc, error) {
 
-			updateDesc, res, err := updateInvoice(ctx, inv)
-			if err != nil {
-				return nil, err
-			}
+	callback := func(inv *Invoice) (*InvoiceUpdateDesc, error) {
+		updateDesc, res, err := updateInvoice(ctx, inv)
+		if err != nil {
+			return nil, err
+		}
 
-			// Only send an update if the invoice state was changed.
-			updateSubscribers = updateDesc != nil &&
-				updateDesc.State != nil
+		// Only send an update if the invoice state was changed.
+		updateSubscribers = updateDesc != nil &&
+			updateDesc.State != nil
 
-			// Assign resolution to outer scope variable.
-			resolution = res
+		// Assign resolution to outer scope variable.
+		resolution = res
 
-			return updateDesc, nil
-		},
-	)
+		return updateDesc, nil
+	}
 
-	if _, ok := err.(channeldb.ErrDuplicateSetID); ok {
+	invoiceRef := ctx.invoiceRef()
+	setID := (*SetID)(ctx.setID())
+	invoice, err := i.idb.UpdateInvoice(invoiceRef, setID, callback)
+
+	var duplicateSetIDErr ErrDuplicateSetID
+	if errors.As(err, &duplicateSetIDErr) {
 		return NewFailResolution(
 			ctx.circuitKey, ctx.currentHeight,
 			ResultInvoiceNotFound,
@@ -1055,7 +1054,7 @@ func (i *InvoiceRegistry) notifyExitHopHtlcLocked(
 	}
 
 	switch err {
-	case channeldb.ErrInvoiceNotFound:
+	case ErrInvoiceNotFound:
 		// If the invoice was not found, return a failure resolution
 		// with an invoice not found result.
 		return NewFailResolution(
@@ -1063,7 +1062,7 @@ func (i *InvoiceRegistry) notifyExitHopHtlcLocked(
 			ResultInvoiceNotFound,
 		), nil, nil
 
-	case channeldb.ErrInvRefEquivocation:
+	case ErrInvRefEquivocation:
 		return NewFailResolution(
 			ctx.circuitKey, ctx.currentHeight,
 			ResultInvoiceNotFound,
@@ -1105,7 +1104,7 @@ func (i *InvoiceRegistry) notifyExitHopHtlcLocked(
 		// Also cancel any HTLCs in the HTLC set that are also in the
 		// canceled state with the same failure result.
 		setID := ctx.setID()
-		canceledHtlcSet := invoice.HTLCSet(setID, channeldb.HtlcStateCanceled)
+		canceledHtlcSet := invoice.HTLCSet(setID, HtlcStateCanceled)
 		for key, htlc := range canceledHtlcSet {
 			htlcFailResolution := NewFailResolution(
 				key, int32(htlc.AcceptHeight), res.Outcome,
@@ -1125,7 +1124,7 @@ func (i *InvoiceRegistry) notifyExitHopHtlcLocked(
 		// marked as settled, we should follow now and settle the htlc
 		// with our peer.
 		setID := ctx.setID()
-		settledHtlcSet := invoice.HTLCSet(setID, channeldb.HtlcStateSettled)
+		settledHtlcSet := invoice.HTLCSet(setID, HtlcStateSettled)
 		for key, htlc := range settledHtlcSet {
 			preimage := res.Preimage
 			if htlc.AMP != nil && htlc.AMP.Preimage != nil {
@@ -1155,7 +1154,7 @@ func (i *InvoiceRegistry) notifyExitHopHtlcLocked(
 		//
 		// TODO(roasbeef): can remove now??
 		canceledHtlcSet := invoice.HTLCSetCompliment(
-			setID, channeldb.HtlcStateCanceled,
+			setID, HtlcStateCanceled,
 		)
 		for key, htlc := range canceledHtlcSet {
 			htlcFailResolution := NewFailResolution(
@@ -1189,7 +1188,7 @@ func (i *InvoiceRegistry) notifyExitHopHtlcLocked(
 		// Auto-release the htlc if the invoice is still open. It can
 		// only happen for mpp payments that there are htlcs in state
 		// Accepted while the invoice is Open.
-		if invoice.State == channeldb.ContractOpen {
+		if invoice.State == ContractOpen {
 			res.acceptTime = invoiceHtlc.AcceptTime
 			res.autoRelease = true
 		}
@@ -1231,29 +1230,31 @@ func (i *InvoiceRegistry) SettleHodlInvoice(preimage lntypes.Preimage) error {
 	i.Lock()
 	defer i.Unlock()
 
-	updateInvoice := func(invoice *channeldb.Invoice) (
-		*channeldb.InvoiceUpdateDesc, error) {
+	updateInvoice := func(invoice *Invoice) (
+		*InvoiceUpdateDesc, error) {
 
 		switch invoice.State {
-		case channeldb.ContractOpen:
-			return nil, channeldb.ErrInvoiceStillOpen
-		case channeldb.ContractCanceled:
-			return nil, channeldb.ErrInvoiceAlreadyCanceled
-		case channeldb.ContractSettled:
-			return nil, channeldb.ErrInvoiceAlreadySettled
+		case ContractOpen:
+			return nil, ErrInvoiceStillOpen
+
+		case ContractCanceled:
+			return nil, ErrInvoiceAlreadyCanceled
+
+		case ContractSettled:
+			return nil, ErrInvoiceAlreadySettled
 		}
 
-		return &channeldb.InvoiceUpdateDesc{
-			State: &channeldb.InvoiceStateUpdateDesc{
-				NewState: channeldb.ContractSettled,
+		return &InvoiceUpdateDesc{
+			State: &InvoiceStateUpdateDesc{
+				NewState: ContractSettled,
 				Preimage: &preimage,
 			},
 		}, nil
 	}
 
 	hash := preimage.Hash()
-	invoiceRef := channeldb.InvoiceRefByHash(hash)
-	invoice, err := i.cdb.UpdateInvoice(invoiceRef, nil, updateInvoice)
+	invoiceRef := InvoiceRefByHash(hash)
+	invoice, err := i.idb.UpdateInvoice(invoiceRef, nil, updateInvoice)
 	if err != nil {
 		log.Errorf("SettleHodlInvoice with preimage %v: %v",
 			preimage, err)
@@ -1271,7 +1272,7 @@ func (i *InvoiceRegistry) SettleHodlInvoice(preimage lntypes.Preimage) error {
 	// that were already settled before, will be notified again. This isn't
 	// necessary but doesn't hurt either.
 	for key, htlc := range invoice.Htlcs {
-		if htlc.State != channeldb.HtlcStateSettled {
+		if htlc.State != HtlcStateSettled {
 			continue
 		}
 
@@ -1296,8 +1297,8 @@ func (i *InvoiceRegistry) CancelInvoice(payHash lntypes.Hash) error {
 // cancel already accepted invoices, taking our force cancel boolean into
 // account. This is pulled out into its own function so that tests that mock
 // cancelInvoiceImpl can reuse this logic.
-func shouldCancel(state channeldb.ContractState, cancelAccepted bool) bool {
-	if state != channeldb.ContractAccepted {
+func shouldCancel(state ContractState, cancelAccepted bool) bool {
+	if state != ContractAccepted {
 		return true
 	}
 
@@ -1316,12 +1317,10 @@ func (i *InvoiceRegistry) cancelInvoiceImpl(payHash lntypes.Hash,
 	i.Lock()
 	defer i.Unlock()
 
-	ref := channeldb.InvoiceRefByHash(payHash)
+	ref := InvoiceRefByHash(payHash)
 	log.Debugf("Invoice%v: canceling invoice", ref)
 
-	updateInvoice := func(invoice *channeldb.Invoice) (
-		*channeldb.InvoiceUpdateDesc, error) {
-
+	updateInvoice := func(invoice *Invoice) (*InvoiceUpdateDesc, error) {
 		if !shouldCancel(invoice.State, cancelAccepted) {
 			return nil, nil
 		}
@@ -1329,19 +1328,19 @@ func (i *InvoiceRegistry) cancelInvoiceImpl(payHash lntypes.Hash,
 		// Move invoice to the canceled state. Rely on validation in
 		// channeldb to return an error if the invoice is already
 		// settled or canceled.
-		return &channeldb.InvoiceUpdateDesc{
-			State: &channeldb.InvoiceStateUpdateDesc{
-				NewState: channeldb.ContractCanceled,
+		return &InvoiceUpdateDesc{
+			State: &InvoiceStateUpdateDesc{
+				NewState: ContractCanceled,
 			},
 		}, nil
 	}
 
-	invoiceRef := channeldb.InvoiceRefByHash(payHash)
-	invoice, err := i.cdb.UpdateInvoice(invoiceRef, nil, updateInvoice)
+	invoiceRef := InvoiceRefByHash(payHash)
+	invoice, err := i.idb.UpdateInvoice(invoiceRef, nil, updateInvoice)
 
 	// Implement idempotency by returning success if the invoice was already
 	// canceled.
-	if err == channeldb.ErrInvoiceAlreadyCanceled {
+	if errors.Is(err, ErrInvoiceAlreadyCanceled) {
 		log.Debugf("Invoice%v: already canceled", ref)
 		return nil
 	}
@@ -1350,7 +1349,7 @@ func (i *InvoiceRegistry) cancelInvoiceImpl(payHash lntypes.Hash,
 	}
 
 	// Return without cancellation if the invoice state is ContractAccepted.
-	if invoice.State == channeldb.ContractAccepted {
+	if invoice.State == ContractAccepted {
 		log.Debugf("Invoice%v: remains accepted as cancel wasn't"+
 			"explicitly requested.", ref)
 		return nil
@@ -1364,7 +1363,7 @@ func (i *InvoiceRegistry) cancelInvoiceImpl(payHash lntypes.Hash,
 	// before, will be notified again. This isn't necessary but doesn't hurt
 	// either.
 	for key, htlc := range invoice.Htlcs {
-		if htlc.State != channeldb.HtlcStateCanceled {
+		if htlc.State != HtlcStateCanceled {
 			continue
 		}
 
@@ -1381,24 +1380,22 @@ func (i *InvoiceRegistry) cancelInvoiceImpl(payHash lntypes.Hash,
 	if i.cfg.GcCanceledInvoicesOnTheFly {
 		// Assemble the delete reference and attempt to delete through
 		// the invocice from the DB.
-		deleteRef := channeldb.InvoiceDeleteRef{
+		deleteRef := InvoiceDeleteRef{
 			PayHash:     payHash,
 			AddIndex:    invoice.AddIndex,
 			SettleIndex: invoice.SettleIndex,
 		}
-		if invoice.Terms.PaymentAddr != channeldb.BlankPayAddr {
+		if invoice.Terms.PaymentAddr != BlankPayAddr {
 			deleteRef.PayAddr = &invoice.Terms.PaymentAddr
 		}
 
-		err = i.cdb.DeleteInvoice(
-			[]channeldb.InvoiceDeleteRef{deleteRef},
-		)
+		err = i.idb.DeleteInvoice([]InvoiceDeleteRef{deleteRef})
 		// If by any chance deletion failed, then log it instead of
-		// returning the error, as the invoice itsels has already been
+		// returning the error, as the invoice itself has already been
 		// canceled.
 		if err != nil {
-			log.Warnf("Invoice%v could not be deleted: %v",
-				ref, err)
+			log.Warnf("Invoice %v could not be deleted: %v", ref,
+				err)
 		}
 	}
 
@@ -1408,7 +1405,7 @@ func (i *InvoiceRegistry) cancelInvoiceImpl(payHash lntypes.Hash,
 // notifyClients notifies all currently registered invoice notification clients
 // of a newly added/settled invoice.
 func (i *InvoiceRegistry) notifyClients(hash lntypes.Hash,
-	invoice *channeldb.Invoice, setID *[32]byte) {
+	invoice *Invoice, setID *[32]byte) {
 
 	event := &invoiceEvent{
 		invoice: invoice,
@@ -1451,12 +1448,12 @@ type InvoiceSubscription struct {
 	// NewInvoices is a channel that we'll use to send all newly created
 	// invoices with an invoice index greater than the specified
 	// StartingInvoiceIndex field.
-	NewInvoices chan *channeldb.Invoice
+	NewInvoices chan *Invoice
 
 	// SettledInvoices is a channel that we'll use to send all settled
 	// invoices with an invoices index greater than the specified
 	// StartingInvoiceIndex field.
-	SettledInvoices chan *channeldb.Invoice
+	SettledInvoices chan *Invoice
 
 	// addIndex is the highest add index the caller knows of. We'll use
 	// this information to send out an event backlog to the notifications
@@ -1477,11 +1474,19 @@ type InvoiceSubscription struct {
 type SingleInvoiceSubscription struct {
 	invoiceSubscriptionKit
 
-	invoiceRef channeldb.InvoiceRef
+	invoiceRef InvoiceRef
 
 	// Updates is a channel that we'll use to send all invoice events for
 	// the invoice that is subscribed to.
-	Updates chan *channeldb.Invoice
+	Updates chan *Invoice
+}
+
+// PayHash returns the optional payment hash of the target invoice.
+//
+// TODO(positiveblue): This method is only supposed to be used in tests. It will
+// be deleted as soon as invoiceregistery_test is in the same module.
+func (s *SingleInvoiceSubscription) PayHash() *lntypes.Hash {
+	return s.invoiceRef.PayHash()
 }
 
 // Cancel unregisters the InvoiceSubscription, freeing any previously allocated
@@ -1498,6 +1503,7 @@ func (i *invoiceSubscriptionKit) Cancel() {
 func (i *invoiceSubscriptionKit) notify(event *invoiceEvent) error {
 	select {
 	case i.ntfnQueue.ChanIn() <- event:
+
 	case <-i.cancelChan:
 		// This can only be triggered by delivery of non-backlog
 		// events.
@@ -1518,8 +1524,8 @@ func (i *InvoiceRegistry) SubscribeNotifications(
 	addIndex, settleIndex uint64) (*InvoiceSubscription, error) {
 
 	client := &InvoiceSubscription{
-		NewInvoices:     make(chan *channeldb.Invoice),
-		SettledInvoices: make(chan *channeldb.Invoice),
+		NewInvoices:     make(chan *Invoice),
+		SettledInvoices: make(chan *Invoice),
 		addIndex:        addIndex,
 		settleIndex:     settleIndex,
 		invoiceSubscriptionKit: invoiceSubscriptionKit{
@@ -1556,24 +1562,25 @@ func (i *InvoiceRegistry) SubscribeNotifications(
 			case ntfn := <-client.ntfnQueue.ChanOut():
 				invoiceEvent := ntfn.(*invoiceEvent)
 
-				var targetChan chan *channeldb.Invoice
+				var targetChan chan *Invoice
 				state := invoiceEvent.invoice.State
 				switch {
 				// AMP invoices never move to settled, but will
 				// be sent with a set ID if an HTLC set is
 				// being settled.
-				case state == channeldb.ContractOpen &&
+				case state == ContractOpen &&
 					invoiceEvent.setID != nil:
 					fallthrough
-				case state == channeldb.ContractSettled:
+
+				case state == ContractSettled:
 					targetChan = client.SettledInvoices
 
-				case state == channeldb.ContractOpen:
+				case state == ContractOpen:
 					targetChan = client.NewInvoices
 
 				default:
-					log.Errorf("unknown invoice "+
-						"state: %v", state)
+					log.Errorf("unknown invoice state: %v",
+						state)
 
 					continue
 				}
@@ -1619,14 +1626,14 @@ func (i *InvoiceRegistry) SubscribeSingleInvoice(
 	hash lntypes.Hash) (*SingleInvoiceSubscription, error) {
 
 	client := &SingleInvoiceSubscription{
-		Updates: make(chan *channeldb.Invoice),
+		Updates: make(chan *Invoice),
 		invoiceSubscriptionKit: invoiceSubscriptionKit{
 			quit:             i.quit,
 			ntfnQueue:        queue.NewConcurrentQueue(20),
 			cancelChan:       make(chan struct{}),
 			backlogDelivered: make(chan struct{}),
 		},
-		invoiceRef: channeldb.InvoiceRefByHash(hash),
+		invoiceRef: InvoiceRefByHash(hash),
 	}
 	client.ntfnQueue.Start()
 
@@ -1720,7 +1727,7 @@ func (i *InvoiceRegistry) notifyHodlSubscribers(htlcResolution HtlcResolution) {
 
 // hodlSubscribe adds a new invoice subscription.
 func (i *InvoiceRegistry) hodlSubscribe(subscriber chan<- interface{},
-	circuitKey models.CircuitKey) {
+	circuitKey CircuitKey) {
 
 	i.hodlSubscriptionsMux.Lock()
 	defer i.hodlSubscriptionsMux.Unlock()
@@ -1736,7 +1743,7 @@ func (i *InvoiceRegistry) hodlSubscribe(subscriber chan<- interface{},
 
 	reverseSubscriptions, ok := i.hodlReverseSubscriptions[subscriber]
 	if !ok {
-		reverseSubscriptions = make(map[models.CircuitKey]struct{})
+		reverseSubscriptions = make(map[CircuitKey]struct{})
 		i.hodlReverseSubscriptions[subscriber] = reverseSubscriptions
 	}
 	reverseSubscriptions[circuitKey] = struct{}{}
@@ -1757,7 +1764,7 @@ func (i *InvoiceRegistry) HodlUnsubscribeAll(subscriber chan<- interface{}) {
 
 // copySingleClients copies i.SingleInvoiceSubscription inside a lock. This is
 // useful when we need to iterate the map to send notifications.
-func (i *InvoiceRegistry) copySingleClients() map[uint32]*SingleInvoiceSubscription {
+func (i *InvoiceRegistry) copySingleClients() map[uint32]*SingleInvoiceSubscription { //nolint:lll
 	i.notificationClientMux.RLock()
 	defer i.notificationClientMux.RUnlock()
 

--- a/invoices/invoices.go
+++ b/invoices/invoices.go
@@ -1,0 +1,795 @@
+package invoices
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/lightningnetwork/lnd/feature"
+	"github.com/lightningnetwork/lnd/lntypes"
+	"github.com/lightningnetwork/lnd/lnwire"
+	"github.com/lightningnetwork/lnd/record"
+)
+
+const (
+	// MaxMemoSize is maximum size of the memo field within invoices stored
+	// in the database.
+	MaxMemoSize = 1024
+
+	// MaxPaymentRequestSize is the max size of a payment request for
+	// this invoice.
+	// TODO(halseth): determine the max length payment request when field
+	// lengths are final.
+	MaxPaymentRequestSize = 4096
+)
+
+var (
+	// unknownPreimage is an all-zeroes preimage that indicates that the
+	// preimage for this invoice is not yet known.
+	UnknownPreimage lntypes.Preimage
+
+	// BlankPayAddr is a sentinel payment address for legacy invoices.
+	// Invoices with this payment address are special-cased in the insertion
+	// logic to prevent being indexed in the payment address index,
+	// otherwise they would cause collisions after the first insertion.
+	BlankPayAddr [32]byte
+)
+
+// RefModifier is a modification on top of a base invoice ref. It allows the
+// caller to opt to skip out on HTLCs for a given payAddr, or only return the
+// set of specified HTLCs for a given setID.
+type RefModifier uint8
+
+const (
+	// DefaultModifier is the base modifier that doesn't change any
+	// behavior.
+	DefaultModifier RefModifier = iota
+
+	// HtlcSetOnlyModifier can only be used with a setID based invoice ref,
+	// and specifies that only the set of HTLCs related to that setID are
+	// to be returned.
+	HtlcSetOnlyModifier
+
+	// HtlcSetOnlyModifier can only be used with a payAddr based invoice
+	// ref, and specifies that the returned invoice shouldn't include any
+	// HTLCs at all.
+	HtlcSetBlankModifier
+)
+
+// InvoiceRef is a composite identifier for invoices. Invoices can be referenced
+// by various combinations of payment hash and payment addr, in certain contexts
+// only some of these are known. An InvoiceRef and its constructors thus
+// encapsulate the valid combinations of query parameters that can be supplied
+// to LookupInvoice and UpdateInvoice.
+type InvoiceRef struct {
+	// payHash is the payment hash of the target invoice. All invoices are
+	// currently indexed by payment hash. This value will be used as a
+	// fallback when no payment address is known.
+	payHash *lntypes.Hash
+
+	// payAddr is the payment addr of the target invoice. Newer invoices
+	// (0.11 and up) are indexed by payment address in addition to payment
+	// hash, but pre 0.8 invoices do not have one at all. When this value is
+	// known it will be used as the primary identifier, falling back to
+	// payHash if no value is known.
+	payAddr *[32]byte
+
+	// setID is the optional set id for an AMP payment. This can be used to
+	// lookup or update the invoice knowing only this value. Queries by set
+	// id are only used to facilitate user-facing requests, e.g. lookup,
+	// settle or cancel an AMP invoice. The regular update flow from the
+	// invoice registry will always query for the invoice by
+	// payHash+payAddr.
+	setID *[32]byte
+
+	// refModifier allows an invoice ref to include or exclude specific
+	// HTLC sets based on the payAddr or setId.
+	refModifier RefModifier
+}
+
+// InvoiceRefByHash creates an InvoiceRef that queries for an invoice only by
+// its payment hash.
+func InvoiceRefByHash(payHash lntypes.Hash) InvoiceRef {
+	return InvoiceRef{
+		payHash: &payHash,
+	}
+}
+
+// InvoiceRefByHashAndAddr creates an InvoiceRef that first queries for an
+// invoice by the provided payment address, falling back to the payment hash if
+// the payment address is unknown.
+func InvoiceRefByHashAndAddr(payHash lntypes.Hash,
+	payAddr [32]byte) InvoiceRef {
+
+	return InvoiceRef{
+		payHash: &payHash,
+		payAddr: &payAddr,
+	}
+}
+
+// InvoiceRefByAddr creates an InvoiceRef that queries the payment addr index
+// for an invoice with the provided payment address.
+func InvoiceRefByAddr(addr [32]byte) InvoiceRef {
+	return InvoiceRef{
+		payAddr: &addr,
+	}
+}
+
+// InvoiceRefByAddrBlankHtlc creates an InvoiceRef that queries the payment addr
+// index for an invoice with the provided payment address, but excludes any of
+// the core HTLC information.
+func InvoiceRefByAddrBlankHtlc(addr [32]byte) InvoiceRef {
+	return InvoiceRef{
+		payAddr:     &addr,
+		refModifier: HtlcSetBlankModifier,
+	}
+}
+
+// InvoiceRefBySetID creates an InvoiceRef that queries the set id index for an
+// invoice with the provided setID. If the invoice is not found, the query will
+// not fallback to payHash or payAddr.
+func InvoiceRefBySetID(setID [32]byte) InvoiceRef {
+	return InvoiceRef{
+		setID: &setID,
+	}
+}
+
+// InvoiceRefBySetIDFiltered is similar to the InvoiceRefBySetID identifier,
+// but it specifies that the returned set of HTLCs should be filtered to only
+// include HTLCs that are part of that set.
+func InvoiceRefBySetIDFiltered(setID [32]byte) InvoiceRef {
+	return InvoiceRef{
+		setID:       &setID,
+		refModifier: HtlcSetOnlyModifier,
+	}
+}
+
+// PayHash returns the optional payment hash of the target invoice.
+//
+// NOTE: This value may be nil.
+func (r InvoiceRef) PayHash() *lntypes.Hash {
+	if r.payHash != nil {
+		hash := *r.payHash
+		return &hash
+	}
+
+	return nil
+}
+
+// PayAddr returns the optional payment address of the target invoice.
+//
+// NOTE: This value may be nil.
+func (r InvoiceRef) PayAddr() *[32]byte {
+	if r.payAddr != nil {
+		addr := *r.payAddr
+		return &addr
+	}
+
+	return nil
+}
+
+// SetID returns the optional set id of the target invoice.
+//
+// NOTE: This value may be nil.
+func (r InvoiceRef) SetID() *[32]byte {
+	if r.setID != nil {
+		id := *r.setID
+		return &id
+	}
+
+	return nil
+}
+
+// Modifier defines the set of available modifications to the base invoice ref
+// look up that are available.
+func (r InvoiceRef) Modifier() RefModifier {
+	return r.refModifier
+}
+
+// String returns a human-readable representation of an InvoiceRef.
+func (r InvoiceRef) String() string {
+	var ids []string
+	if r.payHash != nil {
+		ids = append(ids, fmt.Sprintf("pay_hash=%v", *r.payHash))
+	}
+	if r.payAddr != nil {
+		ids = append(ids, fmt.Sprintf("pay_addr=%x", *r.payAddr))
+	}
+	if r.setID != nil {
+		ids = append(ids, fmt.Sprintf("set_id=%x", *r.setID))
+	}
+
+	return fmt.Sprintf("(%s)", strings.Join(ids, ", "))
+}
+
+// ContractState describes the state the invoice is in.
+type ContractState uint8
+
+const (
+	// ContractOpen means the invoice has only been created.
+	ContractOpen ContractState = 0
+
+	// ContractSettled means the htlc is settled and the invoice has been
+	// paid.
+	ContractSettled ContractState = 1
+
+	// ContractCanceled means the invoice has been canceled.
+	ContractCanceled ContractState = 2
+
+	// ContractAccepted means the HTLC has been accepted but not settled
+	// yet.
+	ContractAccepted ContractState = 3
+)
+
+// String returns a human readable identifier for the ContractState type.
+func (c ContractState) String() string {
+	switch c {
+	case ContractOpen:
+		return "Open"
+
+	case ContractSettled:
+		return "Settled"
+
+	case ContractCanceled:
+		return "Canceled"
+
+	case ContractAccepted:
+		return "Accepted"
+	}
+
+	return "Unknown"
+}
+
+// IsFinal returns a boolean indicating whether an invoice state is final.
+func (c ContractState) IsFinal() bool {
+	return c == ContractSettled || c == ContractCanceled
+}
+
+// ContractTerm is a companion struct to the Invoice struct. This struct houses
+// the necessary conditions required before the invoice can be considered fully
+// settled by the payee.
+type ContractTerm struct {
+	// FinalCltvDelta is the minimum required number of blocks before htlc
+	// expiry when the invoice is accepted.
+	FinalCltvDelta int32
+
+	// Expiry defines how long after creation this invoice should expire.
+	Expiry time.Duration
+
+	// PaymentPreimage is the preimage which is to be revealed in the
+	// occasion that an HTLC paying to the hash of this preimage is
+	// extended. Set to nil if the preimage isn't known yet.
+	PaymentPreimage *lntypes.Preimage
+
+	// Value is the expected amount of milli-satoshis to be paid to an HTLC
+	// which can be satisfied by the above preimage.
+	Value lnwire.MilliSatoshi
+
+	// PaymentAddr is a randomly generated value include in the MPP record
+	// by the sender to prevent probing of the receiver.
+	PaymentAddr [32]byte
+
+	// Features is the feature vectors advertised on the payment request.
+	Features *lnwire.FeatureVector
+}
+
+// String returns a human-readable description of the prominent contract terms.
+func (c ContractTerm) String() string {
+	return fmt.Sprintf("amt=%v, expiry=%v, final_cltv_delta=%v", c.Value,
+		c.Expiry, c.FinalCltvDelta)
+}
+
+// SetID is the extra unique tuple item for AMP invoices. In addition to
+// setting a payment address, each repeated payment to an AMP invoice will also
+// contain a set ID as well.
+type SetID [32]byte
+
+// InvoiceStateAMP is a struct that associates the current state of an AMP
+// invoice identified by its set ID along with the set of invoices identified
+// by the circuit key. This allows callers to easily look up the latest state
+// of an AMP "sub-invoice" and also look up the invoice HLTCs themselves in the
+// greater HTLC map index.
+type InvoiceStateAMP struct {
+	// State is the state of this sub-AMP invoice.
+	State HtlcState
+
+	// SettleIndex indicates the location in the settle index that
+	// references this instance of InvoiceStateAMP, but only if
+	// this value is set (non-zero), and State is HtlcStateSettled.
+	SettleIndex uint64
+
+	// SettleDate is the date that the setID was settled.
+	SettleDate time.Time
+
+	// InvoiceKeys is the set of circuit keys that can be used to locate
+	// the invoices for a given set ID.
+	InvoiceKeys map[CircuitKey]struct{}
+
+	// AmtPaid is the total amount that was paid in the AMP sub-invoice.
+	// Fetching the full HTLC/invoice state allows one to extract the
+	// custom records as well as the break down of the payment splits used
+	// when paying.
+	AmtPaid lnwire.MilliSatoshi
+}
+
+// copy makes a deep copy of the underlying InvoiceStateAMP.
+func (i *InvoiceStateAMP) copy() (InvoiceStateAMP, error) {
+	result := *i
+
+	// Make a copy of the InvoiceKeys map.
+	result.InvoiceKeys = make(map[CircuitKey]struct{})
+	for k := range i.InvoiceKeys {
+		result.InvoiceKeys[k] = struct{}{}
+	}
+
+	// As a safety measure, copy SettleDate. time.Time is concurrency safe
+	// except when using any of the (un)marshalling methods.
+	settleDateBytes, err := i.SettleDate.MarshalBinary()
+	if err != nil {
+		return InvoiceStateAMP{}, err
+	}
+
+	err = result.SettleDate.UnmarshalBinary(settleDateBytes)
+	if err != nil {
+		return InvoiceStateAMP{}, err
+	}
+
+	return result, nil
+}
+
+// AMPInvoiceState represents a type that stores metadata related to the set of
+// settled AMP "sub-invoices".
+type AMPInvoiceState map[SetID]InvoiceStateAMP
+
+// Invoice is a payment invoice generated by a payee in order to request
+// payment for some good or service. The inclusion of invoices within Lightning
+// creates a payment work flow for merchants very similar to that of the
+// existing financial system within PayPal, etc.  Invoices are added to the
+// database when a payment is requested, then can be settled manually once the
+// payment is received at the upper layer. For record keeping purposes,
+// invoices are never deleted from the database, instead a bit is toggled
+// denoting the invoice has been fully settled. Within the database, all
+// invoices must have a unique payment hash which is generated by taking the
+// sha256 of the payment preimage.
+type Invoice struct {
+	// Memo is an optional memo to be stored along side an invoice.  The
+	// memo may contain further details pertaining to the invoice itself,
+	// or any other message which fits within the size constraints.
+	Memo []byte
+
+	// PaymentRequest is the encoded payment request for this invoice. For
+	// spontaneous (keysend) payments, this field will be empty.
+	PaymentRequest []byte
+
+	// CreationDate is the exact time the invoice was created.
+	CreationDate time.Time
+
+	// SettleDate is the exact time the invoice was settled.
+	SettleDate time.Time
+
+	// Terms are the contractual payment terms of the invoice. Once all the
+	// terms have been satisfied by the payer, then the invoice can be
+	// considered fully fulfilled.
+	//
+	// TODO(roasbeef): later allow for multiple terms to fulfill the final
+	// invoice: payment fragmentation, etc.
+	Terms ContractTerm
+
+	// AddIndex is an auto-incrementing integer that acts as a
+	// monotonically increasing sequence number for all invoices created.
+	// Clients can then use this field as a "checkpoint" of sorts when
+	// implementing a streaming RPC to notify consumers of instances where
+	// an invoice has been added before they re-connected.
+	//
+	// NOTE: This index starts at 1.
+	AddIndex uint64
+
+	// SettleIndex is an auto-incrementing integer that acts as a
+	// monotonically increasing sequence number for all settled invoices.
+	// Clients can then use this field as a "checkpoint" of sorts when
+	// implementing a streaming RPC to notify consumers of instances where
+	// an invoice has been settled before they re-connected.
+	//
+	// NOTE: This index starts at 1.
+	SettleIndex uint64
+
+	// State describes the state the invoice is in. This is the global
+	// state of the invoice which may remain open even when a series of
+	// sub-invoices for this invoice has been settled.
+	State ContractState
+
+	// AmtPaid is the final amount that we ultimately accepted for pay for
+	// this invoice. We specify this value independently as it's possible
+	// that the invoice originally didn't specify an amount, or the sender
+	// overpaid.
+	AmtPaid lnwire.MilliSatoshi
+
+	// Htlcs records all htlcs that paid to this invoice. Some of these
+	// htlcs may have been marked as canceled.
+	Htlcs map[CircuitKey]*InvoiceHTLC
+
+	// AMPState describes the state of any related sub-invoices AMP to this
+	// greater invoice. A sub-invoice is defined by a set of HTLCs with the
+	// same set ID that attempt to make one time or recurring payments to
+	// this greater invoice. It's possible for a sub-invoice to be canceled
+	// or settled, but the greater invoice still open.
+	AMPState AMPInvoiceState
+
+	// HodlInvoice indicates whether the invoice should be held in the
+	// Accepted state or be settled right away.
+	HodlInvoice bool
+}
+
+// HTLCSet returns the set of HTLCs belonging to setID and in the provided
+// state. Passing a nil setID will return all HTLCs in the provided state in the
+// case of legacy or MPP, and no HTLCs in the case of AMP.  Otherwise, the
+// returned set will be filtered by the populated setID which is used to
+// retrieve AMP HTLC sets.
+func (i *Invoice) HTLCSet(setID *[32]byte,
+	state HtlcState) map[CircuitKey]*InvoiceHTLC {
+
+	htlcSet := make(map[CircuitKey]*InvoiceHTLC)
+	for key, htlc := range i.Htlcs {
+		// Only add HTLCs that are in the requested HtlcState.
+		if htlc.State != state {
+			continue
+		}
+
+		if !htlc.IsInHTLCSet(setID) {
+			continue
+		}
+
+		htlcSet[key] = htlc
+	}
+
+	return htlcSet
+}
+
+// HTLCSetCompliment returns the set of all HTLCs not belonging to setID that
+// are in the target state. Passing a nil setID will return no invoices, since
+// all MPP HTLCs are part of the same HTLC set.
+func (i *Invoice) HTLCSetCompliment(setID *[32]byte,
+	state HtlcState) map[CircuitKey]*InvoiceHTLC {
+
+	htlcSet := make(map[CircuitKey]*InvoiceHTLC)
+	for key, htlc := range i.Htlcs {
+		// Only add HTLCs that are in the requested HtlcState.
+		if htlc.State != state {
+			continue
+		}
+
+		// We are constructing the compliment, so filter anything that
+		// matches this set id.
+		if htlc.IsInHTLCSet(setID) {
+			continue
+		}
+
+		htlcSet[key] = htlc
+	}
+
+	return htlcSet
+}
+
+// HtlcState defines the states an htlc paying to an invoice can be in.
+type HtlcState uint8
+
+const (
+	// HtlcStateAccepted indicates the htlc is locked-in, but not resolved.
+	HtlcStateAccepted HtlcState = iota
+
+	// HtlcStateCanceled indicates the htlc is canceled back to the
+	// sender.
+	HtlcStateCanceled
+
+	// HtlcStateSettled indicates the htlc is settled.
+	HtlcStateSettled
+)
+
+// InvoiceHTLC contains details about an htlc paying to this invoice.
+type InvoiceHTLC struct {
+	// Amt is the amount that is carried by this htlc.
+	Amt lnwire.MilliSatoshi
+
+	// MppTotalAmt is a field for mpp that indicates the expected total
+	// amount.
+	MppTotalAmt lnwire.MilliSatoshi
+
+	// AcceptHeight is the block height at which the invoice registry
+	// decided to accept this htlc as a payment to the invoice. At this
+	// height, the invoice cltv delay must have been met.
+	AcceptHeight uint32
+
+	// AcceptTime is the wall clock time at which the invoice registry
+	// decided to accept the htlc.
+	AcceptTime time.Time
+
+	// ResolveTime is the wall clock time at which the invoice registry
+	// decided to settle the htlc.
+	ResolveTime time.Time
+
+	// Expiry is the expiry height of this htlc.
+	Expiry uint32
+
+	// State indicates the state the invoice htlc is currently in. A
+	// canceled htlc isn't just removed from the invoice htlcs map, because
+	// we need AcceptHeight to properly cancel the htlc back.
+	State HtlcState
+
+	// CustomRecords contains the custom key/value pairs that accompanied
+	// the htlc.
+	CustomRecords record.CustomSet
+
+	// AMP encapsulates additional data relevant to AMP HTLCs. This includes
+	// the AMP onion record, in addition to the HTLC's payment hash and
+	// preimage since these are unique to each AMP HTLC, and not the invoice
+	// as a whole.
+	//
+	// NOTE: This value will only be set for AMP HTLCs.
+	AMP *InvoiceHtlcAMPData
+}
+
+// Copy makes a deep copy of the target InvoiceHTLC.
+func (h *InvoiceHTLC) Copy() *InvoiceHTLC {
+	result := *h
+
+	// Make a copy of the CustomSet map.
+	result.CustomRecords = make(record.CustomSet)
+	for k, v := range h.CustomRecords {
+		result.CustomRecords[k] = v
+	}
+
+	result.AMP = h.AMP.Copy()
+
+	return &result
+}
+
+// IsInHTLCSet returns true if this HTLC is part an HTLC set. If nil is passed,
+// this method returns true if this is an MPP HTLC. Otherwise, it only returns
+// true if the AMP HTLC's set id matches the populated setID.
+func (h *InvoiceHTLC) IsInHTLCSet(setID *[32]byte) bool {
+	wantAMPSet := setID != nil
+	isAMPHtlc := h.AMP != nil
+
+	// Non-AMP HTLCs cannot be part of AMP HTLC sets, and vice versa.
+	if wantAMPSet != isAMPHtlc {
+		return false
+	}
+
+	// Skip AMP HTLCs that have differing set ids.
+	if isAMPHtlc && *setID != h.AMP.Record.SetID() {
+		return false
+	}
+
+	return true
+}
+
+// InvoiceHtlcAMPData is a struct hodling the additional metadata stored for
+// each received AMP HTLC. This includes the AMP onion record, in addition to
+// the HTLC's payment hash and preimage.
+type InvoiceHtlcAMPData struct {
+	// AMP is a copy of the AMP record presented in the onion payload
+	// containing the information necessary to correlate and settle a
+	// spontaneous HTLC set. Newly accepted legacy keysend payments will
+	// also have this field set as we automatically promote them into an AMP
+	// payment for internal processing.
+	Record record.AMP
+
+	// Hash is an HTLC-level payment hash that is stored only for AMP
+	// payments. This is done because an AMP HTLC will carry a different
+	// payment hash from the invoice it might be satisfying, so we track the
+	// payment hashes individually to able to compute whether or not the
+	// reconstructed preimage correctly matches the HTLC's hash.
+	Hash lntypes.Hash
+
+	// Preimage is an HTLC-level preimage that satisfies the AMP HTLC's
+	// Hash. The preimage will be derived either from secret share
+	// reconstruction of the shares in the AMP payload.
+	//
+	// NOTE: Preimage will only be present once the HTLC is in
+	// HtlcStateSettled.
+	Preimage *lntypes.Preimage
+}
+
+// Copy returns a deep copy of the InvoiceHtlcAMPData.
+func (d *InvoiceHtlcAMPData) Copy() *InvoiceHtlcAMPData {
+	if d == nil {
+		return nil
+	}
+
+	var preimage *lntypes.Preimage
+	if d.Preimage != nil {
+		pimg := *d.Preimage
+		preimage = &pimg
+	}
+
+	return &InvoiceHtlcAMPData{
+		Record:   d.Record,
+		Hash:     d.Hash,
+		Preimage: preimage,
+	}
+}
+
+// HtlcAcceptDesc describes the details of a newly accepted htlc.
+type HtlcAcceptDesc struct {
+	// AcceptHeight is the block height at which this htlc was accepted.
+	AcceptHeight int32
+
+	// Amt is the amount that is carried by this htlc.
+	Amt lnwire.MilliSatoshi
+
+	// MppTotalAmt is a field for mpp that indicates the expected total
+	// amount.
+	MppTotalAmt lnwire.MilliSatoshi
+
+	// Expiry is the expiry height of this htlc.
+	Expiry uint32
+
+	// CustomRecords contains the custom key/value pairs that accompanied
+	// the htlc.
+	CustomRecords record.CustomSet
+
+	// AMP encapsulates additional data relevant to AMP HTLCs. This includes
+	// the AMP onion record, in addition to the HTLC's payment hash and
+	// preimage since these are unique to each AMP HTLC, and not the invoice
+	// as a whole.
+	//
+	// NOTE: This value will only be set for AMP HTLCs.
+	AMP *InvoiceHtlcAMPData
+}
+
+// InvoiceUpdateDesc describes the changes that should be applied to the
+// invoice.
+type InvoiceUpdateDesc struct {
+	// State is the new state that this invoice should progress to. If nil,
+	// the state is left unchanged.
+	State *InvoiceStateUpdateDesc
+
+	// CancelHtlcs describes the htlcs that need to be canceled.
+	CancelHtlcs map[CircuitKey]struct{}
+
+	// AddHtlcs describes the newly accepted htlcs that need to be added to
+	// the invoice.
+	AddHtlcs map[CircuitKey]*HtlcAcceptDesc
+
+	// SetID is an optional set ID for AMP invoices that allows operations
+	// to be more efficient by ensuring we don't need to read out the
+	// entire HTLC set each timee an HTLC is to be cancelled.
+	SetID *SetID
+}
+
+// InvoiceStateUpdateDesc describes an invoice-level state transition.
+type InvoiceStateUpdateDesc struct {
+	// NewState is the new state that this invoice should progress to.
+	NewState ContractState
+
+	// Preimage must be set to the preimage when NewState is settled.
+	Preimage *lntypes.Preimage
+
+	// HTLCPreimages set the HTLC-level preimages stored for AMP HTLCs.
+	// These are only learned when settling the invoice as a whole. Must be
+	// set when settling an invoice with non-nil SetID.
+	HTLCPreimages map[CircuitKey]lntypes.Preimage
+
+	// SetID identifies a specific set of HTLCs destined for the same
+	// invoice as part of a larger AMP payment. This value will be nil for
+	// legacy or MPP payments.
+	SetID *[32]byte
+}
+
+// InvoiceUpdateCallback is a callback used in the db transaction to update the
+// invoice.
+type InvoiceUpdateCallback = func(invoice *Invoice) (*InvoiceUpdateDesc, error)
+
+func ValidateInvoice(i *Invoice, paymentHash lntypes.Hash) error {
+	// Avoid conflicts with all-zeroes magic value in the database.
+	if paymentHash == UnknownPreimage.Hash() {
+		return fmt.Errorf("cannot use hash of all-zeroes preimage")
+	}
+
+	if len(i.Memo) > MaxMemoSize {
+		return fmt.Errorf("max length a memo is %v, and invoice "+
+			"of length %v was provided", MaxMemoSize, len(i.Memo))
+	}
+	if len(i.PaymentRequest) > MaxPaymentRequestSize {
+		return fmt.Errorf("max length of payment request is %v, "+
+			"length provided was %v", MaxPaymentRequestSize,
+			len(i.PaymentRequest))
+	}
+	if i.Terms.Features == nil {
+		return errors.New("invoice must have a feature vector")
+	}
+
+	err := feature.ValidateDeps(i.Terms.Features)
+	if err != nil {
+		return err
+	}
+
+	// AMP invoices and hodl invoices are allowed to have no preimage
+	// specified.
+	isAMP := i.Terms.Features.HasFeature(
+		lnwire.AMPOptional,
+	)
+	if i.Terms.PaymentPreimage == nil && !(i.HodlInvoice || isAMP) {
+		return errors.New("non-hodl invoices must have a preimage")
+	}
+
+	if len(i.Htlcs) > 0 {
+		return ErrInvoiceHasHtlcs
+	}
+
+	return nil
+}
+
+// IsPending returns true if the invoice is in ContractOpen state.
+func (i *Invoice) IsPending() bool {
+	return i.State == ContractOpen || i.State == ContractAccepted
+}
+
+// copySlice allocates a new slice and copies the source into it.
+func copySlice(src []byte) []byte {
+	dest := make([]byte, len(src))
+	copy(dest, src)
+	return dest
+}
+
+// CopyInvoice makes a deep copy of the supplied invoice.
+func CopyInvoice(src *Invoice) (*Invoice, error) {
+	dest := Invoice{
+		Memo:           copySlice(src.Memo),
+		PaymentRequest: copySlice(src.PaymentRequest),
+		CreationDate:   src.CreationDate,
+		SettleDate:     src.SettleDate,
+		Terms:          src.Terms,
+		AddIndex:       src.AddIndex,
+		SettleIndex:    src.SettleIndex,
+		State:          src.State,
+		AmtPaid:        src.AmtPaid,
+		Htlcs: make(
+			map[CircuitKey]*InvoiceHTLC, len(src.Htlcs),
+		),
+		AMPState:    make(map[SetID]InvoiceStateAMP),
+		HodlInvoice: src.HodlInvoice,
+	}
+
+	dest.Terms.Features = src.Terms.Features.Clone()
+
+	if src.Terms.PaymentPreimage != nil {
+		preimage := *src.Terms.PaymentPreimage
+		dest.Terms.PaymentPreimage = &preimage
+	}
+
+	for k, v := range src.Htlcs {
+		dest.Htlcs[k] = v.Copy()
+	}
+
+	// Lastly, copy the amp invoice state.
+	for k, v := range src.AMPState {
+		ampInvState, err := v.copy()
+		if err != nil {
+			return nil, err
+		}
+
+		dest.AMPState[k] = ampInvState
+	}
+
+	return &dest, nil
+}
+
+// InvoiceDeleteRef holds a reference to an invoice to be deleted.
+type InvoiceDeleteRef struct {
+	// PayHash is the payment hash of the target invoice. All invoices are
+	// currently indexed by payment hash.
+	PayHash lntypes.Hash
+
+	// PayAddr is the payment addr of the target invoice. Newer invoices
+	// (0.11 and up) are indexed by payment address in addition to payment
+	// hash, but pre 0.8 invoices do not have one at all.
+	PayAddr *[32]byte
+
+	// AddIndex is the add index of the invoice.
+	AddIndex uint64
+
+	// SettleIndex is the settle index of the invoice.
+	SettleIndex uint64
+}

--- a/invoices/mock.go
+++ b/invoices/mock.go
@@ -1,0 +1,78 @@
+package invoices
+
+import (
+	"github.com/lightningnetwork/lnd/lntypes"
+	"github.com/stretchr/testify/mock"
+)
+
+type MockInvoiceDB struct {
+	mock.Mock
+}
+
+func NewInvoicesDBMock() *MockInvoiceDB {
+	return &MockInvoiceDB{}
+}
+
+func (m *MockInvoiceDB) AddInvoice(invoice *Invoice,
+	paymentHash lntypes.Hash) (uint64, error) {
+
+	args := m.Called(invoice, paymentHash)
+
+	addIndex, _ := args.Get(0).(uint64)
+
+	// NOTE: this is a side effect of the AddInvoice method.
+	invoice.AddIndex = addIndex
+
+	return addIndex, args.Error(1)
+}
+
+func (m *MockInvoiceDB) InvoicesAddedSince(idx uint64) ([]Invoice, error) {
+	args := m.Called(idx)
+	invoices, _ := args.Get(0).([]Invoice)
+
+	return invoices, args.Error(1)
+}
+
+func (m *MockInvoiceDB) InvoicesSettledSince(idx uint64) ([]Invoice, error) {
+	args := m.Called(idx)
+	invoices, _ := args.Get(0).([]Invoice)
+
+	return invoices, args.Error(1)
+}
+
+func (m *MockInvoiceDB) LookupInvoice(ref InvoiceRef) (Invoice, error) {
+	args := m.Called(ref)
+	invoice, _ := args.Get(0).(Invoice)
+
+	return invoice, args.Error(1)
+}
+
+func (m *MockInvoiceDB) ScanInvoices(scanFunc InvScanFunc,
+	reset func()) error {
+
+	args := m.Called(scanFunc, reset)
+
+	return args.Error(0)
+}
+
+func (m *MockInvoiceDB) QueryInvoices(q InvoiceQuery) (InvoiceSlice, error) {
+	args := m.Called(q)
+	invoiceSlice, _ := args.Get(0).(InvoiceSlice)
+
+	return invoiceSlice, args.Error(1)
+}
+
+func (m *MockInvoiceDB) UpdateInvoice(ref InvoiceRef, setIDHint *SetID,
+	callback InvoiceUpdateCallback) (*Invoice, error) {
+
+	args := m.Called(ref, setIDHint, callback)
+	invoice, _ := args.Get(0).(*Invoice)
+
+	return invoice, args.Error(1)
+}
+
+func (m *MockInvoiceDB) DeleteInvoice(invoices []InvoiceDeleteRef) error {
+	args := m.Called(invoices)
+
+	return args.Error(0)
+}

--- a/invoices/resolution.go
+++ b/invoices/resolution.go
@@ -3,7 +3,7 @@ package invoices
 import (
 	"time"
 
-	"github.com/lightningnetwork/lnd/channeldb"
+	"github.com/lightningnetwork/lnd/channeldb/models"
 	"github.com/lightningnetwork/lnd/lntypes"
 )
 
@@ -11,14 +11,14 @@ import (
 type HtlcResolution interface {
 	// CircuitKey returns the circuit key for the htlc that we have a
 	// resolution for.
-	CircuitKey() channeldb.CircuitKey
+	CircuitKey() models.CircuitKey
 }
 
 // HtlcFailResolution is an implementation of the HtlcResolution interface
 // which is returned when a htlc is failed.
 type HtlcFailResolution struct {
 	// circuitKey is the key of the htlc for which we have a resolution.
-	circuitKey channeldb.CircuitKey
+	circuitKey models.CircuitKey
 
 	// AcceptHeight is the original height at which the htlc was accepted.
 	AcceptHeight int32
@@ -28,8 +28,8 @@ type HtlcFailResolution struct {
 }
 
 // NewFailResolution returns a htlc failure resolution.
-func NewFailResolution(key channeldb.CircuitKey,
-	acceptHeight int32, outcome FailResolutionResult) *HtlcFailResolution {
+func NewFailResolution(key models.CircuitKey, acceptHeight int32,
+	outcome FailResolutionResult) *HtlcFailResolution {
 
 	return &HtlcFailResolution{
 		circuitKey:   key,
@@ -42,7 +42,7 @@ func NewFailResolution(key channeldb.CircuitKey,
 // resolution for.
 //
 // Note: it is part of the HtlcResolution interface.
-func (f *HtlcFailResolution) CircuitKey() channeldb.CircuitKey {
+func (f *HtlcFailResolution) CircuitKey() models.CircuitKey {
 	return f.circuitKey
 }
 
@@ -53,7 +53,7 @@ type HtlcSettleResolution struct {
 	Preimage lntypes.Preimage
 
 	// circuitKey is the key of the htlc for which we have a resolution.
-	circuitKey channeldb.CircuitKey
+	circuitKey models.CircuitKey
 
 	// acceptHeight is the original height at which the htlc was accepted.
 	AcceptHeight int32
@@ -65,7 +65,7 @@ type HtlcSettleResolution struct {
 // NewSettleResolution returns a htlc resolution which is associated with a
 // settle.
 func NewSettleResolution(preimage lntypes.Preimage,
-	key channeldb.CircuitKey, acceptHeight int32,
+	key models.CircuitKey, acceptHeight int32,
 	outcome SettleResolutionResult) *HtlcSettleResolution {
 
 	return &HtlcSettleResolution{
@@ -80,7 +80,7 @@ func NewSettleResolution(preimage lntypes.Preimage,
 // resolution for.
 //
 // Note: it is part of the HtlcResolution interface.
-func (s *HtlcSettleResolution) CircuitKey() channeldb.CircuitKey {
+func (s *HtlcSettleResolution) CircuitKey() models.CircuitKey {
 	return s.circuitKey
 }
 
@@ -92,7 +92,7 @@ func (s *HtlcSettleResolution) CircuitKey() channeldb.CircuitKey {
 // acceptResolution, a nil resolution should be surfaced.
 type htlcAcceptResolution struct {
 	// circuitKey is the key of the htlc for which we have a resolution.
-	circuitKey channeldb.CircuitKey
+	circuitKey models.CircuitKey
 
 	// autoRelease signals that the htlc should be automatically released
 	// after a timeout.
@@ -107,7 +107,7 @@ type htlcAcceptResolution struct {
 
 // newAcceptResolution returns a htlc resolution which is associated with a
 // htlc accept.
-func newAcceptResolution(key channeldb.CircuitKey,
+func newAcceptResolution(key models.CircuitKey,
 	outcome acceptResolutionResult) *htlcAcceptResolution {
 
 	return &htlcAcceptResolution{
@@ -120,6 +120,6 @@ func newAcceptResolution(key channeldb.CircuitKey,
 // resolution for.
 //
 // Note: it is part of the HtlcResolution interface.
-func (a *htlcAcceptResolution) CircuitKey() channeldb.CircuitKey {
+func (a *htlcAcceptResolution) CircuitKey() models.CircuitKey {
 	return a.circuitKey
 }

--- a/invoices/resolution.go
+++ b/invoices/resolution.go
@@ -3,7 +3,6 @@ package invoices
 import (
 	"time"
 
-	"github.com/lightningnetwork/lnd/channeldb/models"
 	"github.com/lightningnetwork/lnd/lntypes"
 )
 
@@ -11,14 +10,14 @@ import (
 type HtlcResolution interface {
 	// CircuitKey returns the circuit key for the htlc that we have a
 	// resolution for.
-	CircuitKey() models.CircuitKey
+	CircuitKey() CircuitKey
 }
 
 // HtlcFailResolution is an implementation of the HtlcResolution interface
 // which is returned when a htlc is failed.
 type HtlcFailResolution struct {
 	// circuitKey is the key of the htlc for which we have a resolution.
-	circuitKey models.CircuitKey
+	circuitKey CircuitKey
 
 	// AcceptHeight is the original height at which the htlc was accepted.
 	AcceptHeight int32
@@ -28,7 +27,7 @@ type HtlcFailResolution struct {
 }
 
 // NewFailResolution returns a htlc failure resolution.
-func NewFailResolution(key models.CircuitKey, acceptHeight int32,
+func NewFailResolution(key CircuitKey, acceptHeight int32,
 	outcome FailResolutionResult) *HtlcFailResolution {
 
 	return &HtlcFailResolution{
@@ -42,7 +41,7 @@ func NewFailResolution(key models.CircuitKey, acceptHeight int32,
 // resolution for.
 //
 // Note: it is part of the HtlcResolution interface.
-func (f *HtlcFailResolution) CircuitKey() models.CircuitKey {
+func (f *HtlcFailResolution) CircuitKey() CircuitKey {
 	return f.circuitKey
 }
 
@@ -53,7 +52,7 @@ type HtlcSettleResolution struct {
 	Preimage lntypes.Preimage
 
 	// circuitKey is the key of the htlc for which we have a resolution.
-	circuitKey models.CircuitKey
+	circuitKey CircuitKey
 
 	// acceptHeight is the original height at which the htlc was accepted.
 	AcceptHeight int32
@@ -64,8 +63,8 @@ type HtlcSettleResolution struct {
 
 // NewSettleResolution returns a htlc resolution which is associated with a
 // settle.
-func NewSettleResolution(preimage lntypes.Preimage,
-	key models.CircuitKey, acceptHeight int32,
+func NewSettleResolution(preimage lntypes.Preimage, key CircuitKey,
+	acceptHeight int32,
 	outcome SettleResolutionResult) *HtlcSettleResolution {
 
 	return &HtlcSettleResolution{
@@ -80,7 +79,7 @@ func NewSettleResolution(preimage lntypes.Preimage,
 // resolution for.
 //
 // Note: it is part of the HtlcResolution interface.
-func (s *HtlcSettleResolution) CircuitKey() models.CircuitKey {
+func (s *HtlcSettleResolution) CircuitKey() CircuitKey {
 	return s.circuitKey
 }
 
@@ -92,7 +91,7 @@ func (s *HtlcSettleResolution) CircuitKey() models.CircuitKey {
 // acceptResolution, a nil resolution should be surfaced.
 type htlcAcceptResolution struct {
 	// circuitKey is the key of the htlc for which we have a resolution.
-	circuitKey models.CircuitKey
+	circuitKey CircuitKey
 
 	// autoRelease signals that the htlc should be automatically released
 	// after a timeout.
@@ -107,7 +106,7 @@ type htlcAcceptResolution struct {
 
 // newAcceptResolution returns a htlc resolution which is associated with a
 // htlc accept.
-func newAcceptResolution(key models.CircuitKey,
+func newAcceptResolution(key CircuitKey,
 	outcome acceptResolutionResult) *htlcAcceptResolution {
 
 	return &htlcAcceptResolution{
@@ -120,6 +119,6 @@ func newAcceptResolution(key models.CircuitKey,
 // resolution for.
 //
 // Note: it is part of the HtlcResolution interface.
-func (a *htlcAcceptResolution) CircuitKey() models.CircuitKey {
+func (a *htlcAcceptResolution) CircuitKey() CircuitKey {
 	return a.circuitKey
 }

--- a/invoices/test_utils.go
+++ b/invoices/test_utils.go
@@ -1,0 +1,287 @@
+package invoices
+
+import (
+	"crypto/rand"
+	"encoding/binary"
+	"encoding/hex"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/btcsuite/btcd/btcec/v2/ecdsa"
+	"github.com/btcsuite/btcd/chaincfg"
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"github.com/lightningnetwork/lnd/chainntnfs"
+	"github.com/lightningnetwork/lnd/clock"
+	"github.com/lightningnetwork/lnd/lntypes"
+	"github.com/lightningnetwork/lnd/lnwire"
+	"github.com/lightningnetwork/lnd/zpay32"
+	"github.com/stretchr/testify/require"
+)
+
+type mockChainNotifier struct {
+	chainntnfs.ChainNotifier
+
+	blockChan chan *chainntnfs.BlockEpoch
+}
+
+func newMockNotifier() *mockChainNotifier {
+	return &mockChainNotifier{
+		blockChan: make(chan *chainntnfs.BlockEpoch),
+	}
+}
+
+// RegisterBlockEpochNtfn mocks a block epoch notification, using the mock's
+// block channel to deliver blocks to the client.
+func (m *mockChainNotifier) RegisterBlockEpochNtfn(*chainntnfs.BlockEpoch) (
+	*chainntnfs.BlockEpochEvent, error) {
+
+	return &chainntnfs.BlockEpochEvent{
+		Epochs: m.blockChan,
+		Cancel: func() {},
+	}, nil
+}
+
+const (
+	testCurrentHeight = int32(1)
+)
+
+var (
+	testTimeout = 5 * time.Second
+
+	testTime = time.Date(2018, time.February, 2, 14, 0, 0, 0, time.UTC)
+
+	testInvoicePreimage = lntypes.Preimage{1}
+
+	testPrivKeyBytes, _ = hex.DecodeString(
+		"e126f68f7eafcc8b74f54d269fe206be715000f94dac067d1c04a8ca3b2d" +
+			"b734",
+	)
+
+	testPrivKey, _ = btcec.PrivKeyFromBytes(testPrivKeyBytes)
+
+	testInvoiceDescription = "coffee"
+
+	testInvoiceAmount = lnwire.MilliSatoshi(100000) //nolint:gomnd
+
+	testNetParams = &chaincfg.MainNetParams
+
+	testMessageSigner = zpay32.MessageSigner{
+		SignCompact: func(msg []byte) ([]byte, error) {
+			hash := chainhash.HashB(msg)
+			sig, err := ecdsa.SignCompact(testPrivKey, hash, true)
+			if err != nil {
+				return nil, fmt.Errorf("can't sign the "+
+					"message: %v", err)
+			}
+
+			return sig, nil
+		},
+	}
+
+	testFeatures = lnwire.NewFeatureVector(
+		nil, lnwire.Features,
+	)
+)
+
+func newTestInvoice(t *testing.T, preimage lntypes.Preimage,
+	timestamp time.Time, expiry time.Duration) *Invoice {
+
+	t.Helper()
+
+	if expiry == 0 {
+		expiry = time.Hour
+	}
+
+	var payAddr [32]byte
+	if _, err := rand.Read(payAddr[:]); err != nil {
+		t.Fatalf("unable to generate payment addr: %v", err)
+	}
+
+	rawInvoice, err := zpay32.NewInvoice(
+		testNetParams,
+		preimage.Hash(),
+		timestamp,
+		zpay32.Amount(testInvoiceAmount),
+		zpay32.Description(testInvoiceDescription),
+		zpay32.Expiry(expiry),
+		zpay32.PaymentAddr(payAddr),
+	)
+	require.NoError(t, err, "Error while creating new invoice")
+
+	paymentRequest, err := rawInvoice.Encode(testMessageSigner)
+
+	require.NoError(t, err, "Error while encoding payment request")
+
+	return &Invoice{
+		Terms: ContractTerm{
+			PaymentPreimage: &preimage,
+			PaymentAddr:     payAddr,
+			Value:           testInvoiceAmount,
+			Expiry:          expiry,
+			Features:        testFeatures,
+		},
+		PaymentRequest: []byte(paymentRequest),
+		CreationDate:   timestamp,
+	}
+}
+
+// invoiceExpiryTestData simply holds generated expired and pending invoices.
+type invoiceExpiryTestData struct {
+	expiredInvoices map[lntypes.Hash]*Invoice
+	pendingInvoices map[lntypes.Hash]*Invoice
+}
+
+// generateInvoiceExpiryTestData generates the specified number of fake expired
+// and pending invoices anchored to the passed now timestamp.
+func generateInvoiceExpiryTestData(
+	t *testing.T, now time.Time,
+	offset, numExpired, numPending int) invoiceExpiryTestData {
+
+	t.Helper()
+
+	var testData invoiceExpiryTestData
+
+	testData.expiredInvoices = make(map[lntypes.Hash]*Invoice)
+	testData.pendingInvoices = make(map[lntypes.Hash]*Invoice)
+
+	expiredCreationDate := now.Add(-24 * time.Hour)
+
+	for i := 1; i <= numExpired; i++ {
+		var preimage lntypes.Preimage
+		binary.BigEndian.PutUint32(preimage[:4], uint32(offset+i))
+		duration := (i + offset) % 24 //nolint:gomnd
+		expiry := time.Duration(duration) * time.Hour
+		invoice := newTestInvoice(
+			t, preimage, expiredCreationDate, expiry,
+		)
+		testData.expiredInvoices[preimage.Hash()] = invoice
+	}
+
+	for i := 1; i <= numPending; i++ {
+		var preimage lntypes.Preimage
+		binary.BigEndian.PutUint32(preimage[4:], uint32(offset+i))
+		duration := (i + offset) % 24 //nolint:gomnd
+		expiry := time.Duration(duration) * time.Hour
+		invoice := newTestInvoice(t, preimage, now, expiry)
+		testData.pendingInvoices[preimage.Hash()] = invoice
+	}
+
+	return testData
+}
+
+type hodlExpiryTest struct {
+	hash         lntypes.Hash
+	state        ContractState
+	stateLock    sync.Mutex
+	mockNotifier *mockChainNotifier
+	mockClock    *clock.TestClock
+	cancelChan   chan lntypes.Hash
+	watcher      *InvoiceExpiryWatcher
+}
+
+func (h *hodlExpiryTest) setState(state ContractState) {
+	h.stateLock.Lock()
+	defer h.stateLock.Unlock()
+
+	h.state = state
+}
+
+func (h *hodlExpiryTest) announceBlock(t *testing.T, height uint32) {
+	t.Helper()
+
+	select {
+	case h.mockNotifier.blockChan <- &chainntnfs.BlockEpoch{
+		Height: int32(height),
+	}:
+
+	case <-time.After(testTimeout):
+		t.Fatalf("block %v not consumed", height)
+	}
+}
+
+func (h *hodlExpiryTest) assertCanceled(t *testing.T, expected lntypes.Hash) {
+	t.Helper()
+
+	select {
+	case actual := <-h.cancelChan:
+		require.Equal(t, expected, actual)
+
+	case <-time.After(testTimeout):
+		t.Fatalf("invoice: %v not canceled", h.hash)
+	}
+}
+
+// setupHodlExpiry creates a hodl invoice in our expiry watcher and runs an
+// arbitrary update function which advances the invoices's state.
+func setupHodlExpiry(t *testing.T, creationDate time.Time,
+	expiry time.Duration, heightDelta uint32,
+	startState ContractState,
+	startHtlcs []*InvoiceHTLC) *hodlExpiryTest {
+
+	t.Helper()
+
+	mockNotifier := newMockNotifier()
+	mockClock := clock.NewTestClock(testTime)
+
+	test := &hodlExpiryTest{
+		state: startState,
+		watcher: NewInvoiceExpiryWatcher(
+			mockClock, heightDelta, uint32(testCurrentHeight), nil,
+			mockNotifier,
+		),
+		cancelChan:   make(chan lntypes.Hash),
+		mockNotifier: mockNotifier,
+		mockClock:    mockClock,
+	}
+
+	// Use an unbuffered channel to block on cancel calls so that the test
+	// does not exit before we've processed all the invoices we expect.
+	cancelImpl := func(paymentHash lntypes.Hash, force bool) error {
+		test.stateLock.Lock()
+		currentState := test.state
+		test.stateLock.Unlock()
+
+		if currentState != ContractOpen && !force {
+			return nil
+		}
+
+		select {
+		case test.cancelChan <- paymentHash:
+		case <-time.After(testTimeout):
+		}
+
+		return nil
+	}
+
+	require.NoError(t, test.watcher.Start(cancelImpl))
+
+	// We set preimage and hash so that we can use our existing test
+	// helpers. In practice we would only have the hash, but this does not
+	// affect what we're testing at all.
+	preimage := lntypes.Preimage{1}
+	test.hash = preimage.Hash()
+
+	invoice := newTestInvoice(t, preimage, creationDate, expiry)
+	invoice.State = startState
+	invoice.HodlInvoice = true
+	invoice.Htlcs = make(map[CircuitKey]*InvoiceHTLC)
+
+	// If we have any htlcs, add them with unique circult keys.
+	for i, htlc := range startHtlcs {
+		key := CircuitKey{
+			HtlcID: uint64(i),
+		}
+
+		invoice.Htlcs[key] = htlc
+	}
+
+	// Create an expiry entry for our invoice in its starting state. This
+	// mimics adding invoices to the watcher on start.
+	entry := makeInvoiceExpiry(test.hash, invoice)
+	test.watcher.AddInvoices(entry)
+
+	return test
+}

--- a/invoices/test_utils_test.go
+++ b/invoices/test_utils_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/lightningnetwork/lnd/chainntnfs"
 	"github.com/lightningnetwork/lnd/channeldb"
+	"github.com/lightningnetwork/lnd/channeldb/models"
 	"github.com/lightningnetwork/lnd/clock"
 	"github.com/lightningnetwork/lnd/lntypes"
 	"github.com/lightningnetwork/lnd/lnwire"
@@ -227,8 +228,8 @@ func newTestContext(t *testing.T) *testContext {
 	return &ctx
 }
 
-func getCircuitKey(htlcID uint64) channeldb.CircuitKey {
-	return channeldb.CircuitKey{
+func getCircuitKey(htlcID uint64) models.CircuitKey {
+	return models.CircuitKey{
 		ChanID: lnwire.ShortChannelID{
 			BlockHeight: 1, TxIndex: 2, TxPosition: 3,
 		},
@@ -453,11 +454,11 @@ func setupHodlExpiry(t *testing.T, creationDate time.Time,
 	invoice := newTestInvoice(t, preimage, creationDate, expiry)
 	invoice.State = startState
 	invoice.HodlInvoice = true
-	invoice.Htlcs = make(map[channeldb.CircuitKey]*channeldb.InvoiceHTLC)
+	invoice.Htlcs = make(map[models.CircuitKey]*channeldb.InvoiceHTLC)
 
 	// If we have any htlcs, add them with unique circult keys.
 	for i, htlc := range startHtlcs {
-		key := channeldb.CircuitKey{
+		key := models.CircuitKey{
 			HtlcID: uint64(i),
 		}
 

--- a/invoices/update.go
+++ b/invoices/update.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/lightningnetwork/lnd/amp"
 	"github.com/lightningnetwork/lnd/channeldb"
+	"github.com/lightningnetwork/lnd/channeldb/models"
 	"github.com/lightningnetwork/lnd/lntypes"
 	"github.com/lightningnetwork/lnd/lnwire"
 	"github.com/lightningnetwork/lnd/record"
@@ -15,7 +16,7 @@ import (
 // update to be carried out.
 type invoiceUpdateCtx struct {
 	hash                 lntypes.Hash
-	circuitKey           channeldb.CircuitKey
+	circuitKey           models.CircuitKey
 	amtPaid              lnwire.MilliSatoshi
 	expiry               uint32
 	currentHeight        int32
@@ -233,7 +234,7 @@ func updateMpp(ctx *invoiceUpdateCtx,
 	}
 
 	// Record HTLC in the invoice database.
-	newHtlcs := map[channeldb.CircuitKey]*channeldb.HtlcAcceptDesc{
+	newHtlcs := map[models.CircuitKey]*channeldb.HtlcAcceptDesc{
 		ctx.circuitKey: acceptDesc,
 	}
 
@@ -258,7 +259,7 @@ func updateMpp(ctx *invoiceUpdateCtx,
 	}
 
 	var (
-		htlcPreimages map[channeldb.CircuitKey]lntypes.Preimage
+		htlcPreimages map[models.CircuitKey]lntypes.Preimage
 		htlcPreimage  lntypes.Preimage
 	)
 	if ctx.amp != nil {
@@ -290,10 +291,10 @@ func updateMpp(ctx *invoiceUpdateCtx,
 }
 
 // HTLCSet is a map of CircuitKey to InvoiceHTLC.
-type HTLCSet = map[channeldb.CircuitKey]*channeldb.InvoiceHTLC
+type HTLCSet = map[models.CircuitKey]*channeldb.InvoiceHTLC
 
 // HTLCPreimages is a map of CircuitKey to preimage.
-type HTLCPreimages = map[channeldb.CircuitKey]lntypes.Preimage
+type HTLCPreimages = map[models.CircuitKey]lntypes.Preimage
 
 // reconstructAMPPreimages reconstructs the root seed for an AMP HTLC set and
 // verifies that all derived child hashes match the payment hashes of the HTLCs
@@ -316,7 +317,7 @@ func reconstructAMPPreimages(ctx *invoiceUpdateCtx,
 
 	// Next, construct an index mapping the position in childDescs to a
 	// circuit key for all preexisting HTLCs.
-	indexToCircuitKey := make(map[int]channeldb.CircuitKey)
+	indexToCircuitKey := make(map[int]models.CircuitKey)
 
 	// Add the child descriptor for each HTLC in the HTLC set, recording
 	// it's position within the slice.
@@ -350,7 +351,7 @@ func reconstructAMPPreimages(ctx *invoiceUpdateCtx,
 	// Finally, construct the map of learned preimages indexed by circuit
 	// key, so that they can be persisted along with each HTLC when updating
 	// the invoice.
-	htlcPreimages := make(map[channeldb.CircuitKey]lntypes.Preimage)
+	htlcPreimages := make(map[models.CircuitKey]lntypes.Preimage)
 	htlcPreimages[ctx.circuitKey] = children[0].Preimage
 	for idx, child := range children[1:] {
 		circuitKey := indexToCircuitKey[idx]
@@ -417,7 +418,7 @@ func updateLegacy(ctx *invoiceUpdateCtx,
 	}
 
 	// Record HTLC in the invoice database.
-	newHtlcs := map[channeldb.CircuitKey]*channeldb.HtlcAcceptDesc{
+	newHtlcs := map[models.CircuitKey]*channeldb.HtlcAcceptDesc{
 		ctx.circuitKey: {
 			Amt:           ctx.amtPaid,
 			Expiry:        ctx.expiry,

--- a/lnrpc/routerrpc/forward_interceptor.go
+++ b/lnrpc/routerrpc/forward_interceptor.go
@@ -3,7 +3,7 @@ package routerrpc
 import (
 	"errors"
 
-	"github.com/lightningnetwork/lnd/channeldb"
+	"github.com/lightningnetwork/lnd/channeldb/models"
 	"github.com/lightningnetwork/lnd/htlcswitch"
 	"github.com/lightningnetwork/lnd/lnrpc"
 	"github.com/lightningnetwork/lnd/lntypes"
@@ -102,7 +102,7 @@ func (r *forwardInterceptor) resolveFromClient(
 
 	log.Tracef("Resolving intercepted packet %v", in)
 
-	circuitKey := channeldb.CircuitKey{
+	circuitKey := models.CircuitKey{
 		ChanID: lnwire.NewShortChanIDFromInt(in.IncomingCircuitKey.ChanId),
 		HtlcID: in.IncomingCircuitKey.HtlcId,
 	}

--- a/lnwallet/test/test_interface.go
+++ b/lnwallet/test/test_interface.go
@@ -3055,10 +3055,10 @@ func TestLightningWallet(t *testing.T, targetBackEnd string) {
 	tempDir := t.TempDir()
 	db, err := channeldb.Open(tempDir)
 	require.NoError(t, err, "unable to create db")
-	testCfg := chainntnfs.CacheConfig{
+	testCfg := channeldb.CacheConfig{
 		QueryDisable: false,
 	}
-	hintCache, err := chainntnfs.NewHeightHintCache(testCfg, db.Backend)
+	hintCache, err := channeldb.NewHeightHintCache(testCfg, db.Backend)
 	require.NoError(t, err, "unable to create height hint cache")
 	blockCache := blockcache.NewBlockCache(10000)
 	chainNotifier, err := btcdnotify.New(

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -5507,7 +5507,7 @@ func (r *rpcServer) LookupInvoice(ctx context.Context,
 
 	invoice, err := r.server.invoices.LookupInvoice(payHash)
 	switch {
-	case err == channeldb.ErrInvoiceNotFound:
+	case errors.Is(err, invoices.ErrInvoiceNotFound):
 		return nil, status.Error(codes.NotFound, err.Error())
 	case err != nil:
 		return nil, err
@@ -5551,7 +5551,7 @@ func (r *rpcServer) ListInvoices(ctx context.Context,
 
 	// Next, we'll map the proto request into a format that is understood by
 	// the database.
-	q := channeldb.InvoiceQuery{
+	q := invoices.InvoiceQuery{
 		IndexOffset:    req.IndexOffset,
 		NumMaxInvoices: req.NumMaxInvoices,
 		PendingOnly:    req.PendingOnly,

--- a/server.go
+++ b/server.go
@@ -614,7 +614,7 @@ func newServer(cfg *Config, listenAddrs []net.Addr,
 		uint32(currentHeight), currentHash, cc.ChainNotifier,
 	)
 	s.invoices = invoices.NewRegistry(
-		dbs.ChanStateDB, expiryWatcher, &registryConfig,
+		dbs.InvoiceDB, expiryWatcher, &registryConfig,
 	)
 
 	s.htlcNotifier = htlcswitch.NewHtlcNotifier(time.Now)

--- a/witness_beacon.go
+++ b/witness_beacon.go
@@ -4,6 +4,7 @@ import (
 	"sync"
 
 	"github.com/lightningnetwork/lnd/channeldb"
+	"github.com/lightningnetwork/lnd/channeldb/models"
 	"github.com/lightningnetwork/lnd/contractcourt"
 	"github.com/lightningnetwork/lnd/htlcswitch"
 	"github.com/lightningnetwork/lnd/htlcswitch/hop"
@@ -95,7 +96,7 @@ func (p *preimageBeacon) SubscribeUpdates(
 		Hash:           htlc.RHash,
 		IncomingExpiry: htlc.RefundTimeout,
 		IncomingAmount: htlc.Amt,
-		IncomingCircuit: channeldb.CircuitKey{
+		IncomingCircuit: models.CircuitKey{
 			ChanID: chanID,
 			HtlcID: htlc.HtlcIndex,
 		},


### PR DESCRIPTION
This PR is part of [6288](https://github.com/lightningnetwork/lnd/issues/6288)

 Many packages depend on channeldb for type definitions, interfaces, etc.

 `chainntnfs` is an example of that. `chainntnfs` defines the  `SpendHintCache` and `ConfirmHintCache` interfaces but it also implments them (`HeightHintCache` struct). The implementation uses logic that should not leak from channeldb (ex: bucket paths).
   
In this PR we try to invert that dependency for the invoices package. The first two commits aim to avoid circular dependencies:

- The invoices package uses `chainntnfs` so it cannot depend on `channeldb`: for solving this we leave the `chainntnfs` interfaces delcared in `chainntnfs` and move the implementation to `channeldb`.

- The Invoices package uses some types (like `CircuitKey`) that are declared in `channeldb`: for solving this we create a new package `lnd/channeldb/entities` where we move those type definitions. This feels like a patch, eventually we should decouple our code to let the types live in their right package without having cycles in our imports.


The third commit inverts the dependency between `channeldb` and `invoices` moving all the non db implementation related code to `invoices` and creating a new interface `InvoiceDB` that is implemented by channeldb.


Fixes https://github.com/lightningnetwork/lnd/issues/6954 

