### PR TITLE
funding: fix flake in itest caused by persistent fee param changes

### DIFF
--- a/chainreg/chainregistry.go
+++ b/chainreg/chainregistry.go
@@ -25,7 +25,7 @@ import (
 	"github.com/lightningnetwork/lnd/chainntnfs/btcdnotify"
 	"github.com/lightningnetwork/lnd/chainntnfs/neutrinonotify"
 	"github.com/lightningnetwork/lnd/channeldb"
-	"github.com/lightningnetwork/lnd/htlcswitch"
+	"github.com/lightningnetwork/lnd/channeldb/models"
 	"github.com/lightningnetwork/lnd/input"
 	"github.com/lightningnetwork/lnd/keychain"
 	"github.com/lightningnetwork/lnd/kvdb"
@@ -195,7 +195,7 @@ type PartialChainControl struct {
 	ChainSource chain.Interface
 
 	// RoutingPolicy is the routing policy we have decided to use.
-	RoutingPolicy htlcswitch.ForwardingPolicy
+	RoutingPolicy models.ForwardingPolicy
 
 	// MinHtlcIn is the minimum HTLC we will accept.
 	MinHtlcIn lnwire.MilliSatoshi
@@ -270,7 +270,7 @@ func NewPartialChainControl(cfg *Config) (*PartialChainControl, func(), error) {
 
 	switch cfg.PrimaryChain() {
 	case BitcoinChain:
-		cc.RoutingPolicy = htlcswitch.ForwardingPolicy{
+		cc.RoutingPolicy = models.ForwardingPolicy{
 			MinHTLCOut:    cfg.Bitcoin.MinHTLCOut,
 			BaseFee:       cfg.Bitcoin.BaseFee,
 			FeeRate:       cfg.Bitcoin.FeeRate,
@@ -282,7 +282,7 @@ func NewPartialChainControl(cfg *Config) (*PartialChainControl, func(), error) {
 			DefaultBitcoinStaticMinRelayFeeRate,
 		)
 	case LitecoinChain:
-		cc.RoutingPolicy = htlcswitch.ForwardingPolicy{
+		cc.RoutingPolicy = models.ForwardingPolicy{
 			MinHTLCOut:    cfg.Litecoin.MinHTLCOut,
 			BaseFee:       cfg.Litecoin.BaseFee,
 			FeeRate:       cfg.Litecoin.FeeRate,

--- a/channeldb/db.go
+++ b/channeldb/db.go
@@ -312,11 +312,6 @@ var (
 	// channelOpeningState for each channel that is currently in the process
 	// of being opened.
 	channelOpeningStateBucket = []byte("channelOpeningState")
-
-	// initialChannelFwdingPolicyBucket is the database bucket used to store
-	// the forwarding policy for each permanent channel that is currently
-	// in the process of being opened.
-	initialChannelFwdingPolicyBucket = []byte("initialChannelFwdingPolicy")
 )
 
 // DB is the primary datastore for the lnd daemon. The database stores
@@ -1431,64 +1426,6 @@ func (c *ChannelStateDB) AbandonChannel(chanPoint *wire.OutPoint,
 	// caller. We set ourselves as the close initiator because we abandoned
 	// the channel.
 	return dbChan.CloseChannel(summary, ChanStatusLocalCloseInitiator)
-}
-
-// SaveInitialFwdingPolicy saves the serialized forwarding policy for the
-// provided permanent channel id to the initialChannelFwdingPolicyBucket.
-func (c *ChannelStateDB) SaveInitialFwdingPolicy(chanID,
-	forwardingPolicy []byte) error {
-
-	return kvdb.Update(c.backend, func(tx kvdb.RwTx) error {
-		bucket, err := tx.CreateTopLevelBucket(
-			initialChannelFwdingPolicyBucket,
-		)
-		if err != nil {
-			return err
-		}
-
-		return bucket.Put(chanID, forwardingPolicy)
-	}, func() {})
-}
-
-// GetInitialFwdingPolicy fetches the serialized forwarding policy for the
-// provided channel id from the database, or returns ErrChannelNotFound if
-// a forwarding policy for this channel id is not found.
-func (c *ChannelStateDB) GetInitialFwdingPolicy(chanID []byte) ([]byte, error) {
-	var serializedState []byte
-	err := kvdb.View(c.backend, func(tx kvdb.RTx) error {
-		bucket := tx.ReadBucket(initialChannelFwdingPolicyBucket)
-		if bucket == nil {
-			// If the bucket does not exist, it means we
-			// never added a channel fees to the db, so
-			// return ErrChannelNotFound.
-			return ErrChannelNotFound
-		}
-
-		stateBytes := bucket.Get(chanID)
-		if stateBytes == nil {
-			return ErrChannelNotFound
-		}
-
-		serializedState = append(serializedState, stateBytes...)
-
-		return nil
-	}, func() {
-		serializedState = nil
-	})
-	return serializedState, err
-}
-
-// DeleteInitialFwdingPolicy removes the forwarding policy for a given channel
-// from the database.
-func (c *ChannelStateDB) DeleteInitialFwdingPolicy(chanID []byte) error {
-	return kvdb.Update(c.backend, func(tx kvdb.RwTx) error {
-		bucket := tx.ReadWriteBucket(initialChannelFwdingPolicyBucket)
-		if bucket == nil {
-			return ErrChannelNotFound
-		}
-
-		return bucket.Delete(chanID)
-	}, func() {})
 }
 
 // SaveChannelOpeningState saves the serialized channel state for the provided

--- a/channeldb/forwarding_policy.go
+++ b/channeldb/forwarding_policy.go
@@ -3,20 +3,22 @@ package channeldb
 import "github.com/lightningnetwork/lnd/kvdb"
 
 var (
-	// initialChannelFwdingPolicyBucket is the database bucket used to store
-	// the forwarding policy for each permanent channel that is currently
-	// in the process of being opened.
-	initialChannelFwdingPolicyBucket = []byte("initialChannelFwdingPolicy")
+	// initialChannelForwardingPolicyBucket is the database bucket used to
+	// store the forwarding policy for each permanent channel that is
+	// currently in the process of being opened.
+	initialChannelForwardingPolicyBucket = []byte(
+		"initialChannelFwdingPolicy",
+	)
 )
 
-// SaveInitialFwdingPolicy saves the serialized forwarding policy for the
-// provided permanent channel id to the initialChannelFwdingPolicyBucket.
-func (c *ChannelStateDB) SaveInitialFwdingPolicy(chanID,
+// SaveInitialForwardingPolicy saves the serialized forwarding policy for the
+// provided permanent channel id to the initialChannelForwardingPolicyBucket.
+func (c *ChannelStateDB) SaveInitialForwardingPolicy(chanID,
 	forwardingPolicy []byte) error {
 
 	return kvdb.Update(c.backend, func(tx kvdb.RwTx) error {
 		bucket, err := tx.CreateTopLevelBucket(
-			initialChannelFwdingPolicyBucket,
+			initialChannelForwardingPolicyBucket,
 		)
 		if err != nil {
 			return err
@@ -26,13 +28,15 @@ func (c *ChannelStateDB) SaveInitialFwdingPolicy(chanID,
 	}, func() {})
 }
 
-// GetInitialFwdingPolicy fetches the serialized forwarding policy for the
+// GetInitialForwardingPolicy fetches the serialized forwarding policy for the
 // provided channel id from the database, or returns ErrChannelNotFound if
 // a forwarding policy for this channel id is not found.
-func (c *ChannelStateDB) GetInitialFwdingPolicy(chanID []byte) ([]byte, error) {
+func (c *ChannelStateDB) GetInitialForwardingPolicy(chanID []byte) ([]byte,
+	error) {
+
 	var serializedState []byte
 	err := kvdb.View(c.backend, func(tx kvdb.RTx) error {
-		bucket := tx.ReadBucket(initialChannelFwdingPolicyBucket)
+		bucket := tx.ReadBucket(initialChannelForwardingPolicyBucket)
 		if bucket == nil {
 			// If the bucket does not exist, it means we
 			// never added a channel fees to the db, so
@@ -54,11 +58,13 @@ func (c *ChannelStateDB) GetInitialFwdingPolicy(chanID []byte) ([]byte, error) {
 	return serializedState, err
 }
 
-// DeleteInitialFwdingPolicy removes the forwarding policy for a given channel
-// from the database.
-func (c *ChannelStateDB) DeleteInitialFwdingPolicy(chanID []byte) error {
+// DeleteInitialForwardingPolicy removes the forwarding policy for a given
+// channel from the database.
+func (c *ChannelStateDB) DeleteInitialForwardingPolicy(chanID []byte) error {
 	return kvdb.Update(c.backend, func(tx kvdb.RwTx) error {
-		bucket := tx.ReadWriteBucket(initialChannelFwdingPolicyBucket)
+		bucket := tx.ReadWriteBucket(
+			initialChannelForwardingPolicyBucket,
+		)
 		if bucket == nil {
 			return ErrChannelNotFound
 		}

--- a/channeldb/forwarding_policy.go
+++ b/channeldb/forwarding_policy.go
@@ -1,0 +1,68 @@
+package channeldb
+
+import "github.com/lightningnetwork/lnd/kvdb"
+
+var (
+	// initialChannelFwdingPolicyBucket is the database bucket used to store
+	// the forwarding policy for each permanent channel that is currently
+	// in the process of being opened.
+	initialChannelFwdingPolicyBucket = []byte("initialChannelFwdingPolicy")
+)
+
+// SaveInitialFwdingPolicy saves the serialized forwarding policy for the
+// provided permanent channel id to the initialChannelFwdingPolicyBucket.
+func (c *ChannelStateDB) SaveInitialFwdingPolicy(chanID,
+	forwardingPolicy []byte) error {
+
+	return kvdb.Update(c.backend, func(tx kvdb.RwTx) error {
+		bucket, err := tx.CreateTopLevelBucket(
+			initialChannelFwdingPolicyBucket,
+		)
+		if err != nil {
+			return err
+		}
+
+		return bucket.Put(chanID, forwardingPolicy)
+	}, func() {})
+}
+
+// GetInitialFwdingPolicy fetches the serialized forwarding policy for the
+// provided channel id from the database, or returns ErrChannelNotFound if
+// a forwarding policy for this channel id is not found.
+func (c *ChannelStateDB) GetInitialFwdingPolicy(chanID []byte) ([]byte, error) {
+	var serializedState []byte
+	err := kvdb.View(c.backend, func(tx kvdb.RTx) error {
+		bucket := tx.ReadBucket(initialChannelFwdingPolicyBucket)
+		if bucket == nil {
+			// If the bucket does not exist, it means we
+			// never added a channel fees to the db, so
+			// return ErrChannelNotFound.
+			return ErrChannelNotFound
+		}
+
+		stateBytes := bucket.Get(chanID)
+		if stateBytes == nil {
+			return ErrChannelNotFound
+		}
+
+		serializedState = append(serializedState, stateBytes...)
+
+		return nil
+	}, func() {
+		serializedState = nil
+	})
+	return serializedState, err
+}
+
+// DeleteInitialFwdingPolicy removes the forwarding policy for a given channel
+// from the database.
+func (c *ChannelStateDB) DeleteInitialFwdingPolicy(chanID []byte) error {
+	return kvdb.Update(c.backend, func(tx kvdb.RwTx) error {
+		bucket := tx.ReadWriteBucket(initialChannelFwdingPolicyBucket)
+		if bucket == nil {
+			return ErrChannelNotFound
+		}
+
+		return bucket.Delete(chanID)
+	}, func() {})
+}

--- a/channeldb/models/channel.go
+++ b/channeldb/models/channel.go
@@ -90,3 +90,41 @@ func (k *CircuitKey) Decode(r io.Reader) error {
 func (k CircuitKey) String() string {
 	return fmt.Sprintf("(Chan ID=%s, HTLC ID=%d)", k.ChanID, k.HtlcID)
 }
+
+// ForwardingPolicy describes the set of constraints that a given ChannelLink
+// is to adhere to when forwarding HTLC's. For each incoming HTLC, this set of
+// constraints will be consulted in order to ensure that adequate fees are
+// paid, and our time-lock parameters are respected. In the event that an
+// incoming HTLC violates any of these constraints, it is to be _rejected_ with
+// the error possibly carrying along a ChannelUpdate message that includes the
+// latest policy.
+type ForwardingPolicy struct {
+	// MinHTLCOut is the smallest HTLC that is to be forwarded.
+	MinHTLCOut lnwire.MilliSatoshi
+
+	// MaxHTLC is the largest HTLC that is to be forwarded.
+	MaxHTLC lnwire.MilliSatoshi
+
+	// BaseFee is the base fee, expressed in milli-satoshi that must be
+	// paid for each incoming HTLC. This field, combined with FeeRate is
+	// used to compute the required fee for a given HTLC.
+	BaseFee lnwire.MilliSatoshi
+
+	// FeeRate is the fee rate, expressed in milli-satoshi that must be
+	// paid for each incoming HTLC. This field combined with BaseFee is
+	// used to compute the required fee for a given HTLC.
+	FeeRate lnwire.MilliSatoshi
+
+	// TimeLockDelta is the absolute time-lock value, expressed in blocks,
+	// that will be subtracted from an incoming HTLC's timelock value to
+	// create the time-lock value for the forwarded outgoing HTLC. The
+	// following constraint MUST hold for an HTLC to be forwarded:
+	//
+	//  * incomingHtlc.timeLock - timeLockDelta = fwdInfo.OutgoingCTLV
+	//
+	// where fwdInfo is the forwarding information extracted from the
+	// per-hop payload of the incoming HTLC's onion packet.
+	TimeLockDelta uint32
+
+	// TODO(roasbeef): add fee module inside of switch
+}

--- a/funding/manager.go
+++ b/funding/manager.go
@@ -639,7 +639,7 @@ func (c channelOpeningState) String() string {
 	case markedOpen:
 		return "markedOpen"
 	case channelReadySent:
-		return "channelReady"
+		return "channelReadySent"
 	case addedToRouterGraph:
 		return "addedToRouterGraph"
 	default:

--- a/funding/manager_test.go
+++ b/funding/manager_test.go
@@ -432,6 +432,7 @@ func createTestFundingManager(t *testing.T, privKey *btcec.PrivateKey,
 		IDKeyLoc:     testKeyLoc,
 		Wallet:       lnw,
 		Notifier:     chainNotifier,
+		ChannelDB:    cdb,
 		FeeEstimator: estimator,
 		SignMessage: func(_ keychain.KeyLocator,
 			_ []byte, _ bool) (*ecdsa.Signature, error) {
@@ -601,6 +602,7 @@ func recreateAliceFundingManager(t *testing.T, alice *testNode) {
 		IDKeyLoc:     oldCfg.IDKeyLoc,
 		Wallet:       oldCfg.Wallet,
 		Notifier:     oldCfg.Notifier,
+		ChannelDB:    oldCfg.ChannelDB,
 		FeeEstimator: oldCfg.FeeEstimator,
 		SignMessage: func(_ keychain.KeyLocator,
 			_ []byte, _ bool) (*ecdsa.Signature, error) {

--- a/funding/manager_test.go
+++ b/funding/manager_test.go
@@ -1347,7 +1347,7 @@ func assertInitialFwdingPolicyNotFound(t *testing.T, node *testNode,
 		if i > 0 {
 			time.Sleep(testPollSleepMs * time.Millisecond)
 		}
-		fwdingPolicy, err = node.fundingMgr.getInitialFwdingPolicy(
+		fwdingPolicy, err = node.fundingMgr.getInitialForwardingPolicy(
 			*chanID,
 		)
 		require.ErrorIs(t, err, channeldb.ErrChannelNotFound)
@@ -3173,13 +3173,13 @@ func TestFundingManagerCustomChannelParameters(t *testing.T) {
 	// After the funding is signed and before the channel announcement
 	// we expect Alice and Bob to store their respective fees in the
 	// database.
-	forwardingPolicy, err := alice.fundingMgr.getInitialFwdingPolicy(
+	forwardingPolicy, err := alice.fundingMgr.getInitialForwardingPolicy(
 		fundingSigned.ChanID,
 	)
 	require.NoError(t, err)
 	require.NoError(t, assertFees(forwardingPolicy, 42, 1337))
 
-	forwardingPolicy, err = bob.fundingMgr.getInitialFwdingPolicy(
+	forwardingPolicy, err = bob.fundingMgr.getInitialForwardingPolicy(
 		fundingSigned.ChanID,
 	)
 	require.NoError(t, err)
@@ -3269,13 +3269,17 @@ func TestFundingManagerCustomChannelParameters(t *testing.T) {
 
 	// After the announcement we expect Alice and Bob to have cleared
 	// the fees for the channel from the database.
-	_, err = alice.fundingMgr.getInitialFwdingPolicy(fundingSigned.ChanID)
+	_, err = alice.fundingMgr.getInitialForwardingPolicy(
+		fundingSigned.ChanID,
+	)
 	if err != channeldb.ErrChannelNotFound {
 		err = fmt.Errorf("channel fees were expected to be deleted" +
 			" but were not")
 		t.Fatal(err)
 	}
-	_, err = bob.fundingMgr.getInitialFwdingPolicy(fundingSigned.ChanID)
+	_, err = bob.fundingMgr.getInitialForwardingPolicy(
+		fundingSigned.ChanID,
+	)
 	if err != channeldb.ErrChannelNotFound {
 		err = fmt.Errorf("channel fees were expected to be deleted" +
 			" but were not")

--- a/htlcswitch/interfaces.go
+++ b/htlcswitch/interfaces.go
@@ -191,7 +191,7 @@ type ChannelLink interface {
 	// UpdateForwardingPolicy updates the forwarding policy for the target
 	// ChannelLink. Once updated, the link will use the new forwarding
 	// policy to govern if it an incoming HTLC should be forwarded or not.
-	UpdateForwardingPolicy(ForwardingPolicy)
+	UpdateForwardingPolicy(models.ForwardingPolicy)
 
 	// CheckHtlcForward should return a nil error if the passed HTLC details
 	// satisfy the current forwarding policy fo the target link. Otherwise,

--- a/htlcswitch/link.go
+++ b/htlcswitch/link.go
@@ -64,44 +64,6 @@ const (
 	DefaultMaxLinkFeeAllocation float64 = 0.5
 )
 
-// ForwardingPolicy describes the set of constraints that a given ChannelLink
-// is to adhere to when forwarding HTLC's. For each incoming HTLC, this set of
-// constraints will be consulted in order to ensure that adequate fees are
-// paid, and our time-lock parameters are respected. In the event that an
-// incoming HTLC violates any of these constraints, it is to be _rejected_ with
-// the error possibly carrying along a ChannelUpdate message that includes the
-// latest policy.
-type ForwardingPolicy struct {
-	// MinHTLC is the smallest HTLC that is to be forwarded.
-	MinHTLCOut lnwire.MilliSatoshi
-
-	// MaxHTLC is the largest HTLC that is to be forwarded.
-	MaxHTLC lnwire.MilliSatoshi
-
-	// BaseFee is the base fee, expressed in milli-satoshi that must be
-	// paid for each incoming HTLC. This field, combined with FeeRate is
-	// used to compute the required fee for a given HTLC.
-	BaseFee lnwire.MilliSatoshi
-
-	// FeeRate is the fee rate, expressed in milli-satoshi that must be
-	// paid for each incoming HTLC. This field combined with BaseFee is
-	// used to compute the required fee for a given HTLC.
-	FeeRate lnwire.MilliSatoshi
-
-	// TimeLockDelta is the absolute time-lock value, expressed in blocks,
-	// that will be subtracted from an incoming HTLC's timelock value to
-	// create the time-lock value for the forwarded outgoing HTLC. The
-	// following constraint MUST hold for an HTLC to be forwarded:
-	//
-	//  * incomingHtlc.timeLock - timeLockDelta = fwdInfo.OutgoingCTLV
-	//
-	//    where fwdInfo is the forwarding information extracted from the
-	//    per-hop payload of the incoming HTLC's onion packet.
-	TimeLockDelta uint32
-
-	// TODO(roasbeef): add fee module inside of switch
-}
-
 // ExpectedFee computes the expected fee for a given htlc amount. The value
 // returned from this function is to be used as a sanity check when forwarding
 // HTLC's to ensure that an incoming HTLC properly adheres to our propagated
@@ -109,7 +71,7 @@ type ForwardingPolicy struct {
 //
 // TODO(roasbeef): also add in current available channel bandwidth, inverse
 // func
-func ExpectedFee(f ForwardingPolicy,
+func ExpectedFee(f models.ForwardingPolicy,
 	htlcAmt lnwire.MilliSatoshi) lnwire.MilliSatoshi {
 
 	return f.BaseFee + (htlcAmt*f.FeeRate)/1000000
@@ -123,7 +85,7 @@ type ChannelLinkConfig struct {
 	// deciding whether to forwarding incoming HTLC's or not. This value
 	// can be updated with subsequent calls to UpdateForwardingPolicy
 	// targeted at a given ChannelLink concrete interface implementation.
-	FwrdingPolicy ForwardingPolicy
+	FwrdingPolicy models.ForwardingPolicy
 
 	// Circuits provides restricted access to the switch's circuit map,
 	// allowing the link to open and close circuits.
@@ -2522,7 +2484,9 @@ func (l *channelLink) AttachMailBox(mailbox MailBox) {
 // update all of the link's FwrdingPolicy's values.
 //
 // NOTE: Part of the ChannelLink interface.
-func (l *channelLink) UpdateForwardingPolicy(newPolicy ForwardingPolicy) {
+func (l *channelLink) UpdateForwardingPolicy(
+	newPolicy models.ForwardingPolicy) {
+
 	l.Lock()
 	defer l.Unlock()
 
@@ -2627,7 +2591,7 @@ func (l *channelLink) CheckHtlcTransit(payHash [32]byte,
 
 // canSendHtlc checks whether the given htlc parameters satisfy
 // the channel's amount and time lock constraints.
-func (l *channelLink) canSendHtlc(policy ForwardingPolicy,
+func (l *channelLink) canSendHtlc(policy models.ForwardingPolicy,
 	payHash [32]byte, amt lnwire.MilliSatoshi, timeout uint32,
 	heightNow uint32, originalScid lnwire.ShortChannelID) *LinkError {
 

--- a/htlcswitch/link_test.go
+++ b/htlcswitch/link_test.go
@@ -23,6 +23,7 @@ import (
 	sphinx "github.com/lightningnetwork/lightning-onion"
 	"github.com/lightningnetwork/lnd/build"
 	"github.com/lightningnetwork/lnd/channeldb"
+	"github.com/lightningnetwork/lnd/channeldb/models"
 	"github.com/lightningnetwork/lnd/contractcourt"
 	"github.com/lightningnetwork/lnd/htlcswitch/hodl"
 	"github.com/lightningnetwork/lnd/htlcswitch/hop"
@@ -1925,7 +1926,7 @@ func newSingleLinkTestHarness(t *testing.T, chanAmt, chanReserve btcutil.Amount)
 			sentMsgs: make(chan lnwire.Message, 2000),
 			quit:     make(chan struct{}),
 		}
-		globalPolicy = ForwardingPolicy{
+		globalPolicy = models.ForwardingPolicy{
 			MinHTLCOut:    lnwire.NewMSatFromSatoshis(5),
 			MaxHTLC:       lnwire.NewMSatFromSatoshis(chanAmt),
 			BaseFee:       lnwire.NewMSatFromSatoshis(1),
@@ -4374,7 +4375,7 @@ func (h *persistentLinkHarness) restartLink(
 			quit:     make(chan struct{}),
 		}
 
-		globalPolicy = ForwardingPolicy{
+		globalPolicy = models.ForwardingPolicy{
 			MinHTLCOut:    lnwire.NewMSatFromSatoshis(5),
 			BaseFee:       lnwire.NewMSatFromSatoshis(1),
 			TimeLockDelta: 6,
@@ -5630,7 +5631,7 @@ func TestExpectedFee(t *testing.T) {
 	}
 
 	for _, test := range testCases {
-		f := ForwardingPolicy{
+		f := models.ForwardingPolicy{
 			BaseFee: test.baseFee,
 			FeeRate: test.feeRate,
 		}
@@ -5716,7 +5717,7 @@ func TestCheckHtlcForward(t *testing.T) {
 
 	link := channelLink{
 		cfg: ChannelLinkConfig{
-			FwrdingPolicy: ForwardingPolicy{
+			FwrdingPolicy: models.ForwardingPolicy{
 				TimeLockDelta: 20,
 				MinHTLCOut:    500,
 				MaxHTLC:       1000,

--- a/htlcswitch/mock.go
+++ b/htlcswitch/mock.go
@@ -840,7 +840,7 @@ func (f *mockChannelLink) getDustClosure() dustClosure {
 func (f *mockChannelLink) HandleChannelUpdate(lnwire.Message) {
 }
 
-func (f *mockChannelLink) UpdateForwardingPolicy(_ ForwardingPolicy) {
+func (f *mockChannelLink) UpdateForwardingPolicy(_ models.ForwardingPolicy) {
 }
 func (f *mockChannelLink) CheckHtlcForward([32]byte, lnwire.MilliSatoshi,
 	lnwire.MilliSatoshi, uint32, uint32, uint32,

--- a/htlcswitch/switch.go
+++ b/htlcswitch/switch.go
@@ -611,7 +611,7 @@ func (s *Switch) SendHTLC(firstHop lnwire.ShortChannelID, attemptID uint64,
 // forwarding policies for all links have been updated, or the switch shuts
 // down.
 func (s *Switch) UpdateForwardingPolicies(
-	chanPolicies map[wire.OutPoint]ForwardingPolicy) {
+	chanPolicies map[wire.OutPoint]models.ForwardingPolicy) {
 
 	log.Tracef("Updating link policies: %v", newLogClosure(func() string {
 		return spew.Sdump(chanPolicies)

--- a/htlcswitch/test_utils.go
+++ b/htlcswitch/test_utils.go
@@ -23,6 +23,7 @@ import (
 	"github.com/go-errors/errors"
 	sphinx "github.com/lightningnetwork/lightning-onion"
 	"github.com/lightningnetwork/lnd/channeldb"
+	"github.com/lightningnetwork/lnd/channeldb/models"
 	"github.com/lightningnetwork/lnd/contractcourt"
 	"github.com/lightningnetwork/lnd/htlcswitch/hop"
 	"github.com/lightningnetwork/lnd/input"
@@ -1069,7 +1070,7 @@ func createTwoClusterChannels(t *testing.T, aliceToBob,
 // hopNetwork is the base struct for two and three hop networks
 type hopNetwork struct {
 	feeEstimator *mockFeeEstimator
-	globalPolicy ForwardingPolicy
+	globalPolicy models.ForwardingPolicy
 	obfuscator   hop.ErrorEncrypter
 
 	defaultDelta uint32
@@ -1078,7 +1079,7 @@ type hopNetwork struct {
 func newHopNetwork() *hopNetwork {
 	defaultDelta := uint32(6)
 
-	globalPolicy := ForwardingPolicy{
+	globalPolicy := models.ForwardingPolicy{
 		MinHTLCOut:    lnwire.NewMSatFromSatoshis(5),
 		BaseFee:       lnwire.NewMSatFromSatoshis(1),
 		TimeLockDelta: defaultDelta,

--- a/peer/brontide.go
+++ b/peer/brontide.go
@@ -21,6 +21,7 @@ import (
 	"github.com/lightningnetwork/lnd/build"
 	"github.com/lightningnetwork/lnd/chainntnfs"
 	"github.com/lightningnetwork/lnd/channeldb"
+	"github.com/lightningnetwork/lnd/channeldb/models"
 	"github.com/lightningnetwork/lnd/channelnotifier"
 	"github.com/lightningnetwork/lnd/contractcourt"
 	"github.com/lightningnetwork/lnd/discovery"
@@ -234,7 +235,7 @@ type Config struct {
 
 	// RoutingPolicy is used to set the forwarding policy for links created by
 	// the Brontide.
-	RoutingPolicy htlcswitch.ForwardingPolicy
+	RoutingPolicy models.ForwardingPolicy
 
 	// Sphinx is used when setting up ChannelLinks so they can decode sphinx
 	// onion blobs.
@@ -877,9 +878,9 @@ func (p *Brontide) loadActiveChannels(chans []*channeldb.OpenChannel) (
 		// If we don't yet have an advertised routing policy, then
 		// we'll use the current default, otherwise we'll translate the
 		// routing policy into a forwarding policy.
-		var forwardingPolicy *htlcswitch.ForwardingPolicy
+		var forwardingPolicy *models.ForwardingPolicy
 		if selfPolicy != nil {
-			forwardingPolicy = &htlcswitch.ForwardingPolicy{
+			forwardingPolicy = &models.ForwardingPolicy{
 				MinHTLCOut:    selfPolicy.MinHTLC,
 				MaxHTLC:       selfPolicy.MaxHTLC,
 				BaseFee:       selfPolicy.FeeBaseMSat,
@@ -934,7 +935,7 @@ func (p *Brontide) loadActiveChannels(chans []*channeldb.OpenChannel) (
 // addLink creates and adds a new ChannelLink from the specified channel.
 func (p *Brontide) addLink(chanPoint *wire.OutPoint,
 	lnChan *lnwallet.LightningChannel,
-	forwardingPolicy *htlcswitch.ForwardingPolicy,
+	forwardingPolicy *models.ForwardingPolicy,
 	chainEvents *contractcourt.ChainEventSubscription,
 	syncStates bool) error {
 
@@ -3839,7 +3840,7 @@ func (p *Brontide) addActiveChannel(c *channeldb.OpenChannel) error {
 	// the total value of outstanding HTLCs.
 	fwdMinHtlc := lnChan.FwdMinHtlc()
 	defaultPolicy := p.cfg.RoutingPolicy
-	forwardingPolicy := &htlcswitch.ForwardingPolicy{
+	forwardingPolicy := &models.ForwardingPolicy{
 		MinHTLCOut:    fwdMinHtlc,
 		MaxHTLC:       c.LocalChanCfg.MaxPendingAmount,
 		BaseFee:       defaultPolicy.BaseFee,

--- a/routing/localchans/manager.go
+++ b/routing/localchans/manager.go
@@ -7,8 +7,8 @@ import (
 
 	"github.com/btcsuite/btcd/wire"
 	"github.com/lightningnetwork/lnd/channeldb"
+	"github.com/lightningnetwork/lnd/channeldb/models"
 	"github.com/lightningnetwork/lnd/discovery"
-	"github.com/lightningnetwork/lnd/htlcswitch"
 	"github.com/lightningnetwork/lnd/kvdb"
 	"github.com/lightningnetwork/lnd/lnrpc"
 	"github.com/lightningnetwork/lnd/lnwire"
@@ -21,7 +21,7 @@ type Manager struct {
 	// UpdateForwardingPolicies is used by the manager to update active
 	// links with a new policy.
 	UpdateForwardingPolicies func(
-		chanPolicies map[wire.OutPoint]htlcswitch.ForwardingPolicy)
+		chanPolicies map[wire.OutPoint]models.ForwardingPolicy)
 
 	// PropagateChanPolicyUpdate is called to persist a new policy to disk
 	// and broadcast it to the network.
@@ -66,7 +66,7 @@ func (r *Manager) UpdatePolicy(newSchema routing.ChannelPolicy,
 
 	var failedUpdates []*lnrpc.FailedUpdate
 	var edgesToUpdate []discovery.EdgeWithInfo
-	policiesToUpdate := make(map[wire.OutPoint]htlcswitch.ForwardingPolicy)
+	policiesToUpdate := make(map[wire.OutPoint]models.ForwardingPolicy)
 
 	// Next, we'll loop over all the outgoing channels the router knows of.
 	// If we have a filter then we'll only collected those channels,
@@ -106,7 +106,7 @@ func (r *Manager) UpdatePolicy(newSchema routing.ChannelPolicy,
 		})
 
 		// Add updated policy to list of policies to send to switch.
-		policiesToUpdate[info.ChannelPoint] = htlcswitch.ForwardingPolicy{
+		policiesToUpdate[info.ChannelPoint] = models.ForwardingPolicy{
 			BaseFee:       edge.FeeBaseMSat,
 			FeeRate:       edge.FeeProportionalMillionths,
 			TimeLockDelta: uint32(edge.TimeLockDelta),

--- a/routing/localchans/manager_test.go
+++ b/routing/localchans/manager_test.go
@@ -7,8 +7,8 @@ import (
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcd/wire"
 	"github.com/lightningnetwork/lnd/channeldb"
+	"github.com/lightningnetwork/lnd/channeldb/models"
 	"github.com/lightningnetwork/lnd/discovery"
-	"github.com/lightningnetwork/lnd/htlcswitch"
 	"github.com/lightningnetwork/lnd/kvdb"
 	"github.com/lightningnetwork/lnd/lnrpc"
 	"github.com/lightningnetwork/lnd/lnwire"
@@ -50,7 +50,7 @@ func TestManager(t *testing.T) {
 	}
 
 	updateForwardingPolicies := func(
-		chanPolicies map[wire.OutPoint]htlcswitch.ForwardingPolicy) {
+		chanPolicies map[wire.OutPoint]models.ForwardingPolicy) {
 
 		if len(chanPolicies) == 0 {
 			return

--- a/server.go
+++ b/server.go
@@ -1297,6 +1297,7 @@ func newServer(cfg *Config, listenAddrs []net.Addr,
 			return cc.Wallet.LabelTransaction(hash, label, true)
 		},
 		Notifier:     cc.ChainNotifier,
+		ChannelDB:    s.chanStateDB,
 		FeeEstimator: cc.FeeEstimator,
 		SignMessage:  cc.MsgSigner.SignMessage,
 		CurrentNodeAnnouncement: func() (lnwire.NodeAnnouncement,

--- a/server.go
+++ b/server.go
@@ -1459,9 +1459,8 @@ func newServer(cfg *Config, listenAddrs []net.Addr,
 		RegisteredChains:              cfg.registeredChains,
 		MaxAnchorsCommitFeeRate: chainfee.SatPerKVByte(
 			s.cfg.MaxCommitFeeRateAnchors * 1000).FeePerKWeight(),
-		DeleteAliasEdge:          deleteAliasEdge,
-		AliasManager:             s.aliasMgr,
-		UpdateForwardingPolicies: s.htlcSwitch.UpdateForwardingPolicies,
+		DeleteAliasEdge: deleteAliasEdge,
+		AliasManager:    s.aliasMgr,
 	})
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Partially reverts changes of #7597, in order to fix an itest flake.