### PR TITLE
scripts: update release notes check for merge queue usage

### DIFF
--- a/scripts/check-release-notes.sh
+++ b/scripts/check-release-notes.sh
@@ -8,8 +8,10 @@ PR_NUMBER=$(echo $GITHUB_REF | awk 'BEGIN { FS = "/" } ; { print $3 }')
 
 # If this is a PR being merged into the main repo, then the PR number will
 # actually be "master" here, so we'll ignore this case, and assume that in
-# order for it to be merged it had to pass the check in its base branch.
-if [ $PR_NUMBER == "master" ]; then
+# order for it to be merged it had to pass the check in its base branch. If
+# we're trying to merge this with the Merge Queue, then the PR number will be
+# "gh-readonly-queue" instead.
+if [ $PR_NUMBER == "master" ] || [ $PR_NUMBER == "gh-readonly-queue"]; then
     exit 0
 fi
 


### PR DESCRIPTION
Without this commit, PRs can fail to be merged via the merge queue, as it'll fail with this error:
```
Run scripts/check-release-notes.sh
PR gh-readonly-queue didn't update release notes
Error: Process completed with exit code 1.
```


Sample failugre: https://github.com/lightningnetwork/lnd/actions/runs/5274576933/jobs/9539169490