### PR TITLE
funding: check error to avoid panic during test

### DIFF
--- a/docs/release-notes/release-notes-0.16.0.md
+++ b/docs/release-notes/release-notes-0.16.0.md
@@ -182,6 +182,9 @@ certain large transactions](https://github.com/lightningnetwork/lnd/pull/7100).
 * [Updated several tlv stream-decoding callsites to use tlv/v1.1.0 P2P variants
   for untrusted input.](https://github.com/lightningnetwork/lnd/pull/7227)
 
+* [Prevent nil pointer dereference during funding manager 
+  test](https://github.com/lightningnetwork/lnd/pull/7268)
+
 ## `lncli`
 
 * [Add an `insecure` flag to skip tls auth as well as a `metadata` string slice

--- a/funding/manager.go
+++ b/funding/manager.go
@@ -4439,10 +4439,7 @@ func (f *Manager) getInitialFwdingPolicy(permChanID lnwire.ChannelID) (
 	chanID := make([]byte, 32)
 	copy(chanID, permChanID[:])
 
-	value, err := f.cfg.Wallet.Cfg.Database.GetInitialFwdingPolicy(
-		chanID,
-	)
-
+	value, err := f.cfg.Wallet.Cfg.Database.GetInitialFwdingPolicy(chanID)
 	if err != nil {
 		return nil, err
 	}

--- a/funding/manager_test.go
+++ b/funding/manager_test.go
@@ -3082,15 +3082,17 @@ func TestFundingManagerCustomChannelParameters(t *testing.T) {
 
 	// After the funding is sigend and before the channel announcement
 	// we expect Alice and Bob to store their respective fees in the database.
-	forwardingPolicy, _ := alice.fundingMgr.getInitialFwdingPolicy(fundingSigned.ChanID)
-	if err := assertFees(forwardingPolicy, 42, 1337); err != nil {
-		t.Fatal(err)
-	}
+	forwardingPolicy, err := alice.fundingMgr.getInitialFwdingPolicy(
+		fundingSigned.ChanID,
+	)
+	require.NoError(t, err)
+	require.NoError(t, assertFees(forwardingPolicy, 42, 1337))
 
-	forwardingPolicy, _ = bob.fundingMgr.getInitialFwdingPolicy(fundingSigned.ChanID)
-	if err := assertFees(forwardingPolicy, 100, 1000); err != nil {
-		t.Fatal(err)
-	}
+	forwardingPolicy, err = bob.fundingMgr.getInitialFwdingPolicy(
+		fundingSigned.ChanID,
+	)
+	require.NoError(t, err)
+	require.NoError(t, assertFees(forwardingPolicy, 100, 1000))
 
 	// Wait for Alice to published the funding tx to the network.
 	var fundingTx *wire.MsgTx


### PR DESCRIPTION
In this commit, the error returned from `getInitialFwdingPolicy` is checked in order to avoid a nil pointer dereference panic during the TestFundingManagerCustomChannelParameters test.

Ran into this in one of my other PRs:

```
--- FAIL: TestFundingManagerCustomChannelParameters (0.02s)
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
	panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x10 pc=0xe33a20]

goroutine 41 [running]:
testing.tRunner.func1.2({0xf61e60, 0x1acc570})
	/opt/hostedtoolcache/go/1.19.2/x64/src/testing/testing.go:1396 +0x24e
testing.tRunner.func1()
	/opt/hostedtoolcache/go/1.19.2/x64/src/testing/testing.go:1399 +0x39f
panic({0xf61e60, 0x1acc570})
	/opt/hostedtoolcache/go/1.19.2/x64/src/runtime/panic.go:884 +0x212
github.com/lightningnetwork/lnd/funding.TestFundingManagerCustomChannelParameters.func5(0x0, 0x86b7f02ee78d156c?, 0x3342ac04e1a9f632?)
	/home/runner/work/lnd/lnd/funding/manager_test.go:2992 +0x20
github.com/lightningnetwork/lnd/funding.TestFundingManagerCustomChannelParameters(0xc00046eb60)
	/home/runner/work/lnd/lnd/funding/manager_test.go:3091 +0x16a2
testing.tRunner(0xc00046eb60, 0x1[224](https://github.com/lightningnetwork/lnd/actions/runs/3755899473/jobs/6381383305#step:5:225)1b8)
	/opt/hostedtoolcache/go/1.19.2/x64/src/testing/testing.go:1446 +0x10b
created by testing.(*T).Run
	/opt/hostedtoolcache/go/1.19.2/x64/src/testing/testing.go:1493 +0x35f
```