### PR TITLE
macaroons: ensure all root keys are re-encrypted or regenerated

### DIFF
--- a/docs/release-notes/release-notes-0.17.0.md
+++ b/docs/release-notes/release-notes-0.17.0.md
@@ -49,6 +49,10 @@ unlock or create.
 * [Restore support](https://github.com/lightningnetwork/lnd/pull/7678) for
   `PKCS8`-encoded cert private keys.
 
+* [Re-encrypt/regenerate](https://github.com/lightningnetwork/lnd/issues/7704) 
+  all macaroon DB root keys on `ChangePassword`/`GenerateNewRootKey` 
+  respectively.
+
 ## Code Health
 
 * Updated [our fork for serializing protobuf as JSON to be based on the

--- a/macaroons/store.go
+++ b/macaroons/store.go
@@ -54,6 +54,10 @@ var (
 	// ErrEncKeyNotFound specifies that there was no encryption key found
 	// even if one was expected to be generated.
 	ErrEncKeyNotFound = fmt.Errorf("macaroon encryption key not found")
+
+	// ErrDefaultRootKeyNotFound is returned when the default root key is
+	// not found in the DB when it is expected to be.
+	ErrDefaultRootKeyNotFound = fmt.Errorf("default root key not found")
 )
 
 // RootKeyStorage implements the bakery.RootKeyStorage interface.
@@ -140,8 +144,8 @@ func (r *RootKeyStorage) CreateUnlock(password *[]byte) error {
 	}, func() {})
 }
 
-// ChangePassword decrypts the macaroon root key with the old password and then
-// encrypts it again with the new password.
+// ChangePassword decrypts all the macaroon root keys with the old password and
+// then encrypts them again with the new password.
 func (r *RootKeyStorage) ChangePassword(oldPw, newPw []byte) error {
 	// We need the store to already be unlocked. With this we can make sure
 	// that there already is a key in the DB.
@@ -159,12 +163,11 @@ func (r *RootKeyStorage) ChangePassword(oldPw, newPw []byte) error {
 		if bucket == nil {
 			return ErrRootKeyBucketNotFound
 		}
-		encKeyDb := bucket.Get(encryptionKeyID)
-		rootKeyDb := bucket.Get(DefaultRootKeyID)
 
-		// Both the encryption key and the root key must be present
-		// otherwise we are in the wrong state to change the password.
-		if len(encKeyDb) == 0 || len(rootKeyDb) == 0 {
+		// The encryption key must be present, otherwise we are in the
+		// wrong state to change the password.
+		encKeyDb := bucket.Get(encryptionKeyID)
+		if len(encKeyDb) == 0 {
 			return ErrEncKeyNotFound
 		}
 
@@ -188,21 +191,44 @@ func (r *RootKeyStorage) ChangePassword(oldPw, newPw []byte) error {
 			return err
 		}
 
-		// Now try to decrypt the root key with the old encryption key,
-		// encrypt it with the new one and then store it in the DB.
-		decryptedKey, err := encKeyOld.Decrypt(rootKeyDb)
+		// foundDefaultRootKey is used to keep track of if we have
+		// found and re-encrypted the default root key so that we can
+		// return an error if it is not found.
+		var foundDefaultRootKey bool
+		err = bucket.ForEach(func(k, v []byte) error {
+			// Skip the key if it is the encryption key ID since
+			// we do not want to re-encrypt this.
+			if bytes.Equal(k, encryptionKeyID) {
+				return nil
+			}
+
+			if bytes.Equal(k, DefaultRootKeyID) {
+				foundDefaultRootKey = true
+			}
+
+			// Now try to decrypt the root key with the old
+			// encryption key, encrypt it with the new one and then
+			// store it in the DB.
+			decryptedKey, err := encKeyOld.Decrypt(v)
+			if err != nil {
+				return err
+			}
+			rootKey := make([]byte, len(decryptedKey))
+			copy(rootKey, decryptedKey)
+
+			encryptedKey, err := encKeyNew.Encrypt(rootKey)
+			if err != nil {
+				return err
+			}
+
+			return bucket.Put(k, encryptedKey)
+		})
 		if err != nil {
 			return err
 		}
-		rootKey := make([]byte, len(decryptedKey))
-		copy(rootKey, decryptedKey)
-		encryptedKey, err := encKeyNew.Encrypt(rootKey)
-		if err != nil {
-			return err
-		}
-		err = bucket.Put(DefaultRootKeyID, encryptedKey)
-		if err != nil {
-			return err
+
+		if !foundDefaultRootKey {
+			return ErrDefaultRootKeyNotFound
 		}
 
 		// Finally, store the new encryption key parameters in the DB

--- a/macaroons/store.go
+++ b/macaroons/store.go
@@ -351,10 +351,33 @@ func (r *RootKeyStorage) GenerateNewRootKey() error {
 		if bucket == nil {
 			return ErrRootKeyBucketNotFound
 		}
+
+		// The default root key should be created even if it does not
+		// yet exist, so we do this separately from the rest of the
+		// root keys.
 		_, err := generateAndStoreNewRootKey(
 			bucket, DefaultRootKeyID, r.encKey,
 		)
-		return err
+		if err != nil {
+			return err
+		}
+
+		// Now iterate over all the other root keys that may exist
+		// and re-generate each of them.
+		return bucket.ForEach(func(k, v []byte) error {
+			if bytes.Equal(k, encryptionKeyID) {
+				return nil
+			}
+
+			if bytes.Equal(k, DefaultRootKeyID) {
+				return nil
+			}
+
+			_, err := generateAndStoreNewRootKey(
+				bucket, k, r.encKey,
+			)
+			return err
+		})
 	}, func() {})
 }
 


### PR DESCRIPTION
Currently, the macaroon store `ChangePassword` method will only re-encrypt the root key stored at the 
default root key ID location (0) and `GenerateNewRootKey` will only re-generate the root key stored at the default location. This PR updates these methods so that all root keys stored in the db are re-encrypted/re-generated respectively.

This will fix an issue noticed in Litd: https://github.com/lightninglabs/lightning-terminal/issues/549