### PR TITLE
lnwallet+rpcserver: fix weight calculation for taproot channels

### DIFF
--- a/itest/list_on_test.go
+++ b/itest/list_on_test.go
@@ -178,6 +178,10 @@ var allTestCases = []*lntest.TestCase{
 		TestFunc: testListPayments,
 	},
 	{
+		Name:     "send direct payment",
+		TestFunc: testSendDirectPayment,
+	},
+	{
 		Name:     "immediate payment after channel opened",
 		TestFunc: testPaymentFollowingChannelOpen,
 	},

--- a/lnwallet/channel.go
+++ b/lnwallet/channel.go
@@ -3027,11 +3027,17 @@ func (lc *LightningChannel) fetchCommitmentView(remoteChain bool,
 	}
 	fee := lc.channelState.Capacity - totalOut
 
+	var witnessWeight int64
+	if lc.channelState.ChanType.IsTaproot() {
+		witnessWeight = input.TaprootKeyPathWitnessSize
+	} else {
+		witnessWeight = input.WitnessCommitmentTxWeight
+	}
+
 	// Since the transaction is not signed yet, we use the witness weight
 	// used for weight calculation.
 	uTx := btcutil.NewTx(commitTx.txn)
-	weight := blockchain.GetTransactionWeight(uTx) +
-		input.WitnessCommitmentTxWeight
+	weight := blockchain.GetTransactionWeight(uTx) + witnessWeight
 
 	effFeeRate := chainfee.SatPerKWeight(fee) * 1000 /
 		chainfee.SatPerKWeight(weight)

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -3476,10 +3476,17 @@ func (r *rpcServer) fetchPendingOpenChannels() (pendingOpenChannels, error) {
 		// broadcast.
 		// TODO(roasbeef): query for funding tx from wallet, display
 		// that also?
+		var witnessWeight int64
+		if pendingChan.ChanType.IsTaproot() {
+			witnessWeight = input.TaprootKeyPathWitnessSize
+		} else {
+			witnessWeight = input.WitnessCommitmentTxWeight
+		}
+
 		localCommitment := pendingChan.LocalCommitment
 		utx := btcutil.NewTx(localCommitment.CommitTx)
 		commitBaseWeight := blockchain.GetTransactionWeight(utx)
-		commitWeight := commitBaseWeight + input.WitnessCommitmentTxWeight
+		commitWeight := commitBaseWeight + witnessWeight
 
 		// FundingExpiryBlocks is the distance from the current block
 		// height to the broadcast height + MaxWaitNumBlocksFundingConf.
@@ -4227,10 +4234,17 @@ func createRPCOpenChannel(r *rpcServer, dbChannel *channeldb.OpenChannel,
 	// estimated weight of the witness to calculate the weight of
 	// the transaction if it were to be immediately unilaterally
 	// broadcast.
+	var witnessWeight int64
+	if dbChannel.ChanType.IsTaproot() {
+		witnessWeight = input.TaprootKeyPathWitnessSize
+	} else {
+		witnessWeight = input.WitnessCommitmentTxWeight
+	}
+
 	localCommit := dbChannel.LocalCommitment
 	utx := btcutil.NewTx(localCommit.CommitTx)
 	commitBaseWeight := blockchain.GetTransactionWeight(utx)
-	commitWeight := commitBaseWeight + input.WitnessCommitmentTxWeight
+	commitWeight := commitBaseWeight + witnessWeight
 
 	localBalance := localCommit.LocalBalance
 	remoteBalance := localCommit.RemoteBalance


### PR DESCRIPTION
Fix the weight calculation found in multiple places.

Fix #8036