### PR TITLE
htlcswitch/hop: use InvalidOnionVersion for replayed packets

### DIFF
--- a/docs/release-notes/release-notes-0.17.1.md
+++ b/docs/release-notes/release-notes-0.17.1.md
@@ -1,0 +1,48 @@
+# Release Notes
+- [Bug Fixes](#bug-fixes)
+- [New Features](#new-features)
+  - [Functional Enhancements](#functional-enhancements)
+  - [RPC Additions](#rpc-additions)
+  - [lncli Additions](#lncli-additions)
+- [Improvements](#improvements)
+  - [Functional Updates](#functional-updates)
+  - [RPC Updates](#rpc-updates)
+  - [lncli Updates](#lncli-updates)
+  - [Breaking Changes](#breaking-changes)
+  - [Performance Improvements](#performance-improvements)
+ - [Technical and Architectural Updates](#technical-and-architectural-updates)
+   - [BOLT Spec Updates](#bolt-spec-updates)
+   - [Testing](#testing)
+   - [Database](#database)
+   - [Code Health](#code-health)
+   - [Tooling and Documentation](#tooling-and-documentation)
+
+# Bug Fixes
+
+* [LND now sets the `BADONION`](https://github.com/lightningnetwork/lnd/pull/7937)
+  bit when sending `update_fail_malformed_htlc`. This avoids a force close
+  with other implementations.
+
+# New Features
+## Functional Enhancements
+## RPC Additions
+## lncli Additions
+
+# Improvements
+## Functional Updates
+## RPC Updates
+## lncli Updates
+## Code Health
+## Breaking Changes
+## Performance Improvements
+
+# Technical and Architectural Updates
+## BOLT Spec Updates
+## Testing
+## Database
+## Code Health
+## Tooling and Documentation
+
+# Contributors (Alphabetical Order)
+
+* Eugene Siegel

--- a/htlcswitch/hop/iterator.go
+++ b/htlcswitch/hop/iterator.go
@@ -364,7 +364,14 @@ func (p *OnionProcessor) DecodeHopIterators(id []byte,
 		if replays.Contains(uint16(i)) {
 			log.Errorf("unable to process onion packet: %v",
 				sphinx.ErrReplayedPacket)
-			resp.FailCode = lnwire.CodeTemporaryChannelFailure
+
+			// We set FailCode to CodeInvalidOnionVersion even
+			// though the ephemeral key isn't the problem. We need
+			// to set the BADONION bit since we're sending back a
+			// malformed packet, but as there isn't a specific
+			// failure code for replays, we reuse one of the
+			// failure codes that has BADONION.
+			resp.FailCode = lnwire.CodeInvalidOnionVersion
 			continue
 		}
 

--- a/itest/lnd_misc_test.go
+++ b/itest/lnd_misc_test.go
@@ -219,7 +219,7 @@ func testSphinxReplayPersistence(ht *lntest.HarnessTest) {
 	// Assert that Fred receives the expected failure after Carol sent a
 	// duplicate packet that fails due to sphinx replay detection.
 	ht.AssertPaymentStatusFromStream(payStream, lnrpc.Payment_FAILED)
-	ht.AssertLastHTLCError(fred, lnrpc.Failure_INVALID_ONION_KEY)
+	ht.AssertLastHTLCError(fred, lnrpc.Failure_INVALID_ONION_VERSION)
 
 	// Since the payment failed, the balance should still be left
 	// unaltered.


### PR DESCRIPTION
The link will send an update_fail_malformed_htlc, so we need to set the BADONION bit. Since there isn't a replay-specific error, we set the failure code to InvalidOnionVersion which has the BADONION bit.

It would be nice if there was a replay-specific failure code in the spec

Fixes https://github.com/lightningnetwork/lnd/issues/7851, https://github.com/lightningnetwork/lnd/issues/5792, https://github.com/lightningnetwork/lnd/issues/5443