### PR TITLE
ci: fix lint VSC permissions error

### DIFF
--- a/docs/release-notes/release-notes-0.16.0.md
+++ b/docs/release-notes/release-notes-0.16.0.md
@@ -396,7 +396,9 @@ Keysend](https://github.com/lightningnetwork/lnd/pull/7334).
   builds](https://github.com/lightningnetwork/lnd/pull/7295).
 
 * Fixed docker image version used in
-  [`tools`](https://github.com/lightningnetwork/lnd/pull/7254).
+  [`tools`](https://github.com/lightningnetwork/lnd/pull/7254) and golangci
+  issue where [it cannot fetch
+  commits](https://github.com/lightningnetwork/lnd/pull/7374).
 
 ### Integration test
 

--- a/tools/Dockerfile
+++ b/tools/Dockerfile
@@ -11,6 +11,7 @@ RUN cd /tmp \
   && mkdir -p /tmp/build/.modcache \
   && cd /tmp/tools \
   && go install -trimpath -tags=tools github.com/golangci/golangci-lint/cmd/golangci-lint \
-  && chmod -R 777 /tmp/build/
+  && chmod -R 777 /tmp/build/ \
+  && git config --global --add safe.directory /build
 
 WORKDIR /build


### PR DESCRIPTION
Linter fails again, and copied fix from https://github.com/lightninglabs/taro/pull/219.