### PR TITLE
make: clean up container after linting

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,7 +55,7 @@ ifneq ($(workers),)
 LINT_WORKERS = --concurrency=$(workers)
 endif
 
-DOCKER_TOOLS = docker run -v $$(pwd):/build lnd-tools
+DOCKER_TOOLS = docker run --rm -v $$(pwd):/build lnd-tools
 
 GREEN := "\\033[0;32m"
 NC := "\\033[0m"


### PR DESCRIPTION
Currently `make lint` creates a new container each time it runs. We can automatically delete these containers once linting is done by using the `--rm` flag.

Tested:
```shell
make lint
docker ps -a  # no new containers created
```