### PR TITLE
trivial: fix loggings, variable names and conf notification order

### DIFF
--- a/contractcourt/channel_arbitrator.go
+++ b/contractcourt/channel_arbitrator.go
@@ -1090,10 +1090,10 @@ func (c *ChannelArbitrator) stateStep(
 			break
 		}
 
-		// Now that we know we'll need to act, we'll process the htlc
-		// actions, then create the structures we need to resolve all
+		// Now that we know we'll need to act, we'll process all the
+		// resolvers, then create the structures we need to resolve all
 		// outstanding contracts.
-		htlcResolvers, pktsToSend, err := c.prepContractResolutions(
+		resolvers, pktsToSend, err := c.prepContractResolutions(
 			contractResolutions, triggerHeight, trigger,
 			confCommitSet,
 		)
@@ -1120,16 +1120,16 @@ func (c *ChannelArbitrator) stateStep(
 		}
 
 		log.Debugf("ChannelArbitrator(%v): inserting %v contract "+
-			"resolvers", c.cfg.ChanPoint, len(htlcResolvers))
+			"resolvers", c.cfg.ChanPoint, len(resolvers))
 
-		err = c.log.InsertUnresolvedContracts(nil, htlcResolvers...)
+		err = c.log.InsertUnresolvedContracts(nil, resolvers...)
 		if err != nil {
 			return StateError, closeTx, err
 		}
 
 		// Finally, we'll launch all the required contract resolvers.
 		// Once they're all resolved, we're no longer needed.
-		c.launchResolvers(htlcResolvers)
+		c.launchResolvers(resolvers)
 
 		nextState = StateWaitingFullResolution
 

--- a/contractcourt/channel_arbitrator.go
+++ b/contractcourt/channel_arbitrator.go
@@ -1103,15 +1103,15 @@ func (c *ChannelArbitrator) stateStep(
 			return StateError, closeTx, err
 		}
 
-		log.Debugf("ChannelArbitrator(%v): sending resolution message=%v",
-			c.cfg.ChanPoint,
-			newLogClosure(func() string {
-				return spew.Sdump(pktsToSend)
-			}))
-
 		// With the commitment broadcast, we'll then send over all
 		// messages we can send immediately.
 		if len(pktsToSend) != 0 {
+			log.Debugf("ChannelArbitrator(%v): sending "+
+				"resolution message=%v", c.cfg.ChanPoint,
+				newLogClosure(func() string {
+					return spew.Sdump(pktsToSend)
+				}))
+
 			err := c.cfg.DeliverResolutionMsg(pktsToSend...)
 			if err != nil {
 				log.Errorf("unable to send pkts: %v", err)

--- a/input/input.go
+++ b/input/input.go
@@ -1,6 +1,8 @@
 package input
 
 import (
+	"fmt"
+
 	"github.com/btcsuite/btcd/btcutil"
 	"github.com/btcsuite/btcd/txscript"
 	"github.com/btcsuite/btcd/wire"
@@ -67,6 +69,11 @@ type TxInfo struct {
 
 	// Weight is the weight of the tx.
 	Weight int64
+}
+
+// String returns a human readable version of the tx info.
+func (t *TxInfo) String() string {
+	return fmt.Sprintf("fee=%v, weight=%v", t.Fee, t.Weight)
 }
 
 // SignDetails is a struct containing information needed to resign certain

--- a/sweep/sweeper.go
+++ b/sweep/sweeper.go
@@ -98,8 +98,13 @@ type ParamsUpdate struct {
 
 // String returns a human readable interpretation of the sweep parameters.
 func (p Params) String() string {
-	return fmt.Sprintf("fee=%v, force=%v, exclusive_group=%v",
-		p.Fee, p.Force, p.ExclusiveGroup)
+	if p.ExclusiveGroup != nil {
+		return fmt.Sprintf("fee=%v, force=%v, exclusive_group=%v",
+			p.Fee, p.Force, *p.ExclusiveGroup)
+	}
+
+	return fmt.Sprintf("fee=%v, force=%v, exclusive_group=nil",
+		p.Fee, p.Force)
 }
 
 // pendingInput is created when an input reaches the main loop for the first
@@ -463,9 +468,10 @@ func (s *UtxoSweeper) SweepInput(input input.Input,
 	absoluteTimeLock, _ := input.RequiredLockTime()
 	log.Infof("Sweep request received: out_point=%v, witness_type=%v, "+
 		"relative_time_lock=%v, absolute_time_lock=%v, amount=%v, "+
-		"params=(%v)", input.OutPoint(), input.WitnessType(),
-		input.BlocksToMaturity(), absoluteTimeLock,
-		btcutil.Amount(input.SignDesc().Output.Value), params)
+		"parent=(%v), params=(%v)", input.OutPoint(),
+		input.WitnessType(), input.BlocksToMaturity(), absoluteTimeLock,
+		btcutil.Amount(input.SignDesc().Output.Value),
+		input.UnconfParent(), params)
 
 	sweeperInput := &sweepInputMessage{
 		input:      input,


### PR DESCRIPTION
Found some trivial issues during code reviews. This PR fixes/improves the logging, renamed a variable name to avoid confusion, and, makes sure registration for confirmation notification happens before publishing the tx.