### PR TITLE
HTLC Interceptor: Fix nil pointer dereference

### DIFF
--- a/docs/release-notes/release-notes-0.16.0.md
+++ b/docs/release-notes/release-notes-0.16.0.md
@@ -125,6 +125,9 @@ current gossip sync query status.
   update in order to use the new versioned RPC and upgrade any on-chain outputs
   to the new version.
 
+* [A bug has been fixed which could cause `lnd` to crash when parsing a
+  malformed HTLC intercept message](https://github.com/lightningnetwork/lnd/pull/7392).
+
 ## Wallet
 
 * [Allows Taproot public keys and tap scripts to be imported as watch-only

--- a/lnrpc/routerrpc/forward_interceptor.go
+++ b/lnrpc/routerrpc/forward_interceptor.go
@@ -100,6 +100,11 @@ func (r *forwardInterceptor) onIntercept(
 func (r *forwardInterceptor) resolveFromClient(
 	in *ForwardHtlcInterceptResponse) error {
 
+	if in.IncomingCircuitKey == nil {
+		return status.Errorf(codes.InvalidArgument,
+			"CircuitKey missing from ForwardHtlcInterceptResponse")
+	}
+
 	log.Tracef("Resolving intercepted packet %v", in)
 
 	circuitKey := models.CircuitKey{


### PR DESCRIPTION
## Change Description
This fixes an issue where LND can crash due to an invalid RPC message from an HTLC interceptor.  Not a security or DoS concern as this is from authenticated messages coming in on grpc, but it's a pretty easy mistake to make on the interceptor side (just leave off the `IncomingCircuit`) so I think it's worth fixing.

All this PR does is add a `==nil` check and returns an error if `IncomingCircuit` is nil.  

Other places you could put this check would be in `(r *forwardInterceptor) run()` above (or maybe in the `Recv()` function somehow?) but this seemed like the most straightforward place.

## Steps to Test
To test: 
Run LND.  
Connect an HTLC interceptor, but in the interceptor code, don't specify an `IncomingCircuitKey` in the `routerrpc.ForwardHtlcInterceptResponse`.  
The first time LND tries to forward an HTLC, it will get a `ForwardHtlcInterceptResponse` without an `IncomingCircuitKey` and crash with `panic: runtime error: invalid memory address or nil pointer dereference`

Apply this patch, try the same thing, and LND will disconnect the interceptor with this showing up in the logs:

`[ERR] RPCS: [/routerrpc.Router/HtlcInterceptor]: rpc error: code = InvalidArgument desc = CircuitKey missing
 from ForwardHtlcInterceptResponse`

(I dunno if "InvalidArgument" is the right error code but seems close enough)

## Pull Request Checklist
### Testing
- [ ] Your PR passes all CI checks.
- [ ] Tests covering the positive and negative (error paths) are included.
- [ ] Bug fixes contain tests triggering the bug to prevent regressions.

### Code Style and Documentation
- [ ] The change obeys the [Code Documentation and Commenting](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#CodeDocumentation) guidelines, and lines wrap at 80.
- [ ] Commits follow the [Ideal Git Commit Structure](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#IdealGitCommitStructure).
- [ ] Any new logging statements use an appropriate subsystem and logging level.
- [ ]  [There is a change description in the release notes](https://github.com/lightningnetwork/lnd/tree/master/docs/release-notes), or `[skip ci]` in the commit message for small changes.