### PR TITLE
funding: remove dead code and sanity check pending chan ID

### DIFF
--- a/lnwallet/test/test_interface.go
+++ b/lnwallet/test/test_interface.go
@@ -773,6 +773,7 @@ func testReservationInitiatorBalanceBelowDustCancel(miner *rpctest.Harness,
 		PushMSat:         0,
 		Flags:            lnwire.FFAnnounceChannel,
 		CommitType:       lnwallet.CommitmentTypeTweakless,
+		PendingChanID:    [32]byte{1},
 	}
 	_, err = alice.InitChannelReservation(req)
 	switch {
@@ -2744,7 +2745,7 @@ var walletTests = []walletTestCase{
 			testSingleFunderReservationWorkflow(
 				miner, alice, bob, t,
 				lnwallet.CommitmentTypeLegacy, nil,
-				nil, [32]byte{}, 0,
+				nil, [32]byte{1}, 0,
 			)
 		},
 	},
@@ -2756,7 +2757,7 @@ var walletTests = []walletTestCase{
 			testSingleFunderReservationWorkflow(
 				miner, alice, bob, t,
 				lnwallet.CommitmentTypeTweakless, nil,
-				nil, [32]byte{}, 0,
+				nil, [32]byte{1}, 0,
 			)
 		},
 	},
@@ -2768,7 +2769,7 @@ var walletTests = []walletTestCase{
 			testSingleFunderReservationWorkflow(
 				miner, alice, bob, t,
 				lnwallet.CommitmentTypeSimpleTaproot, nil,
-				nil, [32]byte{}, 0,
+				nil, [32]byte{1}, 0,
 			)
 		},
 	},

--- a/lnwallet/wallet_test.go
+++ b/lnwallet/wallet_test.go
@@ -1,0 +1,34 @@
+package lnwallet
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestRegisterFundingIntent checks RegisterFundingIntent behaves as expected.
+func TestRegisterFundingIntent(t *testing.T) {
+	t.Parallel()
+
+	require := require.New(t)
+
+	// Create a testing wallet.
+	lw, err := NewLightningWallet(Config{})
+	require.NoError(err)
+
+	// Init an empty testing channel ID.
+	var testID [32]byte
+
+	// Call the method with empty ID should give us an error.
+	err = lw.RegisterFundingIntent(testID, nil)
+	require.ErrorIs(err, ErrEmptyPendingChanID)
+
+	// Modify the ID and call the method again should result in no error.
+	testID[0] = 1
+	err = lw.RegisterFundingIntent(testID, nil)
+	require.NoError(err)
+
+	// Call the method using the same ID should give us an error.
+	err = lw.RegisterFundingIntent(testID, nil)
+	require.ErrorIs(err, ErrDuplicatePendingChanID)
+}


### PR DESCRIPTION
A follow up PR from #7518, this PR removes the unused `newChanBarriers`, renames some of the methods for clarity, and adds a sanity check to make sure `pendingChanID` is not set to zero.