### PR TITLE
funding: notify on pending channel timeout

### DIFF
--- a/lntest/itest/list_on_test.go
+++ b/lntest/itest/list_on_test.go
@@ -16,6 +16,10 @@ var allTestCasesTemp = []*lntemp.TestCase{
 		TestFunc: testBasicChannelFunding,
 	},
 	{
+		Name:     "funding timeout",
+		TestFunc: testChannelFundingTimeout,
+	},
+	{
 		Name:     "multi hop htlc local timeout",
 		TestFunc: testMultiHopHtlcLocalTimeout,
 	},

--- a/server.go
+++ b/server.go
@@ -1407,8 +1407,10 @@ func newServer(cfg *Config, listenAddrs []net.Addr,
 		NotifyOpenChannelEvent:        s.channelNotifier.NotifyOpenChannelEvent,
 		OpenChannelPredicate:          chanPredicate,
 		NotifyPendingOpenChannelEvent: s.channelNotifier.NotifyPendingOpenChannelEvent,
-		EnableUpfrontShutdown:         cfg.EnableUpfrontShutdown,
-		RegisteredChains:              cfg.registeredChains,
+		NotifyClosedChannelEvent: s.channelNotifier.
+			NotifyClosedChannelEvent,
+		EnableUpfrontShutdown: cfg.EnableUpfrontShutdown,
+		RegisteredChains:      cfg.registeredChains,
 		MaxAnchorsCommitFeeRate: chainfee.SatPerKVByte(
 			s.cfg.MaxCommitFeeRateAnchors * 1000).FeePerKWeight(),
 		DeleteAliasEdge: deleteAliasEdge,

--- a/server.go
+++ b/server.go
@@ -1362,6 +1362,12 @@ func newServer(cfg *Config, listenAddrs []net.Addr,
 			// the chain arb so it can react to on-chain events.
 			return s.chainArb.WatchNewChannel(channel)
 		},
+		CancelWatchChannel: func(
+			channel *channeldb.OpenChannel) error {
+
+			return s.chainArb.ResolveContract(
+				channel.FundingOutpoint)
+		},
 		ReportShortChanID: func(chanPoint wire.OutPoint) error {
 			cid := lnwire.NewChanIDFromOutPoint(&chanPoint)
 			return s.htlcSwitch.UpdateShortChanID(cid)


### PR DESCRIPTION
For the non-initiator funding flow, the initiator is responsible for broadcasting the funding transaction.  If the initiator fails to broadcast, we currently time out the pending channel after 2016 blocks.

However, we aren't notifying anyone else about the timeout, so things like channel backups and the channel arbitrator are continuing to operate as if the channel was still pending.

This PR notifies other components on timeout, allowing them to clean up their state properly.

Tested:
```bash
$ make unit pkg=funding
$ make itest icase=funding_timeout temptest=1

# Check the itest log and make sure log spam described in #7208 is gone after timeout
$ vim lntest/itest/.logs-tranche0/1-funding_timeout-Bob-* 
```

Fixes #7208.