### PR TITLE
docker lnd: add support for custom params RPCHOST and RPCCRTPATH

### DIFF
--- a/docker/lnd/start-lnd.sh
+++ b/docker/lnd/start-lnd.sh
@@ -39,6 +39,8 @@ set_default() {
 }
 
 # Set default variables if needed.
+RPCCRTPATH=$(set_default "$RPCCRTPATH" "/rpc/rpc.cert")
+RPCHOST=$(set_default "$RPCHOST" "blockchain")
 RPCUSER=$(set_default "$RPCUSER" "devuser")
 RPCPASS=$(set_default "$RPCPASS" "devpass")
 DEBUG=$(set_default "$DEBUG" "debug")
@@ -60,8 +62,8 @@ exec lnd \
     "--$CHAIN.active" \
     "--$CHAIN.$NETWORK" \
     "--$CHAIN.node"="$BACKEND" \
-    "--$BACKEND.rpccert"="/rpc/rpc.cert" \
-    "--$BACKEND.rpchost"="blockchain" \
+    "--$BACKEND.rpccert"="$RPCCRTPATH" \
+    "--$BACKEND.rpchost"="$RPCHOST" \
     "--$BACKEND.rpcuser"="$RPCUSER" \
     "--$BACKEND.rpcpass"="$RPCPASS" \
     "--rpclisten=$HOSTNAME:10009" \

--- a/docs/release-notes/release-notes-0.16.0.md
+++ b/docs/release-notes/release-notes-0.16.0.md
@@ -455,6 +455,10 @@ in the lnwire package](https://github.com/lightningnetwork/lnd/pull/7303)
   issue where [it cannot fetch
   commits](https://github.com/lightningnetwork/lnd/pull/7374).
 
+* Add support for [custom RPCHOST and 
+  RPCCRTPATH](https://github.com/lightningnetwork/lnd/pull/7429) to the 
+  `lnd` Docker image main script (`/start-lnd.sh`)
+
 ### Integration test
 
 * The `lntest` has been


### PR DESCRIPTION
## Change Description
In this commit we add support for two more custom parameters in the main entrypoint for the `lnd` Docker image script (`start-lnd.sh`)

The two parameters are:
* RPCHOST    to set a custom endpoint for the RPC server
* RPCCRTPATH to set a custom location for the certificate used when
  communicating with the RPC server

## Steps to Test
Change should be 100% backward compatible, but it's as easy as creating a new deployment and set the two new variables via environment variables or leave them empty for default values.

## Pull Request Checklist
### Testing
- [ ] Your PR passes all CI checks.
- [ ] Tests covering the positive and negative (error paths) are included.
- [ ] Bug fixes contain tests triggering the bug to prevent regressions.

### Code Style and Documentation
- [ ] The change obeys the [Code Documentation and Commenting](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#CodeDocumentation) guidelines, and lines wrap at 80.
- [ ] Commits follow the [Ideal Git Commit Structure](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#IdealGitCommitStructure).
- [ ] Any new logging statements use an appropriate subsystem and logging level.
- [ ]  [There is a change description in the release notes](https://github.com/lightningnetwork/lnd/tree/master/docs/release-notes), or `[skip ci]` in the commit message for small changes.

📝 Please see our  [Contribution Guidelines](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md) for further guidance.