### PR TITLE
build: bump version to v0.16.0-rc5

### DIFF
--- a/build/version.go
+++ b/build/version.go
@@ -47,7 +47,7 @@ const (
 
 	// AppPreRelease MUST only contain characters from semanticAlphabet
 	// per the semantic versioning spec.
-	AppPreRelease = "beta.rc3"
+	AppPreRelease = "beta.rc5"
 )
 
 func init() {


### PR DESCRIPTION
Because a tag for RC4 was previously pushed but without bumping the version first, we need to skip RC4 as we can't replace already pushed git tags without causing issues.
