### PR TITLE
Clarify total_limbo_balance description [skip ci]

### DIFF
--- a/lnrpc/lightning.pb.go
+++ b/lnrpc/lightning.pb.go
@@ -8604,7 +8604,8 @@ type PendingChannelsResponse struct {
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	// The balance in satoshis encumbered in pending channels
+	// The balance in satoshis encumbered in pending channels. This does not
+	// include funds from pending_open_channels.
 	TotalLimboBalance int64 `protobuf:"varint,1,opt,name=total_limbo_balance,json=totalLimboBalance,proto3" json:"total_limbo_balance,omitempty"`
 	// Channels pending opening
 	PendingOpenChannels []*PendingChannelsResponse_PendingOpenChannel `protobuf:"bytes,2,rep,name=pending_open_channels,json=pendingOpenChannels,proto3" json:"pending_open_channels,omitempty"`

--- a/lnrpc/lightning.proto
+++ b/lnrpc/lightning.proto
@@ -2781,7 +2781,10 @@ message PendingChannelsResponse {
         AnchorState anchor = 9;
     }
 
-    // The balance in satoshis encumbered in pending channels
+    /*
+    The balance in satoshis encumbered in pending channels. This does not
+    include funds from pending_open_channels.
+    */
     int64 total_limbo_balance = 1;
 
     // Channels pending opening

--- a/lnrpc/lightning.swagger.json
+++ b/lnrpc/lightning.swagger.json
@@ -6233,7 +6233,7 @@
         "total_limbo_balance": {
           "type": "string",
           "format": "int64",
-          "title": "The balance in satoshis encumbered in pending channels"
+          "description": "The balance in satoshis encumbered in pending channels. This does not\ninclude funds from pending_open_channels."
         },
         "pending_open_channels": {
           "type": "array",


### PR DESCRIPTION
## Change Description
The definition of  a pending channel according to the `pendingchannels` API includes pending_open_channels. However, the total_limbo_balance description does not reflect that pending_open_channels are not included in this calculation. This updates the description to clarify that the total_limbo_balance does not include pending_open_channels.

## Steps to Test
Open a channel. While it is waiting to confirm, call `pendingchannels`. total_limbo_balance will return 0.

## Pull Request Checklist
### Testing
- [ ] Your PR passes all CI checks.
- [ ] Tests covering the positive and negative (error paths) are included.
- [ ] Bug fixes contain tests triggering the bug to prevent regressions.

### Code Style and Documentation
- [ ] The change obeys the [Code Documentation and Commenting](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#CodeDocumentation) guidelines, and lines wrap at 80.
- [ ] Commits follow the [Ideal Git Commit Structure](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#IdealGitCommitStructure).
- [ ] Any new logging statements use an appropriate subsystem and logging level.
- [ ]  [There is a change description in the release notes](https://github.com/lightningnetwork/lnd/tree/master/docs/release-notes), or `[skip ci]` in the commit message for small changes.

📝 Please see our  [Contribution Guidelines](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md) for further guidance.