### PR TITLE
contractcourt: modify the incoming contest resolver to use concurrent…

### DIFF
--- a/docs/release-notes/release-notes-0.17.0.md
+++ b/docs/release-notes/release-notes-0.17.0.md
@@ -79,6 +79,11 @@ fails](https://github.com/lightningnetwork/lnd/pull/7876).
 * `lnd` [now properly handles a case where an erroneous force close attempt
   would impeded start up](https://github.com/lightningnetwork/lnd/pull/7985).
 
+* A bug that could cause the invoice related sub-system to lock up (potentially
+  the entire daemon) related to [incoming HTLCs going on chain related to a
+  hodl invoice has been
+  fixed](https://github.com/lightningnetwork/lnd/pull/8024).
+
 # New Features
 ## Functional Enhancements
 


### PR DESCRIPTION
… queue

In this commit, we modify the incoming contest resolver to use a concurrent queue. This is meant to ensure that the invoice registry subscription loop never blocks. This change is meant to be minimal and implements option `5` as outlined here:
https://github.com/lightningnetwork/lnd/issues/8023.

With this change, the inner loop of the subscription dispatch method in the invoice registry will no longer block, as the concurrent queue uses a fixed buffer of a queue, then overflows into another queue when that gets full.

Fixes https://github.com/lightningnetwork/lnd/issues/7917
