### PR TITLE
build: prep for Go 1.22 by using GOEXPERIMENT=loopvar for tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ COMMIT := $(shell git describe --tags --dirty)
 
 GOBUILD := go build -v
 GOINSTALL := go install -v
-GOTEST := go test
+GOTEST := GOEXPERIMENT=loopvar go test
 
 GOFILES_NOVENDOR = $(shell find . -type f -name '*.go' -not -path "./vendor/*" -not -name "*pb.go" -not -name "*pb.gw.go" -not -name "*.pb.json.go")
 

--- a/Makefile
+++ b/Makefile
@@ -21,9 +21,17 @@ ANDROID_BUILD := $(ANDROID_BUILD_DIR)/Lndmobile.aar
 
 COMMIT := $(shell git describe --tags --dirty)
 
-GOBUILD := go build -v
-GOINSTALL := go install -v
-GOTEST := GOEXPERIMENT=loopvar go test
+GO_VERSION := $(shell go version | sed -nre 's/^[^0-9]*(([0-9]+\.)*[0-9]+).*/\1/p')
+GO_VERSION_MINOR := $(shell echo $(GO_VERSION) | cut -d. -f2)
+
+LOOPVARFIX :=
+ifeq ($(shell expr $(GO_VERSION_MINOR) \>= 21), 1)
+	LOOPVARFIX := GOEXPERIMENT=loopvar
+endif
+
+GOBUILD := $(LOOPVARFIX) go build -v
+GOINSTALL := $(LOOPVARFIX) go install -v
+GOTEST := $(LOOPVARFIX) go test
 
 GOFILES_NOVENDOR = $(shell find . -type f -name '*.go' -not -path "./vendor/*" -not -name "*pb.go" -not -name "*pb.gw.go" -not -name "*.pb.json.go")
 

--- a/discovery/chan_series.go
+++ b/discovery/chan_series.go
@@ -163,6 +163,8 @@ func (c *ChanSeries) UpdatesInHorizon(chain chainhash.Hash,
 		return nil, err
 	}
 	for _, nodeAnn := range nodeAnnsInHorizon {
+		nodeAnn := nodeAnn
+
 		// Ensure we only forward nodes that are publicly advertised to
 		// prevent leaking information about nodes.
 		isNodePublic, err := c.graph.IsPublicNode(nodeAnn.PubKeyBytes)

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -98,7 +98,7 @@ function check_tag_correct() {
   fi
 
   # Build lnd to extract version.
-  go build ${PKG}/cmd/lnd
+  env GOEXPERIMENT=loopvar go build ${PKG}/cmd/lnd
 
   # Extract version command output.
   lnd_version_output=$(./lnd --version)
@@ -177,8 +177,8 @@ function build_release() {
     pushd "${dir}"
 
     green " - Building: ${os} ${arch} ${arm} with build tags '${buildtags}'"
-    env CGO_ENABLED=0 GOOS=$os GOARCH=$arch GOARM=$arm go build -v -trimpath -ldflags="${ldflags}" -tags="${buildtags}" ${PKG}/cmd/lnd
-    env CGO_ENABLED=0 GOOS=$os GOARCH=$arch GOARM=$arm go build -v -trimpath -ldflags="${ldflags}" -tags="${buildtags}" ${PKG}/cmd/lncli
+    env GOEXPERIMENT=loopvar CGO_ENABLED=0 GOOS=$os GOARCH=$arch GOARM=$arm go build -v -trimpath -ldflags="${ldflags}" -tags="${buildtags}" ${PKG}/cmd/lnd
+    env GOEXPERIMENT=loopvar CGO_ENABLED=0 GOOS=$os GOARCH=$arch GOARM=$arm go build -v -trimpath -ldflags="${ldflags}" -tags="${buildtags}" ${PKG}/cmd/lncli
     popd
 
     # Add the hashes for the individual binaries as well for easy verification


### PR DESCRIPTION
In this commit, [we prep for some upcoming changes in Go](https://go.dev/blog/loopvar-preview) by running our tests with `GOEXPERIMENT=loopvar`. This changes the loop semantics to fix a common bug where a scoping issue causes a variable to be re-used, which can cause unintended bugs down the line.

If everything passes with this flag on, then we can keep it on, and also rest a bit easier knowing that the compiler will fix a class of bugs that would previously pop up for us.

