### PR TITLE
lntest: set ReadHeaderTimeout for http client

### DIFF
--- a/config.go
+++ b/config.go
@@ -227,7 +227,7 @@ const (
 	defaultGrpcClientPingMinWait = 5 * time.Second
 
 	// defaultHTTPHeaderTimeout is the default timeout for HTTP requests.
-	defaultHTTPHeaderTimeout = 5 * time.Second
+	DefaultHTTPHeaderTimeout = 5 * time.Second
 
 	// BitcoinChainName is a string that represents the Bitcoin blockchain.
 	BitcoinChainName = "bitcoin"
@@ -702,7 +702,7 @@ func DefaultConfig() Config {
 			ClientPingMinWait: defaultGrpcClientPingMinWait,
 		},
 		WtClient:          lncfg.DefaultWtClientCfg(),
-		HTTPHeaderTimeout: defaultHTTPHeaderTimeout,
+		HTTPHeaderTimeout: DefaultHTTPHeaderTimeout,
 	}
 }
 

--- a/config.go
+++ b/config.go
@@ -226,6 +226,9 @@ const (
 	// client should wait before sending a keepalive ping.
 	defaultGrpcClientPingMinWait = 5 * time.Second
 
+	// defaultHTTPHeaderTimeout is the default timeout for HTTP requests.
+	defaultHTTPHeaderTimeout = 5 * time.Second
+
 	// BitcoinChainName is a string that represents the Bitcoin blockchain.
 	BitcoinChainName = "bitcoin"
 
@@ -492,6 +495,10 @@ type Config struct {
 	// Dev specifies configs used for integration tests, which is always
 	// empty if not built with `integration` flag.
 	Dev *lncfg.DevConfig `group:"dev" namespace:"dev"`
+
+	// HTTPHeaderTimeout is the maximum duration that the server will wait
+	// before timing out reading the headers of an HTTP request.
+	HTTPHeaderTimeout time.Duration `long:"http-header-timeout" description:"The maximum duration that the server will wait before timing out reading the headers of an HTTP request."`
 }
 
 // GRPCConfig holds the configuration options for the gRPC server.
@@ -694,7 +701,8 @@ func DefaultConfig() Config {
 			ServerPingTimeout: defaultGrpcServerPingTimeout,
 			ClientPingMinWait: defaultGrpcClientPingMinWait,
 		},
-		WtClient: lncfg.DefaultWtClientCfg(),
+		WtClient:          lncfg.DefaultWtClientCfg(),
+		HTTPHeaderTimeout: defaultHTTPHeaderTimeout,
 	}
 }
 

--- a/docs/release-notes/release-notes-0.18.0.md
+++ b/docs/release-notes/release-notes-0.18.0.md
@@ -8,14 +8,16 @@
   - [Functional Updates](#functional-updates)
   - [RPC Updates](#rpc-updates)
   - [lncli Updates](#lncli-updates)
+  - [Code Health](#code-health)
   - [Breaking Changes](#breaking-changes)
   - [Performance Improvements](#performance-improvements)
- - [Technical and Architectural Updates](#technical-and-architectural-updates)
-   - [BOLT Spec Updates](#bolt-spec-updates)
-   - [Testing](#testing)
-   - [Database](#database)
-   - [Code Health](#code-health)
-   - [Tooling and Documentation](#tooling-and-documentation)
+- [Technical and Architectural Updates](#technical-and-architectural-updates)
+  - [BOLT Spec Updates](#bolt-spec-updates)
+  - [Testing](#testing)
+  - [Database](#database)
+  - [Code Health](#code-health-1)
+  - [Tooling and Documentation](#tooling-and-documentation)
+- [Contributors (Alphabetical Order)](#contributors-alphabetical-order)
 
 # Bug Fixes
 
@@ -36,6 +38,8 @@
   and payment to blinded paths has been added via the `QueryRoutes` (and 
   SendToRouteV2) APIs. This functionality is surfaced in `lncli queryroutes` 
   where the required flags are tagged with `(blinded paths)`.
+* A new config value,
+  [http-header-timeout](https://github.com/lightningnetwork/lnd/pull/7715), is added so users can specify the amount of time the http server will wait for a request to complete before closing the connection. The default value is 5 seconds.
 
 ## RPC Additions
 ## lncli Additions
@@ -75,6 +79,7 @@
 
 # Contributors (Alphabetical Order)
 
+* Amin Bashiri
 * Andras Banki-Horvath
 * Carla Kirk-Cohen
 * Elle Mouton

--- a/lnd.go
+++ b/lnd.go
@@ -214,7 +214,7 @@ func Main(cfg *Config, lisCfg ListenerCfg, implCfg *ImplementationCfg,
 		pprofServer := &http.Server{
 			Addr:              cfg.Profile,
 			Handler:           pprofMux,
-			ReadHeaderTimeout: 5 * time.Second,
+			ReadHeaderTimeout: cfg.HTTPHeaderTimeout,
 		}
 
 		// Shut the server down when lnd is shutting down.
@@ -271,6 +271,8 @@ func Main(cfg *Config, lisCfg ListenerCfg, implCfg *ImplementationCfg,
 		LetsEncryptListen: cfg.LetsEncryptListen,
 
 		DisableRestTLS: cfg.DisableRestTLS,
+
+		HTTPHeaderTimeout: cfg.HTTPHeaderTimeout,
 	}
 	tlsManager := NewTLSManager(tlsManagerCfg)
 	serverOpts, restDialOpts, restListen, cleanUp,

--- a/lntest/fee_service.go
+++ b/lntest/fee_service.go
@@ -9,6 +9,7 @@ import (
 	"sync"
 	"testing"
 
+	"github.com/lightningnetwork/lnd"
 	"github.com/lightningnetwork/lnd/lntest/node"
 	"github.com/lightningnetwork/lnd/lnwallet/chainfee"
 	"github.com/stretchr/testify/require"
@@ -81,8 +82,9 @@ func NewFeeService(t *testing.T) *FeeService {
 	mux.HandleFunc("/fee-estimates.json", f.handleRequest)
 
 	f.srv = &http.Server{
-		Addr:    listenAddr,
-		Handler: mux,
+		Addr:              listenAddr,
+		Handler:           mux,
+		ReadHeaderTimeout: lnd.DefaultHTTPHeaderTimeout,
 	}
 
 	return &f

--- a/sample-lnd.conf
+++ b/sample-lnd.conf
@@ -519,6 +519,9 @@
 ; intelligence services.
 ; color=#3399FF
 
+; The maximum duration that the server will wait before timing out reading
+; the headers of an HTTP request.
+; http-header-timeout=5s
 
 [prometheus]
 

--- a/tls_manager.go
+++ b/tls_manager.go
@@ -39,9 +39,6 @@ var (
 	// - `-----BEGIN PRIVATE KEY-----`    (PKCS8).
 	// - `-----BEGIN EC PRIVATE KEY-----` (SEC1/rfc5915, the legacy format).
 	privateKeyPrefix = []byte("-----BEGIN ")
-
-	// letsEncryptTimeout sets a timeout for the Lets Encrypt server.
-	letsEncryptTimeout = 5 * time.Second
 )
 
 // TLSManagerCfg houses a set of values and methods that is passed to the
@@ -61,6 +58,8 @@ type TLSManagerCfg struct {
 	LetsEncryptListen string
 
 	DisableRestTLS bool
+
+	HTTPHeaderTimeout time.Duration
 }
 
 // TLSManager generates/renews a TLS cert/key pair when needed. When required,
@@ -424,7 +423,7 @@ func (t *TLSManager) setUpLetsEncrypt(certData *tls.Certificate,
 	srv := &http.Server{
 		Addr:              t.cfg.LetsEncryptListen,
 		Handler:           manager.HTTPHandler(nil),
-		ReadHeaderTimeout: letsEncryptTimeout,
+		ReadHeaderTimeout: t.cfg.HTTPHeaderTimeout,
 	}
 	shutdownCompleted := make(chan struct{})
 	cleanUp = func() {


### PR DESCRIPTION
## Change Description
Add ReadHeaderTimeout for HTTP client in lntests.
Fixes #7232 
The same code can be found here: https://github.com/lightningnetwork/lnd/blob/master/tls_manager.go#L424

## Steps to Test

## Pull Request Checklist
### Testing
- [ ] Your PR passes all CI checks.
- [ ] Tests covering the positive and negative (error paths) are included.
- [ ] Bug fixes contain tests triggering the bug to prevent regressions.

### Code Style and Documentation
- [ ] The change obeys the [Code Documentation and Commenting](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#CodeDocumentation) guidelines, and lines wrap at 80.
- [ ] Commits follow the [Ideal Git Commit Structure](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#IdealGitCommitStructure).
- [ ] Any new logging statements use an appropriate subsystem and logging level.
- [ ]  [There is a change description in the release notes](https://github.com/lightningnetwork/lnd/tree/master/docs/release-notes), or `[skip ci]` in the commit message for small changes.
