### PR TITLE
Add test coverage for integration tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -241,13 +241,13 @@ jobs:
       matrix:
         include:
           - name: btcd
-            args: backend=btcd
+            args: backend=btcd cover=1
           - name: bitcoind
-            args: backend=bitcoind
+            args: backend=bitcoind cover=1
           - name: bitcoind-notxindex
             args: backend="bitcoind notxindex"
           - name: bitcoind-rpcpolling
-            args: backend="bitcoind rpcpolling"
+            args: backend="bitcoind rpcpolling" cover=1
           - name: bitcoind-etcd
             args: backend=bitcoind dbbackend=etcd
           - name: bitcoind-postgres
@@ -259,7 +259,7 @@ jobs:
           - name: bitcoind-sqlite-nativesql
             args: backend=bitcoind dbbackend=sqlite nativesql=true
           - name: neutrino
-            args: backend=neutrino
+            args: backend=neutrino cover=1
     steps:
       - name: git checkout
         uses: actions/checkout@v3
@@ -274,9 +274,10 @@ jobs:
         run: ./scripts/install_bitcoind.sh $BITCOIN_VERSION
 
       - name: run ${{ matrix.name }}
-        run: make itest-parallel ${{ matrix.args }} cover=1
+        run: make itest-parallel ${{ matrix.args }}
 
       - name: Send coverage
+        if: ${{ contains(matrix.args, 'cover=1') }}
         uses: shogo82148/actions-goveralls@v1
         with:
           path-to-profile: coverage.txt
@@ -407,3 +408,13 @@ jobs:
 
       - name: release notes check
         run: scripts/check-release-notes.sh
+  
+  # Notify about the completion of all coverage collecting jobs.
+  finish:
+    if: ${{ always() }}
+    needs: [unit-test, ubuntu-integration-test]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: shogo82148/actions-goveralls@v1
+        with:
+          parallel-finished: true

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -225,6 +225,7 @@ jobs:
         if: matrix.unit_type == 'btcd unit-cover'
         with:
           path-to-profile: coverage.txt
+          flag-name: 'unit'
           parallel: true
 
 
@@ -281,6 +282,7 @@ jobs:
         uses: shogo82148/actions-goveralls@v1
         with:
           path-to-profile: coverage.txt
+          flag-name: 'itest-${{ matrix.name }}'
           parallel: true
 
       - name: Zip log files on failure

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -274,7 +274,13 @@ jobs:
         run: ./scripts/install_bitcoind.sh $BITCOIN_VERSION
 
       - name: run ${{ matrix.name }}
-        run: make itest-parallel ${{ matrix.args }}
+        run: make itest-parallel ${{ matrix.args }} cover=1
+
+      - name: Send coverage
+        uses: shogo82148/actions-goveralls@v1
+        with:
+          path-to-profile: coverage.txt
+          parallel: true
 
       - name: Zip log files on failure
         if: ${{ failure() }}

--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,7 @@ itest/.minerlogs
 itest/lnd-itest
 itest/btcd-itest
 itest/.logs-*
+itest/cover
 
 cmd/cmd
 *.key

--- a/Makefile
+++ b/Makefile
@@ -110,7 +110,7 @@ build:
 build-itest:
 	@$(call print, "Building itest btcd and lnd.")
 	CGO_ENABLED=0 $(GOBUILD) -tags="integration" -o itest/btcd-itest$(EXEC_SUFFIX) $(DEV_LDFLAGS) $(BTCD_PKG)
-	CGO_ENABLED=0 $(GOBUILD) -tags="$(ITEST_TAGS)" -o itest/lnd-itest$(EXEC_SUFFIX) $(DEV_LDFLAGS) $(PKG)/cmd/lnd
+	CGO_ENABLED=0 $(GOBUILD) -tags="$(ITEST_TAGS)" $(ITEST_COVERAGE) -o itest/lnd-itest$(EXEC_SUFFIX) $(DEV_LDFLAGS) $(PKG)/cmd/lnd
 
 	@$(call print, "Building itest binary for ${backend} backend.")
 	CGO_ENABLED=0 $(GOTEST) -v ./itest -tags="$(DEV_TAGS) $(RPC_TAGS) integration $(backend)" -c -o itest/itest.test$(EXEC_SUFFIX)
@@ -197,6 +197,7 @@ itest-only: db-instance
 	@$(call print, "Running integration tests with ${backend} backend.")
 	rm -rf itest/*.log itest/.logs-*; date
 	EXEC_SUFFIX=$(EXEC_SUFFIX) scripts/itest_part.sh 0 1 $(TEST_FLAGS) $(ITEST_FLAGS)
+	$(COLLECT_ITEST_COVERAGE)
 
 #? itest: Build and run integration tests
 itest: build-itest itest-only
@@ -209,6 +210,7 @@ itest-parallel: build-itest db-instance
 	@$(call print, "Running tests")
 	rm -rf itest/*.log itest/.logs-*; date
 	EXEC_SUFFIX=$(EXEC_SUFFIX) scripts/itest_parallel.sh $(ITEST_PARALLELISM) $(NUM_ITEST_TRANCHES) $(TEST_FLAGS) $(ITEST_FLAGS)
+	$(COLLECT_ITEST_COVERAGE)
 
 #? itest-clean: Kill all running itest processes
 itest-clean:

--- a/make/testing_flags.mk
+++ b/make/testing_flags.mk
@@ -2,7 +2,9 @@ DEV_TAGS = dev
 RPC_TAGS = autopilotrpc chainrpc invoicesrpc neutrinorpc peersrpc routerrpc signrpc verrpc walletrpc watchtowerrpc wtclientrpc
 LOG_TAGS =
 TEST_FLAGS =
-ITEST_FLAGS = 
+ITEST_FLAGS =
+ITEST_COVERAGE =
+COLLECT_ITEST_COVERAGE =
 EXEC_SUFFIX =
 COVER_PKG = $$(go list -deps -tags="$(DEV_TAGS)" ./... | grep '$(PKG)' | grep -v lnrpc)
 NUM_ITEST_TRANCHES = 4
@@ -75,6 +77,12 @@ endif
 
 ifneq ($(tags),)
 DEV_TAGS += ${tags}
+endif
+
+# Enable integration test coverage (requires Go >= 1.20.0).
+ifneq ($(cover),)
+ITEST_COVERAGE = -cover
+COLLECT_ITEST_COVERAGE = go tool covdata textfmt -i=itest/cover -o coverage.txt
 endif
 
 # Define the log tags that will be applied only when running unit tests. If none

--- a/scripts/itest_part.sh
+++ b/scripts/itest_part.sh
@@ -16,6 +16,8 @@ shift
 EXEC="$WORKDIR"/itest.test"$EXEC_SUFFIX"
 LND_EXEC="$WORKDIR"/lnd-itest"$EXEC_SUFFIX"
 BTCD_EXEC="$WORKDIR"/btcd-itest"$EXEC_SUFFIX"
+export GOCOVERDIR="$WORKDIR/cover"
+mkdir -p "$GOCOVERDIR"
 echo $EXEC -test.v "$@" -logoutput -logdir=.logs-tranche$TRANCHE -lndexec=$LND_EXEC -btcdexec=$BTCD_EXEC -splittranches=$NUM_TRANCHES -runtranche=$TRANCHE
 
 # Exit code 255 causes the parallel jobs to abort, so if one part fails the


### PR DESCRIPTION
Fixes https://github.com/lightningnetwork/lnd/issues/7363.

Adds integration test coverage tracking instrumentation.
Since `Golang v1.20.x` allows writing coverage data even for processes that are started as their own sub process (which we do with `lnd` during the integration tests), we can now better assess the actual test coverage of our code as a combination of unit and integration tests.
