### PR TITLE
Set Dont_Forward bit in Channel Update Message

### DIFF
--- a/docs/release-notes/release-notes-0.18.0.md
+++ b/docs/release-notes/release-notes-0.18.0.md
@@ -46,6 +46,8 @@
 
 # Technical and Architectural Updates
 ## BOLT Spec Updates
+* Make sure to [set the dont_forward msg flag in the channel update msg 
+  for unannounced channels](https://github.com/lightningnetwork/lnd/pull/7759).
 ## Testing
 ## Database
 ## Code Health
@@ -55,3 +57,5 @@
 
 * Elle Mouton
 * Yong Yu
+* ziggie1984
+

--- a/itest/lnd_zero_conf_test.go
+++ b/itest/lnd_zero_conf_test.go
@@ -177,8 +177,6 @@ func testZeroConfChannelOpen(ht *lntest.HarnessTest) {
 	payReq := eve.RPC.DecodePayReq(eveInvoiceResp.PaymentRequest)
 	require.Len(ht, payReq.RouteHints, 0)
 
-	// Make sure Dave is aware of this channel and send the payment.
-	ht.AssertTopologyChannelOpen(dave, fundingPoint3)
 	ht.CompletePaymentRequests(
 		dave, []string{eveInvoiceResp.PaymentRequest},
 	)

--- a/lnwire/channel_update.go
+++ b/lnwire/channel_update.go
@@ -16,6 +16,10 @@ const (
 	// ChanUpdateRequiredMaxHtlc is a bit that indicates whether the
 	// required htlc_maximum_msat field is present in this ChannelUpdate.
 	ChanUpdateRequiredMaxHtlc ChanUpdateMsgFlags = 1 << iota
+
+	// ChanUpdateDontForward is a bit that indicates whether the ChanUpdate
+	// msg should be forwarded to other peers when received.
+	ChanUpdateDontForward
 )
 
 // String returns the bitfield flags as a string.
@@ -27,6 +31,12 @@ func (c ChanUpdateMsgFlags) String() string {
 // message flags.
 func (c ChanUpdateMsgFlags) HasMaxHtlc() bool {
 	return c&ChanUpdateRequiredMaxHtlc != 0
+}
+
+// HasDontForward returns true if the dont_forward option bit is set in the
+// message flags.
+func (c ChanUpdateMsgFlags) HasDontForward() bool {
+	return c&ChanUpdateDontForward != 0
 }
 
 // ChanUpdateChanFlags is a bitfield that signals various options concerning a

--- a/routing/notifications.go
+++ b/routing/notifications.go
@@ -102,7 +102,7 @@ func (r *ChannelRouter) SubscribeTopology() (*TopologyClient, error) {
 // notification channel.
 type topologyClient struct {
 	// ntfnChan is a send-only channel that's used to propagate
-	// notification s from the channel router to an instance of a
+	// notifications from the channel router to an instance of a
 	// topologyClient client.
 	ntfnChan chan<- *TopologyChange
 

--- a/routing/router.go
+++ b/routing/router.go
@@ -1746,7 +1746,9 @@ func (r *ChannelRouter) processUpdate(msg interface{},
 		// new edge policy to the proper directional edge within the
 		// channel graph.
 		if err = r.cfg.Graph.UpdateEdgePolicy(msg, op...); err != nil {
-			err := errors.Errorf("unable to add channel: %v", err)
+			err := errors.Errorf("unable to update channel "+
+				"policy: %v", err)
+
 			log.Error(err)
 			return err
 		}
@@ -2749,11 +2751,19 @@ func (r *ChannelRouter) IsStaleEdgePolicy(chanID lnwire.ShortChannelID,
 	// A flag set of 0 indicates this is an announcement for the "first"
 	// node in the channel.
 	case flags&lnwire.ChanUpdateDirection == 0:
+		log.Trace("ChannelUpdate for edge %v, last update_time=%v, "+
+			"new update_time=%v", chanID.ToUint64(),
+			edge1Timestamp.Unix(), timestamp.Unix())
+
 		return !edge1Timestamp.Before(timestamp)
 
 	// Similarly, a flag set of 1 indicates this is an announcement for the
 	// "second" node in the channel.
 	case flags&lnwire.ChanUpdateDirection == 1:
+		log.Trace("ChannelUpdate for edge %v, last update_time=%v, "+
+			"new update_time=%v", chanID.ToUint64(),
+			edge2Timestamp.Unix(), timestamp.Unix())
+
 		return !edge2Timestamp.Before(timestamp)
 	}
 


### PR DESCRIPTION
Fixes #7416

## Change Description
According to the Specification we must set the `dont_forward` bit when we send a `channelupdate` msg to the peer.
With this change we make sure that our local channel updates for unannounced channels have this bit set. 
Moreover we are performing a migration on the fly for all old unannounced channels as soon as the channel policy is updated.

~~We currently do not use this flag for our own decisions when forwarding a channel_update to the broader network (we use the `AuthProof` instead but we have to introduce this change to be spec. compliant.~~

Currently no new tests where added. Tests in the `gossiper_test.go` are not affected by this change because the bit is set on higher levels. But open for discussions regarding more tests. 

## Steps to Test
Steps for reviewers to follow to test the change.

## Pull Request Checklist
### Testing
- [x] Your PR passes all CI checks.
- [x] Tests covering the positive and negative (error paths) are included.
- [x] Bug fixes contain tests triggering the bug to prevent regressions.

### Code Style and Documentation
- [x] The change obeys the [Code Documentation and Commenting](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#CodeDocumentation) guidelines, and lines wrap at 80.
- [x] Commits follow the [Ideal Git Commit Structure](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#IdealGitCommitStructure).
- [x] Any new logging statements use an appropriate subsystem and logging level.
- [x]  [There is a change description in the release notes](https://github.com/lightningnetwork/lnd/tree/master/docs/release-notes), or `[skip ci]` in the commit message for small changes.

📝 Please see our  [Contribution Guidelines](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md) for further guidance.


<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/lightningnetwork/lnd/7759)
<!-- Reviewable:end -->
