### PR TITLE
Different FeeRates for different Input Types in a Force Close Transaction

### DIFF
--- a/config.go
+++ b/config.go
@@ -690,8 +690,11 @@ func DefaultConfig() Config {
 			Timeout: lncfg.DefaultRemoteSignerRPCTimeout,
 		},
 		Sweeper: &lncfg.Sweeper{
-			BatchWindowDuration: sweep.DefaultBatchWindowDuration,
-			MaxFeeRate:          sweep.DefaultMaxFeeRate,
+			BatchWindowDuration:             sweep.DefaultBatchWindowDuration,
+			MaxFeeRate:                      sweep.DefaultMaxFeeRate,
+			MaxNonTimeSensitiveSweepFeeRate: sweep.DefaultNonTimeSensitiveSweepFeeRate,
+			MaxTimeSensitiveSweepFeeRate:    sweep.DefaultTimeSensitiveSweepFeeRate,
+			MaxAnchorFeerate:                sweep.DefaultMaxAnchorSweepFeeRate,
 		},
 		Htlcswitch: &lncfg.Htlcswitch{
 			MailboxDeliveryTimeout: htlcswitch.DefaultMailboxDeliveryTimeout,

--- a/contractcourt/channel_arbitrator.go
+++ b/contractcourt/channel_arbitrator.go
@@ -1356,14 +1356,18 @@ func (c *ChannelArbitrator) sweepAnchors(anchors *lnwallet.AnchorResolutions,
 		// will only be attempted to sweep when the current fee
 		// estimate for the confirmation target exceeds the commit fee
 		// rate.
+		maxFeeRate := c.cfg.Sweeper.MaxSweepFeeRate(
+			anchorInput.WitnessType(),
+		)
 		_, err = c.cfg.Sweeper.SweepInput(
 			&anchorInput,
 			sweep.Params{
 				Fee: sweep.FeePreference{
 					ConfTarget: deadline,
 				},
-				Force:          force,
-				ExclusiveGroup: &exclusiveGroup,
+				MaxSweepFeeRate: maxFeeRate,
+				Force:           force,
+				ExclusiveGroup:  &exclusiveGroup,
 			},
 		)
 		if err != nil {

--- a/contractcourt/commit_sweep_resolver.go
+++ b/contractcourt/commit_sweep_resolver.go
@@ -352,7 +352,10 @@ func (c *commitSweepResolver) Resolve() (ContractResolver, error) {
 	c.log.Infof("sweeping commit output")
 
 	feePref := sweep.FeePreference{ConfTarget: commitOutputConfTarget}
-	resultChan, err := c.Sweeper.SweepInput(inp, sweep.Params{Fee: feePref})
+	resultChan, err := c.Sweeper.SweepInput(inp, sweep.Params{
+		Fee:             feePref,
+		MaxSweepFeeRate: c.Sweeper.MaxSweepFeeRate(inp.WitnessType()),
+	})
 	if err != nil {
 		c.log.Errorf("unable to sweep input: %v", err)
 

--- a/contractcourt/commit_sweep_resolver_test.go
+++ b/contractcourt/commit_sweep_resolver_test.go
@@ -164,6 +164,24 @@ func (s *mockSweeper) UpdateParams(input wire.OutPoint,
 	return result, nil
 }
 
+func (s *mockSweeper) MaxSweepFeeRate(
+	witnessType input.WitnessType) chainfee.SatPerKWeight {
+
+	var maxFeeRate = sweep.DefaultMaxFeeRate.FeePerKWeight()
+
+	switch witnessType {
+	// For non timesensitive sweeps we cap the maximum feerate.
+	case input.CommitSpendNoDelayTweakless,
+		input.CommitmentNoDelay, input.CommitmentToRemoteConfirmed,
+		input.CommitmentTimeLock, input.HtlcOfferedTimeoutSecondLevel,
+		input.HtlcAcceptedSuccessSecondLevel:
+
+		maxFeeRate = 2500
+	}
+
+	return maxFeeRate
+}
+
 var _ UtxoSweeper = &mockSweeper{}
 
 // TestCommitSweepResolverNoDelay tests resolution of a direct commitment output

--- a/contractcourt/htlc_success_resolver.go
+++ b/contractcourt/htlc_success_resolver.go
@@ -170,7 +170,7 @@ func (h *htlcSuccessResolver) Resolve() (ContractResolver, error) {
 // outpoint of the second-level tx, that we must wait to be spent for the
 // resolver to be fully resolved.
 func (h *htlcSuccessResolver) broadcastSuccessTx() (*wire.OutPoint, error) {
-	// If we have non-nil SignDetails, this means that have a 2nd level
+	// If we have non-nil SignDetails, this means that we have a 2nd level
 	// HTLC transaction that is signed using sighash SINGLE|ANYONECANPAY
 	// (the case for anchor type channels). In this case we can re-sign it
 	// and attach fees at will. We let the sweeper handle this job.  We use
@@ -266,6 +266,9 @@ func (h *htlcSuccessResolver) broadcastReSignedSuccessTx() (
 				Fee: sweep.FeePreference{
 					ConfTarget: secondLevelConfTarget,
 				},
+				MaxSweepFeeRate: h.Sweeper.MaxSweepFeeRate(
+					secondLevelInput.WitnessType(),
+				),
 			},
 		)
 		if err != nil {
@@ -378,6 +381,8 @@ func (h *htlcSuccessResolver) broadcastReSignedSuccessTx() (
 			Fee: sweep.FeePreference{
 				ConfTarget: sweepConfTarget,
 			},
+			MaxSweepFeeRate: h.Sweeper.MaxSweepFeeRate(
+				inp.WitnessType()),
 		},
 	)
 	if err != nil {

--- a/contractcourt/htlc_timeout_resolver.go
+++ b/contractcourt/htlc_timeout_resolver.go
@@ -483,6 +483,7 @@ func (h *htlcTimeoutResolver) sweepSecondLevelTx() error {
 			h.broadcastHeight,
 		))
 	}
+
 	_, err := h.Sweeper.SweepInput(
 		inp,
 		sweep.Params{
@@ -490,6 +491,8 @@ func (h *htlcTimeoutResolver) sweepSecondLevelTx() error {
 				ConfTarget: secondLevelConfTarget,
 			},
 			Force: true,
+			MaxSweepFeeRate: h.Sweeper.MaxSweepFeeRate(
+				inp.WitnessType()),
 		},
 	)
 	if err != nil {
@@ -705,6 +708,8 @@ func (h *htlcTimeoutResolver) handleCommitSpend(
 				Fee: sweep.FeePreference{
 					ConfTarget: sweepConfTarget,
 				},
+				MaxSweepFeeRate: h.Sweeper.MaxSweepFeeRate(
+					inp.WitnessType()),
 			},
 		)
 		if err != nil {
@@ -716,8 +721,8 @@ func (h *htlcTimeoutResolver) handleCommitSpend(
 		claimOutpoint = *op
 		fallthrough
 
-	// Finally, if this was an output on our commitment transaction, we'll
-	// wait for the second-level HTLC output to be spent, and for that
+	// Finally, if this was an HTLC output on our commitment transaction,
+	// we'll wait for the second-level HTLC output to be spent, and for that
 	// transaction itself to confirm.
 	case h.htlcResolution.SignedTimeoutTx != nil:
 		log.Infof("%T(%v): waiting for nursery/sweeper to spend CSV "+

--- a/contractcourt/interfaces.go
+++ b/contractcourt/interfaces.go
@@ -66,6 +66,10 @@ type UtxoSweeper interface {
 	// original sweeping transaction, if any.
 	UpdateParams(input wire.OutPoint, params sweep.ParamsUpdate) (
 		chan sweep.Result, error)
+
+	// MaxSweepFeeRate returns the maximum feerate for a given input witness
+	// type.
+	MaxSweepFeeRate(witnessType input.WitnessType) chainfee.SatPerKWeight
 }
 
 // HtlcNotifier defines the notification functions that contract court requires.

--- a/docs/release-notes/release-notes-0.18.0.md
+++ b/docs/release-notes/release-notes-0.18.0.md
@@ -72,6 +72,9 @@
   where the required flags are tagged with `(blinded paths)`.
 * A new config value,
   [http-header-timeout](https://github.com/lightningnetwork/lnd/pull/7715), is added so users can specify the amount of time the http server will wait for a request to complete before closing the connection. The default value is 5 seconds.
+* [Add new sweeper config
+  setting](https://github.com/lightningnetwork/lnd/pull/7535) to limit FeeRate
+  for non time sensitive sweeps of unilateral channel closures.
 
 * [`routerrpc.usestatusinitiated` is
   introduced](https://github.com/lightningnetwork/lnd/pull/8177) to signal that
@@ -206,3 +209,4 @@
 * Turtle
 * Ononiwu Maureen Chiamaka
 * Yong Yu
+* ziggie

--- a/lncfg/sweeper.go
+++ b/lncfg/sweeper.go
@@ -19,8 +19,11 @@ const (
 
 //nolint:lll
 type Sweeper struct {
-	BatchWindowDuration time.Duration        `long:"batchwindowduration" description:"Duration of the sweep batch window. The sweep is held back during the batch window to allow more inputs to be added and thereby lower the fee per input."`
-	MaxFeeRate          chainfee.SatPerVByte `long:"maxfeerate" description:"Maximum fee rate in sat/vb that the sweeper is allowed to use when sweeping funds. Setting this value too low can result in transactions not being confirmed in time, causing HTLCs to expire hence potentially losing funds."`
+	BatchWindowDuration             time.Duration        `long:"batchwindowduration" description:"Duration of the sweep batch window. The sweep is held back during the batch window to allow more inputs to be added and thereby lower the fee per input."`
+	MaxFeeRate                      chainfee.SatPerVByte `long:"maxfeerate" description:"Maximum fee rate in sat/vb that the sweeper is allowed to use when sweeping funds. Setting this value too low can result in transactions not being confirmed in time, causing HTLCs to expire hence potentially losing funds."`
+	MaxNonTimeSensitiveSweepFeeRate chainfee.SatPerVByte `long:"max-non-time-sensitive-feerate" description:"The maximum fee rate in sat/vbyte that will be used for non time sensitive sweeps of unilateral channel closures."`
+	MaxTimeSensitiveSweepFeeRate    chainfee.SatPerVByte `long:"max-time-sensitive-feerate" description:"The maximum fee rate in sat/vbyte that will be used for time sensitive sweeps of unilateral channel closures."`
+	MaxAnchorFeerate                chainfee.SatPerVByte `long:"max-anchor-feerate" description:"The maximum fee rate in sat/vbyte that will be used to CPFP a commitment tx until unconfirmed."`
 }
 
 // Validate checks the values configured for the sweeper.

--- a/sample-lnd.conf
+++ b/sample-lnd.conf
@@ -1605,6 +1605,27 @@
 ; causing HTLCs to expire hence potentially losing funds.
 ; sweeper.maxfeerate=1000
 
+; The maximum feerate in sat/vbyte that will be used to sweep non time sensitive 
+; outputs into lnd's default wallet. These include all outputs that do not 
+; depend on strict time restrictions where one would run into the risk of 
+; loosing funds. The default confirmation target of those outputs is 6 blocks
+; when the estimation exceeds the limit the feerate is capped at this
+; maximum fee rate.
+; sweeper.max-non-time-sensitive-feerate=10
+
+; The maximum feerate in sat/vbyte that will be used to sweep time sensitive 
+; outputs. These include all outputs that do depend on strict time restrictions
+; (abolute timelocks) where one would run into the risk of loosing funds. 
+; The default confirmation target of those outputs is 6 blocks when the
+; estimation exceeds the limit the feerate is capped at this maximum fee rate.
+; sweeper.max-time-sensitive-feerate=100
+
+; The maximum feerate in sat/vbyte that will be used to CPFP an unconfirmed
+; commitment transaction. This limit referes to the effective fee rate including
+; the parent transaction meaning that the child tx can have a higher fee rate. 
+; sweeper.max-anchor-feerate=100
+
+
 
 [htlcswitch]
 

--- a/server.go
+++ b/server.go
@@ -1058,21 +1058,24 @@ func newServer(cfg *Config, listenAddrs []net.Addr,
 		srvrLog.Errorf("unable to create sweeper store: %v", err)
 		return nil, err
 	}
-
+	//nolint:lll
 	s.sweeper = sweep.New(&sweep.UtxoSweeperConfig{
-		FeeEstimator:         cc.FeeEstimator,
-		DetermineFeePerKw:    sweep.DetermineFeePerKw,
-		GenSweepScript:       newSweepPkScriptGen(cc.Wallet),
-		Signer:               cc.Wallet.Cfg.Signer,
-		Wallet:               newSweeperWallet(cc.Wallet),
-		TickerDuration:       cfg.Sweeper.BatchWindowDuration,
-		Notifier:             cc.ChainNotifier,
-		Store:                sweeperStore,
-		MaxInputsPerTx:       sweep.DefaultMaxInputsPerTx,
-		MaxSweepAttempts:     sweep.DefaultMaxSweepAttempts,
-		NextAttemptDeltaFunc: sweep.DefaultNextAttemptDeltaFunc,
-		MaxFeeRate:           cfg.Sweeper.MaxFeeRate,
-		FeeRateBucketSize:    sweep.DefaultFeeRateBucketSize,
+		FeeEstimator:               cc.FeeEstimator,
+		DetermineFeePerKw:          sweep.DetermineFeePerKw,
+		GenSweepScript:             newSweepPkScriptGen(cc.Wallet),
+		Signer:                     cc.Wallet.Cfg.Signer,
+		Wallet:                     newSweeperWallet(cc.Wallet),
+		TickerDuration:             cfg.Sweeper.BatchWindowDuration,
+		Notifier:                   cc.ChainNotifier,
+		Store:                      sweeperStore,
+		MaxInputsPerTx:             sweep.DefaultMaxInputsPerTx,
+		MaxSweepAttempts:           sweep.DefaultMaxSweepAttempts,
+		NextAttemptDeltaFunc:       sweep.DefaultNextAttemptDeltaFunc,
+		MaxFeeRate:                 cfg.Sweeper.MaxFeeRate,
+		FeeRateBucketSize:          sweep.DefaultFeeRateBucketSize,
+		MaxNonTimeSensitiveFeeRate: cfg.Sweeper.MaxNonTimeSensitiveSweepFeeRate.FeePerKWeight(),
+		MaxTimeSensitiveFeeRate:    cfg.Sweeper.MaxTimeSensitiveSweepFeeRate.FeePerKWeight(),
+		MaxAnchorFeerate:           cfg.Sweeper.MaxAnchorFeerate.FeePerKWeight(),
 	})
 
 	s.utxoNursery = contractcourt.NewUtxoNursery(&contractcourt.NurseryConfig{
@@ -1084,6 +1087,7 @@ func newServer(cfg *Config, listenAddrs []net.Addr,
 		PublishTransaction:  cc.Wallet.PublishTransaction,
 		Store:               utxnStore,
 		SweepInput:          s.sweeper.SweepInput,
+		MaxSweepFeeRate:     s.sweeper.MaxSweepFeeRate,
 	})
 
 	// Construct a closure that wraps the htlcswitch's CloseLink method.

--- a/sweep/defaults.go
+++ b/sweep/defaults.go
@@ -16,4 +16,19 @@ var (
 	// UtxoSweeper. The current value is equivalent to a fee rate of 1,000
 	// sat/vbyte.
 	DefaultMaxFeeRate chainfee.SatPerVByte = 1e3
+	// DefaultNonTimeSensitiveSweepFeeRate specifies the maximum fee rate
+	// (sat/vbyte) which will be used by the sweeper to inputs which are
+	// not time sensitive.
+	DefaultNonTimeSensitiveSweepFeeRate chainfee.SatPerVByte = 10
+
+	// DefaultTimeSensitiveSweepFeeRate specifies the maximum fee rate
+	// (sat/vbyte) which will be used by the sweeper to inputs which are
+	// time sensitive.
+	DefaultTimeSensitiveSweepFeeRate chainfee.SatPerVByte = 100
+
+	// DefaultMaxAnchorSweepFeeRate specifies the maximum fee rate
+	// (sat/vbyte) which will be used by the sweeper to CPFP a commitment
+	// tx which is still unconfirmed. This fee limit refers
+	// to the transaction package (effective fee rate) including the parent.
+	DefaultMaxAnchorSweepFeeRate chainfee.SatPerVByte = 100
 )

--- a/sweep/sweeper_test.go
+++ b/sweep/sweeper_test.go
@@ -2240,7 +2240,8 @@ func TestFeeRateForPreference(t *testing.T) {
 			s.cfg.DetermineFeePerKw = tc.determineFeePerKw
 
 			// Call the function under test.
-			feerate, err := s.feeRateForPreference(tc.feePref)
+			feerate, err := s.feeRateForPreference(tc.feePref,
+				DefaultMaxFeeRate.FeePerKWeight())
 
 			// Assert the expected feerate.
 			require.Equal(t, tc.expectedFeeRate, feerate)


### PR DESCRIPTION
This is far from ready because I did not write any tests, I just want to get early feedback if we wanna go in this direction rather then now spending time writing all the accompanied tests.

This solves #7026


## Change Description
The Basic Idea:

When a channel is unilaterally closed lnd sweeps the different outputs in different stages back to the lnd wallet. This is done because all output are locked to WitnessScripts (P2WSH, or P2WKH in rare cases(to_remote output in a STATIC_REMOTE key channel) and we want to sweep them back to lnd's default wallet. This makes the recover of funds a smooth process because we can just do it by using the seed. If we would not sweep them into the default wallet, we would need to reconstruct the WitnessScript the outputs where locked to which can be cumbersome and definitely need the static_backup_file to get all the necessary information. For HTLCs on our Commitment Transaction they are also kept in so called second-level transactions (Bolt03) for these outputs we cannot recover the outputs without collaboration with our peer, and they are time sensitive in the first place so its a no-brainer to sweep those output of a commitment.

Because of the architecture of the lightning network transaction we can however introduce different feerate levels on different outputs of the commitment transaction. Some of the outputs as already mentioned above are highly time sensitive meaning that we need to sweep them by a specific locktime otherwise we run into the possibility of losing money. Others however are not and it makes sense to give a node runner a fine granular control of this different output sweep fee rates so that everybody can decide by himself how much he wanna pay.
This PR also introduces the ability to limit the fee rate of time sensitive outputs if the users wants to (opinions are welcome here)

In the following I describe the 4 different fee settings of the sweeper config this PR introduces to give everybody a detailed understanding what they are affecting.

`max-anchor-feerate`: This settings relates to the FeeBumping of the Commitment Transaction soley relevant for AnchorType Channels, as the name applies anyways^^. Lnd currently uses the anchor and tries to bump the fee if we have outgoing HTLCs or incoming HTLCs we know the preimage of and the initial Commitment Feerate is too low. Whats important, this setting relates to the effective feerate (taking the commitment tx into account). This Fee Rate is time sensitive so setting this value too low, could lead to your Commitment Tx not confirming in time, getting you into some risk scenarios where you could lose money. Though with this PR it is still possible to bump the fee of the Commitment transaction manually using `lncli bumpfee`. 
(Current Confirmation Target in lnd: 1 block if any timeout passed for relevant HTLCs on the commitment, or 144 blocks)

`max-firstlevel-htlcresolve-feerate`: This setting relates to the firstlevel of sweeps when HTLC outputs are swept. There are some subtle differences here whether the commitment transaction is ours or was broadcasted by the peer. But both of them are time sensitive. We wanna make sure we have a feerate so the Output confirms just in time otherwise we risk losing money (in case the htlc was part of a forward not a payment). So it makes sense to set this fee rate very high or not touch it at all. Though for small htlc amounts it might be not worth it and the node runner wants to take the risk.
(Current Confirmation Target: 6 Blocks)

- Our Commitment Tx is broadcasted: Then this setting will only take effect when the ChannelType is an `Anchor Channel` because only there we can attach an arbitrary amount of fees to the second-level Timeout/Success Tx. In case of a non-anchor channel, fees for the Timeout/Success transaction are the same as for the Commitment Transaction and are negotiated beforehand, we cannot change this feerate when the force close already happended.

- Peer Commitment Tx is broadcasted: In this case the Timeout/Success Output is directly on the Commitment Tx (Bolt03) and we can sweep this transaction attaching an arbitrary feerate. 


`max-secondlevel-htlcresolve-feerate"`: This setting refers to second-level sweep transactions of HTLCs which were on our Commitment Transaction (we force closed the channel) and we had to broadcast the secondlevel timeout/success transaction. This sweep is not time sensitive it sweeps the CSV locked output back to the lnd default wallet. So makes sense to make this fee rate customizable. And Because lnd has the ability to spend 0-confirmation outputs, they are usable as soon as they are swept even at low feerates.
(Current Confimation Target: 6 Blocks)

`max-commitmentresolve-feerate`: This setting relates to the `to_local` output on our commitment transaction or the `to_remote` on the remote commitment transaction . They are not time sensitive but the user might want them to confirm faster because the mostly have a high amount compared to the HTLC amounts. (But one could generalize this setting with the `max-secondlevel-htlcresolve-feerate` which would leave the user with less confusion maybe). 
(Current Confirmation Target: 6 Blocks)


Currently the feerate of the different sweeps are configured with constant confirmation targets, and this PR does not change them but capps them as soon as the bitcoin-core/btcd fee estimate would overshoot this amount. A different solution would be to introduce confirmation targets for all those output types rather than capping the fee rate.

Happy to start a discussion and hear your thoughts :)


## Steps to Test
Steps for reviewers to follow to test the change.

## Pull Request Checklist
### Testing
- [ ] Your PR passes all CI checks.
- [ ] Tests covering the positive and negative (error paths) are included.
- [ ] Bug fixes contain tests triggering the bug to prevent regressions.

### Code Style and Documentation
- [ ] The change obeys the [Code Documentation and Commenting](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#CodeDocumentation) guidelines, and lines wrap at 80.
- [ ] Commits follow the [Ideal Git Commit Structure](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#IdealGitCommitStructure).
- [ ] Any new logging statements use an appropriate subsystem and logging level.
- [ ]  [There is a change description in the release notes](https://github.com/lightningnetwork/lnd/tree/master/docs/release-notes), or `[skip ci]` in the commit message for small changes.

📝 Please see our  [Contribution Guidelines](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md) for further guidance.