### PR TITLE
Return FEE_INSUFFICIENT before checking balance for incoming low-fee HTLCs

### DIFF
--- a/docs/release-notes/release-notes-0.16.1.md
+++ b/docs/release-notes/release-notes-0.16.1.md
@@ -5,3 +5,13 @@
 - The `lncli wallet psbt fund` command now allows users to specify the
   [`--min_confs` flag](https://github.com/lightningnetwork/lnd/pull/7510).
 
+## Misc
+
+* [Return `FEE_INSUFFICIENT` before checking balance for incoming low-fee
+  HTLCs.](https://github.com/lightningnetwork/lnd/pull/7490).
+
+# Contributors (Alphabetical Order)
+
+* Oliver Gugger
+* Tommy Volk
+* Yong Yu

--- a/htlcswitch/link_test.go
+++ b/htlcswitch/link_test.go
@@ -5643,6 +5643,19 @@ func TestCheckHtlcForward(t *testing.T) {
 		}
 	})
 
+	// Test that insufficient fee error takes preference over insufficient
+	// channel balance.
+	t.Run("insufficient fee error preference", func(t *testing.T) {
+		t.Parallel()
+
+		result := link.CheckHtlcForward(
+			hash, 100005, 100000, 200,
+			150, 0, lnwire.ShortChannelID{},
+		)
+		_, ok := result.WireMessage().(*lnwire.FailFeeInsufficient)
+		require.True(t, ok, "expected FailFeeInsufficient failure code")
+	})
+
 	t.Run("expiry too soon", func(t *testing.T) {
 		result := link.CheckHtlcForward(hash, 1500, 1000,
 			200, 150, 190, lnwire.ShortChannelID{})

--- a/htlcswitch/switch_test.go
+++ b/htlcswitch/switch_test.go
@@ -5339,6 +5339,7 @@ func testSwitchHandlePacketForward(t *testing.T, zeroConf, private,
 	ogPacket := &htlcPacket{
 		incomingChanID: bobLink.ShortChanID(),
 		incomingHTLCID: 0,
+		incomingAmount: 1000,
 		obfuscator:     NewMockObfuscator(),
 		htlc: &lnwire.UpdateAddHTLC{
 			PaymentHash: rhash,


### PR DESCRIPTION
Replaces #6417 and fixes #5721.

The comments from the original PR have been addressed.