### PR TITLE
psbt: fix channel funding address for simple taproot channels

### DIFF
--- a/itest/list_on_test.go
+++ b/itest/list_on_test.go
@@ -270,14 +270,6 @@ var allTestCases = []*lntest.TestCase{
 		TestFunc: testPsbtChanFunding,
 	},
 	{
-		Name:     "psbt channel funding external",
-		TestFunc: testPsbtChanFundingExternal,
-	},
-	{
-		Name:     "psbt channel funding single step",
-		TestFunc: testPsbtChanFundingSingleStep,
-	},
-	{
 		Name:     "sign psbt",
 		TestFunc: testSignPsbt,
 	},

--- a/itest/lnd_remote_signer_test.go
+++ b/itest/lnd_remote_signer_test.go
@@ -111,7 +111,10 @@ func testRemoteSigner(ht *lntest.HarnessTest) {
 		name:       "psbt",
 		randomSeed: true,
 		fn: func(tt *lntest.HarnessTest, wo, carol *node.HarnessNode) {
-			runPsbtChanFunding(tt, carol, wo)
+			runPsbtChanFunding(
+				tt, carol, wo, false,
+				lnrpc.CommitmentType_LEGACY,
+			)
 			runSignPsbtSegWitV0P2WKH(tt, wo)
 			runSignPsbtSegWitV1KeySpendBip86(tt, wo)
 			runSignPsbtSegWitV1KeySpendRootHash(tt, wo)


### PR DESCRIPTION
Fixes https://github.com/lightningnetwork/lnd/issues/7929.

Also adds PSBT funding integration tests for simple taproot channels.

Adding the `no-changelog` label as this is part of the RC bug fixing effort.