### PR TITLE
Serialize/deserialize AMP struct in hop

### DIFF
--- a/channeldb/payments_test.go
+++ b/channeldb/payments_test.go
@@ -44,11 +44,25 @@ var (
 		LegacyPayload:    true,
 	}
 
+	testHop3 = &route.Hop{
+		PubKeyBytes:      route.NewVertex(pub),
+		ChannelID:        12345,
+		OutgoingTimeLock: 111,
+		AmtToForward:     555,
+		CustomRecords: record.CustomSet{
+			65536: []byte{},
+			80001: []byte{},
+		},
+		AMP:      record.NewAMP([32]byte{0x69}, [32]byte{0x42}, 1),
+		Metadata: []byte{1, 2, 3},
+	}
+
 	testRoute = route.Route{
 		TotalTimeLock: 123,
 		TotalAmount:   1234567,
 		SourcePubKey:  vertex,
 		Hops: []*route.Hop{
+			testHop3,
 			testHop2,
 			testHop1,
 		},

--- a/docs/release-notes/release-notes-0.18.0.md
+++ b/docs/release-notes/release-notes-0.18.0.md
@@ -53,6 +53,8 @@
   walletrpc endpoint `RemoveTransaction` is introduced which let one easily
   remove unconfirmed transaction manually.
 
+* The AMP struct in payment hops will [now be populated](https://github.com/lightningnetwork/lnd/pull/7976) when the AMP TLV is set.
+
 # New Features
 ## Functional Enhancements
 
@@ -203,6 +205,7 @@
 
 * Amin Bashiri
 * Andras Banki-Horvath
+* BitcoinerCoderBob
 * Carla Kirk-Cohen
 * Elle Mouton
 * ErikEk
@@ -210,6 +213,8 @@
 * Marcos Fernandez Perez
 * Matt Morehouse
 * Slyghtning
+* Tee8z
 * Turtle
 * Ononiwu Maureen Chiamaka
+* w3irdrobot
 * Yong Yu

--- a/itest/lnd_amp_test.go
+++ b/itest/lnd_amp_test.go
@@ -410,6 +410,16 @@ func testSendPaymentAMP(ht *lntest.HarnessTest) {
 		if htlc.Status == lnrpc.HTLCAttempt_SUCCEEDED {
 			succeeded++
 		}
+
+		// When an AMP record is expected, it will only be seen on the
+		// last hop of a route. So we make sure it isn't set on any of
+		// the hops except the last one
+		for _, hop := range htlc.Route.Hops[:len(htlc.Route.Hops)-1] {
+			require.Nil(ht, hop.AmpRecord)
+		}
+
+		lastHop := htlc.Route.Hops[len(htlc.Route.Hops)-1]
+		require.NotNil(ht, lastHop.AmpRecord)
 	}
 
 	const minExpectedShards = 3

--- a/lnrpc/routerrpc/router_backend.go
+++ b/lnrpc/routerrpc/router_backend.go
@@ -613,6 +613,18 @@ func (r *RouterBackend) MarshallRoute(route *route.Route) (*lnrpc.Route, error) 
 			}
 		}
 
+		var amp *lnrpc.AMPRecord
+		if hop.AMP != nil {
+			rootShare := hop.AMP.RootShare()
+			setID := hop.AMP.SetID()
+
+			amp = &lnrpc.AMPRecord{
+				RootShare:  rootShare[:],
+				SetId:      setID[:],
+				ChildIndex: hop.AMP.ChildIndex(),
+			}
+		}
+
 		resp.Hops[i] = &lnrpc.Hop{
 			ChanId:           hop.ChannelID,
 			ChanCapacity:     int64(chanCapacity),
@@ -627,6 +639,7 @@ func (r *RouterBackend) MarshallRoute(route *route.Route) (*lnrpc.Route, error) 
 			CustomRecords: hop.CustomRecords,
 			TlvPayload:    !hop.LegacyPayload,
 			MppRecord:     mpp,
+			AmpRecord:     amp,
 			Metadata:      hop.Metadata,
 			EncryptedData: hop.EncryptedData,
 			TotalAmtMsat:  uint64(hop.TotalAmtMsat),


### PR DESCRIPTION
## Change Description
The AMP struct in a hop was never being set when deserizlied. Also, the AMP TLV record was not being added when the hop was serialized. This sets the TLV record when serializing and correctly sets the AMP struct on the hop when that record is present.

## Steps to Test
1. Send an AMP payment to someone.
2. Observe the `amp_record` is now set in the hops array when using `listpayments`

## Pull Request Checklist
### Testing
- [ ] Your PR passes all CI checks.
- [x] Tests covering the positive and negative (error paths) are included.
- [x] Bug fixes contain tests triggering the bug to prevent regressions.

### Code Style and Documentation
- [x] The change obeys the [Code Documentation and Commenting](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#CodeDocumentation) guidelines, and lines wrap at 80.
- [x] Commits follow the [Ideal Git Commit Structure](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#IdealGitCommitStructure).
- [x] Any new logging statements use an appropriate subsystem and logging level.
- [x]  [There is a change description in the release notes](https://github.com/lightningnetwork/lnd/tree/master/docs/release-notes), or `[skip ci]` in the commit message for small changes.

📝 Please see our  [Contribution Guidelines](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md) for further guidance.