### PR TITLE
Fix race between `channel_ready` and link update

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -214,10 +214,17 @@ issues:
         - gosec
         - funlen
         - revive
+        # Allow duplications in tests so it's easier to follow a single unit
+        # test.
+        - dupl
 
     - path: mock*
       linters:
         - revive
+        # forcetypeassert is skipped for the mock because the test would fail
+        # if the returned value doesn't match the type, so there's no need to
+        # check the convert.
+        - forcetypeassert
 
     - path: test*
       linters:

--- a/config.go
+++ b/config.go
@@ -490,6 +490,10 @@ type Config struct {
 
 	// Estimator is used to estimate routing probabilities.
 	Estimator routing.Estimator
+
+	// Dev specifies configs used for integration tests, which is always
+	// empty if not built with `integration` flag.
+	Dev *lncfg.DevConfig `group:"dev" namespace:"dev"`
 }
 
 // GRPCConfig holds the configuration options for the gRPC server.

--- a/discovery/mock_test.go
+++ b/discovery/mock_test.go
@@ -63,6 +63,12 @@ func (p *mockPeer) RemoteFeatures() *lnwire.FeatureVector {
 	return nil
 }
 
+func (p *mockPeer) AddPendingChannel(_ lnwire.ChannelID,
+	_ <-chan struct{}) error {
+
+	return nil
+}
+
 // mockMessageStore is an in-memory implementation of the MessageStore interface
 // used for the gossiper's unit tests.
 type mockMessageStore struct {

--- a/discovery/mock_test.go
+++ b/discovery/mock_test.go
@@ -69,6 +69,10 @@ func (p *mockPeer) AddPendingChannel(_ lnwire.ChannelID,
 	return nil
 }
 
+func (p *mockPeer) RemovePendingChannel(_ lnwire.ChannelID) error {
+	return nil
+}
+
 // mockMessageStore is an in-memory implementation of the MessageStore interface
 // used for the gossiper's unit tests.
 type mockMessageStore struct {

--- a/docs/release-notes/release-notes-0.17.0.md
+++ b/docs/release-notes/release-notes-0.17.0.md
@@ -216,6 +216,9 @@ compare the default values between lnd and sample-lnd.conf.
   creation](https://github.com/lightningnetwork/lnd/pull/7856) that can arise
   under rare scenarios.
 
+- A race condition found between `channel_ready` and link updates is [now
+  fixed](https://github.com/lightningnetwork/lnd/pull/7518).
+
 ### Tooling and documentation
 
 * Add support for [custom `RPCHOST` and

--- a/funding/manager_test.go
+++ b/funding/manager_test.go
@@ -321,6 +321,12 @@ func (n *testNode) AddNewChannel(channel *channeldb.OpenChannel,
 	}
 }
 
+func (n *testNode) AddPendingChannel(_ lnwire.ChannelID,
+	quit <-chan struct{}) error {
+
+	return nil
+}
+
 func createTestWallet(cdb *channeldb.ChannelStateDB, netParams *chaincfg.Params,
 	notifier chainntnfs.ChainNotifier, wc lnwallet.WalletController,
 	signer input.Signer, keyRing keychain.SecretKeyRing,

--- a/funding/manager_test.go
+++ b/funding/manager_test.go
@@ -327,6 +327,10 @@ func (n *testNode) AddPendingChannel(_ lnwire.ChannelID,
 	return nil
 }
 
+func (n *testNode) RemovePendingChannel(_ lnwire.ChannelID) error {
+	return nil
+}
+
 func createTestWallet(cdb *channeldb.ChannelStateDB, netParams *chaincfg.Params,
 	notifier chainntnfs.ChainNotifier, wc lnwallet.WalletController,
 	signer input.Signer, keyRing keychain.SecretKeyRing,

--- a/htlcswitch/link_test.go
+++ b/htlcswitch/link_test.go
@@ -1888,6 +1888,12 @@ func (m *mockPeer) RemoteFeatures() *lnwire.FeatureVector {
 	return nil
 }
 
+func (m *mockPeer) AddPendingChannel(_ lnwire.ChannelID,
+	_ <-chan struct{}) error {
+
+	return nil
+}
+
 func newSingleLinkTestHarness(t *testing.T, chanAmt, chanReserve btcutil.Amount) (
 	ChannelLink, *lnwallet.LightningChannel, chan time.Time, func() error,
 	func() (*lnwallet.LightningChannel, error), error) {

--- a/htlcswitch/link_test.go
+++ b/htlcswitch/link_test.go
@@ -1894,6 +1894,10 @@ func (m *mockPeer) AddPendingChannel(_ lnwire.ChannelID,
 	return nil
 }
 
+func (m *mockPeer) RemovePendingChannel(_ lnwire.ChannelID) error {
+	return nil
+}
+
 func newSingleLinkTestHarness(t *testing.T, chanAmt, chanReserve btcutil.Amount) (
 	ChannelLink, *lnwallet.LightningChannel, chan time.Time, func() error,
 	func() (*lnwallet.LightningChannel, error), error) {

--- a/htlcswitch/mock.go
+++ b/htlcswitch/mock.go
@@ -678,6 +678,10 @@ func (s *mockServer) AddPendingChannel(_ lnwire.ChannelID,
 	return nil
 }
 
+func (s *mockServer) RemovePendingChannel(_ lnwire.ChannelID) error {
+	return nil
+}
+
 func (s *mockServer) WipeChannel(*wire.OutPoint) {}
 
 func (s *mockServer) LocalFeatures() *lnwire.FeatureVector {

--- a/htlcswitch/mock.go
+++ b/htlcswitch/mock.go
@@ -672,6 +672,12 @@ func (s *mockServer) AddNewChannel(channel *channeldb.OpenChannel,
 	return nil
 }
 
+func (s *mockServer) AddPendingChannel(_ lnwire.ChannelID,
+	cancel <-chan struct{}) error {
+
+	return nil
+}
+
 func (s *mockServer) WipeChannel(*wire.OutPoint) {}
 
 func (s *mockServer) LocalFeatures() *lnwire.FeatureVector {

--- a/itest/list_on_test.go
+++ b/itest/list_on_test.go
@@ -546,4 +546,8 @@ var allTestCases = []*lntest.TestCase{
 		Name:     "utxo selection funding",
 		TestFunc: testChannelUtxoSelection,
 	},
+	{
+		Name:     "update pending open channels",
+		TestFunc: testUpdateOnPendingOpenChannels,
+	},
 }

--- a/lncfg/dev.go
+++ b/lncfg/dev.go
@@ -1,0 +1,23 @@
+//go:build !integration
+
+package lncfg
+
+import "time"
+
+// IsDevBuild returns a bool to indicate whether we are in a development
+// environment.
+//
+// NOTE: always return false here.
+func IsDevBuild() bool {
+	return false
+}
+
+// DevConfig specifies development configs used for production. This struct
+// should always remain empty.
+type DevConfig struct{}
+
+// ChannelReadyWait returns the config value, which is always 0 for production
+// build.
+func (d *DevConfig) ChannelReadyWait() time.Duration {
+	return 0
+}

--- a/lncfg/dev_integration.go
+++ b/lncfg/dev_integration.go
@@ -1,0 +1,26 @@
+//go:build integration
+
+package lncfg
+
+import "time"
+
+// IsDevBuild returns a bool to indicate whether we are in a development
+// environment.
+//
+// NOTE: always return true here.
+func IsDevBuild() bool {
+	return true
+}
+
+// DevConfig specifies configs used for integration tests. These configs can
+// only be used in tests and must NOT be exported for production usage.
+//
+//nolint:lll
+type DevConfig struct {
+	ProcessChannelReadyWait time.Duration `long:"processchannelreadywait" description:"Time to sleep before processing remote node's channel_ready message."`
+}
+
+// ChannelReadyWait returns the config value `ProcessChannelReadyWait`.
+func (d *DevConfig) ChannelReadyWait() time.Duration {
+	return d.ProcessChannelReadyWait
+}

--- a/lnpeer/mock_peer.go
+++ b/lnpeer/mock_peer.go
@@ -1,0 +1,82 @@
+package lnpeer
+
+import (
+	"net"
+
+	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/btcsuite/btcd/wire"
+	"github.com/lightningnetwork/lnd/channeldb"
+	"github.com/lightningnetwork/lnd/lnwire"
+	"github.com/stretchr/testify/mock"
+)
+
+// MockPeer implements the `lnpeer.Peer` interface.
+type MockPeer struct {
+	mock.Mock
+}
+
+// Compile time assertion that MockPeer implements lnpeer.Peer.
+var _ Peer = (*MockPeer)(nil)
+
+func (m *MockPeer) SendMessage(sync bool, msgs ...lnwire.Message) error {
+	args := m.Called(sync, msgs)
+	return args.Error(0)
+}
+
+func (m *MockPeer) SendMessageLazy(sync bool, msgs ...lnwire.Message) error {
+	args := m.Called(sync, msgs)
+	return args.Error(0)
+}
+
+func (m *MockPeer) AddNewChannel(channel *channeldb.OpenChannel,
+	cancel <-chan struct{}) error {
+
+	args := m.Called(channel, cancel)
+	return args.Error(0)
+}
+
+func (m *MockPeer) AddPendingChannel(cid lnwire.ChannelID,
+	cancel <-chan struct{}) error {
+
+	args := m.Called(cid, cancel)
+	return args.Error(0)
+}
+
+func (m *MockPeer) RemovePendingChannel(cid lnwire.ChannelID) error {
+	args := m.Called(cid)
+	return args.Error(0)
+}
+
+func (m *MockPeer) WipeChannel(op *wire.OutPoint) {
+	m.Called(op)
+}
+
+func (m *MockPeer) PubKey() [33]byte {
+	args := m.Called()
+	return args.Get(0).([33]byte)
+}
+
+func (m *MockPeer) IdentityKey() *btcec.PublicKey {
+	args := m.Called()
+	return args.Get(0).(*btcec.PublicKey)
+}
+
+func (m *MockPeer) Address() net.Addr {
+	args := m.Called()
+	return args.Get(0).(net.Addr)
+}
+
+func (m *MockPeer) QuitSignal() <-chan struct{} {
+	args := m.Called()
+	return args.Get(0).(<-chan struct{})
+}
+
+func (m *MockPeer) LocalFeatures() *lnwire.FeatureVector {
+	args := m.Called()
+	return args.Get(0).(*lnwire.FeatureVector)
+}
+
+func (m *MockPeer) RemoteFeatures() *lnwire.FeatureVector {
+	args := m.Called()
+	return args.Get(0).(*lnwire.FeatureVector)
+}

--- a/lnpeer/peer.go
+++ b/lnpeer/peer.go
@@ -31,6 +31,9 @@ type Peer interface {
 	// channel should fail to be added if the cancel chan is closed.
 	AddPendingChannel(cid lnwire.ChannelID, cancel <-chan struct{}) error
 
+	// RemovePendingChannel removes a pending open channel ID to the peer.
+	RemovePendingChannel(cid lnwire.ChannelID) error
+
 	// WipeChannel removes the channel uniquely identified by its channel
 	// point from all indexes associated with the peer.
 	WipeChannel(*wire.OutPoint)

--- a/lnpeer/peer.go
+++ b/lnpeer/peer.go
@@ -27,6 +27,10 @@ type Peer interface {
 	// to be added if the cancel channel is closed.
 	AddNewChannel(channel *channeldb.OpenChannel, cancel <-chan struct{}) error
 
+	// AddPendingChannel adds a pending open channel ID to the peer. The
+	// channel should fail to be added if the cancel chan is closed.
+	AddPendingChannel(cid lnwire.ChannelID, cancel <-chan struct{}) error
+
 	// WipeChannel removes the channel uniquely identified by its channel
 	// point from all indexes associated with the peer.
 	WipeChannel(*wire.OutPoint)

--- a/peer/brontide.go
+++ b/peer/brontide.go
@@ -3734,7 +3734,7 @@ func (p *Brontide) attachChannelEventSubscription() error {
 
 // updateNextRevocation updates the existing channel's next revocation if it's
 // nil.
-func (p *Brontide) updateNextRevocation(c *channeldb.OpenChannel) {
+func (p *Brontide) updateNextRevocation(c *channeldb.OpenChannel) error {
 	chanPoint := &c.FundingOutpoint
 	chanID := lnwire.NewChanIDFromOutPoint(chanPoint)
 
@@ -3744,32 +3744,35 @@ func (p *Brontide) updateNextRevocation(c *channeldb.OpenChannel) {
 	// currentChan should exist, but we perform a check anyway to avoid nil
 	// pointer dereference.
 	if !loaded {
-		p.log.Errorf("missing active channel with chanID=%v", chanID)
-		return
+		return fmt.Errorf("missing active channel with chanID=%v",
+			chanID)
 	}
 
 	// currentChan should not be nil, but we perform a check anyway to
 	// avoid nil pointer dereference.
 	if currentChan == nil {
-		p.log.Errorf("found nil active channel with chanID=%v", chanID)
-		return
+		return fmt.Errorf("found nil active channel with chanID=%v",
+			chanID)
 	}
 
 	// If we're being sent a new channel, and our existing channel doesn't
 	// have the next revocation, then we need to update the current
 	// existing channel.
 	if currentChan.RemoteNextRevocation() != nil {
-		return
+		return nil
 	}
 
 	p.log.Infof("Processing retransmitted ChannelReady for "+
 		"ChannelPoint(%v)", chanPoint)
 
 	nextRevoke := c.RemoteNextRevocation
+
 	err := currentChan.InitNextRevocation(nextRevoke)
 	if err != nil {
-		p.log.Errorf("unable to init chan revocation: %v", err)
+		return fmt.Errorf("unable to init next revocation: %w", err)
 	}
+
+	return nil
 }
 
 // addActiveChannel adds a new active channel to the `activeChannels` map. It
@@ -3855,7 +3858,11 @@ func (p *Brontide) handleNewActiveChannel(req *newChannelMsg) {
 
 		// Handle it and close the err chan on the request.
 		close(req.err)
-		p.updateNextRevocation(newChan)
+
+		// Update the next revocation point.
+		if err := p.updateNextRevocation(newChan); err != nil {
+			p.log.Errorf(err.Error())
+		}
 
 		return
 	}

--- a/peer/brontide_test.go
+++ b/peer/brontide_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/lightningnetwork/lnd/contractcourt"
 	"github.com/lightningnetwork/lnd/htlcswitch"
 	"github.com/lightningnetwork/lnd/lntest/mock"
+	"github.com/lightningnetwork/lnd/lnwallet"
 	"github.com/lightningnetwork/lnd/lnwallet/chancloser"
 	"github.com/lightningnetwork/lnd/lnwire"
 	"github.com/lightningnetwork/lnd/pool"
@@ -1171,3 +1172,171 @@ func TestUpdateNextRevocation(t *testing.T) {
 // TODO(yy): add test for `addActiveChannel` and `handleNewActiveChannel` once
 // we have interfaced `lnwallet.LightningChannel` and
 // `*contractcourt.ChainArbitrator`.
+
+// TestHandleNewPendingChannel checks the method `handleNewPendingChannel`
+// behaves as expected.
+func TestHandleNewPendingChannel(t *testing.T) {
+	t.Parallel()
+
+	// Create three channel IDs for testing.
+	chanIDActive := lnwire.ChannelID{0}
+	chanIDNotExist := lnwire.ChannelID{1}
+	chanIDPending := lnwire.ChannelID{2}
+
+	// Create a test brontide.
+	dummyConfig := Config{}
+	peer := NewBrontide(dummyConfig)
+
+	// Create the test state.
+	peer.activeChannels.Store(chanIDActive, &lnwallet.LightningChannel{})
+	peer.activeChannels.Store(chanIDPending, nil)
+
+	// Assert test state, we should have two channels store, one active and
+	// one pending.
+	require.Equal(t, 2, peer.activeChannels.Len())
+
+	testCases := []struct {
+		name   string
+		chanID lnwire.ChannelID
+
+		// expectChanAdded specifies whether this chanID will be added
+		// to the peer's state.
+		expectChanAdded bool
+	}{
+		{
+			name:            "noop on active channel",
+			chanID:          chanIDActive,
+			expectChanAdded: false,
+		},
+		{
+			name:            "noop on pending channel",
+			chanID:          chanIDPending,
+			expectChanAdded: false,
+		},
+		{
+			name:            "new channel should be added",
+			chanID:          chanIDNotExist,
+			expectChanAdded: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+
+		// Create a request for testing.
+		errChan := make(chan error, 1)
+		req := &newChannelMsg{
+			channelID: tc.chanID,
+			err:       errChan,
+		}
+
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			require := require.New(t)
+
+			// Get the number of channels before mutating the
+			// state.
+			numChans := peer.activeChannels.Len()
+
+			// Call the method.
+			peer.handleNewPendingChannel(req)
+
+			// Add one if we expect this channel to be added.
+			if tc.expectChanAdded {
+				numChans++
+			}
+
+			// Assert the number of channels is correct.
+			require.Equal(numChans, peer.activeChannels.Len())
+
+			// Assert the request's error chan is closed.
+			err, ok := <-req.err
+			require.False(ok, "expect err chan to be closed")
+			require.NoError(err, "expect no error")
+		})
+	}
+}
+
+// TestHandleRemovePendingChannel checks the method
+// `handleRemovePendingChannel` behaves as expected.
+func TestHandleRemovePendingChannel(t *testing.T) {
+	t.Parallel()
+
+	// Create three channel IDs for testing.
+	chanIDActive := lnwire.ChannelID{0}
+	chanIDNotExist := lnwire.ChannelID{1}
+	chanIDPending := lnwire.ChannelID{2}
+
+	// Create a test brontide.
+	dummyConfig := Config{}
+	peer := NewBrontide(dummyConfig)
+
+	// Create the test state.
+	peer.activeChannels.Store(chanIDActive, &lnwallet.LightningChannel{})
+	peer.activeChannels.Store(chanIDPending, nil)
+
+	// Assert test state, we should have two channels store, one active and
+	// one pending.
+	require.Equal(t, 2, peer.activeChannels.Len())
+
+	testCases := []struct {
+		name   string
+		chanID lnwire.ChannelID
+
+		// expectDeleted specifies whether this chanID will be removed
+		// from the peer's state.
+		expectDeleted bool
+	}{
+		{
+			name:          "noop on active channel",
+			chanID:        chanIDActive,
+			expectDeleted: false,
+		},
+		{
+			name:          "pending channel should be removed",
+			chanID:        chanIDPending,
+			expectDeleted: true,
+		},
+		{
+			name:          "noop on non-exist channel",
+			chanID:        chanIDNotExist,
+			expectDeleted: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+
+		// Create a request for testing.
+		errChan := make(chan error, 1)
+		req := &newChannelMsg{
+			channelID: tc.chanID,
+			err:       errChan,
+		}
+
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			require := require.New(t)
+
+			// Get the number of channels before mutating the
+			// state.
+			numChans := peer.activeChannels.Len()
+
+			// Call the method.
+			peer.handleRemovePendingChannel(req)
+
+			// Minus one if we expect this channel to be removed.
+			if tc.expectDeleted {
+				numChans--
+			}
+
+			// Assert the number of channels is correct.
+			require.Equal(numChans, peer.activeChannels.Len())
+
+			// Assert the request's error chan is closed.
+			err, ok := <-req.err
+			require.False(ok, "expect err chan to be closed")
+			require.NoError(err, "expect no error")
+		})
+	}
+}

--- a/server.go
+++ b/server.go
@@ -1276,8 +1276,18 @@ func newServer(cfg *Config, listenAddrs []net.Addr,
 		return ourPolicy, err
 	}
 
+	// Get the development config for funding manager. If we are not in
+	// development mode, this would be nil.
+	var devCfg *funding.DevConfig
+	if lncfg.IsDevBuild() {
+		devCfg = &funding.DevConfig{
+			ProcessChannelReadyWait: cfg.Dev.ChannelReadyWait(),
+		}
+	}
+
 	//nolint:lll
 	s.fundingMgr, err = funding.NewFundingManager(funding.Config{
+		Dev:                devCfg,
 		NoWumboChans:       !cfg.ProtocolOptions.Wumbo(),
 		IDKey:              nodeKeyDesc.PubKey,
 		IDKeyLoc:           nodeKeyDesc.KeyLocator,


### PR DESCRIPTION
Depends on 
- #7517 
- https://github.com/lightninglabs/neutrino/pull/279
- #7794 

This PR starts tracking pending open channels in `peer.Brontide`. Suppose a message is received for this pending channel, it will be cached and processed once this channel becomes active.

Fixes #7401