### PR TITLE
wallet: improve logging around transaction broadcast failures

### DIFF
--- a/docs/release-notes/release-notes-0.16.1.md
+++ b/docs/release-notes/release-notes-0.16.1.md
@@ -1,5 +1,11 @@
 # Release Notes
 
+## Wallet
+
+- The logging around transaction broadcast failures [has been improved by always
+  logging the causing error and the raw transaction as
+  hex](https://github.com/lightningnetwork/lnd/pull/7513).
+
 ## `lncli`
 
 * The `lncli wallet psbt fund` command now allows users to specify the


### PR DESCRIPTION
Related to https://github.com/lightningnetwork/lnd/issues/7505.

~Depends on https://github.com/btcsuite/btcwallet/pull/851.~

The logging around transaction broadcast failures has been improved by always logging the causing error and the raw transaction as hex.