### PR TITLE
kvdb: expand platforms excluded in build flags

### DIFF
--- a/kvdb/kvdb_sqlite.go
+++ b/kvdb/kvdb_sqlite.go
@@ -1,4 +1,4 @@
-//go:build kvdb_sqlite && !(windows && (arm || 386)) && !(linux && (ppc64 || mips || mipsle || mips64))
+//go:build kvdb_sqlite && !(windows && (arm || 386)) && !(linux && (ppc64 || mips || mipsle || mips64)) && !(dragonfly && amd64) && !(netbsd && (386 || amd64)) && !(openbsd && 386)
 
 package kvdb
 

--- a/kvdb/sqlite/db.go
+++ b/kvdb/sqlite/db.go
@@ -1,4 +1,4 @@
-//go:build kvdb_sqlite && !(windows && (arm || 386)) && !(linux && (ppc64 || mips || mipsle || mips64))
+//go:build kvdb_sqlite && !(windows && (arm || 386)) && !(linux && (ppc64 || mips || mipsle || mips64)) && !(dragonfly && amd64) && !(netbsd && (386 || amd64)) && !(openbsd && 386)
 
 package sqlite
 

--- a/kvdb/sqlite/db_test.go
+++ b/kvdb/sqlite/db_test.go
@@ -1,4 +1,4 @@
-//go:build kvdb_sqlite && !(windows && (arm || 386)) && !(linux && (ppc64 || mips || mipsle || mips64))
+//go:build kvdb_sqlite && !(windows && (arm || 386)) && !(linux && (ppc64 || mips || mipsle || mips64)) && !(dragonfly && amd64) && !(netbsd && (386 || amd64)) && !(openbsd && 386)
 
 package sqlite
 

--- a/kvdb/sqlite/driver.go
+++ b/kvdb/sqlite/driver.go
@@ -1,4 +1,4 @@
-//go:build kvdb_sqlite && !(windows && (arm || 386)) && !(linux && (ppc64 || mips || mipsle || mips64))
+//go:build kvdb_sqlite && !(windows && (arm || 386)) && !(linux && (ppc64 || mips || mipsle || mips64)) && !(dragonfly && amd64) && !(netbsd && (386 || amd64)) && !(openbsd && 386)
 
 package sqlite
 


### PR DESCRIPTION
Allow kvdb package to be built for the `dragonfly-amd64`, `netbsd-386`, `netbsd-arm64` and `openbsd-386` platforms by excluding the sqlite files.

NOTE: release note for this is added in the follow up PR that makes use of this one. This PR must be merged and tagged before the follow up can be merged. 