### PR TITLE
invoices: refactor `InvoiceDB` to eliminate `ScanInvoices`

### DIFF
--- a/docs/release-notes/release-notes-0.18.0.md
+++ b/docs/release-notes/release-notes-0.18.0.md
@@ -70,6 +70,9 @@
   a context parameter to all `InvoiceDB` methods which is a pre-requisite for
   the SQL implementation.
 
+* [Refactor InvoiceDB](https://github.com/lightningnetwork/lnd/pull/8081) to
+  eliminate the use of `ScanInvoices`.
+
 ## Code Health
 ## Tooling and Documentation
 

--- a/invoices/interface.go
+++ b/invoices/interface.go
@@ -95,6 +95,10 @@ type InvoiceDB interface {
 	// deserialze them.
 	DeleteInvoice(ctx context.Context,
 		invoicesToDelete []InvoiceDeleteRef) error
+
+	// DeleteCanceledInvoices removes all canceled invoices from the
+	// database.
+	DeleteCanceledInvoices(ctx context.Context) error
 }
 
 // Payload abstracts access to any additional fields provided in the final hop's

--- a/invoices/interface.go
+++ b/invoices/interface.go
@@ -56,6 +56,11 @@ type InvoiceDB interface {
 	ScanInvoices(ctx context.Context, scanFunc InvScanFunc,
 		reset func()) error
 
+	// FetchPendingInvoices returns all invoices that have not yet been
+	// settled or canceled.
+	FetchPendingInvoices(ctx context.Context) (map[lntypes.Hash]Invoice,
+		error)
+
 	// QueryInvoices allows a caller to query the invoice database for
 	// invoices within the specified add index range.
 	QueryInvoices(ctx context.Context, q InvoiceQuery) (InvoiceSlice, error)

--- a/invoices/interface.go
+++ b/invoices/interface.go
@@ -9,10 +9,6 @@ import (
 	"github.com/lightningnetwork/lnd/record"
 )
 
-// InvScanFunc is a helper type used to specify the type used in the
-// ScanInvoices methods (part of the InvoiceDB interface).
-type InvScanFunc func(lntypes.Hash, *Invoice) error
-
 // InvoiceDB is the database that stores the information about invoices.
 type InvoiceDB interface {
 	// AddInvoice inserts the targeted invoice into the database.
@@ -44,17 +40,6 @@ type InvoiceDB interface {
 	// ensure the payer meets the agreed upon contractual terms of the
 	// payment.
 	LookupInvoice(ctx context.Context, ref InvoiceRef) (Invoice, error)
-
-	// ScanInvoices scans through all invoices and calls the passed scanFunc
-	// for each invoice with its respective payment hash. Additionally a
-	// reset() closure is passed which is used to reset/initialize partial
-	// results and also to signal if the kvdb.View transaction has been
-	// retried.
-	//
-	// TODO(positiveblue): abstract this functionality so it makes sense for
-	// other backends like sql.
-	ScanInvoices(ctx context.Context, scanFunc InvScanFunc,
-		reset func()) error
 
 	// FetchPendingInvoices returns all invoices that have not yet been
 	// settled or canceled.

--- a/invoices/mock.go
+++ b/invoices/mock.go
@@ -85,3 +85,9 @@ func (m *MockInvoiceDB) DeleteInvoice(invoices []InvoiceDeleteRef) error {
 
 	return args.Error(0)
 }
+
+func (m *MockInvoiceDB) DeleteCanceledInvoices(ctx context.Context) error {
+	args := m.Called(ctx)
+
+	return args.Error(0)
+}

--- a/invoices/mock.go
+++ b/invoices/mock.go
@@ -1,6 +1,8 @@
 package invoices
 
 import (
+	"context"
+
 	"github.com/lightningnetwork/lnd/lntypes"
 	"github.com/stretchr/testify/mock"
 )
@@ -53,6 +55,13 @@ func (m *MockInvoiceDB) ScanInvoices(scanFunc InvScanFunc,
 	args := m.Called(scanFunc, reset)
 
 	return args.Error(0)
+}
+
+func (m *MockInvoiceDB) FetchPendingInvoices(ctx context.Context) (
+	map[lntypes.Hash]Invoice, error) {
+
+	args := m.Called(ctx)
+	return args.Get(0).(map[lntypes.Hash]Invoice), args.Error(1)
 }
 
 func (m *MockInvoiceDB) QueryInvoices(q InvoiceQuery) (InvoiceSlice, error) {

--- a/invoices/mock.go
+++ b/invoices/mock.go
@@ -49,14 +49,6 @@ func (m *MockInvoiceDB) LookupInvoice(ref InvoiceRef) (Invoice, error) {
 	return invoice, args.Error(1)
 }
 
-func (m *MockInvoiceDB) ScanInvoices(scanFunc InvScanFunc,
-	reset func()) error {
-
-	args := m.Called(scanFunc, reset)
-
-	return args.Error(0)
-}
-
 func (m *MockInvoiceDB) FetchPendingInvoices(ctx context.Context) (
 	map[lntypes.Hash]Invoice, error) {
 


### PR DESCRIPTION
This PR removes `ScanInvoices` from `InvoiceDB` (and the channeldb implementation) and adds two specific methods that can be expressed in SQL more efficiently. Builds on top of https://github.com/lightningnetwork/lnd/pull/8066 and is a pre-requirement for https://github.com/lightningnetwork/lnd/pull/8052

The downside of the refactor is that for k/v implementations we'll need to scan invoices twice, but since we're fully migrating to SQL this is just a temporary issue.

Part of https://github.com/lightningnetwork/lnd/issues/6288