### PR TITLE
tor: enable connecting to tor over unix sockets

### DIFF
--- a/config.go
+++ b/config.go
@@ -1028,14 +1028,16 @@ func ValidateConfig(cfg Config, interceptor signal.Interceptor, fileParser,
 		cfg.Tor.DNS = dns.String()
 	}
 
-	control, err := lncfg.ParseAddressString(
-		cfg.Tor.Control, strconv.Itoa(defaultTorControlPort),
-		cfg.net.ResolveTCPAddr,
-	)
-	if err != nil {
-		return nil, mkErr("error parsing tor control address: %v", err)
+	if !strings.HasPrefix(cfg.Tor.Control, "unix://") {
+		control, err := lncfg.ParseAddressString(
+			cfg.Tor.Control, strconv.Itoa(defaultTorControlPort),
+			cfg.net.ResolveTCPAddr,
+		)
+		if err != nil {
+			return nil, mkErr("error parsing tor control address: %v", err)
+		}
+		cfg.Tor.Control = control.String()
 	}
-	cfg.Tor.Control = control.String()
 
 	// Ensure that tor socks host:port is not equal to tor control
 	// host:port. This would lead to lnd not starting up properly.

--- a/docs/release-notes/release-notes-0.16.1.md
+++ b/docs/release-notes/release-notes-0.16.1.md
@@ -40,6 +40,9 @@
   added to `lnrpc` so the node operator can know whether a certain request has
   happened or not.
 
+## Tor
+* [Make connecting to tor over unix sockets possible](https://github.com/lightningnetwork/lnd/pull/7355)
+
 # Contributors (Alphabetical Order)
 
 * ardevd


### PR DESCRIPTION
## Change Description
Currently, tor can be connected to via a TCP `ControlPort`. This is the default configuration on most desktop environments. However, `tor-android` by default uses a unix socket. This PR makes LND compatible with this environment.

## Steps to Test
Create a lnd.conf that specifies a unix socket with a `unix://` prefix.

## Pull Request Checklist
### Testing
- [ ] Your PR passes all CI checks.
- [ ] Tests covering the positive and negative (error paths) are included.
- [ ] Bug fixes contain tests triggering the bug to prevent regressions.

### Code Style and Documentation
- [x] The change obeys the [Code Documentation and Commenting](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#CodeDocumentation) guidelines, and lines wrap at 80.
- [x] Commits follow the [Ideal Git Commit Structure](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#IdealGitCommitStructure).
- [x] Any new logging statements use an appropriate subsystem and logging level.
- [x]  [There is a change description in the release notes](https://github.com/lightningnetwork/lnd/tree/master/docs/release-notes), or `[skip ci]` in the commit message for small changes.

📝 Please see our  [Contribution Guidelines](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md) for further guidance.