### PR TITLE
lncli: allow specifying `--min_confs` in `wallet psbt fund` to select unconfirmed inputs

### DIFF
--- a/cmd/lncli/walletrpc_active.go
+++ b/cmd/lncli/walletrpc_active.go
@@ -660,6 +660,13 @@ var fundPsbtCommand = cli.Command{
 				"always use the coin selection key scope to " +
 				"generate the change address",
 		},
+		cli.Uint64Flag{
+			Name: "min_confs",
+			Usage: "(optional) the minimum number of " +
+				"confirmations each input used for the PSBT " +
+				"transaction must satisfy",
+			Value: defaultUtxoMinConf,
+		},
 	},
 	Action: actionDecorator(fundPsbt),
 }
@@ -673,8 +680,11 @@ func fundPsbt(ctx *cli.Context) error {
 		return cli.ShowCommandHelp(ctx, "fund")
 	}
 
+	minConfs := int32(ctx.Uint64("min_confs"))
 	req := &walletrpc.FundPsbtRequest{
-		Account: ctx.String("account"),
+		Account:          ctx.String("account"),
+		MinConfs:         minConfs,
+		SpendUnconfirmed: minConfs == 0,
 	}
 
 	// Parse template flags.

--- a/docs/release-notes/release-notes-0.16.1.md
+++ b/docs/release-notes/release-notes-0.16.1.md
@@ -1,0 +1,7 @@
+# Release Notes
+
+## `lncli`
+
+- The `lncli wallet psbt fund` command now allows users to specify the
+  [`--min_confs` flag](https://github.com/lightningnetwork/lnd/pull/7510).
+


### PR DESCRIPTION
## Change Description

The RPC has received the `MinConfs` and `SpendUnconfirmed` fields a while ago, we just never added them to `lncli`.
This PR adds a new flag `--min_confs` with a default value of 1 (which corresponds to the current fallback value) that can be overwritten to 0 if unconfirmed inputs should be used.
