### PR TITLE
Make Anchor Output Sweeps configurable.

### DIFF
--- a/contractcourt/chain_arbitrator.go
+++ b/contractcourt/chain_arbitrator.go
@@ -152,6 +152,11 @@ type ChainArbitratorConfig struct {
 	// Sweeper allows resolvers to sweep their final outputs.
 	Sweeper UtxoSweeper
 
+	// NotRecoverAnchorOutputs stops the sweeping of anchor outputs when
+	// they were not used to fee bump (CPFP) their corresponding commitment
+	// tx.
+	NotRecoverAnchorOutputs bool
+
 	// Registry is the invoice database that is used by resolvers to lookup
 	// preimages and settle invoices.
 	Registry Registry

--- a/contractcourt/channel_arbitrator.go
+++ b/contractcourt/channel_arbitrator.go
@@ -773,8 +773,6 @@ func (c *ChannelArbitrator) relaunchResolvers(commitSet *CommitSet,
 		anchorResolver.SupplementState(chanState)
 
 		unresolvedContracts = append(unresolvedContracts, anchorResolver)
-
-		// TODO(roasbeef): this isn't re-launched?
 	}
 
 	c.launchResolvers(unresolvedContracts)

--- a/contractcourt/channel_arbitrator.go
+++ b/contractcourt/channel_arbitrator.go
@@ -758,7 +758,9 @@ func (c *ChannelArbitrator) relaunchResolvers(commitSet *CommitSet,
 	}
 
 	// The anchor resolver is stateless and can always be re-instantiated.
-	if contractResolutions.AnchorResolution != nil {
+	if contractResolutions.AnchorResolution != nil &&
+		!c.cfg.NotRecoverAnchorOutputs {
+
 		anchorResolver := newAnchorResolver(
 			contractResolutions.AnchorResolution.AnchorSignDescriptor,
 			contractResolutions.AnchorResolution.CommitAnchor,
@@ -2192,7 +2194,9 @@ func (c *ChannelArbitrator) prepContractResolutions(
 
 	// We instantiate an anchor resolver if the commitment tx has an
 	// anchor.
-	if contractResolutions.AnchorResolution != nil {
+	if contractResolutions.AnchorResolution != nil &&
+		!c.cfg.NotRecoverAnchorOutputs {
+
 		anchorResolver := newAnchorResolver(
 			contractResolutions.AnchorResolution.AnchorSignDescriptor,
 			contractResolutions.AnchorResolution.CommitAnchor,

--- a/docs/release-notes/release-notes-0.17.0.md
+++ b/docs/release-notes/release-notes-0.17.0.md
@@ -143,6 +143,11 @@ None
   updated](https://github.com/lightningnetwork/lnd/pull/7877) in preparation for 
   work to be done on route blinding in LND. 
 
+* [Make the recovery of anchor outputs configurable. Default behaviour stays the
+  same but to prevent the blocking of wallet funds indefinitely when mempool 
+  conditions are not in favour of confirming 1 sat/vbyte transactions node 
+  runners can turn it off](https://github.com/lightningnetwork/lnd/pull/7939).
+
 ## RPC Updates
 * [SendOutputs](https://github.com/lightningnetwork/lnd/pull/7631) now adheres
   to the anchor channel reserve requirement.

--- a/lncfg/sweeper.go
+++ b/lncfg/sweeper.go
@@ -7,7 +7,8 @@ import (
 
 //nolint:lll
 type Sweeper struct {
-	BatchWindowDuration time.Duration `long:"batchwindowduration" description:"Duration of the sweep batch window. The sweep is held back during the batch window to allow more inputs to be added and thereby lower the fee per input."`
+	BatchWindowDuration     time.Duration `long:"batchwindowduration" description:"Duration of the sweep batch window. The sweep is held back during the batch window to allow more inputs to be added and thereby lower the fee per input."`
+	NotRecoverAnchorOutputs bool          `long:"notrecoveranchoroutputs" description:"Not recovering anchor outputs when they were not used to bump their commitment transaction."`
 }
 
 // Validate checks the values configured for the sweeper.

--- a/sample-lnd.conf
+++ b/sample-lnd.conf
@@ -1785,6 +1785,16 @@
 ; window to allow more inputs to be added and thereby lower the fee per input.
 ; sweeper.batchwindowduration=30s
 
+; If set to true lnd will not recover the anchor output which was not used
+; bumping the fee of the commitment transaction (can be more than 1 anchor when
+; more channels force close at the same time e.g. SCB). This is only a 330 sats
+; output making them marginally positive yielding when sweeping with
+; 1 sat/vbyte. Bad side effect is that it is blocking other utxos when sweeping
+; this anchor output. Its recommended to set it to true if mempool conditions 
+; do not allow for 1 sat/vbyte transactions to be confirmed in a reasonable 
+; amount of time.
+; sweeper.notrecoveranchoroutputs=false
+
 
 [htlcswitch]
 

--- a/server.go
+++ b/server.go
@@ -1208,6 +1208,7 @@ func newServer(cfg *Config, listenAddrs []net.Addr,
 			return s.chanStatusMgr.RequestDisable(chanPoint, false)
 		},
 		Sweeper:                       s.sweeper,
+		NotRecoverAnchorOutputs:       cfg.Sweeper.NotRecoverAnchorOutputs,
 		Registry:                      s.invoices,
 		NotifyClosedChannel:           s.channelNotifier.NotifyClosedChannelEvent,
 		NotifyFullyResolvedChannel:    s.channelNotifier.NotifyFullyResolvedChannelEvent,


### PR DESCRIPTION
The sweeping of anchor outputs is not really aligned with incentives when mempool conditions do not allow 1 sat/vbyte transactions to be confirmed in a reasonable amount of time. Always sweeping anchor outputs although they have no real chance to be confirmed will cost more eventually when one needs to use the funds which were used to sweep this output. In addition anchor sweeps are mostly bumped by third parties which can lead to a mandatory restart because lnd does not monitor the mempool when RBFs happen. 
Therefore noderunners have now the possibility to switch off the anchor recovery. I did not switch it off by default because a lot of unit test would fail as a consequence.

--sweeper.notrecoveranchoroutputs=true


fixes #7602 

Checking for the tests to pass ....

