### PR TITLE
routerrpc: update QueryProbability documentation

### DIFF
--- a/lnrpc/routerrpc/router.proto
+++ b/lnrpc/routerrpc/router.proto
@@ -95,7 +95,9 @@ service Router {
 
     /*
     Deprecated. QueryProbability returns the current success probability
-    estimate for a given node pair and amount.
+    estimate for a given node pair and amount. The call returns a zero success
+    probability if no channel is available or if the amount violates min/max
+    HTLC constraints.
     */
     rpc QueryProbability (QueryProbabilityRequest)
         returns (QueryProbabilityResponse);

--- a/lnrpc/routerrpc/router.swagger.json
+++ b/lnrpc/routerrpc/router.swagger.json
@@ -116,7 +116,7 @@
     },
     "/v2/router/mc/probability/{from_node}/{to_node}/{amt_msat}": {
       "get": {
-        "summary": "Deprecated. QueryProbability returns the current success probability\nestimate for a given node pair and amount.",
+        "summary": "Deprecated. QueryProbability returns the current success probability\nestimate for a given node pair and amount. The call returns a zero success\nprobability if no channel is available or if the amount violates min/max\nHTLC constraints.",
         "operationId": "Router_QueryProbability",
         "responses": {
           "200": {

--- a/lnrpc/routerrpc/router_grpc.pb.go
+++ b/lnrpc/routerrpc/router_grpc.pb.go
@@ -66,7 +66,9 @@ type RouterClient interface {
 	// provided is valid.
 	SetMissionControlConfig(ctx context.Context, in *SetMissionControlConfigRequest, opts ...grpc.CallOption) (*SetMissionControlConfigResponse, error)
 	// Deprecated. QueryProbability returns the current success probability
-	// estimate for a given node pair and amount.
+	// estimate for a given node pair and amount. The call returns a zero success
+	// probability if no channel is available or if the amount violates min/max
+	// HTLC constraints.
 	QueryProbability(ctx context.Context, in *QueryProbabilityRequest, opts ...grpc.CallOption) (*QueryProbabilityResponse, error)
 	// BuildRoute builds a fully specified route based on a list of hop public
 	// keys. It retrieves the relevant channel policies from the graph in order to
@@ -484,7 +486,9 @@ type RouterServer interface {
 	// provided is valid.
 	SetMissionControlConfig(context.Context, *SetMissionControlConfigRequest) (*SetMissionControlConfigResponse, error)
 	// Deprecated. QueryProbability returns the current success probability
-	// estimate for a given node pair and amount.
+	// estimate for a given node pair and amount. The call returns a zero success
+	// probability if no channel is available or if the amount violates min/max
+	// HTLC constraints.
 	QueryProbability(context.Context, *QueryProbabilityRequest) (*QueryProbabilityResponse, error)
 	// BuildRoute builds a fully specified route based on a list of hop public
 	// keys. It retrieves the relevant channel policies from the graph in order to


### PR DESCRIPTION
Changes the docstring of `QueryProbability` to reflect changes that were introduced in #6857.