### PR TITLE
Suggest increasing busy_timeout to prevent errors

### DIFF
--- a/docs/sqlite.md
+++ b/docs/sqlite.md
@@ -39,7 +39,9 @@ journal_mode=wal
 busy_timeout=5000 // Overried with the db.sqlite.busytimeout option.
 ```
 
-Default `busy_timeout` unit is milliseconds. A 5s timeout could lead to `SQLITE_BUSY` errors, which can be prevented by setting a longer timeout.
+Default `busy_timeout` unit is milliseconds.
+A 5s timeout could lead to `SQLITE_BUSY` errors,
+which can be prevented by setting a longer timeout.
 
 The following pragma options are set by default but can be overridden using the
 `db.sqlite.pragmaoptions` option:

--- a/docs/sqlite.md
+++ b/docs/sqlite.md
@@ -39,8 +39,11 @@ journal_mode=wal
 busy_timeout=5000 // Overried with the db.sqlite.busytimeout option.
 ```
 
+Default `busy_timeout` unit is milliseconds. A 5s timeout could lead to `SQLITE_BUSY` errors, which can be prevented by setting a longer timeout.
+
 The following pragma options are set by default but can be overridden using the
 `db.sqlite.pragmaoptions` option:
+
 
 ``` 
 synchronous=full
@@ -66,7 +69,7 @@ Example as follows:
 [db]
 db.backend=sqlite
 db.sqlite.timeout=0
-db.sqlite.busytimeout=10s
+db.sqlite.busytimeout=1m
 db.sqlite.pragmaoptions=temp_store=memory
 db.sqlite.pragmaoptions=incremental_vacuum
 ```


### PR DESCRIPTION
## Change Description
Update of SQLite doc to explain how `busy_timeout` can be tweaked to reduce `SQLITE_BUSY` errors.

## Steps to Test
Nothing special, this follows up with https://github.com/lightningnetwork/lnd/issues/7869

## Pull Request Checklist
### Testing
- [ ] Your PR passes all CI checks.
- [ ] Tests covering the positive and negative (error paths) are included.
- [ ] Bug fixes contain tests triggering the bug to prevent regressions.

### Code Style and Documentation
- [ ] The change obeys the [Code Documentation and Commenting](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#CodeDocumentation) guidelines, and lines wrap at 80.
- [ ] Commits follow the [Ideal Git Commit Structure](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#IdealGitCommitStructure).
- [ ] Any new logging statements use an appropriate subsystem and logging level.
- [ ]  [There is a change description in the release notes](https://github.com/lightningnetwork/lnd/tree/master/docs/release-notes), or `[skip ci]` in the commit message for small changes.

📝 Please see our  [Contribution Guidelines](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md) for further guidance.