### PR TITLE
WIPL: fix stuck inflight payments

### DIFF
--- a/htlcswitch/switch.go
+++ b/htlcswitch/switch.go
@@ -428,11 +428,11 @@ func (s *Switch) ProcessContractResolution(msg contractcourt.ResolutionMsg) erro
 	}
 }
 
-// GetAttemptResult returns the result of the payment attempt with the given
+// GetAttemptResult returns the result of the HTLC attempt with the given
 // attemptID. The paymentHash should be set to the payment's overall hash, or
 // in case of AMP payments the payment's unique identifier.
 //
-// The method returns a channel where the payment result will be sent when
+// The method returns a channel where the HTLC attempt result will be sent when
 // available, or an error is encountered during forwarding. When a result is
 // received on the channel, the HTLC is guaranteed to no longer be in flight.
 // The switch shutting down is signaled by closing the channel. If the
@@ -449,9 +449,9 @@ func (s *Switch) GetAttemptResult(attemptID uint64, paymentHash lntypes.Hash,
 		}
 	)
 
-	// If the payment is not found in the circuit map, check whether a
-	// result is already available.
-	// Assumption: no one will add this payment ID other than the caller.
+	// If the HTLC is not found in the circuit map, check whether a result
+	// is already available.
+	// Assumption: no one will add this attempt ID other than the caller.
 	if s.circuits.LookupCircuit(inKey) == nil {
 		res, err := s.networkResults.getResult(attemptID)
 		if err != nil {
@@ -461,7 +461,7 @@ func (s *Switch) GetAttemptResult(attemptID uint64, paymentHash lntypes.Hash,
 		c <- res
 		nChan = c
 	} else {
-		// The payment was committed to the circuits, subscribe for a
+		// The HTLC was committed to the circuits, subscribe for a
 		// result.
 		nChan, err = s.networkResults.subscribeResult(attemptID)
 		if err != nil {
@@ -471,7 +471,7 @@ func (s *Switch) GetAttemptResult(attemptID uint64, paymentHash lntypes.Hash,
 
 	resultChan := make(chan *PaymentResult, 1)
 
-	// Since the payment was known, we can start a goroutine that can
+	// Since the attempt was known, we can start a goroutine that can
 	// extract the result when it is available, and pass it on to the
 	// caller.
 	s.wg.Add(1)
@@ -936,7 +936,7 @@ func (s *Switch) handleLocalResponse(pkt *htlcPacket) {
 	// Store the result to the db. This will also notify subscribers about
 	// the result.
 	if err := s.networkResults.storeResult(attemptID, n); err != nil {
-		log.Errorf("Unable to complete payment for pid=%v: %v",
+		log.Errorf("Unable to store attempt result for pid=%v: %v",
 			attemptID, err)
 		return
 	}

--- a/itest/list_on_test.go
+++ b/itest/list_on_test.go
@@ -546,4 +546,12 @@ var allTestCases = []*lntest.TestCase{
 		Name:     "query blinded route",
 		TestFunc: testQueryBlindedRoutes,
 	},
+	{
+		Name:     "payment failed htlc local swept",
+		TestFunc: testPaymentFailedHTLCLocalSwept,
+	},
+	{
+		Name:     "payment succeeded htlc remote swept",
+		TestFunc: testPaymentSucceededHTLCRemoteSwept,
+	},
 }

--- a/lntest/harness.go
+++ b/lntest/harness.go
@@ -299,6 +299,8 @@ func (h *HarnessTest) resetStandbyNodes(t *testing.T) {
 		// config for the coming test. This will also inherit the
 		// test's running context.
 		h.RestartNodeWithExtraArgs(hn, hn.Cfg.OriginalExtraArgs)
+
+		hn.AddToLogf("Finished test case %v", h.manager.currentTestCase)
 	}
 }
 
@@ -1754,6 +1756,14 @@ func (h *HarnessTest) SendPaymentAssertSettled(hn *node.HarnessNode,
 	req *routerrpc.SendPaymentRequest) *lnrpc.Payment {
 
 	return h.SendPaymentAndAssertStatus(hn, req, lnrpc.Payment_SUCCEEDED)
+}
+
+// SendPaymentAssertInflight sends a payment from the passed node and asserts
+// the payment is inflight.
+func (h *HarnessTest) SendPaymentAssertInflight(hn *node.HarnessNode,
+	req *routerrpc.SendPaymentRequest) *lnrpc.Payment {
+
+	return h.SendPaymentAndAssertStatus(hn, req, lnrpc.Payment_IN_FLIGHT)
 }
 
 // OpenChannelRequest is used to open a channel using the method

--- a/lntest/harness_assertion.go
+++ b/lntest/harness_assertion.go
@@ -1328,48 +1328,6 @@ func (h *HarnessTest) assertHLTCActive(hn *node.HarnessNode,
 	return result
 }
 
-// AssertHLTCNotActive asserts the node doesn't have a pending HTLC in the
-// given channel, which mean either the HTLC never exists, or it was pending
-// and now settled. Returns the HTLC if found and active.
-//
-// NOTE: to check a pending HTLC becoming settled, first use AssertHLTCActive
-// then follow this check.
-func (h *HarnessTest) AssertHLTCNotActive(hn *node.HarnessNode,
-	cp *lnrpc.ChannelPoint, payHash []byte) *lnrpc.HTLC {
-
-	var result *lnrpc.HTLC
-	target := hex.EncodeToString(payHash)
-
-	err := wait.NoError(func() error {
-		// We require the RPC call to be succeeded and won't wait for
-		// it as it's an unexpected behavior.
-		ch := h.GetChannelByChanPoint(hn, cp)
-
-		// Check all payment hashes active for this channel.
-		for _, htlc := range ch.PendingHtlcs {
-			h := hex.EncodeToString(htlc.HashLock)
-
-			// Break if found the htlc.
-			if h == target {
-				result = htlc
-				break
-			}
-		}
-
-		// If we've found nothing, we're done.
-		if result == nil {
-			return nil
-		}
-
-		// Otherwise return an error.
-		return fmt.Errorf("node [%s:%x] still has: the payHash %x",
-			hn.Name(), hn.PubKey[:], payHash)
-	}, DefaultTimeout)
-	require.NoError(h, err, "timeout checking pending HTLC")
-
-	return result
-}
-
 // ReceiveSingleInvoice waits until a message is received on the subscribe
 // single invoice stream or the timeout is reached.
 func (h *HarnessTest) ReceiveSingleInvoice(

--- a/routing/payment_lifecycle.go
+++ b/routing/payment_lifecycle.go
@@ -183,7 +183,7 @@ func (p *paymentLifecycle) resumePayment() ([32]byte, *route.Route, error) {
 	for _, a := range payment.InFlightHTLCs() {
 		a := a
 
-		log.Infof("Resuming payment shard %v for payment %v",
+		log.Infof("Resuming HTLC attempt %v for payment %v",
 			a.AttemptID, p.identifier)
 
 		p.resultCollector(&a)

--- a/routing/router.go
+++ b/routing/router.go
@@ -639,6 +639,10 @@ func (r *ChannelRouter) Start() error {
 
 	// If any payments are still in flight, we resume, to make sure their
 	// results are properly handled.
+	//
+	// TODO(yy): check the HTLCs here, if there's no settled HTLCs, and the
+	// network results of the rest cannot be found, we can fail the payment
+	// here.
 	payments, err := r.cfg.Control.FetchInFlightPayments()
 	if err != nil {
 		return err


### PR DESCRIPTION
This PR attempts to fix #8146 and all its related issues.

The original assumption was, when the HTLC timed out, the attempt result wasn't sent back the payment lifecycle, thus causing the payment to be in stuck. However, this assumption is not true, as shown in the newly added itest - when an outgoing HTLC has timed out, the payment will be marked as failed. Moreover, if the outgoing HTLC is swept by the remote via the preimage path, the payment will be marked as succeeded. All these are expected behavior.

If there's already a result in db, `GetAttemptResult` will return it, so the result must not be found in db. Also notice that, since there's no result in db, the only line we can hit is:
https://github.com/lightningnetwork/lnd/blob/e6fbaafda4a9cfe08ccee5106aa6dc1da62bcebc/htlcswitch/switch.go#L466
as otherwise hitting this line will return the error `ErrPaymentIDNotFound`:
https://github.com/lightningnetwork/lnd/blob/e6fbaafda4a9cfe08ccee5106aa6dc1da62bcebc/htlcswitch/switch.go#L456
And the method `GetAttemptResult` is blocking at line:
https://github.com/lightningnetwork/lnd/blob/e6fbaafda4a9cfe08ccee5106aa6dc1da62bcebc/htlcswitch/switch.go#L456

On the other hand, these network results will be cleaned when `ChannelRouter` starts here:
https://github.com/lightningnetwork/lnd/blob/e6fbaafda4a9cfe08ccee5106aa6dc1da62bcebc/routing/router.go#L657

But this cleanup only applied to terminated payments. For inflight payments, we always keep the network results. This rules out the possibility that the HTLC attempt once had a result but was later removed.

This seems to leave us only one possibility - that the network result was never written to disk, causing an HTLC attempt waiting for its result forever, hence the payment stayed inflight.

Still under investigation, pushing here early in case there are better ideas.