### PR TITLE
lnwallet: remove from reservationIDs

### DIFF
--- a/lnwallet/wallet.go
+++ b/lnwallet/wallet.go
@@ -2072,6 +2072,7 @@ func (l *LightningWallet) handleSingleFunderSigs(req *addSingleFunderSigsMsg) {
 
 	l.limboMtx.Lock()
 	delete(l.fundingLimbo, req.pendingFundingID)
+	delete(l.reservationIDs, pendingReservation.pendingChanID)
 	l.limboMtx.Unlock()
 
 	l.intentMtx.Lock()


### PR DESCRIPTION
It's not removed for the responder of the funding flow, but it is initialized for the responder of the funding flow