### PR TITLE
funding: use p2tr by default for batch_open_channel

### DIFF
--- a/docs/release-notes/release-notes-0.16.1.md
+++ b/docs/release-notes/release-notes-0.16.1.md
@@ -74,6 +74,8 @@ https://github.com/lightningnetwork/lnd/pull/7359)
 * [Fix a bug where lnd crashes when psbt data is not fully 
 available](https://github.com/lightningnetwork/lnd/pull/7529).
 
+* [Put back P2TR as default change type
+  in batch_open_channel](https://github.com/lightningnetwork/lnd/pull/7603).
 
 # Contributors (Alphabetical Order)
 
@@ -81,6 +83,7 @@ available](https://github.com/lightningnetwork/lnd/pull/7529).
 * Elle Mouton
 * hieblmi
 * Oliver Gugger
+* Pierre Beugnet
 * Tommy Volk
 * Yong Yu
 * ziggie1984

--- a/funding/batch.go
+++ b/funding/batch.go
@@ -320,6 +320,7 @@ func (b *Batcher) BatchFund(ctx context.Context,
 	// anyway.
 	firstReq := b.channels[0].fundingReq
 	feeRateSatPerKVByte := firstReq.FundingFeePerKw.FeePerKVByte()
+	changeType := walletrpc.ChangeAddressType_CHANGE_ADDRESS_TYPE_P2TR
 	fundPsbtReq := &walletrpc.FundPsbtRequest{
 		Template: &walletrpc.FundPsbtRequest_Raw{
 			Raw: txTemplate,
@@ -329,6 +330,7 @@ func (b *Batcher) BatchFund(ctx context.Context,
 		},
 		MinConfs:         firstReq.MinConfs,
 		SpendUnconfirmed: firstReq.MinConfs == 0,
+		ChangeType:       changeType,
 	}
 	fundPsbtResp, err := b.cfg.WalletKitServer.FundPsbt(ctx, fundPsbtReq)
 	if err != nil {

--- a/lntest/harness_assertion.go
+++ b/lntest/harness_assertion.go
@@ -377,6 +377,20 @@ func (h *HarnessTest) AssertChannelExists(hn *node.HarnessNode,
 	return channel
 }
 
+// AssertOutputScriptClass checks that the specified transaction output has the
+// expected script class.
+func (h *HarnessTest) AssertOutputScriptClass(tx *btcutil.Tx,
+	outputIndex uint32, scriptClass txscript.ScriptClass) {
+
+	require.Greater(h, len(tx.MsgTx().TxOut), int(outputIndex))
+
+	txOut := tx.MsgTx().TxOut[outputIndex]
+
+	pkScript, err := txscript.ParsePkScript(txOut.PkScript)
+	require.NoError(h, err)
+	require.Equal(h, pkScript.Class(), scriptClass)
+}
+
 // findChannel tries to find a target channel in the node using the given
 // channel point.
 func (h *HarnessTest) findChannel(hn *node.HarnessNode,


### PR DESCRIPTION
fixes https://github.com/lightningnetwork/lnd/issues/7601

In LND v0.15.1, batch_open_channel used p2tr by default for change output. However, in a later version, a breaking change has been fixed in FundPSBT to make the change type configurable (default to p2wkh). As batch_open_channel uses FundPsbt, we need to put back p2tr as default for change output for this specific case