### PR TITLE
[WIP] multi: use ChannelAnnouncement2 to advertise Taproot Channels

### DIFF
--- a/channeldb/announcement_nonces.go
+++ b/channeldb/announcement_nonces.go
@@ -1,0 +1,132 @@
+package channeldb
+
+import (
+	"fmt"
+
+	"github.com/btcsuite/btcd/btcec/v2/schnorr/musig2"
+	"github.com/lightningnetwork/lnd/kvdb"
+	"github.com/lightningnetwork/lnd/lnwire"
+)
+
+var announcementNoncesBucket = []byte("announcement-nonces")
+
+func (c *ChannelStateDB) SaveAnnouncementNonces(chanID lnwire.ChannelID, node,
+	btc [musig2.PubNonceSize]byte) error {
+
+	chanIDCopy := make([]byte, 32)
+	copy(chanIDCopy, chanID[:])
+
+	scratch := make([]byte, musig2.PubNonceSize*2)
+	copy(scratch[:musig2.PubNonceSize], node[:])
+	copy(scratch[musig2.PubNonceSize:], btc[:])
+
+	return kvdb.Update(c.backend, func(tx kvdb.RwTx) error {
+		bucket, err := tx.CreateTopLevelBucket(
+			announcementNoncesBucket,
+		)
+		if err != nil {
+			return err
+		}
+
+		return bucket.Put(chanIDCopy, scratch)
+	}, func() {})
+}
+
+type AnnouncementNonces struct {
+	Btc  [musig2.PubNonceSize]byte
+	Node [musig2.PubNonceSize]byte
+}
+
+func (c *ChannelStateDB) GetAllAnnouncementNonces() (map[lnwire.ChannelID]*AnnouncementNonces, error) {
+
+	m := make(map[lnwire.ChannelID]*AnnouncementNonces)
+	err := kvdb.View(c.backend, func(tx kvdb.RTx) error {
+		bucket := tx.ReadBucket(announcementNoncesBucket)
+		if bucket == nil {
+			return nil
+		}
+
+		return bucket.ForEach(func(k, v []byte) error {
+			if len(k) != 32 {
+				return fmt.Errorf("invalid chan ID key")
+			}
+			if len(v) != musig2.PubNonceSize*2 {
+				return fmt.Errorf("wrong number of bytes")
+			}
+
+			var chanID lnwire.ChannelID
+			copy(chanID[:], k)
+
+			var btc, node [musig2.PubNonceSize]byte
+
+			copy(btc[:], v[:musig2.PubNonceSize])
+			copy(node[:], v[musig2.PubNonceSize:])
+
+			m[chanID] = &AnnouncementNonces{
+				Btc:  btc,
+				Node: node,
+			}
+
+			return nil
+		})
+	}, func() {
+		m = make(map[lnwire.ChannelID]*AnnouncementNonces)
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return m, nil
+}
+
+func (c *ChannelStateDB) GetAnnouncementNonces(chanID lnwire.ChannelID) (
+	*[musig2.PubNonceSize]byte, *[musig2.PubNonceSize]byte, error) {
+
+	chanIDCopy := make([]byte, 32)
+	copy(chanIDCopy, chanID[:])
+
+	var node, btc [musig2.PubNonceSize]byte
+	err := kvdb.View(c.backend, func(tx kvdb.RTx) error {
+		bucket := tx.ReadBucket(announcementNoncesBucket)
+		if bucket == nil {
+			return ErrChannelNotFound
+		}
+
+		noncesBytes := bucket.Get(chanIDCopy)
+		if noncesBytes == nil {
+			return ErrChannelNotFound
+		}
+
+		if len(noncesBytes) != musig2.PubNonceSize*2 {
+			return fmt.Errorf("wrong number of bytes")
+		}
+
+		copy(node[:], noncesBytes[:musig2.PubNonceSize])
+		copy(btc[:], noncesBytes[musig2.PubNonceSize:])
+
+		return nil
+	}, func() {})
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return &node, &btc, nil
+}
+
+func (c *ChannelStateDB) DeleteAnnouncementNonces(
+	chanID lnwire.ChannelID) error {
+
+	chanIDCopy := make([]byte, 32)
+	copy(chanIDCopy, chanID[:])
+
+	return kvdb.Update(c.backend, func(tx kvdb.RwTx) error {
+		bucket := tx.ReadWriteBucket(
+			announcementNoncesBucket,
+		)
+		if bucket == nil {
+			return nil
+		}
+
+		return bucket.Delete(chanIDCopy)
+	}, func() {})
+}

--- a/channeldb/waitingproof.go
+++ b/channeldb/waitingproof.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"sync"
 
+	"github.com/btcsuite/btcd/btcec/v2"
 	"github.com/go-errors/errors"
 	"github.com/lightningnetwork/lnd/kvdb"
 	"github.com/lightningnetwork/lnd/lnwire"
@@ -186,27 +187,192 @@ func (s *WaitingProofStore) Get(key WaitingProofKey) (*WaitingProof, error) {
 // proof for the same channel id.
 type WaitingProofKey [9]byte
 
+// WaitingProofType represents the type of the encoded waiting proof.
+type WaitingProofType uint8
+
+const (
+	// WaitingProofTypeLegacy represents a waiting proof for legacy P2WSH
+	// channels.
+	WaitingProofTypeLegacy WaitingProofType = 0
+
+	// WaitingProofTypeTaproot represents a waiting proof for taproot
+	// channels.
+	WaitingProofTypeTaproot WaitingProofType = 1
+)
+
+// typeToWaitingProofType is a map from WaitingProofType to an empty
+// instantiation of the associated type.
+func typeToWaitingProof(pt WaitingProofType) (WaitingProofInterface, bool) {
+	switch pt {
+	case WaitingProofTypeLegacy:
+		return &LegacyWaitingProof{}, true
+	case WaitingProofTypeTaproot:
+		return &TaprootWaitingProof{}, true
+
+	default:
+		return nil, false
+	}
+}
+
+// WaitingProofInterface is an interface that must be implemented by any waiting
+// proof to be stored in the waiting proof DB.
+type WaitingProofInterface interface {
+	// SCID returns the short channel ID of the channel that the waiting
+	// proof is for.
+	SCID() lnwire.ShortChannelID
+
+	// Encode encodes the waiting proof to the given buffer.
+	Encode(w *bytes.Buffer, pver uint32) error
+
+	// Decode parses the bytes from the given reader to reconstruct the
+	// waiting proof.
+	Decode(r io.Reader, pver uint32) error
+
+	// Type returns the waiting proof type.
+	Type() WaitingProofType
+}
+
+// LegacyWaitingProof is an implementation of the WaitingProofInterface to be
+// used for legacy, P2WSH channels.
+type LegacyWaitingProof struct {
+	lnwire.AnnounceSignatures
+}
+
+// SCID returns the short channel ID of the channel that the waiting
+// proof is for.
+//
+// NOTE: this is part of the WaitingProofInterface.
+func (l *LegacyWaitingProof) SCID() lnwire.ShortChannelID {
+	return l.ShortChannelID
+}
+
+// Type returns the waiting proof type.
+//
+// NOTE: this is part of the WaitingProofInterface.
+func (l *LegacyWaitingProof) Type() WaitingProofType {
+	return WaitingProofTypeLegacy
+}
+
+var _ WaitingProofInterface = (*LegacyWaitingProof)(nil)
+
+// TaprootWaitingProof is an implementation of the WaitingProofInterface to be
+// used for taproot channels.
+type TaprootWaitingProof struct {
+	lnwire.AnnouncementSignatures2
+
+	// AggNonce is the aggregate nonce used to construct the partial
+	// signatures. It will be used as the R value in the final signature.
+	AggNonce *btcec.PublicKey
+}
+
+// SCID returns the short channel ID of the channel that the waiting
+// proof is for.
+//
+// NOTE: this is part of the WaitingProofInterface.
+func (t *TaprootWaitingProof) SCID() lnwire.ShortChannelID {
+	return t.ShortChannelID
+}
+
+// Decode parses the bytes from the given reader to reconstruct the
+// waiting proof.
+//
+// NOTE: this is part of the WaitingProofInterface.
+func (t *TaprootWaitingProof) Decode(r io.Reader, pver uint32) error {
+	// Read byte to see if agg nonce is present.
+	var aggNoncePresent bool
+	if err := binary.Read(r, byteOrder, &aggNoncePresent); err != nil {
+		return err
+	}
+
+	// If agg nonce is present, read it in.
+	if aggNoncePresent {
+		var nonceBytes [btcec.PubKeyBytesLenCompressed]byte
+		if err := binary.Read(r, byteOrder, &nonceBytes); err != nil {
+			return err
+		}
+
+		nonce, err := btcec.ParsePubKey(nonceBytes[:])
+		if err != nil {
+			return err
+		}
+
+		t.AggNonce = nonce
+	}
+
+	return t.AnnouncementSignatures2.Decode(r, pver)
+}
+
+// Encode encodes the waiting proof to the given buffer.
+//
+// NOTE: this is part of the WaitingProofInterface.
+func (t *TaprootWaitingProof) Encode(w *bytes.Buffer, pver uint32) error {
+	// If agg nonce is present, write a signaling byte for that.
+	aggNoncePresent := t.AggNonce != nil
+	if err := binary.Write(w, byteOrder, aggNoncePresent); err != nil {
+		return err
+	}
+
+	// Now follow with the actual nonce if present.
+	if aggNoncePresent {
+		err := binary.Write(
+			w, byteOrder, t.AggNonce.SerializeCompressed(),
+		)
+		if err != nil {
+			return err
+		}
+	}
+
+	return t.AnnouncementSignatures2.Encode(w, pver)
+}
+
+// Type returns the waiting proof type.
+//
+// NOTE: this is part of the WaitingProofInterface.
+func (t *TaprootWaitingProof) Type() WaitingProofType {
+	return WaitingProofTypeTaproot
+}
+
+var _ WaitingProofInterface = (*TaprootWaitingProof)(nil)
+
 // WaitingProof is the storable object, which encapsulate the half proof and
 // the information about from which side this proof came. This structure is
 // needed to make channel proof exchange persistent, so that after client
 // restart we may receive remote/local half proof and process it.
 type WaitingProof struct {
-	*lnwire.AnnounceSignatures
+	WaitingProofInterface
 	isRemote bool
 }
 
-// NewWaitingProof constructs a new waiting prof instance.
-func NewWaitingProof(isRemote bool, proof *lnwire.AnnounceSignatures) *WaitingProof {
+// NewLegacyWaitingProof constructs a new waiting prof instance for a legacy,
+// P2WSH channel.
+func NewLegacyWaitingProof(isRemote bool,
+	proof *lnwire.AnnounceSignatures) *WaitingProof {
+
 	return &WaitingProof{
-		AnnounceSignatures: proof,
-		isRemote:           isRemote,
+		WaitingProofInterface: &LegacyWaitingProof{*proof},
+		isRemote:              isRemote,
+	}
+}
+
+// NewTaprootWaitingProof constructs a new waiting prof instance for a taproot
+// channel.
+func NewTaprootWaitingProof(isRemote bool,
+	proof *lnwire.AnnouncementSignatures2,
+	aggNonce *btcec.PublicKey) *WaitingProof {
+
+	return &WaitingProof{
+		WaitingProofInterface: &TaprootWaitingProof{
+			AnnouncementSignatures2: *proof,
+			AggNonce:                aggNonce,
+		},
+		isRemote: isRemote,
 	}
 }
 
 // OppositeKey returns the key which uniquely identifies opposite waiting proof.
 func (p *WaitingProof) OppositeKey() WaitingProofKey {
 	var key [9]byte
-	binary.BigEndian.PutUint64(key[:8], p.ShortChannelID.ToUint64())
+	binary.BigEndian.PutUint64(key[:8], p.SCID().ToUint64())
 
 	if !p.isRemote {
 		key[8] = 1
@@ -217,7 +383,7 @@ func (p *WaitingProof) OppositeKey() WaitingProofKey {
 // Key returns the key which uniquely identifies waiting proof.
 func (p *WaitingProof) Key() WaitingProofKey {
 	var key [9]byte
-	binary.BigEndian.PutUint64(key[:8], p.ShortChannelID.ToUint64())
+	binary.BigEndian.PutUint64(key[:8], p.SCID().ToUint64())
 
 	if p.isRemote {
 		key[8] = 1
@@ -227,6 +393,11 @@ func (p *WaitingProof) Key() WaitingProofKey {
 
 // Encode writes the internal representation of waiting proof in byte stream.
 func (p *WaitingProof) Encode(w io.Writer) error {
+	// Write the type byte.
+	if err := binary.Write(w, byteOrder, p.Type()); err != nil {
+		return err
+	}
+
 	if err := binary.Write(w, byteOrder, p.isRemote); err != nil {
 		return err
 	}
@@ -238,25 +409,31 @@ func (p *WaitingProof) Encode(w io.Writer) error {
 		return fmt.Errorf("expect io.Writer to be *bytes.Buffer")
 	}
 
-	if err := p.AnnounceSignatures.Encode(buf, 0); err != nil {
-		return err
-	}
-
-	return nil
+	return p.WaitingProofInterface.Encode(buf, 0)
 }
 
 // Decode reads the data from the byte stream and initializes the
 // waiting proof object with it.
 func (p *WaitingProof) Decode(r io.Reader) error {
+	var proofType WaitingProofType
+	if err := binary.Read(r, byteOrder, &proofType); err != nil {
+		return err
+	}
+
 	if err := binary.Read(r, byteOrder, &p.isRemote); err != nil {
 		return err
 	}
 
-	msg := &lnwire.AnnounceSignatures{}
-	if err := msg.Decode(r, 0); err != nil {
+	proof, ok := typeToWaitingProof(proofType)
+	if !ok {
+		return fmt.Errorf("unknown proof type")
+	}
+
+	if err := proof.Decode(r, 0); err != nil {
 		return err
 	}
 
-	(*p).AnnounceSignatures = msg
+	p.WaitingProofInterface = proof
+
 	return nil
 }

--- a/channeldb/waitingproof_test.go
+++ b/channeldb/waitingproof_test.go
@@ -1,11 +1,11 @@
 package channeldb
 
 import (
-	"reflect"
+	"errors"
+	"math/rand"
 	"testing"
 
-	"github.com/davecgh/go-spew/spew"
-	"github.com/go-errors/errors"
+	"github.com/btcsuite/btcd/btcec/v2"
 	"github.com/lightningnetwork/lnd/lnwire"
 	"github.com/stretchr/testify/require"
 )
@@ -18,40 +18,75 @@ func TestWaitingProofStore(t *testing.T) {
 	db, err := MakeTestDB(t)
 	require.NoError(t, err, "failed to make test database")
 
-	proof1 := NewWaitingProof(true, &lnwire.AnnounceSignatures{
+	proof1 := NewLegacyWaitingProof(true, &lnwire.AnnounceSignatures{
 		NodeSignature:    wireSig,
 		BitcoinSignature: wireSig,
-		ExtraOpaqueData:  make([]byte, 0),
+		ShortChannelID: lnwire.ShortChannelID{
+			BlockHeight: 1000,
+		},
+		ExtraOpaqueData: make([]byte, 0),
 	})
 
+	// No agg nonce.
+	proof2 := NewTaprootWaitingProof(true, &lnwire.AnnouncementSignatures2{
+		ShortChannelID: lnwire.ShortChannelID{
+			BlockHeight: 2000,
+		},
+		PartialSignature: *randPartialSig(t),
+		ExtraOpaqueData:  make([]byte, 0),
+	}, nil)
+
+	// With agg nonce.
+	priv, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	proof3 := NewTaprootWaitingProof(true, &lnwire.AnnouncementSignatures2{
+		ShortChannelID: lnwire.ShortChannelID{
+			BlockHeight: 2000,
+		},
+		PartialSignature: *randPartialSig(t),
+		ExtraOpaqueData:  make([]byte, 0),
+	}, priv.PubKey())
+
+	proofs := []*WaitingProof{
+		proof1,
+		proof2,
+		proof3,
+	}
+
 	store, err := NewWaitingProofStore(db)
-	if err != nil {
-		t.Fatalf("unable to create the waiting proofs storage: %v",
-			err)
-	}
+	require.NoError(t, err)
 
-	if err := store.Add(proof1); err != nil {
-		t.Fatalf("unable add proof to storage: %v", err)
-	}
+	for _, proof := range proofs {
+		require.NoError(t, store.Add(proof))
 
-	proof2, err := store.Get(proof1.Key())
-	require.NoError(t, err, "unable retrieve proof from storage")
-	if !reflect.DeepEqual(proof1, proof2) {
-		t.Fatalf("wrong proof retrieved: expected %v, got %v",
-			spew.Sdump(proof1), spew.Sdump(proof2))
-	}
+		p2, err := store.Get(proof.Key())
+		require.NoError(t, err, "unable retrieve proof from storage")
+		require.Equal(t, proof, p2)
 
-	if _, err := store.Get(proof1.OppositeKey()); err != ErrWaitingProofNotFound {
-		t.Fatalf("proof shouldn't be found: %v", err)
-	}
+		_, err = store.Get(proof.OppositeKey())
+		require.ErrorIs(t, err, ErrWaitingProofNotFound)
 
-	if err := store.Remove(proof1.Key()); err != nil {
-		t.Fatalf("unable remove proof from storage: %v", err)
+		err = store.Remove(proof.Key())
+		require.NoError(t, err)
 	}
 
 	if err := store.ForAll(func(proof *WaitingProof) error {
 		return errors.New("storage should be empty")
 	}, func() {}); err != nil && err != ErrWaitingProofNotFound {
 		t.Fatal(err)
+	}
+}
+
+func randPartialSig(t *testing.T) *lnwire.PartialSig {
+	var sigBytes [32]byte
+	_, err := rand.Read(sigBytes[:])
+	require.NoError(t, err)
+
+	var s btcec.ModNScalar
+	s.SetByteSlice(sigBytes[:])
+
+	return &lnwire.PartialSig{
+		Sig: s,
 	}
 }

--- a/discovery/chan_series.go
+++ b/discovery/chan_series.go
@@ -122,12 +122,28 @@ func (c *ChanSeries) UpdatesInHorizon(chain chainhash.Hash,
 			continue
 		}
 
-		chanAnn, edge1, edge2, err := netann.CreateChanAnnouncement(
-			channel.Info.AuthProof, channel.Info, channel.Policy1,
-			channel.Policy2,
+		var (
+			chanAnn      lnwire.Message
+			edge1, edge2 *lnwire.ChannelUpdate
 		)
-		if err != nil {
-			return nil, err
+		if channel.Info.IsTaproot {
+			//nolint:lll
+			chanAnn, edge1, edge2, err = netann.CreateChanAnnouncement2(
+				channel.Info.AuthProof, channel.Info, channel.Policy1,
+				channel.Policy2,
+			)
+			if err != nil {
+				return nil, err
+			}
+		} else {
+			//nolint:lll
+			chanAnn, edge1, edge2, err = netann.CreateChanAnnouncement(
+				channel.Info.AuthProof, channel.Info, channel.Policy1,
+				channel.Policy2,
+			)
+			if err != nil {
+				return nil, err
+			}
 		}
 
 		updates = append(updates, chanAnn)
@@ -264,12 +280,29 @@ func (c *ChanSeries) FetchChanAnns(chain chainhash.Hash,
 			continue
 		}
 
-		chanAnn, edge1, edge2, err := netann.CreateChanAnnouncement(
-			channel.Info.AuthProof, channel.Info, channel.Policy1,
-			channel.Policy2,
+		var (
+			chanAnn      lnwire.Message
+			edge1, edge2 *lnwire.ChannelUpdate
 		)
-		if err != nil {
-			return nil, err
+
+		if channel.Info.IsTaproot {
+			//nolint:lll
+			chanAnn, edge1, edge2, err = netann.CreateChanAnnouncement2(
+				channel.Info.AuthProof, channel.Info, channel.Policy1,
+				channel.Policy2,
+			)
+			if err != nil {
+				return nil, err
+			}
+		} else {
+			//nolint:lll
+			chanAnn, edge1, edge2, err = netann.CreateChanAnnouncement(
+				channel.Info.AuthProof, channel.Info, channel.Policy1,
+				channel.Policy2,
+			)
+			if err != nil {
+				return nil, err
+			}
 		}
 
 		chanAnns = append(chanAnns, chanAnn)

--- a/discovery/channel_announcement.go
+++ b/discovery/channel_announcement.go
@@ -1,0 +1,147 @@
+package discovery
+
+import (
+	"bytes"
+	"fmt"
+
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"github.com/lightningnetwork/lnd/channeldb"
+	"github.com/lightningnetwork/lnd/lnwire"
+	"github.com/lightningnetwork/lnd/netann"
+	"github.com/lightningnetwork/lnd/routing"
+)
+
+// ChanAnn is an interface representing the info that the handleChanAnnouncement
+// method needs to know about a channel announcement. This abstraction allows
+// the handleChanAnnouncement method to work for multiple types of channel
+// announcements.
+type ChanAnn interface {
+	// SCID returns the short channel ID of the channel being announced.
+	SCID() lnwire.ShortChannelID
+
+	// ChainHash returns the hash identifying the chain that the channel
+	// was opened on.
+	ChainHash() chainhash.Hash
+
+	// Name returns the underlying lnwire message name.
+	Name() string
+
+	// Msg returns the underlying lnwire.Message.
+	Msg() lnwire.Message
+
+	// Validate validates the message.
+	Validate() error
+
+	// Create constructs a new ChanAnn from the given edge info, channel
+	// proof and edge policies.
+	Create(chanProof *channeldb.ChannelAuthProof,
+		chanInfo *channeldb.ChannelEdgeInfo,
+		e1, e2 *channeldb.ChannelEdgePolicy) (ChanAnn,
+		*lnwire.ChannelUpdate, *lnwire.ChannelUpdate, error)
+
+	// BuildProof converts the lnwire.Message into a
+	// channeldb.ChannelAuthProof.
+	BuildProof() *channeldb.ChannelAuthProof
+
+	// BuildEdgeInfo converts the lnwire.Message into a
+	// channeldb.ChannelEdgeInfo.
+	BuildEdgeInfo() (*channeldb.ChannelEdgeInfo, error)
+
+	lnwire.Message
+}
+
+// chanAnn is an implementation of the ChanAnn interface which represents the
+// lnwire.ChannelAnnouncement message used for P2WSH channels.
+type chanAnn struct {
+	*lnwire.ChannelAnnouncement
+}
+
+// SCID returns the short channel ID of the channel being announced.
+//
+// NOTE: this is part of the ChanAnn interface.
+func (c *chanAnn) SCID() lnwire.ShortChannelID {
+	return c.ShortChannelID
+}
+
+// ChainHash returns the hash identifying the chain that the channel was opened
+// on.
+//
+// NOTE: this is part of the ChanAnn interface.
+func (c *chanAnn) ChainHash() chainhash.Hash {
+	return c.ChannelAnnouncement.ChainHash
+}
+
+// Name returns the underlying lnwire message name.
+//
+// NOTE: this is part of the ChanAnn interface.
+func (c *chanAnn) Name() string {
+	return "ChannelAnnouncement"
+}
+
+// Validate validates the message.
+//
+// NOTE: this is part of the ChanAnn interface.
+func (c *chanAnn) Validate() error {
+	return routing.ValidateChannelAnn(c.ChannelAnnouncement)
+}
+
+// Create constructs a new ChanAnn from the given edge info, channel
+// proof and edge policies.
+//
+// NOTE: this is part of the ChanAnn interface.
+func (c *chanAnn) Create(chanProof *channeldb.ChannelAuthProof,
+	chanInfo *channeldb.ChannelEdgeInfo,
+	e1, e2 *channeldb.ChannelEdgePolicy) (ChanAnn, *lnwire.ChannelUpdate,
+	*lnwire.ChannelUpdate, error) {
+
+	ann, update1, update2, err := netann.CreateChanAnnouncement(
+		chanProof, chanInfo, e1, e2,
+	)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+
+	return &chanAnn{ann}, update1, update2, nil
+}
+
+// BuildProof converts the lnwire.Message into a channeldb.ChannelAuthProof.
+//
+// NOTE: this is part of the ChanAnn interface.
+func (c *chanAnn) BuildProof() *channeldb.ChannelAuthProof {
+	return &channeldb.ChannelAuthProof{
+		NodeSig1Bytes:    c.NodeSig1.ToSignatureBytes(),
+		NodeSig2Bytes:    c.NodeSig2.ToSignatureBytes(),
+		BitcoinSig1Bytes: c.BitcoinSig1.ToSignatureBytes(),
+		BitcoinSig2Bytes: c.BitcoinSig2.ToSignatureBytes(),
+	}
+}
+
+// BuildEdgeInfo converts the lnwire.Message into a channeldb.ChannelEdgeInfo.
+//
+// NOTE: this is part of the ChanAnn interface.
+func (c *chanAnn) BuildEdgeInfo() (*channeldb.ChannelEdgeInfo, error) {
+	var featureBuf bytes.Buffer
+	if err := c.Features.Encode(&featureBuf); err != nil {
+		return nil, fmt.Errorf("unable to encode features: %v", err)
+	}
+
+	return &channeldb.ChannelEdgeInfo{
+		ChannelID:        c.ShortChannelID.ToUint64(),
+		ChainHash:        c.ChainHash(),
+		NodeKey1Bytes:    c.NodeID1,
+		NodeKey2Bytes:    c.NodeID2,
+		BitcoinKey1Bytes: c.BitcoinKey1,
+		BitcoinKey2Bytes: c.BitcoinKey2,
+		Features:         featureBuf.Bytes(),
+		ExtraOpaqueData:  c.ExtraOpaqueData,
+	}, nil
+}
+
+// Msg returns the underlying lnwire.Message.
+//
+// NOTE: this is part of the ChanAnn interface.
+func (c *chanAnn) Msg() lnwire.Message {
+	return c.ChannelAnnouncement
+}
+
+var _ ChanAnn = (*chanAnn)(nil)

--- a/discovery/gossiper.go
+++ b/discovery/gossiper.go
@@ -2266,6 +2266,10 @@ func (d *AuthenticatedGossiper) updateChannel(info *channeldb.ChannelEdgeInfo,
 		return nil, nil, err
 	}
 
+	if info.IsTaproot {
+		panic("implement me")
+	}
+
 	// We'll also create the original channel announcement so the two can
 	// be broadcast along side each other (if necessary), but only if we
 	// have a full channel announcement for this channel.

--- a/discovery/gossiper.go
+++ b/discovery/gossiper.go
@@ -3105,7 +3105,7 @@ func (d *AuthenticatedGossiper) handleAnnSig(nMsg *networkMsg,
 			return nil, false
 		}
 
-		proof := channeldb.NewWaitingProof(nMsg.isRemote, ann)
+		proof := channeldb.NewLegacyWaitingProof(nMsg.isRemote, ann)
 		err := d.cfg.WaitingProofStore.Add(proof)
 		if err != nil {
 			err := fmt.Errorf("unable to store the proof for "+
@@ -3211,8 +3211,8 @@ func (d *AuthenticatedGossiper) handleAnnSig(nMsg *networkMsg,
 	// announcement. If we didn't receive the opposite half of the proof
 	// then we should store this one, and wait for the opposite to be
 	// received.
-	proof := channeldb.NewWaitingProof(nMsg.isRemote, ann)
-	oppProof, err := d.cfg.WaitingProofStore.Get(proof.OppositeKey())
+	proof := channeldb.NewLegacyWaitingProof(nMsg.isRemote, ann)
+	oppositeProof, err := d.cfg.WaitingProofStore.Get(proof.OppositeKey())
 	if err != nil && err != channeldb.ErrWaitingProofNotFound {
 		err := fmt.Errorf("unable to get the opposite proof for "+
 			"short_chan_id=%v: %v", shortChanID, err)
@@ -3236,6 +3236,14 @@ func (d *AuthenticatedGossiper) handleAnnSig(nMsg *networkMsg,
 			shortChanID)
 
 		nMsg.err <- nil
+		return nil, false
+	}
+
+	oppProof, ok := oppositeProof.
+		WaitingProofInterface.(*channeldb.LegacyWaitingProof)
+	if !ok {
+		nMsg.err <- fmt.Errorf("got wrong waiting proof type")
+
 		return nil, false
 	}
 

--- a/discovery/gossiper_test.go
+++ b/discovery/gossiper_test.go
@@ -3269,6 +3269,8 @@ func TestSendChannelUpdateReliably(t *testing.T) {
 			assertMessage(t, staleChannelUpdate, msg)
 		case *lnwire.AnnounceSignatures:
 			assertMessage(t, batch.localProofAnn, msg)
+		case *lnwire.AnnouncementSignatures2:
+			assertMessage(t, batch.localProofAnn, msg)
 		default:
 			t.Fatalf("send unexpected %v message", msg.MsgType())
 		}

--- a/discovery/gossiper_test.go
+++ b/discovery/gossiper_test.go
@@ -2778,6 +2778,8 @@ func TestRetransmit(t *testing.T) {
 			switch msg.(type) {
 			case *lnwire.ChannelAnnouncement:
 				chanAnn++
+			case *lnwire.ChannelAnnouncement2:
+				chanAnn++
 			case *lnwire.ChannelUpdate:
 				chanUpd++
 			case *lnwire.NodeAnnouncement:

--- a/discovery/message_store.go
+++ b/discovery/message_store.go
@@ -85,6 +85,8 @@ func msgShortChanID(msg lnwire.Message) (lnwire.ShortChannelID, error) {
 	switch msg := msg.(type) {
 	case *lnwire.AnnounceSignatures:
 		shortChanID = msg.ShortChannelID
+	case *lnwire.AnnouncementSignatures2:
+		shortChanID = msg.ShortChannelID
 	case *lnwire.ChannelUpdate:
 		shortChanID = msg.ShortChannelID
 	default:

--- a/discovery/message_store_test.go
+++ b/discovery/message_store_test.go
@@ -118,6 +118,8 @@ func TestMessageStoreMessages(t *testing.T) {
 			switch msg := msg.(type) {
 			case *lnwire.AnnounceSignatures:
 				shortChanID = msg.ShortChannelID.ToUint64()
+			case *lnwire.AnnouncementSignatures2:
+				shortChanID = msg.ShortChannelID.ToUint64()
 			case *lnwire.ChannelUpdate:
 				shortChanID = msg.ShortChannelID.ToUint64()
 			default:

--- a/feature/default_sets.go
+++ b/feature/default_sets.go
@@ -87,4 +87,8 @@ var defaultSetDesc = setDesc{
 		SetInit:    {}, // I
 		SetNodeAnn: {}, // N
 	},
+	lnwire.TaprootGossipOptionalStaging: {
+		SetInit:    {}, // I
+		SetNodeAnn: {}, // N
+	},
 }

--- a/funding/manager.go
+++ b/funding/manager.go
@@ -1595,21 +1595,9 @@ func (f *Manager) fundeeProcessOpenChannel(peer lnpeer.Peer,
 	}
 
 	public := msg.ChannelFlags&lnwire.FFAnnounceChannel != 0
-	switch {
-	// Sending the option-scid-alias channel type for a public channel is
-	// disallowed.
-	case public && scid:
+	if public && scid {
 		err = fmt.Errorf("option-scid-alias chantype for public " +
 			"channel")
-		log.Error(err)
-		f.failFundingFlow(peer, cid, err)
-
-		return
-
-	// The current variant of taproot channels can only be used with
-	// unadvertised channels for now.
-	case commitType.IsTaproot() && public:
-		err = fmt.Errorf("taproot channel type for public channel")
 		log.Error(err)
 		f.failFundingFlow(peer, cid, err)
 
@@ -4956,6 +4944,20 @@ func (f *Manager) handleInitFundingMsg(msg *InitFundingMsg) {
 		log.Errorf("channel type negotiation failed: %v", err)
 		msg.Err <- err
 		return
+	}
+
+	// Announced taproot channels are only allowed if our peer also supports
+	// taproot gossip.
+	if !msg.Private && commitType.IsTaproot() {
+		if !msg.Peer.RemoteFeatures().HasFeature(
+			lnwire.TaprootGossipOptionalStaging,
+		) {
+			err := fmt.Errorf("peer does not support taproot " +
+				"gossip")
+			log.Errorf("%v", err)
+			msg.Err <- err
+			return
+		}
 	}
 
 	var (

--- a/funding/manager.go
+++ b/funding/manager.go
@@ -386,6 +386,16 @@ type Config struct {
 	SignMessage func(keyLoc keychain.KeyLocator,
 		msg []byte, doubleHash bool) (*ecdsa.Signature, error)
 
+	// SignMuSig2 generates a MuSig2 partial signature given the passed key
+	// set, secret nonce, public nonce, and private keys.
+	SignMuSig2 func(secNonce [musig2.SecNonceSize]byte,
+		keyLoc keychain.KeyLocator,
+		otherNonces [][musig2.PubNonceSize]byte,
+		combinedNonce [musig2.PubNonceSize]byte,
+		pubKeys []*btcec.PublicKey,
+		msg [32]byte, opts ...musig2.SignOption) (
+		*musig2.PartialSignature, error)
+
 	// CurrentNodeAnnouncement should return the latest, fully signed node
 	// announcement from the backing Lightning Network node with a fresh
 	// timestamp.

--- a/funding/manager_test.go
+++ b/funding/manager_test.go
@@ -1197,6 +1197,8 @@ func assertChannelAnnouncements(t *testing.T, alice, bob *testNode,
 			switch m := msg.(type) {
 			case *lnwire.ChannelAnnouncement:
 				gotChannelAnnouncement = true
+			case *lnwire.ChannelAnnouncement2:
+				gotChannelAnnouncement = true
 			case *lnwire.ChannelUpdate:
 
 				// The channel update sent by the node should

--- a/funding/manager_test.go
+++ b/funding/manager_test.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/btcsuite/btcd/btcec/v2"
 	"github.com/btcsuite/btcd/btcec/v2/ecdsa"
+	"github.com/btcsuite/btcd/btcec/v2/schnorr/musig2"
 	"github.com/btcsuite/btcd/btcutil"
 	"github.com/btcsuite/btcd/chaincfg"
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
@@ -444,6 +445,9 @@ func createTestFundingManager(t *testing.T, privKey *btcec.PrivateKey,
 
 	chainedAcceptor := acpt.NewChainedAcceptor()
 
+	r := *bobPubKey
+	s := *testSScalar
+
 	fundingCfg := Config{
 		IDKey:        privKey.PubKey(),
 		IDKeyLoc:     testKeyLoc,
@@ -455,6 +459,17 @@ func createTestFundingManager(t *testing.T, privKey *btcec.PrivateKey,
 			_ []byte, _ bool) (*ecdsa.Signature, error) {
 
 			return testSig, nil
+		},
+		SignMuSig2: func(secNonce [97]byte, keyLoc keychain.KeyLocator,
+			otherNonces [][66]byte, combinedNonce [66]byte,
+			pubKeys []*btcec.PublicKey, msg [32]byte,
+			opts ...musig2.SignOption) (*musig2.PartialSignature,
+			error) {
+
+			return &musig2.PartialSignature{
+				S: &s,
+				R: &r,
+			}, nil
 		},
 		SendAnnouncement: func(msg lnwire.Message,
 			_ ...discovery.OptionalMsgField) chan error {
@@ -618,6 +633,17 @@ func recreateAliceFundingManager(t *testing.T, alice *testNode) {
 			_ []byte, _ bool) (*ecdsa.Signature, error) {
 
 			return testSig, nil
+		},
+		SignMuSig2: func(secNonce [97]byte, keyLoc keychain.KeyLocator,
+			otherNonces [][66]byte, combinedNonce [66]byte,
+			pubKeys []*btcec.PublicKey, msg [32]byte,
+			opts ...musig2.SignOption) (*musig2.PartialSignature,
+			error) {
+
+			return &musig2.PartialSignature{
+				S: testSScalar,
+				R: bobPubKey,
+			}, nil
 		},
 		SendAnnouncement: func(msg lnwire.Message,
 			_ ...discovery.OptionalMsgField) chan error {
@@ -790,12 +816,6 @@ func fundChannel(t *testing.T, alice, bob *testNode, localFundingAmt,
 		ChannelType:     chanType,
 		Updates:         updateChan,
 		Err:             errChan,
-	}
-
-	// If this is a taproot channel, then we want to force it to be a
-	// private channel, as that's the only channel type supported for now.
-	if isTaprootChanType(chanType) {
-		initReq.Private = true
 	}
 
 	alice.fundingMgr.InitFundingWorkflow(initReq)
@@ -1442,11 +1462,11 @@ func testNormalWorkflow(t *testing.T, chanType *lnwire.ChannelType) {
 		// test.
 		featureBits := []lnwire.FeatureBit{
 			lnwire.ZeroConfOptional,
-			lnwire.ScidAliasOptional,
 			lnwire.ExplicitChannelTypeOptional,
 			lnwire.StaticRemoteKeyOptional,
 			lnwire.AnchorsZeroFeeHtlcTxOptional,
 			lnwire.SimpleTaprootChannelsOptionalStaging,
+			lnwire.TaprootGossipOptionalStaging,
 		}
 		alice.localFeatures = featureBits
 		alice.remoteFeatures = featureBits
@@ -1536,20 +1556,7 @@ func testNormalWorkflow(t *testing.T, chanType *lnwire.ChannelType) {
 		Tx: fundingTx,
 	}
 
-	switch {
-	// For taproot channels, we expect them to only send a node
-	// announcement message at this point. These channels aren't advertised
-	// so we don't expect the other messages.
-	case isTaprootChanType(chanType):
-		assertNodeAnnSent(t, alice, bob)
-
-	// For regular channels, we'll make sure the fundingManagers exchange
-	// announcement signatures.
-	case chanType == nil:
-		fallthrough
-	default:
-		assertAnnouncementSignatures(t, alice, bob)
-	}
+	assertAnnouncementSignatures(t, alice, bob)
 
 	// The internal state-machine should now have deleted the channelStates
 	// from the database, as the channel is announced.
@@ -4486,6 +4493,7 @@ func testZeroConf(t *testing.T, chanType *lnwire.ChannelType) {
 		lnwire.StaticRemoteKeyOptional,
 		lnwire.AnchorsZeroFeeHtlcTxOptional,
 		lnwire.SimpleTaprootChannelsOptionalStaging,
+		lnwire.TaprootGossipOptionalStaging,
 	}
 	alice.localFeatures = featureBits
 	alice.remoteFeatures = featureBits
@@ -4583,12 +4591,9 @@ func testZeroConf(t *testing.T, chanType *lnwire.ChannelType) {
 		Tx: fundingTx,
 	}
 
-	// For taproot channels, we don't expect them to be announced atm.
-	if !isTaprootChanType(chanType) {
-		assertChannelAnnouncements(
-			t, alice, bob, fundingAmt, nil, nil, nil, nil,
-		)
-	}
+	assertChannelAnnouncements(
+		t, alice, bob, fundingAmt, nil, nil, nil, nil,
+	)
 
 	// Both Alice and Bob should send on reportScidChan.
 	select {
@@ -4612,20 +4617,7 @@ func testZeroConf(t *testing.T, chanType *lnwire.ChannelType) {
 		Tx: fundingTx,
 	}
 
-	switch {
-	// For taproot channels, we expect them to only send a node
-	// announcement message at this point. These channels aren't advertised
-	// so we don't expect the other messages.
-	case isTaprootChanType(chanType):
-		assertNodeAnnSent(t, alice, bob)
-
-	// For regular channels, we'll make sure the fundingManagers exchange
-	// announcement signatures.
-	case chanType == nil:
-		fallthrough
-	default:
-		assertAnnouncementSignatures(t, alice, bob)
-	}
+	assertAnnouncementSignatures(t, alice, bob)
 
 	// Assert that the channel state is deleted from the fundingmanager's
 	// datastore.

--- a/funding/manager_test.go
+++ b/funding/manager_test.go
@@ -1286,7 +1286,9 @@ func assertAnnouncementSignatures(t *testing.T, alice, bob *testNode) {
 		gotNodeAnnouncement := false
 		for _, msg := range announcements {
 			switch msg.(type) {
-			case *lnwire.AnnounceSignatures:
+			case *lnwire.AnnounceSignatures,
+				*lnwire.AnnouncementSignatures2:
+
 				gotAnnounceSignatures = true
 			case *lnwire.NodeAnnouncement:
 				gotNodeAnnouncement = true

--- a/htlcswitch/failure_test.go
+++ b/htlcswitch/failure_test.go
@@ -65,7 +65,7 @@ func TestLongFailureMessage(t *testing.T) {
 	var value varBytesRecordProducer
 
 	extraData := incorrectDetails.ExtraOpaqueData()
-	typeMap, err := extraData.ExtractRecords(&value)
+	typeMap, err := extraData.ExtractRecordsFromProducers(&value)
 	require.NoError(t, err)
 	require.Len(t, typeMap, 1)
 

--- a/itest/lnd_channel_backup_test.go
+++ b/itest/lnd_channel_backup_test.go
@@ -107,13 +107,6 @@ func newChanRestoreScenario(ht *lntest.HarnessTest, ct lnrpc.CommitmentType,
 	// with a portion pushed.
 	ht.ConnectNodes(dave, carol)
 
-	// If the commitment type is taproot, then the channel must also be
-	// private.
-	var privateChan bool
-	if ct == lnrpc.CommitmentType_SIMPLE_TAPROOT {
-		privateChan = true
-	}
-
 	return &chanRestoreScenario{
 		carol:    carol,
 		dave:     dave,
@@ -124,7 +117,6 @@ func newChanRestoreScenario(ht *lntest.HarnessTest, ct lnrpc.CommitmentType,
 			PushAmt:        pushAmt,
 			ZeroConf:       zeroConf,
 			CommitmentType: ct,
-			Private:        privateChan,
 		},
 	}
 }
@@ -648,13 +640,6 @@ func runChanRestoreScenarioCommitTypes(ht *lntest.HarnessTest,
 	// channels.backup file.
 	multi, err := ioutil.ReadFile(backupFilePath)
 	require.NoError(ht, err)
-
-	// If this was a zero conf taproot channel, then since it's private,
-	// we'll need to mine an extra block (framework won't mine extra blocks
-	// otherwise).
-	if ct == lnrpc.CommitmentType_SIMPLE_TAPROOT && zeroConf {
-		ht.MineBlocksAndAssertNumTxes(1, 1)
-	}
 
 	// Now that we have Dave's backup file, we'll create a new nodeRestorer
 	// that we'll restore using the on-disk channels.backup.

--- a/itest/lnd_channel_force_close_test.go
+++ b/itest/lnd_channel_force_close_test.go
@@ -268,18 +268,8 @@ func channelForceClosureTest(ht *lntest.HarnessTest,
 	carolBalResp := carol.RPC.WalletBalance()
 	carolStartingBalance := carolBalResp.ConfirmedBalance
 
-	// If the channel is a taproot channel, then we'll need to create a
-	// private channel.
-	//
-	// TODO(roasbeef): lift after G175
-	var privateChan bool
-	if channelType == lnrpc.CommitmentType_SIMPLE_TAPROOT {
-		privateChan = true
-	}
-
 	chanPoint := ht.OpenChannel(
 		alice, carol, lntest.OpenChannelParams{
-			Private:        privateChan,
 			Amt:            chanAmt,
 			PushAmt:        pushAmt,
 			CommitmentType: channelType,

--- a/itest/lnd_funding_test.go
+++ b/itest/lnd_funding_test.go
@@ -60,16 +60,6 @@ func testBasicChannelFunding(ht *lntest.HarnessTest) {
 		// connected to the funding flow can properly be executed.
 		ht.EnsureConnected(carol, dave)
 
-		var privateChan bool
-
-		// If this is to be a taproot channel type, then it needs to be
-		// private, otherwise it'll be rejected by Dave.
-		//
-		// TODO(roasbeef): lift after gossip 1.75
-		if carolCommitType == lnrpc.CommitmentType_SIMPLE_TAPROOT {
-			privateChan = true
-		}
-
 		// If carol wants taproot, but dave wants something
 		// else, then we'll assert that the channel negotiation
 		// attempt fails.
@@ -81,7 +71,6 @@ func testBasicChannelFunding(ht *lntest.HarnessTest) {
 			amt := funding.MaxBtcFundingAmount
 			ht.OpenChannelAssertErr(
 				carol, dave, lntest.OpenChannelParams{
-					Private:        privateChan,
 					Amt:            amt,
 					CommitmentType: carolCommitType,
 				}, expectedErr,
@@ -91,7 +80,7 @@ func testBasicChannelFunding(ht *lntest.HarnessTest) {
 		}
 
 		carolChan, daveChan, closeChan := basicChannelFundingTest(
-			ht, carol, dave, nil, privateChan, &carolCommitType,
+			ht, carol, dave, nil, false, &carolCommitType,
 		)
 
 		// Both nodes should report the same commitment

--- a/itest/lnd_multi-hop_test.go
+++ b/itest/lnd_multi-hop_test.go
@@ -193,13 +193,6 @@ func runMultiHopHtlcLocalTimeout(ht *lntest.HarnessTest,
 	dustPayHash := ht.Random32Bytes()
 	payHash := ht.Random32Bytes()
 
-	// If this is a taproot channel, then we'll need to make some manual
-	// route hints so Alice can actually find a route.
-	var routeHints []*lnrpc.RouteHint
-	if c == lnrpc.CommitmentType_SIMPLE_TAPROOT {
-		routeHints = makeRouteHints(bob, carol, zeroConf)
-	}
-
 	alice.RPC.SendPayment(&routerrpc.SendPaymentRequest{
 		Dest:           carolPubKey,
 		Amt:            int64(dustHtlcAmt),
@@ -207,7 +200,6 @@ func runMultiHopHtlcLocalTimeout(ht *lntest.HarnessTest,
 		FinalCltvDelta: finalCltvDelta,
 		TimeoutSeconds: 60,
 		FeeLimitMsat:   noFeeLimitMsat,
-		RouteHints:     routeHints,
 	})
 
 	alice.RPC.SendPayment(&routerrpc.SendPaymentRequest{
@@ -217,7 +209,6 @@ func runMultiHopHtlcLocalTimeout(ht *lntest.HarnessTest,
 		FinalCltvDelta: finalCltvDelta,
 		TimeoutSeconds: 60,
 		FeeLimitMsat:   noFeeLimitMsat,
-		RouteHints:     routeHints,
 	})
 
 	// Verify that all nodes in the path now have two HTLC's with the
@@ -357,13 +348,6 @@ func runMultiHopReceiverChainClaim(ht *lntest.HarnessTest,
 		ht, alice, bob, false, c, zeroConf,
 	)
 
-	// If this is a taproot channel, then we'll need to make some manual
-	// route hints so Alice can actually find a route.
-	var routeHints []*lnrpc.RouteHint
-	if c == lnrpc.CommitmentType_SIMPLE_TAPROOT {
-		routeHints = makeRouteHints(bob, carol, zeroConf)
-	}
-
 	// With the network active, we'll now add a new hodl invoice at Carol's
 	// end. Make sure the cltv expiry delta is large enough, otherwise Bob
 	// won't send out the outgoing htlc.
@@ -375,7 +359,6 @@ func runMultiHopReceiverChainClaim(ht *lntest.HarnessTest,
 		Value:      invoiceAmt,
 		CltvExpiry: finalCltvDelta,
 		Hash:       payHash[:],
-		RouteHints: routeHints,
 	}
 	carolInvoice := carol.RPC.AddHoldInvoice(invoiceReq)
 
@@ -574,13 +557,6 @@ func runMultiHopLocalForceCloseOnChainHtlcTimeout(ht *lntest.HarnessTest,
 	// opens up the base for out tests.
 	const htlcAmt = btcutil.Amount(300_000)
 
-	// If this is a taproot channel, then we'll need to make some manual
-	// route hints so Alice can actually find a route.
-	var routeHints []*lnrpc.RouteHint
-	if c == lnrpc.CommitmentType_SIMPLE_TAPROOT {
-		routeHints = makeRouteHints(bob, carol, zeroConf)
-	}
-
 	// We'll now send a single HTLC across our multi-hop network.
 	carolPubKey := carol.PubKey[:]
 	payHash := ht.Random32Bytes()
@@ -591,7 +567,6 @@ func runMultiHopLocalForceCloseOnChainHtlcTimeout(ht *lntest.HarnessTest,
 		FinalCltvDelta: finalCltvDelta,
 		TimeoutSeconds: 60,
 		FeeLimitMsat:   noFeeLimitMsat,
-		RouteHints:     routeHints,
 	}
 	alice.RPC.SendPayment(req)
 
@@ -744,13 +719,6 @@ func runMultiHopRemoteForceCloseOnChainHtlcTimeout(ht *lntest.HarnessTest,
 	// opens up the base for out tests.
 	const htlcAmt = btcutil.Amount(30000)
 
-	// If this is a taproot channel, then we'll need to make some manual
-	// route hints so Alice can actually find a route.
-	var routeHints []*lnrpc.RouteHint
-	if c == lnrpc.CommitmentType_SIMPLE_TAPROOT {
-		routeHints = makeRouteHints(bob, carol, zeroConf)
-	}
-
 	// We'll now send a single HTLC across our multi-hop network.
 	var preimage lntypes.Preimage
 	copy(preimage[:], ht.Random32Bytes())
@@ -759,7 +727,6 @@ func runMultiHopRemoteForceCloseOnChainHtlcTimeout(ht *lntest.HarnessTest,
 		Value:      int64(htlcAmt),
 		CltvExpiry: finalCltvDelta,
 		Hash:       payHash[:],
-		RouteHints: routeHints,
 	}
 	carolInvoice := carol.RPC.AddHoldInvoice(invoiceReq)
 
@@ -911,13 +878,6 @@ func runMultiHopHtlcLocalChainClaim(ht *lntest.HarnessTest,
 		ht, alice, bob, false, c, zeroConf,
 	)
 
-	// If this is a taproot channel, then we'll need to make some manual
-	// route hints so Alice can actually find a route.
-	var routeHints []*lnrpc.RouteHint
-	if c == lnrpc.CommitmentType_SIMPLE_TAPROOT {
-		routeHints = makeRouteHints(bob, carol, zeroConf)
-	}
-
 	// With the network active, we'll now add a new hodl invoice at Carol's
 	// end. Make sure the cltv expiry delta is large enough, otherwise Bob
 	// won't send out the outgoing htlc.
@@ -929,7 +889,6 @@ func runMultiHopHtlcLocalChainClaim(ht *lntest.HarnessTest,
 		Value:      invoiceAmt,
 		CltvExpiry: finalCltvDelta,
 		Hash:       payHash[:],
-		RouteHints: routeHints,
 	}
 	carolInvoice := carol.RPC.AddHoldInvoice(invoiceReq)
 
@@ -1223,13 +1182,6 @@ func runMultiHopHtlcRemoteChainClaim(ht *lntest.HarnessTest,
 		ht, alice, bob, false, c, zeroConf,
 	)
 
-	// If this is a taproot channel, then we'll need to make some manual
-	// route hints so Alice can actually find a route.
-	var routeHints []*lnrpc.RouteHint
-	if c == lnrpc.CommitmentType_SIMPLE_TAPROOT {
-		routeHints = makeRouteHints(bob, carol, zeroConf)
-	}
-
 	// With the network active, we'll now add a new hodl invoice at Carol's
 	// end. Make sure the cltv expiry delta is large enough, otherwise Bob
 	// won't send out the outgoing htlc.
@@ -1241,7 +1193,6 @@ func runMultiHopHtlcRemoteChainClaim(ht *lntest.HarnessTest,
 		Value:      invoiceAmt,
 		CltvExpiry: finalCltvDelta,
 		Hash:       payHash[:],
-		RouteHints: routeHints,
 	}
 	carolInvoice := carol.RPC.AddHoldInvoice(invoiceReq)
 
@@ -1510,23 +1461,11 @@ func runMultiHopHtlcAggregation(ht *lntest.HarnessTest,
 		ht, alice, bob, false, c, zeroConf,
 	)
 
-	// If this is a taproot channel, then we'll need to make some manual
-	// route hints so Alice+Carol can actually find a route.
-	var (
-		carolRouteHints []*lnrpc.RouteHint
-		aliceRouteHints []*lnrpc.RouteHint
-	)
-	if c == lnrpc.CommitmentType_SIMPLE_TAPROOT {
-		carolRouteHints = makeRouteHints(bob, carol, zeroConf)
-		aliceRouteHints = makeRouteHints(bob, alice, zeroConf)
-	}
-
 	// To ensure we have capacity in both directions of the route, we'll
 	// make a fairly large payment Alice->Carol and settle it.
 	const reBalanceAmt = 500_000
 	invoice := &lnrpc.Invoice{
-		Value:      reBalanceAmt,
-		RouteHints: carolRouteHints,
+		Value: reBalanceAmt,
 	}
 	resp := carol.RPC.AddInvoice(invoice)
 	ht.CompletePaymentRequests(alice, []string{resp.PaymentRequest})
@@ -1558,7 +1497,6 @@ func runMultiHopHtlcAggregation(ht *lntest.HarnessTest,
 			Value:      invoiceAmt,
 			CltvExpiry: finalCltvDelta,
 			Hash:       payHash[:],
-			RouteHints: carolRouteHints,
 		}
 		carolInvoice := carol.RPC.AddHoldInvoice(invoiceReq)
 
@@ -1580,7 +1518,6 @@ func runMultiHopHtlcAggregation(ht *lntest.HarnessTest,
 			Value:      invoiceAmt,
 			CltvExpiry: thawHeightDelta - 4,
 			Hash:       payHash[:],
-			RouteHints: aliceRouteHints,
 		}
 		aliceInvoice := alice.RPC.AddHoldInvoice(invoiceReq)
 
@@ -1946,13 +1883,7 @@ func createThreeHopNetwork(ht *lntest.HarnessTest,
 		)
 	}
 
-	var privateChan bool
-	if c == lnrpc.CommitmentType_SIMPLE_TAPROOT {
-		privateChan = true
-	}
-
 	aliceParams := lntest.OpenChannelParams{
-		Private:        privateChan,
 		Amt:            chanAmt,
 		CommitmentType: c,
 		FundingShim:    aliceFundingShim,
@@ -1977,7 +1908,6 @@ func createThreeHopNetwork(ht *lntest.HarnessTest,
 	// Prepare params for Bob.
 	bobParams := lntest.OpenChannelParams{
 		Amt:            chanAmt,
-		Private:        privateChan,
 		CommitmentType: c,
 		FundingShim:    bobFundingShim,
 		ZeroConf:       zeroConf,
@@ -2022,18 +1952,8 @@ func createThreeHopNetwork(ht *lntest.HarnessTest,
 	}
 
 	// Make sure alice and carol know each other's channels.
-	//
-	// We'll only do this though if it wasn't a private channel we opened
-	// earlier.
-	if !privateChan {
-		ht.AssertTopologyChannelOpen(alice, bobChanPoint)
-		ht.AssertTopologyChannelOpen(carol, aliceChanPoint)
-	} else {
-		// Otherwise, we want to wait for all the channels to be shown
-		// as active before we proceed.
-		ht.AssertChannelExists(alice, aliceChanPoint)
-		ht.AssertChannelExists(carol, bobChanPoint)
-	}
+	ht.AssertTopologyChannelOpen(alice, bobChanPoint)
+	ht.AssertTopologyChannelOpen(carol, aliceChanPoint)
 
 	return aliceChanPoint, bobChanPoint, carol
 }
@@ -2061,13 +1981,6 @@ func runExtraPreimageFromRemoteCommit(ht *lntest.HarnessTest,
 		ht, alice, bob, false, c, zeroConf,
 	)
 
-	// If this is a taproot channel, then we'll need to make some manual
-	// route hints so Alice can actually find a route.
-	var routeHints []*lnrpc.RouteHint
-	if c == lnrpc.CommitmentType_SIMPLE_TAPROOT {
-		routeHints = makeRouteHints(bob, carol, zeroConf)
-	}
-
 	// With the network active, we'll now add a new hodl invoice at Carol's
 	// end. Make sure the cltv expiry delta is large enough, otherwise Bob
 	// won't send out the outgoing htlc.
@@ -2077,7 +1990,6 @@ func runExtraPreimageFromRemoteCommit(ht *lntest.HarnessTest,
 		Value:      100_000,
 		CltvExpiry: finalCltvDelta,
 		Hash:       payHash[:],
-		RouteHints: routeHints,
 	}
 	eveInvoice := carol.RPC.AddHoldInvoice(invoiceReq)
 
@@ -2220,13 +2132,6 @@ func runExtraPreimageFromLocalCommit(ht *lntest.HarnessTest,
 		ht, alice, bob, false, c, zeroConf,
 	)
 
-	// If this is a taproot channel, then we'll need to make some manual
-	// route hints so Alice can actually find a route.
-	var routeHints []*lnrpc.RouteHint
-	if c == lnrpc.CommitmentType_SIMPLE_TAPROOT {
-		routeHints = makeRouteHints(bob, carol, zeroConf)
-	}
-
 	// With the network active, we'll now add a new hodl invoice at Carol's
 	// end. Make sure the cltv expiry delta is large enough, otherwise Bob
 	// won't send out the outgoing htlc.
@@ -2236,7 +2141,6 @@ func runExtraPreimageFromLocalCommit(ht *lntest.HarnessTest,
 		Value:      100_000,
 		CltvExpiry: finalCltvDelta,
 		Hash:       payHash[:],
-		RouteHints: routeHints,
 	}
 	eveInvoice := carol.RPC.AddHoldInvoice(invoiceReq)
 

--- a/itest/lnd_payment_test.go
+++ b/itest/lnd_payment_test.go
@@ -132,10 +132,6 @@ func testSendDirectPayment(ht *lntest.HarnessTest) {
 				CommitmentType: ct,
 			}
 
-			// Open private channel for taproot channels.
-			params.Private = ct ==
-				lnrpc.CommitmentType_SIMPLE_TAPROOT
-
 			testSendPayment(st, params)
 		})
 	}

--- a/itest/lnd_psbt_test.go
+++ b/itest/lnd_psbt_test.go
@@ -35,20 +35,14 @@ func testPsbtChanFunding(ht *lntest.HarnessTest) {
 	testCases := []struct {
 		name           string
 		commitmentType lnrpc.CommitmentType
-		private        bool
 	}{
 		{
 			name:           "anchors",
 			commitmentType: lnrpc.CommitmentType_ANCHORS,
-			private:        false,
 		},
 		{
 			name:           "simple taproot",
 			commitmentType: lnrpc.CommitmentType_SIMPLE_TAPROOT,
-
-			// Set this to true once simple taproot channels can be
-			// announced to the network.
-			private: true,
 		},
 	}
 
@@ -76,7 +70,7 @@ func testPsbtChanFunding(ht *lntest.HarnessTest) {
 				Name: tc.name,
 				TestFunc: func(sst *lntest.HarnessTest) {
 					runPsbtChanFunding(
-						sst, carol, dave, tc.private,
+						sst, carol, dave, false,
 						tc.commitmentType,
 					)
 				},
@@ -97,7 +91,7 @@ func testPsbtChanFunding(ht *lntest.HarnessTest) {
 				Name: tc.name,
 				TestFunc: func(sst *lntest.HarnessTest) {
 					runPsbtChanFundingExternal(
-						sst, carol, dave, tc.private,
+						sst, carol, dave, false,
 						tc.commitmentType,
 					)
 				},
@@ -114,7 +108,7 @@ func testPsbtChanFunding(ht *lntest.HarnessTest) {
 				Name: tc.name,
 				TestFunc: func(sst *lntest.HarnessTest) {
 					runPsbtChanFundingSingleStep(
-						sst, carol, dave, tc.private,
+						sst, carol, dave, false,
 						tc.commitmentType,
 					)
 				},

--- a/itest/lnd_revocation_test.go
+++ b/itest/lnd_revocation_test.go
@@ -54,12 +54,10 @@ func breachRetributionTestCase(ht *lntest.HarnessTest,
 	// In order to test Carol's response to an uncooperative channel
 	// closure by Bob, we'll first open up a channel between them with a
 	// 0.5 BTC value.
-	privateChan := commitType == lnrpc.CommitmentType_SIMPLE_TAPROOT
 	chanPoint := ht.OpenChannel(
 		carol, bob, lntest.OpenChannelParams{
 			CommitmentType: commitType,
 			Amt:            chanAmt,
-			Private:        privateChan,
 		},
 	)
 
@@ -247,12 +245,10 @@ func revokedCloseRetributionZeroValueRemoteOutputCase(ht *lntest.HarnessTest,
 	// In order to test Dave's response to an uncooperative channel
 	// closure by Carol, we'll first open up a channel between them with a
 	// 0.5 BTC value.
-	privateChan := commitType == lnrpc.CommitmentType_SIMPLE_TAPROOT
 	chanPoint := ht.OpenChannel(
 		dave, carol, lntest.OpenChannelParams{
 			CommitmentType: commitType,
 			Amt:            chanAmt,
-			Private:        privateChan,
 		},
 	)
 
@@ -434,12 +430,10 @@ func revokedCloseRetributionRemoteHodlCase(ht *lntest.HarnessTest,
 	// In order to test Dave's response to an uncooperative channel closure
 	// by Carol, we'll first open up a channel between them with a
 	// funding.MaxBtcFundingAmount (2^24) satoshis value.
-	privateChan := commitType == lnrpc.CommitmentType_SIMPLE_TAPROOT
 	chanPoint := ht.OpenChannel(
 		dave, carol, lntest.OpenChannelParams{
 			Amt:            chanAmt,
 			PushAmt:        pushAmt,
-			Private:        privateChan,
 			CommitmentType: commitType,
 		},
 	)

--- a/keychain/derivation.go
+++ b/keychain/derivation.go
@@ -6,6 +6,7 @@ import (
 	"github.com/btcsuite/btcd/btcec/v2"
 	"github.com/btcsuite/btcd/btcec/v2/ecdsa"
 	"github.com/btcsuite/btcd/btcec/v2/schnorr"
+	"github.com/btcsuite/btcd/btcec/v2/schnorr/musig2"
 )
 
 const (
@@ -241,6 +242,14 @@ type MessageSignerRing interface {
 	SignMessageSchnorr(keyLoc KeyLocator, msg []byte,
 		doubleHash bool, taprootTweak []byte) (*schnorr.Signature,
 		error)
+
+	// SignMuSig2 generates a MuSig2 partial signature given the passed key
+	// set, secret nonce, public nonce, and private keys
+	SignMuSig2(secNonce [musig2.SecNonceSize]byte,
+		keyLoc KeyLocator, otherNonces [][musig2.PubNonceSize]byte,
+		combinedNonce [musig2.PubNonceSize]byte,
+		pubKeys []*btcec.PublicKey, msg [32]byte,
+		opts ...musig2.SignOption) (*musig2.PartialSignature, error)
 }
 
 // SingleKeyMessageSigner is an abstraction interface that hides the
@@ -262,6 +271,14 @@ type SingleKeyMessageSigner interface {
 	// hashing it first, with the wrapped private key and returns the
 	// signature in the compact, public key recoverable format.
 	SignMessageCompact(message []byte, doubleHash bool) ([]byte, error)
+
+	// SignMuSig2 generates a MuSig2 partial signature given the passed key
+	// set, secret nonce, public nonce, and private keys.
+	SignMuSig2(secNonce [musig2.SecNonceSize]byte,
+		keyLoc KeyLocator, otherNonces [][musig2.PubNonceSize]byte,
+		combinedNonce [musig2.PubNonceSize]byte,
+		pubKeys []*btcec.PublicKey, msg [32]byte,
+		opts ...musig2.SignOption) (*musig2.PartialSignature, error)
 }
 
 // ECDHRing is an interface that abstracts away basic low-level ECDH shared key

--- a/lntest/mock/secretkeyring.go
+++ b/lntest/mock/secretkeyring.go
@@ -4,6 +4,7 @@ import (
 	"github.com/btcsuite/btcd/btcec/v2"
 	"github.com/btcsuite/btcd/btcec/v2/ecdsa"
 	"github.com/btcsuite/btcd/btcec/v2/schnorr"
+	"github.com/btcsuite/btcd/btcec/v2/schnorr/musig2"
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcd/txscript"
 	"github.com/lightningnetwork/lnd/keychain"
@@ -57,6 +58,19 @@ func (s *SecretKeyRing) SignMessage(_ keychain.KeyLocator,
 		digest = chainhash.HashB(msg)
 	}
 	return ecdsa.Sign(s.RootKey, digest), nil
+}
+
+// SignMuSig2 generates a MuSig2 partial signature given the passed key set,
+// secret nonce, public nonce, and private keys.
+func (s *SecretKeyRing) SignMuSig2(secNonce [musig2.SecNonceSize]byte,
+	_ keychain.KeyLocator, _ [][musig2.PubNonceSize]byte,
+	combinedNonce [musig2.PubNonceSize]byte, pubKeys []*btcec.PublicKey,
+	msg [32]byte, opts ...musig2.SignOption) (*musig2.PartialSignature,
+	error) {
+
+	return musig2.Sign(
+		secNonce, s.RootKey, combinedNonce, pubKeys, msg, opts...,
+	)
 }
 
 // SignMessageCompact signs the passed message.

--- a/lntest/mock/signer.go
+++ b/lntest/mock/signer.go
@@ -205,3 +205,25 @@ func (s *SingleSigner) SignMessage(keyLoc keychain.KeyLocator,
 	}
 	return ecdsa.Sign(s.Privkey, digest), nil
 }
+
+// SignMuSig2 generates a MuSig2 partial signature given the passed key set,
+// secret nonce, public nonce, and private keys.
+func (s *SingleSigner) SignMuSig2(secNonce [musig2.SecNonceSize]byte,
+	keyLoc keychain.KeyLocator, _ [][musig2.PubNonceSize]byte,
+	combinedNonce [musig2.PubNonceSize]byte, pubKeys []*btcec.PublicKey,
+	msg [32]byte, opts ...musig2.SignOption) (*musig2.PartialSignature,
+	error) {
+
+	mockKeyLoc := s.KeyLoc
+	if s.KeyLoc.IsEmpty() {
+		mockKeyLoc = idKeyLoc
+	}
+
+	if keyLoc != mockKeyLoc {
+		return nil, fmt.Errorf("unknown public key")
+	}
+
+	return musig2.Sign(
+		secNonce, s.Privkey, combinedNonce, pubKeys, msg, opts...,
+	)
+}

--- a/lnwallet/interface.go
+++ b/lnwallet/interface.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/btcsuite/btcd/btcec/v2"
 	"github.com/btcsuite/btcd/btcec/v2/ecdsa"
+	"github.com/btcsuite/btcd/btcec/v2/schnorr/musig2"
 	"github.com/btcsuite/btcd/btcutil"
 	"github.com/btcsuite/btcd/btcutil/hdkeychain"
 	"github.com/btcsuite/btcd/btcutil/psbt"
@@ -575,6 +576,15 @@ type MessageSigner interface {
 	// the single or double SHA-256 of the passed message.
 	SignMessage(keyLoc keychain.KeyLocator, msg []byte,
 		doubleHash bool) (*ecdsa.Signature, error)
+
+	// SignMuSig2 generates a MuSig2 partial signature given the passed key
+	// set, secret nonce, public nonce, and private keys.
+	SignMuSig2(secNonce [musig2.SecNonceSize]byte,
+		keyLoc keychain.KeyLocator,
+		otherNonces [][musig2.PubNonceSize]byte,
+		combinedNonce [musig2.PubNonceSize]byte,
+		pubKeys []*btcec.PublicKey, msg [32]byte,
+		opts ...musig2.SignOption) (*musig2.PartialSignature, error)
 }
 
 // WalletDriver represents a "driver" for a particular concrete

--- a/lnwire/accept_channel.go
+++ b/lnwire/accept_channel.go
@@ -263,7 +263,7 @@ func (a *AcceptChannel) Decode(r io.Reader, pver uint32) error {
 			AcceptChanLocalNonceType,
 		)
 	)
-	typeMap, err := tlvRecords.ExtractRecords(
+	typeMap, err := tlvRecords.ExtractRecordsFromProducers(
 		&a.UpfrontShutdownScript, &chanType, &leaseExpiry, localNonce,
 	)
 	if err != nil {

--- a/lnwire/announcement_signatures_2.go
+++ b/lnwire/announcement_signatures_2.go
@@ -1,0 +1,76 @@
+package lnwire
+
+import (
+	"bytes"
+	"io"
+)
+
+// AnnouncementSignatures2 is a direct message between two endpoints of a
+// channel and serves as an opt-in mechanism to allow the announcement of
+// a taproot channel to the rest of the network. It contains the necessary
+// signatures by the sender to construct the channel_announcement_ message.
+type AnnouncementSignatures2 struct {
+	// ChannelID is the unique description of the funding transaction.
+	// Channel id is better for users and debugging and short channel id is
+	// used for quick test on existence of the particular utxo inside the
+	// blockchain, because it contains information about block.
+	ChannelID ChannelID
+
+	// ShortChannelID is the unique description of the funding transaction.
+	// It is constructed with the most significant 3 bytes as the block
+	// height, the next 3 bytes indicating the transaction index within the
+	// block, and the least significant two bytes indicating the output
+	// index which pays to the channel.
+	ShortChannelID ShortChannelID
+
+	// PartialSignature is the combination of the partial Schnorr signature
+	// created for the node's bitcoin key with the partial signature created
+	// for the node's node ID key.
+	PartialSignature PartialSig
+
+	// ExtraOpaqueData is the set of data that was appended to this
+	// message, some of which we may not actually know how to iterate or
+	// parse. By holding onto this data, we ensure that we're able to
+	// properly validate the set of signatures that cover these new fields,
+	// and ensure we're able to make upgrades to the network in a forwards
+	// compatible manner.
+	ExtraOpaqueData ExtraOpaqueData
+}
+
+// A compile time check to ensure AnnouncementSignatures2 implements the
+// lnwire.Message interface.
+var _ Message = (*AnnouncementSignatures2)(nil)
+
+// Decode deserializes a serialized AnnounceSignatures stored in the passed
+// io.Reader observing the specified protocol version.
+//
+// This is part of the lnwire.Message interface.
+func (a *AnnouncementSignatures2) Decode(r io.Reader, _ uint32) error {
+	return ReadElements(r,
+		&a.ChannelID,
+		&a.ShortChannelID,
+		&a.PartialSignature,
+		&a.ExtraOpaqueData,
+	)
+}
+
+// Encode serializes the target AnnounceSignatures into the passed io.Writer
+// observing the protocol version specified.
+//
+// This is part of the lnwire.Message interface.
+func (a *AnnouncementSignatures2) Encode(w *bytes.Buffer, _ uint32) error {
+	return WriteElements(w,
+		a.ChannelID,
+		a.ShortChannelID,
+		a.PartialSignature,
+		a.ExtraOpaqueData,
+	)
+}
+
+// MsgType returns the integer uniquely identifying this message type on the
+// wire.
+//
+// This is part of the lnwire.Message interface.
+func (a *AnnouncementSignatures2) MsgType() MessageType {
+	return MsgAnnouncementSignatures2
+}

--- a/lnwire/boolean.go
+++ b/lnwire/boolean.go
@@ -1,0 +1,53 @@
+package lnwire
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/lightningnetwork/lnd/tlv"
+)
+
+// BooleanRecordProducer wraps a boolean with the tlv type it should be encoded
+// with. A boolean is by default false, if the TLV is present then the boolean
+// is true.
+type BooleanRecordProducer struct {
+	Bool bool
+	Type tlv.Type
+}
+
+// Record returns the tlv record for the boolean entry.
+func (b *BooleanRecordProducer) Record() tlv.Record {
+	return tlv.MakeStaticRecord(
+		b.Type, &b.Bool, 0, booleanEncoder, booleanDecoder,
+	)
+}
+
+// NewBooleanRecordProducer constructs a new BooleanRecordProducer.
+func NewBooleanRecordProducer(t tlv.Type) *BooleanRecordProducer {
+	return &BooleanRecordProducer{
+		Type: t,
+	}
+}
+
+func booleanEncoder(_ io.Writer, val interface{}, _ *[8]byte) error {
+	if v, ok := val.(*bool); ok {
+		if !*v {
+			return fmt.Errorf("a boolean record should only be " +
+				"encoded if the value of the boolean is true")
+		}
+
+		return nil
+	}
+
+	return tlv.NewTypeForEncodingErr(val, "bool")
+}
+
+func booleanDecoder(_ io.Reader, val interface{}, _ *[8]byte, _ uint64) error {
+	if v, ok := val.(*bool); ok {
+		*v = true
+
+		return nil
+	}
+
+	return tlv.NewTypeForEncodingErr(val, "bool")
+}

--- a/lnwire/boolean_test.go
+++ b/lnwire/boolean_test.go
@@ -1,0 +1,40 @@
+package lnwire
+
+import (
+	"testing"
+
+	"github.com/lightningnetwork/lnd/tlv"
+	"github.com/stretchr/testify/require"
+)
+
+// TestBooleanRecord tests the encoding and decoding of a boolean tlv record.
+func TestBooleanRecord(t *testing.T) {
+	t.Parallel()
+
+	const recordType = tlv.Type(0)
+
+	b1 := BooleanRecordProducer{
+		Bool: false,
+		Type: recordType,
+	}
+
+	var extraData ExtraOpaqueData
+
+	// A false boolean should not be encoded.
+	require.ErrorContains(t, extraData.PackRecordsFromProducers(&b1),
+		"a boolean record should only be encoded if the value of "+
+			"the boolean is true")
+
+	b2 := BooleanRecordProducer{
+		Bool: true,
+		Type: recordType,
+	}
+	require.NoError(t, extraData.PackRecordsFromProducers(&b2))
+
+	b3 := NewBooleanRecordProducer(recordType)
+	tlvs, err := extraData.ExtractRecordsFromProducers(b3)
+	require.NoError(t, err)
+
+	require.Contains(t, tlvs, recordType)
+	require.Equal(t, b2.Bool, b3.Bool)
+}

--- a/lnwire/channel_announcement_2.go
+++ b/lnwire/channel_announcement_2.go
@@ -1,0 +1,268 @@
+package lnwire
+
+import (
+	"bytes"
+	"io"
+
+	"github.com/btcsuite/btcd/chaincfg"
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"github.com/lightningnetwork/lnd/tlv"
+)
+
+const (
+	// ChanAnn2ChainHashType is the tlv number associated with the chain
+	// hash TLV record in the channel_announcement_2 message.
+	ChanAnn2ChainHashType = tlv.Type(0)
+
+	// ChanAnn2FeaturesType is the tlv number associated with the features
+	// TLV record in the channel_announcement_2 message.
+	ChanAnn2FeaturesType = tlv.Type(2)
+
+	// ChanAnn2SCIDType is the tlv number associated with the SCID TLV
+	// record in the channel_announcement_2 message.
+	ChanAnn2SCIDType = tlv.Type(4)
+
+	// ChanAnn2CapacityType is the tlv number associated with the capacity
+	// TLV record in the channel_announcement_2 message.
+	ChanAnn2CapacityType = tlv.Type(6)
+
+	// ChanAnn2NodeID1Type is the tlv number associated with the node ID 1
+	// TLV record in the channel_announcement_2 message.
+	ChanAnn2NodeID1Type = tlv.Type(8)
+
+	// ChanAnn2NodeID2Type is the tlv number associated with the node ID 2
+	// record in the channel_announcement_2 message.
+	ChanAnn2NodeID2Type = tlv.Type(10)
+
+	// ChanAnn2BtcKey1Type is the tlv number associated with the bitcoin ID
+	// 1 record in the channel_announcement_2 message.
+	ChanAnn2BtcKey1Type = tlv.Type(12)
+
+	// ChanAnn2BtcKey2Type is the tlv number associated with the bitcoin ID
+	// 2 record in the channel_announcement_2 message.
+	ChanAnn2BtcKey2Type = tlv.Type(14)
+
+	// ChanAnn2MerkleRootHashType is the tlv number associated with the
+	// merkle root hash record in the channel_announcement_2 message.
+	ChanAnn2MerkleRootHashType = tlv.Type(16)
+)
+
+// ChannelAnnouncement2 message is used to announce the existence of a taproot
+// channel between two peers in the network.
+type ChannelAnnouncement2 struct {
+	// Signature is a Schnorr signature over the TLV stream of the message.
+	Signature Sig
+
+	// ChainHash denotes the target chain that this channel was opened
+	// within. This value should be the genesis hash of the target chain.
+	ChainHash chainhash.Hash
+
+	// Features is the feature vector that encodes the features supported
+	// by the target node. This field can be used to signal the type of the
+	// channel, or modifications to the fields that would normally follow
+	// this vector.
+	Features RawFeatureVector
+
+	// ShortChannelID is the unique description of the funding transaction,
+	// or where exactly it's located within the target blockchain.
+	ShortChannelID ShortChannelID
+
+	// Capacity is the number of satoshis of the capacity of this channel.
+	// It must be less than or equal to the value of the on-chain funding
+	// output.
+	Capacity uint64
+
+	// NodeID1 is the numerically-lesser public key ID of one of the channel
+	// operators.
+	NodeID1 [33]byte
+
+	// NodeID2 is the numerically-greater public key ID of one of the
+	// channel operators.
+	NodeID2 [33]byte
+
+	// BitcoinKey1 is the public key of the key used by Node1 in the
+	// construction of the on-chain funding transaction. This is an optional
+	// field and only needs to be set if the 4-of-4 MuSig construction was
+	// used in the creation of the message signature.
+	BitcoinKey1 *[33]byte
+
+	// BitcoinKey2 is the public key of the key used by Node2 in the
+	// construction of the on-chain funding transaction. This is an optional
+	// field and only needs to be set if the 4-of-4 MuSig construction was
+	// used in the creation of the message signature.
+	BitcoinKey2 *[33]byte
+
+	// MerkleRootHash is the hash used to create the optional tweak in the
+	// funding output. If this is not set but the bitcoin keys are, then
+	// the funding output is a pure 2-of-2 MuSig aggregate public key.
+	MerkleRootHash *[32]byte
+
+	// ExtraOpaqueData is the set of data that was appended to this
+	// message, some of which we may not actually know how to iterate or
+	// parse. By holding onto this data, we ensure that we're able to
+	// properly validate the set of signatures that cover these new fields,
+	// and ensure we're able to make upgrades to the network in a forwards
+	// compatible manner.
+	ExtraOpaqueData ExtraOpaqueData
+}
+
+// Decode deserializes a serialized AnnounceSignatures stored in the passed
+// io.Reader observing the specified protocol version.
+//
+// This is part of the lnwire.Message interface.
+func (c *ChannelAnnouncement2) Decode(r io.Reader, _ uint32) error {
+	err := ReadElement(r, &c.Signature)
+	if err != nil {
+		return err
+	}
+	c.Signature.ForceSchnorr()
+
+	// First extract into extra opaque data.
+	var tlvRecords ExtraOpaqueData
+	if err := ReadElements(r, &tlvRecords); err != nil {
+		return err
+	}
+
+	featuresRecordProducer := NewRawFeatureVectorRecordProducer(
+		ChanAnn2FeaturesType,
+	)
+
+	scidRecordProducer := NewShortChannelIDRecordProducer(
+		ChanAnn2SCIDType,
+	)
+
+	var (
+		chainHash, merkleRootHash [32]byte
+		btcKey1, btcKey2          [33]byte
+	)
+
+	records := []tlv.Record{
+		tlv.MakePrimitiveRecord(ChanAnn2ChainHashType, &chainHash),
+		featuresRecordProducer.Record(),
+		scidRecordProducer.Record(),
+		tlv.MakePrimitiveRecord(ChanAnn2CapacityType, &c.Capacity),
+		tlv.MakePrimitiveRecord(ChanAnn2NodeID1Type, &c.NodeID1),
+		tlv.MakePrimitiveRecord(ChanAnn2NodeID2Type, &c.NodeID2),
+		tlv.MakePrimitiveRecord(ChanAnn2BtcKey1Type, &btcKey1),
+		tlv.MakePrimitiveRecord(ChanAnn2BtcKey2Type, &btcKey2),
+		tlv.MakePrimitiveRecord(
+			ChanAnn2MerkleRootHashType, &merkleRootHash,
+		),
+	}
+
+	typeMap, err := tlvRecords.ExtractRecords(records...)
+	if err != nil {
+		return err
+	}
+
+	// By default, the chain-hash is the bitcoin mainnet genesis block hash.
+	c.ChainHash = *chaincfg.MainNetParams.GenesisHash
+	if _, ok := typeMap[ChanAnn2ChainHashType]; ok {
+		c.ChainHash = chainHash
+	}
+
+	if _, ok := typeMap[ChanAnn2FeaturesType]; ok {
+		c.Features = featuresRecordProducer.RawFeatureVector
+	}
+
+	if _, ok := typeMap[ChanAnn2SCIDType]; ok {
+		c.ShortChannelID = scidRecordProducer.ShortChannelID
+	}
+
+	if _, ok := typeMap[ChanAnn2BtcKey1Type]; ok {
+		c.BitcoinKey1 = &btcKey1
+	}
+
+	if _, ok := typeMap[ChanAnn2BtcKey2Type]; ok {
+		c.BitcoinKey2 = &btcKey2
+	}
+
+	if _, ok := typeMap[ChanAnn2MerkleRootHashType]; ok {
+		c.MerkleRootHash = &merkleRootHash
+	}
+
+	if len(tlvRecords) != 0 {
+		c.ExtraOpaqueData = tlvRecords
+	}
+
+	return nil
+}
+
+// Encode serializes the target AnnounceSignatures into the passed io.Writer
+// observing the protocol version specified.
+//
+// This is part of the lnwire.Message interface.
+func (c *ChannelAnnouncement2) Encode(w *bytes.Buffer, _ uint32) error {
+	var records []tlv.Record
+
+	_, err := w.Write(c.Signature.RawBytes())
+	if err != nil {
+		return err
+	}
+
+	// The chain-hash record is only included if it is _not_ equal to the
+	// bitcoin mainnet genisis block hash.
+	if !c.ChainHash.IsEqual(chaincfg.MainNetParams.GenesisHash) {
+		chainHash := [32]byte(c.ChainHash)
+		records = append(records, tlv.MakePrimitiveRecord(
+			ChanAnn2ChainHashType, &chainHash,
+		))
+	}
+
+	featuresRecordProducer := &RawFeatureVectorRecordProducer{
+		RawFeatureVector: c.Features,
+		Type:             ChanAnn2FeaturesType,
+	}
+
+	scidRecordProducer := &ShortChannelIDRecordProducer{
+		ShortChannelID: c.ShortChannelID,
+		Type:           ChanAnn2SCIDType,
+	}
+
+	records = append(records,
+		featuresRecordProducer.Record(),
+		scidRecordProducer.Record(),
+		tlv.MakePrimitiveRecord(ChanAnn2CapacityType, &c.Capacity),
+		tlv.MakePrimitiveRecord(ChanAnn2NodeID1Type, &c.NodeID1),
+		tlv.MakePrimitiveRecord(ChanAnn2NodeID2Type, &c.NodeID2),
+	)
+
+	if c.BitcoinKey1 != nil && c.BitcoinKey2 != nil {
+		records = append(records,
+			tlv.MakePrimitiveRecord(
+				ChanAnn2BtcKey1Type, c.BitcoinKey1,
+			),
+			tlv.MakePrimitiveRecord(
+				ChanAnn2BtcKey2Type, c.BitcoinKey2,
+			),
+		)
+
+		if c.MerkleRootHash != nil {
+			records = append(records,
+				tlv.MakePrimitiveRecord(
+					ChanAnn2MerkleRootHashType,
+					c.MerkleRootHash,
+				),
+			)
+		}
+	}
+
+	err = EncodeMessageExtraDataFromRecords(&c.ExtraOpaqueData, records...)
+	if err != nil {
+		return err
+	}
+
+	return WriteBytes(w, c.ExtraOpaqueData)
+}
+
+// MsgType returns the integer uniquely identifying this message type on the
+// wire.
+//
+// This is part of the lnwire.Message interface.
+func (c *ChannelAnnouncement2) MsgType() MessageType {
+	return MsgChannelAnnouncement2
+}
+
+// A compile time check to ensure ChannelAnnouncement2 implements the
+// lnwire.Message interface.
+var _ Message = (*ChannelAnnouncement2)(nil)

--- a/lnwire/channel_announcement_2.go
+++ b/lnwire/channel_announcement_2.go
@@ -193,15 +193,37 @@ func (c *ChannelAnnouncement2) Decode(r io.Reader, _ uint32) error {
 //
 // This is part of the lnwire.Message interface.
 func (c *ChannelAnnouncement2) Encode(w *bytes.Buffer, _ uint32) error {
-	var records []tlv.Record
-
 	_, err := w.Write(c.Signature.RawBytes())
 	if err != nil {
 		return err
 	}
 
+	_, err = c.DataToSign()
+	if err != nil {
+		return err
+	}
+
+	return WriteBytes(w, c.ExtraOpaqueData)
+}
+
+// DigestToSign computes the digest of the message to be signed.
+func (c *ChannelAnnouncement2) DigestToSign() (*chainhash.Hash, error) {
+	data, err := c.DataToSign()
+	if err != nil {
+		return nil, err
+	}
+
+	hash := MsgHash(
+		"channel_announcement_2", "announcement_signature", data,
+	)
+
+	return hash, nil
+}
+
+func (c *ChannelAnnouncement2) DataToSign() ([]byte, error) {
 	// The chain-hash record is only included if it is _not_ equal to the
 	// bitcoin mainnet genisis block hash.
+	var records []tlv.Record
 	if !c.ChainHash.IsEqual(chaincfg.MainNetParams.GenesisHash) {
 		chainHash := [32]byte(c.ChainHash)
 		records = append(records, tlv.MakePrimitiveRecord(
@@ -247,12 +269,12 @@ func (c *ChannelAnnouncement2) Encode(w *bytes.Buffer, _ uint32) error {
 		}
 	}
 
-	err = EncodeMessageExtraDataFromRecords(&c.ExtraOpaqueData, records...)
+	err := EncodeMessageExtraDataFromRecords(&c.ExtraOpaqueData, records...)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
-	return WriteBytes(w, c.ExtraOpaqueData)
+	return c.ExtraOpaqueData, nil
 }
 
 // MsgType returns the integer uniquely identifying this message type on the
@@ -266,3 +288,13 @@ func (c *ChannelAnnouncement2) MsgType() MessageType {
 // A compile time check to ensure ChannelAnnouncement2 implements the
 // lnwire.Message interface.
 var _ Message = (*ChannelAnnouncement2)(nil)
+
+const MsgHashTag = "lightning"
+
+func MsgHash(msgName, fieldName string, msg []byte) *chainhash.Hash {
+	tag := []byte(MsgHashTag)
+	tag = append(tag, []byte(msgName)...)
+	tag = append(tag, []byte(fieldName)...)
+
+	return chainhash.TaggedHash(tag, msg)
+}

--- a/lnwire/channel_ready.go
+++ b/lnwire/channel_ready.go
@@ -9,10 +9,18 @@ import (
 )
 
 const (
+	// ChanReadyAnnounceBtcNonce is the TLV type associated with the
+	// bitcoin nonce field in the channel_ready message.
+	ChanReadyAnnounceBtcNonce = tlv.Type(0)
+
 	// ChanReadyAliasScidType is the TLV type of the experimental record of
 	// channel_ready to denote the alias being used in an option_scid_alias
 	// channel.
 	ChanReadyAliasScidType = tlv.Type(1)
+
+	// ChanReadyAnnounceNodeNonce is the TLV type associated with the node
+	// nonce field in the channel_ready message.
+	ChanReadyAnnounceNodeNonce = tlv.Type(2)
 
 	// ChanReadyLocalNonceType is the tlv number associated with the local
 	// nonce TLV record in the channel_ready message.
@@ -37,6 +45,16 @@ type ChannelReady struct {
 	// channel. It can be used instead of the confirmed on-chain
 	// ShortChannelID for forwarding.
 	AliasScid *ShortChannelID
+
+	// AnnouncementBitcoinNonce is an optional field that stores a public
+	// nonce that will be used along with the node's bitcoin key during
+	// signing of the ChannelAnnouncement2 message.
+	AnnouncementBitcoinNonce *Musig2Nonce
+
+	// AnnouncementBitcoinNonce is an optional field that stores a public
+	// nonce that will be used along with the node's ID key during signing
+	// of the ChannelAnnouncement2 message.
+	AnnouncementNodeNonce *Musig2Nonce
 
 	// NextLocalNonce is an optional field that stores a local musig2 nonce.
 	// This will only be populated if the simple taproot channels type was
@@ -84,8 +102,7 @@ func (c *ChannelReady) Decode(r io.Reader, _ uint32) error {
 		return err
 	}
 
-	// Next we'll parse out the set of known records. For now, this is just
-	// the AliasScidRecordType.
+	// Next we'll parse out the set of known records.
 	var (
 		aliasScid = NewShortChannelIDRecordProducer(
 			ChanReadyAliasScidType,
@@ -93,21 +110,33 @@ func (c *ChannelReady) Decode(r io.Reader, _ uint32) error {
 		localNonce = NewMusig2NonceRecordProducer(
 			ChanReadyLocalNonceType,
 		)
+		btcNonce = NewMusig2NonceRecordProducer(
+			ChanReadyAnnounceBtcNonce,
+		)
+		nodeNonce = NewMusig2NonceRecordProducer(
+			ChanReadyAnnounceNodeNonce,
+		)
 	)
 	typeMap, err := tlvRecords.ExtractRecordsFromProducers(
-		aliasScid, localNonce,
+		btcNonce, aliasScid, nodeNonce, localNonce,
 	)
 	if err != nil {
 		return err
 	}
 
-	// We'll only set AliasScid if the corresponding TLV type was included
+	// We'll only set some fields if the corresponding TLV type was included
 	// in the stream.
 	if val, ok := typeMap[ChanReadyAliasScidType]; ok && val == nil {
 		c.AliasScid = &aliasScid.ShortChannelID
 	}
 	if val, ok := typeMap[ChanReadyLocalNonceType]; ok && val == nil {
 		c.NextLocalNonce = &localNonce.Musig2Nonce
+	}
+	if val, ok := typeMap[ChanReadyAnnounceBtcNonce]; ok && val == nil {
+		c.AnnouncementBitcoinNonce = &btcNonce.Musig2Nonce
+	}
+	if val, ok := typeMap[ChanReadyAnnounceNodeNonce]; ok && val == nil {
+		c.AnnouncementNodeNonce = &nodeNonce.Musig2Nonce
 	}
 
 	if len(tlvRecords) != 0 {
@@ -131,13 +160,30 @@ func (c *ChannelReady) Encode(w *bytes.Buffer, _ uint32) error {
 		return err
 	}
 
-	// We'll only encode the AliasScid in a TLV segment if it exists.
+	// We'll only encode the various optional fields in a TLV segment if
+	// they exists.
 	recordProducers := make([]tlv.RecordProducer, 0, 2)
+	if c.AnnouncementBitcoinNonce != nil {
+		recordProducers = append(
+			recordProducers, &Musig2NonceRecordProducer{
+				Type:        ChanReadyAnnounceBtcNonce,
+				Musig2Nonce: *c.AnnouncementBitcoinNonce,
+			},
+		)
+	}
 	if c.AliasScid != nil {
 		recordProducers = append(recordProducers,
 			&ShortChannelIDRecordProducer{
 				ShortChannelID: *c.AliasScid,
 				Type:           ChanReadyAliasScidType,
+			},
+		)
+	}
+	if c.AnnouncementNodeNonce != nil {
+		recordProducers = append(
+			recordProducers, &Musig2NonceRecordProducer{
+				Type:        ChanReadyAnnounceNodeNonce,
+				Musig2Nonce: *c.AnnouncementNodeNonce,
 			},
 		)
 	}

--- a/lnwire/channel_ready.go
+++ b/lnwire/channel_ready.go
@@ -87,7 +87,7 @@ func (c *ChannelReady) Decode(r io.Reader, _ uint32) error {
 			ChanReadyLocalNonceType,
 		)
 	)
-	typeMap, err := tlvRecords.ExtractRecords(
+	typeMap, err := tlvRecords.ExtractRecordsFromProducers(
 		&aliasScid, localNonce,
 	)
 	if err != nil {

--- a/lnwire/channel_reestablish.go
+++ b/lnwire/channel_reestablish.go
@@ -191,7 +191,7 @@ func (a *ChannelReestablish) Decode(r io.Reader, pver uint32) error {
 	}
 
 	localNonce := NewMusig2NonceRecordProducer(ChanReestLocalNonceType)
-	typeMap, err := tlvRecords.ExtractRecords(localNonce)
+	typeMap, err := tlvRecords.ExtractRecordsFromProducers(localNonce)
 	if err != nil {
 		return err
 	}

--- a/lnwire/channel_type.go
+++ b/lnwire/channel_type.go
@@ -1,8 +1,6 @@
 package lnwire
 
 import (
-	"io"
-
 	"github.com/lightningnetwork/lnd/tlv"
 )
 
@@ -15,44 +13,3 @@ const (
 // ChannelType represents a specific channel type as a set of feature bits that
 // comprise it.
 type ChannelType RawFeatureVector
-
-// featureBitLen returns the length in bytes of the encoded feature bits.
-func (c ChannelType) featureBitLen() uint64 {
-	fv := RawFeatureVector(c)
-	return uint64(fv.SerializeSize())
-}
-
-// Record returns a TLV record that can be used to encode/decode the channel
-// type from a given TLV stream.
-func (c *ChannelType) Record() tlv.Record {
-	return tlv.MakeDynamicRecord(
-		ChannelTypeRecordType, c, c.featureBitLen, channelTypeEncoder,
-		channelTypeDecoder,
-	)
-}
-
-// channelTypeEncoder is a custom TLV encoder for the ChannelType record.
-func channelTypeEncoder(w io.Writer, val interface{}, buf *[8]byte) error {
-	if v, ok := val.(*ChannelType); ok {
-		// Encode the feature bits as a byte slice without its length
-		// prepended, as that's already taken care of by the TLV record.
-		fv := RawFeatureVector(*v)
-		return fv.encode(w, fv.SerializeSize(), 8)
-	}
-
-	return tlv.NewTypeForEncodingErr(val, "lnwire.ChannelType")
-}
-
-// channelTypeDecoder is a custom TLV decoder for the ChannelType record.
-func channelTypeDecoder(r io.Reader, val interface{}, buf *[8]byte, l uint64) error {
-	if v, ok := val.(*ChannelType); ok {
-		fv := NewRawFeatureVector()
-		if err := fv.decode(r, int(l), 8); err != nil {
-			return err
-		}
-		*v = ChannelType(*fv)
-		return nil
-	}
-
-	return tlv.NewTypeForEncodingErr(val, "lnwire.ChannelType")
-}

--- a/lnwire/channel_type_test.go
+++ b/lnwire/channel_type_test.go
@@ -11,18 +11,21 @@ import (
 func TestChannelTypeEncodeDecode(t *testing.T) {
 	t.Parallel()
 
-	chanType := ChannelType(*NewRawFeatureVector(
-		StaticRemoteKeyRequired,
-		AnchorsZeroFeeHtlcTxRequired,
-	))
+	record1 := RawFeatureVectorRecordProducer{
+		RawFeatureVector: *NewRawFeatureVector(
+			StaticRemoteKeyRequired,
+			AnchorsZeroFeeHtlcTxRequired,
+		),
+		Type: ChannelTypeRecordType,
+	}
 
 	var extraData ExtraOpaqueData
-	require.NoError(t, extraData.PackRecordsFromProducers(&chanType))
+	require.NoError(t, extraData.PackRecordsFromProducers(&record1))
 
-	var chanType2 ChannelType
-	tlvs, err := extraData.ExtractRecordsFromProducers(&chanType2)
+	record2 := NewRawFeatureVectorRecordProducer(ChannelTypeRecordType)
+	tlvs, err := extraData.ExtractRecordsFromProducers(record2)
 	require.NoError(t, err)
 
 	require.Contains(t, tlvs, ChannelTypeRecordType)
-	require.Equal(t, chanType, chanType2)
+	require.Equal(t, record1.RawFeatureVector, record2.RawFeatureVector)
 }

--- a/lnwire/channel_type_test.go
+++ b/lnwire/channel_type_test.go
@@ -17,10 +17,10 @@ func TestChannelTypeEncodeDecode(t *testing.T) {
 	))
 
 	var extraData ExtraOpaqueData
-	require.NoError(t, extraData.PackRecords(&chanType))
+	require.NoError(t, extraData.PackRecordsFromProducers(&chanType))
 
 	var chanType2 ChannelType
-	tlvs, err := extraData.ExtractRecords(&chanType2)
+	tlvs, err := extraData.ExtractRecordsFromProducers(&chanType2)
 	require.NoError(t, err)
 
 	require.Contains(t, tlvs, ChannelTypeRecordType)

--- a/lnwire/channel_update_2.go
+++ b/lnwire/channel_update_2.go
@@ -1,0 +1,375 @@
+package lnwire
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+
+	"github.com/btcsuite/btcd/chaincfg"
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"github.com/lightningnetwork/lnd/tlv"
+)
+
+const (
+	// ChanUpdate2ChainHashType is the tlv number associated with the chain
+	// hash TLV record in the channel_update_2 message.
+	ChanUpdate2ChainHashType = tlv.Type(0)
+
+	// ChanUpdate2SCIDType is the tlv number associated with the SCID TLV
+	// record in the channel_update_2 message.
+	ChanUpdate2SCIDType = tlv.Type(2)
+
+	// ChanUpdate2BlockHeightType is the tlv number associated with the
+	// block height record in the channel_update_2 message.
+	ChanUpdate2BlockHeightType = tlv.Type(4)
+
+	// ChanUpdate2DisableFlagsType is the tlv number associated with the
+	// disable flags record in the channel_update_2 message.
+	ChanUpdate2DisableFlagsType = tlv.Type(6)
+
+	// ChanUpdate2DirectionType is the tlv number associated with the
+	// disable boolean TLV record in the channel_update_2 message.
+	ChanUpdate2DirectionType = tlv.Type(8)
+
+	// ChanUpdate2CLTVExpiryDeltaType is the tlv number associated with the
+	// CLTV expiry delta TLV record in the channel_update_2 message.
+	ChanUpdate2CLTVExpiryDeltaType = tlv.Type(10)
+
+	// ChanUpdate2HTLCMinMsatType is the tlv number associated with the htlc
+	// minimum msat record in the channel_update_2 message.
+	ChanUpdate2HTLCMinMsatType = tlv.Type(12)
+
+	// ChanUpdate2HTLCMaxMsatType is the tlv number associated with the htlc
+	// maximum msat record in the channel_update_2 message.
+	ChanUpdate2HTLCMaxMsatType = tlv.Type(14)
+
+	// ChanUpdate2FeeBaseMsatType is the tlv number associated with the fee
+	// base msat record in the channel_update_2 message.
+	ChanUpdate2FeeBaseMsatType = tlv.Type(16)
+
+	// ChanUpdate2FeeProportionalMillionthsType is the tlv number associated
+	// with the fee proportional millionths record in the channel_update_2
+	// message.
+	ChanUpdate2FeeProportionalMillionthsType = tlv.Type(18)
+
+	defaultCltvExpiryDelta           = uint16(80)
+	defaultHtlcMinMsat               = MilliSatoshi(1)
+	defaultFeeBaseMsat               = uint32(1000)
+	defaultFeeProportionalMillionths = uint32(1)
+)
+
+// ChannelUpdate2 message is used after taproot channel has been initially
+// announced. Each side independently announces its fees and minimum expiry for
+// HTLCs and other parameters. Also this message is used to redeclare initially
+// set channel parameters.
+type ChannelUpdate2 struct {
+	// Signature is used to validate the announced data and prove the
+	// ownership of node id.
+	Signature Sig
+
+	// ChainHash denotes the target chain that this channel was opened
+	// within. This value should be the genesis hash of the target chain.
+	// Along with the short channel ID, this uniquely identifies the
+	// channel globally in a blockchain.
+	ChainHash chainhash.Hash
+
+	// ShortChannelID is the unique description of the funding transaction.
+	ShortChannelID ShortChannelID
+
+	// BlockHeight allows ordering in the case of multiple announcements. We
+	// should ignore the message if block height is not greater than the
+	// last-received. The block height must always be greater or equal to
+	// the block height that the channel funding transaction was confirmed
+	// in.
+	BlockHeight uint32
+
+	// DisabledFlags is an optional bitfield that describes various reasons
+	// that the node is communicating that the channel should be considered
+	// disabled.
+	DisabledFlags ChanUpdateDisableFlags
+
+	// Direction is false if this update was produced by node 1 of the
+	// channel announcement and true if it is from node 2.
+	Direction bool
+
+	// CLTVExpiryDelta is the minimum number of blocks this node requires to
+	// be added to the expiry of HTLCs. This is a security parameter
+	// determined by the node operator. This value represents the required
+	// gap between the time locks of the incoming and outgoing HTLC's set
+	// to this node.
+	CLTVExpiryDelta uint16
+
+	// HTLCMinimumMsat is the minimum HTLC value which will be accepted.
+	HTLCMinimumMsat MilliSatoshi
+
+	// HtlcMaximumMsat is the maximum HTLC value which will be accepted.
+	HTLCMaximumMsat MilliSatoshi
+
+	// FeeBaseMsat is the base fee that must be used for incoming HTLC's to
+	// this particular channel. This value will be tacked onto the required
+	// for a payment independent of the size of the payment.
+	FeeBaseMsat uint32
+
+	// FeeProportionalMillionths is the fee rate that will be charged per
+	// millionth of a satoshi.
+	FeeProportionalMillionths uint32
+
+	// ExtraOpaqueData is the set of data that was appended to this message
+	// to fill out the full maximum transport message size. These fields can
+	// be used to specify optional data such as custom TLV fields.
+	ExtraOpaqueData ExtraOpaqueData
+}
+
+// Decode deserializes a serialized AnnounceSignatures stored in the passed
+// io.Reader observing the specified protocol version.
+//
+// This is part of the lnwire.Message interface.
+func (c *ChannelUpdate2) Decode(r io.Reader, _ uint32) error {
+	err := ReadElement(r, &c.Signature)
+	if err != nil {
+		return err
+	}
+	c.Signature.ForceSchnorr()
+
+	// First extract into extra opaque data.
+	var tlvRecords ExtraOpaqueData
+	if err := ReadElements(r, &tlvRecords); err != nil {
+		return err
+	}
+
+	scidRecordProducer := NewShortChannelIDRecordProducer(
+		ChanUpdate2SCIDType,
+	)
+
+	directionRecordProducer := NewBooleanRecordProducer(
+		ChanUpdate2DirectionType,
+	)
+
+	var (
+		chainHash        [32]byte
+		htlcMin, htlcMax uint64
+		disableFlags     uint8
+	)
+
+	records := []tlv.Record{
+		tlv.MakePrimitiveRecord(ChanUpdate2ChainHashType, &chainHash),
+		scidRecordProducer.Record(),
+		tlv.MakePrimitiveRecord(
+			ChanUpdate2BlockHeightType, &c.BlockHeight,
+		),
+		tlv.MakePrimitiveRecord(
+			ChanUpdate2DisableFlagsType, &disableFlags,
+		),
+		directionRecordProducer.Record(),
+		tlv.MakePrimitiveRecord(
+			ChanUpdate2CLTVExpiryDeltaType, &c.CLTVExpiryDelta,
+		),
+		tlv.MakePrimitiveRecord(
+			ChanUpdate2HTLCMinMsatType, &htlcMin,
+		),
+		tlv.MakePrimitiveRecord(
+			ChanUpdate2HTLCMaxMsatType, &htlcMax,
+		),
+		tlv.MakePrimitiveRecord(
+			ChanUpdate2FeeBaseMsatType, &c.FeeBaseMsat,
+		),
+		tlv.MakePrimitiveRecord(
+			ChanUpdate2FeeProportionalMillionthsType,
+			&c.FeeProportionalMillionths,
+		),
+	}
+
+	typeMap, err := tlvRecords.ExtractRecords(records...)
+	if err != nil {
+		return err
+	}
+
+	// By default, the chain-hash is the bitcoin mainnet genesis block hash.
+	c.ChainHash = *chaincfg.MainNetParams.GenesisHash
+	if _, ok := typeMap[ChanUpdate2ChainHashType]; ok {
+		c.ChainHash = chainHash
+	}
+
+	if _, ok := typeMap[ChanUpdate2DisableFlagsType]; ok {
+		c.DisabledFlags = ChanUpdateDisableFlags(disableFlags)
+	}
+
+	if _, ok := typeMap[ChanUpdate2SCIDType]; ok {
+		c.ShortChannelID = scidRecordProducer.ShortChannelID
+	}
+
+	if _, ok := typeMap[ChanUpdate2DirectionType]; ok {
+		c.Direction = directionRecordProducer.Bool
+	}
+
+	// If the CLTV expiry delta was not encoded, then set it to the default
+	// value.
+	if _, ok := typeMap[ChanUpdate2CLTVExpiryDeltaType]; !ok {
+		c.CLTVExpiryDelta = defaultCltvExpiryDelta
+	}
+
+	c.HTLCMinimumMsat = defaultHtlcMinMsat
+	if _, ok := typeMap[ChanUpdate2HTLCMinMsatType]; ok {
+		c.HTLCMinimumMsat = MilliSatoshi(htlcMin)
+	}
+
+	if _, ok := typeMap[ChanUpdate2HTLCMaxMsatType]; ok {
+		c.HTLCMaximumMsat = MilliSatoshi(htlcMax)
+	}
+
+	// If the base fee was not encoded, then set it to the default value.
+	if _, ok := typeMap[ChanUpdate2FeeBaseMsatType]; !ok {
+		c.FeeBaseMsat = defaultFeeBaseMsat
+	}
+
+	// If the proportional fee was not encoded, then set it to the default
+	// value.
+	if _, ok := typeMap[ChanUpdate2FeeProportionalMillionthsType]; !ok {
+		c.FeeProportionalMillionths = defaultFeeProportionalMillionths
+	}
+
+	if len(tlvRecords) != 0 {
+		c.ExtraOpaqueData = tlvRecords
+	}
+
+	return nil
+}
+
+// Encode serializes the target AnnounceSignatures into the passed io.Writer
+// observing the protocol version specified.
+//
+// This is part of the lnwire.Message interface.
+func (c *ChannelUpdate2) Encode(w *bytes.Buffer, _ uint32) error {
+	_, err := w.Write(c.Signature.RawBytes())
+	if err != nil {
+		return err
+	}
+
+	var records []tlv.Record
+
+	// The chain-hash record is only included if it is _not_ equal to the
+	// bitcoin mainnet genisis block hash.
+	if !c.ChainHash.IsEqual(chaincfg.MainNetParams.GenesisHash) {
+		chainHash := [32]byte(c.ChainHash)
+		records = append(records, tlv.MakePrimitiveRecord(
+			ChanUpdate2ChainHashType, &chainHash,
+		))
+	}
+
+	scidRecordProducer := &ShortChannelIDRecordProducer{
+		ShortChannelID: c.ShortChannelID,
+		Type:           ChanUpdate2SCIDType,
+	}
+
+	records = append(records,
+		scidRecordProducer.Record(),
+		tlv.MakePrimitiveRecord(
+			ChanUpdate2BlockHeightType, &c.BlockHeight,
+		),
+	)
+
+	// Only include the disable flags if any bit is set.
+	if !c.DisabledFlags.IsEnabled() {
+		disableFlags := uint8(c.DisabledFlags)
+		records = append(records, tlv.MakePrimitiveRecord(
+			ChanUpdate2DisableFlagsType, &disableFlags,
+		))
+	}
+
+	// We only need to encode the direction if the direction is set to 1.
+	if c.Direction {
+		directionRecordProducer := &BooleanRecordProducer{
+			Bool: true,
+			Type: ChanUpdate2DirectionType,
+		}
+		records = append(records, directionRecordProducer.Record())
+	}
+
+	// We only encode the cltv expiry delta if it is not equal to the
+	// default.
+	if c.CLTVExpiryDelta != defaultCltvExpiryDelta {
+		records = append(records, tlv.MakePrimitiveRecord(
+			ChanUpdate2CLTVExpiryDeltaType, &c.CLTVExpiryDelta,
+		))
+	}
+
+	if c.HTLCMinimumMsat != defaultHtlcMinMsat {
+		var htlcMin = uint64(c.HTLCMinimumMsat)
+		records = append(records, tlv.MakePrimitiveRecord(
+			ChanUpdate2HTLCMinMsatType, &htlcMin,
+		))
+	}
+
+	var htlcMax = uint64(c.HTLCMaximumMsat)
+	records = append(records, tlv.MakePrimitiveRecord(
+		ChanUpdate2HTLCMaxMsatType, &htlcMax,
+	))
+
+	if c.FeeBaseMsat != defaultFeeBaseMsat {
+		records = append(records, tlv.MakePrimitiveRecord(
+			ChanUpdate2FeeBaseMsatType, &c.FeeBaseMsat,
+		))
+	}
+
+	if c.FeeProportionalMillionths != defaultFeeProportionalMillionths {
+		records = append(records, tlv.MakePrimitiveRecord(
+			ChanUpdate2FeeProportionalMillionthsType,
+			&c.FeeProportionalMillionths,
+		))
+	}
+
+	err = EncodeMessageExtraDataFromRecords(&c.ExtraOpaqueData, records...)
+	if err != nil {
+		return err
+	}
+
+	return WriteBytes(w, c.ExtraOpaqueData)
+}
+
+// MsgType returns the integer uniquely identifying this message type on the
+// wire.
+//
+// This is part of the lnwire.Message interface.
+func (c *ChannelUpdate2) MsgType() MessageType {
+	return MsgChannelUpdate2
+}
+
+// A compile time check to ensure ChannelUpdate2 implements the lnwire.Message
+// interface.
+var _ Message = (*ChannelUpdate2)(nil)
+
+// ChanUpdateDisableFlags is a bit vector that can be used to indicate various
+// reasons for the channel being marked as disabled.
+type ChanUpdateDisableFlags uint8
+
+const (
+	// ChanUpdateDisableIncoming is a bit indicates that a channel is
+	// disabled in the inbound direction meaning that the node broadcasting
+	// the update is communicating that they cannot receive funds.
+	ChanUpdateDisableIncoming ChanUpdateDisableFlags = 1 << iota
+
+	// ChanUpdateDisableOutgoing is a bit indicates that a channel is
+	// disabled in the outbound direction meaning that the node broadcasting
+	// the update is communicating that they cannot send or route funds.
+	ChanUpdateDisableOutgoing = 2
+)
+
+// IncomingDisabled returns true if the ChanUpdateDisableIncoming bit is set.
+func (c ChanUpdateDisableFlags) IncomingDisabled() bool {
+	return c&ChanUpdateDisableIncoming == ChanUpdateDisableIncoming
+}
+
+// OutgoingDisabled returns true if the ChanUpdateDisableOutgoing bit is set.
+func (c ChanUpdateDisableFlags) OutgoingDisabled() bool {
+	return c&ChanUpdateDisableOutgoing == ChanUpdateDisableOutgoing
+}
+
+// IsEnabled returns true if none of the disable bits are set.
+func (c ChanUpdateDisableFlags) IsEnabled() bool {
+	return c == 0
+}
+
+// String returns the bitfield flags as a string.
+func (c ChanUpdateDisableFlags) String() string {
+	return fmt.Sprintf("%08b", c)
+}

--- a/lnwire/closing_signed.go
+++ b/lnwire/closing_signed.go
@@ -79,7 +79,7 @@ func (c *ClosingSigned) Decode(r io.Reader, pver uint32) error {
 	var (
 		partialSig PartialSig
 	)
-	typeMap, err := tlvRecords.ExtractRecords(&partialSig)
+	typeMap, err := tlvRecords.ExtractRecordsFromProducers(&partialSig)
 	if err != nil {
 		return err
 	}

--- a/lnwire/commit_sig.go
+++ b/lnwire/commit_sig.go
@@ -84,7 +84,7 @@ func (c *CommitSig) Decode(r io.Reader, pver uint32) error {
 	var (
 		partialSig PartialSigWithNonce
 	)
-	typeMap, err := tlvRecords.ExtractRecords(&partialSig)
+	typeMap, err := tlvRecords.ExtractRecordsFromProducers(&partialSig)
 	if err != nil {
 		return err
 	}

--- a/lnwire/extra_bytes.go
+++ b/lnwire/extra_bytes.go
@@ -139,3 +139,19 @@ func EncodeMessageExtraData(extraData *ExtraOpaqueData,
 	// are all properly sorted.
 	return extraData.PackRecordsFromProducers(recordProducers...)
 }
+
+// EncodeMessageExtraDataFromRecords encodes the given records into the given
+// extraData.
+func EncodeMessageExtraDataFromRecords(extraData *ExtraOpaqueData,
+	records ...tlv.Record) error {
+
+	// Treat extraData as a mutable reference.
+	if extraData == nil {
+		return fmt.Errorf("extra data cannot be nil")
+	}
+
+	// Pack in the series of TLV records into this message. The order we
+	// pass them in doesn't matter, as the method will ensure that things
+	// are all properly sorted.
+	return extraData.PackRecords(records...)
+}

--- a/lnwire/extra_bytes_test.go
+++ b/lnwire/extra_bytes_test.go
@@ -118,9 +118,8 @@ func TestExtraOpaqueDataPackUnpackRecords(t *testing.T) {
 	// Now that we have our set of sample records and types, we'll encode
 	// them into the passed ExtraOpaqueData instance.
 	var extraBytes ExtraOpaqueData
-	if err := extraBytes.PackRecords(testRecordsProducers...); err != nil {
-		t.Fatalf("unable to pack records: %v", err)
-	}
+	err := extraBytes.PackRecordsFromProducers(testRecordsProducers...)
+	require.NoError(t, err)
 
 	// We'll now simulate decoding these types _back_ into records on the
 	// other side.
@@ -128,7 +127,7 @@ func TestExtraOpaqueDataPackUnpackRecords(t *testing.T) {
 		&recordProducer{tlv.MakePrimitiveRecord(type1, &channelType2)},
 		&recordProducer{tlv.MakePrimitiveRecord(type2, &hop2)},
 	}
-	typeMap, err := extraBytes.ExtractRecords(newRecords...)
+	typeMap, err := extraBytes.ExtractRecordsFromProducers(newRecords...)
 	require.NoError(t, err, "unable to extract record")
 
 	// We should find that the new backing values have been populated with

--- a/lnwire/features.go
+++ b/lnwire/features.go
@@ -5,6 +5,8 @@ import (
 	"errors"
 	"fmt"
 	"io"
+
+	"github.com/lightningnetwork/lnd/tlv"
 )
 
 var (
@@ -372,7 +374,7 @@ func (fv RawFeatureVector) Equals(other *RawFeatureVector) bool {
 	return true
 }
 
-// Merges sets all feature bits in other on the receiver's feature vector.
+// Merge sets all feature bits in other on the receiver's feature vector.
 func (fv *RawFeatureVector) Merge(other *RawFeatureVector) error {
 	for bit := range other.features {
 		err := fv.SafeSet(bit)
@@ -720,4 +722,67 @@ func (fv *FeatureVector) Features() map[FeatureBit]struct{} {
 func (fv *FeatureVector) Clone() *FeatureVector {
 	features := fv.RawFeatureVector.Clone()
 	return NewFeatureVector(features, fv.featureNames)
+}
+
+// featureBitLen returns the length in bytes of the encoded feature bits.
+func (fv *RawFeatureVector) featureBitLen() uint64 {
+	return uint64(fv.SerializeSize())
+}
+
+// RawFeatureVectorRecordProducer wraps a RawFeatureVector with the TLV type
+// that it should be encoded with.
+type RawFeatureVectorRecordProducer struct {
+	RawFeatureVector
+
+	Type tlv.Type
+}
+
+// NewRawFeatureVectorRecord constructs a new RawFeatureVectorRecordProducer
+// with the given TLV type.
+func NewRawFeatureVectorRecord(
+	tlvType tlv.Type) *RawFeatureVectorRecordProducer {
+
+	return &RawFeatureVectorRecordProducer{
+		Type: tlvType,
+	}
+}
+
+// Record returns a TLV record that can be used to encode/decode the channel
+// type from a given TLV stream.
+func (r *RawFeatureVectorRecordProducer) Record() tlv.Record {
+	return tlv.MakeDynamicRecord(
+		r.Type, &r.RawFeatureVector, r.featureBitLen,
+		rawFeatureVectorEncoder, rawFeatureVectorDecoder,
+	)
+}
+
+// rawFeatureVectorEncoder is a custom TLV encoder for a RawFeatureVector
+// record.
+func rawFeatureVectorEncoder(w io.Writer, val interface{}, _ *[8]byte) error {
+	if v, ok := val.(*RawFeatureVector); ok {
+		// Encode the feature bits as a byte slice without its length
+		// prepended, as that's already taken care of by the TLV record.
+		fv := *v
+		return fv.encode(w, fv.SerializeSize(), 8)
+	}
+
+	return tlv.NewTypeForEncodingErr(val, "lnwire.RawFeatureVector")
+}
+
+// rawFeatureVectorDecoder is a custom TLV decoder for a RawFeatureVector
+// record.
+func rawFeatureVectorDecoder(r io.Reader, val interface{}, _ *[8]byte,
+	l uint64) error {
+
+	if v, ok := val.(*RawFeatureVector); ok {
+		fv := NewRawFeatureVector()
+		if err := fv.decode(r, int(l), 8); err != nil {
+			return err
+		}
+		*v = *fv
+
+		return nil
+	}
+
+	return tlv.NewTypeForEncodingErr(val, "lnwire.RawFeatureVector")
 }

--- a/lnwire/features.go
+++ b/lnwire/features.go
@@ -257,6 +257,12 @@ const (
 	// finalized.
 	SimpleTaprootChannelsOptionalStaging = 181
 
+	TaprootGossipRequiredFinal = 32
+	TaprootGossipOptionalFinal = 33
+
+	TaprootGossipRequiredStaging = 132
+	TaprootGossipOptionalStaging = 133
+
 	// MaxBolt11Feature is the maximum feature bit value allowed in bolt 11
 	// invoices.
 	//
@@ -321,6 +327,10 @@ var Features = map[FeatureBit]string{
 	SimpleTaprootChannelsOptionalFinal:   "simple-taproot-chans",
 	SimpleTaprootChannelsRequiredStaging: "simple-taproot-chans-x",
 	SimpleTaprootChannelsOptionalStaging: "simple-taproot-chans-x",
+	TaprootGossipRequiredFinal:           "taproot-gossip",
+	TaprootGossipOptionalFinal:           "taproot-gossip",
+	TaprootGossipRequiredStaging:         "taproot-gossip-x",
+	TaprootGossipOptionalStaging:         "taproot-gossip-x",
 }
 
 // RawFeatureVector represents a set of feature bits as defined in BOLT-09.  A

--- a/lnwire/features.go
+++ b/lnwire/features.go
@@ -737,9 +737,9 @@ type RawFeatureVectorRecordProducer struct {
 	Type tlv.Type
 }
 
-// NewRawFeatureVectorRecord constructs a new RawFeatureVectorRecordProducer
-// with the given TLV type.
-func NewRawFeatureVectorRecord(
+// NewRawFeatureVectorRecordProducer constructs a new
+// RawFeatureVectorRecordProducer with the given TLV type.
+func NewRawFeatureVectorRecordProducer(
 	tlvType tlv.Type) *RawFeatureVectorRecordProducer {
 
 	return &RawFeatureVectorRecordProducer{

--- a/lnwire/funding_created.go
+++ b/lnwire/funding_created.go
@@ -95,7 +95,7 @@ func (f *FundingCreated) Decode(r io.Reader, pver uint32) error {
 	var (
 		partialSig PartialSigWithNonce
 	)
-	typeMap, err := tlvRecords.ExtractRecords(&partialSig)
+	typeMap, err := tlvRecords.ExtractRecordsFromProducers(&partialSig)
 	if err != nil {
 		return err
 	}

--- a/lnwire/funding_signed.go
+++ b/lnwire/funding_signed.go
@@ -81,7 +81,7 @@ func (f *FundingSigned) Decode(r io.Reader, pver uint32) error {
 	var (
 		partialSig PartialSigWithNonce
 	)
-	typeMap, err := tlvRecords.ExtractRecords(&partialSig)
+	typeMap, err := tlvRecords.ExtractRecordsFromProducers(&partialSig)
 	if err != nil {
 		return err
 	}

--- a/lnwire/lnwire.go
+++ b/lnwire/lnwire.go
@@ -457,6 +457,12 @@ func WriteElement(w *bytes.Buffer, element interface{}) error {
 			return err
 		}
 
+	case PartialSig:
+		sigBytes := e.Sig.Bytes()
+		if _, err := w.Write(sigBytes[:]); err != nil {
+			return err
+		}
+
 	case ExtraOpaqueData:
 		return e.Encode(w)
 
@@ -927,6 +933,19 @@ func ReadElement(r io.Reader, element interface{}) error {
 			return err
 		}
 		*e = addrBytes[:length]
+
+	case *PartialSig:
+		var sBytes [32]byte
+		if _, err := io.ReadFull(r, sBytes[:]); err != nil {
+			return err
+		}
+
+		var s btcec.ModNScalar
+		s.SetBytes(&sBytes)
+
+		*e = PartialSig{
+			Sig: s,
+		}
 
 	case *ExtraOpaqueData:
 		return e.Decode(r)

--- a/lnwire/lnwire_test.go
+++ b/lnwire/lnwire_test.go
@@ -1068,6 +1068,35 @@ func TestLightningWireProtocol(t *testing.T) {
 
 			v[0] = reflect.ValueOf(req)
 		},
+		MsgAnnouncementSignatures2: func(v []reflect.Value,
+			r *rand.Rand) {
+
+			req := AnnouncementSignatures2{
+				ShortChannelID: NewShortChanIDFromInt(
+					uint64(r.Int63()),
+				),
+				ExtraOpaqueData: make([]byte, 0),
+			}
+
+			_, err := r.Read(req.ChannelID[:])
+			require.NoError(t, err)
+
+			partialSig, err := randPartialSig(r)
+			require.NoError(t, err)
+
+			req.PartialSignature = *partialSig
+
+			numExtraBytes := r.Int31n(1000)
+			if numExtraBytes > 0 {
+				req.ExtraOpaqueData = make(
+					[]byte, numExtraBytes,
+				)
+				_, err := r.Read(req.ExtraOpaqueData[:])
+				require.NoError(t, err)
+			}
+
+			v[0] = reflect.ValueOf(req)
+		},
 	}
 
 	// With the above types defined, we'll now generate a slice of
@@ -1251,6 +1280,12 @@ func TestLightningWireProtocol(t *testing.T) {
 		{
 			msgType: MsgReplyChannelRange,
 			scenario: func(m ReplyChannelRange) bool {
+				return mainScenario(&m)
+			},
+		},
+		{
+			msgType: MsgAnnouncementSignatures2,
+			scenario: func(m AnnouncementSignatures2) bool {
 				return mainScenario(&m)
 			},
 		},

--- a/lnwire/lnwire_test.go
+++ b/lnwire/lnwire_test.go
@@ -1137,6 +1137,74 @@ func TestLightningWireProtocol(t *testing.T) {
 
 			v[0] = reflect.ValueOf(req)
 		},
+		MsgChannelUpdate2: func(v []reflect.Value, r *rand.Rand) {
+			req := ChannelUpdate2{
+				Signature: testSchnorrSig,
+				ShortChannelID: NewShortChanIDFromInt(
+					uint64(r.Int63()),
+				),
+				BlockHeight:     r.Uint32(),
+				HTLCMaximumMsat: MilliSatoshi(r.Uint64()),
+				ExtraOpaqueData: make([]byte, 0),
+			}
+
+			// Sometimes set chain hash to bitcoin mainnet genesis
+			// hash.
+			req.ChainHash = *chaincfg.MainNetParams.GenesisHash
+			if r.Int31()%2 == 0 {
+				_, err := r.Read(req.ChainHash[:])
+				require.NoError(t, err)
+			}
+
+			// Sometimes use default htlc min msat.
+			req.HTLCMinimumMsat = defaultHtlcMinMsat
+			if r.Int31()%2 == 0 {
+				req.HTLCMinimumMsat = MilliSatoshi(r.Uint64())
+			}
+
+			// Sometimes set the cltv expiry delta to the default.
+			req.CLTVExpiryDelta = defaultCltvExpiryDelta
+			if r.Int31()%2 == 0 {
+				req.CLTVExpiryDelta = uint16(r.Int31())
+			}
+
+			// Sometimes use default fee base.
+			req.FeeBaseMsat = defaultFeeBaseMsat
+			if r.Int31()%2 == 0 {
+				req.FeeBaseMsat = r.Uint32()
+			}
+
+			// Sometimes use default proportional fee.
+			req.FeeProportionalMillionths =
+				defaultFeeProportionalMillionths
+			if r.Int31()%2 == 0 {
+				req.FeeProportionalMillionths = r.Uint32()
+			}
+
+			// Alternate between the two direction possibilities.
+			if r.Int31()%2 == 0 {
+				req.Direction = true
+			}
+
+			// Sometimes set the incoming disabled flag.
+			if r.Int31()%2 == 0 {
+				req.DisabledFlags |= ChanUpdateDisableIncoming
+			}
+
+			// Sometimes set the outgoing disabled flag.
+			if r.Int31()%2 == 0 {
+				req.DisabledFlags |= ChanUpdateDisableOutgoing
+			}
+
+			numExtraBytes := r.Int31n(1000)
+			if numExtraBytes > 0 {
+				req.ExtraOpaqueData = make(
+					[]byte, numExtraBytes,
+				)
+				_, err := r.Read(req.ExtraOpaqueData[:])
+				require.NoError(t, err)
+			}
+		},
 	}
 
 	// With the above types defined, we'll now generate a slice of

--- a/lnwire/lnwire_test.go
+++ b/lnwire/lnwire_test.go
@@ -630,23 +630,21 @@ func TestLightningWireProtocol(t *testing.T) {
 		},
 		MsgChannelReady: func(v []reflect.Value, r *rand.Rand) {
 			var c [32]byte
-			if _, err := r.Read(c[:]); err != nil {
-				t.Fatalf("unable to generate chan id: %v", err)
-				return
-			}
+			_, err := r.Read(c[:])
+			require.NoError(t, err)
 
 			pubKey, err := randPubKey()
-			if err != nil {
-				t.Fatalf("unable to generate key: %v", err)
-				return
-			}
+			require.NoError(t, err)
 
-			req := NewChannelReady(ChannelID(c), pubKey)
+			req := NewChannelReady(c, pubKey)
 
 			if r.Int31()%2 == 0 {
-				scid := NewShortChanIDFromInt(uint64(r.Int63()))
-				req.AliasScid = &scid
 				req.NextLocalNonce = randLocalNonce(r)
+			}
+
+			if r.Int31()%2 == 0 {
+				req.AnnouncementBitcoinNonce = randLocalNonce(r)
+				req.AnnouncementNodeNonce = randLocalNonce(r)
 			}
 
 			v[0] = reflect.ValueOf(*req)

--- a/lnwire/lnwire_test.go
+++ b/lnwire/lnwire_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/btcsuite/btcd/btcec/v2"
 	"github.com/btcsuite/btcd/btcec/v2/ecdsa"
 	"github.com/btcsuite/btcd/btcutil"
+	"github.com/btcsuite/btcd/chaincfg"
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcd/wire"
 	"github.com/lightningnetwork/lnd/tor"
@@ -26,17 +27,25 @@ import (
 )
 
 var (
-	shaHash1Bytes, _ = hex.DecodeString("e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855")
-	shaHash1, _      = chainhash.NewHash(shaHash1Bytes)
-	outpoint1        = wire.NewOutPoint(shaHash1, 0)
+	shaHash1Bytes, _ = hex.DecodeString("e3b0c44298fc1c149afbf4c8996fb" +
+		"92427ae41e4649b934ca495991b7852b855")
 
-	testRBytes, _ = hex.DecodeString("8ce2bc69281ce27da07e6683571319d18e949ddfa2965fb6caa1bf0314f882d7")
-	testSBytes, _ = hex.DecodeString("299105481d63e0f4bc2a88121167221b6700d72a0ead154c03be696a292d24ae")
-	testRScalar   = new(btcec.ModNScalar)
-	testSScalar   = new(btcec.ModNScalar)
-	_             = testRScalar.SetByteSlice(testRBytes)
-	_             = testSScalar.SetByteSlice(testSBytes)
-	testSig       = ecdsa.NewSignature(testRScalar, testSScalar)
+	shaHash1, _ = chainhash.NewHash(shaHash1Bytes)
+	outpoint1   = wire.NewOutPoint(shaHash1, 0)
+
+	testRBytes, _ = hex.DecodeString("8ce2bc69281ce27da07e6683571" +
+		"319d18e949ddfa2965fb6caa1bf0314f882d7")
+	testSBytes, _ = hex.DecodeString("299105481d63e0f4bc2a" +
+		"88121167221b6700d72a0ead154c03be696a292d24ae")
+	testRScalar          = new(btcec.ModNScalar)
+	testSScalar          = new(btcec.ModNScalar)
+	_                    = testRScalar.SetByteSlice(testRBytes)
+	_                    = testSScalar.SetByteSlice(testSBytes)
+	testSig              = ecdsa.NewSignature(testRScalar, testSScalar)
+	testSchnorrSigStr, _ = hex.DecodeString("04E7F9037658A92AFEB4F2" +
+		"5BAE5339E3DDCA81A353493827D26F16D92308E49E2A25E9220867" +
+		"8A2DF86970DA91B03A8AF8815A8A60498B358DAF560B347AA557")
+	testSchnorrSig, _ = NewSigFromSchnorrRawSignature(testSchnorrSigStr)
 )
 
 const letterBytes = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
@@ -95,17 +104,15 @@ func randPubKey() (*btcec.PublicKey, error) {
 	return priv.PubKey(), nil
 }
 
-func randRawKey() ([33]byte, error) {
+func randRawKey(t *testing.T) [33]byte {
 	var n [33]byte
 
 	priv, err := btcec.NewPrivateKey()
-	if err != nil {
-		return n, err
-	}
+	require.NoError(t, err)
 
 	copy(n[:], priv.PubKey().SerializeCompressed())
 
-	return n, nil
+	return n
 }
 
 func randDeliveryAddress(r *rand.Rand) (DeliveryAddress, error) {
@@ -774,7 +781,13 @@ func TestLightningWireProtocol(t *testing.T) {
 		MsgChannelAnnouncement: func(v []reflect.Value, r *rand.Rand) {
 			var err error
 			req := ChannelAnnouncement{
-				ShortChannelID:  NewShortChanIDFromInt(uint64(r.Int63())),
+				ShortChannelID: NewShortChanIDFromInt(
+					uint64(r.Int63()),
+				),
+				NodeID1:         randRawKey(t),
+				NodeID2:         randRawKey(t),
+				BitcoinKey1:     randRawKey(t),
+				BitcoinKey2:     randRawKey(t),
 				Features:        randRawFeatureVector(r),
 				ExtraOpaqueData: make([]byte, 0),
 			}
@@ -799,26 +812,6 @@ func TestLightningWireProtocol(t *testing.T) {
 				return
 			}
 
-			req.NodeID1, err = randRawKey()
-			if err != nil {
-				t.Fatalf("unable to generate key: %v", err)
-				return
-			}
-			req.NodeID2, err = randRawKey()
-			if err != nil {
-				t.Fatalf("unable to generate key: %v", err)
-				return
-			}
-			req.BitcoinKey1, err = randRawKey()
-			if err != nil {
-				t.Fatalf("unable to generate key: %v", err)
-				return
-			}
-			req.BitcoinKey2, err = randRawKey()
-			if err != nil {
-				t.Fatalf("unable to generate key: %v", err)
-				return
-			}
 			if _, err := r.Read(req.ChainHash[:]); err != nil {
 				t.Fatalf("unable to generate chain hash: %v", err)
 				return
@@ -840,6 +833,7 @@ func TestLightningWireProtocol(t *testing.T) {
 		MsgNodeAnnouncement: func(v []reflect.Value, r *rand.Rand) {
 			var err error
 			req := NodeAnnouncement{
+				NodeID:    randRawKey(t),
 				Features:  randRawFeatureVector(r),
 				Timestamp: uint32(r.Int31()),
 				Alias:     randAlias(r),
@@ -853,12 +847,6 @@ func TestLightningWireProtocol(t *testing.T) {
 			req.Signature, err = NewSigFromSignature(testSig)
 			if err != nil {
 				t.Fatalf("unable to parse sig: %v", err)
-				return
-			}
-
-			req.NodeID, err = randRawKey()
-			if err != nil {
-				t.Fatalf("unable to generate key: %v", err)
 				return
 			}
 
@@ -1097,6 +1085,58 @@ func TestLightningWireProtocol(t *testing.T) {
 
 			v[0] = reflect.ValueOf(req)
 		},
+		MsgChannelAnnouncement2: func(v []reflect.Value, r *rand.Rand) {
+			req := ChannelAnnouncement2{
+				Signature: testSchnorrSig,
+				ShortChannelID: NewShortChanIDFromInt(
+					uint64(r.Int63()),
+				),
+				Capacity:        rand.Uint64(),
+				NodeID1:         randRawKey(t),
+				NodeID2:         randRawKey(t),
+				ExtraOpaqueData: make([]byte, 0),
+			}
+
+			features := randRawFeatureVector(r)
+			req.Features = *features
+
+			// Sometimes set chain hash to bitcoin mainnet genesis
+			// hash.
+			req.ChainHash = *chaincfg.MainNetParams.GenesisHash
+			if r.Int31()%2 == 0 {
+				_, err := r.Read(req.ChainHash[:])
+				require.NoError(t, err)
+			}
+
+			// Sometimes set the bitcoin keys.
+			if r.Int31()%2 == 0 {
+				btcKey1 := randRawKey(t)
+				req.BitcoinKey1 = &btcKey1
+
+				btcKey2 := randRawKey(t)
+				req.BitcoinKey2 = &btcKey2
+
+				// Occasionally also set the merkle root hash.
+				if r.Int31()%2 == 0 {
+					var merkleRootHash [32]byte
+					_, err := r.Read(merkleRootHash[:])
+					require.NoError(t, err)
+
+					req.MerkleRootHash = &merkleRootHash
+				}
+			}
+
+			numExtraBytes := r.Int31n(1000)
+			if numExtraBytes > 0 {
+				req.ExtraOpaqueData = make(
+					[]byte, numExtraBytes,
+				)
+				_, err := r.Read(req.ExtraOpaqueData[:])
+				require.NoError(t, err)
+			}
+
+			v[0] = reflect.ValueOf(req)
+		},
 	}
 
 	// With the above types defined, we'll now generate a slice of
@@ -1286,6 +1326,12 @@ func TestLightningWireProtocol(t *testing.T) {
 		{
 			msgType: MsgAnnouncementSignatures2,
 			scenario: func(m AnnouncementSignatures2) bool {
+				return mainScenario(&m)
+			},
+		},
+		{
+			msgType: MsgChannelAnnouncement2,
+			scenario: func(m ChannelAnnouncement2) bool {
 				return mainScenario(&m)
 			},
 		},

--- a/lnwire/message.go
+++ b/lnwire/message.go
@@ -53,6 +53,7 @@ const (
 	MsgReplyChannelRange                   = 264
 	MsgGossipTimestampRange                = 265
 	MsgChannelAnnouncement2                = 267
+	MsgNodeAnnouncement2                   = 269
 	MsgChannelUpdate2                      = 271
 )
 
@@ -143,6 +144,8 @@ func (t MessageType) String() string {
 		return "ChannelAnnouncement2"
 	case MsgChannelUpdate2:
 		return "ChannelUpdate2"
+	case MsgNodeAnnouncement2:
+		return "NodeAnnouncement2"
 	default:
 		return "<unknown>"
 	}
@@ -251,6 +254,8 @@ func makeEmptyMessage(msgType MessageType) (Message, error) {
 		msg = &ChannelAnnouncement2{}
 	case MsgChannelUpdate2:
 		msg = &ChannelUpdate2{}
+	case MsgNodeAnnouncement2:
+		msg = &NodeAnnouncement2{}
 	default:
 		// If the message is not within our custom range and has not
 		// specifically been overridden, return an unknown message.

--- a/lnwire/message.go
+++ b/lnwire/message.go
@@ -52,6 +52,7 @@ const (
 	MsgQueryChannelRange                   = 263
 	MsgReplyChannelRange                   = 264
 	MsgGossipTimestampRange                = 265
+	MsgChannelAnnouncement2                = 267
 )
 
 // ErrorEncodeMessage is used when failed to encode the message payload.
@@ -137,6 +138,8 @@ func (t MessageType) String() string {
 		return "GossipTimestampRange"
 	case MsgAnnouncementSignatures2:
 		return "MsgAnnouncementSignatures2"
+	case MsgChannelAnnouncement2:
+		return "ChannelAnnouncement2"
 	default:
 		return "<unknown>"
 	}
@@ -241,6 +244,8 @@ func makeEmptyMessage(msgType MessageType) (Message, error) {
 		msg = &GossipTimestampRange{}
 	case MsgAnnouncementSignatures2:
 		msg = &AnnouncementSignatures2{}
+	case MsgChannelAnnouncement2:
+		msg = &ChannelAnnouncement2{}
 	default:
 		// If the message is not within our custom range and has not
 		// specifically been overridden, return an unknown message.

--- a/lnwire/message.go
+++ b/lnwire/message.go
@@ -46,6 +46,7 @@ const (
 	MsgNodeAnnouncement                    = 257
 	MsgChannelUpdate                       = 258
 	MsgAnnounceSignatures                  = 259
+	MsgAnnouncementSignatures2             = 260
 	MsgQueryShortChanIDs                   = 261
 	MsgReplyShortChanIDsEnd                = 262
 	MsgQueryChannelRange                   = 263
@@ -134,6 +135,8 @@ func (t MessageType) String() string {
 		return "ReplyChannelRange"
 	case MsgGossipTimestampRange:
 		return "GossipTimestampRange"
+	case MsgAnnouncementSignatures2:
+		return "MsgAnnouncementSignatures2"
 	default:
 		return "<unknown>"
 	}
@@ -236,6 +239,8 @@ func makeEmptyMessage(msgType MessageType) (Message, error) {
 		msg = &ReplyChannelRange{}
 	case MsgGossipTimestampRange:
 		msg = &GossipTimestampRange{}
+	case MsgAnnouncementSignatures2:
+		msg = &AnnouncementSignatures2{}
 	default:
 		// If the message is not within our custom range and has not
 		// specifically been overridden, return an unknown message.

--- a/lnwire/message.go
+++ b/lnwire/message.go
@@ -53,6 +53,7 @@ const (
 	MsgReplyChannelRange                   = 264
 	MsgGossipTimestampRange                = 265
 	MsgChannelAnnouncement2                = 267
+	MsgChannelUpdate2                      = 271
 )
 
 // ErrorEncodeMessage is used when failed to encode the message payload.
@@ -140,6 +141,8 @@ func (t MessageType) String() string {
 		return "MsgAnnouncementSignatures2"
 	case MsgChannelAnnouncement2:
 		return "ChannelAnnouncement2"
+	case MsgChannelUpdate2:
+		return "ChannelUpdate2"
 	default:
 		return "<unknown>"
 	}
@@ -246,6 +249,8 @@ func makeEmptyMessage(msgType MessageType) (Message, error) {
 		msg = &AnnouncementSignatures2{}
 	case MsgChannelAnnouncement2:
 		msg = &ChannelAnnouncement2{}
+	case MsgChannelUpdate2:
+		msg = &ChannelUpdate2{}
 	default:
 		// If the message is not within our custom range and has not
 		// specifically been overridden, return an unknown message.

--- a/lnwire/musig2.go
+++ b/lnwire/musig2.go
@@ -7,20 +7,31 @@ import (
 	"github.com/lightningnetwork/lnd/tlv"
 )
 
-const (
-	// NonceRecordType is the TLV type used to encode a local musig2 nonce.
-	NonceRecordType tlv.Type = 4
-)
-
 // Musig2Nonce represents a musig2 public nonce, which is the concatenation of
 // two EC points serialized in compressed format.
 type Musig2Nonce [musig2.PubNonceSize]byte
 
+// Musig2NonceRecordProducer wraps a Musig2Nonce with the tlv type it should be
+// encoded under. This can then be used to produce a TLV record.
+type Musig2NonceRecordProducer struct {
+	Musig2Nonce
+
+	Type tlv.Type
+}
+
+// NewMusig2NonceRecordProducer constructs a new Musig2NonceRecordProducer with
+// the given tlv type set.
+func NewMusig2NonceRecordProducer(tlvType tlv.Type) *Musig2NonceRecordProducer {
+	return &Musig2NonceRecordProducer{
+		Type: tlvType,
+	}
+}
+
 // Record returns a TLV record that can be used to encode/decode the musig2
 // nonce from a given TLV stream.
-func (m *Musig2Nonce) Record() tlv.Record {
+func (m *Musig2NonceRecordProducer) Record() tlv.Record {
 	return tlv.MakeStaticRecord(
-		NonceRecordType, m, musig2.PubNonceSize, nonceTypeEncoder,
+		m.Type, &m.Musig2Nonce, musig2.PubNonceSize, nonceTypeEncoder,
 		nonceTypeDecoder,
 	)
 }

--- a/lnwire/node_announcement_2.go
+++ b/lnwire/node_announcement_2.go
@@ -1,0 +1,554 @@
+package lnwire
+
+import (
+	"bytes"
+	"encoding/binary"
+	"fmt"
+	"image/color"
+	"io"
+	"net"
+	"unicode/utf8"
+
+	"github.com/lightningnetwork/lnd/tlv"
+	"github.com/lightningnetwork/lnd/tor"
+)
+
+const (
+	// NodeAnn2FeaturesType is the tlv number associated with the features
+	// vector TLV record in the node_announcement_2 message.
+	NodeAnn2FeaturesType = tlv.Type(0)
+
+	// NodeAnn2RGBColorType is the tlv number associated with the color TLV
+	// record in the node_announcement_2 message.
+	NodeAnn2RGBColorType = tlv.Type(1)
+
+	// NodeAnn2BlockHeightType is the tlv number associated with the block
+	// height TLV record in the node_announcement_2 message.
+	NodeAnn2BlockHeightType = tlv.Type(2)
+
+	// NodeAnn2AliasType is the tlv number associated with the alias vector
+	// TLV record in the node_announcement_2 message.
+	NodeAnn2AliasType = tlv.Type(3)
+
+	// NodeAnn2NodeIDType is the tlv number associated with the node ID TLV
+	// record in the node_announcement_2 message.
+	NodeAnn2NodeIDType = tlv.Type(4)
+
+	// NodeAnn2IPV4AddrsType is the tlv number associated with the ipv4
+	// addresses TLV record in the node_announcement_2 message.
+	NodeAnn2IPV4AddrsType = tlv.Type(5)
+
+	// NodeAnn2IPV6AddrsType is the tlv number associated with the ipv6
+	// addresses TLV record in the node_announcement_2 message.
+	NodeAnn2IPV6AddrsType = tlv.Type(7)
+
+	// NodeAnn2TorV3AddrsType is the tlv number associated with the tor V3
+	// addresses TLV record in the node_announcement_2 message.
+	NodeAnn2TorV3AddrsType = tlv.Type(9)
+)
+
+// NodeAnnouncement2 message is used to announce the presence of a Lightning
+// node and also to signal that the node is accepting incoming connections.
+// Each NodeAnnouncement authenticating the advertised information within the
+// announcement via a signature using the advertised node pubkey.
+type NodeAnnouncement2 struct {
+	// Signature is used to prove the ownership of node id.
+	Signature Sig
+
+	// Features is the list of protocol features this node supports.
+	Features RawFeatureVector
+
+	// RGBColor is an optional field used to customize a node's appearance
+	// in maps and graphs.
+	RGBColor *color.RGBA
+
+	// BlockHeight allows ordering in the case of multiple announcements.
+	BlockHeight uint32
+
+	// Alias is used to customize their node's appearance in maps and
+	// graphs.
+	Alias []byte
+
+	// NodeID is a public key which is used as node identification.
+	NodeID [33]byte
+
+	// Address are addresses on which the node is accepting incoming
+	// connections.
+	Addresses []net.Addr
+
+	// ExtraOpaqueData is the set of data that was appended to this
+	// message, some of which we may not actually know how to iterate or
+	// parse. By holding onto this data, we ensure that we're able to
+	// properly validate the set of signatures that cover these new fields,
+	// and ensure we're able to make upgrades to the network in a forwards
+	// compatible manner.
+	ExtraOpaqueData ExtraOpaqueData
+}
+
+// A compile time check to ensure NodeAnnouncement2 implements the
+// lnwire.Message interface.
+var _ Message = (*NodeAnnouncement2)(nil)
+
+// Decode deserializes a serialized AnnounceSignatures stored in the passed
+// io.Reader observing the specified protocol version.
+//
+// This is part of the lnwire.Message interface.
+func (n *NodeAnnouncement2) Decode(r io.Reader, _ uint32) error {
+	err := ReadElement(r, &n.Signature)
+	if err != nil {
+		return err
+	}
+	n.Signature.ForceSchnorr()
+
+	// First extract into extra opaque data.
+	var tlvRecords ExtraOpaqueData
+	if err := ReadElements(r, &tlvRecords); err != nil {
+		return err
+	}
+
+	featuresRecordProducer := NewRawFeatureVectorRecordProducer(
+		NodeAnn2FeaturesType,
+	)
+
+	var (
+		rbgColour color.RGBA
+		alias     []byte
+		ipv4      IPV4Addrs
+		ipv6      IPV6Addrs
+		torV3     TorV3Addrs
+	)
+	records := []tlv.Record{
+		featuresRecordProducer.Record(),
+		tlv.MakeStaticRecord(
+			NodeAnn2RGBColorType, &rbgColour, 3, rgbEncoder,
+			rgbDecoder,
+		),
+		tlv.MakePrimitiveRecord(
+			NodeAnn2BlockHeightType, &n.BlockHeight,
+		),
+		tlv.MakePrimitiveRecord(NodeAnn2AliasType, &alias),
+		tlv.MakePrimitiveRecord(NodeAnn2NodeIDType, &n.NodeID),
+		tlv.MakeDynamicRecord(
+			NodeAnn2IPV4AddrsType, &ipv4, ipv4.EncodedSize,
+			ipv4AddrsEncoder, ipv4AddrsDecoder,
+		),
+		tlv.MakeDynamicRecord(
+			NodeAnn2IPV6AddrsType, &ipv6, ipv6.EncodedSize,
+			ipv6AddrsEncoder, ipv6AddrsDecoder,
+		),
+		tlv.MakeDynamicRecord(
+			NodeAnn2TorV3AddrsType, &torV3, torV3.EncodedSize,
+			torV3AddrsEncoder, torV3AddrsDecoder,
+		),
+	}
+
+	typeMap, err := tlvRecords.ExtractRecords(records...)
+	if err != nil {
+		return err
+	}
+
+	if _, ok := typeMap[NodeAnn2FeaturesType]; ok {
+		n.Features = featuresRecordProducer.RawFeatureVector
+	}
+
+	if _, ok := typeMap[NodeAnn2RGBColorType]; ok {
+		n.RGBColor = &rbgColour
+	}
+
+	if _, ok := typeMap[NodeAnn2AliasType]; ok {
+		// TODO(elle): do this before we allocate the bytes for it
+		//  somehow?
+		if len(alias) > 32 {
+			return fmt.Errorf("alias too large: max is %v, got %v",
+				32, len(alias))
+		}
+
+		// Validate the alias.
+		if !utf8.ValidString(string(alias)) {
+			return fmt.Errorf("node alias has non-utf8 characters")
+		}
+
+		n.Alias = alias
+	}
+
+	if _, ok := typeMap[NodeAnn2IPV4AddrsType]; ok {
+		for _, addr := range ipv4 {
+			n.Addresses = append(n.Addresses, net.Addr(addr))
+		}
+	}
+
+	if _, ok := typeMap[NodeAnn2IPV6AddrsType]; ok {
+		for _, addr := range ipv6 {
+			n.Addresses = append(n.Addresses, net.Addr(addr))
+		}
+	}
+
+	if _, ok := typeMap[NodeAnn2TorV3AddrsType]; ok {
+		for _, addr := range torV3 {
+			n.Addresses = append(n.Addresses, net.Addr(addr))
+		}
+	}
+
+	if len(tlvRecords) != 0 {
+		n.ExtraOpaqueData = tlvRecords
+	}
+
+	return nil
+}
+
+// Encode serializes the target AnnounceSignatures into the passed io.Writer
+// observing the protocol version specified.
+//
+// This is part of the lnwire.Message interface.
+func (n *NodeAnnouncement2) Encode(w *bytes.Buffer, _ uint32) error {
+	_, err := w.Write(n.Signature.RawBytes())
+	if err != nil {
+		return err
+	}
+
+	featuresRecordProducer := &RawFeatureVectorRecordProducer{
+		RawFeatureVector: n.Features,
+		Type:             NodeAnn2FeaturesType,
+	}
+
+	records := []tlv.Record{
+		featuresRecordProducer.Record(),
+	}
+
+	// Only encode the colour if it is specified.
+	if n.RGBColor != nil {
+		records = append(records, tlv.MakeStaticRecord(
+			NodeAnn2RGBColorType, n.RGBColor, 3, rgbEncoder,
+			rgbDecoder,
+		))
+	}
+
+	records = append(records, tlv.MakePrimitiveRecord(
+		NodeAnn2BlockHeightType, &n.BlockHeight,
+	))
+
+	if len(n.Alias) != 0 {
+		records = append(records,
+			tlv.MakePrimitiveRecord(NodeAnn2AliasType, &n.Alias),
+		)
+	}
+
+	records = append(
+		records, tlv.MakePrimitiveRecord(NodeAnn2NodeIDType, &n.NodeID),
+	)
+
+	// Iterate over the addresses and collect the various types.
+	var (
+		ipv4  IPV4Addrs
+		ipv6  IPV6Addrs
+		torv3 TorV3Addrs
+	)
+	for _, addr := range n.Addresses {
+		switch a := addr.(type) {
+		case *net.TCPAddr:
+			if a.IP.To4() != nil {
+				ipv4 = append(ipv4, a)
+			} else {
+				ipv6 = append(ipv6, a)
+			}
+
+		case *tor.OnionAddr:
+			torv3 = append(torv3, a)
+		}
+	}
+
+	if len(ipv4) > 0 {
+		records = append(records, tlv.MakeDynamicRecord(
+			NodeAnn2IPV4AddrsType, &ipv4, ipv4.EncodedSize,
+			ipv4AddrsEncoder, ipv4AddrsDecoder,
+		))
+	}
+
+	if len(ipv6) > 0 {
+		records = append(records, tlv.MakeDynamicRecord(
+			NodeAnn2IPV6AddrsType, &ipv6, ipv6.EncodedSize,
+			ipv6AddrsEncoder, ipv6AddrsDecoder,
+		))
+	}
+
+	if len(torv3) > 0 {
+		records = append(records, tlv.MakeDynamicRecord(
+			NodeAnn2TorV3AddrsType, &torv3, torv3.EncodedSize,
+			torV3AddrsEncoder, torV3AddrsDecoder,
+		))
+	}
+
+	err = EncodeMessageExtraDataFromRecords(&n.ExtraOpaqueData, records...)
+	if err != nil {
+		return err
+	}
+
+	return WriteBytes(w, n.ExtraOpaqueData)
+}
+
+// MsgType returns the integer uniquely identifying this message type on the
+// wire.
+//
+// This is part of the lnwire.Message interface.
+func (n *NodeAnnouncement2) MsgType() MessageType {
+	return MsgNodeAnnouncement2
+}
+
+func rgbEncoder(w io.Writer, val interface{}, _ *[8]byte) error {
+	if v, ok := val.(*color.RGBA); ok {
+		buf := bytes.NewBuffer(nil)
+		err := WriteColorRGBA(buf, *v)
+		if err != nil {
+			return err
+		}
+
+		_, err = w.Write(buf.Bytes())
+
+		return err
+	}
+
+	return tlv.NewTypeForEncodingErr(val, "color.RGBA")
+}
+
+func rgbDecoder(r io.Reader, val interface{}, _ *[8]byte, l uint64) error {
+	if v, ok := val.(*color.RGBA); ok {
+		return ReadElements(r, &v.R, &v.G, &v.B)
+	}
+
+	return tlv.NewTypeForDecodingErr(val, "color.RGBA", l, 3)
+}
+
+// IPV4Addrs is a list of ipv4 addresses that can be encoded as a TLV record.
+type IPV4Addrs []*net.TCPAddr
+
+// ipv4AddrEncodedSize is the number of bytes required to encode a single ipv4
+// address. Four bytes are used to encode the IP address and two bytes for the
+// port number.
+const ipv4AddrEncodedSize = 4 + 2
+
+// EncodedSize returns the number of bytes required to encode an IPV4Addrs
+// variable.
+func (i *IPV4Addrs) EncodedSize() uint64 {
+	return uint64(len(*i) * ipv4AddrEncodedSize)
+}
+
+func ipv4AddrsEncoder(w io.Writer, val interface{}, _ *[8]byte) error {
+	if v, ok := val.(*IPV4Addrs); ok {
+		for _, ip := range *v {
+			_, err := w.Write(ip.IP.To4())
+			if err != nil {
+				return err
+			}
+
+			var port [2]byte
+			binary.BigEndian.PutUint16(port[:], uint16(ip.Port))
+
+			_, err = w.Write(port[:])
+
+			return err
+		}
+	}
+
+	return tlv.NewTypeForEncodingErr(val, "lnwire.IPV4Addrs")
+}
+
+func ipv4AddrsDecoder(r io.Reader, val interface{}, _ *[8]byte,
+	l uint64) error {
+
+	if v, ok := val.(*IPV4Addrs); ok {
+		if l%(ipv4AddrEncodedSize) != 0 {
+			return fmt.Errorf("invalid ipv4 list encoding")
+		}
+
+		var (
+			numAddrs = int(l / ipv4AddrEncodedSize)
+			addrs    = make([]*net.TCPAddr, 0, numAddrs)
+			ip       [4]byte
+			port     [2]byte
+		)
+		for len(addrs) < numAddrs {
+			_, err := r.Read(ip[:])
+			if err != nil {
+				return err
+			}
+
+			_, err = r.Read(port[:])
+			if err != nil {
+				return err
+			}
+
+			addrs = append(addrs, &net.TCPAddr{
+				IP:   ip[:],
+				Port: int(binary.BigEndian.Uint16(port[:])),
+			})
+		}
+
+		*v = addrs
+
+		return nil
+	}
+
+	return tlv.NewTypeForEncodingErr(val, "lnwire.IPV4Addrs")
+}
+
+// IPV6Addrs is a list of ipv6 addresses that can be encoded as a TLV record.
+type IPV6Addrs []*net.TCPAddr
+
+// ipv6AddrEncodedSize is the number of bytes required to encode a single ipv6
+// address. Sixteen bytes are used to encode the IP address and two bytes for
+// the port number.
+const ipv6AddrEncodedSize = 16 + 2
+
+// EncodedSize returns the number of bytes required to encode an IPV6Addrs
+// variable.
+func (i *IPV6Addrs) EncodedSize() uint64 {
+	return uint64(len(*i) * ipv6AddrEncodedSize)
+}
+
+func ipv6AddrsEncoder(w io.Writer, val interface{}, _ *[8]byte) error {
+	if v, ok := val.(*IPV6Addrs); ok {
+		for _, ip := range *v {
+			_, err := w.Write(ip.IP.To16())
+			if err != nil {
+				return err
+			}
+
+			var port [2]byte
+			binary.BigEndian.PutUint16(port[:], uint16(ip.Port))
+
+			_, err = w.Write(port[:])
+
+			return err
+		}
+	}
+
+	return tlv.NewTypeForEncodingErr(val, "lnwire.IPV6Addrs")
+}
+
+func ipv6AddrsDecoder(r io.Reader, val interface{}, _ *[8]byte,
+	l uint64) error {
+
+	if v, ok := val.(*IPV6Addrs); ok {
+		if l%(ipv6AddrEncodedSize) != 0 {
+			return fmt.Errorf("invalid ipv6 list encoding")
+		}
+
+		var (
+			numAddrs = int(l / ipv6AddrEncodedSize)
+			addrs    = make([]*net.TCPAddr, 0, numAddrs)
+			ip       [16]byte
+			port     [2]byte
+		)
+		for len(addrs) < numAddrs {
+			_, err := r.Read(ip[:])
+			if err != nil {
+				return err
+			}
+
+			_, err = r.Read(port[:])
+			if err != nil {
+				return err
+			}
+
+			addrs = append(addrs, &net.TCPAddr{
+				IP:   ip[:],
+				Port: int(binary.BigEndian.Uint16(port[:])),
+			})
+		}
+
+		*v = addrs
+
+		return nil
+	}
+
+	return tlv.NewTypeForEncodingErr(val, "lnwire.IPV6Addrs")
+}
+
+// TorV3Addrs is a list of tor v3 addresses that can be encoded as a TLV record.
+type TorV3Addrs []*tor.OnionAddr
+
+// torV3AddrEncodedSize is the number of bytes required to encode a single tor
+// v3 address.
+const torV3AddrEncodedSize = tor.V3DecodedLen + 2
+
+// EncodedSize returns the number of bytes required to encode an TorV3Addrs
+// variable.
+func (i *TorV3Addrs) EncodedSize() uint64 {
+	return uint64(len(*i) * torV3AddrEncodedSize)
+}
+
+func torV3AddrsEncoder(w io.Writer, val interface{}, _ *[8]byte) error {
+	if v, ok := val.(*TorV3Addrs); ok {
+		for _, addr := range *v {
+			encodedHostLen := tor.V3Len - tor.OnionSuffixLen
+			host, err := tor.Base32Encoding.DecodeString(
+				addr.OnionService[:encodedHostLen],
+			)
+			if err != nil {
+				return err
+			}
+
+			if len(host) != tor.V3DecodedLen {
+				return fmt.Errorf("expected a tor v3 host "+
+					"length of %d, got: %d",
+					tor.V2DecodedLen, len(host))
+			}
+
+			if _, err = w.Write(host); err != nil {
+				return err
+			}
+
+			var port [2]byte
+			binary.BigEndian.PutUint16(port[:], uint16(addr.Port))
+
+			_, err = w.Write(port[:])
+
+			return err
+		}
+	}
+
+	return tlv.NewTypeForEncodingErr(val, "lnwire.TorV3Addrs")
+}
+
+func torV3AddrsDecoder(r io.Reader, val interface{}, _ *[8]byte,
+	l uint64) error {
+
+	if v, ok := val.(*TorV3Addrs); ok {
+		if l%torV3AddrEncodedSize != 0 {
+			return fmt.Errorf("invalid tor v3 list encoding")
+		}
+
+		var (
+			numAddrs = int(l / torV3AddrEncodedSize)
+			addrs    = make([]*tor.OnionAddr, 0, numAddrs)
+			ip       [tor.V3DecodedLen]byte
+			p        [2]byte
+		)
+		for len(addrs) < numAddrs {
+			_, err := r.Read(ip[:])
+			if err != nil {
+				return err
+			}
+
+			_, err = r.Read(p[:])
+			if err != nil {
+				return err
+			}
+
+			onionService := tor.Base32Encoding.EncodeToString(ip[:])
+			onionService += tor.OnionSuffix
+			port := int(binary.BigEndian.Uint16(p[:]))
+
+			addrs = append(addrs, &tor.OnionAddr{
+				OnionService: onionService,
+				Port:         port,
+			})
+		}
+
+		*v = addrs
+
+		return nil
+	}
+
+	return tlv.NewTypeForEncodingErr(val, "lnwire.TorV3Addrs")
+}

--- a/lnwire/open_channel.go
+++ b/lnwire/open_channel.go
@@ -318,7 +318,7 @@ func (o *OpenChannel) Decode(r io.Reader, pver uint32) error {
 			OpenChanLocalNonceType,
 		)
 	)
-	typeMap, err := tlvRecords.ExtractRecords(
+	typeMap, err := tlvRecords.ExtractRecordsFromProducers(
 		&o.UpfrontShutdownScript, &chanType, &leaseExpiry, localNonce,
 	)
 	if err != nil {

--- a/lnwire/revoke_and_ack.go
+++ b/lnwire/revoke_and_ack.go
@@ -81,7 +81,7 @@ func (c *RevokeAndAck) Decode(r io.Reader, pver uint32) error {
 	}
 
 	musigNonce := NewMusig2NonceRecordProducer(RevAndAckLocalNonceType)
-	typeMap, err := tlvRecords.ExtractRecords(musigNonce)
+	typeMap, err := tlvRecords.ExtractRecordsFromProducers(musigNonce)
 	if err != nil {
 		return err
 	}

--- a/lnwire/short_channel_id.go
+++ b/lnwire/short_channel_id.go
@@ -7,11 +7,28 @@ import (
 	"github.com/lightningnetwork/lnd/tlv"
 )
 
-const (
-	// AliasScidRecordType is the type of the experimental record to denote
-	// the alias being used in an option_scid_alias channel.
-	AliasScidRecordType tlv.Type = 1
-)
+// ShortChannelIDRecordProducer wraps a ShortChannelID with the tlv type that it
+// should be encoded with.
+type ShortChannelIDRecordProducer struct {
+	ShortChannelID
+	Type tlv.Type
+}
+
+// Record returns a TLV record that can be used to encode/decode a
+// ShortChannelID to/from a TLV stream.
+func (c *ShortChannelIDRecordProducer) Record() tlv.Record {
+	return tlv.MakeStaticRecord(
+		c.Type, &c.ShortChannelID, 8, EShortChannelID, DShortChannelID,
+	)
+}
+
+// NewShortChannelIDRecordProducer constructs a new ShortChannelIDRecordProducer
+// with the given TLV type.
+func NewShortChannelIDRecordProducer(t tlv.Type) *ShortChannelIDRecordProducer {
+	return &ShortChannelIDRecordProducer{
+		Type: t,
+	}
+}
 
 // ShortChannelID represents the set of data which is needed to retrieve all
 // necessary data to validate the channel existence.
@@ -47,21 +64,13 @@ func NewShortChanIDFromInt(chanID uint64) ShortChannelID {
 // uint64 (8 bytes).
 func (c ShortChannelID) ToUint64() uint64 {
 	// TODO(roasbeef): explicit error on overflow?
-	return ((uint64(c.BlockHeight) << 40) | (uint64(c.TxIndex) << 16) |
-		(uint64(c.TxPosition)))
+	return (uint64(c.BlockHeight) << 40) | (uint64(c.TxIndex) << 16) |
+		(uint64(c.TxPosition))
 }
 
 // String generates a human-readable representation of the channel ID.
 func (c ShortChannelID) String() string {
 	return fmt.Sprintf("%d:%d:%d", c.BlockHeight, c.TxIndex, c.TxPosition)
-}
-
-// Record returns a TLV record that can be used to encode/decode a
-// ShortChannelID to/from a TLV stream.
-func (c *ShortChannelID) Record() tlv.Record {
-	return tlv.MakeStaticRecord(
-		AliasScidRecordType, c, 8, EShortChannelID, DShortChannelID,
-	)
 }
 
 // IsDefault returns true if the ShortChannelID represents the zero value for

--- a/lnwire/short_channel_id_test.go
+++ b/lnwire/short_channel_id_test.go
@@ -53,10 +53,10 @@ func TestScidTypeEncodeDecode(t *testing.T) {
 	}
 
 	var extraData ExtraOpaqueData
-	require.NoError(t, extraData.PackRecords(&aliasScid))
+	require.NoError(t, extraData.PackRecordsFromProducers(&aliasScid))
 
 	var aliasScid2 ShortChannelID
-	tlvs, err := extraData.ExtractRecords(&aliasScid2)
+	tlvs, err := extraData.ExtractRecordsFromProducers(&aliasScid2)
 	require.NoError(t, err)
 
 	require.Contains(t, tlvs, AliasScidRecordType)

--- a/lnwire/short_channel_id_test.go
+++ b/lnwire/short_channel_id_test.go
@@ -46,19 +46,29 @@ func TestShortChannelIDEncoding(t *testing.T) {
 func TestScidTypeEncodeDecode(t *testing.T) {
 	t.Parallel()
 
-	aliasScid := ShortChannelID{
-		BlockHeight: (1 << 24) - 1,
-		TxIndex:     (1 << 24) - 1,
-		TxPosition:  (1 << 16) - 1,
+	aliasScidRecordProducer := &ShortChannelIDRecordProducer{
+		ShortChannelID: ShortChannelID{
+			BlockHeight: (1 << 24) - 1,
+			TxIndex:     (1 << 24) - 1,
+			TxPosition:  (1 << 16) - 1,
+		},
+		Type: ChanReadyAliasScidType,
 	}
 
 	var extraData ExtraOpaqueData
-	require.NoError(t, extraData.PackRecordsFromProducers(&aliasScid))
+	require.NoError(
+		t, extraData.PackRecordsFromProducers(aliasScidRecordProducer),
+	)
 
-	var aliasScid2 ShortChannelID
-	tlvs, err := extraData.ExtractRecordsFromProducers(&aliasScid2)
+	aliasScid2RecordProducer := NewShortChannelIDRecordProducer(
+		ChanReadyAliasScidType,
+	)
+
+	tlvs, err := extraData.ExtractRecordsFromProducers(
+		aliasScid2RecordProducer,
+	)
 	require.NoError(t, err)
 
-	require.Contains(t, tlvs, AliasScidRecordType)
-	require.Equal(t, aliasScid, aliasScid2)
+	require.Contains(t, tlvs, ChanReadyAliasScidType)
+	require.Equal(t, aliasScidRecordProducer, aliasScid2RecordProducer)
 }

--- a/lnwire/shutdown.go
+++ b/lnwire/shutdown.go
@@ -103,7 +103,7 @@ func (s *Shutdown) Decode(r io.Reader, pver uint32) error {
 	}
 
 	var musigNonce ShutdownNonce
-	typeMap, err := tlvRecords.ExtractRecords(&musigNonce)
+	typeMap, err := tlvRecords.ExtractRecordsFromProducers(&musigNonce)
 	if err != nil {
 		return err
 	}

--- a/lnwire/typed_delivery_addr_test.go
+++ b/lnwire/typed_delivery_addr_test.go
@@ -15,13 +15,13 @@ func TestDeliveryAddressEncodeDecode(t *testing.T) {
 	)
 
 	var extraData ExtraOpaqueData
-	err := extraData.PackRecords(&addr)
+	err := extraData.PackRecordsFromProducers(&addr)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	var addr2 DeliveryAddress
-	tlvs, err := extraData.ExtractRecords(&addr2)
+	tlvs, err := extraData.ExtractRecordsFromProducers(&addr2)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/lnwire/typed_lease_expiry_test.go
+++ b/lnwire/typed_lease_expiry_test.go
@@ -14,10 +14,10 @@ func TestLeaseExpiryEncodeDecode(t *testing.T) {
 	leaseExpiry := LeaseExpiry(1337)
 
 	var extraData ExtraOpaqueData
-	require.NoError(t, extraData.PackRecords(&leaseExpiry))
+	require.NoError(t, extraData.PackRecordsFromProducers(&leaseExpiry))
 
 	var leaseExpiry2 LeaseExpiry
-	tlvs, err := extraData.ExtractRecords(&leaseExpiry2)
+	tlvs, err := extraData.ExtractRecordsFromProducers(&leaseExpiry2)
 	require.NoError(t, err)
 
 	require.Contains(t, tlvs, LeaseExpiryRecordType)

--- a/lnwire/writer.go
+++ b/lnwire/writer.go
@@ -173,6 +173,14 @@ func WriteSigs(buf *bytes.Buffer, sigs []Sig) error {
 	return nil
 }
 
+// WritePartialSig appends the serialised partial signature to the provided
+// buffer.
+func WritePartialSig(buf *bytes.Buffer, sig PartialSig) error {
+	sigBytes := sig.Sig.Bytes()
+
+	return WriteBytes(buf, sigBytes[:])
+}
+
 // WriteFailCode appends the FailCode to the provided buffer.
 func WriteFailCode(buf *bytes.Buffer, e FailCode) error {
 	return WriteUint16(buf, uint16(e))

--- a/netann/channel_update_test.go
+++ b/netann/channel_update_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/btcsuite/btcd/btcec/v2"
 	"github.com/btcsuite/btcd/btcec/v2/ecdsa"
+	"github.com/btcsuite/btcd/btcec/v2/schnorr/musig2"
 	"github.com/lightningnetwork/lnd/keychain"
 	"github.com/lightningnetwork/lnd/lnwallet"
 	"github.com/lightningnetwork/lnd/lnwire"
@@ -20,6 +21,18 @@ type mockSigner struct {
 
 func (m *mockSigner) SignMessage(_ keychain.KeyLocator,
 	_ []byte, _ bool) (*ecdsa.Signature, error) {
+
+	if m.err != nil {
+		return nil, m.err
+	}
+
+	return nil, nil
+}
+
+func (m *mockSigner) SignMuSig2(_ [musig2.SecNonceSize]byte,
+	_ keychain.KeyLocator, _ [][musig2.PubNonceSize]byte,
+	_ [musig2.PubNonceSize]byte, _ []*btcec.PublicKey, _ [32]byte,
+	_ ...musig2.SignOption) (*musig2.PartialSignature, error) {
 
 	if m.err != nil {
 		return nil, m.err

--- a/peer/brontide.go
+++ b/peer/brontide.go
@@ -1661,6 +1661,7 @@ out:
 			*lnwire.ChannelAnnouncement2,
 			*lnwire.NodeAnnouncement,
 			*lnwire.AnnounceSignatures,
+			*lnwire.AnnouncementSignatures2,
 			*lnwire.GossipTimestampRange,
 			*lnwire.QueryShortChanIDs,
 			*lnwire.QueryChannelRange,
@@ -1910,6 +1911,10 @@ func messageSummary(msg lnwire.Message) string {
 	case *lnwire.AnnounceSignatures:
 		return fmt.Sprintf("chan_id=%v, short_chan_id=%v", msg.ChannelID,
 			msg.ShortChannelID.ToUint64())
+
+	case *lnwire.AnnouncementSignatures2:
+		return fmt.Sprintf("chan_id=%v, short_chan_id=%v",
+			msg.ChannelID, msg.ShortChannelID.ToUint64())
 
 	case *lnwire.ChannelAnnouncement:
 		return fmt.Sprintf("chain_hash=%v, short_chan_id=%v",

--- a/peer/brontide.go
+++ b/peer/brontide.go
@@ -1658,6 +1658,7 @@ out:
 
 		case *lnwire.ChannelUpdate,
 			*lnwire.ChannelAnnouncement,
+			*lnwire.ChannelAnnouncement2,
 			*lnwire.NodeAnnouncement,
 			*lnwire.AnnounceSignatures,
 			*lnwire.GossipTimestampRange,
@@ -1911,6 +1912,10 @@ func messageSummary(msg lnwire.Message) string {
 			msg.ShortChannelID.ToUint64())
 
 	case *lnwire.ChannelAnnouncement:
+		return fmt.Sprintf("chain_hash=%v, short_chan_id=%v",
+			msg.ChainHash, msg.ShortChannelID.ToUint64())
+
+	case *lnwire.ChannelAnnouncement2:
 		return fmt.Sprintf("chain_hash=%v, short_chan_id=%v",
 			msg.ChainHash, msg.ShortChannelID.ToUint64())
 

--- a/routing/validation_barrier.go
+++ b/routing/validation_barrier.go
@@ -180,6 +180,8 @@ func (v *ValidationBarrier) InitJobDependencies(job interface{}) {
 	case *lnwire.AnnounceSignatures:
 		// TODO(roasbeef): need to wait on chan ann?
 		return
+	case *lnwire.AnnouncementSignatures2:
+		return
 	}
 }
 
@@ -240,7 +242,7 @@ func (v *ValidationBarrier) WaitForDependants(job interface{}) error {
 
 	// Other types of jobs can be executed immediately, so we'll just
 	// return directly.
-	case *lnwire.AnnounceSignatures:
+	case *lnwire.AnnounceSignatures, *lnwire.AnnouncementSignatures2:
 		// TODO(roasbeef): need to wait on chan ann?
 	case *channeldb.ChannelEdgeInfo:
 	case *lnwire.ChannelAnnouncement:
@@ -340,7 +342,7 @@ func (v *ValidationBarrier) SignalDependants(job interface{}, allow bool) {
 		shortID := lnwire.NewShortChanIDFromInt(msg.ChannelID)
 		delete(v.chanEdgeDependencies, shortID)
 
-	case *lnwire.AnnounceSignatures:
+	case *lnwire.AnnounceSignatures, *lnwire.AnnouncementSignatures2:
 		return
 	}
 }

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -2142,13 +2142,6 @@ func (r *rpcServer) parseOpenChannelReq(in *lnrpc.OpenChannelRequest,
 		*channelType = lnwire.ChannelType(*fv)
 
 	case lnrpc.CommitmentType_SIMPLE_TAPROOT:
-		// If the taproot channel type is being set, then the channel
-		// MUST be private (unadvertised) for now.
-		if !in.Private {
-			return nil, fmt.Errorf("taproot channels must be " +
-				"private")
-		}
-
 		channelType = new(lnwire.ChannelType)
 		fv := lnwire.NewRawFeatureVector(
 			lnwire.SimpleTaprootChannelsRequiredStaging,

--- a/server.go
+++ b/server.go
@@ -4498,6 +4498,28 @@ func (s *server) OpenChannel(
 	req.Peer = peer
 	s.mu.RUnlock()
 
+	// If the desired channel is for an advertised taproot channel, then
+	// it the peer must support taproot gossip.
+	if req.ChannelType != nil {
+		rfv := lnwire.RawFeatureVector(*req.ChannelType)
+		fv := lnwire.NewFeatureVector(&rfv, lnwire.Features)
+
+		if fv.HasFeature(lnwire.SimpleTaprootChannelsOptionalStaging) &&
+			!req.Private {
+
+			if !peer.RemoteFeatures().HasFeature(
+				lnwire.TaprootGossipOptionalStaging,
+			) {
+				req.Err <- fmt.Errorf("peer %x does not "+
+					"support announced taproot channels",
+					pubKeyBytes)
+
+				return req.Updates, req.Err
+			}
+		}
+
+	}
+
 	// We'll wait until the peer is active before beginning the channel
 	// opening process.
 	select {

--- a/server.go
+++ b/server.go
@@ -1294,6 +1294,7 @@ func newServer(cfg *Config, listenAddrs []net.Addr,
 		ChannelDB:    s.chanStateDB,
 		FeeEstimator: cc.FeeEstimator,
 		SignMessage:  cc.MsgSigner.SignMessage,
+		SignMuSig2:   cc.MsgSigner.SignMuSig2,
 		CurrentNodeAnnouncement: func() (lnwire.NodeAnnouncement,
 			error) {
 


### PR DESCRIPTION
In this PR, we start making use of the new `channel_announcement_2` message 
for advertising simple taproot channels. All itests are updated to use public taproot
channels. 

Part of [Gossip 1.75 epic](https://github.com/lightningnetwork/lnd/issues/7961)
Based on #8044 (so ignore the first 11 commits)

NOTE: currently, the legacy `channel_update` message is still used for the taproot
channels. The switch to `channel_update_2` will be addressed in the next PR. 

TODO: 
     - a bunch of cleanup.
     - more abstractions
     - more tests
     - add migration for the waiting proof store 
     - flesh out & clean up the nonce generation/persistence logic 


