### PR TITLE
trivial: fix unit test flake for `Ping` message

### DIFF
--- a/lnwire/lnwire_test.go
+++ b/lnwire/lnwire_test.go
@@ -937,8 +937,9 @@ func TestLightningWireProtocol(t *testing.T) {
 			//
 			// We'll allow the test to generate padding bytes up to
 			// the max message limit, factoring in the 2 bytes for
-			// the num pong bytes.
-			paddingBytes := make([]byte, r.Intn(MaxMsgBody-1))
+			// the num pong bytes and 2 bytes for encoding the
+			// length of the padding bytes.
+			paddingBytes := make([]byte, rand.Intn(MaxMsgBody-3))
 			req := Ping{
 				NumPongBytes: uint16(r.Intn(MaxPongBytes + 1)),
 				PaddingBytes: paddingBytes,


### PR DESCRIPTION
Found a unit test flake from [this build](https://github.com/lightningnetwork/lnd/actions/runs/5888391278/job/15969508055?pr=7881), turns out we need to subtract the 2 bytes used to encode the padding bytes length.