### PR TITLE
Fix Benchmark Test (BenchmarkReadMessage/Funding_Locked) in the lnwire  package

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -196,6 +196,10 @@ unit-race:
 	@$(call print, "Running unit race tests.")
 	env CGO_ENABLED=1 GORACE="history_size=7 halt_on_errors=1" $(UNIT_RACE)
 
+unit-bench: $(BTCD_BIN)
+	@$(call print, "Running benchmark tests.")
+	$(UNIT_BENCH)
+
 # =============
 # FLAKE HUNTING
 # =============

--- a/docs/release-notes/release-notes-0.17.0.md
+++ b/docs/release-notes/release-notes-0.17.0.md
@@ -17,6 +17,9 @@
 
 * [Ensure that both the byte and string form of a TXID is populated in the 
   lnrpc.Outpoint message](https://github.com/lightningnetwork/lnd/pull/7624). 
+  
+* [Fix Benchmark Test (BenchmarkReadMessage/Channel_Ready) in the lnwire 
+package](https://github.com/lightningnetwork/lnd/pull/7356)
 
 ## RPC
 
@@ -49,3 +52,4 @@ unlock or create.
 * Erik Arvstedt
 * hieblmi
 * Jordi Montes
+* ziggie1984

--- a/lnwire/message_test.go
+++ b/lnwire/message_test.go
@@ -452,8 +452,20 @@ func newMsgChannelReady(t testing.TB, r io.Reader) *lnwire.ChannelReady {
 
 	pubKey := randPubKey(t)
 
-	msg := lnwire.NewChannelReady(lnwire.ChannelID(c), pubKey)
-	msg.ExtraData = createExtraData(t, r)
+	// When testing the ChannelReady msg type in the WriteMessage
+	// function we need to populate the alias here to test the encoding
+	// of the TLV stream.
+	aliasScid := lnwire.NewShortChanIDFromInt(rand.Uint64())
+	msg := &lnwire.ChannelReady{
+		ChanID:                 lnwire.ChannelID(c),
+		NextPerCommitmentPoint: pubKey,
+		AliasScid:              &aliasScid,
+		ExtraData:              make([]byte, 0),
+	}
+
+	// We do not include the TLV record (aliasScid) into the ExtraData
+	// because when the msg is encoded the ExtraData is overwritten
+	// with the current aliasScid value.
 
 	return msg
 }

--- a/make/testing_flags.mk
+++ b/make/testing_flags.mk
@@ -100,12 +100,16 @@ ifeq ($(UNIT_TARGETED), yes)
 UNIT := $(GOTEST) -tags="$(DEV_TAGS) $(LOG_TAGS)" $(TEST_FLAGS) $(UNITPKG)
 UNIT_DEBUG := $(GOTEST) -v -tags="$(DEV_TAGS) $(LOG_TAGS)" $(TEST_FLAGS) $(UNITPKG)
 UNIT_RACE := $(GOTEST) -tags="$(DEV_TAGS) $(LOG_TAGS) lowscrypt" $(TEST_FLAGS) -race $(UNITPKG)
+# NONE is a special value which selects no other tests but only executes the benchmark tests here.
+UNIT_BENCH := $(GOTEST) -tags="$(DEV_TAGS) $(LOG_TAGS)" -test.bench=. -test.run=NONE $(UNITPKG)
 endif
 
 ifeq ($(UNIT_TARGETED), no)
 UNIT := $(GOLIST) | $(XARGS) env $(GOTEST) -tags="$(DEV_TAGS) $(LOG_TAGS)" $(TEST_FLAGS)
 UNIT_DEBUG := $(GOLIST) | $(XARGS) env $(GOTEST) -v -tags="$(DEV_TAGS) $(LOG_TAGS)" $(TEST_FLAGS)
 UNIT_RACE := $(UNIT) -race
+# NONE is a special value which selects no other tests but only executes the benchmark tests here.
+UNIT_BENCH := $(GOLIST) | $(XARGS) env $(GOTEST) -tags="$(DEV_TAGS) $(LOG_TAGS)" -test.bench=. -test.run=NONE
 endif
 
 


### PR DESCRIPTION
## Change Description

This PR fixes #7152

The benchmark tests failed as described in the issue. Currently the tests produce random data for the `ExtraOpaqueData` field of most of the message types. This can be dangerous as soon as new data is added to a msg type via a tlv record. In this case other tests will fail too, if they use the random data generator for the tlv part.  
The benchmark tests failed now, because the `funding_locked` msg type is the first message in the code base which has an tlv record nested in the overall message type therefore this behaviour was not observed before. Except the `Open_channel` msg but this is a special kind of message because the `upfront_script` has to be always in the tlv_data therefore the tests swap the `ExtraOpaqueData` and encode the relevant `upfront_script` record in the tlv stream

My approach was to narrow down the funding_locked message, discarding the random part of the `ExtraOpaqueData` data and including the new `AliasScid` tlv record, this way the tests will test the encode and decode method of the `funding_locked` msg more throughly. 

Though as soon as another msg type introduces a new nested tlv field the tests will fail again. So maybe we should get rid of the random message generation part for the `ExtraOpaqueData` field for all msg types, or restrict its size to 0, and add additional tests which really try to push the max size of the whole message to its boundaries to actually test the size limits of the payload etc.

Moreover I added the Benchmark tests to the CI which which only runs the benchmark tests, explicitly avoiding all the other unit tests with the `test.run=NONE` option.


## Steps to Test

In the lnwire directory run: `go test -v  -bench=BenchmarkReadMessage`

or more general:

`make unit-bench` which runs all benchmark tests of all packages

## Pull Request Checklist
### Testing
- [x] Your PR passes all CI checks.
- [x] Tests covering the positive and negative (error paths) are included.
- [ ] Bug fixes contain tests triggering the bug to prevent regressions.

### Code Style and Documentation
- [x] The change obeys the [Code Documentation and Commenting](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#CodeDocumentation) guidelines, and lines wrap at 80.
- [x] Commits follow the [Ideal Git Commit Structure](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#IdealGitCommitStructure).
- [x] Any new logging statements use an appropriate subsystem and logging level.
- [x]  [There is a change description in the release notes](https://github.com/lightningnetwork/lnd/tree/master/docs/release-notes), or `[skip ci]` in the commit message for small changes.

📝 Please see our  [Contribution Guidelines](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md) for further guidance.