### PR TITLE
remote signer: fix channel funding with mixed funding input types

### DIFF
--- a/docs/release-notes/release-notes-0.16.0.md
+++ b/docs/release-notes/release-notes-0.16.0.md
@@ -139,6 +139,10 @@ current gossip sync query status.
 * [Add log message for edge
   case](https://github.com/lightningnetwork/lnd/pull/7115).
 
+* [A remote signer issue was fixed that caused opening channels to fail when
+  multiple mixed-type inputs were used for the funding
+  transaction](https://github.com/lightningnetwork/lnd/pull/7386).
+
 ## Build
 
 * [The project has updated to Go

--- a/lntest/itest/lnd_remote_signer_test.go
+++ b/lntest/itest/lnd_remote_signer_test.go
@@ -116,6 +116,11 @@ func testRemoteSigner(ht *lntemp.HarnessTest) {
 			runSignPsbtSegWitV1KeySpendBip86(tt, wo)
 			runSignPsbtSegWitV1KeySpendRootHash(tt, wo)
 			runSignPsbtSegWitV1ScriptSpend(tt, wo)
+
+			// The above tests all make sure we can sign for keys
+			// that aren't in the wallet. But we also want to make
+			// sure we can fund and then sign PSBTs from our wallet.
+			runFundAndSignPsbt(ht, wo)
 		},
 	}, {
 		name:      "sign output raw",

--- a/lntest/itest/lnd_remote_signer_test.go
+++ b/lntest/itest/lnd_remote_signer_test.go
@@ -85,6 +85,12 @@ func testRemoteSigner(ht *lntemp.HarnessTest) {
 			runBasicChannelCreationAndUpdates(tt, wo, carol)
 		},
 	}, {
+		name:      "channel funding input types",
+		sendCoins: false,
+		fn: func(tt *lntemp.HarnessTest, wo, carol *node.HarnessNode) {
+			runChannelFundingInputTypes(tt, carol, wo)
+		},
+	}, {
 		name:      "async payments",
 		sendCoins: true,
 		fn: func(tt *lntemp.HarnessTest, wo, carol *node.HarnessNode) {

--- a/lnwallet/chanfunding/wallet_assembler.go
+++ b/lnwallet/chanfunding/wallet_assembler.go
@@ -110,13 +110,12 @@ func (f *FullIntent) CompileFundingTx(extraInputs []*wire.TxIn,
 	prevOutFetcher := NewSegWitV0DualFundingPrevOutputFetcher(
 		f.coinSource, extraInputs,
 	)
-	signDesc := input.SignDescriptor{
-		SigHashes: txscript.NewTxSigHashes(
-			fundingTx, prevOutFetcher,
-		),
-		PrevOutputFetcher: prevOutFetcher,
-	}
+	sigHashes := txscript.NewTxSigHashes(fundingTx, prevOutFetcher)
 	for i, txIn := range fundingTx.TxIn {
+		signDesc := input.SignDescriptor{
+			SigHashes:         sigHashes,
+			PrevOutputFetcher: prevOutFetcher,
+		}
 		// We can only sign this input if it's ours, so we'll ask the
 		// coin source if it can map this outpoint into a coin we own.
 		// If not, then we'll continue as it isn't our input.

--- a/lnwallet/rpcwallet/rpcwallet.go
+++ b/lnwallet/rpcwallet/rpcwallet.go
@@ -159,6 +159,10 @@ func (r *RPCKeyRing) SendOutputs(outputs []*wire.TxOut,
 			return nil, fmt.Errorf("error looking up utxo: %v", err)
 		}
 
+		if txscript.IsPayToTaproot(info.PkScript) {
+			signDesc.HashType = txscript.SigHashDefault
+		}
+
 		// Now that we know the input is ours, we'll populate the
 		// signDesc with the per input unique information.
 		signDesc.Output = &wire.TxOut{
@@ -593,7 +597,7 @@ func (r *RPCKeyRing) ComputeInputScript(tx *wire.MsgTx,
 		signDesc.SignMethod = input.TaprootKeySpendBIP0086SignMethod
 		signDesc.WitnessScript = nil
 
-		sig, err := r.remoteSign(tx, signDesc, sigScript)
+		sig, err := r.remoteSign(tx, signDesc, nil)
 		if err != nil {
 			return nil, fmt.Errorf("error signing with remote"+
 				"instance: %v", err)

--- a/lnwallet/rpcwallet/rpcwallet.go
+++ b/lnwallet/rpcwallet/rpcwallet.go
@@ -617,7 +617,7 @@ func (r *RPCKeyRing) ComputeInputScript(tx *wire.MsgTx,
 
 	// Let's give the TX to the remote instance now, so it can sign the
 	// input.
-	sig, err := r.remoteSign(tx, signDesc, sigScript)
+	sig, err := r.remoteSign(tx, signDesc, witnessProgram)
 	if err != nil {
 		return nil, fmt.Errorf("error signing with remote instance: %v",
 			err)


### PR DESCRIPTION
Fixes https://github.com/lightningnetwork/lnd/issues/7276.

This fixes an issue where channels couldn't be opened if there were a number of mixed type (p2tr and p2wkh for example) inputs used for the funding transaction.
