### PR TITLE
build: update to actions/checkout v3

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -136,7 +136,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: git checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Fetch all history for linter
         run: git fetch --prune --unshallow


### PR DESCRIPTION
In this commit, we update the `checkout` action to v3 in an attempt to debug the current issue with the vcs and the linter.
