### PR TITLE
Man pages

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -307,6 +307,16 @@ clean-mobile:
 	$(RM) -r mobile/build
 	$(RM) mobile/*_generated.go
 
+docs:
+	@$(call print, "Generating man pages documents.")
+	if [ -f ./lnd-debug ] && [ -f ./lncli-debug ]; then \
+	./lnd-debug --manpage; \
+	./lncli-debug generatemanpage; \
+	elif [ -f ./lnd ] && [ -f ./lncli ]; then \
+	./lnd --manpage; \
+	./lncli generatemanpage; \
+	fi
+
 .PHONY: all \
 	btcd \
 	default \
@@ -334,4 +344,5 @@ clean-mobile:
 	ios \
 	android \
 	mobile \
-	clean
+	clean \
+	docs

--- a/cmd/lncli/commands.go
+++ b/cmd/lncli/commands.go
@@ -1323,6 +1323,30 @@ func channelBalance(ctx *cli.Context) error {
 	return nil
 }
 
+var generateManPageCommand = cli.Command{
+	Name:   "generatemanpage",
+	Usage:  "Generates a man page for lncli.",
+	Hidden: true,
+	Action: actionDecorator(generateManPage),
+}
+
+func generateManPage(ctx *cli.Context) error {
+	docs, manErr := ctx.App.ToMan()
+        if manErr != nil {
+		return manErr
+        }
+
+	writeErr := ioutil.WriteFile(
+		"lncli.1",
+		[]byte(docs),
+		0644,
+	)
+	if writeErr != nil {
+		return writeErr
+	}
+	return nil
+}
+
 var getInfoCommand = cli.Command{
 	Name:   "getinfo",
 	Usage:  "Returns basic information related to the active daemon.",

--- a/cmd/lncli/main.go
+++ b/cmd/lncli/main.go
@@ -488,6 +488,7 @@ func main() {
 		subscribeCustomCommand,
 		fishCompletionCommand,
 		listAliasesCommand,
+		generateManPageCommand,
 	}
 
 	// Add any extra commands determined by build flags.

--- a/config.go
+++ b/config.go
@@ -5,6 +5,7 @@
 package lnd
 
 import (
+	"bytes"
 	"encoding/hex"
 	"errors"
 	"fmt"
@@ -258,6 +259,7 @@ var (
 //nolint:lll
 type Config struct {
 	ShowVersion bool `short:"V" long:"version" description:"Display version information and exit"`
+	GenerateManPage bool `long:"manpage" description:"Generates a man page as lnd.1 file for lnd and exits"`
 
 	LndDir       string `long:"lnddir" description:"The base directory that contains lnd's data, logs, configuration file, etc."`
 	ConfigFile   string `short:"C" long:"configfile" description:"Path to configuration file"`
@@ -683,6 +685,17 @@ func LoadConfig(interceptor signal.Interceptor) (*Config, error) {
 	if preCfg.ShowVersion {
 		fmt.Println(appName, "version", build.Version(),
 			"commit="+build.Commit)
+		os.Exit(0)
+	}
+
+	if preCfg.GenerateManPage {
+		fileParser := flags.NewParser(&preCfg, flags.Default)
+		var buf bytes.Buffer
+		fileParser.WriteManPage(&buf)
+		err := ioutil.WriteFile("lnd.1", buf.Bytes(), 0644)
+		if err != nil {
+			return nil, err
+		}
 		os.Exit(0)
 	}
 


### PR DESCRIPTION
Paired with @lightningorb

## Change Description
This commits aim to generate man pages docs of lnd and lncli using formatting tools from already used packages.

To do this we:
1. add a flag on lnd that given that generates documentation and exits
2. add a hidden Command to lncli that generates documentation
3. add a makefile command to generate both docs depending on the installation / building

Haven't checked tests in these files.

closes #5605

## Steps to Test
```bash
make build
make docs
```
or 
```bash
make build
./lncli-debug generatemanpage
./lnd-debug --manpage
```

## Pull Request Checklist
### Testing
- [ ] Your PR passes all CI checks.
- [ ] Tests covering the positive and negative (error paths) are included.
- [ ] Bug fixes contain tests triggering the bug to prevent regressions.

### Code Style and Documentation
- [ ] The change obeys the [Code Documentation and Commenting](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#CodeDocumentation) guidelines, and lines wrap at 80.
- [ ] Commits follow the [Ideal Git Commit Structure](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#IdealGitCommitStructure).
- [ ] Any new logging statements use an appropriate subsystem and logging level.
- [ ]  [There is a change description in the release notes](https://github.com/lightningnetwork/lnd/tree/master/docs/release-notes), or `[skip ci]` in the commit message for small changes.

📝 Please see our  [Contribution Guidelines](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md) for further guidance.