### PR TITLE
walletunlocker: fix unit test flake by closing DB

### DIFF
--- a/docs/release-notes/release-notes-0.16.0.md
+++ b/docs/release-notes/release-notes-0.16.0.md
@@ -344,8 +344,11 @@ in the lnwire package](https://github.com/lightningnetwork/lnd/pull/7303)
   issue found in `bitcoindnotify/bitcoind_test.go`.
 
 * Add methods to easily check if an invoice [is AMP or 
-Keysend](https://github.com/lightningnetwork/lnd/pull/7334).
- 
+  Keysend](https://github.com/lightningnetwork/lnd/pull/7334).
+
+* [Fixed a unit test flake in the wallet
+  unlocker](https://github.com/lightningnetwork/lnd/pull/7384).
+
 ## Watchtowers
 
 * [Create a towerID-to-sessionID index in the wtclient DB to improve the 


### PR DESCRIPTION
This fixes a unit test flake that occurred sometimes if the temporary directory was attempted to be deleted but the wallet or macaroon DB hasn't been closed yet.

````
--- FAIL: TestChangeWalletPasswordNewRootkey (1.63s)
    testing.go:1097: TempDir RemoveAll cleanup: unlinkat /tmp/TestChangeWalletPasswordNewRootkey3063283009/001/mainnet: directory not empty
FAIL
FAIL	github.com/lightningnetwork/lnd/walletunlocker	6.171s
FAIL
````
