### PR TITLE
routing+lnrpc: subscribe payment stream before sending it

### DIFF
--- a/docs/release-notes/release-notes-0.17.0.md
+++ b/docs/release-notes/release-notes-0.17.0.md
@@ -77,6 +77,11 @@ unlock or create.
 
 * Added ability to use [ENV variables to override `lncli` global flags](https://github.com/lightningnetwork/lnd/pull/7693). Flags will have preference over ENVs.
 
+## Bug Fix
+
+* Make sure payment stream returns all the events by [subscribing it before
+  sending](https://github.com/lightningnetwork/lnd/pull/7722).
+
 # Contributors (Alphabetical Order)
 
 * Carla Kirk-Cohen

--- a/itest/lnd_multi-hop_test.go
+++ b/itest/lnd_multi-hop_test.go
@@ -1371,6 +1371,9 @@ func runMultiHopHtlcAggregation(ht *lntest.HarnessTest,
 	resp := carol.RPC.AddInvoice(invoice)
 	ht.CompletePaymentRequests(alice, []string{resp.PaymentRequest})
 
+	// Make sure Carol has settled the invoice.
+	ht.AssertInvoiceSettled(carol, resp.PaymentAddr)
+
 	// With the network active, we'll now add a new hodl invoices at both
 	// Alice's and Carol's end. Make sure the cltv expiry delta is large
 	// enough, otherwise Bob won't send out the outgoing htlc.


### PR DESCRIPTION
Fix an itest flake from [this build](https://github.com/lightningnetwork/lnd/actions/runs/5044112934/jobs/9046751557),
```
lnd_max_htlcs_test.go:141: 
        	Error Trace:	/home/runner/work/lnd/lnd/itest/lnd_max_htlcs_test.go:141
        	            				/home/runner/work/lnd/lnd/itest/lnd_max_htlcs_test.go:40
        	            				/home/runner/work/lnd/lnd/itest/harness.go:286
        	            				/home/runner/work/lnd/lnd/itest/lnd_test.go:136
        	Error:      	Should be empty, but was [attempt_id:4  route:{total_time_lock:1336  total_amt:10  hops:{chan_id:1372190511529985  chan_capacity:1000000  amt_to_forward:10  expiry:1336  amt_to_forward_msat:10000  pub_key:"03262458bb5f1c0684b26b595ae5a01fd64217d0087a481d62e61fb15f474f7014"  tlv_payload:true  mpp_record:{payment_addr:"W\x1d\x01\x0f\xd4W\xa8\xfc\xa5\xf6\xf4\xa2\xeanU\xd1\xcaw\x1c\xb6p\x86\xd2\xe7\xd1\xf4\x97v\x0c=G)"  total_amt_msat:10000}}  total_amt_msat:10000}  attempt_time_ns:1684749400511303408]
        	Test:       	TestLightningNetworkDaemon/tranche01/59-of-132/bitcoind/max_htlc_pathfind
```

This PR moves the subscription of a given payment before it's been sent so we won't miss any events.