### PR TITLE
lntest+lnd: gracefully shutdown pprof server

### DIFF
--- a/lntest/wait/timeouts.go
+++ b/lntest/wait/timeouts.go
@@ -16,7 +16,7 @@ const (
 
 	// ChannelCloseTimeout is the max time we will wait before a channel is
 	// considered closed.
-	ChannelCloseTimeout = time.Second * 30
+	ChannelCloseTimeout = time.Second * 60
 
 	// DefaultTimeout is a timeout that will be used for various wait
 	// scenarios where no custom timeout value is defined.


### PR DESCRIPTION
This commit makes sure when lnd is shutting down, the optional pprof server is also gracefully shutting down.

Errors from itest build,
```
itest error from [multi_hop_htlc_local_chain_claim:Bob]: timeout waiting for process to exit
=== NAME  TestLightningNetworkDaemon
    harness_rpc.go:97: 
        	Error Trace:	/home/runner/work/lnd/lnd/itest/harness_rpc.go:97
        	            				/home/runner/work/lnd/lnd/itest/lnd.go:84
        	            				/home/runner/work/lnd/lnd/itest/harness_node.go:603
        	            				/home/runner/work/lnd/lnd/itest/harness_node.go:565
        	            				/home/runner/work/lnd/lnd/itest/harness_node.go:457
        	            				/home/runner/work/lnd/lnd/itest/harness_node_manager.go:146
        	            				/home/runner/work/lnd/lnd/itest/harness.go:525
        	            				/home/runner/work/lnd/lnd/itest/harness.go:565
        	            				/home/runner/work/lnd/lnd/itest/harness.go:301
        	            				/home/runner/work/lnd/lnd/itest/harness.go:328
        	            				/home/runner/work/lnd/lnd/itest/lnd_multi-hop_test.go:77
        	Error:      	Received unexpected error:
        	            	rpc error: code = Unknown desc = cannot retrieve macaroon: cannot get macaroon: macaroon store is locked
        	Messages:   	Bob: failed to call GetInfo
```

From logs, the pprof server is still running,
```
2023-04-19 02:17:00.992 [INF] LTND: Pprof listening on 127.0.0.1:5572
listen tcp 127.0.0.1:5572: bind: address already in use
```

And we wanna stop the test if the shutdown process is timed out.