### PR TITLE
docker+docs: bump btcd version

### DIFF
--- a/docker/btcd/Dockerfile
+++ b/docker/btcd/Dockerfile
@@ -8,7 +8,7 @@ RUN apk add --no-cache git gcc musl-dev
 WORKDIR $GOPATH/src/github.com/btcsuite/btcd
 
 # Pin down btcd to a version that we know works with lnd.
-ARG BTCD_VERSION=v0.23.1
+ARG BTCD_VERSION=v0.23.5
 
 # Grab and install the latest version of of btcd and all related dependencies.
 RUN git clone https://github.com/btcsuite/btcd.git . \

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -355,7 +355,7 @@ bitcoind:
 On FreeBSD, use gmake instead of make.
 
 In order to be able to utilize the latest Taproot features, [`btcd` version
-`v0.23.1`](https://github.com/btcsuite/btcd/releases/tag/v0.23.1) MUST be used.
+`v0.23.5`](https://github.com/btcsuite/btcd/releases/tag/v0.23.5) MUST be used.
 
 To install btcd, run the following commands:
 


### PR DESCRIPTION
Update instructions and tutorial `btcd` version to allow sync on testnet.