### PR TITLE
lnwallet: Fix wallet reservation error message

### DIFF
--- a/docs/release-notes/release-notes-0.16.0.md
+++ b/docs/release-notes/release-notes-0.16.0.md
@@ -282,6 +282,9 @@ in the lnwire package](https://github.com/lightningnetwork/lnd/pull/7303)
   link is falling behind, which is now fixed by [retrying the enable
   request](https://github.com/lightningnetwork/lnd/pull/7157). 
 
+* [Fix wallet reservatoion](https://github.com/lightningnetwork/lnd/pull/7351)
+  error message.
+
 ## Code Health
 
 * [test: use `T.TempDir` to create temporary test

--- a/lnwallet/reservation.go
+++ b/lnwallet/reservation.go
@@ -281,7 +281,7 @@ func NewChannelReservation(capacity, localFundingAmt btcutil.Amount,
 		// the fees, then we'll exit with an error.
 		if int64(ourBalance) < 0 {
 			return nil, ErrFunderBalanceDust(
-				int64(commitFee), int64(ourBalance),
+				int64(commitFee), int64(-(-ourBalance).ToSatoshis()),
 				int64(2*defaultDust),
 			)
 		}


### PR DESCRIPTION
Converts milli satoshis to satoshis in one of `NewChannelReservation`'s error branches.

Specifically this part https://github.com/lightningnetwork/lnd/pull/7351/files#diff-e308f199858d836b06a0c920d2dd019fbb3acb7ef0d9e3d8a360601623128d78R284 prints `ourBalance` in milli satoshis whereas all other error messages in `NewChannelReservation` are converted to satoshis.