### PR TITLE
multi: Forward Blinded Payments

### DIFF
--- a/feature/default_sets.go
+++ b/feature/default_sets.go
@@ -49,6 +49,13 @@ var defaultSetDesc = setDesc{
 		SetInit:    {}, // I
 		SetNodeAnn: {}, // N
 	},
+	// Note: we set route blinding optionally in our init and announcement,
+	// but not yet in invoices (9) as the spec instructs because we do not
+	// yet support receiving payments to blinded routes, only relaying them.
+	lnwire.RouteBlindingOptional: {
+		SetInit:    {}, // I
+		SetNodeAnn: {}, // N
+	},
 	lnwire.WumboChannelsOptional: {
 		SetInit:    {}, // I
 		SetNodeAnn: {}, // N

--- a/htlcswitch/hop/forwarding_info.go
+++ b/htlcswitch/hop/forwarding_info.go
@@ -1,6 +1,7 @@
 package hop
 
 import (
+	"github.com/btcsuite/btcd/btcec/v2"
 	"github.com/lightningnetwork/lnd/lnwire"
 )
 
@@ -22,4 +23,9 @@ type ForwardingInfo struct {
 	// OutgoingCTLV is the specified value of the CTLV timelock to be used
 	// in the outgoing HTLC.
 	OutgoingCTLV uint32
+
+	// NextBlinding is an optional blinding point to be passed to the next
+	// node in UpdateAddHtlc. This field is set if the htlc is part of a
+	// blinded route.
+	NextBlinding *btcec.PublicKey
 }

--- a/htlcswitch/hop/iterator.go
+++ b/htlcswitch/hop/iterator.go
@@ -174,10 +174,11 @@ func (p *OnionProcessor) ReconstructHopIterator(r io.Reader, rHash []byte) (
 // packet, perform sphinx replay detection, and schedule the entry for garbage
 // collection.
 type DecodeHopIteratorRequest struct {
-	OnionReader   io.Reader
-	RHash         []byte
-	IncomingCltv  uint32
-	BlindingPoint *btcec.PublicKey
+	OnionReader    io.Reader
+	RHash          []byte
+	IncomingCltv   uint32
+	IncomingAmount lnwire.MilliSatoshi
+	BlindingPoint  *btcec.PublicKey
 }
 
 // DecodeHopIteratorResponse encapsulates the outcome of a batched sphinx onion

--- a/htlcswitch/hop/iterator.go
+++ b/htlcswitch/hop/iterator.go
@@ -146,50 +146,6 @@ func (p *OnionProcessor) Stop() error {
 	return nil
 }
 
-// DecodeHopIterator attempts to decode a valid sphinx packet from the passed io.Reader
-// instance using the rHash as the associated data when checking the relevant
-// MACs during the decoding process.
-func (p *OnionProcessor) DecodeHopIterator(r io.Reader, rHash []byte,
-	incomingCltv uint32) (Iterator, lnwire.FailCode) {
-
-	onionPkt := &sphinx.OnionPacket{}
-	if err := onionPkt.Decode(r); err != nil {
-		switch err {
-		case sphinx.ErrInvalidOnionVersion:
-			return nil, lnwire.CodeInvalidOnionVersion
-		case sphinx.ErrInvalidOnionKey:
-			return nil, lnwire.CodeInvalidOnionKey
-		default:
-			log.Errorf("unable to decode onion packet: %v", err)
-			return nil, lnwire.CodeInvalidOnionKey
-		}
-	}
-
-	// Attempt to process the Sphinx packet. We include the payment hash of
-	// the HTLC as it's authenticated within the Sphinx packet itself as
-	// associated data in order to thwart attempts a replay attacks. In the
-	// case of a replay, an attacker is *forced* to use the same payment
-	// hash twice, thereby losing their money entirely.
-	sphinxPacket, err := p.router.ProcessOnionPacket(
-		onionPkt, rHash, incomingCltv,
-	)
-	if err != nil {
-		switch err {
-		case sphinx.ErrInvalidOnionVersion:
-			return nil, lnwire.CodeInvalidOnionVersion
-		case sphinx.ErrInvalidOnionHMAC:
-			return nil, lnwire.CodeInvalidOnionHmac
-		case sphinx.ErrInvalidOnionKey:
-			return nil, lnwire.CodeInvalidOnionKey
-		default:
-			log.Errorf("unable to process onion packet: %v", err)
-			return nil, lnwire.CodeInvalidOnionKey
-		}
-	}
-
-	return makeSphinxHopIterator(onionPkt, sphinxPacket), lnwire.CodeNone
-}
-
 // ReconstructHopIterator attempts to decode a valid sphinx packet from the passed io.Reader
 // instance using the rHash as the associated data when checking the relevant
 // MACs during the decoding process.

--- a/htlcswitch/hop/iterator.go
+++ b/htlcswitch/hop/iterator.go
@@ -116,9 +116,14 @@ func (r *sphinxHopIterator) ExtractErrorEncrypter(
 // BlindingProcessor is an interface that provides the cryptographic operations
 // required for processing blinded hops.
 type BlindingProcessor interface {
-	// DecryptBlindedData decrypts a blinded blob of data using the
-	// ephemeral key provided.
-	DecryptBlindedData(*btcec.PublicKey, []byte) ([]byte, error)
+	// UnBlindData decrypts a blinded blob of data using the ephemeral key
+	// provided.
+	UnBlindData(ephemPub *btcec.PublicKey,
+		encryptedData []byte) ([]byte, error)
+
+	// NextEphemeral returns the next hop's ephemeral key, calculated
+	// from the current ephemeral key provided.
+	NextEphemeral(*btcec.PublicKey) (*btcec.PublicKey, error)
 }
 
 // BlindingKit contains the components required to extract forwarding
@@ -208,11 +213,17 @@ func deriveForwardingInfo(processor BlindingProcessor,
 			)
 		}
 
+		nextEph, err := processor.NextEphemeral(blinding)
+		if err != nil {
+			return nil, err
+		}
+
 		return &ForwardingInfo{
 			Network:         BitcoinNetwork,
 			NextHop:         nextHop,
 			AmountToForward: fwdAmt,
 			OutgoingCTLV:    expiry,
+			NextBlinding:    nextEph,
 		}, nil
 	}
 }

--- a/htlcswitch/hop/iterator.go
+++ b/htlcswitch/hop/iterator.go
@@ -174,9 +174,10 @@ func (p *OnionProcessor) ReconstructHopIterator(r io.Reader, rHash []byte) (
 // packet, perform sphinx replay detection, and schedule the entry for garbage
 // collection.
 type DecodeHopIteratorRequest struct {
-	OnionReader  io.Reader
-	RHash        []byte
-	IncomingCltv uint32
+	OnionReader   io.Reader
+	RHash         []byte
+	IncomingCltv  uint32
+	BlindingPoint *btcec.PublicKey
 }
 
 // DecodeHopIteratorResponse encapsulates the outcome of a batched sphinx onion

--- a/htlcswitch/hop/iterator_test.go
+++ b/htlcswitch/hop/iterator_test.go
@@ -98,3 +98,48 @@ func TestSphinxHopIteratorForwardingInstructions(t *testing.T) {
 		}
 	}
 }
+
+// TestForwardingAmountCalc tests calculation of forwarding amounts from the
+// hop's forwarding parameters.
+func TestForwardingAmountCalc(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name           string
+		incomingAmount lnwire.MilliSatoshi
+		baseFee        uint32
+		proportional   uint32
+		forwardAmount  lnwire.MilliSatoshi
+		expectErr      bool
+	}{
+		{
+			name:           "overflow",
+			incomingAmount: 10,
+			baseFee:        100,
+			expectErr:      true,
+		},
+		{
+			name:           "ok",
+			incomingAmount: 100_000,
+			baseFee:        1000,
+			proportional:   10,
+			forwardAmount:  99000,
+		},
+	}
+
+	for _, testCase := range tests {
+		testCase := testCase
+
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			actual, err := calculateForwardingAmount(
+				testCase.incomingAmount, testCase.baseFee,
+				testCase.proportional,
+			)
+
+			require.Equal(t, testCase.expectErr, err != nil)
+			require.Equal(t, testCase.forwardAmount, actual)
+		})
+	}
+}

--- a/htlcswitch/hop/payload.go
+++ b/htlcswitch/hop/payload.go
@@ -134,8 +134,12 @@ func NewLegacyPayload(f *sphinx.HopData) *Payload {
 }
 
 // NewPayloadFromReader builds a new Hop from the passed io.Reader. The reader
-// should correspond to the bytes encapsulated in a TLV onion payload.
-func NewPayloadFromReader(r io.Reader) (*Payload, error) {
+// should correspond to the bytes encapsulated in a TLV onion payload. A
+// blinding kit is passed in to help handle payloads that are part of a blinded
+// route.
+func NewPayloadFromReader(r io.Reader, blindingKit *BlindingKit) (
+	*Payload, error) {
+
 	var (
 		cid           uint64
 		amt           uint64

--- a/htlcswitch/hop/payload_test.go
+++ b/htlcswitch/hop/payload_test.go
@@ -361,7 +361,9 @@ func testDecodeHopPayloadValidation(t *testing.T, test decodePayloadTest) {
 		testChildIndex = uint32(9)
 	)
 
-	p, err := hop.NewPayloadFromReader(bytes.NewReader(test.payload))
+	p, err := hop.NewPayloadFromReader(
+		bytes.NewReader(test.payload), &hop.BlindingKit{},
+	)
 	if !reflect.DeepEqual(test.expErr, err) {
 		t.Fatalf("expected error mismatch, want: %v, got: %v",
 			test.expErr, err)

--- a/htlcswitch/link.go
+++ b/htlcswitch/link.go
@@ -3094,8 +3094,11 @@ func (l *channelLink) processRemoteAdds(fwdPkg *channeldb.FwdPkg,
 				// Otherwise, it was already processed, we can
 				// can collect it and continue.
 				addMsg := &lnwire.UpdateAddHTLC{
-					Expiry:      fwdInfo.OutgoingCTLV,
-					Amount:      fwdInfo.AmountToForward,
+					Expiry: fwdInfo.OutgoingCTLV,
+					Amount: fwdInfo.AmountToForward,
+					BlindingPoint: lnwire.NewBlindingPoint(
+						fwdInfo.NextBlinding,
+					),
 					PaymentHash: pd.RHash,
 				}
 
@@ -3136,8 +3139,11 @@ func (l *channelLink) processRemoteAdds(fwdPkg *channeldb.FwdPkg,
 			// create the outgoing HTLC using the parameters as
 			// specified in the forwarding info.
 			addMsg := &lnwire.UpdateAddHTLC{
-				Expiry:      fwdInfo.OutgoingCTLV,
-				Amount:      fwdInfo.AmountToForward,
+				Expiry: fwdInfo.OutgoingCTLV,
+				Amount: fwdInfo.AmountToForward,
+				BlindingPoint: lnwire.NewBlindingPoint(
+					fwdInfo.NextBlinding,
+				),
 				PaymentHash: pd.RHash,
 			}
 

--- a/htlcswitch/link.go
+++ b/htlcswitch/link.go
@@ -2939,9 +2939,10 @@ func (l *channelLink) processRemoteAdds(fwdPkg *channeldb.FwdPkg,
 			onionReader := bytes.NewReader(pd.OnionBlob)
 
 			req := hop.DecodeHopIteratorRequest{
-				OnionReader:  onionReader,
-				RHash:        pd.RHash[:],
-				IncomingCltv: pd.Timeout,
+				OnionReader:   onionReader,
+				RHash:         pd.RHash[:],
+				IncomingCltv:  pd.Timeout,
+				BlindingPoint: pd.BlindingPoint,
 			}
 
 			decodeReqs = append(decodeReqs, req)

--- a/htlcswitch/link.go
+++ b/htlcswitch/link.go
@@ -2939,10 +2939,11 @@ func (l *channelLink) processRemoteAdds(fwdPkg *channeldb.FwdPkg,
 			onionReader := bytes.NewReader(pd.OnionBlob)
 
 			req := hop.DecodeHopIteratorRequest{
-				OnionReader:   onionReader,
-				RHash:         pd.RHash[:],
-				IncomingCltv:  pd.Timeout,
-				BlindingPoint: pd.BlindingPoint,
+				OnionReader:    onionReader,
+				RHash:          pd.RHash[:],
+				IncomingCltv:   pd.Timeout,
+				IncomingAmount: pd.Amount,
+				BlindingPoint:  pd.BlindingPoint,
 			}
 
 			decodeReqs = append(decodeReqs, req)

--- a/itest/list_on_test.go
+++ b/itest/list_on_test.go
@@ -546,4 +546,8 @@ var allTestCases = []*lntest.TestCase{
 		Name:     "query blinded route",
 		TestFunc: testQueryBlindedRoutes,
 	},
+	{
+		Name:     "forward blinded",
+		TestFunc: testForwardBlindedRoute,
+	},
 }

--- a/itest/lnd_route_blinding.go
+++ b/itest/lnd_route_blinding.go
@@ -320,28 +320,118 @@ type blindedForwardTest struct {
 	carol    *node.HarnessNode
 	dave     *node.HarnessNode
 	channels []*lnrpc.ChannelPoint
+
+	// ctx is a context to be used by the test.
+	ctx context.Context //nolint:containedctx
+
+	// cancel will cancel the test's top level context.
+	cancel func()
 }
 
 func newBlindedForwardTest(ht *lntest.HarnessTest) *blindedForwardTest {
+	ctx, cancel := context.WithCancel(context.Background())
+
 	return &blindedForwardTest{
-		ht: ht,
+		ht:     ht,
+		ctx:    ctx,
+		cancel: cancel,
 	}
 }
 
 // setup spins up additional nodes needed for our test and creates a four hop
-// network for testing blinded forwarding.
-func (b *blindedForwardTest) setup() {
+// network for testing blinded forwarding and returns a blinded route from
+// Bob -> Carol -> Dave, with Bob acting as the introduction point.
+func (b *blindedForwardTest) setup() *routing.BlindedPayment {
 	b.carol = b.ht.NewNode("Carol", nil)
 	b.dave = b.ht.NewNode("Dave", nil)
 
 	b.channels = setupFourHopNetwork(b.ht, b.carol, b.dave)
+
+	// Create a blinded route to Dave via Bob --- Carol --- Dave:
+	bobChan := b.ht.GetChannelByChanPoint(b.ht.Bob, b.channels[1])
+	carolChan := b.ht.GetChannelByChanPoint(b.carol, b.channels[2])
+
+	edges := []*forwardingEdge{
+		getForwardingEdge(b.ctx, b.ht, b.ht.Bob, bobChan.ChanId),
+		getForwardingEdge(b.ctx, b.ht, b.carol, carolChan.ChanId),
+	}
+
+	davePk, err := btcec.ParsePubKey(b.dave.PubKey[:])
+	require.NoError(b.ht, err, "dave pubkey")
+
+	return b.createBlindedRoute(edges, davePk)
 }
 
-// cleanup tears down all channels created by the test.
+// cleanup tears down all channels created by the test and cancels the top
+// level context used in the test.
 func (b *blindedForwardTest) cleanup() {
 	b.ht.CloseChannel(b.ht.Alice, b.channels[0])
 	b.ht.CloseChannel(b.ht.Bob, b.channels[1])
 	b.ht.CloseChannel(b.carol, b.channels[2])
+
+	b.cancel()
+}
+
+// createRouteToBlinded queries for a route from alice to the blinded path
+// provided.
+//
+//nolint:gomnd
+func (b *blindedForwardTest) createRouteToBlinded(paymentAmt int64,
+	route *routing.BlindedPayment) *lnrpc.Route {
+
+	intro := route.BlindedPath.IntroductionPoint.SerializeCompressed()
+	blinding := route.BlindedPath.BlindingPoint.SerializeCompressed()
+
+	blindedRoute := &lnrpc.BlindedPath{
+		IntroductionNode: intro,
+		BlindingPoint:    blinding,
+		BlindedHops: make(
+			[]*lnrpc.BlindedHop,
+			len(route.BlindedPath.BlindedHops),
+		),
+	}
+
+	for i, hop := range route.BlindedPath.BlindedHops {
+		blindedRoute.BlindedHops[i] = &lnrpc.BlindedHop{
+			BlindedNode:   hop.NodePub.SerializeCompressed(),
+			EncryptedData: hop.Payload,
+		}
+	}
+	blindedPath := &lnrpc.BlindedPaymentPath{
+		BlindedPath: blindedRoute,
+		BaseFeeMsat: uint64(
+			route.BaseFee,
+		),
+		ProportionalFeeMsat: uint64(
+			route.ProportionalFee,
+		),
+		TotalCltvDelta: uint32(
+			route.CltvExpiryDelta,
+		),
+	}
+
+	ctxt, cancel := context.WithTimeout(b.ctx, defaultTimeout)
+	req := &lnrpc.QueryRoutesRequest{
+		AmtMsat: paymentAmt,
+		// Our fee limit doesn't really matter, we just want to
+		// be able to make the payment.
+		FeeLimit: &lnrpc.FeeLimit{
+			Limit: &lnrpc.FeeLimit_Percent{
+				Percent: 50,
+			},
+		},
+		BlindedPaymentPaths: []*lnrpc.BlindedPaymentPath{
+			blindedPath,
+		},
+	}
+
+	resp, err := b.ht.Alice.RPC.LN.QueryRoutes(ctxt, req)
+	cancel()
+	require.NoError(b.ht, err, "query routes")
+	require.Greater(b.ht, len(resp.Routes), 0, "no routes")
+	require.Len(b.ht, resp.Routes[0].Hops, 3, "unexpected route length")
+
+	return resp.Routes[0]
 }
 
 // setupFourHopNetwork creates a network with the following topology and
@@ -498,8 +588,42 @@ type forwardingEdge struct {
 	edge      *lnrpc.RoutingPolicy
 }
 
+func getForwardingEdge(ctxb context.Context, ht *lntest.HarnessTest,
+	node *node.HarnessNode, chanID uint64) *forwardingEdge {
+
+	ctxt, cancel := context.WithTimeout(ctxb, defaultTimeout)
+	chanInfo, err := node.RPC.LN.GetChanInfo(ctxt, &lnrpc.ChanInfoRequest{
+		ChanId: chanID,
+	})
+	cancel()
+	require.NoError(ht, err, "%v chan info", node.Cfg.Name)
+
+	pubkey, err := btcec.ParsePubKey(node.PubKey[:])
+	require.NoError(ht, err, "%v pubkey", node.Cfg.Name)
+
+	fwdEdge := &forwardingEdge{
+		pubkey:    pubkey,
+		channelID: lnwire.NewShortChanIDFromInt(chanID),
+	}
+
+	if chanInfo.Node1Pub == node.PubKeyStr {
+		fwdEdge.edge = chanInfo.Node1Policy
+	} else {
+		require.Equal(ht, node.PubKeyStr, chanInfo.Node2Pub,
+			"policy edge sanity check")
+
+		fwdEdge.edge = chanInfo.Node2Policy
+	}
+
+	return fwdEdge
+}
+
 // testForwardBlindedRoute tests lnd's ability to forward payments in a blinded
 // route.
 func testForwardBlindedRoute(ht *lntest.HarnessTest) {
-	newBlindedForwardTest(ht)
+	testCase := newBlindedForwardTest(ht)
+	defer testCase.cleanup()
+
+	route := testCase.setup()
+	testCase.createRouteToBlinded(100_000, route)
 }

--- a/lnwire/blinding_point.go
+++ b/lnwire/blinding_point.go
@@ -1,0 +1,29 @@
+package lnwire
+
+import (
+	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/lightningnetwork/lnd/tlv"
+)
+
+const (
+	// BlindingPointRecordType is the type for ephemeral pubkeys used in
+	// route blinding.
+	BlindingPointRecordType tlv.Type = 0
+)
+
+// BlindingPoint is used to communicate ephemeral pubkeys used by route
+// blinding.
+//
+// Note: this struct wraps a *btcec.Pubkey key so that we can implement the
+// RecordProducer interface on the struct and re-use the existing tlv library
+// functions for public keys.
+type BlindingPoint struct {
+	*btcec.PublicKey
+}
+
+// Record returns a TLV record for blinded pubkeys.
+//
+// Note: implements the RecordProducer interface.
+func (p *BlindingPoint) Record() tlv.Record {
+	return tlv.MakePrimitiveRecord(BlindingPointRecordType, &p.PublicKey)
+}

--- a/lnwire/blinding_point.go
+++ b/lnwire/blinding_point.go
@@ -1,6 +1,8 @@
 package lnwire
 
 import (
+	"io"
+
 	"github.com/btcsuite/btcd/btcec/v2"
 	"github.com/lightningnetwork/lnd/tlv"
 )
@@ -14,16 +16,73 @@ const (
 // BlindingPoint is used to communicate ephemeral pubkeys used by route
 // blinding.
 //
-// Note: this struct wraps a *btcec.Pubkey key so that we can implement the
+// Note: this struct wraps a btcec.Pubkey key so that we can implement the
 // RecordProducer interface on the struct and re-use the existing tlv library
-// functions for public keys.
-type BlindingPoint struct {
-	*btcec.PublicKey
+// functions for public keys. The type is unexported to enforce proper handling
+// of aliasing / nil types.
+type blindingPoint btcec.PublicKey
+
+// NewBlindingPoint converts a pubkey into its aliased blinding point type,
+// returning nil if the pubkey provided is nil.
+//
+//nolint:revive
+func NewBlindingPoint(pubkey *btcec.PublicKey) *blindingPoint {
+	if pubkey == nil {
+		return nil
+	}
+
+	blindingPoint := blindingPoint(*pubkey)
+
+	return &blindingPoint
+}
+
+// Pubkey returns the underlying btcec.Pubkey type for a blinding point.
+func (b *blindingPoint) Pubkey() *btcec.PublicKey {
+	if b == nil {
+		return nil
+	}
+
+	pubkey := btcec.PublicKey(*b)
+
+	return &pubkey
 }
 
 // Record returns a TLV record for blinded pubkeys.
 //
 // Note: implements the RecordProducer interface.
-func (p *BlindingPoint) Record() tlv.Record {
-	return tlv.MakePrimitiveRecord(BlindingPointRecordType, &p.PublicKey)
+func (b *blindingPoint) Record() tlv.Record {
+	return tlv.MakeStaticRecord(
+		BlindingPointRecordType, b, 33,
+		blindingPointEncoder, blindingPointDecoder,
+	)
+}
+
+// blindingPointEncoder is a custom TLV encoder for the BlindingPoint record.
+func blindingPointEncoder(w io.Writer, val interface{}, buf *[8]byte) error {
+	if v, ok := val.(*blindingPoint); ok {
+		// EPubkey requires a double pointer, so we de-alias and
+		// reference the blinding point provided.
+		pubkey := btcec.PublicKey(*v)
+		pubkeyRef := &pubkey
+		return tlv.EPubKey(w, &pubkeyRef, buf)
+	}
+
+	return tlv.NewTypeForEncodingErr(val, "lnwire.BlindingPoint")
+}
+
+// blindingPointDecoder is a custom TLV decoder for the BlindingPoint record.
+func blindingPointDecoder(r io.Reader, val interface{}, buf *[8]byte,
+	l uint64) error {
+
+	if v, ok := val.(*blindingPoint); ok {
+		var pubkey *btcec.PublicKey
+		if err := tlv.DPubKey(r, &pubkey, buf, l); err != nil {
+			return err
+		}
+		*v = blindingPoint(*pubkey)
+
+		return nil
+	}
+
+	return tlv.NewTypeForEncodingErr(val, "lnwire.BlindingPoint")
 }

--- a/lnwire/features.go
+++ b/lnwire/features.go
@@ -141,6 +141,15 @@ const (
 	// transactions, which also imply anchor commitments.
 	AnchorsZeroFeeHtlcTxOptional FeatureBit = 23
 
+	// RouteBlindingRequired is a required bit that indicates that the
+	// receiving peer must understand forwarding of blinded payments.
+	RouteBlindingRequired = 24
+
+	// RouteBlindingOptional is an optional bit that indicates that this
+	// node understands forwarding of blinded payments, but the remote
+	// peer is not required to.
+	RouteBlindingOptional = 25
+
 	// ShutdownAnySegwitRequired is an required feature bit that signals
 	// that the sender is able to properly handle/parse segwit witness
 	// programs up to version 16. This enables utilization of Taproot
@@ -299,6 +308,8 @@ var Features = map[FeatureBit]string{
 	AnchorsOptional:                      "anchor-commitments",
 	AnchorsZeroFeeHtlcTxRequired:         "anchors-zero-fee-htlc-tx",
 	AnchorsZeroFeeHtlcTxOptional:         "anchors-zero-fee-htlc-tx",
+	RouteBlindingRequired:                "route-blinding",
+	RouteBlindingOptional:                "route-blinding",
 	WumboChannelsRequired:                "wumbo-channels",
 	WumboChannelsOptional:                "wumbo-channels",
 	AMPRequired:                          "amp",

--- a/lnwire/features.go
+++ b/lnwire/features.go
@@ -5,6 +5,8 @@ import (
 	"errors"
 	"fmt"
 	"io"
+
+	"github.com/lightningnetwork/lnd/tlv"
 )
 
 var (
@@ -610,6 +612,41 @@ func (fv *RawFeatureVector) decode(r io.Reader, length, width int) error {
 	}
 
 	return nil
+}
+
+// sizeFunc returns the length required to encode the feature vector.
+func (fv *RawFeatureVector) sizeFunc() uint64 {
+	return uint64(fv.SerializeSize())
+}
+
+// Record returns a TLV record that can be used to encode/decode raw feature
+// vectors. Note that the length of the feature vector is not included, because
+// it is covered by the TLV record's length field.
+func (fv *RawFeatureVector) Record(recordType tlv.Type) tlv.Record {
+	return tlv.MakeDynamicRecord(
+		recordType, fv, fv.sizeFunc, rawFeatureEncoder,
+		rawFeatureDecoder,
+	)
+}
+
+// rawFeatureEncoder is a custom TLV encoder for raw feature vectors.
+func rawFeatureEncoder(w io.Writer, val interface{}, buf *[8]byte) error {
+	if f, ok := val.(*RawFeatureVector); ok {
+		return f.encode(w, f.SerializeSize(), 8)
+	}
+
+	return tlv.NewTypeForEncodingErr(val, "*lnwire.RawFeatureVector")
+}
+
+// rawFeatureDecoder is a custom TLV decoder for raw feature vectors.
+func rawFeatureDecoder(r io.Reader, val interface{}, buf *[8]byte,
+	l uint64) error {
+
+	if f, ok := val.(*RawFeatureVector); ok {
+		return f.decode(r, int(l), 8)
+	}
+
+	return tlv.NewTypeForEncodingErr(val, "*lnwire.RawFeatureVector")
 }
 
 // FeatureVector represents a set of enabled features. The set stores

--- a/lnwire/features.go
+++ b/lnwire/features.go
@@ -715,6 +715,18 @@ func (fv *FeatureVector) UnknownRequiredFeatures() []FeatureBit {
 	return unknown
 }
 
+// UnknownFeatures returns a boolean if a feature vector contains *any*
+// unknown features (even if they are off).
+func (fv *FeatureVector) UnknownFeatures() bool {
+	for feature := range fv.features {
+		if !fv.IsKnown(feature) {
+			return true
+		}
+	}
+
+	return false
+}
+
 // Name returns a string identifier for the feature represented by this bit. If
 // the bit does not represent a known feature, this returns a string indicating
 // as such.

--- a/lnwire/lnwire_test.go
+++ b/lnwire/lnwire_test.go
@@ -1079,9 +1079,8 @@ func TestLightningWireProtocol(t *testing.T) {
 				return
 			}
 
-			req.BlindingPoint = BlindingPoint{
-				PublicKey: pubkey,
-			}
+			blinding := blindingPoint(*pubkey)
+			req.BlindingPoint = &blinding
 
 			v[0] = reflect.ValueOf(*req)
 		},

--- a/lnwire/lnwire_test.go
+++ b/lnwire/lnwire_test.go
@@ -1070,6 +1070,21 @@ func TestLightningWireProtocol(t *testing.T) {
 
 			v[0] = reflect.ValueOf(req)
 		},
+		MsgUpdateAddHTLC: func(v []reflect.Value, r *rand.Rand) {
+			req := NewUpdateAddHTLC()
+
+			pubkey, err := randPubKey()
+			if err != nil {
+				t.Fatalf("unable to generate key: %v", err)
+				return
+			}
+
+			req.BlindingPoint = BlindingPoint{
+				PublicKey: pubkey,
+			}
+
+			v[0] = reflect.ValueOf(*req)
+		},
 	}
 
 	// With the above types defined, we'll now generate a slice of

--- a/lnwire/update_add_htlc_test.go
+++ b/lnwire/update_add_htlc_test.go
@@ -1,0 +1,48 @@
+package lnwire
+
+import (
+	"bytes"
+	"encoding/hex"
+	"testing"
+
+	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/stretchr/testify/require"
+)
+
+// TestUpdateAddHTLCExtraData tests encoding of update_add_htlc with and
+// without a blinding point TLV included.
+func TestUpdateAddHTLCExtraData(t *testing.T) {
+	t.Parallel()
+
+	// First, test an update_add_htlc that does not include a blinding
+	// point.
+	htlc := UpdateAddHTLC{
+		ID:        1,
+		Amount:    100,
+		Expiry:    25,
+		ExtraData: make([]byte, 0),
+	}
+
+	var b bytes.Buffer
+	require.NoError(t, htlc.Encode(&b, 0))
+
+	var htlcDecoded UpdateAddHTLC
+	require.NoError(t, htlcDecoded.Decode(&b, 0))
+
+	require.Equal(t, htlc, htlcDecoded)
+
+	// Next test inclusion of a blinding point.
+	pubKeyStr := "036a0c5ea35df8a528b98edf6f290b28676d51d0fe202b073fe677612a39c0aa09" //nolint:lll
+	pubHex, err := hex.DecodeString(pubKeyStr)
+	require.NoError(t, err, "unable to decode pubkey")
+
+	pubKey, err := btcec.ParsePubKey(pubHex)
+	require.NoError(t, err, "unable to parse pubkey")
+	blindingPoint := blindingPoint(*pubKey)
+
+	htlc.BlindingPoint = &blindingPoint
+
+	require.NoError(t, htlc.Encode(&b, 0))
+	require.NoError(t, htlcDecoded.Decode(&b, 0))
+	require.Equal(t, htlc, htlcDecoded)
+}

--- a/record/blinded_data.go
+++ b/record/blinded_data.go
@@ -1,0 +1,319 @@
+package record
+
+import (
+	"bytes"
+	"encoding/binary"
+	"io"
+
+	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/lightningnetwork/lnd/lnwire"
+	"github.com/lightningnetwork/lnd/tlv"
+)
+
+const (
+	// ShortChannelIDType is a record type for the outgoing channel short
+	// ID.
+	ShortChannelIDType tlv.Type = 2
+
+	// NextNodeType is a record type for the unblinded next node ID.
+	NextNodeType tlv.Type = 4
+
+	// PaymentRelayType is the record type for a tlv containing fee and
+	// cltv forwarding information.
+	PaymentRelayType tlv.Type = 10
+
+	// PaymentConstraintType is a tlv containing the constraints placed
+	// on a forwarded payment.
+	PaymentConstraintType tlv.Type = 12
+
+	// FeatureVectorType is the record type for a tlv with the features
+	// supported by the blinded hop.
+	FeatureVectorType tlv.Type = 14
+)
+
+// BlindedRouteData contains the information that is included in a blinded
+// route encrypted data blob.
+type BlindedRouteData struct {
+	// ShortChannelID is the channel ID of the next hop.
+	ShortChannelID *lnwire.ShortChannelID
+
+	// NextNodeID is the unblinded node ID of the next hop.
+	NextNodeID *btcec.PublicKey
+
+	// RelayInfo provides the relay parameters for the hop.
+	RelayInfo *PaymentRelayInfo
+
+	// Constraints provides the payment relay constraints for the hop.
+	Constraints *PaymentConstraints
+
+	// Features is the set of features the payment requires.
+	Features *lnwire.FeatureVector
+}
+
+// DecodeBlindedRouteData decodes the data provided within a blinded route.
+func DecodeBlindedRouteData(r io.Reader) (*BlindedRouteData, error) {
+	var (
+		routeData = &BlindedRouteData{
+			RelayInfo:   &PaymentRelayInfo{},
+			Constraints: &PaymentConstraints{},
+			// We create a non-nil but empty set of features by
+			// default, so that we don't need to worry about nil
+			// values and can decode directly into the raw vector.
+			Features: lnwire.NewFeatureVector(
+				lnwire.NewRawFeatureVector(), lnwire.Features,
+			),
+		}
+
+		shortID uint64
+	)
+
+	records := []tlv.Record{
+		tlv.MakePrimitiveRecord(ShortChannelIDType, &shortID),
+		tlv.MakePrimitiveRecord(NextNodeType, &routeData.NextNodeID),
+		newPaymentRelayRecord(routeData.RelayInfo),
+		newPaymentConstraintsRecord(routeData.Constraints),
+		routeData.Features.Record(FeatureVectorType),
+	}
+
+	stream, err := tlv.NewStream(records...)
+	if err != nil {
+		return nil, err
+	}
+
+	tlvMap, err := stream.DecodeWithParsedTypes(r)
+	if err != nil {
+		return nil, err
+	}
+
+	if _, ok := tlvMap[PaymentRelayType]; !ok {
+		routeData.RelayInfo = nil
+	}
+
+	if _, ok := tlvMap[PaymentConstraintType]; !ok {
+		routeData.Constraints = nil
+	}
+
+	if _, ok := tlvMap[ShortChannelIDType]; ok {
+		shortID := lnwire.NewShortChanIDFromInt(shortID)
+		routeData.ShortChannelID = &shortID
+	}
+
+	return routeData, nil
+}
+
+// EncodeBlindedRouteData encodes the blinded route data provided.
+func EncodeBlindedRouteData(data *BlindedRouteData) ([]byte, error) {
+	var (
+		w       = new(bytes.Buffer)
+		records []tlv.Record
+	)
+
+	if data.ShortChannelID != nil {
+		shortID := data.ShortChannelID.ToUint64()
+		shortIDRecord := tlv.MakePrimitiveRecord(
+			ShortChannelIDType, &shortID,
+		)
+
+		records = append(records, shortIDRecord)
+	}
+
+	if data.NextNodeID != nil {
+		nodeIDRecord := tlv.MakePrimitiveRecord(
+			NextNodeType, &data.NextNodeID,
+		)
+		records = append(records, nodeIDRecord)
+	}
+
+	if data.RelayInfo != nil {
+		relayRecord := newPaymentRelayRecord(data.RelayInfo)
+		records = append(records, relayRecord)
+	}
+
+	if data.Constraints != nil {
+		constraintsRecord := newPaymentConstraintsRecord(
+			data.Constraints,
+		)
+		records = append(records, constraintsRecord)
+	}
+
+	if data.Features != nil && !data.Features.IsEmpty() {
+		featuresRecord := data.Features.RawFeatureVector.Record(
+			FeatureVectorType,
+		)
+		records = append(records, featuresRecord)
+	}
+
+	stream, err := tlv.NewStream(records...)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := stream.Encode(w); err != nil {
+		return nil, err
+	}
+
+	return w.Bytes(), nil
+}
+
+// PaymentRelayInfo describes the relay policy for a blinded path.
+type PaymentRelayInfo struct {
+	// CltvExpiryDelta is the expiry delta for the payment.
+	CltvExpiryDelta uint16
+
+	// FeeRate is the fee rate that will be charged per millionth of a
+	// satoshi.
+	FeeRate uint32
+
+	// BaseFee is the per-htlc fee charged.
+	BaseFee uint32
+}
+
+// newPaymentRelayRecord creates a tlv.Record that encodes the payment relay
+// (type 10) type for an encrypted blob payload.
+func newPaymentRelayRecord(info *PaymentRelayInfo) tlv.Record {
+	return tlv.MakeDynamicRecord(
+		PaymentRelayType, &info, func() uint64 {
+			// uint16 + uint32 + tuint32
+			return 2 + 4 + tlv.SizeTUint32(info.BaseFee)
+		}, encodePaymentRelay, decodePaymentRelay,
+	)
+}
+
+func encodePaymentRelay(w io.Writer, val interface{}, buf *[8]byte) error {
+	if t, ok := val.(**PaymentRelayInfo); ok {
+		relayInfo := *t
+
+		// Just write our first 6 bytes directly.
+		binary.BigEndian.PutUint16(buf[:2], relayInfo.CltvExpiryDelta)
+		binary.BigEndian.PutUint32(buf[2:6], relayInfo.FeeRate)
+		if _, err := w.Write(buf[0:6]); err != nil {
+			return err
+		}
+
+		// We can safely reuse buf here because we overwrite its
+		// contents.
+		return tlv.ETUint32(w, &relayInfo.BaseFee, buf)
+	}
+
+	return tlv.NewTypeForEncodingErr(val, "*hop.paymentRelayInfo")
+}
+
+func decodePaymentRelay(r io.Reader, val interface{}, buf *[8]byte,
+	l uint64) error {
+
+	if t, ok := val.(**PaymentRelayInfo); ok && l <= 10 {
+		scratch := make([]byte, l)
+
+		n, err := io.ReadFull(r, scratch)
+		if err != nil {
+			return err
+		}
+
+		// We expect at least 6 bytes, because we have q, bytes for
+		// cltv delta and 4 bytes for fee rate.
+		if n < 6 {
+			return tlv.NewTypeForDecodingErr(val,
+				"*hop.paymentRelayInfo", uint64(n), 6)
+		}
+
+		relayInfo := *t
+
+		relayInfo.CltvExpiryDelta = binary.BigEndian.Uint16(
+			scratch[0:2],
+		)
+		relayInfo.FeeRate = binary.BigEndian.Uint32(scratch[2:6])
+
+		// To be able to re-use the DTUint32 function we create a
+		// buffer with just the bytes holding the variable length u32.
+		// If the base fee is zero, this will be an empty buffer, which
+		// is okay.
+		b := bytes.NewBuffer(scratch[6:])
+
+		return tlv.DTUint32(b, &relayInfo.BaseFee, buf, l-6)
+	}
+
+	return tlv.NewTypeForDecodingErr(val, "*hop.paymentRelayInfo", l, 10)
+}
+
+// PaymentConstraints is a set of restrictions on a payment.
+type PaymentConstraints struct {
+	// MaxCltvExpiry is the maximum expiry height for the payment.
+	MaxCltvExpiry uint32
+
+	// HtlcMinimumMsat is the minimum htlc size for the payment.
+	HtlcMinimumMsat lnwire.MilliSatoshi
+}
+
+func newPaymentConstraintsRecord(constraints *PaymentConstraints) tlv.Record {
+	return tlv.MakeDynamicRecord(
+		PaymentConstraintType, &constraints, func() uint64 {
+			// uint32 + tuint64.
+			return 4 + tlv.SizeTUint64(uint64(
+				constraints.HtlcMinimumMsat,
+			))
+		},
+		encodePaymentConstraints, decodePaymentConstraints,
+	)
+}
+
+func encodePaymentConstraints(w io.Writer, val interface{},
+	buf *[8]byte) error {
+
+	if c, ok := val.(**PaymentConstraints); ok {
+		constraints := *c
+
+		binary.BigEndian.PutUint32(buf[:4], constraints.MaxCltvExpiry)
+		if _, err := w.Write(buf[:4]); err != nil {
+			return err
+		}
+
+		// We can safely re-use buf here because we overwrite its
+		// contents.
+		htlcMsat := uint64(constraints.HtlcMinimumMsat)
+
+		return tlv.ETUint64(w, &htlcMsat, buf)
+	}
+
+	return tlv.NewTypeForEncodingErr(val, "**PaymentConstraints")
+}
+
+func decodePaymentConstraints(r io.Reader, val interface{}, buf *[8]byte,
+	l uint64) error {
+
+	if c, ok := val.(**PaymentConstraints); ok && l <= 12 {
+		scratch := make([]byte, l)
+
+		n, err := io.ReadFull(r, scratch)
+		if err != nil {
+			return err
+		}
+
+		// We expect at least 4 bytes for our uint32.
+		if n < 4 {
+			return tlv.NewTypeForDecodingErr(val,
+				"*paymentConstraints", uint64(n), 4)
+		}
+
+		payConstraints := *c
+
+		payConstraints.MaxCltvExpiry = binary.BigEndian.Uint32(
+			scratch[:4],
+		)
+
+		// This could be empty if our minimum is zero, that's okay.
+		var (
+			b       = bytes.NewBuffer(scratch[4:])
+			minHtlc uint64
+		)
+
+		err = tlv.DTUint64(b, &minHtlc, buf, l-4)
+		if err != nil {
+			return err
+		}
+		payConstraints.HtlcMinimumMsat = lnwire.MilliSatoshi(minHtlc)
+
+		return nil
+	}
+
+	return tlv.NewTypeForDecodingErr(val, "**PaymentConstraints", l, l)
+}

--- a/record/blinded_data_test.go
+++ b/record/blinded_data_test.go
@@ -1,0 +1,119 @@
+package record
+
+import (
+	"bytes"
+	"encoding/hex"
+	"math"
+	"testing"
+
+	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/lightningnetwork/lnd/lnwire"
+	"github.com/stretchr/testify/require"
+)
+
+//nolint:lll
+const pubkeyStr = "02eec7245d6b7d2ccb30380bfbe2a3648cd7a942653f5aa340edcea1f283686619"
+
+func pubkey(t *testing.T) *btcec.PublicKey {
+	t.Helper()
+
+	nodeBytes, err := hex.DecodeString(pubkeyStr)
+	require.NoError(t, err)
+
+	nodePk, err := btcec.ParsePubKey(nodeBytes)
+	require.NoError(t, err)
+
+	return nodePk
+}
+
+// TestBlindedDataEncoding tests encoding and decoding of blinded data blobs.
+// These tests specifically cover cases where the variable length encoded
+// integers values have different numbers of leading zeros trimmed because
+// these TLVs are the first composite records with variable length tlvs
+// (previously, a variable length integer would take up the whole record).
+func TestBlindedDataEncoding(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		baseFee  uint32
+		htlcMin  lnwire.MilliSatoshi
+		features *lnwire.FeatureVector
+	}{
+		{
+			name:    "zero variable values",
+			baseFee: 0,
+			htlcMin: 0,
+		},
+		{
+			name:    "zeros trimmed",
+			baseFee: math.MaxUint32 / 2,
+			htlcMin: math.MaxUint64 / 2,
+		},
+		{
+			name:    "no zeros trimmed",
+			baseFee: math.MaxUint32,
+			htlcMin: math.MaxUint64,
+		},
+		{
+			name:     "nil feature vector",
+			features: nil,
+		},
+		{
+			name:     "non-nil, but empty feature vector",
+			features: lnwire.EmptyFeatureVector(),
+		},
+		{
+			name: "populated feature vector",
+			features: lnwire.NewFeatureVector(
+				lnwire.NewRawFeatureVector(lnwire.AMPOptional),
+				lnwire.Features,
+			),
+		},
+	}
+
+	for _, testCase := range tests {
+		testCase := testCase
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			// Create a standard set of blinded route data, using
+			// the values from our test case for the variable
+			// length encoded values.
+			channelID := lnwire.NewShortChanIDFromInt(1)
+			encodedData := &BlindedRouteData{
+				ShortChannelID: &channelID,
+				NextNodeID:     pubkey(t),
+				RelayInfo: &PaymentRelayInfo{
+					FeeRate:         2,
+					CltvExpiryDelta: 3,
+					BaseFee:         testCase.baseFee,
+				},
+				Constraints: &PaymentConstraints{
+					MaxCltvExpiry:   4,
+					HtlcMinimumMsat: testCase.htlcMin,
+				},
+				Features: testCase.features,
+			}
+
+			encoded, err := EncodeBlindedRouteData(encodedData)
+			require.NoError(t, err)
+
+			// We fill a non-nil feature vector if there is no
+			// features tlv, so we set our expected feature vector
+			// to an empty one if that's what we expect
+			if encodedData.Features == nil ||
+				encodedData.Features.IsEmpty() {
+
+				//nolint:lll
+				encodedData.Features = lnwire.EmptyFeatureVector()
+			}
+
+			b := bytes.NewBuffer(encoded)
+			decodedData, err := DecodeBlindedRouteData(b)
+			require.NoError(t, err)
+
+			require.Equal(t, encodedData, decodedData)
+		})
+	}
+}


### PR DESCRIPTION
## Change Description
This PR adds forwarding of payments in blinded paths to LND, and depends on #7267, #7297. 

Opening early for general approach feedback 🙏 and to provide an idea of the scope of the change (many rpc changes are inflating the change delta - it looks worse than it is, promise 😅 ).

There are a few notably missing elements: 
* Forwarding works without #7297 with a very small workaround, but we'll probably want to store that data properly
* As noted in #7267, we'll need to migrate one of our on-chain resolvers and thread the `blinding_point` through to it (tbd separately)
* Error handling for blinded payments is not included (this will be done in a followup PR to split things up a little)
* There can always be more unit tests

## Steps to Test
Since LND doesn't _produce_ blinded routes, you'll need the following setup: 
`Alice (LND) --- Bob(LND) --- Carol (LND) --privatechan-- Dave(CL)`

Since we need to _retrieve_ a raw CL invoice, you need another CL node connected to Dave to fetch the invoice from an offer: 

- `dave offer 1000 test` -> `lno...` is your offer
- `cl fetchinvoice lno...` -> `lni....` is your invoice
- `cl decode lni...` -> This will give blinded hops/data etc. 

You can then pay the blinded invoice from LND: 
```
lncli queryroutes --introduction_point={cleartext_introduction_node_id} --blinding_point={blinding_point} --blinded_hops={blinded_introduction_node}:{introduction_node_data} --blinded_cltv={blinded_route_total_cltv} --amt={invoice_amount} | lncli sendtoroute --payment_hash={payment_hash} -
```

It's also covered in an itest, which may make life _a little_ easier :')