### PR TITLE
config: fix bug in walletrpc interaction due to mismatched coin type

### DIFF
--- a/config.go
+++ b/config.go
@@ -1231,6 +1231,15 @@ func ValidateConfig(cfg Config, interceptor signal.Interceptor, fileParser,
 		if cfg.Bitcoin.SimNet {
 			numNets++
 			cfg.ActiveNetParams = chainreg.BitcoinSimNetParams
+
+			// For simnet, the btcsuite chain params uses a
+			// cointype of 115. However, we override this in
+			// chainreg/chainparams.go, but the raw ChainParam
+			// field is used elsewhere. To ensure everything is
+			// consistent, we'll also override the cointype within
+			// the raw params.
+			targetCoinType := chainreg.BitcoinSigNetParams.CoinType
+			cfg.ActiveNetParams.Params.HDCoinType = targetCoinType
 		}
 		if cfg.Bitcoin.SigNet {
 			numNets++


### PR DESCRIPTION
In this commit, we fix a bug that would cause the walletrpc on the simnet chain to not be able to respond to all RPC calls. The issue is that for the SimNet backend, within chainparams.go: https://github.com/lightningnetwork/lnd/blob/6e0a67d05bd375c4b39db53dc45df74157227a57/chainreg/chainparams.go#L45-L51, we set a new CoinType for Simnet in order to match the RegTest value.

Later on, when we go to verify the on disk accounts against the in-memory cointype, we fall through to an error case as the in-memory cointype is 115, while the on disk cointype is 1.

To fix this, when we know we're doing simnet mode, we'll override the cointype similar to the way we did/do for LTC.

Fixes https://github.com/lightningnetwork/lnd/issues/6807.
