### PR TITLE
kvdb: remove etcd test fixture cleanup calls

### DIFF
--- a/kvdb/etcd/db_test.go
+++ b/kvdb/etcd/db_test.go
@@ -81,7 +81,6 @@ func TestNewEtcdClient(t *testing.T) {
 	t.Parallel()
 
 	f := NewEtcdTestFixture(t)
-	defer f.Cleanup()
 
 	client, ctx, cancel, err := NewEtcdClient(
 		context.Background(), f.BackendConfig(),

--- a/kvdb/etcd_test.go
+++ b/kvdb/etcd_test.go
@@ -158,7 +158,6 @@ func TestEtcd(t *testing.T) {
 				t.Parallel()
 
 				f := etcd.NewEtcdTestFixture(t)
-				defer f.Cleanup()
 
 				test.test(t, f.NewBackend(doRwLock))
 


### PR DESCRIPTION
Remove the cleanup calls which no longer exist since `t.Cleanup` is now called from within `NewEtcdTestFixture`.

Accidentally had this in the second sqlite PR instead of in the first `kvdb` one 🙈 my bad