### PR TITLE
channeldb+invoices: fix unit test flakes

### DIFF
--- a/channeldb/db_test.go
+++ b/channeldb/db_test.go
@@ -243,11 +243,13 @@ func TestFetchChannel(t *testing.T) {
 			spew.Sdump(channelState), spew.Sdump(dbChannel))
 	}
 
-	// If we attempt to query for a non-exist ante channel, then we should
+	// If we attempt to query for a non-existent channel, then we should
 	// get an error.
 	channelState2 := createTestChannelState(t, cdb)
 	require.NoError(t, err, "unable to create channel state")
-	channelState2.FundingOutpoint.Index ^= 1
+
+	uniqueOutputIndex.Add(1)
+	channelState2.FundingOutpoint.Index = uniqueOutputIndex.Load()
 
 	_, err = cdb.FetchChannel(nil, channelState2.FundingOutpoint)
 	if err == nil {


### PR DESCRIPTION
From this [build](https://github.com/lightningnetwork/lnd/actions/runs/4128434176/jobs/7132878444),
```
--- FAIL: TestFetchChannels (0.00s)
    --- FAIL: TestFetchChannels/not_waiting_close_channels (0.01s)
        channel_test.go:195: unable to save and serialize channel state: channel already exists
FAIL
```

Though a tiny chance, it looks like the `rand.Uint32()` produced the same value twice. We now avoid this possibility by making the outpoint unique deterministically.

Also from this [build](https://github.com/lightningnetwork/lnd/actions/runs/4142208064/jobs/7162611176),
```
--- FAIL: TestInvoiceExpiryWithRegistry (0.53s)
    invoiceregistry_test.go:1028: 
        	Error Trace:	/home/runner/work/lnd/lnd/invoices/invoiceregistry_test.go:1028
        	Error:      	Not equal: 
        	            	expected: 0x2
        	            	actual  : 0x0
        	Test:       	TestInvoiceExpiryWithRegistry
```
Turns out that when the `registry` stops before marking the invoices as canceled the test would then fail. It's now fixed to make sure the required state is reached before stopping the `registry`.