### PR TITLE
chainntnfs: remove block info from conf detail copy

### DIFF
--- a/chainntnfs/txnotifier.go
+++ b/chainntnfs/txnotifier.go
@@ -666,11 +666,15 @@ func (n *TxNotifier) RegisterConf(txid *chainhash.Hash, pkScript []byte,
 		// block along with the rest of the details. However not all
 		// clients want the block, so we make a copy here w/o the block
 		// if needed so we can give clients only what they ask for.
-		if !ntfn.includeBlock && confSet.details != nil {
-			confSet.details.Block = nil
+		confDetails := confSet.details
+		if !ntfn.includeBlock && confDetails != nil {
+			confDetailsCopy := *confDetails
+			confDetailsCopy.Block = nil
+
+			confDetails = &confDetailsCopy
 		}
 
-		err := n.dispatchConfDetails(ntfn, confSet.details)
+		err := n.dispatchConfDetails(ntfn, confDetails)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
Noticed this while updating to latest `master` in another project: If there are two notifications for the same output being registered and the first one does _NOT_ request the block to be included, then the second one also will not receive the block, even if it explicitly requests it.
This is caused by the block being removed from the original confirmation set instead of a copy (as it is done in `NotifyHeight` and `UpdateConfDetails`).

Fixes https://github.com/lightningnetwork/lnd/issues/7501

