### PR TITLE
sweep: remove possible RBF when sweeping new inputs

### DIFF
--- a/docs/release-notes/release-notes-0.18.0.md
+++ b/docs/release-notes/release-notes-0.18.0.md
@@ -28,6 +28,10 @@
 * LND will now [enforce pong responses
   ](https://github.com/lightningnetwork/lnd/pull/7828) from its peers
 
+* [Fixed a possible unintended RBF
+  attempt](https://github.com/lightningnetwork/lnd/pull/8091) when sweeping new
+  inputs with retried ones.
+
 # New Features
 ## Functional Enhancements
 

--- a/itest/lnd_channel_backup_test.go
+++ b/itest/lnd_channel_backup_test.go
@@ -1524,18 +1524,12 @@ func assertDLPExecuted(ht *lntest.HarnessTest,
 
 	if commitType == lnrpc.CommitmentType_SCRIPT_ENFORCED_LEASE {
 		// Dave should sweep his anchor only, since he still has the
-		// lease CLTV constraint on his commitment output.
-		ht.Miner.AssertNumTxsInMempool(1)
+		// lease CLTV constraint on his commitment output. We'd also
+		// see Carol's anchor sweep here.
+		ht.Miner.AssertNumTxsInMempool(2)
 
-		// Mine Dave's anchor sweep tx.
-		ht.MineBlocksAndAssertNumTxes(1, 1)
-		blocksMined++
-
-		// The above block will trigger Carol's sweeper to reconsider
-		// the anchor sweeping. Because we are now sweeping at the fee
-		// rate floor, the sweeper will consider this input has
-		// positive yield thus attempts the sweeping.
-		ht.MineBlocksAndAssertNumTxes(1, 1)
+		// Mine anchor sweep txes for Carol and Dave.
+		ht.MineBlocksAndAssertNumTxes(1, 2)
 		blocksMined++
 
 		// After Carol's output matures, she should also reclaim her
@@ -1564,10 +1558,10 @@ func assertDLPExecuted(ht *lntest.HarnessTest,
 		ht.AssertNumPendingForceClose(dave, 0)
 	} else {
 		// Dave should sweep his funds immediately, as they are not
-		// timelocked. We also expect Dave to sweep his anchor, if
-		// present.
+		// timelocked. We also expect Carol and Dave sweep their
+		// anchors.
 		if lntest.CommitTypeHasAnchors(commitType) {
-			ht.MineBlocksAndAssertNumTxes(1, 2)
+			ht.MineBlocksAndAssertNumTxes(1, 3)
 		} else {
 			ht.MineBlocksAndAssertNumTxes(1, 1)
 		}
@@ -1576,15 +1570,6 @@ func assertDLPExecuted(ht *lntest.HarnessTest,
 
 		// Now Dave should consider the channel fully closed.
 		ht.AssertNumPendingForceClose(dave, 0)
-
-		// The above block will trigger Carol's sweeper to reconsider
-		// the anchor sweeping. Because we are now sweeping at the fee
-		// rate floor, the sweeper will consider this input has
-		// positive yield thus attempts the sweeping.
-		if lntest.CommitTypeHasAnchors(commitType) {
-			ht.MineBlocksAndAssertNumTxes(1, 1)
-			blocksMined++
-		}
 
 		// After Carol's output matures, she should also reclaim her
 		// funds.

--- a/itest/lnd_routing_test.go
+++ b/itest/lnd_routing_test.go
@@ -528,7 +528,6 @@ func testPrivateChannels(ht *lntest.HarnessTest) {
 			Private: true,
 		},
 	)
-	defer ht.CloseChannel(carol, chanPointPrivate)
 
 	// The channel should be available for payments between Carol and Alice.
 	// We check this by sending payments from Carol to Bob, that
@@ -602,6 +601,7 @@ func testPrivateChannels(ht *lntest.HarnessTest) {
 	ht.CloseChannel(alice, chanPointAlice)
 	ht.CloseChannel(dave, chanPointDave)
 	ht.CloseChannel(carol, chanPointCarol)
+	ht.CloseChannel(carol, chanPointPrivate)
 }
 
 // testInvoiceRoutingHints tests that the routing hints for an invoice are

--- a/server.go
+++ b/server.go
@@ -1059,14 +1059,12 @@ func newServer(cfg *Config, listenAddrs []net.Addr,
 	}
 
 	s.sweeper = sweep.New(&sweep.UtxoSweeperConfig{
-		FeeEstimator:      cc.FeeEstimator,
-		DetermineFeePerKw: sweep.DetermineFeePerKw,
-		GenSweepScript:    newSweepPkScriptGen(cc.Wallet),
-		Signer:            cc.Wallet.Cfg.Signer,
-		Wallet:            newSweeperWallet(cc.Wallet),
-		NewBatchTimer: func() <-chan time.Time {
-			return time.NewTimer(cfg.Sweeper.BatchWindowDuration).C
-		},
+		FeeEstimator:         cc.FeeEstimator,
+		DetermineFeePerKw:    sweep.DetermineFeePerKw,
+		GenSweepScript:       newSweepPkScriptGen(cc.Wallet),
+		Signer:               cc.Wallet.Cfg.Signer,
+		Wallet:               newSweeperWallet(cc.Wallet),
+		TickerDuration:       cfg.Sweeper.BatchWindowDuration,
 		Notifier:             cc.ChainNotifier,
 		Store:                sweeperStore,
 		MaxInputsPerTx:       sweep.DefaultMaxInputsPerTx,

--- a/sweep/sweeper.go
+++ b/sweep/sweeper.go
@@ -264,10 +264,11 @@ type UtxoSweeperConfig struct {
 	// Wallet contains the wallet functions that sweeper requires.
 	Wallet Wallet
 
-	// NewBatchTimer creates a channel that will be sent on when a certain
-	// time window has passed. During this time window, new inputs can still
-	// be added to the sweep tx that is about to be generated.
-	NewBatchTimer func() <-chan time.Time
+	// TickerDuration is used to create a channel that will be sent on when
+	// a certain time window has passed. During this time window, new
+	// inputs can still be added to the sweep tx that is about to be
+	// generated.
+	TickerDuration time.Duration
 
 	// Notifier is an instance of a chain notifier we'll use to watch for
 	// certain on-chain events.
@@ -1019,7 +1020,7 @@ func (s *UtxoSweeper) scheduleSweep(currentHeight int32) error {
 
 	// Start sweep timer to create opportunity for more inputs to be added
 	// before a tx is constructed.
-	s.timer = s.cfg.NewBatchTimer()
+	s.timer = time.NewTicker(s.cfg.TickerDuration).C
 
 	log.Debugf("Sweep timer started")
 

--- a/sweep/sweeper.go
+++ b/sweep/sweeper.go
@@ -1348,9 +1348,9 @@ func (s *UtxoSweeper) sweep(inputs inputSet, feeRate chainfee.SatPerKWeight,
 	return nil
 }
 
-// waitForSpend registers a spend notification with the chain notifier. It
+// monitorSpend registers a spend notification with the chain notifier. It
 // returns a cancel function that can be used to cancel the registration.
-func (s *UtxoSweeper) waitForSpend(outpoint wire.OutPoint,
+func (s *UtxoSweeper) monitorSpend(outpoint wire.OutPoint,
 	script []byte, heightHint uint32) (func(), error) {
 
 	log.Tracef("Wait for spend of %v at heightHint=%v",
@@ -1611,7 +1611,7 @@ func (s *UtxoSweeper) handleNewInput(input *sweepInputMessage,
 
 	// Start watching for spend of this input, either by us or the remote
 	// party.
-	cancel, err := s.waitForSpend(
+	cancel, err := s.monitorSpend(
 		outpoint, input.input.SignDesc().Output.PkScript,
 		input.input.HeightHint(),
 	)

--- a/sweep/sweeper_test.go
+++ b/sweep/sweeper_test.go
@@ -127,15 +127,11 @@ func createSweeperTestContext(t *testing.T) *sweeperTestContext {
 	}
 
 	ctx.sweeper = New(&UtxoSweeperConfig{
-		Notifier: notifier,
-		Wallet:   backend,
-		NewBatchTimer: func() <-chan time.Time {
-			c := make(chan time.Time, 1)
-			ctx.timeoutChan <- c
-			return c
-		},
-		Store:  store,
-		Signer: &mock.DummySigner{},
+		Notifier:       notifier,
+		Wallet:         backend,
+		TickerDuration: 100 * time.Millisecond,
+		Store:          store,
+		Signer:         &mock.DummySigner{},
 		GenSweepScript: func() ([]byte, error) {
 			script := make([]byte, input.P2WPKHSize)
 			script[0] = 0

--- a/sweep/sweeper_test.go
+++ b/sweep/sweeper_test.go
@@ -2150,7 +2150,7 @@ func TestFeeRateForPreference(t *testing.T) {
 		return 0, dummyErr
 	}
 
-	// Set the relay fee rate to be 1.
+	// Set the relay fee rate to be 1 sat/kw.
 	s.relayFeeRate = 1
 
 	// smallFeeFunc is a mock over DetermineFeePerKw that always return a
@@ -2198,7 +2198,7 @@ func TestFeeRateForPreference(t *testing.T) {
 			expectedErr: ErrNoFeePreference,
 		},
 		{
-			// When an error is returned from the fee determinor,
+			// When an error is returned from the fee determiner,
 			// we should return it.
 			name:              "error from DetermineFeePerKw",
 			feePref:           FeePreference{FeeRate: 1},


### PR DESCRIPTION
Depends on some of the test framework from,
- #7965 
- #7824

Fixes #7972 and possible #7181

This PR removes a possible case that when sweeping new and old inputs, the new inputs may end up in a second transaction which accidentally attempts an RBF(and fails). It also refactors the sweeper and simplified the ticker logic, preparing for incoming refactors.
