### PR TITLE
funding: Add support for SCID Alias and Static Remote Key in channel funding

### DIFF
--- a/chanacceptor/rpcacceptor.go
+++ b/chanacceptor/rpcacceptor.go
@@ -332,6 +332,13 @@ func (r *RPCAcceptor) sendAcceptRequests(errChan chan error,
 					commitmentType = lnrpc.CommitmentType_ANCHORS
 
 				case channelFeatures.OnlyContains(
+					lnwire.ZeroConfRequired,
+					lnwire.ScidAliasRequired,
+					lnwire.StaticRemoteKeyRequired,
+				):
+					commitmentType = lnrpc.CommitmentType_STATIC_REMOTE_KEY
+
+				case channelFeatures.OnlyContains(
 					lnwire.StaticRemoteKeyRequired,
 				):
 					commitmentType = lnrpc.CommitmentType_STATIC_REMOTE_KEY

--- a/docs/release-notes/release-notes-0.17.0.md
+++ b/docs/release-notes/release-notes-0.17.0.md
@@ -62,6 +62,9 @@ unlock or create.
 * [Restore support](https://github.com/lightningnetwork/lnd/pull/7678) for
   `PKCS8`-encoded cert private keys.
 
+* [Add support for accepting Zero-Conf channels](https://github.com/lightningnetwork/lnd/pull/7740) with type `ScidAliasRequired` and  
+  `StaticRemoteKeyRequired`.
+
 ## Code Health
 
 * Updated [our fork for serializing protobuf as JSON to be based on the
@@ -99,6 +102,7 @@ unlock or create.
 * Elle Mouton
 * Erik Arvstedt
 * ErikEk
+* Graham Krizek
 * Guillermo Caracuel
 * hieblmi
 * Jordi Montes


### PR DESCRIPTION
## Change Description

Resolves #7642 

This PR adds support for LND to receive zero conf channels that support ScidAliasRequired and StaticRemoteKeyRequired. This is necessary for compatibility with other implementations until other implementations have better support for Anchors.

## Steps to Test

- Run CoreLN 23.05
- Run this PR for LND
- Run a channel acceptor on LND to allow for zero-conf channels
- Attempt a zero-conf channel open from CoreLN into LND

## Pull Request Checklist
### Testing
- [ ] Your PR passes all CI checks.
- [ ] Tests covering the positive and negative (error paths) are included.
- [ ] Bug fixes contain tests triggering the bug to prevent regressions.

### Code Style and Documentation
- [ ] The change obeys the [Code Documentation and Commenting](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#CodeDocumentation) guidelines, and lines wrap at 80.
- [ ] Commits follow the [Ideal Git Commit Structure](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#IdealGitCommitStructure).
- [ ] Any new logging statements use an appropriate subsystem and logging level.
- [ ]  [There is a change description in the release notes](https://github.com/lightningnetwork/lnd/tree/master/docs/release-notes), or `[skip ci]` in the commit message for small changes.

📝 Please see our  [Contribution Guidelines](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md) for further guidance.