### PR TITLE
multi: populate both string and byte TXID in lnrpc.Outpoint

### DIFF
--- a/docs/release-notes/release-notes-0.17.0.md
+++ b/docs/release-notes/release-notes-0.17.0.md
@@ -12,6 +12,11 @@
   wtdb.BackupIDs](https://github.com/lightningnetwork/lnd/pull/7623) instead of 
   the entire retribution struct. This reduces the amount of data that needs to 
   be held in memory. 
+ 
+## Misc
+
+* [Ensure that both the byte and string form of a TXID is populated in the 
+  lnrpc.Outpoint message](https://github.com/lightningnetwork/lnd/pull/7624). 
 
 # Contributors (Alphabetical Order)
 

--- a/funding/batch.go
+++ b/funding/batch.go
@@ -490,6 +490,7 @@ func (b *Batcher) cleanup(ctx context.Context) {
 		rpcOP := &lnrpc.OutPoint{
 			OutputIndex: lockedUTXO.Outpoint.OutputIndex,
 			TxidBytes:   lockedUTXO.Outpoint.TxidBytes,
+			TxidStr:     lockedUTXO.Outpoint.TxidStr,
 		}
 		_, err := b.cfg.WalletKitServer.ReleaseOutput(
 			ctx, &walletrpc.ReleaseOutputRequest{

--- a/lnrpc/marshall_utils.go
+++ b/lnrpc/marshall_utils.go
@@ -8,6 +8,7 @@ import (
 	"github.com/btcsuite/btcd/btcutil"
 	"github.com/btcsuite/btcd/chaincfg"
 	"github.com/btcsuite/btcd/txscript"
+	"github.com/btcsuite/btcd/wire"
 	"github.com/lightningnetwork/lnd/lnwallet"
 	"github.com/lightningnetwork/lnd/lnwire"
 )
@@ -106,11 +107,7 @@ func MarshalUtxos(utxos []*lnwallet.Utxo, activeNetParams *chaincfg.Params) (
 
 		// Now that we know we have a proper mapping to an address,
 		// we'll convert the regular outpoint to an lnrpc variant.
-		outpoint := &OutPoint{
-			TxidBytes:   utxo.OutPoint.Hash[:],
-			TxidStr:     utxo.OutPoint.Hash.String(),
-			OutputIndex: utxo.OutPoint.Index,
-		}
+		outpoint := MarshalOutPoint(&utxo.OutPoint)
 
 		utxoResp := Utxo{
 			AddressType:   addrType,
@@ -171,5 +168,14 @@ func MarshallOutputType(o txscript.ScriptClass) OutputScriptType {
 		return OutputScriptType_SCRIPT_TYPE_WITNESS_V1_TAPROOT
 	default:
 		return OutputScriptType_SCRIPT_TYPE_PUBKEY_HASH
+	}
+}
+
+// MarshalOutPoint converts a wire.OutPoint to its proto counterpart.
+func MarshalOutPoint(op *wire.OutPoint) *OutPoint {
+	return &OutPoint{
+		TxidBytes:   op.Hash[:],
+		TxidStr:     op.Hash.String(),
+		OutputIndex: op.Index,
 	}
 }

--- a/lnrpc/walletrpc/walletkit_server.go
+++ b/lnrpc/walletrpc/walletkit_server.go
@@ -756,10 +756,7 @@ func (w *WalletKit) PendingSweeps(ctx context.Context,
 				pendingInput.OutPoint)
 		}
 
-		op := &lnrpc.OutPoint{
-			TxidBytes:   pendingInput.OutPoint.Hash[:],
-			OutputIndex: pendingInput.OutPoint.Index,
-		}
+		op := lnrpc.MarshalOutPoint(&pendingInput.OutPoint)
 		amountSat := uint32(pendingInput.Amount)
 		satPerVbyte := uint64(pendingInput.LastFeeRate.FeePerKVByte() / 1000)
 		broadcastAttempts := uint32(pendingInput.BroadcastAttempts)
@@ -1241,12 +1238,8 @@ func marshallLeases(locks []*base.ListLeasedOutputResult) []*UtxoLease {
 		lock := lock
 
 		rpcLocks[idx] = &UtxoLease{
-			Id: lock.LockID[:],
-			Outpoint: &lnrpc.OutPoint{
-				TxidBytes:   lock.Outpoint.Hash[:],
-				TxidStr:     lock.Outpoint.Hash.String(),
-				OutputIndex: lock.Outpoint.Index,
-			},
+			Id:         lock.LockID[:],
+			Outpoint:   lnrpc.MarshalOutPoint(&lock.Outpoint),
 			Expiration: uint64(lock.Expiration.Unix()),
 			PkScript:   lock.PkScript,
 			Value:      uint64(lock.Value),

--- a/routing/localchans/manager.go
+++ b/routing/localchans/manager.go
@@ -265,11 +265,7 @@ func (r *Manager) getHtlcAmtLimits(tx kvdb.RTx, chanPoint wire.OutPoint) (
 func makeFailureItem(outPoint wire.OutPoint, updateFailure lnrpc.UpdateFailure,
 	errStr string) *lnrpc.FailedUpdate {
 
-	outpoint := &lnrpc.OutPoint{
-		TxidBytes:   outPoint.Hash[:],
-		TxidStr:     outPoint.Hash.String(),
-		OutputIndex: outPoint.Index,
-	}
+	outpoint := lnrpc.MarshalOutPoint(&outPoint)
 
 	return &lnrpc.FailedUpdate{
 		Outpoint:    outpoint,

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -4496,11 +4496,7 @@ func rpcChannelResolution(report *channeldb.ResolverReport) (*lnrpc.Resolution,
 
 	res := &lnrpc.Resolution{
 		AmountSat: uint64(report.Amount),
-		Outpoint: &lnrpc.OutPoint{
-			OutputIndex: report.OutPoint.Index,
-			TxidStr:     report.OutPoint.Hash.String(),
-			TxidBytes:   report.OutPoint.Hash[:],
-		},
+		Outpoint:  lnrpc.MarshalOutPoint(&report.OutPoint),
 	}
 
 	if report.SpendTxID != nil {


### PR DESCRIPTION
This commit adds a a new `MarshalOutPoint` helper in the `lnrpc` package that can be used to convert a `wire.Outpoint` to an `lnrpc.Outpoint`. By using this helper, we are less likely to forget to populate both the string and byte form of the TXID.

Fixes https://github.com/lightningnetwork/lnd/issues/7605