### PR TITLE
lnrpc: fully dockerize protobuf generation

### DIFF
--- a/lnrpc/gen_protos_docker.sh
+++ b/lnrpc/gen_protos_docker.sh
@@ -5,8 +5,13 @@ set -e
 # Directory of the script file, independent of where it's called from.
 DIR="$(cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd)"
 
-PROTOBUF_VERSION=$(go list -f '{{.Version}}' -m google.golang.org/protobuf)
-GRPC_GATEWAY_VERSION=$(go list -f '{{.Version}}' -m github.com/grpc-ecosystem/grpc-gateway/v2)
+# golang docker image version used in this script.
+GO_IMAGE=golang:1.19.7-alpine
+
+PROTOBUF_VERSION=$(docker run --rm -v $DIR/../:/lnd -w /lnd $GO_IMAGE \
+  go list -f '{{.Version}}' -m google.golang.org/protobuf)
+GRPC_GATEWAY_VERSION=$(docker run --rm -v $DIR/../:/lnd -w /lnd $GO_IMAGE \
+  go list -f '{{.Version}}' -m github.com/grpc-ecosystem/grpc-gateway/v2)
 
 echo "Building protobuf compiler docker image..."
 docker build -t lnd-protobuf-builder \


### PR DESCRIPTION
Remove the need for golang on the host by utilizing golang docker containers to obtain protobuf and grpc gateway versions.

## Change Description
Improve the dockerized protobuf generation by removing the need for golang on the host system. Makes life easier for those of us who prefers to our host systems clean and use vscode devcontainers or docker containers for their development environment.

## Pull Request Checklist
### Testing
- [ ] Your PR passes all CI checks.
- [ ] Tests covering the positive and negative (error paths) are included.
- [ ] Bug fixes contain tests triggering the bug to prevent regressions.

### Code Style and Documentation
- [x] The change obeys the [Code Documentation and Commenting](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#CodeDocumentation) guidelines, and lines wrap at 80.
- [x] Commits follow the [Ideal Git Commit Structure](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#IdealGitCommitStructure).
- [x] Any new logging statements use an appropriate subsystem and logging level.
- [ ]  [There is a change description in the release notes](https://github.com/lightningnetwork/lnd/tree/master/docs/release-notes), or `[skip ci]` in the commit message for small changes.