### PR TITLE
refactor(lncli): print message if backup verified

### DIFF
--- a/cmd/lncli/commands.go
+++ b/cmd/lncli/commands.go
@@ -2446,8 +2446,13 @@ func verifyChanBackup(ctx *cli.Context) error {
 	if err != nil {
 		return err
 	}
+	
+	if resp.String() == "" {
+		fmt.Println("Backup successfully verified")
+	} else {
+		printRespJSON(resp)
+	}
 
-	printRespJSON(resp)
 	return nil
 }
 


### PR DESCRIPTION
Instead of returning an empty json response we check if the response from VerifyChanBackup actually contains a message. If not, we can assume the backup was successfully verified and inform the user.

Fixes #7440

## Steps to Test
Create a backup and attempt to verify it.