### PR TITLE
docs: fix simple-taproot-channels typo [skip ci]

### DIFF
--- a/channeldb/channel.go
+++ b/channeldb/channel.go
@@ -306,7 +306,7 @@ const (
 	// negotiated during the lifetime of this channel.
 	ScidAliasFeatureBit ChannelType = 1 << 9
 
-	// SimpleTaprootFeatureBit indicates that the simple-taproot-channels
+	// SimpleTaprootFeatureBit indicates that the simple-taproot-chans
 	// feature bit was negotiated during the lifetime of the channel.
 	SimpleTaprootFeatureBit ChannelType = 1 << 10
 )

--- a/docs/release-notes/release-notes-0.17.0.md
+++ b/docs/release-notes/release-notes-0.17.0.md
@@ -68,7 +68,7 @@
 * This release marks the first release that includes the new [musig2-based
   taproot channel type](https://github.com/lightningnetwork/lnd/pull/7904). As
   new protocol feature hasn't yet been finalized, users must enable taproot
-  channels with a new flag: `--protocol.simple-taproot-channels`. Once enabled,
+  channels with a new flag: `--protocol.simple-taproot-chans`. Once enabled,
   user MUST use the explicit channel type to request the taproot channel type
   (pending support by the remote peer). For `lncli openchannel`,
   `--channel_type=taproot` should be used.


### PR DESCRIPTION
## Change Description
In the release notes for [v0.17.0](https://github.com/lightningnetwork/lnd/blob/master/docs/release-notes/release-notes-0.17.0.md), it states to use the startup flag `--simple-taproot-channels` but the correct flag is named `--simple-taproot-chans`. This PR just updates this typo. 

I also found one more reference to `simple-taproot-channels` in a comment of the [channel.go](https://github.com/jamaljsr/lnd/blob/79b766579c3d709e86e8400d18e90c3cdd9b8893/channeldb/channel.go) file so I fixed that as well.

## Steps to Test
This fixes only documentation and code comments. There are no test steps to perform.

## Pull Request Checklist
### Testing
- [x] Your PR passes all CI checks.
- [x] Tests covering the positive and negative (error paths) are included.
- [x] Bug fixes contain tests triggering the bug to prevent regressions.

### Code Style and Documentation
- [x] The change obeys the [Code Documentation and Commenting](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#CodeDocumentation) guidelines, and lines wrap at 80.
- [x] Commits follow the [Ideal Git Commit Structure](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#IdealGitCommitStructure).
- [x] Any new logging statements use an appropriate subsystem and logging level.
- [x]  [There is a change description in the release notes](https://github.com/lightningnetwork/lnd/tree/master/docs/release-notes), or `[skip ci]` in the commit message for small changes.

📝 Please see our  [Contribution Guidelines](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md) for further guidance.