### PR TITLE
Add more information when a co-op close is failing.

### DIFF
--- a/htlcswitch/link.go
+++ b/htlcswitch/link.go
@@ -1267,6 +1267,10 @@ func (l *channelLink) htlcManager() {
 				return
 			}
 
+			l.log.Infof("Channel is in an unclean state " +
+				"(lingering updates), graceful shutdown of " +
+				"channel link not possible")
+
 			// Otherwise, the channel has lingering updates, send
 			// an error and continue.
 			req.err <- ErrLinkFailedShutdown

--- a/peer/brontide.go
+++ b/peer/brontide.go
@@ -2982,7 +2982,10 @@ func (p *Brontide) handleLocalCloseReq(req *htlcswitch.ChanClose) {
 		// failed.
 		if err := p.tryLinkShutdown(chanID); err != nil {
 			p.log.Errorf("failed link shutdown: %v", err)
-			req.Err <- err
+
+			req.Err <- fmt.Errorf("failed handling co-op closing "+
+				"request with (try force closing "+
+				"it instead): %w", err)
 			return
 		}
 
@@ -3683,8 +3686,8 @@ func (p *Brontide) handleCloseMsg(msg *closeMsg) {
 func (p *Brontide) HandleLocalCloseChanReqs(req *htlcswitch.ChanClose) {
 	select {
 	case p.localCloseChanReqs <- req:
-		p.log.Info("Local close channel request delivered to " +
-			"peer")
+		p.log.Info("Local close channel request is going to be " +
+			"delivered to the peer")
 	case <-p.quit:
 		p.log.Info("Unable to deliver local close channel request " +
 			"to peer")


### PR DESCRIPTION
## Change Description
Resulting from discussions in the noderunner group where someone could not co-op close a channel but was not able to understand why:

Logs where only showing:

```
==> /var/log/syslog <==
Oct 10 13:21:09 lnd[1591]: 2023-10-10 13:21:09.933 [INF] PEER: Peer(xxx): Local close channel request delivered to peer
==> /home/bitcoin/.lnd/logs/bitcoin/mainnet/lnd.log <==2023-10-10 13:21:09.950 [ERR] PEER: Peer(xxx): failed link shutdown: link failed to shutdown
```
This had the appearance that the peer somehow was not willing to cooperate ("request delivered to peer"), now we give the user better feedback what's happening.

Now would be:

```
2023-10-12 11:22:08.349 [INF] PEER: Peer(0355402a07589a522375f83b6f6c42c4144d219ec3810e0a2aefb8ae99bdabd095): Local close channel request is going to be delivered to the peer
2023-10-12 11:22:08.367 [INF] PEER: Peer(0355402a07589a522375f83b6f6c42c4144d219ec3810e0a2aefb8ae99bdabd095): Delivery addr for channel close: bcrt1p2szcuwgt3dzkf5awkw27xzjrshf6vdsrx0y5sqj67w6flueh0pwqelcxp2
2023-10-12 11:22:08.367 [INF] HSWC: ChannelLink(877b1cd70661da033ab740928b6d0ca9ee6dcf023859f8f38e1381d45b036efc:0): Channel is in an unclean state (lingering updates), graceful shutdown of channel link not possible
2023-10-12 11:22:08.367 [ERR] PEER: Peer(0355402a07589a522375f83b6f6c42c4144d219ec3810e0a2aefb8ae99bdabd095): failed link shutdown: link failed to shutdown
```
And for the receiver:
`[lncli] rpc error: code = Unknown desc = failed handling co-op closing request with (try force closing it instead): link failed to shutdown`
