### PR TITLE
input: fix `RequiredLockTime` for `HtlcSecondLevelAnchorInput`

### DIFF
--- a/input/input.go
+++ b/input/input.go
@@ -314,7 +314,7 @@ func (i *HtlcSecondLevelAnchorInput) RequiredTxOut() *wire.TxOut {
 // of the input to be valid. For a second level HTLC timeout this will be the
 // CLTV expiry, for HTLC success it will be zero.
 func (i *HtlcSecondLevelAnchorInput) RequiredLockTime() (uint32, bool) {
-	return i.SignedTx.LockTime, true
+	return i.SignedTx.LockTime, i.SignedTx.LockTime > 0
 }
 
 // CraftInputScript returns a valid set of input scripts allowing this output


### PR DESCRIPTION
This commit changes the method `RequiredLockTime` for `HtlcSecondLevelAnchorInput` from always returning true to returning a boolean based on the actual locktime value. Previously this would mean the second level HTLC success would also be put into a locktime group by the sweeper with a locktime of 0. This is a preventive fix rather than an actual bug fix.