### PR TITLE
build: fix Makefile ldflags for mac and mobile, bump gomobile deps, enable gomodules

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -277,22 +277,22 @@ vendor:
 apple: vendor mobile-rpc
 	@$(call print, "Building iOS and macOS cxframework ($(IOS_BUILD)).")
 	mkdir -p $(IOS_BUILD_DIR)
-	$(GOMOBILE_BIN) bind -target=ios,iossimulator,macos -tags="mobile $(DEV_TAGS) $(RPC_TAGS)" $(RELEASE_LDFLAGS) -v -o $(IOS_BUILD) $(MOBILE_PKG)
+	$(GOMOBILE_BIN) bind -target=ios,iossimulator,macos -tags="mobile $(DEV_TAGS) $(RPC_TAGS)" -ldflags "$(RELEASE_LDFLAGS)" -v -o $(IOS_BUILD) $(MOBILE_PKG)
 
 ios: vendor mobile-rpc
 	@$(call print, "Building iOS cxframework ($(IOS_BUILD)).")
 	mkdir -p $(IOS_BUILD_DIR)
-	$(GOMOBILE_BIN) bind -target=ios,iossimulator -tags="mobile $(DEV_TAGS) $(RPC_TAGS)" $(RELEASE_LDFLAGS) -v -o $(IOS_BUILD) $(MOBILE_PKG)
+	$(GOMOBILE_BIN) bind -target=ios,iossimulator -tags="mobile $(DEV_TAGS) $(RPC_TAGS)" -ldflags "$(RELEASE_LDFLAGS)" -v -o $(IOS_BUILD) $(MOBILE_PKG)
 
 macos: vendor mobile-rpc
 	@$(call print, "Building macOS cxframework ($(IOS_BUILD)).")
 	mkdir -p $(IOS_BUILD_DIR)
-	$(GOMOBILE_BIN) bind -target=macos -tags="mobile $(DEV_TAGS) $(RPC_TAGS)" $(RELEASE_LDFLAGS) -v -o $(IOS_BUILD) $(MOBILE_PKG)
+	$(GOMOBILE_BIN) bind -target=macos -tags="mobile $(DEV_TAGS) $(RPC_TAGS)" -ldflags "$(RELEASE_LDFLAGS)" -v -o $(IOS_BUILD) $(MOBILE_PKG)
 
 android: vendor mobile-rpc
 	@$(call print, "Building Android library ($(ANDROID_BUILD)).")
 	mkdir -p $(ANDROID_BUILD_DIR)
-	$(GOMOBILE_BIN) bind -target=android -tags="mobile $(DEV_TAGS) $(RPC_TAGS)" $(RELEASE_LDFLAGS) -v -o $(ANDROID_BUILD) $(MOBILE_PKG)
+	$(GOMOBILE_BIN) bind -target=android -tags="mobile $(DEV_TAGS) $(RPC_TAGS)" -ldflags "$(RELEASE_LDFLAGS)" -v -o $(ANDROID_BUILD) $(MOBILE_PKG)
 
 mobile: ios android
 

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ GOIMPORTS_PKG := github.com/rinchsan/gosimports/cmd/gosimports
 GO_BIN := ${GOPATH}/bin
 BTCD_BIN := $(GO_BIN)/btcd
 GOIMPORTS_BIN := $(GO_BIN)/gosimports
-GOMOBILE_BIN := GO111MODULE=off $(GO_BIN)/gomobile
+GOMOBILE_BIN := $(GO_BIN)/gomobile
 GOACC_BIN := $(GO_BIN)/go-acc
 
 MOBILE_BUILD_DIR :=${GOPATH}/src/$(MOBILE_PKG)/build
@@ -274,25 +274,25 @@ vendor:
 	@$(call print, "Re-creating vendor directory.")
 	rm -r vendor/; go mod vendor
 
-apple: vendor mobile-rpc
+apple: mobile-rpc
 	@$(call print, "Building iOS and macOS cxframework ($(IOS_BUILD)).")
 	mkdir -p $(IOS_BUILD_DIR)
 	$(GOMOBILE_BIN) bind -target=ios,iossimulator,macos -tags="mobile $(DEV_TAGS) $(RPC_TAGS)" -ldflags "$(RELEASE_LDFLAGS)" -v -o $(IOS_BUILD) $(MOBILE_PKG)
 
-ios: vendor mobile-rpc
+ios: mobile-rpc
 	@$(call print, "Building iOS cxframework ($(IOS_BUILD)).")
 	mkdir -p $(IOS_BUILD_DIR)
 	$(GOMOBILE_BIN) bind -target=ios,iossimulator -tags="mobile $(DEV_TAGS) $(RPC_TAGS)" -ldflags "$(RELEASE_LDFLAGS)" -v -o $(IOS_BUILD) $(MOBILE_PKG)
 
-macos: vendor mobile-rpc
+macos: mobile-rpc
 	@$(call print, "Building macOS cxframework ($(IOS_BUILD)).")
 	mkdir -p $(IOS_BUILD_DIR)
 	$(GOMOBILE_BIN) bind -target=macos -tags="mobile $(DEV_TAGS) $(RPC_TAGS)" -ldflags "$(RELEASE_LDFLAGS)" -v -o $(IOS_BUILD) $(MOBILE_PKG)
 
-android: vendor mobile-rpc
+android: mobile-rpc
 	@$(call print, "Building Android library ($(ANDROID_BUILD)).")
 	mkdir -p $(ANDROID_BUILD_DIR)
-	$(GOMOBILE_BIN) bind -target=android -tags="mobile $(DEV_TAGS) $(RPC_TAGS)" -ldflags "$(RELEASE_LDFLAGS)" -v -o $(ANDROID_BUILD) $(MOBILE_PKG)
+	$(GOMOBILE_BIN) bind -target=android -androidapi 21 -tags="mobile $(DEV_TAGS) $(RPC_TAGS)" -ldflags "$(RELEASE_LDFLAGS)" -v -o $(ANDROID_BUILD) $(MOBILE_PKG)
 
 mobile: ios android
 

--- a/docs/release-notes/release-notes-0.16.0.md
+++ b/docs/release-notes/release-notes-0.16.0.md
@@ -200,6 +200,9 @@ https://github.com/lightningnetwork/lnd/pull/6963/)
 * [A wire parsing bug has been fixed that would cause lnd to be unable _decode_
 certain large transactions](https://github.com/lightningnetwork/lnd/pull/7100).
 
+* [ldflags were being incorrectly passed](
+https://github.com/lightningnetwork/lnd/pull/7359)
+
 ## Invoices
 
 * Define a new [InvoiceDB](https://github.com/lightningnetwork/lnd/pull/7215) 

--- a/docs/release-notes/release-notes-0.16.0.md
+++ b/docs/release-notes/release-notes-0.16.0.md
@@ -200,9 +200,6 @@ https://github.com/lightningnetwork/lnd/pull/6963/)
 * [A wire parsing bug has been fixed that would cause lnd to be unable _decode_
 certain large transactions](https://github.com/lightningnetwork/lnd/pull/7100).
 
-* [ldflags were being incorrectly passed](
-https://github.com/lightningnetwork/lnd/pull/7359)
-
 ## Invoices
 
 * Define a new [InvoiceDB](https://github.com/lightningnetwork/lnd/pull/7215) 

--- a/docs/release-notes/release-notes-0.16.1.md
+++ b/docs/release-notes/release-notes-0.16.1.md
@@ -24,6 +24,10 @@
   `exclude_exhausted_sessions` boolean flag to the relevant lncli wtclient
   commands.
 
+## Build
+* [ldflags were being incorrectly passed](
+https://github.com/lightningnetwork/lnd/pull/7359)
+
 ## Misc
 
 * [Return `FEE_INSUFFICIENT` before checking balance for incoming low-fee

--- a/go.mod
+++ b/go.mod
@@ -52,8 +52,9 @@ require (
 	go.etcd.io/etcd/client/v3 v3.5.7
 	golang.org/x/crypto v0.1.0
 	golang.org/x/exp v0.0.0-20221111094246-ab4555d3164f
+	golang.org/x/mobile v0.0.0-20190719004257-d2bd2a29d028
 	golang.org/x/net v0.4.0
-	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c
+	golang.org/x/sync v0.0.0-20220819030929-7fc1605a5dde
 	golang.org/x/term v0.3.0
 	golang.org/x/time v0.0.0-20210220033141-f8bda1e9f3ba
 	google.golang.org/grpc v1.41.0

--- a/go.sum
+++ b/go.sum
@@ -654,6 +654,7 @@ golang.org/x/lint v0.0.0-20200130185559-910be7a94367/go.mod h1:3xt1FjdF8hUf6vQPI
 golang.org/x/lint v0.0.0-20200302205851-738671d3881b/go.mod h1:3xt1FjdF8hUf6vQPIChWIBhFzV8gjjsPE/fR3IyQdNY=
 golang.org/x/lint v0.0.0-20210508222113-6edffad5e616/go.mod h1:3xt1FjdF8hUf6vQPIChWIBhFzV8gjjsPE/fR3IyQdNY=
 golang.org/x/mobile v0.0.0-20190312151609-d3739f865fa6/go.mod h1:z+o9i4GpDbdi3rU15maQ/Ox0txvL9dWGYEHz965HBQE=
+golang.org/x/mobile v0.0.0-20190719004257-d2bd2a29d028 h1:4+4C/Iv2U4fMZBiMCc98MG1In4gJY5YRhtpDNeDeHWs=
 golang.org/x/mobile v0.0.0-20190719004257-d2bd2a29d028/go.mod h1:E/iHnbuqvinMTCcRqshq8CkpyQDoeVncDDYHnLhea+o=
 golang.org/x/mod v0.0.0-20190513183733-4bf6d317e70e/go.mod h1:mXi4GBBbnImb6dmsKGUJ2LatrhH/nqhxcFungHvyanc=
 golang.org/x/mod v0.1.0/go.mod h1:0QHyrYULN0/3qlju5TqG8bIK38QM8yzMo5ekMj3DlcY=
@@ -721,8 +722,9 @@ golang.org/x/sync v0.0.0-20200317015054-43a5402ce75a/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20201207232520-09787c993a3a/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
-golang.org/x/sync v0.0.0-20210220032951-036812b2e83c h1:5KslGYwFpkhGh+Q16bwMP3cOontH8FOep7tGV86Y7SQ=
 golang.org/x/sync v0.0.0-20210220032951-036812b2e83c/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.0.0-20220819030929-7fc1605a5dde h1:ejfdSekXMDxDLbRrJMwUk6KnSLZ2McaUCVcIKM+N6jc=
+golang.org/x/sync v0.0.0-20220819030929-7fc1605a5dde/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20180816055513-1c9583448a9c/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180905080454-ebe1bf3edb33/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=

--- a/mobile/README.md
+++ b/mobile/README.md
@@ -13,16 +13,8 @@ To build for Android, you need either
 
 ### Go and Go mobile
 
-First, follow the instructions to [install Go](https://github.com/lightningnetwork/lnd/blob/master/docs/INSTALL.md#building-a-development-version-from-source).
-
-Then, install [Go mobile](https://github.com/golang/go/wiki/Mobile) and 
-initialize it:
-
-```shell
-go install golang.org/x/mobile/cmd/gomobile@latest
-go mod download golang.org/x/mobile
-gomobile init
-```
+First, follow the instructions to [install
+Go](https://github.com/lightningnetwork/lnd/blob/master/docs/INSTALL.md#building-a-development-version-from-source).
 
 ### Docker
 
@@ -42,14 +34,8 @@ Note that `gomobile` only supports building projects from `$GOPATH` at this
 point. However, with the introduction of Go modules, the source code files are 
 no longer installed there by default.
 
-To be able to do so, we must turn off module and using the now deprecated 
-`go get` command before turning modules back on again.
-
 ```shell
-go env -w GO111MODULE="off"
-go get github.com/lightningnetwork/lnd
-go get golang.org/x/mobile/bind
-go env -w GO111MODULE="on"
+git clone https://github.com/lightningnetwork/lnd.git $GOPATH/src/github.com/lightningnetwork/lnd
 ```
 
 Finally, let’s change directory to the newly created lnd folder inside `$GOPATH`:
@@ -58,11 +44,19 @@ Finally, let’s change directory to the newly created lnd folder inside `$GOPAT
 cd $GOPATH/src/github.com/lightningnetwork/lnd
 ```
 
-It is not recommended building from the master branch for mainnet. To checkout
+It is not recommended building from the master branch for mainnet. To check out
 the latest tagged release of lnd, run
 
 ```shell
 git checkout $(git describe --match "v[0-9]*" --abbrev=0)
+```
+
+Then, install [Go mobile](https://github.com/golang/go/wiki/Mobile) and
+initialize it:
+
+```shell
+go install golang.org/x/mobile/cmd/gomobile
+gomobile init
 ```
 
 ### iOS

--- a/mobile/bindings.go
+++ b/mobile/bindings.go
@@ -13,6 +13,7 @@ import (
 	flags "github.com/jessevdk/go-flags"
 	"github.com/lightningnetwork/lnd"
 	"github.com/lightningnetwork/lnd/signal"
+	_ "golang.org/x/mobile/bind"
 	"google.golang.org/grpc"
 )
 


### PR DESCRIPTION
## Change Description
PR [6963](https://github.com/lightningnetwork/lnd/pull/6963) refactored the Makefile to have a more streamlined approach to ldflags. However, in the process it also introduced two subtle but critical errors.
1. The `-ldflags` parameter is missing.
2. The ldflags themselves are not wrapped in a string.

The result is that the arguments are mangled, and gomobile complains about `-s` not being a parameter.

Before 6963:
```GO111MODULE=off /home/synthlock/go/bin/gomobile bind -target=android -tags="mobile dev autopilotrpc chainrpc invoicesrpc neutrinorpc peersrpc routerrpc signrpc verrpc walletrpc watchtowerrpc wtclientrpc" -ldflags " -s -w -X github.com/lightningnetwork/lnd/build.Commit=v0.15.5-beta -X github.com/lightningnetwork/lnd/build.CommitHash=c0a09209782b1c62c3393fcea0844e095c25046b -X github.com/lightningnetwork/lnd/build.GoVersion=go1.18.10 -X github.com/lightningnetwork/lnd/build.RawTags=" -v -o /home/synthlock/go/src/github.com/lightningnetwork/lnd/mobile/build/android/Lndmobile.aar github.com/lightningnetwork/lnd/mobile```
After 6963:
```GO111MODULE=off /home/synthlock/go/bin/gomobile bind -target=android -tags="mobile dev autopilotrpc chainrpc invoicesrpc neutrinorpc peersrpc routerrpc signrpc verrpc walletrpc watchtowerrpc wtclientrpc"  -s -w -buildid= -X github.com/lightningnetwork/lnd/build.Commit=kvdb/v1.4.1-6-g9187d4679 -v -o /home/synthlock/go/src/github.com/lightningnetwork/lnd/mobile/build/android/Lndmobile.aar github.com/lightningnetwork/lnd/mobile```

This PR adds in the correct behavior for ldflag passing. `-ldflags` is explicitly set in each affected stanza, and the ldflags are wrapped in a string.


## Steps to Test
`make android` on v0.15.5 release versus master.

## Pull Request Checklist
### Testing
- [ ] Your PR passes all CI checks.
- [ ] Tests covering the positive and negative (error paths) are included.
- [ ] Bug fixes contain tests triggering the bug to prevent regressions.

### Code Style and Documentation
- [x] The change obeys the [Code Documentation and Commenting](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#CodeDocumentation) guidelines, and lines wrap at 80.
- [x] Commits follow the [Ideal Git Commit Structure](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#IdealGitCommitStructure).
- [x] Any new logging statements use an appropriate subsystem and logging level.
- [x]  [There is a change description in the release notes](https://github.com/lightningnetwork/lnd/tree/master/docs/release-notes), or `[skip ci]` in the commit message for small changes.

📝 Please see our  [Contribution Guidelines](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md) for further guidance.