### PR TITLE
lnwire: encode channel_update type in onion errors

### DIFF
--- a/lnwire/onion_error.go
+++ b/lnwire/onion_error.go
@@ -697,21 +697,12 @@ func (f *FailTemporaryChannelFailure) Decode(r io.Reader, pver uint32) error {
 func (f *FailTemporaryChannelFailure) Encode(w *bytes.Buffer,
 	pver uint32) error {
 
-	var payload []byte
 	if f.Update != nil {
-		var bw bytes.Buffer
-		if err := f.Update.Encode(&bw, pver); err != nil {
-			return err
-		}
-		payload = bw.Bytes()
+		return writeOnionErrorChanUpdate(w, f.Update, pver)
 	}
 
-	if err := WriteUint16(w, uint16(len(payload))); err != nil {
-		return err
-	}
-
-	_, err := w.Write(payload)
-	return err
+	// Write zero length to indicate no channel_update is present.
+	return WriteUint16(w, 0)
 }
 
 // FailAmountBelowMinimum is returned if the HTLC does not reach the current
@@ -1468,13 +1459,13 @@ func writeOnionErrorChanUpdate(w *bytes.Buffer, chanUpdate *ChannelUpdate,
 	// First, we encode the channel update in a temporary buffer in order
 	// to get the exact serialized size.
 	var b bytes.Buffer
-	if err := chanUpdate.Encode(&b, pver); err != nil {
+	updateLen, err := WriteMessage(&b, chanUpdate, pver)
+	if err != nil {
 		return err
 	}
 
 	// Now that we know the size, we can write the length out in the main
 	// writer.
-	updateLen := b.Len()
 	if err := WriteUint16(w, uint16(updateLen)); err != nil {
 		return err
 	}

--- a/lnwire/onion_error_test.go
+++ b/lnwire/onion_error_test.go
@@ -184,15 +184,15 @@ func TestWriteOnionErrorChanUpdate(t *testing.T) {
 	// raw serialized length.
 	var b bytes.Buffer
 	update := testChannelUpdate
-	if err := update.Encode(&b, 0); err != nil {
+	trueUpdateLength, err := WriteMessage(&b, &update, 0)
+	if err != nil {
 		t.Fatalf("unable to write update: %v", err)
 	}
-	trueUpdateLength := b.Len()
 
 	// Next, we'll use the function to encode the update as we would in a
 	// onion error message.
 	var errorBuf bytes.Buffer
-	err := writeOnionErrorChanUpdate(&errorBuf, &update, 0)
+	err = writeOnionErrorChanUpdate(&errorBuf, &update, 0)
 	require.NoError(t, err, "unable to encode onion error")
 
 	// Finally, read the length encoded and ensure that it matches the raw


### PR DESCRIPTION
For about [a year](https://github.com/lightning/bolts/pull/979), the spec has prescribed encoding `channel_updates` with their type prefix (`0x0102`) in onion failure messages. LND can decode correctly with or without the prefix but hasn't been writing the prefix during encoding. This PR starts writing the prefix.

I ran across this while running some new encoding/decoding fuzz tests for onion errors, which I intend to submit in a separate PR.  Those fuzz tests offer additional regression testing for this change.

Resolves https://github.com/lightningnetwork/lnd/issues/6461.