### PR TITLE
remote signer: allow stateless init of watch-only node

### DIFF
--- a/docs/release-notes/release-notes-0.16.0.md
+++ b/docs/release-notes/release-notes-0.16.0.md
@@ -354,6 +354,9 @@ in the lnwire package](https://github.com/lightningnetwork/lnd/pull/7303)
 
 * [Sign/Verify messages and signatures for single
   addresses](https://github.com/lightningnetwork/lnd/pull/7231).
+  
+* [Allow `--stateless_init` mode to be used for watch-only
+  wallets](https://github.com/lightningnetwork/lnd/pull/7462).
 
 ## Code Health
 


### PR DESCRIPTION
Fixes https://github.com/lightningnetwork/lnd/issues/7457 by adding the `--stateless_init` flag to the `createwatchonly` command.

@saubyk Would be great to get this in for 0.16.0. I would classify it as a bug fix, as the flag was simply forgotten when the `createwatchonly` command was created.