### PR TITLE
docs: add notes on contents of Postgres DB as Key-Value store to Postgres.md

### DIFF
--- a/docs/postgres.md
+++ b/docs/postgres.md
@@ -45,3 +45,23 @@ might be slow for unexpected reasons.
 ## Important note about replication
 
 In case a replication architecture is planned, streaming replication should be avoided, as the master does not verify the replica is indeed identical, but it will only forward the edits queue, and let the slave catch up autonomously; synchronous mode, albeit slower, is paramount for `lnd` data integrity across the copies, as it will finalize writes only after the slave confirmed successful replication.
+
+## What is in the database?
+
+At present, the Postgres Database functions as a Key-Value Store, much as Bolt DB does. Some values are TLV-encoded while others are not. More schema will be introduced over time. At present the schema for each table/relation is simply: `key`, `value`, `parent_id`, `id`, `sequence`.
+
+List of tables/relations:
+
+```
+              List of relations
+ Schema |       Name       | Type  |  Owner   
+--------+------------------+-------+----------
+ public | channeldb_kv     | table | lndadmin
+ public | decayedlogdb_kv  | table | lndadmin
+ public | macaroondb_kv    | table | lndadmin
+ public | towerclientdb_kv | table | lndadmin
+ public | towerserverdb_kv | table | lndadmin
+ public | walletdb_kv      | table | lndadmin
+```
+
+Notably, Invoice DB is maintained separately alongside the LND node.

--- a/docs/release-notes/release-notes-0.16.0.md
+++ b/docs/release-notes/release-notes-0.16.0.md
@@ -469,6 +469,10 @@ in the lnwire package](https://github.com/lightningnetwork/lnd/pull/7303)
   [`tools`](https://github.com/lightningnetwork/lnd/pull/7254) and golangci
   issue where [it cannot fetch
   commits](https://github.com/lightningnetwork/lnd/pull/7374).
+  
+* [Update Postgres.md](https://github.com/lightningnetwork/lnd/pull/7442) 
+  to clarify how the database is currently used as a Key-Value store, but
+  in the future will have new schema introduced.
 
 ### Integration test
 
@@ -489,6 +493,7 @@ refactor the itest for code health and maintenance.
 
 # Contributors (Alphabetical Order)
 
+* Adam Anderson
 * Alejandro Pedraza
 * Alyssa Hertig
 * Andras Banki-Horvath


### PR DESCRIPTION
## Change Description
Adding notes on how Postgres DB is currently used as a Key-Value store, and which tables are included.

Addresses Issue #6619 - "Missing documentation for postgresql database structure"

## Steps to Test
Key/Value pairs are not all TLV-encoded. Schema/structure is unclear (outside of K/V column names). However, some Key Names and Values are possible to decode into human-readable strings. For example: I used Python + psycopg2 + text processing to decode some of these, such as Node names (see comment on Gist): https://gist.github.com/84adam/d85f5f40e8821925585f263f68b655eb

SQL statements do not reveal any consistent encoding or structure:

```
select * from channeldb_kv limit 5;
                  key                   | value | parent_id | id | sequence 
----------------------------------------+-------+-----------+----+----------
 \x6f70656e2d6368616e2d6275636b6574     |       |           |  1 |         
 \x636c6f7365642d6368616e2d6275636b6574 |       |           |  2 |         
 \x636972637569742d6677642d6c6f67       |       |           |  3 |         
 \x6677642d7061636b61676573             |       |           |  4 |         
 \x696e766f69636573                     |       |           |  5 |         
```

```
select * from walletdb_kv limit 5;
        key         | value | parent_id | id | sequence 
--------------------+-------+-----------+----+----------
 \x77616464726d6772 |       |           |  1 |         
 \x7774786d6772     |       |           |  2 |         
 \x6d61696e         |       |         1 |  3 |         
 \x73796e63         |       |         1 |  4 |         
 \x73636f7065       |       |         1 |  5 | 
```

This documentation update attempts to make clear that users cannot expect consistency for now in issuing SQL queries to their Postgres databases, and points out where more documentation will be required once additional schema is introduced into these tables.