### PR TITLE
contractcourt: log amount if incoming htlc times out

### DIFF
--- a/contractcourt/channel_arbitrator.go
+++ b/contractcourt/channel_arbitrator.go
@@ -1743,10 +1743,10 @@ func (c *ChannelArbitrator) checkCommitChainActions(height uint32,
 				int64(height)
 
 			log.Infof("ChannelArbitrator(%v): go to chain for "+
-				"outgoing htlc %x: timeout=%v, "+
+				"outgoing htlc %x: timeout=%v, amount=%v, "+
 				"blocks_until_expiry=%v, broadcast_delta=%v",
 				c.cfg.ChanPoint, htlc.RHash[:],
-				htlc.RefundTimeout, remainingBlocks,
+				htlc.RefundTimeout, htlc.Amt, remainingBlocks,
 				c.cfg.OutgoingBroadcastDelta,
 			)
 		}
@@ -1778,10 +1778,10 @@ func (c *ChannelArbitrator) checkCommitChainActions(height uint32,
 				int64(height)
 
 			log.Infof("ChannelArbitrator(%v): go to chain for "+
-				"incoming htlc %x: timeout=%v, "+
+				"incoming htlc %x: timeout=%v, amount=%v, "+
 				"blocks_until_expiry=%v, broadcast_delta=%v",
 				c.cfg.ChanPoint, htlc.RHash[:],
-				htlc.RefundTimeout, remainingBlocks,
+				htlc.RefundTimeout, htlc.Amt, remainingBlocks,
 				c.cfg.IncomingBroadcastDelta,
 			)
 		}

--- a/docs/release-notes/release-notes-0.18.0.md
+++ b/docs/release-notes/release-notes-0.18.0.md
@@ -11,6 +11,7 @@
   - [Code Health](#code-health)
   - [Breaking Changes](#breaking-changes)
   - [Performance Improvements](#performance-improvements)
+  - [Misc](#misc)
 - [Technical and Architectural Updates](#technical-and-architectural-updates)
   - [BOLT Spec Updates](#bolt-spec-updates)
   - [Testing](#testing)
@@ -65,6 +66,12 @@
 * [Bool was added](https://github.com/lightningnetwork/lnd/pull/8057) to the
   primitive type of the tlv package.
 
+## Misc
+### Logging
+* [Add the htlc amount](https://github.com/lightningnetwork/lnd/pull/8156) to
+  contract court logs in case of timed-out htlcs in order to easily spot dust
+  outputs.
+
 ## RPC Updates
 
 * [Deprecated](https://github.com/lightningnetwork/lnd/pull/7175)
@@ -114,6 +121,7 @@
 * Elle Mouton
 * Keagan McClelland
 * Matt Morehouse
+* Slyghtning
 * Turtle
 * Ononiwu Maureen Chiamaka
 * Yong Yu


### PR DESCRIPTION
This PR adds logging of the amount of incoming and outcoming HTLCs when they timeout. This helps to identify HTLCs with sub-dust amount.