### PR TITLE
GitHub: fix Golang build cache in actions

### DIFF
--- a/.github/actions/setup-go/action.yml
+++ b/.github/actions/setup-go/action.yml
@@ -1,14 +1,18 @@
-# A resuable workflow that's used to setup the go enviroment and cache.
-name: Setup go enviroment
+name: "Setup Golang environment"
+description: "A reusable workflow that's used to set up the Go environment and cache."
+inputs:
+  go-version:
+    description: "The version of Golang to set up"
+    required: true
 
 runs:
   using: "composite"
 
   steps:
-    - name: setup go ${{ env.GO_VERSION }}
+    - name: setup go ${{ inputs.go-version }}
       uses: actions/setup-go@v3
       with:
-        go-version: '${{ env.GO_VERSION }}'
+        go-version: '${{ inputs.go-version }}'
 
     - name: go cache
       uses: actions/cache@v3
@@ -23,9 +27,9 @@ runs:
           ~/.cache/go-build
           ~/Library/Caches/go-build
           ~\AppData\Local\go-build
-        key: ${{ runner.os }}-go-${{ env.GO_VERSION }}-${{ hashFiles('**/go.sum') }}
+        key: ${{ runner.os }}-go-${{ inputs.go-version }}-${{ hashFiles('**/go.sum') }}
         restore-keys: |
-          ${{ runner.os }}-go-${{ env.GO_VERSION }}-
+          ${{ runner.os }}-go-${{ inputs.go-version }}-
 
     - name: set GOPATH
       shell: bash

--- a/.github/actions/setup-go/action.yml
+++ b/.github/actions/setup-go/action.yml
@@ -26,3 +26,8 @@ runs:
         key: ${{ runner.os }}-go-${{ env.GO_VERSION }}-${{ hashFiles('**/go.sum') }}
         restore-keys: |
           ${{ runner.os }}-go-${{ env.GO_VERSION }}-
+
+    - name: set GOPATH
+      shell: bash
+      run: |
+        echo "GOPATH=$(go env GOPATH)" >> $GITHUB_ENV

--- a/.github/actions/setup-go/action.yml
+++ b/.github/actions/setup-go/action.yml
@@ -27,8 +27,9 @@ runs:
           ~/.cache/go-build
           ~/Library/Caches/go-build
           ~\AppData\Local\go-build
-        key: ${{ runner.os }}-go-${{ inputs.go-version }}-${{ hashFiles('**/go.sum') }}
+        key: ${{ runner.os }}-go-${{ inputs.go-version }}-${{ github.job }}-${{ hashFiles('**/go.sum') }}
         restore-keys: |
+          ${{ runner.os }}-go-${{ inputs.go-version }}-${{ github.job }}-
           ${{ runner.os }}-go-${{ inputs.go-version }}-
 
     - name: set GOPATH

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -39,9 +39,10 @@ jobs:
       - name: git checkout
         uses: actions/checkout@v3
 
-      - id: setup
-        name: Setup go env
+      - name: setup go ${{ env.GO_VERSION }}
         uses: ./.github/actions/setup-go
+        with:
+          go-version: '${{ env.GO_VERSION }}'
 
       - name: run check
         run: make rpc-check
@@ -68,9 +69,10 @@ jobs:
         with:
           fetch-depth: 0
 
-      - id: setup
-        name: Setup go env
+      - name: setup go ${{ env.GO_VERSION }}
         uses: ./.github/actions/setup-go
+        with:
+          go-version: '${{ env.GO_VERSION }}'
 
       - name: fetch and rebase on ${{ github.base_ref }}
         run: |
@@ -95,9 +97,10 @@ jobs:
         with:
           fetch-depth: 0
 
-      - id: setup
-        name: Setup go env
+      - name: setup go ${{ env.GO_VERSION }}
         uses: ./.github/actions/setup-go
+        with:
+          go-version: '${{ env.GO_VERSION }}'
 
       - name: check code format
         run: make fmt-check
@@ -115,9 +118,10 @@ jobs:
       - name: git checkout
         uses: actions/checkout@v3
 
-      - id: setup
-        name: Setup go env
+      - name: setup go ${{ env.GO_VERSION }}
         uses: ./.github/actions/setup-go
+        with:
+          go-version: '${{ env.GO_VERSION }}'
 
       - name: build release for all architectures
         run: make release
@@ -132,9 +136,10 @@ jobs:
       - name: git checkout
         uses: actions/checkout@v3
 
-      - id: setup
-        name: Setup go env
+      - name: setup go ${{ env.GO_VERSION }}
         uses: ./.github/actions/setup-go
+        with:
+          go-version: '${{ env.GO_VERSION }}'
 
       - name: check all command line flags exist in sample-lnd.conf file
         run: make sample-conf-check
@@ -158,9 +163,10 @@ jobs:
       - name: git checkout
         uses: actions/checkout@v3
 
-      - id: setup
-        name: Setup go env
+      - name: setup go ${{ env.GO_VERSION }}
         uses: ./.github/actions/setup-go
+        with:
+          go-version: '${{ env.GO_VERSION }}'
 
       - name: install bitcoind
         run: ./scripts/install_bitcoind.sh
@@ -204,9 +210,10 @@ jobs:
       - name: git checkout
         uses: actions/checkout@v3
 
-      - id: setup
-        name: Setup go env
+      - name: setup go ${{ env.GO_VERSION }}
         uses: ./.github/actions/setup-go
+        with:
+          go-version: '${{ env.GO_VERSION }}'
 
       - name: install bitcoind
         run: ./scripts/install_bitcoind.sh
@@ -237,9 +244,10 @@ jobs:
       - name: git checkout
         uses: actions/checkout@v3
 
-      - id: setup
-        name: Setup go env
+      - name: setup go ${{ env.GO_VERSION }}
         uses: ./.github/actions/setup-go
+        with:
+          go-version: '${{ env.GO_VERSION }}'
 
       - name: run itest
         run: make itest-parallel windows=1 tranches=2 parallel=2
@@ -285,9 +293,10 @@ jobs:
       - name: git checkout
         uses: actions/checkout@v3
 
-      - id: setup
-        name: Setup go env
+      - name: setup go ${{ env.GO_VERSION }}
         uses: ./.github/actions/setup-go
+        with:
+          go-version: '${{ env.GO_VERSION }}'
 
       - name: install bitcoind
         run: ./scripts/install_bitcoind.sh
@@ -318,9 +327,10 @@ jobs:
       - name: git checkout
         uses: actions/checkout@v3
 
-      - id: setup
-        name: Setup go env
+      - name: setup go ${{ env.GO_VERSION }}
         uses: ./.github/actions/setup-go
+        with:
+          go-version: '${{ env.GO_VERSION }}'
 
       - name: run new itest
         run: make itest-parallel temptest=true windows=1 tranches=2 parallel=2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,9 +18,6 @@ defaults:
     shell: bash
 
 env:
-  # go needs absolute directories, using the $HOME variable doesn't work here.
-  GOCACHE: /home/runner/work/go/pkg/build
-  GOPATH: /home/runner/work/go
   BITCOIN_VERSION: "23.0"
 
   # If you change this value, please change it in the following files as well:
@@ -236,9 +233,6 @@ jobs:
   windows-integration-test:
     name: run windows itest
     runs-on: windows-latest
-    env:
-      GOCACHE: ${{ github.workspace }}/go/pkg/build
-      GOPATH: ${{ github.workspace }}/go
     steps:
       - name: git checkout
         uses: actions/checkout@v3
@@ -320,9 +314,6 @@ jobs:
   new-windows-integration-test:
     name: run new windows itest
     runs-on: windows-latest
-    env:
-      GOCACHE: ${{ github.workspace }}/go/pkg/build
-      GOPATH: ${{ github.workspace }}/go
     steps:
       - name: git checkout
         uses: actions/checkout@v3

--- a/docs/release-notes/release-notes-0.16.0.md
+++ b/docs/release-notes/release-notes-0.16.0.md
@@ -312,7 +312,8 @@ certain large transactions](https://github.com/lightningnetwork/lnd/pull/7100).
   branch](https://github.com/lightningnetwork/lnd/pull/7103) rather than just 
   using the master branch. And [skip the commit 
   check](https://github.com/lightningnetwork/lnd/pull/7114) for all non-PR 
-  events.
+  events. The Golang build cache [was also optimized to speed up tests and
+  builds](https://github.com/lightningnetwork/lnd/pull/7295).
 
 * Fixed docker image version used in
   [`tools`](https://github.com/lightningnetwork/lnd/pull/7254).


### PR DESCRIPTION
For some reason we used to override the `GOCACHE` and `GOPATH` variables
earlier. This now causes the updated cache action not to pick up any
caches. As the overrides shouldn't be needed anymore, we remove them.