### PR TITLE
routing: log node pubkey as hex

### DIFF
--- a/routing/router.go
+++ b/routing/router.go
@@ -1434,7 +1434,7 @@ func (r *ChannelRouter) processUpdate(msg interface{},
 		}
 
 		if err := r.cfg.Graph.AddLightningNode(msg, op...); err != nil {
-			return errors.Errorf("unable to add node %v to the "+
+			return errors.Errorf("unable to add node %x to the "+
 				"graph: %v", msg.PubKeyBytes, err)
 		}
 


### PR DESCRIPTION
## Description

This PR changes the error log for failing to add a node to the graph so that it prints the pub key as hex and not as a byte array.
