### PR TITLE
contractcourt: force the sweeper to always resolve outgoing HTLCs

### DIFF
--- a/contractcourt/htlc_timeout_resolver.go
+++ b/contractcourt/htlc_timeout_resolver.go
@@ -327,6 +327,7 @@ func (h *htlcTimeoutResolver) sweepSecondLevelTx() error {
 			Fee: sweep.FeePreference{
 				ConfTarget: secondLevelConfTarget,
 			},
+			Force: true,
 		},
 	)
 

--- a/contractcourt/utxonursery.go
+++ b/contractcourt/utxonursery.go
@@ -781,9 +781,10 @@ func (u *UtxoNursery) sweepMatureOutputs(classHeight uint32,
 		// passed in with disastrous consequences.
 		local := output
 
-		resultChan, err := u.cfg.SweepInput(
-			&local, sweep.Params{Fee: feePref},
-		)
+		resultChan, err := u.cfg.SweepInput(&local, sweep.Params{
+			Fee:   feePref,
+			Force: true,
+		})
 		if err != nil {
 			return err
 		}

--- a/docs/release-notes/release-notes-0.16.3.md
+++ b/docs/release-notes/release-notes-0.16.3.md
@@ -20,6 +20,14 @@
   peer, then this'll force a reconnect, which may restart things and help avoid
   certain force close scenarios.
 
+
+## Consistent Contract Resolution
+
+* If lnd decides to go to chain for an HTLC, it will now _always_ ensure the
+  HTLC is fully swept on the outgoing link. Prior logic would avoid sweeping
+  due to negative yield, but combined with other inputs, the HTLC will usually
+  be positive yield.
+
 # Contributors (Alphabetical Order)
 
 * Elle Mouton


### PR DESCRIPTION
In this commit, we attempt to fix an issue that may lead to force closes due to small value HTLCs. The sweeper has built in a "negative yield" heuristic where it won't sweep something that'll result in paying more fees than the HTLC amount. However for HTLCs, we want to always sweep them, as we don't cancel back the HTLCs before the outgoing contract is fully resolved.

In the future, we'll start to make more economical decisions about if we should go to chain at all for small value HTLCs, and also do things like cancel back early if the HTLC is small and we think we might be contested by chain fees.