### PR TITLE
lnwire: signature parsing/conversion fuzz tests

### DIFF
--- a/docs/release-notes/release-notes-0.17.0.md
+++ b/docs/release-notes/release-notes-0.17.0.md
@@ -54,6 +54,11 @@ unlock or create.
   `github.com/golang/protobuf/jsonpb`
   module](https://github.com/lightningnetwork/lnd/pull/7659).
 
+## Testing
+
+* [Added fuzz tests](https://github.com/lightningnetwork/lnd/pull/7649) for
+  signature parsing and conversion.
+
 # Contributors (Alphabetical Order)
 
 * Carla Kirk-Cohen
@@ -62,6 +67,7 @@ unlock or create.
 * Erik Arvstedt
 * hieblmi
 * Jordi Montes
+* Matt Morehouse
 * Michael Street
 * Oliver Gugger
 * ziggie1984

--- a/lnwire/fuzz_test.go
+++ b/lnwire/fuzz_test.go
@@ -822,3 +822,24 @@ func FuzzCustomMessage(f *testing.F) {
 		harness(t, data)
 	})
 }
+
+// FuzzParseRawSignature tests that our DER-encoded signature parsing does not
+// panic for arbitrary inputs and that serializing and reparsing the signatures
+// does not mutate them.
+func FuzzParseRawSignature(f *testing.F) {
+	f.Fuzz(func(t *testing.T, data []byte) {
+		sig, err := NewSigFromRawSignature(data)
+		if err != nil {
+			return
+		}
+
+		sig2, err := NewSigFromRawSignature(sig.ToSignatureBytes())
+		if err != nil {
+			t.Fatalf("failed to reparse signature: %v", err)
+		}
+
+		if !reflect.DeepEqual(sig, sig2) {
+			t.Fatalf("signature mismatch: %v != %v", sig, sig2)
+		}
+	})
+}


### PR DESCRIPTION
We call lnwire's signature parsing and conversion functions from many places in LND, often with untrusted inputs, and existing fuzz tests had incomplete coverage of these functions.

No crashes found after 100+ CPU-hours of fuzzing for each fuzz target.