### PR TITLE
build: bump version to v0.16.99

### DIFF
--- a/build/version.go
+++ b/build/version.go
@@ -43,7 +43,7 @@ const (
 	AppMinor uint = 16
 
 	// AppPatch defines the application patch for this binary.
-	AppPatch uint = 0
+	AppPatch uint = 99
 
 	// AppPreRelease MUST only contain characters from semanticAlphabet
 	// per the semantic versioning spec.


### PR DESCRIPTION
In this commit, we bump the version of the master branch to v0.16.99. This reflects the fact that master will be a super set of all the minor releases until v0.17, and will also include changes towards v0.17.