### PR TITLE
multi: add tower config defaults

### DIFF
--- a/config.go
+++ b/config.go
@@ -638,9 +638,7 @@ func DefaultConfig() Config {
 			ChannelCacheSize: channeldb.DefaultChannelCacheSize,
 		},
 		Prometheus: lncfg.DefaultPrometheus(),
-		Watchtower: &lncfg.Watchtower{
-			TowerDir: defaultTowerDir,
-		},
+		Watchtower: lncfg.DefaultWatchtowerCfg(defaultTowerDir),
 		HealthChecks: &lncfg.HealthCheckConfig{
 			ChainCheck: &lncfg.CheckConfig{
 				Interval: defaultChainInterval,

--- a/config.go
+++ b/config.go
@@ -713,6 +713,7 @@ func DefaultConfig() Config {
 			ServerPingTimeout: defaultGrpcServerPingTimeout,
 			ClientPingMinWait: defaultGrpcClientPingMinWait,
 		},
+		WtClient: lncfg.DefaultWtClientCfg(),
 	}
 }
 

--- a/docs/release-notes/release-notes-0.17.0.md
+++ b/docs/release-notes/release-notes-0.17.0.md
@@ -12,8 +12,18 @@
   wtdb.BackupIDs](https://github.com/lightningnetwork/lnd/pull/7623) instead of 
   the entire retribution struct. This reduces the amount of data that needs to 
   be held in memory. 
+ 
 * [Replace in-mem task pipeline with a disk-overflow
   queue](https://github.com/lightningnetwork/lnd/pull/7380)
+ 
+* [Add defaults](https://github.com/lightningnetwork/lnd/pull/7771) to the 
+  wtclient and watchtower config structs and use these to populate the defaults 
+  of the main LND config struct so that the defaults appear in the `lnd --help` 
+  command output. 
+ 
+* The deprecated "wtclient.private-tower-uris" option has also been 
+  [removed](https://github.com/lightningnetwork/lnd/pull/7771). This field was 
+  deprecated in v0.8.0-beta. 
  
 ## Misc
 

--- a/lncfg/watchtower.go
+++ b/lncfg/watchtower.go
@@ -13,3 +13,14 @@ type Watchtower struct {
 
 	watchtower.Conf
 }
+
+// DefaultWatchtowerCfg creates a Watchtower with some default values filled
+// out.
+func DefaultWatchtowerCfg(defaultTowerDir string) *Watchtower {
+	conf := watchtower.DefaultConf()
+
+	return &Watchtower{
+		TowerDir: defaultTowerDir,
+		Conf:     *conf,
+	}
+}

--- a/lncfg/wtclient.go
+++ b/lncfg/wtclient.go
@@ -15,10 +15,6 @@ type WtClient struct {
 	// back up channel states with registered watchtowers.
 	Active bool `long:"active" description:"Whether the daemon should use private watchtowers to back up revoked channel states."`
 
-	// PrivateTowerURIs specifies the lightning URIs of the towers the
-	// watchtower client should send new backups to.
-	PrivateTowerURIs []string `long:"private-tower-uris" description:"(Deprecated) Specifies the URIs of private watchtowers to use in backing up revoked states. URIs must be of the form <pubkey>@<addr>. Only 1 URI is supported at this time, if none are provided the tower will not be enabled."`
-
 	// SweepFeeRate specifies the fee rate in sat/byte to be used when
 	// constructing justice transactions sent to the tower.
 	SweepFeeRate uint64 `long:"sweep-fee-rate" description:"Specifies the fee rate in sat/byte to be used when constructing justice transactions sent to the watchtower."`
@@ -58,15 +54,6 @@ func DefaultWtClientCfg() *WtClient {
 //
 // NOTE: Part of the Validator interface.
 func (c *WtClient) Validate() error {
-	// TODO(wilmer): remove in v0.9.0 release.
-	if len(c.PrivateTowerURIs) > 0 {
-		return fmt.Errorf("the `wtclient.private-tower-uris` option " +
-			"has been deprecated as of v0.8.0-beta and will be " +
-			"removed in v0.9.0-beta. To setup watchtowers for " +
-			"the client, set `wtclient.active` and run " +
-			"`lncli wtclient -h` for more information")
-	}
-
 	if c.SweepFeeRate == 0 {
 		return fmt.Errorf("sweep-fee-rate must be non-zero")
 	}

--- a/sample-lnd.conf
+++ b/sample-lnd.conf
@@ -992,11 +992,6 @@ litecoin.node=ltcd
 ; specified in sat/byte, the default is 10 sat/byte.
 ; wtclient.sweep-fee-rate=10
 
-; (Deprecated) Specifies the URIs of private watchtowers to use in backing up
-; revoked states. URIs must be of the form <pubkey>@<addr>. Only 1 URI is
-; supported at this time, if none are provided the tower will not be enabled.
-; wtclient.private-tower-uris=
-
 ; The range over which to choose a random number of blocks to wait after the
 ; last channel of a session is closed before sending the DeleteSession message
 ; to the tower server. The default is currently 288. Note that setting this to

--- a/server.go
+++ b/server.go
@@ -1497,29 +1497,15 @@ func newServer(cfg *Config, listenAddrs []net.Addr,
 
 	if cfg.WtClient.Active {
 		policy := wtpolicy.DefaultPolicy()
+		policy.MaxUpdates = cfg.WtClient.MaxUpdates
 
-		if cfg.WtClient.SweepFeeRate != 0 {
-			// We expose the sweep fee rate in sat/vbyte, but the
-			// tower protocol operations on sat/kw.
-			sweepRateSatPerVByte := chainfee.SatPerKVByte(
-				1000 * cfg.WtClient.SweepFeeRate,
-			)
-			policy.SweepFeeRate = sweepRateSatPerVByte.FeePerKWeight()
-		}
+		// We expose the sweep fee rate in sat/vbyte, but the tower
+		// protocol operations on sat/kw.
+		sweepRateSatPerVByte := chainfee.SatPerKVByte(
+			1000 * cfg.WtClient.SweepFeeRate,
+		)
 
-		if cfg.WtClient.MaxUpdates != 0 {
-			policy.MaxUpdates = cfg.WtClient.MaxUpdates
-		}
-
-		sessionCloseRange := uint32(wtclient.DefaultSessionCloseRange)
-		if cfg.WtClient.SessionCloseRange != 0 {
-			sessionCloseRange = cfg.WtClient.SessionCloseRange
-		}
-
-		maxTasksInMemQueue := uint64(wtclient.DefaultMaxTasksInMemQueue)
-		if cfg.WtClient.MaxTasksInMemQueue != 0 {
-			maxTasksInMemQueue = cfg.WtClient.MaxTasksInMemQueue
-		}
+		policy.SweepFeeRate = sweepRateSatPerVByte.FeePerKWeight()
 
 		if err := policy.Validate(); err != nil {
 			return nil, err
@@ -1565,7 +1551,7 @@ func newServer(cfg *Config, listenAddrs []net.Addr,
 		s.towerClient, err = wtclient.New(&wtclient.Config{
 			FetchClosedChannel:     fetchClosedChannel,
 			BuildBreachRetribution: buildBreachRetribution,
-			SessionCloseRange:      sessionCloseRange,
+			SessionCloseRange:      cfg.WtClient.SessionCloseRange,
 			ChainNotifier:          s.cc.ChainNotifier,
 			SubscribeChannelEvents: func() (subscribe.Subscription,
 				error) {
@@ -1584,7 +1570,7 @@ func newServer(cfg *Config, listenAddrs []net.Addr,
 			MinBackoff:         10 * time.Second,
 			MaxBackoff:         5 * time.Minute,
 			ForceQuitDelay:     wtclient.DefaultForceQuitDelay,
-			MaxTasksInMemQueue: maxTasksInMemQueue,
+			MaxTasksInMemQueue: cfg.WtClient.MaxTasksInMemQueue,
 		})
 		if err != nil {
 			return nil, err
@@ -1599,7 +1585,7 @@ func newServer(cfg *Config, listenAddrs []net.Addr,
 		s.anchorTowerClient, err = wtclient.New(&wtclient.Config{
 			FetchClosedChannel:     fetchClosedChannel,
 			BuildBreachRetribution: buildBreachRetribution,
-			SessionCloseRange:      sessionCloseRange,
+			SessionCloseRange:      cfg.WtClient.SessionCloseRange,
 			ChainNotifier:          s.cc.ChainNotifier,
 			SubscribeChannelEvents: func() (subscribe.Subscription,
 				error) {
@@ -1618,7 +1604,7 @@ func newServer(cfg *Config, listenAddrs []net.Addr,
 			MinBackoff:         10 * time.Second,
 			MaxBackoff:         5 * time.Minute,
 			ForceQuitDelay:     wtclient.DefaultForceQuitDelay,
-			MaxTasksInMemQueue: maxTasksInMemQueue,
+			MaxTasksInMemQueue: cfg.WtClient.MaxTasksInMemQueue,
 		})
 		if err != nil {
 			return nil, err

--- a/watchtower/conf.go
+++ b/watchtower/conf.go
@@ -23,6 +23,14 @@ type Conf struct {
 	WriteTimeout time.Duration `long:"writetimeout" description:"Duration the watchtower server will wait for messages to be written before hanging up on client connections"`
 }
 
+// DefaultConf returns a Conf with some default values filled in.
+func DefaultConf() *Conf {
+	return &Conf{
+		ReadTimeout:  DefaultReadTimeout,
+		WriteTimeout: DefaultWriteTimeout,
+	}
+}
+
 // Apply completes the passed Config struct by applying any parsed Conf options.
 // If the corresponding values parsed by Conf are already set in the Config,
 // those fields will be not be modified.


### PR DESCRIPTION
Add `DefaultWtclientCfg` and `DefaultWatchtowerConfig` functions that populate 
defaults for the `lncfg.Wtclient` and `lncfg.Watchtower` config structs. These are 
then used in the main LND config struct so that the defaults are shown to a user  in 
the `lnd --help` command. 

This PR also removes the deprecated `PrivateTowerURIs` member from the `Wtclient`
config struct since it has been deprecated since `v0.8.0-beta` and currently LND would
fail to start if a user specified it. 

Fixes #7769 