### PR TITLE
Change defaultMaxLocalCSVDelay to protect user from high delays

### DIFF
--- a/config.go
+++ b/config.go
@@ -175,9 +175,10 @@ const (
 	defaultRemoteMaxHtlcs = 483
 
 	// defaultMaxLocalCSVDelay is the maximum delay we accept on our
-	// commitment output.
-	// TODO(halseth): find a more scientific choice of value.
-	defaultMaxLocalCSVDelay = 10000
+	// commitment output. The local csv delay maximum is now equal to
+	// the remote csv delay maximum we require for the remote commitment
+	// transaction.
+	defaultMaxLocalCSVDelay = 2016
 
 	// defaultChannelCommitInterval is the default maximum time between
 	// receiving a channel state update and signing a new commitment.

--- a/docs/release-notes/release-notes-0.17.0.md
+++ b/docs/release-notes/release-notes-0.17.0.md
@@ -39,6 +39,10 @@ package](https://github.com/lightningnetwork/lnd/pull/7356)
 * [HTLC serialization updated](https://github.com/lightningnetwork/lnd/pull/7710) 
   to allow storing extra data transmitted in TLVs.
 
+* [MaxLocalCSVDelay now has a default value of 2016. It is still possible to 
+override this value with the config option --maxlocaldelay for those who rely
+on the old value of 10000](https://github.com/lightningnetwork/lnd/pull/7780).
+
 ## RPC
 
 * [SendOutputs](https://github.com/lightningnetwork/lnd/pull/7631) now adheres

--- a/funding/manager_test.go
+++ b/funding/manager_test.go
@@ -59,7 +59,7 @@ const (
 
 	// defaultMaxLocalCSVDelay is the maximum delay we accept on our
 	// commitment output.
-	defaultMaxLocalCSVDelay = 10000
+	defaultMaxLocalCSVDelay = 2016
 )
 
 var (


### PR DESCRIPTION
Relates to #7770 where we found that this asymmetry is not really practical especially because a node runner can suffer from a peer burdening him with a csv delay for the local outputs of almost 10 weeks.


## Pull Request Checklist
### Testing
- [x] Your PR passes all CI checks.
- [x] Tests covering the positive and negative (error paths) are included.
- [x] Bug fixes contain tests triggering the bug to prevent regressions.

### Code Style and Documentation
- [x] The change obeys the [Code Documentation and Commenting](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#CodeDocumentation) guidelines, and lines wrap at 80.
- [x] Commits follow the [Ideal Git Commit Structure](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#IdealGitCommitStructure).
- [x] Any new logging statements use an appropriate subsystem and logging level.
- [x]  [There is a change description in the release notes](https://github.com/lightningnetwork/lnd/tree/master/docs/release-notes), or `[skip ci]` in the commit message for small changes.

📝 Please see our  [Contribution Guidelines](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md) for further guidance.