### PR TITLE
tor: short circuit host lookup if connecting to IP

### DIFF
--- a/tor/tor.go
+++ b/tor/tor.go
@@ -220,12 +220,20 @@ func ResolveTCPAddr(address, socksAddr string) (*net.TCPAddr, error) {
 		return nil, err
 	}
 
-	ip, err := LookupHost(host, socksAddr)
+	p, err := strconv.Atoi(port)
 	if err != nil {
 		return nil, err
 	}
 
-	p, err := strconv.Atoi(port)
+	// Do we already have an IP? Then we don't need to look up anything.
+	if ip := net.ParseIP(host); ip != nil {
+		return &net.TCPAddr{
+			IP:   ip,
+			Port: p,
+		}, nil
+	}
+
+	ip, err := LookupHost(host, socksAddr)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
With this commit we avoid calling LookupHost if we already have an IPv4 or IPv6 address, as we can return that directly.
This avoids asking Tor to resolve an IPv6 address, which it cannot do.

See https://github.com/lightningnetwork/lnd/issues/6493 for context.
This does not yet fix that issue, as we'll need to push a tag for the `tor` submodule first and create another PR. That's why this one also doesn't contain a change log and skips integration tests.