### PR TITLE
multi: fix wait.NoError and sub-test names

### DIFF
--- a/chainntnfs/bitcoindnotify/bitcoind_test.go
+++ b/chainntnfs/bitcoindnotify/bitcoind_test.go
@@ -105,12 +105,12 @@ func syncNotifierWithMiner(t *testing.T, notifier *BitcoindNotifier,
 // TestHistoricalConfDetailsTxIndex ensures that we correctly retrieve
 // historical confirmation details using the backend node's txindex.
 func TestHistoricalConfDetailsTxIndex(t *testing.T) {
-	t.Run("txindex enabled", func(st *testing.T) {
+	t.Run("rpc polling enabled", func(st *testing.T) {
 		st.Parallel()
 		testHistoricalConfDetailsTxIndex(st, true)
 	})
 
-	t.Run("txindex disabled", func(st *testing.T) {
+	t.Run("rpc polling disabled", func(st *testing.T) {
 		st.Parallel()
 		testHistoricalConfDetailsTxIndex(st, false)
 	})
@@ -200,12 +200,12 @@ func testHistoricalConfDetailsTxIndex(t *testing.T, rpcPolling bool) {
 // historical confirmation details using the set of fallback methods when the
 // backend node's txindex is disabled.
 func TestHistoricalConfDetailsNoTxIndex(t *testing.T) {
-	t.Run("txindex enabled", func(st *testing.T) {
+	t.Run("rpc polling enabled", func(st *testing.T) {
 		st.Parallel()
 		testHistoricalConfDetailsNoTxIndex(st, true)
 	})
 
-	t.Run("txindex disabled", func(st *testing.T) {
+	t.Run("rpc polling disabled", func(st *testing.T) {
 		st.Parallel()
 		testHistoricalConfDetailsNoTxIndex(st, false)
 	})

--- a/lntest/wait/wait.go
+++ b/lntest/wait/wait.go
@@ -58,6 +58,13 @@ func NoError(f func() error, timeout time.Duration) error {
 	// If f() doesn't succeed within the timeout, return the last
 	// encountered error.
 	if err := Predicate(pred, timeout); err != nil {
+		// Handle the case where the passed in method, f, hangs for the
+		// full timeout
+		if predErr == nil {
+			return fmt.Errorf("method did not return within the " +
+				"timeout")
+		}
+
 		return predErr
 	}
 


### PR DESCRIPTION
This PR makes a few miscellaneous changes to some test related code:

1. Fixes a bug in the wait.NoError function. If the predicate
function, f, passed to the NoError function would hang for the full
timeout, then the `predErr` would remain nil and so a nil error would be
returned from the function. This PR handles that case.

2. Rename some sub tests to correctly reflect what they are testing

3. Small fixes to the `NewBitcoindBackend` test util func
