### PR TITLE
multi: catch a few uncaught instances of "funding locked" 

### DIFF
--- a/channeldb/channel.go
+++ b/channeldb/channel.go
@@ -3532,7 +3532,7 @@ func deserializeCloseChannelSummary(r io.Reader) (*ChannelCloseSummary, error) {
 
 	// Finally, we'll attempt to read the next unrevoked commitment point
 	// for the remote party. If we closed the channel before receiving a
-	// funding locked message then this might not be present. A boolean
+	// channel_ready message then this might not be present. A boolean
 	// indicating whether the field is present will come first.
 	var hasRemoteNextRevocation bool
 	err = ReadElements(r, &hasRemoteNextRevocation)

--- a/channeldb/legacy_serialization.go
+++ b/channeldb/legacy_serialization.go
@@ -40,7 +40,7 @@ func deserializeCloseChannelSummaryV6(r io.Reader) (*ChannelCloseSummary, error)
 
 	// Finally, we'll attempt to read the next unrevoked commitment point
 	// for the remote party. If we closed the channel before receiving a
-	// funding locked message, then this can be nil. As a result, we'll use
+	// channel_ready message, then this can be nil. As a result, we'll use
 	// the same technique to read the field, only if there's still data
 	// left in the buffer.
 	err = ReadElements(r, &c.RemoteNextRevocation)

--- a/funding/manager.go
+++ b/funding/manager.go
@@ -942,7 +942,7 @@ func (f *Manager) reservationCoordinator() {
 // advanceFundingState will advance the channel through the steps after the
 // funding transaction is broadcasted, up until the point where the channel is
 // ready for operation. This includes waiting for the funding transaction to
-// confirm, sending funding locked to the peer, adding the channel to the
+// confirm, sending channel_ready to the peer, adding the channel to the
 // router graph, and announcing the channel. The updateChan can be set non-nil
 // to get OpenStatusUpdates.
 //
@@ -1057,7 +1057,7 @@ func (f *Manager) stateStep(channel *channeldb.OpenChannel,
 	// channelReady was sent to peer, but the channel was not added to the
 	// router graph and the channel announcement was not sent.
 	case channelReadySent:
-		// We must wait until we've received the peer's funding locked
+		// We must wait until we've received the peer's channel_ready
 		// before sending a channel_update according to BOLT#07.
 		received, err := f.receivedChannelReady(
 			channel.IdentityPub, chanID,
@@ -1126,7 +1126,7 @@ func (f *Manager) stateStep(channel *channeldb.OpenChannel,
 
 		// Give the caller a final update notifying them that
 		// the channel is now open.
-		// TODO(roasbeef): only notify after recv of funding locked?
+		// TODO(roasbeef): only notify after recv of channel_ready?
 		fundingPoint := channel.FundingOutpoint
 		cp := &lnrpc.ChannelPoint{
 			FundingTxid: &lnrpc.ChannelPoint_FundingTxidBytes{
@@ -2322,8 +2322,8 @@ func (f *Manager) handleFundingCreated(peer lnpeer.Peer,
 	}
 
 	// Create an entry in the local discovery map so we can ensure that we
-	// process the channel confirmation fully before we receive a funding
-	// locked message.
+	// process the channel confirmation fully before we receive a
+	// channel_ready message.
 	f.localDiscoveryMtx.Lock()
 	f.localDiscoverySignals[channelID] = make(chan struct{})
 	f.localDiscoveryMtx.Unlock()
@@ -2386,8 +2386,8 @@ func (f *Manager) handleFundingSigned(peer lnpeer.Peer,
 	}
 
 	// Create an entry in the local discovery map so we can ensure that we
-	// process the channel confirmation fully before we receive a funding
-	// locked message.
+	// process the channel confirmation fully before we receive a
+	// channel_ready message.
 	fundingPoint := resCtx.reservation.FundingOutpoint()
 	permChanID := lnwire.NewChanIDFromOutPoint(fundingPoint)
 	f.localDiscoveryMtx.Lock()
@@ -2907,7 +2907,7 @@ func (f *Manager) handleFundingConfirmation(
 
 	// Close the discoverySignal channel, indicating to a separate
 	// goroutine that the channel now is marked as open in the database
-	// and that it is acceptable to process funding locked messages
+	// and that it is acceptable to process channel_ready messages
 	// from the peer.
 	f.localDiscoveryMtx.Lock()
 	if discoverySignal, ok := f.localDiscoverySignals[chanID]; ok {
@@ -2929,7 +2929,7 @@ func (f *Manager) sendChannelReady(completeChan *channeldb.OpenChannel,
 	var peerKey [33]byte
 	copy(peerKey[:], completeChan.IdentityPub.SerializeCompressed())
 
-	// Next, we'll send over the funding locked message which marks that we
+	// Next, we'll send over the channel_ready message which marks that we
 	// consider the channel open by presenting the remote party with our
 	// next revocation key. Without the revocation key, the remote party
 	// will be unable to propose state transitions.
@@ -3451,7 +3451,7 @@ func (f *Manager) handleChannelReady(peer lnpeer.Peer,
 		"peer %x", msg.ChanID,
 		peer.IdentityKey().SerializeCompressed())
 
-	// If we are currently in the process of handling a funding locked
+	// If we are currently in the process of handling a channel_ready
 	// message for this channel, ignore.
 	f.handleChannelReadyMtx.Lock()
 	_, ok := f.handleChannelReadyBarriers[msg.ChanID]
@@ -3478,7 +3478,7 @@ func (f *Manager) handleChannelReady(peer lnpeer.Peer,
 	f.localDiscoveryMtx.Unlock()
 
 	if ok {
-		// Before we proceed with processing the funding locked
+		// Before we proceed with processing the channel_ready
 		// message, we'll wait for the local waitForFundingConfirmation
 		// goroutine to signal that it has the necessary state in
 		// place. Otherwise, we may be missing critical information
@@ -3596,7 +3596,7 @@ func (f *Manager) handleChannelReady(peer lnpeer.Peer,
 		return
 	}
 
-	// The funding locked message contains the next commitment point we'll
+	// The channel_ready message contains the next commitment point we'll
 	// need to create the next commitment state for the remote party. So
 	// we'll insert that into the channel now before passing it along to
 	// other sub-systems.

--- a/funding/manager.go
+++ b/funding/manager.go
@@ -1063,7 +1063,7 @@ func (f *Manager) stateStep(channel *channeldb.OpenChannel,
 			channel.IdentityPub, chanID,
 		)
 		if err != nil {
-			return fmt.Errorf("failed to check if funding locked "+
+			return fmt.Errorf("failed to check if channel_ready "+
 				"was received: %v", err)
 		}
 
@@ -3574,7 +3574,7 @@ func (f *Manager) handleChannelReady(peer lnpeer.Peer,
 
 			err = peer.SendMessage(true, channelReadyMsg)
 			if err != nil {
-				log.Errorf("unable to send funding locked: %v",
+				log.Errorf("unable to send channel_ready: %v",
 					err)
 				return
 			}

--- a/funding/manager_test.go
+++ b/funding/manager_test.go
@@ -1412,7 +1412,7 @@ func TestFundingManagerNormalWorkflow(t *testing.T) {
 	).(*lnwire.ChannelReady)
 	require.True(t, ok)
 
-	// And similarly Bob will send funding locked to Alice.
+	// And similarly Bob will send channel_ready to Alice.
 	channelReadyBob, ok := assertFundingMsgSent(
 		t, bob.msgChan, "ChannelReady",
 	).(*lnwire.ChannelReady)
@@ -1679,7 +1679,7 @@ func TestFundingManagerRestartBehavior(t *testing.T) {
 		// Expected.
 	}
 
-	// Bob will send funding locked to Alice.
+	// Bob will send channel_ready to Alice.
 	channelReadyBob, ok := assertFundingMsgSent(
 		t, bob.msgChan, "ChannelReady",
 	).(*lnwire.ChannelReady)
@@ -1838,7 +1838,7 @@ func TestFundingManagerOfflinePeer(t *testing.T) {
 		// Expected.
 	}
 
-	// Bob will send funding locked to Alice
+	// Bob will send channel_ready to Alice
 	channelReadyBob, ok := assertFundingMsgSent(
 		t, bob.msgChan, "ChannelReady",
 	).(*lnwire.ChannelReady)
@@ -2323,7 +2323,7 @@ func TestFundingManagerReceiveChannelReadyTwice(t *testing.T) {
 	).(*lnwire.ChannelReady)
 	require.True(t, ok)
 
-	// And similarly Bob will send funding locked to Alice.
+	// And similarly Bob will send channel_ready to Alice.
 	channelReadyBob, ok := assertFundingMsgSent(
 		t, bob.msgChan, "ChannelReady",
 	).(*lnwire.ChannelReady)
@@ -2342,7 +2342,7 @@ func TestFundingManagerReceiveChannelReadyTwice(t *testing.T) {
 	assertHandleChannelReady(t, alice, bob)
 
 	// Alice should not send the channel state the second time, as the
-	// second funding locked should just be ignored.
+	// second channel_ready should just be ignored.
 	select {
 	case <-alice.newChannels:
 		t.Fatalf("alice sent new channel to peer a second time")
@@ -2436,7 +2436,7 @@ func TestFundingManagerRestartAfterChanAnn(t *testing.T) {
 	).(*lnwire.ChannelReady)
 	require.True(t, ok)
 
-	// And similarly Bob will send funding locked to Alice.
+	// And similarly Bob will send channel_ready to Alice.
 	channelReadyBob, ok := assertFundingMsgSent(
 		t, bob.msgChan, "ChannelReady",
 	).(*lnwire.ChannelReady)
@@ -2535,7 +2535,7 @@ func TestFundingManagerRestartAfterReceivingChannelReady(t *testing.T) {
 	).(*lnwire.ChannelReady)
 	require.True(t, ok)
 
-	// And similarly Bob will send funding locked to Alice.
+	// And similarly Bob will send channel_ready to Alice.
 	channelReadyBob, ok := assertFundingMsgSent(
 		t, bob.msgChan, "ChannelReady",
 	).(*lnwire.ChannelReady)
@@ -2630,7 +2630,7 @@ func TestFundingManagerPrivateChannel(t *testing.T) {
 	).(*lnwire.ChannelReady)
 	require.True(t, ok)
 
-	// And similarly Bob will send funding locked to Alice.
+	// And similarly Bob will send channel_ready to Alice.
 	channelReadyBob, ok := assertFundingMsgSent(
 		t, bob.msgChan, "ChannelReady",
 	).(*lnwire.ChannelReady)
@@ -2755,7 +2755,7 @@ func TestFundingManagerPrivateRestart(t *testing.T) {
 	).(*lnwire.ChannelReady)
 	require.True(t, ok)
 
-	// And similarly Bob will send funding locked to Alice.
+	// And similarly Bob will send channel_ready to Alice.
 	channelReadyBob, ok := assertFundingMsgSent(
 		t, bob.msgChan, "ChannelReady",
 	).(*lnwire.ChannelReady)
@@ -3192,7 +3192,7 @@ func TestFundingManagerCustomChannelParameters(t *testing.T) {
 	).(*lnwire.ChannelReady)
 	require.True(t, ok)
 
-	// And similarly Bob will send funding locked to Alice.
+	// And similarly Bob will send channel_ready to Alice.
 	channelReadyBob, ok := assertFundingMsgSent(
 		t, bob.msgChan, "ChannelReady",
 	).(*lnwire.ChannelReady)

--- a/htlcswitch/link.go
+++ b/htlcswitch/link.go
@@ -722,7 +722,7 @@ func (l *channelLink) syncChanStates() error {
 
 		// If the remote party indicates that they think we haven't
 		// done any state updates yet, then we'll retransmit the
-		// funding locked message first. We do this, as at this point
+		// channel_ready message first. We do this, as at this point
 		// we can't be sure if they've really received the
 		// ChannelReady message.
 		if remoteChanSyncMsg.NextLocalCommitHeight == 1 &&
@@ -1091,7 +1091,7 @@ func (l *channelLink) htlcManager() {
 	// allow the switch to forward HTLCs in the outbound direction.
 	l.markReestablished()
 
-	// Now that we've received both funding locked and channel reestablish,
+	// Now that we've received both channel_ready and channel reestablish,
 	// we can go ahead and send the active channel notification. We'll also
 	// defer the inactive notification for when the link exits to ensure
 	// that every active notification is matched by an inactive one.

--- a/htlcswitch/switch_test.go
+++ b/htlcswitch/switch_test.go
@@ -115,7 +115,7 @@ func TestSwitchHasActiveLink(t *testing.T) {
 		t.Fatalf("link should not be active yet, still pending")
 	}
 
-	// Finally, simulate the link receiving funding locked by setting its
+	// Finally, simulate the link receiving channel_ready by setting its
 	// eligibility to true.
 	aliceChannelLink.eligible = true
 


### PR DESCRIPTION
A follow-up from https://github.com/lightningnetwork/lnd/pull/7517, found a few more 
instances of the "funding locked" strings (again have left the ones found in any 
migration files)