### PR TITLE
[rpcServer]: add time_lock_delta overflow check for UpdateChannelPolicy

### DIFF
--- a/config.go
+++ b/config.go
@@ -98,6 +98,10 @@ const (
 	// HTLCs on our channels.
 	minTimeLockDelta = routing.MinCLTVDelta
 
+	// MaxTimeLockDelta is the maximum CLTV delta that can be applied to
+	// forwarded HTLCs.
+	MaxTimeLockDelta = routing.MaxCLTVDelta
+
 	// defaultAcceptorTimeout is the time after which an RPCAcceptor will time
 	// out and return false if it hasn't yet received a response.
 	defaultAcceptorTimeout = 15 * time.Second

--- a/docs/release-notes/release-notes-0.16.1.md
+++ b/docs/release-notes/release-notes-0.16.1.md
@@ -4,6 +4,10 @@
 
 * The `lncli wallet psbt fund` command now allows users to specify the
   [`--min_confs` flag](https://github.com/lightningnetwork/lnd/pull/7510).
+ 
+* [Add time_lock_delta overflow check for UpdateChannelPolicy](https://github.com/lightningnetwork/lnd/pull/7350)
+  that ensure `time_lock_delta` is greater or equal than `0` and less or equal than `65535`
+
 
 ## Watchtowers
 

--- a/lnrpc/invoicesrpc/addinvoice.go
+++ b/lnrpc/invoicesrpc/addinvoice.go
@@ -348,7 +348,7 @@ func AddInvoice(ctx context.Context, cfg *AddInvoiceConfig,
 	// We'll use our current default CLTV value unless one was specified as
 	// an option on the command line when creating an invoice.
 	switch {
-	case invoice.CltvExpiry > math.MaxUint16:
+	case invoice.CltvExpiry > routing.MaxCLTVDelta:
 		return nil, nil, fmt.Errorf("CLTV delta of %v is too large, "+
 			"max accepted is: %v", invoice.CltvExpiry,
 			math.MaxUint16)

--- a/routing/router.go
+++ b/routing/router.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	goErrors "errors"
 	"fmt"
+	"math"
 	"runtime"
 	"strings"
 	"sync"
@@ -80,6 +81,10 @@ const (
 	// bitcoin (160 for litecoin), though we now clamp the lower end of this
 	// range for user-chosen deltas to 18 blocks to be conservative.
 	MinCLTVDelta = 18
+
+	// MaxCLTVDelta is the maximum CLTV value accepted by LND for all
+	// timelock deltas.
+	MaxCLTVDelta = math.MaxUint16
 )
 
 var (

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -6827,6 +6827,10 @@ func (r *rpcServer) UpdateChannelPolicy(ctx context.Context,
 		return nil, fmt.Errorf("time lock delta of %v is too small, "+
 			"minimum supported is %v", req.TimeLockDelta,
 			minTimeLockDelta)
+	} else if req.TimeLockDelta > uint32(MaxTimeLockDelta) {
+		return nil, fmt.Errorf("time lock delta of %v is too big, "+
+			"maximum supported is %v", req.TimeLockDelta,
+			MaxTimeLockDelta)
 	}
 
 	baseFeeMsat := lnwire.MilliSatoshi(req.BaseFeeMsat)


### PR DESCRIPTION
Signed-off-by: Eval EXEC <execvy@gmail.com>

## Change Description
This PR want to add time_lock_delta overflow check in rpcServer, the maximum time_lock_delta should be `max(uint16)`, fix #7320
## Steps to Test

## Pull Request Checklist
### Testing
- [ ] Your PR passes all CI checks.
- [ ] Tests covering the positive and negative (error paths) are included.
- [ ] Bug fixes contain tests triggering the bug to prevent regressions.

### Code Style and Documentation
- [x] The change obeys the [Code Documentation and Commenting](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#CodeDocumentation) guidelines, and lines wrap at 80.
- [x] Commits follow the [Ideal Git Commit Structure](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#IdealGitCommitStructure).
- [x] Any new logging statements use an appropriate subsystem and logging level.
- [x]  [There is a change description in the release notes](https://github.com/lightningnetwork/lnd/tree/master/docs/release-notes), or `[skip ci]` in the commit message for small changes.

📝 Please see our  [Contribution Guidelines](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md) for further guidance.