### PR TITLE
rpc: assign peer alias lookup error string

### DIFF
--- a/docs/release-notes/release-notes-0.16.0.md
+++ b/docs/release-notes/release-notes-0.16.0.md
@@ -149,6 +149,10 @@ of order is also [fixed](https://github.com/lightningnetwork/lnd/pull/7264).
   parameter is enabled by default but can be disabled with a new flag
   `--skip_peer_alias_lookup`.
 
+* Assign potential peer alias lookup errors in the [`ListChannels` and
+  `ForwardingHistory`rpcs](https://github.com/lightningnetwork/lnd/pull/7471) to
+  the rpc response.
+
 ## Wallet
 
 * [Allows Taproot public keys and tap scripts to be imported as watch-only

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -4176,8 +4176,8 @@ func createRPCOpenChannel(r *rpcServer, dbChannel *channeldb.OpenChannel,
 	if peerAliasLookup {
 		peerAlias, err := r.server.graphDB.LookupAlias(nodePub)
 		if err != nil {
-			return nil, fmt.Errorf("unable to lookup peer "+
-				"alias: %w", err)
+			peerAlias = fmt.Sprintf("unable to lookup "+
+				"peer alias: %v", err)
 		}
 		channel.PeerAlias = peerAlias
 	}
@@ -7018,16 +7018,15 @@ func (r *rpcServer) ForwardingHistory(ctx context.Context,
 		if req.PeerAliasLookup {
 			aliasIn, err := getRemoteAlias(event.IncomingChanID)
 			if err != nil {
-				return nil, fmt.Errorf("unable to lookup peer "+
+				aliasIn = fmt.Sprintf("unable to lookup peer "+
+					"alias: %v", err)
+			}
+			aliasOut, err := getRemoteAlias(event.OutgoingChanID)
+			if err != nil {
+				aliasOut = fmt.Sprintf("unable to lookup peer"+
 					"alias: %v", err)
 			}
 			resp.ForwardingEvents[i].PeerAliasIn = aliasIn
-
-			aliasOut, err := getRemoteAlias(event.OutgoingChanID)
-			if err != nil {
-				return nil, fmt.Errorf("unable to lookup peer "+
-					"alias: %v", err)
-			}
 			resp.ForwardingEvents[i].PeerAliasOut = aliasOut
 		}
 	}


### PR DESCRIPTION
This PR removes the error handling of the peer alias lookups in the RPCs `ListChannels` and `ForwardingHistory` in order to run the commands uninterrupted in case the peer alias can't be found for a channel or a forwarding event. See discussion https://github.com/lightningnetwork/lnd/pull/7322#issuecomment-1450328599

Cc @saubyk @guggero 