### PR TITLE
Better temp miner management and more verbose loggings

### DIFF
--- a/lntest/btcd.go
+++ b/lntest/btcd.go
@@ -21,12 +21,6 @@ import (
 // logDirPattern is the pattern of the name of the temporary log directory.
 const logDirPattern = "%s/.backendlogs"
 
-// temp is used to signal we want to establish a temporary connection using the
-// btcd Node API.
-//
-// NOTE: Cannot be const, since the node API expects a reference.
-var temp = "temp"
-
 // BtcdBackendConfig is an implementation of the BackendConfig interface
 // backed by a btcd node.
 type BtcdBackendConfig struct {

--- a/peer/brontide.go
+++ b/peer/brontide.go
@@ -1099,7 +1099,7 @@ func (p *Brontide) readNextMessage() (lnwire.Message, error) {
 
 	pktLen, err := noiseConn.ReadNextHeader()
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("read next header: %w", err)
 	}
 
 	// First we'll read the next _full_ message. We do this rather than
@@ -1128,7 +1128,7 @@ func (p *Brontide) readNextMessage() (lnwire.Message, error) {
 		// pool.
 		rawMsg, readErr := noiseConn.ReadNextBody(buf[:pktLen])
 		if readErr != nil {
-			return readErr
+			return fmt.Errorf("read next body: %w", readErr)
 		}
 		msgLen = uint64(len(rawMsg))
 

--- a/server.go
+++ b/server.go
@@ -4012,6 +4012,7 @@ func (s *server) peerTerminationWatcher(p *peer.Brontide, ready chan struct{}) {
 	// If the server is exiting then we can bail out early ourselves as all
 	// the other sub-systems will already be shutting down.
 	if s.Stopped() {
+		srvrLog.Debugf("Server quitting, exit early for peer %v", p)
 		return
 	}
 


### PR DESCRIPTION
Some code changes from working on other issues - one commit for decreasing duplication round temp miner creation and the other for more verbose logging.