### PR TITLE
peer: eliminate circular waiting by calling maybeSendNodeAnn async

### DIFF
--- a/peer/brontide.go
+++ b/peer/brontide.go
@@ -672,7 +672,7 @@ func (p *Brontide) Start() error {
 	//
 	// TODO(wilmer): Remove this once we're able to query for node
 	// announcements through their timestamps.
-	p.maybeSendNodeAnn(activeChans)
+	go p.maybeSendNodeAnn(activeChans)
 
 	return nil
 }


### PR DESCRIPTION
In this commit, we attempt to fix circular waiting scenario introduced inadvertently when [fixing a race condition
scenario](https://github.com/lightningnetwork/lnd/pull/7856). With that PR, we added a new channel that would block `Disconnect`, and `WaitForDisconnect` to ensure that only until the `Start` method has finished would those calls be allowed to succeed.

The issue is that if the server is trying to disconnect a peer due to a concurrent connection, but `Start` is blocked on `maybeSendNodeAnn`, which then wants to grab the main server mutex, then `Start` can never exit, which causes `startReady` to never be closed, which then causes the server to be blocked.

This PR attempts to fix the issue by calling `maybeSendNodeAnn` in a goroutine, so it can grab the server mutex and not block the `Start` method.

Fixes https://github.com/lightningnetwork/lnd/issues/7924

Fixes https://github.com/lightningnetwork/lnd/issues/7928

Fixes https://github.com/lightningnetwork/lnd/issues/7866

Fixes https://github.com/lightningnetwork/lnd/issues/7917

