### PR TITLE
Fix docker compose run issue

### DIFF
--- a/docker/btcd/Dockerfile
+++ b/docker/btcd/Dockerfile
@@ -8,7 +8,7 @@ RUN apk add --no-cache git gcc musl-dev
 WORKDIR $GOPATH/src/github.com/btcsuite/btcd
 
 # Pin down btcd to a version that we know works with lnd.
-ARG BTCD_VERSION=v0.23.5
+ARG BTCD_VERSION=v0.23.4
 
 # Grab and install the latest version of of btcd and all related dependencies.
 RUN git clone https://github.com/btcsuite/btcd.git . \


### PR DESCRIPTION
docker-compose run -d --name alice --volume simnet_lnd_alice:/root/.lnd lnd

 => ERROR [builder 4/4] RUN git clone https://github.com/btcsuite/btcd.git .     && git checkout v0.23  6.2s
------
 > [builder 4/4] RUN git clone https://github.com/btcsuite/btcd.git .     && git checkout v0.23.5     && go install -v . ./cmd/...:
#0 0.253 Cloning into '.'...
#0 6.059 error: pathspec 'v0.23.5' did not match any file(s) known to git ------
failed to solve: executor failed running [/bin/sh -c git clone https://github.com/btcsuite/btcd.git .     && git checkout $BTCD_VERSION     && go install -v . ./cmd/...]: exit code: 1

## Change Description
Description of change / link to associated issue.


## Steps to Test
Steps for reviewers to follow to test the change.

```
$cd docker 
$docker-compose run -d --name alice --volume simnet_lnd_alice:/root/.lnd lnd
```

## Pull Request Checklist
### Testing
- [ x] Your PR passes all CI checks.
- [ x] Tests covering the positive and negative (error paths) are included.
- [ x] Bug fixes contain tests triggering the bug to prevent regressions.

### Code Style and Documentation
- [ x] The change obeys the [Code Documentation and Commenting](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#CodeDocumentation) guidelines, and lines wrap at 80.
- [ x] Commits follow the [Ideal Git Commit Structure](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#IdealGitCommitStructure).
- [ x] Any new logging statements use an appropriate subsystem and logging level.
- [ x]  [There is a change description in the release notes](https://github.com/lightningnetwork/lnd/tree/master/docs/release-notes), or `[skip ci]` in the commit message for small changes.

📝 Please see our  [Contribution Guidelines](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md) for further guidance.