### PR TITLE
lncli: Global flags to accept ENV vars overrides

### DIFF
--- a/cmd/lncli/main.go
+++ b/cmd/lncli/main.go
@@ -34,6 +34,18 @@ const (
 	defaultMacaroonFilename = "admin.macaroon"
 	defaultRPCPort          = "10009"
 	defaultRPCHostPort      = "localhost:" + defaultRPCPort
+
+	envVarRPCServer       = "LNCLI_RPCSERVER"
+	envVarLNDDir          = "LNCLI_LNDDIR"
+	envVarSOCKSProxy      = "LNCLI_SOCKSPROXY"
+	envVarTLSCertPath     = "LNCLI_TLSCERTPATH"
+	envVarChain           = "LNCLI_CHAIN"
+	envVarNetwork         = "LNCLI_NETWORK"
+	envVarMacaroonPath    = "LNCLI_MACAROONPATH"
+	envVarMacaroonTimeout = "LNCLI_MACAROONTIMEOUT"
+	envVarMacaroonIP      = "LNCLI_MACAROONIP"
+	envVarProfile         = "LNCLI_PROFILE"
+	envVarMacFromJar      = "LNCLI_MACFROMJAR"
 )
 
 var (
@@ -342,38 +354,44 @@ func main() {
 	app.Usage = "control plane for your Lightning Network Daemon (lnd)"
 	app.Flags = []cli.Flag{
 		cli.StringFlag{
-			Name:  "rpcserver",
-			Value: defaultRPCHostPort,
-			Usage: "The host:port of LN daemon.",
+			Name:   "rpcserver",
+			Value:  defaultRPCHostPort,
+			Usage:  "The host:port of LN daemon.",
+			EnvVar: envVarRPCServer,
 		},
 		cli.StringFlag{
 			Name:      "lnddir",
 			Value:     defaultLndDir,
 			Usage:     "The path to lnd's base directory.",
 			TakesFile: true,
+			EnvVar:    envVarLNDDir,
 		},
 		cli.StringFlag{
 			Name: "socksproxy",
 			Usage: "The host:port of a SOCKS proxy through " +
 				"which all connections to the LN " +
 				"daemon will be established over.",
+			EnvVar: envVarSOCKSProxy,
 		},
 		cli.StringFlag{
 			Name:      "tlscertpath",
 			Value:     defaultTLSCertPath,
 			Usage:     "The path to lnd's TLS certificate.",
 			TakesFile: true,
+			EnvVar:    envVarTLSCertPath,
 		},
 		cli.StringFlag{
-			Name:  "chain, c",
-			Usage: "The chain lnd is running on, e.g. bitcoin.",
-			Value: "bitcoin",
+			Name:   "chain, c",
+			Usage:  "The chain lnd is running on, e.g. bitcoin.",
+			Value:  "bitcoin",
+			EnvVar: envVarChain,
 		},
 		cli.StringFlag{
 			Name: "network, n",
 			Usage: "The network lnd is running on, e.g. mainnet, " +
 				"testnet, etc.",
-			Value: "mainnet",
+			Value:  "mainnet",
+			EnvVar: envVarNetwork,
 		},
 		cli.BoolFlag{
 			Name:  "no-macaroons",
@@ -383,15 +401,19 @@ func main() {
 			Name:      "macaroonpath",
 			Usage:     "The path to macaroon file.",
 			TakesFile: true,
+			EnvVar:    envVarMacaroonPath,
 		},
 		cli.Int64Flag{
 			Name:  "macaroontimeout",
 			Value: 60,
-			Usage: "Anti-replay macaroon validity time in seconds.",
+			Usage: "Anti-replay macaroon validity time in " +
+				"seconds.",
+			EnvVar: envVarMacaroonTimeout,
 		},
 		cli.StringFlag{
-			Name:  "macaroonip",
-			Usage: "If set, lock macaroon to specific IP address.",
+			Name:   "macaroonip",
+			Usage:  "If set, lock macaroon to specific IP address.",
+			EnvVar: envVarMacaroonIP,
 		},
 		cli.StringFlag{
 			Name: "profile, p",
@@ -401,12 +423,14 @@ func main() {
 				"a default profile is set, this flag can be " +
 				"set to an empty string to disable reading " +
 				"values from the profiles file.",
+			EnvVar: envVarProfile,
 		},
 		cli.StringFlag{
 			Name: "macfromjar",
 			Usage: "Use this macaroon from the profile's " +
 				"macaroon jar instead of the default one. " +
 				"Can only be used if profiles are defined.",
+			EnvVar: envVarMacFromJar,
 		},
 		cli.StringSliceFlag{
 			Name: "metadata",

--- a/docs/release-notes/release-notes-0.17.0.md
+++ b/docs/release-notes/release-notes-0.17.0.md
@@ -77,6 +77,10 @@ unlock or create.
 * [Added fuzz tests](https://github.com/lightningnetwork/lnd/pull/7649) for
   signature parsing and conversion.
 
+## `lncli`
+
+* Added ability to use [ENV variables to override `lncli` global flags](https://github.com/lightningnetwork/lnd/pull/7693). Flags will have preference over ENVs.
+
 # Contributors (Alphabetical Order)
 
 * Carla Kirk-Cohen
@@ -84,6 +88,7 @@ unlock or create.
 * Elle Mouton
 * Erik Arvstedt
 * ErikEk
+* Guillermo Caracuel
 * hieblmi
 * Jordi Montes
 * Matt Morehouse


### PR DESCRIPTION
## Change Description
Adds ability to global flags to de config using ENV variables.
This is extremely useful when running `lncli` in containers and lnd not using default values or they do not exist at all.

## Steps to Test
Compile `lncli` run no command or help command manually.
Testing is covered by `urfave/cli` library

## Pull Request Checklist
### Testing
- [x] Your PR passes all CI checks.
- [x] Tests covering the positive and negative (error paths) are included.
- [x] Bug fixes contain tests triggering the bug to prevent regressions.

### Code Style and Documentation
- [x] The change obeys the [Code Documentation and Commenting](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#CodeDocumentation) guidelines, and lines wrap at 80.
- [x] Commits follow the [Ideal Git Commit Structure](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#IdealGitCommitStructure).
- [x] Any new logging statements use an appropriate subsystem and logging level.
- [x]  [There is a change description in the release notes](https://github.com/lightningnetwork/lnd/tree/master/docs/release-notes), or `[skip ci]` in the commit message for small changes.

📝 Please see our  [Contribution Guidelines](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md) for further guidance.