### PR TITLE
build: bump Go version to v1.21.0, lnd version to v0.17.0 rc1

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,7 +29,7 @@ env:
   # /dev.Dockerfile
   # /make/builder.Dockerfile
   # /.github/workflows/release.yml
-  GO_VERSION: 1.20.3
+  GO_VERSION: 1.21.0
 
 jobs:
   ########################

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -16,7 +16,7 @@ env:
   # /dev.Dockerfile
   # /make/builder.Dockerfile
   # /.github/workflows/main.yml
-  GO_VERSION: 1.20.3
+  GO_VERSION: 1.21.0
 
 jobs:
   main:

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ go:
   # /make/builder.Dockerfile
   # /.github/workflows/main.yml
   # /.github/workflows/release.yml
-  - "1.20.3"
+  - "1.21.0"
 
 env:
   global:

--- a/build/version.go
+++ b/build/version.go
@@ -40,14 +40,14 @@ const (
 	AppMajor uint = 0
 
 	// AppMinor defines the minor version of this binary.
-	AppMinor uint = 16
+	AppMinor uint = 17
 
 	// AppPatch defines the application patch for this binary.
-	AppPatch uint = 99
+	AppPatch uint = 0
 
 	// AppPreRelease MUST only contain characters from semanticAlphabet
 	// per the semantic versioning spec.
-	AppPreRelease = "beta"
+	AppPreRelease = "beta.rc1"
 )
 
 func init() {

--- a/dev.Dockerfile
+++ b/dev.Dockerfile
@@ -4,7 +4,7 @@
 # /make/builder.Dockerfile
 # /.github/workflows/main.yml
 # /.github/workflows/release.yml
-FROM golang:1.20.3-alpine as builder
+FROM golang:1.21.0-alpine as builder
 
 LABEL maintainer="Olaoluwa Osuntokun <laolu@lightning.engineering>"
 

--- a/make/builder.Dockerfile
+++ b/make/builder.Dockerfile
@@ -4,7 +4,7 @@
 # /dev.Dockerfile
 # /.github/workflows/main.yml
 # /.github/workflows/release.yml
-FROM golang:1.20.3-buster
+FROM golang:1.21.0-buster
 
 MAINTAINER Olaoluwa Osuntokun <laolu@lightning.engineering>
 


### PR DESCRIPTION
With this PR, we kick off the start of the v0.17 rc cycle. We first update the build system to use the latest version of Go, then bump to the latest v0.17.0 rc1 version. 