### PR TITLE
peer: send messages in Start via writeMessage to bypass writeHandler 

### DIFF
--- a/docs/release-notes/release-notes-0.17.1.md
+++ b/docs/release-notes/release-notes-0.17.1.md
@@ -19,6 +19,8 @@
 
 # Bug Fixes
 
+* A bug that caused certain API calls to hang [has been fixed](https://github.com/lightningnetwork/lnd/pull/8158).
+
 * [LND now sets the `BADONION`](https://github.com/lightningnetwork/lnd/pull/7937)
   bit when sending `update_fail_malformed_htlc`. This avoids a force close
   with other implementations.


### PR DESCRIPTION
Without this the following could happen:

* `InboundPeerConnected` is called while we already have an inbound connection with the peer. This calls `removePeer` which calls `Disconnect`.
* If the peer is starting up in Start, it may be sending messages synchronously via `SendMessage(true, ...)`. This eventually calls the `writeMessage` function which will exit if disconnect is set to 1.
* Since `Disconnect` was called, disconnect will be 1 and `writeMessage` will exit, causing `writeHandler` to exit.
* If there is more than 1 message being sent, later messages will queue in `queueHandler` but be unable to get into `sendQueue` as the `writeHandler` goroutine has exited.
* The synchronous sends will be waiting on the `errChan` indefinitely and `startReady` will never get closed meaning `Disconnect` will never proceed.

The end result is that the server's mutex will be held until shutdown.

Tested locally and this does fix the issue.
