### PR TITLE
Fix web fee estimator test flake and increase retry timeout for channel close

### DIFF
--- a/lntest/harness.go
+++ b/lntest/harness.go
@@ -1132,7 +1132,7 @@ func (h *HarnessTest) CloseChannelAssertPending(hn *node.HarnessNode,
 		// active htlcs` or `link failed to shutdown` if we close the
 		// channel. We need to investigate the order of settling the
 		// payments and updating commitments to properly fix it.
-		time.Sleep(2 * time.Second)
+		time.Sleep(5 * time.Second)
 
 		// Give it another chance.
 		stream = hn.RPC.CloseChannel(closeReq)


### PR DESCRIPTION
Two flakes were found in [this build](https://github.com/lightningnetwork/lnd/actions/runs/4482285819/jobs/7880172996?pr=7520),

For the web fee estimator, we need more verbose logs to understand the failure. For the channel close under windows, we just increase the waiting period, which could be removed once the new coop flow is merged.
