### PR TITLE
sweep+lnrpc: enforce provided fee rate is no less than relay fee

### DIFF
--- a/docs/release-notes/release-notes-0.17.0.md
+++ b/docs/release-notes/release-notes-0.17.0.md
@@ -31,6 +31,10 @@ package](https://github.com/lightningnetwork/lnd/pull/7356)
 * [SendOutputs](https://github.com/lightningnetwork/lnd/pull/7631) now adheres
   to the anchor channel reserve requirement.
 
+* Enforce provided [fee rate is no less than the relay or minimum mempool
+  fee](https://github.com/lightningnetwork/lnd/pull/7645) when calling
+  `OpenChannel`, `CloseChannel`, `SendCoins`, and `SendMany`.
+
 * The [UpdateNodeAnnouncement](https://github.com/lightningnetwork/lnd/pull/7568)
   API can no longer be used to set/unset protocol features that are defined by 
   LND.  
@@ -76,4 +80,5 @@ unlock or create.
 * Matt Morehouse
 * Michael Street
 * Oliver Gugger
+* Shaurya Arora
 * ziggie1984

--- a/sweep/walletsweep_test.go
+++ b/sweep/walletsweep_test.go
@@ -43,12 +43,20 @@ func TestDetermineFeePerKw(t *testing.T) {
 		// fail determines if this test case should fail or not.
 		fail bool
 	}{
-		// A fee rate below the fee rate floor should output the floor.
+		// A fee rate below the floor should error out.
 		{
 			feePref: FeePreference{
 				FeeRate: chainfee.SatPerKWeight(99),
 			},
-			fee: chainfee.FeePerKwFloor,
+			fail: true,
+		},
+
+		// A fee rate below the relay fee should error out.
+		{
+			feePref: FeePreference{
+				FeeRate: chainfee.SatPerKWeight(299),
+			},
+			fail: true,
 		},
 
 		// A fee rate above the floor, should pass through and return


### PR DESCRIPTION
## Change Description
Fixes #7512 by enforcing that if a manual fee rate is provided in RPC calls then that fee rate is no less than the relay fee of the underlying chain node. To achieve this, as suggested, the `calculateFeeRate()` function was refactored out of `rpcserver.go` and into `rpc_utils.go`, and reused in `walletkit_server.go`. This way `FundPsbt` rpc call can use the same fee estimation logic as `OpenChannel`, `SendCoins`, etc. `FundPsbt` will be handled in a follow-up PR.

I've tried my best to follow the required practices (code style, linting, comments etc.). Since this is my first PR, I'd love any feedback about what I may have overlooked :slightly_smiling_face: 

## Steps to Test
Attempt any one of the rpc calls whilst providing a manual sat per vbyte which would fall below the relay fee of the chain node that lnd is connected to. Notice that the fee rate used is actually the relay fee.
- `OpenChannel`
- `SendCoins`
- `SendMany`
- `CloseChannel`

## Pull Request Checklist
### Testing
- [ ] Your PR passes all CI checks.
- [X] Tests covering the positive and negative (error paths) are included. (existing test was updated)
- [X] Bug fixes contain tests triggering the bug to prevent regressions.

### Code Style and Documentation
- [X] The change obeys the [Code Documentation and Commenting](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#CodeDocumentation) guidelines, and lines wrap at 80.
- [X] Commits follow the [Ideal Git Commit Structure](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#IdealGitCommitStructure).
- [X] Any new logging statements use an appropriate subsystem and logging level.
- [X]  [There is a change description in the release notes](https://github.com/lightningnetwork/lnd/tree/master/docs/release-notes), or `[skip ci]` in the commit message for small changes.

📝 Please see our  [Contribution Guidelines](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md) for further guidance.