### PR TITLE
tlsmanager: fix autocert autogeneration

### DIFF
--- a/docs/release-notes/release-notes-0.17.0.md
+++ b/docs/release-notes/release-notes-0.17.0.md
@@ -164,6 +164,8 @@ unlock or create.
 
 * [Stop rejecting payments that overpay or over-timelock the final hop](https://github.com/lightningnetwork/lnd/pull/7768)
 
+* [Fix let's encrypt autocert generation](https://github.com/lightningnetwork/lnd/pull/7739)
+
 ### Tooling and documentation
 
 * Add support for [custom `RPCHOST` and
@@ -190,6 +192,7 @@ unlock or create.
 * hieblmi
 * Jordi Montes
 * Keagan McClelland
+* Konstantin Nick
 * Lele Calo
 * Matt Morehouse
 * Maxwell Sayles

--- a/tls_manager_test.go
+++ b/tls_manager_test.go
@@ -53,9 +53,9 @@ func TestGenerateOrRenewCert(t *testing.T) {
 		TLSCertDuration: testTLSCertDuration,
 	}
 	tlsManager := NewTLSManager(cfg)
-	_, cleanUp, err := tlsManager.generateOrRenewCert()
+	_, err := tlsManager.generateOrRenewCert()
 	require.NoError(t, err)
-	_, _, _, err = tlsManager.getConfig()
+	_, _, _, cleanUp, err := tlsManager.getConfig()
 	require.NoError(t, err, "couldn't retrieve TLS config")
 	t.Cleanup(cleanUp)
 
@@ -86,7 +86,7 @@ func TestTLSManagerGenCert(t *testing.T) {
 	}
 	tlsManager := NewTLSManager(cfg)
 
-	_, _, err := tlsManager.generateOrRenewCert()
+	_, err := tlsManager.generateOrRenewCert()
 	require.NoError(t, err, "failed to generate new certificate")
 
 	// After this is run, a new certificate should be created and written


### PR DESCRIPTION
As the getConfig() function would previously overwrite the GetCertificate function of the tls config, the autocert manager would never be used.

This PR moves the `setUpLetsEncrypt` func to where it would correctly override the `GetCertificate` function.


Closes https://github.com/lightningnetwork/lnd/issues/7734