### PR TITLE
chainreg: increase default CLTV value to 80 blocks (~13 hrs)

### DIFF
--- a/chainreg/chainregistry.go
+++ b/chainreg/chainregistry.go
@@ -128,7 +128,7 @@ const (
 
 	// DefaultBitcoinTimeLockDelta is the default forwarding time lock
 	// delta.
-	DefaultBitcoinTimeLockDelta = 40
+	DefaultBitcoinTimeLockDelta = 80
 
 	DefaultLitecoinMinHTLCInMSat  = lnwire.MilliSatoshi(1)
 	DefaultLitecoinMinHTLCOutMSat = lnwire.MilliSatoshi(1000)

--- a/docs/release-notes/release-notes-0.16.1.md
+++ b/docs/release-notes/release-notes-0.16.1.md
@@ -1,5 +1,10 @@
 # Release Notes
 
+## Routing
+
+* The default CLTV delta delay [has been increased from 40 blocks to 80
+  blocks](https://github.com/lightningnetwork/lnd/pull/7609).
+
 ## Wallet
 
 - The logging around transaction broadcast failures [has been improved by always

--- a/sample-lnd.conf
+++ b/sample-lnd.conf
@@ -532,7 +532,7 @@ bitcoin.node=btcd
 ; bitcoin.feerate=1
 
 ; The CLTV delta we will subtract from a forwarded HTLC's timelock value.
-; bitcoin.timelockdelta=40
+; bitcoin.timelockdelta=80
 
 ; The seed DNS server(s) to use for initial peer discovery. Must be specified as
 ; a '<primary_dns>[,<soa_primary_dns>]' tuple where the SOA address is needed


### PR DESCRIPTION
In this commit, we increase the default CTLV value to 80 blocks. Initially this was set to 144 blocks in the early days, but then was lowered to 40 blocks as the lnd implementation matured. By setting this to a higher value, we increase the safety window (MTTR) when it comes to node downtime, and also add some buffer room around time locks which may become more stressed in the future assuming the current mempool load remains persistent.

## Change Description
Description of change / link to associated issue.

## Steps to Test
Steps for reviewers to follow to test the change.

## Pull Request Checklist
### Testing
- [ ] Your PR passes all CI checks.
- [ ] Tests covering the positive and negative (error paths) are included.
- [ ] Bug fixes contain tests triggering the bug to prevent regressions.

### Code Style and Documentation
- [x] The change obeys the [Code Documentation and Commenting](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#CodeDocumentation) guidelines, and lines wrap at 80.
- [x] Commits follow the [Ideal Git Commit Structure](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#IdealGitCommitStructure).
- [x] Any new logging statements use an appropriate subsystem and logging level.
- [ ]  [There is a change description in the release notes](https://github.com/lightningnetwork/lnd/tree/master/docs/release-notes), or `[skip ci]` in the commit message for small changes.

📝 Please see our  [Contribution Guidelines](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md) for further guidance.