### PR TITLE
[skip ci] htlcswitch: fix double sat/kw output

### DIFF
--- a/htlcswitch/link.go
+++ b/htlcswitch/link.go
@@ -2771,7 +2771,7 @@ func (l *channelLink) ShutdownIfChannelClean() error {
 // updateChannelFee updates the commitment fee-per-kw on this channel by
 // committing to an update_fee message.
 func (l *channelLink) updateChannelFee(feePerKw chainfee.SatPerKWeight) error {
-	l.log.Infof("updating commit fee to %v sat/kw", feePerKw)
+	l.log.Infof("updating commit fee to %v", feePerKw)
 
 	// We skip sending the UpdateFee message if the channel is not
 	// currently eligible to forward messages.


### PR DESCRIPTION
## Change Description

While analysing a bug this small output redundancy caught my eye, the type SatPerKWeight already has the dimension in it:

```
13:58:28.355 [INF] HSWC: ChannelLink(3d18e199b8b8e3a2da0e905d379125707b5148440d5e9387934cfbf1813bbaac:1): updating commit fee to 750 sat/kw sat/kw

```
