### PR TITLE
contractcourt: don't factor in dust HTLCS into go-to-chain decisions

### DIFF
--- a/contractcourt/channel_arbitrator.go
+++ b/contractcourt/channel_arbitrator.go
@@ -1549,6 +1549,13 @@ func (c *ChannelArbitrator) shouldGoOnChain(htlc channeldb.HTLC,
 		return true
 	}
 
+	// If this is a dust HTLC, then we don't want this to factor into our
+	// decision to go to chain as we'll likley end up spending more in
+	// chain costs.
+	if htlc.OutputIndex < 0 {
+		return false
+	}
+
 	// For htlcs that are result of our initiated payments we give some grace
 	// period before force closing the channel. During this time we expect
 	// both nodes to connect and give a chance to the other node to send its
@@ -1592,8 +1599,8 @@ func (c *ChannelArbitrator) checkCommitChainActions(height uint32,
 	for _, htlc := range htlcs.outgoingHTLCs {
 		// We'll need to go on-chain for an outgoing HTLC if it was
 		// never resolved downstream, and it's "close" to timing out.
-		toChain := c.shouldGoOnChain(htlc, c.cfg.OutgoingBroadcastDelta,
-			height,
+		toChain := c.shouldGoOnChain(
+			htlc, c.cfg.OutgoingBroadcastDelta, height,
 		)
 
 		if toChain {
@@ -1627,8 +1634,8 @@ func (c *ChannelArbitrator) checkCommitChainActions(height uint32,
 			continue
 		}
 
-		toChain := c.shouldGoOnChain(htlc, c.cfg.IncomingBroadcastDelta,
-			height,
+		toChain := c.shouldGoOnChain(
+			htlc, c.cfg.IncomingBroadcastDelta, height,
 		)
 
 		if toChain {


### PR DESCRIPTION
In this commit, we modify our go to chain heuristics to ensure that we won't force close due to dust HTLCs. Dust HTLCs can't actually be claimed on chain, so we only have a direct cost by going on chain.

This is a very simple PoC implementation, to demonstrate a possible fix. In the past, there were questions on if this violated the spec as it states:

> if an HTLC which it offered is in either node's current commitment
> transaction, AND is past this timeout deadline: MUST fail the channel.

Where fail the channel here means to force close. However, it's easy to come up with some scenarios (namely high chain fees) where it doesn't make economic sense to go to chain with a very small valued HTLC. As a force close is required, the on chain fee needs to be paid, and also the funds are locked for the CSV duration.

We can further extend this logic by integrating components of #3955 that attempts to compute the total sweep cost for an HTLC. This'll expand the heuristic to keeping the channel open for very small HTLCs, that may actually be beyond dust.

One down side of this type of change is that these HTLCs will still occupy space towards the current 488 HTLC limit. In the past, it had been suggested that we should actually have two limits: one for dust HTLCs, and one for regular HTLCs. In the future, we may be able to introduce this extra set of flow control constraints using dynamic commitments.

Fixes https://github.com/lightningnetwork/lnd/issues/1226

## Change Description
Description of change / link to associated issue.

## Steps to Test
Steps for reviewers to follow to test the change.

## Pull Request Checklist
### Testing
- [ ] Your PR passes all CI checks.
- [ ] Tests covering the positive and negative (error paths) are included.
- [ ] Bug fixes contain tests triggering the bug to prevent regressions.

### Code Style and Documentation
- [ ] The change obeys the [Code Documentation and Commenting](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#CodeDocumentation) guidelines, and lines wrap at 80.
- [ ] Commits follow the [Ideal Git Commit Structure](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#IdealGitCommitStructure).
- [ ] Any new logging statements use an appropriate subsystem and logging level.
- [ ]  [There is a change description in the release notes](https://github.com/lightningnetwork/lnd/tree/master/docs/release-notes), or `[skip ci]` in the commit message for small changes.

📝 Please see our  [Contribution Guidelines](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md) for further guidance.