### PR TITLE
docs: fix whitespace in sample-lnd.conf

### DIFF
--- a/sample-lnd.conf
+++ b/sample-lnd.conf
@@ -47,8 +47,8 @@
 ; (old tls files must be deleted if changed)
 ; tlsextradomain=
 
-; If set, then all certs will automatically be refreshed if they're close to 
-; expiring, or if any parameters related to extra IPs or domains in the cert 
+; If set, then all certs will automatically be refreshed if they're close to
+; expiring, or if any parameters related to extra IPs or domains in the cert
 ; change.
 ; tlsautorefresh=true
 
@@ -119,8 +119,8 @@
 ; 'largest' and 'random'.
 ; coin-selection-strategy=largest
 
-; A period to wait before for closing channels with outgoing htlcs that have 
-; timed out and are a result of this nodes instead payment. In addition to our 
+; A period to wait before for closing channels with outgoing htlcs that have
+; timed out and are a result of this nodes instead payment. In addition to our
 ; current block based deadline, if specified this grace period will also be taken
 ; into account. Valid time units are {s, m, h}.
 ; payments-expiration-grace-period=30s
@@ -212,8 +212,8 @@
 
 ; Debug logging level.
 ; Valid levels are {trace, debug, info, warn, error, critical}
-; You may also specify <global-level>,<subsystem>=<level>,<subsystem2>=<level>,... 
-; to set log level for individual subsystems. Use lncli debuglevel --show to 
+; You may also specify <global-level>,<subsystem>=<level>,<subsystem2>=<level>,...
+; to set log level for individual subsystems. Use lncli debuglevel --show to
 ; list available subsystems.
 ; debuglevel=debug,PEER=info
 
@@ -283,7 +283,7 @@
 ; minchansize=
 
 ; The largest channel size (in satoshis) that we should accept. Incoming
-; channels larger than this will be rejected. For non-Wumbo channels this 
+; channels larger than this will be rejected. For non-Wumbo channels this
 ; limit remains 16777215 satoshis by default as specified in BOLT-0002.
 ; For wumbo channels this limit is 1,000,000,000 satoshis (10 BTC).
 ; Set this config option explicitly to restrict your maximum channel size
@@ -306,7 +306,7 @@
 ; The maximum time that is allowed to pass while waiting for the remote party
 ; to revoke a locally initiated commitment state. Setting this to a longer
 ; duration if a slow response is expected from the remote party or large
-; number of payments are attempted at the same time. 
+; number of payments are attempted at the same time.
 ; (default: 1m0s)
 ; pending-commit-interval=5m
 
@@ -331,8 +331,8 @@
 ; on the network. (default: 19m0s)
 ; chan-enable-timeout=22m
 
-; The duration that must elapse after first detecting that an already active 
-; channel is actually inactive and sending channel update disabling it to the 
+; The duration that must elapse after first detecting that an already active
+; channel is actually inactive and sending channel update disabling it to the
 ; network. The pending disable can be canceled if the peer reconnects and becomes
 ; stable for chan-enable-timeout before the disable update is sent.
 ; (default: 20m0s)
@@ -437,8 +437,8 @@
 ; can be tuned to save bandwidth for light clients or routing nodes. (default: 3)
 ; numgraphsyncpeers=9
 
-; If true, lnd will start the Prometheus exporter. Prometheus flags are 
-; behind a build/compile flag and are not available by default. lnd must be built 
+; If true, lnd will start the Prometheus exporter. Prometheus flags are
+; behind a build/compile flag and are not available by default. lnd must be built
 ; with the monitoring tag; `make && make install tags=monitoring` to activate them.
 ; prometheus.enable=true
 
@@ -494,7 +494,7 @@ bitcoin.simnet=true
 
 ; Specify the chain back-end. Options are btcd, bitcoind and neutrino.
 ;
-; NOTE: Please note that switching between a full back-end (btcd/bitcoind) and 
+; NOTE: Please note that switching between a full back-end (btcd/bitcoind) and
 ; a light back-end (neutrino) is not supported.
 bitcoin.node=btcd
 ; bitcoin.node=bitcoind
@@ -640,7 +640,7 @@ bitcoin.node=btcd
 ; neutrino.connect=
 
 ; Max number of inbound and outbound peers.
-; 
+;
 ; NOTE: This value is currently unused.
 ; neutrino.maxpeers=
 
@@ -649,12 +649,12 @@ bitcoin.node=btcd
 
 ; How long to ban misbehaving peers. Valid time units are {s, m, h}. Minimum 1
 ; second.
-; 
+;
 ; NOTE: This value is currently unused.
 ; neutrino.banduration=
 
 ; Maximum allowed ban score before disconnecting and banning misbehaving peers.
-; 
+;
 ; NOTE: This value is currently unused.
 ; neutrino.banthreshold=
 
@@ -938,7 +938,7 @@ litecoin.node=ltcd
 ; The path to the private key of the onion service being created
 ; tor.privatekeypath=/path/to/torkey
 
-;The path to the private key of the watchtower onion service being created
+; The path to the private key of the watchtower onion service being created
 ; tor.watchtowerkeypath=/other/path/
 
 ; Instructs lnd to encrypt the private key using the wallet's seed.
@@ -1055,11 +1055,11 @@ litecoin.node=ltcd
 ; gracefully shutting down. Set this value to 0 to disable this health check.
 ; healthcheck.torconnection.attempts=3
 
-; The amount of time we allow a call to our tor connection to take before we 
+; The amount of time we allow a call to our tor connection to take before we
 ; fail the attempt. This value must be >= 1s.
 ; healthcheck.torconnection.timeout=10s
 
-; The amount of time we should backoff between failed attempts to check tor 
+; The amount of time we should backoff between failed attempts to check tor
 ; connection. This value must be >= 1s.
 ; healthcheck.torconnection.backoff=30s
 
@@ -1300,7 +1300,7 @@ litecoin.node=ltcd
 
 [bolt]
 
-; If true, prevents the database from syncing its freelist to disk. 
+; If true, prevents the database from syncing its freelist to disk.
 ; db.bolt.nofreelistsync=1
 
 ; Whether the databases used within lnd should automatically be compacted on
@@ -1335,7 +1335,7 @@ litecoin.node=ltcd
 ; cluster.id=example.com
 
 ; The session TTL in seconds after which a new leader is elected if the old
-; leader is shut down, crashed or becomes unreachable. 
+; leader is shut down, crashed or becomes unreachable.
 ; cluster.leader-session-ttl=30
 
 [rpcmiddleware]
@@ -1407,19 +1407,19 @@ litecoin.node=ltcd
 
 [invoices]
 
-; If a hold invoice has accepted htlcs that reach their expiry height and are 
+; If a hold invoice has accepted htlcs that reach their expiry height and are
 ; not timed out, the channel holding the htlc is force closed to resolve the
-; invoice's htlcs. To prevent force closes, lnd automatically cancels these 
+; invoice's htlcs. To prevent force closes, lnd automatically cancels these
 ; invoices before they reach their expiry height.
 ;
-; Hold expiry delta describes the number of blocks before expiry that these 
+; Hold expiry delta describes the number of blocks before expiry that these
 ; invoices should be canceled. Setting this value to 0 will ensure that hold
 ; invoices can be settled right up until their expiry height, but will result
 ; in the channel they are on being force closed if they are not resolved before
 ; expiry.
-; 
-; Lnd goes to chain before the expiry for a htlc is reached so that there is 
-; time to resolve it on chain. This value needs to be greater than the 
+;
+; Lnd goes to chain before the expiry for a htlc is reached so that there is
+; time to resolve it on chain. This value needs to be greater than the
 ; DefaultIncomingBroadcastDelta set by lnd, otherwise the channel will be force
 ; closed anyway. A warning will be logged on startup if this value is not large
 ; enough to prevent force closes.
@@ -1429,7 +1429,7 @@ litecoin.node=ltcd
 
 [routing]
 
-; DEPRECATED: This is now turned on by default for Neutrino (use 
+; DEPRECATED: This is now turned on by default for Neutrino (use
 ; neutrino.validatechannels=true to turn off) and shouldn't be used for any
 ; other backend!
 ; routing.assumechanvalid=true


### PR DESCRIPTION
This PR fixes whitespace in `sample-lnd.conf` in two ways:
- removes dangling spaces at end of the lines `s/ *$//`
- adds extra space after `^;` where needed (once instance)
