### PR TITLE
Path Finding Size Estimation including Blinded Path Data

### DIFF
--- a/docs/release-notes/release-notes-0.18.0.md
+++ b/docs/release-notes/release-notes-0.18.0.md
@@ -77,6 +77,9 @@
 
 * [Add Taproot witness types
   to rpc](https://github.com/lightningnetwork/lnd/pull/8431)
+  
+* [Fixed](https://github.com/lightningnetwork/lnd/pull/7852) the payload size
+  calculation in our pathfinder because blinded hops introduced new tlv records.
 
 # New Features
 ## Functional Enhancements

--- a/itest/lnd_amp_test.go
+++ b/itest/lnd_amp_test.go
@@ -104,6 +104,10 @@ func testSendPaymentAMPInvoiceCase(ht *lntest.HarnessTest,
 	// expect an extra invoice to appear in the ListInvoices response, since
 	// a new invoice will be JIT inserted under a different payment address
 	// than the one in the invoice.
+	//
+	// NOTE: This will only work when the peer has spontaneous AMP payments
+	// enabled otherwise no invoice under a different payment_addr will be
+	// found.
 	var (
 		expNumInvoices  = 1
 		externalPayAddr []byte

--- a/lnrpc/routerrpc/router_backend.go
+++ b/lnrpc/routerrpc/router_backend.go
@@ -967,6 +967,9 @@ func (r *RouterBackend) extractIntentFromSendRequest(
 			// pseudo-reusable, e.g. the invoice parameters are
 			// reused (amt, cltv, hop hints, etc) even though the
 			// payments will share different payment hashes.
+			//
+			// NOTE: This will only work when the peer has
+			// spontaneous AMP payments enabled.
 			if len(rpcPayReq.PaymentAddr) > 0 {
 				var addr [32]byte
 				copy(addr[:], rpcPayReq.PaymentAddr)

--- a/lnrpc/routerrpc/router_backend.go
+++ b/lnrpc/routerrpc/router_backend.go
@@ -390,6 +390,7 @@ func (r *RouterBackend) parseQueryRoutesRequest(in *lnrpc.QueryRoutesRequest) (
 		DestCustomRecords: record.CustomSet(in.DestCustomRecords),
 		CltvLimit:         cltvLimit,
 		DestFeatures:      destinationFeatures,
+		BlindedPayment:    blindedPmt,
 	}
 
 	// Pass along an outgoing channel restriction if specified.

--- a/lnrpc/routerrpc/router_backend.go
+++ b/lnrpc/routerrpc/router_backend.go
@@ -15,7 +15,6 @@ import (
 	"github.com/btcsuite/btcd/wire"
 	sphinx "github.com/lightningnetwork/lightning-onion"
 	"github.com/lightningnetwork/lnd/channeldb"
-	"github.com/lightningnetwork/lnd/channeldb/models"
 	"github.com/lightningnetwork/lnd/feature"
 	"github.com/lightningnetwork/lnd/htlcswitch"
 	"github.com/lightningnetwork/lnd/lnrpc"
@@ -280,7 +279,7 @@ func (r *RouterBackend) parseQueryRoutesRequest(in *lnrpc.QueryRoutesRequest) (
 	// inside of the path rather than the request's fields.
 	var (
 		targetPubKey   *route.Vertex
-		routeHintEdges map[route.Vertex][]*models.CachedEdgePolicy
+		routeHintEdges map[route.Vertex][]routing.AdditionalEdge
 		blindedPmt     *routing.BlindedPayment
 
 		// finalCLTVDelta varies depending on whether we're sending to

--- a/record/amp.go
+++ b/record/amp.go
@@ -19,6 +19,16 @@ type AMP struct {
 	childIndex uint32
 }
 
+// MaxAmpPayLoadSize is an AMP Record which when serialized to a tlv record uses
+// the maximum payload size. The `childIndex` is created randomly and is a
+// 4 byte `varint` type so we make sure we use an index which will be encoded in
+// 4 bytes.
+var MaxAmpPayLoadSize = AMP{
+	rootShare:  [32]byte{},
+	setID:      [32]byte{},
+	childIndex: 0x80000000,
+}
+
 // NewAMP generate a new AMP record with the given root_share, set_id, and
 // child_index.
 func NewAMP(rootShare, setID [32]byte, childIndex uint32) *AMP {

--- a/routing/additional_edge.go
+++ b/routing/additional_edge.go
@@ -1,0 +1,107 @@
+package routing
+
+import (
+	"errors"
+
+	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/lightningnetwork/lnd/channeldb/models"
+	"github.com/lightningnetwork/lnd/lnwire"
+	"github.com/lightningnetwork/lnd/routing/route"
+)
+
+var (
+	// ErrNoPayLoadSizeFunc is returned when no payload size function is
+	// definied.
+	ErrNoPayLoadSizeFunc = errors.New("no payloadSizeFunc defined for " +
+		"additional edge")
+)
+
+// AdditionalEdge is an interface which specifies additional edges which can
+// be appended to an existing route. Compared to normal edges of a route they
+// provide an explicit payload size function and are introduced because blinded
+// paths differ in their payload structure.
+type AdditionalEdge interface {
+	// IntermediatePayloadSize returns the size of the payload for the
+	// additional edge when being an intermediate hop in a route NOT the
+	// final hop.
+	IntermediatePayloadSize(amount lnwire.MilliSatoshi, expiry uint32,
+		legacy bool, channelID uint64) uint64
+
+	// EdgePolicy returns the policy of the additional edge.
+	EdgePolicy() *models.CachedEdgePolicy
+}
+
+// PayloadSizeFunc defines the interface for the payload size function.
+type PayloadSizeFunc func(amount lnwire.MilliSatoshi, expiry uint32,
+	legacy bool, channelID uint64) uint64
+
+// PrivateEdge implements the AdditionalEdge interface. As the name implies it
+// is used for private route hints that the receiver adds for example to an
+// invoice.
+type PrivateEdge struct {
+	policy *models.CachedEdgePolicy
+}
+
+// EdgePolicy return the policy of the PrivateEdge.
+func (p *PrivateEdge) EdgePolicy() *models.CachedEdgePolicy {
+	return p.policy
+}
+
+// IntermediatePayloadSize returns the sphinx payload size defined in BOLT04 if
+// this edge were to be included in a route.
+func (p *PrivateEdge) IntermediatePayloadSize(amount lnwire.MilliSatoshi,
+	expiry uint32, legacy bool, channelID uint64) uint64 {
+
+	hop := route.Hop{
+		AmtToForward:     amount,
+		OutgoingTimeLock: expiry,
+		LegacyPayload:    legacy,
+	}
+
+	return hop.PayloadSize(channelID)
+}
+
+// BlindedEdge implements the AdditionalEdge interface. Blinded hops are viewed
+// as additional edges because they are appened at the end of a normal route.
+type BlindedEdge struct {
+	policy        *models.CachedEdgePolicy
+	cipherText    []byte
+	blindingPoint *btcec.PublicKey
+}
+
+// EdgePolicy return the policy of the BlindedEdge.
+func (b *BlindedEdge) EdgePolicy() *models.CachedEdgePolicy {
+	return b.policy
+}
+
+// IntermediatePayloadSize returns the sphinx payload size defined in BOLT04 if
+// this edge were to be included in a route.
+func (b *BlindedEdge) IntermediatePayloadSize(_ lnwire.MilliSatoshi, _ uint32,
+	_ bool, _ uint64) uint64 {
+
+	hop := route.Hop{
+		BlindingPoint: b.blindingPoint,
+		LegacyPayload: false,
+		EncryptedData: b.cipherText,
+	}
+
+	// For blinded paths the next chanID is in the encrypted data tlv.
+	return hop.PayloadSize(0)
+}
+
+// Compile-time constraints to ensure the PrivateEdge and the BlindedEdge
+// implement the AdditionalEdge interface.
+var _ AdditionalEdge = (*PrivateEdge)(nil)
+var _ AdditionalEdge = (*BlindedEdge)(nil)
+
+// defaultHopPayloadSize is the default payload size of a normal (not-blinded)
+// hop in the route.
+func defaultHopPayloadSize(amount lnwire.MilliSatoshi, expiry uint32,
+	legacy bool, channelID uint64) uint64 {
+
+	// The payload size of a cleartext intermediate hop is equal to the
+	// payload size of a private edge therefore we reuse its size function.
+	edge := PrivateEdge{}
+
+	return edge.IntermediatePayloadSize(amount, expiry, legacy, channelID)
+}

--- a/routing/additional_edge_test.go
+++ b/routing/additional_edge_test.go
@@ -1,0 +1,136 @@
+package routing
+
+import (
+	"bytes"
+	"encoding/binary"
+	"encoding/hex"
+	"testing"
+
+	"github.com/btcsuite/btcd/btcec/v2"
+	sphinx "github.com/lightningnetwork/lightning-onion"
+	"github.com/lightningnetwork/lnd/routing/route"
+	"github.com/stretchr/testify/require"
+)
+
+// TestIntermediatePayloadSize tests the payload size functions of the
+// PrivateEdge and the BlindedEdge.
+func TestIntermediatePayloadSize(t *testing.T) {
+	t.Parallel()
+
+	testPrivKeyBytes, _ := hex.DecodeString("e126f68f7eafcc8b74f54d269fe" +
+		"206be715000f94dac067d1c04a8ca3b2db734")
+	_, blindedPoint := btcec.PrivKeyFromBytes(testPrivKeyBytes)
+
+	testCases := []struct {
+		name    string
+		hop     route.Hop
+		nextHop uint64
+		edge    AdditionalEdge
+	}{
+		{
+			name: "Legacy payload private edge",
+			hop: route.Hop{
+				AmtToForward:     1000,
+				OutgoingTimeLock: 600000,
+				ChannelID:        3432483437438,
+				LegacyPayload:    true,
+			},
+			nextHop: 1,
+			edge:    &PrivateEdge{},
+		},
+		{
+			name: "Tlv payload private edge",
+			hop: route.Hop{
+				AmtToForward:     1000,
+				OutgoingTimeLock: 600000,
+				ChannelID:        3432483437438,
+				LegacyPayload:    false,
+			},
+			nextHop: 1,
+			edge:    &PrivateEdge{},
+		},
+		{
+			name: "Blinded edge",
+			hop: route.Hop{
+				EncryptedData: []byte{12, 13},
+			},
+			edge: &BlindedEdge{
+				cipherText: []byte{12, 13},
+			},
+		},
+		{
+			name: "Blinded edge - introduction point",
+			hop: route.Hop{
+				EncryptedData: []byte{12, 13},
+				BlindingPoint: blindedPoint,
+			},
+			edge: &BlindedEdge{
+				cipherText:    []byte{12, 13},
+				blindingPoint: blindedPoint,
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		testCase := testCase
+
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			payLoad, err := createHopPayload(
+				testCase.hop, testCase.nextHop, false,
+			)
+			require.NoErrorf(t, err, "failed to create hop payload")
+
+			expectedPayloadSize := testCase.edge.
+				IntermediatePayloadSize(
+					testCase.hop.AmtToForward,
+					testCase.hop.OutgoingTimeLock,
+					testCase.hop.LegacyPayload,
+					testCase.nextHop,
+				)
+
+			require.Equal(
+				t, expectedPayloadSize,
+				uint64(payLoad.NumBytes()),
+			)
+		})
+	}
+}
+
+// createHopPayload creates the hop payload of the sphinx package to facilitate
+// the testing of the payload size.
+func createHopPayload(hop route.Hop, nextHop uint64,
+	finalHop bool) (sphinx.HopPayload, error) {
+
+	// If this is the legacy payload, then we can just include the
+	// hop data as normal.
+	if hop.LegacyPayload {
+		// Before we encode this value, we'll pack the next hop
+		// into the NextAddress field of the hop info to ensure
+		// we point to the right now.
+		hopData := sphinx.HopData{
+			ForwardAmount: uint64(hop.AmtToForward),
+			OutgoingCltv:  hop.OutgoingTimeLock,
+		}
+		binary.BigEndian.PutUint64(
+			hopData.NextAddress[:], nextHop,
+		)
+
+		return sphinx.NewLegacyHopPayload(&hopData)
+	}
+
+	// For non-legacy payloads, we'll need to pack the
+	// routing information, along with any extra TLV
+	// information into the new per-hop payload format.
+	// We'll also pass in the chan ID of the hop this
+	// channel should be forwarded to so we can construct a
+	// valid payload.
+	var b bytes.Buffer
+	err := hop.PackHopPayload(&b, nextHop, finalHop)
+	if err != nil {
+		return sphinx.HopPayload{}, err
+	}
+
+	return sphinx.NewTLVHopPayload(b.Bytes())
+}

--- a/routing/blinding_test.go
+++ b/routing/blinding_test.go
@@ -1,10 +1,12 @@
 package routing
 
 import (
+	"bytes"
 	"testing"
 
 	"github.com/btcsuite/btcd/btcec/v2"
 	sphinx "github.com/lightningnetwork/lightning-onion"
+	"github.com/lightningnetwork/lnd/channeldb/models"
 	"github.com/lightningnetwork/lnd/lnwire"
 	"github.com/lightningnetwork/lnd/routing/route"
 	"github.com/stretchr/testify/require"
@@ -94,6 +96,12 @@ func TestBlindedPaymentToHints(t *testing.T) {
 		htlcMin   uint64 = 100
 		htlcMax   uint64 = 100_000_000
 
+		sizeEncryptedData = 100
+		cipherText        = bytes.Repeat(
+			[]byte{1}, sizeEncryptedData,
+		)
+		_, blindedPoint = btcec.PrivKeyFromBytes([]byte{5})
+
 		rawFeatures = lnwire.NewRawFeatureVector(
 			lnwire.AMPOptional,
 		)
@@ -108,6 +116,7 @@ func TestBlindedPaymentToHints(t *testing.T) {
 	blindedPayment := &BlindedPayment{
 		BlindedPath: &sphinx.BlindedPath{
 			IntroductionPoint: pk1,
+			BlindingPoint:     blindedPoint,
 			BlindedHops: []*sphinx.BlindedHopInfo{
 				{},
 			},
@@ -125,40 +134,52 @@ func TestBlindedPaymentToHints(t *testing.T) {
 	blindedPayment.BlindedPath.BlindedHops = []*sphinx.BlindedHopInfo{
 		{
 			BlindedNodePub: pkb1,
+			CipherText:     cipherText,
 		},
 		{
 			BlindedNodePub: pkb2,
+			CipherText:     cipherText,
 		},
 		{
 			BlindedNodePub: pkb3,
+			CipherText:     cipherText,
 		},
 	}
 
 	expected := RouteHints{
 		v1: {
-			{
-				TimeLockDelta: cltvDelta,
-				MinHTLC:       lnwire.MilliSatoshi(htlcMin),
-				MaxHTLC:       lnwire.MilliSatoshi(htlcMax),
-				FeeBaseMSat:   lnwire.MilliSatoshi(baseFee),
-				FeeProportionalMillionths: lnwire.MilliSatoshi(
-					ppmFee,
-				),
-				ToNodePubKey: func() route.Vertex {
-					return vb2
+			//nolint:lll
+			&BlindedEdge{
+				policy: &models.CachedEdgePolicy{
+					TimeLockDelta: cltvDelta,
+					MinHTLC:       lnwire.MilliSatoshi(htlcMin),
+					MaxHTLC:       lnwire.MilliSatoshi(htlcMax),
+					FeeBaseMSat:   lnwire.MilliSatoshi(baseFee),
+					FeeProportionalMillionths: lnwire.MilliSatoshi(
+						ppmFee,
+					),
+					ToNodePubKey: func() route.Vertex {
+						return vb2
+					},
+					ToNodeFeatures: features,
 				},
-				ToNodeFeatures: features,
+				blindingPoint: blindedPoint,
+				cipherText:    cipherText,
 			},
 		},
 		vb2: {
-			{
-				ToNodePubKey: func() route.Vertex {
-					return vb3
+			&BlindedEdge{
+				policy: &models.CachedEdgePolicy{
+					ToNodePubKey: func() route.Vertex {
+						return vb3
+					},
+					ToNodeFeatures: features,
 				},
-				ToNodeFeatures: features,
+				cipherText: cipherText,
 			},
 		},
 	}
+
 	actual := blindedPayment.toRouteHints()
 
 	require.Equal(t, len(expected), len(actual))
@@ -170,13 +191,24 @@ func TestBlindedPaymentToHints(t *testing.T) {
 		require.Len(t, actualHint, 1)
 
 		// We can't assert that our functions are equal, so we check
-		// their output and then mark as nil so that we can use
+		// their output and then mark them as nil so that we can use
 		// require.Equal for all our other fields.
-		require.Equal(t, expectedHint[0].ToNodePubKey(),
-			actualHint[0].ToNodePubKey())
+		require.Equal(t, expectedHint[0].EdgePolicy().ToNodePubKey(),
+			actualHint[0].EdgePolicy().ToNodePubKey())
 
-		actualHint[0].ToNodePubKey = nil
-		expectedHint[0].ToNodePubKey = nil
+		actualHint[0].EdgePolicy().ToNodePubKey = nil
+		expectedHint[0].EdgePolicy().ToNodePubKey = nil
+
+		// The arguments we use for the payload do not matter as long as
+		// both functions return the same payload.
+		expectedPayloadSize := expectedHint[0].IntermediatePayloadSize(
+			0, 0, false, 0,
+		)
+		actualPayloadSize := actualHint[0].IntermediatePayloadSize(
+			0, 0, false, 0,
+		)
+
+		require.Equal(t, expectedPayloadSize, actualPayloadSize)
 
 		require.Equal(t, expectedHint[0], actualHint[0])
 	}

--- a/routing/mocks.go
+++ b/routing/mocks.go
@@ -1,0 +1,32 @@
+package routing
+
+import (
+	"github.com/lightningnetwork/lnd/channeldb/models"
+	"github.com/lightningnetwork/lnd/lnwire"
+	"github.com/stretchr/testify/mock"
+)
+
+// mockAdditionalEdge is a mock of the AdditionalEdge interface.
+type mockAdditionalEdge struct{ mock.Mock }
+
+// IntermediatePayloadSize returns the sphinx payload size defined in BOLT04 if
+// this edge were to be included in a route.
+func (m *mockAdditionalEdge) IntermediatePayloadSize(amount lnwire.MilliSatoshi,
+	expiry uint32, legacy bool, channelID uint64) uint64 {
+
+	args := m.Called(amount, expiry, legacy, channelID)
+
+	return args.Get(0).(uint64)
+}
+
+// EdgePolicy return the policy of the mockAdditionalEdge.
+func (m *mockAdditionalEdge) EdgePolicy() *models.CachedEdgePolicy {
+	args := m.Called()
+
+	edgePolicy := args.Get(0)
+	if edgePolicy == nil {
+		return nil
+	}
+
+	return edgePolicy.(*models.CachedEdgePolicy)
+}

--- a/routing/pathfind.go
+++ b/routing/pathfind.go
@@ -408,6 +408,11 @@ type RestrictParams struct {
 	// invoices.
 	PaymentAddr *[32]byte
 
+	// Amp signals to the pathfinder that this payment is an AMP payment
+	// and therefore it needs to account for additional AMP data in the
+	// final hop payload size calculation.
+	Amp *AMPOptions
+
 	// Metadata is additional data that is sent along with the payment to
 	// the payee.
 	Metadata []byte
@@ -1134,12 +1139,21 @@ func lastHopPayloadSize(r *RestrictParams, finalHtlcExpiry int32,
 		mpp = record.NewMPP(amount, *r.PaymentAddr)
 	}
 
+	var amp *record.AMP
+	if r.Amp != nil {
+		// The AMP payload is not easy accessible at this point but we
+		// are only interested in the size of the payload so we just use
+		// the AMP record dummy.
+		amp = &record.MaxAmpPayLoadSize
+	}
+
 	finalHop := route.Hop{
 		AmtToForward:     amount,
 		OutgoingTimeLock: uint32(finalHtlcExpiry),
 		CustomRecords:    r.DestCustomRecords,
 		LegacyPayload:    legacy,
 		MPP:              mpp,
+		AMP:              amp,
 		Metadata:         r.Metadata,
 	}
 

--- a/routing/pathfind_test.go
+++ b/routing/pathfind_test.go
@@ -3469,6 +3469,7 @@ func TestLastHopPayloadSize(t *testing.T) {
 		)
 		_, blindedPoint       = btcec.PrivKeyFromBytes([]byte{5})
 		paymentAddr           = &[32]byte{1}
+		ampOptions            = &AMPOptions{}
 		amtToForward          = lnwire.MilliSatoshi(10000)
 		finalHopExpiry  int32 = 144
 
@@ -3510,6 +3511,7 @@ func TestLastHopPayloadSize(t *testing.T) {
 				PaymentAddr:       paymentAddr,
 				DestCustomRecords: customRecords,
 				Metadata:          metadata,
+				Amp:               ampOptions,
 			},
 			amount:         amtToForward,
 			finalHopExpiry: finalHopExpiry,
@@ -3524,6 +3526,7 @@ func TestLastHopPayloadSize(t *testing.T) {
 				PaymentAddr:       paymentAddr,
 				DestCustomRecords: customRecords,
 				Metadata:          metadata,
+				Amp:               ampOptions,
 			},
 			amount:         amtToForward,
 			finalHopExpiry: finalHopExpiry,
@@ -3560,6 +3563,13 @@ func TestLastHopPayloadSize(t *testing.T) {
 				)
 			}
 
+			// In case it's an AMP payment we use the max AMP record
+			// size to estimate the final hop size.
+			var amp *record.AMP
+			if tc.restrictions.Amp != nil {
+				amp = &record.MaxAmpPayLoadSize
+			}
+
 			var finalHop route.Hop
 			if tc.restrictions.BlindedPayment != nil {
 				blindedPath := tc.restrictions.BlindedPayment.
@@ -3586,6 +3596,7 @@ func TestLastHopPayloadSize(t *testing.T) {
 					OutgoingTimeLock: uint32(tc.finalHopExpiry),
 					Metadata:         tc.restrictions.Metadata,
 					MPP:              mpp,
+					AMP:              amp,
 					CustomRecords:    tc.restrictions.DestCustomRecords,
 				}
 			}

--- a/routing/payment_lifecycle.go
+++ b/routing/payment_lifecycle.go
@@ -628,7 +628,7 @@ func (p *paymentLifecycle) createNewPaymentAttempt(rt *route.Route,
 		return nil, err
 	}
 
-	// It this shard carries MPP or AMP options, add them to the last hop
+	// If this shard carries MPP or AMP options, add them to the last hop
 	// on the route.
 	hop := rt.Hops[len(rt.Hops)-1]
 	if shard.MPP() != nil {

--- a/routing/payment_session.go
+++ b/routing/payment_session.go
@@ -163,7 +163,7 @@ type PaymentSession interface {
 // loop if payment attempts take long enough. An additional set of edges can
 // also be provided to assist in reaching the payment's destination.
 type paymentSession struct {
-	additionalEdges map[route.Vertex][]*models.CachedEdgePolicy
+	additionalEdges map[route.Vertex][]AdditionalEdge
 
 	getBandwidthHints func(routingGraph) (bandwidthHints, error)
 
@@ -441,11 +441,12 @@ func (p *paymentSession) GetAdditionalEdgePolicy(pubKey *btcec.PublicKey,
 	}
 
 	for _, edge := range edges {
-		if edge.ChannelID != channelID {
+		policy := edge.EdgePolicy()
+		if policy.ChannelID != channelID {
 			continue
 		}
 
-		return edge
+		return policy
 	}
 
 	return nil

--- a/routing/payment_session.go
+++ b/routing/payment_session.go
@@ -258,6 +258,7 @@ func (p *paymentSession) RequestRoute(maxAmt, feeLimit lnwire.MilliSatoshi,
 		DestCustomRecords:  p.payment.DestCustomRecords,
 		DestFeatures:       p.payment.DestFeatures,
 		PaymentAddr:        p.payment.PaymentAddr,
+		Amp:                p.payment.amp,
 		Metadata:           p.payment.Metadata,
 	}
 

--- a/routing/payment_session_source.go
+++ b/routing/payment_session_source.go
@@ -95,9 +95,9 @@ func (m *SessionSource) NewPaymentSessionEmpty() PaymentSession {
 // RouteHintsToEdges converts a list of invoice route hints to an edge map that
 // can be passed into pathfinding.
 func RouteHintsToEdges(routeHints [][]zpay32.HopHint, target route.Vertex) (
-	map[route.Vertex][]*models.CachedEdgePolicy, error) {
+	map[route.Vertex][]AdditionalEdge, error) {
 
-	edges := make(map[route.Vertex][]*models.CachedEdgePolicy)
+	edges := make(map[route.Vertex][]AdditionalEdge)
 
 	// Traverse through all of the available hop hints and include them in
 	// our edges map, indexed by the public key of the channel's starting
@@ -127,7 +127,7 @@ func RouteHintsToEdges(routeHints [][]zpay32.HopHint, target route.Vertex) (
 			// Finally, create the channel edge from the hop hint
 			// and add it to list of edges corresponding to the node
 			// at the start of the channel.
-			edge := &models.CachedEdgePolicy{
+			edgePolicy := &models.CachedEdgePolicy{
 				ToNodePubKey: func() route.Vertex {
 					return endNode.PubKeyBytes
 				},
@@ -140,6 +140,10 @@ func RouteHintsToEdges(routeHints [][]zpay32.HopHint, target route.Vertex) (
 					hopHint.FeeProportionalMillionths,
 				),
 				TimeLockDelta: hopHint.CLTVExpiryDelta,
+			}
+
+			edge := &PrivateEdge{
+				policy: edgePolicy,
 			}
 
 			v := route.NewVertex(hopHint.NodeID)

--- a/routing/payment_session_test.go
+++ b/routing/payment_session_test.go
@@ -138,7 +138,7 @@ func TestUpdateAdditionalEdge(t *testing.T) {
 	require.Equal(t, 1, len(policies), "should have 1 edge policy")
 
 	// Check that the policy has been created as expected.
-	policy := policies[0]
+	policy := policies[0].EdgePolicy()
 	require.Equal(t, testChannelID, policy.ChannelID, "channel ID mismatch")
 	require.Equal(t,
 		oldExpiryDelta, policy.TimeLockDelta, "timelock delta mismatch",

--- a/routing/router.go
+++ b/routing/router.go
@@ -1954,7 +1954,7 @@ type RouteRequest struct {
 
 // RouteHints is an alias type for a set of route hints, with the source node
 // as the map's key and the details of the hint(s) in the edge policy.
-type RouteHints map[route.Vertex][]*models.CachedEdgePolicy
+type RouteHints map[route.Vertex][]AdditionalEdge
 
 // NewRouteRequest produces a new route request for a regular payment or one
 // to a blinded route, validating that the target, routeHints and finalExpiry

--- a/routing/router_test.go
+++ b/routing/router_test.go
@@ -3954,7 +3954,7 @@ func TestNewRouteRequest(t *testing.T) {
 			name:           "hints and blinded",
 			blindedPayment: blindedMultiHop,
 			routeHints: make(
-				map[route.Vertex][]*models.CachedEdgePolicy,
+				map[route.Vertex][]AdditionalEdge,
 			),
 			err: ErrHintsAndBlinded,
 		},

--- a/routing/unified_edges_test.go
+++ b/routing/unified_edges_test.go
@@ -41,15 +41,17 @@ func TestNodeEdgeUnifier(t *testing.T) {
 	c2 := btcutil.Amount(8)
 
 	unifierFilled := newNodeEdgeUnifier(source, toNode, nil)
-	unifierFilled.addPolicy(fromNode, &p1, c1)
-	unifierFilled.addPolicy(fromNode, &p2, c2)
+	unifierFilled.addPolicy(fromNode, &p1, c1, defaultHopPayloadSize)
+	unifierFilled.addPolicy(fromNode, &p2, c2, defaultHopPayloadSize)
 
 	unifierNoCapacity := newNodeEdgeUnifier(source, toNode, nil)
-	unifierNoCapacity.addPolicy(fromNode, &p1, 0)
-	unifierNoCapacity.addPolicy(fromNode, &p2, 0)
+	unifierNoCapacity.addPolicy(fromNode, &p1, 0, defaultHopPayloadSize)
+	unifierNoCapacity.addPolicy(fromNode, &p2, 0, defaultHopPayloadSize)
 
 	unifierNoInfo := newNodeEdgeUnifier(source, toNode, nil)
-	unifierNoInfo.addPolicy(fromNode, &models.CachedEdgePolicy{}, 0)
+	unifierNoInfo.addPolicy(
+		fromNode, &models.CachedEdgePolicy{}, 0, defaultHopPayloadSize,
+	)
 
 	tests := []struct {
 		name             string


### PR DESCRIPTION
## Change Description
When blinded payments were introduced we decided with Carla to fix the payload size estimate in a follow-up PR. This PR addresses this issue. 

Design Choices which were made:

1. Introduced a new type `AdditionalEdge` which houses the size functions for an additonal edge. We currently have 2 different types of additional edge: Blinded Hops and Routing Hints (unannounced channels)
2. A new element `hopPayloadSize` was added to the `unifiedEdge` struct so that we can calculate the payload size in the `pathfind` function.

Only unit tests were added because this change touches the inner workings of the pathfinder which can be tested sufficiently by unit-tests.

[reviewable.io](https://reviewable.io/reviews/lightningnetwork/lnd/7852)
   





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new field for blinded payments in route queries, enhancing privacy and flexibility.
	- Added functionality to define and handle additional edges in routes, supporting both private and blinded edges.
	- Improved spontaneous AMP payments handling by requiring them to be enabled for certain scenarios.

- **Bug Fixes**
	- Fixed payload size calculation for routes involving new TLV records with blinded hops.

- **Tests**
	- Added tests for intermediate payload size calculations of private and blinded edges.
	- Introduced new test cases for pathfinding with maximum payload size restrictions and final hop payload size.

- **Documentation**
	- Updated documentation to reflect changes in payload size calculation and the requirement for spontaneous AMP payments.

- **Refactor**
	- Refactored internal structures to support additional edge types and simplified handling of route hints.
	- Minor correction in a comment for better clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->