### PR TITLE
contractcourt: stop lnd when received witness is empty

### DIFF
--- a/chainntnfs/bitcoindnotify/bitcoind.go
+++ b/chainntnfs/bitcoindnotify/bitcoind.go
@@ -487,7 +487,12 @@ func (b *BitcoindNotifier) handleRelevantTx(tx *btcutil.Tx,
 	// If this is a mempool spend, we'll ask the mempool notifier to hanlde
 	// it.
 	if mempool {
-		b.memNotifier.ProcessRelevantSpendTx(tx)
+		err := b.memNotifier.ProcessRelevantSpendTx(tx)
+		if err != nil {
+			chainntnfs.Log.Errorf("Unable to process transaction "+
+				"%v: %v", tx.Hash(), err)
+		}
+
 		return
 	}
 

--- a/chainntnfs/btcdnotify/btcd.go
+++ b/chainntnfs/btcdnotify/btcd.go
@@ -536,7 +536,12 @@ func (b *BtcdNotifier) handleRelevantTx(tx *btcutil.Tx,
 	// If this is a mempool spend, we'll ask the mempool notifier to hanlde
 	// it.
 	if mempool {
-		b.memNotifier.ProcessRelevantSpendTx(tx)
+		err := b.memNotifier.ProcessRelevantSpendTx(tx)
+		if err != nil {
+			chainntnfs.Log.Errorf("Unable to process transaction "+
+				"%v: %v", tx.Hash(), err)
+		}
+
 		return
 	}
 

--- a/chainntnfs/interface.go
+++ b/chainntnfs/interface.go
@@ -278,6 +278,34 @@ type SpendDetail struct {
 	SpendingHeight    int32
 }
 
+// HasSpenderWitness returns true if the spending transaction has non-empty
+// witness.
+func (s *SpendDetail) HasSpenderWitness() bool {
+	tx := s.SpendingTx
+
+	// If there are no inputs, then there is no witness.
+	if len(tx.TxIn) == 0 {
+		return false
+	}
+
+	// If the spender input index is larger than the number of inputs, then
+	// we don't have a witness and this is an error case so we log it.
+	if uint32(len(tx.TxIn)) <= s.SpenderInputIndex {
+		Log.Errorf("SpenderInputIndex %d is out of range for tx %v",
+			s.SpenderInputIndex, tx.TxHash())
+
+		return false
+	}
+
+	// If the witness is empty, then there is no witness.
+	if len(tx.TxIn[s.SpenderInputIndex].Witness) == 0 {
+		return false
+	}
+
+	// If the witness is non-empty, then we have a witness.
+	return true
+}
+
 // String returns a string representation of SpendDetail.
 func (s *SpendDetail) String() string {
 	return fmt.Sprintf("%v[%d] spending %v at height=%v", s.SpenderTxHash,

--- a/chainntnfs/mempool.go
+++ b/chainntnfs/mempool.go
@@ -146,7 +146,13 @@ func (m *MempoolNotifier) UnsubsribeConfirmedSpentTx(tx *btcutil.Tx) {
 	Log.Tracef("Unsubscribe confirmed tx %s", tx.Hash())
 
 	// Get the spent inputs of interest.
-	spentInputs := m.findRelevantInputs(tx)
+	spentInputs, err := m.findRelevantInputs(tx)
+	if err != nil {
+		Log.Errorf("Unable to find relevant inputs for tx %s: %v",
+			tx.Hash(), err)
+
+		return
+	}
 
 	// Unsubscribe the subscribers.
 	for outpoint := range spentInputs {
@@ -160,15 +166,20 @@ func (m *MempoolNotifier) UnsubsribeConfirmedSpentTx(tx *btcutil.Tx) {
 // ProcessRelevantSpendTx takes a transaction and checks whether it spends any
 // of the subscribed inputs. If so, spend notifications are sent to the
 // relevant subscribers.
-func (m *MempoolNotifier) ProcessRelevantSpendTx(tx *btcutil.Tx) {
+func (m *MempoolNotifier) ProcessRelevantSpendTx(tx *btcutil.Tx) error {
 	Log.Tracef("Processing mempool tx %s", tx.Hash())
 	defer Log.Tracef("Finished processing mempool tx %s", tx.Hash())
 
 	// Get the spent inputs of interest.
-	spentInputs := m.findRelevantInputs(tx)
+	spentInputs, err := m.findRelevantInputs(tx)
+	if err != nil {
+		return err
+	}
 
 	// Notify the subscribers.
 	m.notifySpent(spentInputs)
+
+	return nil
 }
 
 // TearDown stops the notifier and cleans up resources.
@@ -182,7 +193,9 @@ func (m *MempoolNotifier) TearDown() {
 
 // findRelevantInputs takes a transaction to find the subscribed inputs and
 // returns them.
-func (m *MempoolNotifier) findRelevantInputs(tx *btcutil.Tx) inputsWithTx {
+func (m *MempoolNotifier) findRelevantInputs(tx *btcutil.Tx) (inputsWithTx,
+	error) {
+
 	txid := tx.Hash()
 	watchedInputs := make(inputsWithTx)
 
@@ -209,9 +222,15 @@ func (m *MempoolNotifier) findRelevantInputs(tx *btcutil.Tx) inputsWithTx {
 			SpendingHeight:    0,
 		}
 		watchedInputs[*op] = details
+
+		// Return an error if the witness data is not present in the
+		// spending transaction.
+		if !details.HasSpenderWitness() {
+			return nil, ErrEmptyWitnessStack
+		}
 	}
 
-	return watchedInputs
+	return watchedInputs, nil
 }
 
 // notifySpent iterates all the spentInputs and notifies the subscribers about

--- a/chainntnfs/mempool.go
+++ b/chainntnfs/mempool.go
@@ -223,11 +223,19 @@ func (m *MempoolNotifier) findRelevantInputs(tx *btcutil.Tx) (inputsWithTx,
 		}
 		watchedInputs[*op] = details
 
+		// Sanity check the witness stack. If it's not empty, continue
+		// to next iteration.
+		if details.HasSpenderWitness() {
+			continue
+		}
+
 		// Return an error if the witness data is not present in the
 		// spending transaction.
-		if !details.HasSpenderWitness() {
-			return nil, ErrEmptyWitnessStack
-		}
+		Log.Criticalf("Found spending tx for outpoint=%v in mempool, "+
+			"but the transaction %v does not have witness",
+			op, details.SpendingTx.TxHash())
+
+		return nil, ErrEmptyWitnessStack
 	}
 
 	return watchedInputs, nil

--- a/chainntnfs/txnotifier.go
+++ b/chainntnfs/txnotifier.go
@@ -1305,10 +1305,13 @@ func (n *TxNotifier) updateSpendDetails(spendRequest SpendRequest,
 	// Return an error if the witness data is not present in the spending
 	// transaction.
 	//
-	// TODO(yy): maybe we should do a panic here instead to inform the user
-	// to reindex the bitcoind since it's critical error?
-	// panic("Please re-index your bitcoind...")
+	// NOTE: if the witness stack is empty, we will do a critical log which
+	// shuts down the node.
 	if !details.HasSpenderWitness() {
+		Log.Criticalf("Found spending tx for outpoint=%v, but the "+
+			"transaction %v does not have witness",
+			spendRequest.OutPoint, details.SpendingTx.TxHash())
+
 		return ErrEmptyWitnessStack
 	}
 

--- a/chainntnfs/txnotifier_test.go
+++ b/chainntnfs/txnotifier_test.go
@@ -34,6 +34,8 @@ var (
 		0x86, 0xf4, 0xcb, 0xf9, 0x8e, 0xae, 0xd2, 0x21,
 		0xb3, 0x0b, 0xd9, 0xa0, 0xb9, 0x28,
 	}
+
+	testWitness = [][]byte{{0x01}}
 )
 
 type mockHintCache struct {
@@ -747,6 +749,7 @@ func TestTxNotifierHistoricalSpendDispatch(t *testing.T) {
 	spendTx := wire.NewMsgTx(2)
 	spendTx.AddTxIn(&wire.TxIn{
 		PreviousOutPoint: spentOutpoint,
+		Witness:          testWitness,
 		SignatureScript:  testSigScript,
 	})
 	spendTxHash := spendTx.TxHash()
@@ -894,10 +897,17 @@ func TestTxNotifierMultipleHistoricalSpendRescans(t *testing.T) {
 	// register another notification. We should also expect not to see a
 	// historical rescan request since the confirmation details should be
 	// cached.
+	msgTx := &wire.MsgTx{
+		TxIn: []*wire.TxIn{
+			{PreviousOutPoint: op, Witness: testWitness},
+		},
+		TxOut: []*wire.TxOut{},
+	}
+
 	spendDetails := &chainntnfs.SpendDetail{
 		SpentOutPoint:     &op,
 		SpenderTxHash:     &chainntnfs.ZeroHash,
-		SpendingTx:        wire.NewMsgTx(2),
+		SpendingTx:        msgTx,
 		SpenderInputIndex: 0,
 		SpendingHeight:    startingHeight - 1,
 	}
@@ -1021,10 +1031,17 @@ func TestTxNotifierMultipleHistoricalNtfns(t *testing.T) {
 	// We'll assume a historical rescan was dispatched and found the
 	// following spend details. We'll let the notifier know so that it can
 	// stop watching at tip.
+	msgTx := &wire.MsgTx{
+		TxIn: []*wire.TxIn{
+			{PreviousOutPoint: op, Witness: testWitness},
+		},
+		TxOut: []*wire.TxOut{},
+	}
+
 	expectedSpendDetails := &chainntnfs.SpendDetail{
 		SpentOutPoint:     &op,
 		SpenderTxHash:     &chainntnfs.ZeroHash,
-		SpendingTx:        wire.NewMsgTx(2),
+		SpendingTx:        msgTx,
 		SpenderInputIndex: 0,
 		SpendingHeight:    startingHeight - 1,
 	}
@@ -1744,6 +1761,7 @@ func TestTxNotifierSpendReorgMissed(t *testing.T) {
 	spendTx := wire.NewMsgTx(2)
 	spendTx.AddTxIn(&wire.TxIn{
 		PreviousOutPoint: op,
+		Witness:          testWitness,
 		SignatureScript:  testSigScript,
 	})
 	spendTxHash := spendTx.TxHash()

--- a/docs/release-notes/release-notes-0.18.0.md
+++ b/docs/release-notes/release-notes-0.18.0.md
@@ -32,6 +32,10 @@
   attempt](https://github.com/lightningnetwork/lnd/pull/8091) when sweeping new
   inputs with retried ones.
 
+* [Fixed](https://github.com/lightningnetwork/lnd/pull/7811) a case where `lnd`
+  might panic due to empty witness data found in a transaction. More details
+  can be found [here](https://github.com/bitcoin/bitcoin/issues/28730).
+
 # New Features
 ## Functional Enhancements
 


### PR DESCRIPTION
This is the first commit from #7615. Making a PR for it so affected users can apply the patch first.

This commit adds a length check in `isPreimageSpend` to make sure it won't ever panic and adds a unit test to verify it.