### PR TITLE
lnd: generate default macaroons independently

### DIFF
--- a/config_builder.go
+++ b/config_builder.go
@@ -470,14 +470,10 @@ func (d *DefaultWalletImpl) BuildWalletConfig(ctx context.Context,
 
 		// If the user requested a stateless initialization, no macaroon
 		// files should be created.
-		if !walletInitParams.StatelessInit &&
-			!lnrpc.FileExists(d.cfg.AdminMacPath) &&
-			!lnrpc.FileExists(d.cfg.ReadMacPath) &&
-			!lnrpc.FileExists(d.cfg.InvoiceMacPath) {
-
-			// Create macaroon files for lncli to use if they don't
-			// exist.
-			err = genMacaroons(
+		if !walletInitParams.StatelessInit {
+			// Create default macaroon files for lncli to use if
+			// they don't exist.
+			err = genDefaultMacaroons(
 				ctx, macaroonService, d.cfg.AdminMacPath,
 				d.cfg.ReadMacPath, d.cfg.InvoiceMacPath,
 			)

--- a/docs/release-notes/release-notes-0.17.0.md
+++ b/docs/release-notes/release-notes-0.17.0.md
@@ -13,8 +13,14 @@
   the entire retribution struct. This reduces the amount of data that needs to 
   be held in memory. 
 
+## Misc
+
+* [Generate default macaroons
+independently](https://github.com/lightningnetwork/lnd/pull/7592) on wallet
+unlock or create.
+
 # Contributors (Alphabetical Order)
 
+* Daniel McNally
 * Elle Mouton
 * Jordi Montes
-


### PR DESCRIPTION
## Change Description

This modifies the `genMacaroons` logic to indepently check for each of the three default macaroons (admin, readonly, invoice) and generate whichever are missing. Previously, this was an all or nothing routine. In other words, either all three didn't exist on disk and all three are created, or no macaroons are created. Although that works for the first run of a new node, it can result in inconsistent states if only one or two of the macaroons is deleted.

See https://github.com/lightningnetwork/lnd/discussions/7566.

## Steps to Test

1. Start fresh lnd node and create a wallet.
2. Observer that default macaroons including `admin.macaroon` are created.
3. Delete `admin.macaroon`.
4. Restart lnd node.
5. Observe that `admin.macaroon` has been recreated.