### PR TITLE
lint: disable `thelper` linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -179,6 +179,11 @@ linters:
 
     # Disable nil check to allow returning multiple nil values.
     - nilnil
+    
+    # We often split tests into separate test functions. If we are forced to
+    # call t.Helper() within those functions, we lose the information where
+    # exactly a test failed in the generated failure stack trace.
+    - thelper
 
 
 issues:

--- a/docs/release-notes/release-notes-0.16.0.md
+++ b/docs/release-notes/release-notes-0.16.0.md
@@ -301,7 +301,9 @@ certain large transactions](https://github.com/lightningnetwork/lnd/pull/7100).
   adding a data migration functionality to `lndinit`.
 
 * [`golangci-lint` will now check new code using additional
-  linters.](https://github.com/lightningnetwork/lnd/pull/7064)
+  linters](https://github.com/lightningnetwork/lnd/pull/7064) and was
+  [fine-tuned](https://github.com/lightningnetwork/lnd/pull/7289) to fit our
+  code style.
 
 * Update github actions to [check commits against the target base 
   branch](https://github.com/lightningnetwork/lnd/pull/7103) rather than just 

--- a/lnwire/onion_error_test.go
+++ b/lnwire/onion_error_test.go
@@ -101,7 +101,7 @@ func TestEncodeDecodeTlv(t *testing.T) {
 
 var testTlv, _ = hex.DecodeString("fd023104deadbeef")
 
-func testEncodeDecodeTlv(t *testing.T, testFailure FailureMessage) { //nolint: lll,thelper
+func testEncodeDecodeTlv(t *testing.T, testFailure FailureMessage) {
 	var failureMessageBuffer bytes.Buffer
 
 	err := EncodeFailureMessage(&failureMessageBuffer, testFailure, 0)


### PR DESCRIPTION
We often split tests into separate test functions. If we are forced to
call `t.Helper()` within those functions, we lose the information where
exactly a test failed in the generated failure stack trace.