### PR TITLE
itest: simple taproot channel activation test

### DIFF
--- a/itest/list_on_test.go
+++ b/itest/list_on_test.go
@@ -463,6 +463,10 @@ var allTestCases = []*lntest.TestCase{
 		TestFunc: testTaproot,
 	},
 	{
+		Name:     "simple taproot channel activation",
+		TestFunc: testSimpleTaprootChannelActivation,
+	},
+	{
 		Name:     "wallet import account",
 		TestFunc: testWalletImportAccount,
 	},


### PR DESCRIPTION
Ensures that https://github.com/lightningnetwork/lnd/issues/8065 is fixed.

This PR adds an integration test that ensures that a channel appears active if the initiating peer is disconnected from the channel peer during channel confirmation and reconnected after the channel confirmed.

Depends on,
- #8078