### PR TITLE
lnrpc: update docs for invoice amt_paid

### DIFF
--- a/lnrpc/invoicesrpc/invoices.swagger.json
+++ b/lnrpc/invoicesrpc/invoices.swagger.json
@@ -533,12 +533,12 @@
         "amt_paid_sat": {
           "type": "string",
           "format": "int64",
-          "description": "The amount that was accepted for this invoice, in satoshis. This will ONLY\nbe set if this invoice has been settled. We provide this field as if the\ninvoice was created with a zero value, then we need to record what amount\nwas ultimately accepted. Additionally, it's possible that the sender paid\nMORE that was specified in the original invoice. So we'll record that here\nas well.\nNote: Output only, don't specify for creating an invoice."
+          "description": "The amount that was accepted for this invoice, in satoshis. This will ONLY\nbe set if this invoice has been settled or accepted. We provide this field\nas if the invoice was created with a zero value, then we need to record what\namount was ultimately accepted. Additionally, it's possible that the sender\npaid MORE that was specified in the original invoice. So we'll record that\nhere as well.\nNote: Output only, don't specify for creating an invoice."
         },
         "amt_paid_msat": {
           "type": "string",
           "format": "int64",
-          "description": "The amount that was accepted for this invoice, in millisatoshis. This will\nONLY be set if this invoice has been settled. We provide this field as if\nthe invoice was created with a zero value, then we need to record what\namount was ultimately accepted. Additionally, it's possible that the sender\npaid MORE that was specified in the original invoice. So we'll record that\nhere as well.\nNote: Output only, don't specify for creating an invoice."
+          "description": "The amount that was accepted for this invoice, in millisatoshis. This will\nONLY be set if this invoice has been settled or accepted. We provide this\nfield as if the invoice was created with a zero value, then we need to\nrecord what amount was ultimately accepted. Additionally, it's possible that\nthe sender paid MORE that was specified in the original invoice. So we'll\nrecord that here as well.\nNote: Output only, don't specify for creating an invoice."
         },
         "state": {
           "$ref": "#/definitions/InvoiceInvoiceState",

--- a/lnrpc/lightning.pb.go
+++ b/lnrpc/lightning.pb.go
@@ -11696,19 +11696,19 @@ type Invoice struct {
 	// Deprecated: Do not use.
 	AmtPaid int64 `protobuf:"varint,18,opt,name=amt_paid,json=amtPaid,proto3" json:"amt_paid,omitempty"`
 	// The amount that was accepted for this invoice, in satoshis. This will ONLY
-	// be set if this invoice has been settled. We provide this field as if the
-	// invoice was created with a zero value, then we need to record what amount
-	// was ultimately accepted. Additionally, it's possible that the sender paid
-	// MORE that was specified in the original invoice. So we'll record that here
-	// as well.
-	// Note: Output only, don't specify for creating an invoice.
-	AmtPaidSat int64 `protobuf:"varint,19,opt,name=amt_paid_sat,json=amtPaidSat,proto3" json:"amt_paid_sat,omitempty"`
-	// The amount that was accepted for this invoice, in millisatoshis. This will
-	// ONLY be set if this invoice has been settled. We provide this field as if
-	// the invoice was created with a zero value, then we need to record what
+	// be set if this invoice has been settled or accepted. We provide this field
+	// as if the invoice was created with a zero value, then we need to record what
 	// amount was ultimately accepted. Additionally, it's possible that the sender
 	// paid MORE that was specified in the original invoice. So we'll record that
 	// here as well.
+	// Note: Output only, don't specify for creating an invoice.
+	AmtPaidSat int64 `protobuf:"varint,19,opt,name=amt_paid_sat,json=amtPaidSat,proto3" json:"amt_paid_sat,omitempty"`
+	// The amount that was accepted for this invoice, in millisatoshis. This will
+	// ONLY be set if this invoice has been settled or accepted. We provide this
+	// field as if the invoice was created with a zero value, then we need to
+	// record what amount was ultimately accepted. Additionally, it's possible that
+	// the sender paid MORE that was specified in the original invoice. So we'll
+	// record that here as well.
 	// Note: Output only, don't specify for creating an invoice.
 	AmtPaidMsat int64 `protobuf:"varint,20,opt,name=amt_paid_msat,json=amtPaidMsat,proto3" json:"amt_paid_msat,omitempty"`
 	// The state the invoice is in.

--- a/lnrpc/lightning.proto
+++ b/lnrpc/lightning.proto
@@ -3456,22 +3456,22 @@ message Invoice {
 
     /*
     The amount that was accepted for this invoice, in satoshis. This will ONLY
-    be set if this invoice has been settled. We provide this field as if the
-    invoice was created with a zero value, then we need to record what amount
-    was ultimately accepted. Additionally, it's possible that the sender paid
-    MORE that was specified in the original invoice. So we'll record that here
-    as well.
+    be set if this invoice has been settled or accepted. We provide this field
+    as if the invoice was created with a zero value, then we need to record what
+    amount was ultimately accepted. Additionally, it's possible that the sender
+    paid MORE that was specified in the original invoice. So we'll record that
+    here as well.
     Note: Output only, don't specify for creating an invoice.
     */
     int64 amt_paid_sat = 19;
 
     /*
     The amount that was accepted for this invoice, in millisatoshis. This will
-    ONLY be set if this invoice has been settled. We provide this field as if
-    the invoice was created with a zero value, then we need to record what
-    amount was ultimately accepted. Additionally, it's possible that the sender
-    paid MORE that was specified in the original invoice. So we'll record that
-    here as well.
+    ONLY be set if this invoice has been settled or accepted. We provide this
+    field as if the invoice was created with a zero value, then we need to
+    record what amount was ultimately accepted. Additionally, it's possible that
+    the sender paid MORE that was specified in the original invoice. So we'll
+    record that here as well.
     Note: Output only, don't specify for creating an invoice.
     */
     int64 amt_paid_msat = 20;

--- a/lnrpc/lightning.swagger.json
+++ b/lnrpc/lightning.swagger.json
@@ -5116,12 +5116,12 @@
         "amt_paid_sat": {
           "type": "string",
           "format": "int64",
-          "description": "The amount that was accepted for this invoice, in satoshis. This will ONLY\nbe set if this invoice has been settled. We provide this field as if the\ninvoice was created with a zero value, then we need to record what amount\nwas ultimately accepted. Additionally, it's possible that the sender paid\nMORE that was specified in the original invoice. So we'll record that here\nas well.\nNote: Output only, don't specify for creating an invoice."
+          "description": "The amount that was accepted for this invoice, in satoshis. This will ONLY\nbe set if this invoice has been settled or accepted. We provide this field\nas if the invoice was created with a zero value, then we need to record what\namount was ultimately accepted. Additionally, it's possible that the sender\npaid MORE that was specified in the original invoice. So we'll record that\nhere as well.\nNote: Output only, don't specify for creating an invoice."
         },
         "amt_paid_msat": {
           "type": "string",
           "format": "int64",
-          "description": "The amount that was accepted for this invoice, in millisatoshis. This will\nONLY be set if this invoice has been settled. We provide this field as if\nthe invoice was created with a zero value, then we need to record what\namount was ultimately accepted. Additionally, it's possible that the sender\npaid MORE that was specified in the original invoice. So we'll record that\nhere as well.\nNote: Output only, don't specify for creating an invoice."
+          "description": "The amount that was accepted for this invoice, in millisatoshis. This will\nONLY be set if this invoice has been settled or accepted. We provide this\nfield as if the invoice was created with a zero value, then we need to\nrecord what amount was ultimately accepted. Additionally, it's possible that\nthe sender paid MORE that was specified in the original invoice. So we'll\nrecord that here as well.\nNote: Output only, don't specify for creating an invoice."
         },
         "state": {
           "$ref": "#/definitions/InvoiceInvoiceState",


### PR DESCRIPTION
This corrects the documentation for the `amt_paid` and `amt_paid_msat` fields on the `Invoice` message to indicate that the fields will be set if the state of the invoice is either accepted or settled, not only settled. This reflects the actual behavior of lnd, as demonstrated in the below `lncli` output:

```
"amt_paid": "10000",
"amt_paid_sat": "10",
"amt_paid_msat": "10000",
"state": "ACCEPTED",
```