### PR TITLE
Limit FeeRate change for the UpdateFee msg to prevent sharp changes

### DIFF
--- a/docs/release-notes/release-notes-0.18.0.md
+++ b/docs/release-notes/release-notes-0.18.0.md
@@ -56,7 +56,7 @@
 * [Fixed](https://github.com/lightningnetwork/lnd/pull/8096) a case where `lnd`
   might dip below its channel reserve when htlcs are added concurrently. A
   fee buffer (additional balance) is now always kept on the local side ONLY
-  if the channel was opened locally. This is in accordance with the BOTL 02
+  if the channel was opened locally. This is in accordance with the BOLT 02
   specification and protects against sharp fee changes because there is always
   this buffer which can be used to increase the commitment fee and it also
   protects against the case where htlcs are added asynchronously resulting in
@@ -90,10 +90,18 @@
   precision issue when querying payments and invoices using the start and end
   date filters.
 
+<<<<<<< HEAD
 * [Fixed](https://github.com/lightningnetwork/lnd/pull/8496) an issue where
   `locked_balance` is not updated in `WalletBalanceResponse` when outputs are
   reserved for `OpenChannel` by using non-volatile leases instead of volatile
   locks.
+=======
+* [Fixed](https://github.com/lightningnetwork/lnd/pull/7805) a case where `lnd`
+  might propose a low fee rate for the channel (when initiator) due to the
+  mempool not having enough data yet or the channel might be drained locally
+  which with the default fee allocation in place will eventually lead to the
+  downsizing to the fee floor (1 sat/vbyte) in the worst case.
+>>>>>>> ae6f11c56 (docs: add release-notes.)
 
 # New Features
 ## Functional Enhancements
@@ -328,7 +336,7 @@
   option. 
 
 * [Update min_final_cltv_expiry_delta](https://github.com/lightningnetwork/lnd/pull/8308).
-  This only effects external invoices which do not supply the 
+  This only affects external invoices which do not supply the 
   min_final_cltv_expiry parameter. LND has NOT allowed the creation of invoices
   with a lower min_final_cltv_expiry_delta value than 18 blocks since
   LND 0.11.0.


### PR DESCRIPTION
Relates to #7666 and #7756

## Detailed Problem explanation:

In lnd (lightning) there exist the feeupdate msg which allows channel openers to change the fee of the commitment transaction. For STATIC_REMOTE_KEY channels HTLCs which are part of the Commitment Transaction do have Timeout/Success Transactions which are signed with the same feerate as the Commitment Transaction (see BOLT3 for more details about the HTLC Transaction). 
The FeeUpdate is only allowed to be sent by the Channel Opener but it should be in acceptable Limits, because especially for non-achor channels there is no way to accelerate this transaction (only if you pay a miner directly). CLN nodes will check for a specific range and will not allow the feeupdate from happening. If CLN does reject the feeupdate the channel will either be force-closed by the peer (lndk) or the channel becomes unusable and needs to be force-closed eventually by the peer.

This PR fixes 2 Problems:

### No valid Fee Estimation by our backend

In case you either wipe your mempool or restart a new bitcoind node you want to connect to your lnd node, there is a short time period where bitcoind is not reporting any fee estimations because it does not have enough data available.

It will report: 
```
bitcoin-cli estimatesmartfee 3
{
  "errors": [
    "Insufficient data or no feerate found"
  ],
  "blocks": 0
}
```
In such cases lnd would just read this response and the fee estimation would remain zero and then would just enforce the min mempool fee instead. This is a bad choice because when our mempool is big enough this fee rate is always 1 sat/vbyte and does not represent the current fee rate conditions. This PR will return an error in such cases and lnd will use its fallback feerate of 25 sats/vbyte. It is always better to overestimate rather than underestimate in such cases. 


### Limit Fee Estimation when channel is drained locally

Moreover Lnd reevaluates the MaxFeeRate it is willing to allocate for a Channel every time a feeupdate  msg will be sent. When the channel is locally drained this could lead to a situation where we decrease the feerate all the way to the fee floor which does not reflect the current bitcoin network fee rate correctly and could also lead to our peer rejecting these low fee rate updates. With this PR we do not lower the MaxFeeRate we are willing to allocate for this channel if it would fall below the old fee rate. This guarantees that if we had a high fee rate on a channel, that we do not decrease it when the local balance is drained.   


Locking for a Concept Ack here before writing tests.

This change will not fix existing channels which ran into this issue, but will most likely prevent future channels form being unusable when proposing very low fee rate updates leading to the channel-peer rejecting those.

## Change Description
~~This PR limits the FeeRate update to a maximum of 30% of the old feerate. It only applies to non-anchor channels because for those the negotiated fee cannot be changed when resolving on-chain.~~

~~Open for discussions whether we want to pursue this route if 30% is too conservative and so one.~~

~~Needs some style fixing will solve this in the coming days.~~

## Tests 

I currently just updated the unit tests in the `lnwallet` package. I think it is enough and testing this in the `htlcswitch` where we drain the channel locally and send consecutively fee updates with the default fee-allocation might not be worth it IMO, what are your takes?


Fixes https://github.com/lightningnetwork/lnd/issues/7756


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Fixed an issue where low fee rates could be proposed for channel transactions, ensuring alignment with network standards.
	- Adjusted fee buffer handling in channel openings to comply with BOLT 02 specification.
	- Improved fee estimation when external data is insufficient.
- **New Features**
	- Added support for Taproot witness types in RPC calls.
- **Documentation**
	- Updated handling instructions for `min_final_cltv_expiry_delta` for external invoices.
- **Tests**
	- Enhanced testing for channel fee rate calculations to cover more scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->