### PR TITLE
disable lookup when not opted-in and add itest for `LookupHtlc`

### DIFF
--- a/itest/list_on_test.go
+++ b/itest/list_on_test.go
@@ -511,4 +511,8 @@ var allTestCases = []*lntest.TestCase{
 		Name:     "async bidirectional payments",
 		TestFunc: testBidirectionalAsyncPayments,
 	},
+	{
+		Name:     "lookup htlc",
+		TestFunc: testLookupHTLC,
+	},
 }

--- a/itest/lnd_htlc_test.go
+++ b/itest/lnd_htlc_test.go
@@ -1,0 +1,71 @@
+package itest
+
+import (
+	"github.com/btcsuite/btcd/btcutil"
+	"github.com/lightningnetwork/lnd/lnrpc"
+	"github.com/lightningnetwork/lnd/lntest"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// testLookupHTLC checks that `LookupHtlc` returns the correct HTLC
+// information.
+func testLookupHTLC(ht *lntest.HarnessTest) {
+	const chanAmt = btcutil.Amount(1000000)
+
+	alice := ht.Alice
+	carol := ht.NewNode("Carol", []string{
+		"--store-final-htlc-resolutions",
+	})
+	ht.EnsureConnected(alice, carol)
+
+	// Open a channel between Alice and Carol.
+	cp := ht.OpenChannel(
+		alice, carol, lntest.OpenChannelParams{Amt: chanAmt},
+	)
+
+	// Channel should be ready for payments.
+	const payAmt = 100
+
+	// Create an invoice.
+	invoice := &lnrpc.Invoice{
+		Memo:      "alice to carol htlc lookup",
+		RPreimage: ht.Random32Bytes(),
+		Value:     payAmt,
+	}
+
+	// Carol adds the invoice to her database.
+	resp := carol.RPC.AddInvoice(invoice)
+
+	// Subscribe the invoice.
+	stream := carol.RPC.SubscribeSingleInvoice(resp.RHash)
+
+	// Alice pays Carol's invoice.
+	ht.CompletePaymentRequests(alice, []string{resp.PaymentRequest})
+
+	// Carol waits until the invoice is settled.
+	ht.AssertInvoiceState(stream, lnrpc.Invoice_SETTLED)
+
+	// Get the channel using the assert function.
+	//
+	// TODO(yy): make `ht.OpenChannel` return lnrpc.Channel instead of
+	// lnrpc.ChannelPoint.
+	channel := ht.AssertChannelExists(carol, cp)
+
+	// Lookup the HTLC and assert the htlc is settled offchain.
+	req := &lnrpc.LookupHtlcRequest{
+		ChanId:    channel.ChanId,
+		HtlcIndex: 0,
+	}
+
+	// Check that Alice will get an error from LookupHtlc.
+	err := alice.RPC.LookupHtlcAssertErr(req)
+	gErr := status.Convert(err)
+	require.Equal(ht, codes.Unavailable, gErr.Code())
+
+	// Check that Carol can get the final htlc info.
+	finalHTLC := carol.RPC.LookupHtlc(req)
+	require.True(ht, finalHTLC.Settled, "htlc should be settled")
+	require.True(ht, finalHTLC.Offchain, "htlc should be Offchain")
+}

--- a/lnrpc/lightning.pb.go
+++ b/lnrpc/lightning.pb.go
@@ -1355,7 +1355,9 @@ type LookupHtlcResponse struct {
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	Settled  bool `protobuf:"varint,1,opt,name=settled,proto3" json:"settled,omitempty"`
+	// Settled is true is the htlc was settled. If false, the htlc was failed.
+	Settled bool `protobuf:"varint,1,opt,name=settled,proto3" json:"settled,omitempty"`
+	// Offchain indicates whether the htlc was resolved off-chain or on-chain.
 	Offchain bool `protobuf:"varint,2,opt,name=offchain,proto3" json:"offchain,omitempty"`
 }
 

--- a/lnrpc/lightning.proto
+++ b/lnrpc/lightning.proto
@@ -582,6 +582,10 @@ service Lightning {
     */
     rpc ListAliases (ListAliasesRequest) returns (ListAliasesResponse);
 
+    /*
+    LookupHtlc retrieves a final htlc resolution from the database. If the htlc
+    has no final resolution yet, a NotFound grpc status code is returned.
+    */
     rpc LookupHtlc (LookupHtlcRequest) returns (LookupHtlcResponse);
 }
 
@@ -592,8 +596,10 @@ message LookupHtlcRequest {
 }
 
 message LookupHtlcResponse {
+    // Settled is true is the htlc was settled. If false, the htlc was failed.
     bool settled = 1;
 
+    // Offchain indicates whether the htlc was resolved off-chain or on-chain.
     bool offchain = 2;
 }
 

--- a/lnrpc/lightning.swagger.json
+++ b/lnrpc/lightning.swagger.json
@@ -1603,6 +1603,7 @@
     },
     "/v1/htlc/{chan_id}/{htlc_index}": {
       "get": {
+        "summary": "LookupHtlc retrieves a final htlc resolution from the database. If the htlc\nhas no final resolution yet, a NotFound grpc status code is returned.",
         "operationId": "Lightning_LookupHtlc",
         "responses": {
           "200": {
@@ -5440,10 +5441,12 @@
       "type": "object",
       "properties": {
         "settled": {
-          "type": "boolean"
+          "type": "boolean",
+          "description": "Settled is true is the htlc was settled. If false, the htlc was failed."
         },
         "offchain": {
-          "type": "boolean"
+          "type": "boolean",
+          "description": "Offchain indicates whether the htlc was resolved off-chain or on-chain."
         }
       }
     },

--- a/lnrpc/lightning_grpc.pb.go
+++ b/lnrpc/lightning_grpc.pb.go
@@ -402,6 +402,8 @@ type LightningClient interface {
 	// their confirmed SCID (if it exists) and/or the base SCID (in the case of
 	// zero conf).
 	ListAliases(ctx context.Context, in *ListAliasesRequest, opts ...grpc.CallOption) (*ListAliasesResponse, error)
+	// LookupHtlc retrieves a final htlc resolution from the database. If the htlc
+	// has no final resolution yet, a NotFound grpc status code is returned.
 	LookupHtlc(ctx context.Context, in *LookupHtlcRequest, opts ...grpc.CallOption) (*LookupHtlcResponse, error)
 }
 
@@ -1701,6 +1703,8 @@ type LightningServer interface {
 	// their confirmed SCID (if it exists) and/or the base SCID (in the case of
 	// zero conf).
 	ListAliases(context.Context, *ListAliasesRequest) (*ListAliasesResponse, error)
+	// LookupHtlc retrieves a final htlc resolution from the database. If the htlc
+	// has no final resolution yet, a NotFound grpc status code is returned.
 	LookupHtlc(context.Context, *LookupHtlcRequest) (*LookupHtlcResponse, error)
 	mustEmbedUnimplementedLightningServer()
 }

--- a/lntest/harness.go
+++ b/lntest/harness.go
@@ -412,6 +412,10 @@ func (h *HarnessTest) shutdownNodes(skipStandby bool) {
 			return h.manager.shutdownNode(node)
 		}, DefaultTimeout)
 
+		if err == nil {
+			continue
+		}
+
 		// Instead of returning the error, we will log it instead. This
 		// is needed so other nodes can continue their shutdown
 		// processes.

--- a/lntest/rpc/lnd.go
+++ b/lntest/rpc/lnd.go
@@ -696,3 +696,29 @@ func (h *HarnessRPC) GetChanInfo(
 
 	return resp
 }
+
+// LookupHtlc makes a RPC call to the node's LookupHtlc and returns the
+// response.
+func (h *HarnessRPC) LookupHtlc(
+	req *lnrpc.LookupHtlcRequest) *lnrpc.LookupHtlcResponse {
+
+	ctxt, cancel := context.WithTimeout(h.runCtx, DefaultTimeout)
+	defer cancel()
+
+	resp, err := h.LN.LookupHtlc(ctxt, req)
+	h.NoError(err, "LookupHtlc")
+
+	return resp
+}
+
+// LookupHtlcAssertErr makes a RPC call to the node's LookupHtlc and asserts
+// an RPC error is returned.
+func (h *HarnessRPC) LookupHtlcAssertErr(req *lnrpc.LookupHtlcRequest) error {
+	ctxt, cancel := context.WithTimeout(h.runCtx, DefaultTimeout)
+	defer cancel()
+
+	_, err := h.LN.LookupHtlc(ctxt, req)
+	require.Error(h, err, "expected an error")
+
+	return err
+}

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -3942,6 +3942,11 @@ func (r *rpcServer) ClosedChannels(ctx context.Context,
 func (r *rpcServer) LookupHtlc(ctx context.Context,
 	in *lnrpc.LookupHtlcRequest) (*lnrpc.LookupHtlcResponse, error) {
 
+	if !r.cfg.StoreFinalHtlcResolutions {
+		return nil, status.Error(codes.Unavailable, "cannot lookup "+
+			"with flag --store-final-htlc-resolutions=false")
+	}
+
 	chanID := lnwire.NewShortChanIDFromInt(in.ChanId)
 
 	info, err := r.server.chanStateDB.LookupFinalHtlc(chanID, in.HtlcIndex)


### PR DESCRIPTION
This is a follow-up on #7341. The change is trivial - that we disable `LookupHtlc` when the flag is not set, and added an itest case.