### PR TITLE
Log Output Fix (Missing Value)

### DIFF
--- a/docs/release-notes/release-notes-0.16.1.md
+++ b/docs/release-notes/release-notes-0.16.1.md
@@ -76,6 +76,9 @@ available](https://github.com/lightningnetwork/lnd/pull/7529).
 
 * [Put back P2TR as default change type
   in batch_open_channel](https://github.com/lightningnetwork/lnd/pull/7603).
+  
+* [Fix log output](https://github.com/lightningnetwork/lnd/pull/7604).
+
 
 # Contributors (Alphabetical Order)
 

--- a/netann/chan_status_manager.go
+++ b/netann/chan_status_manager.go
@@ -398,7 +398,9 @@ func (m *ChanStatusManager) processEnableRequest(outpoint wire.OutPoint,
 
 	// Channel is already enabled, nothing to do.
 	case ChanStatusEnabled:
-		log.Debugf("Channel(%v) already enabled, skipped announcement")
+		log.Debugf("Channel(%v) already enabled, skipped "+
+			"announcement", outpoint)
+
 		return nil
 
 	// The channel is enabled, though we are now canceling the scheduled


### PR DESCRIPTION
Mini Driveby PR I came across today.

```
2023-04-17 10:33:05.717 [DBG] NANN: Channel(%!v(MISSING)) already enabled, skipped announcement
```


## Steps to Test
Steps for reviewers to follow to test the change.

## Pull Request Checklist
### Testing
- [x] Your PR passes all CI checks.
- [x] Tests covering the positive and negative (error paths) are included.
- [x] Bug fixes contain tests triggering the bug to prevent regressions.

### Code Style and Documentation
- [x] The change obeys the [Code Documentation and Commenting](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#CodeDocumentation) guidelines, and lines wrap at 80.
- [x] Commits follow the [Ideal Git Commit Structure](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#IdealGitCommitStructure).
- [x] Any new logging statements use an appropriate subsystem and logging level.
- [x]  [There is a change description in the release notes](https://github.com/lightningnetwork/lnd/tree/master/docs/release-notes), or `[skip ci]` in the commit message for small changes.

📝 Please see our  [Contribution Guidelines](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md) for further guidance.