### PR TITLE
travis: increase timeout to 120 minutes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,7 @@ jobs:
       name: Bitcoind Integration ARM
       script:
         - bash ./scripts/install_bitcoind.sh
-        - GOMEMLIMIT=500MiB GOARM=7 GOARCH=arm GOOS=linux travis_wait 30 make itest-parallel backend=bitcoind 
+        - GOMEMLIMIT=1024MiB GOARM=7 GOARCH=arm GOOS=linux travis_wait 120 make itest-parallel backend=bitcoind tranches=8
       arch: arm64
 
 after_failure:


### PR DESCRIPTION
Observed on this build: https://app.travis-ci.com/github/lightningnetwork/lnd/builds/261672783
Sounds like Travis is red most of the time because it simply takes longer than 30 minutes to run the build.
