### PR TITLE
routing: fix reace condition in `TestUpdatePaymentState`

### DIFF
--- a/docs/release-notes/release-notes-0.16.0.md
+++ b/docs/release-notes/release-notes-0.16.0.md
@@ -219,6 +219,9 @@ data.
 
 * [Fix gomnd linter error](https://github.com/lightningnetwork/lnd/pull/7325)
 
+* [Fix race condition in 
+`TestUpdatePaymentState`](https://github.com/lightningnetwork/lnd/pull/7336)
+
 ## `lncli`
 
 * [Add an `insecure` flag to skip tls auth as well as a `metadata` string slice


### PR DESCRIPTION
The test cases in `TestUpdatePaymentState` run in parallel. One of the parameters is a pointer and the value to the struct it points to gets modified during the test.

The race condition was introduced in 8d49dfb07ea00352effc9ed99ce995db270b78e6 To test the fix run from the main folder `go test  ./routing/. -race` before this fix and after.
