### PR TITLE
Cancel the Rebroadcasting of a Transaction when Abandoning a Channel

### DIFF
--- a/docs/release-notes/release-notes-0.17.0.md
+++ b/docs/release-notes/release-notes-0.17.0.md
@@ -141,6 +141,9 @@ It is possible to distinguish between defaults and examples now.
 A check script has been developed and integrated into the building process to 
 compare the default values between lnd and sample-lnd.conf.
 
+* [Cancel rebroadcasting of a transaction when abandoning
+a channel](https://github.com/lightningnetwork/lnd/pull/7819)
+
 ## Code Health
 
 * Updated [our fork for serializing protobuf as JSON to be based on the

--- a/lnwallet/wallet.go
+++ b/lnwallet/wallet.go
@@ -2315,6 +2315,15 @@ func (l *LightningWallet) ValidateChannel(channelState *channeldb.OpenChannel,
 	return nil
 }
 
+// CancelRebroadcast cancels the rebroadcast of the given transaction.
+func (l *LightningWallet) CancelRebroadcast(txid chainhash.Hash) {
+	// For neutrino, we don't config the rebroadcaster for the wallet as it
+	// manages the rebroadcasting logic in neutrino itself.
+	if l.Cfg.Rebroadcaster != nil {
+		l.Cfg.Rebroadcaster.MarkAsConfirmed(txid)
+	}
+}
+
 // CoinSource is a wrapper around the wallet that implements the
 // chanfunding.CoinSource interface.
 type CoinSource struct {


### PR DESCRIPTION
Resulted from discussions in #7746.

Short follow-up PR which makes sure we do not end up confirming a channel although we already abandoned it.

More detailed description [here](https://github.com/lightningnetwork/lnd/pull/7746#discussion_r1249338471)
