### PR TITLE
[2/3]: Support Forwarding of Blinded Payments

### DIFF
--- a/config.go
+++ b/config.go
@@ -626,8 +626,9 @@ func DefaultConfig() Config {
 			RejectCacheSize:  channeldb.DefaultRejectCacheSize,
 			ChannelCacheSize: channeldb.DefaultChannelCacheSize,
 		},
-		Prometheus: lncfg.DefaultPrometheus(),
-		Watchtower: lncfg.DefaultWatchtowerCfg(defaultTowerDir),
+		Prometheus:      lncfg.DefaultPrometheus(),
+		Watchtower:      lncfg.DefaultWatchtowerCfg(defaultTowerDir),
+		ProtocolOptions: lncfg.DefaultProtocol(),
 		HealthChecks: &lncfg.HealthCheckConfig{
 			ChainCheck: &lncfg.CheckConfig{
 				Interval: defaultChainInterval,

--- a/contractcourt/htlc_incoming_contest_resolver_test.go
+++ b/contractcourt/htlc_incoming_contest_resolver_test.go
@@ -6,7 +6,6 @@ import (
 	"io/ioutil"
 	"testing"
 
-	"github.com/btcsuite/btcd/btcec/v2"
 	sphinx "github.com/lightningnetwork/lightning-onion"
 	"github.com/lightningnetwork/lnd/chainntnfs"
 	"github.com/lightningnetwork/lnd/channeldb"
@@ -290,7 +289,7 @@ type mockOnionProcessor struct {
 }
 
 func (o *mockOnionProcessor) ReconstructHopIterator(r io.Reader, rHash []byte,
-	blindingPoint *btcec.PublicKey) (hop.Iterator, error) {
+	_ hop.ReconstructBlindingInfo) (hop.Iterator, error) {
 
 	data, err := ioutil.ReadAll(r)
 	if err != nil {

--- a/contractcourt/interfaces.go
+++ b/contractcourt/interfaces.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"io"
 
-	"github.com/btcsuite/btcd/btcec/v2"
 	"github.com/btcsuite/btcd/wire"
 	"github.com/lightningnetwork/lnd/channeldb"
 	"github.com/lightningnetwork/lnd/channeldb/models"
@@ -42,7 +41,7 @@ type OnionProcessor interface {
 	// ReconstructHopIterator attempts to decode a valid sphinx packet from
 	// the passed io.Reader instance.
 	ReconstructHopIterator(r io.Reader, rHash []byte,
-		blindingKey *btcec.PublicKey) (hop.Iterator, error)
+		blindingInfo hop.ReconstructBlindingInfo) (hop.Iterator, error)
 }
 
 // UtxoSweeper defines the sweep functions that contract court requires.

--- a/docs/release-notes/release-notes-0.18.0.md
+++ b/docs/release-notes/release-notes-0.18.0.md
@@ -187,7 +187,9 @@ call where arguments were swapped.
 bitcoin peers' feefilter values into account](https://github.com/lightningnetwork/lnd/pull/8418).
 
 * [Preparatory work](https://github.com/lightningnetwork/lnd/pull/8159) for 
-  forwarding of blinded routes was added.
+  forwarding of blinded routes was added, along with [support](https://github.com/lightningnetwork/lnd/pull/8160)
+  for forwarding blinded payments. Forwarding of blinded payments is disabled 
+  by default, and the feature is not yet advertised to the network.
 
 ## RPC Additions
 

--- a/htlcswitch/hop/forwarding_info.go
+++ b/htlcswitch/hop/forwarding_info.go
@@ -22,4 +22,9 @@ type ForwardingInfo struct {
 	// OutgoingCTLV is the specified value of the CTLV timelock to be used
 	// in the outgoing HTLC.
 	OutgoingCTLV uint32
+
+	// NextBlinding is an optional blinding point to be passed to the next
+	// node in UpdateAddHtlc. This field is set if the htlc is part of a
+	// blinded route.
+	NextBlinding lnwire.BlindingPointRecord
 }

--- a/htlcswitch/hop/fuzz_test.go
+++ b/htlcswitch/hop/fuzz_test.go
@@ -117,7 +117,7 @@ func fuzzPayload(f *testing.F, finalPayload bool) {
 
 		r := bytes.NewReader(data)
 
-		payload1, err := NewPayloadFromReader(r, finalPayload)
+		payload1, _, err := NewPayloadFromReader(r, finalPayload)
 		if err != nil {
 			return
 		}
@@ -146,7 +146,7 @@ func fuzzPayload(f *testing.F, finalPayload bool) {
 			require.NoError(t, err)
 		}
 
-		payload2, err := NewPayloadFromReader(&b, finalPayload)
+		payload2, _, err := NewPayloadFromReader(&b, finalPayload)
 		require.NoError(t, err)
 
 		require.Equal(t, payload1, payload2)

--- a/htlcswitch/hop/iterator.go
+++ b/htlcswitch/hop/iterator.go
@@ -114,6 +114,51 @@ func (r *sphinxHopIterator) ExtractErrorEncrypter(
 	return extracter(r.ogPacket.EphemeralKey)
 }
 
+// calculateForwardingAmount calculates the amount to forward for a blinded
+// hop based on the incoming amount and forwarding parameters.
+//
+// When forwarding a payment, the fee we take is calculated, not on the
+// incoming amount, but rather on the amount we forward. We charge fees based
+// on our own liquidity we are forwarding downstream.
+//
+// With route blinding, we are NOT given the amount to forward.  This
+// unintuitive looking formula comes from the fact that without the amount to
+// forward, we cannot compute the fees taken directly.
+//
+// The amount to be forwarded can be computed as follows:
+//
+// amt_to_forward = incoming_amount - total_fees
+// total_fees = base_fee + amt_to_forward*(fee_rate/1000000)
+//
+// Solving for amount_to_forward:
+// amt_to_forward = incoming_amount - base_fee - (amount_to_forward * fee_rate)/1e6
+// amt_to_forward + (amount_to_forward * fee_rate) / 1e6 = incoming_amount - base_fee
+// amt_to_forward * 1e6 + (amount_to_forward * fee_rate) = (incoming_amount - base_fee) * 1e6
+// amt_to_forward * (1e6 + fee_rate) = (incoming_amount - base_fee) * 1e6
+// amt_to_forward = ((incoming_amount - base_fee) * 1e6) / (1e6 + fee_rate)
+//
+// From there we use a ceiling formula for integer division so that we always
+// round up, otherwise the sender may receive slightly less than intended:
+//
+// ceil(a/b) = (a + b - 1)/(b).
+//
+//nolint:lll,dupword
+func calculateForwardingAmount(incomingAmount lnwire.MilliSatoshi, baseFee,
+	proportionalFee uint32) (lnwire.MilliSatoshi, error) {
+
+	// Sanity check to prevent overflow.
+	if incomingAmount < lnwire.MilliSatoshi(baseFee) {
+		return 0, fmt.Errorf("incoming amount: %v < base fee: %v",
+			incomingAmount, baseFee)
+	}
+	numerator := (uint64(incomingAmount) - uint64(baseFee)) * 1e6
+	denominator := 1e6 + uint64(proportionalFee)
+
+	ceiling := (numerator + denominator - 1) / denominator
+
+	return lnwire.MilliSatoshi(ceiling), nil
+}
+
 // OnionProcessor is responsible for keeping all sphinx dependent parts inside
 // and expose only decoding function. With such approach we give freedom for
 // subsystems which wants to decode sphinx path to not be dependable from

--- a/htlcswitch/hop/iterator.go
+++ b/htlcswitch/hop/iterator.go
@@ -131,6 +131,10 @@ type BlindingProcessor interface {
 	// ephemeral key provided.
 	DecryptBlindedHopData(ephemPub *btcec.PublicKey,
 		encryptedData []byte) ([]byte, error)
+
+	// NextEphemeral returns the next hop's ephemeral key, calculated
+	// from the current ephemeral key provided.
+	NextEphemeral(*btcec.PublicKey) (*btcec.PublicKey, error)
 }
 
 // BlindingKit contains the components required to extract forwarding
@@ -250,11 +254,39 @@ func (b *BlindingKit) DecryptAndValidateFwdInfo(payload *Payload,
 		return nil, err
 	}
 
+	// If we have an override for the blinding point for the next node,
+	// we'll just use it without tweaking (the sender intended to switch
+	// out directly for this blinding point). Otherwise, we'll tweak our
+	// blinding point to get the next ephemeral key.
+	nextEph, err := routeData.NextBlindingOverride.UnwrapOrFuncErr(
+		func() (tlv.RecordT[tlv.TlvType8,
+			*btcec.PublicKey], error) {
+
+			next, err := b.Processor.NextEphemeral(blindingPoint)
+			if err != nil {
+				// Return a zero record because we expect the
+				// error to be checked.
+				return routeData.NextBlindingOverride.Zero(),
+					err
+			}
+
+			return tlv.NewPrimitiveRecord[tlv.TlvType8](next), nil
+		},
+	)
+	if err != nil {
+		return nil, err
+	}
+
 	return &ForwardingInfo{
 		NextHop:         routeData.ShortChannelID.Val,
 		AmountToForward: fwdAmt,
 		OutgoingCTLV: b.IncomingCltv - uint32(
 			routeData.RelayInfo.Val.CltvExpiryDelta,
+		),
+		// Remap from blinding override type to blinding point type.
+		NextBlinding: tlv.SomeRecordT(
+			tlv.NewPrimitiveRecord[lnwire.BlindingPointTlvType](
+				nextEph.Val),
 		),
 	}, nil
 }

--- a/htlcswitch/hop/iterator.go
+++ b/htlcswitch/hop/iterator.go
@@ -200,7 +200,8 @@ func (b *BlindingKit) validateBlindingPoint(payloadBlinding *btcec.PublicKey,
 // DecryptAndValidateFwdInfo performs all operations required to decrypt and
 // validate a blinded route.
 func (b *BlindingKit) DecryptAndValidateFwdInfo(payload *Payload,
-	isFinalHop bool) (*ForwardingInfo, error) {
+	isFinalHop bool, payloadParsed map[tlv.Type][]byte) (
+	*ForwardingInfo, error) {
 
 	// We expect this function to be called when we have encrypted data
 	// present, and a blinding key is set either in the payload or the
@@ -227,6 +228,14 @@ func (b *BlindingKit) DecryptAndValidateFwdInfo(payload *Payload,
 			ErrDecodeFailed, err)
 	}
 
+	// Validate the contents of the payload against the values we've
+	// just pulled out of the encrypted data blob.
+	err = ValidatePayloadWithBlinded(isFinalHop, payloadParsed)
+	if err != nil {
+		return nil, err
+	}
+	// Validate the data in the blinded route against our incoming htlc's
+	// information.
 	if err := ValidateBlindedRouteData(
 		routeData, b.IncomingAmount, b.IncomingCltv,
 	); err != nil {

--- a/htlcswitch/hop/iterator.go
+++ b/htlcswitch/hop/iterator.go
@@ -106,10 +106,12 @@ func (r *sphinxHopIterator) HopPayload() (*Payload, error) {
 	// Otherwise, if this is the TLV payload, then we'll make a new stream
 	// to decode only what we need to make routing decisions.
 	case sphinx.PayloadTLV:
-		return NewPayloadFromReader(
+		payload, _, err := NewPayloadFromReader(
 			bytes.NewReader(r.processedPacket.Payload.Payload),
 			r.processedPacket.Action == sphinx.ExitNode,
 		)
+
+		return payload, err
 
 	default:
 		return nil, fmt.Errorf("unknown sphinx payload type: %v",

--- a/htlcswitch/hop/iterator_test.go
+++ b/htlcswitch/hop/iterator_test.go
@@ -170,6 +170,13 @@ func (m *mockProcessor) DecryptBlindedHopData(_ *btcec.PublicKey,
 	return data, m.decryptErr
 }
 
+// NextEphemeral mocks getting our next ephemeral key.
+func (m *mockProcessor) NextEphemeral(*btcec.PublicKey) (*btcec.PublicKey,
+	error) {
+
+	return nil, nil
+}
+
 // TestDecryptAndValidateFwdInfo tests deriving forwarding info using a
 // blinding kit. This test does not cover assertions on the calculations of
 // forwarding information, because this is covered in a test dedicated to those

--- a/htlcswitch/hop/iterator_test.go
+++ b/htlcswitch/hop/iterator_test.go
@@ -287,6 +287,7 @@ func TestDecryptAndValidateFwdInfo(t *testing.T) {
 					encryptedData: testCase.data,
 					blindingPoint: testCase.payloadBlinding,
 				}, false,
+				make(map[tlv.Type][]byte),
 			)
 			require.ErrorIs(t, err, testCase.expectedErr)
 		})

--- a/htlcswitch/hop/iterator_test.go
+++ b/htlcswitch/hop/iterator_test.go
@@ -3,8 +3,10 @@ package hop
 import (
 	"bytes"
 	"encoding/binary"
+	"errors"
 	"testing"
 
+	"github.com/btcsuite/btcd/btcec/v2"
 	"github.com/davecgh/go-spew/spew"
 	sphinx "github.com/lightningnetwork/lightning-onion"
 	"github.com/lightningnetwork/lnd/lnwire"
@@ -150,6 +152,143 @@ func TestForwardingAmountCalc(t *testing.T) {
 			require.Equal(t, testCase.expectErr, err != nil)
 			require.Equal(t, testCase.forwardAmount.ToSatoshis(),
 				actual.ToSatoshis())
+		})
+	}
+}
+
+// mockProcessor is a mocked blinding point processor that just returns the
+// data that it is called with when "decrypting".
+type mockProcessor struct {
+	decryptErr error
+}
+
+// DecryptBlindedHopData mocks blob decryption, returning the same data that
+// it was called with and an optionally configured error.
+func (m *mockProcessor) DecryptBlindedHopData(_ *btcec.PublicKey,
+	data []byte) ([]byte, error) {
+
+	return data, m.decryptErr
+}
+
+// TestDecryptAndValidateFwdInfo tests deriving forwarding info using a
+// blinding kit. This test does not cover assertions on the calculations of
+// forwarding information, because this is covered in a test dedicated to those
+// calculations.
+func TestDecryptAndValidateFwdInfo(t *testing.T) {
+	t.Parallel()
+
+	// Encode valid blinding data that we'll fake decrypting for our test.
+	maxCltv := 1000
+	blindedData := record.NewBlindedRouteData(
+		lnwire.NewShortChanIDFromInt(1500), nil,
+		record.PaymentRelayInfo{
+			CltvExpiryDelta: 10,
+			BaseFee:         100,
+			FeeRate:         0,
+		},
+		&record.PaymentConstraints{
+			MaxCltvExpiry:   1000,
+			HtlcMinimumMsat: lnwire.MilliSatoshi(1),
+		},
+		nil,
+	)
+
+	validData, err := record.EncodeBlindedRouteData(blindedData)
+	require.NoError(t, err)
+
+	// Mocked error.
+	errDecryptFailed := errors.New("could not decrypt")
+
+	tests := []struct {
+		name              string
+		data              []byte
+		incomingCLTV      uint32
+		updateAddBlinding *btcec.PublicKey
+		payloadBlinding   *btcec.PublicKey
+		processor         *mockProcessor
+		expectedErr       error
+	}{
+		{
+			name:      "no blinding point",
+			data:      validData,
+			processor: &mockProcessor{},
+			expectedErr: ErrInvalidPayload{
+				Type:      record.BlindingPointOnionType,
+				Violation: OmittedViolation,
+			},
+		},
+		{
+			name:              "both blinding points",
+			data:              validData,
+			updateAddBlinding: &btcec.PublicKey{},
+			payloadBlinding:   &btcec.PublicKey{},
+			processor:         &mockProcessor{},
+			expectedErr: ErrInvalidPayload{
+				Type:      record.BlindingPointOnionType,
+				Violation: IncludedViolation,
+			},
+		},
+		{
+			name:              "decryption failed",
+			data:              validData,
+			updateAddBlinding: &btcec.PublicKey{},
+			incomingCLTV:      500,
+			processor: &mockProcessor{
+				decryptErr: errDecryptFailed,
+			},
+			expectedErr: errDecryptFailed,
+		},
+		{
+			name:              "decode fails",
+			data:              []byte{1, 2, 3},
+			updateAddBlinding: &btcec.PublicKey{},
+			incomingCLTV:      500,
+			processor:         &mockProcessor{},
+			expectedErr:       ErrDecodeFailed,
+		},
+		{
+			name:              "validation fails",
+			data:              validData,
+			updateAddBlinding: &btcec.PublicKey{},
+			incomingCLTV:      uint32(maxCltv) + 10,
+			processor:         &mockProcessor{},
+			expectedErr: ErrInvalidPayload{
+				Type:      record.LockTimeOnionType,
+				Violation: InsufficientViolation,
+			},
+		},
+		{
+			name:              "valid",
+			updateAddBlinding: &btcec.PublicKey{},
+			data:              validData,
+			processor:         &mockProcessor{},
+			expectedErr:       nil,
+		},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			// We don't actually use blinding keys due to our
+			// mocking so they can be nil.
+			kit := BlindingKit{
+				Processor:      testCase.processor,
+				IncomingAmount: 10000,
+				IncomingCltv:   testCase.incomingCLTV,
+			}
+
+			if testCase.updateAddBlinding != nil {
+				kit.UpdateAddBlinding = tlv.SomeRecordT(
+					//nolint:lll
+					tlv.NewPrimitiveRecord[lnwire.BlindingPointTlvType](testCase.updateAddBlinding),
+				)
+			}
+			_, err := kit.DecryptAndValidateFwdInfo(
+				&Payload{
+					encryptedData: testCase.data,
+					blindingPoint: testCase.payloadBlinding,
+				}, false,
+			)
+			require.ErrorIs(t, err, testCase.expectedErr)
 		})
 	}
 }

--- a/htlcswitch/hop/payload.go
+++ b/htlcswitch/hop/payload.go
@@ -133,11 +133,14 @@ func NewLegacyPayload(f *sphinx.HopData) *Payload {
 	}
 }
 
-// NewPayloadFromReader builds a new Hop from the passed io.Reader. The reader
+// NewPayloadFromReader builds a new Hop from the passed io.Reader and returns
+// a map of all the types that were found in the payload. The reader
 // should correspond to the bytes encapsulated in a TLV onion payload. The
 // final hop bool signals that this payload was the final packet parsed by
 // sphinx.
-func NewPayloadFromReader(r io.Reader, finalHop bool) (*Payload, error) {
+func NewPayloadFromReader(r io.Reader, finalHop bool) (*Payload,
+	map[tlv.Type][]byte, error) {
+
 	var (
 		cid           uint64
 		amt           uint64
@@ -162,27 +165,27 @@ func NewPayloadFromReader(r io.Reader, finalHop bool) (*Payload, error) {
 		record.NewTotalAmtMsatBlinded(&totalAmtMsat),
 	)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	// Since this data is provided by a potentially malicious peer, pass it
 	// into the P2P decoding variant.
 	parsedTypes, err := tlvStream.DecodeWithParsedTypesP2P(r)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	// Validate whether the sender properly included or omitted tlv records
 	// in accordance with BOLT 04.
 	err = ValidateParsedPayloadTypes(parsedTypes, finalHop)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	// Check for violation of the rules for mandatory fields.
 	violatingType := getMinRequiredViolation(parsedTypes)
 	if violatingType != nil {
-		return nil, ErrInvalidPayload{
+		return nil, nil, ErrInvalidPayload{
 			Type:      *violatingType,
 			Violation: RequiredViolation,
 			FinalHop:  finalHop,
@@ -229,7 +232,7 @@ func NewPayloadFromReader(r io.Reader, finalHop bool) (*Payload, error) {
 		blindingPoint: blindingPoint,
 		customRecords: customRecords,
 		totalAmtMsat:  lnwire.MilliSatoshi(totalAmtMsat),
-	}, nil
+	}, nil, nil
 }
 
 // ForwardingInfo returns the basic parameters required for HTLC forwarding,

--- a/htlcswitch/hop/payload_test.go
+++ b/htlcswitch/hop/payload_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/lightningnetwork/lnd/htlcswitch/hop"
 	"github.com/lightningnetwork/lnd/lnwire"
 	"github.com/lightningnetwork/lnd/record"
+	"github.com/lightningnetwork/lnd/tlv"
 	"github.com/stretchr/testify/require"
 )
 
@@ -692,6 +693,70 @@ func TestValidateBlindedRouteData(t *testing.T) {
 				testCase.incomingTimelock,
 			)
 			require.Equal(t, testCase.err, err)
+		})
+	}
+}
+
+// TestValidatePayloadWithBlinded tests validation of the contents of a
+// payload when it's for a blinded payment.
+func TestValidatePayloadWithBlinded(t *testing.T) {
+	t.Parallel()
+
+	finalHopMap := map[tlv.Type][]byte{
+		record.AmtOnionType:            nil,
+		record.LockTimeOnionType:       nil,
+		record.TotalAmtMsatBlindedType: nil,
+	}
+
+	tests := []struct {
+		name    string
+		isFinal bool
+		parsed  map[tlv.Type][]byte
+		err     bool
+	}{
+		{
+			name:    "final hop, valid",
+			isFinal: true,
+			parsed:  finalHopMap,
+		},
+		{
+			name:    "intermediate hop, invalid",
+			isFinal: false,
+			parsed:  finalHopMap,
+			err:     true,
+		},
+		{
+			name:    "intermediate hop, invalid",
+			isFinal: false,
+			parsed: map[tlv.Type][]byte{
+				record.EncryptedDataOnionType: nil,
+				record.BlindingPointOnionType: nil,
+			},
+		},
+		{
+			name:    "unknown record, invalid",
+			isFinal: false,
+			parsed: map[tlv.Type][]byte{
+				tlv.Type(99): nil,
+			},
+			err: true,
+		},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			err := hop.ValidatePayloadWithBlinded(
+				testCase.isFinal, testCase.parsed,
+			)
+
+			// We can't determine our exact error because we
+			// iterate through a map (non-deterministic) in the
+			// function.
+			if testCase.err {
+				require.NotNil(t, err)
+			} else {
+				require.Nil(t, err)
+			}
 		})
 	}
 }

--- a/htlcswitch/hop/payload_test.go
+++ b/htlcswitch/hop/payload_test.go
@@ -479,7 +479,7 @@ func testDecodeHopPayloadValidation(t *testing.T, test decodePayloadTest) {
 		testChildIndex = uint32(9)
 	)
 
-	p, err := hop.NewPayloadFromReader(
+	p, _, err := hop.NewPayloadFromReader(
 		bytes.NewReader(test.payload), test.isFinalHop,
 	)
 	if !reflect.DeepEqual(test.expErr, err) {

--- a/htlcswitch/link.go
+++ b/htlcswitch/link.go
@@ -3348,9 +3348,10 @@ func (l *channelLink) processRemoteAdds(fwdPkg *channeldb.FwdPkg,
 				// Otherwise, it was already processed, we can
 				// can collect it and continue.
 				addMsg := &lnwire.UpdateAddHTLC{
-					Expiry:      fwdInfo.OutgoingCTLV,
-					Amount:      fwdInfo.AmountToForward,
-					PaymentHash: pd.RHash,
+					Expiry:        fwdInfo.OutgoingCTLV,
+					Amount:        fwdInfo.AmountToForward,
+					PaymentHash:   pd.RHash,
+					BlindingPoint: fwdInfo.NextBlinding,
 				}
 
 				// Finally, we'll encode the onion packet for
@@ -3393,9 +3394,10 @@ func (l *channelLink) processRemoteAdds(fwdPkg *channeldb.FwdPkg,
 			// create the outgoing HTLC using the parameters as
 			// specified in the forwarding info.
 			addMsg := &lnwire.UpdateAddHTLC{
-				Expiry:      fwdInfo.OutgoingCTLV,
-				Amount:      fwdInfo.AmountToForward,
-				PaymentHash: pd.RHash,
+				Expiry:        fwdInfo.OutgoingCTLV,
+				Amount:        fwdInfo.AmountToForward,
+				PaymentHash:   pd.RHash,
+				BlindingPoint: fwdInfo.NextBlinding,
 			}
 
 			// Finally, we'll encode the onion packet for the

--- a/itest/list_on_test.go
+++ b/itest/list_on_test.go
@@ -559,6 +559,10 @@ var allTestCases = []*lntest.TestCase{
 		TestFunc: testQueryBlindedRoutes,
 	},
 	{
+		Name:     "forward blinded",
+		TestFunc: testForwardBlindedRoute,
+	},
+	{
 		Name:     "removetx",
 		TestFunc: testRemoveTx,
 	},

--- a/itest/lnd_route_blinding_test.go
+++ b/itest/lnd_route_blinding_test.go
@@ -1,9 +1,11 @@
 package itest
 
 import (
+	"bytes"
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
+	"time"
 
 	"github.com/btcsuite/btcd/btcec/v2"
 	"github.com/btcsuite/btcd/btcutil"
@@ -13,6 +15,7 @@ import (
 	"github.com/lightningnetwork/lnd/lnrpc/routerrpc"
 	"github.com/lightningnetwork/lnd/lntest"
 	"github.com/lightningnetwork/lnd/lntest/node"
+	"github.com/lightningnetwork/lnd/lntypes"
 	"github.com/lightningnetwork/lnd/lnwire"
 	"github.com/lightningnetwork/lnd/record"
 	"github.com/lightningnetwork/lnd/routing"
@@ -323,6 +326,10 @@ type blindedForwardTest struct {
 	dave     *node.HarnessNode
 	channels []*lnrpc.ChannelPoint
 
+	carolInterceptor routerrpc.Router_HtlcInterceptorClient
+
+	preimage [32]byte
+
 	// cancel will cancel the test's top level context.
 	cancel func()
 }
@@ -333,16 +340,28 @@ func newBlindedForwardTest(ht *lntest.HarnessTest) (context.Context,
 	ctx, cancel := context.WithCancel(context.Background())
 
 	return ctx, &blindedForwardTest{
-		ht:     ht,
-		cancel: cancel,
+		ht:       ht,
+		cancel:   cancel,
+		preimage: [32]byte{1, 2, 3},
 	}
 }
 
 // setup spins up additional nodes needed for our test and creates a four hop
 // network for testing blinded forwarding and returns a blinded route from
-// Bob -> Carol -> Dave, with Bob acting as the introduction point.
-func (b *blindedForwardTest) setup() *routing.BlindedPayment {
-	b.carol = b.ht.NewNode("Carol", nil)
+// Bob -> Carol -> Dave, with Bob acting as the introduction point and an
+// interceptor on Carol's node to manage HTLCs (as Dave does not yet support
+// receiving).
+func (b *blindedForwardTest) setup(
+	ctx context.Context) *routing.BlindedPayment {
+
+	b.carol = b.ht.NewNode("Carol", []string{
+		"requireinterceptor",
+	})
+
+	var err error
+	b.carolInterceptor, err = b.carol.RPC.Router.HtlcInterceptor(ctx)
+	require.NoError(b.ht, err, "interceptor")
+
 	b.dave = b.ht.NewNode("Dave", nil)
 
 	b.channels = setupFourHopNetwork(b.ht, b.carol, b.dave)
@@ -427,6 +446,82 @@ func (b *blindedForwardTest) createRouteToBlinded(paymentAmt int64,
 	require.Len(b.ht, resp.Routes[0].Hops, 3, "unexpected route length")
 
 	return resp.Routes[0]
+}
+
+// sendBlindedPayment dispatches a payment to the route provided.
+func (b *blindedForwardTest) sendBlindedPayment(ctx context.Context,
+	route *lnrpc.Route) {
+
+	hash := sha256.Sum256(b.preimage[:])
+	sendReq := &routerrpc.SendToRouteRequest{
+		PaymentHash: hash[:],
+		Route:       route,
+	}
+
+	// Dispatch in a goroutine because this call is blocking - we assume
+	// that we'll have assertions that this payment is sent by the caller.
+	go func() {
+		b.ht.Alice.RPC.SendToRouteV2(sendReq)
+	}()
+}
+
+// interceptFinalHop launches a goroutine to intercept Carol's htlcs and
+// returns a closure that can be used to resolve intercepted htlcs.
+//
+//nolint:lll
+func (b *blindedForwardTest) interceptFinalHop() func(routerrpc.ResolveHoldForwardAction) {
+	hash := sha256.Sum256(b.preimage[:])
+	htlcReceived := make(chan *routerrpc.ForwardHtlcInterceptRequest)
+
+	// Launch a goroutine which will receive from the interceptor and pipe
+	// it into our request channel.
+	go func() {
+		forward, err := b.carolInterceptor.Recv()
+		if err != nil {
+			b.ht.Fatalf("intercept receive failed: %v", err)
+		}
+
+		if !bytes.Equal(forward.PaymentHash, hash[:]) {
+			b.ht.Fatalf("unexpected payment hash: %v", hash)
+		}
+
+		select {
+		case htlcReceived <- forward:
+
+		case <-time.After(lntest.DefaultTimeout):
+			b.ht.Fatal("timeout waiting to send intercepted htlc")
+		}
+	}()
+
+	// Create a closure that will wait for the intercept request and
+	// resolve the HTLC with the appropriate action.
+	resolve := func(action routerrpc.ResolveHoldForwardAction) {
+		select {
+		case forward := <-htlcReceived:
+			resp := &routerrpc.ForwardHtlcInterceptResponse{
+				IncomingCircuitKey: forward.IncomingCircuitKey,
+			}
+
+			switch action {
+			case routerrpc.ResolveHoldForwardAction_FAIL:
+				resp.Action = routerrpc.ResolveHoldForwardAction_FAIL
+
+			case routerrpc.ResolveHoldForwardAction_SETTLE:
+				resp.Action = routerrpc.ResolveHoldForwardAction_SETTLE
+				resp.Preimage = b.preimage[:]
+
+			case routerrpc.ResolveHoldForwardAction_RESUME:
+				resp.Action = routerrpc.ResolveHoldForwardAction_RESUME
+			}
+
+			require.NoError(b.ht, b.carolInterceptor.Send(resp))
+
+		case <-time.After(lntest.DefaultTimeout):
+			b.ht.Fatal("timeout waiting for htlc intercept")
+		}
+	}
+
+	return resolve
 }
 
 // setupFourHopNetwork creates a network with the following topology and
@@ -654,9 +749,42 @@ func getForwardingEdge(ht *lntest.HarnessTest,
 // testForwardBlindedRoute tests lnd's ability to forward payments in a blinded
 // route.
 func testForwardBlindedRoute(ht *lntest.HarnessTest) {
-	_, testCase := newBlindedForwardTest(ht)
+	ctx, testCase := newBlindedForwardTest(ht)
 	defer testCase.cleanup()
 
-	route := testCase.setup()
-	testCase.createRouteToBlinded(100_000, route)
+	route := testCase.setup(ctx)
+	blindedRoute := testCase.createRouteToBlinded(10_000_000, route)
+
+	// Receiving via blinded routes is not yet supported, so Dave won't be
+	// able to process the payment.
+	//
+	// We have an interceptor at our disposal that will catch htlcs as they
+	// are forwarded (ie, it won't intercept a HTLC that dave is receiving,
+	// since no forwarding occurs). We initiate this interceptor with
+	// Carol, so that we can catch it and settle on the outgoing link to
+	// Dave. Once we hit the outgoing link, we know that we successfully
+	// parsed the htlc, so this is an acceptable compromise.
+	// Assert that our interceptor has exited without an error.
+	resolveHTLC := testCase.interceptFinalHop()
+
+	// Once our interceptor is set up, we can send the blinded payment.
+	testCase.sendBlindedPayment(ctx, blindedRoute)
+
+	// Wait for the HTLC to be active on Alice's channel.
+	hash := sha256.Sum256(testCase.preimage[:])
+	ht.AssertOutgoingHTLCActive(ht.Alice, testCase.channels[0], hash[:])
+	ht.AssertOutgoingHTLCActive(ht.Bob, testCase.channels[1], hash[:])
+
+	// Intercept and settle the HTLC.
+	resolveHTLC(routerrpc.ResolveHoldForwardAction_SETTLE)
+
+	// Wait for the HTLC to reflect as settled for Alice.
+	preimage, err := lntypes.MakePreimage(testCase.preimage[:])
+	require.NoError(ht, err)
+	ht.AssertPaymentStatus(ht.Alice, preimage, lnrpc.Payment_SUCCEEDED)
+
+	// Assert that the HTLC has settled before test cleanup runs so that
+	// we can cooperatively close all channels.
+	ht.AssertHLTCNotActive(ht.Bob, testCase.channels[1], hash[:])
+	ht.AssertHLTCNotActive(ht.Alice, testCase.channels[0], hash[:])
 }

--- a/lncfg/protocol.go
+++ b/lncfg/protocol.go
@@ -59,6 +59,14 @@ type ProtocolOptions struct {
 	NoRouteBlindingOption bool `long:"no-route-blinding" description:"do not forward payments that are a part of a blinded route"`
 }
 
+// DefaultProtocol returns a protocol config with route blinding turned off,
+// temporarily in place until full handling of blinded route errors is merged.
+func DefaultProtocol() *ProtocolOptions {
+	return &ProtocolOptions{
+		NoRouteBlindingOption: true,
+	}
+}
+
 // Wumbo returns true if lnd should permit the creation and acceptance of wumbo
 // channels.
 func (l *ProtocolOptions) Wumbo() bool {

--- a/lncfg/protocol.go
+++ b/lncfg/protocol.go
@@ -54,6 +54,9 @@ type ProtocolOptions struct {
 	// also mean that we won't respond with timestamps if requested by our
 	// peers.
 	NoTimestampQueryOption bool `long:"no-timestamp-query-option" description:"do not query syncing peers for announcement timestamps and do not respond with timestamps if requested"`
+
+	// NoRouteBlindingOption disables forwarding of payments in blinded routes.
+	NoRouteBlindingOption bool `long:"no-route-blinding" description:"do not forward payments that are a part of a blinded route"`
 }
 
 // Wumbo returns true if lnd should permit the creation and acceptance of wumbo
@@ -96,4 +99,9 @@ func (l *ProtocolOptions) NoAnySegwit() bool {
 // requested by our peer.
 func (l *ProtocolOptions) NoTimestampsQuery() bool {
 	return l.NoTimestampQueryOption
+}
+
+// NoRouteBlinding returns true if forwarding of blinded payments is disabled.
+func (l *ProtocolOptions) NoRouteBlinding() bool {
+	return l.NoRouteBlindingOption
 }

--- a/lncfg/protocol_integration.go
+++ b/lncfg/protocol_integration.go
@@ -57,6 +57,9 @@ type ProtocolOptions struct {
 	// also mean that we won't respond with timestamps if requested by our
 	// peers.
 	NoTimestampQueryOption bool `long:"no-timestamp-query-option" description:"do not query syncing peers for announcement timestamps and do not respond with timestamps if requested"`
+
+	// NoRouteBlindingOption disables forwarding of payments in blinded routes.
+	NoRouteBlindingOption bool `long:"no-route-blinding" description:"do not forward payments that are a part of a blinded route"`
 }
 
 // Wumbo returns true if lnd should permit the creation and acceptance of wumbo
@@ -91,4 +94,9 @@ func (l *ProtocolOptions) ZeroConf() bool {
 // segwit witness versions for co-op close addresses.
 func (l *ProtocolOptions) NoAnySegwit() bool {
 	return l.NoOptionAnySegwit
+}
+
+// NoRouteBlinding returns true if forwarding of blinded payments is disabled.
+func (l *ProtocolOptions) NoRouteBlinding() bool {
+	return l.NoRouteBlindingOption
 }

--- a/lncfg/protocol_integration.go
+++ b/lncfg/protocol_integration.go
@@ -62,6 +62,13 @@ type ProtocolOptions struct {
 	NoRouteBlindingOption bool `long:"no-route-blinding" description:"do not forward payments that are a part of a blinded route"`
 }
 
+// DefaultProtocol returns a protocol config with route blinding turned on,
+// so that itests can run against route blinding features even while we've
+// got it turned off for the daemon (pending completion of error handling).
+func DefaultProtocol() *ProtocolOptions {
+	return &ProtocolOptions{}
+}
+
 // Wumbo returns true if lnd should permit the creation and acceptance of wumbo
 // channels.
 func (l *ProtocolOptions) Wumbo() bool {

--- a/lnwallet/channel_test.go
+++ b/lnwallet/channel_test.go
@@ -11045,7 +11045,8 @@ func TestBlindingPointPersistence(t *testing.T) {
 	// Assert that the blinding point is restored from disk.
 	remoteCommit := aliceChannel.remoteCommitChain.tip()
 	require.Len(t, remoteCommit.outgoingHTLCs, 1)
-	require.Equal(t, blinding, remoteCommit.outgoingHTLCs[0].BlindingPoint)
+	require.Equal(t, blinding,
+		remoteCommit.outgoingHTLCs[0].BlindingPoint.UnwrapOrFailV(t))
 
 	// Next, update bob's commitment and assert that we can still retrieve
 	// his incoming blinding point after restart.
@@ -11061,5 +11062,6 @@ func TestBlindingPointPersistence(t *testing.T) {
 	// Assert that Bob is able to recover the blinding point from disk.
 	bobCommit := bobChannel.localCommitChain.tip()
 	require.Len(t, bobCommit.incomingHTLCs, 1)
-	require.Equal(t, blinding, bobCommit.incomingHTLCs[0].BlindingPoint)
+	require.Equal(t, blinding,
+		bobCommit.incomingHTLCs[0].BlindingPoint.UnwrapOrFailV(t))
 }

--- a/lnwire/update_add_htlc.go
+++ b/lnwire/update_add_htlc.go
@@ -78,19 +78,6 @@ type UpdateAddHTLC struct {
 	ExtraData ExtraOpaqueData
 }
 
-// BlingingPointOrNil returns the blinding point associated with the update, or
-// nil.
-func (c *UpdateAddHTLC) BlingingPointOrNil() *btcec.PublicKey {
-	var blindingPoint *btcec.PublicKey
-	c.BlindingPoint.WhenSome(func(b tlv.RecordT[BlindingPointTlvType,
-		*btcec.PublicKey]) {
-
-		blindingPoint = b.Val
-	})
-
-	return blindingPoint
-}
-
 // NewUpdateAddHTLC returns a new empty UpdateAddHTLC message.
 func NewUpdateAddHTLC() *UpdateAddHTLC {
 	return &UpdateAddHTLC{}

--- a/peer/brontide.go
+++ b/peer/brontide.go
@@ -365,6 +365,11 @@ type Config struct {
 	// this across multiple Peer struct instances.
 	PongBuf []byte
 
+	// Adds the option to disable forwarding payments in blinded routes
+	// by failing back any blinding-related payloads as if they were
+	// invalid.
+	DisallowRouteBlinding bool
+
 	// Quit is the server's quit channel. If this is closed, we halt operation.
 	Quit chan struct{}
 }
@@ -1155,6 +1160,7 @@ func (p *Brontide) addLink(chanPoint *wire.OutPoint,
 		HtlcNotifier:            p.cfg.HtlcNotifier,
 		GetAliases:              p.cfg.GetAliases,
 		PreviouslySentShutdown:  shutdownMsg,
+		DisallowRouteBlinding:   p.cfg.DisallowRouteBlinding,
 	}
 
 	// Before adding our new link, purge the switch of any pending or live

--- a/sample-lnd.conf
+++ b/sample-lnd.conf
@@ -1282,6 +1282,9 @@
 ; Set to enable support for the experimental taproot channel type.
 ; protocol.simple-taproot-chans=false
 
+; Set to disable blinded route forwarding.
+; protocol.no-route-blinding=false
+
 [db]
 
 ; The selected database backend. The current default backend is "bolt". lnd

--- a/server.go
+++ b/server.go
@@ -3872,6 +3872,7 @@ func (s *server) peerConnected(conn net.Conn, connReq *connmgr.ConnReq,
 		GetAliases:             s.aliasMgr.GetAliases,
 		RequestAlias:           s.aliasMgr.RequestAlias,
 		AddLocalAlias:          s.aliasMgr.AddLocalAlias,
+		DisallowRouteBlinding:  s.cfg.ProtocolOptions.NoRouteBlinding(),
 		Quit:                   s.quit,
 	}
 


### PR DESCRIPTION
This PR is the second in a series to add the ability for LND to forward payments to blinded routes.

**Reviewer Notes**: 
* This PR does not signal the route blinding feature yet because it does not include error handling for blinded forwards, which is critical to receiver privacy so LND should not advertise the feature until it fully support it.
* Itests can be squashed, they're broken into multiple commits to aid readability. 

Replaces #7376 
Fixes #7298