### PR TITLE
Add Custom Message to Fuzz Testing

### DIFF
--- a/docs/release-notes/release-notes-0.16.0.md
+++ b/docs/release-notes/release-notes-0.16.0.md
@@ -225,6 +225,9 @@ data.
 * [Decreased the mutex lock
   scope](https://github.com/lightningnetwork/lnd/pull/7330) inside `ChannelRouter`.
 
+* [Add Custom Message to the fuzz testsuite
+in the lnwire package](https://github.com/lightningnetwork/lnd/pull/7303)
+
 ## `lncli`
 
 * [Add an `insecure` flag to skip tls auth as well as a `metadata` string slice
@@ -411,3 +414,4 @@ refactor the itest for code health and maintenance.
 * Tommy Volk
 * Yong Yu
 * Yusuke Shimizu
+* ziggie1984

--- a/lnwire/fuzz_test.go
+++ b/lnwire/fuzz_test.go
@@ -807,3 +807,18 @@ func FuzzUpdateFulfillHTLC(f *testing.F) {
 		harness(t, data)
 	})
 }
+
+func FuzzCustomMessage(f *testing.F) {
+	f.Fuzz(func(t *testing.T, data []byte, customMessageType uint16) {
+		if customMessageType < uint16(CustomTypeStart) {
+			customMessageType += uint16(CustomTypeStart)
+		}
+
+		// Prefix with CustomMessage.
+		data = prefixWithMsgType(data, MessageType(customMessageType))
+
+		// Pass the message into our general fuzz harness for wire
+		// messages!
+		harness(t, data)
+	})
+}


### PR DESCRIPTION
## Change Description
This PR addresses #7237 and adds the custom message of the lnwire package to the fuzz tests.

@Crypt-iQ could you take a look and check whether I am missing something before I set it to "ready for review", thanks in advance :)
## Steps to Test
Run the fuzz test suite for the lnwire package with `make fuzz pkg=lnwire` or test the new fuzz test explicitly with 
`go test -fuzz=FuzzCustomMessage` in the lnwire directory

## Pull Request Checklist
### Testing
- [x] Your PR passes all CI checks.
- [x] Tests covering the positive and negative (error paths) are included.
- [x] Bug fixes contain tests triggering the bug to prevent regressions.

### Code Style and Documentation
- [x] The change obeys the [Code Documentation and Commenting](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#CodeDocumentation) guidelines, and lines wrap at 80.
- [x] Commits follow the [Ideal Git Commit Structure](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#IdealGitCommitStructure).
- [x] Any new logging statements use an appropriate subsystem and logging level.
- [x]  [There is a change description in the release notes](https://github.com/lightningnetwork/lnd/tree/master/docs/release-notes), or `[skip ci]` in the commit message for small changes.

📝 Please see our  [Contribution Guidelines](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md) for further guidance.