### PR TITLE
cmd/lncli: fix linter complaint by running make fmt

### DIFF
--- a/cmd/lncli/commands.go
+++ b/cmd/lncli/commands.go
@@ -680,10 +680,10 @@ func connectPeer(ctx *cli.Context) error {
 }
 
 var disconnectCommand = cli.Command{
-	Name:      "disconnect",
-	Category:  "Peers",
-	Usage:     "Disconnect a remote lightning peer identified by " +
-		    "public key.",
+	Name:     "disconnect",
+	Category: "Peers",
+	Usage: "Disconnect a remote lightning peer identified by " +
+		"public key.",
 	ArgsUsage: "<pubkey>",
 	Flags: []cli.Flag{
 		cli.StringFlag{


### PR DESCRIPTION
Linter was broken by https://github.com/lightningnetwork/lnd/pull/8053 which didn't run `make fmt`.