### PR TITLE
watchtower: miscellaneous fixes

### DIFF
--- a/watchtower/blob/type.go
+++ b/watchtower/blob/type.go
@@ -67,6 +67,20 @@ const (
 	TypeRewardCommit = Type(FlagCommitOutputs | FlagReward)
 )
 
+// Identifier returns a unique, stable string identifier for the blob Type.
+func (t Type) Identifier() (string, error) {
+	switch t {
+	case TypeAltruistCommit:
+		return "legacy", nil
+	case TypeAltruistAnchorCommit:
+		return "anchor", nil
+	case TypeRewardCommit:
+		return "reward", nil
+	default:
+		return "", fmt.Errorf("unknown blob type: %v", t)
+	}
+}
+
 // Has returns true if the Type has the passed flag enabled.
 func (t Type) Has(flag Flag) bool {
 	return Flag(t)&flag == flag

--- a/watchtower/wtclient/client.go
+++ b/watchtower/wtclient/client.go
@@ -678,7 +678,11 @@ func (c *TowerClient) Start() error {
 
 		// Start the task pipeline to which new backup tasks will be
 		// submitted from active links.
-		c.pipeline.Start()
+		err = c.pipeline.Start()
+		if err != nil {
+			returnErr = err
+			return
+		}
 
 		c.wg.Add(1)
 		go c.backupDispatcher()
@@ -727,7 +731,10 @@ func (c *TowerClient) Stop() error {
 
 		// 4. Since all valid tasks have been assigned to session
 		// queues, we no longer need to negotiate sessions.
-		c.negotiator.Stop()
+		err = c.negotiator.Stop()
+		if err != nil {
+			returnErr = err
+		}
 
 		c.log.Debugf("Waiting for active session queues to finish "+
 			"draining, stats: %s", c.stats)

--- a/watchtower/wtclient/client.go
+++ b/watchtower/wtclient/client.go
@@ -350,10 +350,12 @@ func New(config *Config) (*TowerClient, error) {
 		cfg.WriteTimeout = DefaultWriteTimeout
 	}
 
-	prefix := "(legacy)"
-	if cfg.Policy.IsAnchorChannel() {
-		prefix = "(anchor)"
+	identifier, err := cfg.Policy.BlobType.Identifier()
+	if err != nil {
+		return nil, err
 	}
+	prefix := fmt.Sprintf("(%s)", identifier)
+
 	plog := build.NewPrefixLog(prefix, log)
 
 	// Load the sweep pkscripts that have been generated for all previously
@@ -363,10 +365,7 @@ func New(config *Config) (*TowerClient, error) {
 		return nil, err
 	}
 
-	var (
-		policy  = cfg.Policy.BlobType.String()
-		queueDB = cfg.DB.GetDBQueue([]byte(policy))
-	)
+	queueDB := cfg.DB.GetDBQueue([]byte(identifier))
 	queue, err := NewDiskOverflowQueue[*wtdb.BackupID](
 		queueDB, cfg.MaxTasksInMemQueue, plog,
 	)


### PR DESCRIPTION
This PR is a small follow up to https://github.com/lightningnetwork/lnd/pull/7380 which added a disk over flow queue to the tower client. 

The first commit adds a few missing error checks. The second commit, changes the identifier used by the client to store its
disk queue under to be a more stable value. This is required because currently, the `blob.Type` `String` method is used to get an identifier but this value is _not stable_ because the name includes any feature bits that it does _not include_. In other words, we could have a situation where we have an anchor client. Its Blob String would return: `[FlagAnchorChannel|FlagCommitOutputs|No-FlagReward]` but then as soon as we start supporting taproot channels and add a taproot client, the value for the anchor client will change to: `[No-FlagTaprootChannel|FlagAnchorChannel|FlagCommitOutputs|No-FlagReward]`. This would create a new disk queue instead of reading from the existing one. 

So the second commit ensures that a stable identifier is used (ex, `anchor`, `legacy` etc)

