### PR TITLE
add release build and go report status badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,10 @@
 ## Lightning Network Daemon
 
-[![Build Status](https://img.shields.io/travis/lightningnetwork/lnd.svg)](https://travis-ci.org/lightningnetwork/lnd)
+[![Release build](https://github.com/lightningnetwork/lnd/actions/workflows/release.yaml/badge.svg)](https://github.com/lightningnetwork/lnd/actions/workflows/release.yaml)
 [![MIT licensed](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/lightningnetwork/lnd/blob/master/LICENSE)
 [![Irc](https://img.shields.io/badge/chat-on%20libera-brightgreen.svg)](https://web.libera.chat/#lnd)
 [![Godoc](https://godoc.org/github.com/lightningnetwork/lnd?status.svg)](https://godoc.org/github.com/lightningnetwork/lnd)
+[![Go Report Card](https://goreportcard.com/badge/github.com/lightningnetwork/lnd)](https://goreportcard.com/report/github.com/lightningnetwork/lnd)
 
 <img src="logo.png">
 


### PR DESCRIPTION
## Change Description
*Safe and fast to merge PR*:  
Added the `release build` and `go report` status badges to the readme in order to upgrade docs quality.  
See the outlook in my [fork](https://github.com/R3DRUN3/lnd/blob/master/README.md).

## Steps to Test
No need to test, no code modification.

## Pull Request Checklist
### Testing
- [X] Your PR passes all CI checks.
- [X] Tests covering the positive and negative (error paths) are included.
- [X] Bug fixes contain tests triggering the bug to prevent regressions.

### Code Style and Documentation
- [X] The change obeys the [Code Documentation and Commenting](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#CodeDocumentation) guidelines, and lines wrap at 80.
- [X] Commits follow the [Ideal Git Commit Structure](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#IdealGitCommitStructure).
- [X] Any new logging statements use an appropriate subsystem and logging level.
- [X]  [There is a change description in the release notes](https://github.com/lightningnetwork/lnd/tree/master/docs/release-notes), or `[skip ci]` in the commit message for small changes.