### PR TITLE
[6/?] - lnwallet+chancloser: update channel state machine and co-op close for musig2 flow

### DIFF
--- a/channeldb/channel.go
+++ b/channeldb/channel.go
@@ -3776,8 +3776,6 @@ func putChanRevocationState(chanBucket kvdb.RwBucket, channel *OpenChannel) erro
 		return err
 	}
 
-	// TODO(roasbeef): don't keep producer on disk
-
 	// If the next revocation is present, which is only the case after the
 	// FundingLocked message has been sent, then we'll write it to disk.
 	if channel.RemoteNextRevocation != nil {

--- a/channeldb/channel.go
+++ b/channeldb/channel.go
@@ -1501,6 +1501,30 @@ func (c *OpenChannel) ChanSyncMsg() (*lnwire.ChannelReestablish, error) {
 		}
 	}
 
+	// If this is a taproot channel, then we'll need to generate our next
+	// verification nonce to send to the remote party. They'll use this to
+	// sign the next update to our commitment transaction.
+	var nextTaprootNonce *lnwire.Musig2Nonce
+	if c.ChanType.IsTaproot() {
+		taprootRevProducer, err := DeriveMusig2Shachain(
+			c.RevocationProducer,
+		)
+		if err != nil {
+			return nil, err
+		}
+
+		nextNonce, err := NewMusigVerificationNonce(
+			c.LocalChanCfg.MultiSigKey.PubKey,
+			nextLocalCommitHeight, taprootRevProducer,
+		)
+		if err != nil {
+			return nil, fmt.Errorf("unable to gen next "+
+				"nonce: %w", err)
+		}
+
+		nextTaprootNonce = (*lnwire.Musig2Nonce)(&nextNonce.PubNonce)
+	}
+
 	return &lnwire.ChannelReestablish{
 		ChanID: lnwire.NewChanIDFromOutPoint(
 			&c.FundingOutpoint,
@@ -1511,6 +1535,7 @@ func (c *OpenChannel) ChanSyncMsg() (*lnwire.ChannelReestablish, error) {
 		LocalUnrevokedCommitPoint: input.ComputeCommitmentPoint(
 			currentCommitSecret[:],
 		),
+		LocalNonce: nextTaprootNonce,
 	}, nil
 }
 

--- a/channeldb/channel.go
+++ b/channeldb/channel.go
@@ -2,6 +2,7 @@ package channeldb
 
 import (
 	"bytes"
+	"crypto/hmac"
 	"crypto/sha256"
 	"encoding/binary"
 	"errors"
@@ -13,6 +14,7 @@ import (
 	"sync"
 
 	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/btcsuite/btcd/btcec/v2/schnorr/musig2"
 	"github.com/btcsuite/btcd/btcutil"
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcd/wire"
@@ -1367,6 +1369,65 @@ func (c *OpenChannel) SecondCommitmentPoint() (*btcec.PublicKey, error) {
 	}
 
 	return input.ComputeCommitmentPoint(revocation[:]), nil
+}
+
+var (
+	// taprootRevRootKey is the key used to derive the revocation root for
+	// the taproot nonces. This is done via HMAC of the existing revocation
+	// root.
+	taprootRevRootKey = []byte("taproot-rev-root")
+)
+
+// DeriveMusig2Shachain derives a shachain producer for the taproot channel
+// from normal shachain revocation root.
+func DeriveMusig2Shachain(revRoot shachain.Producer) (shachain.Producer, error) { //nolint:lll
+	// In order to obtain the revocation root hash to create the taproot
+	// revocation, we'll encode the producer into a buffer, then use that
+	// to derive the shachain root needed.
+	var rootHashBuf bytes.Buffer
+	if err := revRoot.Encode(&rootHashBuf); err != nil {
+		return nil, fmt.Errorf("unable to encode producer: %w", err)
+	}
+
+	revRootHash := chainhash.HashH(rootHashBuf.Bytes())
+
+	// For taproot channel types, we'll also generate a distinct shachain
+	// root using the same seed information. We'll use this to generate
+	// verification nonces for the channel. We'll bind with this a simple
+	// hmac.
+	taprootRevHmac := hmac.New(sha256.New, taprootRevRootKey)
+	if _, err := taprootRevHmac.Write(revRootHash[:]); err != nil {
+		return nil, err
+	}
+
+	taprootRevRoot := taprootRevHmac.Sum(nil)
+
+	// Once we have the root, we can then generate our shachain producer
+	// and from that generate the per-commitment point.
+	return shachain.NewRevocationProducerFromBytes(
+		taprootRevRoot,
+	)
+}
+
+// NewMusigVerificationNonce generates the local or verification nonce for
+// another musig2 session. In order to permit our implementation to not have to
+// write any secret nonce state to disk, we'll use the _next_ shachain
+// pre-image as our primary randomness source. When used to generate the nonce
+// again to broadcast our commitment hte current height will be used.
+func NewMusigVerificationNonce(pubKey *btcec.PublicKey, targetHeight uint64,
+	shaGen shachain.Producer) (*musig2.Nonces, error) {
+
+	// Now that we know what height we need, we'll grab the shachain
+	// pre-image at the target destination.
+	nextPreimage, err := shaGen.AtIndex(targetHeight)
+	if err != nil {
+		return nil, err
+	}
+
+	shaChainRand := musig2.WithCustomRand(bytes.NewBuffer(nextPreimage[:]))
+	pubKeyOpt := musig2.WithPublicKey(pubKey)
+
+	return musig2.GenNonces(pubKeyOpt, shaChainRand)
 }
 
 // ChanSyncMsg returns the ChannelReestablish message that should be sent upon

--- a/contractcourt/chain_watcher_test.go
+++ b/contractcourt/chain_watcher_test.go
@@ -145,7 +145,7 @@ func TestChainWatcherRemoteUnilateralClosePendingCommit(t *testing.T) {
 
 	// With the HTLC added, we'll now manually initiate a state transition
 	// from Alice to Bob.
-	_, _, _, err = aliceChannel.SignNextCommitment()
+	_, err = aliceChannel.SignNextCommitment()
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/htlcswitch/link.go
+++ b/htlcswitch/link.go
@@ -1929,7 +1929,10 @@ func (l *channelLink) handleUpstreamMsg(msg lnwire.Message) {
 		// We just received a new updates to our local commitment
 		// chain, validate this new commitment, closing the link if
 		// invalid.
-		err = l.channel.ReceiveNewCommitment(msg.CommitSig, msg.HtlcSigs)
+		err = l.channel.ReceiveNewCommitment(&lnwallet.CommitSigs{
+			CommitSig:  msg.CommitSig,
+			HtlcSigs:   msg.HtlcSigs,
+		})
 		if err != nil {
 			// If we were unable to reconstruct their proposed
 			// commitment, then we'll examine the type of error. If
@@ -2259,7 +2262,7 @@ func (l *channelLink) updateCommitTx() error {
 		return nil
 	}
 
-	theirCommitSig, htlcSigs, pendingHTLCs, err := l.channel.SignNextCommitment()
+	newCommit, err := l.channel.SignNextCommitment()
 	if err == lnwallet.ErrNoWindow {
 		l.cfg.PendingCommitTicker.Resume()
 		l.log.Trace("PendingCommitTicker resumed")
@@ -2291,7 +2294,7 @@ func (l *channelLink) updateCommitTx() error {
 	// pending).
 	newUpdate := &contractcourt.ContractUpdate{
 		HtlcKey: contractcourt.RemotePendingHtlcSet,
-		Htlcs:   pendingHTLCs,
+		Htlcs:   newCommit.PendingHTLCs,
 	}
 	err = l.cfg.NotifyContractUpdate(newUpdate)
 	if err != nil {
@@ -2306,9 +2309,9 @@ func (l *channelLink) updateCommitTx() error {
 	}
 
 	commitSig := &lnwire.CommitSig{
-		ChanID:    l.ChanID(),
-		CommitSig: theirCommitSig,
-		HtlcSigs:  htlcSigs,
+		ChanID:     l.ChanID(),
+		CommitSig:  newCommit.CommitSig,
+		HtlcSigs:   newCommit.HtlcSigs,
 	}
 	l.cfg.Peer.SendMessage(false, commitSig)
 

--- a/htlcswitch/link.go
+++ b/htlcswitch/link.go
@@ -741,7 +741,7 @@ func (l *channelLink) syncChanStates() error {
 			// very same nonce that we sent above, as they should
 			// take the latest verification nonce we send.
 			if chanState.ChanType.IsTaproot() {
-				fundingLockedMsg.NextLocalNonce = localChanSyncMsg.LocalNonce
+				fundingLockedMsg.NextLocalNonce = localChanSyncMsg.LocalNonce //nolint:lll
 			}
 
 			// For channels that negotiated the option-scid-alias

--- a/htlcswitch/link.go
+++ b/htlcswitch/link.go
@@ -698,7 +698,6 @@ func (l *channelLink) syncChanStates() error {
 		return fmt.Errorf("unable to generate chan sync message for "+
 			"ChannelPoint(%v)", l.channel.ChannelPoint())
 	}
-
 	if err := l.cfg.Peer.SendMessage(true, localChanSyncMsg); err != nil {
 		return fmt.Errorf("unable to send chan sync message for "+
 			"ChannelPoint(%v): %v", l.channel.ChannelPoint(), err)
@@ -737,6 +736,13 @@ func (l *channelLink) syncChanStates() error {
 			fundingLockedMsg := lnwire.NewFundingLocked(
 				l.ChanID(), nextRevocation,
 			)
+
+			// If this is a taproot channel, then we'll send the
+			// very same nonce that we sent above, as they should
+			// take the latest verification nonce we send.
+			if chanState.ChanType.IsTaproot() {
+				fundingLockedMsg.NextLocalNonce = localChanSyncMsg.LocalNonce
+			}
 
 			// For channels that negotiated the option-scid-alias
 			// feature bit, ensure that we send over the alias in
@@ -1930,8 +1936,8 @@ func (l *channelLink) handleUpstreamMsg(msg lnwire.Message) {
 		// chain, validate this new commitment, closing the link if
 		// invalid.
 		err = l.channel.ReceiveNewCommitment(&lnwallet.CommitSigs{
-			CommitSig:  msg.CommitSig,
-			HtlcSigs:   msg.HtlcSigs,
+			CommitSig: msg.CommitSig,
+			HtlcSigs:  msg.HtlcSigs,
 		})
 		if err != nil {
 			// If we were unable to reconstruct their proposed
@@ -2309,9 +2315,9 @@ func (l *channelLink) updateCommitTx() error {
 	}
 
 	commitSig := &lnwire.CommitSig{
-		ChanID:     l.ChanID(),
-		CommitSig:  newCommit.CommitSig,
-		HtlcSigs:   newCommit.HtlcSigs,
+		ChanID:    l.ChanID(),
+		CommitSig: newCommit.CommitSig,
+		HtlcSigs:  newCommit.HtlcSigs,
 	}
 	l.cfg.Peer.SendMessage(false, commitSig)
 

--- a/htlcswitch/link_isolated_test.go
+++ b/htlcswitch/link_isolated_test.go
@@ -93,14 +93,14 @@ func (l *linkTestContext) receiveHtlcAliceToBob() {
 func (l *linkTestContext) sendCommitSigBobToAlice(expHtlcs int) {
 	l.t.Helper()
 
-	sig, htlcSigs, _, err := l.bobChannel.SignNextCommitment()
+	sigs, err := l.bobChannel.SignNextCommitment()
 	if err != nil {
 		l.t.Fatalf("error signing commitment: %v", err)
 	}
 
 	commitSig := &lnwire.CommitSig{
-		CommitSig: sig,
-		HtlcSigs:  htlcSigs,
+		CommitSig: sigs.CommitSig,
+		HtlcSigs:  sigs.HtlcSigs,
 	}
 
 	if len(commitSig.HtlcSigs) != expHtlcs {
@@ -141,9 +141,10 @@ func (l *linkTestContext) receiveCommitSigAliceToBob(expHtlcs int) {
 
 	comSig := l.receiveCommitSigAlice(expHtlcs)
 
-	err := l.bobChannel.ReceiveNewCommitment(
-		comSig.CommitSig, comSig.HtlcSigs,
-	)
+	err := l.bobChannel.ReceiveNewCommitment(&lnwallet.CommitSigs{
+		CommitSig: comSig.CommitSig,
+		HtlcSigs:  comSig.HtlcSigs,
+	})
 	if err != nil {
 		l.t.Fatalf("bob failed receiving commitment: %v", err)
 	}

--- a/htlcswitch/link_test.go
+++ b/htlcswitch/link_test.go
@@ -1954,8 +1954,10 @@ func handleStateUpdate(link *channelLink,
 
 	// Let the remote channel receive the commit sig, and
 	// respond with a revocation + commitsig.
-	err := remoteChannel.ReceiveNewCommitment(
-		commitSig.CommitSig, commitSig.HtlcSigs)
+	err := remoteChannel.ReceiveNewCommitment(&lnwallet.CommitSigs{
+		CommitSig: commitSig.CommitSig,
+		HtlcSigs:  commitSig.HtlcSigs,
+	})
 	if err != nil {
 		return err
 	}
@@ -1966,13 +1968,13 @@ func handleStateUpdate(link *channelLink,
 	}
 	link.HandleChannelUpdate(remoteRev)
 
-	remoteSig, remoteHtlcSigs, _, err := remoteChannel.SignNextCommitment()
+	remoteSigs, err := remoteChannel.SignNextCommitment()
 	if err != nil {
 		return err
 	}
 	commitSig = &lnwire.CommitSig{
-		CommitSig: remoteSig,
-		HtlcSigs:  remoteHtlcSigs,
+		CommitSig: remoteSigs.CommitSig,
+		HtlcSigs:  remoteSigs.HtlcSigs,
 	}
 	link.HandleChannelUpdate(commitSig)
 
@@ -2017,14 +2019,14 @@ func updateState(batchTick chan time.Time, link *channelLink,
 
 	// The remote is triggering the state update, emulate this by
 	// signing and sending CommitSig to the link.
-	remoteSig, remoteHtlcSigs, _, err := remoteChannel.SignNextCommitment()
+	remoteSigs, err := remoteChannel.SignNextCommitment()
 	if err != nil {
 		return err
 	}
 
 	commitSig := &lnwire.CommitSig{
-		CommitSig: remoteSig,
-		HtlcSigs:  remoteHtlcSigs,
+		CommitSig: remoteSigs.CommitSig,
+		HtlcSigs:  remoteSigs.HtlcSigs,
 	}
 	link.HandleChannelUpdate(commitSig)
 
@@ -2057,8 +2059,10 @@ func updateState(batchTick chan time.Time, link *channelLink,
 		return fmt.Errorf("expected CommitSig, got %T", msg)
 	}
 
-	err = remoteChannel.ReceiveNewCommitment(
-		commitSig.CommitSig, commitSig.HtlcSigs)
+	err = remoteChannel.ReceiveNewCommitment(&lnwallet.CommitSigs{
+		CommitSig: commitSig.CommitSig,
+		HtlcSigs:  commitSig.HtlcSigs,
+	})
 	if err != nil {
 		return err
 	}
@@ -3131,7 +3135,10 @@ func TestChannelLinkTrimCircuitsRemoteCommit(t *testing.T) {
 			t.Fatalf("alice did not send commitment signature")
 		}
 
-		err := bobChan.ReceiveNewCommitment(sig.CommitSig, sig.HtlcSigs)
+		err := bobChan.ReceiveNewCommitment(&lnwallet.CommitSigs{
+			CommitSig: sig.CommitSig,
+			HtlcSigs:  sig.HtlcSigs,
+		})
 		if err != nil {
 			t.Fatalf("unable to receive new commitment: %v", err)
 		}
@@ -4719,9 +4726,10 @@ func TestChannelLinkNoEmptySig(t *testing.T) {
 	ctx.sendCommitSigBobToAlice(1)
 
 	// Now send Bob the signature from Alice covering both htlcs.
-	err = bobChannel.ReceiveNewCommitment(
-		commitSigAlice.CommitSig, commitSigAlice.HtlcSigs,
-	)
+	err = bobChannel.ReceiveNewCommitment(&lnwallet.CommitSigs{
+		CommitSig: commitSigAlice.CommitSig,
+		HtlcSigs:  commitSigAlice.HtlcSigs,
+	})
 	require.NoError(t, err, "bob failed receiving commitment")
 
 	// Both Alice and Bob revoke their previous commitment txes.
@@ -5323,8 +5331,7 @@ func TestChannelLinkFail(t *testing.T) {
 
 				// Sign a commitment that will include
 				// signature for the HTLC just sent.
-				sig, htlcSigs, _, err :=
-					remoteChannel.SignNextCommitment()
+				sigs, err := remoteChannel.SignNextCommitment()
 				if err != nil {
 					t.Fatalf("error signing commitment: %v",
 						err)
@@ -5333,8 +5340,8 @@ func TestChannelLinkFail(t *testing.T) {
 				// Remove the HTLC sig, such that the commit
 				// sig will be invalid.
 				commitSig := &lnwire.CommitSig{
-					CommitSig: sig,
-					HtlcSigs:  htlcSigs[1:],
+					CommitSig: sigs.CommitSig,
+					HtlcSigs:  sigs.HtlcSigs[1:],
 				}
 
 				c.HandleChannelUpdate(commitSig)
@@ -5365,8 +5372,7 @@ func TestChannelLinkFail(t *testing.T) {
 
 				// Sign a commitment that will include
 				// signature for the HTLC just sent.
-				sig, htlcSigs, _, err :=
-					remoteChannel.SignNextCommitment()
+				sigs, err := remoteChannel.SignNextCommitment()
 				if err != nil {
 					t.Fatalf("error signing commitment: %v",
 						err)
@@ -5374,7 +5380,7 @@ func TestChannelLinkFail(t *testing.T) {
 
 				// Flip a bit on the signature, rendering it
 				// invalid.
-				sigCopy := sig.Copy()
+				sigCopy := sigs.CommitSig.Copy()
 				copyBytes := sigCopy.RawBytes()
 				copyBytes[19] ^= 1
 				modifiedSig, err := lnwire.NewSigFromWireECDSA(
@@ -5383,7 +5389,7 @@ func TestChannelLinkFail(t *testing.T) {
 				require.NoError(t, err)
 				commitSig := &lnwire.CommitSig{
 					CommitSig: modifiedSig,
-					HtlcSigs:  htlcSigs,
+					HtlcSigs:  sigs.HtlcSigs,
 				}
 
 				c.HandleChannelUpdate(commitSig)

--- a/input/musig2_session_manager.go
+++ b/input/musig2_session_manager.go
@@ -78,7 +78,7 @@ func (m *MusigSessionManager) MuSig2CreateSession(bipVersion MuSig2Version,
 	// Create a signing context and session with the given private key and
 	// list of all known signer public keys.
 	musigContext, musigSession, err := MuSig2CreateContext(
-		bipVersion, privKey, allSignerPubKeys, tweaks,
+		bipVersion, privKey, allSignerPubKeys, tweaks, sessionOpts...,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("error creating signing context: %w",

--- a/lnwallet/chancloser/chancloser.go
+++ b/lnwallet/chancloser/chancloser.go
@@ -4,9 +4,9 @@ import (
 	"bytes"
 	"fmt"
 
+	"github.com/btcsuite/btcd/btcec/v2/schnorr/musig2"
 	"github.com/btcsuite/btcd/btcutil"
 	"github.com/btcsuite/btcd/chaincfg"
-	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcd/txscript"
 	"github.com/btcsuite/btcd/wire"
 	"github.com/davecgh/go-spew/spew"
@@ -94,74 +94,15 @@ const (
 	defaultMaxFeeMultiplier = 3
 )
 
-// Channel abstracts away from the core channel state machine by exposing an
-// interface that requires only the methods we need to carry out the channel
-// closing process.
-type Channel interface {
-	// ChannelPoint returns the channel point of the target channel.
-	ChannelPoint() *wire.OutPoint
-
-	// MarkCoopBroadcasted persistently marks that the channel close
-	// transaction has been broadcast.
-	MarkCoopBroadcasted(*wire.MsgTx, bool) error
-
-	// IsInitiator returns true we are the initiator of the channel.
-	IsInitiator() bool
-
-	// ShortChanID returns the scid of the channel.
-	ShortChanID() lnwire.ShortChannelID
-
-	// AbsoluteThawHeight returns the absolute thaw height of the channel.
-	// If the channel is pending, or an unconfirmed zero conf channel, then
-	// an error should be returned.
-	AbsoluteThawHeight() (uint32, error)
-
-	// LocalBalanceDust returns true if when creating a co-op close
-	// transaction, the balance of the local party will be dust after
-	// accounting for any anchor outputs.
-	LocalBalanceDust() bool
-
-	// RemoteBalanceDust returns true if when creating a co-op close
-	// transaction, the balance of the remote party will be dust after
-	// accounting for any anchor outputs.
-	RemoteBalanceDust() bool
-
-	// RemoteUpfrontShutdownScript returns the upfront shutdown script of
-	// the remote party. If the remote party didn't specify such a script,
-	// an empty delivery address should be returned.
-	RemoteUpfrontShutdownScript() lnwire.DeliveryAddress
-
-	// CreateCloseProposal creates a new co-op close proposal in the form
-	// of a valid signature, the chainhash of the final txid, and our final
-	// balance in the created state.
-	CreateCloseProposal(proposedFee btcutil.Amount, localDeliveryScript []byte,
-		remoteDeliveryScript []byte) (input.Signature, *chainhash.Hash,
-		btcutil.Amount, error)
-
-	// CompleteCooperativeClose persistently "completes" the cooperative
-	// close by producing a fully signed co-op close transaction.
-	CompleteCooperativeClose(localSig, remoteSig input.Signature,
-		localDeliveryScript, remoteDeliveryScript []byte,
-		proposedFee btcutil.Amount) (*wire.MsgTx, btcutil.Amount, error)
-}
-
-// CoopFeeEstimator is used to estimate the fee of a co-op close transaction.
-type CoopFeeEstimator interface {
-	// EstimateFee estimates an _absolute_ fee for a co-op close transaction
-	// given the local+remote tx outs (for the co-op close transaction),
-	// channel type, and ideal fee rate. If a passed TxOut is nil, then
-	// that indicates that an output is dust on the co-op close transaction
-	// _before_ fees are accounted for.
-	EstimateFee(chanType channeldb.ChannelType,
-		localTxOut, remoteTxOut *wire.TxOut,
-		idealFeeRate chainfee.SatPerKWeight) btcutil.Amount
-}
-
 // ChanCloseCfg holds all the items that a ChanCloser requires to carry out its
 // duties.
 type ChanCloseCfg struct {
 	// Channel is the channel that should be closed.
 	Channel Channel
+
+	// MusigSession is used to handle generating musig2 nonces, and also
+	// creating the proper set of closing options for taproot channels.
+	MusigSession MusigSession
 
 	// BroadcastTx broadcasts the passed transaction to the network.
 	BroadcastTx func(*wire.MsgTx, string) error
@@ -367,19 +308,35 @@ func (c *ChanCloser) initChanShutdown() (*lnwire.Shutdown, error) {
 	// closing script.
 	shutdown := lnwire.NewShutdown(c.cid, c.localDeliveryScript)
 
-	// Before closing, we'll attempt to send a disable update for the channel.
-	// We do so before closing the channel as otherwise the current edge policy
-	// won't be retrievable from the graph.
+	// If this is a taproot channel, then we'll need to also generate a
+	// nonce that'll be used sign the co-op close transaction offer.
+	if c.cfg.Channel.ChanType().IsTaproot() {
+		firstClosingNonce, err := c.cfg.MusigSession.ClosingNonce()
+		if err != nil {
+			return nil, err
+		}
+
+		shutdown.ShutdownNonce = (*lnwire.ShutdownNonce)(
+			&firstClosingNonce.PubNonce,
+		)
+
+		chancloserLog.Infof("Initiating shutdown w/ nonce: %v",
+			spew.Sdump(firstClosingNonce.PubNonce))
+	}
+
+	// Before closing, we'll attempt to send a disable update for the
+	// channel.  We do so before closing the channel as otherwise the
+	// current edge policy won't be retrievable from the graph.
 	if err := c.cfg.DisableChannel(c.chanPoint); err != nil {
 		chancloserLog.Warnf("Unable to disable channel %v on close: %v",
 			c.chanPoint, err)
 	}
 
-	// Before continuing, mark the channel as cooperatively closed with a nil
-	// txn. Even though we haven't negotiated the final txn, this guarantees
-	// that our listchannels rpc will be externally consistent, and reflect
-	// that the channel is being shutdown by the time the closing request
-	// returns.
+	// Before continuing, mark the channel as cooperatively closed with a
+	// nil txn. Even though we haven't negotiated the final txn, this
+	// guarantees that our listchannels rpc will be externally consistent,
+	// and reflect that the channel is being shutdown by the time the
+	// closing request returns.
 	err := c.cfg.Channel.MarkCoopBroadcasted(nil, c.locallyInitiated)
 	if err != nil {
 		return nil, err
@@ -448,6 +405,7 @@ func (c *ChanCloser) CloseRequest() *htlcswitch.ChanClose {
 // NOTE: This method will PANIC if the underlying channel implementation isn't
 // the desired type.
 func (c *ChanCloser) Channel() *lnwallet.LightningChannel {
+	// TODO(roasbeef): remove this
 	return c.cfg.Channel.(*lnwallet.LightningChannel)
 }
 
@@ -522,8 +480,9 @@ func (c *ChanCloser) ProcessCloseMsg(msg lnwire.Message) ([]lnwire.Message,
 		// as otherwise, this is an attempted invalid state transition.
 		shutdownMsg, ok := msg.(*lnwire.Shutdown)
 		if !ok {
-			return nil, false, fmt.Errorf("expected lnwire.Shutdown, instead "+
-				"have %v", spew.Sdump(msg))
+			return nil, false, fmt.Errorf("expected "+
+				"lnwire.Shutdown, instead have %v",
+				spew.Sdump(msg))
 		}
 
 		// As we're the responder to this shutdown (the other party
@@ -571,6 +530,20 @@ func (c *ChanCloser) ProcessCloseMsg(msg lnwire.Message) ([]lnwire.Message,
 			return nil, false, err
 		}
 
+		// If this is a taproot channel, then we'll want to stash the
+		// remote nonces so we can properly create a new musig
+		// session for signing.
+		if c.cfg.Channel.ChanType().IsTaproot() {
+			if shutdownMsg.ShutdownNonce == nil {
+				return nil, false, fmt.Errorf("shutdown " +
+					"nonce not populated")
+			}
+
+			c.cfg.MusigSession.InitRemoteNonce(&musig2.Nonces{
+				PubNonce: *shutdownMsg.ShutdownNonce,
+			})
+		}
+
 		chancloserLog.Infof("ChannelPoint(%v): responding to shutdown",
 			c.chanPoint)
 
@@ -588,7 +561,8 @@ func (c *ChanCloser) ProcessCloseMsg(msg lnwire.Message) ([]lnwire.Message,
 		if chanInitiator {
 			closeSigned, err := c.proposeCloseSigned(c.idealFeeSat)
 			if err != nil {
-				return nil, false, err
+				return nil, false, fmt.Errorf("unable to sign "+
+					"new co op close offer: %w", err)
 			}
 			msgsToSend = append(msgsToSend, closeSigned)
 		}
@@ -628,9 +602,23 @@ func (c *ChanCloser) ProcessCloseMsg(msg lnwire.Message) ([]lnwire.Message,
 		// closing transaction should look like.
 		c.state = closeFeeNegotiation
 
-		// Now that we know their desried delivery script, we can
+		// Now that we know their desired delivery script, we can
 		// compute what our max/ideal fee will be.
 		c.initFeeBaseline()
+
+		// If this is a taproot channel, then we'll want to stash the
+		// local+remote nonces so we can properly create a new musig
+		// session for signing.
+		if c.cfg.Channel.ChanType().IsTaproot() {
+			if shutdownMsg.ShutdownNonce == nil {
+				return nil, false, fmt.Errorf("shutdown " +
+					"nonce not populated")
+			}
+
+			c.cfg.MusigSession.InitRemoteNonce(&musig2.Nonces{
+				PubNonce: *shutdownMsg.ShutdownNonce,
+			})
+		}
 
 		chancloserLog.Infof("ChannelPoint(%v): shutdown response received, "+
 			"entering fee negotiation", c.chanPoint)
@@ -641,7 +629,8 @@ func (c *ChanCloser) ProcessCloseMsg(msg lnwire.Message) ([]lnwire.Message,
 		if c.cfg.Channel.IsInitiator() {
 			closeSigned, err := c.proposeCloseSigned(c.idealFeeSat)
 			if err != nil {
-				return nil, false, err
+				return nil, false, fmt.Errorf("unable to sign "+
+					"new co op close offer: %w", err)
 			}
 
 			return []lnwire.Message{closeSigned}, false, nil
@@ -661,14 +650,68 @@ func (c *ChanCloser) ProcessCloseMsg(msg lnwire.Message) ([]lnwire.Message,
 				"instead have %v", spew.Sdump(msg))
 		}
 
-		// We'll compare the proposed total fee, to what we've proposed during
-		// the negotiations. If it doesn't match any of our prior offers, then
-		// we'll attempt to ratchet the fee closer to
+		// If this is a taproot channel, then it MUST have a partial
+		// signature set at this point.
+		isTaproot := c.cfg.Channel.ChanType().IsTaproot()
+		if isTaproot && closeSignedMsg.PartialSig == nil {
+			return nil, false, fmt.Errorf("partial sig not set " +
+				"for taproot chan")
+		}
+
+		isInitiator := c.cfg.Channel.IsInitiator()
+
+		// We'll compare the proposed total fee, to what we've proposed
+		// during the negotiations. If it doesn't match any of our
+		// prior offers, then we'll attempt to ratchet the fee closer
+		// to our ideal fee.
 		remoteProposedFee := closeSignedMsg.FeeSatoshis
-		if _, ok := c.priorFeeOffers[remoteProposedFee]; !ok {
-			// We'll now attempt to ratchet towards a fee deemed acceptable by
-			// both parties, factoring in our ideal fee rate, and the last
-			// proposed fee by both sides.
+
+		_, feeMatchesOffer := c.priorFeeOffers[remoteProposedFee]
+		switch {
+		// For taproot channels, since nonces are involved, we can't do
+		// the existing co-op close negotiation process without going
+		// to a fully round based model. Rather than do this, we'll
+		// just accept the very first offer by the initiator.
+		case isTaproot && !isInitiator:
+			chancloserLog.Infof("ChannelPoint(%v) accepting "+
+				"initiator fee of %v", c.chanPoint,
+				remoteProposedFee)
+
+			// To auto-accept the initiators proposal, we'll just
+			// send back a signature w/ the same offer. We don't
+			// send the message here, as we can drop down and
+			// finalize the closure and broadcast, then echo back
+			// to Alice the final signature.
+			_, err := c.proposeCloseSigned(remoteProposedFee)
+			if err != nil {
+				return nil, false, fmt.Errorf("unable to sign "+
+					"new co op close offer: %w", err)
+			}
+
+			break
+
+		// Otherwise, if we are the initiator, and we just sent a
+		// signature for a taproot channel, then we'll ensure that the
+		// fee rate matches up exactly.
+		case isTaproot && isInitiator && !feeMatchesOffer:
+			return nil, false, fmt.Errorf("fee rate for "+
+				"taproot channels was not accepted: "+
+				"sent %v, got %v",
+				c.idealFeeSat, remoteProposedFee)
+
+		// If we're the initiator of the taproot channel, and we had
+		// our fee echo'd back, then it's all good, and we can proceed
+		// with final broadcast.
+		case isTaproot && isInitiator && feeMatchesOffer:
+			break
+
+		// Otherwise, if this is a normal segwit v0 channel, and the
+		// fee doesn't match our offer, then we'll try to "negotiate" a
+		// new fee.
+		case !feeMatchesOffer:
+			// We'll now attempt to ratchet towards a fee deemed
+			// acceptable by both parties, factoring in our ideal
+			// fee rate, and the last proposed fee by both sides.
 			feeProposal := calcCompromiseFee(c.chanPoint, c.idealFeeSat,
 				c.lastFeeProposal, remoteProposedFee,
 			)
@@ -678,17 +721,19 @@ func (c *ChanCloser) ProcessCloseMsg(msg lnwire.Message) ([]lnwire.Message,
 					c.maxFee)
 			}
 
-			// With our new fee proposal calculated, we'll craft a new close
-			// signed signature to send to the other party so we can continue
-			// the fee negotiation process.
+			// With our new fee proposal calculated, we'll craft a
+			// new close signed signature to send to the other
+			// party so we can continue the fee negotiation
+			// process.
 			closeSigned, err := c.proposeCloseSigned(feeProposal)
 			if err != nil {
-				return nil, false, err
+				return nil, false, fmt.Errorf("unable to sign "+
+					"new co op close offer: %w", err)
 			}
 
-			// If the compromise fee doesn't match what the peer proposed, then
-			// we'll return this latest close signed message so we can continue
-			// negotiation.
+			// If the compromise fee doesn't match what the peer
+			// proposed, then we'll return this latest close signed
+			// message so we can continue negotiation.
 			if feeProposal != remoteProposedFee {
 				chancloserLog.Debugf("ChannelPoint(%v): close tx fee "+
 					"disagreement, continuing negotiation", c.chanPoint)
@@ -699,38 +744,56 @@ func (c *ChanCloser) ProcessCloseMsg(msg lnwire.Message) ([]lnwire.Message,
 		chancloserLog.Infof("ChannelPoint(%v) fee of %v accepted, ending "+
 			"negotiation", c.chanPoint, remoteProposedFee)
 
-		// Otherwise, we've agreed on a fee for the closing transaction! We'll
-		// craft the final closing transaction so we can broadcast it to the
-		// network.
-		matchingSig := c.priorFeeOffers[remoteProposedFee].Signature
-		localSig, err := matchingSig.ToSignature()
-		if err != nil {
-			return nil, false, err
-		}
-
-		remoteSig, err := closeSignedMsg.Signature.ToSignature()
-		if err != nil {
-			return nil, false, err
+		// Otherwise, we've agreed on a fee for the closing
+		// transaction! We'll craft the final closing transaction so we
+		// can broadcast it to the network.
+		var (
+			localSig, remoteSig input.Signature
+			closeOpts           []lnwallet.ChanCloseOpt
+			err                 error
+		)
+		matchingSig := c.priorFeeOffers[remoteProposedFee]
+		if c.cfg.Channel.ChanType().IsTaproot() {
+			muSession := c.cfg.MusigSession
+			localSig, remoteSig, closeOpts, err = muSession.CombineClosingOpts( //nolint:ll
+				*matchingSig.PartialSig,
+				*closeSignedMsg.PartialSig,
+			)
+			if err != nil {
+				return nil, false, err
+			}
+		} else {
+			localSig, err = matchingSig.Signature.ToSignature()
+			if err != nil {
+				return nil, false, err
+			}
+			remoteSig, err = closeSignedMsg.Signature.ToSignature()
+			if err != nil {
+				return nil, false, err
+			}
 		}
 
 		closeTx, _, err := c.cfg.Channel.CompleteCooperativeClose(
-			localSig, remoteSig, c.localDeliveryScript, c.remoteDeliveryScript,
-			remoteProposedFee,
+			localSig, remoteSig, c.localDeliveryScript,
+			c.remoteDeliveryScript, remoteProposedFee, closeOpts...,
 		)
 		if err != nil {
 			return nil, false, err
 		}
 		c.closingTx = closeTx
 
-		// Before publishing the closing tx, we persist it to the database,
-		// such that it can be republished if something goes wrong.
-		err = c.cfg.Channel.MarkCoopBroadcasted(closeTx, c.locallyInitiated)
+		// Before publishing the closing tx, we persist it to the
+		// database, such that it can be republished if something goes
+		// wrong.
+		err = c.cfg.Channel.MarkCoopBroadcasted(
+			closeTx, c.locallyInitiated,
+		)
 		if err != nil {
 			return nil, false, err
 		}
 
-		// With the closing transaction crafted, we'll now broadcast it to the
-		// network.
+		// With the closing transaction crafted, we'll now broadcast it
+		// to the network.
 		chancloserLog.Infof("Broadcasting cooperative close tx: %v",
 			newLogClosure(func() string {
 				return spew.Sdump(closeTx)
@@ -747,10 +810,11 @@ func (c *ChanCloser) ProcessCloseMsg(msg lnwire.Message) ([]lnwire.Message,
 			return nil, false, err
 		}
 
-		// Finally, we'll transition to the closeFinished state, and also
-		// return the final close signed message we sent. Additionally, we
-		// return true for the second argument to indicate we're finished with
-		// the channel closing negotiation.
+		// Finally, we'll transition to the closeFinished state, and
+		// also return the final close signed message we sent.
+		// Additionally, we return true for the second argument to
+		// indicate we're finished with the channel closing
+		// negotiation.
 		c.state = closeFinished
 		matchingOffer := c.priorFeeOffers[remoteProposedFee]
 		return []lnwire.Message{matchingOffer}, true, nil
@@ -778,8 +842,23 @@ func (c *ChanCloser) ProcessCloseMsg(msg lnwire.Message) ([]lnwire.Message,
 // transaction for a channel based on the prior fee negotiations and our current
 // compromise fee.
 func (c *ChanCloser) proposeCloseSigned(fee btcutil.Amount) (*lnwire.ClosingSigned, error) {
+	var (
+		closeOpts []lnwallet.ChanCloseOpt
+		err       error
+	)
+
+	// If this is a taproot channel, then we'll include the musig session
+	// generated for the next co-op close negotiation round.
+	if c.cfg.Channel.ChanType().IsTaproot() {
+		closeOpts, err = c.cfg.MusigSession.ProposalClosingOpts()
+		if err != nil {
+			return nil, err
+		}
+	}
+
 	rawSig, _, _, err := c.cfg.Channel.CreateCloseProposal(
 		fee, c.localDeliveryScript, c.remoteDeliveryScript,
+		closeOpts...,
 	)
 	if err != nil {
 		return nil, err
@@ -788,20 +867,41 @@ func (c *ChanCloser) proposeCloseSigned(fee btcutil.Amount) (*lnwire.ClosingSign
 	// We'll note our last signature and proposed fee so when the remote
 	// party responds we'll be able to decide if we've agreed on fees or
 	// not.
-	c.lastFeeProposal = fee
+	var (
+		parsedSig  lnwire.Sig
+		partialSig *lnwire.PartialSigWithNonce
+	)
+	if c.cfg.Channel.ChanType().IsTaproot() {
+		musig, ok := rawSig.(*lnwallet.MusigPartialSig)
+		if !ok {
+			return nil, fmt.Errorf("expected MusigPartialSig, "+
+				"got %T", rawSig)
+		}
 
-	parsedSig, err := lnwire.NewSigFromSignature(rawSig)
-	if err != nil {
-		return nil, err
+		partialSig = musig.ToWireSig()
+	} else {
+		parsedSig, err = lnwire.NewSigFromSignature(rawSig)
+		if err != nil {
+			return nil, err
+		}
 	}
+
+	c.lastFeeProposal = fee
 
 	chancloserLog.Infof("ChannelPoint(%v): proposing fee of %v sat to "+
 		"close chan", c.chanPoint, int64(fee))
 
-	// We'll assemble a ClosingSigned message using this information and return
-	// it to the caller so we can kick off the final stage of the channel
-	// closure process.
+	// We'll assemble a ClosingSigned message using this information and
+	// return it to the caller so we can kick off the final stage of the
+	// channel closure process.
 	closeSignedMsg := lnwire.NewClosingSigned(c.cid, fee, parsedSig)
+
+	// For musig2 channels, the main sig is blank, and instead we'll send
+	// over a partial signature which'll be combine donce our offer is
+	// accepted.
+	if partialSig != nil {
+		closeSignedMsg.PartialSig = &partialSig.PartialSig
+	}
 
 	// We'll also save this close signed, in the case that the remote party
 	// accepts our offer. This way, we don't have to re-sign.

--- a/lnwallet/chancloser/chancloser.go
+++ b/lnwallet/chancloser/chancloser.go
@@ -688,8 +688,6 @@ func (c *ChanCloser) ProcessCloseMsg(msg lnwire.Message) ([]lnwire.Message,
 					"new co op close offer: %w", err)
 			}
 
-			break
-
 		// Otherwise, if we are the initiator, and we just sent a
 		// signature for a taproot channel, then we'll ensure that the
 		// fee rate matches up exactly.
@@ -755,7 +753,7 @@ func (c *ChanCloser) ProcessCloseMsg(msg lnwire.Message) ([]lnwire.Message,
 		matchingSig := c.priorFeeOffers[remoteProposedFee]
 		if c.cfg.Channel.ChanType().IsTaproot() {
 			muSession := c.cfg.MusigSession
-			localSig, remoteSig, closeOpts, err = muSession.CombineClosingOpts( //nolint:ll
+			localSig, remoteSig, closeOpts, err = muSession.CombineClosingOpts( //nolint:lll
 				*matchingSig.PartialSig,
 				*closeSignedMsg.PartialSig,
 			)

--- a/lnwallet/chancloser/chancloser_test.go
+++ b/lnwallet/chancloser/chancloser_test.go
@@ -4,7 +4,10 @@ import (
 	"bytes"
 	"fmt"
 	"testing"
+	"time"
 
+	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/btcsuite/btcd/btcec/v2/schnorr/musig2"
 	"github.com/btcsuite/btcd/btcutil"
 	"github.com/btcsuite/btcd/chaincfg"
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
@@ -12,6 +15,9 @@ import (
 	"github.com/btcsuite/btcd/wire"
 	"github.com/lightningnetwork/lnd/channeldb"
 	"github.com/lightningnetwork/lnd/input"
+	"github.com/lightningnetwork/lnd/keychain"
+	"github.com/lightningnetwork/lnd/lnutils"
+	"github.com/lightningnetwork/lnd/lnwallet"
 	"github.com/lightningnetwork/lnd/lnwallet/chainfee"
 	"github.com/lightningnetwork/lnd/lnwire"
 	"github.com/stretchr/testify/require"
@@ -135,6 +141,9 @@ type mockChannel struct {
 	chanPoint wire.OutPoint
 	initiator bool
 	scid      lnwire.ShortChannelID
+	chanType  channeldb.ChannelType
+	localKey  keychain.KeyDescriptor
+	remoteKey keychain.KeyDescriptor
 }
 
 func (m *mockChannel) ChannelPoint() *wire.OutPoint {
@@ -162,15 +171,26 @@ func (m *mockChannel) RemoteUpfrontShutdownScript() lnwire.DeliveryAddress {
 }
 
 func (m *mockChannel) CreateCloseProposal(fee btcutil.Amount,
-	localScript, remoteScript []byte,
+	localScript, remoteScript []byte, _ ...lnwallet.ChanCloseOpt,
 ) (input.Signature, *chainhash.Hash, btcutil.Amount, error) {
+
+	if m.chanType.IsTaproot() {
+		return lnwallet.NewMusigPartialSig(
+			&musig2.PartialSignature{
+				S: new(btcec.ModNScalar),
+				R: new(btcec.PublicKey),
+			},
+			lnwire.Musig2Nonce{}, lnwire.Musig2Nonce{}, nil,
+		), nil, 0, nil
+	}
 
 	return nil, nil, 0, nil
 }
 
 func (m *mockChannel) CompleteCooperativeClose(localSig,
 	remoteSig input.Signature, localScript, remoteScript []byte,
-	proposedFee btcutil.Amount) (*wire.MsgTx, btcutil.Amount, error) {
+	proposedFee btcutil.Amount,
+	_ ...lnwallet.ChanCloseOpt) (*wire.MsgTx, btcutil.Amount, error) {
 
 	return nil, 0, nil
 }
@@ -181,6 +201,73 @@ func (m *mockChannel) LocalBalanceDust() bool {
 
 func (m *mockChannel) RemoteBalanceDust() bool {
 	return false
+}
+
+func (m *mockChannel) ChanType() channeldb.ChannelType {
+	return m.chanType
+}
+
+func (m *mockChannel) FundingTxOut() *wire.TxOut {
+	return nil
+}
+
+func (m *mockChannel) MultiSigKeys() (keychain.KeyDescriptor, keychain.KeyDescriptor) {
+	return m.localKey, m.remoteKey
+}
+
+func newMockTaprootChan(t *testing.T, initiator bool) *mockChannel {
+	taprootBits := channeldb.SimpleTaprootFeatureBit |
+		channeldb.AnchorOutputsBit |
+		channeldb.ZeroHtlcTxFeeBit |
+		channeldb.SingleFunderTweaklessBit
+
+	localKey, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	remoteKey, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	return &mockChannel{
+		chanPoint: wire.OutPoint{
+			Hash:  chainhash.Hash{},
+			Index: 0,
+		},
+		initiator: initiator,
+		chanType:  taprootBits,
+		localKey: keychain.KeyDescriptor{
+			PubKey: localKey.PubKey(),
+		},
+		remoteKey: keychain.KeyDescriptor{
+			PubKey: remoteKey.PubKey(),
+		},
+	}
+}
+
+type mockMusigSession struct {
+}
+
+func newMockMusigSession() *mockMusigSession {
+	return &mockMusigSession{}
+}
+
+func (m *mockMusigSession) ProposalClosingOpts() ([]lnwallet.ChanCloseOpt, error) {
+	return nil, nil
+}
+
+func (m *mockMusigSession) CombineClosingOpts(localSig,
+	remoteSig lnwire.PartialSig,
+) (input.Signature, input.Signature, []lnwallet.ChanCloseOpt, error) {
+
+	return &lnwallet.MusigPartialSig{}, &lnwallet.MusigPartialSig{}, nil,
+		nil
+}
+
+func (m *mockMusigSession) ClosingNonce() (*musig2.Nonces, error) {
+	return &musig2.Nonces{}, nil
+}
+
+func (m *mockMusigSession) InitRemoteNonce(nonce *musig2.Nonces) {
+	return
 }
 
 type mockCoopFeeEstimator struct {
@@ -376,4 +463,131 @@ func TestParseUpfrontShutdownAddress(t *testing.T) {
 			require.NoError(t, err)
 		})
 	}
+}
+
+func assertType[T any](t *testing.T, typ any) T {
+	value, ok := typ.(T)
+	require.True(t, ok)
+
+	return value
+}
+
+// TestTaprootFastClose tests that we are able to properly execute a fast close
+// (skip negotiation) for taproot channels.
+func TestTaprootFastClose(t *testing.T) {
+	t.Parallel()
+
+	aliceChan := newMockTaprootChan(t, true)
+	bobChan := newMockTaprootChan(t, false)
+
+	broadcastSignal := make(chan struct{}, 2)
+
+	idealFee := chainfee.SatPerKWeight(506)
+
+	// Next, we'll make a channel for Alice and Bob, with Alice being the
+	// initiator.
+	aliceCloser := NewChanCloser(
+		ChanCloseCfg{
+			Channel:      aliceChan,
+			MusigSession: newMockMusigSession(),
+			BroadcastTx: func(_ *wire.MsgTx, _ string) error {
+				broadcastSignal <- struct{}{}
+				return nil
+			},
+			MaxFee:       chainfee.SatPerKWeight(1000),
+			FeeEstimator: &SimpleCoopFeeEstimator{},
+			DisableChannel: func(wire.OutPoint) error {
+				return nil
+			},
+		}, nil, idealFee, 0, nil, true,
+	)
+	aliceCloser.initFeeBaseline()
+
+	bobCloser := NewChanCloser(
+		ChanCloseCfg{
+			Channel:      bobChan,
+			MusigSession: newMockMusigSession(),
+			MaxFee:       chainfee.SatPerKWeight(1000),
+			BroadcastTx: func(_ *wire.MsgTx, _ string) error {
+				broadcastSignal <- struct{}{}
+				return nil
+			},
+			FeeEstimator: &SimpleCoopFeeEstimator{},
+			DisableChannel: func(wire.OutPoint) error {
+				return nil
+			},
+		}, nil, idealFee, 0, nil, false,
+	)
+	bobCloser.initFeeBaseline()
+
+	// With our set up complete, we'll now initialize the shutdown
+	// procedure kicked off by Alice.
+	msg, err := aliceCloser.ShutdownChan()
+	require.NoError(t, err)
+	require.NotNil(t, msg)
+
+	// Bob will then process this message. As he's the responder, he should
+	// only send the shutdown message back to Alice.
+	bobMsgs, closeFinished, err := bobCloser.ProcessCloseMsg(msg)
+	require.NoError(t, err)
+	require.False(t, closeFinished)
+	require.Len(t, bobMsgs, 1)
+	require.IsType(t, &lnwire.Shutdown{}, bobMsgs[0])
+
+	// Alice should process the shutdown message, and create a closing
+	// signed of her own.
+	aliceMsgs, closeFinished, err := aliceCloser.ProcessCloseMsg(bobMsgs[0])
+	require.NoError(t, err)
+	require.False(t, closeFinished)
+	require.Len(t, aliceMsgs, 1)
+	require.IsType(t, &lnwire.ClosingSigned{}, aliceMsgs[0])
+
+	// Next, Bob will process the closing signed message, and send back a
+	// new one that should match exactly the offer Alice sent.
+	bobMsgs, closeFinished, err = bobCloser.ProcessCloseMsg(aliceMsgs[0])
+	require.NoError(t, err)
+	require.True(t, closeFinished)
+	require.Len(t, aliceMsgs, 1)
+	require.IsType(t, &lnwire.ClosingSigned{}, bobMsgs[0])
+
+	// At this point, Bob has accepted the offer, so he can broadcast the
+	// closing transaction, and considers the channel closed.
+	_, err = lnutils.RecvOrTimeout(broadcastSignal, time.Second*1)
+	require.NoError(t, err)
+
+	// Bob's fee proposal should exactly match Alice's initial fee.
+	aliceOffer := assertType[*lnwire.ClosingSigned](t, aliceMsgs[0])
+	bobOffer := assertType[*lnwire.ClosingSigned](t, bobMsgs[0])
+	require.Equal(t, aliceOffer.FeeSatoshis, bobOffer.FeeSatoshis)
+
+	// If we modify Bob's offer, and try to have Alice process it, then she
+	// should reject it.
+	ogOffer := bobOffer.FeeSatoshis
+	bobOffer.FeeSatoshis /= 2
+
+	aliceMsgs, _, err = aliceCloser.ProcessCloseMsg(bobOffer)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "was not accepted")
+
+	// We'll now restore the original offer before passing it on to Alice.
+	bobOffer.FeeSatoshis = ogOffer
+
+	// If we use the original offer, then Alice should accept this message,
+	// and finalize the shutdown process. We expect a message here as Alice
+	// will echo back the final message.
+	aliceMsgs, closeFinished, err = aliceCloser.ProcessCloseMsg(bobMsgs[0])
+	require.NoError(t, err)
+	require.True(t, closeFinished)
+	require.Len(t, aliceMsgs, 1)
+	require.IsType(t, &lnwire.ClosingSigned{}, aliceMsgs[0])
+
+	// Alice should now also broadcast her closing transaction.
+	_, err = lnutils.RecvOrTimeout(broadcastSignal, time.Second*1)
+	require.NoError(t, err)
+
+	// Finally, Bob will process Alice's echo message, and conclude.
+	bobMsgs, closeFinished, err = bobCloser.ProcessCloseMsg(aliceMsgs[0])
+	require.NoError(t, err)
+	require.True(t, closeFinished)
+	require.Len(t, bobMsgs, 0)
 }

--- a/lnwallet/chancloser/chancloser_test.go
+++ b/lnwallet/chancloser/chancloser_test.go
@@ -211,7 +211,9 @@ func (m *mockChannel) FundingTxOut() *wire.TxOut {
 	return nil
 }
 
-func (m *mockChannel) MultiSigKeys() (keychain.KeyDescriptor, keychain.KeyDescriptor) {
+func (m *mockChannel) MultiSigKeys() (
+	keychain.KeyDescriptor, keychain.KeyDescriptor) {
+
 	return m.localKey, m.remoteKey
 }
 
@@ -250,7 +252,9 @@ func newMockMusigSession() *mockMusigSession {
 	return &mockMusigSession{}
 }
 
-func (m *mockMusigSession) ProposalClosingOpts() ([]lnwallet.ChanCloseOpt, error) {
+func (m *mockMusigSession) ProposalClosingOpts() ([]lnwallet.ChanCloseOpt,
+	error) {
+
 	return nil, nil
 }
 
@@ -267,7 +271,6 @@ func (m *mockMusigSession) ClosingNonce() (*musig2.Nonces, error) {
 }
 
 func (m *mockMusigSession) InitRemoteNonce(nonce *musig2.Nonces) {
-	return
 }
 
 type mockCoopFeeEstimator struct {
@@ -565,7 +568,7 @@ func TestTaprootFastClose(t *testing.T) {
 	ogOffer := bobOffer.FeeSatoshis
 	bobOffer.FeeSatoshis /= 2
 
-	aliceMsgs, _, err = aliceCloser.ProcessCloseMsg(bobOffer)
+	_, _, err = aliceCloser.ProcessCloseMsg(bobOffer)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "was not accepted")
 

--- a/lnwallet/chancloser/interface.go
+++ b/lnwallet/chancloser/interface.go
@@ -1,0 +1,109 @@
+package chancloser
+
+import (
+	"github.com/btcsuite/btcd/btcec/v2/schnorr/musig2"
+	"github.com/btcsuite/btcd/btcutil"
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"github.com/btcsuite/btcd/wire"
+	"github.com/lightningnetwork/lnd/channeldb"
+	"github.com/lightningnetwork/lnd/input"
+	"github.com/lightningnetwork/lnd/lnwallet"
+	"github.com/lightningnetwork/lnd/lnwallet/chainfee"
+	"github.com/lightningnetwork/lnd/lnwire"
+)
+
+// CoopFeeEstimator is used to estimate the fee of a co-op close transaction.
+type CoopFeeEstimator interface {
+	// EstimateFee estimates an _absolute_ fee for a co-op close transaction
+	// given the local+remote tx outs (for the co-op close transaction),
+	// channel type, and ideal fee rate. If a passed TxOut is nil, then
+	// that indicates that an output is dust on the co-op close transaction
+	// _before_ fees are accounted for.
+	EstimateFee(chanType channeldb.ChannelType,
+		localTxOut, remoteTxOut *wire.TxOut,
+		idealFeeRate chainfee.SatPerKWeight) btcutil.Amount
+}
+
+// Channel abstracts away from the core channel state machine by exposing an
+// interface that requires only the methods we need to carry out the channel
+// closing process.
+type Channel interface {
+	// ChannelPoint returns the channel point of the target channel.
+	ChannelPoint() *wire.OutPoint
+
+	// MarkCoopBroadcasted persistently marks that the channel close
+	// transaction has been broadcast.
+	MarkCoopBroadcasted(*wire.MsgTx, bool) error
+
+	// IsInitiator returns true we are the initiator of the channel.
+	IsInitiator() bool
+
+	// ShortChanID returns the scid of the channel.
+	ShortChanID() lnwire.ShortChannelID
+
+	// ChanType returns the channel type of the channel.
+	ChanType() channeldb.ChannelType
+
+	// FundingTxOut returns the funding output of the channel.
+	FundingTxOut() *wire.TxOut
+
+	// AbsoluteThawHeight returns the absolute thaw height of the channel.
+	// If the channel is pending, or an unconfirmed zero conf channel, then
+	// an error should be returned.
+	AbsoluteThawHeight() (uint32, error)
+
+	// LocalBalanceDust returns true if when creating a co-op close
+	// transaction, the balance of the local party will be dust after
+	// accounting for any anchor outputs.
+	LocalBalanceDust() bool
+
+	// RemoteBalanceDust returns true if when creating a co-op close
+	// transaction, the balance of the remote party will be dust after
+	// accounting for any anchor outputs.
+	RemoteBalanceDust() bool
+
+	// RemoteUpfrontShutdownScript returns the upfront shutdown script of
+	// the remote party. If the remote party didn't specify such a script,
+	// an empty delivery address should be returned.
+	RemoteUpfrontShutdownScript() lnwire.DeliveryAddress
+
+	// CreateCloseProposal creates a new co-op close proposal in the form
+	// of a valid signature, the chainhash of the final txid, and our final
+	// balance in the created state.
+	CreateCloseProposal(proposedFee btcutil.Amount, localDeliveryScript []byte,
+		remoteDeliveryScript []byte,
+		closeOpt ...lnwallet.ChanCloseOpt) (input.Signature, *chainhash.Hash,
+		btcutil.Amount, error)
+
+	// CompleteCooperativeClose persistently "completes" the cooperative
+	// close by producing a fully signed co-op close transaction.
+	CompleteCooperativeClose(localSig, remoteSig input.Signature,
+		localDeliveryScript, remoteDeliveryScript []byte,
+		proposedFee btcutil.Amount, closeOpt ...lnwallet.ChanCloseOpt,
+	) (*wire.MsgTx, btcutil.Amount, error)
+}
+
+// MusigSession is an interface that abstracts away the details of the musig2
+// session details. A session is used to generate the necessary closing options
+// needed to close a channel cooperatively.
+type MusigSession interface {
+	// ProposalClosingOpts generates the set of closing options needed to
+	// generate a new musig2 proposal signature.
+	ProposalClosingOpts() ([]lnwallet.ChanCloseOpt, error)
+
+	// CombineClosingOpts returns the options that should be used when
+	// combining the final musig partial signature. The method also maps
+	// the lnwire partial signatures into an input.Signature that can be
+	// used more generally.
+	CombineClosingOpts(localSig, remoteSig lnwire.PartialSig,
+	) (input.Signature, input.Signature, []lnwallet.ChanCloseOpt, error)
+
+	// ClosingNonce generates the nonce we'll use to generate the musig2
+	// partial signatures for the co-op close transaction.
+	ClosingNonce() (*musig2.Nonces, error)
+
+	// InitRemoteNonce saves the remote nonce the party sent during their
+	// shutdown message so it can be used later to generate and verify
+	// signatures.
+	InitRemoteNonce(nonce *musig2.Nonces)
+}

--- a/lnwallet/chancloser/interface.go
+++ b/lnwallet/chancloser/interface.go
@@ -27,7 +27,7 @@ type CoopFeeEstimator interface {
 // Channel abstracts away from the core channel state machine by exposing an
 // interface that requires only the methods we need to carry out the channel
 // closing process.
-type Channel interface {
+type Channel interface { //nolint:interfacebloat
 	// ChannelPoint returns the channel point of the target channel.
 	ChannelPoint() *wire.OutPoint
 
@@ -70,10 +70,11 @@ type Channel interface {
 	// CreateCloseProposal creates a new co-op close proposal in the form
 	// of a valid signature, the chainhash of the final txid, and our final
 	// balance in the created state.
-	CreateCloseProposal(proposedFee btcutil.Amount, localDeliveryScript []byte,
-		remoteDeliveryScript []byte,
-		closeOpt ...lnwallet.ChanCloseOpt) (input.Signature, *chainhash.Hash,
-		btcutil.Amount, error)
+	CreateCloseProposal(proposedFee btcutil.Amount,
+		localDeliveryScript []byte, remoteDeliveryScript []byte,
+		closeOpt ...lnwallet.ChanCloseOpt,
+	) (
+		input.Signature, *chainhash.Hash, btcutil.Amount, error)
 
 	// CompleteCooperativeClose persistently "completes" the cooperative
 	// close by producing a fully signed co-op close transaction.

--- a/lnwallet/channel.go
+++ b/lnwallet/channel.go
@@ -1398,7 +1398,7 @@ func NewLightningChannel(signer input.Signer,
 
 	logPrefix := fmt.Sprintf("ChannelPoint(%v):", state.FundingOutpoint)
 
-	taprootNonceProducer, err := deriveMusig2Shachain(
+	taprootNonceProducer, err := channeldb.DeriveMusig2Shachain(
 		state.RevocationProducer,
 	)
 	if err != nil {
@@ -6105,7 +6105,7 @@ func (lc *LightningChannel) getSignedCommitTx() (*wire.MsgTx, error) {
 		// the remote party to create this musig session. We pass in
 		// the same height here as we're generating the nonce needed
 		// for the _current_ state.
-		localNonce, err := NewMusigVerificationNonce(
+		localNonce, err := channeldb.NewMusigVerificationNonce(
 			ourKey.PubKey, lc.currentHeight,
 			lc.taprootNonceProducer,
 		)
@@ -8165,7 +8165,7 @@ func (lc *LightningChannel) GenMusigNonces() (*musig2.Nonces, error) {
 	// We pass in the current height+1 as this'll be the set of
 	// verification nonces we'll send to the party to create our _next_
 	// state.
-	lc.pendingVerificationNonce, err = NewMusigVerificationNonce(
+	lc.pendingVerificationNonce, err = channeldb.NewMusigVerificationNonce(
 		lc.channelState.LocalChanCfg.MultiSigKey.PubKey,
 		lc.currentHeight+1, lc.taprootNonceProducer,
 	)
@@ -8174,27 +8174,6 @@ func (lc *LightningChannel) GenMusigNonces() (*musig2.Nonces, error) {
 	}
 
 	return lc.pendingVerificationNonce, nil
-}
-
-// NewMusigVerificationNonce generates the local or verification nonce for
-// another musig2 session. In order to permit our implementation to not have to
-// write any secret nonce state to disk, we'll use the _next_ shachain
-// pre-image as our primary randomness source. When used to generate the nonce
-// again to broadcast our commitment hte current height will be used.
-func NewMusigVerificationNonce(pubKey *btcec.PublicKey, targetHeight uint64,
-	shaGen shachain.Producer) (*musig2.Nonces, error) {
-
-	// Now that we know what height we need, we'll grab the shachain
-	// pre-image at the target destination.
-	nextPreimage, err := shaGen.AtIndex(targetHeight)
-	if err != nil {
-		return nil, err
-	}
-
-	shaChainRand := musig2.WithCustomRand(bytes.NewBuffer(nextPreimage[:]))
-	pubKeyOpt := musig2.WithPublicKey(pubKey)
-
-	return musig2.GenNonces(pubKeyOpt, shaChainRand)
 }
 
 // HasRemoteNonces returns true if the channel has a remote nonce pair.

--- a/lnwallet/channel.go
+++ b/lnwallet/channel.go
@@ -1398,17 +1398,9 @@ func NewLightningChannel(signer input.Signer,
 
 	logPrefix := fmt.Sprintf("ChannelPoint(%v):", state.FundingOutpoint)
 
-	// In order to obtain the revocation root hash to create the taproot
-	// revocation, we'll encode the producer into a buffer, then use that
-	// to derive the shachain root needed.
-	var rootHashBuf bytes.Buffer
-	if err := state.RevocationProducer.Encode(&rootHashBuf); err != nil {
-		return nil, fmt.Errorf("unable to encode producer: %v", err)
-	}
-
-	revRootHash := chainhash.HashH(rootHashBuf.Bytes())
-
-	taprootNonceProducer, err := deriveMusig2Shachain(revRootHash)
+	taprootNonceProducer, err := deriveMusig2Shachain(
+		state.RevocationProducer,
+	)
 	if err != nil {
 		return nil, fmt.Errorf("unable to derive shachain: %v", err)
 	}

--- a/lnwallet/channel.go
+++ b/lnwallet/channel.go
@@ -4094,8 +4094,6 @@ func (lc *LightningChannel) ProcessChanSyncMsg(
 	msg *lnwire.ChannelReestablish) ([]lnwire.Message, []models.CircuitKey,
 	[]models.CircuitKey, error) {
 
-	// TODO(roasbeef): need to replace w/ received nonces
-
 	// Now we'll examine the state we have, vs what was contained in the
 	// chain sync message. If we're de-synchronized, then we'll send a
 	// batch of messages which when applied will kick start the chain
@@ -4132,6 +4130,25 @@ func (lc *LightningChannel) ProcessChanSyncMsg(
 			lc.log.Errorf("sync failed: remote provided invalid " +
 				"commit secret!")
 			return nil, nil, nil, ErrInvalidLastCommitSecret
+		}
+	}
+
+	// If this is a taproot channel, then we expect that the remote party
+	// has sent the next verification nonce. If they haven't, then we'll
+	// bail out, otherwise we'll init our local session then continue as
+	// normal.
+	switch {
+	case lc.channelState.ChanType.IsTaproot() && msg.LocalNonce == nil:
+		return nil, nil, nil, fmt.Errorf("remote verification nonce " +
+			"not sent")
+
+	case lc.channelState.ChanType.IsTaproot() && msg.LocalNonce != nil:
+		err := lc.InitRemoteMusigNonces(&musig2.Nonces{
+			PubNonce: *msg.LocalNonce,
+		})
+		if err != nil {
+			return nil, nil, nil, fmt.Errorf("unable to init "+
+				"remote nonce: %w", err)
 		}
 	}
 
@@ -4212,12 +4229,12 @@ func (lc *LightningChannel) ProcessChanSyncMsg(
 			"while we have %v, we owe them a revocation",
 			msg.RemoteCommitTailHeight, localTailHeight)
 
-		revocationMsg, err := lc.generateRevocation(
-			localTailHeight - 1,
-		)
+		heightToRetransmit := localTailHeight - 1
+		revocationMsg, err := lc.generateRevocation(heightToRetransmit)
 		if err != nil {
 			return nil, nil, nil, err
 		}
+
 		updates = append(updates, revocationMsg)
 
 		// Next, as a precaution, we'll check a special edge case. If

--- a/lnwallet/channel.go
+++ b/lnwallet/channel.go
@@ -26,6 +26,7 @@ import (
 	"github.com/lightningnetwork/lnd/channeldb"
 	"github.com/lightningnetwork/lnd/channeldb/models"
 	"github.com/lightningnetwork/lnd/input"
+	"github.com/lightningnetwork/lnd/keychain"
 	"github.com/lightningnetwork/lnd/lnwallet/chainfee"
 	"github.com/lightningnetwork/lnd/lnwire"
 	"github.com/lightningnetwork/lnd/shachain"
@@ -7093,6 +7094,30 @@ func NewLocalForceCloseSummary(chanState *channeldb.OpenChannel,
 	}, nil
 }
 
+// chanCloseOpt is a functional option that can be used to modify the co-op
+// close process.
+type chanCloseOpt struct {
+	musigSession *MusigSession
+}
+
+// ChanCloseOpt is a closure type that cen be used to modify the set of default
+// options.
+type ChanCloseOpt func(*chanCloseOpt)
+
+// defaultCloseOpts is the default set of close options.
+func defaultCloseOpts() *chanCloseOpt {
+	return &chanCloseOpt{}
+}
+
+// WithCoopCloseMusigSession can be used to apply an existing musig2 session to
+// the cooperative close process. If specified, then a musig2 co-op close
+// (single sig keyspend) will be used.
+func WithCoopCloseMusigSession(session *MusigSession) ChanCloseOpt {
+	return func(opts *chanCloseOpt) {
+		opts.musigSession = session
+	}
+}
+
 // CreateCloseProposal is used by both parties in a cooperative channel close
 // workflow to generate proposed close transactions and signatures. This method
 // should only be executed once all pending HTLCs (if any) on the channel have
@@ -7104,8 +7129,8 @@ func NewLocalForceCloseSummary(chanState *channeldb.OpenChannel,
 // TODO(roasbeef): caller should initiate signal to reject all incoming HTLCs,
 // settle any in flight.
 func (lc *LightningChannel) CreateCloseProposal(proposedFee btcutil.Amount,
-	localDeliveryScript []byte,
-	remoteDeliveryScript []byte) (input.Signature, *chainhash.Hash,
+	localDeliveryScript []byte, remoteDeliveryScript []byte,
+	closeOpts ...ChanCloseOpt) (input.Signature, *chainhash.Hash,
 	btcutil.Amount, error) {
 
 	lc.Lock()
@@ -7115,6 +7140,11 @@ func (lc *LightningChannel) CreateCloseProposal(proposedFee btcutil.Amount,
 	if lc.status == channelClosed {
 		// TODO(roasbeef): check to ensure no pending payments
 		return nil, nil, 0, ErrChanClosing
+	}
+
+	opts := defaultCloseOpts()
+	for _, optFunc := range closeOpts {
+		optFunc(opts)
 	}
 
 	// Get the final balances after subtracting the proposed fee, taking
@@ -7142,14 +7172,25 @@ func (lc *LightningChannel) CreateCloseProposal(proposedFee btcutil.Amount,
 		return nil, nil, 0, err
 	}
 
-	// Finally, sign the completed cooperative closure transaction. As the
-	// initiator we'll simply send our signature over to the remote party,
-	// using the generated txid to be notified once the closure transaction
-	// has been confirmed.
-	lc.signDesc.SigHashes = input.NewTxSigHashesV0Only(closeTx)
-	sig, err := lc.Signer.SignOutputRaw(closeTx, lc.signDesc)
-	if err != nil {
-		return nil, nil, 0, err
+	// If we have a co-op close musig session, then this is a taproot
+	// channel, so we'll generate a _partial_ signature.
+	var sig input.Signature
+	if opts.musigSession != nil {
+		sig, err = opts.musigSession.SignCommit(closeTx)
+		if err != nil {
+			return nil, nil, 0, err
+		}
+	} else {
+		// For regular channels we'll, sign the completed cooperative
+		// closure transaction. As the initiator we'll simply send our
+		// signature over to the remote party, using the generated txid
+		// to be notified once the closure transaction has been
+		// confirmed.
+		lc.signDesc.SigHashes = input.NewTxSigHashesV0Only(closeTx)
+		sig, err = lc.Signer.SignOutputRaw(closeTx, lc.signDesc)
+		if err != nil {
+			return nil, nil, 0, err
+		}
 	}
 
 	// As everything checks out, indicate in the channel status that a
@@ -7170,7 +7211,8 @@ func (lc *LightningChannel) CreateCloseProposal(proposedFee btcutil.Amount,
 func (lc *LightningChannel) CompleteCooperativeClose(
 	localSig, remoteSig input.Signature,
 	localDeliveryScript, remoteDeliveryScript []byte,
-	proposedFee btcutil.Amount) (*wire.MsgTx, btcutil.Amount, error) {
+	proposedFee btcutil.Amount,
+	closeOpts ...ChanCloseOpt) (*wire.MsgTx, btcutil.Amount, error) {
 
 	lc.Lock()
 	defer lc.Unlock()
@@ -7179,6 +7221,11 @@ func (lc *LightningChannel) CompleteCooperativeClose(
 	if lc.status == channelClosed {
 		// TODO(roasbeef): check to ensure no pending payments
 		return nil, 0, ErrChanClosing
+	}
+
+	opts := defaultCloseOpts()
+	for _, optFunc := range closeOpts {
+		optFunc(opts)
 	}
 
 	// Get the final balances after subtracting the proposed fee.
@@ -7203,31 +7250,62 @@ func (lc *LightningChannel) CompleteCooperativeClose(
 	// consensus rules such as being too big, or having any value with a
 	// negative output.
 	tx := btcutil.NewTx(closeTx)
+	prevOut := lc.signDesc.Output
 	if err := blockchain.CheckTransactionSanity(tx); err != nil {
 		return nil, 0, err
 	}
-	hashCache := input.NewTxSigHashesV0Only(closeTx)
 
-	// Finally, construct the witness stack minding the order of the
-	// pubkeys+sigs on the stack.
-	ourKey := lc.channelState.LocalChanCfg.MultiSigKey.PubKey.
-		SerializeCompressed()
-	theirKey := lc.channelState.RemoteChanCfg.MultiSigKey.PubKey.
-		SerializeCompressed()
-	witness := input.SpendMultiSig(
-		lc.signDesc.WitnessScript, ourKey, localSig, theirKey,
-		remoteSig,
+	prevOutputFetcher := txscript.NewCannedPrevOutputFetcher(
+		prevOut.PkScript, prevOut.Value,
 	)
-	closeTx.TxIn[0].Witness = witness
+	hashCache := txscript.NewTxSigHashes(closeTx, prevOutputFetcher)
+
+	// Next, we'll complete the co-op close transaction. Depending on the
+	// set of options, we'll either do a regular p2wsh spend, or construct
+	// the final schnorr signature from a set of partial sigs.
+	if opts.musigSession != nil {
+		// For taproot channels, we'll use the attached session to
+		// combine the two partial signatures into a proper schnorr
+		// signature.
+		remotePartialSig, ok := remoteSig.(*MusigPartialSig)
+		if !ok {
+			return nil, 0, fmt.Errorf("expected MusigPartialSig, "+
+				"got %T", remoteSig)
+		}
+
+		finalSchnorrSig, err := opts.musigSession.CombineSigs(
+			remotePartialSig.sig,
+		)
+		if err != nil {
+			return nil, 0, fmt.Errorf("unable to combine "+
+				"final co-op close sig: %w", err)
+		}
+
+		// The witness for a keyspend is just the signature itself.
+		closeTx.TxIn[0].Witness = wire.TxWitness{
+			finalSchnorrSig.Serialize(),
+		}
+	} else {
+
+		// For regular channels, we'll need to , construct the witness
+		// stack minding the order of the pubkeys+sigs on the stack.
+		ourKey := lc.channelState.LocalChanCfg.MultiSigKey.PubKey.
+			SerializeCompressed()
+		theirKey := lc.channelState.RemoteChanCfg.MultiSigKey.PubKey.
+			SerializeCompressed()
+		witness := input.SpendMultiSig(
+			lc.signDesc.WitnessScript, ourKey, localSig, theirKey,
+			remoteSig,
+		)
+		closeTx.TxIn[0].Witness = witness
+
+	}
 
 	// Validate the finalized transaction to ensure the output script is
 	// properly met, and that the remote peer supplied a valid signature.
-	prevOut := lc.signDesc.Output
 	vm, err := txscript.NewEngine(
 		prevOut.PkScript, closeTx, 0, txscript.StandardVerifyFlags, nil,
-		hashCache, prevOut.Value, txscript.NewCannedPrevOutputFetcher(
-			prevOut.PkScript, prevOut.Value,
-		),
+		hashCache, prevOut.Value, prevOutputFetcher,
 	)
 	if err != nil {
 		return nil, 0, err
@@ -7887,10 +7965,22 @@ func (lc *LightningChannel) IdealCommitFeeRate(netFeeRate, minRelayFeeRate,
 	return absoluteMaxFee
 }
 
-// RemoteNextRevocation returns the channelState's RemoteNextRevocation.
+// RemoteNextRevocation returns the channelState's RemoteNextRevocation. For
+// musig2 channels, until a nonce pair is processed by the remote party, a nil
+// public key is returned.
+//
+// TODO(roasbeef): revisit, maybe just make a more general method instead?
 func (lc *LightningChannel) RemoteNextRevocation() *btcec.PublicKey {
 	lc.RLock()
 	defer lc.RUnlock()
+
+	if !lc.channelState.ChanType.IsTaproot() {
+		return lc.channelState.RemoteNextRevocation
+	}
+
+	if lc.musigSessions == nil {
+		return nil
+	}
 
 	return lc.channelState.RemoteNextRevocation
 }
@@ -8159,4 +8249,29 @@ func (lc *LightningChannel) InitRemoteMusigNonces(remoteNonce *musig2.Nonces,
 	lc.pendingVerificationNonce = nil
 
 	return nil
+}
+
+// ChanType returns the channel type.
+func (lc *LightningChannel) ChanType() channeldb.ChannelType {
+	lc.RLock()
+	defer lc.RUnlock()
+
+	return lc.channelState.ChanType
+}
+
+// FundingTxOut returns the funding output of the channel.
+func (lc *LightningChannel) FundingTxOut() *wire.TxOut {
+	lc.RLock()
+	defer lc.RUnlock()
+
+	return &lc.fundingOutput
+}
+
+// MultiSigKeys returns the set of multi-sig keys for an channel.
+func (lc *LightningChannel) MultiSigKeys() (keychain.KeyDescriptor, keychain.KeyDescriptor) {
+	lc.RLock()
+	defer lc.RUnlock()
+
+	return lc.channelState.LocalChanCfg.MultiSigKey,
+		lc.channelState.RemoteChanCfg.MultiSigKey
 }

--- a/lnwallet/channel.go
+++ b/lnwallet/channel.go
@@ -3299,7 +3299,7 @@ func genRemoteHtlcSigJobs(keyRing *CommitmentKeyRing,
 
 		// If the HTLC isn't dust, then we'll create an empty sign job
 		// to add to the batch momentarily.
-		sigJob := SignJob{}
+		var sigJob SignJob
 		sigJob.Cancel = cancelChan
 		sigJob.Resp = make(chan SignJobResp, 1)
 
@@ -3326,20 +3326,34 @@ func genRemoteHtlcSigJobs(keyRing *CommitmentKeyRing,
 			return nil, nil, err
 		}
 
+		// Construct a full hash cache as we may be signing a segwit v1
+		// sighash.
+		txOut := remoteCommitView.txn.TxOut[htlc.remoteOutputIndex]
+		prevFetcher := txscript.NewCannedPrevOutputFetcher(
+			txOut.PkScript, int64(htlc.Amount.ToSatoshis()),
+		)
+		hashCache := txscript.NewTxSigHashes(sigJob.Tx, prevFetcher)
+
 		// Finally, we'll generate a sign descriptor to generate a
 		// signature to give to the remote party for this commitment
 		// transaction. Note we use the raw HTLC amount.
-		txOut := remoteCommitView.txn.TxOut[htlc.remoteOutputIndex]
 		sigJob.SignDesc = input.SignDescriptor{
-			KeyDesc:       localChanCfg.HtlcBasePoint,
-			SingleTweak:   keyRing.LocalHtlcKeyTweak,
-			WitnessScript: htlc.theirWitnessScript,
-			Output:        txOut,
-			HashType:      sigHashType,
-			SigHashes:     input.NewTxSigHashesV0Only(sigJob.Tx),
-			InputIndex:    0,
+			KeyDesc:           localChanCfg.HtlcBasePoint,
+			SingleTweak:       keyRing.LocalHtlcKeyTweak,
+			WitnessScript:     htlc.theirWitnessScript,
+			Output:            txOut,
+			PrevOutputFetcher: prevFetcher,
+			HashType:          sigHashType,
+			SigHashes:         hashCache,
+			InputIndex:        0,
 		}
 		sigJob.OutputIndex = htlc.remoteOutputIndex
+
+		// If this is a taproot channel, then we'll need to set the
+		// method type to ensure we generate a valid signature.
+		if chanType.IsTaproot() {
+			sigJob.SignDesc.SignMethod = input.TaprootScriptSpendSignMethod
+		}
 
 		sigBatch = append(sigBatch, sigJob)
 	}
@@ -3380,20 +3394,34 @@ func genRemoteHtlcSigJobs(keyRing *CommitmentKeyRing,
 			return nil, nil, err
 		}
 
+		// Construct a full hash cache as we may be signing a segwit v1
+		// sighash.
+		txOut := remoteCommitView.txn.TxOut[htlc.remoteOutputIndex]
+		prevFetcher := txscript.NewCannedPrevOutputFetcher(
+			txOut.PkScript, int64(htlc.Amount.ToSatoshis()),
+		)
+		hashCache := txscript.NewTxSigHashes(sigJob.Tx, prevFetcher)
+
 		// Finally, we'll generate a sign descriptor to generate a
 		// signature to give to the remote party for this commitment
 		// transaction. Note we use the raw HTLC amount.
-		txOut := remoteCommitView.txn.TxOut[htlc.remoteOutputIndex]
 		sigJob.SignDesc = input.SignDescriptor{
-			KeyDesc:       localChanCfg.HtlcBasePoint,
-			SingleTweak:   keyRing.LocalHtlcKeyTweak,
-			WitnessScript: htlc.theirWitnessScript,
-			Output:        txOut,
-			HashType:      sigHashType,
-			SigHashes:     input.NewTxSigHashesV0Only(sigJob.Tx),
-			InputIndex:    0,
+			KeyDesc:           localChanCfg.HtlcBasePoint,
+			SingleTweak:       keyRing.LocalHtlcKeyTweak,
+			WitnessScript:     htlc.theirWitnessScript,
+			Output:            txOut,
+			PrevOutputFetcher: prevFetcher,
+			HashType:          sigHashType,
+			SigHashes:         hashCache,
+			InputIndex:        0,
 		}
 		sigJob.OutputIndex = htlc.remoteOutputIndex
+
+		// If this is a taproot channel, then we'll need to set the
+		// method type to ensure we generate a valid signature.
+		if chanType.IsTaproot() {
+			sigJob.SignDesc.SignMethod = input.TaprootScriptSpendSignMethod
+		}
 
 		sigBatch = append(sigBatch, sigJob)
 	}

--- a/lnwallet/channel.go
+++ b/lnwallet/channel.go
@@ -13,6 +13,7 @@ import (
 	"github.com/btcsuite/btcd/blockchain"
 	"github.com/btcsuite/btcd/btcec/v2"
 	"github.com/btcsuite/btcd/btcec/v2/ecdsa"
+	"github.com/btcsuite/btcd/btcec/v2/schnorr/musig2"
 	"github.com/btcsuite/btcd/btcutil"
 	"github.com/btcsuite/btcd/btcutil/txsort"
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
@@ -27,6 +28,7 @@ import (
 	"github.com/lightningnetwork/lnd/input"
 	"github.com/lightningnetwork/lnd/lnwallet/chainfee"
 	"github.com/lightningnetwork/lnd/lnwire"
+	"github.com/lightningnetwork/lnd/shachain"
 )
 
 var (
@@ -1317,7 +1319,50 @@ type LightningChannel struct {
 	// log is a channel-specific logging instance.
 	log btclog.Logger
 
+	// musigSessions holds the current musig2 pair session for the channel.
+	musigSessions *MusigPairSession
+
+	// pendingVerificationNonce is the initial verification nonce generated
+	// for musig2 channels when the state machine is intiated. Once we know
+	// the verification nonce of the remote party, then we can star tto use
+	// the channel as normal.
+	pendingVerificationNonce *musig2.Nonces
+
+	// fundingOutput is the funding output (script+value).
+	fundingOutput wire.TxOut
+
 	sync.RWMutex
+}
+
+// ChannelOpt is a functional option that lets callers modify how a new channel
+// is created.
+type ChannelOpt func(*channelOpts)
+
+// WithLocalMusigNonces is used to bind an existing verification/local nonce to
+// a new channel.
+func WithLocalMusigNonces(nonce *musig2.Nonces) ChannelOpt {
+	return func(o *channelOpts) {
+		o.localNonce = nonce
+	}
+}
+
+// WithRemoteMusigNonces is used to bind the remote party's local/verification
+// nonce to a new channel.
+func WithRemoteMusigNonces(nonces *musig2.Nonces) ChannelOpt {
+	return func(o *channelOpts) {
+		o.remoteNonce = nonces
+	}
+}
+
+// channelOpts is the set of options used to create a new channel.
+type channelOpts struct {
+	localNonce  *musig2.Nonces
+	remoteNonce *musig2.Nonces
+}
+
+// defaultChannelOpts returns the set of default options for a new channel.
+func defaultChannelOpts() *channelOpts {
+	return &channelOpts{}
 }
 
 // NewLightningChannel creates a new, active payment channel given an
@@ -1327,7 +1372,12 @@ type LightningChannel struct {
 // manner.
 func NewLightningChannel(signer input.Signer,
 	state *channeldb.OpenChannel,
-	sigPool *SigPool) (*LightningChannel, error) {
+	sigPool *SigPool, chanOpts ...ChannelOpt) (*LightningChannel, error) {
+
+	opts := defaultChannelOpts()
+	for _, optFunc := range chanOpts {
+		optFunc(opts)
+	}
 
 	localCommit := state.LocalCommitment
 	remoteCommit := state.RemoteCommitment
@@ -1360,6 +1410,18 @@ func NewLightningChannel(signer input.Signer,
 		log:               build.NewPrefixLog(logPrefix, walletLog),
 	}
 
+	// At this point, we mwy already have of nonces that were passed in, so
+	// we'll check that now as this lets us skip some steps later.
+	if opts.localNonce != nil {
+		lc.pendingVerificationNonce = opts.localNonce
+	}
+	if lc.pendingVerificationNonce != nil && opts.remoteNonce != nil {
+		err := lc.InitRemoteMusigNonces(opts.remoteNonce)
+		if err != nil {
+			return nil, err
+		}
+	}
+
 	// With the main channel struct reconstructed, we'll now restore the
 	// commitment state in memory and also the update logs themselves.
 	err := lc.restoreCommitState(&localCommit, &remoteCommit)
@@ -1380,29 +1442,47 @@ func NewLightningChannel(signer input.Signer,
 // createSignDesc derives the SignDescriptor for commitment transactions from
 // other fields on the LightningChannel.
 func (lc *LightningChannel) createSignDesc() error {
-	localKey := lc.channelState.LocalChanCfg.MultiSigKey.PubKey.
-		SerializeCompressed()
-	remoteKey := lc.channelState.RemoteChanCfg.MultiSigKey.PubKey.
-		SerializeCompressed()
 
-	multiSigScript, err := input.GenMultiSigScript(localKey, remoteKey)
-	if err != nil {
-		return err
+	var (
+		fundingPkScript, multiSigScript []byte
+		err                             error
+	)
+
+	chanState := lc.channelState
+	localKey := chanState.LocalChanCfg.MultiSigKey.PubKey
+	remoteKey := chanState.RemoteChanCfg.MultiSigKey.PubKey
+
+	if chanState.ChanType.IsTaproot() {
+		fundingPkScript, _, err = input.GenTaprootFundingScript(
+			localKey, remoteKey, int64(lc.channelState.Capacity),
+		)
+		if err != nil {
+			return err
+		}
+	} else {
+		multiSigScript, err = input.GenMultiSigScript(
+			localKey.SerializeCompressed(), remoteKey.SerializeCompressed(),
+		)
+		if err != nil {
+			return err
+		}
+
+		fundingPkScript, err = input.WitnessScriptHash(multiSigScript)
+		if err != nil {
+			return err
+		}
 	}
 
-	fundingPkScript, err := input.WitnessScriptHash(multiSigScript)
-	if err != nil {
-		return err
+	lc.fundingOutput = wire.TxOut{
+		PkScript: fundingPkScript,
+		Value:    int64(lc.channelState.Capacity),
 	}
 	lc.signDesc = &input.SignDescriptor{
 		KeyDesc:       lc.channelState.LocalChanCfg.MultiSigKey,
 		WitnessScript: multiSigScript,
-		Output: &wire.TxOut{
-			PkScript: fundingPkScript,
-			Value:    int64(lc.channelState.Capacity),
-		},
-		HashType:   txscript.SigHashAll,
-		InputIndex: 0,
+		Output:        &lc.fundingOutput,
+		HashType:      txscript.SigHashAll,
+		InputIndex:    0,
 	}
 
 	return nil
@@ -7664,4 +7744,96 @@ func (lc *LightningChannel) unsignedLocalUpdates(remoteMessageIndex,
 	}
 
 	return localPeerUpdates
+}
+
+// GenMusigNonces generates the verification nonce to start off a new musig2
+// channel session.
+func (lc *LightningChannel) GenMusigNonces() (*musig2.Nonces, error) {
+	lc.RLock()
+	defer lc.RUnlock()
+
+	var err error
+	lc.pendingVerificationNonce, err = NewMusigVerificationNonce(
+		lc.channelState.LocalChanCfg.MultiSigKey.PubKey,
+		lc.currentHeight, lc.channelState.RevocationProducer,
+		false,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	return lc.pendingVerificationNonce, nil
+}
+
+// NewMusigVerificationNonce generates the local or verification nonce for
+// another musig2 session. In order to permit our implementation to not have to
+// write any secret nonce state to disk, we'll use the _next_ shachain
+// pre-image as our primary randomness source.
+func NewMusigVerificationNonce(pubKey *btcec.PublicKey, currentHeight uint64,
+	shaGen shachain.Producer, forBroadcast bool) (*musig2.Nonces, error) {
+
+	// If we're broadcasting this commitment, then we need to get the nonce
+	// for the current height. Otherwise, we'll add one, as we're
+	// generating a local nonce for the _next_ height.
+	targetHeight := func() uint64 {
+		if forBroadcast {
+			return currentHeight
+		}
+
+		return currentHeight + 1
+	}()
+
+	// Now that we know what height we need, we'll grab the shachain
+	// pre-image at the target destination.
+	nextPreimage, err := shaGen.AtIndex(targetHeight)
+	if err != nil {
+		return nil, err
+	}
+
+	shaChainRand := musig2.WithCustomRand(bytes.NewBuffer(nextPreimage[:]))
+	pubKeyOpt := musig2.WithPublicKey(pubKey)
+
+	return musig2.GenNonces(pubKeyOpt, shaChainRand)
+}
+
+// HasRemoteNonces returns true if the channel has a remote nonce pair.
+func (lc *LightningChannel) HasRemoteNonces() bool {
+	return lc.musigSessions != nil
+}
+
+// InitRemoteMusigNonces processes the remote musig nonces sent by the remote
+// party. This should be called upon connection re-establishment, after we've
+// generated our own nonces. Once this method returns a nil error, then the
+// channel can be used to sign commitment states.
+func (lc *LightningChannel) InitRemoteMusigNonces(remoteNonce *musig2.Nonces,
+) error {
+
+	lc.RLock()
+	defer lc.RUnlock()
+
+	// Now that we have the set of local and remote nonces, we can generate
+	// a new pair of musig sessions for our local commitment and the
+	// commitment of the remote party.
+	localNonce := lc.pendingVerificationNonce
+
+	localChanCfg := lc.channelState.LocalChanCfg
+	remoteChanCfg := lc.channelState.RemoteChanCfg
+
+	// TODO(roasbeef): propagate rename of signing and verification nonces
+
+	sessionCfg := &MusigSessionCfg{
+		LocalKey:    localChanCfg.MultiSigKey,
+		RemoteKey:   remoteChanCfg.MultiSigKey,
+		LocalNonce:  *localNonce,
+		RemoteNonce: *remoteNonce,
+		Signer:      lc.Signer,
+		InputTxOut:  &lc.fundingOutput,
+	}
+	lc.musigSessions = NewMusigPairSession(
+		sessionCfg,
+	)
+
+	lc.pendingVerificationNonce = nil
+
+	return nil
 }

--- a/lnwallet/channel.go
+++ b/lnwallet/channel.go
@@ -1319,12 +1319,16 @@ type LightningChannel struct {
 	// log is a channel-specific logging instance.
 	log btclog.Logger
 
+	// taprootNonceProducer is used to generate a shachain tree for the
+	// purpose of generating verification nonces for taproot channels.
+	taprootNonceProducer shachain.Producer
+
 	// musigSessions holds the current musig2 pair session for the channel.
 	musigSessions *MusigPairSession
 
 	// pendingVerificationNonce is the initial verification nonce generated
 	// for musig2 channels when the state machine is intiated. Once we know
-	// the verification nonce of the remote party, then we can star tto use
+	// the verification nonce of the remote party, then we can start to use
 	// the channel as normal.
 	pendingVerificationNonce *musig2.Nonces
 
@@ -1393,24 +1397,40 @@ func NewLightningChannel(signer input.Signer,
 
 	logPrefix := fmt.Sprintf("ChannelPoint(%v):", state.FundingOutpoint)
 
-	lc := &LightningChannel{
-		Signer:            signer,
-		sigPool:           sigPool,
-		currentHeight:     localCommit.CommitHeight,
-		remoteCommitChain: newCommitmentChain(),
-		localCommitChain:  newCommitmentChain(),
-		channelState:      state,
-		commitBuilder:     NewCommitmentBuilder(state),
-		localUpdateLog:    localUpdateLog,
-		remoteUpdateLog:   remoteUpdateLog,
-		ChanPoint:         &state.FundingOutpoint,
-		Capacity:          state.Capacity,
-		LocalFundingKey:   state.LocalChanCfg.MultiSigKey.PubKey,
-		RemoteFundingKey:  state.RemoteChanCfg.MultiSigKey.PubKey,
-		log:               build.NewPrefixLog(logPrefix, walletLog),
+	// In order to obtain the revocation root hash to create the taproot
+	// revocation, we'll encode the producer into a buffer, then use that
+	// to derive the shachain root needed.
+	var rootHashBuf bytes.Buffer
+	if err := state.RevocationProducer.Encode(&rootHashBuf); err != nil {
+		return nil, fmt.Errorf("unable to encode producer: %v", err)
 	}
 
-	// At this point, we mwy already have of nonces that were passed in, so
+	revRootHash := chainhash.HashH(rootHashBuf.Bytes())
+
+	taprootNonceProducer, err := deriveMusig2Shachain(revRootHash)
+	if err != nil {
+		return nil, fmt.Errorf("unable to derive shachain: %v", err)
+	}
+
+	lc := &LightningChannel{
+		Signer:               signer,
+		sigPool:              sigPool,
+		currentHeight:        localCommit.CommitHeight,
+		remoteCommitChain:    newCommitmentChain(),
+		localCommitChain:     newCommitmentChain(),
+		channelState:         state,
+		commitBuilder:        NewCommitmentBuilder(state),
+		localUpdateLog:       localUpdateLog,
+		remoteUpdateLog:      remoteUpdateLog,
+		ChanPoint:            &state.FundingOutpoint,
+		Capacity:             state.Capacity,
+		LocalFundingKey:      state.LocalChanCfg.MultiSigKey.PubKey,
+		RemoteFundingKey:     state.RemoteChanCfg.MultiSigKey.PubKey,
+		taprootNonceProducer: taprootNonceProducer,
+		log:                  build.NewPrefixLog(logPrefix, walletLog),
+	}
+
+	// At this point, we may already have nonces that were passed in, so
 	// we'll check that now as this lets us skip some steps later.
 	if opts.localNonce != nil {
 		lc.pendingVerificationNonce = opts.localNonce
@@ -1424,7 +1444,7 @@ func NewLightningChannel(signer input.Signer,
 
 	// With the main channel struct reconstructed, we'll now restore the
 	// commitment state in memory and also the update logs themselves.
-	err := lc.restoreCommitState(&localCommit, &remoteCommit)
+	err = lc.restoreCommitState(&localCommit, &remoteCommit)
 	if err != nil {
 		return nil, err
 	}
@@ -3826,17 +3846,21 @@ func (lc *LightningChannel) validateCommitmentSanity(theirLogCounter,
 	return nil
 }
 
-// CommitSig holds the set of related signatures for a new commitment
+// CommitSigs holds the set of related signatures for a new commitment
 // transaction state.
 type CommitSigs struct {
 	// CommitSig is the normal commitment signature. This will only be a
-	// non-zero commitment signature for taproot channels.
+	// non-zero commitment signature for non-taproot channels.
 	CommitSig lnwire.Sig
 
 	// HtlcSigs is the set of signatures for all HTLCs in the commitment
 	// transaction. Depending on the channel type, these will either be
 	// ECDSA or Schnorr signatures.
 	HtlcSigs []lnwire.Sig
+
+	// PartialSig is the musig2 partial signature for taproot commitment
+	// transactions.
+	PartialSig *lnwire.PartialSigWithNonce
 }
 
 // NewCommitState wraps the various signatures needed to properly
@@ -3875,8 +3899,9 @@ func (lc *LightningChannel) SignNextCommitment() (*NewCommitState, error) {
 	}
 
 	var (
-		sig      lnwire.Sig
-		htlcSigs []lnwire.Sig
+		sig        lnwire.Sig
+		partialSig *lnwire.PartialSigWithNonce
+		htlcSigs   []lnwire.Sig
 	)
 
 	// If we're awaiting for an ACK to a commitment signature, or if we
@@ -3964,16 +3989,38 @@ func (lc *LightningChannel) SignNextCommitment() (*NewCommitState, error) {
 	// While the jobs are being carried out, we'll Sign their version of
 	// the new commitment transaction while we're waiting for the rest of
 	// the HTLC signatures to be processed.
-	lc.signDesc.SigHashes = input.NewTxSigHashesV0Only(newCommitView.txn)
-	rawSig, err := lc.Signer.SignOutputRaw(newCommitView.txn, lc.signDesc)
-	if err != nil {
-		close(cancelChan)
-		return nil, err
-	}
-	sig, err = lnwire.NewSigFromSignature(rawSig)
-	if err != nil {
-		close(cancelChan)
-		return nil, err
+	//
+	// TODO(roasbeef): abstract into CommitSigner interface?
+	if lc.channelState.ChanType.IsTaproot() {
+		// In this case, we'll send out a partial signature as this is
+		// a musig2 channel. The encoded normal ECDSA signature will be
+		// just blank.
+		remoteSession := lc.musigSessions.RemoteSession
+		musig, err := remoteSession.SignCommit(
+			newCommitView.txn,
+		)
+		if err != nil {
+			close(cancelChan)
+			return nil, err
+		}
+
+		partialSig = musig.ToWireSig()
+	} else {
+		lc.signDesc.SigHashes = input.NewTxSigHashesV0Only(
+			newCommitView.txn,
+		)
+		rawSig, err := lc.Signer.SignOutputRaw(
+			newCommitView.txn, lc.signDesc,
+		)
+		if err != nil {
+			close(cancelChan)
+			return nil, err
+		}
+		sig, err = lnwire.NewSigFromSignature(rawSig)
+		if err != nil {
+			close(cancelChan)
+			return nil, err
+		}
 	}
 
 	// We'll need to send over the signatures to the remote party in the
@@ -4021,8 +4068,9 @@ func (lc *LightningChannel) SignNextCommitment() (*NewCommitState, error) {
 
 	return &NewCommitState{
 		CommitSigs: &CommitSigs{
-			CommitSig: sig,
-			HtlcSigs:  htlcSigs,
+			CommitSig:  sig,
+			HtlcSigs:   htlcSigs,
+			PartialSig: partialSig,
 		},
 		PendingHTLCs: commitDiff.Commitment.Htlcs,
 	}, nil
@@ -4052,6 +4100,8 @@ func (lc *LightningChannel) SignNextCommitment() (*NewCommitState, error) {
 func (lc *LightningChannel) ProcessChanSyncMsg(
 	msg *lnwire.ChannelReestablish) ([]lnwire.Message, []models.CircuitKey,
 	[]models.CircuitKey, error) {
+
+	// TODO(roasbeef): need to replace w/ received nonces
 
 	// Now we'll examine the state we have, vs what was contained in the
 	// chain sync message. If we're de-synchronized, then we'll send a
@@ -4193,8 +4243,9 @@ func (lc *LightningChannel) ProcessChanSyncMsg(
 					ChanID: lnwire.NewChanIDFromOutPoint(
 						&lc.channelState.FundingOutpoint,
 					),
-					CommitSig: newCommit.CommitSig,
-					HtlcSigs:  newCommit.HtlcSigs,
+					CommitSig:  newCommit.CommitSig,
+					HtlcSigs:   newCommit.HtlcSigs,
+					PartialSig: newCommit.PartialSig,
 				}
 
 				updates = append(updates, commitSig)
@@ -4277,6 +4328,9 @@ func (lc *LightningChannel) ProcessChanSyncMsg(
 		// With the batch of updates accumulated, we'll now re-send the
 		// original CommitSig message required to re-sync their remote
 		// commitment chain with our local version of their chain.
+		//
+		// TODO(roasbeef): need to re-sign commitment states w/
+		// fresh nonce
 		commitUpdates = append(commitUpdates, commitDiff.CommitSig)
 
 		// NOTE: If a revocation is not owed, then updates is empty.
@@ -4505,11 +4559,30 @@ func genHtlcSigValidationJobs(localCommitmentView *commitment,
 					return nil, err
 				}
 
+				htlcAmt := int64(htlc.Amount.ToSatoshis())
+
+				if chanType.IsTaproot() {
+					// TODO(roasbeef): add abstraction in front
+					prevFetcher := txscript.NewCannedPrevOutputFetcher(
+						htlc.ourPkScript, htlcAmt,
+					)
+					hashCache := txscript.NewTxSigHashes(
+						successTx, prevFetcher,
+					)
+					tapLeaf := txscript.NewBaseTapLeaf(
+						htlc.ourWitnessScript,
+					)
+					return txscript.CalcTapscriptSignaturehash(
+						hashCache, sigHashType, successTx, 0,
+						prevFetcher, tapLeaf,
+					)
+				}
+
 				hashCache := input.NewTxSigHashesV0Only(successTx)
 				sigHash, err := txscript.CalcWitnessSigHash(
 					htlc.ourWitnessScript, hashCache,
 					sigHashType, successTx, 0,
-					int64(htlc.Amount.ToSatoshis()),
+					htlcAmt,
 				)
 				if err != nil {
 					return nil, err
@@ -4522,6 +4595,13 @@ func genHtlcSigValidationJobs(localCommitmentView *commitment,
 			if i >= len(htlcSigs) {
 				return nil, fmt.Errorf("not enough HTLC " +
 					"signatures")
+			}
+
+			// If this is a taproot channel, then we'll convert it
+			// to a schnorr signature, so we can get correct type
+			// from ToSignature below.
+			if chanType.IsTaproot() {
+				htlcSigs[i].ForceSchnorr()
 			}
 
 			// With the sighash generated, we'll also store the
@@ -4560,11 +4640,30 @@ func genHtlcSigValidationJobs(localCommitmentView *commitment,
 					return nil, err
 				}
 
+				htlcAmt := int64(htlc.Amount.ToSatoshis())
+
+				if chanType.IsTaproot() {
+					// TODO(roasbeef): add abstraction in front
+					prevFetcher := txscript.NewCannedPrevOutputFetcher(
+						htlc.ourPkScript, htlcAmt,
+					)
+					hashCache := txscript.NewTxSigHashes(
+						timeoutTx, prevFetcher,
+					)
+					tapLeaf := txscript.NewBaseTapLeaf(
+						htlc.ourWitnessScript,
+					)
+					return txscript.CalcTapscriptSignaturehash(
+						hashCache, sigHashType, timeoutTx, 0,
+						prevFetcher, tapLeaf,
+					)
+				}
+
 				hashCache := input.NewTxSigHashesV0Only(timeoutTx)
 				sigHash, err := txscript.CalcWitnessSigHash(
 					htlc.ourWitnessScript, hashCache,
 					sigHashType, timeoutTx, 0,
-					int64(htlc.Amount.ToSatoshis()),
+					htlcAmt,
 				)
 				if err != nil {
 					return nil, err
@@ -4579,6 +4678,13 @@ func genHtlcSigValidationJobs(localCommitmentView *commitment,
 					"signatures")
 			}
 
+			// If this is a taproot channel, then we'll convert it
+			// to a schnorr signature, so we can get correct type
+			// from ToSignature below.
+			if chanType.IsTaproot() {
+				htlcSigs[i].ForceSchnorr()
+			}
+
 			// With the sighash generated, we'll also store the
 			// signature so it can be written to disk if this state
 			// is valid.
@@ -4586,6 +4692,7 @@ func genHtlcSigValidationJobs(localCommitmentView *commitment,
 			if err != nil {
 				return nil, err
 			}
+
 			htlc.sig = sig
 
 		default:
@@ -4638,6 +4745,22 @@ func (i *InvalidCommitSigError) Error() string {
 // A compile time flag to ensure that InvalidCommitSigError implements the
 // error interface.
 var _ error = (*InvalidCommitSigError)(nil)
+
+// InvalidPartialCommitSigError is used when we encounter an invalid musig2
+// partial signature.
+type InvalidPartialCommitSigError struct {
+	InvalidCommitSigError
+
+	*invalidPartialSigError
+}
+
+// Error returns a detailed error string including the exact transaction that
+// caused an invalid partial commit sig signature.
+func (i *InvalidPartialCommitSigError) Error() string {
+	return fmt.Sprintf("rejected commitment: commit_height=%v, "+
+		"commit_tx=%x -- %v", i.commitHeight, i.commitTx,
+		i.invalidPartialSigError)
+}
 
 // InvalidHtlcSigError is a struct that implements the error interface to
 // report a failure to validate an htlc signature from a remote peer. We'll use
@@ -4748,23 +4871,8 @@ func (lc *LightningChannel) ReceiveNewCommitment(commitSigs *CommitSigs) error {
 		}),
 	)
 
-	// Construct the sighash of the commitment transaction corresponding to
-	// this newly proposed state update.
-	localCommitTx := localCommitmentView.txn
-	multiSigScript := lc.signDesc.WitnessScript
-	hashCache := input.NewTxSigHashesV0Only(localCommitTx)
-	sigHash, err := txscript.CalcWitnessSigHash(
-		multiSigScript, hashCache, txscript.SigHashAll,
-		localCommitTx, 0, int64(lc.channelState.Capacity),
-	)
-	if err != nil {
-		// TODO(roasbeef): fetchview has already mutated the HTLCs...
-		//  * need to either roll-back, or make pure
-		return err
-	}
-
 	// As an optimization, we'll generate a series of jobs for the worker
-	// pool to verify each of the HTLc signatures presented. Once
+	// pool to verify each of the HTLC signatures presented. Once
 	// generated, we'll submit these jobs to the worker pool.
 	var leaseExpiry uint32
 	if lc.channelState.ChanType.HasLeaseExpiration() {
@@ -4783,29 +4891,104 @@ func (lc *LightningChannel) ReceiveNewCommitment(commitSigs *CommitSigs) error {
 	cancelChan := make(chan struct{})
 	verifyResps := lc.sigPool.SubmitVerifyBatch(verifyJobs, cancelChan)
 
+	localCommitTx := localCommitmentView.txn
+
 	// While the HTLC verification jobs are proceeding asynchronously,
 	// we'll ensure that the newly constructed commitment state has a valid
 	// signature.
-	verifyKey := lc.channelState.RemoteChanCfg.MultiSigKey.PubKey
+	//
+	// To do that we'll, construct the sighash of the commitment
+	// transaction corresponding to this newly proposed state update.  If
+	// this is a taproot channel, then in order to validate the sighash,
+	// we'll need to call into the relevant tapscript methods.
+	if lc.channelState.ChanType.IsTaproot() {
+		localSession := lc.musigSessions.LocalSession
 
-	cSig, err := commitSigs.CommitSig.ToSignature()
-	if err != nil {
-		return err
-	}
-	if !cSig.Verify(sigHash, verifyKey) {
-		close(cancelChan)
+		// As we want to ensure we never write nonces to disk, we'll
+		// use the shachain state to generate a nonce for our next
+		// local state. Similar to generateRevocation, we do height + 2
+		// (next height + 1) here, as this is for the _next_ local
+		// state, and we're about to accept height + 1.
+		localCtrNonce := WithLocalCounterNonce(
+			nextHeight+1, lc.taprootNonceProducer,
+		)
+		nextVerificationNonce, err := localSession.VerifyCommitSig(
+			localCommitTx, commitSigs.PartialSig, localCtrNonce,
+		)
+		if err != nil {
+			close(cancelChan)
 
-		// If we fail to validate their commitment signature, we'll
-		// generate a special error to send over the protocol. We'll
-		// include the exact signature and commitment we failed to
-		// verify against in order to aide debugging.
-		var txBytes bytes.Buffer
-		localCommitTx.Serialize(&txBytes)
-		return &InvalidCommitSigError{
-			commitHeight: nextHeight,
-			commitSig:    commitSigs.CommitSig.ToSignatureBytes(),
-			sigHash:      sigHash,
-			commitTx:     txBytes.Bytes(),
+			var sigErr invalidPartialSigError
+			if errors.As(err, &sigErr) {
+				// If we fail to validate their commitment
+				// signature, we'll generate a special error to
+				// send over the protocol. We'll include the
+				// exact signature and commitment we failed to
+				// verify against in order to aide debugging.
+				var txBytes bytes.Buffer
+				localCommitTx.Serialize(&txBytes)
+				return &InvalidPartialCommitSigError{
+					invalidPartialSigError: &sigErr,
+					InvalidCommitSigError: InvalidCommitSigError{ //nolint:lll
+						commitHeight: nextHeight,
+						commitTx:     txBytes.Bytes(),
+					},
+				}
+			}
+
+			return err
+		}
+
+		// Now that we have the next verification nonce for our local
+		// session, we'll refresh it to yield a new session we'll use
+		// for the next incoming signature.
+		newLocalSession, err := lc.musigSessions.LocalSession.Refresh(
+			nextVerificationNonce,
+		)
+		if err != nil {
+			return err
+		}
+		lc.musigSessions.LocalSession = newLocalSession
+
+	} else {
+		multiSigScript := lc.signDesc.WitnessScript
+		prevFetcher := txscript.NewCannedPrevOutputFetcher(
+			multiSigScript, int64(lc.channelState.Capacity),
+		)
+		hashCache := txscript.NewTxSigHashes(localCommitTx, prevFetcher)
+
+		sigHash, err := txscript.CalcWitnessSigHash(
+			multiSigScript, hashCache, txscript.SigHashAll,
+			localCommitTx, 0, int64(lc.channelState.Capacity),
+		)
+		if err != nil {
+			// TODO(roasbeef): fetchview has already mutated the HTLCs...
+			//  * need to either roll-back, or make pure
+			return err
+		}
+
+		verifyKey := lc.channelState.RemoteChanCfg.MultiSigKey.PubKey
+
+		cSig, err := commitSigs.CommitSig.ToSignature()
+		if err != nil {
+			return err
+		}
+		if !cSig.Verify(sigHash, verifyKey) {
+			close(cancelChan)
+
+			// If we fail to validate their commitment signature,
+			// we'll generate a special error to send over the
+			// protocol. We'll include the exact signature and
+			// commitment we failed to verify against in order to
+			// aide debugging.
+			var txBytes bytes.Buffer
+			localCommitTx.Serialize(&txBytes)
+			return &InvalidCommitSigError{
+				commitHeight: nextHeight,
+				commitSig:    commitSigs.CommitSig.ToSignatureBytes(),
+				sigHash:      sigHash,
+				commitTx:     txBytes.Bytes(),
+			}
 		}
 	}
 
@@ -4842,8 +5025,21 @@ func (lc *LightningChannel) ReceiveNewCommitment(commitSigs *CommitSigs) error {
 	}
 
 	// The signature checks out, so we can now add the new commitment to
-	// our local commitment chain.
-	localCommitmentView.sig = commitSigs.CommitSig.ToSignatureBytes()
+	// our local commitment chain. For regular channels, we can just
+	// serialize the ECDSA sig. For taproot channels, we'll serialize the
+	// partial sig that includes the nonce that was used for signing.
+	if lc.channelState.ChanType.IsTaproot() {
+		var sigBytes [lnwire.PartialSigWithNonceLen]byte
+		b := bytes.NewBuffer(sigBytes[0:0])
+		if err := commitSigs.PartialSig.Encode(b); err != nil {
+			return err
+		}
+
+		localCommitmentView.sig = sigBytes[:]
+	} else {
+		localCommitmentView.sig = commitSigs.CommitSig.ToSignatureBytes()
+	}
+
 	lc.localCommitChain.addCommitment(localCommitmentView)
 
 	return nil
@@ -5021,6 +5217,17 @@ func (lc *LightningChannel) RevokeCurrentCommitment() (*lnwire.RevokeAndAck,
 	revocationMsg.ChanID = lnwire.NewChanIDFromOutPoint(
 		&lc.channelState.FundingOutpoint,
 	)
+
+	// If this is a taproot channel, We've now accepted+revoked a new
+	// commitment, so we'll send the remote party another verification
+	// nonce they can use to generate new commitments.
+	if lc.channelState.ChanType.IsTaproot() {
+		localSession := lc.musigSessions.LocalSession
+		nextVerificationNonce := localSession.VerificationNonce()
+		revocationMsg.LocalNonce = (*lnwire.Musig2Nonce)(
+			&nextVerificationNonce.PubNonce,
+		)
+	}
 
 	return revocationMsg, newCommitment.Htlcs, finalHtlcs, nil
 }
@@ -5248,6 +5455,24 @@ func (lc *LightningChannel) ReceiveRevocation(revMsg *lnwire.RevokeAndAck) (
 	)
 	if err != nil {
 		return nil, nil, nil, nil, err
+	}
+
+	// Now that we have a new verification nonce from them, we can refresh
+	// our remote musig2 session which allows us to create another state.
+	if lc.channelState.ChanType.IsTaproot() {
+		if revMsg.LocalNonce == nil {
+			return nil, nil, nil, nil, fmt.Errorf("next " +
+				"revocation nonce not set")
+		}
+		newRemoteSession, err := lc.musigSessions.RemoteSession.Refresh(
+			&musig2.Nonces{
+				PubNonce: *revMsg.LocalNonce,
+			},
+		)
+		if err != nil {
+			return nil, nil, nil, nil, err
+		}
+		lc.musigSessions.RemoteSession = newRemoteSession
 	}
 
 	// At this point, the revocation has been accepted, and we've rotated
@@ -5875,30 +6100,103 @@ func (lc *LightningChannel) getSignedCommitTx() (*wire.MsgTx, error) {
 	localCommit := lc.channelState.LocalCommitment
 	commitTx := localCommit.CommitTx.Copy()
 
-	theirSig, err := ecdsa.ParseDERSignature(localCommit.CommitSig)
-	if err != nil {
-		return nil, err
+	ourKey := lc.channelState.LocalChanCfg.MultiSigKey
+	theirKey := lc.channelState.RemoteChanCfg.MultiSigKey
+
+	var witness wire.TxWitness
+	switch {
+	// If this is a taproot channel, then we'll need to re-derive the nonce
+	// we need to generate a new signature
+	case lc.channelState.ChanType.IsTaproot():
+		// First, we'll need to re-derive the local nonce we sent to
+		// the remote party to create this musig session. We pass in
+		// the same height here as we're generating the nonce needed
+		// for the _current_ state.
+		localNonce, err := NewMusigVerificationNonce(
+			ourKey.PubKey, lc.currentHeight,
+			lc.taprootNonceProducer,
+		)
+		if err != nil {
+			return nil, err
+		}
+
+		// Now that we have the local nonce, we'll re-create the musig
+		// session we had for this height.
+		musigSession := NewPartialMusigSession(
+			*localNonce, ourKey, theirKey, lc.Signer,
+			&lc.fundingOutput, LocalMusigCommit,
+		)
+
+		var remoteSig lnwire.PartialSigWithNonce
+		err = remoteSig.Decode(
+			bytes.NewReader(localCommit.CommitSig),
+		)
+		if err != nil {
+			return nil, fmt.Errorf("unable to decode remote "+
+				"partial sig: %w", err)
+		}
+
+		// Next, we'll manually finalize the session with the signing
+		// nonce we got from the remote party which is embedded in the
+		// signature we have.
+		err = musigSession.FinalizeSession(musig2.Nonces{
+			PubNonce: remoteSig.Nonce,
+		})
+		if err != nil {
+			return nil, fmt.Errorf("unable to finalize musig "+
+				"session: %w", err)
+		}
+
+		// Now that the session has been finalized, we can generate our
+		// half of the signature for the state. We don't capture the
+		// sig as it's stored within the session.
+		if _, err := musigSession.SignCommit(commitTx); err != nil {
+			return nil, err
+		}
+
+		// The final step is now to combine this signature we generated
+		// above, with the remote party's signature. We only need to
+		// pass the remote sig, as the local sig was already cached in
+		// the session.
+		var partialSig MusigPartialSig
+		partialSig.FromWireSig(&remoteSig)
+		finalSig, err := musigSession.CombineSigs(partialSig.sig)
+		if err != nil {
+			return nil, fmt.Errorf("unable to combine musig "+
+				"partial sigs: %w", err)
+		}
+
+		// The witness is the single keyspend schnorr sig.
+		witness = wire.TxWitness{
+			finalSig.Serialize(),
+		}
+
+	// Otherwise, the final witness we generate will be a normal p2wsh
+	// multi-sig spend.
+	default:
+		theirSig, err := ecdsa.ParseDERSignature(localCommit.CommitSig)
+		if err != nil {
+			return nil, err
+		}
+
+		// With this, we then generate the full witness so the caller
+		// can broadcast a fully signed transaction.
+		lc.signDesc.SigHashes = input.NewTxSigHashesV0Only(commitTx)
+		ourSig, err := lc.Signer.SignOutputRaw(commitTx, lc.signDesc)
+		if err != nil {
+			return nil, err
+		}
+
+		// With the final signature generated, create the witness stack
+		// required to spend from the multi-sig output.
+		witness = input.SpendMultiSig(
+			lc.signDesc.WitnessScript,
+			ourKey.PubKey.SerializeCompressed(), ourSig,
+			theirKey.PubKey.SerializeCompressed(), theirSig,
+		)
 	}
 
-	// With this, we then generate the full witness so the caller can
-	// broadcast a fully signed transaction.
-	lc.signDesc.SigHashes = input.NewTxSigHashesV0Only(commitTx)
-	ourSig, err := lc.Signer.SignOutputRaw(commitTx, lc.signDesc)
-	if err != nil {
-		return nil, err
-	}
-
-	// With the final signature generated, create the witness stack
-	// required to spend from the multi-sig output.
-	ourKey := lc.channelState.LocalChanCfg.MultiSigKey.PubKey.
-		SerializeCompressed()
-	theirKey := lc.channelState.RemoteChanCfg.MultiSigKey.PubKey.
-		SerializeCompressed()
-
-	commitTx.TxIn[0].Witness = input.SpendMultiSig(
-		lc.signDesc.WitnessScript, ourKey,
-		ourSig, theirKey, theirSig,
-	)
+	commitTx.TxIn[0].Witness = witness
 
 	return commitTx, nil
 }
@@ -7777,14 +8075,17 @@ func (lc *LightningChannel) unsignedLocalUpdates(remoteMessageIndex,
 // GenMusigNonces generates the verification nonce to start off a new musig2
 // channel session.
 func (lc *LightningChannel) GenMusigNonces() (*musig2.Nonces, error) {
-	lc.RLock()
-	defer lc.RUnlock()
+	lc.Lock()
+	defer lc.Unlock()
 
 	var err error
+
+	// We pass in the current height+1 as this'll be the set of
+	// verification nonces we'll send to the party to create our _next_
+	// state.
 	lc.pendingVerificationNonce, err = NewMusigVerificationNonce(
 		lc.channelState.LocalChanCfg.MultiSigKey.PubKey,
-		lc.currentHeight, lc.channelState.RevocationProducer,
-		false,
+		lc.currentHeight+1, lc.taprootNonceProducer,
 	)
 	if err != nil {
 		return nil, err
@@ -7796,20 +8097,10 @@ func (lc *LightningChannel) GenMusigNonces() (*musig2.Nonces, error) {
 // NewMusigVerificationNonce generates the local or verification nonce for
 // another musig2 session. In order to permit our implementation to not have to
 // write any secret nonce state to disk, we'll use the _next_ shachain
-// pre-image as our primary randomness source.
-func NewMusigVerificationNonce(pubKey *btcec.PublicKey, currentHeight uint64,
-	shaGen shachain.Producer, forBroadcast bool) (*musig2.Nonces, error) {
-
-	// If we're broadcasting this commitment, then we need to get the nonce
-	// for the current height. Otherwise, we'll add one, as we're
-	// generating a local nonce for the _next_ height.
-	targetHeight := func() uint64 {
-		if forBroadcast {
-			return currentHeight
-		}
-
-		return currentHeight + 1
-	}()
+// pre-image as our primary randomness source. When used to generate the nonce
+// again to broadcast our commitment hte current height will be used.
+func NewMusigVerificationNonce(pubKey *btcec.PublicKey, targetHeight uint64,
+	shaGen shachain.Producer) (*musig2.Nonces, error) {
 
 	// Now that we know what height we need, we'll grab the shachain
 	// pre-image at the target destination.
@@ -7836,8 +8127,12 @@ func (lc *LightningChannel) HasRemoteNonces() bool {
 func (lc *LightningChannel) InitRemoteMusigNonces(remoteNonce *musig2.Nonces,
 ) error {
 
-	lc.RLock()
-	defer lc.RUnlock()
+	lc.Lock()
+	defer lc.Unlock()
+
+	if lc.pendingVerificationNonce == nil {
+		return fmt.Errorf("pending verification nonce is not set")
+	}
 
 	// Now that we have the set of local and remote nonces, we can generate
 	// a new pair of musig sessions for our local commitment and the

--- a/lnwallet/channel.go
+++ b/lnwallet/channel.go
@@ -5211,17 +5211,6 @@ func (lc *LightningChannel) RevokeCurrentCommitment() (*lnwire.RevokeAndAck,
 		&lc.channelState.FundingOutpoint,
 	)
 
-	// If this is a taproot channel, We've now accepted+revoked a new
-	// commitment, so we'll send the remote party another verification
-	// nonce they can use to generate new commitments.
-	if lc.channelState.ChanType.IsTaproot() {
-		localSession := lc.musigSessions.LocalSession
-		nextVerificationNonce := localSession.VerificationNonce()
-		revocationMsg.LocalNonce = (*lnwire.Musig2Nonce)(
-			&nextVerificationNonce.PubNonce,
-		)
-	}
-
 	return revocationMsg, newCommitment.Htlcs, finalHtlcs, nil
 }
 
@@ -7761,8 +7750,9 @@ func (lc *LightningChannel) generateRevocation(height uint64) (*lnwire.RevokeAnd
 	// revocation.
 	//
 	// Put simply in the window slides to the left by one.
+	revHeight := height + 2
 	nextCommitSecret, err := lc.channelState.RevocationProducer.AtIndex(
-		height + 2,
+		revHeight,
 	)
 	if err != nil {
 		return nil, err
@@ -7772,6 +7762,21 @@ func (lc *LightningChannel) generateRevocation(height uint64) (*lnwire.RevokeAnd
 	revocationMsg.ChanID = lnwire.NewChanIDFromOutPoint(
 		&lc.channelState.FundingOutpoint,
 	)
+
+	// If this is a taproot channel, then we also need to generate the
+	// verification nonce for this target state.
+	if lc.channelState.ChanType.IsTaproot() {
+		nextVerificationNonce, err := channeldb.NewMusigVerificationNonce( //nolint:lll
+			lc.channelState.LocalChanCfg.MultiSigKey.PubKey,
+			revHeight, lc.taprootNonceProducer,
+		)
+		if err != nil {
+			return nil, err
+		}
+		revocationMsg.LocalNonce = (*lnwire.Musig2Nonce)(
+			&nextVerificationNonce.PubNonce,
+		)
+	}
 
 	return revocationMsg, nil
 }

--- a/lnwallet/channel.go
+++ b/lnwallet/channel.go
@@ -3718,6 +3718,30 @@ func (lc *LightningChannel) validateCommitmentSanity(theirLogCounter,
 	return nil
 }
 
+// CommitSig holds the set of related signatures for a new commitment
+// transaction state.
+type CommitSigs struct {
+	// CommitSig is the normal commitment signature. This will only be a
+	// non-zero commitment signature for taproot channels.
+	CommitSig lnwire.Sig
+
+	// HtlcSigs is the set of signatures for all HTLCs in the commitment
+	// transaction. Depending on the channel type, these will either be
+	// ECDSA or Schnorr signatures.
+	HtlcSigs []lnwire.Sig
+}
+
+// NewCommitState wraps the various signatures needed to properly
+// propose/accept a new commitment state. This includes the signer's nonce for
+// musig2 channels.
+type NewCommitState struct {
+	*CommitSigs
+
+	// PendingHTLCs is the set of new/pending HTLCs produced by this
+	// commitment state.
+	PendingHTLCs []channeldb.HTLC
+}
+
 // SignNextCommitment signs a new commitment which includes any previous
 // unsettled HTLCs, any new HTLCs, and any modifications to prior HTLCs
 // committed in previous commitment updates. Signing a new commitment
@@ -3729,8 +3753,7 @@ func (lc *LightningChannel) validateCommitmentSanity(theirLogCounter,
 // any). The HTLC signatures are sorted according to the BIP 69 order of the
 // HTLC's on the commitment transaction. Finally, the new set of pending HTLCs
 // for the remote party's commitment are also returned.
-func (lc *LightningChannel) SignNextCommitment() (lnwire.Sig, []lnwire.Sig,
-	[]channeldb.HTLC, error) {
+func (lc *LightningChannel) SignNextCommitment() (*NewCommitState, error) {
 
 	lc.Lock()
 	defer lc.Unlock()
@@ -3757,7 +3780,7 @@ func (lc *LightningChannel) SignNextCommitment() (lnwire.Sig, []lnwire.Sig,
 	if unacked || commitPoint == nil {
 		lc.log.Tracef("waiting for remote ack=%v, nil "+
 			"RemoteNextRevocation: %v", unacked, commitPoint == nil)
-		return sig, htlcSigs, nil, ErrNoWindow
+		return nil, ErrNoWindow
 	}
 
 	// Determine the last update on the remote log that has been locked in.
@@ -3772,7 +3795,7 @@ func (lc *LightningChannel) SignNextCommitment() (lnwire.Sig, []lnwire.Sig,
 		remoteACKedIndex, lc.localUpdateLog.logIndex, true, nil, nil,
 	)
 	if err != nil {
-		return sig, htlcSigs, nil, err
+		return nil, err
 	}
 
 	// Grab the next commitment point for the remote party. This will be
@@ -3795,7 +3818,7 @@ func (lc *LightningChannel) SignNextCommitment() (lnwire.Sig, []lnwire.Sig,
 		remoteACKedIndex, remoteHtlcIndex, keyRing,
 	)
 	if err != nil {
-		return sig, htlcSigs, nil, err
+		return nil, err
 	}
 
 	lc.log.Tracef("extending remote chain to height %v, "+
@@ -3826,7 +3849,7 @@ func (lc *LightningChannel) SignNextCommitment() (lnwire.Sig, []lnwire.Sig,
 		&lc.channelState.RemoteChanCfg, newCommitView,
 	)
 	if err != nil {
-		return sig, htlcSigs, nil, err
+		return nil, err
 	}
 	lc.sigPool.SubmitSignBatch(sigBatch)
 
@@ -3837,12 +3860,12 @@ func (lc *LightningChannel) SignNextCommitment() (lnwire.Sig, []lnwire.Sig,
 	rawSig, err := lc.Signer.SignOutputRaw(newCommitView.txn, lc.signDesc)
 	if err != nil {
 		close(cancelChan)
-		return sig, htlcSigs, nil, err
+		return nil, err
 	}
 	sig, err = lnwire.NewSigFromSignature(rawSig)
 	if err != nil {
 		close(cancelChan)
-		return sig, htlcSigs, nil, err
+		return nil, err
 	}
 
 	// We'll need to send over the signatures to the remote party in the
@@ -3862,7 +3885,7 @@ func (lc *LightningChannel) SignNextCommitment() (lnwire.Sig, []lnwire.Sig,
 		// jobs.
 		if jobResp.Err != nil {
 			close(cancelChan)
-			return sig, htlcSigs, nil, jobResp.Err
+			return nil, jobResp.Err
 		}
 
 		htlcSigs = append(htlcSigs, jobResp.Sig)
@@ -3873,11 +3896,11 @@ func (lc *LightningChannel) SignNextCommitment() (lnwire.Sig, []lnwire.Sig,
 	// can retransmit it if necessary.
 	commitDiff, err := lc.createCommitDiff(newCommitView, sig, htlcSigs)
 	if err != nil {
-		return sig, htlcSigs, nil, err
+		return nil, err
 	}
 	err = lc.channelState.AppendRemoteCommitChain(commitDiff)
 	if err != nil {
-		return sig, htlcSigs, nil, err
+		return nil, err
 	}
 
 	// TODO(roasbeef): check that one eclair bug
@@ -3888,7 +3911,13 @@ func (lc *LightningChannel) SignNextCommitment() (lnwire.Sig, []lnwire.Sig,
 	// latest commitment update.
 	lc.remoteCommitChain.addCommitment(newCommitView)
 
-	return sig, htlcSigs, commitDiff.Commitment.Htlcs, nil
+	return &NewCommitState{
+		CommitSigs: &CommitSigs{
+			CommitSig: sig,
+			HtlcSigs:  htlcSigs,
+		},
+		PendingHTLCs: commitDiff.Commitment.Htlcs,
+	}, nil
 }
 
 // ProcessChanSyncMsg processes a ChannelReestablish message sent by the remote
@@ -4046,19 +4075,21 @@ func (lc *LightningChannel) ProcessChanSyncMsg(
 		// revocation, but also initiate a state transition to re-sync
 		// them.
 		if lc.OweCommitment() {
-			commitSig, htlcSigs, _, err := lc.SignNextCommitment()
+			newCommit, err := lc.SignNextCommitment()
 			switch {
 
 			// If we signed this state, then we'll accumulate
 			// another update to send over.
 			case err == nil:
-				updates = append(updates, &lnwire.CommitSig{
+				commitSig := &lnwire.CommitSig{
 					ChanID: lnwire.NewChanIDFromOutPoint(
 						&lc.channelState.FundingOutpoint,
 					),
-					CommitSig: commitSig,
-					HtlcSigs:  htlcSigs,
-				})
+					CommitSig: newCommit.CommitSig,
+					HtlcSigs:  newCommit.HtlcSigs,
+				}
+
+				updates = append(updates, commitSig)
 
 			// If we get a failure due to not knowing their next
 			// point, then this is fine as they'll either send
@@ -4537,8 +4568,7 @@ var _ error = (*InvalidCommitSigError)(nil)
 // to our local commitment chain. Once we send a revocation for our prior
 // state, then this newly added commitment becomes our current accepted channel
 // state.
-func (lc *LightningChannel) ReceiveNewCommitment(commitSig lnwire.Sig,
-	htlcSigs []lnwire.Sig) error {
+func (lc *LightningChannel) ReceiveNewCommitment(commitSigs *CommitSigs) error {
 
 	lc.Lock()
 	defer lc.Unlock()
@@ -4633,7 +4663,7 @@ func (lc *LightningChannel) ReceiveNewCommitment(commitSig lnwire.Sig,
 		leaseExpiry = lc.channelState.ThawHeight
 	}
 	verifyJobs, err := genHtlcSigValidationJobs(
-		localCommitmentView, keyRing, htlcSigs,
+		localCommitmentView, keyRing, commitSigs.HtlcSigs,
 		lc.channelState.ChanType, lc.channelState.IsInitiator,
 		leaseExpiry, &lc.channelState.LocalChanCfg,
 		&lc.channelState.RemoteChanCfg,
@@ -4650,7 +4680,7 @@ func (lc *LightningChannel) ReceiveNewCommitment(commitSig lnwire.Sig,
 	// signature.
 	verifyKey := lc.channelState.RemoteChanCfg.MultiSigKey.PubKey
 
-	cSig, err := commitSig.ToSignature()
+	cSig, err := commitSigs.CommitSig.ToSignature()
 	if err != nil {
 		return err
 	}
@@ -4665,7 +4695,7 @@ func (lc *LightningChannel) ReceiveNewCommitment(commitSig lnwire.Sig,
 		localCommitTx.Serialize(&txBytes)
 		return &InvalidCommitSigError{
 			commitHeight: nextHeight,
-			commitSig:    commitSig.ToSignatureBytes(),
+			commitSig:    commitSigs.CommitSig.ToSignatureBytes(),
 			sigHash:      sigHash,
 			commitTx:     txBytes.Bytes(),
 		}
@@ -4705,7 +4735,7 @@ func (lc *LightningChannel) ReceiveNewCommitment(commitSig lnwire.Sig,
 
 	// The signature checks out, so we can now add the new commitment to
 	// our local commitment chain.
-	localCommitmentView.sig = commitSig.ToSignatureBytes()
+	localCommitmentView.sig = commitSigs.CommitSig.ToSignatureBytes()
 	lc.localCommitChain.addCommitment(localCommitmentView)
 
 	return nil
@@ -5723,7 +5753,7 @@ func (lc *LightningChannel) RemoteUpfrontShutdownScript() lnwire.DeliveryAddress
 // AbsoluteThawHeight determines a frozen channel's absolute thaw height. If
 // the channel is not frozen, then 0 is returned.
 //
-// An error is returned if the channel is penidng, or is an unconfirmed zero
+// An error is returned if the channel is pending, or is an unconfirmed zero
 // conf channel.
 func (lc *LightningChannel) AbsoluteThawHeight() (uint32, error) {
 	return lc.channelState.AbsoluteThawHeight()

--- a/lnwallet/chanvalidate/validate.go
+++ b/lnwallet/chanvalidate/validate.go
@@ -186,10 +186,14 @@ func Validate(ctx *Context) (*wire.OutPoint, error) {
 	// If we reach this point, then all other checks have succeeded, so
 	// we'll now attempt a full Script VM execution to ensure that we're
 	// able to close the channel using this initial state.
+	prevFetcher := txscript.NewCannedPrevOutputFetcher(
+		ctx.MultiSigPkScript, fundingValue,
+	)
+	commitTx := ctx.CommitCtx.FullySignedCommitTx
+	hashCache := txscript.NewTxSigHashes(commitTx, prevFetcher)
 	vm, err := txscript.NewEngine(
-		ctx.MultiSigPkScript, ctx.CommitCtx.FullySignedCommitTx,
-		0, txscript.StandardVerifyFlags, nil, nil, fundingValue,
-		txscript.NewCannedPrevOutputFetcher(ctx.MultiSigPkScript, 0),
+		ctx.MultiSigPkScript, commitTx, 0, txscript.StandardVerifyFlags,
+		nil, hashCache, fundingValue, prevFetcher,
 	)
 	if err != nil {
 		return nil, err

--- a/lnwallet/musig_session.go
+++ b/lnwallet/musig_session.go
@@ -408,6 +408,23 @@ func WithLocalCounterNonce(targetHeight uint64,
 	}
 }
 
+// invalidPartialSigError is used to return additional debug information to a
+// caller that encounters an invalid partial sig.
+type invalidPartialSigError struct {
+	partialSig        []byte
+	sigHash           []byte
+	signingNonce      [musig2.PubNonceSize]byte
+	verificationNonce [musig2.PubNonceSize]byte
+}
+
+// Error returns the error string for the partial sig error.
+func (i invalidPartialSigError) Error() string {
+	return fmt.Sprintf("invalid partial sig: partial_sig=%x, "+
+		"sig_hash=%x, signing_nonce=%x, verification_nonce=%x",
+		i.partialSig, i.sigHash, i.signingNonce[:],
+		i.verificationNonce[:])
+}
+
 // VerifyCommitSig attempts to verify the passed partial signature against the
 // passed commitment transaction. A keyspend sighash is assumed to generate the
 // signed message. As we never re-use nonces, a new verification nonce (our

--- a/lnwallet/revocation_producer.go
+++ b/lnwallet/revocation_producer.go
@@ -50,7 +50,7 @@ func (l *LightningWallet) nextRevocationProducer(res *ChannelReservation,
 	// Once we have the root, we can then generate our shachain producer
 	// and from that generate the per-commitment point.
 	shaChainRoot := shachain.NewRevocationProducer(revRoot)
-	taprootShaChainRoot, err := deriveMusig2Shachain(revRoot)
+	taprootShaChainRoot, err := deriveMusig2Shachain(shaChainRoot)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/lnwallet/revocation_producer.go
+++ b/lnwallet/revocation_producer.go
@@ -3,6 +3,7 @@
 package lnwallet
 
 import (
+	"github.com/lightningnetwork/lnd/channeldb"
 	"github.com/lightningnetwork/lnd/keychain"
 	"github.com/lightningnetwork/lnd/shachain"
 )
@@ -50,7 +51,7 @@ func (l *LightningWallet) nextRevocationProducer(res *ChannelReservation,
 	// Once we have the root, we can then generate our shachain producer
 	// and from that generate the per-commitment point.
 	shaChainRoot := shachain.NewRevocationProducer(revRoot)
-	taprootShaChainRoot, err := deriveMusig2Shachain(shaChainRoot)
+	taprootShaChainRoot, err := channeldb.DeriveMusig2Shachain(shaChainRoot)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/lnwallet/revocation_producer_itest.go
+++ b/lnwallet/revocation_producer_itest.go
@@ -4,6 +4,7 @@ package lnwallet
 
 import (
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"github.com/lightningnetwork/lnd/channeldb"
 	"github.com/lightningnetwork/lnd/keychain"
 	"github.com/lightningnetwork/lnd/shachain"
 )
@@ -46,7 +47,9 @@ func (l *LightningWallet) nextRevocationProducer(res *ChannelReservation,
 		}
 		shaChainRoot := shachain.NewRevocationProducer(*revRoot)
 
-		taprootShaChainRoot, err := deriveMusig2Shachain(*revRoot)
+		taprootShaChainRoot, err := channeldb.DeriveMusig2Shachain(
+			shaChainRoot,
+		)
 		if err != nil {
 			return nil, nil, err
 		}
@@ -81,7 +84,9 @@ func (l *LightningWallet) nextRevocationProducer(res *ChannelReservation,
 	// Once we have the root, we can then generate our shachain producer
 	// and from that generate the per-commitment point.
 	shaChainRoot := shachain.NewRevocationProducer(revRoot)
-	taprootShaChainRoot, err := deriveMusig2Shachain(revRoot)
+	taprootShaChainRoot, err := channeldb.DeriveMusig2Shachain(
+		shaChainRoot,
+	)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/lnwallet/sigpool.go
+++ b/lnwallet/sigpool.go
@@ -113,8 +113,6 @@ type SignJobResp struct {
 	Err error
 }
 
-// TODO(roasbeef); fix description
-
 // SigPool is a struct that is meant to allow the current channel state
 // machine to parallelize all signature generation and verification. This
 // struct is needed as _each_ HTLC when creating a commitment transaction
@@ -206,7 +204,11 @@ func (s *SigPool) poolWorker() {
 				}
 			}
 
+			// Use the sig mapper to go from the input.Signature
+			// into the serialized lnwire.Sig that we'll send
+			// across the wire.
 			sig, err := lnwire.NewSigFromSignature(rawSig)
+
 			select {
 			case sigMsg.Resp <- SignJobResp{
 				Sig: sig,

--- a/lnwallet/test_utils.go
+++ b/lnwallet/test_utils.go
@@ -534,10 +534,12 @@ func ForceStateTransition(chanA, chanB *LightningChannel) error {
 		return err
 	}
 
-	if _, _, _, _, err := chanA.ReceiveRevocation(bobRevocation); err != nil {
+	_, _, _, _, err = chanA.ReceiveRevocation(bobRevocation)
+	if err != nil {
 		return err
 	}
-	if err := chanA.ReceiveNewCommitment(bobNewCommit.CommitSigs); err != nil {
+	err = chanA.ReceiveNewCommitment(bobNewCommit.CommitSigs)
+	if err != nil {
 		return err
 	}
 
@@ -545,7 +547,8 @@ func ForceStateTransition(chanA, chanB *LightningChannel) error {
 	if err != nil {
 		return err
 	}
-	if _, _, _, _, err := chanB.ReceiveRevocation(aliceRevocation); err != nil {
+	_, _, _, _, err = chanB.ReceiveRevocation(aliceRevocation)
+	if err != nil {
 		return err
 	}
 

--- a/lnwallet/test_utils.go
+++ b/lnwallet/test_utils.go
@@ -495,11 +495,12 @@ func calcStaticFee(chanType channeldb.ChannelType, numHTLCs int) btcutil.Amount 
 // pending updates. This method is useful when testing interactions between two
 // live state machines.
 func ForceStateTransition(chanA, chanB *LightningChannel) error {
-	aliceSig, aliceHtlcSigs, _, err := chanA.SignNextCommitment()
+	aliceNewCommit, err := chanA.SignNextCommitment()
 	if err != nil {
 		return err
 	}
-	if err = chanB.ReceiveNewCommitment(aliceSig, aliceHtlcSigs); err != nil {
+	err = chanB.ReceiveNewCommitment(aliceNewCommit.CommitSigs)
+	if err != nil {
 		return err
 	}
 
@@ -507,7 +508,7 @@ func ForceStateTransition(chanA, chanB *LightningChannel) error {
 	if err != nil {
 		return err
 	}
-	bobSig, bobHtlcSigs, _, err := chanB.SignNextCommitment()
+	bobNewCommit, err := chanB.SignNextCommitment()
 	if err != nil {
 		return err
 	}
@@ -515,7 +516,7 @@ func ForceStateTransition(chanA, chanB *LightningChannel) error {
 	if _, _, _, _, err := chanA.ReceiveRevocation(bobRevocation); err != nil {
 		return err
 	}
-	if err := chanA.ReceiveNewCommitment(bobSig, bobHtlcSigs); err != nil {
+	if err := chanA.ReceiveNewCommitment(bobNewCommit.CommitSigs); err != nil {
 		return err
 	}
 

--- a/lnwallet/transactions.go
+++ b/lnwallet/transactions.go
@@ -8,6 +8,7 @@ import (
 	"github.com/btcsuite/btcd/btcutil"
 	"github.com/btcsuite/btcd/wire"
 	"github.com/lightningnetwork/lnd/channeldb"
+	"github.com/lightningnetwork/lnd/input"
 )
 
 const (
@@ -41,9 +42,13 @@ var (
 // state transition to create another output which actually allows redemption
 // or revocation of an HTLC.
 //
-// In order to spend the HTLC output, the witness for the passed transaction
-// should be:
+// In order to spend the segwit v0 HTLC output, the witness for the passed
+// transaction should be:
 //   - <0> <sender sig> <recvr sig> <preimage>
+//
+// In order to spend the segwit v1 (taproot) HTLC output, the witness for the
+// passed transaction should be:
+//   - <sender sig> <receiver sig> <preimage> <sucess_script> <control_block>
 func CreateHtlcSuccessTx(chanType channeldb.ChannelType, initiator bool,
 	htlcOutput wire.OutPoint, htlcAmt btcutil.Amount, csvDelay,
 	leaseExpiry uint32, revocationKey, delayKey *btcec.PublicKey) (
@@ -62,10 +67,12 @@ func CreateHtlcSuccessTx(chanType channeldb.ChannelType, initiator bool,
 	}
 	successTx.AddTxIn(txin)
 
+	var pkScript []byte
+
 	// Next, we'll generate the script used as the output for all second
 	// level HTLC which forces a covenant w.r.t what can be done with all
 	// HTLC outputs.
-	script, err := SecondLevelHtlcScript(
+	scriptInfo, err := SecondLevelHtlcScript(
 		chanType, initiator, revocationKey, delayKey, csvDelay,
 		leaseExpiry,
 	)
@@ -73,11 +80,13 @@ func CreateHtlcSuccessTx(chanType channeldb.ChannelType, initiator bool,
 		return nil, err
 	}
 
+	pkScript = scriptInfo.PkScript
+
 	// Finally, the output is simply the amount of the HTLC (minus the
 	// required fees), paying to the timeout script.
 	successTx.AddTxOut(&wire.TxOut{
 		Value:    int64(htlcAmt),
-		PkScript: script.PkScript,
+		PkScript: pkScript,
 	})
 
 	return successTx, nil
@@ -92,9 +101,13 @@ func CreateHtlcSuccessTx(chanType channeldb.ChannelType, initiator bool,
 // transaction is locked with an absolute lock-time so the sender can only
 // attempt to claim the output using it after the lock time has passed.
 //
-// In order to spend the HTLC output, the witness for the passed transaction
-// should be:
-// * <0> <sender sig> <receiver sig> <0>
+// In order to spend the HTLC output for segwit v0, the witness for the passed
+// transaction should be:
+//   - <0> <sender sig> <receiver sig> <0>
+//
+// In order to spend the HTLC output for segwit v1, then witness for the passed
+// transaction should be:
+//   - <sender sig> <receiver sig> <timeout_script> <control_block>
 //
 // NOTE: The passed amount for the HTLC should take into account the required
 // fee rate at the time the HTLC was created. The fee should be able to
@@ -121,22 +134,43 @@ func CreateHtlcTimeoutTx(chanType channeldb.ChannelType, initiator bool,
 	}
 	timeoutTx.AddTxIn(txin)
 
-	// Next, we'll generate the script used as the output for all second
-	// level HTLC which forces a covenant w.r.t what can be done with all
-	// HTLC outputs.
-	script, err := SecondLevelHtlcScript(
-		chanType, initiator, revocationKey, delayKey, csvDelay,
-		leaseExpiry,
-	)
-	if err != nil {
-		return nil, err
+	var pkScript []byte
+
+	// Depending on if this is a taproot channel or not, we'll create a v0
+	// vs v1 segwit script.
+	if chanType.IsTaproot() {
+		taprootOutputKey, err := input.TaprootSecondLevelHtlcScript(
+			revocationKey, delayKey, csvDelay,
+		)
+		if err != nil {
+			return nil, err
+		}
+
+		pkScript, err = input.PayToTaprootScript(taprootOutputKey)
+		if err != nil {
+			return nil, err
+		}
+
+	} else {
+		// Next, we'll generate the script used as the output for all second
+		// level HTLC which forces a covenant w.r.t what can be done with all
+		// HTLC outputs.
+		scriptInfo, err := SecondLevelHtlcScript(
+			chanType, initiator, revocationKey, delayKey, csvDelay,
+			leaseExpiry,
+		)
+		if err != nil {
+			return nil, err
+		}
+
+		pkScript = scriptInfo.PkScript
 	}
 
 	// Finally, the output is simply the amount of the HTLC (minus the
 	// required fees), paying to the regular second level HTLC script.
 	timeoutTx.AddTxOut(&wire.TxOut{
 		Value:    int64(htlcAmt),
-		PkScript: script.PkScript,
+		PkScript: pkScript,
 	})
 
 	return timeoutTx, nil

--- a/lnwallet/transactions_test.go
+++ b/lnwallet/transactions_test.go
@@ -285,10 +285,10 @@ func testVectors(t *testing.T, chanType channeldb.ChannelType, test testCase) {
 
 	// Execute commit dance to arrive at the point where the local node has
 	// received the test commitment and the remote signature.
-	localSig, localHtlcSigs, _, err := localChannel.SignNextCommitment()
+	localNewCommit, err := localChannel.SignNextCommitment()
 	require.NoError(t, err, "local unable to sign commitment")
 
-	err = remoteChannel.ReceiveNewCommitment(localSig, localHtlcSigs)
+	err = remoteChannel.ReceiveNewCommitment(localNewCommit.CommitSigs)
 	require.NoError(t, err)
 
 	revMsg, _, _, err := remoteChannel.RevokeCurrentCommitment()
@@ -297,16 +297,16 @@ func testVectors(t *testing.T, chanType channeldb.ChannelType, test testCase) {
 	_, _, _, _, err = localChannel.ReceiveRevocation(revMsg)
 	require.NoError(t, err)
 
-	remoteSig, remoteHtlcSigs, _, err := remoteChannel.SignNextCommitment()
+	remoteNewCommit, err := remoteChannel.SignNextCommitment()
 	require.NoError(t, err)
 
-	require.Equal(t, test.RemoteSigHex, hex.EncodeToString(remoteSig.ToSignatureBytes()))
+	require.Equal(t, test.RemoteSigHex, hex.EncodeToString(remoteNewCommit.CommitSig.ToSignatureBytes()))
 
-	for i, sig := range remoteHtlcSigs {
+	for i, sig := range remoteNewCommit.HtlcSigs {
 		require.Equal(t, test.HtlcDescs[i].RemoteSigHex, hex.EncodeToString(sig.ToSignatureBytes()))
 	}
 
-	err = localChannel.ReceiveNewCommitment(remoteSig, remoteHtlcSigs)
+	err = localChannel.ReceiveNewCommitment(remoteNewCommit.CommitSigs)
 	require.NoError(t, err)
 
 	_, _, _, err = localChannel.RevokeCurrentCommitment()

--- a/lnwallet/transactions_test.go
+++ b/lnwallet/transactions_test.go
@@ -300,10 +300,18 @@ func testVectors(t *testing.T, chanType channeldb.ChannelType, test testCase) {
 	remoteNewCommit, err := remoteChannel.SignNextCommitment()
 	require.NoError(t, err)
 
-	require.Equal(t, test.RemoteSigHex, hex.EncodeToString(remoteNewCommit.CommitSig.ToSignatureBytes()))
+	require.Equal(
+		t, test.RemoteSigHex,
+		hex.EncodeToString(
+			remoteNewCommit.CommitSig.ToSignatureBytes(),
+		),
+	)
 
 	for i, sig := range remoteNewCommit.HtlcSigs {
-		require.Equal(t, test.HtlcDescs[i].RemoteSigHex, hex.EncodeToString(sig.ToSignatureBytes()))
+		require.Equal(
+			t, test.HtlcDescs[i].RemoteSigHex,
+			hex.EncodeToString(sig.ToSignatureBytes()),
+		)
 	}
 
 	err = localChannel.ReceiveNewCommitment(remoteNewCommit.CommitSigs)
@@ -321,7 +329,10 @@ func testVectors(t *testing.T, chanType channeldb.ChannelType, test testCase) {
 	var txBytes bytes.Buffer
 	require.NoError(t, forceCloseSum.CloseTx.Serialize(&txBytes))
 
-	require.Equal(t, test.ExpectedCommitmentTxHex, hex.EncodeToString(txBytes.Bytes()))
+	require.Equal(
+		t, test.ExpectedCommitmentTxHex,
+		hex.EncodeToString(txBytes.Bytes()),
+	)
 
 	// Obtain the second level transactions that the local node's channel
 	// state machine has produced. Store them in a map indexed by commit tx

--- a/lnwallet/wallet.go
+++ b/lnwallet/wallet.go
@@ -2373,26 +2373,43 @@ func (l *LightningWallet) ValidateChannel(channelState *channeldb.OpenChannel,
 	if err != nil {
 		return err
 	}
-	signedCommitTx, err := channel.getSignedCommitTx()
-	if err != nil {
-		return err
-	}
+
+	localKey := channelState.LocalChanCfg.MultiSigKey.PubKey
+	remoteKey := channelState.RemoteChanCfg.MultiSigKey.PubKey
 
 	// We'll also need the multi-sig witness script itself so the
 	// chanvalidate package can check it for correctness against the
 	// funding transaction, and also commitment validity.
-	localKey := channelState.LocalChanCfg.MultiSigKey.PubKey
-	remoteKey := channelState.RemoteChanCfg.MultiSigKey.PubKey
-	witnessScript, err := input.GenMultiSigScript(
-		localKey.SerializeCompressed(),
-		remoteKey.SerializeCompressed(),
-	)
+	var fundingScript []byte
+	if channelState.ChanType.IsTaproot() {
+		fundingScript, _, err = input.GenTaprootFundingScript(
+			localKey, remoteKey, int64(channel.Capacity),
+		)
+		if err != nil {
+			return err
+		}
+
+	} else {
+		witnessScript, err := input.GenMultiSigScript(
+			localKey.SerializeCompressed(),
+			remoteKey.SerializeCompressed(),
+		)
+		if err != nil {
+			return err
+		}
+		fundingScript, err = input.WitnessScriptHash(witnessScript)
+		if err != nil {
+			return err
+		}
+	}
+
+	signedCommitTx, err := channel.getSignedCommitTx()
 	if err != nil {
 		return err
 	}
-	pkScript, err := input.WitnessScriptHash(witnessScript)
-	if err != nil {
-		return err
+	commitCtx := &chanvalidate.CommitmentContext{
+		Value:               channel.Capacity,
+		FullySignedCommitTx: signedCommitTx,
 	}
 
 	// Finally, we'll pass in all the necessary context needed to fully
@@ -2402,12 +2419,9 @@ func (l *LightningWallet) ValidateChannel(channelState *channeldb.OpenChannel,
 		Locator: &chanvalidate.OutPointChanLocator{
 			ChanPoint: channelState.FundingOutpoint,
 		},
-		MultiSigPkScript: pkScript,
+		MultiSigPkScript: fundingScript,
 		FundingTx:        fundingTx,
-		CommitCtx: &chanvalidate.CommitmentContext{
-			Value:               channel.Capacity,
-			FullySignedCommitTx: signedCommitTx,
-		},
+		CommitCtx:        commitCtx,
 	})
 	if err != nil {
 		return err

--- a/lnwallet/wallet.go
+++ b/lnwallet/wallet.go
@@ -2388,7 +2388,6 @@ func (l *LightningWallet) ValidateChannel(channelState *channeldb.OpenChannel,
 		if err != nil {
 			return err
 		}
-
 	} else {
 		witnessScript, err := input.GenMultiSigScript(
 			localKey.SerializeCompressed(),

--- a/peer/brontide.go
+++ b/peer/brontide.go
@@ -2945,6 +2945,7 @@ func (p *Brontide) createChanCloser(channel *lnwallet.LightningChannel,
 	chanCloser := chancloser.NewChanCloser(
 		chancloser.ChanCloseCfg{
 			Channel:      channel,
+			MusigSession: NewMusigChanCloser(channel),
 			FeeEstimator: &chancloser.SimpleCoopFeeEstimator{},
 			BroadcastTx:  p.cfg.Wallet.PublishTransaction,
 			DisableChannel: func(op wire.OutPoint) error {

--- a/peer/musig_chan_closer.go
+++ b/peer/musig_chan_closer.go
@@ -1,0 +1,127 @@
+package peer
+
+import (
+	"fmt"
+
+	"github.com/btcsuite/btcd/btcec/v2/schnorr/musig2"
+	"github.com/lightningnetwork/lnd/input"
+	"github.com/lightningnetwork/lnd/lnwallet"
+	"github.com/lightningnetwork/lnd/lnwallet/chancloser"
+	"github.com/lightningnetwork/lnd/lnwire"
+)
+
+// MusigChanCloser is an adapter over the normal channel state machine that
+// allows the chan closer to handle the musig2 details of closing taproot
+// channels.
+type MusigChanCloser struct {
+	channel *lnwallet.LightningChannel
+
+	musigSession *lnwallet.MusigSession
+
+	localNonce  *musig2.Nonces
+	remoteNonce *musig2.Nonces
+}
+
+// NewMusigChanCloser creates a new musig chan closer from a normal channel.
+func NewMusigChanCloser(channel *lnwallet.LightningChannel) *MusigChanCloser {
+	return &MusigChanCloser{
+		channel: channel,
+	}
+}
+
+// ProposalClosingOpts returns the options that should be used when
+// generating a new co-op close signature.
+func (m *MusigChanCloser) ProposalClosingOpts() ([]lnwallet.ChanCloseOpt, error) {
+	switch {
+	case m.localNonce == nil:
+		return nil, fmt.Errorf("local nonce not generated")
+
+	case m.remoteNonce == nil:
+		return nil, fmt.Errorf("remote nonce not generated")
+	}
+
+	localKey, remoteKey := m.channel.MultiSigKeys()
+	m.musigSession = lnwallet.NewPartialMusigSession(
+		*m.localNonce, localKey, remoteKey,
+		m.channel.Signer, m.channel.FundingTxOut(),
+		lnwallet.RemoteMusigCommit,
+	)
+
+	err := m.musigSession.FinalizeSession(*m.remoteNonce)
+	if err != nil {
+		return nil, err
+	}
+
+	return []lnwallet.ChanCloseOpt{
+		lnwallet.WithCoopCloseMusigSession(m.musigSession),
+	}, nil
+}
+
+// CombineClosingOpts returns the options that should be used when combining
+// the final musig partial signature. The method also maps the lnwire partial
+// signatures into an input.Signature that can be used more generally.
+func (m *MusigChanCloser) CombineClosingOpts(localSig,
+	remoteSig lnwire.PartialSig) (input.Signature, input.Signature,
+	[]lnwallet.ChanCloseOpt, error) {
+
+	if m.musigSession == nil {
+		return nil, nil, nil, fmt.Errorf("musig session not created")
+	}
+
+	// We'll convert the wire partial signatures into an input.Signature
+	// compliant struct so we can pass it into the final combination
+	// function.
+	localPartialSig := &lnwire.PartialSigWithNonce{
+		PartialSig: localSig,
+		Nonce:      m.localNonce.PubNonce,
+	}
+	remotePartialSig := &lnwire.PartialSigWithNonce{
+		PartialSig: remoteSig,
+		Nonce:      m.remoteNonce.PubNonce,
+	}
+
+	localMuSig := new(lnwallet.MusigPartialSig).FromWireSig(
+		localPartialSig,
+	)
+	remoteMuSig := new(lnwallet.MusigPartialSig).FromWireSig(
+		remotePartialSig,
+	)
+
+	opts := []lnwallet.ChanCloseOpt{
+		lnwallet.WithCoopCloseMusigSession(m.musigSession),
+	}
+
+	// For taproot channels, we'll need to pass along the session so the
+	// final combined signature can be created.
+	return localMuSig, remoteMuSig, opts, nil
+}
+
+// ClosingNonce returns the nonce that should be used when generating the our
+// partial signature for the remote party.
+func (m *MusigChanCloser) ClosingNonce() (*musig2.Nonces, error) {
+	if m.localNonce != nil {
+		return m.localNonce, nil
+	}
+
+	localKey, _ := m.channel.MultiSigKeys()
+	nonce, err := musig2.GenNonces(
+		musig2.WithPublicKey(localKey.PubKey),
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	m.localNonce = nonce
+
+	return nonce, nil
+}
+
+// InitRemoteNonce saves the remote nonce the party sent during their shutdown
+// message so it can be used later to generate and verify signatures.
+func (m *MusigChanCloser) InitRemoteNonce(nonce *musig2.Nonces) {
+	m.remoteNonce = nonce
+}
+
+// A compile-time assertion to ensure MusigChanCloser implements the
+// chancloser.MusigSession interface.
+var _ chancloser.MusigSession = (*MusigChanCloser)(nil)

--- a/peer/musig_chan_closer.go
+++ b/peer/musig_chan_closer.go
@@ -31,7 +31,9 @@ func NewMusigChanCloser(channel *lnwallet.LightningChannel) *MusigChanCloser {
 
 // ProposalClosingOpts returns the options that should be used when
 // generating a new co-op close signature.
-func (m *MusigChanCloser) ProposalClosingOpts() ([]lnwallet.ChanCloseOpt, error) {
+func (m *MusigChanCloser) ProposalClosingOpts() (
+	[]lnwallet.ChanCloseOpt, error) {
+
 	switch {
 	case m.localNonce == nil:
 		return nil, fmt.Errorf("local nonce not generated")


### PR DESCRIPTION
## Change Description


In this PR, we update the channel state machine to be aware of the new musig2 flow. Along the way, we update some util functions to ensure we can use them to generate scripts/transactions for both segwit v0 and v1 channels. 

In this new flow, each time we send a signature, we sig a partial sig along with the nonce that we used to sign. Upon receiving that signature, the remote party will use the nonce to complete their local session (for that state).

Each time a signature is received, a party will generate another nonce that'll be used to create their next local state. This next local/verification nonce is then sent alongside the revoke_and_ack message. Upon receiving the revocation, the party that originally sent the sig, can then use the new local nonce to prep the session for the next state.

We also update the co-op close state machine to be proper taproot aware. This involves setting the new nonce and partial signatures fields in the shutdown and closing signed messages. The other big change here is that we'll short circuit most of the co-op close flow. Rather than attempt a "negotiation", we'll just have the responder accept w/e the initiator sends, as they're the ones that pay the fees in the end.

---

In the next PR, we'll hook the new reservation flow up to the funding manager, and fill out the other functionality needed for the other sub-systems to be aware of the new channel type. 

## Steps to Test
Steps for reviewers to follow to test the change.

## Pull Request Checklist
### Testing
- [ ] Your PR passes all CI checks.
- [ ] Tests covering the positive and negative (error paths) are included.
- [ ] Bug fixes contain tests triggering the bug to prevent regressions.

### Code Style and Documentation
- [ ] The change obeys the [Code Documentation and Commenting](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#CodeDocumentation) guidelines, and lines wrap at 80.
- [ ] Commits follow the [Ideal Git Commit Structure](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#IdealGitCommitStructure).
- [ ] Any new logging statements use an appropriate subsystem and logging level.
- [ ]  [There is a change description in the release notes](https://github.com/lightningnetwork/lnd/tree/master/docs/release-notes), or `[skip ci]` in the commit message for small changes.

📝 Please see our  [Contribution Guidelines](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md) for further guidance.