### PR TITLE
github: fix merge group directive

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,7 +7,7 @@ on:
   pull_request:
     branches:
       - "*"
-  merge_queue:
+  merge_group:
     branches:
       - "master"
 


### PR DESCRIPTION
Oops, I should have taken a look at the Taro PR, apparently the setting for the merge queue is called `merge_group` and not `merge_queue`.