### PR TITLE
lntemp: after mining, sync to latest block

### DIFF
--- a/docs/release-notes/release-notes-0.16.0.md
+++ b/docs/release-notes/release-notes-0.16.0.md
@@ -294,6 +294,7 @@ details. Along the way, several
 PRs([6776](https://github.com/lightningnetwork/lnd/pull/6776),
 [6822](https://github.com/lightningnetwork/lnd/pull/6822),
 [7172](https://github.com/lightningnetwork/lnd/pull/7172),
+[7242](https://github.com/lightningnetwork/lnd/pull/7242),
 [7245](https://github.com/lightningnetwork/lnd/pull/7245)) have been made to
 refactor the itest for code health and maintenance.
 

--- a/lntemp/harness.go
+++ b/lntemp/harness.go
@@ -1291,7 +1291,8 @@ func (h *HarnessTest) MineBlocks(num uint32) []*wire.MsgBlock {
 	blocks := h.Miner.MineBlocksSlow(num)
 
 	// Make sure all the active nodes are synced.
-	h.AssertActiveNodesSynced()
+	bestBlock := blocks[len(blocks)-1]
+	h.AssertActiveNodesSyncedTo(bestBlock)
 
 	return blocks
 }
@@ -1318,7 +1319,8 @@ func (h *HarnessTest) MineBlocksAndAssertNumTxes(num uint32,
 	}
 
 	// Finally, make sure all the active nodes are synced.
-	h.AssertActiveNodesSynced()
+	bestBlock := blocks[len(blocks)-1]
+	h.AssertActiveNodesSyncedTo(bestBlock)
 
 	return blocks
 }


### PR DESCRIPTION
Ensure active nodes are synced to the latest block mined, since the nodes may actually be "fully synced" to an old block when SyncedToChain is true.

This patch was useful for diagnosing #7241 and may reduce test flakiness.

@yyforyongyu 