### PR TITLE
Export unmarshall outpoint functionality

### DIFF
--- a/lnrpc/walletrpc/walletkit_server.go
+++ b/lnrpc/walletrpc/walletkit_server.go
@@ -464,7 +464,7 @@ func (w *WalletKit) LeaseOutput(ctx context.Context,
 		return nil, errors.New("reserved id cannot be used")
 	}
 
-	op, err := unmarshallOutPoint(req.Outpoint)
+	op, err := UnmarshallOutPoint(req.Outpoint)
 	if err != nil {
 		return nil, err
 	}
@@ -505,7 +505,7 @@ func (w *WalletKit) ReleaseOutput(ctx context.Context,
 	var lockID wtxmgr.LockID
 	copy(lockID[:], req.Id)
 
-	op, err := unmarshallOutPoint(req.Outpoint)
+	op, err := UnmarshallOutPoint(req.Outpoint)
 	if err != nil {
 		return nil, err
 	}
@@ -807,9 +807,9 @@ func (w *WalletKit) PendingSweeps(ctx context.Context,
 	}, nil
 }
 
-// unmarshallOutPoint converts an outpoint from its lnrpc type to its canonical
+// UnmarshallOutPoint converts an outpoint from its lnrpc type to its canonical
 // type.
-func unmarshallOutPoint(op *lnrpc.OutPoint) (*wire.OutPoint, error) {
+func UnmarshallOutPoint(op *lnrpc.OutPoint) (*wire.OutPoint, error) {
 	if op == nil {
 		return nil, fmt.Errorf("empty outpoint provided")
 	}
@@ -851,7 +851,7 @@ func (w *WalletKit) BumpFee(ctx context.Context,
 	in *BumpFeeRequest) (*BumpFeeResponse, error) {
 
 	// Parse the outpoint from the request.
-	op, err := unmarshallOutPoint(in.Outpoint)
+	op, err := UnmarshallOutPoint(in.Outpoint)
 	if err != nil {
 		return nil, err
 	}
@@ -1125,7 +1125,7 @@ func (w *WalletKit) FundPsbt(_ context.Context,
 
 		txIn := make([]*wire.OutPoint, len(tpl.Inputs))
 		for idx, in := range tpl.Inputs {
-			op, err := unmarshallOutPoint(in)
+			op, err := UnmarshallOutPoint(in)
 			if err != nil {
 				return nil, fmt.Errorf("error parsing "+
 					"outpoint: %v", err)

--- a/lnrpc/walletrpc/walletkit_server.go
+++ b/lnrpc/walletrpc/walletkit_server.go
@@ -816,12 +816,10 @@ func UnmarshallOutPoint(op *lnrpc.OutPoint) (*wire.OutPoint, error) {
 
 	var hash chainhash.Hash
 	switch {
+	// Return an error if both txid fields are unpopulated.
 	case len(op.TxidBytes) == 0 && len(op.TxidStr) == 0:
-		fallthrough
-
-	case len(op.TxidBytes) != 0 && len(op.TxidStr) != 0:
-		return nil, fmt.Errorf("either TxidBytes or TxidStr must be " +
-			"specified, but not both")
+		return nil, fmt.Errorf("TxidBytes and TxidStr are both " +
+			"unspecified")
 
 	// The hash was provided as raw bytes.
 	case len(op.TxidBytes) != 0:


### PR DESCRIPTION
## Change Description
This PR exports the existing `walletkit` function
```
unmarshallOutPoint(op *lnrpc.OutPoint) (*wire.OutPoint, error)
```
I think this function should be exported because it is useful when interpreting RPC return data.

This PR also modifies `unmarshallOutPoint` such that it accepts an `lnrpc.OutPoint` which has both txid fields populated. I think this change is useful because some RPC endpoints return `lnrpc.OutPoint` with both txid fields populated (`WalletKit.ListLeases` is one such RPC endpoint). I don't see why it should raise an error rather than make a best attempt at unmarshalling.

## Steps to Test
Ensure unit tests and itests pass.

## Pull Request Checklist
### Testing
- [ ] Your PR passes all CI checks.
- [ ] Tests covering the positive and negative (error paths) are included.
- [ ] Bug fixes contain tests triggering the bug to prevent regressions.

### Code Style and Documentation
- [ ] The change obeys the [Code Documentation and Commenting](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#CodeDocumentation) guidelines, and lines wrap at 80.
- [ ] Commits follow the [Ideal Git Commit Structure](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#IdealGitCommitStructure).
- [ ] Any new logging statements use an appropriate subsystem and logging level.
- [ ]  [There is a change description in the release notes](https://github.com/lightningnetwork/lnd/tree/master/docs/release-notes), or `[skip ci]` in the commit message for small changes.

📝 Please see our  [Contribution Guidelines](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md) for further guidance.