### PR TITLE
multi: skip InitRemoteMusigNonces if we've already called it

### DIFF
--- a/docs/release-notes/release-notes-0.17.1.md
+++ b/docs/release-notes/release-notes-0.17.1.md
@@ -23,6 +23,9 @@
   bit when sending `update_fail_malformed_htlc`. This avoids a force close
   with other implementations.
 
+* A bug that would cause taproot channels to sometimes not display as active
+  [has been fixed](https://github.com/lightningnetwork/lnd/pull/8104).
+
 # New Features
 ## Functional Enhancements
 
@@ -67,4 +70,5 @@
 
 # Contributors (Alphabetical Order)
 * Eugene Siegel
+* Olaoluwa Osuntokun
 * Yong Yu

--- a/itest/list_on_test.go
+++ b/itest/list_on_test.go
@@ -463,6 +463,10 @@ var allTestCases = []*lntest.TestCase{
 		TestFunc: testTaproot,
 	},
 	{
+		Name:     "simple taproot channel activation",
+		TestFunc: testSimpleTaprootChannelActivation,
+	},
+	{
 		Name:     "wallet import account",
 		TestFunc: testWalletImportAccount,
 	},

--- a/itest/lnd_open_channel_test.go
+++ b/itest/lnd_open_channel_test.go
@@ -768,3 +768,57 @@ func testFundingExpiryBlocksOnPending(ht *lntest.HarnessTest) {
 	chanPoint := lntest.ChanPointFromPendingUpdate(update)
 	ht.CloseChannel(alice, chanPoint)
 }
+
+// testSimpleTaprootChannelActivation ensures that a simple taproot channel is
+// active if the initiator disconnects and reconnects in between channel opening
+// and channel confirmation.
+func testSimpleTaprootChannelActivation(ht *lntest.HarnessTest) {
+	simpleTaprootChanArgs := lntest.NodeArgsForCommitType(
+		lnrpc.CommitmentType_SIMPLE_TAPROOT,
+	)
+
+	// Make the new set of participants.
+	alice := ht.NewNode("alice", simpleTaprootChanArgs)
+	defer ht.Shutdown(alice)
+	bob := ht.NewNode("bob", simpleTaprootChanArgs)
+	defer ht.Shutdown(bob)
+
+	ht.FundCoins(btcutil.SatoshiPerBitcoin, alice)
+
+	// Make sure Alice and Bob are connected.
+	ht.EnsureConnected(alice, bob)
+
+	// Create simple taproot channel opening parameters.
+	params := lntest.OpenChannelParams{
+		FundMax:        true,
+		CommitmentType: lnrpc.CommitmentType_SIMPLE_TAPROOT,
+		Private:        true,
+	}
+
+	// Alice opens the channel to Bob.
+	pendingChan := ht.OpenChannelAssertPending(alice, bob, params)
+
+	// We'll create the channel point to be able to close the channel once
+	// our test is done.
+	chanPoint := &lnrpc.ChannelPoint{
+		FundingTxid: &lnrpc.ChannelPoint_FundingTxidBytes{
+			FundingTxidBytes: pendingChan.Txid,
+		},
+		OutputIndex: pendingChan.OutputIndex,
+	}
+
+	// We disconnect and reconnect Alice and Bob before the channel is
+	// confirmed. Our expectation is that the channel is active once the
+	// channel is confirmed.
+	ht.DisconnectNodes(alice, bob)
+	ht.EnsureConnected(alice, bob)
+
+	// Mine six blocks to confirm the channel funding transaction.
+	ht.MineBlocksAndAssertNumTxes(6, 1)
+
+	// Verify that Alice sees an active channel to Bob.
+	ht.AssertChannelActive(alice, chanPoint)
+
+	// Our test is done and Alice closes her channel to Bob.
+	ht.CloseChannel(alice, chanPoint)
+}

--- a/lntest/harness_assertion.go
+++ b/lntest/harness_assertion.go
@@ -352,6 +352,31 @@ func (h *HarnessTest) AssertTopologyChannelOpen(hn *node.HarnessNode,
 func (h *HarnessTest) AssertChannelExists(hn *node.HarnessNode,
 	cp *lnrpc.ChannelPoint) *lnrpc.Channel {
 
+	return h.assertChannelStatus(hn, cp, true)
+}
+
+// AssertChannelActive checks if a channel identified by the specified channel
+// point is active.
+func (h *HarnessTest) AssertChannelActive(hn *node.HarnessNode,
+	cp *lnrpc.ChannelPoint) *lnrpc.Channel {
+
+	return h.assertChannelStatus(hn, cp, true)
+}
+
+// AssertChannelInactive checks if a channel identified by the specified channel
+// point is inactive.
+func (h *HarnessTest) AssertChannelInactive(hn *node.HarnessNode,
+	cp *lnrpc.ChannelPoint) *lnrpc.Channel {
+
+	return h.assertChannelStatus(hn, cp, false)
+}
+
+// assertChannelStatus asserts that a channel identified by the specified
+// channel point exists from the point-of-view of the node and that it is either
+// active or inactive depending on the value of the active parameter.
+func (h *HarnessTest) assertChannelStatus(hn *node.HarnessNode,
+	cp *lnrpc.ChannelPoint, active bool) *lnrpc.Channel {
+
 	var (
 		channel *lnrpc.Channel
 		err     error
@@ -364,11 +389,12 @@ func (h *HarnessTest) AssertChannelExists(hn *node.HarnessNode,
 		}
 
 		// Check whether the channel is active, exit early if it is.
-		if channel.Active {
+		if channel.Active == active {
 			return nil
 		}
 
-		return fmt.Errorf("channel point not active")
+		return fmt.Errorf("expected channel_active=%v, got %v",
+			active, channel.Active)
 	}, DefaultTimeout)
 
 	require.NoErrorf(h, err, "%s: timeout checking for channel point: %v",

--- a/peer/brontide.go
+++ b/peer/brontide.go
@@ -3824,23 +3824,30 @@ func (p *Brontide) addActiveChannel(c *lnpeer.NewChannel) error {
 	chanPoint := &c.FundingOutpoint
 	chanID := lnwire.NewChanIDFromOutPoint(chanPoint)
 
-	// If not already active, we'll add this channel to the set of active
-	// channels, so we can look it up later easily according to its channel
-	// ID.
-	lnChan, err := lnwallet.NewLightningChannel(
-		p.cfg.Signer, c.OpenChannel,
-		p.cfg.SigPool, c.ChanOpts...,
-	)
-	if err != nil {
-		return fmt.Errorf("unable to create LightningChannel: %w", err)
-	}
-
 	// If we've reached this point, there are two possible scenarios.  If
 	// the channel was in the active channels map as nil, then it was
 	// loaded from disk and we need to send reestablish. Else, it was not
 	// loaded from disk and we don't need to send reestablish as this is a
 	// fresh channel.
 	shouldReestablish := p.isLoadedFromDisk(chanID)
+
+	chanOpts := c.ChanOpts
+	if shouldReestablish {
+		// If we have to do the reestablish dance for this channel,
+		// ensure that we don't try to call InitRemoteMusigNonces twice
+		// by calling SkipNonceInit.
+		chanOpts = append(chanOpts, lnwallet.WithSkipNonceInit())
+	}
+
+	// If not already active, we'll add this channel to the set of active
+	// channels, so we can look it up later easily according to its channel
+	// ID.
+	lnChan, err := lnwallet.NewLightningChannel(
+		p.cfg.Signer, c.OpenChannel, p.cfg.SigPool, chanOpts...,
+	)
+	if err != nil {
+		return fmt.Errorf("unable to create LightningChannel: %w", err)
+	}
 
 	// Store the channel in the activeChannels map.
 	p.activeChannels.Store(chanID, lnChan)


### PR DESCRIPTION
Prior to this commit, taproot channels had a bug:

- If a disconnect happened before `peer.AddNewChannel` was called, then the subsequent reconnect would call `peer.AddNewChannel` and attempt the ChannelReestablish dance.

- `peer.AddNewChannel` would call `NewLightningChannel` with populated nonce ChannelOpts. This in turn would call `InitRemoteMusigNonces` which would create a new musig pair session and set the channel's `pendingVerificationNonce` to nil.

- During the reestablish dance, `ProcessChanSyncMsg` would be called. This would also call `InitRemoteMusigNonces`, except it would fail since `pendingVerificationNonce` was set to nil in the previous invocation.

To fix this, a new function `SkipNonceInit` is exposed on `LightningChannel` that will skip the next call to `InitRemoteMusigNonces` in `ProcessChanSyncMsg`.

Fixes #8065 

Addresses review comments from  https://github.com/lightningnetwork/lnd/pull/8078