### PR TITLE
multi: fix peer unit test and disable `paralleltest`

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -147,6 +147,7 @@ linters:
     - deadcode
     - nosnakecase
 
+
     # Disable gofumpt as it has weird behavior regarding formatting multiple
     # lines for a function which is in conflict with our contribution
     # guidelines. See https://github.com/mvdan/gofumpt/issues/235.
@@ -201,6 +202,10 @@ linters:
     # will also catch magic numbers that make sense to extract.
     - gomnd
 
+      # Some of the tests cannot be parallelized. On the other hand, we don't
+      # gain much performance with this check so we disable it for now until
+      # unit tests become our CI bottleneck.
+    - paralleltest
 
 issues:
   # Only show newly introduced problems.
@@ -257,10 +262,6 @@ issues:
     - path: lnd\.go
       linters:
         - forbidigo
-
-    - path: itest/.*
-      linters:
-        - paralleltest
 
     - path: lnmock/*
       linters:

--- a/funding/manager_test.go
+++ b/funding/manager_test.go
@@ -1579,7 +1579,6 @@ func TestFundingManagerNormalWorkflow(t *testing.T) {
 		},
 	}
 
-	//nolint:paralleltest
 	for _, testCase := range testCases {
 		t.Run(testCase.typeName, func(t *testing.T) {
 			testNormalWorkflow(t, testCase.chanType)
@@ -4747,7 +4746,6 @@ func TestFundingManagerZeroConf(t *testing.T) {
 		},
 	}
 
-	//nolint:paralleltest
 	for _, testCase := range testCases {
 		t.Run(testCase.typeName, func(t *testing.T) {
 			testZeroConf(t, testCase.chanType)

--- a/input/taproot_test.go
+++ b/input/taproot_test.go
@@ -839,7 +839,7 @@ func TestTaprootReceiverHtlcSpend(t *testing.T) {
 			valid: false,
 		},
 	}
-	for i, testCase := range testCases { //nolint:paralleltest
+	for i, testCase := range testCases {
 		i := i
 		testCase := testCase
 		spendTxCopy := spendTx.Copy()
@@ -1140,7 +1140,7 @@ func TestTaprootCommitScriptToSelf(t *testing.T) {
 		},
 	}
 
-	for i, testCase := range testCases { //nolint:paralleltest
+	for i, testCase := range testCases {
 		i := i
 		testCase := testCase
 		spendTxCopy := spendTx.Copy()
@@ -1317,7 +1317,7 @@ func TestTaprootCommitScriptRemote(t *testing.T) {
 		},
 	}
 
-	for i, testCase := range testCases { //nolint:paralleltest
+	for i, testCase := range testCases {
 		i := i
 		testCase := testCase
 		spendTxCopy := spendTx.Copy()
@@ -1536,7 +1536,7 @@ func TestTaprootAnchorScript(t *testing.T) {
 		},
 	}
 
-	for i, testCase := range testCases { //nolint:paralleltest
+	for i, testCase := range testCases {
 		i := i
 		testCase := testCase
 		spendTxCopy := spendTx.Copy()
@@ -1833,7 +1833,7 @@ func TestTaprootSecondLevelHtlcScript(t *testing.T) {
 		},
 	}
 
-	for i, testCase := range testCases { //nolint:paralleltest
+	for i, testCase := range testCases {
 		i := i
 		testCase := testCase
 		spendTxCopy := spendTx.Copy()

--- a/lnwallet/channel_test.go
+++ b/lnwallet/channel_test.go
@@ -371,7 +371,7 @@ func TestSimpleAddSettleWorkflow(t *testing.T) {
 		})
 	}
 
-	t.Run("anchors", func(t *testing.T) { //nolint:paralleltest
+	t.Run("anchors", func(t *testing.T) {
 		testAddSettleWorkflow(
 			t, true,
 			channeldb.AnchorOutputsBit|channeldb.ZeroHtlcTxFeeBit,
@@ -379,13 +379,12 @@ func TestSimpleAddSettleWorkflow(t *testing.T) {
 		)
 	})
 
-	t.Run("taproot", func(t *testing.T) { //nolint:paralleltest
+	t.Run("taproot", func(t *testing.T) {
 		testAddSettleWorkflow(
 			t, true, channeldb.SimpleTaprootFeatureBit, false,
 		)
 	})
 
-	//nolint:paralleltest
 	t.Run("storeFinalHtlcResolutions=true", func(t *testing.T) {
 		testAddSettleWorkflow(t, false, 0, true)
 	})
@@ -819,7 +818,7 @@ func TestForceClose(t *testing.T) {
 			anchorAmt:            anchorSize * 2,
 		})
 	})
-	t.Run("taproot", func(t *testing.T) { //nolint:paralleltest
+	t.Run("taproot", func(t *testing.T) {
 		testForceClose(t, &forceCloseTestCase{
 			chanType: channeldb.SingleFunderTweaklessBit |
 				channeldb.AnchorOutputsBit |
@@ -3594,10 +3593,10 @@ func testChanSyncOweRevocation(t *testing.T, chanType channeldb.ChannelType) {
 func TestChanSyncOweRevocation(t *testing.T) {
 	t.Parallel()
 
-	t.Run("tweakless", func(t *testing.T) { //nolint:paralleltest
+	t.Run("tweakless", func(t *testing.T) {
 		testChanSyncOweRevocation(t, channeldb.SingleFunderTweaklessBit)
 	})
-	t.Run("taproot", func(t *testing.T) { //nolint:paralleltest
+	t.Run("taproot", func(t *testing.T) {
 		taprootBits := channeldb.SimpleTaprootFeatureBit |
 			channeldb.AnchorOutputsBit |
 			channeldb.ZeroHtlcTxFeeBit |
@@ -3777,12 +3776,12 @@ func testChanSyncOweRevocationAndCommit(t *testing.T,
 func TestChanSyncOweRevocationAndCommit(t *testing.T) {
 	t.Parallel()
 
-	t.Run("tweakless", func(t *testing.T) { //nolint:paralleltest
+	t.Run("tweakless", func(t *testing.T) {
 		testChanSyncOweRevocationAndCommit(
 			t, channeldb.SingleFunderTweaklessBit,
 		)
 	})
-	t.Run("taproot", func(t *testing.T) { //nolint:paralleltest
+	t.Run("taproot", func(t *testing.T) {
 		taprootBits := channeldb.SimpleTaprootFeatureBit |
 			channeldb.AnchorOutputsBit |
 			channeldb.ZeroHtlcTxFeeBit |
@@ -4006,12 +4005,12 @@ func testChanSyncOweRevocationAndCommitForceTransition(t *testing.T,
 func TestChanSyncOweRevocationAndCommitForceTransition(t *testing.T) {
 	t.Parallel()
 
-	t.Run("tweakless", func(t *testing.T) { //nolint:paralleltest
+	t.Run("tweakless", func(t *testing.T) {
 		testChanSyncOweRevocationAndCommitForceTransition(
 			t, channeldb.SingleFunderTweaklessBit,
 		)
 	})
-	t.Run("taproot", func(t *testing.T) { //nolint:paralleltest
+	t.Run("taproot", func(t *testing.T) {
 		taprootBits := channeldb.SimpleTaprootFeatureBit |
 			channeldb.AnchorOutputsBit |
 			channeldb.ZeroHtlcTxFeeBit |

--- a/lnwallet/musig_session_test.go
+++ b/lnwallet/musig_session_test.go
@@ -228,7 +228,7 @@ func TestMusigSesssion(t *testing.T) {
 	// commitment, and one for the remote commitment.
 	muSessions := newMuSessionHarness(t)
 
-	t.Run("session_round_trips", func(t *testing.T) { //nolint:paralleltest
+	t.Run("session_round_trips", func(t *testing.T) {
 		const numRounds = 10
 		for i := 0; i < numRounds; i++ {
 			// We'll now simulate a full commitment dance.
@@ -262,7 +262,7 @@ func TestMusigSesssion(t *testing.T) {
 		}
 	})
 
-	t.Run("no_finalize_error", func(t *testing.T) { //nolint:paralleltest
+	t.Run("no_finalize_error", func(t *testing.T) {
 		// If a local party attempts to sign for their local commitment
 		// without finalizing first, they'll get this error.
 		_, err := muSessions.aliceSession.LocalSession.SignCommit(

--- a/lnwallet/rebroadcaster_test.go
+++ b/lnwallet/rebroadcaster_test.go
@@ -131,7 +131,7 @@ func TestWalletRebroadcaster(t *testing.T) {
 		ChainIO:          chainIO,
 	}
 
-	t.Run("rebroadcast bypass", func(t *testing.T) { //nolint:paralleltest
+	t.Run("rebroadcast bypass", func(t *testing.T) {
 		// We'll make a copy of the config, but without the
 		// broadcaster.
 		testCfg := *cfg
@@ -166,7 +166,7 @@ func TestWalletRebroadcaster(t *testing.T) {
 		require.NoError(t, err)
 	})
 
-	t.Run("rebroadcast normal", func(t *testing.T) { //nolint:paralleltest
+	t.Run("rebroadcast normal", func(t *testing.T) {
 		wallet, err := NewLightningWallet(*cfg)
 		require.NoError(t, err)
 		require.NoError(t, wallet.Startup())

--- a/peer/brontide_test.go
+++ b/peer/brontide_test.go
@@ -1267,18 +1267,6 @@ func TestHandleRemovePendingChannel(t *testing.T) {
 	chanIDNotExist := lnwire.ChannelID{1}
 	chanIDPending := lnwire.ChannelID{2}
 
-	// Create a test brontide.
-	dummyConfig := Config{}
-	peer := NewBrontide(dummyConfig)
-
-	// Create the test state.
-	peer.activeChannels.Store(chanIDActive, &lnwallet.LightningChannel{})
-	peer.activeChannels.Store(chanIDPending, nil)
-
-	// Assert test state, we should have two channels store, one active and
-	// one pending.
-	require.Equal(t, 2, peer.activeChannels.Len())
-
 	testCases := []struct {
 		name   string
 		chanID lnwire.ChannelID
@@ -1314,8 +1302,23 @@ func TestHandleRemovePendingChannel(t *testing.T) {
 			err:       errChan,
 		}
 
+		// Create a test brontide.
+		dummyConfig := Config{}
+		peer := NewBrontide(dummyConfig)
+
+		// Create the test state.
+		peer.activeChannels.Store(
+			chanIDActive, &lnwallet.LightningChannel{},
+		)
+		peer.activeChannels.Store(chanIDPending, nil)
+
+		// Assert test state, we should have two channels store, one
+		// active and one pending.
+		require.Equal(t, 2, peer.activeChannels.Len())
+
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
+
 			require := require.New(t)
 
 			// Get the number of channels before mutating the


### PR DESCRIPTION
Running the test locally,
`make unit log="stdlog debug" pkg=peer case=TestHandleRemovePendingChannel timeout=1m`
gives the following error
```
 Running unit tests.
go test -tags="dev stdlog debug"  -test.run=TestHandleRemovePendingChannel -test.timeout=1m github.com/lightningnetwork/lnd/peer
2023-10-12 23:53:15.863 [ERR] PEER: Peer(000000000000000000000000000000000000000000000000000000000000000000): Channel(0000000000000000000000000000000000000000000000000000000000000000) is active, ignoring remove request
2023-10-12 23:53:15.863 [WRN] PEER: Peer(000000000000000000000000000000000000000000000000000000000000000000): Channel(0100000000000000000000000000000000000000000000000000000000000000) not found, removing it anyway
--- FAIL: TestHandleRemovePendingChannel (0.00s)
    --- FAIL: TestHandleRemovePendingChannel/noop_on_active_channel (0.00s)
        brontide_test.go:1334: 
                Error Trace:    /Users/yong/Projects/lightning_labs/lnd/peer/brontide_test.go:1334
                Error:          Not equal: 
                                expected: 2
                                actual  : 1
                Test:           TestHandleRemovePendingChannel/noop_on_active_channel
    --- FAIL: TestHandleRemovePendingChannel/noop_on_non-exist_channel (0.00s)
        brontide_test.go:1334: 
                Error Trace:    /Users/yong/Projects/lightning_labs/lnd/peer/brontide_test.go:1334
                Error:          Not equal: 
                                expected: 2
                                actual  : 1
                Test:           TestHandleRemovePendingChannel/noop_on_non-exist_channel
FAIL
FAIL    github.com/lightningnetwork/lnd/peer    0.495s
FAIL
make: *** [unit] Error 1
```

This is due to the test cannot be parallelized. We also remove this linter as it doesn't help much.