### PR TITLE
lncli: fix linter error

### DIFF
--- a/cmd/lncli/cmd_payments.go
+++ b/cmd/lncli/cmd_payments.go
@@ -1652,6 +1652,8 @@ func clearLines(count int) {
 }
 
 // ordinalNumber returns the ordinal number as a string of a number.
+//
+//nolint:gomnd
 func ordinalNumber(num uint32) string {
 	switch num {
 	case 1:


### PR DESCRIPTION
Fix linter error, too small to add a release note but still wanna see the build result.