### PR TITLE
Makefile: add testing_flags to coverage test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -190,7 +190,7 @@ unit-debug: $(BTCD_BIN)
 
 unit-cover: $(GOACC_BIN)
 	@$(call print, "Running unit coverage tests.")
-	$(GOACC_BIN) $(COVER_PKG) -- -tags="$(DEV_TAGS) $(LOG_TAGS)"
+	$(GOACC)
 
 unit-race:
 	@$(call print, "Running unit race tests.")

--- a/make/testing_flags.mk
+++ b/make/testing_flags.mk
@@ -116,3 +116,6 @@ endif
 
 # Construct the integration test command with the added build flags.
 ITEST_TAGS := $(DEV_TAGS) $(RPC_TAGS) integration $(backend)
+
+# Construct the coverage test command with the added build flags.
+GOACC := $(GOACC_BIN) $(COVER_PKG) -- -tags="$(DEV_TAGS) $(LOG_TAGS)" $(TEST_FLAGS)


### PR DESCRIPTION
Make sure the `TEST_FLAGS` is also used in coverage test, e.g., timeout.