### PR TITLE
build: use the new merge_group selector for the merge queue

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,6 +7,9 @@ on:
   pull_request:
     branches:
       - "*"
+  merge_queue:
+    branches:
+      - "master"
 
 concurrency:
   # Cancel any previous workflows if they are from a PR or push.


### PR DESCRIPTION
In this commit, we activate the merge queue by using the new merge_group selector. Without this, the CI won't report back the progress of a CI run to the merge queue, so things won't get auto merged.