### PR TITLE
Restore support for `PKCS8`-encoded cert private keys

### DIFF
--- a/docs/release-notes/release-notes-0.17.0.md
+++ b/docs/release-notes/release-notes-0.17.0.md
@@ -33,11 +33,14 @@
 independently](https://github.com/lightningnetwork/lnd/pull/7592) on wallet
 unlock or create.
 
+* [Restore support](https://github.com/lightningnetwork/lnd/pull/7678) for
+  `PKCS8`-encoded cert private keys.
 
 # Contributors (Alphabetical Order)
 
 * Carla Kirk-Cohen
 * Daniel McNally
 * Elle Mouton
+* Erik Arvstedt
 * hieblmi
 * Jordi Montes

--- a/tls_manager.go
+++ b/tls_manager.go
@@ -35,7 +35,10 @@ const (
 
 var (
 	// privateKeyPrefix is the prefix to a plaintext TLS key.
-	privateKeyPrefix = []byte("-----BEGIN EC PRIVATE KEY-----")
+	// It should match these two key formats:
+	// - `-----BEGIN PRIVATE KEY-----`    (PKCS8).
+	// - `-----BEGIN EC PRIVATE KEY-----` (SEC1/rfc5915, the legacy format).
+	privateKeyPrefix = []byte("-----BEGIN ")
 
 	// letsEncryptTimeout sets a timeout for the Lets Encrypt server.
 	letsEncryptTimeout = 5 * time.Second


### PR DESCRIPTION
#### Copy of commit msg
c0f44a17b75784f018652cb382c6ef4cd34d7ae0, available since `v0.16.x`, broke support for certificate private keys encoded in the widely-used
`PKCS8` format.

#### Discussion
`PKCS8` is also used by [nix-bitcoin](https://nixbitcoin.org/)'s cert generation scheme for lnd instances.
Consequently, lnd `v0.16.x` is broken on all nix-bitcoin based deployments.

Further reading: [ECDSA private key formats (stackexchange)](https://security.stackexchange.com/a/218410).

This PR has a trivial fix.
To make this more robust and handle some rare edge cases that were previously covered by the prefix check, we might want to use a regexp or a double string match instead.