### PR TITLE
CI: disable code coverage submission to coveralls

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -229,7 +229,6 @@ jobs:
       fail-fast: false
       matrix:
         unit_type:
-          - btcd unit-cover
           - unit tags="kvdb_etcd"
           - unit tags="kvdb_postgres"
           - btcd unit-race
@@ -258,13 +257,6 @@ jobs:
 
       - name: run ${{ matrix.unit_type }}
         run: make ${{ matrix.unit_type }}
-
-      - name: Send coverage
-        uses: shogo82148/actions-goveralls@v1
-        if: matrix.unit_type == 'btcd unit-cover'
-        with:
-          path-to-profile: coverage.txt
-          parallel: true
 
   ########################
   # run integration tests


### PR DESCRIPTION
## Change Description
This change disables the submission of code test coverage data to coveralls during continuous integration (CI). The test coverage analysis isn't very useful in its current state. Nondeterministic tests can lead to a coverage report which erroneously indicates that coverage has decreased.

Here's an example false decrease coverage report: https://coveralls.io/jobs/110465301/source_files/28544090856  
Associated PR: https://github.com/lightningnetwork/lnd/pull/7197

An "allow-failure" feature might work well here, but I don't think that's possible yet, see: https://github.com/actions/toolkit/issues/399

## Steps to Test
Steps for reviewers to follow to test the change.

## Pull Request Checklist
### Testing
- [ ] Your PR passes all CI checks.
- [ ] Tests covering the positive and negative (error paths) are included.
- [ ] Bug fixes contain tests triggering the bug to prevent regressions.

### Code Style and Documentation
- [ ] The change obeys the [Code Documentation and Commenting](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#CodeDocumentation) guidelines, and lines wrap at 80.
- [ ] Commits follow the [Ideal Git Commit Structure](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#IdealGitCommitStructure).
- [ ] Any new logging statements use an appropriate subsystem and logging level.
- [ ]  [There is a change description in the release notes](https://github.com/lightningnetwork/lnd/tree/master/docs/release-notes), or `[skip ci]` in the commit message for small changes.

📝 Please see our  [Contribution Guidelines](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md) for further guidance.