### PR TITLE
itest: assert change output type

### DIFF
--- a/itest/lnd_psbt_test.go
+++ b/itest/lnd_psbt_test.go
@@ -1087,6 +1087,34 @@ func assertPsbtFundSignSpend(ht *lntest.HarnessTest, alice *node.HarnessNode,
 	)
 	require.GreaterOrEqual(ht, fundResp.ChangeOutputIndex, int32(-1))
 
+	// Make sure our change output has all the meta information required for
+	// signing.
+	fundedPacket, err := psbt.NewFromRawBytes(
+		bytes.NewReader(fundResp.FundedPsbt), false,
+	)
+	require.NoError(ht, err)
+
+	pOut := fundedPacket.Outputs[fundResp.ChangeOutputIndex]
+	require.NotEmpty(ht, pOut.Bip32Derivation)
+	derivation := pOut.Bip32Derivation[0]
+	_, err = btcec.ParsePubKey(derivation.PubKey)
+	require.NoError(ht, err)
+	require.Len(ht, derivation.Bip32Path, 5)
+
+	// Ensure we get the change output properly decorated with all the new
+	// Taproot related fields, if it is a Taproot output.
+	if changeType == walletrpc.ChangeAddressType_CHANGE_ADDRESS_TYPE_P2TR {
+		require.NotEmpty(ht, pOut.TaprootBip32Derivation)
+		require.NotEmpty(ht, pOut.TaprootInternalKey)
+
+		trDerivation := pOut.TaprootBip32Derivation[0]
+		require.Equal(
+			ht, trDerivation.XOnlyPubKey, pOut.TaprootInternalKey,
+		)
+		_, err := schnorr.ParsePubKey(pOut.TaprootInternalKey)
+		require.NoError(ht, err)
+	}
+
 	var signedPsbt []byte
 	if useFinalize {
 		finalizeResp := alice.RPC.FinalizePsbt(


### PR DESCRIPTION
Fixes https://github.com/lightningnetwork/lnd/issues/6918.

It turns out that the main body of work for https://github.com/lightningnetwork/lnd/issues/6918 was already done in https://github.com/lightningnetwork/lnd/pull/7348 and https://github.com/lightningnetwork/lnd/pull/7209 (through https://github.com/btcsuite/btcwallet/pull/837).

So all we need to add are integration tests that assert these new assumptions around change outputs.

NOTE: I decided that we shouldn't add a change output type field to `SendCoins`, `SendMany` or `EstimateFee`. If anyone needs more control over creating on-chain transactions, they should use the PSBT APIs which can replace all three of those calls.