### PR TITLE
fix: use full image name for gen_protos_docker.sh

### DIFF
--- a/lnrpc/gen_protos_docker.sh
+++ b/lnrpc/gen_protos_docker.sh
@@ -6,7 +6,7 @@ set -e
 DIR="$(cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd)"
 
 # golang docker image version used in this script.
-GO_IMAGE=golang:1.20.4-alpine
+GO_IMAGE=docker.io/library/golang:1.20.4-alpine
 
 PROTOBUF_VERSION=$(docker run --rm -v $DIR/../:/lnd -w /lnd $GO_IMAGE \
   go list -f '{{.Version}}' -m google.golang.org/protobuf)


### PR DESCRIPTION
## Change Description
By defining the full name for the docker image we avoid the issue that occurs when using `podman` (tested on Fedora 38) where podman will prompt the user for what docker repository to pull the image from.

## Steps to Test
Run  `gen_protos_docker.sh` on a system with podman installed (and symlinked to `docker`). 

## Pull Request Checklist
### Testing
- [ ] Your PR passes all CI checks.