### PR TITLE
peer: launch persistent peer pruning in background goroutine

### DIFF
--- a/peer/brontide.go
+++ b/peer/brontide.go
@@ -551,7 +551,7 @@ func (p *Brontide) Start() error {
 	}
 
 	if len(activeChans) == 0 {
-		p.cfg.PrunePersistentPeerConnection(p.cfg.PubKeyBytes)
+		go p.cfg.PrunePersistentPeerConnection(p.cfg.PubKeyBytes)
 	}
 
 	// Quickly check if we have any existing legacy channels with this


### PR DESCRIPTION
This PR is a follow up, to a [follow
up](https://github.com/lightningnetwork/lnd/pull/7938) of an [initial concurrency issue](https://github.com/lightningnetwork/lnd/pull/7856) fixed in the peer goroutine.

In #7938, we noticed that the introduction of `p.startReady` can cause `Disconnect` to block. This happens as `Disconnect` cannot be called until `p.startReady` has been closed. `Disconnect` is also called from `InboundPeerConnected` (the case of concurrent peers, so we need to remove one of the connections) while the main server mutex is held. If `p.Start` blocks for any reason, then this leads to the deadlock as: we can't disconnect until we've finished starting, and we can't finish starting as we need the disconnect caller to exit as it has the mutex.

In this commit, we now make the call to `prunePersistentPeerConnection` async. The call to `prunePersistentPeerConnection` eventually wants to grab the server mutex, which triggers the circular waiting scenario above.

The main learning here is that no calls to the main server mutex path can block from `p.Start`. This is more or less a stop gap to resolve the issue initially introduced in v0.16.4. Assuming we want to move forward with this fix, we should reexamine `p.startReady` all together, and also revisit attempt to refactor this section of the code to eliminate the mega mutex in the server in favor of a dedicated event loop.

Fixes https://github.com/lightningnetwork/lnd/issues/8039