### PR TITLE
Macaroon: Add Handler Panic to solve the crash bug when Macaroon Auth…

### DIFF
--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -263,7 +263,7 @@ release builds & installation.
 You can specify a custom set of tags when installing from source using the `tags=""` parameter. For example:
 
 ```shell
-make install tags="signrpc walletrpc routerrpc invoicesrpc"
+make install tags="signrpc walletrpc routerrpc chainrpc invoicesrpc"
 ```
 
 **Updating**

--- a/macaroons/service.go
+++ b/macaroons/service.go
@@ -200,6 +200,7 @@ func (svc *Service) ValidateMacaroon(ctx context.Context,
 func (svc *Service) CheckMacAuth(ctx context.Context, macBytes []byte,
 	requiredPermissions []bakery.Op, fullMethod string) error {
 
+	defer handlePanic()
 	// With the macaroon obtained, we'll now unmarshal it from binary into
 	// its concrete struct representation.
 	mac := &macaroon.Macaroon{}
@@ -357,4 +358,10 @@ func SafeCopyMacaroon(mac *macaroon.Macaroon) (*macaroon.Macaroon, error) {
 	}
 
 	return newMac, nil
+}
+
+func handlePanic() {
+	if r := recover(); r != nil {
+		fmt.Errorf("Recovered from panic in macaroon auth:", r)
+	}
 }


### PR DESCRIPTION
```

2023-10-21 12:29:58.043 [INF] DISC: Attempting to bootstrap with: BOLT-0010 DNS Seed: [[nodes.lightning.directory soa.nodes.lightning.directory] [lseed.bitcoinstats.com ]]
panic: runtime error: index out of range [0] with length 0

goroutine 488 [running]:
gopkg.in/macaroon-bakery.v2/bakery.(*Oven).decodeMacaroonId(0x14001a4b248?, {0x0?, 0x140008e5c98?, 0x18?})
	/Users/max/go/pkg/mod/gopkg.in/macaroon-bakery.v2@v2.0.1/bakery/oven.go:140 +0x58c
gopkg.in/macaroon-bakery.v2/bakery.(*Oven).VerifyMacaroon(0x14001acc240, {0x101988720, 0x140008e2390}, {0x14000424390, 0x1, 0x1})
	/Users/max/go/pkg/mod/gopkg.in/macaroon-bakery.v2@v2.0.1/bakery/oven.go:113 +0xcc
gopkg.in/macaroon-bakery.v2/bakery.(*AuthChecker).initOnceFunc(0x14000423280, {0x101988720, 0x140008e2390})
	/Users/max/go/pkg/mod/gopkg.in/macaroon-bakery.v2@v2.0.1/bakery/checker.go:176 +0x120
gopkg.in/macaroon-bakery.v2/bakery.(*AuthChecker).init.func1()
	/Users/max/go/pkg/mod/gopkg.in/macaroon-bakery.v2@v2.0.1/bakery/checker.go:167 +0x2c
sync.(*Once).doSlow(0x14001a4b438?, 0x100fcb974?)
	/opt/homebrew/opt/go/libexec/src/sync/once.go:74 +0x104
sync.(*Once).Do(...)
	/opt/homebrew/opt/go/libexec/src/sync/once.go:65
gopkg.in/macaroon-bakery.v2/bakery.(*AuthChecker).init(0x14000423280?, {0x101988720?, 0x140008e2390?})
	/Users/max/go/pkg/mod/gopkg.in/macaroon-bakery.v2@v2.0.1/bakery/checker.go:166 +0x64
gopkg.in/macaroon-bakery.v2/bakery.(*AuthChecker).newAllowContext(0x14000423280, {0x101988720, 0x140008e2390}, {0x140005323a0, 0x1, 0x80?})
	/Users/max/go/pkg/mod/gopkg.in/macaroon-bakery.v2@v2.0.1/bakery/checker.go:277 +0x234
gopkg.in/macaroon-bakery.v2/bakery.(*AuthChecker).Allow(0x14000423280, {0x101988720, 0x140008e2390}, {0x140005323a0, 0x1, 0x1})
	/Users/max/go/pkg/mod/gopkg.in/macaroon-bakery.v2@v2.0.1/bakery/checker.go:316 +0x38
github.com/lightningnetwork/lnd/macaroons.(*Service).CheckMacAuth(0x14000aec300, {0x101988720, 0x140008e2390}, {0x14000757000, 0x1d5, 0x5?}, {0x140005323a0, 0x1, 0x1}, {0x1012a58d4, ...})
	/Users/max/workspaces/lnd/lnd/macaroons/service.go:214 +0x1bc
github.com/lightningnetwork/lnd/macaroons.(*Service).ValidateMacaroon(0x1017128c0?, {0x101988720, 0x140008e2390}, {0x140005323a0, 0x1, 0x1}, {0x1012a58d4, 0x1b})
	/Users/max/workspaces/lnd/lnd/macaroons/service.go:193 +0xc4
github.com/lightningnetwork/lnd/rpcperms.(*InterceptorChain).checkMacaroon(0x140003434a0, {0x101988720, 0x140008e2390}, {0x1012a58d4, 0x1b})
	/Users/max/workspaces/lnd/lnd/rpcperms/interceptor.go:674 +0x274
github.com/lightningnetwork/lnd/rpcperms.(*InterceptorChain).MacaroonUnaryServerInterceptor.func1({0x101988720, 0x140008e2390}, {0x1018603c0, 0x140008b56c0}, 0x1?, 0x1400059e8e0)
	/Users/max/workspaces/lnd/lnd/rpcperms/interceptor.go:685 +0x54
github.com/grpc-ecosystem/go-grpc-middleware.ChainUnaryServer.func1.1.1({0x101988720?, 0x140008e2390?}, {0x1018603c0?, 0x140008b56c0?})
	/Users/max/go/pkg/mod/github.com/grpc-ecosystem/go-grpc-middleware@v1.3.0/chain.go:25 +0x3c
github.com/lightningnetwork/lnd/rpcperms.(*InterceptorChain).rpcStateUnaryServerInterceptor.func1({0x101988720, 0x140008e2390}, {0x1018603c0, 0x140008b56c0}, 0x1400059e8c0, 0x1400059e900)
	/Users/max/workspaces/lnd/lnd/rpcperms/interceptor.go:781 +0x114
github.com/grpc-ecosystem/go-grpc-middleware.ChainUnaryServer.func1.1.1({0x101988720?, 0x140008e2390?}, {0x1018603c0?, 0x140008b56c0?})
	/Users/max/go/pkg/mod/github.com/grpc-ecosystem/go-grpc-middleware@v1.3.0/chain.go:25 +0x3c
github.com/lightningnetwork/lnd/rpcperms.errorLogUnaryServerInterceptor.func1({0x101988720?, 0x140008e2390?}, {0x1018603c0?, 0x140008b56c0?}, 0x1400059e8c0, 0x1400059e8c0?)
	/Users/max/workspaces/lnd/lnd/rpcperms/interceptor.go:605 +0x48
github.com/grpc-ecosystem/go-grpc-middleware.ChainUnaryServer.func1.1.1({0x101988720?, 0x140008e2390?}, {0x1018603c0?, 0x140008b56c0?})
	/Users/max/go/pkg/mod/github.com/grpc-ecosystem/go-grpc-middleware@v1.3.0/chain.go:25 +0x3c
github.com/grpc-ecosystem/go-grpc-middleware.ChainUnaryServer.func1({0x101988720, 0x140008e2390}, {0x1018603c0, 0x140008b56c0}, 0x14000809a28?, 0x100fa4364?)
	/Users/max/go/pkg/mod/github.com/grpc-ecosystem/go-grpc-middleware@v1.3.0/chain.go:34 +0xb8
github.com/lightningnetwork/lnd/lnrpc._Lightning_NewAddress_Handler({0x101968f80?, 0x14000240300}, {0x101988720, 0x140008e2390}, 0x1400058cee0, 0x1400050f260)
	/Users/max/workspaces/lnd/lnd/lnrpc/lightning_grpc.pb.go:2098 +0x138
google.golang.org/grpc.(*Server).processUnaryRPC(0x140000fa1e0, {0x101991cf8, 0x14000980680}, 0x140001fdb00, 0x1400050f4a0, 0x1023ee728, 0x0)
	/Users/max/go/pkg/mod/google.golang.org/grpc@v1.53.0/server.go:1336 +0xbac
google.golang.org/grpc.(*Server).handleStream(0x140000fa1e0, {0x101991cf8, 0x14000980680}, 0x140001fdb00, 0x0)
	/Users/max/go/pkg/mod/google.golang.org/grpc@v1.53.0/server.go:1704 +0x82c
google.golang.org/grpc.(*Server).serveStreams.func1.2()
	/Users/max/go/pkg/mod/google.golang.org/grpc@v1.53.0/server.go:965 +0x84
created by google.golang.org/grpc.(*Server).serveStreams.func1
	/Users/max/go/pkg/mod/google.golang.org/grpc@v1.53.0/server.go:963 +0x28c
❯
❯
❯ ./start-lnd.sh
```


When I use REST API to invoke service, the bug cause LND node crash and shutdown.

```
import base64, codecs, json, requests

REST_HOST = 'localhost:8080'
MACAROON_PATH = 'your_macaroon.macaroon'


url = f'https://{REST_HOST}/v1/newaddress'
macaroon = codecs.encode(open(MACAROON_PATH, 'rb').read(), 'hex')
headers = {'Grpc-Metadata-macaroon': macaroon}
r = requests.get(url, headers=headers, verify=False)
print(r.json())
```


and I found the [macaroon-bakery](https://github.com/go-macaroon-bakery/macaroon-bakery/blob/6b59d06e7a1f56ea2009a8c27df8dc393d97a8ad/bakery/oven.go#L140) panic.

this means is use a fake macaroon file to invoke the service, all the lnd nodes will be crashed and shutdown.
<img width="1157" alt="Screenshot 2023-10-21 at 1 41 57 PM" src="https://github.com/lightningnetwork/lnd/assets/137863052/966d1f0f-9d40-42a0-a78b-dad599bb6101">
