### PR TITLE
itest+rpcserver: fix itest flake in `3rd_party_anchor_spend`

### DIFF
--- a/docs/release-notes/release-notes-0.16.1.md
+++ b/docs/release-notes/release-notes-0.16.1.md
@@ -10,6 +10,12 @@
 * [Return `FEE_INSUFFICIENT` before checking balance for incoming low-fee
   HTLCs.](https://github.com/lightningnetwork/lnd/pull/7490).
 
+## RPC
+
+- A [debug log](https://github.com/lightningnetwork/lnd/pull/7514) has been
+  added to `lnrpc` so the node operator can know whether a certain request has
+  happened or not.
+
 # Contributors (Alphabetical Order)
 
 * Oliver Gugger

--- a/itest/lnd_onchain_test.go
+++ b/itest/lnd_onchain_test.go
@@ -430,6 +430,15 @@ func testAnchorThirdPartySpend(ht *lntest.HarnessTest) {
 	commitTxn := ht.Miner.GetRawTransaction(forceCloseTxID)
 	ht.Miner.MineBlockWithTxes([]*btcutil.Tx{commitTxn})
 
+	// Assert that the channel is now in PendingForceClose.
+	//
+	// NOTE: We must do this check to make sure `lnd` node has updated its
+	// internal state regarding the closing transaction, otherwise the
+	// `SendCoins` below might fail since it involves a reserved value
+	// check, which requires a certain amount of coins to be reserved based
+	// on the number of anchor channels.
+	ht.AssertChannelPendingForceClose(alice, aliceChanPoint1)
+
 	// With the anchor output located, and the main commitment mined we'll
 	// instruct the wallet to send all coins in the wallet to a new address
 	// (to the miner), including unconfirmed change.

--- a/rpcperms/interceptor.go
+++ b/rpcperms/interceptor.go
@@ -772,6 +772,8 @@ func (r *InterceptorChain) rpcStateUnaryServerInterceptor() grpc.UnaryServerInte
 	return func(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo,
 		handler grpc.UnaryHandler) (interface{}, error) {
 
+		r.rpcsLog.Debugf("[%v] requested", info.FullMethod)
+
 		if err := r.checkRPCState(info.Server); err != nil {
 			return nil, err
 		}
@@ -785,6 +787,8 @@ func (r *InterceptorChain) rpcStateUnaryServerInterceptor() grpc.UnaryServerInte
 func (r *InterceptorChain) rpcStateStreamServerInterceptor() grpc.StreamServerInterceptor {
 	return func(srv interface{}, ss grpc.ServerStream,
 		info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
+
+		r.rpcsLog.Debugf("[%v] requested", info.FullMethod)
 
 		if err := r.checkRPCState(srv); err != nil {
 			return err

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -2941,8 +2941,6 @@ func (r *rpcServer) GetRecoveryInfo(ctx context.Context,
 func (r *rpcServer) ListPeers(ctx context.Context,
 	in *lnrpc.ListPeersRequest) (*lnrpc.ListPeersResponse, error) {
 
-	rpcsLog.Tracef("[listpeers] request")
-
 	serverPeers := r.server.Peers()
 	resp := &lnrpc.ListPeersResponse{
 		Peers: make([]*lnrpc.Peer, 0, len(serverPeers)),
@@ -3700,8 +3698,6 @@ func (r *rpcServer) fetchWaitingCloseChannels() (waitingCloseChannels,
 func (r *rpcServer) PendingChannels(ctx context.Context,
 	in *lnrpc.PendingChannelsRequest) (
 	*lnrpc.PendingChannelsResponse, error) {
-
-	rpcsLog.Debugf("[pendingchannels]")
 
 	resp := &lnrpc.PendingChannelsResponse{}
 
@@ -6409,8 +6405,6 @@ func marshallTopologyChange(topChange *routing.TopologyChange) *lnrpc.GraphTopol
 func (r *rpcServer) ListPayments(ctx context.Context,
 	req *lnrpc.ListPaymentsRequest) (*lnrpc.ListPaymentsResponse, error) {
 
-	rpcsLog.Debugf("[ListPayments]")
-
 	// If both dates are set, we check that the start date is less than the
 	// end date, otherwise we'll get an empty result.
 	if req.CreationDateStart != 0 && req.CreationDateEnd != 0 {
@@ -6626,10 +6620,6 @@ const feeBase float64 = 1000000
 // schedule enforced by the node globally for each channel.
 func (r *rpcServer) FeeReport(ctx context.Context,
 	_ *lnrpc.FeeReportRequest) (*lnrpc.FeeReportResponse, error) {
-
-	// TODO(roasbeef): use UnaryInterceptor to add automated logging
-
-	rpcsLog.Debugf("[feereport]")
 
 	channelGraph := r.server.graphDB
 	selfNode, err := channelGraph.SourceNode()
@@ -6893,8 +6883,6 @@ func (r *rpcServer) UpdateChannelPolicy(ctx context.Context,
 func (r *rpcServer) ForwardingHistory(ctx context.Context,
 	req *lnrpc.ForwardingHistoryRequest) (*lnrpc.ForwardingHistoryResponse,
 	error) {
-
-	rpcsLog.Debugf("[forwardinghistory]")
 
 	// Before we perform the queries below, we'll instruct the switch to
 	// flush any pending events to disk. This ensure we get a complete
@@ -7426,8 +7414,6 @@ func (r *rpcServer) ChannelAcceptor(stream lnrpc.Lightning_ChannelAcceptorServer
 func (r *rpcServer) BakeMacaroon(ctx context.Context,
 	req *lnrpc.BakeMacaroonRequest) (*lnrpc.BakeMacaroonResponse, error) {
 
-	rpcsLog.Debugf("[bakemacaroon]")
-
 	// If the --no-macaroons flag is used to start lnd, the macaroon service
 	// is not initialized. Therefore we can't bake new macaroons.
 	if r.macService == nil {
@@ -7514,8 +7500,6 @@ func (r *rpcServer) ListMacaroonIDs(ctx context.Context,
 	req *lnrpc.ListMacaroonIDsRequest) (
 	*lnrpc.ListMacaroonIDsResponse, error) {
 
-	rpcsLog.Debugf("[listmacaroonids]")
-
 	// If the --no-macaroons flag is used to start lnd, the macaroon service
 	// is not initialized. Therefore we can't show any IDs.
 	if r.macService == nil {
@@ -7546,8 +7530,6 @@ func (r *rpcServer) DeleteMacaroonID(ctx context.Context,
 	req *lnrpc.DeleteMacaroonIDRequest) (
 	*lnrpc.DeleteMacaroonIDResponse, error) {
 
-	rpcsLog.Debugf("[deletemacaroonid]")
-
 	// If the --no-macaroons flag is used to start lnd, the macaroon service
 	// is not initialized. Therefore we can't delete any IDs.
 	if r.macService == nil {
@@ -7576,8 +7558,6 @@ func (r *rpcServer) DeleteMacaroonID(ctx context.Context,
 func (r *rpcServer) ListPermissions(_ context.Context,
 	_ *lnrpc.ListPermissionsRequest) (*lnrpc.ListPermissionsResponse,
 	error) {
-
-	rpcsLog.Debugf("[listpermissions]")
 
 	permissionMap := make(map[string]*lnrpc.MacaroonPermissionList)
 	for uri, perms := range r.interceptorChain.Permissions() {


### PR DESCRIPTION
Found a new flake from [this build](https://github.com/lightningnetwork/lnd/actions/runs/4422237723/jobs/7753851726):

```
harness_rpc.go:97: 
        	Error Trace:	/home/runner/work/lnd/lnd/itest/harness_rpc.go:97
        	            				/home/runner/work/lnd/lnd/itest/lnd.go:372
        	            				/home/runner/work/lnd/lnd/itest/lnd_onchain_test.go:443
        	            				/home/runner/work/lnd/lnd/itest/harness.go:286
        	            				/home/runner/work/lnd/lnd/itest/lnd_test.go:136
        	Error:      	Received unexpected error:
        	            	rpc error: code = Unknown desc = reserved wallet balance invalidated: transaction would leave insufficient funds for fee bumping anchor channel closings (see debug log for details)
        	Messages:   	Alice: failed to call SendCoins
    harness.go:342: finished test: 3rd_party_anchor_spend, start height=506, end height=514, mined blocks=8
    harness.go:348: test failed, skipped cleanup
```

This PR fixes it and adds more debug logs to the rpcserver.