### PR TITLE
funding: use default forwarding policy if persisted values not found

### DIFF
--- a/docs/release-notes/release-notes-0.16.1.md
+++ b/docs/release-notes/release-notes-0.16.1.md
@@ -84,10 +84,13 @@ available](https://github.com/lightningnetwork/lnd/pull/7529).
   
 * [Fix log output](https://github.com/lightningnetwork/lnd/pull/7604).
 
-
 * [Channels opened with custom fee policies are now able to forward payments
   correctly without needing to restart
   first](https://github.com/lightningnetwork/lnd/pull/7597).
+
+* [Fix a bug](https://github.com/lightningnetwork/lnd/pull/7613) where the 
+  funding manager would error out if no persisted initial forwarding policy is 
+  found for a channel. 
 
 # Contributors (Alphabetical Order)
 

--- a/funding/manager.go
+++ b/funding/manager.go
@@ -3729,10 +3729,11 @@ func (f *Manager) newChanAnnouncement(localPubKey,
 	}
 
 	// The caller of newChanAnnouncement is expected to provide the initial
-	// forwarding policy to be announced. We abort the channel announcement
-	// if they are not provided.
+	// forwarding policy to be announced. If no persisted initial policy
+	// values are found, then we will use the default policy values in the
+	// channel announcement.
 	storedFwdingPolicy, err := f.getInitialFwdingPolicy(chanID)
-	if err != nil {
+	if err != nil && !errors.Is(err, channeldb.ErrChannelNotFound) {
 		return nil, errors.Errorf("unable to generate channel "+
 			"update announcement: %v", err)
 	}

--- a/funding/manager_test.go
+++ b/funding/manager_test.go
@@ -3154,7 +3154,7 @@ func TestFundingManagerCustomChannelParameters(t *testing.T) {
 		t.Fatal("OpenStatusUpdate was not OpenStatusUpdate_ChanPending")
 	}
 
-	// After the funding is sigend and before the channel announcement
+	// After the funding is signed and before the channel announcement
 	// we expect Alice and Bob to store their respective fees in the
 	// database.
 	forwardingPolicy, err := alice.fundingMgr.getInitialFwdingPolicy(
@@ -3169,7 +3169,7 @@ func TestFundingManagerCustomChannelParameters(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, assertFees(forwardingPolicy, 100, 1000))
 
-	// Wait for Alice to published the funding tx to the network.
+	// Wait for Alice to publish the funding tx to the network.
 	var fundingTx *wire.MsgTx
 	select {
 	case fundingTx = <-alice.publTxChan:


### PR DESCRIPTION
In this commit, a bug is fixed in the funding manager that could result in the funding process erroring out if the persisted initial forwarding policy is not found. This could occur if a node restarts after opening a channel that is not yet fully confirmed and also upgrades their node from a pre-0.16 version to 0.16 since the values are only expected to be persisted after 0.16 (which includes the changes made in https://github.com/lightningnetwork/lnd/pull/6753). 

This addresses the issue reported in [this comment](https://github.com/lightningnetwork/lnd/issues/6987#issuecomment-1510377248)

