### PR TITLE
discovery: don't merge a peer when no message is sent to it

### DIFF
--- a/discovery/gossiper.go
+++ b/discovery/gossiper.go
@@ -1099,17 +1099,18 @@ func splitAnnouncementBatches(subBatchSize int,
 func (d *AuthenticatedGossiper) sendBatch(announcementBatch []msgWithSenders) {
 	syncerPeers := d.syncMgr.GossipSyncers()
 
-	// We'll first attempt to filter out this new message
-	// for all peers that have active gossip syncers
-	// active.
+	// We'll first attempt to filter out this new message for all peers
+	// that have active gossip syncers active.
 	for _, syncer := range syncerPeers {
 		syncer.FilterGossipMsgs(announcementBatch...)
 	}
 
 	for _, msgChunk := range announcementBatch {
-		// With the syncers taken care of, we'll merge
-		// the sender map with the set of syncers, so
-		// we don't send out duplicate messages.
+		msgChunk := msgChunk
+
+		// With the syncers taken care of, we'll merge the sender map
+		// with the set of syncers, so we don't send out duplicate
+		// messages.
 		msgChunk.mergeSyncerMap(syncerPeers)
 
 		err := d.cfg.Broadcast(

--- a/discovery/sync_manager.go
+++ b/discovery/sync_manager.go
@@ -755,13 +755,19 @@ func (m *SyncManager) GossipSyncers() map[route.Vertex]*GossipSyncer {
 
 // gossipSyncers returns all of the currently initialized gossip syncers.
 func (m *SyncManager) gossipSyncers() map[route.Vertex]*GossipSyncer {
-	numSyncers := len(m.inactiveSyncers) + len(m.activeSyncers)
+	numSyncers := len(m.inactiveSyncers) + len(m.activeSyncers) +
+		len(m.pinnedActiveSyncers)
 	syncers := make(map[route.Vertex]*GossipSyncer, numSyncers)
 
 	for _, syncer := range m.inactiveSyncers {
 		syncers[syncer.cfg.peerPub] = syncer
 	}
+
 	for _, syncer := range m.activeSyncers {
+		syncers[syncer.cfg.peerPub] = syncer
+	}
+
+	for _, syncer := range m.pinnedActiveSyncers {
 		syncers[syncer.cfg.peerPub] = syncer
 	}
 

--- a/docs/release-notes/release-notes-0.16.0.md
+++ b/docs/release-notes/release-notes-0.16.0.md
@@ -205,6 +205,9 @@ certain large transactions](https://github.com/lightningnetwork/lnd/pull/7100).
 * [Allow lncli to read binary PSBTs](https://github.com/lightningnetwork/lnd/pull/7122)
   from a file during PSBT channel funding flow to comply with [BIP 174](https://github.com/bitcoin/bips/blob/master/bip-0174.mediawiki#specification)
 
+* [Fixed case where channel announcements might not be sent to some of the
+  peers.](https://github.com/lightningnetwork/lnd/pull/7240)
+
 ## Code Health
 
 * [test: use `T.TempDir` to create temporary test


### PR DESCRIPTION
This is an attempt to fix #6531 and can be viewed as an alternative to #7239. When we broadcast messages, we'd skip peers who have syncer as the syncing logic will take care of sending the messages. However, it is suspected that some of the syncers haven't finished setting up yet, which ends up having ` g.remoteUpdateHorizon == nil` that causes some messages to never be sent to the peers. In general, even if the `remoteUpdateHorizon` is nil, the syncer will still send the messages later once it's active, so **a nil `remoteUpdateHorizon` alone is not the cause**, which has been manifested in a local itest. However, it's possible that by the time the `remoteUpdateHorizon` is set, the timestamp used here has already passed those used in the above messages, causing them to be filtered out, hence nothing gets sent.

This PR fixes it by not skipping the peers if no message is sent from their syncers. Meanwhile, the pinned syncers seem to be missing from `GossipSyncers`, and they are added back.

Another mitigation might be adding a delta value [here](https://github.com/lightningnetwork/lnd/blob/master/discovery/syncer.go#L1477) instead of using `time.Now()`. Something like `time.Now() - 1 min` so we can add some redundancy when requesting channel updates, at the cost of receiving potentially duplicate messages. 