### PR TITLE
brontide: refactor peer to prepare channel ready fix

### DIFF
--- a/peer/test_utils.go
+++ b/peer/test_utils.go
@@ -408,7 +408,7 @@ func createTestPeer(t *testing.T, notifier chainntnfs.ChainNotifier,
 	alicePeer.remoteFeatures = lnwire.NewFeatureVector(nil, lnwire.Features)
 
 	chanID := lnwire.NewChanIDFromOutPoint(channelAlice.ChannelPoint())
-	alicePeer.activeChannels[chanID] = channelAlice
+	alicePeer.activeChannels.Store(chanID, channelAlice)
 
 	alicePeer.wg.Add(1)
 	go alicePeer.channelManager()


### PR DESCRIPTION
This PR extracts the first 5 commits from #7518 to provide a better view experience. In this PR, we focus on replacing normal maps with `SyncMap`, providing abstracted methods to determine a given channel's state(pending/active/loaded from disk), and adding a new method `handleNewActiveChannel` to handle new channels in a more structured manner.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/lightningnetwork/lnd/7794)
<!-- Reviewable:end -->
