### PR TITLE
watchtower: let client recover after data loss

### DIFF
--- a/docs/release-notes/release-notes-0.16.1.md
+++ b/docs/release-notes/release-notes-0.16.1.md
@@ -25,6 +25,8 @@
   needed](https://github.com/lightningnetwork/lnd/pull/7405). Also add a new
   `exclude_exhausted_sessions` boolean flag to the relevant lncli wtclient
   commands.
+* [Recover from StateUpdateCodeClientBehind 
+  error](https://github.com/lightningnetwork/lnd/pull/7541) after data loss. 
 
 ## Misc
 

--- a/watchtower/wtclient/client_test.go
+++ b/watchtower/wtclient/client_test.go
@@ -1466,7 +1466,7 @@ var clientTests = []clientTest{
 			h.waitServerUpdates(hints[:numUpdates/2], time.Second)
 
 			// Stop the client, which should have no more backups.
-			h.client.Stop()
+			require.NoError(h.t, h.client.Stop())
 
 			// Record the policy that the first half was stored
 			// under. We'll expect the second half to also be stored
@@ -1527,7 +1527,7 @@ var clientTests = []clientTest{
 
 			// Restart the client, so we can ensure the deduping is
 			// maintained across restarts.
-			h.client.Stop()
+			require.NoError(h.t, h.client.Stop())
 			h.startClient()
 
 			// Try to back up the full range of retributions. Only
@@ -2011,6 +2011,61 @@ var clientTests = []clientTest{
 
 			}, waitTime)
 			require.NoError(h.t, err)
+		},
+	},
+	{
+		// Demonstrate that the client is unable to upload state updates
+		// to a tower if the client deletes its database after already
+		// having created and started to use a session with a tower.
+		// This happens because the session key is generated
+		// deterministically and will only be unique for new sessions
+		// if the same DB is used. The server therefore rejects these
+		// updates with the StateUpdateCodeClientBehind error.
+		name: "demonstrate the StateUpdateCodeClientBehind error",
+		cfg: harnessCfg{
+			localBalance:  localBalance,
+			remoteBalance: remoteBalance,
+			policy: wtpolicy.Policy{
+				TxPolicy:   defaultTxPolicy,
+				MaxUpdates: 5,
+			},
+		},
+		fn: func(h *testHarness) {
+			const (
+				numUpdates = 5
+				chanID     = 0
+			)
+
+			// Generate numUpdates retributions.
+			hints := h.advanceChannelN(chanID, numUpdates)
+
+			// Back half of the states up.
+			h.backupStates(chanID, 0, numUpdates/2, nil)
+
+			// Wait for the updates to be populated in the server's
+			// database.
+			h.waitServerUpdates(hints[:numUpdates/2], waitTime)
+
+			// Now stop the client and reset its database.
+			require.NoError(h.t, h.client.Stop())
+
+			db := wtmock.NewClientDB()
+			h.clientDB = db
+			h.clientCfg.DB = db
+
+			// Restart the client.
+			h.startClient()
+
+			// We need to re-register the channel due to the client
+			// db being reset.
+			h.registerChannel(0)
+
+			// Attempt to back up the remaining tasks.
+			h.backupStates(chanID, numUpdates/2, numUpdates, nil)
+
+			// Show that the server does not get the remaining
+			// updates.
+			h.waitServerUpdates(nil, waitTime)
 		},
 	},
 }

--- a/watchtower/wtclient/client_test.go
+++ b/watchtower/wtclient/client_test.go
@@ -2014,14 +2014,12 @@ var clientTests = []clientTest{
 		},
 	},
 	{
-		// Demonstrate that the client is unable to upload state updates
-		// to a tower if the client deletes its database after already
-		// having created and started to use a session with a tower.
-		// This happens because the session key is generated
-		// deterministically and will only be unique for new sessions
-		// if the same DB is used. The server therefore rejects these
-		// updates with the StateUpdateCodeClientBehind error.
-		name: "demonstrate the StateUpdateCodeClientBehind error",
+		// Demonstrate that the client is unable to recover after
+		// deleting its database by skipping through key indices until
+		// it gets to one that does not result in the
+		// CreateSessionCodeAlreadyExists error code being returned from
+		// the server.
+		name: "continue after client database deletion",
 		cfg: harnessCfg{
 			localBalance:  localBalance,
 			remoteBalance: remoteBalance,
@@ -2063,9 +2061,8 @@ var clientTests = []clientTest{
 			// Attempt to back up the remaining tasks.
 			h.backupStates(chanID, numUpdates/2, numUpdates, nil)
 
-			// Show that the server does not get the remaining
-			// updates.
-			h.waitServerUpdates(nil, waitTime)
+			// Show that the server does get the remaining updates.
+			h.waitServerUpdates(hints[numUpdates/2:], waitTime)
 		},
 	},
 }

--- a/watchtower/wtclient/errors.go
+++ b/watchtower/wtclient/errors.go
@@ -34,4 +34,9 @@ var (
 	// revoked state because the channel had not been previously registered
 	// with the client.
 	ErrUnregisteredChannel = errors.New("channel is not registered")
+
+	// ErrSessionKeyAlreadyUsed indicates that the client attempted to
+	// create a new session with a tower with a session key that has already
+	// been used in the past.
+	ErrSessionKeyAlreadyUsed = errors.New("session key already used")
 )

--- a/watchtower/wtclient/interface.go
+++ b/watchtower/wtclient/interface.go
@@ -49,8 +49,8 @@ type DB interface {
 	// (tower, blob type) pair until CreateClientSession is invoked for that
 	// tower and index, at which point a new index for that tower can be
 	// reserved. Multiple calls to this method before CreateClientSession is
-	// invoked should return the same index.
-	NextSessionKeyIndex(wtdb.TowerID, blob.Type) (uint32, error)
+	// invoked should return the same index unless forceNext is true.
+	NextSessionKeyIndex(wtdb.TowerID, blob.Type, bool) (uint32, error)
 
 	// CreateClientSession saves a newly negotiated client session to the
 	// client's database. This enables the session to be used across

--- a/watchtower/wtclient/session_negotiator.go
+++ b/watchtower/wtclient/session_negotiator.go
@@ -306,7 +306,7 @@ retryWithBackoff:
 		// with this specific tower. If one is already reserved, the
 		// existing index will be returned.
 		keyIndex, err := n.cfg.DB.NextSessionKeyIndex(
-			tower.ID, n.cfg.Policy.BlobType,
+			tower.ID, n.cfg.Policy.BlobType, false,
 		)
 		if err != nil {
 			n.log.Debugf("Unable to reserve session key index "+

--- a/watchtower/wtclient/session_negotiator.go
+++ b/watchtower/wtclient/session_negotiator.go
@@ -1,6 +1,7 @@
 package wtclient
 
 import (
+	"errors"
 	"fmt"
 	"sync"
 	"time"
@@ -272,6 +273,7 @@ retryWithBackoff:
 		}
 	}
 
+tryNextCandidate:
 	for {
 		select {
 		case <-n.quit:
@@ -302,28 +304,39 @@ retryWithBackoff:
 		n.log.Debugf("Attempting session negotiation with tower=%x",
 			towerPub)
 
-		// Before proceeding, we will reserve a session key index to use
-		// with this specific tower. If one is already reserved, the
-		// existing index will be returned.
-		keyIndex, err := n.cfg.DB.NextSessionKeyIndex(
-			tower.ID, n.cfg.Policy.BlobType, false,
-		)
-		if err != nil {
-			n.log.Debugf("Unable to reserve session key index "+
-				"for tower=%x: %v", towerPub, err)
-			continue
-		}
+		var forceNextKey bool
+		for {
+			// Before proceeding, we will reserve a session key
+			// index to use with this specific tower. If one is
+			// already reserved, the existing index will be
+			// returned.
+			keyIndex, err := n.cfg.DB.NextSessionKeyIndex(
+				tower.ID, n.cfg.Policy.BlobType, forceNextKey,
+			)
+			if err != nil {
+				n.log.Debugf("Unable to reserve session key "+
+					"index for tower=%x: %v", towerPub, err)
 
-		// We'll now attempt the CreateSession dance with the tower to
-		// get a new session, trying all addresses if necessary.
-		err = n.createSession(tower, keyIndex)
-		if err != nil {
-			// An unexpected error occurred, updpate our backoff.
+				goto tryNextCandidate
+			}
+
+			// We'll now attempt the CreateSession dance with the
+			// tower to get a new session, trying all addresses if
+			// necessary.
+			err = n.createSession(tower, keyIndex)
+			if err == nil {
+				return
+			} else if errors.Is(err, ErrSessionKeyAlreadyUsed) {
+				forceNextKey = true
+				continue
+			}
+
+			// An unexpected error occurred, update our backoff.
 			updateBackoff()
 
 			n.log.Debugf("Session negotiation with tower=%x "+
-				"failed, trying again -- reason: %v",
-				tower.IdentityKey.SerializeCompressed(), err)
+				"failed, trying again -- reason: %v", towerPub,
+				err)
 
 			goto retryWithBackoff
 		}
@@ -360,7 +373,10 @@ func (n *sessionNegotiator) createSession(tower *Tower, keyIndex uint32) error {
 		err = n.tryAddress(sessionKey, keyIndex, tower, lnAddr)
 		tower.Addresses.ReleaseLock(addr)
 		switch {
-		case err == ErrPermanentTowerFailure:
+		case errors.Is(err, ErrSessionKeyAlreadyUsed):
+			return err
+
+		case errors.Is(err, ErrPermanentTowerFailure):
 			// TODO(conner): report to iterator? can then be reset
 			// with restart
 			fallthrough
@@ -454,12 +470,7 @@ func (n *sessionNegotiator) tryAddress(sessionKey keychain.SingleKeyECDH,
 	}
 
 	switch createSessionReply.Code {
-	case wtwire.CodeOK, wtwire.CreateSessionCodeAlreadyExists:
-
-		// TODO(conner): add last-applied to create session reply to
-		// handle case where we lose state, session already exists, and
-		// we want to possibly resume using the session
-
+	case wtwire.CodeOK:
 		// TODO(conner): validate reward address
 		rewardPkScript := createSessionReply.Data
 
@@ -499,6 +510,16 @@ func (n *sessionNegotiator) tryAddress(sessionKey keychain.SingleKeyECDH,
 		case <-n.quit:
 			return ErrNegotiatorExiting
 		}
+
+	case wtwire.CreateSessionCodeAlreadyExists:
+		// TODO(conner): use the last-applied in the create session
+		//  reply to handle case where we lose state, session already
+		//  exists, and we want to possibly resume using the session.
+		//  NOTE that this should not be done until the server code
+		//  has been adapted to first check that the CreateSession
+		//  request is for the same blob-type as the initial session.
+
+		return ErrSessionKeyAlreadyUsed
 
 	// TODO(conner): handle error codes properly
 	case wtwire.CreateSessionCodeRejectBlobType:


### PR DESCRIPTION
## The Problem

Since the watchtower subserver was added, if ever users have run into issues, 
the common advice has been to delete the `wtclient.db`. This however, leads
to the linked issues. Basically: session IDs are derived deterministically from an 
incrementing DB key. This means that if a client had a session (`A`) with a server
and pushed some updates to the server using session `A`, but then deleted
the `wtclient.db` file, they would then still derive the same ID they used for the 
original session `A`. This means that the client would end up sending a state
update to the server over session `A` with sequence number 1 while the server 
would be expecting a higher sequence number and so would return the 
`StateUpdateCodeClientBehind` error code back to the client. 

## The Solution 

If the client receives the `CreateSessionCodeAlreadyExists` error code from the
server after sending the `CreateSession` message, it will skip forward 1000 key 
indices and attempt session creation again. It will do this until it arrives at a 
session that the server has not yet seen before.

## Other solutions considered: 

If the client is in the situation described above, it would send a `CreateSession` 
message to the server and the server would reply with a `CreateSessionReply` 
with the `CreateSessionCodeAlreadyExists` error code _and_ with the
`LastApplied` sequence number that the server is aware of. The client could start
using this field to set its SeqNum and LastApplied values and then could continue
using the session. This was the original approach taken in this PR but due to the
findings outlined in [this comment](https://github.com/lightningnetwork/lnd/pull/7541#issuecomment-1488128849) this approach was not used.

Fixes #7468
Fixes #6785