### PR TITLE
routing: launch fetchFundingTx in goroutine so router can exit

### DIFF
--- a/docs/release-notes/release-notes-0.17.3.md
+++ b/docs/release-notes/release-notes-0.17.3.md
@@ -26,6 +26,8 @@
 * [Fixed](https://github.com/lightningnetwork/lnd/pull/8220) a loop variable
   issue which may affect programs built using go `v1.20` and below. 
 
+* [An issue where LND would hang on shutdown has been fixed.](https://github.com/lightningnetwork/lnd/pull/8151)
+
 # New Features
 ## Functional Enhancements
 ## RPC Additions
@@ -47,4 +49,5 @@
 ## Tooling and Documentation
 
 # Contributors (Alphabetical Order)
+* Eugene Siegel
 * Yong Yu

--- a/routing/router.go
+++ b/routing/router.go
@@ -1590,7 +1590,7 @@ func (r *ChannelRouter) processUpdate(msg interface{},
 		// to obtain the full funding outpoint that's encoded within
 		// the channel ID.
 		channelID := lnwire.NewShortChanIDFromInt(msg.ChannelID)
-		fundingTx, err := r.fetchFundingTx(&channelID)
+		fundingTx, err := r.fetchFundingTxWrapper(&channelID)
 		if err != nil {
 			// In order to ensure we don't erroneously mark a
 			// channel as a zombie due to an RPC failure, we'll
@@ -1798,6 +1798,36 @@ func (r *ChannelRouter) processUpdate(msg interface{},
 	}
 
 	return nil
+}
+
+// fetchFundingTxWrapper is a wrapper around fetchFundingTx, except that it
+// will exit if the router has stopped.
+func (r *ChannelRouter) fetchFundingTxWrapper(chanID *lnwire.ShortChannelID) (
+	*wire.MsgTx, error) {
+
+	txChan := make(chan *wire.MsgTx, 1)
+	errChan := make(chan error, 1)
+
+	go func() {
+		tx, err := r.fetchFundingTx(chanID)
+		if err != nil {
+			errChan <- err
+			return
+		}
+
+		txChan <- tx
+	}()
+
+	select {
+	case tx := <-txChan:
+		return tx, nil
+
+	case err := <-errChan:
+		return nil, err
+
+	case <-r.quit:
+		return nil, ErrRouterShuttingDown
+	}
 }
 
 // fetchFundingTx returns the funding transaction identified by the passed


### PR DESCRIPTION
This commit introduces a wrapper function `fetchFundingTxWrapper` which calls `fetchFundingTx` in a goroutine. This is to avoid an issue with pruned nodes where the router is attempting to stop, but the `prunedBlockDispatcher` is waiting to connect to peers that can serve the block. This can cause the shutdown process to hang until we connect to a peer that can send us the block.  Marking as draft for now until I can test this.  I opted for this approach rather than passing in a `quit` channel to `GetBlock`.


See https://github.com/lightningnetwork/lnd/issues/7928#issuecomment-1791061270 for more info