### PR TITLE
channeldb/invoices: add `IsAMP` and `IsKeysend` helpers

### DIFF
--- a/docs/release-notes/release-notes-0.16.0.md
+++ b/docs/release-notes/release-notes-0.16.0.md
@@ -306,6 +306,9 @@ data.
 
 * [Fixed a test closure](https://github.com/lightningnetwork/lnd/pull/7337)
   issue found in `bitcoindnotify/bitcoind_test.go`.
+
+* Add methods to easily check if an invoice [is AMP or 
+Keysend](https://github.com/lightningnetwork/lnd/pull/7334).
  
 ## Watchtowers
 

--- a/lnrpc/invoicesrpc/utils.go
+++ b/lnrpc/invoicesrpc/utils.go
@@ -150,8 +150,6 @@ func CreateRPCInvoice(invoice *invoices.Invoice,
 		rpcHtlcs = append(rpcHtlcs, &rpcHtlc)
 	}
 
-	isAmp := invoice.Terms.Features.HasFeature(lnwire.AMPOptional)
-
 	rpcInvoice := &lnrpc.Invoice{
 		Memo:            string(invoice.Memo),
 		RHash:           rHash,
@@ -175,9 +173,9 @@ func CreateRPCInvoice(invoice *invoices.Invoice,
 		State:           state,
 		Htlcs:           rpcHtlcs,
 		Features:        CreateRPCFeatures(invoice.Terms.Features),
-		IsKeysend:       len(invoice.PaymentRequest) == 0 && !isAmp,
+		IsKeysend:       invoice.IsKeysend(),
 		PaymentAddr:     invoice.Terms.PaymentAddr[:],
-		IsAmp:           isAmp,
+		IsAmp:           invoice.IsAMP(),
 	}
 
 	rpcInvoice.AmpInvoiceState = make(map[string]*lnrpc.AMPInvoiceState)


### PR DESCRIPTION
The only way to know if an invoice is AMP, Keysend, etc is to look at its shape/characteristics. This commit adds a couple of helper functions to encapsulate the logic of these checks.

If all these types cannot intersect: an invoice cannot be AMP and Keysend or Keysend and Bolt12, etc it could be useful to add an extra field to store this information instead of relying on checking how the invoice looks like.


