### PR TITLE
itest: kill lnd on windows to access log files

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -298,6 +298,11 @@ jobs:
 
       - name: run itest
         run: make itest-parallel windows=1
+        
+      - name: kill any remaining lnd processes
+        if: ${{ failure() }}
+        shell: powershell
+        run: taskkill /IM lnd-itest.exe /T /F
 
       - name: Zip log files on failure
         if: ${{ failure() }}

--- a/scripts/itest_parallel.sh
+++ b/scripts/itest_parallel.sh
@@ -26,13 +26,12 @@ for pid in "${pids[@]}"; do
 
     # Overwrite the exit code if current itest doesn't return 0.
     if [ $current_exit_code -ne 0 ]; then
-	# Only write the exit code of the first failing itest.
-	if [ $exit_code -eq 0 ]; then
+        # Only write the exit code of the first failing itest.
+        if [ $exit_code -eq 0 ]; then
             exit_code=$current_exit_code
-	fi
+        fi
     fi
 done
-
 
 # Exit with the exit code of the first failing itest or 0.
 exit $exit_code


### PR DESCRIPTION
For some reason lnd doesn't properly shut down on some windows itests, and the process still running makes it impossible to access its log files.
So for the Windows integration test, we attempt to kill the whole process tree once the process indicates it is done.
