### PR TITLE
Fix panic when canceling rebroadcast for neutrino backend

### DIFF
--- a/sweeper_wallet.go
+++ b/sweeper_wallet.go
@@ -21,5 +21,9 @@ func newSweeperWallet(w *lnwallet.LightningWallet) *sweeperWallet {
 
 // CancelRebroadcast cancels the rebroadcast of the given transaction.
 func (s *sweeperWallet) CancelRebroadcast(txid chainhash.Hash) {
-	s.Cfg.Rebroadcaster.MarkAsConfirmed(txid)
+	// For neutrino, we don't config the rebroadcaster for the wallet as it
+	// manages the rebroadcasting logic in neutrino itself.
+	if s.Cfg.Rebroadcaster != nil {
+		s.Cfg.Rebroadcaster.MarkAsConfirmed(txid)
+	}
 }


### PR DESCRIPTION
There's a panic in our itest when we try to cancel rebroadcast when using neutrino backend,
```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x20 pc=0x12a0e0c]

goroutine 362 [running]:
github.com/lightningnetwork/lnd.(*sweeperWallet).CancelRebroadcast(0xc00003efc0?, {0x32, 0x4a, 0x4f, 0x97, 0x6e, 0x13, 0xe5, 0x4e, 0x53, ...})
	/home/runner/work/lnd/lnd/sweeper_wallet.go:24 +0x2c
github.com/lightningnetwork/lnd/sweep.(*UtxoSweeper).removeLastSweepDescendants(0xc00040b000, 0xc00168d000)
	/home/runner/work/lnd/lnd/sweep/sweeper.go:588 +0x611
github.com/lightningnetwork/lnd/sweep.(*UtxoSweeper).collector(0xc00040b000, 0xc0004cade0)
	/home/runner/work/lnd/lnd/sweep/sweeper.go:713 +0x48e
github.com/lightningnetwork/lnd/sweep.(*UtxoSweeper).Start.func1()
	/home/runner/work/lnd/lnd/sweep/sweeper.go:385 +0x8c
created by github.com/lightningnetwork/lnd/sweep.(*UtxoSweeper).Start
	/home/runner/work/lnd/lnd/sweep/sweeper.go:381 +0x37a
```

This happens because we don't have the broadcaster configured for neutrino, which caused the above panic,
https://github.com/lightningnetwork/lnd/blob/4355ce62d2ad986a284b5aaf938fcb095b83f4fc/config_builder.go#L710-L731