### PR TITLE
multi: skip InitRemoteMusigNonces if we've already called it

### DIFF
--- a/itest/list_on_test.go
+++ b/itest/list_on_test.go
@@ -463,6 +463,10 @@ var allTestCases = []*lntest.TestCase{
 		TestFunc: testTaproot,
 	},
 	{
+		Name:     "simple taproot channel activation",
+		TestFunc: testSimpleTaprootChannelActivation,
+	},
+	{
 		Name:     "wallet import account",
 		TestFunc: testWalletImportAccount,
 	},

--- a/peer/brontide.go
+++ b/peer/brontide.go
@@ -3867,6 +3867,13 @@ func (p *Brontide) addActiveChannel(c *lnpeer.NewChannel) error {
 			"policy: %v", err)
 	}
 
+	if shouldReestablish {
+		// If we have to do the reestablish dance for this channel,
+		// ensure that we don't try to call InitRemoteMusigNonces
+		// twice by calling SkipNonceInit.
+		lnChan.SkipNonceInit()
+	}
+
 	// Create the link and add it to the switch.
 	err = p.addLink(
 		chanPoint, lnChan, initialPolicy, chainEvents,


### PR DESCRIPTION
Prior to this commit, taproot channels had a bug:

- If a disconnect happened before `peer.AddNewChannel` was called, then the subsequent reconnect would call `peer.AddNewChannel` and attempt the ChannelReestablish dance.

- `peer.AddNewChannel` would call `NewLightningChannel` with populated nonce ChannelOpts. This in turn would call `InitRemoteMusigNonces` which would create a new musig pair session and set the channel's `pendingVerificationNonce` to nil.

- During the reestablish dance, `ProcessChanSyncMsg` would be called. This would also call `InitRemoteMusigNonces`, except it would fail since `pendingVerificationNonce` was set to nil in the previous invocation.

To fix this, a new function `SkipNonceInit` is exposed on `LightningChannel` that will skip the next call to `InitRemoteMusigNonces` in `ProcessChanSyncMsg`.

Fixes #8065 