### PR TITLE
multi: add local and remote amount fields to revocation log

### DIFF
--- a/channeldb/channel.go
+++ b/channeldb/channel.go
@@ -2657,8 +2657,8 @@ func (c *OpenChannel) AdvanceCommitChainTail(fwdPkg *FwdPkg,
 		// With the commitment pointer swapped, we can now add the
 		// revoked (prior) state to the revocation log.
 		err = putRevocationLog(
-			logBucket, &c.RemoteCommitment,
-			ourOutputIndex, theirOutputIndex,
+			logBucket, &c.RemoteCommitment, ourOutputIndex,
+			theirOutputIndex, c.Db.parent.noRevLogAmtData,
 		)
 		if err != nil {
 			return err

--- a/channeldb/db.go
+++ b/channeldb/db.go
@@ -63,12 +63,24 @@ type mandatoryVersion struct {
 	migration migration
 }
 
+// MigrationConfig is an interface combines the config interfaces of all
+// optional migrations.
+type MigrationConfig interface {
+	migration30.MigrateRevLogConfig
+}
+
+// MigrationConfigImpl is a super set of all the various migration configs and
+// an implementation of MigrationConfig.
+type MigrationConfigImpl struct {
+	migration30.MigrateRevLogConfigImpl
+}
+
 // optionalMigration defines an optional migration function. When a migration
 // is optional, it usually involves a large scale of changes that might touch
 // millions of keys. Due to OOM concern, the update cannot be safely done
 // within one db transaction. Thus, for optional migrations, they must take the
 // db backend and construct transactions as needed.
-type optionalMigration func(db kvdb.Backend) error
+type optionalMigration func(db kvdb.Backend, cfg MigrationConfig) error
 
 // optionalVersion defines a db version that can be optionally applied. When
 // applying migrations, we must apply all the mandatory migrations first before
@@ -273,8 +285,12 @@ var (
 	// to determine its state.
 	optionalVersions = []optionalVersion{
 		{
-			name:      "prune revocation log",
-			migration: migration30.MigrateRevocationLog,
+			name: "prune revocation log",
+			migration: func(db kvdb.Backend,
+				cfg MigrationConfig) error {
+
+				return migration30.MigrateRevocationLog(db, cfg)
+			},
 		},
 	}
 
@@ -1545,8 +1561,12 @@ func (d *DB) applyOptionalVersions(cfg OptionalMiragtionConfig) error {
 	version := optionalVersions[0]
 	log.Infof("Performing database optional migration: %s", version.name)
 
+	migrationCfg := &MigrationConfigImpl{
+		migration30.MigrateRevLogConfigImpl{},
+	}
+
 	// Migrate the data.
-	if err := version.migration(d); err != nil {
+	if err := version.migration(d, migrationCfg); err != nil {
 		log.Errorf("Unable to apply optional migration: %s, error: %v",
 			version.name, err)
 		return err

--- a/channeldb/db.go
+++ b/channeldb/db.go
@@ -324,6 +324,10 @@ type DB struct {
 	dryRun                    bool
 	keepFailedPaymentAttempts bool
 	storeFinalHtlcResolutions bool
+
+	// noRevLogAmtData if true, means that commitment transaction amount
+	// data should not be stored in the revocation log.
+	noRevLogAmtData bool
 }
 
 // Open opens or creates channeldb. Any necessary schemas migrations due
@@ -382,6 +386,7 @@ func CreateWithBackend(backend kvdb.Backend,
 		dryRun:                    opts.dryRun,
 		keepFailedPaymentAttempts: opts.keepFailedPaymentAttempts,
 		storeFinalHtlcResolutions: opts.storeFinalHtlcResolutions,
+		noRevLogAmtData:           opts.NoRevLogAmtData,
 	}
 
 	// Set the parent pointer (only used in tests).
@@ -1562,7 +1567,9 @@ func (d *DB) applyOptionalVersions(cfg OptionalMiragtionConfig) error {
 	log.Infof("Performing database optional migration: %s", version.name)
 
 	migrationCfg := &MigrationConfigImpl{
-		migration30.MigrateRevLogConfigImpl{},
+		migration30.MigrateRevLogConfigImpl{
+			NoAmountData: d.noRevLogAmtData,
+		},
 	}
 
 	// Migrate the data.

--- a/channeldb/meta_test.go
+++ b/channeldb/meta_test.go
@@ -530,7 +530,9 @@ func TestApplyOptionalVersions(t *testing.T) {
 	// Overwrite the migration function so we can count how many times the
 	// migration has happened.
 	migrateCount := 0
-	optionalVersions[0].migration = func(_ kvdb.Backend) error {
+	optionalVersions[0].migration = func(_ kvdb.Backend,
+		_ MigrationConfig) error {
+
 		migrateCount++
 		return nil
 	}

--- a/channeldb/migration30/migration.go
+++ b/channeldb/migration30/migration.go
@@ -560,6 +560,11 @@ func convertRevocationLog(commit *mig.ChannelCommitment,
 		HTLCEntries:      make([]*HTLCEntry, 0, len(commit.Htlcs)),
 	}
 
+	if !noAmtData {
+		rl.TheirBalance = &commit.RemoteBalance
+		rl.OurBalance = &commit.LocalBalance
+	}
+
 	for _, htlc := range commit.Htlcs {
 		// Skip dust HTLCs.
 		if htlc.OutputIndex < 0 {

--- a/channeldb/migration30/migration.go
+++ b/channeldb/migration30/migration.go
@@ -23,10 +23,17 @@ import (
 // indexes.
 const recordsPerTx = 20_000
 
+// MigrateRevLogConfig is an interface that defines the config that should be
+// passed to the MigrateRevocationLog function.
+type MigrateRevLogConfig interface{}
+
+// MigrateRevLogConfigImpl implements the MigrationRevLogConfig interface.
+type MigrateRevLogConfigImpl struct{}
+
 // MigrateRevocationLog migrates the old revocation logs into the newer format
 // and deletes them once finished, with the deletion only happens once ALL the
 // old logs have been migrates.
-func MigrateRevocationLog(db kvdb.Backend) error {
+func MigrateRevocationLog(db kvdb.Backend, _ MigrateRevLogConfig) error {
 	log.Infof("Migrating revocation logs, might take a while...")
 
 	var (

--- a/channeldb/migration30/migration.go
+++ b/channeldb/migration30/migration.go
@@ -25,15 +25,29 @@ const recordsPerTx = 20_000
 
 // MigrateRevLogConfig is an interface that defines the config that should be
 // passed to the MigrateRevocationLog function.
-type MigrateRevLogConfig interface{}
+type MigrateRevLogConfig interface {
+	// GetNoAmountData returns true if the amount data of revoked commitment
+	// transactions should not be stored in the revocation log.
+	GetNoAmountData() bool
+}
 
 // MigrateRevLogConfigImpl implements the MigrationRevLogConfig interface.
-type MigrateRevLogConfigImpl struct{}
+type MigrateRevLogConfigImpl struct {
+	// NoAmountData if set to true will result in the amount data of revoked
+	// commitment transactions not being stored in the revocation log.
+	NoAmountData bool
+}
+
+// GetNoAmountData returns true if the amount data of revoked commitment
+// transactions should not be stored in the revocation log.
+func (c *MigrateRevLogConfigImpl) GetNoAmountData() bool {
+	return c.NoAmountData
+}
 
 // MigrateRevocationLog migrates the old revocation logs into the newer format
 // and deletes them once finished, with the deletion only happens once ALL the
 // old logs have been migrates.
-func MigrateRevocationLog(db kvdb.Backend, _ MigrateRevLogConfig) error {
+func MigrateRevocationLog(db kvdb.Backend, cfg MigrateRevLogConfig) error {
 	log.Infof("Migrating revocation logs, might take a while...")
 
 	var (
@@ -71,7 +85,7 @@ func MigrateRevocationLog(db kvdb.Backend, _ MigrateRevLogConfig) error {
 
 		// Process the migration.
 		err = kvdb.Update(db, func(tx kvdb.RwTx) error {
-			finished, err = processMigration(tx)
+			finished, err = processMigration(tx, cfg)
 			if err != nil {
 				return err
 			}
@@ -121,7 +135,7 @@ func MigrateRevocationLog(db kvdb.Backend, _ MigrateRevLogConfig) error {
 // processMigration finds the next un-migrated revocation logs, reads a max
 // number of `recordsPerTx` records, converts them into the new revocation logs
 // and save them to disk.
-func processMigration(tx kvdb.RwTx) (bool, error) {
+func processMigration(tx kvdb.RwTx, cfg MigrateRevLogConfig) (bool, error) {
 	openChanBucket := tx.ReadWriteBucket(openChannelBucket)
 
 	// If no bucket is found, we can exit early.
@@ -141,7 +155,7 @@ func processMigration(tx kvdb.RwTx) (bool, error) {
 	}
 
 	// Read a list of old revocation logs.
-	entryMap, err := readOldRevocationLogs(openChanBucket, locator)
+	entryMap, err := readOldRevocationLogs(openChanBucket, locator, cfg)
 	if err != nil {
 		return false, fmt.Errorf("read old logs err: %v", err)
 	}
@@ -375,7 +389,7 @@ type result struct {
 // readOldRevocationLogs finds a list of old revocation logs and converts them
 // into the new revocation logs.
 func readOldRevocationLogs(openChanBucket kvdb.RwBucket,
-	locator *updateLocator) (logEntries, error) {
+	locator *updateLocator, cfg MigrateRevLogConfig) (logEntries, error) {
 
 	entries := make(logEntries)
 	results := make([]*result, 0)
@@ -422,7 +436,9 @@ func readOldRevocationLogs(openChanBucket kvdb.RwBucket,
 		// Convert the old logs into the new logs. We do this early in
 		// the read tx so the old large revocation log can be set to
 		// nil here so save us some memory space.
-		newLog, err := convertRevocationLog(&c, ourIndex, theirIndex)
+		newLog, err := convertRevocationLog(
+			&c, ourIndex, theirIndex, cfg.GetNoAmountData(),
+		)
 		if err != nil {
 			r.errChan <- err
 		}
@@ -526,7 +542,8 @@ func readOldRevocationLogs(openChanBucket kvdb.RwBucket,
 // convertRevocationLog uses the fields `CommitTx` and `Htlcs` from a
 // ChannelCommitment to construct a revocation log entry.
 func convertRevocationLog(commit *mig.ChannelCommitment,
-	ourOutputIndex, theirOutputIndex uint32) (*RevocationLog, error) {
+	ourOutputIndex, theirOutputIndex uint32,
+	noAmtData bool) (*RevocationLog, error) {
 
 	// Sanity check that the output indexes can be safely converted.
 	if ourOutputIndex > math.MaxUint16 {

--- a/channeldb/migration30/migration_test.go
+++ b/channeldb/migration30/migration_test.go
@@ -512,6 +512,10 @@ func assertRevocationLog(t testing.TB, want, got RevocationLog) {
 		"wrong TheirOutputIndex")
 	require.Equal(t, want.CommitTxHash, got.CommitTxHash,
 		"wrong CommitTxHash")
+	require.Equal(t, want.TheirBalance, got.TheirBalance,
+		"wrong TheirBalance")
+	require.Equal(t, want.OurBalance, got.OurBalance,
+		"wrong OurBalance")
 	require.Equal(t, len(want.HTLCEntries), len(got.HTLCEntries),
 		"wrong HTLCEntries length")
 

--- a/channeldb/migration30/migration_test.go
+++ b/channeldb/migration30/migration_test.go
@@ -103,11 +103,15 @@ func TestMigrateRevocationLog(t *testing.T) {
 				return nil
 			}
 
+			cfg := &MigrateRevLogConfigImpl{}
+
 			migtest.ApplyMigrationWithDB(
 				t,
 				beforeMigration,
 				afterMigration,
-				MigrateRevocationLog,
+				func(db kvdb.Backend) error {
+					return MigrateRevocationLog(db, cfg)
+				},
 				false,
 			)
 		})
@@ -559,6 +563,8 @@ func BenchmarkMigration(b *testing.B) {
 		return setupTestLogs(db, c, oldLogs, nil)
 	}
 
+	cfg := &MigrateRevLogConfigImpl{}
+
 	// Run the migration test.
 	migtest.ApplyMigrationWithDB(
 		b,
@@ -568,7 +574,7 @@ func BenchmarkMigration(b *testing.B) {
 			b.StartTimer()
 			defer b.StopTimer()
 
-			return MigrateRevocationLog(db)
+			return MigrateRevocationLog(db, cfg)
 		},
 		false,
 	)

--- a/channeldb/migration30/migration_test.go
+++ b/channeldb/migration30/migration_test.go
@@ -75,6 +75,7 @@ func TestMigrateRevocationLog(t *testing.T) {
 	}
 
 	fmt.Printf("Running %d test cases...\n", len(testCases))
+	fmt.Printf("withAmtData is set to: %v\n", withAmtData)
 
 	for i, tc := range testCases {
 		tc := tc
@@ -103,7 +104,9 @@ func TestMigrateRevocationLog(t *testing.T) {
 				return nil
 			}
 
-			cfg := &MigrateRevLogConfigImpl{}
+			cfg := &MigrateRevLogConfigImpl{
+				NoAmountData: !withAmtData,
+			}
 
 			migtest.ApplyMigrationWithDB(
 				t,
@@ -563,7 +566,9 @@ func BenchmarkMigration(b *testing.B) {
 		return setupTestLogs(db, c, oldLogs, nil)
 	}
 
-	cfg := &MigrateRevLogConfigImpl{}
+	cfg := &MigrateRevLogConfigImpl{
+		NoAmountData: !withAmtData,
+	}
 
 	// Run the migration test.
 	migtest.ApplyMigrationWithDB(

--- a/channeldb/migration30/migration_test.go
+++ b/channeldb/migration30/migration_test.go
@@ -103,7 +103,7 @@ func TestMigrateRevocationLog(t *testing.T) {
 				return nil
 			}
 
-			migtest.ApplyMigrationWithDb(
+			migtest.ApplyMigrationWithDB(
 				t,
 				beforeMigration,
 				afterMigration,
@@ -560,7 +560,7 @@ func BenchmarkMigration(b *testing.B) {
 	}
 
 	// Run the migration test.
-	migtest.ApplyMigrationWithDb(
+	migtest.ApplyMigrationWithDB(
 		b,
 		beforeMigration,
 		nil,

--- a/channeldb/migration30/revocation_log.go
+++ b/channeldb/migration30/revocation_log.go
@@ -16,8 +16,18 @@ import (
 	"github.com/lightningnetwork/lnd/tlv"
 )
 
-// OutputIndexEmpty is used when the output index doesn't exist.
-const OutputIndexEmpty = math.MaxUint16
+const (
+	// OutputIndexEmpty is used when the output index doesn't exist.
+	OutputIndexEmpty = math.MaxUint16
+
+	// A set of tlv type definitions used to serialize the body of
+	// revocation logs to the database.
+	//
+	// NOTE: A migration should be added whenever this list changes.
+	revLogOurOutputIndexType   tlv.Type = 0
+	revLogTheirOutputIndexType tlv.Type = 1
+	revLogCommitTxHashType     tlv.Type = 2
+)
 
 var (
 	// revocationLogBucketDeprecated is dedicated for storing the necessary
@@ -208,29 +218,6 @@ type RevocationLog struct {
 	HTLCEntries []*HTLCEntry
 }
 
-// toTlvStream converts an RevocationLog record into a tlv representation.
-func (rl *RevocationLog) toTlvStream() (*tlv.Stream, error) {
-	const (
-		// A set of tlv type definitions used to serialize the body of
-		// revocation logs to the database. We define it here instead
-		// of the head of the file to avoid naming conflicts.
-		//
-		// NOTE: A migration should be added whenever this list
-		// changes.
-		ourOutputIndexType   tlv.Type = 0
-		theirOutputIndexType tlv.Type = 1
-		commitTxHashType     tlv.Type = 2
-	)
-
-	return tlv.NewStream(
-		tlv.MakePrimitiveRecord(ourOutputIndexType, &rl.OurOutputIndex),
-		tlv.MakePrimitiveRecord(
-			theirOutputIndexType, &rl.TheirOutputIndex,
-		),
-		tlv.MakePrimitiveRecord(commitTxHashType, &rl.CommitTxHash),
-	)
-}
-
 // putRevocationLog uses the fields `CommitTx` and `Htlcs` from a
 // ChannelCommitment to construct a revocation log entry and saves them to
 // disk. It also saves our output index and their output index, which are
@@ -304,8 +291,21 @@ func fetchRevocationLog(log kvdb.RBucket,
 // serializeRevocationLog serializes a RevocationLog record based on tlv
 // format.
 func serializeRevocationLog(w io.Writer, rl *RevocationLog) error {
+	// Add the tlv records for all non-optional fields.
+	records := []tlv.Record{
+		tlv.MakePrimitiveRecord(
+			revLogOurOutputIndexType, &rl.OurOutputIndex,
+		),
+		tlv.MakePrimitiveRecord(
+			revLogTheirOutputIndexType, &rl.TheirOutputIndex,
+		),
+		tlv.MakePrimitiveRecord(
+			revLogCommitTxHashType, &rl.CommitTxHash,
+		),
+	}
+
 	// Create the tlv stream.
-	tlvStream, err := rl.toTlvStream()
+	tlvStream, err := tlv.NewStream(records...)
 	if err != nil {
 		return err
 	}
@@ -351,13 +351,20 @@ func deserializeRevocationLog(r io.Reader) (RevocationLog, error) {
 	var rl RevocationLog
 
 	// Create the tlv stream.
-	tlvStream, err := rl.toTlvStream()
-	if err != nil {
-		return rl, err
-	}
+	tlvStream, err := tlv.NewStream(
+		tlv.MakePrimitiveRecord(
+			revLogOurOutputIndexType, &rl.OurOutputIndex,
+		),
+		tlv.MakePrimitiveRecord(
+			revLogTheirOutputIndexType, &rl.TheirOutputIndex,
+		),
+		tlv.MakePrimitiveRecord(
+			revLogCommitTxHashType, &rl.CommitTxHash,
+		),
+	)
 
 	// Read the tlv stream.
-	if err := readTlvStream(r, tlvStream); err != nil {
+	if _, err := readTlvStream(r, tlvStream); err != nil {
 		return rl, err
 	}
 
@@ -382,7 +389,7 @@ func deserializeHTLCEntries(r io.Reader) ([]*HTLCEntry, error) {
 		}
 
 		// Read the HTLC entry.
-		if err := readTlvStream(r, tlvStream); err != nil {
+		if _, err := readTlvStream(r, tlvStream); err != nil {
 			// We've reached the end when hitting an EOF.
 			if err == io.ErrUnexpectedEOF {
 				break
@@ -427,7 +434,7 @@ func writeTlvStream(w io.Writer, s *tlv.Stream) error {
 
 // readTlvStream is a helper function that decodes the tlv stream from the
 // reader.
-func readTlvStream(r io.Reader, s *tlv.Stream) error {
+func readTlvStream(r io.Reader, s *tlv.Stream) (tlv.TypeMap, error) {
 	var bodyLen uint64
 
 	// Read the stream's length.
@@ -436,16 +443,17 @@ func readTlvStream(r io.Reader, s *tlv.Stream) error {
 	// We'll convert any EOFs to ErrUnexpectedEOF, since this results in an
 	// invalid record.
 	case err == io.EOF:
-		return io.ErrUnexpectedEOF
+		return nil, io.ErrUnexpectedEOF
 
 	// Other unexpected errors.
 	case err != nil:
-		return err
+		return nil, err
 	}
 
 	// TODO(yy): add overflow check.
 	lr := io.LimitReader(r, int64(bodyLen))
-	return s.Decode(lr)
+
+	return s.DecodeWithParsedTypes(lr)
 }
 
 // fetchLogBucket returns a read bucket by visiting both the new and the old

--- a/channeldb/migration30/revocation_log.go
+++ b/channeldb/migration30/revocation_log.go
@@ -223,7 +223,7 @@ type RevocationLog struct {
 // disk. It also saves our output index and their output index, which are
 // useful when creating breach retribution.
 func putRevocationLog(bucket kvdb.RwBucket, commit *mig.ChannelCommitment,
-	ourOutputIndex, theirOutputIndex uint32) error {
+	ourOutputIndex, theirOutputIndex uint32, noAmtData bool) error {
 
 	// Sanity check that the output indexes can be safely converted.
 	if ourOutputIndex > math.MaxUint16 {

--- a/channeldb/migration30/test_utils.go
+++ b/channeldb/migration30/test_utils.go
@@ -3,6 +3,8 @@ package migration30
 import (
 	"bytes"
 	"fmt"
+	"math/rand"
+	"time"
 
 	"github.com/btcsuite/btcd/btcec/v2"
 	"github.com/btcsuite/btcd/btcutil"
@@ -260,6 +262,12 @@ var (
 		0xf8, 0xc3, 0xfc, 0x7, 0x2d, 0x15, 0x99, 0x55,
 		0x8, 0x69, 0xf6, 0x1, 0xa2, 0xcd, 0x6b, 0xa7,
 	})
+
+	// withAmtData if set, will result in the amount data of the revoked
+	// commitment transactions also being stored in the new revocation log.
+	// The value of this variable is set randomly in the init function of
+	// this package.
+	withAmtData bool
 )
 
 // setupTestLogs takes care of creating the related buckets and inserts testing
@@ -550,4 +558,11 @@ func createFinished(cdb kvdb.Backend, c *mig26.OpenChannel,
 		newLogs = append(newLogs, newLog3)
 	}
 	return setupTestLogs(cdb, c, oldLogs, newLogs)
+}
+
+func init() {
+	rand.Seed(time.Now().Unix())
+	if rand.Intn(2) == 0 {
+		withAmtData = true
+	}
 }

--- a/channeldb/migration30/test_utils.go
+++ b/channeldb/migration30/test_utils.go
@@ -306,7 +306,7 @@ func setupTestLogs(db kvdb.Backend, c *mig26.OpenChannel,
 		}
 
 		// Create new logs.
-		return writeNewRevocationLogs(chanBucket, newLogs)
+		return writeNewRevocationLogs(chanBucket, newLogs, !withAmtData)
 	}, func() {})
 }
 
@@ -460,7 +460,7 @@ func writeOldRevocationLogs(chanBucket kvdb.RwBucket,
 
 // writeNewRevocationLogs saves a new revocation log to db.
 func writeNewRevocationLogs(chanBucket kvdb.RwBucket,
-	oldLogs []mig.ChannelCommitment) error {
+	oldLogs []mig.ChannelCommitment, noAmtData bool) error {
 
 	// Don't bother continue if the logs are empty.
 	if len(oldLogs) == 0 {
@@ -480,7 +480,7 @@ func writeNewRevocationLogs(chanBucket kvdb.RwBucket,
 		// old commit tx. We do this intentionally so we can
 		// distinguish a newly created log from an already saved one.
 		err := putRevocationLog(
-			logBucket, &c, testOurIndex, testTheirIndex,
+			logBucket, &c, testOurIndex, testTheirIndex, noAmtData,
 		)
 		if err != nil {
 			return err

--- a/channeldb/migtest/migtest.go
+++ b/channeldb/migtest/migtest.go
@@ -84,12 +84,12 @@ func ApplyMigration(t *testing.T,
 	}
 }
 
-// ApplyMigrationWithDb is a helper test function that encapsulates the general
+// ApplyMigrationWithDB is a helper test function that encapsulates the general
 // steps which are needed to properly check the result of applying migration
 // function. This function differs from ApplyMigration as it requires the
 // supplied migration functions to take a db instance and construct their own
 // database transactions.
-func ApplyMigrationWithDb(t testing.TB, beforeMigration, afterMigration,
+func ApplyMigrationWithDB(t testing.TB, beforeMigration, afterMigration,
 	migrationFunc func(db kvdb.Backend) error, shouldFail bool) {
 
 	t.Helper()

--- a/channeldb/migtest/migtest.go
+++ b/channeldb/migtest/migtest.go
@@ -89,7 +89,8 @@ func ApplyMigration(t *testing.T,
 // function. This function differs from ApplyMigration as it requires the
 // supplied migration functions to take a db instance and construct their own
 // database transactions.
-func ApplyMigrationWithDB(t testing.TB, beforeMigration, afterMigration,
+func ApplyMigrationWithDB(t testing.TB, beforeMigration,
+	afterMigration func(db kvdb.Backend) error,
 	migrationFunc func(db kvdb.Backend) error, shouldFail bool) {
 
 	t.Helper()

--- a/channeldb/options.go
+++ b/channeldb/options.go
@@ -64,6 +64,10 @@ type Options struct {
 	// applications that use the channeldb package as a library.
 	NoMigration bool
 
+	// NoRevLogAmtData when set to true, indicates that amount data should
+	// not be stored in the revocation log.
+	NoRevLogAmtData bool
+
 	// clock is the time source used by the database.
 	clock clock.Clock
 
@@ -127,6 +131,14 @@ func OptionSetPreAllocCacheNumNodes(n int) OptionModifier {
 func OptionSetUseGraphCache(use bool) OptionModifier {
 	return func(o *Options) {
 		o.UseGraphCache = use
+	}
+}
+
+// OptionNoRevLogAmtData sets the NoRevLogAmtData option to the given value. If
+// it is set to true then amount data will not be stored in the revocation log.
+func OptionNoRevLogAmtData(noAmtData bool) OptionModifier {
+	return func(o *Options) {
+		o.NoRevLogAmtData = noAmtData
 	}
 }
 

--- a/channeldb/revocation_log.go
+++ b/channeldb/revocation_log.go
@@ -12,8 +12,18 @@ import (
 	"github.com/lightningnetwork/lnd/tlv"
 )
 
-// OutputIndexEmpty is used when the output index doesn't exist.
-const OutputIndexEmpty = math.MaxUint16
+const (
+	// OutputIndexEmpty is used when the output index doesn't exist.
+	OutputIndexEmpty = math.MaxUint16
+
+	// A set of tlv type definitions used to serialize the body of
+	// revocation logs to the database.
+	//
+	// NOTE: A migration should be added whenever this list changes.
+	revLogOurOutputIndexType   tlv.Type = 0
+	revLogTheirOutputIndexType tlv.Type = 1
+	revLogCommitTxHashType     tlv.Type = 2
+)
 
 var (
 	// revocationLogBucketDeprecated is dedicated for storing the necessary
@@ -196,29 +206,6 @@ type RevocationLog struct {
 	HTLCEntries []*HTLCEntry
 }
 
-// toTlvStream converts an RevocationLog record into a tlv representation.
-func (rl *RevocationLog) toTlvStream() (*tlv.Stream, error) {
-	const (
-		// A set of tlv type definitions used to serialize the body of
-		// revocation logs to the database. We define it here instead
-		// of the head of the file to avoid naming conflicts.
-		//
-		// NOTE: A migration should be added whenever this list
-		// changes.
-		ourOutputIndexType   tlv.Type = 0
-		theirOutputIndexType tlv.Type = 1
-		commitTxHashType     tlv.Type = 2
-	)
-
-	return tlv.NewStream(
-		tlv.MakePrimitiveRecord(ourOutputIndexType, &rl.OurOutputIndex),
-		tlv.MakePrimitiveRecord(
-			theirOutputIndexType, &rl.TheirOutputIndex,
-		),
-		tlv.MakePrimitiveRecord(commitTxHashType, &rl.CommitTxHash),
-	)
-}
-
 // putRevocationLog uses the fields `CommitTx` and `Htlcs` from a
 // ChannelCommitment to construct a revocation log entry and saves them to
 // disk. It also saves our output index and their output index, which are
@@ -292,8 +279,21 @@ func fetchRevocationLog(log kvdb.RBucket,
 // serializeRevocationLog serializes a RevocationLog record based on tlv
 // format.
 func serializeRevocationLog(w io.Writer, rl *RevocationLog) error {
+	// Add the tlv records for all non-optional fields.
+	records := []tlv.Record{
+		tlv.MakePrimitiveRecord(
+			revLogOurOutputIndexType, &rl.OurOutputIndex,
+		),
+		tlv.MakePrimitiveRecord(
+			revLogTheirOutputIndexType, &rl.TheirOutputIndex,
+		),
+		tlv.MakePrimitiveRecord(
+			revLogCommitTxHashType, &rl.CommitTxHash,
+		),
+	}
+
 	// Create the tlv stream.
-	tlvStream, err := rl.toTlvStream()
+	tlvStream, err := tlv.NewStream(records...)
 	if err != nil {
 		return err
 	}
@@ -339,13 +339,20 @@ func deserializeRevocationLog(r io.Reader) (RevocationLog, error) {
 	var rl RevocationLog
 
 	// Create the tlv stream.
-	tlvStream, err := rl.toTlvStream()
-	if err != nil {
-		return rl, err
-	}
+	tlvStream, err := tlv.NewStream(
+		tlv.MakePrimitiveRecord(
+			revLogOurOutputIndexType, &rl.OurOutputIndex,
+		),
+		tlv.MakePrimitiveRecord(
+			revLogTheirOutputIndexType, &rl.TheirOutputIndex,
+		),
+		tlv.MakePrimitiveRecord(
+			revLogCommitTxHashType, &rl.CommitTxHash,
+		),
+	)
 
 	// Read the tlv stream.
-	if err := readTlvStream(r, tlvStream); err != nil {
+	if _, err := readTlvStream(r, tlvStream); err != nil {
 		return rl, err
 	}
 
@@ -370,7 +377,7 @@ func deserializeHTLCEntries(r io.Reader) ([]*HTLCEntry, error) {
 		}
 
 		// Read the HTLC entry.
-		if err := readTlvStream(r, tlvStream); err != nil {
+		if _, err := readTlvStream(r, tlvStream); err != nil {
 			// We've reached the end when hitting an EOF.
 			if err == io.ErrUnexpectedEOF {
 				break
@@ -415,7 +422,7 @@ func writeTlvStream(w io.Writer, s *tlv.Stream) error {
 
 // readTlvStream is a helper function that decodes the tlv stream from the
 // reader.
-func readTlvStream(r io.Reader, s *tlv.Stream) error {
+func readTlvStream(r io.Reader, s *tlv.Stream) (tlv.TypeMap, error) {
 	var bodyLen uint64
 
 	// Read the stream's length.
@@ -424,16 +431,17 @@ func readTlvStream(r io.Reader, s *tlv.Stream) error {
 	// We'll convert any EOFs to ErrUnexpectedEOF, since this results in an
 	// invalid record.
 	case err == io.EOF:
-		return io.ErrUnexpectedEOF
+		return nil, io.ErrUnexpectedEOF
 
 	// Other unexpected errors.
 	case err != nil:
-		return err
+		return nil, err
 	}
 
 	// TODO(yy): add overflow check.
 	lr := io.LimitReader(r, int64(bodyLen))
-	return s.Decode(lr)
+
+	return s.DecodeWithParsedTypes(lr)
 }
 
 // fetchOldRevocationLog finds the revocation log from the deprecated

--- a/channeldb/revocation_log.go
+++ b/channeldb/revocation_log.go
@@ -211,7 +211,7 @@ type RevocationLog struct {
 // disk. It also saves our output index and their output index, which are
 // useful when creating breach retribution.
 func putRevocationLog(bucket kvdb.RwBucket, commit *ChannelCommitment,
-	ourOutputIndex, theirOutputIndex uint32) error {
+	ourOutputIndex, theirOutputIndex uint32, noAmtData bool) error {
 
 	// Sanity check that the output indexes can be safely converted.
 	if ourOutputIndex > math.MaxUint16 {

--- a/channeldb/revocation_log_test.go
+++ b/channeldb/revocation_log_test.go
@@ -368,6 +368,7 @@ func TestPutRevocationLog(t *testing.T) {
 		commit      ChannelCommitment
 		ourIndex    uint32
 		theirIndex  uint32
+		noAmtData   bool
 		expectedErr error
 		expectedLog RevocationLog
 	}{
@@ -435,6 +436,7 @@ func TestPutRevocationLog(t *testing.T) {
 			// Save the log.
 			err = putRevocationLog(
 				bucket, &tc.commit, tc.ourIndex, tc.theirIndex,
+				tc.noAmtData,
 			)
 			if err != nil {
 				return RevocationLog{}, err
@@ -542,7 +544,7 @@ func TestFetchRevocationLogCompatible(t *testing.T) {
 				require.NoError(t, err)
 
 				err = putRevocationLog(
-					lb, &testChannelCommit, 0, 1,
+					lb, &testChannelCommit, 0, 1, false,
 				)
 				require.NoError(t, err)
 			}

--- a/channeldb/revocation_log_test.go
+++ b/channeldb/revocation_log_test.go
@@ -127,7 +127,7 @@ func TestReadTLVStream(t *testing.T) {
 
 	// Read the tlv stream.
 	buf := bytes.NewBuffer(testValueBytes)
-	err = readTlvStream(buf, ts)
+	_, err = readTlvStream(buf, ts)
 	require.NoError(t, err)
 
 	// Check the bytes are read as expected.
@@ -150,7 +150,7 @@ func TestReadTLVStreamErr(t *testing.T) {
 
 	// Read the tlv stream.
 	buf := bytes.NewBuffer(b)
-	err = readTlvStream(buf, ts)
+	_, err = readTlvStream(buf, ts)
 	require.ErrorIs(t, err, io.ErrUnexpectedEOF)
 
 	// Check the bytes are not read.

--- a/config.go
+++ b/config.go
@@ -981,6 +981,13 @@ func ValidateConfig(cfg Config, interceptor signal.Interceptor, fileParser,
 		)
 	}
 
+	// Ensure that the amount data for revoked commitment transactions is
+	// stored if the watchtower client is active.
+	if cfg.DB.NoRevLogAmtData && cfg.WtClient.Active {
+		return nil, mkErr("revocation log amount data must be stored " +
+			"if the watchtower client is active")
+	}
+
 	// Ensure a valid max channel fee allocation was set.
 	if cfg.MaxChannelFeeAllocation <= 0 || cfg.MaxChannelFeeAllocation > 1 {
 		return nil, mkErr("invalid max channel fee allocation: %v, "+

--- a/config_builder.go
+++ b/config_builder.go
@@ -867,15 +867,22 @@ func (d *DefaultDatabaseBuilder) BuildDatabase(
 
 	dbOptions := []channeldb.OptionModifier{
 		channeldb.OptionSetRejectCacheSize(cfg.Caches.RejectCacheSize),
-		channeldb.OptionSetChannelCacheSize(cfg.Caches.ChannelCacheSize),
-		channeldb.OptionSetBatchCommitInterval(cfg.DB.BatchCommitInterval),
+		channeldb.OptionSetChannelCacheSize(
+			cfg.Caches.ChannelCacheSize,
+		),
+		channeldb.OptionSetBatchCommitInterval(
+			cfg.DB.BatchCommitInterval,
+		),
 		channeldb.OptionDryRunMigration(cfg.DryRunMigration),
 		channeldb.OptionSetUseGraphCache(!cfg.DB.NoGraphCache),
-		channeldb.OptionKeepFailedPaymentAttempts(cfg.KeepFailedPaymentAttempts),
+		channeldb.OptionKeepFailedPaymentAttempts(
+			cfg.KeepFailedPaymentAttempts,
+		),
 		channeldb.OptionStoreFinalHtlcResolutions(
 			cfg.StoreFinalHtlcResolutions,
 		),
 		channeldb.OptionPruneRevocationLog(cfg.DB.PruneRevocation),
+		channeldb.OptionNoRevLogAmtData(cfg.DB.NoRevLogAmtData),
 	}
 
 	// We want to pre-allocate the channel graph cache according to what we

--- a/docs/release-notes/release-notes-0.16.0.md
+++ b/docs/release-notes/release-notes-0.16.0.md
@@ -404,6 +404,14 @@ in the lnwire package](https://github.com/lightningnetwork/lnd/pull/7303)
   3.5.7](https://github.com/lightningnetwork/lnd/pull/7353) to resolve linking
   issues with outdated dependencies.
 
+* [Re-add local and remote output amounts to the revocation 
+  log](https://github.com/lightningnetwork/lnd/pull/7379) and add a new 
+  `--db.no-rev-log-amt-data` flag that can be used to explicitly opt out of  
+  storing this extra data. It should be noted that setting this flag is not 
+  recommended unless the user is sure that they will never activate their 
+  watchtower client (`--wtclient.active`) in the future. The new flag can not
+  be set at all if the `--wtclient.active` flag has been set.
+
 ## Pathfinding
 
 * [Pathfinding takes capacity of edges into account to improve success

--- a/lncfg/db.go
+++ b/lncfg/db.go
@@ -85,6 +85,8 @@ type DB struct {
 	NoGraphCache bool `long:"no-graph-cache" description:"Don't use the in-memory graph cache for path finding. Much slower but uses less RAM. Can only be used with a bolt database backend."`
 
 	PruneRevocation bool `long:"prune-revocation" description:"Run the optional migration that prunes the revocation logs to save disk space."`
+
+	NoRevLogAmtData bool `long:"no-rev-log-amt-data" description:"If set, the to-local and to-remote output amounts of revoked commitment transactions will not be stored in the revocation log. Note that once this data is lost, a watchtower client will not be able to back up the revoked state."`
 }
 
 // DefaultDB creates and returns a new default DB config.

--- a/sample-lnd.conf
+++ b/sample-lnd.conf
@@ -1241,6 +1241,12 @@ litecoin.node=ltcd
 ; channels prior to lnd@v0.15.0.
 ; db.prune-revocation=false
 
+; If set to true, then the to-local and to-remote output amount data of revoked
+; commitment transactions will not be stored in the revocation log. Note that
+; this flag can only be set if --wtclient.active is not set. It is not
+; recommended to set this flag if you plan on ever setting wtclient.active in
+; the future.
+; db.no-rev-log-amt-data=false
 
 [etcd]
 

--- a/watchtower/wtdb/migration4/client_db_test.go
+++ b/watchtower/wtdb/migration4/client_db_test.go
@@ -237,7 +237,7 @@ func TestMigrateAckedUpdates(t *testing.T) {
 			// summary bucket and a new index bucket.
 			after := after(test.shouldFail, test.pre, test.post)
 
-			migtest.ApplyMigrationWithDb(
+			migtest.ApplyMigrationWithDB(
 				t, before, after, MigrateAckedUpdates(2),
 				test.shouldFail,
 			)


### PR DESCRIPTION
This PR re-adds the `LocalBalance` and `RemoteBalance` fields to the `RevocationLog`. It also tweaks the existing `channeldb/migration30` to include these fields so that users who have not yet run the optional migration dont have to lose these fields. 

The reason for re-adding these fields is for a use cases where we want to be able to construct an `lnwallet.BreachRetribution` _without_ having access to the actual breach transaction. An example of this use case is with watchtowers where we might want to re-play a backup onto a different tower's session queue which means we will need to re-sign the justice transaction. This is required for [this PR](https://github.com/lightningnetwork/lnd/pull/7380) in order to solve [this issue](https://github.com/lightningnetwork/lnd/issues/5983)

By re-adding these two fields to the revocation log, we also get the added bonus of the tower client needing to carry around less info in it's task pipeline which will make the amount of info we need to persist in a disk overflow queue (pr incoming) much more minimal.