### PR TITLE
peer: ensure the peer has been started before Disconnect can be called

### DIFF
--- a/docs/release-notes/release-notes-0.17.0.md
+++ b/docs/release-notes/release-notes-0.17.0.md
@@ -194,6 +194,10 @@ unlock or create.
   Tor](https://github.com/lightningnetwork/lnd/pull/7783), even when
   `tor.skip-proxy-for-clearnet-targets=true` was set.
 
+* Fix a [concurrency issue related to rapid peer teardown and
+  creation](https://github.com/lightningnetwork/lnd/pull/7856) that can arise
+  under rare scenarios.
+
 ### Tooling and documentation
 
 * Add support for [custom `RPCHOST` and
@@ -226,6 +230,7 @@ unlock or create.
 * Maxwell Sayles
 * Michael Street
 * MG-ng
+* Olaoluwa Osuntokun
 * Oliver Gugger
 * Pierre Beugnet
 * Satarupa Deb

--- a/peer/brontide.go
+++ b/peer/brontide.go
@@ -469,9 +469,8 @@ type Brontide struct {
 	// potentially holding lots of un-consumed events.
 	channelEventClient *subscribe.Client
 
-	queueQuit chan struct{}
-	quit      chan struct{}
-	wg        sync.WaitGroup
+	quit chan struct{}
+	wg   sync.WaitGroup
 
 	// log is a peer-specific logging instance.
 	log btclog.Logger
@@ -501,7 +500,6 @@ func NewBrontide(cfg Config) *Brontide {
 		linkFailures:       make(chan linkFailureReport),
 		chanCloseMsgs:      make(chan *closeMsg),
 		resentChanSyncMsg:  make(map[lnwire.ChannelID]struct{}),
-		queueQuit:          make(chan struct{}),
 		quit:               make(chan struct{}),
 		log:                build.NewPrefixLog(logPrefix, peerLog),
 	}


### PR DESCRIPTION
In this commit, we make sure that all the `wg.Add(1)` calls succeed
before we attempt to wait on the shutdown of all the goroutines. Under
rare scheduling scenarios, if both `Start` and `Disconnect` are called
concurrently, then this internal race error can be hit, causing the
panic to occur.

Fixes https://github.com/lightningnetwork/lnd/issues/7853