### PR TITLE
kvdb/postgres: remove global application level lock

### DIFF
--- a/channeldb/graph.go
+++ b/channeldb/graph.go
@@ -1492,9 +1492,15 @@ func (c *ChannelGraph) pruneGraphNodes(nodes kvdb.RwBucket,
 		// If we reach this point, then there are no longer any edges
 		// that connect this node, so we can delete it.
 		if err := c.deleteLightningNode(nodes, nodePubKey[:]); err != nil {
-			log.Warnf("Unable to prune node %x from the "+
-				"graph: %v", nodePubKey, err)
-			continue
+			if errors.Is(err, ErrGraphNodeNotFound) ||
+				errors.Is(err, ErrGraphNodesNotFound) {
+
+				log.Warnf("Unable to prune node %x from the "+
+					"graph: %v", nodePubKey, err)
+				continue
+			}
+
+			return err
 		}
 
 		log.Infof("Pruned unconnected node %x from channel graph",

--- a/go.mod
+++ b/go.mod
@@ -212,4 +212,6 @@ replace google.golang.org/protobuf => github.com/lightninglabs/protobuf-go-hex-d
 // docs/INSTALL.md.
 go 1.19
 
+replace github.com/lightningnetwork/lnd/kvdb => ./kvdb
+
 retract v0.0.2

--- a/go.sum
+++ b/go.sum
@@ -448,8 +448,6 @@ github.com/lightningnetwork/lnd/clock v1.1.1 h1:OfR3/zcJd2RhH0RU+zX/77c0ZiOnIMsD
 github.com/lightningnetwork/lnd/clock v1.1.1/go.mod h1:mGnAhPyjYZQJmebS7aevElXKTFDuO+uNFFfMXK1W8xQ=
 github.com/lightningnetwork/lnd/healthcheck v1.2.3 h1:oqhOOy8WmIEa6RBkYKC0mmYZkhl8T2kGD97n9jpML8o=
 github.com/lightningnetwork/lnd/healthcheck v1.2.3/go.mod h1:eDxH3dEwV9DeBW/6inrmlVh1qBOFV0AI14EEPnGt9gc=
-github.com/lightningnetwork/lnd/kvdb v1.4.4 h1:bCv63rVCvzqj1BkagN/EWTov6NDDgYEG/t0z2HepRMk=
-github.com/lightningnetwork/lnd/kvdb v1.4.4/go.mod h1:9SuaIqMA9ugrVkdvgQkYXa8CAKYNYd4vsEYORP4V698=
 github.com/lightningnetwork/lnd/queue v1.1.1 h1:99ovBlpM9B0FRCGYJo6RSFDlt8/vOkQQZznVb18iNMI=
 github.com/lightningnetwork/lnd/queue v1.1.1/go.mod h1:7A6nC1Qrm32FHuhx/mi1cieAiBZo5O6l8IBIoQxvkz4=
 github.com/lightningnetwork/lnd/ticker v1.1.1 h1:J/b6N2hibFtC7JLV77ULQp++QLtCwT6ijJlbdiZFbSM=

--- a/kvdb/postgres/db.go
+++ b/kvdb/postgres/db.go
@@ -28,7 +28,6 @@ func newPostgresBackend(ctx context.Context, config *Config, prefix string) (
 		Schema:                "public",
 		TableNamePrefix:       prefix,
 		SQLiteCmdReplacements: sqliteCmdReplacements,
-		WithTxLevelLock:       true,
 	}
 
 	return sqlbase.NewSqlBackend(ctx, cfg)

--- a/kvdb/sqlbase/db.go
+++ b/kvdb/sqlbase/db.go
@@ -330,16 +330,20 @@ func (db *db) executeTransaction(f func(tx walletdb.ReadWriteTx) error,
 			return fnErr
 		}
 
-		dbErr := tx.Commit()
-		if IsSerializationError(dbErr) {
+		commitErr := tx.Commit()
+		if commitErr != nil {
 			_ = tx.Rollback()
 
-			if waitBeforeRetry(i) {
-				continue
+			dbErr := MapSQLError(fnErr)
+			if IsSerializationError(dbErr) {
+
+				if waitBeforeRetry(i) {
+					continue
+				}
 			}
 		}
 
-		return dbErr
+		return commitErr
 	}
 
 	// If we get to this point, then we weren't able to successfully commit

--- a/kvdb/sqlbase/db.go
+++ b/kvdb/sqlbase/db.go
@@ -66,10 +66,6 @@ type Config struct {
 	// commands. Note that the sqlite keywords to be replaced are
 	// case-sensitive.
 	SQLiteCmdReplacements SQLiteCmdReplacements
-
-	// WithTxLevelLock when set will ensure that there is a transaction
-	// level lock.
-	WithTxLevelLock bool
 }
 
 // db holds a reference to the sql db connection.
@@ -89,10 +85,6 @@ type db struct {
 
 	// db is the underlying database connection instance.
 	db *sql.DB
-
-	// lock is the global write lock that ensures single writer. This is
-	// only used if cfg.WithTxLevelLock is set.
-	lock sync.RWMutex
 
 	// table is the name of the table that contains the data for all
 	// top-level buckets that have keys that cannot be mapped to a distinct

--- a/kvdb/sqlbase/db.go
+++ b/kvdb/sqlbase/db.go
@@ -308,6 +308,8 @@ func (db *db) executeTransaction(f func(tx walletdb.ReadWriteTx) error,
 			}
 
 			return err
+					continue
+				}
 		}
 
 		dbErr := tx.Commit()

--- a/kvdb/sqlbase/sqlerrors_postgres.go
+++ b/kvdb/sqlbase/sqlerrors_postgres.go
@@ -5,6 +5,7 @@ package sqlbase
 import (
 	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/jackc/pgconn"
 	"github.com/jackc/pgerrcode"
@@ -13,6 +14,15 @@ import (
 // parsePostgresError attempts to parse a postgres error as a database agnostic
 // SQL error.
 func parsePostgresError(err error) error {
+	// Sometimes the error won't be properly wrapped, so we'll need to
+	// inspect raw error itself to detect something we can wrap properly.
+	const postgresErrMsg = "could not serialize access"
+	if strings.Contains(err.Error(), postgresErrMsg) {
+		return &ErrSerializationError{
+			DBError: err,
+		}
+	}
+
 	var pqErr *pgconn.PgError
 	if !errors.As(err, &pqErr) {
 		return nil

--- a/kvdb/sqlbase/sqlerrors_sqlite.go
+++ b/kvdb/sqlbase/sqlerrors_sqlite.go
@@ -5,6 +5,7 @@ package sqlbase
 import (
 	"errors"
 	"fmt"
+	"strings"
 
 	"modernc.org/sqlite"
 	sqlite3 "modernc.org/sqlite/lib"
@@ -13,6 +14,17 @@ import (
 // parseSqliteError attempts to parse a sqlite error as a database agnostic
 // SQL error.
 func parseSqliteError(err error) error {
+	// If the error isn't wrapped properly, the errors.As call with fail,
+	// so we'll also try to check the expected error message directly.
+	// This is taken from:
+	// https://gitlab.com/cznic/sqlite/-/blob/v1.25.0/sqlite.go#L75.
+	const sqliteErrMsg = "SQLITE_BUSY"
+	if strings.Contains(err.Error(), sqliteErrMsg) {
+		return &ErrSerializationError{
+			DBError: err,
+		}
+	}
+
 	var sqliteErr *sqlite.Error
 	if !errors.As(err, &sqliteErr) {
 		return nil

--- a/sqldb/sqlerrors.go
+++ b/sqldb/sqlerrors.go
@@ -3,6 +3,7 @@ package sqldb
 import (
 	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/jackc/pgconn"
 	"github.com/jackc/pgerrcode"
@@ -29,6 +30,26 @@ func MapSQLError(err error) error {
 	var pqErr *pgconn.PgError
 	if errors.As(err, &pqErr) {
 		return parsePostgresError(pqErr)
+	}
+
+	// Sometimes the error won't be properly wrapped, so we'll need to
+	// inspect raw error itself to detect something we can wrap properly.
+	// This handles a postgres variant of the error.
+	const postgresErrMsg = "could not serialize access"
+	if strings.Contains(err.Error(), postgresErrMsg) {
+		return &ErrSerializationError{
+			DBError: err,
+		}
+	}
+
+	// We'll also attempt to catch this for sqlite, that uses a slightly
+	// different error message. This is taken from:
+	// https://gitlab.com/cznic/sqlite/-/blob/v1.25.0/sqlite.go#L75.
+	const sqliteErrMsg = "SQLITE_BUSY"
+	if strings.Contains(err.Error(), sqliteErrMsg) {
+		return &ErrSerializationError{
+			DBError: err,
+		}
 	}
 
 	// Return original error if it could not be classified as a database


### PR DESCRIPTION
In this commit, we remove the global application level lock from the postgres backend. This lock prevents multiple write transactions from happening at the same time, and will also block a writer if a read is on going. Since this lock was added, we know always open DB connections with the strongest level of concurrency control available: `LevelSerializable`. In concert with the new auto retry logic, we ensure that if db transactions conflict (writing the same key/row in this case), then the tx is retried automatically.

Removing this lock should increase perf for the postgres backend, as now concurrent write transactions can proceed, being serialized as needed. Rather then trying to handle concurrency at the application level, we'll set postgres do its job, with the application only needing to retry as necessary.

