### PR TITLE
aliasmgr+channeldb: stop deleting zero-conf edges from graph if reorg occurs

### DIFF
--- a/aliasmgr/aliasmgr.go
+++ b/aliasmgr/aliasmgr.go
@@ -53,10 +53,10 @@ var (
 	// endBlockHeight is the ending block height of the alias range.
 	endBlockHeight = 16_250_000
 
-	// startingAlias is the first alias ShortChannelID that will get
+	// StartingAlias is the first alias ShortChannelID that will get
 	// assigned by RequestAlias. The starting BlockHeight is chosen so that
 	// legitimate SCIDs in integration tests aren't mistaken for an alias.
-	startingAlias = lnwire.ShortChannelID{
+	StartingAlias = lnwire.ShortChannelID{
 		BlockHeight: uint32(startingBlockHeight),
 		TxIndex:     0,
 		TxPosition:  0,
@@ -401,8 +401,8 @@ func (m *Manager) RequestAlias() (lnwire.ShortChannelID, error) {
 		lastBytes := bucket.Get(lastAliasKey)
 		if lastBytes == nil {
 			// If the key does not exist, then we can write the
-			// startingAlias to it.
-			nextAlias = startingAlias
+			// StartingAlias to it.
+			nextAlias = StartingAlias
 
 			var scratch [8]byte
 			byteOrder.PutUint64(scratch[:], nextAlias.ToUint64())

--- a/aliasmgr/aliasmgr_test.go
+++ b/aliasmgr/aliasmgr_test.go
@@ -32,12 +32,12 @@ func TestAliasStorePeerAlias(t *testing.T) {
 
 	// Test that we can put the (chanID, alias) mapping in the database.
 	// Also check that we retrieve exactly what we put in.
-	err = aliasStore.PutPeerAlias(chanID1, startingAlias)
+	err = aliasStore.PutPeerAlias(chanID1, StartingAlias)
 	require.NoError(t, err)
 
 	storedAlias, err := aliasStore.GetPeerAlias(chanID1)
 	require.NoError(t, err)
-	require.Equal(t, startingAlias, storedAlias)
+	require.Equal(t, StartingAlias, storedAlias)
 }
 
 // TestAliasStoreRequest tests that the aliasStore delivers the expected SCID.
@@ -55,12 +55,12 @@ func TestAliasStoreRequest(t *testing.T) {
 	aliasStore, err := NewManager(db)
 	require.NoError(t, err)
 
-	// We'll assert that the very first alias we receive is startingAlias.
+	// We'll assert that the very first alias we receive is StartingAlias.
 	alias1, err := aliasStore.RequestAlias()
 	require.NoError(t, err)
-	require.Equal(t, startingAlias, alias1)
+	require.Equal(t, StartingAlias, alias1)
 
-	// The next alias should be the result of passing in startingAlias to
+	// The next alias should be the result of passing in StartingAlias to
 	// getNextScid.
 	nextAlias := getNextScid(alias1)
 	alias2, err := aliasStore.RequestAlias()
@@ -78,7 +78,7 @@ func TestGetNextScid(t *testing.T) {
 	}{
 		{
 			name:    "starting alias",
-			current: startingAlias,
+			current: StartingAlias,
 			expected: lnwire.ShortChannelID{
 				BlockHeight: uint32(startingBlockHeight),
 				TxIndex:     0,

--- a/docs/release-notes/release-notes-0.16.0.md
+++ b/docs/release-notes/release-notes-0.16.0.md
@@ -234,6 +234,9 @@ in the lnwire package](https://github.com/lightningnetwork/lnd/pull/7303)
 * [Remove non-existent Cleanup calls from etcd test code in the `kvdb` 
   package](https://github.com/lightningnetwork/lnd/pull/7352)
 
+* [A bug has been fixed where a reorg would cause zero-conf channels to be deleted
+  from the graph.](https://github.com/lightningnetwork/lnd/pull/7292)
+
 ## `lncli`
 
 * [Add an `insecure` flag to skip tls auth as well as a `metadata` string slice

--- a/lntest/itest/list_on_test.go
+++ b/lntest/itest/list_on_test.go
@@ -505,4 +505,8 @@ var allTestCasesTemp = []*lntemp.TestCase{
 		Name:     "sign verify message with addr",
 		TestFunc: testSignVerifyMessageWithAddr,
 	},
+	{
+		Name:     "zero conf reorg edge existence",
+		TestFunc: testZeroConfReorg,
+	},
 }


### PR DESCRIPTION
Fixes #7229 

Description of issue:

When a block is disconnected due to a reorg, DisconnectBlockAtHeight is called for the block height. Prior to this patch, it would delete every SCID in the graph with a block height greater than the disconnected height. This meant that a reorg would delete every zero-conf channel edge from the graph. The fix simply iterates up until the StartingAlias and deletes every SCID between the disconnected height and the StartingAlias height.

An integration test is included that asserts that the fix works.