### PR TITLE
funding: don't fail if we are not able to delete the fwdPolicy

### DIFF
--- a/funding/manager.go
+++ b/funding/manager.go
@@ -3234,9 +3234,11 @@ func (f *Manager) annAfterSixConfs(completeChan *channeldb.OpenChannel,
 
 		// For private channels we do not announce the channel policy
 		// to the network but still need to delete them from the
-		// database.
+		// database. It is possible that we do not have a stored
+		// forwarding policy for this channel so we ignore that specific
+		// type of error.
 		err = f.deleteInitialFwdingPolicy(chanID)
-		if err != nil {
+		if err != nil && !errors.Is(err, channeldb.ErrChannelNotFound) {
 			log.Infof("Could not delete channel fees "+
 				"for chanId %x.", chanID)
 		}
@@ -3863,9 +3865,11 @@ func (f *Manager) announceChannel(localIDKey, remoteIDKey *btcec.PublicKey,
 	}
 
 	// After the fee parameters have been stored in the announcement
-	// we can delete them from the database.
+	// we can delete them from the database. It is possible that we do not
+	// have a stored forwarding policy for this channel so we ignore that
+	// specific type of error.
 	err = f.deleteInitialFwdingPolicy(chanID)
-	if err != nil {
+	if err != nil && !errors.Is(err, channeldb.ErrChannelNotFound) {
 		log.Infof("Could not delete channel fees for chanId %x.",
 			chanID)
 	}


### PR DESCRIPTION
In #6753 we added support to custom base and fee rate fees when opening a channel. Since v0.16.0 all channels store their initial fwdPolicy even if they are using the default values. However, there is an edge case where a channel is open before migrating to >v0.16.0 but updating to +v0.16.0 before that channel gets confirmed.

For those cases we won't be able to retrieve/delete the initial fwdPolicy. In that case we need to use the default values but we also need to ensure that we do not fail when trying to read/delete the initial fwdPolicy. #7613 fixed the problem for reading, here we fix it for deleting.

