### PR TITLE
lnwire+peer: Add error type for disconnecting on unknown message type

### DIFF
--- a/lnwire/message.go
+++ b/lnwire/message.go
@@ -139,17 +139,32 @@ func (t MessageType) String() string {
 	}
 }
 
-// UnknownMessage is an implementation of the error interface that allows the
+// UnknownOddMessage is an implementation of the error interface that allows the
 // creation of an error in response to an unknown message.
-type UnknownMessage struct {
+type UnknownOddMessage struct {
 	messageType MessageType
 }
 
 // Error returns a human readable string describing the error.
 //
 // This is part of the error interface.
-func (u *UnknownMessage) Error() string {
+func (u *UnknownOddMessage) Error() string {
 	return fmt.Sprintf("unable to parse message of unknown type: %v",
+		u.messageType)
+}
+
+// UnknownEvenMessage is an implementation of the error interface that allows the
+// creation of an error in response to an unknown message, which should
+// also lead to disonnecting from the peer
+type UnknownEvenMessage struct {
+	messageType MessageType
+}
+
+// Error returns a human readable string describing the error.
+//
+// This is part of the error interface.
+func (u *UnknownEvenMessage) Error() string {
+	return fmt.Sprintf("unable to parse message of unknown type: %v, must disconnect",
 		u.messageType)
 }
 
@@ -243,8 +258,15 @@ func makeEmptyMessage(msgType MessageType) (Message, error) {
 		// Note that we do not allow custom message overrides to replace
 		// known message types, only protocol messages that are not yet
 		// known to lnd.
+
+		// In case the unknown message type is even
+		// then disconnect from peer
+		if msgType%2 == 0 && !IsCustomOverride(msgType){
+			return nil, &UnknownEvenMessage{msgType}
+		}
+
 		if msgType < CustomTypeStart && !IsCustomOverride(msgType) {
-			return nil, &UnknownMessage{msgType}
+			return nil, &UnknownOddMessage{msgType}
 		}
 
 		msg = &Custom{

--- a/peer/brontide.go
+++ b/peer/brontide.go
@@ -1485,10 +1485,17 @@ out:
 			// we'll continue processing as normal as this allows
 			// us to introduce new messages in a forwards
 			// compatible manner.
-			case *lnwire.UnknownMessage:
+			case *lnwire.UnknownOddMessage:
 				p.storeError(e)
 				idleTimer.Reset(idleTimeout)
 				continue
+
+			// If this is just a message we don't yet recognize,
+			// that must also make us disconnect, then
+			// disconnect from the peer
+			case *lnwire.UnknownEvenMessage:
+				p.storeError(e)
+				break out
 
 			// If they sent us an address type that we don't yet
 			// know of, then this isn't a wire error, so we'll

--- a/peer/test_utils.go
+++ b/peer/test_utils.go
@@ -493,6 +493,8 @@ type mockMessageConn struct {
 
 	readMessages   chan []byte
 	curReadMessage []byte
+
+	isClosed bool
 }
 
 func newMockConn(t *testing.T, expectedMessages int) *mockMessageConn {
@@ -500,6 +502,7 @@ func newMockConn(t *testing.T, expectedMessages int) *mockMessageConn {
 		t:               t,
 		writtenMessages: make(chan []byte, expectedMessages),
 		readMessages:    make(chan []byte, 1),
+		isClosed:        false,
 	}
 }
 
@@ -555,5 +558,10 @@ func (m *mockMessageConn) RemoteAddr() net.Addr {
 }
 
 func (m *mockMessageConn) LocalAddr() net.Addr {
+	return nil
+}
+
+func (m *mockMessageConn) Close() error {
+	m.isClosed = true
 	return nil
 }


### PR DESCRIPTION
This commit differentiates the handling of unknown even and odd message types in message.go, brontide.go, brontide_test.go and test_utils.go. Unknown odd messages are now represented by the UnknownOddMessage struct, while unknown even messages use the UnknownEvenMessage struct. When an unknown even message is encountered, the peer connection is terminated. Tests for unknown message handling have been added to brontide_test.go.

## Change Description
Fixes https://github.com/lightningnetwork/lnd/issues/7318

This PR is a duplicate of https://github.com/lightningnetwork/lnd/pull/7413 which got closed due to a force push.

## Steps to Test
go test 'github.com/lightningnetwork/lnd/peer'
go test 'github.com/lightningnetwork/lnd/lnwire'

## Pull Request Checklist
### Testing
- [ ] Your PR passes all CI checks.
- [x] Tests covering the positive and negative (error paths) are included.
- [ ] Bug fixes contain tests triggering the bug to prevent regressions.

### Code Style and Documentation
- [ ] The change obeys the [Code Documentation and Commenting](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#CodeDocumentation) guidelines, and lines wrap at 80.
- [ ] Commits follow the [Ideal Git Commit Structure](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#IdealGitCommitStructure).
- [ ] Any new logging statements use an appropriate subsystem and logging level.
- [ ]  [There is a change description in the release notes](https://github.com/lightningnetwork/lnd/tree/master/docs/release-notes), or `[skip ci]` in the commit message for small changes.

📝 Please see our  [Contribution Guidelines](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md) for further guidance.