### PR TITLE
Fix non-deterministic behaviour for custom accounts

### DIFF
--- a/cmd/lncli/walletrpc_active.go
+++ b/cmd/lncli/walletrpc_active.go
@@ -1447,6 +1447,9 @@ var importAccountCommand = cli.Command{
 	The address type can usually be inferred from the key's version, but may
 	be required for certain keys to map them into the proper scope.
 
+	If an account with the same name already exists (even with a different
+	key scope), an error will be returned.
+
 	For BIP-0044 keys, an address type must be specified as we intend to not
 	support importing BIP-0044 keys into the wallet using the legacy
 	pay-to-pubkey-hash (P2PKH) scheme. A nested witness address type will

--- a/docs/release-notes/release-notes-0.17.0.md
+++ b/docs/release-notes/release-notes-0.17.0.md
@@ -80,6 +80,13 @@ package](https://github.com/lightningnetwork/lnd/pull/7356)
 * [Fixed a bug where we didn't check for correct networks when submitting
   onchain transactions](https://github.com/lightningnetwork/lnd/pull/6448).
 
+* [Fix non-deterministic behaviour in RPC calls for
+  custom accounts](https://github.com/lightningnetwork/lnd/pull/7565).
+  In theory, it should be only one custom account with a given name. However,
+  due to a lack of check, users could have created custom accounts with various
+  key scopes. The non-deterministic behaviours linked to this case are fixed,
+  and users can no longer create two custom accounts with the same name.
+
 ## Misc
 
 * [Generate default macaroons
@@ -157,6 +164,7 @@ unlock or create.
 * Michael Street
 * MG-ng
 * Oliver Gugger
+* Pierre Beugnet
 * Satarupa Deb
 * Shaurya Arora
 * Torkel Rogstad

--- a/lntest/rpc/wallet_kit.go
+++ b/lntest/rpc/wallet_kit.go
@@ -235,6 +235,20 @@ func (h *HarnessRPC) ImportAccount(
 	return resp
 }
 
+// ImportAccountAssertErr makes the ImportAccount RPC call and asserts an error
+// is returned. It then returns the error.
+func (h *HarnessRPC) ImportAccountAssertErr(
+	req *walletrpc.ImportAccountRequest) error {
+
+	ctxt, cancel := context.WithTimeout(h.runCtx, DefaultTimeout)
+	defer cancel()
+
+	_, err := h.WalletKit.ImportAccount(ctxt, req)
+	require.Error(h, err)
+
+	return err
+}
+
 // ImportPublicKey makes a RPC call to the node's WalletKitClient and asserts.
 //
 //nolint:lll

--- a/lnwallet/btcwallet/btcwallet.go
+++ b/lnwallet/btcwallet/btcwallet.go
@@ -82,11 +82,6 @@ var (
 	// requested for the default imported account within the wallet.
 	errNoImportedAddrGen = errors.New("addresses cannot be generated for " +
 		"the default imported account")
-
-	// errIncompatibleAccountAddr is an error returned when the type of a
-	// new address being requested is incompatible with the account.
-	errIncompatibleAccountAddr = errors.New("incompatible address type " +
-		"for account")
 )
 
 // BtcWallet is an implementation of the lnwallet.WalletController interface
@@ -516,18 +511,14 @@ func (b *BtcWallet) keyScopeForAccountAddr(accountName string,
 		return addrKeyScope, defaultAccount, nil
 	}
 
-	// Otherwise, look up the account's key scope and check that it supports
-	// the requested address type.
-	keyScope, account, err := b.wallet.LookupAccount(accountName)
+	// Otherwise, look up the custom account and if it supports the given
+	// key scope.
+	accountNumber, err := b.wallet.AccountNumber(addrKeyScope, accountName)
 	if err != nil {
 		return waddrmgr.KeyScope{}, 0, err
 	}
 
-	if keyScope != addrKeyScope {
-		return waddrmgr.KeyScope{}, 0, errIncompatibleAccountAddr
-	}
-
-	return keyScope, account, nil
+	return addrKeyScope, accountNumber, nil
 }
 
 // NewAddress returns the next external or internal address for the wallet

--- a/lnwallet/btcwallet/psbt.go
+++ b/lnwallet/btcwallet/psbt.go
@@ -97,7 +97,7 @@ func (b *BtcWallet) FundPsbt(packet *psbt.Packet, minConfs int32,
 				"custom change type for custom accounts")
 		}
 
-		scope, account, err := b.wallet.LookupAccount(accountName)
+		scope, account, err := b.lookupFirstCustomAccount(accountName)
 		if err != nil {
 			return 0, err
 		}
@@ -512,7 +512,7 @@ func (b *BtcWallet) FinalizePsbt(packet *psbt.Packet, accountName string) error 
 	// number to determine if the inputs belonging to this account should be
 	// signed.
 	default:
-		scope, account, err := b.wallet.LookupAccount(accountName)
+		scope, account, err := b.lookupFirstCustomAccount(accountName)
 		if err != nil {
 			return err
 		}
@@ -521,4 +521,37 @@ func (b *BtcWallet) FinalizePsbt(packet *psbt.Packet, accountName string) error 
 	}
 
 	return b.wallet.FinalizePsbt(keyScope, accountNum, packet)
+}
+
+// lookupFirstCustomAccount returns the first custom account found. In theory,
+// there should be only one custom account for the given name. However, due to a
+// lack of check, users could have created custom accounts with various key
+// scopes. This behaviour has been fixed but, we still need to handle this
+// specific case to avoid non-deterministic behaviour implied by LookupAccount.
+func (b *BtcWallet) lookupFirstCustomAccount(
+	name string) (waddrmgr.KeyScope, uint32, error) {
+
+	var (
+		account  *waddrmgr.AccountProperties
+		keyScope waddrmgr.KeyScope
+	)
+	for _, scope := range waddrmgr.DefaultKeyScopes {
+		var err error
+		account, err = b.wallet.AccountPropertiesByName(scope, name)
+		if waddrmgr.IsError(err, waddrmgr.ErrAccountNotFound) {
+			continue
+		}
+		if err != nil {
+			return keyScope, 0, err
+		}
+
+		keyScope = scope
+
+		break
+	}
+	if account == nil {
+		return waddrmgr.KeyScope{}, 0, newAccountNotFoundError(name)
+	}
+
+	return keyScope, account.AccountNumber, nil
 }


### PR DESCRIPTION
This PR fixes: https://github.com/lightningnetwork/lnd/issues/7265

1) fix non-deterministic behaviour for custom accounts with same name but different key scopes (ListAccounts/LookupAccount)

2) Forbid users to create a custom account if the name is already used

## Steps to Test
This PR was tested, here are the steps to test:

1) -> You will need to cherry-pick the two first commit (otherwise the 3rd commit will prevent you from create 2 custom accounts with the same name). Then import 2 accounts (different key scope but same name) and check if `ListAccounts` returns the 2 accounts (and not only one as before)

2) -> Now, you can include the 3rd commit, check that you cant import 2 accounts with the same name anymore