### PR TITLE
github: run fuzz tests with unit tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -167,6 +167,15 @@ jobs:
       - name: git checkout
         uses: actions/checkout@v3
 
+      - name: git checkout fuzzing seeds
+        uses: actions/checkout@v3
+        with:
+          repository: lightninglabs/lnd-fuzz
+          path: lnd-fuzz
+
+      - name: rsync fuzzing seeds
+        run: rsync -a --ignore-existing lnd-fuzz/ ./
+
       - name: setup go ${{ env.GO_VERSION }}
         uses: ./.github/actions/setup-go
         with:

--- a/docs/release-notes/release-notes-0.17.0.md
+++ b/docs/release-notes/release-notes-0.17.0.md
@@ -67,6 +67,9 @@ unlock or create.
 
 ## Testing
 
+* [Started](https://github.com/lightningnetwork/lnd/pull/7494) running fuzz
+  tests in CI.
+
 * [Added fuzz tests](https://github.com/lightningnetwork/lnd/pull/7649) for
   signature parsing and conversion.
 


### PR DESCRIPTION
Downloads and extracts the fuzz test seed corpora into the LND tree so that "make unit" automatically runs the fuzz tests on the seeds.

The PR currently uses my own [repository](https://github.com/morehouse/lnd-fuzz-seed-corpus) to host the seeds, since one doesn't exist under https://github.com/lightningnetwork yet.  @Crypt-iQ: Can you set up an official repo for this?

I verified this works by modifying `FuzzAcceptChannel` to fail on certain seed inputs and checking that the fuzz test failure showed up in unit tests in CI.

Updates https://github.com/lightningnetwork/lnd/issues/7452.