### PR TITLE
lncli+docs: skip gomnd check in switch statement

### DIFF
--- a/cmd/lncli/cmd_payments.go
+++ b/cmd/lncli/cmd_payments.go
@@ -1653,6 +1653,7 @@ func clearLines(count int) {
 
 // ordinalNumber returns the ordinal number as a string of a number.
 func ordinalNumber(num uint32) string {
+	//nolint:gomnd
 	switch num {
 	case 1:
 		return "1st"

--- a/docs/release-notes/release-notes-0.16.0.md
+++ b/docs/release-notes/release-notes-0.16.0.md
@@ -208,6 +208,8 @@ certain large transactions](https://github.com/lightningnetwork/lnd/pull/7100).
 * [Fixed a flake in the TestMailBoxAddExpiry unit
   test](https://github.com/lightningnetwork/lnd/pull/7314).
 
+* [Fix gomnd linter error](https://github.com/lightningnetwork/lnd/pull/7325)
+
 ## `lncli`
 
 * [Add an `insecure` flag to skip tls auth as well as a `metadata` string slice


### PR DESCRIPTION
Skip the gomnd lint check in lncli switch statement