### PR TITLE
contractcourt: fix potential panic during startup

### DIFF
--- a/contractcourt/channel_arbitrator.go
+++ b/contractcourt/channel_arbitrator.go
@@ -731,13 +731,14 @@ func (c *ChannelArbitrator) relaunchResolvers(commitSet *CommitSet,
 
 		if chanState != nil {
 			resolver.SupplementState(chanState)
-		}
 
-		// For taproot channels, we'll need to also make sure the
-		// control block information was set properly.
-		maybeAugmentTaprootResolvers(
-			chanState.ChanType, resolver, contractResolutions,
-		)
+			// For taproot channels, we'll need to also make sure
+			// the control block information was set properly.
+			maybeAugmentTaprootResolvers(
+				chanState.ChanType, resolver,
+				contractResolutions,
+			)
+		}
 
 		unresolvedContracts[i] = resolver
 


### PR DESCRIPTION
Related to this fix https://github.com/lightningnetwork/lnd/commit/5a285827194f85af10c138da735b35a1faee97aa, we may not have the historical data for old channels so we skip it here too.

Fixes #7935 