### PR TITLE
invoices/test: Cleanup Invoice Registry Tests

### DIFF
--- a/invoices/invoiceregistry_test.go
+++ b/invoices/invoiceregistry_test.go
@@ -19,6 +19,8 @@ import (
 
 // TestSettleInvoice tests settling of an invoice and related notifications.
 func TestSettleInvoice(t *testing.T) {
+	t.Parallel()
+
 	ctx := newTestContext(t, nil)
 
 	allSubscriptions, err := ctx.registry.SubscribeNotifications(0, 0)
@@ -194,6 +196,8 @@ func TestSettleInvoice(t *testing.T) {
 }
 
 func testCancelInvoice(t *testing.T, gc bool) {
+	t.Parallel()
+
 	cfg := defaultRegistryConfig()
 
 	// If set to true, then also delete the invoice from the DB after
@@ -326,6 +330,8 @@ func testCancelInvoice(t *testing.T, gc bool) {
 
 // TestCancelInvoice tests cancellation of an invoice and related notifications.
 func TestCancelInvoice(t *testing.T) {
+	t.Parallel()
+
 	// Test cancellation both with garbage collection (meaning that canceled
 	// invoice will be deleted) and without (meaning it'll be kept).
 	t.Run("garbage collect", func(t *testing.T) {
@@ -340,6 +346,7 @@ func TestCancelInvoice(t *testing.T) {
 // TestSettleHoldInvoice tests settling of a hold invoice and related
 // notifications.
 func TestSettleHoldInvoice(t *testing.T) {
+	t.Parallel()
 	defer timeout()()
 
 	idb, err := newTestChannelDB(t, clock.NewTestClock(time.Time{}))
@@ -513,6 +520,7 @@ func TestSettleHoldInvoice(t *testing.T) {
 // TestCancelHoldInvoice tests canceling of a hold invoice and related
 // notifications.
 func TestCancelHoldInvoice(t *testing.T) {
+	t.Parallel()
 	defer timeout()()
 
 	testClock := clock.NewTestClock(testTime)
@@ -593,6 +601,7 @@ func TestCancelHoldInvoice(t *testing.T) {
 // if we are the exit hop, but in htlcIncomingContestResolver it is called with
 // forwarded htlc hashes as well.
 func TestUnknownInvoice(t *testing.T) {
+	t.Parallel()
 	ctx := newTestContext(t, nil)
 
 	// Notify arrival of a new htlc paying to this invoice. This should
@@ -613,6 +622,8 @@ func TestUnknownInvoice(t *testing.T) {
 // TestKeySend tests receiving a spontaneous payment with and without keysend
 // enabled.
 func TestKeySend(t *testing.T) {
+	t.Parallel()
+
 	t.Run("enabled", func(t *testing.T) {
 		testKeySend(t, true)
 	})
@@ -624,6 +635,7 @@ func TestKeySend(t *testing.T) {
 // testKeySend is the inner test function that tests keysend for a particular
 // enabled state on the receiver end.
 func testKeySend(t *testing.T, keySendEnabled bool) {
+	t.Parallel()
 	defer timeout()()
 
 	cfg := defaultRegistryConfig()
@@ -738,6 +750,8 @@ func testKeySend(t *testing.T, keySendEnabled bool) {
 
 // TestHoldKeysend tests receiving a spontaneous payment that is held.
 func TestHoldKeysend(t *testing.T) {
+	t.Parallel()
+
 	t.Run("settle", func(t *testing.T) {
 		testHoldKeysend(t, false)
 	})
@@ -748,6 +762,7 @@ func TestHoldKeysend(t *testing.T) {
 
 // testHoldKeysend is the inner test function that tests hold-keysend.
 func testHoldKeysend(t *testing.T, timeoutKeysend bool) {
+	t.Parallel()
 	defer timeout()()
 
 	const holdDuration = time.Minute
@@ -838,6 +853,7 @@ func testHoldKeysend(t *testing.T, timeoutKeysend bool) {
 // It covers the case where there is a mpp timeout before the whole invoice is
 // paid and the case where the invoice is settled in time.
 func TestMppPayment(t *testing.T) {
+	t.Parallel()
 	defer timeout()()
 
 	ctx := newTestContext(t, nil)
@@ -1199,6 +1215,8 @@ func TestOldInvoiceRemovalOnStart(t *testing.T) {
 // invoice is settled before expiry (and thus not canceled), and the case
 // where the invoice is expired.
 func TestHeightExpiryWithRegistry(t *testing.T) {
+	t.Parallel()
+
 	t.Run("single shot settled before expiry", func(t *testing.T) {
 		testHeightExpiryWithRegistry(t, 1, true)
 	})
@@ -1613,6 +1631,7 @@ func TestSettleInvoicePaymentAddrRequiredOptionalGrace(t *testing.T) {
 // TestAMPWithoutMPPPayload asserts that we correctly reject an AMP HTLC that
 // does not include an MPP record.
 func TestAMPWithoutMPPPayload(t *testing.T) {
+	t.Parallel()
 	defer timeout()()
 
 	cfg := defaultRegistryConfig()
@@ -1645,6 +1664,8 @@ func TestAMPWithoutMPPPayload(t *testing.T) {
 // TestSpontaneousAmpPayment tests receiving a spontaneous AMP payment with both
 // valid and invalid reconstructions.
 func TestSpontaneousAmpPayment(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name               string
 		ampEnabled         bool
@@ -1698,6 +1719,7 @@ func TestSpontaneousAmpPayment(t *testing.T) {
 func testSpontaneousAmpPayment(
 	t *testing.T, ampEnabled, failReconstruction bool, numShards int) {
 
+	t.Parallel()
 	defer timeout()()
 
 	cfg := defaultRegistryConfig()

--- a/invoices/invoiceregistry_test.go
+++ b/invoices/invoiceregistry_test.go
@@ -299,7 +299,7 @@ func testCancelInvoice(t *testing.T, gc bool) {
 	// result in a cancel resolution.
 	hodlChan := make(chan interface{})
 	resolution, err := ctx.registry.NotifyExitHopHtlc(
-		testInvoicePaymentHash, testInvoiceAmt, testHtlcExpiry,
+		testInvoicePaymentHash, testInvoiceAmount, testHtlcExpiry,
 		testCurrentHeight, getCircuitKey(0), hodlChan, testPayload,
 	)
 	if err != nil {
@@ -850,7 +850,7 @@ func TestMppPayment(t *testing.T) {
 	}
 
 	mppPayload := &mockPayload{
-		mpp: record.NewMPP(testInvoiceAmt, [32]byte{}),
+		mpp: record.NewMPP(testInvoiceAmount, [32]byte{}),
 	}
 
 	// Send htlc 1.
@@ -949,7 +949,7 @@ func TestMppPaymentWithOverpayment(t *testing.T) {
 		}
 
 		mppPayload := &mockPayload{
-			mpp: record.NewMPP(testInvoiceAmt, [32]byte{}),
+			mpp: record.NewMPP(testInvoiceAmount, [32]byte{}),
 		}
 
 		// We constrain overpayment amount to be [1,1000].
@@ -1236,7 +1236,7 @@ func testHeightExpiryWithRegistry(t *testing.T, numParts int, settle bool) {
 	payLoad := testPayload
 	if numParts > 1 {
 		payLoad = &mockPayload{
-			mpp: record.NewMPP(testInvoiceAmt, [32]byte{}),
+			mpp: record.NewMPP(testInvoiceAmount, [32]byte{}),
 		}
 	}
 
@@ -1338,7 +1338,7 @@ func TestMultipleSetHeightExpiry(t *testing.T) {
 	require.NoError(t, err)
 
 	mppPayload := &mockPayload{
-		mpp: record.NewMPP(testInvoiceAmt, [32]byte{}),
+		mpp: record.NewMPP(testInvoiceAmount, [32]byte{}),
 	}
 
 	// Send htlc 1.
@@ -1507,7 +1507,7 @@ func TestSettleInvoicePaymentAddrRequiredOptionalGrace(t *testing.T) {
 	invoice := &invpkg.Invoice{
 		Terms: invpkg.ContractTerm{
 			PaymentPreimage: &testInvoicePreimage,
-			Value:           testInvoiceAmt,
+			Value:           testInvoiceAmount,
 			Expiry:          time.Hour,
 			Features: lnwire.NewFeatureVector(
 				lnwire.NewRawFeatureVector(
@@ -1555,7 +1555,7 @@ func TestSettleInvoicePaymentAddrRequiredOptionalGrace(t *testing.T) {
 	// no problem as we should allow these existing invoices to be settled.
 	hodlChan := make(chan interface{}, 1)
 	resolution, err := ctx.registry.NotifyExitHopHtlc(
-		testInvoicePaymentHash, testInvoiceAmt,
+		testInvoicePaymentHash, testInvoiceAmount,
 		testHtlcExpiry, testCurrentHeight,
 		getCircuitKey(10), hodlChan, testPayload,
 	)

--- a/invoices/test_utils_test.go
+++ b/invoices/test_utils_test.go
@@ -132,12 +132,10 @@ var (
 )
 
 var (
-	testInvoiceAmt = lnwire.MilliSatoshi(100000)
-
 	testPayAddrReqInvoice = &invpkg.Invoice{
 		Terms: invpkg.ContractTerm{
 			PaymentPreimage: &testInvoicePreimage,
-			Value:           testInvoiceAmt,
+			Value:           testInvoiceAmount,
 			Expiry:          time.Hour,
 			Features: lnwire.NewFeatureVector(
 				lnwire.NewRawFeatureVector(
@@ -249,7 +247,7 @@ func getCircuitKey(htlcID uint64) invpkg.CircuitKey {
 func newInvoice(t *testing.T, hodl bool) *invpkg.Invoice {
 	invoice := &invpkg.Invoice{
 		Terms: invpkg.ContractTerm{
-			Value:    testInvoiceAmt,
+			Value:    testInvoiceAmount,
 			Expiry:   time.Hour,
 			Features: testFeatures.Clone(),
 		},

--- a/invoices/test_utils_test.go
+++ b/invoices/test_utils_test.go
@@ -149,22 +149,6 @@ var (
 		},
 		CreationDate: testInvoiceCreationDate,
 	}
-
-	testPayAddrOptionalInvoice = &invpkg.Invoice{
-		Terms: invpkg.ContractTerm{
-			PaymentPreimage: &testInvoicePreimage,
-			Value:           testInvoiceAmt,
-			Expiry:          time.Hour,
-			Features: lnwire.NewFeatureVector(
-				lnwire.NewRawFeatureVector(
-					lnwire.TLVOnionPayloadOptional,
-					lnwire.PaymentAddrOptional,
-				),
-				lnwire.Features,
-			),
-		},
-		CreationDate: testInvoiceCreationDate,
-	}
 )
 
 func newTestChannelDB(t *testing.T, clock clock.Clock) (*channeldb.DB, error) {

--- a/invoices/test_utils_test.go
+++ b/invoices/test_utils_test.go
@@ -131,24 +131,6 @@ var (
 	testInvoiceCreationDate = testTime
 )
 
-var (
-	testPayAddrReqInvoice = &invpkg.Invoice{
-		Terms: invpkg.ContractTerm{
-			PaymentPreimage: &testInvoicePreimage,
-			Value:           testInvoiceAmount,
-			Expiry:          time.Hour,
-			Features: lnwire.NewFeatureVector(
-				lnwire.NewRawFeatureVector(
-					lnwire.TLVOnionPayloadOptional,
-					lnwire.PaymentAddrRequired,
-				),
-				lnwire.Features,
-			),
-		},
-		CreationDate: testInvoiceCreationDate,
-	}
-)
-
 func newTestChannelDB(t *testing.T, clock clock.Clock) (*channeldb.DB, error) {
 	t.Helper()
 


### PR DESCRIPTION
~Depends on #7826 (just the first commit).~ Rebased!

This PR cleans up some of the test values used in invoice registry tests: 
* Move away from global variables that can be mutated, using constructors where appropriate 
* Make all tests parallel, so that any "hidden races" between tests that are run in series are revealed 
* Simplify the ambiguously named global vars (testInvoiceAmt vs testInvoiceAmount, fml)