### PR TITLE
multi: fix test flakes in unit tests and itests

### DIFF
--- a/itest/lnd_multi-hop_test.go
+++ b/itest/lnd_multi-hop_test.go
@@ -2166,7 +2166,6 @@ func runExtraPreimageFromRemoteCommit(ht *lntest.HarnessTest,
 	if ht.IsNeutrinoBackend() {
 		// Mine a block to confirm Carol's 2nd level success tx.
 		ht.MineBlocksAndAssertNumTxes(1, 1)
-		numTxesMempool--
 		numBlocks--
 	}
 
@@ -2195,12 +2194,6 @@ func runExtraPreimageFromRemoteCommit(ht *lntest.HarnessTest,
 	// anchor sweep tx in the mempool.
 	case lnrpc.CommitmentType_SCRIPT_ENFORCED_LEASE:
 		numTxesMempool++
-
-		// For neutrino backend, because of the additional block mined,
-		// Bob's output is now mature.
-		if ht.IsNeutrinoBackend() {
-			numTxesMempool++
-		}
 	}
 
 	// Mine a block to clean the mempool.

--- a/lntest/harness.go
+++ b/lntest/harness.go
@@ -1504,11 +1504,13 @@ func (h *HarnessTest) CleanupForceClose(hn *node.HarnessNode) {
 	h.AssertNumPendingForceClose(hn, 1)
 
 	// Mine enough blocks for the node to sweep its funds from the force
-	// closed channel.
+	// closed channel. The commit sweep resolver is able to broadcast the
+	// sweep tx up to one block before the CSV elapses, so wait until
+	// defaulCSV-1.
 	//
-	// The commit sweep resolver is able to broadcast the sweep tx up to
-	// one block before the CSV elapses, so wait until defaulCSV-1.
-	h.MineBlocks(node.DefaultCSV - 1)
+	// NOTE: we might empty blocks here as we don't know the exact number
+	// of blocks to mine. This may end up mining more blocks than needed.
+	h.MineEmptyBlocks(node.DefaultCSV - 1)
 
 	// The node should now sweep the funds, clean up by mining the sweeping
 	// tx.


### PR DESCRIPTION
Fix these flakes,
```
harness_miner.go:218: 
        	Error Trace:	/home/runner/work/lnd/lnd/lntest/harness_miner.go:218
        	            				/home/runner/work/lnd/lnd/lntest/harness.go:1641
        	            				/home/runner/work/lnd/lnd/itest/lnd_multi-hop_test.go:2207
        	            				/home/runner/work/lnd/lnd/itest/lnd_multi-hop_test.go:152
        	Error:      	Received unexpected error:
        	            	want 2, got 3 in mempool: [a7cbb5724e39579cfc75d0469270f691988cb67fcc51a332256cafb193cf40bd b12a03a0622a3cf7d53867f060a6de8166e564a1a3109bc2be1ec0b720f305da 073d66885ccded1a770dc9aa5f1d44c8e10ac4e916e5ab50ef5149a5649ec8ba]
        	Test:       	TestLightningNetworkDaemon/tranche03/130-of-135/neutrino/htlc_timeout_resolver_extract_preimage_remote/zeroconf=false/committype=SIMPLE_TAPROOT
        	Messages:   	assert tx in mempool timeout
    harness.go:339: finished test: htlc_timeout_resolver_extract_preimage_remote, start height=1312, end height=1347, mined blocks=35
    harness.go:345: test failed, skipped cleanup
```

```
harness_miner.go:218: 
        	Error Trace:	/home/runner/work/lnd/lnd/lntest/harness_miner.go:218
        	            				/home/runner/work/lnd/lnd/lntest/harness.go:1641
        	            				/home/runner/work/lnd/lnd/lntest/harness.go:1515
        	            				/home/runner/work/lnd/lnd/itest/lnd_wipe_fwdpkgs_test.go:121
        	            				/home/runner/work/lnd/lnd/lntest/harness.go:286
        	            				/home/runner/work/lnd/lnd/itest/lnd_test.go:136
        	Error:      	Received unexpected error:
        	            	want 1, got 0 in mempool: []
        	Test:       	TestLightningNetworkDaemon/tranche02/91-of-135/neutrino/wipe_forwarding_packages
        	Messages:   	assert tx in mempool timeout
    harness.go:339: finished test: wipe_forwarding_packages, start height=1636, end height=1653, mined blocks=17
```

```
--- FAIL: TestInvoiceExpiryWithRegistry (5.02s)
    invoiceregistry_test.go:1121: 
        	Error Trace:	/home/runner/work/lnd/lnd/invoices/invoiceregistry_test.go:1121
        	Error:      	Condition never satisfied
        	Test:       	TestInvoiceExpiryWithRegistry
```