### PR TITLE
multi: ensure link is always torn down due to db failures, add exponential back off for sql-kvdb failures

### DIFF
--- a/docs/release-notes/release-notes-0.17.0.md
+++ b/docs/release-notes/release-notes-0.17.0.md
@@ -66,6 +66,11 @@
 fails](https://github.com/lightningnetwork/lnd/pull/7876).
 
 
+* Failed `sqlite` or `postgres` transactions due to a serialization error will
+  now be [automatically
+  retried](https://github.com/lightningnetwork/lnd/pull/7927) with an
+  exponential back off.
+
 # New Features
 ## Functional Enhancements
 ### Protocol Features

--- a/docs/release-notes/release-notes-0.17.0.md
+++ b/docs/release-notes/release-notes-0.17.0.md
@@ -59,8 +59,12 @@
   have to make sure to not broadcast outdated transactions which can lead to
   locked up wallet funds indefinitely in the worst case.
 
-- [Remove nil value](https://github.com/lightningnetwork/lnd/pull/7922) from
+* [Remove nil value](https://github.com/lightningnetwork/lnd/pull/7922) from
   variadic parameter list.
+
+* Make sure to [fail a channel if revoking the old channel state 
+fails](https://github.com/lightningnetwork/lnd/pull/7876).
+
 
 # New Features
 ## Functional Enhancements

--- a/htlcswitch/link.go
+++ b/htlcswitch/link.go
@@ -1943,6 +1943,23 @@ func (l *channelLink) handleUpstreamMsg(msg lnwire.Message) {
 			l.channel.RevokeCurrentCommitment()
 		if err != nil {
 			l.log.Errorf("unable to revoke commitment: %v", err)
+
+			// We need to fail the channel in case revoking our
+			// local commitment does not succeed. We might have
+			// already advanced our channel state which would lead
+			// us to proceed with an unclean state.
+			//
+			// NOTE: We do not trigger a force close because this
+			// could resolve itself in case our db was just busy not
+			// accepting new transactions.
+			l.fail(
+				LinkFailureError{
+					code: ErrInternalError,
+				},
+				"ChannelPoint(%v): unable to accept new "+
+					"commitment: %v",
+				l.channel.ChannelPoint(), err,
+			)
 			return
 		}
 		l.cfg.Peer.SendMessage(false, nextRevocation)

--- a/htlcswitch/link.go
+++ b/htlcswitch/link.go
@@ -1950,11 +1950,13 @@ func (l *channelLink) handleUpstreamMsg(msg lnwire.Message) {
 			// us to proceed with an unclean state.
 			//
 			// NOTE: We do not trigger a force close because this
-			// could resolve itself in case our db was just busy not
-			// accepting new transactions.
+			// could resolve itself in case our db was just busy
+			// not accepting new transactions.
 			l.fail(
 				LinkFailureError{
-					code: ErrInternalError,
+					code:          ErrInternalError,
+					Warning:       true,
+					FailureAction: LinkFailureDisconnect,
 				},
 				"ChannelPoint(%v): unable to accept new "+
 					"commitment: %v",
@@ -2024,8 +2026,13 @@ func (l *channelLink) handleUpstreamMsg(msg lnwire.Message) {
 			ReceiveRevocation(msg)
 		if err != nil {
 			// TODO(halseth): force close?
-			l.fail(LinkFailureError{code: ErrInvalidRevocation},
-				"unable to accept revocation: %v", err)
+			l.fail(
+				LinkFailureError{
+					code:          ErrInvalidRevocation,
+					FailureAction: LinkFailureDisconnect,
+				},
+				"unable to accept revocation: %v", err,
+			)
 			return
 		}
 

--- a/htlcswitch/linkfailure.go
+++ b/htlcswitch/linkfailure.go
@@ -86,6 +86,10 @@ type LinkFailureError struct {
 	// the channel should not be attempted loaded again.
 	PermanentFailure bool
 
+	// Warning denotes if this is a non-terminal error that doesn't warrant
+	// failing the channel all together.
+	Warning bool
+
 	// SendData is a byte slice that will be sent to the peer. If nil a
 	// generic error will be sent.
 	SendData []byte

--- a/kvdb/sqlbase/readwrite_tx.go
+++ b/kvdb/sqlbase/readwrite_tx.go
@@ -49,7 +49,8 @@ func newReadWriteTx(db *db, readOnly bool) (*readWriteTx, error) {
 	tx, err := db.db.BeginTx(
 		context.Background(),
 		&sql.TxOptions{
-			ReadOnly: readOnly,
+			ReadOnly:  readOnly,
+			Isolation: sql.LevelSerializable,
 		},
 	)
 	if err != nil {

--- a/lnwallet/channel.go
+++ b/lnwallet/channel.go
@@ -4425,7 +4425,7 @@ func (lc *LightningChannel) ProcessChanSyncMsg(
 	case msg.NextLocalCommitHeight == remoteTipHeight:
 		lc.log.Debugf("sync: remote's next commit height is %v, while "+
 			"we believe it is %v, we owe them a commitment",
-			msg.NextLocalCommitHeight, remoteTipHeight)
+			msg.NextLocalCommitHeight, remoteTipHeight+1)
 
 		// Grab the current remote chain tip from the database.  This
 		// commit diff contains all the information required to re-sync

--- a/peer/brontide.go
+++ b/peer/brontide.go
@@ -3093,10 +3093,21 @@ func (p *Brontide) handleLinkFailure(failure linkFailureReport) {
 		if failure.linkErr.SendData != nil {
 			data = failure.linkErr.SendData
 		}
-		err := p.SendMessage(true, &lnwire.Error{
-			ChanID: failure.chanID,
-			Data:   data,
-		})
+
+		var networkMsg lnwire.Message
+		if failure.linkErr.Warning {
+			networkMsg = &lnwire.Warning{
+				ChanID: failure.chanID,
+				Data:   data,
+			}
+		} else {
+			networkMsg = &lnwire.Error{
+				ChanID: failure.chanID,
+				Data:   data,
+			}
+		}
+
+		err := p.SendMessage(true, networkMsg)
 		if err != nil {
 			p.log.Errorf("unable to send msg to "+
 				"remote peer: %v", err)


### PR DESCRIPTION
This PR resolves two outstanding issues:
  1. If a revoke failed in the past, we wouldn't tear down the link. This could lead to desynchornized state, eventually leading to a force close. 
  2. For the `kvdb` SQL emulation backends, if we got an error (`SQLITE_BUSY`, etc), we should just fail right then. We now implement an exponential back off with some jitter to give other writing goroutines time to finish/interleave their writes. 

For 1, I tacked on an extra commit to just tear down the link all together. This may save us from a scenario where Alice had a DB failure, Bob then tries to send a new state, but Alice has torn down the link, but _not_ the TCP connection. In this case, Bob is now "stuck" as she's sent out a sig, and if Alice never recovers, they may need to go on chain to time out the HTLC. 

In the 0.18 cycle, as we move to integrate the pure SQL backends for payments/invoices, we'll want to attempt to unify some of this logic, as we effectively have two sql scaffoldings today: KV-emulation, and proper schema based.  


Replaces https://github.com/lightningnetwork/lnd/pull/7876/files 

Fixes https://github.com/lightningnetwork/lnd/issues/7869