### PR TITLE
build: bump to version v0.16.0-beta final

### DIFF
--- a/build/version.go
+++ b/build/version.go
@@ -47,7 +47,7 @@ const (
 
 	// AppPreRelease MUST only contain characters from semanticAlphabet
 	// per the semantic versioning spec.
-	AppPreRelease = "beta.rc5"
+	AppPreRelease = "beta"
 )
 
 func init() {


### PR DESCRIPTION
Bump version definition for final release version of `v0.16.0-beta`.