### PR TITLE
itest+lntemp: add `ChainKitClient` RPCs and refactor `testChainKit`

### DIFF
--- a/docs/release-notes/release-notes-0.16.0.md
+++ b/docs/release-notes/release-notes-0.16.0.md
@@ -290,7 +290,8 @@ implemented, please refer to
 details. Along the way, several
 PRs([6776](https://github.com/lightningnetwork/lnd/pull/6776),
 [6822](https://github.com/lightningnetwork/lnd/pull/6822),
-[7172](https://github.com/lightningnetwork/lnd/pull/7172)) have been made to
+[7172](https://github.com/lightningnetwork/lnd/pull/7172),
+[7245](https://github.com/lightningnetwork/lnd/pull/7245)) have been made to
 refactor the itest for code health and maintenance.
 
 # Contributors (Alphabetical Order)

--- a/lntemp/rpc/chain_kit.go
+++ b/lntemp/rpc/chain_kit.go
@@ -1,0 +1,64 @@
+package rpc
+
+import (
+	"context"
+
+	"github.com/lightningnetwork/lnd/lnrpc/chainrpc"
+)
+
+// =====================
+// ChainKitClient related RPCs.
+// =====================
+
+// GetBestBlock makes an RPC call to chain kit client's GetBestBlock and
+// asserts.
+func (h *HarnessRPC) GetBestBlock(
+	req *chainrpc.GetBestBlockRequest) *chainrpc.GetBestBlockResponse {
+
+	if req == nil {
+		req = &chainrpc.GetBestBlockRequest{}
+	}
+
+	ctxt, cancel := context.WithTimeout(h.runCtx, DefaultTimeout)
+	defer cancel()
+
+	resp, err := h.ChainKit.GetBestBlock(ctxt, req)
+	h.NoError(err, "GetBestBlock")
+
+	return resp
+}
+
+// GetBlock makes an RPC call to chain kit client's GetBlock and asserts.
+func (h *HarnessRPC) GetBlock(
+	req *chainrpc.GetBlockRequest) *chainrpc.GetBlockResponse {
+
+	if req == nil {
+		req = &chainrpc.GetBlockRequest{}
+	}
+
+	ctxt, cancel := context.WithTimeout(h.runCtx, DefaultTimeout)
+	defer cancel()
+
+	resp, err := h.ChainKit.GetBlock(ctxt, req)
+	h.NoError(err, "GetBlock")
+
+	return resp
+}
+
+// GetBlockHash makes an RPC call to chain kit client's GetBlockHash and
+// asserts.
+func (h *HarnessRPC) GetBlockHash(
+	req *chainrpc.GetBlockHashRequest) *chainrpc.GetBlockHashResponse {
+
+	if req == nil {
+		req = &chainrpc.GetBlockHashRequest{}
+	}
+
+	ctxt, cancel := context.WithTimeout(h.runCtx, DefaultTimeout)
+	defer cancel()
+
+	resp, err := h.ChainKit.GetBlockHash(ctxt, req)
+	h.NoError(err, "GetBlockHash")
+
+	return resp
+}

--- a/lntest/itest/lnd_onchain_test.go
+++ b/lntest/itest/lnd_onchain_test.go
@@ -24,34 +24,28 @@ import (
 
 // testChainKit tests ChainKit RPC endpoints.
 func testChainKit(ht *lntemp.HarnessTest) {
-	ctx := context.Background()
-
-	// Test functions registered as test cases spin up separate nodes during
-	// execution. By calling sub-test functions as seen below we avoid the
-	// need to start separate nodes.
-	testChainKitGetBlock(ctx, ht)
-	testChainKitGetBlockHash(ctx, ht)
+	// Test functions registered as test cases spin up separate nodes
+	// during execution. By calling sub-test functions as seen below we
+	// avoid the need to start separate nodes.
+	testChainKitGetBlock(ht)
+	testChainKitGetBlockHash(ht)
 }
 
 // testChainKitGetBlock ensures that given a block hash, the RPC endpoint
 // returns the correct target block.
-func testChainKitGetBlock(ctx context.Context, ht *lntemp.HarnessTest) {
+func testChainKitGetBlock(ht *lntemp.HarnessTest) {
 	// Get best block hash.
-	bestBlockRes, err := ht.Alice.RPC.ChainKit.GetBestBlock(
-		ctx, &chainrpc.GetBestBlockRequest{},
-	)
-	require.NoError(ht, err)
+	bestBlockRes := ht.Alice.RPC.GetBestBlock(nil)
+
 	var bestBlockHash chainhash.Hash
-	err = bestBlockHash.SetBytes(bestBlockRes.BlockHash)
+	err := bestBlockHash.SetBytes(bestBlockRes.BlockHash)
 	require.NoError(ht, err)
 
 	// Retrieve the best block by hash.
-	getBlockRes, err := ht.Alice.RPC.ChainKit.GetBlock(
-		ctx, &chainrpc.GetBlockRequest{
-			BlockHash: bestBlockHash.CloneBytes(),
-		},
-	)
-	require.NoError(ht, err)
+	getBlockReq := &chainrpc.GetBlockRequest{
+		BlockHash: bestBlockHash[:],
+	}
+	getBlockRes := ht.Alice.RPC.GetBlock(getBlockReq)
 
 	// Deserialize the block which was retrieved by hash.
 	msgBlock := &wire.MsgBlock{}
@@ -67,20 +61,15 @@ func testChainKitGetBlock(ctx context.Context, ht *lntemp.HarnessTest) {
 
 // testChainKitGetBlockHash ensures that given a block height, the RPC endpoint
 // returns the correct target block hash.
-func testChainKitGetBlockHash(ctx context.Context, ht *lntemp.HarnessTest) {
+func testChainKitGetBlockHash(ht *lntemp.HarnessTest) {
 	// Get best block hash.
-	bestBlockRes, err := ht.Alice.RPC.ChainKit.GetBestBlock(
-		ctx, &chainrpc.GetBestBlockRequest{},
-	)
-	require.NoError(ht, err)
+	bestBlockRes := ht.Alice.RPC.GetBestBlock(nil)
 
 	// Retrieve the block hash at best block height.
-	getBlockHashRes, err := ht.Alice.RPC.ChainKit.GetBlockHash(
-		ctx, &chainrpc.GetBlockHashRequest{
-			BlockHeight: int64(bestBlockRes.BlockHeight),
-		},
-	)
-	require.NoError(ht, err)
+	req := &chainrpc.GetBlockHashRequest{
+		BlockHeight: int64(bestBlockRes.BlockHeight),
+	}
+	getBlockHashRes := ht.Alice.RPC.GetBlockHash(req)
 
 	// Ensure best block hash is the same as retrieved block hash.
 	expected := bestBlockRes.BlockHash


### PR DESCRIPTION
This PR adds the newly added `ChainKitClient` to `HarnessRPC`, which can be used in other tests.