### PR TITLE
[1/5]sweep: store fee info for published sweeping transactions

### DIFF
--- a/docs/release-notes/release-notes-0.18.0.md
+++ b/docs/release-notes/release-notes-0.18.0.md
@@ -352,6 +352,10 @@
   for SQL backends enabling new users to optionally use  an experimental native
   SQL invoices database.
 
+* [Expanded SweeperStore](https://github.com/lightningnetwork/lnd/pull/8147) to
+  also store the feerate, fees paid, and whether it's published or not for a
+  given sweeping transaction.
+
 ## Code Health
 
 * [Remove database pointers](https://github.com/lightningnetwork/lnd/pull/8117) 

--- a/sweep/store.go
+++ b/sweep/store.go
@@ -39,8 +39,8 @@ type SweeperStore interface {
 	// hash.
 	IsOurTx(hash chainhash.Hash) (bool, error)
 
-	// NotifyPublishTx signals that we are about to publish a tx.
-	NotifyPublishTx(*wire.MsgTx) error
+	// StoreTx stores a tx hash we are about to publish.
+	StoreTx(chainhash.Hash) error
 
 	// ListSweeps lists all the sweeps we have successfully published.
 	ListSweeps() ([]chainhash.Hash, error)
@@ -147,8 +147,8 @@ func migrateTxHashes(tx kvdb.RwTx, txHashesBucket kvdb.RwBucket,
 	return nil
 }
 
-// NotifyPublishTx signals that we are about to publish a tx.
-func (s *sweeperStore) NotifyPublishTx(sweepTx *wire.MsgTx) error {
+// StoreTx stores that we are about to publish a tx.
+func (s *sweeperStore) StoreTx(txid chainhash.Hash) error {
 	return kvdb.Update(s.db, func(tx kvdb.RwTx) error {
 
 		txHashesBucket := tx.ReadWriteBucket(txHashesBucketKey)
@@ -156,9 +156,7 @@ func (s *sweeperStore) NotifyPublishTx(sweepTx *wire.MsgTx) error {
 			return errNoTxHashesBucket
 		}
 
-		hash := sweepTx.TxHash()
-
-		return txHashesBucket.Put(hash[:], []byte{})
+		return txHashesBucket.Put(txid[:], []byte{})
 	}, func() {})
 }
 

--- a/sweep/store.go
+++ b/sweep/store.go
@@ -4,17 +4,19 @@ import (
 	"bytes"
 	"encoding/binary"
 	"errors"
+	"io"
 
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcd/wire"
 	"github.com/lightningnetwork/lnd/kvdb"
+	"github.com/lightningnetwork/lnd/tlv"
 )
 
 var (
 	// txHashesBucketKey is the key that points to a bucket containing the
 	// hashes of all sweep txes that were published successfully.
 	//
-	// maps: txHash -> empty slice
+	// maps: txHash -> TxRecord
 	txHashesBucketKey = []byte("sweeper-tx-hashes")
 
 	// utxnChainPrefix is the bucket prefix for nursery buckets.
@@ -31,7 +33,89 @@ var (
 	byteOrder = binary.BigEndian
 
 	errNoTxHashesBucket = errors.New("tx hashes bucket does not exist")
+
+	// ErrTxNotFound is returned when querying using a txid that's not
+	// found in our db.
+	ErrTxNotFound = errors.New("tx not found")
 )
+
+// TxRecord specifies a record of a tx that's stored in the database.
+type TxRecord struct {
+	// Txid is the sweeping tx's txid, which is used as the key to store
+	// the following values.
+	Txid chainhash.Hash
+
+	// FeeRate is the fee rate of the sweeping tx, unit is sats/kw.
+	FeeRate uint64
+
+	// Fee is the fee of the sweeping tx, unit is sat.
+	Fee uint64
+
+	// Published indicates whether the tx has been published.
+	Published bool
+}
+
+// toTlvStream converts TxRecord into a tlv representation.
+func (t *TxRecord) toTlvStream() (*tlv.Stream, error) {
+	const (
+		// A set of tlv type definitions used to serialize TxRecord.
+		// We define it here instead of the head of the file to avoid
+		// naming conflicts.
+		//
+		// NOTE: A migration should be added whenever the existing type
+		// changes.
+		//
+		// NOTE: Txid is stored as the key, so it's not included here.
+		feeRateType tlv.Type = 0
+		feeType     tlv.Type = 1
+		boolType    tlv.Type = 2
+	)
+
+	return tlv.NewStream(
+		tlv.MakeBigSizeRecord(feeRateType, &t.FeeRate),
+		tlv.MakeBigSizeRecord(feeType, &t.Fee),
+		tlv.MakePrimitiveRecord(boolType, &t.Published),
+	)
+}
+
+// serializeTxRecord serializes a TxRecord based on tlv format.
+func serializeTxRecord(w io.Writer, tx *TxRecord) error {
+	// Create the tlv stream.
+	tlvStream, err := tx.toTlvStream()
+	if err != nil {
+		return err
+	}
+
+	// Encode the tlv stream.
+	var buf bytes.Buffer
+	if err := tlvStream.Encode(&buf); err != nil {
+		return err
+	}
+
+	// Write the tlv stream.
+	if _, err = w.Write(buf.Bytes()); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// deserializeTxRecord deserializes a TxRecord based on tlv format.
+func deserializeTxRecord(r io.Reader) (*TxRecord, error) {
+	var tx TxRecord
+
+	// Create the tlv stream.
+	tlvStream, err := tx.toTlvStream()
+	if err != nil {
+		return nil, err
+	}
+
+	if err := tlvStream.Decode(r); err != nil {
+		return nil, err
+	}
+
+	return &tx, nil
+}
 
 // SweeperStore stores published txes.
 type SweeperStore interface {
@@ -40,7 +124,7 @@ type SweeperStore interface {
 	IsOurTx(hash chainhash.Hash) (bool, error)
 
 	// StoreTx stores a tx hash we are about to publish.
-	StoreTx(chainhash.Hash) error
+	StoreTx(*TxRecord) error
 
 	// ListSweeps lists all the sweeps we have successfully published.
 	ListSweeps() ([]chainhash.Hash, error)
@@ -83,6 +167,8 @@ func NewSweeperStore(db kvdb.Backend, chainHash *chainhash.Hash) (
 
 // migrateTxHashes migrates nursery finalized txes to the tx hashes bucket. This
 // is not implemented as a database migration, to keep the downgrade path open.
+//
+// TODO(yy): delete this function once nursery is removed.
 func migrateTxHashes(tx kvdb.RwTx, txHashesBucket kvdb.RwBucket,
 	chainHash *chainhash.Hash) error {
 
@@ -138,7 +224,24 @@ func migrateTxHashes(tx kvdb.RwTx, txHashesBucket kvdb.RwBucket,
 		log.Debugf("Inserting nursery tx %v in hash list "+
 			"(height=%v)", hash, byteOrder.Uint32(k))
 
-		return txHashesBucket.Put(hash[:], []byte{})
+		// Create the transaction record. Since this is an old record,
+		// we can assume it's already been published. Although it's
+		// possible to calculate the fees and fee rate used here, we
+		// skip it as it's unlikely we'd perform RBF on these old
+		// sweeping transactions.
+		tr := &TxRecord{
+			Txid:      hash,
+			Published: true,
+		}
+
+		// Serialize tx record.
+		var b bytes.Buffer
+		err = serializeTxRecord(&b, tr)
+		if err != nil {
+			return err
+		}
+
+		return txHashesBucket.Put(tr.Txid[:], b.Bytes())
 	})
 	if err != nil {
 		return err
@@ -148,15 +251,21 @@ func migrateTxHashes(tx kvdb.RwTx, txHashesBucket kvdb.RwBucket,
 }
 
 // StoreTx stores that we are about to publish a tx.
-func (s *sweeperStore) StoreTx(txid chainhash.Hash) error {
+func (s *sweeperStore) StoreTx(tr *TxRecord) error {
 	return kvdb.Update(s.db, func(tx kvdb.RwTx) error {
-
 		txHashesBucket := tx.ReadWriteBucket(txHashesBucketKey)
 		if txHashesBucket == nil {
 			return errNoTxHashesBucket
 		}
 
-		return txHashesBucket.Put(txid[:], []byte{})
+		// Serialize tx record.
+		var b bytes.Buffer
+		err := serializeTxRecord(&b, tr)
+		if err != nil {
+			return err
+		}
+
+		return txHashesBucket.Put(tr.Txid[:], b.Bytes())
 	}, func() {})
 }
 

--- a/sweep/store_mock.go
+++ b/sweep/store_mock.go
@@ -41,5 +41,16 @@ func (s *MockSweeperStore) ListSweeps() ([]chainhash.Hash, error) {
 	return txns, nil
 }
 
+// GetTx queries the database to find the tx that matches the given txid.
+// Returns ErrTxNotFound if it cannot be found.
+func (s *MockSweeperStore) GetTx(hash chainhash.Hash) (*TxRecord, error) {
+	return nil, ErrTxNotFound
+}
+
+// DeleteTx removes the given tx from db.
+func (s *MockSweeperStore) DeleteTx(txid chainhash.Hash) error {
+	return nil
+}
+
 // Compile-time constraint to ensure MockSweeperStore implements SweeperStore.
 var _ SweeperStore = (*MockSweeperStore)(nil)

--- a/sweep/store_mock.go
+++ b/sweep/store_mock.go
@@ -25,8 +25,8 @@ func (s *MockSweeperStore) IsOurTx(hash chainhash.Hash) (bool, error) {
 }
 
 // StoreTx stores a tx we are about to publish.
-func (s *MockSweeperStore) StoreTx(txid chainhash.Hash) error {
-	s.ourTxes[txid] = struct{}{}
+func (s *MockSweeperStore) StoreTx(tr *TxRecord) error {
+	s.ourTxes[tr.Txid] = struct{}{}
 
 	return nil
 }

--- a/sweep/store_mock.go
+++ b/sweep/store_mock.go
@@ -2,54 +2,58 @@ package sweep
 
 import (
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"github.com/stretchr/testify/mock"
 )
 
 // MockSweeperStore is a mock implementation of sweeper store. This type is
 // exported, because it is currently used in nursery tests too.
 type MockSweeperStore struct {
-	ourTxes map[chainhash.Hash]struct{}
+	mock.Mock
 }
 
 // NewMockSweeperStore returns a new instance.
 func NewMockSweeperStore() *MockSweeperStore {
-	return &MockSweeperStore{
-		ourTxes: make(map[chainhash.Hash]struct{}),
-	}
+	return &MockSweeperStore{}
 }
 
-// IsOurTx determines whether a tx is published by us, based on its
-// hash.
+// IsOurTx determines whether a tx is published by us, based on its hash.
 func (s *MockSweeperStore) IsOurTx(hash chainhash.Hash) (bool, error) {
-	_, ok := s.ourTxes[hash]
-	return ok, nil
+	args := s.Called(hash)
+
+	return args.Bool(0), args.Error(1)
 }
 
 // StoreTx stores a tx we are about to publish.
 func (s *MockSweeperStore) StoreTx(tr *TxRecord) error {
-	s.ourTxes[tr.Txid] = struct{}{}
-
-	return nil
+	args := s.Called(tr)
+	return args.Error(0)
 }
 
 // ListSweeps lists all the sweeps we have successfully published.
 func (s *MockSweeperStore) ListSweeps() ([]chainhash.Hash, error) {
-	var txns []chainhash.Hash
-	for tx := range s.ourTxes {
-		txns = append(txns, tx)
-	}
+	args := s.Called()
 
-	return txns, nil
+	return args.Get(0).([]chainhash.Hash), args.Error(1)
 }
 
 // GetTx queries the database to find the tx that matches the given txid.
 // Returns ErrTxNotFound if it cannot be found.
 func (s *MockSweeperStore) GetTx(hash chainhash.Hash) (*TxRecord, error) {
-	return nil, ErrTxNotFound
+	args := s.Called(hash)
+
+	tr := args.Get(0)
+	if tr != nil {
+		return args.Get(0).(*TxRecord), args.Error(1)
+	}
+
+	return nil, args.Error(1)
 }
 
 // DeleteTx removes the given tx from db.
 func (s *MockSweeperStore) DeleteTx(txid chainhash.Hash) error {
-	return nil
+	args := s.Called(txid)
+
+	return args.Error(0)
 }
 
 // Compile-time constraint to ensure MockSweeperStore implements SweeperStore.

--- a/sweep/store_mock.go
+++ b/sweep/store_mock.go
@@ -2,7 +2,6 @@ package sweep
 
 import (
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
-	"github.com/btcsuite/btcd/wire"
 )
 
 // MockSweeperStore is a mock implementation of sweeper store. This type is
@@ -25,10 +24,9 @@ func (s *MockSweeperStore) IsOurTx(hash chainhash.Hash) (bool, error) {
 	return ok, nil
 }
 
-// NotifyPublishTx signals that we are about to publish a tx.
-func (s *MockSweeperStore) NotifyPublishTx(tx *wire.MsgTx) error {
-	txHash := tx.TxHash()
-	s.ourTxes[txHash] = struct{}{}
+// StoreTx stores a tx we are about to publish.
+func (s *MockSweeperStore) StoreTx(txid chainhash.Hash) error {
+	s.ourTxes[txid] = struct{}{}
 
 	return nil
 }

--- a/sweep/store_test.go
+++ b/sweep/store_test.go
@@ -50,7 +50,7 @@ func testStore(t *testing.T, createStore func() (SweeperStore, error)) {
 		},
 	})
 
-	err = store.NotifyPublishTx(&tx1)
+	err = store.StoreTx(tx1.TxHash())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -63,7 +63,7 @@ func testStore(t *testing.T, createStore func() (SweeperStore, error)) {
 		},
 	})
 
-	err = store.NotifyPublishTx(&tx2)
+	err = store.StoreTx(tx2.TxHash())
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/sweep/sweeper.go
+++ b/sweep/sweeper.go
@@ -1163,7 +1163,7 @@ func (s *UtxoSweeper) sweep(inputs inputSet, feeRate chainfee.SatPerKWeight,
 	}
 
 	// Create sweep tx.
-	tx, err := createSweepTx(
+	tx, _, err := createSweepTx(
 		inputs, nil, s.currentOutputScript, uint32(currentHeight),
 		feeRate, s.cfg.MaxFeeRate.FeePerKWeight(), s.cfg.Signer,
 	)
@@ -1467,10 +1467,12 @@ func (s *UtxoSweeper) CreateSweepTx(inputs []input.Input, feePref FeePreference,
 		return nil, err
 	}
 
-	return createSweepTx(
+	tx, _, err := createSweepTx(
 		inputs, nil, pkScript, currentBlockHeight, feePerKw,
 		s.cfg.MaxFeeRate.FeePerKWeight(), s.cfg.Signer,
 	)
+
+	return tx, err
 }
 
 // DefaultNextAttemptDeltaFunc is the default calculation for next sweep attempt

--- a/sweep/sweeper.go
+++ b/sweep/sweeper.go
@@ -1176,9 +1176,9 @@ func (s *UtxoSweeper) sweep(inputs inputSet, feeRate chainfee.SatPerKWeight,
 	// publish, we loose track of this tx. Even republication on startup
 	// doesn't prevent this, because that call returns a double spend error
 	// then and would also not add the hash to the store.
-	err = s.cfg.Store.NotifyPublishTx(tx)
+	err = s.cfg.Store.StoreTx(tx.TxHash())
 	if err != nil {
-		return fmt.Errorf("notify publish tx: %w", err)
+		return fmt.Errorf("store tx: %w", err)
 	}
 
 	// Reschedule the inputs that we just tried to sweep. This is done in

--- a/sweep/walletsweep.go
+++ b/sweep/walletsweep.go
@@ -319,7 +319,7 @@ func CraftSweepAllTx(feeRate, maxFeeRate chainfee.SatPerKWeight,
 
 	// Finally, we'll ask the sweeper to craft a sweep transaction which
 	// respects our fee preference and targets all the UTXOs of the wallet.
-	sweepTx, err := createSweepTx(
+	sweepTx, _, err := createSweepTx(
 		inputsToSweep, txOuts, changePkScript, blockHeight,
 		feeRate, maxFeeRate, signer,
 	)


### PR DESCRIPTION
This PR prepares for #8424 by storing fee info in `SweeperStore`. Due to the current data format used, no migration is needed to store this extra info. In addition, two methods, `GetTx` and `DeleteTx` are added to access the database.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Expanded `SweeperStore` functionality to include detailed transaction information such as fee rate, fees paid, and publication status.
	- Introduced `TxRecord` struct for better transaction record management in the database.
	- Added new error `ErrLocktimeConflict` to handle transactions with conflicting `nLockTime` values.
- **Refactor**
	- Renamed functions for better clarity in revocation log handling.
	- Updated `SweeperStore` interface and its mock implementation to enhance testability and functionality.
	- Modified `sweep` function logic in `UtxoSweeper` for improved transaction tracking.
- **Tests**
	- Added and refactored tests for `SweeperStore` to ensure reliability and compatibility with new changes.
- **Documentation**
	- Updated release notes to reflect new features and improvements in version 0.18.0.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->