### PR TITLE
Add trace logs for `discovery` to catch test flakes

### DIFF
--- a/discovery/gossiper.go
+++ b/discovery/gossiper.go
@@ -1293,7 +1293,8 @@ func (d *AuthenticatedGossiper) sendRemoteBatch(annBatch []msgWithSenders) {
 
 	// We'll first attempt to filter out this new message for all peers
 	// that have active gossip syncers active.
-	for _, syncer := range syncerPeers {
+	for pub, syncer := range syncerPeers {
+		log.Tracef("Sending messages batch to GossipSyncer(%x)", pub)
 		syncer.FilterGossipMsgs(annBatch...)
 	}
 

--- a/discovery/syncer.go
+++ b/discovery/syncer.go
@@ -1251,6 +1251,8 @@ func (g *GossipSyncer) FilterGossipMsgs(msgs ...msgWithSenders) {
 	// If the peer doesn't have an update horizon set, then we won't send
 	// it any new update messages.
 	if g.remoteUpdateHorizon == nil {
+		log.Tracef("GossipSyncer(%x): skipped due to nil "+
+			"remoteUpdateHorizon", g.cfg.peerPub[:])
 		return
 	}
 

--- a/lntest/node/config.go
+++ b/lntest/node/config.go
@@ -207,7 +207,7 @@ func (cfg *BaseNodeConfig) GenArgs() []string {
 	nodeArgs := []string{
 		"--bitcoin.active",
 		"--nobootstrap",
-		"--debuglevel=debug",
+		"--debuglevel=debug,DISC=trace",
 		"--bitcoin.defaultchanconfs=1",
 		"--accept-keysend",
 		"--keep-failed-payment-attempts",

--- a/server.go
+++ b/server.go
@@ -3202,7 +3202,7 @@ func (s *server) BroadcastMessage(skips map[route.Vertex]struct{},
 	for pubStr, sPeer := range s.peersByPub {
 		if skips != nil {
 			if _, ok := skips[sPeer.PubKey()]; ok {
-				srvrLog.Debugf("Skipping %x in broadcast with "+
+				srvrLog.Tracef("Skipping %x in broadcast with "+
 					"pubStr=%x", sPeer.PubKey(), pubStr)
 				continue
 			}


### PR DESCRIPTION
This PR adds more logs the `discovery` and uses `trace` for `DISC` in itest - we will keep it there for a while until all gossip related flakes have been fixed.