### PR TITLE
contractcourt: make sure we force sweep outgoing htlcs

### DIFF
--- a/contractcourt/htlc_timeout_resolver.go
+++ b/contractcourt/htlc_timeout_resolver.go
@@ -462,6 +462,7 @@ func (h *htlcTimeoutResolver) sweepSecondLevelTx() error {
 			Fee: sweep.FeePreference{
 				ConfTarget: secondLevelConfTarget,
 			},
+			Force: true,
 		},
 	)
 	if err != nil {


### PR DESCRIPTION
We added this change in #7726, but it was removed in master, probably due to recent rebase.