### PR TITLE
itest: bind to local addr in network test

### DIFF
--- a/docs/release-notes/release-notes-0.17.0.md
+++ b/docs/release-notes/release-notes-0.17.0.md
@@ -148,6 +148,9 @@ unlock or create.
 * [Simplify fuzz tests](https://github.com/lightningnetwork/lnd/pull/7709)
   using the `require` package.
 
+* [Removed](https://github.com/lightningnetwork/lnd/pull/7854) need for an
+  active internet connection for the network connection itest.
+
 ## `lncli`
 
 * Added ability to use [ENV variables to override `lncli` global flags](https://github.com/lightningnetwork/lnd/pull/7693). Flags will have preference over ENVs.


### PR DESCRIPTION
This makes the test work even if the local OS has no outside network connections available or if DNS lookups are failing.

This was motivated because I was running the complete set of tests while being offline from the internet, thus the DNS queries for "lightning.engineering" were failing (instead of the desired connection timeout).

This also has a small privacy benefit because it prevents announcing to the upstream DNS providers whenever you're running the suite of tests.